### PR TITLE
Adds spouse_has_pro_gear bool to orders payloads

### DIFF
--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -1480,6 +1480,9 @@ definitions:
       has_dependents:
         type: boolean
         title: Are dependents included in your orders?
+      spouse_has_pro_gear:
+        type: boolean
+        title: Do you have a spouse that will need to move stuff related to their job?
       new_duty_station:
         $ref: '#/definitions/DutyStationPayload'
       uploaded_orders:
@@ -1510,6 +1513,8 @@ definitions:
       - report_by_date
       - orders_type
       - has_dependents
+      # TODO: Uncomment below after spouse_has_pro_gear UI is completed
+      # - spouse_has_pro_gear
       - new_duty_station
       - uploaded_orders
       - created_at
@@ -1540,6 +1545,9 @@ definitions:
       has_dependents:
         type: boolean
         title: Are dependents included in your orders?
+      spouse_has_pro_gear:
+        type: boolean
+        title: Do you have a spouse that will need to move stuff related to their job?
       new_duty_station_id:
         type: string
         format: uuid
@@ -1565,6 +1573,8 @@ definitions:
       - report_by_date
       - orders_type
       - has_dependents
+      # TODO: Uncomment below after spouse_has_pro_gear UI is completed
+      # - spouse_has_pro_gear
       - new_duty_station_id
   InvalidRequestResponsePayload:
     type: object


### PR DESCRIPTION
## Description

Adds field for spouse_has_pro_gear

## Code Review Verification Steps

* [ ] All tests pass.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/blob/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* [ ] Any migrations/schema changes also update the diagram in docs/schema/dp3.sqs
* [ ] There are no aXe warnings for UI.
* [ ] This works in IE.
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @willowbl00
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Request review from a member of a different team.
* [ ] (TRIAL) Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/158041489) for this change
