### PR TITLE
Make border on date picker widget darker

### DIFF
--- a/src/shared/JsonSchemaForm/index.css
+++ b/src/shared/JsonSchemaForm/index.css
@@ -23,3 +23,7 @@ h1.sm-heading {
 h2.sm-heading-2 {
   font-size: 2.5rem;
 }
+
+.DayPicker {
+   border: 0.1rem solid #5b616b;
+}


### PR DESCRIPTION
## Description

Make border on date picker widget darker to address instance of a service member not being able to see the widget.

## Code Review Verification Steps

* [x] All tests pass.
* [x] (TRIAL) Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/158090315) for this change

## Screenshots

<img width="566" alt="screen shot 2018-06-27 at 5 25 59 pm" src="https://user-images.githubusercontent.com/8170735/42006536-352c7694-7a2f-11e8-92d0-9ddd937b4c5d.png">
