### PR TITLE
prepare to connect PPM slider to rate engine API endpoint [#157524795]

### DIFF
--- a/src/scenes/Moves/Ppm/Weight.jsx
+++ b/src/scenes/Moves/Ppm/Weight.jsx
@@ -5,10 +5,11 @@ import PropTypes from 'prop-types';
 import Slider from 'react-rangeslider'; //todo: pull from node_modules, override
 
 import WizardPage from 'shared/WizardPage';
+import Alert from 'shared/Alert';
 import {
   setPendingPpmWeight,
   loadPpm,
-  getIncentive,
+  getPpmEstimate,
   createOrUpdatePpm,
 } from './ducks';
 
@@ -66,17 +67,23 @@ export class PpmWeight extends Component {
     this.props.setPendingPpmWeight(value);
   };
   onWeightSelected = value => {
-    this.props.getIncentive(this.props.pendingPpmWeight);
+    const { currentPpm } = this.props;
+    this.props.getPpmEstimate(
+      currentPpm.planned_move_date,
+      currentPpm.pickup_zip,
+      currentPpm.destination_zip,
+      this.props.pendingPpmWeight,
+    );
   };
   render() {
     const {
       pendingPpmWeight,
       currentPpm,
-      moveDistance,
       incentive,
       pages,
       pageKey,
       hasSubmitSuccess,
+      error,
     } = this.props;
     const currentInfo = getWeightInfo(currentPpm);
     const setOrPendingWeight =
@@ -94,6 +101,13 @@ export class PpmWeight extends Component {
         pageIsDirty={Boolean(pendingPpmWeight)}
         hasSucceeded={hasSubmitSuccess}
       >
+        {error && (
+          <div className="usa-width-one-whole error-message">
+            <Alert type="error" heading="An error occurred">
+              {error.message}
+            </Alert>
+          </div>
+        )}
         <h2>
           <img
             className="icon"
@@ -122,23 +136,23 @@ export class PpmWeight extends Component {
         </div>
         <h4>
           {' '}
-          Your PPM Incentive:{' '}
-          <span className="incentive Todo">{incentive}</span>
+          Your PPM Incentive: <span className="incentive">{incentive}</span>
         </h4>
         <div className="info">
           <h3> How is my PPM Incentive calculated?</h3>
           <p>
             The government gives you 95% of what they would pay a mover when you
             move your own belongings, based on weight and distance. You pay
-            taxes on this income.
+            taxes on this income. You can reduce the amount taxable incentive by
+            saving receipts for approved expenses.
           </p>
-          <p className="Todo">Your move Distance: {moveDistance} miles </p>
+
           <p>
-            This estimator just presents a range of possible incentives. You’ll
-            need to inventory and weigh the stuff you’re carrying, and submit
-            weight tickets to get an accurate incentive. The amount you receive
-            also depends on the date you move. We’ll let you know later how to
-            weigh the stuff you carry.
+            This estimator just presents a range of possible incentives based on
+            your anticipated shipment weight, anticipated moving date, and the
+            specific route that you will be traveling. During your move, you
+            will need to weigh the stuff you’re carrying, and submit weight
+            tickets. We’ll let you know later how to weigh the stuff you carry.
           </p>
         </div>
       </WizardPage>
@@ -166,7 +180,7 @@ function mapStateToProps(state) {
 function mapDispatchToProps(dispatch) {
   return bindActionCreators(
     //todo: will want to load move to get distance
-    { setPendingPpmWeight, loadPpm, getIncentive, createOrUpdatePpm },
+    { setPendingPpmWeight, loadPpm, getPpmEstimate, createOrUpdatePpm },
     dispatch,
   );
 }

--- a/src/scenes/Moves/Ppm/api.js
+++ b/src/scenes/Moves/Ppm/api.js
@@ -1,9 +1,5 @@
 import { getClient, checkResponse } from 'shared/api';
 
-export async function GetSpec() {
-  const client = await getClient();
-  return client.spec;
-}
 export async function GetPpm(moveId) {
   const client = await getClient();
   const response = await client.apis.ppm.indexPersonallyProcuredMoves({
@@ -47,13 +43,15 @@ export async function GetPpmEstimate(
   destZip,
   weightEstimate,
 ) {
-  const client = await getClient();
-  const response = await client.apis.ppm.showPPMEstimate({
-    planned_move_date: moveDate,
-    origin_zip: originZip,
-    destination_zip: destZip,
-    weight_estimate: weightEstimate,
-  });
-  checkResponse(response, 'failed to update ppm due to server error');
-  return response.body;
+  //TODO: make api call once data is loaded on staging and prod
+  return { range_min: 75 * weightEstimate, range_max: 115 * weightEstimate };
+  //  const client = await getClient();
+  // const response = await client.apis.ppm.showPPMEstimate({
+  //   planned_move_date: moveDate,
+  //   origin_zip: originZip,
+  //   destination_zip: destZip,
+  //   weight_estimate: weightEstimate,
+  // });
+  // checkResponse(response, 'failed to update ppm due to server error');
+  // return response.body;
 }

--- a/src/scenes/Moves/Ppm/api.js
+++ b/src/scenes/Moves/Ppm/api.js
@@ -40,3 +40,20 @@ export async function UpdatePpm(
   checkResponse(response, 'failed to update ppm due to server error');
   return response.body;
 }
+
+export async function GetPpmEstimate(
+  moveDate,
+  originZip,
+  destZip,
+  weightEstimate,
+) {
+  const client = await getClient();
+  const response = await client.apis.ppm.showPPMEstimate({
+    planned_move_date: moveDate,
+    origin_zip: originZip,
+    destination_zip: destZip,
+    weight_estimate: weightEstimate,
+  });
+  checkResponse(response, 'failed to update ppm due to server error');
+  return response.body;
+}

--- a/src/scenes/Moves/Ppm/ducks.js
+++ b/src/scenes/Moves/Ppm/ducks.js
@@ -8,7 +8,6 @@ export const SET_PENDING_PPM_WEIGHT = 'SET_PENDING_PPM_WEIGHT';
 export const CREATE_OR_UPDATE_PPM = ReduxHelpers.generateAsyncActionTypes(
   'CREATE_OR_UPDATE_PPM',
 );
-export const GET_INCENTIVE = 'GET_INCENTIVE'; //TOOD: this should be async when rate engine is available
 export const GET_PPM = ReduxHelpers.generateAsyncActionTypes('GET_PPM');
 export const GET_PPM_ESTIMATE = ReduxHelpers.generateAsyncActionTypes(
   'GET_PPM_ESTIMATE',
@@ -16,7 +15,9 @@ export const GET_PPM_ESTIMATE = ReduxHelpers.generateAsyncActionTypes(
 
 function formatPpmEstimate(estimate) {
   // Range values arrive in cents, so convert to dollars
-  return `$${estimate.range_min / 100} - $${estimate.range_max / 100}`;
+  const range_min = (estimate.range_min / 100).toFixed(2);
+  const range_max = (estimate.range_max / 100).toFixed(2);
+  return `$${range_min} - $${range_max}`;
 }
 
 // Action creation
@@ -89,10 +90,6 @@ export function ppmReducer(state = initialState, action) {
     case SET_PENDING_PPM_WEIGHT:
       return Object.assign({}, state, {
         pendingPpmWeight: action.payload,
-      });
-    case GET_INCENTIVE:
-      return Object.assign({}, state, {
-        incentive: action.payload,
       });
     case CREATE_OR_UPDATE_PPM.start:
       return Object.assign({}, state, {

--- a/src/scenes/Moves/Ppm/ducks.test.js
+++ b/src/scenes/Moves/Ppm/ducks.test.js
@@ -49,6 +49,8 @@ describe('Ppm Reducer', () => {
       expect(newState).toEqual({
         pendingValue: '',
         currentPpm: samplePpm,
+        incentive: null,
+        pendingPpmWeight: null,
         hasSubmitError: false,
         hasSubmitSuccess: true,
       });

--- a/src/scenes/Review/Review.jsx
+++ b/src/scenes/Review/Review.jsx
@@ -314,10 +314,7 @@ export class Review extends Component {
                   </tr>
                   <tr>
                     <td> Estimated PPM Incentive: </td>
-                    <td className="Todo">
-                      {' '}
-                      {currentPpm && currentPpm.estimated_incentive}
-                    </td>
+                    <td> {currentPpm && currentPpm.estimated_incentive}</td>
                   </tr>
                 </tbody>
               </table>


### PR DESCRIPTION
## Description

This PR originally connected the PPM weight slider to the PPM estimate endpoint, updating the PPM model with actual rate estimates, but that code has been commented out until rate engine data can be loaded on production and staging.  We want to merge this now because it also updates some text per design.

## Code Review Verification Steps

* [ ] All tests pass.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/blob/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* [ ] Any migrations/schema changes also update the diagram in docs/schema/dp3.sqs
* [ ] There are no [aXe](https://www.deque.com/products/aXe/) warnings for UI.
* [ ] This works in IE.
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @willowbl00
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Request review from a member of a different team.
* [ ] (TRIAL) Have the Pivotal acceptance criteria been met for this change?

