### PR TITLE
add clarifying comment to code and add moveID where lacking

### DIFF
--- a/pkg/models/move_test.go
+++ b/pkg/models/move_test.go
@@ -56,6 +56,7 @@ func (suite *ModelSuite) TestFetchMove() {
 			Market:                  &market,
 			ServiceMember:           &order1.ServiceMember,
 			Move:                    move,
+			MoveID:                  move.ID,
 		},
 	})
 
@@ -228,6 +229,7 @@ func (suite *ModelSuite) TestSaveMoveDependenciesSetsGBLOCSuccess() {
 			Market:                  &market,
 			ServiceMember:           &serviceMember,
 			Move:                    move,
+			MoveID:                  move.ID,
 		},
 	})
 	// Associate Shipment with the move it's on.

--- a/pkg/testdatagen/make_backup_contact.go
+++ b/pkg/testdatagen/make_backup_contact.go
@@ -11,8 +11,7 @@ import (
 // MakeBackupContact creates a single BackupContact and associated service member.
 func MakeBackupContact(db *pop.Connection, assertions Assertions) models.BackupContact {
 	serviceMember := assertions.BackupContact.ServiceMember
-	// In a real scenario, ID will have to be populated for the model
-	// To be populated by Eager, which is why ID is required
+	// ID is required because it must be populated for Eager saving to work.
 	if isZeroUUID(assertions.BackupContact.ServiceMemberID) {
 		serviceMember = MakeServiceMember(db, assertions)
 	}

--- a/pkg/testdatagen/make_backup_contact.go
+++ b/pkg/testdatagen/make_backup_contact.go
@@ -11,6 +11,8 @@ import (
 // MakeBackupContact creates a single BackupContact and associated service member.
 func MakeBackupContact(db *pop.Connection, assertions Assertions) models.BackupContact {
 	serviceMember := assertions.BackupContact.ServiceMember
+	// In a real scenario, ID will have to be populated for the model
+	// To be populated by Eager, which is why ID is required
 	if isZeroUUID(assertions.BackupContact.ServiceMemberID) {
 		serviceMember = MakeServiceMember(db, assertions)
 	}

--- a/pkg/testdatagen/make_document.go
+++ b/pkg/testdatagen/make_document.go
@@ -9,6 +9,8 @@ import (
 // MakeDocument creates a single Document.
 func MakeDocument(db *pop.Connection, assertions Assertions) models.Document {
 	sm := assertions.Document.ServiceMember
+	// In a real scenario, ID will have to be populated for the model
+	// To be populated by Eager, which is why ID is required
 	if isZeroUUID(assertions.Document.ServiceMemberID) {
 		sm = MakeServiceMember(db, assertions)
 	}

--- a/pkg/testdatagen/make_document.go
+++ b/pkg/testdatagen/make_document.go
@@ -9,8 +9,7 @@ import (
 // MakeDocument creates a single Document.
 func MakeDocument(db *pop.Connection, assertions Assertions) models.Document {
 	sm := assertions.Document.ServiceMember
-	// In a real scenario, ID will have to be populated for the model
-	// To be populated by Eager, which is why ID is required
+	// ID is required because it must be populated for Eager saving to work.
 	if isZeroUUID(assertions.Document.ServiceMemberID) {
 		sm = MakeServiceMember(db, assertions)
 	}

--- a/pkg/testdatagen/make_duty_station.go
+++ b/pkg/testdatagen/make_duty_station.go
@@ -15,6 +15,8 @@ func MakeDutyStation(db *pop.Connection, assertions Assertions) models.DutyStati
 	}
 
 	address := assertions.DutyStation.Address
+	// In a real scenario, ID will have to be populated for the model
+	// To be populated by Eager, which is why ID is required
 	if isZeroUUID(assertions.DutyStation.AddressID) {
 		address = MakeAddress(db, assertions)
 	}

--- a/pkg/testdatagen/make_duty_station.go
+++ b/pkg/testdatagen/make_duty_station.go
@@ -15,8 +15,7 @@ func MakeDutyStation(db *pop.Connection, assertions Assertions) models.DutyStati
 	}
 
 	address := assertions.DutyStation.Address
-	// In a real scenario, ID will have to be populated for the model
-	// To be populated by Eager, which is why ID is required
+	// ID is required because it must be populated for Eager saving to work.
 	if isZeroUUID(assertions.DutyStation.AddressID) {
 		address = MakeAddress(db, assertions)
 	}

--- a/pkg/testdatagen/make_move.go
+++ b/pkg/testdatagen/make_move.go
@@ -11,6 +11,8 @@ func MakeMove(db *pop.Connection, assertions Assertions) models.Move {
 
 	// Create new Orders if not provided
 	orders := assertions.Order
+	// In a real scenario, ID will have to be populated for the model
+	// To be populated by Eager, which is why ID is required
 	if isZeroUUID(assertions.Order.ID) {
 		orders = MakeOrder(db, assertions)
 	}

--- a/pkg/testdatagen/make_move.go
+++ b/pkg/testdatagen/make_move.go
@@ -11,8 +11,7 @@ func MakeMove(db *pop.Connection, assertions Assertions) models.Move {
 
 	// Create new Orders if not provided
 	orders := assertions.Order
-	// In a real scenario, ID will have to be populated for the model
-	// To be populated by Eager, which is why ID is required
+	// ID is required because it must be populated for Eager saving to work.
 	if isZeroUUID(assertions.Order.ID) {
 		orders = MakeOrder(db, assertions)
 	}

--- a/pkg/testdatagen/make_move_document.go
+++ b/pkg/testdatagen/make_move_document.go
@@ -9,8 +9,7 @@ import (
 // MakeMoveDocument creates a single Move Document.
 func MakeMoveDocument(db *pop.Connection, assertions Assertions) models.MoveDocument {
 	document := assertions.MoveDocument.Document
-	// In a real scenario, ID will have to be populated for the model
-	// To be populated by Eager, which is why ID is required
+	// ID is required because it must be populated for Eager saving to work.
 	if isZeroUUID(assertions.MoveDocument.DocumentID) {
 		document = MakeDocument(db, assertions)
 	}

--- a/pkg/testdatagen/make_move_document.go
+++ b/pkg/testdatagen/make_move_document.go
@@ -9,11 +9,14 @@ import (
 // MakeMoveDocument creates a single Move Document.
 func MakeMoveDocument(db *pop.Connection, assertions Assertions) models.MoveDocument {
 	document := assertions.MoveDocument.Document
+	// In a real scenario, ID will have to be populated for the model
+	// To be populated by Eager, which is why ID is required
 	if isZeroUUID(assertions.MoveDocument.DocumentID) {
 		document = MakeDocument(db, assertions)
 	}
 
 	move := assertions.MoveDocument.Move
+	// See note above
 	if isZeroUUID(assertions.MoveDocument.MoveID) {
 		move = MakeMove(db, assertions)
 	}

--- a/pkg/testdatagen/make_moving_expense_document.go
+++ b/pkg/testdatagen/make_moving_expense_document.go
@@ -10,6 +10,8 @@ import (
 // MakeMovingExpenseDocument creates a single Moving Expense Document.
 func MakeMovingExpenseDocument(db *pop.Connection, assertions Assertions) models.MovingExpenseDocument {
 	moveDoc := assertions.MovingExpenseDocument.MoveDocument
+	// In a real scenario, ID will have to be populated for the model
+	// To be populated by Eager, which is why ID is required
 	if isZeroUUID(assertions.MovingExpenseDocument.MoveDocumentID) {
 		moveDoc = MakeMoveDocument(db, assertions)
 	}

--- a/pkg/testdatagen/make_moving_expense_document.go
+++ b/pkg/testdatagen/make_moving_expense_document.go
@@ -10,8 +10,7 @@ import (
 // MakeMovingExpenseDocument creates a single Moving Expense Document.
 func MakeMovingExpenseDocument(db *pop.Connection, assertions Assertions) models.MovingExpenseDocument {
 	moveDoc := assertions.MovingExpenseDocument.MoveDocument
-	// In a real scenario, ID will have to be populated for the model
-	// To be populated by Eager, which is why ID is required
+	// ID is required because it must be populated for Eager saving to work.
 	if isZeroUUID(assertions.MovingExpenseDocument.MoveDocumentID) {
 		moveDoc = MakeMoveDocument(db, assertions)
 	}

--- a/pkg/testdatagen/make_order.go
+++ b/pkg/testdatagen/make_order.go
@@ -13,16 +13,20 @@ import (
 func MakeOrder(db *pop.Connection, assertions Assertions) models.Order {
 	// Create new relational data if not provided
 	sm := assertions.Order.ServiceMember
+	// In a real scenario, ID will have to be populated for the model
+	// To be populated by Eager, which is why ID is required
 	if isZeroUUID(assertions.Order.ServiceMemberID) {
 		sm = MakeExtendedServiceMember(db, assertions)
 	}
 
 	station := assertions.Order.NewDutyStation
+	// Note above
 	if isZeroUUID(assertions.Order.NewDutyStationID) {
 		station = MakeDefaultDutyStation(db)
 	}
 
 	document := assertions.Order.UploadedOrders
+	// Note above
 	if isZeroUUID(assertions.Order.UploadedOrdersID) {
 		document = MakeDocument(db, Assertions{
 			Document: models.Document{

--- a/pkg/testdatagen/make_order.go
+++ b/pkg/testdatagen/make_order.go
@@ -13,8 +13,7 @@ import (
 func MakeOrder(db *pop.Connection, assertions Assertions) models.Order {
 	// Create new relational data if not provided
 	sm := assertions.Order.ServiceMember
-	// In a real scenario, ID will have to be populated for the model
-	// To be populated by Eager, which is why ID is required
+	// ID is required because it must be populated for Eager saving to work.
 	if isZeroUUID(assertions.Order.ServiceMemberID) {
 		sm = MakeExtendedServiceMember(db, assertions)
 	}

--- a/pkg/testdatagen/make_ppm.go
+++ b/pkg/testdatagen/make_ppm.go
@@ -15,8 +15,7 @@ func MakePPM(db *pop.Connection, assertions Assertions) models.PersonallyProcure
 
 	// Create new Move if not provided
 	move := assertions.PersonallyProcuredMove.Move
-	// In a real scenario, ID will have to be populated for the model
-	// To be populated by Eager, which is why ID is required
+	// ID is required because it must be populated for Eager saving to work.
 	if isZeroUUID(assertions.PersonallyProcuredMove.MoveID) {
 		move = MakeMove(db, assertions)
 	}

--- a/pkg/testdatagen/make_ppm.go
+++ b/pkg/testdatagen/make_ppm.go
@@ -15,6 +15,8 @@ func MakePPM(db *pop.Connection, assertions Assertions) models.PersonallyProcure
 
 	// Create new Move if not provided
 	move := assertions.PersonallyProcuredMove.Move
+	// In a real scenario, ID will have to be populated for the model
+	// To be populated by Eager, which is why ID is required
 	if isZeroUUID(assertions.PersonallyProcuredMove.MoveID) {
 		move = MakeMove(db, assertions)
 	}

--- a/pkg/testdatagen/make_service_member.go
+++ b/pkg/testdatagen/make_service_member.go
@@ -9,8 +9,7 @@ import (
 // MakeServiceMember creates a single ServiceMember with associated data.
 func MakeServiceMember(db *pop.Connection, assertions Assertions) models.ServiceMember {
 	user := assertions.ServiceMember.User
-	// In a real scenario, ID will have to be populated for the model
-	// To be populated by Eager, which is why ID is required
+	// ID is required because it must be populated for Eager saving to work.
 	if isZeroUUID(assertions.ServiceMember.UserID) {
 		user = MakeUser(db, assertions)
 	}

--- a/pkg/testdatagen/make_service_member.go
+++ b/pkg/testdatagen/make_service_member.go
@@ -9,6 +9,8 @@ import (
 // MakeServiceMember creates a single ServiceMember with associated data.
 func MakeServiceMember(db *pop.Connection, assertions Assertions) models.ServiceMember {
 	user := assertions.ServiceMember.User
+	// In a real scenario, ID will have to be populated for the model
+	// To be populated by Eager, which is why ID is required
 	if isZeroUUID(assertions.ServiceMember.UserID) {
 		user = MakeUser(db, assertions)
 	}

--- a/pkg/testdatagen/make_shipment_offer_records.go
+++ b/pkg/testdatagen/make_shipment_offer_records.go
@@ -151,6 +151,7 @@ func CreateShipmentOfferData(db *pop.Connection, numTspUsers int, numShipments i
 				SourceGBLOC:             &sourceGBLOC,
 				Market:                  &market,
 				Move:                    &move,
+				MoveID:                  &move.ID,
 				Status:                  statuses[rand.Intn(len(statuses))],
 			},
 		}

--- a/pkg/testdatagen/make_shipment_offer_records.go
+++ b/pkg/testdatagen/make_shipment_offer_records.go
@@ -151,7 +151,7 @@ func CreateShipmentOfferData(db *pop.Connection, numTspUsers int, numShipments i
 				SourceGBLOC:             &sourceGBLOC,
 				Market:                  &market,
 				Move:                    &move,
-				MoveID:                  &move.ID,
+				MoveID:                  move.ID,
 				Status:                  statuses[rand.Intn(len(statuses))],
 			},
 		}

--- a/pkg/testdatagen/make_shipment_records.go
+++ b/pkg/testdatagen/make_shipment_records.go
@@ -47,7 +47,9 @@ func MakeShipment(db *pop.Connection, assertions Assertions) models.Shipment {
 	}
 
 	move := assertions.Shipment.Move
-	if move == nil || isZeroUUID(assertions.Shipment.Move.ID) {
+	// In a real scenario, ID will have to be populated for the model
+	// To be populated by Eager, which is why ID is required
+	if isZeroUUID(assertions.Shipment.MoveID) {
 		newMove := MakeMove(db, assertions)
 		move = &newMove
 	}

--- a/pkg/testdatagen/make_shipment_records.go
+++ b/pkg/testdatagen/make_shipment_records.go
@@ -47,8 +47,7 @@ func MakeShipment(db *pop.Connection, assertions Assertions) models.Shipment {
 	}
 
 	move := assertions.Shipment.Move
-	// In a real scenario, ID will have to be populated for the model
-	// To be populated by Eager, which is why ID is required
+	// ID is required because it must be populated for Eager saving to work.
 	if isZeroUUID(assertions.Shipment.MoveID) {
 		newMove := MakeMove(db, assertions)
 		move = &newMove


### PR DESCRIPTION
## Description

It wasn't clear why the following pattern was being used in test data generation ,so I added a comment throughout to clarify and made changes to tests to pass both move and move id in when creating shipments. Comment included in code snippet below.

```
	move := assertions.Shipment.Move
	// In a real scenario, ID will have to be populated for the model
	// To be populated by Eager, which is why ID is required
	if isZeroUUID(assertions.Shipment.MoveID) {
		newMove := MakeMove(db, assertions)
		move = &newMove
	}
```