### PR TITLE
Name the composeEnhancers so they are easier to identify in the redux devtools dropdown

### DIFF
--- a/src/shared/store.js
+++ b/src/shared/store.js
@@ -21,13 +21,15 @@ if (isDevelopment && !window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__) {
   middlewares.push(logger);
 }
 
-const composeEnhancers = composeWithDevTools({});
+const composeEnhancers = composeWithDevTools({ name: 'sm-office' });
 
 export const store = composeEnhancers(applyMiddleware(...middlewares))(
   createStore,
 )(appReducer);
 
-export const tspStore = composeEnhancers(applyMiddleware(...middlewares))(
+const tspComposeEnhancers = composeWithDevTools({ name: 'tsp' });
+
+export const tspStore = tspComposeEnhancers(applyMiddleware(...middlewares))(
   createStore,
 )(tspAppReducer);
 


### PR DESCRIPTION
## Description

Redux DevTools does an autoselect for the redux store to show.  This can be confusing if it picks the wrong one (imagine running the TSP, Office, SM, and Swagger apps at the same time).  This change will make it easier to identify which store you're looking at.

Here's an example of the confusing state where I've got the Office app open but the wrong redux store was selected:

<img width="1225" alt="screen shot 2018-08-27 at 2 16 44 pm" src="https://user-images.githubusercontent.com/219296/44687514-450ff700-aa06-11e8-8f65-23e3446a5b5e.png">

Now you can pick with a more useful name:

<img width="717" alt="screen shot 2018-08-27 at 2 34 45 pm" src="https://user-images.githubusercontent.com/219296/44687555-640e8900-aa06-11e8-8498-db16339d82ab.png">

## Reviewers

I just picked easy names.  I'm open to changing them.