### PR TITLE
Clears move doc upload form, improves upload form validation [finishes #159172924]

### DIFF
--- a/src/scenes/Office/DocumentViewer/DocumentUploader.jsx
+++ b/src/scenes/Office/DocumentViewer/DocumentUploader.jsx
@@ -20,15 +20,17 @@ export class DocumentUploader extends Component {
 
     this.state = {
       newUploads: [],
+      uploaderIsIdle: true,
       moveDocumentCreateError: null,
     };
 
     this.onChange = this.onChange.bind(this);
     this.onSubmit = this.onSubmit.bind(this);
+    this.onAddFile = this.onAddFile.bind(this);
   }
 
   onSubmit() {
-    const { formValues } = this.props;
+    const { formValues, reset } = this.props;
     const uploadIds = map(this.state.newUploads, 'id');
     const moveId = this.props.match.params.moveId;
     this.setState({
@@ -43,6 +45,10 @@ export class DocumentUploader extends Component {
         'AWAITING_REVIEW',
         formValues.notes,
       )
+      .then(() => {
+        reset();
+        this.uploader.clearFiles();
+      })
       .catch(err => {
         this.setState({
           moveDocumentCreateError: err,
@@ -58,9 +64,16 @@ export class DocumentUploader extends Component {
     // });
   }
 
-  onChange(files) {
+  onAddFile() {
     this.setState({
-      newUploads: files,
+      uploaderIsIdle: false,
+    });
+  }
+
+  onChange(newUploads, uploaderIsIdle) {
+    this.setState({
+      newUploads,
+      uploaderIsIdle,
     });
   }
 
@@ -68,7 +81,7 @@ export class DocumentUploader extends Component {
     const { handleSubmit, schema, formValues } = this.props;
     const hasFormFilled = formValues && formValues.move_document_type;
     const hasFiles = this.state.newUploads.length;
-    const isValid = hasFormFilled && hasFiles;
+    const isValid = hasFormFilled && hasFiles && this.state.uploaderIsIdle;
     return (
       <Fragment>
         {this.state.moveDocumentCreateError && (
@@ -101,7 +114,11 @@ export class DocumentUploader extends Component {
               Upload a PDF or take a picture of each page and upload the images.
             </p>
             <div className="uploader-box">
-              <Uploader onChange={this.onChange} />
+              <Uploader
+                onRef={ref => (this.uploader = ref)}
+                onChange={this.onChange}
+                onAddFile={this.onAddFile}
+              />
               <div className="hint">(Each page must be clear and legible)</div>
             </div>
           </div>

--- a/src/scenes/Orders/UploadOrders.jsx
+++ b/src/scenes/Orders/UploadOrders.jsx
@@ -12,6 +12,9 @@ import WizardPage from 'shared/WizardPage';
 
 import './UploadOrders.css';
 
+const uploaderLabelIdle =
+  'Drag & drop or <span class="filepond--label-action">click to upload orders</span>';
+
 export class UploadOrders extends Component {
   constructor(props) {
     super(props);
@@ -89,6 +92,7 @@ export class UploadOrders extends Component {
             <Uploader
               document={currentOrders.uploaded_orders}
               onChange={this.onChange}
+              labelIdle={uploaderLabelIdle}
             />
             <div className="hint">(Each page must be clear and legible)</div>
           </div>

--- a/src/scenes/Review/EditOrders.jsx
+++ b/src/scenes/Review/EditOrders.jsx
@@ -26,6 +26,8 @@ import './Review.css';
 import profileImage from './images/profile.png';
 
 const editOrdersFormName = 'edit_orders';
+const uploaderLabelIdle =
+  'Drag & drop or <span class="filepond--label-action">click to upload orders</span>';
 
 let EditOrdersForm = props => {
   const {
@@ -75,6 +77,7 @@ let EditOrdersForm = props => {
         <Uploader
           document={initialValues.uploaded_orders}
           onChange={onUpload}
+          labelIdle={uploaderLabelIdle}
         />
       )}
       <SaveCancelButtons valid={valid} submitting={submitting} />

--- a/src/shared/Uploader/index.jsx
+++ b/src/shared/Uploader/index.jsx
@@ -3,11 +3,12 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import 'filepond-polyfill/dist/filepond-polyfill.js';
 import { FilePond, registerPlugin } from 'react-filepond';
+import { FileStatus } from 'filepond';
 import { bindActionCreators } from 'redux';
 import PropTypes from 'prop-types';
 import { CreateUpload, DeleteUpload } from 'shared/api.js';
 import isMobile from 'is-mobile';
-import { concat, reject } from 'lodash';
+import { concat, reject, every, includes } from 'lodash';
 
 import 'filepond/dist/filepond.min.css';
 import './index.css';
@@ -21,6 +22,11 @@ registerPlugin(FilepondPluginFileValidateType);
 registerPlugin(FilepondPluginImageExifOrientation);
 registerPlugin(FilePondImagePreview);
 
+const idleStatuses = [
+  FileStatus.PROCESSING_COMPLETE,
+  FileStatus.PROCESSING_ERROR,
+];
+
 export class Uploader extends Component {
   constructor(props) {
     super(props);
@@ -30,7 +36,42 @@ export class Uploader extends Component {
     };
   }
 
+  componentDidMount() {
+    if (this.props.onRef) {
+      this.props.onRef(this);
+    }
+  }
+
+  componentWillUnmount() {
+    if (this.props.onRef) {
+      this.props.onRef(undefined);
+    }
+  }
+
+  clearFiles() {
+    this.pond._pond.removeFiles();
+
+    this.setState({
+      files: [],
+    });
+
+    if (this.props.onChange) {
+      this.props.onChange([], true);
+    }
+  }
+
+  isIdle() {
+    // Returns a boolean: is FilePond done with all uploading?
+    const existingFiles = this.pond._pond.getFiles();
+    const isIdle = every(existingFiles, f => {
+      return includes(idleStatuses, f.status);
+    });
+
+    return isIdle;
+  }
+
   handlePondInit() {
+    const { labelIdle } = this.props;
     this.pond._pond.setOptions({
       allowMultiple: true,
       server: {
@@ -41,9 +82,22 @@ export class Uploader extends Component {
       iconUndo: this.pond._pond.iconRemove,
       imagePreviewMaxHeight: 100,
       labelIdle:
-        'Drag & drop or <span class="filepond--label-action">click to upload orders</span>',
+        labelIdle ||
+        'Drag & drop or <span class="filepond--label-action">click to upload</span>',
       labelTapToUndo: 'tap to delete',
       acceptedFileTypes: ['image/*', 'application/pdf'],
+    });
+
+    this.pond._pond.on('processfile', e => {
+      if (this.props.onChange) {
+        this.props.onChange(this.state.files, this.isIdle());
+      }
+    });
+
+    this.pond._pond.on('addfilestart', e => {
+      if (this.props.onAddFile) {
+        this.props.onAddFile();
+      }
     });
 
     // Don't mention drag and drop if on mobile device
@@ -64,12 +118,6 @@ export class Uploader extends Component {
         self.setState({
           files: newFiles,
         });
-        // Call onChange after the upload completes
-        self.pond._pond.onOnce('processfile', e => {
-          if (self.props.onChange) {
-            self.props.onChange(newFiles);
-          }
-        });
       })
       .catch(error);
 
@@ -88,7 +136,7 @@ export class Uploader extends Component {
           files: newFiles,
         });
         if (this.props.onChange) {
-          this.props.onChange(newFiles);
+          this.props.onChange(newFiles, this.isIdle());
         }
       })
       .catch(error);
@@ -109,6 +157,7 @@ export class Uploader extends Component {
 Uploader.propTypes = {
   document: PropTypes.object,
   onChange: PropTypes.func,
+  labelIdle: PropTypes.string,
 };
 
 function mapStateToProps(state) {


### PR DESCRIPTION
## Description

On a move document form save, this PR clears the form fields, and clears the uploader of files.

The move document uploader component now gets better info about when uploads are still in progress, adding that info to form validation. Basically, can't save form if uploads are in progress.

## Code Review Verification Steps

* [ ] All tests pass.
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/blob/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* [ ] Any migrations/schema changes also update the diagram in docs/schema/dp3.sqs
* [ ] There are no aXe warnings for UI.
* [ ] This works in IE.
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @willowbl00
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Request review from a member of a different team.
* [ ] (TRIAL) Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/159172924) for this change

## Screenshots

![upload clear](https://user-images.githubusercontent.com/5151804/42975714-8bd16622-8b72-11e8-8663-d5f0822273b1.gif)