### PR TITLE
Remove TSP name field from TSP table

### DIFF
--- a/migrations/20180518041122_remove_tsp_name.down.fizz
+++ b/migrations/20180518041122_remove_tsp_name.down.fizz
@@ -1,0 +1,1 @@
+add_column("transportation_service_providers", "name", "string", {"null": false})

--- a/migrations/20180518041122_remove_tsp_name.up.fizz
+++ b/migrations/20180518041122_remove_tsp_name.up.fizz
@@ -1,0 +1,1 @@
+drop_column("transportation_service_providers", "name")


### PR DESCRIPTION
## Description

[A previous PR](https://github.com/transcom/mymove/pull/457) removed the name field from the rest of the code. This removes it from the transportation_service_providers as well, as was originally intended. 

## Reviewer Notes

Should the .down.fizz file be omitted? 

## Code Review Verification Steps

* [ ] All tests pass.
