### PR TITLE
Rename public api fields from _uuid to _id to be consistent with internal API

### DIFF
--- a/pkg/handlers/publicapi/documents.go
+++ b/pkg/handlers/publicapi/documents.go
@@ -7,7 +7,7 @@ import (
 	"github.com/transcom/mymove/pkg/handlers"
 )
 
-// CreateDocumentUploadHandler creates a new document upload via POST /document/{document_id}/uploads
+// CreateDocumentUploadHandler creates a new document upload via POST /document/{documentId}/uploads
 type CreateDocumentUploadHandler struct {
 	handlers.HandlerContext
 }

--- a/pkg/handlers/publicapi/documents.go
+++ b/pkg/handlers/publicapi/documents.go
@@ -7,7 +7,7 @@ import (
 	"github.com/transcom/mymove/pkg/handlers"
 )
 
-// CreateDocumentUploadHandler creates a new document upload via POST /document/{document_uuid}/uploads
+// CreateDocumentUploadHandler creates a new document upload via POST /document/{document_id}/uploads
 type CreateDocumentUploadHandler struct {
 	handlers.HandlerContext
 }

--- a/pkg/handlers/publicapi/documents.go
+++ b/pkg/handlers/publicapi/documents.go
@@ -7,7 +7,7 @@ import (
 	"github.com/transcom/mymove/pkg/handlers"
 )
 
-// CreateDocumentUploadHandler creates a new document upload via POST /document/{documentId}/uploads
+// CreateDocumentUploadHandler creates a new document upload
 type CreateDocumentUploadHandler struct {
 	handlers.HandlerContext
 }

--- a/pkg/handlers/publicapi/service_agents_test.go
+++ b/pkg/handlers/publicapi/service_agents_test.go
@@ -109,7 +109,7 @@ func (suite *HandlerSuite) TestPatchServiceAgentHandler() {
 	serviceAgent := serviceAgents[0]
 
 	// And: the context contains the auth values
-	req := httptest.NewRequest("PATCH", "/shipments/shipmentId/service_agents/service_agentsId", nil)
+	req := httptest.NewRequest("PATCH", "/shipments/shipmentId/service_agents/serviceAgentsId", nil)
 	req = suite.AuthenticateTspRequest(req, tspUser)
 
 	UpdatePayload := apimessages.ServiceAgent{
@@ -156,7 +156,7 @@ func (suite *HandlerSuite) TestPatchServiceAgentHandlerOnlyPOC() {
 	serviceAgent := serviceAgents[0]
 
 	// And: the context contains the auth values
-	req := httptest.NewRequest("PATCH", "/shipments/shipmentId/service_agents/service_agentsId", nil)
+	req := httptest.NewRequest("PATCH", "/shipments/shipmentId/service_agents/serviceAgentsId", nil)
 	req = suite.AuthenticateTspRequest(req, tspUser)
 
 	UpdatePayload := apimessages.ServiceAgent{
@@ -200,7 +200,7 @@ func (suite *HandlerSuite) TestPatchServiceAgentHandlerOnlyEmail() {
 	serviceAgent := serviceAgents[0]
 
 	// And: the context contains the auth values
-	req := httptest.NewRequest("PATCH", "/shipments/shipmentId/service_agents/service_agentsId", nil)
+	req := httptest.NewRequest("PATCH", "/shipments/shipmentId/service_agents/serviceAgentsId", nil)
 	req = suite.AuthenticateTspRequest(req, tspUser)
 
 	UpdatePayload := apimessages.ServiceAgent{
@@ -244,7 +244,7 @@ func (suite *HandlerSuite) TestPatchServiceAgentHandlerOnlyPhoneNumber() {
 	serviceAgent := serviceAgents[0]
 
 	// And: the context contains the auth values
-	req := httptest.NewRequest("PATCH", "/shipments/shipmentId/service_agents/service_agentsId", nil)
+	req := httptest.NewRequest("PATCH", "/shipments/shipmentId/service_agents/serviceAgentsId", nil)
 	req = suite.AuthenticateTspRequest(req, tspUser)
 
 	UpdatePayload := apimessages.ServiceAgent{
@@ -288,7 +288,7 @@ func (suite *HandlerSuite) TestPatchServiceAgentHandlerOnlyNotes() {
 	serviceAgent := serviceAgents[0]
 
 	// And: the context contains the auth values
-	req := httptest.NewRequest("PATCH", "/shipments/shipmentId/service_agents/service_agentsId", nil)
+	req := httptest.NewRequest("PATCH", "/shipments/shipmentId/service_agents/serviceAgentsId", nil)
 	req = suite.AuthenticateTspRequest(req, tspUser)
 
 	UpdatePayload := apimessages.ServiceAgent{
@@ -334,7 +334,7 @@ func (suite *HandlerSuite) TestPatchServiceAgentHandlerWrongTSP() {
 	otherTspUser := testdatagen.MakeDefaultTspUser(suite.TestDB())
 
 	// And: the context contains the auth values
-	req := httptest.NewRequest("PATCH", "/shipments/shipmentId/service_agents/service_agentsId", nil)
+	req := httptest.NewRequest("PATCH", "/shipments/shipmentId/service_agents/serviceAgentsId", nil)
 	req = suite.AuthenticateTspRequest(req, otherTspUser)
 
 	UpdatePayload := apimessages.ServiceAgent{

--- a/pkg/handlers/publicapi/service_agents_test.go
+++ b/pkg/handlers/publicapi/service_agents_test.go
@@ -55,7 +55,8 @@ func (suite *HandlerSuite) TestCreateServiceAgentHandlerAllValues() {
 	shipment := shipments[0]
 
 	// And: the context contains the auth values
-	req := httptest.NewRequest("POST", "/shipments/shipment_id/service_agents", nil)
+	path := fmt.Sprintf("/shipments/%s/service_agents", shipment.ID.String())
+	req := httptest.NewRequest("POST", path, nil)
 	req = suite.AuthenticateTspRequest(req, tspUser)
 
 	pointOfContact := "Pete and Repeat"

--- a/pkg/handlers/publicapi/service_agents_test.go
+++ b/pkg/handlers/publicapi/service_agents_test.go
@@ -109,7 +109,7 @@ func (suite *HandlerSuite) TestPatchServiceAgentHandler() {
 	serviceAgent := serviceAgents[0]
 
 	// And: the context contains the auth values
-	req := httptest.NewRequest("PATCH", "/shipments/shipment_id/service_agents/service_agents_id", nil)
+	req := httptest.NewRequest("PATCH", "/shipments/shipmentId/service_agents/service_agentsId", nil)
 	req = suite.AuthenticateTspRequest(req, tspUser)
 
 	UpdatePayload := apimessages.ServiceAgent{
@@ -156,7 +156,7 @@ func (suite *HandlerSuite) TestPatchServiceAgentHandlerOnlyPOC() {
 	serviceAgent := serviceAgents[0]
 
 	// And: the context contains the auth values
-	req := httptest.NewRequest("PATCH", "/shipments/shipment_id/service_agents/service_agents_id", nil)
+	req := httptest.NewRequest("PATCH", "/shipments/shipmentId/service_agents/service_agentsId", nil)
 	req = suite.AuthenticateTspRequest(req, tspUser)
 
 	UpdatePayload := apimessages.ServiceAgent{
@@ -200,7 +200,7 @@ func (suite *HandlerSuite) TestPatchServiceAgentHandlerOnlyEmail() {
 	serviceAgent := serviceAgents[0]
 
 	// And: the context contains the auth values
-	req := httptest.NewRequest("PATCH", "/shipments/shipment_id/service_agents/service_agents_id", nil)
+	req := httptest.NewRequest("PATCH", "/shipments/shipmentId/service_agents/service_agentsId", nil)
 	req = suite.AuthenticateTspRequest(req, tspUser)
 
 	UpdatePayload := apimessages.ServiceAgent{
@@ -244,7 +244,7 @@ func (suite *HandlerSuite) TestPatchServiceAgentHandlerOnlyPhoneNumber() {
 	serviceAgent := serviceAgents[0]
 
 	// And: the context contains the auth values
-	req := httptest.NewRequest("PATCH", "/shipments/shipment_id/service_agents/service_agents_id", nil)
+	req := httptest.NewRequest("PATCH", "/shipments/shipmentId/service_agents/service_agentsId", nil)
 	req = suite.AuthenticateTspRequest(req, tspUser)
 
 	UpdatePayload := apimessages.ServiceAgent{
@@ -288,7 +288,7 @@ func (suite *HandlerSuite) TestPatchServiceAgentHandlerOnlyNotes() {
 	serviceAgent := serviceAgents[0]
 
 	// And: the context contains the auth values
-	req := httptest.NewRequest("PATCH", "/shipments/shipment_id/service_agents/service_agents_id", nil)
+	req := httptest.NewRequest("PATCH", "/shipments/shipmentId/service_agents/service_agentsId", nil)
 	req = suite.AuthenticateTspRequest(req, tspUser)
 
 	UpdatePayload := apimessages.ServiceAgent{
@@ -334,7 +334,7 @@ func (suite *HandlerSuite) TestPatchServiceAgentHandlerWrongTSP() {
 	otherTspUser := testdatagen.MakeDefaultTspUser(suite.TestDB())
 
 	// And: the context contains the auth values
-	req := httptest.NewRequest("PATCH", "/shipments/shipment_id/service_agents/service_agents_id", nil)
+	req := httptest.NewRequest("PATCH", "/shipments/shipmentId/service_agents/service_agentsId", nil)
 	req = suite.AuthenticateTspRequest(req, otherTspUser)
 
 	UpdatePayload := apimessages.ServiceAgent{

--- a/pkg/handlers/publicapi/shipments.go
+++ b/pkg/handlers/publicapi/shipments.go
@@ -97,7 +97,7 @@ func (h GetShipmentHandler) Handle(params shipmentop.GetShipmentParams) middlewa
 
 	session := auth.SessionFromRequestContext(params.HTTPRequest)
 
-	shipmentID, _ := uuid.FromString(params.ShipmentUUID.String())
+	shipmentID, _ := uuid.FromString(params.ShipmentID.String())
 
 	// TODO: (cgilmer 2018_07_25) This is an extra query we don't need to run on every request. Put the
 	// TransportationServiceProviderID into the session object after refactoring the session code to be more readable.
@@ -196,7 +196,7 @@ func (h PatchShipmentHandler) Handle(params shipmentop.PatchShipmentParams) midd
 
 	session := auth.SessionFromRequestContext(params.HTTPRequest)
 
-	shipmentID, _ := uuid.FromString(params.ShipmentUUID.String())
+	shipmentID, _ := uuid.FromString(params.ShipmentID.String())
 
 	tspUser, err := models.FetchTspUserByID(h.DB(), session.TspUserID)
 	if err != nil {

--- a/pkg/handlers/publicapi/shipments_test.go
+++ b/pkg/handlers/publicapi/shipments_test.go
@@ -31,8 +31,8 @@ func (suite *HandlerSuite) TestGetShipmentHandler() {
 	req = suite.AuthenticateTspRequest(req, tspUser)
 
 	params := shipmentop.GetShipmentParams{
-		HTTPRequest:  req,
-		ShipmentUUID: strfmt.UUID(shipment.ID.String()),
+		HTTPRequest: req,
+		ShipmentID:  strfmt.UUID(shipment.ID.String()),
 	}
 
 	// And: get shipment is returned
@@ -75,9 +75,9 @@ func (suite *HandlerSuite) TestPatchShipmentHandler() {
 	}
 
 	params := shipmentop.PatchShipmentParams{
-		HTTPRequest:  req,
-		ShipmentUUID: strfmt.UUID(shipment.ID.String()),
-		Update:       &UpdatePayload,
+		HTTPRequest: req,
+		ShipmentID:  strfmt.UUID(shipment.ID.String()),
+		Update:      &UpdatePayload,
 	}
 
 	// And: patch shipment is returned
@@ -129,9 +129,9 @@ func (suite *HandlerSuite) TestPatchShipmentHandlerWrongTSP() {
 	}
 
 	params := shipmentop.PatchShipmentParams{
-		HTTPRequest:  req,
-		ShipmentUUID: strfmt.UUID(shipment.ID.String()),
-		Update:       &UpdatePayload,
+		HTTPRequest: req,
+		ShipmentID:  strfmt.UUID(shipment.ID.String()),
+		Update:      &UpdatePayload,
 	}
 
 	// And: patch shipment is returned

--- a/pkg/handlers/publicapi/shipments_test.go
+++ b/pkg/handlers/publicapi/shipments_test.go
@@ -59,7 +59,7 @@ func (suite *HandlerSuite) TestPatchShipmentHandler() {
 	shipment := shipments[0]
 
 	// And: the context contains the auth values
-	req := httptest.NewRequest("PATCH", "/shipments/shipment_id", nil)
+	req := httptest.NewRequest("PATCH", "/shipments/shipmentId", nil)
 	req = suite.AuthenticateTspRequest(req, tspUser)
 
 	genericDate := time.Now()
@@ -113,7 +113,7 @@ func (suite *HandlerSuite) TestPatchShipmentHandlerWrongTSP() {
 	otherTspUser := testdatagen.MakeDefaultTspUser(suite.TestDB())
 
 	// And: the context contains the auth values for the wrong tsp
-	req := httptest.NewRequest("PATCH", "/shipments/shipment_id", nil)
+	req := httptest.NewRequest("PATCH", "/shipments/shipmentId", nil)
 	req = suite.AuthenticateTspRequest(req, otherTspUser)
 
 	genericDate := time.Now()

--- a/pkg/handlers/publicapi/shipments_test.go
+++ b/pkg/handlers/publicapi/shipments_test.go
@@ -501,7 +501,8 @@ func (suite *HandlerSuite) TestCreateShipmentAcceptHandler() {
 	handler := CreateShipmentAcceptHandler{handlers.NewHandlerContext(suite.TestDB(), suite.TestLogger())}
 
 	// Test query with first user
-	req := httptest.NewRequest("POST", fmt.Sprintf("/shipments/%s/accept", shipment.ID.String()), nil)
+	path := fmt.Sprintf("/shipments/%s/accept", shipment.ID.String())
+	req := httptest.NewRequest("POST", path, nil)
 	req = suite.AuthenticateTspRequest(req, tspUser)
 	params := shipmentop.CreateShipmentAcceptParams{
 		HTTPRequest: req,

--- a/src/scenes/TransportationServiceProvider/api.js
+++ b/src/scenes/TransportationServiceProvider/api.js
@@ -28,7 +28,7 @@ export async function RetrieveShipmentsForTSP(queueType) {
 export async function LoadShipment(shipmentId) {
   const client = await getPublicClient();
   const response = await client.apis.shipments.getShipment({
-    shipment_uuid: shipmentId,
+    shipmentId,
   });
   checkResponse(response, 'failed to load shipment due to server error');
   return response.body;
@@ -38,7 +38,7 @@ export async function PatchShipment(shipmentId, shipment) {
   const client = await getPublicClient();
   const payloadDef = client.spec.definitions.Shipment;
   const response = await client.apis.shipments.patchShipment({
-    shipment_uuid: shipmentId,
+    shipmentId,
     update: formatPayload(shipment, payloadDef),
   });
   checkResponse(response, 'failed to load shipment due to server error');

--- a/swagger/api.yaml
+++ b/swagger/api.yaml
@@ -94,7 +94,7 @@ definitions:
         description: unique id of the blackout in the system
         format: uuid
         example: c56a4180-65aa-42ec-a945-5fd21dec0538
-      tspId:
+      tsp_id:
         type: string
         description: ID of the TSP filing this blackout
         format: uuid
@@ -210,7 +210,7 @@ definitions:
         type: string
         format: uuid
         example: c56a4180-65aa-42ec-a945-5fd21dec0538
-      shipmentId:
+      shipment_id:
         type: string
         format: uuid
         example: c56a4180-65aa-42ec-a945-5fd21dec0538
@@ -274,7 +274,7 @@ definitions:
     properties:
       selected_move_type:
         $ref: '#/definitions/SelectedMoveType'
-      ordersId:
+      orders_id:
         type: string
         format: uuid
         example: c56a4180-65aa-42ec-a945-5fd21dec0538
@@ -288,7 +288,7 @@ definitions:
         example: "Change of orders"
         x-nullable: true
     required:
-      - ordersId
+      - orders_id
       - locator
   MoveStatus:
     type: string

--- a/swagger/api.yaml
+++ b/swagger/api.yaml
@@ -210,7 +210,7 @@ definitions:
         type: string
         format: uuid
         example: c56a4180-65aa-42ec-a945-5fd21dec0538
-      shipment_uuid:
+      shipment_id:
         type: string
         format: uuid
         example: c56a4180-65aa-42ec-a945-5fd21dec0538
@@ -852,7 +852,7 @@ paths:
           description: not authorized to create blackouts
         500:
           description: server error
-  /blackouts/{blackout_uuid}:
+  /blackouts/{blackout_id}:
     get:
       summary: retrieve the details of a blackout period
       operationId: getBlackout
@@ -860,7 +860,7 @@ paths:
         - blackouts
       parameters:
         - in: path
-          name: blackout_uuid
+          name: blackout_id
           type: string
           format: uuid
           required: true
@@ -887,7 +887,7 @@ paths:
         - blackouts
       parameters:
         - in: path
-          name: blackout_uuid
+          name: blackout_id
           type: string
           format: uuid
           required: true
@@ -919,7 +919,7 @@ paths:
         - blackouts
       parameters:
         - in: path
-          name: blackout_uuid
+          name: blackout_id
           type: string
           format: uuid
           required: true
@@ -937,7 +937,7 @@ paths:
           description: no blackout found with that UUID
         500:
           description: server error
-  /documents/{document_uuid}/uploads:
+  /documents/{document_id}/uploads:
     post:
       summary: Adds a new upload to a document
       description: Uploads represent a single digital file, such as a JPEG or PDF.
@@ -948,7 +948,7 @@ paths:
         - multipart/form-data
       parameters:
         - in: path
-          name: document_uuid
+          name: document_id
           type: string
           format: uuid
           required: true
@@ -1029,7 +1029,7 @@ paths:
           description: cannot process request with given information
         500:
           description: server error
-  /shipments/{shipment_uuid}:
+  /shipments/{shipment_id}:
     get:
       summary: Gets a particular shipment
       description: Allows a user to retrieve the details of a particular shipment
@@ -1037,7 +1037,7 @@ paths:
       tags:
         - shipments
       parameters:
-        - name: shipment_uuid
+        - name: shipment_id
           in: path
           type: string
           format: uuid
@@ -1065,7 +1065,7 @@ paths:
       tags:
         - shipments
       parameters:
-        - name: shipment_uuid
+        - name: shipment_id
           in: path
           type: string
           format: uuid
@@ -1426,7 +1426,7 @@ paths:
           description: must be authenticated to access this endpoint
         500:
           description: server error
-  /tsps/{tsp_uuid}/shipments:
+  /tsps/{tsp_id}/shipments:
     get:
       summary: Retrieve shipments associated with a TSP
       description: Gets a list of all shipments associated with a TSP. Shipments can be restricted to be in a certain state, e.g. AWARDED
@@ -1436,7 +1436,7 @@ paths:
       x-access: Access to this endpoint is restricted to members of the Admin, Transcom and JPPSO user groups along with the agents of the TSP.
       parameters:
         - in: path
-          name: tsp_uuid
+          name: tsp_id
           type: string
           format: uuid
           required: true
@@ -1480,7 +1480,7 @@ paths:
           description: TSP UUID not found in system
         500:
           description: server error
-  /tsps/{tsp_uuid}/blackouts:
+  /tsps/{tsp_id}/blackouts:
     get:
       summary: Retrieve a list of the blackouts associated with a TSP
       description: Gets a list of all blackouts associated with a TSP. Blackouts retrieved can be restricted by one or more
@@ -1490,7 +1490,7 @@ paths:
       x-access: Access to this endpoint is restricted to members of the Admin, Transcom and JPPSO user groups along with the agents of the TSP.
       parameters:
         - in: path
-          name: tsp_uuid
+          name: tsp_id
           type: string
           format: uuid
           required: true

--- a/swagger/api.yaml
+++ b/swagger/api.yaml
@@ -94,7 +94,7 @@ definitions:
         description: unique id of the blackout in the system
         format: uuid
         example: c56a4180-65aa-42ec-a945-5fd21dec0538
-      tsp_id:
+      tspId:
         type: string
         description: ID of the TSP filing this blackout
         format: uuid
@@ -210,7 +210,7 @@ definitions:
         type: string
         format: uuid
         example: c56a4180-65aa-42ec-a945-5fd21dec0538
-      shipment_id:
+      shipmentId:
         type: string
         format: uuid
         example: c56a4180-65aa-42ec-a945-5fd21dec0538
@@ -274,7 +274,7 @@ definitions:
     properties:
       selected_move_type:
         $ref: '#/definitions/SelectedMoveType'
-      orders_id:
+      ordersId:
         type: string
         format: uuid
         example: c56a4180-65aa-42ec-a945-5fd21dec0538
@@ -288,7 +288,7 @@ definitions:
         example: "Change of orders"
         x-nullable: true
     required:
-      - orders_id
+      - ordersId
       - locator
   MoveStatus:
     type: string
@@ -852,7 +852,7 @@ paths:
           description: not authorized to create blackouts
         500:
           description: server error
-  /blackouts/{blackout_id}:
+  /blackouts/{blackoutId}:
     get:
       summary: retrieve the details of a blackout period
       operationId: getBlackout
@@ -860,7 +860,7 @@ paths:
         - blackouts
       parameters:
         - in: path
-          name: blackout_id
+          name: blackoutId
           type: string
           format: uuid
           required: true
@@ -887,7 +887,7 @@ paths:
         - blackouts
       parameters:
         - in: path
-          name: blackout_id
+          name: blackoutId
           type: string
           format: uuid
           required: true
@@ -919,7 +919,7 @@ paths:
         - blackouts
       parameters:
         - in: path
-          name: blackout_id
+          name: blackoutId
           type: string
           format: uuid
           required: true
@@ -937,7 +937,7 @@ paths:
           description: no blackout found with that UUID
         500:
           description: server error
-  /documents/{document_id}/uploads:
+  /documents/{documentId}/uploads:
     post:
       summary: Adds a new upload to a document
       description: Uploads represent a single digital file, such as a JPEG or PDF.
@@ -948,7 +948,7 @@ paths:
         - multipart/form-data
       parameters:
         - in: path
-          name: document_id
+          name: documentId
           type: string
           format: uuid
           required: true
@@ -1029,7 +1029,7 @@ paths:
           description: cannot process request with given information
         500:
           description: server error
-  /shipments/{shipment_id}:
+  /shipments/{shipmentId}:
     get:
       summary: Gets a particular shipment
       description: Allows a user to retrieve the details of a particular shipment
@@ -1037,7 +1037,7 @@ paths:
       tags:
         - shipments
       parameters:
-        - name: shipment_id
+        - name: shipmentId
           in: path
           type: string
           format: uuid
@@ -1065,7 +1065,7 @@ paths:
       tags:
         - shipments
       parameters:
-        - name: shipment_id
+        - name: shipmentId
           in: path
           type: string
           format: uuid
@@ -1426,7 +1426,7 @@ paths:
           description: must be authenticated to access this endpoint
         500:
           description: server error
-  /tsps/{tsp_id}/shipments:
+  /tsps/{tspId}/shipments:
     get:
       summary: Retrieve shipments associated with a TSP
       description: Gets a list of all shipments associated with a TSP. Shipments can be restricted to be in a certain state, e.g. AWARDED
@@ -1436,7 +1436,7 @@ paths:
       x-access: Access to this endpoint is restricted to members of the Admin, Transcom and JPPSO user groups along with the agents of the TSP.
       parameters:
         - in: path
-          name: tsp_id
+          name: tspId
           type: string
           format: uuid
           required: true
@@ -1480,7 +1480,7 @@ paths:
           description: TSP UUID not found in system
         500:
           description: server error
-  /tsps/{tsp_id}/blackouts:
+  /tsps/{tspId}/blackouts:
     get:
       summary: Retrieve a list of the blackouts associated with a TSP
       description: Gets a list of all blackouts associated with a TSP. Blackouts retrieved can be restricted by one or more
@@ -1490,7 +1490,7 @@ paths:
       x-access: Access to this endpoint is restricted to members of the Admin, Transcom and JPPSO user groups along with the agents of the TSP.
       parameters:
         - in: path
-          name: tsp_id
+          name: tspId
           type: string
           format: uuid
           required: true


### PR DESCRIPTION
## Description

The internal api doesn't specify `_uuid` and instead uses `_id`.  We've only partially changed the public api to be consistent and this PR goes the rest of the way towards getting it done.
## Code Review Verification Steps

* [x] Request review from a member of a different team.