### PR TITLE
Sb add migration documentation

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -24,7 +24,7 @@ echo "Code goes here"
 * Any new migrations/schema changes:
   * [ ] Update the diagram in docs/schema/dp3.sqs (see [Updating and changing the model](./docs/schema/README.md#updating-and-changing-the-model))
   * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](./docs/database.md#zero-downtime-migrations))
-  * [ ] Have been communicated to all engineers, likely on slack
+  * [ ] Have been communicated to #dp3-engineering
 * [ ] There are no aXe warnings for UI.
 * [ ] This works in IE.
 * Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,11 +17,14 @@ echo "Code goes here"
 ## Code Review Verification Steps
 
 * [ ] End to end tests pass (`make e2e_test`).
-* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/blob/master/docs/backend.md#logging)
+* [ ] Code follows the guidelines for [Logging](./docs/backend.md#logging)
 * [ ] The requirements listed in
- [Querying the Database Safely](https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely)
+ [Querying the Database Safely](./docs/backend.md#querying-the-database-safely)
  have been satisfied.
-* [ ] Any migrations/schema changes also update the diagram in docs/schema/dp3.sqs (see [Updating and changing the model](https://github.com/transcom/mymove/blob/master/docs/schema/README.md#updating-and-changing-the-model)
+* Any new migrations/schema changes:
+  * [ ] Update the diagram in docs/schema/dp3.sqs (see [Updating and changing the model](./docs/schema/README.md#updating-and-changing-the-model))
+  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](./docs/database.md#zero-downtime-migrations))
+  * [ ] Have been communicated to all engineers, likely on slack
 * [ ] There are no aXe warnings for UI.
 * [ ] This works in IE.
 * Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:

--- a/.spelling
+++ b/.spelling
@@ -318,6 +318,7 @@ pjdufour-truss
 dynamike
 fillable
 symlinked
+dp3-engineering
 - /usr/local
 # Put all custom terms BEFORE this comment, lest you end up in an mdspell pain cycle.
  - docs/data/tspp-data-creation.md

--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ There are a few handy targets in the Makefile to help you interact with the dev 
 
 #### Migrations
 
-To add new migrations, see the [database development guide](./docs/database.md)
+To add new regular and/or secure migrations, see the [database development guide](./docs/database.md)
 
 Running migrations in local development:
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ This prototype was built by a [Defense Digital Service](https://www.dds.mil/) te
   * [Database](#database)
     * [Dev Commands](#dev-commands)
     * [Migrations](#migrations)
-    * [Secure Migrations](#secure-migrations)
   * [Environment Variables](#environment-variables)
   * [Documentation](#documentation)
   * [Spellcheck](#spellcheck)
@@ -275,15 +274,7 @@ There are a few handy targets in the Makefile to help you interact with the dev 
 
 #### Migrations
 
-If you need to change the database schema, you'll need to write a migration.
-
-Creating a migration:
-
-Use soda (a part of [pop](https://github.com/gobuffalo/pop/)) to generate migrations. In order to make using soda easy, a wrapper is in `./bin/soda` that sets the go environment and working directory correctly.
-
-If you are generating a new model, use `./bin/gen_model model-name column-name:type column-name:type ...`. id, created_at and updated_at are all created automatically.
-
-If you are modifying an existing model, use `./bin/soda generate migration migration-name` and add the [Fizz instructions](https://github.com/gobuffalo/fizz) yourself to the created files.
+To add new migrations, see the [database development guide](./docs/database.md)
 
 Running migrations in local development:
 
@@ -299,35 +290,6 @@ Migrations are run automatically by CircleCI as part of the standard deploy proc
 1. Migrations run inside the container against the environment's database.
 1. If migrations fail, CircleCI fails the deploy.
 1. If migrations pass, CircleCI continues with the deploy.
-
-#### Secure Migrations
-
-**NOTICE**: Before adding SSNs or other PII, please consult with Infra.
-
-We are piggy-backing on the migration system for importing static datasets. This approach causes problems if the data isn't public, as all of the migrations are in this open source repository. To address this, we have what are called "secure migrations."
-
-To create a secure migration:
-
-* Generate new migration files: `bin/generate-secure-migration <migration_name>`
-  * This creates two migration files: a local test file with no secret data, and a production file to be uploaded to S3 that will have sensitive data.
-* Edit the production migration first, and put whatever sensitive data in it that you need to.
-* Copy the production migration into the local test migration.
-* Scrub the test migration of sensitive data, but use it to test the gist of the production migration operation.
-* Test the local migration by running `make db_dev_migrate`. You should see it run your local migration.
-* Upload the migration to S3 with: `bin/upload-secure-migration <production_migration_file>`
-* Open a pull request!
-* When the pull request lands, the production migrations will be run on Staging and Prod.
-
-Gory Details:
-
-When this migration is run, `soda` will shell out to our script, `apply-secure-migration.sh`. This script will:
-
-* Look at `$SECURE_MIGRATION_SOURCE` to determine if the migrations should be found locally (`local`, for dev & testing,) or on S3 (`s3`).
-* If the file is to be found on S3, it is downloaded from `${AWS_S3_BUCKET_NAME}/secure-migrations/${FILENAME}`.
-* If it is to be found locally, the script looks for it in `$SECURE_MIGRATION_DIR`.
-* Regardless of where the migration comes from, it is then applied to the database by essentially doing: `psql < ${FILENAME}`.
-
-There is an example of a secure migration [in the repo](https://github.com/transcom/mymove/blob/master/migrations/20180424010930_test_secure_migrations.up.fizz).
 
 ### Environment Variables
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,3 +8,4 @@ If you are looking to understand choices made in this project, see the list of [
 
 * [Front-end / React](frontend.md) guide
 * [Back-end / Go](backend.md) guide
+* [Database / Postgres](database.md) guide

--- a/docs/database.md
+++ b/docs/database.md
@@ -28,7 +28,7 @@ If you are modifying an existing model, use `./bin/soda generate migration migra
 
 ## Zero-Downtime Migrations
 
-As a good practice, all of our migrations should create a database state that works both with the current version of the application code _and_ the new version of the application code. This allows us to run migrations before the new app code is live without creating downtime for our users.
+As a good practice, all of our migrations should create a database state that works both with the current version of the application code _and_ the new version of the application code. This allows us to run migrations before the new app code is live without creating downtime for our users. More in-depth list of migrations that might cause issues are outlined in our [google drive](https://docs.google.com/document/d/1ht57qz1ut--fqTQdLKbCqbZO_f_S0UoVSIyO6Bg-wJw).
 
 Eg: If we need to rename a column, doing a traditional rename would cause the app to fail if the database changes went live before the new application code (pointing to the new column name) went live. Instead, this should be done in a two-stage process.
 

--- a/docs/database.md
+++ b/docs/database.md
@@ -1,5 +1,19 @@
 # Database Development Guide
 
+## Table of Contents
+
+<!-- Table of Contents auto-generated with `bin/generate-md-toc.sh` -->
+
+<!-- toc -->
+
+* [Migrations](#migrations)
+* [Zero-Downtime Migrations](#zero-downtime-migrations)
+* [Secure Migrations](#secure-migrations)
+
+Regenerate with "bin/generate-md-toc.sh"
+
+<!-- tocstop -->
+
 ## Migrations
 
 If you need to change the database schema, you'll need to write a migration.

--- a/docs/database.md
+++ b/docs/database.md
@@ -12,6 +12,17 @@ If you are generating a new model, use `./bin/gen_model model-name column-name:t
 
 If you are modifying an existing model, use `./bin/soda generate migration migration-name` and add the [Fizz instructions](https://github.com/gobuffalo/fizz) yourself to the created files.
 
+## Zero-Downtime Migrations
+
+As a good practice, all of our migrations should create a database state that works both with the current version of the application code _and_ the new version of the application code. This allows us to run migrations before the new app code is live without creating downtime for our users.
+
+Eg: If we need to rename a column, doing a traditional rename would cause the app to fail if the database changes went live before the new application code (pointing to the new column name) went live. Instead, this should be done in a two-stage process.
+
+1. Write a migration adding a new column with the preferred name and copy the data from the old column into it. The old column will effectively be deprecated at this point.
+2. After the migration and new app code have been deployed to production, write a second migration to remove the old/deprecated column.
+
+Similarly, if a column needs to be dropped, we should deprecate the column in one pull request and then actually remove it in a follow-up pull request. Deprecation can be done by renaming the column to `deprecated_column_name`. This process has an added side affect of helping us keep our migrations reversible, since columns can always be re-added, but getting old data back into those columns is a more difficult process.
+
 ## Secure Migrations
 
 **NOTICE**: Before adding SSNs or other PII, please consult with Infra.


### PR DESCRIPTION
## Description

Add documentation to outline the new zero-downtime deploy process we would like the team to follow.

## Reviewer Notes

I moved some content from the main README into a new developer doc. It made sense to me to keep all of the info about writing code co-located, while all of the information about running the code is still in the main README for the repo. But maybe there's a better way to organize this so it makes sense to brains other than mine?

## Code Review Verification Steps

* [ ] Request review from a member of a different team.

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/160296600) that inspired the need for this change
