### PR TITLE
Rek allmovesqueue

### DIFF
--- a/pkg/models/queue.go
+++ b/pkg/models/queue.go
@@ -66,7 +66,7 @@ func GetMoveQueueItems(db *pop.Connection, lifecycleState string) ([]MoveQueueIt
 			LEFT JOIN personally_procured_moves AS ppm ON moves.id = ppm.move_id
 			WHERE moves.status = 'APPROVED'
 		`
-	} else {
+	} else if lifecycleState == "all" {
 		query = `
 			SELECT moves.ID,
 				COALESCE(sm.edipi, '*missing*') as edipi,

--- a/src/scenes/Office/QueueList.jsx
+++ b/src/scenes/Office/QueueList.jsx
@@ -17,6 +17,11 @@ export default class QueueList extends Component {
               <span>PPMs</span>
             </NavLink>
           </li>
+          <li>
+            <NavLink to="/queues/all" activeClassName="usa-current">
+              <span>All Moves</span>
+            </NavLink>
+          </li>
         </ul>
       </div>
     );

--- a/src/scenes/Office/QueueTable.jsx
+++ b/src/scenes/Office/QueueTable.jsx
@@ -45,6 +45,7 @@ class QueueTable extends Component {
       new: 'New Moves',
       troubleshooting: 'Troubleshooting',
       ppm: 'PPMs',
+      all: 'All Moves',
     };
 
     return (

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -2927,6 +2927,7 @@ paths:
           - new
           - troubleshooting
           - ppm
+          - all
           required: true
           description: Queue type to show
       responses:


### PR DESCRIPTION
## Description

This creates a queue that shows all moves (i.e. in every status) on the queues table page.

## Reviewer notes

This is based off PR [735](https://github.com/transcom/mymove/pull/735) so you can have canceled moves. Once that's landed, the breadth of these changes will be more visible.

## Code Review Verification Steps

* [x] All tests pass.
* [x] There are no aXe warnings for UI.
* [x] This works in IE.
* [x] Request review from a member of a different team.
* [x] (TRIAL) Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/158611929) for this change

## Screenshots

<img width="1401" alt="screen shot 2018-06-28 at 11 44 51 am" src="https://user-images.githubusercontent.com/7401870/42054307-d9009950-7ac8-11e8-83e7-df36052e53e3.png">
