### PR TITLE
 Updates models to use eager loading feature [delivers #155792199]

### DIFF
--- a/pkg/models/form1299.go
+++ b/pkg/models/form1299.go
@@ -26,7 +26,7 @@ type Form1299 struct {
 	DestOfficeName                         *string                             `json:"dest_office_name" db:"dest_office_name"`
 	OriginOfficeAddressName                *string                             `json:"origin_office_address_name" db:"origin_office_address_name"`
 	OriginOfficeAddressID                  *uuid.UUID                          `json:"origin_office_address_id" db:"origin_office_address_id"`
-	OriginOfficeAddress                    *Address                            `db:"-"`
+	OriginOfficeAddress                    *Address                            `belongs_to:"address"`
 	ServiceMemberFirstName                 *string                             `json:"service_member_first_name" db:"service_member_first_name"`
 	ServiceMemberMiddleInitial             *string                             `json:"service_member_middle_initial" db:"service_member_middle_initial"`
 	ServiceMemberLastName                  *string                             `json:"service_member_last_name" db:"service_member_last_name"`
@@ -57,15 +57,15 @@ type Form1299 struct {
 	StationOrdersParagraphNumber           *string                             `json:"station_orders_paragraph_number" db:"station_orders_paragraph_number"`
 	StationOrdersInTransitTelephone        *string                             `json:"station_orders_in_transit_telephone" db:"station_orders_in_transit_telephone"`
 	InTransitAddressID                     *uuid.UUID                          `json:"in_transit_address_id" db:"in_transit_address_id"`
-	InTransitAddress                       *Address                            `db:"-"`
+	InTransitAddress                       *Address                            `belongs_to:"address"`
 	PickupAddressID                        *uuid.UUID                          `json:"pickup_address_id" db:"pickup_address_id"`
-	PickupAddress                          *Address                            `db:"-"`
+	PickupAddress                          *Address                            `belongs_to:"address"`
 	PickupTelephone                        *string                             `json:"pickup_telephone" db:"pickup_telephone"`
 	DestAddressID                          *uuid.UUID                          `json:"dest_address_id" db:"dest_address_id"`
-	DestAddress                            *Address                            `db:"-"`
+	DestAddress                            *Address                            `belongs_to:"address"`
 	AgentToReceiveHhg                      *string                             `json:"agent_to_receive_hhg" db:"agent_to_receive_hhg"`
 	ExtraAddressID                         *uuid.UUID                          `json:"extra_address_id" db:"extra_address_id"`
-	ExtraAddress                           *Address                            `db:"-"`
+	ExtraAddress                           *Address                            `belongs_to:"address"`
 	PackScheduledDate                      *time.Time                          `json:"pack_scheduled_date" db:"pack_scheduled_date"`
 	PickupScheduledDate                    *time.Time                          `json:"pickup_scheduled_date" db:"pickup_scheduled_date"`
 	DeliveryScheduledDate                  *time.Time                          `json:"delivery_scheduled_date" db:"delivery_scheduled_date"`
@@ -81,7 +81,7 @@ type Form1299 struct {
 	ServiceMemberSignature                 *string                             `json:"service_member_signature" db:"service_member_signature"`
 	DateSigned                             *time.Time                          `json:"date_signed" db:"date_signed"`
 	ContractorAddressID                    *uuid.UUID                          `json:"contractor_address_id" db:"contractor_address_id"`
-	ContractorAddress                      *Address                            `db:"-"`
+	ContractorAddress                      *Address                            `belongs_to:"address"`
 	ContractorName                         *string                             `json:"contractor_name" db:"contractor_name"`
 	NonavailabilityOfSignatureReason       *string                             `json:"nonavailability_of_signature_reason" db:"nonavailability_of_signature_reason"`
 	CertifiedBySignature                   *string                             `json:"certified_by_signature" db:"certified_by_signature"`
@@ -147,13 +147,8 @@ func CreateForm1299WithAddresses(dbConnection *pop.Connection, form1299 *Form129
 func FetchAllForm1299s(dbConnection *pop.Connection) (Form1299s, error) {
 	var err error
 	form1299s := []Form1299{}
-	if err := dbConnection.All(&form1299s); err != nil {
+	if err := dbConnection.Eager().All(&form1299s); err != nil {
 		zap.L().Error("DB Query", zap.Error(err))
-	} else {
-		for i, form1299 := range form1299s {
-			form1299.PopulateAddresses(dbConnection)
-			form1299s[i] = form1299
-		}
 	}
 	return form1299s, err
 }
@@ -161,40 +156,11 @@ func FetchAllForm1299s(dbConnection *pop.Connection) (Form1299s, error) {
 // FetchForm1299ByID fetches a single Form1299 by ID and populated address fields
 func FetchForm1299ByID(dbConnection *pop.Connection, id strfmt.UUID) (Form1299, error) {
 	form1299 := Form1299{}
-	err := dbConnection.Find(&form1299, id)
+	err := dbConnection.Eager().Find(&form1299, id)
 	if err != nil {
 		zap.L().Error("DB Query", zap.Error(err))
-	} else {
-		form1299.PopulateAddresses(dbConnection)
 	}
 	return form1299, err
-}
-
-// PopulateAddresses populates address fields for form1299 structs if ID is present
-func (f *Form1299) PopulateAddresses(dbConnection *pop.Connection) {
-	if f.OriginOfficeAddressID != nil {
-		f.OriginOfficeAddress = FetchAddressByID(dbConnection, f.OriginOfficeAddressID)
-	}
-
-	if f.InTransitAddressID != nil {
-		f.InTransitAddress = FetchAddressByID(dbConnection, f.InTransitAddressID)
-	}
-
-	if f.PickupAddressID != nil {
-		f.PickupAddress = FetchAddressByID(dbConnection, f.PickupAddressID)
-	}
-
-	if f.DestAddressID != nil {
-		f.DestAddress = FetchAddressByID(dbConnection, f.DestAddressID)
-	}
-
-	if f.ExtraAddressID != nil {
-		f.ExtraAddress = FetchAddressByID(dbConnection, f.ExtraAddressID)
-	}
-
-	if f.ContractorAddressID != nil {
-		f.ContractorAddress = FetchAddressByID(dbConnection, f.ContractorAddressID)
-	}
 }
 
 // String is not required by pop and may be deleted

--- a/pkg/models/form1299_test.go
+++ b/pkg/models/form1299_test.go
@@ -135,39 +135,6 @@ func (suite *ModelSuite) TestFetchForm1299ByIDReturnsError() {
 	}
 }
 
-func (suite *ModelSuite) TestPopulateAddressesMethod() {
-	t := suite.T()
-
-	// Given: A form that should have an address but doesn't
-	address := Address{
-		StreetAddress1: "123 My Way",
-		City:           "Seattle",
-		State:          "NY",
-		Zip:            "12345",
-	}
-	suite.db.Create(&address)
-
-	sentForm := Form1299{
-		OriginOfficeAddress:   &address,
-		OriginOfficeAddressID: &address.ID,
-	}
-	suite.db.Create(&sentForm)
-	returnedForm := Form1299{}
-	suite.db.Find(&returnedForm, sentForm.ID)
-
-	if returnedForm.OriginOfficeAddress != nil {
-		t.Fatal("Form should not have an address yet")
-	}
-
-	// When: populateAddresses is called
-	returnedForm.PopulateAddresses(suite.db)
-
-	// Then: Addresses are populated as expected
-	if returnedForm.OriginOfficeAddress == nil {
-		t.Fatal("Form should have an address populated")
-	}
-}
-
 func (suite *ModelSuite) TestCreateForm1299WithAddressesSavesAddresses() {
 	t := suite.T()
 

--- a/pkg/models/form1299_test.go
+++ b/pkg/models/form1299_test.go
@@ -28,10 +28,7 @@ func (suite *ModelSuite) TestBasicForm1299Instantiation() {
 	}
 
 	// When: A Form entry is created in the db
-	err := suite.db.Create(&newForm)
-	if err != nil {
-		t.Fatal("Didn't write to the db.")
-	}
+	suite.mustSave(&newForm)
 
 	// Then: assert that the ID has a value of type uuid
 	if newForm.ID == uuid.Nil {
@@ -79,11 +76,8 @@ func (suite *ModelSuite) TestFetchAllForm1299s() {
 		ServiceMemberFirstName: &serviceMemberFirstName2,
 	}
 
-	err1 := suite.db.Create(&form1)
-	err2 := suite.db.Create(&form2)
-	if err1 != nil || err2 != nil {
-		t.Fatal("Didn't write to the db.")
-	}
+	suite.mustSave(&form1)
+	suite.mustSave(&form2)
 
 	// When: Fetch all Form1299s is called
 	form1299s, _ := FetchAllForm1299s(suite.db)
@@ -101,10 +95,7 @@ func (suite *ModelSuite) TestFetchForm1299ByID() {
 	form := Form1299{
 		ServiceMemberFirstName: &serviceMemberFirstName1,
 	}
-
-	if err := suite.db.Create(&form); err != nil {
-		t.Fatal("Didn't write to the db.")
-	}
+	suite.mustSave(&form)
 
 	// When: Fetch form 1299 by ID is called
 	id := strfmt.UUID(form.ID.String())
@@ -118,6 +109,35 @@ func (suite *ModelSuite) TestFetchForm1299ByID() {
 	if *form.ServiceMemberFirstName != *returnedForm.ServiceMemberFirstName {
 		t.Fatal(fmt.Sprintf("The returned form's contents don't match expected: %s vs %s",
 			*form.ServiceMemberFirstName, *returnedForm.ServiceMemberFirstName))
+	}
+}
+
+func (suite *ModelSuite) TestFetchForm1299ByIDEagerLoads() {
+	t := suite.T()
+	// Given: A 1299 form
+	address := Address{
+		StreetAddress1: "123 My Way",
+		City:           "Seattle",
+		State:          "NY",
+		Zip:            "12345",
+	}
+	suite.mustSave(&address)
+	form := Form1299{
+		OriginOfficeAddressID: &address.ID,
+	}
+	suite.mustSave(&form)
+
+	// When: Fetch form 1299 by ID is called
+	id := strfmt.UUID(form.ID.String())
+	returnedForm, err := FetchForm1299ByID(suite.db, id)
+
+	// Then: The specified record is returned and the address model is populated
+	if err != nil {
+		t.Fatal("No record found for that ID")
+	}
+
+	if returnedForm.OriginOfficeAddress == nil || returnedForm.OriginOfficeAddress.ID != *returnedForm.OriginOfficeAddressID {
+		t.Fatal("Address model wasn't populated onto form 1299")
 	}
 }
 

--- a/pkg/models/move.go
+++ b/pkg/models/move.go
@@ -20,6 +20,7 @@ type Move struct {
 	CreatedAt        time.Time                          `json:"created_at" db:"created_at"`
 	UpdatedAt        time.Time                          `json:"updated_at" db:"updated_at"`
 	UserID           uuid.UUID                          `json:"user_id" db:"user_id"`
+	User             User                               `belongs_to:"user"`
 	SelectedMoveType *internalmessages.SelectedMoveType `json:"selected_move_type" db:"selected_move_type"`
 }
 

--- a/pkg/models/personally_procured_move.go
+++ b/pkg/models/personally_procured_move.go
@@ -14,6 +14,7 @@ import (
 type PersonallyProcuredMove struct {
 	ID             uuid.UUID                    `json:"id" db:"id"`
 	MoveID         uuid.UUID                    `json:"move_id" db:"move_id"`
+	Move           Move                         `belongs_to:"move"`
 	CreatedAt      time.Time                    `json:"created_at" db:"created_at"`
 	UpdatedAt      time.Time                    `json:"updated_at" db:"updated_at"`
 	Size           *internalmessages.TShirtSize `json:"size" db:"size"`


### PR DESCRIPTION
## Description

As a follow up to #291, this implements some of the new relational features that were added to Pop recently. Namely, we're setting up relationships between the Form1299 model and Address sub-models, and allowing Pop to handle automatically populating those Address models from the address table.

We don't exactly use the Form1299 model much anymore, but it provides a nice example for how this relationship can be implemented.

## Reviewer Notes

There's still some models A-team set up that have foreign keys and could take advantage of these ORM features, but I lack context on them and they have some fancy joining that I haven't looked much into. @jim or @akostibas might know more about whether those models could benefit from something like this.

## Verification Steps

* [x] All tests pass.
* [x] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely) have been satisfied.

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/155792199) for this change
* [this article](https://gobuffalo.io/en/docs/db/relations) explains more about the approach used.