### PR TITLE
Shows optional label when not custom component [delivers #157708253]

### DIFF
--- a/src/shared/JsonSchemaForm/JsonSchemaField.js
+++ b/src/shared/JsonSchemaForm/JsonSchemaField.js
@@ -184,7 +184,7 @@ const renderInputField = ({
         {title}
         {!always_required &&
           type !== 'boolean' &&
-          !component && <span className="label-optional">Optional</span>}
+          !customComponent && <span className="label-optional">Optional</span>}
       </label>
       {touched &&
         error && (


### PR DESCRIPTION
## Description

`component` is always something, should have been `customComponent`

## Code Review Verification Steps

* [ ] All tests pass.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/blob/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* [ ] Any migrations/schema changes also update the diagram in docs/schema/dp3.sqs
* [ ] There are no [aXe](https://www.deque.com/products/aXe/) warnings for UI.
* [ ] This works in IE.
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @willowbl00
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Request review from a member of a different team.
* [ ] (TRIAL) Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/157708253) for this change

## Screenshots

<img width="69" alt="screenshot 2018-05-18 15 12 28" src="https://user-images.githubusercontent.com/5151804/40260128-e575e6da-5aad-11e8-8d3a-06c20860c8dc.png">

