### PR TITLE
Bb add gbloc blackout query

### DIFF
--- a/pkg/awardqueue/awardqueue_test.go
+++ b/pkg/awardqueue/awardqueue_test.go
@@ -30,7 +30,7 @@ func (suite *AwardQueueSuite) Test_CheckAllTSPsBlackedOut() {
 	deliverDate := blackoutStartDate.Add(time.Hour * 24 * 60)
 	market := "dHHG"
 	sourceGBLOC := "OHAI"
-	shipment, _ := testdatagen.MakeShipment(suite.db, pickupDate, pickupDate, deliverDate, tdl, sourceGBLOC, market)
+	shipment, _ := testdatagen.MakeShipment(suite.db, pickupDate, pickupDate, deliverDate, tdl, sourceGBLOC, &market)
 
 	// Create a ShipmentWithOffer to feed the award queue
 	shipmentWithOffer := models.ShipmentWithOffer{
@@ -74,8 +74,8 @@ func (suite *AwardQueueSuite) Test_CheckShipmentDuringBlackOut() {
 	deliverDate := blackoutStartDate.AddDate(0, 0, 5)
 
 	// Create a shipment within blackout dates and one not within blackout dates
-	blackoutShipment, _ := testdatagen.MakeShipment(suite.db, pickupDate, pickupDate, deliverDate, tdl, sourceGBLOC, market)
-	shipment, _ := testdatagen.MakeShipment(suite.db, time.Now(), time.Now(), time.Now().AddDate(0, 0, 1), tdl, sourceGBLOC, market)
+	blackoutShipment, _ := testdatagen.MakeShipment(suite.db, pickupDate, pickupDate, deliverDate, tdl, sourceGBLOC, &market)
+	shipment, _ := testdatagen.MakeShipment(suite.db, time.Now(), time.Now(), time.Now().AddDate(0, 0, 1), tdl, sourceGBLOC, &market)
 
 	// Run the Award Queue
 	queue.assignShipments()
@@ -120,8 +120,8 @@ func (suite *AwardQueueSuite) Test_ShipmentWithinBlackoutDates() {
 	testPickupDateAfter := testEndDate.Add(time.Hour * 24 * 5)
 
 	// Two shipments using these pickup dates to provide to ShipmentWithinBlackoutDates
-	testShipmentBetween, _ := testdatagen.MakeShipment(suite.db, testPickupDateBetween, testStartDate, testEndDate, testTDL, sourceGBLOC, market)
-	testShipmentAfter, _ := testdatagen.MakeShipment(suite.db, testPickupDateAfter, testStartDate, testEndDate, testTDL, sourceGBLOC, market)
+	testShipmentBetween, _ := testdatagen.MakeShipment(suite.db, testPickupDateBetween, testStartDate, testEndDate, testTDL, sourceGBLOC, &market)
+	testShipmentAfter, _ := testdatagen.MakeShipment(suite.db, testPickupDateAfter, testStartDate, testEndDate, testTDL, sourceGBLOC, &market)
 
 	// One TSP with no blackout dates
 	testTSP2, _ := testdatagen.MakeTSP(suite.db, "A Spotless TSP", "PORK")
@@ -197,7 +197,7 @@ func (suite *AwardQueueSuite) Test_OfferSingleShipment() {
 	tdl, _ := testdatagen.MakeTDL(suite.db, "california", "90210", "2")
 	market := "dHHG"
 	sourceGBLOC := "OHAI"
-	shipment, _ := testdatagen.MakeShipment(suite.db, time.Now(), time.Now(), time.Now(), tdl, sourceGBLOC, market)
+	shipment, _ := testdatagen.MakeShipment(suite.db, time.Now(), time.Now(), time.Now(), tdl, sourceGBLOC, &market)
 
 	// Make a TSP to handle it
 	tsp, _ := testdatagen.MakeTSP(suite.db, "Test Shipper", "TEST")
@@ -236,7 +236,7 @@ func (suite *AwardQueueSuite) Test_FailOfferingSingleShipment() {
 	tdl, _ := testdatagen.MakeTDL(suite.db, "california", "90210", "2")
 	market := "dHHG"
 	sourceGBLOC := "OHAI"
-	shipment, _ := testdatagen.MakeShipment(suite.db, time.Now(), time.Now(), time.Now(), tdl, sourceGBLOC, market)
+	shipment, _ := testdatagen.MakeShipment(suite.db, time.Now(), time.Now(), time.Now(), tdl, sourceGBLOC, &market)
 
 	// Create a ShipmentWithOffer to feed the award queue
 	shipmentWithOffer := models.ShipmentWithOffer{
@@ -276,7 +276,7 @@ func (suite *AwardQueueSuite) TestAssignShipmentsSingleTSP() {
 
 	// Make a few shipments in this TDL
 	for i := 0; i < shipmentsToMake; i++ {
-		testdatagen.MakeShipment(suite.db, time.Now(), time.Now(), time.Now(), tdl, sourceGBLOC, market)
+		testdatagen.MakeShipment(suite.db, time.Now(), time.Now(), time.Now(), tdl, sourceGBLOC, &market)
 	}
 
 	// Make a TSP in the same TDL to handle these shipments
@@ -319,7 +319,7 @@ func (suite *AwardQueueSuite) TestAssignShipmentsToMultipleTSPs() {
 
 	// Make shipments in this TDL
 	for i := 0; i < shipmentsToMake; i++ {
-		testdatagen.MakeShipment(suite.db, time.Now(), time.Now(), time.Now(), tdl, sourceGBLOC, market)
+		testdatagen.MakeShipment(suite.db, time.Now(), time.Now(), time.Now(), tdl, sourceGBLOC, &market)
 	}
 
 	// Make TSPs in the same TDL to handle these shipments

--- a/pkg/awardqueue/awardqueue_test.go
+++ b/pkg/awardqueue/awardqueue_test.go
@@ -29,7 +29,8 @@ func (suite *AwardQueueSuite) Test_CheckAllTSPsBlackedOut() {
 	pickupDate := blackoutStartDate.Add(time.Hour)
 	deliverDate := blackoutStartDate.Add(time.Hour * 24 * 60)
 	market := "dHHG"
-	shipment, _ := testdatagen.MakeShipment(suite.db, pickupDate, pickupDate, deliverDate, tdl, market)
+	sourceGBLOC := "OHAI"
+	shipment, _ := testdatagen.MakeShipment(suite.db, pickupDate, pickupDate, deliverDate, tdl, sourceGBLOC, market)
 
 	// Create a ShipmentWithOffer to feed the award queue
 	shipmentWithOffer := models.ShipmentWithOffer{
@@ -61,19 +62,20 @@ func (suite *AwardQueueSuite) Test_CheckShipmentDuringBlackOut() {
 	tsp, _ := testdatagen.MakeTSP(suite.db, "A Very Excellent TSP", "XYZA")
 	tdl, _ := testdatagen.MakeTDL(suite.db, "Oklahoma", "62240", "5")
 	market := "dHHG"
+	sourceGBLOC := "OHAI"
 	testdatagen.MakeTSPPerformance(suite.db, tsp, tdl, swag.Int(1), mps+1, 0)
 	// Sets a blackout period that starts 12 months from today and ends 13 months from today
 	blackoutStartDate := time.Now().AddDate(1, 0, 0)
 	blackoutEndDate := blackoutStartDate.AddDate(0, 1, 0)
 
-	testdatagen.MakeBlackoutDate(suite.db, tsp, blackoutStartDate, blackoutEndDate, &tdl, nil, &market)
+	testdatagen.MakeBlackoutDate(suite.db, tsp, blackoutStartDate, blackoutEndDate, &tdl, &sourceGBLOC, &market)
 
 	pickupDate := blackoutStartDate.AddDate(0, 0, 1)
 	deliverDate := blackoutStartDate.AddDate(0, 0, 5)
 
 	// Create a shipment within blackout dates and one not within blackout dates
-	blackoutShipment, _ := testdatagen.MakeShipment(suite.db, pickupDate, pickupDate, deliverDate, tdl, market)
-	shipment, _ := testdatagen.MakeShipment(suite.db, time.Now(), time.Now(), time.Now().AddDate(0, 0, 1), tdl, market)
+	blackoutShipment, _ := testdatagen.MakeShipment(suite.db, pickupDate, pickupDate, deliverDate, tdl, sourceGBLOC, market)
+	shipment, _ := testdatagen.MakeShipment(suite.db, time.Now(), time.Now(), time.Now().AddDate(0, 0, 1), tdl, sourceGBLOC, market)
 
 	// Run the Award Queue
 	queue.assignShipments()
@@ -108,6 +110,7 @@ func (suite *AwardQueueSuite) Test_ShipmentWithinBlackoutDates() {
 	testTSP1, _ := testdatagen.MakeTSP(suite.db, "A Very Excellent TSP", "XYZA")
 	testTDL, _ := testdatagen.MakeTDL(suite.db, "Oklahoma", "62240", "5")
 	market := "dHHG"
+	sourceGBLOC := "OHAI"
 	testStartDate := time.Now()
 	testEndDate := testStartDate.Add(time.Hour * 24 * 2)
 	testdatagen.MakeBlackoutDate(suite.db, testTSP1, testStartDate, testEndDate, &testTDL, nil, nil)
@@ -117,8 +120,8 @@ func (suite *AwardQueueSuite) Test_ShipmentWithinBlackoutDates() {
 	testPickupDateAfter := testEndDate.Add(time.Hour * 24 * 5)
 
 	// Two shipments using these pickup dates to provide to ShipmentWithinBlackoutDates
-	testShipmentBetween, _ := testdatagen.MakeShipment(suite.db, testPickupDateBetween, testStartDate, testEndDate, testTDL, market)
-	testShipmentAfter, _ := testdatagen.MakeShipment(suite.db, testPickupDateAfter, testStartDate, testEndDate, testTDL, market)
+	testShipmentBetween, _ := testdatagen.MakeShipment(suite.db, testPickupDateBetween, testStartDate, testEndDate, testTDL, sourceGBLOC, market)
+	testShipmentAfter, _ := testdatagen.MakeShipment(suite.db, testPickupDateAfter, testStartDate, testEndDate, testTDL, sourceGBLOC, market)
 
 	// One TSP with no blackout dates
 	testTSP2, _ := testdatagen.MakeTSP(suite.db, "A Spotless TSP", "PORK")
@@ -193,7 +196,8 @@ func (suite *AwardQueueSuite) Test_OfferSingleShipment() {
 	// Make a shipment
 	tdl, _ := testdatagen.MakeTDL(suite.db, "california", "90210", "2")
 	market := "dHHG"
-	shipment, _ := testdatagen.MakeShipment(suite.db, time.Now(), time.Now(), time.Now(), tdl, market)
+	sourceGBLOC := "OHAI"
+	shipment, _ := testdatagen.MakeShipment(suite.db, time.Now(), time.Now(), time.Now(), tdl, sourceGBLOC, market)
 
 	// Make a TSP to handle it
 	tsp, _ := testdatagen.MakeTSP(suite.db, "Test Shipper", "TEST")
@@ -231,7 +235,8 @@ func (suite *AwardQueueSuite) Test_FailOfferingSingleShipment() {
 	// Make a shipment in a new TDL, which inherently has no TSPs
 	tdl, _ := testdatagen.MakeTDL(suite.db, "california", "90210", "2")
 	market := "dHHG"
-	shipment, _ := testdatagen.MakeShipment(suite.db, time.Now(), time.Now(), time.Now(), tdl, market)
+	sourceGBLOC := "OHAI"
+	shipment, _ := testdatagen.MakeShipment(suite.db, time.Now(), time.Now(), time.Now(), tdl, sourceGBLOC, market)
 
 	// Create a ShipmentWithOffer to feed the award queue
 	shipmentWithOffer := models.ShipmentWithOffer{
@@ -266,9 +271,12 @@ func (suite *AwardQueueSuite) TestAssignShipmentsSingleTSP() {
 	// Make a market
 	market := "dHHG"
 
+	// Make a source GBLOC
+	sourceGBLOC := "OHAI"
+
 	// Make a few shipments in this TDL
 	for i := 0; i < shipmentsToMake; i++ {
-		testdatagen.MakeShipment(suite.db, time.Now(), time.Now(), time.Now(), tdl, market)
+		testdatagen.MakeShipment(suite.db, time.Now(), time.Now(), time.Now(), tdl, sourceGBLOC, market)
 	}
 
 	// Make a TSP in the same TDL to handle these shipments
@@ -306,9 +314,12 @@ func (suite *AwardQueueSuite) TestAssignShipmentsToMultipleTSPs() {
 	// Make a market
 	market := "dHHG"
 
+	// Make a source GBLOC
+	sourceGBLOC := "OHAI"
+
 	// Make shipments in this TDL
 	for i := 0; i < shipmentsToMake; i++ {
-		testdatagen.MakeShipment(suite.db, time.Now(), time.Now(), time.Now(), tdl, market)
+		testdatagen.MakeShipment(suite.db, time.Now(), time.Now(), time.Now(), tdl, sourceGBLOC, market)
 	}
 
 	// Make TSPs in the same TDL to handle these shipments

--- a/pkg/models/blackout_dates.go
+++ b/pkg/models/blackout_dates.go
@@ -32,22 +32,15 @@ func FetchTSPBlackoutDates(tx *pop.Connection, tspID uuid.UUID, shipment Shipmen
 
 	query := tx.Where("transportation_service_provider_id = $1", tspID).Where("$2 BETWEEN start_blackout_date and end_blackout_date", shipment.PickupDate)
 
-	// if shipment.Market != nil {
-	// 	sql := `SELECT
-	// 		*
-	// 	FROM
-	// 		blackout_dates
-	// 	WHERE
-	// 		transportation_service_provider_id = $1
-	// 	AND
-	// 		$2 BETWEEN start_blackout_date and end_blackout_date
-	// 	AND
-	// 		market = $3`
-	// 	err = tx.RawQuery(sql, tspID, shipment.PickupDate, *shipment.Market).All(&blackoutDates)
+	if shipment.Market != nil {
+		query = query.Where("market = $3", *shipment.Market)
+	}
 
-	// } else {
+	if shipment.SourceGBLOC != nil {
+		query = query.Where("source_gbloc = $4", *shipment.SourceGBLOC)
+	}
+
 	err = query.All(&blackoutDates)
-	// }
 
 	return blackoutDates, err
 }

--- a/pkg/models/blackout_dates.go
+++ b/pkg/models/blackout_dates.go
@@ -29,15 +29,15 @@ type BlackoutDate struct {
 func FetchTSPBlackoutDates(tx *pop.Connection, tspID uuid.UUID, shipment ShipmentWithOffer) ([]BlackoutDate, error) {
 	blackoutDates := []BlackoutDate{}
 	var err error
-
-	query := tx.Where("transportation_service_provider_id = $1", tspID).Where("$2 BETWEEN start_blackout_date and end_blackout_date", shipment.PickupDate)
+	pop.Debug = true
+	query := tx.Where("transportation_service_provider_id = ?", tspID).Where("? BETWEEN start_blackout_date and end_blackout_date", shipment.PickupDate)
 
 	if shipment.Market != nil {
-		query = query.Where("market = $3", *shipment.Market)
+		query = query.Where("market = ?", *shipment.Market)
 	}
 
 	if shipment.SourceGBLOC != nil {
-		query = query.Where("source_gbloc = $4", *shipment.SourceGBLOC)
+		query = query.Where("source_gbloc = ?", *shipment.SourceGBLOC)
 	}
 
 	err = query.All(&blackoutDates)

--- a/pkg/models/blackout_dates.go
+++ b/pkg/models/blackout_dates.go
@@ -30,31 +30,24 @@ func FetchTSPBlackoutDates(tx *pop.Connection, tspID uuid.UUID, shipment Shipmen
 	blackoutDates := []BlackoutDate{}
 	var err error
 
-	if shipment.Market != nil {
-		sql := `SELECT
-			*
-		FROM
-			blackout_dates
-		WHERE
-			transportation_service_provider_id = $1
-		AND
-			$2 BETWEEN start_blackout_date and end_blackout_date
-		AND
-			market = $3`
-		err = tx.RawQuery(sql, tspID, shipment.PickupDate, *shipment.Market).All(&blackoutDates)
+	query := tx.Where("transportation_service_provider_id = $1", tspID).Where("$2 BETWEEN start_blackout_date and end_blackout_date", shipment.PickupDate)
 
-	} else {
-		sql := `SELECT
-			*
-		FROM
-			blackout_dates
-		WHERE
-			transportation_service_provider_id = $1
-		AND
-			$2 BETWEEN start_blackout_date and end_blackout_date`
+	// if shipment.Market != nil {
+	// 	sql := `SELECT
+	// 		*
+	// 	FROM
+	// 		blackout_dates
+	// 	WHERE
+	// 		transportation_service_provider_id = $1
+	// 	AND
+	// 		$2 BETWEEN start_blackout_date and end_blackout_date
+	// 	AND
+	// 		market = $3`
+	// 	err = tx.RawQuery(sql, tspID, shipment.PickupDate, *shipment.Market).All(&blackoutDates)
 
-		err = tx.RawQuery(sql, tspID, shipment.PickupDate).All(&blackoutDates)
-	}
+	// } else {
+	err = query.All(&blackoutDates)
+	// }
 
 	return blackoutDates, err
 }

--- a/pkg/models/blackout_dates_test.go
+++ b/pkg/models/blackout_dates_test.go
@@ -21,11 +21,12 @@ func (suite *ModelSuite) Test_FetchTSPBlackoutDates() {
 	pickupDate := blackoutStartDate.Add(time.Hour)
 	deliveryDate := blackoutStartDate.Add(time.Hour * 24 * 60)
 	market1 := "dHHG"
-	testdatagen.MakeBlackoutDate(suite.db, tsp, blackoutStartDate, blackoutEndDate, &tdl, nil, &market1)
+	sourceGBLOC := "OHAI"
+	testdatagen.MakeBlackoutDate(suite.db, tsp, blackoutStartDate, blackoutEndDate, &tdl, &sourceGBLOC, &market1)
 
 	// Create two shipments, one with market and one without.
-	shipmentWithDomesticMarket, _ := testdatagen.MakeShipment(suite.db, pickupDate, pickupDate, deliveryDate, tdl, market1)
-	shipmentWithInternationalMarket, _ := testdatagen.MakeShipment(suite.db, pickupDate, pickupDate, deliveryDate, tdl, market1)
+	shipmentWithDomesticMarket, _ := testdatagen.MakeShipment(suite.db, pickupDate, pickupDate, deliveryDate, tdl, sourceGBLOC, market1)
+	shipmentWithInternationalMarket, _ := testdatagen.MakeShipment(suite.db, pickupDate, pickupDate, deliveryDate, tdl, sourceGBLOC, market1)
 
 	// Create two ShipmentWithOffers, one using the first set of times and a market, the other using the same times but without a market.
 	shipmentWithOfferWithDomesticMarket := models.ShipmentWithOffer{

--- a/pkg/models/blackout_dates_test.go
+++ b/pkg/models/blackout_dates_test.go
@@ -102,7 +102,7 @@ func (suite *ModelSuite) Test_FetchTSPBlackoutDatesWithGBLOC() {
 	if err != nil {
 		t.Errorf("Error fetching blackout dates.")
 	} else if len(fetchWithMatchingGBLOC) != 1 {
-		t.Errorf("Blackout dates query should have returned one result but returned zero instead.")
+		t.Errorf("Blackout dates query should have returned one result but returned zero  instead.")
 	}
 
 	fetchWithMismatchedGBLOC, err := FetchTSPBlackoutDates(suite.db, tsp.ID, shipmentWithOfferInGBLOC2)

--- a/pkg/models/blackout_dates_test.go
+++ b/pkg/models/blackout_dates_test.go
@@ -101,7 +101,7 @@ func (suite *ModelSuite) Test_FetchTSPBlackoutDatesWithGBLOC() {
 	fetchWithMatchingGBLOC, err := FetchTSPBlackoutDates(suite.db, tsp.ID, shipmentWithOfferInGBLOC1)
 	if err != nil {
 		t.Errorf("Error fetching blackout dates.")
-	} else if len(fetchWithMatchingGBLOC) == 0 {
+	} else if len(fetchWithMatchingGBLOC) != 1 {
 		t.Errorf("Blackout dates query should have returned one result but returned zero instead.")
 	}
 

--- a/pkg/models/blackout_dates_test.go
+++ b/pkg/models/blackout_dates_test.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/go-openapi/swag"
+	"github.com/gobuffalo/uuid"
 
 	"github.com/transcom/mymove/pkg/models"
 	. "github.com/transcom/mymove/pkg/models"
@@ -19,18 +20,13 @@ func (suite *ModelSuite) Test_FetchTSPBlackoutDates() {
 	blackoutStartDate := time.Now()
 	blackoutEndDate := blackoutStartDate.Add(time.Hour * 24 * 2)
 	pickupDate := blackoutStartDate.Add(time.Hour)
-	deliveryDate := blackoutStartDate.Add(time.Hour * 24 * 60)
 	market1 := "dHHG"
 	sourceGBLOC := "OHAI"
 	testdatagen.MakeBlackoutDate(suite.db, tsp, blackoutStartDate, blackoutEndDate, &tdl, &sourceGBLOC, &market1)
 
-	// Create two shipments, one with market and one without.
-	shipmentWithDomesticMarket, _ := testdatagen.MakeShipment(suite.db, pickupDate, pickupDate, deliveryDate, tdl, sourceGBLOC, market1)
-	shipmentWithInternationalMarket, _ := testdatagen.MakeShipment(suite.db, pickupDate, pickupDate, deliveryDate, tdl, sourceGBLOC, market1)
-
 	// Create two ShipmentWithOffers, one using the first set of times and a market, the other using the same times but without a market.
 	shipmentWithOfferWithDomesticMarket := models.ShipmentWithOffer{
-		ID: shipmentWithDomesticMarket.ID,
+		ID: uuid.Must(uuid.NewV4()),
 		TrafficDistributionListID:       tdl.ID,
 		PickupDate:                      pickupDate,
 		TransportationServiceProviderID: nil,
@@ -41,7 +37,7 @@ func (suite *ModelSuite) Test_FetchTSPBlackoutDates() {
 	}
 
 	shipmentWithOfferWithInternationalMarket := models.ShipmentWithOffer{
-		ID: shipmentWithInternationalMarket.ID,
+		ID: uuid.Must(uuid.NewV4()),
 		TrafficDistributionListID:       tdl.ID,
 		PickupDate:                      pickupDate,
 		TransportationServiceProviderID: nil,
@@ -63,5 +59,56 @@ func (suite *ModelSuite) Test_FetchTSPBlackoutDates() {
 		t.Errorf("Error fetching blackout dates.")
 	} else if len(fetchWithInternationalMarket) == 0 {
 		t.Errorf("Blackout dates query should have returned one result but returned zero instead.")
+	}
+}
+
+// Need a test where the GBLOC does and doesn't match
+func (suite *ModelSuite) Test_FetchTSPBlackoutDatesWithGBLOC() {
+	t := suite.T()
+	// Use FetchTSPBlackoutDates on two queries: one that should use a market value and one that doesn't.
+	// Create one blackout date object with a market.
+	tsp, _ := testdatagen.MakeTSP(suite.db, "A Very Excellent TSP", "XYZA")
+	tdl, _ := testdatagen.MakeTDL(suite.db, "Oklahoma", "62240", "5")
+	blackoutStartDate := time.Now()
+	blackoutEndDate := blackoutStartDate.Add(time.Hour * 24 * 2)
+	pickupDate := blackoutStartDate.Add(time.Hour)
+	market1 := "dHHG"
+	sourceGBLOC1 := "OHAI"
+	sourceGBLOC2 := "OHNO"
+	testdatagen.MakeBlackoutDate(suite.db, tsp, blackoutStartDate, blackoutEndDate, &tdl, &sourceGBLOC1, &market1)
+
+	// Create two ShipmentWithOffers, one using the first set of times and a market, the other using the same times but without a market.
+	shipmentWithOfferInGBLOC1 := models.ShipmentWithOffer{
+		ID: uuid.Must(uuid.NewV4()),
+		TrafficDistributionListID: tdl.ID,
+		PickupDate:                pickupDate,
+		SourceGBLOC:               &sourceGBLOC1,
+		Market:                    &market1,
+		AdministrativeShipment:    swag.Bool(false),
+		BookDate:                  testdatagen.DateInsidePerformancePeriod,
+	}
+
+	shipmentWithOfferInGBLOC2 := models.ShipmentWithOffer{
+		ID: uuid.Must(uuid.NewV4()),
+		TrafficDistributionListID: tdl.ID,
+		PickupDate:                pickupDate,
+		SourceGBLOC:               &sourceGBLOC2,
+		Market:                    nil,
+		AdministrativeShipment:    swag.Bool(false),
+		BookDate:                  testdatagen.DateInsidePerformancePeriod,
+	}
+
+	fetchWithMatchingGBLOC, err := FetchTSPBlackoutDates(suite.db, tsp.ID, shipmentWithOfferInGBLOC1)
+	if err != nil {
+		t.Errorf("Error fetching blackout dates.")
+	} else if len(fetchWithMatchingGBLOC) == 0 {
+		t.Errorf("Blackout dates query should have returned one result but returned zero instead.")
+	}
+
+	fetchWithMismatchedGBLOC, err := FetchTSPBlackoutDates(suite.db, tsp.ID, shipmentWithOfferInGBLOC2)
+	if err != nil {
+		t.Errorf("Error fetching blackout dates: %s.", err)
+	} else if len(fetchWithMismatchedGBLOC) != 0 {
+		t.Errorf("Blackout dates query should have returned no results but returned one instead.")
 	}
 }

--- a/pkg/models/blackout_dates_test.go
+++ b/pkg/models/blackout_dates_test.go
@@ -102,7 +102,7 @@ func (suite *ModelSuite) Test_FetchTSPBlackoutDatesWithGBLOC() {
 	if err != nil {
 		t.Errorf("Error fetching blackout dates.")
 	} else if len(fetchWithMatchingGBLOC) != 1 {
-		t.Errorf("Blackout dates query should have returned one result but returned zero  instead.")
+		t.Errorf("Blackout dates query should have returned one result but returned zero instead.")
 	}
 
 	fetchWithMismatchedGBLOC, err := FetchTSPBlackoutDates(suite.db, tsp.ID, shipmentWithOfferInGBLOC2)

--- a/pkg/models/shipment.go
+++ b/pkg/models/shipment.go
@@ -39,6 +39,7 @@ type ShipmentWithOffer struct {
 	RequestedPickupDate             time.Time  `db:"requested_pickup_date"`
 	TrafficDistributionListID       uuid.UUID  `db:"traffic_distribution_list_id"`
 	TransportationServiceProviderID *uuid.UUID `db:"transportation_service_provider_id"`
+	SourceGBLOC                     *string    `db:"source_gbloc"`
 	Market                          *string    `db:"market"`
 	Accepted                        *bool      `db:"accepted"`
 	RejectionReason                 *string    `db:"rejection_reason"`
@@ -65,6 +66,7 @@ func FetchShipments(dbConnection *pop.Connection, onlyUnassigned bool) ([]Shipme
 				shipments.requested_pickup_date,
 				shipments.book_date,
 				shipments.traffic_distribution_list_id,
+				shipments.source_gbloc,
 				shipments.market,
 				shipment_offers.transportation_service_provider_id,
 				shipment_offers.administrative_shipment

--- a/pkg/models/shipment_offer_test.go
+++ b/pkg/models/shipment_offer_test.go
@@ -24,7 +24,7 @@ func (suite *ModelSuite) Test_CreateShipmentOffer() {
 	now := time.Now()
 	tdl, _ := testdatagen.MakeTDL(suite.db, "california", "90210", "2")
 	tsp, _ := testdatagen.MakeTSP(suite.db, "Test TSP 1", "TSP1")
-	shipment, _ := testdatagen.MakeShipment(suite.db, now, now, now.AddDate(0, 0, 1), tdl, "dHHG")
+	shipment, _ := testdatagen.MakeShipment(suite.db, now, now, now.AddDate(0, 0, 1), tdl, "OHAI", "dHHG")
 	shipmentOffer, err := CreateShipmentOffer(suite.db, shipment.ID, tsp.ID, false)
 
 	if err != nil {

--- a/pkg/models/shipment_offer_test.go
+++ b/pkg/models/shipment_offer_test.go
@@ -24,7 +24,8 @@ func (suite *ModelSuite) Test_CreateShipmentOffer() {
 	now := time.Now()
 	tdl, _ := testdatagen.MakeTDL(suite.db, "california", "90210", "2")
 	tsp, _ := testdatagen.MakeTSP(suite.db, "Test TSP 1", "TSP1")
-	shipment, _ := testdatagen.MakeShipment(suite.db, now, now, now.AddDate(0, 0, 1), tdl, "OHAI", "dHHG")
+	market := "dHHG"
+	shipment, _ := testdatagen.MakeShipment(suite.db, now, now, now.AddDate(0, 0, 1), tdl, "OHAI", &market)
 	shipmentOffer, err := CreateShipmentOffer(suite.db, shipment.ID, tsp.ID, false)
 
 	if err != nil {

--- a/pkg/models/shipment_test.go
+++ b/pkg/models/shipment_test.go
@@ -24,8 +24,9 @@ func (suite *ModelSuite) Test_FetchAllShipments() {
 	now := time.Now()
 	tdl, _ := testdatagen.MakeTDL(suite.db, "california", "90210", "2")
 	market := "dHHG"
-	shipment, _ := testdatagen.MakeShipment(suite.db, now, now, now.AddDate(0, 0, 1), tdl, market)
-	shipment2, _ := testdatagen.MakeShipment(suite.db, now, now, now.AddDate(0, 0, 1), tdl, market)
+	sourceGBLOC := "OHAI"
+	shipment, _ := testdatagen.MakeShipment(suite.db, now, now, now.AddDate(0, 0, 1), tdl, sourceGBLOC, market)
+	shipment2, _ := testdatagen.MakeShipment(suite.db, now, now, now.AddDate(0, 0, 1), tdl, sourceGBLOC, market)
 	tsp, _ := testdatagen.MakeTSP(suite.db, "Test TSP 1", "TSP1")
 	CreateShipmentOffer(suite.db, shipment.ID, tsp.ID, false)
 	shipments, err := FetchShipments(suite.db, false)
@@ -45,8 +46,9 @@ func (suite *ModelSuite) Test_FetchUnassignedShipments() {
 	now := time.Now()
 	tdl, _ := testdatagen.MakeTDL(suite.db, "california", "90210", "2")
 	market := "dHHG"
-	shipment, _ := testdatagen.MakeShipment(suite.db, now, now, now.AddDate(0, 0, 1), tdl, market)
-	shipment2, _ := testdatagen.MakeShipment(suite.db, now, now, now.AddDate(0, 0, 1), tdl, market)
+	sourceGBLOC := "OHAI"
+	shipment, _ := testdatagen.MakeShipment(suite.db, now, now, now.AddDate(0, 0, 1), tdl, sourceGBLOC, market)
+	shipment2, _ := testdatagen.MakeShipment(suite.db, now, now, now.AddDate(0, 0, 1), tdl, sourceGBLOC, market)
 	tsp, _ := testdatagen.MakeTSP(suite.db, "Test TSP 1", "TSP1")
 	CreateShipmentOffer(suite.db, shipment.ID, tsp.ID, false)
 	shipments, err := FetchShipments(suite.db, true)

--- a/pkg/models/shipment_test.go
+++ b/pkg/models/shipment_test.go
@@ -25,8 +25,8 @@ func (suite *ModelSuite) Test_FetchAllShipments() {
 	tdl, _ := testdatagen.MakeTDL(suite.db, "california", "90210", "2")
 	market := "dHHG"
 	sourceGBLOC := "OHAI"
-	shipment, _ := testdatagen.MakeShipment(suite.db, now, now, now.AddDate(0, 0, 1), tdl, sourceGBLOC, market)
-	shipment2, _ := testdatagen.MakeShipment(suite.db, now, now, now.AddDate(0, 0, 1), tdl, sourceGBLOC, market)
+	shipment, _ := testdatagen.MakeShipment(suite.db, now, now, now.AddDate(0, 0, 1), tdl, sourceGBLOC, &market)
+	shipment2, _ := testdatagen.MakeShipment(suite.db, now, now, now.AddDate(0, 0, 1), tdl, sourceGBLOC, &market)
 	tsp, _ := testdatagen.MakeTSP(suite.db, "Test TSP 1", "TSP1")
 	CreateShipmentOffer(suite.db, shipment.ID, tsp.ID, false)
 	shipments, err := FetchShipments(suite.db, false)
@@ -47,8 +47,8 @@ func (suite *ModelSuite) Test_FetchUnassignedShipments() {
 	tdl, _ := testdatagen.MakeTDL(suite.db, "california", "90210", "2")
 	market := "dHHG"
 	sourceGBLOC := "OHAI"
-	shipment, _ := testdatagen.MakeShipment(suite.db, now, now, now.AddDate(0, 0, 1), tdl, sourceGBLOC, market)
-	shipment2, _ := testdatagen.MakeShipment(suite.db, now, now, now.AddDate(0, 0, 1), tdl, sourceGBLOC, market)
+	shipment, _ := testdatagen.MakeShipment(suite.db, now, now, now.AddDate(0, 0, 1), tdl, sourceGBLOC, &market)
+	shipment2, _ := testdatagen.MakeShipment(suite.db, now, now, now.AddDate(0, 0, 1), tdl, sourceGBLOC, &market)
 	tsp, _ := testdatagen.MakeTSP(suite.db, "Test TSP 1", "TSP1")
 	CreateShipmentOffer(suite.db, shipment.ID, tsp.ID, false)
 	shipments, err := FetchShipments(suite.db, true)

--- a/pkg/testdatagen/make_shipment_records.go
+++ b/pkg/testdatagen/make_shipment_records.go
@@ -12,7 +12,7 @@ import (
 // MakeShipment creates a single shipment record.
 func MakeShipment(db *pop.Connection, requestedPickup time.Time,
 	pickup time.Time, delivery time.Time,
-	tdl models.TrafficDistributionList, sourceGBLOC string, market string) (models.Shipment, error) {
+	tdl models.TrafficDistributionList, sourceGBLOC string, market *string) (models.Shipment, error) {
 
 	shipment := models.Shipment{
 		TrafficDistributionListID: tdl.ID,
@@ -21,7 +21,7 @@ func MakeShipment(db *pop.Connection, requestedPickup time.Time,
 		DeliveryDate:              delivery,
 		BookDate:                  DateInsidePerformancePeriod,
 		SourceGBLOC:               sourceGBLOC,
-		Market:                    &market,
+		Market:                    market,
 	}
 
 	_, err := db.ValidateAndSave(&shipment)
@@ -50,7 +50,7 @@ func MakeShipmentData(db *pop.Connection) {
 	market := "dHHG"
 	sourceGBLOC := "OHAI"
 
-	MakeShipment(db, now, now, now.Add(thirtyMin), tdlList[0], sourceGBLOC, market)
-	MakeShipment(db, now.Add(oneWeek), now.Add(oneWeek), now.Add(oneWeek).Add(thirtyMin), tdlList[1], sourceGBLOC, market)
-	MakeShipment(db, now.Add(oneWeek*2), now.Add(oneWeek*2), now.Add(oneWeek*2).Add(thirtyMin), tdlList[2], sourceGBLOC, market)
+	MakeShipment(db, now, now, now.Add(thirtyMin), tdlList[0], sourceGBLOC, &market)
+	MakeShipment(db, now.Add(oneWeek), now.Add(oneWeek), now.Add(oneWeek).Add(thirtyMin), tdlList[1], sourceGBLOC, &market)
+	MakeShipment(db, now.Add(oneWeek*2), now.Add(oneWeek*2), now.Add(oneWeek*2).Add(thirtyMin), tdlList[2], sourceGBLOC, &market)
 }

--- a/pkg/testdatagen/make_shipment_records.go
+++ b/pkg/testdatagen/make_shipment_records.go
@@ -12,7 +12,7 @@ import (
 // MakeShipment creates a single shipment record.
 func MakeShipment(db *pop.Connection, requestedPickup time.Time,
 	pickup time.Time, delivery time.Time,
-	tdl models.TrafficDistributionList, market string) (models.Shipment, error) {
+	tdl models.TrafficDistributionList, sourceGBLOC string, market string) (models.Shipment, error) {
 
 	shipment := models.Shipment{
 		TrafficDistributionListID: tdl.ID,
@@ -20,7 +20,7 @@ func MakeShipment(db *pop.Connection, requestedPickup time.Time,
 		RequestedPickupDate:       requestedPickup,
 		DeliveryDate:              delivery,
 		BookDate:                  DateInsidePerformancePeriod,
-		SourceGBLOC:               "AGFM",
+		SourceGBLOC:               sourceGBLOC,
 		Market:                    &market,
 	}
 
@@ -48,8 +48,9 @@ func MakeShipmentData(db *pop.Connection) {
 	thirtyMin, _ := time.ParseDuration("30m")
 	oneWeek, _ := time.ParseDuration("7d")
 	market := "dHHG"
+	sourceGBLOC := "OHAI"
 
-	MakeShipment(db, now, now, now.Add(thirtyMin), tdlList[0], market)
-	MakeShipment(db, now.Add(oneWeek), now.Add(oneWeek), now.Add(oneWeek).Add(thirtyMin), tdlList[1], market)
-	MakeShipment(db, now.Add(oneWeek*2), now.Add(oneWeek*2), now.Add(oneWeek*2).Add(thirtyMin), tdlList[2], market)
+	MakeShipment(db, now, now, now.Add(thirtyMin), tdlList[0], sourceGBLOC, market)
+	MakeShipment(db, now.Add(oneWeek), now.Add(oneWeek), now.Add(oneWeek).Add(thirtyMin), tdlList[1], sourceGBLOC, market)
+	MakeShipment(db, now.Add(oneWeek*2), now.Add(oneWeek*2), now.Add(oneWeek*2).Add(thirtyMin), tdlList[2], sourceGBLOC, market)
 }

--- a/pkg/testdatagen/scenario_1.go
+++ b/pkg/testdatagen/scenario_1.go
@@ -23,7 +23,7 @@ func RunScenarioOne(db *pop.Connection) {
 
 	// Make shipments in this TDL
 	for i := 0; i < shipmentsToMake; i++ {
-		MakeShipment(db, time.Now(), time.Now(), time.Now(), tdl, sourceGBLOC, market)
+		MakeShipment(db, time.Now(), time.Now(), time.Now(), tdl, sourceGBLOC, &market)
 	}
 
 	// Make TSPs in the same TDL to handle these shipments

--- a/pkg/testdatagen/scenario_1.go
+++ b/pkg/testdatagen/scenario_1.go
@@ -18,9 +18,12 @@ func RunScenarioOne(db *pop.Connection) {
 	// Make a market
 	market := "dHHG"
 
+	// Make a source GBLOC
+	sourceGBLOC := "OHAI"
+
 	// Make shipments in this TDL
 	for i := 0; i < shipmentsToMake; i++ {
-		MakeShipment(db, time.Now(), time.Now(), time.Now(), tdl, market)
+		MakeShipment(db, time.Now(), time.Now(), time.Now(), tdl, sourceGBLOC, market)
 	}
 
 	// Make TSPs in the same TDL to handle these shipments

--- a/pkg/testdatagen/scenario_2.go
+++ b/pkg/testdatagen/scenario_2.go
@@ -25,11 +25,11 @@ func RunScenarioTwo(db *pop.Connection) {
 
 	// Make shipments in first TDL
 	for i := 0; i < shipmentsToMake; i++ {
-		MakeShipment(db, shipmentDate, shipmentDate, shipmentDate, tdl, sourceGBLOC, market)
+		MakeShipment(db, shipmentDate, shipmentDate, shipmentDate, tdl, sourceGBLOC, &market)
 	}
 	// Make shipments in second TDL
 	for i := 0; i <= shipmentsToMake; i++ {
-		MakeShipment(db, shipmentDate, shipmentDate, shipmentDate, tdl2, sourceGBLOC, market)
+		MakeShipment(db, shipmentDate, shipmentDate, shipmentDate, tdl2, sourceGBLOC, &market)
 	}
 
 	// Make TSPs

--- a/pkg/testdatagen/scenario_2.go
+++ b/pkg/testdatagen/scenario_2.go
@@ -20,13 +20,16 @@ func RunScenarioTwo(db *pop.Connection) {
 	// Make a market
 	market := "dHHG"
 
+	// Make a source GBLOC
+	sourceGBLOC := "OHAI"
+
 	// Make shipments in first TDL
 	for i := 0; i < shipmentsToMake; i++ {
-		MakeShipment(db, shipmentDate, shipmentDate, shipmentDate, tdl, market)
+		MakeShipment(db, shipmentDate, shipmentDate, shipmentDate, tdl, sourceGBLOC, market)
 	}
 	// Make shipments in second TDL
 	for i := 0; i <= shipmentsToMake; i++ {
-		MakeShipment(db, shipmentDate, shipmentDate, shipmentDate, tdl2, market)
+		MakeShipment(db, shipmentDate, shipmentDate, shipmentDate, tdl2, sourceGBLOC, market)
 	}
 
 	// Make TSPs


### PR DESCRIPTION
## Description

This PR brings SourceGBLOC into the blackout dates query (and changes all associated tests to account for this). 

## Reviewer Notes

I worked with @jim, and we switched from the $1, $2, etc. method of query construction to ?, as this query will vary in length for as long as fields such as GBLOC and market are optional in blackout dates, shipments, and the like. We feel this makes the code more sustainable without introducing risk. (This is how the query is actually run/created: 
`[POP] 2018/03/28 12:51:12 SELECT blackout_dates.created_at, blackout_dates.end_blackout_date, blackout_dates.id, blackout_dates.market, blackout_dates.source_gbloc, blackout_dates.start_blackout_date, blackout_dates.traffic_distribution_list_id, blackout_dates.transportation_service_provider_id, blackout_dates.updated_at, blackout_dates.volume_move, blackout_dates.zip3 FROM blackout_dates AS blackout_dates WHERE transportation_service_provider_id = $1 AND $2 BETWEEN start_blackout_date and end_blackout_date AND source_gbloc = $3 | [b1c1b256-00bb-4191-9db2-73584bf4b989 2018-03-28 13:51:12.827540944 -0700 PDT m=+3603.426694740 "OHNO"]`)

## Verification Steps

* [ ] All tests pass.
* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely) have been satisfied.

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/155643358) for this change
