### PR TITLE
Always copies swagger-ui deps with client_deps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,14 +18,10 @@ test: client_test server_test
 
 client_deps_update:
 	yarn upgrade
-# This will execute when any file in the public/swagger-ui folder changes
-swagger-ui_deps: .swagger-ui_deps.stamp
-.swagger-ui_deps.stamp: $(shell find public/swagger-ui -type f)
-	bin/copy_swagger_ui.sh
-	touch .swagger-ui_deps.stamp
-client_deps: .client_deps.stamp swagger-ui_deps
+client_deps: .client_deps.stamp
 .client_deps.stamp: yarn.lock
 	yarn install
+	bin/copy_swagger_ui.sh
 	touch .client_deps.stamp
 client_build: client_deps
 	yarn build


### PR DESCRIPTION
`swagger-ui_deps` should have really been watching the node-modules/swagger-ui-dist folder for changes, but that still isn't a guarantee that the files we want are copied over. Instead we should just run `copy_swagger_ui` every time `client_deps` is run since it's an inexpensive operation and does a better job ensuring those assets are there when we need them.