### PR TITLE
Add stations and service member profile endpoints

### DIFF
--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -938,8 +938,9 @@ definitions:
         example: 57893457897
         pattern: /^[0-9]{10}$/
         x-nullable: true
-      ssn:
-        $ref: '#/definitions/SocialSecurityNumber'
+      has_social_security_number:
+        type: boolean
+        x-nullable: true
       first_name:
         type: string
         example: John
@@ -1017,8 +1018,12 @@ definitions:
         example: 57893457897
         x-nullable: true
         title: 'DoD ID #'
-      ssn:
-        $ref: '#/definitions/SocialSecurityNumber'
+      social_security_number:
+        type: string
+        format: ssn
+        x-nullable: true
+        title: 'Social Security Number'
+        example: '555-55-5555'
       first_name:
         type: string
         example: John
@@ -1093,8 +1098,12 @@ definitions:
         example: 57893457897
         x-nullable: true
         title: 'EDIPI ID'
-      ssn:
-        $ref: '#/definitions/SocialSecurityNumber'
+      social_security_number:
+        type: string
+        format: ssn
+        x-nullable: true
+        title: 'Social Security Number'
+        example: '555-55-5555'
       first_name:
         type: string
         example: John
@@ -2195,12 +2204,3 @@ definitions:
       - city
       - state
       - postal_code
-  SocialSecurityNumber:
-    type: object
-    properties:
-      encrypted_hash:
-        type: string
-        title: Social Security Number
-        x-nullable: true
-    required:
-      - encrypted_hash

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -484,7 +484,6 @@ paths:
           description: not found
         500:
           description: server error
-
   /stations:
     get:
       summary: Returns a list of stations based on search string
@@ -544,7 +543,6 @@ paths:
           description: station is not found
         500:
           description: internal server error
-
   /service_members:
     get:
       summary: List all service members
@@ -567,7 +565,6 @@ paths:
           description: no service members found
         500:
           description: internal server error
-  /service_members/{userId}:
     post:
       summary: Creates service member for a logged-in user
       description: Creates an instance of a service member tied to a user
@@ -580,12 +577,6 @@ paths:
           required: true
           schema:
             $ref: '#/definitions/CreateServiceMemberPayload'
-        - in: path
-          name: userId
-          type: string
-          format: uuid
-          required: true
-          description: UUID of the service member
       responses:
         201:
           description: created instance of service member
@@ -601,6 +592,7 @@ paths:
           description: service member not found
         500:
           description: internal server error
+  /service_members/{serviceMemberId}:
     get:
       summary: Returns the given service member
       description: Returns the given service member
@@ -609,7 +601,7 @@ paths:
         - service_members
       parameters:
         - in: path
-          name: userId
+          name: serviceMemberId
           type: string
           format: uuid
           required: true
@@ -637,7 +629,7 @@ paths:
         - service_members
       parameters:
         - in: path
-          name: userId
+          name: serviceMemberId
           type: string
           format: uuid
           required: true
@@ -646,7 +638,7 @@ paths:
           name: patchServiceMemberPayload
           required: true
           schema:
-            $ref: '#/definitions/ServiceMemberPayload'
+            $ref: '#/definitions/PatchServiceMemberPayload'
       responses:
         201:
           description: updated instance of service member
@@ -662,7 +654,6 @@ paths:
           description: service member not found
         500:
           description: internal server error
-
   /service_members/{serviceMemberId}/backup_contact:
     post:
       summary: Submits backup contact for a logged-in user
@@ -771,7 +762,7 @@ paths:
           name: patchServiceMemberBackupContactPayload
           required: true
           schema:
-            $ref: '#/definitions/ServiceMemberBackupContactPayload'
+            $ref: '#/definitions/PatchServiceMemberBackupContactPayload'
         - in: path
           name: backupContactId
           type: string
@@ -905,7 +896,6 @@ definitions:
     type: array
     items:
       $ref: '#/definitions/MovePayload'
-
   Station:
     type: object
     properties:
@@ -931,7 +921,6 @@ definitions:
       - address
       - created_at
       - updated_at
-
   ServiceMemberPayload:
     type: object
     properties:
@@ -943,18 +932,14 @@ definitions:
         type: string
         format: uuid
         example: c56a4180-65aa-42ec-a945-5fd21dec0538
-      edipi_text:
+      edipi:
         type: string
         format: string
         example: 57893457897
         pattern: /^[0-9]{10}$/
         x-nullable: true
       ssn:
-        type: string
-        format: ssn
-        pattern: '^\d{3}-\d{2}-\d{4}$'
-        example: 555-55-5555
-        x-nullable: true
+        $ref: '#/definitions/SocialSecurityNumber'
       first_name:
         type: string
         example: John
@@ -985,10 +970,10 @@ definitions:
         x-nullable: true
       personal_email:
         type: string
-        format: telephone
-        pattern: '^([a-zA-Z0-9_\-\.]+)@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.)|(([a-zA-Z0-9\-]+\.)+))([a-zA-Z]{2,4}|[0-9]{1,3})(\]?)$'
-        example: john_bob.joe@foo.edu
+        pattern: ^(.+)@(.+)\.(.{1,3})$
+        example: john_bob@foo.edu
         x-nullable: true
+        title: personal email address
       phone_is_preferred:
         type: boolean
         x-nullable: true
@@ -1025,7 +1010,7 @@ definitions:
         type: string
         format: uuid
         example: c56a4180-65aa-42ec-a945-5fd21dec0538
-      edipi_text:
+      edipi:
         type: string
         format: string
         pattern: /^[0-9]{10}$/
@@ -1033,12 +1018,7 @@ definitions:
         x-nullable: true
         title: 'DoD ID #'
       ssn:
-        type: string
-        format: ssn
-        pattern: '^\d{3}-\d{2}-\d{4}$'
-        example: 555-55-5555
-        x-nullable: true
-        title: 'ssn #'
+        $ref: '#/definitions/SocialSecurityNumber'
       first_name:
         type: string
         example: John
@@ -1075,9 +1055,8 @@ definitions:
         title: Secondary Telephone
       personal_email:
         type: string
-        format: telephone
-        pattern: '^([a-zA-Z0-9_\-\.]+)@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.)|(([a-zA-Z0-9\-]+\.)+))([a-zA-Z]{2,4}|[0-9]{1,3})(\]?)$'
-        example: john_bob.joe@foo.edu
+        pattern: ^(.+)@(.+)\.(.{1,3})$
+        example: john_bob@foo.edu
         x-nullable: true
         title: personal email address
       phone_is_preferred:
@@ -1107,7 +1086,7 @@ definitions:
         type: string
         format: uuid
         example: c56a4180-65aa-42ec-a945-5fd21dec0538
-      edipi_text:
+      edipi:
         type: string
         format: string
         pattern: /^[0-9]{10}$/
@@ -1115,12 +1094,7 @@ definitions:
         x-nullable: true
         title: 'EDIPI ID'
       ssn:
-        type: string
-        format: ssn
-        pattern: '^\d{3}-\d{2}-\d{4}$'
-        example: 555-55-5555
-        x-nullable: true
-        title: 'ssn #'
+        $ref: '#/definitions/SocialSecurityNumber'
       first_name:
         type: string
         example: John
@@ -1157,10 +1131,10 @@ definitions:
         title: Secondary Telephone
       personal_email:
         type: string
-        format: telephone
-        pattern: '^([a-zA-Z0-9_\-\.]+)@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.)|(([a-zA-Z0-9\-]+\.)+))([a-zA-Z]{2,4}|[0-9]{1,3})(\]?)$'
-        example: john_bob.joe@foo.edu
+        pattern: ^(.+)@(.+)\.(.{1,3})$
+        example: john_bob@foo.edu
         x-nullable: true
+        title: personal email address
         title: personal email address
       phone_is_preferred:
         type: boolean
@@ -1210,10 +1184,10 @@ definitions:
         x-nullable: true
       email:
         type: string
-        format: telephone
-        pattern: '^([a-zA-Z0-9_\-\.]+)@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.)|(([a-zA-Z0-9\-]+\.)+))([a-zA-Z]{2,4}|[0-9]{1,3})(\]?)$'
-        example: john_bob.joe@foo.edu
+        pattern: ^(.+)@(.+)\.(.{1,3})$
+        example: john_bob@foo.edu
         x-nullable: true
+        title: email address
       authorized_to_meet_mover:
         type: boolean
         x-nullable: true
@@ -1247,10 +1221,10 @@ definitions:
         x-nullable: true
       email:
         type: string
-        format: telephone
-        pattern: '^([a-zA-Z0-9_\-\.]+)@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.)|(([a-zA-Z0-9\-]+\.)+))([a-zA-Z]{2,4}|[0-9]{1,3})(\]?)$'
-        example: john_bob.joe@foo.edu
+        pattern: ^(.+)@(.+)\.(.{1,3})$
+        example: john_bob@foo.edu
         x-nullable: true
+        title: email address
       authorized_to_meet_mover:
         type: boolean
         x-nullable: true
@@ -1273,10 +1247,10 @@ definitions:
         x-nullable: true
       email:
         type: string
-        format: telephone
-        pattern: '^([a-zA-Z0-9_\-\.]+)@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.)|(([a-zA-Z0-9\-]+\.)+))([a-zA-Z]{2,4}|[0-9]{1,3})(\]?)$'
-        example: john_bob.joe@foo.edu
+        pattern: ^(.+)@(.+)\.(.{1,3})$
+        example: john_bob@foo.edu
         x-nullable: true
+        title: email address
       authorized_to_meet_mover:
         type: boolean
         x-nullable: true
@@ -2210,3 +2184,12 @@ definitions:
       - city
       - state
       - zip
+  SocialSecurityNumber:
+    type: object
+    properties:
+      encrypted_hash:
+        type: string
+        title: Social Security Number
+        x-nullable: true
+    required:
+      - encrypted_hash

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -484,6 +484,7 @@ paths:
           description: not found
         500:
           description: server error
+
   /stations/search/{searchString}:
     get:
       summary: Returns a list of stations based on search string
@@ -543,6 +544,7 @@ paths:
           description: station is not found
         500:
           description: internal server error
+
   /profiles/service_member_profile:
     post:
       summary: Submits profile for a logged-in user
@@ -567,6 +569,10 @@ paths:
           description: request requires user authentication
         403:
           description: user is not authorized to create this profile
+        404:
+          description: profile not found
+        500:
+          description: internal server error
     get:
       summary: List all service member profiles
       description: List all service member profiles
@@ -582,6 +588,12 @@ paths:
           description: invalid request
         401:
           description: request requires user authentication
+        403:
+          description: user is not authorized to create this profile
+        404:
+          description: no profiles found
+        500:
+          description: internal server error
   /profiles/service_member_profile/{userId}:
     get:
       summary: Returns the given service member profile
@@ -644,6 +656,7 @@ paths:
           description: profile not found
         500:
           description: internal server error
+
   /profiles/service_member_profile/{userId}/backup_contact:
     post:
       summary: Submits backup contact for a logged-in user
@@ -674,6 +687,10 @@ paths:
           description: request requires user authentication
         403:
           description: user is not authorized to create this backup contact
+        404:
+          description: contact not found
+        500:
+          description: internal server error
     get:
       summary: List all service member backup contacts
       description: List all service member backup contacts
@@ -696,6 +713,12 @@ paths:
           description: invalid request
         401:
           description: request requires user authentication
+        403:
+          description: user is not authorized to see this backup contact
+        404:
+          description: contact not found
+        500:
+          description: internal server error
   /profiles/service_member_profile/{userId}/backup_contact/{backupContactId}:
     get:
       summary: Returns the given service member backup contact
@@ -876,6 +899,7 @@ definitions:
     type: array
     items:
       $ref: '#/definitions/MovePayload'
+
   Station:
     type: object
     properties:
@@ -901,6 +925,7 @@ definitions:
       - address
       - created_at
       - updated_at
+
   ServiceMemberProfilePayload:
     type: object
     properties:
@@ -1155,6 +1180,7 @@ definitions:
     type: array
     items:
       $ref: '#/definitions/ServiceMemberProfilePayload'
+
   ServiceMemberBackupContactPayload:
     type: object
     properties:
@@ -1252,6 +1278,7 @@ definitions:
     type: array
     items:
       $ref: '#/definitions/ServiceMemberBackupContactPayload'
+
   CreateSignedCertificationPayload:
     type: object
     properties:

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -485,7 +485,7 @@ paths:
         500:
           description: server error
 
-  /stations/search/{searchString}:
+  /stations:
     get:
       summary: Returns a list of stations based on search string
       description: List all stations based on search string
@@ -493,11 +493,11 @@ paths:
       tags:
         - stations
       parameters:
-        - in: path
+        - in: query
           name: searchString
           type: string
           required: true
-          description: string to search
+          description: string to search with
       responses:
         200:
           description: list of stations matching search string
@@ -545,62 +545,68 @@ paths:
         500:
           description: internal server error
 
-  /profiles/service_member_profile:
-    post:
-      summary: Submits profile for a logged-in user
-      description: Creates an instance of a profile tied to a service member user
-      operationId: createServiceMemberProfile
-      tags:
-        - profiles
-      parameters:
-        - in: body
-          name: createProfilePayload
-          required: true
-          schema:
-            $ref: '#/definitions/CreateServiceMemberProfilePayload'
-      responses:
-        201:
-          description: created instance of service member profile
-          schema:
-            $ref: '#/definitions/ServiceMemberProfilePayload'
-        400:
-          description: invalid request
-        401:
-          description: request requires user authentication
-        403:
-          description: user is not authorized to create this profile
-        404:
-          description: profile not found
-        500:
-          description: internal server error
+  /service_members:
     get:
-      summary: List all service member profiles
-      description: List all service member profiles
-      operationId: indexServiceMemberProfiles
+      summary: List all service members
+      description: List all service members
+      operationId: indexServiceMembers
       tags:
-        - profiles
+        - service_members
       responses:
         200:
-          description: list of service member profiles
+          description: list of service members
           schema:
-            $ref: '#/definitions/IndexServiceMemberProfilesPayload'
+            $ref: '#/definitions/IndexServiceMembersPayload'
         400:
           description: invalid request
         401:
           description: request requires user authentication
         403:
-          description: user is not authorized to create this profile
+          description: user is not authorized
         404:
-          description: no profiles found
+          description: no service members found
         500:
           description: internal server error
-  /profiles/service_member_profile/{userId}:
-    get:
-      summary: Returns the given service member profile
-      description: Returns the given service member profile
-      operationId: showServiceMemberProfile
+  /service_members/{userId}:
+    post:
+      summary: Creates service member for a logged-in user
+      description: Creates an instance of a service member tied to a user
+      operationId: createServiceMember
       tags:
-        - profiles
+        - service_members
+      parameters:
+        - in: body
+          name: createServiceMemberPayload
+          required: true
+          schema:
+            $ref: '#/definitions/CreateServiceMemberPayload'
+        - in: path
+          name: userId
+          type: string
+          format: uuid
+          required: true
+          description: UUID of the service member
+      responses:
+        201:
+          description: created instance of service member
+          schema:
+            $ref: '#/definitions/ServiceMemberPayload'
+        400:
+          description: invalid request
+        401:
+          description: request requires user authentication
+        403:
+          description: user is not authorized
+        404:
+          description: service member not found
+        500:
+          description: internal server error
+    get:
+      summary: Returns the given service member
+      description: Returns the given service member
+      operationId: showServiceMember
+      tags:
+        - service_members
       parameters:
         - in: path
           name: userId
@@ -610,9 +616,9 @@ paths:
           description: UUID of the service member
       responses:
         200:
-          description: the instance of the service member profile
+          description: the instance of the service member
           schema:
-            $ref: '#/definitions/ServiceMemberProfilePayload'
+            $ref: '#/definitions/ServiceMemberPayload'
         400:
           description: invalid request
         401:
@@ -620,15 +626,15 @@ paths:
         403:
           description: user is not authorized
         404:
-          description: profile not found
+          description: service member not found
         500:
           description: internal server error
     patch:
-      summary: Patches the service member profile
-      description: Any fields sent in this request will be set on the profile referenced
-      operationId: patchServiceMemberProfile
+      summary: Patches the service member
+      description: Any fields sent in this request will be set on the service member referenced
+      operationId: patchServiceMember
       tags:
-        - profiles
+        - service_members
       parameters:
         - in: path
           name: userId
@@ -637,15 +643,15 @@ paths:
           required: true
           description: UUID of the service member
         - in: body
-          name: patchServiceMemberProfilePayload
+          name: patchServiceMemberPayload
           required: true
           schema:
-            $ref: '#/definitions/ServiceMemberProfilePayload'
+            $ref: '#/definitions/ServiceMemberPayload'
       responses:
         201:
-          description: updated instance of profile
+          description: updated instance of service member
           schema:
-            $ref: '#/definitions/ServiceMemberProfilePayload'
+            $ref: '#/definitions/ServiceMemberPayload'
         400:
           description: invalid request
         401:
@@ -653,11 +659,11 @@ paths:
         403:
           description: user is not authorized
         404:
-          description: profile not found
+          description: service member not found
         500:
           description: internal server error
 
-  /profiles/service_member_profile/{userId}/backup_contact:
+  /service_members/{serviceMemberId}/backup_contact:
     post:
       summary: Submits backup contact for a logged-in user
       description: Creates an instance of a backup contact tied to a service member user
@@ -671,7 +677,7 @@ paths:
           schema:
             $ref: '#/definitions/CreateServiceMemberBackupContactPayload'
         - in: path
-          name: userId
+          name: serviceMemberId
           type: string
           format: uuid
           required: true
@@ -699,7 +705,7 @@ paths:
         - backup_contacts
       parameters:
         - in: path
-          name: userId
+          name: serviceMemberId
           type: string
           format: uuid
           required: true
@@ -719,7 +725,7 @@ paths:
           description: contact not found
         500:
           description: internal server error
-  /profiles/service_member_profile/{userId}/backup_contact/{backupContactId}:
+  /service_members/{serviceMemberId}/backup_contact/{backupContactId}:
     get:
       summary: Returns the given service member backup contact
       description: Returns the given service member backup contact
@@ -728,7 +734,7 @@ paths:
         - backup_contacts
       parameters:
         - in: path
-          name: userId
+          name: serviceMemberId
           type: string
           format: uuid
           required: true
@@ -773,7 +779,7 @@ paths:
           required: true
           description: UUID of the service member backup contact
         - in: path
-          name: userId
+          name: serviceMemberId
           type: string
           format: uuid
           required: true
@@ -926,7 +932,7 @@ definitions:
       - created_at
       - updated_at
 
-  ServiceMemberProfilePayload:
+  ServiceMemberPayload:
     type: object
     properties:
       id:
@@ -1012,7 +1018,7 @@ definitions:
       - profile_complete
       - created_at
       - updated_at
-  CreateServiceMemberProfilePayload:
+  CreateServiceMemberPayload:
     type: object
     properties:
       user_id:
@@ -1094,7 +1100,7 @@ definitions:
         $ref: '#/definitions/Address'
       profile_complete:
         type: boolean
-  PatchServiceMemberProfilePayload:
+  PatchServiceMemberPayload:
     type: object
     properties:
       user_id:
@@ -1176,10 +1182,10 @@ definitions:
         $ref: '#/definitions/Address'
       profile_complete:
         type: boolean
-  IndexServiceMemberProfilesPayload:
+  IndexServiceMembersPayload:
     type: array
     items:
-      $ref: '#/definitions/ServiceMemberProfilePayload'
+      $ref: '#/definitions/ServiceMemberPayload'
 
   ServiceMemberBackupContactPayload:
     type: object

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -1097,7 +1097,7 @@ definitions:
         pattern: /^[0-9]{10}$/
         example: 57893457897
         x-nullable: true
-        title: 'EDIPI ID'
+        title: 'DoD ID #'
       social_security_number:
         type: string
         format: ssn
@@ -1169,7 +1169,6 @@ definitions:
     type: array
     items:
       $ref: '#/definitions/ServiceMemberPayload'
-
   ServiceMemberBackupContactPayload:
     type: object
     properties:
@@ -1267,7 +1266,6 @@ definitions:
     type: array
     items:
       $ref: '#/definitions/ServiceMemberBackupContactPayload'
-
   CreateSignedCertificationPayload:
     type: object
     properties:

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -486,6 +486,166 @@ paths:
           description: not found
         500:
           description: server error
+  /stations/search/{searchString}:
+    get:
+      summary: Returns a list of stations based on search string
+      description: List all stations based on search string
+      operationId: showStations
+      tags:
+        - stations
+      parameters:
+        - in: path
+          name: searchString
+          type: string
+          required: true
+          description: string to search
+      responses:
+        200:
+          description: list of stations matching search string
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Station'
+        400:
+          description: invalid request
+        401:
+          description: request requires user authentication
+        403:
+          description: user is not authorized
+        404:
+          description: no stations found
+        500:
+          description: internal server error
+  /stations/{stationId}:
+    get:
+      summary: Returns the given station
+      description: Returns the given station
+      operationId: showStation
+      tags:
+        - stations
+      parameters:
+        - in: path
+          name: stationId
+          type: string
+          format: uuid
+          required: true
+          description: UUID of station
+      responses:
+        200:
+          description: the instance of the station
+          schema:
+            $ref: '#/definitions/Station'
+        400:
+          description: invalid request
+        401:
+          description: request requires user authentication
+        403:
+          description: user is not authorized
+        404:
+          description: station is not found
+        500:
+          description: internal server error
+  /profiles/service_member_profile:
+    post:
+      summary: Submits profile for a logged-in user
+      description: Creates an instance of a profile tied to a service member user
+      operationId: createServiceMemberProfile
+      tags:
+        - profiles
+      parameters:
+        - in: body
+          name: createProfilePayload
+          required: true
+          schema:
+            $ref: '#/definitions/CreateServiceMemberProfilePayload'
+      responses:
+        201:
+          description: created instance of service member profile
+          schema:
+            $ref: '#/definitions/ServiceMemberProfilePayload'
+        400:
+          description: invalid request
+        401:
+          description: request requires user authentication
+        403:
+          description: user is not authorized to create this profile
+    get:
+      summary: List all service member profiles
+      description: List all service member profiles
+      operationId: indexServiceMemberProfiles
+      tags:
+        - profiles
+      responses:
+        200:
+          description: list of service member profiles
+          schema:
+            $ref: '#/definitions/IndexServiceMemberProfilesPayload'
+        400:
+          description: invalid request
+        401:
+          description: request requires user authentication
+  /profiles/service_member_profile/{profileId}:
+    get:
+      summary: Returns the given service member profile
+      description: Returns the given service member profile
+      operationId: showServiceMemberProfile
+      tags:
+        - profiles
+      parameters:
+        - in: path
+          name: profileId
+          type: string
+          format: uuid
+          required: true
+          description: UUID of the service member profile
+      responses:
+        200:
+          description: the instance of the service member profile
+          schema:
+            $ref: '#/definitions/ServiceMemberProfilePayload'
+        400:
+          description: invalid request
+        401:
+          description: request requires user authentication
+        403:
+          description: user is not authorized
+        404:
+          description: profile not found
+        500:
+          description: internal server error
+    patch:
+      summary: Patches the service member profile
+      description: Any fields sent in this request will be set on the profile referenced
+      operationId: patchServiceMemberProfile
+      tags:
+        - profiles
+      parameters:
+        - in: path
+          name: profileId
+          type: string
+          format: uuid
+          required: true
+          description: UUID of the profile
+        - in: body
+          name: patchServiceMemberProfilePayload
+          required: true
+          schema:
+            $ref: '#/definitions/ServiceMemberProfilePayload'
+      responses:
+        201:
+          description: updated instance of profile
+          schema:
+            $ref: '#/definitions/ServiceMemberProfilePayload'
+        400:
+          description: invalid request
+        401:
+          description: request requires user authentication
+        403:
+          description: user is not authorized
+        404:
+          description: profile not found
+        500:
+          description: internal server error
 
 definitions:
   CreatePersonallyProcuredMovePayload:
@@ -592,6 +752,312 @@ definitions:
     type: array
     items:
       $ref: '#/definitions/MovePayload'
+  Station:
+    type: object
+    properties:
+      id:
+        type: string
+        format: uuid
+        example: c56a4180-65aa-42ec-a945-5fd21dec0538
+      name:
+        type: string
+        format: string
+        example: Fort Bragg North Station
+      address:
+        $ref: '#/definitions/Address'
+      created_at:
+        type: string
+        format: date-time
+      updated_at:
+        type: string
+        format: date-time
+    required:
+      - id
+      - name
+      - address
+      - created_at
+      - updated_at
+  IndexStationsBySubstringPayload:
+    type: array
+    items:
+      $ref: '#/definitions/Station'
+  ServiceMemberProfilePayload:
+    type: object
+    properties:
+      id:
+        type: string
+        format: uuid
+        example: c56a4180-65aa-42ec-a945-5fd21dec0538
+      user_id:
+        type: string
+        format: uuid
+        example: c56a4180-65aa-42ec-a945-5fd21dec0538
+      edipi_text:
+        type: string
+        format: string
+        example: alsdkjflksjdf
+        x-nullable: true
+      ssn:
+        type: string
+        format: ssn
+        pattern: '^\d{3}-\d{2}-\d{4}$'
+        example: 555-55-5555
+        x-nullable: true
+      human_title:
+        $ref: '#/definitions/HumanTitle'
+      first_name:
+        type: string
+        example: John
+        x-nullable: true
+      middle_initial:
+        type: string
+        example: L.
+        x-nullable: true
+      last_name:
+        type: string
+        example: Donut
+        x-nullable: true
+      suffix:
+        type: string
+        example: Jr.
+        x-nullable: true
+      telephone:
+        type: string
+        format: telephone
+        pattern: '^[2-9]\d{2}-\d{3}-\d{4}$'
+        example: 212-555-5555
+        x-nullable: true
+      secondary_telephone:
+        type: string
+        format: telephone
+        pattern: '^[2-9]\d{2}-\d{3}-\d{4}$'
+        example: 212-555-5555
+        x-nullable: true
+      personal_email:
+        type: string
+        format: telephone
+        pattern: '^([a-zA-Z0-9_\-\.]+)@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.)|(([a-zA-Z0-9\-]+\.)+))([a-zA-Z]{2,4}|[0-9]{1,3})(\]?)$'
+        example: john_bob.joe@foo.edu
+        x-nullable: true
+      phone_is_preferred:
+        type: boolean
+        x-nullable: true
+      secondary_phone_is_preferred:
+        type: boolean
+        x-nullable: true
+      email_is_preferred:
+        type: boolean
+        x-nullable: true
+      current_station:
+        $ref: '#/definitions/Station'
+      residential_address:
+        $ref: '#/definitions/Address'
+      backup_mailing_address:
+        $ref: '#/definitions/Address'
+      profile_complete:
+        type: boolean
+      created_at:
+        type: string
+        format: date-time
+      updated_at:
+        type: string
+        format: date-time
+    required:
+      - id
+      - user_id
+      - profile_complete
+      - created_at
+      - updated_at
+  CreateServiceMemberProfilePayload:
+    type: object
+    properties:
+      id:
+        type: string
+        format: uuid
+        example: c56a4180-65aa-42ec-a945-5fd21dec0538
+      user_id:
+        type: string
+        format: uuid
+        example: c56a4180-65aa-42ec-a945-5fd21dec0538
+      edipi_text:
+        type: string
+        format: string
+        example: alsdkjflksjdf
+        x-nullable: true
+        title: EDIPI ID
+      ssn:
+        type: string
+        format: ssn
+        pattern: '^\d{3}-\d{2}-\d{4}$'
+        example: 555-55-5555
+        x-nullable: true
+        title: Social Security Number
+      human_title:
+        $ref: '#/definitions/HumanTitle'
+      first_name:
+        type: string
+        example: John
+        x-nullable: true
+        title: First Name
+      middle_initial:
+        type: string
+        example: L.
+        x-nullable: true
+        title: Middle Initial
+      last_name:
+        type: string
+        example: Donut
+        x-nullable: true
+        title: Last Name
+      suffix:
+        type: string
+        example: Jr.
+        x-nullable: true
+        title: Suffix
+      telephone:
+        type: string
+        format: telephone
+        pattern: '^[2-9]\d{2}-\d{3}-\d{4}$'
+        example: 212-555-5555
+        x-nullable: true
+        title: telephone
+      secondary_telephone:
+        type: string
+        format: telephone
+        pattern: '^[2-9]\d{2}-\d{3}-\d{4}$'
+        example: 212-555-5555
+        x-nullable: true
+        title: Secondary Telephone
+      personal_email:
+        type: string
+        format: telephone
+        pattern: '^([a-zA-Z0-9_\-\.]+)@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.)|(([a-zA-Z0-9\-]+\.)+))([a-zA-Z]{2,4}|[0-9]{1,3})(\]?)$'
+        example: john_bob.joe@foo.edu
+        x-nullable: true
+        title: personal email address
+      phone_is_preferred:
+        type: boolean
+        x-nullable: true
+        title: Phone is Preferred
+      secondary_phone_is_preferred:
+        type: boolean
+        x-nullable: true
+        title: Secondary Phone is Preferred
+      email_is_preferred:
+        type: boolean
+        x-nullable: true
+        title: Email is Preferred
+      # current_station:
+      #   ref: '$/definitions/Station'
+      residential_address:
+        $ref: '#/definitions/Address'
+      backup_mailing_address:
+        $ref: '#/definitions/Address'
+      profile_complete:
+        type: boolean
+      created_at:
+        type: string
+        format: date-time
+      updated_at:
+        type: string
+        format: date-time
+  PatchServiceMemberProfilePayload:
+    type: object
+    properties:
+      id:
+        type: string
+        format: uuid
+        example: c56a4180-65aa-42ec-a945-5fd21dec0538
+      user_id:
+        type: string
+        format: uuid
+        example: c56a4180-65aa-42ec-a945-5fd21dec0538
+      edipi_text:
+        type: string
+        format: string
+        example: alsdkjflksjdf
+        x-nullable: true
+        title: EDIPI ID
+      ssn:
+        type: string
+        format: ssn
+        pattern: '^\d{3}-\d{2}-\d{4}$'
+        example: 555-55-5555
+        x-nullable: true
+        title: Social Security Number
+      human_title:
+        $ref: '#/definitions/HumanTitle'
+      first_name:
+        type: string
+        example: John
+        x-nullable: true
+        title: First Name
+      middle_initial:
+        type: string
+        example: L.
+        x-nullable: true
+        title: Middle Initial
+      last_name:
+        type: string
+        example: Donut
+        x-nullable: true
+        title: Last Name
+      suffix:
+        type: string
+        example: Jr.
+        x-nullable: true
+        title: Suffix
+      telephone:
+        type: string
+        format: telephone
+        pattern: '^[2-9]\d{2}-\d{3}-\d{4}$'
+        example: 212-555-5555
+        x-nullable: true
+        title: telephone
+      secondary_telephone:
+        type: string
+        format: telephone
+        pattern: '^[2-9]\d{2}-\d{3}-\d{4}$'
+        example: 212-555-5555
+        x-nullable: true
+        title: Secondary Telephone
+      personal_email:
+        type: string
+        format: telephone
+        pattern: '^([a-zA-Z0-9_\-\.]+)@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.)|(([a-zA-Z0-9\-]+\.)+))([a-zA-Z]{2,4}|[0-9]{1,3})(\]?)$'
+        example: john_bob.joe@foo.edu
+        x-nullable: true
+        title: personal email address
+      phone_is_preferred:
+        type: boolean
+        x-nullable: true
+        title: Phone is Preferred
+      secondary_phone_is_preferred:
+        type: boolean
+        x-nullable: true
+        title: Secondary Phone is Preferred
+      email_is_preferred:
+        type: boolean
+        x-nullable: true
+        title: Email is Preferred
+      # current_station:
+      #   ref: '$/definitions/Station'
+      residential_address:
+        $ref: '#/definitions/Address'
+      backup_mailing_address:
+        $ref: '#/definitions/Address'
+      profile_complete:
+        type: boolean
+      created_at:
+        type: string
+        format: date-time
+      updated_at:
+        type: string
+        format: date-time
+  IndexServiceMemberProfilesPayload:
+    type: array
+    items:
+      $ref: '#/definitions/ServiceMemberProfilePayload'
   CreateSignedCertificationPayload:
     type: object
     properties:
@@ -1517,3 +1983,16 @@ definitions:
       - city
       - state
       - zip
+  HumanTitle:
+    type: string
+    title: Title
+    enum:
+      - MS
+      - MX
+      - MR
+      - DR
+    x-display-value:
+      MS: Ms.
+      MX: Mx.
+      MR: Mr.
+      DR: Dr.

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -219,7 +219,6 @@ paths:
           description: move is not found
         500:
           description: internal server error
-
   /moves/{moveId}/signed_certification:
     post:
       summary: Submits signed certification for the given move ID
@@ -252,7 +251,6 @@ paths:
           description: move not found
         500:
           description: internal server error
-
   /moves/{moveId}/personally_procured_move:
     post:
       summary: Creates a new PPM for the given move
@@ -584,7 +582,7 @@ paths:
           description: invalid request
         401:
           description: request requires user authentication
-  /profiles/service_member_profile/{profileId}:
+  /profiles/service_member_profile/{userId}:
     get:
       summary: Returns the given service member profile
       description: Returns the given service member profile
@@ -593,11 +591,11 @@ paths:
         - profiles
       parameters:
         - in: path
-          name: profileId
+          name: userId
           type: string
           format: uuid
           required: true
-          description: UUID of the service member profile
+          description: UUID of the service member
       responses:
         200:
           description: the instance of the service member profile
@@ -621,11 +619,11 @@ paths:
         - profiles
       parameters:
         - in: path
-          name: profileId
+          name: userId
           type: string
           format: uuid
           required: true
-          description: UUID of the profile
+          description: UUID of the service member
         - in: body
           name: patchServiceMemberProfilePayload
           required: true
@@ -644,6 +642,132 @@ paths:
           description: user is not authorized
         404:
           description: profile not found
+        500:
+          description: internal server error
+  /profiles/service_member_profile/{userId}/backup_contact:
+    post:
+      summary: Submits backup contact for a logged-in user
+      description: Creates an instance of a backup contact tied to a service member user
+      operationId: createServiceMemberBackupContact
+      tags:
+        - backup_contacts
+      parameters:
+        - in: body
+          name: createBackupContactPayload
+          required: true
+          schema:
+            $ref: '#/definitions/CreateServiceMemberBackupContactPayload'
+        - in: path
+          name: userId
+          type: string
+          format: uuid
+          required: true
+          description: UUID of the service member
+      responses:
+        201:
+          description: created instance of service member backup contact
+          schema:
+            $ref: '#/definitions/ServiceMemberBackupContactPayload'
+        400:
+          description: invalid request
+        401:
+          description: request requires user authentication
+        403:
+          description: user is not authorized to create this backup contact
+    get:
+      summary: List all service member backup contacts
+      description: List all service member backup contacts
+      operationId: indexServiceMemberBackupContacts
+      tags:
+        - backup_contacts
+      parameters:
+        - in: path
+          name: userId
+          type: string
+          format: uuid
+          required: true
+          description: UUID of the service member
+      responses:
+        200:
+          description: list of service member backup contacts
+          schema:
+            $ref: '#/definitions/IndexServiceMemberBackupContactsPayload'
+        400:
+          description: invalid request
+        401:
+          description: request requires user authentication
+  /profiles/service_member_profile/{userId}/backup_contact/{backupContactId}:
+    get:
+      summary: Returns the given service member backup contact
+      description: Returns the given service member backup contact
+      operationId: showServiceMemberBackupContact
+      tags:
+        - backup_contacts
+      parameters:
+        - in: path
+          name: userId
+          type: string
+          format: uuid
+          required: true
+          description: UUID of the service member
+        - in: path
+          name: backupContactId
+          type: string
+          format: uuid
+          required: true
+          description: UUID of the service member backup contact
+      responses:
+        200:
+          description: the instance of the service member backup contact
+          schema:
+            $ref: '#/definitions/ServiceMemberBackupContactPayload'
+        400:
+          description: invalid request
+        401:
+          description: request requires user authentication
+        403:
+          description: user is not authorized
+        404:
+          description: backup contact not found
+        500:
+          description: internal server error
+    patch:
+      summary: Patches the service member backup contact
+      description: Any fields sent in this request will be set on the backup contact referenced
+      operationId: patchServiceMemberBackupContact
+      tags:
+        - backup_contacts
+      parameters:
+        - in: body
+          name: patchServiceMemberBackupContactPayload
+          required: true
+          schema:
+            $ref: '#/definitions/ServiceMemberBackupContactPayload'
+        - in: path
+          name: backupContactId
+          type: string
+          format: uuid
+          required: true
+          description: UUID of the service member backup contact
+        - in: path
+          name: userId
+          type: string
+          format: uuid
+          required: true
+          description: UUID of the service member
+      responses:
+        201:
+          description: updated instance of backup contact
+          schema:
+            $ref: '#/definitions/ServiceMemberBackupContactPayload'
+        400:
+          description: invalid request
+        401:
+          description: request requires user authentication
+        403:
+          description: user is not authorized
+        404:
+          description: backup contact not found
         500:
           description: internal server error
 
@@ -777,10 +901,6 @@ definitions:
       - address
       - created_at
       - updated_at
-  IndexStationsBySubstringPayload:
-    type: array
-    items:
-      $ref: '#/definitions/Station'
   ServiceMemberProfilePayload:
     type: object
     properties:
@@ -795,7 +915,8 @@ definitions:
       edipi_text:
         type: string
         format: string
-        example: alsdkjflksjdf
+        example: 57893457897
+        pattern: /^[0-9]{10}$/
         x-nullable: true
       ssn:
         type: string
@@ -803,8 +924,6 @@ definitions:
         pattern: '^\d{3}-\d{2}-\d{4}$'
         example: 555-55-5555
         x-nullable: true
-      human_title:
-        $ref: '#/definitions/HumanTitle'
       first_name:
         type: string
         example: John
@@ -871,10 +990,6 @@ definitions:
   CreateServiceMemberProfilePayload:
     type: object
     properties:
-      id:
-        type: string
-        format: uuid
-        example: c56a4180-65aa-42ec-a945-5fd21dec0538
       user_id:
         type: string
         format: uuid
@@ -882,18 +997,17 @@ definitions:
       edipi_text:
         type: string
         format: string
-        example: alsdkjflksjdf
+        pattern: /^[0-9]{10}$/
+        example: 57893457897
         x-nullable: true
-        title: EDIPI ID
+        title: 'DoD ID #'
       ssn:
         type: string
         format: ssn
         pattern: '^\d{3}-\d{2}-\d{4}$'
         example: 555-55-5555
         x-nullable: true
-        title: Social Security Number
-      human_title:
-        $ref: '#/definitions/HumanTitle'
+        title: 'ssn #'
       first_name:
         type: string
         example: John
@@ -947,21 +1061,101 @@ definitions:
         type: boolean
         x-nullable: true
         title: Email is Preferred
-      # current_station:
-      #   ref: '$/definitions/Station'
+      current_station:
+        $ref: '#/definitions/Station'
       residential_address:
         $ref: '#/definitions/Address'
       backup_mailing_address:
         $ref: '#/definitions/Address'
       profile_complete:
         type: boolean
-      created_at:
-        type: string
-        format: date-time
-      updated_at:
-        type: string
-        format: date-time
   PatchServiceMemberProfilePayload:
+    type: object
+    properties:
+      user_id:
+        type: string
+        format: uuid
+        example: c56a4180-65aa-42ec-a945-5fd21dec0538
+      edipi_text:
+        type: string
+        format: string
+        pattern: /^[0-9]{10}$/
+        example: 57893457897
+        x-nullable: true
+        title: 'EDIPI ID'
+      ssn:
+        type: string
+        format: ssn
+        pattern: '^\d{3}-\d{2}-\d{4}$'
+        example: 555-55-5555
+        x-nullable: true
+        title: 'ssn #'
+      first_name:
+        type: string
+        example: John
+        x-nullable: true
+        title: First Name
+      middle_initial:
+        type: string
+        example: L.
+        x-nullable: true
+        title: Middle Initial
+      last_name:
+        type: string
+        example: Donut
+        x-nullable: true
+        title: Last Name
+      suffix:
+        type: string
+        example: Jr.
+        x-nullable: true
+        title: Suffix
+      telephone:
+        type: string
+        format: telephone
+        pattern: '^[2-9]\d{2}-\d{3}-\d{4}$'
+        example: 212-555-5555
+        x-nullable: true
+        title: telephone
+      secondary_telephone:
+        type: string
+        format: telephone
+        pattern: '^[2-9]\d{2}-\d{3}-\d{4}$'
+        example: 212-555-5555
+        x-nullable: true
+        title: Secondary Telephone
+      personal_email:
+        type: string
+        format: telephone
+        pattern: '^([a-zA-Z0-9_\-\.]+)@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.)|(([a-zA-Z0-9\-]+\.)+))([a-zA-Z]{2,4}|[0-9]{1,3})(\]?)$'
+        example: john_bob.joe@foo.edu
+        x-nullable: true
+        title: personal email address
+      phone_is_preferred:
+        type: boolean
+        x-nullable: true
+        title: Phone is Preferred
+      secondary_phone_is_preferred:
+        type: boolean
+        x-nullable: true
+        title: Secondary Phone is Preferred
+      email_is_preferred:
+        type: boolean
+        x-nullable: true
+        title: Email is Preferred
+      current_station:
+        $ref: '#/definitions/Station'
+      residential_address:
+        $ref: '#/definitions/Address'
+      backup_mailing_address:
+        $ref: '#/definitions/Address'
+      profile_complete:
+        type: boolean
+  IndexServiceMemberProfilesPayload:
+    type: array
+    items:
+      $ref: '#/definitions/ServiceMemberProfilePayload'
+  ServiceMemberBackupContactPayload:
     type: object
     properties:
       id:
@@ -972,92 +1166,92 @@ definitions:
         type: string
         format: uuid
         example: c56a4180-65aa-42ec-a945-5fd21dec0538
-      edipi_text:
+      name:
         type: string
-        format: string
-        example: alsdkjflksjdf
+        example: Susan Smith
         x-nullable: true
-        title: EDIPI ID
-      ssn:
-        type: string
-        format: ssn
-        pattern: '^\d{3}-\d{2}-\d{4}$'
-        example: 555-55-5555
-        x-nullable: true
-        title: Social Security Number
-      human_title:
-        $ref: '#/definitions/HumanTitle'
-      first_name:
-        type: string
-        example: John
-        x-nullable: true
-        title: First Name
-      middle_initial:
-        type: string
-        example: L.
-        x-nullable: true
-        title: Middle Initial
-      last_name:
-        type: string
-        example: Donut
-        x-nullable: true
-        title: Last Name
-      suffix:
-        type: string
-        example: Jr.
-        x-nullable: true
-        title: Suffix
       telephone:
         type: string
         format: telephone
         pattern: '^[2-9]\d{2}-\d{3}-\d{4}$'
         example: 212-555-5555
         x-nullable: true
-        title: telephone
-      secondary_telephone:
-        type: string
-        format: telephone
-        pattern: '^[2-9]\d{2}-\d{3}-\d{4}$'
-        example: 212-555-5555
-        x-nullable: true
-        title: Secondary Telephone
-      personal_email:
+      email:
         type: string
         format: telephone
         pattern: '^([a-zA-Z0-9_\-\.]+)@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.)|(([a-zA-Z0-9\-]+\.)+))([a-zA-Z]{2,4}|[0-9]{1,3})(\]?)$'
         example: john_bob.joe@foo.edu
         x-nullable: true
-        title: personal email address
-      phone_is_preferred:
+      authorized_to_meet_mover:
         type: boolean
         x-nullable: true
-        title: Phone is Preferred
-      secondary_phone_is_preferred:
-        type: boolean
-        x-nullable: true
-        title: Secondary Phone is Preferred
-      email_is_preferred:
-        type: boolean
-        x-nullable: true
-        title: Email is Preferred
-      # current_station:
-      #   ref: '$/definitions/Station'
-      residential_address:
-        $ref: '#/definitions/Address'
-      backup_mailing_address:
-        $ref: '#/definitions/Address'
-      profile_complete:
-        type: boolean
       created_at:
         type: string
         format: date-time
       updated_at:
         type: string
         format: date-time
-  IndexServiceMemberProfilesPayload:
+    required:
+      - id
+      - user_id
+      - created_at
+      - updated_at
+  CreateServiceMemberBackupContactPayload:
+    type: object
+    properties:
+      user_id:
+        type: string
+        format: uuid
+        example: c56a4180-65aa-42ec-a945-5fd21dec0538
+      name:
+        type: string
+        example: Susan Smith
+        x-nullable: true
+      telephone:
+        type: string
+        format: telephone
+        pattern: '^[2-9]\d{2}-\d{3}-\d{4}$'
+        example: 212-555-5555
+        x-nullable: true
+      email:
+        type: string
+        format: telephone
+        pattern: '^([a-zA-Z0-9_\-\.]+)@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.)|(([a-zA-Z0-9\-]+\.)+))([a-zA-Z]{2,4}|[0-9]{1,3})(\]?)$'
+        example: john_bob.joe@foo.edu
+        x-nullable: true
+      authorized_to_meet_mover:
+        type: boolean
+        x-nullable: true
+  PatchServiceMemberBackupContactPayload:
+    type: object
+    properties:
+      user_id:
+        type: string
+        format: uuid
+        example: c56a4180-65aa-42ec-a945-5fd21dec0538
+      name:
+        type: string
+        example: Susan Smith
+        x-nullable: true
+      telephone:
+        type: string
+        format: telephone
+        pattern: '^[2-9]\d{2}-\d{3}-\d{4}$'
+        example: 212-555-5555
+        x-nullable: true
+      email:
+        type: string
+        format: telephone
+        pattern: '^([a-zA-Z0-9_\-\.]+)@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.)|(([a-zA-Z0-9\-]+\.)+))([a-zA-Z]{2,4}|[0-9]{1,3})(\]?)$'
+        example: john_bob.joe@foo.edu
+        x-nullable: true
+      authorized_to_meet_mover:
+        type: boolean
+        x-nullable: true
+  IndexServiceMemberBackupContactsPayload:
     type: array
     items:
-      $ref: '#/definitions/ServiceMemberProfilePayload'
+      $ref: '#/definitions/ServiceMemberBackupContactPayload'
   CreateSignedCertificationPayload:
     type: object
     properties:
@@ -1983,16 +2177,3 @@ definitions:
       - city
       - state
       - zip
-  HumanTitle:
-    type: string
-    title: Title
-    enum:
-      - MS
-      - MX
-      - MR
-      - DR
-    x-display-value:
-      MS: Ms.
-      MX: Mx.
-      MR: Mr.
-      DR: Dr.


### PR DESCRIPTION
## Description

This PR adds swagger endpoints for Stations, ServiceMembers, and Service Member backup contacts.

Note:
* This PR assumes that we know that the logged in user is a Service Member, meaning that they've been asked somehow of what type of user they are (task tbd).
*  since we aren't storing actual ssn's but rather their hash, for the SM payload, we are returning a boolean of whether or not we have an ssn for a SM. The create and patch payloads take an unencrypted ssn.

## Verification Steps

* [ ] All tests pass.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/blob/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* [ ] There are no [aXe](https://www.deque.com/products/aXe/) warnings for UI.
* [ ] This works in IE.
* [ ] Any new third party client side dependencies (e.g., login.gov, google analytics, CDN libraries, etc.) have been communicated to @willowbl00.

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/156434597) for this change
