### PR TITLE
Adding jen as a backup code owner for ADRs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,4 +7,5 @@
 # Add language specific code owners if it becomes relevant
 
 # ADRs are architectural decisions that, at least for now, should all be run by Nick
-/docs/adr/* @ntwyman
+# with Jen Leech as a backup.
+/docs/adr/* @ntwyman @jen2000


### PR DESCRIPTION
## Description

We need more than one person available to approve ADRs. Right now Nick is out of town, and thus blocking the landing of ADR PRs. Adding Jen Leech (@jen2000) as a code owner.