### PR TITLE
server_test should depend on server_deps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ tsp_run_only_docker: db_dev_run
 
 build: server_build tools_build client_build
 
-server_test: db_dev_run db_test_reset server_deps server_generate
+server_test: server_deps server_generate db_dev_run db_test_reset
 	# Don't run tests in /cmd or /pkg/gen
 	# Use -test.parallel 1 to test packages serially and avoid database collisions
 	# Disable test caching with `-count 1` - caching was masking local test failures


### PR DESCRIPTION
## Description

Attempting to run `make server_test` in a freshly checked out repo will fail because the server dependencies (specifically `soda`) aren't installed yet. This patch reorders the `server_test` target's dependencies so that `server_deps` is processed first.

## Verification Steps

* [x] CI is green.
* [x] `server_test` works in a fresh project checkout.

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/155474255) for this change