### PR TITLE
Rek compute ppm

### DIFF
--- a/pkg/rateengine/linehaul.go
+++ b/pkg/rateengine/linehaul.go
@@ -66,11 +66,9 @@ func (re *RateEngine) shorthaulCharge(mileage int, cwt int) (shorthaulChargeCent
 }
 
 // Determine Linehaul Charge (LC) TOTAL
-// Formula: LC= [BLH + OLF + DLF + {SH}] x InvdLH
-func (re *RateEngine) linehaulChargeTotal(originZip int, destinationZip int, date time.Time) (linehaulChargeCents int, err error) {
+// Formula: LC= [BLH + OLF + DLF + [SH]
+func (re *RateEngine) linehaulChargeTotal(weight int, originZip int, destinationZip int, date time.Time) (linehaulChargeCents int, err error) {
 	mileage, err := re.determineMileage(originZip, destinationZip)
-	// TODO: Where is weight coming from?
-	weight := 2000
 	cwt := re.determineCWT(weight)
 	baseLinehaulChargeCents, err := re.baseLinehaul(mileage, cwt)
 	originLinehaulFactorCents, err := re.linehaulFactors(cwt, originZip, date)

--- a/pkg/rateengine/linehaul.go
+++ b/pkg/rateengine/linehaul.go
@@ -76,12 +76,8 @@ func (re *RateEngine) linehaulChargeTotal(originZip int, destinationZip int, dat
 	originLinehaulFactorCents, err := re.linehaulFactors(cwt, originZip, date)
 	destinationLinehaulFactorCents, err := re.linehaulFactors(cwt, destinationZip, date)
 	shorthaulChargeCents, err := re.shorthaulCharge(mileage, cwt)
-	// TODO: Where is our discount coming from?
-	discount := 0.41
-	inverseDiscount := 1.0 - discount
-	// TODO: Make real error
 	if err != nil {
-		err = errors.New("Oops determineLinehaulChargeTotal")
+		return 0, err
 	}
-	return int(float64(baseLinehaulChargeCents+originLinehaulFactorCents+destinationLinehaulFactorCents+shorthaulChargeCents) * inverseDiscount), err
+	return int(baseLinehaulChargeCents + originLinehaulFactorCents + destinationLinehaulFactorCents + shorthaulChargeCents), err
 }

--- a/pkg/rateengine/linehaul_test.go
+++ b/pkg/rateengine/linehaul_test.go
@@ -87,7 +87,7 @@ func (suite *RateEngineSuite) Test_CheckShorthaulCharge() {
 func (suite *RateEngineSuite) Test_CheckLinehaulChargeTotal() {
 	t := suite.T()
 	engine := NewRateEngine(suite.db, suite.logger)
-	linehaulChargeTotal, err := engine.linehaulChargeTotal(10024, 94103, testdatagen.RateEngineDate)
+	linehaulChargeTotal, err := engine.linehaulChargeTotal(2000, 395, 336, testdatagen.RateEngineDate)
 	if err != nil {
 		t.Error("Unable to determine linehaulChargeTotal: ", err)
 	}

--- a/pkg/rateengine/linehaul_test.go
+++ b/pkg/rateengine/linehaul_test.go
@@ -91,7 +91,7 @@ func (suite *RateEngineSuite) Test_CheckLinehaulChargeTotal() {
 	if err != nil {
 		t.Error("Unable to determine linehaulChargeTotal: ", err)
 	}
-	expected := 11800
+	expected := 20000
 	if linehaulChargeTotal != expected {
 		t.Errorf("Determined linehaul factor incorrectly. Expected %d, got %d", expected, linehaulChargeTotal)
 	}

--- a/pkg/rateengine/nonlinehaul.go
+++ b/pkg/rateengine/nonlinehaul.go
@@ -40,8 +40,7 @@ func (re *RateEngine) fullUnpackCents(cwt int, zip3 int) (int, error) {
 	return cwt * fullUnpackRate / 1000, nil
 }
 
-func (re *RateEngine) nonLinehaulChargeTotalCents(originZip int, destinationZip int) (int, error) {
-	weight := 4000
+func (re *RateEngine) nonLinehaulChargeTotalCents(weight int, originZip int, destinationZip int) (int, error) {
 	cwt := re.determineCWT(weight)
 	originServiceFee, err := re.serviceFeeCents(cwt, originZip)
 	destinationServiceFee, err := re.serviceFeeCents(cwt, destinationZip)

--- a/pkg/rateengine/nonlinehaul.go
+++ b/pkg/rateengine/nonlinehaul.go
@@ -40,7 +40,7 @@ func (re *RateEngine) fullUnpackCents(cwt int, zip3 int) (int, error) {
 	return cwt * fullUnpackRate / 1000, nil
 }
 
-func (re *RateEngine) nonLinehaulChargeTotalCents(originZip int, destinationZip int, inverseDiscount float64) (int, error) {
+func (re *RateEngine) nonLinehaulChargeTotalCents(originZip int, destinationZip int) (int, error) {
 	weight := 4000
 	cwt := re.determineCWT(weight)
 	originServiceFee, err := re.serviceFeeCents(cwt, originZip)
@@ -51,5 +51,5 @@ func (re *RateEngine) nonLinehaulChargeTotalCents(originZip int, destinationZip 
 		return 0, err
 	}
 	subTotal := originServiceFee + destinationServiceFee + pack + unpack
-	return int(float64(subTotal) * inverseDiscount), nil
+	return subTotal, nil
 }

--- a/pkg/rateengine/nonlinehaul_test.go
+++ b/pkg/rateengine/nonlinehaul_test.go
@@ -216,13 +216,13 @@ func (suite *RateEngineSuite) Test_CheckNonLinehaulChargeTotal() {
 	}
 	suite.mustSave(&fullUnpackRate)
 
-	fee, err := engine.nonLinehaulChargeTotalCents(395, 336, 0.5)
+	fee, err := engine.nonLinehaulChargeTotalCents(395, 336)
 
 	if err != nil {
 		t.Fatalf("failed to calculate non linehaul charge: %s", err)
 	}
-	// (14000 + 26520 + 217160 + 21716) * .5
-	expected := 139698
+	// (14000 + 26520 + 217160 + 21716)
+	expected := 279396
 	if fee != expected {
 		t.Errorf("wrong non-linehaul charge total: expected %d, got %d", expected, fee)
 	}

--- a/pkg/rateengine/nonlinehaul_test.go
+++ b/pkg/rateengine/nonlinehaul_test.go
@@ -216,13 +216,13 @@ func (suite *RateEngineSuite) Test_CheckNonLinehaulChargeTotal() {
 	}
 	suite.mustSave(&fullUnpackRate)
 
-	fee, err := engine.nonLinehaulChargeTotalCents(395, 336)
+	fee, err := engine.nonLinehaulChargeTotalCents(2000, 395, 336)
 
 	if err != nil {
 		t.Fatalf("failed to calculate non linehaul charge: %s", err)
 	}
-	// (14000 + 26520 + 217160 + 21716)
-	expected := 279396
+	// (7000 + 13260 + 108580 + 10858)
+	expected := 139698
 	if fee != expected {
 		t.Errorf("wrong non-linehaul charge total: expected %d, got %d", expected, fee)
 	}

--- a/pkg/rateengine/rateengine.go
+++ b/pkg/rateengine/rateengine.go
@@ -1,6 +1,8 @@
 package rateengine
 
 import (
+	"time"
+
 	"github.com/gobuffalo/pop"
 	"go.uber.org/zap"
 )
@@ -13,6 +15,59 @@ type RateEngine struct {
 
 func (re *RateEngine) determineCWT(weight int) (cwt int) {
 	return weight / 100
+}
+
+func (re *RateEngine) computePPM(weight int, originZip int, destinationZip int, date time.Time, inverseDiscount float64) (int, error) {
+	cwt := re.determineCWT(weight)
+	// Linehaul charges
+	mileage, err := re.determineMileage(originZip, destinationZip)
+	if err != nil {
+		re.logger.Error("Failed to determine mileage", zap.Error(err))
+		return 0, err
+	}
+	baseLinehaulChargeCents, err := re.baseLinehaul(mileage, cwt)
+	if err != nil {
+		re.logger.Error("Failed to determine base linehaul charge", zap.Error(err))
+		return 0, err
+	}
+	originLinehaulFactorCents, err := re.linehaulFactors(cwt, originZip, date)
+	if err != nil {
+		re.logger.Error("Failed to determine origin linehaul factor", zap.Error(err))
+		return 0, err
+	}
+	destinationLinehaulFactorCents, err := re.linehaulFactors(cwt, destinationZip, date)
+	if err != nil {
+		re.logger.Error("Failed to determine destination linehaul factor", zap.Error(err))
+		return 0, err
+	}
+	shorthaulChargeCents, err := re.shorthaulCharge(mileage, cwt)
+	if err != nil {
+		re.logger.Error("Failed to determine shorthaul charge", zap.Error(err))
+		return 0, err
+	}
+	// Non linehaul charges
+	originServiceFee, err := re.serviceFeeCents(cwt, originZip)
+	if err != nil {
+		re.logger.Error("Failed to determine origin service fee", zap.Error(err))
+		return 0, err
+	}
+	destinationServiceFee, err := re.serviceFeeCents(cwt, destinationZip)
+	if err != nil {
+		re.logger.Error("Failed to determine destination service fee", zap.Error(err))
+		return 0, err
+	}
+	pack, err := re.fullPackCents(cwt, originZip)
+	if err != nil {
+		re.logger.Error("Failed to determine full pack cost", zap.Error(err))
+		return 0, err
+	}
+	unpack, err := re.fullUnpackCents(cwt, destinationZip)
+	if err != nil {
+		re.logger.Error("Failed to determine full unpack cost", zap.Error(err))
+		return 0, err
+	}
+	ppmCost := int(float64(baseLinehaulChargeCents+originLinehaulFactorCents+destinationLinehaulFactorCents+shorthaulChargeCents+originServiceFee+destinationServiceFee+pack+unpack) * inverseDiscount)
+	return ppmCost, nil
 }
 
 // NewRateEngine creates a new RateEngine

--- a/pkg/rateengine/rateengine.go
+++ b/pkg/rateengine/rateengine.go
@@ -66,8 +66,10 @@ func (re *RateEngine) computePPM(weight int, originZip int, destinationZip int, 
 		re.logger.Error("Failed to determine full unpack cost", zap.Error(err))
 		return 0, err
 	}
-	ppmCost := int(float64(baseLinehaulChargeCents+originLinehaulFactorCents+destinationLinehaulFactorCents+shorthaulChargeCents+originServiceFee+destinationServiceFee+pack+unpack) * inverseDiscount)
-	return ppmCost, nil
+	ppmBestValue := int(float64(baseLinehaulChargeCents+originLinehaulFactorCents+destinationLinehaulFactorCents+shorthaulChargeCents+originServiceFee+destinationServiceFee+pack+unpack) * inverseDiscount)
+	// PPMs only pay 95% of the best value
+	ppmPayback := int(float64(ppmBestValue) * .95)
+	return ppmPayback, nil
 }
 
 // NewRateEngine creates a new RateEngine

--- a/pkg/rateengine/rateengine_test.go
+++ b/pkg/rateengine/rateengine_test.go
@@ -3,10 +3,14 @@ package rateengine
 import (
 	"log"
 	"testing"
+	"time"
 
 	"github.com/gobuffalo/pop"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/zap"
+
+	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/testdatagen"
 )
 
 func (suite *RateEngineSuite) Test_CheckDetermineCWT() {
@@ -17,6 +21,86 @@ func (suite *RateEngineSuite) Test_CheckDetermineCWT() {
 
 	if cwt != 25 {
 		t.Errorf("CWT should have been 25 but is %d.", cwt)
+	}
+}
+
+func (suite *RateEngineSuite) Test_CheckPPMTotal() {
+	t := suite.T()
+	t.Skip("Waiting on linehaul implementation")
+	engine := NewRateEngine(suite.db, suite.logger)
+	defaultRateDateLower := time.Date(2017, 5, 15, 0, 0, 0, 0, time.UTC)
+	defaultRateDateUpper := time.Date(2018, 5, 15, 0, 0, 0, 0, time.UTC)
+
+	originZip3 := models.Tariff400ngZip3{
+		Zip3:          395,
+		BasepointCity: "Saucier",
+		State:         "MS",
+		ServiceArea:   428,
+		RateArea:      "48",
+		Region:        11,
+	}
+	suite.mustSave(&originZip3)
+
+	originServiceArea := models.Tariff400ngServiceArea{
+		Name:               "Gulfport, MS",
+		ServiceArea:        428,
+		LinehaulFactor:     57,
+		ServiceChargeCents: 350,
+		ServicesSchedule:   1,
+		EffectiveDateLower: defaultRateDateLower,
+		EffectiveDateUpper: defaultRateDateUpper,
+	}
+	suite.mustSave(&originServiceArea)
+
+	destinationZip3 := models.Tariff400ngZip3{
+		Zip3:          336,
+		BasepointCity: "Tampa",
+		State:         "FL",
+		ServiceArea:   197,
+		RateArea:      "4964400",
+		Region:        13,
+	}
+	suite.mustSave(&destinationZip3)
+
+	destinationServiceArea := models.Tariff400ngServiceArea{
+		Name:               "Tampa, FL",
+		ServiceArea:        197,
+		LinehaulFactor:     69,
+		ServiceChargeCents: 663,
+		ServicesSchedule:   1,
+		EffectiveDateLower: defaultRateDateLower,
+		EffectiveDateUpper: defaultRateDateUpper,
+	}
+	suite.mustSave(&destinationServiceArea)
+
+	fullPackRate := models.Tariff400ngFullPackRate{
+		Schedule:           1,
+		WeightLbsLower:     0,
+		WeightLbsUpper:     16001,
+		RateCents:          5429,
+		EffectiveDateLower: defaultRateDateLower,
+		EffectiveDateUpper: defaultRateDateUpper,
+	}
+	suite.mustSave(&fullPackRate)
+
+	fullUnpackRate := models.Tariff400ngFullUnpackRate{
+		Schedule:           1,
+		RateMillicents:     542900,
+		EffectiveDateLower: defaultRateDateLower,
+		EffectiveDateUpper: defaultRateDateUpper,
+	}
+	suite.mustSave(&fullUnpackRate)
+
+	// 27145 +20000
+	fee, err := engine.computePPM(4000, 395, 336, testdatagen.RateEngineDate, .40)
+
+	if err != nil {
+		t.Fatalf("failed to calculate ppm charge: %s", err)
+	}
+
+	expected := 17915
+	if fee != expected {
+		t.Errorf("wrong PPM charge total: expected %d, got %d", expected, fee)
 	}
 }
 

--- a/pkg/rateengine/rateengine_test.go
+++ b/pkg/rateengine/rateengine_test.go
@@ -26,7 +26,6 @@ func (suite *RateEngineSuite) Test_CheckDetermineCWT() {
 
 func (suite *RateEngineSuite) Test_CheckPPMTotal() {
 	t := suite.T()
-	t.Skip("Waiting on linehaul implementation")
 	engine := NewRateEngine(suite.db, suite.logger)
 	defaultRateDateLower := time.Date(2017, 5, 15, 0, 0, 0, 0, time.UTC)
 	defaultRateDateUpper := time.Date(2018, 5, 15, 0, 0, 0, 0, time.UTC)
@@ -91,14 +90,14 @@ func (suite *RateEngineSuite) Test_CheckPPMTotal() {
 	}
 	suite.mustSave(&fullUnpackRate)
 
-	// 27145 +20000
-	fee, err := engine.computePPM(4000, 395, 336, testdatagen.RateEngineDate, .40)
+	// 139698 +20000
+	fee, err := engine.computePPM(2000, 395, 336, testdatagen.RateEngineDate, .40)
 
 	if err != nil {
 		t.Fatalf("failed to calculate ppm charge: %s", err)
 	}
 
-	expected := 17915
+	expected := 61642
 	if fee != expected {
 		t.Errorf("wrong PPM charge total: expected %d, got %d", expected, fee)
 	}


### PR DESCRIPTION
## Description

This func calculates PPM value and returns the reimbursement expected for specified weight, zips, date, etc.
Removes inverse discount calculation from linehaul and nonlinehaul totals and puts it in ppm calculation instead.

## Reviewer Notes

Isn't there a better way to handle these errors?
Have to make the test fully functional once linehaul is all implemented.

## Code Review Verification Steps

* [x] All tests pass.
* [x] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/blob/master/docs/backend.md#logging)
* [x] Request review from a member of a different team.
* [ ] (TRIAL) Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/156455543) for this change
