### PR TITLE
Rek upload permissions

### DIFF
--- a/pkg/handlers/uploads.go
+++ b/pkg/handlers/uploads.go
@@ -34,16 +34,19 @@ func (h CreateUploadHandler) Handle(params uploadop.CreateUploadParams) middlewa
 
 	userID, ok := authctx.GetUserID(params.HTTPRequest.Context())
 	if !ok {
+		h.logger.Error("Missing User ID in context")
 		return uploadop.NewCreateUploadBadRequest()
 	}
 
 	moveID, err := uuid.FromString(params.MoveID.String())
 	if err != nil {
+		h.logger.Error("Badly formed UUID for moveId", zap.String("move_id", params.MoveID.String()), zap.Error(err))
 		return uploadop.NewCreateUploadBadRequest()
 	}
 
 	documentID, err := uuid.FromString(params.DocumentID.String())
 	if err != nil {
+		h.logger.Error("Badly formed UUID for document", zap.String("document_id", params.DocumentID.String()), zap.Error(err))
 		return uploadop.NewCreateUploadBadRequest()
 	}
 

--- a/pkg/handlers/uploads.go
+++ b/pkg/handlers/uploads.go
@@ -34,18 +34,19 @@ func (h CreateUploadHandler) Handle(params uploadop.CreateUploadParams) middlewa
 
 	userID, ok := authctx.GetUserID(params.HTTPRequest.Context())
 	if !ok {
-		h.logger.Panic("No User ID, this should never happen.")
+		return uploadop.NewCreateUploadBadRequest()
 	}
 
 	moveID, err := uuid.FromString(params.MoveID.String())
 	if err != nil {
-		h.logger.Panic("Invalid MoveID, this should never happen.")
+		return uploadop.NewCreateUploadBadRequest()
 	}
 
 	documentID, err := uuid.FromString(params.DocumentID.String())
 	if err != nil {
-		h.logger.Panic("Invalid DocumentID, this should never happen.")
+		return uploadop.NewCreateUploadBadRequest()
 	}
+
 	// Validate that the document and move exists in the db, and that they belong to user
 	docExists, moveExists, userOwns := models.ValidateDocumentOwnership(h.db, userID, moveID, documentID)
 	if !docExists || !moveExists {
@@ -57,11 +58,13 @@ func (h CreateUploadHandler) Handle(params uploadop.CreateUploadParams) middlewa
 
 	hash := md5.New()
 	if _, err := io.Copy(hash, file.Data); err != nil {
-		h.logger.Panic("failed to hash uploaded file", zap.Error(err))
+		h.logger.Error("failed to hash uploaded file", zap.Error(err))
+		return uploadop.NewCreateUploadBadRequest()
 	}
 	_, err = file.Data.Seek(0, io.SeekStart) // seek back to beginning of file
 	if err != nil {
-		h.logger.Panic("failed to seek to beginning of uploaded file", zap.Error(err))
+		h.logger.Error("failed to seek to beginning of uploaded file", zap.Error(err))
+		return uploadop.NewCreateUploadBadRequest()
 	}
 
 	checksum := base64.StdEncoding.EncodeToString(hash.Sum(nil))

--- a/pkg/handlers/uploads.go
+++ b/pkg/handlers/uploads.go
@@ -48,8 +48,8 @@ func (h CreateUploadHandler) Handle(params uploadop.CreateUploadParams) middlewa
 	}
 
 	// Validate that the document and move exists in the db, and that they belong to user
-	docExists, moveExists, userOwns := models.ValidateDocumentOwnership(h.db, userID, moveID, documentID)
-	if !docExists || !moveExists {
+	exists, userOwns := models.ValidateDocumentOwnership(h.db, userID, moveID, documentID)
+	if !exists {
 		return uploadop.NewCreateUploadNotFound()
 	}
 	if !userOwns {

--- a/pkg/handlers/uploads.go
+++ b/pkg/handlers/uploads.go
@@ -46,7 +46,7 @@ func (h CreateUploadHandler) Handle(params uploadop.CreateUploadParams) middlewa
 	if err != nil {
 		h.logger.Panic("Invalid DocumentID, this should never happen.")
 	}
-
+	// Validate that the document and move exists in the db, and that they belong to user
 	docExists, moveExists, userOwns := models.ValidateDocumentOwnership(h.db, userID, moveID, documentID)
 	if !docExists || !moveExists {
 		return uploadop.NewCreateUploadNotFound()

--- a/pkg/handlers/uploads_test.go
+++ b/pkg/handlers/uploads_test.go
@@ -8,7 +8,7 @@ import (
 	"path"
 
 	"github.com/go-openapi/strfmt"
-	// "github.com/gobuffalo/uuid"
+	"github.com/gobuffalo/uuid"
 
 	authcontext "github.com/transcom/mymove/pkg/auth/context"
 	uploadop "github.com/transcom/mymove/pkg/gen/internalapi/internaloperations/uploads"
@@ -118,49 +118,51 @@ func (suite *HandlerSuite) TestCreateUploadsHandler() {
 	// TODO verify Body
 }
 
-// func (suite *HandlerSuite) TestCreateUploadsHandlerWrongUser() {
-// 	t := suite.T()
+func (suite *HandlerSuite) TestCreateUploadsHandlerFailsWithWrongUser() {
+	t := suite.T()
 
-// 	move, err := testdatagen.MakeMove(suite.db)
-// 	if err != nil {
-// 		t.Fatalf("could not create move: %s", err)
-// 	}
+	move, err := testdatagen.MakeMove(suite.db)
+	if err != nil {
+		t.Fatalf("could not create move: %s", err)
+	}
 
-// 	document, err := testdatagen.MakeDocument(suite.db, &move)
-// 	if err != nil {
-// 		t.Fatalf("could not create document: %s", err)
-// 	}
-// 	fakeS3 := &fakeS3Storage{}
+	document, err := testdatagen.MakeDocument(suite.db, &move)
+	if err != nil {
+		t.Fatalf("could not create document: %s", err)
+	}
+	fakeS3 := &fakeS3Storage{}
 
-// 	user := models.User{
-// 		LoginGovUUID:  uuid.Must(uuid.NewV4()),
-// 		LoginGovEmail: "email@example.com",
-// 	}
-// 	suite.mustSave(&user)
+	user := models.User{
+		LoginGovUUID:  uuid.Must(uuid.NewV4()),
+		LoginGovEmail: "email@example.com",
+	}
+	suite.mustSave(&user)
 
-// 	params := uploadop.NewCreateUploadParams()
-// 	params.MoveID = strfmt.UUID(move.ID.String())
-// 	params.DocumentID = strfmt.UUID(document.ID.String())
-// 	params.File = *suite.fixture("test.pdf")
+	params := uploadop.NewCreateUploadParams()
+	params.MoveID = strfmt.UUID(move.ID.String())
+	params.DocumentID = strfmt.UUID(document.ID.String())
+	params.File = *suite.fixture("test.pdf")
 
-// 	ctx := authcontext.PopulateAuthContext(context.Background(), user.ID, "fake token")
-// 	params.HTTPRequest = (&http.Request{}).WithContext(ctx)
+	ctx := authcontext.PopulateAuthContext(context.Background(), user.ID, "fake token")
+	params.HTTPRequest = (&http.Request{}).WithContext(ctx)
 
-// 	context := NewHandlerContext(suite.db, suite.logger)
-// 	fileContext := NewFileHandlerContext(context, fakeS3)
-// 	handler := CreateUploadHandler(fileContext)
-// 	response := handler.Handle(params)
+	context := NewHandlerContext(suite.db, suite.logger)
+	fileContext := NewFileHandlerContext(context, fakeS3)
+	handler := CreateUploadHandler(fileContext)
+	response := handler.Handle(params)
 
-// 	createdResponse, ok := response.(*uploadop.CreateUploadCreated)
-// 	if !ok {
-// 		t.Fatalf("Request failed: %#v", response)
-// 	}
+	_, ok := response.(*uploadop.CreateUploadBadRequest)
+	if !ok {
+		t.Fatalf("Request was success, expected failure")
+	}
 
-// 	uploadPayload := createdResponse.Payload
-// 	upload := models.Upload{}
-// 	err = suite.db.Find(&upload, uploadPayload.ID)
-// 	if err != nil {
-// 		t.Fatalf("Couldn't find expected upload.")
-// 	}
+	count, err := suite.db.Count(&models.Upload{})
 
-// }
+	if err != nil {
+		t.Fatalf("Couldn't count uploads in database: %s", err)
+	}
+
+	if count != 0 {
+		t.Fatalf("Wrong number of uploads in database: expected 0, got %d", count)
+	}
+}

--- a/pkg/handlers/uploads_test.go
+++ b/pkg/handlers/uploads_test.go
@@ -8,6 +8,7 @@ import (
 	"path"
 
 	"github.com/go-openapi/strfmt"
+	// "github.com/gobuffalo/uuid"
 
 	authcontext "github.com/transcom/mymove/pkg/auth/context"
 	uploadop "github.com/transcom/mymove/pkg/gen/internalapi/internaloperations/uploads"
@@ -116,3 +117,50 @@ func (suite *HandlerSuite) TestCreateUploadsHandler() {
 
 	// TODO verify Body
 }
+
+// func (suite *HandlerSuite) TestCreateUploadsHandlerWrongUser() {
+// 	t := suite.T()
+
+// 	move, err := testdatagen.MakeMove(suite.db)
+// 	if err != nil {
+// 		t.Fatalf("could not create move: %s", err)
+// 	}
+
+// 	document, err := testdatagen.MakeDocument(suite.db, &move)
+// 	if err != nil {
+// 		t.Fatalf("could not create document: %s", err)
+// 	}
+// 	fakeS3 := &fakeS3Storage{}
+
+// 	user := models.User{
+// 		LoginGovUUID:  uuid.Must(uuid.NewV4()),
+// 		LoginGovEmail: "email@example.com",
+// 	}
+// 	suite.mustSave(&user)
+
+// 	params := uploadop.NewCreateUploadParams()
+// 	params.MoveID = strfmt.UUID(move.ID.String())
+// 	params.DocumentID = strfmt.UUID(document.ID.String())
+// 	params.File = *suite.fixture("test.pdf")
+
+// 	ctx := authcontext.PopulateAuthContext(context.Background(), user.ID, "fake token")
+// 	params.HTTPRequest = (&http.Request{}).WithContext(ctx)
+
+// 	context := NewHandlerContext(suite.db, suite.logger)
+// 	fileContext := NewFileHandlerContext(context, fakeS3)
+// 	handler := CreateUploadHandler(fileContext)
+// 	response := handler.Handle(params)
+
+// 	createdResponse, ok := response.(*uploadop.CreateUploadCreated)
+// 	if !ok {
+// 		t.Fatalf("Request failed: %#v", response)
+// 	}
+
+// 	uploadPayload := createdResponse.Payload
+// 	upload := models.Upload{}
+// 	err = suite.db.Find(&upload, uploadPayload.ID)
+// 	if err != nil {
+// 		t.Fatalf("Couldn't find expected upload.")
+// 	}
+
+// }

--- a/pkg/models/document.go
+++ b/pkg/models/document.go
@@ -44,3 +44,25 @@ func (d *Document) Validate(tx *pop.Connection) (*validate.Errors, error) {
 		&validators.UUIDIsPresent{Field: d.MoveID, Name: "MoveID"},
 	), nil
 }
+
+// ValidateDocumentOwnership validates that a user owns the move that contains a document and that move and document both exist
+func ValidateDocumentOwnership(db *pop.Connection, userID uuid.UUID, moveID uuid.UUID, documentID uuid.UUID) (bool, bool, bool) {
+	docExists := false
+	moveExists := false
+	userOwns := false
+	var move Move
+	var document Document
+	err := db.Find(&document, documentID)
+	if err == nil {
+		docExists = true
+	}
+	err = db.Find(&move, moveID)
+	if err == nil {
+		moveExists = true
+		// TODO: Handle case where more than one user is authorized to modify move
+		if uuid.Equal(move.UserID, userID) && uuid.Equal(document.MoveID, moveID) {
+			userOwns = true
+		}
+	}
+	return docExists, moveExists, userOwns
+}

--- a/pkg/models/document.go
+++ b/pkg/models/document.go
@@ -46,23 +46,19 @@ func (d *Document) Validate(tx *pop.Connection) (*validate.Errors, error) {
 }
 
 // ValidateDocumentOwnership validates that a user owns the move that contains a document and that move and document both exist
-func ValidateDocumentOwnership(db *pop.Connection, userID uuid.UUID, moveID uuid.UUID, documentID uuid.UUID) (bool, bool, bool) {
-	docExists := false
-	moveExists := false
+func ValidateDocumentOwnership(db *pop.Connection, userID uuid.UUID, moveID uuid.UUID, documentID uuid.UUID) (bool, bool) {
+	exists := false
 	userOwns := false
 	var move Move
 	var document Document
-	err := db.Find(&document, documentID)
-	if err == nil {
-		docExists = true
-	}
-	err = db.Find(&move, moveID)
-	if err == nil {
-		moveExists = true
+	docErr := db.Find(&document, documentID)
+	moveErr := db.Find(&move, moveID)
+	if docErr == nil && moveErr == nil {
+		exists = true
 		// TODO: Handle case where more than one user is authorized to modify move
 		if uuid.Equal(move.UserID, userID) && uuid.Equal(document.MoveID, moveID) {
 			userOwns = true
 		}
 	}
-	return docExists, moveExists, userOwns
+	return exists, userOwns
 }

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -480,6 +480,10 @@ paths:
             $ref: '#/definitions/UploadPayload'
         400:
           description: invalid request
+        403:
+          description: not authorized
+        404:
+          description: not found
         500:
           description: server error
 


### PR DESCRIPTION
## Description

A user should only be able to upload files to their own moves. This PR prevents any user other than the user who owns the move from being able to upload files.

## Reviewer Notes

I'm using a function from models/move `GetMovesForUserID`, which I know @macrael isn't totally comfortable with as a way to authenticate user ownership. We're going to discuss whether there's a better way, but just stay alert.

## Verification Steps

* [x] All tests pass.
* [x] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/blob/master/docs/backend.md#logging)
* [x] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/156282848) for this change
