### PR TITLE
Link to order viewer in the move info sidebar [delivers #157546611]

### DIFF
--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -6,7 +6,7 @@ import { connect } from 'react-redux';
 import { get, capitalize } from 'lodash';
 
 import { RoutedTabs, NavTab } from 'react-router-tabs';
-import { Switch, Redirect } from 'react-router-dom';
+import { Switch, Redirect, Link } from 'react-router-dom';
 
 import LoadingPlaceholder from 'shared/LoadingPlaceholder';
 import PrivateRoute from 'shared/User/PrivateRoute';
@@ -64,12 +64,7 @@ class MoveInfo extends Component {
     // const officeBackupContacts = this.props.officeBackupContacts || []
     const officePPMs = this.props.officePPMs || [];
 
-    let uploads;
-    if (this.props.officeOrders) {
-      uploads = this.props.officeOrders.uploaded_orders.uploads;
-    } else {
-      uploads = [];
-    }
+    let upload = get(this.props, 'officeOrders.uploaded_orders.uploads.0'); // there can be only one
 
     if (
       !this.props.loadDependenciesHasSuccess &&
@@ -188,21 +183,17 @@ class MoveInfo extends Component {
                 Documents
                 <FontAwesomeIcon className="icon" icon={faExternalLinkAlt} />
               </h2>
-              {uploads.length === 0 && <p>No orders have been uploaded.</p>}
-              {uploads.map(upload => {
-                return (
-                  <div key={upload.url} className="document">
-                    <FontAwesomeIcon
-                      style={{ color: 'red' }}
-                      className="icon"
-                      icon={faExclamationCircle}
-                    />
-                    <a href={upload.url} target="_blank">
-                      Orders ({formatDate(upload.created_at)})
-                    </a>
-                  </div>
-                );
-              })}
+              {!upload && <p>No orders have been uploaded.</p>}
+              <div className="document">
+                <FontAwesomeIcon
+                  style={{ color: 'red' }}
+                  className="icon"
+                  icon={faExclamationCircle}
+                />
+                <Link to={`/moves/${officeMove.id}/orders`} target="_blank">
+                  Orders ({formatDate(upload.created_at)})
+                </Link>
+              </div>
             </div>
           </div>
         </div>

--- a/src/scenes/Office/OrdersPanel.jsx
+++ b/src/scenes/Office/OrdersPanel.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { reduxForm } from 'redux-form';
+import { Link } from 'react-router-dom';
 
 import editablePanel from './editablePanel';
 import { no_op_action } from 'shared/utils';

--- a/src/scenes/Office/OrdersPanel.jsx
+++ b/src/scenes/Office/OrdersPanel.jsx
@@ -3,8 +3,8 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { reduxForm } from 'redux-form';
-import editablePanel from './editablePanel';
 
+import editablePanel from './editablePanel';
 import { no_op_action } from 'shared/utils';
 import { loadEntitlements } from 'scenes/Office/ducks';
 
@@ -27,13 +27,10 @@ const OrdersDisplay = props => {
     <React.Fragment>
       <div className="editable-panel-column">
         <PanelField title="Orders Number">
-          <a
-            href={get(props.orders, 'uploaded_orders.uploads[0].url')}
-            target="_blank"
-          >
+          <Link to={`/moves/${props.move.id}/orders`} target="_blank">
             <SwaggerValue fieldName="orders_number" {...fieldProps} />&nbsp;
             <FontAwesomeIcon className="icon" icon={faExternalLinkAlt} />
-          </a>
+          </Link>
         </PanelField>
         <PanelSwaggerField
           title="Date issued"
@@ -189,6 +186,7 @@ function mapStateToProps(state) {
     hasError: false,
     errorMessage: state.office.error,
     orders: get(state, 'office.officeOrders'),
+    move: get(state, 'office.officeMove'),
     serviceMember: get(state, 'office.officeServiceMember'),
     entitlements: loadEntitlements(state),
     isUpdating: false,


### PR DESCRIPTION
## Description

This PR connects the document link in the Move Info page's sidebar with the document viewer built previously.

## Code Review Verification Steps

* [x] All tests pass.
* [x] There are no [aXe](https://www.deque.com/products/aXe/) warnings for UI.
* [x] This works in IE.
* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/157546611) for this change

## Screenshots

![docu](https://user-images.githubusercontent.com/3331/40317487-3d8f5bfe-5ce7-11e8-8424-def04c27bb30.gif)
