### PR TITLE
Expands SM patch test, fixes SSN patching

### DIFF
--- a/pkg/handlers/converters.go
+++ b/pkg/handlers/converters.go
@@ -61,6 +61,11 @@ func stringFromEmail(email *strfmt.Email) *string {
 	return &emailString
 }
 
+func fmtSSN(s string) *strfmt.SSN {
+	ssn := strfmt.SSN(s)
+	return &ssn
+}
+
 func stringFromSSN(ssn *strfmt.SSN) *string {
 	var stringPointer *string
 	if ssn != nil {

--- a/pkg/handlers/service_member_test.go
+++ b/pkg/handlers/service_member_test.go
@@ -238,9 +238,25 @@ func (suite *HandlerSuite) TestPatchServiceMemberHandler() {
 	}
 	suite.mustSave(&newServiceMember)
 
+	branch := internalmessages.MilitaryBranchARMY
+	rank := internalmessages.ServiceMemberRankE1
 	patchPayload := internalmessages.PatchServiceMemberPayload{
-		Edipi:              &newEdipi,
-		ResidentialAddress: fakeAddress(),
+		Edipi:                &newEdipi,
+		BackupMailingAddress: fakeAddress(),
+		ResidentialAddress:   fakeAddress(),
+		Branch:               &branch,
+		EmailIsPreferred:     swag.Bool(true),
+		FirstName:            swag.String("Firstname"),
+		LastName:             swag.String("Lastname"),
+		MiddleName:           swag.String("Middlename"),
+		PersonalEmail:        fmtEmail("name@domain.com"),
+		PhoneIsPreferred:     swag.Bool(true),
+		Rank:                 &rank,
+		TextMessageIsPreferred: swag.Bool(true),
+		SecondaryTelephone:     swag.String("555555555"),
+		SocialSecurityNumber:   fmtSSN("555-55-5555"),
+		Suffix:                 swag.String("Sr."),
+		Telephone:              swag.String("555555555"),
 	}
 
 	// And: the context contains the auth values
@@ -274,7 +290,7 @@ func (suite *HandlerSuite) TestPatchServiceMemberHandler() {
 	addresses := []models.Address{}
 	suite.db.All(&addresses)
 
-	if len(addresses) != 1 {
+	if len(addresses) != 2 {
 		t.Errorf("Expected to find one address but found %v", len(addresses))
 	}
 }

--- a/pkg/models/service_member_test.go
+++ b/pkg/models/service_member_test.go
@@ -1,11 +1,11 @@
 package models_test
 
 import (
-	"github.com/go-openapi/swag"
 	"github.com/gobuffalo/uuid"
 
 	"github.com/transcom/mymove/pkg/gen/internalmessages"
 	. "github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/testdatagen"
 )
 
 func (suite *ModelSuite) TestBasicServiceMemberInstantiation() {
@@ -38,14 +38,7 @@ func (suite *ModelSuite) TestIsProfileCompleteWithIncompleteSM() {
 	lastName := "sally"
 	telephone := "510 555-5555"
 	email := "bobsally@gmail.com"
-	fakeAddress := Address{
-		StreetAddress1: "123 main st.",
-		StreetAddress2: swag.String("Apt.1"),
-		City:           "Pleasantville",
-		State:          "AL",
-		PostalCode:     "01234",
-		Country:        swag.String("USA"),
-	}
+	fakeAddress, _ := testdatagen.MakeAddress(suite.db)
 	servicemember := ServiceMember{
 		UserID:             user1.ID,
 		Edipi:              &edipi,

--- a/pkg/testdatagen/make_address.go
+++ b/pkg/testdatagen/make_address.go
@@ -1,0 +1,33 @@
+package testdatagen
+
+import (
+	"log"
+
+	"github.com/go-openapi/swag"
+	"github.com/gobuffalo/pop"
+
+	"github.com/transcom/mymove/pkg/models"
+)
+
+// MakeAddress creates a single Address and associated service member.
+func MakeAddress(db *pop.Connection) (models.Address, error) {
+	address := models.Address{
+		StreetAddress1: "123 Any Street",
+		StreetAddress2: swag.String("P.O. Box 12345"),
+		StreetAddress3: swag.String("c/o Some Person"),
+		City:           "Beverly Hills",
+		State:          "CA",
+		PostalCode:     "90210",
+		Country:        swag.String("US"),
+	}
+
+	verrs, err := db.ValidateAndSave(&address)
+	if err != nil {
+		log.Fatal(err)
+	}
+	if verrs.Count() != 0 {
+		log.Fatal(verrs.Error())
+	}
+
+	return address, err
+}


### PR DESCRIPTION
## Description

This started with me realizing that we aren't testing a lot of our patch SM function, and turned into fixing how we set SSNs. Specifically we would fail on creating a new SSN because we were only ever calling `update` on the model.

## Code Review Verification Steps

* [ ] All tests pass.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/blob/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* [ ] There are no [aXe](https://www.deque.com/products/aXe/) warnings for UI.
* [ ] This works in IE.
* [ ] Any new third party client side dependencies (e.g., login.gov, google analytics, CDN libraries, etc.) have been communicated to @willowbl00.
* [ ] Request review from a member of a different team.
* [ ] (TRIAL) Have the Pivotal acceptance criteria been met for this change?