### PR TITLE
Local filesystem implementation for uploads in local development [delivers #155920096]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,7 @@ __snapshots__
 /build
 
 # development
-/uploads
+/tmp
 
 # built binaries
 /bin/webserver

--- a/cmd/webserver/main.go
+++ b/cmd/webserver/main.go
@@ -130,12 +130,14 @@ func main() {
 
 	var storer handlers.FileStorer
 	if *storageBackend == "s3" {
+		zap.L().Info("Using s3 storage backend")
 		if len(*s3Bucket) == 0 {
 			log.Fatalln(errors.New("Must provide aws_s3_bucket_name parameter, exiting"))
 		}
 		aws := awssession.Must(awssession.NewSession())
 		storer = storage.NewS3(*s3Bucket, logger, aws)
 	} else {
+		zap.L().Info("Using filesystem storage backend")
 		absTmpPath, err := filepath.Abs("tmp")
 		if err != nil {
 			log.Fatalln(errors.New("Could not get absolute path for tmp"))

--- a/config/app.container-definition.json
+++ b/config/app.container-definition.json
@@ -59,6 +59,10 @@
     {
       "name": "AWS_S3_KEY_NAMESPACE",
       "value": "app"
+    },
+    {
+      "name": "STORAGE_BACKEND",
+      "value": "s3"
     }
   ],
   "logConfiguration": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,9 @@
     "/internal": {
       "target": "http://localhost:8080"
     },
+    "/storage": {
+      "target": "http://localhost:8080"
+    },
     "/auth": {
       "target": "http://localhost:8080"
     },

--- a/pkg/handlers/handlers.go
+++ b/pkg/handlers/handlers.go
@@ -32,21 +32,22 @@ func NewHandlerContext(db *pop.Connection, logger *zap.SugaredLogger) HandlerCon
 	}
 }
 
-type fileStorer interface {
+// FileStorer is the set of methods needed to store and retrieve objects.
+type FileStorer interface {
 	Store(string, io.ReadSeeker, string) (*storage.StoreResult, error)
 	Key(...string) string
-	PresignedURL(string) (string, error)
+	PresignedURL(string, string) (string, error)
 }
 
 // FileHandlerContext wraps a HandlerContext with an additional dependency for file
 // manipulation
 type FileHandlerContext struct {
 	HandlerContext
-	storage fileStorer
+	storage FileStorer
 }
 
 // NewFileHandlerContext returns a new FileHandlerContext with its private fields set.
-func NewFileHandlerContext(context HandlerContext, storage fileStorer) FileHandlerContext {
+func NewFileHandlerContext(context HandlerContext, storage FileStorer) FileHandlerContext {
 	return FileHandlerContext{
 		HandlerContext: context,
 		storage:        storage,

--- a/pkg/handlers/uploads.go
+++ b/pkg/handlers/uploads.go
@@ -98,7 +98,7 @@ func (h CreateUploadHandler) Handle(params uploadop.CreateUploadParams) middlewa
 
 	h.logger.Infof("created an upload with id %s, s3 key %s\n", newUpload.ID, key)
 
-	url, err := h.storage.PresignedURL(key)
+	url, err := h.storage.PresignedURL(key, contentType)
 	if err != nil {
 		h.logger.Error("failed to get presigned url", zap.Error(err))
 		return uploadop.NewCreateUploadInternalServerError()

--- a/pkg/handlers/uploads_test.go
+++ b/pkg/handlers/uploads_test.go
@@ -51,8 +51,8 @@ func (fake *fakeS3Storage) Store(key string, data io.ReadSeeker, md5 string) (*s
 	return nil, errors.New("failed to push")
 }
 
-func (fake *fakeS3Storage) PresignedURL(key string) (string, error) {
-	url := fmt.Sprintf("https://example.test/dir/%s", key)
+func (fake *fakeS3Storage) PresignedURL(key string, contentType string) (string, error) {
+	url := fmt.Sprintf("https://example.test/dir/%s?contentType=%%2F%s", key, contentType)
 	return url, nil
 }
 

--- a/pkg/storage/filesystem.go
+++ b/pkg/storage/filesystem.go
@@ -1,0 +1,76 @@
+package storage
+
+import (
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+	"go.uber.org/zap"
+)
+
+// Filesystem is a storage backend that uses the local filesystem. It is intended only
+// for use in development to avoid dependency on an external service.
+type Filesystem struct {
+	root    string
+	webRoot string
+	logger  *zap.Logger
+}
+
+// NewFilesystem creates a new S3 using the provided AWS session.
+func NewFilesystem(root string, webRoot string, logger *zap.Logger) *Filesystem {
+	return &Filesystem{root, webRoot, logger}
+}
+
+// Store stores the content from an io.ReadSeeker at the specified key.
+func (fs *Filesystem) Store(key string, data io.ReadSeeker, md5 string) (*StoreResult, error) {
+	joined := path.Join(fs.root, key)
+	dir := filepath.Dir(joined)
+
+	err := os.MkdirAll(dir, 0755)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not create parent directory")
+	}
+
+	file, err := os.Create(joined)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not open file")
+	}
+	defer file.Close()
+
+	_, err = io.Copy(file, data)
+	if err != nil {
+		return nil, errors.Wrap(err, "write to disk failed")
+	}
+	return &StoreResult{}, nil
+}
+
+// Key returns a joined key
+func (fs *Filesystem) Key(args ...string) string {
+	return path.Join(args...)
+}
+
+// PresignedURL returns a URL that provides access to a file for 15 mintes.
+func (fs *Filesystem) PresignedURL(key, contentType string) (string, error) {
+	values := url.Values{}
+	values.Add("contentType", contentType)
+	url := fs.webRoot + "/" + key + "?" + values.Encode()
+	return url, nil
+}
+
+// NewFilesystemHandler returns an Handler that adds a Content-Type header so that
+// files are handled properly by the browser.
+func NewFilesystemHandler(root string) http.HandlerFunc {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		contentType := r.URL.Query().Get("contentType")
+		if contentType != "" {
+			w.Header().Add("Content-Type", contentType)
+		}
+
+		input := filepath.Join(root, filepath.FromSlash(path.Clean("/"+r.URL.Path)))
+		http.ServeFile(w, r, input)
+	})
+}

--- a/pkg/storage/filesystem.go
+++ b/pkg/storage/filesystem.go
@@ -27,7 +27,7 @@ func NewFilesystem(root string, webRoot string, logger *zap.Logger) *Filesystem 
 
 // Store stores the content from an io.ReadSeeker at the specified key.
 func (fs *Filesystem) Store(key string, data io.ReadSeeker, md5 string) (*StoreResult, error) {
-	joined := path.Join(fs.root, key)
+	joined := filepath.Join(fs.root, key)
 	dir := filepath.Dir(joined)
 
 	err := os.MkdirAll(dir, 0755)

--- a/pkg/storage/filesystem_test.go
+++ b/pkg/storage/filesystem_test.go
@@ -1,0 +1,21 @@
+package storage
+
+import (
+	"go.uber.org/zap"
+	"testing"
+)
+
+func TestPresignedURL(t *testing.T) {
+	logger := zap.NewNop()
+	fs := NewFilesystem("/home/username", "https://example.text/files", logger)
+
+	url, err := fs.PresignedURL("key/to/file/12345", "image/jpeg")
+	if err != nil {
+		t.Fatalf("could not get presigned url: %s", err)
+	}
+
+	expected := "https://example.text/files/key/to/file/12345contentType=image%2Fjpeg"
+	if url != expected {
+		t.Errorf("wrong presigned url: expected %s, got %s", expected, url)
+	}
+}

--- a/pkg/storage/filesystem_test.go
+++ b/pkg/storage/filesystem_test.go
@@ -14,7 +14,7 @@ func TestPresignedURL(t *testing.T) {
 		t.Fatalf("could not get presigned url: %s", err)
 	}
 
-	expected := "https://example.text/files/key/to/file/12345contentType=image%2Fjpeg"
+	expected := "https://example.text/files/key/to/file/12345?contentType=image%2Fjpeg"
 	if url != expected {
 		t.Errorf("wrong presigned url: expected %s, got %s", expected, url)
 	}

--- a/pkg/storage/s3.go
+++ b/pkg/storage/s3.go
@@ -49,10 +49,11 @@ func (s *S3) Key(args ...string) string {
 }
 
 // PresignedURL returns a URL that provides access to a file for 15 mintes.
-func (s *S3) PresignedURL(key string) (string, error) {
+func (s *S3) PresignedURL(key string, contentType string) (string, error) {
 	req, _ := s.client.GetObjectRequest(&s3.GetObjectInput{
-		Bucket: &s.bucket,
-		Key:    &key,
+		Bucket:              &s.bucket,
+		Key:                 &key,
+		ResponseContentType: &contentType,
 	})
 	url, err := req.Presign(15 * time.Minute)
 	if err != nil {


### PR DESCRIPTION
## Description

This PR provides further develops our uploading code and adds support for using the local filesystem instead of S3 for file storage. This removes a dependency on an external service for development and the requirement that all developers have AWS credentials.

## Reviewer Notes

- The handler in `pkg/handlers/uploads.go` is getting pretty long, but I don't think it's worth moving to another location just yet.
- There is a new command line flag/environment, `STORAGE_BACKEND`, that can have the value `s3` or `filesystem`. It is configured to be `s3` in the deployed environments and will default to `filesystem` otherwise. If you are working with S3 locally, you can set this value in your `.envrc`.

## Verification Steps

* [ ] All tests pass.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/blob/master/docs/backend.md#logging)
* [ ] This works in IE.

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/155920096) for this change
* Documentation for [`http.DetectContentType`](https://golang.org/pkg/net/http/#DetectContentType), which this patch uses to determine an upload's content type.