### PR TITLE
Fix alert message to include non receipts for no doc found error

### DIFF
--- a/src/scenes/Office/Ppm/PaymentsPanel.jsx
+++ b/src/scenes/Office/Ppm/PaymentsPanel.jsx
@@ -19,7 +19,7 @@ import './PaymentsPanel.css';
 
 const attachmentsErrorMessages = {
   422: 'Encountered an error while trying to create attachments bundle: Document is in the wrong format',
-  424: 'Could not find any receipts for this PPM',
+  424: 'Could not find any receipts or documents for this PPM',
   500: 'An unexpected error has occurred',
 };
 


### PR DESCRIPTION
## Description

If there are no docs of type "other", "weight_ticket", or "storage_expense", a 424 error is returned and this error message is displayed. If the user clicked on the button to retrieve all docs except expense, this error message would currently be confusing.

## Reviewer Notes

@tinyels - If there are no docs of the types listed above except for orders, should the button return a pdf of just the orders?

## Code Review Verification Steps

* [ ] End to end tests pass (`make e2e_test`).
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/blob/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* [ ] Any migrations/schema changes also update the diagram in docs/schema/dp3.sqs
* [ ] There are no aXe warnings for UI.
* [ ] This works in IE.
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @willowbl00
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## Screenshots
<img width="1165" alt="screen shot 2018-09-10 at 1 17 35 pm" src="https://user-images.githubusercontent.com/8170735/45322048-f1b8a100-b4fb-11e8-8bc9-44abfd37ff2c.png">
