### PR TITLE
Add sign in/log out link to nav

### DIFF
--- a/src/scenes/Landing/index.jsx
+++ b/src/scenes/Landing/index.jsx
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 
+import LoginButton from 'shared/User/LoginButton';
 import { bindActionCreators } from 'redux';
 import { loadUserAndToken } from 'shared/User/ducks';
 import { push } from 'react-router-redux';
@@ -21,7 +22,11 @@ export class Landing extends Component {
   render() {
     return (
       <div className="usa-grid">
-        <h1>Welcome!</h1>
+        <h1>Welcome! </h1>
+        <div>
+          <LoginButton />
+          <div />
+        </div>
         {this.props.isLoggedIn && (
           <button onClick={this.startMove}>Start a move</button>
         )}

--- a/src/scenes/Landing/index.jsx
+++ b/src/scenes/Landing/index.jsx
@@ -1,7 +1,6 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 
-import LoginButton from 'shared/User/LoginButton';
 import { bindActionCreators } from 'redux';
 import { loadUserAndToken } from 'shared/User/ducks';
 import { push } from 'react-router-redux';

--- a/src/scenes/Landing/index.jsx
+++ b/src/scenes/Landing/index.jsx
@@ -23,10 +23,6 @@ export class Landing extends Component {
     return (
       <div className="usa-grid">
         <h1>Welcome!</h1>
-        <div>
-          <LoginButton />
-          <div />
-        </div>
         {this.props.isLoggedIn && (
           <button onClick={this.startMove}>Start a move</button>
         )}

--- a/src/shared/Header/index.jsx
+++ b/src/shared/Header/index.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { NavLink } from 'react-router-dom';
+
 import LoginButton from 'shared/User/LoginButton';
+import Email from 'shared/User/Email';
 
 import usaFlag from 'shared/images/us-flag.png';
 import govIcon from 'shared/images/icon-dot-gov.svg';
@@ -157,6 +159,9 @@ function Header() {
             </li>
             <li>
               <LoginButton />
+            </li>
+            <li>
+              <Email />
             </li>
           </ul>
           <form className="usa-search usa-search-small">

--- a/src/shared/Header/index.jsx
+++ b/src/shared/Header/index.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { NavLink } from 'react-router-dom';
+import LoginButton from 'shared/User/LoginButton';
 
 import usaFlag from 'shared/images/us-flag.png';
 import govIcon from 'shared/images/icon-dot-gov.svg';
@@ -153,6 +154,9 @@ function Header() {
                   </NavLink>
                 </li>
               </ul>
+            </li>
+            <li>
+              <LoginButton />
             </li>
           </ul>
           <form className="usa-search usa-search-small">

--- a/src/shared/User/Email.jsx
+++ b/src/shared/User/Email.jsx
@@ -1,0 +1,27 @@
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+
+import { bindActionCreators } from 'redux';
+import { loadUserAndToken } from 'shared/User/ducks';
+
+export class Email extends Component {
+  componentDidMount() {
+    this.props.loadUserAndToken();
+  }
+  render() {
+    return (
+      <span>{this.props.isLoggedIn && <span>{this.props.email}</span>}</span>
+    );
+  }
+}
+
+function mapStateToProps(state) {
+  return {
+    isLoggedIn: state.user.isLoggedIn,
+    email: state.user.email,
+  };
+}
+function mapDispatchToProps(dispatch) {
+  return bindActionCreators({ loadUserAndToken }, dispatch);
+}
+export default connect(mapStateToProps, mapDispatchToProps)(Email);


### PR DESCRIPTION
## Description

There is a login/logout link in nav bar - shows "Sign in" when user is not logged in, "Log out" and email address when user is signed in. 

## Reviewer Notes

Is the user data best stored in ducks under `shared/User/`, or does it make more sense for it to be stored somewhere like `shared/AppWrapper/`? 

## Verification Steps

* [x] All tests pass.
* [x] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/blob/master/docs/backend.md#logging)
* [x] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* [x] There are no [aXe](https://www.deque.com/products/aXe/) warnings for UI.
* [ ] This works in IE.
* [ ] Any new third party client side dependencies (e.g., login.gov, google analytics, CDN libraries, etc.) have been communicated to @willowbl00.

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/155131915) for this change

## Screenshots
![screen shot 2018-03-30 at 4 59 18 pm](https://user-images.githubusercontent.com/8170735/38157599-57c4eb1a-343d-11e8-8547-aa2d5b99cdc2.png)
![screen shot 2018-03-30 at 4 59 08 pm](https://user-images.githubusercontent.com/8170735/38157601-5b399714-343d-11e8-8977-b7b4de7591d4.png)
