### PR TITLE
Remove debug flag from migration Dockerfile...

### DIFF
--- a/Dockerfile.migrations
+++ b/Dockerfile.migrations
@@ -26,7 +26,7 @@ COPY config/database.yml /migrate
 ENV GO_ENV=container
 
 ENTRYPOINT ["/bin/soda"]
-CMD ["migrate", "-d", \
+CMD ["migrate", \
      "-c", "/migrate/database.yml", \
      "-p", "/migrate/migrations", \
      "up"]


### PR DESCRIPTION
...to avoid leaking db credentials.

## Description

The `-d` flag to `soda migrate` causes all SQL statements to be logged, which end up including the database username and password:

```
[POP] 2018/02/21 21:53:23 pg_dump -s --dbname=postgres://USERNAME:PASSWORD@host:5432/app?sslmode=disable
```

It turns out that we added this flag when we were first setting up the project and no longer have a need for it. Pop already prints the name of migrations as it runs them, which is the info we really were interested in in case of debugging a failed migration.

## Verification Steps

* [x] Docker can build an image from `Dockerfile.migrations` (I verified this locally using `docker build --no-cache . -f Dockerfile.migrations`).
* [x] The code changes and rationale make sense to other developers.

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/155420540) for this change
* [GitHub issue on the Pop repository](https://github.com/gobuffalo/pop/issues/2).