### PR TITLE
Stores token in secure cookie and adds parsing middleware, logout path

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -90,6 +90,10 @@ E2E_BASE
 url
 ngrok
 localtunnel
+Redis
+stateful
+Memcached
+jwt-go
  - docs/backend.md
 _Regenerate
 _

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -266,18 +266,6 @@
   version = "v1.3.0"
 
 [[projects]]
-  name = "github.com/gorilla/securecookie"
-  packages = ["."]
-  revision = "667fe4e3466a040b780561fe9b51a83a3753eefc"
-  version = "v1.1"
-
-[[projects]]
-  name = "github.com/gorilla/sessions"
-  packages = ["."]
-  revision = "ca9ada44574153444b00d3fd9c8559e4cc95f896"
-  version = "v1.1"
-
-[[projects]]
   branch = "master"
   name = "github.com/hashicorp/hcl"
   packages = [

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -254,10 +254,28 @@
   version = "v1.0.0"
 
 [[projects]]
+  name = "github.com/gorilla/context"
+  packages = ["."]
+  revision = "1ea25387ff6f684839d82767c1733ff4d4d15d0a"
+  version = "v1.1"
+
+[[projects]]
   name = "github.com/gorilla/handlers"
   packages = ["."]
   revision = "90663712d74cb411cbef281bc1e08c19d1a76145"
   version = "v1.3.0"
+
+[[projects]]
+  name = "github.com/gorilla/securecookie"
+  packages = ["."]
+  revision = "667fe4e3466a040b780561fe9b51a83a3753eefc"
+  version = "v1.1"
+
+[[projects]]
+  name = "github.com/gorilla/sessions"
+  packages = ["."]
+  revision = "ca9ada44574153444b00d3fd9c8559e4cc95f896"
+  version = "v1.1"
 
 [[projects]]
   branch = "master"
@@ -714,6 +732,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "0c0a24008bdcdce6ba276aa276e32b9df1015d0c98d39815b60fdf4639eb3142"
+  inputs-digest = "bf6b43ebe32aecad2eff7118509440920c5649b1e15528ef0d2e3e37f4f3fe11"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cmd/webserver/main.go
+++ b/cmd/webserver/main.go
@@ -98,7 +98,8 @@ func main() {
 	fullHostname := fmt.Sprintf("%s%s:%s", *protocol, *hostname, *callbackPort)
 	auth.RegisterProvider(logger, *loginGovSecretKey, fullHostname, *loginGovClientID)
 
-	authMiddleware := auth.UserAuthMiddleware(*clientAuthSecretKey, fullHostname)
+	enforceAuthMiddleware := auth.UserAuthMiddleware(*clientAuthSecretKey, fullHostname, true)
+	passiveAuthMiddleware := auth.UserAuthMiddleware(*clientAuthSecretKey, fullHostname, false)
 
 	// Base routes
 	root := goji.NewMux()
@@ -110,16 +111,17 @@ func main() {
 
 	internalMux := goji.SubMux()
 	root.Handle(pat.New("/internal/*"), internalMux)
-	internalMux.Use(authMiddleware)
+	internalMux.Use(enforceAuthMiddleware)
 	internalMux.Handle(pat.Get("/swagger.yaml"), fileHandler(*internalSwagger))
 	internalMux.Handle(pat.Get("/docs"), fileHandler(path.Join(*build, "swagger-ui", "internal.html")))
 	internalMux.Handle(pat.New("/*"), internalAPI.Serve(nil)) // Serve(nil) returns an http.Handler for the swagger api
 
 	authMux := goji.SubMux()
 	root.Handle(pat.New("/auth/*"), authMux)
+	authMux.Use(passiveAuthMiddleware)
 	authMux.Handle(pat.Get("/login-gov"), auth.AuthorizationRedirectHandler(logger))
 	authMux.Handle(pat.Get("/login-gov/callback"), auth.AuthorizationCallbackHandler(*clientAuthSecretKey, *loginGovSecretKey, *loginGovClientID, fullHostname, logger))
-	authMux.Handle(pat.Get("/logout"), authMiddleware(auth.AuthorizationLogoutHandler(fullHostname)))
+	authMux.Handle(pat.Get("/logout"), auth.AuthorizationLogoutHandler(fullHostname))
 
 	root.Handle(pat.Get("/static/*"), clientHandler)
 	root.Handle(pat.Get("/swagger-ui/*"), clientHandler)

--- a/cmd/webserver/main.go
+++ b/cmd/webserver/main.go
@@ -45,8 +45,9 @@ func main() {
 	internalSwagger := flag.String("internal-swagger", "swagger/internal.yaml", "The location of the internal API swagger definition")
 	apiSwagger := flag.String("swagger", "swagger/api.yaml", "The location of the public API swagger definition")
 	debugLogging := flag.Bool("debug_logging", false, "log messages at the debug level.")
-	loginGovSecretKey := flag.String("login_gov_secret_key", "", "Auth secret JWT key.")
+	loginGovSecretKey := flag.String("login_gov_secret_key", "", "Login.gov auth secret JWT key.")
 	loginGovClientID := flag.String("login_gov_client_id", "", "Client ID registered with login gov.")
+	clientAuthSecretKey := flag.String("client_auth_secret_key", "", "Client auth secret JWT key.")
 
 	flag.Parse()
 
@@ -89,6 +90,9 @@ func main() {
 	// Serves files out of build folder
 	clientHandler := http.FileServer(http.Dir(*build))
 
+	// Sets max age on cookie store
+	auth.SetCookieStoreMaxAge()
+
 	// Register Login.gov authentication provider
 	if *env == "development" {
 		*protocol = "http://"
@@ -104,8 +108,9 @@ func main() {
 	root.Handle(pat.Get("/internal/swagger.yaml"), fileHandler(*internalSwagger))
 	root.Handle(pat.Get("/internal/docs"), fileHandler(path.Join(*build, "swagger-ui", "internal.html")))
 	root.Handle(pat.New("/internal/*"), internalAPI.Serve(nil)) // Serve(nil) returns an http.Handler for the swagger api
-	root.Handle(pat.Get("/auth/login-gov"), auth.NewAuthorizationRedirectHandler(logger))
-	root.Handle(pat.Get("/auth/login-gov/callback"), auth.NewAuthorizationCallbackHandler(*loginGovSecretKey, *loginGovClientID, fullHostname, logger))
+	root.Handle(pat.Get("/auth/login-gov"), auth.AuthorizationRedirectHandler(logger))
+	root.Handle(pat.Get("/auth/login-gov/callback"), auth.AuthorizationCallbackHandler(*clientAuthSecretKey, *loginGovSecretKey, *loginGovClientID, fullHostname, logger))
+	root.Handle(pat.Get("/auth/logout"), auth.AuthorizationLogoutHandler(fullHostname))
 	root.Handle(pat.Get("/static/*"), clientHandler)
 	root.Handle(pat.Get("/swagger-ui/*"), clientHandler)
 	root.Handle(pat.Get("/favicon.ico"), clientHandler)
@@ -113,6 +118,7 @@ func main() {
 
 	// And request logging
 	root.Use(requestLogger)
+	root.Use(auth.UserAuthMiddleware(*clientAuthSecretKey))
 
 	address := fmt.Sprintf("%s:%s", *listenInterface, *port)
 	zap.L().Info("Starting the server listening", zap.String("address", address))

--- a/cmd/webserver/main.go
+++ b/cmd/webserver/main.go
@@ -118,8 +118,8 @@ func main() {
 	authMux := goji.SubMux()
 	root.Handle(pat.New("/auth/*"), authMux)
 	authMux.Use(authMiddleware)
-	authMux.Handle(pat.Get("/login-gov"), auth.AuthorizationRedirectHandler(logger, fullHostname))
-	authMux.Handle(pat.Get("/login-gov/callback"), auth.AuthorizationCallbackHandler(*clientAuthSecretKey, *loginGovSecretKey, *loginGovClientID, fullHostname, logger))
+	authMux.Handle(pat.Get("/login-gov"), auth.NewAuthorizationRedirectHandler(logger, fullHostname))
+	authMux.Handle(pat.Get("/login-gov/callback"), auth.NewAuthorizationCallbackHandler(*clientAuthSecretKey, *loginGovSecretKey, *loginGovClientID, fullHostname, logger))
 	authMux.Handle(pat.Get("/logout"), auth.AuthorizationLogoutHandler(fullHostname))
 
 	root.Handle(pat.Get("/static/*"), clientHandler)

--- a/cmd/webserver/main.go
+++ b/cmd/webserver/main.go
@@ -119,7 +119,7 @@ func main() {
 	authMux := goji.SubMux()
 	root.Handle(pat.New("/auth/*"), authMux)
 	authMux.Use(passiveAuthMiddleware)
-	authMux.Handle(pat.Get("/login-gov"), auth.AuthorizationRedirectHandler(logger))
+	authMux.Handle(pat.Get("/login-gov"), auth.AuthorizationRedirectHandler(logger, fullHostname))
 	authMux.Handle(pat.Get("/login-gov/callback"), auth.AuthorizationCallbackHandler(*clientAuthSecretKey, *loginGovSecretKey, *loginGovClientID, fullHostname, logger))
 	authMux.Handle(pat.Get("/logout"), auth.AuthorizationLogoutHandler(fullHostname))
 

--- a/docs/adr/0015-session-storage.md
+++ b/docs/adr/0015-session-storage.md
@@ -1,0 +1,44 @@
+# Session storage/handling
+
+**User Story:** [155140012](https://www.pivotaltracker.com/story/show/155140012)
+
+We want our users to be able to log in to our site and have that authentication backed by <http://www.login.gov>. We also want that authentication to spawn a session that persists until the user logs out or until a designated amount of time elapses.
+
+## Considered Alternatives
+
+* Encode our session data in a JSON web token that's stored on the client
+* Encode session data in a secure cookie using gorilla/sessions
+* Store session data server-side in Redis or an equivalent cache store
+
+## Decision Outcome
+
+* Chosen Alternative: **Encode our session data in a JSON web token that's stored on the client**
+
+* Ultimately the real choice comes down to whether we want to store session information in a stateful or a stateless manner. A conventional stateful store backed by Redis or Memcached creates both a natural performance bottleneck and a single point of failure for session management. Alternatively, in a stateless system the server is only responsible for creating, reading, and verifying information that is securely stored on the client as a cookie. This makes stateless session storage, through JSON web tokens or some other means, an obvious choice.
+
+* Storing sessions in encrypted cookies adds a bit of computational latency for encrypting and decrypting tokens, but this is easily outweighed by its advantages in contributing to a reliable, scalable architecture.
+
+* We looked at a couple Go libraries that would allow us to easily implement client-side session storage: [jwt-go](https://github.com/dgrijalva/jwt-go) and [gorilla/sessions](https://github.com/gorilla/sessions) cookie stores. Gorilla adds some convenience around setting/retrieving client-side tokens, but the requisite data storage implementation (one-time-read flash messages) felt clumsy and wasn't necessary for our uses. jwt-go leaves us to set/retrieve cookies on our own, but the JWT claims data structure and expiration handling, including combined parsing and claims validation, doesn't leave many loopholes for accidentally dealing with an expired session. Since cookie handling is relatively simple through the `http` library, we opted for the jwt-go library.
+
+## Pros and Cons of the Alternatives <!-- optional -->
+
+### Encode our session data in a JSON web token that's stored on the client
+
+* `+` Stateless session management
+* `+` Provides structure for token expiration
+* `+` Data is self contained in token
+* `-` Vulnerable to replay attacks
+
+### Encode session data in a secure cookie using gorilla/sessions
+
+* `+` Stateless session management
+* `+` Handles cookie setting/retrieval for us
+* `-` Flash data storage is awkward
+
+### Store session data server-side in Redis or an equivalent cache store
+
+* `+` Maintain control over session state
+* `+` Less data being transmitted to/from client
+* `-` Single point of failure
+* `-` Requires maintenance to avoid ballooning
+* `-` Not terribly scalable

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -17,6 +17,7 @@ This log lists the architectural decisions for DP3 server- and client-side code.
 - [ADR-0010](0010-isolate-test-access-to-database.md) - Isolate Test Access to Database
 - [ADR-0011](0011-test-suites.md) - Test Suites
 - [ADR-0012](0012-tsp-data-models.md) - The TSP Data Models
+- [ADR-0015](0015-session-storage.md) - Session storage/handling
 
 <!-- adrlogstop -->
 

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -137,7 +137,7 @@ func RegisterProvider(logger *zap.Logger, loginGovSecretKey, hostname, loginGovC
 	}
 }
 
-// UserAuthMiddleware attempts to populate user data or optionally redirects to landing page
+// UserAuthMiddleware attempts to populate user data onto request context
 func UserAuthMiddleware(secret string) func(next http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		mw := func(w http.ResponseWriter, r *http.Request) {
@@ -173,21 +173,6 @@ func UserAuthMiddleware(secret string) func(next http.Handler) http.Handler {
 	}
 }
 
-// AuthorizationRedirectHandler handles redirection
-type AuthorizationRedirectHandler struct {
-	logger   *zap.Logger
-	hostname string
-}
-
-// NewAuthorizationRedirectHandler creates a new AuthorizationRedirectHandler
-func NewAuthorizationRedirectHandler(logger *zap.Logger, hostname string) *AuthorizationRedirectHandler {
-	handler := AuthorizationRedirectHandler{
-		logger:   logger,
-		hostname: hostname,
-	}
-	return &handler
-}
-
 // AuthorizationLogoutHandler handles logging the user out of login.gov
 func AuthorizationLogoutHandler(hostname string) http.HandlerFunc {
 	logoutURL := "https://idp.int.identitysandbox.gov/openid_connect/logout"
@@ -218,6 +203,21 @@ func AuthorizationLogoutHandler(hostname string) http.HandlerFunc {
 
 		http.Redirect(w, r, parsedURL.String(), http.StatusTemporaryRedirect)
 	}
+}
+
+// AuthorizationRedirectHandler handles redirection
+type AuthorizationRedirectHandler struct {
+	logger   *zap.Logger
+	hostname string
+}
+
+// NewAuthorizationRedirectHandler creates a new AuthorizationRedirectHandler
+func NewAuthorizationRedirectHandler(logger *zap.Logger, hostname string) *AuthorizationRedirectHandler {
+	handler := AuthorizationRedirectHandler{
+		logger:   logger,
+		hostname: hostname,
+	}
+	return &handler
 }
 
 // AuthorizationRedirectHandler constructs the Login.gov authentication URL and redirects to it

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -44,8 +44,6 @@ func getExpiryTimeFromMinutes(min int64) int64 {
 func shouldRenewForClaims(claims UserClaims) bool {
 	exp := claims.StandardClaims.ExpiresAt
 	renewal := getExpiryTimeFromMinutes(sessionRenewalTimeInMinutes)
-	fmt.Println(exp)
-	fmt.Println(renewal)
 	return exp < renewal
 }
 

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -149,6 +149,7 @@ func UserAuthMiddleware(secret string) func(next http.Handler) http.Handler {
 		mw := func(w http.ResponseWriter, r *http.Request) {
 			claims, ok := getUserClaimsFromRequest(secret, r)
 			if !ok {
+				next.ServeHTTP(w, r)
 				return
 			}
 

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -110,7 +110,7 @@ func deleteCookie(w http.ResponseWriter, name string) {
 func getUserClaimsFromCookie(secret string, r *http.Request) (claims *UserClaims, ok bool) {
 	cookie, err := r.Cookie(JwtCookieName)
 	if err != nil {
-		zap.L().Error("No cookie set on client", zap.Error(err))
+		// No cookie set on client
 		return
 	}
 
@@ -152,15 +152,10 @@ type AuthorizationRedirectHandler struct {
 }
 
 // UserAuthMiddleware attempts to populate user data or optionally redirects to landing page
-func UserAuthMiddleware(secret string, hostname string, enforceAuth bool) func(next http.Handler) http.Handler {
-	redirectURL := fmt.Sprintf("%s/landing", hostname)
+func UserAuthMiddleware(secret string) func(next http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		mw := func(w http.ResponseWriter, r *http.Request) {
 			claims, ok := getUserClaimsFromCookie(secret, r)
-			if enforceAuth && !ok {
-				http.Redirect(w, r, redirectURL, http.StatusTemporaryRedirect)
-				return
-			}
 
 			if ok && shouldRenewForClaims(*claims) {
 				// Renew the token

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -28,7 +28,7 @@ const sessionRenewalTimeInMinutes = sessionExpiryInMinutes - 1
 // JwtCookieName is the key at which we're storing our token cookie
 const JwtCookieName = "JWT_COOKIE"
 
-// UserClaims does a thing
+// UserClaims wraps StandardClaims with some user info we care about
 type UserClaims struct {
 	Email   string `json:"email"`
 	IDToken string `json:"id_token"`

--- a/pkg/auth/auth_test.go
+++ b/pkg/auth/auth_test.go
@@ -1,13 +1,266 @@
 package auth
 
 import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"regexp"
 	"testing"
+
+	"github.com/gorilla/context"
+	"github.com/markbates/pop"
+	"github.com/pkg/errors"
 )
+
+const testHostname = "hostname"
 
 func TestGenerateNonce(t *testing.T) {
 	nonce := generateNonce()
 
 	if (nonce == "") || (len(nonce) < 1) {
 		t.Error("No nonce was returned.")
+	}
+}
+
+var dbConnection *pop.Connection
+
+func setupDBConnection() {
+	configLocation := "../../config"
+	pop.AddLookupPaths(configLocation)
+	conn, err := pop.Connect("test")
+	if err != nil {
+		log.Panic(err)
+	}
+
+	dbConnection = conn
+}
+
+func getHandlerParamsWithCookie(ss string) (*httptest.ResponseRecorder, *http.Request) {
+	rr := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/protected", nil)
+
+	// Set a secure cookie on the recorder
+	s, _ := cookieStore.Get(req, JwtCookieName)
+	s.AddFlash(ss)
+	s.IsNew = false
+	s.Save(req, rr)
+
+	// Calling Get sets the Set-Cookie header, so let's grab that cookie
+	// and set it as the Cookie header to trick the middleware
+	cookies := rr.Header()["Set-Cookie"]
+	req.Header.Set("Cookie", cookies[0])
+	// And refresh the recorder to get rid of the Set-Cookie header
+	rr = httptest.NewRecorder()
+
+	return rr, req
+}
+
+func createRandomRSAPEM() (s string, err error) {
+	priv, err := rsa.GenerateKey(rand.Reader, 1024)
+	if err != nil {
+		err = errors.Wrap(err, "failed to generate key")
+		return
+	}
+
+	asn1 := x509.MarshalPKCS1PrivateKey(priv)
+	privBytes := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: asn1,
+	})
+	s = string(privBytes[:])
+
+	return
+}
+
+func TestMain(m *testing.M) {
+	setupDBConnection()
+	os.Exit(m.Run())
+}
+
+func TestAuthorizationLogoutHandler(t *testing.T) {
+	fakeToken := "some_token"
+	responsePattern := regexp.MustCompile(`href="(.+)"`)
+	req, err := http.NewRequest("GET", "/auth/logout", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rr := httptest.NewRecorder()
+	handler := http.HandlerFunc(AuthorizationLogoutHandler(fmt.Sprintf("http://%s", testHostname)))
+
+	context.Set(req, "id_token", fakeToken)
+
+	handler.ServeHTTP(rr, req)
+
+	if status := rr.Code; status != http.StatusTemporaryRedirect {
+		t.Errorf("handler returned wrong status code: got %v wanted %v", status, http.StatusTemporaryRedirect)
+	}
+
+	redirectURL, err := url.Parse(responsePattern.FindStringSubmatch(rr.Body.String())[1])
+	if err != nil {
+		t.Fatal(err)
+	}
+	params := redirectURL.Query()
+
+	postRedirectURI, err := url.Parse(params["post_logout_redirect_uri"][0])
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if testHostname != postRedirectURI.Host {
+		t.Errorf("handler returned wrong redirect URI hostname: got %v wanted %v", postRedirectURI.Host, testHostname)
+	}
+
+	fmt.Println(params)
+	if token := params["id_token_hint"][0]; token != fakeToken {
+		t.Errorf("handler returned wrong id_token: got %v wanted %v", token, fakeToken)
+	}
+}
+
+func TestUserAuthMiddlewareWithBadToken(t *testing.T) {
+	fakeToken := "some_token"
+	pem, err := createRandomRSAPEM()
+	if err != nil {
+		t.Error("error creating RSA key", err)
+	}
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+	middleware := UserAuthMiddleware(pem, testHostname)(handler)
+
+	rr, req := getHandlerParamsWithCookie(fakeToken)
+
+	middleware.ServeHTTP(rr, req)
+
+	if status := rr.Code; status != http.StatusTemporaryRedirect {
+		t.Errorf("handler returned wrong status code: got %v wanted %v", status, http.StatusTemporaryRedirect)
+	}
+
+	if incomingToken, ok := context.Get(req, "id_token").(*string); ok {
+		t.Errorf("expected id_token to be nil, got %v", incomingToken)
+	}
+}
+
+func TestUserAuthMiddlewareWithValidToken(t *testing.T) {
+	email := "some_email@domain.com"
+	idToken := "fake_id_token"
+
+	pem, err := createRandomRSAPEM()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Brand new token, shouldn't be renewed
+	expiry := getExpiryTimeFromMinutes(sessionExpiryInMinutes)
+	ss, err := signedTokenStringWithUserInfo(email, idToken, expiry, pem)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+	middleware := UserAuthMiddleware(pem, testHostname)(handler)
+
+	rr, req := getHandlerParamsWithCookie(ss)
+
+	middleware.ServeHTTP(rr, req)
+
+	// We should get a 200 OK
+	if status := rr.Code; status != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got %v wanted %v", status, http.StatusOK)
+	}
+
+	// And there should be an ID token in the request context
+	if incomingToken, ok := context.Get(req, "id_token").(string); !ok || incomingToken != idToken {
+		t.Errorf("handler returned wrong id_token: got %v, wanted %v", incomingToken, idToken)
+	}
+
+	// And the cookie should not be renewed
+	if setCookies := rr.HeaderMap["Set-Cookie"]; len(setCookies) != 0 {
+		t.Errorf("expected no cookies to be set, got %v", len(setCookies))
+	}
+}
+
+func TestUserAuthMiddlewareWithRenewalToken(t *testing.T) {
+	email := "some_email@domain.com"
+	idToken := "fake_id_token"
+
+	pem, err := createRandomRSAPEM()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Token will expire in 1 minute, should be renewed
+	expiry := getExpiryTimeFromMinutes(1)
+	ss, err := signedTokenStringWithUserInfo(email, idToken, expiry, pem)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Println(r.Header)
+	})
+	middleware := UserAuthMiddleware(pem, testHostname)(handler)
+
+	rr, req := getHandlerParamsWithCookie(ss)
+
+	middleware.ServeHTTP(rr, req)
+
+	// We should get a 200 OK
+	if status := rr.Code; status != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got %v wanted %v", status, http.StatusOK)
+	}
+
+	// And there should be an ID token in the request context
+	if incomingToken, ok := context.Get(req, "id_token").(string); !ok || incomingToken != idToken {
+		t.Errorf("handler returned wrong id_token: got %v, wanted %v", incomingToken, idToken)
+	}
+
+	// And the cookie should be renewed
+	if setCookies := rr.HeaderMap["Set-Cookie"]; len(setCookies) != 1 {
+		t.Errorf("expected 1 cookie to be set, got %v", len(setCookies))
+	}
+}
+
+func TestUserAuthMiddlewareWithExpiredToken(t *testing.T) {
+	email := "some_email@domain.com"
+	idToken := "fake_id_token"
+
+	pem, err := createRandomRSAPEM()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expiry := getExpiryTimeFromMinutes(-1)
+	ss, err := signedTokenStringWithUserInfo(email, idToken, expiry, pem)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+	middleware := UserAuthMiddleware(pem, testHostname)(handler)
+
+	rr, req := getHandlerParamsWithCookie(ss)
+
+	middleware.ServeHTTP(rr, req)
+
+	// We should be redirected to the landing page
+	if status := rr.Code; status != http.StatusTemporaryRedirect {
+		t.Errorf("handler returned wrong status code: got %v wanted %v", status, http.StatusTemporaryRedirect)
+	}
+
+	// And there should be no token passed through
+	if incomingToken, ok := context.Get(req, "id_token").(string); ok {
+		t.Errorf("expected id_token to be nil, got %v", incomingToken)
+	}
+
+	// And the cookie should not be renewed
+	if setCookies := rr.HeaderMap["Set-Cookie"]; len(setCookies) != 0 {
+		t.Errorf("expected no cookies to be set, got %v", len(setCookies))
 	}
 }

--- a/pkg/auth/auth_test.go
+++ b/pkg/auth/auth_test.go
@@ -47,7 +47,7 @@ func getHandlerParamsWithToken(ss string, expiry time.Time) (*httptest.ResponseR
 
 	// Set a secure cookie on the request
 	cookie := http.Cookie{
-		Name:    JwtCookieName,
+		Name:    UserSessionCookieName,
 		Value:   ss,
 		Path:    "/",
 		Expires: expiry,


### PR DESCRIPTION
## Description

Stores token information on the client as a secure cookie, and adds middleware that parses the cookie and passes info to the http handlers in the context object

## Verification Steps

- [x] login.gov token is stored on client, eg can JWT_COOKIE in dev tools -> application -> storage -> cookies
- [x] ADR for token storage
- [x] for now, application works when user is not signed in

## References

- [Pivotal story](https://www.pivotaltracker.com/story/show/155140012) for this change