### PR TITLE
Rek add mps

### DIFF
--- a/pkg/awardqueue/awardqueue_test.go
+++ b/pkg/awardqueue/awardqueue_test.go
@@ -117,7 +117,7 @@ func TestAwardQueueEndToEnd(t *testing.T) {
 func Test_FetchTSPsInTDL(t *testing.T) {
 	tdl, _ := testdatagen.MakeTDL(db, "source", "dest", "cos")
 	tsp, _ := testdatagen.MakeTSP(db, "Test TSP", "TSP1")
-	testdatagen.MakeBestValueScore(db, tsp, tdl, 10)
+	testdatagen.MakeBestValueScore(db, tsp, tdl, 15)
 
 	tsps, err := models.FetchTSPsInTDLSortByAward(db, tdl.ID)
 
@@ -131,7 +131,7 @@ func Test_FetchTSPsInTDL(t *testing.T) {
 func Test_FetchTSPsInTDLByBVS(t *testing.T) {
 	tdl, _ := testdatagen.MakeTDL(db, "source", "dest", "cos")
 	tsp, _ := testdatagen.MakeTSP(db, "Test TSP", "TSP1")
-	testdatagen.MakeBestValueScore(db, tsp, tdl, 10)
+	testdatagen.MakeBestValueScore(db, tsp, tdl, 15)
 
 	tsps, err := models.FetchTSPsInTDLSortByBVS(db, tdl.ID)
 
@@ -167,10 +167,10 @@ func Test_assignTSPsToBands(t *testing.T) {
 	// Make a TDL to contain our tests
 	tdl, _ := testdatagen.MakeTDL(db, "california", "90210", "2")
 
-	// Make 10 (not divisible by 4) TSPs in this TDL with BVSs
+	// Make 5 (not divisible by 4) TSPs in this TDL with BVSs
 	for i := 0; i < tspsToMake; i++ {
 		tsp, _ := testdatagen.MakeTSP(db, "Test Shipper", "TEST")
-		testdatagen.MakeBestValueScore(db, tsp, tdl, 10)
+		testdatagen.MakeBestValueScore(db, tsp, tdl, 15)
 	}
 	// Fetch TSPs in TDL
 	tspsbb, err := models.FetchTSPsInTDLSortByBVS(db, tdl.ID)
@@ -178,8 +178,35 @@ func Test_assignTSPsToBands(t *testing.T) {
 	if err != nil {
 		t.Errorf("Failed to find TSPs: %v", err)
 	}
-	if len(qbs[0]) != 2 || len(qbs[2]) != 1 {
+	if len(qbs[0]) != 2 || len(qbs[1]) != 1 {
 		t.Errorf("Failed to correctly add TSPs to quality bands.")
+	}
+}
+
+func Test_BVSWithLowMPS(t *testing.T) {
+	tspsToMake := 5
+
+	// Make a TDL to contain our tests
+	tdl, _ := testdatagen.MakeTDL(db, "california", "90210", "2")
+
+	// Make 5 (not divisible by 4) TSPs in this TDL with BVSs above MPS threshold
+	for i := 0; i < tspsToMake; i++ {
+		tsp, _ := testdatagen.MakeTSP(db, "Test Shipper", "TEST")
+		testdatagen.MakeBestValueScore(db, tsp, tdl, 15)
+	}
+	// Make 1 TSP in this TDL with BVS below the MPS threshold
+	tsp, _ := testdatagen.MakeTSP(db, "Low BVS Test Shipper", "TEST")
+	testdatagen.MakeBestValueScore(db, tsp, tdl, 1)
+
+	// Fetch TSPs in TDL
+	tspsbb, err := models.FetchTSPsInTDLSortByBVS(db, tdl.ID)
+	qbs := assignTSPsToBands(tspsbb)
+	if err != nil {
+		t.Errorf("Failed to find TSPs: %v", err)
+	}
+
+	if len(qbs[0]) != 2 || len(qbs[1]) != 1 {
+		t.Errorf("Failed to correctly add TSPs to quality bands abiding by MPS.")
 	}
 }
 

--- a/pkg/awardqueue/awardqueue_test.go
+++ b/pkg/awardqueue/awardqueue_test.go
@@ -195,18 +195,21 @@ func Test_BVSWithLowMPS(t *testing.T) {
 		testdatagen.MakeBestValueScore(db, tsp, tdl, 15)
 	}
 	// Make 1 TSP in this TDL with BVS below the MPS threshold
-	tsp, _ := testdatagen.MakeTSP(db, "Low BVS Test Shipper", "TEST")
-	testdatagen.MakeBestValueScore(db, tsp, tdl, 1)
+	mpsTSP, _ := testdatagen.MakeTSP(db, "Low BVS Test Shipper", "TEST")
+	testdatagen.MakeBestValueScore(db, mpsTSP, tdl, 1)
 
 	// Fetch TSPs in TDL
 	tspsbb, err := models.FetchTSPsInTDLSortByBVS(db, tdl.ID)
-	qbs := assignTSPsToBands(tspsbb)
+
+	// Then: Expect to find TSPs in TDL
 	if err != nil {
 		t.Errorf("Failed to find TSPs: %v", err)
 	}
-
-	if len(qbs[0]) != 2 || len(qbs[1]) != 1 {
-		t.Errorf("Failed to correctly add TSPs to quality bands abiding by MPS.")
+	// Then: Expect TSP with low BVS won't be in sorted TSP slice
+	for _, tsp := range tspsbb {
+		if tsp.ID == mpsTSP.ID {
+			t.Errorf("TSP: %v with a BVS below MPS incorrectly included.", mpsTSP.ID)
+		}
 	}
 }
 

--- a/pkg/models/transportation_service_provider.go
+++ b/pkg/models/transportation_service_provider.go
@@ -47,7 +47,8 @@ func (t TransportationServiceProvider) String() string {
 // TransportationServiceProviders is not required by pop and may be deleted
 type TransportationServiceProviders []TransportationServiceProvider
 
-// Minimum Performance Score (MPS) is currently a constant, which we expect to change
+// Minimum Performance Score (MPS) is the lowest BVS a TSP can have and still be assigned shipments.
+// TODO: Implement as something other than a constant.
 const mps = 10
 
 // String is not required by pop and may be deleted

--- a/pkg/models/transportation_service_provider.go
+++ b/pkg/models/transportation_service_provider.go
@@ -47,6 +47,9 @@ func (t TransportationServiceProvider) String() string {
 // TransportationServiceProviders is not required by pop and may be deleted
 type TransportationServiceProviders []TransportationServiceProvider
 
+// Minimum Performance Score (MPS) is currently a constant, which we expect to change
+const MPS = 10
+
 // String is not required by pop and may be deleted
 func (t TransportationServiceProviders) String() string {
 	jt, _ := json.Marshal(t)
@@ -114,14 +117,16 @@ func FetchTSPsInTDLSortByBVS(tx *pop.Connection, tdlID uuid.UUID) ([]TSPWithBVSC
 			transportation_service_providers
 		JOIN best_value_scores ON
 			transportation_service_providers.id = best_value_scores.transportation_service_provider_id
+		AND
+			best_value_scores.score > $1
 		WHERE
-			best_value_scores.traffic_distribution_list_id = ?
+			best_value_scores.traffic_distribution_list_id = $2
 		GROUP BY best_value_scores.id
 		ORDER BY best_value_score DESC
 		`
 
 	tsps := []TSPWithBVSCount{}
-	err := tx.RawQuery(sql, tdlID).All(&tsps)
+	err := tx.RawQuery(sql, MPS, tdlID).All(&tsps)
 
 	return tsps, err
 }

--- a/pkg/models/transportation_service_provider.go
+++ b/pkg/models/transportation_service_provider.go
@@ -48,7 +48,7 @@ func (t TransportationServiceProvider) String() string {
 type TransportationServiceProviders []TransportationServiceProvider
 
 // Minimum Performance Score (MPS) is currently a constant, which we expect to change
-const MPS = 10
+const mps = 10
 
 // String is not required by pop and may be deleted
 func (t TransportationServiceProviders) String() string {
@@ -86,14 +86,16 @@ func FetchTSPsInTDLSortByAward(tx *pop.Connection, tdlID uuid.UUID) ([]TSPWithBV
 			transportation_service_providers.id = best_value_scores.transportation_service_provider_id
 		LEFT JOIN shipment_awards ON
 			transportation_service_providers.id = shipment_awards.transportation_service_provider_id
+		AND
+			best_value_scores.score > $1
 		WHERE
-			best_value_scores.traffic_distribution_list_id = ?
+			best_value_scores.traffic_distribution_list_id = $2
 		GROUP BY best_value_scores.id
 		ORDER BY award_count ASC, best_value_score DESC
 		`
 
 	tsps := []TSPWithBVSAndAwardCount{}
-	err := tx.RawQuery(sql, tdlID).All(&tsps)
+	err := tx.RawQuery(sql, mps, tdlID).All(&tsps)
 
 	return tsps, err
 }
@@ -126,7 +128,7 @@ func FetchTSPsInTDLSortByBVS(tx *pop.Connection, tdlID uuid.UUID) ([]TSPWithBVSC
 		`
 
 	tsps := []TSPWithBVSCount{}
-	err := tx.RawQuery(sql, MPS, tdlID).All(&tsps)
+	err := tx.RawQuery(sql, mps, tdlID).All(&tsps)
 
 	return tsps, err
 }


### PR DESCRIPTION
## Description

This PR adds minimum performance score (MPS) to the sql queries for TSPs available to be awarded shipments.

## Reviewer Notes

I've also changed the sql parameters to abide by our new postgres-native parameter style. Please take a look at that as well.
I've started with an mps as 10. This WILL change once we determine how mps will be loaded into the system. Alexi and I decided that was out of scope for this task.

## Verification Steps

* [ ] The server tests pass.

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/155343843) for this change
