### PR TITLE
Restore gin to Gopkg.toml.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -344,7 +344,10 @@
 
 [[projects]]
   name = "github.com/markbates/goth"
-  packages = ["."]
+  packages = [
+    ".",
+    "providers/openidConnect"
+  ]
   revision = "7bce57bf3e9a3d61d19787b7abc41daefb8dbc44"
   version = "v1.45.2"
 
@@ -682,6 +685,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "86a2c74be1c2cb59e04fb57d86e1d76aef39aac9935a6374188b92dd1ae5ce1e"
+  inputs-digest = "d12b7adbee1155f5b316079baa20847cff7cf0b322746504369b57eb45364017"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -2,6 +2,7 @@ required = [
 	"github.com/markbates/pop/soda",
 	"github.com/golang/lint/golint",
 	"github.com/go-swagger/go-swagger/cmd/swagger",
+	"github.com/codegangsta/gin",
 	"github.com/segmentio/chamber",
 	]
 


### PR DESCRIPTION
## Description

An [earlier commit](https://github.com/transcom/mymove/commit/b9f753d3919529f84e3f7e74fc4d89d108ac2c23) (I think) acidentally removed `gin` from `Gopkg.toml`, which led to a CI failure on a [different branch](https://circleci.com/gh/transcom/mymove/2130). Since we don't import `gin` anywhere, it needs to be explicitly listed.