### PR TITLE
Add links to godoc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![Build status](https://img.shields.io/circleci/project/github/transcom/mymove/master.svg)](https://circleci.com/gh/transcom/mymove/tree/master)
 
+[![GoDoc](https://godoc.org/github.com/transcom/mymove?status.svg)](https://godoc.org/github.com/transcom/mymove)
+
 This repository contains the application source code for the Personal Property Prototype, a possible next generation version of the Defense Personal Property System (DPS). DPS is an online system managed by the U.S. [Department of Defense](https://www.defense.gov/) (DoD) [Transportation Command](http://www.ustranscom.mil/) (USTRANSCOM) and is used by service members and their families to manage household goods moves.
 
 This prototype was built by a [Defense Digital Service](https://www.dds.mil/) team in support of USTRANSCOM's mission.
@@ -29,6 +31,7 @@ This prototype was built by a [Defense Digital Service](https://www.dds.mil/) te
   * [Database](#database)
     * [Dev Commands](#dev-commands)
     * [Migrations](#migrations)
+  * [Documentation](#documentation)
   * [Troubleshooting](#troubleshooting)
 
 _Regenerate with `bin/generate-md-toc.sh`_
@@ -206,6 +209,19 @@ Migrations are run automatically by CircleCI as part of the standard deploy proc
 1. Migrations run inside the container against the environment's database.
 1. If migrations fail, CircleCI fails the deploy.
 1. If migrations pass, CircleCI continues with the deploy.
+
+### Documentation
+
+You can view the project's godoc on [godoc.org](https://godoc.org/github.com/transcom/mymove).
+
+Alternatively, run the documentation locally using:
+
+```shell
+# within the project's root dir
+$ godoc -http=:6060
+```
+
+Then visit [http://localhost:6060/pkg/github.com/transcom/mymove/](http://localhost:6060/pkg/github.com/transcom/mymove/) in a web browser.
 
 ### Troubleshooting
 


### PR DESCRIPTION
## Description

This PR adds a link to the auto-generated go documentation for the project's code on godoc.org. It also adds instructions to the README to run the doc server locally.

## Verification Steps

* [ ] The links work.

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/155524131) for this change