### PR TITLE
Use correct date format in orders panel [delivers #157686120]

### DIFF
--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -124,7 +124,8 @@ class MoveInfo extends Component {
               <li>Locator# {officeMove.locator}</li>
               <li className="Todo">KKFA to HAFC</li>
               <li>
-                Requested Pickup {get(officePPMs, '[0].planned_move_date')}
+                Requested Pickup{' '}
+                {formatDate(get(officePPMs, '[0].planned_move_date'))}
               </li>
             </ul>
           </div>

--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -124,8 +124,7 @@ class MoveInfo extends Component {
               <li>Locator# {officeMove.locator}</li>
               <li className="Todo">KKFA to HAFC</li>
               <li>
-                Requested Pickup{' '}
-                {formatDate(get(officePPMs, '[0].planned_move_date'))}
+                Move date {formatDate(get(officePPMs, '[0].planned_move_date'))}
               </li>
             </ul>
           </div>

--- a/src/scenes/Office/OrdersPanel.jsx
+++ b/src/scenes/Office/OrdersPanel.jsx
@@ -7,6 +7,7 @@ import editablePanel from './editablePanel';
 
 import { no_op_action } from 'shared/utils';
 import { loadEntitlements } from 'scenes/Office/ducks';
+import { formatDate } from './helpers';
 
 import {
   PanelSwaggerField,
@@ -35,17 +36,15 @@ const OrdersDisplay = props => {
             <FontAwesomeIcon className="icon" icon={faExternalLinkAlt} />
           </a>
         </PanelField>
-        <PanelSwaggerField
+        <PanelField
           title="Date issued"
-          fieldName="issue_date"
-          {...fieldProps}
+          value={formatDate(props.orders.issue_date)}
         />
         <PanelSwaggerField fieldName="orders_type" {...fieldProps} />
         <PanelSwaggerField fieldName="orders_type_detail" {...fieldProps} />
-        <PanelSwaggerField
+        <PanelField
           title="Report by"
-          fieldName="report_by_date"
-          {...fieldProps}
+          value={formatDate(props.orders.report_by_date)}
         />
         <PanelField title="Current Duty Station">
           {get(props.serviceMember, 'current_station.name', '')}

--- a/src/scenes/Office/helpers.jsx
+++ b/src/scenes/Office/helpers.jsx
@@ -1,15 +1,15 @@
 import moment from 'moment';
 
-// Format a date and ignore any time values, e.g. 30-Jan-2018
+// Format a date and ignore any time values, e.g. 03-Jan-2018
 export function formatDate(date) {
   if (date) {
-    return moment(date).format('D-MMM-YY');
+    return moment(date).format('DD-MMM-YY');
   }
 }
 
-// Format a date and include its time, e.g. 30-Jan-2018 21:23
+// Format a date and include its time, e.g. 03-Jan-2018 21:23
 export function formatDateTime(date) {
   if (date) {
-    return moment(date).format('D-MMM-YY HH:mm');
+    return moment(date).format('DD-MMM-YY HH:mm');
   }
 }


### PR DESCRIPTION
## Description

This adjusts the date formatting used throughout the Office app to be `01-Jan-18`. Note the leading zero and use of Month name to avoid ambiguity.

## Code Review Verification Steps

* [x] All tests pass.
* [x] There are no [aXe](https://www.deque.com/products/aXe/) warnings for UI.
* [x] This works in IE.
* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/157686120) for this change