### PR TITLE
Els submit move for approval [delivers 

### DIFF
--- a/pkg/handlers/handlers.go
+++ b/pkg/handlers/handlers.go
@@ -105,6 +105,7 @@ func NewInternalAPIHandler(context HandlerContext) http.Handler {
 	internalAPI.MovesCreateMoveHandler = CreateMoveHandler(context)
 	internalAPI.MovesPatchMoveHandler = PatchMoveHandler(context)
 	internalAPI.MovesShowMoveHandler = ShowMoveHandler(context)
+	internalAPI.MovesSubmitMoveForApprovalHandler = SubmitMoveHandler(context)
 
 	internalAPI.ServiceMembersCreateServiceMemberHandler = CreateServiceMemberHandler(context)
 	internalAPI.ServiceMembersPatchServiceMemberHandler = PatchServiceMemberHandler(context)

--- a/pkg/handlers/moves.go
+++ b/pkg/handlers/moves.go
@@ -117,3 +117,31 @@ func (h PatchMoveHandler) Handle(params moveop.PatchMoveParams) middleware.Respo
 	movePayload := payloadForMoveModel(orders, *move)
 	return moveop.NewPatchMoveCreated().WithPayload(&movePayload)
 }
+
+// SubmitMoveHandler approves a move via POST /moves/{moveId}/approve
+type SubmitMoveHandler HandlerContext
+
+// Handle ... patches a new ServiceMember from a request payload
+func (h SubmitMoveHandler) Handle(params moveop.SubmitMoveForApprovalParams) middleware.Responder {
+	// User should always be populated by middleware
+	user, _ := auth.GetUser(params.HTTPRequest.Context())
+	moveID, _ := uuid.FromString(params.MoveID.String())
+	reqApp := app.GetAppFromContext(params.HTTPRequest)
+
+	move, err := models.FetchMove(h.db, user, reqApp, moveID)
+	if err != nil {
+		return responseForError(h.logger, err)
+	}
+
+	//TODO: update PPM status too
+
+	move.Status = models.MoveStatusSUBMITTED
+
+	verrs, err := h.db.ValidateAndUpdate(move)
+	if err != nil || verrs.HasAny() {
+		return responseForVErrors(h.logger, verrs, err)
+	}
+
+	movePayload := payloadForMoveModel(move.Orders, *move)
+	return moveop.NewSubmitMoveForApprovalOK().WithPayload(&movePayload)
+}

--- a/src/scenes/Landing/MoveSummary.jsx
+++ b/src/scenes/Landing/MoveSummary.jsx
@@ -39,8 +39,7 @@ export const MoveSummary = props => {
           </div>
           <div className="shipment_box_contents">
             {/* Submitted Move */}
-            {/* TODO: Change status to SUBMITTED when moves get that status on submit */}
-            {move.status === 'DRAFT' && (
+            {move.status === 'SUBMITTED' && (
               <div>
                 <img src={ppmSubmitted} alt="status" />
                 <div className="step-contents">

--- a/src/scenes/Legalese/ducks.js
+++ b/src/scenes/Legalese/ducks.js
@@ -29,7 +29,7 @@ export const loadCertificationText = ReduxHelpers.generateAsyncActionCreator(
   GetCertificationText,
 );
 
-export const createSignedCertification = ReduxHelpers.generateAsyncActionCreator(
+const createSignedCertification = ReduxHelpers.generateAsyncActionCreator(
   'CREATE_SIGNED_CERT',
   CreateCertification,
 );

--- a/src/scenes/Legalese/index.jsx
+++ b/src/scenes/Legalese/index.jsx
@@ -14,21 +14,12 @@ import './index.css';
 import {
   loadCertificationText,
   loadLatestCertification,
-  createSignedCertification,
+  signAndSubmitForApproval,
 } from './ducks';
 
 const validateSignatureForm = (values, form) => {
-  let errors = {};
-
-  const required_fields = ['signature', 'date'];
-
-  required_fields.forEach(fieldName => {
-    if (values[fieldName] === undefined || values[fieldName] === '') {
-      errors[fieldName] = 'Required.';
-    }
-  });
-
-  return errors;
+  // all the validation is taken care of by the schema fields
+  return {};
 };
 
 const formName = 'signature-form';
@@ -46,10 +37,6 @@ export class SignedCertification extends Component {
       this.props.loadCertificationText();
       return;
     }
-
-    if (this.props.hasSubmitSuccess) {
-      this.props.push('/');
-    }
   }
 
   handleSubmit = () => {
@@ -61,15 +48,16 @@ export class SignedCertification extends Component {
     }
 
     if (pendingValues) {
-      const certRequest = {
-        moveId: this.props.match.params.moveId,
-        createSignedCertificationPayload: {
-          certification_text: this.props.certificationText,
-          signature: pendingValues.signature,
-          date: pendingValues.date,
-        },
-      };
-      this.props.createSignedCertification(certRequest);
+      const moveId = this.props.match.params.moveId;
+
+      this.props
+        .signAndSubmitForApproval(
+          moveId,
+          this.props.certificationText,
+          pendingValues.signature,
+          pendingValues.date,
+        )
+        .then(() => this.props.push('/'));
     }
   };
 
@@ -78,7 +66,6 @@ export class SignedCertification extends Component {
       hasSubmitError,
       pages,
       pageKey,
-      hasSubmitSuccess,
       latestSignedCertification,
     } = this.props;
     const today = new Date(Date.now()).toISOString().split('T')[0];
@@ -94,7 +81,7 @@ export class SignedCertification extends Component {
             className={formName}
             pageList={pages}
             pageKey={pageKey}
-            hasSucceeded={hasSubmitSuccess}
+            hasSucceeded={false}
             initialValues={initialValues}
           >
             <div className="usa-grid">
@@ -153,7 +140,7 @@ export class SignedCertification extends Component {
 }
 
 SignedCertification.propTypes = {
-  createSignedCertification: PropTypes.func.isRequired,
+  signAndSubmitForApproval: PropTypes.func.isRequired,
   loadLatestCertification: PropTypes.func.isRequired,
   match: PropTypes.object.isRequired,
   handleSubmit: PropTypes.func,
@@ -178,7 +165,7 @@ function mapDispatchToProps(dispatch) {
     {
       loadCertificationText,
       loadLatestCertification,
-      createSignedCertification,
+      signAndSubmitForApproval,
       push,
     },
     dispatch,

--- a/src/scenes/Moves/api.js
+++ b/src/scenes/Moves/api.js
@@ -1,10 +1,5 @@
 import { getClient, checkResponse } from 'shared/api';
 
-export async function GetSpec() {
-  const client = await getClient();
-  return client.spec;
-}
-
 export async function CreateMove(ordersId, payload) {
   const client = await getClient();
   const response = await client.apis.moves.createMove({
@@ -34,5 +29,18 @@ export async function UpdateMove(
     patchMovePayload: payload,
   });
   checkResponse(response, 'failed to update move due to server error');
+  return response.body;
+}
+
+export async function SubmitMoveForApproval(moveId) {
+  console.log('submit for approval');
+  const client = await getClient();
+  const response = await client.apis.moves.submitMoveForApproval({
+    moveId,
+  });
+  checkResponse(
+    response,
+    'failed to submit move for approval due to server error',
+  );
   return response.body;
 }

--- a/src/scenes/Moves/ducks.js
+++ b/src/scenes/Moves/ducks.js
@@ -1,5 +1,11 @@
-import { CreateMove, UpdateMove, GetMove } from './api.js';
+import {
+  CreateMove,
+  UpdateMove,
+  GetMove,
+  SubmitMoveForApproval,
+} from './api.js';
 
+import * as ReduxHelpers from 'shared/ReduxHelpers';
 // Types
 export const SET_PENDING_MOVE_TYPE = 'SET_PENDING_MOVE_TYPE';
 export const CREATE_MOVE = 'CREATE_MOVE';
@@ -79,6 +85,15 @@ export function loadMove(moveId) {
   };
 }
 
+const SUBMIT_FOR_APPROVAL = 'SUBMIT_FOR_APPROVAL';
+export const SUBMIT_FOR_APPROVAL_TYPES = ReduxHelpers.generateAsyncActionTypes(
+  SUBMIT_FOR_APPROVAL,
+);
+export const SubmitForApproval = ReduxHelpers.generateAsyncActionCreator(
+  SUBMIT_FOR_APPROVAL,
+  SubmitMoveForApproval,
+);
+
 // Reducer
 const initialState = {
   currentMove: null,
@@ -124,6 +139,20 @@ export function moveReducer(state = initialState, action) {
         currentMove: {},
         hasSubmitSuccess: false,
         hasSubmitError: true,
+        error: action.error,
+      });
+    case SUBMIT_FOR_APPROVAL_TYPES.start:
+      return Object.assign({}, state, {
+        submittedForApproval: false,
+      });
+    case SUBMIT_FOR_APPROVAL_TYPES.success:
+      return Object.assign({}, state, {
+        currentMove: action.item,
+        submittedForApproval: true,
+      });
+    case SUBMIT_FOR_APPROVAL_TYPES.failure:
+      return Object.assign({}, state, {
+        submittedForApproval: false,
         error: action.error,
       });
     default:

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -2195,6 +2195,37 @@ paths:
             $ref: '#/definitions/MovePayload'
         500:
           description: server error
+  /moves/{moveId}/submit:
+    post:
+      summary: Submits a move for approval
+      description: Submits a move for approval by the office. The status of the move will be updated to SUBMITTED
+      operationId: submitMoveForApproval
+      tags:
+        - moves
+      parameters:
+        - name: moveId
+          in: path
+          type: string
+          format: uuid
+          required: true
+          description: UUID of the move
+      responses:
+        200:
+          description: returns updated (submitted) move object
+          schema:
+            $ref: '#/definitions/MovePayload'
+        400:
+          description: invalid request
+        401:
+          description: must be authenticated to use this endpoint
+        403:
+          description: not authorized to approve this move
+        409:
+          description: the move is not in a state to be approved
+          schema:
+            $ref: '#/definitions/MovePayload'
+        500:
+          description: server error
   /documents:
     post:
       summary: Create a new document


### PR DESCRIPTION
## Description

The endpoint for submitting a move for approval is defined and implemented.
The complete button on the last page in the SM flow submits the signed certification and then submits the move for approval.
The home page uses the SUBMITTED status to render the move differently than an APPROVED move.

## Reviewer Notes

Attempts to mark the PPM as SUBMITTED failed for weird pop reasons that we will need to address later. Since the approve endpoint does not manipulate the ppm, we leave that for a future story.
Since the signed certification is only created if there is not already a new one, you will need to start a new move to test this, or clear the signed_certifications table in your db.

## Code Review Verification Steps

* [ ] All tests pass.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/blob/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* [ ] Any migrations/schema changes also update the diagram in docs/schema/dp3.sqs
* [ ] There are no [aXe] warnings for UI.
* [ ] This works in IE.
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @willowbl00
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Request review from a member of a different team.
* [ ] (TRIAL) Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/157556819) for this change

