### PR TITLE
disable 'text message is preferred' checkbox, clean up links on home page 

### DIFF
--- a/src/scenes/Landing/MoveSummary.jsx
+++ b/src/scenes/Landing/MoveSummary.jsx
@@ -191,9 +191,15 @@ export const MoveSummary = props => {
                           receipts. For more information, read the PPM info
                           packet.
                         </div>
-                        <button className="usa-button-secondary">
-                          Read PPM Info Packet
-                        </button>
+                        <a
+                          href={ppmInfoPacket}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                        >
+                          <button className="usa-button-secondary">
+                            Read PPM Info Packet
+                          </button>
+                        </a>
                       </div>
                       <div className="step">
                         <div className="title">Next step: Request Payment</div>

--- a/src/scenes/Landing/MoveSummary.jsx
+++ b/src/scenes/Landing/MoveSummary.jsx
@@ -9,6 +9,7 @@ import ppmDraft from './images/ppm-draft.png';
 import ppmSubmitted from './images/ppm-submitted.png';
 import ppmApproved from './images/ppm-approved.png';
 import ppmInProgress from './images/ppm-in-progress.png';
+import { ppmInfoPacket } from 'shared/constants';
 
 const DutyStationContactInfo = props => {
   const { dutyStation, origin } = props;
@@ -150,7 +151,13 @@ export const MoveSummary = props => {
                     <div className="titled_block">
                       <div className="title">Documents</div>
                       <div className="details-links">
-                        <a>PPM Info Packet</a>
+                        <a
+                          href={ppmInfoPacket}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                        >
+                          PPM Info Packet
+                        </a>
                       </div>
                     </div>
                   </div>
@@ -195,8 +202,11 @@ export const MoveSummary = props => {
                           advance against your PPM payment before your move is
                           done.
                         </div>
-                        <button className="usa-button-secondary">
-                          Request Payment
+                        <button
+                          className="usa-button-secondary"
+                          disabled={true}
+                        >
+                          Request Payment - Coming Soon!
                         </button>
                       </div>
                     </div>
@@ -217,7 +227,6 @@ export const MoveSummary = props => {
                         <div className="title">Documents</div>
                         <div className="details-links">
                           <a>PPM Info Packet</a>
-                          <a>Advance paperwork</a>
                         </div>
                       </div>
                     </div>
@@ -253,8 +262,11 @@ export const MoveSummary = props => {
                           advance against your PPM payment before your move is
                           done.
                         </div>
-                        <button className="usa-button-secondary">
-                          Request Payment
+                        <button
+                          className="usa-button-secondary"
+                          disabled={true}
+                        >
+                          Request Payment - Coming Soon!
                         </button>
                       </div>
                     </div>
@@ -275,7 +287,6 @@ export const MoveSummary = props => {
                         <div className="title">Documents</div>
                         <div className="details-links">
                           <a>PPM Info Packet</a>
-                          <a>Advance paperwork</a>
                         </div>
                       </div>
                     </div>

--- a/src/scenes/Landing/MoveSummary.jsx
+++ b/src/scenes/Landing/MoveSummary.jsx
@@ -232,7 +232,13 @@ export const MoveSummary = props => {
                       <div className="titled_block">
                         <div className="title">Documents</div>
                         <div className="details-links">
-                          <a>PPM Info Packet</a>
+                          <a
+                            href={ppmInfoPacket}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                          >
+                            PPM Info Packet
+                          </a>
                         </div>
                       </div>
                     </div>
@@ -292,7 +298,13 @@ export const MoveSummary = props => {
                       <div className="titled_block">
                         <div className="title">Documents</div>
                         <div className="details-links">
-                          <a>PPM Info Packet</a>
+                          <a
+                            href={ppmInfoPacket}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                          >
+                            PPM Info Packet
+                          </a>
                         </div>
                       </div>
                     </div>

--- a/src/scenes/Review/EditContactInfo.jsx
+++ b/src/scenes/Review/EditContactInfo.jsx
@@ -53,6 +53,7 @@ let EditContactForm = props => {
           <SwaggerField
             fieldName="text_message_is_preferred"
             swagger={serviceMemberSchema}
+            disabled={true}
           />
           <SwaggerField
             fieldName="email_is_preferred"

--- a/src/scenes/ServiceMembers/ContactInfo.jsx
+++ b/src/scenes/ServiceMembers/ContactInfo.jsx
@@ -88,6 +88,7 @@ export class ContactInfo extends Component {
           <SwaggerField
             fieldName="text_message_is_preferred"
             swagger={schema}
+            disabled={true}
           />
           <SwaggerField fieldName="email_is_preferred" swagger={schema} />
         </fieldset>

--- a/src/shared/JsonSchemaForm/JsonSchemaField.js
+++ b/src/shared/JsonSchemaForm/JsonSchemaField.js
@@ -17,9 +17,15 @@ const parseNumberField = value => {
 };
 
 // ----- Field configuration -----
-const createCheckbox = (fieldName, field, nameAttr) => {
+const createCheckbox = (fieldName, field, nameAttr, isDisabled) => {
   return (
-    <Field id={fieldName} name={nameAttr} component="input" type="checkbox" />
+    <Field
+      id={fieldName}
+      name={nameAttr}
+      component="input"
+      type="checkbox"
+      disabled={isDisabled}
+    />
   );
 };
 
@@ -276,7 +282,7 @@ const createSchemaField = (
   if (swaggerField.type === 'boolean' && !component) {
     return (
       <Fragment key={fieldName}>
-        {createCheckbox(fieldName, swaggerField, nameAttr)}
+        {createCheckbox(fieldName, swaggerField, nameAttr, disabled)}
         <label htmlFor={fieldName} className="usa-input-label">
           {title || swaggerField.title || fieldName}
         </label>

--- a/src/shared/constants.js
+++ b/src/shared/constants.js
@@ -4,3 +4,5 @@ export const isProduction = process.env.NODE_ENV === 'production';
 export const isDevelopment = process.env.NODE_ENV === 'development';
 export const isTest = process.env.NODE_ENV === 'test';
 export const NULL_UUID = '00000000-0000-0000-0000-000000000000';
+export const ppmInfoPacket =
+  'https://s3.amazonaws.com/prod.tracker2/resource/89609252/PPM_Info_Sheet.pdf?response-content-disposition=inline&response-content-type=application%2Fpdf&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAJJBSFJ4TCVKKGAIA%2F20180530%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20180530T230724Z&X-Amz-Expires=1800&X-Amz-SignedHeaders=host&X-Amz-Signature=c66580dd5fe891c4fde94a4a28faceac307ac41d559c90d99719cfbb871c788f';

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -517,7 +517,7 @@ definitions:
       text_message_is_preferred:
         type: boolean
         x-nullable: true
-        title: Text Message
+        title: Text Message - Coming Soon!
       email_is_preferred:
         type: boolean
         x-nullable: true
@@ -618,7 +618,7 @@ definitions:
       text_message_is_preferred:
         type: boolean
         x-nullable: true
-        title: Text Message
+        title: Text Message - Coming Soon!
       email_is_preferred:
         type: boolean
         x-nullable: true
@@ -706,7 +706,7 @@ definitions:
       text_message_is_preferred:
         type: boolean
         x-nullable: true
-        title: Text Message
+        title: Text Message - Coming Soon!
       email_is_preferred:
         type: boolean
         x-nullable: true


### PR DESCRIPTION
## Description

* Disables text message is preferred checkbox on contactinfo and editcontact info screen and adds a "coming soon" text to the title in swagger.
* Disables 'request payment' button, add "coming soon"
* removes advance paperwork link
* activates ppm info paperwork link to pdf

## Code Review Verification Steps

* [ ] All tests pass.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/blob/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* [ ] Any migrations/schema changes also update the diagram in docs/schema/dp3.sqs
* [ ] There are no aXe warnings for UI.
* [ ] This works in IE.
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @willowbl00
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Request review from a member of a different team.
* [ ] (TRIAL) Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/157890255) for this change

## Screenshots
<img width="602" alt="screen shot 2018-05-30 at 4 14 43 pm" src="https://user-images.githubusercontent.com/8170735/40752493-9873ad4c-6424-11e8-85ea-c92fce058b19.png">
