### PR TITLE
Els expense summary ui [delivers #159220461]

### DIFF
--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -18,6 +18,7 @@ import PaymentsPanel from './Ppm/PaymentsPanel';
 import PPMEstimatesPanel from './Ppm/PPMEstimatesPanel';
 import StorageReimbursementCalculator from './Ppm/StorageReimbursementCalculator';
 import IncentiveCalculator from './Ppm/IncentiveCalculator';
+import ExpensesPanel from './Ppm/ExpensesPanel';
 import DocumentList from 'scenes/Office/DocumentViewer/DocumentList';
 import DatesAndTrackingPanel from './Hhg/DatesAndTrackingPanel';
 import { withContext } from 'shared/AppContext';
@@ -62,6 +63,7 @@ const PPMTabContent = props => {
   return (
     <div className="office-tab">
       <PaymentsPanel title="Payments" moveId={props.match.params.moveId} />
+      <ExpensesPanel title="Expenses" />
       <IncentiveCalculator />
       <StorageReimbursementCalculator />
       <PPMEstimatesPanel title="Estimates" moveId={props.match.params.moveId} />

--- a/src/scenes/Office/Ppm/ExpensesPanel.jsx
+++ b/src/scenes/Office/Ppm/ExpensesPanel.jsx
@@ -1,0 +1,111 @@
+import { get } from 'lodash';
+import React, { Component } from 'react';
+import { formatCents } from 'shared/formatters';
+import { getTabularExpenses } from 'scenes/Office/Ppm/ducks';
+import { connect } from 'react-redux';
+
+const dollar = cents => (cents ? '$' + formatCents(cents) : null);
+
+class ExpensesPanel extends Component {
+  render() {
+    const expenseData = {
+      categories: [
+        {
+          category: 'CONTRACTED_EXPENSE',
+          payment_methods: {
+            GTCC: 600,
+          },
+          total: 600,
+        },
+        {
+          category: 'RENTAL_EQUIPMENT',
+          payment_methods: {
+            MIL_PAY: 500,
+          },
+          total: 500,
+        },
+        {
+          category: 'TOLLS',
+          payment_methods: {
+            OTHER_DD: 500,
+          },
+          total: 500,
+        },
+      ],
+      grand_total: {
+        payment_method_totals: {
+          GTCC: 600,
+          MIL_PAY: 500,
+          OTHER_DD: 500,
+        },
+        total: 1600,
+      },
+    };
+    const { schemaMovingExpenseType } = this.props;
+
+    const tabularData = getTabularExpenses(
+      expenseData,
+      schemaMovingExpenseType,
+    );
+    return (
+      <div className="calculator-panel expense-panel">
+        <div className="calculator-panel-title">Expenses</div>
+        <div>
+          <table cellSpacing={0}>
+            <tbody>
+              <tr>
+                <th>&nbsp;</th>
+                <th className="expense-header payment-method" colSpan={3}>
+                  Payment Method
+                </th>
+                <th colSpan={2}>&nbsp;</th>
+              </tr>
+              <tr>
+                <th
+                  className="expense-header"
+                  width="40%"
+                  style={{ textAlign: 'left' }}
+                >
+                  Items
+                </th>
+                <th className="expense-header" width="10%">
+                  GTCC
+                </th>
+                <th className="expense-header" width="15%">
+                  Other
+                </th>
+                <th className="expense-header" width="20%">
+                  Total
+                </th>
+                <th className="expense-header" width="15%">
+                  &nbsp;
+                </th>
+              </tr>
+              {tabularData.map(row => {
+                return (
+                  <tr key={row.type}>
+                    <td>{row.type}</td>
+                    <td align="right">{dollar(row.GTCC)}</td>
+                    <td align="right"> {dollar(row.other)} </td>
+                    <td align="right">{dollar(row.total)} </td>
+                    <td>&nbsp;</td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    );
+  }
+}
+function mapStateToProps(state) {
+  return {
+    schemaMovingExpenseType: get(
+      state,
+      'swagger.spec.definitions.MovingExpenseType',
+      {},
+    ),
+  };
+}
+export default connect(mapStateToProps)(ExpensesPanel);

--- a/src/scenes/Office/Ppm/api.js
+++ b/src/scenes/Office/Ppm/api.js
@@ -11,3 +11,12 @@ export async function GetPpmIncentive(moveDate, originZip, destZip, weight) {
   checkResponse(response, 'failed to update ppm due to server error');
   return response.body;
 }
+
+export async function GetExpenseSummary(personallyProcuredMoveId) {
+  const client = await getClient();
+  const response = await client.apis.ppm.requestPPMExpenseSummary({
+    personallyProcuredMoveId,
+  });
+  checkResponse(response, 'failed to retrieve summary due to server error');
+  return response.body;
+}

--- a/src/scenes/Office/Ppm/ducks.js
+++ b/src/scenes/Office/Ppm/ducks.js
@@ -1,8 +1,9 @@
 import { get } from 'lodash';
-import { GetPpmIncentive } from './api.js';
+import { GetPpmIncentive, GetExpenseSummary } from './api.js';
 import * as ReduxHelpers from 'shared/ReduxHelpers';
 import reduceReducers from 'reduce-reducers';
 const GET_PPM_INCENTIVE = 'GET_PPM_INCENTIVE';
+const GET_PPM_EXPENSE_SUMMARY = 'GET_PPM_EXPENSE_SUMMARY';
 const CLEAR_PPM_INCENTIVE = 'CLEAR_PPM_INCENTIVE';
 export const getIncentiveActionType = ReduxHelpers.generateAsyncActionTypes(
   GET_PPM_INCENTIVE,
@@ -10,6 +11,22 @@ export const getIncentiveActionType = ReduxHelpers.generateAsyncActionTypes(
 export const getPpmIncentive = ReduxHelpers.generateAsyncActionCreator(
   GET_PPM_INCENTIVE,
   GetPpmIncentive,
+);
+
+export const getExpenseSummaryActionType = ReduxHelpers.generateAsyncActionTypes(
+  GET_PPM_EXPENSE_SUMMARY,
+);
+export const getPpmExpenseSummary = ReduxHelpers.generateAsyncActionCreator(
+  GET_PPM_EXPENSE_SUMMARY,
+  GetExpenseSummary,
+);
+const summaryReducer = ReduxHelpers.generateAsyncReducer(
+  GET_PPM_EXPENSE_SUMMARY,
+  v => {
+    return {
+      summary: { ...v },
+    };
+  },
 );
 
 export const clearPpmIncentive = () => ({ type: CLEAR_PPM_INCENTIVE });
@@ -21,6 +38,7 @@ const getOtherExpenses = item => {
   return val > 0 ? val : null;
 };
 export const getTabularExpenses = (expenseData, movingExpenseSchema) => {
+  if (!expenseData || !movingExpenseSchema) return [];
   const expenses = movingExpenseSchema.enum.map(type => {
     const item = expenseData.categories.find(item => item.category === type);
     if (!item)
@@ -68,4 +86,4 @@ const incentiveReducer = ReduxHelpers.generateAsyncReducer(
   }),
 );
 
-export default reduceReducers(clearReducer, incentiveReducer);
+export default reduceReducers(clearReducer, incentiveReducer, summaryReducer);

--- a/src/scenes/Office/Ppm/ducks.test.js
+++ b/src/scenes/Office/Ppm/ducks.test.js
@@ -1,5 +1,4 @@
 import reducer, { getIncentiveActionType, getTabularExpenses } from './ducks';
-import { pick } from 'lodash';
 describe('office ppm reducer', () => {
   describe('GET_PPM_INCENTIVE', () => {
     it('handles SUCCESS', () => {
@@ -73,7 +72,11 @@ describe('getTabularExpenses', () => {
       OTHER: 'Other',
     },
   };
-
+  describe('when there is no expense data', () => {
+    it('return and empty array', () => {
+      expect(getTabularExpenses(null, null)).toEqual([]);
+    });
+  });
   describe('when there is no milpay', () => {
     const expenseData = {
       categories: [

--- a/src/scenes/Office/Ppm/ducks.test.js
+++ b/src/scenes/Office/Ppm/ducks.test.js
@@ -1,9 +1,9 @@
-import reducer, { getIncentiveActionType } from './ducks';
-
+import reducer, { getIncentiveActionType, getTabularExpenses } from './ducks';
+import { pick } from 'lodash';
 describe('office ppm reducer', () => {
   describe('GET_PPM_INCENTIVE', () => {
     it('handles SUCCESS', () => {
-      const newState = reducer(undefined, {
+      const newState = reducer(null, {
         type: getIncentiveActionType.success,
         payload: { gcc: 123400, incentive_percentage: 12400 },
       });
@@ -16,7 +16,7 @@ describe('office ppm reducer', () => {
       });
     });
     it('handles START', () => {
-      const newState = reducer(undefined, {
+      const newState = reducer(null, {
         type: getIncentiveActionType.start,
       });
       expect(newState).toEqual({
@@ -26,7 +26,7 @@ describe('office ppm reducer', () => {
       });
     });
     it('handles FAILURE', () => {
-      const newState = reducer(undefined, {
+      const newState = reducer(null, {
         type: getIncentiveActionType.failure,
       });
       expect(newState).toEqual({
@@ -38,13 +38,240 @@ describe('office ppm reducer', () => {
   });
   describe('CLEAR_PPM_INCENTIVE', () => {
     it('handles SUCCESS', () => {
-      const newState = reducer(undefined, {
+      const newState = reducer(null, {
         type: 'CLEAR_PPM_INCENTIVE',
       });
 
       expect(newState).toEqual({
         calculation: null,
       });
+    });
+  });
+});
+describe('getTabularExpenses', () => {
+  const schema = {
+    type: 'string',
+    title: 'Moving Expense Type',
+    enum: [
+      'CONTRACTED_EXPENSE',
+      'RENTAL_EQUIPMENT',
+      'PACKING_MATERIALS',
+      'WEIGHING_FEES',
+      'GAS',
+      'TOLLS',
+      'OIL',
+      'OTHER',
+    ],
+    'x-display-value': {
+      CONTRACTED_EXPENSE: 'Contracted Expense',
+      RENTAL_EQUIPMENT: 'Rental Equipment',
+      PACKING_MATERIALS: 'Packing Materials',
+      WEIGHING_FEES: 'Weighing Fees',
+      GAS: 'Gas',
+      TOLLS: 'Tolls',
+      OIL: 'Oil',
+      OTHER: 'Other',
+    },
+  };
+
+  describe('when there is no milpay', () => {
+    const expenseData = {
+      categories: [
+        {
+          category: 'CONTRACTED_EXPENSE',
+          payment_methods: {
+            GTCC: 600,
+          },
+          total: 600,
+        },
+        {
+          category: 'RENTAL_EQUIPMENT',
+          payment_methods: {
+            OTHER_DD: 500,
+          },
+          total: 500,
+        },
+        {
+          category: 'TOLLS',
+          payment_methods: {
+            OTHER_DD: 500,
+          },
+          total: 500,
+        },
+      ],
+      grand_total: {
+        payment_method_totals: {
+          GTCC: 600,
+          OTHER_DD: 1000,
+        },
+        total: 1600,
+      },
+    };
+    const result = getTabularExpenses(expenseData, schema);
+    it('should fill in all categories', () => {
+      expect(result.map(r => r.type)).toEqual([
+        'Contracted Expense',
+        'Rental Equipment',
+        'Packing Materials',
+        'Weighing Fees',
+        'Gas',
+        'Tolls',
+        'Oil',
+        'Other',
+        'Total',
+      ]);
+    });
+    it('should extract GTCC', () => {
+      expect(result[0].GTCC).toEqual(600);
+    });
+    it('should extract other', () => {
+      expect(result[1].other).toEqual(500);
+    });
+
+    it('should include total as last object in array', () => {
+      expect(result[result.length - 1]).toEqual({
+        GTCC: 600,
+        other: 1000,
+        total: 1600,
+        type: 'Total',
+      });
+    });
+
+    it('should reshape by category', () => {
+      expect(result).toEqual([
+        { GTCC: 600, other: null, total: 600, type: 'Contracted Expense' },
+        {
+          GTCC: null,
+          other: 500,
+          total: 500,
+          type: 'Rental Equipment',
+        },
+        {
+          GTCC: null,
+          other: null,
+          total: null,
+          type: 'Packing Materials',
+        },
+        {
+          GTCC: null,
+          other: null,
+          total: null,
+          type: 'Weighing Fees',
+        },
+        { GTCC: null, other: null, total: null, type: 'Gas' },
+        { GTCC: null, other: 500, total: 500, type: 'Tolls' },
+        { GTCC: null, other: null, total: null, type: 'Oil' },
+        { GTCC: null, other: null, total: null, type: 'Other' },
+        { GTCC: 600, other: 1000, total: 1600, type: 'Total' },
+      ]);
+    });
+  });
+  describe('when there are milpay values', () => {
+    const expenseData = {
+      categories: [
+        {
+          category: 'CONTRACTED_EXPENSE',
+          payment_methods: {
+            GTCC: 600,
+          },
+          total: 600,
+        },
+        {
+          category: 'RENTAL_EQUIPMENT',
+          payment_methods: {
+            OTHER_DD: 500,
+          },
+          total: 500,
+        },
+        {
+          category: 'TOLLS',
+          payment_methods: {
+            OTHER_DD: 250,
+            MIL_PAY: 250,
+          },
+          total: 500,
+        },
+      ],
+      grand_total: {
+        payment_method_totals: {
+          GTCC: 600,
+          MIL_PAY: 500,
+          OTHER_DD: 500,
+        },
+        total: 1600,
+      },
+    };
+    const result = getTabularExpenses(expenseData, schema);
+    it('should fill in all categories', () => {
+      expect(result.map(r => r.type)).toEqual([
+        'Contracted Expense',
+        'Rental Equipment',
+        'Packing Materials',
+        'Weighing Fees',
+        'Gas',
+        'Tolls',
+        'Oil',
+        'Other',
+        'Total',
+      ]);
+    });
+    it('should extract GTCC', () => {
+      expect(result[0].type).toEqual('Contracted Expense');
+      expect(result[0].GTCC).toEqual(600);
+      expect(result[0].other).toBeNull();
+    });
+    it('should extract other', () => {
+      expect(result[1].type).toEqual('Rental Equipment');
+      expect(result[1].other).toEqual(500);
+      expect(result[1].GTCC).toBeNull();
+    });
+    it('should return null for empty values', () => {
+      expect(result[2].type).toEqual('Packing Materials');
+      expect(result[2].other).toBeNull();
+      expect(result[2].GTCC).toBeNull();
+    });
+    it('should add milpay to other', () => {
+      expect(result[5].type).toEqual('Tolls');
+      expect(result[5].GTCC).toBeNull();
+      expect(result[5].other).toEqual(500);
+    });
+    describe('the total (last object in array)', () => {
+      it('it should add milpay to other', () => {
+        const grandTotal = result[result.length - 1];
+        expect(grandTotal.type).toEqual('Total');
+        expect(grandTotal.GTCC).toEqual(600);
+        expect(grandTotal.other).toEqual(1000);
+        expect(grandTotal.total).toEqual(1600);
+      });
+    });
+
+    it('should reshape by category', () => {
+      expect(result).toEqual([
+        { GTCC: 600, other: null, total: 600, type: 'Contracted Expense' },
+        {
+          GTCC: null,
+          other: 500,
+          total: 500,
+          type: 'Rental Equipment',
+        },
+        {
+          GTCC: null,
+          other: null,
+          total: null,
+          type: 'Packing Materials',
+        },
+        {
+          GTCC: null,
+          other: null,
+          total: null,
+          type: 'Weighing Fees',
+        },
+        { GTCC: null, other: null, total: null, type: 'Gas' },
+        { GTCC: null, other: 500, total: 500, type: 'Tolls' },
+        { GTCC: null, other: null, total: null, type: 'Oil' },
+        { GTCC: null, other: null, total: null, type: 'Other' },
+        { GTCC: 600, other: 1000, total: 1600, type: 'Total' },
+      ]);
     });
   });
 });

--- a/src/scenes/Office/office.css
+++ b/src/scenes/Office/office.css
@@ -390,8 +390,70 @@ head .panel-subhead {
   margin: 1em;
   display: block;
 }
-.calculator-panel .buttons {
-}
+
 .calculator-panel .calculated-result {
   margin: 1em;
+}
+
+.expense-panel {
+  border: solid #f1f1f1;
+  border-width: 3px;
+  width: 100%;
+  empty-cells: hide;
+  margin-bottom: 18px;
+}
+.expense-panel table {
+  margin: 1em;
+  width: 97%;
+  display: table;
+  border-spacing: 2px;
+}
+
+.expense-panel th,
+.expense-panel td {
+  border: none;
+}
+
+.expense-panel .expense-header {
+  font-weight: bold;
+  font-size: 0.9em;
+  border-bottom: solid 1px #a2a2a2;
+  text-align: right;
+  width: 15%;
+}
+.expense-panel .payment-method {
+  border-bottom-width: 0;
+  text-align: center;
+  text-decoration: underline;
+}
+.expense-panel th {
+  padding: 0;
+}
+
+.expense-panel table > tbody > tr > td {
+  border-bottom: 1px solid #f1f1f1;
+  font-size: 0.8em;
+  padding: 4px 0;
+}
+
+.expense-panel table > tbody > tr > td:first-child {
+  width: 1%;
+  white-space: nowrap;
+}
+.expense-panel table > tbody > tr > td:last-child {
+  padding-left: 10px;
+  font-weight: bold;
+}
+.expense-panel table > tbody > tr:first-child > td {
+  padding-top: 0;
+}
+.expense-panel table > tbody > tr:last-child > td {
+  border-bottom-width: 0;
+  font-weight: bold;
+}
+.expense-panel table > tbody tr:nth-last-child(2) > td {
+  border-bottom-color: black;
+}
+.expense-panel table > tbody > tr > td:last-child {
+  font-weight: normal;
 }


### PR DESCRIPTION
## Description

This adds an expenses panel to the ppm tab

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Setup

You will want to add moving expenses to a PPM by making a payment request in the service member app and then approving those expenses in the Office document viewer.

## Code Review Verification Steps

* [ ] There are unit tests for the transform of the summary data into tabular form
* [ ] There are no aXe warnings for UI.
* [ ] This works in IE.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/159220461) for this change

## Screenshots

![image](https://user-images.githubusercontent.com/3142631/43718525-e5c38036-9958-11e8-944c-40c5a48a2e28.png)
