### PR TITLE
add 'get' to load empty objs

### DIFF
--- a/src/scenes/Office/BackupInfoPanel.jsx
+++ b/src/scenes/Office/BackupInfoPanel.jsx
@@ -123,16 +123,15 @@ function mapStateToProps(state) {
     // reduxForm
     initialValues: {
       backupContact: backupContact,
-      backupMailingAddress: serviceMember.backup_mailing_address,
+      backupMailingAddress: get(serviceMember, 'backup_mailing_address', {}),
     },
-
     addressSchema: get(state, 'swagger.spec.definitions.Address', {}),
     backupContactSchema: get(
       state,
       'swagger.spec.definitions.ServiceMemberBackupContactPayload',
       {},
     ),
-    backupMailingAddress: serviceMember.backup_mailing_address,
+    backupMailingAddress: get(serviceMember, 'backup_mailing_address', {}),
     backupContact: backupContact,
 
     getUpdateArgs: function() {


### PR DESCRIPTION
## Description

Add get around loading backup mailing address, so you can load page without that element.


## Code Review Verification Steps

* [ ] All tests pass.
* [ ] This works in IE.
* [ ] Request review from a member of a different team.
* [ ] (TRIAL) Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/157782056) for this change
