### PR TITLE
Duty Station Cleanup

### DIFF
--- a/pkg/handlers/duty_stations.go
+++ b/pkg/handlers/duty_stations.go
@@ -27,13 +27,13 @@ type SearchDutyStationsHandler HandlerContext
 // Handle returns a list of stations based on the search query
 func (h SearchDutyStationsHandler) Handle(params stationop.SearchDutyStationsParams) middleware.Responder {
 	var stations models.DutyStations
-	var response middleware.Responder
 	var err error
 
-	stations, err = models.FindDutyStations(h.db, params.Search, params.Affiliation)
+	stations, err = models.FindDutyStations(h.db, params.Search)
 	if err != nil {
 		h.logger.Error("Finding duty stations", zap.Error(err))
-		response = stationop.NewSearchDutyStationsInternalServerError()
+		return stationop.NewSearchDutyStationsInternalServerError()
+
 	}
 
 	stationPayloads := make(internalmessages.DutyStationsPayload, len(stations))
@@ -41,7 +41,5 @@ func (h SearchDutyStationsHandler) Handle(params stationop.SearchDutyStationsPar
 		stationPayload := payloadForDutyStationModel(station)
 		stationPayloads[i] = stationPayload
 	}
-	response = stationop.NewSearchDutyStationsOK().WithPayload(stationPayloads)
-
-	return response
+	return stationop.NewSearchDutyStationsOK().WithPayload(stationPayloads)
 }

--- a/pkg/handlers/duty_stations_test.go
+++ b/pkg/handlers/duty_stations_test.go
@@ -46,7 +46,6 @@ func (suite *HandlerSuite) TestSearchDutyStationHandler() {
 	req := httptest.NewRequest("GET", "/duty_stations", nil)
 	newSearchParams := stationop.SearchDutyStationsParams{
 		HTTPRequest: req,
-		Affiliation: string(internalmessages.AffiliationARMY),
 		Search:      "first",
 	}
 

--- a/pkg/handlers/service_members.go
+++ b/pkg/handlers/service_members.go
@@ -2,7 +2,6 @@ package handlers
 
 import (
 	"github.com/go-openapi/runtime/middleware"
-	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 	"github.com/gobuffalo/uuid"
 	"github.com/gobuffalo/validate"
@@ -14,9 +13,10 @@ import (
 )
 
 func payloadForServiceMemberModel(user models.User, serviceMember models.ServiceMember) *internalmessages.ServiceMemberPayload {
-	var stationID *strfmt.UUID
+
+	var dutyStationPayload *internalmessages.DutyStationPayload
 	if serviceMember.DutyStation != nil {
-		stationID = fmtUUID(serviceMember.DutyStation.ID)
+		dutyStationPayload = payloadForDutyStationModel(*serviceMember.DutyStation)
 	}
 
 	serviceMemberPayload := internalmessages.ServiceMemberPayload{
@@ -41,7 +41,7 @@ func payloadForServiceMemberModel(user models.User, serviceMember models.Service
 		BackupMailingAddress:    payloadForAddressModel(serviceMember.BackupMailingAddress),
 		HasSocialSecurityNumber: fmtBool(serviceMember.SocialSecurityNumberID != nil),
 		IsProfileComplete:       fmtBool(serviceMember.IsProfileComplete()),
-		CurrentStationID:        stationID,
+		CurrentStation:          dutyStationPayload,
 	}
 	return &serviceMemberPayload
 }

--- a/pkg/models/duty_station.go
+++ b/pkg/models/duty_station.go
@@ -2,7 +2,6 @@ package models
 
 import (
 	"encoding/json"
-	"fmt"
 	"time"
 
 	"github.com/gobuffalo/pop"
@@ -74,8 +73,18 @@ func FindDutyStations(tx *pop.Connection, search string) (DutyStations, error) {
 	var stations DutyStations
 
 	// ILIKE does case-insensitive pattern matching, "%" matches any string
-	searchQuery := fmt.Sprintf("%%%s%%", search)
-	query := tx.Q().Eager().Where("name ILIKE $1", searchQuery)
+	// We build a query by inserting '%' between each letter in the search string.
+	// This allows matching substrings as well as abbreviations.
+	// It would probably be worth ordering the results by similarity to the search string, one day.
+	searchQuery := []rune("%")
+
+	for _, runeChar := range search {
+		searchQuery = append(searchQuery, runeChar)
+		searchQuery = append(searchQuery, '%')
+	}
+	queryString := string(searchQuery)
+
+	query := tx.Q().Eager().Where("name ILIKE $1", queryString)
 
 	if err := query.All(&stations); err != nil {
 		if errors.Cause(err).Error() != recordNotFoundErrorString {

--- a/pkg/models/duty_station.go
+++ b/pkg/models/duty_station.go
@@ -70,12 +70,12 @@ func FetchDutyStation(tx *pop.Connection, id uuid.UUID) (DutyStation, error) {
 }
 
 // FindDutyStations returns all duty stations matching a search query and military affiliation
-func FindDutyStations(tx *pop.Connection, search string, affiliation string) (DutyStations, error) {
+func FindDutyStations(tx *pop.Connection, search string) (DutyStations, error) {
 	var stations DutyStations
 
 	// ILIKE does case-insensitive pattern matching, "%" matches any string
 	searchQuery := fmt.Sprintf("%%%s%%", search)
-	query := tx.Q().Eager().Where("affiliation = $1 AND name ILIKE $2", affiliation, searchQuery)
+	query := tx.Q().Eager().Where("name ILIKE $1", searchQuery)
 
 	if err := query.All(&stations); err != nil {
 		if errors.Cause(err).Error() != recordNotFoundErrorString {

--- a/pkg/models/duty_station_test.go
+++ b/pkg/models/duty_station_test.go
@@ -30,7 +30,7 @@ func (suite *ModelSuite) TestFindDutyStations() {
 	}
 	suite.mustSave(&station2)
 
-	stations, err := models.FindDutyStations(suite.db, "first", string(internalmessages.AffiliationARMY))
+	stations, err := models.FindDutyStations(suite.db, "first")
 	if err != nil {
 		t.Errorf("Find duty stations error: %v", err)
 	}

--- a/src/scenes/Orders/Orders.jsx
+++ b/src/scenes/Orders/Orders.jsx
@@ -155,11 +155,7 @@ export class Orders extends Component {
           </legend>
           <Field name="has_dependents" component={YesNoBoolean} />
         </fieldset>
-        <Field
-          name="new_duty_station"
-          component={DutyStationSearchBox}
-          affiliation={this.props.affiliation}
-        />
+        <Field name="new_duty_station" component={DutyStationSearchBox} />
       </OrdersWizardForm>
     );
   }
@@ -182,15 +178,11 @@ function mapStateToProps(state) {
   const currentServiceMember = state.loggedInUser.loggedInUser
     ? state.loggedInUser.loggedInUser.service_member
     : null;
-  const affiliation = currentServiceMember
-    ? currentServiceMember.affiliation
-    : null;
   const error = state.loggedInUser.error || state.orders.error;
   const hasSubmitSuccess =
     state.loggedInUser.hasSubmitSuccess || state.orders.hasSubmitSuccess;
   const props = {
     currentServiceMember,
-    affiliation,
     schema: {},
     formData: state.form[formName],
     currentOrders: state.orders.currentOrders,

--- a/src/scenes/ServiceMembers/DutyStation.css
+++ b/src/scenes/ServiceMembers/DutyStation.css
@@ -1,17 +1,8 @@
-.station-description {
-  list-style-type: none;
-  padding-left: 20px;
+.duty-input-box {
+  margin-left: -10px;
 }
 
-.station-description li {
-  margin-left: 0;
-}
-
-.station-description li:first-child {
-  font-weight: bold;
-}
-
-div#react-select-2-listbox{
+div#react-select-2-listbox {
   height: 100%;
   max-height: 300px;
 }

--- a/src/scenes/ServiceMembers/DutyStation.jsx
+++ b/src/scenes/ServiceMembers/DutyStation.jsx
@@ -52,7 +52,7 @@ export class DutyStation extends Component {
     const pendingValues = this.props.formData.values;
     if (pendingValues) {
       this.props.updateServiceMember({
-        current_station: pendingValues.current_station,
+        current_station_id: pendingValues.current_station.id,
       });
     }
   };

--- a/src/scenes/ServiceMembers/DutyStation.jsx
+++ b/src/scenes/ServiceMembers/DutyStation.jsx
@@ -82,11 +82,7 @@ export class DutyStation extends Component {
         serverError={error}
       >
         <h1 className="sm-heading">Current Duty Station</h1>
-        <Field
-          name="current_station"
-          component={DutyStationSearchBox}
-          affiliation={this.props.affiliation}
-        />
+        <Field name="current_station" component={DutyStationSearchBox} />
       </DutyStationWizardForm>
     );
   }
@@ -109,11 +105,7 @@ function mapStateToProps(state) {
     currentServiceMember && currentServiceMember.current_station
       ? currentServiceMember.current_station
       : null;
-  const affiliation = currentServiceMember
-    ? currentServiceMember.affiliation
-    : null;
   const props = {
-    affiliation,
     formData: state.form[dutyStationFormName],
     existingStation: dutyStation,
     ...state.serviceMember,

--- a/src/scenes/ServiceMembers/DutyStationSearchBox.jsx
+++ b/src/scenes/ServiceMembers/DutyStationSearchBox.jsx
@@ -2,6 +2,7 @@ import { debounce, sortBy } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { Component, Fragment } from 'react';
 import AsyncSelect from 'react-select/lib/Async';
+import Alert from 'shared/Alert';
 import { components } from 'react-select';
 import Highlighter from 'react-highlight-words';
 
@@ -29,12 +30,8 @@ export class DutyStationSearchBox extends Component {
   }
 
   loadOptions(inputValue, callback) {
-    if (
-      this.props.affiliation &&
-      inputValue &&
-      inputValue.length >= minSearchLength
-    ) {
-      return SearchDutyStations(this.props.affiliation, inputValue)
+    if (inputValue && inputValue.length >= minSearchLength) {
+      return SearchDutyStations(inputValue)
         .then(item => {
           this.setState({
             error: null,
@@ -94,6 +91,13 @@ export class DutyStationSearchBox extends Component {
   render() {
     return (
       <Fragment>
+        {this.state.error && (
+          <div className="usa-width-one-whole error-message">
+            <Alert type="error" heading="An error occurred">
+              {this.state.error.message}
+            </Alert>
+          </div>
+        )}
         <label>Name of Duty Station</label>
         <AsyncSelect
           cacheOptions
@@ -121,7 +125,6 @@ export class DutyStationSearchBox extends Component {
   }
 }
 DutyStationSearchBox.propTypes = {
-  affiliation: PropTypes.string,
   onChange: PropTypes.func,
   existingStation: PropTypes.object,
 };

--- a/src/scenes/ServiceMembers/DutyStationSearchBox.jsx
+++ b/src/scenes/ServiceMembers/DutyStationSearchBox.jsx
@@ -20,13 +20,26 @@ export class DutyStationSearchBox extends Component {
 
     this.state = {
       inputValue: '',
+      initialValueSet: false,
     };
+
     this.loadOptions = this.loadOptions.bind(this);
     this.getDebouncedOptions = this.getDebouncedOptions.bind(this);
     this.debouncedLoadOptions = this.debouncedLoadOptions.bind(this);
     this.localOnChange = this.localOnChange.bind(this);
     this.onInputChange = this.onInputChange.bind(this);
     this.renderOption = this.renderOption.bind(this);
+  }
+
+  static getDerivedStateFromProps(nextProps, prevState) {
+    if (
+      prevState.inputValue === '' &&
+      nextProps.input.value &&
+      !prevState.initialValueSet
+    ) {
+      return { inputValue: nextProps.input.value.name, initialValueSet: true };
+    }
+    return null;
   }
 
   loadOptions(inputValue, callback) {
@@ -98,8 +111,9 @@ export class DutyStationSearchBox extends Component {
             </Alert>
           </div>
         )}
-        <label>Name of Duty Station</label>
+        <p>Name of Duty Station:</p>
         <AsyncSelect
+          className="duty-input-box"
           cacheOptions
           inputValue={this.state.inputValue}
           getOptionLabel={getOptionName}
@@ -111,14 +125,11 @@ export class DutyStationSearchBox extends Component {
           placeholder="Start typing a duty station..."
         />
         {this.props.input.value && (
-          <ul className="station-description">
-            <li>{this.props.input.value.name}</li>
-            <li>
-              {this.props.input.value.address.city},{' '}
-              {this.props.input.value.address.state}{' '}
-              {this.props.input.value.address.postal_code}
-            </li>
-          </ul>
+          <p>
+            {this.props.input.value.address.city},{' '}
+            {this.props.input.value.address.state}{' '}
+            {this.props.input.value.address.postal_code}
+          </p>
         )}
       </Fragment>
     );

--- a/src/scenes/ServiceMembers/api.js
+++ b/src/scenes/ServiceMembers/api.js
@@ -88,10 +88,9 @@ export async function UpdateBackupContactAPI(
   return response.body;
 }
 
-export async function SearchDutyStations(affiliation, query) {
+export async function SearchDutyStations(query) {
   const client = await getClient();
   const response = await client.apis.duty_stations.searchDutyStations({
-    affiliation: affiliation,
     search: query,
   });
   checkResponse(response, 'failed to query duty stations due to server error');

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -2175,11 +2175,6 @@ paths:
         - duty_stations
       parameters:
         - in: query
-          name: affiliation
-          required: true
-          type: string
-          enum: *AFFILIATION
-        - in: query
           name: search
           type: string
           format: string

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -408,11 +408,8 @@ definitions:
       email_is_preferred:
         type: boolean
         x-nullable: true
-      current_station_id:
-        type: string
-        format: uuid
-        example: c56a4180-65aa-42ec-a945-5fd21dec0538
-        x-nullable: true
+      current_station:
+        $ref: '#/definitions/DutyStationPayload'
       residential_address:
         $ref: '#/definitions/Address'
       backup_mailing_address:


### PR DESCRIPTION
## Description

This change addresses a number of issues with the duty station search box

* Fixes client and server to be talking the same format so it is saved on save
* Removes the filter on affiliation from search
* Makes the search fuzzier, allowing searching by acronyms
* Fixes the styling to match the wireframes

## Reviewer Notes

Just one main thing I've still go a question on: Should we be sending duty_station_id here or should we be sending the whole object up to the server and having it pull the ID out? The client and server were doing it differently.

## Code Review Verification Steps

* [ ] All tests pass.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/blob/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* [ ] Any migrations/schema changes also update the diagram in docs/schema/dp3.sqs
* [ ] There are no [aXe](https://www.deque.com/products/aXe/) warnings for UI.
* [ ] This works in IE.
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @willowbl00
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Request review from a member of a different team.
* [ ] (TRIAL) Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/157335755) for this change

## Screenshots

<img width="434" alt="screen shot 2018-05-09 at 2 04 15 pm" src="https://user-images.githubusercontent.com/55759/39839729-03e3fe72-5392-11e8-87d1-c1e7af77da35.png">
