### PR TITLE
Quiet the output of swagger generate server in our build script

### DIFF
--- a/bin/gen_server.sh
+++ b/bin/gen_server.sh
@@ -6,6 +6,6 @@ gendir=./pkg/gen
 
 rm -rf $gendir
 mkdir -p $gendir
-./bin/swagger generate server -f swagger/internal.yaml -t $gendir --model-package internalmessages --server-package internalapi --api-package internaloperations --exclude-main -A mymove
-./bin/swagger generate server -f swagger/api.yaml -t $gendir --model-package apimessages --server-package restapi --api-package apioperations --exclude-main -A mymove
-./bin/swagger generate server -f swagger/orders.yaml -t $gendir --model-package ordersmessages --server-package ordersapi --api-package ordersoperations --exclude-main -A mymove
+./bin/swagger generate server -q -f swagger/internal.yaml -t $gendir --model-package internalmessages --server-package internalapi --api-package internaloperations --exclude-main -A mymove
+./bin/swagger generate server -q -f swagger/api.yaml -t $gendir --model-package apimessages --server-package restapi --api-package apioperations --exclude-main -A mymove
+./bin/swagger generate server -q -f swagger/orders.yaml -t $gendir --model-package ordersmessages --server-package ordersapi --api-package ordersoperations --exclude-main -A mymove


### PR DESCRIPTION
## Description

The `./bin/gen_server.sh` script has a ton of output.  This has only increased since adding the public and orders APIs.  The change here silences the output but does not prevent errors from printing.  Here's an example of the output when there is an error:

<img width="1110" alt="screen shot 2018-08-28 at 1 06 13 pm" src="https://user-images.githubusercontent.com/219296/44748162-ed37c580-aac3-11e8-849a-390c5197980a.png">

This should also significantly reduce the output we see in CircleCI and when we build docker images.