### PR TITLE
Remove the --write flag from prettier in pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
     hooks:
       - id: prettier
         name: prettier
-        entry: node_modules/.bin/prettier --write
+        entry: node_modules/.bin/prettier
         language: node
         files: \.(js|jsx)$
 


### PR DESCRIPTION
## Description

I feel that only two behaviors are acceptable for the prettier command in the pre-commit hook:
- Fix the offending code and exit 0 (pass pre-commit)
- Don't fix the offending code and exit 1 (fail pre-commit)

What currently happens is:
- Fix the offending code and exit 1 (fail pre-commit)

The current behavior was optimized so that people could review the changed code and commit it to the repo.  However, its more likely that the user will not review the change and still commit.  The user could possibly dislike the change prettier made but its unclear that they have any real choice in changing it without modifying prettier rules.

The change in this PR disables the auto-fixing.  The reason is that prettier will always exit 1 (fail) if it's forced to change code.  Also, pre-commit doesn't have an override field which will ignore non-zero exit codes.

Going forward people will be forced to run `make pretty` (or similar) before committing their code. 