### PR TITLE
Kma require branch rank

### DIFF
--- a/src/scenes/Office/CustomerInfoPanel.jsx
+++ b/src/scenes/Office/CustomerInfoPanel.jsx
@@ -114,8 +114,8 @@ const CustomerInfoEdit = props => {
           </div>
           <div className="editable-panel-column">
             <SwaggerField fieldName="edipi" swagger={schema} required />
-            <SwaggerField fieldName="affiliation" swagger={schema} />
-            <SwaggerField fieldName="rank" swagger={schema} />
+            <SwaggerField fieldName="affiliation" swagger={schema} required />
+            <SwaggerField fieldName="rank" swagger={schema} required />
           </div>
         </FormSection>
       </div>

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -28,7 +28,6 @@ definitions:
       - id
   Affiliation:
     type: string
-    x-nullable: true
     title: Branch
     enum: &AFFILIATION
       - ARMY
@@ -1139,7 +1138,6 @@ definitions:
       - L
   ServiceMemberRank:
     type: string
-    x-nullable: true
     title: Rank
     enum:
       - E_1

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -28,6 +28,7 @@ definitions:
       - id
   Affiliation:
     type: string
+    x-nullable: true
     title: Branch
     enum: &AFFILIATION
       - ARMY
@@ -1138,6 +1139,7 @@ definitions:
       - L
   ServiceMemberRank:
     type: string
+    x-nullable: true
     title: Rank
     enum:
       - E_1


### PR DESCRIPTION
## Description
Branch and Rank are now required fields on the client side(it is still nullable in the server side definition since the service member is initiated without a rank or branch)
Previously, a user could hit Save with a null value for branch and rank and it would look like it had saved but it would not.

## Reviewer Notes
Will follow up on why server validates affiliation but it isn’t marked as such in swagger
Ideally for the UX, there would be no blank (null) option to choose from the dropdown

## Code Review Verification Steps

* [x] All tests pass.
* [x] There are no aXe warnings for UI.
* [x] This works in IE.
* [x] Request review from a member of a different team.
* [ ] (TRIAL) Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/158271950) for this change
* [this article](tbd) explains more about the approach used.
