### PR TITLE
Uses summed entitlement amount on home screen [delivers #157616831]

### DIFF
--- a/src/scenes/Landing/MoveSummary.jsx
+++ b/src/scenes/Landing/MoveSummary.jsx
@@ -32,7 +32,7 @@ export const MoveSummary = props => {
         {entitlement && (
           <div>
             Weight Entitlement:{' '}
-            <span>{entitlement.total.toLocaleString()} lbs</span>
+            <span>{entitlement.sum.toLocaleString()} lbs</span>
           </div>
         )}
         <div className="shipment_box">


### PR DESCRIPTION
## Description

Uses total + pro gear amounts instead of just total

## Code Review Verification Steps

* [ ] All tests pass.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/blob/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* [ ] Any migrations/schema changes also update the diagram in docs/schema/dp3.sqs
* [ ] There are no [aXe](https://www.deque.com/products/aXe/) warnings for UI.
* [ ] This works in IE.
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @willowbl00
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Request review from a member of a different team.
* [ ] (TRIAL) Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/157616831) for this change