### PR TITLE
Allow configuring the listening interface for development, to prevent the firewall from complaining.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,10 +54,10 @@ server_build: server_deps server_generate
 	go build -i -o bin/webserver ./cmd/webserver
 # This command is for running the server by itself, it will serve the compiled frontend on its own
 server_run_standalone: client_build server_build db_dev_run
-	./bin/webserver \
-		-debug_logging
+	DEBUG_LOGGING=true ./bin/webserver
 # This command runs the server behind gin, a hot-reload server
 server_run: server_deps server_generate db_dev_run
+	INTERFACE=localhost DEBUG_LOGGING=true \
 	./bin/gin --build ./cmd/webserver \
 		--bin /bin/webserver \
 		--port 8080 --appPort 8081 \

--- a/cmd/webserver/main.go
+++ b/cmd/webserver/main.go
@@ -38,6 +38,7 @@ func main() {
 	build := flag.String("build", "build", "the directory to serve static files from.")
 	config := flag.String("config-dir", "config", "The location of server config files")
 	env := flag.String("env", "development", "The environment to run in, configures the database, presenetly.")
+	listenInterface := flag.String("interface", "", "The interface spec to listen for connections on. Default is all.")
 	port := flag.String("port", "8080", "the `port` to listen on.")
 	swagger := flag.String("swagger", "swagger.yaml", "The location of the swagger API definition")
 	debugLogging := flag.Bool("debug_logging", false, "log messages at the debug level.")
@@ -94,8 +95,8 @@ func main() {
 	// And request logging
 	root.Use(requestLogger)
 
-	zap.L().Info("Starting the server listening", zap.String("port", *port))
-	address := fmt.Sprintf(":%s", *port)
+	address := fmt.Sprintf("%s:%s", *listenInterface, *port)
+	zap.L().Info("Starting the server listening", zap.String("address", address))
 	log.Fatal(http.ListenAndServe(address, root))
 }
 


### PR DESCRIPTION
We are experimenting with requiring the macOS firewall being enabled via fleetsmith. This was really annoying because it meant every time you rebuilt and restarted the web server, the os prompted you for wether you wanted to allow it to accept incoming connections. By passing more of the connect string in as a parameter, we are able to restrict it to localhost for dev which the firewall doesn't care to prompt for. 