### PR TITLE
Rek edit orders

### DIFF
--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -32,45 +32,24 @@ import faExternalLinkAlt from '@fortawesome/fontawesome-free-solid/faExternalLin
 
 const BasicsTabContent = props => {
   return (
-    <React.Fragment>
-      <OrdersPanel
-        title="Orders"
-        className="basics"
-        moveId={props.match.params.moveId}
-      />
+    <div className="basics">
+      <OrdersPanel title="Orders" moveId={props.match.params.moveId} />
       <CustomerInfoPanel
         title="Customer Info"
-        className="basics"
         moveId={props.match.params.moveId}
       />
-      <BackupInfoPanel
-        title="Backup Info"
-        className="basics"
-        moveId={props.match.params.moveId}
-      />
-      <AccountingPanel
-        title="Accounting"
-        className="basics"
-        moveId={props.match.params.moveId}
-      />
-    </React.Fragment>
+      <BackupInfoPanel title="Backup Info" moveId={props.match.params.moveId} />
+      <AccountingPanel title="Accounting" moveId={props.match.params.moveId} />
+    </div>
   );
 };
 
 const PPMTabContent = props => {
   return (
-    <React.Fragment>
-      <PaymentsPanel
-        title="Payments"
-        className="basics"
-        moveId={props.match.params.moveId}
-      />
-      <PPMEstimatesPanel
-        title="Estimates"
-        className="basics"
-        moveId={props.match.params.moveId}
-      />
-    </React.Fragment>
+    <div className="basics">
+      <PaymentsPanel title="Payments" moveId={props.match.params.moveId} />
+      <PPMEstimatesPanel title="Estimates" moveId={props.match.params.moveId} />
+    </div>
   );
 };
 

--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -33,13 +33,26 @@ import faExternalLinkAlt from '@fortawesome/fontawesome-free-solid/faExternalLin
 const BasicsTabContent = props => {
   return (
     <React.Fragment>
-      <OrdersPanel title="Orders" moveId={props.match.params.moveId} />
-      <CustomerInfoPanel
-        title="Customer Info"
+      <OrdersPanel
+        title="Orders"
+        className="basics"
         moveId={props.match.params.moveId}
       />
-      <BackupInfoPanel title="Backup Info" moveId={props.match.params.moveId} />
-      <AccountingPanel title="Accounting" moveId={props.match.params.moveId} />
+      <CustomerInfoPanel
+        title="Customer Info"
+        className="basics"
+        moveId={props.match.params.moveId}
+      />
+      <BackupInfoPanel
+        title="Backup Info"
+        className="basics"
+        moveId={props.match.params.moveId}
+      />
+      <AccountingPanel
+        title="Accounting"
+        className="basics"
+        moveId={props.match.params.moveId}
+      />
     </React.Fragment>
   );
 };
@@ -47,8 +60,16 @@ const BasicsTabContent = props => {
 const PPMTabContent = props => {
   return (
     <React.Fragment>
-      <PaymentsPanel title="Payments" moveId={props.match.params.moveId} />
-      <PPMEstimatesPanel title="Estimates" moveId={props.match.params.moveId} />
+      <PaymentsPanel
+        title="Payments"
+        className="basics"
+        moveId={props.match.params.moveId}
+      />
+      <PPMEstimatesPanel
+        title="Estimates"
+        className="basics"
+        moveId={props.match.params.moveId}
+      />
     </React.Fragment>
   );
 };

--- a/src/scenes/Office/OrdersInfo.jsx
+++ b/src/scenes/Office/OrdersInfo.jsx
@@ -35,7 +35,6 @@ class OrdersInfo extends Component {
   }
 
   render() {
-    const move = this.props.move;
     const orders = this.props.orders;
     const serviceMember = this.props.serviceMember;
     const name = compact([
@@ -82,7 +81,7 @@ class OrdersInfo extends Component {
             <OrdersViewerPanel
               title={name}
               className="document-viewer"
-              moveId={move.ID}
+              moveId={this.props.match.params.moveId}
             />
           </div>
         </div>
@@ -98,7 +97,6 @@ OrdersInfo.propTypes = {
 const mapStateToProps = state => ({
   swaggerError: state.swagger.hasErrored,
   ordersSchema: get(state, 'swagger.spec.definitions.CreateUpdateOrders', {}),
-  move: state.office.officeMove || {},
   orders: state.office.officeOrders || {},
   serviceMember: state.office.officeServiceMember || {},
   loadDependenciesHasSuccess: state.office.loadDependenciesHasSuccess,

--- a/src/scenes/Office/OrdersInfo.jsx
+++ b/src/scenes/Office/OrdersInfo.jsx
@@ -8,9 +8,6 @@ import LoadingPlaceholder from 'shared/LoadingPlaceholder';
 import Alert from 'shared/Alert';
 import OrdersViewerPanel from './OrdersViewerPanel';
 import { loadMoveDependencies } from './ducks.js';
-import { formatDate, formatDateTime } from 'shared/formatters';
-
-import { PanelSwaggerField, PanelField } from 'shared/EditablePanel';
 
 import './office.css';
 
@@ -38,11 +35,6 @@ class OrdersInfo extends Component {
   }
 
   render() {
-    const ordersFieldsProps = {
-      values: this.props.orders,
-      schema: this.props.ordersSchema,
-    };
-
     const move = this.props.move;
     const orders = this.props.orders;
     const serviceMember = this.props.serviceMember;
@@ -87,11 +79,10 @@ class OrdersInfo extends Component {
             {uploads}
           </div>
           <div className="usa-width-one-third orders-page-fields">
-            <h2 className="usa-heading">{name}</h2>
-
             <OrdersViewerPanel
-              title="Orders Viewer"
-              moveId={this.props.move.ID}
+              title={name}
+              className="document-viewer"
+              moveId={move.ID}
             />
           </div>
         </div>

--- a/src/scenes/Office/OrdersInfo.jsx
+++ b/src/scenes/Office/OrdersInfo.jsx
@@ -6,6 +6,7 @@ import { compact, get } from 'lodash';
 
 import LoadingPlaceholder from 'shared/LoadingPlaceholder';
 import Alert from 'shared/Alert';
+import OrdersViewerPanel from './OrdersViewerPanel';
 import { loadMoveDependencies } from './ducks.js';
 import { formatDate, formatDateTime } from 'shared/formatters';
 
@@ -88,67 +89,10 @@ class OrdersInfo extends Component {
           <div className="usa-width-one-third orders-page-fields">
             <h2 className="usa-heading">{name}</h2>
 
-            <PanelField title="Move Locator">{move.locator}</PanelField>
-            <PanelField title="DoD ID">{serviceMember.edipi}</PanelField>
-
-            <h3>
-              Orders {orders.orders_number} ({formatDate(orders.issue_date)})
-            </h3>
-            {uploads.length > 0 && (
-              <p className="uploaded-at">
-                Uploaded{' '}
-                {formatDateTime(orders.uploaded_orders.uploads[0].created_at)}
-              </p>
-            )}
-
-            <PanelSwaggerField
-              fieldName="orders_number"
-              {...ordersFieldsProps}
+            <OrdersViewerPanel
+              title="Orders Viewer"
+              moveId={this.props.move.ID}
             />
-
-            <PanelField
-              title="Date issued"
-              value={formatDate(orders.issue_date)}
-            />
-
-            <PanelSwaggerField fieldName="orders_type" {...ordersFieldsProps} />
-            <PanelSwaggerField
-              fieldName="orders_type_detail"
-              {...ordersFieldsProps}
-            />
-
-            <PanelField
-              title="Report by"
-              value={formatDate(orders.report_by_date)}
-            />
-
-            <PanelField title="Current Duty Station">
-              {orders.current_duty_station && orders.current_duty_station.name}
-            </PanelField>
-            <PanelField title="New Duty Station">
-              {orders.new_duty_station && orders.new_duty_station.name}
-            </PanelField>
-
-            {orders.has_dependents && (
-              <PanelField
-                className="Todo"
-                title="Dependents"
-                value="Authorized"
-              />
-            )}
-
-            <PanelSwaggerField
-              title="Dept. Indicator"
-              fieldName="department_indicator"
-              {...ordersFieldsProps}
-            />
-            <PanelSwaggerField
-              title="TAC"
-              fieldName="tac"
-              {...ordersFieldsProps}
-            />
-
-            <PanelField className="Todo" title="Doc status" />
           </div>
         </div>
       </div>

--- a/src/scenes/Office/OrdersPanel.jsx
+++ b/src/scenes/Office/OrdersPanel.jsx
@@ -159,11 +159,6 @@ function mapStateToProps(state) {
     },
 
     ordersSchema: get(state, 'swagger.spec.definitions.Orders', {}),
-    serviceMemberSchema: get(
-      state,
-      'swagger.spec.definitions.ServiceMemberPayload',
-      {},
-    ),
 
     hasError: false,
     errorMessage: state.office.error,

--- a/src/scenes/Office/OrdersViewerPanel.js
+++ b/src/scenes/Office/OrdersViewerPanel.js
@@ -24,7 +24,12 @@ import './office.css';
 
 const OrdersViewerDisplay = props => {
   const orders = props.orders;
-  const uploads = [];
+  const currentDutyStation = get(
+    props.serviceMember,
+    'current_station.name',
+    '',
+  );
+  const uploads = get(orders, 'uploaded_orders.uploads', []);
   const ordersFieldsProps = {
     values: props.orders,
     schema: props.ordersSchema,
@@ -43,7 +48,6 @@ const OrdersViewerDisplay = props => {
             title="Awaiting Review"
           />Orders {orders.orders_number} ({formatDate(orders.issue_date)})
         </span>
-
         {uploads.length > 0 && (
           <p className="uploaded-at">
             Uploaded{' '}
@@ -51,32 +55,95 @@ const OrdersViewerDisplay = props => {
           </p>
         )}
 
-        <PanelSwaggerField fieldName="orders_number" {...ordersFieldsProps} />
-        <PanelField title="Date issued" value={formatDate(orders.issue_date)} />
-        <PanelSwaggerField fieldName="orders_type" {...ordersFieldsProps} />
-        <PanelSwaggerField
-          fieldName="orders_type_detail"
-          {...ordersFieldsProps}
-        />
-        <PanelField
-          title="Report by"
-          value={formatDate(orders.report_by_date)}
-        />
-        <PanelField title="Current Duty Station">
-          {get(props.serviceMember, 'current_station.name', '')}
-        </PanelField>
-        <PanelField title="New Duty Station">
-          {get(orders, 'new_duty_station.name', '')}
-        </PanelField>
+        {orders.orders_number ? (
+          <PanelSwaggerField fieldName="orders_number" {...ordersFieldsProps} />
+        ) : (
+          <PanelField title="Orders number" className="missing">
+            Missing
+          </PanelField>
+        )}
+        {orders.issue_date ? (
+          <PanelField
+            title="Date issued"
+            value={formatDate(orders.issue_date)}
+          />
+        ) : (
+          <PanelField title="Date issued" className="missing">
+            Missing
+          </PanelField>
+        )}
+        {orders.orders_type ? (
+          <PanelSwaggerField fieldName="orders_type" {...ordersFieldsProps} />
+        ) : (
+          <PanelField title="Orders type" className="missing">
+            Missing
+          </PanelField>
+        )}
+        {orders.orders_type_detail ? (
+          <PanelSwaggerField
+            fieldName="orders_type_detail"
+            {...ordersFieldsProps}
+          />
+        ) : (
+          <PanelField title="Orders type detail" className="missing">
+            {' '}
+            Missing
+          </PanelField>
+        )}
+        {orders.report_by_date ? (
+          <PanelField
+            title="Report by"
+            value={formatDate(orders.report_by_date)}
+          />
+        ) : (
+          <PanelField title="Report by" className="missing">
+            Missing
+          </PanelField>
+        )}
+        {currentDutyStation ? (
+          <PanelField title="Current Duty Station">
+            {currentDutyStation}
+          </PanelField>
+        ) : (
+          <PanelField title="Current Duty Station" className="missing">
+            Missing
+          </PanelField>
+        )}
+        {orders.new_duty_station ? (
+          <PanelField title="New Duty Station">
+            {get(orders, 'new_duty_station.name', '')}
+          </PanelField>
+        ) : (
+          <PanelField title="New Duty Station" className="missing">
+            Missing
+          </PanelField>
+        )}
         {orders.has_dependents && (
           <PanelField title="Dependents" value="Authorized" />
         )}
-        <PanelSwaggerField
-          title="Dept. Indicator"
-          fieldName="department_indicator"
-          {...ordersFieldsProps}
-        />
-        <PanelSwaggerField title="TAC" fieldName="tac" {...ordersFieldsProps} />
+        {orders.department_indicator ? (
+          <PanelSwaggerField
+            title="Dept. Indicator"
+            fieldName="department_indicator"
+            {...ordersFieldsProps}
+          />
+        ) : (
+          <PanelField title="Dept. Indicator" className="missing">
+            Missing
+          </PanelField>
+        )}
+        {orders.tac ? (
+          <PanelSwaggerField
+            title="TAC"
+            fieldName="tac"
+            {...ordersFieldsProps}
+          />
+        ) : (
+          <PanelField title="TAC" className="missing">
+            Missing
+          </PanelField>
+        )}
+
         <PanelField className="Todo" title="Doc status" />
       </div>
     </React.Fragment>
@@ -85,7 +152,7 @@ const OrdersViewerDisplay = props => {
 
 const OrdersViewerEdit = props => {
   const orders = props.orders;
-  const uploads = [];
+  const uploads = get(orders, 'uploaded_orders.uploads', []);
   const schema = props.ordersSchema;
 
   return (
@@ -110,14 +177,10 @@ const OrdersViewerEdit = props => {
 
         <FormSection name="orders">
           <SwaggerField fieldName="orders_number" swagger={schema} />
-          <SwaggerField
-            fieldName="issue_date"
-            swagger={schema}
-            className="half-width"
-          />
+          <SwaggerField fieldName="issue_date" swagger={schema} />
           <SwaggerField fieldName="orders_type" swagger={schema} />
           <SwaggerField fieldName="orders_type_detail" swagger={schema} />
-          <PanelField
+          <SwaggerField
             title="Report by"
             fieldName="report_by_date"
             swagger={schema}

--- a/src/scenes/Office/OrdersViewerPanel.js
+++ b/src/scenes/Office/OrdersViewerPanel.js
@@ -1,0 +1,196 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+import { compact, get } from 'lodash';
+import { reduxForm, getFormValues, isValid } from 'redux-form';
+
+import editablePanel from './editablePanel';
+import LoadingPlaceholder from 'shared/LoadingPlaceholder';
+import Alert from 'shared/Alert';
+import { loadMoveDependencies, updateOrdersInfo } from './ducks.js';
+import { formatDate, formatDateTime } from 'shared/formatters';
+
+import { PanelSwaggerField, PanelField } from 'shared/EditablePanel';
+
+import './office.css';
+
+const OrdersViewerDisplay = props => {
+  const orders = props.orders;
+  const uploads = [];
+  const ordersFieldsProps = {
+    values: props.orders,
+    schema: props.schema,
+  };
+
+  return (
+    <React.Fragment>
+      <div>
+        <PanelField title="Move Locator">{props.move.locator}</PanelField>
+        <PanelField title="DoD ID">{props.serviceMember.edipi}</PanelField>
+
+        <h3>
+          Orders {orders.orders_number} ({formatDate(orders.issue_date)})
+        </h3>
+        {uploads.length > 0 && (
+          <p className="uploaded-at">
+            Uploaded{' '}
+            {formatDateTime(orders.uploaded_orders.uploads[0].created_at)}
+          </p>
+        )}
+
+        <PanelSwaggerField fieldName="orders_number" {...ordersFieldsProps} />
+
+        <PanelField title="Date issued" value={formatDate(orders.issue_date)} />
+
+        <PanelSwaggerField fieldName="orders_type" {...ordersFieldsProps} />
+        <PanelSwaggerField
+          fieldName="orders_type_detail"
+          {...ordersFieldsProps}
+        />
+
+        <PanelField
+          title="Report by"
+          value={formatDate(orders.report_by_date)}
+        />
+
+        <PanelField title="Current Duty Station">
+          {orders.current_duty_station && orders.current_duty_station.name}
+        </PanelField>
+        <PanelField title="New Duty Station">
+          {orders.new_duty_station && orders.new_duty_station.name}
+        </PanelField>
+
+        {orders.has_dependents && (
+          <PanelField className="Todo" title="Dependents" value="Authorized" />
+        )}
+
+        <PanelSwaggerField
+          title="Dept. Indicator"
+          fieldName="department_indicator"
+          {...ordersFieldsProps}
+        />
+        <PanelSwaggerField title="TAC" fieldName="tac" {...ordersFieldsProps} />
+
+        <PanelField className="Todo" title="Doc status" />
+      </div>
+    </React.Fragment>
+  );
+};
+
+const OrdersViewerEdit = props => {
+  const orders = props.orders;
+  const uploads = [];
+  const schema = props.schema;
+
+  return (
+    <React.Fragment>
+      <div>
+        <PanelField title="Move Locator">{props.move.locator}</PanelField>
+        <PanelField title="DoD ID">{props.serviceMember.edipi}</PanelField>
+
+        <h3>
+          Orders {orders.orders_number} ({formatDate(orders.issue_date)})
+        </h3>
+        {uploads.length > 0 && (
+          <p className="uploaded-at">
+            Uploaded{' '}
+            {formatDateTime(orders.uploaded_orders.uploads[0].created_at)}
+          </p>
+        )}
+
+        <PanelSwaggerField fieldName="orders_number" swagger={schema} />
+
+        <PanelField
+          title="Date issued"
+          fieldName="issue_date"
+          swagger={schema}
+        />
+
+        <PanelSwaggerField fieldName="orders_type" swagger={schema} />
+        <PanelSwaggerField fieldName="orders_type_detail" swagger={schema} />
+
+        <PanelField
+          title="Report by"
+          fieldName="report_by_date"
+          swagger={schema}
+        />
+
+        <PanelField title="Current Duty Station">
+          {orders.current_duty_station && orders.current_duty_station.name}
+        </PanelField>
+        <PanelField title="New Duty Station">
+          {orders.new_duty_station && orders.new_duty_station.name}
+        </PanelField>
+
+        {orders.has_dependents && (
+          <PanelField
+            className="Todo"
+            title="Dependents"
+            fieldName="has_dependents"
+            swagger={schema}
+          />
+        )}
+
+        <PanelSwaggerField
+          title="Dept. Indicator"
+          fieldName="department_indicator"
+          swagger={schema}
+        />
+        <PanelSwaggerField title="TAC" fieldName="tac" swagger={schema} />
+        <PanelField
+          className="Todo"
+          title="Doc status"
+          fieldName="orders_status"
+          swagger={schema}
+        />
+      </div>
+    </React.Fragment>
+  );
+};
+
+const formName = 'orders_document_viewer';
+
+let OrdersViewerPanel = editablePanel(OrdersViewerDisplay, OrdersViewerEdit);
+OrdersViewerPanel = reduxForm({ form: formName })(OrdersViewerPanel);
+
+function mapStateToProps(state) {
+  return {
+    // reduxForm
+    initialValues: {
+      orders: get(state, 'office.officeOrders', {}),
+    },
+
+    schema: get(state, 'swagger.spec.definitions.Orders', {}),
+
+    hasError: false,
+    errorMessage: state.office.error,
+    isUpdating: false,
+
+    orders: get(state, 'office.officeOrders', {}),
+    serviceMember: get(state, 'office.officeServiceMember', {}),
+    move: get(state, 'office.officeMove', {}),
+
+    // editablePanel
+    formIsValid: isValid(formName)(state),
+    getUpdateArgs: function() {
+      let values = getFormValues(formName)(state);
+      return [
+        get(state, 'office.officeOrders.id'),
+        values.orders,
+        get(state, 'office.officeServiceMember.id'),
+        values.serviceMember,
+      ];
+    },
+  };
+}
+function mapDispatchToProps(dispatch) {
+  return bindActionCreators(
+    {
+      update: updateOrdersInfo,
+    },
+    dispatch,
+  );
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(OrdersViewerPanel);

--- a/src/scenes/Office/OrdersViewerPanel.js
+++ b/src/scenes/Office/OrdersViewerPanel.js
@@ -176,10 +176,14 @@ const OrdersViewerEdit = props => {
         )}
 
         <FormSection name="orders">
-          <SwaggerField fieldName="orders_number" swagger={schema} />
+          <SwaggerField fieldName="orders_number" swagger={schema} required />
           <SwaggerField fieldName="issue_date" swagger={schema} />
-          <SwaggerField fieldName="orders_type" swagger={schema} />
-          <SwaggerField fieldName="orders_type_detail" swagger={schema} />
+          <SwaggerField fieldName="orders_type" swagger={schema} required />
+          <SwaggerField
+            fieldName="orders_type_detail"
+            swagger={schema}
+            required
+          />
           <SwaggerField
             title="Report by"
             fieldName="report_by_date"

--- a/src/shared/EditablePanel/index.css
+++ b/src/shared/EditablePanel/index.css
@@ -18,7 +18,7 @@
   font-size: .9em;
 }
 
-.editable-panel-header {
+.basics .editable-panel-header {
   font-size: 1.7rem;
   font-weight: bold;
   background-color: #f1f1f1;
@@ -27,15 +27,31 @@
   position: relative;
 }
 
+.document-viewer .editable-panel-header {
+  font-size: 2rem;
+  font-weight: bold;
+  padding: .4em 1em;
+  position: relative;
+}
+
 .short-field {
   max-width: 46rem;
   display: inline-block;
 }
 
-.editable-panel-content {
+.basics .editable-panel-content {
   padding-left: 1.7rem;
   padding-right: 1.7rem;
   border: solid #f1f1f1;
+  border-width: 0 3px 3px 3px;
+  padding-top: 8px;
+  padding-bottom: 9px;
+  background: white;
+}
+
+.document-viewer .editable-panel-content {
+  padding-left: 1.7rem;
+  padding-right: 1.7rem;
   border-width: 0 3px 3px 3px;
   padding-top: 8px;
   padding-bottom: 9px;
@@ -52,7 +68,7 @@
   margin-left: 2em;
 }
 
-.editable-panel-edit {
+.basics .editable-panel-edit {
   font-weight: normal;
   font-size: .9em;
   position: absolute;
@@ -61,12 +77,21 @@
   text-decoration: none;
 }
 
-.editable-panel.is-editable .editable-panel-header {
+.document-viewer .editable-panel-edit {
+  font-size: .9em;
+  position: absolute;
+  top: 1rem;
+  right: 2rem;
+  text-decoration: none;
+}
+
+.basics.editable-panel.is-editable .editable-panel-header {
   background: rgb(176,176,176);
   border-color: rgb(176,176,176);
   color: white;
 }
-.editable-panel.is-editable .editable-panel-content {
+
+.basics.editable-panel.is-editable .editable-panel-content {
   border-style: dashed;
   border-color: rgb(176,176,176);
 }
@@ -105,6 +130,13 @@
 .panel-subhead {
   font-weight: bold;
   margin-top: 2rem;
+}
+
+.document-viewer .panel-subhead {
+  font-weight: bold;
+  margin: 2rem 0 1rem 0;
+  font-size: 1.6rem;
+  display:inline-block;
 }
 
 .panel-subhead + .usa-input .usa-input-label {

--- a/src/shared/EditablePanel/index.css
+++ b/src/shared/EditablePanel/index.css
@@ -121,6 +121,11 @@
   width: 51%;
 }
 
+.panel-field.missing .field-value {
+  color:red;
+  font-style: italic;
+}
+
 .field-value-unbold {
   display: inline-block;
   margin-left: 8%;


### PR DESCRIPTION
## Description

This adds edit functionality to the orders viewer panel.
It:
* Adds a class to editable panels called document viewer to be used on all future doc viewers 
* Adds a class to current editable panels to use the current panel design
* applies editable panel functionality to orders viewer panel

## Reviewer Notes
CSS could probably be better...

## Code Review Verification Steps

* [x] All tests pass.
* [x] There are no aXe warnings for UI.
* [x] This works in IE.
* [x] Request review from a member of a different team.
* [x] (TRIAL) Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/158088346) for this change

## Screenshots
Display view:
<img width="451" alt="screen shot 2018-06-12 at 4 19 18 pm" src="https://user-images.githubusercontent.com/7401870/41322619-cdaddb1a-6e5e-11e8-93e3-a017e8bbd948.png">

Edit view:
<img width="329" alt="screen shot 2018-06-12 at 3 58 32 pm" src="https://user-images.githubusercontent.com/7401870/41322621-d17773be-6e5e-11e8-8b3b-76c273431948.png">
<img width="409" alt="screen shot 2018-06-12 at 4 19 45 pm" src="https://user-images.githubusercontent.com/7401870/41322629-d7867912-6e5e-11e8-8356-1763bdef6376.png">
