### PR TITLE
Add cancelled status to move, ppm and orders

### DIFF
--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -1406,11 +1406,13 @@ definitions:
       - SUBMITTED
       - APPROVED
       - COMPLETED
+      - CANCELLED
     x-display-value:
       DRAFT: Draft
       SUBMITTED: Submitted
       APPROVED: Approved
       COMPLETED: Completed
+      CANCELLED: Cancelled
   PPMStatus:
     type: string
     title: Move status
@@ -1420,12 +1422,14 @@ definitions:
       - APPROVED
       - IN_PROGRESS
       - COMPLETED
+      - CANCELLED
     x-display-value:
       DRAFT: Draft
       SUBMITTED: Submitted
       APPROVED: Approved
       IN_PROGRESS: In Progress
       COMPLETED: Completed
+      CANCELLED: Cancelled
   OrdersStatus:
     type: string
     title: Move status
@@ -1433,10 +1437,12 @@ definitions:
       - DRAFT
       - SUBMITTED
       - APPROVED
+      - CANCELLED
     x-display-value:
       DRAFT: Draft
       SUBMITTED: Submitted
       APPROVED: Approved
+      CANCELLED: Cancelled
   OrdersType:
     type: string
     title: Orders type


### PR DESCRIPTION
## Description

Add cancelled status to move, ppm and orders

## Code Review Verification Steps

* [ ] All tests pass.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/blob/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* [ ] Any migrations/schema changes also update the diagram in docs/schema/dp3.sqs
* [ ] There are no aXe warnings for UI.
* [ ] This works in IE.
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @willowbl00
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Request review from a member of a different team.
* [ ] (TRIAL) Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/158262806) for this change


