### PR TITLE
Eliminates double API call from queue table

### DIFF
--- a/src/scenes/Office/QueueTable.jsx
+++ b/src/scenes/Office/QueueTable.jsx
@@ -15,8 +15,14 @@ class QueueTable extends Component {
     this.fetchData = this.fetchData.bind(this);
   }
 
+  componentDidMount() {
+    this.fetchData();
+  }
+
   componentDidUpdate(prevProps) {
+    console.log(this.props.queueType, prevProps.queueType);
     if (this.props.queueType !== prevProps.queueType) {
+      console.log('This got called!');
       this.fetchData();
     }
   }
@@ -88,7 +94,6 @@ class QueueTable extends Component {
             ]}
             data={this.state.data}
             loading={this.state.loading} // Display the loading overlay when we need it
-            onFetchData={this.fetchData} // Request new data when things change
             pageSize={this.state.data.length}
             className="-striped -highlight"
             getTrProps={(state, rowInfo) => ({

--- a/src/scenes/Office/QueueTable.jsx
+++ b/src/scenes/Office/QueueTable.jsx
@@ -20,9 +20,7 @@ class QueueTable extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    console.log(this.props.queueType, prevProps.queueType);
     if (this.props.queueType !== prevProps.queueType) {
-      console.log('This got called!');
       this.fetchData();
     }
   }


### PR DESCRIPTION
## Description

We were getting a double hit on the API for the queue table on the office side. Now, with fetchData being exclusively called in componentDidMount/Update, it's only called once as needed. 

## Reviewer Notes

Just note that using onFetchData when making a react-table is considered Not Great. See references for more details. It's used in their example code, it worked for us, but it created an unneeded and unwanted side effect. 

## Code Review Verification Steps

* [ ] All tests pass.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/blob/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* [ ] Any migrations/schema changes also update the diagram in docs/schema/dp3.sqs
* [ ] There are no aXe warnings for UI.
* [ ] This works in IE.
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @willowbl00
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Request review from a member of a different team.
* [ ] (TRIAL) Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/158005837) for this change
* [this article](https://github.com/react-tools/react-table/issues/837) explains more about the approach used.

