### PR TITLE
Remove use of Fatal logger calls from documents.go

### DIFF
--- a/pkg/handlers/documents.go
+++ b/pkg/handlers/documents.go
@@ -29,12 +29,13 @@ type CreateDocumentHandler HandlerContext
 func (h CreateDocumentHandler) Handle(params documentop.CreateDocumentParams) middleware.Responder {
 	userID, ok := authctx.GetUserID(params.HTTPRequest.Context())
 	if !ok {
-		h.logger.Info("No User ID, this should never happen.")
+		h.logger.Error("Missing User ID in context")
+		return documentop.NewCreateDocumentBadRequest()
 	}
 
 	moveID, err := uuid.FromString(params.MoveID.String())
 	if err != nil {
-		h.logger.Info("Invalid MoveID.", zap.Error(err))
+		h.logger.Info("Badly formed UUID for moveId", zap.String("move_id", params.MoveID.String()), zap.Error(err))
 		return documentop.NewCreateDocumentBadRequest()
 	}
 

--- a/pkg/handlers/uploads.go
+++ b/pkg/handlers/uploads.go
@@ -41,30 +41,30 @@ func (h CreateUploadHandler) Handle(params uploadop.CreateUploadParams) middlewa
 
 	userID, ok := authctx.GetUserID(params.HTTPRequest.Context())
 	if !ok {
-		h.logger.Error("Missing User ID in context")
+		h.logger.Info("Missing User ID in context")
 		return uploadop.NewCreateUploadBadRequest()
 	}
 
 	moveID, err := uuid.FromString(params.MoveID.String())
 	if err != nil {
-		h.logger.Error("Badly formed UUID for moveId", zap.String("move_id", params.MoveID.String()), zap.Error(err))
+		h.logger.Info("Badly formed UUID for moveId", zap.String("move_id", params.MoveID.String()), zap.Error(err))
 		return uploadop.NewCreateUploadBadRequest()
 	}
 
 	documentID, err := uuid.FromString(params.DocumentID.String())
 	if err != nil {
-		h.logger.Error("Badly formed UUID for document", zap.String("document_id", params.DocumentID.String()), zap.Error(err))
+		h.logger.Info("Badly formed UUID for document", zap.String("document_id", params.DocumentID.String()), zap.Error(err))
 		return uploadop.NewCreateUploadBadRequest()
 	}
 
 	// Validate that the document and move exists in the db, and that they belong to user
 	exists, userOwns := models.ValidateDocumentOwnership(h.db, userID, moveID, documentID)
 	if !exists {
-		h.logger.Error("document or move does not exist", zap.String("document_id", params.DocumentID.String()), zap.String("move_id", params.MoveID.String()), zap.Error(err))
+		h.logger.Info("document or move does not exist", zap.String("document_id", params.DocumentID.String()), zap.String("move_id", params.MoveID.String()), zap.Error(err))
 		return uploadop.NewCreateUploadNotFound()
 	}
 	if !userOwns {
-		h.logger.Error("user does not own document or move", zap.String("document_id", params.DocumentID.String()), zap.String("move_id", params.MoveID.String()), zap.Error(err))
+		h.logger.Info("user does not own document or move", zap.String("document_id", params.DocumentID.String()), zap.String("move_id", params.MoveID.String()), zap.Error(err))
 		return uploadop.NewCreateUploadForbidden()
 	}
 

--- a/pkg/handlers/uploads.go
+++ b/pkg/handlers/uploads.go
@@ -41,7 +41,7 @@ func (h CreateUploadHandler) Handle(params uploadop.CreateUploadParams) middlewa
 
 	userID, ok := authctx.GetUserID(params.HTTPRequest.Context())
 	if !ok {
-		h.logger.Info("Missing User ID in context")
+		h.logger.Error("Missing User ID in context")
 		return uploadop.NewCreateUploadBadRequest()
 	}
 


### PR DESCRIPTION
## Description

We should not be using `logger.Fatal` in application code, as it causes the entire process to exit.

I also adjusted a few log levels in `uploads.go` to more closely follow our logging guidelines while I was at it.

## Code Review Verification Steps

* [ ] All tests pass.
* [ ] Code follows the guidelines for [Logging ](https://github.com/transcom/mymove/blob/master/docs/backend.md#logging)
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/156675947) for this change
* [Our documentation in the backend guide](https://github.com/transcom/mymove/blob/master/docs/backend.md#logging) on logging levels