### PR TITLE
els max advance adjusts with changes to weight [delivers #158091234]

### DIFF
--- a/src/scenes/Moves/Ppm/ducks.js
+++ b/src/scenes/Moves/Ppm/ducks.js
@@ -136,7 +136,7 @@ export function getRawWeightInfo(state) {
 }
 
 export function getMaxAdvance(state) {
-  const maxIncentive = get(state, 'ppm.currentPpm.incentive_estimate_max');
+  const maxIncentive = get(state, 'ppm.incentive_estimate_max');
   // we are using 20000000 since it is the largest number MacRae found that could be stored in table
   // and we don't want to block the user from requesting an advance if the rate engine fails
   return maxIncentive ? 0.6 * maxIncentive : 20000000;

--- a/src/scenes/Moves/Ppm/ducks.test.js
+++ b/src/scenes/Moves/Ppm/ducks.test.js
@@ -3,7 +3,6 @@ import {
   GET_PPM,
   GET_SIT_ESTIMATE,
   GET_PPM_ESTIMATE,
-  GET_PPM_MAX_ESTIMATE,
   ppmReducer,
   getMaxAdvance,
 } from './ducks';
@@ -224,7 +223,7 @@ describe('Ppm Reducer', () => {
   });
   describe('getMaxAdvance', () => {
     describe('when there is a max estimated incentive', () => {
-      const state = { ppm: { currentPpm: { incentive_estimate_max: 10000 } } };
+      const state = { ppm: { incentive_estimate_max: 10000 } };
       it('should return 60% of max estimated incentive', () => {
         expect(getMaxAdvance(state)).toEqual(6000);
       });


### PR DESCRIPTION

## Description

max advance calculation is based on pending values rather than stored values

## Reviewer Notes

To test: when you get to the weight screen adjust the weight and make sure the maximum advance changes with the incentives.

## Code Review Verification Steps

* [ x] All tests pass.
## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/158091234) for this change
