### PR TITLE
add banners to edit page

### DIFF
--- a/src/appReducer.js
+++ b/src/appReducer.js
@@ -15,6 +15,7 @@ import issuesReducer from 'scenes/SubmittedFeedback/ducks';
 import { shipmentsReducer } from 'scenes/Shipments/ducks';
 import { signedCertificationReducer } from 'scenes/Legalese/ducks';
 import { documentReducer } from 'shared/Uploader/ducks';
+import { reviewReducer } from 'scenes/Review/ducks';
 import transportationOfficeReducer from 'shared/TransportationOffices/ducks';
 import { officeReducer } from 'scenes/Office/ducks';
 
@@ -33,6 +34,7 @@ export const appReducer = combineReducers({
   feedback: feedbackReducer,
   signedCertification: signedCertificationReducer,
   upload: documentReducer,
+  review: reviewReducer,
   office: officeReducer,
   transportationOffices: transportationOfficeReducer,
 });

--- a/src/scenes/Review/EditBackupContact.jsx
+++ b/src/scenes/Review/EditBackupContact.jsx
@@ -13,6 +13,7 @@ import { updateBackupContact } from 'scenes/ServiceMembers/ducks';
 import SaveCancelButtons from './SaveCancelButtons';
 import './Review.css';
 import profileImage from './images/profile.png';
+import { editBegin, editSuccessful } from './ducks';
 
 const editBackupContactFormName = 'edit_backup_contact';
 
@@ -36,6 +37,7 @@ EditBackupContactForm = reduxForm({
 
 class EditBackupContact extends Component {
   componentDidMount() {
+    this.props.editBegin();
     window.scrollTo(0, 0);
   }
 
@@ -48,6 +50,7 @@ class EditBackupContact extends Component {
       .then(() => {
         // This promise resolves regardless of error.
         if (!this.props.hasSubmitError) {
+          this.props.editSuccessful();
           this.props.history.goBack();
         } else {
           window.scrollTo(0, 0);
@@ -100,7 +103,10 @@ function mapStateToProps(state) {
 }
 
 function mapDispatchToProps(dispatch) {
-  return bindActionCreators({ push, updateBackupContact }, dispatch);
+  return bindActionCreators(
+    { push, updateBackupContact, editBegin, editSuccessful },
+    dispatch,
+  );
 }
 
 export default connect(mapStateToProps, mapDispatchToProps)(EditBackupContact);

--- a/src/scenes/Review/EditContactInfo.jsx
+++ b/src/scenes/Review/EditContactInfo.jsx
@@ -10,6 +10,7 @@ import Alert from 'shared/Alert'; // eslint-disable-line
 import { SwaggerField } from 'shared/JsonSchemaForm/JsonSchemaField';
 import { updateServiceMember } from 'scenes/ServiceMembers/ducks';
 
+import { editBegin, editSuccessful } from './ducks';
 import 'scenes/ServiceMembers/ServiceMembers.css';
 import './Review.css';
 import SaveCancelButtons from './SaveCancelButtons';
@@ -140,12 +141,18 @@ class EditContact extends Component {
     return this.props.updateServiceMember(serviceMember).then(() => {
       // This promise resolves regardless of error.
       if (!this.props.hasSubmitError) {
+        this.props.editSuccessful();
         this.props.history.goBack();
       } else {
         window.scrollTo(0, 0);
       }
     });
   };
+
+  componentDidMount() {
+    this.props.editBegin();
+  }
+
   render() {
     const {
       error,
@@ -202,7 +209,10 @@ function mapStateToProps(state) {
 }
 
 function mapDispatchToProps(dispatch) {
-  return bindActionCreators({ push, updateServiceMember }, dispatch);
+  return bindActionCreators(
+    { push, updateServiceMember, editBegin, editSuccessful },
+    dispatch,
+  );
 }
 
 export default connect(mapStateToProps, mapDispatchToProps)(EditContact);

--- a/src/scenes/Review/EditDateAndLocation.jsx
+++ b/src/scenes/Review/EditDateAndLocation.jsx
@@ -13,6 +13,7 @@ import { bindActionCreators } from 'redux';
 import { createOrUpdatePpm, getPpmSitEstimate } from 'scenes/Moves/Ppm/ducks';
 import { loadEntitlements } from 'scenes/Orders/ducks';
 import 'scenes/Moves/Ppm/DateAndLocation.css';
+import { editBegin, editSuccessful } from './ducks';
 
 const sitEstimateDebounceTime = 300;
 
@@ -131,6 +132,7 @@ class EditDateAndLocation extends Component {
       return this.props.createOrUpdatePpm(moveId, pendingValues).then(() => {
         // This promise resolves regardless of error.
         if (!this.props.hasSubmitError) {
+          this.props.editSuccessful();
           this.props.history.goBack();
         } else {
           window.scrollTo(0, 0);
@@ -168,6 +170,11 @@ class EditDateAndLocation extends Component {
       entitlement.sum,
     );
   };
+
+  componentDidMount() {
+    this.props.editBegin();
+  }
+
   render() {
     const {
       initialValues,
@@ -240,7 +247,7 @@ function mapStateToProps(state) {
 }
 function mapDispatchToProps(dispatch) {
   return bindActionCreators(
-    { push, createOrUpdatePpm, getPpmSitEstimate },
+    { push, createOrUpdatePpm, getPpmSitEstimate, editBegin, editSuccessful },
     dispatch,
   );
 }

--- a/src/scenes/Review/EditOrders.jsx
+++ b/src/scenes/Review/EditOrders.jsx
@@ -15,6 +15,7 @@ import UploadsTable from 'shared/Uploader/UploadsTable';
 import SaveCancelButtons from './SaveCancelButtons';
 import { updateOrders, deleteUploads, addUploads } from 'scenes/Orders/ducks';
 import { moveIsApproved } from 'scenes/Moves/ducks';
+import { editBegin, editSuccessful } from './ducks';
 
 import './Review.css';
 import profileImage from './images/profile.png';
@@ -111,12 +112,17 @@ class EditOrders extends Component {
       .then(() => {
         // This promise resolves regardless of error.
         if (!this.props.hasSubmitError) {
+          this.props.editSuccessful();
           this.props.history.goBack();
         } else {
           window.scrollTo(0, 0);
         }
       });
   };
+
+  componentDidMount() {
+    this.props.editBegin();
+  }
 
   render() {
     const {
@@ -187,6 +193,8 @@ function mapDispatchToProps(dispatch) {
       updateOrders,
       addUploads,
       deleteUploads,
+      editBegin,
+      editSuccessful,
     },
     dispatch,
   );

--- a/src/scenes/Review/EditProfile.jsx
+++ b/src/scenes/Review/EditProfile.jsx
@@ -13,6 +13,7 @@ import SaveCancelButtons from './SaveCancelButtons';
 import { updateServiceMember } from 'scenes/ServiceMembers/ducks';
 import { moveIsApproved } from 'scenes/Moves/ducks';
 import DutyStationSearchBox from 'scenes/ServiceMembers/DutyStationSearchBox';
+import { editBegin, editSuccessful } from './ducks';
 
 import './Review.css';
 import profileImage from './images/profile.png';
@@ -81,12 +82,17 @@ class EditProfile extends Component {
     return this.props.updateServiceMember(fieldValues).then(() => {
       // This promise resolves regardless of error.
       if (!this.props.hasSubmitError) {
+        this.props.editSuccessful();
         this.props.history.goBack();
       } else {
         window.scrollTo(0, 0);
       }
     });
   };
+
+  componentDidMount() {
+    this.props.editBegin();
+  }
 
   render() {
     const {
@@ -141,7 +147,10 @@ function mapStateToProps(state) {
 }
 
 function mapDispatchToProps(dispatch) {
-  return bindActionCreators({ push, updateServiceMember }, dispatch);
+  return bindActionCreators(
+    { push, updateServiceMember, editBegin, editSuccessful },
+    dispatch,
+  );
 }
 
 export default connect(mapStateToProps, mapDispatchToProps)(EditProfile);

--- a/src/scenes/Review/EditWeight.jsx
+++ b/src/scenes/Review/EditWeight.jsx
@@ -14,6 +14,7 @@ import {
   getPpmWeightEstimate,
 } from 'scenes/Moves/Ppm/ducks';
 import { loadEntitlements } from 'scenes/Orders/ducks';
+import { editBegin, editSuccessful } from './ducks';
 
 import './Review.css';
 import './EditWeight.css';
@@ -190,6 +191,7 @@ EditWeightForm = reduxForm({
 
 class EditWeight extends Component {
   componentDidMount() {
+    this.props.editBegin();
     window.scrollTo(0, 0);
   }
 
@@ -222,6 +224,7 @@ class EditWeight extends Component {
       .then(() => {
         // This promise resolves regardless of error.
         if (!this.props.hasSubmitError) {
+          this.props.editSuccessful();
           this.props.history.goBack();
         } else {
           window.scrollTo(0, 0);
@@ -272,7 +275,13 @@ function mapStateToProps(state) {
 
 function mapDispatchToProps(dispatch) {
   return bindActionCreators(
-    { push, createOrUpdatePpm, getPpmWeightEstimate },
+    {
+      push,
+      createOrUpdatePpm,
+      getPpmWeightEstimate,
+      editBegin,
+      editSuccessful,
+    },
     dispatch,
   );
 }

--- a/src/scenes/Review/Summary.jsx
+++ b/src/scenes/Review/Summary.jsx
@@ -7,6 +7,7 @@ import { withRouter } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import ppmBlack from 'shared/icon/ppm-black.svg';
 import { moveIsApproved } from 'scenes/Moves/ducks';
+import Alert from 'shared/Alert';
 import './Review.css';
 export class Summary extends Component {
   render() {
@@ -91,6 +92,11 @@ export class Summary extends Component {
       : 'Not requested';
     return (
       <Fragment>
+        {this.props.reviewState.editSuccess && (
+          <Alert type="success" heading="Success">
+            Your changes have been saved.
+          </Alert>
+        )}
         <h3>Profile and Orders</h3>
         <div className="usa-grid-full review-content">
           <div className="usa-width-one-half review-section">
@@ -365,6 +371,7 @@ function mapStateToProps(state) {
     schemaOrdersType: get(state, 'swagger.spec.definitions.OrdersType', {}),
     schemaAffiliation: get(state, 'swagger.spec.definitions.Affiliation', {}),
     moveIsApproved: moveIsApproved(state),
+    reviewState: state.review,
   };
 }
 export default withRouter(connect(mapStateToProps)(Summary));

--- a/src/scenes/Review/ducks.js
+++ b/src/scenes/Review/ducks.js
@@ -1,0 +1,30 @@
+const editBeginType = 'EDIT_BEGIN';
+
+export function editBegin() {
+  return function(dispatch, getState) {
+    dispatch({ type: editBeginType });
+  };
+}
+
+const editSuccessfulType = 'EDIT_SUCCESS';
+
+export function editSuccessful() {
+  return function(dispatch, getState) {
+    dispatch({ type: editSuccessfulType });
+  };
+}
+
+export function reviewReducer(state = {}, action) {
+  switch (action.type) {
+    case editBeginType:
+      return Object.assign({}, state, {
+        editSuccess: false,
+      });
+    case editSuccessfulType:
+      return Object.assign({}, state, {
+        editSuccess: true,
+      });
+    default:
+      return state;
+  }
+}


### PR DESCRIPTION
## Description

Edit profile now triggers banners on the main page.

## Reviewer Notes

How are we going to trigger re-calculating the estimate? seems like it should probably be a server-side action when you update one of the fields it depends on , but right now I think that is all client side. 

## Code Review Verification Steps

* [ ] All tests pass.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/blob/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* [ ] Any migrations/schema changes also update the diagram in docs/schema/dp3.sqs
* [ ] There are no aXe warnings for UI.
* [ ] This works in IE.
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @willowbl00
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Request review from a member of a different team.
* [ ] (TRIAL) Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/157748476) for this change

## Screenshots

<img width="822" alt="screen shot 2018-05-31 at 12 57 23 am" src="https://user-images.githubusercontent.com/55759/40769740-9adb0366-646d-11e8-8bc1-1a473df448d0.png">
