### PR TITLE
Allowing draft moves, PPMs, and orders to be cancelled

### DIFF
--- a/pkg/models/move.go
+++ b/pkg/models/move.go
@@ -107,7 +107,8 @@ func (m *Move) Submit() error {
 
 // Cancel cancels the Move and its associated PPMs
 func (m *Move) Cancel(reason string) error {
-	if m.Status != MoveStatusSUBMITTED && m.Status != MoveStatusDRAFT {
+	// We can cancel any move that isn't already complete.
+	if m.Status == MoveStatusCOMPLETED {
 		return errors.Wrap(ErrInvalidTransition, "Cancel")
 	}
 

--- a/pkg/models/move.go
+++ b/pkg/models/move.go
@@ -107,7 +107,7 @@ func (m *Move) Submit() error {
 
 // Cancel cancels the Move and its associated PPMs
 func (m *Move) Cancel(reason string) error {
-	if m.Status != MoveStatusSUBMITTED {
+	if m.Status != MoveStatusSUBMITTED && m.Status != MoveStatusDRAFT {
 		return errors.Wrap(ErrInvalidTransition, "Cancel")
 	}
 

--- a/pkg/models/move.go
+++ b/pkg/models/move.go
@@ -118,7 +118,7 @@ func (m *Move) Approve() error {
 // Cancel cancels the Move and its associated PPMs
 func (m *Move) Cancel(reason string) error {
 	// We can cancel any move that isn't already complete.
-	if m.Status == MoveStatusCOMPLETED {
+	if m.Status == MoveStatusCOMPLETED && m.Status != MoveStatusCANCELED {
 		return errors.Wrap(ErrInvalidTransition, "Cancel")
 	}
 

--- a/pkg/models/move.go
+++ b/pkg/models/move.go
@@ -118,7 +118,7 @@ func (m *Move) Approve() error {
 // Cancel cancels the Move and its associated PPMs
 func (m *Move) Cancel(reason string) error {
 	// We can cancel any move that isn't already complete.
-	if m.Status == MoveStatusCOMPLETED && m.Status != MoveStatusCANCELED {
+	if m.Status == MoveStatusCOMPLETED || m.Status == MoveStatusCANCELED {
 		return errors.Wrap(ErrInvalidTransition, "Cancel")
 	}
 

--- a/pkg/models/move_test.go
+++ b/pkg/models/move_test.go
@@ -2,7 +2,6 @@ package models_test
 
 import (
 	"github.com/gobuffalo/uuid"
-	"github.com/pkg/errors"
 
 	"github.com/transcom/mymove/pkg/auth"
 	"github.com/transcom/mymove/pkg/gen/internalmessages"
@@ -93,10 +92,6 @@ func (suite *ModelSuite) TestMoveStateMachine() {
 	suite.False(verrs.HasAny(), "failed to validate move")
 	reason := ""
 	move.Orders = orders
-
-	// Can't cancel a move with DRAFT status
-	err = move.Cancel(reason)
-	suite.Equal(ErrInvalidTransition, errors.Cause(err))
 
 	// Once submitted
 	err = move.Submit()

--- a/pkg/models/order.go
+++ b/pkg/models/order.go
@@ -105,7 +105,7 @@ func (o *Order) Submit() error {
 
 // Cancel cancels the Order
 func (o *Order) Cancel() error {
-	if o.Status != OrderStatusSUBMITTED && o.Status != OrderStatusDRAFT {
+	if o.Status == OrderStatusCANCELED {
 		return errors.Wrap(ErrInvalidTransition, "Cancel")
 	}
 

--- a/pkg/models/order.go
+++ b/pkg/models/order.go
@@ -105,7 +105,7 @@ func (o *Order) Submit() error {
 
 // Cancel cancels the Order
 func (o *Order) Cancel() error {
-	if o.Status != OrderStatusSUBMITTED {
+	if o.Status != OrderStatusSUBMITTED && o.Status != OrderStatusDRAFT {
 		return errors.Wrap(ErrInvalidTransition, "Cancel")
 	}
 

--- a/pkg/models/order_test.go
+++ b/pkg/models/order_test.go
@@ -4,7 +4,6 @@ import (
 	"time"
 
 	"github.com/gobuffalo/uuid"
-	"github.com/pkg/errors"
 
 	"github.com/transcom/mymove/pkg/auth"
 	"github.com/transcom/mymove/pkg/gen/internalmessages"
@@ -131,12 +130,8 @@ func (suite *ModelSuite) TestOrderStateMachine() {
 	}
 	suite.mustSave(&order)
 
-	// Can't cancel Orders with DRAFT status
-	err := order.Cancel()
-	suite.Equal(ErrInvalidTransition, errors.Cause(err))
-
 	// Submit Orders
-	err = order.Submit()
+	err := order.Submit()
 	suite.Nil(err)
 	suite.Equal(OrderStatusSUBMITTED, order.Status, "expected Submitted")
 

--- a/pkg/models/personally_procured_move.go
+++ b/pkg/models/personally_procured_move.go
@@ -90,7 +90,7 @@ func (p *PersonallyProcuredMove) ValidateUpdate(tx *pop.Connection) (*validate.E
 
 // Cancel cancels the PPM
 func (p *PersonallyProcuredMove) Cancel() error {
-	if p.Status == PPMStatusCOMPLETED && p.Status != PPMStatusCANCELED {
+	if p.Status == PPMStatusCOMPLETED || p.Status == PPMStatusCANCELED {
 		return errors.Wrap(ErrInvalidTransition, "Cancel")
 	}
 

--- a/pkg/models/personally_procured_move.go
+++ b/pkg/models/personally_procured_move.go
@@ -26,6 +26,8 @@ const (
 	PPMStatusAPPROVED PPMStatus = "APPROVED"
 	// PPMStatusINPROGRESS captures enum value "IN_PROGRESS"
 	PPMStatusINPROGRESS PPMStatus = "IN_PROGRESS"
+	// PPMStatusCOMPLETED captures enum value "COMPLETED"
+	PPMStatusCOMPLETED PPMStatus = "COMPLETED"
 	// PPMStatusCANCELED captures enum value "CANCELED"
 	PPMStatusCANCELED PPMStatus = "CANCELED"
 )
@@ -88,7 +90,7 @@ func (p *PersonallyProcuredMove) ValidateUpdate(tx *pop.Connection) (*validate.E
 
 // Cancel cancels the PPM
 func (p *PersonallyProcuredMove) Cancel() error {
-	if p.Status != PPMStatusSUBMITTED && p.Status != PPMStatusDRAFT {
+	if p.Status == PPMStatusCOMPLETED {
 		return errors.Wrap(ErrInvalidTransition, "Cancel")
 	}
 

--- a/pkg/models/personally_procured_move.go
+++ b/pkg/models/personally_procured_move.go
@@ -90,7 +90,7 @@ func (p *PersonallyProcuredMove) ValidateUpdate(tx *pop.Connection) (*validate.E
 
 // Cancel cancels the PPM
 func (p *PersonallyProcuredMove) Cancel() error {
-	if p.Status == PPMStatusCOMPLETED {
+	if p.Status == PPMStatusCOMPLETED && p.Status != PPMStatusCANCELED {
 		return errors.Wrap(ErrInvalidTransition, "Cancel")
 	}
 

--- a/pkg/models/personally_procured_move.go
+++ b/pkg/models/personally_procured_move.go
@@ -88,7 +88,7 @@ func (p *PersonallyProcuredMove) ValidateUpdate(tx *pop.Connection) (*validate.E
 
 // Cancel cancels the PPM
 func (p *PersonallyProcuredMove) Cancel() error {
-	if p.Status != PPMStatusSUBMITTED {
+	if p.Status != PPMStatusSUBMITTED && p.Status != PPMStatusDRAFT {
 		return errors.Wrap(ErrInvalidTransition, "Cancel")
 	}
 

--- a/pkg/models/personally_procured_move_test.go
+++ b/pkg/models/personally_procured_move_test.go
@@ -1,8 +1,6 @@
 package models_test
 
 import (
-	"github.com/pkg/errors"
-
 	"github.com/transcom/mymove/pkg/auth"
 	"github.com/transcom/mymove/pkg/gen/internalmessages"
 	. "github.com/transcom/mymove/pkg/models"
@@ -70,10 +68,6 @@ func (suite *ModelSuite) TestPPMStateMachine() {
 	ppm, verrs, err := move.CreatePPM(suite.db, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, true, &advance)
 	suite.Nil(err)
 	suite.False(verrs.HasAny())
-
-	// Can't cancel a PPM with DRAFT status
-	err = ppm.Cancel()
-	suite.Equal(ErrInvalidTransition, errors.Cause(err))
 
 	ppm.Status = PPMStatusSUBMITTED // NEVER do this outside of a test.
 


### PR DESCRIPTION
## Description

This changes the Cancel() functions in the move, PPM, and orders models to allow DRAFT status objects to be canceled. (Now, it checks to see if the status is draft or submitted on each; if so, cancellation is possible. If not, errrrrror.) 

## Reviewer Notes

I just omitted the step in the connected tests that once tried to cancel a draft-state move, PPM, or order. Do you feel anything should be added elsewhere to keep the tests as robust as we like, or are we good? 

## Code Review Verification Steps

* [ ] All tests pass.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/blob/master/docs/backend.md#logging)
* [ ] Request review from a member of a different team.
* [ ] (TRIAL) Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/158612518) for this change