### PR TITLE
els help links [delivers #157666199]

### DIFF
--- a/src/scenes/Moves/MoveType.css
+++ b/src/scenes/Moves/MoveType.css
@@ -44,6 +44,13 @@ ul {
   color: rgb(55, 155, 252);
 }
 
+.select-move-type h2 a {
+  font-size: 14px;
+}
+
+.select-move-type h2 a:visited {
+  color: #0071bc;
+}
 /* This matches the width at which submit buttons go full-width for mobile devices */
 @media only screen and (max-width: 481px) {
   .move-type-button {

--- a/src/scenes/Moves/MoveType.jsx
+++ b/src/scenes/Moves/MoveType.jsx
@@ -72,9 +72,6 @@ class BigButtonGroup extends Component {
                     </div>
                   );
                 }, this)}
-                <p className="move-type-button-more-info Todo">
-                  <a href="about:blank">more information</a>
-                </p>
               </div>
             )}
           </div>
@@ -180,8 +177,18 @@ export class MoveType extends Component {
     // const selectedOption =
     //   pendingMoveType || (currentMove && currentMove.selected_move_type);
     return (
-      <div className="usa-grid-full">
-        <h2> Select a Move Type</h2>
+      <div className="usa-grid-full select-move-type">
+        <h2>
+          {' '}
+          Select a move type{' '}
+          <a
+            href="https://www.move.mil/moving-guide"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Learn More
+          </a>
+        </h2>
         <BigButtonGroupWithSize
           selectedOption={currentOption}
           onMoveTypeSelected={this.onMoveTypeSelected}

--- a/src/scenes/Moves/Ppm/DateAndLocation.jsx
+++ b/src/scenes/Moves/Ppm/DateAndLocation.jsx
@@ -18,6 +18,15 @@ const formName = 'ppp_date_and_location';
 const DateAndLocationWizardForm = reduxifyWizardForm(formName);
 
 export class DateAndLocation extends Component {
+  state = { showInfo: false };
+
+  openInfo = () => {
+    this.setState({ showInfo: true });
+  };
+  closeInfo = () => {
+    this.setState({ showInfo: false });
+  };
+
   handleSubmit = () => {
     const { sitReimbursement } = this.props;
     const pendingValues = Object.assign({}, this.props.formValues);
@@ -115,8 +124,21 @@ export class DateAndLocation extends Component {
               required
             />
             <span className="grey">
-              Making additional stops may decrease your PPM incentive.
+              Making additional stops may decrease your PPM incentive.{' '}
+              <a onClick={this.openInfo}>Why</a>
             </span>
+            {this.state.showInfo && (
+              <Alert type="info" heading="">
+                Your PPM incentive is based primarily off two factors -- the
+                weight of your household goods and the base rate it would cost
+                the government to transport your household goods between your
+                destination and origin. When you add additional stops, your
+                overall PPM incentive will change to account for any deviations
+                from the standard route and to account for the fact that not
+                100% of your household goods travelled the entire way from
+                origin to destination. <a onClick={this.closeInfo}>Close</a>
+              </Alert>
+            )}
           </Fragment>
         )}
         <h3>Destination Location</h3>

--- a/src/scenes/Moves/Ppm/Weight.jsx
+++ b/src/scenes/Moves/Ppm/Weight.jsx
@@ -82,64 +82,91 @@ const validateAdvanceForm = (values, form) => {
 };
 
 const requestAdvanceFormName = 'request_advance';
-let RequestAdvanceForm = props => {
-  const { schema, hasRequestedAdvance, maxIncentive } = props;
-  let maxAdvance = '';
-  if (maxIncentive) {
-    maxAdvance = formatMaxAdvance(maxIncentive);
-  }
-  return (
-    <div className="whole_box">
-      <div>
-        <div className="usa-width-one-whole">
-          <div className="usa-width-two-thirds">
-            <div className="ppmquestion">
-              Would you like an advance of up to 60% of your PPM incentive? ({
-                maxAdvance
-              })
+class RequestAdvanceForm extends Component {
+  state = { showInfo: false };
+
+  openInfo = () => {
+    this.setState({ showInfo: true });
+  };
+  closeInfo = () => {
+    this.setState({ showInfo: false });
+  };
+
+  render() {
+    const { schema, hasRequestedAdvance, maxIncentive } = this.props;
+    let maxAdvance = '';
+    if (maxIncentive) {
+      maxAdvance = formatMaxAdvance(maxIncentive);
+    }
+    return (
+      <div className="whole_box">
+        <div>
+          <div className="usa-width-one-whole">
+            <div className="usa-width-two-thirds">
+              <div className="ppmquestion">
+                Would you like an advance of up to 60% of your PPM incentive? ({
+                  maxAdvance
+                })
+              </div>
+              <div className="ppmmuted">
+                We recommend paying for expenses with your government travel
+                card, rather than getting an advance.{' '}
+                <a onClick={this.openInfo}>Why?</a>
+              </div>
             </div>
-            <div className="ppmmuted">
-              We recommend paying for expenses with your government travel card,
-              rather than getting an advance.{' '}
-              <a href="/unknown" className="Todo">
-                Why?
-              </a>
+            <div className="usa-width-one-third">
+              <Field name="has_requested_advance" component={YesNoBoolean} />
             </div>
           </div>
-          <div className="usa-width-one-third">
-            <Field name="has_requested_advance" component={YesNoBoolean} />
-          </div>
+          {this.state.showInfo && (
+            <div className="usa-width-one-whole top-buffered">
+              <Alert type="info" className="usa-width-one-whole" heading="">
+                Most of the time it is simpler for you to use your government
+                travel card for moving expenses rather than receiving a direct
+                deposit advance. Not only do you save the effort of filling out
+                the necessary forms to set up direct deposit, you eliminate any
+                chance that the Government may unexpectedly garnish a part of
+                your paycheck to recoup advance overages in the event that you
+                move less weight than you originally estimated or take longer
+                than 45 days to request payment upon arriving at your
+                destination. <a onClick={this.closeInfo}>Close</a>
+              </Alert>
+            </div>
+          )}
+          {hasRequestedAdvance && (
+            <div className="usa-width-one-whole top-buffered">
+              <Alert type="info" heading="">
+                We recommend that Service Families be cautious when requesting
+                an advance on PPM expenses. Because your final incentive is
+                affected by the amount of weight you actually move, if you
+                request a full advance and then move less weight than
+                anticipated, you may have to pay back some of your advance to
+                the military. If you would like to use a more specific move
+                calculator to estimate your anticipated shipment weight, you can
+                do that{' '}
+                <a href="https://www.move.mil/resources/weight-estimator">
+                  here
+                </a>.
+              </Alert>
+              <SwaggerField
+                fieldName="requested_amount"
+                swagger={schema.properties.advance}
+                title={requestedTitle(maxAdvance)}
+                required
+              />
+              <SwaggerField
+                fieldName="method_of_receipt"
+                swagger={schema.properties.advance}
+                title={methodTitle}
+                required
+              />
+            </div>
+          )}
         </div>
-        {hasRequestedAdvance && (
-          <div className="usa-width-one-whole top-buffered">
-            <Alert type="info" heading="">
-              We recommend that Service Families be cautious when requesting an
-              advance on PPM expenses. Because your final incentive is affected
-              by the amount of weight you actually move, if you request a full
-              advance and then move less weight than anticipated, you may have
-              to pay back some of your advance to the military. If you would
-              like to use a more specific move calculator to estimate your
-              anticipated shipment weight, you can do that{' '}
-              <a href="https://www.move.mil/resources/weight-estimator">here</a>.
-            </Alert>
-            <SwaggerField
-              fieldName="requested_amount"
-              swagger={schema.properties.advance}
-              title={requestedTitle(maxAdvance)}
-              required
-            />
-            <SwaggerField
-              fieldName="method_of_receipt"
-              swagger={schema.properties.advance}
-              title={methodTitle}
-              required
-            />
-          </div>
-        )}
       </div>
-    </div>
-  );
-};
+    );
+  }
+}
 
 const WeightWizardForm = reduxifyWizardForm(
   requestAdvanceFormName,


### PR DESCRIPTION
## Description

adds [help text](https://docs.google.com/spreadsheets/d/1aIgH4QB83deYJlbUQd-7fIRmobI5Qt3cjAxlhPOIlcg/edit#gid=0) to select a move type, PPM Dates and Locations, and PPM Customize Weight screens.
## Reviewer Notes

Per conversation with Jenny, we are using alerts for the items that do not open a new page. This will likely change in the future.

## Code Review Verification Steps

* [ ] All tests pass.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/blob/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* [ ] Any migrations/schema changes also update the diagram in docs/schema/dp3.sqs
* [ ] There are no aXe warnings for UI.
* [ ] This works in IE.
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @willowbl00
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Request review from a member of a different team.
* [ ] (TRIAL) Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/157666199) for this change

## Screenshots

![image](https://user-images.githubusercontent.com/3142631/40753778-db0ed2a2-6443-11e8-9eea-809a41854425.png)
![image](https://user-images.githubusercontent.com/3142631/40753791-e81320e8-6443-11e8-9b7d-f280d436d292.png)
![image](https://user-images.githubusercontent.com/3142631/40753807-f690cc06-6443-11e8-9eaf-a63273e8e481.png)
