### PR TITLE
Use get to handle data that hasn't loaded yet [delivers #157991172]

### DIFF
--- a/src/scenes/Office/PPMEstimatesPanel.jsx
+++ b/src/scenes/Office/PPMEstimatesPanel.jsx
@@ -87,8 +87,8 @@ function mapStateToProps(state) {
       'swagger.spec.definitions.PersonallyProcuredMovePayload',
     ),
     hasError: false,
-    errorMessage: state.office.error,
-    PPMEstimate: state.office.officePPMs[0], // unsure about this
+    errorMessage: get(state, 'office.error'),
+    PPMEstimate: get(state, 'office.officePPMs[0]', {}),
     isUpdating: false,
   };
 }


### PR DESCRIPTION
## Description

This PR fixes a bug that is breaking staging currently. We were calling `state.office.officePPMs[0]` instead of using `get` to dig into `state`.

## Code Review Verification Steps

* [ ] All tests pass.

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/157991172) for this change