### PR TITLE
First pass at the TSP Award Queue

### DIFF
--- a/cmd/tsp_award_queue/main.go
+++ b/cmd/tsp_award_queue/main.go
@@ -1,7 +1,42 @@
 package main
 
-import "fmt"
+import (
+	"log"
+
+	"github.com/markbates/pop"
+	"github.com/namsral/flag"
+	"go.uber.org/zap"
+
+	"github.com/transcom/mymove/pkg/awardqueue"
+)
+
+var logger *zap.Logger
 
 func main() {
-	fmt.Println("Hello, TSP Award Queue!")
+	config := flag.String("config-dir", "config", "The location of server config files")
+	env := flag.String("env", "development", "The environment to run in, configures the database, presenetly.")
+	debugLogging := flag.Bool("debug_logging", false, "log messages at the debug level.")
+	flag.Parse()
+
+	// Set up logger for the system
+	var err error
+	if *debugLogging {
+		logger, err = zap.NewDevelopment()
+	} else {
+		logger, err = zap.NewProduction()
+	}
+
+	if err != nil {
+		log.Fatalf("Failed to initialize Zap logging due to %v", err)
+	}
+	zap.ReplaceGlobals(logger)
+
+	// DB connection
+	pop.AddLookupPaths(*config)
+	dbConnection, err := pop.Connect(*env)
+	if err != nil {
+		log.Panic(err)
+	}
+
+	awardqueue.Run(dbConnection)
 }

--- a/pkg/awardqueue/awardqueue.go
+++ b/pkg/awardqueue/awardqueue.go
@@ -12,20 +12,30 @@ var dbConnection *pop.Connection
 
 // This function was made just to get my Golang legs on and play with data
 func findAllUnawardedShipments() ([]models.Shipment, error) {
+	unawardedShipments := []models.Shipment{}
 	shipments := []models.Shipment{}
 	err := dbConnection.All(&shipments)
 
 	if err != nil {
-		fmt.Printf("Oh snap! %s", err)
-		return nil, err
+		return _, err
 	}
-	fmt.Printf("Shipments:\n%v\n", shipments)
 
-	return shipments, nil
+	for _, shipment := range shipments {
+		awardedShipments := []models.AwardedShipment{}
+		queryStr := fmt.Sprintf("shipment_id = '%s'", shipment.ID)
+		asQuery := dbConnection.Where(queryStr)
+		asQuery.All(&awardedShipments)
+
+	}
+
+	return shipments, err
 }
 
 func awardShipment(shipment models.Shipment) {
-	fmt.Printf("Trying to award shipment:\n%v\n", shipment)
+	fmt.Printf("Trying to award shipment: %v\n", shipment.ID)
+
+	// Query shipment's TDL
+	query := dbConnection.Where("")
 }
 
 /*Run will execute the Award Queue algorithm described below.

--- a/pkg/awardqueue/awardqueue.go
+++ b/pkg/awardqueue/awardqueue.go
@@ -11,63 +11,40 @@ import (
 var dbConnection *pop.Connection
 
 // This function was made just to get my Golang legs on and play with data
-func makeSomeStuffUp() {
-	tdl1 := models.TrafficDistributionList{
-		SourceRateArea:    "here",
-		DestinationRegion: "there",
-		CodeOfService:     "place",
-	}
-	dbConnection.ValidateAndSave(&tdl1)
-}
-
-// This function was made just to get my Golang legs on and play with data
-func findAllShipments() error {
+func findAllUnawardedShipments() ([]models.Shipment, error) {
 	shipments := []models.Shipment{}
 	err := dbConnection.All(&shipments)
+
 	if err != nil {
 		fmt.Printf("Oh snap! %s", err)
-		return err
+		return nil, err
 	}
 	fmt.Printf("Shipments:\n%v\n", shipments)
 
-	return nil
+	return shipments, nil
 }
 
-// This function was made just to get my Golang legs on and play with data
-func findAllTrafficDistributionLists() error {
-	tdls := []models.TrafficDistributionList{}
-	err := dbConnection.All(&tdls)
-	if err != nil {
-		fmt.Printf("Oh snap! %s", err)
-		return err
-	}
-
-	for i, tdl := range tdls {
-		fmt.Printf("TDL %d:\n%v\n", i, tdl)
-	}
-
-	return nil
+func awardShipment(shipment models.Shipment) {
+	fmt.Printf("Trying to award shipment:\n%v\n", shipment)
 }
 
 /*Run will execute the Award Queue algorithm described below.
-
-- Query for TDLs, so we know what markets exist
-- Query for shipments that do not have a matching awarded_shipment
-- Group shipments by the TDL they belong to
-- For each TDL:
-  - Sort Shipments by BVS
-  - Query TSPs in this TDL, joined on & sorted by BVS
-  - In order of descending BVS, create AwardedShipments matching
-    shipments to TSPs.
+- Given all unawarded shipments...
+- Query shipment's TDL
+- Query TSPs in the TDL, sorted by awarded_shipments[asc] and bvs[desc]
+- Create awarded_shipment for the shipment<->tsp
 */
 func Run(db *pop.Connection) {
 	dbConnection = db
 
-	makeSomeStuffUp()
-
 	fmt.Println("Hello, TSP Award Queue!")
 
-	findAllShipments()
-	findAllTrafficDistributionLists()
-
+	shipments, err := findAllUnawardedShipments()
+	if err == nil {
+		for _, shipment := range shipments {
+			awardShipment(shipment)
+		}
+	} else {
+		fmt.Printf("Failed to query for shipments!")
+	}
 }

--- a/pkg/awardqueue/awardqueue.go
+++ b/pkg/awardqueue/awardqueue.go
@@ -1,0 +1,53 @@
+package awardqueue
+
+import (
+	"fmt"
+
+	"github.com/markbates/pop"
+
+	"github.com/transcom/mymove/pkg/models"
+)
+
+var dbConnection *pop.Connection
+
+func makeSomeStuffUp() {
+	tdl1 := models.TrafficDistributionList{
+		SourceRateArea:    "here",
+		DestinationRegion: "there",
+		CodeOfService:     "place",
+	}
+	dbConnection.ValidateAndSave(&tdl1)
+}
+
+func findAllShipments() error {
+	shipments := []models.Shipment{}
+	err := dbConnection.All(&shipments)
+	if err != nil {
+		fmt.Printf("Oh snap! %s", err)
+		return err
+	}
+	fmt.Printf("Shipments:\n%v\n", shipments)
+	return nil
+}
+
+func findAllTrafficDistributionLists() {
+	tdls := []models.TrafficDistributionList{}
+	err := dbConnection.All(&tdls)
+	if err != nil {
+		fmt.Printf("Oh snap! %s", err)
+	}
+
+	for i, tdl := range tdls {
+		fmt.Printf("TDL %d:\n%v\n", i, tdl)
+	}
+}
+func Run(db *pop.Connection) {
+	dbConnection = db
+
+	makeSomeStuffUp()
+
+	fmt.Println("Hello, TSP Award Queue!")
+
+	findAllShipments()
+	findAllTrafficDistributionLists()
+}

--- a/pkg/awardqueue/awardqueue.go
+++ b/pkg/awardqueue/awardqueue.go
@@ -23,7 +23,7 @@ func selectTSPToAwardShipment(shipment models.ShipmentWithAwardedTSP) error {
 	err := dbConnection.Find(&tdl, shipment.TrafficDistributionListID)
 
 	// Find TSPs in that TDL sorted by awarded_shipments[asc] and bvs[desc]
-	tsps, err := models.FetchTransportationServiceProvidersInTDL(dbConnection, &tdl)
+	tsps, err := models.FetchTransportationServiceProvidersInTDL(dbConnection, tdl.ID)
 
 	for _, consideredTSP := range tsps {
 		fmt.Printf("\tConsidering TSP: %v\n", consideredTSP)
@@ -34,6 +34,7 @@ func selectTSPToAwardShipment(shipment models.ShipmentWithAwardedTSP) error {
 			// We found a valid TSP to award to!
 			err := models.AwardShipment(dbConnection, shipment.ID, tsp.ID, false)
 			if err == nil {
+				fmt.Print("\tShipment awarded to TSP!\n")
 				break
 			} else {
 				fmt.Printf("\tFailed to award to TSP: %v\n", err)
@@ -54,7 +55,7 @@ func Run(db *pop.Connection) {
 
 	shipments, err := findAllUnawardedShipments()
 	if err == nil {
-		count := 0
+		count := -1
 		for i, shipment := range shipments {
 			err = selectTSPToAwardShipment(shipment)
 			if err != nil {

--- a/pkg/awardqueue/awardqueue.go
+++ b/pkg/awardqueue/awardqueue.go
@@ -63,7 +63,7 @@ func Run(db *pop.Connection) {
 			}
 			count = i
 		}
-		fmt.Printf("Awarded %d shipments.", count+1)
+		fmt.Printf("Awarded %d shipments.\n", count+1)
 	} else {
 		fmt.Printf("Failed to query for shipments: %s", err)
 	}

--- a/pkg/awardqueue/awardqueue.go
+++ b/pkg/awardqueue/awardqueue.go
@@ -10,12 +10,12 @@ import (
 
 var dbConnection *pop.Connection
 
-func findAllUnawardedShipments() ([]models.ShipmentWithAwardedTSP, error) {
+func findAllUnawardedShipments() ([]models.PossiblyAwardedShipment, error) {
 	shipments, err := models.FetchAwardedShipments(dbConnection)
 	return shipments, err
 }
 
-func selectTSPToAwardShipment(shipment models.ShipmentWithAwardedTSP) error {
+func selectTSPToAwardShipment(shipment models.PossiblyAwardedShipment) error {
 	fmt.Printf("Attempting to award shipment: %v\n", shipment.ID)
 
 	// Query the shipment's TDL

--- a/pkg/awardqueue/awardqueue.go
+++ b/pkg/awardqueue/awardqueue.go
@@ -10,6 +10,7 @@ import (
 
 var dbConnection *pop.Connection
 
+// This function was made just to get my Golang legs on and play with data
 func makeSomeStuffUp() {
 	tdl1 := models.TrafficDistributionList{
 		SourceRateArea:    "here",
@@ -19,6 +20,7 @@ func makeSomeStuffUp() {
 	dbConnection.ValidateAndSave(&tdl1)
 }
 
+// This function was made just to get my Golang legs on and play with data
 func findAllShipments() error {
 	shipments := []models.Shipment{}
 	err := dbConnection.All(&shipments)
@@ -27,20 +29,37 @@ func findAllShipments() error {
 		return err
 	}
 	fmt.Printf("Shipments:\n%v\n", shipments)
+
 	return nil
 }
 
-func findAllTrafficDistributionLists() {
+// This function was made just to get my Golang legs on and play with data
+func findAllTrafficDistributionLists() error {
 	tdls := []models.TrafficDistributionList{}
 	err := dbConnection.All(&tdls)
 	if err != nil {
 		fmt.Printf("Oh snap! %s", err)
+		return err
 	}
 
 	for i, tdl := range tdls {
 		fmt.Printf("TDL %d:\n%v\n", i, tdl)
 	}
+
+	return nil
 }
+
+/*Run will execute the Award Queue algorithm described below.
+
+- Query for TDLs, so we know what markets exist
+- Query for shipments that do not have a matching awarded_shipment
+- Group shipments by the TDL they belong to
+- For each TDL:
+  - Sort Shipments by BVS
+  - Query TSPs in this TDL, joined on & sorted by BVS
+  - In order of descending BVS, create AwardedShipments matching
+    shipments to TSPs.
+*/
 func Run(db *pop.Connection) {
 	dbConnection = db
 
@@ -50,4 +69,5 @@ func Run(db *pop.Connection) {
 
 	findAllShipments()
 	findAllTrafficDistributionLists()
+
 }

--- a/pkg/awardqueue/awardqueue.go
+++ b/pkg/awardqueue/awardqueue.go
@@ -20,10 +20,10 @@ func awardShipment(shipment models.ShipmentWithAwardedTSP) error {
 
 	// Query shipment's TDL
 	tdl := models.TrafficDistributionList{}
-	err := dbConnection.Find(&tdl, shipment.TrafficDistributionListId)
+	err := dbConnection.Find(&tdl, shipment.TrafficDistributionListID)
 
 	// Query TSPs in that TDL sorted by awarded_shipments[asc] and bvs[desc]
-	tsps, err := models.FetchTransportationServiceProvidersInTDL(dbConnection, tdl)
+	tsps, err := models.FetchTransportationServiceProvidersInTDL(dbConnection, &tdl)
 
 	for _, tsp := range tsps {
 		fmt.Printf("Considering TSP: %v\n", tsp)

--- a/pkg/awardqueue/awardqueue.go
+++ b/pkg/awardqueue/awardqueue.go
@@ -10,44 +10,37 @@ import (
 
 var dbConnection *pop.Connection
 
-// This function was made just to get my Golang legs on and play with data
-func findAllUnawardedShipments() ([]models.Shipment, error) {
-	unawardedShipments := []models.Shipment{}
-	shipments := []models.Shipment{}
-	err := dbConnection.All(&shipments)
-
-	if err != nil {
-		return _, err
-	}
-
-	for _, shipment := range shipments {
-		awardedShipments := []models.AwardedShipment{}
-		queryStr := fmt.Sprintf("shipment_id = '%s'", shipment.ID)
-		asQuery := dbConnection.Where(queryStr)
-		asQuery.All(&awardedShipments)
-
-	}
-
+func findAllUnawardedShipments() ([]models.ShipmentWithAwardedTSP, error) {
+	shipments, err := models.FetchAwardedShipments(dbConnection)
 	return shipments, err
 }
 
-func awardShipment(shipment models.Shipment) {
-	fmt.Printf("Trying to award shipment: %v\n", shipment.ID)
+func awardShipment(shipment models.ShipmentWithAwardedTSP) error {
+	fmt.Printf("Attempting to award shipment: %v\n", shipment.ID)
 
 	// Query shipment's TDL
-	query := dbConnection.Where("")
+	tdl := models.TrafficDistributionList{}
+	err := dbConnection.Find(&tdl, shipment.TrafficDistributionListId)
+
+	// Query TSPs in that TDL sorted by awarded_shipments[asc] and bvs[desc]
+	tsps, err := models.FetchTransportationServiceProvidersInTDL(dbConnection, tdl)
+
+	for _, tsp := range tsps {
+		fmt.Printf("Considering TSP: %v\n", tsp)
+	}
+
+	return err
 }
 
 /*Run will execute the Award Queue algorithm described below.
 - Given all unawarded shipments...
-- Query shipment's TDL
 - Query TSPs in the TDL, sorted by awarded_shipments[asc] and bvs[desc]
 - Create awarded_shipment for the shipment<->tsp
 */
 func Run(db *pop.Connection) {
 	dbConnection = db
 
-	fmt.Println("Hello, TSP Award Queue!")
+	fmt.Println("TSP Award Queue running.")
 
 	shipments, err := findAllUnawardedShipments()
 	if err == nil {
@@ -55,6 +48,6 @@ func Run(db *pop.Connection) {
 			awardShipment(shipment)
 		}
 	} else {
-		fmt.Printf("Failed to query for shipments!")
+		fmt.Printf("Failed to query for shipments: %s", err)
 	}
 }

--- a/pkg/awardqueue/awardqueue_test.go
+++ b/pkg/awardqueue/awardqueue_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/markbates/pop"
 )
 
-func TestFindAllShipments(t *testing.T) {
-	err := findAllShipments()
+func TestFindAllUnawardedShipments(t *testing.T) {
+	_, err := findAllUnawardedShipments()
 
 	if err != nil {
 		t.Fatal("Unable to find shipments: ", err)

--- a/pkg/awardqueue/awardqueue_test.go
+++ b/pkg/awardqueue/awardqueue_test.go
@@ -1,0 +1,34 @@
+package awardqueue
+
+import (
+	"log"
+	"os"
+	"testing"
+
+	"github.com/markbates/pop"
+)
+
+func TestFindAllShipments(t *testing.T) {
+	err := findAllShipments()
+
+	if err != nil {
+		t.Fatal("Unable to find shipments: ", err)
+	}
+}
+
+func setupDBConnection() {
+	configLocation := "../../../config"
+	pop.AddLookupPaths(configLocation)
+	conn, err := pop.Connect("test")
+	if err != nil {
+		log.Panic(err)
+	}
+
+	dbConnection = conn
+}
+
+func TestMain(m *testing.M) {
+	setupDBConnection()
+
+	os.Exit(m.Run())
+}

--- a/pkg/models/awarded_shipment.go
+++ b/pkg/models/awarded_shipment.go
@@ -2,7 +2,6 @@ package models
 
 import (
 	"encoding/json"
-	"fmt"
 	"time"
 
 	"github.com/markbates/pop"
@@ -70,8 +69,7 @@ func AwardShipment(tx *pop.Connection,
 		TransportationServiceProviderID: tspID,
 		AdministrativeShipment:          administrativeShipment,
 	}
-	awd, err := tx.ValidateAndSave(&awardedShipment)
-	fmt.Printf("Awarding shipment: %s", awd)
+	_, err := tx.ValidateAndSave(&awardedShipment)
 
 	return err
 }

--- a/pkg/models/awarded_shipment.go
+++ b/pkg/models/awarded_shipment.go
@@ -2,11 +2,13 @@ package models
 
 import (
 	"encoding/json"
+	"fmt"
+	"time"
+
 	"github.com/markbates/pop"
 	"github.com/markbates/validate"
 	v "github.com/markbates/validate/validators"
 	"github.com/satori/go.uuid"
-	"time"
 )
 
 // AwardedShipment maps a Transportation Service Provider to a shipment,
@@ -54,4 +56,22 @@ func (a *AwardedShipment) ValidateCreate(tx *pop.Connection) (*validate.Errors, 
 // This method is not required and may be deleted.
 func (a *AwardedShipment) ValidateUpdate(tx *pop.Connection) (*validate.Errors, error) {
 	return validate.NewErrors(), nil
+}
+
+// AwardShipment connects a shipment to a transportation service provider. This
+// function assumes that the match has been validated by the caller.
+func AwardShipment(tx *pop.Connection,
+	shipmentID uuid.UUID,
+	tspID uuid.UUID,
+	administrativeShipment bool) error {
+
+	awardedShipment := AwardedShipment{
+		ShipmentID:                      shipmentID,
+		TransportationServiceProviderID: tspID,
+		AdministrativeShipment:          administrativeShipment,
+	}
+	awd, err := tx.ValidateAndSave(&awardedShipment)
+	fmt.Printf("Awarding shipment: %s", awd)
+
+	return err
 }

--- a/pkg/models/shipment.go
+++ b/pkg/models/shipment.go
@@ -29,14 +29,6 @@ type PossiblyAwardedShipment struct {
 	AdministrativeShipment          *bool      `db:"administrative_shipment"`
 }
 
-// ShipmentWithAwardedTSP
-type ShipmentWithAwardedTSP struct {
-	ID                              uuid.UUID  `json:"id" db:"id"`
-	TrafficDistributionListID       uuid.UUID  `json:"traffic_distribution_list_id" db:"traffic_distribution_list_id"`
-	TransportationServiceProviderID *uuid.UUID `json:"transportation_service_provider_id" db:"transportation_service_provider_id"`
-	AdministrativeShipment          bool       `json:"administrative_shipment" db:"administrative_shipment"`
-}
-
 // FetchPossiblyAwardedShipments runs the SQL query to fetch possibly awarded shipments from db
 func FetchPossiblyAwardedShipments(dbConnection *pop.Connection) ([]PossiblyAwardedShipment, error) {
 	shipments := []PossiblyAwardedShipment{}
@@ -89,8 +81,8 @@ func (s *Shipment) ValidateUpdate(tx *pop.Connection) (*validate.Errors, error) 
 	return validate.NewErrors(), nil
 }
 
-func FetchAwardedShipments(tx *pop.Connection) ([]ShipmentWithAwardedTSP, error) {
-	shipments := []ShipmentWithAwardedTSP{}
+func FetchAwardedShipments(tx *pop.Connection) ([]PossiblyAwardedShipment, error) {
+	shipments := []PossiblyAwardedShipment{}
 
 	sql := `SELECT
 			shipments.id,

--- a/pkg/models/shipment.go
+++ b/pkg/models/shipment.go
@@ -81,6 +81,7 @@ func (s *Shipment) ValidateUpdate(tx *pop.Connection) (*validate.Errors, error) 
 	return validate.NewErrors(), nil
 }
 
+// FetchAwardedShipments looks up all unawarded shipments and returns them in the PossiblyAwardedShipment struct
 func FetchAwardedShipments(tx *pop.Connection) ([]PossiblyAwardedShipment, error) {
 	shipments := []PossiblyAwardedShipment{}
 

--- a/pkg/models/shipment.go
+++ b/pkg/models/shipment.go
@@ -74,3 +74,11 @@ func (s *Shipment) ValidateCreate(tx *pop.Connection) (*validate.Errors, error) 
 func (s *Shipment) ValidateUpdate(tx *pop.Connection) (*validate.Errors, error) {
 	return validate.NewErrors(), nil
 }
+
+// AllShipmentsWithTDLs queries for and returns shipments joined with their TDLs.
+func AllShipmentsWithTDLs(tx *pop.Connection) ([]models.TrafficDistributionList, error) {
+	shipments := []models.Shipment{}
+	err := tx.LeftJoin("shipments", "shipments.traffic_distribution_list_id=traffic_distribution_lists.id")
+
+	return shipmentsWithTDLs, err
+}

--- a/pkg/models/transportation_service_provider.go
+++ b/pkg/models/transportation_service_provider.go
@@ -1,9 +1,8 @@
 package models
 
 import (
-	"errors"
-
 	"encoding/json"
+
 	"github.com/markbates/pop"
 	"github.com/markbates/validate"
 	"github.com/markbates/validate/validators"
@@ -67,11 +66,7 @@ func (t *TransportationServiceProvider) ValidateUpdate(tx *pop.Connection) (*val
 
 // FetchTransportationServiceProvidersInTDL returns TSPs in a given TDL in the
 // order that they should be awarded new shipments.
-func FetchTransportationServiceProvidersInTDL(tx *pop.Connection, tdl *TrafficDistributionList) ([]TSPWithBVSAndAwardCount, error) {
-	if tdl == nil {
-		return nil, errors.New("trafffic distribution list cannot be nil")
-	}
-
+func FetchTransportationServiceProvidersInTDL(tx *pop.Connection, tdlID uuid.UUID) ([]TSPWithBVSAndAwardCount, error) {
 	// We need to get TSPs, along with their Best Value Scores and total
 	// awarded shipments, hence the two joins. Some notes on the query:
 	// - We min() the id and scores, because we need an aggregate function given


### PR DESCRIPTION
The first pass of the TSP Award Queue. This is a work in progress for the Friday Demo.

To test it:
```
# Generate some fake data, so that there are unawarded shipments in your database
$ go run cmd/generate_test_data/main.go 
# Run the award queue!
$ go run cmd/tsp_award_queue/main.go 
TSP Award Queue running.
Attempting to award shipment: b6e7bbf7-7d86-4cc0-8667-89348d2c35b5
	Considering TSP: {3788f0d4-20dc-48b7-9f78-55636841c097 8 128}
	Shipment awarded to TSP!
Attempting to award shipment: 4a50e9d4-ffd7-454c-81bc-fdb2912fd898
	Considering TSP: {e8c50616-9cc1-41ca-8386-c58af7f1e5b9 2 128}
	Shipment awarded to TSP!
Attempting to award shipment: ae1c3665-8b9c-4b6e-b3e9-26e160bc2f2c
	Considering TSP: {0b8577db-70cd-4d0a-b304-7c48bf65b637 11 136}
	Shipment awarded to TSP!
Awarded 3 shipments.
```

There are a lot of places this still needs work:
* Testing!
* Cleaning up how we do queries for awarded & unawarded shipments. There is some competing code that was developed along side another task in the `shipment.go` model file.
* Clean up in general.