### PR TITLE
Add GBLOC and Market to Shipment

### DIFF
--- a/docs/backend.md
+++ b/docs/backend.md
@@ -15,7 +15,7 @@
     * [Models](#models)
     * [Miscellaneous Tips](#miscellaneous-tips)
 
-_Regenerate with `bin/generate-md-toc.sh`_
+Regenerate with "bin/generate-md-toc.sh"
 
 <!-- tocstop -->
 

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -28,7 +28,7 @@
   * [JavaScript Concepts](#javascript-concepts)
   * [Resources](#resources)
 
-_Regenerate with `bin/generate-md-toc.sh`_
+Regenerate with "bin/generate-md-toc.sh"
 
 <!-- tocstop -->
 

--- a/migrations/20180305225630_add_blackout_fields_to_shipment.down.fizz
+++ b/migrations/20180305225630_add_blackout_fields_to_shipment.down.fizz
@@ -1,0 +1,2 @@
+drop_column("shipments", "gbloc")
+drop_column("shipments", "market")

--- a/migrations/20180305225630_add_blackout_fields_to_shipment.up.fizz
+++ b/migrations/20180305225630_add_blackout_fields_to_shipment.up.fizz
@@ -1,0 +1,2 @@
+add_column("shipments", "gbloc", "string", {})
+add_column("shipments", "market", "string", {"null": true})

--- a/pkg/handlers/shipments_test.go
+++ b/pkg/handlers/shipments_test.go
@@ -23,11 +23,13 @@ func (suite *HandlerSuite) TestIndexShipmentsHandler() {
 
 	avs := models.Shipment{
 		TrafficDistributionListID: tdl.ID,
+		Gbloc: "AGFM",
 	}
 	suite.mustSave(&avs)
 
 	aws := models.Shipment{
 		TrafficDistributionListID: tdl.ID,
+		Gbloc: "AGFM",
 	}
 	suite.mustSave(&aws)
 

--- a/pkg/handlers/shipments_test.go
+++ b/pkg/handlers/shipments_test.go
@@ -23,13 +23,13 @@ func (suite *HandlerSuite) TestIndexShipmentsHandler() {
 
 	avs := models.Shipment{
 		TrafficDistributionListID: tdl.ID,
-		Gbloc: "AGFM",
+		GBLOC: "AGFM",
 	}
 	suite.mustSave(&avs)
 
 	aws := models.Shipment{
 		TrafficDistributionListID: tdl.ID,
-		Gbloc: "AGFM",
+		GBLOC: "AGFM",
 	}
 	suite.mustSave(&aws)
 

--- a/pkg/models/shipment.go
+++ b/pkg/models/shipment.go
@@ -18,6 +18,8 @@ type Shipment struct {
 	PickupDate                time.Time `json:"pickup_date" db:"pickup_date"`
 	DeliveryDate              time.Time `json:"delivery_date" db:"delivery_date"`
 	TrafficDistributionListID uuid.UUID `json:"traffic_distribution_list_id" db:"traffic_distribution_list_id"`
+	Gbloc                     string    `json:"gbloc" db:"gbloc"`
+	Market                    *string   `json:"market" db:"market"`
 }
 
 // PossiblyAwardedShipment represents a single awarded shipment within a Service Member's move.
@@ -90,5 +92,6 @@ func (s Shipments) String() string {
 func (s *Shipment) Validate(tx *pop.Connection) (*validate.Errors, error) {
 	return validate.Validate(
 		&validators.UUIDIsPresent{Field: s.TrafficDistributionListID, Name: "traffic_distribution_list_id"},
+		&validators.StringIsPresent{Field: s.Gbloc, Name: "gbloc"},
 	), nil
 }

--- a/pkg/models/shipment.go
+++ b/pkg/models/shipment.go
@@ -18,7 +18,7 @@ type Shipment struct {
 	PickupDate                time.Time `json:"pickup_date" db:"pickup_date"`
 	DeliveryDate              time.Time `json:"delivery_date" db:"delivery_date"`
 	TrafficDistributionListID uuid.UUID `json:"traffic_distribution_list_id" db:"traffic_distribution_list_id"`
-	Gbloc                     string    `json:"gbloc" db:"gbloc"`
+	GBLOC                     string    `json:"gbloc" db:"gbloc"`
 	Market                    *string   `json:"market" db:"market"`
 }
 
@@ -92,6 +92,6 @@ func (s Shipments) String() string {
 func (s *Shipment) Validate(tx *pop.Connection) (*validate.Errors, error) {
 	return validate.Validate(
 		&validators.UUIDIsPresent{Field: s.TrafficDistributionListID, Name: "traffic_distribution_list_id"},
-		&validators.StringIsPresent{Field: s.Gbloc, Name: "gbloc"},
+		&validators.StringIsPresent{Field: s.GBLOC, Name: "gbloc"},
 	), nil
 }

--- a/pkg/models/shipment_test.go
+++ b/pkg/models/shipment_test.go
@@ -7,6 +7,7 @@ func Test_Shipment(t *testing.T) {
 
 	expErrors := map[string][]string{
 		"traffic_distribution_list_id": []string{"traffic_distribution_list_id can not be blank."},
+		"gbloc": []string{"gbloc can not be blank."},
 	}
 
 	verifyValidationErrors(shipment, expErrors, t)

--- a/pkg/testdatagen/make_shipment_records.go
+++ b/pkg/testdatagen/make_shipment_records.go
@@ -13,10 +13,13 @@ import (
 func MakeShipment(db *pop.Connection, pickup time.Time, delivery time.Time,
 	tdl models.TrafficDistributionList) (models.Shipment, error) {
 
+	market := "dHHG"
 	shipment := models.Shipment{
 		TrafficDistributionListID: tdl.ID,
 		PickupDate:                pickup,
 		DeliveryDate:              delivery,
+		Gbloc:                     "AGFM",
+		Market:                    &market,
 	}
 
 	_, err := db.ValidateAndSave(&shipment)

--- a/pkg/testdatagen/make_shipment_records.go
+++ b/pkg/testdatagen/make_shipment_records.go
@@ -18,7 +18,7 @@ func MakeShipment(db *pop.Connection, pickup time.Time, delivery time.Time,
 		TrafficDistributionListID: tdl.ID,
 		PickupDate:                pickup,
 		DeliveryDate:              delivery,
-		Gbloc:                     "AGFM",
+		GBLOC:                     "AGFM",
 		Market:                    &market,
 	}
 


### PR DESCRIPTION
## Description

Explain a little about the changes at a high level.

## Reviewer Notes

* I changed the capitalization of `Gbloc` to `GBLOC`, my thinking being that it was an acronym.
* I made `Market` optional and `GBLOC` required, as I think shipments will always have a value for GBLOC. Is this correct?

## Verification Steps

* [ ] All tests pass.
* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely) have been satisfied.
* [ ] The definitions for the new fields match our understanding of the data model.
* [ ] Data generator updated with new fields.
* [ ] Migration present and working (up and down).
* [ ] Validations updated to account for new fields.

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/155643437) for this change
* [Blackout Dates research](https://docs.google.com/document/d/19WG-Dq7qSCLWDJna0qKC2aLOTMNUwHNJMRala3i5hJM)