### PR TITLE
Add Edit Backup Contact Review Page

### DIFF
--- a/src/scenes/MyMove/index.jsx
+++ b/src/scenes/MyMove/index.jsx
@@ -12,6 +12,7 @@ import Landing from 'scenes/Landing';
 import Shipments from 'scenes/Shipments';
 import SubmittedFeedback from 'scenes/SubmittedFeedback';
 import EditProfile from 'scenes/Review/EditProfile';
+import EditBackupContact from 'scenes/Review/EditBackupContact';
 import Header from 'shared/Header/MyMove';
 import { history } from 'shared/store';
 import Footer from 'shared/Footer';
@@ -64,6 +65,11 @@ export class AppWrapper extends Component {
                   exact
                   path="/moves/:moveId/review/edit-profile"
                   component={EditProfile}
+                />
+                <PrivateRoute
+                  exact
+                  path="/moves/:moveId/review/edit-backup-contact"
+                  component={EditBackupContact}
                 />
                 <Route component={NoMatch} />
               </Switch>

--- a/src/scenes/Review/EditBackupContact.jsx
+++ b/src/scenes/Review/EditBackupContact.jsx
@@ -1,0 +1,126 @@
+import React, { Component } from 'react';
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+import { get } from 'lodash';
+
+import { push } from 'react-router-redux';
+import { reduxForm } from 'redux-form';
+
+import Alert from 'shared/Alert'; // eslint-disable-line
+import { SwaggerField } from 'shared/JsonSchemaForm/JsonSchemaField';
+
+import {
+  updateBackupContact,
+  indexBackupContacts,
+} from 'scenes/ServiceMembers/ducks';
+
+import './Review.css';
+import profileImage from './images/profile.png';
+
+const editBackupContactFormName = 'edit_backup_contact';
+
+let EditBackupContactForm = props => {
+  const { onCancel, schema, handleSubmit, submitting, valid } = props;
+  return (
+    <form onSubmit={handleSubmit}>
+      <img src={profileImage} alt="" /> Backup Contact
+      <hr />
+      <h3 className="sm-heading">Edit Backup Contact:</h3>
+      <SwaggerField fieldName="name" swagger={schema} required />
+      <SwaggerField fieldName="email" swagger={schema} required />
+      <SwaggerField fieldName="telephone" swagger={schema} />
+      <button type="submit" disabled={submitting || !valid}>
+        Save
+      </button>
+      <button type="button" disabled={submitting} onClick={onCancel}>
+        Cancel
+      </button>
+    </form>
+  );
+};
+EditBackupContactForm = reduxForm({
+  form: editBackupContactFormName,
+})(EditBackupContactForm);
+
+class EditBackupContact extends Component {
+  returnToReview = () => {
+    const reviewAddress = `/moves/${this.props.match.params.moveId}/review`;
+    this.props.push(reviewAddress);
+  };
+
+  componentDidUpdate = prevProps => {
+    // Once service member loads, load the backup contact.
+    if (this.props.serviceMember && !prevProps.serviceMember) {
+      this.props.indexBackupContacts(this.props.serviceMember.id);
+    }
+  };
+
+  updateContact = fieldValues => {
+    if (fieldValues.telephone === '') {
+      fieldValues.telephone = null;
+    }
+    return this.props
+      .updateBackupContact(fieldValues.id, fieldValues)
+      .then(() => {
+        // This promise resolves regardless of error.
+        if (!this.props.hasSubmitError) {
+          this.returnToReview();
+        } else {
+          window.scrollTo(0, 0);
+        }
+      });
+  };
+
+  render() {
+    const { error, schema, backupContacts } = this.props;
+
+    let backupContact = null;
+    if (backupContacts) {
+      backupContact = backupContacts[0];
+    }
+
+    return (
+      <div className="usa-grid">
+        {error && (
+          <div className="usa-width-one-whole error-message">
+            <Alert type="error" heading="An error occurred">
+              {error.message}
+            </Alert>
+          </div>
+        )}
+        <div className="usa-width-one-whole">
+          <EditBackupContactForm
+            initialValues={backupContact}
+            onSubmit={this.updateContact}
+            onCancel={this.returnToReview}
+            schema={schema}
+          />
+        </div>
+      </div>
+    );
+  }
+}
+
+function mapStateToProps(state) {
+  return {
+    backupContacts: get(state, 'serviceMember.currentBackupContacts'),
+    serviceMember: get(state, 'loggedInUser.loggedInUser.service_member'),
+    move: get(state, 'moves.currentMove'),
+    error: get(state, 'serviceMember.error'),
+    hasSubmitError: get(state, 'serviceMember.updateBackupContactError'),
+    schema: get(
+      state,
+      'swagger.spec.definitions.CreateServiceMemberBackupContactPayload',
+      {},
+    ),
+  };
+}
+
+function mapDispatchToProps(dispatch) {
+  return bindActionCreators(
+    { push, updateBackupContact, indexBackupContacts },
+    dispatch,
+  );
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(EditBackupContact);

--- a/src/scenes/Review/Review.jsx
+++ b/src/scenes/Review/Review.jsx
@@ -19,6 +19,13 @@ export class Review extends Component {
     if (!this.props.currentPpm) {
       this.props.loadPpm(this.props.match.params.moveId);
     }
+    const service_member = get(this.props.loggedInUser, 'service_member');
+    if (
+      service_member &&
+      !(this.props.currentBackupContacts && this.props.currentBackupContacts[0])
+    ) {
+      this.props.indexBackupContacts(service_member.id);
+    }
   }
   componentWillUpdate(newProps) {
     const service_member = get(newProps.loggedInUser, 'service_member');
@@ -247,7 +254,7 @@ export class Review extends Component {
                 <tbody>
                   <tr>
                     <th>
-                      Backup Contact Info{' '}
+                      Backup Contact{' '}
                       <span className="align-right">
                         <a href={editBackupContactAddress}>Edit</a>
                       </span>

--- a/src/scenes/Review/Review.jsx
+++ b/src/scenes/Review/Review.jsx
@@ -82,6 +82,7 @@ export class Review extends Component {
 
     const thisAddress = `/moves/${this.props.match.params.moveId}/review`;
     const editProfileAddress = thisAddress + '/edit-profile';
+    const editBackupContactAddress = thisAddress + '/edit-backup-contact';
 
     return (
       <WizardPage
@@ -246,7 +247,7 @@ export class Review extends Component {
                     <th>
                       Backup Contact Info{' '}
                       <span className="align-right">
-                        <a href="about:blank">Edit</a>
+                        <a href={editBackupContactAddress}>Edit</a>
                       </span>
                     </th>
                   </tr>


### PR DESCRIPTION
## Description

Adds a page to edit backup contacts from the review page. 

## Code Review Verification Steps

* [ ] All tests pass.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/blob/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* [ ] Any migrations/schema changes also update the diagram in docs/schema/dp3.sqs
* [ ] There are no [aXe](https://www.deque.com/products/aXe/) warnings for UI.
* [ ] This works in IE.
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @willowbl00
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Request review from a member of a different team.
* [ ] (TRIAL) Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](tbd) for this change
* [this article](tbd) explains more about the approach used.

## Screenshots

<img width="564" alt="screen shot 2018-05-19 at 5 32 08 pm" src="https://user-images.githubusercontent.com/55759/40274439-99020030-5b8a-11e8-9223-53bd5a864044.png">
