### PR TITLE
Els wizard error handling [delivers #156435815]

### DIFF
--- a/src/scenes/Moves/MoveType.jsx
+++ b/src/scenes/Moves/MoveType.jsx
@@ -11,7 +11,7 @@ import truckGray from 'shared/icon/truck-gray.svg';
 import hhgPpmCombo from 'shared/icon/hhg-ppm-combo.svg';
 import './MoveType.css';
 
-const { mobileSize } = require('shared/constants');
+import { mobileSize } from 'shared/constants';
 
 class BigButtonGroup extends Component {
   constructor() {

--- a/src/scenes/Moves/MoveTypeWizard.jsx
+++ b/src/scenes/Moves/MoveTypeWizard.jsx
@@ -15,21 +15,29 @@ export class MoveTypeWizardPage extends Component {
     const { pendingMoveType, updateMove } = this.props;
     //todo: we should make sure this move matches the redux state
     const moveId = this.props.match.params.moveId;
-    if (pendingMoveType) {
-      //don't update a move unless the type is selected
-      updateMove(moveId, pendingMoveType);
-    }
+    updateMove(moveId, pendingMoveType);
   };
   render() {
-    const { pages, pageKey, pendingMoveType, currentMove } = this.props;
+    const {
+      pages,
+      pageKey,
+      pendingMoveType,
+      currentMove,
+      hasSubmitSuccess,
+      error,
+    } = this.props;
     const moveType =
       pendingMoveType || (currentMove && 'selected_move_type' in currentMove);
     return (
       <WizardPage
         handleSubmit={this.handleSubmit}
+        isAsync={true}
         pageList={pages}
         pageKey={pageKey}
-        pageIsValid={moveType !== false}
+        pageIsValid={Boolean(moveType)}
+        pageIsDirty={Boolean(pendingMoveType)}
+        hasSucceeded={hasSubmitSuccess}
+        error={error}
       >
         <MoveType />
       </WizardPage>

--- a/src/scenes/Moves/Ppm/PPMSizeWizard.jsx
+++ b/src/scenes/Moves/Ppm/PPMSizeWizard.jsx
@@ -20,14 +20,25 @@ export class PpmSizeWizardPage extends Component {
     }
   };
   render() {
-    const { pages, pageKey, pendingPpmSize, currentPpm } = this.props;
+    const {
+      pages,
+      pageKey,
+      pendingPpmSize,
+      currentPpm,
+      hasSubmitSuccess,
+      error,
+    } = this.props;
     const ppmSize = pendingPpmSize || (currentPpm && currentPpm.size);
     return (
       <WizardPage
         handleSubmit={this.handleSubmit}
+        isAsync={true}
         pageList={pages}
         pageKey={pageKey}
-        pageIsValid={ppmSize !== null}
+        pageIsValid={Boolean(ppmSize)}
+        pageIsDirty={Boolean(pendingPpmSize)}
+        hasSucceeded={hasSubmitSuccess}
+        error={error}
       >
         <PpmSize />
       </WizardPage>
@@ -38,6 +49,8 @@ PpmSizeWizardPage.propTypes = {
   createOrUpdatePpm: PropTypes.func.isRequired,
   pendingPpmSize: PropTypes.string,
   currentPpm: PropTypes.shape({ size: PropTypes.string, id: PropTypes.string }),
+  error: PropTypes.object,
+  hasSubmitSuccess: PropTypes.bool.isRequired,
 };
 
 function mapDispatchToProps(dispatch) {

--- a/src/scenes/Moves/Ppm/Weight.jsx
+++ b/src/scenes/Moves/Ppm/Weight.jsx
@@ -57,10 +57,7 @@ export class PpmWeight extends Component {
     const { pendingPpmWeight, createOrUpdatePpm } = this.props;
     //todo: we should make sure this move matches the redux state
     const moveId = this.props.match.params.moveId;
-    if (pendingPpmWeight) {
-      //don't update a ppm unless the weight has changed?
-      createOrUpdatePpm(moveId, { weight_estimate: pendingPpmWeight });
-    }
+    createOrUpdatePpm(moveId, { weight_estimate: pendingPpmWeight });
   };
   onWeightSelecting = value => {
     this.props.setPendingPpmWeight(value);
@@ -76,6 +73,7 @@ export class PpmWeight extends Component {
       incentive,
       pages,
       pageKey,
+      hasSubmitSuccess,
     } = this.props;
     const currentInfo = getWeightInfo(currentPpm);
     const setOrPendingWeight =
@@ -86,9 +84,12 @@ export class PpmWeight extends Component {
     return (
       <WizardPage
         handleSubmit={this.handleSubmit}
+        isAsync={true}
         pageList={pages}
         pageKey={pageKey}
-        pageIsValid={setOrPendingWeight != null}
+        pageIsValid={Boolean(setOrPendingWeight)}
+        pageIsDirty={Boolean(pendingPpmWeight)}
+        hasSucceeded={hasSubmitSuccess}
       >
         <h2>
           <img
@@ -148,6 +149,7 @@ PpmWeight.propTypes = {
     size: PropTypes.string,
     weight: PropTypes.number,
   }),
+  hasSubmitSuccess: PropTypes.bool.isRequired,
   moveDistance: PropTypes.number,
   setPendingPpmWeight: PropTypes.func.isRequired,
 };

--- a/src/scenes/Moves/Ppm/ducks.js
+++ b/src/scenes/Moves/Ppm/ducks.js
@@ -82,6 +82,10 @@ export function ppmReducer(state = initialState, action) {
       return Object.assign({}, state, {
         incentive: action.payload,
       });
+    case CREATE_OR_UPDATE_PPM.start:
+      return Object.assign({}, state, {
+        hasSubmitSuccess: false,
+      });
     case CREATE_OR_UPDATE_PPM.success:
       return Object.assign({}, state, {
         currentPpm: action.payload,
@@ -95,6 +99,10 @@ export function ppmReducer(state = initialState, action) {
         hasSubmitSuccess: false,
         hasSubmitError: true,
         error: action.error,
+      });
+    case GET_PPM.start:
+      return Object.assign({}, state, {
+        hasSubmitSuccess: false,
       });
     case GET_PPM.success:
       return Object.assign({}, state, {

--- a/src/scenes/Moves/Ppm/ducks.js
+++ b/src/scenes/Moves/Ppm/ducks.js
@@ -86,19 +86,19 @@ export function ppmReducer(state = initialState, action) {
       return Object.assign({}, state, {
         currentPpm: action.payload,
         pendingPpmSize: null,
+        pendingPpmWeight: null,
         hasSubmitSuccess: true,
         hasSubmitError: false,
       });
     case CREATE_OR_UPDATE_PPM.failure:
       return Object.assign({}, state, {
-        currentPpm: null,
         hasSubmitSuccess: false,
         hasSubmitError: true,
         error: action.error,
       });
     case GET_PPM.success:
       return Object.assign({}, state, {
-        currentPpm: action.payload,
+        currentPpm: action.payload.length > 0 ? action.payload[0] : null,
         hasSubmitSuccess: true,
         hasSubmitError: false,
       });

--- a/src/scenes/Moves/Ppm/ducks.js
+++ b/src/scenes/Moves/Ppm/ducks.js
@@ -84,7 +84,7 @@ export function ppmReducer(state = initialState, action) {
       });
     case CREATE_OR_UPDATE_PPM.success:
       return Object.assign({}, state, {
-        currentPpm: action.item,
+        currentPpm: action.payload,
         pendingPpmSize: null,
         hasSubmitSuccess: true,
         hasSubmitError: false,
@@ -98,7 +98,7 @@ export function ppmReducer(state = initialState, action) {
       });
     case GET_PPM.success:
       return Object.assign({}, state, {
-        currentPpm: action.item,
+        currentPpm: action.payload,
         hasSubmitSuccess: true,
         hasSubmitError: false,
       });

--- a/src/scenes/Moves/Ppm/ducks.test.js
+++ b/src/scenes/Moves/Ppm/ducks.test.js
@@ -1,40 +1,73 @@
-import {
-  CREATE_OR_UPDATE_PPM_SUCCESS,
-  CREATE_OR_UPDATE_PPM_FAILURE,
-  ppmReducer,
-} from './ducks';
+import { CREATE_OR_UPDATE_PPM, GET_PPM, ppmReducer } from './ducks';
 
 describe('Ppm Reducer', () => {
-  it('Should handle CREATE_OR_UPDATE_PPM_SUCCESS', () => {
-    const initialState = { pendingValue: '' };
+  describe('CREATE_OR_UPDATE_PPM', () => {
+    it('Should handle CREATE_OR_UPDATE_PPM_SUCCESS', () => {
+      const initialState = { pendingValue: '' };
 
-    const newState = ppmReducer(initialState, {
-      type: CREATE_OR_UPDATE_PPM_SUCCESS,
-      item: 'Successful ppm!',
+      const newState = ppmReducer(initialState, {
+        type: CREATE_OR_UPDATE_PPM.success,
+        item: 'Successful ppm!',
+      });
+
+      expect(newState).toEqual({
+        pendingValue: '',
+        pendingPpmSize: null,
+        currentPpm: 'Successful ppm!',
+        hasSubmitError: false,
+        hasSubmitSuccess: true,
+      });
     });
 
-    expect(newState).toEqual({
-      pendingValue: '',
-      pendingPpmSize: null,
-      currentPpm: 'Successful ppm!',
-      hasSubmitError: false,
-      hasSubmitSuccess: true,
+    it('Should handle CREATE_OR_UPDATE_PPM_FAILURE', () => {
+      const initialState = { pendingValue: '' };
+
+      const newState = ppmReducer(initialState, {
+        type: CREATE_OR_UPDATE_PPM.failure,
+        error: 'No bueno.',
+      });
+
+      expect(newState).toEqual({
+        pendingValue: '',
+        currentPpm: null,
+        hasSubmitError: true,
+        hasSubmitSuccess: false,
+        error: 'No bueno.',
+      });
     });
   });
+  describe('GET_PPM', () => {
+    it('Should handle GET_PPM_SUCCESS', () => {
+      const initialState = { pendingValue: '' };
 
-  it('Should handle CREATE_OR_UPDATE_PPM_FAILURE', () => {
-    const initialState = { pendingValue: '' };
+      const newState = ppmReducer(initialState, {
+        type: GET_PPM.success,
+        item: 'Successful ppm!',
+      });
 
-    const newState = ppmReducer(initialState, {
-      type: CREATE_OR_UPDATE_PPM_FAILURE,
-      error: 'No bueno.',
+      expect(newState).toEqual({
+        pendingValue: '',
+        currentPpm: 'Successful ppm!',
+        hasSubmitError: false,
+        hasSubmitSuccess: true,
+      });
     });
 
-    expect(newState).toEqual({
-      pendingValue: '',
-      currentPpm: null,
-      hasSubmitError: true,
-      hasSubmitSuccess: false,
+    it('Should handle GET_PPM_FAILURE', () => {
+      const initialState = { pendingValue: '' };
+
+      const newState = ppmReducer(initialState, {
+        type: GET_PPM.failure,
+        error: 'No bueno.',
+      });
+
+      expect(newState).toEqual({
+        pendingValue: '',
+        currentPpm: null,
+        hasSubmitError: true,
+        hasSubmitSuccess: false,
+        error: 'No bueno.',
+      });
     });
   });
 });

--- a/src/scenes/Moves/Ppm/ducks.test.js
+++ b/src/scenes/Moves/Ppm/ducks.test.js
@@ -1,26 +1,28 @@
 import { CREATE_OR_UPDATE_PPM, GET_PPM, ppmReducer } from './ducks';
 
 describe('Ppm Reducer', () => {
+  const samplePpm = { id: 'UUID', name: 'foo' };
   describe('CREATE_OR_UPDATE_PPM', () => {
     it('Should handle CREATE_OR_UPDATE_PPM_SUCCESS', () => {
       const initialState = { pendingValue: '' };
 
       const newState = ppmReducer(initialState, {
         type: CREATE_OR_UPDATE_PPM.success,
-        item: 'Successful ppm!',
+        payload: samplePpm,
       });
 
       expect(newState).toEqual({
         pendingValue: '',
         pendingPpmSize: null,
-        currentPpm: 'Successful ppm!',
+        pendingPpmWeight: null,
+        currentPpm: samplePpm,
         hasSubmitError: false,
         hasSubmitSuccess: true,
       });
     });
 
     it('Should handle CREATE_OR_UPDATE_PPM_FAILURE', () => {
-      const initialState = { pendingValue: '' };
+      const initialState = { pendingValue: '', currentPpm: { id: 'bad' } };
 
       const newState = ppmReducer(initialState, {
         type: CREATE_OR_UPDATE_PPM.failure,
@@ -29,7 +31,7 @@ describe('Ppm Reducer', () => {
 
       expect(newState).toEqual({
         pendingValue: '',
-        currentPpm: null,
+        currentPpm: { id: 'bad' },
         hasSubmitError: true,
         hasSubmitSuccess: false,
         error: 'No bueno.',
@@ -39,15 +41,14 @@ describe('Ppm Reducer', () => {
   describe('GET_PPM', () => {
     it('Should handle GET_PPM_SUCCESS', () => {
       const initialState = { pendingValue: '' };
-
       const newState = ppmReducer(initialState, {
         type: GET_PPM.success,
-        item: 'Successful ppm!',
+        payload: [samplePpm],
       });
 
       expect(newState).toEqual({
         pendingValue: '',
-        currentPpm: 'Successful ppm!',
+        currentPpm: samplePpm,
         hasSubmitError: false,
         hasSubmitSuccess: true,
       });

--- a/src/scenes/Moves/ducks.js
+++ b/src/scenes/Moves/ducks.js
@@ -85,6 +85,7 @@ const initialState = {
   pendingMoveType: null,
   hasSubmitError: false,
   hasSubmitSuccess: false,
+  error: null,
 };
 export function moveReducer(state = initialState, action) {
   switch (action.type) {
@@ -98,18 +99,28 @@ export function moveReducer(state = initialState, action) {
         pendingMoveType: null,
         hasSubmitSuccess: true,
         hasSubmitError: false,
+        error: null,
       });
     case CREATE_OR_UPDATE_MOVE_FAILURE:
       return Object.assign({}, state, {
         currentMove: {},
         hasSubmitSuccess: false,
         hasSubmitError: true,
+        error: action.error,
       });
     case GET_MOVE_SUCCESS:
       return Object.assign({}, state, {
         currentMove: action.item,
         hasSubmitSuccess: true,
         hasSubmitError: false,
+        error: null,
+      });
+    case GET_MOVE_FAILURE:
+      return Object.assign({}, state, {
+        currentMove: {},
+        hasSubmitSuccess: false,
+        hasSubmitError: true,
+        error: action.error,
       });
     default:
       return state;

--- a/src/scenes/Moves/ducks.js
+++ b/src/scenes/Moves/ducks.js
@@ -93,6 +93,10 @@ export function moveReducer(state = initialState, action) {
       return Object.assign({}, state, {
         pendingMoveType: action.payload,
       });
+    case UPDATE_MOVE:
+      return Object.assign({}, state, {
+        hasSubmitSuccess: false,
+      });
     case CREATE_OR_UPDATE_MOVE_SUCCESS:
       return Object.assign({}, state, {
         currentMove: action.item,

--- a/src/shared/User/ducks.js
+++ b/src/shared/User/ducks.js
@@ -16,6 +16,8 @@ function getUserInfo() {
   return {
     jwt: cookie,
     email: jwt.email,
+    userId: jwt.user_id,
+    expires: Date(jwt.exp),
     isLoggedIn: true,
   };
 }

--- a/src/shared/WizardPage/index.css
+++ b/src/shared/WizardPage/index.css
@@ -1,3 +1,6 @@
+.error-message {
+  margin-bottom: 1em;
+}
 .center {
   text-align: center;
 }

--- a/src/shared/WizardPage/index.jsx
+++ b/src/shared/WizardPage/index.jsx
@@ -74,11 +74,9 @@ export class WizardPage extends Component {
       pageIsValid,
       pageIsDirty,
     } = this.props;
-    const canMoveForward = !error && pageIsValid;
+    const canMoveForward = pageIsValid;
     const canMoveBackward =
-      !error &&
-      (pageIsValid || !pageIsDirty) &&
-      !isFirstPage(pageList, pageKey);
+      (pageIsValid || !pageIsDirty) && !isFirstPage(pageList, pageKey);
     return (
       <div className="usa-grid">
         {error && (

--- a/src/shared/WizardPage/index.jsx
+++ b/src/shared/WizardPage/index.jsx
@@ -82,7 +82,7 @@ export class WizardPage extends Component {
     return (
       <div className="usa-grid">
         {error && (
-          <div className="usa-width-one-whole">
+          <div className="usa-width-one-whole error-message">
             <Alert type="error" heading="An error occurred">
               {error.message}
             </Alert>

--- a/src/shared/WizardPage/index.jsx
+++ b/src/shared/WizardPage/index.jsx
@@ -24,6 +24,7 @@ export class WizardPage extends Component {
   }
   componentDidUpdate() {
     if (this.props.hasSucceeded) this.onSubmitSuccessful();
+    if (this.props.error) window.scrollTo(0, 0);
   }
   componentDidMount() {
     window.scrollTo(0, 0);

--- a/src/shared/WizardPage/index.test.js
+++ b/src/shared/WizardPage/index.test.js
@@ -113,20 +113,20 @@ describe('given a WizardPage', () => {
         it('it renders button for prev, save, next', () => {
           expect(buttons.length).toBe(3);
         });
-        it('the previous button is first and is disabled', () => {
+        it('the previous button is first and is enabled', () => {
           const prevButton = buttons.first();
           expect(prevButton.text()).toBe('Prev');
-          expect(prevButton.prop('disabled')).toBe(true);
+          expect(prevButton.prop('disabled')).toBe(false);
         });
         it('the save for later button is second and is disabled', () => {
           const prevButton = buttons.at(1);
           expect(prevButton.text()).toBe('Save for later');
           expect(prevButton.prop('disabled')).toBe(true);
         });
-        it('the next button is last and is disabled', () => {
+        it('the next button is last and is enabled', () => {
           const nextButton = buttons.last();
           expect(nextButton.text()).toBe('Next');
-          expect(nextButton.prop('disabled')).toBe(true);
+          expect(nextButton.prop('disabled')).toBe(false);
         });
       });
     });
@@ -485,20 +485,20 @@ describe('given a WizardPage', () => {
         it('it renders button for prev, save, next', () => {
           expect(buttons.length).toBe(3);
         });
-        it('the previous button is first and is disabled', () => {
+        it('the previous button is first and is enabled', () => {
           const prevButton = buttons.first();
           expect(prevButton.text()).toBe('Prev');
-          expect(prevButton.prop('disabled')).toBe(true);
+          expect(prevButton.prop('disabled')).toBe(false);
         });
         it('the save for later button is second and is disabled', () => {
           const prevButton = buttons.at(1);
           expect(prevButton.text()).toBe('Save for later');
           expect(prevButton.prop('disabled')).toBe(true);
         });
-        it('the next button is last and is disabled', () => {
+        it('the next button is last and is enabled', () => {
           const nextButton = buttons.last();
           expect(nextButton.text()).toBe('Next');
-          expect(nextButton.prop('disabled')).toBe(true);
+          expect(nextButton.prop('disabled')).toBe(false);
         });
       });
     });

--- a/src/shared/WizardPage/index.test.js
+++ b/src/shared/WizardPage/index.test.js
@@ -6,12 +6,64 @@ describe('given a WizardPage', () => {
   const pageList = ['1', '2', '3'];
   const submit = jest.fn();
   const mockPush = jest.fn();
-  describe('when there is a pageIsValid prop set', () => {
-    describe('when pageIsValid is false', () => {
-      describe('when on the first page', () => {
+  describe('when handler is not async', () => {
+    describe('when there is a pageIsValid prop set', () => {
+      describe('when pageIsValid is false', () => {
+        describe('when on the first page', () => {
+          beforeEach(() => {
+            history = [];
+            const continueToNextPage = false;
+
+            wrapper = shallow(
+              <WizardPage
+                handleSubmit={submit}
+                pageList={pageList}
+                pageKey="1"
+                history={history}
+                pageIsValid={continueToNextPage}
+                match={{}}
+              >
+                <div>This is page 1</div>
+              </WizardPage>,
+            );
+            buttons = wrapper.find('button');
+          });
+          it('the next button is last and is disabled', () => {
+            const nextButton = buttons.last();
+            expect(nextButton.text()).toBe('Next');
+            expect(nextButton.prop('disabled')).toBeTruthy();
+          });
+        });
+        describe('when on the last page', () => {
+          beforeEach(() => {
+            history = [];
+            const pageIsValid = false;
+
+            wrapper = shallow(
+              <WizardPage
+                handleSubmit={submit}
+                pageList={pageList}
+                pageKey="3"
+                history={history}
+                pageIsValid={pageIsValid}
+                match={{}}
+              >
+                <div>This is page 1</div>
+              </WizardPage>,
+            );
+            buttons = wrapper.find('button');
+          });
+          it('the complete button is last and is disabled', () => {
+            const nextButton = buttons.last();
+            expect(nextButton.text()).toBe('Complete');
+            expect(nextButton.prop('disabled')).toBeTruthy();
+          });
+        });
+      });
+      describe('when pageIsValid is true', () => {
         beforeEach(() => {
           history = [];
-          const continueToNextPage = false;
+          const continueToNextPage = true;
 
           wrapper = shallow(
             <WizardPage
@@ -20,241 +72,686 @@ describe('given a WizardPage', () => {
               pageKey="1"
               history={history}
               pageIsValid={continueToNextPage}
-              match={{}}
             >
               <div>This is page 1</div>
             </WizardPage>,
           );
           buttons = wrapper.find('button');
         });
-        it('the next button is last and is disabled', () => {
+        it('the next button is last and is enabled', () => {
           const nextButton = buttons.last();
           expect(nextButton.text()).toBe('Next');
-          expect(nextButton.prop('disabled')).toBeTruthy();
+          expect(nextButton.prop('disabled')).toBeFalsy();
         });
       });
-      describe('when on the last page', () => {
+    });
+    describe('when there is an error', () => {
+      describe('when on the middle page', () => {
         beforeEach(() => {
-          history = [];
-          const pageIsValid = false;
-
+          mockPush.mockClear();
           wrapper = shallow(
             <WizardPage
               handleSubmit={submit}
               pageList={pageList}
-              pageKey="3"
-              history={history}
-              pageIsValid={pageIsValid}
+              pageKey="2"
+              push={mockPush}
               match={{}}
+              isAsync={true}
+              hasSucceeded={false}
+              error={{ message: 'Something bad happened' }}
             >
-              <div>This is page 1</div>
+              <div>This is page 2</div>
             </WizardPage>,
           );
           buttons = wrapper.find('button');
         });
-        it('the complete button is last and is disabled', () => {
+        it('it shows an error alert before its child', () => {
+          const childContainer = wrapper.find('div.usa-width-one-whole');
+          expect(childContainer.length).toBe(3);
+          expect(childContainer.first().text()).toBe('<Alert />');
+        });
+        it('it renders button for prev, save, next', () => {
+          expect(buttons.length).toBe(3);
+        });
+        it('the previous button is first and is disabled', () => {
+          const prevButton = buttons.first();
+          expect(prevButton.text()).toBe('Prev');
+          expect(prevButton.prop('disabled')).toBe(true);
+        });
+        it('the save for later button is second and is disabled', () => {
+          const prevButton = buttons.at(1);
+          expect(prevButton.text()).toBe('Save for later');
+          expect(prevButton.prop('disabled')).toBe(true);
+        });
+        it('the next button is last and is disabled', () => {
           const nextButton = buttons.last();
-          expect(nextButton.text()).toBe('Complete');
-          expect(nextButton.prop('disabled')).toBeTruthy();
+          expect(nextButton.text()).toBe('Next');
+          expect(nextButton.prop('disabled')).toBe(true);
         });
       });
     });
-    describe('when pageIsValid is true', () => {
+    describe('when page is not dirty', () => {
       beforeEach(() => {
-        history = [];
-        const continueToNextPage = true;
-
+        mockPush.mockClear();
         wrapper = shallow(
           <WizardPage
             handleSubmit={submit}
             pageList={pageList}
-            pageKey="1"
-            history={history}
-            pageIsValid={continueToNextPage}
+            pageKey="2"
+            push={mockPush}
+            match={{}}
+            isAsync={true}
+            hasSucceeded={false}
+            pageIsDirty={false}
           >
-            <div>This is page 1</div>
+            <div>This is page 2</div>
           </WizardPage>,
         );
         buttons = wrapper.find('button');
+      });
+      it('the previous button is first and is enabled', () => {
+        const prevButton = buttons.first();
+        expect(prevButton.text()).toBe('Prev');
+        expect(prevButton.prop('disabled')).toBe(false);
+      });
+      describe('when the prev button is clicked', () => {
+        beforeEach(() => {
+          const prevButton = buttons.first();
+          prevButton.simulate('click');
+        });
+        it('push gets the prev page', () => {
+          expect(mockPush.mock.calls.length).toBe(1);
+          expect(mockPush.mock.calls[0][0]).toBe('1');
+        });
+        it('submit is not called', () => {
+          expect(submit.mock.calls.length).toBe(0);
+        });
+      });
+      it('the save for later button is second and is disabled', () => {
+        const prevButton = buttons.at(1);
+        expect(prevButton.text()).toBe('Save for later');
+        expect(prevButton.prop('disabled')).toBe(true);
       });
       it('the next button is last and is enabled', () => {
         const nextButton = buttons.last();
         expect(nextButton.text()).toBe('Next');
         expect(nextButton.prop('disabled')).toBeFalsy();
       });
-    });
-  });
-  describe('when on the first page', () => {
-    beforeEach(() => {
-      wrapper = shallow(
-        <WizardPage
-          handleSubmit={submit}
-          pageList={pageList}
-          pageKey="1"
-          push={mockPush}
-          match={{}}
-        >
-          <div>This is page 1</div>
-        </WizardPage>,
-      );
-      buttons = wrapper.find('button');
-    });
-    it('it starts on the first page', () => {
-      const childContainer = wrapper.find('div.usa-width-one-whole');
-      expect(childContainer.length).toBe(2);
-      expect(childContainer.first().text()).toBe('This is page 1');
-    });
-    it('it renders button for prev, save, next', () => {
-      expect(buttons.length).toBe(3);
-    });
-    it('the previous button is first and is disabled', () => {
-      const prevButton = buttons.first();
-      expect(prevButton.text()).toBe('Prev');
-      expect(prevButton.prop('disabled')).toBe(true);
-    });
-    it('the save for later button is second and is disabled', () => {
-      const prevButton = buttons.at(1);
-      expect(prevButton.text()).toBe('Save for later');
-      expect(prevButton.prop('disabled')).toBe(true);
-    });
-    it('the next button is last and is enabled', () => {
-      const nextButton = buttons.last();
-      expect(nextButton.text()).toBe('Next');
-      expect(nextButton.prop('disabled')).toBeFalsy();
-    });
-
-    describe('when the next button is clicked', () => {
-      beforeEach(() => {
-        const nextButton = buttons.last();
-        nextButton.simulate('click');
-      });
-      it('push gets the next page', () => {
-        expect(mockPush.mock.calls.length).toBe(1);
-        expect(mockPush.mock.calls[0][0]).toBe('2');
+      describe('when the next button is clicked', () => {
+        beforeEach(() => {
+          const nextButton = buttons.last();
+          nextButton.simulate('click');
+        });
+        it('push gets the next page', () => {
+          expect(mockPush.mock.calls.length).toBe(1);
+          expect(mockPush.mock.calls[0][0]).toBe('3');
+        });
+        it('submit is not called', () => {
+          expect(submit.mock.calls.length).toBe(0);
+        });
       });
     });
-  });
-
-  describe('when on the middle page', () => {
-    beforeEach(() => {
-      mockPush.mockClear();
-      wrapper = shallow(
-        <WizardPage
-          handleSubmit={submit}
-          pageList={pageList}
-          pageKey="2"
-          push={mockPush}
-          match={{}}
-        >
-          <div>This is page 2</div>
-        </WizardPage>,
-      );
-      buttons = wrapper.find('button');
-    });
-    it('it shows its child', () => {
-      const childContainer = wrapper.find('div.usa-width-one-whole');
-      expect(childContainer.length).toBe(2);
-      expect(childContainer.first().text()).toBe('This is page 2');
-    });
-    it('it renders button for prev, save, next', () => {
-      expect(buttons.length).toBe(3);
-    });
-    it('the previous button is first and is enabled', () => {
-      const prevButton = buttons.first();
-      expect(prevButton.text()).toBe('Prev');
-      expect(prevButton.prop('disabled')).toBe(false);
-    });
-    describe('when the prev button is clicked', () => {
+    describe('when on the first page', () => {
       beforeEach(() => {
+        wrapper = shallow(
+          <WizardPage
+            handleSubmit={submit}
+            pageList={pageList}
+            pageKey="1"
+            push={mockPush}
+            match={{}}
+          >
+            <div>This is page 1</div>
+          </WizardPage>,
+        );
+        buttons = wrapper.find('button');
+      });
+      afterEach(() => mockPush.mockClear());
+      it('it starts on the first page', () => {
+        const childContainer = wrapper.find('div.usa-width-one-whole');
+        expect(childContainer.length).toBe(2);
+        expect(childContainer.first().text()).toBe('This is page 1');
+      });
+      it('it renders button for prev, save, next', () => {
+        expect(buttons.length).toBe(3);
+      });
+      it('the previous button is first and is disabled', () => {
         const prevButton = buttons.first();
-        prevButton.simulate('click');
+        expect(prevButton.text()).toBe('Prev');
+        expect(prevButton.prop('disabled')).toBe(true);
       });
-      it('push gets the prev page', () => {
-        expect(mockPush.mock.calls.length).toBe(1);
-        expect(mockPush.mock.calls[0][0]).toBe('1');
+      it('the save for later button is second and is disabled', () => {
+        const prevButton = buttons.at(1);
+        expect(prevButton.text()).toBe('Save for later');
+        expect(prevButton.prop('disabled')).toBe(true);
       });
-    });
-    it('the save for later button is second and is disabled', () => {
-      const prevButton = buttons.at(1);
-      expect(prevButton.text()).toBe('Save for later');
-      expect(prevButton.prop('disabled')).toBe(true);
-    });
-    it('the next button is last and is enabled', () => {
-      const nextButton = buttons.last();
-      expect(nextButton.text()).toBe('Next');
-      expect(nextButton.prop('disabled')).toBeFalsy();
-    });
-    describe('when the next button is clicked', () => {
-      beforeEach(() => {
+      it('the next button is last and is enabled', () => {
         const nextButton = buttons.last();
-        nextButton.simulate('click');
+        expect(nextButton.text()).toBe('Next');
+        expect(nextButton.prop('disabled')).toBeFalsy();
       });
-      it('push gets the next page', () => {
-        expect(mockPush.mock.calls.length).toBe(1);
-        expect(mockPush.mock.calls[0][0]).toBe('3');
+
+      describe('when the next button is clicked', () => {
+        beforeEach(() => {
+          const nextButton = buttons.last();
+          nextButton.simulate('click');
+        });
+        it('push gets the next page', () => {
+          expect(mockPush.mock.calls.length).toBe(1);
+          expect(mockPush.mock.calls[0][0]).toBe('2');
+        });
+      });
+    });
+
+    describe('when on the middle page', () => {
+      beforeEach(() => {
+        mockPush.mockClear();
+        wrapper = shallow(
+          <WizardPage
+            handleSubmit={submit}
+            pageList={pageList}
+            pageKey="2"
+            push={mockPush}
+            match={{}}
+          >
+            <div>This is page 2</div>
+          </WizardPage>,
+        );
+        buttons = wrapper.find('button');
+      });
+      it('it shows its child', () => {
+        const childContainer = wrapper.find('div.usa-width-one-whole');
+        expect(childContainer.length).toBe(2);
+        expect(childContainer.first().text()).toBe('This is page 2');
+      });
+      it('it renders button for prev, save, next', () => {
+        expect(buttons.length).toBe(3);
+      });
+      it('the previous button is first and is enabled', () => {
+        const prevButton = buttons.first();
+        expect(prevButton.text()).toBe('Prev');
+        expect(prevButton.prop('disabled')).toBe(false);
+      });
+      describe('when the prev button is clicked', () => {
+        beforeEach(() => {
+          const prevButton = buttons.first();
+          prevButton.simulate('click');
+        });
+        it('push gets the prev page', () => {
+          expect(mockPush.mock.calls.length).toBe(1);
+          expect(mockPush.mock.calls[0][0]).toBe('1');
+        });
+      });
+      it('the save for later button is second and is disabled', () => {
+        const prevButton = buttons.at(1);
+        expect(prevButton.text()).toBe('Save for later');
+        expect(prevButton.prop('disabled')).toBe(true);
+      });
+      it('the next button is last and is enabled', () => {
+        const nextButton = buttons.last();
+        expect(nextButton.text()).toBe('Next');
+        expect(nextButton.prop('disabled')).toBeFalsy();
+      });
+      describe('when the next button is clicked', () => {
+        beforeEach(() => {
+          const nextButton = buttons.last();
+          nextButton.simulate('click');
+        });
+        it('push gets the next page', () => {
+          expect(mockPush.mock.calls.length).toBe(1);
+          expect(mockPush.mock.calls[0][0]).toBe('3');
+        });
+      });
+    });
+    describe('when on the last page', () => {
+      beforeEach(() => {
+        mockPush.mockClear();
+        wrapper = shallow(
+          <WizardPage
+            handleSubmit={submit}
+            pageList={pageList}
+            pageKey="3"
+            push={mockPush}
+            match={{}}
+          >
+            <div>This is page 3</div>
+          </WizardPage>,
+        );
+        buttons = wrapper.find('button');
+      });
+      afterEach(() => {
+        submit.mockClear();
+      });
+
+      it('it shows its child', () => {
+        const childContainer = wrapper.find('div.usa-width-one-whole');
+        expect(childContainer.length).toBe(2);
+        expect(childContainer.first().text()).toBe('This is page 3');
+      });
+      it('it renders button for prev, save, next', () => {
+        expect(buttons.length).toBe(3);
+      });
+      it('the previous button is first and is enabled', () => {
+        const prevButton = buttons.first();
+        expect(prevButton.text()).toBe('Prev');
+        expect(prevButton.prop('disabled')).toBe(false);
+      });
+      describe('when the prev button is clicked', () => {
+        beforeEach(() => {
+          const prevButton = buttons.first();
+          prevButton.simulate('click');
+        });
+        it('push gets the prev page', () => {
+          expect(mockPush.mock.calls.length).toBe(1);
+          expect(mockPush.mock.calls[0][0]).toBe('2');
+        });
+      });
+      it('the save for later button is second and is disabled', () => {
+        const saveButton = buttons.at(1);
+        expect(saveButton.text()).toBe('Save for later');
+        expect(saveButton.prop('disabled')).toBe(true);
+      });
+      it('the Complete button is last and is enabled', () => {
+        const nextButton = buttons.last();
+        expect(nextButton.text()).toBe('Complete');
+        expect(nextButton.prop('disabled')).toBeFalsy();
+      });
+      describe('when the complete button is clicked', () => {
+        beforeEach(() => {
+          const nextButton = buttons.last();
+          nextButton.simulate('click');
+        });
+        it('submit is called', () => {
+          expect(submit.mock.calls.length).toBe(1);
+        });
       });
     });
   });
-  describe('when on the last page', () => {
-    beforeEach(() => {
-      mockPush.mockClear();
-      wrapper = shallow(
-        <WizardPage
-          handleSubmit={submit}
-          pageList={pageList}
-          pageKey="3"
-          push={mockPush}
-          match={{}}
-        >
-          <div>This is page 3</div>
-        </WizardPage>,
-      );
-      buttons = wrapper.find('button');
+  describe('when handler is async', () => {
+    describe('when there is a pageIsValid prop set', () => {
+      describe('when pageIsValid is false', () => {
+        describe('when on the first page', () => {
+          beforeEach(() => {
+            history = [];
+            const continueToNextPage = false;
+
+            wrapper = shallow(
+              <WizardPage
+                handleSubmit={submit}
+                pageList={pageList}
+                pageKey="1"
+                history={history}
+                pageIsValid={continueToNextPage}
+                match={{}}
+                isAsync={true}
+                hasSucceeded={false}
+              >
+                <div>This is page 1</div>
+              </WizardPage>,
+            );
+            buttons = wrapper.find('button');
+          });
+          it('the next button is last and is disabled', () => {
+            const nextButton = buttons.last();
+            expect(nextButton.text()).toBe('Next');
+            expect(nextButton.prop('disabled')).toBeTruthy();
+          });
+        });
+        describe('when on the last page', () => {
+          beforeEach(() => {
+            history = [];
+            const pageIsValid = false;
+
+            wrapper = shallow(
+              <WizardPage
+                handleSubmit={submit}
+                pageList={pageList}
+                pageKey="3"
+                history={history}
+                pageIsValid={pageIsValid}
+                match={{}}
+                isAsync={true}
+                hasSucceeded={false}
+              >
+                <div>This is page 1</div>
+              </WizardPage>,
+            );
+            buttons = wrapper.find('button');
+          });
+          it('the previous button is first and is disabled', () => {
+            const prevButton = buttons.first();
+            expect(prevButton.text()).toBe('Prev');
+            expect(prevButton.prop('disabled')).toBe(true);
+          });
+          it('the complete button is last and is disabled', () => {
+            const nextButton = buttons.last();
+            expect(nextButton.text()).toBe('Complete');
+            expect(nextButton.prop('disabled')).toBeTruthy();
+          });
+        });
+      });
+      describe('when pageIsValid is true', () => {
+        beforeEach(() => {
+          history = [];
+          const continueToNextPage = true;
+
+          wrapper = shallow(
+            <WizardPage
+              handleSubmit={submit}
+              pageList={pageList}
+              pageKey="1"
+              history={history}
+              pageIsValid={continueToNextPage}
+              isAsync={true}
+              hasSucceeded={false}
+            >
+              <div>This is page 1</div>
+            </WizardPage>,
+          );
+          buttons = wrapper.find('button');
+        });
+        it('the next button is last and is enabled', () => {
+          const nextButton = buttons.last();
+          expect(nextButton.text()).toBe('Next');
+          expect(nextButton.prop('disabled')).toBeFalsy();
+        });
+      });
     });
-    afterEach(() => {
-      submit.mockClear();
+    describe('when there is an error', () => {
+      describe('when on the middle page', () => {
+        beforeEach(() => {
+          mockPush.mockClear();
+          wrapper = shallow(
+            <WizardPage
+              handleSubmit={submit}
+              pageList={pageList}
+              pageKey="2"
+              push={mockPush}
+              match={{}}
+              isAsync={true}
+              hasSucceeded={false}
+              error={{ message: 'Something bad happened' }}
+            >
+              <div>This is page 2</div>
+            </WizardPage>,
+          );
+          buttons = wrapper.find('button');
+        });
+        it('it shows an error alert before its child', () => {
+          const childContainer = wrapper.find('div.usa-width-one-whole');
+          expect(childContainer.length).toBe(3);
+          expect(childContainer.first().text()).toBe('<Alert />');
+        });
+        it('it renders button for prev, save, next', () => {
+          expect(buttons.length).toBe(3);
+        });
+        it('the previous button is first and is disabled', () => {
+          const prevButton = buttons.first();
+          expect(prevButton.text()).toBe('Prev');
+          expect(prevButton.prop('disabled')).toBe(true);
+        });
+        it('the save for later button is second and is disabled', () => {
+          const prevButton = buttons.at(1);
+          expect(prevButton.text()).toBe('Save for later');
+          expect(prevButton.prop('disabled')).toBe(true);
+        });
+        it('the next button is last and is disabled', () => {
+          const nextButton = buttons.last();
+          expect(nextButton.text()).toBe('Next');
+          expect(nextButton.prop('disabled')).toBe(true);
+        });
+      });
+    });
+    describe('when page is not dirty', () => {
+      beforeEach(() => {
+        mockPush.mockClear();
+        wrapper = shallow(
+          <WizardPage
+            handleSubmit={submit}
+            pageList={pageList}
+            pageKey="2"
+            push={mockPush}
+            match={{}}
+            isAsync={true}
+            hasSucceeded={false}
+            pageIsDirty={false}
+          >
+            <div>This is page 2</div>
+          </WizardPage>,
+        );
+        buttons = wrapper.find('button');
+      });
+      afterEach(() => {
+        submit.mockClear();
+      });
+      it('the previous button is first and is enabled', () => {
+        const prevButton = buttons.first();
+        expect(prevButton.text()).toBe('Prev');
+        expect(prevButton.prop('disabled')).toBe(false);
+      });
+      describe('when the prev button is clicked', () => {
+        beforeEach(() => {
+          const prevButton = buttons.first();
+          prevButton.simulate('click');
+        });
+        it('submit is not called', () => {
+          expect(submit.mock.calls.length).toBe(0);
+        });
+      });
+      it('the save for later button is second and is disabled', () => {
+        const prevButton = buttons.at(1);
+        expect(prevButton.text()).toBe('Save for later');
+        expect(prevButton.prop('disabled')).toBe(true);
+      });
+      it('the next button is last and is enabled', () => {
+        const nextButton = buttons.last();
+        expect(nextButton.text()).toBe('Next');
+        expect(nextButton.prop('disabled')).toBeFalsy();
+      });
+      describe('when the next button is clicked', () => {
+        beforeEach(() => {
+          const nextButton = buttons.last();
+          nextButton.simulate('click');
+        });
+        it('submit is not called', () => {
+          expect(submit.mock.calls.length).toBe(0);
+        });
+      });
     });
 
-    it('it shows its child', () => {
-      const childContainer = wrapper.find('div.usa-width-one-whole');
-      expect(childContainer.length).toBe(2);
-      expect(childContainer.first().text()).toBe('This is page 3');
-    });
-    it('it renders button for prev, save, next', () => {
-      expect(buttons.length).toBe(3);
-    });
-    it('the previous button is first and is enabled', () => {
-      const prevButton = buttons.first();
-      expect(prevButton.text()).toBe('Prev');
-      expect(prevButton.prop('disabled')).toBe(false);
-    });
-    describe('when the prev button is clicked', () => {
+    describe('when on the first page', () => {
       beforeEach(() => {
+        wrapper = shallow(
+          <WizardPage
+            handleSubmit={submit}
+            pageList={pageList}
+            pageKey="1"
+            push={mockPush}
+            match={{}}
+            isAsync={true}
+            hasSucceeded={false}
+          >
+            <div>This is page 1</div>
+          </WizardPage>,
+        );
+        buttons = wrapper.find('button');
+      });
+      afterEach(() => {
+        submit.mockClear();
+      });
+      it('it starts on the first page', () => {
+        const childContainer = wrapper.find('div.usa-width-one-whole');
+        expect(childContainer.length).toBe(2);
+        expect(childContainer.first().text()).toBe('This is page 1');
+      });
+      it('it renders button for prev, save, next', () => {
+        expect(buttons.length).toBe(3);
+      });
+      it('the previous button is first and is disabled', () => {
         const prevButton = buttons.first();
-        prevButton.simulate('click');
+        expect(prevButton.text()).toBe('Prev');
+        expect(prevButton.prop('disabled')).toBe(true);
       });
-      it('push gets the prev page', () => {
-        expect(mockPush.mock.calls.length).toBe(1);
-        expect(mockPush.mock.calls[0][0]).toBe('2');
+      it('the save for later button is second and is disabled', () => {
+        const prevButton = buttons.at(1);
+        expect(prevButton.text()).toBe('Save for later');
+        expect(prevButton.prop('disabled')).toBe(true);
       });
-    });
-    it('the save for later button is second and is disabled', () => {
-      const saveButton = buttons.at(1);
-      expect(saveButton.text()).toBe('Save for later');
-      expect(saveButton.prop('disabled')).toBe(true);
-    });
-    it('the Complete button is last and is enabled', () => {
-      const nextButton = buttons.last();
-      expect(nextButton.text()).toBe('Complete');
-      expect(nextButton.prop('disabled')).toBeFalsy();
-    });
-    describe('when the complete button is clicked', () => {
-      beforeEach(() => {
+      it('the next button is last and is enabled', () => {
         const nextButton = buttons.last();
-        nextButton.simulate('click');
+        expect(nextButton.text()).toBe('Next');
+        expect(nextButton.prop('disabled')).toBeFalsy();
       });
-      it('submit is called', () => {
-        expect(submit.mock.calls.length).toBe(1);
+
+      describe('when the next button is clicked', () => {
+        beforeEach(() => {
+          const nextButton = buttons.last();
+          nextButton.simulate('click');
+        });
+        it('transitionTo is set to second page', () => {
+          const state = wrapper.state();
+          expect(state.transitionTo).toBe('2');
+        });
+        it('submit is called', () => {
+          expect(submit.mock.calls.length).toBe(1);
+        });
+      });
+    });
+
+    describe('when on the middle page', () => {
+      beforeEach(() => {
+        mockPush.mockClear();
+        wrapper = shallow(
+          <WizardPage
+            handleSubmit={submit}
+            pageList={pageList}
+            pageKey="2"
+            push={mockPush}
+            match={{}}
+            isAsync={true}
+            hasSucceeded={false}
+          >
+            <div>This is page 2</div>
+          </WizardPage>,
+        );
+        buttons = wrapper.find('button');
+      });
+      afterEach(() => {
+        submit.mockClear();
+      });
+      it('it shows its child', () => {
+        const childContainer = wrapper.find('div.usa-width-one-whole');
+        expect(childContainer.length).toBe(2);
+        expect(childContainer.first().text()).toBe('This is page 2');
+      });
+      it('it renders button for prev, save, next', () => {
+        expect(buttons.length).toBe(3);
+      });
+      it('the previous button is first and is enabled', () => {
+        const prevButton = buttons.first();
+        expect(prevButton.text()).toBe('Prev');
+        expect(prevButton.prop('disabled')).toBe(false);
+      });
+      describe('when the prev button is clicked', () => {
+        beforeEach(() => {
+          const prevButton = buttons.first();
+          prevButton.simulate('click');
+        });
+        it('transitionTo is set to first page', () => {
+          const state = wrapper.state();
+          expect(state.transitionTo).toBe('1');
+        });
+        it('submit is called', () => {
+          expect(submit.mock.calls.length).toBe(1);
+        });
+      });
+      it('the save for later button is second and is disabled', () => {
+        const prevButton = buttons.at(1);
+        expect(prevButton.text()).toBe('Save for later');
+        expect(prevButton.prop('disabled')).toBe(true);
+      });
+      it('the next button is last and is enabled', () => {
+        const nextButton = buttons.last();
+        expect(nextButton.text()).toBe('Next');
+        expect(nextButton.prop('disabled')).toBeFalsy();
+      });
+      describe('when the next button is clicked', () => {
+        beforeEach(() => {
+          const nextButton = buttons.last();
+          nextButton.simulate('click');
+        });
+        it('transitionTo is set to third page', () => {
+          const state = wrapper.state();
+          expect(state.transitionTo).toBe('3');
+        });
+
+        it('submit is called', () => {
+          expect(submit.mock.calls.length).toBe(1);
+        });
+      });
+    });
+    describe('when on the last page', () => {
+      beforeEach(() => {
+        mockPush.mockClear();
+        wrapper = shallow(
+          <WizardPage
+            handleSubmit={submit}
+            pageList={pageList}
+            pageKey="3"
+            push={mockPush}
+            match={{}}
+            isAsync={true}
+            hasSucceeded={false}
+          >
+            <div>This is page 3</div>
+          </WizardPage>,
+        );
+        buttons = wrapper.find('button');
+      });
+      afterEach(() => {
+        submit.mockClear();
+      });
+
+      it('it shows its child', () => {
+        const childContainer = wrapper.find('div.usa-width-one-whole');
+        expect(childContainer.length).toBe(2);
+        expect(childContainer.first().text()).toBe('This is page 3');
+      });
+      it('it renders button for prev, save, next', () => {
+        expect(buttons.length).toBe(3);
+      });
+      it('the previous button is first and is enabled', () => {
+        const prevButton = buttons.first();
+        expect(prevButton.text()).toBe('Prev');
+        expect(prevButton.prop('disabled')).toBe(false);
+      });
+      describe('when the prev button is clicked', () => {
+        beforeEach(() => {
+          const prevButton = buttons.first();
+          prevButton.simulate('click');
+        });
+        it('submit is called', () => {
+          expect(submit.mock.calls.length).toBe(1);
+        });
+      });
+      it('the save for later button is second and is disabled', () => {
+        const saveButton = buttons.at(1);
+        expect(saveButton.text()).toBe('Save for later');
+        expect(saveButton.prop('disabled')).toBe(true);
+      });
+      it('the Complete button is last and is enabled', () => {
+        const nextButton = buttons.last();
+        expect(nextButton.text()).toBe('Complete');
+        expect(nextButton.prop('disabled')).toBeFalsy();
+      });
+      describe('when the complete button is clicked', () => {
+        beforeEach(() => {
+          const nextButton = buttons.last();
+          nextButton.simulate('click');
+        });
+        it('submit is called', () => {
+          expect(submit.mock.calls.length).toBe(1);
+        });
       });
     });
   });

--- a/src/shared/constants.js
+++ b/src/shared/constants.js
@@ -1,5 +1,3 @@
 /* This matches the width at which submit buttons go full-width for mobile devices */
-const mobileSize = 481;
-module.exports = {
-  mobileSize,
-};
+export const mobileSize = 481;
+export const isProduction = process.env.NODE_ENV === 'production';


### PR DESCRIPTION
## Description

This work ensures three things:
* pages that make async calls (e.g. saving data on the server) do not move to the next or previous page until the call has completed. 
*  pages only call submit (the async call) if the page is dirty.
* if there is an error, the user is alerted to it and they cannot move to another page

## Reviewer Notes

Is there a better way to separate out the success flags for different async actions? Right now, I am setting hasSubmitted to false when starting actions, but that seems like something someone could forget to do easily.

## Code Review Verification Steps

* [ ] All tests pass.
* [x] ~~Code follows the guidelines for [Logging](https://github.com/transcom/mymove/blob/master/docs/backend.md#logging)~~
* [x] ~~The requirements listed in [Querying the Database Safely (https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely) have been satisfied.~~
* [ ] There are no [aXe](https://www.deque.com/products/aXe/) warnings for UI.
* [ ] This works in IE.
* [x] Any new third party client side dependencies (e.g., login.gov, google analytics, CDN libraries, etc.) have been communicated to @willowbl00.
* [ ] Request review from a member of a different team.
* [ ] (TRIAL) Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/156435815) for this change

## Screenshots

### Errors
![image](https://user-images.githubusercontent.com/3142631/38429132-8bd8588a-398b-11e8-9807-312da45757de.png)
