### PR TITLE
Access env var at the top level instead of within storage package.

### DIFF
--- a/cmd/webserver/main.go
+++ b/cmd/webserver/main.go
@@ -109,6 +109,7 @@ func main() {
 	storageBackend := flag.String("storage_backend", "filesystem", "Storage backend to use, either filesystem or s3.")
 	s3Bucket := flag.String("aws_s3_bucket_name", "", "S3 bucket used for file storage")
 	s3Region := flag.String("aws_s3_region", "", "AWS region used for S3 file storage")
+	s3KeyNamespace := flag.String("aws_s3_key_namespace", "", "Key prefix for all objects written to S3")
 
 	flag.Parse()
 
@@ -174,11 +175,14 @@ func main() {
 		if *s3Region == "" {
 			log.Fatalln(errors.New("Must provide aws_s3_region parameter, exiting"))
 		}
+		if *s3KeyNamespace == "" {
+			log.Fatalln(errors.New("Must provide aws_s3_key_namespace parameter, exiting"))
+		}
 		aws := awssession.Must(awssession.NewSession(&aws.Config{
 			Region: s3Region,
 		}))
 
-		storer = storage.NewS3(*s3Bucket, logger, aws)
+		storer = storage.NewS3(*s3Bucket, *s3KeyNamespace, logger, aws)
 	} else {
 		zap.L().Info("Using filesystem storage backend")
 		absTmpPath, err := filepath.Abs("tmp")

--- a/pkg/storage/s3.go
+++ b/pkg/storage/s3.go
@@ -2,7 +2,6 @@ package storage
 
 import (
 	"io"
-	"os"
 	"path"
 	"time"
 
@@ -14,15 +13,16 @@ import (
 
 // S3 implements the file storage API using S3.
 type S3 struct {
-	bucket string
-	logger *zap.Logger
-	client *s3.S3
+	bucket       string
+	keyNamespace string
+	logger       *zap.Logger
+	client       *s3.S3
 }
 
 // NewS3 creates a new S3 using the provided AWS session.
-func NewS3(bucket string, logger *zap.Logger, session *session.Session) *S3 {
+func NewS3(bucket string, keyNamespace string, logger *zap.Logger, session *session.Session) *S3 {
 	client := s3.New(session)
-	return &S3{bucket, logger, client}
+	return &S3{bucket, keyNamespace, logger, client}
 }
 
 // Store stores the content from an io.ReadSeeker at the specified key.
@@ -43,8 +43,7 @@ func (s *S3) Store(key string, data io.ReadSeeker, md5 string) (*StoreResult, er
 
 // Key returns a joined key plus any global namespace
 func (s *S3) Key(args ...string) string {
-	namespace := os.Getenv("AWS_S3_KEY_NAMESPACE")
-	args = append([]string{namespace}, args...)
+	args = append([]string{s.keyNamespace}, args...)
 	return path.Join(args...)
 }
 


### PR DESCRIPTION
## Description

A follow-up item from a previous retro was to look into how to make sure that all required environment variables are set in staging/production. The result of a conversation about this was to make sure that the app server refuses to boot if it is missing a config value.

I audited the app for where we might be using an environment variable and not raising an error and found one place in the `storage` package. This PR moves the environment variable access to the program's top level, exist if the value isn't set, and passes the resulting value down to be used deeper in the application.

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Code Review Verification Steps

* [ ] All tests pass.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/blob/master/docs/backend.md#logging) have been satisfied.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/157163260) for this change