### PR TITLE
hide editable content on estimates panel

### DIFF
--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -48,7 +48,11 @@ const PPMTabContent = props => {
   return (
     <React.Fragment>
       <PaymentsPanel title="Payments" moveId={props.match.params.moveId} />
-      <PPMEstimatesPanel title="Estimate" moveId={props.match.params.moveId} />
+      <PPMEstimatesPanel
+        className="disable-edit"
+        title="Estimate"
+        moveId={props.match.params.moveId}
+      />
     </React.Fragment>
   );
 };

--- a/src/scenes/Office/editablePanel.jsx
+++ b/src/scenes/Office/editablePanel.jsx
@@ -40,6 +40,7 @@ export default function editablePanel(DisplayComponent, EditComponent) {
           )}
           <EditablePanel
             title={this.props.title}
+            className={this.props.className}
             onSave={this.save}
             onToggle={this.toggleEditable}
             isEditable={isEditable}

--- a/src/scenes/Office/office.css
+++ b/src/scenes/Office/office.css
@@ -223,11 +223,13 @@ head .panel-subhead {
   display: none;
 }
 
+/*PPM PAYMENT PANEL*/
 .payment-panel {
   border: solid #f1f1f1;
   border-width: 3px;
   width: 100%;
   empty-cells: hide;
+  margin-bottom: 18px;
 }
 
 .payment-table {
@@ -277,6 +279,25 @@ head .panel-subhead {
   position: relative;
 }
 
+.approval-ready {
+  color: green;
+  cursor: pointer;
+}
+
+.approval-waiting {
+  color: #fdb81e;
+}
+
+.approval-blocked {
+  color: gray;
+}
+
+.payment-action {
+  color: #0071bc;
+  cursor: pointer;
+}
+
+/*TOOLTIP*/
 .tooltip .tooltiptext {
     visibility: hidden;
     width: 200px;
@@ -304,22 +325,4 @@ head .panel-subhead {
 
 .tooltip:hover .tooltiptext {
   visibility: visible;
-}
-
-.approval-ready {
-  color: green;
-  cursor: pointer;
-}
-
-.approval-waiting {
-  color: #fdb81e;
-}
-
-.approval-blocked {
-  color: gray;
-}
-
-.payment-action {
-  color: #0071bc;
-  cursor: pointer;
 }

--- a/src/shared/EditablePanel/index.css
+++ b/src/shared/EditablePanel/index.css
@@ -125,3 +125,7 @@
   margin-top: 3rem;
   display: block;
 }
+
+.disable-edit .editable-panel-edit {
+  display: none;
+}


### PR DESCRIPTION
## Description

Removes editability of PPM Estimates panel.


## Code Review Verification Steps

* [ ] All tests pass.
* [ ] There are no aXe warnings for UI.
* [ ] This works in IE.
* [ ] Request review from a member of a different team.
* [ ] (TRIAL) Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/157985485) for this change
<img width="1014" alt="screen shot 2018-05-31 at 10 37 54 am" src="https://user-images.githubusercontent.com/7401870/40797993-c70da2c6-64be-11e8-81a5-c8e069bcb1c9.png">
