### PR TITLE
Run server tests within database transactions

### DIFF
--- a/pkg/handlers/form1299s.go
+++ b/pkg/handlers/form1299s.go
@@ -112,7 +112,7 @@ func ShowForm1299Handler(params form1299op.ShowForm1299Params) middleware.Respon
 	var response middleware.Responder
 	// remove this validation when https://github.com/go-swagger/go-swagger/pull/1394 is merged.
 	if strfmt.IsUUID(string(formID)) {
-		form, err := models.FetchForm1299ByID(dbConnection, formID)
+		form, err := models.FetchForm1299ByID(DB, formID)
 		if err != nil {
 			if err.Error() == "sql: no rows in result set" {
 				response = form1299op.NewShowForm1299NotFound()
@@ -200,7 +200,7 @@ func CreateForm1299Handler(params form1299op.CreateForm1299Params) middleware.Re
 		TitleOfCertifiedBySignature:            params.CreateForm1299Payload.TitleOfCertifiedBySignature,
 	}
 	var response middleware.Responder
-	verrs, err := models.CreateForm1299WithAddresses(dbConnection, &newForm1299)
+	verrs, err := models.CreateForm1299WithAddresses(DB, &newForm1299)
 	if verrs.HasAny() {
 		zap.L().Error("DB Validation", zap.Error(verrs))
 		response = form1299op.NewCreateForm1299BadRequest()
@@ -218,7 +218,7 @@ func CreateForm1299Handler(params form1299op.CreateForm1299Params) middleware.Re
 func IndexForm1299sHandler(params form1299op.IndexForm1299sParams) middleware.Responder {
 	var form1299s models.Form1299s
 	var response middleware.Responder
-	form1299s, err := models.FetchAllForm1299s(dbConnection)
+	form1299s, err := models.FetchAllForm1299s(DB)
 	if err != nil {
 		zap.L().Error("DB Query", zap.Error(err))
 		response = form1299op.NewIndexForm1299sBadRequest()

--- a/pkg/handlers/handlers.go
+++ b/pkg/handlers/handlers.go
@@ -4,8 +4,7 @@ import (
 	"github.com/markbates/pop"
 )
 
-// this file defines globals used by all handlers.
-
+// DB is the global *pop.Connection used by handlers.
 var DB *pop.Connection
 
 // Init the API package with its database connection

--- a/pkg/handlers/handlers.go
+++ b/pkg/handlers/handlers.go
@@ -6,9 +6,9 @@ import (
 
 // this file defines globals used by all handlers.
 
-var dbConnection *pop.Connection
+var DB *pop.Connection
 
 // Init the API package with its database connection
 func Init(dbInitialConnection *pop.Connection) {
-	dbConnection = dbInitialConnection
+	DB = dbInitialConnection
 }

--- a/pkg/handlers/handlers_test.go
+++ b/pkg/handlers/handlers_test.go
@@ -1,0 +1,12 @@
+package handlers
+
+import (
+	"github.com/markbates/pop"
+)
+
+func stubDB(newDB *pop.Connection, body func()) {
+	originalDB := DB
+	DB = newDB
+	body()
+	DB = originalDB
+}

--- a/pkg/handlers/issues.go
+++ b/pkg/handlers/issues.go
@@ -33,7 +33,7 @@ func CreateIssueHandler(params issueop.CreateIssueParams) middleware.Responder {
 		DueDate:      (*time.Time)(params.CreateIssuePayload.DueDate),
 	}
 	var response middleware.Responder
-	if _, err := dbConnection.ValidateAndCreate(&newIssue); err != nil {
+	if _, err := DB.ValidateAndCreate(&newIssue); err != nil {
 		zap.L().Error("DB Insertion", zap.Error(err))
 		// how do I raise an erorr?
 		response = issueop.NewCreateIssueBadRequest()
@@ -49,7 +49,7 @@ func CreateIssueHandler(params issueop.CreateIssueParams) middleware.Responder {
 func IndexIssuesHandler(params issueop.IndexIssuesParams) middleware.Responder {
 	var issues models.Issues
 	var response middleware.Responder
-	if err := dbConnection.All(&issues); err != nil {
+	if err := DB.All(&issues); err != nil {
 		zap.L().Error("DB Query", zap.Error(err))
 		response = issueop.NewIndexIssuesBadRequest()
 	} else {

--- a/pkg/handlers/shipments.go
+++ b/pkg/handlers/shipments.go
@@ -29,7 +29,7 @@ func payloadForShipmentModel(s models.PossiblyAwardedShipment) *messages.Shipmen
 func IndexShipmentsHandler(p shipmentop.IndexShipmentsParams) middleware.Responder {
 	var response middleware.Responder
 
-	shipments, err := models.FetchPossiblyAwardedShipments(dbConnection)
+	shipments, err := models.FetchPossiblyAwardedShipments(DB)
 
 	if err != nil {
 		zap.L().Error("DB Query", zap.Error(err))

--- a/pkg/models/models_test.go
+++ b/pkg/models/models_test.go
@@ -79,5 +79,7 @@ func equalSlice(a []string, b []string) bool {
 func TestMain(m *testing.M) {
 	setupDBConnection()
 
+	dbConnection.TruncateAll()
+
 	os.Exit(m.Run())
 }

--- a/pkg/testing/transaction.go
+++ b/pkg/testing/transaction.go
@@ -1,0 +1,51 @@
+package testing
+
+import (
+	"testing"
+
+	"github.com/markbates/pop"
+)
+
+// StartTransaction starts a database transaction and returns that transaction for use in place of a *pop.Connection and a rollback func, which must be called to rollback the transaction at the end of the test.
+//
+// Note that Pop simply returns the current transaction if one has already been started. Using this helper within tests that exercise code that works with transactions itself may have unexpected results.
+//
+// Examples
+//
+//     func ExampleTest(t *testing.T) {
+//         tx, rollback := StartTransaction(t, dbConnection)
+//         defer rollback()
+//
+//         // ...rest of test, using tx in place of dbConnection
+//     }
+//
+func StartTransaction(t *testing.T, db *pop.Connection) (*pop.Connection, func()) {
+	t.Helper()
+
+	tx, err := db.NewTransaction()
+	if err != nil {
+		t.Fatalf("transaction could not be started: %s", err)
+	}
+	rollback := func() {
+		t.Helper()
+
+		err := tx.TX.Rollback()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	return tx, rollback
+}
+
+// MustSave handles saving and error checking for Pop model creation inside tests.
+func MustSave(t *testing.T, db *pop.Connection, s interface{}) {
+	t.Helper()
+
+	verrs, err := db.ValidateAndSave(s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if verrs.Count() > 0 {
+		t.Fatalf("errors encountered saving %v: %v", s, verrs)
+	}
+}


### PR DESCRIPTION
## Description

Our tests currently execute against a single database and do not clean up after themselves. As each tests runs, any mutations made to the database persist. This lack of isolation between tests can lead to test reliability issues.

A common approach is to execute tests within a SQL transaction and then call ROLLBACK() after the test completes. The approach taken in this PR is to do this explicitly at the beginning of a test where this behavior is desired. This keeps control of whether a transaction is used within the test, which allows for us to test other code that uses transactions more easily (since transactions can't be simply nested) at the cost of short but repetitive setup in similar tests.

After getting some feedback on this approach I will make changes as required and update the other handler tests. Our model tests don't currently hit the database, but can be run in a transaction in a similar way.

## Reviewer Notes

1. I'm mostly interested in how to handle the `*pop.Connection` global `dbConnection` (renamed to `DB` in this PR). I don't particularly like having to use `stubDB` and would rather pass a value into a handler under test, either directly or via the request context, than have them rely on a global variable.

2. I'd also like feedback on how to wrap a test in a transaction. The pattern used in this PR involves adding these two lines of code to the beginning of a test that needs to run in a transaction and then using `tx` instead of `DB` throughout the rest of the test:

    ```go
     func TestIndexShipmentsHandler(t *testing.T) {
    	tx, rollback := StartTransaction(t, DB)
    	defer rollback()
    
    	...
    ```

    An alternative approach is to have a `transaction` function similar to [this testing helper used in Pop](https://github.com/markbates/pop/blob/a8be87cba5ab8844d49bc8199ec51529cc9403c5/pop_test.go#L61-L68) ([example usage](https://github.com/markbates/pop/blob/master/query_test.go#L196-L201)) which I didn't go with as I wanted to avoid having to pass long callbacks into a test helper function.

Some other relevant info:

- `go test` runs tests within a package serially unless they are marked as parallel, so the approach to stubbing the global `*pop.Connection` used in the should actually work despite being ugly.
- A `*pop.Connection` wraps a `*sqlx.Connection` which is *not* actually a database connection. sqlx maintains a connection pool internally and certain calls to its methods retrieve a connection, use it to communicate with the database, and then release it to the pool.
- When a transaction is started through pop/sqlx, the database connection is reserved and held open until the transaction is either rolled back or committed.

## Verification Steps

- [ ] The approach to wrapping tests provides additional tests isolation and balances additional mental overhead with code maintainability.

## References

- [Pivotal story](https://www.pivotaltracker.com/story/show/155076695) for this change
