### PR TITLE
Prototype pointer field validator.

### DIFF
--- a/pkg/handlers/issues_test.go
+++ b/pkg/handlers/issues_test.go
@@ -3,6 +3,8 @@ package handlers
 import (
 	"time"
 
+	"github.com/go-openapi/swag"
+
 	issueop "github.com/transcom/mymove/pkg/gen/internalapi/internaloperations/issues"
 	"github.com/transcom/mymove/pkg/gen/internalmessages"
 )
@@ -61,7 +63,7 @@ func (suite *HandlerSuite) TestIndexIssuesHandler() {
 
 	// Given: An issue
 	testDescription := "This is a test issue for your indexIssueHandler."
-	newIssuePayload := internalmessages.CreateIssuePayload{Description: &testDescription}
+	newIssuePayload := internalmessages.CreateIssuePayload{Description: &testDescription, ReporterName: swag.String("Jackie")}
 
 	// When: New issue is posted
 	newIssueParams := issueop.CreateIssueParams{CreateIssuePayload: &newIssuePayload}

--- a/pkg/models/issue.go
+++ b/pkg/models/issue.go
@@ -40,7 +40,7 @@ func (i Issues) String() string {
 func (i *Issue) Validate(tx *pop.Connection) (*validate.Errors, error) {
 	return validate.Validate(
 		&validators.StringIsPresent{Field: i.Description, Name: "Description"},
-		&OptionalStringIsPresent{Field: i.ReporterName, Name: "ReporterName"},
+		&StringIsNilOrNotBlank{Field: i.ReporterName, Name: "ReporterName"},
 	), nil
 }
 

--- a/pkg/models/issue.go
+++ b/pkg/models/issue.go
@@ -40,6 +40,7 @@ func (i Issues) String() string {
 func (i *Issue) Validate(tx *pop.Connection) (*validate.Errors, error) {
 	return validate.Validate(
 		&validators.StringIsPresent{Field: i.Description, Name: "Description"},
+		&OptionalStringIsPresent{Field: i.ReporterName, Name: "ReporterName"},
 	), nil
 }
 

--- a/pkg/models/issue_test.go
+++ b/pkg/models/issue_test.go
@@ -40,3 +40,26 @@ func (suite *ModelSuite) TestOptionalProperty() {
 		t.Error("Somehow got a valid name back")
 	}
 }
+
+func (suite *ModelSuite) TestIssueValidations() {
+	issue := &Issue{}
+
+	expErrors := map[string][]string{
+		"description":   []string{"Description can not be blank."},
+		"reporter_name": []string{"ReporterName can not be blank."},
+	}
+
+	suite.verifyValidationErrors(issue, expErrors)
+
+	empty := ""
+	issue.ReporterName = &empty
+	suite.verifyValidationErrors(issue, expErrors)
+
+	phebe := "Phebe"
+	issue.ReporterName = &phebe
+	expErrors = map[string][]string{
+		"description": []string{"Description can not be blank."},
+	}
+
+	suite.verifyValidationErrors(issue, expErrors)
+}

--- a/pkg/models/issue_test.go
+++ b/pkg/models/issue_test.go
@@ -45,14 +45,17 @@ func (suite *ModelSuite) TestIssueValidations() {
 	issue := &Issue{}
 
 	expErrors := map[string][]string{
-		"description":   []string{"Description can not be blank."},
-		"reporter_name": []string{"ReporterName can not be blank."},
+		"description": []string{"Description can not be blank."},
 	}
 
 	suite.verifyValidationErrors(issue, expErrors)
 
 	empty := ""
 	issue.ReporterName = &empty
+	expErrors = map[string][]string{
+		"description":   []string{"Description can not be blank."},
+		"reporter_name": []string{"ReporterName can not be blank."},
+	}
 	suite.verifyValidationErrors(issue, expErrors)
 
 	phebe := "Phebe"

--- a/pkg/models/validators.go
+++ b/pkg/models/validators.go
@@ -8,14 +8,15 @@ import (
 	"github.com/markbates/validate/validators"
 )
 
-type OptionalStringIsPresent struct {
+// StringIsNilOrNotBlank validates OptionalString fields, which we represent as *string.
+type StringIsNilOrNotBlank struct {
 	Name  string
 	Field *string
 }
 
-func (v *OptionalStringIsPresent) IsValid(errors *validate.Errors) {
+// IsValid adds an error if the pointer is not nil and also an empty string.
+func (v *StringIsNilOrNotBlank) IsValid(errors *validate.Errors) {
 	if v.Field == nil {
-		errors.Add(validators.GenerateKey(v.Name), fmt.Sprintf("%s can not be blank.", v.Name))
 		return
 	}
 	if strings.TrimSpace(*v.Field) == "" {

--- a/pkg/models/validators.go
+++ b/pkg/models/validators.go
@@ -1,0 +1,24 @@
+package models
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/markbates/validate"
+	"github.com/markbates/validate/validators"
+)
+
+type OptionalStringIsPresent struct {
+	Name  string
+	Field *string
+}
+
+func (v *OptionalStringIsPresent) IsValid(errors *validate.Errors) {
+	if v.Field == nil {
+		errors.Add(validators.GenerateKey(v.Name), fmt.Sprintf("%s can not be blank.", v.Name))
+		return
+	}
+	if strings.TrimSpace(*v.Field) == "" {
+		errors.Add(validators.GenerateKey(v.Name), fmt.Sprintf("%s can not be blank.", v.Name))
+	}
+}


### PR DESCRIPTION
## Description

The `validator` package doesn't support validating pointer fields, which we have quite a few of due to our use of GoSwagger.

This patch adds a single new validator for optional strings, which are represented in `struct` fields with the type `*string`. If this approach received approval from the team, it can be extended to support any of the other optional field types in the app.

## Reviewer Notes

* Does `OptionalStringIsPresent` make sense as a name?

## Verification Steps

* [ ] All tests pass.

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/155644359) for this change