### PR TITLE
Changes to Shipment model dates [delivers #156059737]

### DIFF
--- a/migrations/20180319220912_add_requested_pickup_date.down.fizz
+++ b/migrations/20180319220912_add_requested_pickup_date.down.fizz
@@ -1,1 +1,2 @@
 drop_column("shipments", "requested_pickup_date")
+rename_column("shipments", "book_date", "award_date")

--- a/migrations/20180319220912_add_requested_pickup_date.down.fizz
+++ b/migrations/20180319220912_add_requested_pickup_date.down.fizz
@@ -1,0 +1,1 @@
+drop_column("shipments", "requested_pickup_date")

--- a/migrations/20180319220912_add_requested_pickup_date.up.fizz
+++ b/migrations/20180319220912_add_requested_pickup_date.up.fizz
@@ -1,1 +1,2 @@
 add_column("shipments", "requested_pickup_date", "datetime", {})
+rename_column("shipments", "award_date", "book_date")

--- a/migrations/20180319220912_add_requested_pickup_date.up.fizz
+++ b/migrations/20180319220912_add_requested_pickup_date.up.fizz
@@ -1,0 +1,1 @@
+add_column("shipments", "requested_pickup_date", "datetime", {})

--- a/pkg/awardqueue/awardqueue.go
+++ b/pkg/awardqueue/awardqueue.go
@@ -47,14 +47,14 @@ func (aq *AwardQueue) attemptShipmentAward(shipment models.PossiblyAwardedShipme
 	// We _also_ want to watch out for infinite loops, because if all the TSPs in the selection
 	// have blackout dates (imagine a 1-TSP-TDL, with a blackout date) we will keep awarding
 	// administrative shipments forever.
-	firstEligibleTSPPerformance, err := models.NextEligibleTSPPerformance(aq.db, tdl.ID, shipment.AwardDate)
+	firstEligibleTSPPerformance, err := models.NextEligibleTSPPerformance(aq.db, tdl.ID, shipment.BookDate)
 	firstTSPid := firstEligibleTSPPerformance.ID
 	foundAvailableTSP := false
 	loopCount := 0
 
 	for !foundAvailableTSP {
 
-		tspPerformance, err := models.NextEligibleTSPPerformance(aq.db, tdl.ID, shipment.AwardDate)
+		tspPerformance, err := models.NextEligibleTSPPerformance(aq.db, tdl.ID, shipment.BookDate)
 
 		if loopCount != 0 && tspPerformance.ID == firstTSPid {
 			return nil, fmt.Errorf("Could not find a TSP without blackout dates in %d tries", loopCount)

--- a/pkg/awardqueue/awardqueue_test.go
+++ b/pkg/awardqueue/awardqueue_test.go
@@ -27,7 +27,7 @@ func (suite *AwardQueueSuite) Test_CheckAllTSPsBlackedOut() {
 
 	pickupDate := blackoutStartDate.Add(time.Hour)
 	deliverDate := blackoutStartDate.Add(time.Hour * 24 * 60)
-	shipment, _ := testdatagen.MakeShipment(suite.db, pickupDate, deliverDate, tdl)
+	shipment, _ := testdatagen.MakeShipment(suite.db, pickupDate, pickupDate, deliverDate, tdl)
 
 	// Create a PossiblyAwardedShipment to feed the award queue
 	pas := models.PossiblyAwardedShipment{
@@ -38,7 +38,7 @@ func (suite *AwardQueueSuite) Test_CheckAllTSPsBlackedOut() {
 		Accepted:                        nil,
 		RejectionReason:                 nil,
 		AdministrativeShipment:          swag.Bool(false),
-		AwardDate:                       testdatagen.DateInsidePerformancePeriod,
+		BookDate:                        testdatagen.DateInsidePerformancePeriod,
 	}
 
 	// Run the Award Queue
@@ -67,8 +67,8 @@ func (suite *AwardQueueSuite) Test_CheckShipmentDuringBlackOut() {
 	deliverDate := blackoutStartDate.AddDate(0, 0, 5)
 
 	// Create a shipment within blackout dates and one not within blackout dates
-	blackoutShipment, _ := testdatagen.MakeShipment(suite.db, pickupDate, deliverDate, tdl)
-	shipment, _ := testdatagen.MakeShipment(suite.db, time.Now(), time.Now().AddDate(0, 0, 1), tdl)
+	blackoutShipment, _ := testdatagen.MakeShipment(suite.db, pickupDate, pickupDate, deliverDate, tdl)
+	shipment, _ := testdatagen.MakeShipment(suite.db, time.Now(), time.Now(), time.Now().AddDate(0, 0, 1), tdl)
 
 	// Run the Award Queue
 	queue.assignUnawardedShipments()
@@ -155,7 +155,7 @@ func (suite *AwardQueueSuite) Test_AwardSingleShipment() {
 
 	// Make a shipment
 	tdl, _ := testdatagen.MakeTDL(suite.db, "california", "90210", "2")
-	shipment, _ := testdatagen.MakeShipment(suite.db, time.Now(), time.Now(), tdl)
+	shipment, _ := testdatagen.MakeShipment(suite.db, time.Now(), time.Now(), time.Now(), tdl)
 
 	// Make a TSP to handle it
 	tsp, _ := testdatagen.MakeTSP(suite.db, "Test Shipper", "TEST")
@@ -170,7 +170,7 @@ func (suite *AwardQueueSuite) Test_AwardSingleShipment() {
 		Accepted:                        nil,
 		RejectionReason:                 nil,
 		AdministrativeShipment:          swag.Bool(false),
-		AwardDate:                       shipment.AwardDate,
+		BookDate:                        shipment.BookDate,
 	}
 
 	// Run the Award Queue
@@ -192,7 +192,7 @@ func (suite *AwardQueueSuite) Test_FailAwardingSingleShipment() {
 
 	// Make a shipment in a new TDL, which inherently has no TSPs
 	tdl, _ := testdatagen.MakeTDL(suite.db, "california", "90210", "2")
-	shipment, _ := testdatagen.MakeShipment(suite.db, time.Now(), time.Now(), tdl)
+	shipment, _ := testdatagen.MakeShipment(suite.db, time.Now(), time.Now(), time.Now(), tdl)
 
 	// Create a PossiblyAwardedShipment to feed the award queue
 	pas := models.PossiblyAwardedShipment{
@@ -226,7 +226,7 @@ func (suite *AwardQueueSuite) Test_AwardAssignUnawardedShipmentsSingleTSP() {
 
 	// Make a few shipments in this TDL
 	for i := 0; i < shipmentsToMake; i++ {
-		testdatagen.MakeShipment(suite.db, time.Now(), time.Now(), tdl)
+		testdatagen.MakeShipment(suite.db, time.Now(), time.Now(), time.Now(), tdl)
 	}
 
 	// Make a TSP in the same TDL to handle these shipments
@@ -263,7 +263,7 @@ func (suite *AwardQueueSuite) Test_AwardAssignUnawardedShipmentsToMultipleTSPs()
 
 	// Make shipments in this TDL
 	for i := 0; i < shipmentsToMake; i++ {
-		testdatagen.MakeShipment(suite.db, time.Now(), time.Now(), tdl)
+		testdatagen.MakeShipment(suite.db, time.Now(), time.Now(), time.Now(), tdl)
 	}
 
 	// Make TSPs in the same TDL to handle these shipments

--- a/pkg/models/shipment.go
+++ b/pkg/models/shipment.go
@@ -16,8 +16,9 @@ type Shipment struct {
 	CreatedAt                 time.Time `json:"created_at" db:"created_at"`
 	UpdatedAt                 time.Time `json:"updated_at" db:"updated_at"`
 	PickupDate                time.Time `json:"pickup_date" db:"pickup_date"`
+	RequestedPickupDate       time.Time `json:"requested_pickup_date" db:"requested_pickup_date"`
 	DeliveryDate              time.Time `json:"delivery_date" db:"delivery_date"`
-	AwardDate                 time.Time `json:"award_date" db:"award_date"`
+	BookDate                  time.Time `json:"book_date" db:"book_date"`
 	TrafficDistributionListID uuid.UUID `json:"traffic_distribution_list_id" db:"traffic_distribution_list_id"`
 	GBLOC                     string    `json:"gbloc" db:"gbloc"`
 	Market                    *string   `json:"market" db:"market"`
@@ -28,9 +29,10 @@ type PossiblyAwardedShipment struct {
 	ID                              uuid.UUID  `db:"id"`
 	CreatedAt                       time.Time  `db:"created_at"`
 	UpdatedAt                       time.Time  `db:"updated_at"`
-	AwardDate                       time.Time  `json:"award_date" db:"award_date"`
+	BookDate                        time.Time  `json:"book_date" db:"book_date"`
 	TrafficDistributionListID       uuid.UUID  `db:"traffic_distribution_list_id"`
 	PickupDate                      time.Time  `json:"pickup_date" db:"pickup_date"`
+	RequestedPickupDate             time.Time  `json:"requested_pickup_date" db:"requested_pickup_date"`
 	TransportationServiceProviderID *uuid.UUID `db:"transportation_service_provider_id"`
 	Accepted                        *bool      `json:"accepted" db:"accepted"`
 	RejectionReason                 *string    `json:"rejection_reason" db:"rejection_reason"`
@@ -46,7 +48,7 @@ func FetchPossiblyAwardedShipments(dbConnection *pop.Connection) ([]PossiblyAwar
 				shipments.created_at,
 				shipments.updated_at,
 				shipments.pickup_date,
-				shipments.award_date,
+				shipments.book_date,
 				shipments.traffic_distribution_list_id,
 				shipment_awards.transportation_service_provider_id,
 				shipment_awards.administrative_shipment
@@ -72,7 +74,7 @@ func FetchUnawardedShipments(dbConnection *pop.Connection) ([]PossiblyAwardedShi
 				shipments.created_at,
 				shipments.updated_at,
 				shipments.pickup_date,
-				shipments.award_date,
+				shipments.book_date,
 				shipments.traffic_distribution_list_id,
 				shipment_awards.transportation_service_provider_id
 			FROM shipments

--- a/pkg/models/shipment.go
+++ b/pkg/models/shipment.go
@@ -11,6 +11,10 @@ import (
 )
 
 // Shipment represents a single shipment within a Service Member's move.
+// PickupDate: when the shipment is currently scheduled to be picked up by the TSP
+// RequestedPickupDate: when the shipment was originally scheduled to be picked up
+// DeliveryDate: when the shipment is to be delivered
+// BookDate: when the shipment was most recently offered to a TSP
 type Shipment struct {
 	ID                        uuid.UUID `json:"id" db:"id"`
 	CreatedAt                 time.Time `json:"created_at" db:"created_at"`

--- a/pkg/models/shipment_award_test.go
+++ b/pkg/models/shipment_award_test.go
@@ -23,7 +23,7 @@ func (suite *ModelSuite) Test_CreateShipmentAward() {
 	now := time.Now()
 	tdl, _ := testdatagen.MakeTDL(suite.db, "california", "90210", "2")
 	tsp, _ := testdatagen.MakeTSP(suite.db, "Test TSP 1", "TSP1")
-	shipment, _ := testdatagen.MakeShipment(suite.db, now, now.AddDate(0, 0, 1), tdl)
+	shipment, _ := testdatagen.MakeShipment(suite.db, now, now, now.AddDate(0, 0, 1), tdl)
 	shipmentAward, err := CreateShipmentAward(suite.db, shipment.ID, tsp.ID, false)
 
 	if err != nil {

--- a/pkg/models/shipment_test.go
+++ b/pkg/models/shipment_test.go
@@ -23,9 +23,9 @@ func (suite *ModelSuite) Test_FetchPossiblyAwardedShipments() {
 	now := time.Now()
 	tdl, _ := testdatagen.MakeTDL(suite.db, "california", "90210", "2")
 	// Make a shipment to award
-	shipment, _ := testdatagen.MakeShipment(suite.db, now, now.AddDate(0, 0, 1), tdl)
+	shipment, _ := testdatagen.MakeShipment(suite.db, now, now, now.AddDate(0, 0, 1), tdl)
 	// Make a shipment not to award
-	shipment2, _ := testdatagen.MakeShipment(suite.db, now, now.AddDate(0, 0, 1), tdl)
+	shipment2, _ := testdatagen.MakeShipment(suite.db, now, now, now.AddDate(0, 0, 1), tdl)
 	tsp, _ := testdatagen.MakeTSP(suite.db, "Test TSP 1", "TSP1")
 	// Award one of the shipments
 	CreateShipmentAward(suite.db, shipment.ID, tsp.ID, false)
@@ -46,8 +46,8 @@ func (suite *ModelSuite) Test_FetchUnawardedShipments() {
 	t := suite.T()
 	now := time.Now()
 	tdl, _ := testdatagen.MakeTDL(suite.db, "california", "90210", "2")
-	shipment, _ := testdatagen.MakeShipment(suite.db, now, now.AddDate(0, 0, 1), tdl)
-	shipment2, _ := testdatagen.MakeShipment(suite.db, now, now.AddDate(0, 0, 1), tdl)
+	shipment, _ := testdatagen.MakeShipment(suite.db, now, now, now.AddDate(0, 0, 1), tdl)
+	shipment2, _ := testdatagen.MakeShipment(suite.db, now, now, now.AddDate(0, 0, 1), tdl)
 	tsp, _ := testdatagen.MakeTSP(suite.db, "Test TSP 1", "TSP1")
 	// Award one of the shipments
 	CreateShipmentAward(suite.db, shipment.ID, tsp.ID, false)

--- a/pkg/models/transportation_service_provider_performance.go
+++ b/pkg/models/transportation_service_provider_performance.go
@@ -79,7 +79,7 @@ func (t *TransportationServiceProviderPerformance) Validate(tx *pop.Connection) 
 
 // NextTSPPerformanceInQualityBand returns the TSP performance record in a given TDL
 // and Quality Band that will next be awarded a shipment.
-func NextTSPPerformanceInQualityBand(tx *pop.Connection, tdlID uuid.UUID, qualityBand int, awardDate time.Time) (
+func NextTSPPerformanceInQualityBand(tx *pop.Connection, tdlID uuid.UUID, qualityBand int, bookDate time.Time) (
 	TransportationServiceProviderPerformance, error) {
 
 	sql := `SELECT
@@ -98,16 +98,16 @@ func NextTSPPerformanceInQualityBand(tx *pop.Connection, tdlID uuid.UUID, qualit
 		`
 
 	tspp := TransportationServiceProviderPerformance{}
-	err := tx.RawQuery(sql, tdlID, qualityBand, awardDate).First(&tspp)
+	err := tx.RawQuery(sql, tdlID, qualityBand, bookDate).First(&tspp)
 
 	return tspp, err
 }
 
 // GatherNextEligibleTSPPerformances returns a map of QualityBands to their next eligible TSPPerformance.
-func GatherNextEligibleTSPPerformances(tx *pop.Connection, tdlID uuid.UUID, awardDate time.Time) (map[int]TransportationServiceProviderPerformance, error) {
+func GatherNextEligibleTSPPerformances(tx *pop.Connection, tdlID uuid.UUID, bookDate time.Time) (map[int]TransportationServiceProviderPerformance, error) {
 	tspPerformances := make(map[int]TransportationServiceProviderPerformance)
 	for _, qualityBand := range qualityBands {
-		tspPerformance, err := NextTSPPerformanceInQualityBand(tx, tdlID, qualityBand, awardDate)
+		tspPerformance, err := NextTSPPerformanceInQualityBand(tx, tdlID, qualityBand, bookDate)
 		if err != nil {
 			// We don't want the program to error out if Quality Bands don't have a TSPPerformance.
 			//zap.S().Errorf("\tNo TSP returned for Quality Band: %d\n; See error: %s", qualityBand, err)
@@ -122,9 +122,9 @@ func GatherNextEligibleTSPPerformances(tx *pop.Connection, tdlID uuid.UUID, awar
 }
 
 // NextEligibleTSPPerformance wraps GatherNextEligibleTSPPerformances and DetermineNextTSPPerformance.
-func NextEligibleTSPPerformance(db *pop.Connection, tdlID uuid.UUID, awardDate time.Time) (TransportationServiceProviderPerformance, error) {
+func NextEligibleTSPPerformance(db *pop.Connection, tdlID uuid.UUID, bookDate time.Time) (TransportationServiceProviderPerformance, error) {
 	var tspPerformance TransportationServiceProviderPerformance
-	tspPerformances, err := GatherNextEligibleTSPPerformances(db, tdlID, awardDate)
+	tspPerformances, err := GatherNextEligibleTSPPerformances(db, tdlID, bookDate)
 	if err == nil {
 		return SelectNextTSPPerformance(tspPerformances), nil
 	}

--- a/pkg/testdatagen/make_shipment_records.go
+++ b/pkg/testdatagen/make_shipment_records.go
@@ -10,17 +10,19 @@ import (
 )
 
 // MakeShipment creates a single shipment record.
-func MakeShipment(db *pop.Connection, pickup time.Time, delivery time.Time,
+func MakeShipment(db *pop.Connection, requestedPickup time.Time,
+	pickup time.Time, delivery time.Time,
 	tdl models.TrafficDistributionList) (models.Shipment, error) {
 
 	market := "dHHG"
 	shipment := models.Shipment{
 		TrafficDistributionListID: tdl.ID,
 		PickupDate:                pickup,
+		RequestedPickupDate:       requestedPickup,
 		DeliveryDate:              delivery,
+		BookDate:                  DateInsidePerformancePeriod,
 		GBLOC:                     "AGFM",
 		Market:                    &market,
-		AwardDate:                 DateInsidePerformancePeriod,
 	}
 
 	_, err := db.ValidateAndSave(&shipment)
@@ -47,7 +49,7 @@ func MakeShipmentData(db *pop.Connection) {
 	thirtyMin, _ := time.ParseDuration("30m")
 	oneWeek, _ := time.ParseDuration("7d")
 
-	MakeShipment(db, now, now.Add(thirtyMin), tdlList[0])
-	MakeShipment(db, now.Add(oneWeek), now.Add(oneWeek).Add(thirtyMin), tdlList[1])
-	MakeShipment(db, now.Add(oneWeek*2), now.Add(oneWeek*2).Add(thirtyMin), tdlList[2])
+	MakeShipment(db, now, now, now.Add(thirtyMin), tdlList[0])
+	MakeShipment(db, now.Add(oneWeek), now.Add(oneWeek), now.Add(oneWeek).Add(thirtyMin), tdlList[1])
+	MakeShipment(db, now.Add(oneWeek*2), now.Add(oneWeek*2), now.Add(oneWeek*2).Add(thirtyMin), tdlList[2])
 }

--- a/pkg/testdatagen/scenario_1.go
+++ b/pkg/testdatagen/scenario_1.go
@@ -17,7 +17,7 @@ func RunScenarioOne(db *pop.Connection) {
 
 	// Make shipments in this TDL
 	for i := 0; i < shipmentsToMake; i++ {
-		MakeShipment(db, time.Now(), time.Now(), tdl)
+		MakeShipment(db, time.Now(), time.Now(), time.Now(), tdl)
 	}
 
 	// Make TSPs in the same TDL to handle these shipments

--- a/pkg/testdatagen/scenario_2.go
+++ b/pkg/testdatagen/scenario_2.go
@@ -19,11 +19,11 @@ func RunScenarioTwo(db *pop.Connection) {
 
 	// Make shipments in first TDL
 	for i := 0; i < shipmentsToMake; i++ {
-		MakeShipment(db, shipmentDate, shipmentDate, tdl)
+		MakeShipment(db, shipmentDate, shipmentDate, shipmentDate, tdl)
 	}
 	// Make shipments in second TDL
 	for i := 0; i <= shipmentsToMake; i++ {
-		MakeShipment(db, shipmentDate, shipmentDate, tdl2)
+		MakeShipment(db, shipmentDate, shipmentDate, shipmentDate, tdl2)
 	}
 
 	// Make TSPs


### PR DESCRIPTION
## Description

Two small changes to the `shipments` model:

1. Rename `AwardDate` to `BookDate`, to be more consistent with the terminology I've heard from Amie at USTC.
1. Add `RequestedPickupDate`, since the Customer and TSP can negotiate to change the actual pickup date as needed. The `RequestedPickupDate` is the original date selected.

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Verification Steps

* [ ] All tests pass.

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/156059737) for this change