### PR TITLE
Remove proscription on testify assertions

### DIFF
--- a/docs/adr/0011-test-suites.md
+++ b/docs/adr/0011-test-suites.md
@@ -27,8 +27,6 @@ We did not consider adopting [another Go testing framework](https://awesome-go.c
 
 * Providing setup/teardown per-test functionality is familiar to developers who have worked with xUnit-style testing libraries in the past.
 
-* Testify includes a lot of functionality that we don't wish to use at this time, such as its optional assertion packages `assert` and `require`.
-
 ## Pros and Cons of the Alternatives <!-- optional -->
 
 ### Use subtests in the style suggested [on the Go Blog](https://blog.golang.org/subtests#TOC_6.)


### PR DESCRIPTION
## Description

When we originally wrote ADR0011 we were deliberately cautious in the extent to which we wanted to use testify and have that become embedded in the test code. To that end we originally discouraged folks from using the functionality in testify beyond suite setup and tear down.

In practice, the assertions are useful and we would otherwise build our own versions. This change removed the discouragement.

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny? What else did I miss apart from removing 1 sentence.

## Code Review Verification Steps

* [*] All tests pass.
* [n/a] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/blob/master/docs/backend.md#logging)
* [n/a] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* [n/a] There are no [aXe](https://www.deque.com/products/aXe/) warnings for UI.
* [n/a] This works in IE.
* [n/a] Any new third party client side dependencies (e.g., login.gov, google analytics, CDN libraries, etc.) have been communicated to @willowbl00.
* [*] Request review from a member of a different team.
* [n/a] (TRIAL) Have the Pivotal acceptance criteria been met for this change?
