### PR TITLE
Add over 18 years old text to backup contact info pages

### DIFF
--- a/src/scenes/Review/EditBackupContact.jsx
+++ b/src/scenes/Review/EditBackupContact.jsx
@@ -25,8 +25,8 @@ let EditBackupContactForm = props => {
       <hr />
       <h3 className="sm-heading">Edit Backup Contact:</h3>
       <p>
-        Any person you assign as a backup or trusted agent must be 18 years of
-        age or older.
+        Any person you assign as a backup contact must be 18 years of age or
+        older.
       </p>
       <SwaggerField fieldName="name" swagger={schema} required />
       <SwaggerField fieldName="email" swagger={schema} required />

--- a/src/scenes/Review/EditBackupContact.jsx
+++ b/src/scenes/Review/EditBackupContact.jsx
@@ -24,6 +24,10 @@ let EditBackupContactForm = props => {
       <img src={profileImage} alt="" /> Backup Contact
       <hr />
       <h3 className="sm-heading">Edit Backup Contact:</h3>
+      <p>
+        Any person you assign as a backup or trusted agent must be 18 years of
+        age or older.
+      </p>
       <SwaggerField fieldName="name" swagger={schema} required />
       <SwaggerField fieldName="email" swagger={schema} required />
       <SwaggerField fieldName="telephone" swagger={schema} />

--- a/src/scenes/ServiceMembers/BackupContact.jsx
+++ b/src/scenes/ServiceMembers/BackupContact.jsx
@@ -120,6 +120,10 @@ class ContactForm extends Component {
         <p>
           If we can't reach you, who can we contact (such as spouse or parent)?
         </p>
+        <p>
+          Any person you assign as a backup or trusted agent must be 18 years of
+          age or older.
+        </p>
 
         {renderField('name', fields, '')}
         {renderField('email', fields, '')}

--- a/src/scenes/ServiceMembers/BackupContact.jsx
+++ b/src/scenes/ServiceMembers/BackupContact.jsx
@@ -121,8 +121,8 @@ class ContactForm extends Component {
           If we can't reach you, who can we contact (such as spouse or parent)?
         </p>
         <p>
-          Any person you assign as a backup or trusted agent must be 18 years of
-          age or older.
+          Any person you assign as a backup contact must be 18 years of age or
+          older.
         </p>
 
         {renderField('name', fields, '')}


### PR DESCRIPTION
## Description

Add a blurb about backup contacts needing to be 18 years of age or older to the backup contact and edit backup contact pages.

## Code Review Verification Steps

* [ ] End to end tests pass (`make e2e_test`).
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/blob/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* [ ] Any migrations/schema changes also update the diagram in docs/schema/dp3.sqs
* [ ] There are no aXe warnings for UI.
* [ ] This works in IE.
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @willowbl00
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/160258227) for this change

## Screenshots
<img width="702" alt="screen shot 2018-09-04 at 1 56 42 pm" src="https://user-images.githubusercontent.com/8170735/45057396-64cc9e00-b04a-11e8-8d9f-244e5b3431ce.png">

