### PR TITLE
Include TDLs in TSP Award Queue

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,6 +61,6 @@ repos:
   - repo: git://github.com/dnephin/pre-commit-golang
     sha: 12ebecb5071d6c407f722dfbcc3eb6654b38f3df
     hooks:
-    -   id: go-fmt
-    -   id: go-vet
-    -   id: go-lint
+      - id: go-fmt
+      - id: go-vet
+      - id: go-lint

--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ tsp_run_only_docker: db_dev_run
 build: server_build tools_build client_build
 
 server_test: db_dev_run db_test_reset server_deps server_generate
-	go test $$(go list ./... | grep -v \\/pkg\\/gen\\/ | grep -v \\/cmd\\/) # Don't try and run tests in /cmd or /pkg/gen
+	go test -p 1 $$(go list ./... | grep -v \\/pkg\\/gen\\/ | grep -v \\/cmd\\/) # Don't try and run tests in /cmd or /pkg/gen
 
 e2e_test: client_deps
 	yarn e2e-test

--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,9 @@ tsp_run_only_docker: db_dev_run
 build: server_build tools_build client_build
 
 server_test: db_dev_run db_test_reset server_deps server_generate
-	go test -p 1 $$(go list ./... | grep -v \\/pkg\\/gen\\/ | grep -v \\/cmd\\/) # Don't try and run tests in /cmd or /pkg/gen
+	# Disable test caching with `-count 1` - caching was masking local test failures
+	# Disable parallelism with `-p 1` - this is necessary until we have test isolation
+	go test -p 1 -count 1 $$(go list ./... | grep -v \\/pkg\\/gen\\/ | grep -v \\/cmd\\/) # Don't try and run tests in /cmd or /pkg/gen
 
 e2e_test: client_deps
 	yarn e2e-test

--- a/pkg/awardqueue/awardqueue.go
+++ b/pkg/awardqueue/awardqueue.go
@@ -34,11 +34,10 @@ func AttemptShipmentAward(shipment models.PossiblyAwardedShipment) (*models.Ship
 	var shipmentAward *models.ShipmentAward
 
 	for _, consideredTSP := range tsps {
-		fmt.Printf("\tConsidering TSP: %v\n", consideredTSP.Name)
+		fmt.Printf("\tConsidering TSP: %s\n", consideredTSP.Name)
 
 		tsp := models.TransportationServiceProvider{}
-		err := db.Find(&tsp, consideredTSP.ID)
-		if err == nil {
+		if err := db.Find(&tsp, consideredTSP.ID); err == nil {
 			// We found a valid TSP to award to!
 			shipmentAward, err = models.CreateShipmentAward(db, shipment.ID, tsp.ID, false)
 			if err == nil {
@@ -56,9 +55,7 @@ func AttemptShipmentAward(shipment models.PossiblyAwardedShipment) (*models.Ship
 }
 
 // Run will execute the Award Queue algorithm.
-func Run(dbConnection *pop.Connection) {
-	db = dbConnection
-
+func Run(db *pop.Connection) {
 	fmt.Println("TSP Award Queue running.")
 
 	shipments, err := findAllUnawardedShipments()

--- a/pkg/awardqueue/awardqueue.go
+++ b/pkg/awardqueue/awardqueue.go
@@ -55,15 +55,16 @@ func Run(db *pop.Connection) {
 
 	shipments, err := findAllUnawardedShipments()
 	if err == nil {
-		count := -1
-		for i, shipment := range shipments {
+		count := 0
+		for _, shipment := range shipments {
 			err = selectTSPToAwardShipment(shipment)
 			if err != nil {
 				fmt.Printf("Failed to award shipment: %s\n", err)
+			} else {
+				count += 1
 			}
-			count = i
 		}
-		fmt.Printf("Awarded %d shipments.\n", count+1)
+		fmt.Printf("Awarded %d shipments.\n", count)
 	} else {
 		fmt.Printf("Failed to query for shipments: %s", err)
 	}

--- a/pkg/awardqueue/awardqueue_test.go
+++ b/pkg/awardqueue/awardqueue_test.go
@@ -118,6 +118,22 @@ func TestAwardQueueEndToEnd(t *testing.T) {
 	}
 }
 
+// Ensure that if we create a TSP in a TDL, the function that finds it can
+// indeed find it.
+func Test_FetchTSPsInTDLForSQL(t *testing.T) {
+	tdl, _ := testdatagen.MakeTDL(db, "source", "dest", "cos")
+	tsp, _ := testdatagen.MakeTSP(db, "Test TSP", "TSP1")
+	testdatagen.MakeBestValueScore(db, tsp, tdl, 10)
+
+	tsps, err := models.FetchTransportationServiceProvidersInTDL(db, tdl.ID)
+
+	if err != nil {
+		t.Errorf("Failed to find TSP: %v", err)
+	} else if len(tsps) != 1 {
+		t.Errorf("Failed to find TSP. Expected to find 1, found %d", len(tsps))
+	}
+}
+
 func setupDBConnection() {
 	configLocation := "../../../config"
 	pop.AddLookupPaths(configLocation)

--- a/pkg/awardqueue/awardqueue_test.go
+++ b/pkg/awardqueue/awardqueue_test.go
@@ -6,18 +6,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-openapi/swag"
 	"github.com/markbates/pop"
 
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"
 )
-
-// newBoolPtr creates a pointer to a boolean value. Apparently it's not
-// straightforward to do this in Go otherwise.
-// https://stackoverflow.com/questions/28817992/how-to-set-bool-pointer-to-true-in-struct-literal
-func newBoolPtr(value bool) *bool {
-	return &value
-}
 
 func TestFindAllUnawardedShipments(t *testing.T) {
 	_, err := findAllUnawardedShipments()
@@ -43,7 +37,7 @@ func TestAwardSingleShipment(t *testing.T) {
 		ID: shipment.ID,
 		TrafficDistributionListID:       tdl.ID,
 		TransportationServiceProviderID: nil,
-		AdministrativeShipment:          newBoolPtr(false),
+		AdministrativeShipment:          swag.Bool(false),
 	}
 
 	// Run the Award Queue
@@ -70,7 +64,7 @@ func TestFailAwardingSingleShipment(t *testing.T) {
 		ID: shipment.ID,
 		TrafficDistributionListID:       tdl.ID,
 		TransportationServiceProviderID: nil,
-		AdministrativeShipment:          newBoolPtr(false),
+		AdministrativeShipment:          swag.Bool(false),
 	}
 
 	// Run the Award Queue

--- a/pkg/awardqueue/awardqueue_test.go
+++ b/pkg/awardqueue/awardqueue_test.go
@@ -4,15 +4,59 @@ import (
 	"log"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/markbates/pop"
+
+	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/testdatagen"
 )
+
+var db *pop.Connection
+
+// newBoolPtr creates a pointer to a boolean value. Apparently it's not
+// straightforward to do this in Go otherwise.
+// https://stackoverflow.com/questions/28817992/how-to-set-bool-pointer-to-true-in-struct-literal
+func newBoolPtr(value bool) *bool {
+	return &value
+}
 
 func TestFindAllUnawardedShipments(t *testing.T) {
 	_, err := findAllUnawardedShipments()
 
 	if err != nil {
 		t.Fatal("Unable to find shipments: ", err)
+	}
+}
+
+// Test that we can create a shipment that should be awarded, and that
+// it actually gets awarded.
+func TestAwardShipment(t *testing.T) {
+	// Make a shipment
+	tdl, _ := testdatagen.MakeTDL(db, "california", "90210", "2")
+	shipment, _ := testdatagen.MakeShipment(db, time.Now(), time.Now(), tdl)
+
+	// Make a TSP to handle it
+	tsp, _ := testdatagen.MakeTSP(db, "Test Shipper", "TEST")
+	testdatagen.MakeBestValueScore(db, tsp, tdl, 10)
+
+	// Create a PossiblyAwardedShipment to feed the award queue
+	pas := models.PossiblyAwardedShipment{
+		ID: shipment.ID,
+		TrafficDistributionListID:       tdl.ID,
+		TransportationServiceProviderID: &tsp.ID,
+		AdministrativeShipment:          newBoolPtr(false),
+	}
+
+	// Run the Award Queue
+	award, err := AttemptShipmentAward(pas)
+
+	// See if shipment was awarded
+	if err != nil {
+		t.Fatalf("Shipment award expected no errors, received: %v", err)
+	}
+	if award == nil {
+		t.Fatal("ShipmentAward was not found.")
 	}
 }
 
@@ -24,7 +68,7 @@ func setupDBConnection() {
 		log.Panic(err)
 	}
 
-	dbConnection = conn
+	db = conn
 }
 
 func TestMain(m *testing.M) {

--- a/pkg/awardqueue/awardqueue_test.go
+++ b/pkg/awardqueue/awardqueue_test.go
@@ -42,7 +42,7 @@ func TestAwardSingleShipment(t *testing.T) {
 	pas := models.PossiblyAwardedShipment{
 		ID: shipment.ID,
 		TrafficDistributionListID:       tdl.ID,
-		TransportationServiceProviderID: &tsp.ID,
+		TransportationServiceProviderID: nil,
 		AdministrativeShipment:          newBoolPtr(false),
 	}
 

--- a/pkg/handlers/shipments_test.go
+++ b/pkg/handlers/shipments_test.go
@@ -19,6 +19,10 @@ func mustSave(t *testing.T, s interface{}) {
 }
 
 func TestIndexShipmentsHandler(t *testing.T) {
+	// TODO: This test assumes an empty database. This can be removed once we have
+	// a more centralized way of handling test setup & teardown.
+	dbConnection.TruncateAll()
+
 	tsp := models.TransportationServiceProvider{
 		StandardCarrierAlphaCode: "scac",
 		Name: "Transportation Service Provider 1",

--- a/pkg/models/shipment_award.go
+++ b/pkg/models/shipment_award.go
@@ -49,7 +49,7 @@ func (a *ShipmentAward) Validate(tx *pop.Connection) (*validate.Errors, error) {
 func CreateShipmentAward(tx *pop.Connection,
 	shipmentID uuid.UUID,
 	tspID uuid.UUID,
-	administrativeShipment bool) error {
+	administrativeShipment bool) (*ShipmentAward, error) {
 
 	shipmentAward := ShipmentAward{
 		ShipmentID:                      shipmentID,
@@ -58,5 +58,5 @@ func CreateShipmentAward(tx *pop.Connection,
 	}
 	_, err := tx.ValidateAndSave(&shipmentAward)
 
-	return err
+	return &shipmentAward, err
 }

--- a/pkg/models/transportation_service_provider.go
+++ b/pkg/models/transportation_service_provider.go
@@ -66,7 +66,7 @@ func FetchTransportationServiceProvidersInTDL(tx *pop.Connection, tdlID uuid.UUI
 	//   https://github.com/markbates/pop#join-query
 	sql := fmt.Sprintf(`SELECT
 			MIN(CAST(transportation_service_providers.id AS text)) as id,
-			MIN(transportation_service_providers.name AS text) as name,
+			MIN(transportation_service_providers.name) as name,
 			MIN(CAST(best_value_scores.traffic_distribution_list_id AS text)) as traffic_distribution_list_id,
 			MIN(best_value_scores.score) as best_value_score,
 			COUNT(shipment_awards.id) as award_count

--- a/pkg/models/transportation_service_provider.go
+++ b/pkg/models/transportation_service_provider.go
@@ -24,9 +24,11 @@ type TransportationServiceProvider struct {
 // TSPWithBVSAndAwardCount represents a list of TSPs along with their BVS
 // and awarded shipment counts.
 type TSPWithBVSAndAwardCount struct {
-	TransportationServiceProviderID uuid.UUID `json:"id" db:"transportation_service_provider_id"`
-	BestValueScore                  int       `json:"best_value_score" db:"best_value_score"`
-	AwardCount                      int       `json:"award_count" db:"award_count"`
+	ID                        uuid.UUID `json:"id" db:"id"`
+	Name                      string    `json:"name" db:"name"`
+	TrafficDistributionListID uuid.UUID `json:"traffic_distribution_list_id" db:"traffic_distribution_list_id"`
+	BestValueScore            int       `json:"best_value_score" db:"best_value_score"`
+	AwardCount                int       `json:"award_count" db:"award_count"`
 }
 
 // String is not required by pop and may be deleted
@@ -63,7 +65,8 @@ func FetchTransportationServiceProvidersInTDL(tx *pop.Connection, tdlID uuid.UUI
 	// - We might be able to replace this with Pop's join syntax for easier reading:
 	//   https://github.com/markbates/pop#join-query
 	sql := fmt.Sprintf(`SELECT
-			MIN(CAST(transportation_service_providers.id AS text)) as transportation_service_provider_id,
+			MIN(CAST(transportation_service_providers.id AS text)) as id,
+			MIN(transportation_service_providers.name AS text) as name,
 			MIN(CAST(best_value_scores.traffic_distribution_list_id AS text)) as traffic_distribution_list_id,
 			MIN(best_value_scores.score) as best_value_score,
 			COUNT(shipment_awards.id) as award_count

--- a/pkg/models/transportation_service_provider.go
+++ b/pkg/models/transportation_service_provider.go
@@ -2,7 +2,6 @@ package models
 
 import (
 	"encoding/json"
-	"fmt"
 
 	"github.com/markbates/pop"
 	"github.com/markbates/validate"
@@ -64,7 +63,7 @@ func FetchTransportationServiceProvidersInTDL(tx *pop.Connection, tdlID uuid.UUI
 	// - the UUID is CAST() to text to work inside the MIN(), it doesn't accept UUIDs
 	// - We might be able to replace this with Pop's join syntax for easier reading:
 	//   https://github.com/markbates/pop#join-query
-	sql := fmt.Sprintf(`SELECT
+	sql := `SELECT
 			MIN(CAST(transportation_service_providers.id AS text)) as id,
 			MIN(transportation_service_providers.name) as name,
 			MIN(CAST(best_value_scores.traffic_distribution_list_id AS text)) as traffic_distribution_list_id,
@@ -77,13 +76,13 @@ func FetchTransportationServiceProvidersInTDL(tx *pop.Connection, tdlID uuid.UUI
 		LEFT JOIN shipment_awards ON
 			transportation_service_providers.id = shipment_awards.transportation_service_provider_id
 		WHERE
-			best_value_scores.traffic_distribution_list_id = '%s'
+			best_value_scores.traffic_distribution_list_id = ?
 		GROUP BY best_value_scores.id
 		ORDER BY award_count ASC, best_value_score DESC
-		`, tdlID)
+		`
 
 	tsps := []TSPWithBVSAndAwardCount{}
-	err := tx.RawQuery(sql).All(&tsps)
+	err := tx.RawQuery(sql, tdlID).All(&tsps)
 
 	return tsps, err
 }

--- a/pkg/testdatagen/make_shipment_records.go
+++ b/pkg/testdatagen/make_shipment_records.go
@@ -3,6 +3,7 @@ package testdatagen
 import (
 	"fmt"
 	"log"
+	"math/rand"
 	"time"
 
 	"github.com/markbates/pop"

--- a/pkg/testdatagen/make_shipment_records.go
+++ b/pkg/testdatagen/make_shipment_records.go
@@ -3,7 +3,6 @@ package testdatagen
 import (
 	"fmt"
 	"log"
-	"math/rand"
 	"time"
 
 	"github.com/markbates/pop"

--- a/pkg/testdatagen/make_tdl_records.go
+++ b/pkg/testdatagen/make_tdl_records.go
@@ -1,9 +1,11 @@
 package testdatagen
 
 import (
-	"github.com/markbates/pop"
-	"github.com/transcom/mymove/pkg/models"
 	"log"
+
+	"github.com/markbates/pop"
+
+	"github.com/transcom/mymove/pkg/models"
 )
 
 // MakeTDL makes a single traffic_distribution_list record


### PR DESCRIPTION
## Description

Updating the TSP Award Queue to obey TDLs when awarding shipments to TSPs. This means that the shipment and the TSP must be in the same TDL for them to be awarded.

## Reviewer Notes

* Renaming `dbConnection` to the more succinct `db`.
* Modifying various functions that create models so that they `return` the models they create.
* I added some functionality to the `testdatagen` package to generate test data. Unfortunately, using it in the model tests creates a circular dependency (`testdatagen` imports `models`, so `models` can't import `testdatagen`.) This means I couldn't put some of the tests in models that I would have liked to.
  * One solution is to change our model test namespace to `models_test`, but that will have the implication of making our tests "whitebox tests" as they won't have access to the private functions.

## Verification Steps

- [ ] The `awardqueue` tests pass