### PR TITLE
Dropping code_of_service field from shipments table again

### DIFF
--- a/migrations/20180828142819_drop_code_of_service_from_shipments.up.fizz
+++ b/migrations/20180828142819_drop_code_of_service_from_shipments.up.fizz
@@ -1,0 +1,1 @@
+drop_column("shipments", "code_of_service")


### PR DESCRIPTION
Dropping code_of_service field from shipments table again (part of attempt to avoid prod downtime)

## Description

See #927.  This is part 2 of a fix to avoid production downtime.  This PR needed to come after a production deploy took place that contained #927 (which did happen last night).


## Reviewer Notes

NOTE: I have not changed the dp3.sqs file -- it was already updated along with the previous column drop in #918.


## Code Review Verification Steps

* [ ] End to end tests pass (`make e2e_test`).
* [ ] Request review from a member of a different team.
