### PR TITLE
When deploy fails, show logs from recently stopped tasks.

### DIFF
--- a/bin/ecs-deploy-app-container
+++ b/bin/ecs-deploy-app-container
@@ -4,6 +4,8 @@
 #   and environment.
 #
 set -eo pipefail
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+readonly DIR
 
 usage() {
     echo "$0 <template> <image> <environment>"
@@ -70,6 +72,11 @@ if update_service "$green_task_def_arn"; then
     exit 0
 fi
 echo "Service failed to stabilize!"
+
+echo
+echo "Showing logs from recently stopped tasks:"
+"$DIR"/ecs-show-app-stopped-logs || true
+echo
 
 echo "* Rolling back to $blue_task_def_arn"
 if update_service "$blue_task_def_arn"; then

--- a/bin/ecs-show-app-stopped-logs
+++ b/bin/ecs-show-app-stopped-logs
@@ -1,0 +1,30 @@
+#!/bin/bash
+#
+#   Show logs from the most recently stopped app tasks.
+#
+set -eo pipefail
+readonly LIMIT=${LIMIT:-25}
+
+usage() {
+    echo "LIMIT=$LIMIT $0 <environment> | less"
+    exit 1
+}
+[[ -z $1 ]] && usage
+set -u
+
+readonly environment=$1
+readonly container=app
+readonly log_group_name=ecs-tasks-app-$environment
+
+
+# Get list of recently stopped tasks
+for task_id in $(aws ecs describe-services --cluster app-staging --services app --query 'services[].events[].message' | grep stopped | grep -o 'task [0-9a-f-]*' | cut -f 2 -d ' '); do
+    [[ -z $task_id ]] && { echo "Missing task ID"; exit 1; }
+
+    # Display logs for this task
+    log_stream_name=app/app-$environment/$task_id
+    echo "Task $task_id"
+    echo "-----------------------------------------"
+    aws logs get-log-events --limit "$LIMIT" --log-group-name "$log_group_name" --log-stream-name "$log_stream_name" --query 'events[].message' | jq -r '.[]'
+    echo
+done


### PR DESCRIPTION
When the ecs service fails to update, show logs from the recently
stopped tasks. This should hopefully provide enough context in our
CircleCI job to understand why deploy failed without having to dive into
the AWS console.