### PR TITLE
Add logging to HERE errors

### DIFF
--- a/pkg/route/here_planner.go
+++ b/pkg/route/here_planner.go
@@ -3,6 +3,7 @@ package route
 import (
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"time"
 
@@ -75,7 +76,12 @@ func (p *herePlanner) getAddressLatLong(responses chan addressLatLong, address *
 		p.logger.Error("Getting response from HERE.", zap.Error(err), zap.Object("address", address))
 		latLongResponse.err = errors.Wrap(err, "calling HERE")
 	} else if resp.StatusCode != 200 {
-		p.logger.Info("Got non-200 response from HERE.", zap.Int("http_status", resp.StatusCode), zap.Object("address", address))
+		bodyBytes, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			p.logger.Info("Got non-200 response from HERE. Unable to read response body.", zap.Int("http_status", resp.StatusCode), zap.Object("address", address))
+			latLongResponse.err = errors.Wrap(err, "non-200 HERE Response")
+		}
+		p.logger.Info("Got non-200 response from HERE routing.", zap.Int("http_status", resp.StatusCode), zap.String("here_error", string(bodyBytes)), zap.Object("address", address))
 		latLongResponse.err = errors.New("error response from HERE")
 	} else {
 		// Decode Json response and check structure
@@ -133,7 +139,12 @@ func (p *herePlanner) LatLongTransitDistance(source LatLong, dest LatLong) (int,
 		p.logger.Error("Getting route response from HERE.", zap.Error(err))
 		return 0, errors.Wrap(err, "calling HERE routing")
 	} else if resp.StatusCode != 200 {
-		p.logger.Info("Got non-200 response from HERE routing.", zap.Int("http_status", resp.StatusCode))
+		bodyBytes, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			p.logger.Info("Got non-200 response from HERE. Unable to read response body.", zap.Int("http_status", resp.StatusCode))
+			return 0, errors.Wrap(err, "bad Here response, bad body read")
+		}
+		p.logger.Info("Got non-200 response from HERE routing.", zap.Int("http_status", resp.StatusCode), zap.String("here_error", string(bodyBytes)))
 		return 0, errors.New("error response from HERE")
 	} else {
 		routeDecoder := json.NewDecoder(resp.Body)

--- a/pkg/route/here_planner.go
+++ b/pkg/route/here_planner.go
@@ -80,9 +80,10 @@ func (p *herePlanner) getAddressLatLong(responses chan addressLatLong, address *
 		if err != nil {
 			p.logger.Info("Got non-200 response from HERE. Unable to read response body.", zap.Int("http_status", resp.StatusCode), zap.Object("address", address))
 			latLongResponse.err = errors.Wrap(err, "non-200 HERE Response")
+		} else {
+			p.logger.Info("Got non-200 response from HERE routing.", zap.Int("http_status", resp.StatusCode), zap.String("here_error", string(bodyBytes)), zap.Object("address", address))
+			latLongResponse.err = errors.New("error response from HERE")
 		}
-		p.logger.Info("Got non-200 response from HERE routing.", zap.Int("http_status", resp.StatusCode), zap.String("here_error", string(bodyBytes)), zap.Object("address", address))
-		latLongResponse.err = errors.New("error response from HERE")
 	} else {
 		// Decode Json response and check structure
 		locationDecoder := json.NewDecoder(resp.Body)


### PR DESCRIPTION
## Description

Just adds some logging of the actual here errors rather than just the error code. 

## Code Review Verification Steps

* [ ] All tests pass.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/blob/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* [ ] Any migrations/schema changes also update the diagram in docs/schema/dp3.sqs
* [ ] There are no aXe warnings for UI.
* [ ] This works in IE.
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @willowbl00
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Request review from a member of a different team.
* [ ] (TRIAL) Have the Pivotal acceptance criteria been met for this change?
