### PR TITLE
Add authorized user-id, office-user-id, and service-member-id to each request

### DIFF
--- a/cmd/webserver/main.go
+++ b/cmd/webserver/main.go
@@ -210,7 +210,6 @@ func main() {
 	// are added, but the resulting http.Handlers execute in "normal" order
 	// (i.e., the http.Handler returned by the first Middleware added gets
 	// called first).
-	site.Use(logging.LogRequestMiddleware)
 	site.Use(httpsComplianceMiddleware)
 	site.Use(limitBodySizeMiddleware)
 
@@ -220,6 +219,7 @@ func main() {
 	root := goji.NewMux()
 	root.Use(sessionCookieMiddleware)
 	root.Use(appDetectionMiddleware) // Comes after the sessionCookieMiddleware as it sets session state
+	root.Use(logging.LogRequestMiddleware)
 	site.Handle(pat.New("/*"), root)
 
 	apiMux := goji.SubMux()


### PR DESCRIPTION
## Description
* Log the authenticated user ID with each HTTP request
* Log the authorized service member ID / office user ID with each HTTP request 
NOTE: The additional fields will be empty if the HTTP request is unauthenticated or unauthorized

Authorized service-member request
`
2018-06-04T13:50:39.799-0700	INFO	logging/log.go:59	Request	{"accepted-language": "", "content-length": 0, "duration": "23.980914ms", "host": "localhost:3000", "method": "GET", "office-user-id": "", "protocol": "http", "protocol-version": "HTTP/1.1", "referer": "http://localhost:3000/", "resp-size-bytes": 358, "resp-status": 200, "service-member-id": "45b9e503-c6ad-4125-acc8-e0bb0e0895a4", "source": "127.0.0.1:55494", "url": "/internal/duty_stations/2e967b76-9f33-4156-8c79-0ed7c55fd1cc/transportation_office", "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.62 Safari/537.36", "user-id": "d5460fb2-9b44-49d8-a879-da833b660580", "x-amzn-trace-id": "", "x-forwarded-for": "127.0.0.1", "x-forwarded-host": "", "x-forwarded-proto": ""}
`

Authorized office user request
`
2018-06-04T13:52:09.017-0700	INFO	logging/log.go:59	Request	{"accepted-language": "", "content-length": 0, "duration": "8.018719ms", "host": "officelocal:3000", "method": "GET", "office-user-id": "eea078c9-5fae-472b-a897-08d790a88268", "protocol": "http", "protocol-version": "HTTP/1.1", "referer": "http://officelocal:3000/queues/new", "resp-size-bytes": 3, "resp-status": 200, "service-member-id": "", "source": "127.0.0.1:55494", "url": "/internal/queues/new", "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.62 Safari/537.36", "user-id": "25cb228c-bb66-4879-8926-a1900fe897d6", "x-amzn-trace-id": "", "x-forwarded-for": "127.0.0.1", "x-forwarded-host": "", "x-forwarded-proto": ""}
`

Unauthorized request
`
2018-06-04T13:52:39.037-0700	INFO	logging/log.go:59	Request	{"accepted-language": "", "content-length": 0, "duration": "3.259899ms", "host": "localhost:8080", "method": "GET", "office-user-id": "", "protocol": "http", "protocol-version": "HTTP/1.1", "referer": "", "resp-size-bytes": 605, "resp-status": 200, "service-member-id": "", "source": "127.0.0.1:55494", "url": "/", "user-agent": "curl/7.54.0", "user-id": "", "x-amzn-trace-id": "", "x-forwarded-for": "::1", "x-forwarded-host": "", "x-forwarded-proto": ""}
`

## Code Review Verification Steps

* [x] All tests pass.
* [x] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/blob/master/docs/backend.md#logging)
* [x] Request review from a member of a different team.

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/157527030) for this change
