### PR TITLE
Integrate aws-vault in mymove repo

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -114,7 +114,7 @@ require HERE_MAPS_APP_ID "See https://docs.google.com/document/d/16ZomLuR6BPEIK4
 require HERE_MAPS_APP_CODE "See https://docs.google.com/document/d/16ZomLuR6BPEIK4enfMcqu31oiJYZWNDe9Znyf9e88dg"
 
 # Transcom ppp-infra repo path
-require TRANSCOM_PPP_PATH "Set to your local checkout of https://github.com/transcom/ppp-infra (e.g., ~/git/ppp-infra)."
+require PPP_INFRA_PATH "Set to your local checkout of https://github.com/transcom/ppp-infra (e.g., ~/git/ppp-infra)."
 
 ##############################################
 # Load Local Overrides and Check Environment #
@@ -130,9 +130,9 @@ fi
 
 # Source the ppp-infra repo .envrc to get aws-vault wrapper
 # configuration setup.
-if [ -e "$TRANSCOM_PPP_PATH"/transcom-ppp/.envrc ]
+if [ -e "$PPP_INFRA_PATH"/transcom-ppp/.envrc ]
 then
-    source_env "$TRANSCOM_PPP_PATH"/transcom-ppp/.envrc
+    source_env "$PPP_INFRA_PATH"/transcom-ppp/.envrc
 fi
 
 # Check that all required environment variables are set

--- a/.envrc
+++ b/.envrc
@@ -94,8 +94,8 @@ export NO_SESSION_TIMEOUT=true
 #
 #   export STORAGE_BACKEND=filesystem
 #
-# Your AWS credentials should be setup in the transcom-ppp profile. They will be
-# detected and used by the app automatically.
+# Your AWS credentials should be setup in the transcom-ppp profile using
+# aws-vault. They will be detected and used by the app automatically.
 export AWS_S3_BUCKET_NAME="transcom-ppp-app-devlocal-us-west-2"
 export AWS_S3_REGION="us-west-2"
 export AWS_PROFILE=transcom-ppp
@@ -113,6 +113,9 @@ export HERE_MAPS_ROUTING_ENDPOINT="https://route.cit.api.here.com/routing/7.2/ca
 require HERE_MAPS_APP_ID "See https://docs.google.com/document/d/16ZomLuR6BPEIK4enfMcqu31oiJYZWNDe9Znyf9e88dg"
 require HERE_MAPS_APP_CODE "See https://docs.google.com/document/d/16ZomLuR6BPEIK4enfMcqu31oiJYZWNDe9Znyf9e88dg"
 
+# Transcom ppp-infra repo path
+require TRANSCOM_PPP_PATH "Set to your local checkout of https://github.com/transcom/ppp-infra (e.g., ~/git/ppp-infra)."
+
 ##############################################
 # Load Local Overrides and Check Environment #
 ##############################################
@@ -123,6 +126,13 @@ require HERE_MAPS_APP_CODE "See https://docs.google.com/document/d/16ZomLuR6BPEI
 if [ -e .envrc.local ]
 then
   source_env .envrc.local
+fi
+
+# Source the ppp-infra repo .envrc to get aws-vault wrapper
+# configuration setup.
+if [ -e "$TRANSCOM_PPP_PATH"/transcom-ppp/.envrc ]
+then
+    source_env "$TRANSCOM_PPP_PATH"/transcom-ppp/.envrc
 fi
 
 # Check that all required environment variables are set

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,12 @@ NAME = ppp
 DB_DOCKER_CONTAINER = db-dev
 export PGPASSWORD=mysecretpassword
 
+# if S3 access is enabled, wrap webserver in aws-vault command
+# to pass temporary AWS credentials to the binary.
+ifeq ($(STORAGE_BACKEND),s3)
+  AWS_VAULT:=aws-vault exec $(AWS_PROFILE) --
+endif
+
 # This target ensures that the pre-commit hook is installed and kept up to date
 # if pre-commit updates.
 ensure_pre_commit: .git/hooks/pre-commit
@@ -68,11 +74,11 @@ server_build: server_deps server_generate
 	go build -i -o bin/webserver ./cmd/webserver
 # This command is for running the server by itself, it will serve the compiled frontend on its own
 server_run_standalone: client_build server_build db_dev_run
-	DEBUG_LOGGING=true ./bin/webserver
+	DEBUG_LOGGING=true $(AWS_VAULT) ./bin/webserver
 # This command runs the server behind gin, a hot-reload server
 server_run: server_deps server_generate db_dev_run
 	INTERFACE=localhost DEBUG_LOGGING=true \
-	./bin/gin --build ./cmd/webserver \
+	$(AWS_VAULT) ./bin/gin --build ./cmd/webserver \
 		--bin /bin/webserver \
 		--port 8080 --appPort 8081 \
 		--excludeDir vendor --excludeDir node_modules \

--- a/bin/prereqs
+++ b/bin/prereqs
@@ -32,6 +32,7 @@ fi
 # not on CircleCI
 if [[ -z ${CIRCLECI-} ]]; then
     has direnv "brew install direnv"
+    has aws-vault "brew install aws-vault"
 fi
 
 has node "test"

--- a/bin/prereqs
+++ b/bin/prereqs
@@ -32,7 +32,7 @@ fi
 # not on CircleCI
 if [[ -z ${CIRCLECI-} ]]; then
     has direnv "brew install direnv"
-    has aws-vault "brew install aws-vault"
+    has aws-vault "brew cask install aws-vault"
 fi
 
 has node "test"


### PR DESCRIPTION
## Description
Jeremy and I have been testing a more restrictive model for accessing AWS services over the last 2 weeks. At this point it's stable enough to enforce for everyone else. There are two main changes.
1) IAM users initially only have access to manage their own credentials(e.g, change password, access keys and MFA virtual device). To get access to the rest of the API services you must assume a role. 
2) Requiring short term AWS access keys and MFA session token on all AWS API calls.  

We've been testing [aws-vault](https://github.com/99designs/aws-vault) to both assume the necessary role and generate a short term session required. The documentation for setting all of this up is in the [ppp-infra setup docs](https://github.com/transcom/ppp-infra/blob/master/transcom-ppp/README.md#setup).

This PR will integrate `aws-vault` into this repo. By setting `TRANSCOM_PPP_PATH` in the `.evrc.local`, calls to the `aws` cli, `terraform`, and `chamber` will all automatically get wrapped in `aws-vault`. I've also updated the Makefile to conditionally wrap the webserver with `aws-vault` if you are using the S3 as a storage backend.  

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/157413264) for this change
* [ppp-infra setup docs](https://github.com/transcom/ppp-infra/blob/master/transcom-ppp/README.md#setup).
