### PR TITLE
ELS  load /users/logged in sensibly [delivers #157798404] [delivers #157859168] [delivers #157848768]

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "react-rangeslider": "^2.2.0",
     "react-redux": "^5.0.6",
     "react-router-dom": "^4.2.2",
+    "react-router-last-location": "^1.1.0",
     "react-router-redux": "^5.0.0-alpha.8",
     "react-router-tabs": "^1.1.1",
     "react-scripts": "1.0.17",

--- a/src/scenes/Landing/index.jsx
+++ b/src/scenes/Landing/index.jsx
@@ -18,7 +18,6 @@ export class Landing extends Component {
     document.title = 'Transcom PPP: Landing Page';
     //rerun loadLoggedInUser if you have traveled to other pages
     if (!this.props.loggedInUserIsLoading && this.props.lastLocation) {
-      console.log('reloading loggedInUser');
       this.props.loadLoggedInUser();
     }
     window.scrollTo(0, 0);

--- a/src/scenes/Landing/index.jsx
+++ b/src/scenes/Landing/index.jsx
@@ -8,6 +8,7 @@ import { MoveSummary } from './MoveSummary';
 
 import { createServiceMember } from 'scenes/ServiceMembers/ducks';
 import { loadEntitlements } from 'scenes/Orders/ducks';
+import { loadLoggedInUser } from 'shared/User/ducks';
 import { getNextIncompletePage } from 'scenes/MyMove/getWorkflowRoutes';
 import Alert from 'shared/Alert';
 import LoginButton from 'shared/User/LoginButton';
@@ -15,6 +16,9 @@ import LoginButton from 'shared/User/LoginButton';
 export class Landing extends Component {
   componentDidMount() {
     document.title = 'Transcom PPP: Landing Page';
+    if (!this.props.loggedInUserIsLoading) {
+      this.props.loadLoggedInUser();
+    }
     window.scrollTo(0, 0);
   }
   componentDidUpdate() {
@@ -123,7 +127,10 @@ const mapStateToProps = state => ({
 });
 
 function mapDispatchToProps(dispatch) {
-  return bindActionCreators({ push, createServiceMember }, dispatch);
+  return bindActionCreators(
+    { push, createServiceMember, loadLoggedInUser },
+    dispatch,
+  );
 }
 
 export default connect(mapStateToProps, mapDispatchToProps)(Landing);

--- a/src/scenes/MyMove/index.jsx
+++ b/src/scenes/MyMove/index.jsx
@@ -1,5 +1,7 @@
 import React, { Component } from 'react';
 import { get } from 'lodash';
+import { LastLocationProvider } from 'react-router-last-location';
+
 import PrivateRoute from 'shared/User/PrivateRoute';
 import { Route, Switch } from 'react-router-dom';
 import { ConnectedRouter, push } from 'react-router-redux';
@@ -42,56 +44,58 @@ export class AppWrapper extends Component {
     const props = this.props;
     return (
       <ConnectedRouter history={history}>
-        <div className="App site">
-          <Header />
-          <main className="site__content">
-            <div className="usa-grid">
-              <LogoutOnInactivity />
-              {props.swaggerError && (
-                <Alert type="error" heading="An error occurred">
-                  There was an error contacting the server.
-                </Alert>
-              )}
-            </div>
-            {!props.swaggerError && (
-              <Switch>
-                <Route exact path="/" component={Landing} />
-                <Route path="/submitted" component={SubmittedFeedback} />
-                <Route
-                  path="/shipments/:shipmentsStatus"
-                  component={Shipments}
-                />
-                <Route path="/feedback" component={Feedback} />
-                {getWorkflowRoutes(props)}
-                <PrivateRoute
-                  exact
-                  path="/moves/:moveId/review/edit-profile"
-                  component={EditProfile}
-                />
-                <PrivateRoute
-                  exact
-                  path="/moves/:moveId/review/edit-backup-contact"
-                  component={EditBackupContact}
-                />
-                <PrivateRoute
-                  exact
-                  path="/moves/:moveId/review/edit-contact-info"
-                  component={EditContactInfo}
-                />
-                <PrivateRoute
-                  path="/moves/:moveId/review/edit-orders"
-                  component={EditOrders}
+        <LastLocationProvider>
+          <div className="App site">
+            <Header />
+            <main className="site__content">
+              <div className="usa-grid">
+                <LogoutOnInactivity />
+                {props.swaggerError && (
+                  <Alert type="error" heading="An error occurred">
+                    There was an error contacting the server.
+                  </Alert>
+                )}
+              </div>
+              {!props.swaggerError && (
+                <Switch>
+                  <Route exact path="/" component={Landing} />
+                  <Route path="/submitted" component={SubmittedFeedback} />
+                  <Route
+                    path="/shipments/:shipmentsStatus"
+                    component={Shipments}
+                  />
+                  <Route path="/feedback" component={Feedback} />
+                  {getWorkflowRoutes(props)}
+                  <PrivateRoute
+                    exact
+                    path="/moves/:moveId/review/edit-profile"
+                    component={EditProfile}
+                  />
+                  <PrivateRoute
+                    exact
+                    path="/moves/:moveId/review/edit-backup-contact"
+                    component={EditBackupContact}
+                  />
+                  <PrivateRoute
+                    exact
+                    path="/moves/:moveId/review/edit-contact-info"
+                    component={EditContactInfo}
+                  />
+                  <PrivateRoute
+                    path="/moves/:moveId/review/edit-orders"
+                    component={EditOrders}
                 />
                 <PrivateRoute
                   path="/moves/:moveId/review/edit-weight"
                   component={EditWeight}
-                />
-                <Route component={NoMatch} />
-              </Switch>
-            )}
-          </main>
-          <Footer />
-        </div>
+                  />
+                  <Route component={NoMatch} />
+                </Switch>
+              )}
+            </main>
+            <Footer />
+          </div>
+        </LastLocationProvider>
       </ConnectedRouter>
     );
   }

--- a/src/scenes/MyMove/index.jsx
+++ b/src/scenes/MyMove/index.jsx
@@ -84,10 +84,10 @@ export class AppWrapper extends Component {
                   <PrivateRoute
                     path="/moves/:moveId/review/edit-orders"
                     component={EditOrders}
-                />
-                <PrivateRoute
-                  path="/moves/:moveId/review/edit-weight"
-                  component={EditWeight}
+                  />
+                  <PrivateRoute
+                    path="/moves/:moveId/review/edit-weight"
+                    component={EditWeight}
                   />
                   <Route component={NoMatch} />
                 </Switch>

--- a/yarn.lock
+++ b/yarn.lock
@@ -6703,6 +6703,10 @@ react-router-dom@^4.2.2:
     react-router "^4.2.0"
     warning "^3.0.0"
 
+react-router-last-location@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/react-router-last-location/-/react-router-last-location-1.1.0.tgz#cfa1958d7b1fbb22ace38f35b1d12b8ac5ef0326"
+
 react-router-redux@^5.0.0-alpha.8:
   version "5.0.0-alpha.9"
   resolved "https://registry.yarnpkg.com/react-router-redux/-/react-router-redux-5.0.0-alpha.9.tgz#825431516e0e6f1fd93b8807f6bd595e23ec3d10"


### PR DESCRIPTION
## Description

Until we can normalize the content of our redux store, the landing page needs to reload `/users/logged_in` when it is returned to after user activity. However, that endpoint is hit on app load because of code in the AppWrapper, so we only want the landing page to reload it when it is traveled to from another route in the system (e.g. the cancel or complete buttons are clicked)
## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Code Review Verification Steps

* [ ] All tests pass.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/blob/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* [ ] Any migrations/schema changes also update the diagram in docs/schema/dp3.sqs
* [ ] There are no aXe warnings for UI.
* [ ] This works in IE.
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @willowbl00
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Request review from a member of a different team.
* [ ] (TRIAL) Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](tbd) for this change
* [this article](tbd) explains more about the approach used.

## Screenshots

If this PR makes visible UI changes, an image of the finished UI can help reviewers and casual
observers understand the context of the changes. A before image is optional and
can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow instead of using multiple images. You may want to use GIPHY CAPTURE for this! 📸

_Please frame screenshots to show enough useful context but also highlight the affected regions._
