### PR TITLE
Adds addresses and related fields to Move payloads [delivers #156072908]

### DIFF
--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -554,9 +554,6 @@ definitions:
         $ref: '#/definitions/Address'
       use_destination_storage:
         type: boolean
-    # TODO: uncomment below once we start populating pickup address
-    # required:
-    #   - pickup_address
   MovePayload:
     type: object
     properties:

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -548,12 +548,14 @@ definitions:
         $ref: '#/definitions/Address'
       delivery_address_known:
         type: boolean
+        x-nullable: true
       delivery_address:
         $ref: '#/definitions/Address'
       secondary_delivery_address:
         $ref: '#/definitions/Address'
       use_destination_storage:
         type: boolean
+        x-nullable: true
   MovePayload:
     type: object
     properties:
@@ -573,12 +575,14 @@ definitions:
         $ref: '#/definitions/Address'
       delivery_address_known:
         type: boolean
+        x-nullable: true
       delivery_address:
         $ref: '#/definitions/Address'
       secondary_delivery_address:
         $ref: '#/definitions/Address'
       use_destination_storage:
         type: boolean
+        x-nullable: true
       created_at:
         type: string
         format: date-time
@@ -588,13 +592,6 @@ definitions:
     required:
       - id
       - user_id
-      - selected_move_type
-      - pickup_address
-      - secondary_pickup_address
-      - delivery_address_known
-      - delivery_address
-      - secondary_delivery_address
-      - use_destination_storage
       - created_at
       - updated_at
   PatchMovePayload:
@@ -608,12 +605,14 @@ definitions:
         $ref: '#/definitions/Address'
       delivery_address_known:
         type: boolean
+        x-nullable: true
       delivery_address:
         $ref: '#/definitions/Address'
       secondary_delivery_address:
         $ref: '#/definitions/Address'
       use_destination_storage:
         type: boolean
+        x-nullable: true
   SelectedMoveType:
     type: string
     title: Selected Move Type

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -252,7 +252,6 @@ paths:
           description: move not found
         500:
           description: internal server error
-
   /moves/{moveId}/personally_procured_move:
     post:
       summary: Creates a new PPM for the given move
@@ -543,35 +542,81 @@ definitions:
     properties:
       selected_move_type:
         $ref: '#/definitions/SelectedMoveType'
+      pickup_address:
+        $ref: '#/definitions/Address'
+      secondary_pickup_address:
+        $ref: '#/definitions/Address'
+      delivery_address_known:
+        type: boolean
+      delivery_address:
+        $ref: '#/definitions/Address'
+      secondary_delivery_address:
+        $ref: '#/definitions/Address'
+      use_destination_storage:
+        type: boolean
+    # TODO: uncomment below once we start populating pickup address
+    # required:
+    #   - pickup_address
   MovePayload:
-   type: object
-   properties:
-     id:
-       type: string
-       format: uuid
-       example: c56a4180-65aa-42ec-a945-5fd21dec0538
-     user_id:
-       type: string
-       format: uuid
-       example: c56a4180-65aa-42ec-a945-5fd21dec0538
-     selected_move_type:
-       $ref: '#/definitions/SelectedMoveType'
-     created_at:
-       type: string
-       format: date-time
-     updated_at:
-       type: string
-       format: date-time
-   required:
-    - id
-    - user_id
-    - created_at
-    - updated_at
+    type: object
+    properties:
+      id:
+        type: string
+        format: uuid
+        example: c56a4180-65aa-42ec-a945-5fd21dec0538
+      user_id:
+        type: string
+        format: uuid
+        example: c56a4180-65aa-42ec-a945-5fd21dec0538
+      selected_move_type:
+        $ref: '#/definitions/SelectedMoveType'
+      pickup_address:
+        $ref: '#/definitions/Address'
+      secondary_pickup_address:
+        $ref: '#/definitions/Address'
+      delivery_address_known:
+        type: boolean
+      delivery_address:
+        $ref: '#/definitions/Address'
+      secondary_delivery_address:
+        $ref: '#/definitions/Address'
+      use_destination_storage:
+        type: boolean
+      created_at:
+        type: string
+        format: date-time
+      updated_at:
+        type: string
+        format: date-time
+    required:
+      - id
+      - user_id
+      - selected_move_type
+      - pickup_address
+      - secondary_pickup_address
+      - delivery_address_known
+      - delivery_address
+      - secondary_delivery_address
+      - use_destination_storage
+      - created_at
+      - updated_at
   PatchMovePayload:
-   type: object
-   properties:
-     selected_move_type:
-       $ref: '#/definitions/SelectedMoveType'
+    type: object
+    properties:
+      selected_move_type:
+        $ref: '#/definitions/SelectedMoveType'
+      pickup_address:
+        $ref: '#/definitions/Address'
+      secondary_pickup_address:
+        $ref: '#/definitions/Address'
+      delivery_address_known:
+        type: boolean
+      delivery_address:
+        $ref: '#/definitions/Address'
+      secondary_delivery_address:
+        $ref: '#/definitions/Address'
+      use_destination_storage:
+        type: boolean
   SelectedMoveType:
     type: string
     title: Selected Move Type


### PR DESCRIPTION
## Description

This adds fields onto `MovePayload` and related models for pickup, destination, and secondary addresses. Also adds a couple booleans for whether delivery address is known by the SM, and whether SIT will be required

## Reviewer Notes

The Pivotal Tracker story says
> AC: A move has a required pickup address

but since we don't yet have UI for populating this field it would break our current flow. I chose to comment out the part that requires that field for now but left a message saying we should bring it back in when needed.

## Verification Steps

* [ ] All tests pass.
* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely) have been satisfied.
* [ ] There are no [aXe](https://www.deque.com/products/aXe/) warnings for UI.
* [ ] This works in IE.

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/156072908) for this change