### PR TITLE
Wait for 10 seconds before failing.

### DIFF
--- a/e2e/e2e.test.js
+++ b/e2e/e2e.test.js
@@ -22,6 +22,8 @@ promise.USE_PROMISE_MANAGER = false;
 // jest.set_timeout() doesn't work in this circumstance, so using jasmine timeout.
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 60 * 5;
 
+const WAIT_TIME = 1000 * 10;
+
 beforeAll(async function() {
   driver = new webdriver.Builder()
     .withCapabilities({
@@ -46,7 +48,10 @@ describe('issue pages', async () => {
 
   it('loads Submit Feedback page', async () => {
     // When: Page is loaded, should display expected title
-    await driver.wait(until.titleIs('Transcom PPP: Submit Feedback'), 2000);
+    await driver.wait(
+      until.titleIs('Transcom PPP: Submit Feedback'),
+      WAIT_TIME,
+    );
   });
 
   it('allows issue submission and retrieval', async () => {
@@ -62,11 +67,17 @@ describe('issue pages', async () => {
 
     // Then: Visit submitted page
     await driver.get(buildURL('submitted'));
-    await driver.wait(until.titleIs('Transcom PPP: Submitted Feedback'), 2000);
+    await driver.wait(
+      until.titleIs('Transcom PPP: Submitted Feedback'),
+      WAIT_TIME,
+    );
 
     issue_cards = await driver.findElement(By.className('issue-cards'));
     // Expect: Submitted issue exists on page
-    await driver.wait(until.elementTextContains(issue_cards, test_issue), 1000);
+    await driver.wait(
+      until.elementTextContains(issue_cards, test_issue),
+      WAIT_TIME,
+    );
   });
 });
 
@@ -74,19 +85,25 @@ describe('shipments pages', async () => {
   it('loads all shipments page', async () => {
     // When: Page is loaded, should display expected title
     await driver.navigate().to(buildURL('shipments/all'));
-    await driver.wait(until.titleIs('Transcom PPP: All Shipments'), 2000);
+    await driver.wait(until.titleIs('Transcom PPP: All Shipments'), WAIT_TIME);
   });
 
   it('loads available shipments page', async () => {
     // When: Page is loaded, should display expected title
     await driver.navigate().to(buildURL('shipments/available'));
-    await driver.wait(until.titleIs('Transcom PPP: Available Shipments'), 2000);
+    await driver.wait(
+      until.titleIs('Transcom PPP: Available Shipments'),
+      WAIT_TIME,
+    );
   });
 
   it('loads awarded shipments page', async () => {
     // When: Page is loaded, should display expected title
     await driver.navigate().to(buildURL('shipments/awarded'));
-    await driver.wait(until.titleIs('Transcom PPP: Awarded Shipments'), 2000);
+    await driver.wait(
+      until.titleIs('Transcom PPP: Awarded Shipments'),
+      WAIT_TIME,
+    );
   });
 
   it('displays alert on incorrect url', async () => {
@@ -94,7 +111,7 @@ describe('shipments pages', async () => {
     // Expect: Alert error exists on page
     await driver.wait(
       until.elementLocated(By.className('usa-alert-error')),
-      2000,
+      WAIT_TIME,
     );
   });
 });
@@ -104,7 +121,7 @@ describe('DD1299 page', async () => {
 
   it('loads DD1299 page', async () => {
     // When: Page is loaded, should display expected title
-    await driver.wait(until.titleIs('Transcom PPP: DD1299'), 2000);
+    await driver.wait(until.titleIs('Transcom PPP: DD1299'), WAIT_TIME);
   });
 });
 

--- a/e2e/e2e.test.js
+++ b/e2e/e2e.test.js
@@ -22,7 +22,7 @@ promise.USE_PROMISE_MANAGER = false;
 // jest.set_timeout() doesn't work in this circumstance, so using jasmine timeout.
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 60 * 5;
 
-const WAIT_TIME = 1000 * 10;
+const WEB_DRIVER_WAIT_TIME = 1000 * 10;
 
 beforeAll(async function() {
   driver = new webdriver.Builder()
@@ -50,7 +50,7 @@ describe('issue pages', async () => {
     // When: Page is loaded, should display expected title
     await driver.wait(
       until.titleIs('Transcom PPP: Submit Feedback'),
-      WAIT_TIME,
+      WEB_DRIVER_WAIT_TIME,
     );
   });
 
@@ -69,14 +69,14 @@ describe('issue pages', async () => {
     await driver.get(buildURL('submitted'));
     await driver.wait(
       until.titleIs('Transcom PPP: Submitted Feedback'),
-      WAIT_TIME,
+      WEB_DRIVER_WAIT_TIME,
     );
 
     issue_cards = await driver.findElement(By.className('issue-cards'));
     // Expect: Submitted issue exists on page
     await driver.wait(
       until.elementTextContains(issue_cards, test_issue),
-      WAIT_TIME,
+      WEB_DRIVER_WAIT_TIME,
     );
   });
 });
@@ -85,7 +85,10 @@ describe('shipments pages', async () => {
   it('loads all shipments page', async () => {
     // When: Page is loaded, should display expected title
     await driver.navigate().to(buildURL('shipments/all'));
-    await driver.wait(until.titleIs('Transcom PPP: All Shipments'), WAIT_TIME);
+    await driver.wait(
+      until.titleIs('Transcom PPP: All Shipments'),
+      WEB_DRIVER_WAIT_TIME,
+    );
   });
 
   it('loads available shipments page', async () => {
@@ -93,7 +96,7 @@ describe('shipments pages', async () => {
     await driver.navigate().to(buildURL('shipments/available'));
     await driver.wait(
       until.titleIs('Transcom PPP: Available Shipments'),
-      WAIT_TIME,
+      WEB_DRIVER_WAIT_TIME,
     );
   });
 
@@ -102,7 +105,7 @@ describe('shipments pages', async () => {
     await driver.navigate().to(buildURL('shipments/awarded'));
     await driver.wait(
       until.titleIs('Transcom PPP: Awarded Shipments'),
-      WAIT_TIME,
+      WEB_DRIVER_WAIT_TIME,
     );
   });
 
@@ -111,7 +114,7 @@ describe('shipments pages', async () => {
     // Expect: Alert error exists on page
     await driver.wait(
       until.elementLocated(By.className('usa-alert-error')),
-      WAIT_TIME,
+      WEB_DRIVER_WAIT_TIME,
     );
   });
 });
@@ -121,7 +124,10 @@ describe('DD1299 page', async () => {
 
   it('loads DD1299 page', async () => {
     // When: Page is loaded, should display expected title
-    await driver.wait(until.titleIs('Transcom PPP: DD1299'), WAIT_TIME);
+    await driver.wait(
+      until.titleIs('Transcom PPP: DD1299'),
+      WEB_DRIVER_WAIT_TIME,
+    );
   });
 });
 


### PR DESCRIPTION
## Description

Our build is flakey because some of the e2e tests are timing out in various places. I changed all the timeout lengths to 10 seconds to hopefully minimize how often this happens.

## Verification Steps

* [x] All tests pass.

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/155713862) for this change