### PR TITLE
Duty station pointer workaround, fixes service member redux state [delivers #157709882]

### DIFF
--- a/pkg/handlers/service_members.go
+++ b/pkg/handlers/service_members.go
@@ -14,9 +14,7 @@ import (
 func payloadForServiceMemberModel(storage FileStorer, serviceMember models.ServiceMember) *internalmessages.ServiceMemberPayload {
 
 	var dutyStationPayload *internalmessages.DutyStationPayload
-	if serviceMember.DutyStation != nil {
-		dutyStationPayload = payloadForDutyStationModel(*serviceMember.DutyStation)
-	}
+	dutyStationPayload = payloadForDutyStationModel(serviceMember.DutyStation)
 	orders := make([]*internalmessages.Orders, len(serviceMember.Orders))
 	for i, order := range serviceMember.Orders {
 		orderPayload, _ := payloadForOrdersModel(storage, order)
@@ -83,7 +81,7 @@ func (h CreateServiceMemberHandler) Handle(params servicememberop.CreateServiceM
 	}
 
 	var stationID *uuid.UUID
-	var station *models.DutyStation
+	var station models.DutyStation
 	if params.CreateServiceMemberPayload.CurrentStationID != nil {
 		id, err := uuid.FromString(params.CreateServiceMemberPayload.CurrentStationID.String())
 		if err != nil {
@@ -94,7 +92,7 @@ func (h CreateServiceMemberHandler) Handle(params servicememberop.CreateServiceM
 			return responseForError(h.logger, err)
 		}
 		stationID = &id
-		station = &s
+		station = s
 	}
 
 	// User should always be populated by middleware
@@ -236,7 +234,7 @@ func (h PatchServiceMemberHandler) patchServiceMemberWithPayload(serviceMember *
 		if err != nil {
 			return validate.NewErrors(), err
 		}
-		serviceMember.DutyStation = &station
+		serviceMember.DutyStation = station
 		serviceMember.DutyStationID = &stationID
 	}
 	if payload.SocialSecurityNumber != nil {

--- a/pkg/models/service_member.go
+++ b/pkg/models/service_member.go
@@ -42,7 +42,7 @@ type ServiceMember struct {
 	Orders                 Orders                              `has_many:"orders" order_by:"created_at desc"`
 	BackupContacts         *BackupContacts                     `has_many:"backup_contacts"`
 	DutyStationID          *uuid.UUID                          `json:"duty_station_id" db:"duty_station_id"`
-	DutyStation            *DutyStation                        `belongs_to:"duty_stations"`
+	DutyStation            DutyStation                         `belongs_to:"duty_stations"`
 }
 
 // ServiceMembers is not required by pop and may be deleted
@@ -94,13 +94,6 @@ func FetchServiceMember(db *pop.Connection, session *auth.Session, id uuid.UUID)
 	}
 	if serviceMember.SocialSecurityNumberID == nil {
 		serviceMember.SocialSecurityNumber = nil
-	}
-
-	if serviceMember.DutyStationID == nil {
-		serviceMember.DutyStation = nil
-	} else {
-		// Need to do this because Pop's nested eager loading seems to be broken
-		db.Q().Eager().Find(&serviceMember.DutyStation.Address, serviceMember.DutyStation.AddressID)
 	}
 
 	return serviceMember, nil

--- a/pkg/models/user.go
+++ b/pkg/models/user.go
@@ -48,7 +48,7 @@ func (u *User) ValidateUpdate(tx *pop.Connection) (*validate.Errors, error) {
 // GetFullServiceMemberProfile returns a service member profile if one is associated with this user, otherwise returns nil
 func GetFullServiceMemberProfile(db *pop.Connection, session *auth.Session) (*ServiceMember, error) {
 	serviceMembers := ServiceMembers{}
-	err := db.Where("id = $1", session.ServiceMemberID).Eager("DutyStation", "ResidentialAddress", "BackupMailingAddress", "Orders.NewDutyStation.Address", "Orders.UploadedOrders.Uploads", "Orders.Moves.PersonallyProcuredMoves", "BackupContacts", "User").All(&serviceMembers)
+	err := db.Where("id = $1", session.ServiceMemberID).Eager("DutyStation.Address", "ResidentialAddress", "BackupMailingAddress", "Orders.NewDutyStation.Address", "Orders.UploadedOrders.Uploads", "Orders.Moves.PersonallyProcuredMoves", "BackupContacts", "User").All(&serviceMembers)
 	if err != nil {
 		return nil, err
 	}

--- a/src/scenes/MyMove/getWorkflowRoutes.jsx
+++ b/src/scenes/MyMove/getWorkflowRoutes.jsx
@@ -5,7 +5,7 @@ import PrivateRoute from 'shared/User/PrivateRoute';
 import WizardPage from 'shared/WizardPage';
 import generatePath from 'shared/WizardPage/generatePath';
 import { no_op } from 'shared/utils';
-
+import { NULL_UUID } from 'shared/constants';
 import DodInfo from 'scenes/ServiceMembers/DodInfo';
 import SMName from 'scenes/ServiceMembers/Name';
 import ContactInfo from 'scenes/ServiceMembers/ContactInfo';
@@ -100,7 +100,9 @@ const pages = {
   },
   '/service-member/:serviceMemberId/duty-station': {
     isInFlow: always,
-    isComplete: sm => sm.is_profile_complete || Boolean(sm.current_station),
+    isComplete: sm =>
+      sm.is_profile_complete ||
+      get(sm, 'current_station.id', NULL_UUID) !== NULL_UUID,
     render: (key, pages) => ({ match }) => (
       <DutyStation pages={pages} pageKey={key} match={match} />
     ),

--- a/src/scenes/MyMove/getWorkflowRoutes.jsx
+++ b/src/scenes/MyMove/getWorkflowRoutes.jsx
@@ -100,6 +100,9 @@ const pages = {
   },
   '/service-member/:serviceMemberId/duty-station': {
     isInFlow: always,
+
+    // api for duty station always returns an object, even when duty station is not set
+    // if there is no duty station, that object will have a null uuid
     isComplete: sm =>
       sm.is_profile_complete ||
       get(sm, 'current_station.id', NULL_UUID) !== NULL_UUID,
@@ -152,7 +155,7 @@ const pages = {
         orders.orders_type,
         orders.issue_date,
         orders.report_by_date,
-        orders.new_duty_station,
+        get(orders, 'new_duty_station.id', NULL_UUID) !== NULL_UUID,
       ]);
     },
     render: (key, pages) => ({ match }) => (

--- a/src/scenes/MyMove/getWorkflowRoutes.test.js
+++ b/src/scenes/MyMove/getWorkflowRoutes.test.js
@@ -1,5 +1,5 @@
 import { getPagesInFlow, getNextIncompletePage } from './getWorkflowRoutes';
-
+import { NULL_UUID } from 'shared/constants';
 describe('when getting the routes for the current workflow', () => {
   let profileIsComplete;
   describe('given a complete service member', () => {
@@ -261,6 +261,10 @@ describe('when getting the next incomplete page', () => {
           email_is_preferred: true,
           telephone: '666-666-6666',
           personal_email: 'foo@bar.com',
+          current_station: {
+            id: NULL_UUID,
+            name: '',
+          },
         });
         expect(result).toEqual('/service-member/foo/duty-station');
       });

--- a/src/scenes/MyMove/getWorkflowRoutes.test.js
+++ b/src/scenes/MyMove/getWorkflowRoutes.test.js
@@ -373,7 +373,7 @@ describe('when getting the next incomplete page', () => {
               orders_type: 'foo',
               issue_date: '2019-01-01',
               report_by_date: '2019-02-01',
-              new_duty_station: {},
+              new_duty_station: { id: 'something' },
             },
           ],
         });
@@ -390,7 +390,7 @@ describe('when getting the next incomplete page', () => {
               orders_type: 'foo',
               issue_date: '2019-01-01',
               report_by_date: '2019-02-01',
-              new_duty_station: {},
+              new_duty_station: { id: 'something' },
               uploaded_orders: {
                 uploads: [{}],
               },
@@ -411,7 +411,7 @@ describe('when getting the next incomplete page', () => {
               orders_type: 'foo',
               issue_date: '2019-01-01',
               report_by_date: '2019-02-01',
-              new_duty_station: {},
+              new_duty_station: { id: 'something' },
               uploaded_orders: {
                 uploads: [{}],
               },
@@ -438,7 +438,7 @@ describe('when getting the next incomplete page', () => {
               orders_type: 'foo',
               issue_date: '2019-01-01',
               report_by_date: '2019-02-01',
-              new_duty_station: {},
+              new_duty_station: { id: 'something' },
               uploaded_orders: {
                 uploads: [{}],
               },
@@ -472,7 +472,7 @@ describe('when getting the next incomplete page', () => {
               orders_type: 'foo',
               issue_date: '2019-01-01',
               report_by_date: '2019-02-01',
-              new_duty_station: {},
+              new_duty_station: { id: 'something' },
               uploaded_orders: {
                 uploads: [{}],
               },
@@ -507,7 +507,7 @@ describe('when getting the next incomplete page', () => {
               orders_type: 'foo',
               issue_date: '2019-01-01',
               report_by_date: '2019-02-01',
-              new_duty_station: {},
+              new_duty_station: { id: 'something' },
               uploaded_orders: {
                 uploads: [{}],
               },

--- a/src/scenes/ServiceMembers/BackupContact.jsx
+++ b/src/scenes/ServiceMembers/BackupContact.jsx
@@ -6,7 +6,6 @@ import { bindActionCreators } from 'redux';
 
 import {
   updateServiceMember,
-  loadServiceMember,
   indexBackupContacts,
   createBackupContact,
   updateBackupContact,
@@ -243,7 +242,6 @@ function mapDispatchToProps(dispatch) {
   return bindActionCreators(
     {
       updateServiceMember,
-      loadServiceMember,
       indexBackupContacts,
       createBackupContact,
       updateBackupContact,

--- a/src/scenes/ServiceMembers/BackupMailingAddress.jsx
+++ b/src/scenes/ServiceMembers/BackupMailingAddress.jsx
@@ -4,7 +4,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 
-import { updateServiceMember, loadServiceMember } from './ducks';
+import { updateServiceMember } from './ducks';
 
 import { reduxifyWizardForm } from 'shared/WizardPage/Form';
 import { SwaggerField } from 'shared/JsonSchemaForm/JsonSchemaField';
@@ -13,10 +13,6 @@ const formName = 'service_member_backup_mailing_addresss';
 const BackupMailingWizardForm = reduxifyWizardForm(formName);
 
 export class BackupMailingAddress extends Component {
-  componentDidMount() {
-    this.props.loadServiceMember(this.props.match.params.serviceMemberId);
-  }
-
   handleSubmit = () => {
     const newAddress = { backup_mailing_address: this.props.formData.values };
     this.props.updateServiceMember(newAddress);
@@ -79,10 +75,7 @@ BackupMailingAddress.propTypes = {
 };
 
 function mapDispatchToProps(dispatch) {
-  return bindActionCreators(
-    { updateServiceMember, loadServiceMember },
-    dispatch,
-  );
+  return bindActionCreators({ updateServiceMember }, dispatch);
 }
 function mapStateToProps(state) {
   return {

--- a/src/scenes/ServiceMembers/ContactInfo.jsx
+++ b/src/scenes/ServiceMembers/ContactInfo.jsx
@@ -4,7 +4,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 
-import { updateServiceMember, loadServiceMember } from './ducks';
+import { updateServiceMember } from './ducks';
 
 import { reduxifyWizardForm } from 'shared/WizardPage/Form';
 import { SwaggerField } from 'shared/JsonSchemaForm/JsonSchemaField';
@@ -41,10 +41,6 @@ const formName = 'service_member_contact_info';
 const ContactWizardForm = reduxifyWizardForm(formName, validateContactForm);
 
 export class ContactInfo extends Component {
-  componentDidMount() {
-    this.props.loadServiceMember(this.props.match.params.serviceMemberId);
-  }
-
   handleSubmit = () => {
     const pendingValues = this.props.formData.values;
     if (pendingValues) {
@@ -109,10 +105,7 @@ ContactInfo.propTypes = {
 };
 
 function mapDispatchToProps(dispatch) {
-  return bindActionCreators(
-    { updateServiceMember, loadServiceMember },
-    dispatch,
-  );
+  return bindActionCreators({ updateServiceMember }, dispatch);
 }
 function mapStateToProps(state) {
   return {

--- a/src/scenes/ServiceMembers/DodInfo.jsx
+++ b/src/scenes/ServiceMembers/DodInfo.jsx
@@ -7,7 +7,7 @@ import { bindActionCreators } from 'redux';
 import { Field } from 'redux-form';
 import validator from 'shared/JsonSchemaForm/validator';
 
-import { updateServiceMember, loadServiceMember } from './ducks';
+import { updateServiceMember } from './ducks';
 import { reduxifyWizardForm } from 'shared/WizardPage/Form';
 import { SwaggerField } from 'shared/JsonSchemaForm/JsonSchemaField';
 
@@ -112,10 +112,6 @@ const formName = 'service_member_dod_info';
 const DodWizardForm = reduxifyWizardForm(formName, validateDodForm);
 
 export class DodInfo extends Component {
-  componentDidMount() {
-    this.props.loadServiceMember(this.props.match.params.serviceMemberId);
-  }
-
   handleSubmit = () => {
     const pendingValues = this.props.formData.values;
     if (pendingValues) {
@@ -175,10 +171,7 @@ DodInfo.propTypes = {
 };
 
 function mapDispatchToProps(dispatch) {
-  return bindActionCreators(
-    { updateServiceMember, loadServiceMember },
-    dispatch,
-  );
+  return bindActionCreators({ updateServiceMember }, dispatch);
 }
 function mapStateToProps(state) {
   const props = {

--- a/src/scenes/ServiceMembers/DutyStation.jsx
+++ b/src/scenes/ServiceMembers/DutyStation.jsx
@@ -5,7 +5,7 @@ import { bindActionCreators } from 'redux';
 
 import { Field } from 'redux-form';
 
-import { updateServiceMember, loadServiceMember } from './ducks';
+import { updateServiceMember } from './ducks';
 
 import { reduxifyWizardForm } from 'shared/WizardPage/Form';
 
@@ -44,9 +44,6 @@ export class DutyStation extends Component {
   stationOnChange = newStation => {
     this.setState({ value: newStation });
   };
-  componentDidMount() {
-    this.props.loadServiceMember(this.props.match.params.serviceMemberId);
-  }
 
   handleSubmit = (somethings, elses) => {
     const pendingValues = this.props.formData.values;
@@ -94,10 +91,7 @@ DutyStation.propTypes = {
 };
 
 function mapDispatchToProps(dispatch) {
-  return bindActionCreators(
-    { updateServiceMember, loadServiceMember },
-    dispatch,
-  );
+  return bindActionCreators({ updateServiceMember }, dispatch);
 }
 function mapStateToProps(state) {
   const currentServiceMember = state.serviceMember.currentServiceMember;

--- a/src/scenes/ServiceMembers/DutyStation.jsx
+++ b/src/scenes/ServiceMembers/DutyStation.jsx
@@ -4,9 +4,9 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 
 import { Field } from 'redux-form';
-
+import { get } from 'lodash';
 import { updateServiceMember } from './ducks';
-
+import { NULL_UUID } from 'shared/constants';
 import { reduxifyWizardForm } from 'shared/WizardPage/Form';
 
 import DutyStationSearchBox from 'scenes/ServiceMembers/DutyStationSearchBox';
@@ -15,8 +15,9 @@ import './DutyStation.css';
 
 const validateDutyStationForm = (values, form) => {
   let errors = {};
-
-  if (!values.current_station) {
+  // api for duty station always returns an object, even when duty station is not set
+  // if there is no duty station, that object will have a null uuid
+  if (get(values, 'current_station.id', NULL_UUID) === NULL_UUID) {
     const newError = {
       current_station: 'Please select a duty station.',
     };
@@ -62,7 +63,6 @@ export class DutyStation extends Component {
       error,
       existingStation,
     } = this.props;
-    // TODO: make sure isvalid is accurate
 
     let initialValues = null;
     if (existingStation) {

--- a/src/scenes/ServiceMembers/DutyStationSearchBox.jsx
+++ b/src/scenes/ServiceMembers/DutyStationSearchBox.jsx
@@ -91,6 +91,10 @@ export class DutyStationSearchBox extends Component {
   }
   render() {
     const defaultTitle = 'Name of Duty Station:';
+    // api for duty station always returns an object, even when duty station is not set
+    // if there is no duty station, that object will have a null uuid
+    const isEmptyStation =
+      get(this.props, 'input.value.id', NULL_UUID) === NULL_UUID;
     return (
       <Fragment>
         {this.state.error && (
@@ -110,10 +114,10 @@ export class DutyStationSearchBox extends Component {
           onChange={this.localOnChange}
           onInputChange={this.onInputChange}
           components={{ Option: this.renderOption }}
-          value={this.props.input.value}
+          value={isEmptyStation ? null : this.props.input.value}
           placeholder="Start typing a duty station..."
         />
-        {get(this.props, 'input.value.id', NULL_UUID) !== NULL_UUID && (
+        {!isEmptyStation && (
           <p className="location">
             {this.props.input.value.address.city},{' '}
             {this.props.input.value.address.state}{' '}

--- a/src/scenes/ServiceMembers/DutyStationSearchBox.jsx
+++ b/src/scenes/ServiceMembers/DutyStationSearchBox.jsx
@@ -1,11 +1,11 @@
-import { debounce, sortBy } from 'lodash';
+import { debounce, sortBy, get } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { Component, Fragment } from 'react';
 import AsyncSelect from 'react-select/lib/Async';
 import Alert from 'shared/Alert';
 import { components } from 'react-select';
 import Highlighter from 'react-highlight-words';
-
+import { NULL_UUID } from 'shared/constants';
 import { SearchDutyStations } from './api.js';
 
 import './DutyStation.css';
@@ -113,7 +113,7 @@ export class DutyStationSearchBox extends Component {
           value={this.props.input.value}
           placeholder="Start typing a duty station..."
         />
-        {this.props.input.value && (
+        {get(this.props, 'input.value.id', NULL_UUID) !== NULL_UUID && (
           <p className="location">
             {this.props.input.value.address.city},{' '}
             {this.props.input.value.address.state}{' '}

--- a/src/scenes/ServiceMembers/Name.jsx
+++ b/src/scenes/ServiceMembers/Name.jsx
@@ -4,7 +4,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 
-import { updateServiceMember, loadServiceMember } from './ducks';
+import { updateServiceMember } from './ducks';
 import { reduxifyWizardForm } from 'shared/WizardPage/Form';
 import { SwaggerField } from 'shared/JsonSchemaForm/JsonSchemaField';
 
@@ -13,10 +13,6 @@ const formName = 'service_member_name';
 const NameWizardForm = reduxifyWizardForm(formName);
 
 export class Name extends Component {
-  componentDidMount() {
-    this.props.loadServiceMember(this.props.match.params.serviceMemberId);
-  }
-
   handleSubmit = () => {
     const pendingValues = this.props.formData.values;
     if (pendingValues) {
@@ -75,10 +71,7 @@ Name.propTypes = {
 };
 
 function mapDispatchToProps(dispatch) {
-  return bindActionCreators(
-    { updateServiceMember, loadServiceMember },
-    dispatch,
-  );
+  return bindActionCreators({ updateServiceMember }, dispatch);
 }
 function mapStateToProps(state) {
   return {

--- a/src/scenes/ServiceMembers/ResidentialAddress.jsx
+++ b/src/scenes/ServiceMembers/ResidentialAddress.jsx
@@ -4,7 +4,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 
-import { updateServiceMember, loadServiceMember } from './ducks';
+import { updateServiceMember } from './ducks';
 import { reduxifyWizardForm } from 'shared/WizardPage/Form';
 import { SwaggerField } from 'shared/JsonSchemaForm/JsonSchemaField';
 
@@ -12,10 +12,6 @@ const formName = 'service_member_residential_address';
 const ResidentalWizardForm = reduxifyWizardForm(formName);
 
 export class ResidentialAddress extends Component {
-  componentDidMount() {
-    this.props.loadServiceMember(this.props.match.params.serviceMemberId);
-  }
-
   handleSubmit = () => {
     const newAddress = { residential_address: this.props.formData.values };
     this.props.updateServiceMember(newAddress);
@@ -73,10 +69,7 @@ ResidentialAddress.propTypes = {
 };
 
 function mapDispatchToProps(dispatch) {
-  return bindActionCreators(
-    { updateServiceMember, loadServiceMember },
-    dispatch,
-  );
+  return bindActionCreators({ updateServiceMember }, dispatch);
 }
 function mapStateToProps(state) {
   return {

--- a/src/shared/User/ducks.js
+++ b/src/shared/User/ducks.js
@@ -81,8 +81,8 @@ function getUserInfo() {
   if (!cookie) return loggedOutUser;
   const jwt = decode(cookie);
   return {
-    email: jwt.email,
-    userId: jwt.user_id,
+    email: jwt.SessionValue.Email,
+    userId: jwt.SessionValue.UserID,
     isLoggedIn: true,
   };
 }

--- a/src/shared/constants.js
+++ b/src/shared/constants.js
@@ -1,3 +1,6 @@
 /* This matches the width at which submit buttons go full-width for mobile devices */
 export const mobileSize = 481;
 export const isProduction = process.env.NODE_ENV === 'production';
+export const isDevelopment = process.env.NODE_ENV === 'development';
+export const isTest = process.env.NODE_ENV === 'test';
+export const NULL_UUID = '00000000-0000-0000-0000-000000000000';

--- a/src/shared/store.js
+++ b/src/shared/store.js
@@ -6,14 +6,14 @@ import thunk from 'redux-thunk';
 
 import { composeWithDevTools } from 'redux-devtools-extension/logOnlyInProduction';
 
-import { isProduction } from 'shared/constants';
+import { isDevelopment } from 'shared/constants';
 import logger from './reduxLogger';
 
 export const history = createHistory();
 
 const middlewares = [thunk, routerMiddleware(history)];
 
-if (!isProduction && !window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__) {
+if (isDevelopment && !window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__) {
   middlewares.push(logger);
 }
 


### PR DESCRIPTION
## Description

There hasn't been much movement on my [Pop PR](https://github.com/gobuffalo/pop/pull/106), so this implements the workaround: don't use a pointer for `ServiceMember.DutyStation`. It's a non-db field anyway, so instead of being `nil` it will just be an empty struct. We don't seem to nil-check that field anyway.

In the effort of also fixing the duty station bug, I also fixed `service_member` redux state so that it pulls from `loggedInUser` when loaded.

Also we weren't reading the user info correctly from the new session cookie so I fixed that too.

## Code Review Verification Steps

* [ ] All tests pass.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/blob/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* [ ] Any migrations/schema changes also update the diagram in docs/schema/dp3.sqs
* [ ] There are no aXe warnings for UI.
* [ ] This works in IE.
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @willowbl00
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Request review from a member of a different team.
* [ ] (TRIAL) Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/157709882) for this change
