### PR TITLE
Move database migrations to Fargate.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,6 @@ jobs:
           command: make server_generate
       - run:
           name: Run pre-commit tests
-          # TODO(dynamike): Remove skipping gas once we've nailed down all the findings
           command: pre-commit run --all-files
       - save_cache:
           key: pre-commit-dot-cache-{{ checksum ".pre-commit-config.yaml" }}

--- a/bin/ecs-run-app-migrations-container
+++ b/bin/ecs-run-app-migrations-container
@@ -49,13 +49,13 @@ container_definition_json=$(perl -pe "s|{{environment}}|$environment|g; s|{{imag
 readonly container_definition_json
 
 # create new task definition with the given image
-task_definition_arn=$(aws ecs register-task-definition --network-mode awsvpc --task-role-arn "ecs-task-role-app-$environment" --family "$task_family" --container-definitions "$container_definition_json" --query 'taskDefinition.taskDefinitionArn' --output text)
+task_definition_arn=$(aws ecs register-task-definition --network-mode awsvpc --task-role-arn "ecs-task-role-app-$environment" --family "$task_family" --container-definitions "$container_definition_json" --requires-compatibilities FARGATE --execution-role-arn "ecs-task-execution-role-app-$environment" --cpu 256 --memory 512 --query 'taskDefinition.taskDefinitionArn' --output text)
 readonly task_definition_arn
 check_arn "$task_definition_arn"
 
 # run the task
 echo "Running task definition $task_definition_arn …"
-task_arn=$(aws ecs run-task --network-configuration "$network_configuration" --task-definition "$task_definition_arn" --cluster "$cluster" --query 'tasks[].taskArn' --output text)
+task_arn=$(aws ecs run-task --launch-type FARGATE --network-configuration "$network_configuration" --task-definition "$task_definition_arn" --cluster "$cluster" --query 'tasks[].taskArn' --output text)
 readonly task_arn
 check_arn "$task_arn"
 time aws ecs wait tasks-stopped --tasks "$task_arn" --cluster "$cluster"

--- a/config/app-migrations.container-definition.json
+++ b/config/app-migrations.container-definition.json
@@ -1,8 +1,6 @@
 {
   "name": "app-migrations-{{environment}}",
   "image": "{{image}}",
-  "cpu": 512,
-  "memoryReservation": 256,
   "essential": true,
   "entryPoint": [
     "/bin/chamber",


### PR DESCRIPTION
## Description
Now that secure database migrations are streaming directly out of S3, we can switch those containers over to Fargate. This PR updates the ECS container definitions to support Fargate and the corresponding deploy script.

## Code Review Verification Steps

* [x] All tests pass.
* [x] Tested migrations in experimental
* [x] Request review from a member of a different team.

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/157301585) for this change
