### PR TITLE
Add move documents to move info document box list

### DIFF
--- a/cypress/integration/office/documentViewer.js
+++ b/cypress/integration/office/documentViewer.js
@@ -33,14 +33,14 @@ describe('The document viewer', function() {
       .get('button.submit')
       .should('not.be.disabled')
       .click();
-    // TODO: add tests for uploaded document viewe
+    // TODO: add tests for uploaded document viewer
   });
   it('shows the newly uploaded document in the document list tab', () => {
     cy.visit('/moves/c9df71f2-334f-4f0e-b2e7-050ddb22efa1/documents');
     cy.contains('All Documents (1)');
     cy.contains('super secret info document');
     cy
-      .get('.doclist')
+      .get('.pad-ns')
       .find('a')
       .should('have.attr', 'href')
       .and('match', /^\/moves\/[^/]+\/documents\/[^/]+/);

--- a/src/scenes/Office/DocumentViewer/DocumentList.jsx
+++ b/src/scenes/Office/DocumentViewer/DocumentList.jsx
@@ -36,7 +36,7 @@ export class DocumentList extends Component {
   render() {
     const { moveDocuments, moveId } = this.props;
     return (
-      <div className="doclist">
+      <div>
         {moveDocuments.map(doc => {
           const status = this.renderDocStatus(doc.status);
           const detailUrl = `/moves/${moveId}/documents/${doc.id}`;

--- a/src/scenes/Office/DocumentViewer/index.css
+++ b/src/scenes/Office/DocumentViewer/index.css
@@ -32,6 +32,6 @@
   color: #0071bc;
 }
 
-.doclist {
-  margin-top: 3rem;
+.pad-ns {
+  padding: 2rem 0rem 2rem 0rem;
 }

--- a/src/scenes/Office/DocumentViewer/index.jsx
+++ b/src/scenes/Office/DocumentViewer/index.jsx
@@ -108,13 +108,15 @@ class DocumentViewer extends Component {
                 path={listUrl}
                 render={() => (
                   <Fragment>
-                    <span className="status">
-                      <FontAwesomeIcon
-                        className="icon link-blue"
-                        icon={faPlusCircle}
-                      />
-                    </span>
-                    <Link to={newUrl}>Upload new document</Link>
+                    <div className="pad-ns">
+                      <span className="status">
+                        <FontAwesomeIcon
+                          className="icon link-blue"
+                          icon={faPlusCircle}
+                        />
+                      </span>
+                      <Link to={newUrl}>Upload new document</Link>
+                    </div>
                     <div>
                       {' '}
                       <DocumentList moveId={move.id} />
@@ -126,13 +128,15 @@ class DocumentViewer extends Component {
                 path={newUrl}
                 render={() => (
                   <Fragment>
-                    <span className="status">
-                      <FontAwesomeIcon
-                        className="icon link-blue"
-                        icon={faPlusCircle}
-                      />
-                    </span>
-                    <Link to={newUrl}>Upload new document</Link>
+                    <div className="pad-ns">
+                      <span className="status">
+                        <FontAwesomeIcon
+                          className="icon link-blue"
+                          icon={faPlusCircle}
+                        />
+                      </span>
+                      <Link to={newUrl}>Upload new document</Link>
+                    </div>
                     <div>
                       {' '}
                       <DocumentList moveId={move.id} />
@@ -154,6 +158,7 @@ class DocumentViewer extends Component {
 
 DocumentViewer.propTypes = {
   loadMoveDependencies: PropTypes.func.isRequired,
+  indexMoveDocuments: PropTypes.func.isRequired,
 };
 
 const mapStateToProps = state => ({

--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -18,6 +18,7 @@ import PaymentsPanel from './Ppm/PaymentsPanel';
 import PPMEstimatesPanel from './Ppm/PPMEstimatesPanel';
 import StorageReimbursementCalculator from './Ppm/StorageReimbursementCalculator';
 import IncentiveCalculator from './Ppm/IncentiveCalculator';
+import DocumentList from 'scenes/Office/DocumentViewer/DocumentList';
 
 import {
   loadMoveDependencies,
@@ -25,6 +26,7 @@ import {
   approvePPM,
   cancelMove,
 } from './ducks';
+import { indexMoveDocuments } from 'scenes/Office/DocumentViewer/ducks.js';
 import { formatDate } from 'shared/formatters';
 
 import FontAwesomeIcon from '@fortawesome/react-fontawesome';
@@ -144,6 +146,7 @@ class CancelPanel extends Component {
 class MoveInfo extends Component {
   componentDidMount() {
     this.props.loadMoveDependencies(this.props.match.params.moveId);
+    this.props.indexMoveDocuments(this.props.match.params.moveId);
   }
 
   approveBasics = () => {
@@ -195,6 +198,7 @@ class MoveInfo extends Component {
 
     let upload = get(this.props, 'officeOrders.uploaded_orders.uploads.0'); // there can be only one
     let check = <FontAwesomeIcon className="icon" icon={faCheck} />;
+    let moveDocs = get(this.props, 'moveDocuments');
 
     if (
       !this.props.loadDependenciesHasSuccess &&
@@ -328,7 +332,7 @@ class MoveInfo extends Component {
               ) : (
                 <div>
                   {move.status === 'APPROVED' ? (
-                    <div className="document">
+                    <div className="panel-field">
                       <FontAwesomeIcon
                         style={{ color: 'green' }}
                         className="icon"
@@ -339,7 +343,7 @@ class MoveInfo extends Component {
                       </Link>
                     </div>
                   ) : (
-                    <div className="document">
+                    <div className="panel-field">
                       <FontAwesomeIcon
                         style={{ color: 'red' }}
                         className="icon"
@@ -352,6 +356,7 @@ class MoveInfo extends Component {
                   )}
                 </div>
               )}
+              <DocumentList moveId={move.id} />
             </div>
           </div>
         </div>
@@ -362,6 +367,7 @@ class MoveInfo extends Component {
 
 MoveInfo.propTypes = {
   loadMoveDependencies: PropTypes.func.isRequired,
+  indexMoveDocuments: PropTypes.func.isRequired,
 };
 
 const mapStateToProps = state => ({
@@ -372,13 +378,20 @@ const mapStateToProps = state => ({
   officeBackupContacts: get(state, 'office.officeBackupContacts', []),
   officePPM: get(state, 'office.officePPMs.0', {}),
   ppmAdvance: get(state, 'office.officePPMs.0.advance', {}),
+  moveDocuments: get(state, 'moveDocuments.moveDocuments', {}),
   loadDependenciesHasSuccess: get(state, 'office.loadDependenciesHasSuccess'),
   loadDependenciesHasError: get(state, 'office.loadDependenciesHasError'),
 });
 
 const mapDispatchToProps = dispatch =>
   bindActionCreators(
-    { loadMoveDependencies, approveBasics, approvePPM, cancelMove },
+    {
+      loadMoveDependencies,
+      indexMoveDocuments,
+      approveBasics,
+      approvePPM,
+      cancelMove,
+    },
     dispatch,
   );
 

--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -324,7 +324,9 @@ class MoveInfo extends Component {
             <div className="documents">
               <h2 className="extras usa-heading">
                 Documents
-                <FontAwesomeIcon className="icon" icon={faExternalLinkAlt} />
+                <Link to={`/moves/${move.id}/documents`} target="_blank">
+                  <FontAwesomeIcon className="icon" icon={faExternalLinkAlt} />
+                </Link>
               </h2>
               {!upload ? (
                 <p>No orders have been uploaded.</p>

--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -198,7 +198,6 @@ class MoveInfo extends Component {
 
     let upload = get(this.props, 'officeOrders.uploaded_orders.uploads.0'); // there can be only one
     let check = <FontAwesomeIcon className="icon" icon={faCheck} />;
-    let moveDocs = get(this.props, 'moveDocuments');
 
     if (
       !this.props.loadDependenciesHasSuccess &&

--- a/src/scenes/Office/office.css
+++ b/src/scenes/Office/office.css
@@ -203,6 +203,7 @@
 
 .documents a:link, a:visited, a:hover, a:active {
   text-decoration: none;
+  color: #0071bc;
 }
 
 .link-blue {


### PR DESCRIPTION
## Description

Adds the move documents to the "Documents" section in the Move Info page. Each document links to the document viewer detail page for that document. Also adds a link to the Documents Icon on the move info page to open the document viewer in a new tab.

Needs to be synced up with the normalization work, so the way move documents are being loaded may need refactoring. Tbd.

## Code Review Verification Steps

* [ ] All tests pass.
* [ ] Request review from a member of a different team.
* [ ] (TRIAL) Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/159035605) for this change

## Screenshots
<img width="394" alt="screen shot 2018-07-16 at 1 48 59 pm" src="https://user-images.githubusercontent.com/8170735/42782871-10fa0e24-88ff-11e8-8d69-a1a3edeeab2f.png">
