### PR TITLE
Els static analysic js [delivers #158375524]

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,1 +1,4 @@
-{ "extends": "react-app"}
+{
+  "plugins": ["security"],
+  "extends": ["react-app", "plugin:security/recommended"]
+}

--- a/config-overrides.js
+++ b/config-overrides.js
@@ -1,0 +1,12 @@
+const rewireEslint = require('react-app-rewire-eslint');
+
+function overrideEslintOptions(options) {
+  // do stuff with the eslint options...
+  return options;
+}
+
+/* config-overrides.js */
+module.exports = function override(config, env) {
+  config = rewireEslint(config, env, overrideEslintOptions);
+  return config;
+};

--- a/package.json
+++ b/package.json
@@ -8,9 +8,11 @@
     "classnames": "^2.2.5",
     "enzyme": "^3.2.0",
     "enzyme-adapter-react-16": "^1.1.1",
+    "eslint-plugin-security": "^1.4.0",
     "filepond-plugin-file-validate-type": "^1.0.3",
     "filepond-plugin-image-exif-orientation": "^1.0.1",
-    "filepond-plugin-image-preview": "https://github.com/transcom/filepond-plugin-image-preview",
+    "filepond-plugin-image-preview":
+      "https://github.com/transcom/filepond-plugin-image-preview",
     "filepond-polyfill": "^1.0.2",
     "is-mobile": "^0.3.0",
     "jest-canvas-mock": "^1.0.2",
@@ -22,6 +24,8 @@
     "moment": "^2.22.1",
     "path-to-regexp": "^2.2.0",
     "react": "^16.2.0",
+    "react-app-rewire-eslint": "^0.2.3",
+    "react-app-rewired": "^1.5.2",
     "react-day-picker": "^7.1.8",
     "react-dom": "^16.2.0",
     "react-filepond": "^2.0.6",
@@ -51,12 +55,14 @@
   "name": "client",
   "private": true,
   "scripts": {
-    "build": "NODE_PATH=./src react-scripts build",
-    "eject": "NODE_PATH=./src react-scripts eject",
-    "start": "NODE_PATH=./src react-scripts start",
-    "test": "NODE_PATH=./src react-scripts test --env=jsdom",
-    "test:debug": "NODE_PATH=./src react-scripts --inspect-brk test --runInBand --env=jsdom",
-    "test:coverage": "NODE_PATH=./src react-scripts test --coverage --env=jsdom",
+    "build": "NODE_PATH=./src react-app-rewired build",
+    "eject": "NODE_PATH=./src react-app-rewired eject",
+    "start": "NODE_PATH=./src react-app-rewired start",
+    "test": "NODE_PATH=./src react-app-rewired test --env=jsdom",
+    "test:debug":
+      "NODE_PATH=./src react-app-rewired --inspect-brk test --runInBand --env=jsdom",
+    "test:coverage":
+      "NODE_PATH=./src react-app-rewired test --coverage --env=jsdom",
     "e2e-test": "NODE_PATH=./e2e jest ./e2e.test.js --env=jsdom",
     "prettier": "prettier",
     "adr-log": "adr-log -d ./docs/adr -i ./docs/adr/readme.md"

--- a/src/registerServiceWorker.js
+++ b/src/registerServiceWorker.js
@@ -14,7 +14,7 @@ const isLocalhost = Boolean(
     window.location.hostname === '[::1]' ||
     // 127.0.0.1/8 is considered localhost for IPv4.
     window.location.hostname.match(
-      /^127(?:\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}$/,
+      /^127(?:\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}$/, // eslint-disable-line  security/detect-unsafe-regex
     ),
 );
 

--- a/src/scenes/Legalese/SignatureForm.jsx
+++ b/src/scenes/Legalese/SignatureForm.jsx
@@ -4,7 +4,6 @@ import './SignatureForm.css';
 import validator from 'shared/JsonSchemaForm/validator';
 
 function SignatureForm(props) {
-  const { pristine, invalid, submitting } = props;
   return (
     <div>
       <h3>SIGNATURE</h3>

--- a/src/scenes/Legalese/index.jsx
+++ b/src/scenes/Legalese/index.jsx
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { push } from 'react-router-redux';
 import PropTypes from 'prop-types';
-
+import { getFormValues } from 'redux-form';
 import { reduxifyWizardForm } from 'shared/WizardPage/Form';
 import CertificationText from './CertificationText';
 import Alert from 'shared/Alert';
@@ -40,7 +40,7 @@ export class SignedCertification extends Component {
   }
 
   handleSubmit = () => {
-    const pendingValues = this.props.formData.values;
+    const pendingValues = this.props.values;
     const { latestSignedCertification } = this.props;
 
     if (latestSignedCertification) {
@@ -157,7 +157,7 @@ function mapStateToProps(state) {
       {},
     ),
     hasLoggedInUser: state.loggedInUser.hasSucceeded,
-    formData: state.form[formName],
+    values: getFormValues(formName)(state),
     ...state.signedCertification,
     has_sit: get(state.ppm, 'currentPpm.has_sit', false),
     has_advance: get(state.ppm, 'currentPpm.has_requested_advance', false),

--- a/src/scenes/Moves/MoveType.jsx
+++ b/src/scenes/Moves/MoveType.jsx
@@ -62,7 +62,7 @@ class BigButtonGroup extends Component {
             {(!isMobile || (isSelected && !this.state.isHidden)) && (
               <div>
                 {Object.keys(prosList || {}).map(function(key) {
-                  const pros = prosList[key];
+                  const pros = prosList[key]; // eslint-disable-line security/detect-object-injection
                   return (
                     <div key={key.toString()}>
                       <p>{key}</p>

--- a/src/scenes/Moves/Ppm/DateAndLocation.jsx
+++ b/src/scenes/Moves/Ppm/DateAndLocation.jsx
@@ -66,7 +66,7 @@ export class DateAndLocation extends Component {
   getDebouncedSitEstimate = (e, value, _, field) => {
     const { formValues, entitlement } = this.props;
     const estimateValues = cloneDeep(formValues);
-    estimateValues[field] = value;
+    estimateValues[field] = value; // eslint-disable-line security/detect-object-injection
     this.debouncedSitEstimate(
       estimateValues.planned_move_date,
       estimateValues.days_in_storage,

--- a/src/scenes/Moves/Ppm/PPMSizeWizard.jsx
+++ b/src/scenes/Moves/Ppm/PPMSizeWizard.jsx
@@ -21,6 +21,7 @@ export class PpmSizeWizardPage extends Component {
       let weight = currentPpm.weight_estimate;
       if (!isFinite(weight)) {
         // Initialize weight to be mid-range
+        // eslint-disable-next-line security/detect-object-injection
         let weightRange = weightInfo[pendingPpmSize];
         weight = weightRange.min + (weightRange.max - weightRange.min) / 2;
       }

--- a/src/scenes/Moves/Ppm/Size.jsx
+++ b/src/scenes/Moves/Ppm/Size.jsx
@@ -45,6 +45,7 @@ class BigButtonGroup extends Component {
     const smallSize = 'S';
     const medSize = 'M';
     const largeSize = 'L';
+    /* eslint-disable security/detect-object-injection */
     var small = createButton(
       smallSize,
       'A few items in your car?',
@@ -66,7 +67,7 @@ class BigButtonGroup extends Component {
       truckGray,
       'truck-gray',
     );
-
+    /* eslint-enable security/detect-object-injection */
     return (
       <div>
         <div className="usa-width-one-third">{small}</div>

--- a/src/scenes/Moves/Ppm/Weight.jsx
+++ b/src/scenes/Moves/Ppm/Weight.jsx
@@ -5,7 +5,7 @@ import { get, cloneDeep, without, has } from 'lodash';
 import PropTypes from 'prop-types';
 import Slider from 'react-rangeslider'; //todo: pull from node_modules, override
 import { Field } from 'redux-form';
-
+import { getFormValues } from 'redux-form';
 import YesNoBoolean from 'shared/Inputs/YesNoBoolean';
 import { SwaggerField } from 'shared/JsonSchemaForm/JsonSchemaField';
 import { reduxifyWizardForm } from 'shared/WizardPage/Form';
@@ -192,20 +192,20 @@ export class PpmWeight extends Component {
     }
   }
   handleSubmit = () => {
-    const { createOrUpdatePpm, advanceFormData } = this.props;
+    const { createOrUpdatePpm, advanceFormValues } = this.props;
     const moveId = this.props.match.params.moveId;
     const ppmBody = {
       weight_estimate: this.state.pendingPpmWeight,
     };
 
-    if (advanceFormData.values.has_requested_advance) {
+    if (advanceFormValues.has_requested_advance) {
       ppmBody.has_requested_advance = true;
       const requestedAmount = Math.round(
-        parseFloat(advanceFormData.values.requested_amount) * 100,
+        parseFloat(advanceFormValues.requested_amount) * 100,
       );
       ppmBody.advance = {
         requested_amount: requestedAmount,
-        method_of_receipt: advanceFormData.values.method_of_receipt,
+        method_of_receipt: advanceFormValues.method_of_receipt,
       };
     } else {
       ppmBody.has_requested_advance = false;
@@ -241,12 +241,12 @@ export class PpmWeight extends Component {
       error,
       hasEstimateError,
       ppmAdvanceSchema,
-      advanceFormData,
+      advanceFormValues,
       selectedWeightInfo,
     } = this.props;
     const hasRequestedAdvance = get(
-      advanceFormData,
-      'values.has_requested_advance',
+      advanceFormValues,
+      'has_requested_advance',
       false,
     );
     let advanceInitialValues = null;
@@ -408,7 +408,7 @@ function mapStateToProps(state) {
     currentWeight: get(state, 'ppm.currentPpm.weight_estimate'),
     schema: schema,
     ppmAdvanceSchema: ppmAdvanceSchema,
-    advanceFormData: state.form[requestAdvanceFormName],
+    advanceFormValues: getFormValues(requestAdvanceFormName)(state),
   };
 
   return props;

--- a/src/scenes/Moves/Ppm/ducks.js
+++ b/src/scenes/Moves/Ppm/ducks.js
@@ -149,7 +149,7 @@ export function getSelectedWeightInfo(state) {
   }
 
   const size = ppm ? ppm.size : 'L';
-  return weightInfo[size];
+  return weightInfo[size]; // eslint-disable-line security/detect-object-injection
 }
 
 // Reducer

--- a/src/scenes/Moves/Ppm/ducks.test.js
+++ b/src/scenes/Moves/Ppm/ducks.test.js
@@ -3,7 +3,6 @@ import {
   GET_PPM,
   GET_SIT_ESTIMATE,
   GET_PPM_ESTIMATE,
-  GET_PPM_MAX_ESTIMATE,
   ppmReducer,
   getMaxAdvance,
 } from './ducks';

--- a/src/scenes/MyMove/getWorkflowRoutes.jsx
+++ b/src/scenes/MyMove/getWorkflowRoutes.jsx
@@ -260,6 +260,7 @@ const pages = {
 };
 export const getPagesInFlow = state =>
   Object.keys(pages).filter(pageKey => {
+    // eslint-disable-next-line security/detect-object-injection
     const page = pages[pageKey];
     return page.isInFlow(state);
   });
@@ -284,6 +285,7 @@ export const getNextIncompletePage = (
 export const getWorkflowRoutes = props => {
   const pageList = getPagesInFlow(props);
   return Object.keys(pages).map(key => {
+    // eslint-disable-next-line security/detect-object-injection
     const currPage = pages[key];
     if (currPage.isInFlow(props)) {
       const render = currPage.render(

--- a/src/scenes/Review/EditDateAndLocation.jsx
+++ b/src/scenes/Review/EditDateAndLocation.jsx
@@ -161,6 +161,7 @@ class EditDateAndLocation extends Component {
   getDebouncedSitEstimate = (e, value, _, field) => {
     const { formValues, entitlement } = this.props;
     const estimateValues = cloneDeep(formValues);
+    // eslint-disable-next-line
     estimateValues[field] = value;
     this.debouncedSitEstimate(
       estimateValues.planned_move_date,

--- a/src/scenes/Review/Summary.jsx
+++ b/src/scenes/Review/Summary.jsx
@@ -60,9 +60,11 @@ export class Summary extends Component {
       };
       const preferredMethods = [];
       Object.keys(prefs).forEach(propertyName => {
+        /* eslint-disable */
         if (serviceMember[propertyName]) {
           preferredMethods.push(prefs[propertyName]);
         }
+        /* eslint-enable */
       });
       return preferredMethods.join(', ');
     }

--- a/src/scenes/ServiceMembers/BackupContact.jsx
+++ b/src/scenes/ServiceMembers/BackupContact.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
-
+import { getFormValues } from 'redux-form';
 import {
   updateServiceMember,
   createBackupContact,
@@ -134,6 +134,7 @@ class ContactForm extends Component {
 
 const validateContact = (values, form) => {
   let requiredErrors = {};
+  /* eslint-disable security/detect-object-injection */
   ['name', 'email'].forEach(requiredFieldName => {
     if (
       values[requiredFieldName] === undefined ||
@@ -142,6 +143,7 @@ const validateContact = (values, form) => {
       requiredErrors[requiredFieldName] = 'Required.';
     }
   });
+  /* eslint-enable security/detect-object-injection */
   return requiredErrors;
 };
 
@@ -159,7 +161,7 @@ export class BackupContact extends Component {
   }
 
   handleSubmit = () => {
-    const pendingValues = this.props.formData.values;
+    const pendingValues = this.props.values;
 
     if (pendingValues.telephone === '') {
       pendingValues.telephone = null;
@@ -255,7 +257,7 @@ function mapStateToProps(state) {
       'swagger.spec.definitions.CreateServiceMemberBackupContactPayload',
       {},
     ),
-    formData: state.form[formName],
+    values: getFormValues(formName)(state),
   };
 }
 export default connect(mapStateToProps, mapDispatchToProps)(BackupContact);

--- a/src/scenes/ServiceMembers/BackupMailingAddress.jsx
+++ b/src/scenes/ServiceMembers/BackupMailingAddress.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
-
+import { getFormValues } from 'redux-form';
 import { updateServiceMember } from './ducks';
 
 import { reduxifyWizardForm } from 'shared/WizardPage/Form';
@@ -14,7 +14,7 @@ const BackupMailingWizardForm = reduxifyWizardForm(formName);
 
 export class BackupMailingAddress extends Component {
   handleSubmit = () => {
-    const newAddress = { backup_mailing_address: this.props.formData.values };
+    const newAddress = { backup_mailing_address: this.props.values };
     this.props.updateServiceMember(newAddress);
   };
 
@@ -80,7 +80,7 @@ function mapDispatchToProps(dispatch) {
 function mapStateToProps(state) {
   return {
     schema: get(state, 'swagger.spec.definitions.Address', {}),
-    formData: state.form[formName],
+    values: getFormValues(formName)(state),
     ...state.serviceMember,
   };
 }

--- a/src/scenes/ServiceMembers/ContactInfo.jsx
+++ b/src/scenes/ServiceMembers/ContactInfo.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
-
+import { getFormValues } from 'redux-form';
 import { updateServiceMember } from './ducks';
 
 import { reduxifyWizardForm } from 'shared/WizardPage/Form';
@@ -42,7 +42,7 @@ const ContactWizardForm = reduxifyWizardForm(formName, validateContactForm);
 
 export class ContactInfo extends Component {
   handleSubmit = () => {
-    const pendingValues = this.props.formData.values;
+    const pendingValues = this.props.values;
     if (pendingValues) {
       this.props.updateServiceMember(pendingValues);
     }
@@ -116,7 +116,7 @@ function mapStateToProps(state) {
       'swagger.spec.definitions.CreateServiceMemberPayload',
       {},
     ),
-    formData: state.form[formName],
+    values: getFormValues(formName)(state),
     ...state.serviceMember,
   };
 }

--- a/src/scenes/ServiceMembers/DodInfo.jsx
+++ b/src/scenes/ServiceMembers/DodInfo.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
-
+import { getFormValues } from 'redux-form';
 import { Field } from 'redux-form';
 import validator from 'shared/JsonSchemaForm/validator';
 
@@ -113,7 +113,7 @@ const DodWizardForm = reduxifyWizardForm(formName, validateDodForm);
 
 export class DodInfo extends Component {
   handleSubmit = () => {
-    const pendingValues = this.props.formData.values;
+    const pendingValues = this.props.values;
     if (pendingValues) {
       const patch = pick(pendingValues, subsetOfFields);
       this.props.updateServiceMember(patch);
@@ -180,7 +180,7 @@ function mapStateToProps(state) {
       'swagger.spec.definitions.CreateServiceMemberPayload',
       {},
     ),
-    formData: state.form[formName],
+    values: getFormValues(formName)(state),
     ...state.serviceMember,
   };
   return props;

--- a/src/scenes/ServiceMembers/DutyStation.jsx
+++ b/src/scenes/ServiceMembers/DutyStation.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
-
+import { getFormValues } from 'redux-form';
 import { Field } from 'redux-form';
 import { get } from 'lodash';
 import { updateServiceMember } from './ducks';
@@ -47,7 +47,7 @@ export class DutyStation extends Component {
   };
 
   handleSubmit = (somethings, elses) => {
-    const pendingValues = this.props.formData.values;
+    const pendingValues = this.props.values;
     if (pendingValues) {
       this.props.updateServiceMember({
         current_station_id: pendingValues.current_station.id,
@@ -100,7 +100,7 @@ function mapStateToProps(state) {
       ? currentServiceMember.current_station
       : null;
   const props = {
-    formData: state.form[dutyStationFormName],
+    values: getFormValues(dutyStationFormName)(state),
     existingStation: dutyStation,
     ...state.serviceMember,
   };

--- a/src/scenes/ServiceMembers/Name.jsx
+++ b/src/scenes/ServiceMembers/Name.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
-
+import { getFormValues } from 'redux-form';
 import { updateServiceMember } from './ducks';
 import { reduxifyWizardForm } from 'shared/WizardPage/Form';
 import { SwaggerField } from 'shared/JsonSchemaForm/JsonSchemaField';
@@ -14,7 +14,7 @@ const NameWizardForm = reduxifyWizardForm(formName);
 
 export class Name extends Component {
   handleSubmit = () => {
-    const pendingValues = this.props.formData.values;
+    const pendingValues = this.props.values;
     if (pendingValues) {
       const patch = pick(pendingValues, subsetOfFields);
       this.props.updateServiceMember(patch);
@@ -80,7 +80,7 @@ function mapStateToProps(state) {
       'swagger.spec.definitions.CreateServiceMemberPayload',
       {},
     ),
-    formData: state.form[formName],
+    values: getFormValues(formName)(state),
     ...state.serviceMember,
   };
 }

--- a/src/scenes/ServiceMembers/ResidentialAddress.jsx
+++ b/src/scenes/ServiceMembers/ResidentialAddress.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
-
+import { getFormValues } from 'redux-form';
 import { updateServiceMember } from './ducks';
 import { reduxifyWizardForm } from 'shared/WizardPage/Form';
 import { SwaggerField } from 'shared/JsonSchemaForm/JsonSchemaField';
@@ -13,7 +13,7 @@ const ResidentalWizardForm = reduxifyWizardForm(formName);
 
 export class ResidentialAddress extends Component {
   handleSubmit = () => {
-    const newAddress = { residential_address: this.props.formData.values };
+    const newAddress = { residential_address: this.props.values };
     this.props.updateServiceMember(newAddress);
   };
 
@@ -74,7 +74,7 @@ function mapDispatchToProps(dispatch) {
 function mapStateToProps(state) {
   return {
     schema: get(state, 'swagger.spec.definitions.Address', {}),
-    formData: state.form[formName],
+    values: getFormValues(formName)(state),
     ...state.serviceMember,
   };
 }

--- a/src/scenes/Shipments/index.jsx
+++ b/src/scenes/Shipments/index.jsx
@@ -58,10 +58,11 @@ export class Shipments extends Component {
     const cards = [];
     for (let tdl in groupedShipments) {
       const tdlID = tdl.substr(0, 6);
+      const shipments = groupedShipments[tdl]; // eslint-disable-line security/detect-object-injection
       cards.push(
         <div className="tdl-box" key={tdlID}>
           <h3>TDL #{tdlID}</h3>
-          <ShipmentCards shipments={groupedShipments[tdl]} />
+          <ShipmentCards shipments={shipments} />
         </div>,
       );
     }

--- a/src/shared/EditablePanel/index.jsx
+++ b/src/shared/EditablePanel/index.jsx
@@ -24,12 +24,14 @@ PanelField.propTypes = {
 
 export const SwaggerValue = props => {
   const { fieldName, schema, values } = props;
+  /* eslint-disable security/detect-object-injection */
   const swaggerProps = schema.properties[fieldName];
 
   let value = values[fieldName];
   if (swaggerProps.enum) {
     value = swaggerProps['x-display-value'][value];
   }
+  /* eslint-enable security/detect-object-injection */
   return <React.Fragment>{value || null}</React.Fragment>;
 };
 SwaggerValue.propTypes = {

--- a/src/shared/JsonSchemaForm/JsonSchemaField.js
+++ b/src/shared/JsonSchemaForm/JsonSchemaField.js
@@ -36,6 +36,7 @@ const configureDropDown = (swaggerField, props) => {
 };
 
 const dropDownChildren = (swaggerField, props) => {
+  /* eslint-disable security/detect-object-injection */
   return (
     <Fragment>
       <option />
@@ -46,6 +47,7 @@ const dropDownChildren = (swaggerField, props) => {
       ))}
     </Fragment>
   );
+  /* eslint-enable security/detect-object-injection */
 };
 
 const configureNumberField = (swaggerField, props) => {
@@ -238,6 +240,7 @@ export const SwaggerField = props => {
   } = props;
   let swaggerField;
   if (swagger.properties) {
+    // eslint-disable-next-line security/detect-object-injection
     swaggerField = swagger.properties[fieldName];
   }
 
@@ -246,6 +249,7 @@ export const SwaggerField = props => {
   }
 
   if (required) {
+    // eslint-disable-next-line security/detect-object-injection
     swaggerField[ALWAYS_REQUIRED_KEY] = true;
   }
 
@@ -295,6 +299,7 @@ const createSchemaField = (
   fieldProps.title = title || swaggerField.title || fieldName;
   fieldProps.component = renderInputField;
   fieldProps.validate = [];
+  // eslint-disable-next-line security/detect-object-injection
   fieldProps.always_required = swaggerField[ALWAYS_REQUIRED_KEY];
 
   let inputProps = {

--- a/src/shared/JsonSchemaForm/index.jsx
+++ b/src/shared/JsonSchemaForm/index.jsx
@@ -5,6 +5,7 @@ import SchemaField, { ALWAYS_REQUIRED_KEY } from './JsonSchemaField';
 import { isEmpty, uniq } from 'lodash';
 import { reduxForm, Field } from 'redux-form';
 import './index.css';
+/* eslint-disable security/detect-object-injection */
 
 const renderGroupOrField = (fieldName, fields, uiSchema, nameSpace) => {
   /*TODO:

--- a/src/shared/JsonSchemaForm/index.test.js
+++ b/src/shared/JsonSchemaForm/index.test.js
@@ -81,6 +81,7 @@ beforeEach(() => {
 });
 
 it('renders without crashing', () => {
+  // eslint-disable-next-line
   expect(wrapper.exists(<form className="default" />)).toBe(true);
 });
 

--- a/src/shared/JsonSchemaForm/validations.test.js
+++ b/src/shared/JsonSchemaForm/validations.test.js
@@ -244,7 +244,7 @@ describe('SchemaField tests', () => {
     const emailField = {
       type: 'string',
       format: 'x-email',
-      pattern: '^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$',
+      pattern: '^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$', // eslint-disable-line
       example: 'john_bob@example.com',
       'x-nullable': true,
       title: 'Personal Email Address',
@@ -266,7 +266,7 @@ describe('SchemaField tests', () => {
     const ssnField = {
       type: 'string',
       format: 'zip',
-      pattern: /^(\d{5}([-]\d{4})?)$/,
+      pattern: /^(\d{5}([-]\d{4})?)$/, // eslint-disable-line
       example: '61522-3323',
       'x-nullable': true,
       title: 'ZIP Code',

--- a/src/shared/JsonSchemaForm/validator.js
+++ b/src/shared/JsonSchemaForm/validator.js
@@ -56,7 +56,7 @@ const normalizePhone = (value, previousValue) => {
     if (i === 3 || i === 6) {
       normalizedPhone += '-';
     }
-    normalizedPhone += onlyNums[i];
+    normalizedPhone += onlyNums[i]; // eslint-disable-line security/detect-object-injection
   }
   return normalizedPhone;
 };
@@ -74,7 +74,7 @@ const normalizeSSN = (value, previousValue) => {
     if (i === 3 || i === 5) {
       normalizedSSN += '-';
     }
-    normalizedSSN += onlyNums[i];
+    normalizedSSN += onlyNums[i]; // eslint-disable-line security/detect-object-injection
   }
   return normalizedSSN;
 };
@@ -92,7 +92,7 @@ const normalizeZip = (value, previousValue) => {
     if (i === 5) {
       normalizedZip += '-';
     }
-    normalizedZip += onlyNums[i];
+    normalizedZip += onlyNums[i]; // eslint-disable-line security/detect-object-injection
   }
   return normalizedZip;
 };

--- a/src/shared/ReduxHelpers/index.js
+++ b/src/shared/ReduxHelpers/index.js
@@ -10,7 +10,7 @@ function generateActionTypes(resourceName, actionTypes) {
   if (!resourceName) throw new Error('No resource name provided');
   let actions = {};
   actionTypes.forEach(actionType => {
-    actions[actionType] = actionName(resourceName, actionType);
+    actions[actionType] = actionName(resourceName, actionType); // eslint-disable-line security/detect-object-injection
   });
   return actions;
 }

--- a/src/shared/User/Authorization.jsx
+++ b/src/shared/User/Authorization.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-
+import { connect } from 'react-redux';
 // this is from https://hackernoon.com/role-based-authorization-in-react-c70bb7641db4
 // as of 3/8 we are not using this yet, but it seems like it would work once we have a need to include roles in user state
 const AuthorizationContainer = (WrappedComponent, allowedRoles) =>

--- a/src/shared/WizardPage/Form.jsx
+++ b/src/shared/WizardPage/Form.jsx
@@ -29,6 +29,8 @@ export class WizardFormPage extends Component {
   }
   componentDidUpdate(prevProps) {
     if (this.props.additionalValues) {
+      /* eslint-disable security/detect-object-injection */
+
       Object.keys(this.props.additionalValues).forEach(key => {
         if (
           this.props.additionalValues[key] !== prevProps.additionalValues[key]
@@ -37,6 +39,7 @@ export class WizardFormPage extends Component {
         }
       });
     }
+    /* eslint-enable security/detect-object-injection */
 
     if (this.props.hasSucceeded) this.onSubmitSuccessful();
     if (this.props.serverError) window.scrollTo(0, 0);

--- a/src/shared/WizardPage/generatePath.js
+++ b/src/shared/WizardPage/generatePath.js
@@ -1,6 +1,5 @@
 // this is borrowed from https://github.com/ReactTraining/react-router/blob/e6f9017c947b3ae49affa24cc320d0a86f765b55/packages/react-router/modules/generatePath.js
 // which has not been released yet
-
 import pathToRegexp from 'path-to-regexp';
 
 const patternCache = {};
@@ -8,6 +7,7 @@ const cacheLimit = 10000;
 let cacheCount = 0;
 
 const compileGenerator = pattern => {
+  /* eslint-disable security/detect-object-injection */
   const cacheKey = pattern;
   const cache = patternCache[cacheKey] || (patternCache[cacheKey] = {});
 
@@ -19,6 +19,7 @@ const compileGenerator = pattern => {
     cache[pattern] = compiledGenerator;
     cacheCount++;
   }
+  /* eslint-enable security/detect-object-injection */
 
   return compiledGenerator;
 };

--- a/src/shared/WizardPage/index.jsx
+++ b/src/shared/WizardPage/index.jsx
@@ -153,6 +153,7 @@ WizardPage.propTypes = {
   handleSubmit: PropTypes.func.isRequired,
   isAsync: PropTypes.bool.isRequired,
   hasSucceeded: (props, propName) => {
+    //eslint-disable-next-line
     if (props['isAsync'] && typeof props[propName] !== 'boolean') {
       return new Error('Async WizardPages must have hasSucceeded boolean prop');
     }

--- a/src/shared/entitlements.js
+++ b/src/shared/entitlements.js
@@ -12,11 +12,14 @@ export function getEntitlements(
   const totalKey = hasDependents
     ? 'total_weight_self_plus_dependents'
     : 'total_weight_self';
+  // eslint-disable-next-line security/detect-object-injection
+  const rankEntitlement = entitlements[rank];
   const entitlement = {
-    weight: entitlements[rank][totalKey],
-    pro_gear: entitlements[rank].pro_gear_weight,
+    // eslint-disable-next-line security/detect-object-injection
+    weight: rankEntitlement[totalKey],
+    pro_gear: rankEntitlement.pro_gear_weight,
     pro_gear_spouse: spouseHasProGear
-      ? entitlements[rank].pro_gear_weight_spouse
+      ? rankEntitlement.pro_gear_weight_spouse
       : 0,
   };
   entitlement.sum = sum([

--- a/yarn.lock
+++ b/yarn.lock
@@ -2510,7 +2510,7 @@ dot-prop@^4.1.0:
   dependencies:
     is-obj "^1.0.0"
 
-dotenv@4.0.0:
+dotenv@4.0.0, dotenv@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-4.0.0.tgz#864ef1379aced55ce6f95debecdce179f7a0cd1d"
 
@@ -2837,6 +2837,12 @@ eslint-plugin-react@7.4.0:
     has "^1.0.1"
     jsx-ast-utils "^2.0.0"
     prop-types "^15.5.10"
+
+eslint-plugin-security@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-security/-/eslint-plugin-security-1.4.0.tgz#d4f314484a80b1b613b8c8886e84f52efe1526c2"
+  dependencies:
+    safe-regex "^1.1.0"
 
 eslint-scope@^3.7.1:
   version "3.7.1"
@@ -6581,6 +6587,17 @@ rc@^1.0.1, rc@^1.1.6, rc@^1.1.7:
     ini "~1.3.0"
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
+
+react-app-rewire-eslint@^0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/react-app-rewire-eslint/-/react-app-rewire-eslint-0.2.3.tgz#88e93d74569c33fe22185d46f6a2b521c4dd7fb6"
+
+react-app-rewired@^1.5.2:
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/react-app-rewired/-/react-app-rewired-1.5.2.tgz#0f5cdbc92f47f166bb0bcadf8a5d00999b90f68f"
+  dependencies:
+    cross-spawn "^5.1.0"
+    dotenv "^4.0.0"
 
 react-day-picker@^7.1.8:
   version "7.1.9"


### PR DESCRIPTION
## Description

The DoD requires that we do security linting and suggested that we use [eslint-lugin-security](https://github.com/nodesecurity/eslint-plugin-security). `Create react app` doesn't allow configuration of eslint, but it is possible to use [react-app-rewired](https://github.com/timarney/react-app-rewired) to avoid ejecting, so that has also been set up. In addition the warnings it produced have been evaluated and either addressed or disabled on a case by case basis.

## Reviewer Notes

The primary warning that needed to be addressed was `detect-object-injection` which fires anytime `variable[key]` is used. See article below for why this is a warning. TL;DR: These need to be checked to make sure they don't have user input as the key. That was never the case for our code, so in most cases I have disabled the warning using 

```
// eslint-disable-next-line security/detect-object-injection
```
or in some cases by disabling the warning for a block of code like this:
```
 /* eslint-disable security/detect-object-injection */
  const cacheKey = pattern;
  const cache = patternCache[cacheKey] || (patternCache[cacheKey] = {});

  if (cache[pattern]) return cache[pattern];

  const compiledGenerator = pathToRegexp.compile(pattern);

  if (cacheCount < cacheLimit) {
    cache[pattern] = compiledGenerator;
    cacheCount++;
  }
  /* eslint-enable security/detect-object-injection */
```

There were several cases where `mapStateToProps` was using `formData: state.form[formName]`. I've replaced those usages with redux-form's `getFormValues` as this prevents any risk of modifying state.

## Code Review Verification Steps

* [ ] All tests pass.
* [x] There are no build warnings.
## References

* [Pivotal story](tbd) for this change
* [The dangers of square bracket notation](https://blog.liftsecurity.io/2015/01/14/the-dangers-of-square-bracket-notation/) explains more about the primary warning.
