### PR TITLE
Remove unnecessary markdownlint comment.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,3 @@
-<!-- markdownlint-disable -->
 ## Description
 
 Explain a little about the changes at a high level.


### PR DESCRIPTION
## Description

This means you won't have to delete the `<!-- markdownlint-disable -->` from your pull request every time!