### PR TITLE
Rek oversized upload protection

### DIFF
--- a/cmd/webserver/main.go
+++ b/cmd/webserver/main.go
@@ -35,7 +35,7 @@ func requestLogger(h http.Handler) http.Handler {
 }
 
 // max request body size is 20 mb
-const maxBodySize int64 = 20 * 1000 * 1000
+const maxBodySize int64 = 200 * 1000 * 1000
 
 // max request headers size is 1 mb
 const maxHeaderSize int = 1 * 1000 * 1000

--- a/cmd/webserver/main.go
+++ b/cmd/webserver/main.go
@@ -34,6 +34,21 @@ func requestLogger(h http.Handler) http.Handler {
 	return http.HandlerFunc(wrapper)
 }
 
+// max request body size is 20 mb
+const maxBodySize int64 = 2 * 1000 * 1000
+
+// max request headers size is 1 mb
+const maxHeaderSize int = 1 * 1000 * 1000
+
+func limitBodySizeMiddleware(next http.Handler) http.Handler {
+	mw := func(w http.ResponseWriter, r *http.Request) {
+		r.Body = http.MaxBytesReader(w, r.Body, maxBodySize)
+		next.ServeHTTP(w, r)
+		return
+	}
+	return http.HandlerFunc(mw)
+}
+
 func main() {
 
 	build := flag.String("build", "build", "the directory to serve static files from.")
@@ -120,6 +135,7 @@ func main() {
 
 	// Base routes
 	root := goji.NewMux()
+	root.Use(limitBodySizeMiddleware)
 	root.Use(tokenMiddleware)
 
 	// Stub health check
@@ -158,7 +174,12 @@ func main() {
 	go func() { // start http listener
 		addr := fmt.Sprintf("%s:%s", *listenInterface, *httpPort)
 		zap.L().Info("Starting http server listening", zap.String("address", addr))
-		errChan <- http.ListenAndServe(addr, root)
+		s := &http.Server{
+			Addr:           addr,
+			Handler:        root,
+			MaxHeaderBytes: maxHeaderSize,
+		}
+		errChan <- s.ListenAndServe()
 	}()
 	go func() { // start https listener
 		addr := fmt.Sprintf("%s:%s", *listenInterface, *httpsPort)
@@ -194,6 +215,6 @@ func listenAndServeTLS(addr string, certPEMBlock, keyPEMBlock []byte, handler ht
 	defer ln.Close()
 
 	// Start server
-	srv := &http.Server{Addr: addr, Handler: handler}
+	srv := &http.Server{Addr: addr, Handler: handler, MaxHeaderBytes: maxHeaderSize}
 	return srv.Serve(ln)
 }

--- a/cmd/webserver/main.go
+++ b/cmd/webserver/main.go
@@ -35,7 +35,7 @@ func requestLogger(h http.Handler) http.Handler {
 }
 
 // max request body size is 20 mb
-const maxBodySize int64 = 2 * 1000 * 1000
+const maxBodySize int64 = 20 * 1000 * 1000
 
 // max request headers size is 1 mb
 const maxHeaderSize int = 1 * 1000 * 1000


### PR DESCRIPTION
## Description

Added middleware to all handlers to reject any attempted uploads/posts of greater than 20 mb.

## Verification Steps

* [x] All tests pass.
* [x] curled the following to get a response that request body was too large (file IMG_4984.JPG in cwd and larger than maxBodySize, get cookie from browser ): 
```
curl -4 -v -F 'file=@IMG_4984.JPG' 'http://localhost:8080/internal/moves/e4b33216-460c-4176-8ef8-c522a413b935/documents/d39b06d9-f0e6-4f7d-988e-f3a1dabb8c07/uploads' -H 'Cookie: csrftoken=xxxxxx; user_session=xxxx'
```

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/155631619) for this change
