### PR TITLE
els forbid non-office users from office specific endpoints [delivers #159184776]

### DIFF
--- a/pkg/handlers/move_queue_items.go
+++ b/pkg/handlers/move_queue_items.go
@@ -4,6 +4,7 @@ import (
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/go-openapi/swag"
 
+	"github.com/transcom/mymove/pkg/auth"
 	queueop "github.com/transcom/mymove/pkg/gen/internalapi/internaloperations/queues"
 	"github.com/transcom/mymove/pkg/gen/internalmessages"
 	"github.com/transcom/mymove/pkg/models"
@@ -34,7 +35,12 @@ type ShowQueueHandler HandlerContext
 
 // Handle retrieves a list of all MoveQueueItems in the system in the moves queue
 func (h ShowQueueHandler) Handle(params queueop.ShowQueueParams) middleware.Responder {
-	// TODO: Check user is authorized to see office queues
+	session := auth.SessionFromRequestContext(params.HTTPRequest)
+
+	if !session.IsOfficeUser() {
+		return queueop.NewShowQueueForbidden()
+	}
+
 	lifecycleState := params.QueueType
 
 	MoveQueueItems, err := models.GetMoveQueueItems(h.db, lifecycleState)

--- a/pkg/handlers/move_queue_items_test.go
+++ b/pkg/handlers/move_queue_items_test.go
@@ -72,3 +72,29 @@ func (suite *HandlerSuite) TestShowQueueHandler() {
 		suite.Equal(expectedCustomerName, *moveQueueItem.CustomerName)
 	}
 }
+
+func (suite *HandlerSuite) TestShowQueueHandlerForbidden() {
+	for _, queueType := range statusToQueueMap {
+
+		suite.db.TruncateAll()
+
+		// Given: An office user
+		user := testdatagen.MakeDefaultServiceMember(suite.db)
+
+		// And: the context contains the auth values
+		path := "/queues/" + queueType
+		req := httptest.NewRequest("GET", path, nil)
+		req = suite.authenticateRequest(req, user)
+
+		params := queueop.ShowQueueParams{
+			HTTPRequest: req,
+			QueueType:   queueType,
+		}
+		// And: show Queue is queried
+		showHandler := ShowQueueHandler(NewHandlerContext(suite.db, suite.logger))
+		showResponse := showHandler.Handle(params)
+
+		// Then: Expect a 200 status code
+		suite.Assertions.IsType(&queueop.ShowQueueForbidden{}, showResponse)
+	}
+}

--- a/pkg/handlers/move_queue_items_test.go
+++ b/pkg/handlers/move_queue_items_test.go
@@ -76,9 +76,7 @@ func (suite *HandlerSuite) TestShowQueueHandler() {
 func (suite *HandlerSuite) TestShowQueueHandlerForbidden() {
 	for _, queueType := range statusToQueueMap {
 
-		suite.db.TruncateAll()
-
-		// Given: An office user
+		// Given: A non-office user
 		user := testdatagen.MakeDefaultServiceMember(suite.db)
 
 		// And: the context contains the auth values
@@ -94,7 +92,7 @@ func (suite *HandlerSuite) TestShowQueueHandlerForbidden() {
 		showHandler := ShowQueueHandler(NewHandlerContext(suite.db, suite.logger))
 		showResponse := showHandler.Handle(params)
 
-		// Then: Expect a 200 status code
+		// Then: Expect a 403 status code
 		suite.Assertions.IsType(&queueop.ShowQueueForbidden{}, showResponse)
 	}
 }

--- a/pkg/handlers/office.go
+++ b/pkg/handlers/office.go
@@ -17,6 +17,11 @@ type ApproveMoveHandler HandlerContext
 // Handle ... approves a Move from a request payload
 func (h ApproveMoveHandler) Handle(params officeop.ApproveMoveParams) middleware.Responder {
 	session := auth.SessionFromRequestContext(params.HTTPRequest)
+
+	if !session.IsOfficeUser() {
+		return officeop.NewApproveMoveForbidden()
+	}
+
 	// #nosec UUID is pattern matched by swagger and will be ok
 	moveID, _ := uuid.FromString(params.MoveID.String())
 
@@ -47,6 +52,10 @@ type CancelMoveHandler HandlerContext
 // Handle ... cancels a Move from a request payload
 func (h CancelMoveHandler) Handle(params officeop.CancelMoveParams) middleware.Responder {
 	session := auth.SessionFromRequestContext(params.HTTPRequest)
+	if !session.IsOfficeUser() {
+		return officeop.NewCancelMoveForbidden()
+	}
+
 	// #nosec UUID is pattern matched by swagger and will be ok
 	moveID, _ := uuid.FromString(params.MoveID.String())
 
@@ -90,6 +99,9 @@ type ApprovePPMHandler HandlerContext
 // Handle ... approves a Personally Procured Move from a request payload
 func (h ApprovePPMHandler) Handle(params officeop.ApprovePPMParams) middleware.Responder {
 	session := auth.SessionFromRequestContext(params.HTTPRequest)
+	if !session.IsOfficeUser() {
+		return officeop.NewApprovePPMForbidden()
+	}
 
 	// #nosec UUID is pattern matched by swagger and will be ok
 	ppmID, _ := uuid.FromString(params.PersonallyProcuredMoveID.String())
@@ -130,7 +142,7 @@ func (h ApproveReimbursementHandler) Handle(params officeop.ApproveReimbursement
 	session := auth.SessionFromRequestContext(params.HTTPRequest)
 
 	if !session.IsOfficeUser() {
-		return officeop.NewApproveReimbursementUnauthorized()
+		return officeop.NewApproveReimbursementForbidden()
 	}
 
 	// #nosec UUID is pattern matched by swagger and will be ok

--- a/pkg/handlers/office_test.go
+++ b/pkg/handlers/office_test.go
@@ -43,6 +43,27 @@ func (suite *HandlerSuite) TestApproveMoveHandler() {
 	suite.Assertions.Equal(internalmessages.MoveStatusAPPROVED, okResponse.Payload.Status)
 }
 
+func (suite *HandlerSuite) TestApproveMoveHandlerForbidden() {
+	// Given: a set of orders, a move, office user and servicemember user
+	move := testdatagen.MakeDefaultMove(suite.db)
+	// Given: an non-office User
+	user := testdatagen.MakeDefaultServiceMember(suite.db)
+
+	// And: the context contains the auth values
+	req := httptest.NewRequest("POST", "/moves/some_id/approve", nil)
+	req = suite.authenticateRequest(req, user)
+
+	params := officeop.ApproveMoveParams{
+		HTTPRequest: req,
+		MoveID:      strfmt.UUID(move.ID.String()),
+	}
+	// And: a move is approved
+	handler := ApproveMoveHandler(NewHandlerContext(suite.db, suite.logger))
+	response := handler.Handle(params)
+
+	// Then: response is Forbidden
+	suite.Assertions.IsType(&officeop.ApproveMoveForbidden{}, response)
+}
 func (suite *HandlerSuite) TestCancelMoveHandler() {
 	// Given: a set of orders, a move, and office user
 	// Orders has service member with transportation office and phone nums
@@ -96,7 +117,35 @@ func (suite *HandlerSuite) TestCancelMoveHandler() {
 	// And: Returned query to have an canceled status
 	suite.Equal(internalmessages.MoveStatusCANCELED, okResponse.Payload.Status)
 }
+func (suite *HandlerSuite) TestCancelMoveHandlerForbidden() {
+	// Given: a set of orders, a move, office user and servicemember user
+	move := testdatagen.MakeDefaultMove(suite.db)
+	// Given: an non-office User
+	user := testdatagen.MakeDefaultServiceMember(suite.db)
 
+	// And: the context contains the auth values
+	req := httptest.NewRequest("POST", "/moves/some_id/cancel", nil)
+	req = suite.authenticateRequest(req, user)
+
+	// And params include the cancel reason
+	reason := "Orders revoked."
+	reasonPayload := &internalmessages.CancelMove{
+		CancelReason: &reason,
+	}
+	params := officeop.CancelMoveParams{
+		HTTPRequest: req,
+		MoveID:      strfmt.UUID(move.ID.String()),
+		CancelMove:  reasonPayload,
+	}
+	// And: a move is canceled
+	context := NewHandlerContext(suite.db, suite.logger)
+	context.SetNotificationSender(suite.notificationSender)
+	handler := CancelMoveHandler(context)
+	response := handler.Handle(params)
+
+	// Then: response is Forbidden
+	suite.Assertions.IsType(&officeop.CancelMoveForbidden{}, response)
+}
 func (suite *HandlerSuite) TestApprovePPMHandler() {
 	// Given: a set of orders, a move, user and servicemember
 	ppm := testdatagen.MakeDefaultPPM(suite.db)
@@ -125,6 +174,30 @@ func (suite *HandlerSuite) TestApprovePPMHandler() {
 	suite.Equal(internalmessages.PPMStatusAPPROVED, okResponse.Payload.Status)
 }
 
+func (suite *HandlerSuite) TestApprovePPMHandlerForbidden() {
+	// Given: a set of orders, a move, user and servicemember
+	ppm := testdatagen.MakeDefaultPPM(suite.db)
+	user := testdatagen.MakeDefaultServiceMember(suite.db)
+
+	// And: the context contains the auth values
+	req := httptest.NewRequest("POST", "/personally_procured_moves/some_id/approve", nil)
+	req = suite.authenticateRequest(req, user)
+
+	params := officeop.ApprovePPMParams{
+		HTTPRequest:              req,
+		PersonallyProcuredMoveID: strfmt.UUID(ppm.ID.String()),
+	}
+
+	// And: a ppm is approved
+	context := NewHandlerContext(suite.db, suite.logger)
+	context.SetNotificationSender(suite.notificationSender)
+	handler := ApprovePPMHandler(context)
+	response := handler.Handle(params)
+
+	// Then: expect a Forbidden status code
+	suite.Assertions.IsType(&officeop.ApprovePPMForbidden{}, response)
+}
+
 func (suite *HandlerSuite) TestApproveReimbursementHandler() {
 	// Given: a set of orders, a move, user and servicemember
 	reimbursement, _ := testdatagen.MakeRequestedReimbursement(suite.db)
@@ -148,4 +221,25 @@ func (suite *HandlerSuite) TestApproveReimbursementHandler() {
 
 	// And: Returned query to have an approved status
 	suite.Equal(internalmessages.ReimbursementStatusAPPROVED, *okResponse.Payload.Status)
+}
+
+func (suite *HandlerSuite) TestApproveReimbursementHandlerForbidden() {
+	// Given: a set of orders, a move, user and servicemember
+	reimbursement, _ := testdatagen.MakeRequestedReimbursement(suite.db)
+	user := testdatagen.MakeDefaultServiceMember(suite.db)
+
+	// And: the context contains the auth values
+	req := httptest.NewRequest("POST", "/reimbursement/some_id/approve", nil)
+	req = suite.authenticateRequest(req, user)
+	params := officeop.ApproveReimbursementParams{
+		HTTPRequest:     req,
+		ReimbursementID: strfmt.UUID(reimbursement.ID.String()),
+	}
+
+	// And: a reimbursement is approved
+	handler := ApproveReimbursementHandler(NewHandlerContext(suite.db, suite.logger))
+	response := handler.Handle(params)
+
+	// Then: expect Forbidden response
+	suite.Assertions.IsType(&officeop.ApproveReimbursementForbidden{}, response)
 }

--- a/pkg/handlers/personally_procured_move_incentive.go
+++ b/pkg/handlers/personally_procured_move_incentive.go
@@ -21,7 +21,7 @@ func (h ShowPPMIncentiveHandler) Handle(params ppmop.ShowPPMIncentiveParams) mid
 	session := auth.SessionFromRequestContext(params.HTTPRequest)
 
 	if !session.IsOfficeUser() {
-		return ppmop.NewShowPPMIncentiveUnauthorized()
+		return ppmop.NewShowPPMIncentiveForbidden()
 	}
 	engine := rateengine.NewRateEngine(h.db, h.logger, h.planner)
 

--- a/pkg/handlers/personally_procured_move_incentive_test.go
+++ b/pkg/handlers/personally_procured_move_incentive_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/transcom/mymove/pkg/testdatagen/scenario"
 )
 
-func (suite *HandlerSuite) TestShowPPMIncentiveHandlerUnauthorised() {
+func (suite *HandlerSuite) TestShowPPMIncentiveHandlerForbidden() {
 	if err := scenario.RunRateEngineScenario2(suite.db); err != nil {
 		suite.FailNow("failed to run scenario 2: %+v", err)
 	}
@@ -31,10 +31,7 @@ func (suite *HandlerSuite) TestShowPPMIncentiveHandlerUnauthorised() {
 	context.SetPlanner(route.NewTestingPlanner(1693))
 	showHandler := ShowPPMIncentiveHandler(context)
 	showResponse := showHandler.Handle(params)
-
-	_, succeeded := showResponse.(*ppmop.ShowPPMIncentiveUnauthorized)
-	suite.True(succeeded, "ShowPpmIncentive allowed non-office user to call")
-
+	suite.Assertions.IsType(&ppmop.ShowPPMIncentiveForbidden{}, showResponse)
 }
 
 func (suite *HandlerSuite) TestShowPPMIncentiveHandler() {


### PR DESCRIPTION
## Description

non office users are forbidden from hitting office-only endpoints (queues, approve, cancel)

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?


## Code Review Verification Steps

* [ ] try to access api calls when logged in as service member.

## References

* [Pivotal story]([#159184776]) for this change

