### PR TITLE
Bug fix for expense input on doc viewer with commas

### DIFF
--- a/cypress/integration/office/documentViewer.js
+++ b/cypress/integration/office/documentViewer.js
@@ -53,7 +53,7 @@ describe('The document viewer', function() {
     cy.get('select[name="move_document_type"]').select('Expense');
     cy.get('input[name="title"]').type('expense document');
     cy.get('select[name="moving_expense_type"]').select('Contracted Expense');
-    cy.get('input[name="requested_amount_cents"]').type('12');
+    cy.get('input[name="requested_amount_cents"]').type('4,000.92');
     cy.get('select[name="payment_method"]').select('Other account');
 
     cy.get('button.submit').should('be.disabled');
@@ -75,9 +75,14 @@ describe('The document viewer', function() {
 
     cy.contains('expense document').click();
     cy.contains('Details').click();
-    cy.contains('Other account');
-    cy.contains('Edit').click();
 
+    // Verify values have been stored correctly
+    cy.contains('4,000.92');
+    cy.contains('Contracted Expense');
+    cy.contains('Other account');
+
+    // Edit payment method
+    cy.contains('Edit').click();
     cy.get('select[name="moveDocument.payment_method"]').select('GTCC');
     cy.get('select[name="moveDocument.status"]').select('OK');
 
@@ -138,7 +143,9 @@ describe('The document viewer', function() {
     cy
       .get('select[name="moveDocument.moving_expense_type"]')
       .select('Contracted Expense');
-    cy.get('input[name="moveDocument.requested_amount_cents"]').type('12');
+    cy
+      .get('input[name="moveDocument.requested_amount_cents"]')
+      .type('4,999.92');
     cy.get('select[name="moveDocument.payment_method"]').select('GTCC');
     cy.get('select[name="moveDocument.status"]').select('OK');
 
@@ -149,6 +156,7 @@ describe('The document viewer', function() {
       .click();
 
     cy.contains('Expense');
+    cy.contains('4,999.92');
     cy.contains('GTCC');
   });
 });

--- a/src/scenes/Office/DocumentViewer/DocumentDetailPanel.jsx
+++ b/src/scenes/Office/DocumentViewer/DocumentDetailPanel.jsx
@@ -170,18 +170,8 @@ function mapStateToProps(state, props) {
         ]);
       }
       if (get(values.moveDocument, 'move_document_type', '') === 'EXPENSE') {
-        values.moveDocument.requested_amount_cents = parseFloat(
-          values.moveDocument.requested_amount_cents,
-        );
-      }
-      let requested_amount = get(
-        values.moveDocument,
-        'requested_amount_cents',
-        '',
-      );
-      if (requested_amount) {
         values.moveDocument.requested_amount_cents = convertDollarsToCents(
-          requested_amount,
+          values.moveDocument.requested_amount_cents,
         );
       }
       return [


### PR DESCRIPTION
## Description

The requested amount on the document viewer wasn't getting the value stripped of commas before hitting the API, so any values above one thousand containing a comma were stored incorrectly. E.g. $4,000 is stored as $4. This was a previous bug on the advance input on the service member side, but the fix was not implemented for the document viewer forms for expense docs.

## Setup
Try uploading an expense doc, then modifying with a value with a comma. Verify the values displays correctly.

## Code Review Verification Steps

* [x] End to end tests pass (`make e2e_test`).
* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/159451590) for this change

## Screenshots

<img width="414" alt="screen shot 2018-08-30 at 5 13 57 pm" src="https://user-images.githubusercontent.com/8170735/44885862-2153e780-ac78-11e8-9196-bde486403fbd.png">

<img width="246" alt="screen shot 2018-08-30 at 5 14 02 pm" src="https://user-images.githubusercontent.com/8170735/44885861-2153e780-ac78-11e8-831a-4716939adb0a.png">