### PR TITLE
Allow Move Documents to be toggled back and forth between OK and HAS_ISSUE states.

### DIFF
--- a/pkg/handlers/internalapi/move_documents.go
+++ b/pkg/handlers/internalapi/move_documents.go
@@ -156,9 +156,14 @@ func (h UpdateMoveDocumentHandler) Handle(params movedocop.UpdateMoveDocumentPar
 			}
 
 			ppm := &moveDoc.PersonallyProcuredMove
-			err := ppm.Complete()
-			if err != nil {
-				return handlers.ResponseForError(h.Logger(), err)
+			// If the status has already been completed
+			// (because the document has been toggled between OK and HAS_ISSUE and back)
+			// then don't complete it again.
+			if ppm.Status != models.PPMStatusCOMPLETED {
+				err := ppm.Complete()
+				if err != nil {
+					return handlers.ResponseForError(h.Logger(), err)
+				}
 			}
 		}
 	}

--- a/pkg/models/move_document.go
+++ b/pkg/models/move_document.go
@@ -105,7 +105,7 @@ func (m *MoveDocument) AttemptTransition(targetStatus MoveDocumentStatus) error 
 
 // Approve marks the Document as OK
 func (m *MoveDocument) Approve() error {
-	if m.Status != MoveDocumentStatusAWAITINGREVIEW {
+	if m.Status == MoveDocumentStatusOK {
 		return errors.Wrap(ErrInvalidTransition, "Approve")
 	}
 
@@ -115,7 +115,7 @@ func (m *MoveDocument) Approve() error {
 
 // Reject marks the Document as HAS_ISSUE
 func (m *MoveDocument) Reject() error {
-	if m.Status != MoveDocumentStatusAWAITINGREVIEW {
+	if m.Status == MoveDocumentStatusHASISSUE {
 		return errors.Wrap(ErrInvalidTransition, "Reject")
 	}
 


### PR DESCRIPTION
## Description

Previously it was not allowed to change a document's status once it was in HAS_ISSUE or OK, now it is allowed to switch back and forth. 

## Reviewer Notes

I'm still disallowing the OK/HAS_ISSUE -> AWAITING_REVIEW transition, not sure if that's right or not. 

## Code Review Verification Steps

* [ ] End to end tests pass (`make e2e_test`).
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/blob/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* [ ] Any migrations/schema changes also update the diagram in docs/schema/dp3.sqs
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/159859804) for this change