### PR TITLE
Fix service agent e2e test by adding new shipment offer data to e2ebasic scenario

### DIFF
--- a/cypress/integration/tsp/homepage.js
+++ b/cypress/integration/tsp/homepage.js
@@ -1,5 +1,5 @@
 /* global cy */
-describe('The Home Page', function() {
+describe('TSP Home Page', function() {
   beforeEach(() => {
     Cypress.config('baseUrl', 'http://tsplocal:4000');
   });

--- a/cypress/integration/tsp/premoveSurvey.js
+++ b/cypress/integration/tsp/premoveSurvey.js
@@ -1,0 +1,30 @@
+import testPremoveSurvey from '../../support/testPremoveSurvey';
+
+/* global cy */
+describe('TSP User Completes Premove Survey', function() {
+  beforeEach(() => {
+    cy.signIntoTSP();
+  });
+  it('tsp user enters premove survey', function() {
+    tspUserEntersPremoveSurvey();
+  });
+});
+
+function tspUserEntersPremoveSurvey() {
+  // Open new shipments queue
+  cy.location().should(loc => {
+    expect(loc.pathname).to.match(/^\/queues\/new/);
+  });
+
+  // Find shipment and open it
+  cy
+    .get('div')
+    .contains('BACON1')
+    .dblclick();
+
+  cy.location().should(loc => {
+    expect(loc.pathname).to.match(/^\/queues\/new\/shipments\/[^/]+/);
+  });
+
+  testPremoveSurvey();
+}

--- a/cypress/integration/tsp/serviceAgents.js
+++ b/cypress/integration/tsp/serviceAgents.js
@@ -1,5 +1,5 @@
 /* global cy */
-describe('service agents', function() {
+describe('TSP User enters and updates Service Agents', function() {
   beforeEach(() => {
     cy.signIntoTSP();
   });
@@ -74,7 +74,7 @@ function tspUserEntersServiceAgent(role) {
   // Find shipment and open it
   cy
     .get('div')
-    .contains('KBACON')
+    .contains('BACON2')
     .dblclick();
 
   cy.location().should(loc => {
@@ -207,7 +207,7 @@ function tspUserAcceptsShipment() {
   // Find shipment and open it
   cy
     .get('div')
-    .contains('KBACON')
+    .contains('BACON2')
     .dblclick();
 
   cy.location().should(loc => {

--- a/cypress/integration/tsp/tspUser.js
+++ b/cypress/integration/tsp/tspUser.js
@@ -1,15 +1,10 @@
-import testPremoveSurvey from '../../support/testPremoveSurvey';
-
 /* global cy */
-describe('tsp user', function() {
+describe('TSP User Views Shipment', function() {
   beforeEach(() => {
     cy.signIntoTSP();
   });
   it('tsp user views shipments in queue new shipments', function() {
     tspUserViewsShipments();
-  });
-  it('tsp user enters premove survey', function() {
-    tspUserEntersPremoveSurvey();
   });
 });
 
@@ -20,24 +15,5 @@ function tspUserViewsShipments() {
   });
 
   // Find shipment
-  cy.get('div').contains('KBACON');
-}
-
-function tspUserEntersPremoveSurvey() {
-  // Open new shipments queue
-  cy.location().should(loc => {
-    expect(loc.pathname).to.match(/^\/queues\/new/);
-  });
-
-  // Find shipment and open it
-  cy
-    .get('div')
-    .contains('KBACON')
-    .dblclick();
-
-  cy.location().should(loc => {
-    expect(loc.pathname).to.match(/^\/queues\/new\/shipments\/[^/]+/);
-  });
-
-  testPremoveSurvey();
+  cy.get('div').contains('BACON1');
 }

--- a/pkg/testdatagen/scenario/e2ebasic.go
+++ b/pkg/testdatagen/scenario/e2ebasic.go
@@ -21,7 +21,9 @@ var E2eBasicScenario = e2eBasicScenario{"e2e_basic"}
 // Run does that data load thing
 func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader) {
 
-	// Basic user with tsp access
+	/*
+	 * Basic user with tsp access
+	 */
 	email := "tspuser1@example.com"
 	tspUser := testdatagen.MakeTspUser(db, testdatagen.Assertions{
 		User: models.User{
@@ -34,7 +36,9 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader) {
 		},
 	})
 
-	// Basic user with office access
+	/*
+	 * Basic user with office access
+	 */
 	email = "officeuser1@example.com"
 	testdatagen.MakeOfficeUser(db, testdatagen.Assertions{
 		User: models.User{
@@ -47,7 +51,9 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader) {
 		},
 	})
 
-	// Service member with uploaded orders and a new ppm
+	/*
+	 * Service member with uploaded orders and a new ppm
+	 */
 	email = "ppm@incomple.te"
 	uuidStr := "e10d5964-c070-49cb-9bd1-eaf9f7348eb6"
 	testdatagen.MakeUser(db, testdatagen.Assertions{
@@ -76,10 +82,11 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader) {
 		Uploader: loader,
 	})
 	ppm0.Move.Submit()
-	// Save move and dependencies
 	models.SaveMoveDependencies(db, &ppm0.Move)
 
-	// Service member with a ppm in progress
+	/*
+	 * Service member with a ppm in progress
+	 */
 	email = "ppm.in@progre.ss"
 	uuidStr = "20199d12-5165-4980-9ca7-19b5dc9f1032"
 	testdatagen.MakeUser(db, testdatagen.Assertions{
@@ -109,10 +116,11 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader) {
 	})
 	ppm1.Move.Submit()
 	ppm1.Move.Approve()
-	// Save move and dependencies
 	models.SaveMoveDependencies(db, &ppm1.Move)
 
-	// Service member with a ppm move approved, but not in progress
+	/*
+	 * Service member with a ppm move approved, but not in progress
+	 */
 	email = "ppm@approv.ed"
 	uuidStr = "1842091b-b9a0-4d4a-ba22-1e2f38f26317"
 	testdatagen.MakeUser(db, testdatagen.Assertions{
@@ -153,11 +161,11 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader) {
 	// This is the same PPM model as ppm2, but this is the one that will be saved by SaveMoveDependencies
 	ppm2.Move.PersonallyProcuredMoves[0].Submit()
 	ppm2.Move.PersonallyProcuredMoves[0].Approve()
-	// Save move and dependencies
 	models.SaveMoveDependencies(db, &ppm2.Move)
 
-	//service member with orders and a move
-
+	/*
+	 * Service member with orders and a move
+	 */
 	email = "profile@comple.te"
 	uuidStr = "13F3949D-0D53-4BE4-B1B1-AE4314793F34"
 	testdatagen.MakeUser(db, testdatagen.Assertions{
@@ -183,7 +191,9 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader) {
 		Uploader: loader,
 	})
 
-	//service member with orders and a move, but no move type selected to select HHG
+	/*
+	 * Service member with orders and a move, but no move type selected to select HHG
+	 */
 	email = "sm_hhg@example.com"
 	uuidStr = "4b389406-9258-4695-a091-0bf97b5a132f"
 
@@ -209,7 +219,9 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader) {
 		},
 	})
 
-	// Service member with uploaded orders and a new shipment move
+	/*
+	 * Service member with uploaded orders and a new shipment move
+	 */
 	email = "hhg@incomple.te"
 
 	hhg0 := testdatagen.MakeShipment(db, testdatagen.Assertions{
@@ -238,10 +250,11 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader) {
 	})
 
 	hhg0.Move.Submit()
-	// Save move and dependencies
 	models.SaveMoveDependencies(db, &hhg0.Move)
 
-	// Service member with uploaded orders and an approved shipment
+	/*
+	 * Service member with uploaded orders and an approved shipment
+	 */
 	email = "hhg@award.ed"
 
 	offer1 := testdatagen.MakeShipmentOffer(db, testdatagen.Assertions{
@@ -258,7 +271,7 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader) {
 		},
 		Move: models.Move{
 			ID:               uuid.FromStringOrNil("56b8ef45-8145-487b-9b59-0e30d0d465fa"),
-			Locator:          "KBACON",
+			Locator:          "BACON1",
 			SelectedMoveType: models.StringPointer("HHG"),
 		},
 		TrafficDistributionList: models.TrafficDistributionList{
@@ -277,6 +290,45 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader) {
 
 	hhg1 := offer1.Shipment
 	hhg1.Move.Submit()
-	// Save move and dependencies
 	models.SaveMoveDependencies(db, &hhg1.Move)
+
+	/*
+	 * Service member with uploaded orders and an approved shipment to be accepted
+	 */
+	email = "hhg@fromawardedtoaccept.ed"
+
+	offer2 := testdatagen.MakeShipmentOffer(db, testdatagen.Assertions{
+		User: models.User{
+			ID:            uuid.Must(uuid.FromString("179598c5-a5ee-4da5-8259-29749f03a398")),
+			LoginGovEmail: email,
+		},
+		ServiceMember: models.ServiceMember{
+			ID:            uuid.FromStringOrNil("179598c5-a5ee-4da5-8259-29749f03a398"),
+			FirstName:     models.StringPointer("HHG"),
+			LastName:      models.StringPointer("ReadyForAccept"),
+			Edipi:         models.StringPointer("4444567890"),
+			PersonalEmail: models.StringPointer(email),
+		},
+		Move: models.Move{
+			ID:               uuid.FromStringOrNil("849a7880-4a82-4f76-acb4-63cf481e786b"),
+			Locator:          "BACON2",
+			SelectedMoveType: models.StringPointer("HHG"),
+		},
+		TrafficDistributionList: models.TrafficDistributionList{
+			ID:                uuid.FromStringOrNil("5f86c201-1abf-4f9d-8dcb-d039cb1c6bfc"),
+			SourceRateArea:    "US62",
+			DestinationRegion: "11",
+			CodeOfService:     "D",
+		},
+		Shipment: models.Shipment{
+			Status: models.ShipmentStatusAWARDED,
+		},
+		ShipmentOffer: models.ShipmentOffer{
+			TransportationServiceProviderID: tspUser.TransportationServiceProviderID,
+		},
+	})
+
+	hhg2 := offer2.Shipment
+	hhg2.Move.Submit()
+	models.SaveMoveDependencies(db, &hhg2.Move)
 }


### PR DESCRIPTION
## Description

This solves an issue where each test ought to have its own test data.  This is because test order is neither guaranteed nor enforced and it keeps things a lot more manageable overall.

Additionally:
- Break out the premove survey into its own file
- Modify locator ID to be more generic
- Update TSP `describe()` headers.
- Ensure that header comments for data is different than regular code comments in the e2ebasic scenario

## Reviewer Notes

I ran this a few times but on different occasions I'd see an office test fail.  Please verify this isn't because of this change.

## Setup

```sh
make e2e_test
```

## Code Review Verification Steps

* [x] End to end tests pass (`make e2e_test`)
* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/160267187) for this change