### PR TITLE
Adds entitlement data to home screen [delivers #157616831]

### DIFF
--- a/src/scenes/Landing/MoveSummary.jsx
+++ b/src/scenes/Landing/MoveSummary.jsx
@@ -21,7 +21,7 @@ const DutyStationContactInfo = props => {
 };
 
 export const MoveSummary = props => {
-  const { profile, move, orders, ppm, editMove } = props;
+  const { profile, move, orders, ppm, editMove, entitlement } = props;
   return (
     <div className="whole_box">
       <h2>
@@ -29,9 +29,12 @@ export const MoveSummary = props => {
       </h2>
       <div className="usa-width-three-fourths">
         <div>Move Locator: {move.locator}</div>
-        <div>
-          Weight Entitlement: <span className="Todo">10,500 lbs</span>
-        </div>
+        {entitlement && (
+          <div>
+            Weight Entitlement:{' '}
+            <span>{entitlement.total.toLocaleString()} lbs</span>
+          </div>
+        )}
         <div className="shipment_box">
           <div className="shipment_type">
             <img className="move_sm" src={ppmCar} alt="ppm-car" />

--- a/src/scenes/Landing/index.jsx
+++ b/src/scenes/Landing/index.jsx
@@ -7,6 +7,7 @@ import { bindActionCreators } from 'redux';
 import { MoveSummary } from './MoveSummary';
 
 import { createServiceMember } from 'scenes/ServiceMembers/ducks';
+import { loadEntitlements } from 'scenes/Orders/ducks';
 import { loadLoggedInUser } from 'shared/User/ducks';
 import Alert from 'shared/Alert';
 import LoginButton from 'shared/User/LoginButton';
@@ -68,6 +69,7 @@ export class Landing extends Component {
       loggedInUserError,
       createdServiceMemberError,
       loggedInUser,
+      entitlement,
     } = this.props;
 
     let profile = get(loggedInUser, 'service_member');
@@ -94,6 +96,7 @@ export class Landing extends Component {
         </div>
         {displayMove && (
           <MoveSummary
+            entitlement={entitlement}
             profile={profile}
             orders={orders}
             move={move}
@@ -121,6 +124,10 @@ const mapStateToProps = state => ({
   createdServiceMemberSuccess: state.serviceMember.hasSubmitSuccess,
   createdServiceMemberError: state.serviceMember.error,
   createdServiceMember: state.serviceMember.currentServiceMember,
+  entitlement: loadEntitlements(
+    get(state.loggedInUser, 'loggedInUser.service_member.orders.0'),
+    get(state.loggedInUser, 'loggedInUser.service_member'),
+  ),
 });
 
 function mapDispatchToProps(dispatch) {

--- a/src/scenes/Office/OrdersPanel.jsx
+++ b/src/scenes/Office/OrdersPanel.jsx
@@ -57,13 +57,13 @@ const OrdersDisplay = props => {
       <div className="editable-panel-column">
         <span className="editable-panel-column subheader">Entitlements</span>
         <PanelField title="Household Goods">
-          {get(props.entitlements, 'total', '')} lbs
+          {get(props.entitlements, 'total', '').toLocaleString()} lbs
         </PanelField>
         <PanelField title="Pro-gear">
-          {get(props.entitlements, 'pro_gear', '')} lbs
+          {get(props.entitlements, 'pro_gear', '').toLocaleString()} lbs
         </PanelField>
         <PanelField title="Spouse pro-gear">
-          {get(props.entitlements, 'pro_gear_spouse', '')} lbs
+          {get(props.entitlements, 'pro_gear_spouse', '').toLocaleString()} lbs
         </PanelField>
         <PanelField className="Todo" title="Short-term storage">
           90 days

--- a/src/scenes/Orders/ducks.js
+++ b/src/scenes/Orders/ducks.js
@@ -92,6 +92,9 @@ export function addUploads(uploads) {
 
 // Selectors
 export function loadEntitlements(orders, service_member) {
+  if (!orders || !service_member) {
+    return null;
+  }
   var rank = service_member.rank;
   var hasDependents = orders.has_dependents;
   return getEntitlements(rank, hasDependents);


### PR DESCRIPTION
## Description

Adds entitlement data to home screen

## Code Review Verification Steps

* [ ] All tests pass.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/blob/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* [ ] Any migrations/schema changes also update the diagram in docs/schema/dp3.sqs
* [ ] There are no [aXe](https://www.deque.com/products/aXe/) warnings for UI.
* [ ] This works in IE.
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @willowbl00
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Request review from a member of a different team.
* [ ] (TRIAL) Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/157616831) for this change

## Screenshots

<img width="453" alt="screenshot 2018-05-18 17 58 53" src="https://user-images.githubusercontent.com/5151804/40263315-24791e12-5ac5-11e8-8850-0cef7503f6dc.png">
