### PR TITLE
rm troubleshoot/cancel buttons until features exist

### DIFF
--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -225,8 +225,9 @@ class MoveInfo extends Component {
                 Approve PPM
                 {ppm.status === 'APPROVED' && check}
               </button>
+              {/* Disabling until features implemented
               <button>Troubleshoot</button>
-              <button>Cancel Move</button>
+              <button>Cancel Move</button> */}
             </div>
             <div className="documents">
               <h2 className="usa-heading">


### PR DESCRIPTION
## Description

Removes troubleshoot/cancel buttons from the MoveInfo pages.

## Code Review Verification Steps

* [x] All tests pass.
* [x] There are no aXe warnings for UI.
* [x] This works in IE.
* [x] Request review from a member of a different team.
* [x] (TRIAL) Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/158018682) for this change

## Screenshots

<img width="472" alt="screen shot 2018-05-31 at 5 15 14 pm" src="https://user-images.githubusercontent.com/7401870/40814638-3566e5d4-64f6-11e8-899e-a213d4ba7ac5.png">
