### PR TITLE
els handle rate engine errors gracefully [delivers #157889686]

### DIFF
--- a/src/scenes/Moves/Ppm/DateAndLocation.jsx
+++ b/src/scenes/Moves/Ppm/DateAndLocation.jsx
@@ -9,6 +9,7 @@ import { createOrUpdatePpm, getPpmSitEstimate } from './ducks';
 import { reduxifyWizardForm } from 'shared/WizardPage/Form';
 import { SwaggerField } from 'shared/JsonSchemaForm/JsonSchemaField';
 import { loadEntitlements } from 'scenes/Orders/ducks';
+import Alert from 'shared/Alert';
 
 import './DateAndLocation.css';
 
@@ -74,6 +75,7 @@ export class DateAndLocation extends Component {
       currentOrders,
       initialValues,
       sitReimbursement,
+      hasEstimateError,
     } = this.props;
     return (
       <DateAndLocationWizardForm
@@ -156,6 +158,15 @@ export class DateAndLocation extends Component {
                 your receipts to submit with your PPM paperwork.
               </div>
             )}
+            {hasEstimateError && (
+              <div className="usa-width-one-whole error-message">
+                <Alert type="warning" heading="Could not retrieve estimate">
+                  There was an issue retrieving an estimate for how much you
+                  could be reimbursed for private storage. You still qualify but
+                  may need to talk with your local PPPO.
+                </Alert>
+              </div>
+            )}
           </Fragment>
         )}
       </DateAndLocationWizardForm>
@@ -181,6 +192,7 @@ function mapStateToProps(state) {
     currentOrders: state.orders.currentOrders,
     formValues: getFormValues(formName)(state),
     entitlement: loadEntitlements(state),
+    hasEstimateError: state.ppm.hasEstimateError,
   };
   const defaultPickupZip = get(
     state.serviceMember,

--- a/src/scenes/Moves/Ppm/Weight.jsx
+++ b/src/scenes/Moves/Ppm/Weight.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { get } from 'lodash';
@@ -102,6 +102,7 @@ export class PpmWeight extends Component {
       hasEstimateInProgress,
       error,
       entitlement,
+      hasEstimateError,
     } = this.props;
     let currentInfo = null;
     if (hasLoadSuccess) {
@@ -146,6 +147,17 @@ export class PpmWeight extends Component {
                 }}
               />
             </div>
+            {hasEstimateError && (
+              <Fragment>
+                <div className="usa-width-one-whole error-message">
+                  <Alert type="warning" heading="Could not retrieve estimate">
+                    There was an issue retrieving an estimate for your
+                    incentive. You still qualify but may need to talk with your
+                    local PPPO.
+                  </Alert>
+                </div>
+              </Fragment>
+            )}
             <table className="numeric-info">
               <tbody>
                 <tr>
@@ -158,7 +170,6 @@ export class PpmWeight extends Component {
                 </tr>
               </tbody>
             </table>
-
             <div className="info">
               <h3> How is my PPM Incentive calculated?</h3>
               <p>

--- a/src/scenes/Moves/Ppm/ducks.js
+++ b/src/scenes/Moves/Ppm/ducks.js
@@ -222,7 +222,7 @@ export function ppmReducer(state = initialState, action) {
         hasEstimateSuccess: true,
         hasEstimateError: false,
         hasEstimateInProgress: false,
-        error: null,
+        rateEngineError: null,
       });
     case GET_PPM_ESTIMATE.failure:
       return Object.assign({}, state, {
@@ -230,7 +230,7 @@ export function ppmReducer(state = initialState, action) {
         hasEstimateSuccess: false,
         hasEstimateError: true,
         hasEstimateInProgress: false,
-        error: action.error,
+        rateEngineError: action.error,
       });
     case GET_SIT_ESTIMATE.start:
       return Object.assign({}, state, {
@@ -248,7 +248,7 @@ export function ppmReducer(state = initialState, action) {
         hasEstimateSuccess: true,
         hasEstimateError: false,
         hasEstimateInProgress: false,
-        error: null,
+        rateEngineError: null,
       });
     case GET_SIT_ESTIMATE.failure:
       return Object.assign({}, state, {
@@ -256,7 +256,7 @@ export function ppmReducer(state = initialState, action) {
         hasEstimateSuccess: false,
         hasEstimateError: true,
         hasEstimateInProgress: false,
-        error: action.error,
+        rateEngineError: action.error,
       });
     default:
       return state;

--- a/src/scenes/Moves/Ppm/ducks.js
+++ b/src/scenes/Moves/Ppm/ducks.js
@@ -253,6 +253,7 @@ export function ppmReducer(state = initialState, action) {
         hasEstimateError: true,
         hasEstimateInProgress: false,
         rateEngineError: action.error,
+        error: null,
       });
     case GET_PPM_MAX_ESTIMATE.start:
       return Object.assign({}, state, {

--- a/src/scenes/Moves/Ppm/ducks.test.js
+++ b/src/scenes/Moves/Ppm/ducks.test.js
@@ -209,6 +209,7 @@ describe('Ppm Reducer', () => {
         pendingValue: '',
         rateEngineError: 'No bueno.',
         incentive: null,
+        error: null,
       });
     });
   });

--- a/src/scenes/Moves/Ppm/ducks.test.js
+++ b/src/scenes/Moves/Ppm/ducks.test.js
@@ -1,5 +1,10 @@
-import { CREATE_OR_UPDATE_PPM, GET_PPM, ppmReducer } from './ducks';
-import { GET_LOGGED_IN_USER } from 'shared/User/ducks';
+import {
+  CREATE_OR_UPDATE_PPM,
+  GET_PPM,
+  GET_SIT_ESTIMATE,
+  GET_PPM_ESTIMATE,
+  ppmReducer,
+} from './ducks';
 import loggedInUserPayload, {
   emptyPayload,
 } from 'shared/User/sampleLoggedInUserPayload';
@@ -132,6 +137,78 @@ describe('Ppm Reducer', () => {
         hasLoadError: true,
         hasLoadSuccess: false,
         error: 'No bueno.',
+      });
+    });
+  });
+
+  describe('GET_SIT_ESTIMATE', () => {
+    it('Should handle SUCCESS', () => {
+      const initialState = {};
+      const newState = ppmReducer(initialState, {
+        type: GET_SIT_ESTIMATE.success,
+        payload: { estimate: 21505 },
+      });
+
+      expect(newState).toEqual({
+        sitReimbursement: '$215.05',
+        hasEstimateSuccess: true,
+        hasEstimateError: false,
+        hasEstimateInProgress: false,
+        rateEngineError: null,
+      });
+    });
+
+    it('Should handle FAILURE', () => {
+      const initialState = { pendingValue: '' };
+
+      const newState = ppmReducer(initialState, {
+        type: GET_SIT_ESTIMATE.failure,
+        error: 'No bueno.',
+      });
+      // using special error here so it is not caught by WizardPage handling
+      expect(newState).toEqual({
+        hasEstimateError: true,
+        hasEstimateInProgress: false,
+        hasEstimateSuccess: false,
+        pendingValue: '',
+        rateEngineError: 'No bueno.',
+        sitReimbursement: null,
+      });
+    });
+  });
+
+  describe('GET_PPM_ESTIMATE', () => {
+    it('Should handle SUCCESS', () => {
+      const initialState = {};
+      const newState = ppmReducer(initialState, {
+        type: GET_PPM_ESTIMATE.success,
+        payload: { range_min: 21505, range_max: 44403 },
+      });
+
+      expect(newState).toEqual({
+        incentive: '$215.05 - 444.03',
+        hasEstimateSuccess: true,
+        hasEstimateError: false,
+        hasEstimateInProgress: false,
+        rateEngineError: null,
+      });
+    });
+
+    it('Should handle FAILURE', () => {
+      const initialState = { pendingValue: '' };
+
+      const newState = ppmReducer(initialState, {
+        type: GET_PPM_ESTIMATE.failure,
+        error: 'No bueno.',
+      });
+      // using special error here so it is not caught by WizardPage handling
+      expect(newState).toEqual({
+        hasEstimateError: true,
+        hasEstimateInProgress: false,
+        hasEstimateSuccess: false,
+        pendingValue: '',
+        rateEngineError: 'No bueno.',
+        incentive: null,
       });
     });
   });


### PR DESCRIPTION
## Description

If the rate engine is unable to generate an estimate, the user gets a warning but is able to continue scheduling a move.

This is just in case we have a hole in our data, or a user enters a bogus zipcode.
## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Code Review Verification Steps

* [ ] All tests pass.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/blob/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* [ ] Any migrations/schema changes also update the diagram in docs/schema/dp3.sqs
* [ ] There are no aXe warnings for UI.
* [ ] This works in IE.
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @willowbl00
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Request review from a member of a different team.
* [ ] (TRIAL) Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/157889686) for this change
* [this article](tbd) explains more about the approach used.

## Screenshots

![image](https://user-images.githubusercontent.com/3142631/40686038-f5804818-6363-11e8-8e2c-88467fa58611.png)
![image](https://user-images.githubusercontent.com/3142631/40686061-0b324bfc-6364-11e8-88e7-405d3bf88377.png)
