### PR TITLE
Pass content checksum to S3 [delivers #156282636]

### DIFF
--- a/pkg/storage/s3.go
+++ b/pkg/storage/s3.go
@@ -28,9 +28,10 @@ func NewS3(bucket string, logger *zap.Logger, session *session.Session) *S3 {
 // Store stores the content from an io.ReadSeeker at the specified key.
 func (s *S3) Store(key string, data io.ReadSeeker, md5 string) (*StoreResult, error) {
 	input := &s3.PutObjectInput{
-		Bucket: &s.bucket,
-		Key:    &key,
-		Body:   data,
+		Bucket:     &s.bucket,
+		Key:        &key,
+		Body:       data,
+		ContentMD5: &md5,
 	}
 
 	_, err := s.client.PutObject(input)


### PR DESCRIPTION
## Description

We were previously calculating an uploaded file's MD5 checksum and storing it in our database. This patch modifies our S3 code to also pass that value to S3 when uploading a file. This verifies that the file received on the remote end has been successfully transmitted and its use is recommended by AWS:

> Although it is optional, we recommend using the Content-MD5 mechanism as an end-to-end integrity check. 

## Verification Steps

* [x] All tests pass.
* [x] File upload works properly.

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/156282636) for this change
* [AWS documentation for object PUT requests](https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectPUT.html#RESTObjectPUT-requests-request-headers)
