### PR TITLE
Puts move creation in create orders handler, fixes client state sync

### DIFF
--- a/pkg/handlers/orders.go
+++ b/pkg/handlers/orders.go
@@ -86,6 +86,14 @@ func (h CreateOrdersHandler) Handle(params ordersop.CreateOrdersParams) middlewa
 		return responseForVErrors(h.logger, verrs, err)
 	}
 
+	// TODO: Don't default to PPM when we start supporting HHG
+	newMoveType := internalmessages.SelectedMoveTypePPM
+	newMove, verrs, err := newOrder.CreateNewMove(h.db, &newMoveType)
+	if err != nil || verrs.HasAny() {
+		return responseForVErrors(h.logger, verrs, err)
+	}
+	newOrder.Moves = append(newOrder.Moves, *newMove)
+
 	orderPayload, err := payloadForOrdersModel(h.storage, newOrder)
 	if err != nil {
 		return responseForError(h.logger, err)

--- a/pkg/handlers/orders_test.go
+++ b/pkg/handlers/orders_test.go
@@ -43,6 +43,7 @@ func (suite *HandlerSuite) TestCreateOrder() {
 	okResponse := response.(*ordersop.CreateOrdersCreated)
 
 	suite.Assertions.Equal(sm.ID.String(), okResponse.Payload.ServiceMemberID.String())
+	suite.Assertions.Len(okResponse.Payload.Moves, 1)
 	suite.Assertions.Equal(ordersType, okResponse.Payload.OrdersType)
 }
 

--- a/pkg/models/order.go
+++ b/pkg/models/order.go
@@ -91,7 +91,9 @@ func FetchOrder(db *pop.Connection, user User, reqApp string, id uuid.UUID) (Ord
 	var order Order
 	err := db.Q().Eager("ServiceMember.User",
 		"NewDutyStation.Address",
-		"UploadedOrders.Uploads").Find(&order, id)
+		"UploadedOrders.Uploads",
+		"Moves.PersonallyProcuredMoves",
+		"Moves.SignedCertifications").Find(&order, id)
 	if err != nil {
 		if errors.Cause(err).Error() == recordNotFoundErrorString {
 			return Order{}, ErrFetchNotFound

--- a/src/scenes/Moves/ducks.js
+++ b/src/scenes/Moves/ducks.js
@@ -1,53 +1,28 @@
+import { get } from 'lodash';
 import {
   CreateMove,
   UpdateMove,
   GetMove,
   SubmitMoveForApproval,
 } from './api.js';
+import { GET_LOGGED_IN_USER } from 'shared/User/ducks';
 
 import * as ReduxHelpers from 'shared/ReduxHelpers';
 // Types
-export const SET_PENDING_MOVE_TYPE = 'SET_PENDING_MOVE_TYPE';
-export const CREATE_MOVE = 'CREATE_MOVE';
-export const UPDATE_MOVE = 'UPDATE_MOVE';
-export const CREATE_OR_UPDATE_MOVE_SUCCESS = 'CREATE_OR_UPDATE_MOVE_SUCCESS';
-export const CREATE_OR_UPDATE_MOVE_FAILURE = 'CREATE_OR_UPDATE_MOVE_FAILURE';
-export const GET_MOVE = 'GET_MOVE';
-export const GET_MOVE_SUCCESS = 'GET_MOVE_SUCCESS';
-export const GET_MOVE_FAILURE = 'GET_MOVE_FAILURE';
+const SET_PENDING_MOVE_TYPE = 'SET_PENDING_MOVE_TYPE';
 
-export const createMoveRequest = () => ({
-  type: CREATE_MOVE,
-});
+export const getMoveType = 'GET_MOVE';
+export const GET_MOVE = ReduxHelpers.generateAsyncActionTypes(getMoveType);
 
-export const updateMoveRequest = () => ({
-  type: UPDATE_MOVE,
-});
+export const createOrUpdateMoveType = 'CREATE_OR_UPDATE_MOVE';
+export const CREATE_OR_UPDATE_MOVE = ReduxHelpers.generateAsyncActionTypes(
+  createOrUpdateMoveType,
+);
 
-export const createOrUpdateMoveSuccess = item => ({
-  type: CREATE_OR_UPDATE_MOVE_SUCCESS,
-  item,
-});
-
-export const createOrUpdateMoveFailure = error => ({
-  type: CREATE_OR_UPDATE_MOVE_FAILURE,
-  error,
-});
-
-const getMoveRequest = () => ({
-  type: GET_MOVE,
-});
-
-export const getMoveSuccess = item => ({
-  type: GET_MOVE_SUCCESS,
-  item,
-  // item: items.length > 0 ? items[0] : null,
-});
-
-export const getMoveFailure = error => ({
-  type: GET_MOVE_FAILURE,
-  error,
-});
+export const submitForApprovalType = 'SUBMIT_FOR_APPROVAL';
+export const SUBMIT_FOR_APPROVAL = ReduxHelpers.generateAsyncActionTypes(
+  submitForApprovalType,
+);
 
 // Action creation
 export function setPendingMoveType(value) {
@@ -56,37 +31,36 @@ export function setPendingMoveType(value) {
 
 export function createMove(ordersId, movePayload = {}) {
   return function(dispatch) {
-    dispatch(createMoveRequest());
+    const action = ReduxHelpers.generateAsyncActions(createOrUpdateMoveType);
+    dispatch(action.start());
     return CreateMove(ordersId, movePayload)
-      .then(item => dispatch(createOrUpdateMoveSuccess(item)))
-      .catch(error => dispatch(createOrUpdateMoveFailure(error)));
+      .then(item => dispatch(action.success(item)))
+      .catch(error => dispatch(action.failure(error)));
   };
 }
 
 export function updateMove(moveId, moveType) {
   return function(dispatch) {
-    dispatch(updateMoveRequest());
+    const action = ReduxHelpers.generateAsyncActions(createOrUpdateMoveType);
+    dispatch(action.start());
     return UpdateMove(moveId, { selected_move_type: moveType })
-      .then(item => dispatch(createOrUpdateMoveSuccess(item)))
-      .catch(error => dispatch(createOrUpdateMoveFailure(error)));
+      .then(item => dispatch(action.success(item)))
+      .catch(error => dispatch(action.failure(error)));
   };
 }
 
 export function loadMove(moveId) {
   return function(dispatch, getState) {
-    dispatch(getMoveRequest());
+    const action = ReduxHelpers.generateAsyncActions(getMoveType);
+    dispatch(action.start());
     return GetMove(moveId)
-      .then(item => dispatch(getMoveSuccess(item)))
-      .catch(error => dispatch(getMoveFailure(error)));
+      .then(item => dispatch(action.success(item)))
+      .catch(error => dispatch(action.success(error)));
   };
 }
 
-const SUBMIT_FOR_APPROVAL = 'SUBMIT_FOR_APPROVAL';
-export const SUBMIT_FOR_APPROVAL_TYPES = ReduxHelpers.generateAsyncActionTypes(
-  SUBMIT_FOR_APPROVAL,
-);
 export const SubmitForApproval = ReduxHelpers.generateAsyncActionCreator(
-  SUBMIT_FOR_APPROVAL,
+  submitForApprovalType,
   SubmitMoveForApproval,
 );
 
@@ -100,53 +74,54 @@ const initialState = {
 };
 export function moveReducer(state = initialState, action) {
   switch (action.type) {
+    case GET_LOGGED_IN_USER.success:
+      const move = get(action.payload, 'service_member.orders.0.moves.0', null);
+      return Object.assign({}, state, {
+        currentMove: move,
+      });
     case SET_PENDING_MOVE_TYPE:
       return Object.assign({}, state, {
         pendingMoveType: action.payload,
       });
-    case UPDATE_MOVE:
+    case CREATE_OR_UPDATE_MOVE.success:
       return Object.assign({}, state, {
-        hasSubmitSuccess: false,
-      });
-    case CREATE_OR_UPDATE_MOVE_SUCCESS:
-      return Object.assign({}, state, {
-        currentMove: action.item,
+        currentMove: action.payload,
         pendingMoveType: null,
         hasSubmitSuccess: true,
         hasSubmitError: false,
         error: null,
       });
-    case CREATE_OR_UPDATE_MOVE_FAILURE:
+    case CREATE_OR_UPDATE_MOVE.failure:
       return Object.assign({}, state, {
         currentMove: {},
         hasSubmitSuccess: false,
         hasSubmitError: true,
         error: action.error,
       });
-    case GET_MOVE_SUCCESS:
+    case GET_MOVE.success:
       return Object.assign({}, state, {
-        currentMove: action.item,
+        currentMove: action.payload,
         hasSubmitSuccess: true,
         hasSubmitError: false,
         error: null,
       });
-    case GET_MOVE_FAILURE:
+    case GET_MOVE.failure:
       return Object.assign({}, state, {
         currentMove: {},
         hasSubmitSuccess: false,
         hasSubmitError: true,
         error: action.error,
       });
-    case SUBMIT_FOR_APPROVAL_TYPES.start:
+    case SUBMIT_FOR_APPROVAL.start:
       return Object.assign({}, state, {
         submittedForApproval: false,
       });
-    case SUBMIT_FOR_APPROVAL_TYPES.success:
+    case SUBMIT_FOR_APPROVAL.success:
       return Object.assign({}, state, {
-        currentMove: action.item,
+        currentMove: action.payload,
         submittedForApproval: true,
       });
-    case SUBMIT_FOR_APPROVAL_TYPES.failure:
+    case SUBMIT_FOR_APPROVAL.failure:
       return Object.assign({}, state, {
         submittedForApproval: false,
         error: action.error,

--- a/src/scenes/MyMove/getWorkflowRoutes.jsx
+++ b/src/scenes/MyMove/getWorkflowRoutes.jsx
@@ -169,17 +169,19 @@ const pages = {
   '/orders/transition': {
     isInFlow: always,
     isComplete: always,
-    render: (key, pages, description, props) => ({ match }) => (
-      <WizardPage
-        handleSubmit={no_op}
-        isAsync={false}
-        pageList={pages}
-        pageKey={key}
-        additionalParams={{ moveId: props.moveId }}
-      >
-        <TransitionToMove />
-      </WizardPage>
-    ),
+    render: (key, pages, description, props) => ({ match }) => {
+      return (
+        <WizardPage
+          handleSubmit={no_op}
+          isAsync={false}
+          pageList={pages}
+          pageKey={key}
+          additionalParams={{ moveId: props.moveId }}
+        >
+          <TransitionToMove />
+        </WizardPage>
+      );
+    },
   },
   '/moves/:moveId': {
     isInFlow: always,

--- a/src/scenes/Orders/Orders.jsx
+++ b/src/scenes/Orders/Orders.jsx
@@ -34,11 +34,7 @@ export class Orders extends Component {
       if (this.props.currentOrders) {
         this.props.updateOrders(this.props.currentOrders.id, pendingValues);
       } else {
-        this.props
-          .createOrders(pendingValues)
-          .then(dispatchedAction =>
-            this.props.createMove(dispatchedAction.payload.id),
-          );
+        this.props.createOrders(pendingValues);
       }
     }
   };

--- a/src/scenes/Orders/UploadOrders.jsx
+++ b/src/scenes/Orders/UploadOrders.jsx
@@ -28,15 +28,22 @@ export class UploadOrders extends Component {
     this.setShowAmendedOrders = this.setShowAmendedOrders.bind(this);
   }
 
+  componentDidMount() {
+    // If we have a logged in user at mount time, do our loading then.
+    if (this.props.currentServiceMember) {
+      const serviceMemberID = this.props.currentServiceMember.id;
+      this.props.showCurrentOrders(serviceMemberID);
+    }
+  }
+
   componentDidUpdate(prevProps, prevState) {
     // If we don't have a service member yet, fetch one when loggedInUser loads.
     if (
-      !prevProps.user.loggedInUser &&
-      this.props.user.loggedInUser &&
-      !this.props.currentServiceMember
+      !prevProps.currentServiceMember &&
+      this.props.currentServiceMember &&
+      !this.props.currentOrders
     ) {
-      const serviceMemberID = this.props.user.loggedInUser.service_member.id;
-      this.props.loadServiceMember(serviceMemberID);
+      const serviceMemberID = this.props.currentServiceMember.id;
       this.props.showCurrentOrders(serviceMemberID);
     }
   }
@@ -170,6 +177,10 @@ function mapDispatchToProps(dispatch) {
 }
 function mapStateToProps(state) {
   const props = {
+    currentServiceMember: get(
+      state,
+      'loggedInUser.loggedInUser.service_member',
+    ),
     currentOrders: state.orders.currentOrders,
     uploads: get(state, 'orders.currentOrders.uploaded_orders.uploads', []),
     user: state.loggedInUser,

--- a/src/scenes/Orders/ducks.js
+++ b/src/scenes/Orders/ducks.js
@@ -6,6 +6,7 @@ import {
   ShowCurrentOrdersAPI,
 } from './api.js';
 import { DeleteUpload } from 'shared/api.js';
+import { createOrUpdateMoveType } from 'scenes/Moves/ducks';
 import { getEntitlements } from 'shared/entitlements.js';
 import * as ReduxHelpers from 'shared/ReduxHelpers';
 
@@ -39,10 +40,25 @@ export const showCurrentOrders = ReduxHelpers.generateAsyncActionCreator(
   ShowCurrentOrdersAPI,
 );
 
-export const createOrders = ReduxHelpers.generateAsyncActionCreator(
-  createOrUpdateOrdersType,
-  CreateOrders,
-);
+export function createOrders(ordersPayload) {
+  return function(dispatch, getState) {
+    const action = ReduxHelpers.generateAsyncActions(createOrUpdateOrdersType);
+    const moveAction = ReduxHelpers.generateAsyncActions(
+      createOrUpdateMoveType,
+    );
+    const state = getState();
+    const currentOrders = state.orders.currentOrders;
+    if (!currentOrders) {
+      return CreateOrders(ordersPayload)
+        .then(item => {
+          const newMove = get(item, 'moves.0', null);
+          dispatch(action.success(item));
+          dispatch(moveAction.success(newMove));
+        })
+        .catch(error => dispatch(action.error(error)));
+    }
+  };
+}
 
 export const updateOrders = ReduxHelpers.generateAsyncActionCreator(
   createOrUpdateOrdersType,

--- a/src/scenes/ServiceMembers/ducks.js
+++ b/src/scenes/ServiceMembers/ducks.js
@@ -7,6 +7,7 @@ import {
   CreateBackupContactAPI,
   UpdateBackupContactAPI,
 } from './api.js';
+import { GET_LOGGED_IN_USER } from 'shared/User/ducks';
 import * as ReduxHelpers from 'shared/ReduxHelpers';
 
 // Types
@@ -109,6 +110,11 @@ const initialState = {
 };
 export function serviceMemberReducer(state = initialState, action) {
   switch (action.type) {
+    case GET_LOGGED_IN_USER.success:
+      return Object.assign({}, state, {
+        currentServiceMember: action.payload.service_member,
+        isLoading: false,
+      });
     case CREATE_SERVICE_MEMBER.start:
       return Object.assign({}, state, {
         isLoading: true,


### PR DESCRIPTION
## Description

The transition from orders -> moves was breaking if you were editing existing orders because move creation only happened on order creation. I moved move creation into the order creation handler, and now load moves when the showOrders API is hit. Also takes care of syncing move redux state when showOrders is called

## Code Review Verification Steps

* [ ] All tests pass.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/blob/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* [ ] Any migrations/schema changes also update the diagram in docs/schema/dp3.sqs
* [ ] There are no aXe warnings for UI.
* [ ] This works in IE.
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @willowbl00
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Request review from a member of a different team.
* [ ] (TRIAL) Have the Pivotal acceptance criteria been met for this change?