### PR TITLE
Added endpoints to delete and update blackouts/shipments

### DIFF
--- a/pkg/handlers/blackouts.go
+++ b/pkg/handlers/blackouts.go
@@ -12,3 +12,27 @@ type BlackoutIndexHandler HandlerContext
 func (h BlackoutIndexHandler) Handle(params apioperations.IndexBlackoutsParams) middleware.Responder {
 	return middleware.NotImplemented("operation .indexTSPs has not yet been implemented")
 }
+
+// DeleteBlackoutHandler returns a list of all the Blackouts
+type DeleteBlackoutHandler HandlerContext
+
+// Handle simply returns a NotImplementedError
+func (h DeleteBlackoutHandler) Handle(params apioperations.DeleteBlackoutParams) middleware.Responder {
+	return middleware.NotImplemented("operation .indexTSPs has not yet been implemented")
+}
+
+// GetBlackoutHandler returns a list of all the Blackouts
+type GetBlackoutHandler HandlerContext
+
+// Handle simply returns a NotImplementedError
+func (h GetBlackoutHandler) Handle(params apioperations.GetBlackoutParams) middleware.Responder {
+	return middleware.NotImplemented("operation .indexTSPs has not yet been implemented")
+}
+
+// UpdateBlackoutHandler returns a list of all the Blackouts
+type UpdateBlackoutHandler HandlerContext
+
+// Handle simply returns a NotImplementedError
+func (h UpdateBlackoutHandler) Handle(params apioperations.UpdateBlackoutParams) middleware.Responder {
+	return middleware.NotImplemented("operation .indexTSPs has not yet been implemented")
+}

--- a/pkg/handlers/shipments.go
+++ b/pkg/handlers/shipments.go
@@ -84,6 +84,14 @@ func (h RefuseShipmentHandler) Handle(p apioperations.RefuseShipmentParams) midd
 	return middleware.NotImplemented("operation .refuseShipment has not yet been implemented")
 }
 
+// UpdateShipmentHandler allows a TSP to refuse a particular shipment
+type UpdateShipmentHandler HandlerContext
+
+// Handle updates the shipment - checks that currently logged in user is authorized to act for the TSP assigned the shipment
+func (h UpdateShipmentHandler) Handle(p apioperations.UpdateShipmentParams) middleware.Responder {
+	return middleware.NotImplemented("operation .refuseShipment has not yet been implemented")
+}
+
 // ShipmentContactDetailsHandler allows a TSP to accept a particular shipment
 type ShipmentContactDetailsHandler HandlerContext
 

--- a/swagger/api.yaml
+++ b/swagger/api.yaml
@@ -50,6 +50,73 @@ paths:
           description: invalid request
         403:
           description: not authorized to get list of Blackouts
+  /blackouts/{blackout_uuid}:
+    get:
+      summary: retrieve the details of a blackout period
+      operationId: getBlackout
+      parameters:
+        - in: path
+          name: blackout_uuid
+          type: string
+          format: uuid
+          required: true
+          description: the unique identifier for the blackout
+      responses:
+        200:
+          description: the details of the requested blackout period
+          schema:
+              $ref: '#/definitions/Blackout'
+        400:
+          description: invalid request
+        403:
+          description: not authorized to access the associated blackout
+        404:
+          description: no blackout found with that UUID
+    delete:
+      summary: delete the associated blackout period
+      operationId: deleteBlackout
+      parameters:
+        - in: path
+          name: blackout_uuid
+          type: string
+          format: uuid
+          required: true
+          description: the unique identifier for the blackout
+      responses:
+        200:
+          description: the blackout was successfully deleted
+        400:
+          description: invalid request
+        403:
+          description: not authorized to access the associated blackout
+        404:
+          description: no blackout found with that UUID
+    patch:
+      summary: update the associated blackout
+      operationId: updateBlackout
+      parameters:
+        - in: path
+          name: blackout_uuid
+          type: string
+          format: uuid
+          required: true
+          description: the unique identifier for the blackout
+        - in: body
+          name: update
+          required: true
+          schema:
+            $ref: '#/definitions/Blackout'
+      responses:
+        200:
+          description: the blackout was successfully updated
+          schema:
+              $ref: '#/definitions/Blackout'
+        400:
+          description: invalid request
+        403:
+          description: not authorized to access the associated blackout
+        404:
+          description: no blackout found with that UUID
   /shipments:
     get:
       summary: Gets visible shipments
@@ -102,6 +169,35 @@ paths:
           format: uuid
           required: true
           description: UUID of the shipment
+      responses:
+        200:
+          description: returns the details of the shipment
+          schema:
+            $ref: '#/definitions/Shipment'
+        400:
+          description: invalid request
+        401:
+          description: must be authenticated to use this endpoint
+        403:
+          description: not authorized to see the details of this shipment
+        404:
+          description: shipment UUID not found in system
+    patch:
+      summary: Updates a particular shuip,ed
+      description: Takes a partial Shipment object and replaces the fields in the DB with the ones passed in the body
+      operationId: updateShipment
+      parameters:
+        - name: shipment_uuid
+          in: path
+          type: string
+          format: uuid
+          required: true
+          description: UUID of the shipment
+        - name: update
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/Shipment'
       responses:
         200:
           description: returns the details of the shipment
@@ -456,6 +552,11 @@ definitions:
   Blackout:
     type: object
     properties:
+      id:
+        type: string
+        description: unique id of the blackout in the system
+        format: uuid
+        example: c56a4180-65aa-42ec-a945-5fd21dec0538
       tsp_id:
         type: string
         description: ID of the TSP filing this blackout


### PR DESCRIPTION
## Description

More additions to the TSP API.

## Reviewer Notes

I am nearly at the point where I want to send this out to TSPs. I want to add document uploading for weight tickets and then that's it for a first pass.

## Verification Steps

* [ ] All tests pass.
* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely) have been satisfied.
* [ ] There are no [aXe](https://www.deque.com/products/aXe/) warnings for UI.
* [ ] This works in IE.

## References

* [Pivotal story](tbd) for this change
* [this article](tbd) explains more about the approach used.

## Screenshots

If this PR makes visible UI changes, an image of the finished UI can help reviewers and casual
observers understand the context of the changes. A before image is optional and
can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow instead of using multiple images. You may want to use GIPHY CAPTURE for this! 📸

_Please frame screenshots to show enough useful context but also highlight the affected regions._
