### PR TITLE
Removes backup contact permission control/display [delivers #157494305]

### DIFF
--- a/src/scenes/Review/Review.jsx
+++ b/src/scenes/Review/Review.jsx
@@ -65,15 +65,16 @@ export class Review extends Component {
       });
       return preferredMethods.join(', ');
     }
-    function getFullBackupPermission(backup_contact) {
-      const perms = {
-        NONE: '',
-        VIEW: 'View all aspects of this move',
-        EDIT:
-          'Authorized to represent me in all aspects of this move (letter of authorization)',
-      };
-      return `${perms[backup_contact.permission]}`;
-    }
+    // TODO: Uncomment function below after backup contact auth is implemented.
+    // function getFullBackupPermission(backup_contact) {
+    //   const perms = {
+    //     NONE: '',
+    //     VIEW: 'View all aspects of this move',
+    //     EDIT:
+    //       'Authorized to represent me in all aspects of this move (letter of authorization)',
+    //   };
+    //   return `${perms[backup_contact.permission]}`;
+    // }
     function formatDate(date) {
       if (!date) return;
       return moment(date, 'YYYY-MM-DD').format('MM/DD/YYYY');
@@ -249,7 +250,7 @@ export class Review extends Component {
                     <td> Backup Contact: </td>
                     <td>
                       {contact.name} <br />
-                      {getFullBackupPermission(contact)}
+                      {/* getFullBackupPermission(contact) */}
                     </td>
                   </tr>
                   <tr>

--- a/src/scenes/ServiceMembers/BackupContact.jsx
+++ b/src/scenes/ServiceMembers/BackupContact.jsx
@@ -1,6 +1,6 @@
 import { get, pick } from 'lodash';
 import PropTypes from 'prop-types';
-import React, { Component, Fragment } from 'react';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 
@@ -15,85 +15,86 @@ import {
   renderField,
   recursivelyAnnotateRequiredFields,
 } from 'shared/JsonSchemaForm';
-import { reduxForm, Field } from 'redux-form';
+import { reduxForm } from 'redux-form';
 import { no_op } from 'shared/utils';
 import WizardPage from 'shared/WizardPage';
 
 import './BackupContact.css';
 
 const NonePermission = 'NONE';
-const ViewPermission = 'VIEW';
-const EditPermission = 'EDIT';
+// const ViewPermission = 'VIEW';
+// const EditPermission = 'EDIT';
 
-const permissionsField = props => {
-  const {
-    input: { value: rawValue, onChange },
-  } = props;
-  let value;
-  if (![NonePermission, ViewPermission, EditPermission].includes(rawValue)) {
-    value = NonePermission;
-  } else {
-    value = rawValue;
-  }
+// TODO: Uncomment field below after backup contact auth is implemented.
+// const permissionsField = props => {
+//   const {
+//     input: { value: rawValue, onChange },
+//   } = props;
+//   let value;
+//   if (![NonePermission, ViewPermission, EditPermission].includes(rawValue)) {
+//     value = NonePermission;
+//   } else {
+//     value = rawValue;
+//   }
 
-  const localOnChange = event => {
-    if (event.target.id === 'authorizeAgent') {
-      if (event.target.checked && value === NonePermission) {
-        onChange(ViewPermission);
-      } else if (!event.target.checked) {
-        onChange(NonePermission);
-      }
-    } else if (event.target.id === 'aaChoiceView') {
-      onChange(ViewPermission);
-    } else if (event.target.id === 'aaChoiceEdit') {
-      onChange(EditPermission);
-    }
-  };
+//   const localOnChange = event => {
+//     if (event.target.id === 'authorizeAgent') {
+//       if (event.target.checked && value === NonePermission) {
+//         onChange(ViewPermission);
+//       } else if (!event.target.checked) {
+//         onChange(NonePermission);
+//       }
+//     } else if (event.target.id === 'aaChoiceView') {
+//       onChange(ViewPermission);
+//     } else if (event.target.id === 'aaChoiceEdit') {
+//       onChange(EditPermission);
+//     }
+//   };
 
-  const authorizedChecked = value !== NonePermission;
-  const viewChecked = value === ViewPermission;
-  const editChecked = value === EditPermission;
+//   const authorizedChecked = value !== NonePermission;
+//   const viewChecked = value === ViewPermission;
+//   const editChecked = value === EditPermission;
 
-  return (
-    <Fragment>
-      <input
-        id="authorizeAgent"
-        type="checkbox"
-        onChange={localOnChange}
-        checked={authorizedChecked}
-      />
-      <label htmlFor="authorizeAgent">I authorize this person to:</label>
-      <input
-        id="aaChoiceView"
-        type="radio"
-        onChange={localOnChange}
-        checked={viewChecked}
-        disabled={!authorizedChecked}
-      />
-      <label
-        htmlFor="aaChoiceView"
-        className={authorizedChecked ? '' : 'disabled'}
-      >
-        Sign for pickup or delivery in my absence, and view move details in this
-        app.
-      </label>
-      <input
-        id="aaChoiceEdit"
-        type="radio"
-        onChange={localOnChange}
-        checked={editChecked}
-        disabled={!authorizedChecked}
-      />
-      <label
-        htmlFor="aaChoiceEdit"
-        className={authorizedChecked ? '' : 'disabled'}
-      >
-        Represent me in all aspects of this move (this person will be invited to
-        login and will be authorized with power of attorney on your behalf).
-      </label>
-    </Fragment>
-  );
-};
+//   return (
+//     <Fragment>
+//       <input
+//         id="authorizeAgent"
+//         type="checkbox"
+//         onChange={localOnChange}
+//         checked={authorizedChecked}
+//       />
+//       <label htmlFor="authorizeAgent">I authorize this person to:</label>
+//       <input
+//         id="aaChoiceView"
+//         type="radio"
+//         onChange={localOnChange}
+//         checked={viewChecked}
+//         disabled={!authorizedChecked}
+//       />
+//       <label
+//         htmlFor="aaChoiceView"
+//         className={authorizedChecked ? '' : 'disabled'}
+//       >
+//         Sign for pickup or delivery in my absence, and view move details in this
+//         app.
+//       </label>
+//       <input
+//         id="aaChoiceEdit"
+//         type="radio"
+//         onChange={localOnChange}
+//         checked={editChecked}
+//         disabled={!authorizedChecked}
+//       />
+//       <label
+//         htmlFor="aaChoiceEdit"
+//         className={authorizedChecked ? '' : 'disabled'}
+//       >
+//         Represent me in all aspects of this move (this person will be invited to
+//         login and will be authorized with power of attorney on your behalf).
+//       </label>
+//     </Fragment>
+//   );
+// };
 
 const formName = 'service_member_backup_contact';
 
@@ -126,7 +127,8 @@ class ContactForm extends Component {
         {renderField('email', fields, '')}
         {renderField('telephone', fields, '')}
 
-        <Field name="permission" component={permissionsField} />
+        {/* TODO: Uncomment line below after backup contact auth is implemented.  */}
+        {/* <Field name="permission" component={permissionsField} /> */}
       </form>
     );
   }


### PR DESCRIPTION
## Description

Usually I'm a big proponent of deleting code instead of commenting it out, but this feels different. It's probably not. Please tell me this is wrong.

## Code Review Verification Steps

* [ ] All tests pass.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/blob/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* [ ] Any migrations/schema changes also update the diagram in docs/schema/dp3.sqs
* [ ] There are no [aXe](https://www.deque.com/products/aXe/) warnings for UI.
* [ ] This works in IE.
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @willowbl00
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Request review from a member of a different team.
* [ ] (TRIAL) Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/157494305) for this change

## Screenshots

![screenshot 2018-05-16 15 58 36](https://user-images.githubusercontent.com/5151804/40148275-081179e4-5922-11e8-86f3-c48197253d09.png)

