### PR TITLE
Fixes for footer layout in IE11.

### DIFF
--- a/src/App/index.css
+++ b/src/App/index.css
@@ -9,5 +9,10 @@
 }
 
 .site__content {
-  flex: 1;
+  flex: 1 0 auto; /* using auto fixes a bug in IE11 where the footer would float over everything. */
+}
+
+
+img._fix-ie-11-height {
+  max-height: 80px; /* After using auto in .site__content.flex, the transcom logo in IE11 on win8 was not constrained vertically. */
 }

--- a/src/shared/AppWrapper/index.jsx
+++ b/src/shared/AppWrapper/index.jsx
@@ -23,7 +23,7 @@ const AppWrapper = () => (
   <ConnectedRouter history={history}>
     <div className="App site">
       <Header />
-      <div className="site__content">
+      <main className="site__content">
         <Route exact path="/" component={Feedback} />
         <Route path="/submitted" component={SubmittedFeedback} />
         <Route path="/shipments/:shipmentsStatus" component={Shipments} />
@@ -33,7 +33,7 @@ const AppWrapper = () => (
         {WizardDemo()}
         <Route exact path="/demo" render={redirect('/demo/sm')} />
         {DemoWorkflowRoutes()}
-      </div>
+      </main>
       <Footer />
     </div>
   </ConnectedRouter>

--- a/src/shared/AppWrapper/index.jsx
+++ b/src/shared/AppWrapper/index.jsx
@@ -23,7 +23,7 @@ const AppWrapper = () => (
   <ConnectedRouter history={history}>
     <div className="App site">
       <Header />
-      <main className="site__content">
+      <div className="site__content">
         <Route exact path="/" component={Feedback} />
         <Route path="/submitted" component={SubmittedFeedback} />
         <Route path="/shipments/:shipmentsStatus" component={Shipments} />
@@ -33,7 +33,7 @@ const AppWrapper = () => (
         {WizardDemo()}
         <Route exact path="/demo" render={redirect('/demo/sm')} />
         {DemoWorkflowRoutes()}
-      </main>
+      </div>
       <Footer />
     </div>
   </ConnectedRouter>

--- a/src/shared/Footer/index.jsx
+++ b/src/shared/Footer/index.jsx
@@ -36,7 +36,7 @@ function Footer() {
           <div className="usa-footer-logo usa-width-one-half">
             <a href="https://www.ustranscom.mil/">
               <img
-                className="usa-footer-logo-img"
+                className="usa-footer-logo-img _fix-ie-11-height"
                 src={transcomEmblem}
                 alt="United States Transportation Command Emblem"
               />


### PR DESCRIPTION
## Description

There are some issues with flexbox in IE11, this fixes our current
rendering problem where the footer would float above the site content.

This fix changes how things are rendered in IE. In Safari/Chrome/Edge it
renders as intended with the footer pinned to the bottom of the screen.
In IE11 the footer renders as a regular div, just a block attached to
the bottom of the main content.

<main> is not a supported tag in IE11, it renders fine but errors in the
console so I'm happy to put it back in if folks don't mind the error.

## Reviewer Notes

Please consider wether this solution is complete enough, and especially if it is worth adding the _fix-ie-height hacky tacky css selector. 

## Verification Steps

* [ ] This works in IE.

## References

* https://www.pivotaltracker.com/story/show/155088559
* https://caniuse.com/#feat=flexbox

## Screenshots
![screen shot 2018-03-06 at 2 44 38 pm](https://user-images.githubusercontent.com/55759/37063008-eec3b568-214c-11e8-8828-ac56d011625d.png)