### PR TITLE
Els client auth [delivers #155131945]

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -177,6 +177,11 @@ Codegen
 30x
 ish
 _
+HOC
+HOCs
+PrivateRoute
+EnsureLoggedInContainer
+jwt
 # Put all custom terms BEFORE this comment, lest you end up in an mdspell pain cycle.
  - docs/backend.md
  - docs/adr/0007-swagger-client.md

--- a/docs/adr/0017-react-router-redux-authentication.md
+++ b/docs/adr/0017-react-router-redux-authentication.md
@@ -1,0 +1,36 @@
+# Client side route restriction based on authentication
+
+**User Story:** [#155131945](https://www.pivotaltracker.com/story/show/155131945)
+
+    We want the loggedIn state of the user and basic user information (e.g. email address) available in redux state. We also want to be able to restrict access to client routes to logged in users.
+
+## Considered Alternatives
+
+* PrivateRoute component that is used for routes with restricted access
+* HOC to wrap components that should be restricted to logged in users
+* [EnsureLoggedInContainer](https://medium.com/the-many/adding-login-and-authentication-sections-to-your-react-or-react-native-app-7767fd251bd1) to create a section of routes that
+
+## Decision Outcome
+
+* Chosen Alternative: **PrivateRoute component that is used for routes with restricted access**
+
+* This is how most of the samples examined worked. In particular, [react-router-redux example code](https://github.com/ReactTraining/react-router/blob/master/packages/react-router-redux/examples/AuthExample.js) worked this way. However, it is important to note that this only works if the routes are contained by a react router Switch.
+
+There was also work done to build ducks for user state. Here we are using `js-cookie` to retrieve the jwt token and `jwt-decode` to extract the user email. Since login and logout are both performed by a server redirect, there is only one action at present to load the user and token. This action is called when the main route "/" is hit. A fair amount of exploration was done to find a way to fire this action whenever a new route is hit, but every example involved react router api that was removed in 4.0. We will need to do future work to handle expiration.
+
+## Pros and Cons of the Alternatives <!-- optional -->
+
+### PrivateRoute component that is used for routes with restricted access
+
+* `+` Straightforward implementation
+* `-` Dependency on Switch is not obvious from code (and behavior without it is strange and alarming)
+
+### HOC to wrap components that should be restricted to logged in users
+
+* `+` HOCs are the react way
+* `-` Felt more complicated than needed for this use case. (Though a similar mechanism would work well for [authorization](https://hackernoon.com/role-based-authorization-in-react-c70bb7641db4). There is a stub of code for that for the future in `src/shared/User/Authorization.jsx`)
+
+### EnsureLoggedInContainer to create a section of routes that
+
+* `+` seemed like a nice way to group restricted routes
+* `-` Doesn't work in react router 4.0

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "classnames": "^2.2.5",
     "enzyme": "^3.2.0",
     "enzyme-adapter-react-16": "^1.1.1",
+    "js-cookie": "^2.2.0",
     "js-yaml": "^3.10.0",
     "lodash": "^4.17.5",
     "react": "^16.2.0",
@@ -28,7 +29,8 @@
     "eject": "NODE_PATH=./src react-scripts eject",
     "start": "NODE_PATH=./src react-scripts start",
     "test": "NODE_PATH=./src react-scripts test --env=jsdom",
-    "test:debug": "NODE_PATH=./src react-scripts --inspect-brk test --runInBand --env=jsdom",
+    "test:debug":
+      "NODE_PATH=./src react-scripts --inspect-brk test --runInBand --env=jsdom",
     "e2e-test": "NODE_PATH=./e2e jest ./e2e.test.js --env=jsdom",
     "prettier": "prettier",
     "adr-log": "adr-log -d ./docs/adr -i ./docs/adr/readme.md"
@@ -41,6 +43,9 @@
       "target": "http://localhost:8080"
     },
     "/auth": {
+      "target": "http://localhost:8080"
+    },
+    "/logout": {
       "target": "http://localhost:8080"
     }
   },

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "enzyme-adapter-react-16": "^1.1.1",
     "js-cookie": "^2.2.0",
     "js-yaml": "^3.10.0",
+    "jwt-decode": "^2.2.0",
     "lodash": "^4.17.5",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
@@ -29,8 +30,7 @@
     "eject": "NODE_PATH=./src react-scripts eject",
     "start": "NODE_PATH=./src react-scripts start",
     "test": "NODE_PATH=./src react-scripts test --env=jsdom",
-    "test:debug":
-      "NODE_PATH=./src react-scripts --inspect-brk test --runInBand --env=jsdom",
+    "test:debug": "NODE_PATH=./src react-scripts --inspect-brk test --runInBand --env=jsdom",
     "e2e-test": "NODE_PATH=./e2e jest ./e2e.test.js --env=jsdom",
     "prettier": "prettier",
     "adr-log": "adr-log -d ./docs/adr -i ./docs/adr/readme.md"

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -41,7 +41,7 @@ type UserClaims struct {
 }
 
 func landingURL(hostname string) string {
-	return fmt.Sprintf("%s/landing", hostname)
+	return fmt.Sprintf("%s", hostname)
 }
 
 func getExpiryTimeFromMinutes(min int64) time.Time {
@@ -327,8 +327,7 @@ func (h *AuthorizationCallbackHandler) ServeHTTP(w http.ResponseWriter, r *http.
 	}
 	http.SetCookie(w, &cookie)
 
-	landingURL := fmt.Sprintf("%s/landing?email=%s", h.hostname, user.LoginGovEmail)
-	http.Redirect(w, r, landingURL, http.StatusTemporaryRedirect)
+	http.Redirect(w, r, landingURL(h.hostname), http.StatusTemporaryRedirect)
 }
 
 func getAuthorizationURL(logger *zap.Logger) (string, error) {

--- a/src/appReducer.js
+++ b/src/appReducer.js
@@ -1,5 +1,6 @@
 import { combineReducers } from 'redux';
 import { feedbackReducer } from 'scenes/Feedback/ducks';
+import { default as userReducer } from 'shared/User/ducks';
 import issuesReducer from 'scenes/SubmittedFeedback/ducks';
 import { shipmentsReducer } from 'scenes/Shipments/ducks';
 import dd1299Reducer from 'scenes/DD1299/ducks';
@@ -7,6 +8,7 @@ import { reducer as formReducer } from 'redux-form';
 import { routerReducer } from 'react-router-redux';
 
 export const appReducer = combineReducers({
+  user: userReducer,
   submittedIssues: issuesReducer,
   shipments: shipmentsReducer,
   router: routerReducer,

--- a/src/scenes/Landing/LoginButton.jsx
+++ b/src/scenes/Landing/LoginButton.jsx
@@ -1,9 +1,0 @@
-import React, { Component } from 'react';
-
-class LoginButton extends Component {
-  render() {
-    return <a href="/auth/login-gov">Sign In</a>;
-  }
-}
-
-export default LoginButton;

--- a/src/scenes/Landing/index.jsx
+++ b/src/scenes/Landing/index.jsx
@@ -1,7 +1,7 @@
 import React, { Fragment, Component } from 'react';
 import { parse } from 'qs';
 
-import LoginButton from 'scenes/Landing/LoginButton';
+import LoginButton from 'shared/User/LoginButton';
 
 export class Landing extends Component {
   componentDidMount() {

--- a/src/scenes/Landing/index.jsx
+++ b/src/scenes/Landing/index.jsx
@@ -1,29 +1,33 @@
-import React, { Fragment, Component } from 'react';
-import { parse } from 'qs';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
 
 import LoginButton from 'shared/User/LoginButton';
+import { bindActionCreators } from 'redux';
+import { loadUserAndToken } from 'shared/User/ducks';
 
 export class Landing extends Component {
   componentDidMount() {
     document.title = 'Transcom PPP: Landing Page';
+    this.props.loadUserAndToken();
   }
 
   render() {
-    const location = this.props.location;
-    const query = parse(location.search.substr(1));
-
     return (
       <div className="usa-grid">
-        {query.email && <h1>Welcome {query.email}!</h1>}
-        {!query.email && (
-          <Fragment>
-            <h1>Welcome!</h1>
-            <LoginButton />
-          </Fragment>
-        )}
+        <h1>Welcome!</h1>
+        <LoginButton />
       </div>
     );
   }
 }
 
-export default Landing;
+function mapStateToProps(state) {
+  return {
+    loggedIn: state.user.loggedIn,
+  };
+}
+function mapDispatchToProps(dispatch) {
+  return bindActionCreators({ loadUserAndToken }, dispatch);
+}
+
+export default connect(null, mapDispatchToProps)(Landing);

--- a/src/scenes/Landing/index.jsx
+++ b/src/scenes/Landing/index.jsx
@@ -21,11 +21,6 @@ export class Landing extends Component {
   }
 }
 
-function mapStateToProps(state) {
-  return {
-    loggedIn: state.user.loggedIn,
-  };
-}
 function mapDispatchToProps(dispatch) {
   return bindActionCreators({ loadUserAndToken }, dispatch);
 }

--- a/src/shared/AppWrapper/index.jsx
+++ b/src/shared/AppWrapper/index.jsx
@@ -11,7 +11,7 @@ import DD1299 from 'scenes/DD1299';
 import Landing from 'scenes/Landing';
 import WizardDemo from 'scenes/WizardDemo';
 import DemoWorkflowRoutes from 'scenes/DemoWorkflow/routes';
-
+import PrivateRoute from 'shared/User/PrivateRoute';
 const redirect = pathname => () => (
   <Redirect
     to={{

--- a/src/shared/AppWrapper/index.jsx
+++ b/src/shared/AppWrapper/index.jsx
@@ -27,7 +27,7 @@ const AppWrapper = () => (
         <Route exact path="/" component={Feedback} />
         <Route path="/submitted" component={SubmittedFeedback} />
         <Route path="/shipments/:shipmentsStatus" component={Shipments} />
-        <Route path="/DD1299" component={DD1299} />
+        <PrivateRoute path="/DD1299" component={DD1299} />
         <Route path="/landing" component={Landing} />
         <Route exact path="/mymove" render={redirect('/mymove/intro')} />
         {WizardDemo()}

--- a/src/shared/AppWrapper/index.jsx
+++ b/src/shared/AppWrapper/index.jsx
@@ -26,11 +26,11 @@ const AppWrapper = () => (
       <Header />
       <main className="site__content">
         <Switch>
-          <Route exact path="/" component={Feedback} />
+          <Route exact path="/" component={Landing} />
           <Route path="/submitted" component={SubmittedFeedback} />
           <Route path="/shipments/:shipmentsStatus" component={Shipments} />
           <PrivateRoute path="/DD1299" component={DD1299} />
-          <Route path="/landing" component={Landing} />
+          <Route path="/feedback" component={Feedback} />
           <Route exact path="/mymove" render={redirect('/mymove/intro')} />
           {WizardDemo()}
           <Route exact path="/demo" render={redirect('/demo/sm')} />

--- a/src/shared/AppWrapper/index.jsx
+++ b/src/shared/AppWrapper/index.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Route, Redirect } from 'react-router-dom';
+import { Route, Redirect, Switch } from 'react-router-dom';
 import { ConnectedRouter } from 'react-router-redux';
 import Feedback from 'scenes/Feedback';
 import SubmittedFeedback from 'scenes/SubmittedFeedback';
@@ -12,6 +12,7 @@ import Landing from 'scenes/Landing';
 import WizardDemo from 'scenes/WizardDemo';
 import DemoWorkflowRoutes from 'scenes/DemoWorkflow/routes';
 import PrivateRoute from 'shared/User/PrivateRoute';
+
 const redirect = pathname => () => (
   <Redirect
     to={{
@@ -24,15 +25,17 @@ const AppWrapper = () => (
     <div className="App site">
       <Header />
       <main className="site__content">
-        <Route exact path="/" component={Feedback} />
-        <Route path="/submitted" component={SubmittedFeedback} />
-        <Route path="/shipments/:shipmentsStatus" component={Shipments} />
-        <PrivateRoute path="/DD1299" component={DD1299} />
-        <Route path="/landing" component={Landing} />
-        <Route exact path="/mymove" render={redirect('/mymove/intro')} />
-        {WizardDemo()}
-        <Route exact path="/demo" render={redirect('/demo/sm')} />
-        {DemoWorkflowRoutes()}
+        <Switch>
+          <Route exact path="/" component={Feedback} />
+          <Route path="/submitted" component={SubmittedFeedback} />
+          <Route path="/shipments/:shipmentsStatus" component={Shipments} />
+          <PrivateRoute path="/DD1299" component={DD1299} />
+          <Route path="/landing" component={Landing} />
+          <Route exact path="/mymove" render={redirect('/mymove/intro')} />
+          {WizardDemo()}
+          <Route exact path="/demo" render={redirect('/demo/sm')} />
+          {DemoWorkflowRoutes()}
+        </Switch>
       </main>
       <Footer />
     </div>

--- a/src/shared/Header/index.jsx
+++ b/src/shared/Header/index.jsx
@@ -129,9 +129,25 @@ function Header() {
               </ul>
             </li>
             <li>
-              <NavLink to="/submitted" className="usa-nav-link">
-                <span>Submitted Feedback</span>
-              </NavLink>
+              <button
+                className="usa-accordion-button usa-nav-link"
+                aria-expanded="false"
+                aria-controls="side-nav-3"
+              >
+                <span>Feedback</span>
+              </button>
+              <ul id="side-nav-3" className="usa-nav-submenu">
+                <li>
+                  <NavLink to="/Feedback" className="usa-nav-link">
+                    <span>Report a bug</span>
+                  </NavLink>
+                </li>
+                <li>
+                  <NavLink to="/submitted" className="usa-nav-link">
+                    <span>Submitted Feedback</span>
+                  </NavLink>
+                </li>
+              </ul>
             </li>
           </ul>
           <form className="usa-search usa-search-small">

--- a/src/shared/User/Authorization.jsx
+++ b/src/shared/User/Authorization.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+const AuthorizationContainer = (WrappedComponent, allowedRoles) =>
+  function WithAuthorization(props) {
+    const { role } = props;
+    if (allowedRoles.includes(role)) {
+      return <WrappedComponent {...props} />;
+    } else {
+      return (
+        <div className="usa-grid">
+          <h1>You are not authorized to view this page</h1>
+        </div>
+      );
+    }
+  };
+
+const Authorization = connect(state => ({
+  role: state.user.role,
+}))(AuthorizationContainer);
+export default Authorization;

--- a/src/shared/User/Authorization.jsx
+++ b/src/shared/User/Authorization.jsx
@@ -1,4 +1,7 @@
 import React from 'react';
+
+// this is from https://hackernoon.com/role-based-authorization-in-react-c70bb7641db4
+// as of 3/8 we are not using this yet, but it seems like it would work once we have a need to include roles in user state
 const AuthorizationContainer = (WrappedComponent, allowedRoles) =>
   function WithAuthorization(props) {
     const { role } = props;

--- a/src/shared/User/LoginButton.jsx
+++ b/src/shared/User/LoginButton.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { connect } from 'react-redux';
+
+const LoginButton = props => {
+  if (!props.loggedIn) return <a href="/auth/login-gov">Sign In</a>;
+  else return <a href="/auth/logout">Log Out</a>;
+};
+
+function mapStateToProps(state) {
+  return {
+    loggedIn: state.user.loggedIn,
+  };
+}
+//export default connect(mapStateToProps)(LoginButton);
+export default LoginButton;

--- a/src/shared/User/LoginButton.jsx
+++ b/src/shared/User/LoginButton.jsx
@@ -11,5 +11,4 @@ function mapStateToProps(state) {
     loggedIn: state.user.loggedIn,
   };
 }
-//export default connect(mapStateToProps)(LoginButton);
-export default LoginButton;
+export default connect(mapStateToProps)(LoginButton);

--- a/src/shared/User/LoginButton.jsx
+++ b/src/shared/User/LoginButton.jsx
@@ -2,13 +2,13 @@ import React from 'react';
 import { connect } from 'react-redux';
 
 const LoginButton = props => {
-  if (!props.loggedIn) return <a href="/auth/login-gov">Sign In</a>;
+  if (!props.isLoggedIn) return <a href="/auth/login-gov">Sign In</a>;
   else return <a href="/auth/logout">Log Out</a>;
 };
 
 function mapStateToProps(state) {
   return {
-    loggedIn: state.user.loggedIn,
+    isLoggedIn: state.user.isLoggedIn,
   };
 }
 export default connect(mapStateToProps)(LoginButton);

--- a/src/shared/User/PrivateRoute.jsx
+++ b/src/shared/User/PrivateRoute.jsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { Route, Redirect } from 'react-router-dom';
 import { connect } from 'react-redux';
 
+// this was adapted from https://github.com/ReactTraining/react-router/blob/master/packages/react-router-redux/examples/AuthExample.js
+// note that it does not work if the route is not inside a Switch
 class PrivateRouteContainer extends React.Component {
   render() {
     const { isLoggedIn, component: Component, ...props } = this.props;

--- a/src/shared/User/PrivateRoute.jsx
+++ b/src/shared/User/PrivateRoute.jsx
@@ -15,7 +15,7 @@ class PrivateRouteContainer extends React.Component {
             return (
               <Redirect
                 to={{
-                  pathname: '/landing',
+                  pathname: '/',
                   state: { from: props.location },
                 }}
               />

--- a/src/shared/User/PrivateRoute.jsx
+++ b/src/shared/User/PrivateRoute.jsx
@@ -1,34 +1,34 @@
 import React from 'react';
-import { Route } from 'react-router-dom';
-
+import { Route, Redirect } from 'react-router-dom';
 import { connect } from 'react-redux';
-
-import LoginButton from 'shared/User/LoginButton';
 
 class PrivateRouteContainer extends React.Component {
   render() {
     const { isLoggedIn, component: Component, ...props } = this.props;
-
     return (
       <Route
         {...props}
-        render={props =>
-          isLoggedIn ? (
-            <Component {...props} />
-          ) : (
-            <div className="usa-grid">
-              <h1>Please login to access this page </h1>
-              <LoginButton />
-            </div>
-          )
-        }
+        render={props => {
+          if (isLoggedIn) {
+            return <Component {...props} />;
+          } else {
+            return (
+              <Redirect
+                to={{
+                  pathname: '/landing',
+                  state: { from: props.location },
+                }}
+              />
+            );
+          }
+        }}
       />
     );
   }
 }
-
-const PrivateRoute = connect(state => ({
+const mapStateToProps = state => ({
   isLoggedIn: state.user.isLoggedIn,
-}))(PrivateRouteContainer);
+});
+const PrivateRoute = connect(mapStateToProps)(PrivateRouteContainer);
 
 export default PrivateRoute;

--- a/src/shared/User/PrivateRoute.jsx
+++ b/src/shared/User/PrivateRoute.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { Route } from 'react-router-dom';
+
+import { connect } from 'react-redux';
+
+import LoginButton from 'shared/User/LoginButton';
+
+class PrivateRouteContainer extends React.Component {
+  render() {
+    const { isLoggedIn, component: Component, ...props } = this.props;
+
+    return (
+      <Route
+        {...props}
+        render={props =>
+          isLoggedIn ? (
+            <Component {...props} />
+          ) : (
+            <div className="usa-grid">
+              <h1>Please login to access this page </h1>
+              <LoginButton />
+            </div>
+          )
+        }
+      />
+    );
+  }
+}
+
+const PrivateRoute = connect(state => ({
+  isLoggedIn: state.user.isLoggedIn,
+}))(PrivateRouteContainer);
+
+export default PrivateRoute;

--- a/src/shared/User/ducks.js
+++ b/src/shared/User/ducks.js
@@ -1,19 +1,37 @@
 import * as Cookies from 'js-cookie';
 const LOGOUT = 'USER|LOGOUT';
 
+const LOAD_USER_AND_TOKEN = 'LOAD_USER_AND_TOKEN';
+
+function getUserInfo() {
+  const cookie = Cookies.get('user_session');
+  return {
+    jwt: cookie || null,
+    isLoggedIn: cookie && true,
+  };
+}
+
+export function loadUserAndToken() {
+  console.log('action creator');
+  const jwt = getUserInfo();
+  return { type: LOAD_USER_AND_TOKEN, payload: jwt };
+}
+
 export function logOut() {
   //todo: call server endpoint, clean up cookies?
   return {
     type: LOGOUT,
   };
 }
-const initialState = {
-  isLoggedIn: Cookies.get('user_session') ? true : false,
-};
+
+const initialState = getUserInfo();
+
 const userReducer = (state = initialState, action) => {
   switch (action.type) {
+    case LOAD_USER_AND_TOKEN:
+      return action.payload;
     case LOGOUT:
-      return { isLoggedIn: false };
+      return { isLoggedIn: false, jwt: null };
     default: {
       return state;
     }

--- a/src/shared/User/ducks.js
+++ b/src/shared/User/ducks.js
@@ -1,18 +1,17 @@
 import * as Cookies from 'js-cookie';
 const LOGOUT = 'USER|LOGOUT';
 
-const LOAD_USER_AND_TOKEN = 'LOAD_USER_AND_TOKEN';
+const LOAD_USER_AND_TOKEN = 'USER|ZLOAD_USER_AND_TOKEN';
 
 function getUserInfo() {
   const cookie = Cookies.get('user_session');
   return {
     jwt: cookie || null,
-    isLoggedIn: cookie && true,
+    isLoggedIn: cookie ? true : false,
   };
 }
 
 export function loadUserAndToken() {
-  console.log('action creator');
   const jwt = getUserInfo();
   return { type: LOAD_USER_AND_TOKEN, payload: jwt };
 }
@@ -26,7 +25,7 @@ export function logOut() {
 
 const initialState = getUserInfo();
 
-const userReducer = (state = initialState, action) => {
+const userReducer = (state = { jwt: null, isLoggedIn: false }, action) => {
   switch (action.type) {
     case LOAD_USER_AND_TOKEN:
       return action.payload;

--- a/src/shared/User/ducks.js
+++ b/src/shared/User/ducks.js
@@ -1,4 +1,4 @@
-//import * as Cookies from 'js-cookie';
+import * as Cookies from 'js-cookie';
 const LOGOUT = 'USER|LOGOUT';
 
 export function logOut() {
@@ -8,13 +8,12 @@ export function logOut() {
   };
 }
 const initialState = {
-  //  loggedIn: Cookies.get('user_session'),
-  loggedIn: false,
+  isLoggedIn: Cookies.get('user_session') ? true : false,
 };
 const userReducer = (state = initialState, action) => {
   switch (action.type) {
     case LOGOUT:
-      return { loggedIn: false };
+      return { isLoggedIn: false };
     default: {
       return state;
     }

--- a/src/shared/User/ducks.js
+++ b/src/shared/User/ducks.js
@@ -1,8 +1,6 @@
 import * as Cookies from 'js-cookie';
 import * as decode from 'jwt-decode';
 
-const LOGOUT = 'USER|LOGOUT';
-
 const LOAD_USER_AND_TOKEN = 'USER|LOAD_USER_AND_TOKEN';
 
 const loggedOutUser = {
@@ -27,19 +25,10 @@ export function loadUserAndToken() {
   return { type: LOAD_USER_AND_TOKEN, payload: jwt };
 }
 
-export function logOut() {
-  //todo: call server endpoint, clean up cookies?
-  return {
-    type: LOGOUT,
-  };
-}
-
 const userReducer = (state = loggedOutUser, action) => {
   switch (action.type) {
     case LOAD_USER_AND_TOKEN:
       return action.payload;
-    case LOGOUT:
-      return loggedOutUser;
     default: {
       return state;
     }

--- a/src/shared/User/ducks.js
+++ b/src/shared/User/ducks.js
@@ -3,7 +3,7 @@ import * as decode from 'jwt-decode';
 
 const LOGOUT = 'USER|LOGOUT';
 
-const LOAD_USER_AND_TOKEN = 'USER|ZLOAD_USER_AND_TOKEN';
+const LOAD_USER_AND_TOKEN = 'USER|LOAD_USER_AND_TOKEN';
 
 const loggedOutUser = {
   isLoggedIn: false,

--- a/src/shared/User/ducks.js
+++ b/src/shared/User/ducks.js
@@ -1,13 +1,24 @@
 import * as Cookies from 'js-cookie';
+import * as decode from 'jwt-decode';
+
 const LOGOUT = 'USER|LOGOUT';
 
 const LOAD_USER_AND_TOKEN = 'USER|ZLOAD_USER_AND_TOKEN';
 
+const loggedOutUser = {
+  isLoggedIn: false,
+  email: null,
+  jwt: null,
+};
 function getUserInfo() {
   const cookie = Cookies.get('user_session');
+  if (!cookie) return loggedOutUser;
+  const jwt = decode(cookie);
+  //if (jwt.exp <  Date.now().valueOf() / 1000) return loggedOutUser;
   return {
-    jwt: cookie || null,
-    isLoggedIn: cookie ? true : false,
+    jwt: cookie,
+    email: jwt.email,
+    isLoggedIn: true,
   };
 }
 
@@ -23,14 +34,12 @@ export function logOut() {
   };
 }
 
-const initialState = getUserInfo();
-
-const userReducer = (state = { jwt: null, isLoggedIn: false }, action) => {
+const userReducer = (state = loggedOutUser, action) => {
   switch (action.type) {
     case LOAD_USER_AND_TOKEN:
       return action.payload;
     case LOGOUT:
-      return { isLoggedIn: false, jwt: null };
+      return loggedOutUser;
     default: {
       return state;
     }

--- a/src/shared/User/ducks.js
+++ b/src/shared/User/ducks.js
@@ -1,0 +1,24 @@
+//import * as Cookies from 'js-cookie';
+const LOGOUT = 'USER|LOGOUT';
+
+export function logOut() {
+  //todo: call server endpoint, clean up cookies?
+  return {
+    type: LOGOUT,
+  };
+}
+const initialState = {
+  //  loggedIn: Cookies.get('user_session'),
+  loggedIn: false,
+};
+const userReducer = (state = initialState, action) => {
+  switch (action.type) {
+    case LOGOUT:
+      return { loggedIn: false };
+    default: {
+      return state;
+    }
+  }
+};
+
+export default userReducer;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4523,6 +4523,10 @@ js-base64@^2.1.9:
   version "2.4.3"
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.4.3.tgz#2e545ec2b0f2957f41356510205214e98fad6582"
 
+js-cookie@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-2.2.0.tgz#1b2c279a6eece380a12168b92485265b35b1effb"
+
 js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4666,6 +4666,10 @@ jszip@^3.1.3:
     pako "~1.0.2"
     readable-stream "~2.0.6"
 
+jwt-decode@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/jwt-decode/-/jwt-decode-2.2.0.tgz#7d86bd56679f58ce6a84704a657dd392bba81a79"
+
 keyboardevent-key-polyfill@^1.0.2:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/keyboardevent-key-polyfill/-/keyboardevent-key-polyfill-1.1.0.tgz#8a319d8e45a13172fca56286372f90c1d4c7014c"


### PR DESCRIPTION
## Description

We want the loggedIn state of the user and basic user information (e.g. email address) available in redux state. We also want to be able to restrict access to client routes to logged in users.

This also changes the main page of the application to be the landing page. At the moment this is pretty barebones, but will eventually be more useful.

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Verification Steps
* [x] if you are not logged in, attempting to access DD1299 will redirect you to the login prompt
* [x] if you are logged in, you can access the DD1299 form
* [x] in the redux tools you can see user information (e.g., isLoggedIn, email)
* [x] All tests pass.
* [x] There are no [aXe](https://www.deque.com/products/aXe/) warnings for UI.
* [x] This works in IE.

## References

* [#155131945](https://www.pivotaltracker.com/n/projects/2136867/stories/155131945) for this change
* ADR 17 explains the techniques used and links to reference material

## Screenshots

The landing page when not logged in:
![image](https://user-images.githubusercontent.com/3142631/37134846-53f8e068-2268-11e8-9bfb-1ecd17d14a20.png)

The landing page after login:
![image](https://user-images.githubusercontent.com/3142631/37134879-8b4622ba-2268-11e8-8036-38ca386e9f21.png)


