### PR TITLE
Updates size and weight sliders with entitlements [delivers #157200266]

### DIFF
--- a/src/scenes/Landing/index.jsx
+++ b/src/scenes/Landing/index.jsx
@@ -124,10 +124,7 @@ const mapStateToProps = state => ({
   createdServiceMemberSuccess: state.serviceMember.hasSubmitSuccess,
   createdServiceMemberError: state.serviceMember.error,
   createdServiceMember: state.serviceMember.currentServiceMember,
-  entitlement: loadEntitlements(
-    get(state.loggedInUser, 'loggedInUser.service_member.orders.0'),
-    get(state.loggedInUser, 'loggedInUser.service_member'),
-  ),
+  entitlement: loadEntitlements(state),
 });
 
 function mapDispatchToProps(dispatch) {

--- a/src/scenes/Moves/Ppm/Size.css
+++ b/src/scenes/Moves/Ppm/Size.css
@@ -1,5 +1,53 @@
 .ppm-size-content h3 {
-  margin-bottom: 5rem;
+  margin-bottom: 3rem;
   font-weight: bold;
   font-size: 2.5rem;
+}
+
+.entitlement-container {
+  background-color: #C8C8C8;
+  padding: 0.7em;
+  margin-bottom: 3rem;
+}
+
+.entitlement-container > p {
+  margin: 0;
+}
+
+.button-container {
+  display: flex;
+}
+
+.contents {
+  width: 100%;
+}
+
+.text {
+  min-height: 4em;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.radio {
+  width: 30px;
+  height: 30px;
+  -moz-border-radius: 15px;
+  -webkit-border-radius: 15px;
+  border-radius: 15px;
+  border: 1px solid #468ac8;
+  content: "\2713";
+}
+
+.radio.selected {
+  content: "\2713";
+  font-size: 20px;
+  line-height: 25px;
+  color: white;
+  background-color: #0071bc;
+  border: 1px solid #0071bc;
+}
+
+.radio-container {
+  margin: 10px 10px 0 0;
 }

--- a/src/scenes/Moves/Ppm/Size.css
+++ b/src/scenes/Moves/Ppm/Size.css
@@ -32,15 +32,11 @@
 .radio {
   width: 30px;
   height: 30px;
-  -moz-border-radius: 15px;
-  -webkit-border-radius: 15px;
   border-radius: 15px;
   border: 1px solid #468ac8;
-  content: "\2713";
 }
 
 .radio.selected {
-  content: "\2713";
   font-size: 20px;
   line-height: 25px;
   color: white;

--- a/src/scenes/Moves/Ppm/Weight.jsx
+++ b/src/scenes/Moves/Ppm/Weight.jsx
@@ -5,6 +5,7 @@ import { get } from 'lodash';
 import PropTypes from 'prop-types';
 import Slider from 'react-rangeslider'; //todo: pull from node_modules, override
 
+import { loadEntitlements } from 'scenes/Orders/ducks';
 import WizardPage from 'shared/WizardPage';
 import Alert from 'shared/Alert';
 import LoadingPlaceholder from 'shared/LoadingPlaceholder';
@@ -18,37 +19,46 @@ import {
 import 'react-rangeslider/lib/index.css';
 import './Weight.css';
 
-function getWeightInfo(ppm) {
+function getWeightInfo(ppm, entitlement) {
   const size = ppm ? ppm.size : 'L';
   switch (size) {
     case 'S':
       return {
-        min: 100,
-        max: 800,
+        min: 50,
+        max: 1000,
       };
     case 'M':
       return {
-        min: 400,
-        max: 1200,
+        min: 500,
+        max: 2500,
       };
     default:
       return {
-        min: 1000,
-        max: 5000, //TODO: this should be max entitlement
+        min: 1500,
+        max: entitlement.sum,
       };
   }
 }
 export class PpmWeight extends Component {
   componentDidMount() {
     document.title = 'Transcom PPP: Weight Selection';
-    if (!this.props.currentPpm) {
-      this.props.loadPpm(this.props.match.params.moveId);
-    } else {
+    if (this.props.currentPpm) {
       this.updateIncentive();
     }
   }
   componentDidUpdate(prevProps, prevState) {
-    if (!prevProps.hasLoadSuccess && this.props.hasLoadSuccess) {
+    if (
+      !prevProps.loggedInUser.hasSucceeded &&
+      this.props.loggedInUser.hasSucceeded
+    ) {
+      this.props.loadPpm(this.props.match.params.moveId);
+    }
+
+    if (
+      !prevProps.hasLoadSuccess &&
+      this.props.hasLoadSuccess &&
+      this.props.currentPpm
+    ) {
       this.updateIncentive();
     }
   }
@@ -81,6 +91,7 @@ export class PpmWeight extends Component {
   };
   onWeightSelected = value => {
     const { currentPpm } = this.props;
+    debugger;
     this.props.getPpmWeightEstimate(
       currentPpm.planned_move_date,
       currentPpm.pickup_zip,
@@ -99,8 +110,12 @@ export class PpmWeight extends Component {
       currentWeight,
       hasLoadSuccess,
       error,
+      entitlement,
     } = this.props;
-    const currentInfo = getWeightInfo(currentPpm);
+    let currentInfo = null;
+    if (hasLoadSuccess) {
+      currentInfo = getWeightInfo(currentPpm, entitlement);
+    }
 
     return (
       <WizardPage
@@ -135,9 +150,8 @@ export class PpmWeight extends Component {
                 onChange={this.onWeightSelecting}
                 onChangeComplete={this.onWeightSelected}
                 labels={{
-                  [currentInfo.min]: currentInfo.min,
-                  [currentInfo.max]: currentInfo.max,
-                  //[currentWeight]: currentWeight,
+                  [currentInfo.min]: currentInfo.min.toLocaleString(),
+                  [currentInfo.max]: currentInfo.max.toLocaleString(),
                 }}
               />
             </div>
@@ -191,23 +205,26 @@ PpmWeight.propTypes = {
   hasSubmitSuccess: PropTypes.bool.isRequired,
   hasLoadSuccess: PropTypes.bool.isRequired,
   setPendingPpmWeight: PropTypes.func.isRequired,
+  entitlement: PropTypes.object,
 };
 
-function getMiddleWeight(ppm) {
-  const currentInfo = getWeightInfo(ppm);
+function getMiddleWeight(ppm, entitlement) {
+  const currentInfo = getWeightInfo(ppm, entitlement);
   return currentInfo.min + (currentInfo.max - currentInfo.min) / 2;
 }
 function mapStateToProps(state) {
+  const entitlement = loadEntitlements(state);
+  const defaultWeight = state.ppm.hasLoadSuccess
+    ? getMiddleWeight(state.ppm.currentPpm, entitlement)
+    : null;
   const currentWeight =
     state.ppm.pendingPpmWeight ||
-    get(
-      state,
-      'ppm.currentPpm.weight_estimate',
-      getMiddleWeight(state.ppm.currentPpm),
-    );
+    get(state, 'ppm.currentPpm.weight_estimate', defaultWeight);
   const props = {
     ...state.ppm,
+    loggedInUser: state.loggedInUser,
     currentWeight,
+    entitlement: loadEntitlements(state),
   };
 
   return props;

--- a/src/scenes/Moves/Ppm/Weight.jsx
+++ b/src/scenes/Moves/Ppm/Weight.jsx
@@ -91,7 +91,6 @@ export class PpmWeight extends Component {
   };
   onWeightSelected = value => {
     const { currentPpm } = this.props;
-    debugger;
     this.props.getPpmWeightEstimate(
       currentPpm.planned_move_date,
       currentPpm.pickup_zip,

--- a/src/scenes/Moves/Ppm/ducks.js
+++ b/src/scenes/Moves/Ppm/ducks.js
@@ -1,4 +1,4 @@
-import { get } from 'lodash';
+import { get, find } from 'lodash';
 import { CreatePpm, UpdatePpm, GetPpm, GetPpmWeightEstimate } from './api.js';
 import * as ReduxHelpers from 'shared/ReduxHelpers';
 
@@ -71,9 +71,20 @@ export function loadPpm(moveId) {
     const state = getState();
     const currentPpm = state.ppm.currentPpm;
     if (!currentPpm) {
-      GetPpm(moveId)
-        .then(item => dispatch(action.success(item)))
-        .catch(error => dispatch(action.error(error)));
+      // Load PPM from loggedInUser if available
+      const loadedMoves = get(
+        state,
+        'loggedInUser.loggedInUser.service_member.orders.0.moves',
+        [],
+      );
+      const matchingMove = find(loadedMoves, ['id', moveId]);
+      if (get(matchingMove, 'personally_procured_moves.length')) {
+        dispatch(action.success(matchingMove.personally_procured_moves));
+      } else {
+        GetPpm(moveId)
+          .then(item => dispatch(action.success(item)))
+          .catch(error => dispatch(action.error(error)));
+      }
     }
   };
 }

--- a/src/scenes/Office/OrdersPanel.jsx
+++ b/src/scenes/Office/OrdersPanel.jsx
@@ -6,7 +6,7 @@ import { reduxForm } from 'redux-form';
 import editablePanel from './editablePanel';
 
 import { no_op_action } from 'shared/utils';
-import { loadEntitlements } from 'scenes/Orders/ducks';
+import { loadEntitlements } from 'scenes/Office/ducks';
 
 import {
   PanelSwaggerField,
@@ -190,10 +190,7 @@ function mapStateToProps(state) {
     errorMessage: state.office.error,
     orders: get(state, 'office.officeOrders'),
     serviceMember: get(state, 'office.officeServiceMember'),
-    entitlements: loadEntitlements(
-      get(state, 'office.officeOrders'),
-      get(state, 'office.officeServiceMember'),
-    ),
+    entitlements: loadEntitlements(state),
     isUpdating: false,
   };
 }

--- a/src/scenes/Office/ducks.js
+++ b/src/scenes/Office/ducks.js
@@ -1,3 +1,4 @@
+import { isNull, get } from 'lodash';
 import {
   LoadAccountingAPI,
   UpdateAccountingAPI,
@@ -8,6 +9,7 @@ import {
   LoadPPMs,
   ApproveBasics,
 } from './api.js';
+import { getEntitlements } from 'shared/entitlements.js';
 import * as ReduxHelpers from 'shared/ReduxHelpers';
 
 // Types
@@ -108,6 +110,16 @@ export function loadMoveDependencies(moveId) {
       return dispatch(actions.error(ex));
     }
   };
+}
+
+// Selectors
+export function loadEntitlements(state) {
+  const hasDependents = get(state, 'office.officeOrders.has_dependents', null);
+  const rank = get(state, 'office.officeServiceMember.rank', null);
+  if (isNull(hasDependents) || isNull(rank)) {
+    return null;
+  }
+  return getEntitlements(rank, hasDependents);
 }
 
 // Reducer

--- a/src/scenes/Orders/ducks.js
+++ b/src/scenes/Orders/ducks.js
@@ -1,4 +1,4 @@
-import { reject, concat } from 'lodash';
+import { reject, concat, get, isNull } from 'lodash';
 import {
   CreateOrders,
   UpdateOrders,
@@ -91,12 +91,20 @@ export function addUploads(uploads) {
 }
 
 // Selectors
-export function loadEntitlements(orders, service_member) {
-  if (!orders || !service_member) {
+export function loadEntitlements(state) {
+  const hasDependents = get(
+    state.loggedInUser,
+    'loggedInUser.service_member.orders.0.has_dependents',
+    null,
+  );
+  const rank = get(
+    state.loggedInUser,
+    'loggedInUser.service_member.rank',
+    null,
+  );
+  if (isNull(hasDependents) || isNull(rank)) {
     return null;
   }
-  var rank = service_member.rank;
-  var hasDependents = orders.has_dependents;
   return getEntitlements(rank, hasDependents);
 }
 

--- a/src/shared/User/ducks.js
+++ b/src/shared/User/ducks.js
@@ -8,13 +8,13 @@ import {
   SHOW_CURRENT_ORDERS,
 } from 'scenes/Orders/ducks.js';
 
-const GET_LOGGED_IN_USER = 'GET_LOGGED_IN_USER';
+const getLoggedInUserType = 'GET_LOGGED_IN_USER';
 
-export const getUserTypes = helpers.generateAsyncActionTypes(
-  GET_LOGGED_IN_USER,
+export const GET_LOGGED_IN_USER = helpers.generateAsyncActionTypes(
+  getLoggedInUserType,
 );
 
-const getLoggedInActions = helpers.generateAsyncActions(GET_LOGGED_IN_USER);
+const getLoggedInActions = helpers.generateAsyncActions(getLoggedInUserType);
 export const loadLoggedInUser = () => {
   return function(dispatch) {
     const userInfo = getUserInfo();
@@ -27,7 +27,7 @@ export const loadLoggedInUser = () => {
 };
 
 const generatedReducer = helpers.generateAsyncReducer(
-  GET_LOGGED_IN_USER,
+  getLoggedInUserType,
   u => ({ loggedInUser: u }),
 );
 

--- a/src/shared/entitlements.js
+++ b/src/shared/entitlements.js
@@ -1,4 +1,4 @@
-import { has } from 'lodash';
+import { has, sum } from 'lodash';
 
 export function getEntitlements(rank, hasDependents = false) {
   if (!has(entitlements, rank)) {
@@ -12,6 +12,11 @@ export function getEntitlements(rank, hasDependents = false) {
     total: entitlements[rank][totalKey],
     pro_gear: entitlements[rank].pro_gear_weight,
     pro_gear_spouse: entitlements[rank].pro_gear_weight_spouse,
+    sum: sum([
+      entitlements[rank][totalKey],
+      entitlements[rank].pro_gear_weight,
+      entitlements[rank].pro_gear_weight_spouse,
+    ]),
   };
 }
 


### PR DESCRIPTION
## Description

- adds entitlement info to size and weight screens
- updates weight ranges for S/M/L to new values
- updates text on size screen
- implements radio button UI on size screen because I don't read Pivotal tickets that closely

## Code Review Verification Steps

* [ ] All tests pass.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/blob/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* [ ] Any migrations/schema changes also update the diagram in docs/schema/dp3.sqs
* [ ] There are no [aXe](https://www.deque.com/products/aXe/) warnings for UI.
* [ ] This works in IE.
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @willowbl00
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Request review from a member of a different team.
* [ ] (TRIAL) Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/157200266) for this change

## Screenshots

<img width="1024" alt="screenshot 2018-05-19 22 08 16" src="https://user-images.githubusercontent.com/5151804/40275902-a7005f0c-5bb1-11e8-953b-6971d9c03ac0.png">


![entitlements](https://user-images.githubusercontent.com/5151804/40275907-c363cc10-5bb1-11e8-80b4-522647fd03be.gif)

