### PR TITLE
Add weight and inventory panel for HHG office

### DIFF
--- a/src/scenes/Office/Hhg/WeightAndInventoryPanel.jsx
+++ b/src/scenes/Office/Hhg/WeightAndInventoryPanel.jsx
@@ -1,0 +1,93 @@
+import { get } from 'lodash';
+import React from 'react';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import { reduxForm, getFormValues, isValid } from 'redux-form';
+
+import editablePanel from '../editablePanel';
+import { no_op } from 'shared/utils';
+import { SwaggerField } from 'shared/JsonSchemaForm/JsonSchemaField';
+import { PanelField } from 'shared/EditablePanel';
+
+const WeightAndInventoryDisplay = props => {
+  const fieldProps = {
+    schema: props.shipmentSchema,
+    values: props.shipment,
+  };
+  return (
+    <React.Fragment>
+      <div className="editable-panel-column">
+        <span className="column-subhead">Weights</span>
+        <PanelField title="Customer Estimate">
+          {get(fieldProps, 'values.weight_estimate', '').toLocaleString()} lbs
+        </PanelField>
+      </div>
+      <div className="editable-panel-column">
+        <span className="column-subhead">Special Items</span>
+        <PanelField title="Customer Entered" className="Todo-phase2">
+          None
+        </PanelField>
+      </div>
+    </React.Fragment>
+  );
+};
+
+const WeightAndInventoryEdit = props => {
+  const { shipmentSchema } = props;
+  return (
+    <div className="editable-panel-column">
+      <SwaggerField
+        title="Customer Estimate"
+        fieldName="weight_estimate"
+        swagger={shipmentSchema}
+        required
+      />
+    </div>
+  );
+};
+
+const formName = 'office_shipment_info_weight_and_inventory';
+const editEnabled = false; // to remove the "Edit" button on panel header and disable editing
+
+let WeightAndInventoryPanel = editablePanel(
+  WeightAndInventoryDisplay,
+  WeightAndInventoryEdit,
+  editEnabled,
+);
+WeightAndInventoryPanel = reduxForm({ form: formName })(
+  WeightAndInventoryPanel,
+);
+
+function mapStateToProps(state) {
+  let shipment = get(state, 'office.officeMove.shipments.0', {});
+  return {
+    // Wrapper
+    shipmentSchema: get(state, 'swagger.spec.definitions.Shipment', {}),
+    hasError:
+      state.office.shipmentHasLoadError || state.office.shipmentHasUpdateError,
+    errorMessage: state.office.error,
+
+    shipment: shipment,
+    isUpdating: state.office.shipmentIsUpdating,
+
+    // editablePanel
+    formIsValid: isValid(formName)(state),
+    getUpdateArgs: function() {
+      let values = getFormValues(formName)(state);
+      return [shipment.id, values];
+    },
+  };
+}
+
+function mapDispatchToProps(dispatch) {
+  return bindActionCreators(
+    {
+      update: no_op,
+    },
+    dispatch,
+  );
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(
+  WeightAndInventoryPanel,
+);

--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -21,6 +21,7 @@ import IncentiveCalculator from './Ppm/IncentiveCalculator';
 import ExpensesPanel from './Ppm/ExpensesPanel';
 import DocumentList from 'scenes/Office/DocumentViewer/DocumentList';
 import DatesAndTrackingPanel from './Hhg/DatesAndTrackingPanel';
+import WeightAndInventoryPanel from './Hhg/WeightAndInventoryPanel';
 import { withContext } from 'shared/AppContext';
 
 import {
@@ -74,7 +75,11 @@ const PPMTabContent = props => {
 const HHGTabContent = props => {
   return (
     <div className="office-tab">
-      <DatesAndTrackingPanel title="Dates and Tracking" moveId={props.moveId} />
+      <DatesAndTrackingPanel title="Dates & Tracking" moveId={props.moveId} />
+      <WeightAndInventoryPanel
+        title="Weight & Inventory"
+        moveId={props.moveId}
+      />
     </div>
   );
 };

--- a/src/shared/EditablePanel/index.css
+++ b/src/shared/EditablePanel/index.css
@@ -13,9 +13,12 @@
   vertical-align: top;
 }
 
-.editable-panel-column.subheader {
+.column-subhead{
+  display: block;
+  margin: 0.8em;
+  margin-left: 0;
+  font-size: 0.8em;
   font-weight: bold;
-  font-size: .9em;
 }
 
 .office-tab .editable-panel-header {


### PR DESCRIPTION
## Description

This adds a Weight & Inventory panel to the HHG office tab. Special Items not to be implemented yet.

## Setup

Create and HHG move with a Weight Estimate. View on office side under "HHG tab"

## Code Review Verification Steps

* [ ] End to end tests pass (`make e2e_test`).
* [x] There are no aXe warnings for UI.
* [x] This works in IE.
* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/159308691) for this change

## Screenshots

<img width="972" alt="screen shot 2018-08-07 at 5 36 35 pm" src="https://user-images.githubusercontent.com/7401870/43809672-75c422a2-9a68-11e8-9ac1-133fe1cc2e03.png">
