### PR TITLE
Adds entitlement values to client, syncs orders with logged in user [delivers #157577559 #157194900]

### DIFF
--- a/migrations/20180516221730_rank_enum_change.up.fizz
+++ b/migrations/20180516221730_rank_enum_change.up.fizz
@@ -1,0 +1,6 @@
+raw("UPDATE service_members SET rank='O_1_W_1_ACADEMY_GRADUATE' WHERE rank IN ('O_1', 'W_1', 'ACADEMY_GRADUATE');")
+raw("UPDATE service_members SET rank='O_2_W_2' WHERE rank IN ('O_2', 'W_2');")
+raw("UPDATE service_members SET rank='O_3_W_3' WHERE rank IN ('O_3', 'W_3');")
+raw("UPDATE service_members SET rank='O_4_W_4' WHERE rank IN ('O_4', 'W_4');")
+raw("UPDATE service_members SET rank='O_5_W_5' WHERE rank IN ('O_5', 'W_5');")
+raw("UPDATE service_members SET rank='ACADEMY_CADET_MIDSHIPMAN' WHERE rank IN ('ACADEMY_CADET', 'MIDSHIPMAN');")

--- a/src/scenes/Orders/ducks.js
+++ b/src/scenes/Orders/ducks.js
@@ -1,4 +1,4 @@
-import { reject, concat } from 'lodash';
+import { get, reject, concat } from 'lodash';
 import {
   CreateOrders,
   UpdateOrders,
@@ -6,105 +6,53 @@ import {
   ShowCurrentOrdersAPI,
 } from './api.js';
 import { DeleteUpload } from 'shared/api.js';
+import { getEntitlements } from 'shared/entitlements.js';
 import * as ReduxHelpers from 'shared/ReduxHelpers';
 
 // Types
-export const SET_PENDING_ORDERS_TYPE = 'SET_PENDING_ORDERS_TYPE';
-export const CREATE_ORDERS = 'CREATE_ORDERS';
-export const UPDATE_ORDERS = 'UPDATE_ORDERS';
-export const CREATE_OR_UPDATE_ORDERS_SUCCESS =
-  'CREATE_OR_UPDATE_ORDERS_SUCCESS';
-export const CREATE_OR_UPDATE_ORDERS_FAILURE =
-  'CREATE_OR_UPDATE_ORDERS_FAILURE';
-export const GET_ORDERS = 'GET_ORDERS';
-export const GET_ORDERS_SUCCESS = 'GET_ORDERS_SUCCESS';
-export const GET_ORDERS_FAILURE = 'GET_ORDERS_FAILURE';
-export const ADD_UPLOADS_SUCCESS = 'ADD_UPLOADS_SUCCESS';
+const getOrdersType = 'GET_ORDERS';
+export const GET_ORDERS = ReduxHelpers.generateAsyncActionTypes(getOrdersType);
+
+const addUploadsType = 'ADD_UPLOADS';
+export const ADD_UPLOADS = ReduxHelpers.generateAsyncActionTypes(
+  addUploadsType,
+);
+
+const createOrUpdateOrdersType = 'CREATE_OR_UPDATE_ORDERS';
+export const CREATE_OR_UPDATE_ORDERS = ReduxHelpers.generateAsyncActionTypes(
+  createOrUpdateOrdersType,
+);
 
 const showCurrentOrdersType = 'SHOW_CURRENT_ORDERS';
-const deleteUploadType = 'DELETE_UPLOAD';
-
 export const SHOW_CURRENT_ORDERS = ReduxHelpers.generateAsyncActionTypes(
   showCurrentOrdersType,
 );
 
+const deleteUploadType = 'DELETE_UPLOAD';
 export const DELETE_UPLOAD = ReduxHelpers.generateAsyncActionTypes(
   deleteUploadType,
 );
 
+// Actions
 export const showCurrentOrders = ReduxHelpers.generateAsyncActionCreator(
   showCurrentOrdersType,
   ShowCurrentOrdersAPI,
 );
 
-export const createOrdersRequest = () => ({
-  type: CREATE_ORDERS,
-});
+export const createOrders = ReduxHelpers.generateAsyncActionCreator(
+  createOrUpdateOrdersType,
+  CreateOrders,
+);
 
-export const updateOrdersRequest = () => ({
-  type: UPDATE_ORDERS,
-});
+export const updateOrders = ReduxHelpers.generateAsyncActionCreator(
+  createOrUpdateOrdersType,
+  UpdateOrders,
+);
 
-export const createOrUpdateOrdersSuccess = item => ({
-  type: CREATE_OR_UPDATE_ORDERS_SUCCESS,
-  item,
-});
-
-export const createOrUpdateOrdersFailure = error => ({
-  type: CREATE_OR_UPDATE_ORDERS_FAILURE,
-  error,
-});
-
-const getOrdersRequest = () => ({
-  type: GET_ORDERS,
-});
-
-export const getOrdersSuccess = item => ({
-  type: GET_ORDERS_SUCCESS,
-  item,
-  // item: items.length > 0 ? items[0] : null,
-});
-
-export const getOrdersFailure = error => ({
-  type: GET_ORDERS_FAILURE,
-  error,
-});
-
-export const addUploadsSuccess = item => ({
-  type: ADD_UPLOADS_SUCCESS,
-  item,
-});
-
-export function createOrders(orderPayload) {
-  return function(dispatch) {
-    dispatch(createOrdersRequest());
-    CreateOrders(orderPayload)
-      .then(item => dispatch(createOrUpdateOrdersSuccess(item)))
-      .catch(error => dispatch(createOrUpdateOrdersFailure(error)));
-  };
-}
-
-export function updateOrders(orderId, orderPayload) {
-  return function(dispatch) {
-    dispatch(updateOrdersRequest());
-    UpdateOrders(orderId, orderPayload)
-      .then(item => dispatch(createOrUpdateOrdersSuccess(item)))
-      .catch(error => dispatch(createOrUpdateOrdersFailure(error)));
-  };
-}
-
-export function loadOrders(orderId) {
-  return function(dispatch, getState) {
-    const state = getState();
-    const currentOrders = state.orders.currentOrders;
-    if (!currentOrders) {
-      dispatch(getOrdersRequest());
-      GetOrders(orderId)
-        .then(item => dispatch(getOrdersSuccess(item)))
-        .catch(error => dispatch(getOrdersFailure(error)));
-    }
-  };
-}
+export const loadOrders = ReduxHelpers.generateAsyncActionCreator(
+  getOrdersType,
+  GetOrders,
+);
 
 export function deleteUpload(uploadId) {
   return function(dispatch, getState) {
@@ -127,6 +75,7 @@ export function deleteUpload(uploadId) {
 
 export function addUploads(uploads) {
   return function(dispatch, getState) {
+    const action = ReduxHelpers.generateAsyncActions(addUploadsType);
     const state = getState();
     const currentOrders = state.orders.currentOrders;
     if (currentOrders) {
@@ -134,9 +83,19 @@ export function addUploads(uploads) {
         currentOrders.uploaded_orders.uploads,
         ...uploads,
       );
-      dispatch(addUploadsSuccess(currentOrders));
+      dispatch(action.success(currentOrders));
     }
   };
+}
+
+// Selectors
+export function loadEntitlements(state) {
+  if (state.currentOrders) {
+    const rank = get(state, 'currentOrders.service_member.rank');
+    const hasDependents = get(state, 'currentOrders.has_dependents');
+
+    return getEntitlements(rank, hasDependents);
+  }
 }
 
 // Reducer
@@ -148,33 +107,29 @@ const initialState = {
 };
 export function ordersReducer(state = initialState, action) {
   switch (action.type) {
-    case UPDATE_ORDERS:
+    case CREATE_OR_UPDATE_ORDERS.success:
       return Object.assign({}, state, {
-        hasSubmitSuccess: false,
-      });
-    case CREATE_OR_UPDATE_ORDERS_SUCCESS:
-      return Object.assign({}, state, {
-        currentOrders: action.item,
+        currentOrders: action.payload,
         pendingOrdersType: null,
         hasSubmitSuccess: true,
         hasSubmitError: false,
         error: null,
       });
-    case CREATE_OR_UPDATE_ORDERS_FAILURE:
+    case CREATE_OR_UPDATE_ORDERS.failure:
       return Object.assign({}, state, {
         currentOrders: {},
         hasSubmitSuccess: false,
         hasSubmitError: true,
         error: action.error,
       });
-    case GET_ORDERS_SUCCESS:
+    case GET_ORDERS.success:
       return Object.assign({}, state, {
-        currentOrders: action.item,
+        currentOrders: action.payload,
         hasSubmitSuccess: true,
         hasSubmitError: false,
         error: null,
       });
-    case GET_ORDERS_FAILURE:
+    case GET_ORDERS.failure:
       return Object.assign({}, state, {
         currentOrders: {},
         hasSubmitSuccess: false,
@@ -213,9 +168,9 @@ export function ordersReducer(state = initialState, action) {
         hasSubmitError: true,
         error: action.error,
       });
-    case ADD_UPLOADS_SUCCESS:
+    case ADD_UPLOADS.success:
       return Object.assign({}, state, {
-        currentOrders: action.item,
+        currentOrders: action.payload,
         hasSubmitSuccess: true,
         hasSubmitError: false,
         error: null,

--- a/src/shared/User/ducks.js
+++ b/src/shared/User/ducks.js
@@ -1,4 +1,4 @@
-import { concat, filter, orderBy } from 'lodash';
+import { concat, reject, orderBy } from 'lodash';
 import * as Cookies from 'js-cookie';
 import * as decode from 'jwt-decode';
 import * as helpers from 'shared/ReduxHelpers';
@@ -51,7 +51,7 @@ export const loggedInUserReducer = (state, action) => {
       let oldOrders = mutatedState.loggedInUser.service_member.orders;
       // Remove existing orders with same ID and add new orders
       let newOrders = orderBy(
-        concat(filter(oldOrders, ['id', action.payload.id]), action.payload),
+        concat(reject(oldOrders, ['id', action.payload.id]), action.payload),
         'created_at',
         'desc',
       );

--- a/src/shared/User/ducks.js
+++ b/src/shared/User/ducks.js
@@ -1,7 +1,12 @@
+import { concat, filter, orderBy } from 'lodash';
 import * as Cookies from 'js-cookie';
 import * as decode from 'jwt-decode';
 import * as helpers from 'shared/ReduxHelpers';
 import { GetLoggedInUser } from './api.js';
+import {
+  CREATE_OR_UPDATE_ORDERS,
+  SHOW_CURRENT_ORDERS,
+} from 'scenes/Orders/ducks.js';
 
 const LOAD_USER_AND_TOKEN = 'USER|LOAD_USER_AND_TOKEN';
 
@@ -47,6 +52,25 @@ export const loggedInUserReducer = (state, action) => {
         loggedInUser: {
           ...mutatedState.loggedInUser,
           service_member: action.payload,
+        },
+      };
+    case CREATE_OR_UPDATE_ORDERS.success:
+    case SHOW_CURRENT_ORDERS.success:
+      let oldOrders = mutatedState.loggedInUser.service_member.orders;
+      // Remove existing orders with same ID and add new orders
+      let newOrders = orderBy(
+        concat(filter(oldOrders, ['id', action.payload.id]), action.payload),
+        'created_at',
+        'desc',
+      );
+      return {
+        ...mutatedState,
+        loggedInUser: {
+          ...mutatedState.loggedInUser,
+          service_member: {
+            ...mutatedState.loggedInUser.service_member,
+            orders: newOrders,
+          },
         },
       };
     default:

--- a/src/shared/entitlements.js
+++ b/src/shared/entitlements.js
@@ -1,0 +1,153 @@
+import { has } from 'lodash';
+
+export function getEntitlements(rank, hasDependents = false) {
+  if (!has(entitlements, rank)) {
+    return null;
+  }
+
+  const totalKey = hasDependents
+    ? 'total_weight_self_plus_dependents'
+    : 'total_weight_self';
+  return {
+    total: entitlements[rank][totalKey],
+    pro_gear: entitlements[rank].pro_gear_weight,
+    pro_gear_spouse: entitlements[rank].pro_gear_weight_spouse,
+  };
+}
+
+/*
+ * These entitlements are pulled from the move.mil source code
+ * Source: https://github.com/deptofdefense/move.mil/blob/master/lib/data/entitlements.yml
+ */
+const entitlements = {
+  ACADEMY_CADET_MIDSHIPMAN: {
+    total_weight_self: 350,
+    total_weight_self_plus_dependents: 350,
+  },
+  AVIATION_CADET: {
+    total_weight_self: 7000,
+    total_weight_self_plus_dependents: 8000,
+    pro_gear_weight: 2000,
+    pro_gear_weight_spouse: 500,
+  },
+  E_1: {
+    total_weight_self: 5000,
+    total_weight_self_plus_dependents: 8000,
+    pro_gear_weight: 2000,
+    pro_gear_weight_spouse: 500,
+  },
+  E_2: {
+    total_weight_self: 5000,
+    total_weight_self_plus_dependents: 8000,
+    pro_gear_weight: 2000,
+    pro_gear_weight_spouse: 500,
+  },
+  E_3: {
+    total_weight_self: 5000,
+    total_weight_self_plus_dependents: 8000,
+    pro_gear_weight: 2000,
+    pro_gear_weight_spouse: 500,
+  },
+  E_4: {
+    total_weight_self: 7000,
+    total_weight_self_plus_dependents: 8000,
+    pro_gear_weight: 2000,
+    pro_gear_weight_spouse: 500,
+  },
+  E_5: {
+    total_weight_self: 7000,
+    total_weight_self_plus_dependents: 9000,
+    pro_gear_weight: 2000,
+    pro_gear_weight_spouse: 500,
+  },
+  E_6: {
+    total_weight_self: 8000,
+    total_weight_self_plus_dependents: 11000,
+    pro_gear_weight: 2000,
+    pro_gear_weight_spouse: 500,
+  },
+  E_7: {
+    total_weight_self: 11000,
+    total_weight_self_plus_dependents: 13000,
+    pro_gear_weight: 2000,
+    pro_gear_weight_spouse: 500,
+  },
+  E_8: {
+    total_weight_self: 12000,
+    total_weight_self_plus_dependents: 14000,
+    pro_gear_weight: 2000,
+    pro_gear_weight_spouse: 500,
+  },
+  E_9: {
+    total_weight_self: 13000,
+    total_weight_self_plus_dependents: 15000,
+    pro_gear_weight: 2000,
+    pro_gear_weight_spouse: 500,
+  },
+  O_1_W_1_ACADEMY_GRADUATE: {
+    total_weight_self: 10000,
+    total_weight_self_plus_dependents: 12000,
+    pro_gear_weight: 2000,
+    pro_gear_weight_spouse: 500,
+  },
+  O_2_W_2: {
+    total_weight_self: 12500,
+    total_weight_self_plus_dependents: 13500,
+    pro_gear_weight: 2000,
+    pro_gear_weight_spouse: 500,
+  },
+  O_3_W_3: {
+    total_weight_self: 13000,
+    total_weight_self_plus_dependents: 14500,
+    pro_gear_weight: 2000,
+    pro_gear_weight_spouse: 500,
+  },
+  O_4_W_4: {
+    total_weight_self: 14000,
+    total_weight_self_plus_dependents: 17000,
+    pro_gear_weight: 2000,
+    pro_gear_weight_spouse: 500,
+  },
+  O_5_W_5: {
+    total_weight_self: 16000,
+    total_weight_self_plus_dependents: 17500,
+    pro_gear_weight: 2000,
+    pro_gear_weight_spouse: 500,
+  },
+  O_6: {
+    total_weight_self: 18000,
+    total_weight_self_plus_dependents: 18000,
+    pro_gear_weight: 2000,
+    pro_gear_weight_spouse: 500,
+  },
+  O_7: {
+    total_weight_self: 18000,
+    total_weight_self_plus_dependents: 18000,
+    pro_gear_weight: 2000,
+    pro_gear_weight_spouse: 500,
+  },
+  O_8: {
+    total_weight_self: 18000,
+    total_weight_self_plus_dependents: 18000,
+    pro_gear_weight: 2000,
+    pro_gear_weight_spouse: 500,
+  },
+  O_9: {
+    total_weight_self: 18000,
+    total_weight_self_plus_dependents: 18000,
+    pro_gear_weight: 2000,
+    pro_gear_weight_spouse: 500,
+  },
+  O_10: {
+    total_weight_self: 18000,
+    total_weight_self_plus_dependents: 18000,
+    pro_gear_weight: 2000,
+    pro_gear_weight_spouse: 500,
+  },
+  CIVILIAN_EMPLOYEE: {
+    total_weight_self: 18000,
+    total_weight_self_plus_dependents: 18000,
+    pro_gear_weight: 2000,
+    pro_gear_weight_spouse: 500,
+  },
+};

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -936,26 +936,19 @@ definitions:
       - E_7
       - E_8
       - E_9
-      - W_1
-      - W_2
-      - W_3
-      - W_4
-      - W_5
-      - O_1
-      - O_2
-      - O_3
-      - O_4
-      - O_5
+      - O_1_W_1_ACADEMY_GRADUATE
+      - O_2_W_2
+      - O_3_W_3
+      - O_4_W_4
+      - O_5_W_5
       - O_6
       - O_7
       - O_8
       - O_9
       - O_10
-      - ACADEMY_CADET
-      - ACADEMY_GRADUATE
       - AVIATION_CADET
       - CIVILIAN_EMPLOYEE
-      - MIDSHIPMAN
+      - ACADEMY_CADET_MIDSHIPMAN
     x-display-value:
       E_1: E-1
       E_2: E-2
@@ -966,26 +959,19 @@ definitions:
       E_7: E-7
       E_8: E-8
       E_9: E-9
-      W_1: W-1
-      W_2: W-2
-      W_3: W-3
-      W_4: W-4
-      W_5: W-5
-      O_1: O-1
-      O_2: O-2
-      O_3: O-3
-      O_4: O-4
-      O_5: O-5
+      O_1_W_1_ACADEMY_GRADUATE: O-1/W-1/Service Academy Graduate
+      O_2_W_2: O-2/W-2
+      O_3_W_3: O-3/W-3
+      O_4_W_4: O-4/W-4
+      O_5_W_5: O-5/W-5
       O_6: O-6
       O_7: O-7
       O_8: O-8
       O_9: O-9
       O_10: O-10
-      ACADEMY_CADET: Service Academy Cadet
-      ACADEMY_GRADUATE: Service Academy Graduate
       AVIATION_CADET: Aviation Cadet
       CIVILIAN_EMPLOYEE: Civilian Employee
-      MIDSHIPMAN: Midshipman
+      ACADEMY_CADET_MIDSHIPMAN: Service Academy Cadet/Midshipman
   DeptIndicator:
     type: string
     x-nullable: true


### PR DESCRIPTION
## Description

- Adjusts rank enum to match values as used in move.mil codebase
- Imports entitlement data from move.mil and exposes it via methods for both SM flow redux use and more directly for office use
- Adds orders listeners to loggedInUser reducer so loggedInUser is kept in sync with updating orders
- Orders ducks are refactored to match current redux practices

## Code Review Verification Steps

* [ ] All tests pass.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/blob/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* [ ] Any migrations/schema changes also update the diagram in docs/schema/dp3.sqs
* [ ] There are no [aXe](https://www.deque.com/products/aXe/) warnings for UI.
* [ ] This works in IE.
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @willowbl00
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Request review from a member of a different team.
* [ ] (TRIAL) Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/157577559) for entitlements
* [Pivotal story](https://www.pivotaltracker.com/story/show/157194900) for rank enum
