### PR TITLE
Updates to certification page and loads prior certs [delivers #155953611]

### DIFF
--- a/pkg/handlers/converters.go
+++ b/pkg/handlers/converters.go
@@ -72,6 +72,10 @@ func stringFromEmail(email *strfmt.Email) *string {
 	return &emailString
 }
 
+func fmtString(s string) *string {
+	return &s
+}
+
 func fmtSSN(s string) *strfmt.SSN {
 	ssn := strfmt.SSN(s)
 	return &ssn

--- a/pkg/handlers/handlers.go
+++ b/pkg/handlers/handlers.go
@@ -87,6 +87,7 @@ func NewInternalAPIHandler(context HandlerContext) http.Handler {
 	internalAPI.IssuesIndexIssuesHandler = IndexIssuesHandler(context)
 
 	internalAPI.CertificationCreateSignedCertificationHandler = CreateSignedCertificationHandler(context)
+	internalAPI.CertificationIndexSignedCertificationsHandler = IndexSignedCertificationsHandler(context)
 
 	internalAPI.PpmCreatePersonallyProcuredMoveHandler = CreatePersonallyProcuredMoveHandler(context)
 	internalAPI.PpmIndexPersonallyProcuredMovesHandler = IndexPersonallyProcuredMovesHandler(context)

--- a/pkg/handlers/signed_certifications.go
+++ b/pkg/handlers/signed_certifications.go
@@ -8,8 +8,20 @@ import (
 
 	"github.com/transcom/mymove/pkg/auth"
 	certop "github.com/transcom/mymove/pkg/gen/internalapi/internaloperations/certification"
+	"github.com/transcom/mymove/pkg/gen/internalmessages"
 	"github.com/transcom/mymove/pkg/models"
 )
+
+func payloadForSignedCertificationModel(cert models.SignedCertification) *internalmessages.SignedCertificationPayload {
+	return &internalmessages.SignedCertificationPayload{
+		ID:                fmtUUID(cert.ID),
+		CreatedAt:         fmtDateTime(cert.CreatedAt),
+		UpdatedAt:         fmtDateTime(cert.UpdatedAt),
+		CertificationText: fmtString(cert.CertificationText),
+		Signature:         fmtString(cert.Signature),
+		Date:              fmtDate(cert.Date),
+	}
+}
 
 // CreateSignedCertificationHandler creates a new issue via POST /issue
 type CreateSignedCertificationHandler HandlerContext
@@ -32,4 +44,34 @@ func (h CreateSignedCertificationHandler) Handle(params certop.CreateSignedCerti
 	}
 
 	return certop.NewCreateSignedCertificationCreated()
+}
+
+// IndexSignedCertificationsHandler creates a new issue via POST /issue
+type IndexSignedCertificationsHandler HandlerContext
+
+// Handle returns a SignedCertification for a given moveID
+func (h IndexSignedCertificationsHandler) Handle(params certop.IndexSignedCertificationsParams) middleware.Responder {
+	// User should always be populated by middleware
+	user, _ := auth.GetUser(params.HTTPRequest.Context())
+	moveID, _ := uuid.FromString(params.MoveID.String())
+
+	move, err := models.FetchMove(h.db, user, moveID)
+	if err != nil {
+		return responseForError(h.logger, err)
+	}
+
+	certs := move.SignedCertifications
+
+	limit := len(certs)
+	if params.Limit != nil && limit > int(*params.Limit) {
+		limit = int(*params.Limit)
+	}
+
+	payload := make(internalmessages.IndexSignedCertificationsPayload, limit)
+	for i := 0; i < limit; i++ {
+		cert := certs[i]
+		payload[i] = payloadForSignedCertificationModel(cert)
+	}
+
+	return certop.NewIndexSignedCertificationsOK().WithPayload(payload)
 }

--- a/pkg/models/move.go
+++ b/pkg/models/move.go
@@ -22,6 +22,7 @@ type Move struct {
 	Orders                  Order                              `belongs_to:"orders"`
 	SelectedMoveType        *internalmessages.SelectedMoveType `json:"selected_move_type" db:"selected_move_type"`
 	PersonallyProcuredMoves PersonallyProcuredMoves            `has_many:"personally_procured_moves"`
+	SignedCertifications    SignedCertifications               `has_many:"signed_certifications" order_by:"created_at desc"`
 }
 
 // String is not required by pop and may be deleted

--- a/src/scenes/Legalese/SignatureForm.css
+++ b/src/scenes/Legalese/SignatureForm.css
@@ -1,39 +1,3 @@
 
-.signature_form {
-  background-color: #aeb0b5;
-  padding: 2rem;
-  margin-top: 1em;
-}
 
-.signing_box {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: space-between;
-  margin: 0 -10px; /* This trick stolen from https://stackoverflow.com/a/48450531/559073 */
-}
-
-.signing_box > * {
-  margin-top: 0;
-  margin: 0 10px;
-}
-
-#name_field {
-  flex-grow: 1;
-}
-
-#date_field  {
-  flex-grow: 1;
-  max-width: 200px;
-}
-
-/* This matches the width at which submit buttons go full-width for mobile devices */
-@media only screen and (max-width: 481px) {
-    #date_field {
-        max-width: none;
-    }
-}
-
-.signature_form h3 {
-  margin-top: 0;
-}
 

--- a/src/scenes/Legalese/SignatureForm.jsx
+++ b/src/scenes/Legalese/SignatureForm.jsx
@@ -4,9 +4,9 @@ import './SignatureForm.css';
 import validator from 'shared/JsonSchemaForm/validator';
 
 function SignatureForm(props) {
-  const { handleSubmit, pristine, invalid, submitting } = props;
+  const { pristine, invalid, submitting } = props;
   return (
-    <form className="signature_form" onSubmit={handleSubmit}>
+    <div>
       <h3>SIGNATURE</h3>
       <p>
         In consideration of said household goods or mobile homes being shipped
@@ -28,11 +28,8 @@ function SignatureForm(props) {
           Today's date
           <Field name="date" component="input" type="text" readOnly />
         </label>
-        <button type="submit" disabled={pristine || submitting || invalid}>
-          Sign
-        </button>
       </div>
-    </form>
+    </div>
   );
 }
 

--- a/src/scenes/Legalese/api.js
+++ b/src/scenes/Legalese/api.js
@@ -10,6 +10,16 @@ export async function GetCertificationText() {
   return legaleseSample;
 }
 
+export async function GetCertifications(moveId, limit) {
+  const client = await getClient();
+  const response = await client.apis.certification.indexSignedCertifications({
+    moveId,
+    limit,
+  });
+  checkResponse(response, 'failed to find certs due to server error');
+  return response.body;
+}
+
 export async function CreateCertification(certificationRequest) {
   const client = await getClient();
   const response = await client.apis.certification.createSignedCertification(

--- a/src/scenes/Legalese/ducks.js
+++ b/src/scenes/Legalese/ducks.js
@@ -21,15 +21,15 @@ export const GET_CERT_TEXT = ReduxHelpers.generateAsyncActionTypes(
 );
 
 // Action creator
-export function loadCertificationText() {
-  const action = ReduxHelpers.generateAsyncActions('GET_CERT_TEXT');
-  return function(dispatch, getState) {
-    dispatch(action.start);
-    GetCertificationText()
-      .then(item => dispatch(action.success(item)))
-      .catch(error => dispatch(action.error(error)));
-  };
-}
+export const loadCertificationText = ReduxHelpers.generateAsyncActionCreator(
+  'GET_CERT_TEXT',
+  GetCertificationText,
+);
+
+export const createSignedCertification = ReduxHelpers.generateAsyncActionCreator(
+  'CREATE_SIGNED_CERT',
+  CreateCertification,
+);
 
 export function loadLatestCertification(moveId) {
   const action = ReduxHelpers.generateAsyncActions('GET_LATEST_CERT');
@@ -43,16 +43,6 @@ export function loadLatestCertification(moveId) {
         .then(item => dispatch(action.success(item)))
         .catch(error => dispatch(action.error(error)));
     }
-  };
-}
-
-export function createSignedCertification(value) {
-  const action = ReduxHelpers.generateAsyncActions('CREATE_SIGNED_CERT');
-  return function(dispatch, getState) {
-    dispatch(action.start);
-    CreateCertification(value)
-      .then(item => dispatch(action.success(item)))
-      .catch(error => dispatch(action.failure(error)));
   };
 }
 

--- a/src/scenes/Legalese/ducks.js
+++ b/src/scenes/Legalese/ducks.js
@@ -5,7 +5,6 @@ import {
 } from './api.js';
 import * as ReduxHelpers from 'shared/ReduxHelpers';
 import { get } from 'lodash';
-import { push } from 'react-router-redux';
 
 // Actions
 

--- a/src/scenes/Legalese/ducks.test.js
+++ b/src/scenes/Legalese/ducks.test.js
@@ -1,15 +1,11 @@
-import {
-  CREATE_CERTIFICATION_SUCCESS,
-  CREATE_CERTIFICATION_FAILURE,
-  signedCertificationReducer,
-} from './ducks';
+import { CREATE_SIGNED_CERT, signedCertificationReducer } from './ducks';
 
 describe('Feedback Reducer', () => {
   it('Should handle CREATE_CERTIFICATION_SUCCESS', () => {
     const initialState = { pendingValue: '', confirmationText: '' };
 
     const newState = signedCertificationReducer(initialState, {
-      type: CREATE_CERTIFICATION_SUCCESS,
+      type: CREATE_SIGNED_CERT.success,
       item: 'Successful item!',
     });
 
@@ -25,7 +21,7 @@ describe('Feedback Reducer', () => {
     const initialState = { pendingValue: '', confirmationText: '' };
 
     const newState = signedCertificationReducer(initialState, {
-      type: CREATE_CERTIFICATION_FAILURE,
+      type: CREATE_SIGNED_CERT.failure,
       error: 'No bueno.',
     });
 

--- a/src/scenes/Legalese/index.css
+++ b/src/scenes/Legalese/index.css
@@ -6,3 +6,41 @@
 .instructions {
   margin: 0;
 }
+
+.signature_form {
+  background-color: #aeb0b5;
+  padding: 2rem;
+  margin-top: 1em;
+}
+
+.signing_box {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  margin: 0 -10px; /* This trick stolen from https://stackoverflow.com/a/48450531/559073 */
+}
+
+.signing_box > * {
+  margin-top: 0;
+  margin: 0 10px;
+}
+
+div.signature {
+  flex-grow: 1;
+}
+
+div.signature_date  {
+  flex-grow: 1;
+  max-width: 200px;
+}
+
+/* This matches the width at which submit buttons go full-width for mobile devices */
+@media only screen and (max-width: 481px) {
+    input[name="date"] {
+        max-width: none;
+    }
+}
+
+.signature_form h3 {
+  margin-top: 10px;
+}

--- a/src/scenes/Legalese/index.jsx
+++ b/src/scenes/Legalese/index.jsx
@@ -1,60 +1,153 @@
+import { get } from 'lodash';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
+import { push } from 'react-router-redux';
 import PropTypes from 'prop-types';
 
+import { reduxifyWizardForm } from 'shared/WizardPage/Form';
 import CertificationText from './CertificationText';
-import SignatureForm from './SignatureForm';
 import Alert from 'shared/Alert';
+import { SwaggerField } from 'shared/JsonSchemaForm/JsonSchemaField';
 import './index.css';
 
-import { loadCertificationText, createSignedCertification } from './ducks';
+import {
+  loadCertificationText,
+  loadLatestCertification,
+  createSignedCertification,
+} from './ducks';
+
+const validateSignatureForm = (values, form) => {
+  let errors = {};
+
+  const required_fields = ['signature', 'date'];
+
+  required_fields.forEach(fieldName => {
+    if (values[fieldName] === undefined || values[fieldName] === '') {
+      errors[fieldName] = 'Required.';
+    }
+  });
+
+  return errors;
+};
+
+const formName = 'signature_form';
+const SignatureWizardForm = reduxifyWizardForm(formName, validateSignatureForm);
 
 export class SignedCertification extends Component {
   componentDidMount() {
     document.title = 'Transcom PPP: Submit SignedCertification';
-    this.props.loadCertificationText();
+    this.props.loadLatestCertification(this.props.match.params.moveId);
   }
 
-  handleSubmit = values => {
-    const certRequest = {
-      moveId: this.props.match.params.moveId,
-      createSignedCertificationPayload: {
-        certification_text: this.props.certificationText,
-        signature: values.signature,
-        date: values.date,
-      },
-    };
-    this.props.createSignedCertification(certRequest);
+  componentDidUpdate() {
+    const {
+      getCertificationSuccess,
+      certificationText,
+      hasSubmitSuccess,
+    } = this.props;
+    if (getCertificationSuccess && !certificationText) {
+      this.props.loadCertificationText();
+      return;
+    }
+
+    if (this.props.hasSubmitSuccess) {
+      this.props.push('/');
+    }
+  }
+
+  handleSubmit = () => {
+    const pendingValues = this.props.formData.values;
+    const { latestSignedCertification } = this.props;
+
+    if (latestSignedCertification) {
+      return this.props.push('/');
+    }
+
+    if (pendingValues) {
+      const certRequest = {
+        moveId: this.props.match.params.moveId,
+        createSignedCertificationPayload: {
+          certification_text: this.props.certificationText,
+          signature: pendingValues.signature,
+          date: pendingValues.date,
+        },
+      };
+      this.props.createSignedCertification(certRequest);
+    }
   };
 
   render() {
-    const { hasSubmitError } = this.props;
+    const {
+      hasSubmitError,
+      pages,
+      pageKey,
+      hasSubmitSuccess,
+      latestSignedCertification,
+    } = this.props;
     const today = new Date(Date.now()).toISOString().split('T')[0];
     const initialValues = {
-      date: today,
+      date: get(latestSignedCertification, 'date', today),
+      signature: get(latestSignedCertification, 'signature', null),
     };
     return (
-      <div className="usa-grid">
-        <h2>Now for the official part...</h2>
-        <span className="box_top">
-          <p className="instructions">
-            Before officially booking your move, please carefully read and then
-            sign the following.
-          </p>
-          <a className="pdf Todo">Printer Friendly PDF</a>
-        </span>
+      <div>
+        {this.props.certificationText && (
+          <SignatureWizardForm
+            handleSubmit={this.handleSubmit}
+            className={formName}
+            pageList={pages}
+            pageKey={pageKey}
+            hasSucceeded={hasSubmitSuccess}
+            initialValues={initialValues}
+          >
+            <div className="usa-grid">
+              <h2>Now for the official part...</h2>
+              <span className="box_top">
+                <p className="instructions">
+                  Before officially booking your move, please carefully read and
+                  then sign the following.
+                </p>
+                <a className="pdf Todo">Printer Friendly PDF</a>
+              </span>
 
-        <CertificationText certificationText={this.props.certificationText} />
-        <SignatureForm
-          onSubmit={this.handleSubmit}
-          initialValues={initialValues}
-        />
+              <CertificationText
+                certificationText={this.props.certificationText}
+              />
 
-        {hasSubmitError && (
-          <Alert type="error" heading="Server Error">
-            There was a problem saving your signature. Please reload the page.
-          </Alert>
+              <h3>SIGNATURE</h3>
+              <p>
+                In consideration of said household goods or mobile homes being
+                shipped at Government expense,{' '}
+                <strong>
+                  I hereby agree to the certifications stated above.
+                </strong>
+              </p>
+              <div className="signing_box">
+                <SwaggerField
+                  className="signature"
+                  fieldName="signature"
+                  swagger={this.props.schema}
+                  required
+                  disabled={!!initialValues.signature}
+                />
+                <SwaggerField
+                  className="signature_date"
+                  fieldName="date"
+                  swagger={this.props.schema}
+                  required
+                  disabled
+                />
+              </div>
+
+              {hasSubmitError && (
+                <Alert type="error" heading="Server Error">
+                  There was a problem saving your signature. Please reload the
+                  page.
+                </Alert>
+              )}
+            </div>
+          </SignatureWizardForm>
         )}
       </div>
     );
@@ -63,19 +156,33 @@ export class SignedCertification extends Component {
 
 SignedCertification.propTypes = {
   createSignedCertification: PropTypes.func.isRequired,
-  loadCertificationText: PropTypes.func.isRequired,
+  loadLatestCertification: PropTypes.func.isRequired,
   match: PropTypes.object.isRequired,
+  handleSubmit: PropTypes.func,
   hasSubmitError: PropTypes.bool.isRequired,
   hasSubmitSuccess: PropTypes.bool.isRequired,
 };
 
 function mapStateToProps(state) {
-  return state.signedCertification;
+  return {
+    schema: get(
+      state,
+      'swagger.spec.definitions.CreateSignedCertificationPayload',
+      {},
+    ),
+    formData: state.form[formName],
+    ...state.signedCertification,
+  };
 }
 
 function mapDispatchToProps(dispatch) {
   return bindActionCreators(
-    { loadCertificationText, createSignedCertification },
+    {
+      loadCertificationText,
+      loadLatestCertification,
+      createSignedCertification,
+      push,
+    },
     dispatch,
   );
 }

--- a/src/scenes/Legalese/index.jsx
+++ b/src/scenes/Legalese/index.jsx
@@ -41,11 +41,7 @@ export class SignedCertification extends Component {
   }
 
   componentDidUpdate() {
-    const {
-      getCertificationSuccess,
-      certificationText,
-      hasSubmitSuccess,
-    } = this.props;
+    const { getCertificationSuccess, certificationText } = this.props;
     if (getCertificationSuccess && !certificationText) {
       this.props.loadCertificationText();
       return;

--- a/src/scenes/Legalese/index.test.js
+++ b/src/scenes/Legalese/index.test.js
@@ -8,6 +8,7 @@ import store from 'shared/store';
 const dummyFunc = () => {};
 const schema = {};
 const uiSchema = {};
+const match = { params: { moveId: 'someID' } };
 const hasSchemaError = false;
 const hasSubmitError = false;
 const hasSubmitSuccess = false;
@@ -24,7 +25,7 @@ it('renders without crashing', () => {
         uiSchema={uiSchema}
         confirmationText=""
         createIssue={dummyFunc}
-        match={{ match: 'match' }}
+        match={match}
       />
     </Provider>,
     div,

--- a/src/scenes/MyMove/getWorkflowRoutes.jsx
+++ b/src/scenes/MyMove/getWorkflowRoutes.jsx
@@ -48,7 +48,6 @@ const stub = (key, pages, description) => ({ match }) => (
   />
 );
 
-const goHome = props => () => props.push('/');
 const createMove = props => () =>
   props.hasMove || props.createMove(props.currentOrdersId);
 const always = () => true;

--- a/src/scenes/MyMove/getWorkflowRoutes.jsx
+++ b/src/scenes/MyMove/getWorkflowRoutes.jsx
@@ -192,11 +192,7 @@ const pages = {
   '/moves/:moveId/agreement': {
     isInFlow: always,
     render: (key, pages, description, props) => ({ match }) => {
-      return (
-        <WizardPage handleSubmit={goHome(props)} pageList={pages} pageKey={key}>
-          <Agreement match={match} />
-        </WizardPage>
-      );
+      return <Agreement pages={pages} pageKey={key} match={match} />;
     },
   },
 };

--- a/src/shared/JsonSchemaForm/JsonSchemaField.js
+++ b/src/shared/JsonSchemaForm/JsonSchemaField.js
@@ -140,6 +140,8 @@ const renderInputField = ({
   customComponent,
   meta: { touched, error, warning },
   children,
+  className,
+  inputProps,
 }) => {
   let component = 'input';
   if (componentNameOverride) {
@@ -164,13 +166,17 @@ const renderInputField = ({
       type: type,
       step: step,
       'aria-describedby': input.name + '-error',
+      ...inputProps,
     },
     children,
   );
 
   const displayError = touched && error;
+  const classes = `${
+    displayError ? 'usa-input-error' : 'usa-input'
+  } ${className}`;
   return (
-    <div className={displayError ? 'usa-input-error' : 'usa-input'}>
+    <div className={classes}>
       <label
         className={displayError ? 'usa-input-error-label' : 'usa-input-label'}
         htmlFor={input.name}
@@ -194,7 +200,7 @@ const renderInputField = ({
 };
 
 export const SwaggerField = props => {
-  const { fieldName, swagger, required } = props;
+  const { fieldName, swagger, required, className, disabled } = props;
 
   let swaggerField;
   if (swagger.properties) {
@@ -209,12 +215,24 @@ export const SwaggerField = props => {
     swaggerField[ALWAYS_REQUIRED_KEY] = true;
   }
 
-  return createSchemaField(fieldName, swaggerField, undefined);
+  return createSchemaField(
+    fieldName,
+    swaggerField,
+    undefined,
+    className,
+    disabled,
+  );
 };
 
 // This function switches on the type of the field and creates the correct
 // Label and Field combination.
-const createSchemaField = (fieldName, swaggerField, nameSpace) => {
+const createSchemaField = (
+  fieldName,
+  swaggerField,
+  nameSpace,
+  className = '',
+  disabled = false,
+) => {
   // Early return here, this is an edge case for label placement.
   // USWDS CSS only renders a checkbox if it is followed by its label
   const nameAttr = nameSpace ? `${nameSpace}.${fieldName}` : fieldName;
@@ -236,6 +254,10 @@ const createSchemaField = (fieldName, swaggerField, nameSpace) => {
   fieldProps.component = renderInputField;
   fieldProps.validate = [];
   fieldProps.always_required = swaggerField[ALWAYS_REQUIRED_KEY];
+
+  let inputProps = {
+    disabled: disabled,
+  };
 
   if (fieldProps.always_required) {
     fieldProps.validate.push(validator.isRequired);
@@ -285,7 +307,12 @@ const createSchemaField = (fieldName, swaggerField, nameSpace) => {
     );
   }
   return (
-    <Field key={fieldName} {...fieldProps}>
+    <Field
+      key={fieldName}
+      className={className}
+      inputProps={inputProps}
+      {...fieldProps}
+    >
       {children}
     </Field>
   );

--- a/src/shared/JsonSchemaForm/SingleDatePicker.jsx
+++ b/src/shared/JsonSchemaForm/SingleDatePicker.jsx
@@ -3,8 +3,13 @@ import DayPickerInput from 'react-day-picker/DayPickerInput';
 import 'react-day-picker/lib/style.css';
 
 export default function SingleDatePicker(props) {
-  const { value = null, onChange } = props;
+  const { value = null, onChange, disabled } = props;
   return (
-    <DayPickerInput onDayChange={onChange} placeholder="Date" value={value} />
+    <DayPickerInput
+      onDayChange={onChange}
+      placeholder="Date"
+      value={value}
+      inputProps={{ disabled }}
+    />
   );
 }

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -728,6 +728,35 @@ definitions:
     type: array
     items:
       $ref: '#/definitions/ServiceMemberBackupContactPayload'
+  SignedCertificationPayload:
+    type: object
+    properties:
+      id:
+        type: string
+        format: uuid
+        example: c56a4180-65aa-42ec-a945-5fd21dec0538
+      created_at:
+        type: string
+        format: date-time
+      updated_at:
+        type: string
+        format: date-time
+      date:
+        type: string
+        format: date
+        title: Date
+      signature:
+        type: string
+        title: Signature
+      certification_text:
+        type: string
+    required:
+      - id
+      - created_at
+      - updated_at
+      - date
+      - signature
+      - certification_text
   CreateSignedCertificationPayload:
     type: object
     properties:
@@ -744,6 +773,10 @@ definitions:
       - date
       - signature
       - certification_text
+  IndexSignedCertificationsPayload:
+    type: array
+    items:
+      $ref: '#/definitions/SignedCertificationPayload'
   DocumentPayload:
     type: object
     properties:
@@ -1757,7 +1790,40 @@ paths:
           description: move is not found
         500:
           description: internal server error
-  /moves/{moveId}/signed_certification:
+  /moves/{moveId}/signed_certifications:
+    get:
+      summary: Returns signed certifications for the given move
+      description: Returns signed certifications for the given move
+      operationId: indexSignedCertifications
+      tags:
+        - certification
+      parameters:
+        - in: path
+          name: moveId
+          type: string
+          format: uuid
+          required: true
+          description: UUID of the move
+        - in: query
+          name: limit
+          type: integer
+          required: false
+          description: Number of certifications to return
+      responses:
+        200:
+          description: the instance of the move
+          schema:
+            $ref: '#/definitions/IndexSignedCertificationsPayload'
+        400:
+          description: invalid request
+        401:
+          description: request requires user authentication
+        403:
+          description: user is not authorized
+        404:
+          description: move is not found
+        500:
+          description: internal server error
     post:
       summary: Submits signed certification for the given move ID
       description: Create an instance of signed_certification tied to the move ID


### PR DESCRIPTION
## Description

- Removes `Sign` button and just uses wizard's complete
- Date input is disabled
- Loads info from prior signed cert if available
- Makes signature field disabled if prior signed cert exists

## Code Review Verification Steps

* [ ] All tests pass.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/blob/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* [ ] Any migrations/schema changes also update the diagram in docs/schema/dp3.sqs
* [ ] There are no [aXe](https://www.deque.com/products/aXe/) warnings for UI.
* [ ] This works in IE.
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @willowbl00
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Request review from a member of a different team.
* [ ] (TRIAL) Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/155953611) for this change

## Screenshots

If this PR makes visible UI changes, an image of the finished UI can help reviewers and casual
observers understand the context of the changes. A before image is optional and
can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow instead of using multiple images. You may want to use GIPHY CAPTURE for this! 📸

_Please frame screenshots to show enough useful context but also highlight the affected regions._
