### PR TITLE
Add premove survey fields to public api shipment definition

### DIFF
--- a/swagger/api.yaml
+++ b/swagger/api.yaml
@@ -492,6 +492,54 @@ definitions:
         minimum: 0
         example: 200
         x-nullable: true
+      pm_survey_pack_date:
+        type: string
+        format: date
+        example: "2018-04-26"
+        x-nullable: true
+      pm_survey_pickup_date:
+        type: string
+        format: date
+        example: "2018-04-26"
+        x-nullable: true
+      pm_survey_latest_pickup_date:
+        type: string
+        format: date
+        example: "2018-04-26"
+        x-nullable: true
+      pm_survey_earliest_delivery_date:
+        type: string
+        format: date
+        example: "2018-04-26"
+        x-nullable: true
+      pm_survey_latest_delivery_date:
+        type: string
+        format: date
+        example: "2018-04-26"
+        x-nullable: true
+      pm_survey_weight_estimate:
+        type: integer
+        minimum: 0
+        example: 10000
+        title: Weight
+        x-nullable: true
+      pm_survey_pro_gear_weight_estimate:
+        type: integer
+        minimum: 0
+        example: 10000
+        title: Pro-Gear Weight
+        x-nullable: true
+      pm_survey_spousal_pro_gear_weight_estimate:
+        type: integer
+        minimum: 0
+        example: 10000
+        title: Spouse's Pro-Gear
+        x-nullable: true
+      pm_survey_notes:
+        type: string
+        example: This document is good to go!
+        x-nullable: true
+        title: Notes
   IndexServiceAgents:
     type: array
     items:

--- a/swagger/api.yaml
+++ b/swagger/api.yaml
@@ -496,26 +496,31 @@ definitions:
         type: string
         format: date
         example: "2018-04-26"
+        title: "Pack date"
         x-nullable: true
       pm_survey_pickup_date:
         type: string
         format: date
         example: "2018-04-26"
+        title: "Pickup date"
         x-nullable: true
       pm_survey_latest_pickup_date:
         type: string
         format: date
         example: "2018-04-26"
+        title: "Latest pickup date"
         x-nullable: true
       pm_survey_earliest_delivery_date:
         type: string
         format: date
         example: "2018-04-26"
+        title: "Earliest delivery date"
         x-nullable: true
       pm_survey_latest_delivery_date:
         type: string
         format: date
         example: "2018-04-26"
+        title: "Latest delivery date"
         x-nullable: true
       pm_survey_weight_estimate:
         type: integer

--- a/swagger/api.yaml
+++ b/swagger/api.yaml
@@ -528,13 +528,13 @@ definitions:
         example: 10000
         title: Weight
         x-nullable: true
-      pm_survey_pro_gear_weight_estimate:
+      pm_survey_progear_weight_estimate:
         type: integer
         minimum: 0
         example: 10000
         title: Pro-Gear Weight
         x-nullable: true
-      pm_survey_spousal_pro_gear_weight_estimate:
+      pm_survey_spouse_progear_weight_estimate:
         type: integer
         minimum: 0
         example: 10000


### PR DESCRIPTION
## Description

This PR adds optional pre move survey fields to the public API shipment definition.

## Code Review Verification Steps

* [ ] End to end tests pass (`make e2e_test`).
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/blob/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* [ ] Any migrations/schema changes also update the diagram in docs/schema/dp3.sqs
* [ ] There are no aXe warnings for UI.
* [ ] This works in IE.
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @willowbl00
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/159742503) for this change
