### PR TITLE
Adds index moves route and handler [finishes #155838087]

### DIFF
--- a/cmd/webserver/main.go
+++ b/cmd/webserver/main.go
@@ -114,6 +114,7 @@ func main() {
 	internalAPI.ShipmentsIndexShipmentsHandler = handlers.IndexShipmentsHandler(handlerContext)
 
 	internalAPI.MovesCreateMoveHandler = handlers.CreateMoveHandler(handlerContext)
+	internalAPI.MovesIndexMovesHandler = handlers.NewIndexMovesHandler(dbConnection, logger)
 
 	// Serves files out of build folder
 	clientHandler := http.FileServer(http.Dir(*build))

--- a/cmd/webserver/main.go
+++ b/cmd/webserver/main.go
@@ -114,7 +114,7 @@ func main() {
 	internalAPI.ShipmentsIndexShipmentsHandler = handlers.IndexShipmentsHandler(handlerContext)
 
 	internalAPI.MovesCreateMoveHandler = handlers.CreateMoveHandler(handlerContext)
-	internalAPI.MovesIndexMovesHandler = handlers.NewIndexMovesHandler(dbConnection, logger)
+	internalAPI.MovesIndexMovesHandler = handlers.IndexMovesHandler(handlerContext)
 
 	// Serves files out of build folder
 	clientHandler := http.FileServer(http.Dir(*build))

--- a/pkg/handlers/moves.go
+++ b/pkg/handlers/moves.go
@@ -67,7 +67,6 @@ func NewIndexMovesHandler(db *pop.Connection, logger *zap.Logger) IndexMovesHand
 
 // Handle retrieves a list of all moves in the system belonging to the logged in user
 func (h IndexMovesHandler) Handle(params moveop.IndexMovesParams) middleware.Responder {
-	var moves models.Moves
 	var response middleware.Responder
 
 	user, err := models.GetUserFromRequest(h.db, params.HTTPRequest)
@@ -76,8 +75,8 @@ func (h IndexMovesHandler) Handle(params moveop.IndexMovesParams) middleware.Res
 		return response
 	}
 
-	query := h.db.Where("user_id = ?", user.ID)
-	if err := query.All(&moves); err != nil {
+	moves, err := models.GetMovesForUserID(h.db, user.ID)
+	if err != nil {
 		h.logger.Error("DB Query", zap.Error(err))
 		response = moveop.NewIndexMovesBadRequest()
 	} else {

--- a/pkg/handlers/moves.go
+++ b/pkg/handlers/moves.go
@@ -52,18 +52,7 @@ func (h CreateMoveHandler) Handle(params moveop.CreateMoveParams) middleware.Res
 }
 
 // IndexMovesHandler returns a list of all moves
-type IndexMovesHandler struct {
-	db     *pop.Connection
-	logger *zap.Logger
-}
-
-// NewIndexMovesHandler returns a new IndexMovesHandler
-func NewIndexMovesHandler(db *pop.Connection, logger *zap.Logger) IndexMovesHandler {
-	return IndexMovesHandler{
-		db:     db,
-		logger: logger,
-	}
-}
+type IndexMovesHandler HandlerContext
 
 // Handle retrieves a list of all moves in the system belonging to the logged in user
 func (h IndexMovesHandler) Handle(params moveop.IndexMovesParams) middleware.Responder {

--- a/pkg/handlers/moves_test.go
+++ b/pkg/handlers/moves_test.go
@@ -115,7 +115,7 @@ func (suite *HandlerSuite) TestIndexMovesHandler() {
 	indexMovesParams.HTTPRequest = req.WithContext(ctx)
 
 	// And: All moves are queried
-	indexHandler := NewIndexMovesHandler(suite.db, suite.logger)
+	indexHandler := IndexMovesHandler(NewHandlerContext(suite.db, suite.logger))
 	indexResponse := indexHandler.Handle(indexMovesParams)
 
 	// Then: Expect a 200 status code
@@ -158,7 +158,7 @@ func (suite *HandlerSuite) TestIndexMovesHandlerNoUser() {
 	indexMovesParams.HTTPRequest = req
 
 	// And: All moves are queried
-	indexHandler := NewIndexMovesHandler(suite.db, suite.logger)
+	indexHandler := IndexMovesHandler(NewHandlerContext(suite.db, suite.logger))
 	indexResponse := indexHandler.Handle(indexMovesParams)
 
 	// Then: Expect a 401 unauthorized
@@ -201,7 +201,7 @@ func (suite *HandlerSuite) TestIndexMovesWrongUser() {
 	indexMovesParams.HTTPRequest = req.WithContext(ctx)
 
 	// And: All moves are queried
-	indexHandler := NewIndexMovesHandler(suite.db, suite.logger)
+	indexHandler := IndexMovesHandler(NewHandlerContext(suite.db, suite.logger))
 	indexResponse := indexHandler.Handle(indexMovesParams)
 
 	// Then: Expect a 200 status code

--- a/pkg/handlers/moves_test.go
+++ b/pkg/handlers/moves_test.go
@@ -87,3 +87,129 @@ func (suite *HandlerSuite) TestCreateMoveHandlerNoUserID() {
 		t.Errorf("Expected to find no moves but found %v", len(moves))
 	}
 }
+
+func (suite *HandlerSuite) TestIndexMovesHandler() {
+	t := suite.T()
+
+	// Given: A move and a user
+	userUUID, _ := uuid.FromString("2400c3c5-019d-4031-9c27-8a553e022297")
+	user := models.User{
+		LoginGovUUID:  userUUID,
+		LoginGovEmail: "email@example.com",
+	}
+	suite.mustSave(&user)
+
+	move := models.Move{
+		UserID:           user.ID,
+		SelectedMoveType: "HHG",
+	}
+	suite.mustSave(&move)
+
+	req := httptest.NewRequest("GET", "/moves", nil)
+
+	indexMovesParams := moveop.NewIndexMovesParams()
+
+	// And: the context contains the auth values
+	ctx := req.Context()
+	ctx = context.PopulateAuthContext(ctx, user.ID, "fake token")
+	indexMovesParams.HTTPRequest = req.WithContext(ctx)
+
+	// And: All moves are queried
+	indexHandler := NewIndexMovesHandler(suite.db, suite.logger)
+	indexResponse := indexHandler.Handle(indexMovesParams)
+
+	// Then: Expect a 200 status code
+	okResponse := indexResponse.(*moveop.IndexMovesOK)
+	moves := okResponse.Payload
+
+	// And: Returned query to include our posted issue
+	moveExists := false
+	for _, move := range moves {
+		if move.UserID.String() == user.ID.String() {
+			moveExists = true
+			break
+		}
+	}
+
+	if !moveExists {
+		t.Errorf("Expected an move to have user ID '%v'. None do.", user.ID)
+	}
+}
+
+func (suite *HandlerSuite) TestIndexMovesHandlerNoUser() {
+	t := suite.T()
+
+	// Given: A move with a user that isn't logged in
+	userUUID, _ := uuid.FromString("2400c3c5-019d-4031-9c27-8a553e022297")
+	user := models.User{
+		LoginGovUUID:  userUUID,
+		LoginGovEmail: "email@example.com",
+	}
+	suite.mustSave(&user)
+
+	move := models.Move{
+		UserID:           user.ID,
+		SelectedMoveType: "HHG",
+	}
+	suite.mustSave(&move)
+
+	req := httptest.NewRequest("GET", "/moves", nil)
+	indexMovesParams := moveop.NewIndexMovesParams()
+	indexMovesParams.HTTPRequest = req
+
+	// And: All moves are queried
+	indexHandler := NewIndexMovesHandler(suite.db, suite.logger)
+	indexResponse := indexHandler.Handle(indexMovesParams)
+
+	// Then: Expect a 401 unauthorized
+	_, ok := indexResponse.(*moveop.IndexMovesUnauthorized)
+	if !ok {
+		t.Errorf("Expected to get an unauthorized response, but got something else.")
+	}
+}
+
+func (suite *HandlerSuite) TestIndexMovesWrongUser() {
+	t := suite.T()
+
+	// Given: A move with a user and a separate logged in user
+	userUUID, _ := uuid.FromString("2400c3c5-019d-4031-9c27-8a553e022297")
+	user := models.User{
+		LoginGovUUID:  userUUID,
+		LoginGovEmail: "email@example.com",
+	}
+	suite.mustSave(&user)
+
+	userUUID2, _ := uuid.FromString("3511d4d6-019d-4031-9c27-8a553e055543")
+	user2 := models.User{
+		LoginGovUUID:  userUUID2,
+		LoginGovEmail: "email2@example.com",
+	}
+	suite.mustSave(&user2)
+
+	move := models.Move{
+		UserID:           user.ID,
+		SelectedMoveType: "HHG",
+	}
+	suite.mustSave(&move)
+
+	req := httptest.NewRequest("GET", "/moves", nil)
+	indexMovesParams := moveop.NewIndexMovesParams()
+
+	// And: the context contains the auth values for user 2
+	ctx := req.Context()
+	ctx = context.PopulateAuthContext(ctx, user2.ID, "fake token")
+	indexMovesParams.HTTPRequest = req.WithContext(ctx)
+
+	// And: All moves are queried
+	indexHandler := NewIndexMovesHandler(suite.db, suite.logger)
+	indexResponse := indexHandler.Handle(indexMovesParams)
+
+	// Then: Expect a 200 status code
+	okResponse := indexResponse.(*moveop.IndexMovesOK)
+	moves := okResponse.Payload
+
+	// And: No moves should be returned
+	if len(moves) != 0 {
+		t.Errorf("Expected no moves to be found, but found %v", len(moves))
+	}
+}

--- a/pkg/handlers/moves_test.go
+++ b/pkg/handlers/moves_test.go
@@ -122,7 +122,7 @@ func (suite *HandlerSuite) TestIndexMovesHandler() {
 	okResponse := indexResponse.(*moveop.IndexMovesOK)
 	moves := okResponse.Payload
 
-	// And: Returned query to include our posted issue
+	// And: Returned query to include our added move
 	moveExists := false
 	for _, move := range moves {
 		if move.UserID.String() == user.ID.String() {

--- a/pkg/models/move.go
+++ b/pkg/models/move.go
@@ -62,3 +62,11 @@ func GetMoveByID(db *pop.Connection, id uuid.UUID) (Move, error) {
 	err := db.Find(&move, id)
 	return move, err
 }
+
+// GetMovesForUserID gets all move models for a given user ID
+func GetMovesForUserID(db *pop.Connection, userID uuid.UUID) (Moves, error) {
+	var moves Moves
+	query := db.Where("user_id = $1", userID)
+	err := query.All(&moves)
+	return moves, err
+}

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -142,6 +142,21 @@ paths:
           description: request requires user authentication
         403:
           description: user is not authorized to sign for this move
+    get:
+      summary: List all moves
+      description: List all moves
+      operationId: indexMoves
+      tags:
+        - moves
+      responses:
+        200:
+          description: list of moves
+          schema:
+            $ref: '#/definitions/IndexMovesPayload'
+        400:
+          description: invalid request
+        401:
+          description: request requires user authentication
   /moves/{moveId}/signed_certification:
     post:
       summary: Submits signed certification for the given move ID
@@ -429,6 +444,10 @@ definitions:
       HHG: Household Goods Move
       PPM: Personal Property Move
       COMBO: Both HHG and PPM
+  IndexMovesPayload:
+    type: array
+    items:
+      $ref: '#/definitions/MovePayload'
   CreateSignedCertificationPayload:
     type: object
     properties:


### PR DESCRIPTION
## Description

Building on top of @amitch23's PR that sets up the create `move` route, this sets up a `GET` route at `/moves` for retrieval of all moves tied to the user account that the request is made with.

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Verification Steps

* [ ] All tests pass.
* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely) have been satisfied.

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/155838087) for this change
