### PR TITLE
make panel fontsize consistent

### DIFF
--- a/src/scenes/Office/office.css
+++ b/src/scenes/Office/office.css
@@ -246,7 +246,7 @@ head .panel-subhead {
 }
 
 .payment-table .icon {
-  margin-left: 1.5em;
+  margin: 0 .7em 0 .7em;
   font-size: 1.7rem;
   vertical-align: baseline;
 }
@@ -271,10 +271,10 @@ head .panel-subhead {
   font-weight: bold;
   font-size: 0.9em;
   border-bottom: solid 1px #f1f1f1;
-  width: 90%;
 }
 
 .payment-table .payment-table-column-content {
+  font-size: 0.8em;
   border-bottom: solid 1px #f1f1f1;
   position: relative;
 }


### PR DESCRIPTION
## Description

Just makes all the panels have the same fontsize in display mode. Previously the Payment panel was bigger.

