### PR TITLE
Reduce queue table font and set minimum width

### DIFF
--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -30,8 +30,6 @@ import faExclamationCircle from '@fortawesome/fontawesome-free-solid/faExclamati
 import faPlayCircle from '@fortawesome/fontawesome-free-solid/faPlayCircle';
 import faExternalLinkAlt from '@fortawesome/fontawesome-free-solid/faExternalLinkAlt';
 
-import './office.css';
-
 const BasicsTabContent = props => {
   return (
     <React.Fragment>

--- a/src/scenes/Office/QueueTable.jsx
+++ b/src/scenes/Office/QueueTable.jsx
@@ -46,7 +46,7 @@ class QueueTable extends Component {
     return (
       <div>
         <h1>Queue: {titles[this.props.queueType]}</h1>
-        <div>
+        <div className="queue-table">
           <ReactTable
             columns={[
               {
@@ -95,7 +95,6 @@ class QueueTable extends Component {
               onDoubleClick: e =>
                 this.props.history.push(`new/moves/${rowInfo.original.id}`),
             })}
-            className="queue-table"
           />
         </div>
       </div>

--- a/src/scenes/Office/QueueTable.jsx
+++ b/src/scenes/Office/QueueTable.jsx
@@ -95,6 +95,7 @@ class QueueTable extends Component {
               onDoubleClick: e =>
                 this.props.history.push(`new/moves/${rowInfo.original.id}`),
             })}
+            className="queue-table"
           />
         </div>
       </div>

--- a/src/scenes/Office/index.jsx
+++ b/src/scenes/Office/index.jsx
@@ -26,7 +26,9 @@ class Queues extends Component {
           <QueueList />
         </div>
         <div className="usa-width-five-sixths">
-          <QueueTable queueType={this.props.match.params.queueType} />
+          <div className="queue-table-scrollable">
+            <QueueTable queueType={this.props.match.params.queueType} />
+          </div>
         </div>
       </div>
     );

--- a/src/scenes/Office/index.jsx
+++ b/src/scenes/Office/index.jsx
@@ -16,6 +16,8 @@ import { no_op } from 'shared/utils';
 import LogoutOnInactivity from 'shared/User/LogoutOnInactivity';
 import PrivateRoute from 'shared/User/PrivateRoute';
 
+import './office.css';
+
 class Queues extends Component {
   render() {
     return (

--- a/src/scenes/Office/index.jsx
+++ b/src/scenes/Office/index.jsx
@@ -21,11 +21,11 @@ import './office.css';
 class Queues extends Component {
   render() {
     return (
-      <div className="usa-grid grid-wide">
-        <div className="usa-width-one-sixth">
+      <div className="usa-grid grid-wide queue-columns">
+        <div className="queue-menu-column">
           <QueueList />
         </div>
-        <div className="usa-width-five-sixths">
+        <div className="queue-list-column">
           <div className="queue-table-scrollable">
             <QueueTable queueType={this.props.match.params.queueType} />
           </div>

--- a/src/scenes/Office/office.css
+++ b/src/scenes/Office/office.css
@@ -22,6 +22,26 @@
   margin-right: 5%;
 }
 
+
+/* Queue list page */
+.queue-columns {
+  position: relative;
+}
+
+.queue-menu-column {
+  margin-right: 3rem;
+  width: 18rem;
+  position: absolute;
+}
+
+.queue-list-column {
+  margin-left: 22rem;
+}
+
+.ReactTable .rt-thead .rt-resizable-header-content {
+  text-align: left;
+}
+
 /* Use with .usa-grid for a liquid and nearly full-width grid layout. */
 .grid-wide {
   max-width: 2000px;

--- a/src/scenes/Office/office.css
+++ b/src/scenes/Office/office.css
@@ -1,3 +1,8 @@
+.queue-table {
+  font-size: 0.75em;
+  min-width: 1000px;
+}
+
 .fake-link {
   text-decoration: underline;
   color: blue;
@@ -197,7 +202,7 @@ head .panel-subhead {
 .payment-panel {
   border: solid #f1f1f1;
   border-width: 3px;
-  width:100%;
+  width: 100%;
   empty-cells: hide;
 }
 
@@ -205,8 +210,9 @@ head .panel-subhead {
   margin: 1em;
 }
 
-.payment-table td, .payment-table th {
-    border: none;
+.payment-table td,
+.payment-table th {
+  border: none;
 }
 
 .payment-table a {
@@ -223,21 +229,21 @@ head .panel-subhead {
   font-size: 1.7rem;
   font-weight: bold;
   background-color: #f1f1f1;
-  padding: .4em 1em;
+  padding: 0.4em 1em;
   border: 3px solid #f1f1f1;
-  width:100%;
+  width: 100%;
 }
 
 .payment-table .payment-table-column-title {
   font-weight: bold;
-  font-size: .9em;
-  border-bottom: solid 1px #A2A2A2;
+  font-size: 0.9em;
+  border-bottom: solid 1px #a2a2a2;
   width: 15%;
 }
 
 .payment-table .payment-table-subheader {
   font-weight: bold;
-  font-size: .9em;
+  font-size: 0.9em;
   border-bottom: solid 1px #f1f1f1;
   width: 90%;
 }
@@ -248,32 +254,32 @@ head .panel-subhead {
 }
 
 .tooltip .tooltiptext {
-    visibility: hidden;
-    width: 200px;
-    background-color: black;
-    color: #fff;
-    text-align: center;
-    border-radius: 6px;
-    padding: 5px;
-    position: absolute;
-    z-index: 1;
-    top: 60px;
-    margin-left: -105px;
+  visibility: hidden;
+  width: 200px;
+  background-color: black;
+  color: #fff;
+  text-align: center;
+  border-radius: 6px;
+  padding: 5px;
+  position: absolute;
+  z-index: 1;
+  top: 60px;
+  margin-left: -105px;
 }
 
 .tooltip .tooltiptext::after {
-    content: "";
-    position: absolute;
-    bottom: 100%;
-    left: 50%;
-    margin-left: -5px;
-    border-width: 5px;
-    border-style: solid;
-    border-color: transparent transparent black transparent;
+  content: '';
+  position: absolute;
+  bottom: 100%;
+  left: 50%;
+  margin-left: -5px;
+  border-width: 5px;
+  border-style: solid;
+  border-color: transparent transparent black transparent;
 }
 
 .tooltip:hover .tooltiptext {
-    visibility: visible;
+  visibility: visible;
 }
 
 .approval-ready {

--- a/src/scenes/Office/office.css
+++ b/src/scenes/Office/office.css
@@ -3,6 +3,10 @@
   min-width: 1000px;
 }
 
+.queue-table-scrollable {
+  overflow-x: scroll;
+}
+
 .fake-link {
   text-decoration: underline;
   color: blue;


### PR DESCRIPTION
## Description

This reduces the font size within the queue table. There's also now a minimum width on the table itself so that all columns will always be displayed, so any scrolling will be in the browser window, not within the table. 

## Reviewer Notes

How does the width work for you? I found 1000px was the sweet spot, but I'd like to know if that's the case for other folks. 

Also, looks like my linter had some feelings on the CSS file. Is this ok?

## Code Review Verification Steps

* [ ] All tests pass.
* [ ] There are no aXe warnings for UI.
* [ ] This works in IE.
* [ ] Request review from a member of a different team.
* [ ] (TRIAL) Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story #1](https://www.pivotaltracker.com/story/show/157943729) for this change
* [Pivotal story #2](https://www.pivotaltracker.com/story/show/157607000) for this change

## Screenshots

![queue-table-min-width](https://user-images.githubusercontent.com/10379814/40689695-33ec5e0e-6358-11e8-83e9-7ab725fd2e92.gif)

