### PR TITLE
Added code_of_service field back to shipments table to avoid prod downtime

### DIFF
--- a/migrations/20180827205523_add_code_of_service_to_shipments.up.fizz
+++ b/migrations/20180827205523_add_code_of_service_to_shipments.up.fizz
@@ -1,0 +1,1 @@
+add_column("shipments", "code_of_service", "string", {"null": true})


### PR DESCRIPTION
Added code_of_service field back to shipments table to avoid prod downtime (will be removed after next deploy)

## Description

We experienced some temporary downtime on the staging server when #918 was merged into master and subsequently deployed.  As part of the same deploy to staging, a column was dropped in a migration, followed by pushing the new code which removes references to that column.  So, there was a small period of time where the old code was still in place and referencing the now removed column, causing temporary errors.

This PR puts the column in question (shipments.code_of_service) back temporarily so the next production deploy won't cause any downtime.  After we deploy, we can then do another PR to remove shipments.code_of_service again -- then, we shouldn't experience any downtime at all in production since the code will have previously been adjusted to not reference the dropped column.

## Reviewer Notes

NOTE: I have not changed the dp3.sqs file on purpose since this is just a temporary "revert".  The dp3.sqs file is correct for the final desired state.

## Code Review Verification Steps

* [ ] End to end tests pass (`make e2e_test`).
* [ ] Request review from a member of a different team.
