### PR TITLE
Contact Info screen - make button active only if preference selected

### DIFF
--- a/src/scenes/ServiceMembers/ContactInfo.jsx
+++ b/src/scenes/ServiceMembers/ContactInfo.jsx
@@ -64,8 +64,18 @@ export class ContactInfo extends Component {
       currentServiceMember,
       userEmail,
     } = this.props;
-    const isValid = this.refs.currentForm && this.refs.currentForm.valid;
-    const isDirty = this.refs.currentForm && this.refs.currentForm.dirty;
+    let prefSelected = false;
+    if (this.refs.currentForm && this.refs.currentForm.values) {
+      prefSelected = Boolean(
+        this.refs.currentForm.values.phone_is_preferred ||
+          this.refs.currentForm.values.text_message_is_preferred ||
+          this.refs.currentForm.values.email_is_preferred,
+      );
+    }
+    const isValid =
+      this.refs.currentForm && this.refs.currentForm.valid && prefSelected;
+    const isDirty =
+      this.refs.currentForm && this.refs.currentForm.dirty && prefSelected;
     // initialValues has to be null until there are values from the action since only the first values are taken
     const initialValues = currentServiceMember
       ? pick(currentServiceMember, subsetOfFields)


### PR DESCRIPTION
## Description

This PR ensures that a contact preference is selected in order for the next button to be active.
This addresses this [pivotal item](https://www.pivotaltracker.com/story/show/156927754)

## Code Review Verification Steps

* [x] All tests pass.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/blob/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* [ ] There are no [aXe](https://www.deque.com/products/aXe/) warnings for UI.
* [ ] This works in IE.
* [ ] Any new third party client side dependencies (e.g., login.gov, google analytics, CDN libraries, etc.) have been communicated to @willowbl00.
* [ ] Request review from a member of a different team.
* [ ] (TRIAL) Have the Pivotal acceptance criteria been met for this change?

## Screenshots
<img width="233" alt="screen shot 2018-04-19 at 2 27 48 pm" src="https://user-images.githubusercontent.com/8170735/39024623-de72d53c-43dd-11e8-9283-70c57a19c216.png">
