### PR TITLE
make upload route public so we can test on emulator without entering creds

### DIFF
--- a/src/shared/AppWrapper/index.jsx
+++ b/src/shared/AppWrapper/index.jsx
@@ -42,7 +42,7 @@ const AppWrapper = () => (
           <PrivateRoute path="/DD1299" component={DD1299} />
           <PrivateRoute path="/moves/:moveId/legalese" component={Legalese} />
           <Route path="/feedback" component={Feedback} />
-          <PrivateRoute path="/upload" component={Uploader} />
+          <Route path="/upload" component={Uploader} />
           <Route exact path="/mymove" render={redirect('/mymove/intro')} />
           {WizardDemo()}
           <Route exact path="/demo" render={redirect('/demo/sm')} />


### PR DESCRIPTION
## Description

In order to test how the upload is working on Android phones, I want to use emulators. However, I don't want to enter in my credentials. Making this route public allows me to have this. I've created a task to revert once we're content with testing/implementation.

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/155917651) for this change
* [Follow up task to undo change](https://www.pivotaltracker.com/story/show/155917651)

