### PR TITLE
ELS entitlement sum should respect has_dependents [delivers #158037392]

### DIFF
--- a/src/scenes/EntitlementBar/index.css
+++ b/src/scenes/EntitlementBar/index.css
@@ -1,0 +1,9 @@
+.entitlement-container {
+  background-color: #c8c8c8;
+  padding: 0.7em;
+  margin-bottom: 3rem;
+}
+
+.entitlement-container > p {
+  margin: 0;
+}

--- a/src/scenes/EntitlementBar/index.jsx
+++ b/src/scenes/EntitlementBar/index.jsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { mapValues } from 'lodash';
+import './index.css';
+
+const EntitlementBar = props => {
+  const entitlementText = mapValues(props.entitlement, i => i.toLocaleString());
+  const summaryHtml = () => {
+    if (!props.entitlement) return <p />;
+    if (props.entitlement.pro_gear_spouse > 0)
+      return (
+        <p>
+          {entitlementText.weight} lbs. + {entitlementText.pro_gear} lbs. of
+          pro-gear + {entitlementText.pro_gear_spouse} lbs. of spouse's pro-gear
+          = <strong>{entitlementText.sum} lbs.</strong>
+        </p>
+      );
+    return (
+      <p>
+        {entitlementText.weight} lbs. + {entitlementText.pro_gear} lbs. of
+        pro-gear = <strong>{entitlementText.sum} lbs.</strong>
+      </p>
+    );
+  };
+  return (
+    <div className="entitlement-container">
+      <p>
+        <strong>How much are you entitled to move?</strong>
+      </p>
+      {summaryHtml()}
+    </div>
+  );
+};
+EntitlementBar.propTypes = {
+  entitlement: PropTypes.shape({
+    weight: PropTypes.number.isRequired,
+    pro_gear: PropTypes.number.isRequired,
+    pro_gear_spouse: PropTypes.number.isRequired,
+    sum: PropTypes.number.isRequired,
+  }),
+};
+export default EntitlementBar;

--- a/src/scenes/EntitlementBar/index.test.js
+++ b/src/scenes/EntitlementBar/index.test.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { shallow } from 'enzyme';
+import EntitlementBar from '.';
+
+describe('EntitlementBar', () => {
+  const getSummaryHtml = entitlement => {
+    const wrapper = shallow(<EntitlementBar entitlement={entitlement} />);
+    const text = wrapper
+      .find('p')
+      .last()
+      .html();
+    return text;
+  };
+  it('when the entitlement is missing, there is no text', () => {
+    expect(getSummaryHtml()).toEqual('<p></p>');
+  });
+  it('when the entitlement has spouse pro-gear, it is included in summary', () => {
+    expect(
+      getSummaryHtml({
+        pro_gear: 2000,
+        pro_gear_spouse: 500,
+        sum: 7000,
+        weight: 5000,
+      }),
+    ).toEqual(
+      '<p>5,000 lbs. + 2,000 lbs. of pro-gear + 500 lbs. of spouse&#x27;s pro-gear = <strong>7,000 lbs.</strong></p>',
+    );
+  });
+  it('when the entitlement does not have spouse pro-gear, it is excluded from summary', () => {
+    expect(
+      getSummaryHtml({
+        pro_gear: 2000,
+        pro_gear_spouse: 0,
+        sum: 7000,
+        weight: 5000,
+      }),
+    ).toEqual(
+      '<p>5,000 lbs. + 2,000 lbs. of pro-gear = <strong>7,000 lbs.</strong></p>',
+    );
+  });
+});

--- a/src/scenes/Moves/Ppm/Size.css
+++ b/src/scenes/Moves/Ppm/Size.css
@@ -4,16 +4,6 @@
   font-size: 2.5rem;
 }
 
-.entitlement-container {
-  background-color: #C8C8C8;
-  padding: 0.7em;
-  margin-bottom: 3rem;
-}
-
-.entitlement-container > p {
-  margin: 0;
-}
-
 .button-container {
   display: flex;
 }

--- a/src/scenes/Moves/Ppm/Size.jsx
+++ b/src/scenes/Moves/Ppm/Size.jsx
@@ -4,7 +4,7 @@ import { bindActionCreators } from 'redux';
 import PropTypes from 'prop-types';
 import { setPendingPpmSize } from './ducks';
 import { loadEntitlements } from 'scenes/Orders/ducks';
-
+import EntitlementBar from 'scenes/EntitlementBar';
 import BigButton from 'shared/BigButton';
 import carGray from 'shared/icon/car-gray.svg';
 import trailerGray from 'shared/icon/trailer-gray.svg';
@@ -87,17 +87,7 @@ export class PpmSize extends Component {
           <Fragment>
             <h3>How much will you move?</h3>
 
-            <div className="entitlement-container">
-              <p>
-                <strong>How much are you entitled to move?</strong>
-              </p>
-              <p>
-                {entitlement.weight.toLocaleString()} lbs. +{' '}
-                {entitlement.pro_gear.toLocaleString()} lbs. of pro-gear +{' '}
-                {entitlement.pro_gear_spouse.toLocaleString()} lbs. of spouse's
-                pro-gear
-              </p>
-            </div>
+            <EntitlementBar entitlement={entitlement} />
 
             <BigButtonGroup
               selectedOption={selectedOption}

--- a/src/scenes/Moves/Ppm/Size.jsx
+++ b/src/scenes/Moves/Ppm/Size.jsx
@@ -92,7 +92,7 @@ export class PpmSize extends Component {
                 <strong>How much are you entitled to move?</strong>
               </p>
               <p>
-                {entitlement.total.toLocaleString()} lbs. +{' '}
+                {entitlement.weight.toLocaleString()} lbs. +{' '}
                 {entitlement.pro_gear.toLocaleString()} lbs. of pro-gear +{' '}
                 {entitlement.pro_gear_spouse.toLocaleString()} lbs. of spouse's
                 pro-gear

--- a/src/scenes/Office/OrdersPanel.jsx
+++ b/src/scenes/Office/OrdersPanel.jsx
@@ -32,7 +32,7 @@ function renderEntitlements(entitlements) {
     <React.Fragment>
       <span className="panel-subhead">Entitlements</span>
       <PanelField title="Household Goods">
-        {get(entitlements, 'total', '').toLocaleString()} lbs
+        {get(entitlements, 'weight', '').toLocaleString()} lbs
       </PanelField>
       <PanelField title="Pro-gear">
         {get(entitlements, 'pro_gear', '').toLocaleString()} lbs

--- a/src/scenes/Review/EditWeight.jsx
+++ b/src/scenes/Review/EditWeight.jsx
@@ -15,7 +15,7 @@ import {
 } from 'scenes/Moves/Ppm/ducks';
 import { loadEntitlements } from 'scenes/Orders/ducks';
 import { editBegin, editSuccessful } from './ducks';
-
+import EntitlementBar from 'scenes/EntitlementBar';
 import './Review.css';
 import './EditWeight.css';
 import profileImage from './images/profile.png';
@@ -91,19 +91,7 @@ let EditWeightForm = props => {
       <p>
         Changes could impact your move, including the estimated PPM incentive.
       </p>
-      {entitlement && (
-        <div className="edit-ppm-entitlement">
-          <p>
-            <strong>How much are you entitled to move?</strong>
-          </p>
-          <p>
-            {entitlement.weight.toLocaleString()} lbs. +{' '}
-            {entitlement.pro_gear.toLocaleString()} lbs. of pro-gear +{' '}
-            {entitlement.pro_gear_spouse.toLocaleString()} lbs. of spouse's
-            pro-gear
-          </p>
-        </div>
-      )}
+      <EntitlementBar entitlement={entitlement} />
       <div className="edit-weight-container">
         <div className="usa-width-one-half">
           <h4 className="sm-heading">Move estimate</h4>

--- a/src/scenes/Review/EditWeight.jsx
+++ b/src/scenes/Review/EditWeight.jsx
@@ -97,7 +97,7 @@ let EditWeightForm = props => {
             <strong>How much are you entitled to move?</strong>
           </p>
           <p>
-            {entitlement.total.toLocaleString()} lbs. +{' '}
+            {entitlement.weight.toLocaleString()} lbs. +{' '}
             {entitlement.pro_gear.toLocaleString()} lbs. of pro-gear +{' '}
             {entitlement.pro_gear_spouse.toLocaleString()} lbs. of spouse's
             pro-gear

--- a/src/shared/entitlements.js
+++ b/src/shared/entitlements.js
@@ -8,16 +8,19 @@ export function getEntitlements(rank, hasDependents = false) {
   const totalKey = hasDependents
     ? 'total_weight_self_plus_dependents'
     : 'total_weight_self';
-  return {
-    total: entitlements[rank][totalKey],
+  const entitlement = {
+    weight: entitlements[rank][totalKey],
     pro_gear: entitlements[rank].pro_gear_weight,
-    pro_gear_spouse: entitlements[rank].pro_gear_weight_spouse,
-    sum: sum([
-      entitlements[rank][totalKey],
-      entitlements[rank].pro_gear_weight,
-      entitlements[rank].pro_gear_weight_spouse,
-    ]),
+    pro_gear_spouse: hasDependents
+      ? entitlements[rank].pro_gear_weight_spouse
+      : 0,
   };
+  entitlement.sum = sum([
+    entitlement.weight,
+    entitlement.pro_gear,
+    entitlement.pro_gear_spouse,
+  ]);
+  return entitlement;
 }
 
 /*

--- a/src/shared/entitlements.test.js
+++ b/src/shared/entitlements.test.js
@@ -1,0 +1,25 @@
+import { getEntitlements } from './entitlements';
+describe('entitlements', () => {
+  describe('when I have dependents', () => {
+    it('should include spouse progear', () => {
+      const entitlements = getEntitlements(`E_2`, true);
+      expect(entitlements).toEqual({
+        pro_gear: 2000,
+        pro_gear_spouse: 500,
+        sum: 10500,
+        weight: 8000,
+      });
+    });
+  });
+  describe("when I don't have dependents", () => {
+    it('should exclude spouse progear', () => {
+      const entitlements = getEntitlements(`E_2`);
+      expect(entitlements).toEqual({
+        pro_gear: 2000,
+        pro_gear_spouse: 0,
+        sum: 7000,
+        weight: 5000,
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Description

added tests for getEntitlements and corrected logic for when there are no dependents. Also renamed total to weight since total/sum was ambiguous

## Reviewer Notes

AC: entitlement on home page only includes spouse progear if orders have dependents
AC: entitlement bar on SM size screen says 0 for spouse progear if orders don't have dependents
AC: max weight does not include spouse progear if orders don't have dependents
AC: office orders panel shows 0 for spouse progear if orders don't have dependents 
## Code Review Verification Steps

* [ x] All tests pass.
* [ x] There are no aXe warnings for UI.
* [ x] This works in IE.
* [ x] Request review from a member of a different team.

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/158037392) for this change

## Screenshots
### SM home page
![image](https://user-images.githubusercontent.com/3142631/40853732-1fd0f9ec-659d-11e8-84ea-51fb0d804560.png)
### SM Size screen (slightly out of date, but newer version meets Jenny's approval)
![image](https://user-images.githubusercontent.com/3142631/40853590-abafb5ee-659c-11e8-940b-11441cf588eb.png)
### SM Weight screen
![image](https://user-images.githubusercontent.com/3142631/40853630-d0dc27c6-659c-11e8-8850-f15bd6e07f62.png)
### SM Edit: Weight (slightly out of date, but newer version meets Jenny's approval)
![image](https://user-images.githubusercontent.com/3142631/40853662-e69cc6ba-659c-11e8-80d4-87eafc22dca0.png)
### Office Basics panel
![image](https://user-images.githubusercontent.com/3142631/40853756-3cc27ab2-659d-11e8-9fc0-bec3adcee707.png)
