### PR TITLE
add better logging for upload errors

### DIFF
--- a/pkg/handlers/uploads.go
+++ b/pkg/handlers/uploads.go
@@ -54,9 +54,11 @@ func (h CreateUploadHandler) Handle(params uploadop.CreateUploadParams) middlewa
 	// Validate that the document and move exists in the db, and that they belong to user
 	exists, userOwns := models.ValidateDocumentOwnership(h.db, userID, moveID, documentID)
 	if !exists {
+		h.logger.Error("document or move does not exist", zap.String("document_id", params.DocumentID.String()), zap.String("move_id", params.MoveID.String()), zap.Error(err))
 		return uploadop.NewCreateUploadNotFound()
 	}
 	if !userOwns {
+		h.logger.Error("user does not own document or move", zap.String("document_id", params.DocumentID.String()), zap.String("move_id", params.MoveID.String()), zap.Error(err))
 		return uploadop.NewCreateUploadForbidden()
 	}
 


### PR DESCRIPTION
## Description

The uploader was failing without a clear log when the user didn't own the move or document the uploader was attached to. This adds better logging for that scenario and in the case that the move or document doesn't already exist.

## Reviewer Notes

Is this the right way to have multiple structured logs?

## Verification Steps

* [ ] All tests pass.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/blob/master/docs/backend.md#logging)

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/156481172) for this change