### PR TITLE
Add the formReducer to the set of default app reducers

### DIFF
--- a/src/appReducer.js
+++ b/src/appReducer.js
@@ -56,6 +56,7 @@ const entititesReducer = combineReducers({
 });
 
 const defaultReducers = {
+  form: formReducer,
   loggedInUser: loggedInUserReducer,
   router: routerReducer,
   swagger: swaggerReducer,
@@ -71,7 +72,6 @@ export const appReducer = combineReducers(
     serviceMember: serviceMemberReducer,
     orders: ordersReducer,
     shipments: shipmentsReducer,
-    form: formReducer,
     feedback: feedbackReducer,
     signedCertification: signedCertificationReducer,
     upload: documentReducer,


### PR DESCRIPTION
## Description

The formReducer should be part of the default set of reducers so it can be used in the TSP app.