### PR TITLE
Update psql commands to fail on SQL error [finishes #158096867]

### DIFF
--- a/bin/apply-secure-migration.sh
+++ b/bin/apply-secure-migration.sh
@@ -53,4 +53,12 @@ echo "Applying secure migrations: ${migration_file}"
 
 # Don't share the database password
 set +x
-psql -v "ON_ERROR_STOP=1" postgres://"${DB_USER}":"$DB_PASSWORD"@"$DB_HOST":"$DB_PORT"/"$DB_NAME""$psql_ssl_mode" < "$migration"
+
+# Run the migrations file with the following options:
+# - The migration is wrapped in a single transaction
+# - Any errors in the migration file will cause a failure
+psql \
+  --single-transaction \
+  -v "ON_ERROR_STOP=1" \
+  --file="$migration" \
+  postgres://"${DB_USER}":"$DB_PASSWORD"@"$DB_HOST":"$DB_PORT"/"$DB_NAME""$psql_ssl_mode"

--- a/bin/apply-secure-migration.sh
+++ b/bin/apply-secure-migration.sh
@@ -53,4 +53,4 @@ echo "Applying secure migrations: ${migration_file}"
 
 # Don't share the database password
 set +x
-psql postgres://"${DB_USER}":"$DB_PASSWORD"@"$DB_HOST":"$DB_PORT"/"$DB_NAME""$psql_ssl_mode" < "$migration"
+psql -v "ON_ERROR_STOP=1" postgres://"${DB_USER}":"$DB_PASSWORD"@"$DB_HOST":"$DB_PORT"/"$DB_NAME""$psql_ssl_mode" < "$migration"

--- a/bin/apply-secure-migration.sh
+++ b/bin/apply-secure-migration.sh
@@ -59,6 +59,6 @@ set +x
 # - Any errors in the migration file will cause a failure
 psql \
   --single-transaction \
-  -v "ON_ERROR_STOP=1" \
+  --variable "ON_ERROR_STOP=1" \
   --file="$migration" \
   postgres://"${DB_USER}":"$DB_PASSWORD"@"$DB_HOST":"$DB_PORT"/"$DB_NAME""$psql_ssl_mode"

--- a/bin/psql-dev
+++ b/bin/psql-dev
@@ -7,7 +7,7 @@ db_password="mysecretpassword"
 command="${*:-}"
 
 if [ -n "${command[*]}" ]; then
-  exec psql postgres://postgres:${db_password}@localhost/dev_db -c "${command}"
+  exec psql -v "ON_ERROR_STOP=1" postgres://postgres:${db_password}@localhost/dev_db -c "${command}"
 else
-  exec psql postgres://postgres:${db_password}@localhost/dev_db
+  exec psql -v "ON_ERROR_STOP=1" postgres://postgres:${db_password}@localhost/dev_db
 fi

--- a/bin/psql-dev
+++ b/bin/psql-dev
@@ -7,7 +7,7 @@ db_password="mysecretpassword"
 command="${*:-}"
 
 if [ -n "${command[*]}" ]; then
-  exec psql -v "ON_ERROR_STOP=1" postgres://postgres:${db_password}@localhost/dev_db -c "${command}"
+  exec psql --variable "ON_ERROR_STOP=1" postgres://postgres:${db_password}@localhost/dev_db -c "${command}"
 else
-  exec psql -v "ON_ERROR_STOP=1" postgres://postgres:${db_password}@localhost/dev_db
+  exec psql --variable "ON_ERROR_STOP=1" postgres://postgres:${db_password}@localhost/dev_db
 fi

--- a/bin/psql-test
+++ b/bin/psql-test
@@ -7,7 +7,7 @@ db_password="mysecretpassword"
 command="${*:-}"
 
 if [ -n "${command[*]}" ]; then
-  exec psql postgres://postgres:${db_password}@localhost/test_db -c "${command}"
+  exec psql --variable "ON_ERROR_STOP=1" postgres://postgres:${db_password}@localhost/test_db -c "${command}"
 else
-  exec psql postgres://postgres:${db_password}@localhost/test_db
+  exec psql --variable "ON_ERROR_STOP=1" postgres://postgres:${db_password}@localhost/test_db
 fi


### PR DESCRIPTION
## Description

If secure migration SQL fails, `psql` won't error out unless you set the `ON_ERROR_STOP` variable. Let's set that in `psql-dev` and `apply-secure-migrations.sh`, to save us some of the headaches we experienced last week.

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Code Review Verification Steps

* [ ] All tests pass.
* [ ] Request review from a member of a different team.

https://www.pivotaltracker.com/story/show/158096867