### PR TITLE
Remove integration_tests from app workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -217,12 +217,6 @@ workflows:
           filters:
             branches:
               only: master
-      - integration_tests:
-          requires:
-            - deploy_app
-          filters:
-            branches:
-              only: master
 
   dependency_updater:
     triggers:


### PR DESCRIPTION
## Description

Despite earlier attempts to address flakey e2e tests, we are still having issues with them. In the short term this is disrupting our dev flow as the build is frequently breaking.

This PR disables running e2e tests in CI. We will need to return to this issue when the time it right.

## Verification Steps

* [ ] CircleCI file is properly updated.

## References

* [A build that failed this morning](https://circleci.com/gh/transcom/mymove/2960)
* [An attempt to address the issue](https://github.com/transcom/mymove/pull/207) by lengthening the wait time to 10 seconds.