### PR TITLE
Per-tier Environment Variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,6 +341,19 @@ In development, we use [direnv](https://direnv.net/) to setup environment variab
     require NEW_ENV_VAR "Look for info on this value in Google Drive"
     ```
 
+For per-tier environment variables (that are not secret), simply add the variables to the relevant `config/env/[experimental|staging|prod].env` file with the format `NAME=VALUE` on each line.  Then add the relevant section to `config/app.container-definition.json`.  The deploy process uses Go's [template package](https://golang.org/pkg/text/template/) for rendering the container definition.  For example,
+
+```bash
+MY_SPECIAL_TOKEN=abcxyz
+```
+
+```json
+{
+  "name": "MY_SPECIAL_TOKEN",
+  "value": "{{ .MY_SPECIAL_TOKEN }}"
+},
+```
+
 ### Documentation
 
 You can view the project's GoDoc on [godoc.org](https://godoc.org/github.com/transcom/mymove).

--- a/bin/ecs-deploy-service-container
+++ b/bin/ecs-deploy-service-container
@@ -72,13 +72,13 @@ update_service() {
 # get current task definiton (for rollback)
 blue_task_def_arn=$(aws ecs describe-services --services "$name" --cluster "$cluster" --query 'services[0].taskDefinition' | jq -r .)
 
-# get the DB address
+# Get the database host using the instance identifier
 echo "* Looking up DB host"
 db_host=$(aws rds describe-db-instances --db-instance-identifier "$rds" --query 'DBInstances[0].Endpoint.Address' | jq -r .)
 readonly db_host
 
-# create the container definition from the json template
-container_definition_json=$(perl -pe "s|{{db_host}}|$db_host|g; s|{{domain}}|$domain|g; s|{{environment}}|$environment|g; s|{{image}}|$image|g;" "$template")
+# $DIR/../cmd/renderer/main.go builds its template context from (1) environment variables, (2) file at -v FILE, and (3) positional command line args.
+container_definition_json=$(go run $DIR/../cmd/renderer/main.go -t $template -v $DIR/../config/env/${environment}.env environment=$environment image=$image db_host=$db_host domain=$domain)
 readonly container_definition_json
 
 # create new task definition with the given image

--- a/bin/generate-md-toc.sh
+++ b/bin/generate-md-toc.sh
@@ -17,7 +17,7 @@ function generate_toc() {
   regen=$'\n\nRegenerate with "bin/generate-md-toc.sh"'
 
   # shellcheck disable=SC2016
-  yarn run markdown-toc -i "${filename}" --bullets='*' --append="${regen}"
+  node_modules/.bin/markdown-toc -i "${filename}" --bullets='*' --append="${regen}"
 }
 
 filename="${1:-}"

--- a/cmd/renderer/main.go
+++ b/cmd/renderer/main.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"io/ioutil"
+	"log"
+	"os"
+	"strings"
+	"text/template"
+)
+
+func main() {
+
+	templateFile := ""
+	variablesFile := ""
+
+	flag.StringVar(&templateFile, "t", "", "template file")
+	flag.StringVar(&variablesFile, "v", "", "variables file")
+
+	flag.Parse()
+
+	// If no template file given, then error out
+	if len(templateFile) == 0 {
+		log.Fatal(errors.New("error: no template file given"))
+	}
+
+	// Read contents of template file into tmpl
+	tmpl, err := ioutil.ReadFile(templateFile)
+	if err != nil {
+		log.Fatal(errors.New("error reading template file"))
+	}
+
+	// Read contents of variables file into vars
+	vars, err := ioutil.ReadFile(variablesFile)
+	if err != nil {
+		log.Fatal(errors.New("error reading variables file"))
+	}
+
+	ctx := map[string]string{}
+
+	// Adds variables from file into context
+	for _, x := range strings.Split(string(vars), "\n") {
+		// If a line is empty or starts with #, then skip.
+		if len(x) > 0 && x[0] != '#' {
+			// Split each line on the first equals sign into [name, value]
+			pair := strings.SplitAfterN(x, "=", 2)
+			ctx[pair[0][0:len(pair[0])-1]] = pair[1]
+		}
+	}
+
+	// Adds environment vairables to context
+	// os.Environ() returns a copy of strings representing the environment, in the form "key=value".
+	// https://golang.org/pkg/os/#Environ
+	for _, x := range os.Environ() {
+		// Split each environment variable on the first equals sign into [name, value]
+		pair := strings.SplitAfterN(x, "=", 2)
+		// Add to context
+		ctx[pair[0][0:len(pair[0])-1]] = pair[1]
+	}
+
+	// Adds command line arguments to context
+	for _, x := range flag.Args() {
+		// Split each argument on the first equals sign into [name, value]
+		pair := strings.SplitAfterN(x, "=", 2)
+		// Add to context
+		ctx[pair[0][0:len(pair[0])-1]] = pair[1]
+	}
+
+	t, err := template.New("main").Option("missingkey=error").Parse(string(tmpl))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// If template uses variable that does not exist in context, then errors out.
+	err = t.Execute(os.Stdout, ctx)
+	if err != nil {
+		log.Fatal(err)
+	}
+}

--- a/config/app.container-definition.json
+++ b/config/app.container-definition.json
@@ -1,6 +1,6 @@
 {
-  "name": "app-{{environment}}",
-  "image": "{{image}}",
+  "name": "app-{{ .environment }}",
+  "image": "{{ .image }}",
   "portMappings": [
     {
       "containerPort": 8443,
@@ -12,7 +12,7 @@
   "entryPoint": [
     "/bin/chamber",
     "exec",
-    "app-{{environment}}",
+    "app-{{ .environment }}",
     "--",
     "/bin/mymove-server"
   ],
@@ -24,11 +24,11 @@
   "environment": [
     {
       "name": "ENVIRONMENT",
-      "value": "{{environment}}"
+      "value": "{{ .environment }}"
     },
     {
       "name": "DB_HOST",
-      "value": "{{db_host}}"
+      "value": "{{ .db_host }}"
     },
     {
       "name": "DB_PORT",
@@ -52,23 +52,23 @@
     },
     {
       "name": "HTTP_MY_SERVER_NAME",
-      "value": "my.{{domain}}"
+      "value": "my.{{ .domain }}"
     },
     {
       "name": "HTTP_OFFICE_SERVER_NAME",
-      "value": "office.{{domain}}"
+      "value": "office.{{ .domain }}"
     },
     {
       "name": "HTTP_TSP_SERVER_NAME",
-      "value": "tsp.{{domain}}"
+      "value": "tsp.{{ .domain }}"
     },
     {
       "name": "HTTP_ORDERS_SERVER_NAME",
-      "value": "orders.{{domain}}"
+      "value": "orders.{{ .domain }}"
     },
     {
       "name": "AWS_S3_BUCKET_NAME",
-      "value": "transcom-ppp-app-{{environment}}-us-west-2"
+      "value": "transcom-ppp-app-{{ .environment }}-us-west-2"
     },
     {
       "name": "AWS_S3_REGION",
@@ -96,17 +96,21 @@
     },
     {
       "name": "AWS_SES_DOMAIN",
-      "value": "{{domain}}"
+      "value": "{{ .domain }}"
     },
     {
       "name": "AWS_SES_REGION",
       "value": "us-west-2"
+    },
+    {
+      "name": "LOGIN_GOV_HOSTNAME",
+      "value": "{{ .LOGIN_GOV_HOSTNAME }}"
     }
   ],
   "logConfiguration": {
     "logDriver": "awslogs",
     "options": {
-      "awslogs-group": "ecs-tasks-app-{{environment}}",
+      "awslogs-group": "ecs-tasks-app-{{ .environment }}",
       "awslogs-region": "us-west-2",
       "awslogs-stream-prefix": "app"
     }

--- a/config/env/experimental.env
+++ b/config/env/experimental.env
@@ -1,0 +1,1 @@
+LOGIN_GOV_HOSTNAME=idp.int.identitysandbox.gov

--- a/config/env/prod.env
+++ b/config/env/prod.env
@@ -1,0 +1,1 @@
+LOGIN_GOV_HOSTNAME=secure.login.gov

--- a/config/env/staging.env
+++ b/config/env/staging.env
@@ -1,0 +1,1 @@
+LOGIN_GOV_HOSTNAME=idp.int.identitysandbox.gov


### PR DESCRIPTION
## Description

This PR enables the use of `per-tier` environment variables.  See README.md changes for how to add `per-tier` environment variables.  Unlike secrets, these variables will be baked into the `per-tier` container definition.  Starts with the `login_gov_hostname`.

I also had to update `Gopkg.lock` to get past `pre-commit`.