### PR TITLE
removed debugger and resolved/deferred todos for addresses

### DIFF
--- a/src/scenes/ServiceMembers/BackupMailingAddress.jsx
+++ b/src/scenes/ServiceMembers/BackupMailingAddress.jsx
@@ -28,15 +28,6 @@ const uiSchema = {
     },
   },
   requiredFields: subsetOfFields,
-  todos: (
-    <ul>
-      <li>layout of city, state, zip does not match wireframe</li>
-      <li>
-        patch returns original address values (I suspect it is adding a new
-        address rather than updating the existing one)
-      </li>
-    </ul>
-  ),
 };
 const formName = 'service_member_backup_mailing_addresss';
 const CurrentForm = reduxifyForm(formName);
@@ -49,7 +40,6 @@ export class BackupMailingAddress extends Component {
   handleSubmit = () => {
     const pendingValues = this.props.formData.values;
     if (pendingValues) {
-      debugger;
       const patch = pick(pendingValues, subsetOfFields);
       this.props.updateServiceMember(patch);
     }

--- a/src/scenes/ServiceMembers/ResidentialAddress.jsx
+++ b/src/scenes/ServiceMembers/ResidentialAddress.jsx
@@ -26,15 +26,6 @@ const uiSchema = {
     },
   },
   requiredFields: subsetOfFields,
-  todos: (
-    <ul>
-      <li>layout of city, state, zip does not match wireframe</li>
-      <li>
-        patch returns original address values (I suspect it is adding a new
-        address rather than updating the existing one)
-      </li>
-    </ul>
-  ),
 };
 const formName = 'service_member_residential_address';
 const CurrentForm = reduxifyForm(formName);
@@ -47,7 +38,6 @@ export class ResidentialAddress extends Component {
   handleSubmit = () => {
     const pendingValues = this.props.formData.values;
     if (pendingValues) {
-      debugger;
       const patch = pick(pendingValues, subsetOfFields);
       this.props.updateServiceMember(patch);
     }


### PR DESCRIPTION
## Description

This just removes some errant debugger statements and obsolete todo notes.

When this is merged, [Residential Addresses](https://www.pivotaltracker.com/story/show/156435565) and [Backup Address](https://www.pivotaltracker.com/story/show/156435554) can be considered delivered.