### PR TITLE
WIP 159451240 sm hhg flow autopopulate [delivers #159451240]

### DIFF
--- a/pkg/handlers/users.go
+++ b/pkg/handlers/users.go
@@ -38,13 +38,13 @@ func (h ShowLoggedInUserHandler) Handle(params userop.ShowLoggedInUserParams) mi
 		if err != nil {
 			return responseForError(h.logger, err)
 		}
+		serviceMember.DutyStation = dutyStation
+
 		// Fetch duty station transportation office
 		transportationOffice, err := models.FetchDutyStationTransportationOffice(h.db, *serviceMember.DutyStationID)
-		if err != nil {
-			return responseForError(h.logger, err)
+		if err == nil {
+			serviceMember.DutyStation.TransportationOffice = transportationOffice
 		}
-		serviceMember.DutyStation = dutyStation
-		serviceMember.DutyStation.TransportationOffice = transportationOffice
 	}
 
 	// Load the latest orders associations and new duty station transport office
@@ -78,5 +78,4 @@ func (h ShowLoggedInUserHandler) Handle(params userop.ShowLoggedInUserParams) mi
 		ServiceMember: payloadForServiceMemberModel(h.storage, serviceMember),
 	}
 	return userop.NewShowLoggedInUserOK().WithPayload(&userPayload)
-
 }

--- a/pkg/models/order.go
+++ b/pkg/models/order.go
@@ -120,6 +120,7 @@ func FetchOrder(db *pop.Connection, session *auth.Session, id uuid.UUID) (Order,
 		"NewDutyStation.Address",
 		"UploadedOrders.Uploads",
 		"Moves.PersonallyProcuredMoves",
+		"Moves.Shipments",
 		"Moves.SignedCertifications").Find(&order, id)
 	if err != nil {
 		if errors.Cause(err).Error() == recordNotFoundErrorString {
@@ -132,7 +133,6 @@ func FetchOrder(db *pop.Connection, session *auth.Session, id uuid.UUID) (Order,
 	if session.IsMyApp() && order.ServiceMember.ID != session.ServiceMemberID {
 		return Order{}, ErrFetchForbidden
 	}
-
 	return order, nil
 }
 

--- a/src/appReducer.js
+++ b/src/appReducer.js
@@ -38,6 +38,12 @@ import shipments, {
 import addresses, {
   STATE_KEY as ADDRESSES_STATE_KEY,
 } from 'shared/Entities/modules/addresses';
+import moves, {
+  STATE_KEY as MOVES_STATE_KEY,
+} from 'shared/Entities/modules/moves';
+import orders, {
+  STATE_KEY as ORDERS_STATE_KEY,
+} from 'shared/Entities/modules/orders';
 
 const entititesReducer = combineReducers({
   [MOVEDOCUMENTS_STATE_KEY]: moveDocuments,
@@ -45,6 +51,8 @@ const entititesReducer = combineReducers({
   [UPLOADS_STATE_KEY]: uploads,
   [SHIPMENTS_STATE_KEY]: shipments,
   [ADDRESSES_STATE_KEY]: addresses,
+  [MOVES_STATE_KEY]: moves,
+  [ORDERS_STATE_KEY]: orders,
 });
 
 export const appReducer = combineReducers({

--- a/src/scenes/Moves/Hhg/Address.jsx
+++ b/src/scenes/Moves/Hhg/Address.jsx
@@ -20,6 +20,12 @@ export class ShipmentAddress extends Component {
       'formValues.has_delivery_address',
       false,
     );
+    const addressSchema = get(
+      this.props,
+      'schema.properties.pickup_address',
+      {},
+    );
+
     return (
       <div className="form-section">
         <h3 className="instruction-heading">
@@ -32,29 +38,29 @@ export class ShipmentAddress extends Component {
               <div className="address-segment usa-grid">
                 <SwaggerField
                   fieldName="street_address_1"
-                  swagger={this.props.schema.properties.pickup_address}
+                  swagger={addressSchema}
                   required
                 />
                 <SwaggerField
                   fieldName="street_address_2"
-                  swagger={this.props.schema.properties.pickup_address}
+                  swagger={addressSchema}
                 />
                 <SwaggerField
                   className="usa-width-one-fourth"
                   fieldName="city"
-                  swagger={this.props.schema.properties.pickup_address}
+                  swagger={addressSchema}
                   required
                 />
                 <SwaggerField
                   className="usa-width-one-sixth"
                   fieldName="state"
-                  swagger={this.props.schema.properties.pickup_address}
+                  swagger={addressSchema}
                   required
                 />
                 <SwaggerField
                   className="usa-width-one-fourth"
                   fieldName="postal_code"
-                  swagger={this.props.schema.properties.pickup_address}
+                  swagger={addressSchema}
                   required
                 />
               </div>
@@ -71,39 +77,29 @@ export class ShipmentAddress extends Component {
                   <div className="address-segment usa-grid">
                     <SwaggerField
                       fieldName="street_address_1"
-                      swagger={
-                        this.props.schema.properties.secondary_pickup_address
-                      }
+                      swagger={addressSchema}
                       required={hasSecondary}
                     />
                     <SwaggerField
                       fieldName="street_address_2"
-                      swagger={
-                        this.props.schema.properties.secondary_pickup_address
-                      }
+                      swagger={addressSchema}
                     />
                     <SwaggerField
                       className="usa-width-one-fourth"
                       fieldName="city"
-                      swagger={
-                        this.props.schema.properties.secondary_pickup_address
-                      }
+                      swagger={addressSchema}
                       required={hasSecondary}
                     />
                     <SwaggerField
                       className="usa-width-one-sixth"
                       fieldName="state"
-                      swagger={
-                        this.props.schema.properties.secondary_pickup_address
-                      }
+                      swagger={addressSchema}
                       required={hasSecondary}
                     />
                     <SwaggerField
                       className="usa-width-one-fourth"
                       fieldName="postal_code"
-                      swagger={
-                        this.props.schema.properties.secondary_pickup_address
-                      }
+                      swagger={addressSchema}
                       required={hasSecondary}
                     />
                   </div>
@@ -123,29 +119,29 @@ export class ShipmentAddress extends Component {
                   <div className="address-segment usa-grid">
                     <SwaggerField
                       fieldName="street_address_1"
-                      swagger={this.props.schema.properties.delivery_address}
+                      swagger={addressSchema}
                       required={hasDelivery}
                     />
                     <SwaggerField
                       fieldName="street_address_2"
-                      swagger={this.props.schema.properties.delivery_address}
+                      swagger={addressSchema}
                     />
                     <SwaggerField
                       className="usa-width-one-fourth"
                       fieldName="city"
-                      swagger={this.props.schema.properties.delivery_address}
+                      swagger={addressSchema}
                       required={hasDelivery}
                     />
                     <SwaggerField
                       className="usa-width-one-sixth"
                       fieldName="state"
-                      swagger={this.props.schema.properties.delivery_address}
+                      swagger={addressSchema}
                       required={hasDelivery}
                     />
                     <SwaggerField
                       className="usa-width-one-fourth"
                       fieldName="postal_code"
-                      swagger={this.props.schema.properties.delivery_address}
+                      swagger={addressSchema}
                       required={hasDelivery}
                     />
                   </div>

--- a/src/scenes/Moves/Hhg/DatePicker.jsx
+++ b/src/scenes/Moves/Hhg/DatePicker.jsx
@@ -3,7 +3,7 @@ import React, { Component } from 'react';
 import { DayPicker } from 'react-day-picker';
 import 'react-day-picker/lib/style.css';
 
-import { formatSwaggerDate } from 'shared/formatters';
+import { formatSwaggerDate, parseSwaggerDate } from 'shared/formatters';
 import './DatePicker.css';
 
 export class HHGDatePicker extends Component {
@@ -13,7 +13,7 @@ export class HHGDatePicker extends Component {
     super(props);
     this.handleDayClick = this.handleDayClick.bind(this);
     this.state = {
-      selectedDay: undefined,
+      selectedDay: this.props.selectedDay,
     };
   }
 
@@ -34,7 +34,7 @@ export class HHGDatePicker extends Component {
           <div className="usa-width-one-third">
             <DayPicker
               onDayClick={this.handleDayClick}
-              selectedDays={this.state.selectedDay}
+              selectedDays={parseSwaggerDate(this.props.selectedDay)}
             />
           </div>
 

--- a/src/scenes/Moves/Hhg/DatePicker.jsx
+++ b/src/scenes/Moves/Hhg/DatePicker.jsx
@@ -7,21 +7,9 @@ import { formatSwaggerDate, parseSwaggerDate } from 'shared/formatters';
 import './DatePicker.css';
 
 export class HHGDatePicker extends Component {
-  state = { showInfo: false };
-
-  constructor(props) {
-    super(props);
-    this.handleDayClick = this.handleDayClick.bind(this);
-    this.state = {
-      selectedDay: this.props.selectedDay,
-    };
-  }
-
-  handleDayClick(day) {
-    this.setState({ selectedDay: day });
-    this.setState({ showInfo: true });
+  handleDayClick = day => {
     this.props.setDate(formatSwaggerDate(day));
-  }
+  };
 
   render() {
     return (
@@ -39,7 +27,7 @@ export class HHGDatePicker extends Component {
           </div>
 
           <div className="usa-width-two-thirds">
-            {this.state.showInfo && (
+            {this.props.selectedDay && (
               <table className="Todo-phase2">
                 <tbody>
                   <tr>
@@ -83,6 +71,7 @@ export class HHGDatePicker extends Component {
 }
 HHGDatePicker.propTypes = {
   error: PropTypes.object,
+  selectedDay: PropTypes.string,
 };
 
 export default HHGDatePicker;

--- a/src/scenes/Moves/Hhg/ShipmentForm.jsx
+++ b/src/scenes/Moves/Hhg/ShipmentForm.jsx
@@ -8,10 +8,13 @@ import { setCurrentShipment, currentShipment } from 'shared/UI/ducks';
 
 import Alert from 'shared/Alert';
 import { reduxifyWizardForm } from 'shared/WizardPage/Form';
-import ShipmentDatePicker from 'scenes/Moves/Hhg/DatePicker';
-import ShipmentAddress from 'scenes/Moves/Hhg/Address';
+import DatePicker from 'scenes/Moves/Hhg/DatePicker';
+import Address from 'scenes/Moves/Hhg/Address';
 
-import { createOrUpdateShipment, getShipment } from 'shared/Entities/modules/shipments';
+import {
+  createOrUpdateShipment,
+  getShipment,
+} from 'shared/Entities/modules/shipments';
 
 import './ShipmentForm.css';
 
@@ -53,7 +56,7 @@ export class ShipmentForm extends Component {
   };
 
   render() {
-    const { pages, pageKey, error, initialValues } = this.props;
+    const { pages, pageKey, error, initialValues, formValues } = this.props;
 
     const requestedPickupDate = get(this.state, 'requestedPickupDate');
 
@@ -83,13 +86,13 @@ export class ShipmentForm extends Component {
           <div className="usa-grid">
             <h3 className="form-title">Shipment 1 (HHG)</h3>
           </div>
-          <ShipmentDatePicker
+          <DatePicker
             schema={this.props.schema}
             error={error}
-            formValues={this.props.formValues}
+            selectedDay={get(formValues, 'requested_pickup_date')}
             setDate={this.setDate}
           />
-          <ShipmentAddress
+          <Address
             schema={this.props.schema}
             error={error}
             formValues={this.props.formValues}

--- a/src/scenes/Moves/Hhg/ShipmentForm.jsx
+++ b/src/scenes/Moves/Hhg/ShipmentForm.jsx
@@ -89,7 +89,7 @@ export class ShipmentForm extends Component {
           <DatePicker
             schema={this.props.schema}
             error={error}
-            selectedDay={get(formValues, 'requested_pickup_date')}
+            selectedDay={get(formValues, 'requested_pickup_date', null)}
             setDate={this.setDate}
           />
           <Address

--- a/src/scenes/Moves/Hhg/ShipmentForm.jsx
+++ b/src/scenes/Moves/Hhg/ShipmentForm.jsx
@@ -11,7 +11,7 @@ import { reduxifyWizardForm } from 'shared/WizardPage/Form';
 import ShipmentDatePicker from 'scenes/Moves/Hhg/DatePicker';
 import ShipmentAddress from 'scenes/Moves/Hhg/Address';
 
-import { createOrUpdateShipment } from 'shared/Entities/modules/shipments';
+import { createOrUpdateShipment, getShipment } from 'shared/Entities/modules/shipments';
 
 import './ShipmentForm.css';
 
@@ -23,10 +23,18 @@ export class ShipmentForm extends Component {
     shipmentError: null,
   };
 
+  componentDidUpdate(prevProps) {
+    const currentID = get(this.props, 'currentShipment.id');
+    if (currentID !== get(prevProps, 'currentShipment.id')) {
+      this.props.getShipment(this.props.currentShipment.move_id, currentID);
+    }
+  }
+
   handleSubmit = () => {
     const moveId = this.props.match.params.moveId;
     const shipment = this.props.formValues;
-    const currentShipmentId = get(this, 'props.currentShipment.id');
+    const currentShipmentId = get(this.props, 'currentShipment.id');
+
     return this.props
       .createOrUpdateShipment(moveId, shipment, currentShipmentId)
       .then(data => {
@@ -99,17 +107,18 @@ ShipmentForm.propTypes = {
 
 function mapDispatchToProps(dispatch) {
   return bindActionCreators(
-    { createOrUpdateShipment, setCurrentShipment },
+    { createOrUpdateShipment, setCurrentShipment, getShipment },
     dispatch,
   );
 }
 function mapStateToProps(state) {
+  const shipment = currentShipment(state);
   const props = {
     schema: get(state, 'swagger.spec.definitions.Shipment', {}),
     move: get(state, 'moves.currentMove', {}),
-    initialValues: get(state, 'moves.currentMove.shipments[0]', {}),
     formValues: getFormValues(formName)(state),
-    currentShipment: currentShipment(state) || {},
+    currentShipment: shipment,
+    initialValues: shipment,
   };
   return props;
 }

--- a/src/shared/Entities/modules/moves.js
+++ b/src/shared/Entities/modules/moves.js
@@ -1,0 +1,22 @@
+import { moves } from '../schema';
+import { ADD_ENTITIES } from '../actions';
+import { denormalize } from 'normalizr';
+
+export const STATE_KEY = 'moves';
+
+export default function reducer(state = {}, action) {
+  switch (action.type) {
+    case ADD_ENTITIES:
+      return {
+        ...state,
+        ...action.payload.moves,
+      };
+
+    default:
+      return state;
+  }
+}
+
+export const selectMove = (state, id) => {
+  return denormalize([id], moves, state.entities)[0];
+};

--- a/src/shared/Entities/modules/orders.js
+++ b/src/shared/Entities/modules/orders.js
@@ -1,0 +1,22 @@
+import { orders } from '../schema';
+import { ADD_ENTITIES } from '../actions';
+import { denormalize } from 'normalizr';
+
+export const STATE_KEY = 'orders';
+
+export default function reducer(state = {}, action) {
+  switch (action.type) {
+    case ADD_ENTITIES:
+      return {
+        ...state,
+        ...action.payload.orders,
+      };
+
+    default:
+      return state;
+  }
+}
+
+export const selectUpload = (state, id) => {
+  return denormalize([id], orders, state.entities)[0];
+};

--- a/src/shared/Entities/modules/shipments.js
+++ b/src/shared/Entities/modules/shipments.js
@@ -1,7 +1,7 @@
-import { shipments } from '../schema';
-import { ADD_ENTITIES, addEntities } from '../actions';
 import { denormalize, normalize } from 'normalizr';
 
+import { shipments } from '../schema';
+import { ADD_ENTITIES, addEntities } from '../actions';
 import { getClient, checkResponse } from 'shared/api';
 
 export const STATE_KEY = 'shipments';
@@ -25,6 +25,23 @@ export function createOrUpdateShipment(moveId, shipment, id) {
   } else {
     return createShipment(moveId, shipment);
   }
+}
+
+export function getShipment(
+  moveId,
+  shipmentId
+) {
+  return async function(dispatch, getState, { schema }) {
+    const client = await getClient();
+    const response = await client.apis.shipments.getShipment({
+      moveId,
+      shipmentId,
+    });
+    checkResponse(response, 'failed to get shipment due to server error');
+    const data = normalize(response.body, schema.shipment);
+    dispatch(addEntities(data.entities));
+    return response;
+  };
 }
 
 export function createShipment(
@@ -63,7 +80,7 @@ export function updateShipment(
   };
 }
 
-export const selectShipment = (state, id) => {
+export function selectShipment (state, id) {
   if (!id) {
     return null;
   }

--- a/src/shared/Entities/schema.js
+++ b/src/shared/Entities/schema.js
@@ -4,11 +4,6 @@ import { schema } from 'normalizr';
 // User
 export const user = new schema.Entity('users');
 
-// Service Member
-export const serviceMember = new schema.Entity('serviceMembers', {
-  user: user,
-});
-
 // Uploads
 export const upload = new schema.Entity('uploads');
 export const uploads = new schema.Array(upload);
@@ -48,6 +43,7 @@ export const shipments = new schema.Array(shipment);
 // Moves
 export const move = new schema.Entity('moves', {
   personally_procured_moves: personallyProcuredMoves,
+  shipments: shipments,
 });
 export const moves = new schema.Array(move);
 personallyProcuredMove.define({
@@ -61,4 +57,11 @@ moveDocument.define({
 export const order = new schema.Entity('orders', {
   uploaded_orders: documentModel,
   moves: moves,
+});
+export const orders = new schema.Array(order);
+
+// Service Member
+export const serviceMember = new schema.Entity('serviceMembers', {
+  user: user,
+  orders: orders,
 });

--- a/src/shared/UI/ducks.js
+++ b/src/shared/UI/ducks.js
@@ -1,5 +1,8 @@
-import { selectShipment } from 'shared/Entities/modules/shipments';
 import { get } from 'lodash';
+
+import { fetchActive } from 'shared/utils';
+import { GET_LOGGED_IN_USER } from 'shared/User/ducks';
+import { selectShipment } from 'shared/Entities/modules/shipments';
 
 const initialState = {
   currentShipmentID: null,
@@ -9,10 +12,26 @@ const SET_CURRENT_SHIPMENT = 'SET_CURRENT_SHIPMENT';
 
 export default function uiReducer(state = initialState, action) {
   switch (action.type) {
+    case GET_LOGGED_IN_USER.success:
+      try {
+        const activeOrders = fetchActive(
+          get(action.payload, 'service_member.orders'),
+        );
+        const activeMove = fetchActive(get(activeOrders, 'moves'));
+        const activeShipment = fetchActive(get(activeMove, 'shipments'));
+        return {
+          ...state,
+          currentShipmentID: activeShipment ? activeShipment.id : null,
+        };
+      } catch(e) {
+        console.debug(e);
+        return state;
+      }
     case SET_CURRENT_SHIPMENT:
-      return Object.assign({}, state, {
+     return {
+        ...state,
         currentShipmentID: action.shipment.id,
-      });
+      };
     default:
       return state;
   }

--- a/src/shared/User/ducks.js
+++ b/src/shared/User/ducks.js
@@ -2,6 +2,10 @@ import * as Cookies from 'js-cookie';
 import * as decode from 'jwt-decode';
 import * as helpers from 'shared/ReduxHelpers';
 import { GetLoggedInUser } from './api.js';
+import { normalize } from 'normalizr';
+
+import { serviceMember } from 'shared/Entities/schema';
+import { addEntities } from 'shared/Entities/actions';
 
 const getLoggedInUserType = 'GET_LOGGED_IN_USER';
 
@@ -16,7 +20,13 @@ export const loadLoggedInUser = () => {
     if (!userInfo.isLoggedIn) return Promise.resolve();
     dispatch(getLoggedInActions.start());
     return GetLoggedInUser()
-      .then(item => dispatch(getLoggedInActions.success(item)))
+      .then(response => {
+        if (response.service_member) {
+          const data = normalize(response.service_member, serviceMember);
+          dispatch(addEntities(data.entities));
+        }
+        return dispatch(getLoggedInActions.success(response));
+      })
       .catch(error => dispatch(getLoggedInActions.error(error)));
   };
 };

--- a/src/shared/WizardPage/Form.jsx
+++ b/src/shared/WizardPage/Form.jsx
@@ -184,7 +184,10 @@ export const reduxifyWizardForm = (name, additionalValidations) => {
       additionalValidations,
     );
   }
-  return reduxForm({ form: name, validate: validations })(
-    withRouter(connect(null, mapDispatchToProps)(wizardFormPageWithSize)),
-  );
+  return reduxForm({
+    form: name,
+    validate: validations,
+    enableReinitialize: true,
+    keepDirtyOnReinitialize: true,
+  })(withRouter(connect(null, mapDispatchToProps)(wizardFormPageWithSize)));
 };

--- a/src/shared/formatters.js
+++ b/src/shared/formatters.js
@@ -38,6 +38,13 @@ export function formatSwaggerDate(date) {
   return '';
 }
 
+// Parse a date from the format used by Swagger into a Date object
+export function parseSwaggerDate(dateString) {
+  if (dateString) {
+    return moment(dateString, 'YYYY-MM-DD').toDate();
+  }
+}
+
 // Office Formatters
 //
 // The formatters below for the office app, but not the service member app


### PR DESCRIPTION
## Description

Shipment data that was previously saved is now displayed in the HHG form.

To make this work, I had to add `shipments` to the payload returned by `showLoggedInUser`. The Shipment form then fetches the shipment, and its data is then displayed in the form.

## Reviewer Notes

I could not get Pop to load the `*Address` associations on the Shipment during the `FetchOrder` call within `showLoggedInUser`, which is why I went with this approach (in addition to the fact that adding even more stuff to that endpoint seemed questionable.)

This PR also stores a lot of the SM-side data in `state.entities` as a side-affect of loading the shipments using that approach. We'll need to be careful not to get confused about which data to use as there is now duplication, but my hope is that this will help us move towards using the normalized data layout.

## Code Review Verification Steps

* [ ] End to end tests pass (`make e2e_test`).
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/159451240) for this change