### PR TITLE
Don't have edit profile think that the SM is ready for a move if they haven't any backup contacts

### DIFF
--- a/pkg/handlers/backup_contacts.go
+++ b/pkg/handlers/backup_contacts.go
@@ -63,7 +63,7 @@ func (h IndexBackupContactsHandler) Handle(params backupop.IndexServiceMemberBac
 		return responseForError(h.logger, err)
 	}
 
-	contacts := *serviceMember.BackupContacts
+	contacts := serviceMember.BackupContacts
 
 	contactPayloads := make(internalmessages.IndexServiceMemberBackupContactsPayload, len(contacts))
 	for i, contact := range contacts {

--- a/pkg/handlers/service_members.go
+++ b/pkg/handlers/service_members.go
@@ -21,14 +21,10 @@ func payloadForServiceMemberModel(storage FileStorer, serviceMember models.Servi
 		orders[i] = orderPayload
 	}
 
-	contactPayloads := make(internalmessages.IndexServiceMemberBackupContactsPayload, 0)
-	if serviceMember.BackupContacts != nil {
-		contacts := *serviceMember.BackupContacts
-		contactPayloads := make(internalmessages.IndexServiceMemberBackupContactsPayload, len(contacts))
-		for i, contact := range contacts {
-			contactPayload := payloadForBackupContactModel(contact)
-			contactPayloads[i] = &contactPayload
-		}
+	contactPayloads := make(internalmessages.IndexServiceMemberBackupContactsPayload, len(serviceMember.BackupContacts))
+	for i, contact := range serviceMember.BackupContacts {
+		contactPayload := payloadForBackupContactModel(contact)
+		contactPayloads[i] = &contactPayload
 	}
 
 	serviceMemberPayload := internalmessages.ServiceMemberPayload{

--- a/pkg/models/service_member.go
+++ b/pkg/models/service_member.go
@@ -40,7 +40,7 @@ type ServiceMember struct {
 	SocialSecurityNumberID *uuid.UUID                          `json:"social_security_number_id" db:"social_security_number_id"`
 	SocialSecurityNumber   *SocialSecurityNumber               `belongs_to:"address"`
 	Orders                 Orders                              `has_many:"orders" order_by:"created_at desc"`
-	BackupContacts         *BackupContacts                     `has_many:"backup_contacts"`
+	BackupContacts         BackupContacts                      `has_many:"backup_contacts"`
 	DutyStationID          *uuid.UUID                          `json:"duty_station_id" db:"duty_station_id"`
 	DutyStation            DutyStation                         `belongs_to:"duty_stations"`
 }
@@ -259,7 +259,7 @@ func (s *ServiceMember) IsProfileComplete() bool {
 	if s.DutyStationID == nil {
 		return false
 	}
-	if s.BackupContacts == nil || len(*s.BackupContacts) == 0 {
+	if len(s.BackupContacts) == 0 {
 		return false
 	}
 	// All required fields have a set value

--- a/pkg/models/service_member.go
+++ b/pkg/models/service_member.go
@@ -259,7 +259,7 @@ func (s *ServiceMember) IsProfileComplete() bool {
 	if s.DutyStationID == nil {
 		return false
 	}
-	if s.BackupContacts == nil {
+	if s.BackupContacts == nil || len(*s.BackupContacts) == 0 {
 		return false
 	}
 	// All required fields have a set value

--- a/pkg/models/service_member_test.go
+++ b/pkg/models/service_member_test.go
@@ -69,7 +69,7 @@ func (suite *ModelSuite) TestIsProfileCompleteWithIncompleteSM() {
 
 	var backupContacts BackupContacts
 	backupContacts = append(backupContacts, fakeBackupContact)
-	servicemember.BackupContacts = &backupContacts
+	servicemember.BackupContacts = backupContacts
 	// Then: IsProfileComplete should return true
 	if servicemember.IsProfileComplete() != true {
 		t.Error("Expected profile to be complete.")

--- a/src/scenes/MyMove/index.jsx
+++ b/src/scenes/MyMove/index.jsx
@@ -30,7 +30,6 @@ import AccessibilityStatement from 'shared/Statements/AccessibilityStatement';
 import { getWorkflowRoutes } from './getWorkflowRoutes';
 import { loadLoggedInUser } from 'shared/User/ducks';
 import { loadSchema } from 'shared/Swagger/ducks';
-import { indexBackupContacts } from 'scenes/ServiceMembers/ducks';
 import FailWhale from 'shared/FailWhale';
 import { no_op } from 'shared/utils';
 
@@ -48,12 +47,6 @@ export class AppWrapper extends Component {
     this.props.loadSchema();
   }
 
-  componentWillUpdate(newProps) {
-    //HACK: this is not loading properly in loadLoggedInUser
-    if (this.props.currentServiceMemberId !== newProps.currentServiceMemberId) {
-      this.props.indexBackupContacts(newProps.currentServiceMemberId);
-    }
-  }
   componentDidCatch(error, info) {
     this.setState({
       hasError: true,
@@ -152,9 +145,6 @@ const mapStateToProps = state => {
   };
 };
 const mapDispatchToProps = dispatch =>
-  bindActionCreators(
-    { push, loadSchema, loadLoggedInUser, indexBackupContacts },
-    dispatch,
-  );
+  bindActionCreators({ push, loadSchema, loadLoggedInUser }, dispatch);
 
 export default connect(mapStateToProps, mapDispatchToProps)(AppWrapper);

--- a/src/scenes/ServiceMembers/ducks.js
+++ b/src/scenes/ServiceMembers/ducks.js
@@ -1,4 +1,4 @@
-import { pick, without, cloneDeep } from 'lodash';
+import { pick, without, cloneDeep, get } from 'lodash';
 import {
   GetServiceMember,
   UpdateServiceMember,
@@ -107,7 +107,7 @@ const initialState = {
 };
 const reshape = sm => {
   if (!sm) return null;
-  return pick(sm, without(Object.keys(sm || {}), 'orders'));
+  return pick(sm, without(Object.keys(sm || {}), 'orders', 'backup_contacts'));
 };
 const upsertBackUpContact = (contact, state) => {
   const newState = cloneDeep(state);
@@ -119,6 +119,11 @@ export function serviceMemberReducer(state = initialState, action) {
     case GET_LOGGED_IN_USER.success:
       return Object.assign({}, state, {
         currentServiceMember: reshape(action.payload.service_member),
+        currentBackupContacts: get(
+          action,
+          'payload.service_member.backup_contacts',
+          [],
+        ),
         hasLoadError: false,
         hasLoadSuccess: true,
       });
@@ -164,6 +169,7 @@ export function serviceMemberReducer(state = initialState, action) {
     case GET_SERVICE_MEMBER.success:
       return Object.assign({}, state, {
         currentServiceMember: reshape(action.payload),
+        currentBackupContacts: action.payload.backup_contacts,
         hasSubmitSuccess: true,
         hasSubmitError: false,
       });

--- a/src/scenes/ServiceMembers/ducks.test.js
+++ b/src/scenes/ServiceMembers/ducks.test.js
@@ -13,10 +13,10 @@ import { get } from 'lodash';
 import loggedInUserPayload, {
   emptyPayload,
 } from 'shared/User/sampleLoggedInUserPayload';
+import sampleLoggedInUserPayload from '../../shared/User/sampleLoggedInUserPayload';
 const smPayload = { ...loggedInUserPayload.payload.service_member };
 const expectedSM = {
   affiliation: 'ARMY',
-  backup_contacts: [],
   backup_mailing_address: {
     city: 'Washington',
     postal_code: '20021',
@@ -60,6 +60,8 @@ const expectedSM = {
   updated_at: '2018-05-25T21:39:10.484Z',
   user_id: 'b46e651e-9d1c-4be5-bb88-bba58e817696',
 };
+const expectedBackupContacts =
+  loggedInUserPayload.payload.service_member.backup_contacts;
 describe('Service Member Reducer', () => {
   describe('GET_LOGGED_IN_USER', () => {
     it('should handle SUCCESS', () => {
@@ -67,6 +69,7 @@ describe('Service Member Reducer', () => {
       const newState = serviceMemberReducer({}, loggedInUserPayload);
       expect(newState).toEqual({
         currentServiceMember: { ...expectedSM },
+        currentBackupContacts: expectedBackupContacts,
         hasLoadError: false,
         hasLoadSuccess: true,
       });
@@ -76,6 +79,7 @@ describe('Service Member Reducer', () => {
       const newState = serviceMemberReducer({}, emptyPayload);
       expect(newState).toEqual({
         currentServiceMember: null,
+        currentBackupContacts: [],
         hasLoadError: false,
         hasLoadSuccess: true,
       });
@@ -124,6 +128,7 @@ describe('Service Member Reducer', () => {
 
       expect(newState).toEqual({
         currentServiceMember: expectedSM,
+        currentBackupContacts: expectedBackupContacts,
         hasSubmitError: false,
         hasSubmitSuccess: true,
       });

--- a/src/shared/User/sampleLoggedInUserPayload.js
+++ b/src/shared/User/sampleLoggedInUserPayload.js
@@ -13,7 +13,16 @@ export default {
     id: 'b46e651e-9d1c-4be5-bb88-bba58e817696',
     service_member: {
       affiliation: 'ARMY',
-      backup_contacts: [],
+      backup_contacts: [
+        {
+          createdAt: '2018-05-31T00:02:57.302Z',
+          email: 'foo@bar.com',
+          id: '03b2979d-8046-437b-a6e4-11dbe251a912',
+          name: 'Foo',
+          permission: 'NONE',
+          updated_at: '2018-05-31T00:02:57.302Z',
+        },
+      ],
       backup_mailing_address: {
         city: 'Washington',
         postal_code: '20021',


### PR DESCRIPTION
## Description

is_profile_complete was returning true when backup_contacts were empty. This checks that case. 

## Code Review Verification Steps

* [ ] All tests pass.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/blob/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* [ ] Any migrations/schema changes also update the diagram in docs/schema/dp3.sqs
* [ ] There are no aXe warnings for UI.
* [ ] This works in IE.
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @willowbl00
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Request review from a member of a different team.
* [ ] (TRIAL) Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/157863693) for this change
