### PR TITLE
Up work factor to make cracking SSN's sufficiently difficult.

### DIFF
--- a/migrations/20180413234226_delete_ssns_with_old_workfactor.up.fizz
+++ b/migrations/20180413234226_delete_ssns_with_old_workfactor.up.fizz
@@ -1,0 +1,1 @@
+raw("DELETE from social_security_numbers")

--- a/pkg/models/social_security_number.go
+++ b/pkg/models/social_security_number.go
@@ -50,7 +50,11 @@ func (s *SocialSecurityNumber) SetEncryptedHash(unencryptedSSN string) (*validat
 		return verrs, nil
 	}
 
-	byteHash, err := bcrypt.GenerateFromPassword([]byte(unencryptedSSN), -1) // -1 chooses the default cost
+	workFactor := 13 // This was timed on the staging infrastructure to be ~1 second per hash.
+	// # of iterations is 2 ^ workFactor
+	// ~1 second per hash was picked based on this description:
+	// https://security.stackexchange.com/questions/3959/recommended-of-iterations-when-using-pkbdf2-sha256/3993
+	byteHash, err := bcrypt.GenerateFromPassword([]byte(unencryptedSSN), 13)
 	if err != nil {
 		return verrs, err
 	}
@@ -70,7 +74,7 @@ func BuildSocialSecurityNumber(unencryptedSSN string) (*SocialSecurityNumber, *v
 	return &ssn, verrs, nil
 }
 
-// Matches returns true if the encrypted_hahs matches the unencryptedSSN
+// Matches returns true if the encrypted_hash matches the unencryptedSSN
 func (s SocialSecurityNumber) Matches(unencryptedSSN string) bool {
 	err := bcrypt.CompareHashAndPassword([]byte(s.EncryptedHash), []byte(unencryptedSSN))
 	return err == nil

--- a/pkg/models/social_security_number.go
+++ b/pkg/models/social_security_number.go
@@ -50,7 +50,7 @@ func (s *SocialSecurityNumber) SetEncryptedHash(unencryptedSSN string) (*validat
 		return verrs, nil
 	}
 
-	workFactor := 13 // This was timed on the staging infrastructure to be ~1 second per hash.
+	workFactor := 13 // This was timed on the staging infrastructure to be ~1 second per hash. ( .76 sph actual)
 	// # of iterations is 2 ^ workFactor
 	// ~1 second per hash was picked based on this description:
 	// https://security.stackexchange.com/questions/3959/recommended-of-iterations-when-using-pkbdf2-sha256/3993

--- a/pkg/models/social_security_number.go
+++ b/pkg/models/social_security_number.go
@@ -54,7 +54,7 @@ func (s *SocialSecurityNumber) SetEncryptedHash(unencryptedSSN string) (*validat
 	// # of iterations is 2 ^ workFactor
 	// ~1 second per hash was picked based on this description:
 	// https://security.stackexchange.com/questions/3959/recommended-of-iterations-when-using-pkbdf2-sha256/3993
-	byteHash, err := bcrypt.GenerateFromPassword([]byte(unencryptedSSN), 13)
+	byteHash, err := bcrypt.GenerateFromPassword([]byte(unencryptedSSN), workFactor)
 	if err != nil {
 		return verrs, err
 	}


### PR DESCRIPTION
Based on a conversation I had with @brainsik, I have upped the work factor for 
bcrypt from 10 to 13 based on testing on our infrastructure. 

Here is the output from the testing:

```
HELLO TIMER
Took 2.333046263s elapsed to generate 100 hashes with work factor 8 (42.86241622633439 hash/second)
Took 9.586848242s elapsed to generate 100 hashes with work factor 10 (10.430956814555572 hash/second)
Took 38.247243953s elapsed to generate 100 hashes with work factor 12 (2.6145674737475115 hash/second)
```

Code to generate this is found here: https://github.com/macrael/bcrypt_timer