### PR TITLE
Add Cents type and use it instead of ints.

### DIFF
--- a/pkg/models/tariff400ng_full_pack_rate.go
+++ b/pkg/models/tariff400ng_full_pack_rate.go
@@ -8,19 +8,21 @@ import (
 	"github.com/gobuffalo/validate"
 	"github.com/gobuffalo/validate/validators"
 	"github.com/pkg/errors"
+
+	"github.com/transcom/mymove/pkg/unit"
 )
 
 // Tariff400ngFullPackRate describes the rates paid to pack various weights of goods
 type Tariff400ngFullPackRate struct {
-	ID                 uuid.UUID `json:"id" db:"id"`
-	CreatedAt          time.Time `json:"created_at" db:"created_at"`
-	UpdatedAt          time.Time `json:"updated_at" db:"updated_at"`
-	Schedule           int       `json:"schedule" db:"schedule"`
-	WeightLbsLower     int       `json:"weight_lbs_lower" db:"weight_lbs_lower"`
-	WeightLbsUpper     int       `json:"weight_lbs_upper" db:"weight_lbs_upper"`
-	RateCents          int       `json:"rate_cents" db:"rate_cents"`
-	EffectiveDateLower time.Time `json:"effective_date_lower" db:"effective_date_lower"`
-	EffectiveDateUpper time.Time `json:"effective_date_upper" db:"effective_date_upper"`
+	ID                 uuid.UUID  `json:"id" db:"id"`
+	CreatedAt          time.Time  `json:"created_at" db:"created_at"`
+	UpdatedAt          time.Time  `json:"updated_at" db:"updated_at"`
+	Schedule           int        `json:"schedule" db:"schedule"`
+	WeightLbsLower     int        `json:"weight_lbs_lower" db:"weight_lbs_lower"`
+	WeightLbsUpper     int        `json:"weight_lbs_upper" db:"weight_lbs_upper"`
+	RateCents          unit.Cents `json:"rate_cents" db:"rate_cents"`
+	EffectiveDateLower time.Time  `json:"effective_date_lower" db:"effective_date_lower"`
+	EffectiveDateUpper time.Time  `json:"effective_date_upper" db:"effective_date_upper"`
 }
 
 // Tariff400ngFullPackRates is not required by pop and may be deleted
@@ -30,7 +32,7 @@ type Tariff400ngFullPackRates []Tariff400ngFullPackRate
 // This method is not required and may be deleted.
 func (t *Tariff400ngFullPackRate) Validate(tx *pop.Connection) (*validate.Errors, error) {
 	return validate.Validate(
-		&validators.IntIsGreaterThan{Field: t.RateCents, Name: "RateCents", Compared: -1},
+		&validators.IntIsGreaterThan{Field: t.RateCents.Int(), Name: "RateCents", Compared: -1},
 		&validators.IntIsLessThan{Field: t.WeightLbsLower, Name: "WeightLbsLower",
 			Compared: t.WeightLbsUpper},
 		&validators.TimeAfterTime{
@@ -41,7 +43,7 @@ func (t *Tariff400ngFullPackRate) Validate(tx *pop.Connection) (*validate.Errors
 
 // FetchTariff400ngFullPackRateCents returns the full unpack rate for a service
 // schedule and weight in CWT.
-func FetchTariff400ngFullPackRateCents(tx *pop.Connection, weightCWT int, schedule int) (int, error) {
+func FetchTariff400ngFullPackRateCents(tx *pop.Connection, weightCWT int, schedule int) (unit.Cents, error) {
 	rate := Tariff400ngFullPackRate{}
 	err := tx.Where("schedule = ? AND ? BETWEEN weight_lbs_lower AND weight_lbs_upper", schedule, weightCWT).First(&rate)
 	if err != nil {

--- a/pkg/models/tariff400ng_linehaul_rate.go
+++ b/pkg/models/tariff400ng_linehaul_rate.go
@@ -9,22 +9,24 @@ import (
 	"github.com/gobuffalo/uuid"
 	"github.com/gobuffalo/validate"
 	"github.com/gobuffalo/validate/validators"
+
+	"github.com/transcom/mymove/pkg/unit"
 )
 
 // Tariff400ngLinehaulRate describes the rate paids paid to transport various weights of goods
 // various distances.
 type Tariff400ngLinehaulRate struct {
-	ID                 uuid.UUID `json:"id" db:"id"`
-	CreatedAt          time.Time `json:"created_at" db:"created_at"`
-	UpdatedAt          time.Time `json:"updated_at" db:"updated_at"`
-	DistanceMilesLower int       `json:"distance_miles_lower" db:"distance_miles_lower"`
-	DistanceMilesUpper int       `json:"distance_miles_upper" db:"distance_miles_upper"`
-	Type               string    `json:"type" db:"type"`
-	WeightLbsLower     int       `json:"weight_lbs_lower" db:"weight_lbs_lower"`
-	WeightLbsUpper     int       `json:"weight_lbs_upper" db:"weight_lbs_upper"`
-	RateCents          int       `json:"rate_cents" db:"rate_cents"`
-	EffectiveDateLower time.Time `json:"effective_date_lower" db:"effective_date_lower"`
-	EffectiveDateUpper time.Time `json:"effective_date_upper" db:"effective_date_upper"`
+	ID                 uuid.UUID  `json:"id" db:"id"`
+	CreatedAt          time.Time  `json:"created_at" db:"created_at"`
+	UpdatedAt          time.Time  `json:"updated_at" db:"updated_at"`
+	DistanceMilesLower int        `json:"distance_miles_lower" db:"distance_miles_lower"`
+	DistanceMilesUpper int        `json:"distance_miles_upper" db:"distance_miles_upper"`
+	Type               string     `json:"type" db:"type"`
+	WeightLbsLower     int        `json:"weight_lbs_lower" db:"weight_lbs_lower"`
+	WeightLbsUpper     int        `json:"weight_lbs_upper" db:"weight_lbs_upper"`
+	RateCents          unit.Cents `json:"rate_cents" db:"rate_cents"`
+	EffectiveDateLower time.Time  `json:"effective_date_lower" db:"effective_date_lower"`
+	EffectiveDateUpper time.Time  `json:"effective_date_upper" db:"effective_date_upper"`
 }
 
 // String is not required by pop and may be deleted
@@ -46,7 +48,7 @@ func (t Tariff400ngLinehaulRates) String() string {
 // This method is not required and may be deleted.
 func (t *Tariff400ngLinehaulRate) Validate(tx *pop.Connection) (*validate.Errors, error) {
 	return validate.Validate(
-		&validators.IntIsGreaterThan{Field: t.RateCents, Name: "RateCents", Compared: -1},
+		&validators.IntIsGreaterThan{Field: t.RateCents.Int(), Name: "RateCents", Compared: -1},
 		&validators.IntIsLessThan{Field: t.DistanceMilesLower, Name: "DistanceMilesLower",
 			Compared: t.DistanceMilesUpper},
 		&validators.IntIsLessThan{Field: t.WeightLbsLower, Name: "WeightLbsLower",
@@ -70,9 +72,9 @@ func (t *Tariff400ngLinehaulRate) ValidateUpdate(tx *pop.Connection) (*validate.
 }
 
 // FetchBaseLinehaulRate takes a move's distance and weight and queries the tariff400ng_linehaul_rates table to find a move's base linehaul rate.
-func FetchBaseLinehaulRate(tx *pop.Connection, mileage int, cwt int, date time.Time) (linehaulRate int, err error) {
+func FetchBaseLinehaulRate(tx *pop.Connection, mileage int, cwt int, date time.Time) (linehaulRate unit.Cents, err error) {
 	moveType := "ConusLinehaul" // TODO: change to a parameter once we're serving more move types
-	var linehaulRates []int
+	var linehaulRates []unit.Cents
 
 	sql := `SELECT
 		rate_cents
@@ -97,6 +99,6 @@ func FetchBaseLinehaulRate(tx *pop.Connection, mileage int, cwt int, date time.T
 			len(linehaulRates), mileage, cwt, date)
 	}
 
-	return linehaulRates[0], err
+	return unit.Cents(linehaulRates[0]), err
 
 }

--- a/pkg/models/tariff400ng_linehaul_rate_test.go
+++ b/pkg/models/tariff400ng_linehaul_rate_test.go
@@ -5,6 +5,7 @@ import (
 
 	. "github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"
+	"github.com/transcom/mymove/pkg/unit"
 )
 
 func (suite *ModelSuite) Test_LinehaulEffectiveDateValidation() {
@@ -113,7 +114,7 @@ func (suite *ModelSuite) Test_LinehaulDistanceValidation() {
 
 func (suite *ModelSuite) Test_LinehaulRateCreateAndSave() {
 	t := suite.T()
-	mySpecificRate := 474747
+	mySpecificRate := unit.Cents(474747)
 
 	newBaseLinehaul := Tariff400ngLinehaulRate{
 		DistanceMilesLower: 3101,
@@ -127,7 +128,7 @@ func (suite *ModelSuite) Test_LinehaulRateCreateAndSave() {
 
 	suite.mustSave(&newBaseLinehaul)
 
-	linehaulRate := 0
+	linehaulRate := unit.Cents(0)
 
 	sql := `SELECT
 			rate_cents

--- a/pkg/models/tariff400ng_service_area.go
+++ b/pkg/models/tariff400ng_service_area.go
@@ -8,20 +8,22 @@ import (
 	"github.com/gobuffalo/validate"
 	"github.com/gobuffalo/validate/validators"
 	"github.com/pkg/errors"
+
+	"github.com/transcom/mymove/pkg/unit"
 )
 
 // Tariff400ngServiceArea describes the service charges for various service areas
 type Tariff400ngServiceArea struct {
-	ID                 uuid.UUID `json:"id" db:"id"`
-	CreatedAt          time.Time `json:"created_at" db:"created_at"`
-	UpdatedAt          time.Time `json:"updated_at" db:"updated_at"`
-	Name               string    `json:"name" db:"name"`
-	ServiceArea        int       `json:"service_area" db:"service_area"`
-	ServicesSchedule   int       `json:"services_schedule" db:"services_schedule"`
-	LinehaulFactor     int       `json:"linehaul_factor" db:"linehaul_factor"`
-	ServiceChargeCents int       `json:"service_charge_cents" db:"service_charge_cents"`
-	EffectiveDateLower time.Time `json:"effective_date_lower" db:"effective_date_lower"`
-	EffectiveDateUpper time.Time `json:"effective_date_upper" db:"effective_date_upper"`
+	ID                 uuid.UUID  `json:"id" db:"id"`
+	CreatedAt          time.Time  `json:"created_at" db:"created_at"`
+	UpdatedAt          time.Time  `json:"updated_at" db:"updated_at"`
+	Name               string     `json:"name" db:"name"`
+	ServiceArea        int        `json:"service_area" db:"service_area"`
+	ServicesSchedule   int        `json:"services_schedule" db:"services_schedule"`
+	LinehaulFactor     unit.Cents `json:"linehaul_factor" db:"linehaul_factor"`
+	ServiceChargeCents unit.Cents `json:"service_charge_cents" db:"service_charge_cents"`
+	EffectiveDateLower time.Time  `json:"effective_date_lower" db:"effective_date_lower"`
+	EffectiveDateUpper time.Time  `json:"effective_date_upper" db:"effective_date_upper"`
 }
 
 // Tariff400ngServiceAreas is not required by pop and may be deleted
@@ -31,7 +33,7 @@ type Tariff400ngServiceAreas []Tariff400ngServiceArea
 // This method is not required and may be deleted.
 func (t *Tariff400ngServiceArea) Validate(tx *pop.Connection) (*validate.Errors, error) {
 	return validate.Validate(
-		&validators.IntIsGreaterThan{Field: t.ServiceChargeCents, Name: "ServiceChargeCents", Compared: -1},
+		&validators.IntIsGreaterThan{Field: t.ServiceChargeCents.Int(), Name: "ServiceChargeCents", Compared: -1},
 		&validators.TimeAfterTime{
 			FirstTime: t.EffectiveDateUpper, FirstName: "EffectiveDateUpper",
 			SecondTime: t.EffectiveDateLower, SecondName: "EffectiveDateLower"},
@@ -50,7 +52,7 @@ func FetchTariff400ngServiceAreaForZip3(db *pop.Connection, zip3 int) (Tariff400
 }
 
 // FetchTariff400ngLinehaulFactor returns linehaul_factor for an origin or destination based on service area.
-func FetchTariff400ngLinehaulFactor(tx *pop.Connection, serviceArea int, rateEngineDate time.Time) (linehaulFactor int, err error) {
+func FetchTariff400ngLinehaulFactor(tx *pop.Connection, serviceArea int, rateEngineDate time.Time) (linehaulFactor unit.Cents, err error) {
 	sql := `SELECT
 			linehaul_factor
 		FROM
@@ -63,5 +65,5 @@ func FetchTariff400ngLinehaulFactor(tx *pop.Connection, serviceArea int, rateEng
 		`
 	err = tx.RawQuery(sql, serviceArea, rateEngineDate).First(&linehaulFactor)
 
-	return linehaulFactor, err
+	return unit.Cents(linehaulFactor), err
 }

--- a/pkg/models/tariff400ng_shorthaul_rate.go
+++ b/pkg/models/tariff400ng_shorthaul_rate.go
@@ -9,18 +9,20 @@ import (
 	"github.com/gobuffalo/uuid"
 	"github.com/gobuffalo/validate"
 	"github.com/gobuffalo/validate/validators"
+
+	"github.com/transcom/mymove/pkg/unit"
 )
 
 // Tariff400ngShorthaulRate describes the rates paid for shorthaul shipments
 type Tariff400ngShorthaulRate struct {
-	ID                 uuid.UUID `json:"id" db:"id"`
-	CreatedAt          time.Time `json:"created_at" db:"created_at"`
-	UpdatedAt          time.Time `json:"updated_at" db:"updated_at"`
-	CwtMilesLower      int       `json:"cwt_miles_lower" db:"cwt_miles_lower"`
-	CwtMilesUpper      int       `json:"cwt_miles_upper" db:"cwt_miles_upper"`
-	RateCents          int       `json:"rate_cents" db:"rate_cents"`
-	EffectiveDateLower time.Time `json:"effective_date_lower" db:"effective_date_lower"`
-	EffectiveDateUpper time.Time `json:"effective_date_upper" db:"effective_date_upper"`
+	ID                 uuid.UUID  `json:"id" db:"id"`
+	CreatedAt          time.Time  `json:"created_at" db:"created_at"`
+	UpdatedAt          time.Time  `json:"updated_at" db:"updated_at"`
+	CwtMilesLower      int        `json:"cwt_miles_lower" db:"cwt_miles_lower"`
+	CwtMilesUpper      int        `json:"cwt_miles_upper" db:"cwt_miles_upper"`
+	RateCents          unit.Cents `json:"rate_cents" db:"rate_cents"`
+	EffectiveDateLower time.Time  `json:"effective_date_lower" db:"effective_date_lower"`
+	EffectiveDateUpper time.Time  `json:"effective_date_upper" db:"effective_date_upper"`
 }
 
 // String is not required by pop and may be deleted
@@ -42,7 +44,7 @@ func (t Tariff400ngShorthaulRates) String() string {
 // This method is not required and may be deleted.
 func (t *Tariff400ngShorthaulRate) Validate(tx *pop.Connection) (*validate.Errors, error) {
 	return validate.Validate(
-		&validators.IntIsGreaterThan{Field: t.RateCents, Name: "ServiceChargeCents", Compared: -1},
+		&validators.IntIsGreaterThan{Field: t.RateCents.Int(), Name: "ServiceChargeCents", Compared: -1},
 		&validators.IntIsGreaterThan{Field: t.CwtMilesUpper, Name: "CwtMilesUpper",
 			Compared: t.CwtMilesLower},
 		&validators.TimeAfterTime{
@@ -66,7 +68,7 @@ func (t *Tariff400ngShorthaulRate) ValidateUpdate(tx *pop.Connection) (*validate
 // FetchShorthaulRateCents returns the shorthaul rate for a given Centumweight-Miles
 // (cwtMiles is a unit capturing the movement of 100lbs by 1 mile.) The value returned
 // is in cents of 1 USD.
-func FetchShorthaulRateCents(tx *pop.Connection, cwtMiles int, date time.Time) (rateCents int, err error) {
+func FetchShorthaulRateCents(tx *pop.Connection, cwtMiles int, date time.Time) (rateCents unit.Cents, err error) {
 	sh := Tariff400ngShorthaulRates{}
 
 	sql := `SELECT

--- a/pkg/models/tariff400ng_shorthaul_rate_test.go
+++ b/pkg/models/tariff400ng_shorthaul_rate_test.go
@@ -5,6 +5,7 @@ import (
 
 	. "github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"
+	"github.com/transcom/mymove/pkg/unit"
 )
 
 func (suite *ModelSuite) Test_ShorthaulRateEffectiveDateValidation() {
@@ -93,7 +94,7 @@ func (suite *ModelSuite) Test_FetchShorthaulRateCents() {
 	t := suite.T()
 
 	// Test the lower bound of a cwtMile range
-	rate1 := 100
+	rate1 := unit.Cents(100)
 	sh1 := Tariff400ngShorthaulRate{
 		CwtMilesLower:      1000,
 		CwtMilesUpper:      2000,
@@ -112,7 +113,7 @@ func (suite *ModelSuite) Test_FetchShorthaulRateCents() {
 	}
 
 	// Test the upper bound of the CwtMiles
-	rate2 := 200
+	rate2 := unit.Cents(200)
 	sh2 := Tariff400ngShorthaulRate{
 		CwtMilesLower:      2000,
 		CwtMilesUpper:      3000,
@@ -131,7 +132,7 @@ func (suite *ModelSuite) Test_FetchShorthaulRateCents() {
 	}
 
 	// And this rate is in a different EffectiveDate band
-	rate3 := 300
+	rate3 := unit.Cents(300)
 	sh3 := Tariff400ngShorthaulRate{
 		CwtMilesLower:      1000,
 		CwtMilesUpper:      2000,

--- a/pkg/rateengine/linehaul.go
+++ b/pkg/rateengine/linehaul.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/unit"
 	"go.uber.org/zap"
 )
 
@@ -20,7 +21,7 @@ func (re *RateEngine) determineMileage(originZip int, destinationZip int) (milea
 }
 
 // Determine the Base Linehaul (BLH)
-func (re *RateEngine) baseLinehaul(mileage int, cwt int, date time.Time) (baseLinehaulChargeCents int, err error) {
+func (re *RateEngine) baseLinehaul(mileage int, cwt int, date time.Time) (baseLinehaulChargeCents unit.Cents, err error) {
 	baseLinehaulChargeCents, err = models.FetchBaseLinehaulRate(re.db, mileage, cwt, date)
 	if err != nil {
 		re.logger.Error("Base Linehaul query didn't complete: ", zap.Error(err))
@@ -30,7 +31,7 @@ func (re *RateEngine) baseLinehaul(mileage int, cwt int, date time.Time) (baseLi
 }
 
 // Determine the Linehaul Factors (OLF and DLF)
-func (re *RateEngine) linehaulFactors(cwt int, zip3 int, date time.Time) (linehaulFactorCents int, err error) {
+func (re *RateEngine) linehaulFactors(cwt int, zip3 int, date time.Time) (linehaulFactorCents unit.Cents, err error) {
 	serviceArea, err := models.FetchTariff400ngServiceAreaForZip3(re.db, zip3)
 	if err != nil {
 		return 0, err
@@ -39,11 +40,11 @@ func (re *RateEngine) linehaulFactors(cwt int, zip3 int, date time.Time) (lineha
 	if err != nil {
 		return 0, err
 	}
-	return cwt * linehaulFactorCents, nil
+	return linehaulFactorCents.Multiply(cwt), nil
 }
 
 // Determine Shorthaul (SH) Charge (ONLY applies if shipment moves 800 miles and less)
-func (re *RateEngine) shorthaulCharge(mileage int, cwt int, date time.Time) (shorthaulChargeCents int, err error) {
+func (re *RateEngine) shorthaulCharge(mileage int, cwt int, date time.Time) (shorthaulChargeCents unit.Cents, err error) {
 	if mileage >= 800 {
 		return 0, nil
 	}
@@ -58,7 +59,7 @@ func (re *RateEngine) shorthaulCharge(mileage int, cwt int, date time.Time) (sho
 
 // Determine Linehaul Charge (LC) TOTAL
 // Formula: LC= [BLH + OLF + DLF + [SH]
-func (re *RateEngine) linehaulChargeTotal(weight int, originZip int, destinationZip int, date time.Time) (linehaulChargeCents int, err error) {
+func (re *RateEngine) linehaulChargeTotal(weight int, originZip int, destinationZip int, date time.Time) (linehaulChargeCents unit.Cents, err error) {
 	mileage, err := re.determineMileage(originZip, destinationZip)
 	cwt := re.determineCWT(weight)
 	baseLinehaulChargeCents, err := re.baseLinehaul(mileage, cwt, date)
@@ -80,11 +81,11 @@ func (re *RateEngine) linehaulChargeTotal(weight int, originZip int, destination
 
 	linehaulChargeCents = baseLinehaulChargeCents + originLinehaulFactorCents + destinationLinehaulFactorCents + shorthaulChargeCents
 	re.logger.Info("Linehaul charge total calculated",
-		zap.Int("linehaul total", linehaulChargeCents),
-		zap.Int("linehaul", baseLinehaulChargeCents),
-		zap.Int("origin lh factor", originLinehaulFactorCents),
-		zap.Int("destination lh factor", destinationLinehaulFactorCents),
-		zap.Int("shorthaul", shorthaulChargeCents))
+		zap.Stringer("linehaul total", linehaulChargeCents),
+		zap.Stringer("linehaul", baseLinehaulChargeCents),
+		zap.Stringer("origin lh factor", originLinehaulFactorCents),
+		zap.Stringer("destination lh factor", destinationLinehaulFactorCents),
+		zap.Stringer("shorthaul", shorthaulChargeCents))
 
 	return linehaulChargeCents, err
 }

--- a/pkg/rateengine/linehaul_test.go
+++ b/pkg/rateengine/linehaul_test.go
@@ -3,6 +3,7 @@ package rateengine
 import (
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"
+	"github.com/transcom/mymove/pkg/unit"
 )
 
 func (suite *RateEngineSuite) Test_CheckDetermineMileage() {
@@ -22,7 +23,7 @@ func (suite *RateEngineSuite) Test_CheckBaseLinehaul() {
 	t := suite.T()
 	engine := NewRateEngine(suite.db, suite.logger)
 
-	expected := 128000
+	expected := unit.Cents(128000)
 
 	newBaseLinehaul := models.Tariff400ngLinehaulRate{
 		DistanceMilesLower: 3101,
@@ -95,7 +96,7 @@ func (suite *RateEngineSuite) Test_CheckLinehaulFactors() {
 	if err != nil {
 		t.Error("Unable to determine linehaulFactor: ", err)
 	}
-	expected := 3420
+	expected := unit.Cents(3420)
 	if linehaulFactor != expected {
 		t.Errorf("Determined linehaul factor incorrectly. Expected %d, got %d", expected, linehaulFactor)
 	}
@@ -106,7 +107,7 @@ func (suite *RateEngineSuite) Test_CheckShorthaulCharge() {
 	engine := NewRateEngine(suite.db, suite.logger)
 	mileage := 799
 	cwt := 40
-	rate := 5656
+	rate := unit.Cents(5656)
 
 	sh := models.Tariff400ngShorthaulRate{
 		CwtMilesLower:      1,
@@ -127,7 +128,7 @@ func (suite *RateEngineSuite) Test_CheckLinehaulChargeTotal() {
 	t := suite.T()
 	engine := NewRateEngine(suite.db, suite.logger)
 	weight := 2000
-	expected := 8820
+	expected := unit.Cents(8820)
 	zip3Austin := 787
 	zip3SanFrancisco := 941
 

--- a/pkg/rateengine/nonlinehaul.go
+++ b/pkg/rateengine/nonlinehaul.go
@@ -1,19 +1,22 @@
 package rateengine
 
 import (
-	"github.com/transcom/mymove/pkg/models"
 	"go.uber.org/zap"
+	"math"
+
+	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/unit"
 )
 
-func (re *RateEngine) serviceFeeCents(cwt int, zip3 int) (int, error) {
+func (re *RateEngine) serviceFeeCents(cwt int, zip3 int) (unit.Cents, error) {
 	serviceArea, err := models.FetchTariff400ngServiceAreaForZip3(re.db, zip3)
 	if err != nil {
 		return 0, err
 	}
-	return cwt * serviceArea.ServiceChargeCents, nil
+	return serviceArea.ServiceChargeCents.Multiply(cwt), nil
 }
 
-func (re *RateEngine) fullPackCents(cwt int, zip3 int) (int, error) {
+func (re *RateEngine) fullPackCents(cwt int, zip3 int) (unit.Cents, error) {
 	serviceArea, err := models.FetchTariff400ngServiceAreaForZip3(re.db, zip3)
 	if err != nil {
 		return 0, err
@@ -24,10 +27,10 @@ func (re *RateEngine) fullPackCents(cwt int, zip3 int) (int, error) {
 		return 0, err
 	}
 
-	return cwt * fullPackRate, nil
+	return fullPackRate.Multiply(cwt), nil
 }
 
-func (re *RateEngine) fullUnpackCents(cwt int, zip3 int) (int, error) {
+func (re *RateEngine) fullUnpackCents(cwt int, zip3 int) (unit.Cents, error) {
 	serviceArea, err := models.FetchTariff400ngServiceAreaForZip3(re.db, zip3)
 	if err != nil {
 		return 0, err
@@ -38,10 +41,10 @@ func (re *RateEngine) fullUnpackCents(cwt int, zip3 int) (int, error) {
 		return 0, err
 	}
 
-	return cwt * fullUnpackRate / 1000, nil
+	return unit.Cents(math.Round(float64(cwt*fullUnpackRate) / 1000.0)), nil
 }
 
-func (re *RateEngine) nonLinehaulChargeTotalCents(weight int, originZip int, destinationZip int) (int, error) {
+func (re *RateEngine) nonLinehaulChargeTotalCents(weight int, originZip int, destinationZip int) (unit.Cents, error) {
 	cwt := re.determineCWT(weight)
 	originServiceFee, err := re.serviceFeeCents(cwt, originZip)
 	if err != nil {
@@ -62,10 +65,10 @@ func (re *RateEngine) nonLinehaulChargeTotalCents(weight int, originZip int, des
 	subTotal := originServiceFee + destinationServiceFee + pack + unpack
 
 	re.logger.Info("Non-Linehaul charge total calculated",
-		zap.Int("origin service fee", originServiceFee),
-		zap.Int("destination service fee", destinationServiceFee),
-		zap.Int("pack fee", pack),
-		zap.Int("unpack fee", unpack))
+		zap.Int("origin service fee", originServiceFee.Int()),
+		zap.Int("destination service fee", destinationServiceFee.Int()),
+		zap.Int("pack fee", pack.Int()),
+		zap.Int("unpack fee", unpack.Int()))
 
 	return subTotal, nil
 }

--- a/pkg/rateengine/nonlinehaul_test.go
+++ b/pkg/rateengine/nonlinehaul_test.go
@@ -3,6 +3,7 @@ package rateengine
 import (
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"
+	"github.com/transcom/mymove/pkg/unit"
 )
 
 func (suite *RateEngineSuite) Test_CheckServiceFee() {
@@ -34,7 +35,7 @@ func (suite *RateEngineSuite) Test_CheckServiceFee() {
 		t.Fatalf("failed to calculate service fee: %s", err)
 	}
 
-	expected := 17500
+	expected := unit.Cents(17500)
 	if fee != expected {
 		t.Errorf("wrong service fee: expected %d, got %d", expected, fee)
 	}
@@ -81,7 +82,7 @@ func (suite *RateEngineSuite) Test_CheckFullPack() {
 		t.Fatalf("failed to calculate full pack fee: %s", err)
 	}
 
-	expected := 271450
+	expected := unit.Cents(271450)
 	if fee != expected {
 		t.Errorf("wrong full pack fee: expected %d, got %d", expected, fee)
 	}
@@ -135,7 +136,7 @@ func (suite *RateEngineSuite) Test_CheckFullUnpack() {
 		t.Fatalf("failed to calculate full unpack fee: %s", err)
 	}
 
-	expected := 27145
+	expected := unit.Cents(27145)
 	if fee != expected {
 		t.Errorf("wrong full unpack fee: expected %d, got %d", expected, fee)
 	}
@@ -211,7 +212,7 @@ func (suite *RateEngineSuite) Test_CheckNonLinehaulChargeTotal() {
 		t.Fatalf("failed to calculate non linehaul charge: %s", err)
 	}
 	// (7000 + 13260 + 108580 + 10858)
-	expected := 139698
+	expected := unit.Cents(139698)
 	if fee != expected {
 		t.Errorf("wrong non-linehaul charge total: expected %d, got %d", expected, fee)
 	}

--- a/pkg/rateengine/rateengine.go
+++ b/pkg/rateengine/rateengine.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/gobuffalo/pop"
 	"go.uber.org/zap"
+
+	"github.com/transcom/mymove/pkg/unit"
 )
 
 // RateEngine encapsulates the TSP rate engine process
@@ -17,7 +19,7 @@ func (re *RateEngine) determineCWT(weight int) (cwt int) {
 	return weight / 100
 }
 
-func (re *RateEngine) computePPM(weight int, originZip int, destinationZip int, date time.Time, inverseDiscount float64) (int, error) {
+func (re *RateEngine) computePPM(weight int, originZip int, destinationZip int, date time.Time, inverseDiscount float64) (unit.Cents, error) {
 	cwt := re.determineCWT(weight)
 	// Linehaul charges
 	mileage, err := re.determineMileage(originZip, destinationZip)
@@ -68,23 +70,23 @@ func (re *RateEngine) computePPM(weight int, originZip int, destinationZip int, 
 	}
 	ppmSubtotal := baseLinehaulChargeCents + originLinehaulFactorCents + destinationLinehaulFactorCents +
 		shorthaulChargeCents + originServiceFee + destinationServiceFee + pack + unpack
-	ppmBestValue := int(float64(ppmSubtotal) * inverseDiscount)
+	ppmBestValue := ppmSubtotal.MultiplyFloat64(inverseDiscount)
 
 	// PPMs only pay 95% of the best value
-	ppmPayback := int(float64(ppmBestValue) * .95)
+	ppmPayback := ppmBestValue.MultiplyFloat64(.95)
 
 	re.logger.Info("PPM compensation total calculated",
-		zap.Int("PPM compensation total", ppmPayback),
-		zap.Int("PPM subtotal", ppmSubtotal),
+		zap.Int("PPM compensation total", ppmPayback.Int()),
+		zap.Int("PPM subtotal", ppmSubtotal.Int()),
 		zap.Float64("inverse discount", inverseDiscount),
-		zap.Int("base linehaul", baseLinehaulChargeCents),
-		zap.Int("origin lh factor", originLinehaulFactorCents),
-		zap.Int("destination lh factor", destinationLinehaulFactorCents),
-		zap.Int("shorthaul", shorthaulChargeCents),
-		zap.Int("origin service fee", originServiceFee),
-		zap.Int("destination service fee", destinationServiceFee),
-		zap.Int("pack fee", pack),
-		zap.Int("unpack fee", unpack),
+		zap.Int("base linehaul", baseLinehaulChargeCents.Int()),
+		zap.Int("origin lh factor", originLinehaulFactorCents.Int()),
+		zap.Int("destination lh factor", destinationLinehaulFactorCents.Int()),
+		zap.Int("shorthaul", shorthaulChargeCents.Int()),
+		zap.Int("origin service fee", originServiceFee.Int()),
+		zap.Int("destination service fee", destinationServiceFee.Int()),
+		zap.Int("pack fee", pack.Int()),
+		zap.Int("unpack fee", unpack.Int()),
 	)
 
 	return ppmPayback, nil

--- a/pkg/rateengine/rateengine_test.go
+++ b/pkg/rateengine/rateengine_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"
+	"github.com/transcom/mymove/pkg/unit"
 )
 
 func (suite *RateEngineSuite) Test_CheckDetermineCWT() {
@@ -109,7 +110,7 @@ func (suite *RateEngineSuite) Test_CheckPPMTotal() {
 		t.Fatalf("failed to calculate ppm charge: %s", err)
 	}
 
-	expected := 61642
+	expected := unit.Cents(61643)
 	if fee != expected {
 		t.Errorf("wrong PPM charge total: expected %d, got %d", expected, fee)
 	}

--- a/pkg/unit/cents.go
+++ b/pkg/unit/cents.go
@@ -1,0 +1,29 @@
+package unit
+
+import (
+	"math"
+	"strconv"
+)
+
+// Cents represents a value in hundreths of US dollars (aka cents).
+type Cents int
+
+// Multiply returns the value of self multiplied by multiplier
+func (c Cents) Multiply(i int) Cents {
+	return Cents(i * int(c))
+}
+
+// MultiplyFloat64 returns the value of self multiplied by multiplier
+func (c Cents) MultiplyFloat64(f float64) Cents {
+	return Cents(math.Round(float64(c) * f))
+}
+
+// Multiply returns the value of self multiplied by multiplier
+func (c Cents) String() string {
+	return strconv.Itoa(int(c))
+}
+
+// Int returns the value of self as an int
+func (c Cents) Int() int {
+	return int(c)
+}

--- a/pkg/unit/cents_test.go
+++ b/pkg/unit/cents_test.go
@@ -1,0 +1,25 @@
+package unit
+
+import (
+	"testing"
+)
+
+func TestCentsMultiply(t *testing.T) {
+	cents := Cents(25)
+	result := cents.Multiply(5)
+
+	expected := Cents(125)
+	if result != expected {
+		t.Errorf("wrong number of Cents: expected %d, got %d", expected, result)
+	}
+}
+
+func TestCentsMultiplyFloat64(t *testing.T) {
+	cents := Cents(2500)
+	result := cents.MultiplyFloat64(0.333)
+
+	expected := Cents(833)
+	if result != expected {
+		t.Errorf("wrong number of Cents: expected %d, got %d", expected, result)
+	}
+}


### PR DESCRIPTION
## Description

In order to make the interface of our functions more clear and make sure that we're working with money in a safer way, this PR adds a `Cents` type and uses it wherever we are representing a value in cents.

## Reviewer Notes

* I created a new package, `unit`,  as the home for `Cents` as I anticipate us adding other unit types in the future and it didn't feel right to put it in any of our other packages since it is used almost everywhere.
* I did not deal with the millicents in `pkg/models/tariff400ng_full_unpack_rate.go`, as that involves a migration and feels like another story to me.

## Code Review Verification Steps

* [ ] All tests pass.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/156634529) for this change