### PR TITLE
move is approved on SM side only if both ppm and move are approved

### DIFF
--- a/src/scenes/Landing/MoveSummary.jsx
+++ b/src/scenes/Landing/MoveSummary.jsx
@@ -334,7 +334,12 @@ export const MoveSummary = props => {
     resumeMove,
     reviewProfile,
   } = props;
-  const status = get(move, 'status', 'DRAFT');
+  const move_status = get(move, 'status', 'DRAFT');
+  const ppm_status = get(ppm, 'status', 'DRAFT');
+  const status =
+    move_status === 'APPROVED' && ppm_status === 'SUBMITTED'
+      ? ppm_status
+      : move_status;
   const StatusComponent = moveSummaryStatusComponents[status]; // eslint-disable-line security/detect-object-injection
   return (
     <Fragment>

--- a/src/scenes/Landing/MoveSummary.test.jsx
+++ b/src/scenes/Landing/MoveSummary.test.jsx
@@ -94,7 +94,37 @@ describe('MoveSummary', () => {
       ).toEqual('<div class="title">Next Step: Awaiting approval</div>');
     });
   });
-  describe('when a move is in approved state', () => {
+  describe('when a move is in approved state but ppm is submitted state', () => {
+    it('renders submitted rather than approved content', () => {
+      const moveObj = { status: 'APPROVED' };
+      const futureFortNight = moment().add(14, 'day');
+      const ppmObj = {
+        planned_move_date: futureFortNight,
+        weight_estimate: '10000',
+        estimated_incentive: '$24665.59 - 27261.97',
+        status: 'SUBMITTED',
+      };
+      const subComponent = getShallowRender(
+        entitlementObj,
+        serviceMember,
+        ordersObj,
+        moveObj,
+        ppmObj,
+        editMoveFn,
+        resumeMoveFn,
+      ).find(SubmittedMoveSummary);
+      expect(subComponent).not.toBeNull();
+      expect(
+        subComponent
+          .dive()
+          .find('.step')
+          .find('div.title')
+          .first()
+          .html(),
+      ).toEqual('<div class="title">Next Step: Awaiting approval</div>');
+    });
+  });
+  describe('when a move and ppm are in approved state', () => {
     it('renders approved content', () => {
       const moveObj = { status: 'APPROVED' };
       const futureFortNight = moment().add(14, 'day');
@@ -102,6 +132,7 @@ describe('MoveSummary', () => {
         planned_move_date: futureFortNight,
         weight_estimate: '10000',
         estimated_incentive: '$24665.59 - 27261.97',
+        status: 'APPROVED',
       };
       const subComponent = getShallowRender(
         entitlementObj,


### PR DESCRIPTION
## Description

Bug fix-- currently, move on SM side is shown as 'APPROVED' if the move is approved but the PPM is not approved. This fixes that--now a move on the SM side is only shown as approved if both the move and PPM are in the 'APPROVED' state.

## Code Review Verification Steps

* [x] All tests pass.
* [x] There are no aXe warnings for UI.
* [x] This works in IE.
* [x] Request review from a member of a different team.
* [x] (TRIAL) Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/158678654) for this change

## Screenshots

MOVE IS APPROVED BUT PPM IS NOT:
<img width="1207" alt="screen shot 2018-07-06 at 2 49 19 pm" src="https://user-images.githubusercontent.com/7401870/42401716-d0e36a2c-812b-11e8-9420-6d4f43711bc0.png">

SM VIEW:
<img width="856" alt="screen shot 2018-07-06 at 2 49 26 pm" src="https://user-images.githubusercontent.com/7401870/42401730-db07a87e-812b-11e8-9803-195ca1de2454.png">
