### PR TITLE
Record Locator Error Handling Proposal

### DIFF
--- a/pkg/handlers/errors.go
+++ b/pkg/handlers/errors.go
@@ -36,7 +36,7 @@ func responseForError(logger *zap.Logger, err error) middleware.Responder {
 	case models.ErrFetchForbidden:
 		return newErrResponse(http.StatusForbidden)
 	default:
-		logger.Error("Unexpected fetch error", zap.Error(err))
+		logger.Error("Unexpected db error", zap.Error(err))
 		return newErrResponse(http.StatusInternalServerError)
 	}
 }

--- a/pkg/handlers/handlers.go
+++ b/pkg/handlers/handlers.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"io"
 	"log"
 	"net/http"
 	"strings"
@@ -9,8 +10,6 @@ import (
 	"github.com/gobuffalo/pop"
 	"github.com/gobuffalo/validate"
 	"go.uber.org/zap"
-
-	"io"
 
 	"github.com/transcom/mymove/pkg/gen/internalapi"
 	internalops "github.com/transcom/mymove/pkg/gen/internalapi/internaloperations"

--- a/pkg/handlers/personally_procured_move_test.go
+++ b/pkg/handlers/personally_procured_move_test.go
@@ -268,12 +268,14 @@ func (suite *HandlerSuite) TestPatchPPMHandlerWrongMoveID() {
 	orders1, _ := testdatagen.MakeOrder(suite.db)
 
 	var selectedType = internalmessages.SelectedMoveTypeCOMBO
-	move, err := orders.CreateNewMove(suite.db, &selectedType)
+	move, verrs, err := orders.CreateNewMove(suite.db, &selectedType)
 	suite.Nil(err, "Failed to save move")
+	suite.False(verrs.HasAny(), "failed to validate move")
 	move.Orders = orders
 
-	move2, err := orders1.CreateNewMove(suite.db, &selectedType)
+	move2, verrs, err := orders1.CreateNewMove(suite.db, &selectedType)
 	suite.Nil(err, "Failed to save move")
+	suite.False(verrs.HasAny(), "failed to validate move")
 	move2.Orders = orders1
 
 	ppm1 := models.PersonallyProcuredMove{

--- a/pkg/models/errors.go
+++ b/pkg/models/errors.go
@@ -22,5 +22,5 @@ var ErrLocatorGeneration = errors.New("LOCATOR_ERRORS")
 // This is ugly, but the best we can do with go's Postgresql adapter
 const recordNotFoundErrorString = "sql: no rows in result set"
 
-// UniqueConstraintViolationErrorPrefix This is the error we get back from dbConnection.Create()
-const UniqueConstraintViolationErrorPrefix = "pq: duplicate key value violates unique constraint"
+// uniqueConstraintViolationErrorPrefix This is the error we get back from dbConnection.Create()
+const uniqueConstraintViolationErrorPrefix = "pq: duplicate key value violates unique constraint"

--- a/pkg/models/move_test.go
+++ b/pkg/models/move_test.go
@@ -23,8 +23,9 @@ func (suite *ModelSuite) TestFetchMove() {
 	order2, _ := testdatagen.MakeOrder(suite.db)
 
 	var selectedType = internalmessages.SelectedMoveTypeCOMBO
-	move, err := order1.CreateNewMove(suite.db, &selectedType)
+	move, verrs, err := order1.CreateNewMove(suite.db, &selectedType)
 	suite.Nil(err)
+	suite.False(verrs.HasAny(), "failed to validate move")
 	suite.Equal(6, len(move.Locator))
 
 	// All correct

--- a/pkg/models/order.go
+++ b/pkg/models/order.go
@@ -101,6 +101,6 @@ func FetchOrder(db *pop.Connection, user User, id uuid.UUID) (Order, error) {
 }
 
 // CreateNewMove creates a move associated with these Orders
-func (o *Order) CreateNewMove(db *pop.Connection, moveType *internalmessages.SelectedMoveType) (*Move, error) {
+func (o *Order) CreateNewMove(db *pop.Connection, moveType *internalmessages.SelectedMoveType) (*Move, *validate.Errors, error) {
 	return createNewMove(db, o.ID, moveType)
 }

--- a/pkg/testdatagen/make_move.go
+++ b/pkg/testdatagen/make_move.go
@@ -15,8 +15,8 @@ func MakeMove(db *pop.Connection) (models.Move, error) {
 	}
 
 	var selectedType = internalmessages.SelectedMoveTypePPM
-	move, err := orders.CreateNewMove(db, &selectedType)
-	if err != nil {
+	move, verrs, err := orders.CreateNewMove(db, &selectedType)
+	if verrs.HasAny() || err != nil {
 		return models.Move{}, err
 	}
 	move.Orders = orders


### PR DESCRIPTION
## Description

This is a PR that would merge into @ntwyman 's PR for adding a record locator. 

It uses the model creation convention that we've been using elsewhere to bubble up both err and verrs from the pop validateandcreate call. 

## Reviewer Notes

Nick: this is how we've been doing it elsewhere, feel free to take as much or as little as you like. I wanted you to see what our pattern is so you can form an opinion on it.

## Code Review Verification Steps

* [ ] All tests pass.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/blob/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* [ ] Any migrations/schema changes also update the diagram in docs/schema/dp3.sqs
* [ ] There are no [aXe](https://www.deque.com/products/aXe/) warnings for UI.
* [ ] This works in IE.
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @willowbl00
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Request review from a member of a different team.
* [ ] (TRIAL) Have the Pivotal acceptance criteria been met for this change?

