### PR TITLE
Adds PPM screen field changes to swagger [#157005876]

### DIFF
--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -87,6 +87,36 @@ definitions:
     properties:
       size:
         $ref: '#/definitions/TShirtSize'
+      planned_move_date:
+        type: string
+        format: date
+        title: Move Date
+        x-nullable: true
+      pickup_zip:
+        type: string
+        format: zip
+        title: ZIP/Postal Code
+        example: "90210"
+        pattern: '^(\d{5}([\-]\d{4})?)$'
+        x-nullable: true
+      additional_pickup_zip:
+        type: string
+        format: zip
+        title: ZIP/Postal Code
+        example: "90210"
+        pattern: '^(\d{5}([\-]\d{4})?)$'
+        x-nullable: true
+      destination_zip:
+        type: string
+        format: zip
+        title: ZIP/Postal Code
+        example: "90210"
+        pattern: '^(\d{5}([\-]\d{4})?)$'
+        x-nullable: true
+      days_in_storage:
+        type: integer
+        title: Days in Temporary Storage
+        x-nullable: true
       weight_estimate:
         type: integer
         title: Weight Estimate
@@ -100,6 +130,36 @@ definitions:
     properties:
       size:
         $ref: '#/definitions/TShirtSize'
+      planned_move_date:
+        type: string
+        format: date
+        title: Move Date
+        x-nullable: true
+      pickup_zip:
+        type: string
+        format: zip
+        title: ZIP/Postal Code
+        example: "90210"
+        pattern: '^(\d{5}([\-]\d{4})?)$'
+        x-nullable: true
+      additional_pickup_zip:
+        type: string
+        format: zip
+        title: ZIP/Postal Code
+        example: "90210"
+        pattern: '^(\d{5}([\-]\d{4})?)$'
+        x-nullable: true
+      destination_zip:
+        type: string
+        format: zip
+        title: ZIP/Postal Code
+        example: "90210"
+        pattern: '^(\d{5}([\-]\d{4})?)$'
+        x-nullable: true
+      days_in_storage:
+        type: integer
+        title: Days in Temporary Storage
+        x-nullable: true
       weight_estimate:
         type: integer
         title: Weight Estimate
@@ -113,6 +173,36 @@ definitions:
     properties:
       size:
         $ref: '#/definitions/TShirtSize'
+      planned_move_date:
+        type: string
+        format: date
+        title: Move Date
+        x-nullable: true
+      pickup_zip:
+        type: string
+        format: zip
+        title: ZIP/Postal Code
+        example: "90210"
+        pattern: '^(\d{5}([\-]\d{4})?)$'
+        x-nullable: true
+      additional_pickup_zip:
+        type: string
+        format: zip
+        title: ZIP/Postal Code
+        example: "90210"
+        pattern: '^(\d{5}([\-]\d{4})?)$'
+        x-nullable: true
+      destination_zip:
+        type: string
+        format: zip
+        title: ZIP/Postal Code
+        example: "90210"
+        pattern: '^(\d{5}([\-]\d{4})?)$'
+        x-nullable: true
+      days_in_storage:
+        type: integer
+        title: Days in Temporary Storage
+        x-nullable: true
       weight_estimate:
         type: integer
         title: Weight Estimate
@@ -130,6 +220,36 @@ definitions:
         example: c56a4180-65aa-42ec-a945-5fd21dec0538
       size:
         $ref: '#/definitions/TShirtSize'
+      planned_move_date:
+        type: string
+        format: date
+        title: Move Date
+        x-nullable: true
+      pickup_zip:
+        type: string
+        format: zip
+        title: ZIP/Postal Code
+        example: "90210"
+        pattern: '^(\d{5}([\-]\d{4})?)$'
+        x-nullable: true
+      additional_pickup_zip:
+        type: string
+        format: zip
+        title: ZIP/Postal Code
+        example: "90210"
+        pattern: '^(\d{5}([\-]\d{4})?)$'
+        x-nullable: true
+      destination_zip:
+        type: string
+        format: zip
+        title: ZIP/Postal Code
+        example: "90210"
+        pattern: '^(\d{5}([\-]\d{4})?)$'
+        x-nullable: true
+      days_in_storage:
+        type: integer
+        title: Days in Temporary Storage
+        x-nullable: true
       weight_estimate:
         type: integer
         title: Weight Estimate


### PR DESCRIPTION
## Description

Adds a few fields to the PPM model to be in line with updated wireframes

## Code Review Verification Steps

* [ ] All tests pass.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/blob/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* [ ] There are no [aXe](https://www.deque.com/products/aXe/) warnings for UI.
* [ ] This works in IE.
* [ ] Any new third party client side dependencies (e.g., login.gov, google analytics, CDN libraries, etc.) have been communicated to @willowbl00.
* [ ] Request review from a member of a different team.
* [ ] (TRIAL) Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](#157005876) for this change

## Screenshots

This shows the wireframe used to inform which fields needed to be added

<img width="759" alt="screenshot 2018-04-30 16 41 21" src="https://user-images.githubusercontent.com/5151804/39455471-60d26564-4c95-11e8-87da-1b96f8872bc8.png">

