### PR TITLE
Use move.mil domain

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,7 +138,7 @@ jobs:
     docker:
       - image: trussworks/circleci-docker-primary:4bb9cacfdfa1fbc995e89204f030264843f5bc91
     environment:
-      - APP_ENVIRONMENT: "staging"
+      - APP_ENVIRONMENT: "experimental"
     steps: &deploy_migrations_steps
       - checkout
       - run:
@@ -153,8 +153,8 @@ jobs:
     docker:
       - image: trussworks/circleci-docker-primary:4bb9cacfdfa1fbc995e89204f030264843f5bc91
     environment:
-      - APP_ENVIRONMENT: "staging"
-      - APP_REDIRECT_HEALTH_CHECK_URL: "http://my-staging.move.mil/"
+      - APP_ENVIRONMENT: "experimental"
+      - APP_REDIRECT_HEALTH_CHECK_URL: "http://my-experimental.move.mil/"
     steps: &deploy_app_redirect_steps
       - checkout
       - setup_remote_docker
@@ -170,8 +170,8 @@ jobs:
     docker:
       - image: trussworks/circleci-docker-primary:4bb9cacfdfa1fbc995e89204f030264843f5bc91
     environment:
-      - APP_ENVIRONMENT: "staging"
-      - APP_HEALTH_CHECK_URL: "https://my-staging.move.mil/health"
+      - APP_ENVIRONMENT: "experimental"
+      - APP_HEALTH_CHECK_URL: "https://my-experimental.move.mil/health"
     steps: &deploy_app_steps
       - checkout
       - setup_remote_docker
@@ -270,46 +270,20 @@ workflows:
             - build_migrations
           filters:
             branches:
-              only: master
+              only: bsik-dashed-movemil
 
       - deploy_staging_app_redirect:
           requires:
             - deploy_staging_migrations
           filters:
             branches:
-              only: master
+              only: bsik-dashed-movemil
       - deploy_staging_app:
           requires:
             - deploy_staging_migrations
           filters:
             branches:
-              only: master
-
-      - approve_prod_deploy:
-          type: approval
-          requires:
-            - deploy_staging_app_redirect
-            - deploy_staging_app
-
-      - deploy_prod_migrations:
-          requires:
-            - approve_prod_deploy
-          filters:
-            branches:
-              only: master
-
-      - deploy_prod_app_redirect:
-          requires:
-            - deploy_prod_migrations
-          filters:
-            branches:
-              only: master
-      - deploy_prod_app:
-          requires:
-            - deploy_prod_migrations
-          filters:
-            branches:
-              only: master
+              only: bsik-dashed-movemil
 
 
   dependency_updater:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -154,7 +154,7 @@ jobs:
       - image: trussworks/circleci-docker-primary:4bb9cacfdfa1fbc995e89204f030264843f5bc91
     environment:
       - APP_ENVIRONMENT: "staging"
-      - APP_REDIRECT_HEALTH_CHECK_URL: "http://my.staging.dp3.us/"
+      - APP_REDIRECT_HEALTH_CHECK_URL: "http://my-staging.move.mil/"
     steps: &deploy_app_redirect_steps
       - checkout
       - setup_remote_docker
@@ -171,7 +171,7 @@ jobs:
       - image: trussworks/circleci-docker-primary:4bb9cacfdfa1fbc995e89204f030264843f5bc91
     environment:
       - APP_ENVIRONMENT: "staging"
-      - APP_HEALTH_CHECK_URL: "https://my.staging.dp3.us/health"
+      - APP_HEALTH_CHECK_URL: "https://my-staging.move.mil/health"
     steps: &deploy_app_steps
       - checkout
       - setup_remote_docker
@@ -195,7 +195,7 @@ jobs:
       - image: trussworks/circleci-docker-primary:4bb9cacfdfa1fbc995e89204f030264843f5bc91
     environment:
       - APP_ENVIRONMENT: "prod"
-      - APP_REDIRECT_HEALTH_CHECK_URL: "http://my.dp3.us/"
+      - APP_REDIRECT_HEALTH_CHECK_URL: "http://my.move.mil/"
     steps: *deploy_app_redirect_steps
 
   deploy_prod_app:
@@ -203,7 +203,7 @@ jobs:
       - image: trussworks/circleci-docker-primary:4bb9cacfdfa1fbc995e89204f030264843f5bc91
     environment:
       - APP_ENVIRONMENT: "prod"
-      - APP_HEALTH_CHECK_URL: "https://my.dp3.us/health"
+      - APP_HEALTH_CHECK_URL: "https://my.move.mil/health"
     steps: *deploy_app_steps
 
   integration_tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,7 +138,7 @@ jobs:
     docker:
       - image: trussworks/circleci-docker-primary:4bb9cacfdfa1fbc995e89204f030264843f5bc91
     environment:
-      - APP_ENVIRONMENT: "experimental"
+      - APP_ENVIRONMENT: "staging"
     steps: &deploy_migrations_steps
       - checkout
       - run:
@@ -153,8 +153,8 @@ jobs:
     docker:
       - image: trussworks/circleci-docker-primary:4bb9cacfdfa1fbc995e89204f030264843f5bc91
     environment:
-      - APP_ENVIRONMENT: "experimental"
-      - APP_REDIRECT_HEALTH_CHECK_URL: "http://my-experimental.move.mil/"
+      - APP_ENVIRONMENT: "staging"
+      - APP_REDIRECT_HEALTH_CHECK_URL: "http://my-staging.move.mil/"
     steps: &deploy_app_redirect_steps
       - checkout
       - setup_remote_docker
@@ -170,8 +170,8 @@ jobs:
     docker:
       - image: trussworks/circleci-docker-primary:4bb9cacfdfa1fbc995e89204f030264843f5bc91
     environment:
-      - APP_ENVIRONMENT: "experimental"
-      - APP_HEALTH_CHECK_URL: "https://my-experimental.move.mil/health"
+      - APP_ENVIRONMENT: "staging"
+      - APP_HEALTH_CHECK_URL: "https://my-staging.move.mil/health"
     steps: &deploy_app_steps
       - checkout
       - setup_remote_docker
@@ -270,20 +270,46 @@ workflows:
             - build_migrations
           filters:
             branches:
-              only: bsik-dashed-movemil
+              only: master
 
       - deploy_staging_app_redirect:
           requires:
             - deploy_staging_migrations
           filters:
             branches:
-              only: bsik-dashed-movemil
+              only: master
       - deploy_staging_app:
           requires:
             - deploy_staging_migrations
           filters:
             branches:
-              only: bsik-dashed-movemil
+              only: master
+
+      - approve_prod_deploy:
+          type: approval
+          requires:
+            - deploy_staging_app_redirect
+            - deploy_staging_app
+
+      - deploy_prod_migrations:
+          requires:
+            - approve_prod_deploy
+          filters:
+            branches:
+              only: master
+
+      - deploy_prod_app_redirect:
+          requires:
+            - deploy_prod_migrations
+          filters:
+            branches:
+              only: master
+      - deploy_prod_app:
+          requires:
+            - deploy_prod_migrations
+          filters:
+            branches:
+              only: master
 
 
   dependency_updater:

--- a/bin/ecs-deploy-service-container
+++ b/bin/ecs-deploy-service-container
@@ -32,8 +32,18 @@ readonly rds=app-${environment}
 readonly task_family=${name}-${environment}
 readonly container_name=${name}-${environment}
 
-# TODO: Change to move.mil when it's transferred to our infrastructure.
-readonly zone_name="dp3.us"
+readonly zone_name="move.mil"
+
+# TODO: Just use "domain" (below) when we stop using dashed hostnames.
+web_fqdn_suffix=-${environment}.${zone_name}
+[[ $environment = prod ]] && web_fqdn_suffix=.$zone_name
+readonly web_fqdn_suffix
+
+# TODO: Rename to "domain" when we stop using dashed hostnames.
+# use environment subdomain unless we're deploying prod
+email_domain=${environment}.${zone_name}
+[[ $environment = prod ]] && email_domain=$zone_name
+readonly email_domain
 
 
 check_arn() {
@@ -62,11 +72,6 @@ update_service() {
     return $exit_code
 }
 
-# use environment subdomain unless we're deploying prod
-domain=${environment}.${zone_name}
-[[ $environment = prod ]] && domain=$zone_name
-readonly domain
-
 # get current task definiton (for rollback)
 blue_task_def_arn=$(aws ecs describe-services --services "$name" --cluster "$cluster" --query 'services[0].taskDefinition' | jq -r .)
 
@@ -76,7 +81,7 @@ db_host=$(aws rds describe-db-instances --db-instance-identifier "$rds" --query 
 readonly db_host
 
 # create the container definition from the json template
-container_definition_json=$(perl -pe "s|{{db_host}}|$db_host|g; s|{{domain}}|$domain|g; s|{{environment}}|$environment|g; s|{{image}}|$image|g;" "$template")
+container_definition_json=$(perl -pe "s|{{db_host}}|$db_host|g; s|{{email_domain}}|$email_domain|g; s|{{environment}}|$environment|g; s|{{image}}|$image|g; s|{{web_fqdn_suffix}}|$web_fqdn_suffix|g;" "$template")
 readonly container_definition_json
 
 # create new task definition with the given image

--- a/bin/ecs-deploy-service-container
+++ b/bin/ecs-deploy-service-container
@@ -44,7 +44,8 @@ check_arn() {
 update_service() {
     local arn="$1"
 
-    local network_config=$(aws ecs describe-services --services "$name" --cluster "$cluster" --query 'services[0].networkConfiguration')
+    local network_config
+    network_config=$(aws ecs describe-services --services "$name" --cluster "$cluster" --query 'services[0].networkConfiguration')
 
     echo "* Updating $name service to use $arn"
     aws ecs update-service --cluster "$cluster" --service "$name" --task-definition "$arn" --query 'service.deployments' --network-configuration "$network_config" || return 1

--- a/config/app.container-definition.json
+++ b/config/app.container-definition.json
@@ -54,11 +54,11 @@
     },
     {
       "name": "HTTP_MY_SERVER_NAME",
-      "value": "my.{{domain}}"
+      "value": "my{{web_fqdn_suffix}}"
     },
     {
       "name": "HTTP_OFFICE_SERVER_NAME",
-      "value": "office.{{domain}}"
+      "value": "office{{web_fqdn_suffix}}"
     },
     {
       "name": "AWS_S3_BUCKET_NAME",
@@ -86,7 +86,7 @@
     },
     {
       "name": "AWS_SES_DOMAIN",
-      "value": "{{domain}}"
+      "value": "{{email_domain}}"
     },
     {
       "name": "AWS_SES_REGION",


### PR DESCRIPTION
## Description

This migrates all our sites to the `move.mil` domain! It also migrates us to using dashed names for staging and experimental (e.g., `my-staging.move.mil`) in order to use the wildcard cert we've been given.

I had to break out email domain from what we use for the website due to the nature of the dashed names. That will be undone when we move back to dotted names.

This was tested by deploying to experimental:
https://circleci.com/workflow-run/b3aa16b0-b71e-4a09-9742-5be40b15fcaa

## Important

This shouldn't be merged in until the app is properly configured with and at login.gov using these URLs.

- [ ] experimental configured with login.gov
- [x] staging configured with login.gov
- [x] prod configured with login.gov