### PR TITLE
Fix initial submit bug, and get errors back in the mix.

### DIFF
--- a/src/scenes/ServiceMembers/BackupContact.jsx
+++ b/src/scenes/ServiceMembers/BackupContact.jsx
@@ -170,6 +170,10 @@ export class BackupContact extends Component {
       pendingValues.telephone = null;
     }
 
+    if (pendingValues.permission === undefined) {
+      pendingValues.permission = NonePermission;
+    }
+
     if (pendingValues) {
       if (this.props.currentBackupContacts.length > 0) {
         // update existing
@@ -252,6 +256,7 @@ function mapStateToProps(state) {
     hasSubmitSuccess:
       state.serviceMember.createBackupContactSuccess ||
       state.serviceMember.updateBackupContactSuccess,
+    error: state.serviceMember.error,
     loggedInUser: state.loggedInUser.loggedInUser,
     schema: {},
     formData: state.form[formName],


### PR DESCRIPTION
## Description

Initial submit didn't work because of a missing default value. Also, we weren't displaying errors correctly. 

## Code Review Verification Steps

* [ ] All tests pass.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/blob/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* [ ] There are no [aXe](https://www.deque.com/products/aXe/) warnings for UI.
* [ ] This works in IE.
* [ ] Any new third party client side dependencies (e.g., login.gov, google analytics, CDN libraries, etc.) have been communicated to @willowbl00.
* [ ] Request review from a member of a different team.
* [ ] (TRIAL) Have the Pivotal acceptance criteria been met for this change?
