### PR TITLE
Document how to avoid SQL injections

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,3 @@
-
 ## Description
 
 Explain a little about the changes at a high level.
@@ -9,9 +8,10 @@ Is there anything you would like reviewers to give additional scrutiny?
 
 ## Verification Steps
 
-* [ ] The model tests pass.
-* [ ] There are no [aXe](https://www.deque.com/products/aXe/) warning for UI
-* [ ] This works in IE
+* [ ] All tests pass.
+* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely) have been satisfied.
+* [ ] There are no [aXe](https://www.deque.com/products/aXe/) warnings for UI.
+* [ ] This works in IE.
 
 ## References
 

--- a/README.md
+++ b/README.md
@@ -171,6 +171,8 @@ If you need to see some output during the development process (say, for debuggin
 
 ### Database
 
+* Read [Querying the Database Safely](https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely) to prevent SQL injections! *
+
 #### Dev Commands
 
 There are a few handy targets in the Makefile to help you interact with the dev database:

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -6,6 +6,7 @@
 
 * [Go](#go)
   * [Style and Conventions](#style-and-conventions)
+  * [Querying the Database Safely](#querying-the-database-safely)
   * [Libraries](#libraries)
     * [Pop](#pop)
   * [Learning](#learning)
@@ -32,6 +33,26 @@ Beyond what is described above, the following contain additional insights into h
 * [What's in a name?](https://talks.golang.org/2014/names.slide#1) (how to name things in Go)
 * [Go best practices, six years in](https://peter.bourgon.org/go-best-practices-2016/)
 * [A theory of modern Go](https://peter.bourgon.org/blog/2017/06/09/theory-of-modern-go.html)
+
+### Querying the Database Safely
+
+* SQL statements *must* use Postgres-native parameter replacement format (e.g. `$1`, `$2`, etc.) and *never* interpolate values into SQL fragments in any other way.
+* SQL statements must only be defined in the `models` package.
+
+Here is an example of a safe query for a single `Shipment`:
+
+```golang
+// db is a *pop.Connection
+
+id := "0186ad95-14ed-4c9b-9f62-d5bd124f62a1"
+
+query := db.Where("id = $1", id)
+
+shipment := &models.Shipment{}
+if err = query.First(shipment); err == nil {
+  pp.Println(shipment)
+}
+```
 
 ### Libraries
 
@@ -64,7 +85,7 @@ Knowing what deserves a test and what doesn’t can be tricky, especially early 
 #### General
 
 * Use table-driven tests where appropriate.
-* Make judicious use of helper funcs so that the intent of a test is not lost in a sea of error checking and boilerplate.
+* Make judicious use of helper funcs so that the intent of a test is not lost in a sea of error checking and boilerplate. Use [`t.Helper()`](https://golang.org/pkg/testing/#T.Helper) in your test helper funcs to keep stack traces clean.
 
 #### Models
 


### PR DESCRIPTION
## Description

We are adding explicit documentation to our backend guide about how to avoid SQL injection. Additionally, a new item has been added to the PR template to help everyone remember.

## Reviewer Notes

The link to the documentation won't work until this PR is merged 😄 

## Verification Steps

* [ ] The documentation is understandable and properly captures our prior discussion re: avoiding SQL injection.

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/155384995) for this change