### PR TITLE
Fix the award queue test data by enforcing validation errors and fixing data

### DIFF
--- a/pkg/models/validators.go
+++ b/pkg/models/validators.go
@@ -98,7 +98,7 @@ type DiscountRateIsValid struct {
 // IsValid adds an error if the value is not between 0 and 1.
 func (v *DiscountRateIsValid) IsValid(errors *validate.Errors) {
 	if v.Field.Float64() < 0 || v.Field.Float64() > 1 {
-		errors.Add(validators.GenerateKey(v.Name), fmt.Sprintf("%s must be between 0 and 1", v.Name))
+		errors.Add(validators.GenerateKey(v.Name), fmt.Sprintf("%s must be between 0.0 and 1.0, got %f", v.Name, v.Field))
 	}
 }
 

--- a/pkg/testdatagen/make_shipment_records.go
+++ b/pkg/testdatagen/make_shipment_records.go
@@ -2,6 +2,7 @@ package testdatagen
 
 import (
 	"fmt"
+	"log"
 	"time"
 
 	"github.com/gobuffalo/pop"
@@ -46,6 +47,9 @@ func MakeShipment(db *pop.Connection, requestedPickup time.Time,
 	verrs, err := db.ValidateAndSave(&shipment)
 	if verrs.HasAny() {
 		err = fmt.Errorf("shipment validation errors: %v", verrs)
+	}
+	if err != nil {
+		log.Panic(err)
 	}
 
 	return shipment, err

--- a/pkg/testdatagen/make_tdl_records.go
+++ b/pkg/testdatagen/make_tdl_records.go
@@ -2,6 +2,7 @@ package testdatagen
 
 import (
 	"fmt"
+	"log"
 
 	"github.com/gobuffalo/pop"
 
@@ -20,6 +21,9 @@ func MakeTDL(db *pop.Connection, source string, dest string, cos string) (models
 	verrs, err := db.ValidateAndSave(&tdl)
 	if verrs.HasAny() {
 		err = fmt.Errorf("TDL validation errors: %v", verrs)
+	}
+	if err != nil {
+		log.Panic(err)
 	}
 
 	return tdl, err

--- a/pkg/testdatagen/make_tdl_records.go
+++ b/pkg/testdatagen/make_tdl_records.go
@@ -9,24 +9,33 @@ import (
 	"github.com/transcom/mymove/pkg/models"
 )
 
-// MakeTDL makes a single traffic_distribution_list record
+// MakeTDL finds or makes a single traffic_distribution_list record
 func MakeTDL(db *pop.Connection, source string, dest string, cos string) (models.TrafficDistributionList, error) {
 
-	tdl := models.TrafficDistributionList{
-		SourceRateArea:    source,
-		DestinationRegion: dest,
-		CodeOfService:     cos,
+	// Find an existing record against unique constraint
+	tdls := []models.TrafficDistributionList{}
+	query := db.Where(fmt.Sprintf("source_rate_area = '%s' AND destination_region = '%s' AND code_of_service = '%s'", source, dest, cos))
+	err := query.All(&tdls)
+
+	// Create a new record if none are found
+	if len(tdls) == 0 {
+		tdl := models.TrafficDistributionList{
+			SourceRateArea:    source,
+			DestinationRegion: dest,
+			CodeOfService:     cos,
+		}
+
+		verrs, err := db.ValidateAndSave(&tdl)
+		if verrs.HasAny() {
+			err = fmt.Errorf("TDL validation errors: %v", verrs)
+		}
+		if err != nil {
+			log.Panic(err)
+		}
+		return tdl, err
 	}
 
-	verrs, err := db.ValidateAndSave(&tdl)
-	if verrs.HasAny() {
-		err = fmt.Errorf("TDL validation errors: %v", verrs)
-	}
-	if err != nil {
-		log.Panic(err)
-	}
-
-	return tdl, err
+	return tdls[0], err
 }
 
 // MakeTDLData creates three TDL records

--- a/pkg/testdatagen/make_tsp_performance_records.go
+++ b/pkg/testdatagen/make_tsp_performance_records.go
@@ -36,7 +36,10 @@ func MakeTSPPerformance(db *pop.Connection,
 		SITRate:                         SITDiscountRate,
 	}
 
-	_, err := db.ValidateAndSave(&tspPerformance)
+	verrs, err := db.ValidateAndSave(&tspPerformance)
+	if verrs.HasAny() {
+		err = fmt.Errorf("TSP Performance validation errors: %v", verrs)
+	}
 	if err != nil {
 		log.Panic(err)
 	}

--- a/pkg/testdatagen/make_tsp_records.go
+++ b/pkg/testdatagen/make_tsp_records.go
@@ -1,6 +1,7 @@
 package testdatagen
 
 import (
+	"fmt"
 	"log"
 	"math/rand"
 
@@ -25,7 +26,10 @@ func MakeTSP(db *pop.Connection, SCAC string) (models.TransportationServiceProvi
 		StandardCarrierAlphaCode: SCAC,
 	}
 
-	_, err := db.ValidateAndSave(&tsp)
+	verrs, err := db.ValidateAndSave(&tsp)
+	if verrs.HasAny() {
+		err = fmt.Errorf("TSP validation errors: %v", verrs)
+	}
 	if err != nil {
 		log.Panic(err)
 	}

--- a/pkg/testdatagen/scenario/awardqueue.go
+++ b/pkg/testdatagen/scenario/awardqueue.go
@@ -16,7 +16,7 @@ func RunAwardQueueScenario1(db *pop.Connection) {
 	shipmentsToMake := 17
 
 	// Make a TDL to contain our tests
-	tdl, _ := testdatagen.MakeTDL(db, "US California", "90210", "2")
+	tdl, _ := testdatagen.MakeTDL(db, "US13", "90210", "2")
 
 	// Make a market
 	market := "dHHG"
@@ -51,8 +51,8 @@ func RunAwardQueueScenario2(db *pop.Connection) {
 	shipmentDate := time.Now()
 
 	// Make a TDL to contain our tests
-	tdl, _ := testdatagen.MakeTDL(db, "US California", "90210", "2")
-	tdl2, _ := testdatagen.MakeTDL(db, "US New York", "10024", "2")
+	tdl, _ := testdatagen.MakeTDL(db, "US13", "90210", "2")
+	tdl2, _ := testdatagen.MakeTDL(db, "US62", "10024", "2")
 
 	// Make a market
 	market := "dHHG"

--- a/pkg/testdatagen/scenario/awardqueue.go
+++ b/pkg/testdatagen/scenario/awardqueue.go
@@ -16,7 +16,7 @@ func RunAwardQueueScenario1(db *pop.Connection) {
 	shipmentsToMake := 17
 
 	// Make a TDL to contain our tests
-	tdl, _ := testdatagen.MakeTDL(db, "US13", "90210", "2")
+	tdl, _ := testdatagen.MakeTDL(db, "US13", "15", "2")
 
 	// Make a market
 	market := "dHHG"
@@ -51,8 +51,8 @@ func RunAwardQueueScenario2(db *pop.Connection) {
 	shipmentDate := time.Now()
 
 	// Make a TDL to contain our tests
-	tdl, _ := testdatagen.MakeTDL(db, "US13", "90210", "2")
-	tdl2, _ := testdatagen.MakeTDL(db, "US62", "10024", "2")
+	tdl, _ := testdatagen.MakeTDL(db, "US13", "15", "2")
+	tdl2, _ := testdatagen.MakeTDL(db, "US62", "1", "2")
 
 	// Make a market
 	market := "dHHG"

--- a/pkg/testdatagen/scenario/awardqueue.go
+++ b/pkg/testdatagen/scenario/awardqueue.go
@@ -16,7 +16,7 @@ func RunAwardQueueScenario1(db *pop.Connection) {
 	shipmentsToMake := 17
 
 	// Make a TDL to contain our tests
-	tdl, _ := testdatagen.MakeTDL(db, "california", "90210", "2")
+	tdl, _ := testdatagen.MakeTDL(db, "US California", "90210", "2")
 
 	// Make a market
 	market := "dHHG"
@@ -37,11 +37,11 @@ func RunAwardQueueScenario1(db *pop.Connection) {
 	tsp5, _ := testdatagen.MakeTSP(db, testdatagen.RandomSCAC())
 
 	// TSPs should be ordered by offer_count first, then BVS.
-	testdatagen.MakeTSPPerformance(db, tsp1, tdl, swag.Int(1), 5, 0, 4.2, 4.2)
-	testdatagen.MakeTSPPerformance(db, tsp2, tdl, swag.Int(1), 4, 0, 3.3, 3.3)
-	testdatagen.MakeTSPPerformance(db, tsp3, tdl, swag.Int(2), 3, 0, 2.1, 2.1)
-	testdatagen.MakeTSPPerformance(db, tsp4, tdl, swag.Int(3), 2, 0, 1.1, 1.1)
-	testdatagen.MakeTSPPerformance(db, tsp5, tdl, swag.Int(4), 1, 0, .5, .5)
+	testdatagen.MakeTSPPerformance(db, tsp1, tdl, swag.Int(1), 5, 0, 0.42, 0.42)
+	testdatagen.MakeTSPPerformance(db, tsp2, tdl, swag.Int(1), 4, 0, 0.33, 0.33)
+	testdatagen.MakeTSPPerformance(db, tsp3, tdl, swag.Int(2), 3, 0, 0.21, 0.21)
+	testdatagen.MakeTSPPerformance(db, tsp4, tdl, swag.Int(3), 2, 0, 0.11, 0.11)
+	testdatagen.MakeTSPPerformance(db, tsp5, tdl, swag.Int(4), 1, 0, 0.05, 0.05)
 }
 
 // RunAwardQueueScenario2 creates 9 shipments to be divided between 5 TSPs in 1 TDL and 10 shipments to be divided among 4 TSPs in TDL 2.
@@ -51,8 +51,8 @@ func RunAwardQueueScenario2(db *pop.Connection) {
 	shipmentDate := time.Now()
 
 	// Make a TDL to contain our tests
-	tdl, _ := testdatagen.MakeTDL(db, "california", "90210", "2")
-	tdl2, _ := testdatagen.MakeTDL(db, "New York", "10024", "2")
+	tdl, _ := testdatagen.MakeTDL(db, "US California", "90210", "2")
+	tdl2, _ := testdatagen.MakeTDL(db, "US New York", "10024", "2")
 
 	// Make a market
 	market := "dHHG"
@@ -81,16 +81,16 @@ func RunAwardQueueScenario2(db *pop.Connection) {
 	tsp9, _ := testdatagen.MakeTSP(db, testdatagen.RandomSCAC()) // V v bad TSP
 
 	// Put TSPs in 2 TDLs to handle these shipments
-	testdatagen.MakeTSPPerformance(db, tsp1, tdl, swag.Int(1), 5, 0, 4.2, 4.4)
-	testdatagen.MakeTSPPerformance(db, tsp2, tdl, swag.Int(1), 4, 0, 3.1, 3.2)
-	testdatagen.MakeTSPPerformance(db, tsp3, tdl, swag.Int(2), 3, 0, 2.4, 2.5)
-	testdatagen.MakeTSPPerformance(db, tsp4, tdl, swag.Int(3), 2, 0, 1.1, 1.3)
-	testdatagen.MakeTSPPerformance(db, tsp5, tdl, swag.Int(4), 1, 0, .5, .8)
+	testdatagen.MakeTSPPerformance(db, tsp1, tdl, swag.Int(1), 5, 0, 0.42, 0.44)
+	testdatagen.MakeTSPPerformance(db, tsp2, tdl, swag.Int(1), 4, 0, 0.31, 0.32)
+	testdatagen.MakeTSPPerformance(db, tsp3, tdl, swag.Int(2), 3, 0, 0.24, 0.25)
+	testdatagen.MakeTSPPerformance(db, tsp4, tdl, swag.Int(3), 2, 0, 0.11, 0.13)
+	testdatagen.MakeTSPPerformance(db, tsp5, tdl, swag.Int(4), 1, 0, 0.05, 0.08)
 
-	testdatagen.MakeTSPPerformance(db, tsp6, tdl2, swag.Int(1), 5, 0, 4.2, 4.4)
-	testdatagen.MakeTSPPerformance(db, tsp7, tdl2, swag.Int(2), 4, 0, 3.1, 3.2)
-	testdatagen.MakeTSPPerformance(db, tsp8, tdl2, swag.Int(3), 2, 0, 1.1, 1.3)
-	testdatagen.MakeTSPPerformance(db, tsp9, tdl2, swag.Int(4), 1, 0, .5, .8)
+	testdatagen.MakeTSPPerformance(db, tsp6, tdl2, swag.Int(1), 5, 0, 0.42, 0.44)
+	testdatagen.MakeTSPPerformance(db, tsp7, tdl2, swag.Int(2), 4, 0, 0.31, 0.32)
+	testdatagen.MakeTSPPerformance(db, tsp8, tdl2, swag.Int(3), 2, 0, 0.11, 0.13)
+	testdatagen.MakeTSPPerformance(db, tsp9, tdl2, swag.Int(4), 1, 0, 0.05, 0.08)
 	// Add blackout dates
 	blackoutStart := shipmentDate.AddDate(0, 0, -3)
 	blackoutEnd := shipmentDate.AddDate(0, 0, 3)


### PR DESCRIPTION

## Description

I couldn't run `./bin/generate-test-data -scenario=2` and kept getting an error.  Turns out that if a model doesn't validate then `db.ValidateAndSave` will not assign a UUID to the new object but will still return the struct.  This ends up causing an issue with Fkey contraints as indicated by this output:

```
./bin/generate-test-data -scenario=2
2018/07/16 11:36:09 pq: insert or update on table "transportation_service_provider_performances" violates foreign key constraint "transportation_service_provid_traffic_distribution_list_id_fkey"
panic: pq: insert or update on table "transportation_service_provider_performances" violates foreign key constraint "transportation_service_provid_traffic_distribution_list_id_fkey"

goroutine 1 [running]:
log.Panic(0xc42053cff0, 0x1, 0x1)
        /usr/local/Cellar/go/1.10.3/libexec/src/log/log.go:326 +0xc0
github.com/transcom/mymove/pkg/testdatagen.MakeTSPPerformance(0xc4201f0a80, 0xfc42851647eb1599, 0xfc0b223b9d7e70a9, 0xbecb574663e3f5cd, 0x58f5003, 0x1a11c60, 0xbecb574663e3f955, 0x58f538b, 0x1a11c60, 0xc4204e90c0, ...)
        /Users/cgilmer/Projects/go/src/github.com/transcom/mymove/pkg/testdatagen/make_tsp_performance_records.go:41 +0x289
github.com/transcom/mymove/pkg/testdatagen/scenario.RunAwardQueueScenario2(0xc4201f0a80)
        /Users/cgilmer/Projects/go/src/github.com/transcom/mymove/pkg/testdatagen/scenario/awardqueue.go:86 +0xccf
main.main()
        /Users/cgilmer/Projects/go/src/github.com/transcom/mymove/cmd/generate_test_data/main.go:36 +0x675
```

To fix this I made the validators actually report errors or panic.  Then I modified the data to fit what should be there.  It's not perfect but you can now get things working in this order:

```
make db_dev_reset && make db_dev_migrate
go run cmd/generate_test_data/main.go -scenario=2
```

## Reviewer Notes

- I modified the data, which may have implications elsewhere.
- I made an validator a bit more verbose, which may be out of style but its what I like.

## Code Review Verification Steps

* [x] All tests pass.