### PR TITLE
Rek orders panel display view

### DIFF
--- a/pkg/handlers/orders.go
+++ b/pkg/handlers/orders.go
@@ -37,7 +37,7 @@ func payloadForOrdersModel(storage FileStorer, order models.Order) (*internalmes
 		NewDutyStation:   payloadForDutyStationModel(order.NewDutyStation),
 		HasDependents:    fmtBool(order.HasDependents),
 		UploadedOrders:   documentPayload,
-		OrdersNumber:     fmtString(*order.OrdersNumber),
+		OrdersNumber:     order.OrdersNumber,
 		Moves:            moves,
 	}
 

--- a/pkg/handlers/orders.go
+++ b/pkg/handlers/orders.go
@@ -26,17 +26,19 @@ func payloadForOrdersModel(storage FileStorer, order models.Order) (*internalmes
 	}
 
 	payload := &internalmessages.Orders{
-		ID:              fmtUUID(order.ID),
-		CreatedAt:       fmtDateTime(order.CreatedAt),
-		UpdatedAt:       fmtDateTime(order.UpdatedAt),
-		ServiceMemberID: fmtUUID(order.ServiceMemberID),
-		IssueDate:       fmtDate(order.IssueDate),
-		ReportByDate:    fmtDate(order.ReportByDate),
-		OrdersType:      order.OrdersType,
-		NewDutyStation:  payloadForDutyStationModel(order.NewDutyStation),
-		HasDependents:   fmtBool(order.HasDependents),
-		UploadedOrders:  documentPayload,
-		Moves:           moves,
+		ID:               fmtUUID(order.ID),
+		CreatedAt:        fmtDateTime(order.CreatedAt),
+		UpdatedAt:        fmtDateTime(order.UpdatedAt),
+		ServiceMemberID:  fmtUUID(order.ServiceMemberID),
+		IssueDate:        fmtDate(order.IssueDate),
+		ReportByDate:     fmtDate(order.ReportByDate),
+		OrdersType:       order.OrdersType,
+		OrdersTypeDetail: order.OrdersTypeDetail,
+		NewDutyStation:   payloadForDutyStationModel(order.NewDutyStation),
+		HasDependents:    fmtBool(order.HasDependents),
+		UploadedOrders:   documentPayload,
+		OrdersNumber:     fmtString(*order.OrdersNumber),
+		Moves:            moves,
 	}
 
 	return payload, nil

--- a/pkg/models/order.go
+++ b/pkg/models/order.go
@@ -43,7 +43,6 @@ type Order struct {
 	HasDependents       bool                               `json:"has_dependents" db:"has_dependents"`
 	NewDutyStationID    uuid.UUID                          `json:"new_duty_station_id" db:"new_duty_station_id"`
 	NewDutyStation      DutyStation                        `belongs_to:"duty_stations"`
-	CurrentDutyStation  *DutyStation                       `belongs_to:"duty_stations"`
 	UploadedOrders      Document                           `belongs_to:"documents"`
 	UploadedOrdersID    uuid.UUID                          `json:"uploaded_orders_id" db:"uploaded_orders_id"`
 	OrdersNumber        *string                            `json:"orders_number" db:"orders_number"`

--- a/pkg/models/order.go
+++ b/pkg/models/order.go
@@ -100,7 +100,9 @@ func SaveOrder(db *pop.Connection, order *Order) (*validate.Errors, error) {
 // FetchOrder returns orders only if it is allowed for the given user to access those orders.
 func FetchOrder(db *pop.Connection, user User, reqApp string, id uuid.UUID) (Order, error) {
 	var order Order
-	err := db.Q().Eager("ServiceMember.User", "NewDutyStation.Address", "UploadedOrders.Uploads").Find(&order, id)
+	err := db.Q().Eager("ServiceMember.User",
+		"NewDutyStation.Address",
+		"UploadedOrders.Uploads").Find(&order, id)
 	if err != nil {
 		if errors.Cause(err).Error() == recordNotFoundErrorString {
 			return Order{}, ErrFetchNotFound

--- a/src/scenes/Office/AccountingPanel.jsx
+++ b/src/scenes/Office/AccountingPanel.jsx
@@ -11,18 +11,18 @@ import { SwaggerField } from 'shared/JsonSchemaForm/JsonSchemaField';
 import { PanelSwaggerField } from 'shared/EditablePanel';
 
 const AccountingDisplay = props => {
-  const ordersFieldProps = {
+  const fieldProps = {
     schema: props.ordersSchema,
-    values: props.displayOrdersValues,
+    values: props.orders,
   };
 
   return (
     <React.Fragment>
       <div className="editable-panel-column">
-        <PanelSwaggerField fieldName="dept_indicator" {...ordersFieldProps} />
+        <PanelSwaggerField fieldName="dept_indicator" {...fieldProps} />
       </div>
       <div className="editable-panel-column">
-        <PanelSwaggerField fieldName="tac" {...ordersFieldProps} />
+        <PanelSwaggerField fieldName="tac" {...fieldProps} />
       </div>
     </React.Fragment>
   );
@@ -59,7 +59,7 @@ function mapStateToProps(state) {
       state.office.accountingHasLoadError ||
       state.office.accountingHasUpdateError,
     errorMessage: state.office.error,
-    displayOrdersValues: state.office.accounting || {},
+    orders: state.office.accounting || {},
     isUpdating: state.office.accountingIsUpdating,
   };
 }

--- a/src/scenes/Office/AccountingPanel.jsx
+++ b/src/scenes/Office/AccountingPanel.jsx
@@ -1,4 +1,4 @@
-import { get, pick } from 'lodash';
+import { get } from 'lodash';
 import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
@@ -11,14 +11,18 @@ import { SwaggerField } from 'shared/JsonSchemaForm/JsonSchemaField';
 import { PanelSwaggerField } from 'shared/EditablePanel';
 
 const AccountingDisplay = props => {
-  const fieldProps = pick(props, ['schema', 'values']);
+  const ordersFieldProps = {
+    schema: props.ordersSchema,
+    values: props.displayOrdersValues,
+  };
+
   return (
     <React.Fragment>
       <div className="editable-panel-column">
-        <PanelSwaggerField fieldName="dept_indicator" {...fieldProps} />
+        <PanelSwaggerField fieldName="dept_indicator" {...ordersFieldProps} />
       </div>
       <div className="editable-panel-column">
-        <PanelSwaggerField fieldName="tac" {...fieldProps} />
+        <PanelSwaggerField fieldName="tac" {...ordersFieldProps} />
       </div>
     </React.Fragment>
   );
@@ -50,12 +54,12 @@ function mapStateToProps(state) {
     initialValues: state.office.accounting,
 
     // Wrapper
-    schema: get(state, 'swagger.spec.definitions.PatchAccounting', {}),
+    ordersSchema: get(state, 'swagger.spec.definitions.PatchAccounting', {}),
     hasError:
       state.office.accountingHasLoadError ||
       state.office.accountingHasUpdateError,
     errorMessage: state.office.error,
-    displayValues: state.office.accounting || {},
+    displayOrdersValues: state.office.accounting || {},
     isUpdating: state.office.accountingIsUpdating,
   };
 }

--- a/src/scenes/Office/CustomerInfoPanel.jsx
+++ b/src/scenes/Office/CustomerInfoPanel.jsx
@@ -21,11 +21,11 @@ import faComments from '@fortawesome/fontawesome-free-solid/faComments';
 import faEmail from '@fortawesome/fontawesome-free-solid/faEnvelope';
 
 const CustomerInfoDisplay = props => {
-  const serviceMemberFieldProps = {
+  const fieldProps = {
     schema: props.serviceMemberSchema,
-    values: props.displayServiceMemberValues,
+    values: props.serviceMember,
   };
-  const values = props.displayServiceMemberValues;
+  const values = props.serviceMember;
   const name = compact([values.last_name, values.first_name]).join(', ');
   const address = values.residential_address || {};
 
@@ -33,31 +33,27 @@ const CustomerInfoDisplay = props => {
     <React.Fragment>
       <div className="editable-panel-column">
         <PanelField title="Name" value={name} />
-        <PanelSwaggerField
-          title="DoD ID"
-          fieldName="edipi"
-          {...serviceMemberFieldProps}
-        />
+        <PanelSwaggerField title="DoD ID" fieldName="edipi" {...fieldProps} />
         <PanelField title="Branch & rank">
-          <SwaggerValue fieldName="affiliation" {...serviceMemberFieldProps} />{' '}
-          - <SwaggerValue fieldName="rank" {...serviceMemberFieldProps} />
+          <SwaggerValue fieldName="affiliation" {...fieldProps} /> -{' '}
+          <SwaggerValue fieldName="rank" {...fieldProps} />
         </PanelField>
       </div>
       <div className="editable-panel-column">
         <PanelSwaggerField
           title="Phone"
           fieldName="telephone"
-          {...serviceMemberFieldProps}
+          {...fieldProps}
         />
         <PanelSwaggerField
           title="Alt. Phone"
           fieldName="secondary_telephone"
-          {...serviceMemberFieldProps}
+          {...fieldProps}
         />
         <PanelSwaggerField
           title="Email"
           fieldName="personal_email"
-          {...serviceMemberFieldProps}
+          {...fieldProps}
         />
         <PanelField title="Pref. contact" className="contact-prefs">
           {values.phone_is_preferred && (
@@ -230,7 +226,7 @@ function mapStateToProps(state) {
     ),
     hasError: false,
     errorMessage: state.office.error,
-    displayServiceMemberValues: state.office.officeServiceMember,
+    serviceMember: state.office.officeServiceMember,
     isUpdating: false,
   };
 }

--- a/src/scenes/Office/CustomerInfoPanel.jsx
+++ b/src/scenes/Office/CustomerInfoPanel.jsx
@@ -1,4 +1,4 @@
-import { get, pick, compact } from 'lodash';
+import { get, compact } from 'lodash';
 import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
@@ -21,8 +21,11 @@ import faComments from '@fortawesome/fontawesome-free-solid/faComments';
 import faEmail from '@fortawesome/fontawesome-free-solid/faEnvelope';
 
 const CustomerInfoDisplay = props => {
-  const fieldProps = pick(props, ['schema', 'values']);
-  const values = props.values;
+  const serviceMemberFieldProps = {
+    schema: props.serviceMemberSchema,
+    values: props.displayServiceMemberValues,
+  };
+  const values = props.displayServiceMemberValues;
   const name = compact([values.last_name, values.first_name]).join(', ');
   const address = values.residential_address || {};
 
@@ -30,27 +33,31 @@ const CustomerInfoDisplay = props => {
     <React.Fragment>
       <div className="editable-panel-column">
         <PanelField title="Name" value={name} />
-        <PanelSwaggerField title="DoD ID" fieldName="edipi" {...fieldProps} />
+        <PanelSwaggerField
+          title="DoD ID"
+          fieldName="edipi"
+          {...serviceMemberFieldProps}
+        />
         <PanelField title="Branch & rank">
-          <SwaggerValue fieldName="affiliation" {...fieldProps} /> -{' '}
-          <SwaggerValue fieldName="rank" {...fieldProps} />
+          <SwaggerValue fieldName="affiliation" {...serviceMemberFieldProps} />{' '}
+          - <SwaggerValue fieldName="rank" {...serviceMemberFieldProps} />
         </PanelField>
       </div>
       <div className="editable-panel-column">
         <PanelSwaggerField
           title="Phone"
           fieldName="telephone"
-          {...fieldProps}
+          {...serviceMemberFieldProps}
         />
         <PanelSwaggerField
           title="Alt. Phone"
           fieldName="secondary_telephone"
-          {...fieldProps}
+          {...serviceMemberFieldProps}
         />
         <PanelSwaggerField
           title="Email"
           fieldName="personal_email"
-          {...fieldProps}
+          {...serviceMemberFieldProps}
         />
         <PanelField title="Pref. contact" className="contact-prefs">
           {values.phone_is_preferred && (
@@ -217,10 +224,13 @@ function mapStateToProps(state) {
     initialValues: {},
 
     // Wrapper
-    schema: get(state, 'swagger.spec.definitions.ServiceMemberPayload'),
+    serviceMemberSchema: get(
+      state,
+      'swagger.spec.definitions.ServiceMemberPayload',
+    ),
     hasError: false,
     errorMessage: state.office.error,
-    displayValues: state.office.officeServiceMember,
+    displayServiceMemberValues: state.office.officeServiceMember,
     isUpdating: false,
   };
 }

--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -125,8 +125,8 @@ class MoveInfo extends Component {
                   <FontAwesomeIcon className="icon" icon={faEmail} />
                 )}
               </li>
-              <li className="Todo">Locator# {officeMove.locator}</li>
-              <li>KKFA to HAFC</li>
+              <li>Locator# {officeMove.locator}</li>
+              <li className="Todo">KKFA to HAFC</li>
               <li>
                 Requested Pickup {get(officePPMs, '[0].planned_move_date')}
               </li>

--- a/src/scenes/Office/OrdersPanel.jsx
+++ b/src/scenes/Office/OrdersPanel.jsx
@@ -18,43 +18,37 @@ import FontAwesomeIcon from '@fortawesome/react-fontawesome';
 import faExternalLinkAlt from '@fortawesome/fontawesome-free-solid/faExternalLinkAlt';
 
 const OrdersDisplay = props => {
-  const ordersFieldProps = {
+  const fieldProps = {
     schema: props.ordersSchema,
-    values: props.displayOrdersValues,
+    values: props.orders,
   };
 
   return (
     <React.Fragment>
       <div className="editable-panel-column">
         <PanelField title="Orders Number">
-          <a
-            href={props.displayOrdersValues.uploaded_orders.uploads.url}
-            target="_blank"
-          >
-            <SwaggerValue fieldName="orders_number" {...ordersFieldProps} />&nbsp;
+          <a href={props.orders.uploaded_orders.uploads.url} target="_blank">
+            <SwaggerValue fieldName="orders_number" {...fieldProps} />&nbsp;
             <FontAwesomeIcon className="icon" icon={faExternalLinkAlt} />
           </a>
         </PanelField>
         <PanelSwaggerField
           title="Date issued"
           fieldName="issue_date"
-          {...ordersFieldProps}
+          {...fieldProps}
         />
-        <PanelSwaggerField fieldName="orders_type" {...ordersFieldProps} />
-        <PanelSwaggerField
-          fieldName="orders_type_detail"
-          {...ordersFieldProps}
-        />
+        <PanelSwaggerField fieldName="orders_type" {...fieldProps} />
+        <PanelSwaggerField fieldName="orders_type_detail" {...fieldProps} />
         <PanelSwaggerField
           title="Report by"
           fieldName="report_by_date"
-          {...ordersFieldProps}
+          {...fieldProps}
         />
         <PanelField title="Current Duty Station">
-          {get(props.displayServiceMemberValues, 'current_station.name', '')}
+          {get(props.serviceMember, 'current_station.name', '')}
         </PanelField>
         <PanelField title="New Duty Station">
-          {get(props.displayOrdersValues, 'new_duty_station.name', '')}
+          {get(props.orders, 'new_duty_station.name', '')}
         </PanelField>
       </div>
       <div className="editable-panel-column">
@@ -71,14 +65,9 @@ const OrdersDisplay = props => {
         <PanelField className="Todo" title="Short-term storage">
           90 days
         </PanelField>
-        <PanelField
-          title="Dependents"
-          value={
-            props.displayOrdersValues.has_dependents
-              ? 'Authorized'
-              : 'Unauthorized'
-          }
-        />
+        {props.orders.has_dependents && (
+          <PanelField title="Dependents" value="Authorized" />
+        )}
       </div>
     </React.Fragment>
   );
@@ -196,8 +185,8 @@ function mapStateToProps(state) {
 
     hasError: false,
     errorMessage: state.office.error,
-    displayOrdersValues: get(state, 'office.officeOrders'),
-    displayServiceMemberValues: get(state, 'office.officeServiceMember'),
+    orders: get(state, 'office.officeOrders'),
+    serviceMember: get(state, 'office.officeServiceMember'),
     entitlements: loadEntitlements(state),
     isUpdating: false,
   };

--- a/src/scenes/Office/OrdersPanel.jsx
+++ b/src/scenes/Office/OrdersPanel.jsx
@@ -1,4 +1,4 @@
-// import { get, pick } from 'lodash';
+import { get, pick } from 'lodash';
 import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
@@ -7,15 +7,44 @@ import editablePanel from './editablePanel';
 
 import { no_op_action } from 'shared/utils';
 
-// import { updateOrders, loadOrders } from './ducks';
-// import { PanelField } from 'shared/EditablePanel';
-// import { SwaggerField } from 'shared/JsonSchemaForm/JsonSchemaField';
+// import { updateOrders } from './ducks';
+import { PanelSwaggerField, PanelField } from 'shared/EditablePanel';
 
 const OrdersDisplay = props => {
-  // const fieldProps = pick(props, ['schema', 'values']);
+  const fieldProps = pick(props, ['schema', 'values']);
+  const values = props.values;
   return (
     <React.Fragment>
-      <div className="editable-panel-column" />
+      <div className="editable-panel-column">
+        <PanelSwaggerField fieldName="orders_number" {...fieldProps} />
+        <PanelSwaggerField
+          title="Date issued"
+          fieldName="issue_date"
+          {...fieldProps}
+        />
+        <PanelSwaggerField
+          title="Move type"
+          fieldName="orders_type"
+          {...fieldProps}
+        />
+        <PanelSwaggerField
+          title="Orders type"
+          fieldName="orders_type_detail"
+          {...fieldProps}
+        />
+        <PanelSwaggerField
+          title="Report by"
+          fieldName="report_by_date"
+          {...fieldProps}
+        />
+        <PanelField title="Current Duty Station">
+          {values.current_duty_station && `${values.current_duty_station.name}`}
+        </PanelField>
+        <PanelField title="New Duty Station">
+          {values.new_duty_station && `${values.new_duty_station.name}`}
+        </PanelField>
+      </div>
+      <div className="editable-panel-column">Entitlements</div>
     </React.Fragment>
   );
 };
@@ -125,13 +154,12 @@ function mapStateToProps(state) {
   return {
     // reduxForm
     formData: state.form[formName],
-    initialValues: {},
 
     // Wrapper
-    schema: {},
+    schema: get(state, 'swagger.spec.definitions.Orders'),
     hasError: false,
     errorMessage: state.office.error,
-    displayValues: {},
+    displayValues: get(state, 'office.officeOrders'),
     isUpdating: false,
   };
 }

--- a/src/scenes/Office/OrdersPanel.jsx
+++ b/src/scenes/Office/OrdersPanel.jsx
@@ -22,10 +22,6 @@ const OrdersDisplay = props => {
     schema: props.ordersSchema,
     values: props.displayOrdersValues,
   };
-  const serviceMemberFieldProps = {
-    schema: props.serviceMemberSchema,
-    values: props.displayServiceMemberValues,
-  };
 
   return (
     <React.Fragment>
@@ -58,6 +54,20 @@ const OrdersDisplay = props => {
       </div>
       <div className="editable-panel-column">
         <span className="editable-panel-column subheader">Entitlements</span>
+        <PanelField title="Household Goods">
+          {get(props.entitlements, 'total', '')} lbs
+        </PanelField>
+        <PanelField title="Pro-gear">
+          {get(props.entitlements, 'pro_gear', '')} lbs
+        </PanelField>
+        <PanelField title="Spouse pro-gear">
+          {get(props.entitlements, 'pro_gear_spouse', '')} lbs
+        </PanelField>
+        <PanelSwaggerField
+          title="Dependents"
+          fieldName="has_dependents"
+          {...ordersFieldProps}
+        />
       </div>
     </React.Fragment>
   );
@@ -172,16 +182,12 @@ function mapStateToProps(state) {
 
     // Wrapper
     ordersSchema: get(state, 'swagger.spec.definitions.Orders'),
-    serviceMemberSchema: get(
-      state,
-      'swagger.spec.definitions.ServiceMemberPayload',
-    ),
 
     hasError: false,
     errorMessage: state.office.error,
     displayOrdersValues: get(state, 'office.officeOrders'),
     displayServiceMemberValues: get(state, 'office.officeServiceMember'),
-    entitlements: loadEntitlements(state.orders),
+    entitlements: loadEntitlements(state),
     isUpdating: false,
   };
 }

--- a/src/scenes/Office/OrdersPanel.jsx
+++ b/src/scenes/Office/OrdersPanel.jsx
@@ -8,7 +8,14 @@ import editablePanel from './editablePanel';
 import { no_op_action } from 'shared/utils';
 
 // import { updateOrders } from './ducks';
-import { PanelSwaggerField, PanelField } from 'shared/EditablePanel';
+import {
+  PanelSwaggerField,
+  PanelField,
+  SwaggerValue,
+} from 'shared/EditablePanel';
+
+import FontAwesomeIcon from '@fortawesome/react-fontawesome';
+import faExternalLinkAlt from '@fortawesome/fontawesome-free-solid/faExternalLinkAlt';
 
 const OrdersDisplay = props => {
   const fieldProps = pick(props, ['schema', 'values']);
@@ -16,7 +23,10 @@ const OrdersDisplay = props => {
   return (
     <React.Fragment>
       <div className="editable-panel-column">
-        <PanelSwaggerField fieldName="orders_number" {...fieldProps} />
+        <PanelField title="Orders Number">
+          <SwaggerValue fieldName="orders_number" {...fieldProps} />
+          <FontAwesomeIcon className="icon" icon={faExternalLinkAlt} />
+        </PanelField>
         <PanelSwaggerField
           title="Date issued"
           fieldName="issue_date"
@@ -146,6 +156,7 @@ function mapStateToProps(state) {
   return {
     // reduxForm
     formData: state.form[formName],
+    initialValues: {},
 
     // Wrapper
     schema: get(state, 'swagger.spec.definitions.Orders'),

--- a/src/scenes/Office/OrdersPanel.jsx
+++ b/src/scenes/Office/OrdersPanel.jsx
@@ -27,8 +27,13 @@ const OrdersDisplay = props => {
     <React.Fragment>
       <div className="editable-panel-column">
         <PanelField title="Orders Number">
-          <SwaggerValue fieldName="orders_number" {...ordersFieldProps} />&nbsp;
-          <FontAwesomeIcon className="icon" icon={faExternalLinkAlt} />
+          <a
+            href={props.displayOrdersValues.uploaded_orders.uploads.url}
+            target="_blank"
+          >
+            <SwaggerValue fieldName="orders_number" {...ordersFieldProps} />&nbsp;
+            <FontAwesomeIcon className="icon" icon={faExternalLinkAlt} />
+          </a>
         </PanelField>
         <PanelSwaggerField
           title="Date issued"
@@ -64,13 +69,16 @@ const OrdersDisplay = props => {
           {get(props.entitlements, 'pro_gear_spouse', '')} lbs
         </PanelField>
         <PanelField className="Todo" title="Short-term storage">
-          TODO
+          90 days
         </PanelField>
-        <PanelField title="Dependents" fieldName="has_dependents">
-          {props.displayOrdersValues.has_dependents
-            ? 'Authorized'
-            : 'Unauthorized'}
-        </PanelField>
+        <PanelField
+          title="Dependents"
+          value={
+            props.displayOrdersValues.has_dependents
+              ? 'Authorized'
+              : 'Unauthorized'
+          }
+        />
       </div>
     </React.Fragment>
   );

--- a/src/scenes/Office/OrdersPanel.jsx
+++ b/src/scenes/Office/OrdersPanel.jsx
@@ -1,4 +1,4 @@
-import { get, pick } from 'lodash';
+import { get } from 'lodash';
 import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
@@ -6,7 +6,7 @@ import { reduxForm } from 'redux-form';
 import editablePanel from './editablePanel';
 
 import { no_op_action } from 'shared/utils';
-
+import { loadEntitlements } from 'scenes/Orders/ducks';
 // import { updateOrders } from './ducks';
 import {
   PanelSwaggerField,
@@ -18,32 +18,42 @@ import FontAwesomeIcon from '@fortawesome/react-fontawesome';
 import faExternalLinkAlt from '@fortawesome/fontawesome-free-solid/faExternalLinkAlt';
 
 const OrdersDisplay = props => {
-  const fieldProps = pick(props, ['schema', 'values']);
-  const values = props.values;
+  const ordersFieldProps = {
+    schema: props.ordersSchema,
+    values: props.displayOrdersValues,
+  };
+  const serviceMemberFieldProps = {
+    schema: props.serviceMemberSchema,
+    values: props.displayServiceMemberValues,
+  };
+
   return (
     <React.Fragment>
       <div className="editable-panel-column">
         <PanelField title="Orders Number">
-          <SwaggerValue fieldName="orders_number" {...fieldProps} />&nbsp;
+          <SwaggerValue fieldName="orders_number" {...ordersFieldProps} />&nbsp;
           <FontAwesomeIcon className="icon" icon={faExternalLinkAlt} />
         </PanelField>
         <PanelSwaggerField
           title="Date issued"
           fieldName="issue_date"
-          {...fieldProps}
+          {...ordersFieldProps}
         />
-        <PanelSwaggerField fieldName="orders_type" {...fieldProps} />
-        <PanelSwaggerField fieldName="orders_type_detail" {...fieldProps} />
+        <PanelSwaggerField fieldName="orders_type" {...ordersFieldProps} />
+        <PanelSwaggerField
+          fieldName="orders_type_detail"
+          {...ordersFieldProps}
+        />
         <PanelSwaggerField
           title="Report by"
           fieldName="report_by_date"
-          {...fieldProps}
+          {...ordersFieldProps}
         />
         <PanelField title="Current Duty Station">
-          {values.current_duty_station && `${values.current_duty_station.name}`}
+          {get(props.displayServiceMemberValues, 'current_station.name', '')}
         </PanelField>
         <PanelField title="New Duty Station">
-          {values.new_duty_station && `${values.new_duty_station.name}`}
+          {get(props.displayOrdersValues, 'new_duty_station.name', '')}
         </PanelField>
       </div>
       <div className="editable-panel-column">
@@ -161,12 +171,17 @@ function mapStateToProps(state) {
     initialValues: {},
 
     // Wrapper
-    schema: get(state, 'swagger.spec.definitions.Orders'),
-    serviceMemberSchema: get(state, 'swagger.spec.definitions.ServiceMember'),
+    ordersSchema: get(state, 'swagger.spec.definitions.Orders'),
+    serviceMemberSchema: get(
+      state,
+      'swagger.spec.definitions.ServiceMemberPayload',
+    ),
+
     hasError: false,
     errorMessage: state.office.error,
-    displayValues: get(state, 'office.officeOrders'),
-    displayServiceMember: get(state, 'office.officeServiceMember'),
+    displayOrdersValues: get(state, 'office.officeOrders'),
+    displayServiceMemberValues: get(state, 'office.officeServiceMember'),
+    entitlements: loadEntitlements(state.orders),
     isUpdating: false,
   };
 }

--- a/src/scenes/Office/OrdersPanel.jsx
+++ b/src/scenes/Office/OrdersPanel.jsx
@@ -63,11 +63,14 @@ const OrdersDisplay = props => {
         <PanelField title="Spouse pro-gear">
           {get(props.entitlements, 'pro_gear_spouse', '')} lbs
         </PanelField>
-        <PanelSwaggerField
-          title="Dependents"
-          fieldName="has_dependents"
-          {...ordersFieldProps}
-        />
+        <PanelField className="Todo" title="Short-term storage">
+          TODO
+        </PanelField>
+        <PanelField title="Dependents" fieldName="has_dependents">
+          {props.displayOrdersValues.has_dependents
+            ? 'Authorized'
+            : 'Unauthorized'}
+        </PanelField>
       </div>
     </React.Fragment>
   );

--- a/src/scenes/Office/OrdersPanel.jsx
+++ b/src/scenes/Office/OrdersPanel.jsx
@@ -22,16 +22,8 @@ const OrdersDisplay = props => {
           fieldName="issue_date"
           {...fieldProps}
         />
-        <PanelSwaggerField
-          title="Move type"
-          fieldName="orders_type"
-          {...fieldProps}
-        />
-        <PanelSwaggerField
-          title="Orders type"
-          fieldName="orders_type_detail"
-          {...fieldProps}
-        />
+        <PanelSwaggerField fieldName="orders_type" {...fieldProps} />
+        <PanelSwaggerField fieldName="orders_type_detail" {...fieldProps} />
         <PanelSwaggerField
           title="Report by"
           fieldName="report_by_date"

--- a/src/scenes/Office/OrdersPanel.jsx
+++ b/src/scenes/Office/OrdersPanel.jsx
@@ -24,7 +24,7 @@ const OrdersDisplay = props => {
     <React.Fragment>
       <div className="editable-panel-column">
         <PanelField title="Orders Number">
-          <SwaggerValue fieldName="orders_number" {...fieldProps} />
+          <SwaggerValue fieldName="orders_number" {...fieldProps} />&nbsp;
           <FontAwesomeIcon className="icon" icon={faExternalLinkAlt} />
         </PanelField>
         <PanelSwaggerField
@@ -46,7 +46,9 @@ const OrdersDisplay = props => {
           {values.new_duty_station && `${values.new_duty_station.name}`}
         </PanelField>
       </div>
-      <div className="editable-panel-column">Entitlements</div>
+      <div className="editable-panel-column">
+        <span className="editable-panel-column subheader">Entitlements</span>
+      </div>
     </React.Fragment>
   );
 };
@@ -160,9 +162,11 @@ function mapStateToProps(state) {
 
     // Wrapper
     schema: get(state, 'swagger.spec.definitions.Orders'),
+    serviceMemberSchema: get(state, 'swagger.spec.definitions.ServiceMember'),
     hasError: false,
     errorMessage: state.office.error,
     displayValues: get(state, 'office.officeOrders'),
+    displayServiceMember: get(state, 'office.officeServiceMember'),
     isUpdating: false,
   };
 }

--- a/src/scenes/Office/editablePanel.jsx
+++ b/src/scenes/Office/editablePanel.jsx
@@ -50,8 +50,6 @@ export default function editablePanel(DisplayComponent, EditComponent) {
   };
 
   Wrapper.propTypes = {
-    // schema: PropTypes.object.isRequired,
-    // displayValues: PropTypes.object.isRequired,
     update: PropTypes.func.isRequired,
     moveId: PropTypes.string.isRequired,
     title: PropTypes.string.isRequired,

--- a/src/scenes/Office/editablePanel.jsx
+++ b/src/scenes/Office/editablePanel.jsx
@@ -42,10 +42,7 @@ export default function editablePanel(DisplayComponent, EditComponent) {
             onToggle={this.toggleEditable}
             isEditable={isEditable}
           >
-            <Content
-              values={this.props.displayValues}
-              schema={this.props.schema}
-            />
+            <Content {...this.props} />
           </EditablePanel>
         </React.Fragment>
       );
@@ -53,8 +50,8 @@ export default function editablePanel(DisplayComponent, EditComponent) {
   };
 
   Wrapper.propTypes = {
-    schema: PropTypes.object.isRequired,
-    displayValues: PropTypes.object.isRequired,
+    // schema: PropTypes.object.isRequired,
+    // displayValues: PropTypes.object.isRequired,
     update: PropTypes.func.isRequired,
     moveId: PropTypes.string.isRequired,
     title: PropTypes.string.isRequired,

--- a/src/scenes/Orders/ducks.js
+++ b/src/scenes/Orders/ducks.js
@@ -90,10 +90,16 @@ export function addUploads(uploads) {
 
 // Selectors
 export function loadEntitlements(state) {
-  if (state.currentOrders) {
-    const rank = get(state, 'currentOrders.service_member.rank');
-    const hasDependents = get(state, 'currentOrders.has_dependents');
-
+  if (state.currentOrders || state.office) {
+    var rank;
+    var hasDependents;
+    if (state.currentOrders) {
+      rank = get(state, 'currentOrders.service_member.rank');
+      hasDependents = get(state, 'currentOrders.has_dependents');
+    } else if (state.office.officeOrders) {
+      rank = get(state, 'office.officeServiceMember.rank');
+      hasDependents = get(state, 'office.officeOrders.has_dependents');
+    }
     return getEntitlements(rank, hasDependents);
   }
 }

--- a/src/shared/EditablePanel/index.css
+++ b/src/shared/EditablePanel/index.css
@@ -13,6 +13,11 @@
   vertical-align: top;
 }
 
+.editable-panel-column.subheader {
+  font-weight: bold;
+  font-size: .9em;
+}
+
 .editable-panel-header {
   font-size: 1.7rem;
   font-weight: bold;

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -1282,8 +1282,6 @@ definitions:
         title: Are dependents included in your orders?
       new_duty_station:
         $ref: '#/definitions/DutyStationPayload'
-      current_duty_station:
-        $ref: '#/definitions/DutyStationPayload'
       uploaded_orders:
         $ref: '#/definitions/DocumentPayload'
       moves:

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -1244,7 +1244,7 @@ definitions:
       VARIOUS: Various
   OrdersTypeDetail:
     type: string
-    title: Orders type details
+    title: Orders type detail
     enum:
       - HHG_PERMITTED
       - PCS_TDY

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -1261,6 +1261,7 @@ definitions:
       INSTRUCTION_20_WEEKS: Course of Instruction 20 Weeks or More
       HHG_PROHIBITED_20_WEEKS: Shipment of HHG Prohibited but Authorized within 20 weeks
       DELAYED_APPROVAL: Delayed Approval 20 Weeks or More
+    x-nullable: true
   Orders:
     type: object
     properties:
@@ -1290,7 +1291,6 @@ definitions:
         $ref: "#/definitions/OrdersType"
       orders_type_detail:
         $ref: "#/definitions/OrdersTypeDetail"
-        x-nullable: true
       has_dependents:
         type: boolean
         title: Are dependents included in your orders?
@@ -1298,7 +1298,6 @@ definitions:
         $ref: '#/definitions/DutyStationPayload'
       current_duty_station:
         $ref: '#/definitions/DutyStationPayload'
-        x-nullable: true
       uploaded_orders:
         $ref: '#/definitions/DocumentPayload'
       moves:


### PR DESCRIPTION
## Description

This makes an editable-panel of the orders panel for the office page. It includes loading entitlements as well as info from service member. It should be used to model loading multiple schemas (i.e. orders and service member) in the future. 

## Special attention
* The link to the orders doesn't work and I don't know why. Pointers?
* How do I get commas in the lbs?

## Code Review Verification Steps

* [x] All tests pass.
* [x] There are no [aXe](https://www.deque.com/products/aXe/) warnings for UI.
* [x] This works in IE.
* [x] Request review from a member of a different team.
* [x] (TRIAL) Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/157604358) for this change

## Screenshots

<img width="957" alt="screen shot 2018-05-17 at 1 19 53 pm" src="https://user-images.githubusercontent.com/7401870/40201924-5ef510fa-59d5-11e8-9b8d-c4ddbecc9cc8.png">
