### PR TITLE
POST-DEMO Improved logging when login.gov returns and error.

### DIFF
--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -355,8 +355,10 @@ func fetchToken(logger *zap.Logger, code string, clientID string, loginGovProvid
 		return nil, err
 	}
 
+	logger.Info("Token response Body", zap.String("body", string(responseBody)))
 	var parsedResponse LoginGovTokenResponse
 	json.Unmarshal(responseBody, &parsedResponse)
+	logger.Info("Parsed token response Body", zap.Any("body", parsedResponse))
 
 	// TODO: get goth session from storage instead of constructing a new one
 	session := openidConnect.Session{

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -271,6 +271,7 @@ func (h AuthorizationCallbackHandler) ServeHTTP(w http.ResponseWriter, r *http.R
 
 	authError := r.URL.Query().Get("error")
 	lURL := h.landingURL(r)
+	h.logger.Info("CB")
 
 	// The user has either cancelled or declined to authorize the client
 	if authError == "access_denied" {
@@ -290,6 +291,7 @@ func (h AuthorizationCallbackHandler) ServeHTTP(w http.ResponseWriter, r *http.R
 		return
 	}
 
+	h.logger.Info("FETCH TOKEN")
 	// TODO: validate the state is the same (pull from session)
 	code := r.URL.Query().Get("code")
 	session, err := fetchToken(h.logger, code, provider.ClientKey, h.loginGovProvider)
@@ -298,6 +300,7 @@ func (h AuthorizationCallbackHandler) ServeHTTP(w http.ResponseWriter, r *http.R
 		return
 	}
 
+	h.logger.Info("SESSION", zap.Any("session", session))
 	openIDuser, err := provider.FetchUser(session)
 	if err != nil {
 		h.logger.Error("Login.gov user info request", zap.Error(err))

--- a/pkg/auth/login_gov.go
+++ b/pkg/auth/login_gov.go
@@ -179,6 +179,7 @@ func (p LoginGovProvider) createClientAssertionJWT(clientID string, expiry time.
 
 // LoginGovTokenResponse is a struct for parsing responses from the token endpoint
 type LoginGovTokenResponse struct {
+	Error       string `json:"error"`
 	AccessToken string `json:"access_token"`
 	ExpiresIn   int    `json:"expires_in"`
 	IDToken     string `json:"id_token"`


### PR DESCRIPTION
## Description

When a request to a login.gov endpoint returns an error, it does so as a field in the JSON return. 

This change makes sure we pay attention to those errors.

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Code Review Verification Steps

* [ ] All tests pass.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/blob/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* [ ] Any migrations/schema changes also update the diagram in docs/schema/dp3.sqs
* [ ] There are no [aXe](https://www.deque.com/products/aXe/) warnings for UI.
* [ ] This works in IE.
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @willowbl00
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Request review from a member of a different team.
* [ ] (TRIAL) Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](tbd) for this change
* [this article](tbd) explains more about the approach used.

## Screenshots

If this PR makes visible UI changes, an image of the finished UI can help reviewers and casual
observers understand the context of the changes. A before image is optional and
can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow instead of using multiple images. You may want to use GIPHY CAPTURE for this! 📸

_Please frame screenshots to show enough useful context but also highlight the affected regions._
