### PR TITLE
Wrap non-accounting info in panels [delivers #157541731]

### DIFF
--- a/src/scenes/Office/AccountingPanel.jsx
+++ b/src/scenes/Office/AccountingPanel.jsx
@@ -1,15 +1,14 @@
 import { get, pick } from 'lodash';
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
+import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { reduxForm } from 'redux-form';
+import editablePanel from './editablePanel';
 
-import { updateAccounting, loadAccounting } from './ducks';
+import { updateAccounting } from './ducks';
 
 import { SwaggerField } from 'shared/JsonSchemaForm/JsonSchemaField';
-import Alert from 'shared/Alert';
-import { EditablePanel, PanelField } from 'shared/EditablePanel';
+import { PanelField } from 'shared/EditablePanel';
 
 const AccountingDisplay = props => {
   const fieldProps = pick(props, ['schema', 'values']);
@@ -39,68 +38,6 @@ const AccountingEdit = props => {
   );
 };
 
-function editablePanel(DisplayComponent, EditComponent) {
-  let Wrapper = class extends Component {
-    constructor(props) {
-      super(props);
-      this.state = {
-        isEditable: false,
-      };
-    }
-
-    componentDidMount() {
-      this.props.load(this.props.moveId);
-    }
-
-    save = () => {
-      this.props.update(this.props.moveId, this.props.formData.values);
-      this.toggleEditable();
-    };
-
-    toggleEditable = () => {
-      this.setState({
-        isEditable: !this.state.isEditable,
-      });
-    };
-
-    render() {
-      const isEditable = this.state.isEditable || this.props.isUpdating;
-      const Content = isEditable ? EditComponent : DisplayComponent;
-
-      return (
-        <React.Fragment>
-          {this.props.hasError && (
-            <Alert type="error" heading="An error occurred">
-              There was an error: <em>{this.props.errorMessage}</em>.
-            </Alert>
-          )}
-          <EditablePanel
-            title="Accounting"
-            onSave={this.save}
-            onToggle={this.toggleEditable}
-            isEditable={isEditable}
-          >
-            <Content
-              values={this.props.displayValues}
-              schema={this.props.schema}
-            />
-          </EditablePanel>
-        </React.Fragment>
-      );
-    }
-  };
-
-  Wrapper.propTypes = {
-    schema: PropTypes.object.isRequired,
-    displayValues: PropTypes.object.isRequired,
-    load: PropTypes.func.isRequired,
-    update: PropTypes.func.isRequired,
-    moveId: PropTypes.string.isRequired,
-  };
-
-  return Wrapper;
-}
-
 const formName = 'office_move_info_accounting';
 
 let AccountingPanel = editablePanel(AccountingDisplay, AccountingEdit);
@@ -127,7 +64,6 @@ function mapDispatchToProps(dispatch) {
   return bindActionCreators(
     {
       update: updateAccounting,
-      load: loadAccounting,
     },
     dispatch,
   );

--- a/src/scenes/Office/AccountingPanel.jsx
+++ b/src/scenes/Office/AccountingPanel.jsx
@@ -1,4 +1,4 @@
-import { get } from 'lodash';
+import { get, pick } from 'lodash';
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
@@ -12,14 +12,14 @@ import Alert from 'shared/Alert';
 import { EditablePanel, PanelField } from 'shared/EditablePanel';
 
 const AccountingDisplay = props => {
-  const { values } = props;
+  const fieldProps = pick(props, ['schema', 'values']);
   return (
     <React.Fragment>
       <div className="editable-panel-column">
-        <PanelField title="Dept. indicator" value={values.dept_indicator} />
+        <PanelField fieldName="dept_indicator" {...fieldProps} />
       </div>
       <div className="editable-panel-column">
-        <PanelField title="TAC" value={values.tac} />
+        <PanelField fieldName="tac" {...fieldProps} />
       </div>
     </React.Fragment>
   );
@@ -114,10 +114,11 @@ function mapStateToProps(state) {
     // Wrapper
     schema: get(state, 'swagger.spec.definitions.PatchAccounting', {}),
     hasError:
-      state.office.accountingHasLoadError || state.office.hasUpdateError,
+      state.office.accountingHasLoadError ||
+      state.office.accountingHasUpdateError,
     errorMessage: state.office.error,
     displayValues: state.office.accounting || {},
-    isUpdating: state.isUpdating,
+    isUpdating: state.office.accountingIsUpdating,
   };
 }
 

--- a/src/scenes/Office/AccountingPanel.jsx
+++ b/src/scenes/Office/AccountingPanel.jsx
@@ -64,7 +64,8 @@ function editablePanel(DisplayComponent, EditComponent) {
     };
 
     render() {
-      const Content = this.state.isEditable ? EditComponent : DisplayComponent;
+      const isEditable = this.state.isEditable || this.props.isUpdating;
+      const Content = isEditable ? EditComponent : DisplayComponent;
 
       return (
         <React.Fragment>
@@ -76,8 +77,8 @@ function editablePanel(DisplayComponent, EditComponent) {
           <EditablePanel
             title="Accounting"
             onSave={this.save}
-            toggleEditable={this.toggleEditable}
-            isEditable={this.state.isEditable || this.props.isUpdating}
+            onToggle={this.toggleEditable}
+            isEditable={isEditable}
           >
             <Content
               values={this.props.displayValues}

--- a/src/scenes/Office/AccountingPanel.jsx
+++ b/src/scenes/Office/AccountingPanel.jsx
@@ -20,106 +20,121 @@ const PanelField = props => {
   );
 };
 
-class AccountingPanel extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      isEditable: false,
-    };
-  }
-
-  componentDidMount() {
-    this.props.loadAccounting(this.props.moveId);
-  }
-
-  save = () => {
-    this.props.updateAccounting(this.props.moveId, this.props.formData.values);
-    this.toggleEditable();
-  };
-
-  toggleEditable = () => {
-    this.setState({
-      isEditable: !this.state.isEditable,
-    });
-  };
-
-  render() {
-    const displayContent = () => {
-      const values = this.props.accounting || {};
-      return (
-        <React.Fragment>
-          <div className="editable-panel-column">
-            <PanelField title="Dept. indicator" value={values.dept_indicator} />
-          </div>
-          <div className="editable-panel-column">
-            <PanelField title="TAC" value={values.tac} />
-          </div>
-        </React.Fragment>
-      );
-    };
-
-    const editableContent = () => {
-      const { schema } = this.props;
-      return (
-        <React.Fragment>
-          <div className="editable-panel-column">
-            <SwaggerField
-              fieldName="dept_indicator"
-              swagger={schema}
-              required
-            />
-          </div>
-          <div className="editable-panel-column">
-            <SwaggerField fieldName="tac" swagger={schema} required />
-          </div>
-        </React.Fragment>
-      );
-    };
-
-    return (
-      <React.Fragment>
-        {this.props.hasError && (
-          <Alert type="error" heading="An error occurred">
-            There was an error: <em>{this.props.errorMessage}</em>.
-          </Alert>
-        )}
-        <EditablePanel
-          title="Accounting"
-          editableContent={editableContent}
-          displayContent={displayContent}
-          onSave={this.save}
-          toggleEditable={this.toggleEditable}
-          isEditable={this.state.isEditable || this.props.isUpdating}
-        />
-      </React.Fragment>
-    );
-  }
-}
-
-AccountingPanel.propTypes = {
-  schema: PropTypes.object.isRequired,
-  moveId: PropTypes.string.isRequired,
+const AccountingDisplay = props => {
+  const { values } = props;
+  return (
+    <React.Fragment>
+      <div className="editable-panel-column">
+        <PanelField title="Dept. indicator" value={values.dept_indicator} />
+      </div>
+      <div className="editable-panel-column">
+        <PanelField title="TAC" value={values.tac} />
+      </div>
+    </React.Fragment>
+  );
 };
 
+const AccountingEdit = props => {
+  const { schema } = props;
+  return (
+    <React.Fragment>
+      <div className="editable-panel-column">
+        <SwaggerField fieldName="dept_indicator" swagger={schema} required />
+      </div>
+      <div className="editable-panel-column">
+        <SwaggerField fieldName="tac" swagger={schema} required />
+      </div>
+    </React.Fragment>
+  );
+};
+
+function editablePanel(DisplayComponent, EditComponent) {
+  let Wrapper = class extends Component {
+    constructor(props) {
+      super(props);
+      this.state = {
+        isEditable: false,
+      };
+    }
+
+    componentDidMount() {
+      this.props.load(this.props.moveId);
+    }
+
+    save = () => {
+      this.props.update(this.props.moveId, this.props.formData.values);
+      this.toggleEditable();
+    };
+
+    toggleEditable = () => {
+      this.setState({
+        isEditable: !this.state.isEditable,
+      });
+    };
+
+    render() {
+      const Content = this.state.isEditable ? EditComponent : DisplayComponent;
+
+      return (
+        <React.Fragment>
+          {this.props.hasError && (
+            <Alert type="error" heading="An error occurred">
+              There was an error: <em>{this.props.errorMessage}</em>.
+            </Alert>
+          )}
+          <EditablePanel
+            title="Accounting"
+            onSave={this.save}
+            toggleEditable={this.toggleEditable}
+            isEditable={this.state.isEditable || this.props.isUpdating}
+          >
+            <Content
+              values={this.props.displayValues}
+              schema={this.props.schema}
+            />
+          </EditablePanel>
+        </React.Fragment>
+      );
+    }
+  };
+
+  Wrapper.propTypes = {
+    schema: PropTypes.object.isRequired,
+    displayValues: PropTypes.object.isRequired,
+    load: PropTypes.func.isRequired,
+    update: PropTypes.func.isRequired,
+    moveId: PropTypes.string.isRequired,
+  };
+
+  return Wrapper;
+}
+
 const formName = 'office_move_info_accounting';
+
+let AccountingPanel = editablePanel(AccountingDisplay, AccountingEdit);
 AccountingPanel = reduxForm({ form: formName })(AccountingPanel);
 
 function mapStateToProps(state) {
   return {
-    schema: get(state, 'swagger.spec.definitions.PatchAccounting', {}),
-    hasError: state.office.hasLoadError || state.office.hasUpdateError,
-    errorMessage: state.office.error,
+    // reduxForm
     formData: state.form[formName],
     initialValues: state.office.accounting,
-    ...state.office,
+
+    // Wrapper
+    schema: get(state, 'swagger.spec.definitions.PatchAccounting', {}),
+    hasError:
+      state.office.accountingHasLoadError || state.office.hasUpdateError,
+    errorMessage: state.office.error,
+    displayValues: state.office.accounting || {},
+    isUpdating: state.isUpdating,
   };
 }
 
 function mapDispatchToProps(dispatch) {
   return bindActionCreators(
     {
-      updateAccounting,
-      loadAccounting,
+      update: updateAccounting,
+      load: loadAccounting,
     },
     dispatch,
   );

--- a/src/scenes/Office/AccountingPanel.jsx
+++ b/src/scenes/Office/AccountingPanel.jsx
@@ -9,16 +9,7 @@ import { updateAccounting, loadAccounting } from './ducks';
 
 import { SwaggerField } from 'shared/JsonSchemaForm/JsonSchemaField';
 import Alert from 'shared/Alert';
-import { EditablePanel } from 'shared/EditablePanel';
-
-const PanelField = props => {
-  return (
-    <div className="panel-field">
-      <span className="field-title">{props.title}</span>
-      <span className="field-value">{props.value}</span>
-    </div>
-  );
-};
+import { EditablePanel, PanelField } from 'shared/EditablePanel';
 
 const AccountingDisplay = props => {
   const { values } = props;

--- a/src/scenes/Office/BackupInfoPanel.jsx
+++ b/src/scenes/Office/BackupInfoPanel.jsx
@@ -1,0 +1,109 @@
+//import { pick } from 'lodash';
+import React from 'react';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import { reduxForm } from 'redux-form';
+import editablePanel from './editablePanel';
+
+import { no_op } from 'shared/utils';
+
+// import { updateBackupInfo, loadBackupInfo } from './ducks';
+// import { PanelField } from 'shared/EditablePanel';
+// import { SwaggerField } from 'shared/JsonSchemaForm/JsonSchemaField';
+
+const BackupInfoDisplay = props => {
+  //const fieldProps = pick(props, ['schema', 'values']);
+  return (
+    <React.Fragment>
+      <div className="editable-panel-column" />
+    </React.Fragment>
+  );
+};
+
+const BackupInfoEdit = props => {
+  // const { schema } = props;
+  return (
+    <React.Fragment>
+      <div className="form-column">
+        <b>Backup Contact 1</b>
+        <label>Name</label>
+        <input type="text" name="backup-contact-1-name" />
+      </div>
+      <div className="form-column">
+        <label>Phone</label>
+        <input type="tel" name="backup-contact-1-phone" />
+      </div>
+      <div className="form-column">
+        <label>Email (optional)</label>
+        <input type="text" name="backup-contact-1-email" />
+      </div>
+      <div className="form-column">
+        <b>Authorization</b>
+        <input type="radio" name="authorization" value="none" />
+        <label htmlFor="none">None</label>
+        <input
+          type="radio"
+          name="authorization"
+          value="letter-of-authorization"
+        />
+        <label htmlFor="letter-of-authorization">Letter of Authorization</label>
+        <input
+          type="radio"
+          name="authorization"
+          value="sign-for-pickup-delivery-only"
+        />
+        <label htmlFor="sign-for-pickup-delivery-only">
+          Sign for pickup/delivery only
+        </label>
+      </div>
+      <div className="form-column">
+        <b>Backup Mailing Address</b>
+        <label>Mailing address 1</label>
+        <input type="text" name="backup-contact-1-mailing-address-1" />
+      </div>
+      <div className="form-column">
+        <label>Mailing address 2</label>
+        <input type="text" name="backup-contact-1-mailing-address-2" />
+      </div>
+      <div className="form-column">
+        <label>City</label>
+        <input type="text" name="backup-contact-1-city" />
+      </div>
+      <div className="form-column">
+        <label>State</label>
+        <input type="text" name="backup-contact-1-state" />
+      </div>
+    </React.Fragment>
+  );
+};
+
+const formName = 'office_move_info_backup_info';
+
+let BackupInfoPanel = editablePanel(BackupInfoDisplay, BackupInfoEdit);
+BackupInfoPanel = reduxForm({ form: formName })(BackupInfoPanel);
+
+function mapStateToProps(state) {
+  return {
+    // reduxForm
+    formData: state.form[formName],
+    initialValues: {},
+
+    // Wrapper
+    schema: {},
+    hasError: false,
+    errorMessage: state.office.error,
+    displayValues: {},
+    isUpdating: false,
+  };
+}
+
+function mapDispatchToProps(dispatch) {
+  return bindActionCreators(
+    {
+      update: no_op,
+    },
+    dispatch,
+  );
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(BackupInfoPanel);

--- a/src/scenes/Office/CustomerInfoPanel.jsx
+++ b/src/scenes/Office/CustomerInfoPanel.jsx
@@ -1,0 +1,163 @@
+// import { get, pick } from 'lodash';
+import React from 'react';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import { reduxForm } from 'redux-form';
+import editablePanel from './editablePanel';
+
+import { no_op } from 'shared/utils';
+
+// import { updateCustomerInfo, loadCustomerInfo } from './ducks';
+// import { PanelField } from 'shared/EditablePanel';
+// import { SwaggerField } from 'shared/JsonSchemaForm/JsonSchemaField';
+
+const CustomerInfoDisplay = props => {
+  // const fieldProps = pick(props, ['schema', 'values']);
+  return (
+    <React.Fragment>
+      <div className="editable-panel-column" />
+    </React.Fragment>
+  );
+};
+
+const CustomerInfoEdit = props => {
+  // const { schema } = props;
+  return (
+    <React.Fragment>
+      <div className="form-column">
+        <label>Title (optional)</label>
+        <input type="text" name="title" />
+      </div>
+      <div className="form-column">
+        <label>First name</label>
+        <input type="text" name="first-name" />
+      </div>
+      <div className="form-column">
+        <label>Middle name (optional)</label>
+        <input type="text" name="middle-name" />
+      </div>
+      <div className="form-column">
+        <label>Last name</label>
+        <input type="text" name="last-name" />
+      </div>
+      <div className="form-column">
+        <label>Suffix (optional)</label>
+        <input type="text" name="name-suffix" />
+      </div>
+      <div className="form-column">
+        <label>DoD ID</label>
+        <input type="number" name="dod-id" />
+      </div>
+      <div className="form-column">
+        <label>Branch</label>
+        <select name="branch">
+          <option value="army">Army</option>
+          <option value="navy">Navy</option>
+          <option value="air-force">Air Force</option>
+          <option value="marines">Marines</option>
+          <option value="coast-guard">Coast Guard</option>
+        </select>
+      </div>
+      <div className="form-column">
+        <label>Rank</label>
+        <select name="rank">
+          <option value="E-7">E-7</option>
+          <option value="another-rank">Another rank</option>
+          <option value="and-another-rank">And another rank</option>
+        </select>
+      </div>
+      <div className="form-column">
+        <b>Contact</b>
+        <label>Phone</label>
+        <input type="tel" name="contact-phone-number" />
+      </div>
+      <div className="form-column">
+        <label>Alternate phone</label>
+        <input type="tel" name="alternate-contact-phone-number" />
+      </div>
+      <div className="form-column">
+        <label>Email</label>
+        <input type="text" name="contact-email" />
+      </div>
+      <div className="form-column">
+        <label>Preferred contact methods</label>
+        <div>
+          <input
+            type="checkbox"
+            id="phone-preference"
+            name="preferred-contact-phone"
+          />
+          <label htmlFor="phone-preference">Phone</label>
+        </div>
+        <div>
+          <input
+            type="checkbox"
+            id="text-preference"
+            name="preferred-contact-text-message"
+          />
+          <label htmlFor="text-preference">Text message</label>
+        </div>
+        <div>
+          <input
+            type="checkbox"
+            id="email-preference"
+            name="preferred-contact-email"
+          />
+          <label htmlFor="email-preference">Email</label>
+        </div>
+      </div>
+      <div className="form-column">
+        <b>Current Residence Address</b>
+        <label>Address 1</label>
+        <input type="text" name="contact-address-1" />
+      </div>
+      <div className="form-column">
+        <label>Address 2</label>
+        <input type="text" name="contact-address-2" />
+      </div>
+      <div className="form-column">
+        <label>City</label>
+        <input type="text" name="contact-city" />
+      </div>
+      <div className="form-column">
+        <label>State</label>
+        <input type="text" name="contact-state" />
+      </div>
+      <div className="form-column">
+        <label>Zip</label>
+        <input type="number" name="contact-zip" />
+      </div>
+    </React.Fragment>
+  );
+};
+
+const formName = 'office_move_info_customer_info';
+
+let CustomerInfoPanel = editablePanel(CustomerInfoDisplay, CustomerInfoEdit);
+CustomerInfoPanel = reduxForm({ form: formName })(CustomerInfoPanel);
+
+function mapStateToProps(state) {
+  return {
+    // reduxForm
+    formData: state.form[formName],
+    initialValues: {},
+
+    // Wrapper
+    schema: {},
+    hasError: false,
+    errorMessage: state.office.error,
+    displayValues: {},
+    isUpdating: false,
+  };
+}
+
+function mapDispatchToProps(dispatch) {
+  return bindActionCreators(
+    {
+      update: no_op,
+    },
+    dispatch,
+  );
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(CustomerInfoPanel);

--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -8,7 +8,11 @@ import { RoutedTabs, NavTab } from 'react-router-tabs';
 import { Route, Switch, Redirect } from 'react-router-dom';
 
 import AccountingPanel from './AccountingPanel';
-import { loadMove } from './ducks.js';
+import BackupInfoPanel from './BackupInfoPanel';
+import CustomerInfoPanel from './CustomerInfoPanel';
+import OrdersPanel from './OrdersPanel';
+
+import { loadMove, loadAccounting } from './ducks.js';
 
 import FontAwesomeIcon from '@fortawesome/react-fontawesome';
 import faPhone from '@fortawesome/fontawesome-free-solid/faPhone';
@@ -20,282 +24,15 @@ import './office.css';
 
 const BasicsTabContent = props => {
   return (
-    <div>
-      <div>
-        <div>
-          <h2>Customer Info</h2>
-          <span className="fake-link">Edit</span>
-          <br />
-          <div className="form-column">
-            <label>Title (optional)</label>
-            <input type="text" name="title" />
-          </div>
-          <div className="form-column">
-            <label>First name</label>
-            <input type="text" name="first-name" />
-          </div>
-          <div className="form-column">
-            <label>Middle name (optional)</label>
-            <input type="text" name="middle-name" />
-          </div>
-          <div className="form-column">
-            <label>Last name</label>
-            <input type="text" name="last-name" />
-          </div>
-          <div className="form-column">
-            <label>Suffix (optional)</label>
-            <input type="text" name="name-suffix" />
-          </div>
-          <div className="form-column">
-            <label>DoD ID</label>
-            <input type="number" name="dod-id" />
-          </div>
-          <div className="form-column">
-            <label>Branch</label>
-            <select name="branch">
-              <option value="army">Army</option>
-              <option value="navy">Navy</option>
-              <option value="air-force">Air Force</option>
-              <option value="marines">Marines</option>
-              <option value="coast-guard">Coast Guard</option>
-            </select>
-          </div>
-          <div className="form-column">
-            <label>Rank</label>
-            <select name="rank">
-              <option value="E-7">E-7</option>
-              <option value="another-rank">Another rank</option>
-              <option value="and-another-rank">And another rank</option>
-            </select>
-          </div>
-          <div className="form-column">
-            <b>Contact</b>
-            <label>Phone</label>
-            <input type="tel" name="contact-phone-number" />
-          </div>
-          <div className="form-column">
-            <label>Alternate phone</label>
-            <input type="tel" name="alternate-contact-phone-number" />
-          </div>
-          <div className="form-column">
-            <label>Email</label>
-            <input type="text" name="contact-email" />
-          </div>
-          <div className="form-column">
-            <label>Preferred contact methods</label>
-            <div>
-              <input
-                type="checkbox"
-                id="phone-preference"
-                name="preferred-contact-phone"
-              />
-              <label htmlFor="phone-preference">Phone</label>
-            </div>
-            <div>
-              <input
-                type="checkbox"
-                id="text-preference"
-                name="preferred-contact-text-message"
-              />
-              <label htmlFor="text-preference">Text message</label>
-            </div>
-            <div>
-              <input
-                type="checkbox"
-                id="email-preference"
-                name="preferred-contact-email"
-              />
-              <label htmlFor="email-preference">Email</label>
-            </div>
-          </div>
-          <div className="form-column">
-            <b>Current Residence Address</b>
-            <label>Address 1</label>
-            <input type="text" name="contact-address-1" />
-          </div>
-          <div className="form-column">
-            <label>Address 2</label>
-            <input type="text" name="contact-address-2" />
-          </div>
-          <div className="form-column">
-            <label>City</label>
-            <input type="text" name="contact-city" />
-          </div>
-          <div className="form-column">
-            <label>State</label>
-            <input type="text" name="contact-state" />
-          </div>
-          <div className="form-column">
-            <label>Zip</label>
-            <input type="number" name="contact-zip" />
-          </div>
-        </div>
-        <div>
-          <h2>Backup Info</h2>
-          <span className="fake-link">Edit</span>
-          <br />
-          <form>
-            <div className="form-column">
-              <b>Backup Contact 1</b>
-              <label>Name</label>
-              <input type="text" name="backup-contact-1-name" />
-            </div>
-            <div className="form-column">
-              <label>Phone</label>
-              <input type="tel" name="backup-contact-1-phone" />
-            </div>
-            <div className="form-column">
-              <label>Email (optional)</label>
-              <input type="text" name="backup-contact-1-email" />
-            </div>
-            <div className="form-column">
-              <b>Authorization</b>
-              <input type="radio" name="authorization" value="none" />
-              <label htmlFor="none">None</label>
-              <input
-                type="radio"
-                name="authorization"
-                value="letter-of-authorization"
-              />
-              <label htmlFor="letter-of-authorization">
-                Letter of Authorization
-              </label>
-              <input
-                type="radio"
-                name="authorization"
-                value="sign-for-pickup-delivery-only"
-              />
-              <label htmlFor="sign-for-pickup-delivery-only">
-                Sign for pickup/delivery only
-              </label>
-            </div>
-            <div className="form-column">
-              <b>Backup Mailing Address</b>
-              <label>Mailing address 1</label>
-              <input type="text" name="backup-contact-1-mailing-address-1" />
-            </div>
-            <div className="form-column">
-              <label>Mailing address 2</label>
-              <input type="text" name="backup-contact-1-mailing-address-2" />
-            </div>
-            <div className="form-column">
-              <label>City</label>
-              <input type="text" name="backup-contact-1-city" />
-            </div>
-            <div className="form-column">
-              <label>State</label>
-              <input type="text" name="backup-contact-1-state" />
-            </div>
-          </form>
-        </div>
-        <div>
-          <h2>Orders</h2>
-          <span className="fake-link">Edit</span>
-          <br />
-          <div className="form-group">
-            <form>
-              <div className="form-column">
-                <label>Orders number</label>
-                <input type="text" name="orders-number" />
-              </div>
-              <div className="form-column">
-                <label>Date issued</label>
-                <input type="text" name="date-issued" />
-              </div>
-              <div className="form-column">
-                <label>Move type</label>
-                <select name="move-type">
-                  <option value="permanent-change-of-station">
-                    Permanent Change of Station
-                  </option>
-                  <option value="separation">Separation</option>
-                  <option value="retirement">Retirement</option>
-                  <option value="local-move">Local Move</option>
-                  <option value="tdy">Temporary Duty</option>
-                  <option value="dependent-travel">Dependent Travel</option>
-                  <option value="bluebark">Bluebark</option>
-                  <option value="various">Various</option>
-                </select>
-              </div>
-              <div className="form-column">
-                <label>Orders type</label>
-                <select name="orders-type">
-                  <option value="shipment-of-hhg-permitted">
-                    Shipment of HHG Permitted
-                  </option>
-                  <option value="pcs-with-tdy-en-route">
-                    PCS with TDY En Route
-                  </option>
-                  <option value="shipment-of-hhg-restricted-or-prohibited">
-                    Shipment of HHG Restricted or Prohibited
-                  </option>
-                  <option value="hhg-restricted-area-hhg-prohibited">
-                    HHG Restricted Area - HHG Prohibited
-                  </option>
-                  <option value="course-of-instruction-20-weeks-or-more">
-                    Course of Instruction 20 Weeks or More
-                  </option>
-                  <option value="shipment-of-hhg-prohibited-but-authorized-within-20-weeks">
-                    Shipment of HHG Prohibited but Authorized within 20 Weeks
-                  </option>
-                  <option value="delayed-approval-20-weeks-or-more">
-                    Delayed Approval 20 Weeks or More
-                  </option>
-                </select>
-              </div>
-              <div className="form-column">
-                <label>Report by</label>
-                <input type="date" name="report-by-date" />
-              </div>
-              <div className="form-column">
-                <label>Current duty station</label>
-                <input type="text" name="current-duty-station" />
-              </div>
-              <div className="form-column">
-                <label>New duty station</label>
-                <input type="text" name="new-duty-station" />
-              </div>
-              <div>
-                <div className="form-column">
-                  <b>Entitlements</b>
-                  <label>Household goods</label>
-                  <input type="number" name="household-goods-weight" /> lbs
-                </div>
-                <div className="form-column">
-                  <label>Pro-gear</label>
-                  <input type="number" name="pro-gear-weight" /> lbs
-                </div>
-                <div className="form-column">
-                  <label>Spouse pro-gear</label>
-                  <input type="number" name="spouse-pro-gear-weight" /> lbs
-                </div>
-                <div className="form-column">
-                  <label>Short-term storage</label>
-                  <input type="number" name="short-term-storage-days" /> days
-                </div>
-                <div className="form-column">
-                  <label>Long-term storage</label>
-                  <input type="number" name="long-term-storage-days" /> days
-                </div>
-                <div className="form-column">
-                  <input
-                    type="checkbox"
-                    id="dependents-checkbox"
-                    name="dependents-authorized"
-                  />
-                  <label htmlFor="dependents-checkbox">
-                    Dependents authorized
-                  </label>
-                </div>
-              </div>
-              <button>Cancel</button>
-              <button>Save</button>
-            </form>
-          </div>
-        </div>
-        <AccountingPanel moveId={props.match.params.moveId} />
-      </div>
-    </div>
+    <React.Fragment>
+      <OrdersPanel title="Orders" moveId={props.match.params.moveId} />
+      <CustomerInfoPanel
+        title="Customer Info"
+        moveId={props.match.params.moveId}
+      />
+      <BackupInfoPanel title="Backup Info" moveId={props.match.params.moveId} />
+      <AccountingPanel title="Accounting" moveId={props.match.params.moveId} />
+    </React.Fragment>
   );
 };
 
@@ -306,6 +43,7 @@ const PPMTabContent = () => {
 class MoveInfo extends Component {
   componentDidMount() {
     this.props.loadMove(this.props.match.params.moveId);
+    this.props.loadAccounting(this.props.match.params.moveId);
   }
 
   render() {
@@ -400,6 +138,7 @@ class MoveInfo extends Component {
 
 MoveInfo.propTypes = {
   loadMove: PropTypes.func.isRequired,
+  loadAccounting: PropTypes.func.isRequired,
 };
 
 const mapStateToProps = state => ({
@@ -408,6 +147,6 @@ const mapStateToProps = state => ({
 });
 
 const mapDispatchToProps = dispatch =>
-  bindActionCreators({ loadMove }, dispatch);
+  bindActionCreators({ loadMove, loadAccounting }, dispatch);
 
 export default connect(mapStateToProps, mapDispatchToProps)(MoveInfo);

--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -194,15 +194,13 @@ const BasicsTabContent = props => {
           <br />
           <div className="form-group">
             <form>
-              <div className="within-form-group">
-                <div className="form-column">
-                  <label>Orders number</label>
-                  <input type="text" name="orders-number" />
-                </div>
-                <div className="form-column">
-                  <label>Date issued</label>
-                  <input type="text" name="date-issued" />
-                </div>
+              <div className="form-column">
+                <label>Orders number</label>
+                <input type="text" name="orders-number" />
+              </div>
+              <div className="form-column">
+                <label>Date issued</label>
+                <input type="text" name="date-issued" />
               </div>
               <div className="form-column">
                 <label>Move type</label>

--- a/src/scenes/Office/OrdersPanel.jsx
+++ b/src/scenes/Office/OrdersPanel.jsx
@@ -1,0 +1,148 @@
+// import { get, pick } from 'lodash';
+import React from 'react';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import { reduxForm } from 'redux-form';
+import editablePanel from './editablePanel';
+
+import { no_op } from 'shared/utils';
+
+// import { updateOrders, loadOrders } from './ducks';
+// import { PanelField } from 'shared/EditablePanel';
+// import { SwaggerField } from 'shared/JsonSchemaForm/JsonSchemaField';
+
+const OrdersDisplay = props => {
+  // const fieldProps = pick(props, ['schema', 'values']);
+  return (
+    <React.Fragment>
+      <div className="editable-panel-column" />
+    </React.Fragment>
+  );
+};
+
+const OrdersEdit = props => {
+  // const { schema } = props;
+  return (
+    <React.Fragment>
+      <div className="form-column">
+        <label>Orders number</label>
+        <input type="text" name="orders-number" />
+      </div>
+      <div className="form-column">
+        <label>Date issued</label>
+        <input type="text" name="date-issued" />
+      </div>
+      <div className="form-column">
+        <label>Move type</label>
+        <select name="move-type">
+          <option value="permanent-change-of-station">
+            Permanent Change of Station
+          </option>
+          <option value="separation">Separation</option>
+          <option value="retirement">Retirement</option>
+          <option value="local-move">Local Move</option>
+          <option value="tdy">Temporary Duty</option>
+          <option value="dependent-travel">Dependent Travel</option>
+          <option value="bluebark">Bluebark</option>
+          <option value="various">Various</option>
+        </select>
+      </div>
+      <div className="form-column">
+        <label>Orders type</label>
+        <select name="orders-type">
+          <option value="shipment-of-hhg-permitted">
+            Shipment of HHG Permitted
+          </option>
+          <option value="pcs-with-tdy-en-route">PCS with TDY En Route</option>
+          <option value="shipment-of-hhg-restricted-or-prohibited">
+            Shipment of HHG Restricted or Prohibited
+          </option>
+          <option value="hhg-restricted-area-hhg-prohibited">
+            HHG Restricted Area - HHG Prohibited
+          </option>
+          <option value="course-of-instruction-20-weeks-or-more">
+            Course of Instruction 20 Weeks or More
+          </option>
+          <option value="shipment-of-hhg-prohibited-but-authorized-within-20-weeks">
+            Shipment of HHG Prohibited but Authorized within 20 Weeks
+          </option>
+          <option value="delayed-approval-20-weeks-or-more">
+            Delayed Approval 20 Weeks or More
+          </option>
+        </select>
+      </div>
+      <div className="form-column">
+        <label>Report by</label>
+        <input type="date" name="report-by-date" />
+      </div>
+      <div className="form-column">
+        <label>Current duty station</label>
+        <input type="text" name="current-duty-station" />
+      </div>
+      <div className="form-column">
+        <label>New duty station</label>
+        <input type="text" name="new-duty-station" />
+      </div>
+      <div className="form-column">
+        <b>Entitlements</b>
+        <label>Household goods</label>
+        <input type="number" name="household-goods-weight" /> lbs
+      </div>
+      <div className="form-column">
+        <label>Pro-gear</label>
+        <input type="number" name="pro-gear-weight" /> lbs
+      </div>
+      <div className="form-column">
+        <label>Spouse pro-gear</label>
+        <input type="number" name="spouse-pro-gear-weight" /> lbs
+      </div>
+      <div className="form-column">
+        <label>Short-term storage</label>
+        <input type="number" name="short-term-storage-days" /> days
+      </div>
+      <div className="form-column">
+        <label>Long-term storage</label>
+        <input type="number" name="long-term-storage-days" /> days
+      </div>
+      <div className="form-column">
+        <input
+          type="checkbox"
+          id="dependents-checkbox"
+          name="dependents-authorized"
+        />
+        <label htmlFor="dependents-checkbox">Dependents authorized</label>
+      </div>
+    </React.Fragment>
+  );
+};
+
+const formName = 'office_move_info_orders';
+
+let OrdersPanel = editablePanel(OrdersDisplay, OrdersEdit);
+OrdersPanel = reduxForm({ form: formName })(OrdersPanel);
+
+function mapStateToProps(state) {
+  return {
+    // reduxForm
+    formData: state.form[formName],
+    initialValues: {},
+
+    // Wrapper
+    schema: {},
+    hasError: false,
+    errorMessage: state.office.error,
+    displayValues: {},
+    isUpdating: false,
+  };
+}
+
+function mapDispatchToProps(dispatch) {
+  return bindActionCreators(
+    {
+      update: no_op,
+    },
+    dispatch,
+  );
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(OrdersPanel);

--- a/src/scenes/Office/editablePanel.jsx
+++ b/src/scenes/Office/editablePanel.jsx
@@ -1,0 +1,63 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import Alert from 'shared/Alert';
+import { EditablePanel } from 'shared/EditablePanel';
+
+export default function editablePanel(DisplayComponent, EditComponent) {
+  const Wrapper = class extends Component {
+    constructor(props) {
+      super(props);
+      this.state = {
+        isEditable: false,
+      };
+    }
+
+    save = () => {
+      this.props.update(this.props.moveId, this.props.formData.values);
+      this.toggleEditable();
+    };
+
+    toggleEditable = () => {
+      this.setState({
+        isEditable: !this.state.isEditable,
+      });
+    };
+
+    render() {
+      const isEditable = this.state.isEditable || this.props.isUpdating;
+      const Content = isEditable ? EditComponent : DisplayComponent;
+
+      return (
+        <React.Fragment>
+          {this.props.hasError && (
+            <Alert type="error" heading="An error occurred">
+              There was an error: <em>{this.props.errorMessage}</em>.
+            </Alert>
+          )}
+          <EditablePanel
+            title={this.props.title}
+            onSave={this.save}
+            onToggle={this.toggleEditable}
+            isEditable={isEditable}
+          >
+            <Content
+              values={this.props.displayValues}
+              schema={this.props.schema}
+            />
+          </EditablePanel>
+        </React.Fragment>
+      );
+    }
+  };
+
+  Wrapper.propTypes = {
+    schema: PropTypes.object.isRequired,
+    displayValues: PropTypes.object.isRequired,
+    update: PropTypes.func.isRequired,
+    moveId: PropTypes.string.isRequired,
+    title: PropTypes.string.isRequired,
+    isUpdating: PropTypes.bool.isRequired,
+  };
+
+  return Wrapper;
+}

--- a/src/scenes/Office/office.css
+++ b/src/scenes/Office/office.css
@@ -1,4 +1,3 @@
-/* Use with .usa-grid for a liquid and nearly full-width grid layout. */
 .fake-link {
   text-decoration: underline;
   color: blue;
@@ -10,11 +9,7 @@
   margin-right: 5%;
 }
 
-.within-form-group {
-  display: inline-block;
-  width: 50%;
-}
-
+/* Use with .usa-grid for a liquid and nearly full-width grid layout. */
 .grid-wide {
   max-width: 2000px;
   margin: auto;

--- a/src/shared/EditablePanel/index.jsx
+++ b/src/shared/EditablePanel/index.jsx
@@ -4,6 +4,15 @@ import classNames from 'classnames';
 
 import './index.css';
 
+export const PanelField = props => {
+  return (
+    <div className="panel-field">
+      <span className="field-title">{props.title}</span>
+      <span className="field-value">{props.value}</span>
+    </div>
+  );
+};
+
 export class EditablePanel extends Component {
   handleToggleClick = e => {
     e.preventDefault();

--- a/src/shared/EditablePanel/index.jsx
+++ b/src/shared/EditablePanel/index.jsx
@@ -26,7 +26,7 @@ PanelField.propTypes = {
 export class EditablePanel extends Component {
   handleToggleClick = e => {
     e.preventDefault();
-    this.props.toggleEditable();
+    this.props.onToggle();
   };
 
   handleSaveClick = e => {
@@ -70,7 +70,7 @@ export class EditablePanel extends Component {
       <div className={classes}>
         <div className="editable-panel-header">
           <div className="title">{this.props.title}</div>
-          {!this.props.isEditable && (
+          {!this.props.showControls && (
             <a className="editable-panel-edit" onClick={this.handleToggleClick}>
               Edit
             </a>
@@ -89,6 +89,6 @@ EditablePanel.propTypes = {
   title: PropTypes.string.isRequired,
   children: PropTypes.node.isRequired,
   isEditable: PropTypes.bool.isRequired,
-  toggleEditable: PropTypes.func.isRequired,
+  onToggle: PropTypes.func.isRequired,
   onSave: PropTypes.func.isRequired,
 };

--- a/src/shared/EditablePanel/index.jsx
+++ b/src/shared/EditablePanel/index.jsx
@@ -1,16 +1,26 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import { get } from 'lodash';
 
 import './index.css';
 
 export const PanelField = props => {
+  const { fieldName, schema, values } = props;
+  const title = get(schema, `properties.${fieldName}.title`, '');
+  const value = values[fieldName];
+
   return (
     <div className="panel-field">
-      <span className="field-title">{props.title}</span>
-      <span className="field-value">{props.value}</span>
+      <span className="field-title">{title}</span>
+      <span className="field-value">{value}</span>
     </div>
   );
+};
+PanelField.propTypes = {
+  fieldName: PropTypes.string.isRequired,
+  schema: PropTypes.object.isRequired,
+  values: PropTypes.object,
 };
 
 export class EditablePanel extends Component {

--- a/src/shared/EditablePanel/index.jsx
+++ b/src/shared/EditablePanel/index.jsx
@@ -47,10 +47,6 @@ export class EditablePanel extends Component {
       this.props.className,
     );
 
-    const contentFunc = this.props.isEditable
-      ? this.props.editableContent
-      : this.props.displayContent;
-
     return (
       <div className={classes}>
         <div className="editable-panel-header">
@@ -62,7 +58,7 @@ export class EditablePanel extends Component {
           )}
         </div>
         <div className="editable-panel-content">
-          {contentFunc()}
+          {this.props.children}
           {controls}
         </div>
       </div>
@@ -71,7 +67,9 @@ export class EditablePanel extends Component {
 }
 
 EditablePanel.propTypes = {
-  editableContent: PropTypes.func.isRequired,
-  displayContent: PropTypes.func.isRequired,
+  title: PropTypes.string.isRequired,
+  children: PropTypes.node.isRequired,
   isEditable: PropTypes.bool.isRequired,
+  toggleEditable: PropTypes.func.isRequired,
+  onSave: PropTypes.func.isRequired,
 };

--- a/src/shared/EditablePanel/index.jsx
+++ b/src/shared/EditablePanel/index.jsx
@@ -70,7 +70,7 @@ export class EditablePanel extends Component {
       <div className={classes}>
         <div className="editable-panel-header">
           <div className="title">{this.props.title}</div>
-          {!this.props.showControls && (
+          {!this.props.isEditable && (
             <a className="editable-panel-edit" onClick={this.handleToggleClick}>
               Edit
             </a>


### PR DESCRIPTION
## Description

Explain a little about the changes at a high level.

## Reviewer Notes

* `editablePanel` is a [HOC](https://reactjs.org/docs/higher-order-components.html), which is just a function that returns a new component based on its arguments. It may eventually go live in another place in the codebase, but for not it's pretty coupled to the panels.
* The AC do not mention having any data shown in the display versions of the panels. It'll be relatively easy to add this later using `PanelField`.

## Code Review Verification Steps

* [ ] All tests pass.
* [ ] There are no [aXe](https://www.deque.com/products/aXe/) warnings for UI.
* [ ] This works in IE.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/157541731) for this change

## Screenshots

<img width="1101" alt="screen shot 2018-05-14 at 4 52 26 pm" src="https://user-images.githubusercontent.com/3331/40025543-910c3acc-5797-11e8-8927-7b0050bd1c55.png">
