### PR TITLE
els getWorkflowRoutes props[delivers #159348489]

### DIFF
--- a/src/scenes/Landing/index.jsx
+++ b/src/scenes/Landing/index.jsx
@@ -6,6 +6,8 @@ import { bindActionCreators } from 'redux';
 import { withLastLocation } from 'react-router-last-location';
 import { MoveSummary } from './MoveSummary';
 
+import { selectedMoveType, lastMoveIsCanceled } from 'scenes/Moves/ducks';
+
 import {
   createServiceMember,
   isProfileComplete,
@@ -62,6 +64,8 @@ export class Landing extends Component {
 
   getNextIncompletePage = () => {
     const {
+      selectedMoveType,
+      lastMoveIsCanceled,
       serviceMember,
       orders,
       move,
@@ -69,7 +73,9 @@ export class Landing extends Component {
       hhg,
       backupContacts,
     } = this.props;
-    return getNextIncompletePageInternal(this.props.reduxState, {
+    return getNextIncompletePageInternal({
+      selectedMoveType,
+      lastMoveIsCanceled,
       serviceMember,
       orders,
       move,
@@ -139,7 +145,8 @@ export class Landing extends Component {
 }
 
 const mapStateToProps = state => ({
-  reduxState: state,
+  lastMoveIsCanceled: lastMoveIsCanceled(state),
+  selectedMoveType: selectedMoveType(state),
   isLoggedIn: state.user.isLoggedIn,
   isProfileComplete: isProfileComplete(state),
   serviceMember: state.serviceMember.currentServiceMember || {},

--- a/src/scenes/Moves/ducks.js
+++ b/src/scenes/Moves/ducks.js
@@ -71,6 +71,9 @@ export const moveIsApproved = state =>
 export const lastMoveIsCanceled = state =>
   get(state, 'moves.latestMove.status') === 'CANCELED';
 
+export const selectedMoveType = state =>
+  get(state, 'moves.currentMove.selected_move_type');
+
 // Reducer
 const initialState = {
   currentMove: null,

--- a/src/scenes/MyMove/getWorkflowRoutes.test.js
+++ b/src/scenes/MyMove/getWorkflowRoutes.test.js
@@ -216,23 +216,21 @@ describe('when getting the routes for the current workflow', () => {
       });
     });
   });
-  describe('given a complete servicemember with a complete profile', () => {});
 });
 
 describe('when getting the next incomplete page', () => {
   const serviceMember = { id: 'foo' };
   describe('when the profile is incomplete', () => {
-    const props = {
-      selectedMoveType: 'HHG',
-    };
     it('returns the first page of the user profile', () => {
-      const result = getNextIncompletePage(props, { serviceMember });
+      const result = getNextIncompletePage({
+        selectedMoveType: 'HHG',
+        serviceMember,
+      });
       expect(result).toEqual('/service-member/foo/create');
     });
     describe('when dod info is complete', () => {
-      const props = {};
       it('returns the next page of the user profile', () => {
-        const result = getNextIncompletePage(props, {
+        const result = getNextIncompletePage({
           serviceMember: {
             ...serviceMember,
             is_profile_complete: false,
@@ -246,9 +244,8 @@ describe('when getting the next incomplete page', () => {
       });
     });
     describe('when name is complete', () => {
-      const props = {};
       it('returns the next page of the user profile', () => {
-        const result = getNextIncompletePage(props, {
+        const result = getNextIncompletePage({
           serviceMember: {
             ...serviceMember,
             is_profile_complete: false,
@@ -264,11 +261,9 @@ describe('when getting the next incomplete page', () => {
       });
     });
     describe('when contact-info is complete', () => {
-      const props = {
-        selectedMoveType: 'PPM',
-      };
       it('returns the next page of the user profile', () => {
-        const result = getNextIncompletePage(props, {
+        const result = getNextIncompletePage({
+          selectedMoveType: 'PPM',
           serviceMember: {
             ...serviceMember,
             is_profile_complete: false,
@@ -291,9 +286,8 @@ describe('when getting the next incomplete page', () => {
       });
     });
     describe('when duty-station is complete', () => {
-      const props = {};
       it('returns the next page of the user profile', () => {
-        const result = getNextIncompletePage(props, {
+        const result = getNextIncompletePage({
           serviceMember: {
             ...serviceMember,
             is_profile_complete: false,
@@ -316,9 +310,8 @@ describe('when getting the next incomplete page', () => {
       });
     });
     describe('when residence address is complete', () => {
-      const props = {};
       it('returns the next page of the user profile', () => {
-        const result = getNextIncompletePage(props, {
+        const result = getNextIncompletePage({
           serviceMember: {
             ...serviceMember,
             is_profile_complete: false,
@@ -347,9 +340,8 @@ describe('when getting the next incomplete page', () => {
       });
     });
     describe('when backup address is complete', () => {
-      const props = {};
       it('returns the next page of the user profile', () => {
-        const result = getNextIncompletePage(props, {
+        const result = getNextIncompletePage({
           serviceMember: {
             ...serviceMember,
             is_profile_complete: false,
@@ -424,7 +416,7 @@ describe('when getting the next incomplete page', () => {
             street_address_1: 'zzz',
           },
         };
-        const result = getNextIncompletePage(props, {
+        const result = getNextIncompletePage({
           serviceMember: sm,
           backupContacts,
         });
@@ -433,9 +425,8 @@ describe('when getting the next incomplete page', () => {
     });
   });
   describe('when the profile is complete', () => {
-    const props = {};
     it('returns the orders info', () => {
-      const result = getNextIncompletePage(props, {
+      const result = getNextIncompletePage({
         serviceMember: {
           ...serviceMember,
           is_profile_complete: true,
@@ -444,9 +435,8 @@ describe('when getting the next incomplete page', () => {
       expect(result).toEqual('/orders/');
     });
     describe('when orders info is complete', () => {
-      const props = {};
       it('returns the next page', () => {
-        const result = getNextIncompletePage(props, {
+        const result = getNextIncompletePage({
           serviceMember: {
             ...serviceMember,
             is_profile_complete: true,
@@ -463,9 +453,8 @@ describe('when getting the next incomplete page', () => {
       });
     });
     describe('when orders upload is complete', () => {
-      const props = {};
       it('returns the next page', () => {
-        const result = getNextIncompletePage(props, {
+        const result = getNextIncompletePage({
           serviceMember: {
             ...serviceMember,
             is_profile_complete: true,
@@ -485,11 +474,9 @@ describe('when getting the next incomplete page', () => {
       });
     });
     describe('when move type selection is complete', () => {
-      const props = {
-        selectedMoveType: 'PPM',
-      };
       it('returns the next page', () => {
-        const result = getNextIncompletePage(props, {
+        const result = getNextIncompletePage({
+          selectedMoveType: 'PPM',
           serviceMember: {
             ...serviceMember,
             is_profile_complete: true,
@@ -515,11 +502,9 @@ describe('when getting the next incomplete page', () => {
       });
     });
     describe('when ppm date is complete', () => {
-      const props = {
-        selectedMoveType: 'PPM',
-      };
       it('returns the next page', () => {
-        const result = getNextIncompletePage(props, {
+        const result = getNextIncompletePage({
+          selectedMoveType: 'PPM',
           serviceMember: {
             ...serviceMember,
             is_profile_complete: true,
@@ -549,10 +534,8 @@ describe('when getting the next incomplete page', () => {
     });
     describe('when ppm size is complete', () => {
       it('returns the next page', () => {
-        const props = {
+        const result = getNextIncompletePage({
           selectedMoveType: 'PPM',
-        };
-        const result = getNextIncompletePage(props, {
           serviceMember: {
             ...serviceMember,
             is_profile_complete: true,
@@ -582,11 +565,9 @@ describe('when getting the next incomplete page', () => {
       });
     });
     describe('when ppm incentive is complete', () => {
-      const props = {
-        selectedMoveType: 'PPM',
-      };
       it('returns the next page', () => {
-        const result = getNextIncompletePage(props, {
+        const result = getNextIncompletePage({
+          selectedMoveType: 'PPM',
           serviceMember: {
             ...serviceMember,
             is_profile_complete: true,
@@ -617,11 +598,9 @@ describe('when getting the next incomplete page', () => {
       });
     });
     describe('when HHG move type selection is complete', () => {
-      const props = {
-        selectedMoveType: 'HHG',
-      };
       it('returns the next page', () => {
-        const result = getNextIncompletePage(props, {
+        const result = getNextIncompletePage({
+          selectedMoveType: 'HHG',
           serviceMember: {
             ...serviceMember,
             is_profile_complete: true,

--- a/src/scenes/MyMove/index.jsx
+++ b/src/scenes/MyMove/index.jsx
@@ -27,7 +27,7 @@ import Footer from 'shared/Footer';
 import LogoutOnInactivity from 'shared/User/LogoutOnInactivity';
 import PrivacyPolicyStatement from 'shared/Statements/PrivacyAndPolicyStatement';
 import AccessibilityStatement from 'shared/Statements/AccessibilityStatement';
-import { lastMoveIsCanceled } from 'scenes/Moves/ducks';
+import { selectedMoveType, lastMoveIsCanceled } from 'scenes/Moves/ducks';
 import { getWorkflowRoutes } from './getWorkflowRoutes';
 import { loadLoggedInUser } from 'shared/User/ducks';
 import { loadSchema } from 'shared/Swagger/ducks';
@@ -145,7 +145,7 @@ const mapStateToProps = state => {
   return {
     swaggerError: state.swagger.hasErrored,
     currentServiceMemberId: get(state, 'serviceMember.currentServiceMember.id'),
-    selectedMoveType: get(state, 'moves.currentMove.selected_move_type', 'PPM'), // hack: this makes development easier when an eng has to reload a page in the ppm flow over and over but there must be a better way.
+    selectedMoveType: selectedMoveType(state),
     moveId: get(state, 'moves.currentMove.id'),
     lastMoveIsCanceled: lastMoveIsCanceled(state),
     latestMove: get(state, 'moves.latestMove'),

--- a/src/scenes/Review/ProfileReview.jsx
+++ b/src/scenes/Review/ProfileReview.jsx
@@ -4,6 +4,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { push } from 'react-router-redux';
+import { selectedMoveType, lastMoveIsCanceled } from 'scenes/Moves/ducks';
 
 import Summary from './Summary';
 import { getNextIncompletePage as getNextIncompletePageInternal } from 'scenes/MyMove/getWorkflowRoutes';
@@ -17,6 +18,8 @@ class ProfileReview extends Component {
   };
   getNextIncompletePage = () => {
     const {
+      selectedMoveType,
+      lastMoveIsCanceled,
       serviceMember,
       orders,
       move,
@@ -24,7 +27,9 @@ class ProfileReview extends Component {
       hhg,
       backupContacts,
     } = this.props;
-    return getNextIncompletePageInternal(this.props.reduxState, {
+    return getNextIncompletePageInternal({
+      selectedMoveType,
+      lastMoveIsCanceled,
       serviceMember,
       orders,
       move,
@@ -58,8 +63,9 @@ ProfileReview.propTypes = {
 
 function mapStateToProps(state) {
   return {
-    reduxState: state,
     serviceMember: state.serviceMember.currentServiceMember,
+    lastMoveIsCanceled: lastMoveIsCanceled(state),
+    selectedMoveType: selectedMoveType(state),
   };
 }
 function mapDispatchToProps(dispatch) {


### PR DESCRIPTION

## Description

Changes made to support HHG were passing all of state into `getNextIncompletePage` but the code expected `selectedMoveType` to be in a different location. I changed the method to make it more explicit what was expected and created some selectors to reshape state for this purpose. 

## Reviewer Notes

calls to getNextIncompletePage were not passing state in the shape expected, so I refactored it to make explicit what is needed

## Code Review Verification Steps

* [x ] This works in IE.
* [x ] Request review from a member of a different team.

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/159348489) for this change
