### PR TITLE
premove survey changes

### DIFF
--- a/cypress/support/testPremoveSurvey.js
+++ b/cypress/support/testPremoveSurvey.js
@@ -9,27 +9,17 @@ export default function testPremoveSurvey() {
 
   // Enter details in form and save orders
   cy
-    .get('input[name="survey.pm_survey_pack_date"]')
+    .get('input[name="survey.pm_survey_planned_pack_date"]')
     .first()
     .type('8/1/2018')
     .blur();
   cy
-    .get('input[name="survey.pm_survey_pickup_date"]')
+    .get('input[name="survey.pm_survey_planned_pickup_date"]')
     .first()
     .type('8/2/2018')
     .blur();
   cy
-    .get('input[name="survey.pm_survey_latest_pickup_date"]')
-    .first()
-    .type('8/3/2018')
-    .blur();
-  cy
-    .get('input[name="survey.pm_survey_earliest_delivery_date"]')
-    .first()
-    .type('8/4/2018')
-    .blur();
-  cy
-    .get('input[name="survey.pm_survey_latest_delivery_date"]')
+    .get('input[name="survey.pm_survey_planned_delivery_date"]')
     .first()
     .type('8/5/2018')
     .blur();
@@ -53,6 +43,7 @@ export default function testPremoveSurvey() {
     .first()
     .type('Notes notes notes')
     .blur();
+  cy.get('select[name="survey.pm_survey_method"]').select('PHONE');
 
   cy
     .get('button')
@@ -71,7 +62,7 @@ export default function testPremoveSurvey() {
   cy.reload();
 
   cy
-    .get('div.pm_survey_earliest_delivery_date')
+    .get('div.pm_survey_planned_delivery_date')
     .get('span')
     .contains('7,000 lbs');
   cy.get('div.pm_survey_notes').contains('Notes notes notes');

--- a/docs/schema/dp3.sqs
+++ b/docs/schema/dp3.sqs
@@ -1556,11 +1556,11 @@
         <schema><![CDATA[public]]></schema>
         <location>
             <x>23.00</x>
-            <y>1388.00</y>
+            <y>1387.00</y>
         </location>
         <size>
             <width>440.00</width>
-            <height>780.00</height>
+            <height>760.00</height>
         </size>
         <zorder>14</zorder>
         <SQLField>
@@ -1807,27 +1807,17 @@
             <uid><![CDATA[E70C45A6-A1C6-480E-B3C2-6675E255EDF8]]></uid>
         </SQLField>
         <SQLField>
-            <name><![CDATA[pm_survey_pack_date]]></name>
+            <name><![CDATA[pm_survey_planned_pack_date]]></name>
             <type><![CDATA[timestamp without time zone]]></type>
             <uid><![CDATA[91E342FC-4659-4EC1-821C-87D15C84B0D8]]></uid>
         </SQLField>
         <SQLField>
-            <name><![CDATA[pm_survey_pickup_date]]></name>
+            <name><![CDATA[pm_survey_planned_pickup_date]]></name>
             <type><![CDATA[timestamp without time zone]]></type>
             <uid><![CDATA[2BC30B8C-56D8-4D2A-9005-14D352DF1771]]></uid>
         </SQLField>
         <SQLField>
-            <name><![CDATA[pm_survey_latest_pickup_date]]></name>
-            <type><![CDATA[timestamp without time zone]]></type>
-            <uid><![CDATA[8C7D69D1-7650-4363-BC31-8C85E4940F78]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[pm_survey_earliest_delivery_date]]></name>
-            <type><![CDATA[timestamp without timezone]]></type>
-            <uid><![CDATA[576140C6-8155-472F-8F88-52170B0B9328]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[pm_survey_latest_delivery_date]]></name>
+            <name><![CDATA[pm_survey_planned_delivery_date]]></name>
             <type><![CDATA[timestamp without time zone]]></type>
             <uid><![CDATA[2DCAA711-9F0F-4360-A92C-C44DBE6DC0EC]]></uid>
         </SQLField>
@@ -1850,6 +1840,11 @@
             <name><![CDATA[pm_survey_notes]]></name>
             <type><![CDATA[TEXT]]></type>
             <uid><![CDATA[3040475E-ABFA-4EBF-8B8A-BF2804B45661]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[pm_survey_method]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <uid><![CDATA[2D1FE455-CC16-4ABA-8BAF-657BC38B71D3]]></uid>
         </SQLField>
         <labelWindowIndex><![CDATA[23]]></labelWindowIndex>
         <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
@@ -3189,7 +3184,7 @@
         <windowHeight><![CDATA[835.000000]]></windowHeight>
         <windowLocationX><![CDATA[2.000000]]></windowLocationX>
         <windowLocationY><![CDATA[42.000000]]></windowLocationY>
-        <windowScrollOrigin><![CDATA[{444, 1190.5}]]></windowScrollOrigin>
+        <windowScrollOrigin><![CDATA[{0, 1216.5}]]></windowScrollOrigin>
         <windowWidth><![CDATA[1440.000000]]></windowWidth>
     </SQLDocumentInfo>
     <AllowsIndexRenamingOnInsert><![CDATA[1]]></AllowsIndexRenamingOnInsert>

--- a/migrations/20180822222712_premove_changes.down.fizz
+++ b/migrations/20180822222712_premove_changes.down.fizz
@@ -1,0 +1,11 @@
+add_column("shipments", "pm_survey_latest_pickup_date", "datetime", {"null": true})
+add_column("shipments", "pm_survey_earliest_delivery_date", "datetime", {"null": true})
+
+rename_column("shipments", "pm_survey_planned_delivery_date", "pm_survey_latest_delivery_date")
+
+rename_column("shipments", "pm_survey_planned_pack_date", "pm_survey_pack_date")
+
+rename_column("shipments", "pm_survey_planned_pickup_date", "pm_survey_pickup_date")
+
+drop_column("shipments", "pm_survey_method")
+

--- a/migrations/20180822222712_premove_changes.up.fizz
+++ b/migrations/20180822222712_premove_changes.up.fizz
@@ -1,0 +1,9 @@
+drop_column("shipments", "pm_survey_latest_pickup_date")
+drop_column("shipments", "pm_survey_earliest_delivery_date")
+
+rename_column("shipments", "pm_survey_latest_delivery_date", "pm_survey_planned_delivery_date")
+rename_column("shipments", "pm_survey_pack_date", "pm_survey_planned_pack_date")
+rename_column("shipments", "pm_survey_pickup_date", "pm_survey_planned_pickup_date")
+
+add_column("shipments", "pm_survey_method", "text", {"null": true})
+

--- a/migrations/20180822222712_premove_changes.up.fizz
+++ b/migrations/20180822222712_premove_changes.up.fizz
@@ -5,5 +5,5 @@ rename_column("shipments", "pm_survey_latest_delivery_date", "pm_survey_planned_
 rename_column("shipments", "pm_survey_pack_date", "pm_survey_planned_pack_date")
 rename_column("shipments", "pm_survey_pickup_date", "pm_survey_planned_pickup_date")
 
-add_column("shipments", "pm_survey_method", "text", {"null": true})
+add_column("shipments", "pm_survey_method", "text")
 

--- a/pkg/handlers/shipments.go
+++ b/pkg/handlers/shipments.go
@@ -54,6 +54,7 @@ func payloadForShipmentModel(s models.Shipment) *internalmessages.Shipment {
 		PmSurveyProgearWeightEstimate:       fmtPoundPtr(s.PmSurveyProgearWeightEstimate),
 		PmSurveySpouseProgearWeightEstimate: fmtPoundPtr(s.PmSurveySpouseProgearWeightEstimate),
 		PmSurveyNotes:                       s.PmSurveyNotes,
+		PmSurveyMethod:                      s.PmSurveyMethod,
 	}
 	return shipmentPayload
 }

--- a/pkg/handlers/shipments.go
+++ b/pkg/handlers/shipments.go
@@ -47,11 +47,9 @@ func payloadForShipmentModel(s models.Shipment) *internalmessages.Shipment {
 		WeightEstimate:                      fmtPoundPtr(s.WeightEstimate),
 		ProgearWeightEstimate:               fmtPoundPtr(s.ProgearWeightEstimate),
 		SpouseProgearWeightEstimate:         fmtPoundPtr(s.SpouseProgearWeightEstimate),
-		PmSurveyPackDate:                    fmtDatePtr(s.PmSurveyPackDate),
-		PmSurveyPickupDate:                  fmtDatePtr(s.PmSurveyPickupDate),
-		PmSurveyLatestPickupDate:            fmtDatePtr(s.PmSurveyLatestPickupDate),
-		PmSurveyEarliestDeliveryDate:        fmtDatePtr(s.PmSurveyEarliestDeliveryDate),
-		PmSurveyLatestDeliveryDate:          fmtDatePtr(s.PmSurveyLatestDeliveryDate),
+		PmSurveyPlannedPackDate:             fmtDatePtr(s.PmSurveyPlannedPackDate),
+		PmSurveyPlannedPickupDate:           fmtDatePtr(s.PmSurveyPlannedPickupDate),
+		PmSurveyPlannedDeliveryDate:         fmtDatePtr(s.PmSurveyPlannedDeliveryDate),
 		PmSurveyWeightEstimate:              fmtPoundPtr(s.PmSurveyWeightEstimate),
 		PmSurveyProgearWeightEstimate:       fmtPoundPtr(s.PmSurveyProgearWeightEstimate),
 		PmSurveySpouseProgearWeightEstimate: fmtPoundPtr(s.PmSurveySpouseProgearWeightEstimate),
@@ -123,17 +121,16 @@ func (h CreateShipmentHandler) Handle(params shipmentop.CreateShipmentParams) mi
 
 func patchShipmentWithPremoveSurveyFields(shipment *models.Shipment, payload *internalmessages.Shipment) {
 	// Premove Survey values entered by TSP agent
-	requiredValue := payload.PmSurveyPackDate
+	requiredValue := payload.PmSurveyPlannedPackDate
 
 	// If any PmSurvey data was sent, update all fields
 	// This takes advantage of the fact that all PmSurvey data is updated at once and allows us to null out optional fields
 	if requiredValue != nil {
-		shipment.PmSurveyEarliestDeliveryDate = (*time.Time)(payload.PmSurveyEarliestDeliveryDate)
-		shipment.PmSurveyLatestDeliveryDate = (*time.Time)(payload.PmSurveyLatestDeliveryDate)
-		shipment.PmSurveyLatestPickupDate = (*time.Time)(payload.PmSurveyLatestPickupDate)
+		shipment.PmSurveyPlannedPackDate = (*time.Time)(payload.PmSurveyPlannedPackDate)
+		shipment.PmSurveyPlannedPickupDate = (*time.Time)(payload.PmSurveyPlannedPickupDate)
+		shipment.PmSurveyPlannedDeliveryDate = (*time.Time)(payload.PmSurveyPlannedDeliveryDate)
 		shipment.PmSurveyNotes = payload.PmSurveyNotes
-		shipment.PmSurveyPackDate = (*time.Time)(payload.PmSurveyPackDate)
-		shipment.PmSurveyPickupDate = (*time.Time)(payload.PmSurveyPickupDate)
+		shipment.PmSurveyMethod = payload.PmSurveyMethod
 		shipment.PmSurveyProgearWeightEstimate = poundPtrFromInt64Ptr(payload.PmSurveyProgearWeightEstimate)
 		shipment.PmSurveySpouseProgearWeightEstimate = poundPtrFromInt64Ptr(payload.PmSurveySpouseProgearWeightEstimate)
 		shipment.PmSurveyWeightEstimate = poundPtrFromInt64Ptr(payload.PmSurveyWeightEstimate)

--- a/pkg/handlers/shipments_public.go
+++ b/pkg/handlers/shipments_public.go
@@ -54,7 +54,7 @@ func publicPayloadForShipmentModel(s models.Shipment) *apimessages.Shipment {
 		PmSurveyProgearWeightEstimate:       fmtPoundPtr(s.PmSurveyProgearWeightEstimate),
 		PmSurveySpouseProgearWeightEstimate: fmtPoundPtr(s.PmSurveySpouseProgearWeightEstimate),
 		PmSurveyNotes:                       s.PmSurveyNotes,
-		// PmSurveyMethod:						 s.PmSurveyMethod,
+		PmSurveyMethod:                      s.PmSurveyMethod,
 	}
 	return shipmentPayload
 }
@@ -156,6 +156,9 @@ func publicPatchShipmentWithPayload(shipment *models.Shipment, payload *apimessa
 	}
 	if payload.PmSurveyNotes != nil {
 		shipment.PmSurveyNotes = payload.PmSurveyNotes
+	}
+	if payload.PmSurveyMethod != nil {
+		shipment.PmSurveyMethod = payload.PmSurveyMethod
 	}
 	if payload.PmSurveyPlannedPackDate != nil {
 		shipment.PmSurveyPlannedPackDate = (*time.Time)(payload.PmSurveyPlannedPackDate)

--- a/pkg/handlers/shipments_public.go
+++ b/pkg/handlers/shipments_public.go
@@ -157,9 +157,8 @@ func publicPatchShipmentWithPayload(shipment *models.Shipment, payload *apimessa
 	if payload.PmSurveyNotes != nil {
 		shipment.PmSurveyNotes = payload.PmSurveyNotes
 	}
-	if payload.PmSurveyMethod != nil {
-		shipment.PmSurveyMethod = payload.PmSurveyMethod
-	}
+	shipment.PmSurveyMethod = payload.PmSurveyMethod
+
 	if payload.PmSurveyPlannedPackDate != nil {
 		shipment.PmSurveyPlannedPackDate = (*time.Time)(payload.PmSurveyPlannedPackDate)
 	}

--- a/pkg/handlers/shipments_public.go
+++ b/pkg/handlers/shipments_public.go
@@ -47,15 +47,14 @@ func publicPayloadForShipmentModel(s models.Shipment) *apimessages.Shipment {
 		WeightEstimate:                      fmtInt64(s.WeightEstimate.Int64()),
 		ProgearWeightEstimate:               fmtInt64(s.ProgearWeightEstimate.Int64()),
 		SpouseProgearWeightEstimate:         fmtInt64(s.SpouseProgearWeightEstimate.Int64()),
-		PmSurveyPackDate:                    fmtDatePtr(s.PmSurveyPackDate),
-		PmSurveyPickupDate:                  fmtDatePtr(s.PmSurveyPickupDate),
-		PmSurveyLatestPickupDate:            fmtDatePtr(s.PmSurveyLatestPickupDate),
-		PmSurveyEarliestDeliveryDate:        fmtDatePtr(s.PmSurveyEarliestDeliveryDate),
-		PmSurveyLatestDeliveryDate:          fmtDatePtr(s.PmSurveyLatestDeliveryDate),
+		PmSurveyPlannedPackDate:             fmtDatePtr(s.PmSurveyPlannedPackDate),
+		PmSurveyPlannedPickupDate:           fmtDatePtr(s.PmSurveyPlannedPickupDate),
+		PmSurveyPlannedDeliveryDate:         fmtDatePtr(s.PmSurveyPlannedDeliveryDate),
 		PmSurveyWeightEstimate:              fmtPoundPtr(s.PmSurveyWeightEstimate),
 		PmSurveyProgearWeightEstimate:       fmtPoundPtr(s.PmSurveyProgearWeightEstimate),
 		PmSurveySpouseProgearWeightEstimate: fmtPoundPtr(s.PmSurveySpouseProgearWeightEstimate),
 		PmSurveyNotes:                       s.PmSurveyNotes,
+		// PmSurveyMethod:						 s.PmSurveyMethod,
 	}
 	return shipmentPayload
 }
@@ -152,21 +151,29 @@ func (h PublicCreateShipmentRejectHandler) Handle(params publicshipmentop.Create
 
 func publicPatchShipmentWithPayload(shipment *models.Shipment, payload *apimessages.Shipment) {
 	// Premove Survey values entered by TSP agent
-	requiredValue := payload.PmSurveyPackDate
-
-	// If any PmSurvey data was sent, update all fields
-	// This takes advantage of the fact that all PmSurvey data is updated at once and allows us to null out optional fields
-	if requiredValue != nil {
-		shipment.PmSurveyEarliestDeliveryDate = (*time.Time)(payload.PmSurveyEarliestDeliveryDate)
-		shipment.PmSurveyLatestDeliveryDate = (*time.Time)(payload.PmSurveyLatestDeliveryDate)
-		shipment.PmSurveyLatestPickupDate = (*time.Time)(payload.PmSurveyLatestPickupDate)
+	if payload.PmSurveyPlannedDeliveryDate != nil {
+		shipment.PmSurveyPlannedDeliveryDate = (*time.Time)(payload.PmSurveyPlannedDeliveryDate)
+	}
+	if payload.PmSurveyNotes != nil {
 		shipment.PmSurveyNotes = payload.PmSurveyNotes
-		shipment.PmSurveyPackDate = (*time.Time)(payload.PmSurveyPackDate)
-		shipment.PmSurveyPickupDate = (*time.Time)(payload.PmSurveyPickupDate)
+	}
+	if payload.PmSurveyPlannedPackDate != nil {
+		shipment.PmSurveyPlannedPackDate = (*time.Time)(payload.PmSurveyPlannedPackDate)
+	}
+	if payload.PmSurveyPlannedPickupDate != nil {
+		shipment.PmSurveyPlannedPickupDate = (*time.Time)(payload.PmSurveyPlannedPickupDate)
+	}
+
+	if payload.PmSurveyProgearWeightEstimate != nil {
 		shipment.PmSurveyProgearWeightEstimate = poundPtrFromInt64Ptr(payload.PmSurveyProgearWeightEstimate)
+	}
+	if payload.PmSurveySpouseProgearWeightEstimate != nil {
 		shipment.PmSurveySpouseProgearWeightEstimate = poundPtrFromInt64Ptr(payload.PmSurveySpouseProgearWeightEstimate)
+	}
+	if payload.PmSurveyWeightEstimate != nil {
 		shipment.PmSurveyWeightEstimate = poundPtrFromInt64Ptr(payload.PmSurveyWeightEstimate)
 	}
+
 }
 
 // PublicPatchShipmentHandler allows a TSP to patch a particular shipment

--- a/pkg/handlers/shipments_public.go
+++ b/pkg/handlers/shipments_public.go
@@ -151,31 +151,20 @@ func (h PublicCreateShipmentRejectHandler) Handle(params publicshipmentop.Create
 
 func publicPatchShipmentWithPayload(shipment *models.Shipment, payload *apimessages.Shipment) {
 	// Premove Survey values entered by TSP agent
-	if payload.PmSurveyPlannedDeliveryDate != nil {
+	requiredValue := payload.PmSurveyPlannedPackDate
+
+	// If any PmSurvey data was sent, update all fields
+	// This takes advantage of the fact that all PmSurvey data is updated at once and allows us to null out optional fields
+	if requiredValue != nil {
 		shipment.PmSurveyPlannedDeliveryDate = (*time.Time)(payload.PmSurveyPlannedDeliveryDate)
-	}
-	if payload.PmSurveyNotes != nil {
 		shipment.PmSurveyNotes = payload.PmSurveyNotes
-	}
-	shipment.PmSurveyMethod = payload.PmSurveyMethod
-
-	if payload.PmSurveyPlannedPackDate != nil {
+		shipment.PmSurveyMethod = payload.PmSurveyMethod
 		shipment.PmSurveyPlannedPackDate = (*time.Time)(payload.PmSurveyPlannedPackDate)
-	}
-	if payload.PmSurveyPlannedPickupDate != nil {
 		shipment.PmSurveyPlannedPickupDate = (*time.Time)(payload.PmSurveyPlannedPickupDate)
-	}
-
-	if payload.PmSurveyProgearWeightEstimate != nil {
 		shipment.PmSurveyProgearWeightEstimate = poundPtrFromInt64Ptr(payload.PmSurveyProgearWeightEstimate)
-	}
-	if payload.PmSurveySpouseProgearWeightEstimate != nil {
 		shipment.PmSurveySpouseProgearWeightEstimate = poundPtrFromInt64Ptr(payload.PmSurveySpouseProgearWeightEstimate)
-	}
-	if payload.PmSurveyWeightEstimate != nil {
 		shipment.PmSurveyWeightEstimate = poundPtrFromInt64Ptr(payload.PmSurveyWeightEstimate)
 	}
-
 }
 
 // PublicPatchShipmentHandler allows a TSP to patch a particular shipment

--- a/pkg/handlers/shipments_public_test.go
+++ b/pkg/handlers/shipments_public_test.go
@@ -68,14 +68,14 @@ func (suite *HandlerSuite) TestPublicPatchShipmentHandler() {
 
 	genericDate := time.Now()
 	UpdatePayload := apimessages.Shipment{
-		PmSurveyPackDate:                    fmtDatePtr(&genericDate),
-		PmSurveyPickupDate:                  fmtDatePtr(&genericDate),
-		PmSurveyEarliestDeliveryDate:        fmtDatePtr(&genericDate),
-		PmSurveyLatestDeliveryDate:          fmtDatePtr(&genericDate),
+		PmSurveyPlannedPackDate:             fmtDatePtr(&genericDate),
+		PmSurveyPlannedPickupDate:           fmtDatePtr(&genericDate),
+		PmSurveyPlannedDeliveryDate:         fmtDatePtr(&genericDate),
 		PmSurveyWeightEstimate:              swag.Int64(33),
 		PmSurveyProgearWeightEstimate:       swag.Int64(53),
 		PmSurveySpouseProgearWeightEstimate: swag.Int64(54),
 		PmSurveyNotes:                       swag.String("Unsure about pickup date."),
+		PmSurveyMethod:                      swag.String("PHONE"),
 	}
 
 	params := publicshipmentop.PatchShipmentParams{
@@ -95,13 +95,13 @@ func (suite *HandlerSuite) TestPublicPatchShipmentHandler() {
 	// And: Payload has new values
 	suite.Equal(strfmt.UUID(shipment.ID.String()), okResponse.Payload.ID)
 	suite.Equal(*UpdatePayload.PmSurveyNotes, *okResponse.Payload.PmSurveyNotes)
+	suite.Equal(*UpdatePayload.PmSurveyMethod, *okResponse.Payload.PmSurveyMethod)
 	suite.Equal(int64(54), *okResponse.Payload.PmSurveySpouseProgearWeightEstimate)
 	suite.Equal(int64(53), *okResponse.Payload.PmSurveyProgearWeightEstimate)
 	suite.Equal(int64(33), *okResponse.Payload.PmSurveyWeightEstimate)
-	suite.Equal(genericDate, *(*time.Time)(okResponse.Payload.PmSurveyLatestDeliveryDate))
-	suite.Equal(genericDate, *(*time.Time)(okResponse.Payload.PmSurveyEarliestDeliveryDate))
-	suite.Equal(genericDate, *(*time.Time)(okResponse.Payload.PmSurveyPickupDate))
-	suite.Equal(genericDate, *(*time.Time)(okResponse.Payload.PmSurveyPackDate))
+	suite.Equal(genericDate, *(*time.Time)(okResponse.Payload.PmSurveyPlannedDeliveryDate))
+	suite.Equal(genericDate, *(*time.Time)(okResponse.Payload.PmSurveyPlannedPickupDate))
+	suite.Equal(genericDate, *(*time.Time)(okResponse.Payload.PmSurveyPlannedPackDate))
 }
 
 func (suite *HandlerSuite) TestPublicPatchShipmentHandlerWrongTSP() {
@@ -122,14 +122,14 @@ func (suite *HandlerSuite) TestPublicPatchShipmentHandlerWrongTSP() {
 
 	genericDate := time.Now()
 	UpdatePayload := apimessages.Shipment{
-		PmSurveyPackDate:                    fmtDatePtr(&genericDate),
-		PmSurveyPickupDate:                  fmtDatePtr(&genericDate),
-		PmSurveyEarliestDeliveryDate:        fmtDatePtr(&genericDate),
-		PmSurveyLatestDeliveryDate:          fmtDatePtr(&genericDate),
+		PmSurveyPlannedPackDate:             fmtDatePtr(&genericDate),
+		PmSurveyPlannedPickupDate:           fmtDatePtr(&genericDate),
+		PmSurveyPlannedDeliveryDate:         fmtDatePtr(&genericDate),
 		PmSurveyWeightEstimate:              swag.Int64(33),
 		PmSurveyProgearWeightEstimate:       swag.Int64(53),
 		PmSurveySpouseProgearWeightEstimate: swag.Int64(54),
 		PmSurveyNotes:                       swag.String("Unsure about pickup date."),
+		PmSurveyMethod:                      swag.String("PHONE"),
 	}
 
 	params := publicshipmentop.PatchShipmentParams{

--- a/pkg/handlers/shipments_public_test.go
+++ b/pkg/handlers/shipments_public_test.go
@@ -75,7 +75,7 @@ func (suite *HandlerSuite) TestPublicPatchShipmentHandler() {
 		PmSurveyProgearWeightEstimate:       swag.Int64(53),
 		PmSurveySpouseProgearWeightEstimate: swag.Int64(54),
 		PmSurveyNotes:                       swag.String("Unsure about pickup date."),
-		PmSurveyMethod:                      swag.String("PHONE"),
+		PmSurveyMethod:                      "PHONE",
 	}
 
 	params := publicshipmentop.PatchShipmentParams{
@@ -95,7 +95,7 @@ func (suite *HandlerSuite) TestPublicPatchShipmentHandler() {
 	// And: Payload has new values
 	suite.Equal(strfmt.UUID(shipment.ID.String()), okResponse.Payload.ID)
 	suite.Equal(*UpdatePayload.PmSurveyNotes, *okResponse.Payload.PmSurveyNotes)
-	suite.Equal(*UpdatePayload.PmSurveyMethod, *okResponse.Payload.PmSurveyMethod)
+	suite.Equal(UpdatePayload.PmSurveyMethod, okResponse.Payload.PmSurveyMethod)
 	suite.Equal(int64(54), *okResponse.Payload.PmSurveySpouseProgearWeightEstimate)
 	suite.Equal(int64(53), *okResponse.Payload.PmSurveyProgearWeightEstimate)
 	suite.Equal(int64(33), *okResponse.Payload.PmSurveyWeightEstimate)
@@ -129,7 +129,7 @@ func (suite *HandlerSuite) TestPublicPatchShipmentHandlerWrongTSP() {
 		PmSurveyProgearWeightEstimate:       swag.Int64(53),
 		PmSurveySpouseProgearWeightEstimate: swag.Int64(54),
 		PmSurveyNotes:                       swag.String("Unsure about pickup date."),
-		PmSurveyMethod:                      swag.String("PHONE"),
+		PmSurveyMethod:                      "PHONE",
 	}
 
 	params := publicshipmentop.PatchShipmentParams{

--- a/pkg/models/shipment.go
+++ b/pkg/models/shipment.go
@@ -78,7 +78,7 @@ type Shipment struct {
 	PmSurveyProgearWeightEstimate       *unit.Pound              `json:"pm_survey_progear_weight_estimate" db:"pm_survey_progear_weight_estimate"`
 	PmSurveySpouseProgearWeightEstimate *unit.Pound              `json:"pm_survey_spouse_progear_weight_estimate" db:"pm_survey_spouse_progear_weight_estimate"`
 	PmSurveyNotes                       *string                  `json:"pm_survey_notes" db:"pm_survey_notes"`
-	PmSurveyMethod                      *string                  `json:"pm_survey_method" db:"pm_survey_method"`
+	PmSurveyMethod                      string                   `json:"pm_survey_method" db:"pm_survey_method"`
 }
 
 // ShipmentWithOffer represents a single offered shipment within a Service Member's move.

--- a/pkg/models/shipment.go
+++ b/pkg/models/shipment.go
@@ -71,15 +71,14 @@ type Shipment struct {
 	ProgearWeightEstimate               *unit.Pound              `json:"progear_weight_estimate" db:"progear_weight_estimate"`
 	SpouseProgearWeightEstimate         *unit.Pound              `json:"spouse_progear_weight_estimate" db:"spouse_progear_weight_estimate"`
 	ServiceAgents                       ServiceAgents            `has_many:"service_agents" order_by:"created_at desc"`
-	PmSurveyPackDate                    *time.Time               `json:"pm_survey_pack_date" db:"pm_survey_pack_date"`
-	PmSurveyPickupDate                  *time.Time               `json:"pm_survey_pickup_date" db:"pm_survey_pickup_date"`
-	PmSurveyLatestPickupDate            *time.Time               `json:"pm_survey_latest_pickup_date" db:"pm_survey_latest_pickup_date"`
-	PmSurveyEarliestDeliveryDate        *time.Time               `json:"pm_survey_earliest_delivery_date" db:"pm_survey_earliest_delivery_date"`
-	PmSurveyLatestDeliveryDate          *time.Time               `json:"pm_survey_latest_delivery_date" db:"pm_survey_latest_delivery_date"`
+	PmSurveyPlannedPackDate             *time.Time               `json:"pm_survey_planned_pack_date" db:"pm_survey_planned_pack_date"`
+	PmSurveyPlannedPickupDate           *time.Time               `json:"pm_survey_planned_pickup_date" db:"pm_survey_planned_pickup_date"`
+	PmSurveyPlannedDeliveryDate         *time.Time               `json:"pm_survey_planned_delivery_date" db:"pm_survey_planned_delivery_date"`
 	PmSurveyWeightEstimate              *unit.Pound              `json:"pm_survey_weight_estimate" db:"pm_survey_weight_estimate"`
 	PmSurveyProgearWeightEstimate       *unit.Pound              `json:"pm_survey_progear_weight_estimate" db:"pm_survey_progear_weight_estimate"`
 	PmSurveySpouseProgearWeightEstimate *unit.Pound              `json:"pm_survey_spouse_progear_weight_estimate" db:"pm_survey_spouse_progear_weight_estimate"`
 	PmSurveyNotes                       *string                  `json:"pm_survey_notes" db:"pm_survey_notes"`
+	PmSurveyMethod                      *string                  `json:"pm_survey_method" db:"pm_survey_method"`
 }
 
 // ShipmentWithOffer represents a single offered shipment within a Service Member's move.

--- a/pkg/testdatagen/scenario/e2ebasic.go
+++ b/pkg/testdatagen/scenario/e2ebasic.go
@@ -208,14 +208,19 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader) {
 
 	// Service member with uploaded orders and a new shipment move
 	email = "hhg@incomple.te"
+	uuidStr = "ebc176e0-bb34-47d4-ba37-ff13e2dd40b9"
 
-	hhg0 := testdatagen.MakeShipment(db, testdatagen.Assertions{
+	testdatagen.MakeUser(db, testdatagen.Assertions{
 		User: models.User{
-			ID:            uuid.Must(uuid.FromString("ebc176e0-bb34-47d4-ba37-ff13e2dd40b9")),
+			ID:            uuid.Must(uuid.FromString(uuidStr)),
 			LoginGovEmail: email,
 		},
+	})
+
+	hhg0 := testdatagen.MakeShipment(db, testdatagen.Assertions{
 		ServiceMember: models.ServiceMember{
 			ID:            uuid.FromStringOrNil("0d719b18-81d6-474a-86aa-b87246fff65c"),
+			UserID:        uuid.FromStringOrNil("ebc176e0-bb34-47d4-ba37-ff13e2dd40b9"),
 			FirstName:     models.StringPointer("HHG"),
 			LastName:      models.StringPointer("Submitted"),
 			Edipi:         models.StringPointer("4444567890"),
@@ -239,14 +244,19 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader) {
 
 	// Service member with uploaded orders and an approved shipment
 	email = "hhg@award.ed"
+	uuidStr = "7980f0cf-63e3-4722-b5aa-ba46f8f7ac64"
 
-	offer1 := testdatagen.MakeShipmentOffer(db, testdatagen.Assertions{
+	testdatagen.MakeUser(db, testdatagen.Assertions{
 		User: models.User{
-			ID:            uuid.Must(uuid.FromString("7980f0cf-63e3-4722-b5aa-ba46f8f7ac64")),
+			ID:            uuid.Must(uuid.FromString(uuidStr)),
 			LoginGovEmail: email,
 		},
+	})
+
+	offer1 := testdatagen.MakeShipmentOffer(db, testdatagen.Assertions{
 		ServiceMember: models.ServiceMember{
 			ID:            uuid.FromStringOrNil("8a66beef-1cdf-4117-9db2-aad548f54430"),
+			UserID:        uuid.FromStringOrNil("7980f0cf-63e3-4722-b5aa-ba46f8f7ac64"),
 			FirstName:     models.StringPointer("HHG"),
 			LastName:      models.StringPointer("Submitted"),
 			Edipi:         models.StringPointer("4444567890"),

--- a/pkg/testdatagen/scenario/e2ebasic.go
+++ b/pkg/testdatagen/scenario/e2ebasic.go
@@ -208,19 +208,14 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader) {
 
 	// Service member with uploaded orders and a new shipment move
 	email = "hhg@incomple.te"
-	uuidStr = "ebc176e0-bb34-47d4-ba37-ff13e2dd40b9"
-
-	testdatagen.MakeUser(db, testdatagen.Assertions{
-		User: models.User{
-			ID:            uuid.Must(uuid.FromString(uuidStr)),
-			LoginGovEmail: email,
-		},
-	})
 
 	hhg0 := testdatagen.MakeShipment(db, testdatagen.Assertions{
+		User: models.User{
+			ID:            uuid.Must(uuid.FromString("ebc176e0-bb34-47d4-ba37-ff13e2dd40b9")),
+			LoginGovEmail: email,
+		},
 		ServiceMember: models.ServiceMember{
 			ID:            uuid.FromStringOrNil("0d719b18-81d6-474a-86aa-b87246fff65c"),
-			UserID:        uuid.FromStringOrNil("ebc176e0-bb34-47d4-ba37-ff13e2dd40b9"),
 			FirstName:     models.StringPointer("HHG"),
 			LastName:      models.StringPointer("Submitted"),
 			Edipi:         models.StringPointer("4444567890"),
@@ -238,25 +233,21 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader) {
 			CodeOfService:     "D",
 		},
 	})
+
 	hhg0.Move.Submit()
 	// Save move and dependencies
 	models.SaveMoveDependencies(db, hhg0.Move)
 
 	// Service member with uploaded orders and an approved shipment
 	email = "hhg@award.ed"
-	uuidStr = "7980f0cf-63e3-4722-b5aa-ba46f8f7ac64"
-
-	testdatagen.MakeUser(db, testdatagen.Assertions{
-		User: models.User{
-			ID:            uuid.Must(uuid.FromString(uuidStr)),
-			LoginGovEmail: email,
-		},
-	})
 
 	offer1 := testdatagen.MakeShipmentOffer(db, testdatagen.Assertions{
+		User: models.User{
+			ID:            uuid.Must(uuid.FromString("7980f0cf-63e3-4722-b5aa-ba46f8f7ac64")),
+			LoginGovEmail: email,
+		},
 		ServiceMember: models.ServiceMember{
 			ID:            uuid.FromStringOrNil("8a66beef-1cdf-4117-9db2-aad548f54430"),
-			UserID:        uuid.FromStringOrNil("7980f0cf-63e3-4722-b5aa-ba46f8f7ac64"),
 			FirstName:     models.StringPointer("HHG"),
 			LastName:      models.StringPointer("Submitted"),
 			Edipi:         models.StringPointer("4444567890"),
@@ -280,6 +271,7 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader) {
 			TransportationServiceProviderID: tspUser.TransportationServiceProviderID,
 		},
 	})
+
 	hhg1 := offer1.Shipment
 	hhg1.Move.Submit()
 	// Save move and dependencies

--- a/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
+++ b/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
@@ -53,22 +53,23 @@ class ShipmentInfo extends Component {
             </ul>
           </div>
         </div>
-        <div className="office-tab">
-          <PremoveSurvey
-            title="Premove Survey"
-            shipment={this.props.shipment}
-            update={this.props.patchShipment}
-          />
-        </div>
         <div className="usa-grid grid-wide tabs">
-          <div className="usa-width-two-thirds">
+          <div className=" office-tab usa-width-three-fourths">
+            <PremoveSurvey
+              title="Premove Survey"
+              shipment={this.props.shipment}
+              update={this.props.patchShipment}
+            />
+          </div>
+
+          <div className="usa-width-one-fourth">
             <p>
               <button className="usa-button-primary">Accept</button>
               <button className="usa-button-secondary">Reject</button>
             </p>
           </div>
-          <div className="usa-width-one-third" />
         </div>
+        <div className="usa-width-one-third" />
       </div>
     );
   }

--- a/src/shared/EditablePanel/index.jsx
+++ b/src/shared/EditablePanel/index.jsx
@@ -53,7 +53,6 @@ export const PanelSwaggerField = props => {
   const { fieldName, nullWarning, schema, values } = props;
   const title =
     props.title || get(schema, `properties.${fieldName}.title`, fieldName);
-
   let component = (
     <PanelField title={title} className={fieldName}>
       <SwaggerValue {...props} />

--- a/src/shared/JsonSchemaForm/validations.test.js
+++ b/src/shared/JsonSchemaForm/validations.test.js
@@ -55,11 +55,14 @@ describe('SchemaField tests', () => {
         let values = storeData.values;
         let errors = storeData.syncErrors;
 
-        if (expectedValue != null) {
+        if (expectedValue === undefined) {
+          expect(values).toBeUndefined();
+        } else if (expectedValue === null) {
+          expect(values).not.toBeUndefined();
+          expect(values.test_field).toBeNull();
+        } else {
           expect(values).not.toBeUndefined();
           expect(values.test_field).toEqual(expectedValue);
-        } else {
-          expect(values).toBeUndefined();
         }
 
         if (expectedError) {

--- a/src/shared/PremoveSurvey/index.jsx
+++ b/src/shared/PremoveSurvey/index.jsx
@@ -12,15 +12,16 @@ import { SwaggerField } from 'shared/JsonSchemaForm/JsonSchemaField';
 import './index.css';
 
 const surveyFields = [
-  'pm_survey_pack_date',
-  'pm_survey_pickup_date',
+  'pm_survey_planned_pack_date',
+  'pm_survey_planned_pickup_date',
   'pm_survey_latest_pickup_date',
   'pm_survey_earliest_delivery_date',
-  'pm_survey_latest_delivery_date',
+  'pm_survey_planned_delivery_date',
   'pm_survey_weight_estimate',
   'pm_survey_progear_weight_estimate',
   'pm_survey_spouse_progear_weight_estimate',
   'pm_survey_notes',
+  'pm_survey_method',
 ];
 
 const SurveyDisplay = props => {
@@ -33,34 +34,20 @@ const SurveyDisplay = props => {
     <React.Fragment>
       <div className="editable-panel-3-column">
         <PanelSwaggerField
-          title="Pack Date"
-          fieldName="pm_survey_pack_date"
+          title="Planned Pack Date"
+          fieldName="pm_survey_planned_pack_date"
           nullWarning
           {...fieldProps}
         />
         <PanelSwaggerField
-          title="Pickup Date"
-          fieldName="pm_survey_pickup_date"
+          title="Planned Pickup Date"
+          fieldName="pm_survey_planned_pickup_date"
           nullWarning
           {...fieldProps}
         />
         <PanelSwaggerField
-          title="Latest Pickup Date"
-          fieldName="pm_survey_latest_pickup_date"
-          nullWarning
-          {...fieldProps}
-        />
-      </div>
-      <div className="editable-panel-3-column">
-        <PanelSwaggerField
-          title="Earliest Pickup Date"
-          fieldName="pm_survey_earliest_delivery_date"
-          nullWarning
-          {...fieldProps}
-        />
-        <PanelSwaggerField
-          title="Latest Delivery Date"
-          fieldName="pm_survey_latest_delivery_date"
+          title="Planned Delivery Date"
+          fieldName="pm_survey_planned_delivery_date"
           nullWarning
           {...fieldProps}
         />
@@ -85,10 +72,16 @@ const SurveyDisplay = props => {
           {...fieldProps}
         />
       </div>
-      <div className="editable-panel-column">
+      <div className="editable-panel-3-column">
         <PanelSwaggerField
           title="Notes"
           fieldName="pm_survey_notes"
+          nullWarning
+          {...fieldProps}
+        />
+        <PanelSwaggerField
+          title="Method"
+          fieldName="pm_survey_method"
           nullWarning
           {...fieldProps}
         />
@@ -102,65 +95,41 @@ const SurveyEdit = props => {
   return (
     <React.Fragment>
       <FormSection name="survey">
-        <div className="editable-panel-3-column">
+        <div className="editable-panel-column">
           <SwaggerField
-            fieldName="pm_survey_pack_date"
+            fieldName="pm_survey_planned_pack_date"
             swagger={schema}
-            className="half-width"
             required
           />
           <SwaggerField
-            fieldName="pm_survey_pickup_date"
+            fieldName="pm_survey_planned_pickup_date"
             swagger={schema}
-            className="half-width"
             required
           />
           <SwaggerField
-            fieldName="pm_survey_latest_pickup_date"
+            fieldName="pm_survey_planned_delivery_date"
             swagger={schema}
-            className="half-width"
             required
           />
         </div>
 
-        <div className="editable-panel-3-column">
-          <SwaggerField
-            fieldName="pm_survey_earliest_delivery_date"
-            swagger={schema}
-            className="half-width"
-            required
-          />
-          <SwaggerField
-            fieldName="pm_survey_latest_delivery_date"
-            swagger={schema}
-            className="half-width"
-            required
-          />
-        </div>
-
-        <div className="editable-panel-3-column">
+        <div className="editable-panel-column">
           <SwaggerField
             fieldName="pm_survey_weight_estimate"
             swagger={schema}
-            className="half-width"
             required
           />
           <SwaggerField
             fieldName="pm_survey_progear_weight_estimate"
             swagger={schema}
-            className="half-width"
           />
           <SwaggerField
             fieldName="pm_survey_spouse_progear_weight_estimate"
             swagger={schema}
-            className="half-width"
           />
         </div>
-        <SwaggerField
-          fieldName="pm_survey_notes"
-          swagger={schema}
-          className="half-width"
-        />
+        <SwaggerField fieldName="pm_survey_notes" swagger={schema} />
+        <SwaggerField fieldName="pm_survey_method" swagger={schema} />
       </FormSection>
     </React.Fragment>
   );

--- a/src/shared/PremoveSurvey/index.jsx
+++ b/src/shared/PremoveSurvey/index.jsx
@@ -60,7 +60,7 @@ const SurveyDisplay = props => {
         <PanelSwaggerField
           title="Progear Weight Estimate"
           fieldName="pm_survey_progear_weight_estimate"
-          nullWarning
+          nullWarning="false"
           {...fieldProps}
         />
         <PanelSwaggerField
@@ -127,7 +127,7 @@ const SurveyEdit = props => {
           />
         </div>
         <SwaggerField fieldName="pm_survey_notes" swagger={schema} />
-        <SwaggerField fieldName="pm_survey_method" swagger={schema} />
+        <SwaggerField fieldName="pm_survey_method" swagger={schema} required />
       </FormSection>
     </React.Fragment>
   );

--- a/swagger/api.yaml
+++ b/swagger/api.yaml
@@ -495,35 +495,23 @@ definitions:
         example: 200
         x-nullable: true
         x-formatting: weight
-      pm_survey_pack_date:
+      pm_survey_planned_pack_date:
         type: string
         format: date
         example: "2018-04-26"
-        title: "Pack date"
+        title: "Planned pack date"
         x-nullable: true
-      pm_survey_pickup_date:
+      pm_survey_planned_pickup_date:
         type: string
         format: date
         example: "2018-04-26"
-        title: "Pickup date"
+        title: "Planned pickup date"
         x-nullable: true
-      pm_survey_latest_pickup_date:
+      pm_survey_planned_delivery_date:
         type: string
         format: date
         example: "2018-04-26"
-        title: "Latest pickup date"
-        x-nullable: true
-      pm_survey_earliest_delivery_date:
-        type: string
-        format: date
-        example: "2018-04-26"
-        title: "Earliest delivery date"
-        x-nullable: true
-      pm_survey_latest_delivery_date:
-        type: string
-        format: date
-        example: "2018-04-26"
-        title: "Latest delivery date"
+        title: "Planned delivery date"
         x-nullable: true
       pm_survey_weight_estimate:
         type: integer
@@ -551,6 +539,16 @@ definitions:
         example: This document is good to go!
         x-nullable: true
         title: Notes
+      pm_survey_method:
+        type: string
+        enum:
+          - IN_PERSON
+          - PHONE
+          - VIDEO
+        x-display-value:
+          IN_PERSON: In person
+          PHONE: Phone
+          VIDEO: Video
   IndexServiceAgents:
     type: array
     items:

--- a/swagger/api.yaml
+++ b/swagger/api.yaml
@@ -524,14 +524,14 @@ definitions:
         type: integer
         minimum: 0
         example: 10000
-        title: Pro-Gear Weight
+        title: Pro-Gear weight
         x-nullable: true
         x-formatting: weight
       pm_survey_spouse_progear_weight_estimate:
         type: integer
         minimum: 0
         example: 10000
-        title: Spouse's Pro-Gear
+        title: Spouse's pro-gear
         x-nullable: true
         x-formatting: weight
       pm_survey_notes:
@@ -542,6 +542,7 @@ definitions:
       pm_survey_method:
         type: string
         x-nullable: true
+        title: Survey method
         enum:
           - IN_PERSON
           - PHONE

--- a/swagger/api.yaml
+++ b/swagger/api.yaml
@@ -541,7 +541,6 @@ definitions:
         title: Notes
       pm_survey_method:
         type: string
-        x-nullable: true
         title: Survey method
         enum:
           - IN_PERSON

--- a/swagger/api.yaml
+++ b/swagger/api.yaml
@@ -541,7 +541,6 @@ definitions:
         title: Notes
       pm_survey_method:
         type: string
-        title: Survey method
         x-nullable: true
         title: Survey method
         enum:

--- a/swagger/api.yaml
+++ b/swagger/api.yaml
@@ -541,6 +541,7 @@ definitions:
         title: Notes
       pm_survey_method:
         type: string
+        x-nullable: true
         enum:
           - IN_PERSON
           - PHONE

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -1508,23 +1508,23 @@ definitions:
         title: Spouse's Pro-Gear
         x-nullable: true
         x-formatting: weight
-      pm_survey_pack_date:
+      pm_survey_planned_pack_date:
         type: string
         format: date
         example: "2018-04-26"
-        title: "Pack date"
+        title: "Planned pack date"
         x-nullable: true
-      pm_survey_pickup_date:
+      pm_survey_planned_pickup_date:
         type: string
         format: date
         example: "2018-04-26"
-        title: "Pickup date"
+        title: "Planned pickup date"
         x-nullable: true
-      pm_survey_latest_pickup_date:
+      pm_survey_planned_delivery_date:
         type: string
         format: date
         example: "2018-04-26"
-        title: "Latest pickup date"
+        title: "Planned delivery date"
         x-nullable: true
       pm_survey_earliest_delivery_date:
         type: string
@@ -1564,6 +1564,17 @@ definitions:
         example: This document is good to go!
         x-nullable: true
         title: Notes
+      pm_survey_method:
+        type: string
+        x-nullable: true
+        enum:
+          - IN_PERSON
+          - PHONE
+          - VIDEO
+        x-display-value:
+          IN_PERSON: In person
+          PHONE: Phone
+          VIDEO: Video
       created_at:
         type: string
         format: date-time

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -1549,14 +1549,14 @@ definitions:
         type: integer
         minimum: 0
         example: 10000
-        title: Pro-Gear Weight
+        title: Pro-Gear weight
         x-nullable: true
         x-formatting: weight
       pm_survey_spouse_progear_weight_estimate:
         type: integer
         minimum: 0
         example: 10000
-        title: Spouse's Pro-Gear
+        title: Spouse's pro-gear
         x-nullable: true
         x-formatting: weight
       pm_survey_notes:
@@ -1567,6 +1567,7 @@ definitions:
       pm_survey_method:
         type: string
         x-nullable: true
+        title: Survey method
         enum:
           - IN_PERSON
           - PHONE

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -1566,7 +1566,6 @@ definitions:
         title: Notes
       pm_survey_method:
         type: string
-        x-nullable: true
         title: Survey method
         enum:
           - IN_PERSON


### PR DESCRIPTION
## Description

This PR makes the following changes based on this doc from design: https://docs.google.com/spreadsheets/d/1leyc06TJ5nGXKPIZXzZ4xLGIftRWFPr3MSKYfBVRQQ4/edit?usp=sharing

* removes `latest pickup date`
* removes `earliest delivery date`
* changes `latest delivery date` to `planned_delivery_date`
* changes pack_date and pickup_date to be prefixed with "planned"
* adds a field for how the PM survey was conducted - `pm_survey_method`. i.e. In person, over the phone, or video.

## Setup

-populate db with hhg awarded data: `make db_populate_e2e`
-run tsp app, select hhg move info from table - verify the values in the premove survey box match the data. Edit the values, ensure they persist.

## Code Review Verification Steps

* [ ] End to end tests pass (`make e2e_test`).
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/blob/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* [ ] Any migrations/schema changes also update the diagram in docs/schema/dp3.sqs
* [ ] There are no aXe warnings for UI.
* [ ] This works in IE.
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @willowbl00
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/159965926) for this change
* Reference dates doc: https://docs.google.com/spreadsheets/d/1leyc06TJ5nGXKPIZXzZ4xLGIftRWFPr3MSKYfBVRQQ4/edit?usp=sharing

## Screenshots
<img width="1158" alt="screen shot 2018-08-23 at 5 40 11 pm" src="https://user-images.githubusercontent.com/8170735/44558924-a4ff5880-a6fb-11e8-8ac8-78640b7fbccb.png">
<img width="892" alt="screen shot 2018-08-23 at 5 40 21 pm" src="https://user-images.githubusercontent.com/8170735/44558929-a7fa4900-a6fb-11e8-9a10-1bdf2ac25d19.png">
