### PR TITLE
Adding SIT calculations to the rate engine [delivers #156824380]

### DIFF
--- a/pkg/rateengine/nonlinehaul.go
+++ b/pkg/rateengine/nonlinehaul.go
@@ -46,7 +46,39 @@ func (re *RateEngine) fullUnpackCents(cwt unit.CWT, zip3 string, date time.Time)
 	return unit.Cents(math.Round(float64(cwt.Int()*fullUnpackRate) / 1000.0)), nil
 }
 
-func (re *RateEngine) nonLinehaulChargeTotalCents(weight unit.Pound, originZip5 string, destinationZip5 string, date time.Time) (unit.Cents, error) {
+// sitCharge calculates the SIT charge based on various factors.
+// If `isPPM` (Personally Procured Move) is True we do not apply the first-day
+// storage fees, 185A, to the total.
+func (re *RateEngine) sitCharge(cwt unit.CWT, daysInSIT int, zip3 string, date time.Time, isPPM bool) (unit.Cents, error) {
+	if daysInSIT <= 0 {
+		re.logger.Info("requested sitCharge for zero or less days in SIT?")
+		return 0, nil
+	}
+
+	sa, err := models.FetchTariff400ngServiceAreaForZip3(re.db, zip3, date)
+	if err != nil {
+		return 0, err
+	}
+
+	var sitTotal unit.Cents
+
+	if isPPM {
+		sitTotal = unit.Cents(cwt.Int() * sa.SIT185BRateCents.Int() * daysInSIT)
+	} else {
+		sitTotal = unit.Cents(cwt.Int() * sa.SIT185ARateCents.Int())
+		daysInSIT--
+		if daysInSIT > 0 {
+			sitTotal += unit.Cents(cwt.Int() * sa.SIT185BRateCents.Int() * daysInSIT)
+		}
+	}
+	re.logger.Info("sit calculation", zap.Int("cwt", cwt.Int()), zap.Int("185B", sa.SIT185BRateCents.Int()), zap.Int("days", daysInSIT), zap.Int("total", sitTotal.Int()))
+
+	return sitTotal, err
+}
+
+func (re *RateEngine) nonLinehaulChargeTotalCents(weight unit.Pound, originZip5 string,
+	destinationZip5 string, date time.Time, daysInSIT int, isPPM bool) (unit.Cents, error) {
+
 	originZip3, destinationZip3 := re.zip5ToZip3(originZip5, destinationZip5)
 	originServiceFee, err := re.serviceFeeCents(weight.ToCWT(), originZip3, date)
 	if err != nil {
@@ -64,13 +96,18 @@ func (re *RateEngine) nonLinehaulChargeTotalCents(weight unit.Pound, originZip5 
 	if err != nil {
 		return 0, err
 	}
-	subTotal := originServiceFee + destinationServiceFee + pack + unpack
+	sit, err := re.sitCharge(weight.ToCWT(), daysInSIT, destinationZip3, date, isPPM)
+	if err != nil {
+		return 0, err
+	}
+	subTotal := originServiceFee + destinationServiceFee + pack + unpack + sit
 
 	re.logger.Info("Non-Linehaul charge total calculated",
 		zap.Int("origin service fee", originServiceFee.Int()),
 		zap.Int("destination service fee", destinationServiceFee.Int()),
 		zap.Int("pack fee", pack.Int()),
-		zap.Int("unpack fee", unpack.Int()))
+		zap.Int("unpack fee", unpack.Int()),
+		zap.Int("SIT fee", sit.Int()))
 
 	return subTotal, nil
 }

--- a/pkg/rateengine/nonlinehaul_test.go
+++ b/pkg/rateengine/nonlinehaul_test.go
@@ -151,6 +151,62 @@ func (suite *RateEngineSuite) Test_CheckFullUnpack() {
 	}
 }
 
+func (suite *RateEngineSuite) Test_SITCharge() {
+	t := suite.T()
+	engine := NewRateEngine(suite.db, suite.logger, suite.planner)
+
+	cwt := unit.CWT(10)
+	daysInSIT := 4
+	zip3 := "395"
+	sit185ARate := unit.Cents(1854)
+	sit185BRate := unit.Cents(431)
+
+	z := models.Tariff400ngZip3{
+		Zip3:          zip3,
+		BasepointCity: "Saucier",
+		State:         "MS",
+		ServiceArea:   428,
+		RateArea:      "48",
+		Region:        11,
+	}
+	suite.mustSave(&z)
+
+	sa := models.Tariff400ngServiceArea{
+		Name:               "Tampa, FL",
+		ServiceArea:        428,
+		LinehaulFactor:     69,
+		ServiceChargeCents: 663,
+		ServicesSchedule:   1,
+		EffectiveDateLower: testdatagen.PeakRateCycleStart,
+		EffectiveDateUpper: testdatagen.PeakRateCycleEnd,
+		SIT185ARateCents:   sit185ARate,
+		SIT185BRateCents:   sit185BRate,
+		SITPDSchedule:      1,
+	}
+	suite.mustSave(&sa)
+
+	// Test PPM SIT charges
+	charge, err := engine.sitCharge(cwt, daysInSIT, zip3, testdatagen.DateInsidePeakRateCycle, true)
+	if err != nil {
+		t.Fatalf("error calculating SIT charge: %s", err)
+	}
+	expected := sit185BRate.Multiply(daysInSIT).Multiply(cwt.Int())
+	if charge != expected {
+		t.Errorf("wrong non-linehaul charge total: expected %d, got %d", expected, charge)
+	}
+
+	// Test HHG SIT charges
+	charge, err = engine.sitCharge(cwt, daysInSIT, zip3, testdatagen.DateInsidePeakRateCycle, false)
+	if err != nil {
+		t.Fatalf("error calculating SIT charge: %s", err)
+	}
+	expected = unit.Cents(
+		sit185ARate.Multiply(cwt.Int()).Int() + sit185BRate.Multiply(daysInSIT-1).Multiply(cwt.Int()).Int())
+	if charge != expected {
+		t.Errorf("wrong non-linehaul charge total: expected %d, got %d", expected, charge)
+	}
+}
+
 func (suite *RateEngineSuite) Test_CheckNonLinehaulChargeTotal() {
 	t := suite.T()
 	engine := NewRateEngine(suite.db, suite.logger, suite.planner)
@@ -197,7 +253,7 @@ func (suite *RateEngineSuite) Test_CheckNonLinehaulChargeTotal() {
 		ServicesSchedule:   1,
 		EffectiveDateLower: testdatagen.PeakRateCycleStart,
 		EffectiveDateUpper: testdatagen.PeakRateCycleEnd,
-		SIT185ARateCents:   unit.Cents(50),
+		SIT185ARateCents:   unit.Cents(1750),
 		SIT185BRateCents:   unit.Cents(50),
 		SITPDSchedule:      1,
 	}
@@ -221,13 +277,20 @@ func (suite *RateEngineSuite) Test_CheckNonLinehaulChargeTotal() {
 	}
 	suite.mustSave(&fullUnpackRate)
 
-	fee, err := engine.nonLinehaulChargeTotalCents(unit.Pound(2000), "395", "336", testdatagen.DateInsidePeakRateCycle)
+	daysInSIT := 3
 
+	fee, err := engine.nonLinehaulChargeTotalCents(
+		unit.Pound(2000), "39503", "33607", testdatagen.DateInsidePeakRateCycle, daysInSIT, false)
 	if err != nil {
 		t.Fatalf("failed to calculate non linehaul charge: %s", err)
 	}
-	// (7000 + 13260 + 108580 + 10858)
-	expected := unit.Cents(139698)
+
+	// origin service fee:  7000
+	// dest. service fee:  13260
+	// pack fee:          108580
+	// unpack fee:         10858
+	// SIT:                37000
+	expected := unit.Cents(176698)
 	if fee != expected {
 		t.Errorf("wrong non-linehaul charge total: expected %d, got %d", expected, fee)
 	}

--- a/pkg/rateengine/rateengine_test.go
+++ b/pkg/rateengine/rateengine_test.go
@@ -105,13 +105,13 @@ func (suite *RateEngineSuite) Test_CheckPPMTotal() {
 	suite.mustSave(&shorthaul)
 
 	// 139698 +20000
-	fee, err := engine.computePPM(2000, "39574", "33633", testdatagen.RateEngineDate, 1, .40)
+	fee, err := engine.computePPM(2000, "39574", "33633", testdatagen.RateEngineDate, 1, .40, .5)
 
 	if err != nil {
 		t.Fatalf("failed to calculate ppm charge: %s", err)
 	}
 
-	expected := unit.Cents(63330)
+	expected := unit.Cents(63752)
 	if fee != expected {
 		t.Errorf("wrong PPM charge total: expected %d, got %d", expected, fee)
 	}

--- a/pkg/rateengine/rateengine_test.go
+++ b/pkg/rateengine/rateengine_test.go
@@ -59,8 +59,8 @@ func (suite *RateEngineSuite) Test_CheckPPMTotal() {
 		ServicesSchedule:   1,
 		EffectiveDateLower: testdatagen.PeakRateCycleStart,
 		EffectiveDateUpper: testdatagen.PeakRateCycleEnd,
-		SIT185ARateCents:   unit.Cents(50),
-		SIT185BRateCents:   unit.Cents(50),
+		SIT185ARateCents:   unit.Cents(5550),
+		SIT185BRateCents:   unit.Cents(222),
 		SITPDSchedule:      1,
 	}
 	suite.mustSave(&destinationServiceArea)
@@ -105,13 +105,13 @@ func (suite *RateEngineSuite) Test_CheckPPMTotal() {
 	suite.mustSave(&shorthaul)
 
 	// 139698 +20000
-	fee, err := engine.computePPM(2000, "39574", "33633", testdatagen.RateEngineDate, .40)
+	fee, err := engine.computePPM(2000, "39574", "33633", testdatagen.RateEngineDate, 1, .40)
 
 	if err != nil {
 		t.Fatalf("failed to calculate ppm charge: %s", err)
 	}
 
-	expected := unit.Cents(61643)
+	expected := unit.Cents(63330)
 	if fee != expected {
 		t.Errorf("wrong PPM charge total: expected %d, got %d", expected, fee)
 	}


### PR DESCRIPTION
## Description

PPM should be compensated for Storage in Transit (SIT.) Thus, if the service member expects to be holding their goods in storage we need to be able to calculate the reimbursement.

For PPM, SIT only applies at the destination, and excludes the 1st day costs that are normally associated. [link](https://defensedigitalservice.slack.com/archives/G8HJRJBMZ/p1524160950000548)

## Code Review Verification Steps

* [ ] All tests pass.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/blob/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* [ ] Request review from a member of a different team.
* [ ] (TRIAL) Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/156824380) for this change
