### PR TITLE
Added additional fields for orders

### DIFF
--- a/docs/schema/dp3.sqs
+++ b/docs/schema/dp3.sqs
@@ -4,12 +4,12 @@
         <name><![CDATA[public.orders]]></name>
         <schema><![CDATA[public]]></schema>
         <location>
-            <x>1030.00</x>
+            <x>1028.00</x>
             <y>3.00</y>
         </location>
         <size>
-            <width>300.00</width>
-            <height>320.00</height>
+            <width>299.00</width>
+            <height>400.00</height>
         </size>
         <zorder>19</zorder>
         <SQLField>
@@ -128,6 +128,26 @@
             <name><![CDATA[status]]></name>
             <type><![CDATA[TEXT]]></type>
             <uid><![CDATA[481E6D30-CC47-4D2B-9D37-7FFAEFAE015E]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[sac]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <uid><![CDATA[414812BD-A037-4183-8066-6644B752F0E6]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[orders_issuing_agency]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <uid><![CDATA[376E56EC-C484-43C5-BDEF-8136F701EA32]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[paragraph_number]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <uid><![CDATA[5E796488-DAE5-4B48-9766-396342B13FB9]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[tac]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <uid><![CDATA[68A4A79B-0C75-4251-97FA-25DB8F9FE286]]></uid>
         </SQLField>
         <labelWindowIndex><![CDATA[28]]></labelWindowIndex>
         <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
@@ -3186,11 +3206,11 @@
         <SourceSidebarWidth><![CDATA[312.000000]]></SourceSidebarWidth>
         <SQLEditorFileFormatVersion><![CDATA[4]]></SQLEditorFileFormatVersion>
         <uid><![CDATA[2D9326C9-9311-4608-922D-10EEAD4704B1]]></uid>
-        <windowHeight><![CDATA[835.000000]]></windowHeight>
-        <windowLocationX><![CDATA[2.000000]]></windowLocationX>
-        <windowLocationY><![CDATA[42.000000]]></windowLocationY>
-        <windowScrollOrigin><![CDATA[{444, 1190.5}]]></windowScrollOrigin>
-        <windowWidth><![CDATA[1440.000000]]></windowWidth>
+        <windowHeight><![CDATA[947.000000]]></windowHeight>
+        <windowLocationX><![CDATA[0.000000]]></windowLocationX>
+        <windowLocationY><![CDATA[80.000000]]></windowLocationY>
+        <windowScrollOrigin><![CDATA[{654, 0}]]></windowScrollOrigin>
+        <windowWidth><![CDATA[1680.000000]]></windowWidth>
     </SQLDocumentInfo>
     <AllowsIndexRenamingOnInsert><![CDATA[1]]></AllowsIndexRenamingOnInsert>
     <defaultLabelExpanded><![CDATA[1]]></defaultLabelExpanded>

--- a/migrations/20180827182555_add_gbl_fields_to_orders.down.fizz
+++ b/migrations/20180827182555_add_gbl_fields_to_orders.down.fizz
@@ -1,0 +1,3 @@
+drop_column("orders", "orders_issuing_agency")
+drop_column("orders", "paragraph_number")
+drop_column("orders", "sac")

--- a/migrations/20180827182555_add_gbl_fields_to_orders.up.fizz
+++ b/migrations/20180827182555_add_gbl_fields_to_orders.up.fizz
@@ -1,0 +1,3 @@
+add_column("orders", "orders_issuing_agency", "text", {"null": true})
+add_column("orders", "paragraph_number", "text", {"null": true})
+add_column("orders", "sac", "text", {"null": true})

--- a/pkg/handlers/orders.go
+++ b/pkg/handlers/orders.go
@@ -41,8 +41,11 @@ func payloadForOrdersModel(storer storage.FileStorer, order models.Order) (*inte
 		SpouseHasProGear:    fmtBool(order.SpouseHasProGear),
 		UploadedOrders:      documentPayload,
 		OrdersNumber:        order.OrdersNumber,
+		ParagraphNumber:     order.ParagraphNumber,
+		OrdersIssuingAgency: order.OrdersIssuingAgency,
 		Moves:               moves,
 		Tac:                 order.TAC,
+		Sac:                 order.SAC,
 		DepartmentIndicator: (*internalmessages.DeptIndicator)(order.DepartmentIndicator),
 		Status:              internalmessages.OrdersStatus(order.Status),
 	}
@@ -151,6 +154,8 @@ func (h UpdateOrdersHandler) Handle(params ordersop.UpdateOrdersParams) middlewa
 	}
 
 	order.OrdersNumber = payload.OrdersNumber
+	order.ParagraphNumber = payload.ParagraphNumber
+	order.OrdersIssuingAgency = payload.OrdersIssuingAgency
 	order.IssueDate = time.Time(*payload.IssueDate)
 	order.ReportByDate = time.Time(*payload.ReportByDate)
 	order.OrdersType = payload.OrdersType
@@ -160,6 +165,7 @@ func (h UpdateOrdersHandler) Handle(params ordersop.UpdateOrdersParams) middlewa
 	order.NewDutyStationID = dutyStation.ID
 	order.NewDutyStation = dutyStation
 	order.TAC = payload.Tac
+	order.SAC = payload.Sac
 
 	if payload.DepartmentIndicator != nil {
 		order.DepartmentIndicator = fmtString(string(*payload.DepartmentIndicator))

--- a/pkg/models/order.go
+++ b/pkg/models/order.go
@@ -48,9 +48,12 @@ type Order struct {
 	UploadedOrders      Document                           `belongs_to:"documents"`
 	UploadedOrdersID    uuid.UUID                          `json:"uploaded_orders_id" db:"uploaded_orders_id"`
 	OrdersNumber        *string                            `json:"orders_number" db:"orders_number"`
+	ParagraphNumber     *string                            `json:"paragraph_number" db:"paragraph_number"`
+	OrdersIssuingAgency *string                            `json:"orders_issuing_agency" db:"orders_issuing_agency"`
 	Moves               Moves                              `has_many:"moves" fk_id:"orders_id" order_by:"created_at desc"`
 	Status              OrderStatus                        `json:"status" db:"status"`
 	TAC                 *string                            `json:"tac" db:"tac"`
+	SAC                 *string                            `json:"sac" db:"sac"`
 	DepartmentIndicator *string                            `json:"department_indicator" db:"department_indicator"`
 }
 
@@ -68,6 +71,9 @@ func (o *Order) Validate(tx *pop.Connection) (*validate.Errors, error) {
 		&validators.UUIDIsPresent{Field: o.NewDutyStationID, Name: "NewDutyStationID"},
 		&validators.StringIsPresent{Field: string(o.Status), Name: "Status"},
 		&StringIsNilOrNotBlank{Field: o.TAC, Name: "Transportation Accounting Code"},
+		&StringIsNilOrNotBlank{Field: o.SAC, Name: "Something Accounting Code"},
+		&StringIsNilOrNotBlank{Field: o.OrdersIssuingAgency, Name: "Orders Issuing Agency"},
+		&StringIsNilOrNotBlank{Field: o.ParagraphNumber, Name: "Paragraph Number"},
 		&StringIsNilOrNotBlank{Field: o.DepartmentIndicator, Name: "Department Indicator"},
 		&CannotBeTrueIfFalse{Field1: o.SpouseHasProGear, Name1: "SpouseHasProGear", Field2: o.HasDependents, Name2: "HasDependents"},
 	), nil

--- a/pkg/models/order_test.go
+++ b/pkg/models/order_test.go
@@ -44,6 +44,12 @@ func (suite *ModelSuite) TestFetchOrderForUser() {
 	deptIndicator := testdatagen.DefaultDepartmentIndicator
 	TAC := testdatagen.DefaultTransportationAccountingCode
 	suite.mustSave(&uploadedOrder)
+
+	SAC := "N002214CSW32Y9"
+	ordersNumber := "FD4534JFJ"
+	paragraphNumber := "djfklda;ej"
+	ordersIssuingAgency := "SOMETHING AGENCY"
+
 	order := Order{
 		ServiceMemberID:     serviceMember1.ID,
 		ServiceMember:       serviceMember1,
@@ -57,7 +63,11 @@ func (suite *ModelSuite) TestFetchOrderForUser() {
 		UploadedOrdersID:    uploadedOrder.ID,
 		UploadedOrders:      uploadedOrder,
 		Status:              OrderStatusSUBMITTED,
+		OrdersNumber:        &ordersNumber,
+		ParagraphNumber:     &paragraphNumber,
+		OrdersIssuingAgency: &ordersIssuingAgency,
 		TAC:                 &TAC,
+		SAC:                 &SAC,
 		DepartmentIndicator: &deptIndicator,
 	}
 	suite.mustSave(&order)

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -1868,6 +1868,14 @@ definitions:
         title: Orders Number
         x-nullable: true
         example: "030-00362"
+      paragraph_number:
+        type: string
+        title: Paragraph Number
+        x-nullable: true
+      orders_issuing_agency:
+        type: string
+        title: Orders Issuing Agency
+        x-nullable: true
       created_at:
         type: string
         format: date-time
@@ -1876,7 +1884,13 @@ definitions:
         format: date-time
       tac:
         type: string
+        title: TAC
         example: "F8J1"
+        x-nullable: true
+      sac:
+        type: string
+        title: SAC
+        example: "N002214CSW32Y9"
         x-nullable: true
       department_indicator:
         $ref: '#/definitions/DeptIndicator'
@@ -1934,9 +1948,23 @@ definitions:
         title: Orders Number
         x-nullable: true
         example: "030-00362"
+      paragraph_number:
+        type: string
+        title: Paragraph Number
+        x-nullable: true
+      orders_issuing_agency:
+        type: string
+        title: Orders Issuing Agency
+        x-nullable: true
       tac:
         type: string
+        title: TAC
         example: "F8J1"
+        x-nullable: true
+      sac:
+        type: string
+        title: SAC
+        example: "N002214CSW32Y9"
         x-nullable: true
       department_indicator:
         $ref: '#/definitions/DeptIndicator'


### PR DESCRIPTION
## Description

Added additional fields for the order.
Fields added:
- orders_issuing_agency
- paragraph_number
- sac

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make db_dev_migrate
```

## Code Review Verification Steps

* [ ] End to end tests pass (`make e2e_test`).
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/blob/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* [ ] Any migrations/schema changes also update the diagram in docs/schema/dp3.sqs
* [ ] There are no aXe warnings for UI.
* [ ] This works in IE.
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @willowbl00
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/160069609) for this change