### PR TITLE
Rename AWS_REGION to AWS_S3_REGION and give it a default value in app container

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -67,7 +67,7 @@ export NO_SESSION_TIMEOUT=true
 # Your AWS credentials should be setup in the transcom-ppp profile. They will be
 # detected and used by the app automatically.
 export AWS_S3_BUCKET_NAME="transcom-ppp-app-devlocal-us-west-2"
-export AWS_REGION="us-west-2"
+export AWS_S3_REGION="us-west-2"
 export AWS_PROFILE=transcom-ppp
 require AWS_S3_KEY_NAMESPACE "Use something unique across the project such as your GitHub username"
 

--- a/cmd/webserver/main.go
+++ b/cmd/webserver/main.go
@@ -9,6 +9,7 @@ import (
 	"path"
 	"path/filepath"
 
+	aws "github.com/aws/aws-sdk-go/aws"
 	awssession "github.com/aws/aws-sdk-go/aws/session"
 	"github.com/dgrijalva/jwt-go"
 	"github.com/gobuffalo/pop"
@@ -76,6 +77,7 @@ func main() {
 
 	storageBackend := flag.String("storage_backend", "filesystem", "Storage backend to use, either filesystem or s3.")
 	s3Bucket := flag.String("aws_s3_bucket_name", "", "S3 bucket used for file storage")
+	s3Region := flag.String("aws_s3_region", "", "AWS region used for S3 file storage")
 
 	flag.Parse()
 
@@ -135,7 +137,13 @@ func main() {
 		if len(*s3Bucket) == 0 {
 			log.Fatalln(errors.New("Must provide aws_s3_bucket_name parameter, exiting"))
 		}
-		aws := awssession.Must(awssession.NewSession())
+		if *s3Region == "" {
+			log.Fatalln(errors.New("Must provide aws_s3_region parameter, exiting"))
+		}
+		aws := awssession.Must(awssession.NewSession(&aws.Config{
+			Region: s3Region,
+		}))
+
 		storer = storage.NewS3(*s3Bucket, logger, aws)
 	} else {
 		zap.L().Info("Using filesystem storage backend")

--- a/config/app.container-definition.json
+++ b/config/app.container-definition.json
@@ -57,6 +57,10 @@
       "value": "transcom-ppp-app-{{environment}}-us-west-2"
     },
     {
+      "name": "AWS_S3_REGION",
+      "value": "us-west-2"
+    },
+    {
       "name": "AWS_S3_KEY_NAMESPACE",
       "value": "app"
     },


### PR DESCRIPTION
## Description

This resolves an issue where we were unable to upload files to S3 in staging because one of the required environment variables was not set.

It also renames `AWS_REGION` to `AWS_S3_REGION` to make the use of the variable, which is only to direct file uploads to the correct region, more obvious.

## Reviewer Notes

- I've tested the app locally and verified that both local and s3 uploads still work.

## Code Review Verification Steps

* [ ] All tests pass.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/blob/master/docs/backend.md#logging)
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/156735516) for this change