### PR TITLE
[WIP] Added additional order fields to ui

### DIFF
--- a/src/scenes/Office/AccountingPanel.jsx
+++ b/src/scenes/Office/AccountingPanel.jsx
@@ -33,6 +33,14 @@ const AccountingDisplay = props => {
             missing
           </PanelField>
         )}
+
+        {props.orders.sac ? (
+          <PanelSwaggerField title="SAC" fieldName="sac" {...fieldProps} />
+        ) : (
+          <PanelField title="SAC" className="missing">
+            missing
+          </PanelField>
+        )}
       </div>
       <div className="editable-panel-column">
         {props.orders.tac ? (
@@ -63,6 +71,14 @@ const AccountingEdit = props => {
         <SwaggerField
           title="TAC"
           fieldName="tac"
+          swagger={ordersSchema}
+          required
+        />
+      </div>
+      <div className="editable-panel-column">
+        <SwaggerField
+          title="SAC"
+          fieldName="sac"
           swagger={ordersSchema}
           required
         />

--- a/src/scenes/Office/OrdersPanel.jsx
+++ b/src/scenes/Office/OrdersPanel.jsx
@@ -92,6 +92,30 @@ const OrdersDisplay = props => {
         <PanelField title="New Duty Station">
           {get(props.orders, 'new_duty_station.name', '')}
         </PanelField>
+
+        {props.orders.orders_issuing_agency ? (
+          <PanelSwaggerField
+            title="Orders Issuing Agency"
+            fieldName="orders_issuing_agency"
+            {...fieldProps}
+          />
+        ) : (
+          <PanelField title="Orders Issuing Agency" className="missing">
+            missing
+          </PanelField>
+        )}
+
+        {props.orders.paragraph_number ? (
+          <PanelSwaggerField
+            title="Paragraph Number"
+            fieldName="paragraph_number"
+            {...fieldProps}
+          />
+        ) : (
+          <PanelField title="Paragraph Number" className="missing">
+            missing
+          </PanelField>
+        )}
       </div>
       <div className="editable-panel-column">
         {renderEntitlements(props.entitlements, props.orders)}
@@ -147,6 +171,22 @@ const OrdersEdit = props => {
               props={{ title: 'New Duty Station' }}
             />
           </div>
+        </FormSection>
+
+        <FormSection name="orders">
+          <SwaggerField
+            fieldName="orders_issuing_agency"
+            swagger={schema}
+            className="half-width"
+            required
+          />
+
+          <SwaggerField
+            fieldName="paragraph_number"
+            swagger={schema}
+            className="half-width"
+            required
+          />
         </FormSection>
       </div>
       <div className="editable-panel-column">


### PR DESCRIPTION
## Description

WIP - DNR

Added additional fields to the ui.

Fields added:
- orders_issuing_agency
- paragraph_number
- sac

## Code Review Verification Steps

* [ ] End to end tests pass (`make e2e_test`).
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/blob/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* [ ] Any migrations/schema changes also update the diagram in docs/schema/dp3.sqs
* [ ] There are no aXe warnings for UI.
* [ ] This works in IE.
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @willowbl00
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/160032296) for this change

## Screenshots

<img width="1258" alt="screen shot 2018-08-30 at 12 22 17 pm" src="https://user-images.githubusercontent.com/1522549/44874443-0c635e00-ac50-11e8-9fcd-2c0d11aab115.png">
