### PR TITLE
Fix Office Login for old accounts

### DIFF
--- a/pkg/auth/authentication/auth.go
+++ b/pkg/auth/authentication/auth.go
@@ -226,10 +226,8 @@ func (h CallbackHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		session.Middle = userIdentity.Middle()
 
 	} else if err == models.ErrFetchNotFound { // Never heard of them so far
-		user, err := models.CreateUser(h.db, openIDUser.UserID, openIDUser.Email)
 
 		var officeUser *models.OfficeUser
-
 		if session.IsOfficeApp() { // Look to see if we have OfficeUser with this email address
 			officeUser, err = models.FetchOfficeUserByEmail(h.db, session.Email)
 			if err == models.ErrFetchNotFound {
@@ -243,6 +241,7 @@ func (h CallbackHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 
+		user, err := models.CreateUser(h.db, openIDUser.UserID, openIDUser.Email)
 		if err == nil { // Successfully created the user
 			session.UserID = user.ID
 			if officeUser != nil {


### PR DESCRIPTION
## Description

Normally we create an `office_users` record before someone is allowed to login to the office.move.mil app. Only once that record is verified should an associated `users` entry be created and the two linked together.

However, in the current staging (and presumably prod) databases truss folks logged in before we were checking `office_users`. This means that there are existing `users` records in the DB without a link to the newly created `office_users` records.

This change makes sure that the two records get hooked up.

## Reviewer Notes

I have tested this locally by manually creating the records in the state described above. Unfortunately the way the code is currently structured means that it is nigh on impossible to write a unite test for the Authentication Callback handler as it calls out to login.gov.

This handler should be refactored (at a less harried time) to compartmentalize the logic here and make it testable.

## Code Review Verification Steps

* [ ] All tests pass.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/blob/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* [ ] Any migrations/schema changes also update the diagram in docs/schema/dp3.sqs
* [ ] There are no aXe warnings for UI.
* [ ] This works in IE.
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @willowbl00
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Request review from a member of a different team.
* [ ] (TRIAL) Have the Pivotal acceptance criteria been met for this change?
