### PR TITLE
els max estimate fails gracefully [delivers #157889686]

### DIFF
--- a/src/scenes/Moves/Ppm/ducks.js
+++ b/src/scenes/Moves/Ppm/ducks.js
@@ -266,15 +266,16 @@ export function ppmReducer(state = initialState, action) {
         hasMaxEstimateSuccess: true,
         hasMaxEstimateError: false,
         hasMaxEstimateInProgress: false,
-        error: null,
+        rateEngineError: null,
       });
     case GET_PPM_MAX_ESTIMATE.failure:
       return Object.assign({}, state, {
-        incentive: null,
+        maxIncentive: null,
         hasMaxEstimateSuccess: false,
         hasMaxEstimateError: true,
         hasMaxEstimateInProgress: false,
-        error: action.error,
+        rateEngineError: action.error,
+        error: null,
       });
     case GET_SIT_ESTIMATE.start:
       return Object.assign({}, state, {

--- a/src/scenes/Moves/Ppm/ducks.test.js
+++ b/src/scenes/Moves/Ppm/ducks.test.js
@@ -3,6 +3,7 @@ import {
   GET_PPM,
   GET_SIT_ESTIMATE,
   GET_PPM_ESTIMATE,
+  GET_PPM_MAX_ESTIMATE,
   ppmReducer,
 } from './ducks';
 import loggedInUserPayload, {
@@ -209,6 +210,43 @@ describe('Ppm Reducer', () => {
         pendingValue: '',
         rateEngineError: 'No bueno.',
         incentive: null,
+        error: null,
+      });
+    });
+  });
+
+  describe('GET_PPM_MAX_ESTIMATE', () => {
+    it('Should handle SUCCESS', () => {
+      const initialState = {};
+      const newState = ppmReducer(initialState, {
+        type: GET_PPM_MAX_ESTIMATE.success,
+        payload: { range_min: 21505, range_max: 44403 },
+      });
+
+      expect(newState).toEqual({
+        maxIncentive: 266.41799999999995,
+        hasMaxEstimateSuccess: true,
+        hasMaxEstimateError: false,
+        hasMaxEstimateInProgress: false,
+        rateEngineError: null,
+      });
+    });
+
+    it('Should handle FAILURE', () => {
+      const initialState = { pendingValue: '' };
+
+      const newState = ppmReducer(initialState, {
+        type: GET_PPM_MAX_ESTIMATE.failure,
+        error: 'No bueno.',
+      });
+      // using special error here so it is not caught by WizardPage handling
+      expect(newState).toEqual({
+        hasMaxEstimateError: true,
+        hasMaxEstimateInProgress: false,
+        hasMaxEstimateSuccess: false,
+        pendingValue: '',
+        rateEngineError: 'No bueno.',
+        maxIncentive: null,
         error: null,
       });
     });


### PR DESCRIPTION
## Description

no more errors on the weight screen when there are issues getting estimates from the rate engine

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Code Review Verification Steps

* [ ] All tests pass.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/blob/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* [ ] Any migrations/schema changes also update the diagram in docs/schema/dp3.sqs
* [ ] There are no aXe warnings for UI.
* [ ] This works in IE.
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @willowbl00
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Request review from a member of a different team.
* [ ] (TRIAL) Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](tbd) for this change
* [this article](tbd) explains more about the approach used.

## Screenshots

If this PR makes visible UI changes, an image of the finished UI can help reviewers and casual
observers understand the context of the changes. A before image is optional and
can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow instead of using multiple images. You may want to use GIPHY CAPTURE for this! 📸

_Please frame screenshots to show enough useful context but also highlight the affected regions._
