### PR TITLE
Home screen cleanup [delivers #157709814]

### DIFF
--- a/src/scenes/Landing/MoveSummary.jsx
+++ b/src/scenes/Landing/MoveSummary.jsx
@@ -45,7 +45,7 @@ export const MoveSummary = props => {
                 <div className="step-contents">
                   <div className="status_box usa-width-two-thirds">
                     <div className="step">
-                      <div className="title">Awaiting Approval</div>
+                      <div className="title">Next Step: Awaiting approval</div>
                       <div>
                         Your shipment is awaiting approval. This can take up to
                         3 business days. Questions or need help? Contact your
@@ -186,7 +186,7 @@ export const MoveSummary = props => {
             className="usa-button-secondary"
             onClick={() => editMove(move)}
           >
-            Edit Move Details
+            Edit Move
           </button>
         </div>
 

--- a/src/scenes/Landing/index.jsx
+++ b/src/scenes/Landing/index.jsx
@@ -103,9 +103,10 @@ export class Landing extends Component {
         )}
 
         {!isLoggedIn && <LoginButton />}
-        {loggedInUserSuccess && (
-          <button onClick={this.startMove}>Start a move</button>
-        )}
+        {!displayMove &&
+          loggedInUserSuccess && (
+            <button onClick={this.startMove}>Start a move</button>
+          )}
       </div>
     );
   }


### PR DESCRIPTION
## Description

- adds "Next Step:" before Awaiting approval.
- names the button "Edit Move" instead of Edit Move Details
- removes start a new move if there is a move

## Code Review Verification Steps

* [ ] All tests pass.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/blob/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* [ ] Any migrations/schema changes also update the diagram in docs/schema/dp3.sqs
* [ ] There are no [aXe](https://www.deque.com/products/aXe/) warnings for UI.
* [ ] This works in IE.
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @willowbl00
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Request review from a member of a different team.
* [ ] (TRIAL) Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/157709814) for this change

## Screenshots

<img width="1060" alt="screenshot 2018-05-18 17 19 54" src="https://user-images.githubusercontent.com/5151804/40262822-b464999e-5abf-11e8-8fea-3b3741444f9d.png">
