### PR TITLE
Rek ppm estimates edit

### DIFF
--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -48,7 +48,7 @@ const PPMTabContent = props => {
   return (
     <React.Fragment>
       <PaymentsPanel title="Payments" moveId={props.match.params.moveId} />
-      <PPMEstimatesPanel title="Estimate" moveId={props.match.params.moveId} />
+      <PPMEstimatesPanel title="Estimates" moveId={props.match.params.moveId} />
     </React.Fragment>
   );
 };

--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -48,11 +48,7 @@ const PPMTabContent = props => {
   return (
     <React.Fragment>
       <PaymentsPanel title="Payments" moveId={props.match.params.moveId} />
-      <PPMEstimatesPanel
-        className="disable-edit"
-        title="Estimate"
-        moveId={props.match.params.moveId}
-      />
+      <PPMEstimatesPanel title="Estimate" moveId={props.match.params.moveId} />
     </React.Fragment>
   );
 };

--- a/src/scenes/Office/PPMEstimatesPanel.jsx
+++ b/src/scenes/Office/PPMEstimatesPanel.jsx
@@ -89,7 +89,7 @@ const EstimatesEdit = props => {
       <FormSection name="PPMEstimate">
         <div className="editable-panel-column">
           <PanelField title="Incentive estimate">
-            ${get(props, 'PPMEstimate.estimated_incentive', 0)}
+            ${get(props, 'PPMEstimate.estimated_incentive', '')}
           </PanelField>
           <SwaggerField
             className="short-field"

--- a/src/scenes/Office/PPMEstimatesPanel.jsx
+++ b/src/scenes/Office/PPMEstimatesPanel.jsx
@@ -2,11 +2,9 @@ import { get } from 'lodash';
 import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
-import { reduxForm, FormSection } from 'redux-form';
+import { reduxForm, getFormValues, isValid, FormSection } from 'redux-form';
+
 import editablePanel from './editablePanel';
-
-import { no_op_action } from 'shared/utils';
-
 import { PanelSwaggerField, PanelField } from 'shared/EditablePanel';
 import { SwaggerField } from 'shared/JsonSchemaForm/JsonSchemaField';
 
@@ -132,6 +130,7 @@ PPMEstimatesPanel = reduxForm({ form: formName })(PPMEstimatesPanel);
 
 function mapStateToProps(state) {
   let PPMEstimate = get(state, 'office.officePPMs[0]', {});
+  let officeMove = get(state, 'office.officeMove', {});
 
   return {
     // reduxForm
@@ -147,7 +146,13 @@ function mapStateToProps(state) {
     errorMessage: get(state, 'office.error'),
     PPMEstimate: PPMEstimate,
     isUpdating: false,
-    formIsValid: true,
+
+    // editablePanel
+    formIsValid: isValid(formName)(state),
+    getUpdateArgs: function() {
+      let values = getFormValues(formName)(state);
+      return [officeMove.id, values.PPMEstimate.id, values.PPMEstimate];
+    },
   };
 }
 

--- a/src/scenes/Office/PPMEstimatesPanel.jsx
+++ b/src/scenes/Office/PPMEstimatesPanel.jsx
@@ -88,12 +88,9 @@ const EstimatesEdit = props => {
     <React.Fragment>
       <FormSection name="PPMEstimate">
         <div className="editable-panel-column">
-          <SwaggerField
-            title="Incentive estimate"
-            fieldName="estimated_incentive"
-            swagger={schema}
-            required
-          />
+          <PanelField title="Incentive estimate">
+            ${get(props, 'PPMEstimate.estimated_incentive', 0)}
+          </PanelField>
           <SwaggerField
             className="short-field"
             fieldName="weight_estimate"

--- a/src/scenes/Office/PPMEstimatesPanel.jsx
+++ b/src/scenes/Office/PPMEstimatesPanel.jsx
@@ -7,8 +7,9 @@ import { reduxForm, getFormValues, isValid, FormSection } from 'redux-form';
 import editablePanel from './editablePanel';
 import { PanelSwaggerField, PanelField } from 'shared/EditablePanel';
 import { SwaggerField } from 'shared/JsonSchemaForm/JsonSchemaField';
+import YesNoBoolean from 'shared/Inputs/YesNoBoolean';
 
-import { createOrUpdatePpm } from 'scenes/Moves/Ppm/ducks';
+import { updatePPM } from 'scenes/Office/ducks';
 
 const EstimatesDisplay = props => {
   const fieldProps = {
@@ -19,21 +20,27 @@ const EstimatesDisplay = props => {
   return (
     <React.Fragment>
       <div className="editable-panel-column">
-        <PanelSwaggerField fieldName="estimated_incentive" {...fieldProps} />
+        <PanelSwaggerField
+          title="Incentive estimate"
+          fieldName="estimated_incentive"
+          {...fieldProps}
+        />
         <PanelSwaggerField fieldName="weight_estimate" {...fieldProps} />
         <PanelSwaggerField
           title="Planned departure"
           fieldName="planned_move_date"
           {...fieldProps}
         />
-        <PanelField title="Storage planned" fieldName="days_in_storage">
+        <PanelField title="Storage planned" fieldName="has_sit">
           {fieldProps.values.has_sit ? 'Yes' : 'No'}
         </PanelField>
-        <PanelSwaggerField
-          title="Storage days"
-          fieldName="days_in_storage"
-          {...fieldProps}
-        />
+        {fieldProps.values.has_sit && (
+          <PanelSwaggerField
+            title="Planned days in storage"
+            fieldName="days_in_storage"
+            {...fieldProps}
+          />
+        )}
         <PanelField
           title="Max. storage cost"
           value="Max. storage cost"
@@ -72,25 +79,39 @@ const EstimatesEdit = props => {
     <React.Fragment>
       <FormSection name="PPMEstimate">
         <div className="editable-panel-column">
-          <SwaggerField fieldName="estimated_incentive" swagger={schema} />
-          <SwaggerField fieldName="weight_estimate" swagger={schema} />
           <SwaggerField
-            title="Planned departure"
+            title="Incentive estimate"
+            fieldName="estimated_incentive"
+            swagger={schema}
+            required
+          />
+          <SwaggerField
+            className="short-field"
+            fieldName="weight_estimate"
+            swagger={schema}
+            required
+          />{' '}
+          lbs
+          <SwaggerField
+            title="Planned departure date"
             fieldName="planned_move_date"
             swagger={schema}
+            required
+          />
+          <div className="panel-subhead">Storage</div>
+          <SwaggerField
+            title="Storage planned?"
+            fieldName="has_sit"
+            swagger={schema}
+            component={YesNoBoolean}
           />
           <SwaggerField
-            title="Storage planned"
+            title="Planned days in storage"
             fieldName="days_in_storage"
             swagger={schema}
           />
           <SwaggerField
-            title="Storage days"
-            fieldName="days_in_storage"
-            swagger={schema}
-          />
-          <SwaggerField
-            title="Max. storage cost"
+            title="Max cost for XX days"
             swagger={schema}
             className="Todo"
           />
@@ -100,19 +121,22 @@ const EstimatesEdit = props => {
             title="Origin zip code"
             fieldName="pickup_postal_code"
             swagger={schema}
+            required
           />
           <SwaggerField
             title="Additional stop zip code"
             fieldName="additional_pickup_postal_code"
             swagger={schema}
+            required
           />
           <SwaggerField
             title="Destination zip code"
             fieldName="destination_postal_code"
             swagger={schema}
+            required
           />
           {/*<SwaggerField
-          title="Distance estimate"
+          title="Distance from origin to destination"
           fieldName="destination_postal_code"
           value="863 miles"
           className="Todo"
@@ -159,7 +183,7 @@ function mapStateToProps(state) {
 function mapDispatchToProps(dispatch) {
   return bindActionCreators(
     {
-      update: createOrUpdatePpm,
+      update: updatePPM,
     },
     dispatch,
   );

--- a/src/scenes/Office/PPMEstimatesPanel.jsx
+++ b/src/scenes/Office/PPMEstimatesPanel.jsx
@@ -9,7 +9,15 @@ import { PanelSwaggerField, PanelField } from 'shared/EditablePanel';
 import { SwaggerField } from 'shared/JsonSchemaForm/JsonSchemaField';
 import YesNoBoolean from 'shared/Inputs/YesNoBoolean';
 
-import { updatePPM } from 'scenes/Office/ducks';
+import { loadEntitlements, updatePPM } from 'scenes/Office/ducks';
+
+const validateWeight = (value, formValues, props, fieldName) => {
+  if (value && props.entitlement && value > props.entitlement.sum) {
+    return `Cannot be more than full entitlement weight (${
+      props.entitlement.sum
+    } lbs)`;
+  }
+};
 
 const EstimatesDisplay = props => {
   const fieldProps = {
@@ -89,6 +97,7 @@ const EstimatesEdit = props => {
             className="short-field"
             fieldName="weight_estimate"
             swagger={schema}
+            validate={validateWeight}
             required
           />{' '}
           lbs
@@ -172,6 +181,7 @@ function mapStateToProps(state) {
     errorMessage: get(state, 'office.error'),
     PPMEstimate: PPMEstimate,
     isUpdating: false,
+    entitlement: loadEntitlements(state),
 
     // editablePanel
     formIsValid: isValid(formName)(state),

--- a/src/scenes/Office/PPMEstimatesPanel.jsx
+++ b/src/scenes/Office/PPMEstimatesPanel.jsx
@@ -92,6 +92,7 @@ const EstimatesEdit = props => {
             title="Incentive estimate"
             fieldName="estimated_incentive"
             swagger={schema}
+            required
           />
           <SwaggerField
             className="short-field"

--- a/src/scenes/Office/PPMEstimatesPanel.jsx
+++ b/src/scenes/Office/PPMEstimatesPanel.jsx
@@ -75,6 +75,7 @@ const EstimatesDisplay = props => {
 
 const EstimatesEdit = props => {
   const schema = props.PPMEstimateSchema;
+
   return (
     <React.Fragment>
       <FormSection name="PPMEstimate">
@@ -105,11 +106,13 @@ const EstimatesEdit = props => {
             swagger={schema}
             component={YesNoBoolean}
           />
-          <SwaggerField
-            title="Planned days in storage"
-            fieldName="days_in_storage"
-            swagger={schema}
-          />
+          {get(props, 'formValues.PPMEstimate.has_sit', false) && (
+            <SwaggerField
+              title="Planned days in storage"
+              fieldName="days_in_storage"
+              swagger={schema}
+            />
+          )}
           <SwaggerField
             title="Max cost for XX days"
             swagger={schema}
@@ -155,10 +158,11 @@ PPMEstimatesPanel = reduxForm({ form: formName })(PPMEstimatesPanel);
 function mapStateToProps(state) {
   let PPMEstimate = get(state, 'office.officePPMs[0]', {});
   let officeMove = get(state, 'office.officeMove', {});
+  let formValues = getFormValues(formName)(state);
 
   return {
     // reduxForm
-    formData: state.form[formName],
+    formValues: formValues,
     initialValues: { PPMEstimate: PPMEstimate },
 
     // Wrapper
@@ -174,8 +178,7 @@ function mapStateToProps(state) {
     // editablePanel
     formIsValid: isValid(formName)(state),
     getUpdateArgs: function() {
-      let values = getFormValues(formName)(state);
-      return [officeMove.id, values.PPMEstimate.id, values.PPMEstimate];
+      return [officeMove.id, formValues.PPMEstimate.id, formValues.PPMEstimate];
     },
   };
 }

--- a/src/scenes/Office/PPMEstimatesPanel.jsx
+++ b/src/scenes/Office/PPMEstimatesPanel.jsx
@@ -2,12 +2,15 @@ import { get } from 'lodash';
 import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
-import { reduxForm } from 'redux-form';
+import { reduxForm, FormSection } from 'redux-form';
 import editablePanel from './editablePanel';
 
 import { no_op_action } from 'shared/utils';
 
 import { PanelSwaggerField, PanelField } from 'shared/EditablePanel';
+import { SwaggerField } from 'shared/JsonSchemaForm/JsonSchemaField';
+
+import { createOrUpdatePpm } from 'scenes/Moves/Ppm/ducks';
 
 const EstimatesDisplay = props => {
   const fieldProps = {
@@ -66,8 +69,60 @@ const EstimatesDisplay = props => {
 };
 
 const EstimatesEdit = props => {
-  // const { schema } = props;
-  return <React.Fragment>This is where the editing happens!</React.Fragment>;
+  const schema = props.PPMEstimateSchema;
+  return (
+    <React.Fragment>
+      <FormSection name="PPMEstimate">
+        <div className="editable-panel-column">
+          <SwaggerField fieldName="estimated_incentive" swagger={schema} />
+          <SwaggerField fieldName="weight_estimate" swagger={schema} />
+          <SwaggerField
+            title="Planned departure"
+            fieldName="planned_move_date"
+            swagger={schema}
+          />
+          <SwaggerField
+            title="Storage planned"
+            fieldName="days_in_storage"
+            swagger={schema}
+          />
+          <SwaggerField
+            title="Storage days"
+            fieldName="days_in_storage"
+            swagger={schema}
+          />
+          <SwaggerField
+            title="Max. storage cost"
+            swagger={schema}
+            className="Todo"
+          />
+        </div>
+        <div className="editable-panel-column">
+          <SwaggerField
+            title="Origin zip code"
+            fieldName="pickup_postal_code"
+            swagger={schema}
+          />
+          <SwaggerField
+            title="Additional stop zip code"
+            fieldName="additional_pickup_postal_code"
+            swagger={schema}
+          />
+          <SwaggerField
+            title="Destination zip code"
+            fieldName="destination_postal_code"
+            swagger={schema}
+          />
+          {/*<SwaggerField
+          title="Distance estimate"
+          fieldName="destination_postal_code"
+          value="863 miles"
+          className="Todo"
+        />*/}
+        </div>
+      </FormSection>
+    </React.Fragment>
+  );
 };
 
 const formName = 'ppm_estimate_and_details';
@@ -76,10 +131,12 @@ let PPMEstimatesPanel = editablePanel(EstimatesDisplay, EstimatesEdit);
 PPMEstimatesPanel = reduxForm({ form: formName })(PPMEstimatesPanel);
 
 function mapStateToProps(state) {
+  let PPMEstimate = get(state, 'office.officePPMs[0]', {});
+
   return {
     // reduxForm
     formData: state.form[formName],
-    initialValues: {},
+    initialValues: { PPMEstimate: PPMEstimate },
 
     // Wrapper
     PPMEstimateSchema: get(
@@ -88,7 +145,7 @@ function mapStateToProps(state) {
     ),
     hasError: false,
     errorMessage: get(state, 'office.error'),
-    PPMEstimate: get(state, 'office.officePPMs[0]', {}),
+    PPMEstimate: PPMEstimate,
     isUpdating: false,
     formIsValid: true,
   };
@@ -97,7 +154,7 @@ function mapStateToProps(state) {
 function mapDispatchToProps(dispatch) {
   return bindActionCreators(
     {
-      update: no_op_action,
+      update: createOrUpdatePpm,
     },
     dispatch,
   );

--- a/src/scenes/Office/PPMEstimatesPanel.jsx
+++ b/src/scenes/Office/PPMEstimatesPanel.jsx
@@ -89,7 +89,7 @@ const EstimatesEdit = props => {
       <FormSection name="PPMEstimate">
         <div className="editable-panel-column">
           <PanelField title="Incentive estimate">
-            ${get(props, 'PPMEstimate.estimated_incentive', '')}
+            {get(props, 'PPMEstimate.estimated_incentive', '')}
           </PanelField>
           <SwaggerField
             className="short-field"

--- a/src/scenes/Office/PPMEstimatesPanel.jsx
+++ b/src/scenes/Office/PPMEstimatesPanel.jsx
@@ -84,7 +84,6 @@ const EstimatesEdit = props => {
             title="Incentive estimate"
             fieldName="estimated_incentive"
             swagger={schema}
-            required
           />
           <SwaggerField
             className="short-field"
@@ -130,7 +129,6 @@ const EstimatesEdit = props => {
             title="Additional stop zip code"
             fieldName="additional_pickup_postal_code"
             swagger={schema}
-            required
           />
           <SwaggerField
             title="Destination zip code"
@@ -178,6 +176,15 @@ function mapStateToProps(state) {
     // editablePanel
     formIsValid: isValid(formName)(state),
     getUpdateArgs: function() {
+      if (
+        formValues.PPMEstimate.additional_pickup_postal_code !== '' &&
+        formValues.PPMEstimate.additional_pickup_postal_code !== undefined
+      ) {
+        formValues.PPMEstimate.has_additional_postal_code = true;
+      } else {
+        delete formValues.PPMEstimate.additional_pickup_postal_code;
+        formValues.PPMEstimate.has_additional_postal_code = false;
+      }
       return [officeMove.id, formValues.PPMEstimate.id, formValues.PPMEstimate];
     },
   };

--- a/src/scenes/Office/ducks.js
+++ b/src/scenes/Office/ducks.js
@@ -12,6 +12,7 @@ import {
   ApproveReimbursement,
 } from './api.js';
 
+import { UpdatePpm } from 'scenes/Moves/Ppm/api.js';
 import { UpdateOrders } from 'scenes/Orders/api.js';
 import { getEntitlements } from 'shared/entitlements.js';
 import * as ReduxHelpers from 'shared/ReduxHelpers';
@@ -25,6 +26,7 @@ const updateServiceMemberType = 'UPDATE_SERVICE_MEMBER';
 const loadBackupContactType = 'LOAD_BACKUP_CONTACT';
 const updateBackupContactType = 'UPDATE_BACKUP_CONTACT';
 const loadPPMsType = 'LOAD_PPMS';
+const updatePPMType = 'UPDATE_PPM';
 const approveBasicsType = 'APPROVE_BASICS';
 const approvePPMType = 'APPROVE_PPM';
 const approveReimbursementType = 'APPROVE_REIMBURSEMENT';
@@ -59,6 +61,8 @@ const UPDATE_BACKUP_CONTACT = ReduxHelpers.generateAsyncActionTypes(
 );
 
 const LOAD_PPMS = ReduxHelpers.generateAsyncActionTypes(loadPPMsType);
+
+const UPDATE_PPM = ReduxHelpers.generateAsyncActionTypes(updatePPMType);
 
 const APPROVE_BASICS = ReduxHelpers.generateAsyncActionTypes(approveBasicsType);
 
@@ -122,6 +126,11 @@ export const updateBackupContact = ReduxHelpers.generateAsyncActionCreator(
 export const loadPPMs = ReduxHelpers.generateAsyncActionCreator(
   loadPPMsType,
   LoadPPMs,
+);
+
+export const updatePPM = ReduxHelpers.generateAsyncActionCreator(
+  updatePPMType,
+  UpdatePpm,
 );
 
 export const approveBasics = ReduxHelpers.generateAsyncActionCreator(
@@ -228,6 +237,7 @@ const initialState = {
   serviceMemberIsLoading: false,
   backupContactsAreLoading: false,
   ppmsAreLoading: false,
+  ppmIsUpdating: false,
   moveHasLoadError: null,
   moveHasLoadSuccess: false,
   ordersHaveLoadError: null,
@@ -242,6 +252,8 @@ const initialState = {
   backupContactsHaveLoadSuccess: false,
   ppmsHaveLoadError: null,
   ppmsHaveLoadSuccess: false,
+  ppmHasUpdateError: null,
+  ppmHasUpdateSuccess: false,
   loadDependenciesHasError: null,
   loadDependenciesHasSuccess: false,
 };
@@ -415,6 +427,26 @@ export function officeReducer(state = initialState, action) {
         officePPMs: null,
         PPMsHaveLoadSuccess: false,
         PPMsHaveLoadError: true,
+        error: action.error.message,
+      });
+    case UPDATE_PPM.start:
+      return Object.assign({}, state, {
+        PPMIsUpdating: true,
+        PPMHasUpdateSuccess: false,
+      });
+    case UPDATE_PPM.success:
+      return Object.assign({}, state, {
+        PPMIsUpdating: false,
+        officePPMs: [action.payload],
+        PPMHasUpdateSuccess: true,
+        PPMHasUpdateError: false,
+      });
+    case UPDATE_PPM.failure:
+      return Object.assign({}, state, {
+        PPMIsUpdating: false,
+        officePPMs: null,
+        PPMHasUpdateSuccess: false,
+        PPMHasUpdateError: true,
         error: action.error.message,
       });
 

--- a/src/scenes/Office/editablePanel.jsx
+++ b/src/scenes/Office/editablePanel.jsx
@@ -23,6 +23,11 @@ export default function editablePanel(DisplayComponent, EditComponent) {
       }
     };
 
+    cancel = () => {
+      this.props.reset();
+      this.toggleEditable();
+    };
+
     toggleEditable = () => {
       this.setState({
         isEditable: !this.state.isEditable,
@@ -45,7 +50,8 @@ export default function editablePanel(DisplayComponent, EditComponent) {
             title={this.props.title}
             className={this.props.className}
             onSave={this.save}
-            onToggle={this.toggleEditable}
+            onEdit={this.toggleEditable}
+            onCancel={this.cancel}
             isEditable={isEditable}
             isValid={this.props.formIsValid}
           >

--- a/src/scenes/Review/EditWeight.jsx
+++ b/src/scenes/Review/EditWeight.jsx
@@ -129,10 +129,7 @@ let EditWeightForm = props => {
           <div className="display-value">
             <p>Estimated Incentive</p>
             <p className={incentiveClass}>
-              <strong>
-                {incentive}
-                {incentive || 'Unable to Calculate'}
-              </strong>
+              <strong>{incentive || 'Unable to Calculate'}</strong>
             </p>
             {initialValues &&
               initialValues.estimated_incentive &&

--- a/src/shared/EditablePanel/index.css
+++ b/src/shared/EditablePanel/index.css
@@ -27,6 +27,11 @@
   position: relative;
 }
 
+.short-field {
+  max-width: 46rem;
+  display: inline-block;
+}
+
 .editable-panel-content {
   padding-left: 1.7rem;
   padding-right: 1.7rem;

--- a/src/shared/EditablePanel/index.jsx
+++ b/src/shared/EditablePanel/index.jsx
@@ -57,9 +57,14 @@ PanelSwaggerField.propTypes = {
 };
 
 export class EditablePanel extends Component {
-  handleToggleClick = e => {
+  handleEditClick = e => {
     e.preventDefault();
-    this.props.onToggle();
+    this.props.onEdit();
+  };
+
+  handleCancelClick = e => {
+    e.preventDefault();
+    this.props.onCancel();
   };
 
   handleSaveClick = e => {
@@ -76,7 +81,7 @@ export class EditablePanel extends Component {
           <p>
             <button
               className="usa-button-secondary editable-panel-cancel"
-              onClick={this.handleToggleClick}
+              onClick={this.handleCancelClick}
             >
               Cancel
             </button>
@@ -105,7 +110,7 @@ export class EditablePanel extends Component {
         <div className="editable-panel-header">
           <div className="title">{this.props.title}</div>
           {!this.props.isEditable && (
-            <a className="editable-panel-edit" onClick={this.handleToggleClick}>
+            <a className="editable-panel-edit" onClick={this.handleEditClick}>
               Edit
             </a>
           )}
@@ -124,6 +129,7 @@ EditablePanel.propTypes = {
   children: PropTypes.node.isRequired,
   isEditable: PropTypes.bool.isRequired,
   isValid: PropTypes.bool.isRequired,
-  onToggle: PropTypes.func.isRequired,
+  onCancel: PropTypes.func.isRequired,
+  onEdit: PropTypes.func.isRequired,
   onSave: PropTypes.func.isRequired,
 };

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -301,6 +301,7 @@ definitions:
         x-nullable: true
       estimated_storage_reimbursement:
         type: string
+        example: "$1200"
         title: Estimated Storage Reimbursement
         x-nullable: true
       weight_estimate:
@@ -310,6 +311,7 @@ definitions:
         x-nullable: true
       estimated_incentive:
         type: string
+        example: "$1000-2000"
         title: Estimated Incentive
         x-nullable: true
       has_requested_advance:


### PR DESCRIPTION
## Description

This PR adds edit functionality to PPM Estimates panel. 
If office user attempts to allow too great weight, shows warning and doesn't save.
If office user adds additional stop zip, will change ppm has_additional_postal_code.

STILL TO DECIDE: 
When rate engine chokes and no Incentive estimate is recorded, how do we handle on office side?

## Code Review Verification Steps

* [x] All tests pass.
* [x] There are no aXe warnings for UI.
* [x] This works in IE.
* [x] Request review from a member of a different team.
* [x] (TRIAL) Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/157651176) for this change

## Screenshots
<img width="858" alt="screen shot 2018-06-05 at 11 46 55 am" src="https://user-images.githubusercontent.com/7401870/40996265-3fd213a4-68b6-11e8-83cb-a86613bd1c93.png">
<img width="888" alt="screen shot 2018-06-05 at 11 47 16 am" src="https://user-images.githubusercontent.com/7401870/40996266-3fe87afe-68b6-11e8-9808-69cb371f74e3.png">