### PR TITLE
Els ppm screen pickup delivery 2 [delivers #157008498]

### DIFF
--- a/src/scenes/Moves/Ppm/DateAndLocation.css
+++ b/src/scenes/Moves/Ppm/DateAndLocation.css
@@ -1,0 +1,4 @@
+label.inline_radio {
+  margin-top: 1px;
+  margin-bottom: 1px;
+}

--- a/src/scenes/Moves/Ppm/DateAndLocation.jsx
+++ b/src/scenes/Moves/Ppm/DateAndLocation.jsx
@@ -13,6 +13,8 @@ import {
 import WizardPage from 'shared/WizardPage';
 import YesNoBoolean from 'shared/Inputs/YesNoBoolean';
 import { loadPpm, createOrUpdatePpm } from './ducks';
+import './DateAndLocation.css';
+
 const NULL_ZIP = ''; //HACK: until we can figure out how to unset zip
 const formName = 'ppp_date_and_location';
 const subsetOfFields = [
@@ -53,7 +55,6 @@ export class DateAndLocation extends React.Component {
   }
   handleSubmit = () => {
     const { createOrUpdatePpm, dirty } = this.props;
-    debugger;
     if (dirty) {
       const moveId = this.props.match.params.moveId;
       const pendingValues = Object.assign({}, this.props.formData.values);
@@ -127,9 +128,8 @@ export class DateAndLocation extends React.Component {
           />
           {this.state.showTempStorage && (
             <Fragment>
-              <p>How many days do you plan to put your stuff in storage?</p>
-              <p className="explanatory">You can choose up to 90 days.</p>
               {renderField('days_in_storage', fields, '')}
+              <p>You can choose up to 90 days.</p>
             </Fragment>
           )}
         </form>

--- a/src/scenes/Moves/Ppm/DateAndLocation.jsx
+++ b/src/scenes/Moves/Ppm/DateAndLocation.jsx
@@ -149,7 +149,11 @@ DateAndLocation.propTypes = {
 
 function mapStateToProps(state) {
   const props = {
-    schema: {},
+    schema: get(
+      state,
+      'swagger.spec.definitions.UpdatePersonallyProcuredMovePayload',
+      {},
+    ),
     ...state.ppm,
     formData: state.form[formName],
     enableReinitialize: true,
@@ -165,10 +169,6 @@ function mapStateToProps(state) {
           pickup_zip: defaultPickupZip,
         }
       : null;
-  if (state.swagger.spec) {
-    props.schema =
-      state.swagger.spec.definitions.UpdatePersonallyProcuredMovePayload;
-  }
   return props;
 }
 function mapDispatchToProps(dispatch) {

--- a/src/scenes/Moves/Ppm/DateAndLocation.jsx
+++ b/src/scenes/Moves/Ppm/DateAndLocation.jsx
@@ -13,7 +13,7 @@ import {
 import WizardPage from 'shared/WizardPage';
 import YesNoBoolean from 'shared/Inputs/YesNoBoolean';
 import { loadPpm, createOrUpdatePpm } from './ducks';
-const NULL_ZIP = '00000'; //HACK: until we can figure out how to unset zip
+const NULL_ZIP = ''; //HACK: until we can figure out how to unset zip
 const formName = 'ppp_date_and_location';
 const subsetOfFields = [
   'planned_move_date',
@@ -36,14 +36,14 @@ export class DateAndLocation extends React.Component {
       result.showTempStorage = true;
     return result;
   }
-  setShowAdditionalPickup = value => {
-    this.setState({ showAdditionalPickup: value }, () => {
-      if (!value) this.props.change('additional_pickup_zip', NULL_ZIP);
+  setShowAdditionalPickup = show => {
+    this.setState({ showAdditionalPickup: show }, () => {
+      if (!show) this.props.change('additional_pickup_zip', NULL_ZIP);
     });
   };
-  setShowTempStorage = value => {
-    this.setState({ showTempStorage: value }, () => {
-      if (!value) this.props.change('days_in_storage', '0');
+  setShowTempStorage = show => {
+    this.setState({ showTempStorage: show }, () => {
+      if (!show) this.props.change('days_in_storage', '0');
     });
   };
   componentDidMount() {
@@ -53,7 +53,7 @@ export class DateAndLocation extends React.Component {
   }
   handleSubmit = () => {
     const { createOrUpdatePpm, dirty } = this.props;
-
+    debugger;
     if (dirty) {
       const moveId = this.props.match.params.moveId;
       const pendingValues = Object.assign({}, this.props.formData.values);

--- a/src/scenes/Moves/Ppm/DateAndLocation.jsx
+++ b/src/scenes/Moves/Ppm/DateAndLocation.jsx
@@ -1,10 +1,9 @@
 import { pick, get } from 'lodash';
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { Fragment } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { reduxForm } from 'redux-form';
-
 import {
   renderField,
   recursivelyAnnotateRequiredFields,
@@ -12,15 +11,35 @@ import {
   addUiSchemaRequiredFields,
 } from 'shared/JsonSchemaForm';
 import WizardPage from 'shared/WizardPage';
-
+import YesNoBoolean from 'shared/Inputs/YesNoBoolean';
 import { loadPpm, createOrUpdatePpm } from './ducks';
 
 const formName = 'ppp_date_and_location';
 const uiSchema = {
   requiredFields: ['planned_move_date', 'pickup_zip', 'destination_zip'],
 };
-const subsetOfFields = ['planned_move_date', 'pickup_zip', 'destination_zip'];
+const subsetOfFields = [
+  'planned_move_date',
+  'pickup_zip',
+  'destination_zip',
+  'additional_pickup_zip',
+  'days_in_storage',
+];
+
 export class DateAndLocation extends React.Component {
+  state = { showAdditionalPickup: false, showTempStorage: false };
+  // static getDerivedStateFromProps(nextProps, prevState) {
+  //   const result = {};
+  //   if (nextProps.additional_pickup_zip) result.showAdditionalPickup = true;
+  //   if (nextProps.days_in_storage > 0) result.showTempStorage = true;
+  //   return result;
+  // }
+  setShowAdditionalPickup = value => {
+    this.setState({ showAdditionalPickup: value });
+  };
+  setShowTempStorage = value => {
+    this.setState({ showTempStorage: value });
+  };
   componentDidMount() {
     const moveId = this.props.match.params.moveId;
     this.props.loadPpm(moveId);
@@ -44,7 +63,6 @@ export class DateAndLocation extends React.Component {
       hasSubmitSuccess,
       error,
     } = this.props;
-
     addUiSchemaRequiredFields(schema, uiSchema);
     recursivelyAnnotateRequiredFields(schema);
     const fields = schema.properties || {};
@@ -65,12 +83,38 @@ export class DateAndLocation extends React.Component {
           {renderField('planned_move_date', fields, '')}
           <h3>Pickup Location</h3>
           {renderField('pickup_zip', fields, '')}
+          <p>Do you have stuff at another pickup location?</p>
+          <YesNoBoolean
+            value={this.state.showAdditionalPickup}
+            onChange={this.setShowAdditionalPickup}
+          />
+          {this.state.showAdditionalPickup && (
+            <Fragment>
+              {renderField('additional_pickup_zip', fields, '')}
+              <p>Making additional stops may decrease your PPM incentive.</p>
+            </Fragment>
+          )}
           <h3>Destination Location</h3>
           <p>
             Enter the ZIP for your new home if you know it, or for destination
             duty station if you don't
           </p>
           {renderField('destination_zip', fields, '')}
+          <p>
+            Are you going to put your stuff in temporary storage before moving
+            into your new home?
+          </p>
+          <YesNoBoolean
+            value={this.state.showTempStorage}
+            onChange={this.setShowTempStorage}
+          />
+          {this.state.showTempStorage && (
+            <Fragment>
+              <p>How many days do you plan to put your stuff in storage?</p>
+              <p className="explanatory">You can choose up to 90 days.</p>
+              {renderField('days_in_storage', fields, '')}
+            </Fragment>
+          )}
         </form>
       </WizardPage>
     );
@@ -121,3 +165,31 @@ const DateAndLocationForm = reduxForm({
 export default connect(mapStateToProps, mapDispatchToProps)(
   DateAndLocationForm,
 );
+
+/*
+          <p>
+            Are you going to put your stuff in temporary storage before moving
+            into your new home?
+          </p>
+          <label>
+            <input
+              type="radio"
+              checked={this.state.showTempStorage}
+              onChange={this.setShowTempStorage}
+            />Yes
+          </label>
+          <label>
+            <input
+              type="radio"
+              checked={!this.state.showTempStorage}
+              onChange={this.setShowTempStorage}
+            />No
+          </label>{' '}
+          {this.state.showTempStorage && (
+            <Fragment>
+              <p>How many days do you plan to put your stuff in storage?</p>
+              <p className="explanatory">You can choose up to 90 days.</p>
+              {renderField('days_in_storage', fields, '')}
+            </Fragment>
+          )}
+*/

--- a/src/scenes/Orders/Orders.css
+++ b/src/scenes/Orders/Orders.css
@@ -6,12 +6,3 @@ form.orders_info legend {
   font-size: 1.7rem;
   font-weight: 400;
 }
-
-.inline_radio {
-  margin-left: 4px;
-  display: inline-block;
-}
-
-#no_label {
-  margin-left: 2em;
-}

--- a/src/scenes/Orders/Orders.jsx
+++ b/src/scenes/Orders/Orders.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React, { Component, Fragment } from 'react';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 
@@ -9,52 +9,10 @@ import { createOrders, updateOrders, showCurrentOrders } from './ducks';
 import { loadServiceMember } from 'scenes/ServiceMembers/ducks';
 import { reduxifyWizardForm } from 'shared/WizardPage/Form';
 import DutyStationSearchBox from 'scenes/ServiceMembers/DutyStationSearchBox';
-
+import YesNoBoolean from 'shared/Inputs/YesNoBoolean';
 import { SwaggerField } from 'shared/JsonSchemaForm/JsonSchemaField';
 
 import './Orders.css';
-
-const YesNoBoolean = props => {
-  const {
-    input: { value: rawValue, onChange },
-  } = props;
-  let value = rawValue;
-  const yesChecked = value === true;
-  const noChecked = value === false;
-
-  const localOnChange = event => {
-    if (event.target.id === 'yes') {
-      onChange(true);
-    } else {
-      onChange(false);
-    }
-  };
-
-  return (
-    <Fragment>
-      <input
-        id="yes"
-        className="inline_radio"
-        type="radio"
-        onChange={localOnChange}
-        checked={yesChecked}
-      />
-      <label className="inline_radio" htmlFor="yes">
-        Yes
-      </label>
-      <input
-        id="no"
-        className="inline_radio"
-        type="radio"
-        onChange={localOnChange}
-        checked={noChecked}
-      />
-      <label id="no_label" className="inline_radio" htmlFor="no">
-        No
-      </label>
-    </Fragment>
-  );
-};
 
 const validateOrdersForm = (values, form) => {
   let errors = {};

--- a/src/shared/Inputs/YesNoBoolean.css
+++ b/src/shared/Inputs/YesNoBoolean.css
@@ -1,0 +1,5 @@
+.inline_radio {
+  margin-left: 4px;
+  display: inline-block;
+  margin-right: 10px;
+}

--- a/src/shared/Inputs/YesNoBoolean.jsx
+++ b/src/shared/Inputs/YesNoBoolean.jsx
@@ -1,0 +1,53 @@
+import PropTypes from 'prop-types';
+import React, { Fragment } from 'react';
+import { uniqueId } from 'lodash';
+import './YesNoBoolean.css';
+const YesNoBoolean = props => {
+  let value, onChange;
+  if (props.input) {
+    value = Boolean(props.input.value);
+    onChange = props.input.onChange;
+  } else {
+    value = Boolean(props.value);
+    onChange = props.onChange;
+  }
+  const yesId = uniqueId('yes_no_');
+  const noId = uniqueId('yes_no_');
+  const localOnChange = event => {
+    onChange(event.target.value === 'yes');
+  };
+
+  return (
+    <Fragment>
+      <input
+        className="inline_radio"
+        id={yesId}
+        type="radio"
+        value="yes"
+        onChange={localOnChange}
+        checked={value}
+      />
+      <label className="inline_radio" htmlFor={yesId}>
+        Yes
+      </label>
+      <input
+        className="inline_radio"
+        id={noId}
+        value="no"
+        type="radio"
+        onChange={localOnChange}
+        checked={!value}
+      />
+      <label className="inline_radio" htmlFor={noId}>
+        No
+      </label>
+    </Fragment>
+  );
+};
+YesNoBoolean.propTypes = {
+  input: PropTypes.shape({
+    value: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]).isRequired,
+    onChange: PropTypes.func.isRequired,
+  }),
+};
+export default YesNoBoolean;

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -116,6 +116,8 @@ definitions:
       days_in_storage:
         type: integer
         title: Days in Temporary Storage
+        minimum: 0
+        maximum: 90
         x-nullable: true
       weight_estimate:
         type: integer
@@ -159,6 +161,8 @@ definitions:
       days_in_storage:
         type: integer
         title: Days in Temporary Storage
+        minimum: 0
+        maximum: 90
         x-nullable: true
       weight_estimate:
         type: integer
@@ -202,6 +206,8 @@ definitions:
       days_in_storage:
         type: integer
         title: Days in Temporary Storage
+        minimum: 0
+        maximum: 90
         x-nullable: true
       weight_estimate:
         type: integer
@@ -249,6 +255,8 @@ definitions:
       days_in_storage:
         type: integer
         title: Days in Temporary Storage
+        minimum: 0
+        maximum: 90
         x-nullable: true
       weight_estimate:
         type: integer

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -115,7 +115,7 @@ definitions:
         x-nullable: true
       days_in_storage:
         type: integer
-        title: Days in Temporary Storage
+        title: How many days do you plan to put your stuff in storage?
         minimum: 0
         maximum: 90
         x-nullable: true
@@ -160,7 +160,7 @@ definitions:
         x-nullable: true
       days_in_storage:
         type: integer
-        title: Days in Temporary Storage
+        title: How many days do you plan to put your stuff in storage?
         minimum: 0
         maximum: 90
         x-nullable: true
@@ -205,7 +205,7 @@ definitions:
         x-nullable: true
       days_in_storage:
         type: integer
-        title: Days in Temporary Storage
+        title: How many days do you plan to put your stuff in storage?
         minimum: 0
         maximum: 90
         x-nullable: true
@@ -254,7 +254,7 @@ definitions:
         x-nullable: true
       days_in_storage:
         type: integer
-        title: Days in Temporary Storage
+        title: How many days do you plan to put your stuff in storage?
         minimum: 0
         maximum: 90
         x-nullable: true


### PR DESCRIPTION
## Description

added additional pickup zip and days in temp storage

## Reviewer Notes

Suggestions on spacing improvements are welcome. Also, when the additional_pickup_zip is set and saved, there is currently no way to unset it. That work is deferred to #157008301

## Code Review Verification Steps

* [ ] All tests pass.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/blob/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* [ ] Any migrations/schema changes also update the diagram in docs/schema/dp3.sqs
* [ ] There are no [aXe](https://www.deque.com/products/aXe/) warnings for UI.
* [ ] This works in IE.
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @willowbl00
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Request review from a member of a different team.
* [ ] (TRIAL) Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/157008498) for this change
* [this article](tbd) explains more about the approach used.

## Screenshots

![image](https://user-images.githubusercontent.com/3142631/39828839-74cdfa1e-538a-11e8-859c-3105f73d1c41.png)
