### PR TITLE
Rek double click row

### DIFF
--- a/src/scenes/Office/QueueTable.jsx
+++ b/src/scenes/Office/QueueTable.jsx
@@ -80,6 +80,9 @@ export default class QueueTable extends Component {
             onFetchData={this.fetchData} // Request new data when things change
             pageSize={this.state.data.length}
             className="-striped -highlight"
+            getTrProps={(state, rowInfo, column, instance) => ({
+              onDoubleClick: e => alert('A row was clicked!'),
+            })}
           />
         </div>
       </div>

--- a/src/scenes/Office/QueueTable.jsx
+++ b/src/scenes/Office/QueueTable.jsx
@@ -1,9 +1,10 @@
 import React, { Component } from 'react';
+import { withRouter } from 'react-router';
 import ReactTable from 'react-table';
 import 'react-table/react-table.css';
 import { RetrieveMovesForOffice } from './api.js';
 
-export default class QueueTable extends Component {
+class QueueTable extends Component {
   constructor() {
     super();
     this.state = {
@@ -80,8 +81,9 @@ export default class QueueTable extends Component {
             onFetchData={this.fetchData} // Request new data when things change
             pageSize={this.state.data.length}
             className="-striped -highlight"
-            getTrProps={(state, rowInfo, column, instance) => ({
-              onDoubleClick: e => alert('A row was clicked!'),
+            getTrProps={(state, rowInfo) => ({
+              onDoubleClick: e =>
+                this.props.history.push(`new/moves/${rowInfo.original.id}}`),
             })}
           />
         </div>
@@ -89,3 +91,5 @@ export default class QueueTable extends Component {
     );
   }
 }
+
+export default withRouter(QueueTable);


### PR DESCRIPTION
## Description

This allows a user to double click on a queue table row to be taken to the details page for that move.

## Reviewer Notes

Is push the right way to do?

## Code Review Verification Steps

* [x] All tests pass.
* [x] There are no [aXe](https://www.deque.com/products/aXe/) warnings for UI.
* [x] This works in IE.
* [x] Request review from a member of a different team.
* [x] (TRIAL) Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/157340520) for this change

## Screenshots
![doubleclick](https://user-images.githubusercontent.com/7401870/39786963-de801ad6-52d7-11e8-8fe2-656d2ef2ed1a.gif)
