### PR TITLE
Rek add hhg profile to e2e

### DIFF
--- a/pkg/awardqueue/awardqueue_test.go
+++ b/pkg/awardqueue/awardqueue_test.go
@@ -21,7 +21,7 @@ func (suite *AwardQueueSuite) Test_CheckAllTSPsBlackedOut() {
 	queue := NewAwardQueue(suite.db, suite.logger)
 
 	tsp := testdatagen.MakeDefaultTSP(suite.db)
-	tdl, _ := testdatagen.MakeTDL(suite.db, testdatagen.DefaultSrcRateArea, testdatagen.DefaultDstRegion, "5")
+	tdl := testdatagen.MakeDefaultTDL(suite.db)
 	testdatagen.MakeTSPPerformance(suite.db, tsp, tdl, swag.Int(1), mps+1, 0, .3, .3)
 
 	blackoutStartDate := testdatagen.DateInsidePeakRateCycle
@@ -80,7 +80,7 @@ func (suite *AwardQueueSuite) Test_CheckShipmentDuringBlackOut() {
 	t := suite.T()
 	queue := NewAwardQueue(suite.db, suite.logger)
 	tsp := testdatagen.MakeDefaultTSP(suite.db)
-	tdl, _ := testdatagen.MakeTDL(suite.db, testdatagen.DefaultSrcRateArea, testdatagen.DefaultDstRegion, "5")
+	tdl := testdatagen.MakeDefaultTDL(suite.db)
 
 	market := testdatagen.DefaultMarket
 	sourceGBLOC := testdatagen.DefaultSrcGBLOC
@@ -159,7 +159,7 @@ func (suite *AwardQueueSuite) Test_ShipmentWithinBlackoutDates() {
 	queue := NewAwardQueue(suite.db, suite.logger)
 	// Creates a TSP and TDL with a blackout date connected to both.
 	testTSP1 := testdatagen.MakeDefaultTSP(suite.db)
-	testTDL, _ := testdatagen.MakeTDL(suite.db, testdatagen.DefaultSrcRateArea, testdatagen.DefaultDstRegion, "5")
+	testTDL := testdatagen.MakeDefaultTDL(suite.db)
 
 	market := testdatagen.DefaultMarket
 	sourceGBLOC := testdatagen.DefaultSrcGBLOC
@@ -272,7 +272,7 @@ func (suite *AwardQueueSuite) Test_OfferSingleShipment() {
 	queue := NewAwardQueue(suite.db, suite.logger)
 
 	// Make a shipment
-	tdl, _ := testdatagen.MakeTDL(suite.db, testdatagen.DefaultSrcRateArea, testdatagen.DefaultDstRegion, "2")
+	tdl := testdatagen.MakeDefaultTDL(suite.db)
 	market := testdatagen.DefaultMarket
 	sourceGBLOC := testdatagen.DefaultSrcGBLOC
 	pickupDate := testdatagen.DateInsidePeakRateCycle
@@ -324,7 +324,7 @@ func (suite *AwardQueueSuite) Test_FailOfferingSingleShipment() {
 	queue := NewAwardQueue(suite.db, suite.logger)
 
 	// Make a shipment in a new TDL, which inherently has no TSPs
-	tdl, _ := testdatagen.MakeTDL(suite.db, testdatagen.DefaultSrcRateArea, testdatagen.DefaultDstRegion, "2")
+	tdl := testdatagen.MakeDefaultTDL(suite.db)
 	market := "dHHG"
 	sourceGBLOC := "OHAI"
 	pickupDate := testdatagen.DateInsidePeakRateCycle
@@ -371,7 +371,7 @@ func (suite *AwardQueueSuite) TestAssignShipmentsSingleTSP() {
 	shipmentsToMake := 10
 
 	// Make a TDL to contain our tests
-	tdl, _ := testdatagen.MakeTDL(suite.db, testdatagen.DefaultSrcRateArea, testdatagen.DefaultDstRegion, "2")
+	tdl := testdatagen.MakeDefaultTDL(suite.db)
 
 	// Shipment details
 	market := testdatagen.DefaultMarket
@@ -423,7 +423,7 @@ func (suite *AwardQueueSuite) TestAssignShipmentsToMultipleTSPs() {
 	shipmentsToMake := 17
 
 	// Make a TDL to contain our tests
-	tdl, _ := testdatagen.MakeTDL(suite.db, testdatagen.DefaultSrcRateArea, testdatagen.DefaultDstRegion, "2")
+	tdl := testdatagen.MakeDefaultTDL(suite.db)
 
 	// Shipment details
 	market := testdatagen.DefaultMarket
@@ -495,10 +495,7 @@ func (suite *AwardQueueSuite) Test_AssignTSPsToBands() {
 	queue := NewAwardQueue(suite.db, suite.logger)
 	tspsToMake := 5
 
-	tdl, err := testdatagen.MakeTDL(suite.db, testdatagen.DefaultSrcRateArea, testdatagen.DefaultDstRegion, "2")
-	if err != nil {
-		t.Errorf("Failed to create TDL: %v", err)
-	}
+	tdl := testdatagen.MakeDefaultTDL(suite.db)
 
 	for i := 0; i < tspsToMake; i++ {
 		tsp := testdatagen.MakeDefaultTSP(suite.db)
@@ -508,7 +505,7 @@ func (suite *AwardQueueSuite) Test_AssignTSPsToBands() {
 		testdatagen.MakeTSPPerformance(suite.db, tsp, tdl, nil, score, 0, rate, rate)
 	}
 
-	err = queue.assignPerformanceBands()
+	err := queue.assignPerformanceBands()
 
 	if err != nil {
 		t.Errorf("Failed to assign to performance bands: %v", err)
@@ -541,7 +538,7 @@ func (suite *AwardQueueSuite) Test_AwardTSPsInDifferentRateCycles() {
 	twoMonths, _ := time.ParseDuration("2 months")
 	twoMonthsLater := testdatagen.PerformancePeriodStart.Add(twoMonths)
 
-	tdl, _ := testdatagen.MakeTDL(suite.db, testdatagen.DefaultSrcRateArea, testdatagen.DefaultDstRegion, "2")
+	tdl := testdatagen.MakeDefaultTDL(suite.db)
 
 	// Make Peak TSP and Shipment
 	tspPeak := testdatagen.MakeDefaultTSP(suite.db)

--- a/pkg/handlers/personally_procured_move_sit_estimate_test.go
+++ b/pkg/handlers/personally_procured_move_sit_estimate_test.go
@@ -14,7 +14,13 @@ func (suite *HandlerSuite) TestShowPPMSitEstimateHandlerWithDcos() {
 	t := suite.T()
 
 	// Given: a TDL, TSP and TSP performance with SITRate for relevant location and date
-	tdl, _ := testdatagen.MakeTDL(suite.db, "US68", "5", "D") // Victoria, TX to Salina, KS
+	tdl := testdatagen.MakeTDL(suite.db, testdatagen.Assertions{
+		TrafficDistributionList: models.TrafficDistributionList{
+			SourceRateArea:    "US68",
+			DestinationRegion: "5",
+			CodeOfService:     "D",
+		},
+	}) // Victoria, TX to Salina, KS
 	tsp := testdatagen.MakeDefaultTSP(suite.db)
 
 	suite.mustSave(&models.Tariff400ngZip3{Zip3: "779", RateArea: "US68", BasepointCity: "Victoria", State: "TX", ServiceArea: "748", Region: "6"})
@@ -93,7 +99,13 @@ func (suite *HandlerSuite) TestShowPPMSitEstimateHandler2cos() {
 	t := suite.T()
 
 	// Given: a TDL, TSP and TSP performance with SITRate for relevant location and date
-	tdl, _ := testdatagen.MakeTDL(suite.db, "US68", "5", "2") // Victoria, TX to Salina, KS
+	tdl := testdatagen.MakeTDL(suite.db, testdatagen.Assertions{
+		TrafficDistributionList: models.TrafficDistributionList{
+			SourceRateArea:    "US68",
+			DestinationRegion: "5",
+			CodeOfService:     "2",
+		},
+	}) // Victoria, TX to Salina, KS
 	tsp := testdatagen.MakeDefaultTSP(suite.db)
 
 	suite.mustSave(&models.Tariff400ngZip3{Zip3: "779", RateArea: "US68", BasepointCity: "Victoria", State: "TX", ServiceArea: "748", Region: "6"})

--- a/pkg/models/blackout_dates_test.go
+++ b/pkg/models/blackout_dates_test.go
@@ -16,7 +16,7 @@ func (suite *ModelSuite) Test_FetchTSPBlackoutDates() {
 	// Use FetchTSPBlackoutDates on two queries: one that should use a market value and one that doesn't.
 	// Create one blackout date object with a market.
 	tsp := testdatagen.MakeDefaultTSP(suite.db)
-	tdl, _ := testdatagen.MakeTDL(suite.db, testdatagen.DefaultSrcRateArea, testdatagen.DefaultDstRegion, testdatagen.DefaultCOS)
+	tdl := testdatagen.MakeDefaultTDL(suite.db)
 	blackoutStartDate := time.Now()
 	blackoutEndDate := blackoutStartDate.Add(time.Hour * 24 * 2)
 	pickupDate := blackoutStartDate.Add(time.Hour)
@@ -77,7 +77,7 @@ func (suite *ModelSuite) Test_FetchTSPBlackoutDatesWithGBLOC() {
 	// Use FetchTSPBlackoutDates on two queries: one that should use a market value and one that doesn't.
 	// Create one blackout date object with a market.
 	tsp := testdatagen.MakeDefaultTSP(suite.db)
-	tdl, _ := testdatagen.MakeTDL(suite.db, testdatagen.DefaultSrcRateArea, testdatagen.DefaultDstRegion, testdatagen.DefaultCOS)
+	tdl := testdatagen.MakeDefaultTDL(suite.db)
 	blackoutStartDate := time.Now()
 	blackoutEndDate := blackoutStartDate.Add(time.Hour * 24 * 2)
 	pickupDate := blackoutStartDate.Add(time.Hour)

--- a/pkg/models/move_test.go
+++ b/pkg/models/move_test.go
@@ -28,7 +28,9 @@ func (suite *ModelSuite) TestFetchMove() {
 
 	pickupDate := time.Now()
 	deliveryDate := time.Now().AddDate(0, 0, 1)
+
 	tdl := testdatagen.MakeDefaultTDL(suite.db)
+
 	market := "dHHG"
 	sourceGBLOC := "BMLK"
 
@@ -37,7 +39,7 @@ func (suite *ModelSuite) TestFetchMove() {
 		ServiceMemberID: order1.ServiceMemberID,
 		ApplicationName: auth.MyApp,
 	}
-	var selectedType = internalmessages.SelectedMoveTypeCOMBO
+	var selectedType = internalmessages.SelectedMoveTypeHHG
 
 	move, verrs, err := order1.CreateNewMove(suite.db, &selectedType)
 	suite.Nil(err)
@@ -208,6 +210,14 @@ func (suite *ModelSuite) TestSaveMoveDependenciesSetsGBLOCSuccess() {
 	market := "dHHG"
 	sourceGBLOC := "BMLK"
 
+	orders := testdatagen.MakeDefaultOrder(suite.db)
+	orders.Status = OrderStatusSUBMITTED
+
+	var selectedType = internalmessages.SelectedMoveTypeCOMBO
+	move, verrs, err := orders.CreateNewMove(suite.db, &selectedType)
+	suite.Nil(err)
+	suite.False(verrs.HasAny(), "failed to validate move")
+
 	shipment := testdatagen.MakeShipment(suite.db, testdatagen.Assertions{
 		Shipment: Shipment{
 			RequestedPickupDate:     &pickupDate,
@@ -217,17 +227,9 @@ func (suite *ModelSuite) TestSaveMoveDependenciesSetsGBLOCSuccess() {
 			SourceGBLOC:             &sourceGBLOC,
 			Market:                  &market,
 			ServiceMember:           &serviceMember,
+			Move:                    move,
 		},
 	})
-
-	orders := testdatagen.MakeDefaultOrder(suite.db)
-	orders.Status = OrderStatusSUBMITTED
-
-	var selectedType = internalmessages.SelectedMoveTypeCOMBO
-	move, verrs, err := orders.CreateNewMove(suite.db, &selectedType)
-	suite.Nil(err)
-	suite.False(verrs.HasAny(), "failed to validate move")
-
 	// Associate Shipment with the move it's on.
 	move.Shipments = append(move.Shipments, shipment)
 	move.Orders = orders

--- a/pkg/models/move_test.go
+++ b/pkg/models/move_test.go
@@ -184,11 +184,7 @@ func (suite *ModelSuite) TestSaveMoveDependenciesSetsGBLOCSuccess() {
 
 	pickupDate := time.Now()
 	deliveryDate := time.Now().AddDate(0, 0, 1)
-	tdl, _ := testdatagen.MakeTDL(
-		suite.db,
-		testdatagen.DefaultSrcRateArea,
-		testdatagen.DefaultDstRegion,
-		testdatagen.DefaultCOS)
+	tdl := testdatagen.MakeDefaultTDL(suite.db)
 	market := "dHHG"
 	sourceGBLOC := "BMLK"
 

--- a/pkg/models/move_test.go
+++ b/pkg/models/move_test.go
@@ -28,11 +28,7 @@ func (suite *ModelSuite) TestFetchMove() {
 
 	pickupDate := time.Now()
 	deliveryDate := time.Now().AddDate(0, 0, 1)
-	tdl, _ := testdatagen.MakeTDL(
-		suite.db,
-		testdatagen.DefaultSrcRateArea,
-		testdatagen.DefaultDstRegion,
-		testdatagen.DefaultCOS)
+	tdl := testdatagen.MakeDefaultTDL(suite.db)
 	market := "dHHG"
 	sourceGBLOC := "BMLK"
 

--- a/pkg/models/shipment_offer_test.go
+++ b/pkg/models/shipment_offer_test.go
@@ -23,12 +23,7 @@ func (suite *ModelSuite) Test_CreateShipmentOffer() {
 	t := suite.T()
 	pickupDate := time.Now()
 	deliveryDate := time.Now().AddDate(0, 0, 1)
-	tdl, err := testdatagen.MakeTDL(suite.db,
-		testdatagen.DefaultSrcRateArea,
-		testdatagen.DefaultDstRegion,
-		testdatagen.DefaultCOS)
-	suite.Nil(err, "error making TDL")
-
+	tdl := testdatagen.MakeDefaultTDL(suite.db)
 	tsp := testdatagen.MakeDefaultTSP(suite.db)
 
 	sourceGBLOC := "OHAI"

--- a/pkg/models/shipment_test.go
+++ b/pkg/models/shipment_test.go
@@ -41,11 +41,7 @@ func (suite *ModelSuite) Test_FetchAllShipments() {
 	t := suite.T()
 	pickupDate := time.Now()
 	deliveryDate := time.Now().AddDate(0, 0, 1)
-	tdl, _ := testdatagen.MakeTDL(
-		suite.db,
-		testdatagen.DefaultSrcRateArea,
-		testdatagen.DefaultDstRegion,
-		testdatagen.DefaultCOS)
+	tdl := testdatagen.MakeDefaultTDL(suite.db)
 	market := "dHHG"
 	sourceGBLOC := "OHAI"
 
@@ -88,11 +84,7 @@ func (suite *ModelSuite) Test_FetchUnassignedShipments() {
 	t := suite.T()
 	pickupDate := time.Now()
 	deliveryDate := time.Now().AddDate(0, 0, 1)
-	tdl, _ := testdatagen.MakeTDL(
-		suite.db,
-		testdatagen.DefaultSrcRateArea,
-		testdatagen.DefaultDstRegion,
-		testdatagen.DefaultCOS)
+	tdl := testdatagen.MakeDefaultTDL(suite.db)
 	market := "dHHG"
 	sourceGBLOC := "OHAI"
 

--- a/pkg/models/traffic_distribution_list_test.go
+++ b/pkg/models/traffic_distribution_list_test.go
@@ -22,11 +22,23 @@ func (suite *ModelSuite) Test_TrafficDistributionList() {
 func (suite *ModelSuite) Test_FetchTDLsAwaitingBandAssignment() {
 	t := suite.T()
 
-	foundTDL, _ := testdatagen.MakeTDL(suite.db, "US14", "3", "2")
+	foundTDL := testdatagen.MakeTDL(suite.db, testdatagen.Assertions{
+		TrafficDistributionList: TrafficDistributionList{
+			SourceRateArea:    "US14",
+			DestinationRegion: "3",
+			CodeOfService:     "2",
+		},
+	})
 	foundTSP := testdatagen.MakeDefaultTSP(suite.db)
 	testdatagen.MakeTSPPerformance(suite.db, foundTSP, foundTDL, nil, float64(mps+1), 0, .2, .3)
 
-	notFoundTDL, _ := testdatagen.MakeTDL(suite.db, "US14", "5", "2")
+	notFoundTDL := testdatagen.MakeTDL(suite.db, testdatagen.Assertions{
+		TrafficDistributionList: TrafficDistributionList{
+			SourceRateArea:    "US14",
+			DestinationRegion: "5",
+			CodeOfService:     "2",
+		},
+	})
 	notFoundTSP := testdatagen.MakeDefaultTSP(suite.db)
 	testdatagen.MakeTSPPerformance(suite.db, notFoundTSP, notFoundTDL, swag.Int(1), float64(mps+1), 0, .4, .3)
 
@@ -47,7 +59,13 @@ func (suite *ModelSuite) Test_FetchTDLsAwaitingBandAssignment() {
 func (suite *ModelSuite) Test_FetchOrCreateTDL() {
 	t := suite.T()
 
-	foundTDL, _ := testdatagen.MakeTDL(suite.db, "US28", "4", "2")
+	foundTDL := testdatagen.MakeTDL(suite.db, testdatagen.Assertions{
+		TrafficDistributionList: TrafficDistributionList{
+			SourceRateArea:    "US28",
+			DestinationRegion: "4",
+			CodeOfService:     "2",
+		},
+	})
 	foundTSP := testdatagen.MakeDefaultTSP(suite.db)
 	testdatagen.MakeTSPPerformance(suite.db, foundTSP, foundTDL, swag.Int(1), float64(mps+1), 0, .2, .3)
 
@@ -84,8 +102,13 @@ func (suite *ModelSuite) Test_FetchOrCreateTDL() {
 func (suite *ModelSuite) Test_TDLUniqueChannelCOS() {
 	t := suite.T()
 
-	tdl, _ := testdatagen.MakeTDL(suite.db, "US28", "4", "2")
-
+	tdl := testdatagen.MakeTDL(suite.db, testdatagen.Assertions{
+		TrafficDistributionList: TrafficDistributionList{
+			SourceRateArea:    "US28",
+			DestinationRegion: "4",
+			CodeOfService:     "2",
+		},
+	})
 	fetchedTDL, err := FetchOrCreateTDL(suite.db, "US28", "4", "2")
 	if err != nil {
 		t.Errorf("Something went wrong fetching the test object: %s\n", err)

--- a/pkg/models/transportation_service_provider_performance_test.go
+++ b/pkg/models/transportation_service_provider_performance_test.go
@@ -92,7 +92,7 @@ func (suite *ModelSuite) Test_GetRateCycle() {
 func (suite *ModelSuite) Test_IncrementTSPPerformanceOfferCount() {
 	t := suite.T()
 
-	tdl, _ := testdatagen.MakeTDL(suite.db, testdatagen.DefaultSrcRateArea, testdatagen.DefaultDstRegion, testdatagen.DefaultCOS)
+	tdl := testdatagen.MakeDefaultTDL(suite.db)
 	tsp := testdatagen.MakeDefaultTSP(suite.db)
 	perf, _ := testdatagen.MakeTSPPerformance(suite.db, tsp, tdl, nil, mps, 0, .2, .1)
 
@@ -114,7 +114,11 @@ func (suite *ModelSuite) Test_IncrementTSPPerformanceOfferCount() {
 func (suite *ModelSuite) Test_AssignQualityBandToTSPPerformance() {
 	t := suite.T()
 
-	tdl, _ := testdatagen.MakeTDL(suite.db, testdatagen.DefaultSrcRateArea, testdatagen.DefaultDstRegion, "2")
+	tdl := testdatagen.MakeTDL(suite.db, testdatagen.Assertions{
+		TrafficDistributionList: TrafficDistributionList{
+			CodeOfService: "2",
+		},
+	})
 	tsp := testdatagen.MakeDefaultTSP(suite.db)
 	perf, _ := testdatagen.MakeTSPPerformance(suite.db, tsp, tdl, nil, mps, 0, .2, .3)
 	band := 1
@@ -141,7 +145,11 @@ func (suite *ModelSuite) Test_BVSWithLowMPS() {
 	tspsToMake := 5
 
 	// Make a TDL to contain our tests
-	tdl, _ := testdatagen.MakeTDL(suite.db, testdatagen.DefaultSrcRateArea, testdatagen.DefaultDstRegion, "2")
+	tdl := testdatagen.MakeTDL(suite.db, testdatagen.Assertions{
+		TrafficDistributionList: TrafficDistributionList{
+			CodeOfService: "2",
+		},
+	})
 
 	// Make 5 (not divisible by 4) TSPs in this TDL with BVSs above MPS threshold
 	for i := 0; i < tspsToMake; i++ {
@@ -171,7 +179,7 @@ func (suite *ModelSuite) Test_BVSWithLowMPS() {
 func (suite *ModelSuite) Test_FetchNextQualityBandTSPPerformance() {
 	t := suite.T()
 
-	tdl, _ := testdatagen.MakeTDL(suite.db, testdatagen.DefaultSrcRateArea, testdatagen.DefaultDstRegion, testdatagen.DefaultCOS)
+	tdl := testdatagen.MakeDefaultTDL(suite.db)
 	tsp1 := testdatagen.MakeDefaultTSP(suite.db)
 	tsp2 := testdatagen.MakeDefaultTSP(suite.db)
 	tsp3 := testdatagen.MakeDefaultTSP(suite.db)
@@ -354,7 +362,7 @@ func (suite *ModelSuite) Test_SelectNextTSPPerformancePartialRound() {
 // order for the Award Queue operation.
 func (suite *ModelSuite) Test_GatherNextEligibleTSPPerformances() {
 	t := suite.T()
-	tdl, _ := testdatagen.MakeTDL(suite.db, testdatagen.DefaultSrcRateArea, testdatagen.DefaultDstRegion, testdatagen.DefaultCOS)
+	tdl := testdatagen.MakeDefaultTDL(suite.db)
 	tsp1 := testdatagen.MakeDefaultTSP(suite.db)
 	tsp2 := testdatagen.MakeDefaultTSP(suite.db)
 	tsp3 := testdatagen.MakeDefaultTSP(suite.db)
@@ -394,7 +402,7 @@ func (suite *ModelSuite) Test_GatherNextEligibleTSPPerformances() {
 func (suite *ModelSuite) Test_FetchTSPPerformanceForQualityBandAssignment() {
 	t := suite.T()
 
-	tdl, _ := testdatagen.MakeTDL(suite.db, testdatagen.DefaultSrcRateArea, testdatagen.DefaultDstRegion, testdatagen.DefaultCOS)
+	tdl := testdatagen.MakeDefaultTDL(suite.db)
 	tsp1 := testdatagen.MakeDefaultTSP(suite.db)
 	tsp2 := testdatagen.MakeDefaultTSP(suite.db)
 	tsp3 := testdatagen.MakeDefaultTSP(suite.db)
@@ -426,7 +434,7 @@ func (suite *ModelSuite) Test_FetchTSPPerformanceForQualityBandAssignment() {
 func (suite *ModelSuite) Test_MinimumPerformanceScore() {
 	t := suite.T()
 
-	tdl, _ := testdatagen.MakeTDL(suite.db, testdatagen.DefaultSrcRateArea, testdatagen.DefaultDstRegion, testdatagen.DefaultCOS)
+	tdl := testdatagen.MakeDefaultTDL(suite.db)
 	tsp1 := testdatagen.MakeDefaultTSP(suite.db)
 	tsp2 := testdatagen.MakeDefaultTSP(suite.db)
 	// Make 2 TSPs, one with a BVS above the MPS and one below the MPS.
@@ -451,7 +459,13 @@ func (suite *ModelSuite) Test_MinimumPerformanceScore() {
 func (suite *ModelSuite) Test_FetchDiscountRatesBVS() {
 	t := suite.T()
 
-	tdl, _ := testdatagen.MakeTDL(suite.db, "US68", "5", "2") // Victoria, TX to Salina, KS
+	tdl := testdatagen.MakeTDL(suite.db, testdatagen.Assertions{
+		TrafficDistributionList: TrafficDistributionList{
+			SourceRateArea:    "US68",
+			DestinationRegion: "5",
+			CodeOfService:     "2",
+		},
+	}) // Victoria, TX to Salina, KS
 	tsp := testdatagen.MakeDefaultTSP(suite.db)
 
 	suite.mustSave(&Tariff400ngZip3{Zip3: "779", RateArea: "US68", BasepointCity: "Victoria", State: "TX", ServiceArea: "320", Region: "6"})

--- a/pkg/testdatagen/constants.go
+++ b/pkg/testdatagen/constants.go
@@ -17,7 +17,7 @@ var DefaultMarket = "dHHG"
 var DefaultServiceArea = "4"
 
 // DefaultCOS is the default Code of Service for testing.
-var DefaultCOS = "2"
+var DefaultCOS = "D"
 
 // DefaultSrcRateArea is a default rate area (California) for testing.
 var DefaultSrcRateArea = "US87"

--- a/pkg/testdatagen/make_move.go
+++ b/pkg/testdatagen/make_move.go
@@ -23,7 +23,7 @@ func MakeMove(db *pop.Connection, assertions Assertions) models.Move {
 	move := models.Move{
 		Orders:           orders,
 		OrdersID:         orders.ID,
-		SelectedMoveType: stringPointer(*selectedMoveType),
+		SelectedMoveType: selectedMoveType,
 		Status:           models.MoveStatusDRAFT,
 		Locator:          models.GenerateLocator(),
 	}

--- a/pkg/testdatagen/make_move.go
+++ b/pkg/testdatagen/make_move.go
@@ -15,11 +15,15 @@ func MakeMove(db *pop.Connection, assertions Assertions) models.Move {
 		orders = MakeOrder(db, assertions)
 	}
 
-	selectedMoveType := "PPM"
+	defaultMoveType := "PPM"
+	selectedMoveType := assertions.Move.SelectedMoveType
+	if selectedMoveType == nil {
+		selectedMoveType = &defaultMoveType
+	}
 	move := models.Move{
 		Orders:           orders,
 		OrdersID:         orders.ID,
-		SelectedMoveType: &selectedMoveType,
+		SelectedMoveType: stringPointer(*selectedMoveType),
 		Status:           models.MoveStatusDRAFT,
 		Locator:          models.GenerateLocator(),
 	}

--- a/pkg/testdatagen/make_shipment_offer_records.go
+++ b/pkg/testdatagen/make_shipment_offer_records.go
@@ -117,11 +117,14 @@ func CreateShipmentOfferData(db *pop.Connection, numTspUsers int, numShipments i
 	}
 
 	// Create shipments
-	tdl, _ := MakeTDL(
-		db,
-		DefaultSrcRateArea,
-		DefaultDstRegion,
-		DefaultCOS)
+	tdl := MakeTDL(
+		db, Assertions{
+			TrafficDistributionList: models.TrafficDistributionList{
+				SourceRateArea:    DefaultSrcRateArea,
+				DestinationRegion: DefaultDstRegion,
+				CodeOfService:     DefaultCOS,
+			},
+		})
 	market := "dHHG"
 	sourceGBLOC := "OHAI"
 	oneWeek, _ := time.ParseDuration("7d")

--- a/pkg/testdatagen/make_shipment_records.go
+++ b/pkg/testdatagen/make_shipment_records.go
@@ -14,29 +14,41 @@ import (
 func MakeShipment(db *pop.Connection, assertions Assertions) models.Shipment {
 
 	requestedPickupDate := assertions.Shipment.RequestedPickupDate
+	if requestedPickupDate == nil {
+		requestedPickupDate = models.TimePointer(PerformancePeriodStart)
+	}
 	pickupDate := assertions.Shipment.PickupDate
+	if pickupDate == nil {
+		pickupDate = models.TimePointer(DateInsidePerformancePeriod)
+	}
 	deliveryDate := assertions.Shipment.DeliveryDate
+	if deliveryDate == nil {
+		deliveryDate = models.TimePointer(DateOutsidePerformancePeriod)
+	}
+
 	tdl := assertions.Shipment.TrafficDistributionList
 	if tdl == nil {
 		newTDL := MakeDefaultTDL(db)
 		tdl = &newTDL
 	}
 
-	defaultGBLOC := "OHAI"
 	sourceGBLOC := assertions.Shipment.SourceGBLOC
 	if sourceGBLOC == nil {
-		sourceGBLOC = &defaultGBLOC
+		sourceGBLOC = &DefaultSrcGBLOC
 	}
 	destinationGBLOC := assertions.Shipment.DestinationGBLOC
 	if destinationGBLOC == nil {
-		destinationGBLOC = &defaultGBLOC
+		destinationGBLOC = &DefaultSrcGBLOC
 	}
 
 	market := assertions.Shipment.Market
+	if market == nil {
+		market = &DefaultMarket
+	}
 
 	move := assertions.Shipment.Move
-	if move == nil {
-		newMove := MakeDefaultMove(db)
+	if isZeroUUID(assertions.Shipment.MoveID) {
+		newMove := MakeMove(db, assertions)
 		move = &newMove
 	}
 
@@ -48,8 +60,7 @@ func MakeShipment(db *pop.Connection, assertions Assertions) models.Shipment {
 
 	codeOfService := assertions.Shipment.CodeOfService
 	if codeOfService == nil {
-		newCodeOfService := "D"
-		codeOfService = &newCodeOfService
+		codeOfService = &DefaultCOS
 	}
 
 	pickupAddress := assertions.Shipment.PickupAddress

--- a/pkg/testdatagen/make_shipment_records.go
+++ b/pkg/testdatagen/make_shipment_records.go
@@ -47,7 +47,7 @@ func MakeShipment(db *pop.Connection, assertions Assertions) models.Shipment {
 	}
 
 	move := assertions.Shipment.Move
-	if isZeroUUID(assertions.Shipment.MoveID) {
+	if move == nil || isZeroUUID(assertions.Shipment.Move.ID) {
 		newMove := MakeMove(db, assertions)
 		move = &newMove
 	}

--- a/pkg/testdatagen/make_shipment_records.go
+++ b/pkg/testdatagen/make_shipment_records.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/gobuffalo/pop"
+
 	"github.com/transcom/mymove/pkg/models"
 )
 
@@ -17,8 +18,8 @@ func MakeShipment(db *pop.Connection, assertions Assertions) models.Shipment {
 	deliveryDate := assertions.Shipment.DeliveryDate
 	tdl := assertions.Shipment.TrafficDistributionList
 	if tdl == nil {
-		// TODO: Fix TDL
-		// tdl = MakeDefaultTDL(db)
+		newTDL := MakeDefaultTDL(db)
+		tdl = &newTDL
 	}
 
 	defaultGBLOC := "OHAI"

--- a/pkg/testdatagen/scenario/awardqueue.go
+++ b/pkg/testdatagen/scenario/awardqueue.go
@@ -16,7 +16,13 @@ func RunAwardQueueScenario1(db *pop.Connection) {
 	shipmentsToMake := 17
 
 	// Make a TDL to contain our tests
-	tdl, _ := testdatagen.MakeTDL(db, "US13", "15", "2")
+	tdl := testdatagen.MakeTDL(db, testdatagen.Assertions{
+		TrafficDistributionList: models.TrafficDistributionList{
+			SourceRateArea:    "US13",
+			DestinationRegion: "5",
+			CodeOfService:     "2",
+		},
+	})
 
 	// Make a market
 	market := "dHHG"
@@ -61,8 +67,20 @@ func RunAwardQueueScenario2(db *pop.Connection) {
 	shipmentDate := time.Now()
 
 	// Make a TDL to contain our tests
-	tdl, _ := testdatagen.MakeTDL(db, "US13", "15", "2")
-	tdl2, _ := testdatagen.MakeTDL(db, "US62", "1", "2")
+	tdl := testdatagen.MakeTDL(db, testdatagen.Assertions{
+		TrafficDistributionList: models.TrafficDistributionList{
+			SourceRateArea:    "US13",
+			DestinationRegion: "15",
+			CodeOfService:     "2",
+		},
+	})
+	tdl2 := testdatagen.MakeTDL(db, testdatagen.Assertions{
+		TrafficDistributionList: models.TrafficDistributionList{
+			SourceRateArea:    "US62",
+			DestinationRegion: "1",
+			CodeOfService:     "2",
+		},
+	})
 
 	// Make a market
 	market := "dHHG"

--- a/pkg/testdatagen/scenario/e2ebasic.go
+++ b/pkg/testdatagen/scenario/e2ebasic.go
@@ -183,12 +183,9 @@ func (e e2eBasicScenario) Run(db *pop.Connection) {
 			PersonalEmail: models.StringPointer(email),
 		},
 		Move: models.Move{
-			ID:      uuid.FromStringOrNil("2ed0b5a2-26d9-49a3-a775-5220055e8ffe"),
-			Locator: "RLKBEM",
-		},
-		Shipment: models.Shipment{
-			PickupDate:          &nowTime,
-			RequestedPickupDate: &nowTime,
+			ID:               uuid.FromStringOrNil("2ed0b5a2-26d9-49a3-a775-5220055e8ffe"),
+			Locator:          "RLKBEM",
+			SelectedMoveType: models.StringPointer("HHG"),
 		},
 		TrafficDistributionList: models.TrafficDistributionList{
 			ID:                uuid.FromStringOrNil("0dfdbdda-c57e-4b29-994a-09fb8641fc75"),

--- a/pkg/testdatagen/scenario/e2ebasic.go
+++ b/pkg/testdatagen/scenario/e2ebasic.go
@@ -42,7 +42,7 @@ func (e e2eBasicScenario) Run(db *pop.Connection) {
 		},
 	})
 
-	// Service member with uploaded orders and a new move
+	// Service member with uploaded orders and a new ppm
 	email := "ppm@incomple.te"
 	uuidStr := "e10d5964-c070-49cb-9bd1-eaf9f7348eb6"
 	testdatagen.MakeUser(db, testdatagen.Assertions{
@@ -73,7 +73,7 @@ func (e e2eBasicScenario) Run(db *pop.Connection) {
 	// Save move and dependencies
 	models.SaveMoveDependencies(db, &ppm0.Move)
 
-	// Service member with a move in progress
+	// Service member with a ppm in progress
 	email = "ppm.in@progre.ss"
 	uuidStr = "20199d12-5165-4980-9ca7-19b5dc9f1032"
 	testdatagen.MakeUser(db, testdatagen.Assertions{
@@ -105,7 +105,7 @@ func (e e2eBasicScenario) Run(db *pop.Connection) {
 	// Save move and dependencies
 	models.SaveMoveDependencies(db, &ppm1.Move)
 
-	// Service member with a move approved, but not in progress
+	// Service member with a ppm move approved, but not in progress
 	email = "ppm@approv.ed"
 	uuidStr = "1842091b-b9a0-4d4a-ba22-1e2f38f26317"
 	testdatagen.MakeUser(db, testdatagen.Assertions{
@@ -162,5 +162,43 @@ func (e e2eBasicScenario) Run(db *pop.Connection) {
 			Locator: "BLABLA",
 		},
 	})
+
+	// Service member with uploaded orders and a new shipment move
+	email = "hhg@incomple.te"
+	uuidStr = "ebc176e0-bb34-47d4-ba37-ff13e2dd40b9"
+	testdatagen.MakeUser(db, testdatagen.Assertions{
+		User: models.User{
+			ID:            uuid.Must(uuid.FromString(uuidStr)),
+			LoginGovEmail: email,
+		},
+	})
+	nowTime = time.Now()
+	hhg0 := testdatagen.MakeShipment(db, testdatagen.Assertions{
+		ServiceMember: models.ServiceMember{
+			ID:            uuid.FromStringOrNil("0d719b18-81d6-474a-86aa-b87246fff65c"),
+			UserID:        uuid.FromStringOrNil(uuidStr),
+			FirstName:     models.StringPointer("HHG"),
+			LastName:      models.StringPointer("Submitted"),
+			Edipi:         models.StringPointer("4444567890"),
+			PersonalEmail: models.StringPointer(email),
+		},
+		Move: models.Move{
+			ID:      uuid.FromStringOrNil("2ed0b5a2-26d9-49a3-a775-5220055e8ffe"),
+			Locator: "RLKBEM",
+		},
+		Shipment: models.Shipment{
+			PickupDate:          &nowTime,
+			RequestedPickupDate: &nowTime,
+		},
+		TrafficDistributionList: models.TrafficDistributionList{
+			ID:                uuid.FromStringOrNil("0dfdbdda-c57e-4b29-994a-09fb8641fc75"),
+			SourceRateArea:    "US62",
+			DestinationRegion: "11",
+			CodeOfService:     "D",
+		},
+	})
+	hhg0.Move.Submit()
+	// Save move and dependencies
+	models.SaveMoveDependencies(db, hhg0.Move)
 
 }

--- a/pkg/testdatagen/shared.go
+++ b/pkg/testdatagen/shared.go
@@ -31,6 +31,7 @@ type Assertions struct {
 	ServiceMember                 models.ServiceMember
 	Shipment                      models.Shipment
 	ShipmentOffer                 models.ShipmentOffer
+	TrafficDistributionList       models.TrafficDistributionList
 	TransportationServiceProvider models.TransportationServiceProvider
 	TspUser                       models.TspUser
 	Upload                        models.Upload


### PR DESCRIPTION
## Description

This adds a SM with an HHG shipment/move in the submitted state to the populate e2e command.

## Reviewer Notes 

We can't yet do Approved because we don't have that work done. I've made some changes--including changing MakeTDL to use assertions and creating a MakeDefaultTDL fnc. I've also used pre-existing constants more in the MakeShipment testdatagen package.

## Setup

Run `make db_populate_e2e`. Then go to local login and select the user `hhg@incomple.te`. This will take you to the edit page for a filled out profile with an associated move and HHG shipment. Uses mostly defaults to create supporting models (so you'll be going Yuma to Yuma).

## Code Review Verification Steps

* [ ] End to end tests pass (`make e2e_test`).
* [x] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/159709592) for this change
