### PR TITLE
Display the ecs-deploy command being run

### DIFF
--- a/bin/ecs-deploy-service-container
+++ b/bin/ecs-deploy-service-container
@@ -13,6 +13,9 @@ usage() {
 }
 [[ -z $1 || -z $2 || -z $3 || -z $4 ]] && usage
 
+# Display command being run
+echo "$0 $*"
+
 set -u
 
 readonly name=$1


### PR DESCRIPTION
Too often, I want to see exactly what parameters were used for a deploy.
This displays them.