### PR TITLE
Els international addresses 156072932

### DIFF
--- a/migrations/20180329183912_internationalize_addresses.down.fizz
+++ b/migrations/20180329183912_internationalize_addresses.down.fizz
@@ -1,0 +1,3 @@
+drop_column("addresses", "street_address_3")
+drop_column("addresses", "country")
+rename_column("addresses", "postal_code", "zip")

--- a/migrations/20180329183912_internationalize_addresses.up.fizz
+++ b/migrations/20180329183912_internationalize_addresses.up.fizz
@@ -1,0 +1,3 @@
+add_column("addresses", "street_address_3", "string", {"null": true})
+add_column("addresses", "country", "string", {"null": true, "default":"United States"})
+rename_column("addresses", "zip", "postal_code")

--- a/pkg/handlers/form1299s.go
+++ b/pkg/handlers/form1299s.go
@@ -18,9 +18,11 @@ func payloadForAddressModel(a *models.Address) *internalmessages.Address {
 		return &internalmessages.Address{
 			StreetAddress1: swag.String(a.StreetAddress1),
 			StreetAddress2: a.StreetAddress2,
+			StreetAddress3: a.StreetAddress3,
 			City:           swag.String(a.City),
 			State:          swag.String(a.State),
-			Zip:            swag.String(a.Zip),
+			PostalCode:     swag.String(a.PostalCode),
+			Country:        a.Country,
 		}
 	}
 	return nil
@@ -33,9 +35,11 @@ func addressModelFromPayload(rawAddress *internalmessages.Address) *models.Addre
 	address := models.Address{
 		StreetAddress1: *rawAddress.StreetAddress1,
 		StreetAddress2: rawAddress.StreetAddress2,
+		StreetAddress3: rawAddress.StreetAddress3,
 		City:           *rawAddress.City,
 		State:          *rawAddress.State,
-		Zip:            *rawAddress.Zip,
+		PostalCode:     *rawAddress.PostalCode,
+		Country:        rawAddress.Country,
 	}
 	return &address
 }

--- a/pkg/handlers/form1299s_test.go
+++ b/pkg/handlers/form1299s_test.go
@@ -77,9 +77,10 @@ func fakeAddress() *internalmessages.Address {
 	return &internalmessages.Address{
 		StreetAddress1: swag.String("An address"),
 		StreetAddress2: swag.String("Apt. 2"),
+		StreetAddress3: swag.String("address line 3"),
 		City:           swag.String("Happytown"),
 		State:          swag.String("AL"),
-		Zip:            swag.String("01234"),
+		PostalCode:     swag.String("01234"),
 	}
 }
 

--- a/pkg/models/address.go
+++ b/pkg/models/address.go
@@ -18,9 +18,11 @@ type Address struct {
 	UpdatedAt      time.Time `json:"updated_at" db:"updated_at"`
 	StreetAddress1 string    `json:"street_address_1" db:"street_address_1"`
 	StreetAddress2 *string   `json:"street_address_2" db:"street_address_2"`
+	StreetAddress3 *string   `json:"street_address_3" db:"street_address_3"`
 	City           string    `json:"city" db:"city"`
 	State          string    `json:"state" db:"state"`
-	Zip            string    `json:"zip" db:"zip"`
+	PostalCode     string    `json:"postal_code" db:"postal_code"`
+	Country        *string   `json:"country" db:"country"`
 }
 
 // String is not required by pop and may be deleted
@@ -75,7 +77,7 @@ func (a *Address) Validate(tx *pop.Connection) (*validate.Errors, error) {
 		"StreetAddress1": a.StreetAddress1,
 		"City":           a.City,
 		"State":          a.State,
-		"Zip":            a.Zip,
+		"PostalCode":     a.PostalCode,
 	}
 
 	for key, field := range stringFields {

--- a/pkg/models/address_test.go
+++ b/pkg/models/address_test.go
@@ -11,9 +11,10 @@ func (suite *ModelSuite) TestBasicAddressInstantiation() {
 	newAddress := Address{
 		StreetAddress1: "street 1",
 		StreetAddress2: swag.String("street 2"),
+		StreetAddress3: swag.String("street 3"),
 		City:           "city",
 		State:          "state",
-		Zip:            "90210",
+		PostalCode:     "90210",
 	}
 
 	verrs, err := suite.db.ValidateAndCreate(&newAddress)

--- a/pkg/models/form1299_test.go
+++ b/pkg/models/form1299_test.go
@@ -164,7 +164,6 @@ func (suite *ModelSuite) TestCreateForm1299WithAddressesSavesAddresses() {
 		City:           "Seattle",
 		State:          "NY",
 		PostalCode:     "12345",
-		Country:        "United States",
 	}
 	form := Form1299{
 		OriginOfficeAddress: &address,

--- a/pkg/models/form1299_test.go
+++ b/pkg/models/form1299_test.go
@@ -119,7 +119,7 @@ func (suite *ModelSuite) TestFetchForm1299ByIDEagerLoads() {
 		StreetAddress1: "123 My Way",
 		City:           "Seattle",
 		State:          "NY",
-		Zip:            "12345",
+		PostalCode:     "12345",
 	}
 	suite.mustSave(&address)
 	form := Form1299{
@@ -163,7 +163,8 @@ func (suite *ModelSuite) TestCreateForm1299WithAddressesSavesAddresses() {
 		StreetAddress1: "123 My Way",
 		City:           "Seattle",
 		State:          "NY",
-		Zip:            "12345",
+		PostalCode:     "12345",
+		Country:        "United States",
 	}
 	form := Form1299{
 		OriginOfficeAddress: &address,
@@ -189,9 +190,9 @@ func (suite *ModelSuite) TestCreateForm1299WithAddressesReturnsErrors() {
 
 	// Given: A form1299 model with a blank StreetAddress1 field
 	address := Address{
-		City:  "Seattle",
-		State: "NY",
-		Zip:   "12345",
+		City:       "Seattle",
+		State:      "NY",
+		PostalCode: "12345",
 	}
 	form := Form1299{
 		OriginOfficeAddress: &address,

--- a/src/scenes/DD1299/uiSchema.js
+++ b/src/scenes/DD1299/uiSchema.js
@@ -28,7 +28,7 @@ definitions:
       - street_address_2
       - city
       - state
-      - zip
+      - postal_code
 groups:
   origin_office:
     title: To (Responsible Origin Personal Property Shipping Office)

--- a/swagger/api.yaml
+++ b/swagger/api.yaml
@@ -567,16 +567,23 @@ definitions:
           - WV
           - WI
           - WY
-      zip:
+      postal_code:
         type: string
+        format: zip
         title: ZIP/Postal Code
         example: "90210"
         pattern: '^(\d{5}([\-]\d{4})?)$'
+      country:
+        type: string
+        title: Country
+        x-nullable: true
+        example: "United States"
+        default: United States
     required:
-    - street_address_1
-    - city
-    - state
-    - zip
+      - street_address_1
+      - city
+      - state
+      - postal_code
   Blackout:
     type: object
     properties:

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -1395,6 +1395,11 @@ definitions:
         example: Apartment 9000
         x-nullable: true
         title: Address Line 2
+      street_address_3:
+        type: string
+        example: Apartment 9000
+        x-nullable: true
+        title: Address Line 3
       city:
         type: string
         example: Anytown
@@ -1506,14 +1511,20 @@ definitions:
           - WV
           - WI
           - WY
-      zip:
+      postal_code:
         type: string
         format: zip
         title: ZIP/Postal Code
         example: "90210"
         pattern: '^(\d{5}([\-]\d{4})?)$'
+      country:
+        type: string
+        title: Country
+        x-nullable: true
+        example: "United States"
+        default: United States
     required:
       - street_address_1
       - city
       - state
-      - zip
+      - postal_code

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -1397,7 +1397,7 @@ definitions:
         title: Address Line 2
       street_address_3:
         type: string
-        example: Apartment 9000
+        example: Montmâtre
         x-nullable: true
         title: Address Line 3
       city:


### PR DESCRIPTION
## Description

This modifies our addresses table to minimize the migrations that would be necessary when we support OCONUS. This work does not completely support OCONUS at this point. There are things that will need to be changed then. For instance, the state field should not be required or it should be able to get a list of country appropriate states/territories.

The changes made at this time are:
 * added `addresses.country` field with a default value of "United States"
 * added `addresses.address_line_3` nullable field
 * renamed `addresses.zip` to `addresses.postal_code`

## Verification Steps

* [ x] All tests pass.
* [ x] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/blob/master/docs/backend.md#logging)
* [x ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* [ n/a] There are no aXe warnings for UI.
* [ n/a] This works in IE.
* [ n/a] Any new third party client side dependencies (e.g., login.gov, google analytics, CDN libraries, etc.) have been communicated to @willowbl00.

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/156072932) for this change
