### PR TITLE
Fixes double path push on new service member [delivers #157720580]

### DIFF
--- a/src/scenes/Landing/index.jsx
+++ b/src/scenes/Landing/index.jsx
@@ -21,27 +21,21 @@ export class Landing extends Component {
   }
   componentDidUpdate() {
     if (this.props.loggedInUserSuccess) {
-      // Once the logged in user loads, if the service member doesn't
-      // exist we need to dispatch creating one, once.
       if (
         !this.props.createdServiceMemberIsLoading &&
         !this.props.loggedInUser.service_member
       ) {
-        this.props.createServiceMember({}).then(something => {
-          this.props.push(
-            `service-member/${
-              this.props.loggedInUser.service_member.id
-            }/create`,
-          );
-        });
-        // If the service member exists, but is not complete, redirect as well.
+        // Once the logged in user loads, if the service member doesn't
+        // exist we need to dispatch creating one, once.
+        this.props.createServiceMember({});
       } else if (
         this.props.loggedInUser &&
         this.props.loggedInUser.service_member &&
         !this.props.loggedInUser.service_member.is_profile_complete
       ) {
+        // If the service member exists, but is not complete, redirect to profile creation.
         this.props.push(
-          `service-member/${this.props.loggedInUser.service_member.id}/create`,
+          `/service-member/${this.props.loggedInUser.service_member.id}/create`,
         );
       }
     }


### PR DESCRIPTION
## Description

We were accidentally pushing a route twice, once after calling `createServiceMember`, and again after `componentDidUpdate` fired again with an incomplete service member profile. This make it such that the route is only pushed when a loaded but incomplete SM profile is found.

## Code Review Verification Steps

* [ ] All tests pass.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/blob/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* [ ] Any migrations/schema changes also update the diagram in docs/schema/dp3.sqs
* [ ] There are no [aXe](https://www.deque.com/products/aXe/) warnings for UI.
* [ ] This works in IE.
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @willowbl00
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Request review from a member of a different team.
* [ ] (TRIAL) Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/157720580) for this change