### PR TITLE
Updated award queue to use raw zap.Logger rather than Sugar'd version

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -690,6 +690,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "8b9eeeb9bfb4905edd5320f56de65b296d5954e6d5a98c1b2766c7ce04a10b52"
+  inputs-digest = "3188dc00e1733838e01e27c6acf4459f97c57f966d2ed8844b63a46f925aa2f3"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/pkg/awardqueue/awardqueue.go
+++ b/pkg/awardqueue/awardqueue.go
@@ -128,7 +128,7 @@ func (aq *AwardQueue) assignShipments() {
 				count++
 			}
 		}
-		aq.logger.Info("Awarded some shipments.", zap.Int("count", count))
+		aq.logger.Info("Awarded some shipments.", zap.Int("total_count", count))
 	} else {
 		aq.logger.Error("Failed to query for shipments", zap.Error(err))
 	}
@@ -176,7 +176,7 @@ func (aq *AwardQueue) assignPerformanceBands() error {
 // This assumes that all TransportationServiceProviderPerformances have been properly
 // created and have a valid BestValueScore.
 func (aq *AwardQueue) assignPerformanceBandsForTDL(tdl models.TrafficDistributionList) error {
-	aq.logger.Info("Assigning performance bands", zap.Object("TDL", tdl))
+	aq.logger.Info("Assigning performance bands", zap.Object("tdl", tdl))
 
 	perfs, err := models.FetchTSPPerformanceForQualityBandAssignment(aq.db, tdl.ID, mps)
 	if err != nil {
@@ -189,7 +189,7 @@ func (aq *AwardQueue) assignPerformanceBandsForTDL(tdl models.TrafficDistributio
 	for band, count := range bands {
 		for i := 0; i < count; i++ {
 			performance := perfs[perfsIndex]
-			aq.logger.Info("Assigning tsp to band", zap.Any("tdp_id", performance.ID), zap.Int("band", band+1))
+			aq.logger.Info("Assigning tspPerformance to band", zap.Any("tdp_id", performance.ID), zap.Int("band", band+1))
 			err := models.AssignQualityBandToTSPPerformance(aq.db, band+1, performance.ID)
 			if err != nil {
 				return err

--- a/pkg/awardqueue/awardqueue.go
+++ b/pkg/awardqueue/awardqueue.go
@@ -189,7 +189,7 @@ func (aq *AwardQueue) assignPerformanceBandsForTDL(tdl models.TrafficDistributio
 	for band, count := range bands {
 		for i := 0; i < count; i++ {
 			performance := perfs[perfsIndex]
-			aq.logger.Info("Assigning tspPerformance to band", zap.Any("tdp_id", performance.ID), zap.Int("band", band+1))
+			aq.logger.Info("Assigning tspPerformance to band", zap.Any("tsp_performance_id", performance.ID), zap.Int("band", band+1))
 			err := models.AssignQualityBandToTSPPerformance(aq.db, band+1, performance.ID)
 			if err != nil {
 				return err

--- a/pkg/awardqueue/awardqueue.go
+++ b/pkg/awardqueue/awardqueue.go
@@ -28,7 +28,7 @@ const mps = 10
 // AwardQueue encapsulates the TSP award queue process
 type AwardQueue struct {
 	db     *pop.Connection
-	logger *zap.SugaredLogger
+	logger *zap.Logger
 }
 
 func (aq *AwardQueue) findAllUnassignedShipments() ([]models.ShipmentWithOffer, error) {
@@ -40,7 +40,7 @@ func (aq *AwardQueue) findAllUnassignedShipments() ([]models.ShipmentWithOffer, 
 // a TSP.
 // TODO: refactor this method to ensure the transaction is wrapping what it needs to
 func (aq *AwardQueue) attemptShipmentOffer(shipment models.ShipmentWithOffer) (*models.ShipmentOffer, error) {
-	aq.logger.Infof("Attempting to offer shipment: %s", shipment.ID)
+	aq.logger.Info("Attempting to offer shipment", zap.Any("shipment_id", shipment.ID))
 
 	// Query the shipment's TDL
 	tdl := models.TrafficDistributionList{}
@@ -66,7 +66,7 @@ func (aq *AwardQueue) attemptShipmentOffer(shipment models.ShipmentWithOffer) (*
 		tspPerformance, err := models.NextEligibleTSPPerformance(aq.db, tdl.ID, shipment.BookDate)
 
 		if loopCount != 0 && tspPerformance.ID == firstTSPid {
-			return nil, fmt.Errorf("Could not find a TSP without blackout dates in %d tries", loopCount)
+			return nil, fmt.Errorf("could not find a TSP without blackout dates in %d tries", loopCount)
 		}
 		loopCount++
 		if err != nil {
@@ -76,7 +76,7 @@ func (aq *AwardQueue) attemptShipmentOffer(shipment models.ShipmentWithOffer) (*
 		err = aq.db.Transaction(func(tx *pop.Connection) error {
 			tsp := models.TransportationServiceProvider{}
 			if err := aq.db.Find(&tsp, tspPerformance.TransportationServiceProviderID); err == nil {
-				aq.logger.Infof("Attempting to offer to TSP: %s", tsp.Name)
+				aq.logger.Info("Attempting to offer to TSP", zap.Object("tsp", tsp))
 
 				isAdministrativeShipment, err := aq.ShipmentWithinBlackoutDates(tsp.ID, shipment)
 				if err != nil {
@@ -90,17 +90,17 @@ func (aq *AwardQueue) attemptShipmentOffer(shipment models.ShipmentWithOffer) (*
 							aq.logger.Info("Shipment pickup date is during a blackout period. Awarding Administrative Shipment to TSP.")
 						} else {
 							// TODO: OfferCount is off by 1
-							aq.logger.Infof("Shipment offered to TSP! TSP now has %d shipment offers.", tspPerformance.OfferCount+1)
+							aq.logger.Info("Shipment offered to TSP!", zap.Int("current_count", tspPerformance.OfferCount+1))
 							foundAvailableTSP = true
 						}
 						return nil
 					}
 				} else {
-					aq.logger.Errorf("Failed to offer to TSP: %s", err)
+					aq.logger.Error("Failed to offer to TSP", zap.Error(err))
 				}
 			}
 
-			aq.logger.Errorf("Failed to offer to TSP: %s", err)
+			aq.logger.Error("Failed to offer to TSP", zap.Error(err))
 			return err
 		})
 
@@ -123,14 +123,14 @@ func (aq *AwardQueue) assignShipments() {
 		for _, shipment := range shipments {
 			_, err = aq.attemptShipmentOffer(shipment)
 			if err != nil {
-				aq.logger.Errorf("Failed to offer shipment: %s", err)
+				aq.logger.Error("Failed to offer shipment", zap.Error(err))
 			} else {
 				count++
 			}
 		}
-		aq.logger.Infof("Awarded %d shipments.", count)
+		aq.logger.Info("Awarded some shipments.", zap.Int("count", count))
 	} else {
-		aq.logger.Errorf("Failed to query for shipments %s", err)
+		aq.logger.Error("Failed to query for shipments", zap.Error(err))
 	}
 }
 
@@ -176,7 +176,7 @@ func (aq *AwardQueue) assignPerformanceBands() error {
 // This assumes that all TransportationServiceProviderPerformances have been properly
 // created and have a valid BestValueScore.
 func (aq *AwardQueue) assignPerformanceBandsForTDL(tdl models.TrafficDistributionList) error {
-	aq.logger.Infof("Assigning performance bands for TDL %s", tdl.ID)
+	aq.logger.Info("Assigning performance bands", zap.Object("TDL", tdl))
 
 	perfs, err := models.FetchTSPPerformanceForQualityBandAssignment(aq.db, tdl.ID, mps)
 	if err != nil {
@@ -189,7 +189,7 @@ func (aq *AwardQueue) assignPerformanceBandsForTDL(tdl models.TrafficDistributio
 	for band, count := range bands {
 		for i := 0; i < count; i++ {
 			performance := perfs[perfsIndex]
-			aq.logger.Infof("Assigning tspp %s to band %d", performance.ID, band+1)
+			aq.logger.Info("Assigning tsp to band", zap.Any("tdp_id", performance.ID), zap.Int("band", band+1))
 			err := models.AssignQualityBandToTSPPerformance(aq.db, band+1, performance.ID)
 			if err != nil {
 				return err
@@ -226,5 +226,5 @@ func (aq *AwardQueue) ShipmentWithinBlackoutDates(tspID uuid.UUID, shipment mode
 
 // NewAwardQueue creates a new AwardQueue
 func NewAwardQueue(db *pop.Connection, logger *zap.Logger) *AwardQueue {
-	return &AwardQueue{db: db, logger: logger.Sugar()}
+	return &AwardQueue{db: db, logger: logger}
 }

--- a/pkg/awardqueue/awardqueue_test.go
+++ b/pkg/awardqueue/awardqueue_test.go
@@ -47,7 +47,7 @@ func (suite *AwardQueueSuite) Test_CheckAllTSPsBlackedOut() {
 	// Run the Award Queue
 	offer, err := queue.attemptShipmentOffer(shipmentWithOffer)
 
-	expectedError := "Could not find a TSP without blackout dates"
+	expectedError := "could not find a TSP without blackout dates"
 	// See if shipment was offered
 	if err == nil || offer != nil {
 		t.Errorf("Shipment was offered to a blacked out TSP!")

--- a/pkg/models/traffic_distribution_list.go
+++ b/pkg/models/traffic_distribution_list.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gobuffalo/uuid"
 	"github.com/gobuffalo/validate"
 	"github.com/gobuffalo/validate/validators"
+	"go.uber.org/zap/zapcore"
 )
 
 // TrafficDistributionList items are essentially different markets, based on
@@ -68,4 +69,12 @@ func FetchTDLsAwaitingBandAssignment(db *pop.Connection) (TrafficDistributionLis
 	err := db.RawQuery(sql).All(&tdls)
 
 	return tdls, err
+}
+
+// MarshalLogObject is required to be able to zap.Object log TDLs
+func (t TrafficDistributionList) MarshalLogObject(encoder zapcore.ObjectEncoder) error {
+	encoder.AddString("src", t.SourceRateArea)
+	encoder.AddString("dest", t.DestinationRegion)
+	encoder.AddString("cos", t.CodeOfService)
+	return nil
 }

--- a/pkg/models/transportation_service_provider.go
+++ b/pkg/models/transportation_service_provider.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gobuffalo/uuid"
 	"github.com/gobuffalo/validate"
 	"github.com/gobuffalo/validate/validators"
+	"go.uber.org/zap/zapcore"
 )
 
 // TransportationServiceProvider models moving companies used to move
@@ -59,4 +60,11 @@ func (t *TransportationServiceProvider) Validate(tx *pop.Connection) (*validate.
 		&validators.StringIsPresent{Field: t.StandardCarrierAlphaCode, Name: "StandardCarrierAlphaCode"},
 		&validators.StringIsPresent{Field: t.Name, Name: "Name"},
 	), nil
+}
+
+// MarshalLogObject is required to control the logging of this
+func (t TransportationServiceProvider) MarshalLogObject(encoder zapcore.ObjectEncoder) error {
+	encoder.AddString("id", t.ID.String())
+	encoder.AddString("name", t.Name)
+	return nil
 }


### PR DESCRIPTION
## Description

Backed out the use of the Sugar'd Logger in favor of the raw, structured logger which should give more machine friendly logs.  

Along the way I also added func MarshalLogObject(encoder)... to the TPS and TPL structures. This lets them be logged natively using zap.Object.

## Reviewer Notes

Check that I didn't accidentally break anything else.

## Verification Steps

* [*] All tests pass.
* [*] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/blob/master/docs/backend.md#logging)
* [n/a] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* [n/a] There are no [aXe](https://www.deque.com/products/aXe/) warnings for UI.
* [n/a] This works in IE.
* [n/a] Any new third party client side dependencies (e.g., login.gov, google analytics, CDN libraries, etc.) have been communicated to @willowbl00.
