### PR TITLE
ELS swagger errors [delivers #157103338]

### DIFF
--- a/src/scenes/Feedback/index.jsx
+++ b/src/scenes/Feedback/index.jsx
@@ -1,3 +1,4 @@
+import { get } from 'lodash';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
@@ -53,11 +54,10 @@ Feedback.propTypes = {
 };
 
 function mapStateToProps(state) {
-  const props = { ...state.feedback, schema: {} };
-  if (state.swagger.spec) {
-    props.schema = state.swagger.spec.definitions.CreateIssuePayload;
-  }
-  return props;
+  return {
+    ...state.feedback,
+    schema: get(state, 'swagger.spec.definitions.CreateIssuePayload', {}),
+  };
 }
 
 function mapDispatchToProps(dispatch) {

--- a/src/scenes/Moves/Ppm/DateAndLocation.jsx
+++ b/src/scenes/Moves/Ppm/DateAndLocation.jsx
@@ -88,7 +88,11 @@ DateAndLocation.propTypes = {
 
 function mapStateToProps(state) {
   const props = {
-    schema: {},
+    schema: get(
+      state,
+      'swagger.spec.definitions.UpdatePersonallyProcuredMovePayload',
+      {},
+    ),
     ...state.ppm,
     formData: state.form[formName],
     enableReinitialize: true,
@@ -104,10 +108,6 @@ function mapStateToProps(state) {
           pickup_zip: defaultPickupZip,
         }
       : null;
-  if (state.swagger.spec) {
-    props.schema =
-      state.swagger.spec.definitions.UpdatePersonallyProcuredMovePayload;
-  }
   return props;
 }
 function mapDispatchToProps(dispatch) {

--- a/src/scenes/Orders/Orders.jsx
+++ b/src/scenes/Orders/Orders.jsx
@@ -1,3 +1,4 @@
+import { get } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
@@ -179,27 +180,28 @@ function mapDispatchToProps(dispatch) {
   );
 }
 function mapStateToProps(state) {
-  const currentServiceMember = state.loggedInUser.loggedInUser
-    ? state.loggedInUser.loggedInUser.service_member
-    : null;
-  const affiliation = currentServiceMember
-    ? currentServiceMember.affiliation
-    : null;
   const error = state.loggedInUser.error || state.orders.error;
   const hasSubmitSuccess =
     state.loggedInUser.hasSubmitSuccess || state.orders.hasSubmitSuccess;
   const props = {
-    currentServiceMember,
-    affiliation,
-    schema: {},
+    currentServiceMember: get(
+      state,
+      'loggedInUser.loggedInUser.service_member',
+    ),
+    affiliation: get(
+      state,
+      'loggedInUser.loggedInUser.service_member.affiliation',
+    ),
+    schema: get(
+      state,
+      'swagger.spec.definitions.CreateUpdateOrdersPayload',
+      {},
+    ),
     formData: state.form[formName],
     currentOrders: state.orders.currentOrders,
     error,
     hasSubmitSuccess,
   };
-  if (state.swagger.spec) {
-    props.schema = state.swagger.spec.definitions.CreateUpdateOrdersPayload;
-  }
   return props;
 }
 export default connect(mapStateToProps, mapDispatchToProps)(Orders);

--- a/src/scenes/Review/Review.jsx
+++ b/src/scenes/Review/Review.jsx
@@ -340,16 +340,12 @@ function mapDispatchToProps(dispatch) {
 }
 
 function mapStateToProps(state) {
-  const props = {
+  return {
     ...state.ppm,
     ...state.loggedInUser,
     currentBackupContacts: state.serviceMember.currentBackupContacts,
     currentOrders: state.orders.currentOrders,
-    schemaRank: {},
+    schemaRank: get(state, 'swagger.spec.definitions.ServiceMemberRank', {}),
   };
-  if (state.swagger.spec) {
-    props.schemaRank = state.swagger.spec.definitions.ServiceMemberRank;
-  }
-  return props;
 }
 export default connect(mapStateToProps, mapDispatchToProps)(Review);

--- a/src/scenes/ServiceMembers/BackupContact.jsx
+++ b/src/scenes/ServiceMembers/BackupContact.jsx
@@ -1,4 +1,4 @@
-import { pick } from 'lodash';
+import { get, pick } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
@@ -250,20 +250,19 @@ function mapDispatchToProps(dispatch) {
   );
 }
 function mapStateToProps(state) {
-  const props = {
+  return {
     currentBackupContacts: state.serviceMember.currentBackupContacts,
     hasSubmitSuccess:
       state.serviceMember.createBackupContactSuccess ||
       state.serviceMember.updateBackupContactSuccess,
     error: state.serviceMember.error,
     loggedInUser: state.loggedInUser.loggedInUser,
-    schema: {},
+    schema: get(
+      state,
+      'swagger.spec.definitions.CreateServiceMemberBackupContactPayload',
+      {},
+    ),
     formData: state.form[formName],
   };
-  if (state.swagger.spec) {
-    props.schema =
-      state.swagger.spec.definitions.CreateServiceMemberBackupContactPayload;
-  }
-  return props;
 }
 export default connect(mapStateToProps, mapDispatchToProps)(BackupContact);

--- a/src/scenes/ServiceMembers/BackupMailingAddress.jsx
+++ b/src/scenes/ServiceMembers/BackupMailingAddress.jsx
@@ -1,4 +1,4 @@
-import { pick } from 'lodash';
+import { get, pick } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
@@ -97,15 +97,15 @@ function mapDispatchToProps(dispatch) {
   );
 }
 function mapStateToProps(state) {
-  const props = {
-    schema: {},
+  return {
+    schema: get(
+      state,
+      'swagger.spec.definitions.CreateServiceMemberPayload',
+      {},
+    ),
     formData: state.form[formName],
     ...state.serviceMember,
   };
-  if (state.swagger.spec) {
-    props.schema = state.swagger.spec.definitions.CreateServiceMemberPayload;
-  }
-  return props;
 }
 export default connect(mapStateToProps, mapDispatchToProps)(
   BackupMailingAddress,

--- a/src/scenes/ServiceMembers/ContactInfo.jsx
+++ b/src/scenes/ServiceMembers/ContactInfo.jsx
@@ -1,4 +1,4 @@
-import { pick } from 'lodash';
+import { get, pick } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
@@ -115,15 +115,15 @@ function mapDispatchToProps(dispatch) {
   );
 }
 function mapStateToProps(state) {
-  const props = {
+  return {
     userEmail: state.user.email,
-    schema: {},
+    schema: get(
+      state,
+      'swagger.spec.definitions.CreateServiceMemberPayload',
+      {},
+    ),
     formData: state.form[formName],
     ...state.serviceMember,
   };
-  if (state.swagger.spec) {
-    props.schema = state.swagger.spec.definitions.CreateServiceMemberPayload;
-  }
-  return props;
 }
 export default connect(mapStateToProps, mapDispatchToProps)(ContactInfo);

--- a/src/scenes/ServiceMembers/DodInfo.jsx
+++ b/src/scenes/ServiceMembers/DodInfo.jsx
@@ -1,4 +1,4 @@
-import { pick } from 'lodash';
+import { get, pick } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
@@ -95,13 +95,14 @@ function mapDispatchToProps(dispatch) {
 }
 function mapStateToProps(state) {
   const props = {
-    schema: {},
+    schema: get(
+      state,
+      'swagger.spec.definitions.CreateServiceMemberPayload',
+      {},
+    ),
     formData: state.form[formName],
     ...state.serviceMember,
   };
-  if (state.swagger.spec) {
-    props.schema = state.swagger.spec.definitions.CreateServiceMemberPayload;
-  }
   return props;
 }
 export default connect(mapStateToProps, mapDispatchToProps)(DodInfo);

--- a/src/scenes/ServiceMembers/Name.jsx
+++ b/src/scenes/ServiceMembers/Name.jsx
@@ -1,4 +1,4 @@
-import { pick } from 'lodash';
+import { get, pick } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
@@ -83,14 +83,14 @@ function mapDispatchToProps(dispatch) {
   );
 }
 function mapStateToProps(state) {
-  const props = {
-    schema: {},
+  return {
+    schema: get(
+      state,
+      'swagger.spec.definitions.CreateServiceMemberPayload',
+      {},
+    ),
     formData: state.form[formName],
     ...state.serviceMember,
   };
-  if (state.swagger.spec) {
-    props.schema = state.swagger.spec.definitions.CreateServiceMemberPayload;
-  }
-  return props;
 }
 export default connect(mapStateToProps, mapDispatchToProps)(Name);

--- a/src/scenes/ServiceMembers/ResidentialAddress.jsx
+++ b/src/scenes/ServiceMembers/ResidentialAddress.jsx
@@ -1,4 +1,4 @@
-import { pick } from 'lodash';
+import { get, pick } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
@@ -95,14 +95,14 @@ function mapDispatchToProps(dispatch) {
   );
 }
 function mapStateToProps(state) {
-  const props = {
-    schema: {},
+  return {
+    schema: get(
+      state,
+      'swagger.spec.definitions.CreateServiceMemberPayload',
+      {},
+    ),
     formData: state.form[formName],
     ...state.serviceMember,
   };
-  if (state.swagger.spec) {
-    props.schema = state.swagger.spec.definitions.CreateServiceMemberPayload;
-  }
-  return props;
 }
 export default connect(mapStateToProps, mapDispatchToProps)(ResidentialAddress);


### PR DESCRIPTION
## Description

using lodash `get` to extract swagger schema more safely

## Reviewer Notes

This prevents an empty page, but the UI still doesn't always clearly indicate that the server is down.
(In some cases, you will have a page missing the form inputs). Would love suggestions for how to handle that? Perhaps if schema is empty, we should show an alert. (Though this would result in flicker of alert until props are resolved)

## Code Review Verification Steps

* [ ] All tests pass.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/blob/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* [ ] Any migrations/schema changes also update the diagram in docs/schema/dp3.sqs
* [ ] There are no [aXe](https://www.deque.com/products/aXe/) warnings for UI.
* [ ] This works in IE.
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @willowbl00
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Request review from a member of a different team.
* [ ] (TRIAL) Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](tbd) for this change
* [this article](tbd) explains more about the approach used.

## Screenshots

If this PR makes visible UI changes, an image of the finished UI can help reviewers and casual
observers understand the context of the changes. A before image is optional and
can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow instead of using multiple images. You may want to use GIPHY CAPTURE for this! 📸

_Please frame screenshots to show enough useful context but also highlight the affected regions._
