### PR TITLE
using ${CIRCLECI-} to give default empty value

### DIFF
--- a/bin/prereqs
+++ b/bin/prereqs
@@ -30,7 +30,7 @@ if [[ $(uname -s) = Darwin ]]; then
 fi
 
 # not on CircleCI
-if [[ -z $CIRCLECI ]]; then
+if [[ -z ${CIRCLECI-} ]]; then
     has direnv "brew install direnv"
 fi
 


### PR DESCRIPTION
## Description

Without this change, running `make prereqs` when there is no env var $CIRCLECI will result in the following error:
```bin/prereqs: line 33: CIRCLECI: unbound variable```

## Verification Steps

* [x] Can run `make prereqs` in environment where $CIRCLECI isn't set

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/155978214) for this change
* [this article](https://vaneyckt.io/posts/safer_bash_scripts_with_set_euxo_pipefail/) explains more about the approach used.
