### PR TITLE
Fixing uncaught errors in Rate Engine [finishes #156588854]

### DIFF
--- a/pkg/models/tariff400ng_linehaul_rate.go
+++ b/pkg/models/tariff400ng_linehaul_rate.go
@@ -93,7 +93,8 @@ func FetchBaseLinehaulRate(tx *pop.Connection, mileage int, cwt int, date time.T
 		return 0, fmt.Errorf("Error fetching linehaul rate: %s", err)
 	}
 	if len(linehaulRates) != 1 {
-		return 0, fmt.Errorf("Found too few/many linehaul rates for parameters: %v, %v, %v", mileage, cwt, date)
+		return 0, fmt.Errorf("Wanted 1 rate, found %d rates for parameters: %v, %v, %v",
+			len(linehaulRates), mileage, cwt, date)
 	}
 
 	return linehaulRates[0], err

--- a/pkg/models/tariff400ng_service_area.go
+++ b/pkg/models/tariff400ng_service_area.go
@@ -42,7 +42,7 @@ func (t *Tariff400ngServiceArea) Validate(tx *pop.Connection) (*validate.Errors,
 func FetchTariff400ngServiceAreaForZip3(db *pop.Connection, zip3 int) (Tariff400ngServiceArea, error) {
 	serviceArea := Tariff400ngServiceArea{}
 	err := db.Q().LeftJoin("tariff400ng_zip3s", "tariff400ng_zip3s.service_area=tariff400ng_service_areas.service_area").
-		Where(`tariff400ng_zip3s.zip3 = ?`, zip3).First(&serviceArea)
+		Where(`tariff400ng_zip3s.zip3 = $1`, zip3).First(&serviceArea)
 	if err != nil {
 		return serviceArea, errors.Wrap(err, "could not find a matching Tariff400ngServiceArea")
 	}

--- a/pkg/rateengine/linehaul.go
+++ b/pkg/rateengine/linehaul.go
@@ -33,11 +33,11 @@ func (re *RateEngine) baseLinehaul(mileage int, cwt int, date time.Time) (baseLi
 func (re *RateEngine) linehaulFactors(cwt int, zip3 int, date time.Time) (linehaulFactorCents int, err error) {
 	serviceArea, err := models.FetchTariff400ngServiceAreaForZip3(re.db, zip3)
 	if err != nil {
-		return 0.0, err
+		return 0, err
 	}
 	linehaulFactorCents, err = models.FetchTariff400ngLinehaulFactor(re.db, serviceArea.ServiceArea, date)
 	if err != nil {
-		return 0.0, err
+		return 0, err
 	}
 	return cwt * linehaulFactorCents, nil
 }
@@ -65,9 +65,14 @@ func (re *RateEngine) linehaulChargeTotal(weight int, originZip int, destination
 	if err != nil {
 		return 0, err
 	}
-
 	originLinehaulFactorCents, err := re.linehaulFactors(cwt, originZip, date)
+	if err != nil {
+		return 0, err
+	}
 	destinationLinehaulFactorCents, err := re.linehaulFactors(cwt, destinationZip, date)
+	if err != nil {
+		return 0, err
+	}
 	shorthaulChargeCents, err := re.shorthaulCharge(mileage, cwt, date)
 	if err != nil {
 		return 0, err

--- a/pkg/rateengine/linehaul.go
+++ b/pkg/rateengine/linehaul.go
@@ -77,5 +77,14 @@ func (re *RateEngine) linehaulChargeTotal(weight int, originZip int, destination
 	if err != nil {
 		return 0, err
 	}
-	return int(baseLinehaulChargeCents + originLinehaulFactorCents + destinationLinehaulFactorCents + shorthaulChargeCents), err
+
+	linehaulChargeCents = baseLinehaulChargeCents + originLinehaulFactorCents + destinationLinehaulFactorCents + shorthaulChargeCents
+	re.logger.Info("Linehaul charge total calculated",
+		zap.Int("linehaul total", linehaulChargeCents),
+		zap.Int("linehaul", baseLinehaulChargeCents),
+		zap.Int("origin lh factor", originLinehaulFactorCents),
+		zap.Int("destination lh factor", destinationLinehaulFactorCents),
+		zap.Int("shorthaul", shorthaulChargeCents))
+
+	return linehaulChargeCents, err
 }

--- a/pkg/rateengine/linehaul_test.go
+++ b/pkg/rateengine/linehaul_test.go
@@ -146,7 +146,47 @@ func (suite *RateEngineSuite) Test_CheckLinehaulChargeTotal() {
 
 	suite.mustSave(&newBaseLinehaul)
 
-	linehaulChargeTotal, err := engine.linehaulChargeTotal(2000, 395, 336, testdatagen.RateEngineDate)
+	zipAustin := models.Tariff400ngZip3{
+		Zip3:          787,
+		BasepointCity: "Austin",
+		State:         "TX",
+		ServiceArea:   1,
+		RateArea:      "1",
+		Region:        1,
+	}
+	suite.mustSave(&zipAustin)
+
+	zipSanFrancisco := models.Tariff400ngZip3{
+		Zip3:          941,
+		BasepointCity: "San Francisco",
+		State:         "CA",
+		ServiceArea:   2,
+		RateArea:      "2",
+		Region:        2,
+	}
+	suite.mustSave(&zipSanFrancisco)
+
+	sa1 := models.Tariff400ngServiceArea{
+		Name:               "Austin",
+		ServiceChargeCents: 100,
+		ServiceArea:        1,
+		LinehaulFactor:     1,
+		EffectiveDateLower: testdatagen.PeakRateCycleStart,
+		EffectiveDateUpper: testdatagen.PeakRateCycleEnd,
+	}
+	suite.mustSave(&sa1)
+
+	sa2 := models.Tariff400ngServiceArea{
+		Name:               "SF",
+		ServiceChargeCents: 200,
+		ServiceArea:        2,
+		LinehaulFactor:     1,
+		EffectiveDateLower: testdatagen.PeakRateCycleStart,
+		EffectiveDateUpper: testdatagen.PeakRateCycleEnd,
+	}
+	suite.mustSave(&sa2)
+
+	linehaulChargeTotal, err := engine.linehaulChargeTotal(2000, 787, 941, testdatagen.DateInsidePeakRateCycle)
 	if err != nil {
 		t.Error("Unable to determine linehaulChargeTotal: ", err)
 	}

--- a/pkg/rateengine/nonlinehaul.go
+++ b/pkg/rateengine/nonlinehaul.go
@@ -43,8 +43,17 @@ func (re *RateEngine) fullUnpackCents(cwt int, zip3 int) (int, error) {
 func (re *RateEngine) nonLinehaulChargeTotalCents(weight int, originZip int, destinationZip int) (int, error) {
 	cwt := re.determineCWT(weight)
 	originServiceFee, err := re.serviceFeeCents(cwt, originZip)
+	if err != nil {
+		return 0, err
+	}
 	destinationServiceFee, err := re.serviceFeeCents(cwt, destinationZip)
+	if err != nil {
+		return 0, err
+	}
 	pack, err := re.fullPackCents(cwt, originZip)
+	if err != nil {
+		return 0, err
+	}
 	unpack, err := re.fullUnpackCents(cwt, destinationZip)
 	if err != nil {
 		return 0, err

--- a/pkg/rateengine/nonlinehaul.go
+++ b/pkg/rateengine/nonlinehaul.go
@@ -2,6 +2,7 @@ package rateengine
 
 import (
 	"github.com/transcom/mymove/pkg/models"
+	"go.uber.org/zap"
 )
 
 func (re *RateEngine) serviceFeeCents(cwt int, zip3 int) (int, error) {
@@ -59,5 +60,12 @@ func (re *RateEngine) nonLinehaulChargeTotalCents(weight int, originZip int, des
 		return 0, err
 	}
 	subTotal := originServiceFee + destinationServiceFee + pack + unpack
+
+	re.logger.Info("Non-Linehaul charge total calculated",
+		zap.Int("origin service fee", originServiceFee),
+		zap.Int("destination service fee", destinationServiceFee),
+		zap.Int("pack fee", pack),
+		zap.Int("unpack fee", unpack))
+
 	return subTotal, nil
 }

--- a/pkg/rateengine/rateengine.go
+++ b/pkg/rateengine/rateengine.go
@@ -66,9 +66,27 @@ func (re *RateEngine) computePPM(weight int, originZip int, destinationZip int, 
 		re.logger.Error("Failed to determine full unpack cost", zap.Error(err))
 		return 0, err
 	}
-	ppmBestValue := int(float64(baseLinehaulChargeCents+originLinehaulFactorCents+destinationLinehaulFactorCents+shorthaulChargeCents+originServiceFee+destinationServiceFee+pack+unpack) * inverseDiscount)
+	ppmSubtotal := baseLinehaulChargeCents + originLinehaulFactorCents + destinationLinehaulFactorCents +
+		shorthaulChargeCents + originServiceFee + destinationServiceFee + pack + unpack
+	ppmBestValue := int(float64(ppmSubtotal) * inverseDiscount)
+
 	// PPMs only pay 95% of the best value
 	ppmPayback := int(float64(ppmBestValue) * .95)
+
+	re.logger.Info("PPM compensation total calculated",
+		zap.Int("PPM compensation total", ppmPayback),
+		zap.Int("PPM subtotal", ppmSubtotal),
+		zap.Float64("inverse discount", inverseDiscount),
+		zap.Int("base linehaul", baseLinehaulChargeCents),
+		zap.Int("origin lh factor", originLinehaulFactorCents),
+		zap.Int("destination lh factor", destinationLinehaulFactorCents),
+		zap.Int("shorthaul", shorthaulChargeCents),
+		zap.Int("origin service fee", originServiceFee),
+		zap.Int("destination service fee", destinationServiceFee),
+		zap.Int("pack fee", pack),
+		zap.Int("unpack fee", unpack),
+	)
+
 	return ppmPayback, nil
 }
 


### PR DESCRIPTION
## Description

There are two functions in `linehaul.go` and `nonlinehaul.go` that add up all of the constituent parts to generate the [non]linehaul totals. They were dropping a few `err`s on the floor, which is bad news. I added some error handling, which turned up some failed tests. So I fixed the tests.

## Code Review Verification Steps

* [ ] All tests pass.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/blob/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* [ ] Request review from a member of a different team.
* [ ] (TRIAL) Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/156588854) for this change