### PR TITLE
Passes app into model fetchers to control auth [#157560413]

### DIFF
--- a/pkg/app/app_detector.go
+++ b/pkg/app/app_detector.go
@@ -12,8 +12,12 @@ type appCtxKey string
 
 const appKey = appCtxKey("app")
 const hostnameKey = appCtxKey("hostname")
-const officeApp = "OFFICE"
-const myApp = "MY"
+
+// OfficeApp describes an office app
+const OfficeApp = "OFFICE"
+
+// MyApp describes a my move app
+const MyApp = "MY"
 
 func fromContext(r *http.Request, key appCtxKey) string {
 	if app, ok := r.Context().Value(key).(string); ok {
@@ -22,23 +26,36 @@ func fromContext(r *http.Request, key appCtxKey) string {
 	return ""
 }
 
-func appFromContext(r *http.Request) string {
+// GetAppFromContext returns an app string for a request
+func GetAppFromContext(r *http.Request) string {
 	return fromContext(r, appKey)
 }
 
 // IsOfficeApp returns true iff the request is for the office.move.mil host
 func IsOfficeApp(r *http.Request) bool {
-	return appFromContext(r) == officeApp
+	return GetAppFromContext(r) == OfficeApp
 }
 
 // IsMyApp returns true iff the request is for the my.move.mil host
 func IsMyApp(r *http.Request) bool {
-	return appFromContext(r) == myApp
+	return GetAppFromContext(r) == MyApp
 }
 
 // GetHostname returns the hostname used to hit this server
 func GetHostname(r *http.Request) string {
 	return fromContext(r, hostnameKey)
+}
+
+// PopulateAppContext adds the app onto request context
+func PopulateAppContext(ctx context.Context, app string) context.Context {
+	ctx = context.WithValue(ctx, appKey, app)
+	return ctx
+}
+
+// PopulateHostnameContext adds the app onto request context
+func PopulateHostnameContext(ctx context.Context, hostname string) context.Context {
+	ctx = context.WithValue(ctx, hostnameKey, hostname)
+	return ctx
 }
 
 // DetectorMiddleware detects which application we are serving based on the hostname
@@ -49,16 +66,16 @@ func DetectorMiddleware(logger *zap.Logger, myHostname string, officeHostname st
 			parts := strings.Split(r.Host, ":")
 			var app string
 			if strings.EqualFold(parts[0], myHostname) {
-				app = myApp
+				app = MyApp
 			} else if strings.EqualFold(parts[0], officeHostname) {
-				app = officeApp
+				app = OfficeApp
 			} else {
 				logger.Error("Bad hostname", zap.String("hostname", r.Host))
 				http.Error(w, http.StatusText(400), http.StatusBadRequest)
 				return
 			}
-			ctx := context.WithValue(r.Context(), appKey, app)
-			ctx = context.WithValue(ctx, hostnameKey, strings.ToLower(parts[0]))
+			ctx := PopulateAppContext(r.Context(), app)
+			ctx = PopulateHostnameContext(ctx, strings.ToLower(parts[0]))
 			next.ServeHTTP(w, r.WithContext(ctx))
 			return
 		}

--- a/pkg/handlers/backup_contacts.go
+++ b/pkg/handlers/backup_contacts.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/gobuffalo/uuid"
+	"github.com/transcom/mymove/pkg/app"
 	"github.com/transcom/mymove/pkg/auth"
 	backupop "github.com/transcom/mymove/pkg/gen/internalapi/internaloperations/backup_contacts"
 	"github.com/transcom/mymove/pkg/gen/internalmessages"
@@ -29,9 +30,10 @@ type CreateBackupContactHandler HandlerContext
 func (h CreateBackupContactHandler) Handle(params backupop.CreateServiceMemberBackupContactParams) middleware.Responder {
 	// User should always be populated by middleware
 	user, _ := auth.GetUser(params.HTTPRequest.Context())
+	reqApp := app.GetAppFromContext(params.HTTPRequest)
 
 	serviceMemberID, _ := uuid.FromString(params.ServiceMemberID.String())
-	serviceMember, err := models.FetchServiceMember(h.db, user, serviceMemberID)
+	serviceMember, err := models.FetchServiceMember(h.db, user, reqApp, serviceMemberID)
 	if err != nil {
 		return responseForError(h.logger, err)
 	}
@@ -56,9 +58,10 @@ type IndexBackupContactsHandler HandlerContext
 func (h IndexBackupContactsHandler) Handle(params backupop.IndexServiceMemberBackupContactsParams) middleware.Responder {
 	// User should always be populated by middleware
 	user, _ := auth.GetUser(params.HTTPRequest.Context())
+	reqApp := app.GetAppFromContext(params.HTTPRequest)
 
 	serviceMemberID, _ := uuid.FromString(params.ServiceMemberID.String())
-	serviceMember, err := models.FetchServiceMember(h.db, user, serviceMemberID)
+	serviceMember, err := models.FetchServiceMember(h.db, user, reqApp, serviceMemberID)
 	if err != nil {
 		return responseForError(h.logger, err)
 	}
@@ -81,9 +84,10 @@ type ShowBackupContactHandler HandlerContext
 func (h ShowBackupContactHandler) Handle(params backupop.ShowServiceMemberBackupContactParams) middleware.Responder {
 	// User should always be populated by middleware
 	user, _ := auth.GetUser(params.HTTPRequest.Context())
+	reqApp := app.GetAppFromContext(params.HTTPRequest)
 
 	contactID, _ := uuid.FromString(params.BackupContactID.String())
-	contact, err := models.FetchBackupContact(h.db, user, contactID)
+	contact, err := models.FetchBackupContact(h.db, user, reqApp, contactID)
 	if err != nil {
 		return responseForError(h.logger, err)
 	}
@@ -99,9 +103,10 @@ type UpdateBackupContactHandler HandlerContext
 func (h UpdateBackupContactHandler) Handle(params backupop.UpdateServiceMemberBackupContactParams) middleware.Responder {
 	// User should always be populated by middleware
 	user, _ := auth.GetUser(params.HTTPRequest.Context())
+	reqApp := app.GetAppFromContext(params.HTTPRequest)
 
 	contactID, _ := uuid.FromString(params.BackupContactID.String())
-	contact, err := models.FetchBackupContact(h.db, user, contactID)
+	contact, err := models.FetchBackupContact(h.db, user, reqApp, contactID)
 	if err != nil {
 		return responseForError(h.logger, err)
 	}

--- a/pkg/handlers/documents.go
+++ b/pkg/handlers/documents.go
@@ -6,6 +6,7 @@ import (
 	"github.com/gobuffalo/uuid"
 	"go.uber.org/zap"
 
+	"github.com/transcom/mymove/pkg/app"
 	auth "github.com/transcom/mymove/pkg/auth"
 	documentop "github.com/transcom/mymove/pkg/gen/internalapi/internaloperations/documents"
 	"github.com/transcom/mymove/pkg/gen/internalmessages"
@@ -42,6 +43,7 @@ type CreateDocumentHandler HandlerContext
 func (h CreateDocumentHandler) Handle(params documentop.CreateDocumentParams) middleware.Responder {
 	// User should always be populated by middleware
 	user, _ := auth.GetUser(params.HTTPRequest.Context())
+	app := app.GetAppFromContext(params.HTTPRequest)
 
 	serviceMemberID, err := uuid.FromString(params.DocumentPayload.ServiceMemberID.String())
 	if err != nil {
@@ -49,7 +51,7 @@ func (h CreateDocumentHandler) Handle(params documentop.CreateDocumentParams) mi
 	}
 
 	// Fetch to check auth
-	serviceMember, err := models.FetchServiceMember(h.db, user, serviceMemberID)
+	serviceMember, err := models.FetchServiceMember(h.db, user, app, serviceMemberID)
 	if err != nil {
 		return responseForError(h.logger, err)
 	}
@@ -83,13 +85,14 @@ type ShowDocumentHandler HandlerContext
 func (h ShowDocumentHandler) Handle(params documentop.ShowDocumentParams) middleware.Responder {
 	// User should always be populated by middleware
 	user, _ := auth.GetUser(params.HTTPRequest.Context())
+	app := app.GetAppFromContext(params.HTTPRequest)
 
 	documentID, err := uuid.FromString(params.DocumentID.String())
 	if err != nil {
 		return responseForError(h.logger, err)
 	}
 
-	document, err := models.FetchDocument(h.db, user, documentID)
+	document, err := models.FetchDocument(h.db, user, app, documentID)
 	if err != nil {
 		return responseForError(h.logger, err)
 	}

--- a/pkg/handlers/handlers_test.go
+++ b/pkg/handlers/handlers_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/zap"
 
+	"github.com/transcom/mymove/pkg/app"
 	"github.com/transcom/mymove/pkg/auth"
 	"github.com/transcom/mymove/pkg/models"
 )
@@ -79,6 +80,7 @@ func (suite *HandlerSuite) authenticateRequest(req *http.Request, user models.Us
 	ctx := req.Context()
 	ctx = auth.PopulateAuthContext(ctx, user.ID, "fake token")
 	ctx = auth.PopulateUserModel(ctx, user)
+	ctx = app.PopulateAppContext(ctx, app.MyApp)
 	return req.WithContext(ctx)
 }
 

--- a/pkg/handlers/moves.go
+++ b/pkg/handlers/moves.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/gobuffalo/uuid"
+	"github.com/transcom/mymove/pkg/app"
 	"github.com/transcom/mymove/pkg/auth"
 	moveop "github.com/transcom/mymove/pkg/gen/internalapi/internaloperations/moves"
 	"github.com/transcom/mymove/pkg/gen/internalmessages"
@@ -29,8 +30,9 @@ func (h CreateMoveHandler) Handle(params moveop.CreateMoveParams) middleware.Res
 	var response middleware.Responder
 	// Get orders for authorized user
 	user, _ := auth.GetUser(params.HTTPRequest.Context())
+	reqApp := app.GetAppFromContext(params.HTTPRequest)
 	ordersID, _ := uuid.FromString(params.OrdersID.String())
-	orders, err := models.FetchOrder(h.db, user, ordersID)
+	orders, err := models.FetchOrder(h.db, user, reqApp, ordersID)
 	if err != nil {
 		return responseForError(h.logger, err)
 	}
@@ -61,15 +63,16 @@ type ShowMoveHandler HandlerContext
 func (h ShowMoveHandler) Handle(params moveop.ShowMoveParams) middleware.Responder {
 	// User should always be populated by middleware
 	user, _ := auth.GetUser(params.HTTPRequest.Context())
+	reqApp := app.GetAppFromContext(params.HTTPRequest)
 	moveID, _ := uuid.FromString(params.MoveID.String())
 
 	// Validate that this move belongs to the current user
-	move, err := models.FetchMove(h.db, user, moveID)
+	move, err := models.FetchMove(h.db, user, reqApp, moveID)
 	if err != nil {
 		return responseForError(h.logger, err)
 	}
 	// Fetch orders for authorized user
-	orders, err := models.FetchOrder(h.db, user, move.OrdersID)
+	orders, err := models.FetchOrder(h.db, user, reqApp, move.OrdersID)
 	if err != nil {
 		return responseForError(h.logger, err)
 	}
@@ -85,15 +88,16 @@ type PatchMoveHandler HandlerContext
 func (h PatchMoveHandler) Handle(params moveop.PatchMoveParams) middleware.Responder {
 	// User should always be populated by middleware
 	user, _ := auth.GetUser(params.HTTPRequest.Context())
+	reqApp := app.GetAppFromContext(params.HTTPRequest)
 	moveID, _ := uuid.FromString(params.MoveID.String())
 
 	// Validate that this move belongs to the current user
-	move, err := models.FetchMove(h.db, user, moveID)
+	move, err := models.FetchMove(h.db, user, reqApp, moveID)
 	if err != nil {
 		return responseForError(h.logger, err)
 	}
 	// Fetch orders for authorized user
-	orders, err := models.FetchOrder(h.db, user, move.OrdersID)
+	orders, err := models.FetchOrder(h.db, user, reqApp, move.OrdersID)
 	if err != nil {
 		return responseForError(h.logger, err)
 	}

--- a/pkg/handlers/orders.go
+++ b/pkg/handlers/orders.go
@@ -6,6 +6,7 @@ import (
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/gobuffalo/uuid"
 
+	"github.com/transcom/mymove/pkg/app"
 	"github.com/transcom/mymove/pkg/auth"
 	ordersop "github.com/transcom/mymove/pkg/gen/internalapi/internaloperations/orders"
 	"github.com/transcom/mymove/pkg/gen/internalmessages"
@@ -40,6 +41,7 @@ type CreateOrdersHandler HandlerContext
 func (h CreateOrdersHandler) Handle(params ordersop.CreateOrdersParams) middleware.Responder {
 	// User should always be populated by middleware
 	user, _ := auth.GetUser(params.HTTPRequest.Context())
+	reqApp := app.GetAppFromContext(params.HTTPRequest)
 
 	payload := params.CreateOrders
 
@@ -47,7 +49,7 @@ func (h CreateOrdersHandler) Handle(params ordersop.CreateOrdersParams) middlewa
 	if err != nil {
 		return responseForError(h.logger, err)
 	}
-	serviceMember, err := models.FetchServiceMember(h.db, user, serviceMemberID)
+	serviceMember, err := models.FetchServiceMember(h.db, user, reqApp, serviceMemberID)
 	if err != nil {
 		return responseForError(h.logger, err)
 	}
@@ -86,9 +88,10 @@ type ShowOrdersHandler HandlerContext
 func (h ShowOrdersHandler) Handle(params ordersop.ShowOrdersParams) middleware.Responder {
 	// User should always be populated by middleware
 	user, _ := auth.GetUser(params.HTTPRequest.Context())
+	reqApp := app.GetAppFromContext(params.HTTPRequest)
 
 	orderID, _ := uuid.FromString(params.OrdersID.String())
-	order, err := models.FetchOrder(h.db, user, orderID)
+	order, err := models.FetchOrder(h.db, user, reqApp, orderID)
 	if err != nil {
 		return responseForError(h.logger, err)
 	}
@@ -107,12 +110,13 @@ type UpdateOrdersHandler HandlerContext
 func (h UpdateOrdersHandler) Handle(params ordersop.UpdateOrdersParams) middleware.Responder {
 	// User should always be populated by middleware
 	user, _ := auth.GetUser(params.HTTPRequest.Context())
+	reqApp := app.GetAppFromContext(params.HTTPRequest)
 
 	orderID, err := uuid.FromString(params.OrdersID.String())
 	if err != nil {
 		return responseForError(h.logger, err)
 	}
-	order, err := models.FetchOrder(h.db, user, orderID)
+	order, err := models.FetchOrder(h.db, user, reqApp, orderID)
 	if err != nil {
 		return responseForError(h.logger, err)
 	}

--- a/pkg/handlers/personally_procured_move.go
+++ b/pkg/handlers/personally_procured_move.go
@@ -7,6 +7,7 @@ import (
 	"github.com/gobuffalo/uuid"
 	"go.uber.org/zap"
 
+	"github.com/transcom/mymove/pkg/app"
 	"github.com/transcom/mymove/pkg/auth"
 	ppmop "github.com/transcom/mymove/pkg/gen/internalapi/internaloperations/ppm"
 	"github.com/transcom/mymove/pkg/gen/internalmessages"
@@ -38,10 +39,11 @@ type CreatePersonallyProcuredMoveHandler HandlerContext
 func (h CreatePersonallyProcuredMoveHandler) Handle(params ppmop.CreatePersonallyProcuredMoveParams) middleware.Responder {
 	// User should always be populated by middleware
 	user, _ := auth.GetUser(params.HTTPRequest.Context())
+	reqApp := app.GetAppFromContext(params.HTTPRequest)
 	moveID, _ := uuid.FromString(params.MoveID.String())
 
 	// Validate that this move belongs to the current user
-	move, err := models.FetchMove(h.db, user, moveID)
+	move, err := models.FetchMove(h.db, user, reqApp, moveID)
 	if err != nil {
 		return responseForError(h.logger, err)
 	}
@@ -72,10 +74,11 @@ type IndexPersonallyProcuredMovesHandler HandlerContext
 func (h IndexPersonallyProcuredMovesHandler) Handle(params ppmop.IndexPersonallyProcuredMovesParams) middleware.Responder {
 	// User should always be populated by middleware
 	user, _ := auth.GetUser(params.HTTPRequest.Context())
+	reqApp := app.GetAppFromContext(params.HTTPRequest)
 	moveID, _ := uuid.FromString(params.MoveID.String())
 
 	// Validate that this move belongs to the current user
-	move, err := models.FetchMove(h.db, user, moveID)
+	move, err := models.FetchMove(h.db, user, reqApp, moveID)
 	if err != nil {
 		return responseForError(h.logger, err)
 	}
@@ -126,10 +129,11 @@ type PatchPersonallyProcuredMoveHandler HandlerContext
 func (h PatchPersonallyProcuredMoveHandler) Handle(params ppmop.PatchPersonallyProcuredMoveParams) middleware.Responder {
 	// User should always be populated by middleware
 	user, _ := auth.GetUser(params.HTTPRequest.Context())
+	reqApp := app.GetAppFromContext(params.HTTPRequest)
 	moveID, _ := uuid.FromString(params.MoveID.String())
 	ppmID, _ := uuid.FromString(params.PersonallyProcuredMoveID.String())
 
-	ppm, err := models.FetchPersonallyProcuredMove(h.db, user, ppmID)
+	ppm, err := models.FetchPersonallyProcuredMove(h.db, user, reqApp, ppmID)
 	if err != nil {
 		return responseForError(h.logger, err)
 	}

--- a/pkg/handlers/personally_procured_move_test.go
+++ b/pkg/handlers/personally_procured_move_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/go-openapi/swag"
 	"github.com/gobuffalo/uuid"
 
-	"github.com/transcom/mymove/pkg/auth"
 	ppmop "github.com/transcom/mymove/pkg/gen/internalapi/internaloperations/ppm"
 	"github.com/transcom/mymove/pkg/gen/internalmessages"
 	"github.com/transcom/mymove/pkg/models"
@@ -40,9 +39,7 @@ func (suite *HandlerSuite) TestCreatePPMHandler() {
 	}
 
 	request := httptest.NewRequest("POST", "/fake/path", nil)
-	ctx := request.Context()
-	ctx = auth.PopulateUserModel(ctx, orders.ServiceMember.User)
-	request = request.WithContext(ctx)
+	request = suite.authenticateRequest(request, orders.ServiceMember.User)
 
 	newPPMPayload := internalmessages.CreatePersonallyProcuredMovePayload{WeightEstimate: swag.Int64(12), PickupZip: swag.String("00112"), DaysInStorage: swag.Int64(3)}
 
@@ -60,8 +57,7 @@ func (suite *HandlerSuite) TestCreatePPMHandler() {
 	fmt.Println(createdIssuePayload)
 
 	// Next try the wrong user
-	ctx = auth.PopulateUserModel(ctx, user1)
-	request = request.WithContext(ctx)
+	request = suite.authenticateRequest(request, user1)
 	newPPMParams.HTTPRequest = request
 
 	badUserResponse := handler.Handle(newPPMParams)
@@ -114,14 +110,12 @@ func (suite *HandlerSuite) TestIndexPPMHandler() {
 		t.Error(verrs, err)
 	}
 
-	request := httptest.NewRequest("GET", "/fake/path", nil)
-	ctx := request.Context()
-	ctx = auth.PopulateUserModel(ctx, move1.Orders.ServiceMember.User)
-	request = request.WithContext(ctx)
+	req := httptest.NewRequest("GET", "/fake/path", nil)
+	req = suite.authenticateRequest(req, move1.Orders.ServiceMember.User)
 
 	indexPPMParams := ppmop.IndexPersonallyProcuredMovesParams{
 		MoveID:      strfmt.UUID(move1.ID.String()),
-		HTTPRequest: request,
+		HTTPRequest: req,
 	}
 
 	handler := IndexPersonallyProcuredMovesHandler(NewHandlerContext(suite.db, suite.logger))
@@ -165,10 +159,8 @@ func (suite *HandlerSuite) TestPatchPPMHandler() {
 	}
 	suite.mustSave(&ppm1)
 
-	request := httptest.NewRequest("GET", "/fake/path", nil)
-	ctx := request.Context()
-	ctx = auth.PopulateUserModel(ctx, move.Orders.ServiceMember.User)
-	request = request.WithContext(ctx)
+	req := httptest.NewRequest("GET", "/fake/path", nil)
+	req = suite.authenticateRequest(req, move.Orders.ServiceMember.User)
 
 	payload := internalmessages.PatchPersonallyProcuredMovePayload{
 		Size:            &newSize,
@@ -177,7 +169,7 @@ func (suite *HandlerSuite) TestPatchPPMHandler() {
 	}
 
 	patchPPMParams := ppmop.PatchPersonallyProcuredMoveParams{
-		HTTPRequest: request,
+		HTTPRequest: req,
 		MoveID:      strfmt.UUID(move.ID.String()),
 		PersonallyProcuredMoveID:           strfmt.UUID(ppm1.ID.String()),
 		PatchPersonallyProcuredMovePayload: &payload,
@@ -233,10 +225,8 @@ func (suite *HandlerSuite) TestPatchPPMHandlerWrongUser() {
 	}
 	suite.mustSave(&ppm1)
 
-	request := httptest.NewRequest("PATCH", "/fake/path", nil)
-	ctx := request.Context()
-	ctx = auth.PopulateUserModel(ctx, user2)
-	request = request.WithContext(ctx)
+	req := httptest.NewRequest("PATCH", "/fake/path", nil)
+	req = suite.authenticateRequest(req, user2)
 
 	payload := internalmessages.PatchPersonallyProcuredMovePayload{
 		Size:            &newSize,
@@ -245,7 +235,7 @@ func (suite *HandlerSuite) TestPatchPPMHandlerWrongUser() {
 	}
 
 	patchPPMParams := ppmop.PatchPersonallyProcuredMoveParams{
-		HTTPRequest: request,
+		HTTPRequest: req,
 		MoveID:      strfmt.UUID(move.ID.String()),
 		PersonallyProcuredMoveID:           strfmt.UUID(ppm1.ID.String()),
 		PatchPersonallyProcuredMovePayload: &payload,
@@ -290,10 +280,8 @@ func (suite *HandlerSuite) TestPatchPPMHandlerWrongMoveID() {
 	}
 	suite.mustSave(&ppm1)
 
-	request := httptest.NewRequest("GET", "/fake/path", nil)
-	ctx := request.Context()
-	ctx = auth.PopulateUserModel(ctx, orders.ServiceMember.User)
-	request = request.WithContext(ctx)
+	req := httptest.NewRequest("GET", "/fake/path", nil)
+	req = suite.authenticateRequest(req, orders.ServiceMember.User)
 
 	payload := internalmessages.PatchPersonallyProcuredMovePayload{
 		Size:           &newSize,
@@ -301,7 +289,7 @@ func (suite *HandlerSuite) TestPatchPPMHandlerWrongMoveID() {
 	}
 
 	patchPPMParams := ppmop.PatchPersonallyProcuredMoveParams{
-		HTTPRequest: request,
+		HTTPRequest: req,
 		MoveID:      strfmt.UUID(move.ID.String()),
 		PersonallyProcuredMoveID:           strfmt.UUID(ppm1.ID.String()),
 		PatchPersonallyProcuredMovePayload: &payload,
@@ -333,10 +321,8 @@ func (suite *HandlerSuite) TestPatchPPMHandlerNoMove() {
 	}
 	suite.mustSave(&ppm1)
 
-	request := httptest.NewRequest("GET", "/fake/path", nil)
-	ctx := request.Context()
-	ctx = auth.PopulateUserModel(ctx, move.Orders.ServiceMember.User)
-	request = request.WithContext(ctx)
+	req := httptest.NewRequest("GET", "/fake/path", nil)
+	req = suite.authenticateRequest(req, move.Orders.ServiceMember.User)
 
 	payload := internalmessages.PatchPersonallyProcuredMovePayload{
 		Size:           &newSize,
@@ -344,7 +330,7 @@ func (suite *HandlerSuite) TestPatchPPMHandlerNoMove() {
 	}
 
 	patchPPMParams := ppmop.PatchPersonallyProcuredMoveParams{
-		HTTPRequest: request,
+		HTTPRequest: req,
 		MoveID:      strfmt.UUID(badMoveID.String()),
 		PersonallyProcuredMoveID:           strfmt.UUID(ppm1.ID.String()),
 		PatchPersonallyProcuredMovePayload: &payload,

--- a/pkg/handlers/service_member_test.go
+++ b/pkg/handlers/service_member_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/go-openapi/swag"
 	"github.com/gobuffalo/uuid"
 
+	"github.com/transcom/mymove/pkg/app"
 	servicememberop "github.com/transcom/mymove/pkg/gen/internalapi/internaloperations/service_members"
 	"github.com/transcom/mymove/pkg/gen/internalmessages"
 	"github.com/transcom/mymove/pkg/models"
@@ -118,6 +119,7 @@ func (suite *HandlerSuite) TestSubmitServiceMemberHandlerAllValues() {
 func (suite *HandlerSuite) TestSubmitServiceMemberSSN() {
 	// Given: A logged-in user
 	user, _ := testdatagen.MakeUser(suite.db)
+	reqApp := app.MyApp
 
 	// When: a new ServiceMember is posted
 	ssn := "123-45-6789"
@@ -149,7 +151,7 @@ func (suite *HandlerSuite) TestSubmitServiceMemberSSN() {
 	suite.Assertions.Len(servicemembers, 1)
 
 	serviceMemberID, _ := uuid.FromString(okResponse.Payload.ID.String())
-	serviceMember, err := models.FetchServiceMember(suite.db, user, serviceMemberID)
+	serviceMember, err := models.FetchServiceMember(suite.db, user, reqApp, serviceMemberID)
 	suite.Assertions.NoError(err)
 
 	suite.Assertions.True(serviceMember.SocialSecurityNumber.Matches(ssn))

--- a/pkg/handlers/service_members.go
+++ b/pkg/handlers/service_members.go
@@ -5,6 +5,7 @@ import (
 	"github.com/gobuffalo/uuid"
 	"github.com/gobuffalo/validate"
 
+	"github.com/transcom/mymove/pkg/app"
 	"github.com/transcom/mymove/pkg/auth"
 	servicememberop "github.com/transcom/mymove/pkg/gen/internalapi/internaloperations/service_members"
 	"github.com/transcom/mymove/pkg/gen/internalmessages"
@@ -128,9 +129,10 @@ type ShowServiceMemberHandler HandlerContext
 func (h ShowServiceMemberHandler) Handle(params servicememberop.ShowServiceMemberParams) middleware.Responder {
 	// User should always be populated by middleware
 	user, _ := auth.GetUser(params.HTTPRequest.Context())
+	reqApp := app.GetAppFromContext(params.HTTPRequest)
 
 	serviceMemberID, _ := uuid.FromString(params.ServiceMemberID.String())
-	serviceMember, err := models.FetchServiceMember(h.db, user, serviceMemberID)
+	serviceMember, err := models.FetchServiceMember(h.db, user, reqApp, serviceMemberID)
 	if err != nil {
 		return responseForError(h.logger, err)
 	}
@@ -146,9 +148,10 @@ type PatchServiceMemberHandler HandlerContext
 func (h PatchServiceMemberHandler) Handle(params servicememberop.PatchServiceMemberParams) middleware.Responder {
 	// User should always be populated by middleware
 	user, _ := auth.GetUser(params.HTTPRequest.Context())
+	reqApp := app.GetAppFromContext(params.HTTPRequest)
 
 	serviceMemberID, _ := uuid.FromString(params.ServiceMemberID.String())
-	serviceMember, err := models.FetchServiceMember(h.db, user, serviceMemberID)
+	serviceMember, err := models.FetchServiceMember(h.db, user, reqApp, serviceMemberID)
 	if err != nil {
 		return responseForError(h.logger, err)
 	}
@@ -253,9 +256,10 @@ type ShowServiceMemberOrdersHandler HandlerContext
 func (h ShowServiceMemberOrdersHandler) Handle(params servicememberop.ShowServiceMemberOrdersParams) middleware.Responder {
 	// User should always be populated by middleware
 	user, _ := auth.GetUser(params.HTTPRequest.Context())
+	reqApp := app.GetAppFromContext(params.HTTPRequest)
 
 	serviceMemberID, _ := uuid.FromString(params.ServiceMemberID.String())
-	serviceMember, err := models.FetchServiceMember(h.db, user, serviceMemberID)
+	serviceMember, err := models.FetchServiceMember(h.db, user, reqApp, serviceMemberID)
 	if err != nil {
 		return responseForError(h.logger, err)
 	}

--- a/pkg/handlers/signed_certifications.go
+++ b/pkg/handlers/signed_certifications.go
@@ -6,6 +6,7 @@ import (
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/gobuffalo/uuid"
 
+	"github.com/transcom/mymove/pkg/app"
 	"github.com/transcom/mymove/pkg/auth"
 	certop "github.com/transcom/mymove/pkg/gen/internalapi/internaloperations/certification"
 	"github.com/transcom/mymove/pkg/models"
@@ -18,9 +19,10 @@ type CreateSignedCertificationHandler HandlerContext
 func (h CreateSignedCertificationHandler) Handle(params certop.CreateSignedCertificationParams) middleware.Responder {
 	// User should always be populated by middleware
 	user, _ := auth.GetUser(params.HTTPRequest.Context())
+	reqApp := app.GetAppFromContext(params.HTTPRequest)
 	moveID, _ := uuid.FromString(params.MoveID.String())
 
-	move, err := models.FetchMove(h.db, user, moveID)
+	move, err := models.FetchMove(h.db, user, reqApp, moveID)
 	if err != nil {
 		return responseForError(h.logger, err)
 	}

--- a/pkg/handlers/uploads.go
+++ b/pkg/handlers/uploads.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gobuffalo/uuid"
 	"go.uber.org/zap"
 
+	"github.com/transcom/mymove/pkg/app"
 	"github.com/transcom/mymove/pkg/auth"
 	uploadop "github.com/transcom/mymove/pkg/gen/internalapi/internaloperations/uploads"
 	"github.com/transcom/mymove/pkg/gen/internalmessages"
@@ -45,6 +46,7 @@ func (h CreateUploadHandler) Handle(params uploadop.CreateUploadParams) middlewa
 
 	// User should always be populated by middleware
 	user, _ := auth.GetUser(params.HTTPRequest.Context())
+	reqApp := app.GetAppFromContext(params.HTTPRequest)
 
 	documentID, err := uuid.FromString(params.DocumentID.String())
 	if err != nil {
@@ -53,7 +55,7 @@ func (h CreateUploadHandler) Handle(params uploadop.CreateUploadParams) middlewa
 	}
 
 	//fetching document to ensure user has access to it
-	_, docErr := models.FetchDocument(h.db, user, documentID)
+	_, docErr := models.FetchDocument(h.db, user, reqApp, documentID)
 	if docErr != nil {
 		return responseForError(h.logger, docErr)
 	}
@@ -145,9 +147,10 @@ type DeleteUploadHandler HandlerContext
 func (h DeleteUploadHandler) Handle(params uploadop.DeleteUploadParams) middleware.Responder {
 	// User should always be populated by middleware
 	user, _ := auth.GetUser(params.HTTPRequest.Context())
+	app := app.GetAppFromContext(params.HTTPRequest)
 
 	uploadID, _ := uuid.FromString(params.UploadID.String())
-	upload, err := models.FetchUpload(h.db, user, uploadID)
+	upload, err := models.FetchUpload(h.db, user, app, uploadID)
 	if err != nil {
 		return responseForError(h.logger, err)
 	}

--- a/pkg/models/backup_contact.go
+++ b/pkg/models/backup_contact.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gobuffalo/validate/validators"
 	"github.com/pkg/errors"
 
+	"github.com/transcom/mymove/pkg/app"
 	"github.com/transcom/mymove/pkg/gen/internalmessages"
 )
 
@@ -64,7 +65,7 @@ func (b *BackupContact) ValidateUpdate(tx *pop.Connection) (*validate.Errors, er
 }
 
 // FetchBackupContact returns a specific backup contact model
-func FetchBackupContact(db *pop.Connection, authUser User, id uuid.UUID) (BackupContact, error) {
+func FetchBackupContact(db *pop.Connection, authUser User, reqApp string, id uuid.UUID) (BackupContact, error) {
 	var contact BackupContact
 	err := db.Q().Eager().Find(&contact, id)
 	if err != nil {
@@ -75,7 +76,7 @@ func FetchBackupContact(db *pop.Connection, authUser User, id uuid.UUID) (Backup
 		return BackupContact{}, err
 	}
 	// TODO: Handle case where more than one user is authorized to modify contact
-	if contact.ServiceMember.UserID != authUser.ID {
+	if reqApp == app.MyApp && contact.ServiceMember.UserID != authUser.ID {
 		return BackupContact{}, ErrFetchForbidden
 	}
 

--- a/pkg/models/backup_contact_test.go
+++ b/pkg/models/backup_contact_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/gobuffalo/uuid"
 
+	"github.com/transcom/mymove/pkg/app"
 	"github.com/transcom/mymove/pkg/gen/internalmessages"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"
@@ -55,6 +56,7 @@ func (suite *ModelSuite) Test_FetchBackupContact() {
 
 	serviceMember1, _ := testdatagen.MakeServiceMember(suite.db)
 	serviceMember2, _ := testdatagen.MakeServiceMember(suite.db)
+	reqApp := app.MyApp
 
 	backupContact := models.BackupContact{
 		ServiceMemberID: serviceMember1.ID,
@@ -64,12 +66,12 @@ func (suite *ModelSuite) Test_FetchBackupContact() {
 	}
 	suite.mustSave(&backupContact)
 
-	shouldSucceed, err := models.FetchBackupContact(suite.db, serviceMember1.User, backupContact.ID)
+	shouldSucceed, err := models.FetchBackupContact(suite.db, serviceMember1.User, reqApp, backupContact.ID)
 	if err != nil || !uuid.Equal(backupContact.ID, shouldSucceed.ID) {
 		t.Errorf("failed retrieving own backup contact: %v", err)
 	}
 
-	_, err = models.FetchBackupContact(suite.db, serviceMember2.User, backupContact.ID)
+	_, err = models.FetchBackupContact(suite.db, serviceMember2.User, reqApp, backupContact.ID)
 	if err == nil {
 		t.Error("should have failed getting other user's contact")
 	}

--- a/pkg/models/document.go
+++ b/pkg/models/document.go
@@ -47,7 +47,7 @@ func (d *Document) Validate(tx *pop.Connection) (*validate.Errors, error) {
 }
 
 // FetchDocument returns a document if the user has access to that document
-func FetchDocument(db *pop.Connection, user User, id uuid.UUID) (Document, error) {
+func FetchDocument(db *pop.Connection, user User, reqApp string, id uuid.UUID) (Document, error) {
 	var document Document
 	err := db.Q().Eager().Find(&document, id)
 	if err != nil {
@@ -58,7 +58,7 @@ func FetchDocument(db *pop.Connection, user User, id uuid.UUID) (Document, error
 		return Document{}, err
 	}
 
-	_, smErr := FetchServiceMember(db, user, document.ServiceMemberID)
+	_, smErr := FetchServiceMember(db, user, reqApp, document.ServiceMemberID)
 	if smErr != nil {
 		return Document{}, smErr
 	}

--- a/pkg/models/move.go
+++ b/pkg/models/move.go
@@ -60,7 +60,7 @@ func (m *Move) ValidateUpdate(tx *pop.Connection) (*validate.Errors, error) {
 }
 
 // FetchMove fetches and validates a Move for this User
-func FetchMove(db *pop.Connection, authUser User, id uuid.UUID) (*Move, error) {
+func FetchMove(db *pop.Connection, authUser User, reqApp string, id uuid.UUID) (*Move, error) {
 	var move Move
 	err := db.Q().Eager().Find(&move, id)
 	if err != nil {
@@ -72,7 +72,7 @@ func FetchMove(db *pop.Connection, authUser User, id uuid.UUID) (*Move, error) {
 	}
 
 	// Ensure that the logged-in user is authorized to access this move
-	_, authErr := FetchOrder(db, authUser, move.OrdersID)
+	_, authErr := FetchOrder(db, authUser, reqApp, move.OrdersID)
 	if authErr != nil {
 		return nil, authErr
 	}

--- a/pkg/models/move_test.go
+++ b/pkg/models/move_test.go
@@ -3,6 +3,7 @@ package models_test
 import (
 	"github.com/gobuffalo/uuid"
 
+	"github.com/transcom/mymove/pkg/app"
 	"github.com/transcom/mymove/pkg/gen/internalmessages"
 	. "github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"
@@ -23,6 +24,7 @@ func (suite *ModelSuite) TestFetchMove() {
 
 	order1, _ := testdatagen.MakeOrder(suite.db)
 	order2, _ := testdatagen.MakeOrder(suite.db)
+	reqApp := app.MyApp
 
 	var selectedType = internalmessages.SelectedMoveTypeCOMBO
 	move := Move{
@@ -35,7 +37,7 @@ func (suite *ModelSuite) TestFetchMove() {
 	}
 
 	// All correct
-	fetchedMove, err := FetchMove(suite.db, order1.ServiceMember.User, move.ID)
+	fetchedMove, err := FetchMove(suite.db, order1.ServiceMember.User, reqApp, move.ID)
 	if err != nil {
 		t.Error("Expected to get moveResult back.", err)
 	}
@@ -44,13 +46,13 @@ func (suite *ModelSuite) TestFetchMove() {
 	}
 
 	// Bad Move
-	fetchedMove, err = FetchMove(suite.db, order1.ServiceMember.User, uuid.Must(uuid.NewV4()))
+	fetchedMove, err = FetchMove(suite.db, order1.ServiceMember.User, reqApp, uuid.Must(uuid.NewV4()))
 	if err != ErrFetchNotFound {
 		t.Error("Expected to get fetchnotfound.", err)
 	}
 
 	// Bad User
-	fetchedMove, err = FetchMove(suite.db, order2.ServiceMember.User, move.ID)
+	fetchedMove, err = FetchMove(suite.db, order2.ServiceMember.User, reqApp, move.ID)
 	if err != ErrFetchForbidden {
 		t.Error("Expected to get a Forbidden back.", err)
 	}

--- a/pkg/models/order.go
+++ b/pkg/models/order.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gobuffalo/validate/validators"
 	"github.com/pkg/errors"
 
+	"github.com/transcom/mymove/pkg/app"
 	"github.com/transcom/mymove/pkg/gen/internalmessages"
 )
 
@@ -82,7 +83,7 @@ func SaveOrder(db *pop.Connection, order *Order) (*validate.Errors, error) {
 }
 
 // FetchOrder returns orders only if it is allowed for the given user to access those orders.
-func FetchOrder(db *pop.Connection, user User, id uuid.UUID) (Order, error) {
+func FetchOrder(db *pop.Connection, user User, reqApp string, id uuid.UUID) (Order, error) {
 	var order Order
 	err := db.Q().Eager("ServiceMember.User", "NewDutyStation.Address", "UploadedOrders.Uploads").Find(&order, id)
 	if err != nil {
@@ -93,7 +94,7 @@ func FetchOrder(db *pop.Connection, user User, id uuid.UUID) (Order, error) {
 		return Order{}, err
 	}
 	// TODO: Handle case where more than one user is authorized to modify orders
-	if order.ServiceMember.UserID != user.ID {
+	if reqApp == app.MyApp && order.ServiceMember.UserID != user.ID {
 		return Order{}, ErrFetchForbidden
 	}
 

--- a/pkg/models/order_test.go
+++ b/pkg/models/order_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/gobuffalo/uuid"
 
+	"github.com/transcom/mymove/pkg/app"
 	"github.com/transcom/mymove/pkg/gen/internalmessages"
 	. "github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"
@@ -28,6 +29,7 @@ func (suite *ModelSuite) TestFetchOrder() {
 
 	serviceMember1, _ := testdatagen.MakeServiceMember(suite.db)
 	serviceMember2, _ := testdatagen.MakeServiceMember(suite.db)
+	reqApp := app.MyApp
 
 	dutyStation := testdatagen.MakeAnyDutyStation(suite.db)
 	issueDate := time.Date(2018, time.March, 10, 0, 0, 0, 0, time.UTC)
@@ -55,7 +57,7 @@ func (suite *ModelSuite) TestFetchOrder() {
 	suite.mustSave(&order)
 
 	// User is authorized to fetch order
-	goodOrder, err := FetchOrder(suite.db, serviceMember1.User, order.ID)
+	goodOrder, err := FetchOrder(suite.db, serviceMember1.User, reqApp, order.ID)
 	if suite.NoError(err) {
 		suite.True(order.IssueDate.Equal(goodOrder.IssueDate))
 		suite.True(order.ReportByDate.Equal(goodOrder.ReportByDate))
@@ -65,14 +67,14 @@ func (suite *ModelSuite) TestFetchOrder() {
 	}
 
 	// User is forbidden from fetching order
-	_, err = FetchOrder(suite.db, serviceMember2.User, order.ID)
+	_, err = FetchOrder(suite.db, serviceMember2.User, reqApp, order.ID)
 	if suite.Error(err) {
 		suite.Equal(ErrFetchForbidden, err)
 	}
 
 	// Wrong Order ID
 	wrongID, _ := uuid.NewV4()
-	_, err = FetchOrder(suite.db, serviceMember1.User, wrongID)
+	_, err = FetchOrder(suite.db, serviceMember1.User, reqApp, wrongID)
 	if suite.Error(err) {
 		suite.Equal(ErrFetchNotFound, err)
 	}

--- a/pkg/models/personally_procured_move.go
+++ b/pkg/models/personally_procured_move.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gobuffalo/validate"
 
 	"github.com/pkg/errors"
+	"github.com/transcom/mymove/pkg/app"
 	"github.com/transcom/mymove/pkg/gen/internalmessages"
 )
 
@@ -50,7 +51,7 @@ func (p *PersonallyProcuredMove) ValidateUpdate(tx *pop.Connection) (*validate.E
 }
 
 // FetchPersonallyProcuredMove Fetches and Validates a PPM model
-func FetchPersonallyProcuredMove(db *pop.Connection, authUser User, id uuid.UUID) (*PersonallyProcuredMove, error) {
+func FetchPersonallyProcuredMove(db *pop.Connection, authUser User, reqApp string, id uuid.UUID) (*PersonallyProcuredMove, error) {
 	var ppm PersonallyProcuredMove
 	err := db.Q().Eager("Move.Orders.ServiceMember").Find(&ppm, id)
 	if err != nil {
@@ -61,7 +62,7 @@ func FetchPersonallyProcuredMove(db *pop.Connection, authUser User, id uuid.UUID
 		return nil, err
 	}
 	// TODO: Handle case where more than one user is authorized to modify ppm
-	if ppm.Move.Orders.ServiceMember.UserID != authUser.ID {
+	if reqApp == app.MyApp && ppm.Move.Orders.ServiceMember.UserID != authUser.ID {
 		return nil, ErrFetchForbidden
 	}
 

--- a/pkg/models/service_member.go
+++ b/pkg/models/service_member.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gobuffalo/validate/validators"
 	"github.com/pkg/errors"
 
+	"github.com/transcom/mymove/pkg/app"
 	"github.com/transcom/mymove/pkg/gen/internalmessages"
 )
 
@@ -82,7 +83,7 @@ func (s *ServiceMember) ValidateUpdate(tx *pop.Connection) (*validate.Errors, er
 
 // FetchServiceMember returns a service member only if it is allowed for the given user to access that service member.
 // This method is thereby a useful way of performing access control checks.
-func FetchServiceMember(db *pop.Connection, user User, id uuid.UUID) (ServiceMember, error) {
+func FetchServiceMember(db *pop.Connection, user User, reqApp string, id uuid.UUID) (ServiceMember, error) {
 	var serviceMember ServiceMember
 	err := db.Q().Eager().Find(&serviceMember, id)
 	if err != nil {
@@ -93,7 +94,7 @@ func FetchServiceMember(db *pop.Connection, user User, id uuid.UUID) (ServiceMem
 		return ServiceMember{}, err
 	}
 	// TODO: Handle case where more than one user is authorized to modify serviceMember
-	if serviceMember.UserID != user.ID {
+	if reqApp == app.MyApp && serviceMember.UserID != user.ID {
 		return ServiceMember{}, ErrFetchForbidden
 	}
 

--- a/pkg/models/service_member_test.go
+++ b/pkg/models/service_member_test.go
@@ -3,6 +3,7 @@ package models_test
 import (
 	"github.com/gobuffalo/uuid"
 
+	"github.com/transcom/mymove/pkg/app"
 	"github.com/transcom/mymove/pkg/gen/internalmessages"
 	. "github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"
@@ -68,6 +69,7 @@ func (suite *ModelSuite) TestIsProfileCompleteWithIncompleteSM() {
 func (suite *ModelSuite) TestFetchServiceMember() {
 	user1, _ := testdatagen.MakeUser(suite.db)
 	user2, _ := testdatagen.MakeUser(suite.db)
+	reqApp := app.MyApp
 
 	firstName := "Oliver"
 	resAddress, _ := testdatagen.MakeAddress(suite.db)
@@ -81,21 +83,21 @@ func (suite *ModelSuite) TestFetchServiceMember() {
 	suite.mustSave(&sm)
 
 	// User is authorized to fetch order
-	goodSm, err := FetchServiceMember(suite.db, user1, sm.ID)
+	goodSm, err := FetchServiceMember(suite.db, user1, reqApp, sm.ID)
 	if suite.NoError(err) {
 		suite.Equal(sm.FirstName, goodSm.FirstName)
 		suite.Equal(sm.ResidentialAddress.ID, goodSm.ResidentialAddress.ID)
 	}
 
 	// User is forbidden from fetching order
-	_, err = FetchServiceMember(suite.db, user2, sm.ID)
+	_, err = FetchServiceMember(suite.db, user2, reqApp, sm.ID)
 	if suite.Error(err) {
 		suite.Equal(ErrFetchForbidden, err)
 	}
 
 	// Wrong Order ID
 	wrongID, _ := uuid.NewV4()
-	_, err = FetchServiceMember(suite.db, user1, wrongID)
+	_, err = FetchServiceMember(suite.db, user1, reqApp, wrongID)
 	if suite.Error(err) {
 		suite.Equal(ErrFetchNotFound, err)
 	}

--- a/pkg/models/upload.go
+++ b/pkg/models/upload.go
@@ -52,7 +52,7 @@ func (u *Upload) Validate(tx *pop.Connection) (*validate.Errors, error) {
 }
 
 // FetchUpload returns an Upload if the user has access to that upload
-func FetchUpload(db *pop.Connection, user User, id uuid.UUID) (Upload, error) {
+func FetchUpload(db *pop.Connection, user User, reqApp string, id uuid.UUID) (Upload, error) {
 	var upload Upload
 	err := db.Q().Eager().Find(&upload, id)
 	if err != nil {
@@ -63,7 +63,7 @@ func FetchUpload(db *pop.Connection, user User, id uuid.UUID) (Upload, error) {
 		return Upload{}, err
 	}
 
-	_, docErr := FetchDocument(db, user, upload.DocumentID)
+	_, docErr := FetchDocument(db, user, reqApp, upload.DocumentID)
 	if docErr != nil {
 		return Upload{}, docErr
 	}


### PR DESCRIPTION
## Description

MyMove users are restricted to viewing data that belongs to them, while Office users necessarily need to view many users' data. This PR allows that as a stopgap by letting all office users see all data.

## Reviewer Notes

I tried to be clever initially and create a `Session` type that housed both the `User` and an `App` type, but ran into a lot of circular dependency issues. Handlers need Sessions, Sessions need models, models need Sessions to auth. Seems like I would have needed to put `Session` in models, but that seems wrong. Went with the dumb way instead.

## Code Review Verification Steps

* [ ] All tests pass.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/blob/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* [ ] Any migrations/schema changes also update the diagram in docs/schema/dp3.sqs
* [ ] There are no [aXe](https://www.deque.com/products/aXe/) warnings for UI.
* [ ] This works in IE.
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @willowbl00
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Request review from a member of a different team.
* [ ] (TRIAL) Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/157560413) for this change