### PR TITLE
WIP: add 2278 endpoint definitions for submissions and index

### DIFF
--- a/migrations/20180217011350_create_service_members.down.fizz
+++ b/migrations/20180217011350_create_service_members.down.fizz
@@ -1,0 +1,1 @@
+drop_table("service_members")

--- a/migrations/20180217011350_create_service_members.up.fizz
+++ b/migrations/20180217011350_create_service_members.up.fizz
@@ -1,0 +1,9 @@
+create_table("service_members", func(t) {
+	t.Column("id", "uuid", {"primary": true})
+	t.Column("first_name", "string", {})
+	t.Column("middle_initial", "string", {})
+	t.Column("last_name", "string", {})
+	t.Column("rank", "string", {})
+	t.Column("ssn", "string", {})
+	t.Column("agency", "string", {"null": true})
+})

--- a/migrations/20180217013452_service_member_foreign_keys.down.fizz
+++ b/migrations/20180217013452_service_member_foreign_keys.down.fizz
@@ -1,0 +1,3 @@
+drop_foreign_key("form1299s", "service_member", {"if_exists": true})
+
+add_column("form1299s", "service_member", "string", {"null": true})

--- a/migrations/20180217013452_service_member_foreign_keys.up.fizz
+++ b/migrations/20180217013452_service_member_foreign_keys.up.fizz
@@ -1,0 +1,3 @@
+drop_column("form1299s", "service_member")
+
+raw("ALTER TABLE form1299s ADD COLUMN service_member_id UUID REFERENCES service_member(id);")

--- a/pkg/handlers/form1299s.go
+++ b/pkg/handlers/form1299s.go
@@ -19,7 +19,7 @@ func payloadForAddressModel(a *models.Address) *messages.Address {
 			StreetAddress1: swag.String(a.StreetAddress1),
 			StreetAddress2: a.StreetAddress2,
 			City:           swag.String(a.City),
-			State:          swag.String(a.State),
+			State:          &a.State,
 			Zip:            swag.String(a.Zip),
 		}
 	}

--- a/pkg/handlers/form1299s_test.go
+++ b/pkg/handlers/form1299s_test.go
@@ -77,11 +77,12 @@ func compareRequestAndResponsePayloads(t *testing.T, requestPayload interface{},
 }
 
 func fakeAddress() *messages.Address {
+	alabama := messages.StateAL
 	return &messages.Address{
 		StreetAddress1: swag.String("An address"),
 		StreetAddress2: swag.String("Apt. 2"),
 		City:           swag.String("Happytown"),
-		State:          swag.String("AL"),
+		State:          &alabama,
 		Zip:            swag.String("01234"),
 	}
 }
@@ -97,7 +98,7 @@ func setUpLogger() {
 }
 
 func TestSubmitForm1299HandlerAllValues(t *testing.T) {
-	var rankE6 = messages.ServiceMemberRankE6
+	rankE6 := messages.ServiceMemberRankE6
 	setUpLogger()
 	// Given: an instance of Form1299 with all valid values
 	newForm1299Payload := messages.CreateForm1299Payload{

--- a/pkg/models/address.go
+++ b/pkg/models/address.go
@@ -9,19 +9,23 @@ import (
 	"github.com/satori/go.uuid"
 	"go.uber.org/zap"
 	"time"
+
+	"github.com/transcom/mymove/pkg/gen/messages"
 )
 
 // Address is an address
 type Address struct {
-	ID             uuid.UUID `json:"id" db:"id"`
-	CreatedAt      time.Time `json:"created_at" db:"created_at"`
-	UpdatedAt      time.Time `json:"updated_at" db:"updated_at"`
-	StreetAddress1 string    `json:"street_address_1" db:"street_address_1"`
-	StreetAddress2 *string   `json:"street_address_2" db:"street_address_2"`
-	City           string    `json:"city" db:"city"`
-	State          string    `json:"state" db:"state"`
-	Zip            string    `json:"zip" db:"zip"`
+	ID             uuid.UUID      `json:"id" db:"id"`
+	CreatedAt      time.Time      `json:"created_at" db:"created_at"`
+	UpdatedAt      time.Time      `json:"updated_at" db:"updated_at"`
+	StreetAddress1 string         `json:"street_address_1" db:"street_address_1"`
+	StreetAddress2 *string        `json:"street_address_2" db:"street_address_2"`
+	City           string         `json:"city" db:"city"`
+	State          messages.State `json:"state" db:"state"`
+	Zip            string         `json:"zip" db:"zip"`
 }
+
+//
 
 // String is not required by pop and may be deleted
 func (a Address) String() string {
@@ -74,7 +78,7 @@ func (a *Address) Validate(tx *pop.Connection) (*validate.Errors, error) {
 	stringFields := map[string]string{
 		"StreetAddress1": a.StreetAddress1,
 		"City":           a.City,
-		"State":          a.State,
+		"State":          string(a.State),
 		"Zip":            a.Zip,
 	}
 
@@ -83,7 +87,6 @@ func (a *Address) Validate(tx *pop.Connection) (*validate.Errors, error) {
 			verrs.Add(key, fmt.Sprintf("%s must not be blank!", key))
 		}
 	}
-
 	return verrs, nil
 }
 

--- a/pkg/models/form1299.go
+++ b/pkg/models/form1299.go
@@ -17,71 +17,67 @@ import (
 
 // Form1299 is an application for shipment or storage of personal property
 type Form1299 struct {
-	ID                                     uuid.UUID                   `json:"id" db:"id"`
-	CreatedAt                              time.Time                   `json:"created_at" db:"created_at"`
-	UpdatedAt                              time.Time                   `json:"updated_at" db:"updated_at"`
-	DatePrepared                           *time.Time                  `json:"date_prepared" db:"date_prepared"`
-	ShipmentNumber                         *string                     `json:"shipment_number" db:"shipment_number"`
-	NameOfPreparingOffice                  *string                     `json:"name_of_preparing_office" db:"name_of_preparing_office"`
-	DestOfficeName                         *string                     `json:"dest_office_name" db:"dest_office_name"`
-	OriginOfficeAddressName                *string                     `json:"origin_office_address_name" db:"origin_office_address_name"`
-	OriginOfficeAddressID                  *uuid.UUID                  `json:"origin_office_address_id" db:"origin_office_address_id"`
-	OriginOfficeAddress                    *Address                    `db:"-"`
-	ServiceMemberFirstName                 *string                     `json:"service_member_first_name" db:"service_member_first_name"`
-	ServiceMemberMiddleInitial             *string                     `json:"service_member_middle_initial" db:"service_member_middle_initial"`
-	ServiceMemberLastName                  *string                     `json:"service_member_last_name" db:"service_member_last_name"`
-	ServiceMemberRank                      *messages.ServiceMemberRank `json:"service_member_rank" db:"service_member_rank"`
-	ServiceMemberSsn                       *string                     `json:"service_member_ssn" db:"service_member_ssn"`
-	ServiceMemberAgency                    *string                     `json:"service_member_agency" db:"service_member_agency"`
-	HhgTotalPounds                         *int64                      `json:"hhg_total_pounds" db:"hhg_total_pounds"`
-	HhgProgearPounds                       *int64                      `json:"hhg_progear_pounds" db:"hhg_progear_pounds"`
-	HhgValuableItemsCartons                *int64                      `json:"hhg_valuable_items_cartons" db:"hhg_valuable_items_cartons"`
-	MobileHomeSerialNumber                 *string                     `json:"mobile_home_serial_number" db:"mobile_home_serial_number"`
-	MobileHomeLengthFt                     *int64                      `json:"mobile_home_length_ft" db:"mobile_home_length_ft"`
-	MobileHomeLengthInches                 *int64                      `json:"mobile_home_length_inches" db:"mobile_home_length_inches"`
-	MobileHomeWidthFt                      *int64                      `json:"mobile_home_width_ft" db:"mobile_home_width_ft"`
-	MobileHomeWidthInches                  *int64                      `json:"mobile_home_width_inches" db:"mobile_home_width_inches"`
-	MobileHomeHeightFt                     *int64                      `json:"mobile_home_height_ft" db:"mobile_home_height_ft"`
-	MobileHomeHeightInches                 *int64                      `json:"mobile_home_height_inches" db:"mobile_home_height_inches"`
-	MobileHomeTypeExpando                  *string                     `json:"mobile_home_type_expando" db:"mobile_home_type_expando"`
-	MobileHomeContentsPackedRequested      bool                        `json:"mobile_home_contents_packed_requested" db:"mobile_home_contents_packed_requested"`
-	MobileHomeBlockedRequested             bool                        `json:"mobile_home_blocked_requested" db:"mobile_home_blocked_requested"`
-	MobileHomeUnblockedRequested           bool                        `json:"mobile_home_unblocked_requested" db:"mobile_home_unblocked_requested"`
-	MobileHomeStoredAtOriginRequested      bool                        `json:"mobile_home_stored_at_origin_requested" db:"mobile_home_stored_at_origin_requested"`
-	MobileHomeStoredAtDestinationRequested bool                        `json:"mobile_home_stored_at_destination_requested" db:"mobile_home_stored_at_destination_requested"`
-	StationOrdersType                      *string                     `json:"station_orders_type" db:"station_orders_type"`
-	StationOrdersIssuedBy                  *string                     `json:"station_orders_issued_by" db:"station_orders_issued_by"`
-	StationOrdersNewAssignment             *string                     `json:"station_orders_new_assignment" db:"station_orders_new_assignment"`
-	StationOrdersDate                      *time.Time                  `json:"station_orders_date" db:"station_orders_date"`
-	StationOrdersNumber                    *string                     `json:"station_orders_number" db:"station_orders_number"`
-	StationOrdersParagraphNumber           *string                     `json:"station_orders_paragraph_number" db:"station_orders_paragraph_number"`
-	StationOrdersInTransitTelephone        *string                     `json:"station_orders_in_transit_telephone" db:"station_orders_in_transit_telephone"`
-	InTransitAddressID                     *uuid.UUID                  `json:"in_transit_address_id" db:"in_transit_address_id"`
-	InTransitAddress                       *Address                    `db:"-"`
-	PickupAddressID                        *uuid.UUID                  `json:"pickup_address_id" db:"pickup_address_id"`
-	PickupAddress                          *Address                    `db:"-"`
-	PickupTelephone                        *string                     `json:"pickup_telephone" db:"pickup_telephone"`
-	DestAddressID                          *uuid.UUID                  `json:"dest_address_id" db:"dest_address_id"`
-	DestAddress                            *Address                    `db:"-"`
-	AgentToReceiveHhg                      *string                     `json:"agent_to_receive_hhg" db:"agent_to_receive_hhg"`
-	ExtraAddressID                         *uuid.UUID                  `json:"extra_address_id" db:"extra_address_id"`
-	ExtraAddress                           *Address                    `db:"-"`
-	PackScheduledDate                      *time.Time                  `json:"pack_scheduled_date" db:"pack_scheduled_date"`
-	PickupScheduledDate                    *time.Time                  `json:"pickup_scheduled_date" db:"pickup_scheduled_date"`
-	DeliveryScheduledDate                  *time.Time                  `json:"delivery_scheduled_date" db:"delivery_scheduled_date"`
-	Remarks                                *string                     `json:"remarks" db:"remarks"`
-	OtherMoveFrom                          *string                     `json:"other_move_from" db:"other_move_from"`
-	OtherMoveTo                            *string                     `json:"other_move_to" db:"other_move_to"`
-	OtherMoveNetPounds                     *int64                      `json:"other_move_net_pounds" db:"other_move_net_pounds"`
-	OtherMoveProgearPounds                 *int64                      `json:"other_move_progear_pounds" db:"other_move_progear_pounds"`
-	ServiceMemberSignature                 *string                     `json:"service_member_signature" db:"service_member_signature"`
-	DateSigned                             *time.Time                  `json:"date_signed" db:"date_signed"`
-	ContractorAddressID                    *uuid.UUID                  `json:"contractor_address_id" db:"contractor_address_id"`
-	ContractorAddress                      *Address                    `db:"-"`
-	ContractorName                         *string                     `json:"contractor_name" db:"contractor_name"`
-	NonavailabilityOfSignatureReason       *string                     `json:"nonavailability_of_signature_reason" db:"nonavailability_of_signature_reason"`
-	CertifiedBySignature                   *string                     `json:"certified_by_signature" db:"certified_by_signature"`
-	TitleOfCertifiedBySignature            *string                     `json:"title_of_certified_by_signature" db:"title_of_certified_by_signature"`
+	ID                                     uuid.UUID               `json:"id" db:"id"`
+	CreatedAt                              time.Time               `json:"created_at" db:"created_at"`
+	UpdatedAt                              time.Time               `json:"updated_at" db:"updated_at"`
+	DatePrepared                           *time.Time              `json:"date_prepared" db:"date_prepared"`
+	ShipmentNumber                         *string                 `json:"shipment_number" db:"shipment_number"`
+	NameOfPreparingOffice                  *string                 `json:"name_of_preparing_office" db:"name_of_preparing_office"`
+	DestOfficeName                         *string                 `json:"dest_office_name" db:"dest_office_name"`
+	OriginOfficeAddressName                *string                 `json:"origin_office_address_name" db:"origin_office_address_name"`
+	OriginOfficeAddressID                  *uuid.UUID              `json:"origin_office_address_id" db:"origin_office_address_id"`
+	OriginOfficeAddress                    *Address                `db:"-"`
+	ServiceMemberID                        *uuid.UUID              `json:"service_member_id" db:"service_member_id"`
+	ServiceMember                          *messages.ServiceMember `db:"-"`
+	HhgTotalPounds                         *int64                  `json:"hhg_total_pounds" db:"hhg_total_pounds"`
+	HhgProgearPounds                       *int64                  `json:"hhg_progear_pounds" db:"hhg_progear_pounds"`
+	HhgValuableItemsCartons                *int64                  `json:"hhg_valuable_items_cartons" db:"hhg_valuable_items_cartons"`
+	MobileHomeSerialNumber                 *string                 `json:"mobile_home_serial_number" db:"mobile_home_serial_number"`
+	MobileHomeLengthFt                     *int64                  `json:"mobile_home_length_ft" db:"mobile_home_length_ft"`
+	MobileHomeLengthInches                 *int64                  `json:"mobile_home_length_inches" db:"mobile_home_length_inches"`
+	MobileHomeWidthFt                      *int64                  `json:"mobile_home_width_ft" db:"mobile_home_width_ft"`
+	MobileHomeWidthInches                  *int64                  `json:"mobile_home_width_inches" db:"mobile_home_width_inches"`
+	MobileHomeHeightFt                     *int64                  `json:"mobile_home_height_ft" db:"mobile_home_height_ft"`
+	MobileHomeHeightInches                 *int64                  `json:"mobile_home_height_inches" db:"mobile_home_height_inches"`
+	MobileHomeTypeExpando                  *string                 `json:"mobile_home_type_expando" db:"mobile_home_type_expando"`
+	MobileHomeContentsPackedRequested      bool                    `json:"mobile_home_contents_packed_requested" db:"mobile_home_contents_packed_requested"`
+	MobileHomeBlockedRequested             bool                    `json:"mobile_home_blocked_requested" db:"mobile_home_blocked_requested"`
+	MobileHomeUnblockedRequested           bool                    `json:"mobile_home_unblocked_requested" db:"mobile_home_unblocked_requested"`
+	MobileHomeStoredAtOriginRequested      bool                    `json:"mobile_home_stored_at_origin_requested" db:"mobile_home_stored_at_origin_requested"`
+	MobileHomeStoredAtDestinationRequested bool                    `json:"mobile_home_stored_at_destination_requested" db:"mobile_home_stored_at_destination_requested"`
+	StationOrdersType                      *string                 `json:"station_orders_type" db:"station_orders_type"`
+	StationOrdersIssuedBy                  *string                 `json:"station_orders_issued_by" db:"station_orders_issued_by"`
+	StationOrdersNewAssignment             *string                 `json:"station_orders_new_assignment" db:"station_orders_new_assignment"`
+	StationOrdersDate                      *time.Time              `json:"station_orders_date" db:"station_orders_date"`
+	StationOrdersNumber                    *string                 `json:"station_orders_number" db:"station_orders_number"`
+	StationOrdersParagraphNumber           *string                 `json:"station_orders_paragraph_number" db:"station_orders_paragraph_number"`
+	StationOrdersInTransitTelephone        *string                 `json:"station_orders_in_transit_telephone" db:"station_orders_in_transit_telephone"`
+	InTransitAddressID                     *uuid.UUID              `json:"in_transit_address_id" db:"in_transit_address_id"`
+	InTransitAddress                       *Address                `db:"-"`
+	PickupAddressID                        *uuid.UUID              `json:"pickup_address_id" db:"pickup_address_id"`
+	PickupAddress                          *Address                `db:"-"`
+	PickupTelephone                        *string                 `json:"pickup_telephone" db:"pickup_telephone"`
+	DestAddressID                          *uuid.UUID              `json:"dest_address_id" db:"dest_address_id"`
+	DestAddress                            *Address                `db:"-"`
+	AgentToReceiveHhg                      *string                 `json:"agent_to_receive_hhg" db:"agent_to_receive_hhg"`
+	ExtraAddressID                         *uuid.UUID              `json:"extra_address_id" db:"extra_address_id"`
+	ExtraAddress                           *Address                `db:"-"`
+	PackScheduledDate                      *time.Time              `json:"pack_scheduled_date" db:"pack_scheduled_date"`
+	PickupScheduledDate                    *time.Time              `json:"pickup_scheduled_date" db:"pickup_scheduled_date"`
+	DeliveryScheduledDate                  *time.Time              `json:"delivery_scheduled_date" db:"delivery_scheduled_date"`
+	Remarks                                *string                 `json:"remarks" db:"remarks"`
+	OtherMoveFrom                          *string                 `json:"other_move_from" db:"other_move_from"`
+	OtherMoveTo                            *string                 `json:"other_move_to" db:"other_move_to"`
+	OtherMoveNetPounds                     *int64                  `json:"other_move_net_pounds" db:"other_move_net_pounds"`
+	OtherMoveProgearPounds                 *int64                  `json:"other_move_progear_pounds" db:"other_move_progear_pounds"`
+	ServiceMemberSignature                 *string                 `json:"service_member_signature" db:"service_member_signature"`
+	DateSigned                             *time.Time              `json:"date_signed" db:"date_signed"`
+	ContractorAddressID                    *uuid.UUID              `json:"contractor_address_id" db:"contractor_address_id"`
+	ContractorAddress                      *Address                `db:"-"`
+	ContractorName                         *string                 `json:"contractor_name" db:"contractor_name"`
+	NonavailabilityOfSignatureReason       *string                 `json:"nonavailability_of_signature_reason" db:"nonavailability_of_signature_reason"`
+	CertifiedBySignature                   *string                 `json:"certified_by_signature" db:"certified_by_signature"`
+	TitleOfCertifiedBySignature            *string                 `json:"title_of_certified_by_signature" db:"title_of_certified_by_signature"`
 }
 
 // CreateForm1299WithAddresses takes a form1299 with Address structs and coordinates saving it all in a transaction

--- a/pkg/models/service_member.go
+++ b/pkg/models/service_member.go
@@ -1,0 +1,75 @@
+package models
+
+import (
+	"encoding/json"
+	"github.com/markbates/pop"
+	"github.com/markbates/validate"
+	"github.com/markbates/validate/validators"
+	"github.com/satori/go.uuid"
+	"time"
+
+	"github.com/transcom/mymove/pkg/gen/messages"
+)
+
+// ServiceMember holds basic identifying data about a service member
+type ServiceMember struct {
+	ID            uuid.UUID                  `json:"id" db:"id"`
+	CreatedAt     time.Time                  `json:"created_at" db:"created_at"`
+	UpdatedAt     time.Time                  `json:"updated_at" db:"updated_at"`
+	FirstName     string                     `json:"first_name" db:"first_name"`
+	MiddleInitial string                     `json:"middle_initial" db:"middle_initial"`
+	LastName      string                     `json:"last_name" db:"last_name"`
+	Rank          messages.ServiceMemberRank `json:"rank" db:"rank"`
+	Ssn           string                     `json:"ssn" db:"ssn"`
+	Agency        *string                    `json:"agency" db:"agency"`
+}
+
+// String is not required by pop and may be deleted
+func (s ServiceMember) String() string {
+	js, _ := json.Marshal(s)
+	return string(js)
+}
+
+// TODO amitchell - add getservicememberid and fetchaddressbyid
+
+// ServiceMembers is not required by pop and may be deleted
+type ServiceMembers []ServiceMember
+
+// String is not required by pop and may be deleted
+func (s ServiceMembers) String() string {
+	js, _ := json.Marshal(s)
+	return string(js)
+}
+
+// Validate gets run every time you call a "pop.Validate*" (pop.ValidateAndSave, pop.ValidateAndCreate, pop.ValidateAndUpdate) method.
+// This method is not required and may be deleted.
+func (s *ServiceMember) Validate(tx *pop.Connection) (*validate.Errors, error) {
+	verrs := validate.NewErrors()
+
+	stringFields := map[string]string{
+		"FirstName":     a.FirstName,
+		"MiddleInitial": a.MiddleInitial,
+		"LastName":      a.LastName,
+		"Rank":          string(a.Rank),
+		"Ssn":           a.Ssn,
+	}
+
+	for key, field := range stringFields {
+		if field == "" {
+			verrs.Add(key, fmt.Sprintf("%s must not be blank!", key))
+		}
+	}
+	return verrs, nil
+}
+
+// ValidateCreate gets run every time you call "pop.ValidateAndCreate" method.
+// This method is not required and may be deleted.
+func (s *ServiceMember) ValidateCreate(tx *pop.Connection) (*validate.Errors, error) {
+	return validate.NewErrors(), nil
+}
+
+// ValidateUpdate gets run every time you call "pop.ValidateAndUpdate" method.
+// This method is not required and may be deleted.
+func (s *ServiceMember) ValidateUpdate(tx *pop.Connection) (*validate.Errors, error) {
+	return validate.NewErrors(), nil
+}

--- a/pkg/models/service_member_test.go
+++ b/pkg/models/service_member_test.go
@@ -1,0 +1,6 @@
+package models_test
+
+import "testing"
+
+func Test_ServiceMember(t *testing.T) {
+}

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -240,8 +240,8 @@ definitions:
         title: Name
       origin_office_address:
         $ref: '#/definitions/Address'
-      service_member_info:
-        $ref: '#/definitions/ServiceMemberInfo'
+      service_member:
+        $ref: '#/definitions/ServiceMember'
       hhg_total_pounds:
         type: integer
         example: 10000
@@ -500,8 +500,8 @@ definitions:
         x-nullable: true
       origin_office_address:
         $ref: '#/definitions/Address'
-      service_member_info:
-        $ref: '#/definitions/ServiceMemberInfo'
+      service_member:
+        $ref: '#/definitions/ServiceMember'
       hhg_total_pounds:
         type: integer
         example: 10000
@@ -696,8 +696,8 @@ definitions:
         example: "4550"
         x-nullable: true
         title: Shipment Number
-      service_member_info:
-        $ref: '#/definitions/ServiceMemberInfo'
+      service_member:
+        $ref: '#/definitions/ServiceMember'
       station_orders_type:
         type: string
         enum:
@@ -832,8 +832,8 @@ definitions:
         type: string
         example: "4550"
         x-nullable: true
-      service_member_info:
-        $ref: '#/definitions/ServiceMemberInfo'
+      service_member:
+        $ref: '#/definitions/ServiceMember'
       station_orders_type:
         type: string
         enum:
@@ -930,38 +930,38 @@ definitions:
         x-nullable: true
         example: 90
         title: Temporary Storage Number Days
-  ServiceMemberInfo:
+  ServiceMember:
     type: object
     properties:
-      service_member_first_name:
+      first_name:
         type: string
         example: Focaccia
         title: First Name
-      service_member_middle_initial:
+      middle_initial:
         type: string
         example: L.
         title: Middle Initial
-      service_member_last_name:
+      last_name:
         type: string
         example: Roll
         title: Last Name
-      service_member_rank:
+      rank:
         $ref: '#/definitions/ServiceMemberRank'
-      service_member_ssn:
+      ssn:
         type: string
         pattern: '^\d{3}-\d{2}-\d{4}$'
         example: 555-55-5555
         title: SSN
-      service_member_agency:
+      agency:
         type: string
         example: Air Force
         x-nullable: true
         title: Agency
     required:
-      - service_member_first_name
-      - service_member_middle_initial
-      - service_member_last_name
-      - service_member_rank
+      - first_name
+      - middle_initial
+      - last_name
+      - rank
   ServiceMemberRank:
     type: string
     x-nullable: true

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -80,6 +80,39 @@ paths:
             $ref: '#/definitions/IndexForm1299sPayload'
         400:
           description: invalid request
+  /form2278s:
+    post:
+      summary: Create a new shipment or storage of personal property application
+      description: Create an instance of form 2278
+      operationId: createForm2278
+      tags:
+        - form2278s
+      parameters:
+        - in: body
+          name: createForm2278Payload
+          required: true
+          schema:
+            $ref: '#/definitions/CreateForm2278Payload'
+      responses:
+        201:
+          description: created instance of form 2278
+          schema:
+            $ref: '#/definitions/Form2278Payload'
+        400:
+          description: invalid request
+    get:
+      summary: List all submitted 2278 forms
+      description: List all submitted 2278 forms
+      operationId: indexForm2278s
+      tags:
+        - form2278s
+      responses:
+        200:
+          description: list of submitted forms 2278
+          schema:
+            $ref: '#/definitions/IndexForm2278sPayload'
+        400:
+          description: invalid request
   /shipments:
     get:
       summary: List all shipments
@@ -695,6 +728,302 @@ definitions:
       - mobile_home_unblocked_requested
       - mobile_home_stored_at_origin_requested
       - mobile_home_stored_at_destination_requested
+  CreateForm2278Payload:
+    type: object
+    title: Application For DITY Move and Counseling Checklist (DD2278)
+    properties:
+      date_prepared:
+        type: string
+        format: date
+        example: 2018-01-03
+        x-nullable: true
+        title: Date Prepared
+      shipment_number:
+        type: string
+        example: "4550"
+        x-nullable: true
+        title: Shipment Number
+      service_member_first_name:
+        type: string
+        example: Focaccia
+        x-nullable: true
+        title: First Name
+      service_member_middle_initial:
+        type: string
+        example: L.
+        x-nullable: true
+        title: Middle Initial
+      service_member_last_name:
+        type: string
+        example: Roll
+        x-nullable: true
+        title: Last Name
+      service_member_rank:
+        $ref: '#/definitions/ServiceMemberRank'
+      service_member_ssn:
+        type: string
+        pattern: '^\d{3}-\d{2}-\d{4}$'
+        example: 555-55-5555
+        x-nullable: true
+        title: SSN
+      service_member_agency:
+        type: string
+        example: Air Force
+        x-nullable: true
+        title: Agency
+      station_orders_type:
+        type: string
+        enum:
+        - LOCAL
+        - PERMANENT
+        - TEMPORARY
+        x-display-value:
+          LOCAL: local
+          PERMANENT: permanent
+          TEMPORARY: temporary
+        x-nullable: true
+        title: Type Orders
+      station_orders_date:
+        type: string
+        format: date
+        example: 2018-03-15
+        x-nullable: true
+        title: Date of Orders
+      station_orders_issued_by:
+        type: string
+        example: Sergeant Naan
+        x-nullable: true
+        title: Issued By
+      station_orders_new_assignment:
+        type: string
+        example: ACCOUNTING OPS
+        x-nullable: true
+        title: New Duty Assignment
+      station_orders_number:
+        type: string
+        example: "98374"
+        x-nullable: true
+        title: Orders Number
+      number_of_miles:
+        type: integer
+        example: 766
+        x-nullable: true
+        title: Number Of Miles
+      name_of_preparing_office:
+        type: string
+        example: pumpernickel office
+        x-nullable: true
+        title: Name of Preparing Office
+      preparing_office_address:
+        $ref: '#/definitions/Address'
+      paying_afo_or_f&ao_navy_&_marine_corps:
+        type: string
+        example: Finance and Accounting Office FORT DRUM, NY 13602
+        x-nullable: true
+        title: Paying Office Navy and Marine Corps
+      send_check_to:
+        $ref: '#/definitions/Address'
+      state_of_legal_residence:
+        $ref: '#/definitions/State'
+      entitlements_option_of_gbl_and_or_dity_move:
+        type: boolean
+        x-nullable: true
+        title: Option Of GBL and/or DITY Move
+      entitlements_option_of_gbl_and_or_dity_move:
+        type: boolean
+        x-nullable: true
+        title: Option Of GBL and/or DITY Move
+      dity_move_authorized_from:
+        type: string
+        x-nullable: true
+        title: Dity Move Authorized From
+        example: Fayetteville, NC
+      dity_move_authorized_to:
+        type: string
+        x-nullable: true
+        title: Dity Move Authorized To
+        example: Watertown, NY
+      tmo_provided_with_hhg_weight:
+        type: boolean
+        x-nullable: true
+        title: TMO Provided With Hhg Weight
+      hhg_total_pounds:
+        type: integer
+        example: 7000
+        x-nullable: true
+        title: Hhg Pounds
+      maximum_authorized_weight:
+        type: integer
+        example: 7000
+        x-nullable: true
+        title: Maximum Authorized Weight
+      power_of_attorney:
+        type: boolean
+        x-nullable: true
+        title: Power of Attorney
+      type_of_vehicle_authorized:
+        type: boolean
+        x-nullable: true
+        title: Type of Vehicle Authorized
+      max_gov_liability_of_loss_or_damage:
+        type: integer
+        x-nullable: true
+        example: 100000
+        title: Maximum Government Loss or Damage
+      temporary_storage_num_days:
+        type: integer
+        x-nullable: true
+        example: 90
+        title: Temporary Storage Number Days
+  IndexForm2278sPayload:
+    type: array
+    items:
+      $ref: '#/definitions/Form2278Payload'
+  Form2278Payload:
+    type: object
+    properties:
+      id:
+        type: string
+        format: uuid
+        example: c56a4180-65aa-42ec-a945-5fd21dec0538
+      created_at:
+        type: string
+        format: date-time
+      updated_at:
+        type: string
+        format: date-time
+      form_completed:
+        type: boolean
+        example: false
+        x-nullable: true
+      date_prepared:
+        type: string
+        format: date
+        example: 2018-01-03
+        x-nullable: true
+      shipment_number:
+        type: string
+        example: "4550"
+        x-nullable: true
+      service_member_first_name:
+        type: string
+        example: Focaccia
+        x-nullable: true
+      service_member_middle_initial:
+        type: string
+        example: L.
+        x-nullable: true
+      service_member_last_name:
+        type: string
+        example: Roll
+        x-nullable: true
+      service_member_rank:
+        $ref: '#/definitions/ServiceMemberRank'
+      service_member_ssn:
+        type: string
+        pattern: '^\d{3}-\d{2}-\d{4}$'
+        example: 555-55-5555
+        x-nullable: true
+      service_member_agency:
+        type: string
+        example: Air Force
+        x-nullable: true
+      station_orders_type:
+        type: string
+        enum:
+        - LOCAL
+        - PERMANENT
+        - TEMPORARY
+        x-display-value:
+          LOCAL: local
+          PERMANENT: permanent
+          TEMPORARY: temporary
+        x-nullable: true
+      station_orders_date:
+        type: string
+        format: date
+        example: 2018-03-15
+        x-nullable: true
+      station_orders_issued_by:
+        type: string
+        example: Sergeant Naan
+        x-nullable: true
+      station_orders_new_assignment:
+        type: string
+        example: ACCOUNTING OPS
+        x-nullable: true
+      station_orders_number:
+        type: string
+        example: "98374"
+        x-nullable: true
+      number_of_miles:
+        type: integer
+        example: 766
+        x-nullable: true
+      name_of_preparing_office:
+        type: string
+        example: pumpernickel office
+        x-nullable: true
+      preparing_office_address:
+        $ref: '#/definitions/Address'
+      paying_afo_or_f&ao_navy_&_marine_corps:
+        type: string
+        example: Finance and Accounting Office FORT DRUM, NY 13602
+        x-nullable: true
+      send_check_to:
+        $ref: '#/definitions/Address'
+      state_of_legal_residence:
+        $ref: '#/definitions/State'
+      entitlements_option_of_gbl_and_or_dity_move:
+        type: boolean
+        x-nullable: true
+        title: Option Of GBL and/or DITY Move
+      entitlements_option_of_gbl_and_or_dity_move:
+        type: boolean
+        x-nullable: true
+        title: Option Of GBL and/or DITY Move
+      dity_move_authorized_from:
+        type: string
+        x-nullable: true
+        title: Dity Move Authorized From
+        example: Fayetteville, NC
+      dity_move_authorized_to:
+        type: string
+        x-nullable: true
+        title: Dity Move Authorized To
+        example: Watertown, NY
+      tmo_provided_with_hhg_weight:
+        type: boolean
+        x-nullable: true
+        title: TMO Provided With Hhg Weight
+      hhg_total_pounds:
+        type: integer
+        example: 7000
+        x-nullable: true
+        title: Hhg Pounds
+      maximum_authorized_weight:
+        type: integer
+        example: 7000
+        x-nullable: true
+        title: Maximum Authorized Weight
+      power_of_attorney:
+        type: boolean
+        x-nullable: true
+        title: Power of Attorney
+      type_of_vehicle_authorized:
+        type: boolean
+        x-nullable: true
+        title: Type of Vehicle Authorized
+      max_gov_liability_of_loss_or_damage:
+        type: integer
+        x-nullable: true
+        example: 100000
+        title: Maximum Government Loss or Damage
+      temporary_storage_num_days:
+        type: integer
+        x-nullable: true
+        example: 90
+        title: Temporary Storage Number Days
   ServiceMemberRank:
     type: string
     x-nullable: true
@@ -819,112 +1148,7 @@ definitions:
         example: Anytown
         title: City
       state:
-        title: State
-        type: string
-        x-display-value:
-          AL: AL
-          AK: AK
-          AZ: AZ
-          AR: AR
-          CA: CA
-          CO: CO
-          CT: CT
-          DE: DE
-          DC: DC
-          FL: FL
-          GA: GA
-          HI: HI
-          ID: ID
-          IL: IL
-          IN: IN
-          IA: IA
-          KS: KS
-          KY: KY
-          LA: LA
-          ME: ME
-          MD: MD
-          MA: MA
-          MI: MI
-          MN: MN
-          MS: MS
-          MO: MO
-          MT: MT
-          NE: NE
-          NV: NV
-          NH: NH
-          NJ: NJ
-          NM: NM
-          NY: NY
-          NC: NC
-          ND: ND
-          OH: OH
-          OK: OK
-          OR: OR
-          PA: PA
-          RI: RI
-          SC: SC
-          SD: SD
-          TN: TN
-          TX: TX
-          UT: UT
-          VT: VT
-          VA: VA
-          WA: WA
-          WV: WV
-          WI: WI
-          WY: WY
-        enum:
-          - AL
-          - AK
-          - AZ
-          - AR
-          - CA
-          - CO
-          - CT
-          - DE
-          - DC
-          - FL
-          - GA
-          - HI
-          - ID
-          - IL
-          - IN
-          - IA
-          - KS
-          - KY
-          - LA
-          - ME
-          - MD
-          - MA
-          - MI
-          - MN
-          - MS
-          - MO
-          - MT
-          - NE
-          - NV
-          - NH
-          - NJ
-          - NM
-          - NY
-          - NC
-          - ND
-          - OH
-          - OK
-          - OR
-          - PA
-          - RI
-          - SC
-          - SD
-          - TN
-          - TX
-          - UT
-          - VT
-          - VA
-          - WA
-          - WV
-          - WI
-          - WY
+        $ref: '#/definitions/State'
       zip:
         type: string
         title: ZIP/Postal Code
@@ -935,3 +1159,111 @@ definitions:
       - city
       - state
       - zip
+  State:
+    title: State
+    type: string
+    x-nullable: true
+    x-display-value:
+      AL: AL
+      AK: AK
+      AZ: AZ
+      AR: AR
+      CA: CA
+      CO: CO
+      CT: CT
+      DE: DE
+      DC: DC
+      FL: FL
+      GA: GA
+      HI: HI
+      ID: ID
+      IL: IL
+      IN: IN
+      IA: IA
+      KS: KS
+      KY: KY
+      LA: LA
+      ME: ME
+      MD: MD
+      MA: MA
+      MI: MI
+      MN: MN
+      MS: MS
+      MO: MO
+      MT: MT
+      NE: NE
+      NV: NV
+      NH: NH
+      NJ: NJ
+      NM: NM
+      NY: NY
+      NC: NC
+      ND: ND
+      OH: OH
+      OK: OK
+      OR: OR
+      PA: PA
+      RI: RI
+      SC: SC
+      SD: SD
+      TN: TN
+      TX: TX
+      UT: UT
+      VT: VT
+      VA: VA
+      WA: WA
+      WV: WV
+      WI: WI
+      WY: WY
+    enum:
+      - AL
+      - AK
+      - AZ
+      - AR
+      - CA
+      - CO
+      - CT
+      - DE
+      - DC
+      - FL
+      - GA
+      - HI
+      - ID
+      - IL
+      - IN
+      - IA
+      - KS
+      - KY
+      - LA
+      - ME
+      - MD
+      - MA
+      - MI
+      - MN
+      - MS
+      - MO
+      - MT
+      - NE
+      - NV
+      - NH
+      - NJ
+      - NM
+      - NY
+      - NC
+      - ND
+      - OH
+      - OK
+      - OR
+      - PA
+      - RI
+      - SC
+      - SD
+      - TN
+      - TX
+      - UT
+      - VT
+      - VA
+      - WA
+      - WV
+      - WI
+      - WY

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -240,34 +240,8 @@ definitions:
         title: Name
       origin_office_address:
         $ref: '#/definitions/Address'
-      service_member_first_name:
-        type: string
-        example: Focaccia
-        x-nullable: true
-        title: First Name
-      service_member_middle_initial:
-        type: string
-        example: L.
-        x-nullable: true
-        title: Middle Initial
-      service_member_last_name:
-        type: string
-        example: Roll
-        x-nullable: true
-        title: Last Name
-      service_member_rank:
-        $ref: '#/definitions/ServiceMemberRank'
-      service_member_ssn:
-        type: string
-        pattern: '^\d{3}-\d{2}-\d{4}$'
-        example: 555-55-5555
-        x-nullable: true
-        title: SSN
-      service_member_agency:
-        type: string
-        example: Air Force
-        x-nullable: true
-        title: Agency
+      service_member_info:
+        $ref: '#/definitions/ServiceMemberInfo'
       hhg_total_pounds:
         type: integer
         example: 10000
@@ -526,29 +500,8 @@ definitions:
         x-nullable: true
       origin_office_address:
         $ref: '#/definitions/Address'
-      service_member_first_name:
-        type: string
-        example: Focaccia
-        x-nullable: true
-      service_member_middle_initial:
-        type: string
-        example: L.
-        x-nullable: true
-      service_member_last_name:
-        type: string
-        example: Roll
-        x-nullable: true
-      service_member_rank:
-        $ref: '#/definitions/ServiceMemberRank'
-      service_member_ssn:
-        type: string
-        pattern: '^\d{3}-\d{2}-\d{4}$'
-        example: 555-55-5555
-        x-nullable: true
-      service_member_agency:
-        type: string
-        example: Air Force
-        x-nullable: true
+      service_member_info:
+        $ref: '#/definitions/ServiceMemberInfo'
       hhg_total_pounds:
         type: integer
         example: 10000
@@ -743,34 +696,8 @@ definitions:
         example: "4550"
         x-nullable: true
         title: Shipment Number
-      service_member_first_name:
-        type: string
-        example: Focaccia
-        x-nullable: true
-        title: First Name
-      service_member_middle_initial:
-        type: string
-        example: L.
-        x-nullable: true
-        title: Middle Initial
-      service_member_last_name:
-        type: string
-        example: Roll
-        x-nullable: true
-        title: Last Name
-      service_member_rank:
-        $ref: '#/definitions/ServiceMemberRank'
-      service_member_ssn:
-        type: string
-        pattern: '^\d{3}-\d{2}-\d{4}$'
-        example: 555-55-5555
-        x-nullable: true
-        title: SSN
-      service_member_agency:
-        type: string
-        example: Air Force
-        x-nullable: true
-        title: Agency
+      service_member_info:
+        $ref: '#/definitions/ServiceMemberInfo'
       station_orders_type:
         type: string
         enum:
@@ -905,29 +832,8 @@ definitions:
         type: string
         example: "4550"
         x-nullable: true
-      service_member_first_name:
-        type: string
-        example: Focaccia
-        x-nullable: true
-      service_member_middle_initial:
-        type: string
-        example: L.
-        x-nullable: true
-      service_member_last_name:
-        type: string
-        example: Roll
-        x-nullable: true
-      service_member_rank:
-        $ref: '#/definitions/ServiceMemberRank'
-      service_member_ssn:
-        type: string
-        pattern: '^\d{3}-\d{2}-\d{4}$'
-        example: 555-55-5555
-        x-nullable: true
-      service_member_agency:
-        type: string
-        example: Air Force
-        x-nullable: true
+      service_member_info:
+        $ref: '#/definitions/ServiceMemberInfo'
       station_orders_type:
         type: string
         enum:
@@ -1024,6 +930,38 @@ definitions:
         x-nullable: true
         example: 90
         title: Temporary Storage Number Days
+  ServiceMemberInfo:
+    type: object
+    properties:
+      service_member_first_name:
+        type: string
+        example: Focaccia
+        title: First Name
+      service_member_middle_initial:
+        type: string
+        example: L.
+        title: Middle Initial
+      service_member_last_name:
+        type: string
+        example: Roll
+        title: Last Name
+      service_member_rank:
+        $ref: '#/definitions/ServiceMemberRank'
+      service_member_ssn:
+        type: string
+        pattern: '^\d{3}-\d{2}-\d{4}$'
+        example: 555-55-5555
+        title: SSN
+      service_member_agency:
+        type: string
+        example: Air Force
+        x-nullable: true
+        title: Agency
+    required:
+      - service_member_first_name
+      - service_member_middle_initial
+      - service_member_last_name
+      - service_member_rank
   ServiceMemberRank:
     type: string
     x-nullable: true


### PR DESCRIPTION
<!-- markdownlint-disable -->
## Description
Start on adding form 2278 (DITY move application) to swagger as post and index payload definitions. 

Also, extract the state property definition from address in order to avoid unnecessary repetition for form 2278, which has a "State of legal residence field".

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Verification Steps

- [x] The model tests pass.
- [x] Submit form1299 manually locally

## References

- [Pivotal story](tbd) for this change
- [this article](tbd) explains more about the approach used.

## Screenshots

If this PR makes visible UI changes, an image of the finished UI can help reviewers and casual
observers understand the context of the changes. A before image is optional and
can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow instead of using multiple images. You may want to use GIPHY CAPTURE for this! 📸

_Please frame screenshots to show enough useful context but also highlight the affected regions._
