### PR TITLE
Adds labels to move summary for advance, SIT [delivers #158020566]

### DIFF
--- a/src/scenes/Landing/MoveSummary.jsx
+++ b/src/scenes/Landing/MoveSummary.jsx
@@ -31,9 +31,12 @@ export const MoveSummary = props => {
   const privateStorageString = get(ppm, 'estimated_storage_reimbursement')
     ? `(up to ${ppm.estimated_storage_reimbursement})`
     : '';
-  const hasSitString = ppm.has_sit
-    ? `Temp. Storage: ${ppm.days_in_storage} days ${privateStorageString}`
-    : 'Not requested';
+  const advanceString = ppm.has_requested_advance
+    ? `Advance Requested: $${(ppm.advance.requested_amount / 100).toFixed(2)}`
+    : '';
+  const hasSitString = `Temp. Storage: ${
+    ppm.days_in_storage
+  } days ${privateStorageString}`;
   return (
     <div className="whole_box">
       <h2>
@@ -129,7 +132,8 @@ export const MoveSummary = props => {
                       <div className="title">Details</div>
                       <div>Weight (est.): {ppm.weight_estimate} lbs</div>
                       <div>Incentive (est.): {ppm.estimated_incentive}</div>
-                      <div>{hasSitString}</div>
+                      {ppm.has_sit && <div>{hasSitString}</div>}
+                      {ppm.has_requested_advance && <div>{advanceString}</div>}
                     </div>
                     <div className="titled_block">
                       <div className="title">Documents</div>
@@ -204,7 +208,10 @@ export const MoveSummary = props => {
                         <div className="title">Details</div>
                         <div>Weight (est.): {ppm.weight_estimate} lbs</div>
                         <div>Incentive (est.): {ppm.estimated_incentive}</div>
-                        <div>{hasSitString}</div>
+                        {ppm.has_sit && <div>{hasSitString}</div>}
+                        {ppm.has_requested_advance && (
+                          <div>{advanceString}</div>
+                        )}
                       </div>
                       <div className="titled_block">
                         <div className="title">Documents</div>
@@ -264,7 +271,10 @@ export const MoveSummary = props => {
                         <div className="title">Details</div>
                         <div>Weight (est.): {ppm.weight_estimate} lbs</div>
                         <div>Incentive (est.): {ppm.estimated_incentive}</div>
-                        <div>{hasSitString}</div>
+                        {ppm.has_sit && <div>{hasSitString}</div>}
+                        {ppm.has_requested_advance && (
+                          <div>{advanceString}</div>
+                        )}
                       </div>
                       <div className="titled_block">
                         <div className="title">Documents</div>

--- a/src/scenes/Landing/MoveSummary.jsx
+++ b/src/scenes/Landing/MoveSummary.jsx
@@ -12,6 +12,7 @@ import ppmSubmitted from './images/ppm-submitted.png';
 import ppmApproved from './images/ppm-approved.png';
 import ppmInProgress from './images/ppm-in-progress.png';
 import { ppmInfoPacket } from 'shared/constants';
+import { formatCents } from 'shared/formatters';
 
 export const MoveSummary = props => {
   const {
@@ -32,7 +33,7 @@ export const MoveSummary = props => {
     ? `(up to ${ppm.estimated_storage_reimbursement})`
     : '';
   const advanceString = ppm.has_requested_advance
-    ? `Advance Requested: $${(ppm.advance.requested_amount / 100).toFixed(2)}`
+    ? `Advance Requested: $${formatCents(ppm.advance.requested_amount)}`
     : '';
   const hasSitString = `Temp. Storage: ${
     ppm.days_in_storage


### PR DESCRIPTION
## Description

Adds labels for Advance and SIT that are only visible when relevant

## Code Review Verification Steps

* [ ] All tests pass.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/blob/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* [ ] Any migrations/schema changes also update the diagram in docs/schema/dp3.sqs
* [ ] There are no aXe warnings for UI.
* [ ] This works in IE.
* [ ] Request review from a member of a different team.
* [ ] (TRIAL) Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/158020566) for this change

## Screenshots

<img width="793" alt="screenshot 2018-06-08 09 20 03" src="https://user-images.githubusercontent.com/5151804/41169891-37325b64-6aff-11e8-9805-2a3f64618bef.png">

