### PR TITLE
Adds Admin route; redirects to blank page

### DIFF
--- a/src/scenes/Admin/index.jsx
+++ b/src/scenes/Admin/index.jsx
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 
 class Admin extends Component {
   render() {
-    return <h1>Office</h1>;
+    return <div />;
   }
 }
 

--- a/src/scenes/Admin/index.jsx
+++ b/src/scenes/Admin/index.jsx
@@ -1,0 +1,9 @@
+import React, { Component } from 'react';
+
+class Admin extends Component {
+  render() {
+    return <h1>Office</h1>;
+  }
+}
+
+export default Admin;

--- a/src/scenes/Admin/index.jsx
+++ b/src/scenes/Admin/index.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 
 export default function() {
   return <div />;

--- a/src/scenes/Admin/index.jsx
+++ b/src/scenes/Admin/index.jsx
@@ -1,9 +1,5 @@
 import React, { Component } from 'react';
 
-class Admin extends Component {
-  render() {
-    return <div />;
-  }
+export default function() {
+  return <div />;
 }
-
-export default Admin;

--- a/src/shared/AppWrapper/index.jsx
+++ b/src/shared/AppWrapper/index.jsx
@@ -14,6 +14,7 @@ import { history } from 'shared/store';
 import Footer from 'shared/Footer';
 import Uploader from 'shared/Uploader';
 import PrivateRoute from 'shared/User/PrivateRoute';
+import Admin from 'scenes/Admin';
 
 import { getWorkflowRoutes } from './getWorkflowRoutes';
 import { createMove } from 'scenes/Moves/ducks';
@@ -49,6 +50,7 @@ export class AppWrapper extends Component {
               <Route path="/shipments/:shipmentsStatus" component={Shipments} />
               <Route path="/DD1299" component={DD1299} />
               <Route path="/feedback" component={Feedback} />
+              <Route path="/admin" component={Admin} />
               <PrivateRoute path="/upload" component={Uploader} />
               {getWorkflowRoutes(props)}
               <Route component={NoMatch} />


### PR DESCRIPTION
## Description

I added a new route for /admin. It goes to a blank page (with a header for some quick clarity). 

## Reviewer Notes

Getting some aXe warnings that pre-date this new route - is there some deliberate working around happening? 

## Code Review Verification Steps

* [ ] All tests pass.
* [ ] There are no [aXe](https://www.deque.com/products/aXe/) warnings for UI.
* [ ] This works in IE.
* [ ] Request review from a member of a different team.
* [ ] (TRIAL) Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/157014523) for this change
