### PR TITLE
disable submit button when there are form is pristine, submitting or invalid

### DIFF
--- a/src/shared/JsonSchemaForm/index.jsx
+++ b/src/shared/JsonSchemaForm/index.jsx
@@ -79,13 +79,16 @@ const renderSchema = (schema, uiSchema) => {
   }
 };
 const JsonSchemaForm = props => {
+  const { pristine, submitting, invalid } = props;
   const { handleSubmit, schema, uiSchema } = props;
   const title = schema ? schema.title : '';
   return (
     <form className="default" onSubmit={handleSubmit}>
       <h1>{title}</h1>
       {renderSchema(schema, uiSchema)}
-      <button type="submit">Submit</button>
+      <button type="submit" disabled={pristine || submitting || invalid}>
+        Submit
+      </button>
     </form>
   );
 };


### PR DESCRIPTION
AC: submit button is disabled when there are no changes to form values
AC: submit button is disabled when there is a submit in process
AC: submit button is disabled when there is a field with an invalid value

The last two are hard to test for since the a) the form submits fairly quickly and b) we are not validating many fields. I've tested for invalid fields by adding non-numeric value for a weight in firefox (chrome doesn't let you enter a non-numeric value)
[delivers #155088044]