### PR TITLE
Adding accounting fields to Orders

### DIFF
--- a/migrations/20180516211155_add_accounting_to_orders.down.fizz
+++ b/migrations/20180516211155_add_accounting_to_orders.down.fizz
@@ -1,0 +1,2 @@
+drop_column("orders", "transportation_accounting_code")
+drop_column("orders", "department_indicator")

--- a/migrations/20180516211155_add_accounting_to_orders.down.fizz
+++ b/migrations/20180516211155_add_accounting_to_orders.down.fizz
@@ -1,3 +1,3 @@
-drop_column("orders", "transportation_accounting_code")
+drop_column("orders", "tac")
 drop_column("orders", "department_indicator")
 add_column("orders", "current_duty_station_id", "uuid", {"null": true})

--- a/migrations/20180516211155_add_accounting_to_orders.down.fizz
+++ b/migrations/20180516211155_add_accounting_to_orders.down.fizz
@@ -1,2 +1,3 @@
 drop_column("orders", "transportation_accounting_code")
 drop_column("orders", "department_indicator")
+add_column("orders", "current_duty_station_id", "uuid", {"null": true})

--- a/migrations/20180516211155_add_accounting_to_orders.up.fizz
+++ b/migrations/20180516211155_add_accounting_to_orders.up.fizz
@@ -1,0 +1,2 @@
+add_column("orders", "transportation_accounting_code", "string", {"null": true})
+add_column("orders", "department_indicator", "string", {"null": true})

--- a/migrations/20180516211155_add_accounting_to_orders.up.fizz
+++ b/migrations/20180516211155_add_accounting_to_orders.up.fizz
@@ -1,3 +1,3 @@
-add_column("orders", "transportation_accounting_code", "string", {"null": true})
+add_column("orders", "tac", "string", {"null": true})
 add_column("orders", "department_indicator", "string", {"null": true})
 drop_column("orders", "current_duty_station_id")

--- a/migrations/20180516211155_add_accounting_to_orders.up.fizz
+++ b/migrations/20180516211155_add_accounting_to_orders.up.fizz
@@ -1,2 +1,3 @@
 add_column("orders", "transportation_accounting_code", "string", {"null": true})
 add_column("orders", "department_indicator", "string", {"null": true})
+drop_column("orders", "current_duty_station_id")

--- a/pkg/handlers/orders.go
+++ b/pkg/handlers/orders.go
@@ -26,17 +26,19 @@ func payloadForOrdersModel(storage FileStorer, order models.Order) (*internalmes
 	}
 
 	payload := &internalmessages.Orders{
-		ID:              fmtUUID(order.ID),
-		CreatedAt:       fmtDateTime(order.CreatedAt),
-		UpdatedAt:       fmtDateTime(order.UpdatedAt),
-		ServiceMemberID: fmtUUID(order.ServiceMemberID),
-		IssueDate:       fmtDate(order.IssueDate),
-		ReportByDate:    fmtDate(order.ReportByDate),
-		OrdersType:      order.OrdersType,
-		NewDutyStation:  payloadForDutyStationModel(order.NewDutyStation),
-		HasDependents:   fmtBool(order.HasDependents),
-		UploadedOrders:  documentPayload,
-		Moves:           moves,
+		ID:                  fmtUUID(order.ID),
+		CreatedAt:           fmtDateTime(order.CreatedAt),
+		UpdatedAt:           fmtDateTime(order.UpdatedAt),
+		ServiceMemberID:     fmtUUID(order.ServiceMemberID),
+		IssueDate:           fmtDate(order.IssueDate),
+		ReportByDate:        fmtDate(order.ReportByDate),
+		OrdersType:          order.OrdersType,
+		NewDutyStation:      payloadForDutyStationModel(order.NewDutyStation),
+		HasDependents:       fmtBool(order.HasDependents),
+		UploadedOrders:      documentPayload,
+		Moves:               moves,
+		Tac:                 order.TAC,
+		DepartmentIndicator: (*internalmessages.DeptIndicator)(order.DepartmentIndicator),
 	}
 
 	return payload, nil

--- a/pkg/models/order.go
+++ b/pkg/models/order.go
@@ -31,27 +31,26 @@ const (
 
 // Order is a set of orders received by a service member
 type Order struct {
-	ID                           uuid.UUID                          `json:"id" db:"id"`
-	CreatedAt                    time.Time                          `json:"created_at" db:"created_at"`
-	UpdatedAt                    time.Time                          `json:"updated_at" db:"updated_at"`
-	ServiceMemberID              uuid.UUID                          `json:"service_member_id" db:"service_member_id"`
-	ServiceMember                ServiceMember                      `belongs_to:"service_members"`
-	IssueDate                    time.Time                          `json:"issue_date" db:"issue_date"`
-	ReportByDate                 time.Time                          `json:"report_by_date" db:"report_by_date"`
-	OrdersType                   internalmessages.OrdersType        `json:"orders_type" db:"orders_type"`
-	OrdersTypeDetail             *internalmessages.OrdersTypeDetail `json:"orders_type_detail" db:"orders_type_detail"`
-	HasDependents                bool                               `json:"has_dependents" db:"has_dependents"`
-	NewDutyStationID             uuid.UUID                          `json:"new_duty_station_id" db:"new_duty_station_id"`
-	NewDutyStation               DutyStation                        `belongs_to:"duty_stations"`
-	CurrentDutyStationID         *uuid.UUID                         `json:"current_duty_station_id" db:"current_duty_station_id"`
-	CurrentDutyStation           *DutyStation                       `belongs_to:"duty_stations"`
-	UploadedOrders               Document                           `belongs_to:"documents"`
-	UploadedOrdersID             uuid.UUID                          `json:"uploaded_orders_id" db:"uploaded_orders_id"`
-	OrdersNumber                 *string                            `json:"orders_number" db:"orders_number"`
-	Moves                        Moves                              `has_many:"moves" fk_id:"orders_id" order_by:"created_at desc"`
-	Status                       OrderStatus                        `json:"status" db:"status"`
-	TransportationAccountingCode *string                            `json:"transportation_accounting_code" db:"transportation_accounting_code"`
-	DepartmentIndicator          *string                            `json:"department_indicator" db:"department_indicator"`
+	ID                  uuid.UUID                          `json:"id" db:"id"`
+	CreatedAt           time.Time                          `json:"created_at" db:"created_at"`
+	UpdatedAt           time.Time                          `json:"updated_at" db:"updated_at"`
+	ServiceMemberID     uuid.UUID                          `json:"service_member_id" db:"service_member_id"`
+	ServiceMember       ServiceMember                      `belongs_to:"service_members"`
+	IssueDate           time.Time                          `json:"issue_date" db:"issue_date"`
+	ReportByDate        time.Time                          `json:"report_by_date" db:"report_by_date"`
+	OrdersType          internalmessages.OrdersType        `json:"orders_type" db:"orders_type"`
+	OrdersTypeDetail    *internalmessages.OrdersTypeDetail `json:"orders_type_detail" db:"orders_type_detail"`
+	HasDependents       bool                               `json:"has_dependents" db:"has_dependents"`
+	NewDutyStationID    uuid.UUID                          `json:"new_duty_station_id" db:"new_duty_station_id"`
+	NewDutyStation      DutyStation                        `belongs_to:"duty_stations"`
+	CurrentDutyStation  *DutyStation                       `belongs_to:"duty_stations"`
+	UploadedOrders      Document                           `belongs_to:"documents"`
+	UploadedOrdersID    uuid.UUID                          `json:"uploaded_orders_id" db:"uploaded_orders_id"`
+	OrdersNumber        *string                            `json:"orders_number" db:"orders_number"`
+	Moves               Moves                              `has_many:"moves" fk_id:"orders_id" order_by:"created_at desc"`
+	Status              OrderStatus                        `json:"status" db:"status"`
+	TAC                 *string                            `json:"tac" db:"tac"`
+	DepartmentIndicator *string                            `json:"department_indicator" db:"department_indicator"`
 }
 
 // String is not required by pop and may be deleted
@@ -79,7 +78,7 @@ func (o *Order) Validate(tx *pop.Connection) (*validate.Errors, error) {
 		&validators.UUIDIsPresent{Field: o.ServiceMemberID, Name: "ServiceMemberID"},
 		&validators.UUIDIsPresent{Field: o.NewDutyStationID, Name: "NewDutyStationID"},
 		&validators.StringIsPresent{Field: string(o.Status), Name: "Status"},
-		&StringIsNilOrNotBlank{Field: o.TransportationAccountingCode, Name: "Transportation Accounting Code"},
+		&StringIsNilOrNotBlank{Field: o.TAC, Name: "Transportation Accounting Code"},
 		&StringIsNilOrNotBlank{Field: o.DepartmentIndicator, Name: "Department Indicator"},
 	), nil
 }

--- a/pkg/models/order.go
+++ b/pkg/models/order.go
@@ -31,25 +31,27 @@ const (
 
 // Order is a set of orders received by a service member
 type Order struct {
-	ID                   uuid.UUID                          `json:"id" db:"id"`
-	CreatedAt            time.Time                          `json:"created_at" db:"created_at"`
-	UpdatedAt            time.Time                          `json:"updated_at" db:"updated_at"`
-	ServiceMemberID      uuid.UUID                          `json:"service_member_id" db:"service_member_id"`
-	ServiceMember        ServiceMember                      `belongs_to:"service_members"`
-	IssueDate            time.Time                          `json:"issue_date" db:"issue_date"`
-	ReportByDate         time.Time                          `json:"report_by_date" db:"report_by_date"`
-	OrdersType           internalmessages.OrdersType        `json:"orders_type" db:"orders_type"`
-	OrdersTypeDetail     *internalmessages.OrdersTypeDetail `json:"orders_type_detail" db:"orders_type_detail"`
-	HasDependents        bool                               `json:"has_dependents" db:"has_dependents"`
-	NewDutyStationID     uuid.UUID                          `json:"new_duty_station_id" db:"new_duty_station_id"`
-	NewDutyStation       DutyStation                        `belongs_to:"duty_stations"`
-	CurrentDutyStationID *uuid.UUID                         `json:"current_duty_station_id" db:"current_duty_station_id"`
-	CurrentDutyStation   *DutyStation                       `belongs_to:"duty_stations"`
-	UploadedOrders       Document                           `belongs_to:"documents"`
-	UploadedOrdersID     uuid.UUID                          `json:"uploaded_orders_id" db:"uploaded_orders_id"`
-	OrdersNumber         *string                            `json:"orders_number" db:"orders_number"`
-	Moves                Moves                              `has_many:"moves" fk_id:"orders_id" order_by:"created_at desc"`
-	Status               OrderStatus                        `json:"status" db:"status"`
+	ID                           uuid.UUID                          `json:"id" db:"id"`
+	CreatedAt                    time.Time                          `json:"created_at" db:"created_at"`
+	UpdatedAt                    time.Time                          `json:"updated_at" db:"updated_at"`
+	ServiceMemberID              uuid.UUID                          `json:"service_member_id" db:"service_member_id"`
+	ServiceMember                ServiceMember                      `belongs_to:"service_members"`
+	IssueDate                    time.Time                          `json:"issue_date" db:"issue_date"`
+	ReportByDate                 time.Time                          `json:"report_by_date" db:"report_by_date"`
+	OrdersType                   internalmessages.OrdersType        `json:"orders_type" db:"orders_type"`
+	OrdersTypeDetail             *internalmessages.OrdersTypeDetail `json:"orders_type_detail" db:"orders_type_detail"`
+	HasDependents                bool                               `json:"has_dependents" db:"has_dependents"`
+	NewDutyStationID             uuid.UUID                          `json:"new_duty_station_id" db:"new_duty_station_id"`
+	NewDutyStation               DutyStation                        `belongs_to:"duty_stations"`
+	CurrentDutyStationID         *uuid.UUID                         `json:"current_duty_station_id" db:"current_duty_station_id"`
+	CurrentDutyStation           *DutyStation                       `belongs_to:"duty_stations"`
+	UploadedOrders               Document                           `belongs_to:"documents"`
+	UploadedOrdersID             uuid.UUID                          `json:"uploaded_orders_id" db:"uploaded_orders_id"`
+	OrdersNumber                 *string                            `json:"orders_number" db:"orders_number"`
+	Moves                        Moves                              `has_many:"moves" fk_id:"orders_id" order_by:"created_at desc"`
+	Status                       OrderStatus                        `json:"status" db:"status"`
+	TransportationAccountingCode *string                            `json:"transportation_accounting_code" db:"transportation_accounting_code"`
+	DepartmentIndicator          *string                            `json:"department_indicator" db:"department_indicator"`
 }
 
 // String is not required by pop and may be deleted
@@ -77,6 +79,8 @@ func (o *Order) Validate(tx *pop.Connection) (*validate.Errors, error) {
 		&validators.UUIDIsPresent{Field: o.ServiceMemberID, Name: "ServiceMemberID"},
 		&validators.UUIDIsPresent{Field: o.NewDutyStationID, Name: "NewDutyStationID"},
 		&validators.StringIsPresent{Field: string(o.Status), Name: "Status"},
+		&StringIsNilOrNotBlank{Field: o.TransportationAccountingCode, Name: "Transportation Accounting Code"},
+		&StringIsNilOrNotBlank{Field: o.DepartmentIndicator, Name: "Department Indicator"},
 	), nil
 }
 

--- a/pkg/models/order_test.go
+++ b/pkg/models/order_test.go
@@ -42,6 +42,8 @@ func (suite *ModelSuite) TestFetchOrder() {
 		ServiceMemberID: serviceMember1.ID,
 		Name:            UploadedOrdersDocumentName,
 	}
+	deptIndicator := testdatagen.DefaultDepartmentIndicator
+	TAC := testdatagen.DefaultTransportationAccountingCode
 	suite.mustSave(&uploadedOrder)
 	order := Order{
 		ServiceMemberID:  serviceMember1.ID,
@@ -55,6 +57,8 @@ func (suite *ModelSuite) TestFetchOrder() {
 		UploadedOrdersID: uploadedOrder.ID,
 		UploadedOrders:   uploadedOrder,
 		Status:           OrderStatusSUBMITTED,
+		TransportationAccountingCode: &TAC,
+		DepartmentIndicator:          &deptIndicator,
 	}
 	suite.mustSave(&order)
 

--- a/pkg/models/order_test.go
+++ b/pkg/models/order_test.go
@@ -46,19 +46,19 @@ func (suite *ModelSuite) TestFetchOrder() {
 	TAC := testdatagen.DefaultTransportationAccountingCode
 	suite.mustSave(&uploadedOrder)
 	order := Order{
-		ServiceMemberID:  serviceMember1.ID,
-		ServiceMember:    serviceMember1,
-		IssueDate:        issueDate,
-		ReportByDate:     reportByDate,
-		OrdersType:       ordersType,
-		HasDependents:    hasDependents,
-		NewDutyStationID: dutyStation.ID,
-		NewDutyStation:   dutyStation,
-		UploadedOrdersID: uploadedOrder.ID,
-		UploadedOrders:   uploadedOrder,
-		Status:           OrderStatusSUBMITTED,
-		TransportationAccountingCode: &TAC,
-		DepartmentIndicator:          &deptIndicator,
+		ServiceMemberID:     serviceMember1.ID,
+		ServiceMember:       serviceMember1,
+		IssueDate:           issueDate,
+		ReportByDate:        reportByDate,
+		OrdersType:          ordersType,
+		HasDependents:       hasDependents,
+		NewDutyStationID:    dutyStation.ID,
+		NewDutyStation:      dutyStation,
+		UploadedOrdersID:    uploadedOrder.ID,
+		UploadedOrders:      uploadedOrder,
+		Status:              OrderStatusSUBMITTED,
+		TAC:                 &TAC,
+		DepartmentIndicator: &deptIndicator,
 	}
 	suite.mustSave(&order)
 

--- a/pkg/testdatagen/constants.go
+++ b/pkg/testdatagen/constants.go
@@ -59,3 +59,9 @@ var DateOutsidePerformancePeriod = time.Date(TestYear, time.August, 1, 0, 0, 0, 
 
 // RateEngineDate is a date for the rate engine to use on generation for tests.
 var RateEngineDate = time.Date(TestYear, time.May, 18, 0, 0, 0, 0, time.UTC)
+
+// DefaultDepartmentIndicator is a code for orders accounting that indicates which branch the orders are for.
+var DefaultDepartmentIndicator = "57 - United States Air Force"
+
+// DefaultTransportationAccountingCode (TAC) is an accounting code used for orders.
+var DefaultTransportationAccountingCode = "F8J1"

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -1314,6 +1314,12 @@ definitions:
       updated_at:
         type: string
         format: date-time
+      tac:
+        type: string
+        example: "F8J1"
+        x-nullable: true
+      department_indicator:
+        $ref: '#/definitions/DeptIndicator'
     required:
       - id
       - service_member_id
@@ -1364,6 +1370,12 @@ definitions:
         title: Orders Number
         x-nullable: true
         example: "030-00362"
+      tac:
+        type: string
+        example: "F8J1"
+        x-nullable: true
+      department_indicator:
+        $ref: '#/definitions/DeptIndicator'
     required:
       - service_member_id
       - issue_date


### PR DESCRIPTION
## Description

This adds the TAC and department indicator fields to the db, to the Orders model, and throughout Orders definitions in Swagger. 

The migrations also removes `current_duty_station_id` from the orders table, per a request from Rebecca. 

## Reviewer Notes

Just whether I've done everything the Pivotal task requires. 

## Code Review Verification Steps

* [ ] All tests pass.
* [ ] Request review from a member of a different team.
* [ ] (TRIAL) Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/157525137) for this change
