### PR TITLE
UI fixes

### DIFF
--- a/src/App/index.css
+++ b/src/App/index.css
@@ -43,3 +43,27 @@ img._fix-ie-11-height {
 .usa-input-label {
   margin-bottom: 1rem;
 }
+
+.usa-input {
+  margin: 0rem 1.5rem 0rem 0rem;
+}
+
+.rounded select {
+  background-color: rgb(248, 248, 248);
+  border-radius: 7px;
+}
+
+.city_state_zip {
+  display: inline-block;
+}
+.city_state_zip input {
+  display: inline-block;
+  width: 18rem;
+}
+.city_state_zip select {
+  display: inline-block;
+}
+
+.address_inline {
+  display: inline-block;
+}

--- a/src/scenes/Moves/Ppm/Weight.jsx
+++ b/src/scenes/Moves/Ppm/Weight.jsx
@@ -251,7 +251,7 @@ export class PpmWeight extends Component {
     if (currentPpm) {
       let requestedAmount = get(currentPpm, 'advance.requested_amount');
       if (requestedAmount) {
-        requestedAmount = parseFloat(requestedAmount) / 100;
+        requestedAmount = formatCents(requestedAmount);
       }
       let methodOfReceipt = get(currentPpm, 'advance.method_of_receipt');
       // GTCC is an invalid method of receipt in PPM advances, so default to direct deposit

--- a/src/scenes/Review/EditContactInfo.jsx
+++ b/src/scenes/Review/EditContactInfo.jsx
@@ -72,13 +72,26 @@ let EditContactForm = props => {
           required
         />
         <SwaggerField fieldName="street_address_2" swagger={addressSchema} />
-        <SwaggerField fieldName="city" swagger={addressSchema} required />
-        <SwaggerField fieldName="state" swagger={addressSchema} required />
-        <SwaggerField
-          fieldName="postal_code"
-          swagger={addressSchema}
-          required
-        />
+        <div className="address_inline">
+          <SwaggerField
+            fieldName="city"
+            swagger={addressSchema}
+            className="city_state_zip"
+            required
+          />
+          <SwaggerField
+            fieldName="state"
+            swagger={addressSchema}
+            className="city_state_zip"
+            required
+          />
+          <SwaggerField
+            fieldName="postal_code"
+            swagger={addressSchema}
+            className="city_state_zip"
+            required
+          />
+        </div>
       </FormSection>
       <hr className="spacer" />
       <FormSection name="backupAddress">
@@ -89,13 +102,26 @@ let EditContactForm = props => {
           required
         />
         <SwaggerField fieldName="street_address_2" swagger={addressSchema} />
-        <SwaggerField fieldName="city" swagger={addressSchema} required />
-        <SwaggerField fieldName="state" swagger={addressSchema} required />
-        <SwaggerField
-          fieldName="postal_code"
-          swagger={addressSchema}
-          required
-        />
+        <div className="address_inline">
+          <SwaggerField
+            fieldName="city"
+            swagger={addressSchema}
+            className="city_state_zip"
+            required
+          />
+          <SwaggerField
+            fieldName="state"
+            swagger={addressSchema}
+            className="city_state_zip"
+            required
+          />
+          <SwaggerField
+            fieldName="postal_code"
+            swagger={addressSchema}
+            className="city_state_zip"
+            required
+          />
+        </div>
       </FormSection>
       <SaveCancelButtons valid={valid} submitting={submitting} />
     </form>

--- a/src/scenes/Review/EditWeight.jsx
+++ b/src/scenes/Review/EditWeight.jsx
@@ -7,6 +7,7 @@ import { push } from 'react-router-redux';
 import { reduxForm } from 'redux-form';
 
 import Alert from 'shared/Alert'; // eslint-disable-line
+import { formatCents } from 'shared/formatters';
 import { SwaggerField } from 'shared/JsonSchemaForm/JsonSchemaField';
 
 import {
@@ -73,7 +74,7 @@ let EditWeightForm = props => {
   if (
     incentive_estimate_max &&
     advanceAmt &&
-    incentive_estimate_max < advanceAmt / 100
+    incentive_estimate_max < formatCents(advanceAmt)
   ) {
     advanceError = true;
     incentiveClass = 'error';
@@ -157,7 +158,9 @@ let EditWeightForm = props => {
             <div className="display-value">
               <p>Advance</p>
               <p>
-                <strong>${initialValues.advance.requested_amount / 100}</strong>
+                <strong>
+                  ${formatCents(initialValues.advance.requested_amount)}
+                </strong>
               </p>
             </div>
           )}

--- a/src/scenes/Review/Review.css
+++ b/src/scenes/Review/Review.css
@@ -53,6 +53,7 @@
 .ppm-container h3 {
   background-color: rgb(209, 219, 233);
   padding: 1.5rem 1rem 1.5rem 1rem;
+  margin-left: 1px;
 }
 
 .ppm-container img {

--- a/src/scenes/Review/Summary.jsx
+++ b/src/scenes/Review/Summary.jsx
@@ -8,7 +8,7 @@ import { withRouter } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import ppmBlack from 'shared/icon/ppm-black.svg';
 import { moveIsApproved, lastMoveIsCanceled } from 'scenes/Moves/ducks';
-import { formatCentsRange } from 'shared/formatters';
+import { formatCentsRange, formatCents } from 'shared/formatters';
 import { loadEntitlementsFromState } from 'shared/entitlements';
 import { checkEntitlement } from './ducks';
 import Alert from 'shared/Alert';
@@ -421,9 +421,7 @@ export class Summary extends Component {
                         <td> Advance: </td>
                         <td>
                           {' '}
-                          ${(
-                            currentPpm.advance.requested_amount / 100
-                          ).toLocaleString()}
+                          ${formatCents(currentPpm.advance.requested_amount)}
                         </td>
                       </tr>
                     )}

--- a/src/scenes/ServiceMembers/BackupMailingAddress.jsx
+++ b/src/scenes/ServiceMembers/BackupMailingAddress.jsx
@@ -35,8 +35,8 @@ export class BackupMailingAddress extends Component {
       >
         <h1 className="sm-heading">Backup mailing address</h1>
         <p>
-          Enter a backup mailing address, such as your permanent residence or a
-          parent’s address.
+          Enter the address where mail will reach you if we can’t reach you at
+          your primary address, such as your parents’ address.
         </p>
 
         <SwaggerField
@@ -48,13 +48,27 @@ export class BackupMailingAddress extends Component {
           fieldName="street_address_2"
           swagger={this.props.schema}
         />
-        <SwaggerField fieldName="city" swagger={this.props.schema} required />
-        <SwaggerField fieldName="state" swagger={this.props.schema} required />
-        <SwaggerField
-          fieldName="postal_code"
-          swagger={this.props.schema}
-          required
-        />
+
+        <div className="address_inline">
+          <SwaggerField
+            fieldName="city"
+            swagger={this.props.schema}
+            className="city_state_zip"
+            required
+          />
+          <SwaggerField
+            fieldName="state"
+            swagger={this.props.schema}
+            className="city_state_zip"
+            required
+          />
+          <SwaggerField
+            fieldName="postal_code"
+            swagger={this.props.schema}
+            className="city_state_zip"
+            required
+          />
+        </div>
       </BackupMailingWizardForm>
     );
   }

--- a/src/scenes/ServiceMembers/DodInfo.jsx
+++ b/src/scenes/ServiceMembers/DodInfo.jsx
@@ -60,7 +60,7 @@ class SSNField extends Component {
           className={displayError ? 'usa-input-error-label' : 'usa-input-label'}
           htmlFor={name}
         >
-          Social Security Number
+          Social security number
         </label>
         {touched &&
           error && (
@@ -141,6 +141,10 @@ export class DodInfo extends Component {
         ssnOnServer={ssnOnServer}
       >
         <h1 className="sm-heading">Create your profile</h1>
+        <p>
+          Before we can schedule your move, we need to know a little more about
+          you.
+        </p>
         <SwaggerField fieldName="affiliation" swagger={schema} required />
         <SwaggerField fieldName="edipi" swagger={schema} required />
         <Field

--- a/src/scenes/ServiceMembers/ResidentialAddress.jsx
+++ b/src/scenes/ServiceMembers/ResidentialAddress.jsx
@@ -42,13 +42,26 @@ export class ResidentialAddress extends Component {
           fieldName="street_address_2"
           swagger={this.props.schema}
         />
-        <SwaggerField fieldName="city" swagger={this.props.schema} required />
-        <SwaggerField fieldName="state" swagger={this.props.schema} required />
-        <SwaggerField
-          fieldName="postal_code"
-          swagger={this.props.schema}
-          required
-        />
+        <div className="address_inline">
+          <SwaggerField
+            fieldName="city"
+            swagger={this.props.schema}
+            className="city_state_zip"
+            required
+          />
+          <SwaggerField
+            fieldName="state"
+            swagger={this.props.schema}
+            className="city_state_zip"
+            required
+          />
+          <SwaggerField
+            fieldName="postal_code"
+            swagger={this.props.schema}
+            className="city_state_zip"
+            required
+          />
+        </div>
       </ResidentalWizardForm>
     );
   }

--- a/src/shared/EditablePanel/index.jsx
+++ b/src/shared/EditablePanel/index.jsx
@@ -36,6 +36,11 @@ export const SwaggerValue = props => {
   if (swaggerProps.format === 'cents') {
     value = formatCents(value);
   }
+  if (swaggerProps.type === 'integer') {
+    if (fieldName === 'weight_estimate') {
+      value = value.toLocaleString() + ' lbs';
+    }
+  }
   /* eslint-enable security/detect-object-injection */
   return <React.Fragment>{value || null}</React.Fragment>;
 };

--- a/src/shared/JsonSchemaForm/JsonSchemaField.js
+++ b/src/shared/JsonSchemaForm/JsonSchemaField.js
@@ -320,6 +320,7 @@ const createSchemaField = (
   } else if (swaggerField.enum) {
     fieldProps = configureDropDown(swaggerField, fieldProps);
     children = dropDownChildren(swaggerField);
+    className += ' rounded';
   } else if (['integer', 'number'].includes(swaggerField.type)) {
     if (swaggerField.format === 'cents') {
       fieldProps = configureCentsField(swaggerField, fieldProps);

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -29,7 +29,7 @@ definitions:
   Affiliation:
     type: string
     x-nullable: true
-    title: Branch
+    title: Branch of service
     enum: &AFFILIATION
       - ARMY
       - NAVY
@@ -746,7 +746,7 @@ definitions:
         example: '5789345789'
         pattern: '^[0-9]{10}$'
         x-nullable: true
-        title: DoD ID
+        title: DoD ID number
       orders:
         type: array
         items:
@@ -849,7 +849,7 @@ definitions:
         pattern: '^[0-9]{10}$'
         example: '5789345789'
         x-nullable: true
-        title: 'DoD ID #'
+        title: 'DoD ID number'
       affiliation:
         $ref: '#/definitions/Affiliation'
       rank:
@@ -858,7 +858,7 @@ definitions:
         type: string
         format: ssn
         x-nullable: true
-        title: 'Social Security Number'
+        title: 'Social security number'
         example: '555-55-5555'
       first_name:
         type: string
@@ -937,7 +937,7 @@ definitions:
         pattern: '^[0-9]{10}$'
         example: '5789345789'
         x-nullable: true
-        title: DoD ID
+        title: DoD ID number
       affiliation:
         $ref: '#/definitions/Affiliation'
       rank:
@@ -946,7 +946,7 @@ definitions:
         type: string
         format: ssn
         x-nullable: true
-        title: Social Security Number
+        title: Social security number
         example: '555-55-5555'
       first_name:
         type: string


### PR DESCRIPTION
## Description

This PR includes various text and CSS fixes:
*  weight estimate on PPM tab has comma formatting
* advance amount on review and slider pages have 2 digits after decimal
* Create profile page has updated text
* Residential and backup mailing address pages format city, state and zip inputs on the same line and includes updated instructions.

## Code Review Verification Steps

* [ ] End to end tests pass (`make e2e_test`) - NA: broken in master
* [x] This works in IE.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* pivotal stories:
- https://www.pivotaltracker.com/story/show/158638097
- https://www.pivotaltracker.com/story/show/158637827
- https://www.pivotaltracker.com/story/show/158503603
- https://www.pivotaltracker.com/story/show/158225807


## Screenshots
<img width="633" alt="screen shot 2018-08-10 at 3 11 47 pm" src="https://user-images.githubusercontent.com/8170735/43984431-736106ac-9cb5-11e8-98a5-2abb134f30b0.png">
<img width="972" alt="screen shot 2018-08-10 at 3 11 34 pm" src="https://user-images.githubusercontent.com/8170735/43984433-75ff7858-9cb5-11e8-9cb3-7336be5ab258.png">
<img width="426" alt="screen shot 2018-08-10 at 3 53 25 pm" src="https://user-images.githubusercontent.com/8170735/43984469-a484455a-9cb5-11e8-965b-45eac7485af9.png">
