### PR TITLE
Rename a lot of "awards" to "offers" [Finishes #156031299]

### DIFF
--- a/cmd/generate_test_data/main.go
+++ b/cmd/generate_test_data/main.go
@@ -34,7 +34,7 @@ func main() {
 		testdatagen.MakeTDLData(db)
 		testdatagen.MakeTSPs(db, *numTSP)
 		testdatagen.MakeShipmentData(db)
-		testdatagen.MakeShipmentAwardData(db)
+		testdatagen.MakeShipmentOfferData(db)
 		testdatagen.MakeTSPPerformanceData(db, *rounds)
 		testdatagen.MakeBlackoutDateData(db)
 		testdatagen.MakeMoveData(db)

--- a/migrations/20180320184300_rename_shipment_awards_to_offers.down.fizz
+++ b/migrations/20180320184300_rename_shipment_awards_to_offers.down.fizz
@@ -1,0 +1,1 @@
+rename_table("shipment_offers", "shipment_awards")

--- a/migrations/20180320184300_rename_shipment_awards_to_offers.down.fizz
+++ b/migrations/20180320184300_rename_shipment_awards_to_offers.down.fizz
@@ -1,1 +1,2 @@
 rename_table("shipment_offers", "shipment_awards")
+rename_column("transportation_service_provider_performances", "offer_count", "award_count")

--- a/migrations/20180320184300_rename_shipment_awards_to_offers.up.fizz
+++ b/migrations/20180320184300_rename_shipment_awards_to_offers.up.fizz
@@ -1,1 +1,2 @@
 rename_table("shipment_awards", "shipment_offers")
+rename_column("transportation_service_provider_performances", "award_count", "offer_count")

--- a/migrations/20180320184300_rename_shipment_awards_to_offers.up.fizz
+++ b/migrations/20180320184300_rename_shipment_awards_to_offers.up.fizz
@@ -1,0 +1,1 @@
+rename_table("shipment_awards", "shipment_offers")

--- a/pkg/awardqueue/awardqueue.go
+++ b/pkg/awardqueue/awardqueue.go
@@ -32,7 +32,7 @@ type AwardQueue struct {
 	logger *zap.SugaredLogger
 }
 
-func (aq *AwardQueue) findAllUnassignedShipments() ([]models.PossiblyAwardedShipment, error) {
+func (aq *AwardQueue) findAllUnassignedShipments() ([]models.ShipmentWithOffer, error) {
 	shipments, err := models.FetchShipments(aq.db, true)
 	return shipments, err
 }
@@ -40,7 +40,7 @@ func (aq *AwardQueue) findAllUnassignedShipments() ([]models.PossiblyAwardedShip
 // attemptShipmentOffer will attempt to take the given Shipment and award it to
 // a TSP.
 // TODO: refactor this method to ensure the transaction is wrapping what it needs to
-func (aq *AwardQueue) attemptShipmentOffer(shipment models.PossiblyAwardedShipment) (*models.ShipmentOffer, error) {
+func (aq *AwardQueue) attemptShipmentOffer(shipment models.ShipmentWithOffer) (*models.ShipmentOffer, error) {
 	aq.logger.Infof("Attempting to offer shipment: %s", shipment.ID)
 
 	// Query the shipment's TDL
@@ -91,7 +91,7 @@ func (aq *AwardQueue) attemptShipmentOffer(shipment models.PossiblyAwardedShipme
 							aq.logger.Info("Shipment pickup date is during a blackout period. Awarding Administrative Shipment to TSP.")
 						} else {
 							// TODO: AwardCount is off by 1
-							aq.logger.Infof("Shipment offered to TSP! TSP now has %d shipment offers.", tspPerformance.AwardCount+1)
+							aq.logger.Infof("Shipment offered to TSP! TSP now has %d shipment offers.", tspPerformance.OfferCount+1)
 							foundAvailableTSP = true
 						}
 						return nil

--- a/pkg/awardqueue/awardqueue.go
+++ b/pkg/awardqueue/awardqueue.go
@@ -1,3 +1,10 @@
+// Package awardqueue implements the Award Queue mechanism as defined in the
+// following document:
+// https://docs.google.com/document/d/1WEQZya_yVvW6xbPS7j0-7DP8XSoz9DOntLzIv0FAUHM/edit#
+//
+// Note on terminology: while the system is referred to as the "award queue"
+// it is technically awarding "offers" to TSPs, who then need to accept the
+// offer.
 package awardqueue
 
 import (
@@ -25,16 +32,16 @@ type AwardQueue struct {
 	logger *zap.SugaredLogger
 }
 
-func (aq *AwardQueue) findAllUnawardedShipments() ([]models.PossiblyAwardedShipment, error) {
-	shipments, err := models.FetchUnawardedShipments(aq.db)
+func (aq *AwardQueue) findAllUnassignedShipments() ([]models.PossiblyAwardedShipment, error) {
+	shipments, err := models.FetchShipments(aq.db, true)
 	return shipments, err
 }
 
-// AttemptShipmentAward will attempt to take the given Shipment and award it to
+// attemptShipmentOffer will attempt to take the given Shipment and award it to
 // a TSP.
 // TODO: refactor this method to ensure the transaction is wrapping what it needs to
-func (aq *AwardQueue) attemptShipmentAward(shipment models.PossiblyAwardedShipment) (*models.ShipmentAward, error) {
-	aq.logger.Infof("Attempting to award shipment: %s", shipment.ID)
+func (aq *AwardQueue) attemptShipmentOffer(shipment models.PossiblyAwardedShipment) (*models.ShipmentOffer, error) {
+	aq.logger.Infof("Attempting to offer shipment: %s", shipment.ID)
 
 	// Query the shipment's TDL
 	tdl := models.TrafficDistributionList{}
@@ -44,7 +51,7 @@ func (aq *AwardQueue) attemptShipmentAward(shipment models.PossiblyAwardedShipme
 		return nil, errors.Wrap(err, "Cannot find TDL in database")
 	}
 
-	var shipmentAward *models.ShipmentAward
+	var shipmentOffer *models.ShipmentOffer
 
 	// We need to loop here, because if a TSP has a blackout date we need to try again.
 	// We _also_ want to watch out for infinite loops, because if all the TSPs in the selection
@@ -70,31 +77,31 @@ func (aq *AwardQueue) attemptShipmentAward(shipment models.PossiblyAwardedShipme
 		err = aq.db.Transaction(func(tx *pop.Connection) error {
 			tsp := models.TransportationServiceProvider{}
 			if err := aq.db.Find(&tsp, tspPerformance.TransportationServiceProviderID); err == nil {
-				aq.logger.Infof("Attempting to award to TSP: %s", tsp.Name)
+				aq.logger.Infof("Attempting to offer to TSP: %s", tsp.Name)
 
 				isAdministrativeShipment, err := aq.ShipmentWithinBlackoutDates(tsp.ID, shipment.PickupDate)
 				if err != nil {
 					return err
 				}
 
-				shipmentAward, err = models.CreateShipmentAward(aq.db, shipment.ID, tsp.ID, isAdministrativeShipment)
+				shipmentOffer, err = models.CreateShipmentOffer(aq.db, shipment.ID, tsp.ID, isAdministrativeShipment)
 				if err == nil {
 					if err = models.IncrementTSPPerformanceAwardCount(aq.db, tspPerformance.ID); err == nil {
 						if isAdministrativeShipment == true {
 							aq.logger.Info("Shipment pickup date is during a blackout period. Awarding Administrative Shipment to TSP.")
 						} else {
 							// TODO: AwardCount is off by 1
-							aq.logger.Infof("Shipment awarded to TSP! TSP now has %d shipment awards.", tspPerformance.AwardCount+1)
+							aq.logger.Infof("Shipment offered to TSP! TSP now has %d shipment offers.", tspPerformance.AwardCount+1)
 							foundAvailableTSP = true
 						}
 						return nil
 					}
 				} else {
-					aq.logger.Errorf("Failed to award to TSP: %s", err)
+					aq.logger.Errorf("Failed to offer to TSP: %s", err)
 				}
 			}
 
-			aq.logger.Errorf("Failed to award to TSP: %s", err)
+			aq.logger.Errorf("Failed to offer to TSP: %s", err)
 			return err
 		})
 
@@ -103,19 +110,21 @@ func (aq *AwardQueue) attemptShipmentAward(shipment models.PossiblyAwardedShipme
 		}
 	}
 
-	return shipmentAward, err
+	return shipmentOffer, err
 }
 
-func (aq *AwardQueue) assignUnawardedShipments() {
+// assignShipments searches for all shipments that haven't been offered
+// yet to a TSP, and attempts to generate offers for each of them.
+func (aq *AwardQueue) assignShipments() {
 	aq.logger.Info("TSP Award Queue running.")
 
-	shipments, err := aq.findAllUnawardedShipments()
+	shipments, err := aq.findAllUnassignedShipments()
 	if err == nil {
 		count := 0
 		for _, shipment := range shipments {
-			_, err = aq.attemptShipmentAward(shipment)
+			_, err = aq.attemptShipmentOffer(shipment)
 			if err != nil {
-				aq.logger.Errorf("Failed to award shipment: %s", err)
+				aq.logger.Errorf("Failed to offer shipment: %s", err)
 			} else {
 				count++
 			}
@@ -199,7 +208,7 @@ func (aq *AwardQueue) Run() error {
 	}
 
 	// This method should also return an error
-	aq.assignUnawardedShipments()
+	aq.assignShipments()
 	return nil
 }
 

--- a/pkg/awardqueue/awardqueue.go
+++ b/pkg/awardqueue/awardqueue.go
@@ -86,7 +86,7 @@ func (aq *AwardQueue) attemptShipmentOffer(shipment models.ShipmentWithOffer) (*
 
 				shipmentOffer, err = models.CreateShipmentOffer(aq.db, shipment.ID, tsp.ID, isAdministrativeShipment)
 				if err == nil {
-					if err = models.IncrementTSPPerformanceAwardCount(aq.db, tspPerformance.ID); err == nil {
+					if err = models.IncrementTSPPerformanceOfferCount(aq.db, tspPerformance.ID); err == nil {
 						if isAdministrativeShipment == true {
 							aq.logger.Info("Shipment pickup date is during a blackout period. Awarding Administrative Shipment to TSP.")
 						} else {

--- a/pkg/awardqueue/awardqueue.go
+++ b/pkg/awardqueue/awardqueue.go
@@ -90,7 +90,7 @@ func (aq *AwardQueue) attemptShipmentOffer(shipment models.ShipmentWithOffer) (*
 						if isAdministrativeShipment == true {
 							aq.logger.Info("Shipment pickup date is during a blackout period. Awarding Administrative Shipment to TSP.")
 						} else {
-							// TODO: AwardCount is off by 1
+							// TODO: OfferCount is off by 1
 							aq.logger.Infof("Shipment offered to TSP! TSP now has %d shipment offers.", tspPerformance.OfferCount+1)
 							foundAvailableTSP = true
 						}

--- a/pkg/awardqueue/awardqueue_test.go
+++ b/pkg/awardqueue/awardqueue_test.go
@@ -30,7 +30,7 @@ func (suite *AwardQueueSuite) Test_CheckAllTSPsBlackedOut() {
 	deliverDate := blackoutStartDate.Add(time.Hour * 24 * 60)
 	shipment, _ := testdatagen.MakeShipment(suite.db, pickupDate, pickupDate, deliverDate, tdl)
 
-	// Create a ShipmentWithOfferAwardedShipment to feed the award queue
+	// Create a ShipmentWithOffer to feed the award queue
 	shipmentWithOffer := models.ShipmentWithOffer{
 		ID: shipment.ID,
 		TrafficDistributionListID:       tdl.ID,

--- a/pkg/awardqueue/awardqueue_test.go
+++ b/pkg/awardqueue/awardqueue_test.go
@@ -74,9 +74,9 @@ func (suite *AwardQueueSuite) Test_CheckShipmentDuringBlackOut() {
 	// Run the Award Queue
 	queue.assignShipments()
 
-	shipmentAward := models.ShipmentOffer{}
+	shipmentOffer := models.ShipmentOffer{}
 	query := suite.db.Where("shipment_id = $1", shipment.ID)
-	if err := query.First(&shipmentAward); err != nil {
+	if err := query.First(&shipmentOffer); err != nil {
 		t.Errorf("Couldn't find shipment offer with shipment_ID: %v\n", shipment.ID)
 	}
 
@@ -86,7 +86,7 @@ func (suite *AwardQueueSuite) Test_CheckShipmentDuringBlackOut() {
 		t.Errorf("Couldn't find shipment offer: %v", blackoutShipment.ID)
 	}
 
-	if shipmentAward.AdministrativeShipment != false || blackoutShipmentAward.AdministrativeShipment != true {
+	if shipmentOffer.AdministrativeShipment != false || blackoutShipmentAward.AdministrativeShipment != true {
 		t.Errorf("Shipment Awards erroneously assigned administrative status.")
 	}
 
@@ -150,7 +150,7 @@ func (suite *AwardQueueSuite) Test_FindAllUnassignedShipments() {
 
 // Test that we can create a shipment that should be offered, and that
 // it actually gets offered.
-func (suite *AwardQueueSuite) Test_AwardSingleShipment() {
+func (suite *AwardQueueSuite) Test_OfferSingleShipment() {
 	t := suite.T()
 	queue := NewAwardQueue(suite.db, suite.logger)
 
@@ -162,7 +162,7 @@ func (suite *AwardQueueSuite) Test_AwardSingleShipment() {
 	tsp, _ := testdatagen.MakeTSP(suite.db, "Test Shipper", "TEST")
 	testdatagen.MakeTSPPerformance(suite.db, tsp, tdl, swag.Int(1), mps+1, 0)
 
-	// Create a ShipmentWithOfferAwardedShipment to feed the award queue
+	// Create a ShipmentWithOffer to feed the award queue
 	shipmentWithOffer := models.ShipmentWithOffer{
 		ID: shipment.ID,
 		TrafficDistributionListID:       tdl.ID,
@@ -181,13 +181,13 @@ func (suite *AwardQueueSuite) Test_AwardSingleShipment() {
 	if err != nil {
 		t.Errorf("Shipment offer expected no errors, received: %v", err)
 	} else if offer == nil {
-		t.Error("ShipmentAward was not found.")
+		t.Error("ShipmentOffer was not found.")
 	}
 }
 
 // Test that we can create a shipment that should NOT be offered because it is not in a TDL
 // with any TSPs, and that it doens't get offered.
-func (suite *AwardQueueSuite) Test_FailAwardingSingleShipment() {
+func (suite *AwardQueueSuite) Test_FailOfferingSingleShipment() {
 	t := suite.T()
 	queue := NewAwardQueue(suite.db, suite.logger)
 

--- a/pkg/awardqueue/awardqueue_test.go
+++ b/pkg/awardqueue/awardqueue_test.go
@@ -80,13 +80,13 @@ func (suite *AwardQueueSuite) Test_CheckShipmentDuringBlackOut() {
 		t.Errorf("Couldn't find shipment offer with shipment_ID: %v\n", shipment.ID)
 	}
 
-	blackoutShipmentAward := models.ShipmentOffer{}
+	blackoutShipmentOffer := models.ShipmentOffer{}
 	blackoutQuery := suite.db.Where("shipment_id = $1", blackoutShipment.ID)
-	if err := blackoutQuery.First(&blackoutShipmentAward); err != nil {
+	if err := blackoutQuery.First(&blackoutShipmentOffer); err != nil {
 		t.Errorf("Couldn't find shipment offer: %v", blackoutShipment.ID)
 	}
 
-	if shipmentOffer.AdministrativeShipment != false || blackoutShipmentAward.AdministrativeShipment != true {
+	if shipmentOffer.AdministrativeShipment != false || blackoutShipmentOffer.AdministrativeShipment != true {
 		t.Errorf("Shipment Awards erroneously assigned administrative status.")
 	}
 

--- a/pkg/handlers/shipments.go
+++ b/pkg/handlers/shipments.go
@@ -11,7 +11,7 @@ import (
 	"github.com/transcom/mymove/pkg/models"
 )
 
-func payloadForShipmentModel(s models.PossiblyAwardedShipment) *internalmessages.ShipmentPayload {
+func payloadForShipmentModel(s models.ShipmentWithOffer) *internalmessages.ShipmentPayload {
 	shipmentPayload := &internalmessages.ShipmentPayload{
 		ID:                              fmtUUID(s.ID),
 		PickupDate:                      fmtDate(time.Now()),

--- a/pkg/handlers/shipments.go
+++ b/pkg/handlers/shipments.go
@@ -32,7 +32,7 @@ type IndexShipmentsHandler HandlerContext
 func (h IndexShipmentsHandler) Handle(p shipmentop.IndexShipmentsParams) middleware.Responder {
 	var response middleware.Responder
 
-	shipments, err := models.FetchPossiblyAwardedShipments(h.db)
+	shipments, err := models.FetchShipments(h.db, false)
 
 	if err != nil {
 		h.logger.Error("DB Query", zap.Error(err))

--- a/pkg/handlers/shipments_test.go
+++ b/pkg/handlers/shipments_test.go
@@ -33,7 +33,7 @@ func (suite *HandlerSuite) TestIndexShipmentsHandler() {
 	}
 	suite.mustSave(&aws)
 
-	award := models.ShipmentAward{
+	award := models.ShipmentOffer{
 		ShipmentID:                      aws.ID,
 		TransportationServiceProviderID: tsp.ID,
 	}

--- a/pkg/handlers/shipments_test.go
+++ b/pkg/handlers/shipments_test.go
@@ -33,11 +33,11 @@ func (suite *HandlerSuite) TestIndexShipmentsHandler() {
 	}
 	suite.mustSave(&aws)
 
-	award := models.ShipmentOffer{
+	offer := models.ShipmentOffer{
 		ShipmentID:                      aws.ID,
 		TransportationServiceProviderID: tsp.ID,
 	}
-	suite.mustSave(&award)
+	suite.mustSave(&offer)
 
 	params := shipmentop.NewIndexShipmentsParams()
 	indexHandler := IndexShipmentsHandler(NewHandlerContext(suite.db, suite.logger))
@@ -53,11 +53,11 @@ func (suite *HandlerSuite) TestIndexShipmentsHandler() {
 		t.Errorf("expected %d shipments, got %d", 2, len(shipments))
 	}
 
-	awardedCount := 0
+	offeredCount := 0
 	availableCount := 0
 	for _, shipment := range shipments {
 		if shipment.TransportationServiceProviderID != nil {
-			awardedCount++
+			offeredCount++
 			if shipment.TransportationServiceProviderID.String() != tsp.ID.String() {
 				t.Errorf("got wrong tsp id, expected %s, got %s", tsp.ID.String(), shipment.TransportationServiceProviderID.String())
 
@@ -67,8 +67,8 @@ func (suite *HandlerSuite) TestIndexShipmentsHandler() {
 		}
 	}
 
-	if awardedCount != 1 {
-		t.Errorf("expected %d awarded shipments, got %d", 1, awardedCount)
+	if offeredCount != 1 {
+		t.Errorf("expected %d offered shipments, got %d", 1, offeredCount)
 	}
 
 	if availableCount != 1 {

--- a/pkg/models/shipment.go
+++ b/pkg/models/shipment.go
@@ -50,10 +50,10 @@ type PossiblyAwardedShipment struct {
 func FetchShipments(dbConnection *pop.Connection, onlyUnassigned bool) ([]PossiblyAwardedShipment, error) {
 	shipments := []PossiblyAwardedShipment{}
 
-	var unassignedSql string
+	var unassignedSQL string
 
 	if onlyUnassigned {
-		unassignedSql = "WHERE shipment_offers.id IS NULL"
+		unassignedSQL = "WHERE shipment_offers.id IS NULL"
 	}
 
 	sql := fmt.Sprintf(`SELECT
@@ -70,7 +70,7 @@ func FetchShipments(dbConnection *pop.Connection, onlyUnassigned bool) ([]Possib
 			LEFT JOIN shipment_offers ON
 				shipment_offers.shipment_id=shipments.id
 			%s`,
-		unassignedSql)
+		unassignedSQL)
 
 	err := dbConnection.RawQuery(sql).All(&shipments)
 

--- a/pkg/models/shipment.go
+++ b/pkg/models/shipment.go
@@ -29,8 +29,8 @@ type Shipment struct {
 	Market                    *string   `json:"market" db:"market"`
 }
 
-// PossiblyAwardedShipment represents a single awarded shipment within a Service Member's move.
-type PossiblyAwardedShipment struct {
+// ShipmentWithOffer represents a single awarded shipment within a Service Member's move.
+type ShipmentWithOffer struct {
 	ID                              uuid.UUID  `db:"id"`
 	CreatedAt                       time.Time  `db:"created_at"`
 	UpdatedAt                       time.Time  `db:"updated_at"`
@@ -45,10 +45,10 @@ type PossiblyAwardedShipment struct {
 }
 
 // FetchShipments looks up all shipments joined with their award information in a
-// PossiblyAwardedShipment struct. Optionally, you can only query for unassigned
+// ShipmentWithOffer struct. Optionally, you can only query for unassigned
 // shipments with the `onlyUnassigned` parameter.
-func FetchShipments(dbConnection *pop.Connection, onlyUnassigned bool) ([]PossiblyAwardedShipment, error) {
-	shipments := []PossiblyAwardedShipment{}
+func FetchShipments(dbConnection *pop.Connection, onlyUnassigned bool) ([]ShipmentWithOffer, error) {
+	shipments := []ShipmentWithOffer{}
 
 	var unassignedSQL string
 

--- a/pkg/models/shipment.go
+++ b/pkg/models/shipment.go
@@ -29,7 +29,7 @@ type Shipment struct {
 	Market                    *string   `json:"market" db:"market"`
 }
 
-// ShipmentWithOffer represents a single awarded shipment within a Service Member's move.
+// ShipmentWithOffer represents a single offered shipment within a Service Member's move.
 type ShipmentWithOffer struct {
 	ID                              uuid.UUID  `db:"id"`
 	CreatedAt                       time.Time  `db:"created_at"`
@@ -44,7 +44,7 @@ type ShipmentWithOffer struct {
 	AdministrativeShipment          *bool      `db:"administrative_shipment"`
 }
 
-// FetchShipments looks up all shipments joined with their award information in a
+// FetchShipments looks up all shipments joined with their offer information in a
 // ShipmentWithOffer struct. Optionally, you can only query for unassigned
 // shipments with the `onlyUnassigned` parameter.
 func FetchShipments(dbConnection *pop.Connection, onlyUnassigned bool) ([]ShipmentWithOffer, error) {

--- a/pkg/models/shipment_offer.go
+++ b/pkg/models/shipment_offer.go
@@ -11,7 +11,7 @@ import (
 )
 
 // ShipmentOffer maps a Transportation Service Provider to a shipment,
-// indicating that the shipment has been awarded to that TSP.
+// indicating that the shipment has been offered to that TSP.
 type ShipmentOffer struct {
 	ID                              uuid.UUID `json:"id" db:"id"`
 	CreatedAt                       time.Time `json:"created_at" db:"created_at"`

--- a/pkg/models/shipment_offer.go
+++ b/pkg/models/shipment_offer.go
@@ -10,9 +10,9 @@ import (
 	"github.com/satori/go.uuid"
 )
 
-// ShipmentAward maps a Transportation Service Provider to a shipment,
+// ShipmentOffer maps a Transportation Service Provider to a shipment,
 // indicating that the shipment has been awarded to that TSP.
-type ShipmentAward struct {
+type ShipmentOffer struct {
 	ID                              uuid.UUID `json:"id" db:"id"`
 	CreatedAt                       time.Time `json:"created_at" db:"created_at"`
 	UpdatedAt                       time.Time `json:"updated_at" db:"updated_at"`
@@ -24,41 +24,41 @@ type ShipmentAward struct {
 }
 
 // String is not required by pop and may be deleted
-func (a ShipmentAward) String() string {
+func (a ShipmentOffer) String() string {
 	ja, _ := json.Marshal(a)
 	return string(ja)
 }
 
-// ShipmentAwards is not required by pop and may be deleted
-type ShipmentAwards []ShipmentAward
+// ShipmentOffers is not required by pop and may be deleted
+type ShipmentOffers []ShipmentOffer
 
 // String is not required by pop and may be deleted
-func (a ShipmentAwards) String() string {
+func (a ShipmentOffers) String() string {
 	ja, _ := json.Marshal(a)
 	return string(ja)
 }
 
 // Validate gets run every time you call a "pop.Validate*" (pop.ValidateAndSave, pop.ValidateAndCreate, pop.ValidateAndUpdate) method.
-func (a *ShipmentAward) Validate(tx *pop.Connection) (*validate.Errors, error) {
+func (a *ShipmentOffer) Validate(tx *pop.Connection) (*validate.Errors, error) {
 	return validate.Validate(
 		&validators.UUIDIsPresent{Field: a.ShipmentID, Name: "ShipmentID"},
 		&validators.UUIDIsPresent{Field: a.TransportationServiceProviderID, Name: "TransportationServiceProviderID"},
 	), nil
 }
 
-// CreateShipmentAward connects a shipment to a transportation service provider. This
+// CreateShipmentOffer connects a shipment to a transportation service provider. This
 // function assumes that the match has been validated by the caller.
-func CreateShipmentAward(tx *pop.Connection,
+func CreateShipmentOffer(tx *pop.Connection,
 	shipmentID uuid.UUID,
 	tspID uuid.UUID,
-	administrativeShipment bool) (*ShipmentAward, error) {
+	administrativeShipment bool) (*ShipmentOffer, error) {
 
-	shipmentAward := ShipmentAward{
+	shipmentOffer := ShipmentOffer{
 		ShipmentID:                      shipmentID,
 		TransportationServiceProviderID: tspID,
 		AdministrativeShipment:          administrativeShipment,
 	}
-	_, err := tx.ValidateAndSave(&shipmentAward)
+	_, err := tx.ValidateAndSave(&shipmentOffer)
 
-	return &shipmentAward, err
+	return &shipmentOffer, err
 }

--- a/pkg/models/shipment_offer_test.go
+++ b/pkg/models/shipment_offer_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/transcom/mymove/pkg/testdatagen"
 )
 
-func (suite *ModelSuite) Test_ShipmentAwardValidations() {
+func (suite *ModelSuite) Test_ShipmentOfferValidations() {
 	sa := &ShipmentOffer{}
 
 	var expErrors = map[string][]string{
@@ -18,20 +18,20 @@ func (suite *ModelSuite) Test_ShipmentAwardValidations() {
 	suite.verifyValidationErrors(sa, expErrors)
 }
 
-// Test_CreateShipmentAward tests that a shipment is created when expected
-func (suite *ModelSuite) Test_CreateShipmentAward() {
+// Test_CreateShipmentOffer tests that a shipment is created when expected
+func (suite *ModelSuite) Test_CreateShipmentOffer() {
 	t := suite.T()
 	now := time.Now()
 	tdl, _ := testdatagen.MakeTDL(suite.db, "california", "90210", "2")
 	tsp, _ := testdatagen.MakeTSP(suite.db, "Test TSP 1", "TSP1")
 	shipment, _ := testdatagen.MakeShipment(suite.db, now, now, now.AddDate(0, 0, 1), tdl)
-	shipmentAward, err := CreateShipmentOffer(suite.db, shipment.ID, tsp.ID, false)
+	shipmentOffer, err := CreateShipmentOffer(suite.db, shipment.ID, tsp.ID, false)
 
 	if err != nil {
-		t.Errorf("Failed to create Shipment Award: %v", err)
+		t.Errorf("Failed to create Shipment Offer: %v", err)
 	}
-	expectedShipmentAward := ShipmentOffer{}
-	if err := suite.db.Find(&expectedShipmentAward, shipmentAward.ID); err != nil {
-		t.Fatalf("could not find shipmentAward: %v", err)
+	expectedShipmentOffer := ShipmentOffer{}
+	if err := suite.db.Find(&expectedShipmentOffer, shipmentOffer.ID); err != nil {
+		t.Fatalf("could not find shipmentOffer: %v", err)
 	}
 }

--- a/pkg/models/shipment_offer_test.go
+++ b/pkg/models/shipment_offer_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func (suite *ModelSuite) Test_ShipmentAwardValidations() {
-	sa := &ShipmentAward{}
+	sa := &ShipmentOffer{}
 
 	var expErrors = map[string][]string{
 		"shipment_id":                        []string{"ShipmentID can not be blank."},
@@ -25,12 +25,12 @@ func (suite *ModelSuite) Test_CreateShipmentAward() {
 	tdl, _ := testdatagen.MakeTDL(suite.db, "california", "90210", "2")
 	tsp, _ := testdatagen.MakeTSP(suite.db, "Test TSP 1", "TSP1")
 	shipment, _ := testdatagen.MakeShipment(suite.db, now, now, now.AddDate(0, 0, 1), tdl)
-	shipmentAward, err := CreateShipmentAward(suite.db, shipment.ID, tsp.ID, false)
+	shipmentAward, err := CreateShipmentOffer(suite.db, shipment.ID, tsp.ID, false)
 
 	if err != nil {
 		t.Errorf("Failed to create Shipment Award: %v", err)
 	}
-	expectedShipmentAward := ShipmentAward{}
+	expectedShipmentAward := ShipmentOffer{}
 	if err := suite.db.Find(&expectedShipmentAward, shipmentAward.ID); err != nil {
 		t.Fatalf("could not find shipmentAward: %v", err)
 	}

--- a/pkg/models/shipment_test.go
+++ b/pkg/models/shipment_test.go
@@ -19,7 +19,7 @@ func (suite *ModelSuite) Test_ShipmentValidations() {
 }
 
 // Test_FetchPossiblyAwardedShipments tests that a shipment is returned when we fetch possibly awarded shipments
-func (suite *ModelSuite) Test_FetchPossiblyAwardedShipments() {
+func (suite *ModelSuite) Test_FetchAllShipments() {
 	t := suite.T()
 	now := time.Now()
 	tdl, _ := testdatagen.MakeTDL(suite.db, "california", "90210", "2")
@@ -29,9 +29,9 @@ func (suite *ModelSuite) Test_FetchPossiblyAwardedShipments() {
 	shipment2, _ := testdatagen.MakeShipment(suite.db, now, now, now.AddDate(0, 0, 1), tdl)
 	tsp, _ := testdatagen.MakeTSP(suite.db, "Test TSP 1", "TSP1")
 	// Award one of the shipments
-	CreateShipmentAward(suite.db, shipment.ID, tsp.ID, false)
+	CreateShipmentOffer(suite.db, shipment.ID, tsp.ID, false)
 	// Run FetchPossiblyAwardedShipments
-	shipments, err := FetchPossiblyAwardedShipments(suite.db)
+	shipments, err := FetchShipments(suite.db, false)
 
 	// Expect both shipments returned
 	if err != nil {
@@ -43,7 +43,7 @@ func (suite *ModelSuite) Test_FetchPossiblyAwardedShipments() {
 }
 
 // Test_FetchUnawardedShipments tests that a shipment is returned when we fetch possibly awarded shipments
-func (suite *ModelSuite) Test_FetchUnawardedShipments() {
+func (suite *ModelSuite) Test_FetchUnassignedShipments() {
 	t := suite.T()
 	now := time.Now()
 	tdl, _ := testdatagen.MakeTDL(suite.db, "california", "90210", "2")
@@ -51,9 +51,9 @@ func (suite *ModelSuite) Test_FetchUnawardedShipments() {
 	shipment2, _ := testdatagen.MakeShipment(suite.db, now, now, now.AddDate(0, 0, 1), tdl)
 	tsp, _ := testdatagen.MakeTSP(suite.db, "Test TSP 1", "TSP1")
 	// Award one of the shipments
-	CreateShipmentAward(suite.db, shipment.ID, tsp.ID, false)
+	CreateShipmentOffer(suite.db, shipment.ID, tsp.ID, false)
 	// Run FetchUnawardedShipments
-	shipments, err := FetchUnawardedShipments(suite.db)
+	shipments, err := FetchShipments(suite.db, true)
 	// Expect only unawarded shipment returned
 	if err != nil {
 		t.Errorf("Failed to find Shipments: %v", err)

--- a/pkg/models/shipment_test.go
+++ b/pkg/models/shipment_test.go
@@ -18,19 +18,15 @@ func (suite *ModelSuite) Test_ShipmentValidations() {
 	suite.verifyValidationErrors(shipment, expErrors)
 }
 
-// Test_FetchPossiblyAwardedShipments tests that a shipment is returned when we fetch possibly awarded shipments
+// Test_FetchAllShipments tests that a shipment is returned when we fetch possibly awarded shipments
 func (suite *ModelSuite) Test_FetchAllShipments() {
 	t := suite.T()
 	now := time.Now()
 	tdl, _ := testdatagen.MakeTDL(suite.db, "california", "90210", "2")
-	// Make a shipment to award
 	shipment, _ := testdatagen.MakeShipment(suite.db, now, now, now.AddDate(0, 0, 1), tdl)
-	// Make a shipment not to award
 	shipment2, _ := testdatagen.MakeShipment(suite.db, now, now, now.AddDate(0, 0, 1), tdl)
 	tsp, _ := testdatagen.MakeTSP(suite.db, "Test TSP 1", "TSP1")
-	// Award one of the shipments
 	CreateShipmentOffer(suite.db, shipment.ID, tsp.ID, false)
-	// Run FetchPossiblyAwardedShipments
 	shipments, err := FetchShipments(suite.db, false)
 
 	// Expect both shipments returned
@@ -50,10 +46,9 @@ func (suite *ModelSuite) Test_FetchUnassignedShipments() {
 	shipment, _ := testdatagen.MakeShipment(suite.db, now, now, now.AddDate(0, 0, 1), tdl)
 	shipment2, _ := testdatagen.MakeShipment(suite.db, now, now, now.AddDate(0, 0, 1), tdl)
 	tsp, _ := testdatagen.MakeTSP(suite.db, "Test TSP 1", "TSP1")
-	// Award one of the shipments
 	CreateShipmentOffer(suite.db, shipment.ID, tsp.ID, false)
-	// Run FetchUnawardedShipments
 	shipments, err := FetchShipments(suite.db, true)
+
 	// Expect only unawarded shipment returned
 	if err != nil {
 		t.Errorf("Failed to find Shipments: %v", err)
@@ -62,7 +57,7 @@ func (suite *ModelSuite) Test_FetchUnassignedShipments() {
 	}
 }
 
-func equalShipmentsSlice(a []PossiblyAwardedShipment, b []PossiblyAwardedShipment) bool {
+func equalShipmentsSlice(a []ShipmentWithOffer, b []ShipmentWithOffer) bool {
 	if len(a) != len(b) {
 		return false
 	}

--- a/pkg/models/shipment_test.go
+++ b/pkg/models/shipment_test.go
@@ -18,7 +18,7 @@ func (suite *ModelSuite) Test_ShipmentValidations() {
 	suite.verifyValidationErrors(shipment, expErrors)
 }
 
-// Test_FetchAllShipments tests that a shipment is returned when we fetch possibly awarded shipments
+// Test_FetchAllShipments tests that a shipment is returned when we fetch shipments with their offers.
 func (suite *ModelSuite) Test_FetchAllShipments() {
 	t := suite.T()
 	now := time.Now()
@@ -38,7 +38,7 @@ func (suite *ModelSuite) Test_FetchAllShipments() {
 	}
 }
 
-// Test_FetchUnawardedShipments tests that a shipment is returned when we fetch possibly awarded shipments
+// Test_FetchUnassignedShipments tests that a shipment is returned when we fetch shipments with offers.
 func (suite *ModelSuite) Test_FetchUnassignedShipments() {
 	t := suite.T()
 	now := time.Now()
@@ -49,7 +49,7 @@ func (suite *ModelSuite) Test_FetchUnassignedShipments() {
 	CreateShipmentOffer(suite.db, shipment.ID, tsp.ID, false)
 	shipments, err := FetchShipments(suite.db, true)
 
-	// Expect only unawarded shipment returned
+	// Expect only unassigned shipment returned
 	if err != nil {
 		t.Errorf("Failed to find Shipments: %v", err)
 	} else if len(shipments) != 1 {

--- a/pkg/models/transportation_service_provider.go
+++ b/pkg/models/transportation_service_provider.go
@@ -20,14 +20,14 @@ type TransportationServiceProvider struct {
 	Name                     string    `json:"name" db:"name"`
 }
 
-// TSPWithBVSAndAwardCount represents a list of TSPs along with their BVS
-// and awarded shipment counts.
-type TSPWithBVSAndAwardCount struct {
+// TSPWithBVSAndOfferCount represents a list of TSPs along with their BVS
+// and offered shipment counts.
+type TSPWithBVSAndOfferCount struct {
 	ID                        uuid.UUID `json:"id" db:"id"`
 	Name                      string    `json:"name" db:"name"`
 	TrafficDistributionListID uuid.UUID `json:"traffic_distribution_list_id" db:"traffic_distribution_list_id"`
 	BestValueScore            int       `json:"best_value_score" db:"best_value_score"`
-	AwardCount                int       `json:"award_count" db:"award_count"`
+	OfferCount                int       `json:"offer_count" db:"offer_count"`
 }
 
 // TSPWithBVSCount represents a list of TSPs along with their BVS counts.

--- a/pkg/models/transportation_service_provider_performance.go
+++ b/pkg/models/transportation_service_provider_performance.go
@@ -17,8 +17,8 @@ import (
 
 var qualityBands = []int{1, 2, 3, 4}
 
-// AwardsPerQualityBand is a map of the number of shipments to be awarded per round to each quality band
-var AwardsPerQualityBand = map[int]int{
+// OffersPerQualityBand is a map of the number of shipments to be offered per round to each quality band
+var OffersPerQualityBand = map[int]int{
 	1: 5,
 	2: 3,
 	3: 2,
@@ -78,7 +78,7 @@ func (t *TransportationServiceProviderPerformance) Validate(tx *pop.Connection) 
 }
 
 // NextTSPPerformanceInQualityBand returns the TSP performance record in a given TDL
-// and Quality Band that will next be awarded a shipment.
+// and Quality Band that will next be offered a shipment.
 func NextTSPPerformanceInQualityBand(tx *pop.Connection, tdlID uuid.UUID, qualityBand int, bookDate time.Time) (
 	TransportationServiceProviderPerformance, error) {
 
@@ -135,13 +135,13 @@ func NextEligibleTSPPerformance(db *pop.Connection, tdlID uuid.UUID, bookDate ti
 func SelectNextTSPPerformance(tspPerformances map[int]TransportationServiceProviderPerformance) TransportationServiceProviderPerformance {
 	bands := sortedMapIntKeys(tspPerformances)
 	// First time through, no rounds have yet occurred so rounds is set to the maximum rounds that have already occured.
-	// Since the TSPs in quality band 1 will always have been awarded the greatest number of shipments, we use that to calculate max.
-	maxRounds := float64(tspPerformances[bands[0]].OfferCount) / float64(AwardsPerQualityBand[bands[0]])
+	// Since the TSPs in quality band 1 will always have been offered the greatest number of shipments, we use that to calculate max.
+	maxRounds := float64(tspPerformances[bands[0]].OfferCount) / float64(OffersPerQualityBand[bands[0]])
 	previousRounds := math.Ceil(maxRounds)
 
 	for _, band := range bands {
 		tspPerformance := tspPerformances[band]
-		rounds := float64(tspPerformance.OfferCount) / float64(AwardsPerQualityBand[band])
+		rounds := float64(tspPerformance.OfferCount) / float64(OffersPerQualityBand[band])
 
 		if rounds < previousRounds {
 			return tspPerformance
@@ -150,7 +150,7 @@ func SelectNextTSPPerformance(tspPerformances map[int]TransportationServiceProvi
 	}
 
 	// If we get all the way through, it means all of the TSPPerformances have had the
-	// same number of awards and we should wrap around and assign the next award to
+	// same number of offers and we should wrap around and assign the next offer to
 	// the first quality band.
 	return tspPerformances[bands[0]]
 }
@@ -202,8 +202,8 @@ func AssignQualityBandToTSPPerformance(db *pop.Connection, band int, id uuid.UUI
 	return nil
 }
 
-// IncrementTSPPerformanceAwardCount increments the offer_count column by 1 and validates.
-func IncrementTSPPerformanceAwardCount(db *pop.Connection, tspPerformanceID uuid.UUID) error {
+// IncrementTSPPerformanceOfferCount increments the offer_count column by 1 and validates.
+func IncrementTSPPerformanceOfferCount(db *pop.Connection, tspPerformanceID uuid.UUID) error {
 	var tspPerformance TransportationServiceProviderPerformance
 	if err := db.Find(&tspPerformance, tspPerformanceID); err != nil {
 		return err

--- a/pkg/models/transportation_service_provider_performance_test.go
+++ b/pkg/models/transportation_service_provider_performance_test.go
@@ -45,8 +45,8 @@ func (suite *ModelSuite) Test_IncrementTSPPerformanceAwardCount() {
 		t.Fatalf("could not find perf: %v", err)
 	}
 
-	if performance.AwardCount != 1 {
-		t.Errorf("Wrong AwardCount: expected %d, got %d", 1, performance.AwardCount)
+	if performance.OfferCount != 1 {
+		t.Errorf("Wrong AwardCount: expected %d, got %d", 1, performance.OfferCount)
 	}
 }
 
@@ -132,10 +132,10 @@ func (suite *ModelSuite) Test_FetchNextQualityBandTSPPerformance() {
 
 func (suite *ModelSuite) Test_SelectNextTSPPerformanceAllZeros() {
 	t := suite.T()
-	tspp1 := TransportationServiceProviderPerformance{AwardCount: 0, QualityBand: swag.Int(1)}
-	tspp2 := TransportationServiceProviderPerformance{AwardCount: 0, QualityBand: swag.Int(2)}
-	tspp3 := TransportationServiceProviderPerformance{AwardCount: 0, QualityBand: swag.Int(3)}
-	tspp4 := TransportationServiceProviderPerformance{AwardCount: 0, QualityBand: swag.Int(4)}
+	tspp1 := TransportationServiceProviderPerformance{OfferCount: 0, QualityBand: swag.Int(1)}
+	tspp2 := TransportationServiceProviderPerformance{OfferCount: 0, QualityBand: swag.Int(2)}
+	tspp3 := TransportationServiceProviderPerformance{OfferCount: 0, QualityBand: swag.Int(3)}
+	tspp4 := TransportationServiceProviderPerformance{OfferCount: 0, QualityBand: swag.Int(4)}
 
 	choices := map[int]TransportationServiceProviderPerformance{
 		1: tspp1,
@@ -152,10 +152,10 @@ func (suite *ModelSuite) Test_SelectNextTSPPerformanceAllZeros() {
 
 func (suite *ModelSuite) Test_SelectNextTSPPerformanceOneAssigned() {
 	t := suite.T()
-	tspp1 := TransportationServiceProviderPerformance{AwardCount: 1, QualityBand: swag.Int(1)}
-	tspp2 := TransportationServiceProviderPerformance{AwardCount: 0, QualityBand: swag.Int(2)}
-	tspp3 := TransportationServiceProviderPerformance{AwardCount: 0, QualityBand: swag.Int(3)}
-	tspp4 := TransportationServiceProviderPerformance{AwardCount: 0, QualityBand: swag.Int(4)}
+	tspp1 := TransportationServiceProviderPerformance{OfferCount: 1, QualityBand: swag.Int(1)}
+	tspp2 := TransportationServiceProviderPerformance{OfferCount: 0, QualityBand: swag.Int(2)}
+	tspp3 := TransportationServiceProviderPerformance{OfferCount: 0, QualityBand: swag.Int(3)}
+	tspp4 := TransportationServiceProviderPerformance{OfferCount: 0, QualityBand: swag.Int(4)}
 
 	choices := map[int]TransportationServiceProviderPerformance{
 		1: tspp1,
@@ -172,10 +172,10 @@ func (suite *ModelSuite) Test_SelectNextTSPPerformanceOneAssigned() {
 
 func (suite *ModelSuite) Test_SelectNextTSPPerformanceOneFullRound() {
 	t := suite.T()
-	tspp1 := TransportationServiceProviderPerformance{AwardCount: 5, QualityBand: swag.Int(1)}
-	tspp2 := TransportationServiceProviderPerformance{AwardCount: 3, QualityBand: swag.Int(2)}
-	tspp3 := TransportationServiceProviderPerformance{AwardCount: 2, QualityBand: swag.Int(3)}
-	tspp4 := TransportationServiceProviderPerformance{AwardCount: 1, QualityBand: swag.Int(4)}
+	tspp1 := TransportationServiceProviderPerformance{OfferCount: 5, QualityBand: swag.Int(1)}
+	tspp2 := TransportationServiceProviderPerformance{OfferCount: 3, QualityBand: swag.Int(2)}
+	tspp3 := TransportationServiceProviderPerformance{OfferCount: 2, QualityBand: swag.Int(3)}
+	tspp4 := TransportationServiceProviderPerformance{OfferCount: 1, QualityBand: swag.Int(4)}
 
 	choices := map[int]TransportationServiceProviderPerformance{
 		1: tspp1,
@@ -192,10 +192,10 @@ func (suite *ModelSuite) Test_SelectNextTSPPerformanceOneFullRound() {
 
 func (suite *ModelSuite) Test_SelectNextTSPPerformanceTwoFullRounds() {
 	t := suite.T()
-	tspp1 := TransportationServiceProviderPerformance{AwardCount: 10, QualityBand: swag.Int(1)}
-	tspp2 := TransportationServiceProviderPerformance{AwardCount: 6, QualityBand: swag.Int(2)}
-	tspp3 := TransportationServiceProviderPerformance{AwardCount: 4, QualityBand: swag.Int(3)}
-	tspp4 := TransportationServiceProviderPerformance{AwardCount: 2, QualityBand: swag.Int(4)}
+	tspp1 := TransportationServiceProviderPerformance{OfferCount: 10, QualityBand: swag.Int(1)}
+	tspp2 := TransportationServiceProviderPerformance{OfferCount: 6, QualityBand: swag.Int(2)}
+	tspp3 := TransportationServiceProviderPerformance{OfferCount: 4, QualityBand: swag.Int(3)}
+	tspp4 := TransportationServiceProviderPerformance{OfferCount: 2, QualityBand: swag.Int(4)}
 
 	choices := map[int]TransportationServiceProviderPerformance{
 		1: tspp1,
@@ -212,10 +212,10 @@ func (suite *ModelSuite) Test_SelectNextTSPPerformanceTwoFullRounds() {
 
 func (suite *ModelSuite) Test_SelectNextTSPPerformanceFirstBandFilled() {
 	t := suite.T()
-	tspp1 := TransportationServiceProviderPerformance{AwardCount: 5, QualityBand: swag.Int(1)}
-	tspp2 := TransportationServiceProviderPerformance{AwardCount: 0, QualityBand: swag.Int(2)}
-	tspp3 := TransportationServiceProviderPerformance{AwardCount: 0, QualityBand: swag.Int(3)}
-	tspp4 := TransportationServiceProviderPerformance{AwardCount: 0, QualityBand: swag.Int(4)}
+	tspp1 := TransportationServiceProviderPerformance{OfferCount: 5, QualityBand: swag.Int(1)}
+	tspp2 := TransportationServiceProviderPerformance{OfferCount: 0, QualityBand: swag.Int(2)}
+	tspp3 := TransportationServiceProviderPerformance{OfferCount: 0, QualityBand: swag.Int(3)}
+	tspp4 := TransportationServiceProviderPerformance{OfferCount: 0, QualityBand: swag.Int(4)}
 
 	choices := map[int]TransportationServiceProviderPerformance{
 		1: tspp1,
@@ -232,9 +232,9 @@ func (suite *ModelSuite) Test_SelectNextTSPPerformanceFirstBandFilled() {
 
 func (suite *ModelSuite) Test_SelectNextTSPPerformanceThreeBands() {
 	t := suite.T()
-	tspp1 := TransportationServiceProviderPerformance{AwardCount: 10, QualityBand: swag.Int(1)}
-	tspp2 := TransportationServiceProviderPerformance{AwardCount: 3, QualityBand: swag.Int(2)}
-	tspp3 := TransportationServiceProviderPerformance{AwardCount: 2, QualityBand: swag.Int(3)}
+	tspp1 := TransportationServiceProviderPerformance{OfferCount: 10, QualityBand: swag.Int(1)}
+	tspp2 := TransportationServiceProviderPerformance{OfferCount: 3, QualityBand: swag.Int(2)}
+	tspp3 := TransportationServiceProviderPerformance{OfferCount: 2, QualityBand: swag.Int(3)}
 
 	choices := map[int]TransportationServiceProviderPerformance{
 		1: tspp1,
@@ -250,10 +250,10 @@ func (suite *ModelSuite) Test_SelectNextTSPPerformanceThreeBands() {
 
 func (suite *ModelSuite) Test_SelectNextTSPPerformanceHalfAwarded() {
 	t := suite.T()
-	tspp1 := TransportationServiceProviderPerformance{AwardCount: 5, QualityBand: swag.Int(1)}
-	tspp2 := TransportationServiceProviderPerformance{AwardCount: 3, QualityBand: swag.Int(2)}
-	tspp3 := TransportationServiceProviderPerformance{AwardCount: 0, QualityBand: swag.Int(3)}
-	tspp4 := TransportationServiceProviderPerformance{AwardCount: 0, QualityBand: swag.Int(4)}
+	tspp1 := TransportationServiceProviderPerformance{OfferCount: 5, QualityBand: swag.Int(1)}
+	tspp2 := TransportationServiceProviderPerformance{OfferCount: 3, QualityBand: swag.Int(2)}
+	tspp3 := TransportationServiceProviderPerformance{OfferCount: 0, QualityBand: swag.Int(3)}
+	tspp4 := TransportationServiceProviderPerformance{OfferCount: 0, QualityBand: swag.Int(4)}
 
 	choices := map[int]TransportationServiceProviderPerformance{
 		1: tspp1,
@@ -270,10 +270,10 @@ func (suite *ModelSuite) Test_SelectNextTSPPerformanceHalfAwarded() {
 
 func (suite *ModelSuite) Test_SelectNextTSPPerformancePartialRound() {
 	t := suite.T()
-	tspp1 := TransportationServiceProviderPerformance{AwardCount: 5, QualityBand: swag.Int(1)}
-	tspp2 := TransportationServiceProviderPerformance{AwardCount: 3, QualityBand: swag.Int(2)}
-	tspp3 := TransportationServiceProviderPerformance{AwardCount: 1, QualityBand: swag.Int(3)}
-	tspp4 := TransportationServiceProviderPerformance{AwardCount: 0, QualityBand: swag.Int(4)}
+	tspp1 := TransportationServiceProviderPerformance{OfferCount: 5, QualityBand: swag.Int(1)}
+	tspp2 := TransportationServiceProviderPerformance{OfferCount: 3, QualityBand: swag.Int(2)}
+	tspp3 := TransportationServiceProviderPerformance{OfferCount: 1, QualityBand: swag.Int(3)}
+	tspp4 := TransportationServiceProviderPerformance{OfferCount: 0, QualityBand: swag.Int(4)}
 
 	choices := map[int]TransportationServiceProviderPerformance{
 		1: tspp1,

--- a/pkg/models/transportation_service_provider_performance_test.go
+++ b/pkg/models/transportation_service_provider_performance_test.go
@@ -28,16 +28,16 @@ func (suite *ModelSuite) Test_BestValueScoreValidations() {
 	suite.verifyValidationErrors(tspPerformance, expErrors)
 }
 
-func (suite *ModelSuite) Test_IncrementTSPPerformanceAwardCount() {
+func (suite *ModelSuite) Test_IncrementTSPPerformanceOfferCount() {
 	t := suite.T()
 
 	tdl, _ := testdatagen.MakeTDL(suite.db, "california", "90210", "2")
 	tsp, _ := testdatagen.MakeTSP(suite.db, "Test Shipper", "TEST")
 	perf, _ := testdatagen.MakeTSPPerformance(suite.db, tsp, tdl, nil, mps, 0)
 
-	err := IncrementTSPPerformanceAwardCount(suite.db, perf.ID)
+	err := IncrementTSPPerformanceOfferCount(suite.db, perf.ID)
 	if err != nil {
-		t.Fatalf("Could not increment award_count: %v", err)
+		t.Fatalf("Could not increment offer_count: %v", err)
 	}
 
 	performance := TransportationServiceProviderPerformance{}
@@ -46,7 +46,7 @@ func (suite *ModelSuite) Test_IncrementTSPPerformanceAwardCount() {
 	}
 
 	if performance.OfferCount != 1 {
-		t.Errorf("Wrong AwardCount: expected %d, got %d", 1, performance.OfferCount)
+		t.Errorf("Wrong OfferCount: expected %d, got %d", 1, performance.OfferCount)
 	}
 }
 
@@ -115,7 +115,7 @@ func (suite *ModelSuite) Test_FetchNextQualityBandTSPPerformance() {
 	tsp2, _ := testdatagen.MakeTSP(suite.db, "Test TSP 2", "TSP2")
 	tsp3, _ := testdatagen.MakeTSP(suite.db, "Test TSP 3", "TSP2")
 
-	// TSPs should be orderd by award_count first, then BVS.
+	// TSPs should be orderd by offer_count first, then BVS.
 	testdatagen.MakeTSPPerformance(suite.db, tsp1, tdl, swag.Int(1), mps+1, 0)
 	testdatagen.MakeTSPPerformance(suite.db, tsp2, tdl, swag.Int(1), mps+3, 0)
 	testdatagen.MakeTSPPerformance(suite.db, tsp3, tdl, swag.Int(1), mps+2, 0)
@@ -248,7 +248,7 @@ func (suite *ModelSuite) Test_SelectNextTSPPerformanceThreeBands() {
 	}
 }
 
-func (suite *ModelSuite) Test_SelectNextTSPPerformanceHalfAwarded() {
+func (suite *ModelSuite) Test_SelectNextTSPPerformanceHalfOffered() {
 	t := suite.T()
 	tspp1 := TransportationServiceProviderPerformance{OfferCount: 5, QualityBand: swag.Int(1)}
 	tspp2 := TransportationServiceProviderPerformance{OfferCount: 3, QualityBand: swag.Int(2)}
@@ -298,7 +298,7 @@ func (suite *ModelSuite) Test_GatherNextEligibleTSPPerformances() {
 	tsp3, _ := testdatagen.MakeTSP(suite.db, "Test TSP 3", "TSP3")
 	tsp4, _ := testdatagen.MakeTSP(suite.db, "Test TSP 4", "TSP4")
 	tsp5, _ := testdatagen.MakeTSP(suite.db, "Test TSP 5", "TSP5")
-	// TSPs should be orderd by award_count first, then BVS.
+	// TSPs should be orderd by offer_count first, then BVS.
 	testdatagen.MakeTSPPerformance(suite.db, tsp1, tdl, swag.Int(1), mps+5, 0)
 	testdatagen.MakeTSPPerformance(suite.db, tsp2, tdl, swag.Int(1), mps+4, 0)
 	testdatagen.MakeTSPPerformance(suite.db, tsp3, tdl, swag.Int(2), mps+3, 0)
@@ -336,7 +336,7 @@ func (suite *ModelSuite) Test_FetchTSPPerformanceForQualityBandAssignment() {
 	tsp1, _ := testdatagen.MakeTSP(suite.db, "Test TSP 1", "TSP1")
 	tsp2, _ := testdatagen.MakeTSP(suite.db, "Test TSP 2", "TSP2")
 	tsp3, _ := testdatagen.MakeTSP(suite.db, "Test TSP 3", "TSP2")
-	// What matter is the BVS score order; award_count has no influence.
+	// What matter is the BVS score order; offer count has no influence.
 	testdatagen.MakeTSPPerformance(suite.db, tsp1, tdl, nil, 90, 0)
 	testdatagen.MakeTSPPerformance(suite.db, tsp2, tdl, nil, 50, 1)
 	testdatagen.MakeTSPPerformance(suite.db, tsp3, tdl, nil, 15, 1)

--- a/pkg/testdatagen/make_awarded_shipment_record.go
+++ b/pkg/testdatagen/make_awarded_shipment_record.go
@@ -14,10 +14,10 @@ import (
 // MakeShipmentAward a single AwardedShipment record
 func MakeShipmentAward(db *pop.Connection, shipment models.Shipment,
 	tsp models.TransportationServiceProvider, admin bool, accepted *bool,
-	rejectionReason *string) (models.ShipmentAward, error) {
+	rejectionReason *string) (models.ShipmentOffer, error) {
 
 	// Add one awarded shipment record using existing shipment and TSP IDs
-	shipmentAward := models.ShipmentAward{
+	shipmentAward := models.ShipmentOffer{
 		ShipmentID:                      shipment.ID,
 		TransportationServiceProviderID: tsp.ID,
 		AdministrativeShipment:          admin,

--- a/pkg/testdatagen/make_offered_shipment_record.go
+++ b/pkg/testdatagen/make_offered_shipment_record.go
@@ -11,13 +11,13 @@ import (
 	"github.com/transcom/mymove/pkg/models"
 )
 
-// MakeShipmentAward a single AwardedShipment record
-func MakeShipmentAward(db *pop.Connection, shipment models.Shipment,
+// MakeShipmentOffer a single ShipmentOffer record
+func MakeShipmentOffer(db *pop.Connection, shipment models.Shipment,
 	tsp models.TransportationServiceProvider, admin bool, accepted *bool,
 	rejectionReason *string) (models.ShipmentOffer, error) {
 
-	// Add one awarded shipment record using existing shipment and TSP IDs
-	shipmentAward := models.ShipmentOffer{
+	// Add one offered shipment record using existing shipment and TSP IDs
+	shipmentOffer := models.ShipmentOffer{
 		ShipmentID:                      shipment.ID,
 		TransportationServiceProviderID: tsp.ID,
 		AdministrativeShipment:          admin,
@@ -25,16 +25,16 @@ func MakeShipmentAward(db *pop.Connection, shipment models.Shipment,
 		RejectionReason:                 rejectionReason,
 	}
 
-	_, err := db.ValidateAndSave(&shipmentAward)
+	_, err := db.ValidateAndSave(&shipmentOffer)
 	if err != nil {
 		log.Panic(err)
 	}
 
-	return shipmentAward, err
+	return shipmentOffer, err
 }
 
-// MakeShipmentAwardData creates one awarded shipment record
-func MakeShipmentAwardData(db *pop.Connection) {
+// MakeShipmentOfferData creates one offered shipment record
+func MakeShipmentOfferData(db *pop.Connection) {
 	// Get a shipment ID
 	shipmentList := []models.Shipment{}
 	err := db.All(&shipmentList)
@@ -49,8 +49,8 @@ func MakeShipmentAwardData(db *pop.Connection) {
 		fmt.Println("TSP ID import failed.")
 	}
 
-	// Add one awarded shipment record using existing, random shipment and TSP IDs
-	MakeShipmentAward(db,
+	// Add one offered shipment record using existing, random shipment and TSP IDs
+	MakeShipmentOffer(db,
 		shipmentList[rand.Intn(len(shipmentList))],
 		tspList[rand.Intn(len(tspList))],
 		false,

--- a/pkg/testdatagen/make_tsp_performance_records.go
+++ b/pkg/testdatagen/make_tsp_performance_records.go
@@ -20,7 +20,7 @@ func MakeTSPPerformance(db *pop.Connection, tsp models.TransportationServiceProv
 		TrafficDistributionListID:       tdl.ID,
 		QualityBand:                     qualityBand,
 		BestValueScore:                  score,
-		AwardCount:                      awardCount,
+		OfferCount:                      awardCount,
 	}
 
 	_, err := db.ValidateAndSave(&tspPerformance)

--- a/pkg/testdatagen/make_tsp_performance_records.go
+++ b/pkg/testdatagen/make_tsp_performance_records.go
@@ -11,7 +11,7 @@ import (
 
 // MakeTSPPerformance makes a single best_value_score record
 func MakeTSPPerformance(db *pop.Connection, tsp models.TransportationServiceProvider,
-	tdl models.TrafficDistributionList, qualityBand *int, score int, awardCount int) (models.TransportationServiceProviderPerformance, error) {
+	tdl models.TrafficDistributionList, qualityBand *int, score int, offerCount int) (models.TransportationServiceProviderPerformance, error) {
 
 	tspPerformance := models.TransportationServiceProviderPerformance{
 		PerformancePeriodStart:          PerformancePeriodStart,
@@ -20,7 +20,7 @@ func MakeTSPPerformance(db *pop.Connection, tsp models.TransportationServiceProv
 		TrafficDistributionListID:       tdl.ID,
 		QualityBand:                     qualityBand,
 		BestValueScore:                  score,
-		OfferCount:                      awardCount,
+		OfferCount:                      offerCount,
 	}
 
 	_, err := db.ValidateAndSave(&tspPerformance)
@@ -32,8 +32,8 @@ func MakeTSPPerformance(db *pop.Connection, tsp models.TransportationServiceProv
 }
 
 // MakeTSPPerformanceData creates three best value score records
-// Variable rounds describes how many rounds should have already been awarded
-// `none` indicates no rounds have been awarded, `half` indicates half a round, and `full` a full round.
+// Variable rounds describes how many rounds should have already been offered
+// `none` indicates no rounds have been offered, `half` indicates half a round, and `full` a full round.
 func MakeTSPPerformanceData(db *pop.Connection, rounds string) {
 	// These two queries duplicate ones in other testdatagen files; not optimal
 	tspList := []models.TransportationServiceProvider{}
@@ -52,22 +52,22 @@ func MakeTSPPerformanceData(db *pop.Connection, rounds string) {
 	for qualityBand := 1; qualityBand < 5; qualityBand++ {
 		// For quality band 1, generate a random number between 75 - 100,
 		// for quality band 2 between 50-75, etc.
-		var awards int
+		var offers int
 		minBvs := (qualityBand - 1) * 25
 		bvs := 100 - (rand.Intn(25) + minBvs)
 		// Set rounds according to the flag passed in
 
 		if rounds == "half" {
 			if qualityBand == 1 || qualityBand == 2 {
-				awards = models.AwardsPerQualityBand[qualityBand]
+				offers = models.OffersPerQualityBand[qualityBand]
 			} else {
-				awards = 0
+				offers = 0
 			}
 		} else if rounds == "full" {
-			awards = models.AwardsPerQualityBand[qualityBand]
+			offers = models.OffersPerQualityBand[qualityBand]
 		} else {
-			// default case, no awards
-			awards = 0
+			// default case, no offers
+			offers = 0
 		}
 
 		MakeTSPPerformance(
@@ -76,7 +76,7 @@ func MakeTSPPerformanceData(db *pop.Connection, rounds string) {
 			tdlList[rand.Intn(len(tdlList))],
 			&qualityBand,
 			bvs,
-			awards,
+			offers,
 		)
 	}
 }

--- a/pkg/testdatagen/scenario_1.go
+++ b/pkg/testdatagen/scenario_1.go
@@ -27,7 +27,7 @@ func RunScenarioOne(db *pop.Connection) {
 	tsp4, _ := MakeTSP(db, "OK TSP", "TSP4")
 	tsp5, _ := MakeTSP(db, "Bad TSP", "TSP5")
 
-	// TSPs should be orderd by award_count first, then BVS.
+	// TSPs should be orderd by offer_count first, then BVS.
 	MakeTSPPerformance(db, tsp1, tdl, swag.Int(1), 5, 0)
 	MakeTSPPerformance(db, tsp2, tdl, swag.Int(1), 4, 0)
 	MakeTSPPerformance(db, tsp3, tdl, swag.Int(2), 3, 0)


### PR DESCRIPTION
## Description

Amie helped us realize that the Award Queue was really more of an _offer_ queue, though it is still called the Award Queue by all the back office people.

The backend representations make a lot more sense if they're called "offers," so I've renamed quite a few functions and the database table `shipment_awards` to `shipment_offers`. I didn't rename everything because it is known by the name "Award Queue."

Hopefully this makes things make _more_ sense, not less.

## Reviewer Notes

* Keep an eye out for other functions or variables which might also benefit from the "award" -> "offer" renaming.

## Verification Steps

* [ ] All tests pass.
* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely) have been satisfied.

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/156031299) for this change