### PR TITLE
change name field from string to string pointer for tsp model

### DIFF
--- a/cmd/generate_test_data/main.go
+++ b/cmd/generate_test_data/main.go
@@ -42,5 +42,6 @@ func main() {
 		testdatagen.MakeBlackoutDateData(db)
 		testdatagen.MakeMoveData(db)
 		testdatagen.MakeDocumentData(db)
+		testdatagen.MakeServiceMember(db)
 	}
 }

--- a/pkg/models/transportation_service_provider.go
+++ b/pkg/models/transportation_service_provider.go
@@ -18,7 +18,7 @@ type TransportationServiceProvider struct {
 	CreatedAt                time.Time `json:"created_at" db:"created_at"`
 	UpdatedAt                time.Time `json:"updated_at" db:"updated_at"`
 	StandardCarrierAlphaCode string    `json:"standard_carrier_alpha_code" db:"standard_carrier_alpha_code"`
-	Name                     string    `json:"name" db:"name"`
+	Name                     *string   `json:"name" db:"name"`
 }
 
 // TSPWithBVSAndOfferCount represents a list of TSPs along with their BVS
@@ -58,13 +58,12 @@ func (t TransportationServiceProviders) String() string {
 func (t *TransportationServiceProvider) Validate(tx *pop.Connection) (*validate.Errors, error) {
 	return validate.Validate(
 		&validators.StringIsPresent{Field: t.StandardCarrierAlphaCode, Name: "StandardCarrierAlphaCode"},
-		&validators.StringIsPresent{Field: t.Name, Name: "Name"},
 	), nil
 }
 
 // MarshalLogObject is required to control the logging of this
 func (t TransportationServiceProvider) MarshalLogObject(encoder zapcore.ObjectEncoder) error {
 	encoder.AddString("id", t.ID.String())
-	encoder.AddString("name", t.Name)
+	encoder.AddString("name", *t.Name)
 	return nil
 }

--- a/pkg/testdatagen/make_tsp_records.go
+++ b/pkg/testdatagen/make_tsp_records.go
@@ -24,7 +24,7 @@ func RandomSCAC() string {
 func MakeTSP(db *pop.Connection, name string, SCAC string) (models.TransportationServiceProvider, error) {
 	tsp := models.TransportationServiceProvider{
 		StandardCarrierAlphaCode: SCAC,
-		Name: name}
+		Name: &name}
 
 	_, err := db.ValidateAndSave(&tsp)
 	if err != nil {

--- a/pkg/testdatagen/scenario/rateengine.go
+++ b/pkg/testdatagen/scenario/rateengine.go
@@ -59,9 +59,10 @@ func RunRateEngineScenario1(db *pop.Connection) error {
 		return err
 	}
 
+	name := "Standard Moving"
 	tsp := models.TransportationServiceProvider{
 		StandardCarrierAlphaCode: "STDM",
-		Name: "Standard Moving",
+		Name: &name,
 	}
 	if err := save(db, &tsp); err != nil {
 		return err
@@ -210,9 +211,10 @@ func RunRateEngineScenario2(db *pop.Connection) error {
 		return err
 	}
 
+	name := "Standard Moving"
 	tsp := models.TransportationServiceProvider{
 		StandardCarrierAlphaCode: "STDM",
-		Name: "Standard Moving",
+		Name: &name,
 	}
 	if err := save(db, &tsp); err != nil {
 		return err


### PR DESCRIPTION
## Description

SCACs imported via migration don't have names and names are a required field on TSPs. As a result, our testdatagen script will fail when trying to create shipments with offers because it needs to query for TSPs and a bunch of our TSPs are missing a name field.

Refer to slack:
https://defensedigitalservice.slack.com/archives/G8P7UD05U/p1525203128000646
https://defensedigitalservice.slack.com/archives/G8P7UD05U/p1525203523000612

We're fixing by making name a pointer field on TSP model rather than string. In the future, we'll need to add names to TSPs.

## Code Review Verification Steps

* [ ] All tests pass.
* [ ] Request review from a member of a different team.
* [ ] (TRIAL) Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/157231419) for this change
