### PR TITLE
Populates user model onto context in auth enforcement middleware

### DIFF
--- a/cmd/webserver/main.go
+++ b/cmd/webserver/main.go
@@ -125,6 +125,7 @@ func main() {
 
 	// Populates user info using cookie and renews token
 	tokenMiddleware := auth.TokenParsingMiddleware(logger, *clientAuthSecretKey, *noSessionTimeout)
+	userAuthMiddleware := auth.UserAuthMiddleware(dbConnection)
 
 	handlerContext := handlers.NewHandlerContext(dbConnection, logger)
 
@@ -165,10 +166,14 @@ func main() {
 
 	internalMux := goji.SubMux()
 	root.Handle(pat.New("/internal/*"), internalMux)
-	internalMux.Use(auth.RequireAuthMiddleware)
 	internalMux.Handle(pat.Get("/swagger.yaml"), fileHandler(*internalSwagger))
 	internalMux.Handle(pat.Get("/docs"), fileHandler(path.Join(*build, "swagger-ui", "internal.html")))
-	internalMux.Handle(pat.New("/*"), handlers.NewInternalAPIHandler(handlerContext, fileHandlerContext))
+
+	// Mux for internal API that enforces auth
+	internalAPIMux := goji.SubMux()
+	internalAPIMux.Use(userAuthMiddleware)
+	internalMux.Handle(pat.New("/*"), internalAPIMux)
+	internalAPIMux.Handle(pat.New("/*"), handlers.NewInternalAPIHandler(handlerContext, fileHandlerContext))
 
 	authContext := auth.NewAuthContext(fullHostname, logger, loginGovProvider)
 	authMux := goji.SubMux()

--- a/pkg/auth/context/context.go
+++ b/pkg/auth/context/context.go
@@ -4,6 +4,8 @@ import (
 	"context"
 
 	"github.com/gobuffalo/uuid"
+
+	"github.com/transcom/mymove/pkg/models"
 )
 
 // Keys for values stored in the context are supposed to be of a custom type, not string
@@ -11,6 +13,7 @@ import (
 type moveCtxKey string
 
 var userIDKey = moveCtxKey("user_id")
+var userKey = moveCtxKey("user")
 var idTokenKey = moveCtxKey("id_token")
 
 // PopulateAuthContext sets the values that the auth package wants in the context
@@ -20,10 +23,22 @@ func PopulateAuthContext(ctx context.Context, userID uuid.UUID, idToken string) 
 	return ctx
 }
 
+// PopulateUserModel sets a user model onto a request context
+func PopulateUserModel(ctx context.Context, user models.User) context.Context {
+	ctx = context.WithValue(ctx, userKey, user)
+	return ctx
+}
+
 // GetUserID retrieves the UserID from the context
 func GetUserID(ctx context.Context) (uuid.UUID, bool) {
 	id, ok := ctx.Value(userIDKey).(uuid.UUID)
 	return id, ok
+}
+
+// GetUser retrieves the User from the context
+func GetUser(ctx context.Context) (models.User, bool) {
+	user, ok := ctx.Value(userKey).(models.User)
+	return user, ok
 }
 
 // GetIDToken retrieves the IDToken from the context

--- a/pkg/handlers/duty_stations.go
+++ b/pkg/handlers/duty_stations.go
@@ -30,13 +30,7 @@ type SearchDutyStationsHandler HandlerContext
 func (h SearchDutyStationsHandler) Handle(params stationop.SearchDutyStationsParams) middleware.Responder {
 	var stations models.DutyStations
 	var response middleware.Responder
-
-	// Verify user is logged in
-	_, err := models.GetUserFromRequest(h.db, params.HTTPRequest)
-	if err != nil {
-		response = stationop.NewSearchDutyStationsUnauthorized()
-		return response
-	}
+	var err error
 
 	stations, err = models.FindDutyStations(h.db, params.Search, params.Branch)
 	if err != nil {

--- a/pkg/handlers/moves.go
+++ b/pkg/handlers/moves.go
@@ -28,10 +28,8 @@ type CreateMoveHandler HandlerContext
 // Handle ... creates a new Move from a request payload
 func (h CreateMoveHandler) Handle(params moveop.CreateMoveParams) middleware.Responder {
 	var response middleware.Responder
-	user, ok := context.GetUser(params.HTTPRequest.Context())
-	if !ok {
-		h.logger.Error("No User, this should never happen.")
-	}
+	// User should always be populated by middleware
+	user, _ := context.GetUser(params.HTTPRequest.Context())
 
 	// Create a new move for an authenticated user
 	newMove := models.Move{
@@ -58,10 +56,8 @@ type IndexMovesHandler HandlerContext
 // Handle retrieves a list of all moves in the system belonging to the logged in user
 func (h IndexMovesHandler) Handle(params moveop.IndexMovesParams) middleware.Responder {
 	var response middleware.Responder
-	user, ok := context.GetUser(params.HTTPRequest.Context())
-	if !ok {
-		h.logger.Error("No User, this should never happen.")
-	}
+	// User should always be populated by middleware
+	user, _ := context.GetUser(params.HTTPRequest.Context())
 
 	moves, err := models.GetMovesForUserID(h.db, user.ID)
 	if err != nil {
@@ -84,10 +80,8 @@ type ShowMoveHandler HandlerContext
 // Handle retrieves a move in the system belonging to the logged in user given move ID
 func (h ShowMoveHandler) Handle(params moveop.ShowMoveParams) middleware.Responder {
 	var response middleware.Responder
-	user, ok := context.GetUser(params.HTTPRequest.Context())
-	if !ok {
-		h.logger.Error("No User, this should never happen.")
-	}
+	// User should always be populated by middleware
+	user, _ := context.GetUser(params.HTTPRequest.Context())
 
 	moveID, err := uuid.FromString(params.MoveID.String())
 	if err != nil {
@@ -123,10 +117,8 @@ type PatchMoveHandler HandlerContext
 // Handle ... patches a new Move from a request payload
 func (h PatchMoveHandler) Handle(params moveop.PatchMoveParams) middleware.Responder {
 	var response middleware.Responder
-	user, ok := context.GetUser(params.HTTPRequest.Context())
-	if !ok {
-		h.logger.Error("No User, this should never happen.")
-	}
+	// User should always be populated by middleware
+	user, _ := context.GetUser(params.HTTPRequest.Context())
 
 	moveID, err := uuid.FromString(params.MoveID.String())
 	if err != nil {

--- a/pkg/handlers/moves.go
+++ b/pkg/handlers/moves.go
@@ -7,6 +7,8 @@ import (
 	"github.com/transcom/mymove/pkg/gen/internalmessages"
 	"github.com/transcom/mymove/pkg/models"
 	"go.uber.org/zap"
+
+	"github.com/transcom/mymove/pkg/auth/context"
 )
 
 func payloadForMoveModel(user models.User, move models.Move) internalmessages.MovePayload {
@@ -26,11 +28,9 @@ type CreateMoveHandler HandlerContext
 // Handle ... creates a new Move from a request payload
 func (h CreateMoveHandler) Handle(params moveop.CreateMoveParams) middleware.Responder {
 	var response middleware.Responder
-	// Get user id from context
-	user, err := models.GetUserFromRequest(h.db, params.HTTPRequest)
-	if err != nil {
-		response = moveop.NewCreateMoveUnauthorized()
-		return response
+	user, ok := context.GetUser(params.HTTPRequest.Context())
+	if !ok {
+		h.logger.Error("No User, this should never happen.")
 	}
 
 	// Create a new move for an authenticated user
@@ -58,11 +58,9 @@ type IndexMovesHandler HandlerContext
 // Handle retrieves a list of all moves in the system belonging to the logged in user
 func (h IndexMovesHandler) Handle(params moveop.IndexMovesParams) middleware.Responder {
 	var response middleware.Responder
-
-	user, err := models.GetUserFromRequest(h.db, params.HTTPRequest)
-	if err != nil {
-		response = moveop.NewIndexMovesUnauthorized()
-		return response
+	user, ok := context.GetUser(params.HTTPRequest.Context())
+	if !ok {
+		h.logger.Error("No User, this should never happen.")
 	}
 
 	moves, err := models.GetMovesForUserID(h.db, user.ID)
@@ -86,11 +84,9 @@ type ShowMoveHandler HandlerContext
 // Handle retrieves a move in the system belonging to the logged in user given move ID
 func (h ShowMoveHandler) Handle(params moveop.ShowMoveParams) middleware.Responder {
 	var response middleware.Responder
-
-	user, err := models.GetUserFromRequest(h.db, params.HTTPRequest)
-	if err != nil {
-		response = moveop.NewShowMoveUnauthorized()
-		return response
+	user, ok := context.GetUser(params.HTTPRequest.Context())
+	if !ok {
+		h.logger.Error("No User, this should never happen.")
 	}
 
 	moveID, err := uuid.FromString(params.MoveID.String())
@@ -127,12 +123,11 @@ type PatchMoveHandler HandlerContext
 // Handle ... patches a new Move from a request payload
 func (h PatchMoveHandler) Handle(params moveop.PatchMoveParams) middleware.Responder {
 	var response middleware.Responder
-	// Get user id from context
-	user, err := models.GetUserFromRequest(h.db, params.HTTPRequest)
-	if err != nil {
-		response = moveop.NewPatchMoveUnauthorized()
-		return response
+	user, ok := context.GetUser(params.HTTPRequest.Context())
+	if !ok {
+		h.logger.Error("No User, this should never happen.")
 	}
+
 	moveID, err := uuid.FromString(params.MoveID.String())
 	if err != nil {
 		h.logger.Fatal("Invalid MoveID, this should never happen.")

--- a/pkg/handlers/moves_test.go
+++ b/pkg/handlers/moves_test.go
@@ -35,6 +35,7 @@ func (suite *HandlerSuite) TestSubmitMoveHandlerAllValues() {
 	// And: the context contains the auth values
 	ctx := params.HTTPRequest.Context()
 	ctx = context.PopulateAuthContext(ctx, user.ID, "fake token")
+	ctx = context.PopulateUserModel(ctx, user)
 	params.HTTPRequest = params.HTTPRequest.WithContext(ctx)
 
 	handler := CreateMoveHandler(NewHandlerContext(suite.db, suite.logger))
@@ -54,36 +55,6 @@ func (suite *HandlerSuite) TestSubmitMoveHandlerAllValues() {
 		t.Errorf("Expected to find 1 move but found %v", len(moves))
 	}
 
-}
-
-func (suite *HandlerSuite) TestCreateMoveHandlerNoUserID() {
-	t := suite.T()
-	// Given: no authentication values in context
-	// When: a new Move is posted
-	var selectedType = internalmessages.SelectedMoveTypeHHG
-	movePayload := internalmessages.CreateMovePayload{
-		SelectedMoveType: &selectedType,
-	}
-	req := httptest.NewRequest("GET", "/moves", nil)
-	params := moveop.CreateMoveParams{
-		CreateMovePayload: &movePayload,
-		HTTPRequest:       req,
-	}
-
-	handler := CreateMoveHandler(NewHandlerContext(suite.db, suite.logger))
-	response := handler.Handle(params)
-
-	_, ok := response.(*moveop.CreateMoveUnauthorized)
-	if !ok {
-		t.Fatalf("Request failed: %#v", response)
-	}
-	// Then: we expect no moves to have been created
-	moves := []models.Move{}
-	suite.db.All(&moves)
-
-	if len(moves) > 0 {
-		t.Errorf("Expected to find no moves but found %v", len(moves))
-	}
 }
 
 func (suite *HandlerSuite) TestIndexMovesHandler() {
@@ -110,6 +81,7 @@ func (suite *HandlerSuite) TestIndexMovesHandler() {
 	// And: the context contains the auth values
 	ctx := req.Context()
 	ctx = context.PopulateAuthContext(ctx, user.ID, "fake token")
+	ctx = context.PopulateUserModel(ctx, user)
 	indexMovesParams.HTTPRequest = req.WithContext(ctx)
 
 	// And: All moves are queried
@@ -131,38 +103,6 @@ func (suite *HandlerSuite) TestIndexMovesHandler() {
 
 	if !moveExists {
 		t.Errorf("Expected an move to have user ID '%v'. None do.", user.ID)
-	}
-}
-
-func (suite *HandlerSuite) TestIndexMovesHandlerNoUser() {
-	t := suite.T()
-
-	// Given: A move with a user that isn't logged in
-	user := models.User{
-		LoginGovUUID:  uuid.Must(uuid.NewV4()),
-		LoginGovEmail: "email@example.com",
-	}
-	suite.mustSave(&user)
-
-	var selectedType = internalmessages.SelectedMoveTypeHHG
-	move := models.Move{
-		UserID:           user.ID,
-		SelectedMoveType: &selectedType,
-	}
-	suite.mustSave(&move)
-
-	req := httptest.NewRequest("GET", "/moves", nil)
-	indexMovesParams := moveop.NewIndexMovesParams()
-	indexMovesParams.HTTPRequest = req
-
-	// And: All moves are queried
-	indexHandler := IndexMovesHandler(NewHandlerContext(suite.db, suite.logger))
-	indexResponse := indexHandler.Handle(indexMovesParams)
-
-	// Then: Expect a 401 unauthorized
-	_, ok := indexResponse.(*moveop.IndexMovesUnauthorized)
-	if !ok {
-		t.Errorf("Expected to get an unauthorized response, but got something else.")
 	}
 }
 
@@ -195,6 +135,7 @@ func (suite *HandlerSuite) TestIndexMovesWrongUser() {
 	// And: the context contains the auth values for user 2
 	ctx := req.Context()
 	ctx = context.PopulateAuthContext(ctx, user2.ID, "fake token")
+	ctx = context.PopulateUserModel(ctx, user2)
 	indexMovesParams.HTTPRequest = req.WithContext(ctx)
 
 	// And: All moves are queried
@@ -237,6 +178,7 @@ func (suite *HandlerSuite) TestPatchMoveHandler() {
 	req := httptest.NewRequest("PATCH", "/moves/some_id", nil)
 	ctx := req.Context()
 	ctx = context.PopulateAuthContext(ctx, user.ID, "fake token")
+	ctx = context.PopulateUserModel(ctx, user)
 	req = req.WithContext(ctx)
 
 	params := moveop.PatchMoveParams{
@@ -292,6 +234,7 @@ func (suite *HandlerSuite) TestPatchMoveHandlerWrongUser() {
 	req := httptest.NewRequest("PATCH", "/moves/some_id", nil)
 	ctx := req.Context()
 	ctx = context.PopulateAuthContext(ctx, user2.ID, "fake token")
+	ctx = context.PopulateUserModel(ctx, user2)
 	req = req.WithContext(ctx)
 
 	params := moveop.PatchMoveParams{
@@ -331,6 +274,7 @@ func (suite *HandlerSuite) TestPatchMoveHandlerNoMove() {
 	req := httptest.NewRequest("PATCH", "/moves/some_id", nil)
 	ctx := req.Context()
 	ctx = context.PopulateAuthContext(ctx, user.ID, "fake token")
+	ctx = context.PopulateUserModel(ctx, user)
 	req = req.WithContext(ctx)
 
 	params := moveop.PatchMoveParams{
@@ -371,6 +315,7 @@ func (suite *HandlerSuite) TestPatchMoveHandlerNoType() {
 	req := httptest.NewRequest("PATCH", "/moves/some_id", nil)
 	ctx := req.Context()
 	ctx = context.PopulateAuthContext(ctx, user.ID, "fake token")
+	ctx = context.PopulateUserModel(ctx, user)
 	req = req.WithContext(ctx)
 
 	params := moveop.PatchMoveParams{
@@ -407,6 +352,7 @@ func (suite *HandlerSuite) TestShowMoveHandler() {
 	req := httptest.NewRequest("GET", "/moves/some_id", nil)
 	ctx := req.Context()
 	ctx = context.PopulateAuthContext(ctx, user.ID, "fake token")
+	ctx = context.PopulateUserModel(ctx, user)
 	req = req.WithContext(ctx)
 
 	params := moveop.ShowMoveParams{
@@ -426,36 +372,6 @@ func (suite *HandlerSuite) TestShowMoveHandler() {
 		t.Errorf("Expected an move to have user ID '%v'. None do.", user.ID)
 	}
 
-}
-
-func (suite *HandlerSuite) TestShowMoveHandlerNoUser() {
-	t := suite.T()
-
-	// Given: A move with a user that isn't logged in
-	user := models.User{
-		LoginGovUUID:  uuid.Must(uuid.NewV4()),
-		LoginGovEmail: "email@example.com",
-	}
-	suite.mustSave(&user)
-
-	move := models.Move{
-		UserID: user.ID,
-	}
-	suite.mustSave(&move)
-
-	req := httptest.NewRequest("GET", "/moves/some_id", nil)
-	showMoveParams := moveop.NewShowMoveParams()
-	showMoveParams.HTTPRequest = req
-
-	// And: Show move is queried
-	showHandler := ShowMoveHandler(NewHandlerContext(suite.db, suite.logger))
-	showResponse := showHandler.Handle(showMoveParams)
-
-	// Then: Expect a 401 unauthorized
-	_, ok := showResponse.(*moveop.ShowMoveUnauthorized)
-	if !ok {
-		t.Errorf("Expected to get an unauthorized response, but got something else.")
-	}
 }
 
 func (suite *HandlerSuite) TestShowMoveWrongUser() {
@@ -486,6 +402,7 @@ func (suite *HandlerSuite) TestShowMoveWrongUser() {
 	req := httptest.NewRequest("GET", "/moves/some_id", nil)
 	ctx := req.Context()
 	ctx = context.PopulateAuthContext(ctx, loggedInUser.ID, "fake token")
+	ctx = context.PopulateUserModel(ctx, loggedInUser)
 	req = req.WithContext(ctx)
 	showMoveParams := moveop.ShowMoveParams{
 		HTTPRequest: req,

--- a/pkg/handlers/service_member_test.go
+++ b/pkg/handlers/service_member_test.go
@@ -33,6 +33,7 @@ func (suite *HandlerSuite) TestShowServiceMemberHandler() {
 	req := httptest.NewRequest("GET", "/service_members/some_id", nil)
 	ctx := req.Context()
 	ctx = context.PopulateAuthContext(ctx, user.ID, "fake token")
+	ctx = context.PopulateUserModel(ctx, user)
 	req = req.WithContext(ctx)
 
 	params := servicememberop.ShowServiceMemberParams{
@@ -50,36 +51,6 @@ func (suite *HandlerSuite) TestShowServiceMemberHandler() {
 	// And: Returned query to include our added servicemember
 	if servicemember.UserID.String() != user.ID.String() {
 		t.Errorf("Expected an servicemember to have user ID '%v'. None do.", user.ID)
-	}
-}
-
-func (suite *HandlerSuite) TestShowServiceMemberHandlerNoUser() {
-	t := suite.T()
-
-	// Given: A servicemember with a user that isn't logged in
-	user := models.User{
-		LoginGovUUID:  uuid.Must(uuid.NewV4()),
-		LoginGovEmail: "email@example.com",
-	}
-	suite.mustSave(&user)
-
-	servicemember := models.ServiceMember{
-		UserID: user.ID,
-	}
-	suite.mustSave(&servicemember)
-
-	req := httptest.NewRequest("GET", "/service_members/some_id", nil)
-	showServiceMemberParams := servicememberop.NewShowServiceMemberParams()
-	showServiceMemberParams.HTTPRequest = req
-
-	// And: Show servicemember is queried
-	showHandler := ShowServiceMemberHandler(NewHandlerContext(suite.db, suite.logger))
-	showResponse := showHandler.Handle(showServiceMemberParams)
-
-	// Then: Expect a 401 unauthorized
-	_, ok := showResponse.(*servicememberop.ShowServiceMemberUnauthorized)
-	if !ok {
-		t.Errorf("Expected to get an unauthorized response, but got something else.")
 	}
 }
 
@@ -109,6 +80,7 @@ func (suite *HandlerSuite) TestShowServiceMemberWrongUser() {
 	req := httptest.NewRequest("GET", "/service_members/some_id", nil)
 	ctx := req.Context()
 	ctx = context.PopulateAuthContext(ctx, loggedInUser.ID, "fake token")
+	ctx = context.PopulateUserModel(ctx, loggedInUser)
 	req = req.WithContext(ctx)
 	showServiceMemberParams := servicememberop.ShowServiceMemberParams{
 		HTTPRequest:     req,
@@ -161,6 +133,7 @@ func (suite *HandlerSuite) TestSubmitServiceMemberHandlerAllValues() {
 	// And: the context contains the auth values for logged-in user
 	ctx := params.HTTPRequest.Context()
 	ctx = context.PopulateAuthContext(ctx, user.ID, "fake token")
+	ctx = context.PopulateUserModel(ctx, user)
 	params.HTTPRequest = params.HTTPRequest.WithContext(ctx)
 
 	handler := CreateServiceMemberHandler(NewHandlerContext(suite.db, suite.logger))
@@ -178,33 +151,6 @@ func (suite *HandlerSuite) TestSubmitServiceMemberHandlerAllValues() {
 
 	if len(servicemembers) != 1 {
 		t.Errorf("Expected to find 1 servicemember but found %v", len(servicemembers))
-	}
-}
-
-func (suite *HandlerSuite) TestCreateServiceMemberHandlerNoUserID() {
-	t := suite.T()
-	// Given: no authentication values in context
-	// When: a new ServiceMember is posted
-	servicememberPayload := internalmessages.CreateServiceMemberPayload{}
-	req := httptest.NewRequest("GET", "/service_members", nil)
-	params := servicememberop.CreateServiceMemberParams{
-		CreateServiceMemberPayload: &servicememberPayload,
-		HTTPRequest:                req,
-	}
-
-	handler := CreateServiceMemberHandler(NewHandlerContext(suite.db, suite.logger))
-	response := handler.Handle(params)
-
-	_, ok := response.(*servicememberop.CreateServiceMemberUnauthorized)
-	if !ok {
-		t.Fatalf("Request failed: %#v", response)
-	}
-	// Then: we expect no servicemembers to have been created
-	servicemembers := []models.ServiceMember{}
-	suite.db.All(&servicemembers)
-
-	if len(servicemembers) > 0 {
-		t.Errorf("Expected to find no servicemembers but found %v", len(servicemembers))
 	}
 }
 
@@ -236,6 +182,7 @@ func (suite *HandlerSuite) TestPatchServiceMemberHandler() {
 	req := httptest.NewRequest("PATCH", "/service_members/some_id", nil)
 	ctx := req.Context()
 	ctx = context.PopulateAuthContext(ctx, user.ID, "fake token")
+	ctx = context.PopulateUserModel(ctx, user)
 	req = req.WithContext(ctx)
 
 	params := servicememberop.PatchServiceMemberParams{
@@ -299,6 +246,7 @@ func (suite *HandlerSuite) TestPatchServiceMemberHandlerWrongUser() {
 	req := httptest.NewRequest("PATCH", "/service_members/some_id", nil)
 	ctx := req.Context()
 	ctx = context.PopulateAuthContext(ctx, user2.ID, "fake token")
+	ctx = context.PopulateUserModel(ctx, user2)
 	req = req.WithContext(ctx)
 
 	params := servicememberop.PatchServiceMemberParams{
@@ -378,6 +326,7 @@ func (suite *HandlerSuite) TestPatchServiceMemberHandlerNoChange() {
 	req := httptest.NewRequest("PATCH", "/service_members/some_id", nil)
 	ctx := req.Context()
 	ctx = context.PopulateAuthContext(ctx, user.ID, "fake token")
+	ctx = context.PopulateUserModel(ctx, user)
 	req = req.WithContext(ctx)
 
 	params := servicememberop.PatchServiceMemberParams{

--- a/pkg/handlers/service_members.go
+++ b/pkg/handlers/service_members.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/gobuffalo/uuid"
+	"github.com/transcom/mymove/pkg/auth/context"
 	servicememberop "github.com/transcom/mymove/pkg/gen/internalapi/internaloperations/service_members"
 	"github.com/transcom/mymove/pkg/gen/internalmessages"
 	"github.com/transcom/mymove/pkg/models"
@@ -40,15 +41,12 @@ type CreateServiceMemberHandler HandlerContext
 
 // Handle ... creates a new ServiceMember from a request payload
 func (h CreateServiceMemberHandler) Handle(params servicememberop.CreateServiceMemberParams) middleware.Responder {
+	var response middleware.Responder
 	residentialAddress := models.AddressModelFromPayload(params.CreateServiceMemberPayload.ResidentialAddress)
 	backupMailingAddress := models.AddressModelFromPayload(params.CreateServiceMemberPayload.BackupMailingAddress)
-	// Get user id from context
-	var response middleware.Responder
-	user, err := models.GetUserFromRequest(h.db, params.HTTPRequest)
-	if err != nil {
-		response = servicememberop.NewCreateServiceMemberUnauthorized()
-		return response
-	}
+
+	// User should always be populated by middleware
+	user, _ := context.GetUser(params.HTTPRequest.Context())
 
 	// Create a new serviceMember for an authenticated user
 	newServiceMember := models.ServiceMember{
@@ -89,12 +87,8 @@ type ShowServiceMemberHandler HandlerContext
 // Handle retrieves a service member in the system belonging to the logged in user given service member ID
 func (h ShowServiceMemberHandler) Handle(params servicememberop.ShowServiceMemberParams) middleware.Responder {
 	var response middleware.Responder
-
-	user, err := models.GetUserFromRequest(h.db, params.HTTPRequest)
-	if err != nil {
-		response = servicememberop.NewShowServiceMemberUnauthorized()
-		return response
-	}
+	// User should always be populated by middleware
+	user, _ := context.GetUser(params.HTTPRequest.Context())
 
 	serviceMemberID, err := uuid.FromString(params.ServiceMemberID.String())
 	if err != nil {
@@ -130,12 +124,9 @@ type PatchServiceMemberHandler HandlerContext
 // Handle ... patches a new ServiceMember from a request payload
 func (h PatchServiceMemberHandler) Handle(params servicememberop.PatchServiceMemberParams) middleware.Responder {
 	var response middleware.Responder
-	// Get user id from context
-	user, err := models.GetUserFromRequest(h.db, params.HTTPRequest)
-	if err != nil {
-		response = servicememberop.NewPatchServiceMemberUnauthorized()
-		return response
-	}
+	// User should always be populated by middleware
+	user, _ := context.GetUser(params.HTTPRequest.Context())
+
 	serviceMemberID, err := uuid.FromString(params.ServiceMemberID.String())
 	if err != nil {
 		response = servicememberop.NewPatchServiceMemberBadRequest()

--- a/pkg/handlers/signed_certifications.go
+++ b/pkg/handlers/signed_certifications.go
@@ -18,10 +18,8 @@ type CreateSignedCertificationHandler HandlerContext
 // Handle creates a new SignedCertification from a request payload
 func (h CreateSignedCertificationHandler) Handle(params certop.CreateSignedCertificationParams) middleware.Responder {
 	var response middleware.Responder
-	user, ok := context.GetUser(params.HTTPRequest.Context())
-	if !ok {
-		h.logger.Error("No User, this should never happen.")
-	}
+	// User should always be populated by middleware
+	user, _ := context.GetUser(params.HTTPRequest.Context())
 
 	moveID, err := uuid.FromString(params.MoveID.String())
 	if err != nil {

--- a/pkg/handlers/signed_certifications.go
+++ b/pkg/handlers/signed_certifications.go
@@ -7,6 +7,7 @@ import (
 	"github.com/gobuffalo/uuid"
 	"go.uber.org/zap"
 
+	"github.com/transcom/mymove/pkg/auth/context"
 	certop "github.com/transcom/mymove/pkg/gen/internalapi/internaloperations/certification"
 	"github.com/transcom/mymove/pkg/models"
 )
@@ -17,10 +18,9 @@ type CreateSignedCertificationHandler HandlerContext
 // Handle creates a new SignedCertification from a request payload
 func (h CreateSignedCertificationHandler) Handle(params certop.CreateSignedCertificationParams) middleware.Responder {
 	var response middleware.Responder
-	user, err := models.GetUserFromRequest(h.db, params.HTTPRequest)
-	if err != nil {
-		response = certop.NewCreateSignedCertificationUnauthorized()
-		return response
+	user, ok := context.GetUser(params.HTTPRequest.Context())
+	if !ok {
+		h.logger.Error("No User, this should never happen.")
 	}
 
 	moveID, err := uuid.FromString(params.MoveID.String())

--- a/pkg/models/user.go
+++ b/pkg/models/user.go
@@ -2,7 +2,6 @@ package models
 
 import (
 	"encoding/json"
-	"net/http"
 	"time"
 
 	"github.com/gobuffalo/pop"
@@ -11,8 +10,6 @@ import (
 	"github.com/gobuffalo/validate/validators"
 	"github.com/markbates/goth"
 	"github.com/pkg/errors"
-
-	"github.com/transcom/mymove/pkg/auth/context"
 )
 
 // User is an entity with a registered uuid and email at login.gov
@@ -64,22 +61,6 @@ func (u *User) ValidateUpdate(tx *pop.Connection) (*validate.Errors, error) {
 func GetUserByID(db *pop.Connection, id uuid.UUID) (User, error) {
 	user := User{}
 	err := db.Find(&user, id)
-	return user, err
-}
-
-// GetUserFromRequest extracts the user model from the request context's user ID
-func GetUserFromRequest(db *pop.Connection, r *http.Request) (user User, err error) {
-	userID, ok := context.GetUserID(r.Context())
-	if !ok {
-		err = errors.New("Failed to fetch user_id from context")
-		return
-	}
-
-	user, err = GetUserByID(db, userID)
-	if err != nil {
-		return
-	}
-
 	return user, err
 }
 


### PR DESCRIPTION
## Description

Based on @ntwyman's comment in #344, and our subsequent conversation, I made this PR to populate the `User` model onto the request context in middleware instead of doing this in our request handlers. This also removes auth protections from our API docs à la #277.

## Code Review Verification Steps

* [x] All tests pass.
* [x] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/blob/master/docs/backend.md#logging)
* [x] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* [x] There are no [aXe](https://www.deque.com/products/aXe/) warnings for UI.
* [x] This works in IE.
* [x] Any new third party client side dependencies (e.g., login.gov, google analytics, CDN libraries, etc.) have been communicated to @willowbl00.
* [x] Request review from a member of a different team.
* [ ] (TRIAL) Have the Pivotal acceptance criteria been met for this change?