### PR TITLE
Initializes ppm client state on loggedInUser fetch

### DIFF
--- a/src/scenes/Moves/Ppm/DateAndLocation.jsx
+++ b/src/scenes/Moves/Ppm/DateAndLocation.jsx
@@ -5,7 +5,7 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { getFormValues } from 'redux-form';
 import YesNoBoolean from 'shared/Inputs/YesNoBoolean';
-import { loadPpm, createOrUpdatePpm } from './ducks';
+import { createOrUpdatePpm } from './ducks';
 import { reduxifyWizardForm } from 'shared/WizardPage/Form';
 import { SwaggerField } from 'shared/JsonSchemaForm/JsonSchemaField';
 
@@ -17,10 +17,6 @@ const DateAndLocationWizardForm = reduxifyWizardForm(formName);
 export class DateAndLocation extends Component {
   componentDidMount() {
     document.title = 'Transcom PPP: Date & Locations';
-    const moveId = this.props.match.params.moveId;
-    if (!this.props.currentPpm) {
-      this.props.loadPpm(moveId);
-    }
   }
   handleSubmit = () => {
     const pendingValues = Object.assign({}, this.props.formValues);
@@ -120,7 +116,6 @@ export class DateAndLocation extends Component {
 
 DateAndLocation.propTypes = {
   schema: PropTypes.object.isRequired,
-  loadPpm: PropTypes.func.isRequired,
   createOrUpdatePpm: PropTypes.func.isRequired,
   error: PropTypes.object,
   hasSubmitSuccess: PropTypes.bool.isRequired,
@@ -155,7 +150,7 @@ function mapStateToProps(state) {
   return props;
 }
 function mapDispatchToProps(dispatch) {
-  return bindActionCreators({ loadPpm, createOrUpdatePpm }, dispatch);
+  return bindActionCreators({ createOrUpdatePpm }, dispatch);
 }
 
 export default connect(mapStateToProps, mapDispatchToProps)(DateAndLocation);

--- a/src/scenes/Moves/Ppm/PPMSizeWizard.jsx
+++ b/src/scenes/Moves/Ppm/PPMSizeWizard.jsx
@@ -2,16 +2,11 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import PropTypes from 'prop-types';
-import { createOrUpdatePpm, loadPpm } from './ducks';
+import { createOrUpdatePpm } from './ducks';
 import WizardPage from 'shared/WizardPage';
 import PpmSize from './Size';
 
 export class PpmSizeWizardPage extends Component {
-  componentDidMount() {
-    if (!this.props.currentPpm) {
-      this.props.loadPpm(this.props.match.params.moveId);
-    }
-  }
   handleSubmit = () => {
     const { pendingPpmSize, createOrUpdatePpm } = this.props;
     //todo: we should make sure this move matches the redux state
@@ -56,7 +51,7 @@ PpmSizeWizardPage.propTypes = {
 };
 
 function mapDispatchToProps(dispatch) {
-  return bindActionCreators({ createOrUpdatePpm, loadPpm }, dispatch);
+  return bindActionCreators({ createOrUpdatePpm }, dispatch);
 }
 function mapStateToProps(state) {
   return { ...state.ppm, move: state.submittedMoves };

--- a/src/scenes/Moves/Ppm/Weight.jsx
+++ b/src/scenes/Moves/Ppm/Weight.jsx
@@ -11,7 +11,6 @@ import Alert from 'shared/Alert';
 import LoadingPlaceholder from 'shared/LoadingPlaceholder';
 import {
   setPendingPpmWeight,
-  loadPpm,
   getPpmWeightEstimate,
   createOrUpdatePpm,
 } from './ducks';
@@ -47,13 +46,6 @@ export class PpmWeight extends Component {
     }
   }
   componentDidUpdate(prevProps, prevState) {
-    if (
-      !prevProps.loggedInUser.hasSucceeded &&
-      this.props.loggedInUser.hasSucceeded
-    ) {
-      this.props.loadPpm(this.props.match.params.moveId);
-    }
-
     if (
       !prevProps.hasLoadSuccess &&
       this.props.hasLoadSuccess &&
@@ -232,7 +224,7 @@ function mapStateToProps(state) {
 
 function mapDispatchToProps(dispatch) {
   return bindActionCreators(
-    { setPendingPpmWeight, loadPpm, getPpmWeightEstimate, createOrUpdatePpm },
+    { setPendingPpmWeight, getPpmWeightEstimate, createOrUpdatePpm },
     dispatch,
   );
 }

--- a/src/scenes/Moves/Ppm/ducks.js
+++ b/src/scenes/Moves/Ppm/ducks.js
@@ -1,6 +1,7 @@
 import { get, find } from 'lodash';
 import { CreatePpm, UpdatePpm, GetPpm, GetPpmWeightEstimate } from './api.js';
 import * as ReduxHelpers from 'shared/ReduxHelpers';
+import { GET_LOGGED_IN_USER } from 'shared/User/ducks';
 
 // Types
 export const SET_PENDING_PPM_SIZE = 'SET_PENDING_PPM_SIZE';
@@ -104,6 +105,22 @@ const initialState = {
 };
 export function ppmReducer(state = initialState, action) {
   switch (action.type) {
+    case GET_LOGGED_IN_USER.success:
+      // Initilize state when we get the logged in user
+      const user = action.payload;
+      const currentPpm = get(
+        user,
+        'service_member.orders.0.moves.0.personally_procured_moves.0',
+        null,
+      );
+      return Object.assign({}, state, {
+        currentPpm: currentPpm,
+        pendingPpmSize: get(currentPpm, 'size', null),
+        pendingPpmWeight: get(currentPpm, 'weight_estimate', null),
+        incentive: get(currentPpm, 'estimated_incentive', null),
+        hasLoadSuccess: true,
+        hasLoadError: false,
+      });
     case SET_PENDING_PPM_SIZE:
       return Object.assign({}, state, {
         pendingPpmSize: action.payload,

--- a/src/scenes/Review/Review.jsx
+++ b/src/scenes/Review/Review.jsx
@@ -5,7 +5,6 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import PropTypes from 'prop-types';
 
-import { loadPpm } from 'scenes/Moves/Ppm/ducks';
 import { no_op } from 'shared/utils';
 import WizardPage from 'shared/WizardPage';
 
@@ -16,9 +15,6 @@ import './Review.css';
 
 export class Review extends Component {
   componentWillMount() {
-    if (!this.props.currentPpm) {
-      this.props.loadPpm(this.props.match.params.moveId);
-    }
     const service_member = get(this.props.loggedInUser, 'service_member');
     if (
       service_member &&
@@ -351,7 +347,7 @@ Review.propTypes = {
 };
 
 function mapDispatchToProps(dispatch) {
-  return bindActionCreators({ loadPpm, indexBackupContacts }, dispatch);
+  return bindActionCreators({ indexBackupContacts }, dispatch);
 }
 
 function mapStateToProps(state) {


### PR DESCRIPTION
## Description

If a user tried to resume the move flow and landed on the weight screen, UI would break because that component wasn't initializing PPM state properly. With this the PPM reducer will listen for `loggedInUser` being loaded and extract PPM info if it exists.

## Code Review Verification Steps

* [ ] All tests pass.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/blob/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* [ ] Any migrations/schema changes also update the diagram in docs/schema/dp3.sqs
* [ ] There are no aXe warnings for UI.
* [ ] This works in IE.
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @willowbl00
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Request review from a member of a different team.
* [ ] (TRIAL) Have the Pivotal acceptance criteria been met for this change?