### PR TITLE
Update beeline-go to pull in request host fixes

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -502,7 +502,7 @@
   revision = "ef8a98b0bbce4a65b5aa4c368430a80ddc533168"
 
 [[projects]]
-  digest = "1:9e3ac020d096502e1199238a35b384141ab82b68f613ba6b59fa91870c7e087b"
+  digest = "1:ba26b234a639dcc4f44c36433688fe3068ecaf65ca2aa5865914c6616ecd277e"
   name = "github.com/honeycombio/beeline-go"
   packages = [
     ".",
@@ -511,8 +511,8 @@
     "wrappers/hnynethttp",
   ]
   pruneopts = ""
-  revision = "1b6a542ada4bafe957b31fd955de895a72aa4840"
-  version = "v0.1.0"
+  revision = "6acc807d0ea48acf418285c0262d71272591326e"
+  version = "v0.1.1"
 
 [[projects]]
   digest = "1:cd507d3e666790a625f34d59d5b0c314ce18b914e1ce3a73d0305b96914d66ae"


### PR DESCRIPTION
## Description

beeline-go wasn't correctly pulling in host header values. https://github.com/honeycombio/beeline-go/pull/16 fixes this issue and this PR just updates beeline-go to 0.1.1 to pull in the fix.

## Code Review Verification Steps

* [x] End to end tests pass (`make e2e_test`).








