### PR TITLE
Workaround awscli bug triggered by `--output text`

### DIFF
--- a/bin/ecs-run-migration-container
+++ b/bin/ecs-run-migration-container
@@ -35,7 +35,7 @@ show_logs() {
 }
 
 # get the latest container definition
-container_definition=$(aws ecs list-task-definitions --family-prefix "$family" --sort DESC --query 'taskDefinitionArns[0]' --output text)
+container_definition=$(aws ecs list-task-definitions --family-prefix "$family" --sort DESC --query 'taskDefinitionArns[0]' --output json | jq -r .)
 if [[ $container_definition = None ]]; then
     echo "Error: No existing $family task definitions found."
     echo "There should be at least one task definition already created by Terraform."


### PR DESCRIPTION
Suddenly, when indexing a list, the awscli returns **2** elements instead of 1, when using `--output text`. Using `--output json` does not have this problem so we are piping output through `jq`.

This code hasn't changed, the problem appears to be new to the awscli. I don't believe the version of awscli has changed, so perhaps this is happening at the AWS API level?