### PR TITLE
Create an Approve func to the state machine

### DIFF
--- a/pkg/handlers/office.go
+++ b/pkg/handlers/office.go
@@ -25,7 +25,7 @@ func (h ApproveMoveHandler) Handle(params officeop.ApproveMoveParams) middleware
 		return responseForError(h.logger, err)
 	}
 
-	move.Status = models.MoveStatusAPPROVED
+	move.Approve()
 
 	verrs, err := h.db.ValidateAndUpdate(move)
 	if err != nil || verrs.HasAny() {

--- a/pkg/handlers/office_test.go
+++ b/pkg/handlers/office_test.go
@@ -13,27 +13,17 @@ import (
 
 func (suite *HandlerSuite) TestApproveMoveHandler() {
 	// Given: a set of orders, a move, office user and servicemember user
-	orders, err := testdatagen.MakeOrder(suite.db)
+	move, err := testdatagen.MakeMove(suite.db)
 	suite.Nil(err)
-	var selectedType = internalmessages.SelectedMoveTypePPM
-	move, verrs, err := orders.CreateNewMove(suite.db, &selectedType)
-	suite.Nil(err)
-	suite.False(verrs.HasAny(), "failed to validate move")
+	// Given: an office User
 	officeUser, err := testdatagen.MakeOfficeUser(suite.db)
 	suite.Nil(err)
 
-	// Move is submitted
+	// Move is submitted and saved
 	err = move.Submit()
 	suite.Nil(err)
 	suite.Equal(models.MoveStatusSUBMITTED, move.Status, "expected Submitted")
-
-	// And: Orders are submitted and saved on move
-	err = orders.Submit()
-	suite.Nil(err)
-	suite.Equal(models.OrderStatusSUBMITTED, orders.Status, "expected Submitted")
-	suite.mustSave(&orders)
-	move.Orders = orders
-	suite.mustSave(move)
+	suite.mustSave(&move)
 
 	// And: the context contains the auth values
 	req := httptest.NewRequest("POST", "/moves/some_id/approve", nil)

--- a/pkg/handlers/office_test.go
+++ b/pkg/handlers/office_test.go
@@ -12,10 +12,28 @@ import (
 )
 
 func (suite *HandlerSuite) TestApproveMoveHandler() {
-	// Given: a set of orders, a move, user and servicemember
-	move, _ := testdatagen.MakeMove(suite.db)
-	// Given: and office User
-	officeUser, _ := testdatagen.MakeOfficeUser(suite.db)
+	// Given: a set of orders, a move, office user and servicemember user
+	orders, err := testdatagen.MakeOrder(suite.db)
+	suite.Nil(err)
+	var selectedType = internalmessages.SelectedMoveTypePPM
+	move, verrs, err := orders.CreateNewMove(suite.db, &selectedType)
+	suite.Nil(err)
+	suite.False(verrs.HasAny(), "failed to validate move")
+	officeUser, err := testdatagen.MakeOfficeUser(suite.db)
+	suite.Nil(err)
+
+	// Move is submitted
+	err = move.Submit()
+	suite.Nil(err)
+	suite.Equal(models.MoveStatusSUBMITTED, move.Status, "expected Submitted")
+
+	// And: Orders are submitted and saved on move
+	err = orders.Submit()
+	suite.Nil(err)
+	suite.Equal(models.OrderStatusSUBMITTED, orders.Status, "expected Submitted")
+	suite.mustSave(&orders)
+	move.Orders = orders
+	suite.mustSave(move)
 
 	// And: the context contains the auth values
 	req := httptest.NewRequest("POST", "/moves/some_id/approve", nil)

--- a/pkg/models/move.go
+++ b/pkg/models/move.go
@@ -105,6 +105,16 @@ func (m *Move) Submit() error {
 	return nil
 }
 
+// Approve approves the Move
+func (m *Move) Approve() error {
+	if m.Status != MoveStatusSUBMITTED {
+		return errors.Wrap(ErrInvalidTransition, "Approve")
+	}
+
+	m.Status = MoveStatusAPPROVED
+	return nil
+}
+
 // Cancel cancels the Move and its associated PPMs
 func (m *Move) Cancel(reason string) error {
 	if m.Status != MoveStatusSUBMITTED {

--- a/pkg/testdatagen/make_move.go
+++ b/pkg/testdatagen/make_move.go
@@ -35,7 +35,7 @@ func MakeMoveData(db *pop.Connection) {
 
 	for i := 0; i < 2; i++ {
 		move, _ := MakeMove(db)
-		move.Status = models.MoveStatusAPPROVED
+		move.Approve()
 		db.ValidateAndUpdate(&move)
 	}
 }


### PR DESCRIPTION
## Description

This creates an `Approve()` function on the state machine for moves.  Previously this was done by setting the state property on the move explicitly.  

I've also updated the tests to push a move through to submission before approval is done to ensure it can pass the test.  This pretty much copied from the Cancel Move test flow.

## Reviewer Notes

The new test copies from the Cancel Move test flow.  It was unclear to me what differences I should worry about between these and when one is more appropriate than the other:

```go
move, _ := testdatagen.MakeMove(suite.db)
```

and

```go
orders, err := testdatagen.MakeOrder(suite.db)
var selectedType = internalmessages.SelectedMoveTypePPM
move, verrs, err := orders.CreateNewMove(suite.db, &selectedType)
```

## Code Review Verification Steps

* [x] All tests pass.
* [x] Request review from a member of a different team.
* [x] (TRIAL) Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/n/projects/2136865/stories/158438373) for this change