### PR TITLE
add e2e test to circle ci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,6 +81,7 @@ jobs:
       - run: make client_build
       - run: make client_test
       - run: make server_test
+      - run: make e2e_test
       - run: make tools_build
       - run: make server_build_docker
       - run:


### PR DESCRIPTION
This PR addresses https://www.pivotaltracker.com/story/show/154580324 by adding the e2e tests to CI.