### PR TITLE
Fix sql security hole and query antipattern

### DIFF
--- a/pkg/models/shipment.go
+++ b/pkg/models/shipment.go
@@ -295,7 +295,6 @@ func FetchShipmentsByTSP(tx *pop.Connection, tspID uuid.UUID, status []string, o
 		for index, st := range status {
 			statusStrings[index] = st
 		}
-
 		query = query.Where("shipments.status IN ($2)", statusStrings...)
 	}
 

--- a/pkg/models/shipment.go
+++ b/pkg/models/shipment.go
@@ -287,7 +287,7 @@ func FetchShipmentsByTSP(tx *pop.Connection, tspID uuid.UUID, status []string, o
 		"SecondaryPickupAddress",
 		"DeliveryAddress",
 		"PartialSITDeliveryAddress").
-		Where("shipment_offers.transportation_service_provider_id = ?", tspID).
+		Where("shipment_offers.transportation_service_provider_id = $1", tspID).
 		LeftJoin("shipment_offers", "shipments.id=shipment_offers.shipment_id")
 
 	if len(status) > 0 {
@@ -295,7 +295,8 @@ func FetchShipmentsByTSP(tx *pop.Connection, tspID uuid.UUID, status []string, o
 		for index, st := range status {
 			statusStrings[index] = st
 		}
-		query = query.Where("shipments.status IN (?)", statusStrings...)
+
+		query = query.Where("shipments.status IN ($2)", statusStrings...)
 	}
 
 	// Manage ordering by pickup or delivery date

--- a/pkg/models/shipment.go
+++ b/pkg/models/shipment.go
@@ -2,7 +2,6 @@ package models
 
 import (
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/gobuffalo/pop"
@@ -280,7 +279,7 @@ func FetchShipmentsByTSP(tx *pop.Connection, tspID uuid.UUID, status []string, o
 
 	shipments := []Shipment{}
 
-	query := tx.Eager(
+	query := tx.Q().Eager(
 		"TrafficDistributionList",
 		"ServiceMember",
 		"Move",
@@ -288,15 +287,15 @@ func FetchShipmentsByTSP(tx *pop.Connection, tspID uuid.UUID, status []string, o
 		"SecondaryPickupAddress",
 		"DeliveryAddress",
 		"PartialSITDeliveryAddress").
-		Where("shipment_offers.transportation_service_provider_id = $1", tspID).
+		Where("shipment_offers.transportation_service_provider_id = ?", tspID).
 		LeftJoin("shipment_offers", "shipments.id=shipment_offers.shipment_id")
 
 	if len(status) > 0 {
-		statusStrings := make([]string, len(status))
+		statusStrings := make([]interface{}, len(status))
 		for index, st := range status {
-			statusStrings[index] = fmt.Sprintf("'%s'", st)
+			statusStrings[index] = st
 		}
-		query = query.Where(fmt.Sprintf("shipments.status IN (%s)", strings.Join(statusStrings, ", ")))
+		query = query.Where("shipments.status IN (?)", statusStrings...)
 	}
 
 	// Manage ordering by pickup or delivery date


### PR DESCRIPTION
## Description

The fix here closes a security hole I introduced while building out the API.  @ntwyman caught it while we were looking at related code and so here's the fix.

https://xkcd.com/327/

## Reviewer Notes

I've had to rely on `?` instead of `$1` parameter injection.  This is because I can't know in advance the number of status strings I'm expecting.  And unfortunately Pop doesn't keep track of the current number I'm using in with the `$1` type statements.  This means Pop will do strange things like use the UUID from the first argument as part of the argument list to the IN clause.  I wasn't particularly happy with that.

It's worth looking at the code here: https://github.com/gobuffalo/pop/blob/master/query.go#L116-L136

## Setup

```sh
go test ./pkg/handlers/publicapi/ -v -testify.m TestIndexShipmentsHandlerFilterByStatus
```

## Code Review Verification Steps

* [x] End to end tests pass (`make e2e_test`).
* [x] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* [x] Request review from a member of a different team.

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/160498928) for this change