### PR TITLE
[#155714213] Creates legalese payload definition in internal API spec

### DIFF
--- a/bin/gen_server.sh
+++ b/bin/gen_server.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -eu -o pipefail
+
 gendir=./pkg/gen
 
 rm -rf $gendir

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -118,14 +118,14 @@ paths:
           description: unknown form1299Id
         500:
           description: server error
-  /moves/{moveId}/legalese:
+  /moves/{moveId}/sign_certification:
     post:
-      summary: Submits signed legalese for the given move ID
-      description: Create an instance of legalese tied to the move ID
-      operationId: createLegalese
+      summary: Submits signed certification for the given move ID
+      description: Create an instance of signed_certification tied to the move ID
+      operationId: createSignedCertification
       tags:
         - moves
-        - legalese
+        - certification
       parameters:
         - in: path
           name: moveId
@@ -134,20 +134,22 @@ paths:
           required: true
           description: UUID of the move being signed for
         - in: body
-          name: createLegalesePayload
+          name: createSignedCertificationPayload
           required: true
           schema:
-            $ref: '#/definitions/LegalesePayload'
+            $ref: '#/definitions/SignedCertificationPayload'
       responses:
         201:
-          description: created instance of legalese
-          schema:
-            $ref: '#/definitions/Form1299Payload'
+          description: created instance of signed_certification
         400:
           description: invalid request
+        401:
+          description: request requires user authentication
+        403:
+          description: user is not authorized to sign for this move
 
 definitions:
-  LegalesePayload:
+  SignedCertificationPayload:
     type: object
     properties:
       date:
@@ -155,12 +157,12 @@ definitions:
         format: date
       signature:
         type: string
-      legalese_text:
+      certification_text:
         type: string
     required:
       - date
       - signature
-      - legalese_text
+      - certification_text
   CreateIssuePayload:
     type: object
     properties:

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -118,6 +118,33 @@ paths:
           description: unknown form1299Id
         500:
           description: server error
+  /moves/{moveId}/legalese:
+    post:
+      summary: Submits signed legalese for the given move ID
+      description: Create an instance of legalese tied to the move ID
+      operationId: createLegalese
+      tags:
+        - moves
+        - legalese
+      parameters:
+        - in: path
+          name: moveId
+          type: string
+          format: uuid
+          required: true
+          description: UUID of the move being signed for
+        - in: body
+          name: createLegalesePayload
+          required: true
+          schema:
+            $ref: '#/definitions/LegalesePayload'
+      responses:
+        201:
+          description: created instance of legalese
+          schema:
+            $ref: '#/definitions/Form1299Payload'
+        400:
+          description: invalid request
 
 definitions:
   LegalesePayload:

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -120,6 +120,20 @@ paths:
           description: server error
 
 definitions:
+  LegalesePayload:
+    type: object
+    properties:
+      date:
+        type: string
+        format: date
+      signature:
+        type: string
+      legalese_text:
+        type: string
+    required:
+      - date
+      - signature
+      - legalese_text
   CreateIssuePayload:
     type: object
     properties:


### PR DESCRIPTION
## Description

Creates a legalese payload definition in our internal API swagger spec file. This will be used for ferrying info about signed legal forms.

## Reviewer Notes

`user_id` is something we also care about, but that should be taken from the authentication token in the handler that consumes this data.

`move_id`, being the ID of the move that the user is signing for, is something I expect we'll get from the URL routing, e.g. POSTing to `/api/v1/moves/:move_id:/legalese`

## Verification Steps

* [ ] All tests pass

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/155714213) for this change