### PR TITLE
Protect move.Status by renaming to move.status

### DIFF
--- a/pkg/handlers/move_queue_items_test.go
+++ b/pkg/handlers/move_queue_items_test.go
@@ -27,8 +27,8 @@ func (suite *HandlerSuite) TestShowQueueHandler() {
 
 		newMove := models.Move{
 			OrdersID: order.ID,
-			status:   models.MoveStatus(status),
 		}
+		newMove.SetStatus(models.MoveStatus(status))
 		suite.mustSave(&newMove)
 
 		// Make a PPM

--- a/pkg/handlers/move_queue_items_test.go
+++ b/pkg/handlers/move_queue_items_test.go
@@ -27,7 +27,7 @@ func (suite *HandlerSuite) TestShowQueueHandler() {
 
 		newMove := models.Move{
 			OrdersID: order.ID,
-			Status:   models.MoveStatus(status),
+			status:   models.MoveStatus(status),
 		}
 		suite.mustSave(&newMove)
 

--- a/pkg/handlers/moves.go
+++ b/pkg/handlers/moves.go
@@ -32,7 +32,7 @@ func payloadForMoveModel(storer storage.FileStorer, order models.Order, move mod
 		UpdatedAt:               fmtDateTime(move.UpdatedAt),
 		PersonallyProcuredMoves: ppmPayloads,
 		OrdersID:                fmtUUID(order.ID),
-		Status:                  internalmessages.MoveStatus(move.Status),
+		Status:                  internalmessages.MoveStatus(move.Status()),
 	}
 	return movePayload, nil
 }
@@ -147,7 +147,7 @@ func (h SubmitMoveHandler) Handle(params moveop.SubmitMoveForApprovalParams) mid
 
 	err = move.Submit()
 	if err != nil {
-		h.logger.Error("Failed to change move status to submit", zap.String("move_id", moveID.String()), zap.String("move_status", string(move.Status)))
+		h.logger.Error("Failed to change move status to submit", zap.String("move_id", moveID.String()), zap.String("move_status", string(move.Status())))
 		return responseForError(h.logger, err)
 	}
 

--- a/pkg/handlers/moves.go
+++ b/pkg/handlers/moves.go
@@ -32,7 +32,7 @@ func payloadForMoveModel(storer storage.FileStorer, order models.Order, move mod
 		UpdatedAt:               fmtDateTime(move.UpdatedAt),
 		PersonallyProcuredMoves: ppmPayloads,
 		OrdersID:                fmtUUID(order.ID),
-		Status:                  internalmessages.MoveStatus(move.Status()),
+		Status:                  internalmessages.MoveStatus(move.GetStatus()),
 	}
 	return movePayload, nil
 }
@@ -147,7 +147,7 @@ func (h SubmitMoveHandler) Handle(params moveop.SubmitMoveForApprovalParams) mid
 
 	err = move.Submit()
 	if err != nil {
-		h.logger.Error("Failed to change move status to submit", zap.String("move_id", moveID.String()), zap.String("move_status", string(move.Status())))
+		h.logger.Error("Failed to change move status to submit", zap.String("move_id", moveID.String()), zap.String("move_status", string(move.GetStatus())))
 		return responseForError(h.logger, err)
 	}
 

--- a/pkg/handlers/office.go
+++ b/pkg/handlers/office.go
@@ -56,7 +56,7 @@ func (h CancelMoveHandler) Handle(params officeop.CancelMoveParams) middleware.R
 	// Canceling move will result in canceled associated PPMs
 	err = move.Cancel(*params.Reason)
 	if err != nil {
-		h.logger.Error("Attempted to cancel move, got invalid transition", zap.Error(err), zap.String("move_status", string(move.Status())))
+		h.logger.Error("Attempted to cancel move, got invalid transition", zap.Error(err), zap.String("move_status", string(move.GetStatus())))
 		return responseForError(h.logger, err)
 	}
 

--- a/pkg/handlers/office.go
+++ b/pkg/handlers/office.go
@@ -56,7 +56,7 @@ func (h CancelMoveHandler) Handle(params officeop.CancelMoveParams) middleware.R
 	// Canceling move will result in canceled associated PPMs
 	err = move.Cancel(*params.Reason)
 	if err != nil {
-		h.logger.Error("Attempted to cancel move, got invalid transition", zap.Error(err), zap.String("move_status", string(move.Status)))
+		h.logger.Error("Attempted to cancel move, got invalid transition", zap.Error(err), zap.String("move_status", string(move.Status())))
 		return responseForError(h.logger, err)
 	}
 

--- a/pkg/handlers/office_test.go
+++ b/pkg/handlers/office_test.go
@@ -25,7 +25,7 @@ func (suite *HandlerSuite) TestApproveMoveHandler() {
 	// Move is submitted
 	err = move.Submit()
 	suite.Nil(err)
-	suite.Equal(models.MoveStatusSUBMITTED, move.Status, "expected Submitted")
+	suite.Equal(models.MoveStatusSUBMITTED, move.GetStatus(), "expected Submitted")
 
 	// And: Orders are submitted and saved on move
 	err = orders.Submit()
@@ -69,7 +69,7 @@ func (suite *HandlerSuite) TestCancelMoveHandler() {
 	// Move is submitted
 	err = move.Submit()
 	suite.Nil(err)
-	suite.Equal(models.MoveStatusSUBMITTED, move.Status, "expected Submitted")
+	suite.Equal(models.MoveStatusSUBMITTED, move.GetStatus(), "expected Submitted")
 
 	// And: Orders are submitted and saved on move
 	err = orders.Submit()

--- a/pkg/handlers/office_test.go
+++ b/pkg/handlers/office_test.go
@@ -22,7 +22,7 @@ func (suite *HandlerSuite) TestApproveMoveHandler() {
 	// Move is submitted and saved
 	err = move.Submit()
 	suite.Nil(err)
-	suite.Equal(models.MoveStatusSUBMITTED, move.Status, "expected Submitted")
+	suite.Equal(models.MoveStatusSUBMITTED, move.GetStatus(), "expected Submitted")
 	suite.mustSave(&move)
 
 	// And: the context contains the auth values

--- a/pkg/models/move.go
+++ b/pkg/models/move.go
@@ -78,9 +78,15 @@ func (m *Move) ValidateUpdate(tx *pop.Connection) (*validate.Errors, error) {
 // State Machine
 // Use these methods to change the state.
 
-// Status returns the status of a move
-func (m *Move) Status() MoveStatus {
+// GetStatus returns the status of a move
+func (m *Move) GetStatus() MoveStatus {
 	return m.status
+}
+
+// SetStatus sets the status of a move
+func (m *Move) SetStatus(status MoveStatus) error {
+	m.status = status
+	return nil
 }
 
 // Submit submits the Move

--- a/pkg/models/move.go
+++ b/pkg/models/move.go
@@ -46,7 +46,7 @@ type Move struct {
 	Orders                  Order                              `belongs_to:"orders"`
 	SelectedMoveType        *internalmessages.SelectedMoveType `json:"selected_move_type" db:"selected_move_type"`
 	PersonallyProcuredMoves PersonallyProcuredMoves            `has_many:"personally_procured_moves" order_by:"created_at desc"`
-	status                  MoveStatus                         `json:"status" db:"status"`
+	status                  MoveStatus                         `db:"status"`
 	SignedCertifications    SignedCertifications               `has_many:"signed_certifications" order_by:"created_at desc"`
 	CancelReason            *string                            `json:"cancel_reason" db:"cancel_reason"`
 }
@@ -78,7 +78,7 @@ func (m *Move) ValidateUpdate(tx *pop.Connection) (*validate.Errors, error) {
 // State Machine
 // Use these methods to change the state.
 
-// Get the Status of a move
+// Status returns the status of a move
 func (m *Move) Status() MoveStatus {
 	return m.status
 }

--- a/pkg/models/move_test.go
+++ b/pkg/models/move_test.go
@@ -70,12 +70,12 @@ func (suite *ModelSuite) TestMoveCancellationWithReason() {
 	// Check to ensure move shows SUBMITTED before Cancel()
 	err = move.Submit()
 	suite.Nil(err)
-	suite.Equal(MoveStatusSUBMITTED, move.Status, "expected Submitted")
+	suite.Equal(MoveStatusSUBMITTED, move.GetStatus(), "expected Submitted")
 
 	// Can cancel move, and status changes as expected
 	err = move.Cancel(reason)
 	suite.Nil(err)
-	suite.Equal(MoveStatusCANCELED, move.Status, "expected Canceled")
+	suite.Equal(MoveStatusCANCELED, move.GetStatus(), "expected Canceled")
 	suite.Equal(&reason, move.CancelReason, "expected 'SM's orders revoked'")
 
 }
@@ -101,12 +101,12 @@ func (suite *ModelSuite) TestMoveStateMachine() {
 	// Once submitted
 	err = move.Submit()
 	suite.Nil(err)
-	suite.Equal(MoveStatusSUBMITTED, move.Status, "expected Submitted")
+	suite.Equal(MoveStatusSUBMITTED, move.GetStatus(), "expected Submitted")
 
 	// Can cancel move
 	err = move.Cancel(reason)
 	suite.Nil(err)
-	suite.Equal(MoveStatusCANCELED, move.Status, "expected Canceled")
+	suite.Equal(MoveStatusCANCELED, move.GetStatus(), "expected Canceled")
 	suite.Nil(move.CancelReason)
 }
 
@@ -136,14 +136,14 @@ func (suite *ModelSuite) TestCancelMoveCancelsOrdersPPM() {
 	move.PersonallyProcuredMoves = append(move.PersonallyProcuredMoves, *ppm)
 	err = move.Submit()
 	suite.Nil(err)
-	suite.Equal(MoveStatusSUBMITTED, move.Status, "expected Submitted")
+	suite.Equal(MoveStatusSUBMITTED, move.GetStatus(), "expected Submitted")
 
 	// When move is canceled, expect associated PPM and Order to be canceled
 	reason := "Orders changed"
 	err = move.Cancel(reason)
 	suite.Nil(err)
 
-	suite.Equal(MoveStatusCANCELED, move.Status, "expected Canceled")
+	suite.Equal(MoveStatusCANCELED, move.GetStatus(), "expected Canceled")
 	suite.Equal(PPMStatusCANCELED, move.PersonallyProcuredMoves[0].Status, "expected Canceled")
 	suite.Equal(OrderStatusCANCELED, move.Orders.Status, "expected Canceled")
 }

--- a/pkg/models/order_test.go
+++ b/pkg/models/order_test.go
@@ -194,7 +194,7 @@ func (suite *ModelSuite) TestCanceledMoveCancelsOrder() {
 	reason := "Mistaken identity"
 	err = move.Cancel(reason)
 	suite.Nil(err)
-	suite.Equal(MoveStatusCANCELED, move.Status, "expected Canceled")
+	suite.Equal(MoveStatusCANCELED, move.GetStatus(), "expected Canceled")
 	suite.Equal(OrderStatusCANCELED, move.Orders.Status, "expected Canceled")
 
 }


### PR DESCRIPTION
## Description

Branches from https://github.com/transcom/mymove/pull/728

Moving to using a state machine means the value of `move.Status` should not be accessible directly.  ~~This change will lowercase it to `move.status` so that it cannot be exported.~~  It will then add `GetStatus()` and `SetStatus()` as the methods for getting and setting the value.

## Reviewer Notes

~~I am pretty certain that this disrupts the JSON api endpoints that rely on marshaling the `Move` struct with an accessible `move.Status`.~~ Turns out the JSON api doesn't rely upon the metadata in the Pop model.

Pop does not currently let you have a protected field in a struct.  This is because it needs to fill that field from the DB during the hydration step.  In order to get around that we'd need to do callbacks and probably include an additional struct for the state machine to operate upon.

## Code Review Verification Steps

* [x] All tests pass.
* [ ] Request review from a member of a different team.
* [ ] (TRIAL) Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/n/projects/2136865/stories/158438373) for this change