### PR TITLE
disabled HHG button if flag is set to false

### DIFF
--- a/src/scenes/Moves/MoveType.jsx
+++ b/src/scenes/Moves/MoveType.jsx
@@ -142,7 +142,7 @@ class BigButtonGroup extends Component {
       },
       'truck-gray',
       isMobile,
-      false,
+      true,
     );
     var enabledHHG = createButton(
       'HHG',


### PR DESCRIPTION
## Description

Corrects an error where button was not disabled when flag was set to false.

## Reviewer Notes

Go to HHG selection page with flag set to false, should not be able to select HHG.