### PR TITLE
Els add eslint config

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,1 @@
+{ "extends": "react-app"}

--- a/src/scenes/EntitlementBar/index.test.js
+++ b/src/scenes/EntitlementBar/index.test.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
 import { shallow } from 'enzyme';
 import EntitlementBar from '.';
 

--- a/src/scenes/Feedback/index.test.js
+++ b/src/scenes/Feedback/index.test.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
-import { shallow } from 'enzyme';
 import { Feedback } from '.';
 import store from 'shared/store';
 

--- a/src/scenes/Landing/index.test.js
+++ b/src/scenes/Landing/index.test.js
@@ -1,9 +1,6 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
-import { Provider } from 'react-redux';
 import { shallow } from 'enzyme';
 import { Landing } from '.';
-import { no_op } from 'shared/utils';
 
 describe('HomePage tests', () => {
   let wrapper;

--- a/src/scenes/Legalese/index.test.js
+++ b/src/scenes/Legalese/index.test.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
-import { shallow } from 'enzyme';
 import SignedCertification from '.';
 import store from 'shared/store';
 

--- a/src/scenes/Moves/ducks.test.js
+++ b/src/scenes/Moves/ducks.test.js
@@ -4,8 +4,6 @@ import {
   SUBMIT_FOR_APPROVAL,
   moveReducer,
 } from './ducks';
-import { GET_LOGGED_IN_USER } from 'shared/User/ducks';
-import { get } from 'lodash';
 import loggedInUserPayload, {
   emptyPayload,
 } from 'shared/User/sampleLoggedInUserPayload';

--- a/src/scenes/MyMove/getWorkflowRoutes.test.js
+++ b/src/scenes/MyMove/getWorkflowRoutes.test.js
@@ -1,9 +1,7 @@
 import { getPagesInFlow, getNextIncompletePage } from './getWorkflowRoutes';
 import { NULL_UUID } from 'shared/constants';
 describe('when getting the routes for the current workflow', () => {
-  let profileIsComplete;
   describe('given a complete service member', () => {
-    profileIsComplete = true;
     describe('given a PPM', () => {
       const props = {
         selectedMoveType: 'PPM',
@@ -88,7 +86,6 @@ describe('when getting the routes for the current workflow', () => {
     });
   });
   describe('given an incomplete service member', () => {
-    profileIsComplete = false;
     describe('given no move', () => {
       const props = {
         selectedMoveType: null,

--- a/src/scenes/MyMove/index.test.js
+++ b/src/scenes/MyMove/index.test.js
@@ -13,7 +13,7 @@ describe('AppWrapper tests', () => {
 
   it('renders without crashing', () => {
     const appWrapper = _wrapper.find('div');
-    expect(appWrapper).toBeDefined;
+    expect(appWrapper).toBeDefined();
   });
 
   it('renders Header component', () => {

--- a/src/scenes/Office/ducks.test.js
+++ b/src/scenes/Office/ducks.test.js
@@ -1,12 +1,5 @@
 import { APPROVE_REIMBURSEMENT, officeReducer } from './ducks';
 
-import { GET_LOGGED_IN_USER } from 'shared/User/ducks';
-import { get } from 'lodash';
-
-import loggedInUserPayload, {
-  emptyPayload,
-} from 'shared/User/sampleLoggedInUserPayload';
-
 function createAdvance(status) {
   return {
     id: '5d2b211c-0dca-4e6a-b0c0-a987d4fed5fb',

--- a/src/scenes/Orders/ducks.test.js
+++ b/src/scenes/Orders/ducks.test.js
@@ -6,8 +6,6 @@ import {
   ADD_UPLOADS,
   ordersReducer,
 } from './ducks';
-import { GET_LOGGED_IN_USER } from 'shared/User/ducks';
-import { get } from 'lodash';
 import loggedInUserPayload, {
   emptyPayload,
 } from 'shared/User/sampleLoggedInUserPayload';

--- a/src/scenes/ServiceMembers/ducks.test.js
+++ b/src/scenes/ServiceMembers/ducks.test.js
@@ -9,12 +9,9 @@ import {
   serviceMemberReducer,
 } from './ducks';
 
-import { GET_LOGGED_IN_USER } from 'shared/User/ducks';
-import { get } from 'lodash';
 import loggedInUserPayload, {
   emptyPayload,
 } from 'shared/User/sampleLoggedInUserPayload';
-import sampleLoggedInUserPayload from '../../shared/User/sampleLoggedInUserPayload';
 const smPayload = { ...loggedInUserPayload.payload.service_member };
 const expectedSM = {
   affiliation: 'ARMY',

--- a/src/scenes/Shipments/ducks.test.js
+++ b/src/scenes/Shipments/ducks.test.js
@@ -1,5 +1,4 @@
 import configureStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
 import {
   shipmentsReducer,
   createShowShipmentsRequest,

--- a/src/scenes/SubmittedFeedback/ducks.test.js
+++ b/src/scenes/SubmittedFeedback/ducks.test.js
@@ -1,12 +1,8 @@
 import configureStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
 import issuesReducer, {
   createShowIssuesRequest,
   createShowIssuesSuccess,
   createShowIssuesFailure,
-  SHOW_ISSUES,
-  SHOW_ISSUES_SUCCESS,
-  loadIssues,
 } from './ducks';
 
 jest.mock('./api');
@@ -73,21 +69,19 @@ describe('Issues Actions', () => {
 
 // TODO: Figure out how to mock the Swagger API call
 describe('given there are issues, when loadIssues is called', () => {
-  const middlewares = [thunk];
-  const initialState = { issues: null, hasError: false };
-  const mockStore = configureStore(middlewares);
+  // const middlewares = [thunk];
+  // const initialState = { issues: null, hasError: false };
+  // const mockStore = configureStore(middlewares);
 
   it('it creates SHOW_ISSUES_SUCCESS when submitted issues have been loaded and SHOW_ISSUES_SUCCESS payload is those issues', () => {
-    const expectedActions = [
-      { type: SHOW_ISSUES },
-      {
-        type: SHOW_ISSUES_SUCCESS,
-        items: { issues: [{ id: 11, description: 'too few dogs' }] },
-      },
-    ];
-
-    const store = mockStore(initialState);
-
+    // const expectedActions = [
+    //   { type: SHOW_ISSUES },
+    //   {
+    //     type: SHOW_ISSUES_SUCCESS,
+    //     items: { issues: [{ id: 11, description: 'too few dogs' }] },
+    //   },
+    // ];
+    // const store = mockStore(initialState);
     // return store.dispatch(loadIssues()).then(() => {
     //   // return of async actions
     //   expect(store.getActions()).toEqual(expectedActions);

--- a/src/shared/FailWhale/index.test.js
+++ b/src/shared/FailWhale/index.test.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
 import { shallow } from 'enzyme';
 import FailWhale from '.';
 

--- a/src/shared/JsonSchemaForm/JsonSchemaField.js
+++ b/src/shared/JsonSchemaForm/JsonSchemaField.js
@@ -69,7 +69,7 @@ const configureNumberField = (swaggerField, props) => {
 
 // TODO: This field should be smarter, it should store int-cents in the redux store
 // but allow the user to enter in dollars.
-// On first pass, that did not seem striaghtforward.
+// On first pass, that did not seem straightforward.
 const configureCentsField = (swaggerField, props) => {
   props.type = 'text';
   props.validate.push(validator.isNumber);

--- a/src/shared/JsonSchemaForm/index.test.js
+++ b/src/shared/JsonSchemaForm/index.test.js
@@ -1,10 +1,9 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
 
 import { reduxifyForm } from '.';
 import configureStore from 'redux-mock-store';
-import { shallow, mount, render } from 'enzyme';
+import { mount } from 'enzyme';
 
 const simpleSchema = {
   title: 'A registration form',

--- a/src/shared/JsonSchemaForm/validations.test.js
+++ b/src/shared/JsonSchemaForm/validations.test.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
 
 import { Provider } from 'react-redux';
 import { reducer as formReducer, reduxForm } from 'redux-form';
@@ -8,7 +7,7 @@ import { createStore, combineReducers } from 'redux';
 import JsonSchemaField from './JsonSchemaField';
 import { recursivelyValidateRequiredFields } from './index';
 
-import { shallow, mount, render } from 'enzyme';
+import { mount } from 'enzyme';
 
 describe('SchemaField tests', () => {
   const formHolster = field => {
@@ -47,7 +46,7 @@ describe('SchemaField tests', () => {
         !expectedError ? 'no error' : `error: ${expectedError}`
       }`, () => {
         let input = subject.find('input');
-        if (input.length == 0) {
+        if (input.length === 0) {
           input = subject.find('textarea');
         }
         input.simulate('change', { target: { value: testValue } });
@@ -267,7 +266,7 @@ describe('SchemaField tests', () => {
     const ssnField = {
       type: 'string',
       format: 'zip',
-      pattern: /^(\d{5}([\-]\d{4})?)$/,
+      pattern: /^(\d{5}([-]\d{4})?)$/,
       example: '61522-3323',
       'x-nullable': true,
       title: 'ZIP Code',

--- a/src/shared/LoadingPlaceholder/index.test.js
+++ b/src/shared/LoadingPlaceholder/index.test.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { shallow } from 'enzyme';
 import LoadingPlaceholder from '.';
 
 it('renders without crashing', () => {

--- a/src/shared/TransportationOffices/TransportationOfficeContactInfo.test.js
+++ b/src/shared/TransportationOffices/TransportationOfficeContactInfo.test.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
 import { shallow } from 'enzyme';
 import { TransportationOfficeContactInfo } from './TransportationOfficeContactInfo';
 

--- a/src/shared/Uploader/api.js
+++ b/src/shared/Uploader/api.js
@@ -1,4 +1,4 @@
-import { getClient, checkResponse } from 'shared/api';
+import { getClient } from 'shared/api';
 
 export async function GetSpec() {
   const client = await getClient();

--- a/src/shared/Uploader/index.test.js
+++ b/src/shared/Uploader/index.test.js
@@ -1,11 +1,11 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
-import { Provider } from 'react-redux';
+// import React from 'react';
+// import ReactDOM from 'react-dom';
+// import { Provider } from 'react-redux';
 //import { Uploader } from '.';
-import store from 'shared/store';
-const dummyFunc = () => {};
-const hasErrored = false;
-const hasSucceeded = false;
+// import store from 'shared/store';
+// const dummyFunc = () => {};
+// const hasErrored = false;
+// const hasSucceeded = false;
 
 it('renders without crashing', () => {
   // const div = document.createElement('div');

--- a/src/shared/User/Signin.test.js
+++ b/src/shared/User/Signin.test.js
@@ -1,13 +1,10 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
 import { shallow } from 'enzyme';
 import SignIn from './SignIn';
 
 describe('SignIn tests', () => {
-  let wrapper;
   it('renders without crashing', () => {
     const div = document.createElement('div');
-    wrapper = shallow(<SignIn />, div);
-    //expect(wrapper.find('.usa-grid').length).toEqual(1);
+    shallow(<SignIn />, div);
   });
 });

--- a/src/shared/WizardPage/index.test.js
+++ b/src/shared/WizardPage/index.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { mount, shallow } from 'enzyme';
+import { shallow } from 'enzyme';
 import { WizardPage } from 'shared/WizardPage';
 describe('given a WizardPage', () => {
   let wrapper, buttons;


### PR DESCRIPTION
## Description

I've added an `.eslintrc` file to the root of the project that applies the eslint rules that are used by the build. This means that editors with eslint support will apply same rules as the build and that you can run 
```
npx eslint --ignore-pattern '*.test.js' src
```
to see the warnings that appear in builds.

The build does not lint the test files but running
```
npx eslint src
```
will, so I have corrected the warnings that were appearing from that as well.

If we want to add additional rules, we will need to use `react-app-rewired` to configure the build to apply those rules. I've got another branch with that in place but wanted to get this in first.