### PR TITLE
standardize sql param notation

### DIFF
--- a/pkg/models/transportation_service_provider_performance.go
+++ b/pkg/models/transportation_service_provider_performance.go
@@ -94,7 +94,7 @@ func FetchTSPPerformanceForQualityBandAssignment(tx *pop.Connection, tdlID uuid.
 		FROM
 			transportation_service_provider_performances
 		WHERE
-			traffic_distribution_list_id = ?
+			traffic_distribution_list_id = $1
 			AND
 			best_value_score > $2
 		ORDER BY


### PR DESCRIPTION
## Description

Currently using both ? and $ notation in sql in tsp_performance queries. Changing that.

## Verification Steps

* [ ] All tests pass.
* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely) have been satisfied.