### PR TITLE
Comment out 500 response when email sending fails [delivers #157986481]

### DIFF
--- a/pkg/handlers/office.go
+++ b/pkg/handlers/office.go
@@ -65,7 +65,8 @@ func (h ApprovePPMHandler) Handle(params officeop.ApprovePPMParams) middleware.R
 	)
 	if err != nil {
 		h.logger.Error("problem sending email to user", zap.Error(err))
-		return newErrResponse(500)
+		// TODO how should we handle this error?
+		// return newErrResponse(500)
 	}
 
 	ppmPayload := payloadForPPMModel(*ppm)


### PR DESCRIPTION
## Description

This is a temporary fix to the issue that prevents approving PPMs when running in development unless prod AWS have been setup.

I want to come back and do something better for developers, but that is more invasive than I have the stomach for today.

## Code Review Verification Steps

* [x] All tests pass.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/blob/master/docs/backend.md#logging)
* [ ] Request review from a member of a different team.

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/157986481) for this change