### PR TITLE
initial ppm routes [delivers 155870254]

### DIFF
--- a/src/scenes/DemoWorkflow/index.jsx
+++ b/src/scenes/DemoWorkflow/index.jsx
@@ -2,7 +2,6 @@ import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import PropTypes from 'prop-types';
-import { withRouter } from 'react-router-dom';
 
 import { reduxifyForm } from 'shared/JsonSchemaForm';
 
@@ -97,6 +96,4 @@ function mapDispatchToProps(dispatch) {
   return bindActionCreators({ loadSchema, submitForm, resetSuccess }, dispatch);
 }
 
-export default withRouter(
-  connect(mapStateToProps, mapDispatchToProps)(DemoWorkflow),
-);
+export default connect(mapStateToProps, mapDispatchToProps)(DemoWorkflow);

--- a/src/scenes/Moves/routes.js
+++ b/src/scenes/Moves/routes.js
@@ -1,0 +1,45 @@
+import React from 'react';
+import { Route } from 'react-router-dom';
+import WizardPage from 'shared/WizardPage';
+import Agreement from 'scenes/Legalese';
+const Placeholder = props => {
+  return (
+    <WizardPage
+      handleSubmit={() => undefined}
+      pageList={props.pageList}
+      pageKey={props.pageKey}
+    >
+      <h1>Placeholder for {props.title}</h1>
+    </WizardPage>
+  );
+};
+const stub = (key, pages) => {
+  return () => <Placeholder pageList={pages} pageKey={key} title={key} />;
+};
+export default () => {
+  const pages = {
+    '/moves/:moveId': { render: stub },
+    '/moves/:moveId/ppm-transition': { render: stub },
+    '/moves/:moveId/ppm-size': { render: stub },
+    '/moves/:moveId/ppm-incentive': { render: stub },
+    '/moves/:moveId/agreement': {
+      render: (key, pages) => {
+        return () => (
+          <WizardPage
+            handleSubmit={() => undefined}
+            pageList={pages}
+            pageKey={key}
+          >
+            <Agreement />
+          </WizardPage>
+        );
+      },
+    },
+  };
+  const pageList = Object.keys(pages);
+  const val = pageList.map(key => {
+    const render = pages[key].render(key, pageList);
+    return <Route exact path={key} key={key} render={render} />;
+  });
+  return val;
+};

--- a/src/scenes/Moves/routes.js
+++ b/src/scenes/Moves/routes.js
@@ -1,7 +1,9 @@
 import React from 'react';
-import { Route } from 'react-router-dom';
+
+import PrivateRoute from 'shared/User/PrivateRoute';
 import WizardPage from 'shared/WizardPage';
 import Agreement from 'scenes/Legalese';
+
 const Placeholder = props => {
   return (
     <WizardPage
@@ -13,9 +15,11 @@ const Placeholder = props => {
     </WizardPage>
   );
 };
-const stub = (key, pages) => {
-  return () => <Placeholder pageList={pages} pageKey={key} title={key} />;
-};
+
+const stub = (key, pages) => () => (
+  <Placeholder pageList={pages} pageKey={key} title={key} />
+);
+
 export default () => {
   const pages = {
     '/moves/:moveId': { render: stub },
@@ -23,23 +27,20 @@ export default () => {
     '/moves/:moveId/ppm-size': { render: stub },
     '/moves/:moveId/ppm-incentive': { render: stub },
     '/moves/:moveId/agreement': {
-      render: (key, pages) => {
-        return () => (
-          <WizardPage
-            handleSubmit={() => undefined}
-            pageList={pages}
-            pageKey={key}
-          >
-            <Agreement />
-          </WizardPage>
-        );
-      },
+      render: (key, pages) => () => (
+        <WizardPage
+          handleSubmit={() => undefined}
+          pageList={pages}
+          pageKey={key}
+        >
+          <Agreement />
+        </WizardPage>
+      ),
     },
   };
   const pageList = Object.keys(pages);
-  const val = pageList.map(key => {
+  return pageList.map(key => {
     const render = pages[key].render(key, pageList);
-    return <Route exact path={key} key={key} render={render} />;
+    return <PrivateRoute exact path={key} key={key} render={render} />;
   });
-  return val;
 };

--- a/src/scenes/Moves/routes.js
+++ b/src/scenes/Moves/routes.js
@@ -27,13 +27,13 @@ export default () => {
     '/moves/:moveId/ppm-size': { render: stub },
     '/moves/:moveId/ppm-incentive': { render: stub },
     '/moves/:moveId/agreement': {
-      render: (key, pages) => () => (
+      render: (key, pages) => ({ match }) => (
         <WizardPage
           handleSubmit={() => undefined}
           pageList={pages}
           pageKey={key}
         >
-          <Agreement />
+          <Agreement match={match} />
         </WizardPage>
       ),
     },

--- a/src/scenes/WizardDemo/index.jsx
+++ b/src/scenes/WizardDemo/index.jsx
@@ -1,14 +1,13 @@
 import React from 'react';
 import { Route } from 'react-router-dom';
 import WizardPage from 'shared/WizardPage';
-import { withRouter } from 'react-router-dom';
 import intro from './intro.png';
 import moveType from './select-move-type.png';
 import dateSelection from './select-date.png';
 import mover from './select-mover.png';
 import review from './review-locations.png';
 
-const C = props => (
+const ImagePage = props => (
   <WizardPage
     handleSubmit={() => undefined}
     pageList={props.pageList}
@@ -18,8 +17,6 @@ const C = props => (
     <img src={props.src} alt={props.path} />
   </WizardPage>
 );
-
-const ImagePage = withRouter(C);
 
 export default () => {
   const pages = {

--- a/src/shared/AppWrapper/index.jsx
+++ b/src/shared/AppWrapper/index.jsx
@@ -12,6 +12,7 @@ import Legalese from 'scenes/Legalese';
 import Landing from 'scenes/Landing';
 import WizardDemo from 'scenes/WizardDemo';
 import DemoWorkflowRoutes from 'scenes/DemoWorkflow/routes';
+import MoveRoutes from 'scenes/Moves/routes';
 import PrivateRoute from 'shared/User/PrivateRoute';
 
 const redirect = pathname => () => (
@@ -44,6 +45,7 @@ const AppWrapper = () => (
           {WizardDemo()}
           <Route exact path="/demo" render={redirect('/demo/sm')} />
           {DemoWorkflowRoutes()}
+          {MoveRoutes()}
           <Route component={NoMatch} />
         </Switch>
       </main>

--- a/src/shared/AppWrapper/index.jsx
+++ b/src/shared/AppWrapper/index.jsx
@@ -21,6 +21,13 @@ const redirect = pathname => () => (
     }}
   />
 );
+const NoMatch = ({ location }) => (
+  <div>
+    <h3>
+      No match for <code>{location.pathname}</code>
+    </h3>
+  </div>
+);
 const AppWrapper = () => (
   <ConnectedRouter history={history}>
     <div className="App site">
@@ -37,6 +44,7 @@ const AppWrapper = () => (
           {WizardDemo()}
           <Route exact path="/demo" render={redirect('/demo/sm')} />
           {DemoWorkflowRoutes()}
+          <Route component={NoMatch} />
         </Switch>
       </main>
       <Footer />

--- a/src/shared/AppWrapper/index.jsx
+++ b/src/shared/AppWrapper/index.jsx
@@ -22,7 +22,7 @@ const redirect = pathname => () => (
   />
 );
 const NoMatch = ({ location }) => (
-  <div>
+  <div className="usa-grid">
     <h3>
       No match for <code>{location.pathname}</code>
     </h3>

--- a/src/shared/User/PrivateRoute.jsx
+++ b/src/shared/User/PrivateRoute.jsx
@@ -5,10 +5,11 @@ import { connect } from 'react-redux';
 import LoginButton from './LoginButton';
 
 const NotAuthenticated = ({ location }) => (
-  <div>
+  <div className="usa-grid">
     <h3>
       Please login to access <code>{location.pathname}</code>
     </h3>
+    <LoginButton />
   </div>
 );
 
@@ -16,24 +17,9 @@ const NotAuthenticated = ({ location }) => (
 // note that it does not work if the route is not inside a Switch
 class PrivateRouteContainer extends React.Component {
   render() {
-    const { isLoggedIn, component: Component, ...props } = this.props;
-    return (
-      <Route
-        {...props}
-        render={props => {
-          if (isLoggedIn) {
-            return <Component {...props} />;
-          } else {
-            return (
-              <div className="usa-grid">
-                <NotAuthenticated location={props.location} />
-                <LoginButton />
-              </div>
-            );
-          }
-        }}
-      />
-    );
+    const { isLoggedIn, path, ...props } = this.props;
+    if (isLoggedIn) return <Route {...props} />;
+    else return <Route path={path} component={NotAuthenticated} />;
   }
 }
 const mapStateToProps = state => ({

--- a/src/shared/User/PrivateRoute.jsx
+++ b/src/shared/User/PrivateRoute.jsx
@@ -1,6 +1,16 @@
 import React from 'react';
-import { Route, Redirect } from 'react-router-dom';
+import { Route } from 'react-router-dom';
 import { connect } from 'react-redux';
+
+import LoginButton from './LoginButton';
+
+const NotAuthenticated = ({ location }) => (
+  <div>
+    <h3>
+      Please login to access <code>{location.pathname}</code>
+    </h3>
+  </div>
+);
 
 // this was adapted from https://github.com/ReactTraining/react-router/blob/master/packages/react-router-redux/examples/AuthExample.js
 // note that it does not work if the route is not inside a Switch
@@ -15,12 +25,10 @@ class PrivateRouteContainer extends React.Component {
             return <Component {...props} />;
           } else {
             return (
-              <Redirect
-                to={{
-                  pathname: '/',
-                  state: { from: props.location },
-                }}
-              />
+              <div className="usa-grid">
+                <NotAuthenticated location={props.location} />
+                <LoginButton />
+              </div>
             );
           }
         }}

--- a/src/shared/WizardPage/generatePath.js
+++ b/src/shared/WizardPage/generatePath.js
@@ -1,0 +1,37 @@
+// this is borrowed from https://github.com/ReactTraining/react-router/blob/e6f9017c947b3ae49affa24cc320d0a86f765b55/packages/react-router/modules/generatePath.js
+// which has not been released yet
+
+import pathToRegexp from 'path-to-regexp';
+
+const patternCache = {};
+const cacheLimit = 10000;
+let cacheCount = 0;
+
+const compileGenerator = pattern => {
+  const cacheKey = pattern;
+  const cache = patternCache[cacheKey] || (patternCache[cacheKey] = {});
+
+  if (cache[pattern]) return cache[pattern];
+
+  const compiledGenerator = pathToRegexp.compile(pattern);
+
+  if (cacheCount < cacheLimit) {
+    cache[pattern] = compiledGenerator;
+    cacheCount++;
+  }
+
+  return compiledGenerator;
+};
+
+/**
+ * Public API for generating a URL pathname from a pattern and parameters.
+ */
+const generatePath = (pattern = '/', params = {}) => {
+  if (pattern === '/') {
+    return pattern;
+  }
+  const generator = compileGenerator(pattern);
+  return generator(params);
+};
+
+export default generatePath;

--- a/src/shared/WizardPage/index.jsx
+++ b/src/shared/WizardPage/index.jsx
@@ -2,7 +2,9 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
+import { withRouter } from 'react-router-dom';
 import { push } from 'react-router-redux';
+import generatePath from './generatePath';
 
 import {
   getNextPagePath,
@@ -18,21 +20,22 @@ export class WizardPage extends Component {
     this.previousPage = this.previousPage.bind(this);
   }
   componentDidMount() {
-    //  window.scrollTo(0, 0);
+    window.scrollTo(0, 0);
   }
 
   nextPage() {
-    const { pageList, pageKey, push } = this.props;
+    const { pageList, pageKey, push, match: { params } } = this.props;
     const path = getNextPagePath(pageList, pageKey);
-    // comes from react router redux: doing this moves to the route at path
-    push(path);
+    console.log(params);
+    // comes from react router redux: doing this moves to the route at path  (might consider going back to history since we need withRouter)
+    push(generatePath(path, params));
   }
 
   previousPage() {
-    const { pageList, pageKey, push } = this.props;
+    const { pageList, pageKey, push, match: { params } } = this.props;
     const path = getPreviousPagePath(pageList, pageKey);
     // push comes from react router redux : doing this moves to the route at path
-    push(path);
+    push(generatePath(path, params));
   }
 
   render() {
@@ -72,10 +75,11 @@ WizardPage.propTypes = {
   pageList: PropTypes.arrayOf(PropTypes.string).isRequired,
   pageKey: PropTypes.string.isRequired,
   push: PropTypes.func,
+  match: PropTypes.object, //from withRouter
 };
 
 function mapDispatchToProps(dispatch) {
   return bindActionCreators({ push }, dispatch);
 }
 
-export default connect(null, mapDispatchToProps)(WizardPage);
+export default withRouter(connect(null, mapDispatchToProps)(WizardPage));

--- a/src/shared/WizardPage/index.jsx
+++ b/src/shared/WizardPage/index.jsx
@@ -1,5 +1,8 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import { push } from 'react-router-redux';
 
 import {
   getNextPagePath,
@@ -8,7 +11,7 @@ import {
   isLastPage,
 } from './utils';
 
-class WizardPage extends Component {
+export class WizardPage extends Component {
   constructor(props) {
     super(props);
     this.nextPage = this.nextPage.bind(this);
@@ -19,17 +22,17 @@ class WizardPage extends Component {
   }
 
   nextPage() {
-    const { pageList, pageKey, history } = this.props;
+    const { pageList, pageKey, push } = this.props;
     const path = getNextPagePath(pageList, pageKey);
-    // history comes from react router: doing this moves to the route at path
-    history.push(path);
+    // comes from react router redux: doing this moves to the route at path
+    push(path);
   }
 
   previousPage() {
-    const { pageList, pageKey, history } = this.props;
+    const { pageList, pageKey, push } = this.props;
     const path = getPreviousPagePath(pageList, pageKey);
-    // history comes from react router: doing this moves to the route at path
-    history.push(path);
+    // push comes from react router redux : doing this moves to the route at path
+    push(path);
   }
 
   render() {
@@ -68,6 +71,11 @@ WizardPage.propTypes = {
   handleSubmit: PropTypes.func.isRequired,
   pageList: PropTypes.arrayOf(PropTypes.string).isRequired,
   pageKey: PropTypes.string.isRequired,
+  push: PropTypes.func,
 };
 
-export default WizardPage;
+function mapDispatchToProps(dispatch) {
+  return bindActionCreators({ push }, dispatch);
+}
+
+export default connect(null, mapDispatchToProps)(WizardPage);

--- a/src/shared/WizardPage/index.jsx
+++ b/src/shared/WizardPage/index.jsx
@@ -26,7 +26,6 @@ export class WizardPage extends Component {
   nextPage() {
     const { pageList, pageKey, push, match: { params } } = this.props;
     const path = getNextPagePath(pageList, pageKey);
-    console.log(params);
     // comes from react router redux: doing this moves to the route at path  (might consider going back to history since we need withRouter)
     push(generatePath(path, params));
   }

--- a/src/shared/WizardPage/index.test.js
+++ b/src/shared/WizardPage/index.test.js
@@ -14,6 +14,7 @@ describe('given a WizardPage', () => {
           pageList={pageList}
           pageKey="1"
           push={mockPush}
+          match={{}}
         >
           <div>This is page 1</div>
         </WizardPage>,
@@ -65,6 +66,7 @@ describe('given a WizardPage', () => {
           pageList={pageList}
           pageKey="2"
           push={mockPush}
+          match={{}}
         >
           <div>This is page 2</div>
         </WizardPage>,
@@ -124,6 +126,7 @@ describe('given a WizardPage', () => {
           pageList={pageList}
           pageKey="3"
           push={mockPush}
+          match={{}}
         >
           <div>This is page 3</div>
         </WizardPage>,

--- a/src/shared/WizardPage/index.test.js
+++ b/src/shared/WizardPage/index.test.js
@@ -1,19 +1,19 @@
 import React from 'react';
 import { mount, shallow } from 'enzyme';
-import WizardPage from 'shared/WizardPage';
+import { WizardPage } from 'shared/WizardPage';
 describe('given a WizardPage', () => {
-  let wrapper, buttons, history;
+  let wrapper, buttons;
   const pageList = ['1', '2', '3'];
   const submit = jest.fn();
+  const mockPush = jest.fn();
   describe('when on the first page', () => {
     beforeEach(() => {
-      history = [];
       wrapper = shallow(
         <WizardPage
           handleSubmit={submit}
           pageList={pageList}
           pageKey="1"
-          history={history}
+          push={mockPush}
         >
           <div>This is page 1</div>
         </WizardPage>,
@@ -49,21 +49,22 @@ describe('given a WizardPage', () => {
         const nextButton = buttons.last();
         nextButton.simulate('click');
       });
-      it('history gets the next page', () => {
-        expect(history[0]).toBe('2');
+      it('push gets the next page', () => {
+        expect(mockPush.mock.calls.length).toBe(1);
+        expect(mockPush.mock.calls[0][0]).toBe('2');
       });
     });
   });
 
   describe('when on the middle page', () => {
     beforeEach(() => {
-      history.length = 0;
+      mockPush.mockClear();
       wrapper = shallow(
         <WizardPage
           handleSubmit={submit}
           pageList={pageList}
           pageKey="2"
-          history={history}
+          push={mockPush}
         >
           <div>This is page 2</div>
         </WizardPage>,
@@ -88,8 +89,9 @@ describe('given a WizardPage', () => {
         const prevButton = buttons.first();
         prevButton.simulate('click');
       });
-      it('history gets the previous page', () => {
-        expect(history[0]).toBe('1');
+      it('push gets the prev page', () => {
+        expect(mockPush.mock.calls.length).toBe(1);
+        expect(mockPush.mock.calls[0][0]).toBe('1');
       });
     });
     it('the save for later button is second and is disabled', () => {
@@ -107,20 +109,21 @@ describe('given a WizardPage', () => {
         const nextButton = buttons.last();
         nextButton.simulate('click');
       });
-      it('history gets the next page', () => {
-        expect(history[0]).toBe('3');
+      it('push gets the next page', () => {
+        expect(mockPush.mock.calls.length).toBe(1);
+        expect(mockPush.mock.calls[0][0]).toBe('3');
       });
     });
   });
   describe('when on the last page', () => {
     beforeEach(() => {
-      history.length = 0;
+      mockPush.mockClear();
       wrapper = shallow(
         <WizardPage
           handleSubmit={submit}
           pageList={pageList}
           pageKey="3"
-          history={history}
+          push={mockPush}
         >
           <div>This is page 3</div>
         </WizardPage>,
@@ -145,14 +148,15 @@ describe('given a WizardPage', () => {
         const prevButton = buttons.first();
         prevButton.simulate('click');
       });
-      it('history gets the previous page', () => {
-        expect(history[0]).toBe('2');
+      it('push gets the prev page', () => {
+        expect(mockPush.mock.calls.length).toBe(1);
+        expect(mockPush.mock.calls[0][0]).toBe('2');
       });
     });
     it('the save for later button is second and is disabled', () => {
-      const prevButton = buttons.at(1);
-      expect(prevButton.text()).toBe('Save for later');
-      expect(prevButton.prop('disabled')).toBe(true);
+      const saveButton = buttons.at(1);
+      expect(saveButton.text()).toBe('Save for later');
+      expect(saveButton.prop('disabled')).toBe(true);
     });
     it('the Complete button is last and is enabled', () => {
       const nextButton = buttons.last();


### PR DESCRIPTION
## Description

Sets up routes for move flow with placeholders for the PPM screens and the Legalese/Agreement at the end.

## Reviewer Notes

Some additional cleanup happened in this branch to deal with annoyances/unhandled situations:

- WizardPage now handles route parameters
- PrivateRoute now can handle render prop or children nodes
- Private Routes no longer redirect users to landing page, but indicate that current location requires a log in.
- If an unsupported route is used (e.g. '~/thisIsNotASupportedRoute', you get a useful page instead of an empty one.

## Verification Steps

* [ ] All tests pass.
* [n/a ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely) have been satisfied.
* [ ] There are no [aXe](https://www.deque.com/products/aXe/) warnings for UI.
* [ ] This works in IE.

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/155870254) for this change


## Screenshots

### Not logged in
![image](https://user-images.githubusercontent.com/3142631/37361611-b6d68040-26c9-11e8-83ea-b0ab8b73790f.png)

### No match for url
![image](https://user-images.githubusercontent.com/3142631/37361638-d00e05c4-26c9-11e8-8f72-857cd943d8c1.png)

### Routes
![ppm-routes](https://user-images.githubusercontent.com/3142631/37361893-52ad4db4-26ca-11e8-93af-f26cfe030235.gif)
