### PR TITLE
Handle user creation

### DIFF
--- a/cmd/webserver/main.go
+++ b/cmd/webserver/main.go
@@ -119,7 +119,7 @@ func main() {
 	root.Handle(pat.New("/auth/*"), authMux)
 	authMux.Use(authMiddleware)
 	authMux.Handle(pat.Get("/login-gov"), auth.NewAuthorizationRedirectHandler(logger, fullHostname))
-	authMux.Handle(pat.Get("/login-gov/callback"), auth.NewAuthorizationCallbackHandler(*clientAuthSecretKey, *loginGovSecretKey, *loginGovClientID, fullHostname, logger))
+	authMux.Handle(pat.Get("/login-gov/callback"), auth.NewAuthorizationCallbackHandler(*clientAuthSecretKey, *loginGovSecretKey, *loginGovClientID, fullHostname, logger, dbConnection))
 	authMux.Handle(pat.Get("/logout"), auth.AuthorizationLogoutHandler(fullHostname))
 
 	root.Handle(pat.Get("/static/*"), clientHandler)

--- a/cmd/webserver/main.go
+++ b/cmd/webserver/main.go
@@ -119,7 +119,7 @@ func main() {
 	root.Handle(pat.New("/auth/*"), authMux)
 	authMux.Use(authMiddleware)
 	authMux.Handle(pat.Get("/login-gov"), auth.NewAuthorizationRedirectHandler(logger, fullHostname))
-	authMux.Handle(pat.Get("/login-gov/callback"), auth.NewAuthorizationCallbackHandler(*clientAuthSecretKey, *loginGovSecretKey, *loginGovClientID, fullHostname, logger, dbConnection))
+	authMux.Handle(pat.Get("/login-gov/callback"), auth.NewAuthorizationCallbackHandler(dbConnection, *clientAuthSecretKey, *loginGovSecretKey, *loginGovClientID, fullHostname, logger))
 	authMux.Handle(pat.Get("/logout"), auth.AuthorizationLogoutHandler(fullHostname))
 
 	root.Handle(pat.Get("/static/*"), clientHandler)

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -16,7 +16,6 @@ import (
 	"github.com/gorilla/context"
 	"github.com/markbates/goth"
 	"github.com/markbates/goth/providers/openidConnect"
-	"github.com/markbates/pop"
 	"github.com/pkg/errors"
 	"github.com/satori/go.uuid"
 

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -306,8 +306,6 @@ func (h *AuthorizationCallbackHandler) ServeHTTP(w http.ResponseWriter, r *http.
 		return
 	}
 
-	fmt.Println("!!! ", openIDuser)
-	fmt.Println(openIDuser.UserID)
 	user, err := models.GetOrCreateUser(h.db, openIDuser)
 	if err != nil {
 		h.logger.Error("Unable to create user.", zap.Error(err))

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -335,7 +335,7 @@ func getOrCreateUser(db *pop.Connection, userData map[string]interface{}) (model
 
 	// Check if user already exists
 	loginGovUUID := userData["sub"].(string)
-	query := db.Where("login_gov_uuid = ?", loginGovUUID)
+	query := db.Where("login_gov_uuid = $1", loginGovUUID)
 	var users []models.User
 	err := query.All(&users)
 	if err != nil {

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -306,7 +306,9 @@ func (h *AuthorizationCallbackHandler) ServeHTTP(w http.ResponseWriter, r *http.
 		return
 	}
 
-	user, err := models.GetOrCreateUser(h.db, openIDuser.RawData)
+	fmt.Println("!!! ", openIDuser)
+	fmt.Println(openIDuser.UserID)
+	user, err := models.GetOrCreateUser(h.db, openIDuser)
 	if err != nil {
 		h.logger.Error("Unable to create user.", zap.Error(err))
 		http.Error(w, http.StatusText(500), http.StatusInternalServerError)

--- a/pkg/auth/auth_test.go
+++ b/pkg/auth/auth_test.go
@@ -293,7 +293,14 @@ func (suite *AuthSuite) TestPassiveUserAuthMiddlewareWithExpiredToken() {
 	}
 }
 
-//func (suite *AuthSuite) TestGetOrCreateUserWithNewUser() {
-//t := suite.T()
-//
-//}
+func (suite *AuthSuite) TestGetOrCreateUserWithNewUser() {
+	t := suite.T()
+
+	userData := map[string]interface{}{}
+	userData["sub"] = "39b28c92-0506-4bef-8b57-e39519f42dc2"
+	userData["email"] = "sally@government.gov"
+
+	newUser, err := getOrCreateUser(suite.db, userData)
+
+	fmt.Println(newUser)
+}

--- a/pkg/auth/auth_test.go
+++ b/pkg/auth/auth_test.go
@@ -330,7 +330,7 @@ func (suite *AuthSuite) TestGetOrCreateUser() {
 	}
 
 	// And: no new user to have been created
-	query := suite.db.Where("login_gov_uuid = ?", loginGovUUID)
+	query := suite.db.Where("login_gov_uuid = $1", loginGovUUID)
 	var users []models.User
 	queryErr := query.All(&users)
 	if queryErr != nil {

--- a/pkg/auth/auth_test.go
+++ b/pkg/auth/auth_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/gorilla/context"
 	"github.com/markbates/pop"
 	"github.com/pkg/errors"
+	"github.com/satori/go.uuid"
 )
 
 func TestGenerateNonce(t *testing.T) {
@@ -153,6 +154,7 @@ func TestEnforceUserAuthMiddlewareWithBadToken(t *testing.T) {
 func TestUserAuthMiddlewareWithValidToken(t *testing.T) {
 	email := "some_email@domain.com"
 	idToken := "fake_id_token"
+	fakeUUID, _ := uuid.FromString("39b28c92-0506-4bef-8b57-e39519f42dc2")
 
 	pem, err := createRandomRSAPEM()
 	if err != nil {
@@ -161,7 +163,7 @@ func TestUserAuthMiddlewareWithValidToken(t *testing.T) {
 
 	// Brand new token, shouldn't be renewed
 	expiry := getExpiryTimeFromMinutes(sessionExpiryInMinutes)
-	ss, err := signTokenStringWithUserInfo(email, idToken, expiry, pem)
+	ss, err := signTokenStringWithUserInfo(fakeUUID, email, idToken, expiry, pem)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -191,6 +193,7 @@ func TestUserAuthMiddlewareWithValidToken(t *testing.T) {
 func TestUserAuthMiddlewareWithRenewalToken(t *testing.T) {
 	email := "some_email@domain.com"
 	idToken := "fake_id_token"
+	fakeUUID, _ := uuid.FromString("39b28c92-0506-4bef-8b57-e39519f42dc2")
 
 	pem, err := createRandomRSAPEM()
 	if err != nil {
@@ -199,7 +202,7 @@ func TestUserAuthMiddlewareWithRenewalToken(t *testing.T) {
 
 	// Token will expire in 1 minute, should be renewed
 	expiry := getExpiryTimeFromMinutes(1)
-	ss, err := signTokenStringWithUserInfo(email, idToken, expiry, pem)
+	ss, err := signTokenStringWithUserInfo(fakeUUID, email, idToken, expiry, pem)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -229,6 +232,7 @@ func TestUserAuthMiddlewareWithRenewalToken(t *testing.T) {
 func TestPassiveUserAuthMiddlewareWithExpiredToken(t *testing.T) {
 	email := "some_email@domain.com"
 	idToken := "fake_id_token"
+	fakeUUID, _ := uuid.FromString("39b28c92-0506-4bef-8b57-e39519f42dc2")
 
 	pem, err := createRandomRSAPEM()
 	if err != nil {
@@ -236,7 +240,7 @@ func TestPassiveUserAuthMiddlewareWithExpiredToken(t *testing.T) {
 	}
 
 	expiry := getExpiryTimeFromMinutes(-1)
-	ss, err := signTokenStringWithUserInfo(email, idToken, expiry, pem)
+	ss, err := signTokenStringWithUserInfo(fakeUUID, email, idToken, expiry, pem)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/auth/auth_test.go
+++ b/pkg/auth/auth_test.go
@@ -20,6 +20,8 @@ import (
 	"github.com/satori/go.uuid"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/zap"
+
+	"github.com/transcom/mymove/pkg/models"
 )
 
 type AuthSuite struct {
@@ -293,14 +295,48 @@ func (suite *AuthSuite) TestPassiveUserAuthMiddlewareWithExpiredToken() {
 	}
 }
 
-func (suite *AuthSuite) TestGetOrCreateUserWithNewUser() {
+func (suite *AuthSuite) TestGetOrCreateUser() {
 	t := suite.T()
 
+	// When: login gov UUID is passed to create user func
 	userData := map[string]interface{}{}
 	userData["sub"] = "39b28c92-0506-4bef-8b57-e39519f42dc2"
 	userData["email"] = "sally@government.gov"
+	loginGovUUID, _ := uuid.FromString(userData["sub"].(string))
 
+	// And: user does not yet exist in the db
 	newUser, err := getOrCreateUser(suite.db, userData)
+	if err != nil {
+		t.Error("error querying or creating user.")
+	}
 
-	fmt.Println(newUser)
+	// Then: expect fields to be set on returned user
+	if newUser.LoginGovEmail != userData["email"] {
+		t.Error("expected email to be set")
+	}
+	if newUser.LoginGovUUID != loginGovUUID {
+		t.Error("expected uuid to be set")
+	}
+
+	// When: The same UUID is passed in func
+	sameUser, err := getOrCreateUser(suite.db, userData)
+	if err != nil {
+		t.Error("error querying or creating user.")
+	}
+
+	// Then: expect the existing user to be returned
+	if sameUser.LoginGovEmail != newUser.LoginGovEmail {
+		t.Error("expected existing user to have been returned")
+	}
+
+	// And: no new user to have been created
+	query := suite.db.Where("login_gov_uuid = ?", loginGovUUID)
+	var users []models.User
+	queryErr := query.All(&users)
+	if queryErr != nil {
+		t.Error("DB Query Error", zap.Error(err))
+	}
+	if len(users) > 1 {
+		t.Error("1 user should have been returned")
+	}
 }

--- a/pkg/models/user_test.go
+++ b/pkg/models/user_test.go
@@ -3,6 +3,7 @@ package models_test
 import (
 	"github.com/satori/go.uuid"
 
+	"github.com/markbates/goth"
 	. "github.com/transcom/mymove/pkg/models"
 	"go.uber.org/zap"
 )
@@ -71,19 +72,17 @@ func (suite *ModelSuite) TestGetOrCreateUser() {
 	t := suite.T()
 
 	// When: login gov UUID is passed to create user func
-	userData := map[string]interface{}{}
-	userData["sub"] = "39b28c92-0506-4bef-8b57-e39519f42dc2"
-	userData["email"] = "sally@government.gov"
-	loginGovUUID, _ := uuid.FromString(userData["sub"].(string))
+	gothUser := goth.User{Email: "sally@government.gov", UserID: "39b28c92-0506-4bef-8b57-e39519f42dc2"}
+	loginGovUUID, _ := uuid.FromString(gothUser.UserID)
 
 	// And: user does not yet exist in the db
-	newUser, err := GetOrCreateUser(suite.db, userData)
+	newUser, err := GetOrCreateUser(suite.db, gothUser)
 	if err != nil {
 		t.Error("error querying or creating user.")
 	}
 
 	// Then: expect fields to be set on returned user
-	if newUser.LoginGovEmail != userData["email"] {
+	if newUser.LoginGovEmail != gothUser.Email {
 		t.Error("expected email to be set")
 	}
 	if newUser.LoginGovUUID != loginGovUUID {
@@ -91,7 +90,7 @@ func (suite *ModelSuite) TestGetOrCreateUser() {
 	}
 
 	// When: The same UUID is passed in func
-	sameUser, err := GetOrCreateUser(suite.db, userData)
+	sameUser, err := GetOrCreateUser(suite.db, gothUser)
 	if err != nil {
 		t.Error("error querying or creating user.")
 	}


### PR DESCRIPTION
## Description

This PR handles the retrieval, or creation, of a user upon a successful redirect from login.gov to our callback URL. 

If the user doesn't exist, it is created, and the user.ID is put in the cookie. The middleware unpacks the cookie and sets the user id to the context, in order for whatever downstream handler to have a reference to a logged in user.

If the user does exist, it is retrieved from the DB, and all the above requirements are met the same way.


## Verification Steps

* [x] All tests pass.
* [x] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely) have been satisfied.
* [x] There are no [aXe](https://www.deque.com/products/aXe/) warnings for UI. - NA
* [x] This works in IE. -NA

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/155131855) for this change
