### PR TITLE
POST DEMO force login to access office pages

### DIFF
--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -7,7 +7,7 @@ import { get, capitalize } from 'lodash';
 import moment from 'moment';
 
 import { RoutedTabs, NavTab } from 'react-router-tabs';
-import { Route, Switch, Redirect } from 'react-router-dom';
+import { Switch, Redirect } from 'react-router-dom';
 
 import LoadingPlaceholder from 'shared/LoadingPlaceholder';
 import PrivateRoute from 'shared/User/PrivateRoute';

--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -10,6 +10,7 @@ import { RoutedTabs, NavTab } from 'react-router-tabs';
 import { Route, Switch, Redirect } from 'react-router-dom';
 
 import LoadingPlaceholder from 'shared/LoadingPlaceholder';
+import PrivateRoute from 'shared/User/PrivateRoute';
 import Alert from 'shared/Alert'; // eslint-disable-line
 import AccountingPanel from './AccountingPanel';
 import BackupInfoPanel from './BackupInfoPanel';
@@ -158,18 +159,18 @@ class MoveInfo extends Component {
 
             <div className="tab-content">
               <Switch>
-                <Route
+                <PrivateRoute
                   exact
                   path={`${this.props.match.url}`}
                   render={() => (
                     <Redirect replace to={`${this.props.match.url}/basics`} />
                   )}
                 />
-                <Route
+                <PrivateRoute
                   path={`${this.props.match.path}/basics`}
                   component={BasicsTabContent}
                 />
-                <Route
+                <PrivateRoute
                   path={`${this.props.match.path}/ppm`}
                   component={PPMTabContent}
                 />

--- a/src/scenes/Office/index.jsx
+++ b/src/scenes/Office/index.jsx
@@ -13,6 +13,7 @@ import { loadUserAndToken } from 'shared/User/ducks';
 import { loadLoggedInUser } from 'shared/User/ducks';
 import { loadSchema } from 'shared/Swagger/ducks';
 import { no_op } from 'shared/utils';
+import PrivateRoute from 'shared/User/PrivateRoute';
 
 class Queues extends Component {
   render() {
@@ -45,11 +46,11 @@ class OfficeWrapper extends Component {
             <div>
               <Switch>
                 <Redirect from="/" to="/queues/new" exact />
-                <Route
+                <PrivateRoute
                   path="/queues/:queueType/moves/:moveId"
                   component={MoveInfo}
                 />
-                <Route path="/queues/:queueType" component={Queues} />
+                <PrivateRoute path="/queues/:queueType" component={Queues} />
               </Switch>
             </div>
           </main>

--- a/src/scenes/Office/index.jsx
+++ b/src/scenes/Office/index.jsx
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { Redirect, Route, Switch } from 'react-router-dom';
+import { Redirect, Switch } from 'react-router-dom';
 import { ConnectedRouter } from 'react-router-redux';
 import { history } from 'shared/store';
 import { connect } from 'react-redux';


### PR DESCRIPTION
## Description

If user tries to see a page in office flow without logging in, they're redirected to login.

## Reviewer Notes

Using shared PrivateRoute functionality

## Code Review Verification Steps

* [x] All tests pass.
* [x] This works in IE.
* [x] Request review from a member of a different team.
* [x] (TRIAL) Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/157612325) for this change

## Screenshots

<img width="1346" alt="screen shot 2018-05-16 at 10 58 54 am" src="https://user-images.githubusercontent.com/7401870/40134830-6c3966cc-58f8-11e8-9111-f85eda54fbf8.png">
<img width="1421" alt="screen shot 2018-05-16 at 10 59 01 am" src="https://user-images.githubusercontent.com/7401870/40134831-6c4dfc7c-58f8-11e8-9876-4110df128c9c.png">
