### PR TITLE
"make clean" could make things a little cleaner

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -188,9 +188,9 @@ pre_commit_tests:
 
 clean:
 	rm .*.stamp || true
-	rm -rf ./node_modules || true
-	rm -rf ./vendor || true
-	rm -rf ./pkg/gen || true
+	rm -rf ./node_modules
+	rm -rf ./vendor
+	rm -rf ./pkg/gen
 	rm -rf $$GOPATH/pkg/dep/sources || true
 
 .PHONY: pre-commit deps test client_deps client_build client_run client_test prereqs

--- a/Makefile
+++ b/Makefile
@@ -191,7 +191,7 @@ clean:
 	rm -rf ./node_modules
 	rm -rf ./vendor
 	rm -rf ./pkg/gen
-	rm -rf $$GOPATH/pkg/dep/sources || true
+	rm -rf $$GOPATH/pkg/dep/sources
 
 .PHONY: pre-commit deps test client_deps client_build client_run client_test prereqs
 .PHONY: server_deps_update server_generate server_deps server_build server_run_standalone server_run server_run_dev server_build_docker server_run_only_docker server_test

--- a/Makefile
+++ b/Makefile
@@ -187,10 +187,11 @@ pre_commit_tests:
 	pre-commit run --all-files
 
 clean:
-	rm .*.stamp
-	rm -rf ./node_modules
-	rm -rf ./vendor
-	rm -rf ./pkg/gen
+	rm .*.stamp || true
+	rm -rf ./node_modules || true
+	rm -rf ./vendor || true
+	rm -rf ./pkg/gen || true
+	rm -rf $$GOPATH/pkg/dep/sources || true
 
 .PHONY: pre-commit deps test client_deps client_build client_run client_test prereqs
 .PHONY: server_deps_update server_generate server_deps server_build server_run_standalone server_run server_run_dev server_build_docker server_run_only_docker server_test

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ This prototype was built by a [Defense Digital Service](https://www.dds.mil/) te
   * [Spellcheck](#spellcheck)
     * [Tips for staying sane](#tips-for-staying-sane)
   * [Troubleshooting](#troubleshooting)
+    * [Postgres Issues](#postgres-issues)
 
 Regenerate with "bin/generate-md-toc.sh"
 


### PR DESCRIPTION
## Description

I and others have run into issues with `dep` getting into a broken state where it returns errors like this:
```
Solving failure: No versions of google.golang.org/appengine met constraints:
	v1.1.0: https://github.com/golang/appengine does not exist in the local cache and fetching failed: unable to get repository: fatal: destination path '/Users/alexi/Documents/projects/golang/pkg/dep/sources/https---github.com-golang-appengine' already exists and is not an empty directory.
: command failed: [git clone --recursive -v --progress https://github.com/golang/appengine /Users/alexi/Documents/projects/golang/pkg/dep/sources/https---github.com-golang-appengine]: exit status 128
```

Even worse, sometimes that's the underlying error, but the particular `dep` sub-command doesn't explicitly say so.

This PR does two things for `make clean`:
* ensures that if one of the `rm` commands fails (say, due to the file not existing,) it will continue on its way
* cleans out `dep`'s source directory, so that `dep` commands start from a fresh state.

Hopefully this spares others the anguish I've had to deal with a few times.