### PR TITLE
Adding CancelReason to move model

### DIFF
--- a/migrations/20180619004251_add_cancel_reason_to_move.up.fizz
+++ b/migrations/20180619004251_add_cancel_reason_to_move.up.fizz
@@ -1,0 +1,1 @@
+add_column("moves", "cancel_reason", "string", {"null": true})

--- a/pkg/models/move.go
+++ b/pkg/models/move.go
@@ -106,12 +106,17 @@ func (m *Move) Submit() error {
 }
 
 // Cancel cancels the Move and its associated PPMs
-func (m *Move) Cancel() error {
+func (m *Move) Cancel(reason *string) error {
 	if m.Status != MoveStatusSUBMITTED {
 		return errors.Wrap(ErrInvalidTransition, "Cancel")
 	}
 
 	m.Status = MoveStatusCANCELED
+
+	// If a reason was submitted, add it to the move record.
+	if *reason != "" {
+		m.CancelReason = reason
+	}
 
 	// This will work only if you use the PPM in question rather than a var representing it
 	// i.e. you can't use _, ppm := range PPMs, has to be PPMS[i] as below

--- a/pkg/models/move.go
+++ b/pkg/models/move.go
@@ -48,6 +48,7 @@ type Move struct {
 	PersonallyProcuredMoves PersonallyProcuredMoves            `has_many:"personally_procured_moves" order_by:"created_at desc"`
 	Status                  MoveStatus                         `json:"status" db:"status"`
 	SignedCertifications    SignedCertifications               `has_many:"signed_certifications" order_by:"created_at desc"`
+	CancelReason            *string                            `json:"cancel_reason" db:"cancel_reason"`
 }
 
 // Moves is not required by pop and may be deleted

--- a/pkg/models/move.go
+++ b/pkg/models/move.go
@@ -106,7 +106,7 @@ func (m *Move) Submit() error {
 }
 
 // Cancel cancels the Move and its associated PPMs
-func (m *Move) Cancel(reason *string) error {
+func (m *Move) Cancel(reason string) error {
 	if m.Status != MoveStatusSUBMITTED {
 		return errors.Wrap(ErrInvalidTransition, "Cancel")
 	}
@@ -114,8 +114,8 @@ func (m *Move) Cancel(reason *string) error {
 	m.Status = MoveStatusCANCELED
 
 	// If a reason was submitted, add it to the move record.
-	if *reason != "" {
-		m.CancelReason = reason
+	if reason != "" {
+		m.CancelReason = &reason
 	}
 
 	// This will work only if you use the PPM in question rather than a var representing it

--- a/pkg/models/move_test.go
+++ b/pkg/models/move_test.go
@@ -64,7 +64,7 @@ func (suite *ModelSuite) TestMoveStateMachine() {
 	reason := ""
 
 	// Can't cancel a move with DRAFT status
-	err = move.Cancel(&reason)
+	err = move.Cancel(reason)
 	suite.Equal(ErrInvalidTransition, errors.Cause(err))
 
 	// Once submitted
@@ -73,7 +73,7 @@ func (suite *ModelSuite) TestMoveStateMachine() {
 	suite.Equal(MoveStatusSUBMITTED, move.Status, "expected Submitted")
 
 	// Can cancel move
-	err = move.Cancel(&reason)
+	err = move.Cancel(reason)
 	suite.Nil(err)
 	suite.Equal(MoveStatusCANCELED, move.Status, "expected Canceled")
 
@@ -95,7 +95,7 @@ func (suite *ModelSuite) TestMoveCancellationWithReason() {
 	suite.Equal(MoveStatusSUBMITTED, move.Status, "expected Submitted")
 
 	// Can cancel move, and status changes as expected
-	err = move.Cancel(&reason)
+	err = move.Cancel(reason)
 	suite.Nil(err)
 	suite.Equal(MoveStatusCANCELED, move.Status, "expected Canceled")
 	suite.Equal(&reason, move.CancelReason, "expected 'SM's orders revoked'")

--- a/pkg/models/move_test.go
+++ b/pkg/models/move_test.go
@@ -61,9 +61,10 @@ func (suite *ModelSuite) TestMoveStateMachine() {
 	move, verrs, err := order1.CreateNewMove(suite.db, &selectedType)
 	suite.Nil(err)
 	suite.False(verrs.HasAny(), "failed to validate move")
+	reason := ""
 
 	// Can't cancel a move with DRAFT status
-	err = move.Cancel()
+	err = move.Cancel(&reason)
 	suite.Equal(ErrInvalidTransition, errors.Cause(err))
 
 	// Once submitted
@@ -72,7 +73,29 @@ func (suite *ModelSuite) TestMoveStateMachine() {
 	suite.Equal(MoveStatusSUBMITTED, move.Status, "expected Submitted")
 
 	// Can cancel move
-	err = move.Cancel()
+	err = move.Cancel(&reason)
+	suite.Nil(err)
+	suite.Equal(MoveStatusCANCELED, move.Status, "expected Canceled")
+
+}
+
+func (suite *ModelSuite) TestMoveCancellationWithReason() {
+	order1, _ := testdatagen.MakeOrder(suite.db)
+
+	var selectedType = internalmessages.SelectedMoveTypeCOMBO
+
+	move, verrs, err := order1.CreateNewMove(suite.db, &selectedType)
+	suite.Nil(err)
+	suite.False(verrs.HasAny(), "failed to validate move")
+	reason := "SM's orders revoked"
+
+	// Check to ensure move shows SUBMITTED before Cancel()
+	err = move.Submit()
+	suite.Nil(err)
+	suite.Equal(MoveStatusSUBMITTED, move.Status, "expected Submitted")
+
+	// Can cancel move, and status changes as expected
+	err = move.Cancel(&reason)
 	suite.Nil(err)
 	suite.Equal(MoveStatusCANCELED, move.Status, "expected Canceled")
 

--- a/pkg/models/move_test.go
+++ b/pkg/models/move_test.go
@@ -61,7 +61,7 @@ func (suite *ModelSuite) TestMoveStateMachine() {
 	move, verrs, err := order1.CreateNewMove(suite.db, &selectedType)
 	suite.Nil(err)
 	suite.False(verrs.HasAny(), "failed to validate move")
-	reason := "Just joking"
+	reason := ""
 
 	// Can't cancel a move with DRAFT status
 	err = move.Cancel(reason)
@@ -76,7 +76,7 @@ func (suite *ModelSuite) TestMoveStateMachine() {
 	err = move.Cancel(reason)
 	suite.Nil(err)
 	suite.Equal(MoveStatusCANCELED, move.Status, "expected Canceled")
-	suite.Equal(&reason, move.CancelReason, "expected 'Just joking'")
+	suite.Nil(move.CancelReason)
 
 }
 

--- a/pkg/models/move_test.go
+++ b/pkg/models/move_test.go
@@ -61,7 +61,7 @@ func (suite *ModelSuite) TestMoveStateMachine() {
 	move, verrs, err := order1.CreateNewMove(suite.db, &selectedType)
 	suite.Nil(err)
 	suite.False(verrs.HasAny(), "failed to validate move")
-	reason := ""
+	reason := "Just joking"
 
 	// Can't cancel a move with DRAFT status
 	err = move.Cancel(reason)
@@ -76,6 +76,7 @@ func (suite *ModelSuite) TestMoveStateMachine() {
 	err = move.Cancel(reason)
 	suite.Nil(err)
 	suite.Equal(MoveStatusCANCELED, move.Status, "expected Canceled")
+	suite.Equal(&reason, move.CancelReason, "expected 'Just joking'")
 
 }
 

--- a/pkg/models/move_test.go
+++ b/pkg/models/move_test.go
@@ -98,5 +98,6 @@ func (suite *ModelSuite) TestMoveCancellationWithReason() {
 	err = move.Cancel(&reason)
 	suite.Nil(err)
 	suite.Equal(MoveStatusCANCELED, move.Status, "expected Canceled")
+	suite.Equal(&reason, move.CancelReason, "expected 'SM's orders revoked'")
 
 }

--- a/pkg/models/personally_procured_move_test.go
+++ b/pkg/models/personally_procured_move_test.go
@@ -82,7 +82,8 @@ func (suite *ModelSuite) TestPPMStateMachine() {
 	suite.Equal(MoveStatusSUBMITTED, move.Status, "expected Submitted")
 
 	// When move is canceled, expect associated PPM to be canceled
-	err = move.Cancel()
+	reason := "Orders changed"
+	err = move.Cancel(&reason)
 	suite.Nil(err)
 	suite.Equal(MoveStatusCANCELED, move.Status, "expected Canceled")
 

--- a/pkg/models/personally_procured_move_test.go
+++ b/pkg/models/personally_procured_move_test.go
@@ -83,7 +83,7 @@ func (suite *ModelSuite) TestPPMStateMachine() {
 
 	// When move is canceled, expect associated PPM to be canceled
 	reason := "Orders changed"
-	err = move.Cancel(&reason)
+	err = move.Cancel(reason)
 	suite.Nil(err)
 	suite.Equal(MoveStatusCANCELED, move.Status, "expected Canceled")
 

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -467,6 +467,9 @@ definitions:
         format: date-time
       personally_procured_moves:
         $ref: '#/definitions/IndexPersonallyProcuredMovePayload'
+      cancel_reason:
+        type: string
+        x-nullable: true
     required:
       - id
       - orders_id


### PR DESCRIPTION
## Description

This expands the `move` model to have a CancelReason field (and has a migration to match). It creates a nullable field that can hold a string, should the office person canceling a move provide a typed explanation. The move.Cancel() function also now takes a string pointer and stores it as part of the move record upon cancellation. 

## Reviewer Notes

Especially open to hearing if the implementation of `reason` as an argument is done as effectively as it could be.

## Code Review Verification Steps

* [ ] All tests pass.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/blob/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* [ ] Any migrations/schema changes also update the diagram in docs/schema/dp3.sqs
* [ ] There are no aXe warnings for UI.
* [ ] This works in IE.
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @willowbl00
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Request review from a member of a different team.
* [ ] (TRIAL) Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/158309457) for this change
