### PR TITLE
Fetch shorthaul rates from DB [delivers #156586442]

### DIFF
--- a/pkg/models/tariff400ng_shorthaul_rate.go
+++ b/pkg/models/tariff400ng_shorthaul_rate.go
@@ -61,3 +61,19 @@ func (t *Tariff400ngShorthaulRate) ValidateCreate(tx *pop.Connection) (*validate
 func (t *Tariff400ngShorthaulRate) ValidateUpdate(tx *pop.Connection) (*validate.Errors, error) {
 	return validate.NewErrors(), nil
 }
+
+// FetchShorthaulRateCents returns the shorthaul rate for a given Centumweight-Miles
+// (cwtMiles is a unit capturing the movement of 100lbs by 1 mile.) The value returned
+// is in cents of 1 USD.
+func FetchShorthaulRateCents(tx *pop.Connection, cwtMiles int, date Time.time) (rateCents int, err error) {
+	sql = `SELECT rate_cents FROM tariff400ng_shorthaul_rates WHERE
+		cwt_mi_lower <= $2 AND $2 < cwt_mi_upper AND
+		effective_date_lower <= $3 AND $3 < effective_date_upper`
+
+	err := tx.RawQuery(sql, cwtMiles, date).First(&rateCents)
+	if err != nil {
+		return 0, errors.Wrap(err, "error fetching shorthaul rate")
+	}
+
+	return rateCents
+}

--- a/pkg/models/tariff400ng_shorthaul_rate.go
+++ b/pkg/models/tariff400ng_shorthaul_rate.go
@@ -69,9 +69,14 @@ func (t *Tariff400ngShorthaulRate) ValidateUpdate(tx *pop.Connection) (*validate
 func FetchShorthaulRateCents(tx *pop.Connection, cwtMiles int, date time.Time) (rateCents int, err error) {
 	sh := Tariff400ngShorthaulRates{}
 
-	sql := `SELECT rate_cents FROM tariff400ng_shorthaul_rates WHERE
-		cwt_mi_lower <= $2 AND $2 < cwt_mi_upper AND
-		effective_date_lower <= $3 AND $3 < effective_date_upper`
+	sql := `SELECT
+		rate_cents
+	FROM
+		tariff400ng_shorthaul_rates
+	WHERE
+		cwt_miles_lower <= $1 AND $1 < cwt_miles_upper
+	AND
+		effective_date_lower <= $2 AND $2 < effective_date_upper`
 
 	err = tx.RawQuery(sql, cwtMiles, date).All(&sh)
 	if err != nil {

--- a/pkg/models/tariff400ng_shorthaul_rate_test.go
+++ b/pkg/models/tariff400ng_shorthaul_rate_test.go
@@ -136,7 +136,7 @@ func (suite *ModelSuite) Test_FetchShorthaulRateCents() {
 	if err != nil {
 		t.Fatalf("Unable to query shorthaul rate: %s", err)
 	}
-	if rate != rate1 {
+	if rate != rate2 {
 		t.Errorf("Incorrect shorthaul rate. Got: %d, expected %d", rate, rate2)
 	}
 
@@ -145,7 +145,7 @@ func (suite *ModelSuite) Test_FetchShorthaulRateCents() {
 	if err != nil {
 		t.Fatalf("Unable to query shorthaul rate: %s", err)
 	}
-	if rate != rate1 {
+	if rate != rate3 {
 		t.Errorf("Incorrect shorthaul rate. Got: %d, expected %d", rate, rate3)
 	}
 

--- a/pkg/models/tariff400ng_shorthaul_rate_test.go
+++ b/pkg/models/tariff400ng_shorthaul_rate_test.go
@@ -111,7 +111,7 @@ func (suite *ModelSuite) Test_FetchShorthaulRateCents() {
 		t.Errorf("Incorrect shorthaul rate. Got: %d, expected %d", rate, rate1)
 	}
 
-	// Test the lower bound of the CwtMiles
+	// Test the upper bound of the CwtMiles
 	rate2 := 200
 	sh2 := Tariff400ngShorthaulRate{
 		CwtMilesLower:      2000,
@@ -122,7 +122,7 @@ func (suite *ModelSuite) Test_FetchShorthaulRateCents() {
 	}
 	suite.mustSave(&sh2)
 
-	rate, err = FetchShorthaulRateCents(suite.db, 2000, testdatagen.DateInsidePeakRateCycle)
+	rate, err = FetchShorthaulRateCents(suite.db, 2999, testdatagen.DateInsidePeakRateCycle)
 	if err != nil {
 		t.Fatalf("Unable to query shorthaul rate: %s", err)
 	}

--- a/pkg/models/tariff400ng_shorthaul_rate_test.go
+++ b/pkg/models/tariff400ng_shorthaul_rate_test.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	. "github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/testdatagen"
 )
 
 func (suite *ModelSuite) Test_ShorthaulRateEffectiveDateValidation() {
@@ -86,4 +87,66 @@ func (suite *ModelSuite) Test_ShorthaulRateCreateAndSave() {
 	}
 
 	suite.mustSave(&validShorthaulRate)
+}
+
+func (suite *ModelSuite) Test_FetchShorthaulRateCents() {
+	t := suite.T()
+
+	rate1 := 100
+	sh1 := Tariff400ngShorthaulRate{
+		CwtMilesLower:      1000,
+		CwtMilesUpper:      2000,
+		RateCents:          rate1,
+		EffectiveDateLower: testdatagen.PeakRateCycleStart,
+		EffectiveDateUpper: testdatagen.PeakRateCycleEnd,
+	}
+	suite.mustSave(&sh1)
+
+	rate2 := 200
+	sh2 := Tariff400ngShorthaulRate{
+		CwtMilesLower:      2000,
+		CwtMilesUpper:      3000,
+		RateCents:          rate2,
+		EffectiveDateLower: testdatagen.PeakRateCycleStart,
+		EffectiveDateUpper: testdatagen.PeakRateCycleEnd,
+	}
+	suite.mustSave(&sh2)
+
+	rate3 := 300
+	sh3 := Tariff400ngShorthaulRate{
+		CwtMilesLower:      2000,
+		CwtMilesUpper:      3000,
+		RateCents:          rate3,
+		EffectiveDateLower: testdatagen.NonPeakRateCycleStart,
+		EffectiveDateUpper: testdatagen.NonPeakRateCycleEnd,
+	}
+	suite.mustSave(&sh3)
+
+	// Test the lower bound of a cwtMile range
+	rate, err := FetchShorthaulRateCents(suite.db, 1000, testdatagen.DateInsidePeakRateCycle)
+	if err != nil {
+		t.Fatalf("Unable to query shorthaul rate: %s", err)
+	}
+	if rate != rate1 {
+		t.Errorf("Incorrect shorthaul rate. Got: %d, expected %d", rate, rate1)
+	}
+
+	// Test the upper bound of a cwtMile range
+	rate, err = FetchShorthaulRateCents(suite.db, 2000, testdatagen.DateInsidePeakRateCycle)
+	if err != nil {
+		t.Fatalf("Unable to query shorthaul rate: %s", err)
+	}
+	if rate != rate1 {
+		t.Errorf("Incorrect shorthaul rate. Got: %d, expected %d", rate, rate2)
+	}
+
+	// Test date matching
+	rate, err = FetchShorthaulRateCents(suite.db, 2000, testdatagen.DateOutsidePeakRateCycle)
+	if err != nil {
+		t.Fatalf("Unable to query shorthaul rate: %s", err)
+	}
+	if rate != rate1 {
+		t.Errorf("Incorrect shorthaul rate. Got: %d, expected %d", rate, rate3)
+	}
+
 }

--- a/pkg/rateengine/linehaul.go
+++ b/pkg/rateengine/linehaul.go
@@ -49,19 +49,14 @@ func (re *RateEngine) linehaulFactors(cwt int, zip3 int, date time.Time) (lineha
 }
 
 // Determine Shorthaul (SH) Charge (ONLY applies if shipment moves 800 miles and less)
-func (re *RateEngine) shorthaulCharge(mileage int, cwt int, date Time.time) (shorthaulChargeCents int, err error) {
+func (re *RateEngine) shorthaulCharge(mileage int, cwt int, date time.Time) (shorthaulChargeCents int, err error) {
 	if mileage >= 800 {
 		return 0, nil
 	}
 
 	cwtMiles := mileage * cwt
-	// TODO: shorthaulChargeCents will be a lookup
-	shorthaulChargeCents = models.Tariff400ngShorthaulRate(re.db, cwtMiles, date)
-	if shorthaulChargeCents == 0 {
-		err = errors.New("Oops determineShorthaulCharge")
-	} else {
-		err = nil
-	}
+	shorthaulChargeCents, err = models.FetchShorthaulRateCents(re.db, cwtMiles, date)
+
 	return shorthaulChargeCents, err
 }
 

--- a/pkg/rateengine/linehaul.go
+++ b/pkg/rateengine/linehaul.go
@@ -4,8 +4,6 @@ import (
 	"errors"
 	"time"
 
-	"go.uber.org/zap"
-
 	"github.com/transcom/mymove/pkg/models"
 	"go.uber.org/zap"
 )

--- a/pkg/rateengine/linehaul.go
+++ b/pkg/rateengine/linehaul.go
@@ -56,7 +56,7 @@ func (re *RateEngine) shorthaulCharge(mileage int, cwt int) (shorthaulChargeCent
 
 	cwtMiles := mileage * cwt
 	// TODO: shorthaulChargeCents will be a lookup
-	shorthaulChargeCents = cwtMiles
+	shorthaulChargeCents = models.Tariff400ngShorthaulRate(re.db, cwtMiles, date)
 	if shorthaulChargeCents == 0 {
 		err = errors.New("Oops determineShorthaulCharge")
 	} else {

--- a/pkg/rateengine/linehaul.go
+++ b/pkg/rateengine/linehaul.go
@@ -2,16 +2,14 @@ package rateengine
 
 import (
 	"errors"
-	"fmt"
 	"time"
 
 	"github.com/transcom/mymove/pkg/models"
+	"go.uber.org/zap"
 )
 
 func (re *RateEngine) determineMileage(originZip int, destinationZip int) (mileage int, err error) {
 	// TODO (Rebecca): make a proper error
-	fmt.Print(originZip)
-	fmt.Print(destinationZip)
 	// TODO (Rebecca): Lookup originZip to destinationZip mileage
 	mileage = 1000
 	if mileage != 1000 {
@@ -53,6 +51,8 @@ func (re *RateEngine) shorthaulCharge(mileage int, cwt int, date time.Time) (sho
 	if mileage >= 800 {
 		return 0, nil
 	}
+	re.logger.Debug("Shipment qualifies for shorthaul fee",
+		zap.Int("miles", mileage))
 
 	cwtMiles := mileage * cwt
 	shorthaulChargeCents, err = models.FetchShorthaulRateCents(re.db, cwtMiles, date)

--- a/pkg/rateengine/linehaul.go
+++ b/pkg/rateengine/linehaul.go
@@ -49,7 +49,7 @@ func (re *RateEngine) linehaulFactors(cwt int, zip3 int, date time.Time) (lineha
 }
 
 // Determine Shorthaul (SH) Charge (ONLY applies if shipment moves 800 miles and less)
-func (re *RateEngine) shorthaulCharge(mileage int, cwt int) (shorthaulChargeCents int, err error) {
+func (re *RateEngine) shorthaulCharge(mileage int, cwt int, date Time.time) (shorthaulChargeCents int, err error) {
 	if mileage >= 800 {
 		return 0, nil
 	}
@@ -73,7 +73,7 @@ func (re *RateEngine) linehaulChargeTotal(weight int, originZip int, destination
 	baseLinehaulChargeCents, err := re.baseLinehaul(mileage, cwt)
 	originLinehaulFactorCents, err := re.linehaulFactors(cwt, originZip, date)
 	destinationLinehaulFactorCents, err := re.linehaulFactors(cwt, destinationZip, date)
-	shorthaulChargeCents, err := re.shorthaulCharge(mileage, cwt)
+	shorthaulChargeCents, err := re.shorthaulCharge(mileage, cwt, date)
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/rateengine/linehaul_test.go
+++ b/pkg/rateengine/linehaul_test.go
@@ -78,9 +78,9 @@ func (suite *RateEngineSuite) Test_CheckShorthaulCharge() {
 	cwt := 40
 	rate := 5656
 
-	sh := Tariff400ngShorthaulRate{
+	sh := models.Tariff400ngShorthaulRate{
 		CwtMilesLower:      1,
-		CwtMilesUpper:      800,
+		CwtMilesUpper:      50000,
 		RateCents:          rate,
 		EffectiveDateLower: testdatagen.PeakRateCycleStart,
 		EffectiveDateUpper: testdatagen.PeakRateCycleEnd,

--- a/pkg/rateengine/linehaul_test.go
+++ b/pkg/rateengine/linehaul_test.go
@@ -76,11 +76,20 @@ func (suite *RateEngineSuite) Test_CheckShorthaulCharge() {
 	engine := NewRateEngine(suite.db, suite.logger)
 	mileage := 799
 	cwt := 40
+	rate := 5656
 
-	shc, _ := engine.shorthaulCharge(mileage, cwt)
-	expected := 31960
-	if shc != expected {
-		t.Errorf("Shorthaul charge should have been %d, but is %d.", expected, shc)
+	sh := Tariff400ngShorthaulRate{
+		CwtMilesLower:      1,
+		CwtMilesUpper:      800,
+		RateCents:          rate,
+		EffectiveDateLower: testdatagen.PeakRateCycleStart,
+		EffectiveDateUpper: testdatagen.PeakRateCycleEnd,
+	}
+	suite.mustSave(&sh)
+
+	shc, _ := engine.shorthaulCharge(mileage, cwt, testdatagen.DateInsidePeakRateCycle)
+	if shc != rate {
+		t.Errorf("Shorthaul charge should have been %d, but is %d.", rate, shc)
 	}
 }
 

--- a/pkg/rateengine/rateengine.go
+++ b/pkg/rateengine/rateengine.go
@@ -40,7 +40,7 @@ func (re *RateEngine) computePPM(weight int, originZip int, destinationZip int, 
 		re.logger.Error("Failed to determine destination linehaul factor", zap.Error(err))
 		return 0, err
 	}
-	shorthaulChargeCents, err := re.shorthaulCharge(mileage, cwt)
+	shorthaulChargeCents, err := re.shorthaulCharge(mileage, cwt, date)
 	if err != nil {
 		re.logger.Error("Failed to determine shorthaul charge", zap.Error(err))
 		return 0, err


### PR DESCRIPTION
## Description

The Linehaul calculations had just been using a static value for "shorthaul" rates. This change looks up the appropriate rate from the database and returns it in cents.

## Code Review Verification Steps

* [ ] All tests pass.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/blob/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* [ ] (TRIAL) Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/156586442) for this changem