### PR TITLE
Wrap saving move and associated models' statuses in transactions

### DIFF
--- a/pkg/handlers/office.go
+++ b/pkg/handlers/office.go
@@ -61,20 +61,9 @@ func (h CancelMoveHandler) Handle(params officeop.CancelMoveParams) middleware.R
 	}
 
 	// Save move, orders, and PPMs statuses
-	verrs, err := h.db.ValidateAndUpdate(move)
+	verrs, err := models.SaveMoveStatuses(h.db, move)
 	if err != nil || verrs.HasAny() {
 		return responseForVErrors(h.logger, verrs, err)
-	}
-	verrs, err = h.db.ValidateAndUpdate(&move.Orders)
-	if err != nil || verrs.HasAny() {
-		return responseForVErrors(h.logger, verrs, err)
-	}
-
-	for i := range move.PersonallyProcuredMoves {
-		verrs, err = h.db.ValidateAndUpdate(move.PersonallyProcuredMoves[i])
-		if err != nil || verrs.HasAny() {
-			return responseForVErrors(h.logger, verrs, err)
-		}
 	}
 
 	movePayload, err := payloadForMoveModel(h.storage, move.Orders, *move)

--- a/pkg/models/move.go
+++ b/pkg/models/move.go
@@ -296,12 +296,18 @@ func SaveMoveStatuses(db *pop.Connection, move *Move) (*validate.Errors, error) 
 					return transactionError
 				}
 			}
-			// TODO: Add back in once we are updating PPM Status
-			// if verrs, err := db.ValidateAndSave(ppm); verrs.HasAny() || err != nil {
-			// 	responseVErrors.Append(verrs)
-			// 	responseError = errors.Wrap(err, "Error Saving PPM")
-			// 	return transactionError
-			// }
+
+			if verrs, err := db.ValidateAndSave(&ppm); verrs.HasAny() || err != nil {
+				responseVErrors.Append(verrs)
+				responseError = errors.Wrap(err, "Error Saving PPM")
+				return transactionError
+			}
+		}
+
+		if verrs, err := db.ValidateAndSave(&move.Orders); verrs.HasAny() || err != nil {
+			responseVErrors.Append(verrs)
+			responseError = errors.Wrap(err, "Error Saving Orders")
+			return transactionError
 		}
 
 		if verrs, err := db.ValidateAndSave(move); verrs.HasAny() || err != nil {


### PR DESCRIPTION
## Description

This puts saving move, ppm, and orders statuses once canceled in a transaction. This ensures that a ppm's/orders' status will always be reflective of its move's status on move CANCEL. 

## Code Review Verification Steps

* [x] All tests pass.
* [x] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/blob/master/docs/backend.md#logging)
* [x] Request review from a member of a different team.
* [x] (TRIAL) Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/158532536) for this change
