### PR TITLE
Updates Office queue code to fetch data that exists in current models #157525295

### DIFF
--- a/pkg/handlers/handlers_test.go
+++ b/pkg/handlers/handlers_test.go
@@ -93,7 +93,7 @@ func (suite *HandlerSuite) fixture(name string) *runtime.File {
 
 	info, err := os.Stat(fixturePath)
 	if err != nil {
-		suite.T().Error(err)
+		suite.T().Fatal(err)
 	}
 	header := multipart.FileHeader{
 		Filename: name,

--- a/pkg/handlers/move_queue_items.go
+++ b/pkg/handlers/move_queue_items.go
@@ -7,6 +7,7 @@ import (
 	queueop "github.com/transcom/mymove/pkg/gen/internalapi/internaloperations/queues"
 	"github.com/transcom/mymove/pkg/gen/internalmessages"
 	"github.com/transcom/mymove/pkg/models"
+	"go.uber.org/zap"
 )
 
 func payloadForMoveQueueItem(MoveQueueItem models.MoveQueueItem) *internalmessages.MoveQueueItem {
@@ -37,6 +38,7 @@ func (h ShowQueueHandler) Handle(params queueop.ShowQueueParams) middleware.Resp
 
 	MoveQueueItems, err := models.GetMoveQueueItems(h.db, lifecycleState)
 	if err != nil {
+		h.logger.Error("Loading Queue", zap.String("State", lifecycleState), zap.Error(err))
 		return responseForError(h.logger, err)
 	}
 

--- a/pkg/handlers/move_queue_items_test.go
+++ b/pkg/handlers/move_queue_items_test.go
@@ -13,9 +13,6 @@ import (
 )
 
 func (suite *HandlerSuite) TestShowQueueHandler() {
-	t := suite.T()
-	t.Skip("don't test stubbed out endpoint")
-
 	// Given: An office user
 	officeUser := models.User{
 		LoginGovUUID:  uuid.Must(uuid.NewV4()),
@@ -32,7 +29,7 @@ func (suite *HandlerSuite) TestShowQueueHandler() {
 	suite.mustSave(&newMove)
 
 	// And: the context contains the auth values
-	req := httptest.NewRequest("GET", "/queues/some_queue", nil)
+	req := httptest.NewRequest("GET", "/queues/new", nil)
 	req = suite.authenticateRequest(req, officeUser)
 
 	params := queueop.ShowQueueParams{
@@ -48,8 +45,6 @@ func (suite *HandlerSuite) TestShowQueueHandler() {
 	moveQueueItem := okResponse.Payload[0]
 
 	// And: Returned query to include our added move
-	expectedCustomerName := fmt.Sprintf("%v %v", *order.ServiceMember.FirstName, *order.ServiceMember.LastName)
-	if *moveQueueItem.CustomerName != expectedCustomerName {
-		t.Errorf("Expected move queue item to have service member name '%v', instead has '%v'", expectedCustomerName, *moveQueueItem.CustomerName)
-	}
+	expectedCustomerName := fmt.Sprintf("%v, %v", *order.ServiceMember.LastName, *order.ServiceMember.FirstName)
+	suite.Equal(expectedCustomerName, *moveQueueItem.CustomerName)
 }

--- a/pkg/models/queue.go
+++ b/pkg/models/queue.go
@@ -39,7 +39,7 @@ func GetMoveQueueItems(db *pop.Connection, lifecycleState string) ([]MoveQueueIt
 			'*missing*' as locator,
 			ord.orders_type as orders_type,
 			current_date as move_date,
-			move.created_at as created_at,
+			moves.created_at as created_at,
 			'Awaiting review' as status,
 			current_time as last_modified_date
 		FROM moves

--- a/pkg/models/queue.go
+++ b/pkg/models/queue.go
@@ -29,18 +29,17 @@ func GetMoveQueueItems(db *pop.Connection, lifecycleState string) ([]MoveQueueIt
 	moveQueueItems := []MoveQueueItem{}
 	// TODO: Add clause `SELECT moves.ID, sm.edipi, sm.rank, CONCAT(sm.last_name, ', ', sm.first_name) AS customer_name`
 	// TODO: add clause `JOIN personally_procured_moves AS ppm ON moves.id = ppm.move_id`
-	// TODO: add `CONCAT(sm.last_name, ', ', sm.first_name)` back to query, once data is in place
 
 	// TODO: replace hardcoded values with actual query values once data is available
 	query := `
 		SELECT moves.ID,
-			COALESCE(sm.edipi, 'test ID') as edipi,
-			COALESCE(sm.rank, 'major') as rank,
-			'Tester, Telly' AS customer_name,
-			'12345' as locator,
-			COALESCE(moves.selected_move_type, 'COMBO') as orders_type,
+			COALESCE(sm.edipi, '*missing*') as edipi,
+			COALESCE(sm.rank, '*missing*') as rank,
+			CONCAT(COALESCE(sm.last_name, '*missing*'), ', ', COALESCE(sm.first_name, '*missing*')) AS customer_name,
+			'*missing*' as locator,
+			ord.orders_type as orders_type,
 			current_date as move_date,
-			current_time as created_at,
+			move.created_at as created_at,
 			'Awaiting review' as status,
 			current_time as last_modified_date
 		FROM moves

--- a/pkg/testdatagen/make_order.go
+++ b/pkg/testdatagen/make_order.go
@@ -35,7 +35,7 @@ func MakeOrderForServiceMember(db *pop.Connection, sm models.ServiceMember) (mod
 		NewDutyStation:   station,
 		IssueDate:        time.Date(2018, time.March, 15, 0, 0, 0, 0, time.UTC),
 		ReportByDate:     time.Date(2018, time.August, 1, 0, 0, 0, 0, time.UTC),
-		OrdersType:       internalmessages.OrdersTypeBLUEBARK,
+		OrdersType:       internalmessages.OrdersTypePERMANENTCHANGEOFSTATION,
 		HasDependents:    true,
 		UploadedOrdersID: document.ID,
 		UploadedOrders:   document,

--- a/pkg/testdatagen/make_service_member.go
+++ b/pkg/testdatagen/make_service_member.go
@@ -16,8 +16,10 @@ func MakeServiceMember(db *pop.Connection) (models.ServiceMember, error) {
 	}
 
 	serviceMember := models.ServiceMember{
-		UserID: user.ID,
-		User:   user,
+		UserID:    user.ID,
+		User:      user,
+		FirstName: models.StringPointer("Leo"),
+		LastName:  models.StringPointer("Spacemen"),
 	}
 
 	verrs, err := db.ValidateAndSave(&serviceMember)


### PR DESCRIPTION
## Description

Updates the queue code to fetch some data which was missing from the models when it was written. In particular the service member name.

Also fixed the test for this handler so that it runs and is no longer skipped. 

## Reviewer Notes
NOTE: I added some logging to the handler as I noticed, when testing the code, that the handler would fail without logging anything on the server, viz:
```		h.logger.Error("Loading Queue", zap.String("State", lifecycleState), zap.Error(err))```

When reviewing future handler changes please look out for this level of logging. It's going to make debugging production isssue much much easier.

## Code Review Verification Steps

* [ ] All tests pass.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/blob/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* [ ] Any migrations/schema changes also update the diagram in docs/schema/dp3.sqs
* [ ] There are no [aXe](https://www.deque.com/products/aXe/) warnings for UI.
* [ ] This works in IE.
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @willowbl00
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Request review from a member of a different team.
* [ ] (TRIAL) Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/157525295) for this change

<img width="733" alt="screen shot 2018-05-12 at 4 57 08 pm" src="https://user-images.githubusercontent.com/317739/39962508-892d3c72-5605-11e8-888d-3718a215ffd0.png">
