### PR TITLE
Removed healthcheck from hostname checks

### DIFF
--- a/cmd/webserver/main.go
+++ b/cmd/webserver/main.go
@@ -180,19 +180,21 @@ func main() {
 	handlerContext.SetFileStorer(storer)
 
 	// Base routes
-	root := goji.NewMux()
-
+	site := goji.NewMux()
 	// Add middleware: they are evaluated in the reverse order in which they
 	// are added, but the resulting http.Handlers execute in "normal" order
 	// (i.e., the http.Handler returned by the first Middleware added gets
 	// called first).
-	root.Use(requestLoggerMiddleware)
-	root.Use(limitBodySizeMiddleware)
-	root.Use(appDetectionMiddleware)
-	root.Use(tokenMiddleware)
+	site.Use(requestLoggerMiddleware)
+	site.Use(limitBodySizeMiddleware)
 
 	// Stub health check
-	root.HandleFunc(pat.Get("/health"), func(w http.ResponseWriter, r *http.Request) {})
+	site.HandleFunc(pat.Get("/health"), func(w http.ResponseWriter, r *http.Request) {})
+
+	root := goji.NewMux()
+	root.Use(appDetectionMiddleware)
+	root.Use(tokenMiddleware)
+	site.Handle(pat.New("/*"), root)
 
 	apiMux := goji.SubMux()
 	root.Handle(pat.New("/api/v1/*"), apiMux)
@@ -236,7 +238,7 @@ func main() {
 		zap.L().Info("Starting http server listening", zap.String("address", addr))
 		s := &http.Server{
 			Addr:           addr,
-			Handler:        root,
+			Handler:        site,
 			MaxHeaderBytes: maxHeaderSize,
 		}
 		errChan <- s.ListenAndServe()
@@ -244,7 +246,7 @@ func main() {
 	go func() { // start https listener
 		addr := fmt.Sprintf("%s:%s", *listenInterface, *httpsPort)
 		zap.L().Info("Starting https server listening", zap.String("address", addr))
-		errChan <- listenAndServeTLS(addr, []byte(*httpsCert), []byte(*httpsKey), root)
+		errChan <- listenAndServeTLS(addr, []byte(*httpsCert), []byte(*httpsKey), site)
 	}()
 	log.Fatal(<-errChan)
 }


### PR DESCRIPTION
## Description

The app.DetectorMiddleware checks that a hostname is passed in with a request that it matches the expected hosts for (my|office).move.mil.

In most cases this is correct BUT in AWS the load balancer relies on sending `GET /health` periodically to check the health of the server. At this level there is no knowledge of the context/hostnames. This fix  moves the `/health` route out of that middleware.

## Reviewer Notes

What did I break in this quick fix. I checked that the tests still work and I can access the root URLs which I moved into a SubMux
## Code Review Verification Steps

* [ ] All tests pass.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/blob/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* [ ] There are no [aXe](https://www.deque.com/products/aXe/) warnings for UI.
* [ ] This works in IE.
* [ ] Any new third party client side dependencies (e.g., login.gov, google analytics, CDN libraries, etc.) have been communicated to @willowbl00.
* [ ] Request review from a member of a different team.
* [ ] (TRIAL) Have the Pivotal acceptance criteria been met for this change?

