### PR TITLE
Updating test make target to pass in needed environment variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,11 +107,15 @@ server_test: server_deps server_generate db_dev_run db_test_reset
 	# Don't run tests in /cmd or /pkg/gen & pass `-short` to exclude long running tests
 	# Use -test.parallel 1 to test packages serially and avoid database collisions
 	# Disable test caching with `-count 1` - caching was masking local test failures
-	go test -p 1 -count 1 -short $$(go list ./... | grep -v \\/pkg\\/gen\\/ | grep -v \\/cmd\\/)
+	# Database name comes from the env_vars, so set that before running tests.
+	DB_NAME=test_db \
+		go test -p 1 -count 1 -short $$(go list ./... | grep -v \\/pkg\\/gen\\/ | grep -v \\/cmd\\/)
 
 server_test_all: server_deps server_generate db_dev_run db_test_reset
-	# Like server_test but
-	go test -p 1 -count 1 $$(go list ./... | grep -v \\/pkg\\/gen\\/ | grep -v \\/cmd\\/)
+	# Like server_test but runs extended tests that may hit external services.
+	# Database name comes from the env_vars, so set that before running tests.
+	DB_NAME=test_db \
+		go test -p 1 -count 1 $$(go list ./... | grep -v \\/pkg\\/gen\\/ | grep -v \\/cmd\\/)
 
 server_test_coverage: server_deps server_generate db_dev_run db_test_reset
 	# Don't run tests in /cmd or /pkg/gen

--- a/Makefile
+++ b/Makefile
@@ -107,15 +107,11 @@ server_test: server_deps server_generate db_dev_run db_test_reset
 	# Don't run tests in /cmd or /pkg/gen & pass `-short` to exclude long running tests
 	# Use -test.parallel 1 to test packages serially and avoid database collisions
 	# Disable test caching with `-count 1` - caching was masking local test failures
-	# Database name comes from the env_vars, so set that before running tests.
-	DB_NAME=test_db \
-		go test -p 1 -count 1 -short $$(go list ./... | grep -v \\/pkg\\/gen\\/ | grep -v \\/cmd\\/)
+	go test -p 1 -count 1 -short $$(go list ./... | grep -v \\/pkg\\/gen\\/ | grep -v \\/cmd\\/)
 
 server_test_all: server_deps server_generate db_dev_run db_test_reset
 	# Like server_test but runs extended tests that may hit external services.
-	# Database name comes from the env_vars, so set that before running tests.
-	DB_NAME=test_db \
-		go test -p 1 -count 1 $$(go list ./... | grep -v \\/pkg\\/gen\\/ | grep -v \\/cmd\\/)
+	go test -p 1 -count 1 $$(go list ./... | grep -v \\/pkg\\/gen\\/ | grep -v \\/cmd\\/)
 
 server_test_coverage: server_deps server_generate db_dev_run db_test_reset
 	# Don't run tests in /cmd or /pkg/gen

--- a/config/database.yml
+++ b/config/database.yml
@@ -8,7 +8,10 @@ development:
 
 test:
   dialect: "postgres"
-  database: {{ env "DB_NAME" }}
+  # Leave the test database name hardcoded, since we run tests in the same
+  # environment as development, and it's extra confusing to have to swap env
+  # variables before running tests.
+  database: "test_db"
   host: {{ env "DB_HOST" }}
   port: {{ env "DB_PORT" }}
   user: {{ env "DB_USER" }}


### PR DESCRIPTION
## Description

With the Secure Migrations tool, the database credentials have largely been moved to environment variables. There are some places where they aren't being set correctly, an this can cause problems with the application trying to read the wrong database.

This fixes an issue where the tests were trying to read from the `dev-db` database, if your local environment specified that (which it should, since that's what's in `.envrc`)

## Reviewer Notes

* Make sure you can run `make server_test`

## Code Review Verification Steps

* [ ] All tests pass.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/blob/master/docs/backend.md#logging)
* [ ] Request review from a member of a different team.
* [ ] (TRIAL) Have the Pivotal acceptance criteria been met for this change?