### PR TITLE
run e2e after new image is pushed to staging

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,7 +98,6 @@ jobs:
           key: yarn-node-modules-cache-{{ checksum "yarn.lock" }}
           paths:
             - node_modules
-      - run: make e2e_test
 
       - run: *announce_failure
 
@@ -141,6 +140,14 @@ jobs:
           command: |
             bash -c "$(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION)"
             ecs-deploy -c app-staging -n app -t 600 -i ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/app:${CIRCLE_SHA1}
+      - run: *announce_failure
+
+  integration_tests:
+    docker:
+      - image: trussworks/circleci-docker-primary:25fb58d78157ba0664802478ea7195cdb1d5f9d7
+    steps:
+      - checkout
+      - run: make e2e_test
       - run: *announce_failure
 
   update_dependencies:
@@ -198,6 +205,18 @@ workflows:
           filters:
             branches:
               only: master
+      - integration_tests:
+          requires:
+            - deploy_app
+          filters:
+            branches:
+              only: master
+
+  rebecca:
+    jobs:
+      - integration_tests:
+          filters:
+            branches: rek_move-e2e-run
 
   dependency_updater:
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -216,7 +216,8 @@ workflows:
     jobs:
       - integration_tests:
           filters:
-            branches: rek_move-e2e-run
+            branches:
+              only: rek_move-e2e-run
 
   dependency_updater:
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,6 @@ jobs:
       - run: make client_build
       - run: make client_test
       - run: make server_test
-      - run: make e2e_test
       - run: make tools_build
       - run: make server_build_docker
       - run:
@@ -99,6 +98,7 @@ jobs:
           key: yarn-node-modules-cache-{{ checksum "yarn.lock" }}
           paths:
             - node_modules
+      - run: make e2e_test
 
       - run: *announce_failure
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -212,13 +212,6 @@ workflows:
             branches:
               only: master
 
-  rebecca:
-    jobs:
-      - integration_tests:
-          filters:
-            branches:
-              only: rek_move-e2e-run
-
   dependency_updater:
     triggers:
       - schedule:

--- a/e2e/e2e.test.js
+++ b/e2e/e2e.test.js
@@ -8,91 +8,103 @@ function buildStagingURL(path) {
 var webdriver = require('selenium-webdriver'),
   By = webdriver.By,
   until = webdriver.until,
+  promise = webdriver.promise,
   username = 'movemil',
   accessKey = process.env.SAUCE_ACCESS_KEY,
   driver;
 
-driver = new webdriver.Builder()
-  .withCapabilities({
-    browserName: 'internet explorer',
-    platform: 'Windows 8.1',
-    version: '11.0',
-    username: username,
-    accessKey: accessKey,
-  })
-  .usingServer(
-    'http://' +
-      username +
-      ':' +
-      accessKey +
-      '@ondemand.saucelabs.com:80/wd/hub',
-  )
-  .build();
+// async/await do not work well when the promise manager is enabled.
+promise.USE_PROMISE_MANAGER = false;
 
 // jest.set_timeout() doesn't work in this circumstance, so using jasmine timeout.
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 60 * 5;
 
-// TESTS
-describe('issue pages', () => {
-  beforeEach(() => driver.navigate().to(STAGING_BASE));
+beforeAll(async function() {
+  driver = new webdriver.Builder()
+    .withCapabilities({
+      browserName: 'internet explorer',
+      platform: 'Windows 8.1',
+      version: '11.0',
+      username: username,
+      accessKey: accessKey,
+    })
+    .usingServer(
+      'http://' +
+        username +
+        ':' +
+        accessKey +
+        '@ondemand.saucelabs.com:80/wd/hub',
+    )
+    .build();
+});
 
-  it('loads Submit Feedback page', () => {
+describe('issue pages', async () => {
+  beforeEach(async () => await driver.navigate().to(STAGING_BASE));
+
+  it('loads Submit Feedback page', async () => {
     // When: Page is loaded, should display expected title
-    driver.wait(until.titleIs('Transcom PPP: Submit Feedback'), 2000);
+    await driver.wait(until.titleIs('Transcom PPP: Submit Feedback'), 2000);
   });
 
-  it('allows issue submission and retrieval', () => {
+  it('allows issue submission and retrieval', async () => {
     // Given: A test issue and a feedback form on index page
-    test_issue = 'Too few dogs. Time: ' + Date.now();
-    driver.wait(until.elementLocated(By.css('[data-test="feedback-form"]')));
-    feedback_form = driver.findElement(By.css('[data-test="feedback-form"]'));
+    test_issue = 'Too much Alexi. Time: ' + Date.now();
+    await driver.wait(
+      until.elementLocated(By.css('[data-test="feedback-form"]')),
+    );
+    feedback_form = await driver.findElement(
+      By.css('[data-test="feedback-form"]'),
+    );
     feedback_form.clear();
     // When: Submit issue
     feedback_form.sendKeys(test_issue);
-    driver.findElement(By.css("input[type='submit']")).click();
+    await driver.findElement(By.css("input[type='submit']")).click();
     // Then: Visit submitted page
-    driver.get(buildStagingURL('submitted'));
-    issue_cards = driver.findElement(By.className('issue-cards'));
+    await driver.get(buildStagingURL('submitted'));
+    issue_cards = await driver.findElement(By.className('issue-cards'));
     // Expect: Submitted issue exists on page
-    driver.wait(until.elementTextContains(issue_cards, test_issue), 1000);
+    await driver.wait(until.elementTextContains(issue_cards, test_issue), 1000);
   });
 });
 
-describe('shipments pages', () => {
-  it('loads all shipments page', () => {
+describe('shipments pages', async () => {
+  it('loads all shipments page', async () => {
     // When: Page is loaded, should display expected title
-    driver.navigate().to(buildStagingURL('shipments/all'));
-    driver.wait(until.titleIs('Transcom PPP: All Shipments'), 2000);
+    await driver.navigate().to(buildStagingURL('shipments/all'));
+    await driver.wait(until.titleIs('Transcom PPP: All Shipments'), 2000);
   });
 
-  it('loads available shipments page', () => {
+  it('loads available shipments page', async () => {
     // When: Page is loaded, should display expected title
-    driver.navigate().to(buildStagingURL('shipments/available'));
-    driver.wait(until.titleIs('Transcom PPP: Available Shipments'), 2000);
+    await driver.navigate().to(buildStagingURL('shipments/available'));
+    await driver.wait(until.titleIs('Transcom PPP: Available Shipments'), 2000);
   });
 
-  it('loads awarded shipments page', () => {
+  it('loads awarded shipments page', async () => {
     // When: Page is loaded, should display expected title
-    driver.navigate().to(buildStagingURL('shipments/awarded'));
-    driver.wait(until.titleIs('Transcom PPP: Awarded Shipments'), 2000);
+    await driver.navigate().to(buildStagingURL('shipments/awarded'));
+    await driver.wait(until.titleIs('Transcom PPP: Awarded Shipments'), 2000);
   });
 
-  it('displays alert on incorrect url', () => {
-    driver.navigate().to(buildStagingURL('shipments/dogs'));
+  it('displays alert on incorrect url', async () => {
+    await driver.navigate().to(buildStagingURL('shipments/dogs'));
     // Expect: Alert error exists on page
-    driver.wait(until.elementLocated(By.className('usa-alert-error')), 2000);
+    await driver.wait(
+      until.elementLocated(By.className('usa-alert-error')),
+      2000,
+    );
   });
 });
 
-describe('DD1299 page', () => {
-  beforeEach(() => driver.navigate().to(buildStagingURL('DD1299')));
+describe('DD1299 page', async () => {
+  beforeEach(async () => await driver.navigate().to(buildStagingURL('DD1299')));
 
-  it('loads DD1299 page', () => {
+  it('loads DD1299 page', async () => {
     // When: Page is loaded, should display expected title
-    driver.wait(until.titleIs('Transcom PPP: 1299'), 2000);
+    await driver.wait(until.titleIs('Transcom PPP: DD1299'), 2000);
   });
 });
 
-afterAll(() => {
-  driver.quit();
+afterAll(async () => {
+  await driver.quit();
 });

--- a/e2e/e2e.test.js
+++ b/e2e/e2e.test.js
@@ -48,7 +48,7 @@ describe('issue pages', async () => {
 
   it('allows issue submission and retrieval', async () => {
     // Given: A test issue and a feedback form on index page
-    test_issue = 'Too much Alexi. Time: ' + Date.now();
+    test_issue = 'Too few dogs. Time: ' + Date.now();
     await driver.wait(
       until.elementLocated(By.css('[data-test="feedback-form"]')),
     );


### PR DESCRIPTION
## Description

E2E tests were running before the new image was pushed to staging. Therefore, we weren't actually testing against the new code. This fixes that.
It also makes sure that we're running the tests and executing commands in the order we save by making use of selenium's async/await functionality.

## Reviewer Notes

Should e2e be moved before cache is saved?
Review the following for description of async/await in selenium webdriver: https://github.com/SeleniumHQ/selenium/wiki/WebDriverJs#moving-to-asyncawait

## Verification Steps

- [ ] The CI tests pass.
- [ ] On Sauce, expect to see passing tests in order they were given.

## References

- [Pivotal story](https://www.pivotaltracker.com/story/show/154580324)
