### PR TITLE
Rek load orders sm

### DIFF
--- a/cmd/generate_test_data/main.go
+++ b/cmd/generate_test_data/main.go
@@ -48,5 +48,6 @@ func main() {
 		testdatagen.MakeBlackoutDateData(db)
 		testdatagen.MakeMoveData(db)
 		testdatagen.MakeServiceMember(db)
+		testdatagen.MakeBackupContact(db)
 	}
 }

--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -8,7 +8,7 @@ import { RoutedTabs, NavTab } from 'react-router-tabs';
 import { Route, Switch, Redirect } from 'react-router-dom';
 
 import AccountingPanel from './AccountingPanel';
-import { loadMove } from './ducks.js';
+import { loadMove, loadOrders } from './ducks.js';
 
 import FontAwesomeIcon from '@fortawesome/react-fontawesome';
 import faPhone from '@fortawesome/fontawesome-free-solid/faPhone';
@@ -402,14 +402,16 @@ class MoveInfo extends Component {
 
 MoveInfo.propTypes = {
   loadMove: PropTypes.func.isRequired,
+  loadOrders: PropTypes.func.isRequired,
 };
 
 const mapStateToProps = state => ({
   swaggerError: state.swagger.hasErrored,
   officeMove: state.office.officeMove,
+  officeOrders: state.office.officeOrders,
 });
 
 const mapDispatchToProps = dispatch =>
-  bindActionCreators({ loadMove }, dispatch);
+  bindActionCreators({ loadMove, loadOrders }, dispatch);
 
 export default connect(mapStateToProps, mapDispatchToProps)(MoveInfo);

--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -8,7 +8,7 @@ import { RoutedTabs, NavTab } from 'react-router-tabs';
 import { Route, Switch, Redirect } from 'react-router-dom';
 
 import AccountingPanel from './AccountingPanel';
-import { loadMove, loadOrders } from './ducks.js';
+import { loadMoveDependencies } from './ducks.js';
 
 import FontAwesomeIcon from '@fortawesome/react-fontawesome';
 import faPhone from '@fortawesome/fontawesome-free-solid/faPhone';
@@ -307,15 +307,22 @@ const PPMTabContent = () => {
 
 class MoveInfo extends Component {
   componentDidMount() {
-    this.props.loadMove(this.props.match.params.moveId);
+    this.props.loadMoveDependencies(this.props.match.params.moveId);
   }
 
   render() {
+    const officeMove = this.props.officeMove || {};
+    const officeOrders = this.props.officeOrders || {};
+    const officeServiceMember = this.props.officeServiceMember || {};
+
     return (
       <div>
         <div className="usa-grid grid-wide">
           <div className="usa-width-two-thirds Todo">
-            <h1>Move Info: Johnson, Casey</h1>
+            <h1>
+              Move Info: {officeServiceMember.last_name},{' '}
+              {officeServiceMember.first_name}
+            </h1>
           </div>
           <div className="usa-width-one-third nav-controls">
             <NavLink to="/queues/new" activeClassName="usa-current">
@@ -326,9 +333,9 @@ class MoveInfo extends Component {
         <div className="usa-grid grid-wide">
           <div className="usa-width-one-whole Todo">
             <ul className="move-info-header-meta">
-              <li>ID# 3938593893</li>
+              <li>ID# {officeServiceMember.id}</li>
               <li>
-                (303) 936-8181
+                {officeServiceMember.telephone}
                 <FontAwesomeIcon
                   className="icon"
                   icon={faPhone}
@@ -337,7 +344,9 @@ class MoveInfo extends Component {
                 <FontAwesomeIcon className="icon" icon={faComments} />
               </li>
               <li>Locator# ABC89</li>
-              <li>KKFA to HAFC</li>
+              <li>
+                {officeOrders.orders_type} to {officeOrders.new_duty_station_id}
+              </li>
               <li>Requested Pickup 5/10/18</li>
             </ul>
           </div>
@@ -345,7 +354,7 @@ class MoveInfo extends Component {
 
         <div className="usa-grid grid-wide tabs">
           <div className="usa-width-three-fourths">
-            <p>Displaying move {this.props.match.params.moveID}.</p>
+            <p>Displaying move {officeMove.id}.</p>
 
             <RoutedTabs startPathWith={this.props.match.url}>
               <NavTab to="/basics">
@@ -401,17 +410,17 @@ class MoveInfo extends Component {
 }
 
 MoveInfo.propTypes = {
-  loadMove: PropTypes.func.isRequired,
-  loadOrders: PropTypes.func.isRequired,
+  loadMoveDependencies: PropTypes.func.isRequired,
 };
 
 const mapStateToProps = state => ({
   swaggerError: state.swagger.hasErrored,
   officeMove: state.office.officeMove,
   officeOrders: state.office.officeOrders,
+  officeServiceMember: state.office.officeServiceMember,
 });
 
 const mapDispatchToProps = dispatch =>
-  bindActionCreators({ loadMove, loadOrders }, dispatch);
+  bindActionCreators({ loadMoveDependencies }, dispatch);
 
 export default connect(mapStateToProps, mapDispatchToProps)(MoveInfo);

--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -3,6 +3,7 @@ import { NavLink } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
+import { get } from 'lodash';
 
 import { RoutedTabs, NavTab } from 'react-router-tabs';
 import { Route, Switch, Redirect } from 'react-router-dom';
@@ -317,7 +318,7 @@ class MoveInfo extends Component {
     const officeOrders = this.props.officeOrders || {};
     const officeServiceMember = this.props.officeServiceMember || {};
     // const officeBackupContacts = this.props.officeBackupContacts || []
-    // const officePPMs = this.props.officePPMs || []
+    const officePPMs = this.props.officePPMs || [];
 
     if (
       !this.props.loadDependenciesHasSuccess &&
@@ -368,7 +369,9 @@ class MoveInfo extends Component {
               </li>
               <li>Locator# ABC89</li>
               <li>KKFA to HAFC</li>
-              <li>Requested Pickup **{officeOrders.report_by_date}**</li>
+              <li>
+                Requested Pickup {get(officePPMs, '[0].planned_move_date')}
+              </li>
             </ul>
           </div>
         </div>

--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -7,6 +7,8 @@ import { connect } from 'react-redux';
 import { RoutedTabs, NavTab } from 'react-router-tabs';
 import { Route, Switch, Redirect } from 'react-router-dom';
 
+import LoadingPlaceholder from 'shared/LoadingPlaceholder';
+import Alert from 'shared/Alert'; // eslint-disable-line
 import AccountingPanel from './AccountingPanel';
 import { loadMoveDependencies } from './ducks.js';
 
@@ -314,12 +316,28 @@ class MoveInfo extends Component {
     const officeMove = this.props.officeMove || {};
     const officeOrders = this.props.officeOrders || {};
     const officeServiceMember = this.props.officeServiceMember || {};
-    const officeBackupContact = this.props.officeBackupContact || {};
+    // const officeBackupContacts = this.props.officeBackupContacts || []
+    // const officePPMs = this.props.officePPMs || []
 
+    if (
+      !this.props.loadDependenciesHasSuccess &&
+      !this.props.loadDependenciesHasError
+    )
+      return <LoadingPlaceholder />;
+    if (this.props.loadDependenciesHasError)
+      return (
+        <div className="usa-grid">
+          <div className="usa-width-one-whole error-message">
+            <Alert type="error" heading="An error occurred">
+              Something went wrong contacting the server.
+            </Alert>
+          </div>
+        </div>
+      );
     return (
       <div>
         <div className="usa-grid grid-wide">
-          <div className="usa-width-two-thirds Todo">
+          <div className="usa-width-two-thirds">
             <h1>
               Move Info: {officeServiceMember.last_name},{' '}
               {officeServiceMember.first_name}
@@ -337,20 +355,20 @@ class MoveInfo extends Component {
               <li>ID# {officeServiceMember.id}</li>
               <li>
                 {officeServiceMember.telephone}
-                {officeServiceMember && (
+                {officeServiceMember.phone_is_preferred && (
                   <FontAwesomeIcon
                     className="icon"
                     icon={faPhone}
                     flip="horizontal"
                   />
                 )}
-                {officeServiceMember && (
+                {officeServiceMember.text_is_preferred && (
                   <FontAwesomeIcon className="icon" icon={faComments} />
                 )}
               </li>
               <li>Locator# ABC89</li>
-              <li>GBLOC/Channel to GBLOC/Channel</li>
-              <li>Requested Pickup 5/10/18</li>
+              <li>KKFA to HAFC</li>
+              <li>Requested Pickup **{officeOrders.report_by_date}**</li>
             </ul>
           </div>
         </div>
@@ -421,7 +439,10 @@ const mapStateToProps = state => ({
   officeMove: state.office.officeMove,
   officeOrders: state.office.officeOrders,
   officeServiceMember: state.office.officeServiceMember,
-  officeBackupContact: state.office.officeBackupContact,
+  officeBackupContacts: state.office.officeBackupContacts,
+  officePPMs: state.office.officePPMs,
+  loadDependenciesHasSuccess: state.office.loadDependenciesHasSuccess,
+  loadDependenciesHasError: state.office.loadDependenciesHasError,
 });
 
 const mapDispatchToProps = dispatch =>

--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -315,7 +315,8 @@ class MoveInfo extends Component {
   }
 
   render() {
-    const officeMove = this.props.officeMove || {};
+    // TODO: If the following vars are not used to load data, remove them.
+    // const officeMove = this.props.officeMove || {};
     // const officeOrders = this.props.officeOrders || {};
     const officeServiceMember = this.props.officeServiceMember || {};
     // const officeBackupContacts = this.props.officeBackupContacts || []

--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -16,6 +16,7 @@ import { loadMoveDependencies } from './ducks.js';
 import FontAwesomeIcon from '@fortawesome/react-fontawesome';
 import faPhone from '@fortawesome/fontawesome-free-solid/faPhone';
 import faComments from '@fortawesome/fontawesome-free-solid/faComments';
+import faEmail from '@fortawesome/fontawesome-free-solid/faEnvelope';
 import faExclamationTriangle from '@fortawesome/fontawesome-free-solid/faExclamationTriangle';
 import faPlayCircle from '@fortawesome/fontawesome-free-solid/faPlayCircle';
 
@@ -315,7 +316,7 @@ class MoveInfo extends Component {
 
   render() {
     const officeMove = this.props.officeMove || {};
-    const officeOrders = this.props.officeOrders || {};
+    // const officeOrders = this.props.officeOrders || {};
     const officeServiceMember = this.props.officeServiceMember || {};
     // const officeBackupContacts = this.props.officeBackupContacts || []
     const officePPMs = this.props.officePPMs || [];
@@ -351,7 +352,7 @@ class MoveInfo extends Component {
           </div>
         </div>
         <div className="usa-grid grid-wide">
-          <div className="usa-width-one-whole Todo">
+          <div className="usa-width-one-whole">
             <ul className="move-info-header-meta">
               <li>ID# {officeServiceMember.id}</li>
               <li>
@@ -363,11 +364,14 @@ class MoveInfo extends Component {
                     flip="horizontal"
                   />
                 )}
-                {officeServiceMember.text_is_preferred && (
+                {officeServiceMember.text_message_is_preferred && (
                   <FontAwesomeIcon className="icon" icon={faComments} />
                 )}
+                {officeServiceMember.email_is_preferred && (
+                  <FontAwesomeIcon className="icon" icon={faEmail} />
+                )}
               </li>
-              <li>Locator# ABC89</li>
+              <li className="Todo">Locator# ABC89</li>
               <li>KKFA to HAFC</li>
               <li>
                 Requested Pickup {get(officePPMs, '[0].planned_move_date')}
@@ -378,8 +382,6 @@ class MoveInfo extends Component {
 
         <div className="usa-grid grid-wide tabs">
           <div className="usa-width-three-fourths">
-            <p>Displaying move {officeMove.id}.</p>
-
             <RoutedTabs startPathWith={this.props.match.url}>
               <NavTab to="/basics">
                 <span className="title">Basics</span>

--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -314,6 +314,7 @@ class MoveInfo extends Component {
     const officeMove = this.props.officeMove || {};
     const officeOrders = this.props.officeOrders || {};
     const officeServiceMember = this.props.officeServiceMember || {};
+    const officeBackupContact = this.props.officeBackupContact || {};
 
     return (
       <div>
@@ -336,17 +337,19 @@ class MoveInfo extends Component {
               <li>ID# {officeServiceMember.id}</li>
               <li>
                 {officeServiceMember.telephone}
-                <FontAwesomeIcon
-                  className="icon"
-                  icon={faPhone}
-                  flip="horizontal"
-                />
-                <FontAwesomeIcon className="icon" icon={faComments} />
+                {officeServiceMember && (
+                  <FontAwesomeIcon
+                    className="icon"
+                    icon={faPhone}
+                    flip="horizontal"
+                  />
+                )}
+                {officeServiceMember && (
+                  <FontAwesomeIcon className="icon" icon={faComments} />
+                )}
               </li>
               <li>Locator# ABC89</li>
-              <li>
-                {officeOrders.orders_type} to {officeOrders.new_duty_station_id}
-              </li>
+              <li>GBLOC/Channel to GBLOC/Channel</li>
               <li>Requested Pickup 5/10/18</li>
             </ul>
           </div>
@@ -418,6 +421,7 @@ const mapStateToProps = state => ({
   officeMove: state.office.officeMove,
   officeOrders: state.office.officeOrders,
   officeServiceMember: state.office.officeServiceMember,
+  officeBackupContact: state.office.officeBackupContact,
 });
 
 const mapDispatchToProps = dispatch =>

--- a/src/scenes/Office/MoveInfo.test.js
+++ b/src/scenes/Office/MoveInfo.test.js
@@ -1,26 +1,4 @@
 import React from 'react';
-import { shallow } from 'enzyme';
-import { MoveInfo } from '.';
-import Header from 'shared/Header/Office';
-
-describe('MoveInfo tests', () => {
-  let _moveInfo;
-
-  beforeEach(() => {
-    _moveInfo = shallow(<MoveInfo />);
-  });
-
-  it('renders without crashing', () => {
-    const moveInfo = _moveInfo.find('div');
-    expect(moveInfo).toBeDefined;
-  });
-
-  it('renders Header component', () => {
-    expect(_moveInfo.find(Header)).toHaveLength(1);
-  });
-});
-
-import React from 'react';
 import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
 import MoveInfo from './MoveInfo';

--- a/src/scenes/Office/MoveInfo.test.js
+++ b/src/scenes/Office/MoveInfo.test.js
@@ -1,9 +1,10 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
+import MockRouter from 'react-mock-router';
+
 import MoveInfo from './MoveInfo';
 import store from 'shared/store';
-import MockRouter from 'react-mock-router';
 
 const dummyFunc = () => {};
 const moveIsLoading = false;

--- a/src/scenes/Office/MoveInfo.test.js
+++ b/src/scenes/Office/MoveInfo.test.js
@@ -11,14 +11,18 @@ const moveIsLoading = false;
 const ordersAreLoading = false;
 const serviceMemberIsLoading = false;
 const backupContactsAreLoading = false;
-const moveHasLoadError = false;
-const moveHasLoadSuccess = null;
-const ordersHaveLoadError = false;
-const ordersHaveLoadSuccess = null;
-const serviceMemberHasLoadError = false;
-const serviceMemberHasLoadSuccess = null;
-const backupContactsHaveLoadError = false;
-const backupContactsHaveLoadSuccess = null;
+const moveHasLoadError = null;
+const moveHasLoadSuccess = false;
+const ordersHaveLoadError = null;
+const ordersHaveLoadSuccess = false;
+const serviceMemberHasLoadError = null;
+const serviceMemberHasLoadSuccess = false;
+const backupContactsHaveLoadError = null;
+const backupContactsHaveLoadSuccess = false;
+const PPMsHaveLoadError = null;
+const PPMsHaveLoadSuccess = false;
+const loadDependenciesHasError = null;
+const loadDependenciesHasSuccess = false;
 const match = {
   params: { moveID: '123456' },
   url: 'www.nino.com',
@@ -46,6 +50,10 @@ describe('Loads MoveInfo', () => {
             backupContactsAreLoading={backupContactsAreLoading}
             backupContactsHaveLoadError={backupContactsHaveLoadError}
             backupContactsHaveLoadSuccess={backupContactsHaveLoadSuccess}
+            PPMsHaveLoadError={PPMsHaveLoadError}
+            PPMsHaveLoadSuccess={PPMsHaveLoadSuccess}
+            loadDependenciesHasError={loadDependenciesHasError}
+            loadDependenciesHasSuccess={loadDependenciesHasSuccess}
             match={match}
             loadMoveDependencies={dummyFunc}
           />

--- a/src/scenes/Office/MoveInfo.test.js
+++ b/src/scenes/Office/MoveInfo.test.js
@@ -7,8 +7,17 @@ import MockRouter from 'react-mock-router';
 
 const dummyFunc = () => {};
 const moveIsLoading = false;
+const ordersAreLoading = false;
+const serviceMemberIsLoading = false;
+const backupContactsAreLoading = false;
 const moveHasLoadError = false;
 const moveHasLoadSuccess = null;
+const ordersHaveLoadError = false;
+const ordersHaveLoadSuccess = null;
+const serviceMemberHasLoadError = false;
+const serviceMemberHasLoadSuccess = null;
+const backupContactsHaveLoadError = false;
+const backupContactsHaveLoadSuccess = null;
 const match = {
   params: { moveID: '123456' },
   url: 'www.nino.com',
@@ -26,8 +35,17 @@ it('renders without crashing', () => {
           moveIsLoading={moveIsLoading}
           moveHasLoadError={moveHasLoadError}
           moveHasLoadSuccess={moveHasLoadSuccess}
+          serviceMemberIsLoading={serviceMemberIsLoading}
+          serviceMemberHasLoadError={serviceMemberHasLoadError}
+          serviceMemberHasLoadSuccess={serviceMemberHasLoadSuccess}
+          ordersAreLoading={ordersAreLoading}
+          ordersHaveLoadError={ordersHaveLoadError}
+          ordersHaveLoadSuccess={ordersHaveLoadSuccess}
+          backupContactsAreLoading={backupContactsAreLoading}
+          backupContactsHaveLoadError={backupContactsHaveLoadError}
+          backupContactsHaveLoadSuccess={backupContactsHaveLoadSuccess}
           match={match}
-          loadMove={dummyFunc}
+          loadMoveDependencies={dummyFunc}
         />
       </MockRouter>
     </Provider>,

--- a/src/scenes/Office/MoveInfo.test.js
+++ b/src/scenes/Office/MoveInfo.test.js
@@ -26,29 +26,31 @@ const match = {
 
 const push = jest.fn();
 
-it('renders without crashing', () => {
-  const div = document.createElement('div');
-  ReactDOM.render(
-    <Provider store={store}>
-      <MockRouter push={push}>
-        <MoveInfo
-          moveIsLoading={moveIsLoading}
-          moveHasLoadError={moveHasLoadError}
-          moveHasLoadSuccess={moveHasLoadSuccess}
-          serviceMemberIsLoading={serviceMemberIsLoading}
-          serviceMemberHasLoadError={serviceMemberHasLoadError}
-          serviceMemberHasLoadSuccess={serviceMemberHasLoadSuccess}
-          ordersAreLoading={ordersAreLoading}
-          ordersHaveLoadError={ordersHaveLoadError}
-          ordersHaveLoadSuccess={ordersHaveLoadSuccess}
-          backupContactsAreLoading={backupContactsAreLoading}
-          backupContactsHaveLoadError={backupContactsHaveLoadError}
-          backupContactsHaveLoadSuccess={backupContactsHaveLoadSuccess}
-          match={match}
-          loadMoveDependencies={dummyFunc}
-        />
-      </MockRouter>
-    </Provider>,
-    div,
-  );
+describe('Loads MoveInfo', () => {
+  it('renders without crashing', () => {
+    const div = document.createElement('div');
+    ReactDOM.render(
+      <Provider store={store}>
+        <MockRouter push={push}>
+          <MoveInfo
+            moveIsLoading={moveIsLoading}
+            moveHasLoadError={moveHasLoadError}
+            moveHasLoadSuccess={moveHasLoadSuccess}
+            serviceMemberIsLoading={serviceMemberIsLoading}
+            serviceMemberHasLoadError={serviceMemberHasLoadError}
+            serviceMemberHasLoadSuccess={serviceMemberHasLoadSuccess}
+            ordersAreLoading={ordersAreLoading}
+            ordersHaveLoadError={ordersHaveLoadError}
+            ordersHaveLoadSuccess={ordersHaveLoadSuccess}
+            backupContactsAreLoading={backupContactsAreLoading}
+            backupContactsHaveLoadError={backupContactsHaveLoadError}
+            backupContactsHaveLoadSuccess={backupContactsHaveLoadSuccess}
+            match={match}
+            loadMoveDependencies={dummyFunc}
+          />
+        </MockRouter>
+      </Provider>,
+      div,
+    );
+  });
 });

--- a/src/scenes/Office/api.js
+++ b/src/scenes/Office/api.js
@@ -5,6 +5,7 @@ export async function GetSpec() {
   return client.spec;
 }
 
+// MOVE QUEUE
 export async function RetrieveMovesForOffice(queueType) {
   const client = await getClient();
   const response = await client.apis.queues.showQueue({
@@ -14,6 +15,7 @@ export async function RetrieveMovesForOffice(queueType) {
   return response.body;
 }
 
+// ACCOUNTING
 export async function LoadAccountingAPI(moveId) {
   const client = await getClient();
   const response = await client.apis.office.showAccounting({
@@ -39,11 +41,22 @@ export async function UpdateAccountingAPI(moveId, payload) {
   return response.body;
 }
 
+// MOVE
 export async function LoadMove(moveId) {
   const client = await getClient();
   const response = await client.apis.moves.showMove({
     moveId,
   });
   checkResponse(response, 'failed to load move due to server error');
+  return LoadOrders(response.body.orders_id);
+}
+
+// ORDERS
+export async function LoadOrders(ordersId) {
+  const client = await getClient();
+  const response = await client.apis.orders.showOrders({
+    ordersId,
+  });
+  checkResponse(response, 'failed to load orders due to server error');
   return response.body;
 }

--- a/src/scenes/Office/api.js
+++ b/src/scenes/Office/api.js
@@ -67,6 +67,18 @@ export async function LoadServiceMember(serviceMemberId) {
   const response = await client.apis.service_members.showServiceMember({
     serviceMemberId,
   });
-  checkResponse(response, 'failed to load orders due to server error');
+  checkResponse(response, 'failed to load service member due to server error');
+  return response.body;
+}
+
+// BACKUP CONTACT
+export async function LoadBackupContacts(serviceMemberId) {
+  const client = await getClient();
+  const response = await client.apis.backup_contacts.indexServiceMemberBackupContacts(
+    {
+      serviceMemberId,
+    },
+  );
+  checkResponse(response, 'failed to load backup contacts due to server error');
   return response.body;
 }

--- a/src/scenes/Office/api.js
+++ b/src/scenes/Office/api.js
@@ -48,7 +48,7 @@ export async function LoadMove(moveId) {
     moveId,
   });
   checkResponse(response, 'failed to load move due to server error');
-  return LoadOrders(response.body.orders_id);
+  return response.body;
 }
 
 // ORDERS
@@ -56,6 +56,16 @@ export async function LoadOrders(ordersId) {
   const client = await getClient();
   const response = await client.apis.orders.showOrders({
     ordersId,
+  });
+  checkResponse(response, 'failed to load orders due to server error');
+  return response.body;
+}
+
+// SERVICE MEMBER
+export async function LoadServiceMember(serviceMemberId) {
+  const client = await getClient();
+  const response = await client.apis.service_members.showServiceMember({
+    serviceMemberId,
   });
   checkResponse(response, 'failed to load orders due to server error');
   return response.body;

--- a/src/scenes/Office/api.js
+++ b/src/scenes/Office/api.js
@@ -1,10 +1,5 @@
 import { getClient, checkResponse } from 'shared/api';
 
-export async function GetSpec() {
-  const client = await getClient();
-  return client.spec;
-}
-
 // MOVE QUEUE
 export async function RetrieveMovesForOffice(queueType) {
   const client = await getClient();
@@ -80,5 +75,15 @@ export async function LoadBackupContacts(serviceMemberId) {
     },
   );
   checkResponse(response, 'failed to load backup contacts due to server error');
+  return response.body;
+}
+
+// PPM
+export async function LoadPPMs(moveId) {
+  const client = await getClient();
+  const response = await client.apis.ppm.indexPersonallyProcuredMoves({
+    moveId,
+  });
+  checkResponse(response, 'failed to load PPMs due to server error');
   return response.body;
 }

--- a/src/scenes/Office/ducks.js
+++ b/src/scenes/Office/ducks.js
@@ -92,6 +92,7 @@ export function loadMoveDependencies(moveId) {
       await dispatch(loadServiceMember(orders.service_member_id));
       const sm = getState().office.officeServiceMember;
       await dispatch(loadBackupContacts(sm.id));
+      // TODO: load PPMs in parallel to move using moveId
       await dispatch(loadPPMs(moveId));
       return dispatch(actions.success());
     } catch (ex) {

--- a/src/scenes/Office/ducks.js
+++ b/src/scenes/Office/ducks.js
@@ -34,14 +34,14 @@ export const updateAccounting = ReduxHelpers.generateAsyncActionCreator(
   UpdateAccountingAPI,
 );
 
-export const loadMove = ReduxHelpers.generateAsyncActionCreator(
-  loadMoveType,
-  LoadMove,
-);
-
 export const loadOrders = ReduxHelpers.generateAsyncActionCreator(
   loadOrdersType,
   LoadOrders,
+);
+
+export const loadMove = ReduxHelpers.generateOtherAsyncActionCreatorDispatch(
+  loadMoveType,
+  loadOrders,
 );
 
 // Reducer

--- a/src/scenes/Office/ducks.js
+++ b/src/scenes/Office/ducks.js
@@ -1,10 +1,16 @@
-import { LoadAccountingAPI, UpdateAccountingAPI, LoadMove } from './api.js';
+import {
+  LoadAccountingAPI,
+  UpdateAccountingAPI,
+  LoadMove,
+  LoadOrders,
+} from './api.js';
 import * as ReduxHelpers from 'shared/ReduxHelpers';
 
 // Types
 const loadAccountingType = 'LOAD_ACCOUNTING';
 const updateAccountingType = 'UPDATE_ACCOUNTING';
 const loadMoveType = 'LOAD_MOVE';
+const loadOrdersType = 'LOAD_ORDERS';
 
 const LOAD_ACCOUNTING = ReduxHelpers.generateAsyncActionTypes(
   loadAccountingType,
@@ -15,6 +21,8 @@ const UPDATE_ACCOUNTING = ReduxHelpers.generateAsyncActionTypes(
 );
 
 const LOAD_MOVE = ReduxHelpers.generateAsyncActionTypes(loadMoveType);
+
+const LOAD_ORDERS = ReduxHelpers.generateAsyncActionTypes(loadOrdersType);
 
 export const loadAccounting = ReduxHelpers.generateAsyncActionCreator(
   loadAccountingType,
@@ -31,17 +39,25 @@ export const loadMove = ReduxHelpers.generateAsyncActionCreator(
   LoadMove,
 );
 
+export const loadOrders = ReduxHelpers.generateAsyncActionCreator(
+  loadOrdersType,
+  LoadOrders,
+);
+
 // Reducer
 const initialState = {
   accountingIsLoading: false,
   accountingIsUpdating: false,
   moveIsLoading: false,
+  ordersAreLoading: false,
   accountingHasLoadError: false,
   accountingHasLoadSuccess: null,
   accountingHasUpdateError: false,
   accountingHasUpdateSuccess: null,
   moveHasLoadError: false,
   moveHasLoadSuccess: null,
+  ordersHaveLoadError: false,
+  ordersHaveLoadSuccess: null,
 };
 
 export function officeReducer(state = initialState, action) {
@@ -86,6 +102,8 @@ export function officeReducer(state = initialState, action) {
         accountingHasUpdateError: true,
         error: action.error.message,
       });
+
+    // Moves
     case LOAD_MOVE.start:
       return Object.assign({}, state, {
         moveIsLoading: true,
@@ -104,6 +122,28 @@ export function officeReducer(state = initialState, action) {
         officeMove: null,
         moveHasLoadSuccess: false,
         moveHasLoadError: true,
+        error: action.error.message,
+      });
+
+    // ORDERS
+    case LOAD_ORDERS.start:
+      return Object.assign({}, state, {
+        ordersAreLoading: true,
+        ordersHaveLoadSuccess: false,
+      });
+    case LOAD_ORDERS.success:
+      return Object.assign({}, state, {
+        ordersAreLoading: false,
+        officeOrders: action.payload,
+        ordersHaveLoadSuccess: true,
+        ordersHaveLoadError: false,
+      });
+    case LOAD_ORDERS.failure:
+      return Object.assign({}, state, {
+        ordersAreLoading: false,
+        officeOrders: null,
+        ordersHaveLoadSuccess: false,
+        ordersHaveLoadError: true,
         error: action.error.message,
       });
     default:

--- a/src/shared/ReduxHelpers/index.js
+++ b/src/shared/ReduxHelpers/index.js
@@ -58,26 +58,9 @@ export function generateAsyncActionCreator(resourceName, asyncAction) {
   return function actionCreator(...args) {
     return function(dispatch) {
       dispatch(actions.start());
-      asyncAction(...args)
+      return asyncAction(...args)
         .then(item => dispatch(actions.success(item)))
         .catch(error => dispatch(actions.error(error)));
-    };
-  };
-}
-
-/**
- *  This dispatches a different action creator.
- * @param {*} resourceName the name of the resource included in the action type descriptions (for start, success, failure)
- * @param {*} otherActionName is the name of the   the async action that is wrapped by this action creator
- */
-export function generateOtherAsyncActionCreatorDispatch(
-  resourceName,
-  otherAction,
-) {
-  const actions = generateAsyncActions(resourceName);
-  return function actionCreator(...args) {
-    return function(dispatch) {
-      dispatch(otherAction());
     };
   };
 }

--- a/src/shared/ReduxHelpers/index.js
+++ b/src/shared/ReduxHelpers/index.js
@@ -66,6 +66,23 @@ export function generateAsyncActionCreator(resourceName, asyncAction) {
 }
 
 /**
+ *  This dispatches a different action creator.
+ * @param {*} resourceName the name of the resource included in the action type descriptions (for start, success, failure)
+ * @param {*} otherActionName is the name of the   the async action that is wrapped by this action creator
+ */
+export function generateOtherAsyncActionCreatorDispatch(
+  resourceName,
+  otherAction,
+) {
+  const actions = generateAsyncActions(resourceName);
+  return function actionCreator(...args) {
+    return function(dispatch) {
+      dispatch(otherAction());
+    };
+  };
+}
+
+/**
  * This produces a reducer for the provided resourceName
  * @param {*} resourceName the name of the resource the actions should be filtered by
  * @param {*} onSuccess a transform that is called on the payload of a successful action


### PR DESCRIPTION
## Description

This PR loads PPMs, Orders, Service member, and backup contacts into react store using the move id to start the series of loads. The only code that is novel is the function in `office/ducks` called `loadMoveDependencies`, which is responsible for loading one of objects after the other before returning. It will catch errors and fail should any one fail to load. 
This PR also replaces some hard coded data with data from the redux store. 
It shows a loading placeholder until all the above data is loaded into store.

## Reviewer Notes

Once the [load moves PR](https://github.com/transcom/mymove/pull/498) is landed, this will look a lot more manageable. (DONE)
Do I need to write a test for `loadMoveDependencies`? ANSWERED, NO

## Code Review Verification Steps

* [x] All tests pass.
* [x] There are no [aXe](https://www.deque.com/products/aXe/) warnings for UI.
* [x] This works in IE.
* [x] Request review from a member of a different team.
* [x] (TRIAL) Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/157526782) for this change
<img width="1414" alt="screen shot 2018-05-14 at 3 49 52 pm" src="https://user-images.githubusercontent.com/7401870/40027353-80f00564-578e-11e8-8c49-98f577fc564b.png">
