### PR TITLE
els fix behavior on completion of sm flow  [delivers #158010313]

### DIFF
--- a/src/scenes/Landing/index.jsx
+++ b/src/scenes/Landing/index.jsx
@@ -28,7 +28,6 @@ export class Landing extends Component {
       isProfileComplete,
     } = this.props;
     if (loggedInUserSuccess) {
-      console.log(this.props);
       if (!createdServiceMemberIsLoading && isEmpty(serviceMember)) {
         // Once the logged in user loads, if the service member doesn't
         // exist we need to dispatch creating one, once.

--- a/src/scenes/MyMove/getWorkflowRoutes.jsx
+++ b/src/scenes/MyMove/getWorkflowRoutes.jsx
@@ -128,10 +128,8 @@ const pages = {
   },
   '/service-member/:serviceMemberId/backup-contacts': {
     isInFlow: always,
-    isComplete: sm => {
-      return (
-        sm.is_profile_complete || get(sm, 'backup_contacts', []).length > 0
-      );
+    isComplete: (sm, orders, move, ppm, backup_contacts) => {
+      return sm.is_profile_complete || backup_contacts.length > 0;
     },
     render: (key, pages) => ({ match }) => (
       <BackupContact pages={pages} pageKey={key} match={match} />
@@ -271,10 +269,11 @@ export const getNextIncompletePage = (
   orders = {},
   move = {},
   ppm = {},
+  backupContacts = [],
 ) => {
   const rawPath = findKey(
     pages,
-    p => !p.isComplete(service_member, orders, move, ppm),
+    p => !p.isComplete(service_member, orders, move, ppm, backupContacts),
   );
   const compiledPath = generatePath(rawPath, {
     serviceMemberId: get(service_member, 'id'),

--- a/src/scenes/MyMove/getWorkflowRoutes.test.js
+++ b/src/scenes/MyMove/getWorkflowRoutes.test.js
@@ -339,6 +339,57 @@ describe('when getting the next incomplete page', () => {
         expect(result).toEqual('/service-member/foo/backup-contacts');
       });
     });
+    describe('when backup contacts is complete', () => {
+      it('returns the order transition page', () => {
+        const backupContacts = [
+          {
+            createdAt: '2018-05-31T00:02:57.302Z',
+            email: 'foo@bar.com',
+            id: '03b2979d-8046-437b-a6e4-11dbe251a912',
+            name: 'Foo',
+            permission: 'NONE',
+            updated_at: '2018-05-31T00:02:57.302Z',
+          },
+        ];
+        const sm = {
+          ...service_member,
+          is_profile_complete: false,
+          edipi: '1234567890',
+          has_social_security_number: true,
+          rank: 'E_6',
+          affiliation: 'Marines',
+          last_name: 'foo',
+          first_name: 'foo',
+          phone_is_preferred: true,
+          telephone: '666-666-6666',
+          personal_email: 'foo@bar.com',
+          current_station: {
+            id: '5e30f356-e590-4372-b9c0-30c3fd1ff42d',
+            name: 'Blue Grass Army Depot',
+          },
+          residential_address: {
+            city: 'Atlanta',
+            postal_code: '30030',
+            state: 'GA',
+            street_address_1: 'xxx',
+          },
+          backup_mailing_address: {
+            city: 'Atlanta',
+            postal_code: '30030',
+            state: 'GA',
+            street_address_1: 'zzz',
+          },
+        };
+        const result = getNextIncompletePage(
+          sm,
+          undefined,
+          undefined,
+          undefined,
+          backupContacts,
+        );
+        expect(result).toEqual('/orders/');
+      });
+    });
   });
   describe('when the profile is complete', () => {
     // service_member.is_profile_complete = true;

--- a/src/scenes/ServiceMembers/ducks.js
+++ b/src/scenes/ServiceMembers/ducks.js
@@ -1,4 +1,6 @@
-import { pick, without, cloneDeep, get } from 'lodash';
+import { pick, without, cloneDeep, get, every } from 'lodash';
+import { NULL_UUID } from 'shared/constants';
+
 import {
   GetServiceMember,
   UpdateServiceMember,
@@ -96,6 +98,23 @@ export function loadServiceMember(serviceMemberId) {
   };
 }
 
+//this is similar to go service_member.IsProfileComplete and we should figure out how to use just one if possible
+export const isProfileComplete = state => {
+  const sm = get(state, 'serviceMember.currentServiceMember') || {};
+  return every([
+    sm.rank,
+    sm.edipi,
+    sm.affiliation,
+    sm.first_name,
+    sm.last_name,
+    sm.telephone,
+    sm.personal_email,
+    get(sm, 'current_station.id', NULL_UUID) !== NULL_UUID,
+    get(sm, 'residential_address.postal_code'),
+    get(sm, 'backup_mailing_address.postal_code'),
+    get(state, 'serviceMember.currentBackupContacts', []).length > 0,
+  ]);
+};
 // Reducer
 const initialState = {
   currentServiceMember: null,

--- a/src/scenes/ServiceMembers/ducks.test.js
+++ b/src/scenes/ServiceMembers/ducks.test.js
@@ -5,6 +5,7 @@ import {
   CREATE_BACKUP_CONTACT,
   UPDATE_BACKUP_CONTACT,
   INDEX_BACKUP_CONTACTS,
+  isProfileComplete,
   serviceMemberReducer,
 } from './ducks';
 
@@ -296,6 +297,31 @@ describe('Service Member Reducer', () => {
         indexBackupContactsSuccess: false,
         error: 'No bueno.',
       });
+    });
+  });
+});
+
+describe('isProfileComplete', () => {
+  describe('given a state with empty currentBackupContacts', () => {
+    const state = {
+      serviceMember: {
+        currentServiceMember: expectedSM,
+        currentBackupContacts: [],
+      },
+    };
+    it('isProfileComplete should return false', () => {
+      expect(isProfileComplete(state)).toBe(false);
+    });
+  });
+  describe('given a state with some currentBackupContacts', () => {
+    const state = {
+      serviceMember: {
+        currentServiceMember: expectedSM,
+        currentBackupContacts: ['something'],
+      },
+    };
+    it('isProfileComplete should return true', () => {
+      expect(isProfileComplete(state)).toBe(true);
     });
   });
 });


### PR DESCRIPTION


## Description
 correctly detect that service member profile is complete when backup contacts are added
## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Code Review Verification Steps

* [ ] All tests pass.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/blob/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* [ ] Any migrations/schema changes also update the diagram in docs/schema/dp3.sqs
* [ ] There are no aXe warnings for UI.
* [ ] This works in IE.
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @willowbl00
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Request review from a member of a different team.
* [ ] (TRIAL) Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](tbd) for this change
* [this article](tbd) explains more about the approach used.

## Screenshots

If this PR makes visible UI changes, an image of the finished UI can help reviewers and casual
observers understand the context of the changes. A before image is optional and
can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow instead of using multiple images. You may want to use GIPHY CAPTURE for this! 📸

_Please frame screenshots to show enough useful context but also highlight the affected regions._
