### PR TITLE
Send HSTS header 

### DIFF
--- a/cmd/webserver/main.go
+++ b/cmd/webserver/main.go
@@ -60,6 +60,18 @@ func limitBodySizeMiddleware(inner http.Handler) http.Handler {
 	return http.HandlerFunc(mw)
 }
 
+func httpsComplianceMiddleware(inner http.Handler) http.Handler {
+	zap.L().Info("httpsComplianceMiddleware installed")
+	mw := func(w http.ResponseWriter, r *http.Request) {
+		// set the HSTS header using values recommended by OWASP
+		// https://www.owasp.org/index.php/HTTP_Strict_Transport_Security_Cheat_Sheet#Examples
+		w.Header().Set("strict-transport-security", "max-age=31536000; includeSubdomains; preload")
+		inner.ServeHTTP(w, r)
+		return
+	}
+	return http.HandlerFunc(mw)
+}
+
 func main() {
 
 	build := flag.String("build", "build", "the directory to serve static files from.")
@@ -186,6 +198,7 @@ func main() {
 	// (i.e., the http.Handler returned by the first Middleware added gets
 	// called first).
 	site.Use(requestLoggerMiddleware)
+	site.Use(httpsComplianceMiddleware)
 	site.Use(limitBodySizeMiddleware)
 
 	// Stub health check


### PR DESCRIPTION
## Description

This enables HTTP Strict Transport Security by sending the appropriate header. We send it on every request without caring whether the connection is to the app's http or https port. In production, we only ever talk to the https port, so making this not send for http requests would only affect dev. 

Additionally, sending on every request ensures it's always sent and, in the worst case scenario of sending it over http, browsers ignore the header anyway.

## Reviewer Notes

Is there any problem with doing this via middleware? That's the only way I knew how. Maybe there is a better way.

## Code Review Verification Steps

* [x] All tests pass.
* [x] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/blob/master/docs/backend.md#logging)

## References

* [#156859312 – Send HSTS header](https://www.pivotaltracker.com/story/show/156859312) 
