### PR TITLE
Rename AwardedShipment to ShipmentAward.

### DIFF
--- a/cmd/generate_test_data/main.go
+++ b/cmd/generate_test_data/main.go
@@ -140,13 +140,13 @@ func main() {
 	}
 
 	// Add one awarded shipment record using existing shipment and TSP IDs
-	awardedShipment1 := models.AwardedShipment{
+	award1 := models.ShipmentAward{
 		ShipmentID:                      shipmentList[0].ID,
 		TransportationServiceProviderID: tspList[0].ID,
 		AdministrativeShipment:          false,
 	}
 
-	_, err = dbConnection.ValidateAndSave(&awardedShipment1)
+	_, err = dbConnection.ValidateAndSave(&award1)
 	if err != nil {
 		log.Panic(err)
 	}

--- a/migrations/20180212211942_rename_awarded_shipments.down.fizz
+++ b/migrations/20180212211942_rename_awarded_shipments.down.fizz
@@ -1,0 +1,2 @@
+rename_table("shipment_awards", "awarded_shipments")
+

--- a/migrations/20180212211942_rename_awarded_shipments.up.fizz
+++ b/migrations/20180212211942_rename_awarded_shipments.up.fizz
@@ -1,0 +1,1 @@
+rename_table("awarded_shipments", "shipment_awards")

--- a/pkg/awardqueue/awardqueue.go
+++ b/pkg/awardqueue/awardqueue.go
@@ -22,7 +22,7 @@ func selectTSPToAwardShipment(shipment models.PossiblyAwardedShipment) error {
 	tdl := models.TrafficDistributionList{}
 	err := dbConnection.Find(&tdl, shipment.TrafficDistributionListID)
 
-	// Find TSPs in that TDL sorted by awarded_shipments[asc] and bvs[desc]
+	// Find TSPs in that TDL sorted by shipment_awards[asc] and bvs[desc]
 	tsps, err := models.FetchTransportationServiceProvidersInTDL(dbConnection, tdl.ID)
 
 	for _, consideredTSP := range tsps {
@@ -32,7 +32,7 @@ func selectTSPToAwardShipment(shipment models.PossiblyAwardedShipment) error {
 		err := dbConnection.Find(&tsp, consideredTSP.TransportationServiceProviderID)
 		if err == nil {
 			// We found a valid TSP to award to!
-			err := models.AwardShipment(dbConnection, shipment.ID, tsp.ID, false)
+			err := models.CreateShipmentAward(dbConnection, shipment.ID, tsp.ID, false)
 			if err == nil {
 				fmt.Print("\tShipment awarded to TSP!\n")
 				break

--- a/pkg/handlers/shipments_test.go
+++ b/pkg/handlers/shipments_test.go
@@ -42,18 +42,18 @@ func TestIndexShipmentsHandler(t *testing.T) {
 	}
 	mustSave(t, &aws)
 
-	awarded := models.AwardedShipment{
+	award := models.ShipmentAward{
 		ShipmentID:                      aws.ID,
 		TransportationServiceProviderID: tsp.ID,
 	}
-	mustSave(t, &awarded)
+	mustSave(t, &award)
 
 	params := shipmentop.NewIndexShipmentsParams()
 	indexResponse := IndexShipmentsHandler(params)
 
 	okResponse, ok := indexResponse.(*shipmentop.IndexShipmentsOK)
 	if !ok {
-		t.Errorf("Request failed: %#v", indexResponse)
+		t.Fatalf("Request failed: %#v", indexResponse)
 	}
 	shipments := okResponse.Payload
 

--- a/pkg/models/shipment.go
+++ b/pkg/models/shipment.go
@@ -34,15 +34,15 @@ func FetchPossiblyAwardedShipments(dbConnection *pop.Connection) ([]PossiblyAwar
 	shipments := []PossiblyAwardedShipment{}
 
 	// TODO Can Q() be .All(&shipments)
-	query := dbConnection.Q().LeftOuterJoin("awarded_shipments", "awarded_shipments.shipment_id=shipments.id")
+	query := dbConnection.Q().LeftOuterJoin("shipment_awards", "shipment_awards.shipment_id=shipments.id")
 
 	sql, args := query.ToSQL(&pop.Model{Value: Shipment{}},
 		"shipments.id",
 		"shipments.created_at",
 		"shipments.updated_at",
 		"shipments.traffic_distribution_list_id",
-		"awarded_shipments.transportation_service_provider_id",
-		"awarded_shipments.administrative_shipment",
+		"shipment_awards.transportation_service_provider_id",
+		"shipment_awards.administrative_shipment",
 	)
 	err := dbConnection.RawQuery(sql, args...).All(&shipments)
 	return shipments, err
@@ -88,11 +88,11 @@ func FetchAwardedShipments(tx *pop.Connection) ([]PossiblyAwardedShipment, error
 	sql := `SELECT
 			shipments.id,
 			shipments.traffic_distribution_list_id,
-			awarded_shipments.transportation_service_provider_id
+			shipment_awards.transportation_service_provider_id
 		FROM shipments
-		LEFT JOIN awarded_shipments ON
-			awarded_shipments.shipment_id=shipments.id
-		WHERE awarded_shipments.id IS NULL`
+		LEFT JOIN shipment_awards ON
+			shipment_awards.shipment_id=shipments.id
+		WHERE shipment_awards.id IS NULL`
 
 	err := tx.RawQuery(sql).All(&shipments)
 

--- a/pkg/models/shipment_award.go
+++ b/pkg/models/shipment_award.go
@@ -10,9 +10,9 @@ import (
 	"github.com/satori/go.uuid"
 )
 
-// AwardedShipment maps a Transportation Service Provider to a shipment,
+// ShipmentAward maps a Transportation Service Provider to a shipment,
 // indicating that the shipment has been awarded to that TSP.
-type AwardedShipment struct {
+type ShipmentAward struct {
 	ID                              uuid.UUID `json:"id" db:"id"`
 	CreatedAt                       time.Time `json:"created_at" db:"created_at"`
 	UpdatedAt                       time.Time `json:"updated_at" db:"updated_at"`
@@ -22,23 +22,23 @@ type AwardedShipment struct {
 }
 
 // String is not required by pop and may be deleted
-func (a AwardedShipment) String() string {
+func (a ShipmentAward) String() string {
 	ja, _ := json.Marshal(a)
 	return string(ja)
 }
 
-// AwardedShipments is not required by pop and may be deleted
-type AwardedShipments []AwardedShipment
+// ShipmentAwards is not required by pop and may be deleted
+type ShipmentAwards []ShipmentAward
 
 // String is not required by pop and may be deleted
-func (a AwardedShipments) String() string {
+func (a ShipmentAwards) String() string {
 	ja, _ := json.Marshal(a)
 	return string(ja)
 }
 
 // Validate gets run every time you call a "pop.Validate*" (pop.ValidateAndSave, pop.ValidateAndCreate, pop.ValidateAndUpdate) method.
 // This method is not required and may be deleted.
-func (a *AwardedShipment) Validate(tx *pop.Connection) (*validate.Errors, error) {
+func (a *ShipmentAward) Validate(tx *pop.Connection) (*validate.Errors, error) {
 	return validate.Validate(
 		&v.UUIDIsPresent{Field: a.ShipmentID, Name: "ShipmentID"},
 		&v.UUIDIsPresent{Field: a.TransportationServiceProviderID, Name: "TransportationServiceProviderID"},
@@ -47,29 +47,29 @@ func (a *AwardedShipment) Validate(tx *pop.Connection) (*validate.Errors, error)
 
 // ValidateCreate gets run every time you call "pop.ValidateAndCreate" method.
 // This method is not required and may be deleted.
-func (a *AwardedShipment) ValidateCreate(tx *pop.Connection) (*validate.Errors, error) {
+func (a *ShipmentAward) ValidateCreate(tx *pop.Connection) (*validate.Errors, error) {
 	return validate.NewErrors(), nil
 }
 
 // ValidateUpdate gets run every time you call "pop.ValidateAndUpdate" method.
 // This method is not required and may be deleted.
-func (a *AwardedShipment) ValidateUpdate(tx *pop.Connection) (*validate.Errors, error) {
+func (a *ShipmentAward) ValidateUpdate(tx *pop.Connection) (*validate.Errors, error) {
 	return validate.NewErrors(), nil
 }
 
-// AwardShipment connects a shipment to a transportation service provider. This
+// CreateShipmentAward connects a shipment to a transportation service provider. This
 // function assumes that the match has been validated by the caller.
-func AwardShipment(tx *pop.Connection,
+func CreateShipmentAward(tx *pop.Connection,
 	shipmentID uuid.UUID,
 	tspID uuid.UUID,
 	administrativeShipment bool) error {
 
-	awardedShipment := AwardedShipment{
+	shipmentAward := ShipmentAward{
 		ShipmentID:                      shipmentID,
 		TransportationServiceProviderID: tspID,
 		AdministrativeShipment:          administrativeShipment,
 	}
-	_, err := tx.ValidateAndSave(&awardedShipment)
+	_, err := tx.ValidateAndSave(&shipmentAward)
 
 	return err
 }

--- a/pkg/models/shipment_award_test.go
+++ b/pkg/models/shipment_award_test.go
@@ -6,14 +6,14 @@ import (
 	"github.com/satori/go.uuid"
 )
 
-func Test_AwardedShipment(t *testing.T) {
-	awardedShipment := AwardedShipment{
+func Test_ShipmentAward(t *testing.T) {
+	shipmentAward := ShipmentAward{
 		ShipmentID:                      uuid.Must(uuid.NewV4()),
 		TransportationServiceProviderID: uuid.Must(uuid.NewV4()),
 		AdministrativeShipment:          false,
 	}
 
-	dbConnection.Create(&awardedShipment)
+	dbConnection.Create(&shipmentAward)
 
 	// TODO: Complete tests here. As written, this will fail because we're
 	// making up UUIDs for foreign keys and that will violate the foreign
@@ -24,18 +24,18 @@ func Test_AwardedShipment(t *testing.T) {
 			t.Fatal("Didn't write it to the db: ", err)
 		}
 
-		if awardedShipment.ID == uuid.Nil {
+		if shipmentAward.ID == uuid.Nil {
 			t.Error("didn't get an ID back")
 		}
 
-		if awardedShipment.CreatedAt.IsZero() {
+		if shipmentAward.CreatedAt.IsZero() {
 			t.Error("wasn't assigned a created_at time")
 		}
 	*/
 }
 
-func Test_AwardedShipmentValidations(t *testing.T) {
-	as := &AwardedShipment{}
+func Test_ShipmentAwardValidations(t *testing.T) {
+	as := &ShipmentAward{}
 	verrs, err := dbConnection.ValidateAndSave(as)
 	if err != nil {
 		t.Error(err)

--- a/pkg/models/transportation_service_provider.go
+++ b/pkg/models/transportation_service_provider.go
@@ -79,13 +79,13 @@ func FetchTransportationServiceProvidersInTDL(tx *pop.Connection, tdlID uuid.UUI
 	sql := `SELECT
 			MIN(CAST(transportation_service_providers.id AS text)) as transportation_service_provider_id,
 			MIN(best_value_scores.score) as best_value_score,
-			COUNT(awarded_shipments.id) as award_count
+			COUNT(shipment_awards.id) as award_count
 		FROM
 			transportation_service_providers
 		JOIN best_value_scores ON
 			transportation_service_providers.id = best_value_scores.transportation_service_provider_id
-		LEFT JOIN awarded_shipments ON
-			transportation_service_providers.id = awarded_shipments.transportation_service_provider_id
+		LEFT JOIN shipment_awards ON
+			transportation_service_providers.id = shipment_awards.transportation_service_provider_id
 		GROUP BY transportation_service_providers.id
 		ORDER BY award_count ASC, best_value_score DESC
 		`


### PR DESCRIPTION
`ShipmentAward` is easier to distinguish from `Shipment`, making it easier to talk about and understand our data model.

Pivotal: https://www.pivotaltracker.com/story/show/155080535