### PR TITLE
Ensure that shipments is always an array.

### DIFF
--- a/src/scenes/Shipments/ducks.js
+++ b/src/scenes/Shipments/ducks.js
@@ -40,7 +40,7 @@ export function shipmentsReducer(
     case SHOW_SHIPMENTS_SUCCESS:
       return { shipments: action.shipments, hasError: false };
     case SHOW_SHIPMENTS_FAILURE:
-      return { shipments: null, hasError: true };
+      return { shipments: [], hasError: true };
     default:
       return state;
   }

--- a/src/scenes/Shipments/ducks.test.js
+++ b/src/scenes/Shipments/ducks.test.js
@@ -11,17 +11,17 @@ import {
 
 describe('Shipments Reducer', () => {
   it('Should handle SHOW_SHIPMENTS', () => {
-    const initialState = { shipments: null, hasError: false };
+    const initialState = { shipments: [], hasError: false };
 
     const newState = shipmentsReducer(initialState, {
       type: 'SHOW_SHIPMENTS',
     });
 
-    expect(newState).toEqual({ shipments: null, hasError: false });
+    expect(newState).toEqual({ shipments: [], hasError: false });
   });
 
   it('Should handle SHOW_SHIPMENTS_SUCCESS', () => {
-    const initialState = { shipments: null, hasError: false };
+    const initialState = { shipments: [], hasError: false };
 
     const newState = shipmentsReducer(initialState, {
       type: 'SHOW_SHIPMENTS_SUCCESS',
@@ -35,19 +35,19 @@ describe('Shipments Reducer', () => {
   });
 
   it('Should handle SHOW_SHIPMENTS_FAILURE', () => {
-    const initialState = { shipments: null, hasError: false };
+    const initialState = { shipments: [], hasError: false };
 
     const newState = shipmentsReducer(initialState, {
       type: 'SHOW_SHIPMENTS_FAILURE',
       error: 'Boring',
     });
 
-    expect(newState).toEqual({ shipments: null, hasError: true });
+    expect(newState).toEqual({ shipments: [], hasError: true });
   });
 });
 
 describe('Shipments actions without optional props', () => {
-  const initialState = { shipments: null, hasError: false };
+  const initialState = { shipments: [], hasError: false };
   const mockStore = configureStore();
   let store;
 
@@ -89,7 +89,7 @@ describe('Shipments actions without optional props', () => {
 });
 
 describe('Shipments actions with optional props', () => {
-  const initialState = { shipments: null, hasError: false };
+  const initialState = { shipments: [], hasError: false };
   const mockStore = configureStore();
   let store;
 


### PR DESCRIPTION
## Description

`shipments` would sometimes be `null` and sometimes an Array, which was causing the app to crash when we'd attempt to call an Array method on `null`. This patch changes the app to always represent `shipments` as an Array (empty or not), so that these kind of iteration methods are no-ops when there are no shipments.

## Verification Steps

- [x] Hitting `/shipments` or associated paths displays a graceful server error instead of crashing the page.

## References

- [Pivotal story](https://www.pivotaltracker.com/story/show/155231916) for this change

## Screenshots

After being applied, attempting to view the shipments without a server running results in:

<img width="1021" alt="screen shot 2018-02-26 at 11 27 39 am" src="https://user-images.githubusercontent.com/3331/36685248-5b383bbc-1ae8-11e8-97ae-8e284ba53338.png">

