### PR TITLE
Add application and session id fields to honeycomb

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -153,7 +153,7 @@ server_test_coverage: server_deps server_generate db_dev_run db_test_reset
 	go test -coverprofile=coverage.out -p 1 -count 1 $$(go list ./... | grep -v \\/pkg\\/gen\\/ | grep -v \\/cmd\\/)
 	go tool cover -html=coverage.out
 
-e2e_test: server_deps server_generate client_build db_e2e_init
+e2e_test: server_build client_build db_e2e_init
 	$(AWS_VAULT) ./bin/run-e2e-test
 
 db_populate_e2e: db_dev_reset db_dev_migrate tools_build

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ The client application (i.e. website) makes outbound requests to the following d
 
 * S3 for document downloads; exact domains TBD.
 * New Relic for browser performance monitoring; specifically `bam.nr-data.net` and `js-agent.newrelic.*`. [More info and IPs are listed here](https://docs.newrelic.com/docs/apm/new-relic-apm/getting-started/networks#agents).
-* Honeycomb for server-side debugging and observability. Currently being testing in staging and experimental environments.
+* Honeycomb for server-side debugging and observability. Currently being tested in staging and experimental environments.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ The client application (i.e. website) makes outbound requests to the following d
 
 * S3 for document downloads; exact domains TBD.
 * New Relic for browser performance monitoring; specifically `bam.nr-data.net` and `js-agent.newrelic.*`. [More info and IPs are listed here](https://docs.newrelic.com/docs/apm/new-relic-apm/getting-started/networks#agents).
+* Honeycomb for server-side debugging and observability. Currently being testing in staging and experimental environments.
 
 ## Development
 

--- a/pkg/auth/app_detector.go
+++ b/pkg/auth/app_detector.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/honeycombio/beeline-go"
 	"go.uber.org/zap"
 )
 
@@ -54,6 +55,7 @@ func DetectorMiddleware(logger *zap.Logger, myHostname string, officeHostname st
 			}
 			session.ApplicationName = appName
 			session.Hostname = strings.ToLower(parts[0])
+			beeline.AddField(r.Context(), "application_name", appName)
 			next.ServeHTTP(w, r)
 			return
 		}


### PR DESCRIPTION
## Description

This PR will add some application specific fields to Honeycomb, which will allow us to query requests based on any combination of
* application_name (e.g., MY, OFFICE, TSP)
* user_id
* service_member_id
* office_user_id
* tsp_user_id

I added the ids to `UserAuthMiddleware` and the `AuthorizationCallbackHandler` and the application_name to `DetectorMiddleware`.

## Setup
To test this locally, define environment variables in your `.envrc.local`

```shell
export HONEYCOMB_ENABLED=true                                                                                                                                                                              
export HONEYCOMB_DATASET=app-devlocal                                                                                                                                                                      
export HONEYCOMB_API_KEY=<ask-me>
```

## Code Review Verification Steps

* [x] End to end tests pass (`make e2e_test`).
* [x] Request review from a member of a different team.

