### PR TITLE
delete all uploads and documents

### DIFF
--- a/migrations/20180427215024_add_service_member_id_to_documents.up.fizz
+++ b/migrations/20180427215024_add_service_member_id_to_documents.up.fizz
@@ -1,3 +1,5 @@
+raw("delete from uploads;")
+raw("delete from documents;")
 drop_foreign_key("documents", "move_id", {"if_exists": true})
 drop_column("documents", "move_id")
 add_column("documents", "service_member_id", "uuid", {})


### PR DESCRIPTION
## Description

documents are now associated to service members. There is no easy way to make sure documents in staging have service members so deleting them all.

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Code Review Verification Steps

* [ ] All tests pass.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/blob/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* [ ] There are no [aXe](https://www.deque.com/products/aXe/) warnings for UI.
* [ ] This works in IE.
* [ ] Any new third party client side dependencies (e.g., login.gov, google analytics, CDN libraries, etc.) have been communicated to @willowbl00.
* [ ] Request review from a member of a different team.
* [ ] (TRIAL) Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](tbd) for this change
* [this article](tbd) explains more about the approach used.

## Screenshots

If this PR makes visible UI changes, an image of the finished UI can help reviewers and casual
observers understand the context of the changes. A before image is optional and
can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow instead of using multiple images. You may want to use GIPHY CAPTURE for this! 📸

_Please frame screenshots to show enough useful context but also highlight the affected regions._
