### PR TITLE
Include userAuthMiddleware in TSP API endpoints. 

### DIFF
--- a/cmd/webserver/main.go
+++ b/cmd/webserver/main.go
@@ -282,6 +282,7 @@ func main() {
 	externalAPIMux := goji.SubMux()
 	apiMux.Handle(pat.New("/*"), externalAPIMux)
 	externalAPIMux.Use(noCacheMiddleware)
+	externalAPIMux.Use(userAuthMiddleware)
 	externalAPIMux.Handle(pat.New("/*"), publicapi.NewPublicAPIHandler(handlerContext))
 
 	internalMux := goji.SubMux()

--- a/pkg/handlers/publicapi/service_agents.go
+++ b/pkg/handlers/publicapi/service_agents.go
@@ -41,13 +41,6 @@ func (h CreateServiceAgentHandler) Handle(params serviceagentop.CreateServiceAge
 
 	shipmentID, _ := uuid.FromString(params.ShipmentID.String())
 
-	// Possible they are coming from the wrong endpoint and thus the session is missing the
-	// TspUserID
-	if session.TspUserID == uuid.Nil {
-		h.Logger().Error("Missing TSP User ID")
-		return serviceagentop.NewCreateServiceAgentForbidden()
-	}
-
 	// TODO (rebecca): Find a way to check Shipment belongs to TSP without 2 queries
 	tspUser, err := models.FetchTspUserByID(h.DB(), session.TspUserID)
 	if err != nil {

--- a/pkg/handlers/publicapi/shipments.go
+++ b/pkg/handlers/publicapi/shipments.go
@@ -64,13 +64,6 @@ func (h IndexShipmentsHandler) Handle(params shipmentop.IndexShipmentsParams) mi
 
 	session := auth.SessionFromRequestContext(params.HTTPRequest)
 
-	// Possible they are coming from the wrong endpoint and thus the session is missing the
-	// TspUserID
-	if session.TspUserID == uuid.Nil {
-		h.Logger().Error("Missing TSP User ID")
-		return shipmentop.NewIndexShipmentsForbidden()
-	}
-
 	// TODO: (cgilmer 2018_07_25) This is an extra query we don't need to run on every request. Put the
 	// TransportationServiceProviderID into the session object after refactoring the session code to be more readable.
 	// See original commits in https://github.com/transcom/mymove/pull/802
@@ -105,13 +98,6 @@ func (h GetShipmentHandler) Handle(params shipmentop.GetShipmentParams) middlewa
 	session := auth.SessionFromRequestContext(params.HTTPRequest)
 
 	shipmentID, _ := uuid.FromString(params.ShipmentUUID.String())
-
-	// Possible they are coming from the wrong endpoint and thus the session is missing the
-	// TspUserID
-	if session.TspUserID == uuid.Nil {
-		h.Logger().Error("Missing TSP User ID")
-		return shipmentop.NewGetShipmentForbidden()
-	}
 
 	// TODO: (cgilmer 2018_07_25) This is an extra query we don't need to run on every request. Put the
 	// TransportationServiceProviderID into the session object after refactoring the session code to be more readable.
@@ -181,13 +167,6 @@ func (h PatchShipmentHandler) Handle(params shipmentop.PatchShipmentParams) midd
 	session := auth.SessionFromRequestContext(params.HTTPRequest)
 
 	shipmentID, _ := uuid.FromString(params.ShipmentUUID.String())
-
-	// Possible they are coming from the wrong endpoint and thus the session is missing the
-	// TspUserID
-	if session.TspUserID == uuid.Nil {
-		h.Logger().Error("Missing TSP User ID")
-		return shipmentop.NewGetShipmentForbidden()
-	}
 
 	tspUser, err := models.FetchTspUserByID(h.DB(), session.TspUserID)
 	if err != nil {


### PR DESCRIPTION
## Description

All the endpoints in the public API have to-date included some check for the TSP user ID.  However, the `userAuthMiddleware` handles this for us.  Also, none of the public endpoints should work without being logged in AND this is a safer way to ensure it.

## Reviewer Notes

We don't currently have an public API endpoints that should work without auth.  But if that day comes we'll need to update this.

## Setup

There should be no difference between endpoints before and after this change.

## Code Review Verification Steps

* [x] Request review from a member of a different team.