### PR TITLE
Add make target for tsp award queue and generate test data binaries

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,6 +78,7 @@ jobs:
       - run: make client_build
       - run: make client_test
       - run: make server_test
+      - run: make tools_build
       - run: make server_build_docker
       - run:
           name: Tag and push image

--- a/.gitignore
+++ b/.gitignore
@@ -16,11 +16,11 @@ __snapshots__
 # built binaries
 /bin/webserver
 /bin/tsp-award-queue
+/bin/generate-test-data
 /bin/soda
 /bin/golint
 /bin/swagger
 /bin/gin
-/bin/generate_test_data
 
 # misc
 .DS_Store

--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ tsp_run_only_docker: db_dev_run
 	docker rm tsp || true
 	docker run --name tsp ppp:tsp-dev
 
-build: server_build tools_build
+build: server_build tools_build client_build
 
 server_test: db_dev_run db_test_reset server_deps server_generate
 	go test $$(go list ./... | grep -v \\/pkg\\/gen\\/ | grep -v \\/cmd\\/) # Don't try and run tests in /cmd or /pkg/gen

--- a/Makefile
+++ b/Makefile
@@ -69,9 +69,11 @@ server_run_only_docker: db_dev_run
 	docker rm web || true
 	docker run --name web -p 8080:8080 ppp:web-dev
 
-tsp_build: server_deps
+tools_build: server_deps
 	go build -i -o bin/tsp-award-queue ./cmd/tsp_award_queue
-tsp_run: tsp_build db_dev_run
+	go build -i -o bin/generate-test-data ./cmd/generate_test_data
+
+tsp_run: tools_build db_dev_run
 	./bin/tsp-award-queue
 
 tsp_build_docker:
@@ -80,11 +82,6 @@ tsp_run_only_docker: db_dev_run
 	docker stop tsp || true
 	docker rm tsp || true
 	docker run --name tsp ppp:tsp-dev
-
-data_gen_build: server_deps
-	go build -i -o bin/generate-test-data ./cmd/generate_test_data
-
-tools_build: tsp_build data_gen_build
 
 build: server_build tools_build
 

--- a/Makefile
+++ b/Makefile
@@ -81,6 +81,13 @@ tsp_run_only_docker: db_dev_run
 	docker rm tsp || true
 	docker run --name tsp ppp:tsp-dev
 
+data_gen_build: server_deps
+	go build -i -o bin/generate-test-data ./cmd/generate_test_data
+
+tools_build: tsp_build data_gen_build
+
+build: server_build tools_build
+
 server_test: db_dev_run db_test_reset server_deps server_generate
 	go test $$(go list ./... | grep -v \\/pkg\\/gen\\/ | grep -v \\/cmd\\/) # Don't try and run tests in /cmd or /pkg/gen
 


### PR DESCRIPTION
With this patch, you can now run:
`make tools_build` to build the TSP Award Queue and Test Data Generator
`make build` to build those and the webserver.

I used the name `tools_build` instead of `build_tools` to remain consistent with the other make targets, which use a $NOUN_$VERB naming convention.

Pivotal: https://www.pivotaltracker.com/story/show/155089943