### PR TITLE
els uploads refactor

### DIFF
--- a/cmd/generate_test_data/main.go
+++ b/cmd/generate_test_data/main.go
@@ -41,6 +41,5 @@ func main() {
 		testdatagen.MakeTSPPerformanceData(db, *rounds)
 		testdatagen.MakeBlackoutDateData(db)
 		testdatagen.MakeMoveData(db)
-		testdatagen.MakeDocumentData(db)
 	}
 }

--- a/migrations/20180427215024_add_service_member_id_to_documents.down.fizz
+++ b/migrations/20180427215024_add_service_member_id_to_documents.down.fizz
@@ -1,0 +1,3 @@
+drop_foreign_key("documents", "service_member_id", {"if_exists": true})
+drop_column("documents", "service_member_id")
+add_foreign_key("documents", "move_id", {"moves": ["id"]}, {})

--- a/migrations/20180427215024_add_service_member_id_to_documents.down.fizz
+++ b/migrations/20180427215024_add_service_member_id_to_documents.down.fizz
@@ -1,3 +1,4 @@
 drop_foreign_key("documents", "service_member_id", {"if_exists": true})
 drop_column("documents", "service_member_id")
+add_column("documents", "move_id","uuid", {})
 add_foreign_key("documents", "move_id", {"moves": ["id"]}, {})

--- a/migrations/20180427215024_add_service_member_id_to_documents.up.fizz
+++ b/migrations/20180427215024_add_service_member_id_to_documents.up.fizz
@@ -1,0 +1,3 @@
+drop_foreign_key("documents", "move_id", {"if_exists": true})
+add_column("documents", "service_member_id", "uuid", {})
+add_foreign_key("documents", "service_member_id", {"service_members": ["id"]}, {})

--- a/migrations/20180427215024_add_service_member_id_to_documents.up.fizz
+++ b/migrations/20180427215024_add_service_member_id_to_documents.up.fizz
@@ -1,3 +1,4 @@
 drop_foreign_key("documents", "move_id", {"if_exists": true})
+drop_column("documents", "move_id")
 add_column("documents", "service_member_id", "uuid", {})
 add_foreign_key("documents", "service_member_id", {"service_members": ["id"]}, {})

--- a/pkg/handlers/documents.go
+++ b/pkg/handlers/documents.go
@@ -15,9 +15,10 @@ import (
 
 func payloadForDocumentModel(document models.Document) internalmessages.DocumentPayload {
 	documentPayload := internalmessages.DocumentPayload{
-		ID:      fmtUUID(document.ID),
-		Name:    swag.String(document.Name),
-		Uploads: []*internalmessages.UploadPayload{},
+		ID:              fmtUUID(document.ID),
+		ServiceMemberID: fmtUUID(document.ServiceMemberID),
+		Name:            swag.String(document.Name),
+		Uploads:         []*internalmessages.UploadPayload{},
 	}
 	return documentPayload
 }

--- a/pkg/handlers/documents.go
+++ b/pkg/handlers/documents.go
@@ -22,7 +22,7 @@ func payloadForDocumentModel(document models.Document) internalmessages.Document
 	return documentPayload
 }
 
-// CreateDocumentHandler creates a new document via POST /moves/{moveID}/documents/
+// CreateDocumentHandler creates a new document via POST /documents/
 type CreateDocumentHandler HandlerContext
 
 // Handle creates a new Document from a request payload
@@ -33,16 +33,16 @@ func (h CreateDocumentHandler) Handle(params documentop.CreateDocumentParams) mi
 		return documentop.NewCreateDocumentBadRequest()
 	}
 
-	moveID, err := uuid.FromString(params.MoveID.String())
+	serviceMemberID, err := uuid.FromString(params.DocumentPayload.ServiceMemberID.String())
 	if err != nil {
-		h.logger.Info("Badly formed UUID for moveId", zap.String("move_id", params.MoveID.String()), zap.Error(err))
+		h.logger.Info("Badly formed UUID for serviceMemberId", zap.String("service_member_id", params.DocumentPayload.ServiceMemberID.String()), zap.Error(err))
 		return documentop.NewCreateDocumentBadRequest()
 	}
 
 	newDocument := models.Document{
-		UploaderID: userID,
-		MoveID:     moveID,
-		Name:       params.DocumentPayload.Name,
+		UploaderID:      userID,
+		ServiceMemberID: serviceMemberID,
+		Name:            params.DocumentPayload.Name,
 	}
 
 	verrs, err := h.db.ValidateAndCreate(&newDocument)

--- a/pkg/handlers/documents_test.go
+++ b/pkg/handlers/documents_test.go
@@ -16,16 +16,15 @@ import (
 func (suite *HandlerSuite) TestCreateDocumentsHandler() {
 	t := suite.T()
 
-	move, err := testdatagen.MakeMove(suite.db)
+	serviceMember, err := testdatagen.MakeServiceMember(suite.db)
 	if err != nil {
-		t.Fatalf("could not create move: %s", err)
+		t.Fatalf("could not create serviceMember: %s", err)
 	}
 
-	userID := move.UserID
+	userID := serviceMember.UserID
 
 	params := documentop.NewCreateDocumentParams()
-	params.MoveID = *fmtUUID(move.ID)
-	params.DocumentPayload = &internalmessages.PostDocumentPayload{Name: "test document"}
+	params.DocumentPayload = &internalmessages.PostDocumentPayload{Name: "test document", ServiceMemberID: *fmtUUID(serviceMember.ID)}
 
 	ctx := authcontext.PopulateAuthContext(context.Background(), userID, "fake token")
 	params.HTTPRequest = (&http.Request{}).WithContext(ctx)
@@ -41,6 +40,10 @@ func (suite *HandlerSuite) TestCreateDocumentsHandler() {
 
 	if uuid.Must(uuid.FromString(documentPayload.ID.String())) == uuid.Nil {
 		t.Errorf("got empty document uuid")
+	}
+
+	if uuid.Must(uuid.FromString(documentPayload.ServiceMemberID.String())) == uuid.Nil {
+		t.Errorf("got empty serviceMember uuid")
 	}
 
 	if documentPayload.Name == nil {

--- a/pkg/models/document_test.go
+++ b/pkg/models/document_test.go
@@ -8,14 +8,14 @@ import (
 func (suite *ModelSuite) Test_DocumentCreate() {
 	t := suite.T()
 
-	move, err := testdatagen.MakeMove(suite.db)
+	serviceMember, err := testdatagen.MakeServiceMember(suite.db)
 	if err != nil {
 		t.Fatalf("could not create move: %v", err)
 	}
 
 	document := models.Document{
-		UploaderID: move.UserID,
-		MoveID:     move.ID,
+		UploaderID:      serviceMember.UserID,
+		ServiceMemberID: serviceMember.ID,
 	}
 
 	verrs, err := suite.db.ValidateAndSave(&document)
@@ -33,8 +33,8 @@ func (suite *ModelSuite) Test_DocumentValidations() {
 	document := &models.Document{}
 
 	var expErrors = map[string][]string{
-		"uploader_id": []string{"UploaderID can not be blank."},
-		"move_id":     []string{"MoveID can not be blank."},
+		"uploader_id":       []string{"UploaderID can not be blank."},
+		"service_member_id": []string{"ServiceMemberID can not be blank."},
 	}
 
 	suite.verifyValidationErrors(document, expErrors)

--- a/pkg/models/service_member.go
+++ b/pkg/models/service_member.go
@@ -238,3 +238,15 @@ func (s *ServiceMember) IsProfileComplete() bool {
 	// All required fields have a set value
 	return true
 }
+
+// ValidateServiceMemberAccess validates that a user has access to serviceMember
+func ValidateServiceMemberAccess(db *pop.Connection, userID uuid.UUID, serviceMemberID uuid.UUID) bool {
+	userHasAccess := false
+	// TODO: Handle case where more than one user is authorized to modify move
+	var serviceMember ServiceMember
+	smErr := db.Find(&serviceMember, serviceMemberID)
+	if smErr == nil {
+		userHasAccess = uuid.Equal(userID, serviceMember.UserID)
+	}
+	return userHasAccess
+}

--- a/pkg/models/service_member.go
+++ b/pkg/models/service_member.go
@@ -2,7 +2,6 @@ package models
 
 import (
 	"encoding/json"
-	"fmt"
 	"time"
 
 	"github.com/gobuffalo/pop"
@@ -81,6 +80,7 @@ func (s *ServiceMember) ValidateUpdate(tx *pop.Connection) (*validate.Errors, er
 }
 
 // FetchServiceMember returns a service member only if it is allowed for the given user to access that service member.
+// This method is thereby a useful way of performing access control checks.
 func FetchServiceMember(db *pop.Connection, user User, id uuid.UUID) (ServiceMember, error) {
 	var serviceMember ServiceMember
 	err := db.Q().Eager().Find(&serviceMember, id)
@@ -93,7 +93,6 @@ func FetchServiceMember(db *pop.Connection, user User, id uuid.UUID) (ServiceMem
 	}
 	// TODO: Handle case where more than one user is authorized to modify serviceMember
 	if serviceMember.UserID != user.ID {
-		fmt.Println("*****", user.ID, serviceMember.UserID)
 		return ServiceMember{}, ErrFetchForbidden
 	}
 
@@ -239,16 +238,4 @@ func (s *ServiceMember) IsProfileComplete() bool {
 	// TODO: add check for station, SSN, and backup contacts
 	// All required fields have a set value
 	return true
-}
-
-// ValidateServiceMemberAccess validates that a user has access to serviceMember
-func ValidateServiceMemberAccess(db *pop.Connection, userID uuid.UUID, serviceMemberID uuid.UUID) bool {
-	userHasAccess := false
-	// TODO: Handle case where more than one user is authorized to modify move
-	var serviceMember ServiceMember
-	smErr := db.Find(&serviceMember, serviceMemberID)
-	if smErr == nil {
-		userHasAccess = uuid.Equal(userID, serviceMember.UserID)
-	}
-	return userHasAccess
 }

--- a/pkg/models/service_member.go
+++ b/pkg/models/service_member.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"encoding/json"
+	"fmt"
 	"time"
 
 	"github.com/gobuffalo/pop"
@@ -92,6 +93,7 @@ func FetchServiceMember(db *pop.Connection, user User, id uuid.UUID) (ServiceMem
 	}
 	// TODO: Handle case where more than one user is authorized to modify serviceMember
 	if serviceMember.UserID != user.ID {
+		fmt.Println("*****", user.ID, serviceMember.UserID)
 		return ServiceMember{}, ErrFetchForbidden
 	}
 

--- a/pkg/models/upload.go
+++ b/pkg/models/upload.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gobuffalo/uuid"
 	"github.com/gobuffalo/validate"
 	"github.com/gobuffalo/validate/validators"
+	"github.com/pkg/errors"
 )
 
 // An Upload represents an uploaded file, such as an image or PDF.
@@ -48,4 +49,23 @@ func (u *Upload) Validate(tx *pop.Connection) (*validate.Errors, error) {
 		&AllowedFiletype{Field: u.ContentType, Name: "ContentType"},
 		&validators.StringIsPresent{Field: u.Checksum, Name: "Checksum"},
 	), nil
+}
+
+// FetchUpload returns an Upload if the user has access to that upload
+func FetchUpload(db *pop.Connection, user User, id uuid.UUID) (Upload, error) {
+	var upload Upload
+	err := db.Q().Eager().Find(&upload, id)
+	if err != nil {
+		if errors.Cause(err).Error() == RecordNotFoundErrorString {
+			return Upload{}, ErrFetchNotFound
+		}
+		// Otherwise, it's an unexpected err so we return that.
+		return Upload{}, err
+	}
+
+	_, docErr := FetchDocument(db, user, upload.DocumentID)
+	if docErr != nil {
+		return Upload{}, docErr
+	}
+	return upload, nil
 }

--- a/pkg/models/upload_test.go
+++ b/pkg/models/upload_test.go
@@ -10,11 +10,6 @@ import (
 func (suite *ModelSuite) Test_UploadCreate() {
 	t := suite.T()
 
-	move, err := testdatagen.MakeMove(suite.db)
-	if err != nil {
-		t.Fatalf("could not create move: %v", err)
-	}
-
 	document := models.Document{
 		UploaderID: move.UserID,
 		MoveID:     move.ID,

--- a/pkg/models/upload_test.go
+++ b/pkg/models/upload_test.go
@@ -10,15 +10,11 @@ import (
 func (suite *ModelSuite) Test_UploadCreate() {
 	t := suite.T()
 
-	document := models.Document{
-		UploaderID: move.UserID,
-		MoveID:     move.ID,
-	}
-	suite.mustSave(&document)
+	document, _ := testdatagen.MakeDocument(suite.db, nil)
 
 	upload := models.Upload{
 		DocumentID:  document.ID,
-		UploaderID:  move.UserID,
+		UploaderID:  document.UploaderID,
 		Filename:    "test.pdf",
 		Bytes:       1048576,
 		ContentType: "application/pdf",
@@ -39,22 +35,13 @@ func (suite *ModelSuite) Test_UploadCreate() {
 func (suite *ModelSuite) Test_UploadCreateWithID() {
 	t := suite.T()
 
-	move, err := testdatagen.MakeMove(suite.db)
-	if err != nil {
-		t.Fatalf("could not create move: %v", err)
-	}
-
-	document := models.Document{
-		UploaderID: move.UserID,
-		MoveID:     move.ID,
-	}
-	suite.mustSave(&document)
+	document, _ := testdatagen.MakeDocument(suite.db, nil)
 
 	id := uuid.Must(uuid.NewV4())
 	upload := models.Upload{
 		ID:          id,
 		DocumentID:  document.ID,
-		UploaderID:  move.UserID,
+		UploaderID:  document.UploaderID,
 		Filename:    "test.pdf",
 		Bytes:       1048576,
 		ContentType: "application/pdf",

--- a/pkg/testdatagen/make_document.go
+++ b/pkg/testdatagen/make_document.go
@@ -21,6 +21,7 @@ func MakeDocument(db *pop.Connection, serviceMember *models.ServiceMember) (mode
 	document := models.Document{
 		UploaderID:      serviceMember.UserID,
 		ServiceMemberID: serviceMember.ID,
+		ServiceMember:   *serviceMember,
 	}
 
 	verrs, err := db.ValidateAndSave(&document)

--- a/pkg/testdatagen/make_document.go
+++ b/pkg/testdatagen/make_document.go
@@ -9,18 +9,18 @@ import (
 )
 
 // MakeDocument creates a single Document.
-func MakeDocument(db *pop.Connection, move *models.Move) (models.Document, error) {
-	if move == nil {
-		newMove, err := MakeMove(db)
+func MakeDocument(db *pop.Connection, serviceMember *models.ServiceMember) (models.Document, error) {
+	if serviceMember == nil {
+		newServiceMember, err := MakeServiceMember(db)
 		if err != nil {
 			log.Panic(err)
 		}
-		move = &newMove
+		serviceMember = &newServiceMember
 	}
 
 	document := models.Document{
-		UploaderID: move.UserID,
-		MoveID:     move.ID,
+		UploaderID:      serviceMember.UserID,
+		ServiceMemberID: serviceMember.ID,
 	}
 
 	verrs, err := db.ValidateAndSave(&document)
@@ -32,24 +32,4 @@ func MakeDocument(db *pop.Connection, move *models.Move) (models.Document, error
 	}
 
 	return document, err
-}
-
-// MakeDocumentData creates a Document for every Move in the database.
-func MakeDocumentData(db *pop.Connection) {
-	moveList := []models.Move{}
-	err := db.All(&moveList)
-	if err != nil {
-		log.Panic(err)
-	}
-
-	for _, move := range moveList {
-		document, err := MakeDocument(db, &move)
-		if err != nil {
-			log.Panic(err)
-		}
-		_, err = MakeUpload(db, &document)
-		if err != nil {
-			log.Panic(err)
-		}
-	}
 }

--- a/src/shared/Uploader/api.js
+++ b/src/shared/Uploader/api.js
@@ -5,25 +5,27 @@ export async function GetSpec() {
   return client.spec;
 }
 
-export async function CreateUpload(fileUpload, moveID, documentID) {
+export async function CreateUpload(fileUpload, documentId) {
+  console.log(arguments);
   const client = await getClient();
   const response = await client.apis.uploads.createUpload({
     file: fileUpload,
-    moveId: moveID,
-    documentId: documentID,
+    documentId,
   });
   checkResponse(response, 'failed to upload file due to server error');
   return response.body;
 }
 
-export async function CreateDocument(fileUpload, moveID) {
+export async function CreateDocument(fileUpload, serviceMemberId) {
   const client = await getClient();
   const response = await client.apis.documents.createDocument({
-    documentPayload: { name: 'document' },
-    moveId: moveID,
+    documentPayload: {
+      name: 'document',
+      service_member_id: serviceMemberId,
+    },
   });
   checkResponse(response, 'failed to create document due to server error');
-  return CreateUpload(fileUpload, moveID, response.body.id);
+  return CreateUpload(fileUpload, response.body.id);
 }
 
 export default CreateDocument;

--- a/src/shared/Uploader/api.js
+++ b/src/shared/Uploader/api.js
@@ -6,7 +6,6 @@ export async function GetSpec() {
 }
 
 export async function CreateUpload(fileUpload, documentId) {
-  console.log(arguments);
   const client = await getClient();
   const response = await client.apis.uploads.createUpload({
     file: fileUpload,

--- a/src/shared/Uploader/ducks.js
+++ b/src/shared/Uploader/ducks.js
@@ -22,10 +22,10 @@ export const createDocumentFailure = error => ({
 });
 
 // Action creator
-export function createDocument(fileUpload, moveID) {
+export function createDocument(fileUpload, serviceMemberId) {
   return function(dispatch, getState) {
     dispatch(createDocumentRequest());
-    CreateDocument(fileUpload, moveID)
+    CreateDocument(fileUpload, serviceMemberId)
       .then(item => dispatch(createDocumentSuccess(item)))
       .catch(error => dispatch(createDocumentFailure(error)));
   };

--- a/src/shared/Uploader/index.jsx
+++ b/src/shared/Uploader/index.jsx
@@ -17,18 +17,21 @@ export class Uploader extends Component {
   }
 
   uploadFile() {
-    this.props.createDocument(this.fileInput.files[0], this.moveIdInput.value);
+    this.props.createDocument(
+      this.fileInput.files[0],
+      this.serviceMemberId.value,
+    );
   }
 
   render() {
     const { hasErrored, hasSucceeded } = this.props;
     return (
       <div className="usa-grid">
-        Enter Move ID:{' '}
+        Enter Service Member ID:{' '}
         <input
           type="text"
           ref={input => {
-            this.moveIdInput = input;
+            this.serviceMemberId = input;
           }}
         />
         <input

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -717,6 +717,7 @@ definitions:
     required:
       - id
       - name
+      - service_member_id
       - uploads
   PostDocumentPayload:
     type: object

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -706,6 +706,10 @@ definitions:
       name:
         type: string
         title: Human-understandable name for this document
+      service_member_id:
+        type: string
+        format: uuid
+        title: The service member this document belongs to
       uploads:
         type: array
         items:
@@ -720,6 +724,10 @@ definitions:
       name:
         type: string
         title: Human-understandable name for this document
+      service_member_id:
+        type: string
+        format: uuid
+        title: The service member this document belongs to
   UploadPayload:
     type: object
     properties:
@@ -1674,7 +1682,7 @@ paths:
           description: request requires user authentication
         403:
           description: user is not authorized
-  /moves/{moveId}/documents:
+  /documents:
     post:
       summary: Create a new document
       description: Documents represent a physical artifact such as a scanned document or a PDF file
@@ -1682,12 +1690,6 @@ paths:
       tags:
         - documents
       parameters:
-        - in: path
-          name: moveId
-          type: string
-          format: uuid
-          required: true
-          description: UUID of the move
         - in: body
           name: documentPayload
           required: true
@@ -1702,7 +1704,7 @@ paths:
           description: invalid request
         500:
           description: server error
-  /moves/{moveId}/documents/{documentId}/uploads:
+  /documents/{documentId}/uploads:
     post:
       summary: Create a new upload
       description: Uploads represent a single digital file, such as a JPEG or PDF.
@@ -1712,12 +1714,6 @@ paths:
       consumes:
         - multipart/form-data
       parameters:
-        - in: path
-          name: moveId
-          type: string
-          format: uuid
-          required: true
-          description: UUID of the move
         - in: path
           name: documentId
           type: string


### PR DESCRIPTION
## Description

decoupling uploads from moves (since orders come before moves) and associating with service members

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?
http://localhost:3000/upload still works but is no longer in the nav bar. (You will need to look up the servicememberid)

## Code Review Verification Steps

* [ ] All tests pass.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/blob/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* [ ] There are no [aXe](https://www.deque.com/products/aXe/) warnings for UI.
* [ ] This works in IE.
* [ x] Any new third party client side dependencies (e.g., login.gov, google analytics, CDN libraries, etc.) have been communicated to @willowbl00.
* [ x] Request review from a member of a different team.
* [ ] (TRIAL) Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](tbd) for this change
* [this article](tbd) explains more about the approach used.

## Screenshots

If this PR makes visible UI changes, an image of the finished UI can help reviewers and casual
observers understand the context of the changes. A before image is optional and
can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow instead of using multiple images. You may want to use GIPHY CAPTURE for this! 📸

_Please frame screenshots to show enough useful context but also highlight the affected regions._
