### PR TITLE
Update Orders Type values and Orders screen title

### DIFF
--- a/src/scenes/Orders/Orders.jsx
+++ b/src/scenes/Orders/Orders.jsx
@@ -92,7 +92,7 @@ export class Orders extends Component {
         initialValues={initialValues}
         additionalParams={{ serviceMemberId }}
       >
-        <h1 className="sm-heading">Your Orders</h1>
+        <h1 className="sm-heading">Tell Us About Your Move Orders</h1>
         <SwaggerField
           fieldName="orders_type"
           swagger={this.props.schema}

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -1124,21 +1124,23 @@ definitions:
     type: string
     title: Orders type
     enum:
-      - accession
-      - brac
-      - operational
-      - rotational
-      - separation
-      - training
-      - unit-move
+      - PERMANENT_CHANGE_OF_STATION
+      - SEPARATION
+      - RETIREMENT
+      - LOCAL_MOVE
+      - TEMPORARY_DUTY
+      - DEPENDENT_TRAVEL
+      - BLUEBARK
+      - VARIOUS
     x-display-value:
-      accession: accession
-      brac: brac
-      operational: operational
-      rotational: rotational
-      separation: separation
-      training: training
-      unit-move: unit-move
+      PERMANENT_CHANGE_OF_STATION: Permanent Change Of Station
+      SEPARATION: Separation
+      RETIREMENT: Retirement
+      LOCAL_MOVE: Local Move
+      TEMPORARY_DUTY: Temporary Duty
+      DEPENDENT_TRAVEL: Dependent Travel
+      BLUEBARK: Bluebark
+      VARIOUS: Various
   OrdersPayload:
     type: object
     properties:


### PR DESCRIPTION
## Description

This PR adds the orders type values to what's in the wireframe for the Orders Screen. It also updates the title to match the wireframe.

## Code Review Verification Steps

* [ ] All tests pass.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/blob/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* [ ] Any migrations/schema changes also update the diagram in docs/schema/dp3.sqs
* [ ] There are no [aXe](https://www.deque.com/products/aXe/) warnings for UI.
* [ ] This works in IE.
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @willowbl00
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Request review from a member of a different team.
* [ ] (TRIAL) Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/157356624) for this change

## Screenshots
<img width="805" alt="screen shot 2018-05-10 at 1 45 33 pm" src="https://user-images.githubusercontent.com/8170735/39893410-749e907a-5458-11e8-86ec-dd8372d9cbe4.png">
