### PR TITLE
Adjust handler code to prevent orphan uploads from being created [delivers #156282874]

### DIFF
--- a/pkg/handlers/uploads.go
+++ b/pkg/handlers/uploads.go
@@ -95,7 +95,6 @@ func (h CreateUploadHandler) Handle(params uploadop.CreateUploadParams) middlewa
 		h.logger.Error("DB Insertion", zap.Error(err))
 		return uploadop.NewCreateUploadInternalServerError()
 	}
-	h.logger.Infof("created an upload with id %s, s3 id %s\n", newUpload.ID, newUpload.ID)
 
 	url, err := h.storage.PresignedURL(key)
 	if err != nil {

--- a/pkg/handlers/uploads.go
+++ b/pkg/handlers/uploads.go
@@ -96,6 +96,8 @@ func (h CreateUploadHandler) Handle(params uploadop.CreateUploadParams) middlewa
 		return uploadop.NewCreateUploadInternalServerError()
 	}
 
+	h.logger.Infof("created an upload with id %s, s3 key %s\n", newUpload.ID, key)
+
 	url, err := h.storage.PresignedURL(key)
 	if err != nil {
 		h.logger.Error("failed to get presigned url", zap.Error(err))

--- a/pkg/handlers/uploads_test.go
+++ b/pkg/handlers/uploads_test.go
@@ -136,7 +136,7 @@ func (suite *HandlerSuite) TestCreateUploadsHandlerSuccess() {
 	// TODO verify Body
 }
 
-func (suite *HandlerSuite) TestCreateUploadsHandlerFailuer() {
+func (suite *HandlerSuite) TestCreateUploadsHandlerFailure() {
 	t := suite.T()
 	fakeS3 := newFakeS3Storage(false)
 	_, _, response := createUpload(suite, fakeS3)
@@ -153,6 +153,6 @@ func (suite *HandlerSuite) TestCreateUploadsHandlerFailuer() {
 	}
 
 	if count != 0 {
-		t.Fatalf("Wroung number of uploads in database: expected 0, got %d", count)
+		t.Fatalf("Wrong number of uploads in database: expected 0, got %d", count)
 	}
 }

--- a/pkg/handlers/uploads_test.go
+++ b/pkg/handlers/uploads_test.go
@@ -93,7 +93,7 @@ func createUpload(suite *HandlerSuite, fakeS3 *fakeS3Storage) (models.Move, mode
 	return move, document, response
 }
 
-func (suite *HandlerSuite) TestCreateUploadsHandler() {
+func (suite *HandlerSuite) TestCreateUploadsHandlerSuccess() {
 	t := suite.T()
 	fakeS3 := newFakeS3Storage(true)
 	move, document, response := createUpload(suite, fakeS3)
@@ -134,4 +134,25 @@ func (suite *HandlerSuite) TestCreateUploadsHandler() {
 	}
 
 	// TODO verify Body
+}
+
+func (suite *HandlerSuite) TestCreateUploadsHandlerFailuer() {
+	t := suite.T()
+	fakeS3 := newFakeS3Storage(false)
+	_, _, response := createUpload(suite, fakeS3)
+
+	_, ok := response.(*uploadop.CreateUploadInternalServerError)
+	if !ok {
+		t.Fatalf("Request was success, expected failure")
+	}
+
+	count, err := suite.db.Count(&models.Upload{})
+
+	if err != nil {
+		t.Fatalf("Couldn't count uploads in database: %s", err)
+	}
+
+	if count != 0 {
+		t.Fatalf("Wroung number of uploads in database: expected 0, got %d", count)
+	}
 }

--- a/pkg/handlers/uploads_test.go
+++ b/pkg/handlers/uploads_test.go
@@ -2,11 +2,13 @@ package handlers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"path"
 
+	"github.com/go-openapi/runtime/middleware"
 	"github.com/go-openapi/strfmt"
 
 	authcontext "github.com/transcom/mymove/pkg/auth/context"
@@ -23,7 +25,8 @@ type putFile struct {
 }
 
 type fakeS3Storage struct {
-	putFiles []putFile
+	putFiles    []putFile
+	willSucceed bool
 }
 
 func (fake *fakeS3Storage) Key(args ...string) string {
@@ -42,7 +45,10 @@ func (fake *fakeS3Storage) Store(key string, data io.ReadSeeker, md5 string) (*s
 	if err != nil {
 		return nil, err
 	}
-	return &storage.StoreResult{}, nil
+	if fake.willSucceed {
+		return &storage.StoreResult{}, nil
+	}
+	return nil, errors.New("failed to push")
 }
 
 func (fake *fakeS3Storage) PresignedURL(key string) (string, error) {
@@ -50,7 +56,13 @@ func (fake *fakeS3Storage) PresignedURL(key string) (string, error) {
 	return url, nil
 }
 
-func (suite *HandlerSuite) TestCreateUploadsHandler() {
+func newFakeS3Storage(willSucceed bool) *fakeS3Storage {
+	return &fakeS3Storage{
+		willSucceed: willSucceed,
+	}
+}
+
+func createUpload(suite *HandlerSuite, fakeS3 *fakeS3Storage) (models.Move, models.Document, middleware.Responder) {
 	t := suite.T()
 
 	move, err := testdatagen.MakeMove(suite.db)
@@ -62,7 +74,6 @@ func (suite *HandlerSuite) TestCreateUploadsHandler() {
 	if err != nil {
 		t.Fatalf("could not create document: %s", err)
 	}
-	fakeS3 := &fakeS3Storage{}
 
 	userID := move.UserID
 
@@ -79,6 +90,14 @@ func (suite *HandlerSuite) TestCreateUploadsHandler() {
 	handler := CreateUploadHandler(fileContext)
 	response := handler.Handle(params)
 
+	return move, document, response
+}
+
+func (suite *HandlerSuite) TestCreateUploadsHandler() {
+	t := suite.T()
+	fakeS3 := newFakeS3Storage(true)
+	move, document, response := createUpload(suite, fakeS3)
+
 	createdResponse, ok := response.(*uploadop.CreateUploadCreated)
 	if !ok {
 		t.Fatalf("Request failed: %#v", response)
@@ -86,7 +105,7 @@ func (suite *HandlerSuite) TestCreateUploadsHandler() {
 
 	uploadPayload := createdResponse.Payload
 	upload := models.Upload{}
-	err = suite.db.Find(&upload, uploadPayload.ID)
+	err := suite.db.Find(&upload, uploadPayload.ID)
 	if err != nil {
 		t.Fatalf("Couldn't find expected upload.")
 	}

--- a/pkg/models/upload_test.go
+++ b/pkg/models/upload_test.go
@@ -3,6 +3,8 @@ package models_test
 import (
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"
+
+	"github.com/gobuffalo/uuid"
 )
 
 func (suite *ModelSuite) Test_UploadCreate() {
@@ -36,6 +38,46 @@ func (suite *ModelSuite) Test_UploadCreate() {
 
 	if verrs.Count() != 0 {
 		t.Errorf("did not expect validation errors: %v", verrs)
+	}
+}
+
+func (suite *ModelSuite) Test_UploadCreateWithID() {
+	t := suite.T()
+
+	move, err := testdatagen.MakeMove(suite.db)
+	if err != nil {
+		t.Fatalf("could not create move: %v", err)
+	}
+
+	document := models.Document{
+		UploaderID: move.UserID,
+		MoveID:     move.ID,
+	}
+	suite.mustSave(&document)
+
+	id := uuid.Must(uuid.NewV4())
+	upload := models.Upload{
+		ID:          id,
+		DocumentID:  document.ID,
+		UploaderID:  move.UserID,
+		Filename:    "test.pdf",
+		Bytes:       1048576,
+		ContentType: "application/pdf",
+		Checksum:    "ImGQ2Ush0bDHsaQthV5BnQ==",
+	}
+
+	verrs, err := suite.db.ValidateAndSave(&upload)
+
+	if err != nil {
+		t.Fatalf("could not save Upload: %v", err)
+	}
+
+	if verrs.Count() != 0 {
+		t.Errorf("did not expect validation errors: %v", verrs)
+	}
+
+	if upload.ID.String() != id.String() {
+		t.Errorf("wrong uuid for upload: expected %s, got %s", id.String(), upload.ID.String())
 	}
 }
 


### PR DESCRIPTION
## Description

The previous implementation created a row in the `uploads` table before attempting to store a file on S3, which meant that any errors raised during the upload would leave an invalid row in the database.

We had a few ideas about how to proceed here, including using database transactions, but it turns out that specifying an ID on a Pop model before it created is possible. So we now generate an ID for the new upload, use that to build a key and push the file to S3, and as a last step create the `Upload` in the database. This way, errors that are encountered can simply be returned without having to deal with cleanup (and we avoid needing a database transaction).

## Reviewer Notes

- None of the validation on `Upload` depend on the state of the database, so performing validation before the push to S3 and then skipping it later when it comes time to create the `Upload` isn't an issue.

## Verification Steps

* [ ] All tests pass.

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/156282874) for this change