### PR TITLE
Proxies swagger-ui path to webserver

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,9 @@
   "proxy": {
     "/api": {
       "target": "http://localhost:8080"
+    },
+    "/swagger-ui": {
+      "target": "http://localhost:8080"
     }
   },
   "version": "0.1.0",


### PR DESCRIPTION
`react-scripts`, which houses the server for `make client_run`, is *super* specific about what it serves from the build folder. This proxies the `/swagger-ui/`path to our Go webserver so those assets can be served locally