### PR TITLE
Fix staging callback URL

### DIFF
--- a/cmd/webserver/main.go
+++ b/cmd/webserver/main.go
@@ -44,7 +44,7 @@ func main() {
 	protocol := flag.String("protocol", "https://", "Protocol for non local environments.")
 	hostname := flag.String("http_server_name", "localhost", "Hostname according to environment.")
 	port := flag.String("port", "8080", "the `port` to listen on.")
-	callbackPort := flag.String("callback_port", "80", "The port for callback urls.")
+	callbackPort := flag.String("callback_port", "443", "The port for callback urls.")
 	internalSwagger := flag.String("internal-swagger", "swagger/internal.yaml", "The location of the internal API swagger definition")
 	apiSwagger := flag.String("swagger", "swagger/api.yaml", "The location of the public API swagger definition")
 	debugLogging := flag.Bool("debug_logging", false, "log messages at the debug level.")
@@ -96,11 +96,12 @@ func main() {
 	clientHandler := http.FileServer(http.Dir(*build))
 
 	// Register Login.gov authentication provider
+	fullHostname := fmt.Sprintf("%s%s", *protocol, *hostname) // URL for non-dev environments
 	if *env == "development" {
 		*protocol = "http://"
 		*callbackPort = "3000"
+		fullHostname = fmt.Sprintf("%s%s:%s", *protocol, *hostname, *callbackPort)
 	}
-	fullHostname := fmt.Sprintf("%s%s:%s", *protocol, *hostname, *callbackPort)
 	auth.RegisterProvider(*loginGovSecretKey, fullHostname, *loginGovClientID)
 
 	// Base routes

--- a/cmd/webserver/main.go
+++ b/cmd/webserver/main.go
@@ -95,14 +95,12 @@ func main() {
 	// Serves files out of build folder
 	clientHandler := http.FileServer(http.Dir(*build))
 
-	// URL for non-dev environments
-	fullHostname := fmt.Sprintf("%s%s", *protocol, *hostname)
+	// Register Login.gov authentication provider
 	if *env == "development" {
 		*protocol = "http://"
 		*callbackPort = "3000"
-		fullHostname = fmt.Sprintf("%s%s:%s", *protocol, *hostname, *callbackPort)
 	}
-	// Register Login.gov authentication provider
+	fullHostname := fmt.Sprintf("%s%s:%s", *protocol, *hostname, *callbackPort)
 	auth.RegisterProvider(*loginGovSecretKey, fullHostname, *loginGovClientID)
 
 	// Base routes

--- a/cmd/webserver/main.go
+++ b/cmd/webserver/main.go
@@ -95,13 +95,14 @@ func main() {
 	// Serves files out of build folder
 	clientHandler := http.FileServer(http.Dir(*build))
 
-	// Register Login.gov authentication provider
-	fullHostname := fmt.Sprintf("%s%s", *protocol, *hostname) // URL for non-dev environments
+	// URL for non-dev environments
+	fullHostname := fmt.Sprintf("%s%s", *protocol, *hostname)
 	if *env == "development" {
 		*protocol = "http://"
 		*callbackPort = "3000"
 		fullHostname = fmt.Sprintf("%s%s:%s", *protocol, *hostname, *callbackPort)
 	}
+	// Register Login.gov authentication provider
 	auth.RegisterProvider(*loginGovSecretKey, fullHostname, *loginGovClientID)
 
 	// Base routes


### PR DESCRIPTION
## Description

Match what's registered with login.gov sandbox. The staging sign in process currently breaks at login.gov's login page because the callback URL registered for our staging env does not match their system's, namely: "https://app.staging.dp3.us/auth/login-gov/callback". This PR fixes that.

## Verification Steps

- [x] The model tests pass.
- [ ] After this PR is merged to master, we can test whether it is fixed in our staging environment (not ideal for testing, but will work temporarily.)

## References

- [Pivotal story] related to: https://www.pivotaltracker.com/story/show/155131443

