### PR TITLE
Add actual weight to Shipment patch endpoint 160205326

### DIFF
--- a/pkg/handlers/publicapi/shipments.go
+++ b/pkg/handlers/publicapi/shipments.go
@@ -185,6 +185,10 @@ func patchShipmentWithPayload(shipment *models.Shipment, payload *apimessages.Sh
 		shipment.PmSurveySpouseProgearWeightEstimate = handlers.PoundPtrFromInt64Ptr(payload.PmSurveySpouseProgearWeightEstimate)
 		shipment.PmSurveyWeightEstimate = handlers.PoundPtrFromInt64Ptr(payload.PmSurveyWeightEstimate)
 	}
+
+	if payload.ActualWeight != nil {
+		shipment.ActualWeight = handlers.PoundPtrFromInt64Ptr(payload.ActualWeight)
+	}
 }
 
 // PatchShipmentHandler allows a TSP to refuse a particular shipment


### PR DESCRIPTION
## Description

Requires https://github.com/transcom/mymove/pull/952

This adds the Actual Weight to the public Shipment patch endpoint.  Having this in place should allow us to update the field from the weight panel in the UI.

## Reviewer Notes

This is only adding an update for one field, not the other shipment fields.

## Setup

Try it out:

```sh
make db_test_reset
go test ./pkg/handlers/publicapi/ -v -testify.m TestPatchShipmentHandler
```

## Code Review Verification Steps

* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/160205326) for this change