### PR TITLE
add command to view test coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 
 # testing
 /coverage
+coverage.out
 __snapshots__
 
 # production

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,8 @@ client_run: client_deps
 	yarn start
 client_test: client_deps
 	yarn test
+client_test_coverage : client_deps
+	yarn test:coverage
 
 server_deps_update: server_generate
 	dep ensure -v -update

--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,15 @@ server_test: server_deps server_generate db_dev_run db_test_reset
 	# Disable test caching with `-count 1` - caching was masking local test failures
 	go test -p 1 -count 1 $$(go list ./... | grep -v \\/pkg\\/gen\\/ | grep -v \\/cmd\\/)
 
+server_test_coverage: server_deps server_generate db_dev_run db_test_reset
+	# Don't run tests in /cmd or /pkg/gen
+	# Use -test.parallel 1 to test packages serially and avoid database collisions
+	# Disable test caching with `-count 1` - caching was masking local test failures
+	# Add coverage tracker via go cover
+	# Then open coverage tracker in HTML
+	go test -coverprofile=coverage.out -p 1 -count 1 $$(go list ./... | grep -v \\/pkg\\/gen\\/ | grep -v \\/cmd\\/)
+	go tool cover -html=coverage.out
+
 e2e_test: client_deps
 	yarn e2e-test
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "start": "NODE_PATH=./src react-scripts start",
     "test": "NODE_PATH=./src react-scripts test --env=jsdom",
     "test:debug": "NODE_PATH=./src react-scripts --inspect-brk test --runInBand --env=jsdom",
+    "test:coverage": "NODE_PATH=./src react-scripts test --coverage --env=jsdom",
     "e2e-test": "NODE_PATH=./e2e jest ./e2e.test.js --env=jsdom",
     "prettier": "prettier",
     "adr-log": "adr-log -d ./docs/adr -i ./docs/adr/readme.md"


### PR DESCRIPTION
## Description

We'd like to see how much testing coverage our code has. Go has a tool called cover that allows us to do so. It seems to be the most popular tool. I don't think it warrants an ADR. I've implemented here. 

## Reviewer Notes

Try running `make server_test_coverage`.

## Verification Steps

* [x] make server_test_coverage passes and opens an HTML file that shows you Go testing coverage.

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/155918260) for this change
