### PR TITLE
Allows ppm estimate recalc if daysInStorage isn't set [delivers #158991629]

### DIFF
--- a/pkg/handlers/personally_procured_move.go
+++ b/pkg/handlers/personally_procured_move.go
@@ -263,9 +263,10 @@ func (h PatchPersonallyProcuredMoveHandler) ppmNeedsEstimatesRecalculated(ppm *m
 	destination, destinationChanged, destinationOK := stringForComparison(ppm.DestinationPostalCode, destinationPtr)
 	weight, weightChanged, weightOK := int64ForComparison(ppm.WeightEstimate, weightPtr)
 	date, dateChanged, dateOK := dateForComparison(ppm.PlannedMoveDate, (*time.Time)(datePtr))
-	daysInStorage, daysChanged, daysOK := int64ForComparison(ppm.DaysInStorage, daysPtr)
+	daysInStorage, daysChanged, _ := int64ForComparison(ppm.DaysInStorage, daysPtr)
 
-	valuesOK := originOK && destinationOK && weightOK && dateOK && daysOK
+	// We don't care if daysInStorage is OK, since we just want to meet the minimum bar to recalculate
+	valuesOK := originOK && destinationOK && weightOK && dateOK
 	valuesChanged := originChanged || destinationChanged || weightChanged || dateChanged || daysChanged
 
 	needsUpdate := valuesOK && valuesChanged
@@ -341,7 +342,7 @@ func (h PatchPersonallyProcuredMoveHandler) updateEstimates(ppm *models.Personal
 	if ppm.HasSit != nil && *ppm.HasSit == true {
 		cwtWeight := unit.Pound(*ppm.WeightEstimate).ToCWT()
 		sitZip3 := rateengine.Zip5ToZip3(*ppm.DestinationPostalCode)
-		sitTotal, err := re.SitCharge(cwtWeight, int(*ppm.DaysInStorage), sitZip3, *ppm.PlannedMoveDate, true)
+		sitTotal, err := re.SitCharge(cwtWeight, daysInSIT, sitZip3, *ppm.PlannedMoveDate, true)
 		if err != nil {
 			return err
 		}

--- a/pkg/handlers/personally_procured_move_test.go
+++ b/pkg/handlers/personally_procured_move_test.go
@@ -221,8 +221,6 @@ func (suite *HandlerSuite) TestPatchPPMHandlerSetWeightLater() {
 	weight := swag.Int64(4100)
 
 	moveDate := time.Now()
-	hasSit := swag.Bool(true)
-	daysInStorage := swag.Int64(3)
 
 	pickupPostalCode := swag.String("32168")
 	destinationPostalCode := swag.String("29400")
@@ -233,8 +231,6 @@ func (suite *HandlerSuite) TestPatchPPMHandlerSetWeightLater() {
 		MoveID:                move.ID,
 		Move:                  move,
 		PlannedMoveDate:       &moveDate,
-		HasSit:                hasSit,
-		DaysInStorage:         daysInStorage,
 		PickupPostalCode:      pickupPostalCode,
 		DestinationPostalCode: destinationPostalCode,
 		Status:                models.PPMStatusDRAFT,
@@ -244,7 +240,7 @@ func (suite *HandlerSuite) TestPatchPPMHandlerSetWeightLater() {
 	req := httptest.NewRequest("GET", "/fake/path", nil)
 	req = suite.authenticateRequest(req, move.Orders.ServiceMember)
 
-	payload := internalmessages.PatchPersonallyProcuredMovePayload{
+	payload := &internalmessages.PatchPersonallyProcuredMovePayload{
 		WeightEstimate: weight,
 	}
 
@@ -252,7 +248,7 @@ func (suite *HandlerSuite) TestPatchPPMHandlerSetWeightLater() {
 		HTTPRequest: req,
 		MoveID:      strfmt.UUID(move.ID.String()),
 		PersonallyProcuredMoveID:           strfmt.UUID(ppm1.ID.String()),
-		PatchPersonallyProcuredMovePayload: &payload,
+		PatchPersonallyProcuredMovePayload: payload,
 	}
 
 	handler := PatchPersonallyProcuredMoveHandler(NewHandlerContext(suite.db, suite.logger))
@@ -270,9 +266,25 @@ func (suite *HandlerSuite) TestPatchPPMHandlerSetWeightLater() {
 	suite.Assertions.Equal(int64(900), *patchPPMPayload.Mileage)
 	suite.Assertions.Equal(int64(242246), *patchPPMPayload.IncentiveEstimateMin)
 	suite.Assertions.Equal(int64(267746), *patchPPMPayload.IncentiveEstimateMax)
+	suite.Assertions.Nil(patchPPMPayload.EstimatedStorageReimbursement)
+	suite.Assertions.Equal(int64(0), *patchPPMPayload.PlannedSitMax)
+	suite.Assertions.Equal(int64(97785), *patchPPMPayload.SitMax)
+
+	// Now check that SIT values update when days in storage is set
+	hasSit := swag.Bool(true)
+	daysInStorage := swag.Int64(3)
+	*payload = internalmessages.PatchPersonallyProcuredMovePayload{
+		HasSit:        hasSit,
+		DaysInStorage: daysInStorage,
+	}
+
+	response = handler.Handle(patchPPMParams)
+	// assert we got back the 201 response
+	okResponse = response.(*ppmop.PatchPersonallyProcuredMoveCreated)
+	patchPPMPayload = okResponse.Payload
+
 	suite.Assertions.Equal("$32.60", *patchPPMPayload.EstimatedStorageReimbursement)
 	suite.Assertions.Equal(int64(3260), *patchPPMPayload.PlannedSitMax)
-	suite.Assertions.Equal(int64(97785), *patchPPMPayload.SitMax)
 }
 
 func (suite *HandlerSuite) TestPatchPPMHandlerWrongUser() {


### PR DESCRIPTION
## Description

We ran into a bug where PPM estimate wasn't getting calculated if SIT, specifically `DaysInStorage`, wasn't being set. This PR fixes the function that decides whether recalculates happen such that SIT doesn't need to be selected.

## Code Review Verification Steps

* [ ] All tests pass.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/blob/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* [ ] Any migrations/schema changes also update the diagram in docs/schema/dp3.sqs
* [ ] There are no aXe warnings for UI.
* [ ] This works in IE.
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @willowbl00
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Request review from a member of a different team.
* [ ] (TRIAL) Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/158991629) for this change