### PR TITLE
PPM estimates tab content, part one

### DIFF
--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -49,7 +49,7 @@ const BasicsTabContent = props => {
 const PPMTabContent = props => {
   return (
     <React.Fragment>
-      <PPMEstimatesPanel />
+      <PPMEstimatesPanel title="Estimate" />
       <PaymentsPanel title="Payments" moveId={props.match.params.moveId} />
     </React.Fragment>
   );

--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -16,6 +16,7 @@ import BackupInfoPanel from './BackupInfoPanel';
 import CustomerInfoPanel from './CustomerInfoPanel';
 import OrdersPanel from './OrdersPanel';
 import PaymentsPanel from './PaymentsPanel';
+import PPMEstimatesPanel from './PPMEstimatesPanel';
 import { loadMoveDependencies, approveBasics, approvePPM } from './ducks.js';
 import { formatDate } from './helpers';
 
@@ -48,6 +49,7 @@ const BasicsTabContent = props => {
 const PPMTabContent = props => {
   return (
     <React.Fragment>
+      <PPMEstimatesPanel />
       <PaymentsPanel title="Payments" moveId={props.match.params.moveId} />
     </React.Fragment>
   );

--- a/src/scenes/Office/PPMEstimatesPanel.jsx
+++ b/src/scenes/Office/PPMEstimatesPanel.jsx
@@ -1,4 +1,4 @@
-import { get, compact } from 'lodash';
+import { get } from 'lodash';
 import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
@@ -6,7 +6,6 @@ import { reduxForm } from 'redux-form';
 import editablePanel from './editablePanel';
 
 import { no_op_action } from 'shared/utils';
-import { formatDate } from './helpers';
 
 import { PanelSwaggerField, PanelField } from 'shared/EditablePanel';
 

--- a/src/scenes/Office/PPMEstimatesPanel.jsx
+++ b/src/scenes/Office/PPMEstimatesPanel.jsx
@@ -11,7 +11,59 @@ import { formatDate } from './helpers';
 import { PanelSwaggerField, PanelField } from 'shared/EditablePanel';
 
 const EstimatesDisplay = props => {
-  return <React.Fragment>This is where the viewing happens!</React.Fragment>;
+  const fieldProps = {
+    schema: props.PPMEstimateSchema,
+    values: props.PPMEstimate,
+  };
+
+  return (
+    <React.Fragment>
+      <div className="editable-panel-column">
+        <PanelSwaggerField fieldName="estimated_incentive" {...fieldProps} />
+        <PanelSwaggerField fieldName="weight_estimate" {...fieldProps} />
+        <PanelSwaggerField
+          title="Planned departure"
+          fieldName="planned_move_date"
+          {...fieldProps}
+        />
+        <PanelField title="Storage planned" fieldName="days_in_storage">
+          {fieldProps.values.has_sit ? 'Yes' : 'No'}
+        </PanelField>
+        <PanelSwaggerField
+          title="Storage days"
+          fieldName="days_in_storage"
+          {...fieldProps}
+        />
+        <PanelField
+          title="Max. storage cost"
+          value="Max. storage cost"
+          className="Todo"
+        />
+      </div>
+      <div className="editable-panel-column">
+        <PanelSwaggerField
+          title="Origin zip code"
+          fieldName="pickup_postal_code"
+          {...fieldProps}
+        />
+        <PanelSwaggerField
+          title="Additional stop zip code"
+          fieldName="additional_pickup_postal_code"
+          {...fieldProps}
+        />
+        <PanelSwaggerField
+          title="Destination zip code"
+          fieldName="destination_postal_code"
+          {...fieldProps}
+        />
+        <PanelField
+          title="Distance estimate"
+          value="863 miles"
+          className="Todo"
+        />
+      </div>
+    </React.Fragment>
+  );
 };
 
 const EstimatesEdit = props => {

--- a/src/scenes/Office/PPMEstimatesPanel.jsx
+++ b/src/scenes/Office/PPMEstimatesPanel.jsx
@@ -1,0 +1,54 @@
+import { get, compact } from 'lodash';
+import React from 'react';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import { reduxForm } from 'redux-form';
+import editablePanel from './editablePanel';
+
+import { no_op_action } from 'shared/utils';
+import { formatDate } from './helpers';
+
+import { PanelSwaggerField, PanelField } from 'shared/EditablePanel';
+
+const EstimatesDisplay = props => {
+  return <React.Fragment>This is where the viewing happens!</React.Fragment>;
+};
+
+const EstimatesEdit = props => {
+  // const { schema } = props;
+  return <React.Fragment>This is where the editing happens!</React.Fragment>;
+};
+
+const formName = 'ppm_estimate_and_details';
+
+let PPMEstimatesPanel = editablePanel(EstimatesDisplay, EstimatesEdit);
+PPMEstimatesPanel = reduxForm({ form: formName })(PPMEstimatesPanel);
+
+function mapStateToProps(state) {
+  return {
+    // reduxForm
+    formData: state.form[formName],
+    initialValues: {},
+
+    // Wrapper
+    PPMEstimateSchema: get(
+      state,
+      'swagger.spec.definitions.PersonallyProcuredMovePayload',
+    ),
+    hasError: false,
+    errorMessage: state.office.error,
+    PPMEstimate: state.office.officePPMs[0], // unsure about this
+    isUpdating: false,
+  };
+}
+
+function mapDispatchToProps(dispatch) {
+  return bindActionCreators(
+    {
+      update: no_op_action,
+    },
+    dispatch,
+  );
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(PPMEstimatesPanel);


### PR DESCRIPTION
## Description

This adds view versions of most of the fields, based on stored data. Make a SM record yourself to see them really working.

## Reviewer Notes

Just... does it work. Mostly that. This has a 1 in the branch name because it's the first of a few to complete this task. 

## Code Review Verification Steps

* [ ] All tests pass.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/blob/master/docs/backend.md#logging)
* [ ] There are no aXe warnings for UI.
* [ ] This works in IE.
* [ ] Request review from a member of a different team.
* [ ] (TRIAL) Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/157651179) for this change

## Screenshots

<img width="919" alt="screen shot 2018-05-24 at 3 59 19 pm" src="https://user-images.githubusercontent.com/10379814/40517727-a130dc38-5f6b-11e8-8cab-89e3d218fa48.png">
