### PR TITLE
Fix misspelled words caught by goreportcard

### DIFF
--- a/pkg/handlers/handlers_test.go
+++ b/pkg/handlers/handlers_test.go
@@ -48,7 +48,7 @@ func (suite *HandlerSuite) mustSave(model interface{}) {
 func (suite *HandlerSuite) isNotErrResponse(response middleware.Responder) {
 	r, ok := response.(*errResponse)
 	if ok {
-		suite.logger.Error("Received an unexpected error reponse from handler: ", zap.Error(r.err))
+		suite.logger.Error("Received an unexpected error response from handler: ", zap.Error(r.err))
 		// Formally lodge a complaint
 		suite.IsType(&errResponse{}, response)
 	}

--- a/pkg/models/social_security_number.go
+++ b/pkg/models/social_security_number.go
@@ -46,7 +46,7 @@ var ssnFormatRegex = regexp.MustCompile(`^\d{3}-\d{2}-\d{4}$`)
 func (s *SocialSecurityNumber) SetEncryptedHash(unencryptedSSN string) (*validate.Errors, error) {
 	verrs := validate.NewErrors()
 	if !ssnFormatRegex.MatchString(unencryptedSSN) {
-		verrs.Add("social_secuirty_number", "SSN must be in 123-45-6789 format")
+		verrs.Add("social_security_number", "SSN must be in 123-45-6789 format")
 		return verrs, nil
 	}
 

--- a/pkg/models/tariff400ng_full_pack_rate_test.go
+++ b/pkg/models/tariff400ng_full_pack_rate_test.go
@@ -100,7 +100,7 @@ func (suite *ModelSuite) Test_FetchFullPackRateCents() {
 		t.Fatalf("Unable to query full pack rate: %v", err)
 	}
 	if rate != rate {
-		t.Errorf("Incorrect full pack rate recieved. Got: %d. Expected: %d.", rate, rateExpected)
+		t.Errorf("Incorrect full pack rate received. Got: %d. Expected: %d.", rate, rateExpected)
 	}
 
 	// Test inclusivity of effective_date_lower

--- a/pkg/models/tariff400ng_full_unpack_rate_test.go
+++ b/pkg/models/tariff400ng_full_unpack_rate_test.go
@@ -79,7 +79,7 @@ func (suite *ModelSuite) Test_FetchFullUnPackRateCents() {
 		t.Fatalf("Unable to query full unpack rate: %v", err)
 	}
 	if rate != rateExpected {
-		t.Errorf("Incorrect full unpack rate recieved. Got: %d. Expected: %d.", rate, rateExpected)
+		t.Errorf("Incorrect full unpack rate received. Got: %d. Expected: %d.", rate, rateExpected)
 	}
 
 	// Test exclusivity of effective_date_upper

--- a/pkg/models/tariff400ng_zip5_rate_area.go
+++ b/pkg/models/tariff400ng_zip5_rate_area.go
@@ -9,7 +9,7 @@ import (
 	"github.com/gobuffalo/validate/validators"
 )
 
-// Tariff400ngZip5RateArea repersents the mapping from a full 5-digit zipcode to a
+// Tariff400ngZip5RateArea represents the mapping from a full 5-digit zipcode to a
 // specific rate area. This is only needed for a small subset of zip3s.
 type Tariff400ngZip5RateArea struct {
 	ID        uuid.UUID `json:"id" db:"id"`

--- a/pkg/models/transportation_service_provider_performance.go
+++ b/pkg/models/transportation_service_provider_performance.go
@@ -138,7 +138,7 @@ func NextEligibleTSPPerformance(db *pop.Connection, tdlID uuid.UUID, bookDate ti
 // SelectNextTSPPerformance returns the tspPerformance that is next to receive a shipment.
 func SelectNextTSPPerformance(tspPerformances map[int]TransportationServiceProviderPerformance) TransportationServiceProviderPerformance {
 	bands := sortedMapIntKeys(tspPerformances)
-	// First time through, no rounds have yet occurred so rounds is set to the maximum rounds that have already occured.
+	// First time through, no rounds have yet occurred so rounds is set to the maximum rounds that have already occurred.
 	// Since the TSPs in quality band 1 will always have been offered the greatest number of shipments, we use that to calculate max.
 	maxRounds := float64(tspPerformances[bands[0]].OfferCount) / float64(OffersPerQualityBand[bands[0]])
 	previousRounds := math.Ceil(maxRounds)

--- a/pkg/notifications/move_submitted.go
+++ b/pkg/notifications/move_submitted.go
@@ -90,7 +90,7 @@ func (m MoveSubmitted) emails() ([]emailContent, error) {
 	}
 
 	m.logger.Info("Generated move submitted email to service member",
-		zap.String("sevice member email address", *serviceMember.PersonalEmail))
+		zap.String("service member email address", *serviceMember.PersonalEmail))
 
 	// TODO: Send email to trusted contacts when that's supported
 	return append(emails, smEmail), nil

--- a/pkg/notifications/notification_sender.go
+++ b/pkg/notifications/notification_sender.go
@@ -73,7 +73,7 @@ func sendEmails(emails []emailContent, svc sesiface.SESAPI, logger *zap.Logger) 
 		}
 
 		logger.Info("Sent email to service member",
-			zap.String("sevice member email address", email.recipientEmail))
+			zap.String("service member email address", email.recipientEmail))
 	}
 
 	return nil

--- a/pkg/rateengine/rateengine.go
+++ b/pkg/rateengine/rateengine.go
@@ -137,7 +137,7 @@ func (re *RateEngine) ComputePPM(
 		GCC:    gcc,
 	}
 
-	// Finaly, scale by prorate factor
+	// Finally, scale by prorate factor
 	cost.Scale(prorateFactor)
 
 	re.logger.Info("PPM cost computation", zap.Object("cost", cost))

--- a/pkg/route/planner_test.go
+++ b/pkg/route/planner_test.go
@@ -23,14 +23,14 @@ type PlannerFullSuite struct {
 var testAddressOne = models.Address{
 	StreetAddress1: "1 & 2 Arcacia Ave",
 	StreetAddress2: models.StringPointer("c/o Truss Works"),
-	City:           "San Franciso",
+	City:           "San Francisco",
 	State:          "California",
 	PostalCode:     "94103"}
 
 func (suite *PlannerSuite) TestUrlencodeAddress() {
 
 	encodedAddress := urlencodeAddress(&testAddressOne)
-	expectedString := "1+%26+2+Arcacia+Ave%2Cc%2Fo+Truss+Works%2CSan+Franciso%2CCalifornia%2C94103"
+	expectedString := "1+%26+2+Arcacia+Ave%2Cc%2Fo+Truss+Works%2CSan+Francisco%2CCalifornia%2C94103"
 	if strings.Compare(encodedAddress, expectedString) != 0 {
 		suite.T().Errorf("Encoded address got %s", encodedAddress)
 	}


### PR DESCRIPTION
## Description

This fixes some misspelled words in our code base based on a tool called [Go Report Card](https://goreportcard.com/report/github.com/transcom/mymove). @pjdufour-truss found this site and I noticed at least one of the misspellings might actually affect functionality.

## Reviewer Notes

Look at my comment for the functionality case I mentioned.

## Code Review Verification Steps

* [x] All tests pass.