### PR TITLE
Change a field type in the TSPP model

### DIFF
--- a/pkg/awardqueue/awardqueue_test.go
+++ b/pkg/awardqueue/awardqueue_test.go
@@ -393,7 +393,7 @@ func (suite *AwardQueueSuite) Test_AssignTSPsToBands() {
 
 	for i := 0; i < tspsToMake; i++ {
 		tsp, _ := testdatagen.MakeTSP(suite.db, "Test Shipper", testdatagen.RandomSCAC())
-		score := mps + i + 1
+		score := float64(mps + i + 1)
 		testdatagen.MakeTSPPerformance(suite.db, tsp, tdl, nil, score, 0, float64(score)*.5, float64(score)*.5)
 	}
 

--- a/pkg/awardqueue/awardqueue_test.go
+++ b/pkg/awardqueue/awardqueue_test.go
@@ -394,7 +394,7 @@ func (suite *AwardQueueSuite) Test_AssignTSPsToBands() {
 	for i := 0; i < tspsToMake; i++ {
 		tsp, _ := testdatagen.MakeTSP(suite.db, "Test Shipper", testdatagen.RandomSCAC())
 		score := float64(mps + i + 1)
-		testdatagen.MakeTSPPerformance(suite.db, tsp, tdl, nil, score, 0, float64(score)*.5, float64(score)*.5)
+		testdatagen.MakeTSPPerformance(suite.db, tsp, tdl, nil, score, 0, score*.5, float64(score)*.5)
 	}
 
 	err = queue.assignPerformanceBands()

--- a/pkg/models/traffic_distribution_list_test.go
+++ b/pkg/models/traffic_distribution_list_test.go
@@ -24,11 +24,11 @@ func (suite *ModelSuite) Test_FetchTDLsAwaitingBandAssignment() {
 
 	foundTDL, _ := testdatagen.MakeTDL(suite.db, "US14", "3", "2")
 	foundTSP, _ := testdatagen.MakeTSP(suite.db, "Test Shipper", testdatagen.RandomSCAC())
-	testdatagen.MakeTSPPerformance(suite.db, foundTSP, foundTDL, nil, mps+1, 0, 4.2, 4.3)
+	testdatagen.MakeTSPPerformance(suite.db, foundTSP, foundTDL, nil, float64(mps+1), 0, 4.2, 4.3)
 
 	notFoundTDL, _ := testdatagen.MakeTDL(suite.db, "US14", "5", "2")
 	notFoundTSP, _ := testdatagen.MakeTSP(suite.db, "Test Shipper", testdatagen.RandomSCAC())
-	testdatagen.MakeTSPPerformance(suite.db, notFoundTSP, notFoundTDL, swag.Int(1), mps+1, 0, 4.4, 4.3)
+	testdatagen.MakeTSPPerformance(suite.db, notFoundTSP, notFoundTDL, swag.Int(1), float64(mps+1), 0, 4.4, 4.3)
 
 	tdls, err := FetchTDLsAwaitingBandAssignment(suite.db)
 	if err != nil {
@@ -49,7 +49,7 @@ func (suite *ModelSuite) Test_FetchOrCreateTDL() {
 
 	foundTDL, _ := testdatagen.MakeTDL(suite.db, "US28", "4", "2")
 	foundTSP, _ := testdatagen.MakeTSP(suite.db, "Test Shipper", testdatagen.RandomSCAC())
-	testdatagen.MakeTSPPerformance(suite.db, foundTSP, foundTDL, swag.Int(1), mps+1, 0, 4.2, 4.3)
+	testdatagen.MakeTSPPerformance(suite.db, foundTSP, foundTDL, swag.Int(1), float64(mps+1), 0, 4.2, 4.3)
 
 	fetchedTDL, err := FetchOrCreateTDL(suite.db, "US28", "4", "2")
 	if err != nil {

--- a/pkg/models/transportation_service_provider_performance.go
+++ b/pkg/models/transportation_service_provider_performance.go
@@ -37,7 +37,7 @@ type TransportationServiceProviderPerformance struct {
 	TrafficDistributionListID       uuid.UUID `db:"traffic_distribution_list_id"`
 	TransportationServiceProviderID uuid.UUID `db:"transportation_service_provider_id"`
 	QualityBand                     *int      `db:"quality_band"`
-	BestValueScore                  int       `db:"best_value_score"`
+	BestValueScore                  float64   `db:"best_value_score"`
 	LinehaulRate                    float64   `db:"linehaul_rate"`
 	SITRate                         float64   `db:"sit_rate"`
 	OfferCount                      int       `db:"offer_count"`
@@ -79,10 +79,10 @@ func (t *TransportationServiceProviderPerformance) Validate(tx *pop.Connection) 
 		&validators.IntIsGreaterThan{Field: qualityBand, Name: "QualityBand", Compared: 0},
 		&validators.IntIsLessThan{Field: qualityBand, Name: "QualityBand", Compared: 5},
 
-		// Best Value Scores can range from 0 - 100, as defined in DTR403. See page 7
-		// of https://www.ustranscom.mil/dtr/part-iv/dtr-part-4-403.pdf
-		&validators.IntIsGreaterThan{Field: t.BestValueScore, Name: "BestValueScore", Compared: -1},
-		&validators.IntIsLessThan{Field: t.BestValueScore, Name: "BestValueScore", Compared: 101},
+		// Best Value Scores can range from 0 - 100, with up to four decimal places, as defined
+		// in DTR403. See page 7 of https://www.ustranscom.mil/dtr/part-iv/dtr-part-4-403.pdf
+		&validators.IntIsGreaterThan{Field: int(t.BestValueScore), Name: "BestValueScore", Compared: -1},
+		&validators.IntIsLessThan{Field: int(t.BestValueScore), Name: "BestValueScore", Compared: 101},
 	), nil
 }
 

--- a/pkg/models/transportation_service_provider_performance.go
+++ b/pkg/models/transportation_service_provider_performance.go
@@ -178,7 +178,7 @@ func sortedMapIntKeys(mapWithIntKeys map[int]TransportationServiceProviderPerfor
 
 // FetchTSPPerformanceForQualityBandAssignment returns TSPs in a given TDL in the
 // order that they should be assigned quality bands.
-func FetchTSPPerformanceForQualityBandAssignment(tx *pop.Connection, tdlID uuid.UUID, mps int) (TransportationServiceProviderPerformances, error) {
+func FetchTSPPerformanceForQualityBandAssignment(tx *pop.Connection, tdlID uuid.UUID, mps float64) (TransportationServiceProviderPerformances, error) {
 
 	// TODO: bookDate and requestedPickupDate should also be qualifiers here. BVSs from different
 	// performance periods and rate areas should be broken up into separate quality bands.

--- a/pkg/models/transportation_service_provider_performance_test.go
+++ b/pkg/models/transportation_service_provider_performance_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/transcom/mymove/pkg/testdatagen"
 )
 
-var mps = 10.000
+var mps = 10.0
 
 func (suite *ModelSuite) Test_PerformancePeriodValidations() {
 	now := time.Now()

--- a/pkg/models/transportation_service_provider_performance_test.go
+++ b/pkg/models/transportation_service_provider_performance_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/transcom/mymove/pkg/testdatagen"
 )
 
-var mps = 10
+var mps = 10.000
 
 func (suite *ModelSuite) Test_PerformancePeriodValidations() {
 	now := time.Now()

--- a/pkg/testdatagen/make_tsp_performance_records.go
+++ b/pkg/testdatagen/make_tsp_performance_records.go
@@ -12,7 +12,7 @@ import (
 
 // MakeTSPPerformance makes a single best_value_score record
 func MakeTSPPerformance(db *pop.Connection, tsp models.TransportationServiceProvider,
-	tdl models.TrafficDistributionList, qualityBand *int, score int, offerCount int, linehaulRate float64, SITRate float64) (models.TransportationServiceProviderPerformance, error) {
+	tdl models.TrafficDistributionList, qualityBand *int, score float64, offerCount int, linehaulRate float64, SITRate float64) (models.TransportationServiceProviderPerformance, error) {
 
 	tspPerformance := models.TransportationServiceProviderPerformance{
 		PerformancePeriodStart:          PerformancePeriodStart,
@@ -69,7 +69,7 @@ func MakeTSPPerformanceData(db *pop.Connection, rounds string) {
 		// for quality band 2 between 50-75, etc.
 		var offers int
 		minBvs := (qualityBand - 1) * 25
-		bvs := 100 - (rand.Intn(25) + minBvs)
+		bvs := float64(100 - (rand.Intn(25) + minBvs))
 		// Make linehaul and SIT rates a percentage of BVS--in this case we'll call both discountRate
 		discountRate := float64(bvs) * .3
 


### PR DESCRIPTION
## Description

Based on the nature of the data we're working with, I changed the type of BVS from int to float64. The rest of the PR is the cascading changes (validators, test data) tied to that. This lays the ground for the TSPP data dump I'm working on.

## Reviewer Notes

Was this the best way to do a low-touch switch for these bits of supplied data in tests and data gen? 

## Code Review Verification Steps

* [x] All tests pass.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/blob/master/docs/backend.md#logging)
* [x] Request review from a member of a different team.
* [ ] (TRIAL) Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/156709393) that this change contributes to