### PR TITLE
don't log /health requests

### DIFF
--- a/cmd/webserver/main.go
+++ b/cmd/webserver/main.go
@@ -210,7 +210,6 @@ func main() {
 	// are added, but the resulting http.Handlers execute in "normal" order
 	// (i.e., the http.Handler returned by the first Middleware added gets
 	// called first).
-	site.Use(logging.LogRequestMiddleware)
 	site.Use(httpsComplianceMiddleware)
 	site.Use(limitBodySizeMiddleware)
 
@@ -220,6 +219,7 @@ func main() {
 	root := goji.NewMux()
 	root.Use(sessionCookieMiddleware)
 	root.Use(appDetectionMiddleware) // Comes after the sessionCookieMiddleware as it sets session state
+	root.Use(logging.LogRequestMiddleware)
 	site.Handle(pat.New("/*"), root)
 
 	apiMux := goji.SubMux()


### PR DESCRIPTION
Don't log `/health` requests to remove some of the noise. All other requests logs will be unchanged.



