### PR TITLE
WIP: Add edit date and location screen 

### DIFF
--- a/src/scenes/Moves/Ppm/ducks.js
+++ b/src/scenes/Moves/Ppm/ducks.js
@@ -92,11 +92,11 @@ export function createOrUpdatePpm(moveId, ppm) {
     const state = getState();
     const currentPpm = state.ppm.currentPpm;
     if (currentPpm) {
-      UpdatePpm(moveId, currentPpm.id, ppm)
+      return UpdatePpm(moveId, currentPpm.id, ppm)
         .then(item => dispatch(action.success(item)))
         .catch(error => dispatch(action.error(error)));
     } else {
-      CreatePpm(moveId, ppm)
+      return CreatePpm(moveId, ppm)
         .then(item => dispatch(action.success(item)))
         .catch(error => dispatch(action.error(error)));
     }

--- a/src/scenes/MyMove/index.jsx
+++ b/src/scenes/MyMove/index.jsx
@@ -15,6 +15,7 @@ import EditProfile from 'scenes/Review/EditProfile';
 import EditBackupContact from 'scenes/Review/EditBackupContact';
 import EditContactInfo from 'scenes/Review/EditContactInfo';
 import EditOrders from 'scenes/Review/EditOrders';
+import EditDateAndLocation from 'scenes/Review/EditDateAndLocation';
 import Header from 'shared/Header/MyMove';
 import { history } from 'shared/store';
 import Footer from 'shared/Footer';
@@ -80,6 +81,10 @@ export class AppWrapper extends Component {
                 <PrivateRoute
                   path="/moves/:moveId/review/edit-orders"
                   component={EditOrders}
+                />
+                <PrivateRoute
+                  path="/moves/:moveId/review/edit-date-and-location"
+                  component={EditDateAndLocation}
                 />
                 <Route component={NoMatch} />
               </Switch>

--- a/src/scenes/Review/EditDateAndLocation.jsx
+++ b/src/scenes/Review/EditDateAndLocation.jsx
@@ -1,0 +1,253 @@
+import { debounce, get, bind, cloneDeep } from 'lodash';
+import { push } from 'react-router-redux';
+import PropTypes from 'prop-types';
+import { getFormValues } from 'redux-form';
+
+import React, { Component, Fragment } from 'react';
+import { reduxForm } from 'redux-form';
+import YesNoBoolean from 'shared/Inputs/YesNoBoolean';
+import { SwaggerField } from 'shared/JsonSchemaForm/JsonSchemaField';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import { createOrUpdatePpm, getPpmSitEstimate } from 'scenes/Moves/Ppm/ducks';
+import { loadEntitlements } from 'scenes/Orders/ducks';
+import './Review.css';
+
+const sitEstimateDebounceTime = 300;
+
+let EditDateAndLocationForm = props => {
+  const {
+    handleSubmit,
+    currentOrders,
+    getDebouncedSitEstimate,
+    schema,
+    valid,
+    sitReimbursement,
+    submitting,
+    onCancel,
+  } = props;
+  return (
+    <form onSubmit={handleSubmit}>
+      <h2> Edit PPM Dates & Locations </h2>
+      <p>
+        Changes could impact your move, including the estimated PPM incentive.
+      </p>
+      <h3> Move Date </h3>
+      <SwaggerField
+        fieldName="planned_move_date"
+        onChange={getDebouncedSitEstimate}
+        swagger={schema}
+        required
+      />
+      <hr className="spacer" />
+      <h3>Pickup Location</h3>
+      <SwaggerField
+        fieldName="pickup_postal_code"
+        onChange={getDebouncedSitEstimate}
+        swagger={schema}
+        required
+      />
+      <SwaggerField
+        fieldName="has_additional_postal_code"
+        swagger={schema}
+        component={YesNoBoolean}
+      />
+      {get(props, 'formValues.has_additional_postal_code', false) && (
+        <Fragment>
+          <SwaggerField
+            fieldName="additional_pickup_postal_code"
+            swagger={schema}
+            required
+          />
+          <span className="grey">
+            Making additional stops may decrease your PPM incentive.
+          </span>
+        </Fragment>
+      )}
+      <hr className="spacer" />
+      <h3>Destination Location</h3>
+      <p>
+        Enter the ZIP for your new home if you know it, or for{' '}
+        {currentOrders && currentOrders.new_duty_station.name} if you don't.
+      </p>
+      <SwaggerField
+        fieldName="destination_postal_code"
+        swagger={schema}
+        onChange={getDebouncedSitEstimate}
+        required
+      />
+      <span className="grey">
+        The ZIP code for {currentOrders && currentOrders.new_duty_station.name}{' '}
+        is {currentOrders && currentOrders.new_duty_station.address.postal_code}{' '}
+      </span>
+      <SwaggerField
+        fieldName="has_sit"
+        swagger={schema}
+        component={YesNoBoolean}
+      />
+      {get(props, 'formValues.has_sit', false) && (
+        <Fragment>
+          <SwaggerField
+            className="days-in-storage"
+            fieldName="days_in_storage"
+            swagger={schema}
+            onChange={getDebouncedSitEstimate}
+            required
+          />{' '}
+          <span className="grey">You can choose up to 90 days.</span>
+          {sitReimbursement && (
+            <div className="storage-estimate">
+              You can spend up to {sitReimbursement} on private storage. Save
+              your receipts to submit with your PPM paperwork.
+            </div>
+          )}
+        </Fragment>
+      )}
+      <button type="submit" disabled={submitting || !valid}>
+        Save
+      </button>
+      <button type="button" disabled={submitting} onClick={onCancel}>
+        Cancel
+      </button>
+    </form>
+  );
+};
+
+const editDateAndLocationFormName = 'edit_date_and_location';
+EditDateAndLocationForm = reduxForm({ form: editDateAndLocationFormName })(
+  EditDateAndLocationForm,
+);
+
+class EditDateAndLocation extends Component {
+  returnToReview = () => {
+    const reviewAddress = `/moves/${this.props.match.params.moveId}/review`;
+    this.props.push(reviewAddress);
+  };
+
+  handleSubmit = () => {
+    const { sitReimbursement } = this.props;
+    const pendingValues = Object.assign({}, this.props.formValues);
+    if (pendingValues) {
+      pendingValues.has_additional_postal_code =
+        pendingValues.has_additional_postal_code || false;
+      pendingValues.has_sit = pendingValues.has_sit || false;
+      if (pendingValues.has_sit) {
+        pendingValues.estimated_storage_reimbursement = sitReimbursement;
+      } else {
+        pendingValues.days_in_storage = null;
+        pendingValues.estimated_storage_reimbursement = null;
+      }
+      const moveId = this.props.match.params.moveId;
+      return this.props.createOrUpdatePpm(moveId, pendingValues).then(() => {
+        // This promise resolves regardless of error.
+        if (!this.props.hasSubmitError) {
+          this.returnToReview();
+        } else {
+          window.scrollTo(0, 0);
+        }
+      });
+    }
+  };
+
+  getSitEstimate = (moveDate, sitDays, pickupZip, destZip, weight) => {
+    if (sitDays <= 90 && pickupZip.length === 5 && destZip.length === 5) {
+      this.props.getPpmSitEstimate(
+        moveDate,
+        sitDays,
+        pickupZip,
+        destZip,
+        weight,
+      );
+    }
+  };
+
+  debouncedSitEstimate = debounce(
+    bind(this.getSitEstimate, this),
+    sitEstimateDebounceTime,
+  );
+
+  getDebouncedSitEstimate = (e, value, _, field) => {
+    const { formValues, entitlement } = this.props;
+    const estimateValues = cloneDeep(formValues);
+    estimateValues[field] = value;
+    this.debouncedSitEstimate(
+      estimateValues.planned_move_date,
+      estimateValues.days_in_storage,
+      estimateValues.pickup_postal_code,
+      estimateValues.destination_postal_code,
+      entitlement.sum,
+    );
+  };
+  render() {
+    const {
+      initialValues,
+      schema,
+      formValues,
+      sitReimbursement,
+      currentOrders,
+    } = this.props;
+    return (
+      <div className="usa-grid">
+        <div className="usa-width-one-whole">
+          <EditDateAndLocationForm
+            onSubmit={this.handleSubmit}
+            getSitEstimate={this.getDebouncedSitEstimate}
+            initialValues={initialValues}
+            schema={schema}
+            formValues={formValues}
+            sitReimbursement={sitReimbursement}
+            currentOrders={currentOrders}
+            onCancel={this.returnToReview}
+          />
+        </div>
+      </div>
+    );
+  }
+}
+
+EditDateAndLocation.propTypes = {
+  schema: PropTypes.object.isRequired,
+  createOrUpdatePpm: PropTypes.func.isRequired,
+  error: PropTypes.object,
+  hasSubmitSuccess: PropTypes.bool.isRequired,
+};
+function mapStateToProps(state) {
+  const props = {
+    schema: get(
+      state,
+      'swagger.spec.definitions.UpdatePersonallyProcuredMovePayload',
+      {},
+    ),
+    ...state.ppm,
+    ...state.loggedInUser,
+    move: get(state, 'moves.currentMove'),
+    currentOrders:
+      get(state.loggedInUser, 'loggedInUser.service_member.orders[0]') ||
+      get(state.orders, 'currentOrders'),
+    currentPpm: get(state.ppm, 'currentPpm'),
+    formValues: getFormValues(editDateAndLocationFormName)(state),
+    entitlement: loadEntitlements(state),
+  };
+  const defaultPickupZip = get(
+    state.loggedInUser,
+    'loggedInUser.service_member.residential_address.postal_code',
+  );
+  props.initialValues = props.currentPpm
+    ? props.currentPpm
+    : defaultPickupZip
+      ? {
+          pickup_postal_code: defaultPickupZip,
+        }
+      : null;
+  return props;
+}
+function mapDispatchToProps(dispatch) {
+  return bindActionCreators(
+    { push, createOrUpdatePpm, getPpmSitEstimate },
+    dispatch,
+  );
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(
+  EditDateAndLocation,
+);

--- a/src/scenes/Review/Review.jsx
+++ b/src/scenes/Review/Review.jsx
@@ -96,6 +96,7 @@ export class Review extends Component {
     const editBackupContactAddress = thisAddress + '/edit-backup-contact';
     const editContactInfoAddress = thisAddress + '/edit-contact-info';
     const editOrdersAddress = thisAddress + '/edit-orders';
+    const editDateAndLocationAddress = thisAddress + '/edit-date-and-location';
     const privateStorageString = get(
       currentPpm,
       'estimated_storage_reimbursement',
@@ -305,7 +306,7 @@ export class Review extends Component {
                     <th>
                       Dates & Locations
                       <span className="align-right">
-                        <a href="about:blank">Edit</a>
+                        <a href={editDateAndLocationAddress}>Edit</a>
                       </span>
                     </th>
                   </tr>


### PR DESCRIPTION
## Description

Adds the date and location edit screen. 

## Code Review Verification Steps

* [ ] All tests pass.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/blob/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* [ ] Any migrations/schema changes also update the diagram in docs/schema/dp3.sqs
* [ ] There are no aXe warnings for UI.
* [ ] This works in IE.
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @willowbl00
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Request review from a member of a different team.
* [ ] (TRIAL) Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/157685746) for this change
