### PR TITLE
Server exits if secret keys can't be parsed into RSA keys

### DIFF
--- a/cmd/webserver/main.go
+++ b/cmd/webserver/main.go
@@ -54,14 +54,6 @@ func main() {
 
 	flag.Parse()
 
-	// Assert that our secret keys can be parsed into actual private keys
-	if _, err := jwt.ParseRSAPrivateKeyFromPEM([]byte(*loginGovSecretKey)); err != nil {
-		log.Fatalln(err)
-	}
-	if _, err := jwt.ParseRSAPrivateKeyFromPEM([]byte(*clientAuthSecretKey)); err != nil {
-		log.Fatalln(err)
-	}
-
 	// Set up logger for the system
 	var err error
 	if *debugLogging {
@@ -74,6 +66,15 @@ func main() {
 		log.Fatalf("Failed to initialize Zap logging due to %v", err)
 	}
 	zap.ReplaceGlobals(logger)
+
+	// Assert that our secret keys can be parsed into actual private keys
+	// TODO: Store the parsed key in handlers/AppContext instead of parsing every time
+	if _, err := jwt.ParseRSAPrivateKeyFromPEM([]byte(*loginGovSecretKey)); err != nil {
+		log.Fatalln(err)
+	}
+	if _, err := jwt.ParseRSAPrivateKeyFromPEM([]byte(*clientAuthSecretKey)); err != nil {
+		log.Fatalln(err)
+	}
 
 	//DB connection
 	pop.AddLookupPaths(*config)

--- a/cmd/webserver/main.go
+++ b/cmd/webserver/main.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"path"
 
+	"github.com/dgrijalva/jwt-go"
 	"github.com/go-openapi/loads"
 	"github.com/markbates/pop"
 	"github.com/namsral/flag" // This flag package accepts ENV vars as well as cmd line flags
@@ -52,6 +53,14 @@ func main() {
 	clientAuthSecretKey := flag.String("client_auth_secret_key", "", "Client auth secret JWT key.")
 
 	flag.Parse()
+
+	// Assert that our secret keys can be parsed into actual private keys
+	if _, err := jwt.ParseRSAPrivateKeyFromPEM([]byte(*loginGovSecretKey)); err != nil {
+		log.Fatalln(err)
+	}
+	if _, err := jwt.ParseRSAPrivateKeyFromPEM([]byte(*clientAuthSecretKey)); err != nil {
+		log.Fatalln(err)
+	}
 
 	// Set up logger for the system
 	var err error


### PR DESCRIPTION
## Description

We previously ran into an issue on staging where our secret key parameter was malformed and our authentication was silently failing. This has us verify our parameter is valid on server start or the server exits.