### PR TITLE
Eager load the service member on shipments api calls for displaying in UI

### DIFF
--- a/pkg/handlers/service_members.go
+++ b/pkg/handlers/service_members.go
@@ -6,12 +6,18 @@ import (
 	"github.com/gobuffalo/validate"
 
 	"github.com/transcom/mymove/pkg/auth"
+	"github.com/transcom/mymove/pkg/gen/apimessages"
 	servicememberop "github.com/transcom/mymove/pkg/gen/internalapi/internaloperations/service_members"
 	"github.com/transcom/mymove/pkg/gen/internalmessages"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/storage"
 )
 
+/*
+ * ------------------------------------------
+ * The code below is for the INTERNAL REST API.
+ * ------------------------------------------
+ */
 func payloadForServiceMemberModel(storer storage.FileStorer, serviceMember models.ServiceMember) *internalmessages.ServiceMemberPayload {
 
 	var dutyStationPayload *internalmessages.DutyStationPayload
@@ -285,4 +291,27 @@ func (h ShowServiceMemberOrdersHandler) Handle(params servicememberop.ShowServic
 		return responseForError(h.logger, err)
 	}
 	return servicememberop.NewShowServiceMemberOrdersOK().WithPayload(orderPayload)
+}
+
+/*
+ * ------------------------------------------
+ * The code below is for the PUBLIC REST API.
+ * ------------------------------------------
+ */
+
+func publicPayloadForServiceMemberModel(serviceMember *models.ServiceMember) *apimessages.ServiceMember {
+
+	serviceMemberPayload := apimessages.ServiceMember{
+		FirstName:              serviceMember.FirstName,
+		MiddleName:             serviceMember.MiddleName,
+		LastName:               serviceMember.LastName,
+		Suffix:                 serviceMember.Suffix,
+		Telephone:              serviceMember.Telephone,
+		SecondaryTelephone:     serviceMember.SecondaryTelephone,
+		PersonalEmail:          serviceMember.PersonalEmail,
+		PhoneIsPreferred:       serviceMember.PhoneIsPreferred,
+		TextMessageIsPreferred: serviceMember.TextMessageIsPreferred,
+		EmailIsPreferred:       serviceMember.EmailIsPreferred,
+	}
+	return &serviceMemberPayload
 }

--- a/pkg/handlers/shipments.go
+++ b/pkg/handlers/shipments.go
@@ -254,6 +254,7 @@ func publicPayloadForShipmentModel(s models.Shipment) *apimessages.Shipment {
 	shipmentPayload := &apimessages.Shipment{
 		ID: *fmtUUID(s.ID),
 		TrafficDistributionList:      publicPayloadForTrafficDistributionListModel(s.TrafficDistributionList),
+		ServiceMember:                publicPayloadForServiceMemberModel(s.ServiceMember),
 		PickupDate:                   *fmtDateTimePtr(s.PickupDate),
 		DeliveryDate:                 *fmtDateTimePtr(s.DeliveryDate),
 		CreatedAt:                    strfmt.DateTime(s.CreatedAt),

--- a/pkg/models/shipment.go
+++ b/pkg/models/shipment.go
@@ -132,6 +132,7 @@ func FetchShipmentsByTSP(tx *pop.Connection, tspID uuid.UUID, status []string, o
 
 	query := tx.Eager(
 		"TrafficDistributionList",
+		"ServiceMember",
 		"Move",
 		"PickupAddress",
 		"SecondaryPickupAddress",
@@ -238,6 +239,7 @@ func FetchShipmentByTSP(tx *pop.Connection, tspID uuid.UUID, shipmentID uuid.UUI
 
 	err := tx.Eager(
 		"TrafficDistributionList",
+		"ServiceMember",
 		"Move",
 		"PickupAddress",
 		"SecondaryPickupAddress",

--- a/src/scenes/TransportationServiceProvider/QueueTable.jsx
+++ b/src/scenes/TransportationServiceProvider/QueueTable.jsx
@@ -73,6 +73,15 @@ class QueueTable extends Component {
                 accessor: 'source_gbloc',
               },
               {
+                Header: 'Customer name',
+                accessor: 'service_member',
+                Cell: row => (
+                  <span className="customer_name">
+                    {row.value.last_name}, {row.value.first_name}
+                  </span>
+                ),
+              },
+              {
                 Header: 'Locator #',
                 accessor: 'move.locator',
               },

--- a/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
+++ b/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
@@ -17,12 +17,14 @@ class ShipmentInfo extends Component {
 
   render() {
     var move = this.props.shipment.move;
+    var sm = this.props.shipment && this.props.shipment.service_member;
     return (
       <div>
         <div className="usa-grid grid-wide">
-          <div className="usa-width-two-thirds Todo-phase2">
-            {/* This comes from the Server Member model which is not yet on Shipments */}
-            <h1>Shipment Info: LastName, FirstName</h1>
+          <div className="usa-width-two-thirds">
+            <h1>
+              Shipment Info: {sm && sm.last_name}, {sm && sm.first_name}
+            </h1>
           </div>
           <div className="usa-width-one-third nav-controls">
             <NavLink to="/queues/new" activeClassName="usa-current">
@@ -33,10 +35,12 @@ class ShipmentInfo extends Component {
         <div className="usa-grid grid-wide">
           <div className="usa-width-one-whole">
             <ul className="move-info-header-meta">
-              <li>GBL# {this.props.shipment.source_gbloc}</li>
+              <li className="Todo-phase2">GBL# OHAI9999999</li>
               <li>Locator# {move && move.locator}</li>
-              {/* This comes from Service Member and Order models which are currently not connected to Shipments */}
-              <li className="Todo-phase2">KKFA to HAFC</li>
+              <li>
+                {this.props.shipment.source_gbloc} to{' '}
+                {this.props.shipment.destination_gbloc}
+              </li>
               <li>
                 Requested Move date{' '}
                 {formatDate(this.props.shipment.requested_pickup_date)}

--- a/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
+++ b/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
@@ -16,14 +16,15 @@ class ShipmentInfo extends Component {
   }
 
   render() {
-    var move = this.props.shipment.move;
-    var sm = this.props.shipment && this.props.shipment.service_member;
+    var last_name = get(this.props.shipment, 'service_member.last_name');
+    var first_name = get(this.props.shipment, 'service_member.first_name');
+    var locator = get(this.props.shipment, 'move.locator');
     return (
       <div>
         <div className="usa-grid grid-wide">
           <div className="usa-width-two-thirds">
             <h1>
-              Shipment Info: {sm && sm.last_name}, {sm && sm.first_name}
+              Shipment Info: {last_name}, {first_name}
             </h1>
           </div>
           <div className="usa-width-one-third nav-controls">
@@ -36,7 +37,7 @@ class ShipmentInfo extends Component {
           <div className="usa-width-one-whole">
             <ul className="move-info-header-meta">
               <li className="Todo-phase2">GBL# OHAI9999999</li>
-              <li>Locator# {move && move.locator}</li>
+              <li>Locator# {locator}</li>
               <li>
                 {this.props.shipment.source_gbloc} to{' '}
                 {this.props.shipment.destination_gbloc}

--- a/swagger/api.yaml
+++ b/swagger/api.yaml
@@ -317,6 +317,62 @@ definitions:
       HHG: Household Goods Move
       PPM: Personal Procured Move
       COMBO: Both HHG and PPM
+  ServiceMember:
+    type: object
+    properties:
+      first_name:
+        type: string
+        example: John
+        x-nullable: true
+        title: First Name
+      middle_name:
+        type: string
+        example: L.
+        x-nullable: true
+        title: Middle Name
+      last_name:
+        type: string
+        example: Donut
+        x-nullable: true
+        title: Last Name
+      suffix:
+        type: string
+        example: Jr.
+        x-nullable: true
+        title: Suffix
+      telephone:
+        type: string
+        format: telephone
+        pattern: '^[2-9]\d{2}-\d{3}-\d{4}$'
+        example: 212-555-5555
+        x-nullable: true
+        title: Best Contact Phone
+      secondary_telephone:
+        type: string
+        format: telephone
+        pattern: '^[2-9]\d{2}-\d{3}-\d{4}$'
+        example: 212-555-5555
+        x-nullable: true
+        title: Secondary Phone
+      personal_email:
+        type: string
+        format: x-email
+        pattern: '^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$'
+        example: john_bob@example.com
+        x-nullable: true
+        title: Personal Email Address
+      phone_is_preferred:
+        type: boolean
+        x-nullable: true
+        title: Telephone
+      text_message_is_preferred:
+        type: boolean
+        x-nullable: true
+        title: Text Message - Coming Soon!
+      email_is_preferred:
+        type: boolean
+        x-nullable: true
+        title: Email
   TrafficDistributionList:
     type: object
     properties:
@@ -346,6 +402,9 @@ definitions:
         readOnly: true
       traffic_distribution_list:
         $ref: '#/definitions/TrafficDistributionList'
+        readOnly: true
+      service_member:
+        $ref: '#/definitions/ServiceMember'
         readOnly: true
       pickup_date:
         type: string


### PR DESCRIPTION
## Description

A previous PR (https://github.com/transcom/mymove/pull/854) had added the ShipmentID to the Shipment model.  This makes it easy for me to add the Service Member (with fewer details) onto the Shipment API calls and include that info in the UI.

## Reviewer Notes

For now I've left out a lot of Service Member details in the API return because this would be public and I want to avoid PII leaks.

Double check that I'm not accessing the api data in a way that doesn't match our other UI style.

## Setup

You may want to checkout https://github.com/transcom/mymove/pull/868 and run:

```
./bin/generate-test-data -scenario 7
```

Then log in as any TSP user and you should see the user name show up both in the queue and in the info pages.

You can also check out the swagger calls:
- http://tsplocal:3000/api/v1/docs#/shipments/indexShipments
- http://tsplocal:3000/api/v1/docs#/shipments/getShipment (pick a UUID from the info page URL)

## Code Review Verification Steps

* [x] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* [x] There are no aXe warnings for UI.
* [x] This works in IE.
* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/n/projects/2181745/stories/159480613) for this change

## Screenshots

<img width="1092" alt="screen shot 2018-08-10 at 5 44 12 am" src="https://user-images.githubusercontent.com/219296/43958832-a0614350-9c61-11e8-92e7-5b84404bc71b.png">

<img width="1091" alt="screen shot 2018-08-10 at 5 44 00 am" src="https://user-images.githubusercontent.com/219296/43958834-a2a443ce-9c61-11e8-84fa-3b8382fb5623.png">
