### PR TITLE
Add supported clients section to README

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -132,3 +132,4 @@ _Regenerate
 _
 ish
 30x
+iOS

--- a/.spelling
+++ b/.spelling
@@ -97,6 +97,8 @@ ngrok
 localtunnel
 Redis
 stateful
+iOS
+generate-md-toc
 Memcached
 jwt-go
 ADR-0000
@@ -114,23 +116,14 @@ ADR-0011
 ADR-0012
 ADR-0013
 template.md
- - docs/backend.md
 _Regenerate
-_
+Codegen
 30x
 ish
- - docs/adr/0007-swagger-client.md
-Codegen
- - README.md
-_Regenerate
 _
+# Put all custom terms BEFORE this comment, lest you end up in an mdspell pain cycle.
+ - docs/backend.md
+ - docs/adr/0007-swagger-client.md
+ - README.md
  - docs/frontend.md
 _Regenerate
-_
- - ./docs/backend.md
-_Regenerate
-_
-ish
-30x
-iOS
-generate-md-toc

--- a/.spelling
+++ b/.spelling
@@ -133,3 +133,4 @@ _
 ish
 30x
 iOS
+generate-md-toc

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This prototype was built by a [Defense Digital Service](https://www.dds.mil/) te
 <!-- toc -->
 
 * [Development](#development)
+  * [Supported clients](#supported-clients)
   * [Git](#git)
   * [Project location](#project-location)
   * [Project Layout](#project-layout)
@@ -36,11 +37,15 @@ This prototype was built by a [Defense Digital Service](https://www.dds.mil/) te
     * [Tips for staying sane](#tips-for-staying-sane)
   * [Troubleshooting](#troubleshooting)
 
-_Regenerate with `bin/generate-md-toc.sh`_
+_Regenerate with error: must supply a markdown file to generate table of contents._
 
 <!-- tocstop -->
 
 ## Development
+
+### Supported clients
+
+As of 3/6/2018, DDS has confirmed that support for IE is limited to IE 11 and Edge or newer versions. Currently, the intention is to encourage using Chrome and Firefox instead, with specific versions TBD. Research is incomplete on mobile browsers, but we are assuming support for iOS and Android.
 
 ### Git
 

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ This prototype was built by a [Defense Digital Service](https://www.dds.mil/) te
 
 <!-- toc -->
 
+* [Supported clients](#supported-clients)
 * [Development](#development)
-  * [Supported clients](#supported-clients)
   * [Git](#git)
   * [Project location](#project-location)
   * [Project Layout](#project-layout)
@@ -37,15 +37,15 @@ This prototype was built by a [Defense Digital Service](https://www.dds.mil/) te
     * [Tips for staying sane](#tips-for-staying-sane)
   * [Troubleshooting](#troubleshooting)
 
-_Regenerate with error: must supply a markdown file to generate table of contents._
+Regenerate with "bin/generate-md-toc.sh"
 
 <!-- tocstop -->
 
-## Development
-
-### Supported clients
+## Supported clients
 
 As of 3/6/2018, DDS has confirmed that support for IE is limited to IE 11 and Edge or newer versions. Currently, the intention is to encourage using Chrome and Firefox instead, with specific versions TBD. Research is incomplete on mobile browsers, but we are assuming support for iOS and Android.
+
+## Development
 
 ### Git
 

--- a/bin/generate-md-toc.sh
+++ b/bin/generate-md-toc.sh
@@ -7,11 +7,14 @@
 #
 # Generated with https://github.com/jonschlinkert/markdown-toc
 
-set -eu -o pipefail
+set -eux -o pipefail
 
 function generate_toc() {
   filename="$1"
-  regen=$'\n\n_Regenerate with `bin/generate-md-toc.sh`_'
+  # Using backticks in this appended comment seems to make the script
+  # indicated run after a 3/5 update to markdown-toc 1.2.0;
+  # stick with quotes for now.
+  regen=$'\n\nRegenerate with "bin/generate-md-toc.sh"'
 
   # shellcheck disable=SC2016
   yarn run markdown-toc -i "${filename}" --bullets='*' --append="${regen}"

--- a/bin/generate-md-toc.sh
+++ b/bin/generate-md-toc.sh
@@ -7,7 +7,7 @@
 #
 # Generated with https://github.com/jonschlinkert/markdown-toc
 
-set -eux -o pipefail
+set -eu -o pipefail
 
 function generate_toc() {
   filename="$1"


### PR DESCRIPTION
## Description

Per today's decisions from on high (and a chat with Alexi), I added a section at the top of the README documenting supported clients. It refers briefly to decision to come

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Verification Steps

* [ ] All tests pass.

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/155599293) for this change
* [This doc](https://docs.google.com/document/d/1a33JExAVmGxT6hr5x_DqfFztf7MZhaHJx9tQ2Z32sTA/edit#) gives a lengthier description, with a table and sources.