### PR TITLE
Fix E2E tests and allow for local execution

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -86,6 +86,10 @@ denormalize
 sqlx
 godoc.org
 aXe
+E2E_BASE
+url
+ngrok
+localtunnel
  - docs/backend.md
 _Regenerate
 _

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ There are a few handy targets in the Makefile to help you run tests:
 
 * `make client_test`: Run front-end testing suites.
 * `make server_test`: Run back-end testing suites.
-* `make e2e_test`: Run e2e testing suite. To run locally, add an environment variable called SAUCE_ACCESS_KEY, which you can find in team DP3 Engineering Vault of 1Password under Sauce Labs or by logging in to Sauce itself. In 1Password, the access key is labeled SAUCE_ACCESS_KEY.
+* `make e2e_test`: Run e2e testing suite. To run locally, add an environment variable called SAUCE_ACCESS_KEY, which you can find in team DP3 Engineering Vault of 1Password under Sauce Labs or by logging in to Sauce itself. In 1Password, the access key is labeled SAUCE_ACCESS_KEY. This will run against our staging environment. If you want to point to another instance, add an environment variable called E2E_BASE with the base url for the instance. Note that to test a development instance, you must run `make server_run_standalone` and set up a tunnel (via ngrok or localtunnel).
 * `make test`: Run e2e, client- and server-side testing suites.
 
 ### Logging

--- a/e2e/e2e.test.js
+++ b/e2e/e2e.test.js
@@ -4,7 +4,7 @@ const E2E_BASE = process.env.E2E_BASE || 'https://app.staging.dp3.us/';
 if (process.env.E2E_BASE) console.log('base url is ', E2E_BASE);
 const BASE_URL = new URL(E2E_BASE);
 
-function buildStagingURL(path) {
+function buildURL(path) {
   return new URL(path, BASE_URL);
 }
 
@@ -61,7 +61,7 @@ describe('issue pages', async () => {
     await feedback_form.submit();
 
     // Then: Visit submitted page
-    await driver.get(buildStagingURL('submitted'));
+    await driver.get(buildURL('submitted'));
     await driver.wait(until.titleIs('Transcom PPP: Submitted Feedback'), 2000);
 
     issue_cards = await driver.findElement(By.className('issue-cards'));
@@ -73,24 +73,24 @@ describe('issue pages', async () => {
 describe('shipments pages', async () => {
   it('loads all shipments page', async () => {
     // When: Page is loaded, should display expected title
-    await driver.navigate().to(buildStagingURL('shipments/all'));
+    await driver.navigate().to(buildURL('shipments/all'));
     await driver.wait(until.titleIs('Transcom PPP: All Shipments'), 2000);
   });
 
   it('loads available shipments page', async () => {
     // When: Page is loaded, should display expected title
-    await driver.navigate().to(buildStagingURL('shipments/available'));
+    await driver.navigate().to(buildURL('shipments/available'));
     await driver.wait(until.titleIs('Transcom PPP: Available Shipments'), 2000);
   });
 
   it('loads awarded shipments page', async () => {
     // When: Page is loaded, should display expected title
-    await driver.navigate().to(buildStagingURL('shipments/awarded'));
+    await driver.navigate().to(buildURL('shipments/awarded'));
     await driver.wait(until.titleIs('Transcom PPP: Awarded Shipments'), 2000);
   });
 
   it('displays alert on incorrect url', async () => {
-    await driver.navigate().to(buildStagingURL('shipments/dogs'));
+    await driver.navigate().to(buildURL('shipments/dogs'));
     // Expect: Alert error exists on page
     await driver.wait(
       until.elementLocated(By.className('usa-alert-error')),
@@ -100,7 +100,7 @@ describe('shipments pages', async () => {
 });
 
 describe('DD1299 page', async () => {
-  beforeEach(async () => await driver.navigate().to(buildStagingURL('DD1299')));
+  beforeEach(async () => await driver.navigate().to(buildURL('DD1299')));
 
   it('loads DD1299 page', async () => {
     // When: Page is loaded, should display expected title


### PR DESCRIPTION
## Description

This should fix the master build and allow for users to run E2E tests against non staging environments

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Verification Steps

* [ ] All tests pass.
* [n/a ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely) have been satisfied.
* [n/a ] There are no [aXe](https://www.deque.com/products/aXe/) warnings for UI.
* [n/a ] This works in IE.

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/155668404) for this change
