### PR TITLE
Update readme and add check for python3.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,3 +91,4 @@ Running migrations:
 
 * Random problems may arise if you have old Docker containers running. Run `docker ps` and if you see containers unrelated to our app, consider stopping them.
 * If you have problems connecting to postgres, or running related scripts, make sure you aren't already running a postgres daemon. You can check this by typing `ps aux | grep postgres` and looking for existing processes.
+* If you happen to have installed pre-commit in a virtual environment not with brew, running bin/prereqs will not alert you. You may run into issues when running `make deps`. To install pre-commit: `brew install pre-commit`.

--- a/bin/prereqs
+++ b/bin/prereqs
@@ -21,6 +21,7 @@ has pre-commit "brew install pre-commit"
 has shellcheck "brew install shellcheck"
 has docker "Get Docker CE for Mac from https://download.docker.com/mac/stable/Docker.dmg"
 has psql "brew install postgresql"
+has python3.6 "(assuming you're using pyenv) pyenv install 3.6.2"
 
 if command -v nvm; then
     echo "nvm installed"

--- a/bin/prereqs
+++ b/bin/prereqs
@@ -23,10 +23,6 @@ has docker "Get Docker CE for Mac from https://download.docker.com/mac/stable/Do
 has psql "brew install postgresql"
 has python3.6 "(assuming you're using pyenv) pyenv install 3.6.2"
 
-if command -v nvm; then
-    echo "nvm installed"
-fi
-
 has node "test"
 
 if [[ $prereqs_found == "true" ]]; then


### PR DESCRIPTION
Python3.6.2 is necessary for using pre-commit, as far as I understand, and python won't run if this version is not installed. 