### PR TITLE
Creating blackout_dates test data

### DIFF
--- a/cmd/generate_test_data/main.go
+++ b/cmd/generate_test_data/main.go
@@ -28,4 +28,5 @@ func main() {
 	testdatagen.MakeShipmentData(db)
 	testdatagen.MakeShipmentAwardData(db)
 	testdatagen.MakeTSPPerformanceData(db)
+	testdatagen.MakeBlackoutDateData(db)
 }

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -28,7 +28,7 @@
   * [JavaScript Concepts](#javascript-concepts)
   * [Resources](#resources)
 
-_Regenerate with error: must supply a markdown file to generate table of contents._
+_Regenerate with `bin/generate-md-toc.sh`_
 
 <!-- tocstop -->
 

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -28,7 +28,7 @@
   * [JavaScript Concepts](#javascript-concepts)
   * [Resources](#resources)
 
-_Regenerate with `bin/generate-md-toc.sh`_
+_Regenerate with error: must supply a markdown file to generate table of contents._
 
 <!-- tocstop -->
 

--- a/pkg/models/blackout_dates.go
+++ b/pkg/models/blackout_dates.go
@@ -20,7 +20,7 @@ type BlackoutDate struct {
 	TrafficDistributionListID       *uuid.UUID `json:"traffic_distribution_list_id" db:"traffic_distribution_list_id"`
 	CodeOfService                   *string    `json:"code_of_service" db:"code_of_service"`
 	Channel                         *string    `json:"channel" db:"channel"`
-	Gbloc                           *string    `json:"gbloc" db:"gbloc"`
+	GBLOC                           *string    `json:"gbloc" db:"gbloc"`
 	Market                          *string    `json:"market" db:"market"`
 	Zip3                            *int       `json:"zip3" db:"zip3"`
 	VolumeMove                      *bool      `json:"volume_move" db:"volume_move"`

--- a/pkg/testdatagen/make_blackout_date_records.go
+++ b/pkg/testdatagen/make_blackout_date_records.go
@@ -13,6 +13,8 @@ import (
 
 // No test includes a zip3 or a volume_move value, as we're not
 // currently fully implementing those.
+
+// MakeBlackoutDate creates a test blackoutDate object to add to the database.
 func MakeBlackoutDate(db *pop.Connection, tsp models.TransportationServiceProvider,
 	tdl *models.TrafficDistributionList, cos *string, channel *string, gbloc *string,
 	market *string) (models.BlackoutDate, error) {
@@ -36,8 +38,8 @@ func MakeBlackoutDate(db *pop.Connection, tsp models.TransportationServiceProvid
 	return blackoutDates, err
 }
 
+// MakeBlackoutDateData creates three blackoutDate objects and commits them to the blackout_dates table.
 func MakeBlackoutDateData(db *pop.Connection) {
-
 	// These two queries duplicate ones in other testdatagen files; not optimal
 	tspList := []models.TransportationServiceProvider{}
 	err := db.All(&tspList)

--- a/pkg/testdatagen/make_blackout_date_records.go
+++ b/pkg/testdatagen/make_blackout_date_records.go
@@ -26,7 +26,7 @@ func MakeBlackoutDate(db *pop.Connection, tsp models.TransportationServiceProvid
 		TrafficDistributionListID:       &tdl.ID,
 		CodeOfService:                   cos,
 		Channel:                         channel,
-		Gbloc:                           gbloc,
+		GBLOC:                           gbloc,
 		Market:                          market,
 	}
 

--- a/pkg/testdatagen/make_blackout_date_records.go
+++ b/pkg/testdatagen/make_blackout_date_records.go
@@ -1,0 +1,88 @@
+package testdatagen
+
+import (
+	"fmt"
+	"log"
+	"math/rand"
+	"time"
+
+	"github.com/markbates/pop"
+
+	"github.com/transcom/mymove/pkg/models"
+)
+
+// No test includes a zip3 or a volume_move value, as we're not
+// currently fully implementing those.
+func MakeBlackoutDate(db *pop.Connection, tsp models.TransportationServiceProvider,
+	tdl *models.TrafficDistributionList, cos *string, channel *string, gbloc *string,
+	market *string) (models.BlackoutDate, error) {
+
+	blackoutDates := models.BlackoutDate{
+		TransportationServiceProviderID: tsp.ID,
+		StartBlackoutDate:               time.Now(),
+		EndBlackoutDate:                 time.Now(),
+		TrafficDistributionListID:       &tdl.ID,
+		CodeOfService:                   cos,
+		Channel:                         channel,
+		Gbloc:                           gbloc,
+		Market:                          market,
+	}
+
+	_, err := db.ValidateAndSave(&blackoutDates)
+	if err != nil {
+		log.Panic(err)
+	}
+
+	return blackoutDates, err
+}
+
+func MakeBlackoutDateData(db *pop.Connection) {
+
+	// These two queries duplicate ones in other testdatagen files; not optimal
+	tspList := []models.TransportationServiceProvider{}
+	err := db.All(&tspList)
+	if err != nil {
+		fmt.Println("TSP ID import failed.")
+	}
+
+	tdlList := []models.TrafficDistributionList{}
+	err = db.All(&tdlList)
+	if err != nil {
+		fmt.Println("TDL ID import failed.")
+	}
+
+	conus := "CONUS_CONUS"
+	market := "market"
+	cos := "BKAS"
+	channel := "dHHG"
+
+	// Make a blackout date with market and channel.
+	MakeBlackoutDate(db,
+		tspList[rand.Intn(len(tspList))],
+		&tdlList[rand.Intn(len(tdlList))],
+		nil,
+		&conus,
+		nil,
+		&market,
+	)
+
+	// Make a blackout date with a channel.
+	MakeBlackoutDate(db,
+		tspList[rand.Intn(len(tspList))],
+		&tdlList[rand.Intn(len(tdlList))],
+		nil,
+		&conus,
+		nil,
+		nil,
+	)
+
+	// Make a blackout date with market, GBLOC, and channel.
+	MakeBlackoutDate(db,
+		tspList[rand.Intn(len(tspList))],
+		&tdlList[rand.Intn(len(tdlList))],
+		nil,
+		&conus,
+		&cos,
+		&channel,
+	)
+}


### PR DESCRIPTION
## Description

This PR adds a new testdatagen file, which creates three kinds of blackout dates. The types chosen were based on the three of the most common combinations of fields, based on db pulls provided during blackout_date research (minus the ones that include zip3 and volume_moves, with choices defined by my preference to have blackout dates with one, two, and three fields applied). 

## Reviewer Notes

Do you consider this best Pop practice, at this point in our evolution of working with this tool? 

## Verification Steps

* [ ] All tests pass.

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/155243616) for this change