### PR TITLE
Rek CancelMoveHandle

### DIFF
--- a/pkg/handlers/handlers.go
+++ b/pkg/handlers/handlers.go
@@ -179,6 +179,7 @@ func NewInternalAPIHandler(context HandlerContext) http.Handler {
 	internalAPI.OfficeApproveMoveHandler = ApproveMoveHandler(context)
 	internalAPI.OfficeApprovePPMHandler = ApprovePPMHandler(context)
 	internalAPI.OfficeApproveReimbursementHandler = ApproveReimbursementHandler(context)
+	internalAPI.OfficeCancelMoveHandler = CancelMoveHandler(context)
 
 	internalAPI.EntitlementsValidateEntitlementHandler = ValidateEntitlementHandler(context)
 

--- a/pkg/handlers/office.go
+++ b/pkg/handlers/office.go
@@ -74,7 +74,7 @@ func (h CancelMoveHandler) Handle(params officeop.CancelMoveParams) middleware.R
 	if err != nil || verrs.HasAny() {
 		return responseForVErrors(h.logger, verrs, err)
 	}
-	verrs, err = h.db.ValidateAndUpdate(orders)
+	verrs, err = h.db.ValidateAndUpdate(&orders)
 	if err != nil || verrs.HasAny() {
 		return responseForVErrors(h.logger, verrs, err)
 	}

--- a/pkg/handlers/office.go
+++ b/pkg/handlers/office.go
@@ -52,10 +52,11 @@ func (h CancelMoveHandler) Handle(params officeop.CancelMoveParams) middleware.R
 	if err != nil {
 		return responseForError(h.logger, err)
 	}
+
 	// Canceling move with result in canceled associated PPMs
-	err = move.Cancel()
+	err = move.Cancel(*params.Reason)
 	if err != nil {
-		h.logger.Error("Attempted to cancel move, got invalid transition", zap.Error(err), zap.String("reimbursement_status", string(reimbursement.Status)))
+		h.logger.Error("Attempted to cancel move, got invalid transition", zap.Error(err), zap.String("move_status", string(move.Status)))
 		return responseForError(h.logger, err)
 	}
 	// If move is canceled, orders must be canceled
@@ -65,7 +66,7 @@ func (h CancelMoveHandler) Handle(params officeop.CancelMoveParams) middleware.R
 	}
 	err = orders.Cancel()
 	if err != nil {
-		h.logger.Error("Attempted to cancel orders, got invalid transition", zap.Error(err), zap.String("reimbursement_status", string(reimbursement.Status)))
+		h.logger.Error("Attempted to cancel orders, got invalid transition", zap.Error(err), zap.String("orders_status", string(orders.Status)))
 		return responseForError(h.logger, err)
 	}
 

--- a/pkg/models/move.go
+++ b/pkg/models/move.go
@@ -126,13 +126,20 @@ func (m *Move) Cancel(reason string) error {
 			return err
 		}
 	}
+
+	// TODO: Orders can exist after related moves are canceled
+	err := m.Orders.Cancel()
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 
 // FetchMove fetches and validates a Move for this User
 func FetchMove(db *pop.Connection, session *auth.Session, id uuid.UUID) (*Move, error) {
 	var move Move
-	err := db.Q().Eager("PersonallyProcuredMoves.Advance", "SignedCertifications").Find(&move, id)
+	err := db.Q().Eager("PersonallyProcuredMoves.Advance", "SignedCertifications", "Orders").Find(&move, id)
 	if err != nil {
 		if errors.Cause(err).Error() == recordNotFoundErrorString {
 			return nil, ErrFetchNotFound

--- a/pkg/models/move_test.go
+++ b/pkg/models/move_test.go
@@ -53,15 +53,46 @@ func (suite *ModelSuite) TestFetchMove() {
 	suite.Equal(ErrFetchForbidden, err, "Expected to get a Forbidden back.")
 }
 
-func (suite *ModelSuite) TestMoveStateMachine() {
-	order1, _ := testdatagen.MakeOrder(suite.db)
+func (suite *ModelSuite) TestMoveCancellationWithReason() {
+	orders, err := testdatagen.MakeOrder(suite.db)
+	suite.Nil(err)
+	orders.Status = OrderStatusSUBMITTED // NEVER do this outside of a test.
+	suite.mustSave(&orders)
 
 	var selectedType = internalmessages.SelectedMoveTypeCOMBO
 
-	move, verrs, err := order1.CreateNewMove(suite.db, &selectedType)
+	move, verrs, err := orders.CreateNewMove(suite.db, &selectedType)
+	suite.Nil(err)
+	suite.False(verrs.HasAny(), "failed to validate move")
+	move.Orders = orders
+	reason := "SM's orders revoked"
+
+	// Check to ensure move shows SUBMITTED before Cancel()
+	err = move.Submit()
+	suite.Nil(err)
+	suite.Equal(MoveStatusSUBMITTED, move.Status, "expected Submitted")
+
+	// Can cancel move, and status changes as expected
+	err = move.Cancel(reason)
+	suite.Nil(err)
+	suite.Equal(MoveStatusCANCELED, move.Status, "expected Canceled")
+	suite.Equal(&reason, move.CancelReason, "expected 'SM's orders revoked'")
+
+}
+
+func (suite *ModelSuite) TestMoveStateMachine() {
+	orders, err := testdatagen.MakeOrder(suite.db)
+	suite.Nil(err)
+	orders.Status = OrderStatusSUBMITTED // NEVER do this outside of a test.
+	suite.mustSave(&orders)
+
+	var selectedType = internalmessages.SelectedMoveTypeCOMBO
+
+	move, verrs, err := orders.CreateNewMove(suite.db, &selectedType)
 	suite.Nil(err)
 	suite.False(verrs.HasAny(), "failed to validate move")
 	reason := ""
+	move.Orders = orders
 
 	// Can't cancel a move with DRAFT status
 	err = move.Cancel(reason)
@@ -77,28 +108,42 @@ func (suite *ModelSuite) TestMoveStateMachine() {
 	suite.Nil(err)
 	suite.Equal(MoveStatusCANCELED, move.Status, "expected Canceled")
 	suite.Nil(move.CancelReason)
-
 }
 
-func (suite *ModelSuite) TestMoveCancellationWithReason() {
-	order1, _ := testdatagen.MakeOrder(suite.db)
+func (suite *ModelSuite) TestCancelMoveCancelsOrdersPPM() {
+	// Given: A move with Orders, PPM and Move all in submitted state
+	orders, err := testdatagen.MakeOrder(suite.db)
+	suite.Nil(err)
+	orders.Status = OrderStatusSUBMITTED // NEVER do this outside of a test.
+	suite.mustSave(&orders)
 
 	var selectedType = internalmessages.SelectedMoveTypeCOMBO
 
-	move, verrs, err := order1.CreateNewMove(suite.db, &selectedType)
+	move, verrs, err := orders.CreateNewMove(suite.db, &selectedType)
 	suite.Nil(err)
 	suite.False(verrs.HasAny(), "failed to validate move")
-	reason := "SM's orders revoked"
+	move.Orders = orders
 
-	// Check to ensure move shows SUBMITTED before Cancel()
+	advance := BuildDraftReimbursement(1000, MethodOfReceiptMILPAY)
+
+	ppm, verrs, err := move.CreatePPM(suite.db, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, true, &advance)
+	suite.Nil(err)
+	suite.False(verrs.HasAny())
+
+	ppm.Status = PPMStatusSUBMITTED // NEVER do this outside of a test.
+
+	// Associate PPM with the move it's on.
+	move.PersonallyProcuredMoves = append(move.PersonallyProcuredMoves, *ppm)
 	err = move.Submit()
 	suite.Nil(err)
 	suite.Equal(MoveStatusSUBMITTED, move.Status, "expected Submitted")
 
-	// Can cancel move, and status changes as expected
+	// When move is canceled, expect associated PPM and Order to be canceled
+	reason := "Orders changed"
 	err = move.Cancel(reason)
 	suite.Nil(err)
-	suite.Equal(MoveStatusCANCELED, move.Status, "expected Canceled")
-	suite.Equal(&reason, move.CancelReason, "expected 'SM's orders revoked'")
 
+	suite.Equal(MoveStatusCANCELED, move.Status, "expected Canceled")
+	suite.Equal(PPMStatusCANCELED, move.PersonallyProcuredMoves[0].Status, "expected Canceled")
+	suite.Equal(OrderStatusCANCELED, move.Orders.Status, "expected Canceled")
 }

--- a/pkg/models/order.go
+++ b/pkg/models/order.go
@@ -93,6 +93,16 @@ func SaveOrder(db *pop.Connection, order *Order) (*validate.Errors, error) {
 // State Machine
 // Avoid calling Order.Status = ... ever. Use these methods to change the state.
 
+// Submit submits the Order
+func (o *Order) Submit() error {
+	if o.Status != OrderStatusDRAFT {
+		return errors.Wrap(ErrInvalidTransition, "Submit")
+	}
+
+	o.Status = OrderStatusSUBMITTED
+	return nil
+}
+
 // Cancel cancels the Order
 func (o *Order) Cancel() error {
 	if o.Status != OrderStatusSUBMITTED {

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -459,9 +459,6 @@ definitions:
         $ref: '#/definitions/SelectedMoveType'
       status:
         $ref: '#/definitions/MoveStatus'
-      cancel_reason:
-        type: string
-        example: "Change of orders"
       created_at:
         type: string
         format: date-time
@@ -472,6 +469,7 @@ definitions:
         $ref: '#/definitions/IndexPersonallyProcuredMovePayload'
       cancel_reason:
         type: string
+        example: "Change of orders"
         x-nullable: true
     required:
       - id
@@ -2417,6 +2415,12 @@ paths:
           format: uuid
           required: true
           description: UUID of the move
+        - in: body
+          name: reason
+          schema:
+            type: string
+          required: true
+          description: reason for cancelation of move
       responses:
         200:
           description: returns updated (canceled) move object

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -2419,6 +2419,7 @@ paths:
           name: reason
           schema:
             type: string
+            example: "Orders canceled"
           required: true
           description: reason for cancelation of move
       responses:
@@ -2431,7 +2432,7 @@ paths:
         401:
           description: must be authenticated to use this endpoint
         403:
-          description: not authorized to approve this move
+          description: not authorized to cancel this move
         409:
           description: the move is not in a state to be canceled
           schema:

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -2397,6 +2397,37 @@ paths:
             $ref: '#/definitions/MovePayload'
         500:
           description: server error
+  /moves/{moveId}/cancel:
+    post:
+      summary: Cancels a move
+      description: Cancels the basic details of a move. The status of the move will be updated to CANCELED
+      operationId: cancelMove
+      tags:
+        - office
+      parameters:
+        - name: moveId
+          in: path
+          type: string
+          format: uuid
+          required: true
+          description: UUID of the move
+      responses:
+        200:
+          description: returns updated (canceled) move object
+          schema:
+            $ref: '#/definitions/MovePayload'
+        400:
+          description: invalid request
+        401:
+          description: must be authenticated to use this endpoint
+        403:
+          description: not authorized to approve this move
+        409:
+          description: the move is not in a state to be canceled
+          schema:
+            $ref: '#/definitions/MovePayload'
+        500:
+          description: server error
   /personally_procured_moves/{personallyProcuredMoveId}/approve:
     post:
       summary: Approves the PPM

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -459,6 +459,9 @@ definitions:
         $ref: '#/definitions/SelectedMoveType'
       status:
         $ref: '#/definitions/MoveStatus'
+      cancel_reason:
+        type: string
+        example: "Change of orders"
       created_at:
         type: string
         format: date-time


### PR DESCRIPTION
## Description

This PR includes:
* A CancelMoveHandler which cancels moves (and therefore associated PPMs) as well as orders
* A test for the above
* A Submit() method for the Orders model
* Swagger endpoint for moves/{moveId}/cancel, which includes a reason in the request body

## Code Review Verification Steps

* [x] All tests pass.
* [x] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/blob/master/docs/backend.md#logging)
* [x] Request review from a member of a different team.
* [x] (TRIAL) Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/157646194) for this change
