### PR TITLE
Add missing uniqe index on service member -> user

### DIFF
--- a/migrations/20180406001008_add_uniq_to_service_member_user.down.fizz
+++ b/migrations/20180406001008_add_uniq_to_service_member_user.down.fizz
@@ -1,0 +1,1 @@
+drop_index("service_members", "service_members_user_id_uniq_idx")

--- a/migrations/20180406001008_add_uniq_to_service_member_user.up.fizz
+++ b/migrations/20180406001008_add_uniq_to_service_member_user.up.fizz
@@ -1,0 +1,1 @@
+add_index("service_members", "user_id", {"unique": true, "name": "service_members_user_id_uniq_idx"})

--- a/migrations/20180406001008_add_uniq_to_service_member_user.up.fizz
+++ b/migrations/20180406001008_add_uniq_to_service_member_user.up.fizz
@@ -1,1 +1,2 @@
+raw("delete from service_members;")
 add_index("service_members", "user_id", {"unique": true, "name": "service_members_user_id_uniq_idx"})


### PR DESCRIPTION
## Description

There should only ever be one service member for a given user. This migration adds a unique index to the service member table on user_id

## Code Review Verification Steps

* [ ] All tests pass.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/blob/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* [ ] There are no [aXe](https://www.deque.com/products/aXe/) warnings for UI.
* [ ] This works in IE.
* [ ] Any new third party client side dependencies (e.g., login.gov, google analytics, CDN libraries, etc.) have been communicated to @willowbl00.
* [ ] Request review from a member of a different team.
* [ ] (TRIAL) Have the Pivotal acceptance criteria been met for this change?
