### PR TITLE
Rek add discount rate to tspp

### DIFF
--- a/migrations/20180410214619_add_tsp_performance_discount_rates.down.fizz
+++ b/migrations/20180410214619_add_tsp_performance_discount_rates.down.fizz
@@ -1,0 +1,2 @@
+drop_column("transportation_service_provider_performances", "float")
+drop_column("transportation_service_provider_performances", "float")

--- a/migrations/20180410214619_add_tsp_performance_discount_rates.down.fizz
+++ b/migrations/20180410214619_add_tsp_performance_discount_rates.down.fizz
@@ -1,2 +1,2 @@
-drop_column("transportation_service_provider_performances", "float")
-drop_column("transportation_service_provider_performances", "float")
+drop_column("transportation_service_provider_performances", "linehaul_rate")
+drop_column("transportation_service_provider_performances", "sit_rate")

--- a/migrations/20180410214619_add_tsp_performance_discount_rates.up.fizz
+++ b/migrations/20180410214619_add_tsp_performance_discount_rates.up.fizz
@@ -1,0 +1,2 @@
+add_column("transportation_service_provider_performances", "linehaul_rate", "float", {})
+add_column("transportation_service_provider_performances", "sit_rate", "float", {})

--- a/migrations/20180410214619_add_tsp_performance_discount_rates.up.fizz
+++ b/migrations/20180410214619_add_tsp_performance_discount_rates.up.fizz
@@ -1,2 +1,2 @@
-add_column("transportation_service_provider_performances", "linehaul_rate", "float", {})
-add_column("transportation_service_provider_performances", "sit_rate", "float", {})
+add_column("transportation_service_provider_performances", "linehaul_rate", "float", {"null": true})
+add_column("transportation_service_provider_performances", "sit_rate", "float", {"null": true})

--- a/migrations/20180410214619_add_tsp_performance_discount_rates.up.fizz
+++ b/migrations/20180410214619_add_tsp_performance_discount_rates.up.fizz
@@ -1,2 +1,2 @@
-add_column("transportation_service_provider_performances", "linehaul_rate", "float", {"null": true})
-add_column("transportation_service_provider_performances", "sit_rate", "float", {"null": true})
+add_column("transportation_service_provider_performances", "linehaul_rate", "float", {})
+add_column("transportation_service_provider_performances", "sit_rate", "float", {})

--- a/migrations/20180412142036_add_tdl_uniqueness_constraint.down.sql
+++ b/migrations/20180412142036_add_tdl_uniqueness_constraint.down.sql
@@ -1,0 +1,1 @@
+ALTER table traffic_distribution_lists DROP constraint unique_channel_cos;

--- a/migrations/20180412142036_add_tdl_uniqueness_constraint.up.sql
+++ b/migrations/20180412142036_add_tdl_uniqueness_constraint.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE traffic_distribution_lists ADD CONSTRAINT unique_channel_cos UNIQUE (source_rate_area, destination_region, code_of_service);

--- a/pkg/awardqueue/awardqueue_test.go
+++ b/pkg/awardqueue/awardqueue_test.go
@@ -21,7 +21,7 @@ func (suite *AwardQueueSuite) Test_CheckAllTSPsBlackedOut() {
 
 	tsp, err := testdatagen.MakeTSP(suite.db, "A Very Excellent TSP", testdatagen.RandomSCAC())
 	tdl, err := testdatagen.MakeTDL(suite.db, testdatagen.DefaultSrcRateArea, testdatagen.DefaultDstRegion, "5")
-	testdatagen.MakeTSPPerformance(suite.db, tsp, tdl, swag.Int(1), mps+1, 0)
+	testdatagen.MakeTSPPerformance(suite.db, tsp, tdl, swag.Int(1), mps+1, 0, 4.3, 4.3)
 
 	blackoutStartDate := testdatagen.DateInsidePeakRateCycle
 	blackoutEndDate := blackoutStartDate.Add(time.Hour * 24 * 2)
@@ -68,7 +68,7 @@ func (suite *AwardQueueSuite) Test_CheckShipmentDuringBlackOut() {
 	market := testdatagen.DefaultMarket
 	sourceGBLOC := testdatagen.DefaultSrcGBLOC
 
-	testdatagen.MakeTSPPerformance(suite.db, tsp, tdl, swag.Int(1), mps+1, 0)
+	testdatagen.MakeTSPPerformance(suite.db, tsp, tdl, swag.Int(1), mps+1, 0, 4.3, 4.3)
 
 	blackoutStartDate := testdatagen.DateInsidePeakRateCycle
 	blackoutEndDate := blackoutStartDate.AddDate(0, 1, 0)
@@ -210,7 +210,7 @@ func (suite *AwardQueueSuite) Test_OfferSingleShipment() {
 
 	// Make a TSP to handle it
 	tsp, _ := testdatagen.MakeTSP(suite.db, "Test Shipper", testdatagen.RandomSCAC())
-	testdatagen.MakeTSPPerformance(suite.db, tsp, tdl, swag.Int(1), mps+1, 0)
+	testdatagen.MakeTSPPerformance(suite.db, tsp, tdl, swag.Int(1), mps+1, 0, 4.3, 4.3)
 
 	// Create a ShipmentWithOffer to feed the award queue
 	shipmentWithOffer := models.ShipmentWithOffer{
@@ -297,7 +297,7 @@ func (suite *AwardQueueSuite) TestAssignShipmentsSingleTSP() {
 	tsp, _ := testdatagen.MakeTSP(suite.db, "Test Shipper", testdatagen.RandomSCAC())
 
 	// ... and give this TSP a performance record
-	testdatagen.MakeTSPPerformance(suite.db, tsp, tdl, swag.Int(1), mps+1, 0)
+	testdatagen.MakeTSPPerformance(suite.db, tsp, tdl, swag.Int(1), mps+1, 0, 4.3, 4.3)
 
 	// Run the Award Queue
 	queue.assignShipments()
@@ -344,11 +344,11 @@ func (suite *AwardQueueSuite) TestAssignShipmentsToMultipleTSPs() {
 	tsp5, _ := testdatagen.MakeTSP(suite.db, "Test TSP 5", testdatagen.RandomSCAC())
 
 	// TSPs should be orderd by offer_count first, then BVS.
-	testdatagen.MakeTSPPerformance(suite.db, tsp1, tdl, swag.Int(1), mps+5, 0)
-	testdatagen.MakeTSPPerformance(suite.db, tsp2, tdl, swag.Int(1), mps+4, 0)
-	testdatagen.MakeTSPPerformance(suite.db, tsp3, tdl, swag.Int(2), mps+2, 0)
-	testdatagen.MakeTSPPerformance(suite.db, tsp4, tdl, swag.Int(3), mps+3, 0)
-	testdatagen.MakeTSPPerformance(suite.db, tsp5, tdl, swag.Int(4), mps+1, 0)
+	testdatagen.MakeTSPPerformance(suite.db, tsp1, tdl, swag.Int(1), mps+5, 0, 4.4, 4.4)
+	testdatagen.MakeTSPPerformance(suite.db, tsp2, tdl, swag.Int(1), mps+4, 0, 3.3, 3.3)
+	testdatagen.MakeTSPPerformance(suite.db, tsp3, tdl, swag.Int(2), mps+2, 0, 2.2, 2.2)
+	testdatagen.MakeTSPPerformance(suite.db, tsp4, tdl, swag.Int(3), mps+3, 0, 1.1, 1.1)
+	testdatagen.MakeTSPPerformance(suite.db, tsp5, tdl, swag.Int(4), mps+1, 0, .6, .6)
 
 	// Run the Award Queue
 	queue.assignShipments()
@@ -394,7 +394,7 @@ func (suite *AwardQueueSuite) Test_AssignTSPsToBands() {
 	for i := 0; i < tspsToMake; i++ {
 		tsp, _ := testdatagen.MakeTSP(suite.db, "Test Shipper", testdatagen.RandomSCAC())
 		score := mps + i + 1
-		testdatagen.MakeTSPPerformance(suite.db, tsp, tdl, nil, score, 0)
+		testdatagen.MakeTSPPerformance(suite.db, tsp, tdl, nil, score, 0, float64(score)*.5, float64(score)*.5)
 	}
 
 	err = queue.assignPerformanceBands()

--- a/pkg/models/traffic_distribution_list.go
+++ b/pkg/models/traffic_distribution_list.go
@@ -2,7 +2,6 @@ package models
 
 import (
 	"encoding/json"
-	"fmt"
 	"time"
 
 	"github.com/gobuffalo/pop"
@@ -99,7 +98,7 @@ func FetchOrCreateTDL(db *pop.Connection, rateArea string, region string, codeOf
 	tdls := []TrafficDistributionList{}
 	err := db.RawQuery(sql, rateArea, region, codeOfService).All(&tdls)
 
-	if len(tdls) != 1 {
+	if len(tdls) == 0 {
 		tdl := TrafficDistributionList{
 			SourceRateArea:    rateArea,
 			DestinationRegion: region,
@@ -107,10 +106,10 @@ func FetchOrCreateTDL(db *pop.Connection, rateArea string, region string, codeOf
 		}
 		verrs, err := db.ValidateAndSave(&tdl)
 		if err != nil {
-			fmt.Printf("DB Insertion: %v", err)
+			zap.L().Error("DB insertion error", zap.Error(err))
 			return TrafficDistributionList{}, err
 		} else if verrs.HasAny() {
-			fmt.Printf("Validation errors: %v", verrs)
+			zap.L().Error("Validation errors", zap.Error(verrs))
 			return TrafficDistributionList{}, errors.New("Validation error on TDL")
 		}
 		tdls = append(tdls, tdl)

--- a/pkg/models/traffic_distribution_list.go
+++ b/pkg/models/traffic_distribution_list.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gobuffalo/validate"
 	"github.com/gobuffalo/validate/validators"
 	"github.com/pkg/errors"
+	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
 

--- a/pkg/models/traffic_distribution_list_test.go
+++ b/pkg/models/traffic_distribution_list_test.go
@@ -51,26 +51,20 @@ func (suite *ModelSuite) Test_FetchOrCreateTDL() {
 	foundTSP, _ := testdatagen.MakeTSP(suite.db, "Test Shipper", testdatagen.RandomSCAC())
 	testdatagen.MakeTSPPerformance(suite.db, foundTSP, foundTDL, swag.Int(1), mps+1, 0, 4.2, 4.3)
 
-	fetchedTDLs, err := FetchOrCreateTDL(suite.db, "US28", "4", "2")
+	fetchedTDL, err := FetchOrCreateTDL(suite.db, "US28", "4", "2")
 	if err != nil {
-		t.Fatal(err)
+		t.Errorf("Didn't return expected TDL: %v", fetchedTDL)
 	}
 
-	if len(fetchedTDLs) != 1 {
-		t.Errorf("Got wrong number of TDLs; expected: 1, got: %d", len(fetchedTDLs))
+	if fetchedTDL.ID != foundTDL.ID {
+		t.Errorf("Got wrong TDL; expected: %s, got: %s", foundTDL.ID, fetchedTDL.ID)
 	}
 
-	if fetchedTDLs[0].ID != foundTDL.ID {
-		t.Errorf("Got wrong TDL; expected: %s, got: %s", foundTDL.ID, fetchedTDLs[0].ID)
-	}
-
-	createdTDLs, err := FetchOrCreateTDL(suite.db, "US23", "1", "2")
+	_, err = FetchOrCreateTDL(suite.db, "US23", "1", "2")
 	if err != nil {
 		t.Errorf("Something went wrong creating the test objects: %s\n", err)
 	}
-	if len(createdTDLs) != 1 {
-		t.Errorf("Got wrong number of TDLs; expected: 1, got: %d", len(fetchedTDLs))
-	}
+
 	tdls := TrafficDistributionLists{}
 	sql := `SELECT
 			*

--- a/pkg/models/traffic_distribution_list_test.go
+++ b/pkg/models/traffic_distribution_list_test.go
@@ -22,11 +22,11 @@ func (suite *ModelSuite) Test_TrafficDistributionList() {
 func (suite *ModelSuite) Test_FetchTDLsAwaitingBandAssignment() {
 	t := suite.T()
 
-	foundTDL, _ := testdatagen.MakeTDL(suite.db, "california", "90210", "2")
+	foundTDL, _ := testdatagen.MakeTDL(suite.db, "US14", "3", "2")
 	foundTSP, _ := testdatagen.MakeTSP(suite.db, "Test Shipper", testdatagen.RandomSCAC())
 	testdatagen.MakeTSPPerformance(suite.db, foundTSP, foundTDL, nil, mps+1, 0, 4.2, 4.3)
 
-	notFoundTDL, _ := testdatagen.MakeTDL(suite.db, "california", "90210", "2")
+	notFoundTDL, _ := testdatagen.MakeTDL(suite.db, "US14", "5", "2")
 	notFoundTSP, _ := testdatagen.MakeTSP(suite.db, "Test Shipper", testdatagen.RandomSCAC())
 	testdatagen.MakeTSPPerformance(suite.db, notFoundTSP, notFoundTDL, swag.Int(1), mps+1, 0, 4.4, 4.3)
 
@@ -78,5 +78,20 @@ func (suite *ModelSuite) Test_FetchOrCreateTDL() {
 	}
 	if len(tdls) != 2 {
 		t.Errorf("A new object was not created")
+	}
+}
+
+func (suite *ModelSuite) Test_TDLUniqueChannelCOS() {
+	t := suite.T()
+
+	tdl, _ := testdatagen.MakeTDL(suite.db, "US28", "4", "2")
+
+	fetchedTDL, err := FetchOrCreateTDL(suite.db, "US28", "4", "2")
+	if err != nil {
+		t.Errorf("Something went wrong fetching the test object: %s\n", err)
+	}
+
+	if fetchedTDL.ID != tdl.ID {
+		t.Errorf("Got wrong TDL; expected: %s, got: %s", tdl.ID, fetchedTDL.ID)
 	}
 }

--- a/pkg/models/traffic_distribution_list_test.go
+++ b/pkg/models/traffic_distribution_list_test.go
@@ -24,7 +24,7 @@ func (suite *ModelSuite) Test_FetchTDLsAwaitingBandAssignment() {
 
 	foundTDL, _ := testdatagen.MakeTDL(suite.db, "california", "90210", "2")
 	foundTSP, _ := testdatagen.MakeTSP(suite.db, "Test Shipper", testdatagen.RandomSCAC())
-	testdatagen.MakeTSPPerformance(suite.db, foundTSP, foundTDL, nil, mps+1, 0, nil, nil)
+	testdatagen.MakeTSPPerformance(suite.db, foundTSP, foundTDL, nil, mps+1, 0, 4.2, 4.3)
 
 	notFoundTDL, _ := testdatagen.MakeTDL(suite.db, "california", "90210", "2")
 	notFoundTSP, _ := testdatagen.MakeTSP(suite.db, "Test Shipper", testdatagen.RandomSCAC())

--- a/pkg/models/traffic_distribution_list_test.go
+++ b/pkg/models/traffic_distribution_list_test.go
@@ -24,11 +24,11 @@ func (suite *ModelSuite) Test_FetchTDLsAwaitingBandAssignment() {
 
 	foundTDL, _ := testdatagen.MakeTDL(suite.db, "california", "90210", "2")
 	foundTSP, _ := testdatagen.MakeTSP(suite.db, "Test Shipper", testdatagen.RandomSCAC())
-	testdatagen.MakeTSPPerformance(suite.db, foundTSP, foundTDL, nil, mps+1, 0)
+	testdatagen.MakeTSPPerformance(suite.db, foundTSP, foundTDL, nil, mps+1, 0, nil, nil)
 
 	notFoundTDL, _ := testdatagen.MakeTDL(suite.db, "california", "90210", "2")
 	notFoundTSP, _ := testdatagen.MakeTSP(suite.db, "Test Shipper", testdatagen.RandomSCAC())
-	testdatagen.MakeTSPPerformance(suite.db, notFoundTSP, notFoundTDL, swag.Int(1), mps+1, 0)
+	testdatagen.MakeTSPPerformance(suite.db, notFoundTSP, notFoundTDL, swag.Int(1), mps+1, 0, 4.4, 4.3)
 
 	tdls, err := FetchTDLsAwaitingBandAssignment(suite.db)
 	if err != nil {

--- a/pkg/models/transportation_service_provider_performance.go
+++ b/pkg/models/transportation_service_provider_performance.go
@@ -39,6 +39,8 @@ type TransportationServiceProviderPerformance struct {
 	TransportationServiceProviderID uuid.UUID `db:"transportation_service_provider_id"`
 	QualityBand                     *int      `db:"quality_band"`
 	BestValueScore                  int       `db:"best_value_score"`
+	LinehaulRate                    float64   `db:"linehaul_rate"`
+	SITRate                         float64   `db:"sit_rate"`
 	OfferCount                      int       `db:"offer_count"`
 }
 

--- a/pkg/models/transportation_service_provider_performance_test.go
+++ b/pkg/models/transportation_service_provider_performance_test.go
@@ -93,7 +93,7 @@ func (suite *ModelSuite) Test_IncrementTSPPerformanceOfferCount() {
 
 	tdl, _ := testdatagen.MakeTDL(suite.db, testdatagen.DefaultSrcRateArea, testdatagen.DefaultDstRegion, "2")
 	tsp, _ := testdatagen.MakeTSP(suite.db, "Test Shipper", testdatagen.RandomSCAC())
-	perf, _ := testdatagen.MakeTSPPerformance(suite.db, tsp, tdl, nil, mps, 0, nil, nil)
+	perf, _ := testdatagen.MakeTSPPerformance(suite.db, tsp, tdl, nil, mps, 0, 2.2, 1)
 
 	err := IncrementTSPPerformanceOfferCount(suite.db, perf.ID)
 	if err != nil {
@@ -115,7 +115,7 @@ func (suite *ModelSuite) Test_AssignQualityBandToTSPPerformance() {
 
 	tdl, _ := testdatagen.MakeTDL(suite.db, testdatagen.DefaultSrcRateArea, testdatagen.DefaultDstRegion, "2")
 	tsp, _ := testdatagen.MakeTSP(suite.db, "Test Shipper", testdatagen.RandomSCAC())
-	perf, _ := testdatagen.MakeTSPPerformance(suite.db, tsp, tdl, nil, mps, 0, nil, nil)
+	perf, _ := testdatagen.MakeTSPPerformance(suite.db, tsp, tdl, nil, mps, 0, 2, 2.3)
 	band := 1
 
 	err := AssignQualityBandToTSPPerformance(suite.db, band, perf.ID)
@@ -145,11 +145,11 @@ func (suite *ModelSuite) Test_BVSWithLowMPS() {
 	// Make 5 (not divisible by 4) TSPs in this TDL with BVSs above MPS threshold
 	for i := 0; i < tspsToMake; i++ {
 		tsp, _ := testdatagen.MakeTSP(suite.db, "Test Shipper", testdatagen.RandomSCAC())
-		testdatagen.MakeTSPPerformance(suite.db, tsp, tdl, nil, 15, 0, nil, nil)
+		testdatagen.MakeTSPPerformance(suite.db, tsp, tdl, nil, 15, 0, 4.5, 4.6)
 	}
 	// Make 1 TSP in this TDL with BVS below the MPS threshold
 	mpsTSP, _ := testdatagen.MakeTSP(suite.db, "Low BVS Test Shipper", testdatagen.RandomSCAC())
-	testdatagen.MakeTSPPerformance(suite.db, mpsTSP, tdl, nil, mps-1, 0, nil, nil)
+	testdatagen.MakeTSPPerformance(suite.db, mpsTSP, tdl, nil, mps-1, 0, 2.2, 1.9)
 
 	// Fetch TSPs in TDL
 	tspsbb, err := FetchTSPPerformanceForQualityBandAssignment(suite.db, tdl.ID, mps)
@@ -398,9 +398,9 @@ func (suite *ModelSuite) Test_FetchTSPPerformanceForQualityBandAssignment() {
 	tsp2, _ := testdatagen.MakeTSP(suite.db, "Test TSP 2", testdatagen.RandomSCAC())
 	tsp3, _ := testdatagen.MakeTSP(suite.db, "Test TSP 3", testdatagen.RandomSCAC())
 	// What matter is the BVS score order; offer count has no influence.
-	testdatagen.MakeTSPPerformance(suite.db, tsp1, tdl, nil, 90, 0, nil, nil)
-	testdatagen.MakeTSPPerformance(suite.db, tsp2, tdl, nil, 50, 1, nil, nil)
-	testdatagen.MakeTSPPerformance(suite.db, tsp3, tdl, nil, 15, 1, nil, nil)
+	testdatagen.MakeTSPPerformance(suite.db, tsp1, tdl, nil, 90, 0, 4.5, 4.5)
+	testdatagen.MakeTSPPerformance(suite.db, tsp2, tdl, nil, 50, 1, 3, 2.9)
+	testdatagen.MakeTSPPerformance(suite.db, tsp3, tdl, nil, 15, 1, 1.1, 1.3)
 
 	tsps, err := FetchTSPPerformanceForQualityBandAssignment(suite.db, tdl.ID, mps)
 
@@ -430,8 +430,8 @@ func (suite *ModelSuite) Test_MinimumPerformanceScore() {
 	tsp1, _ := testdatagen.MakeTSP(suite.db, "Test TSP 1", testdatagen.RandomSCAC())
 	tsp2, _ := testdatagen.MakeTSP(suite.db, "Test TSP 2", testdatagen.RandomSCAC())
 	// Make 2 TSPs, one with a BVS above the MPS and one below the MPS.
-	testdatagen.MakeTSPPerformance(suite.db, tsp1, tdl, nil, mps+1, 0, nil)
-	testdatagen.MakeTSPPerformance(suite.db, tsp2, tdl, nil, mps-1, 1, nil)
+	testdatagen.MakeTSPPerformance(suite.db, tsp1, tdl, nil, mps+1, 0, 3.3, 3.4)
+	testdatagen.MakeTSPPerformance(suite.db, tsp2, tdl, nil, mps-1, 1, 1.9, 1.7)
 
 	tsps, err := FetchTSPPerformanceForQualityBandAssignment(suite.db, tdl.ID, mps)
 

--- a/pkg/models/transportation_service_provider_performance_test.go
+++ b/pkg/models/transportation_service_provider_performance_test.go
@@ -93,7 +93,7 @@ func (suite *ModelSuite) Test_IncrementTSPPerformanceOfferCount() {
 
 	tdl, _ := testdatagen.MakeTDL(suite.db, testdatagen.DefaultSrcRateArea, testdatagen.DefaultDstRegion, "2")
 	tsp, _ := testdatagen.MakeTSP(suite.db, "Test Shipper", testdatagen.RandomSCAC())
-	perf, _ := testdatagen.MakeTSPPerformance(suite.db, tsp, tdl, nil, mps, 0)
+	perf, _ := testdatagen.MakeTSPPerformance(suite.db, tsp, tdl, nil, mps, 0, nil, nil)
 
 	err := IncrementTSPPerformanceOfferCount(suite.db, perf.ID)
 	if err != nil {
@@ -115,7 +115,7 @@ func (suite *ModelSuite) Test_AssignQualityBandToTSPPerformance() {
 
 	tdl, _ := testdatagen.MakeTDL(suite.db, testdatagen.DefaultSrcRateArea, testdatagen.DefaultDstRegion, "2")
 	tsp, _ := testdatagen.MakeTSP(suite.db, "Test Shipper", testdatagen.RandomSCAC())
-	perf, _ := testdatagen.MakeTSPPerformance(suite.db, tsp, tdl, nil, mps, 0)
+	perf, _ := testdatagen.MakeTSPPerformance(suite.db, tsp, tdl, nil, mps, 0, nil, nil)
 	band := 1
 
 	err := AssignQualityBandToTSPPerformance(suite.db, band, perf.ID)
@@ -145,11 +145,11 @@ func (suite *ModelSuite) Test_BVSWithLowMPS() {
 	// Make 5 (not divisible by 4) TSPs in this TDL with BVSs above MPS threshold
 	for i := 0; i < tspsToMake; i++ {
 		tsp, _ := testdatagen.MakeTSP(suite.db, "Test Shipper", testdatagen.RandomSCAC())
-		testdatagen.MakeTSPPerformance(suite.db, tsp, tdl, nil, 15, 0)
+		testdatagen.MakeTSPPerformance(suite.db, tsp, tdl, nil, 15, 0, nil, nil)
 	}
 	// Make 1 TSP in this TDL with BVS below the MPS threshold
 	mpsTSP, _ := testdatagen.MakeTSP(suite.db, "Low BVS Test Shipper", testdatagen.RandomSCAC())
-	testdatagen.MakeTSPPerformance(suite.db, mpsTSP, tdl, nil, mps-1, 0)
+	testdatagen.MakeTSPPerformance(suite.db, mpsTSP, tdl, nil, mps-1, 0, nil, nil)
 
 	// Fetch TSPs in TDL
 	tspsbb, err := FetchTSPPerformanceForQualityBandAssignment(suite.db, tdl.ID, mps)
@@ -176,9 +176,9 @@ func (suite *ModelSuite) Test_FetchNextQualityBandTSPPerformance() {
 	tsp3, _ := testdatagen.MakeTSP(suite.db, "Test TSP 3", testdatagen.RandomSCAC())
 
 	// TSPs should be orderd by offer_count first, then BVS.
-	testdatagen.MakeTSPPerformance(suite.db, tsp1, tdl, swag.Int(1), mps+1, 0)
-	testdatagen.MakeTSPPerformance(suite.db, tsp2, tdl, swag.Int(1), mps+3, 0)
-	testdatagen.MakeTSPPerformance(suite.db, tsp3, tdl, swag.Int(1), mps+2, 0)
+	testdatagen.MakeTSPPerformance(suite.db, tsp1, tdl, swag.Int(1), mps+1, 0, 4.4, 4.4)
+	testdatagen.MakeTSPPerformance(suite.db, tsp2, tdl, swag.Int(1), mps+3, 0, 4.4, 4.4)
+	testdatagen.MakeTSPPerformance(suite.db, tsp3, tdl, swag.Int(1), mps+2, 0, 4.4, 4.4)
 
 	tspp, err := NextTSPPerformanceInQualityBand(suite.db, tdl.ID, 1, testdatagen.DateInsidePerformancePeriod,
 		testdatagen.DateInsidePeakRateCycle)
@@ -360,11 +360,11 @@ func (suite *ModelSuite) Test_GatherNextEligibleTSPPerformances() {
 	tsp4, _ := testdatagen.MakeTSP(suite.db, "Test TSP 4", testdatagen.RandomSCAC())
 	tsp5, _ := testdatagen.MakeTSP(suite.db, "Test TSP 5", testdatagen.RandomSCAC())
 	// TSPs should be orderd by offer_count first, then BVS.
-	testdatagen.MakeTSPPerformance(suite.db, tsp1, tdl, swag.Int(1), mps+5, 0)
-	testdatagen.MakeTSPPerformance(suite.db, tsp2, tdl, swag.Int(1), mps+4, 0)
-	testdatagen.MakeTSPPerformance(suite.db, tsp3, tdl, swag.Int(2), mps+3, 0)
-	testdatagen.MakeTSPPerformance(suite.db, tsp4, tdl, swag.Int(3), mps+2, 0)
-	testdatagen.MakeTSPPerformance(suite.db, tsp5, tdl, swag.Int(4), mps+1, 0)
+	testdatagen.MakeTSPPerformance(suite.db, tsp1, tdl, swag.Int(1), mps+5, 0, 4.4, 4.4)
+	testdatagen.MakeTSPPerformance(suite.db, tsp2, tdl, swag.Int(1), mps+4, 0, 4.3, 4.3)
+	testdatagen.MakeTSPPerformance(suite.db, tsp3, tdl, swag.Int(2), mps+3, 0, 3.2, 3.2)
+	testdatagen.MakeTSPPerformance(suite.db, tsp4, tdl, swag.Int(3), mps+2, 0, 2.1, 2.1)
+	testdatagen.MakeTSPPerformance(suite.db, tsp5, tdl, swag.Int(4), mps+1, 0, 1.1, 1.1)
 
 	tsps, err := GatherNextEligibleTSPPerformances(suite.db, tdl.ID, testdatagen.DateInsidePerformancePeriod,
 		testdatagen.DateInsidePeakRateCycle)
@@ -398,9 +398,9 @@ func (suite *ModelSuite) Test_FetchTSPPerformanceForQualityBandAssignment() {
 	tsp2, _ := testdatagen.MakeTSP(suite.db, "Test TSP 2", testdatagen.RandomSCAC())
 	tsp3, _ := testdatagen.MakeTSP(suite.db, "Test TSP 3", testdatagen.RandomSCAC())
 	// What matter is the BVS score order; offer count has no influence.
-	testdatagen.MakeTSPPerformance(suite.db, tsp1, tdl, nil, 90, 0)
-	testdatagen.MakeTSPPerformance(suite.db, tsp2, tdl, nil, 50, 1)
-	testdatagen.MakeTSPPerformance(suite.db, tsp3, tdl, nil, 15, 1)
+	testdatagen.MakeTSPPerformance(suite.db, tsp1, tdl, nil, 90, 0, nil, nil)
+	testdatagen.MakeTSPPerformance(suite.db, tsp2, tdl, nil, 50, 1, nil, nil)
+	testdatagen.MakeTSPPerformance(suite.db, tsp3, tdl, nil, 15, 1, nil, nil)
 
 	tsps, err := FetchTSPPerformanceForQualityBandAssignment(suite.db, tdl.ID, mps)
 
@@ -430,8 +430,8 @@ func (suite *ModelSuite) Test_MinimumPerformanceScore() {
 	tsp1, _ := testdatagen.MakeTSP(suite.db, "Test TSP 1", testdatagen.RandomSCAC())
 	tsp2, _ := testdatagen.MakeTSP(suite.db, "Test TSP 2", testdatagen.RandomSCAC())
 	// Make 2 TSPs, one with a BVS above the MPS and one below the MPS.
-	testdatagen.MakeTSPPerformance(suite.db, tsp1, tdl, nil, mps+1, 0)
-	testdatagen.MakeTSPPerformance(suite.db, tsp2, tdl, nil, mps-1, 1)
+	testdatagen.MakeTSPPerformance(suite.db, tsp1, tdl, nil, mps+1, 0, nil)
+	testdatagen.MakeTSPPerformance(suite.db, tsp2, tdl, nil, mps-1, 1, nil)
 
 	tsps, err := FetchTSPPerformanceForQualityBandAssignment(suite.db, tdl.ID, mps)
 

--- a/pkg/testdatagen/make_tdl_records.go
+++ b/pkg/testdatagen/make_tdl_records.go
@@ -19,7 +19,7 @@ func MakeTDL(db *pop.Connection, source string, dest string, cos string) (models
 
 	_, err := db.ValidateAndSave(&tdl)
 	if err != nil {
-		log.Panic(err)
+		log.Fatalf("Failed to validate and save tdl: %v", err)
 	}
 
 	return tdl, err

--- a/pkg/testdatagen/make_tsp_performance_records.go
+++ b/pkg/testdatagen/make_tsp_performance_records.go
@@ -12,7 +12,7 @@ import (
 
 // MakeTSPPerformance makes a single best_value_score record
 func MakeTSPPerformance(db *pop.Connection, tsp models.TransportationServiceProvider,
-	tdl models.TrafficDistributionList, qualityBand *int, score int, offerCount int) (models.TransportationServiceProviderPerformance, error) {
+	tdl models.TrafficDistributionList, qualityBand *int, score int, offerCount int, linehaulRate float64, SITRate float64) (models.TransportationServiceProviderPerformance, error) {
 
 	tspPerformance := models.TransportationServiceProviderPerformance{
 		PerformancePeriodStart:          PerformancePeriodStart,
@@ -24,6 +24,8 @@ func MakeTSPPerformance(db *pop.Connection, tsp models.TransportationServiceProv
 		QualityBand:                     qualityBand,
 		BestValueScore:                  score,
 		OfferCount:                      offerCount,
+		LinehaulRate:                    linehaulRate,
+		SITRate:                         SITRate,
 	}
 
 	_, err := db.ValidateAndSave(&tspPerformance)
@@ -68,8 +70,10 @@ func MakeTSPPerformanceData(db *pop.Connection, rounds string) {
 		var offers int
 		minBvs := (qualityBand - 1) * 25
 		bvs := 100 - (rand.Intn(25) + minBvs)
-		// Set rounds according to the flag passed in
+		// Make linehaul and SIT rates a percentage of BVS--in this case we'll call both discountRate
+		discountRate := float64(bvs) * .3
 
+		// Set rounds according to the flag passed in
 		if rounds == "half" {
 			if qualityBand == 1 || qualityBand == 2 {
 				offers = models.OffersPerQualityBand[qualityBand]
@@ -90,6 +94,8 @@ func MakeTSPPerformanceData(db *pop.Connection, rounds string) {
 			&qualityBand,
 			bvs,
 			offers,
+			discountRate,
+			discountRate,
 		)
 	}
 }

--- a/pkg/testdatagen/scenario_1.go
+++ b/pkg/testdatagen/scenario_1.go
@@ -33,10 +33,10 @@ func RunScenarioOne(db *pop.Connection) {
 	tsp4, _ := MakeTSP(db, "OK TSP", RandomSCAC())
 	tsp5, _ := MakeTSP(db, "Bad TSP", RandomSCAC())
 
-	// TSPs should be orderd by offer_count first, then BVS.
-	MakeTSPPerformance(db, tsp1, tdl, swag.Int(1), 5, 0)
-	MakeTSPPerformance(db, tsp2, tdl, swag.Int(1), 4, 0)
-	MakeTSPPerformance(db, tsp3, tdl, swag.Int(2), 3, 0)
-	MakeTSPPerformance(db, tsp4, tdl, swag.Int(3), 2, 0)
-	MakeTSPPerformance(db, tsp5, tdl, swag.Int(4), 1, 0)
+	// TSPs should be ordered by offer_count first, then BVS.
+	MakeTSPPerformance(db, tsp1, tdl, swag.Int(1), 5, 0, 4.2, 4.2)
+	MakeTSPPerformance(db, tsp2, tdl, swag.Int(1), 4, 0, 3.3, 3.3)
+	MakeTSPPerformance(db, tsp3, tdl, swag.Int(2), 3, 0, 2.1, 2.1)
+	MakeTSPPerformance(db, tsp4, tdl, swag.Int(3), 2, 0, 1.1, 1.1)
+	MakeTSPPerformance(db, tsp5, tdl, swag.Int(4), 1, 0, .5, .5)
 }

--- a/pkg/testdatagen/scenario_2.go
+++ b/pkg/testdatagen/scenario_2.go
@@ -44,16 +44,16 @@ func RunScenarioTwo(db *pop.Connection) {
 	tsp9, _ := MakeTSP(db, "Going out of business TSP", RandomSCAC())
 
 	// Put TSPs in 2 TDLs to handle these shipments
-	MakeTSPPerformance(db, tsp1, tdl, swag.Int(1), 5, 0)
-	MakeTSPPerformance(db, tsp2, tdl, swag.Int(1), 4, 0)
-	MakeTSPPerformance(db, tsp3, tdl, swag.Int(2), 3, 0)
-	MakeTSPPerformance(db, tsp4, tdl, swag.Int(3), 2, 0)
-	MakeTSPPerformance(db, tsp5, tdl, swag.Int(4), 1, 0)
+	MakeTSPPerformance(db, tsp1, tdl, swag.Int(1), 5, 0, 4.2, 4.4)
+	MakeTSPPerformance(db, tsp2, tdl, swag.Int(1), 4, 0, 3.1, 3.2)
+	MakeTSPPerformance(db, tsp3, tdl, swag.Int(2), 3, 0, 2.4, 2.5)
+	MakeTSPPerformance(db, tsp4, tdl, swag.Int(3), 2, 0, 1.1, 1.3)
+	MakeTSPPerformance(db, tsp5, tdl, swag.Int(4), 1, 0, .5, .8)
 
-	MakeTSPPerformance(db, tsp6, tdl2, swag.Int(1), 5, 0)
-	MakeTSPPerformance(db, tsp7, tdl2, swag.Int(2), 4, 0)
-	MakeTSPPerformance(db, tsp8, tdl2, swag.Int(3), 2, 0)
-	MakeTSPPerformance(db, tsp9, tdl2, swag.Int(4), 1, 0)
+	MakeTSPPerformance(db, tsp6, tdl2, swag.Int(1), 5, 0, 4.2, 4.4)
+	MakeTSPPerformance(db, tsp7, tdl2, swag.Int(2), 4, 0, 3.1, 3.2)
+	MakeTSPPerformance(db, tsp8, tdl2, swag.Int(3), 2, 0, 1.1, 1.3)
+	MakeTSPPerformance(db, tsp9, tdl2, swag.Int(4), 1, 0, .5, .8)
 	// Add blackout dates
 	blackoutStart := shipmentDate.AddDate(0, 0, -3)
 	blackoutEnd := shipmentDate.AddDate(0, 0, 3)


### PR DESCRIPTION
## Description

We decided to add discount rates (specifically for linehaul and SIT) to the tsp_performance model. This PR adds via a migration, then implements throughout the testing suites.

## Reviewer Notes
discount_rates not nullable. Now includes a FindOrCreateTDL() method that finds a TDL using rate_area, region, and COS or creates one using those values.

## Code Review Verification Steps

* [x] All tests pass.
* [x] Request review from a member of a different team.
* [x] (TRIAL) Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/156665455) for this change