### PR TITLE
Create endpoint to request payment for a PPM

### DIFF
--- a/pkg/handlers/handlers.go
+++ b/pkg/handlers/handlers.go
@@ -145,6 +145,7 @@ func NewInternalAPIHandler(context HandlerContext) http.Handler {
 	internalAPI.PpmShowPPMEstimateHandler = ShowPPMEstimateHandler(context)
 	internalAPI.PpmShowPPMSitEstimateHandler = ShowPPMSitEstimateHandler(context)
 	internalAPI.PpmShowPPMIncentiveHandler = ShowPPMIncentiveHandler(context)
+	internalAPI.PpmRequestPPMPaymentHandler = RequestPPMPaymentHandler(context)
 
 	internalAPI.DutyStationsSearchDutyStationsHandler = SearchDutyStationsHandler(context)
 

--- a/pkg/handlers/personally_procured_move_test.go
+++ b/pkg/handlers/personally_procured_move_test.go
@@ -548,3 +548,76 @@ func (suite *HandlerSuite) TestPatchPPMHandlerEdgeCases() {
 	suite.Require().Equal(internalmessages.ReimbursementStatusDRAFT, *created.Payload.Advance.Status, "expected Draft")
 	suite.Require().Equal(initialAmount, *created.Payload.Advance.RequestedAmount, "expected amount to shine through.")
 }
+
+func (suite *HandlerSuite) TestRequestPPMPayment() {
+	t := suite.T()
+
+	initialSize := internalmessages.TShirtSize("S")
+	initialWeight := swag.Int64(1)
+
+	move := testdatagen.MakeDefaultMove(suite.db)
+
+	err := move.Submit()
+	if err != nil {
+		t.Fatal("Should transition.")
+	}
+	err = move.Approve()
+	if err != nil {
+		t.Fatal("Should transition.")
+	}
+	err = move.Complete()
+	if err != nil {
+		t.Fatal("Should transition.")
+	}
+
+	suite.mustSave(&move)
+
+	ppm1 := models.PersonallyProcuredMove{
+		MoveID:         move.ID,
+		Move:           move,
+		Size:           &initialSize,
+		WeightEstimate: initialWeight,
+		Status:         models.PPMStatusDRAFT,
+	}
+	err = ppm1.Submit()
+	if err != nil {
+		t.Fatal("Should transition.")
+	}
+	err = ppm1.Approve()
+	if err != nil {
+		t.Fatal("Should transition.")
+	}
+	err = ppm1.Begin()
+	if err != nil {
+		t.Fatal("Should transition.")
+	}
+	err = ppm1.Complete()
+	if err != nil {
+		t.Fatal("Should transition.")
+	}
+
+	suite.mustSave(&ppm1)
+
+	req := httptest.NewRequest("GET", "/fake/path", nil)
+	req = suite.authenticateRequest(req, move.Orders.ServiceMember)
+
+	requestPaymentParams := ppmop.RequestPPMPaymentParams{
+		HTTPRequest:              req,
+		PersonallyProcuredMoveID: strfmt.UUID(ppm1.ID.String()),
+	}
+
+	handler := RequestPPMPaymentHandler(NewHandlerContext(suite.db, suite.logger))
+	response := handler.Handle(requestPaymentParams)
+
+	created, ok := response.(*ppmop.RequestPPMPaymentOK)
+	if !ok {
+		t.Fatalf("Request failed: %#v", response)
+	}
+
+	suite.Require().Equal(internalmessages.PPMStatusPAYMENTREQUESTED, created.Payload.Status, "expected payment requested")
+
+	err = suite.db.Find(&move, move.ID)
+
+	suite.Require().Equal(string(models.MoveStatusPAYMENTREQUESTED), string(move.Status), "expected payment requested")
+
+}

--- a/pkg/models/errors.go
+++ b/pkg/models/errors.go
@@ -21,6 +21,9 @@ var ErrLocatorGeneration = errors.New("LOCATOR_ERRORS")
 // ErrInvalidPatchGate means that an attempt to patch a model was not given the correct set of fields
 var ErrInvalidPatchGate = errors.New("INVALID_PATCH_GATE")
 
+// ErrInvalidTransition is an error representing an invalid state transition.
+var ErrInvalidTransition = errors.New("INVALID_TRANSITION")
+
 // recordNotFoundErrorString is the error string returned when no matching rows exist in the database
 // This is ugly, but the best we can do with go's Postgresql adapter
 const recordNotFoundErrorString = "sql: no rows in result set"

--- a/pkg/models/move.go
+++ b/pkg/models/move.go
@@ -29,6 +29,8 @@ const (
 	MoveStatusCOMPLETED MoveStatus = "COMPLETED"
 	// MoveStatusCANCELED captures enum value "CANCELED"
 	MoveStatusCANCELED MoveStatus = "CANCELED"
+	// MoveStatusPAYMENTREQUESTED captures enum value "PAYMENT_REQUESTED"
+	MoveStatusPAYMENTREQUESTED MoveStatus = "PAYMENT_REQUESTED"
 )
 
 const maxLocatorAttempts = 3
@@ -116,6 +118,16 @@ func (m *Move) Approve() error {
 	return nil
 }
 
+// Complete Completes the Move
+func (m *Move) Complete() error {
+	if m.Status != MoveStatusAPPROVED {
+		return errors.Wrap(ErrInvalidTransition, "Complete")
+	}
+
+	m.Status = MoveStatusCOMPLETED
+	return nil
+}
+
 // Cancel cancels the Move and its associated PPMs
 func (m *Move) Cancel(reason string) error {
 	// We can cancel any move that isn't already complete.
@@ -144,6 +156,18 @@ func (m *Move) Cancel(reason string) error {
 	if err != nil {
 		return err
 	}
+
+	return nil
+}
+
+// RequestPayment Requests payment for this move
+func (m *Move) RequestPayment() error {
+	// We can cancel any move that isn't already complete.
+	if m.Status != MoveStatusCOMPLETED {
+		return errors.Wrap(ErrInvalidTransition, "RequestPayment")
+	}
+
+	m.Status = MoveStatusPAYMENTREQUESTED
 
 	return nil
 }

--- a/pkg/models/reimbursement.go
+++ b/pkg/models/reimbursement.go
@@ -55,9 +55,6 @@ type Reimbursement struct {
 // State Machine
 // Avoid calling Reimbursement.Status = ... ever. Use these methods to change the state.
 
-// ErrInvalidTransition is an error representing an invalid transition.
-var ErrInvalidTransition = errors.New("INVALID_TRANSITION")
-
 // Request officially requests the reimbursement.
 func (r *Reimbursement) Request() error {
 	if r.Status != ReimbursementStatusDRAFT {

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -1754,12 +1754,14 @@ definitions:
       - APPROVED
       - COMPLETED
       - CANCELED
+      - PAYMENT_REQUESTED
     x-display-value:
       DRAFT: Draft
       SUBMITTED: Submitted
       APPROVED: Approved
       COMPLETED: Completed
       CANCELED: Canceled
+      PAYMENT_REQUESTED: Payment Requested
   PPMStatus:
     type: string
     title: Move status
@@ -1770,6 +1772,7 @@ definitions:
       - IN_PROGRESS
       - COMPLETED
       - CANCELED
+      - PAYMENT_REQUESTED
     x-display-value:
       DRAFT: Draft
       SUBMITTED: Submitted
@@ -1777,6 +1780,7 @@ definitions:
       IN_PROGRESS: In Progress
       COMPLETED: Completed
       CANCELED: Canceled
+      PAYMENT_REQUESTED: Payment Requested
   OrdersStatus:
     type: string
     title: Move status
@@ -2629,6 +2633,35 @@ paths:
           description: request requires user authentication
         403:
           description: user is not authorized
+  /personally_procured_move/{personallyProcuredMoveId}/request_payment:
+    post:
+      summary: Moves the PPM and the move into the PAYMENT_REQUESTED state
+      description: Moves the PPM and the move into the PAYMENT_REQUESTED state
+      operationId: requestPPMPayment
+      tags:
+        - ppm
+      parameters:
+        - in: path
+          name: personallyProcuredMoveId
+          type: string
+          format: uuid
+          required: true
+          description: UUID of the PPM
+      responses:
+        200:
+          description: Sucesssfully requested payement
+          schema:
+            $ref: '#/definitions/PersonallyProcuredMovePayload'
+        400:
+          description: invalid request
+        401:
+          description: request requires user authentication
+        403:
+          description: user is not authorized
+        404:
+          description: move not found
+        500:
+          description: server error
   /moves/{moveId}/shipment:
     post:
       summary: Creates a new Shipment for the given move


### PR DESCRIPTION
## Description

This adds state machinery to PPMs and Moves to request payment for a PPM. 

## Reviewer Notes

I could be convinced that RequestPayment() in PPM should automatically call RequestPayment for its move. 

## Code Review Verification Steps

* [ ] End to end tests pass (`make e2e_test`).
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/blob/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [https://www.pivotaltracker.com/story/show/159220471](tbd) for this change
