### PR TITLE
Carries forward existing ECS network config, fixes deploy

### DIFF
--- a/bin/ecs-deploy-app-container
+++ b/bin/ecs-deploy-app-container
@@ -33,8 +33,10 @@ check_arn() {
 update_service() {
     local arn="$1"
 
+    local network_config=$(aws ecs describe-services --services app --cluster "$cluster" --query 'services[0].networkConfiguration')
+
     echo "* Updating app service to use $arn"
-    aws ecs update-service --cluster "$cluster" --service app --task-definition "$arn" --query 'service.deployments' || return 1
+    aws ecs update-service --cluster "$cluster" --service app --task-definition "$arn" --query 'service.deployments' --network-configuration "$network_config" || return 1
     echo "* Waiting for service to stabilize (this takes a while)"
     time aws ecs wait services-stable --services app --cluster "$cluster"
     local exit_code=$?


### PR DESCRIPTION
AWS enforces that you set an ECS network configuration if you're using `awsvpc` network mode, which we are. Although we have ECS network configuration set in our ECS service via Terraform, it seems that AWS started enforcing that you also define the network config when calling `update-service`. This updates our deploy script to read our current network config and passes it into the call to `update-service`.

Verified this works by running the script locally and successfully deploying to staging.