### PR TITLE
Add show document endpoint [delivers #157546552]

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -468,12 +468,6 @@
   version = "v1.0.0"
 
 [[projects]]
-  name = "github.com/satori/go.uuid"
-  packages = ["."]
-  revision = "f58768cc1a7a7e77a3bd49e98cdd21419399b6a3"
-  version = "v1.2.0"
-
-[[projects]]
   name = "github.com/segmentio/chamber"
   packages = [
     ".",
@@ -707,6 +701,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "8cb7046c4c3c794717c8ece9c6aeea5ad26443847455a6122f3e7aaac5c60c44"
+  inputs-digest = "5df2463d040fc676f69d25224e87ec13fab2487760e8214e53c49aae6c56e40b"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/pkg/handlers/documents.go
+++ b/pkg/handlers/documents.go
@@ -76,6 +76,32 @@ func (h CreateDocumentHandler) Handle(params documentop.CreateDocumentParams) mi
 	return documentop.NewCreateDocumentCreated().WithPayload(documentPayload)
 }
 
+// ShowDocumentHandler shows a document via GETT /documents/:document_id
+type ShowDocumentHandler HandlerContext
+
+// Handle creates a new Document from a request payload
+func (h ShowDocumentHandler) Handle(params documentop.ShowDocumentParams) middleware.Responder {
+	// User should always be populated by middleware
+	user, _ := auth.GetUser(params.HTTPRequest.Context())
+
+	documentID, err := uuid.FromString(params.DocumentID.String())
+	if err != nil {
+		return responseForError(h.logger, err)
+	}
+
+	document, err := models.FetchDocument(h.db, user, documentID)
+	if err != nil {
+		return responseForError(h.logger, err)
+	}
+
+	documentPayload, err := payloadForDocumentModel(h.storage, document)
+	if err != nil {
+		return responseForError(h.logger, err)
+	}
+
+	return documentop.NewShowDocumentOK().WithPayload(documentPayload)
+}
+
 /* NOTE - The code above is for the INTERNAL API. The code below is for the public API. These will, obviously,
 need to be reconciled. This will be done when the NotImplemented code below is Implemented
 */

--- a/pkg/handlers/handlers.go
+++ b/pkg/handlers/handlers.go
@@ -117,7 +117,7 @@ func NewInternalAPIHandler(context HandlerContext) http.Handler {
 	internalAPI.BackupContactsShowServiceMemberBackupContactHandler = ShowBackupContactHandler(context)
 
 	internalAPI.DocumentsCreateDocumentHandler = CreateDocumentHandler(context)
-
+	internalAPI.DocumentsShowDocumentHandler = ShowDocumentHandler(context)
 	internalAPI.UploadsCreateUploadHandler = CreateUploadHandler(context)
 	internalAPI.UploadsDeleteUploadHandler = DeleteUploadHandler(context)
 

--- a/pkg/handlers/uploads.go
+++ b/pkg/handlers/uploads.go
@@ -20,12 +20,13 @@ import (
 
 func payloadForUploadModel(upload models.Upload, url string) *internalmessages.UploadPayload {
 	return &internalmessages.UploadPayload{
-		ID:        fmtUUID(upload.ID),
-		Filename:  swag.String(upload.Filename),
-		URL:       fmtURI(url),
-		Bytes:     &upload.Bytes,
-		CreatedAt: fmtDateTime(upload.CreatedAt),
-		UpdatedAt: fmtDateTime(upload.UpdatedAt),
+		ID:          fmtUUID(upload.ID),
+		Filename:    swag.String(upload.Filename),
+		ContentType: swag.String(upload.ContentType),
+		URL:         fmtURI(url),
+		Bytes:       &upload.Bytes,
+		CreatedAt:   fmtDateTime(upload.CreatedAt),
+		UpdatedAt:   fmtDateTime(upload.UpdatedAt),
 	}
 }
 

--- a/pkg/handlers/uploads_test.go
+++ b/pkg/handlers/uploads_test.go
@@ -67,7 +67,7 @@ func (fake *fakeS3Storage) Store(key string, data io.ReadSeeker, md5 string) (*s
 }
 
 func (fake *fakeS3Storage) PresignedURL(key string, contentType string) (string, error) {
-	url := fmt.Sprintf("https://example.com/dir/%s?contentType=%%2F%s", key, contentType)
+	url := fmt.Sprintf("https://example.com/dir/%s?contentType=%s&signed=test", key, contentType)
 	return url, nil
 }
 

--- a/pkg/testdatagen/make_upload.go
+++ b/pkg/testdatagen/make_upload.go
@@ -18,15 +18,9 @@ func MakeUpload(db *pop.Connection, document *models.Document) (models.Upload, e
 		document = &newDocument
 	}
 
-	var serviceMember models.ServiceMember
-	err := db.Find(&serviceMember, document.ServiceMemberID)
-	if err != nil {
-		log.Panic(err)
-	}
-
 	upload := models.Upload{
 		DocumentID:  document.ID,
-		UploaderID:  serviceMember.UserID,
+		UploaderID:  document.ServiceMember.UserID,
 		Filename:    "testFile.pdf",
 		Bytes:       2202009,
 		ContentType: "application/pdf",

--- a/pkg/testdatagen/make_upload.go
+++ b/pkg/testdatagen/make_upload.go
@@ -8,7 +8,7 @@ import (
 	"github.com/transcom/mymove/pkg/models"
 )
 
-// MakeUpload creates a single User.
+// MakeUpload creates a single Upload.
 func MakeUpload(db *pop.Connection, document *models.Document) (models.Upload, error) {
 	if document == nil {
 		newDocument, err := MakeDocument(db, nil, "")
@@ -18,9 +18,15 @@ func MakeUpload(db *pop.Connection, document *models.Document) (models.Upload, e
 		document = &newDocument
 	}
 
+	var serviceMember models.ServiceMember
+	err := db.Find(&serviceMember, document.ServiceMemberID)
+	if err != nil {
+		log.Panic(err)
+	}
+
 	upload := models.Upload{
 		DocumentID:  document.ID,
-		UploaderID:  document.ServiceMemberID,
+		UploaderID:  serviceMember.UserID,
 		Filename:    "testFile.pdf",
 		Bytes:       2202009,
 		ContentType: "application/pdf",

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -2067,6 +2067,35 @@ paths:
           description: invalid request
         500:
           description: server error
+  /documents/{documentId}:
+    get:
+      summary: Returns a document
+      description: Returns a document and its uploads
+      operationId: showDocument
+      tags:
+        - documents
+      parameters:
+        - in: path
+          name: documentId
+          type: string
+          format: uuid
+          required: true
+          description: UUID of the document to return
+      responses:
+        200:
+          description: the requested document
+          schema:
+            $ref: '#/definitions/DocumentPayload'
+        400:
+          description: invalid request
+          schema:
+            $ref: '#/definitions/InvalidRequestResponsePayload'
+        403:
+          description: not authorized
+        404:
+          description: not found
+        500:
+          description: server error
   /documents/{documentId}/uploads:
     post:
       summary: Create a new upload

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -792,6 +792,10 @@ definitions:
         type: string
         format: string
         example: filename.pdf
+      content_type:
+        type: string
+        format: mime-type
+        example: application/pdf
       bytes:
         type: integer
       created_at:
@@ -804,6 +808,7 @@ definitions:
       - id
       - url
       - filename
+      - content_type
       - bytes
       - created_at
       - updated_at


### PR DESCRIPTION
## Description

This PR adds an endpoint, including Swagger definition and handler, for the retrieval of a document and its uploads. The data returned by this endpoint will ultimately be used by the orders screen to display the orders.

## Code Review Verification Steps

* [ ] All tests pass.
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/157546552) for this change