### PR TITLE
SSN Masking

### DIFF
--- a/src/scenes/ServiceMembers/DodInfo.jsx
+++ b/src/scenes/ServiceMembers/DodInfo.jsx
@@ -4,31 +4,112 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 
-import { updateServiceMember, loadServiceMember } from './ducks';
-import { reduxifyForm } from 'shared/JsonSchemaForm';
-import { no_op } from 'shared/utils';
-import WizardPage from 'shared/WizardPage';
+import { Field } from 'redux-form';
+import validator from 'shared/JsonSchemaForm/validator';
 
-// todo: add branch (once can get yaml anchors to work)
+import { updateServiceMember, loadServiceMember } from './ducks';
+import { reduxifyWizardForm } from 'shared/WizardPage/Form';
+import { SwaggerField } from 'shared/JsonSchemaForm/JsonSchemaField';
+
 const subsetOfFields = [
   'affiliation',
   'edipi',
   'social_security_number',
   'rank',
 ];
-const uiSchema = {
-  title: 'Create your profile',
-  order: subsetOfFields,
-  requiredFields: subsetOfFields,
-  todos: (
-    <ul>
-      <li>SSN should be masked when not active</li>
-    </ul>
-  ),
+
+class SSNField extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      focused: false,
+    };
+
+    this.localOnBlur = this.localOnBlur.bind(this);
+    this.localOnFocus = this.localOnFocus.bind(this);
+  }
+
+  localOnBlur(value, something) {
+    this.setState({ focused: false });
+    this.props.input.onBlur(value);
+  }
+
+  localOnFocus(value, something) {
+    this.setState({ focused: true });
+    this.props.input.onFocus(value);
+  }
+
+  render() {
+    const {
+      input: { value, name },
+      meta: { touched, error },
+      ssnOnServer,
+    } = this.props;
+
+    let displayedValue = value;
+    if (!this.state.focused && (value !== '' || ssnOnServer)) {
+      displayedValue = '•••••••••';
+    }
+    const displayError = touched && error;
+
+    // This is copied from JsonSchemaField to match the styling
+    return (
+      <div className={displayError ? 'usa-input-error' : 'usa-input'}>
+        <label
+          className={displayError ? 'usa-input-error-label' : 'usa-input-label'}
+          htmlFor={name}
+        >
+          Social Security Number
+        </label>
+        {touched &&
+          error && (
+            <span
+              className="usa-input-error-message"
+              id={name + '-error'}
+              role="alert"
+            >
+              {error}
+            </span>
+          )}
+        <input
+          {...this.props.input}
+          onFocus={this.localOnFocus}
+          onBlur={this.localOnBlur}
+          value={displayedValue}
+        />
+      </div>
+    );
+  }
+}
+
+const validateDodForm = (values, form) => {
+  // Everything is taken care of except for SSN
+  let errors = {};
+  const ssn = values.social_security_number;
+  const hasSSN = form.ssnOnServer;
+
+  const validSSNPattern = RegExp('^\\d{3}-\\d{2}-\\d{4}$');
+  const validSSN = validSSNPattern.test(ssn);
+  const ssnPresent = ssn !== '' && ssn !== undefined;
+
+  if (hasSSN) {
+    if (ssnPresent && !validSSN) {
+      errors.social_security_number = 'SSN must have 9 digits.';
+    }
+  } else {
+    if (!ssnPresent) {
+      errors.social_security_number = 'Required.';
+    } else if (!validSSN) {
+      errors.social_security_number = 'SSN must have 9 digits.';
+    }
+  }
+
+  return errors;
 };
 
 const formName = 'service_member_dod_info';
-const CurrentForm = reduxifyForm(formName);
+const DodWizardForm = reduxifyWizardForm(formName, validateDodForm);
 
 export class DodInfo extends Component {
   componentDidMount() {
@@ -50,32 +131,38 @@ export class DodInfo extends Component {
       hasSubmitSuccess,
       error,
       currentServiceMember,
+      schema,
     } = this.props;
-    const isValid = this.refs.currentForm && this.refs.currentForm.valid;
-    const isDirty = this.refs.currentForm && this.refs.currentForm.dirty;
     const initialValues = currentServiceMember
       ? pick(currentServiceMember, subsetOfFields)
       : null;
+
+    const ssnOnServer = currentServiceMember
+      ? currentServiceMember.has_social_security_number
+      : false;
+
     return (
-      <WizardPage
+      <DodWizardForm
         handleSubmit={this.handleSubmit}
-        isAsync={true}
+        className={formName}
         pageList={pages}
         pageKey={pageKey}
-        pageIsValid={isValid}
-        pageIsDirty={isDirty}
         hasSucceeded={hasSubmitSuccess}
-        error={error}
+        serverError={error}
+        initialValues={initialValues}
+        ssnOnServer={ssnOnServer}
       >
-        <CurrentForm
-          ref="currentForm"
-          className={formName}
-          handleSubmit={no_op}
-          schema={this.props.schema}
-          uiSchema={uiSchema}
-          initialValues={initialValues}
+        <h1 className="sm-heading">Create your profile</h1>
+        <SwaggerField fieldName="affiliation" swagger={schema} required />
+        <SwaggerField fieldName="edipi" swagger={schema} required />
+        <Field
+          name="social_security_number"
+          component={SSNField}
+          ssnOnServer={ssnOnServer}
+          normalize={validator.normalizeSSN}
         />
-      </WizardPage>
+        <SwaggerField fieldName="rank" swagger={schema} required />
+      </DodWizardForm>
     );
   }
 }

--- a/src/shared/JsonSchemaForm/JsonSchemaField.js
+++ b/src/shared/JsonSchemaForm/JsonSchemaField.js
@@ -74,18 +74,6 @@ const configureTelephoneField = (swaggerField, props) => {
   return props;
 };
 
-const configureSSNField = (swaggerField, props) => {
-  props.normalize = validator.normalizeSSN;
-  props.validate.push(
-    validator.patternMatches(
-      '^\\d{3}-\\d{2}-\\d{4}$',
-      'SSN must have 9 digits.',
-    ),
-  );
-  props.type = 'text';
-  return props;
-};
-
 const configureZipField = (swaggerField, props) => {
   props.normalize = validator.normalizeZip;
   props.validate.push(
@@ -265,8 +253,6 @@ const createSchemaField = (fieldName, swaggerField, nameSpace) => {
       fieldProps = configureDateField(swaggerField, fieldProps);
     } else if (fieldFormat === 'telephone') {
       fieldProps = configureTelephoneField(swaggerField, fieldProps);
-    } else if (fieldFormat === 'ssn') {
-      fieldProps = configureSSNField(swaggerField, fieldProps);
     } else if (fieldFormat === 'zip') {
       fieldProps = configureZipField(swaggerField, fieldProps);
     } else if (fieldFormat === 'edipi') {


### PR DESCRIPTION
## Description

This PR makes the SSN widget in the SM Info page correctly reflect the server state. This means that if the SSN has been saved on the server we display bullets and don't require a value to be set to continue. If there is no value on the server it behaves as a normal field does. 

## Reviewer Notes

I don't think there is much need for this to be abstracted but it could be. I cleared out the old SSN field from JsonSchemaField because it won't really work the way we are storing them right now. 

## Code Review Verification Steps

* [ ] All tests pass.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/blob/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* [ ] Any migrations/schema changes also update the diagram in docs/schema/dp3.sqs
* [ ] There are no [aXe](https://www.deque.com/products/aXe/) warnings for UI.
* [ ] This works in IE.
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @willowbl00
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Request review from a member of a different team.
* [ ] (TRIAL) Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/157489893) for this change

## Screenshots

![ssnmask](https://user-images.githubusercontent.com/55759/39901777-7bd1c9da-547f-11e8-97a5-22c04d85a50d.gif)
