### PR TITLE
els moves don't default to ppm 

### DIFF
--- a/pkg/handlers/internalapi/orders.go
+++ b/pkg/handlers/internalapi/orders.go
@@ -107,9 +107,7 @@ func (h CreateOrdersHandler) Handle(params ordersop.CreateOrdersParams) middlewa
 		return handlers.ResponseForVErrors(h.Logger(), verrs, err)
 	}
 
-	// TODO: Don't default to PPM when we start supporting HHG
-	newMoveType := internalmessages.SelectedMoveTypePPM
-	newMove, verrs, err := newOrder.CreateNewMove(h.DB(), &newMoveType)
+	newMove, verrs, err := newOrder.CreateNewMove(h.DB(), nil)
 	if err != nil || verrs.HasAny() {
 		return handlers.ResponseForVErrors(h.Logger(), verrs, err)
 	}

--- a/src/scenes/Moves/MoveTypeWizard.jsx
+++ b/src/scenes/Moves/MoveTypeWizard.jsx
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import PropTypes from 'prop-types';
-
+import { get } from 'lodash';
 import { updateMove, loadMove } from './ducks';
 import WizardPage from 'shared/WizardPage';
 import MoveType from './MoveType';
@@ -21,14 +21,15 @@ export class MoveTypeWizardPage extends Component {
   };
   render() {
     const { pages, pageKey, pendingMoveType, currentMove, error } = this.props;
-    const moveType =
-      pendingMoveType || (currentMove && 'selected_move_type' in currentMove);
+    const hasMoveType = Boolean(
+      pendingMoveType || get(currentMove, 'selected_move_type'),
+    );
     return (
       <WizardPage
         handleSubmit={this.handleSubmit}
         pageList={pages}
         pageKey={pageKey}
-        pageIsValid={Boolean(moveType)}
+        pageIsValid={hasMoveType}
         dirty={Boolean(pendingMoveType)}
         error={error}
       >


### PR DESCRIPTION
## Description

Creating orders now creates a move without selecting the move type

## Setup

You need to create a new user, go through the sm flow until orders have been created and uploaded and then reload the web page to confirm that it now prompts you to select the move type.

## Code Review Verification Steps

* [ x] End to end tests pass (`make e2e_test`).
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/160036318) for this change
