### PR TITLE
Query TSP Performance to determine discount rate [delivers #156634751]

### DIFF
--- a/pkg/models/transportation_service_provider_performance.go
+++ b/pkg/models/transportation_service_provider_performance.go
@@ -246,10 +246,10 @@ func GetRateCycle(year int, peak bool) (start time.Time, end time.Time) {
 	return start, end
 }
 
-// FetchDiscountRate returns the discount rate for the TSP with the highest
+// FetchLinehaulRate returns the discount rate for the TSP with the highest
 // BVS during the specified data, limited to those TSPs in the channel defined by the
 // originZip and destinationZip.
-func FetchDiscountRate(db *pop.Connection, originZip string, destinationZip string, cos string, date time.Time) (float64, error) {
+func FetchLinehaulRate(db *pop.Connection, originZip string, destinationZip string, cos string, date time.Time) (float64, error) {
 	rateArea, err := FetchRateAreaForZip5(db, originZip)
 	if err != nil {
 		return 0.0, errors.Wrapf(err, "could not find a rate area for zip %s", originZip)

--- a/pkg/models/transportation_service_provider_performance.go
+++ b/pkg/models/transportation_service_provider_performance.go
@@ -277,6 +277,5 @@ func FetchDiscountRate(db *pop.Connection, originZip string, destinationZip stri
 	if err != nil {
 		return 0.0, errors.Wrap(err, "could find the tsp performance")
 	}
-	// return tspPerformance.DiscountRate, nil
-	return 50.5, nil
+	return tspPerformance.LinehaulRate, nil
 }

--- a/pkg/models/transportation_service_provider_performance.go
+++ b/pkg/models/transportation_service_provider_performance.go
@@ -2,7 +2,6 @@ package models
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"math"
 	"sort"
@@ -12,7 +11,7 @@ import (
 	"github.com/gobuffalo/uuid"
 	"github.com/gobuffalo/validate"
 	"github.com/gobuffalo/validate/validators"
-	//"go.uber.org/zap"
+	"github.com/pkg/errors"
 )
 
 var qualityBands = []int{1, 2, 3, 4}
@@ -245,4 +244,39 @@ func GetRateCycle(year int, peak bool) (start time.Time, end time.Time) {
 	}
 
 	return start, end
+}
+
+// FetchDiscountRate returns the discount rate for the TSP with the highest
+// BVS during the specified data, limited to those TSPs in the channel defined by the
+// originZip and destinationZip.
+func FetchDiscountRate(db *pop.Connection, originZip string, destinationZip string, cos string, date time.Time) (float64, error) {
+	rateArea, err := FetchRateAreaForZip5(db, originZip)
+	if err != nil {
+		return 0.0, errors.Wrapf(err, "could not find a rate area for zip %s", originZip)
+	}
+	region, err := FetchRegionForZip5(db, destinationZip)
+	if err != nil {
+		return 0.0, errors.Wrapf(err, "could not find a region for zip %s", destinationZip)
+	}
+
+	var tspPerformance TransportationServiceProviderPerformance
+
+	query := `
+		SELECT tspp.*
+		FROM transportation_service_provider_performances AS tspp
+		LEFT JOIN traffic_distribution_lists AS tdl ON tdl.id = tspp.traffic_distribution_list_id
+		WHERE
+			tdl.source_rate_area = $1
+			AND tdl.destination_region = $2
+			AND tdl.code_of_service = $3
+			AND tspp.rate_cycle_start <= $4 AND tspp.rate_cycle_end > $4
+		ORDER BY tspp.best_value_score DESC
+	`
+
+	err = db.RawQuery(query, rateArea, region, cos, date).First(&tspPerformance)
+	if err != nil {
+		return 0.0, errors.Wrap(err, "could find the tsp performance")
+	}
+	// return tspPerformance.DiscountRate, nil
+	return 50.5, nil
 }

--- a/pkg/models/transportation_service_provider_performance_test.go
+++ b/pkg/models/transportation_service_provider_performance_test.go
@@ -499,7 +499,7 @@ func (suite *ModelSuite) Test_FetchLinehaulRate() {
 	}
 	suite.mustSave(&otherRateCycleTSPPerformance)
 
-	rate, err := FetchDiscountRate(suite.db, "77901", "67401", "2", testdatagen.DateInsidePeakRateCycle)
+	rate, err := FetchLinehaulRate(suite.db, "77901", "67401", "2", testdatagen.DateInsidePeakRateCycle)
 	if err != nil {
 		t.Fatalf("Failed to find tsp performance: %s", err)
 	}

--- a/pkg/models/transportation_service_provider_performance_test.go
+++ b/pkg/models/transportation_service_provider_performance_test.go
@@ -446,25 +446,63 @@ func (suite *ModelSuite) Test_MinimumPerformanceScore() {
 	}
 }
 
-// Test_FetchDiscountRate tests that the discount rate for the TSP with the best BVS
+// Test_FetchLinehaulRate tests that the discount rate for the TSP with the best BVS
 // for the specified channel and date is returned.
-func (suite *ModelSuite) Test_FetchDiscountRate() {
+func (suite *ModelSuite) Test_FetchLinehaulRate() {
 	t := suite.T()
 
-	testdatagen.MakeTDL(suite.db, "US68", "5", "2") // Victoria, TX to Salina, KS
-	testdatagen.MakeTSP(suite.db, "Quality Moving", testdatagen.RandomSCAC())
+	tdl, _ := testdatagen.MakeTDL(suite.db, "US68", "5", "2") // Victoria, TX to Salina, KS
+	tsp, _ := testdatagen.MakeTSP(suite.db, "Quality Moving", testdatagen.RandomSCAC())
 
 	suite.mustSave(&Tariff400ngZip3{Zip3: "779", RateArea: "US68", BasepointCity: "Victoria", State: "TX", ServiceArea: 320, Region: 6})
-
 	suite.mustSave(&Tariff400ngZip3{Zip3: "674", Region: 5, BasepointCity: "Salina", State: "KS", RateArea: "US58", ServiceArea: 320})
 
-	// TODO create rows in transportation_service_provider_performances
+	tspPerformance := TransportationServiceProviderPerformance{
+		PerformancePeriodStart:          testdatagen.PerformancePeriodStart,
+		PerformancePeriodEnd:            testdatagen.PerformancePeriodEnd,
+		RateCycleStart:                  testdatagen.PeakRateCycleStart,
+		RateCycleEnd:                    testdatagen.PeakRateCycleEnd,
+		TrafficDistributionListID:       tdl.ID,
+		TransportationServiceProviderID: tsp.ID,
+		QualityBand:                     swag.Int(1),
+		BestValueScore:                  90,
+		LinehaulRate:                    50.5,
+		SITRate:                         50.0,
+	}
+	suite.mustSave(&tspPerformance)
 
-	rate := 50.5
-	// rate, err := FetchDiscountRate(suite.db, "77901", "67401", "2", testdatagen.DateInsidePeakRateCycle)
-	// if err != nil {
-	// 	t.Fatalf("Failed to find tsp performance: %s", err)
-	// }
+	lowerTSPPerformance := TransportationServiceProviderPerformance{
+		PerformancePeriodStart:          testdatagen.PerformancePeriodStart,
+		PerformancePeriodEnd:            testdatagen.PerformancePeriodEnd,
+		RateCycleStart:                  testdatagen.PeakRateCycleStart,
+		RateCycleEnd:                    testdatagen.PeakRateCycleEnd,
+		TrafficDistributionListID:       tdl.ID,
+		TransportationServiceProviderID: tsp.ID,
+		QualityBand:                     swag.Int(1),
+		BestValueScore:                  89,
+		LinehaulRate:                    55.5,
+		SITRate:                         50.0,
+	}
+	suite.mustSave(&lowerTSPPerformance)
+
+	otherRateCycleTSPPerformance := TransportationServiceProviderPerformance{
+		PerformancePeriodStart:          testdatagen.PerformancePeriodStart,
+		PerformancePeriodEnd:            testdatagen.PerformancePeriodEnd,
+		RateCycleStart:                  testdatagen.NonPeakRateCycleStart,
+		RateCycleEnd:                    testdatagen.NonPeakRateCycleEnd,
+		TrafficDistributionListID:       tdl.ID,
+		TransportationServiceProviderID: tsp.ID,
+		QualityBand:                     swag.Int(1),
+		BestValueScore:                  91,
+		LinehaulRate:                    55.5,
+		SITRate:                         50.0,
+	}
+	suite.mustSave(&otherRateCycleTSPPerformance)
+
+	rate, err := FetchDiscountRate(suite.db, "77901", "67401", "2", testdatagen.DateInsidePeakRateCycle)
+	if err != nil {
+		t.Fatalf("Failed to find tsp performance: %s", err)
+	}
 
 	expected := 50.5
 	if rate != expected {

--- a/pkg/models/transportation_service_provider_performance_test.go
+++ b/pkg/models/transportation_service_provider_performance_test.go
@@ -446,6 +446,32 @@ func (suite *ModelSuite) Test_MinimumPerformanceScore() {
 	}
 }
 
+// Test_FetchDiscountRate tests that the discount rate for the TSP with the best BVS
+// for the specified channel and date is returned.
+func (suite *ModelSuite) Test_FetchDiscountRate() {
+	t := suite.T()
+
+	testdatagen.MakeTDL(suite.db, "US68", "5", "2") // Victoria, TX to Salina, KS
+	testdatagen.MakeTSP(suite.db, "Quality Moving", testdatagen.RandomSCAC())
+
+	suite.mustSave(&Tariff400ngZip3{Zip3: "779", RateArea: "US68", BasepointCity: "Victoria", State: "TX", ServiceArea: 320, Region: 6})
+
+	suite.mustSave(&Tariff400ngZip3{Zip3: "674", Region: 5, BasepointCity: "Salina", State: "KS", RateArea: "US58", ServiceArea: 320})
+
+	// TODO create rows in transportation_service_provider_performances
+
+	rate := 50.5
+	// rate, err := FetchDiscountRate(suite.db, "77901", "67401", "2", testdatagen.DateInsidePeakRateCycle)
+	// if err != nil {
+	// 	t.Fatalf("Failed to find tsp performance: %s", err)
+	// }
+
+	expected := 50.5
+	if rate != expected {
+		t.Errorf("Wrong discount rate: expected %v, got %v", expected, rate)
+	}
+}
+
 func equalUUIDSlice(a []uuid.UUID, b []uuid.UUID) bool {
 	if len(a) != len(b) {
 		return false


### PR DESCRIPTION
## Description

Now that the `linehaul_rate` and `sit_rate` are present in the `transportation_service_provider_performances` table, we can query that table to find the TSP with the highest BVS and use its `linehaul_rate` to determine the discount rate for the rate engine.

## Reviewer Notes

This story does not include incorporating this new func into the rate engine itself; that will be part of later work.

## Code Review Verification Steps

* [ ] All tests pass.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/blob/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/156634751) for this change