### PR TITLE
Only expose the HTTPS port.

### DIFF
--- a/config/app.container-definition.json
+++ b/config/app.container-definition.json
@@ -5,11 +5,6 @@
   "memoryReservation": 256,
   "portMappings": [
     {
-      "containerPort": 8080,
-      "hostPort": 8080,
-      "protocol": "tcp"
-    },
-    {
       "containerPort": 8443,
       "hostPort": 8443,
       "protocol": "tcp"


### PR DESCRIPTION
This is a bit of cleanup. Now that we're serving traffic using our
internal https endpoint, we no longer need to expose the http one. This
also prevents it from accidentally being used.