### PR TITLE
Streamline the creation of test data generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ All of our code is intermingled in the top level directory of mymove. Here is an
 
 `bin`: A location for tools helpful for developing this project \
 `build`: The build output directory for the client. This is what the development server serves \
-`cmd`: The location of main packages for any go binaries we build (right now, just webserver) \
+`cmd`: The location of main packages for any go binaries we build \
 `config`: Config files can be dropped here \
 `docs`: A location for docs for the project. This is where ADRs are \
 `migrations`: Database migrations live here \
@@ -106,7 +106,16 @@ Dependencies are managed by yarn. To add a new dependency, use `yarn add`
 ### TSP Award Queue
 
 This background job is built as a separate binary which can be built using
-`make tsp_build` and run using `make tsp_run`.
+`make tools_build` and run using `make tsp_run`.
+
+### Test Data Generator
+
+When creating new features, it is helpful to have sample data for the feature to interact with. The TSP Award Queue is an example of that--it matches shipments to TSPs, and it's hard to tell if it's working without some shipments and TSPs in the database!
+
+* `make tools_build` will build the fake data generator binary
+* `bin/generate_test_data` will run binary and create a preconfigured set of test data.
+
+There is also a package (`/pkg/testdatagen`) that can be imported to create arbitrary test data. This could be used in tests, so as not to duplicate functionality.
 
 ### API / Swagger
 

--- a/cmd/generate_test_data/main.go
+++ b/cmd/generate_test_data/main.go
@@ -1,10 +1,11 @@
 package main
 
 import (
+	"log"
+
 	"github.com/markbates/pop"
 	"github.com/namsral/flag"
 	"github.com/transcom/mymove/pkg/testdatagen"
-	"log"
 )
 
 // Hey, refactoring self: you can pull the UUIDs from the objects rather than
@@ -16,16 +17,15 @@ func main() {
 
 	//DB connection
 	pop.AddLookupPaths(*config)
-	dbConnection, err := pop.Connect(*env)
+	db, err := pop.Connect(*env)
 	if err != nil {
 		log.Panic(err)
 	}
 
 	// Can this be less repetitive without being overly clever?
-	testdatagen.MakeTDLData(dbConnection)
-	testdatagen.MakeTSPData(dbConnection)
-	testdatagen.MakeShipmentData(dbConnection)
-	testdatagen.MakeAwardedShipmentData(dbConnection)
-	testdatagen.MakeBestValueScoreRecords(dbConnection)
-
+	testdatagen.MakeTDLData(db)
+	testdatagen.MakeTSPData(db)
+	testdatagen.MakeShipmentData(db)
+	testdatagen.MakeShipmentAwardData(db)
+	testdatagen.MakeBestValueScoreData(db)
 }

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -28,7 +28,7 @@
   * [Javascript Concepts](#javascript-concepts)
   * [Resources](#resources)
 
-_Regenerate with `bin/docs-toc.sh`_
+_Regenerate with `bin/generate-md-toc.sh`_
 
 <!-- tocstop -->
 

--- a/pkg/testdatagen/make_awarded_shipment_record.go
+++ b/pkg/testdatagen/make_awarded_shipment_record.go
@@ -2,36 +2,52 @@ package testdatagen
 
 import (
 	"fmt"
+	"log"
+	"math/rand"
+
 	"github.com/markbates/pop"
 	"github.com/transcom/mymove/pkg/models"
-	"log"
 )
 
-// MakeAwardedShipmentData creates one awarded shipment record
-func MakeAwardedShipmentData(dbConnection *pop.Connection) {
+// MakeShipmentAward a single AwardedShipment record
+func MakeShipmentAward(db *pop.Connection, shipment models.Shipment,
+	tsp models.TransportationServiceProvider, admin bool) error {
+
+	// Add one awarded shipment record using existing shipment and TSP IDs
+	shipmentAward := models.ShipmentAward{
+		ShipmentID:                      shipment.ID,
+		TransportationServiceProviderID: tsp.ID,
+		AdministrativeShipment:          admin,
+	}
+
+	_, err := db.ValidateAndSave(&shipmentAward)
+	if err != nil {
+		log.Panic(err)
+	}
+
+	return err
+}
+
+// MakeShipmentAwardData creates one awarded shipment record
+func MakeShipmentAwardData(db *pop.Connection) {
 	// Get a shipment ID
 	shipmentList := []models.Shipment{}
-	err := dbConnection.All(&shipmentList)
+	err := db.All(&shipmentList)
 	if err != nil {
 		fmt.Println("Shipment ID import failed.")
 	}
 
 	// Get a TSP ID
 	tspList := []models.TransportationServiceProvider{}
-	err = dbConnection.All(&tspList)
+	err = db.All(&tspList)
 	if err != nil {
 		fmt.Println("TSP ID import failed.")
 	}
 
-	// Add one awarded shipment record using existing shipment and TSP IDs
-	awardedShipment := models.ShipmentAward{
-		ShipmentID:                      shipmentList[0].ID,
-		TransportationServiceProviderID: tspList[0].ID,
-		AdministrativeShipment:          false,
-	}
-
-	_, err = dbConnection.ValidateAndSave(&awardedShipment)
-	if err != nil {
-		log.Panic(err)
-	}
+	// Add one awarded shipment record using existing, random shipment and TSP IDs
+	MakeShipmentAward(db,
+		shipmentList[rand.Intn(len(shipmentList))],
+		tspList[rand.Intn(len(tspList))],
+		false,
+	)
 }

--- a/pkg/testdatagen/make_awarded_shipment_record.go
+++ b/pkg/testdatagen/make_awarded_shipment_record.go
@@ -11,7 +11,7 @@ import (
 
 // MakeShipmentAward a single AwardedShipment record
 func MakeShipmentAward(db *pop.Connection, shipment models.Shipment,
-	tsp models.TransportationServiceProvider, admin bool) error {
+	tsp models.TransportationServiceProvider, admin bool) (models.ShipmentAward, error) {
 
 	// Add one awarded shipment record using existing shipment and TSP IDs
 	shipmentAward := models.ShipmentAward{
@@ -25,7 +25,7 @@ func MakeShipmentAward(db *pop.Connection, shipment models.Shipment,
 		log.Panic(err)
 	}
 
-	return err
+	return shipmentAward, err
 }
 
 // MakeShipmentAwardData creates one awarded shipment record

--- a/pkg/testdatagen/make_best_value_score_records.go
+++ b/pkg/testdatagen/make_best_value_score_records.go
@@ -2,56 +2,53 @@ package testdatagen
 
 import (
 	"fmt"
+	"log"
+	"math/rand"
+
 	"github.com/markbates/pop"
 	"github.com/transcom/mymove/pkg/models"
-	"log"
 )
 
-// MakeBestValueScoreRecords creates three best value score records
-func MakeBestValueScoreRecords(dbConnection *pop.Connection) {
+// MakeBestValueScore makes a single best_value_score record
+func MakeBestValueScore(db *pop.Connection, tsp models.TransportationServiceProvider,
+	tdl models.TrafficDistributionList, score int) error {
+
+	bestValueScore := models.BestValueScore{
+		TransportationServiceProviderID: tsp.ID,
+		Score: score,
+		TrafficDistributionListID: tdl.ID,
+	}
+
+	_, err := db.ValidateAndSave(&bestValueScore)
+	if err != nil {
+		log.Panic(err)
+	}
+
+	return err
+}
+
+// MakeBestValueScoreData creates three best value score records
+func MakeBestValueScoreData(db *pop.Connection) {
 	// These two queries duplicate ones in other testdatagen files; not optimal
 	tspList := []models.TransportationServiceProvider{}
-	err := dbConnection.All(&tspList)
+	err := db.All(&tspList)
 	if err != nil {
 		fmt.Println("TSP ID import failed.")
 	}
 
 	tdlList := []models.TrafficDistributionList{}
-	err = dbConnection.All(&tdlList)
+	err = db.All(&tdlList)
 	if err != nil {
 		fmt.Println("TDL ID import failed.")
 	}
 
-	bestValueScore1 := models.BestValueScore{
-		TransportationServiceProviderID: tspList[0].ID,
-		Score: 11,
-		TrafficDistributionListID: tdlList[0].ID,
-	}
-
-	bestValueScore2 := models.BestValueScore{
-		TransportationServiceProviderID: tspList[1].ID,
-		Score: 2,
-		TrafficDistributionListID: tdlList[1].ID,
-	}
-
-	bestValueScore3 := models.BestValueScore{
-		TransportationServiceProviderID: tspList[2].ID,
-		Score: 8,
-		TrafficDistributionListID: tdlList[1].ID,
-	}
-
-	_, err = dbConnection.ValidateAndSave(&bestValueScore1)
-	if err != nil {
-		log.Panic(err)
-	}
-
-	_, err = dbConnection.ValidateAndSave(&bestValueScore2)
-	if err != nil {
-		log.Panic(err)
-	}
-
-	_, err = dbConnection.ValidateAndSave(&bestValueScore3)
-	if err != nil {
-		log.Panic(err)
+	// Make 3 BestValueScores with random TSPs, random TDLs, and random scores
+	for i := 0; i < 3; i++ {
+		MakeBestValueScore(
+			db,
+			tspList[rand.Intn(len(tspList))],
+			tdlList[rand.Intn(len(tdlList))],
+			rand.Intn(99),
+		)
 	}
 }

--- a/pkg/testdatagen/make_best_value_score_records.go
+++ b/pkg/testdatagen/make_best_value_score_records.go
@@ -11,7 +11,7 @@ import (
 
 // MakeBestValueScore makes a single best_value_score record
 func MakeBestValueScore(db *pop.Connection, tsp models.TransportationServiceProvider,
-	tdl models.TrafficDistributionList, score int) error {
+	tdl models.TrafficDistributionList, score int) (models.BestValueScore, error) {
 
 	bestValueScore := models.BestValueScore{
 		TransportationServiceProviderID: tsp.ID,
@@ -24,7 +24,7 @@ func MakeBestValueScore(db *pop.Connection, tsp models.TransportationServiceProv
 		log.Panic(err)
 	}
 
-	return err
+	return bestValueScore, err
 }
 
 // MakeBestValueScoreData creates three best value score records

--- a/pkg/testdatagen/make_shipment_records.go
+++ b/pkg/testdatagen/make_shipment_records.go
@@ -11,7 +11,7 @@ import (
 
 // MakeShipment creates a single shipment record.
 func MakeShipment(db *pop.Connection, pickup time.Time, delivery time.Time,
-	tdl models.TrafficDistributionList) error {
+	tdl models.TrafficDistributionList) (models.Shipment, error) {
 
 	shipment := models.Shipment{
 		TrafficDistributionListID: tdl.ID,
@@ -24,7 +24,7 @@ func MakeShipment(db *pop.Connection, pickup time.Time, delivery time.Time,
 		log.Panic(err)
 	}
 
-	return err
+	return shipment, err
 }
 
 // MakeShipmentData creates three shipment records

--- a/pkg/testdatagen/make_tdl_records.go
+++ b/pkg/testdatagen/make_tdl_records.go
@@ -7,7 +7,8 @@ import (
 )
 
 // MakeTDL makes a single traffic_distribution_list record
-func MakeTDL(db *pop.Connection, source string, dest string, cos string) error {
+func MakeTDL(db *pop.Connection, source string, dest string, cos string) (models.TrafficDistributionList, error) {
+
 	tdl := models.TrafficDistributionList{
 		SourceRateArea:    source,
 		DestinationRegion: dest,
@@ -19,7 +20,7 @@ func MakeTDL(db *pop.Connection, source string, dest string, cos string) error {
 		log.Panic(err)
 	}
 
-	return err
+	return tdl, err
 }
 
 // MakeTDLData creates three TDL records

--- a/pkg/testdatagen/make_tdl_records.go
+++ b/pkg/testdatagen/make_tdl_records.go
@@ -6,36 +6,26 @@ import (
 	"log"
 )
 
+// MakeTDL makes a single traffic_distribution_list record
+func MakeTDL(db *pop.Connection, source string, dest string, cos string) error {
+	tdl := models.TrafficDistributionList{
+		SourceRateArea:    source,
+		DestinationRegion: dest,
+		CodeOfService:     cos,
+	}
+
+	_, err := db.ValidateAndSave(&tdl)
+	if err != nil {
+		log.Panic(err)
+	}
+
+	return err
+}
+
 // MakeTDLData creates three TDL records
-func MakeTDLData(dbConnection *pop.Connection) {
+func MakeTDLData(db *pop.Connection) {
 	// It would be nice to make this less repetitive
-	tdl1 := models.TrafficDistributionList{
-		SourceRateArea:    "california",
-		DestinationRegion: "90210",
-		CodeOfService:     "2"}
-
-	tdl2 := models.TrafficDistributionList{
-		SourceRateArea:    "north carolina",
-		DestinationRegion: "27007",
-		CodeOfService:     "4"}
-
-	tdl3 := models.TrafficDistributionList{
-		SourceRateArea:    "washington",
-		DestinationRegion: "98310",
-		CodeOfService:     "1"}
-
-	_, err := dbConnection.ValidateAndSave(&tdl1)
-	if err != nil {
-		log.Panic(err)
-	}
-
-	_, err = dbConnection.ValidateAndSave(&tdl2)
-	if err != nil {
-		log.Panic(err)
-	}
-
-	_, err = dbConnection.ValidateAndSave(&tdl3)
-	if err != nil {
-		log.Panic(err)
-	}
+	MakeTDL(db, "california", "90210", "2")
+	MakeTDL(db, "north carolina", "27007", "4")
+	MakeTDL(db, "washington", "98310", "1")
 }

--- a/pkg/testdatagen/make_tsp_records.go
+++ b/pkg/testdatagen/make_tsp_records.go
@@ -6,32 +6,23 @@ import (
 	"log"
 )
 
+// MakeTSP makes a single transportation service provider record.
+func MakeTSP(db *pop.Connection, name string, SCAC string) error {
+	tsp := models.TransportationServiceProvider{
+		StandardCarrierAlphaCode: SCAC,
+		Name: name}
+
+	_, err := db.ValidateAndSave(&tsp)
+	if err != nil {
+		log.Panic(err)
+	}
+
+	return err
+}
+
 // MakeTSPData creates three TSP records
-func MakeTSPData(dbConnection *pop.Connection) {
-	tsp1 := models.TransportationServiceProvider{
-		StandardCarrierAlphaCode: "ABCD",
-		Name: "Very Good TSP"}
-
-	tsp2 := models.TransportationServiceProvider{
-		StandardCarrierAlphaCode: "EFGH",
-		Name: "Pretty Alright TSP"}
-
-	tsp3 := models.TransportationServiceProvider{
-		StandardCarrierAlphaCode: "IJKL",
-		Name: "Serviceable and Adequate TSP"}
-
-	_, err := dbConnection.ValidateAndSave(&tsp1)
-	if err != nil {
-		log.Panic(err)
-	}
-
-	_, err = dbConnection.ValidateAndSave(&tsp2)
-	if err != nil {
-		log.Panic(err)
-	}
-
-	_, err = dbConnection.ValidateAndSave(&tsp3)
-	if err != nil {
-		log.Panic(err)
-	}
+func MakeTSPData(db *pop.Connection) {
+	MakeTSP(db, "Very Good TSP", "ABCD")
+	MakeTSP(db, "Pretty Alright TSP", "EFGH")
+	MakeTSP(db, "Serviceable and Adequate TSP", "IJKL")
 }

--- a/pkg/testdatagen/make_tsp_records.go
+++ b/pkg/testdatagen/make_tsp_records.go
@@ -7,7 +7,7 @@ import (
 )
 
 // MakeTSP makes a single transportation service provider record.
-func MakeTSP(db *pop.Connection, name string, SCAC string) error {
+func MakeTSP(db *pop.Connection, name string, SCAC string) (models.TransportationServiceProvider, error) {
 	tsp := models.TransportationServiceProvider{
 		StandardCarrierAlphaCode: SCAC,
 		Name: name}
@@ -17,7 +17,7 @@ func MakeTSP(db *pop.Connection, name string, SCAC string) error {
 		log.Panic(err)
 	}
 
-	return err
+	return tsp, err
 }
 
 // MakeTSPData creates three TSP records


### PR DESCRIPTION
<!-- markdownlint-disable -->
## Description

Break out the record creation into a standalone function so that outside packages can easily use this package to create test data.

I also changed some of the data generation to use random foreign keys, instead of the hardcoded first or second row that was being done. This is just to shake up the test data a bit, might not be the right approach.

## Verification Steps

- [ ] Run the test data generator: `go run cmd/generate_test_data/main.go`

## References

- [Pivotal story](https://www.pivotaltracker.com/story/show/155243768) This is a preliminary PR to help test the linked story here.