### PR TITLE
Removes GTCC as a payment option for PPM advances [delivers #158009918]

### DIFF
--- a/migrations/20180605231218_remove_gtcc_ppm_advance.up.sql
+++ b/migrations/20180605231218_remove_gtcc_ppm_advance.up.sql
@@ -1,0 +1,7 @@
+UPDATE reimbursements r
+SET method_of_receipt = 'OTHER_DD'
+WHERE
+	method_of_receipt = 'GTCC' AND
+	r.id in (
+		SELECT advance_id from personally_procured_moves
+	);

--- a/pkg/models/personally_procured_move.go
+++ b/pkg/models/personally_procured_move.go
@@ -103,6 +103,12 @@ func SavePersonallyProcuredMove(db *pop.Connection, ppm *PersonallyProcuredMove)
 
 		if ppm.HasRequestedAdvance {
 			if ppm.Advance != nil {
+				// GTCC isn't a valid method of receipt for PPM Advances, so reject if that's the case.
+				if ppm.Advance.MethodOfReceipt == MethodOfReceiptGTCC {
+					responseVErrors.Add("MethodOfReceipt", "GTCC is not a valid receipt method for PPM Advances.")
+					return transactionError
+				}
+
 				if verrs, err := db.ValidateAndSave(ppm.Advance); verrs.HasAny() || err != nil {
 					responseVErrors.Append(verrs)
 					responseError = errors.Wrap(err, "Error Saving Advance")

--- a/pkg/models/personally_procured_move_test.go
+++ b/pkg/models/personally_procured_move_test.go
@@ -38,3 +38,13 @@ func (suite *ModelSuite) TestPPMAdvance() {
 	suite.Nil(err)
 	suite.Equal(fetchedPPM.Advance.Status, ReimbursementStatusREQUESTED, "expected Requested")
 }
+
+func (suite *ModelSuite) TestPPMAdvanceNoGTCC() {
+	move, _ := testdatagen.MakeMove(suite.db)
+
+	advance := BuildDraftReimbursement(1000, MethodOfReceiptGTCC)
+
+	_, verrs, err := move.CreatePPM(suite.db, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, true, &advance)
+	suite.Nil(err)
+	suite.True(verrs.HasAny())
+}

--- a/src/scenes/Review/EditWeight.jsx
+++ b/src/scenes/Review/EditWeight.jsx
@@ -147,7 +147,9 @@ let EditWeightForm = props => {
             <div className="display-value">
               <p>Advance</p>
               <p>
-                <strong>${initialValues.advance.requested_amount / 100}</strong>
+                <strong>
+                  ${(initialValues.advance.requested_amount / 100).toFixed(2)}
+                </strong>
               </p>
             </div>
           )}

--- a/src/scenes/Review/EditWeight.jsx
+++ b/src/scenes/Review/EditWeight.jsx
@@ -147,9 +147,7 @@ let EditWeightForm = props => {
             <div className="display-value">
               <p>Advance</p>
               <p>
-                <strong>
-                  ${(initialValues.advance.requested_amount / 100).toFixed(2)}
-                </strong>
+                <strong>${initialValues.advance.requested_amount / 100}</strong>
               </p>
             </div>
           )}


### PR DESCRIPTION
## Description

GTCC isn't a valid payment option for PPM advances, so this removes it.

Initially I had hoped to create separate Swagger definitions for PPM advances that would be identical to `Reimbursement` but without `GTCC` as an option. I decided that this would be too messy because reimbursements use a shared route (and thus a single payload type) for state changes. While it would be possible to get away with shoehorning the two reimbursement types into one another, it didn't seem worth it for what would be gained.

Instead the client handles removing `GTCC` as an option in the one place that currently needs it (weight slider screen), and there's an additional check in the server to ensure we don't save `GTCC` values. Additionally there's a migration that transitions any existing `GTCC` data to `OTHER_DD`.

## Code Review Verification Steps

* [ ] All tests pass.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/blob/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* [ ] Any migrations/schema changes also update the diagram in docs/schema/dp3.sqs
* [ ] There are no aXe warnings for UI.
* [ ] This works in IE.
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @willowbl00
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Request review from a member of a different team.
* [ ] (TRIAL) Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/158009918) for this change
