### PR TITLE
WIP Functions that return rate area and region [delivers #156635384]

### DIFF
--- a/migrations/20180410193716_store_zips_as_strings.down.sql
+++ b/migrations/20180410193716_store_zips_as_strings.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE tariff400ng_zip3s ALTER COLUMN zip3 TYPE integer USING (zip3::integer);
+ALTER TABLE tariff400ng_zip5_rate_areas ALTER COLUMN zip5 TYPE integer USING (zip5::integer);

--- a/migrations/20180410193716_store_zips_as_strings.up.sql
+++ b/migrations/20180410193716_store_zips_as_strings.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE tariff400ng_zip3s ALTER COLUMN zip3 TYPE varchar(3) USING to_char(zip3, 'fm000');
+ALTER TABLE tariff400ng_zip5_rate_areas ALTER COLUMN zip5 TYPE varchar(5) USING to_char(zip5, 'fm00000');

--- a/pkg/models/tariff400ng_zip3.go
+++ b/pkg/models/tariff400ng_zip3.go
@@ -2,11 +2,13 @@ package models
 
 import (
 	"encoding/json"
+	"time"
+
 	"github.com/gobuffalo/pop"
 	"github.com/gobuffalo/uuid"
 	"github.com/gobuffalo/validate"
 	"github.com/gobuffalo/validate/validators"
-	"time"
+	"github.com/pkg/errors"
 )
 
 // Tariff400ngZip3 is the first 3 numbers of a zip for Tariff400NG calculations
@@ -14,7 +16,7 @@ type Tariff400ngZip3 struct {
 	ID            uuid.UUID `json:"id" db:"id"`
 	CreatedAt     time.Time `json:"created_at" db:"created_at"`
 	UpdatedAt     time.Time `json:"updated_at" db:"updated_at"`
-	Zip3          int       `json:"zip3" db:"zip3"`
+	Zip3          string    `json:"zip3" db:"zip3"`
 	BasepointCity string    `json:"basepoint_city" db:"basepoint_city"`
 	State         string    `json:"state" db:"state"`
 	ServiceArea   int       `json:"service_area" db:"service_area"`
@@ -41,7 +43,7 @@ func (t Tariff400ngZip3s) String() string {
 // This method is not required and may be deleted.
 func (t *Tariff400ngZip3) Validate(tx *pop.Connection) (*validate.Errors, error) {
 	return validate.Validate(
-		&validators.IntIsPresent{Field: t.Zip3, Name: "Zip3"},
+		&validators.StringIsPresent{Field: t.Zip3, Name: "Zip3"},
 		&validators.StringIsPresent{Field: t.BasepointCity, Name: "BasepointCity"},
 		&validators.StringIsPresent{Field: t.State, Name: "State"},
 		&validators.IntIsPresent{Field: t.ServiceArea, Name: "ServiceArea"},
@@ -50,14 +52,40 @@ func (t *Tariff400ngZip3) Validate(tx *pop.Connection) (*validate.Errors, error)
 	), nil
 }
 
-// ValidateCreate gets run every time you call "pop.ValidateAndCreate" method.
-// This method is not required and may be deleted.
-func (t *Tariff400ngZip3) ValidateCreate(tx *pop.Connection) (*validate.Errors, error) {
-	return validate.NewErrors(), nil
+// FetchRateAreaForZip5 returns the rate area for a specified zip5.
+func FetchRateAreaForZip5(db *pop.Connection, zip5 string) (string, error) {
+	if len(zip5) != 5 {
+		return "", errors.Errorf("zip5 must have a length of 5, got '%s'", zip5)
+	}
+	zip3 := zip5[0:3]
+
+	tariffZip3 := Tariff400ngZip3{}
+	if err := db.Where("zip3 = ?", zip3).First(&tariffZip3); err != nil {
+		return "", errors.Wrapf(err, "could not find zip3 for %s", zip3)
+	}
+
+	if tariffZip3.RateArea == "ZIP" {
+		zip5RateArea := Tariff400ngZip5RateArea{}
+		if err := db.Where("zip5 = ?", zip5).First(&zip5RateArea); err != nil {
+			return "", errors.Wrapf(err, "could not find zip5_rate_area for %s", zip5)
+		}
+		return zip5RateArea.RateArea, nil
+	}
+
+	return tariffZip3.RateArea, nil
 }
 
-// ValidateUpdate gets run every time you call "pop.ValidateAndUpdate" method.
-// This method is not required and may be deleted.
-func (t *Tariff400ngZip3) ValidateUpdate(tx *pop.Connection) (*validate.Errors, error) {
-	return validate.NewErrors(), nil
+// FetchRegionForZip5 returns the region for a specified zip5.
+func FetchRegionForZip5(db *pop.Connection, zip5 string) (int, error) {
+	if len(zip5) != 5 {
+		return 0, errors.Errorf("zip5 must have a length of 5, got '%s'", zip5)
+	}
+	zip3 := zip5[0:3]
+
+	tariffZip3 := Tariff400ngZip3{}
+	if err := db.Where("zip3 = ?", zip3).First(&tariffZip3); err != nil {
+		return 0, errors.Wrapf(err, "could not find zip3 for %s", zip3)
+	}
+
+	return tariffZip3.Region, nil
 }

--- a/pkg/models/tariff400ng_zip3_test.go
+++ b/pkg/models/tariff400ng_zip3_test.go
@@ -6,7 +6,7 @@ import (
 
 func (suite *ModelSuite) Test_Zip3Validation() {
 	validZip3 := Tariff400ngZip3{
-		Zip3:          139,
+		Zip3:          "139",
 		BasepointCity: "Dogtown",
 		State:         "NY",
 		ServiceArea:   11,
@@ -18,7 +18,7 @@ func (suite *ModelSuite) Test_Zip3Validation() {
 	suite.verifyValidationErrors(&validZip3, expErrors)
 
 	invalidZip3 := Tariff400ngZip3{
-		Zip3:          291,
+		Zip3:          "291",
 		BasepointCity: "",
 		State:         "NY",
 		ServiceArea:   11,
@@ -35,7 +35,7 @@ func (suite *ModelSuite) Test_Zip3Validation() {
 func (suite *ModelSuite) Test_Zip3CreateAndSave() {
 
 	validZip3 := Tariff400ngZip3{
-		Zip3:          720,
+		Zip3:          "720",
 		BasepointCity: "Dogtown",
 		State:         "NY",
 		ServiceArea:   384,
@@ -44,4 +44,83 @@ func (suite *ModelSuite) Test_Zip3CreateAndSave() {
 	}
 
 	suite.mustSave(&validZip3)
+}
+
+func (suite *ModelSuite) Test_FetchRateAreaForZip5() {
+	t := suite.T()
+
+	zip3 := Tariff400ngZip3{
+		Zip3:          "720",
+		BasepointCity: "Dogtown",
+		State:         "NY",
+		ServiceArea:   384,
+		RateArea:      "13",
+		Region:        4,
+	}
+
+	suite.mustSave(&zip3)
+
+	rateArea, err := FetchRateAreaForZip5(suite.db, "72014")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if rateArea != "13" {
+		t.Errorf("wrong rateArea: expected 13, got %s", rateArea)
+	}
+}
+
+func (suite *ModelSuite) Test_FetchRateAreaForZip5UsingZip5sTable() {
+	t := suite.T()
+
+	zip3 := Tariff400ngZip3{
+		Zip3:          "720",
+		BasepointCity: "Dogtown",
+		State:         "NY",
+		ServiceArea:   384,
+		RateArea:      "ZIP",
+		Region:        4,
+	}
+
+	suite.mustSave(&zip3)
+
+	zip5RateArea := Tariff400ngZip5RateArea{
+		Zip5:     "72014",
+		RateArea: "48",
+	}
+
+	suite.mustSave(&zip5RateArea)
+
+	rateArea, err := FetchRateAreaForZip5(suite.db, "72014")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if rateArea != "48" {
+		t.Errorf("wrong rateArea: expected 13, got %s", rateArea)
+	}
+}
+
+func (suite *ModelSuite) Test_FetchRegionForZip5() {
+	t := suite.T()
+
+	zip3 := Tariff400ngZip3{
+		Zip3:          "720",
+		BasepointCity: "Dogtown",
+		State:         "NY",
+		ServiceArea:   384,
+		RateArea:      "13",
+		Region:        4,
+	}
+
+	suite.mustSave(&zip3)
+
+	region, err := FetchRegionForZip5(suite.db, "72014")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if region != 4 {
+		t.Errorf("wrong region: expected 4, got %d", region)
+	}
 }

--- a/pkg/models/tariff400ng_zip5_rate_area.go
+++ b/pkg/models/tariff400ng_zip5_rate_area.go
@@ -1,0 +1,40 @@
+package models
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/gobuffalo/pop"
+	"github.com/gobuffalo/uuid"
+	"github.com/gobuffalo/validate"
+)
+
+// Tariff400ngZip5RateArea repersents the mapping from a full 5-digit zipcode to a
+// specific rate area. This is only needed for a small subset of zip3s.
+type Tariff400ngZip5RateArea struct {
+	ID        uuid.UUID `json:"id" db:"id"`
+	CreatedAt time.Time `json:"created_at" db:"created_at"`
+	UpdatedAt time.Time `json:"updated_at" db:"updated_at"`
+	RateArea  string    `json:"rate_area" db:"rate_area"`
+	Zip5      string    `json:"zip5" db:"zip5"`
+}
+
+// String is not required by pop and may be deleted
+func (t Tariff400ngZip5RateArea) String() string {
+	jt, _ := json.Marshal(t)
+	return string(jt)
+}
+
+// Tariff400ngZip5RateAreas is not required by pop and may be deleted
+type Tariff400ngZip5RateAreas []Tariff400ngZip5RateArea
+
+// String is not required by pop and may be deleted
+func (t Tariff400ngZip5RateAreas) String() string {
+	jt, _ := json.Marshal(t)
+	return string(jt)
+}
+
+// Validate gets run every time you call a "pop.Validate*" (pop.ValidateAndSave, pop.ValidateAndCreate, pop.ValidateAndUpdate) method.
+func (t *Tariff400ngZip5RateArea) Validate(tx *pop.Connection) (*validate.Errors, error) {
+	return validate.NewErrors(), nil
+}

--- a/pkg/models/tariff400ng_zip5_rate_area_test.go
+++ b/pkg/models/tariff400ng_zip5_rate_area_test.go
@@ -1,0 +1,1 @@
+package models

--- a/pkg/rateengine/linehaul_test.go
+++ b/pkg/rateengine/linehaul_test.go
@@ -42,7 +42,7 @@ func (suite *RateEngineSuite) Test_CheckLinehaulFactors() {
 	defaultRateDateUpper := time.Date(2018, 5, 15, 0, 0, 0, 0, time.UTC)
 
 	originZip3 := models.Tariff400ngZip3{
-		Zip3:          395,
+		Zip3:          "395",
 		BasepointCity: "Saucier",
 		State:         "MS",
 		ServiceArea:   428,

--- a/pkg/rateengine/nonlinehaul_test.go
+++ b/pkg/rateengine/nonlinehaul_test.go
@@ -14,7 +14,7 @@ func (suite *RateEngineSuite) Test_CheckServiceFee() {
 	defaultRateDateUpper := time.Date(2018, 5, 15, 0, 0, 0, 0, time.UTC)
 
 	originZip3 := models.Tariff400ngZip3{
-		Zip3:          395,
+		Zip3:          "395",
 		BasepointCity: "Saucier",
 		State:         "MS",
 		ServiceArea:   428,
@@ -52,7 +52,7 @@ func (suite *RateEngineSuite) Test_CheckFullPack() {
 	defaultRateDateUpper := time.Date(2018, 5, 15, 0, 0, 0, 0, time.UTC)
 
 	originZip3 := models.Tariff400ngZip3{
-		Zip3:          395,
+		Zip3:          "395",
 		BasepointCity: "Saucier",
 		State:         "MS",
 		ServiceArea:   428,
@@ -101,7 +101,7 @@ func (suite *RateEngineSuite) Test_CheckFullUnpack() {
 	engine := NewRateEngine(suite.db, suite.logger)
 
 	originZip3 := models.Tariff400ngZip3{
-		Zip3:          395,
+		Zip3:          "395",
 		BasepointCity: "Saucier",
 		State:         "MS",
 		ServiceArea:   428,
@@ -157,7 +157,7 @@ func (suite *RateEngineSuite) Test_CheckNonLinehaulChargeTotal() {
 	defaultRateDateUpper := time.Date(2018, 5, 15, 0, 0, 0, 0, time.UTC)
 
 	originZip3 := models.Tariff400ngZip3{
-		Zip3:          395,
+		Zip3:          "395",
 		BasepointCity: "Saucier",
 		State:         "MS",
 		ServiceArea:   428,
@@ -178,7 +178,7 @@ func (suite *RateEngineSuite) Test_CheckNonLinehaulChargeTotal() {
 	suite.mustSave(&originServiceArea)
 
 	destinationZip3 := models.Tariff400ngZip3{
-		Zip3:          336,
+		Zip3:          "336",
 		BasepointCity: "Tampa",
 		State:         "FL",
 		ServiceArea:   197,

--- a/pkg/rateengine/rateengine_test.go
+++ b/pkg/rateengine/rateengine_test.go
@@ -31,7 +31,7 @@ func (suite *RateEngineSuite) Test_CheckPPMTotal() {
 	defaultRateDateUpper := time.Date(2018, 5, 15, 0, 0, 0, 0, time.UTC)
 
 	originZip3 := models.Tariff400ngZip3{
-		Zip3:          395,
+		Zip3:          "395",
 		BasepointCity: "Saucier",
 		State:         "MS",
 		ServiceArea:   428,
@@ -52,7 +52,7 @@ func (suite *RateEngineSuite) Test_CheckPPMTotal() {
 	suite.mustSave(&originServiceArea)
 
 	destinationZip3 := models.Tariff400ngZip3{
-		Zip3:          336,
+		Zip3:          "336",
 		BasepointCity: "Tampa",
 		State:         "FL",
 		ServiceArea:   197,


### PR DESCRIPTION
## Description

This change adds two funcs, `FetchRateAreaForZip5` and `FetchRegionForZip5` to the `models` package. It also changes zipcodes to be represented using strings instead of ints in a few places (including the database).

## Reviewer Notes

* This code performs explicit length checks on the zip5s that are passed into the new functions. I think this is warranted, as otherwise, the program will panic if we attempt to operate on two short of a value. But we should think about where in the application the responsibility to enforce this should live. Is validating this in Swagger and models enough?

## Code Review Verification Steps

* [ ] All tests pass.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/blob/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/156635384) for this change