### PR TITLE
Update ServiceArea with SIT fields [delivers #156824224]

### DIFF
--- a/pkg/auth/auth_test.go
+++ b/pkg/auth/auth_test.go
@@ -35,12 +35,15 @@ func (suite *AuthSuite) SetupTest() {
 }
 
 func (suite *AuthSuite) mustSave(model interface{}) {
+	t := suite.T()
+	t.Helper()
+
 	verrs, err := suite.db.ValidateAndSave(model)
 	if err != nil {
 		log.Panic(err)
 	}
 	if verrs.Count() > 0 {
-		suite.T().Fatalf("errors encountered saving %v: %v", model, verrs)
+		t.Fatalf("errors encountered saving %v: %v", model, verrs)
 	}
 }
 

--- a/pkg/handlers/handlers_test.go
+++ b/pkg/handlers/handlers_test.go
@@ -25,12 +25,15 @@ func (suite *HandlerSuite) SetupTest() {
 }
 
 func (suite *HandlerSuite) mustSave(model interface{}) {
+	t := suite.T()
+	t.Helper()
+
 	verrs, err := suite.db.ValidateAndSave(model)
 	if err != nil {
 		log.Panic(err)
 	}
 	if verrs.Count() > 0 {
-		suite.T().Fatalf("errors encountered saving %v: %v", model, verrs)
+		t.Fatalf("errors encountered saving %v: %v", model, verrs)
 	}
 }
 

--- a/pkg/models/models_test.go
+++ b/pkg/models/models_test.go
@@ -19,12 +19,15 @@ func (suite *ModelSuite) SetupTest() {
 }
 
 func (suite *ModelSuite) mustSave(model interface{}) {
+	t := suite.T()
+	t.Helper()
+
 	verrs, err := suite.db.ValidateAndSave(model)
 	if err != nil {
 		log.Panic(err)
 	}
 	if verrs.Count() > 0 {
-		suite.T().Fatalf("errors encountered saving %v: %v", model, verrs)
+		t.Fatalf("errors encountered saving %v: %v", model, verrs)
 	}
 }
 

--- a/pkg/models/tariff400ng_service_area.go
+++ b/pkg/models/tariff400ng_service_area.go
@@ -61,20 +61,3 @@ func FetchTariff400ngServiceAreaForZip3(tx *pop.Connection, zip3 string, date ti
 	}
 	return serviceArea, nil
 }
-
-// FetchTariff400ngLinehaulFactor returns linehaul_factor for an origin or destination based on service area.
-func FetchTariff400ngLinehaulFactor(tx *pop.Connection, serviceArea int, rateEngineDate time.Time) (linehaulFactor unit.Cents, err error) {
-	sql := `SELECT
-			linehaul_factor
-		FROM
-			tariff400ng_service_areas
-		WHERE
-			service_area = $1
-		AND
-			$2 BETWEEN effective_date_lower AND effective_date_upper;
-
-		`
-	err = tx.RawQuery(sql, serviceArea, rateEngineDate).First(&linehaulFactor)
-
-	return linehaulFactor, err
-}

--- a/pkg/models/tariff400ng_service_area.go
+++ b/pkg/models/tariff400ng_service_area.go
@@ -24,6 +24,9 @@ type Tariff400ngServiceArea struct {
 	ServiceChargeCents unit.Cents `json:"service_charge_cents" db:"service_charge_cents"`
 	EffectiveDateLower time.Time  `json:"effective_date_lower" db:"effective_date_lower"`
 	EffectiveDateUpper time.Time  `json:"effective_date_upper" db:"effective_date_upper"`
+	SIT185ARateCents   unit.Cents `json:"sit_185a_rate_cents" db:"sit_185a_rate_cents"`
+	SIT185BRateCents   unit.Cents `json:"sit_185b_rate_cents" db:"sit_185b_rate_cents"`
+	SITPDSchedule      int        `json:"sit_pd_schedule" db:"sit_pd_schedule"`
 }
 
 // Tariff400ngServiceAreas is not required by pop and may be deleted
@@ -34,6 +37,9 @@ type Tariff400ngServiceAreas []Tariff400ngServiceArea
 func (t *Tariff400ngServiceArea) Validate(tx *pop.Connection) (*validate.Errors, error) {
 	return validate.Validate(
 		&validators.IntIsGreaterThan{Field: t.ServiceChargeCents.Int(), Name: "ServiceChargeCents", Compared: -1},
+		&validators.IntIsPresent{Field: t.SIT185ARateCents.Int(), Name: "SIT185ARateCents"},
+		&validators.IntIsPresent{Field: t.SIT185BRateCents.Int(), Name: "SIT185BRateCents"},
+		&validators.IntIsPresent{Field: t.SITPDSchedule, Name: "SITPDSchedule"},
 		&validators.TimeAfterTime{
 			FirstTime: t.EffectiveDateUpper, FirstName: "EffectiveDateUpper",
 			SecondTime: t.EffectiveDateLower, SecondName: "EffectiveDateLower"},

--- a/pkg/models/tariff400ng_service_area.go
+++ b/pkg/models/tariff400ng_service_area.go
@@ -41,10 +41,21 @@ func (t *Tariff400ngServiceArea) Validate(tx *pop.Connection) (*validate.Errors,
 }
 
 // FetchTariff400ngServiceAreaForZip3 returns the service area for a specified Zip3.
-func FetchTariff400ngServiceAreaForZip3(db *pop.Connection, zip3 string) (Tariff400ngServiceArea, error) {
+func FetchTariff400ngServiceAreaForZip3(tx *pop.Connection, zip3 string, date time.Time) (Tariff400ngServiceArea, error) {
 	serviceArea := Tariff400ngServiceArea{}
-	err := db.Q().LeftJoin("tariff400ng_zip3s", "tariff400ng_zip3s.service_area=tariff400ng_service_areas.service_area").
-		Where(`tariff400ng_zip3s.zip3 = $1`, zip3).First(&serviceArea)
+	sql := `SELECT
+				tariff400ng_service_areas.*
+			FROM
+				tariff400ng_service_areas
+			LEFT JOIN
+				tariff400ng_zip3s ON tariff400ng_zip3s.service_area = tariff400ng_service_areas.service_area
+			WHERE
+				tariff400ng_zip3s.zip3 = $1
+			AND
+				effective_date_lower <= $2
+			AND effective_date_upper > $2;
+			`
+	err := tx.RawQuery(sql, zip3, date).First(&serviceArea)
 	if err != nil {
 		return serviceArea, errors.Wrap(err, "could not find a matching Tariff400ngServiceArea")
 	}

--- a/pkg/models/tariff400ng_service_area_test.go
+++ b/pkg/models/tariff400ng_service_area_test.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	. "github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/unit"
 )
 
 func (suite *ModelSuite) Test_ServiceAreaEffectiveDateValidation() {
@@ -12,6 +13,9 @@ func (suite *ModelSuite) Test_ServiceAreaEffectiveDateValidation() {
 	validServiceArea := Tariff400ngServiceArea{
 		EffectiveDateLower: now,
 		EffectiveDateUpper: now.AddDate(1, 0, 0),
+		SIT185ARateCents:   unit.Cents(50),
+		SIT185BRateCents:   unit.Cents(50),
+		SITPDSchedule:      1,
 	}
 
 	expErrors := map[string][]string{}
@@ -20,6 +24,9 @@ func (suite *ModelSuite) Test_ServiceAreaEffectiveDateValidation() {
 	invalidServiceArea := Tariff400ngServiceArea{
 		EffectiveDateLower: now,
 		EffectiveDateUpper: now.AddDate(-1, 0, 0),
+		SIT185ARateCents:   unit.Cents(50),
+		SIT185BRateCents:   unit.Cents(50),
+		SITPDSchedule:      1,
 	}
 
 	expErrors = map[string][]string{
@@ -31,6 +38,9 @@ func (suite *ModelSuite) Test_ServiceAreaEffectiveDateValidation() {
 func (suite *ModelSuite) Test_ServiceAreaServiceChargeValidation() {
 	validServiceArea := Tariff400ngServiceArea{
 		ServiceChargeCents: 100,
+		SIT185ARateCents:   unit.Cents(50),
+		SIT185BRateCents:   unit.Cents(50),
+		SITPDSchedule:      1,
 	}
 
 	expErrors := map[string][]string{}
@@ -38,10 +48,26 @@ func (suite *ModelSuite) Test_ServiceAreaServiceChargeValidation() {
 
 	invalidServiceArea := Tariff400ngServiceArea{
 		ServiceChargeCents: -1,
+		SIT185ARateCents:   unit.Cents(50),
+		SIT185BRateCents:   unit.Cents(50),
+		SITPDSchedule:      1,
 	}
 
 	expErrors = map[string][]string{
 		"service_charge_cents": []string{"-1 is not greater than -1."},
+	}
+	suite.verifyValidationErrors(&invalidServiceArea, expErrors)
+}
+
+func (suite *ModelSuite) Test_ServiceAreaSITRatesValidation() {
+	invalidServiceArea := Tariff400ngServiceArea{
+		ServiceChargeCents: 1,
+	}
+
+	expErrors := map[string][]string{
+		"s_i_t185_b_rate_cents": []string{"SIT185BRateCents can not be blank."},
+		"s_i_t_p_d_schedule":    []string{"SITPDSchedule can not be blank."},
+		"s_i_t185_a_rate_cents": []string{"SIT185ARateCents can not be blank."},
 	}
 	suite.verifyValidationErrors(&invalidServiceArea, expErrors)
 }
@@ -56,6 +82,9 @@ func (suite *ModelSuite) Test_ServiceAreaCreateAndSave() {
 		LinehaulFactor:     1,
 		EffectiveDateLower: now,
 		EffectiveDateUpper: now.AddDate(0, 1, 0),
+		SIT185ARateCents:   unit.Cents(50),
+		SIT185BRateCents:   unit.Cents(50),
+		SITPDSchedule:      1,
 	}
 
 	suite.mustSave(&validServiceArea)

--- a/pkg/rateengine/linehaul.go
+++ b/pkg/rateengine/linehaul.go
@@ -36,11 +36,7 @@ func (re *RateEngine) linehaulFactors(cwt int, zip3 string, date time.Time) (lin
 	if err != nil {
 		return 0, err
 	}
-	linehaulFactorCents, err = models.FetchTariff400ngLinehaulFactor(re.db, serviceArea.ServiceArea, date)
-	if err != nil {
-		return 0, err
-	}
-	return linehaulFactorCents.Multiply(cwt), nil
+	return serviceArea.LinehaulFactor.Multiply(cwt), nil
 }
 
 // Determine Shorthaul (SH) Charge (ONLY applies if shipment moves 800 miles and less)

--- a/pkg/rateengine/linehaul.go
+++ b/pkg/rateengine/linehaul.go
@@ -32,7 +32,7 @@ func (re *RateEngine) baseLinehaul(mileage int, cwt int, date time.Time) (baseLi
 
 // Determine the Linehaul Factors (OLF and DLF)
 func (re *RateEngine) linehaulFactors(cwt int, zip3 string, date time.Time) (linehaulFactorCents unit.Cents, err error) {
-	serviceArea, err := models.FetchTariff400ngServiceAreaForZip3(re.db, zip3)
+	serviceArea, err := models.FetchTariff400ngServiceAreaForZip3(re.db, zip3, date)
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/rateengine/linehaul_test.go
+++ b/pkg/rateengine/linehaul_test.go
@@ -89,6 +89,9 @@ func (suite *RateEngineSuite) Test_CheckLinehaulFactors() {
 		ServiceChargeCents: 350,
 		EffectiveDateLower: testdatagen.PeakRateCycleStart,
 		EffectiveDateUpper: testdatagen.PeakRateCycleEnd,
+		SIT185ARateCents:   unit.Cents(50),
+		SIT185BRateCents:   unit.Cents(50),
+		SITPDSchedule:      1,
 	}
 	suite.mustSave(&serviceArea)
 
@@ -174,6 +177,9 @@ func (suite *RateEngineSuite) Test_CheckLinehaulChargeTotal() {
 		LinehaulFactor:     78,
 		EffectiveDateLower: testdatagen.PeakRateCycleStart,
 		EffectiveDateUpper: testdatagen.PeakRateCycleEnd,
+		SIT185ARateCents:   unit.Cents(50),
+		SIT185BRateCents:   unit.Cents(50),
+		SITPDSchedule:      1,
 	}
 	suite.mustSave(&sa1)
 
@@ -184,6 +190,9 @@ func (suite *RateEngineSuite) Test_CheckLinehaulChargeTotal() {
 		LinehaulFactor:     263,
 		EffectiveDateLower: testdatagen.PeakRateCycleStart,
 		EffectiveDateUpper: testdatagen.PeakRateCycleEnd,
+		SIT185ARateCents:   unit.Cents(50),
+		SIT185BRateCents:   unit.Cents(50),
+		SITPDSchedule:      1,
 	}
 	suite.mustSave(&sa2)
 

--- a/pkg/rateengine/nonlinehaul_test.go
+++ b/pkg/rateengine/nonlinehaul_test.go
@@ -30,7 +30,7 @@ func (suite *RateEngineSuite) Test_CheckServiceFee() {
 	}
 	suite.mustSave(&serviceArea)
 
-	fee, err := engine.serviceFeeCents(50, "395")
+	fee, err := engine.serviceFeeCents(50, "395", testdatagen.DateInsidePeakRateCycle)
 	if err != nil {
 		t.Fatalf("failed to calculate service fee: %s", err)
 	}
@@ -77,7 +77,7 @@ func (suite *RateEngineSuite) Test_CheckFullPack() {
 	}
 	suite.mustSave(&fullPackRate)
 
-	fee, err := engine.fullPackCents(50, "395")
+	fee, err := engine.fullPackCents(50, "395", testdatagen.DateInsidePeakRateCycle)
 	if err != nil {
 		t.Fatalf("failed to calculate full pack fee: %s", err)
 	}
@@ -131,7 +131,7 @@ func (suite *RateEngineSuite) Test_CheckFullUnpack() {
 	}
 	suite.mustSave(&fullUnpackRate)
 
-	fee, err := engine.fullUnpackCents(50, "395")
+	fee, err := engine.fullUnpackCents(50, "395", testdatagen.DateInsidePeakRateCycle)
 	if err != nil {
 		t.Fatalf("failed to calculate full unpack fee: %s", err)
 	}
@@ -206,7 +206,7 @@ func (suite *RateEngineSuite) Test_CheckNonLinehaulChargeTotal() {
 	}
 	suite.mustSave(&fullUnpackRate)
 
-	fee, err := engine.nonLinehaulChargeTotalCents(2000, "395", "336")
+	fee, err := engine.nonLinehaulChargeTotalCents(2000, "395", "336", testdatagen.DateInsidePeakRateCycle)
 
 	if err != nil {
 		t.Fatalf("failed to calculate non linehaul charge: %s", err)

--- a/pkg/rateengine/nonlinehaul_test.go
+++ b/pkg/rateengine/nonlinehaul_test.go
@@ -27,6 +27,9 @@ func (suite *RateEngineSuite) Test_CheckServiceFee() {
 		ServiceChargeCents: 350,
 		EffectiveDateLower: testdatagen.PeakRateCycleStart,
 		EffectiveDateUpper: testdatagen.PeakRateCycleEnd,
+		SIT185ARateCents:   unit.Cents(50),
+		SIT185BRateCents:   unit.Cents(50),
+		SITPDSchedule:      1,
 	}
 	suite.mustSave(&serviceArea)
 
@@ -64,6 +67,9 @@ func (suite *RateEngineSuite) Test_CheckFullPack() {
 		ServicesSchedule:   1,
 		EffectiveDateLower: testdatagen.PeakRateCycleStart,
 		EffectiveDateUpper: testdatagen.PeakRateCycleEnd,
+		SIT185ARateCents:   unit.Cents(50),
+		SIT185BRateCents:   unit.Cents(50),
+		SITPDSchedule:      1,
 	}
 	suite.mustSave(&serviceArea)
 
@@ -110,6 +116,9 @@ func (suite *RateEngineSuite) Test_CheckFullUnpack() {
 		ServicesSchedule:   1,
 		EffectiveDateLower: testdatagen.PeakRateCycleStart,
 		EffectiveDateUpper: testdatagen.PeakRateCycleEnd,
+		SIT185ARateCents:   unit.Cents(50),
+		SIT185BRateCents:   unit.Cents(50),
+		SITPDSchedule:      1,
 	}
 	suite.mustSave(&serviceArea)
 
@@ -164,6 +173,9 @@ func (suite *RateEngineSuite) Test_CheckNonLinehaulChargeTotal() {
 		ServicesSchedule:   1,
 		EffectiveDateLower: testdatagen.PeakRateCycleStart,
 		EffectiveDateUpper: testdatagen.PeakRateCycleEnd,
+		SIT185ARateCents:   unit.Cents(50),
+		SIT185BRateCents:   unit.Cents(50),
+		SITPDSchedule:      1,
 	}
 	suite.mustSave(&originServiceArea)
 
@@ -185,6 +197,9 @@ func (suite *RateEngineSuite) Test_CheckNonLinehaulChargeTotal() {
 		ServicesSchedule:   1,
 		EffectiveDateLower: testdatagen.PeakRateCycleStart,
 		EffectiveDateUpper: testdatagen.PeakRateCycleEnd,
+		SIT185ARateCents:   unit.Cents(50),
+		SIT185BRateCents:   unit.Cents(50),
+		SITPDSchedule:      1,
 	}
 	suite.mustSave(&destinationServiceArea)
 

--- a/pkg/rateengine/rateengine.go
+++ b/pkg/rateengine/rateengine.go
@@ -48,22 +48,22 @@ func (re *RateEngine) computePPM(weight int, originZip string, destinationZip st
 		return 0, err
 	}
 	// Non linehaul charges
-	originServiceFee, err := re.serviceFeeCents(cwt, originZip)
+	originServiceFee, err := re.serviceFeeCents(cwt, originZip, date)
 	if err != nil {
 		re.logger.Error("Failed to determine origin service fee", zap.Error(err))
 		return 0, err
 	}
-	destinationServiceFee, err := re.serviceFeeCents(cwt, destinationZip)
+	destinationServiceFee, err := re.serviceFeeCents(cwt, destinationZip, date)
 	if err != nil {
 		re.logger.Error("Failed to determine destination service fee", zap.Error(err))
 		return 0, err
 	}
-	pack, err := re.fullPackCents(cwt, originZip)
+	pack, err := re.fullPackCents(cwt, originZip, date)
 	if err != nil {
 		re.logger.Error("Failed to determine full pack cost", zap.Error(err))
 		return 0, err
 	}
-	unpack, err := re.fullUnpackCents(cwt, destinationZip)
+	unpack, err := re.fullUnpackCents(cwt, destinationZip, date)
 	if err != nil {
 		re.logger.Error("Failed to determine full unpack cost", zap.Error(err))
 		return 0, err

--- a/pkg/rateengine/rateengine_test.go
+++ b/pkg/rateengine/rateengine_test.go
@@ -133,12 +133,15 @@ func (suite *RateEngineSuite) SetupTest() {
 }
 
 func (suite *RateEngineSuite) mustSave(model interface{}) {
+	t := suite.T()
+	t.Helper()
+
 	verrs, err := suite.db.ValidateAndSave(model)
 	if err != nil {
 		log.Panic(err)
 	}
 	if verrs.Count() > 0 {
-		suite.T().Fatalf("errors encountered saving %v: %v", model, verrs)
+		t.Fatalf("errors encountered saving %v: %v", model, verrs)
 	}
 }
 

--- a/pkg/rateengine/rateengine_test.go
+++ b/pkg/rateengine/rateengine_test.go
@@ -45,6 +45,9 @@ func (suite *RateEngineSuite) Test_CheckPPMTotal() {
 		ServicesSchedule:   1,
 		EffectiveDateLower: testdatagen.PeakRateCycleStart,
 		EffectiveDateUpper: testdatagen.PeakRateCycleEnd,
+		SIT185ARateCents:   unit.Cents(50),
+		SIT185BRateCents:   unit.Cents(50),
+		SITPDSchedule:      1,
 	}
 	suite.mustSave(&originServiceArea)
 
@@ -66,6 +69,9 @@ func (suite *RateEngineSuite) Test_CheckPPMTotal() {
 		ServicesSchedule:   1,
 		EffectiveDateLower: testdatagen.PeakRateCycleStart,
 		EffectiveDateUpper: testdatagen.PeakRateCycleEnd,
+		SIT185ARateCents:   unit.Cents(50),
+		SIT185BRateCents:   unit.Cents(50),
+		SITPDSchedule:      1,
 	}
 	suite.mustSave(&destinationServiceArea)
 


### PR DESCRIPTION
## Description

#382 created some new columns on the `tariff_400ng_service_areas` table. This PR extends those changes by adding fields and validations to the Go model.

## Reviewer Notes

* I think we can use the existing `FetchTariff400ngServiceAreaForZip3` func to fetch the service area when performing calculations. Actually doing those calculations is in an [upcoming story](https://www.pivotaltracker.com/story/show/156824380).
* I also fixed the `mustSave` helpers so that their file and line number don't show up in stack traces.

## Code Review Verification Steps

* [ ] All tests pass.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/blob/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/156824224) for this change