### PR TITLE
Use after() in cypress tests to reset db after each set of tests

### DIFF
--- a/cypress/integration/mymove/orders.js
+++ b/cypress/integration/mymove/orders.js
@@ -4,6 +4,9 @@ describe('orders entry', function() {
   beforeEach(() => {
     cy.signInAsNewUser();
   });
+  after(() => {
+    cy.resetDb();
+  });
 
   it('will accept orders information', function() {
     createServiceMember().then(() => cy.visit('/'));

--- a/cypress/integration/mymove/ppm.js
+++ b/cypress/integration/mymove/ppm.js
@@ -6,6 +6,9 @@ describe('completing the ppm flow', function() {
     // cy.resetDb();
     cy.signInAsUser('13F3949D-0D53-4BE4-B1B1-AE4314793F34');
   });
+  after(() => {
+    cy.resetDb();
+  });
 
   //tear down currently means doing this:
   //update moves set status='DRAFT';
@@ -72,6 +75,5 @@ describe('completing the ppm flow', function() {
     cy.contains('Success');
     cy.contains('Next Step: Awaiting approval');
     cy.contains('Advance Requested: $1,333.91');
-    cy.resetDb();
   });
 });

--- a/cypress/integration/mymove/serviceMemberProfile.js
+++ b/cypress/integration/mymove/serviceMemberProfile.js
@@ -3,6 +3,9 @@ describe('setting up service member profile', function() {
   beforeEach(() => {
     cy.signInAsNewUser();
   });
+  after(() => {
+    cy.resetDb();
+  });
   it('progresses thru forms', function() {
     serviceMemberProfile();
   });

--- a/cypress/integration/mymove/shipment.js
+++ b/cypress/integration/mymove/shipment.js
@@ -5,6 +5,9 @@ describe('completing the hhg flow', function() {
     // sm_hhg@example.com
     cy.signInAsUser('4b389406-9258-4695-a091-0bf97b5a132f');
   });
+  after(() => {
+    cy.resetDb();
+  });
 
   it('selects hhg and progresses thru form', function() {
     cy.contains('Continue Move Setup').click();
@@ -88,7 +91,5 @@ describe('completing the hhg flow', function() {
     cy.nextPage();
     cy.contains('Success');
     cy.contains('Next Step: Awaiting approval');
-
-    cy.resetDb();
   });
 });

--- a/cypress/integration/office/documentViewer.js
+++ b/cypress/integration/office/documentViewer.js
@@ -5,6 +5,9 @@ describe('The document viewer', function() {
   beforeEach(() => {
     cy.signIntoOffice();
   });
+  after(() => {
+    cy.resetDb();
+  });
   it('redirects to sign in when not logged in', function() {
     cy.contains('Sign Out').click();
     cy.visit('/moves/foo/documents');

--- a/cypress/integration/office/incentiveCalculator.js
+++ b/cypress/integration/office/incentiveCalculator.js
@@ -3,6 +3,9 @@ describe('office user finds the move', () => {
   beforeEach(() => {
     cy.signIntoOffice();
   });
+  after(() => {
+    cy.resetDb();
+  });
   it('office user uses calculator', () => {
     // Open move ppm tab
     cy.visit('/queues/new/moves/0db80bd6-de75-439e-bf89-deaafa1d0dc8/ppm');

--- a/cypress/integration/office/officePremoveSurvey.js
+++ b/cypress/integration/office/officePremoveSurvey.js
@@ -5,9 +5,11 @@ describe('office user interacts with premove survey', function() {
   beforeEach(() => {
     cy.signIntoOffice();
   });
+  after(() => {
+    cy.resetDb();
+  });
   it('office user enters premove survey', function() {
     officeUserEntersPreMoveSurvey();
-    cy.resetDb();
   });
 });
 

--- a/cypress/integration/office/officeUserPPM.js
+++ b/cypress/integration/office/officeUserPPM.js
@@ -3,6 +3,9 @@ describe('office user finds the move', function() {
   beforeEach(() => {
     cy.signIntoOffice();
   });
+  after(() => {
+    cy.resetDb();
+  });
   it('office user views moves in queue new moves', function() {
     officeUserViewsMoves();
   });
@@ -14,7 +17,6 @@ describe('office user finds the move', function() {
   });
   it('office user approves move, verifies and approves PPM', function() {
     officeUserApprovesMoveAndVerifiesPPM();
-    cy.resetDb();
   });
 });
 

--- a/cypress/integration/office/storageReimbursementCalculator.js
+++ b/cypress/integration/office/storageReimbursementCalculator.js
@@ -3,6 +3,9 @@ describe('office user finds the move', () => {
   beforeEach(() => {
     cy.signIntoOffice();
   });
+  after(() => {
+    cy.resetDb();
+  });
   it('office user uses calculator', () => {
     // Open move ppm tab
     cy.visit('/queues/new/moves/0db80bd6-de75-439e-bf89-deaafa1d0dc8/ppm');

--- a/cypress/integration/tsp/premoveSurvey.js
+++ b/cypress/integration/tsp/premoveSurvey.js
@@ -5,6 +5,9 @@ describe('TSP User Completes Premove Survey', function() {
   beforeEach(() => {
     cy.signIntoTSP();
   });
+  after(() => {
+    cy.resetDb();
+  });
   it('tsp user enters premove survey', function() {
     tspUserEntersPremoveSurvey();
   });

--- a/cypress/integration/tsp/serviceAgents.js
+++ b/cypress/integration/tsp/serviceAgents.js
@@ -3,6 +3,9 @@ describe('TSP User enters and updates Service Agents', function() {
   beforeEach(() => {
     cy.signIntoTSP();
   });
+  after(() => {
+    cy.resetDb();
+  });
   it('tsp user enters and cancels origin service agent', function() {
     tspUserEntersServiceAgent('Origin');
     tspUserInputsServiceAgent('Origin');

--- a/cypress/integration/tsp/tspUser.js
+++ b/cypress/integration/tsp/tspUser.js
@@ -3,6 +3,9 @@ describe('TSP User Views Shipment', function() {
   beforeEach(() => {
     cy.signIntoTSP();
   });
+  after(() => {
+    cy.resetDb();
+  });
   it('tsp user views shipments in queue new shipments', function() {
     tspUserViewsShipments();
   });


### PR DESCRIPTION
## Description

A lot of our tests have `cy.resetDb();` attached to the last test.  This seems brittle since the last test may change or the order might change.  Instead use the `after()` hook from cypress to call this function instead.

## Reviewer Notes

I've added this `after()` clause to all our tests.  This may not be necessary but I like being consistent.

## Setup

```sh
make e2e_test
```

## Code Review Verification Steps

* [ ] End to end tests pass (`make e2e_test`).
* [ ] Request review from a member of a different team.

## References

* [Cypress Hooks](https://docs.cypress.io/guides/core-concepts/writing-and-organizing-tests.html#Hooks) explains more about how this works