### PR TITLE
Add new office users

### DIFF
--- a/local_migrations/20180831151530_august2018-new-office-users.sql
+++ b/local_migrations/20180831151530_august2018-new-office-users.sql
@@ -1,0 +1,10 @@
+-- Local test migration.
+-- This will be run on development environments. It should mirror what you
+-- intend to apply on production, but do not include any sensitive data.
+
+INSERT INTO public.office_users
+VALUES
+    ('cc90e5ef-601c-4e6c-af82-15b8cdc3ab90', NULL, 'Ripley', 'Ellen', NULL, 'ripley@nostromo.space', '(555) 555-5555', '0931a9dc-c1fd-444a-b138-6e1986b1714c', now(), now());
+INSERT INTO public.office_users
+VALUES
+    ('8293e5d2-819c-4597-956e-b43072f5c488', NULL, 'Android', 'Ash', NULL, 'ash@hyperdyne.biz', '(555) 555-5555', '0931a9dc-c1fd-444a-b138-6e1986b1714c', now(), now());

--- a/migrations/20180831151530_august2018-new-office-users.up.fizz
+++ b/migrations/20180831151530_august2018-new-office-users.up.fizz
@@ -1,0 +1,1 @@
+exec("./apply-secure-migration.sh 20180831151530_august2018-new-office-users.sql")


### PR DESCRIPTION
## Description

The newest set of office users is added to the database by the secure migration connected with this PR.

## Setup

You can run `bin/run-prod-migrations` and take a look at the `prod_migrations` database to check out the state of the database after running the new migration.

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/160024716) for this change