### PR TITLE
Update go precommit sha to fix "go vet" issue

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,7 +52,7 @@ repos:
         files: \.md$
 
   - repo: git://github.com/dnephin/pre-commit-golang
-    sha: v0.2
+    sha: 12ebecb5071d6c407f722dfbcc3eb6654b38f3df
     hooks:
     -   id: go-fmt
     -   id: go-vet


### PR DESCRIPTION
## Description

The Golang pre-commit hook was using `go vet` on all our files. This breaks with Go 1.10, as we need to use `go tool vet` on individual files (`go vet` is intended to be used on packages.)

I submitted a pull request upstream and it was accepted. This PR only updates our SHA to use the latest commit in their repo.

## Verification Steps

- [x] The pre-commit tests pass!

## References

- [Upstream PR](https://github.com/dnephin/pre-commit-golang/pull/6)
- [GitHub issue](https://github.com/golang/go/issues/23916) explaining the problem
