### PR TITLE
WizardPage uses pageIsValid prop to enable/disable complete button

### DIFF
--- a/src/shared/WizardPage/index.jsx
+++ b/src/shared/WizardPage/index.jsx
@@ -69,7 +69,9 @@ export class WizardPage extends Component {
             </button>
           )}
           {isLastPage(pageList, pageKey) && (
-            <button onClick={handleSubmit}>Complete</button>
+            <button onClick={handleSubmit} disabled={!pageIsValid}>
+              Complete
+            </button>
           )}
         </div>
       </div>

--- a/src/shared/WizardPage/index.test.js
+++ b/src/shared/WizardPage/index.test.js
@@ -8,28 +8,55 @@ describe('given a WizardPage', () => {
   const mockPush = jest.fn();
   describe('when there is a pageIsValid prop set', () => {
     describe('when pageIsValid is false', () => {
-      beforeEach(() => {
-        history = [];
-        const continueToNextPage = false;
+      describe('when on the first page', () => {
+        beforeEach(() => {
+          history = [];
+          const continueToNextPage = false;
 
-        wrapper = shallow(
-          <WizardPage
-            handleSubmit={submit}
-            pageList={pageList}
-            pageKey="1"
-            history={history}
-            pageIsValid={continueToNextPage}
-            match={{}}
-          >
-            <div>This is page 1</div>
-          </WizardPage>,
-        );
-        buttons = wrapper.find('button');
+          wrapper = shallow(
+            <WizardPage
+              handleSubmit={submit}
+              pageList={pageList}
+              pageKey="1"
+              history={history}
+              pageIsValid={continueToNextPage}
+              match={{}}
+            >
+              <div>This is page 1</div>
+            </WizardPage>,
+          );
+          buttons = wrapper.find('button');
+        });
+        it('the next button is last and is disabled', () => {
+          const nextButton = buttons.last();
+          expect(nextButton.text()).toBe('Next');
+          expect(nextButton.prop('disabled')).toBeTruthy();
+        });
       });
-      it('the next button is last and is disabled', () => {
-        const nextButton = buttons.last();
-        expect(nextButton.text()).toBe('Next');
-        expect(nextButton.prop('disabled')).toBeTruthy();
+      describe('when on the last page', () => {
+        beforeEach(() => {
+          history = [];
+          const pageIsValid = false;
+
+          wrapper = shallow(
+            <WizardPage
+              handleSubmit={submit}
+              pageList={pageList}
+              pageKey="3"
+              history={history}
+              pageIsValid={pageIsValid}
+              match={{}}
+            >
+              <div>This is page 1</div>
+            </WizardPage>,
+          );
+          buttons = wrapper.find('button');
+        });
+        it('the complete button is last and is disabled', () => {
+          const nextButton = buttons.last();
+          expect(nextButton.text()).toBe('Complete');
+          expect(nextButton.prop('disabled')).toBeTruthy();
+        });
       });
     });
     describe('when pageIsValid is true', () => {


### PR DESCRIPTION
## Description

The wizard page component now uses prop `pageIsValid` that controls whether the complete button is enabled.
 
## Reviewer Notes

We don't currently have a wizard in the flow that needs this yet, but the unit tests cover it pretty well. 
## Verification Steps

* [ ] All tests pass.

## References
* [Pivotal story](https://www.pivotaltracker.com/story/show/155984747) for this change
