### PR TITLE
Remove tsp user id check from service agent handlers

### DIFF
--- a/pkg/handlers/publicapi/service_agents.go
+++ b/pkg/handlers/publicapi/service_agents.go
@@ -42,13 +42,6 @@ func (h IndexServiceAgentsHandler) Handle(params serviceagentop.IndexServiceAgen
 
 	shipmentID, _ := uuid.FromString(params.ShipmentID.String())
 
-	// Possible they are coming from the wrong endpoint and thus the session is missing the
-	// TspUserID
-	if session.TspUserID == uuid.Nil {
-		h.Logger().Error("Missing TSP User ID")
-		return serviceagentop.NewIndexServiceAgentsForbidden()
-	}
-
 	// TODO (2018_08_27 cgilmer): Find a way to check Shipment belongs to TSP without 2 queries
 	tspUser, err := models.FetchTspUserByID(h.DB(), session.TspUserID)
 	if err != nil {
@@ -131,13 +124,6 @@ func (h PatchServiceAgentHandler) Handle(params serviceagentop.PatchServiceAgent
 
 	shipmentID, _ := uuid.FromString(params.ShipmentID.String())
 	serviceAgentID, _ := uuid.FromString(params.ServiceAgentID.String())
-
-	// Possible they are coming from the wrong endpoint and thus the session is missing the
-	// TspUserID
-	if session.TspUserID == uuid.Nil {
-		h.Logger().Error("Missing TSP User ID")
-		return serviceagentop.NewPatchServiceAgentForbidden()
-	}
 
 	tspUser, err := models.FetchTspUserByID(h.DB(), session.TspUserID)
 	if err != nil {


### PR DESCRIPTION
## Description

This is a follow on to https://github.com/transcom/mymove/pull/926.  I should have caught this before merging the handler code.

## Code Review Verification Steps

* [x] Request review from a member of a different team.