### PR TITLE
Add X-UA-Compatible meta tag.

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+    <meta http-equiv="X-UA-Compatible" content="IE=EDGE" />
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <meta name="theme-color" content="#000000">


### PR DESCRIPTION
## Description

Opening our app in IE11 for local development in a Windows VM causes it to be rendered in IE Compatibility mode due to being on a local network instead of the internet. The result is that the site is rendered in IE7 Compatibility Mode, which breaks the entire application.

This patch adds a `X-UA-Compatible` `meta` tag that will cause IE to always use the latest compatibility mode that it can. IE 11 will then properly render the site by default.

## Reviewer Notes

* `X-UA-Compatible` is ignored by Edge, so this is purely for local network testing in IE11.
* This may only be an issue for local development, but it's a good idea to have this `meta` tag regardless as we don't know what the settings on a particular PC will be. *Note that it is still possible for the site to not work on IE11 even with this tag depending on the security settings of that particular computer.*
* There is another way to accomplish this, but it involves a modifying a default setting buried deep with the Windows VM's _Internet Options_.

## Code Review Verification Steps

* [ ] All tests pass.
* [ ] There are no [aXe](https://www.deque.com/products/aXe/) warnings for UI.
* [ ] This works in IE.
* [ ] Request review from a member of a different team.

## References

* [Microsoft's docs on `X-UA-Compatible`](https://msdn.microsoft.com/en-us/library/ff955275(v=vs.85).aspx)