### PR TITLE
Defines allowable rank/grade values in API

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -571,3 +571,35 @@ definitions:
       - aviation_cadet
       - civilian_employee
       - midshipman
+    description: >
+      Rank/Pay Grade:
+        * E_1 - E-1
+        * E_2 - E-2
+        * E_3 - E-3
+        * E_4 - E-4
+        * E_5 - E-5
+        * E_6 - E-6
+        * E_7 - E-7
+        * E_8 - E-8
+        * E_9 - E-9
+        * W_1 - W-1
+        * W_2 - W-2
+        * W_3 - W-3
+        * W_4 - W-4
+        * W_5 - W-5
+        * O_1 - O-1
+        * O_2 - O-2
+        * O_3 - O-3
+        * O_4 - O-4
+        * O_5 - O-5
+        * O_6 - O-6
+        * O_7 - O-7
+        * O_8 - O-8
+        * O_9 - O-9
+        * O_10 - O-10
+        * academy_cadet - Service Academy Cadet
+        * academy_graduate - Service Academy Graduate
+        * aviation_cadet - Aviation Cadet
+        * civilian_employee - Civilian Employee
+        * midshipman - Midshipman
+

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -142,8 +142,7 @@ definitions:
         type: string
         example: Roll
       service_member_rank:
-        type: string
-        example: Commodore
+        $ref: '#/definitions/RankGrade'
       service_member_ssn:
         type: string
         pattern: '^\d{3}-\d{2}-\d{4}$'
@@ -394,8 +393,7 @@ definitions:
         type: string
         example: Roll
       service_member_rank:
-        type: string
-        example: Commodore
+        $ref: '#/definitions/RankGrade'
       service_member_ssn:
         type: string
         pattern: '^\d{3}-\d{2}-\d{4}$'
@@ -540,3 +538,36 @@ definitions:
       title_of_certified_by_signature:
         type: string
         example: Colonel Crumpet
+
+  RankGrade:
+    type: string
+    enum:
+      - E_1
+      - E_2
+      - E_3
+      - E_4
+      - E_5
+      - E_6
+      - E_7
+      - E_8
+      - E_9
+      - W_1
+      - W_2
+      - W_3
+      - W_4
+      - W_5
+      - O_1
+      - O_2
+      - O_3
+      - O_4
+      - O_5
+      - O_6
+      - O_7
+      - O_8
+      - O_9
+      - O_10
+      - academy_cadet
+      - academy_graduate
+      - aviation_cadet
+      - civilian_employee
+      - midshipman


### PR DESCRIPTION
Kind of embarrassed at the solution given the amount of time I spent thinking about this, but I think this is the right way to go for now. Ranks/grades are taken from [here](https://github.com/deptofdefense/move.mil/blob/master/db/seeds/entitlements.yml)

As I understand it the needs were:
1. Define allowable ranks/grades _somewhere_ in our system
2. Allow our client to use that rank definition to populate dropdowns

With @tinyels using jsonschema to populate the 1299 form UI, defining this in swagger.yaml should tick both of those boxes without needing to explicitly set up a `/rank` route that serves up that list.

> But these don't look like user facing strings!

We need to separate API values from display string, but we haven't quite solved that problem yet. Until then I figured we should err towards machine readable.

> But these are pay grades and not ranks!

There's a *lot* of ranks. Approximately 4 times the number of pay grades. To stick them all in a giant dropdown wouldn't make for great UI, and ultimately what we have below is all that should be needed to match a service member with their entitlements. When we decide that full rank is useful info, we'll probably need to implement some conditional dropdown filling based on service branch, and maybe pay grade too.