### PR TITLE
Fix issue loading queue for the Office #157522706

### DIFF
--- a/pkg/models/queue.go
+++ b/pkg/models/queue.go
@@ -45,7 +45,7 @@ func GetMoveQueueItems(db *pop.Connection, lifecycleState string) ([]MoveQueueIt
 			current_time as last_modified_date
 		FROM moves
 		JOIN orders as ord ON moves.orders_id = ord.id
-		JOIN service_members AS sm ON ord.service_member_id = sm.user_id
+		JOIN service_members AS sm ON ord.service_member_id = sm.id
 	`
 	// TODO: add clause `WHERE moves.lifecycle_state = $1`
 	// err = db.RawQuery(query, lifecycleState).All(&moveQueueItems)

--- a/pkg/models/queue.go
+++ b/pkg/models/queue.go
@@ -44,7 +44,8 @@ func GetMoveQueueItems(db *pop.Connection, lifecycleState string) ([]MoveQueueIt
 			'Awaiting review' as status,
 			current_time as last_modified_date
 		FROM moves
-		INNER JOIN service_members AS sm ON moves.user_id = sm.user_id
+		JOIN orders as ord ON moves.orders_id = ord.id
+		JOIN service_members AS sm ON ord.service_member_id = sm.user_id
 	`
 	// TODO: add clause `WHERE moves.lifecycle_state = $1`
 	// err = db.RawQuery(query, lifecycleState).All(&moveQueueItems)


### PR DESCRIPTION
## Description

SQL to load queues was based on join between Moves and  Service Members. This now needs to be done via Orders.

## Reviewer Notes

Wasn't able to test with data but the page loaded fine. If you have suitable test data please check

## Code Review Verification Steps

* [*] All tests pass.
* [*] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/blob/master/docs/backend.md#logging)
* [*] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* [n/a] Any migrations/schema changes also update the diagram in docs/schema/dp3.sqs
* [n/a] There are no [aXe](https://www.deque.com/products/aXe/) warnings for UI.
* [n/a] This works in IE.
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [n/a] Communicated to @willowbl00
  * [n/a] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [*] Request review from a member of a different team.
* [ ] (TRIAL) Have the Pivotal acceptance criteria been met for this change?

## References

* [Model changes have broken our Queues endpoint](https://www.pivotaltracker.com/story/show/157522706) for this change
