### PR TITLE
Rek cancelmove btn

### DIFF
--- a/pkg/handlers/office.go
+++ b/pkg/handlers/office.go
@@ -54,7 +54,7 @@ func (h CancelMoveHandler) Handle(params officeop.CancelMoveParams) middleware.R
 	}
 
 	// Canceling move will result in canceled associated PPMs
-	err = move.Cancel(*params.Reason)
+	err = move.Cancel(*params.CancelMove.CancelReason)
 	if err != nil {
 		h.logger.Error("Attempted to cancel move, got invalid transition", zap.Error(err), zap.String("move_status", string(move.Status)))
 		return responseForError(h.logger, err)

--- a/pkg/handlers/office_test.go
+++ b/pkg/handlers/office_test.go
@@ -77,10 +77,13 @@ func (suite *HandlerSuite) TestCancelMoveHandler() {
 
 	// And params include the cancel reason
 	reason := "Orders revoked."
+	reasonPayload := &internalmessages.CancelMove{
+		CancelReason: &reason,
+	}
 	params := officeop.CancelMoveParams{
-		HTTPRequest:             req,
-		MoveID:                  strfmt.UUID(move.ID.String()),
-		CancelMove.CancelReason: &reason,
+		HTTPRequest: req,
+		MoveID:      strfmt.UUID(move.ID.String()),
+		CancelMove:  reasonPayload,
 	}
 
 	// And: a move is canceled

--- a/pkg/handlers/office_test.go
+++ b/pkg/handlers/office_test.go
@@ -78,9 +78,9 @@ func (suite *HandlerSuite) TestCancelMoveHandler() {
 	// And params include the cancel reason
 	reason := "Orders revoked."
 	params := officeop.CancelMoveParams{
-		HTTPRequest: req,
-		MoveID:      strfmt.UUID(move.ID.String()),
-		Reason:      &reason,
+		HTTPRequest:             req,
+		MoveID:                  strfmt.UUID(move.ID.String()),
+		CancelMove.CancelReason: &reason,
 	}
 
 	// And: a move is canceled

--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -93,9 +93,13 @@ class CancelPanel extends Component {
             <Alert type="warning" heading="Cancelation Warning">
               Are you sure you want to cancel the entire move?
             </Alert>
-            <div className="extras buttons">
-              <a onClick={this.setButtonState}>No, never mind</a>
-              <button onClick={this.cancelMove}>Yes, cancel move</button>
+            <div className="usa-grid">
+              <div className="usa-width-one-whole extras options">
+                <a onClick={this.setButtonState}>No, never mind</a>
+              </div>
+              <div className="usa-width-one-whole extras options">
+                <button onClick={this.cancelMove}>Yes, cancel move</button>
+              </div>
             </div>
           </div>
         </div>
@@ -103,13 +107,19 @@ class CancelPanel extends Component {
     } else if (this.state.displayState === 'Confirm') {
       return (
         <div className="cancel-panel">
-          <h2 className="extras usa-heading">Cancel move</h2>
+          <h2 className="extras usa-heading">Cancel Move</h2>
           <div className="extras content">
             Why is the move being canceled?
             <textarea required onChange={this.handleChange} />
-            <div className="extras buttons">
-              <a onClick={this.setButtonState}>Never mind</a>
-              <button onClick={this.setCancelState}>Cancel entire move</button>
+            <div className="usa-grid">
+              <div className="usa-width-one-whole extras options">
+                <a onClick={this.setButtonState}>Never mind</a>
+              </div>
+              <div className="usa-width-one-whole extras options">
+                <button onClick={this.setCancelState}>
+                  Cancel entire move
+                </button>
+              </div>
             </div>
           </div>
         </div>

--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -58,27 +58,81 @@ const PPMTabContent = props => {
   );
 };
 
+// const ConfirmCancel = props => {
+//   if (props.confirmCancelMove) {
+//     return (
+//       <div className="cancel-panel">
+//         <h2 className="extras usa-heading">Cancel Move</h2>
+//         <div className="extras content">
+//           Why?
+//           <form>
+//             <textarea />
+//             <a onClick={props.closeCancelReason}>Nevermind</a>
+//             <button onClick={props.cancelMove}>Cancel Move</button>
+//           </form>
+//         </div>
+//       </div>
+//     );
+//   } else {
+//     return (
+//       <button
+//         className="usa-button-secondary"
+//         onClick={props.openCancelReason}
+//       >
+//         Cancel Move
+//       </button>
+//     );
+//   }
+// };
+
+// export class CancelPanel extends Component {
+//   handleSubmit = values => {
+//     this.props.cancelMove(this.props.officeMove.ID, values);
+//   };
+
+//   setConfirmState = () => {
+//     this.setState({ displayState: 'Confirm' });
+//   };
+//   setCancelState = () => {
+//     this.setState({ displayState: 'Cancel' });
+//   };
+//   setButtonState = () => {
+//     this.setState({ displayState: 'Button' });
+//   };
+
 const CancelPanel = props => {
-  if (props.showCancelPanel) {
+  if (props.displayState === 'Cancel') {
     return (
       <div className="cancel-panel">
         <h2 className="extras usa-heading">Cancel Move</h2>
         <div className="extras content">
+          <Alert type="warning">Are you sure you want to cancel move?</Alert>
+          <div className="extras buttons">
+            <a onClick={props.setButtonState}>No, nevermind</a>
+            <button onSubmit={props.handleSubmit}>Yes, cancel move</button>
+          </div>
+        </div>
+      </div>
+    );
+  } else if (props.displayState === 'Confirm') {
+    return (
+      <div className="cancel-panel">
+        <h2 className="extras usa-heading">Cancel move</h2>
+        <div className="extras content">
           Why?
           <form>
             <textarea />
-            <a onClick={props.closeConfirmCancel}>Nevermind</a>
-            <button onClick={props.cancelMove}>Cancel Move</button>
+            <div className="extras buttons">
+              <a onClick={props.setButtonState}>Nevermind</a>
+              <button onClick={props.setCancelState}>Cancel Move</button>
+            </div>
           </form>
         </div>
       </div>
     );
-  } else {
+  } else if (props.displayState === 'Button') {
     return (
-      <button
-        className="usa-button-secondary"
-        onClick={props.openConfirmCancel}
-      >
+      <button className="usa-button-secondary" onClick={props.setConfirmState}>
         Cancel Move
       </button>
     );
@@ -105,13 +159,17 @@ class MoveInfo extends Component {
     this.props.cancelMove(this.props.officeMove.id);
   };
 
-  state = { confirmCancelMove: false, cancelReason: '' };
+  // Cancel panel
+  state = { displayState: 'Button', cancelReason: '' };
 
-  openConfirmCancel = () => {
-    this.setState({ confirmCancelMove: true });
+  setConfirmState = () => {
+    this.setState({ displayState: 'Confirm' });
   };
-  closeConfirmCancel = () => {
-    this.setState({ confirmCancelMove: false });
+  setCancelState = () => {
+    this.setState({ displayState: 'Cancel' });
+  };
+  setButtonState = () => {
+    this.setState({ displayState: 'Button' });
   };
 
   renderPPMTabStatus = () => {
@@ -270,10 +328,11 @@ class MoveInfo extends Component {
                 {ppm.status === 'APPROVED' && check}
               </button>
               <CancelPanel
+                displayState={this.state.displayState}
                 cancelMove={this.cancelMove}
-                closeConfirmCancel={this.closeConfirmCancel}
-                showCancelPanel={this.state.confirmCancelMove}
-                openConfirmCancel={this.openConfirmCancel}
+                setConfirmState={this.setConfirmState}
+                setCancelState={this.setCancelState}
+                setButtonState={this.setButtonState}
               />
               {/* Disabling until features implemented
               <button>Troubleshoot</button>

--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -6,7 +6,6 @@ import { get, capitalize } from 'lodash';
 
 import { RoutedTabs, NavTab } from 'react-router-tabs';
 import { NavLink, Switch, Redirect, Link } from 'react-router-dom';
-import { push } from 'react-router-redux';
 
 import LoadingPlaceholder from 'shared/LoadingPlaceholder';
 import PrivateRoute from 'shared/User/PrivateRoute';
@@ -82,7 +81,7 @@ class CancelPanel extends Component {
   cancelMove = event => {
     event.preventDefault();
     this.props.cancelMove(this.state.cancelReason);
-    this.props.push('/queues');
+    this.setState({ displayState: 'Redirect' });
   };
 
   render() {
@@ -121,6 +120,8 @@ class CancelPanel extends Component {
           Cancel Move
         </button>
       );
+    } else if (this.state.displayState === 'Redirect') {
+      return <Redirect to="/" />;
     }
   }
 }

--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -17,7 +17,12 @@ import CustomerInfoPanel from './CustomerInfoPanel';
 import OrdersPanel from './OrdersPanel';
 import PaymentsPanel from './PaymentsPanel';
 import PPMEstimatesPanel from './PPMEstimatesPanel';
-import { loadMoveDependencies, approveBasics, approvePPM } from './ducks.js';
+import {
+  loadMoveDependencies,
+  approveBasics,
+  approvePPM,
+  cancelMove,
+} from './ducks.js';
 import { formatDate } from 'shared/formatters';
 
 import FontAwesomeIcon from '@fortawesome/react-fontawesome';
@@ -53,6 +58,29 @@ const PPMTabContent = props => {
   );
 };
 
+const CancelPanel = props => {
+  if (props.showCancelPanel) {
+    return (
+      <div className="cancel-panel">
+        <h2 className="extras usa-heading">Cancel Move</h2>
+        <div className="extras subheader">
+          Why?
+          <form>
+            <input type="text" />
+            <a onClick={props.closeConfirmCancel}>Nevermind</a>
+            <button onClick={props.cancelMove}>Cancel Move</button>
+          </form>
+        </div>
+      </div>
+    );
+  } else {
+    return <button onClick={props.openConfirmCancel}>Cancel</button>;
+  }
+};
+
+// this.setState(cancelReason) = value
+// react text area docs (handle change fnc)
+
 class MoveInfo extends Component {
   componentDidMount() {
     this.props.loadMoveDependencies(this.props.match.params.moveId);
@@ -64,6 +92,19 @@ class MoveInfo extends Component {
 
   approvePPM = () => {
     this.props.approvePPM(this.props.officeMove.id, this.props.officePPM.id);
+  };
+
+  cancelMove = () => {
+    this.props.cancelMove(this.props.officeMove.id);
+  };
+
+  state = { confirmCancelMove: false, cancelReason: '' };
+
+  openConfirmCancel = () => {
+    this.setState({ confirmCancelMove: true });
+  };
+  closeConfirmCancel = () => {
+    this.setState({ confirmCancelMove: false });
   };
 
   renderPPMTabStatus = () => {
@@ -221,12 +262,18 @@ class MoveInfo extends Component {
                 Approve PPM
                 {ppm.status === 'APPROVED' && check}
               </button>
+              <CancelPanel
+                cancelMove={this.cancelMove}
+                closeConfirmCancel={this.closeConfirmCancel}
+                showCancelPanel={this.state.confirmCancelMove}
+                openConfirmCancel={this.openConfirmCancel}
+              />
               {/* Disabling until features implemented
               <button>Troubleshoot</button>
-              <button>Cancel Move</button> */}
+              */}
             </div>
             <div className="documents">
-              <h2 className="usa-heading">
+              <h2 className="extras usa-heading">
                 Documents
                 <FontAwesomeIcon className="icon" icon={faExternalLinkAlt} />
               </h2>
@@ -285,7 +332,7 @@ const mapStateToProps = state => ({
 
 const mapDispatchToProps = dispatch =>
   bindActionCreators(
-    { loadMoveDependencies, approveBasics, approvePPM },
+    { loadMoveDependencies, approveBasics, approvePPM, cancelMove },
     dispatch,
   );
 

--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -94,7 +94,7 @@ class CancelPanel extends Component {
               Are you sure you want to cancel the entire move?
             </Alert>
             <div className="extras buttons">
-              <a onClick={this.setButtonState}>No, nevermind</a>
+              <a onClick={this.setButtonState}>No, never mind</a>
               <button onClick={this.cancelMove}>Yes, cancel move</button>
             </div>
           </div>
@@ -105,10 +105,10 @@ class CancelPanel extends Component {
         <div className="cancel-panel">
           <h2 className="extras usa-heading">Cancel move</h2>
           <div className="extras content">
-            Why is the move being cancelled?
+            Why is the move being canceled?
             <textarea required onChange={this.handleChange} />
             <div className="extras buttons">
-              <a onClick={this.setButtonState}>Nevermind</a>
+              <a onClick={this.setButtonState}>Never mind</a>
               <button onClick={this.setCancelState}>Cancel entire move</button>
             </div>
           </div>

--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -58,48 +58,6 @@ const PPMTabContent = props => {
   );
 };
 
-// const ConfirmCancel = props => {
-//   if (props.confirmCancelMove) {
-//     return (
-//       <div className="cancel-panel">
-//         <h2 className="extras usa-heading">Cancel Move</h2>
-//         <div className="extras content">
-//           Why?
-//           <form>
-//             <textarea />
-//             <a onClick={props.closeCancelReason}>Nevermind</a>
-//             <button onClick={props.cancelMove}>Cancel Move</button>
-//           </form>
-//         </div>
-//       </div>
-//     );
-//   } else {
-//     return (
-//       <button
-//         className="usa-button-secondary"
-//         onClick={props.openCancelReason}
-//       >
-//         Cancel Move
-//       </button>
-//     );
-//   }
-// };
-
-// export class CancelPanel extends Component {
-//   handleSubmit = values => {
-//     this.props.cancelMove(this.props.officeMove.ID, values);
-//   };
-
-//   setConfirmState = () => {
-//     this.setState({ displayState: 'Confirm' });
-//   };
-//   setCancelState = () => {
-//     this.setState({ displayState: 'Cancel' });
-//   };
-//   setButtonState = () => {
-//     this.setState({ displayState: 'Button' });
-//   };
-
 const CancelPanel = props => {
   if (props.displayState === 'Cancel') {
     return (

--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -63,10 +63,10 @@ const CancelPanel = props => {
     return (
       <div className="cancel-panel">
         <h2 className="extras usa-heading">Cancel Move</h2>
-        <div className="extras subheader">
+        <div className="extras content">
           Why?
           <form>
-            <input type="text" />
+            <textarea />
             <a onClick={props.closeConfirmCancel}>Nevermind</a>
             <button onClick={props.cancelMove}>Cancel Move</button>
           </form>
@@ -74,7 +74,14 @@ const CancelPanel = props => {
       </div>
     );
   } else {
-    return <button onClick={props.openConfirmCancel}>Cancel</button>;
+    return (
+      <button
+        className="usa-button-secondary"
+        onClick={props.openConfirmCancel}
+      >
+        Cancel Move
+      </button>
+    );
   }
 };
 

--- a/src/scenes/Office/MoveInfo.test.js
+++ b/src/scenes/Office/MoveInfo.test.js
@@ -23,6 +23,9 @@ const PPMsHaveLoadError = null;
 const PPMsHaveLoadSuccess = false;
 const loadDependenciesHasError = null;
 const loadDependenciesHasSuccess = false;
+const moveIsCanceling = false;
+const moveHasCancelError = null;
+const moveHasCancelSuccess = false;
 const match = {
   params: { moveID: '123456' },
   url: 'www.nino.com',
@@ -56,6 +59,9 @@ describe('Loads MoveInfo', () => {
             loadDependenciesHasSuccess={loadDependenciesHasSuccess}
             match={match}
             loadMoveDependencies={dummyFunc}
+            moveIsCanceling={moveIsCanceling}
+            moveHasCancelError={moveHasCancelError}
+            moveHasCancelSuccess={moveHasCancelSuccess}
           />
         </MockRouter>
       </Provider>,

--- a/src/scenes/Office/api.js
+++ b/src/scenes/Office/api.js
@@ -122,12 +122,13 @@ export async function ApproveReimbursement(reimbursementId) {
 }
 
 // Move status
-export async function CancelMove(moveId, reason) {
+export async function CancelMove(moveId, cancelReason) {
   const client = await getClient();
-  debugger;
   const response = await client.apis.office.cancelMove({
     moveId,
-    reason,
+    cancelMove: {
+      cancel_reason: cancelReason,
+    },
   });
   checkResponse(
     response,

--- a/src/scenes/Office/api.js
+++ b/src/scenes/Office/api.js
@@ -108,7 +108,7 @@ export async function ApprovePPM(moveId, ppmId) {
   return response.body;
 }
 
-// PPM status
+// Reimbursement status
 export async function ApproveReimbursement(reimbursementId) {
   const client = await getClient();
   const response = await client.apis.office.approveReimbursement({
@@ -117,6 +117,21 @@ export async function ApproveReimbursement(reimbursementId) {
   checkResponse(
     response,
     'failed to approve reimbursement due to server error',
+  );
+  return response.body;
+}
+
+// Move status
+export async function CancelMove(moveId, reason) {
+  const client = await getClient();
+  debugger;
+  const response = await client.apis.office.cancelMove({
+    moveId,
+    reason,
+  });
+  checkResponse(
+    response,
+    'failed to cancel move and associated dependencies due to server error',
   );
   return response.body;
 }

--- a/src/scenes/Office/ducks.js
+++ b/src/scenes/Office/ducks.js
@@ -10,6 +10,7 @@ import {
   ApproveBasics,
   ApprovePPM,
   ApproveReimbursement,
+  CancelMove,
 } from './api.js';
 
 import { UpdatePpm } from 'scenes/Moves/Ppm/api.js';
@@ -30,6 +31,7 @@ const updatePPMType = 'UPDATE_PPM';
 const approveBasicsType = 'APPROVE_BASICS';
 const approvePPMType = 'APPROVE_PPM';
 const approveReimbursementType = 'APPROVE_REIMBURSEMENT';
+const cancelMoveType = 'CANCEL_MOVE';
 
 // MULTIPLE-RESOURCE ACTION TYPES
 const updateBackupInfoType = 'UPDATE_BACKUP_INFO';
@@ -67,6 +69,8 @@ const UPDATE_PPM = ReduxHelpers.generateAsyncActionTypes(updatePPMType);
 const APPROVE_BASICS = ReduxHelpers.generateAsyncActionTypes(approveBasicsType);
 
 const APPROVE_PPM = ReduxHelpers.generateAsyncActionTypes(approvePPMType);
+
+const CANCEL_MOVE = ReduxHelpers.generateAsyncActionTypes(cancelMoveType);
 
 export const APPROVE_REIMBURSEMENT = ReduxHelpers.generateAsyncActionTypes(
   approveReimbursementType,
@@ -146,6 +150,11 @@ export const approvePPM = ReduxHelpers.generateAsyncActionCreator(
 export const approveReimbursement = ReduxHelpers.generateAsyncActionCreator(
   approveReimbursementType,
   ApproveReimbursement,
+);
+
+export const cancelMove = ReduxHelpers.generateAsyncActionCreator(
+  cancelMoveType,
+  CancelMove,
 );
 // MULTIPLE-RESOURCE ACTION CREATORS
 //
@@ -247,6 +256,7 @@ const initialState = {
   backupContactsAreLoading: false,
   ppmsAreLoading: false,
   ppmIsUpdating: false,
+  moveIsCanceling: false,
   moveHasLoadError: null,
   moveHasLoadSuccess: false,
   ordersHaveLoadError: null,
@@ -265,6 +275,8 @@ const initialState = {
   ppmHasUpdateSuccess: false,
   loadDependenciesHasError: null,
   loadDependenciesHasSuccess: false,
+  moveHasCancelError: false,
+  moveHasCancelSuccess: false,
 };
 
 export function officeReducer(state = initialState, action) {
@@ -472,6 +484,20 @@ export function officeReducer(state = initialState, action) {
     case APPROVE_BASICS.failure:
       return Object.assign({}, state, {
         basicsIsApproving: false,
+        error: action.error.message,
+      });
+    case CANCEL_MOVE.start:
+      return Object.assign({}, state, {
+        moveIsCanceling: true,
+      });
+    case CANCEL_MOVE.success:
+      return Object.assign({}, state, {
+        moveIsCanceling: false,
+        officeMove: action.payload,
+      });
+    case CANCEL_MOVE.failure:
+      return Object.assign({}, state, {
+        moveIsCanceling: false,
         error: action.error.message,
       });
 

--- a/src/scenes/Office/ducks.js
+++ b/src/scenes/Office/ducks.js
@@ -70,7 +70,9 @@ const APPROVE_BASICS = ReduxHelpers.generateAsyncActionTypes(approveBasicsType);
 
 const APPROVE_PPM = ReduxHelpers.generateAsyncActionTypes(approvePPMType);
 
-const CANCEL_MOVE = ReduxHelpers.generateAsyncActionTypes(cancelMoveType);
+export const CANCEL_MOVE = ReduxHelpers.generateAsyncActionTypes(
+  cancelMoveType,
+);
 
 export const APPROVE_REIMBURSEMENT = ReduxHelpers.generateAsyncActionTypes(
   approveReimbursementType,

--- a/src/scenes/Office/ducks.test.js
+++ b/src/scenes/Office/ducks.test.js
@@ -1,4 +1,4 @@
-import { APPROVE_REIMBURSEMENT, officeReducer } from './ducks';
+import { APPROVE_REIMBURSEMENT, CANCEL_MOVE, officeReducer } from './ducks';
 
 function createAdvance(status) {
   return {
@@ -6,6 +6,18 @@ function createAdvance(status) {
     method_of_receipt: 'MIL_PAY',
     requested_amount: 1000,
     status,
+  };
+}
+
+function createMove(status, cancelReason) {
+  return {
+    id: '1224ba31c-0dca-4e6a-b0c0-a987d4fed32c',
+    locator: 'CAJ214',
+    orders_id: '4134b2a1c-0dca-4e6a-b0c0-a987d4fe55ab',
+    selected_move_type: 'PPM',
+    personally_procured_moves: [],
+    status,
+    cancelReason,
   };
 }
 
@@ -60,6 +72,60 @@ describe('office Reducer', () => {
         otherState: 1,
         officePPMs: [{ id: '1234', advance: createAdvance('DRAFT') }],
         reimbursementIsApproving: false,
+        error: 'something went wrong',
+      });
+    });
+  });
+  describe('CANCEL_MOVE', () => {
+    it('handles SUCCESS', () => {
+      const initialState = {
+        otherState: 1,
+        officeMove: createMove('SUBMITTED', ''),
+      };
+      const newState = officeReducer(initialState, {
+        type: CANCEL_MOVE.success,
+        payload: createMove('CANCELED', 'Got tired'),
+      });
+
+      expect(newState).toEqual({
+        otherState: 1,
+        officeMove: createMove('CANCELED', 'Got tired'),
+        moveIsCanceling: false,
+      });
+    });
+
+    it('handles START', () => {
+      const initialState = {
+        otherState: 1,
+        officeMove: createMove('DRAFT', ''),
+      };
+      const newState = officeReducer(initialState, {
+        type: CANCEL_MOVE.start,
+      });
+
+      expect(newState).toEqual({
+        otherState: 1,
+        officeMove: createMove('DRAFT', ''),
+        moveIsCanceling: true,
+      });
+    });
+
+    it('handles FAILURE', () => {
+      const initialState = {
+        otherState: 1,
+        officeMove: createMove('DRAFT', ''),
+      };
+      const newState = officeReducer(initialState, {
+        type: CANCEL_MOVE.failure,
+        error: {
+          message: 'something went wrong',
+        },
+      });
+
+      expect(newState).toEqual({
+        otherState: 1,
+        officeMove: createMove('DRAFT', ''),
+        moveIsCanceling: false,
         error: 'something went wrong',
       });
     });

--- a/src/scenes/Office/office.css
+++ b/src/scenes/Office/office.css
@@ -137,14 +137,8 @@
   font-family: sans-serif;
 }
 
-.extras.buttons {
-  margin-top: 2rem;
-  margin-bottom: 1rem;
-}
-
-.extras button {
-  float: right;
-  margin-top: -1rem;
+.extras.options {
+  margin-top: 1rem;
 }
 
 .documents {

--- a/src/scenes/Office/office.css
+++ b/src/scenes/Office/office.css
@@ -137,6 +137,11 @@
   font-family: sans-serif;
 }
 
+.extras.buttons {
+  margin-top: 2rem;
+  margin-bottom: 2rem;
+}
+
 .extras button {
   float: right;
 }

--- a/src/scenes/Office/office.css
+++ b/src/scenes/Office/office.css
@@ -139,11 +139,12 @@
 
 .extras.buttons {
   margin-top: 2rem;
-  margin-bottom: 2rem;
+  margin-bottom: 1rem;
 }
 
 .extras button {
   float: right;
+  margin-top: -1rem;
 }
 
 .documents {

--- a/src/scenes/Office/office.css
+++ b/src/scenes/Office/office.css
@@ -132,10 +132,13 @@
   font-family: sans-serif;
 }
 
-.extras.subheader {
-  font-weight: bold;
+.extras.content {
   margin-top: 2rem;
   font-family: sans-serif;
+}
+
+.extras button {
+  float: right;
 }
 
 .documents {

--- a/src/scenes/Office/office.css
+++ b/src/scenes/Office/office.css
@@ -126,15 +126,22 @@
   padding-top: 2rem;
 }
 
+.extras.usa-heading {
+  margin-top: 0;
+  font-size: 2rem;
+  font-family: sans-serif;
+}
+
+.extras.subheader {
+  font-weight: bold;
+  margin-top: 2rem;
+  font-family: sans-serif;
+}
+
 .documents {
   border: solid 1px black;
   padding: 1em;
   margin-top: 1em;
-}
-
-.documents .usa-heading {
-  margin-top: 0;
-  font-size: 2rem;
 }
 
 .documents .usa-heading .icon {
@@ -145,6 +152,12 @@
 
 .documents .document .icon {
   margin-right: 0.3em;
+}
+
+.cancel-panel {
+  border: solid 2px navy;
+  padding: 1em;
+  margin-top: 1em;
 }
 
 .orders-page-column {

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -477,6 +477,15 @@ definitions:
       - locator
       - created_at
       - updated_at
+  CancelMove:
+    type: object
+    properties:
+      cancel_reason:
+        type: string
+        example: "Change of orders"
+        x-nullable: true
+    required:
+      - cancel_reason
   PatchMovePayload:
     type: object
     properties:
@@ -2416,12 +2425,10 @@ paths:
           required: true
           description: UUID of the move
         - in: body
-          name: reason
-          schema:
-            type: string
-            example: "Orders canceled"
+          name: cancelMove
           required: true
-          description: reason for cancelation of move
+          schema:
+            $ref: '#/definitions/CancelMove'
       responses:
         200:
           description: returns updated (canceled) move object


### PR DESCRIPTION
## Description

This creates the user interface for the office user who would like to cancel a move.
They have to confirm cancelation before they can cancel.
The interface requires a reason be entered into the form. 

## Reviewer Notes

* Is this the way to redirect?
* The redirect doesn't refresh the query of new moves...is that in my purview to account for?
* Currently, move, associated PPM and Orders must be in submitted state for this to work.
* Writing tests tomorrow.

## Code Review Verification Steps

* [x] All tests pass.
* [x] There are no aXe warnings for UI.
* [x] This works in IE.
* [x] Request review from a member of a different team.
* [x] (TRIAL) Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/158088540) for this change

## Screenshots
![cancelflow](https://user-images.githubusercontent.com/7401870/42006349-25c24d06-7a2e-11e8-9e29-a96ab618fa47.gif)
