### PR TITLE
Cleans up css on legalese page [delivers #157599042]

### DIFF
--- a/src/scenes/Legalese/index.css
+++ b/src/scenes/Legalese/index.css
@@ -7,20 +7,29 @@
   margin: 0;
 }
 
-.signature_form {
-  background-color: #aeb0b5;
+.signature-form {
   padding: 2rem;
   margin-top: 1em;
 }
 
-.signing_box {
+.signature-box {
+  background-color: #E8E8E8;
+  margin-top: 1em;
+  padding: 1em;
+}
+
+.signature-box > h3 {
+  margin-top: .5em;
+}
+
+.signature-fields {
   display: flex;
   flex-wrap: wrap;
   justify-content: space-between;
   margin: 0 -10px; /* This trick stolen from https://stackoverflow.com/a/48450531/559073 */
 }
 
-.signing_box > * {
+.signature-fields > * {
   margin-top: 0;
   margin: 0 10px;
 }
@@ -29,7 +38,7 @@ div.signature {
   flex-grow: 1;
 }
 
-div.signature_date  {
+div.signature-date  {
   flex-grow: 1;
   max-width: 200px;
 }

--- a/src/scenes/Legalese/index.jsx
+++ b/src/scenes/Legalese/index.jsx
@@ -31,7 +31,7 @@ const validateSignatureForm = (values, form) => {
   return errors;
 };
 
-const formName = 'signature_form';
+const formName = 'signature-form';
 const SignatureWizardForm = reduxifyWizardForm(formName, validateSignatureForm);
 
 export class SignedCertification extends Component {
@@ -111,29 +111,31 @@ export class SignedCertification extends Component {
                 certificationText={this.props.certificationText}
               />
 
-              <h3>SIGNATURE</h3>
-              <p>
-                In consideration of said household goods or mobile homes being
-                shipped at Government expense,{' '}
-                <strong>
-                  I hereby agree to the certifications stated above.
-                </strong>
-              </p>
-              <div className="signing_box">
-                <SwaggerField
-                  className="signature"
-                  fieldName="signature"
-                  swagger={this.props.schema}
-                  required
-                  disabled={!!initialValues.signature}
-                />
-                <SwaggerField
-                  className="signature_date"
-                  fieldName="date"
-                  swagger={this.props.schema}
-                  required
-                  disabled
-                />
+              <div className="signature-box">
+                <h3>SIGNATURE</h3>
+                <p>
+                  In consideration of said household goods or mobile homes being
+                  shipped at Government expense,{' '}
+                  <strong>
+                    I hereby agree to the certifications stated above.
+                  </strong>
+                </p>
+                <div className="signature-fields">
+                  <SwaggerField
+                    className="signature"
+                    fieldName="signature"
+                    swagger={this.props.schema}
+                    required
+                    disabled={!!initialValues.signature}
+                  />
+                  <SwaggerField
+                    className="signature-date"
+                    fieldName="date"
+                    swagger={this.props.schema}
+                    required
+                    disabled
+                  />
+                </div>
               </div>
 
               {hasSubmitError && (


### PR DESCRIPTION
## Description

Legalese page was looking overcast, now it looks better.

## Code Review Verification Steps

* [ ] All tests pass.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/blob/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* [ ] Any migrations/schema changes also update the diagram in docs/schema/dp3.sqs
* [ ] There are no [aXe](https://www.deque.com/products/aXe/) warnings for UI.
* [ ] This works in IE.
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @willowbl00
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Request review from a member of a different team.
* [ ] (TRIAL) Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/157599042) for this change

## Screenshots

<img width="857" alt="screenshot 2018-05-15 09 29 10" src="https://user-images.githubusercontent.com/5151804/40070272-71dcf642-5822-11e8-908a-7fdbf5a19112.png">
