### PR TITLE
Verify ENV vars when booting server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,9 +64,11 @@ server_build: server_deps server_generate
 	go build -i -o bin/webserver ./cmd/webserver
 # This command is for running the server by itself, it will serve the compiled frontend on its own
 server_run_standalone: client_build server_build db_dev_run
+	bin/check_env_vars
 	DEBUG_LOGGING=true ./bin/webserver
 # This command runs the server behind gin, a hot-reload server
 server_run: server_deps server_generate db_dev_run
+	bin/check_env_vars
 	INTERFACE=localhost DEBUG_LOGGING=true \
 	./bin/gin --build ./cmd/webserver \
 		--bin /bin/webserver \

--- a/bin/check_env_vars
+++ b/bin/check_env_vars
@@ -1,8 +1,8 @@
 #! /bin/bash
 
 vars=$(grep -Eo "export [A-Z0-9_]+" example_envrc | grep -Eo "[A-Z0-9_]+")
-
 missing_var=false
+
 for var in $vars; do
   if [[ -z "${!var}" ]]; then
     echo "$var is not set"
@@ -11,5 +11,6 @@ for var in $vars; do
 done
 
 if [[ $missing_var == "true" ]]; then
+  echo "Your environment is missing some variables, aborting."
   exit 1
 fi

--- a/bin/check_env_vars
+++ b/bin/check_env_vars
@@ -1,0 +1,15 @@
+#! /bin/bash
+
+vars=$(grep -Eo "export [A-Z0-9_]+" example_envrc | grep -Eo "[A-Z0-9_]+")
+
+missing_var=false
+for var in $vars; do
+  if [[ -z "${!var}" ]]; then
+    echo "$var is not set"
+    missing_var=true
+  fi
+done
+
+if [[ $missing_var == "true" ]]; then
+  exit 1
+fi


### PR DESCRIPTION
## Description

We've had a few instances recently where environment variables were required for the server to start but their existence was not common knowledge. We tend to document these in the README, but this doesn't always happen and it is hard to scan that long document and determine what is missing.

The compounding issue is that the error messages stemming from missing environment variables are often not obvious. For example, here is what is shown if `HTTPS_CERT` is not set:


```
$ make server_run
... 
db-dev
INTERFACE=localhost DEBUG_LOGGING=true \
	./bin/gin --build ./cmd/webserver \
		--bin /bin/webserver \
		--port 8080 --appPort 8081 \
		--excludeDir vendor --excludeDir node_modules \
		-i --buildArgs "-i"
[gin] Listening on port 8080
[gin] Building...
[gin] Build finished
2018-03-28T13:11:44.258-0500	INFO	webserver/main.go:29	Request logger installed
2018-03-28T13:11:44.258-0500	INFO	webserver/main.go:165	Starting https server listening	{"address": "localhost:8443"}
2018/03/28 13:11:44 tls: failed to find any PEM data in certificate input
```

Unless you think to check that the variables defined in `example_envrc` are all being set in your environment, it's not obvious how to proceed. Additionally, although it appears that the build succeeds, no requests will be handled properly.

With this patch, this is what happens in that same scenario:

```
$ make server_run
...
db-dev
bin/check_env_vars
HTTPS_CERT is not set
HTTPS_KEY is not set
Your environment is missing some variables, aborting.
```

Any environment variable that is mentioned in `example_envrc` but not in the current environment will be detected and the server run aborted. This, of course, assumes that we keep `example_envrc` up to date. So far, though, that has been happening without issue.

## Reviewer Notes

- My `bash` is not great, so any input on improving the scripting would be appreciated.