### PR TITLE
Office queue "updated at" field now shows non-zero date

### DIFF
--- a/pkg/handlers/move_queue_items.go
+++ b/pkg/handlers/move_queue_items.go
@@ -20,7 +20,7 @@ func payloadForMoveQueueItem(MoveQueueItem models.MoveQueueItem) *internalmessag
 		Locator:          swag.String(MoveQueueItem.Locator),
 		Status:           swag.String(MoveQueueItem.Status),
 		OrdersType:       swag.String(MoveQueueItem.OrdersType),
-		MoveDate:         fmtDate(MoveQueueItem.MoveDate),
+		MoveDate:         fmtDatePtr(MoveQueueItem.MoveDate),
 		CustomerDeadline: fmtDate(MoveQueueItem.CustomerDeadline),
 		LastModifiedDate: fmtDateTime(MoveQueueItem.LastModifiedDate),
 		LastModifiedName: swag.String(MoveQueueItem.LastModifiedName),

--- a/pkg/handlers/move_queue_items_test.go
+++ b/pkg/handlers/move_queue_items_test.go
@@ -2,7 +2,6 @@ package handlers
 
 import (
 	"fmt"
-
 	"net/http/httptest"
 
 	queueop "github.com/transcom/mymove/pkg/gen/internalapi/internaloperations/queues"
@@ -30,6 +29,7 @@ func (suite *HandlerSuite) TestShowQueueHandler() {
 			OrdersID: order.ID,
 			Status:   models.MoveStatus(status),
 		}
+		suite.mustSave(&newMove)
 
 		// Make a PPM
 		newMove.CreatePPM(suite.db,
@@ -47,11 +47,6 @@ func (suite *HandlerSuite) TestShowQueueHandler() {
 			true,
 			nil,
 		)
-		suite.mustSave(&newMove)
-
-		// _, verrs, locErr := order.CreateNewMove(suite.db, nil)
-		// suite.False(verrs.HasAny(), "failed to create new move")
-		// suite.Nil(locErr)
 
 		// And: the context contains the auth values
 		path := "/queues/" + queueType

--- a/pkg/handlers/move_queue_items_test.go
+++ b/pkg/handlers/move_queue_items_test.go
@@ -30,11 +30,28 @@ func (suite *HandlerSuite) TestShowQueueHandler() {
 			OrdersID: order.ID,
 			Status:   models.MoveStatus(status),
 		}
+
+		// Make a PPM
+		newMove.CreatePPM(suite.db,
+			nil,
+			models.Int64Pointer(8000),
+			models.StringPointer("estimate incentive"),
+			models.TimePointer(testdatagen.DateInsidePeakRateCycle),
+			models.StringPointer("72017"),
+			models.BoolPointer(false),
+			nil,
+			models.StringPointer("60605"),
+			models.BoolPointer(false),
+			nil,
+			models.StringPointer("estimate sit"),
+			true,
+			nil,
+		)
 		suite.mustSave(&newMove)
 
-		_, verrs, locErr := order.CreateNewMove(suite.db, nil)
-		suite.False(verrs.HasAny(), "failed to create new move")
-		suite.Nil(locErr)
+		// _, verrs, locErr := order.CreateNewMove(suite.db, nil)
+		// suite.False(verrs.HasAny(), "failed to create new move")
+		// suite.Nil(locErr)
 
 		// And: the context contains the auth values
 		path := "/queues/" + queueType
@@ -51,6 +68,7 @@ func (suite *HandlerSuite) TestShowQueueHandler() {
 
 		// Then: Expect a 200 status code
 		okResponse := showResponse.(*queueop.ShowQueueOK)
+		fmt.Printf("status: %v res: %v", status, okResponse)
 		moveQueueItem := okResponse.Payload[0]
 
 		// And: Returned query to include our added move

--- a/pkg/models/queue.go
+++ b/pkg/models/queue.go
@@ -18,7 +18,7 @@ type MoveQueueItem struct {
 	Locator          string                              `json:"locator" db:"locator"`
 	Status           string                              `json:"status" db:"status"`
 	OrdersType       string                              `json:"orders_type" db:"orders_type"`
-	MoveDate         time.Time                           `json:"move_date" db:"move_date"`
+	MoveDate         *time.Time                          `json:"move_date" db:"move_date"`
 	CustomerDeadline time.Time                           `json:"customer_deadline" db:"customer_deadline"`
 	LastModifiedDate time.Time                           `json:"last_modified_date" db:"last_modified_date"`
 	LastModifiedName string                              `json:"last_modified_name" db:"last_modified_name"`
@@ -45,7 +45,7 @@ func GetMoveQueueItems(db *pop.Connection, lifecycleState string) ([]MoveQueueIt
 			FROM moves
 			JOIN orders as ord ON moves.orders_id = ord.id
 			JOIN service_members AS sm ON ord.service_member_id = sm.id
-			JOIN personally_procured_moves AS ppm ON moves.id = ppm.move_id
+			LEFT JOIN personally_procured_moves AS ppm ON moves.id = ppm.move_id
 			WHERE moves.status = 'SUBMITTED'
 		`
 	} else if lifecycleState == "ppm" {
@@ -63,7 +63,7 @@ func GetMoveQueueItems(db *pop.Connection, lifecycleState string) ([]MoveQueueIt
 			FROM moves
 			JOIN orders as ord ON moves.orders_id = ord.id
 			JOIN service_members AS sm ON ord.service_member_id = sm.id
-			JOIN personally_procured_moves AS ppm ON moves.id = ppm.move_id
+			LEFT JOIN personally_procured_moves AS ppm ON moves.id = ppm.move_id
 			WHERE moves.status = 'APPROVED'
 		`
 	} else {
@@ -81,7 +81,7 @@ func GetMoveQueueItems(db *pop.Connection, lifecycleState string) ([]MoveQueueIt
 			FROM moves
 			JOIN orders as ord ON moves.orders_id = ord.id
 			JOIN service_members AS sm ON ord.service_member_id = sm.id
-			JOIN personally_procured_moves AS ppm ON moves.id = ppm.move_id
+			LEFT JOIN personally_procured_moves AS ppm ON moves.id = ppm.move_id
 		`
 	}
 

--- a/pkg/models/queue.go
+++ b/pkg/models/queue.go
@@ -38,13 +38,14 @@ func GetMoveQueueItems(db *pop.Connection, lifecycleState string) ([]MoveQueueIt
 				CONCAT(COALESCE(sm.last_name, '*missing*'), ', ', COALESCE(sm.first_name, '*missing*')) AS customer_name,
 				moves.locator as locator,
 				ord.orders_type as orders_type,
-				current_date as move_date,
+				ppm.planned_move_date as move_date,
 				moves.created_at as created_at,
 				moves.updated_at as last_modified_date,
 				moves.status as status
 			FROM moves
 			JOIN orders as ord ON moves.orders_id = ord.id
 			JOIN service_members AS sm ON ord.service_member_id = sm.id
+			JOIN personally_procured_moves AS ppm ON moves.id = ppm.move_id
 			WHERE moves.status = 'SUBMITTED'
 		`
 	} else if lifecycleState == "ppm" {
@@ -55,13 +56,14 @@ func GetMoveQueueItems(db *pop.Connection, lifecycleState string) ([]MoveQueueIt
 				CONCAT(COALESCE(sm.last_name, '*missing*'), ', ', COALESCE(sm.first_name, '*missing*')) AS customer_name,
 				moves.locator as locator,
 				ord.orders_type as orders_type,
-				current_date as move_date,
+				ppm.planned_move_date as move_date,
 				moves.created_at as created_at,
 				moves.updated_at as last_modified_date,
 				moves.status as status
 			FROM moves
 			JOIN orders as ord ON moves.orders_id = ord.id
 			JOIN service_members AS sm ON ord.service_member_id = sm.id
+			JOIN personally_procured_moves AS ppm ON moves.id = ppm.move_id
 			WHERE moves.status = 'APPROVED'
 		`
 	} else {
@@ -72,13 +74,14 @@ func GetMoveQueueItems(db *pop.Connection, lifecycleState string) ([]MoveQueueIt
 				CONCAT(COALESCE(sm.last_name, '*missing*'), ', ', COALESCE(sm.first_name, '*missing*')) AS customer_name,
 				moves.locator as locator,
 				ord.orders_type as orders_type,
-				current_date as move_date,
+				ppm.planned_move_date as move_date,
 				moves.created_at as created_at,
 				moves.updated_at as last_modified_date,
 				moves.status as status
 			FROM moves
 			JOIN orders as ord ON moves.orders_id = ord.id
 			JOIN service_members AS sm ON ord.service_member_id = sm.id
+			JOIN personally_procured_moves AS ppm ON moves.id = ppm.move_id
 		`
 	}
 

--- a/pkg/models/queue.go
+++ b/pkg/models/queue.go
@@ -40,7 +40,7 @@ func GetMoveQueueItems(db *pop.Connection, lifecycleState string) ([]MoveQueueIt
 				ord.orders_type as orders_type,
 				current_date as move_date,
 				moves.created_at as created_at,
-				current_time as last_modified_date,
+				moves.updated_at as last_modified_date,
 				moves.status as status
 			FROM moves
 			JOIN orders as ord ON moves.orders_id = ord.id
@@ -57,7 +57,7 @@ func GetMoveQueueItems(db *pop.Connection, lifecycleState string) ([]MoveQueueIt
 				ord.orders_type as orders_type,
 				current_date as move_date,
 				moves.created_at as created_at,
-				current_time as last_modified_date,
+				moves.updated_at as last_modified_date,
 				moves.status as status
 			FROM moves
 			JOIN orders as ord ON moves.orders_id = ord.id
@@ -74,7 +74,7 @@ func GetMoveQueueItems(db *pop.Connection, lifecycleState string) ([]MoveQueueIt
 				ord.orders_type as orders_type,
 				current_date as move_date,
 				moves.created_at as created_at,
-				current_time as last_modified_date,
+				moves.updated_at as last_modified_date,
 				moves.status as status
 			FROM moves
 			JOIN orders as ord ON moves.orders_id = ord.id


### PR DESCRIPTION
## Description

This changes the query line that fills the updated_at field to pull from the moves table instead of plopping "current_date" in there. 

## Reviewer Notes

Look ok? 

## Code Review Verification Steps

* [ ] All tests pass.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/blob/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* [ ] Any migrations/schema changes also update the diagram in docs/schema/dp3.sqs
* [ ] There are no aXe warnings for UI.
* [ ] This works in IE.
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @willowbl00
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Request review from a member of a different team.
* [ ] (TRIAL) Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/157617014) for this change
* [this article](https://en.wikipedia.org/wiki/0) explains more about the approach used.

## Screenshots
<img width="1351" alt="screen shot 2018-06-11 at 4 59 49 pm" src="https://user-images.githubusercontent.com/10379814/41263016-0c18ec58-6d99-11e8-8258-094d346bcefd.png">

