### PR TITLE
Support prod hostnames not using 'prod'.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,6 +153,7 @@ jobs:
       - image: trussworks/circleci-docker-primary:4bb9cacfdfa1fbc995e89204f030264843f5bc91
     environment:
       - APP_ENVIRONMENT: "staging"
+      - APP_REDIRECT_HEALTH_CHECK_URL: "http://my.staging.dp3.us/"
     steps: &deploy_app_redirect_steps
       - checkout
       - setup_remote_docker
@@ -161,7 +162,7 @@ jobs:
           command: bin/ecs-deploy-service-container app-redirect config/app-redirect.container-definition.json ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/https-redirect $APP_ENVIRONMENT FARGATE
       - run:
           name: Health check https redirect
-          command: for retry in `seq 1 10`; do if [[ $(curl -f -sS -o /dev/null -w '%{http_code}' http://my.experimental.dp3.us) -eq 301 ]]; then echo Passed.; exit 0; else sleep $(($retry*3)); fi; done; exit 1
+          command: for retry in `seq 1 10`; do if [[ $(curl -f -sS -o /dev/null -w '%{http_code}' $APP_REDIRECT_HEALTH_CHECK_URL) -eq 301 ]]; then echo Passed.; exit 0; else sleep $(($retry*3)); fi; done; exit 1
       - run: *announce_failure
 
   deploy_staging_app:
@@ -169,6 +170,7 @@ jobs:
       - image: trussworks/circleci-docker-primary:4bb9cacfdfa1fbc995e89204f030264843f5bc91
     environment:
       - APP_ENVIRONMENT: "staging"
+      - APP_HEALTH_CHECK_URL: "https://my.staging.dp3.us/health"
     steps: &deploy_app_steps
       - checkout
       - setup_remote_docker
@@ -177,7 +179,7 @@ jobs:
           command: bin/ecs-deploy-service-container app config/app.container-definition.json ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/app:git-${CIRCLE_SHA1} $APP_ENVIRONMENT
       - run:
           name: Health check app site
-          command: for retry in `seq 1 10`; do if curl -f -sS -o /dev/null https://my.staging.dp3.us; then echo Passed.; exit 0; else sleep $(($retry*3)); fi; done; exit 1
+          command: for retry in `seq 1 10`; do if curl -f -sS -o /dev/null $APP_HEALTH_CHECK_URL; then echo Passed.; exit 0; else sleep $(($retry*3)); fi; done; exit 1
       - run: *announce_failure
 
   deploy_prod_migrations:
@@ -192,6 +194,7 @@ jobs:
       - image: trussworks/circleci-docker-primary:4bb9cacfdfa1fbc995e89204f030264843f5bc91
     environment:
       - APP_ENVIRONMENT: "prod"
+      - APP_REDIRECT_HEALTH_CHECK_URL: "http://my.dp3.us/"
     steps: *deploy_app_redirect_steps
 
   deploy_prod_app:
@@ -199,6 +202,7 @@ jobs:
       - image: trussworks/circleci-docker-primary:4bb9cacfdfa1fbc995e89204f030264843f5bc91
     environment:
       - APP_ENVIRONMENT: "prod"
+      - APP_HEALTH_CHECK_URL: "https://my.dp3.us/health"
     steps: *deploy_app_steps
 
   integration_tests:

--- a/bin/ecs-deploy-service-container
+++ b/bin/ecs-deploy-service-container
@@ -32,6 +32,9 @@ readonly rds=app-${environment}
 readonly task_family=${name}-${environment}
 readonly container_name=${name}-${environment}
 
+# TODO: Change to move.mil when it's transferred to our infrastructure.
+readonly zone_name="dp3.us"
+
 
 check_arn() {
     local arn=$1
@@ -58,6 +61,11 @@ update_service() {
     return $exit_code
 }
 
+# use environment subdomain unless we're deploying prod
+domain=${environment}.${zone_name}
+[[ $environment = prod ]] && domain=$zone_name
+readonly domain
+
 # get current task definiton (for rollback)
 blue_task_def_arn=$(aws ecs describe-services --services "$name" --cluster "$cluster" --query 'services[0].taskDefinition' | jq -r .)
 
@@ -67,7 +75,7 @@ db_host=$(aws rds describe-db-instances --db-instance-identifier "$rds" --query 
 readonly db_host
 
 # create the container definition from the json template
-container_definition_json=$(perl -pe "s|{{environment}}|$environment|g; s|{{image}}|$image|g; s|{{db_host}}|$db_host|g;" "$template")
+container_definition_json=$(perl -pe "s|{{db_host}}|$db_host|g; s|{{domain}}|$domain|g; s|{{environment}}|$environment|g; s|{{image}}|$image|g;" "$template")
 readonly container_definition_json
 
 # create new task definition with the given image

--- a/config/app.container-definition.json
+++ b/config/app.container-definition.json
@@ -54,11 +54,11 @@
     },
     {
       "name": "HTTP_MY_SERVER_NAME",
-      "value": "my.{{environment}}.dp3.us"
+      "value": "my.{{domain}}"
     },
     {
       "name": "HTTP_OFFICE_SERVER_NAME",
-      "value": "office.{{environment}}.dp3.us"
+      "value": "office.{{domain}}"
     },
     {
       "name": "AWS_S3_BUCKET_NAME",


### PR DESCRIPTION
## Description

This creates a new container template variable `domain` and removes the hard-coded assumption that all environments (including "prod") would be `{{environment}}.dp3.us`. This makes it so we can have the prod site drop the "prod" subdomain.

This depends on transcom/ppp-infra#205 landing right before merge.

## Code Review Verification Steps

* [x] All tests pass.
* [x] Request review from a member of a different team.

## References

* [#157379383 ](https://www.pivotaltracker.com/story/show/157379383) – Update app deploy to use environment-less dp3.us hostnames for prod
