### PR TITLE
Fix issues with `go vet` with Golang 1.10

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,9 +51,17 @@ repos:
         language: script
         files: \.md$
 
-  - repo: git://github.com/dnephin/pre-commit-golang
-    sha: v0.2
+  # With Goang 1.10, `go vet` thinks variables defined in other files of the
+  # same module are undefined. We need to use `go tool vet` instead. See this
+  # issue for more details:
+  #   https://github.com/golang/go/issues/23916
+  # I have forked the repo and applied a patch for this, as well as submitted
+  # an upstream pull request:
+  #   https://github.com/dnephin/pre-commit-golang/pull/6
+  # When this is accepted, we can revert to the original repo.
+  - repo: git@github.com:akostibas/pre-commit-golang.git
+    sha: v0.3
     hooks:
-    -   id: go-fmt
-    -   id: go-vet
-    -   id: go-lint
+      - id: go-fmt
+      - id: go-vet
+      - id: go-lint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,17 +51,9 @@ repos:
         language: script
         files: \.md$
 
-  # With Goang 1.10, `go vet` thinks variables defined in other files of the
-  # same module are undefined. We need to use `go tool vet` instead. See this
-  # issue for more details:
-  #   https://github.com/golang/go/issues/23916
-  # I have forked the repo and applied a patch for this, as well as submitted
-  # an upstream pull request:
-  #   https://github.com/dnephin/pre-commit-golang/pull/6
-  # When this is accepted, we can revert to the original repo.
-  - repo: git@github.com:akostibas/pre-commit-golang.git
-    sha: v0.3
+  - repo: git://github.com/dnephin/pre-commit-golang
+    sha: 12ebecb5071d6c407f722dfbcc3eb6654b38f3df
     hooks:
-      - id: go-fmt
-      - id: go-vet
-      - id: go-lint
+    - id: go-fmt
+    - id: go-vet
+    - id: go-lint


### PR DESCRIPTION
## Description

When upgrading to Golang 1.10, `go vet` will fail if identifiers are declared outside the file being "vetted". The correct approach is to use `go tool vet` against single files. This is explained in more detail here: https://github.com/golang/go/issues/23916

I've forked and patched the pre-commit repo and updated the pre-commit config in this PR.

Additionally, I submitted an upstream patch. Once accepted, we can revert to using that repository.
https://github.com/dnephin/pre-commit-golang/pull/6

## Verification Steps

- [ ] If you don't have Go 1.10 installed, test that this works by running pre-commit on master:
`pre-commit run --all-files`
- [ ] Upgrade to Go 1.10 and then test the same.

## References

- [go vet issue](https://github.com/golang/go/issues/23916) explained in detail
- [my pull request](https://github.com/dnephin/pre-commit-golang/pull/6) to the upstream pre-commit hook provider