### PR TITLE
Move Type for Mobile Collapseable content

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "react-router-dom": "^4.2.2",
     "react-router-redux": "^5.0.0-alpha.8",
     "react-scripts": "1.0.17",
+    "react-window-size": "^1.0.1",
     "redux": "^3.7.2",
     "redux-form": "^7.2.1",
     "redux-mock-store": "1.5.1",

--- a/src/scenes/Moves/MoveType.css
+++ b/src/scenes/Moves/MoveType.css
@@ -12,7 +12,7 @@
 
 .font-2 {
   font-size: 0.8em;
-  color: rgb(142, 142, 142);
+  color: #525252;
 }
 .move-type-button {
   text-align: left;
@@ -37,9 +37,9 @@ ul {
 }
 
 .move-type-button img {
-  margin-top: 3rem;
+  margin-top: 2.5rem;
   height: 35px;
-  margin-bottom: 3rem;
+  margin-bottom: 2.5rem;
 }
 
 .move-type-button-more-info {
@@ -48,4 +48,16 @@ ul {
 }
 .move-type-button-more-info a:visited {
   color: rgb(55, 155, 252);
+}
+
+/* This matches the width at which submit buttons go full-width for mobile devices */
+@media only screen and (max-width: 481px) {
+    .move-type-button {
+        min-height: 100%;
+    }
+    .collapse-btn {
+      border-top: 2px solid #e2e2e2;
+      padding: 1em 0rem 1em 0em;
+
+    }
 }

--- a/src/scenes/Moves/MoveType.jsx
+++ b/src/scenes/Moves/MoveType.jsx
@@ -11,6 +11,8 @@ import truckGray from 'shared/icon/truck-gray.svg';
 import hhgPpmCombo from 'shared/icon/hhg-ppm-combo.svg';
 import './MoveType.css';
 
+const { mobileSize } = require('shared/constants');
+
 class BigButtonGroup extends Component {
   constructor() {
     super();
@@ -24,7 +26,7 @@ class BigButtonGroup extends Component {
     });
   };
   render() {
-    const isMobile = this.props.windowWidth < 481;
+    const isMobile = this.props.windowWidth < mobileSize;
     const createButton = (
       value,
       description,

--- a/src/scenes/Moves/MoveType.jsx
+++ b/src/scenes/Moves/MoveType.jsx
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
+import windowSize from 'react-window-size';
 import { bindActionCreators } from 'redux';
 import PropTypes from 'prop-types';
 
@@ -10,8 +11,20 @@ import truckGray from 'shared/icon/truck-gray.svg';
 import hhgPpmCombo from 'shared/icon/hhg-ppm-combo.svg';
 import './MoveType.css';
 
-export class BigButtonGroup extends Component {
+class BigButtonGroup extends Component {
+  constructor() {
+    super();
+    this.state = {
+      isHidden: true,
+    };
+  }
+  toggleHidden() {
+    this.setState({
+      isHidden: !this.state.isHidden,
+    });
+  }
   render() {
+    const isMobile = this.props.windowWidth < 481;
     const createButton = (
       value,
       description,
@@ -19,6 +32,7 @@ export class BigButtonGroup extends Component {
       icon,
       prosList,
       altTag,
+      isMobile,
     ) => {
       const onButtonClick = () => {
         this.props.onMoveTypeSelected(value);
@@ -30,23 +44,37 @@ export class BigButtonGroup extends Component {
           onClick={onButtonClick}
           className="move-type-button"
         >
-          <p className="restrict-left">{description}</p>
-          <img src={icon} alt={altTag} />
-          <p className="font-2">{title}</p>
-          {Object.keys(prosList || {}).map(function(key) {
-            const pros = prosList[key];
-            return (
-              <div key={key.toString()}>
-                <p>{key}</p>
-                <ul className="font-3">
-                  {pros.map(item => <li key={item}>{item}</li>)}
-                </ul>
+          <div>
+            <p className="restrict-left">{description}</p>
+            <img src={icon} alt={altTag} />
+            {!isMobile && <p className="font-2">{title}</p>}
+            {isMobile && (
+              <div
+                className="collapse-btn"
+                onClick={this.toggleHidden.bind(this)}
+              >
+                &gt; &nbsp; Pros and Cons:
               </div>
-            );
-          }, this)}
-          <p className="move-type-button-more-info">
-            <a href="about:blank">more information</a>
-          </p>
+            )}
+            {(!isMobile || !this.state.isHidden) && (
+              <div>
+                {Object.keys(prosList || {}).map(function(key) {
+                  const pros = prosList[key];
+                  return (
+                    <div key={key.toString()}>
+                      <p>{key}</p>
+                      <ul className="font-3">
+                        {pros.map(item => <li key={item}>{item}</li>)}
+                      </ul>
+                    </div>
+                  );
+                }, this)}
+                <p className="move-type-button-more-info">
+                  <a href="about:blank">more information</a>
+                </p>
+              </div>
+            )}
+          </div>
         </BigButton>
       );
     };
@@ -68,6 +96,7 @@ export class BigButtonGroup extends Component {
         ],
       },
       'hhg-ppm-combo',
+      isMobile,
     );
     var ppm = createButton(
       'PPM',
@@ -88,6 +117,7 @@ export class BigButtonGroup extends Component {
         ],
       },
       'trailer-gray',
+      isMobile,
     );
     var hhg = createButton(
       'HHG',
@@ -108,6 +138,7 @@ export class BigButtonGroup extends Component {
         ],
       },
       'truck-gray',
+      isMobile,
     );
 
     return (
@@ -120,9 +151,12 @@ export class BigButtonGroup extends Component {
   }
 }
 BigButtonGroup.propTypes = {
+  windowWidth: PropTypes.number,
   selectedOption: PropTypes.string,
   onMoveTypeSelected: PropTypes.func,
 };
+
+const BigButtonGroupWithSize = windowSize(BigButtonGroup);
 
 export class MoveType extends Component {
   componentDidMount() {
@@ -139,7 +173,7 @@ export class MoveType extends Component {
     return (
       <div className="usa-grid-full">
         <h2> Select a Move Type</h2>
-        <BigButtonGroup
+        <BigButtonGroupWithSize
           selectedOption={selectedOption}
           onMoveTypeSelected={this.onMoveTypeSelected}
         />

--- a/src/scenes/Moves/MoveType.jsx
+++ b/src/scenes/Moves/MoveType.jsx
@@ -18,11 +18,11 @@ class BigButtonGroup extends Component {
       isHidden: true,
     };
   }
-  toggleHidden() {
+  toggleHidden = () => {
     this.setState({
       isHidden: !this.state.isHidden,
     });
-  }
+  };
   render() {
     const isMobile = this.props.windowWidth < 481;
     const createButton = (
@@ -37,10 +37,11 @@ class BigButtonGroup extends Component {
       const onButtonClick = () => {
         this.props.onMoveTypeSelected(value);
       };
+      const isSelected = this.props.selectedOption === value;
       return (
         <BigButton
           value={value}
-          selected={this.props.selectedOption === value}
+          selected={isSelected}
           onClick={onButtonClick}
           className="move-type-button"
         >
@@ -49,14 +50,11 @@ class BigButtonGroup extends Component {
             <img src={icon} alt={altTag} />
             {!isMobile && <p className="font-2">{title}</p>}
             {isMobile && (
-              <div
-                className="collapse-btn"
-                onClick={this.toggleHidden.bind(this)}
-              >
+              <div className="collapse-btn" onClick={this.toggleHidden}>
                 &gt; &nbsp; Pros and Cons:
               </div>
             )}
-            {(!isMobile || !this.state.isHidden) && (
+            {(!isMobile || (isSelected && !this.state.isHidden)) && (
               <div>
                 {Object.keys(prosList || {}).map(function(key) {
                   const pros = prosList[key];

--- a/src/shared/BigButton/index.css
+++ b/src/shared/BigButton/index.css
@@ -16,7 +16,7 @@
 }
 
 .big-button p:first-child {
-  margin-top: 3rem;
+  margin-top: 0rem;
 }
 
 .big-button p {

--- a/src/shared/constants.js
+++ b/src/shared/constants.js
@@ -1,0 +1,5 @@
+/* This matches the width at which submit buttons go full-width for mobile devices */
+const mobileSize = 481;
+module.exports = {
+  mobileSize,
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1023,7 +1023,7 @@ babel-register@^6.26.0:
     mkdirp "^0.5.1"
     source-map-support "^0.4.15"
 
-babel-runtime@6.26.0, babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtime@^6.23.0, babel-runtime@^6.26.0:
+babel-runtime@6.26.0, babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtime@^6.23.0, babel-runtime@^6.26.0, babel-runtime@^6.6.1:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
   dependencies:
@@ -6484,6 +6484,12 @@ react-test-renderer@^16.0.0-0:
     fbjs "^0.8.16"
     object-assign "^4.1.1"
     prop-types "^15.6.0"
+
+react-window-size@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/react-window-size/-/react-window-size-1.0.1.tgz#c5e0e52602049ae9fb2c230626a8d1ce9ed8e3e4"
+  dependencies:
+    babel-runtime "^6.6.1"
 
 react@^16.2.0:
   version "16.2.0"


### PR DESCRIPTION
## Description

This PR makes the Move Type Selection Screen for mobile device sizes collapsible on click of "Pros and Cons".

## Verification Steps

* [x] All tests pass.
* [x] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/blob/master/docs/backend.md#logging)
* [x] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* [x] There are no [aXe](https://www.deque.com/products/aXe/) warnings for UI.
* [ ] This works in IE.

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/156073013) for this change

## Screenshots

<img width="379" alt="screen shot 2018-03-29 at 1 58 28 pm" src="https://user-images.githubusercontent.com/8170735/38113261-4aac1d5c-3359-11e8-8284-1ccd7f2394fa.png">
<img width="376" alt="screen shot 2018-03-29 at 1 58 21 pm" src="https://user-images.githubusercontent.com/8170735/38113262-4ac32150-3359-11e8-9a04-1ef713b13f41.png">