### PR TITLE
Sb update readme

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -317,6 +317,8 @@ repos
 pjdufour-truss
 dynamike
 fillable
+symlinked
+- /usr/local
 # Put all custom terms BEFORE this comment, lest you end up in an mdspell pain cycle.
  - docs/data/tspp-data-creation.md
  - docs/backend.md

--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ Dependencies are managed by yarn. To add a new dependency, use `yarn add`
     `127.0.0.1 tsplocal`
 2. Ensure that you have a test account which can log into the TSP site...
     * `make tools_build` to build the tools
+    * run `./bin/generate-test-data -scenario=7` to load test data
     * run `bin/make-tsp-user -email <email>` to set up a TSP user associated with that email address
 3. `make tsp_client_run`
 4. Login with the email used above to access the TSP
@@ -228,6 +229,7 @@ Currently, scenarios have the following numbers:
 * `-scenario=4` for PPM or PPM SIT Estimate Scenario (can also use Rate Engine Scenarios for Estimates)
 * `-scenario=5` for Rate Engine Scenario 1
 * `-scenario=6` for Rate Engine Scenario 2
+* `-scenario=7` for TSP test data
 
 ### API / Swagger
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,9 @@ The following commands will get mymove running on your machine for the first tim
 
 ### Setup: Prerequisites
 
-* Install Go with Homebrew. Make sure you do not have other installations.
+* Install Go version 1.10 with Homebrew. Make sure you do not have other installations.
+  * `brew install go@1.10`
+  * Brew will warn you that "go@1.10 is keg-only, which means it was not symlinked". Add the following to your bash config: `export PATH="/usr/local/opt/go@1.10/bin:$PATH"`. This line needs to appear in the file before your Go paths are declared.
 * Run `bin/prereqs` and install everything it tells you to. _Do not configure PostgreSQL to automatically start at boot time or the DB commands will not work correctly!_
 * For managing local environment variables, we're using [direnv](https://direnv.net/). You need to [configure your shell to use it](https://direnv.net/). For bash, add the command `eval "$(direnv hook bash)"` to whichever file loads upon opening bash (likely `~./bash_profile`, though instructions say `~/.bashrc`).
 * Run `direnv allow` to load up the `.envrc` file. Add a `.envrc.local` file with any values it asks you to define.


### PR DESCRIPTION
## Description

Updating the readme to include:
- How to pin Go to version 1.10 using homebrew
- How to load test data for the TSP client

## Reviewer Notes

Will add a link to this PR in the story to upgrade Go to version 1.11 so the README stays up to date.

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?
