### PR TITLE
Removed explicit Python 3.6 prereq check

### DIFF
--- a/bin/prereqs
+++ b/bin/prereqs
@@ -22,7 +22,6 @@ has pre-commit "brew install pre-commit"
 has shellcheck "brew install shellcheck"
 has docker "Get Docker CE for Mac from https://download.docker.com/mac/stable/Docker.dmg"
 has psql "brew install postgresql"
-has python3.6 "(assuming you're using pyenv) pyenv install 3.6.2"
 
 # macOS only
 if [[ $(uname -s) = Darwin ]]; then


### PR DESCRIPTION
## Description

This PR removes the explicit Python 3.6 prerequisite check.  This was causing problems on a clean dev environment setup because Python 3.7 was installed automatically as a dependency when you `brew install pre-commit` as suggested, so the 3.6 check would fail.  That in turn caused the `make deps` to fail as well.

It doesn't appear that we use Python for anything other than pre-commit at this point.