### PR TITLE
Add most recent changes from form 1299 to swagger.yaml

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -47,17 +47,19 @@ paths:
             $ref: '#/definitions/IndexIssuesPayload'
         400:
           description: invalid request
-  /form1299:
+  /form1299s:
     post:
       summary: Create a new shipment or storage of personal property application
       description: Create an instance of form 1299
       operationId: createForm1299
+      tags:
+        - form1299s
       parameters:
-      - in: body
-        name: createForm1299Payload
-        required: true
-        schema:
-          $ref: "#/definitions/CreateForm1299Payload"
+        - in: body
+          name: createForm1299Payload
+          required: true
+          schema:
+            $ref: "#/definitions/CreateForm1299Payload"
       responses:
         201:
           description: created instance of form 1299
@@ -68,12 +70,14 @@ paths:
     get:
       summary: List all submitted 1299 forms
       description: List all submitted 1299 forms
-      operationId: indexForms1299
+      operationId: indexForm1299s
+      tags:
+        - form1299s
       responses:
         200:
           description: list of submitted forms 1299
           schema:
-            $ref: '#/definitions/IndexForms1299Payload'
+            $ref: '#/definitions/IndexForm1299sPayload'
         400:
           description: invalid request
 
@@ -111,7 +115,6 @@ definitions:
       - description
       - created_at
       - updated_at
-
   CreateForm1299Payload:
     type: object
     properties:
@@ -119,70 +122,94 @@ definitions:
         type: string
         format: date
         example: 2018-01-03
+        x-nullable: true
       shipment_number:
         type: string
         example: "4550"
+        x-nullable: true
       name_of_preparing_office:
         type: string
         example: pumpernickel office
+        x-nullable: true
       dest_office_name:
         type: string
+        example: pecan office
+        x-nullable: true
       origin_office_address_name:
         type: string
         example: Office manager John Dough
+        x-nullable: true
       origin_office_address:
         type: string
         example: '3450 Kneading Way, San Francisco, California 94104'
+        x-nullable: true
       service_member_first_name:
         type: string
         example: Focaccia
+        x-nullable: true
       service_member_middle_initial:
         example: L.
+        x-nullable: true
       service_member_last_name:
         type: string
         example: Roll
+        x-nullable: true
       service_member_rank:
         $ref: '#/definitions/RankGrade'
+        x-nullable: true
       service_member_ssn:
         type: string
         pattern: '^\d{3}-\d{2}-\d{4}$'
         example: 555-55-5555
+        x-nullable: true
       service_member_agency:
         type: string
         example: Air Force
+        x-nullable: true
       hhg_total_pounds:
         type: integer
         example: 10000
+        x-nullable: true
       hhg_progear_pounds:
         type: integer
         example: 350
+        x-nullable: true
       hhg_valuable_items_cartons:
         type: integer
         example: 3
+        x-nullable: true
       mobile_home_serial_number:
         type: string
         example: 45kljs98kljlkwj5
+        x-nullable: true
       mobile_home_length_ft:
         type: integer
         example: 72
+        x-nullable: true
       mobile_home_length_inches:
         type: integer
         example: 4
+        x-nullable: true
       mobile_home_width_ft:
         type: integer
         example: 15
+        x-nullable: true
       mobile_home_width_inches:
         type: integer
         example: 4
+        x-nullable: true
       mobile_home_height_ft:
         type: integer
         example: 10
+        x-nullable: true
       mobile_home_height_inches:
         type: integer
         example: 3
+        x-nullable: true
       mobile_home_type_expando:
         type: string
         example: bathroom and shower unit
+        x-nullable: true
       mobile_home_services_requested:
         type: string
         enum:
@@ -191,167 +218,139 @@ definitions:
         - mobile home unblocked
         - stored at origin
         - stored at destination
+        x-nullable: true
       station_orders_type:
         type: string
         enum:
         - permanent
         - temporary
+        x-nullable: true
       station_orders_issued_by:
         type: string
         example: Sergeant Naan
+        x-nullable: true
       station_orders_new_assignment:
         type: string
         example: ACCOUNTING OPS
+        x-nullable: true
       station_orders_date:
         type: string
         format: date
         example: 2018-03-15
+        x-nullable: true
       station_orders_number:
         type: string
         example: "98374"
+        x-nullable: true
       station_orders_paragraph_number:
         type: string
         example: "5"
+        x-nullable: true
       station_orders_in_transit_telephone:
         type: string
         pattern: '^[2-9]\d{2}-\d{3}-\d{4}$'
         example: 212-666-6666
+        x-nullable: true
       in_transit_address:
         type: string
         example: '3450 Kneading Way, San Francisco, California 94104'
+        x-nullable: true
       pickup_address:
         type: string
         example: '3450 Kneading Way, San Francisco, California 94104'
+        x-nullable: true
       pickup_address_mobile_court_name:
         type: string
         example: Winnebagel court
+        x-nullable: true
       pickup_telephone:
         type: string
         pattern: '^[2-9]\d{2}-\d{3}-\d{4}$'
         example: 212-555-5555
+        x-nullable: true
       dest_address:
         type: string
         example: '3450 Kneading Way, San Francisco, California 94104'
+        x-nullable: true
       dest_address_mobile_court_name:
         type: string
         example: Carraway Court
+        x-nullable: true
       agent_to_receive_hhg:
         type: string
+        x-nullable: true
       extra_address:
         type: string
         example: '3450 Kneading Way, San Francisco, California 94104'
+        x-nullable: true
       pack_scheduled_date:
         type: string
         format: date
         example: 2018-03-08
+        x-nullable: true
       pickup_scheduled_date:
         type: string
         format: date
         example: 2018-03-09
+        x-nullable: true
       delivery_scheduled_date:
         type: string
         format: date
         example: 2018-03-10
+        x-nullable: true
       remarks:
         type: string
         example: please be careful with my stuff
+        x-nullable: true
       other_move_from:
         type: string
+        x-nullable: true
       other_move_to:
         type: string
+        x-nullable: true
       other_move_net_pounds:
         type: integer
         example: 2000
+        x-nullable: true
       other_move_progear_pounds:
         type: integer
         example: 100
+        x-nullable: true
       service_member_signature:
         type: string
         example: Focaccia Roll
+        x-nullable: true
       date_signed:
         type: string
         format: date
         example: 2018-01-23
+        x-nullable: true
       contractor_address:
         type: string
         example: '3450 Kneading Way, San Francisco, California 94104'
+        x-nullable: true
       contractor_name:
         type: string
         example: Mayflower Transit
+        x-nullable: true
       nonavailability_of_signature_reason:
         type: string
         example: service member not present
+        x-nullable: true
       certified_by_signature:
         type: string
         example: Sally Crumpet
+        x-nullable: true
       title_of_certified_by_signature:
         type: string
         example: Colonel Crumpet
-  IndexForms1299Payload:
+        x-nullable: true
+  IndexForm1299sPayload:
     type: array
     items:
       $ref: '#/definitions/Form1299Payload'
   Form1299Payload:
     type: object
-    required:
-    - id
-    - created_at
-    - updated_at
-    - form_completed
-    - date_prepared
-    - shipment_number
-    - name_of_preparing_office
-    - dest_office_name
-    - origin_office_address_name
-    - origin_office_address
-    - service_member_first_name
-    - service_member_middle_initial
-    - service_member_last_name
-    - service_member_rank
-    - service_member_ssn
-    - service_member_agency
-    - hhg_total_pounds
-    - hhg_progear_pounds
-    - hhg_valuable_items_cartons
-    - mobile_home_serial_number
-    - mobile_home_length_ft
-    - mobile_home_length_inches
-    - mobile_home_width_ft
-    - mobile_home_width_inches
-    - mobile_home_height_ft
-    - mobile_home_height_inches
-    - mobile_home_type_expando
-    - mobile_home_services_requested
-    - station_orders_type
-    - station_orders_issued_by
-    - station_orders_new_assignment
-    - station_orders_date
-    - station_orders_number
-    - station_orders_paragraph_number
-    - station_orders_in_transit_telephone
-    - in_transit_address
-    - pickup_address
-    - pickup_address_mobile_court_name
-    - pickup_telephone
-    - dest_address
-    - dest_address_mobile_court_name
-    - agent_to_receive_hhg
-    - extra_address
-    - pack_scheduled_date
-    - pickup_scheduled_date
-    - delivery_scheduled_date
-    - remarks
-    - other_move_from
-    - other_move_to
-    - other_move_net_pounds
-    - other_move_progear_pounds
-    - service_member_signature
-    - date_signed
-    - contractor_address
-    - contractor_name
-    - nonavailability_of_signature_reason
-    - certified_by_signature
-    - title_of_certified_by_signature
     properties:
       id:
         type: string
@@ -366,74 +365,98 @@ definitions:
       form_completed:
         type: boolean
         example: false
+        x-nullable: true
       date_prepared:
         type: string
         format: date
         example: 2018-01-03
+        x-nullable: true
       shipment_number:
         type: string
         example: "4550"
+        x-nullable: true
       name_of_preparing_office:
         type: string
         example: pumpernickel office
+        x-nullable: true
       dest_office_name:
         type: string
+        x-nullable: true
       origin_office_address_name:
         type: string
         example: Office manager John Dough
+        x-nullable: true
       origin_office_address:
         type: string
         example: '3450 Kneading Way, San Francisco, California 94104'
+        x-nullable: true
       service_member_first_name:
         type: string
         example: Focaccia
+        x-nullable: true
       service_member_middle_initial:
         example: L.
+        x-nullable: true
       service_member_last_name:
         type: string
         example: Roll
+        x-nullable: true
       service_member_rank:
         $ref: '#/definitions/RankGrade'
+        x-nullable: true
       service_member_ssn:
         type: string
         pattern: '^\d{3}-\d{2}-\d{4}$'
         example: 555-55-5555
+        x-nullable: true
       service_member_agency:
         type: string
         example: Air Force
+        x-nullable: true
       hhg_total_pounds:
         type: integer
         example: 10000
+        x-nullable: true
       hhg_progear_pounds:
         type: integer
         example: 3000
+        x-nullable: true
       hhg_valuable_items_cartons:
         type: integer
         example: 3
+        x-nullable: true
       mobile_home_serial_number:
         type: string
         example: 45kljs98kljlkwj5
+        x-nullable: true
       mobile_home_length_ft:
         type: integer
         example: 72
+        x-nullable: true
       mobile_home_length_inches:
         type: integer
         example: 4
+        x-nullable: true
       mobile_home_width_ft:
         type: integer
         example: 15
+        x-nullable: true
       mobile_home_width_inches:
         type: integer
         example: 4
+        x-nullable: true
       mobile_home_height_ft:
         type: integer
         example: 10
+        x-nullable: true
       mobile_home_height_inches:
         type: integer
         example: 3
+        x-nullable: true
       mobile_home_type_expando:
         type: string
         example: bathroom and shower unit
+        x-nullable: true
       mobile_home_services_requested:
         type: string
         enum:
@@ -442,103 +465,137 @@ definitions:
         - mobile home unblocked
         - stored at origin
         - stored at destination
+        x-nullable: true
       station_orders_type:
         type: string
         enum:
         - permanent
         - temporary
+        x-nullable: true
       station_orders_issued_by:
         type: string
         example: Sergeant Naan
+        x-nullable: true
       station_orders_new_assignment:
         type: string
         example: ACCOUNTING OPS
+        x-nullable: true
       station_orders_date:
         type: string
         format: date
         example: 2018-03-15
+        x-nullable: true
       station_orders_number:
         type: string
         example: "98374"
+        x-nullable: true
       station_orders_paragraph_number:
         type: string
         example: "5"
+        x-nullable: true
       station_orders_in_transit_telephone:
         type: string
         pattern: '^[2-9]\d{2}-\d{3}-\d{4}$'
         example: 212-666-6666
+        x-nullable: true
       in_transit_address:
         type: string
         example: '3450 Kneading Way, San Francisco, California 94104'
+        x-nullable: true
       pickup_address:
         type: string
         example: '3450 Kneading Way, San Francisco, California 94104'
+        x-nullable: true
       pickup_address_mobile_court_name:
         type: string
         example: Winnebagel court
+        x-nullable: true
       pickup_telephone:
         type: string
         pattern: '^[2-9]\d{2}-\d{3}-\d{4}$'
         example: 212-555-5555
+        x-nullable: true
       dest_address:
         type: string
         example: '3450 Kneading Way, San Francisco, California 94104'
+        x-nullable: true
       dest_address_mobile_court_name:
         type: string
         example: Carraway Court
+        x-nullable: true
       agent_to_receive_hhg:
         type: string
+        x-nullable: true
       extra_address:
         type: string
         example: '3450 Kneading Way, San Francisco, California 94104'
+        x-nullable: true
       pack_scheduled_date:
         type: string
         format: date
         example: 2018-03-08
+        x-nullable: true
       pickup_scheduled_date:
         type: string
         format: date
         example: 2018-03-09
+        x-nullable: true
       delivery_scheduled_date:
         type: string
         format: date
         example: 2018-03-10
+        x-nullable: true
       remarks:
         type: string
         example: please be careful with my stuff
+        x-nullable: true
       other_move_from:
         type: string
+        x-nullable: true
       other_move_to:
         type: string
+        x-nullable: true
       other_move_net_pounds:
         type: integer
         example: 4000
+        x-nullable: true
       other_move_progear_pounds:
         type: integer
         example: 88
+        x-nullable: true
       service_member_signature:
         type: string
         example: Focaccia Roll
+        x-nullable: true
       date_signed:
         type: string
         format: date
         example: 2018-01-23
+        x-nullable: true
       contractor_address:
         type: string
         example: '3450 Kneading Way, San Francisco, California 94104'
+        x-nullable: true
       contractor_name:
         type: string
         example: Mayflower Transit
+        x-nullable: true
       nonavailability_of_signature_reason:
         type: string
         example: service member not present
+        x-nullable: true
       certified_by_signature:
         type: string
         example: Sally Crumpet
+        x-nullable: true
       title_of_certified_by_signature:
         type: string
         example: Colonel Crumpet
-
+        x-nullable: true
+    required:
+      - id
+      - created_at
+      - updated_at
   RankGrade:
     type: string
     enum:
@@ -602,4 +659,3 @@ definitions:
         * aviation_cadet - Aviation Cadet
         * civilian_employee - Civilian Employee
         * midshipman - Midshipman
-


### PR DESCRIPTION
Allows nullable values (using pointers) for go-swagger server code generation, standardizes the plural naming scheme for "form1299s" (Even though "forms1299" might be more grammatically correct, the inconsistency is adding unnecessary complexity at this point.)