### PR TITLE
Rek add ppm estimate data

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This prototype was built by a [Defense Digital Service](https://www.dds.mil/) te
 <!-- toc -->
 
 * [Supported clients](#supported-clients)
+* [Client Network Dependencies](#client-network-dependencies)
 * [Development](#development)
   * [Git](#git)
   * [Project location](#project-location)
@@ -186,6 +187,15 @@ When creating new features, it is helpful to have sample data for the feature to
 * `bin/generate_test_data` will run binary and create a preconfigured set of test data. To determine the data scenario you'd like to use, check out scenarios in the `testdatagen` package. Each scenario contains a description of what data will be created when the scenario is run. Pass the scenario in as a flag to the generate-test-data function. A sample command: `./bin/generate-test-data -scenario=2`. If you'd like to further specify how the data should look, you can specify the number of awards for each TSP performance by use the flag `rounds` with one of three arguments: 'none', 'half', and 'full'. This will create the TSP performance records with either no rounds of awards completed, half a round, or a full round. It will default to none if not specified. To specify how many TSPs should be created, use the flag `numTSP`. It will default to 15 if not specified. A sample command: `./bin/generate-test-data -rounds=half -numTSP=6`. You can use the `numTSP` and `rounds` in conjunction, but you cannot use them with the pre-packaged scenarios.
 
 There is also a package (`/pkg/testdatagen`) that can be imported to create arbitrary test data. This could be used in tests, so as not to duplicate functionality.
+
+Currently, scenarios have the following numbers:
+
+* `-scenario=1` for Award Queue Scenario 1
+* `-scenario=2` for Award Queue Scenario 2
+* `-scenario=3` for Duty Station Scenario
+* `-scenario=4` for PPM Sit Estimate Scenario
+* `-scenario=5` for Rate Engine Scenario 1
+* `-scenario=6` for Rate Engine Scenario 2
 
 ### API / Swagger
 

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Currently, scenarios have the following numbers:
 * `-scenario=1` for Award Queue Scenario 1
 * `-scenario=2` for Award Queue Scenario 2
 * `-scenario=3` for Duty Station Scenario
-* `-scenario=4` for PPM Sit Estimate Scenario
+* `-scenario=4` for PPM or PPM SIT Estimate Scenario (can also use Rate Engine Scenarios for Estimates)
 * `-scenario=5` for Rate Engine Scenario 1
 * `-scenario=6` for Rate Engine Scenario 2
 

--- a/cmd/generate_test_data/main.go
+++ b/cmd/generate_test_data/main.go
@@ -16,7 +16,7 @@ func main() {
 	env := flag.String("env", "development", "The environment to run in, configures the database, presently.")
 	rounds := flag.String("rounds", "none", "If not using premade scenarios: Specify none (no awards), full (1 full round of awards), or half (partial round of awards)")
 	numTSP := flag.Int("numTSP", 15, "If not using premade scenarios: Specify the number of TSPs you'd like to create")
-	scenario := flag.Int("scenario", 0, "Specify which scenario you'd like to run. Current options: 1, 2.")
+	scenario := flag.Int("scenario", 0, "Specify which scenario you'd like to run. Current options: 1, 2, 3, 4, 5, 6.")
 	flag.Parse()
 
 	//DB connection
@@ -32,6 +32,12 @@ func main() {
 		tdgs.RunAwardQueueScenario2(db)
 	} else if *scenario == 3 {
 		tdgs.RunDutyStationScenario3(db)
+	} else if *scenario == 4 {
+		tdgs.RunPPMSITEstimateScenario1(db)
+	} else if *scenario == 5 {
+		tdgs.RunRateEngineScenario1(db)
+	} else if *scenario == 6 {
+		tdgs.RunRateEngineScenario2(db)
 	} else {
 		// Can this be less repetitive without being overly clever?
 		testdatagen.MakeTDLData(db)

--- a/pkg/testdatagen/scenario/estimate.go
+++ b/pkg/testdatagen/scenario/estimate.go
@@ -1,0 +1,112 @@
+package scenario
+
+import (
+	"github.com/gobuffalo/pop"
+	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/unit"
+)
+
+// RunPPMSITEstimateScenario1 runs... scenario 1.
+func RunPPMSITEstimateScenario1(db *pop.Connection) error {
+	originZip5_779 := models.Tariff400ngZip5RateArea{
+		Zip5:     "77901",
+		RateArea: "68",
+	}
+	if err := save(db, &originZip5_779); err != nil {
+		return err
+	}
+
+	destZip5_674 := models.Tariff400ngZip5RateArea{
+		Zip5:     "67401",
+		RateArea: "58",
+	}
+	if err := save(db, &destZip5_674); err != nil {
+		return err
+	}
+
+	originZip3_779 := models.Tariff400ngZip3{
+		Zip3:          "779",
+		RateArea:      "68",
+		BasepointCity: "Victoria",
+		State:         "TX",
+		ServiceArea:   748,
+		Region:        6,
+	}
+	if err := save(db, &originZip3_779); err != nil {
+		return err
+	}
+
+	destZip3_674 := models.Tariff400ngZip3{
+		Zip3:          "674",
+		Region:        5,
+		BasepointCity: "Salina",
+		State:         "KS",
+		RateArea:      "58",
+		ServiceArea:   320,
+	}
+	if err := save(db, &destZip3_674); err != nil {
+		return err
+	}
+
+	tsp := models.TransportationServiceProvider{
+		StandardCarrierAlphaCode: "STDM",
+	}
+	if err := save(db, &tsp); err != nil {
+		return err
+	}
+
+	tdl := models.TrafficDistributionList{
+		SourceRateArea:    "68",
+		DestinationRegion: "5",
+		CodeOfService:     "D",
+	}
+	if err := save(db, &tdl); err != nil {
+		return err
+	}
+
+	originServiceArea := models.Tariff400ngServiceArea{
+		Name:               "Victoria, TX",
+		ServiceArea:        748,
+		LinehaulFactor:     unit.Cents(39),
+		ServiceChargeCents: unit.Cents(350),
+		EffectiveDateLower: may15_2018,
+		EffectiveDateUpper: may15_2019,
+		SIT185ARateCents:   unit.Cents(1402),
+		SIT185BRateCents:   unit.Cents(53),
+		SITPDSchedule:      3,
+	}
+	if err := save(db, &originServiceArea); err != nil {
+		return err
+	}
+
+	destServiceArea := models.Tariff400ngServiceArea{
+		Name:               "Salina, KS",
+		ServiceArea:        320,
+		LinehaulFactor:     unit.Cents(43),
+		ServiceChargeCents: unit.Cents(350),
+		EffectiveDateLower: may15_2018,
+		EffectiveDateUpper: may15_2019,
+		SIT185ARateCents:   unit.Cents(1292),
+		SIT185BRateCents:   unit.Cents(51),
+		SITPDSchedule:      2,
+	}
+	if err := save(db, &destServiceArea); err != nil {
+		return err
+	}
+
+	band := 1
+	tspp := models.TransportationServiceProviderPerformance{
+		PerformancePeriodStart:          may15_2018,
+		PerformancePeriodEnd:            oct15_2018,
+		RateCycleStart:                  may15_2018,
+		RateCycleEnd:                    oct15_2018,
+		TrafficDistributionListID:       tdl.ID,
+		TransportationServiceProviderID: tsp.ID,
+		QualityBand:                     &band,
+		BestValueScore:                  90,
+		LinehaulRate:                    unit.NewDiscountRateFromPercent(50.5),
+		SITRate:                         unit.NewDiscountRateFromPercent(50),
+	}
+
+	return save(db, &tspp)
+}

--- a/pkg/testdatagen/scenario/rateengine.go
+++ b/pkg/testdatagen/scenario/rateengine.go
@@ -1,29 +1,10 @@
 package scenario
 
 import (
-	"time"
-
-	"github.com/pkg/errors"
-
 	"github.com/gobuffalo/pop"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/unit"
 )
-
-var may15_2018 = time.Date(2018, time.May, 15, 0, 0, 0, 0, time.UTC)
-var oct15_2018 = time.Date(2018, time.October, 15, 0, 0, 0, 0, time.UTC)
-var may15_2019 = time.Date(2019, time.May, 15, 0, 0, 0, 0, time.UTC)
-
-func save(db *pop.Connection, model interface{}) error {
-	verrs, err := db.ValidateAndSave(model)
-	if err != nil {
-		return errors.Wrap(err, "Errors encountered saving model")
-	}
-	if verrs.HasAny() {
-		return errors.Errorf("Validation errors encountered saving model: %v", verrs)
-	}
-	return nil
-}
 
 // RunRateEngineScenario1 runs... scenario 1.
 func RunRateEngineScenario1(db *pop.Connection) error {

--- a/pkg/testdatagen/scenario/shared.go
+++ b/pkg/testdatagen/scenario/shared.go
@@ -1,0 +1,24 @@
+package scenario
+
+import (
+	"time"
+
+	"github.com/pkg/errors"
+
+	"github.com/gobuffalo/pop"
+)
+
+var may15_2018 = time.Date(2018, time.May, 15, 0, 0, 0, 0, time.UTC)
+var oct15_2018 = time.Date(2018, time.October, 15, 0, 0, 0, 0, time.UTC)
+var may15_2019 = time.Date(2019, time.May, 15, 0, 0, 0, 0, time.UTC)
+
+func save(db *pop.Connection, model interface{}) error {
+	verrs, err := db.ValidateAndSave(model)
+	if err != nil {
+		return errors.Wrap(err, "Errors encountered saving model")
+	}
+	if verrs.HasAny() {
+		return errors.Errorf("Validation errors encountered saving model: %v", verrs)
+	}
+	return nil
+}

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -1362,13 +1362,13 @@ paths:
           type: integer
           required: true
         - in: query
-          name: destination_zip
+          name: origin_zip
           type: string
           format: zip
           pattern: '^(\d{5}([\-]\d{4})?)$'
           required: true
         - in: query
-          name: origin_zip
+          name: destination_zip
           type: string
           format: zip
           pattern: '^(\d{5}([\-]\d{4})?)$'


### PR DESCRIPTION
## Description

This PR makes scenarios for users to run for PPM and PPM SIT estimation
To run:
`make tools_build`
`./bin/generate-test-data -scenario=6` 
OR `./bin/generate-test-data -scenario=4`
Go to http://localhost:3000/internal/docs#/ppm/showPPMEstimate, login, use the following zip code/date combos:
1. ORIGIN: 77901, DESTINATION: 67401, DATE: 2018-05-25
1. ORIGIN: 94540, DESTINATION: 78626, DATE: 2018-06-18
The dates can be between May 15-Oct 16, 2018 (exclusive). Weight and days in SIT don't matter other than they'll give you a different calculation.

## Reviewer Notes
Do more explicit instructions need to be included in the readme? You still need to use specific zip codes/dates to get this to work.

## Code Review Verification Steps

* [x] All tests pass.
* [x] Request review from a member of a different team.
* [x] (TRIAL) Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/157439896) for this change
