### PR TITLE
Pin Dockerfiles to golang:1.9.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Start from a Debian image with the latest version of Go installed
 # and a workspace (GOPATH) configured at /go.
-FROM golang AS build
+FROM golang:1.9.3 AS build
 
 # Install tools required to build the project
 # We will need to run `docker build --no-cache .` to update those dependencies

--- a/Dockerfile.migrations
+++ b/Dockerfile.migrations
@@ -3,7 +3,7 @@
 
 # Start from a Debian image with the latest version of Go installed
 # and a workspace (GOPATH) configured at /go.
-FROM golang AS build
+FROM golang:1.9.3 AS build
 
 RUN go get github.com/golang/dep/cmd/dep
 

--- a/Dockerfile.tsp
+++ b/Dockerfile.tsp
@@ -1,6 +1,6 @@
 # Start from a Debian image with the latest version of Go installed
 # and a workspace (GOPATH) configured at /go.
-FROM golang AS build
+FROM golang:1.9.3 AS build
 
 # Install tools required to build the project
 # We will need to run `docker build --no-cache .` to update those dependencies


### PR DESCRIPTION
There is a race condition when new images are released where some
architectures are available before others. By relying on `latest` we hit
this race condition whenever a new release happens. Instead, let's pin
on a release.

Additionally, this makes our builds more reproducible.