### PR TITLE
Adds NO_SESSION_TIMEOUT to example envrc

### DIFF
--- a/example_envrc
+++ b/example_envrc
@@ -9,3 +9,6 @@ EOM
 )
 
 export LOGIN_GOV_CLIENT_ID=<login_gov_client_id_value>
+
+# Prevents user sessions from timing out
+export NO_SESSION_TIMEOUT=true


### PR DESCRIPTION
Thought this made it in but the `push` didn't go through