### PR TITLE
Added checkbox to PR to remind developers to check code for uses of logger.Fatal

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,6 +9,7 @@ Is there anything you would like reviewers to give additional scrutiny?
 ## Verification Steps
 
 * [ ] All tests pass.
+* [ ] There are no instances of logger.Fatal ... in the code. Logger.Error is only used for application errors, not bad user input.
 * [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely) have been satisfied.
 * [ ] There are no [aXe](https://www.deque.com/products/aXe/) warnings for UI.
 * [ ] This works in IE.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,8 +9,10 @@ Is there anything you would like reviewers to give additional scrutiny?
 ## Verification Steps
 
 * [ ] All tests pass.
-* [ ] There are no instances of logger.Fatal ... in the code. Logger.Error is only used for application errors, not bad user input.
-* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely) have been satisfied.
+* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/blob/master/docs/backend.md#logging)
+* [ ] The requirements listed in
+ [Querying the Database Safely](https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely)
+ have been satisfied.
 * [ ] There are no [aXe](https://www.deque.com/products/aXe/) warnings for UI.
 * [ ] This works in IE.
 

--- a/.spelling
+++ b/.spelling
@@ -220,6 +220,8 @@ dodids
 edipi
 edipis
 transcom-ppp
+logger.fatal
+logger.error
 # Put all custom terms BEFORE this comment, lest you end up in an mdspell pain cycle.
  - docs/backend.md
  - docs/adr/0007-swagger-client.md

--- a/.spelling
+++ b/.spelling
@@ -222,6 +222,10 @@ edipis
 transcom-ppp
 logger.fatal
 logger.error
+Uber
+sugaredlogger
+main.go.
+zap.String
 # Put all custom terms BEFORE this comment, lest you end up in an mdspell pain cycle.
  - docs/backend.md
  - docs/adr/0007-swagger-client.md

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -8,6 +8,8 @@
   * [Acronyms](#acronyms)
   * [Style and Conventions](#style-and-conventions)
   * [Querying the Database Safely](#querying-the-database-safely)
+  * [Logging](#logging)
+    * [Logging Levels](#logging-levels)
   * [Libraries](#libraries)
     * [Pop](#pop)
   * [Learning](#learning)
@@ -91,6 +93,35 @@ if err = query.First(shipment); err == nil {
   pp.Println(shipment)
 }
 ```
+
+### Logging
+
+We use the [Zap](https://github.com/uber-go/zap) logging framework from Uber to produce structured log records.
+ To this end, code should avoid using the [SugaredLogger](https://godoc.org/go.uber.org/zap#Logger.Sugar)s without
+  a very explicit reason which should be record in an inline comment where the SugaredLogger is constructed.
+
+#### Logging Levels
+
+Another reason to use the Zap logging package is that it provides more nuanced logging levels than the basic Go logging package.
+ That said, leveled logging is only meaningful if there is a common pattern in the usage of each logging level. To that end,
+ the following indicates when each level of Logging should be used.
+
+* **Fatal** This should never be used outside of the server startup code in main.go. Fatal log messages call `sys.exit(1)` which unceremoniously kills the server without running any clean up code. This is almost certainly never what you want in production.
+
+* **Error** Reserved for system failures, e.g. cannot reach a database, a DB insert which was expected to work failed,
+ or an `"enum"` has an unexpected value. In production an Error logging message should alert the team that
+ all is not well with the server, so avoid being the 'Boy Who Cried Wolf'. In particular, if there is an API which takes an object ID as part of the URL,
+ then passing a bad value in should NOT log an Error message. It should log Info and then return 404.
+
+* **Warn** Don't use Warn - it rarely, if ever, adds any meaningful signal to the logs.
+
+* **Info** Use for recording 'Normal' events at a granularity that may be helpful to tracing and debugging requests,
+ e.g. 404's from requests with bad IDs, authentication events (user logs in/out), authorization failures etc.
+
+* **Debug** Debug events are of questionable value and should be used during development, but probably best removed
+ before landing changes. The issue with them is, if they are left in the code, they quickly become so dense in the logs
+ as to obscure other debug log entries. This leads to people an arms race of folks adding 'XXXXXXX' to comments
+ in order to identify their log items. If you must use them, I suggest adding an, e.g. zap.String("owner", "nick")
 
 ### Libraries
 


### PR DESCRIPTION
## Description

I noticed that we've gotten into the (very) bad habit of using logger.Fatal in the server code. This is almost certainly not what we want in production and I would like folks to bear that in mind when checking in.

## Reviewer Notes

Is this a reasonable way to do this? Don't want to make the check list so long that folks ignore it, but I also think this is a big problem unless we get it fixed in folks heads.

## Verification Steps

* [*] All tests pass.
* [n/a] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely) have been satisfied.
* [n/a] There are no aXe warnings for UI.
* [n/a] This works in IE.

