### PR TITLE
Putting shipment into awarded state after AQ offers it to a TSP

### DIFF
--- a/pkg/awardqueue/awardqueue.go
+++ b/pkg/awardqueue/awardqueue.go
@@ -95,6 +95,12 @@ func (aq *AwardQueue) attemptShipmentOffer(shipment models.ShipmentWithOffer) (*
 							// TODO: OfferCount is off by 1
 							aq.logger.Info("Shipment offered to TSP!", zap.Int("current_count", tspPerformance.OfferCount+1))
 							foundAvailableTSP = true
+
+							// Award the shipment
+							if err := models.AwardShipment(aq.db, shipment.ID); err != nil {
+								aq.logger.Error("Failed to set shipment as awarded",
+									zap.Stringer("shipment ID", shipment.ID), zap.Error(err))
+							}
 						}
 						return nil
 					}

--- a/pkg/handlers/internalapi/shipments.go
+++ b/pkg/handlers/internalapi/shipments.go
@@ -99,7 +99,6 @@ func (h CreateShipmentHandler) Handle(params shipmentop.CreateShipmentParams) mi
 		requestedPickupDate = &date
 	}
 
-	// TODO: Set code of service in the TDL linked to from the Shipment model.
 	newShipment := models.Shipment{
 		MoveID:                       move.ID,
 		ServiceMemberID:              session.ServiceMemberID,

--- a/pkg/models/shipment.go
+++ b/pkg/models/shipment.go
@@ -329,6 +329,27 @@ func FetchShipmentByTSP(tx *pop.Connection, tspID uuid.UUID, shipmentID uuid.UUI
 	return &shipments[0], err
 }
 
+// AwardShipment sets the shipment as awarded.
+func AwardShipment(db *pop.Connection, shipmentID uuid.UUID) error {
+	var shipment Shipment
+	if err := db.Find(&shipment, shipmentID); err != nil {
+		return err
+	}
+
+	if err := shipment.Award(); err != nil {
+		return err
+	}
+
+	verrs, err := db.ValidateAndUpdate(&shipment)
+	if err != nil {
+		return err
+	} else if verrs.HasAny() {
+		return fmt.Errorf("Validation failure: %s", verrs)
+	}
+
+	return nil
+}
+
 // AcceptShipmentForTSP accepts a shipment and shipment_offer
 func AcceptShipmentForTSP(db *pop.Connection, tspID uuid.UUID, shipmentID uuid.UUID) (*Shipment, *ShipmentOffer, *validate.Errors, error) {
 


### PR DESCRIPTION
## Description

This PR puts a shipment into "awarded" state once the Award Queue (AQ) has offered the shipment to a TSP.

## Reviewer Notes

The AQ currently attempts to offer shipments regardless of shipment status, so even "draft" shipments will attempt to be awarded.  There's another [story](https://www.pivotaltracker.com/story/show/159912794) to address that.

## Setup

Testing this can be challenging at the moment.  You can certainly review the AQ server tests and verify that they are successful.  Testing it live in the app at the moment is more difficult due to some other issues that need to be addressed for the AQ to award a shipment:

- There must be a TDL reference on the shipment (there's PR #958 to set that when a shipment is saved, but it hasn't been approved/merged yet -- we're still sorting out some issues with it).
- There must be a TSPP within the shipment dates for that TDL.
- There must be a Book Date on the shipment (not sure where this comes from in the UI yet).

If you do get a shipment/TSPP set up as above, then running the AQ via the command line (`make tsp_run`) should cause the shipment to be set as awarded.

## Code Review Verification Steps

* [ ] End to end tests pass (`make e2e_test`).
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/blob/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/n/projects/2136865/stories/159839788) for this change
