### PR TITLE
Rc 160333316 add approve shipment btn

### DIFF
--- a/cypress/integration/office/officeUserHHG.js
+++ b/cypress/integration/office/officeUserHHG.js
@@ -107,7 +107,7 @@ function officeUserApprovesHHG() {
   // Find move and open it
   cy
     .get('div')
-    .contains('BACON3')
+    .contains('BACON5')
     .dblclick();
 
   cy.location().should(loc => {

--- a/cypress/integration/office/officeUserHHG.js
+++ b/cypress/integration/office/officeUserHHG.js
@@ -13,7 +13,7 @@ describe('office user finds the shipment', function() {
     officeUserViewsInTransitShipment();
   });
   it('office user approves basics for move, verifies and approves HHG shipment', function() {
-    officeUserApprovesMoveAndApprovesHHG();
+    officeUserApprovesHHG();
   });
 });
 
@@ -97,7 +97,7 @@ function officeUserViewsInTransitShipment() {
   });
 }
 
-function officeUserApprovesMoveAndApprovesHHG() {
+function officeUserApprovesHHG() {
   // Open accepted hhg queue
   cy.visit('/queues/hhg_accepted');
   cy.location().should(loc => {

--- a/cypress/integration/office/officeUserHHG.js
+++ b/cypress/integration/office/officeUserHHG.js
@@ -12,6 +12,9 @@ describe('office user finds the shipment', function() {
   it('office user views in transit hhg moves in queue HHGs In Transit', function() {
     officeUserViewsInTransitShipment();
   });
+  it('office user approves basics for move, verifies and approves HHG shipment', function() {
+    officeUserApprovesMoveAndApprovesHHG();
+  });
 });
 
 function officeUserViewsMoves() {
@@ -92,4 +95,59 @@ function officeUserViewsInTransitShipment() {
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/queues\/new\/moves\/[^/]+\/hhg/);
   });
+}
+
+function officeUserApprovesMoveAndApprovesHHG() {
+  // Open accepted hhg queue
+  cy.visit('/queues/hhg_accepted');
+  cy.location().should(loc => {
+    expect(loc.pathname).to.match(/^\/queues\/hhg_accepted/);
+  });
+
+  // Find move and open it
+  cy
+    .get('div')
+    .contains('BACON3')
+    .dblclick();
+
+  cy.location().should(loc => {
+    expect(loc.pathname).to.match(/^\/queues\/new\/moves\/[^/]+\/basics/);
+  });
+
+  // Approve basics
+  cy
+    .get('button')
+    .contains('Approve Basics')
+    .click();
+
+  // disabled because not on hhg tab
+  cy
+    .get('button')
+    .contains('Approve Shipment')
+    .should('be.disabled');
+
+  cy.get('.status').contains('Accepted');
+
+  // Click on HHG tab
+  cy
+    .get('span')
+    .contains('HHG')
+    .click();
+
+  cy.location().should(loc => {
+    expect(loc.pathname).to.match(/^\/queues\/new\/moves\/[^/]+\/hhg/);
+  });
+
+  // Approve HHG
+  cy
+    .get('button')
+    .contains('Approve Shipment')
+    .click();
+
+  cy
+    .get('button')
+    .contains('Approve Shipment')
+    .should('be.disabled');
+
+  cy.get('.status').contains('Approved');
 }

--- a/pkg/testdatagen/scenario/e2ebasic.go
+++ b/pkg/testdatagen/scenario/e2ebasic.go
@@ -536,6 +536,10 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader) {
 	 * Service member with accepted shipment
 	 */
 	email = "hhg@in.transit"
+	/*
+	 * Service member with approved basics and accepted shipment
+	 */
+	email = "hhg@appro.ved"
 
 	offer6 := testdatagen.MakeShipmentOffer(db, testdatagen.Assertions{
 		User: models.User{
@@ -574,4 +578,45 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader) {
 	models.SaveMoveDependencies(db, &hhg6.Move)
 
 
+	offer6 := testdatagen.MakeShipmentOffer(db, testdatagen.Assertions{
+		User: models.User{
+			ID:            uuid.Must(uuid.FromString("f79fd68e-4461-4ba8-b630-9618b913e229")),
+			LoginGovEmail: email,
+		},
+		ServiceMember: models.ServiceMember{
+			ID:            uuid.FromStringOrNil("f79fd68e-4461-4ba8-b630-9618b913e229"),
+			FirstName:     models.StringPointer("HHG"),
+			LastName:      models.StringPointer("ReadyForApprove"),
+			Edipi:         models.StringPointer("4444567890"),
+			PersonalEmail: models.StringPointer(email),
+		},
+		Move: models.Move{
+			ID:               uuid.FromStringOrNil("29cd6b2f-9ef2-48be-b4ee-1c1e0a1456ef"),
+			Locator:          "BACON5",
+			SelectedMoveType: models.StringPointer("HHG"),
+		},
+		Order: models.Order{
+			OrdersNumber:        models.StringPointer("54321"),
+			OrdersTypeDetail:    &typeDetail,
+			DepartmentIndicator: models.StringPointer("AIR_FORCE"),
+			TAC:                 models.StringPointer("99"),
+		},
+		TrafficDistributionList: models.TrafficDistributionList{
+			ID:                uuid.FromStringOrNil("d17e2e3e-9bff-4bb0-b301-f97ad03350c1"),
+			SourceRateArea:    "US62",
+			DestinationRegion: "11",
+			CodeOfService:     "D",
+		},
+		Shipment: models.Shipment{
+			Status: models.ShipmentStatusACCEPTED,
+		},
+		ShipmentOffer: models.ShipmentOffer{
+			TransportationServiceProviderID: tspUser.TransportationServiceProviderID,
+			Accepted:                        models.BoolPointer(true),
+		},
+	})
+
+	hhg6 := offer6.Shipment
+	hhg6.Move.Submit()
+	models.SaveMoveDependencies(db, &hhg6.Move)
 }

--- a/pkg/testdatagen/scenario/e2ebasic.go
+++ b/pkg/testdatagen/scenario/e2ebasic.go
@@ -426,6 +426,12 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader) {
 			Locator:          "BACON3",
 			SelectedMoveType: models.StringPointer("HHG"),
 		},
+		Order: models.Order{
+			OrdersNumber:        models.StringPointer("12345"),
+			OrdersTypeDetail:    &typeDetail,
+			DepartmentIndicator: models.StringPointer("AIR_FORCE"),
+			TAC:                 models.StringPointer("99"),
+		},
 		TrafficDistributionList: models.TrafficDistributionList{
 			ID:                uuid.FromStringOrNil("e09f8b8b-67a6-4ce3-b5c3-bd48c82512fc"),
 			SourceRateArea:    "US62",
@@ -566,5 +572,6 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader) {
 	hhg6 := offer6.Shipment
 	hhg6.Move.Submit()
 	models.SaveMoveDependencies(db, &hhg6.Move)
+
 
 }

--- a/pkg/testdatagen/scenario/e2ebasic.go
+++ b/pkg/testdatagen/scenario/e2ebasic.go
@@ -426,12 +426,6 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader) {
 			Locator:          "BACON3",
 			SelectedMoveType: models.StringPointer("HHG"),
 		},
-		Order: models.Order{
-			OrdersNumber:        models.StringPointer("12345"),
-			OrdersTypeDetail:    &typeDetail,
-			DepartmentIndicator: models.StringPointer("AIR_FORCE"),
-			TAC:                 models.StringPointer("99"),
-		},
 		TrafficDistributionList: models.TrafficDistributionList{
 			ID:                uuid.FromStringOrNil("e09f8b8b-67a6-4ce3-b5c3-bd48c82512fc"),
 			SourceRateArea:    "US62",
@@ -536,10 +530,6 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader) {
 	 * Service member with accepted shipment
 	 */
 	email = "hhg@in.transit"
-	/*
-	 * Service member with approved basics and accepted shipment
-	 */
-	email = "hhg@appro.ved"
 
 	offer6 := testdatagen.MakeShipmentOffer(db, testdatagen.Assertions{
 		User: models.User{
@@ -573,12 +563,16 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader) {
 		},
 	})
 
+	/*
+	 * Service member with approved basics and accepted shipment
+	 */
+	email = "hhg@appro.ved"
+
 	hhg6 := offer6.Shipment
 	hhg6.Move.Submit()
 	models.SaveMoveDependencies(db, &hhg6.Move)
 
-
-	offer6 := testdatagen.MakeShipmentOffer(db, testdatagen.Assertions{
+	offer7 := testdatagen.MakeShipmentOffer(db, testdatagen.Assertions{
 		User: models.User{
 			ID:            uuid.Must(uuid.FromString("f79fd68e-4461-4ba8-b630-9618b913e229")),
 			LoginGovEmail: email,
@@ -616,7 +610,7 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader) {
 		},
 	})
 
-	hhg6 := offer6.Shipment
-	hhg6.Move.Submit()
-	models.SaveMoveDependencies(db, &hhg6.Move)
+	hhg7 := offer7.Shipment
+	hhg7.Move.Submit()
+	models.SaveMoveDependencies(db, &hhg7.Move)
 }

--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -154,12 +154,12 @@ class MoveInfo extends Component {
   };
 
   render() {
+    const { moveDocuments, officeShipment } = this.props;
     const move = this.props.officeMove;
     const serviceMember = this.props.officeServiceMember;
     const orders = this.props.officeOrders;
     const ppm = this.props.officePPM;
     const hhg = this.props.officeHHG;
-    const { moveDocuments } = this.props;
     const showDocumentViewer = this.props.context.flags.documentViewer;
     let upload = get(this.props, 'officeOrders.uploaded_orders.uploads.0'); // there can be only one
     let check = <FontAwesomeIcon className="icon" icon={faCheck} />;
@@ -173,6 +173,7 @@ class MoveInfo extends Component {
       ['APPROVED', 'PAYMENT_REQUESTED', 'COMPLETED'],
       ppm.status,
     );
+    const hhgApproved = hhg.status === 'APPROVED';
 
     if (this.state.redirectToHome) {
       return <Redirect to="/" />;
@@ -319,13 +320,20 @@ class MoveInfo extends Component {
                 disabled={
                   ppmApproved || move.status !== 'APPROVED' || !ordersComplete
                 }
-                style={{
-                  backgroundColor: ppmApproved && 'green',
-                }}
+                style={{ backgroundColor: ppmApproved && 'green' }}
               >
                 Approve PPM
                 {ppmApproved && check}
               </button>
+              <button
+                // onClick={() => approveHHG(officeShipment.id)}
+                disabled={hhgApproved || move.status !== 'APPROVED'}
+                style={{ backgroundColor: hhgApproved && 'green' }}
+              >
+                Approve Shipment
+                {hhgApproved && check}
+              </button>
+              <CancelPanel cancelMove={this.cancelMove} />
               <ConfirmWithReasonButton
                 buttonTitle="Cancel Move"
                 reasonPrompt="Why is the move being canceled?"

--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -353,7 +353,6 @@ class MoveInfo extends Component {
                 </button>
               )}
 
-              <CancelPanel cancelMove={this.cancelMove} />
               <ConfirmWithReasonButton
                 buttonTitle="Cancel Move"
                 reasonPrompt="Why is the move being canceled?"

--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -32,6 +32,7 @@ import {
   loadMoveDependencies,
   approveBasics,
   approvePPM,
+  approveHHG,
   cancelMove,
   patchShipment,
 } from './ducks';
@@ -117,6 +118,10 @@ class MoveInfo extends Component {
     this.props.approvePPM(this.props.officeMove.id, this.props.officePPM.id);
   };
 
+  approveHHG = () => {
+    this.props.approveHHG(this.props.officeShipment.id);
+  };
+
   cancelMove = cancelReason => {
     this.props.cancelMove(this.props.officeMove.id, cancelReason).then(() => {
       this.setState({ redirectToHome: true });
@@ -154,7 +159,7 @@ class MoveInfo extends Component {
   };
 
   render() {
-    const { moveDocuments, officeShipment } = this.props;
+    const { moveDocuments } = this.props;
     const move = this.props.officeMove;
     const serviceMember = this.props.officeServiceMember;
     const orders = this.props.officeOrders;
@@ -326,7 +331,7 @@ class MoveInfo extends Component {
                 {ppmApproved && check}
               </button>
               <button
-                // onClick={() => approveHHG(officeShipment.id)}
+                onClick={this.approveHHG}
                 disabled={hhgApproved || move.status !== 'APPROVED'}
                 style={{ backgroundColor: hhgApproved && 'green' }}
               >
@@ -437,6 +442,7 @@ const mapDispatchToProps = dispatch =>
       getMoveDocumentsForMove,
       approveBasics,
       approvePPM,
+      approveHHG,
       cancelMove,
       patchShipment,
     },

--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -184,7 +184,7 @@ class MoveInfo extends Component {
       ppm.status,
     );
     const hhgApproved = hhg.status === 'APPROVED';
-
+    const moveApproved = move.status === 'APPROVED';
     if (this.state.redirectToHome) {
       return <Redirect to="/" />;
     }
@@ -314,39 +314,32 @@ class MoveInfo extends Component {
                 </Alert>
               )}
               <button
+                className={`${moveApproved ? 'btn__approve--green' : ''}`}
                 onClick={this.approveBasics}
-                disabled={move.status === 'APPROVED' || !ordersComplete}
-                style={{
-                  backgroundColor: move.status === 'APPROVED' && 'green',
-                }}
+                disabled={moveApproved || !ordersComplete}
               >
                 Approve Basics
-                {move.status === 'APPROVED' && check}
+                {moveApproved && check}
               </button>
               {isPPM ? (
                 <button
+                  className={`${ppmApproved ? 'btn__approve--green' : ''}`}
                   onClick={this.approvePPM}
-                  disabled={
-                    !isPPM ||
-                    ppmApproved ||
-                    move.status !== 'APPROVED' ||
-                    !ordersComplete
-                  }
-                  style={{ backgroundColor: ppmApproved && 'green' }}
+                  disabled={ppmApproved || !moveApproved || !ordersComplete}
                 >
                   Approve PPM
                   {ppmApproved && check}
                 </button>
               ) : (
                 <button
+                  className={`${hhgApproved ? 'btn__approve--green' : ''}`}
                   onClick={this.approveHHG}
                   disabled={
                     hhgApproved ||
-                    move.status !== 'APPROVED' ||
+                    !moveApproved ||
                     !ordersComplete ||
                     currentTab !== 'hhg'
                   }
-                  style={{ backgroundColor: hhgApproved && 'green' }}
                 >
                   Approve Shipments
                   {hhgApproved && check}
@@ -382,7 +375,7 @@ class MoveInfo extends Component {
                 <p>No orders have been uploaded.</p>
               ) : (
                 <div>
-                  {move.status === 'APPROVED' ? (
+                  {moveApproved ? (
                     <div className="panel-field">
                       <FontAwesomeIcon
                         style={{ color: 'green' }}
@@ -420,6 +413,10 @@ class MoveInfo extends Component {
     );
   }
 }
+
+MoveInfo.defaultProps = {
+  move: {},
+};
 
 MoveInfo.propTypes = {
   loadMoveDependencies: PropTypes.func.isRequired,

--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -110,11 +110,6 @@ class MoveInfo extends Component {
     this.props.getMoveDocumentsForMove(this.props.match.params.moveId);
   }
 
-  get currentTab() {
-    const pathnames = this.props.location.pathname.split('/');
-    return pathnames[pathnames.length - 1];
-  }
-
   approveBasics = () => {
     this.props.approveBasics(this.props.match.params.moveId);
   };
@@ -170,6 +165,11 @@ class MoveInfo extends Component {
     const orders = this.props.officeOrders;
     const ppm = this.props.officePPM;
     const hhg = this.props.officeHHG;
+    const isPPM = !isEmpty(this.props.officePPM);
+    const isHHG = !isEmpty(this.props.officeHHG);
+    const pathnames = this.props.location.pathname.split('/');
+    const currentTab = pathnames[pathnames.length - 1];
+
     const showDocumentViewer = this.props.context.flags.documentViewer;
     let upload = get(this.props, 'officeOrders.uploaded_orders.uploads.0'); // there can be only one
     let check = <FontAwesomeIcon className="icon" icon={faCheck} />;
@@ -255,13 +255,13 @@ class MoveInfo extends Component {
                   {capitalize(move.status)}
                 </span>
               </NavTab>
-              {!isEmpty(ppm) && (
+              {isPPM && (
                 <NavTab to="/ppm">
                   <span className="title">PPM</span>
                   {this.renderPPMTabStatus()}
                 </NavTab>
               )}
-              {!isEmpty(hhg) && (
+              {isHHG && (
                 <NavTab to="/hhg">
                   <span className="title">HHG</span>
                   <span className="status">
@@ -288,12 +288,10 @@ class MoveInfo extends Component {
                   path={`${this.props.match.path}/basics`}
                   component={BasicsTabContent}
                 />
-                !isEmpty(ppm) &&
                 <PrivateRoute
                   path={`${this.props.match.path}/ppm`}
                   component={PPMTabContent}
                 />
-                !isEmpty(hhg) &&
                 <PrivateRoute path={`${this.props.match.path}/hhg`}>
                   <HHGTabContent
                     officeHHG={JSON.stringify(this.props.officeHHG)}
@@ -325,29 +323,36 @@ class MoveInfo extends Component {
                 Approve Basics
                 {move.status === 'APPROVED' && check}
               </button>
-              <button
-                onClick={this.approvePPM}
-                disabled={
-                  ppmApproved || move.status !== 'APPROVED' || !ordersComplete
-                }
-                style={{ backgroundColor: ppmApproved && 'green' }}
-              >
-                Approve PPM
-                {ppmApproved && check}
-              </button>
-              <button
-                onClick={this.approveHHG}
-                disabled={
-                  hhgApproved ||
-                  move.status !== 'APPROVED' ||
-                  !ordersComplete ||
-                  this.currentTab !== 'hhg'
-                }
-                style={{ backgroundColor: hhgApproved && 'green' }}
-              >
-                Approve Shipments
-                {hhgApproved && check}
-              </button>
+              {isPPM ? (
+                <button
+                  onClick={this.approvePPM}
+                  disabled={
+                    !isPPM ||
+                    ppmApproved ||
+                    move.status !== 'APPROVED' ||
+                    !ordersComplete
+                  }
+                  style={{ backgroundColor: ppmApproved && 'green' }}
+                >
+                  Approve PPM
+                  {ppmApproved && check}
+                </button>
+              ) : (
+                <button
+                  onClick={this.approveHHG}
+                  disabled={
+                    hhgApproved ||
+                    move.status !== 'APPROVED' ||
+                    !ordersComplete ||
+                    currentTab !== 'hhg'
+                  }
+                  style={{ backgroundColor: hhgApproved && 'green' }}
+                >
+                  Approve Shipments
+                  {hhgApproved && check}
+                </button>
+              )}
+
               <CancelPanel cancelMove={this.cancelMove} />
               <ConfirmWithReasonButton
                 buttonTitle="Cancel Move"

--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -110,6 +110,11 @@ class MoveInfo extends Component {
     this.props.getMoveDocumentsForMove(this.props.match.params.moveId);
   }
 
+  get currentTab() {
+    const pathnames = this.props.location.pathname.split('/');
+    return pathnames[pathnames.length - 1];
+  }
+
   approveBasics = () => {
     this.props.approveBasics(this.props.match.params.moveId);
   };
@@ -332,10 +337,15 @@ class MoveInfo extends Component {
               </button>
               <button
                 onClick={this.approveHHG}
-                disabled={hhgApproved || move.status !== 'APPROVED'}
+                disabled={
+                  hhgApproved ||
+                  move.status !== 'APPROVED' ||
+                  !ordersComplete ||
+                  this.currentTab !== 'hhg'
+                }
                 style={{ backgroundColor: hhgApproved && 'green' }}
               >
-                Approve Shipment
+                Approve Shipments
                 {hhgApproved && check}
               </button>
               <CancelPanel cancelMove={this.cancelMove} />

--- a/src/scenes/Office/MoveInfo.test.js
+++ b/src/scenes/Office/MoveInfo.test.js
@@ -26,6 +26,9 @@ const loadDependenciesHasSuccess = false;
 const moveIsCanceling = false;
 const moveHasCancelError = null;
 const moveHasCancelSuccess = false;
+const location = {
+  pathname: '',
+};
 const match = {
   params: { moveID: '123456' },
   url: 'www.nino.com',
@@ -57,6 +60,7 @@ describe('Loads MoveInfo', () => {
             PPMsHaveLoadSuccess={PPMsHaveLoadSuccess}
             loadDependenciesHasError={loadDependenciesHasError}
             loadDependenciesHasSuccess={loadDependenciesHasSuccess}
+            location={location}
             match={match}
             loadMoveDependencies={dummyFunc}
             moveIsCanceling={moveIsCanceling}

--- a/src/scenes/Office/api.js
+++ b/src/scenes/Office/api.js
@@ -121,6 +121,16 @@ export async function ApprovePPM(moveId, ppmId) {
   return response.body;
 }
 
+// HHG status
+export async function ApproveHHG(shipmentId) {
+  const client = await getClient();
+  const response = await client.apis.shipments.approveHHG({
+    shipmentId,
+  });
+  checkResponse(response, 'failed to approve hhg due to server error');
+  return response.body;
+}
+
 // Reimbursement status
 export async function ApproveReimbursement(reimbursementId) {
   const client = await getClient();

--- a/src/scenes/Office/ducks.js
+++ b/src/scenes/Office/ducks.js
@@ -601,6 +601,7 @@ export function officeReducer(state = initialState, action) {
         error: action.error.message,
       });
 
+    // HHG STATUS
     case APPROVE_HHG.success:
       return Object.assign({}, state, {
         officeMove: {

--- a/src/scenes/Office/ducks.js
+++ b/src/scenes/Office/ducks.js
@@ -9,6 +9,7 @@ import {
   LoadPPMs,
   ApproveBasics,
   ApprovePPM,
+  ApproveHHG,
   ApproveReimbursement,
   CancelMove,
   DownloadPPMAttachments,
@@ -33,6 +34,7 @@ const loadPPMsType = 'LOAD_PPMS';
 const updatePPMType = 'UPDATE_PPM';
 const approveBasicsType = 'APPROVE_BASICS';
 const approvePPMType = 'APPROVE_PPM';
+const approveHHGType = 'APPROVE_HHG';
 const approveReimbursementType = 'APPROVE_REIMBURSEMENT';
 const downloadPPMAttachmentsType = 'DOWNLOAD_ATTACHMENTS';
 const cancelMoveType = 'CANCEL_MOVE';
@@ -163,6 +165,11 @@ export const approveBasics = ReduxHelpers.generateAsyncActionCreator(
 export const approvePPM = ReduxHelpers.generateAsyncActionCreator(
   approvePPMType,
   ApprovePPM,
+);
+
+export const approveHHG = ReduxHelpers.generateAsyncActionCreator(
+  approveHHGType,
+  ApproveHHG,
 );
 
 export const approveReimbursement = ReduxHelpers.generateAsyncActionCreator(

--- a/src/scenes/Office/ducks.js
+++ b/src/scenes/Office/ducks.js
@@ -79,6 +79,8 @@ const APPROVE_BASICS = ReduxHelpers.generateAsyncActionTypes(approveBasicsType);
 
 const APPROVE_PPM = ReduxHelpers.generateAsyncActionTypes(approvePPMType);
 
+const APPROVE_HHG = ReduxHelpers.generateAsyncActionTypes(approveHHGType);
+
 export const CANCEL_MOVE = ReduxHelpers.generateAsyncActionTypes(
   cancelMoveType,
 );
@@ -596,6 +598,19 @@ export function officeReducer(state = initialState, action) {
     case APPROVE_PPM.failure:
       return Object.assign({}, state, {
         ppmIsApproving: false,
+        error: action.error.message,
+      });
+
+    case APPROVE_HHG.success:
+      return Object.assign({}, state, {
+        officeMove: {
+          ...state.officeMove,
+          shipments: [action.payload],
+        },
+      });
+
+    case APPROVE_HHG.failure:
+      return Object.assign({}, state, {
         error: action.error.message,
       });
 

--- a/src/shared/Header/Office/index.css
+++ b/src/shared/Header/Office/index.css
@@ -21,3 +21,7 @@
 header.header {
   border-bottom: 3px solid black;
 }
+
+.usa-width-one-fourth .btn__approve--green {
+  background-color: green;
+}


### PR DESCRIPTION
## Description 
An office user reviewing an HHG move can now approve the HHG Shipment after reviewing and approving the basic information is valid

## Reviewer Notes
- As I was adding code for checking if the move is PPM or HHG, I noticed some code not being used in the route that I removed
- For HHG, I made it so they cannot approve the shipment until they are on the HHG tab, but I left the Approve PPM behavior as is

## Setup

Make some test data

```sh
make db_dev_reset && make db_dev_migrate && ./bin/generate-test-data -scenario=7
```
Run the client and server

```sh
make server_run
make office_client_run
```

## Code Review Verification Steps

* [ ] End to end tests pass (`make e2e_test`).
* [ ] There are no aXe warnings for UI.
* [ ] This works in IE.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/n/projects/2181745/stories/159670548) for this change

## Screenshots and videos

https://streamable.com/e0q70
