### PR TITLE
Allows loggedInUser return with no transportation office [delivers #159288926]

### DIFF
--- a/pkg/handlers/users.go
+++ b/pkg/handlers/users.go
@@ -46,10 +46,9 @@ func (h ShowLoggedInUserHandler) Handle(params userop.ShowLoggedInUserParams) mi
 			if errors.Cause(err) != models.ErrFetchNotFound {
 				return responseForError(h.logger, err)
 			}
-		} else {
-			dutyStation.TransportationOffice = transportationOffice
 		}
 		serviceMember.DutyStation = dutyStation
+		serviceMember.DutyStation.TransportationOffice = transportationOffice
 	}
 
 	// Load the latest orders associations and new duty station transport office

--- a/pkg/handlers/users_test.go
+++ b/pkg/handlers/users_test.go
@@ -3,90 +3,80 @@ package handlers
 import (
 	"net/http/httptest"
 
-	"github.com/transcom/mymove/pkg/auth"
 	userop "github.com/transcom/mymove/pkg/gen/internalapi/internaloperations/users"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"
 )
 
 func (suite *HandlerSuite) TestUnknownLoggedInUserHandler() {
-	t := suite.T()
-
 	unknownUser := testdatagen.MakeDefaultUser(suite.db)
 
-	params := userop.NewShowLoggedInUserParams()
 	req := httptest.NewRequest("GET", "/users/logged_in", nil)
+	req = suite.authenticateUserRequest(req, unknownUser)
 
-	session := &auth.Session{
-		ApplicationName: auth.MyApp,
-		UserID:          unknownUser.ID,
-		IDToken:         "fake token",
+	params := userop.ShowLoggedInUserParams{
+		HTTPRequest: req,
 	}
-	ctx := auth.SetSessionInRequestContext(req, session)
-
-	params.HTTPRequest = req.WithContext(ctx)
 
 	handler := ShowLoggedInUserHandler(NewHandlerContext(suite.db, suite.logger))
 
 	response := handler.Handle(params)
 
 	okResponse, ok := response.(*userop.ShowLoggedInUserOK)
-	if !ok {
-		t.Fatalf("Request failed: %#v", response)
-	}
-
-	if *okResponse.Payload.ID != *fmtUUID(unknownUser.ID) {
-		t.Fatalf("Didn't get back what we wanted. %#v", okResponse)
-	}
-
+	suite.True(ok)
+	suite.Equal(okResponse.Payload.ID.String(), unknownUser.ID.String())
 }
 
 func (suite *HandlerSuite) TestServiceMemberLoggedInUserHandler() {
-	t := suite.T()
-
-	smUser := testdatagen.MakeDefaultUser(suite.db)
-
 	firstName := "Joseph"
-	serviceMember := models.ServiceMember{
-		UserID:    smUser.ID,
-		User:      smUser,
-		FirstName: &firstName,
-	}
+	sm := testdatagen.MakeExtendedServiceMember(suite.db, testdatagen.Assertions{
+		ServiceMember: models.ServiceMember{
+			FirstName: &firstName,
+		},
+	})
 
-	verrs, err := models.SaveServiceMember(suite.db, &serviceMember)
-	if verrs.HasAny() || err != nil {
-		t.Error(verrs, err)
-		t.Fatal("Couldnt create theSM")
-	}
-
-	params := userop.NewShowLoggedInUserParams()
 	req := httptest.NewRequest("GET", "/users/logged_in", nil)
+	req = suite.authenticateRequest(req, sm)
 
-	session := &auth.Session{
-		ApplicationName: auth.MyApp,
-		UserID:          smUser.ID,
-		ServiceMemberID: serviceMember.ID,
-		IDToken:         "fake token",
+	params := userop.ShowLoggedInUserParams{
+		HTTPRequest: req,
 	}
-	ctx := auth.SetSessionInRequestContext(req, session)
-
-	params.HTTPRequest = req.WithContext(ctx)
 
 	handler := ShowLoggedInUserHandler(NewHandlerContext(suite.db, suite.logger))
 
 	response := handler.Handle(params)
 
 	okResponse, ok := response.(*userop.ShowLoggedInUserOK)
-	if !ok {
-		t.Fatalf("Request failed: %#v", response)
+	suite.True(ok)
+	suite.Equal(okResponse.Payload.ID.String(), sm.UserID.String())
+	suite.Equal("Joseph", *okResponse.Payload.ServiceMember.FirstName)
+}
+
+func (suite *HandlerSuite) TestServiceMemberNoTransportationOfficeLoggedInUserHandler() {
+	firstName := "Joseph"
+	sm := testdatagen.MakeExtendedServiceMember(suite.db, testdatagen.Assertions{
+		ServiceMember: models.ServiceMember{
+			FirstName: &firstName,
+		},
+	})
+
+	// Remove transportation office info from current station
+	station := sm.DutyStation
+	station.TransportationOfficeID = nil
+	suite.mustSave(&station)
+
+	req := httptest.NewRequest("GET", "/users/logged_in", nil)
+	req = suite.authenticateRequest(req, sm)
+
+	params := userop.ShowLoggedInUserParams{
+		HTTPRequest: req,
 	}
 
-	if *okResponse.Payload.ID != *fmtUUID(smUser.ID) {
-		t.Fatalf("Didn't get back what we wanted. %#v", okResponse.Payload)
-	}
+	handler := ShowLoggedInUserHandler(NewHandlerContext(suite.db, suite.logger))
 
-	if *okResponse.Payload.ServiceMember.FirstName != "Joseph" {
-		t.Fatalf("Didn't get the SM right. %#v", okResponse.Payload.ServiceMember)
-	}
+	response := handler.Handle(params)
 
+	okResponse, ok := response.(*userop.ShowLoggedInUserOK)
+	suite.True(ok)
+	suite.Equal(okResponse.Payload.ID.String(), sm.UserID.String())
 }


### PR DESCRIPTION
## Description

Prevents loggedInUser route from returning 404 if no transportation office info is found for a SM's current duty station

## Code Review Verification Steps

* [ ] End to end tests pass (`make e2e_test`).
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/blob/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* [ ] Any migrations/schema changes also update the diagram in docs/schema/dp3.sqs
* [ ] There are no aXe warnings for UI.
* [ ] This works in IE.
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @willowbl00
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/159288926) for this change

## Screenshots

<img width="242" alt="screenshot 2018-08-07 13 53 42" src="https://user-images.githubusercontent.com/5151804/43802066-a14e590c-9a49-11e8-9b77-4db058f9211e.png">
