### PR TITLE
Update Go Swagger to pull from master

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -205,6 +205,7 @@
   version = "v1.3"
 
 [[projects]]
+  branch = "master"
   name = "github.com/go-swagger/go-swagger"
   packages = [
     "cmd/swagger",
@@ -214,8 +215,7 @@
     "generator",
     "scan"
   ]
-  revision = "b015bda48dfc648fdd95e7bc81dbb5cefc17c975"
-  version = "0.13.0"
+  revision = "2d443fa7eea569af9f20dd6f0302aef6c3b10651"
 
 [[projects]]
   name = "github.com/gobuffalo/envy"
@@ -690,6 +690,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "8b9eeeb9bfb4905edd5320f56de65b296d5954e6d5a98c1b2766c7ce04a10b52"
+  inputs-digest = "5bd87b0fe43467acec6f46ac49bfc9ecfba4bfbe924b58604cecc95eb101a2c8"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -6,3 +6,7 @@ required = [
 	"github.com/segmentio/chamber",
 	"github.com/docker/go-units"
 	]
+
+[[constraint]]
+  name = "github.com/go-swagger/go-swagger"
+  branch = "master"

--- a/pkg/handlers/form1299s.go
+++ b/pkg/handlers/form1299s.go
@@ -118,22 +118,18 @@ func (h ShowForm1299Handler) Handle(params form1299op.ShowForm1299Params) middle
 
 	var response middleware.Responder
 	// remove this validation when https://github.com/go-swagger/go-swagger/pull/1394 is merged.
-	if strfmt.IsUUID(string(formID)) {
-		form, err := models.FetchForm1299ByID(h.db, formID)
-		if err != nil {
-			if err.Error() == "sql: no rows in result set" {
-				response = form1299op.NewShowForm1299NotFound()
-			} else {
-				// This is an unknown error from the db, nothing to do but log and 500
-				h.logger.Error("DB Insertion error", zap.Error(err))
-				response = form1299op.NewShowForm1299InternalServerError()
-			}
+	form, err := models.FetchForm1299ByID(h.db, formID)
+	if err != nil {
+		if err.Error() == "sql: no rows in result set" {
+			response = form1299op.NewShowForm1299NotFound()
 		} else {
-			formPayload := payloadForForm1299Model(form)
-			response = form1299op.NewShowForm1299OK().WithPayload(&formPayload)
+			// This is an unknown error from the db, nothing to do but log and 500
+			h.logger.Error("DB Insertion error", zap.Error(err))
+			response = form1299op.NewShowForm1299InternalServerError()
 		}
 	} else {
-		return form1299op.NewShowForm1299BadRequest()
+		formPayload := payloadForForm1299Model(form)
+		response = form1299op.NewShowForm1299OK().WithPayload(&formPayload)
 	}
 
 	return response

--- a/pkg/handlers/form1299s_test.go
+++ b/pkg/handlers/form1299s_test.go
@@ -184,17 +184,6 @@ func (suite *HandlerSuite) TestShowUnknown() {
 	_ = response.(*form1299op.ShowForm1299NotFound)
 }
 
-func (suite *HandlerSuite) TestShowBadID() {
-	badID := strfmt.UUID("2400c3c5-019d-4031-9c27-8a553e022297xxx")
-	showFormParams := form1299op.ShowForm1299Params{Form1299ID: badID}
-
-	handler := ShowForm1299Handler(NewHandlerContext(suite.db, suite.logger))
-	response := handler.Handle(showFormParams)
-
-	// assert we got back the 400 response
-	_ = response.(*form1299op.ShowForm1299BadRequest)
-}
-
 func (suite *HandlerSuite) TestSubmitForm1299HandlerNoRequiredValues() {
 	t := suite.T()
 

--- a/pkg/handlers/uploads.go
+++ b/pkg/handlers/uploads.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"io"
 
+	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/go-openapi/swag"
 	"github.com/gobuffalo/uuid"
@@ -29,7 +30,11 @@ type CreateUploadHandler FileHandlerContext
 
 // Handle creates a new Upload from a request payload
 func (h CreateUploadHandler) Handle(params uploadop.CreateUploadParams) middleware.Responder {
-	file := params.File
+	file, ok := params.File.(*runtime.File)
+	if !ok {
+		h.logger.Error("This should always be a runtime.File, something has changed in go-swagger.")
+		return uploadop.NewCreateUploadInternalServerError()
+	}
 	h.logger.Infof("%s has a length of %d bytes.\n", file.Header.Filename, file.Header.Size)
 
 	userID, ok := authctx.GetUserID(params.HTTPRequest.Context())

--- a/pkg/handlers/uploads_test.go
+++ b/pkg/handlers/uploads_test.go
@@ -160,7 +160,7 @@ func (suite *HandlerSuite) TestCreateUploadsHandlerFailsWithWrongUser() {
 	params := uploadop.NewCreateUploadParams()
 	params.MoveID = strfmt.UUID(move.ID.String())
 	params.DocumentID = strfmt.UUID(document.ID.String())
-	params.File = *suite.fixture("test.pdf")
+	params.File = suite.fixture("test.pdf")
 
 	ctx := authcontext.PopulateAuthContext(context.Background(), user.ID, "fake token")
 	params.HTTPRequest = (&http.Request{}).WithContext(ctx)
@@ -202,7 +202,7 @@ func (suite *HandlerSuite) TestCreateUploadsHandlerFailsWithMissingDoc() {
 	params.MoveID = strfmt.UUID(move.ID.String())
 	// Include non existent document ID in params
 	params.DocumentID = strfmt.UUID(documentID.String())
-	params.File = *suite.fixture("test.pdf")
+	params.File = suite.fixture("test.pdf")
 
 	ctx := authcontext.PopulateAuthContext(context.Background(), userID, "fake token")
 	params.HTTPRequest = (&http.Request{}).WithContext(ctx)

--- a/pkg/handlers/uploads_test.go
+++ b/pkg/handlers/uploads_test.go
@@ -69,7 +69,7 @@ func (suite *HandlerSuite) TestCreateUploadsHandler() {
 	params := uploadop.NewCreateUploadParams()
 	params.MoveID = strfmt.UUID(move.ID.String())
 	params.DocumentID = strfmt.UUID(document.ID.String())
-	params.File = *suite.fixture("test.pdf")
+	params.File = suite.fixture("test.pdf")
 
 	ctx := authcontext.PopulateAuthContext(context.Background(), userID, "fake token")
 	params.HTTPRequest = (&http.Request{}).WithContext(ctx)


### PR DESCRIPTION
## Description

After talking to contributors on the go swagger slack it has become clear that cutting timely releases is not a priority for them and they recommended living on master. There are a heap of good fixes that have been made since the last release last december, many of which around improving validations. One concrete fix is that previously poorly formed UUIDs were still sent into handlers, now they are bounced by swagger like any other poorly formatted parameter. 

## Reviewer Notes

Unfortunately, most all of our tests are at the handler level, (we have chosen to to validate swagger's behaviors) so it is probably worth trying to hit some some of our APIs with invalid data and make sure that you get back the expected swagger error. 

## Verification Steps

* [ ] All tests pass.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/blob/master/docs/backend.md#logging)
* [ ] Uploading a file still works (the only breaking api change I had to update for)
* [ ] Swagger still returns errors for invalid data