### PR TITLE
Rek shipment intransit backend

### DIFF
--- a/cmd/generate_test_data/main.go
+++ b/cmd/generate_test_data/main.go
@@ -73,7 +73,7 @@ func main() {
 		numTspUsers := 2
 		numShipments := 25
 		numShipmentOfferSplit := []int{15, 10}
-		status := []models.ShipmentStatus{"DRAFT", "AWARDED", "ACCEPTED"}
+		status := []models.ShipmentStatus{"DRAFT", "AWARDED", "ACCEPTED", "IN_TRANSIT"}
 		_, _, _, err := testdatagen.CreateShipmentOfferData(db, numTspUsers, numShipments, numShipmentOfferSplit, status)
 		if err != nil {
 			log.Panic(err)

--- a/cypress/integration/office/officeUserHHG.js
+++ b/cypress/integration/office/officeUserHHG.js
@@ -9,6 +9,9 @@ describe('office user finds the shipment', function() {
   it('office user views accepted hhg moves in queue Accepted HHGs', function() {
     officeUserViewsAcceptedShipment();
   });
+  it('office user views in transit hhg moves in queue HHGs In Transit', function() {
+    officeUserViewsInTransitShipment();
+  });
 });
 
 function officeUserViewsMoves() {
@@ -48,6 +51,33 @@ function officeUserViewsAcceptedShipment() {
   cy
     .get('div')
     .contains('BACON3')
+    .dblclick();
+
+  cy.location().should(loc => {
+    expect(loc.pathname).to.match(/^\/queues\/new\/moves\/[^/]+\/basics/);
+  });
+
+  cy
+    .get('a')
+    .contains('HHG')
+    .click(); // navtab
+
+  cy.location().should(loc => {
+    expect(loc.pathname).to.match(/^\/queues\/new\/moves\/[^/]+\/hhg/);
+  });
+}
+
+function officeUserViewsInTransitShipment() {
+  // Open new moves queue
+  cy.visit('/queues/hhg_in_transit');
+  cy.location().should(loc => {
+    expect(loc.pathname).to.match(/^\/queues\/hhg_in_transit/);
+  });
+
+  // Find move (generated in e2ebasic.go) and open it
+  cy
+    .get('div')
+    .contains('NINOPK')
     .dblclick();
 
   cy.location().should(loc => {

--- a/docs/schema/dp3.sqs
+++ b/docs/schema/dp3.sqs
@@ -1,723 +1,94 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SQLContainer>
     <SQLTable>
-        <name><![CDATA[public.office_users]]></name>
+        <name><![CDATA[public.gbl_number_trackers]]></name>
         <schema><![CDATA[public]]></schema>
         <location>
-            <x>1689.00</x>
-            <y>260.00</y>
-        </location>
-        <size>
-            <width>317.00</width>
-            <height>220.00</height>
-        </size>
-        <zorder>24</zorder>
-        <SQLField>
-            <name><![CDATA[id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <primaryKey>1</primaryKey>
-            <notNull><![CDATA[1]]></notNull>
-            <PK_NAME><![CDATA[office_users_pkey]]></PK_NAME>
-            <uid><![CDATA[DAF73953-0372-4ABC-870D-A4C4999350B4]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[user_id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <referencesField>id</referencesField>
-            <referencesTable>public.users</referencesTable>
-            <deleteAction>4</deleteAction>
-            <updateAction>4</updateAction>
-            <referencesField><![CDATA[id]]></referencesField>
-            <referencesTable><![CDATA[public.users]]></referencesTable>
-            <sourceCardinality>0</sourceCardinality>
-            <destinationCardinality>0</destinationCardinality>
-            <referencesFieldUID><![CDATA[BD0EC088-24B4-4DFF-A08C-82DC78218CA7]]></referencesFieldUID>
-            <referencesTableUID><![CDATA[C515D33B-5FF0-4039-A550-4E3ED3683006]]></referencesTableUID>
-            <foreignKeyName><![CDATA[office_users_user_id_fkey]]></foreignKeyName>
-            <uid><![CDATA[1F2C2F0A-8A41-482B-ACB8-319AEAA69D2A]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[last_name]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[8379E60D-EEB9-4B5C-AD0F-0295D497A291]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[first_name]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[58CA91BE-42C6-4AAA-96D9-B748A9998468]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[middle_initials]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <uid><![CDATA[60EA79C5-ECF0-4AB2-BFDF-B023A8E259C0]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[email]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[2D95CDCA-340B-4DF4-A094-82ABF0C16684]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[telephone]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[EB4DCE12-B3E1-4FB3-A646-358A69EECB97]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[transportation_office_id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <referencesField>id</referencesField>
-            <referencesTable>public.transportation_offices</referencesTable>
-            <deleteAction>4</deleteAction>
-            <updateAction>4</updateAction>
-            <referencesField><![CDATA[id]]></referencesField>
-            <referencesTable><![CDATA[public.transportation_offices]]></referencesTable>
-            <sourceCardinality>0</sourceCardinality>
-            <destinationCardinality>0</destinationCardinality>
-            <referencesFieldUID><![CDATA[656AE989-CC75-4EDF-9251-D3F9345307F3]]></referencesFieldUID>
-            <referencesTableUID><![CDATA[2827CA86-4F1C-483D-AD59-976B282F0DDB]]></referencesTableUID>
-            <foreignKeyName><![CDATA[office_users_transportation_office_id_fkey]]></foreignKeyName>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[870126AE-8FF5-4305-B9D9-DC4BC4C9BEEE]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[created_at]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[E0713863-C9E8-4F86-B5BB-CD9C9A33E9EB]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[updated_at]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[CE6D7DF1-9C9F-47EE-B0FC-8D06A19C5DBB]]></uid>
-        </SQLField>
-        <labelWindowIndex><![CDATA[24]]></labelWindowIndex>
-        <PK_KEY_NAME><![CDATA[office_users_pkey]]></PK_KEY_NAME>
-        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
-        <uid><![CDATA[01585FC9-1CAC-431C-B293-89D6245C4CDF]]></uid>
-    </SQLTable>
-    <SQLTable>
-        <name><![CDATA[public.personally_procured_moves]]></name>
-        <schema><![CDATA[public]]></schema>
-        <location>
-            <x>10.00</x>
-            <y>670.00</y>
-        </location>
-        <size>
-            <width>386.00</width>
-            <height>480.00</height>
-        </size>
-        <zorder>22</zorder>
-        <SQLField>
-            <name><![CDATA[id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <primaryKey>1</primaryKey>
-            <forcedUnique><![CDATA[1]]></forcedUnique>
-            <notNull><![CDATA[1]]></notNull>
-            <PK_NAME><![CDATA[personally_procured_moves_pkey]]></PK_NAME>
-            <uid><![CDATA[6532847F-1005-4BCB-BB4B-716FAF280CE8]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[move_id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <referencesField>id</referencesField>
-            <referencesTable>public.moves</referencesTable>
-            <deleteAction>4</deleteAction>
-            <updateAction>4</updateAction>
-            <referencesField><![CDATA[id]]></referencesField>
-            <referencesTable><![CDATA[public.moves]]></referencesTable>
-            <sourceCardinality>0</sourceCardinality>
-            <destinationCardinality>0</destinationCardinality>
-            <referencesFieldUID><![CDATA[C922530B-6397-4EC9-BC45-4225E4B7F9E0]]></referencesFieldUID>
-            <referencesTableUID><![CDATA[E5CC2853-5488-415D-ACA3-C18092A0E3E5]]></referencesTableUID>
-            <foreignKeyName><![CDATA[personally_procured_moves_move_id_fkey]]></foreignKeyName>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[8187C07F-85E8-4A63-8213-248CBBF0FFFA]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[size]]></name>
-            <type><![CDATA[CHARACTER VARYING(255)]]></type>
-            <uid><![CDATA[64F14F47-B336-4FAF-9B8D-C5BE6ED55585]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[weight_estimate]]></name>
-            <type><![CDATA[INTEGER]]></type>
-            <uid><![CDATA[DBAE87C8-339E-4695-9AAB-322161CFB1BA]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[created_at]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[4FDA384C-8851-4B1D-AE1B-B7CB79A28544]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[updated_at]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[8155020F-9CDE-481C-A218-8F69A0226CF0]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[planned_move_date]]></name>
-            <type><![CDATA[DATE]]></type>
-            <uid><![CDATA[B22193B1-9580-4E56-BBC1-EF8361B1680F]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[pickup_postal_code]]></name>
-            <type><![CDATA[CHARACTER VARYING(255)]]></type>
-            <uid><![CDATA[D5FFD9D5-B869-4064-9932-CA8711599392]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[additional_pickup_postal_code]]></name>
-            <type><![CDATA[CHARACTER VARYING(255)]]></type>
-            <uid><![CDATA[097F6230-3719-46C5-9A1E-6DBC5048D657]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[destination_postal_code]]></name>
-            <type><![CDATA[CHARACTER VARYING(255)]]></type>
-            <uid><![CDATA[D757DBCA-1FE0-4C13-8EA5-B0D134CD591E]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[days_in_storage]]></name>
-            <type><![CDATA[INTEGER]]></type>
-            <uid><![CDATA[4FFE437E-EA87-4DE0-98A9-4186E9ACECEC]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[status]]></name>
-            <type><![CDATA[CHARACTER VARYING(255)]]></type>
-            <defaultValue><![CDATA['DRAFT'::character varying]]></defaultValue>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[3788164A-2E0B-469D-9BBE-9027C9669669]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[has_additional_postal_code]]></name>
-            <type><![CDATA[BOOLEAN]]></type>
-            <uid><![CDATA[38224CF3-D7F5-4007-BE5C-F49976A722B9]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[has_sit]]></name>
-            <type><![CDATA[BOOLEAN]]></type>
-            <uid><![CDATA[C3FD7298-E132-4FFF-8DA4-D328A467D600]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[has_requested_advance]]></name>
-            <type><![CDATA[BOOLEAN]]></type>
-            <defaultValue><![CDATA[false]]></defaultValue>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[2122383C-1D15-4500-8119-DECE487160E3]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[advance_id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <uid><![CDATA[7BEB4B59-2B16-4D9C-9A7F-F6C53BA53580]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[estimated_storage_reimbursement]]></name>
-            <type><![CDATA[CHARACTER VARYING(255)]]></type>
-            <uid><![CDATA[89DAB339-5CFF-4006-83E5-A636ADCCD808]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[mileage]]></name>
-            <type><![CDATA[INTEGER]]></type>
-            <uid><![CDATA[E3D70043-4653-4656-8411-A619BB5C88D9]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[planned_sit_max]]></name>
-            <type><![CDATA[INTEGER]]></type>
-            <uid><![CDATA[B3C0A058-7ED1-424D-8E17-388D27412D90]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[sit_max]]></name>
-            <type><![CDATA[INTEGER]]></type>
-            <uid><![CDATA[4027D6F7-07FF-4BEC-86B9-71BDE83B87F3]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[incentive_estimate_min]]></name>
-            <type><![CDATA[INTEGER]]></type>
-            <uid><![CDATA[93287DD6-6F5B-4285-A86B-79B81FE6E28D]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[incentive_estimate_max]]></name>
-            <type><![CDATA[INTEGER]]></type>
-            <uid><![CDATA[35C0E714-54EC-464A-9D6D-7C275FCCFC3A]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[advance_worksheet_id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <referencesField>id</referencesField>
-            <referencesTable>public.documents</referencesTable>
-            <deleteAction>4</deleteAction>
-            <updateAction>4</updateAction>
-            <referencesField><![CDATA[id]]></referencesField>
-            <referencesTable><![CDATA[public.documents]]></referencesTable>
-            <sourceCardinality>0</sourceCardinality>
-            <destinationCardinality>0</destinationCardinality>
-            <referencesFieldUID><![CDATA[DB1CEAC4-39C1-4ED6-941D-DA5F6464C239]]></referencesFieldUID>
-            <referencesTableUID><![CDATA[DB441E2F-FED4-4952-AF6B-16954AD95900]]></referencesTableUID>
-            <foreignKeyName><![CDATA[personally_procured_moves_documents_id_fk]]></foreignKeyName>
-            <uid><![CDATA[2E8AB823-176A-4F51-AF88-143552D3FAF7]]></uid>
-        </SQLField>
-        <labelWindowIndex><![CDATA[22]]></labelWindowIndex>
-        <PK_KEY_NAME><![CDATA[personally_procured_moves_pkey]]></PK_KEY_NAME>
-        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
-        <uid><![CDATA[0D98D8B2-0787-4014-ADA5-F0880771C07E]]></uid>
-    </SQLTable>
-    <SQLTable>
-        <name><![CDATA[public.traffic_distribution_lists]]></name>
-        <schema><![CDATA[public]]></schema>
-        <location>
-            <x>626.00</x>
-            <y>1710.00</y>
-        </location>
-        <size>
-            <width>372.00</width>
-            <height>160.00</height>
-        </size>
-        <zorder>6</zorder>
-        <SQLField>
-            <name><![CDATA[id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <primaryKey>1</primaryKey>
-            <forcedUnique><![CDATA[1]]></forcedUnique>
-            <notNull><![CDATA[1]]></notNull>
-            <PK_NAME><![CDATA[traffic_distribution_lists_pkey]]></PK_NAME>
-            <uid><![CDATA[9C3D964B-5687-4441-B562-A7025E3DAC94]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[source_rate_area]]></name>
-            <type><![CDATA[CHARACTER VARYING(255)]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[7492AB17-A956-4C08-BC45-7295C6832A80]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[destination_region]]></name>
-            <type><![CDATA[CHARACTER VARYING(255)]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[937BDC26-686D-4549-83DD-A2B4F08C3783]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[code_of_service]]></name>
-            <type><![CDATA[CHARACTER VARYING(255)]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[A5A2EB1A-2C5D-48C1-98B9-1E548DD2A2E3]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[created_at]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[08477C91-DF3A-4196-8226-97BBD0A85A4F]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[updated_at]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[89620670-AFC1-405B-9C44-1EED32865880]]></uid>
-        </SQLField>
-        <SQLConstraint>
-            <name><![CDATA[unique_channel_cos]]></name>
-            <fieldName><![CDATA[source_rate_area]]></fieldName>
-            <fieldName><![CDATA[destination_region]]></fieldName>
-            <fieldName><![CDATA[code_of_service]]></fieldName>
-            <SQLIndexEntry>
-                <name><![CDATA[source_rate_area]]></name>
-                <prefixSize><![CDATA[]]></prefixSize>
-                <fieldUid><![CDATA[7492AB17-A956-4C08-BC45-7295C6832A80]]></fieldUid>
-            </SQLIndexEntry>
-            <SQLIndexEntry>
-                <name><![CDATA[destination_region]]></name>
-                <prefixSize><![CDATA[]]></prefixSize>
-                <fieldUid><![CDATA[937BDC26-686D-4549-83DD-A2B4F08C3783]]></fieldUid>
-            </SQLIndexEntry>
-            <SQLIndexEntry>
-                <name><![CDATA[code_of_service]]></name>
-                <prefixSize><![CDATA[]]></prefixSize>
-                <fieldUid><![CDATA[A5A2EB1A-2C5D-48C1-98B9-1E548DD2A2E3]]></fieldUid>
-            </SQLIndexEntry>
-            <deferrable><![CDATA[0]]></deferrable>
-            <indexType><![CDATA[UNIQUE]]></indexType>
-            <initiallyDeferred><![CDATA[0]]></initiallyDeferred>
-            <uid><![CDATA[3A544344-E339-4D4B-969C-CCB27834721F]]></uid>
-        </SQLConstraint>
-        <labelWindowIndex><![CDATA[6]]></labelWindowIndex>
-        <PK_KEY_NAME><![CDATA[traffic_distribution_lists_pkey]]></PK_KEY_NAME>
-        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
-        <uid><![CDATA[1986824A-2FFE-4FAF-A010-7BFEB6066A21]]></uid>
-    </SQLTable>
-    <SQLTable>
-        <name><![CDATA[public.blackout_dates]]></name>
-        <schema><![CDATA[public]]></schema>
-        <location>
-            <x>664.00</x>
+            <x>1690.00</x>
             <y>10.00</y>
         </location>
         <size>
-            <width>362.00</width>
-            <height>240.00</height>
+            <width>229.00</width>
+            <height>80.00</height>
         </size>
-        <zorder>34</zorder>
+        <zorder>31</zorder>
         <SQLField>
-            <name><![CDATA[id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <primaryKey>1</primaryKey>
-            <notNull><![CDATA[1]]></notNull>
-            <PK_NAME><![CDATA[blackout_dates_pkey]]></PK_NAME>
-            <uid><![CDATA[1D37B147-1C57-4590-AF93-0097E6178E51]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[transportation_service_provider_id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <referencesField>id</referencesField>
-            <referencesTable>public.transportation_service_providers</referencesTable>
-            <deleteAction>4</deleteAction>
-            <updateAction>4</updateAction>
-            <referencesField><![CDATA[id]]></referencesField>
-            <referencesTable><![CDATA[public.transportation_service_providers]]></referencesTable>
-            <sourceCardinality>0</sourceCardinality>
-            <destinationCardinality>0</destinationCardinality>
-            <referencesFieldUID><![CDATA[B2FC2241-6268-451C-A898-2CCD98B1A7CE]]></referencesFieldUID>
-            <referencesTableUID><![CDATA[336A1743-A267-4705-9723-19495DAEC0A7]]></referencesTableUID>
-            <foreignKeyName><![CDATA[blackout_dates_transportation_service_provider_id_fkey]]></foreignKeyName>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[8D066DE7-30B4-4005-BC39-49AE5A7A8133]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[start_blackout_date]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[35A75C31-B180-4891-B3B8-1745E5D439E0]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[end_blackout_date]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[6C4479B9-1DE3-4E27-8532-CC15EB597832]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[traffic_distribution_list_id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <referencesField>id</referencesField>
-            <referencesTable>public.traffic_distribution_lists</referencesTable>
-            <deleteAction>4</deleteAction>
-            <updateAction>4</updateAction>
-            <referencesField><![CDATA[id]]></referencesField>
-            <referencesTable><![CDATA[public.traffic_distribution_lists]]></referencesTable>
-            <sourceCardinality>0</sourceCardinality>
-            <destinationCardinality>0</destinationCardinality>
-            <referencesFieldUID><![CDATA[9C3D964B-5687-4441-B562-A7025E3DAC94]]></referencesFieldUID>
-            <referencesTableUID><![CDATA[1986824A-2FFE-4FAF-A010-7BFEB6066A21]]></referencesTableUID>
-            <foreignKeyName><![CDATA[blackout_dates_traffic_distribution_list_id_fkey]]></foreignKeyName>
-            <uid><![CDATA[CCE631A6-3CBE-4BA7-9329-1B0C45483A52]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[created_at]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[E3A9C50D-CBE7-4446-B445-7153399D0E4C]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[updated_at]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[7251DC02-23CF-461E-9271-C628491A9471]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[source_gbloc]]></name>
-            <type><![CDATA[CHARACTER VARYING(255)]]></type>
-            <uid><![CDATA[98229094-04E4-46DE-AB15-F6779BD7DFAA]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[market]]></name>
-            <type><![CDATA[CHARACTER VARYING(255)]]></type>
-            <uid><![CDATA[755C4255-A447-4058-B62D-5B3B37795F87]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[zip3]]></name>
+            <name><![CDATA[sequence_number]]></name>
             <type><![CDATA[INTEGER]]></type>
-            <uid><![CDATA[B025BA81-06A1-4643-BD3A-63CDF1F53022]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[volume_move]]></name>
-            <type><![CDATA[BOOLEAN]]></type>
-            <uid><![CDATA[FF342ED9-2421-4B23-962F-70D82B2B44BE]]></uid>
-        </SQLField>
-        <labelWindowIndex><![CDATA[34]]></labelWindowIndex>
-        <PK_KEY_NAME><![CDATA[blackout_dates_pkey]]></PK_KEY_NAME>
-        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
-        <uid><![CDATA[1DEF2D52-14CD-4C2A-9EB7-75AE2CCE3FD9]]></uid>
-    </SQLTable>
-    <SQLTable>
-        <name><![CDATA[public.reimbursements]]></name>
-        <schema><![CDATA[public]]></schema>
-        <location>
-            <x>406.00</x>
-            <y>670.00</y>
-        </location>
-        <size>
-            <width>319.00</width>
-            <height>160.00</height>
-        </size>
-        <zorder>21</zorder>
-        <SQLField>
-            <name><![CDATA[id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <primaryKey>1</primaryKey>
-            <notNull><![CDATA[1]]></notNull>
-            <PK_NAME><![CDATA[reimbursements_pkey]]></PK_NAME>
-            <uid><![CDATA[10412959-2C0E-44B7-9A71-595F21BA52B6]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[requested_amount]]></name>
-            <type><![CDATA[INTEGER]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[8C495684-961D-4094-97E5-E85FCBC25211]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[method_of_receipt]]></name>
-            <type><![CDATA[CHARACTER VARYING(255)]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[BC563DEE-4C16-4AEC-B290-F45B14E347B5]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[status]]></name>
-            <type><![CDATA[CHARACTER VARYING(255)]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[AA547C59-C2F8-4AE4-BED4-70DB8B2495C7]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[requested_date]]></name>
-            <type><![CDATA[DATE]]></type>
-            <uid><![CDATA[F333638E-454F-490E-918F-59D6AC0555F1]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[created_at]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[4B041DAC-ABB2-49BE-A7AE-6DE09F73A992]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[updated_at]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[A95A7282-7946-4AC5-939F-91DA77BEB9B7]]></uid>
-        </SQLField>
-        <labelWindowIndex><![CDATA[21]]></labelWindowIndex>
-        <PK_KEY_NAME><![CDATA[reimbursements_pkey]]></PK_KEY_NAME>
-        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
-        <uid><![CDATA[26F5FE72-7732-45D8-9CA0-BB44D3840E7C]]></uid>
-    </SQLTable>
-    <SQLTable>
-        <name><![CDATA[public.transportation_offices]]></name>
-        <schema><![CDATA[public]]></schema>
-        <location>
-            <x>1008.00</x>
-            <y>1710.00</y>
-        </location>
-        <size>
-            <width>317.00</width>
-            <height>260.00</height>
-        </size>
-        <zorder>5</zorder>
-        <SQLField>
-            <name><![CDATA[id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <primaryKey>1</primaryKey>
-            <forcedUnique><![CDATA[1]]></forcedUnique>
-            <notNull><![CDATA[1]]></notNull>
-            <PK_NAME><![CDATA[transportation_offices_pkey]]></PK_NAME>
-            <uid><![CDATA[656AE989-CC75-4EDF-9251-D3F9345307F3]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[shipping_office_id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <referencesField>id</referencesField>
-            <referencesTable>public.transportation_offices</referencesTable>
-            <deleteAction>4</deleteAction>
-            <updateAction>4</updateAction>
-            <referencesField><![CDATA[id]]></referencesField>
-            <referencesTable><![CDATA[public.transportation_offices]]></referencesTable>
-            <sourceCardinality>0</sourceCardinality>
-            <destinationCardinality>0</destinationCardinality>
-            <referencesFieldUID><![CDATA[656AE989-CC75-4EDF-9251-D3F9345307F3]]></referencesFieldUID>
-            <referencesTableUID><![CDATA[2827CA86-4F1C-483D-AD59-976B282F0DDB]]></referencesTableUID>
-            <foreignKeyName><![CDATA[transportation_offices_shipping_office_id_fkey]]></foreignKeyName>
-            <uid><![CDATA[463A52D4-F3D6-460D-8348-0942220F5DA8]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[name]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[B67A852C-0F31-434B-AA42-C88C4C3A8BBE]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[address_id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <referencesField>id</referencesField>
-            <referencesTable>public.addresses</referencesTable>
-            <deleteAction>4</deleteAction>
-            <updateAction>4</updateAction>
-            <referencesField><![CDATA[id]]></referencesField>
-            <referencesTable><![CDATA[public.addresses]]></referencesTable>
-            <sourceCardinality>0</sourceCardinality>
-            <destinationCardinality>0</destinationCardinality>
-            <referencesFieldUID><![CDATA[4728081A-13E5-40AB-AEC0-8380BA3CC087]]></referencesFieldUID>
-            <referencesTableUID><![CDATA[457FF940-6EAC-42A2-B9C9-3DF7C9E6A946]]></referencesTableUID>
-            <foreignKeyName><![CDATA[transportation_offices_address_id_fkey]]></foreignKeyName>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[13135720-896D-4FCC-83A2-0E9533C4B93B]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[latitude]]></name>
-            <type><![CDATA[REAL]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[1487D250-E53B-4C10-AD07-263B635D7336]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[longitude]]></name>
-            <type><![CDATA[REAL]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[0A85AAFA-BAA1-4ECB-BC00-3027A518DCE0]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[hours]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <uid><![CDATA[1B9D4EC6-7EAB-45AB-BA33-7D7E42BD2C83]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[services]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <uid><![CDATA[9A128633-89FA-4ECF-80CE-B0D5D005A238]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[note]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <uid><![CDATA[180DD96B-80B6-491D-8395-01531B232F23]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[created_at]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[A61CADF9-EA07-49B0-98CB-15C59D4641AD]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[updated_at]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[2D0B1600-300B-49CD-81D4-F1655DB688F9]]></uid>
+            <uid><![CDATA[438E66D4-8A19-435A-97BA-96D54276B34A]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[gbloc]]></name>
             <type><![CDATA[CHARACTER VARYING(255)]]></type>
-            <defaultValue><![CDATA['XXXX'::character varying]]></defaultValue>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[E80392CD-53AB-47E5-8383-4B6D2371FB22]]></uid>
+            <uid><![CDATA[A37E0098-3A20-4470-B9F5-5C506890ABA6]]></uid>
         </SQLField>
-        <labelWindowIndex><![CDATA[5]]></labelWindowIndex>
-        <PK_KEY_NAME><![CDATA[transportation_offices_pkey]]></PK_KEY_NAME>
+        <SQLConstraint>
+            <name><![CDATA[gbl_number_trackers_gbloc_key]]></name>
+            <fieldName><![CDATA[gbloc]]></fieldName>
+            <SQLIndexEntry>
+                <name><![CDATA[gbloc]]></name>
+                <prefixSize><![CDATA[]]></prefixSize>
+                <fieldUid><![CDATA[A37E0098-3A20-4470-B9F5-5C506890ABA6]]></fieldUid>
+            </SQLIndexEntry>
+            <deferrable><![CDATA[0]]></deferrable>
+            <indexType><![CDATA[UNIQUE]]></indexType>
+            <initiallyDeferred><![CDATA[0]]></initiallyDeferred>
+            <uid><![CDATA[C42A1E8C-2558-457E-82EC-BC85C951F87C]]></uid>
+        </SQLConstraint>
+        <labelWindowIndex><![CDATA[31]]></labelWindowIndex>
         <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
-        <uid><![CDATA[2827CA86-4F1C-483D-AD59-976B282F0DDB]]></uid>
+        <uid><![CDATA[013E2782-E0ED-4413-A200-D115EFE512E3]]></uid>
     </SQLTable>
     <SQLTable>
-        <name><![CDATA[public.service_agents]]></name>
+        <name><![CDATA[public.tariff400ng_full_unpack_rates]]></name>
         <schema><![CDATA[public]]></schema>
         <location>
-            <x>1003.00</x>
-            <y>670.00</y>
+            <x>972.00</x>
+            <y>1420.00</y>
         </location>
         <size>
-            <width>317.00</width>
-            <height>280.00</height>
+            <width>298.00</width>
+            <height>160.00</height>
         </size>
-        <zorder>19</zorder>
+        <zorder>12</zorder>
         <SQLField>
             <name><![CDATA[id]]></name>
             <type><![CDATA[UUID]]></type>
-            <primaryKey>1</primaryKey>
-            <notNull><![CDATA[1]]></notNull>
-            <PK_NAME><![CDATA[service_agents_pkey]]></PK_NAME>
-            <uid><![CDATA[DF5D063F-0C9E-40EC-B248-318D035FEDB6]]></uid>
+            <uid><![CDATA[D992BDFF-0767-4BA0-BC8F-19960E3D59A3]]></uid>
         </SQLField>
         <SQLField>
-            <name><![CDATA[shipment_id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <referencesField>id</referencesField>
-            <referencesTable>public.shipments</referencesTable>
-            <deleteAction>4</deleteAction>
-            <updateAction>4</updateAction>
-            <referencesField><![CDATA[id]]></referencesField>
-            <referencesTable><![CDATA[public.shipments]]></referencesTable>
-            <sourceCardinality>0</sourceCardinality>
-            <destinationCardinality>0</destinationCardinality>
-            <referencesFieldUID><![CDATA[982DC590-943B-4DCF-A094-997BAF5B0B1D]]></referencesFieldUID>
-            <referencesTableUID><![CDATA[C2B63AAC-0C9F-42F9-9655-E87AF3C8AB11]]></referencesTableUID>
-            <foreignKeyName><![CDATA[service_agents_shipment_id_fkey]]></foreignKeyName>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[61E670FD-C62E-44D8-ACF1-2AD93BE309E4]]></uid>
+            <name><![CDATA[schedule]]></name>
+            <type><![CDATA[INTEGER]]></type>
+            <uid><![CDATA[3B10218D-7E15-46EB-B46D-F5DF004FD5FA]]></uid>
         </SQLField>
         <SQLField>
-            <name><![CDATA[role]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[8312EDB4-54BC-417E-92D8-F42B10088AB8]]></uid>
+            <name><![CDATA[rate_millicents]]></name>
+            <type><![CDATA[INTEGER]]></type>
+            <uid><![CDATA[882CBE41-0BB1-426B-BF61-3E17F1853F49]]></uid>
         </SQLField>
         <SQLField>
-            <name><![CDATA[point_of_contact]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <uid><![CDATA[592FFACA-C729-41A3-9355-2B2E9A7D35AD]]></uid>
+            <name><![CDATA[effective_date_lower]]></name>
+            <type><![CDATA[DATE]]></type>
+            <uid><![CDATA[928D243F-BD4A-48C8-BDEF-E708EC17205E]]></uid>
         </SQLField>
         <SQLField>
-            <name><![CDATA[email]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <uid><![CDATA[807A5964-DA3D-4755-A886-936BD6A6120B]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[phone_number]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <uid><![CDATA[24B213B6-3EDC-43BE-AB67-0D921A5CF3C4]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[fax_number]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <uid><![CDATA[396DAED2-A432-48A8-AFA1-E6141A7A01D6]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[email_is_preferred]]></name>
-            <type><![CDATA[BOOLEAN]]></type>
-            <uid><![CDATA[34809157-CE61-438E-B5E8-26ED571EBA96]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[phone_is_preferred]]></name>
-            <type><![CDATA[BOOLEAN]]></type>
-            <uid><![CDATA[CA306EA0-FE71-4E89-9E54-E7D82D19901A]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[notes]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <uid><![CDATA[725C4E0D-4619-4E1F-A7E5-3940D72FC0E9]]></uid>
+            <name><![CDATA[effective_date_upper]]></name>
+            <type><![CDATA[DATE]]></type>
+            <uid><![CDATA[6D430DB9-8ECE-4638-BA59-C11F84D53618]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[created_at]]></name>
             <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[FAE8CCA3-24E0-4AAE-9CBD-F20FF785742A]]></uid>
+            <uid><![CDATA[6743FD65-D6B9-48D0-ABF9-53FA1CAB994D]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[updated_at]]></name>
             <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[53F3D42B-E034-47A8-8E9B-C09B81F40FAA]]></uid>
+            <uid><![CDATA[C169168E-3817-40FB-88BE-5966EA539A85]]></uid>
         </SQLField>
-        <SQLField>
-            <name><![CDATA[company]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[FBB4E043-9AE4-4BEC-8100-CDE13C2B9510]]></uid>
-        </SQLField>
-        <labelWindowIndex><![CDATA[19]]></labelWindowIndex>
-        <PK_KEY_NAME><![CDATA[service_agents_pkey]]></PK_KEY_NAME>
+        <labelWindowIndex><![CDATA[12]]></labelWindowIndex>
         <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
-        <uid><![CDATA[32CDDFA3-7BF9-4CC2-8CFA-0890A7952E13]]></uid>
+        <uid><![CDATA[0209854D-7430-47B2-81EC-BFBAB5D9096F]]></uid>
     </SQLTable>
     <SQLTable>
         <name><![CDATA[public.transportation_service_providers]]></name>
@@ -738,752 +109,30 @@
             <forcedUnique><![CDATA[1]]></forcedUnique>
             <notNull><![CDATA[1]]></notNull>
             <PK_NAME><![CDATA[transportation_service_providers_pkey]]></PK_NAME>
-            <uid><![CDATA[B2FC2241-6268-451C-A898-2CCD98B1A7CE]]></uid>
+            <uid><![CDATA[33B103F7-65E6-4CD2-BF2C-6A9E75620737]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[standard_carrier_alpha_code]]></name>
             <type><![CDATA[TEXT]]></type>
             <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[34EEB034-5441-4754-8A07-9DC80212019B]]></uid>
+            <uid><![CDATA[1F28BFEA-430A-4113-B038-974BF09DAC55]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[created_at]]></name>
             <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
             <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[9EC7D20A-270A-4994-91BD-A6F34BB23D06]]></uid>
+            <uid><![CDATA[04744089-8C75-4019-8AFF-D07F1B0B10E8]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[updated_at]]></name>
             <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
             <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[B3D404B2-0E3B-4E71-8A70-49C74EB5D169]]></uid>
+            <uid><![CDATA[4A32341E-59C7-4B9F-AF0E-EDA5A543D89B]]></uid>
         </SQLField>
         <labelWindowIndex><![CDATA[3]]></labelWindowIndex>
         <PK_KEY_NAME><![CDATA[transportation_service_providers_pkey]]></PK_KEY_NAME>
         <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
-        <uid><![CDATA[336A1743-A267-4705-9723-19495DAEC0A7]]></uid>
-    </SQLTable>
-    <SQLTable>
-        <name><![CDATA[public.tariff400ng_zip5_rate_areas]]></name>
-        <schema><![CDATA[public]]></schema>
-        <location>
-            <x>318.00</x>
-            <y>1710.00</y>
-        </location>
-        <size>
-            <width>298.00</width>
-            <height>120.00</height>
-        </size>
-        <zorder>7</zorder>
-        <SQLField>
-            <name><![CDATA[id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <uid><![CDATA[07FE0CEB-3DE9-4AE7-BCDE-B66ED5FC30D5]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[zip5]]></name>
-            <type><![CDATA[CHARACTER VARYING(5)]]></type>
-            <uid><![CDATA[E207AE61-D6B8-4A48-B6B3-DFC54FB7286F]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[rate_area]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <uid><![CDATA[F7F2B0AA-1861-4250-AD55-13215F54E6DC]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[created_at]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <uid><![CDATA[65DC392D-1DB4-4019-A215-E7EAFF58D5B5]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[updated_at]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <uid><![CDATA[0ED69C50-6F0D-466B-B609-D38C847E4BDB]]></uid>
-        </SQLField>
-        <labelWindowIndex><![CDATA[7]]></labelWindowIndex>
-        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
-        <uid><![CDATA[36D43E72-6045-4A77-B01A-9426A0BA294D]]></uid>
-    </SQLTable>
-    <SQLTable>
-        <name><![CDATA[public.addresses]]></name>
-        <schema><![CDATA[public]]></schema>
-        <location>
-            <x>10.00</x>
-            <y>10.00</y>
-        </location>
-        <size>
-            <width>317.00</width>
-            <height>220.00</height>
-        </size>
-        <zorder>36</zorder>
-        <SQLField>
-            <name><![CDATA[id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <primaryKey>1</primaryKey>
-            <forcedUnique><![CDATA[1]]></forcedUnique>
-            <notNull><![CDATA[1]]></notNull>
-            <PK_NAME><![CDATA[addresses_pkey]]></PK_NAME>
-            <uid><![CDATA[4728081A-13E5-40AB-AEC0-8380BA3CC087]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[street_address_1]]></name>
-            <type><![CDATA[CHARACTER VARYING(255)]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[B1F654CC-8CB2-4C09-8CAE-F0DC7E185383]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[street_address_2]]></name>
-            <type><![CDATA[CHARACTER VARYING(255)]]></type>
-            <uid><![CDATA[8B870296-DEB3-4457-90BE-946F83E62A22]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[city]]></name>
-            <type><![CDATA[CHARACTER VARYING(255)]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[EDA6A650-998C-4DAB-934B-1694F64F4ABD]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[state]]></name>
-            <type><![CDATA[CHARACTER VARYING(255)]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[9390DAEF-CE79-424D-AFED-B2553A0816D3]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[postal_code]]></name>
-            <type><![CDATA[CHARACTER VARYING(255)]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[550D1698-D443-477E-B81D-9E65F18271B7]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[created_at]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[E98C5D5C-8E50-4B82-BFF9-8D8F534D368E]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[updated_at]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[694D11A5-B948-4629-9DDB-290E0F18F337]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[street_address_3]]></name>
-            <type><![CDATA[CHARACTER VARYING(255)]]></type>
-            <uid><![CDATA[01909A41-BA93-4922-950B-6997D7F6D1AA]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[country]]></name>
-            <type><![CDATA[CHARACTER VARYING(255)]]></type>
-            <defaultValue><![CDATA['United States'::character varying]]></defaultValue>
-            <uid><![CDATA[7AF51826-A30F-44F6-9126-DF176A1DDFC9]]></uid>
-        </SQLField>
-        <labelWindowIndex><![CDATA[36]]></labelWindowIndex>
-        <PK_KEY_NAME><![CDATA[addresses_pkey]]></PK_KEY_NAME>
-        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
-        <uid><![CDATA[457FF940-6EAC-42A2-B9C9-3DF7C9E6A946]]></uid>
-    </SQLTable>
-    <SQLTable>
-        <name><![CDATA[public.backup_contacts]]></name>
-        <schema><![CDATA[public]]></schema>
-        <location>
-            <x>337.00</x>
-            <y>10.00</y>
-        </location>
-        <size>
-            <width>317.00</width>
-            <height>180.00</height>
-        </size>
-        <zorder>35</zorder>
-        <SQLField>
-            <name><![CDATA[id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <primaryKey>1</primaryKey>
-            <notNull><![CDATA[1]]></notNull>
-            <PK_NAME><![CDATA[backup_contacts_pkey]]></PK_NAME>
-            <uid><![CDATA[6A711965-1079-426B-9887-5B931F76FF87]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[service_member_id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[94FB5527-1703-40CC-9705-E7E1BB480FF6]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[name]]></name>
-            <type><![CDATA[CHARACTER VARYING(255)]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[86D590BA-6B49-4F91-B503-3CB08495C162]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[email]]></name>
-            <type><![CDATA[CHARACTER VARYING(255)]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[ED853DF4-46AF-4293-872B-026D11ED21F6]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[phone]]></name>
-            <type><![CDATA[CHARACTER VARYING(255)]]></type>
-            <uid><![CDATA[4309061D-157E-4EC5-B4BF-5562A19C09B7]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[permission]]></name>
-            <type><![CDATA[CHARACTER VARYING(255)]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[549356AE-6754-45CF-84C2-10131CE604CA]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[created_at]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[F978BAD5-7D5C-4D85-A2A8-AA46A3F47505]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[updated_at]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[E065D672-DB4C-4478-8AA5-8809AC9CF903]]></uid>
-        </SQLField>
-        <labelWindowIndex><![CDATA[35]]></labelWindowIndex>
-        <PK_KEY_NAME><![CDATA[backup_contacts_pkey]]></PK_KEY_NAME>
-        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
-        <uid><![CDATA[49CD8AB5-F158-455F-A259-A04894F3C1E3]]></uid>
-    </SQLTable>
-    <SQLTable>
-        <name><![CDATA[public.signed_certifications]]></name>
-        <schema><![CDATA[public]]></schema>
-        <location>
-            <x>10.00</x>
-            <y>1420.00</y>
-        </location>
-        <size>
-            <width>317.00</width>
-            <height>180.00</height>
-        </size>
-        <zorder>15</zorder>
-        <SQLField>
-            <name><![CDATA[id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <primaryKey>1</primaryKey>
-            <notNull><![CDATA[1]]></notNull>
-            <PK_NAME><![CDATA[signed_certifications_pkey]]></PK_NAME>
-            <uid><![CDATA[39F74B46-7EC5-4428-9A78-13101C0CCCD5]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[submitting_user_id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <referencesField>id</referencesField>
-            <referencesTable>public.users</referencesTable>
-            <deleteAction>4</deleteAction>
-            <updateAction>4</updateAction>
-            <referencesField><![CDATA[id]]></referencesField>
-            <referencesTable><![CDATA[public.users]]></referencesTable>
-            <sourceCardinality>0</sourceCardinality>
-            <destinationCardinality>0</destinationCardinality>
-            <referencesFieldUID><![CDATA[BD0EC088-24B4-4DFF-A08C-82DC78218CA7]]></referencesFieldUID>
-            <referencesTableUID><![CDATA[C515D33B-5FF0-4039-A550-4E3ED3683006]]></referencesTableUID>
-            <foreignKeyName><![CDATA[signed_certifications_submitting_user_id_fkey]]></foreignKeyName>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[6D48327E-368E-40D1-B3E2-558528C71E8C]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[move_id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[8B0EB6B1-0465-4A3A-AE58-34DCBDBFEA7E]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[certification_text]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[37267641-B8F5-4087-BD21-6EAC21267FCE]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[signature]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[73604276-5FF0-46CD-B0BB-9BD1BD3BF573]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[date]]></name>
-            <type><![CDATA[DATE]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[A5E91995-93B4-46EF-A131-934EC13BBB18]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[created_at]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[45377DB7-7645-443E-B03B-0765ED2168ED]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[updated_at]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[E49B7AFC-6801-4BC7-8688-985EFE1AB414]]></uid>
-        </SQLField>
-        <labelWindowIndex><![CDATA[15]]></labelWindowIndex>
-        <PK_KEY_NAME><![CDATA[signed_certifications_pkey]]></PK_KEY_NAME>
-        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
-        <uid><![CDATA[49EA6748-FCB9-4CFA-8748-F4F060158247]]></uid>
-    </SQLTable>
-    <SQLTable>
-        <name><![CDATA[public.tariff400ng_full_unpack_rates]]></name>
-        <schema><![CDATA[public]]></schema>
-        <location>
-            <x>972.00</x>
-            <y>1420.00</y>
-        </location>
-        <size>
-            <width>298.00</width>
-            <height>160.00</height>
-        </size>
-        <zorder>12</zorder>
-        <SQLField>
-            <name><![CDATA[id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <uid><![CDATA[B6F81D45-5257-473A-970E-620C7A162741]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[schedule]]></name>
-            <type><![CDATA[INTEGER]]></type>
-            <uid><![CDATA[4918A41A-4E36-42E1-8658-D6B4A7F7033B]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[rate_millicents]]></name>
-            <type><![CDATA[INTEGER]]></type>
-            <uid><![CDATA[6CC9C88D-07D4-4630-86E4-F5C20B51D876]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[effective_date_lower]]></name>
-            <type><![CDATA[DATE]]></type>
-            <uid><![CDATA[93045EA5-A4F8-4FCE-9439-AD1925161A09]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[effective_date_upper]]></name>
-            <type><![CDATA[DATE]]></type>
-            <uid><![CDATA[9C111815-98B8-45ED-9CAC-9A53C4914E78]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[created_at]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <uid><![CDATA[2D37AF60-D62F-42D3-9C81-09094CD48AAF]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[updated_at]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <uid><![CDATA[E445E5CE-F262-4449-B1E0-6CF0C4CE6252]]></uid>
-        </SQLField>
-        <labelWindowIndex><![CDATA[12]]></labelWindowIndex>
-        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
-        <uid><![CDATA[559325B6-2A80-41DF-B329-69A3A0841436]]></uid>
-    </SQLTable>
-    <SQLTable>
-        <name><![CDATA[public.tariff400ng_service_areas]]></name>
-        <schema><![CDATA[public]]></schema>
-        <location>
-            <x>1588.00</x>
-            <y>1420.00</y>
-        </location>
-        <size>
-            <width>298.00</width>
-            <height>280.00</height>
-        </size>
-        <zorder>10</zorder>
-        <SQLField>
-            <name><![CDATA[id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <uid><![CDATA[27B44855-D616-444D-9B9B-5AC9743B9933]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[service_area]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <uid><![CDATA[02EB394C-ACD4-455A-8187-99FC2B3CA851]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[name]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <uid><![CDATA[191AEEB3-CEC4-4D09-B03B-929029C0E351]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[services_schedule]]></name>
-            <type><![CDATA[INTEGER]]></type>
-            <uid><![CDATA[57ABCCDE-DD0A-48D7-AB38-B53F48741FE0]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[linehaul_factor]]></name>
-            <type><![CDATA[INTEGER]]></type>
-            <uid><![CDATA[AF8BCAB3-8146-45B7-9BDE-53BB29FFE1C0]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[service_charge_cents]]></name>
-            <type><![CDATA[INTEGER]]></type>
-            <uid><![CDATA[ABBB4BBC-A7B6-459C-8124-4A0C629BAEAE]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[effective_date_lower]]></name>
-            <type><![CDATA[DATE]]></type>
-            <uid><![CDATA[DFAC108D-2683-4A38-AE7C-F3674FA0E30B]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[effective_date_upper]]></name>
-            <type><![CDATA[DATE]]></type>
-            <uid><![CDATA[C156B7E9-9B6B-424F-9A17-B5AE9D838CDC]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[created_at]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <uid><![CDATA[253EA7C3-974B-4CE2-8643-50F20676AB1A]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[updated_at]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <uid><![CDATA[94CEAE56-8E32-4329-AACC-032D7075361A]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[sit_185a_rate_cents]]></name>
-            <type><![CDATA[INTEGER]]></type>
-            <uid><![CDATA[CBE42770-B189-4E4A-8430-C30CB68BF4A7]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[sit_185b_rate_cents]]></name>
-            <type><![CDATA[INTEGER]]></type>
-            <uid><![CDATA[9EFCD15D-A5A4-4979-BE68-E545048177FA]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[sit_pd_schedule]]></name>
-            <type><![CDATA[INTEGER]]></type>
-            <uid><![CDATA[55028FAA-6029-4129-9E82-975CDB26EA80]]></uid>
-        </SQLField>
-        <labelWindowIndex><![CDATA[10]]></labelWindowIndex>
-        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
-        <uid><![CDATA[56E7A9A3-AAF3-4AC6-83DE-A8C948E6CBF3]]></uid>
-    </SQLTable>
-    <SQLTable>
-        <name><![CDATA[public.service_members]]></name>
-        <schema><![CDATA[public]]></schema>
-        <location>
-            <x>1330.00</x>
-            <y>670.00</y>
-        </location>
-        <size>
-            <width>317.00</width>
-            <height>440.00</height>
-        </size>
-        <zorder>18</zorder>
-        <SQLField>
-            <name><![CDATA[id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <primaryKey>1</primaryKey>
-            <forcedUnique><![CDATA[1]]></forcedUnique>
-            <notNull><![CDATA[1]]></notNull>
-            <PK_NAME><![CDATA[service_members_pkey]]></PK_NAME>
-            <uid><![CDATA[054FCC0C-61B5-4D99-BF9F-10C3DB0DFD7C]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[user_id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <referencesField>id</referencesField>
-            <referencesTable>public.users</referencesTable>
-            <deleteAction>4</deleteAction>
-            <updateAction>4</updateAction>
-            <referencesField><![CDATA[id]]></referencesField>
-            <referencesTable><![CDATA[public.users]]></referencesTable>
-            <sourceCardinality>0</sourceCardinality>
-            <destinationCardinality>0</destinationCardinality>
-            <referencesFieldUID><![CDATA[BD0EC088-24B4-4DFF-A08C-82DC78218CA7]]></referencesFieldUID>
-            <referencesTableUID><![CDATA[C515D33B-5FF0-4039-A550-4E3ED3683006]]></referencesTableUID>
-            <foreignKeyName><![CDATA[service_members_user_id_fkey]]></foreignKeyName>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[AA95283C-C962-45B9-9B1D-9AA2BD72C7DD]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[edipi]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <uid><![CDATA[9A441310-8616-4B2A-AD07-A310E3304BD9]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[affiliation]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <uid><![CDATA[6FD23ACA-7B6F-48A7-AA98-45CAB1BA1B08]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[rank]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <uid><![CDATA[9F6B82F7-3DCA-4BD0-9EEF-C2379D1A6F70]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[first_name]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <uid><![CDATA[EB8E8218-C3BD-42FB-9A0D-C6ECDE50CBAA]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[middle_name]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <uid><![CDATA[4C849FD0-C881-4C91-8823-A58C89B09D9F]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[last_name]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <uid><![CDATA[86884D7C-D5FC-4195-A9E9-D5E2CAE68691]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[suffix]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <uid><![CDATA[FBE407D1-97EC-469C-8005-9B2416A7501B]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[telephone]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <uid><![CDATA[023B06DB-9EFC-4E7B-8D84-D8739E81BAF1]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[secondary_telephone]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <uid><![CDATA[00E5A34E-4DB9-45D2-B130-913AF8A47837]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[personal_email]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <uid><![CDATA[E46D2E77-D826-4ABD-9A0A-F6F0AD1FC959]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[phone_is_preferred]]></name>
-            <type><![CDATA[BOOLEAN]]></type>
-            <uid><![CDATA[CFF233FA-B3A3-4E67-AC78-2A6A9858F32E]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[text_message_is_preferred]]></name>
-            <type><![CDATA[BOOLEAN]]></type>
-            <uid><![CDATA[576AFE64-3EBE-40D0-9039-5D14F723657B]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[email_is_preferred]]></name>
-            <type><![CDATA[BOOLEAN]]></type>
-            <uid><![CDATA[B70A1E9D-D11C-4B0B-A17D-3CACA7390C78]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[residential_address_id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <referencesField>id</referencesField>
-            <referencesTable>public.addresses</referencesTable>
-            <deleteAction>4</deleteAction>
-            <updateAction>4</updateAction>
-            <referencesField><![CDATA[id]]></referencesField>
-            <referencesTable><![CDATA[public.addresses]]></referencesTable>
-            <sourceCardinality>0</sourceCardinality>
-            <destinationCardinality>0</destinationCardinality>
-            <referencesFieldUID><![CDATA[4728081A-13E5-40AB-AEC0-8380BA3CC087]]></referencesFieldUID>
-            <referencesTableUID><![CDATA[457FF940-6EAC-42A2-B9C9-3DF7C9E6A946]]></referencesTableUID>
-            <foreignKeyName><![CDATA[service_members_residential_address_id_fkey]]></foreignKeyName>
-            <uid><![CDATA[66590360-2E47-45F0-9008-7D207A75E8CE]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[backup_mailing_address_id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <referencesField>id</referencesField>
-            <referencesTable>public.addresses</referencesTable>
-            <deleteAction>4</deleteAction>
-            <updateAction>4</updateAction>
-            <referencesField><![CDATA[id]]></referencesField>
-            <referencesTable><![CDATA[public.addresses]]></referencesTable>
-            <sourceCardinality>0</sourceCardinality>
-            <destinationCardinality>0</destinationCardinality>
-            <referencesFieldUID><![CDATA[4728081A-13E5-40AB-AEC0-8380BA3CC087]]></referencesFieldUID>
-            <referencesTableUID><![CDATA[457FF940-6EAC-42A2-B9C9-3DF7C9E6A946]]></referencesTableUID>
-            <foreignKeyName><![CDATA[service_members_backup_mailing_address_id_fkey]]></foreignKeyName>
-            <uid><![CDATA[38AA0540-FEF1-48DA-9E61-D4A0E1E5B9A6]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[created_at]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[48DEB4AA-171C-47CB-8C17-7FD0EB342AA7]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[updated_at]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[B3F3D778-4B8B-46B0-B2E8-2EB8BD9A9D3B]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[social_security_number_id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <referencesField>id</referencesField>
-            <referencesTable>public.social_security_numbers</referencesTable>
-            <deleteAction>3</deleteAction>
-            <updateAction>4</updateAction>
-            <referencesField><![CDATA[id]]></referencesField>
-            <referencesTable><![CDATA[public.social_security_numbers]]></referencesTable>
-            <sourceCardinality>0</sourceCardinality>
-            <destinationCardinality>0</destinationCardinality>
-            <referencesFieldUID><![CDATA[4E371793-FAD3-4039-982B-41371F5E395D]]></referencesFieldUID>
-            <referencesTableUID><![CDATA[C4387D27-42FF-4C16-A502-09B4E8354036]]></referencesTableUID>
-            <foreignKeyName><![CDATA[sm_ssn_fk]]></foreignKeyName>
-            <uid><![CDATA[2B416496-F361-40CF-B49C-C785C07E930C]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[duty_station_id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <referencesField>id</referencesField>
-            <referencesTable>public.duty_stations</referencesTable>
-            <deleteAction>3</deleteAction>
-            <updateAction>4</updateAction>
-            <referencesField><![CDATA[id]]></referencesField>
-            <referencesTable><![CDATA[public.duty_stations]]></referencesTable>
-            <sourceCardinality>0</sourceCardinality>
-            <destinationCardinality>0</destinationCardinality>
-            <referencesFieldUID><![CDATA[27EDCC68-3148-4109-A437-0D27FEFA9FE9]]></referencesFieldUID>
-            <referencesTableUID><![CDATA[C22BFDE9-D1F2-4844-9F12-2D8DC1552579]]></referencesTableUID>
-            <foreignKeyName><![CDATA[sm_duty_station_fk]]></foreignKeyName>
-            <uid><![CDATA[695FD534-7350-480F-91AF-D83C16B2F14E]]></uid>
-        </SQLField>
-        <labelWindowIndex><![CDATA[18]]></labelWindowIndex>
-        <PK_KEY_NAME><![CDATA[service_members_pkey]]></PK_KEY_NAME>
-        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
-        <uid><![CDATA[5E420AFB-4EEF-4B8D-9335-68B41E67A652]]></uid>
-    </SQLTable>
-    <SQLTable>
-        <name><![CDATA[public.schema_migration]]></name>
-        <schema><![CDATA[public]]></schema>
-        <location>
-            <x>735.00</x>
-            <y>670.00</y>
-        </location>
-        <size>
-            <width>258.00</width>
-            <height>40.00</height>
-        </size>
-        <zorder>20</zorder>
-        <SQLField>
-            <name><![CDATA[version]]></name>
-            <type><![CDATA[CHARACTER VARYING(255)]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[B641AF09-9C06-40D7-9B64-92BC4B5C0BF1]]></uid>
-        </SQLField>
-        <labelWindowIndex><![CDATA[20]]></labelWindowIndex>
-        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
-        <uid><![CDATA[656E957B-4FE1-42B8-8FA5-6F81E649820C]]></uid>
-    </SQLTable>
-    <SQLTable>
-        <name><![CDATA[public.office_emails]]></name>
-        <schema><![CDATA[public]]></schema>
-        <location>
-            <x>1035.00</x>
-            <y>260.00</y>
-        </location>
-        <size>
-            <width>317.00</width>
-            <height>140.00</height>
-        </size>
-        <zorder>26</zorder>
-        <SQLField>
-            <name><![CDATA[id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <primaryKey>1</primaryKey>
-            <notNull><![CDATA[1]]></notNull>
-            <PK_NAME><![CDATA[office_emails_pkey]]></PK_NAME>
-            <uid><![CDATA[F94CE6EB-CD8E-4F57-B866-634E5920A7EC]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[transportation_office_id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <referencesField>id</referencesField>
-            <referencesTable>public.transportation_offices</referencesTable>
-            <deleteAction>4</deleteAction>
-            <updateAction>4</updateAction>
-            <referencesField><![CDATA[id]]></referencesField>
-            <referencesTable><![CDATA[public.transportation_offices]]></referencesTable>
-            <sourceCardinality>0</sourceCardinality>
-            <destinationCardinality>0</destinationCardinality>
-            <referencesFieldUID><![CDATA[656AE989-CC75-4EDF-9251-D3F9345307F3]]></referencesFieldUID>
-            <referencesTableUID><![CDATA[2827CA86-4F1C-483D-AD59-976B282F0DDB]]></referencesTableUID>
-            <foreignKeyName><![CDATA[office_emails_transportation_office_id_fkey]]></foreignKeyName>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[E62CC5EE-BAB6-4023-B78E-304E4712C537]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[email]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[57DD4656-C23F-4747-886F-C1764448C511]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[label]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <uid><![CDATA[2DC965D1-989F-4960-9220-81F653C40735]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[created_at]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[CE7C9941-1132-44F5-85ED-CCC5741B9F2C]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[updated_at]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[1475A07F-5229-4E5D-A52E-838F5988A816]]></uid>
-        </SQLField>
-        <labelWindowIndex><![CDATA[26]]></labelWindowIndex>
-        <PK_KEY_NAME><![CDATA[office_emails_pkey]]></PK_KEY_NAME>
-        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
-        <uid><![CDATA[662640FF-43DB-4363-846C-FFD0DB594BCF]]></uid>
-    </SQLTable>
-    <SQLTable>
-        <name><![CDATA[public.tariff400ng_shorthaul_rates]]></name>
-        <schema><![CDATA[public]]></schema>
-        <location>
-            <x>1896.00</x>
-            <y>1420.00</y>
-        </location>
-        <size>
-            <width>298.00</width>
-            <height>180.00</height>
-        </size>
-        <zorder>9</zorder>
-        <SQLField>
-            <name><![CDATA[id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <uid><![CDATA[9421423B-FD2C-4B8C-8199-A15E1DA2BDDA]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[cwt_miles_lower]]></name>
-            <type><![CDATA[INTEGER]]></type>
-            <uid><![CDATA[57827CE6-BF0E-4D86-BC9E-F173088F228B]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[cwt_miles_upper]]></name>
-            <type><![CDATA[INTEGER]]></type>
-            <uid><![CDATA[E5BC3237-00C2-42E5-AB9D-66816D0C679C]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[rate_cents]]></name>
-            <type><![CDATA[INTEGER]]></type>
-            <uid><![CDATA[1945882A-2CD4-4B72-BDE4-B8A674FEED6B]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[effective_date_lower]]></name>
-            <type><![CDATA[DATE]]></type>
-            <uid><![CDATA[7594A7BA-AC0D-471E-9E91-7B2B14F5E89B]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[effective_date_upper]]></name>
-            <type><![CDATA[DATE]]></type>
-            <uid><![CDATA[06C17244-0C75-458F-9741-70D7B32EEF2E]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[created_at]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <uid><![CDATA[1BCB51FB-9C1B-4CE8-A441-8BA5245E6815]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[updated_at]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <uid><![CDATA[0E4908FD-7242-40F9-BF6D-588BE6DF0C07]]></uid>
-        </SQLField>
-        <labelWindowIndex><![CDATA[9]]></labelWindowIndex>
-        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
-        <uid><![CDATA[76DDE448-8004-4A7E-9464-A7E718E43BDB]]></uid>
+        <uid><![CDATA[03657CA9-D150-49B8-B269-48D3FC7E462E]]></uid>
     </SQLTable>
     <SQLTable>
         <name><![CDATA[public.tariff400ng_linehaul_rates]]></name>
@@ -1500,213 +149,180 @@
         <SQLField>
             <name><![CDATA[id]]></name>
             <type><![CDATA[UUID]]></type>
-            <uid><![CDATA[10B99213-FF12-4EE6-B16A-1F1BE9DFE34F]]></uid>
+            <uid><![CDATA[8289ABE1-D7F5-4D50-8BE7-2A91BE85A2E1]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[distance_miles_lower]]></name>
             <type><![CDATA[INTEGER]]></type>
-            <uid><![CDATA[48889657-5C23-4DE1-B819-09B9101C4FC7]]></uid>
+            <uid><![CDATA[CB97061E-A08B-4E88-8439-02BC32EA3335]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[distance_miles_upper]]></name>
             <type><![CDATA[INTEGER]]></type>
-            <uid><![CDATA[A29095DD-2A93-4E5F-BD6E-DFEC845FABE5]]></uid>
+            <uid><![CDATA[9BD29612-BDC9-49F8-86E5-797EA3626FF6]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[weight_lbs_lower]]></name>
             <type><![CDATA[INTEGER]]></type>
-            <uid><![CDATA[BB40CE70-E73C-4B5B-BEB3-B884990CFBEF]]></uid>
+            <uid><![CDATA[A2E436D9-AA67-46BA-8398-1398C2DAFF5E]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[weight_lbs_upper]]></name>
             <type><![CDATA[INTEGER]]></type>
-            <uid><![CDATA[01ACA4E8-619D-432F-9994-49CDB7D6EA3F]]></uid>
+            <uid><![CDATA[B9F9DB2E-8BBF-4150-B5D0-702B33A5CB94]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[rate_cents]]></name>
             <type><![CDATA[INTEGER]]></type>
-            <uid><![CDATA[5B296558-9444-435A-B237-F4C09E8B490B]]></uid>
+            <uid><![CDATA[DCF9E730-6A77-4AA0-AEB8-2194ABDB2747]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[effective_date_lower]]></name>
             <type><![CDATA[DATE]]></type>
-            <uid><![CDATA[7CC04E17-5BD6-4064-9DFF-14F6F1FCFDB2]]></uid>
+            <uid><![CDATA[F199FD03-0808-43E9-B908-8122E19B407B]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[effective_date_upper]]></name>
             <type><![CDATA[DATE]]></type>
-            <uid><![CDATA[4A81991F-D638-43E1-AA07-34E87F343023]]></uid>
+            <uid><![CDATA[377CD1D1-19D0-46B6-AC49-E9E8CF9AE061]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[type]]></name>
             <type><![CDATA[TEXT]]></type>
-            <uid><![CDATA[47CA4C4C-A78E-4419-97BA-B9D7E5C1147E]]></uid>
+            <uid><![CDATA[6CD2ADC6-71E2-486D-B693-33394C0D6E2E]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[created_at]]></name>
             <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <uid><![CDATA[BDCF2CE2-7C53-4E17-A048-6C6546B23AC4]]></uid>
+            <uid><![CDATA[3B85CD2A-F4D0-40B6-90EF-4FEA6F75D568]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[updated_at]]></name>
             <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <uid><![CDATA[6631E154-4BA2-45BD-91FB-7D210BC297F6]]></uid>
+            <uid><![CDATA[B02E6C05-B274-4B44-8B67-AF3FFA275DAC]]></uid>
         </SQLField>
         <labelWindowIndex><![CDATA[11]]></labelWindowIndex>
         <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
-        <uid><![CDATA[87D474EE-2EED-4312-BB9D-D59CC1F08EEB]]></uid>
+        <uid><![CDATA[05F0DD9E-7864-4982-9BDB-71B068092A93]]></uid>
     </SQLTable>
     <SQLTable>
-        <name><![CDATA[public.issues]]></name>
+        <name><![CDATA[public.reimbursements]]></name>
         <schema><![CDATA[public]]></schema>
         <location>
-            <x>1929.00</x>
-            <y>10.00</y>
+            <x>406.00</x>
+            <y>670.00</y>
         </location>
         <size>
-            <width>317.00</width>
-            <height>140.00</height>
+            <width>319.00</width>
+            <height>160.00</height>
         </size>
-        <zorder>30</zorder>
+        <zorder>21</zorder>
         <SQLField>
             <name><![CDATA[id]]></name>
             <type><![CDATA[UUID]]></type>
             <primaryKey>1</primaryKey>
             <notNull><![CDATA[1]]></notNull>
-            <PK_NAME><![CDATA[issues_pkey]]></PK_NAME>
-            <uid><![CDATA[80D65CDA-A235-4650-9D71-8B5FA8DF593C]]></uid>
+            <PK_NAME><![CDATA[reimbursements_pkey]]></PK_NAME>
+            <uid><![CDATA[7F814812-3D8B-4B47-B65F-31A38C51C2F1]]></uid>
         </SQLField>
         <SQLField>
-            <name><![CDATA[description]]></name>
-            <type><![CDATA[TEXT]]></type>
+            <name><![CDATA[requested_amount]]></name>
+            <type><![CDATA[INTEGER]]></type>
             <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[458B3516-DF2C-44A1-B735-B7C6D18D5569]]></uid>
+            <uid><![CDATA[03765CD6-4736-436A-BC4E-3CFCA03355A5]]></uid>
         </SQLField>
         <SQLField>
-            <name><![CDATA[created_at]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[101F00A8-D775-45C2-8111-445A1F49D0C1]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[updated_at]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[5040AD4C-8698-4AD9-B5A3-507FEFD5A7BD]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[reporter_name]]></name>
+            <name><![CDATA[method_of_receipt]]></name>
             <type><![CDATA[CHARACTER VARYING(255)]]></type>
-            <uid><![CDATA[564D1202-014A-4609-8C82-62C32045D384]]></uid>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[1F1C9A9A-F74C-4225-A888-E224DA1A0A5A]]></uid>
         </SQLField>
         <SQLField>
-            <name><![CDATA[due_date]]></name>
+            <name><![CDATA[status]]></name>
+            <type><![CDATA[CHARACTER VARYING(255)]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[D1B0E51B-FA85-4870-9726-FA4C5D12149B]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[requested_date]]></name>
             <type><![CDATA[DATE]]></type>
-            <uid><![CDATA[5B0C7600-0C53-422D-A510-535E42EB32C3]]></uid>
-        </SQLField>
-        <labelWindowIndex><![CDATA[30]]></labelWindowIndex>
-        <PK_KEY_NAME><![CDATA[issues_pkey]]></PK_KEY_NAME>
-        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
-        <uid><![CDATA[97DC8B8E-1F77-4595-8A58-50F8F47D29CA]]></uid>
-    </SQLTable>
-    <SQLTable>
-        <name><![CDATA[public.uploads]]></name>
-        <schema><![CDATA[public]]></schema>
-        <location>
-            <x>10.00</x>
-            <y>2020.00</y>
-        </location>
-        <size>
-            <width>317.00</width>
-            <height>220.00</height>
-        </size>
-        <zorder>1</zorder>
-        <SQLField>
-            <name><![CDATA[id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <primaryKey>1</primaryKey>
-            <notNull><![CDATA[1]]></notNull>
-            <PK_NAME><![CDATA[uploads_pkey]]></PK_NAME>
-            <uid><![CDATA[9327AC99-8BD2-4673-B2AD-89DA3E9B8655]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[document_id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <referencesField>id</referencesField>
-            <referencesTable>public.documents</referencesTable>
-            <deleteAction>4</deleteAction>
-            <updateAction>4</updateAction>
-            <referencesField><![CDATA[id]]></referencesField>
-            <referencesTable><![CDATA[public.documents]]></referencesTable>
-            <sourceCardinality>0</sourceCardinality>
-            <destinationCardinality>0</destinationCardinality>
-            <referencesFieldUID><![CDATA[DB1CEAC4-39C1-4ED6-941D-DA5F6464C239]]></referencesFieldUID>
-            <referencesTableUID><![CDATA[DB441E2F-FED4-4952-AF6B-16954AD95900]]></referencesTableUID>
-            <foreignKeyName><![CDATA[uploads_document_id_fkey]]></foreignKeyName>
-            <uid><![CDATA[BB608B91-F0D2-4F09-A1E9-996DE9F1030F]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[uploader_id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <referencesField>id</referencesField>
-            <referencesTable>public.users</referencesTable>
-            <deleteAction>4</deleteAction>
-            <updateAction>4</updateAction>
-            <referencesField><![CDATA[id]]></referencesField>
-            <referencesTable><![CDATA[public.users]]></referencesTable>
-            <sourceCardinality>0</sourceCardinality>
-            <destinationCardinality>0</destinationCardinality>
-            <referencesFieldUID><![CDATA[BD0EC088-24B4-4DFF-A08C-82DC78218CA7]]></referencesFieldUID>
-            <referencesTableUID><![CDATA[C515D33B-5FF0-4039-A550-4E3ED3683006]]></referencesTableUID>
-            <foreignKeyName><![CDATA[uploads_uploader_id_fkey]]></foreignKeyName>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[FEE539FA-E93A-4BEC-8E8B-5E3C7FE8A79B]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[filename]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[5D380B21-FF70-4C1B-8430-858CC64BC7D5]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[bytes]]></name>
-            <type><![CDATA[BIGINT]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[36F07FA7-BEE9-4423-BD10-F841AD2620BF]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[content_type]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[63D42BF0-C380-417A-86FB-98697BED70FB]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[checksum]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[642CE787-34EE-4B07-8878-7AF1FB13BB90]]></uid>
+            <uid><![CDATA[C3B33899-9FF0-414A-980B-3F03D957DB9F]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[created_at]]></name>
             <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
             <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[EAF18027-BCA8-4501-BCD8-5CD624A23C9B]]></uid>
+            <uid><![CDATA[19E10E88-60C7-41C1-9A85-401EE0FA24D5]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[updated_at]]></name>
             <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
             <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[E4D91657-CB3D-4CDD-A138-B01A91F22E06]]></uid>
+            <uid><![CDATA[4884D806-DE39-4A8B-A4C3-BC01F4F5DE1A]]></uid>
+        </SQLField>
+        <labelWindowIndex><![CDATA[21]]></labelWindowIndex>
+        <PK_KEY_NAME><![CDATA[reimbursements_pkey]]></PK_KEY_NAME>
+        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
+        <uid><![CDATA[0A81A8EB-74CE-4135-932C-3BC96A130BF6]]></uid>
+    </SQLTable>
+    <SQLTable>
+        <name><![CDATA[public.moving_expense_documents]]></name>
+        <schema><![CDATA[public]]></schema>
+        <location>
+            <x>685.00</x>
+            <y>260.00</y>
+        </location>
+        <size>
+            <width>340.00</width>
+            <height>160.00</height>
+        </size>
+        <zorder>27</zorder>
+        <SQLField>
+            <name><![CDATA[id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <primaryKey>1</primaryKey>
+            <notNull><![CDATA[1]]></notNull>
+            <PK_NAME><![CDATA[moving_expense_documents_pkey]]></PK_NAME>
+            <uid><![CDATA[FC4DFA37-D140-482B-B2FA-DD27C8E3B873]]></uid>
         </SQLField>
         <SQLField>
-            <name><![CDATA[storage_key]]></name>
-            <type><![CDATA[CHARACTER VARYING(1024)]]></type>
-            <uid><![CDATA[64ED4754-18EA-4DC9-9B5E-A3E09140A926]]></uid>
+            <name><![CDATA[move_document_id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[53B6CB16-8748-4D71-979B-E3FA5790F639]]></uid>
         </SQLField>
-        <labelWindowIndex><![CDATA[1]]></labelWindowIndex>
-        <PK_KEY_NAME><![CDATA[uploads_pkey]]></PK_KEY_NAME>
+        <SQLField>
+            <name><![CDATA[moving_expense_type]]></name>
+            <type><![CDATA[CHARACTER VARYING(255)]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[972124D0-04F5-4A56-A784-4F3AF5AAFD5B]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[created_at]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[B243CD2A-1B0A-49AE-9F5E-5C8DAA9FC89F]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[updated_at]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[A6C43450-DEE8-4396-ADDA-F37A0CC6A8F7]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[requested_amount_cents]]></name>
+            <type><![CDATA[INTEGER]]></type>
+            <uid><![CDATA[86459E10-77C2-420A-BFFF-F8934B027EB5]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[payment_method]]></name>
+            <type><![CDATA[CHARACTER VARYING]]></type>
+            <uid><![CDATA[BEAFCFC3-3129-4F44-B2AF-7C5AA4F00386]]></uid>
+        </SQLField>
+        <labelWindowIndex><![CDATA[27]]></labelWindowIndex>
+        <PK_KEY_NAME><![CDATA[moving_expense_documents_pkey]]></PK_KEY_NAME>
         <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
-        <uid><![CDATA[A0ACFD08-C5DF-476E-8E5D-29A6A7E8BDA0]]></uid>
+        <uid><![CDATA[0FD4B487-2A9B-4E80-BFE3-38DF16DF3135]]></uid>
     </SQLTable>
     <SQLTable>
         <name><![CDATA[public.tariff400ng_zip3s]]></name>
@@ -1723,976 +339,51 @@
         <SQLField>
             <name><![CDATA[id]]></name>
             <type><![CDATA[UUID]]></type>
-            <uid><![CDATA[D4815832-48CE-4922-9C78-EFA142F38572]]></uid>
+            <uid><![CDATA[A41EAFDE-411C-43A2-AC2C-65CED0D37C23]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[zip3]]></name>
             <type><![CDATA[CHARACTER VARYING(3)]]></type>
-            <uid><![CDATA[D79968BB-D788-4492-8E89-877A8457186C]]></uid>
+            <uid><![CDATA[DDACBA51-2C08-43D4-920A-00CAB1D38693]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[basepoint_city]]></name>
             <type><![CDATA[TEXT]]></type>
-            <uid><![CDATA[66C7605F-595D-44C2-B4AF-E37C5DEB3383]]></uid>
+            <uid><![CDATA[504DAF1A-367D-465C-89A0-E80C6ECA0665]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[state]]></name>
             <type><![CDATA[TEXT]]></type>
-            <uid><![CDATA[F3A49A04-46F8-4BD5-B983-9E288151F7BF]]></uid>
+            <uid><![CDATA[03E006F0-6BA7-418B-B6C2-E2FFEA884777]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[service_area]]></name>
             <type><![CDATA[TEXT]]></type>
-            <uid><![CDATA[5AEC4399-EAE0-4E3F-8732-76DD19176026]]></uid>
+            <uid><![CDATA[5CDC2A48-D535-409C-905F-4BAD3D360EA9]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[rate_area]]></name>
             <type><![CDATA[TEXT]]></type>
-            <uid><![CDATA[81146261-95FA-40F7-9A57-4A707D84D0FF]]></uid>
+            <uid><![CDATA[BBD341CF-B42D-41DB-A9A3-B6BBA9ED83AE]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[region]]></name>
             <type><![CDATA[TEXT]]></type>
-            <uid><![CDATA[479B200A-C319-4600-A6D4-F0E78B878D31]]></uid>
+            <uid><![CDATA[B4861C50-682D-4AE1-9040-4BF148727ABE]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[created_at]]></name>
             <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <uid><![CDATA[5E71AC61-2D4D-425E-83C7-3C949C0FA72A]]></uid>
+            <uid><![CDATA[261A73E5-3C2D-40A9-A12A-1F22764C0978]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[updated_at]]></name>
             <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <uid><![CDATA[2D073DE9-045A-464E-8BE2-3C1D6E9A50E7]]></uid>
+            <uid><![CDATA[65A2DEC9-B79D-4B04-8941-BE54973C4CA9]]></uid>
         </SQLField>
         <labelWindowIndex><![CDATA[8]]></labelWindowIndex>
         <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
-        <uid><![CDATA[A8EF41F7-D289-4BF7-BBA1-56F3596E3A41]]></uid>
-    </SQLTable>
-    <SQLTable>
-        <name><![CDATA[public.orders]]></name>
-        <schema><![CDATA[public]]></schema>
-        <location>
-            <x>2016.00</x>
-            <y>260.00</y>
-        </location>
-        <size>
-            <width>317.00</width>
-            <height>400.00</height>
-        </size>
-        <zorder>23</zorder>
-        <SQLField>
-            <name><![CDATA[id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <primaryKey>1</primaryKey>
-            <forcedUnique><![CDATA[1]]></forcedUnique>
-            <notNull><![CDATA[1]]></notNull>
-            <PK_NAME><![CDATA[orders_pkey]]></PK_NAME>
-            <uid><![CDATA[01D1B709-C50F-416C-AF86-82A52C581C38]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[service_member_id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <referencesField>id</referencesField>
-            <referencesTable>public.service_members</referencesTable>
-            <deleteAction>1</deleteAction>
-            <updateAction>4</updateAction>
-            <referencesField><![CDATA[id]]></referencesField>
-            <referencesTable><![CDATA[public.service_members]]></referencesTable>
-            <sourceCardinality>0</sourceCardinality>
-            <destinationCardinality>0</destinationCardinality>
-            <referencesFieldUID><![CDATA[054FCC0C-61B5-4D99-BF9F-10C3DB0DFD7C]]></referencesFieldUID>
-            <referencesTableUID><![CDATA[5E420AFB-4EEF-4B8D-9335-68B41E67A652]]></referencesTableUID>
-            <foreignKeyName><![CDATA[orders_service_member_id_fkey]]></foreignKeyName>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[F7AA44B9-9B6C-46B1-8E0C-189206DD7A64]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[issue_date]]></name>
-            <type><![CDATA[DATE]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[1AEA7EBB-D5D6-4F37-AF6C-DC7E1DD0C399]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[report_by_date]]></name>
-            <type><![CDATA[DATE]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[A30306B4-A5CC-49B1-956E-E8581446EA0C]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[orders_type]]></name>
-            <type><![CDATA[CHARACTER VARYING(255)]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[DD5DB1D1-550F-430F-9557-FDE79050E441]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[has_dependents]]></name>
-            <type><![CDATA[BOOLEAN]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[B7D8288D-DA21-40C3-AE53-5CB163DF038A]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[new_duty_station_id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <referencesField>id</referencesField>
-            <referencesTable>public.duty_stations</referencesTable>
-            <deleteAction>1</deleteAction>
-            <updateAction>4</updateAction>
-            <referencesField><![CDATA[id]]></referencesField>
-            <referencesTable><![CDATA[public.duty_stations]]></referencesTable>
-            <sourceCardinality>0</sourceCardinality>
-            <destinationCardinality>0</destinationCardinality>
-            <referencesFieldUID><![CDATA[27EDCC68-3148-4109-A437-0D27FEFA9FE9]]></referencesFieldUID>
-            <referencesTableUID><![CDATA[C22BFDE9-D1F2-4844-9F12-2D8DC1552579]]></referencesTableUID>
-            <foreignKeyName><![CDATA[orders_new_duty_station_id_fkey]]></foreignKeyName>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[A4680FA1-564A-43C6-A1D3-CAA436C01355]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[created_at]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[0628A1E6-AAA1-4521-88C9-CDE55EFC1D17]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[updated_at]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[E71905DC-BCCE-4163-A907-E2C02916DC94]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[uploaded_orders_id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <referencesField>id</referencesField>
-            <referencesTable>public.documents</referencesTable>
-            <deleteAction>4</deleteAction>
-            <updateAction>4</updateAction>
-            <referencesField><![CDATA[id]]></referencesField>
-            <referencesTable><![CDATA[public.documents]]></referencesTable>
-            <sourceCardinality>0</sourceCardinality>
-            <destinationCardinality>0</destinationCardinality>
-            <referencesFieldUID><![CDATA[DB1CEAC4-39C1-4ED6-941D-DA5F6464C239]]></referencesFieldUID>
-            <referencesTableUID><![CDATA[DB441E2F-FED4-4952-AF6B-16954AD95900]]></referencesTableUID>
-            <foreignKeyName><![CDATA[orders_documents_id_fk]]></foreignKeyName>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[12C0E7C9-0EF6-4F24-8F27-F6AE3A3717E9]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[orders_number]]></name>
-            <type><![CDATA[CHARACTER VARYING(255)]]></type>
-            <uid><![CDATA[9DF5FADE-33C4-4961-8EF1-85F66DC1EE36]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[orders_type_detail]]></name>
-            <type><![CDATA[CHARACTER VARYING(255)]]></type>
-            <uid><![CDATA[AD5D03AA-7BFA-4B1E-956D-9D46DA38C0C1]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[status]]></name>
-            <type><![CDATA[CHARACTER VARYING(255)]]></type>
-            <defaultValue><![CDATA['DRAFT'::character varying]]></defaultValue>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[B620762D-DCEC-4C41-BEAC-9D0A39B61E00]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[tac]]></name>
-            <type><![CDATA[CHARACTER VARYING(255)]]></type>
-            <uid><![CDATA[1A940785-A3E3-4DB1-94F8-0122866CB39F]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[department_indicator]]></name>
-            <type><![CDATA[CHARACTER VARYING(255)]]></type>
-            <uid><![CDATA[2108D4A4-49F4-4846-BAD1-C8F0E9959179]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[spouse_has_pro_gear]]></name>
-            <type><![CDATA[BOOLEAN]]></type>
-            <defaultValue><![CDATA[false]]></defaultValue>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[79A39C41-84F9-4A03-8062-21AA72EE1D5D]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[orders_issuing_agency]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <uid><![CDATA[E28CCE36-44B3-44D2-A7D0-2D6400591257]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[paragraph_number]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <uid><![CDATA[6B265E49-E464-412B-8E98-D50950FA594A]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[sac]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <uid><![CDATA[29DC73D5-D35B-450B-A5FC-D1336C1F51F5]]></uid>
-        </SQLField>
-        <labelWindowIndex><![CDATA[23]]></labelWindowIndex>
-        <PK_KEY_NAME><![CDATA[orders_pkey]]></PK_KEY_NAME>
-        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
-        <uid><![CDATA[AB1BDA4B-DD98-45A5-954A-2F43D2057701]]></uid>
-    </SQLTable>
-    <SQLTable>
-        <name><![CDATA[public.duty_stations]]></name>
-        <schema><![CDATA[public]]></schema>
-        <location>
-            <x>1363.00</x>
-            <y>10.00</y>
-        </location>
-        <size>
-            <width>317.00</width>
-            <height>160.00</height>
-        </size>
-        <zorder>32</zorder>
-        <SQLField>
-            <name><![CDATA[id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <primaryKey>1</primaryKey>
-            <forcedUnique><![CDATA[1]]></forcedUnique>
-            <notNull><![CDATA[1]]></notNull>
-            <PK_NAME><![CDATA[duty_stations_pkey]]></PK_NAME>
-            <uid><![CDATA[27EDCC68-3148-4109-A437-0D27FEFA9FE9]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[name]]></name>
-            <type><![CDATA[CHARACTER VARYING(255)]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[1332D29E-8A3F-4C2D-A5E5-583E738B2C77]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[affiliation]]></name>
-            <type><![CDATA[CHARACTER VARYING(255)]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[D6B91A58-E27F-468F-8747-2BE20AB10775]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[address_id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <referencesField>id</referencesField>
-            <referencesTable>public.addresses</referencesTable>
-            <deleteAction>4</deleteAction>
-            <updateAction>4</updateAction>
-            <referencesField><![CDATA[id]]></referencesField>
-            <referencesTable><![CDATA[public.addresses]]></referencesTable>
-            <sourceCardinality>0</sourceCardinality>
-            <destinationCardinality>0</destinationCardinality>
-            <referencesFieldUID><![CDATA[4728081A-13E5-40AB-AEC0-8380BA3CC087]]></referencesFieldUID>
-            <referencesTableUID><![CDATA[457FF940-6EAC-42A2-B9C9-3DF7C9E6A946]]></referencesTableUID>
-            <foreignKeyName><![CDATA[duty_stations_address_id_fkey]]></foreignKeyName>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[C3424920-4568-409F-AEDD-4A953B084F84]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[created_at]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[78D253B0-6714-4802-A24F-E555D0B918B0]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[updated_at]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[42C78FF1-CFA4-4395-9934-1C05476034FA]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[transportation_office_id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <uid><![CDATA[AD56CC36-B190-4546-962C-46BFCB9E472C]]></uid>
-        </SQLField>
-        <labelWindowIndex><![CDATA[32]]></labelWindowIndex>
-        <PK_KEY_NAME><![CDATA[duty_stations_pkey]]></PK_KEY_NAME>
-        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
-        <uid><![CDATA[C22BFDE9-D1F2-4844-9F12-2D8DC1552579]]></uid>
-    </SQLTable>
-    <SQLTable>
-        <name><![CDATA[public.shipments]]></name>
-        <schema><![CDATA[public]]></schema>
-        <location>
-            <x>1984.00</x>
-            <y>670.00</y>
-        </location>
-        <size>
-            <width>424.00</width>
-            <height>740.00</height>
-        </size>
-        <zorder>16</zorder>
-        <SQLField>
-            <name><![CDATA[id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <primaryKey>1</primaryKey>
-            <forcedUnique><![CDATA[1]]></forcedUnique>
-            <notNull><![CDATA[1]]></notNull>
-            <PK_NAME><![CDATA[shipments_pkey]]></PK_NAME>
-            <uid><![CDATA[982DC590-943B-4DCF-A094-997BAF5B0B1D]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[traffic_distribution_list_id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <referencesField>id</referencesField>
-            <referencesTable>public.traffic_distribution_lists</referencesTable>
-            <deleteAction>4</deleteAction>
-            <updateAction>4</updateAction>
-            <referencesField><![CDATA[id]]></referencesField>
-            <referencesTable><![CDATA[public.traffic_distribution_lists]]></referencesTable>
-            <sourceCardinality>0</sourceCardinality>
-            <destinationCardinality>0</destinationCardinality>
-            <referencesFieldUID><![CDATA[9C3D964B-5687-4441-B562-A7025E3DAC94]]></referencesFieldUID>
-            <referencesTableUID><![CDATA[1986824A-2FFE-4FAF-A010-7BFEB6066A21]]></referencesTableUID>
-            <foreignKeyName><![CDATA[shipments_traffic_distribution_list_id_fkey]]></foreignKeyName>
-            <uid><![CDATA[B33B4A39-0876-48A8-BF32-CA0BD2A1F62B]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[pickup_date]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <uid><![CDATA[FCB4998F-9873-4738-94E4-BD248281D18E]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[delivery_date]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <uid><![CDATA[2D7209B9-9243-48CA-A547-6A55C262F4D0]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[created_at]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[4B6EDD84-39DC-4990-86EF-A9FDEB9B3E95]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[updated_at]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[23D04CED-E658-479B-948E-534EC23E8F15]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[source_gbloc]]></name>
-            <type><![CDATA[CHARACTER VARYING(255)]]></type>
-            <uid><![CDATA[4EAD5372-EF69-4022-9E69-DCA61A968F4F]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[market]]></name>
-            <type><![CDATA[CHARACTER VARYING(255)]]></type>
-            <uid><![CDATA[738DFF92-8748-4E7F-81BA-9BBD652779E0]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[book_date]]></name>
-            <type><![CDATA[DATE]]></type>
-            <uid><![CDATA[3E87B6DC-610C-4CA6-8089-D8CC8FEB82A2]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[requested_pickup_date]]></name>
-            <type><![CDATA[DATE]]></type>
-            <uid><![CDATA[6EA2149F-F80F-44C7-9B40-F98A97896821]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[move_id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[3504025B-511C-420D-9D0E-AEB615548A1D]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[status]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <defaultValue><![CDATA['DRAFT'::text]]></defaultValue>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[63ADFAFE-6B5C-44D3-B7F6-ACAEA6FEB265]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[estimated_pack_days]]></name>
-            <type><![CDATA[INTEGER]]></type>
-            <uid><![CDATA[47A84158-0B90-4F4E-AAE0-4DDCF8951356]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[estimated_transit_days]]></name>
-            <type><![CDATA[INTEGER]]></type>
-            <uid><![CDATA[92AF30B9-1E1E-483A-AC62-79B23C76E72D]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[pickup_address_id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <referencesField>id</referencesField>
-            <referencesTable>public.addresses</referencesTable>
-            <deleteAction>4</deleteAction>
-            <updateAction>4</updateAction>
-            <referencesField><![CDATA[id]]></referencesField>
-            <referencesTable><![CDATA[public.addresses]]></referencesTable>
-            <sourceCardinality>0</sourceCardinality>
-            <destinationCardinality>0</destinationCardinality>
-            <referencesFieldUID><![CDATA[4728081A-13E5-40AB-AEC0-8380BA3CC087]]></referencesFieldUID>
-            <referencesTableUID><![CDATA[457FF940-6EAC-42A2-B9C9-3DF7C9E6A946]]></referencesTableUID>
-            <foreignKeyName><![CDATA[shipments_address_id_fk]]></foreignKeyName>
-            <uid><![CDATA[C8B209C8-36D6-4C70-B1C9-414D3D8A976C]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[has_secondary_pickup_address]]></name>
-            <type><![CDATA[BOOLEAN]]></type>
-            <defaultValue><![CDATA[false]]></defaultValue>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[BB5AF7DC-2761-420B-9224-7BFFFBDFC4D8]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[secondary_pickup_address_id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <referencesField>id</referencesField>
-            <referencesTable>public.addresses</referencesTable>
-            <deleteAction>4</deleteAction>
-            <updateAction>4</updateAction>
-            <referencesField><![CDATA[id]]></referencesField>
-            <referencesTable><![CDATA[public.addresses]]></referencesTable>
-            <sourceCardinality>0</sourceCardinality>
-            <destinationCardinality>0</destinationCardinality>
-            <referencesFieldUID><![CDATA[4728081A-13E5-40AB-AEC0-8380BA3CC087]]></referencesFieldUID>
-            <referencesTableUID><![CDATA[457FF940-6EAC-42A2-B9C9-3DF7C9E6A946]]></referencesTableUID>
-            <foreignKeyName><![CDATA[shipments_secondary_address_id_fk]]></foreignKeyName>
-            <uid><![CDATA[92784B6A-5DD3-4FBF-92D9-87CB5D812276]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[has_delivery_address]]></name>
-            <type><![CDATA[BOOLEAN]]></type>
-            <defaultValue><![CDATA[false]]></defaultValue>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[8F451B13-360E-414B-9A97-A0C179FD89F1]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[delivery_address_id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <referencesField>id</referencesField>
-            <referencesTable>public.addresses</referencesTable>
-            <deleteAction>4</deleteAction>
-            <updateAction>4</updateAction>
-            <referencesField><![CDATA[id]]></referencesField>
-            <referencesTable><![CDATA[public.addresses]]></referencesTable>
-            <sourceCardinality>0</sourceCardinality>
-            <destinationCardinality>0</destinationCardinality>
-            <referencesFieldUID><![CDATA[4728081A-13E5-40AB-AEC0-8380BA3CC087]]></referencesFieldUID>
-            <referencesTableUID><![CDATA[457FF940-6EAC-42A2-B9C9-3DF7C9E6A946]]></referencesTableUID>
-            <foreignKeyName><![CDATA[delivery_address_id_fk]]></foreignKeyName>
-            <uid><![CDATA[10AF8DB9-51F1-4C7D-9D93-1FC7ECC36890]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[has_partial_sit_delivery_address]]></name>
-            <type><![CDATA[BOOLEAN]]></type>
-            <defaultValue><![CDATA[false]]></defaultValue>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[F3F2244C-C6A9-4E75-A08A-EE1000C69719]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[partial_sit_delivery_address_id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <referencesField>id</referencesField>
-            <referencesTable>public.addresses</referencesTable>
-            <deleteAction>4</deleteAction>
-            <updateAction>4</updateAction>
-            <referencesField><![CDATA[id]]></referencesField>
-            <referencesTable><![CDATA[public.addresses]]></referencesTable>
-            <sourceCardinality>0</sourceCardinality>
-            <destinationCardinality>0</destinationCardinality>
-            <referencesFieldUID><![CDATA[4728081A-13E5-40AB-AEC0-8380BA3CC087]]></referencesFieldUID>
-            <referencesTableUID><![CDATA[457FF940-6EAC-42A2-B9C9-3DF7C9E6A946]]></referencesTableUID>
-            <foreignKeyName><![CDATA[partial_sit_delivery_address_id_fk]]></foreignKeyName>
-            <uid><![CDATA[DAD144B1-D759-4313-84A5-B134EE20C85C]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[weight_estimate]]></name>
-            <type><![CDATA[INTEGER]]></type>
-            <uid><![CDATA[7953F748-7DC4-4F02-A9A4-5EF0335B8B0F]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[progear_weight_estimate]]></name>
-            <type><![CDATA[INTEGER]]></type>
-            <uid><![CDATA[BE8C9AAB-01ED-49E0-910D-E0F716C39B5B]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[spouse_progear_weight_estimate]]></name>
-            <type><![CDATA[INTEGER]]></type>
-            <uid><![CDATA[8566AF67-D36B-4705-9EAF-FF2096FEB9BA]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[destination_gbloc]]></name>
-            <type><![CDATA[CHARACTER VARYING(255)]]></type>
-            <uid><![CDATA[EED257D3-E847-468D-88A7-58FF582A4F62]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[service_member_id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <referencesField>id</referencesField>
-            <referencesTable>public.service_members</referencesTable>
-            <deleteAction>4</deleteAction>
-            <updateAction>4</updateAction>
-            <referencesField><![CDATA[id]]></referencesField>
-            <referencesTable><![CDATA[public.service_members]]></referencesTable>
-            <sourceCardinality>0</sourceCardinality>
-            <destinationCardinality>0</destinationCardinality>
-            <referencesFieldUID><![CDATA[054FCC0C-61B5-4D99-BF9F-10C3DB0DFD7C]]></referencesFieldUID>
-            <referencesTableUID><![CDATA[5E420AFB-4EEF-4B8D-9335-68B41E67A652]]></referencesTableUID>
-            <foreignKeyName><![CDATA[shipments_service_member_id_fk]]></foreignKeyName>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[87175E2D-BE57-4EEF-B76F-61ED73013017]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[pm_survey_planned_pack_date]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <uid><![CDATA[864B6EB9-7A00-4F29-B10E-439E44EBF2B9]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[pm_survey_planned_pickup_date]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <uid><![CDATA[D57E03CC-6689-47F7-BEC5-2A0242CD12AE]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[pm_survey_planned_delivery_date]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <uid><![CDATA[B2EEBA53-F4F4-472E-970E-374DA2FE9C2B]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[pm_survey_weight_estimate]]></name>
-            <type><![CDATA[INTEGER]]></type>
-            <uid><![CDATA[F23399C2-E6F8-476A-8A1A-18A60742082E]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[pm_survey_progear_weight_estimate]]></name>
-            <type><![CDATA[INTEGER]]></type>
-            <uid><![CDATA[57538B50-8867-4F39-863A-9A5C57EFCE2E]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[pm_survey_spouse_progear_weight_estimate]]></name>
-            <type><![CDATA[INTEGER]]></type>
-            <uid><![CDATA[87BEB40D-34E0-41A0-9398-077AB2B8B5EF]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[pm_survey_notes]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <uid><![CDATA[15F91BFA-8865-46BE-A2AE-21D26F4E0C08]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[pm_survey_method]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[F8EDEE02-5099-4E23-9DB2-19375A3E3B78]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[actual_weight]]></name>
-            <type><![CDATA[INTEGER]]></type>
-            <uid><![CDATA[4AD9A67C-9FC3-44A7-BCE5-EF69BBB4FFE4]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[gbl_number]]></name>
-            <type><![CDATA[CHARACTER VARYING(255)]]></type>
-            <uid><![CDATA[60D1FC03-AF23-478D-B0F6-C0FB1167E6B2]]></uid>
-        </SQLField>
-        <labelWindowIndex><![CDATA[16]]></labelWindowIndex>
-        <PK_KEY_NAME><![CDATA[shipments_pkey]]></PK_KEY_NAME>
-        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
-        <uid><![CDATA[C2B63AAC-0C9F-42F9-9655-E87AF3C8AB11]]></uid>
-    </SQLTable>
-    <SQLTable>
-        <name><![CDATA[public.office_phone_lines]]></name>
-        <schema><![CDATA[public]]></schema>
-        <location>
-            <x>1362.00</x>
-            <y>260.00</y>
-        </location>
-        <size>
-            <width>317.00</width>
-            <height>180.00</height>
-        </size>
-        <zorder>25</zorder>
-        <SQLField>
-            <name><![CDATA[id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <primaryKey>1</primaryKey>
-            <notNull><![CDATA[1]]></notNull>
-            <PK_NAME><![CDATA[office_phone_lines_pkey]]></PK_NAME>
-            <uid><![CDATA[53A8DC93-3565-4D88-A9C8-EDF6B768EB67]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[transportation_office_id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <referencesField>id</referencesField>
-            <referencesTable>public.transportation_offices</referencesTable>
-            <deleteAction>4</deleteAction>
-            <updateAction>4</updateAction>
-            <referencesField><![CDATA[id]]></referencesField>
-            <referencesTable><![CDATA[public.transportation_offices]]></referencesTable>
-            <sourceCardinality>0</sourceCardinality>
-            <destinationCardinality>0</destinationCardinality>
-            <referencesFieldUID><![CDATA[656AE989-CC75-4EDF-9251-D3F9345307F3]]></referencesFieldUID>
-            <referencesTableUID><![CDATA[2827CA86-4F1C-483D-AD59-976B282F0DDB]]></referencesTableUID>
-            <foreignKeyName><![CDATA[office_phone_lines_transportation_office_id_fkey]]></foreignKeyName>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[E4D34761-9975-4FB3-A879-231C43992292]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[number]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[69CACA7D-7634-48A9-9DD6-4AEDB0CAE065]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[label]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <uid><![CDATA[7614D8E1-D128-48EA-8530-8B2B35DC9121]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[is_dsn_number]]></name>
-            <type><![CDATA[BOOLEAN]]></type>
-            <defaultValue><![CDATA[false]]></defaultValue>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[F8C9E06F-C00C-45C2-8ED8-E0B8E2498BE5]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[type]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <defaultValue><![CDATA['voice'::text]]></defaultValue>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[40F80D13-BEAF-43CC-92A6-5A7F05EDFF73]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[created_at]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[2702D674-70BF-423B-A469-8F2D183D92D5]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[updated_at]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[9932BB4C-3452-4DD0-AECB-FBDCD20300A9]]></uid>
-        </SQLField>
-        <labelWindowIndex><![CDATA[25]]></labelWindowIndex>
-        <PK_KEY_NAME><![CDATA[office_phone_lines_pkey]]></PK_KEY_NAME>
-        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
-        <uid><![CDATA[C3E3BE92-F317-478F-904C-6A8E2ECF4627]]></uid>
-    </SQLTable>
-    <SQLTable>
-        <name><![CDATA[public.social_security_numbers]]></name>
-        <schema><![CDATA[public]]></schema>
-        <location>
-            <x>337.00</x>
-            <y>1420.00</y>
-        </location>
-        <size>
-            <width>317.00</width>
-            <height>100.00</height>
-        </size>
-        <zorder>14</zorder>
-        <SQLField>
-            <name><![CDATA[id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <primaryKey>1</primaryKey>
-            <forcedUnique><![CDATA[1]]></forcedUnique>
-            <notNull><![CDATA[1]]></notNull>
-            <PK_NAME><![CDATA[social_security_numbers_pkey]]></PK_NAME>
-            <uid><![CDATA[4E371793-FAD3-4039-982B-41371F5E395D]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[encrypted_hash]]></name>
-            <type><![CDATA[CHARACTER VARYING(255)]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[B8502765-4AB0-46BE-B3CC-00864F0D8FC8]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[created_at]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[FE78C0CE-AE2B-443E-92AD-1121CD2D3AAD]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[updated_at]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[0A306226-4293-4B26-99D3-80B2B832C4D6]]></uid>
-        </SQLField>
-        <labelWindowIndex><![CDATA[14]]></labelWindowIndex>
-        <PK_KEY_NAME><![CDATA[social_security_numbers_pkey]]></PK_KEY_NAME>
-        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
-        <uid><![CDATA[C4387D27-42FF-4C16-A502-09B4E8354036]]></uid>
-    </SQLTable>
-    <SQLTable>
-        <name><![CDATA[public.users]]></name>
-        <schema><![CDATA[public]]></schema>
-        <location>
-            <x>337.00</x>
-            <y>2020.00</y>
-        </location>
-        <size>
-            <width>317.00</width>
-            <height>140.00</height>
-        </size>
-        <zorder>0</zorder>
-        <SQLField>
-            <name><![CDATA[id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <primaryKey>1</primaryKey>
-            <forcedUnique><![CDATA[1]]></forcedUnique>
-            <notNull><![CDATA[1]]></notNull>
-            <PK_NAME><![CDATA[users_pkey]]></PK_NAME>
-            <uid><![CDATA[BD0EC088-24B4-4DFF-A08C-82DC78218CA7]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[login_gov_uuid]]></name>
-            <type><![CDATA[UUID]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[46F2BCC3-AE7B-4A9D-9E31-5B09700D7AD4]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[login_gov_email]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[92ADDD89-9CE7-4494-937F-2A5E7DD18EEB]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[created_at]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[D9927082-FB4A-4E90-8ABF-3A4017DCE847]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[updated_at]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[65B2C948-4F52-43E1-9200-B27653ADCC42]]></uid>
-        </SQLField>
-        <SQLConstraint>
-            <name><![CDATA[constraint_name]]></name>
-            <fieldName><![CDATA[login_gov_uuid]]></fieldName>
-            <SQLIndexEntry>
-                <name><![CDATA[login_gov_uuid]]></name>
-                <prefixSize><![CDATA[]]></prefixSize>
-                <fieldUid><![CDATA[46F2BCC3-AE7B-4A9D-9E31-5B09700D7AD4]]></fieldUid>
-            </SQLIndexEntry>
-            <deferrable><![CDATA[0]]></deferrable>
-            <indexType><![CDATA[UNIQUE]]></indexType>
-            <initiallyDeferred><![CDATA[0]]></initiallyDeferred>
-            <uid><![CDATA[69056A47-656C-45E3-9E65-E164C72B1886]]></uid>
-        </SQLConstraint>
-        <labelWindowIndex><![CDATA[0]]></labelWindowIndex>
-        <PK_KEY_NAME><![CDATA[users_pkey]]></PK_KEY_NAME>
-        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
-        <uid><![CDATA[C515D33B-5FF0-4039-A550-4E3ED3683006]]></uid>
-    </SQLTable>
-    <SQLTable>
-        <name><![CDATA[public.gbl_number_trackers]]></name>
-        <schema><![CDATA[public]]></schema>
-        <location>
-            <x>1690.00</x>
-            <y>10.00</y>
-        </location>
-        <size>
-            <width>229.00</width>
-            <height>80.00</height>
-        </size>
-        <zorder>31</zorder>
-        <SQLField>
-            <name><![CDATA[sequence_number]]></name>
-            <type><![CDATA[INTEGER]]></type>
-            <uid><![CDATA[33092A50-7971-4637-86C7-59A2726499B3]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[gbloc]]></name>
-            <type><![CDATA[CHARACTER VARYING(255)]]></type>
-            <uid><![CDATA[C8897941-1348-4F60-9A63-9347CE8EEF16]]></uid>
-        </SQLField>
-        <SQLConstraint>
-            <name><![CDATA[gbl_number_trackers_gbloc_key]]></name>
-            <fieldName><![CDATA[gbloc]]></fieldName>
-            <SQLIndexEntry>
-                <name><![CDATA[gbloc]]></name>
-                <prefixSize><![CDATA[]]></prefixSize>
-                <fieldUid><![CDATA[C8897941-1348-4F60-9A63-9347CE8EEF16]]></fieldUid>
-            </SQLIndexEntry>
-            <deferrable><![CDATA[0]]></deferrable>
-            <indexType><![CDATA[UNIQUE]]></indexType>
-            <initiallyDeferred><![CDATA[0]]></initiallyDeferred>
-            <uid><![CDATA[2BB3C49C-940B-4F1C-A7A4-F90CF05573FC]]></uid>
-        </SQLConstraint>
-        <labelWindowIndex><![CDATA[31]]></labelWindowIndex>
-        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
-        <uid><![CDATA[CDCD4676-A1ED-4192-9DD5-D2648231927A]]></uid>
-    </SQLTable>
-    <SQLTable>
-        <name><![CDATA[public.shipment_offers]]></name>
-        <schema><![CDATA[public]]></schema>
-        <location>
-            <x>1657.00</x>
-            <y>670.00</y>
-        </location>
-        <size>
-            <width>317.00</width>
-            <height>180.00</height>
-        </size>
-        <zorder>17</zorder>
-        <SQLField>
-            <name><![CDATA[id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <primaryKey>1</primaryKey>
-            <notNull><![CDATA[1]]></notNull>
-            <PK_NAME><![CDATA[awarded_shipments_pkey]]></PK_NAME>
-            <uid><![CDATA[3F46FCAC-06EE-44A8-9D19-D30C873DC570]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[shipment_id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <referencesField>id</referencesField>
-            <referencesTable>public.shipments</referencesTable>
-            <deleteAction>4</deleteAction>
-            <updateAction>4</updateAction>
-            <referencesField><![CDATA[id]]></referencesField>
-            <referencesTable><![CDATA[public.shipments]]></referencesTable>
-            <sourceCardinality>0</sourceCardinality>
-            <destinationCardinality>0</destinationCardinality>
-            <referencesFieldUID><![CDATA[982DC590-943B-4DCF-A094-997BAF5B0B1D]]></referencesFieldUID>
-            <referencesTableUID><![CDATA[C2B63AAC-0C9F-42F9-9655-E87AF3C8AB11]]></referencesTableUID>
-            <foreignKeyName><![CDATA[awarded_shipments_shipment_id_fkey]]></foreignKeyName>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[F7E95362-7D41-4EC6-B1A9-06448A92A1E4]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[transportation_service_provider_id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <referencesField>id</referencesField>
-            <referencesTable>public.transportation_service_providers</referencesTable>
-            <deleteAction>4</deleteAction>
-            <updateAction>4</updateAction>
-            <referencesField><![CDATA[id]]></referencesField>
-            <referencesTable><![CDATA[public.transportation_service_providers]]></referencesTable>
-            <sourceCardinality>0</sourceCardinality>
-            <destinationCardinality>0</destinationCardinality>
-            <referencesFieldUID><![CDATA[B2FC2241-6268-451C-A898-2CCD98B1A7CE]]></referencesFieldUID>
-            <referencesTableUID><![CDATA[336A1743-A267-4705-9723-19495DAEC0A7]]></referencesTableUID>
-            <foreignKeyName><![CDATA[awarded_shipments_transportation_service_provider_id_fkey]]></foreignKeyName>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[719B0B39-2ABD-4E82-9667-C16EEE735A77]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[administrative_shipment]]></name>
-            <type><![CDATA[BOOLEAN]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[7B4B467B-1AE7-4936-8BB1-044BEDBA66FC]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[created_at]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[27DA77D6-5AD1-426D-B9F8-EEFFB51A806E]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[updated_at]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[106F86BD-EFAE-438F-AF62-305D45CA1872]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[accepted]]></name>
-            <type><![CDATA[BOOLEAN]]></type>
-            <uid><![CDATA[A4D5FF9D-661B-4B89-ABC4-A0DBAA0FF691]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[rejection_reason]]></name>
-            <type><![CDATA[CHARACTER VARYING(255)]]></type>
-            <uid><![CDATA[5AF69EFD-2A44-4693-8E61-70BE62AA7FE2]]></uid>
-        </SQLField>
-        <labelWindowIndex><![CDATA[17]]></labelWindowIndex>
-        <PK_KEY_NAME><![CDATA[awarded_shipments_pkey]]></PK_KEY_NAME>
-        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
-        <uid><![CDATA[D0B30242-898F-467E-9496-AAB66DD967C2]]></uid>
-    </SQLTable>
-    <SQLTable>
-        <name><![CDATA[public.tsp_users]]></name>
-        <schema><![CDATA[public]]></schema>
-        <location>
-            <x>2014.00</x>
-            <y>1710.00</y>
-        </location>
-        <size>
-            <width>317.00</width>
-            <height>220.00</height>
-        </size>
-        <zorder>2</zorder>
-        <SQLField>
-            <name><![CDATA[id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <primaryKey>1</primaryKey>
-            <notNull><![CDATA[1]]></notNull>
-            <PK_NAME><![CDATA[tsp_users_pkey]]></PK_NAME>
-            <uid><![CDATA[37899ABA-E082-46E6-B87D-F08AACAEFA58]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[user_id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <referencesField>id</referencesField>
-            <referencesTable>public.users</referencesTable>
-            <deleteAction>4</deleteAction>
-            <updateAction>4</updateAction>
-            <referencesField><![CDATA[id]]></referencesField>
-            <referencesTable><![CDATA[public.users]]></referencesTable>
-            <sourceCardinality>0</sourceCardinality>
-            <destinationCardinality>0</destinationCardinality>
-            <referencesFieldUID><![CDATA[BD0EC088-24B4-4DFF-A08C-82DC78218CA7]]></referencesFieldUID>
-            <referencesTableUID><![CDATA[C515D33B-5FF0-4039-A550-4E3ED3683006]]></referencesTableUID>
-            <foreignKeyName><![CDATA[tsp_users_user_id_fkey]]></foreignKeyName>
-            <uid><![CDATA[A3AFA9DD-E37C-4920-9B48-C1A468E9768A]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[last_name]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[F97B0056-A79A-4064-BAF6-A00C0AD3EAF6]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[first_name]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[6F6347E6-8413-4810-8A9F-BDA79408BE1E]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[middle_initials]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <uid><![CDATA[65B3641A-E585-4832-8193-C892992A80B6]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[email]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[38D9ACC5-7802-4734-855C-2B6C138C71A5]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[telephone]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[AC2CBD53-7A7E-46DA-AC31-56539EF9FC06]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[transportation_service_provider_id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <referencesField>id</referencesField>
-            <referencesTable>public.transportation_service_providers</referencesTable>
-            <deleteAction>4</deleteAction>
-            <updateAction>4</updateAction>
-            <referencesField><![CDATA[id]]></referencesField>
-            <referencesTable><![CDATA[public.transportation_service_providers]]></referencesTable>
-            <sourceCardinality>0</sourceCardinality>
-            <destinationCardinality>0</destinationCardinality>
-            <referencesFieldUID><![CDATA[B2FC2241-6268-451C-A898-2CCD98B1A7CE]]></referencesFieldUID>
-            <referencesTableUID><![CDATA[336A1743-A267-4705-9723-19495DAEC0A7]]></referencesTableUID>
-            <foreignKeyName><![CDATA[tsp_users_transportation_service_provider_id_fkey]]></foreignKeyName>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[9FF939C3-0F9C-4E74-B6C9-93E95E010939]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[created_at]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[488B6AFD-5369-446D-8462-DCA850FA5907]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[updated_at]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[46BD3F38-CAB3-430F-8BA5-947D867E3511]]></uid>
-        </SQLField>
-        <labelWindowIndex><![CDATA[2]]></labelWindowIndex>
-        <PK_KEY_NAME><![CDATA[tsp_users_pkey]]></PK_KEY_NAME>
-        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
-        <uid><![CDATA[D26D5B83-05C6-4155-9D90-81F31F07D25E]]></uid>
+        <uid><![CDATA[20B6B702-109B-4ABB-B286-0300427D23D4]]></uid>
     </SQLTable>
     <SQLTable>
         <name><![CDATA[public.documents]]></name>
@@ -2713,19 +404,19 @@
             <forcedUnique><![CDATA[1]]></forcedUnique>
             <notNull><![CDATA[1]]></notNull>
             <PK_NAME><![CDATA[documents_pkey]]></PK_NAME>
-            <uid><![CDATA[DB1CEAC4-39C1-4ED6-941D-DA5F6464C239]]></uid>
+            <uid><![CDATA[3370E717-87B8-4ACC-8AFD-81FEDCD58164]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[created_at]]></name>
             <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
             <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[C009E34B-62C7-4BFE-B0E8-6FE74B57BF9A]]></uid>
+            <uid><![CDATA[FADF2908-68EF-4ACD-AC80-C157761C747A]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[updated_at]]></name>
             <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
             <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[7180C761-F5EA-45E7-A1B0-5040F3685E97]]></uid>
+            <uid><![CDATA[45E35966-5AC4-4AD3-98C5-3BD97E2C50C0]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[service_member_id]]></name>
@@ -2738,77 +429,1489 @@
             <referencesTable><![CDATA[public.service_members]]></referencesTable>
             <sourceCardinality>0</sourceCardinality>
             <destinationCardinality>0</destinationCardinality>
-            <referencesFieldUID><![CDATA[054FCC0C-61B5-4D99-BF9F-10C3DB0DFD7C]]></referencesFieldUID>
-            <referencesTableUID><![CDATA[5E420AFB-4EEF-4B8D-9335-68B41E67A652]]></referencesTableUID>
+            <referencesFieldUID><![CDATA[461A9476-10E6-4746-A8C4-3CA6C32BDEF4]]></referencesFieldUID>
+            <referencesTableUID><![CDATA[73DE4768-12E2-40FC-95C7-A4548B8CDBB8]]></referencesTableUID>
             <foreignKeyName><![CDATA[documents_service_members_id_fk]]></foreignKeyName>
             <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[792B63A5-C4E2-485C-B89C-9B92302C2310]]></uid>
+            <uid><![CDATA[9CE9EA27-C371-4A67-81DD-496F5D753EBD]]></uid>
         </SQLField>
         <labelWindowIndex><![CDATA[33]]></labelWindowIndex>
         <PK_KEY_NAME><![CDATA[documents_pkey]]></PK_KEY_NAME>
         <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
-        <uid><![CDATA[DB441E2F-FED4-4952-AF6B-16954AD95900]]></uid>
+        <uid><![CDATA[3FFFC432-1F1B-40DD-80A4-84CC20C5E1D0]]></uid>
     </SQLTable>
     <SQLTable>
-        <name><![CDATA[public.tariff400ng_full_pack_rates]]></name>
+        <name><![CDATA[public.traffic_distribution_lists]]></name>
         <schema><![CDATA[public]]></schema>
         <location>
-            <x>664.00</x>
-            <y>1420.00</y>
+            <x>626.00</x>
+            <y>1710.00</y>
         </location>
         <size>
-            <width>298.00</width>
-            <height>200.00</height>
+            <width>372.00</width>
+            <height>160.00</height>
         </size>
-        <zorder>13</zorder>
+        <zorder>6</zorder>
         <SQLField>
             <name><![CDATA[id]]></name>
             <type><![CDATA[UUID]]></type>
-            <uid><![CDATA[9BC2CACA-A20F-49D8-90B1-9BC8BFE07B9E]]></uid>
+            <primaryKey>1</primaryKey>
+            <forcedUnique><![CDATA[1]]></forcedUnique>
+            <notNull><![CDATA[1]]></notNull>
+            <PK_NAME><![CDATA[traffic_distribution_lists_pkey]]></PK_NAME>
+            <uid><![CDATA[2E5B406F-1D96-456A-93A2-B199011E1071]]></uid>
         </SQLField>
         <SQLField>
-            <name><![CDATA[schedule]]></name>
-            <type><![CDATA[INTEGER]]></type>
-            <uid><![CDATA[42A59320-845D-4B7E-AD7F-A18F84B402EF]]></uid>
+            <name><![CDATA[source_rate_area]]></name>
+            <type><![CDATA[CHARACTER VARYING(255)]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[8F36DEE5-C119-4EE1-AA5E-F696F5FD2820]]></uid>
         </SQLField>
         <SQLField>
-            <name><![CDATA[weight_lbs_lower]]></name>
-            <type><![CDATA[INTEGER]]></type>
-            <uid><![CDATA[7B644A15-869F-4B2B-96FE-3E9128A6CF85]]></uid>
+            <name><![CDATA[destination_region]]></name>
+            <type><![CDATA[CHARACTER VARYING(255)]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[1B5A595F-1EA3-487B-B939-567BF234C0B8]]></uid>
         </SQLField>
         <SQLField>
-            <name><![CDATA[weight_lbs_upper]]></name>
-            <type><![CDATA[INTEGER]]></type>
-            <uid><![CDATA[6376210D-03C6-418A-B32F-7C1C0ABBC39E]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[rate_cents]]></name>
-            <type><![CDATA[INTEGER]]></type>
-            <uid><![CDATA[DCC74429-ED0D-4651-AC92-700EA4D1CF8F]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[effective_date_lower]]></name>
-            <type><![CDATA[DATE]]></type>
-            <uid><![CDATA[24AE58E0-C84B-4771-B977-A42B462A5535]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[effective_date_upper]]></name>
-            <type><![CDATA[DATE]]></type>
-            <uid><![CDATA[A8E79E9D-85AF-4FFE-B14C-F8EE88F4DB42]]></uid>
+            <name><![CDATA[code_of_service]]></name>
+            <type><![CDATA[CHARACTER VARYING(255)]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[6B24C8A1-3840-457B-9876-72B56D281271]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[created_at]]></name>
             <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <uid><![CDATA[2D36A411-2B86-4033-B19D-162FBD3F9CDA]]></uid>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[9E4FC47F-F853-4618-83B0-E148EEECC64E]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[updated_at]]></name>
             <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <uid><![CDATA[3C9E85AC-5510-4AED-B659-3C76CFBBBC67]]></uid>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[B1D7CC66-E203-4B62-B2A6-E9CAFF0A8480]]></uid>
         </SQLField>
-        <labelWindowIndex><![CDATA[13]]></labelWindowIndex>
+        <SQLConstraint>
+            <name><![CDATA[unique_channel_cos]]></name>
+            <fieldName><![CDATA[source_rate_area]]></fieldName>
+            <fieldName><![CDATA[destination_region]]></fieldName>
+            <fieldName><![CDATA[code_of_service]]></fieldName>
+            <SQLIndexEntry>
+                <name><![CDATA[source_rate_area]]></name>
+                <prefixSize><![CDATA[]]></prefixSize>
+                <fieldUid><![CDATA[8F36DEE5-C119-4EE1-AA5E-F696F5FD2820]]></fieldUid>
+            </SQLIndexEntry>
+            <SQLIndexEntry>
+                <name><![CDATA[destination_region]]></name>
+                <prefixSize><![CDATA[]]></prefixSize>
+                <fieldUid><![CDATA[1B5A595F-1EA3-487B-B939-567BF234C0B8]]></fieldUid>
+            </SQLIndexEntry>
+            <SQLIndexEntry>
+                <name><![CDATA[code_of_service]]></name>
+                <prefixSize><![CDATA[]]></prefixSize>
+                <fieldUid><![CDATA[6B24C8A1-3840-457B-9876-72B56D281271]]></fieldUid>
+            </SQLIndexEntry>
+            <deferrable><![CDATA[0]]></deferrable>
+            <indexType><![CDATA[UNIQUE]]></indexType>
+            <initiallyDeferred><![CDATA[0]]></initiallyDeferred>
+            <uid><![CDATA[CF63F949-3872-4E42-9DF2-9C189734871B]]></uid>
+        </SQLConstraint>
+        <labelWindowIndex><![CDATA[6]]></labelWindowIndex>
+        <PK_KEY_NAME><![CDATA[traffic_distribution_lists_pkey]]></PK_KEY_NAME>
         <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
-        <uid><![CDATA[DD951AF0-2C33-49EC-A688-371BCE445848]]></uid>
+        <uid><![CDATA[47606E6D-CCE4-4973-83D0-04F2295472DB]]></uid>
+    </SQLTable>
+    <SQLTable>
+        <name><![CDATA[public.users]]></name>
+        <schema><![CDATA[public]]></schema>
+        <location>
+            <x>337.00</x>
+            <y>2020.00</y>
+        </location>
+        <size>
+            <width>317.00</width>
+            <height>140.00</height>
+        </size>
+        <zorder>0</zorder>
+        <SQLField>
+            <name><![CDATA[id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <primaryKey>1</primaryKey>
+            <forcedUnique><![CDATA[1]]></forcedUnique>
+            <notNull><![CDATA[1]]></notNull>
+            <PK_NAME><![CDATA[users_pkey]]></PK_NAME>
+            <uid><![CDATA[D4D187F7-AADA-48B8-A8C6-3CAEA7E3CC29]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[login_gov_uuid]]></name>
+            <type><![CDATA[UUID]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[ABD8BD5E-5DBD-44EB-B1EC-D47813E8E970]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[login_gov_email]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[7F742244-B1F3-474A-A73F-A07AEA7193F4]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[created_at]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[64292DD6-4D6B-4953-BE6C-990EB332FE4F]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[updated_at]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[C921DCAF-65E4-4F40-AD44-CDD015E1849A]]></uid>
+        </SQLField>
+        <SQLConstraint>
+            <name><![CDATA[constraint_name]]></name>
+            <fieldName><![CDATA[login_gov_uuid]]></fieldName>
+            <SQLIndexEntry>
+                <name><![CDATA[login_gov_uuid]]></name>
+                <prefixSize><![CDATA[]]></prefixSize>
+                <fieldUid><![CDATA[ABD8BD5E-5DBD-44EB-B1EC-D47813E8E970]]></fieldUid>
+            </SQLIndexEntry>
+            <deferrable><![CDATA[0]]></deferrable>
+            <indexType><![CDATA[UNIQUE]]></indexType>
+            <initiallyDeferred><![CDATA[0]]></initiallyDeferred>
+            <uid><![CDATA[D702373E-4F0B-48D4-848A-AF833347FDF3]]></uid>
+        </SQLConstraint>
+        <labelWindowIndex><![CDATA[0]]></labelWindowIndex>
+        <PK_KEY_NAME><![CDATA[users_pkey]]></PK_KEY_NAME>
+        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
+        <uid><![CDATA[4770FB7F-1D23-40FF-90EA-84AFA3AA5CB2]]></uid>
+    </SQLTable>
+    <SQLTable>
+        <name><![CDATA[public.duty_stations]]></name>
+        <schema><![CDATA[public]]></schema>
+        <location>
+            <x>1363.00</x>
+            <y>10.00</y>
+        </location>
+        <size>
+            <width>317.00</width>
+            <height>160.00</height>
+        </size>
+        <zorder>32</zorder>
+        <SQLField>
+            <name><![CDATA[id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <primaryKey>1</primaryKey>
+            <forcedUnique><![CDATA[1]]></forcedUnique>
+            <notNull><![CDATA[1]]></notNull>
+            <PK_NAME><![CDATA[duty_stations_pkey]]></PK_NAME>
+            <uid><![CDATA[4958559A-061C-4DE2-A054-35E489DF3A59]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[name]]></name>
+            <type><![CDATA[CHARACTER VARYING(255)]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[78449E0F-C91F-4722-8166-D8DDA23A9747]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[affiliation]]></name>
+            <type><![CDATA[CHARACTER VARYING(255)]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[635B1E49-4261-417B-AA94-DC35776F76C4]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[address_id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <referencesField>id</referencesField>
+            <referencesTable>public.addresses</referencesTable>
+            <deleteAction>4</deleteAction>
+            <updateAction>4</updateAction>
+            <referencesField><![CDATA[id]]></referencesField>
+            <referencesTable><![CDATA[public.addresses]]></referencesTable>
+            <sourceCardinality>0</sourceCardinality>
+            <destinationCardinality>0</destinationCardinality>
+            <referencesFieldUID><![CDATA[8A595576-135D-4DC5-9E9A-6F4ABF2BE75E]]></referencesFieldUID>
+            <referencesTableUID><![CDATA[EE6CFACF-C2CF-4DDA-A8C0-56742C7EA4B7]]></referencesTableUID>
+            <foreignKeyName><![CDATA[duty_stations_address_id_fkey]]></foreignKeyName>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[E119E225-BE22-422E-AB03-A79B796BD4EC]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[created_at]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[E5FE7640-4DC5-4B61-AC2F-0CC550881F8E]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[updated_at]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[9A828A2B-3B06-4D8F-B863-1A172098BDB0]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[transportation_office_id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <uid><![CDATA[5172CD2A-F195-4520-B1A3-361BFD9EC623]]></uid>
+        </SQLField>
+        <labelWindowIndex><![CDATA[32]]></labelWindowIndex>
+        <PK_KEY_NAME><![CDATA[duty_stations_pkey]]></PK_KEY_NAME>
+        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
+        <uid><![CDATA[4833725A-7A93-433E-9E02-DAC861D0DFB2]]></uid>
+    </SQLTable>
+    <SQLTable>
+        <name><![CDATA[public.office_phone_lines]]></name>
+        <schema><![CDATA[public]]></schema>
+        <location>
+            <x>1362.00</x>
+            <y>260.00</y>
+        </location>
+        <size>
+            <width>317.00</width>
+            <height>180.00</height>
+        </size>
+        <zorder>25</zorder>
+        <SQLField>
+            <name><![CDATA[id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <primaryKey>1</primaryKey>
+            <notNull><![CDATA[1]]></notNull>
+            <PK_NAME><![CDATA[office_phone_lines_pkey]]></PK_NAME>
+            <uid><![CDATA[7CF7DB06-4E13-4A47-969C-6A6CC13E2BC1]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[transportation_office_id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <referencesField>id</referencesField>
+            <referencesTable>public.transportation_offices</referencesTable>
+            <deleteAction>4</deleteAction>
+            <updateAction>4</updateAction>
+            <referencesField><![CDATA[id]]></referencesField>
+            <referencesTable><![CDATA[public.transportation_offices]]></referencesTable>
+            <sourceCardinality>0</sourceCardinality>
+            <destinationCardinality>0</destinationCardinality>
+            <referencesFieldUID><![CDATA[9705C664-CD6F-4F37-98D3-36BB4FEA25C1]]></referencesFieldUID>
+            <referencesTableUID><![CDATA[E739E7A3-15AF-4D15-8BF6-DBCF6B06361D]]></referencesTableUID>
+            <foreignKeyName><![CDATA[office_phone_lines_transportation_office_id_fkey]]></foreignKeyName>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[A09DF36D-EF94-4F43-BF66-E975B3909AE4]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[number]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[B4DBEDEB-D1E5-44EA-A1AA-18AAA42CB66F]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[label]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <uid><![CDATA[9C2C2B4E-D35F-4DA2-8C88-B0D55D106CE0]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[is_dsn_number]]></name>
+            <type><![CDATA[BOOLEAN]]></type>
+            <defaultValue><![CDATA[false]]></defaultValue>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[58123DB7-5AD5-4BB5-912F-5767DD1DA55E]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[type]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <defaultValue><![CDATA['voice'::text]]></defaultValue>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[F921F336-793F-4A10-843E-347004AC0BE9]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[created_at]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[35B7B4B6-716C-4B3F-8AB9-92AA0BD316FD]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[updated_at]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[E0B2E828-7D11-4AF0-9CCF-9F0FBF7A935A]]></uid>
+        </SQLField>
+        <labelWindowIndex><![CDATA[25]]></labelWindowIndex>
+        <PK_KEY_NAME><![CDATA[office_phone_lines_pkey]]></PK_KEY_NAME>
+        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
+        <uid><![CDATA[489FFE6F-F931-4F80-ACC3-1796A4DC4749]]></uid>
+    </SQLTable>
+    <SQLTable>
+        <name><![CDATA[public.tsp_users]]></name>
+        <schema><![CDATA[public]]></schema>
+        <location>
+            <x>2014.00</x>
+            <y>1710.00</y>
+        </location>
+        <size>
+            <width>317.00</width>
+            <height>220.00</height>
+        </size>
+        <zorder>2</zorder>
+        <SQLField>
+            <name><![CDATA[id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <primaryKey>1</primaryKey>
+            <notNull><![CDATA[1]]></notNull>
+            <PK_NAME><![CDATA[tsp_users_pkey]]></PK_NAME>
+            <uid><![CDATA[5F25A90A-1CD0-46CE-A799-54A7CA85CB41]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[user_id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <referencesField>id</referencesField>
+            <referencesTable>public.users</referencesTable>
+            <deleteAction>4</deleteAction>
+            <updateAction>4</updateAction>
+            <referencesField><![CDATA[id]]></referencesField>
+            <referencesTable><![CDATA[public.users]]></referencesTable>
+            <sourceCardinality>0</sourceCardinality>
+            <destinationCardinality>0</destinationCardinality>
+            <referencesFieldUID><![CDATA[D4D187F7-AADA-48B8-A8C6-3CAEA7E3CC29]]></referencesFieldUID>
+            <referencesTableUID><![CDATA[4770FB7F-1D23-40FF-90EA-84AFA3AA5CB2]]></referencesTableUID>
+            <foreignKeyName><![CDATA[tsp_users_user_id_fkey]]></foreignKeyName>
+            <uid><![CDATA[F32C12A4-6BA6-47D5-95AA-D2EA447AB18A]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[last_name]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[20E8CFC1-7D73-41A0-A627-70211EF02168]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[first_name]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[A743387A-D841-4B0B-B3C7-F30E78EDA60D]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[middle_initials]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <uid><![CDATA[1EEEDFF1-A811-470D-9BD6-80B497FEFAB6]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[email]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[668D6707-5112-4B0B-8CEC-822204AD7DA2]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[telephone]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[255E3100-D270-4D49-A7DC-660188B73D93]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[transportation_service_provider_id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <referencesField>id</referencesField>
+            <referencesTable>public.transportation_service_providers</referencesTable>
+            <deleteAction>4</deleteAction>
+            <updateAction>4</updateAction>
+            <referencesField><![CDATA[id]]></referencesField>
+            <referencesTable><![CDATA[public.transportation_service_providers]]></referencesTable>
+            <sourceCardinality>0</sourceCardinality>
+            <destinationCardinality>0</destinationCardinality>
+            <referencesFieldUID><![CDATA[33B103F7-65E6-4CD2-BF2C-6A9E75620737]]></referencesFieldUID>
+            <referencesTableUID><![CDATA[03657CA9-D150-49B8-B269-48D3FC7E462E]]></referencesTableUID>
+            <foreignKeyName><![CDATA[tsp_users_transportation_service_provider_id_fkey]]></foreignKeyName>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[C7FBF08A-85F1-4C74-B72E-C5A2E9B755E3]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[created_at]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[FF21B865-4859-48CC-ACAA-68AD2FBAC536]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[updated_at]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[BC2D801B-F12B-405C-92E7-74CED896B523]]></uid>
+        </SQLField>
+        <labelWindowIndex><![CDATA[2]]></labelWindowIndex>
+        <PK_KEY_NAME><![CDATA[tsp_users_pkey]]></PK_KEY_NAME>
+        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
+        <uid><![CDATA[4C3C8DF4-1F74-4B43-8612-D9B466A56CE2]]></uid>
+    </SQLTable>
+    <SQLTable>
+        <name><![CDATA[public.move_documents]]></name>
+        <schema><![CDATA[public]]></schema>
+        <location>
+            <x>10.00</x>
+            <y>260.00</y>
+        </location>
+        <size>
+            <width>338.00</width>
+            <height>220.00</height>
+        </size>
+        <zorder>29</zorder>
+        <SQLField>
+            <name><![CDATA[id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <primaryKey>1</primaryKey>
+            <notNull><![CDATA[1]]></notNull>
+            <PK_NAME><![CDATA[move_documents_pkey]]></PK_NAME>
+            <uid><![CDATA[472AEC6E-3B6F-41ED-9712-D5C3EDD41DD8]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[move_id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <referencesField>id</referencesField>
+            <referencesTable>public.moves</referencesTable>
+            <deleteAction>2</deleteAction>
+            <updateAction>4</updateAction>
+            <referencesField><![CDATA[id]]></referencesField>
+            <referencesTable><![CDATA[public.moves]]></referencesTable>
+            <sourceCardinality>0</sourceCardinality>
+            <destinationCardinality>0</destinationCardinality>
+            <referencesFieldUID><![CDATA[DD1EC5BC-97F2-44CF-A78A-BE8BE273AEE9]]></referencesFieldUID>
+            <referencesTableUID><![CDATA[90239C45-C70E-4CF0-8BB1-0D210754F818]]></referencesTableUID>
+            <foreignKeyName><![CDATA[move_documents_move_id_fkey]]></foreignKeyName>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[13263B6A-A601-4E38-A625-52743E5A16E3]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[document_id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <referencesField>id</referencesField>
+            <referencesTable>public.documents</referencesTable>
+            <deleteAction>1</deleteAction>
+            <updateAction>4</updateAction>
+            <referencesField><![CDATA[id]]></referencesField>
+            <referencesTable><![CDATA[public.documents]]></referencesTable>
+            <sourceCardinality>0</sourceCardinality>
+            <destinationCardinality>0</destinationCardinality>
+            <referencesFieldUID><![CDATA[3370E717-87B8-4ACC-8AFD-81FEDCD58164]]></referencesFieldUID>
+            <referencesTableUID><![CDATA[3FFFC432-1F1B-40DD-80A4-84CC20C5E1D0]]></referencesTableUID>
+            <foreignKeyName><![CDATA[move_documents_document_id_fkey]]></foreignKeyName>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[11DC6189-EA9F-49E9-B79D-AC847FA0E7A9]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[move_document_type]]></name>
+            <type><![CDATA[CHARACTER VARYING(255)]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[08BA8DBD-068D-4A58-8076-BED9D6F955EE]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[status]]></name>
+            <type><![CDATA[CHARACTER VARYING(255)]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[17EDC22F-88F4-44AA-AA9A-500665520B99]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[notes]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <uid><![CDATA[08EC9943-2AB8-43C3-8ED2-AA6BB1C0ACFC]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[created_at]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[A09A34B8-7CEC-44CD-A8F4-933A4C6847A8]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[updated_at]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[9F0542EC-062C-48E4-A362-1AB6CD4D4962]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[title]]></name>
+            <type><![CDATA[CHARACTER VARYING(255)]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[7EC8709F-E8CF-442A-8223-542E9EFA565C]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[personally_procured_move_id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <referencesField>id</referencesField>
+            <referencesTable>public.personally_procured_moves</referencesTable>
+            <deleteAction>2</deleteAction>
+            <updateAction>4</updateAction>
+            <referencesField><![CDATA[id]]></referencesField>
+            <referencesTable><![CDATA[public.personally_procured_moves]]></referencesTable>
+            <sourceCardinality>0</sourceCardinality>
+            <destinationCardinality>0</destinationCardinality>
+            <referencesFieldUID><![CDATA[F41B27F5-746D-47FB-8D2D-B92FB8558E26]]></referencesFieldUID>
+            <referencesTableUID><![CDATA[6C0B6DDE-9F19-48CE-B40D-4D59A1DA4639]]></referencesTableUID>
+            <foreignKeyName><![CDATA[move_documents_personally_procured_move_id_fkey]]></foreignKeyName>
+            <uid><![CDATA[63D58196-EFE9-49FA-916B-F6732A39D551]]></uid>
+        </SQLField>
+        <labelWindowIndex><![CDATA[29]]></labelWindowIndex>
+        <PK_KEY_NAME><![CDATA[move_documents_pkey]]></PK_KEY_NAME>
+        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
+        <uid><![CDATA[538B0BE2-2419-459F-9F73-E796668368D7]]></uid>
+    </SQLTable>
+    <SQLTable>
+        <name><![CDATA[public.issues]]></name>
+        <schema><![CDATA[public]]></schema>
+        <location>
+            <x>1929.00</x>
+            <y>10.00</y>
+        </location>
+        <size>
+            <width>317.00</width>
+            <height>140.00</height>
+        </size>
+        <zorder>30</zorder>
+        <SQLField>
+            <name><![CDATA[id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <primaryKey>1</primaryKey>
+            <notNull><![CDATA[1]]></notNull>
+            <PK_NAME><![CDATA[issues_pkey]]></PK_NAME>
+            <uid><![CDATA[F6D64A72-894E-4F95-9BB8-11884CA54FB4]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[description]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[300D0C92-9E3B-4981-9F3E-52C9C3FB8C94]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[created_at]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[B3BE77E8-CAA2-4A3C-BB4B-17F4C544661D]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[updated_at]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[30290DC6-CAA8-48D2-A6B4-1F311B6769E6]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[reporter_name]]></name>
+            <type><![CDATA[CHARACTER VARYING(255)]]></type>
+            <uid><![CDATA[5CE53280-8E6E-4328-8668-119BE711A79B]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[due_date]]></name>
+            <type><![CDATA[DATE]]></type>
+            <uid><![CDATA[8F27C96E-AA60-4F0E-9BE6-1E8F66361B86]]></uid>
+        </SQLField>
+        <labelWindowIndex><![CDATA[30]]></labelWindowIndex>
+        <PK_KEY_NAME><![CDATA[issues_pkey]]></PK_KEY_NAME>
+        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
+        <uid><![CDATA[659CC3FD-594E-47AF-9E98-171BB6F49C5B]]></uid>
+    </SQLTable>
+    <SQLTable>
+        <name><![CDATA[public.tariff400ng_shorthaul_rates]]></name>
+        <schema><![CDATA[public]]></schema>
+        <location>
+            <x>1896.00</x>
+            <y>1420.00</y>
+        </location>
+        <size>
+            <width>298.00</width>
+            <height>180.00</height>
+        </size>
+        <zorder>9</zorder>
+        <SQLField>
+            <name><![CDATA[id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <uid><![CDATA[EE139397-18BD-462E-910A-1EF58EC63ACB]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[cwt_miles_lower]]></name>
+            <type><![CDATA[INTEGER]]></type>
+            <uid><![CDATA[9FBDCEB8-C2EA-4B1B-ACA2-EC010BDA1340]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[cwt_miles_upper]]></name>
+            <type><![CDATA[INTEGER]]></type>
+            <uid><![CDATA[FB7C0F30-2207-4968-89C0-A46AD745D2AF]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[rate_cents]]></name>
+            <type><![CDATA[INTEGER]]></type>
+            <uid><![CDATA[599552F0-1BE1-4172-BBDB-F6E7966F6172]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[effective_date_lower]]></name>
+            <type><![CDATA[DATE]]></type>
+            <uid><![CDATA[E74346E0-F989-4D6E-A153-927657014C7F]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[effective_date_upper]]></name>
+            <type><![CDATA[DATE]]></type>
+            <uid><![CDATA[826A9EA6-B105-42D5-8564-4B9018CBDC08]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[created_at]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <uid><![CDATA[420335CB-54D6-4280-9CBE-1022E28DD4F5]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[updated_at]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <uid><![CDATA[4D71F8B6-083A-42B6-B7CD-81B22CD9760E]]></uid>
+        </SQLField>
+        <labelWindowIndex><![CDATA[9]]></labelWindowIndex>
+        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
+        <uid><![CDATA[6B5FAC77-36CC-4170-B164-9767DDE5E2B5]]></uid>
+    </SQLTable>
+    <SQLTable>
+        <name><![CDATA[public.personally_procured_moves]]></name>
+        <schema><![CDATA[public]]></schema>
+        <location>
+            <x>10.00</x>
+            <y>670.00</y>
+        </location>
+        <size>
+            <width>386.00</width>
+            <height>480.00</height>
+        </size>
+        <zorder>22</zorder>
+        <SQLField>
+            <name><![CDATA[id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <primaryKey>1</primaryKey>
+            <forcedUnique><![CDATA[1]]></forcedUnique>
+            <notNull><![CDATA[1]]></notNull>
+            <PK_NAME><![CDATA[personally_procured_moves_pkey]]></PK_NAME>
+            <uid><![CDATA[F41B27F5-746D-47FB-8D2D-B92FB8558E26]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[move_id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <referencesField>id</referencesField>
+            <referencesTable>public.moves</referencesTable>
+            <deleteAction>4</deleteAction>
+            <updateAction>4</updateAction>
+            <referencesField><![CDATA[id]]></referencesField>
+            <referencesTable><![CDATA[public.moves]]></referencesTable>
+            <sourceCardinality>0</sourceCardinality>
+            <destinationCardinality>0</destinationCardinality>
+            <referencesFieldUID><![CDATA[DD1EC5BC-97F2-44CF-A78A-BE8BE273AEE9]]></referencesFieldUID>
+            <referencesTableUID><![CDATA[90239C45-C70E-4CF0-8BB1-0D210754F818]]></referencesTableUID>
+            <foreignKeyName><![CDATA[personally_procured_moves_move_id_fkey]]></foreignKeyName>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[3C118CC9-D758-42E1-9371-14AD2ADFA653]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[size]]></name>
+            <type><![CDATA[CHARACTER VARYING(255)]]></type>
+            <uid><![CDATA[276E8D60-2707-427C-ACA2-2765994717E6]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[weight_estimate]]></name>
+            <type><![CDATA[INTEGER]]></type>
+            <uid><![CDATA[46BB8FDB-8E5C-47B6-98C2-B30DE3B588D0]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[created_at]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[7696C910-EE0D-49A2-A82A-B432DE98C387]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[updated_at]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[D1768F2B-96C8-479C-B679-7144EA62812B]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[planned_move_date]]></name>
+            <type><![CDATA[DATE]]></type>
+            <uid><![CDATA[7A4EF9ED-E0ED-420F-9DF8-B02F0D40372E]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[pickup_postal_code]]></name>
+            <type><![CDATA[CHARACTER VARYING(255)]]></type>
+            <uid><![CDATA[5F2701C7-08C9-4B2F-93BC-5DDA8FF655E0]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[additional_pickup_postal_code]]></name>
+            <type><![CDATA[CHARACTER VARYING(255)]]></type>
+            <uid><![CDATA[2D6963A5-F9B6-46A2-B52F-9A1DF6AE58C6]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[destination_postal_code]]></name>
+            <type><![CDATA[CHARACTER VARYING(255)]]></type>
+            <uid><![CDATA[4FDFE282-B2D8-425A-8675-D90B1B16CB6E]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[days_in_storage]]></name>
+            <type><![CDATA[INTEGER]]></type>
+            <uid><![CDATA[AE67BCBF-41D7-405A-865C-F948D74AB546]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[status]]></name>
+            <type><![CDATA[CHARACTER VARYING(255)]]></type>
+            <defaultValue><![CDATA['DRAFT'::character varying]]></defaultValue>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[A38094C4-D1EB-4F3E-BF20-0603A42B0F95]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[has_additional_postal_code]]></name>
+            <type><![CDATA[BOOLEAN]]></type>
+            <uid><![CDATA[50F6C52B-14AC-4E8F-AE2B-24389D81BF11]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[has_sit]]></name>
+            <type><![CDATA[BOOLEAN]]></type>
+            <uid><![CDATA[A1BC06D0-AB2F-42F9-B24F-F517031AD662]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[has_requested_advance]]></name>
+            <type><![CDATA[BOOLEAN]]></type>
+            <defaultValue><![CDATA[false]]></defaultValue>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[391C3C0C-DEAD-4F4C-94F3-0CDEE5EEB0A0]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[advance_id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <uid><![CDATA[CE14E5AD-00DD-4ACE-8241-3FB327480A00]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[estimated_storage_reimbursement]]></name>
+            <type><![CDATA[CHARACTER VARYING(255)]]></type>
+            <uid><![CDATA[4219BF18-7679-4F1E-BF46-5FFA300E3C07]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[mileage]]></name>
+            <type><![CDATA[INTEGER]]></type>
+            <uid><![CDATA[17D7EA5E-BBF1-4F95-8C2A-6AF6E64537FC]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[planned_sit_max]]></name>
+            <type><![CDATA[INTEGER]]></type>
+            <uid><![CDATA[C4396712-E6C7-4229-AF8D-BCAAEF527EFA]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[sit_max]]></name>
+            <type><![CDATA[INTEGER]]></type>
+            <uid><![CDATA[7AD8F716-9202-455A-899E-BDCDB313A130]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[incentive_estimate_min]]></name>
+            <type><![CDATA[INTEGER]]></type>
+            <uid><![CDATA[E713245F-30D0-4BE8-AE78-B1C202E86F1D]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[incentive_estimate_max]]></name>
+            <type><![CDATA[INTEGER]]></type>
+            <uid><![CDATA[452BD6B1-A9A8-433E-B2E5-3D9D3041610C]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[advance_worksheet_id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <referencesField>id</referencesField>
+            <referencesTable>public.documents</referencesTable>
+            <deleteAction>4</deleteAction>
+            <updateAction>4</updateAction>
+            <referencesField><![CDATA[id]]></referencesField>
+            <referencesTable><![CDATA[public.documents]]></referencesTable>
+            <sourceCardinality>0</sourceCardinality>
+            <destinationCardinality>0</destinationCardinality>
+            <referencesFieldUID><![CDATA[3370E717-87B8-4ACC-8AFD-81FEDCD58164]]></referencesFieldUID>
+            <referencesTableUID><![CDATA[3FFFC432-1F1B-40DD-80A4-84CC20C5E1D0]]></referencesTableUID>
+            <foreignKeyName><![CDATA[personally_procured_moves_documents_id_fk]]></foreignKeyName>
+            <uid><![CDATA[380791C6-9E20-4BB4-8B17-A2A92E0F0936]]></uid>
+        </SQLField>
+        <labelWindowIndex><![CDATA[22]]></labelWindowIndex>
+        <PK_KEY_NAME><![CDATA[personally_procured_moves_pkey]]></PK_KEY_NAME>
+        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
+        <uid><![CDATA[6C0B6DDE-9F19-48CE-B40D-4D59A1DA4639]]></uid>
+    </SQLTable>
+    <SQLTable>
+        <name><![CDATA[public.orders]]></name>
+        <schema><![CDATA[public]]></schema>
+        <location>
+            <x>2016.00</x>
+            <y>260.00</y>
+        </location>
+        <size>
+            <width>317.00</width>
+            <height>400.00</height>
+        </size>
+        <zorder>23</zorder>
+        <SQLField>
+            <name><![CDATA[id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <primaryKey>1</primaryKey>
+            <forcedUnique><![CDATA[1]]></forcedUnique>
+            <notNull><![CDATA[1]]></notNull>
+            <PK_NAME><![CDATA[orders_pkey]]></PK_NAME>
+            <uid><![CDATA[A6E9ED98-B0E6-4FC5-8E1B-4068015F41A4]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[service_member_id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <referencesField>id</referencesField>
+            <referencesTable>public.service_members</referencesTable>
+            <deleteAction>1</deleteAction>
+            <updateAction>4</updateAction>
+            <referencesField><![CDATA[id]]></referencesField>
+            <referencesTable><![CDATA[public.service_members]]></referencesTable>
+            <sourceCardinality>0</sourceCardinality>
+            <destinationCardinality>0</destinationCardinality>
+            <referencesFieldUID><![CDATA[461A9476-10E6-4746-A8C4-3CA6C32BDEF4]]></referencesFieldUID>
+            <referencesTableUID><![CDATA[73DE4768-12E2-40FC-95C7-A4548B8CDBB8]]></referencesTableUID>
+            <foreignKeyName><![CDATA[orders_service_member_id_fkey]]></foreignKeyName>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[0F6B2028-93DD-43E3-B2BB-D075BFF009C9]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[issue_date]]></name>
+            <type><![CDATA[DATE]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[8A7829C9-22DF-4305-AE81-1F7B04FE64FC]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[report_by_date]]></name>
+            <type><![CDATA[DATE]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[8F445EC0-F721-4A45-80D6-60EE51743222]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[orders_type]]></name>
+            <type><![CDATA[CHARACTER VARYING(255)]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[B90532B4-6BE2-4FEC-A02E-E791170A2B94]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[has_dependents]]></name>
+            <type><![CDATA[BOOLEAN]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[9D09A8F5-468B-4AB7-AC13-3A6908E1C5C8]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[new_duty_station_id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <referencesField>id</referencesField>
+            <referencesTable>public.duty_stations</referencesTable>
+            <deleteAction>1</deleteAction>
+            <updateAction>4</updateAction>
+            <referencesField><![CDATA[id]]></referencesField>
+            <referencesTable><![CDATA[public.duty_stations]]></referencesTable>
+            <sourceCardinality>0</sourceCardinality>
+            <destinationCardinality>0</destinationCardinality>
+            <referencesFieldUID><![CDATA[4958559A-061C-4DE2-A054-35E489DF3A59]]></referencesFieldUID>
+            <referencesTableUID><![CDATA[4833725A-7A93-433E-9E02-DAC861D0DFB2]]></referencesTableUID>
+            <foreignKeyName><![CDATA[orders_new_duty_station_id_fkey]]></foreignKeyName>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[05C5E7DB-E21F-46B4-A1E8-9F24EDBC58E1]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[created_at]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[18C6B06B-589B-41FC-9253-F7E4674C11FE]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[updated_at]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[9EBB4E29-B986-4996-9565-4347419E2C42]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[uploaded_orders_id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <referencesField>id</referencesField>
+            <referencesTable>public.documents</referencesTable>
+            <deleteAction>4</deleteAction>
+            <updateAction>4</updateAction>
+            <referencesField><![CDATA[id]]></referencesField>
+            <referencesTable><![CDATA[public.documents]]></referencesTable>
+            <sourceCardinality>0</sourceCardinality>
+            <destinationCardinality>0</destinationCardinality>
+            <referencesFieldUID><![CDATA[3370E717-87B8-4ACC-8AFD-81FEDCD58164]]></referencesFieldUID>
+            <referencesTableUID><![CDATA[3FFFC432-1F1B-40DD-80A4-84CC20C5E1D0]]></referencesTableUID>
+            <foreignKeyName><![CDATA[orders_documents_id_fk]]></foreignKeyName>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[CE0EF7D3-6ADB-4C3A-9F69-7027F42C802C]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[orders_number]]></name>
+            <type><![CDATA[CHARACTER VARYING(255)]]></type>
+            <uid><![CDATA[DE7D7A72-2D89-429B-8D23-E4BBC94E1EF8]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[orders_type_detail]]></name>
+            <type><![CDATA[CHARACTER VARYING(255)]]></type>
+            <uid><![CDATA[BCFF953B-017C-4618-B751-68505503AE1C]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[status]]></name>
+            <type><![CDATA[CHARACTER VARYING(255)]]></type>
+            <defaultValue><![CDATA['DRAFT'::character varying]]></defaultValue>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[70384EB1-DB6A-4612-BC8C-A51278194CB7]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[tac]]></name>
+            <type><![CDATA[CHARACTER VARYING(255)]]></type>
+            <uid><![CDATA[A588F492-2642-498C-A8C8-249D82DF3593]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[department_indicator]]></name>
+            <type><![CDATA[CHARACTER VARYING(255)]]></type>
+            <uid><![CDATA[E92A9DCA-859F-46F0-8739-3710D303D806]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[spouse_has_pro_gear]]></name>
+            <type><![CDATA[BOOLEAN]]></type>
+            <defaultValue><![CDATA[false]]></defaultValue>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[B8CB7BF6-7329-4A59-AFE0-E546A7BC9B30]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[orders_issuing_agency]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <uid><![CDATA[48ADA44B-CC94-4BB6-A9AE-EB5A79B8D62B]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[paragraph_number]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <uid><![CDATA[63306551-7F9D-4F92-91B2-7CEDBFFF247B]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[sac]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <uid><![CDATA[9B492CAA-4D07-461D-A1D5-F446106F707E]]></uid>
+        </SQLField>
+        <labelWindowIndex><![CDATA[23]]></labelWindowIndex>
+        <PK_KEY_NAME><![CDATA[orders_pkey]]></PK_KEY_NAME>
+        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
+        <uid><![CDATA[7209D1F4-B51A-4A9C-8682-26F7B653CB41]]></uid>
+    </SQLTable>
+    <SQLTable>
+        <name><![CDATA[public.service_members]]></name>
+        <schema><![CDATA[public]]></schema>
+        <location>
+            <x>1330.00</x>
+            <y>670.00</y>
+        </location>
+        <size>
+            <width>317.00</width>
+            <height>440.00</height>
+        </size>
+        <zorder>18</zorder>
+        <SQLField>
+            <name><![CDATA[id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <primaryKey>1</primaryKey>
+            <forcedUnique><![CDATA[1]]></forcedUnique>
+            <notNull><![CDATA[1]]></notNull>
+            <PK_NAME><![CDATA[service_members_pkey]]></PK_NAME>
+            <uid><![CDATA[461A9476-10E6-4746-A8C4-3CA6C32BDEF4]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[user_id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <referencesField>id</referencesField>
+            <referencesTable>public.users</referencesTable>
+            <deleteAction>4</deleteAction>
+            <updateAction>4</updateAction>
+            <referencesField><![CDATA[id]]></referencesField>
+            <referencesTable><![CDATA[public.users]]></referencesTable>
+            <sourceCardinality>0</sourceCardinality>
+            <destinationCardinality>0</destinationCardinality>
+            <referencesFieldUID><![CDATA[D4D187F7-AADA-48B8-A8C6-3CAEA7E3CC29]]></referencesFieldUID>
+            <referencesTableUID><![CDATA[4770FB7F-1D23-40FF-90EA-84AFA3AA5CB2]]></referencesTableUID>
+            <foreignKeyName><![CDATA[service_members_user_id_fkey]]></foreignKeyName>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[55AE1DF7-368C-4023-8E0E-28CBC3C3F560]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[edipi]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <uid><![CDATA[C54A8B2D-B9DD-42D2-A5F3-186637F5AF1F]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[affiliation]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <uid><![CDATA[18DFA3D7-76CA-4CBD-9AA3-751E5EC74E29]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[rank]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <uid><![CDATA[238074E7-DEF5-448B-8632-28921FB8B93B]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[first_name]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <uid><![CDATA[65D4998E-8E42-4E48-AF2B-D604CA7A5311]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[middle_name]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <uid><![CDATA[F5E844D2-1279-453D-8DA8-A2C43E4CD4D2]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[last_name]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <uid><![CDATA[553CF6E2-B04C-4294-BD90-1A1CF08BBA1D]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[suffix]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <uid><![CDATA[5E0C3BD8-971F-44E0-AA39-63127FF17384]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[telephone]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <uid><![CDATA[8B1C0053-5BFD-4FBB-9DAB-B7825078FBA8]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[secondary_telephone]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <uid><![CDATA[A1642747-A829-4A2D-8074-FAACEBA6097B]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[personal_email]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <uid><![CDATA[41B6430F-A817-4C2A-992C-52B01B325331]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[phone_is_preferred]]></name>
+            <type><![CDATA[BOOLEAN]]></type>
+            <uid><![CDATA[05A92C85-73AD-4BCF-82BA-594C63EF18D7]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[text_message_is_preferred]]></name>
+            <type><![CDATA[BOOLEAN]]></type>
+            <uid><![CDATA[89C85E07-4AE9-48FC-A179-A8CABCD14580]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[email_is_preferred]]></name>
+            <type><![CDATA[BOOLEAN]]></type>
+            <uid><![CDATA[7E79895E-50AF-40EA-B450-ABEFB6A592FD]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[residential_address_id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <referencesField>id</referencesField>
+            <referencesTable>public.addresses</referencesTable>
+            <deleteAction>4</deleteAction>
+            <updateAction>4</updateAction>
+            <referencesField><![CDATA[id]]></referencesField>
+            <referencesTable><![CDATA[public.addresses]]></referencesTable>
+            <sourceCardinality>0</sourceCardinality>
+            <destinationCardinality>0</destinationCardinality>
+            <referencesFieldUID><![CDATA[8A595576-135D-4DC5-9E9A-6F4ABF2BE75E]]></referencesFieldUID>
+            <referencesTableUID><![CDATA[EE6CFACF-C2CF-4DDA-A8C0-56742C7EA4B7]]></referencesTableUID>
+            <foreignKeyName><![CDATA[service_members_residential_address_id_fkey]]></foreignKeyName>
+            <uid><![CDATA[E125D8AC-3821-4133-AF0A-EA2008B1E0AA]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[backup_mailing_address_id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <referencesField>id</referencesField>
+            <referencesTable>public.addresses</referencesTable>
+            <deleteAction>4</deleteAction>
+            <updateAction>4</updateAction>
+            <referencesField><![CDATA[id]]></referencesField>
+            <referencesTable><![CDATA[public.addresses]]></referencesTable>
+            <sourceCardinality>0</sourceCardinality>
+            <destinationCardinality>0</destinationCardinality>
+            <referencesFieldUID><![CDATA[8A595576-135D-4DC5-9E9A-6F4ABF2BE75E]]></referencesFieldUID>
+            <referencesTableUID><![CDATA[EE6CFACF-C2CF-4DDA-A8C0-56742C7EA4B7]]></referencesTableUID>
+            <foreignKeyName><![CDATA[service_members_backup_mailing_address_id_fkey]]></foreignKeyName>
+            <uid><![CDATA[4691E179-0EDE-4D14-8AFE-14977E0F9B36]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[created_at]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[E1592342-4FB5-4DD4-B4C8-07BD536E82CF]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[updated_at]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[32658C03-5815-4EB1-8D02-F1AEFEE63CFD]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[social_security_number_id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <referencesField>id</referencesField>
+            <referencesTable>public.social_security_numbers</referencesTable>
+            <deleteAction>3</deleteAction>
+            <updateAction>4</updateAction>
+            <referencesField><![CDATA[id]]></referencesField>
+            <referencesTable><![CDATA[public.social_security_numbers]]></referencesTable>
+            <sourceCardinality>0</sourceCardinality>
+            <destinationCardinality>0</destinationCardinality>
+            <referencesFieldUID><![CDATA[DDD59E98-A0A7-4EB8-8067-7BBFCF7352AC]]></referencesFieldUID>
+            <referencesTableUID><![CDATA[FBBEF921-4A29-4E71-8933-629C23DACECC]]></referencesTableUID>
+            <foreignKeyName><![CDATA[sm_ssn_fk]]></foreignKeyName>
+            <uid><![CDATA[02F86C26-DC32-451F-A391-18A534062BC7]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[duty_station_id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <referencesField>id</referencesField>
+            <referencesTable>public.duty_stations</referencesTable>
+            <deleteAction>3</deleteAction>
+            <updateAction>4</updateAction>
+            <referencesField><![CDATA[id]]></referencesField>
+            <referencesTable><![CDATA[public.duty_stations]]></referencesTable>
+            <sourceCardinality>0</sourceCardinality>
+            <destinationCardinality>0</destinationCardinality>
+            <referencesFieldUID><![CDATA[4958559A-061C-4DE2-A054-35E489DF3A59]]></referencesFieldUID>
+            <referencesTableUID><![CDATA[4833725A-7A93-433E-9E02-DAC861D0DFB2]]></referencesTableUID>
+            <foreignKeyName><![CDATA[sm_duty_station_fk]]></foreignKeyName>
+            <uid><![CDATA[CD91AD44-AB73-4425-952B-DA57061E8C67]]></uid>
+        </SQLField>
+        <labelWindowIndex><![CDATA[18]]></labelWindowIndex>
+        <PK_KEY_NAME><![CDATA[service_members_pkey]]></PK_KEY_NAME>
+        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
+        <uid><![CDATA[73DE4768-12E2-40FC-95C7-A4548B8CDBB8]]></uid>
+    </SQLTable>
+    <SQLTable>
+        <name><![CDATA[public.transportation_service_provider_performances]]></name>
+        <schema><![CDATA[public]]></schema>
+        <location>
+            <x>1335.00</x>
+            <y>1710.00</y>
+        </location>
+        <size>
+            <width>342.00</width>
+            <height>300.00</height>
+        </size>
+        <zorder>4</zorder>
+        <SQLField>
+            <name><![CDATA[id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <primaryKey>1</primaryKey>
+            <notNull><![CDATA[1]]></notNull>
+            <PK_NAME><![CDATA[transportation_service_provider_performances_pkey]]></PK_NAME>
+            <uid><![CDATA[15BFD78B-3815-4D9C-BA18-A5830933B359]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[performance_period_start]]></name>
+            <type><![CDATA[DATE]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[9005370A-3169-43CB-AF8A-0C0F492F5A0F]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[performance_period_end]]></name>
+            <type><![CDATA[DATE]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[AAAD9584-D23A-4467-92F9-FFC6410DE2BE]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[traffic_distribution_list_id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <referencesField>id</referencesField>
+            <referencesTable>public.traffic_distribution_lists</referencesTable>
+            <deleteAction>4</deleteAction>
+            <updateAction>4</updateAction>
+            <referencesField><![CDATA[id]]></referencesField>
+            <referencesTable><![CDATA[public.traffic_distribution_lists]]></referencesTable>
+            <sourceCardinality>0</sourceCardinality>
+            <destinationCardinality>0</destinationCardinality>
+            <referencesFieldUID><![CDATA[2E5B406F-1D96-456A-93A2-B199011E1071]]></referencesFieldUID>
+            <referencesTableUID><![CDATA[47606E6D-CCE4-4973-83D0-04F2295472DB]]></referencesTableUID>
+            <foreignKeyName><![CDATA[transportation_service_provid_traffic_distribution_list_id_fkey]]></foreignKeyName>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[1890A086-F618-4977-B753-9CE9D34F7124]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[quality_band]]></name>
+            <type><![CDATA[INTEGER]]></type>
+            <uid><![CDATA[F40AD88D-704A-4A36-B656-EBD2C906EF39]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[offer_count]]></name>
+            <type><![CDATA[INTEGER]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[03224DE6-0005-4F67-8C66-DA0372B81875]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[best_value_score]]></name>
+            <type><![CDATA[DOUBLE PRECISION]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[9567F2FF-4F35-467D-976B-1AAB1AFFA075]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[transportation_service_provider_id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <referencesField>id</referencesField>
+            <referencesTable>public.transportation_service_providers</referencesTable>
+            <deleteAction>4</deleteAction>
+            <updateAction>4</updateAction>
+            <referencesField><![CDATA[id]]></referencesField>
+            <referencesTable><![CDATA[public.transportation_service_providers]]></referencesTable>
+            <sourceCardinality>0</sourceCardinality>
+            <destinationCardinality>0</destinationCardinality>
+            <referencesFieldUID><![CDATA[33B103F7-65E6-4CD2-BF2C-6A9E75620737]]></referencesFieldUID>
+            <referencesTableUID><![CDATA[03657CA9-D150-49B8-B269-48D3FC7E462E]]></referencesTableUID>
+            <foreignKeyName><![CDATA[transportation_service_provid_transportation_service_provi_fkey]]></foreignKeyName>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[9138FDE3-DC8C-4748-9143-7816F2BCCD36]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[created_at]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[6C20A459-8116-456B-BC67-D00F99EC9075]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[updated_at]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[36108D19-F416-408B-8F05-799A2EF13A14]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[rate_cycle_start]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[0AE2DD61-C8C8-4DCB-9746-DF48B87848A2]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[rate_cycle_end]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[5E64AC07-5F37-4A6A-8C24-A9928315929E]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[linehaul_rate]]></name>
+            <type><![CDATA[DOUBLE PRECISION]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[36743F4A-6CAF-487C-96FE-4FBF6C9C6240]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[sit_rate]]></name>
+            <type><![CDATA[DOUBLE PRECISION]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[3BB98349-5330-4DF5-8200-4D6E38FC16CF]]></uid>
+        </SQLField>
+        <labelWindowIndex><![CDATA[4]]></labelWindowIndex>
+        <PK_KEY_NAME><![CDATA[transportation_service_provider_performances_pkey]]></PK_KEY_NAME>
+        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
+        <uid><![CDATA[762FC6FB-C67D-4FC7-A633-BA0ED00B47A8]]></uid>
+    </SQLTable>
+    <SQLTable>
+        <name><![CDATA[public.signed_certifications]]></name>
+        <schema><![CDATA[public]]></schema>
+        <location>
+            <x>10.00</x>
+            <y>1420.00</y>
+        </location>
+        <size>
+            <width>317.00</width>
+            <height>180.00</height>
+        </size>
+        <zorder>15</zorder>
+        <SQLField>
+            <name><![CDATA[id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <primaryKey>1</primaryKey>
+            <notNull><![CDATA[1]]></notNull>
+            <PK_NAME><![CDATA[signed_certifications_pkey]]></PK_NAME>
+            <uid><![CDATA[3AA60BA5-230C-4BB7-AE35-21A78F078AD1]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[submitting_user_id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <referencesField>id</referencesField>
+            <referencesTable>public.users</referencesTable>
+            <deleteAction>4</deleteAction>
+            <updateAction>4</updateAction>
+            <referencesField><![CDATA[id]]></referencesField>
+            <referencesTable><![CDATA[public.users]]></referencesTable>
+            <sourceCardinality>0</sourceCardinality>
+            <destinationCardinality>0</destinationCardinality>
+            <referencesFieldUID><![CDATA[D4D187F7-AADA-48B8-A8C6-3CAEA7E3CC29]]></referencesFieldUID>
+            <referencesTableUID><![CDATA[4770FB7F-1D23-40FF-90EA-84AFA3AA5CB2]]></referencesTableUID>
+            <foreignKeyName><![CDATA[signed_certifications_submitting_user_id_fkey]]></foreignKeyName>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[2D087F65-BB38-41B6-84A6-FB88616C71BE]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[move_id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[E9FC0637-783E-4E5C-813A-9575B4075826]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[certification_text]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[9DE7C686-33DC-4C34-BEF5-C83334808B76]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[signature]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[370227A0-CAD9-43CB-A187-E983B158779C]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[date]]></name>
+            <type><![CDATA[DATE]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[BCFC4FAC-68AF-4BC9-AF23-128EE2CB99EB]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[created_at]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[19D80C54-7F22-4478-B436-C5E2EDC167F0]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[updated_at]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[0C03866B-1252-4A46-906E-131C560A55BC]]></uid>
+        </SQLField>
+        <labelWindowIndex><![CDATA[15]]></labelWindowIndex>
+        <PK_KEY_NAME><![CDATA[signed_certifications_pkey]]></PK_KEY_NAME>
+        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
+        <uid><![CDATA[7C0E0F27-C8B7-4171-AD67-879CE731DC61]]></uid>
+    </SQLTable>
+    <SQLTable>
+        <name><![CDATA[public.tariff400ng_service_areas]]></name>
+        <schema><![CDATA[public]]></schema>
+        <location>
+            <x>1588.00</x>
+            <y>1420.00</y>
+        </location>
+        <size>
+            <width>298.00</width>
+            <height>280.00</height>
+        </size>
+        <zorder>10</zorder>
+        <SQLField>
+            <name><![CDATA[id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <uid><![CDATA[F3D2BDB9-62FB-4322-A352-12C38D42BB1D]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[service_area]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <uid><![CDATA[50D24C8C-5BB3-4FB3-A3C6-A76049A74C61]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[name]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <uid><![CDATA[3E6B1372-AB1A-4471-B909-E063157258EB]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[services_schedule]]></name>
+            <type><![CDATA[INTEGER]]></type>
+            <uid><![CDATA[2F86CA97-AB76-4DFF-BAF5-159A0D788CAD]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[linehaul_factor]]></name>
+            <type><![CDATA[INTEGER]]></type>
+            <uid><![CDATA[9ADCC4ED-8708-46B3-BB0D-48EF82C7D21A]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[service_charge_cents]]></name>
+            <type><![CDATA[INTEGER]]></type>
+            <uid><![CDATA[994BBC47-058A-4FBA-A302-DC1E2A0E3D6F]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[effective_date_lower]]></name>
+            <type><![CDATA[DATE]]></type>
+            <uid><![CDATA[68BBB671-AF7C-4DFB-9891-BA589CC1C77F]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[effective_date_upper]]></name>
+            <type><![CDATA[DATE]]></type>
+            <uid><![CDATA[2F99FB9E-A739-4EE7-AE04-673315C49C65]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[created_at]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <uid><![CDATA[F6E2B623-8122-4560-946A-10B037558931]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[updated_at]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <uid><![CDATA[980A5294-C682-473F-BDE5-4471233352F0]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[sit_185a_rate_cents]]></name>
+            <type><![CDATA[INTEGER]]></type>
+            <uid><![CDATA[8B6C9831-79B5-4EB4-8A22-5469F29E5DD9]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[sit_185b_rate_cents]]></name>
+            <type><![CDATA[INTEGER]]></type>
+            <uid><![CDATA[2C8C0559-C607-4EFC-8202-2ABC82FE1A1A]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[sit_pd_schedule]]></name>
+            <type><![CDATA[INTEGER]]></type>
+            <uid><![CDATA[E8A761AB-1CF1-4760-A751-1C9CEE58A139]]></uid>
+        </SQLField>
+        <labelWindowIndex><![CDATA[10]]></labelWindowIndex>
+        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
+        <uid><![CDATA[83C7BB0D-AE9E-4049-8A55-F221ED587D68]]></uid>
+    </SQLTable>
+    <SQLTable>
+        <name><![CDATA[public.backup_contacts]]></name>
+        <schema><![CDATA[public]]></schema>
+        <location>
+            <x>337.00</x>
+            <y>10.00</y>
+        </location>
+        <size>
+            <width>317.00</width>
+            <height>180.00</height>
+        </size>
+        <zorder>35</zorder>
+        <SQLField>
+            <name><![CDATA[id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <primaryKey>1</primaryKey>
+            <notNull><![CDATA[1]]></notNull>
+            <PK_NAME><![CDATA[backup_contacts_pkey]]></PK_NAME>
+            <uid><![CDATA[5C08B905-4346-4139-94AC-CC25E65F1D10]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[service_member_id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[5A469A87-5FA4-48D6-955C-9D58A8254248]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[name]]></name>
+            <type><![CDATA[CHARACTER VARYING(255)]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[5E6AB3C6-0DF9-47D7-B78C-DAF547D5C254]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[email]]></name>
+            <type><![CDATA[CHARACTER VARYING(255)]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[3EB25520-C078-4E6D-8AC0-A9908D48322F]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[phone]]></name>
+            <type><![CDATA[CHARACTER VARYING(255)]]></type>
+            <uid><![CDATA[425FF947-79D6-4668-B91C-DB23626D41BF]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[permission]]></name>
+            <type><![CDATA[CHARACTER VARYING(255)]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[94A93FD0-02B9-49A7-8437-5D91C2E50D2F]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[created_at]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[DA3E159B-F26E-4D02-A97F-770D9C6E713B]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[updated_at]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[034FC7DF-8377-4563-855D-B9B5CBDDA886]]></uid>
+        </SQLField>
+        <labelWindowIndex><![CDATA[35]]></labelWindowIndex>
+        <PK_KEY_NAME><![CDATA[backup_contacts_pkey]]></PK_KEY_NAME>
+        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
+        <uid><![CDATA[864CC0B3-CD14-48D2-A96B-EF6EC8FD5CD7]]></uid>
     </SQLTable>
     <SQLTable>
         <name><![CDATA[public.moves]]></name>
@@ -2829,24 +1932,24 @@
             <forcedUnique><![CDATA[1]]></forcedUnique>
             <notNull><![CDATA[1]]></notNull>
             <PK_NAME><![CDATA[moves_pkey]]></PK_NAME>
-            <uid><![CDATA[C922530B-6397-4EC9-BC45-4225E4B7F9E0]]></uid>
+            <uid><![CDATA[DD1EC5BC-97F2-44CF-A78A-BE8BE273AEE9]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[selected_move_type]]></name>
             <type><![CDATA[CHARACTER VARYING(255)]]></type>
-            <uid><![CDATA[55F7F957-272A-4491-9EF3-F31640056493]]></uid>
+            <uid><![CDATA[B2154088-479D-4526-8DD8-7D197DEAFD99]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[created_at]]></name>
             <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
             <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[66DDB338-F059-4A5D-8730-64CBB6ADDC4C]]></uid>
+            <uid><![CDATA[0644C363-4C69-4749-84CF-DCD55858F05A]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[updated_at]]></name>
             <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
             <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[B58D81C1-42D2-4333-BC7B-8CCFB0387C4B]]></uid>
+            <uid><![CDATA[EA102EF7-EFA0-45D0-B4BD-94745BFC9654]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[orders_id]]></name>
@@ -2859,158 +1962,169 @@
             <referencesTable><![CDATA[public.orders]]></referencesTable>
             <sourceCardinality>0</sourceCardinality>
             <destinationCardinality>0</destinationCardinality>
-            <referencesFieldUID><![CDATA[01D1B709-C50F-416C-AF86-82A52C581C38]]></referencesFieldUID>
-            <referencesTableUID><![CDATA[AB1BDA4B-DD98-45A5-954A-2F43D2057701]]></referencesTableUID>
+            <referencesFieldUID><![CDATA[A6E9ED98-B0E6-4FC5-8E1B-4068015F41A4]]></referencesFieldUID>
+            <referencesTableUID><![CDATA[7209D1F4-B51A-4A9C-8682-26F7B653CB41]]></referencesTableUID>
             <foreignKeyName><![CDATA[moves_orders_id_fk]]></foreignKeyName>
             <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[9CB39032-36F9-4483-8641-CE22A3E6D115]]></uid>
+            <uid><![CDATA[7FA9F28B-AC38-45B1-8526-6A6F65A5EC4B]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[status]]></name>
             <type><![CDATA[CHARACTER VARYING(255)]]></type>
             <defaultValue><![CDATA['DRAFT'::character varying]]></defaultValue>
             <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[B0B74FC1-C394-4FA1-B78C-E85798CFEFE2]]></uid>
+            <uid><![CDATA[F3BF64D9-CD21-4A13-BF87-80973D4071C0]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[locator]]></name>
             <type><![CDATA[CHARACTER(6)]]></type>
-            <uid><![CDATA[BEEEDB7D-83BD-47EE-AE8D-CCDDE034CFCD]]></uid>
+            <uid><![CDATA[F60585D9-3923-428A-8198-0BD2BA793398]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[cancel_reason]]></name>
             <type><![CDATA[CHARACTER VARYING(255)]]></type>
-            <uid><![CDATA[3A6FC1D8-399A-4803-AE78-A78CC52CA878]]></uid>
+            <uid><![CDATA[E9E7AEBF-7B81-4066-8DC2-600188E54FEC]]></uid>
         </SQLField>
         <labelWindowIndex><![CDATA[28]]></labelWindowIndex>
         <PK_KEY_NAME><![CDATA[moves_pkey]]></PK_KEY_NAME>
         <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
-        <uid><![CDATA[E5CC2853-5488-415D-ACA3-C18092A0E3E5]]></uid>
+        <uid><![CDATA[90239C45-C70E-4CF0-8BB1-0D210754F818]]></uid>
     </SQLTable>
     <SQLTable>
-        <name><![CDATA[public.moving_expense_documents]]></name>
+        <name><![CDATA[public.office_users]]></name>
         <schema><![CDATA[public]]></schema>
         <location>
-            <x>685.00</x>
+            <x>1689.00</x>
             <y>260.00</y>
         </location>
         <size>
-            <width>340.00</width>
-            <height>160.00</height>
+            <width>317.00</width>
+            <height>220.00</height>
         </size>
-        <zorder>27</zorder>
+        <zorder>24</zorder>
         <SQLField>
             <name><![CDATA[id]]></name>
             <type><![CDATA[UUID]]></type>
             <primaryKey>1</primaryKey>
             <notNull><![CDATA[1]]></notNull>
-            <PK_NAME><![CDATA[moving_expense_documents_pkey]]></PK_NAME>
-            <uid><![CDATA[1CD9F94A-65DD-4831-90AF-5430F417550E]]></uid>
+            <PK_NAME><![CDATA[office_users_pkey]]></PK_NAME>
+            <uid><![CDATA[DC80807F-6D43-4719-80B6-AA10C52D9AA5]]></uid>
         </SQLField>
         <SQLField>
-            <name><![CDATA[move_document_id]]></name>
+            <name><![CDATA[user_id]]></name>
             <type><![CDATA[UUID]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[D94D0438-4136-4678-9800-37929F0254C8]]></uid>
+            <referencesField>id</referencesField>
+            <referencesTable>public.users</referencesTable>
+            <deleteAction>4</deleteAction>
+            <updateAction>4</updateAction>
+            <referencesField><![CDATA[id]]></referencesField>
+            <referencesTable><![CDATA[public.users]]></referencesTable>
+            <sourceCardinality>0</sourceCardinality>
+            <destinationCardinality>0</destinationCardinality>
+            <referencesFieldUID><![CDATA[D4D187F7-AADA-48B8-A8C6-3CAEA7E3CC29]]></referencesFieldUID>
+            <referencesTableUID><![CDATA[4770FB7F-1D23-40FF-90EA-84AFA3AA5CB2]]></referencesTableUID>
+            <foreignKeyName><![CDATA[office_users_user_id_fkey]]></foreignKeyName>
+            <uid><![CDATA[C853726E-418E-478B-8AC4-C4F594C0214E]]></uid>
         </SQLField>
         <SQLField>
-            <name><![CDATA[moving_expense_type]]></name>
-            <type><![CDATA[CHARACTER VARYING(255)]]></type>
+            <name><![CDATA[last_name]]></name>
+            <type><![CDATA[TEXT]]></type>
             <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[63190D9F-8546-4668-8FF4-89762C385760]]></uid>
+            <uid><![CDATA[1E42A531-3A54-401B-89A2-978E53FA8A7F]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[first_name]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[36C3A64A-8391-4F4E-8061-B218F1415A55]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[middle_initials]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <uid><![CDATA[EFD10B31-A8D5-4E71-B704-EF2E0DEF76EB]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[email]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[5DB35825-D400-4062-BF05-8ECE45C5CC23]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[telephone]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[DB034A8C-1FD5-4876-8EC3-F975377711DF]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[transportation_office_id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <referencesField>id</referencesField>
+            <referencesTable>public.transportation_offices</referencesTable>
+            <deleteAction>4</deleteAction>
+            <updateAction>4</updateAction>
+            <referencesField><![CDATA[id]]></referencesField>
+            <referencesTable><![CDATA[public.transportation_offices]]></referencesTable>
+            <sourceCardinality>0</sourceCardinality>
+            <destinationCardinality>0</destinationCardinality>
+            <referencesFieldUID><![CDATA[9705C664-CD6F-4F37-98D3-36BB4FEA25C1]]></referencesFieldUID>
+            <referencesTableUID><![CDATA[E739E7A3-15AF-4D15-8BF6-DBCF6B06361D]]></referencesTableUID>
+            <foreignKeyName><![CDATA[office_users_transportation_office_id_fkey]]></foreignKeyName>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[977F4790-CE1B-48D9-8749-E0986F4BC414]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[created_at]]></name>
             <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
             <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[EBC15792-6AD5-4FF5-AE21-5B98990B8419]]></uid>
+            <uid><![CDATA[3AE3557A-1458-407F-BFB1-66B7E500EB44]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[updated_at]]></name>
             <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
             <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[B66F4D7A-3019-4235-A740-F4F602C80DCA]]></uid>
+            <uid><![CDATA[1F8CE29E-6BA5-41CE-85AE-36716701A802]]></uid>
         </SQLField>
-        <SQLField>
-            <name><![CDATA[requested_amount_cents]]></name>
-            <type><![CDATA[INTEGER]]></type>
-            <uid><![CDATA[75770705-6E45-42E5-822E-EEF2909207B3]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[payment_method]]></name>
-            <type><![CDATA[CHARACTER VARYING]]></type>
-            <uid><![CDATA[1FE052EA-D154-47A5-BFA1-89463AF54F2E]]></uid>
-        </SQLField>
-        <labelWindowIndex><![CDATA[27]]></labelWindowIndex>
-        <PK_KEY_NAME><![CDATA[moving_expense_documents_pkey]]></PK_KEY_NAME>
+        <labelWindowIndex><![CDATA[24]]></labelWindowIndex>
+        <PK_KEY_NAME><![CDATA[office_users_pkey]]></PK_KEY_NAME>
         <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
-        <uid><![CDATA[F6657A97-1C87-469E-A7F5-D4E5EB4D2CDC]]></uid>
+        <uid><![CDATA[910B3652-90F0-4B63-8085-06DDB579E2F5]]></uid>
     </SQLTable>
     <SQLTable>
-        <name><![CDATA[public.transportation_service_provider_performances]]></name>
+        <name><![CDATA[public.shipment_offers]]></name>
         <schema><![CDATA[public]]></schema>
         <location>
-            <x>1335.00</x>
-            <y>1710.00</y>
+            <x>1657.00</x>
+            <y>670.00</y>
         </location>
         <size>
-            <width>342.00</width>
-            <height>300.00</height>
+            <width>317.00</width>
+            <height>180.00</height>
         </size>
-        <zorder>4</zorder>
+        <zorder>17</zorder>
         <SQLField>
             <name><![CDATA[id]]></name>
             <type><![CDATA[UUID]]></type>
             <primaryKey>1</primaryKey>
             <notNull><![CDATA[1]]></notNull>
-            <PK_NAME><![CDATA[transportation_service_provider_performances_pkey]]></PK_NAME>
-            <uid><![CDATA[9F8A0258-05F2-4EE5-9680-B8461F0CDC0C]]></uid>
+            <PK_NAME><![CDATA[awarded_shipments_pkey]]></PK_NAME>
+            <uid><![CDATA[893E3275-0860-4037-9CBA-DCA0501AA952]]></uid>
         </SQLField>
         <SQLField>
-            <name><![CDATA[performance_period_start]]></name>
-            <type><![CDATA[DATE]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[ECBC8384-69A4-4606-8394-C5B715600E30]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[performance_period_end]]></name>
-            <type><![CDATA[DATE]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[019B3D6D-E663-4505-A274-484432EE0AF6]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[traffic_distribution_list_id]]></name>
+            <name><![CDATA[shipment_id]]></name>
             <type><![CDATA[UUID]]></type>
             <referencesField>id</referencesField>
-            <referencesTable>public.traffic_distribution_lists</referencesTable>
+            <referencesTable>public.shipments</referencesTable>
             <deleteAction>4</deleteAction>
             <updateAction>4</updateAction>
             <referencesField><![CDATA[id]]></referencesField>
-            <referencesTable><![CDATA[public.traffic_distribution_lists]]></referencesTable>
+            <referencesTable><![CDATA[public.shipments]]></referencesTable>
             <sourceCardinality>0</sourceCardinality>
             <destinationCardinality>0</destinationCardinality>
-            <referencesFieldUID><![CDATA[9C3D964B-5687-4441-B562-A7025E3DAC94]]></referencesFieldUID>
-            <referencesTableUID><![CDATA[1986824A-2FFE-4FAF-A010-7BFEB6066A21]]></referencesTableUID>
-            <foreignKeyName><![CDATA[transportation_service_provid_traffic_distribution_list_id_fkey]]></foreignKeyName>
+            <referencesFieldUID><![CDATA[C46744A0-8995-4768-8588-28BB9C72B4C2]]></referencesFieldUID>
+            <referencesTableUID><![CDATA[D9353FF8-A58C-4533-8FE9-34BA22F260CC]]></referencesTableUID>
+            <foreignKeyName><![CDATA[awarded_shipments_shipment_id_fkey]]></foreignKeyName>
             <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[D7609BC7-556D-4C9C-A2B8-AEB67532E079]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[quality_band]]></name>
-            <type><![CDATA[INTEGER]]></type>
-            <uid><![CDATA[4A28DA74-C79A-40AC-A18B-57DC23DFC66C]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[offer_count]]></name>
-            <type><![CDATA[INTEGER]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[24FBDDCB-548F-4375-9FE0-3B127CF69410]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[best_value_score]]></name>
-            <type><![CDATA[DOUBLE PRECISION]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[2FCC4CDF-C951-4A79-8761-5A68C604C42D]]></uid>
+            <uid><![CDATA[EBFBEE8C-2F96-4BF5-B94C-296440653442]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[transportation_service_provider_id]]></name>
@@ -3023,162 +2137,1048 @@
             <referencesTable><![CDATA[public.transportation_service_providers]]></referencesTable>
             <sourceCardinality>0</sourceCardinality>
             <destinationCardinality>0</destinationCardinality>
-            <referencesFieldUID><![CDATA[B2FC2241-6268-451C-A898-2CCD98B1A7CE]]></referencesFieldUID>
-            <referencesTableUID><![CDATA[336A1743-A267-4705-9723-19495DAEC0A7]]></referencesTableUID>
-            <foreignKeyName><![CDATA[transportation_service_provid_transportation_service_provi_fkey]]></foreignKeyName>
+            <referencesFieldUID><![CDATA[33B103F7-65E6-4CD2-BF2C-6A9E75620737]]></referencesFieldUID>
+            <referencesTableUID><![CDATA[03657CA9-D150-49B8-B269-48D3FC7E462E]]></referencesTableUID>
+            <foreignKeyName><![CDATA[awarded_shipments_transportation_service_provider_id_fkey]]></foreignKeyName>
             <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[BAD664FC-11C6-4A0B-8188-C3EC169BD5BD]]></uid>
+            <uid><![CDATA[417F49F2-F9C6-4057-AA63-658315BF1B8E]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[administrative_shipment]]></name>
+            <type><![CDATA[BOOLEAN]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[88C5C97D-7344-4F8B-AA36-77F5780C4334]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[created_at]]></name>
             <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
             <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[AB3FF41E-04D7-4530-9105-19B4FDF18A59]]></uid>
+            <uid><![CDATA[409A51D9-412F-494E-9BDE-55A4DE18490D]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[updated_at]]></name>
             <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
             <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[4D2CE005-E07D-4663-9FE8-E6B98027F9FB]]></uid>
+            <uid><![CDATA[D3EBEF24-E0A7-451F-A050-313A786EA204]]></uid>
         </SQLField>
         <SQLField>
-            <name><![CDATA[rate_cycle_start]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[FDB65661-807A-47EB-8833-B07FA91CF1FE]]></uid>
+            <name><![CDATA[accepted]]></name>
+            <type><![CDATA[BOOLEAN]]></type>
+            <uid><![CDATA[8C69F9EC-3308-4915-9FAE-887A41DC9DCA]]></uid>
         </SQLField>
         <SQLField>
-            <name><![CDATA[rate_cycle_end]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[7FBBDD34-3F14-4CEA-B279-BE667FF5E0F3]]></uid>
+            <name><![CDATA[rejection_reason]]></name>
+            <type><![CDATA[CHARACTER VARYING(255)]]></type>
+            <uid><![CDATA[8B227FB3-18A4-4A4D-A889-26D493EA6944]]></uid>
         </SQLField>
-        <SQLField>
-            <name><![CDATA[linehaul_rate]]></name>
-            <type><![CDATA[DOUBLE PRECISION]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[0D711C59-C325-4AE1-8C5C-62B1903F51DE]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[sit_rate]]></name>
-            <type><![CDATA[DOUBLE PRECISION]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[10BB5034-8D44-40B3-B1E3-3356A8332DAA]]></uid>
-        </SQLField>
-        <labelWindowIndex><![CDATA[4]]></labelWindowIndex>
-        <PK_KEY_NAME><![CDATA[transportation_service_provider_performances_pkey]]></PK_KEY_NAME>
+        <labelWindowIndex><![CDATA[17]]></labelWindowIndex>
+        <PK_KEY_NAME><![CDATA[awarded_shipments_pkey]]></PK_KEY_NAME>
         <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
-        <uid><![CDATA[FB7D8DBD-CC1F-4682-8ECB-4CAE6D41750E]]></uid>
+        <uid><![CDATA[9AEBF66C-75E4-49D6-9EA1-A1EF94F42249]]></uid>
     </SQLTable>
     <SQLTable>
-        <name><![CDATA[public.move_documents]]></name>
+        <name><![CDATA[public.service_agents]]></name>
         <schema><![CDATA[public]]></schema>
         <location>
-            <x>10.00</x>
-            <y>260.00</y>
+            <x>1003.00</x>
+            <y>670.00</y>
         </location>
         <size>
-            <width>338.00</width>
-            <height>220.00</height>
+            <width>317.00</width>
+            <height>280.00</height>
         </size>
-        <zorder>29</zorder>
+        <zorder>19</zorder>
         <SQLField>
             <name><![CDATA[id]]></name>
             <type><![CDATA[UUID]]></type>
             <primaryKey>1</primaryKey>
             <notNull><![CDATA[1]]></notNull>
-            <PK_NAME><![CDATA[move_documents_pkey]]></PK_NAME>
-            <uid><![CDATA[EE9B9F3B-C47B-4ABE-9971-E9612273BFC3]]></uid>
+            <PK_NAME><![CDATA[service_agents_pkey]]></PK_NAME>
+            <uid><![CDATA[9C70E0C8-E2B0-4672-81A2-EE79E69A7E82]]></uid>
         </SQLField>
         <SQLField>
-            <name><![CDATA[move_id]]></name>
+            <name><![CDATA[shipment_id]]></name>
             <type><![CDATA[UUID]]></type>
             <referencesField>id</referencesField>
-            <referencesTable>public.moves</referencesTable>
-            <deleteAction>2</deleteAction>
+            <referencesTable>public.shipments</referencesTable>
+            <deleteAction>4</deleteAction>
             <updateAction>4</updateAction>
             <referencesField><![CDATA[id]]></referencesField>
-            <referencesTable><![CDATA[public.moves]]></referencesTable>
+            <referencesTable><![CDATA[public.shipments]]></referencesTable>
             <sourceCardinality>0</sourceCardinality>
             <destinationCardinality>0</destinationCardinality>
-            <referencesFieldUID><![CDATA[C922530B-6397-4EC9-BC45-4225E4B7F9E0]]></referencesFieldUID>
-            <referencesTableUID><![CDATA[E5CC2853-5488-415D-ACA3-C18092A0E3E5]]></referencesTableUID>
-            <foreignKeyName><![CDATA[move_documents_move_id_fkey]]></foreignKeyName>
+            <referencesFieldUID><![CDATA[C46744A0-8995-4768-8588-28BB9C72B4C2]]></referencesFieldUID>
+            <referencesTableUID><![CDATA[D9353FF8-A58C-4533-8FE9-34BA22F260CC]]></referencesTableUID>
+            <foreignKeyName><![CDATA[service_agents_shipment_id_fkey]]></foreignKeyName>
             <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[25CB2FB9-0C97-4B0A-832D-06247107CD6E]]></uid>
+            <uid><![CDATA[9FE318B4-F4C6-4900-9528-C87EEB03EA1B]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[role]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[094CBDE3-C9AF-4470-AF9C-F49AD4D052E6]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[point_of_contact]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <uid><![CDATA[DF942361-C637-402E-A3B4-9AE276CB0A92]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[email]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <uid><![CDATA[45838DEC-385A-4B4D-94B2-EEC184BAE6EE]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[phone_number]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <uid><![CDATA[4384FEE3-2A38-4286-89F1-387B5C64B8B1]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[fax_number]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <uid><![CDATA[15AFF24A-5498-4A2E-8315-7486E25E2F7E]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[email_is_preferred]]></name>
+            <type><![CDATA[BOOLEAN]]></type>
+            <uid><![CDATA[80BF8FEF-EBD2-43E7-9AF9-6EE1850E4AAE]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[phone_is_preferred]]></name>
+            <type><![CDATA[BOOLEAN]]></type>
+            <uid><![CDATA[811B064E-D389-4583-B704-505252635C68]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[notes]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <uid><![CDATA[5D04BA65-586F-4975-B950-39F35CAC84CC]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[created_at]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[8035C543-D114-4AA9-83B7-3050BEB84722]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[updated_at]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[D6717DB2-D7FD-4722-B491-28197F8506DE]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[company]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[62BC5711-04D7-44D9-B677-F24D7F9EF23F]]></uid>
+        </SQLField>
+        <labelWindowIndex><![CDATA[19]]></labelWindowIndex>
+        <PK_KEY_NAME><![CDATA[service_agents_pkey]]></PK_KEY_NAME>
+        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
+        <uid><![CDATA[A135FA81-C816-4233-808B-CCE7E4CBDC31]]></uid>
+    </SQLTable>
+    <SQLTable>
+        <name><![CDATA[public.tariff400ng_full_pack_rates]]></name>
+        <schema><![CDATA[public]]></schema>
+        <location>
+            <x>664.00</x>
+            <y>1420.00</y>
+        </location>
+        <size>
+            <width>298.00</width>
+            <height>200.00</height>
+        </size>
+        <zorder>13</zorder>
+        <SQLField>
+            <name><![CDATA[id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <uid><![CDATA[13CECE4F-1C17-4829-B1A4-DF6FD16C49EE]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[schedule]]></name>
+            <type><![CDATA[INTEGER]]></type>
+            <uid><![CDATA[85246963-543A-4491-BA0F-B60BFEB0279B]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[weight_lbs_lower]]></name>
+            <type><![CDATA[INTEGER]]></type>
+            <uid><![CDATA[3C749676-704D-4447-ACCF-5BB4C1DE3E92]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[weight_lbs_upper]]></name>
+            <type><![CDATA[INTEGER]]></type>
+            <uid><![CDATA[5D96F9E7-5E6D-4C6F-A15C-9DCD3A65D8C0]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[rate_cents]]></name>
+            <type><![CDATA[INTEGER]]></type>
+            <uid><![CDATA[6E3D972E-D304-478F-AAA6-EEE8C870E277]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[effective_date_lower]]></name>
+            <type><![CDATA[DATE]]></type>
+            <uid><![CDATA[BC9C1B48-7CA9-466E-B0FB-87857359A868]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[effective_date_upper]]></name>
+            <type><![CDATA[DATE]]></type>
+            <uid><![CDATA[04CF2C53-583C-4C30-BE6A-170C7370084C]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[created_at]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <uid><![CDATA[B09C439F-D116-4766-BD96-699BE7657587]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[updated_at]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <uid><![CDATA[39DD66A4-8CA3-4366-87FD-02BAE0A2477B]]></uid>
+        </SQLField>
+        <labelWindowIndex><![CDATA[13]]></labelWindowIndex>
+        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
+        <uid><![CDATA[A513E635-940F-4275-AC6C-9BC8E1462940]]></uid>
+    </SQLTable>
+    <SQLTable>
+        <name><![CDATA[public.tariff400ng_zip5_rate_areas]]></name>
+        <schema><![CDATA[public]]></schema>
+        <location>
+            <x>318.00</x>
+            <y>1710.00</y>
+        </location>
+        <size>
+            <width>298.00</width>
+            <height>120.00</height>
+        </size>
+        <zorder>7</zorder>
+        <SQLField>
+            <name><![CDATA[id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <uid><![CDATA[C4F6321C-675D-4018-B4F5-787FFFC29171]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[zip5]]></name>
+            <type><![CDATA[CHARACTER VARYING(5)]]></type>
+            <uid><![CDATA[096D8640-63D5-4519-BA51-A8D5B03366C3]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[rate_area]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <uid><![CDATA[8049FB1E-C5D3-4995-AAA1-63F453D4E83E]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[created_at]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <uid><![CDATA[0E480595-E323-42E9-A975-BA6D98D49345]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[updated_at]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <uid><![CDATA[4C407DA0-13D2-4A79-B483-428E7A1B5DAD]]></uid>
+        </SQLField>
+        <labelWindowIndex><![CDATA[7]]></labelWindowIndex>
+        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
+        <uid><![CDATA[B676A2FB-B509-4583-8EBC-520B8050B432]]></uid>
+    </SQLTable>
+    <SQLTable>
+        <name><![CDATA[public.schema_migration]]></name>
+        <schema><![CDATA[public]]></schema>
+        <location>
+            <x>735.00</x>
+            <y>670.00</y>
+        </location>
+        <size>
+            <width>258.00</width>
+            <height>40.00</height>
+        </size>
+        <zorder>20</zorder>
+        <SQLField>
+            <name><![CDATA[version]]></name>
+            <type><![CDATA[CHARACTER VARYING(255)]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[ED0A7A44-EAE4-49E2-A175-6B2FCC51B779]]></uid>
+        </SQLField>
+        <labelWindowIndex><![CDATA[20]]></labelWindowIndex>
+        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
+        <uid><![CDATA[BD43D5D8-07A5-464D-8115-07CAB1ABD593]]></uid>
+    </SQLTable>
+    <SQLTable>
+        <name><![CDATA[public.uploads]]></name>
+        <schema><![CDATA[public]]></schema>
+        <location>
+            <x>10.00</x>
+            <y>2020.00</y>
+        </location>
+        <size>
+            <width>317.00</width>
+            <height>220.00</height>
+        </size>
+        <zorder>1</zorder>
+        <SQLField>
+            <name><![CDATA[id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <primaryKey>1</primaryKey>
+            <notNull><![CDATA[1]]></notNull>
+            <PK_NAME><![CDATA[uploads_pkey]]></PK_NAME>
+            <uid><![CDATA[E347E54D-0C7A-4080-BC07-49FE8EC391DC]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[document_id]]></name>
             <type><![CDATA[UUID]]></type>
             <referencesField>id</referencesField>
             <referencesTable>public.documents</referencesTable>
-            <deleteAction>1</deleteAction>
+            <deleteAction>4</deleteAction>
             <updateAction>4</updateAction>
             <referencesField><![CDATA[id]]></referencesField>
             <referencesTable><![CDATA[public.documents]]></referencesTable>
             <sourceCardinality>0</sourceCardinality>
             <destinationCardinality>0</destinationCardinality>
-            <referencesFieldUID><![CDATA[DB1CEAC4-39C1-4ED6-941D-DA5F6464C239]]></referencesFieldUID>
-            <referencesTableUID><![CDATA[DB441E2F-FED4-4952-AF6B-16954AD95900]]></referencesTableUID>
-            <foreignKeyName><![CDATA[move_documents_document_id_fkey]]></foreignKeyName>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[4F9FD7D8-D806-4592-9E48-E2E93209B5FC]]></uid>
+            <referencesFieldUID><![CDATA[3370E717-87B8-4ACC-8AFD-81FEDCD58164]]></referencesFieldUID>
+            <referencesTableUID><![CDATA[3FFFC432-1F1B-40DD-80A4-84CC20C5E1D0]]></referencesTableUID>
+            <foreignKeyName><![CDATA[uploads_document_id_fkey]]></foreignKeyName>
+            <uid><![CDATA[4823C4DA-0799-4E91-B0C3-9D9DCE74F1BE]]></uid>
         </SQLField>
         <SQLField>
-            <name><![CDATA[move_document_type]]></name>
-            <type><![CDATA[CHARACTER VARYING(255)]]></type>
+            <name><![CDATA[uploader_id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <referencesField>id</referencesField>
+            <referencesTable>public.users</referencesTable>
+            <deleteAction>4</deleteAction>
+            <updateAction>4</updateAction>
+            <referencesField><![CDATA[id]]></referencesField>
+            <referencesTable><![CDATA[public.users]]></referencesTable>
+            <sourceCardinality>0</sourceCardinality>
+            <destinationCardinality>0</destinationCardinality>
+            <referencesFieldUID><![CDATA[D4D187F7-AADA-48B8-A8C6-3CAEA7E3CC29]]></referencesFieldUID>
+            <referencesTableUID><![CDATA[4770FB7F-1D23-40FF-90EA-84AFA3AA5CB2]]></referencesTableUID>
+            <foreignKeyName><![CDATA[uploads_uploader_id_fkey]]></foreignKeyName>
             <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[262EEB88-3458-4AD0-A563-7EFE9EFFD068]]></uid>
+            <uid><![CDATA[20650A42-4798-480D-B91C-92794D229947]]></uid>
         </SQLField>
         <SQLField>
-            <name><![CDATA[status]]></name>
-            <type><![CDATA[CHARACTER VARYING(255)]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[8C14C902-B6CA-4C6B-84DC-87858258765F]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[notes]]></name>
+            <name><![CDATA[filename]]></name>
             <type><![CDATA[TEXT]]></type>
-            <uid><![CDATA[E57BD446-604B-4A65-B47A-C30527EE9FEC]]></uid>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[A396EB8D-E4F5-4294-AAC5-748023E2A51E]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[bytes]]></name>
+            <type><![CDATA[BIGINT]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[E83A6976-5A6A-4270-ACFC-6414EC09DF0D]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[content_type]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[0E4CFE30-8C9A-417C-B512-3B7CF5FF0074]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[checksum]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[CC7318BC-12D9-4636-AA55-BD3D0A2532B7]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[created_at]]></name>
             <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
             <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[F714DA3C-CB79-46B6-976D-9B79FA5BC7B6]]></uid>
+            <uid><![CDATA[EE5FEF0C-AFC4-41F3-9951-4635983F1DA6]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[updated_at]]></name>
             <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
             <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[4761F041-80AF-4C76-A1BB-B6C7BA85C35E]]></uid>
+            <uid><![CDATA[D50AE68C-AD9A-4905-92F3-399EA595B5BB]]></uid>
         </SQLField>
         <SQLField>
-            <name><![CDATA[title]]></name>
-            <type><![CDATA[CHARACTER VARYING(255)]]></type>
+            <name><![CDATA[storage_key]]></name>
+            <type><![CDATA[CHARACTER VARYING(1024)]]></type>
+            <uid><![CDATA[712D63BC-A24A-4044-9435-F755B02F631D]]></uid>
+        </SQLField>
+        <labelWindowIndex><![CDATA[1]]></labelWindowIndex>
+        <PK_KEY_NAME><![CDATA[uploads_pkey]]></PK_KEY_NAME>
+        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
+        <uid><![CDATA[C7F3C5C1-A2F1-4C56-BB81-E963000DB6B3]]></uid>
+    </SQLTable>
+    <SQLTable>
+        <name><![CDATA[public.shipments]]></name>
+        <schema><![CDATA[public]]></schema>
+        <location>
+            <x>1984.00</x>
+            <y>670.00</y>
+        </location>
+        <size>
+            <width>424.00</width>
+            <height>740.00</height>
+        </size>
+        <zorder>16</zorder>
+        <SQLField>
+            <name><![CDATA[id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <primaryKey>1</primaryKey>
+            <forcedUnique><![CDATA[1]]></forcedUnique>
             <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[C8E61B26-E4D6-49F2-8234-28D7C68B96C5]]></uid>
+            <PK_NAME><![CDATA[shipments_pkey]]></PK_NAME>
+            <uid><![CDATA[C46744A0-8995-4768-8588-28BB9C72B4C2]]></uid>
         </SQLField>
         <SQLField>
-            <name><![CDATA[personally_procured_move_id]]></name>
+            <name><![CDATA[traffic_distribution_list_id]]></name>
             <type><![CDATA[UUID]]></type>
             <referencesField>id</referencesField>
-            <referencesTable>public.personally_procured_moves</referencesTable>
-            <deleteAction>2</deleteAction>
+            <referencesTable>public.traffic_distribution_lists</referencesTable>
+            <deleteAction>4</deleteAction>
             <updateAction>4</updateAction>
             <referencesField><![CDATA[id]]></referencesField>
-            <referencesTable><![CDATA[public.personally_procured_moves]]></referencesTable>
+            <referencesTable><![CDATA[public.traffic_distribution_lists]]></referencesTable>
             <sourceCardinality>0</sourceCardinality>
             <destinationCardinality>0</destinationCardinality>
-            <referencesFieldUID><![CDATA[6532847F-1005-4BCB-BB4B-716FAF280CE8]]></referencesFieldUID>
-            <referencesTableUID><![CDATA[0D98D8B2-0787-4014-ADA5-F0880771C07E]]></referencesTableUID>
-            <foreignKeyName><![CDATA[move_documents_personally_procured_move_id_fkey]]></foreignKeyName>
-            <uid><![CDATA[48E0202E-51FE-4CA7-BAB6-D18F8E00F38A]]></uid>
+            <referencesFieldUID><![CDATA[2E5B406F-1D96-456A-93A2-B199011E1071]]></referencesFieldUID>
+            <referencesTableUID><![CDATA[47606E6D-CCE4-4973-83D0-04F2295472DB]]></referencesTableUID>
+            <foreignKeyName><![CDATA[shipments_traffic_distribution_list_id_fkey]]></foreignKeyName>
+            <uid><![CDATA[1073E0E1-2E82-4647-A122-C0F5C9FFED32]]></uid>
         </SQLField>
-        <labelWindowIndex><![CDATA[29]]></labelWindowIndex>
-        <PK_KEY_NAME><![CDATA[move_documents_pkey]]></PK_KEY_NAME>
+        <SQLField>
+            <name><![CDATA[actual_pickup_date]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <uid><![CDATA[9442E833-EFEC-45C6-AB70-58C3ED547BD1]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[delivery_date]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <uid><![CDATA[F52A9A81-361E-4A06-A655-285A3EAB5172]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[created_at]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[690800CF-207C-40A9-B2EC-EBA93EE5603F]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[updated_at]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[28EAB93D-A04F-4FA2-B33D-C89967F37DD0]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[source_gbloc]]></name>
+            <type><![CDATA[CHARACTER VARYING(255)]]></type>
+            <uid><![CDATA[B38F71A3-D5CB-4EF2-BB0C-4ED65F09CC99]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[market]]></name>
+            <type><![CDATA[CHARACTER VARYING(255)]]></type>
+            <uid><![CDATA[19AC8FFC-0FEC-48F3-99BC-194F023D2040]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[book_date]]></name>
+            <type><![CDATA[DATE]]></type>
+            <uid><![CDATA[EDE9D823-9451-4898-B671-7A575BC5F268]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[requested_pickup_date]]></name>
+            <type><![CDATA[DATE]]></type>
+            <uid><![CDATA[9EB4576D-8A7B-4EEE-B57D-C52796F13A59]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[move_id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[62430DCA-E237-488E-A6B8-201B342511AE]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[status]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <defaultValue><![CDATA['DRAFT'::text]]></defaultValue>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[7DDC0278-519C-4FC6-A895-7622370014C6]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[estimated_pack_days]]></name>
+            <type><![CDATA[INTEGER]]></type>
+            <uid><![CDATA[E24F2B12-4A3F-4AD3-8911-ECD49B111823]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[estimated_transit_days]]></name>
+            <type><![CDATA[INTEGER]]></type>
+            <uid><![CDATA[2BA7952E-0658-4787-B991-5B9B52455633]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[pickup_address_id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <referencesField>id</referencesField>
+            <referencesTable>public.addresses</referencesTable>
+            <deleteAction>4</deleteAction>
+            <updateAction>4</updateAction>
+            <referencesField><![CDATA[id]]></referencesField>
+            <referencesTable><![CDATA[public.addresses]]></referencesTable>
+            <sourceCardinality>0</sourceCardinality>
+            <destinationCardinality>0</destinationCardinality>
+            <referencesFieldUID><![CDATA[8A595576-135D-4DC5-9E9A-6F4ABF2BE75E]]></referencesFieldUID>
+            <referencesTableUID><![CDATA[EE6CFACF-C2CF-4DDA-A8C0-56742C7EA4B7]]></referencesTableUID>
+            <foreignKeyName><![CDATA[shipments_address_id_fk]]></foreignKeyName>
+            <uid><![CDATA[2AA42038-85B8-4263-BB60-35EE32858D85]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[has_secondary_pickup_address]]></name>
+            <type><![CDATA[BOOLEAN]]></type>
+            <defaultValue><![CDATA[false]]></defaultValue>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[AAB42976-51A8-4433-A98C-59A82287A46E]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[secondary_pickup_address_id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <referencesField>id</referencesField>
+            <referencesTable>public.addresses</referencesTable>
+            <deleteAction>4</deleteAction>
+            <updateAction>4</updateAction>
+            <referencesField><![CDATA[id]]></referencesField>
+            <referencesTable><![CDATA[public.addresses]]></referencesTable>
+            <sourceCardinality>0</sourceCardinality>
+            <destinationCardinality>0</destinationCardinality>
+            <referencesFieldUID><![CDATA[8A595576-135D-4DC5-9E9A-6F4ABF2BE75E]]></referencesFieldUID>
+            <referencesTableUID><![CDATA[EE6CFACF-C2CF-4DDA-A8C0-56742C7EA4B7]]></referencesTableUID>
+            <foreignKeyName><![CDATA[shipments_secondary_address_id_fk]]></foreignKeyName>
+            <uid><![CDATA[FBC5307F-A5C7-44AC-BC7D-3EF2518A8BC2]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[has_delivery_address]]></name>
+            <type><![CDATA[BOOLEAN]]></type>
+            <defaultValue><![CDATA[false]]></defaultValue>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[697093B1-6279-4ECD-9878-0883D7DF9C73]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[delivery_address_id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <referencesField>id</referencesField>
+            <referencesTable>public.addresses</referencesTable>
+            <deleteAction>4</deleteAction>
+            <updateAction>4</updateAction>
+            <referencesField><![CDATA[id]]></referencesField>
+            <referencesTable><![CDATA[public.addresses]]></referencesTable>
+            <sourceCardinality>0</sourceCardinality>
+            <destinationCardinality>0</destinationCardinality>
+            <referencesFieldUID><![CDATA[8A595576-135D-4DC5-9E9A-6F4ABF2BE75E]]></referencesFieldUID>
+            <referencesTableUID><![CDATA[EE6CFACF-C2CF-4DDA-A8C0-56742C7EA4B7]]></referencesTableUID>
+            <foreignKeyName><![CDATA[delivery_address_id_fk]]></foreignKeyName>
+            <uid><![CDATA[6326D353-593F-462C-8216-79DEAE817D79]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[has_partial_sit_delivery_address]]></name>
+            <type><![CDATA[BOOLEAN]]></type>
+            <defaultValue><![CDATA[false]]></defaultValue>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[7ABCB58A-E01F-4F39-B1E7-25080793577A]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[partial_sit_delivery_address_id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <referencesField>id</referencesField>
+            <referencesTable>public.addresses</referencesTable>
+            <deleteAction>4</deleteAction>
+            <updateAction>4</updateAction>
+            <referencesField><![CDATA[id]]></referencesField>
+            <referencesTable><![CDATA[public.addresses]]></referencesTable>
+            <sourceCardinality>0</sourceCardinality>
+            <destinationCardinality>0</destinationCardinality>
+            <referencesFieldUID><![CDATA[8A595576-135D-4DC5-9E9A-6F4ABF2BE75E]]></referencesFieldUID>
+            <referencesTableUID><![CDATA[EE6CFACF-C2CF-4DDA-A8C0-56742C7EA4B7]]></referencesTableUID>
+            <foreignKeyName><![CDATA[partial_sit_delivery_address_id_fk]]></foreignKeyName>
+            <uid><![CDATA[848C2AA7-BA6E-46B5-8442-815307DC41ED]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[weight_estimate]]></name>
+            <type><![CDATA[INTEGER]]></type>
+            <uid><![CDATA[25E79140-4A2D-40CF-9BD4-DB370C697474]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[progear_weight_estimate]]></name>
+            <type><![CDATA[INTEGER]]></type>
+            <uid><![CDATA[E6ADECB2-8A7A-43DE-A96B-9AFD5470C79C]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[spouse_progear_weight_estimate]]></name>
+            <type><![CDATA[INTEGER]]></type>
+            <uid><![CDATA[4483ABCC-3D63-41C7-BDA6-95EE6B7C89C7]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[destination_gbloc]]></name>
+            <type><![CDATA[CHARACTER VARYING(255)]]></type>
+            <uid><![CDATA[2A540D0D-4581-4423-AEDE-E7A9DA47A358]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[service_member_id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <referencesField>id</referencesField>
+            <referencesTable>public.service_members</referencesTable>
+            <deleteAction>4</deleteAction>
+            <updateAction>4</updateAction>
+            <referencesField><![CDATA[id]]></referencesField>
+            <referencesTable><![CDATA[public.service_members]]></referencesTable>
+            <sourceCardinality>0</sourceCardinality>
+            <destinationCardinality>0</destinationCardinality>
+            <referencesFieldUID><![CDATA[461A9476-10E6-4746-A8C4-3CA6C32BDEF4]]></referencesFieldUID>
+            <referencesTableUID><![CDATA[73DE4768-12E2-40FC-95C7-A4548B8CDBB8]]></referencesTableUID>
+            <foreignKeyName><![CDATA[shipments_service_member_id_fk]]></foreignKeyName>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[7A2AA269-6A2E-44A7-9F77-40AD8AAFBE9F]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[pm_survey_planned_pack_date]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <uid><![CDATA[D5E5C0F2-34C5-4182-88C2-C48CCDC9D64A]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[pm_survey_planned_pickup_date]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <uid><![CDATA[D4F1A736-7FEB-4369-B3E4-29DD1629B5D8]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[pm_survey_planned_delivery_date]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <uid><![CDATA[A1B60997-A32F-4164-93D7-8C11C1BA7E59]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[pm_survey_weight_estimate]]></name>
+            <type><![CDATA[INTEGER]]></type>
+            <uid><![CDATA[9DF08818-93F4-40F1-9861-64A2485A0865]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[pm_survey_progear_weight_estimate]]></name>
+            <type><![CDATA[INTEGER]]></type>
+            <uid><![CDATA[BD480ACD-5496-4AEE-9124-670CFF0AF39B]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[pm_survey_spouse_progear_weight_estimate]]></name>
+            <type><![CDATA[INTEGER]]></type>
+            <uid><![CDATA[89A58FA1-9F47-4F67-8078-429AA858A4CF]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[pm_survey_notes]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <uid><![CDATA[FE0BD8C0-0B0A-4821-8323-C32C225125E8]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[pm_survey_method]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[8F1AA41D-95CD-4123-A7B6-4BD619617F3F]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[actual_weight]]></name>
+            <type><![CDATA[INTEGER]]></type>
+            <uid><![CDATA[01D2221A-E691-40D4-B7F4-75FCCAF84960]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[gbl_number]]></name>
+            <type><![CDATA[CHARACTER VARYING(255)]]></type>
+            <uid><![CDATA[7DEA9762-7E83-44B4-B790-B0EED2EBBD7A]]></uid>
+        </SQLField>
+        <labelWindowIndex><![CDATA[16]]></labelWindowIndex>
+        <PK_KEY_NAME><![CDATA[shipments_pkey]]></PK_KEY_NAME>
         <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
-        <uid><![CDATA[FE4D1DA2-829D-453A-BB9A-570FCF3012DE]]></uid>
+        <uid><![CDATA[D9353FF8-A58C-4533-8FE9-34BA22F260CC]]></uid>
+    </SQLTable>
+    <SQLTable>
+        <name><![CDATA[public.transportation_offices]]></name>
+        <schema><![CDATA[public]]></schema>
+        <location>
+            <x>1008.00</x>
+            <y>1710.00</y>
+        </location>
+        <size>
+            <width>317.00</width>
+            <height>260.00</height>
+        </size>
+        <zorder>5</zorder>
+        <SQLField>
+            <name><![CDATA[id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <primaryKey>1</primaryKey>
+            <forcedUnique><![CDATA[1]]></forcedUnique>
+            <notNull><![CDATA[1]]></notNull>
+            <PK_NAME><![CDATA[transportation_offices_pkey]]></PK_NAME>
+            <uid><![CDATA[9705C664-CD6F-4F37-98D3-36BB4FEA25C1]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[shipping_office_id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <referencesField>id</referencesField>
+            <referencesTable>public.transportation_offices</referencesTable>
+            <deleteAction>4</deleteAction>
+            <updateAction>4</updateAction>
+            <referencesField><![CDATA[id]]></referencesField>
+            <referencesTable><![CDATA[public.transportation_offices]]></referencesTable>
+            <sourceCardinality>0</sourceCardinality>
+            <destinationCardinality>0</destinationCardinality>
+            <referencesFieldUID><![CDATA[9705C664-CD6F-4F37-98D3-36BB4FEA25C1]]></referencesFieldUID>
+            <referencesTableUID><![CDATA[E739E7A3-15AF-4D15-8BF6-DBCF6B06361D]]></referencesTableUID>
+            <foreignKeyName><![CDATA[transportation_offices_shipping_office_id_fkey]]></foreignKeyName>
+            <uid><![CDATA[746321E1-E9F2-48AD-BFE8-F360B8B83AE4]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[name]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[A2390626-D8BE-49DB-9E1B-7C5EBE54DDE8]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[address_id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <referencesField>id</referencesField>
+            <referencesTable>public.addresses</referencesTable>
+            <deleteAction>4</deleteAction>
+            <updateAction>4</updateAction>
+            <referencesField><![CDATA[id]]></referencesField>
+            <referencesTable><![CDATA[public.addresses]]></referencesTable>
+            <sourceCardinality>0</sourceCardinality>
+            <destinationCardinality>0</destinationCardinality>
+            <referencesFieldUID><![CDATA[8A595576-135D-4DC5-9E9A-6F4ABF2BE75E]]></referencesFieldUID>
+            <referencesTableUID><![CDATA[EE6CFACF-C2CF-4DDA-A8C0-56742C7EA4B7]]></referencesTableUID>
+            <foreignKeyName><![CDATA[transportation_offices_address_id_fkey]]></foreignKeyName>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[F27CA58C-6A12-4E78-BDC3-F9C34B179A97]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[latitude]]></name>
+            <type><![CDATA[REAL]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[3D0A9C23-1794-43A0-BD75-474480B36EC8]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[longitude]]></name>
+            <type><![CDATA[REAL]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[681289D6-6DE2-4DAE-86EC-ECD96BE3B55D]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[hours]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <uid><![CDATA[4500D336-36A7-4B02-8B08-AF5F4ED54B6B]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[services]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <uid><![CDATA[D93F3983-ABB5-4A08-AF0F-FC95D7433B18]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[note]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <uid><![CDATA[B562FF09-84D0-49EB-A88A-016283AB0BCE]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[created_at]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[0BF6032A-DDC1-4E87-8A66-6DE3487AA731]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[updated_at]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[EF3F7CC4-70A8-4ABF-B4AF-E59996239696]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[gbloc]]></name>
+            <type><![CDATA[CHARACTER VARYING(255)]]></type>
+            <defaultValue><![CDATA['XXXX'::character varying]]></defaultValue>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[3F27180C-1C6A-43FA-9A1C-5D6B6FA27334]]></uid>
+        </SQLField>
+        <labelWindowIndex><![CDATA[5]]></labelWindowIndex>
+        <PK_KEY_NAME><![CDATA[transportation_offices_pkey]]></PK_KEY_NAME>
+        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
+        <uid><![CDATA[E739E7A3-15AF-4D15-8BF6-DBCF6B06361D]]></uid>
+    </SQLTable>
+    <SQLTable>
+        <name><![CDATA[public.addresses]]></name>
+        <schema><![CDATA[public]]></schema>
+        <location>
+            <x>10.00</x>
+            <y>10.00</y>
+        </location>
+        <size>
+            <width>317.00</width>
+            <height>220.00</height>
+        </size>
+        <zorder>36</zorder>
+        <SQLField>
+            <name><![CDATA[id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <primaryKey>1</primaryKey>
+            <forcedUnique><![CDATA[1]]></forcedUnique>
+            <notNull><![CDATA[1]]></notNull>
+            <PK_NAME><![CDATA[addresses_pkey]]></PK_NAME>
+            <uid><![CDATA[8A595576-135D-4DC5-9E9A-6F4ABF2BE75E]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[street_address_1]]></name>
+            <type><![CDATA[CHARACTER VARYING(255)]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[83C5D330-48E9-4EFE-B862-826E8D3470F2]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[street_address_2]]></name>
+            <type><![CDATA[CHARACTER VARYING(255)]]></type>
+            <uid><![CDATA[7E6B9BBF-E101-4C29-942A-760C0B7A70CF]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[city]]></name>
+            <type><![CDATA[CHARACTER VARYING(255)]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[901DE732-9489-43AA-942D-86F3B768869C]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[state]]></name>
+            <type><![CDATA[CHARACTER VARYING(255)]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[5A2F2134-B06F-452A-9CA6-E4D7652D1FED]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[postal_code]]></name>
+            <type><![CDATA[CHARACTER VARYING(255)]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[DF8B248E-6A0F-413D-9C10-C3F9CF5A6876]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[created_at]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[5F800ECF-47AC-4E9B-B0AE-CC9E58CFB3D2]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[updated_at]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[535D9AB1-353C-43BC-9413-2AAF9F6026FE]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[street_address_3]]></name>
+            <type><![CDATA[CHARACTER VARYING(255)]]></type>
+            <uid><![CDATA[0D657E80-9E35-454B-9D56-B57DFEB034C0]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[country]]></name>
+            <type><![CDATA[CHARACTER VARYING(255)]]></type>
+            <defaultValue><![CDATA['United States'::character varying]]></defaultValue>
+            <uid><![CDATA[3A3FC99B-31F2-4828-BB2F-AB485E5265D1]]></uid>
+        </SQLField>
+        <labelWindowIndex><![CDATA[36]]></labelWindowIndex>
+        <PK_KEY_NAME><![CDATA[addresses_pkey]]></PK_KEY_NAME>
+        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
+        <uid><![CDATA[EE6CFACF-C2CF-4DDA-A8C0-56742C7EA4B7]]></uid>
+    </SQLTable>
+    <SQLTable>
+        <name><![CDATA[public.blackout_dates]]></name>
+        <schema><![CDATA[public]]></schema>
+        <location>
+            <x>664.00</x>
+            <y>10.00</y>
+        </location>
+        <size>
+            <width>362.00</width>
+            <height>240.00</height>
+        </size>
+        <zorder>34</zorder>
+        <SQLField>
+            <name><![CDATA[id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <primaryKey>1</primaryKey>
+            <notNull><![CDATA[1]]></notNull>
+            <PK_NAME><![CDATA[blackout_dates_pkey]]></PK_NAME>
+            <uid><![CDATA[89BC4BE0-5968-4728-BFDC-8574F99EB9AB]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[transportation_service_provider_id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <referencesField>id</referencesField>
+            <referencesTable>public.transportation_service_providers</referencesTable>
+            <deleteAction>4</deleteAction>
+            <updateAction>4</updateAction>
+            <referencesField><![CDATA[id]]></referencesField>
+            <referencesTable><![CDATA[public.transportation_service_providers]]></referencesTable>
+            <sourceCardinality>0</sourceCardinality>
+            <destinationCardinality>0</destinationCardinality>
+            <referencesFieldUID><![CDATA[33B103F7-65E6-4CD2-BF2C-6A9E75620737]]></referencesFieldUID>
+            <referencesTableUID><![CDATA[03657CA9-D150-49B8-B269-48D3FC7E462E]]></referencesTableUID>
+            <foreignKeyName><![CDATA[blackout_dates_transportation_service_provider_id_fkey]]></foreignKeyName>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[07A80DC0-53A4-41E2-8FA7-0C5075377A1C]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[start_blackout_date]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[84E7361E-E609-4561-8342-92616BDE90E5]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[end_blackout_date]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[23DB014A-3132-4429-B7B8-BC22F9EA3F33]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[traffic_distribution_list_id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <referencesField>id</referencesField>
+            <referencesTable>public.traffic_distribution_lists</referencesTable>
+            <deleteAction>4</deleteAction>
+            <updateAction>4</updateAction>
+            <referencesField><![CDATA[id]]></referencesField>
+            <referencesTable><![CDATA[public.traffic_distribution_lists]]></referencesTable>
+            <sourceCardinality>0</sourceCardinality>
+            <destinationCardinality>0</destinationCardinality>
+            <referencesFieldUID><![CDATA[2E5B406F-1D96-456A-93A2-B199011E1071]]></referencesFieldUID>
+            <referencesTableUID><![CDATA[47606E6D-CCE4-4973-83D0-04F2295472DB]]></referencesTableUID>
+            <foreignKeyName><![CDATA[blackout_dates_traffic_distribution_list_id_fkey]]></foreignKeyName>
+            <uid><![CDATA[A4A3B3BF-FCE7-4BA2-9A73-DD4BB7C2E1A2]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[created_at]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[5D6D9582-FEAF-4C3C-A77E-99F717F9A217]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[updated_at]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[8B6C9ED9-1F38-4DA8-A16B-2AE301638FF5]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[source_gbloc]]></name>
+            <type><![CDATA[CHARACTER VARYING(255)]]></type>
+            <uid><![CDATA[9E6BB02B-C657-4D58-91AB-041B49A27A93]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[market]]></name>
+            <type><![CDATA[CHARACTER VARYING(255)]]></type>
+            <uid><![CDATA[818272FB-6E7F-4024-9392-E5F69BE01A72]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[zip3]]></name>
+            <type><![CDATA[INTEGER]]></type>
+            <uid><![CDATA[01AEF666-AF58-491B-8A5A-8F05C1AE1397]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[volume_move]]></name>
+            <type><![CDATA[BOOLEAN]]></type>
+            <uid><![CDATA[3F27C5D6-2098-4161-9DDE-178B26D4A152]]></uid>
+        </SQLField>
+        <labelWindowIndex><![CDATA[34]]></labelWindowIndex>
+        <PK_KEY_NAME><![CDATA[blackout_dates_pkey]]></PK_KEY_NAME>
+        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
+        <uid><![CDATA[EFFD5B71-DB1F-45C7-97FC-317F4E6738CE]]></uid>
+    </SQLTable>
+    <SQLTable>
+        <name><![CDATA[public.office_emails]]></name>
+        <schema><![CDATA[public]]></schema>
+        <location>
+            <x>1035.00</x>
+            <y>260.00</y>
+        </location>
+        <size>
+            <width>317.00</width>
+            <height>140.00</height>
+        </size>
+        <zorder>26</zorder>
+        <SQLField>
+            <name><![CDATA[id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <primaryKey>1</primaryKey>
+            <notNull><![CDATA[1]]></notNull>
+            <PK_NAME><![CDATA[office_emails_pkey]]></PK_NAME>
+            <uid><![CDATA[87F15CC6-0B1F-4C8F-A057-B32AACCAE3E4]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[transportation_office_id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <referencesField>id</referencesField>
+            <referencesTable>public.transportation_offices</referencesTable>
+            <deleteAction>4</deleteAction>
+            <updateAction>4</updateAction>
+            <referencesField><![CDATA[id]]></referencesField>
+            <referencesTable><![CDATA[public.transportation_offices]]></referencesTable>
+            <sourceCardinality>0</sourceCardinality>
+            <destinationCardinality>0</destinationCardinality>
+            <referencesFieldUID><![CDATA[9705C664-CD6F-4F37-98D3-36BB4FEA25C1]]></referencesFieldUID>
+            <referencesTableUID><![CDATA[E739E7A3-15AF-4D15-8BF6-DBCF6B06361D]]></referencesTableUID>
+            <foreignKeyName><![CDATA[office_emails_transportation_office_id_fkey]]></foreignKeyName>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[75E525A7-B60D-4188-AB69-2B52DE0CC57D]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[email]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[DC042493-0914-4ADD-9373-0F43FE60B5C4]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[label]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <uid><![CDATA[36CF9C26-BA74-446B-BA00-8608182EDFBB]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[created_at]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[E387A6F5-3E63-49FC-92DC-396272DA2884]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[updated_at]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[9A513467-FB6B-4E92-8FE9-344319BE98C7]]></uid>
+        </SQLField>
+        <labelWindowIndex><![CDATA[26]]></labelWindowIndex>
+        <PK_KEY_NAME><![CDATA[office_emails_pkey]]></PK_KEY_NAME>
+        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
+        <uid><![CDATA[F715E114-3673-42E5-AD93-9C2199A3F9CB]]></uid>
+    </SQLTable>
+    <SQLTable>
+        <name><![CDATA[public.social_security_numbers]]></name>
+        <schema><![CDATA[public]]></schema>
+        <location>
+            <x>337.00</x>
+            <y>1420.00</y>
+        </location>
+        <size>
+            <width>317.00</width>
+            <height>100.00</height>
+        </size>
+        <zorder>14</zorder>
+        <SQLField>
+            <name><![CDATA[id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <primaryKey>1</primaryKey>
+            <forcedUnique><![CDATA[1]]></forcedUnique>
+            <notNull><![CDATA[1]]></notNull>
+            <PK_NAME><![CDATA[social_security_numbers_pkey]]></PK_NAME>
+            <uid><![CDATA[DDD59E98-A0A7-4EB8-8067-7BBFCF7352AC]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[encrypted_hash]]></name>
+            <type><![CDATA[CHARACTER VARYING(255)]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[579210FA-460A-4323-A625-EA3F250FD4B0]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[created_at]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[DE5F41AD-E6F1-44D8-BB60-84DD208FA388]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[updated_at]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[9333EA35-F248-4BCE-8F4E-E19EB902159C]]></uid>
+        </SQLField>
+        <labelWindowIndex><![CDATA[14]]></labelWindowIndex>
+        <PK_KEY_NAME><![CDATA[social_security_numbers_pkey]]></PK_KEY_NAME>
+        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
+        <uid><![CDATA[FBBEF921-4A29-4E71-8933-629C23DACECC]]></uid>
     </SQLTable>
     <SQLDocumentInfo>
         <encodedPrintInfo><![CDATA[BAtzdHJlYW10eXBlZIHoA4QBQISEhAtOU1ByaW50SW5mbwGEhAhOU09iamVjdACFkoSEhBNOU011dGFibGVEaWN0aW9uYXJ5AISEDE5TRGljdGlvbmFyeQCUhAFpDZKEhIQITlNTdHJpbmcBlIQBKw5OU1BNUGFnZUZvcm1hdIaShISEDU5TTXV0YWJsZURhdGEAhIQGTlNEYXRhAJSXgbIbhAdbNzA5MGNdPD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPCFET0NUWVBFIHBsaXN0IFBVQkxJQyAiLS8vQXBwbGUvL0RURCBQTElTVCAxLjAvL0VOIiAiaHR0cDovL3d3dy5hcHBsZS5jb20vRFREcy9Qcm9wZXJ0eUxpc3QtMS4wLmR0ZCI+CjxwbGlzdCB2ZXJzaW9uPSIxLjAiPgo8ZGljdD4KCTxrZXk+Y29tLmFwcGxlLnByaW50LlBhZ2VGb3JtYXQuUE1Ib3Jpem9udGFsUmVzPC9rZXk+Cgk8ZGljdD4KCQk8a2V5PmNvbS5hcHBsZS5wcmludC50aWNrZXQuY3JlYXRvcjwva2V5PgoJCTxzdHJpbmc+Y29tLmFwcGxlLmpvYnRpY2tldDwvc3RyaW5nPgoJCTxrZXk+Y29tLmFwcGxlLnByaW50LnRpY2tldC5pdGVtQXJyYXk8L2tleT4KCQk8YXJyYXk+CgkJCTxkaWN0PgoJCQkJPGtleT5jb20uYXBwbGUucHJpbnQuUGFnZUZvcm1hdC5QTUhvcml6b250YWxSZXM8L2tleT4KCQkJCTxyZWFsPjcyPC9yZWFsPgoJCQkJPGtleT5jb20uYXBwbGUucHJpbnQudGlja2V0LnN0YXRlRmxhZzwva2V5PgoJCQkJPGludGVnZXI+MDwvaW50ZWdlcj4KCQkJPC9kaWN0PgoJCTwvYXJyYXk+Cgk8L2RpY3Q+Cgk8a2V5PmNvbS5hcHBsZS5wcmludC5QYWdlRm9ybWF0LlBNT3JpZW50YXRpb248L2tleT4KCTxkaWN0PgoJCTxrZXk+Y29tLmFwcGxlLnByaW50LnRpY2tldC5jcmVhdG9yPC9rZXk+CgkJPHN0cmluZz5jb20uYXBwbGUuam9idGlja2V0PC9zdHJpbmc+CgkJPGtleT5jb20uYXBwbGUucHJpbnQudGlja2V0Lml0ZW1BcnJheTwva2V5PgoJCTxhcnJheT4KCQkJPGRpY3Q+CgkJCQk8a2V5PmNvbS5hcHBsZS5wcmludC5QYWdlRm9ybWF0LlBNT3JpZW50YXRpb248L2tleT4KCQkJCTxpbnRlZ2VyPjE8L2ludGVnZXI+CgkJCQk8a2V5PmNvbS5hcHBsZS5wcmludC50aWNrZXQuc3RhdGVGbGFnPC9rZXk+CgkJCQk8aW50ZWdlcj4wPC9pbnRlZ2VyPgoJCQk8L2RpY3Q+CgkJPC9hcnJheT4KCTwvZGljdD4KCTxrZXk+Y29tLmFwcGxlLnByaW50LlBhZ2VGb3JtYXQuUE1TY2FsaW5nPC9rZXk+Cgk8ZGljdD4KCQk8a2V5PmNvbS5hcHBsZS5wcmludC50aWNrZXQuY3JlYXRvcjwva2V5PgoJCTxzdHJpbmc+Y29tLmFwcGxlLmpvYnRpY2tldDwvc3RyaW5nPgoJCTxrZXk+Y29tLmFwcGxlLnByaW50LnRpY2tldC5pdGVtQXJyYXk8L2tleT4KCQk8YXJyYXk+CgkJCTxkaWN0PgoJCQkJPGtleT5jb20uYXBwbGUucHJpbnQuUGFnZUZvcm1hdC5QTVNjYWxpbmc8L2tleT4KCQkJCTxyZWFsPjE8L3JlYWw+CgkJCQk8a2V5PmNvbS5hcHBsZS5wcmludC50aWNrZXQuc3RhdGVGbGFnPC9rZXk+CgkJCQk8aW50ZWdlcj4wPC9pbnRlZ2VyPgoJCQk8L2RpY3Q+CgkJPC9hcnJheT4KCTwvZGljdD4KCTxrZXk+Y29tLmFwcGxlLnByaW50LlBhZ2VGb3JtYXQuUE1WZXJ0aWNhbFJlczwva2V5PgoJPGRpY3Q+CgkJPGtleT5jb20uYXBwbGUucHJpbnQudGlja2V0LmNyZWF0b3I8L2tleT4KCQk8c3RyaW5nPmNvbS5hcHBsZS5qb2J0aWNrZXQ8L3N0cmluZz4KCQk8a2V5PmNvbS5hcHBsZS5wcmludC50aWNrZXQuaXRlbUFycmF5PC9rZXk+CgkJPGFycmF5PgoJCQk8ZGljdD4KCQkJCTxrZXk+Y29tLmFwcGxlLnByaW50LlBhZ2VGb3JtYXQuUE1WZXJ0aWNhbFJlczwva2V5PgoJCQkJPHJlYWw+NzI8L3JlYWw+CgkJCQk8a2V5PmNvbS5hcHBsZS5wcmludC50aWNrZXQuc3RhdGVGbGFnPC9rZXk+CgkJCQk8aW50ZWdlcj4wPC9pbnRlZ2VyPgoJCQk8L2RpY3Q+CgkJPC9hcnJheT4KCTwvZGljdD4KCTxrZXk+Y29tLmFwcGxlLnByaW50LlBhZ2VGb3JtYXQuUE1WZXJ0aWNhbFNjYWxpbmc8L2tleT4KCTxkaWN0PgoJCTxrZXk+Y29tLmFwcGxlLnByaW50LnRpY2tldC5jcmVhdG9yPC9rZXk+CgkJPHN0cmluZz5jb20uYXBwbGUuam9idGlja2V0PC9zdHJpbmc+CgkJPGtleT5jb20uYXBwbGUucHJpbnQudGlja2V0Lml0ZW1BcnJheTwva2V5PgoJCTxhcnJheT4KCQkJPGRpY3Q+CgkJCQk8a2V5PmNvbS5hcHBsZS5wcmludC5QYWdlRm9ybWF0LlBNVmVydGljYWxTY2FsaW5nPC9rZXk+CgkJCQk8cmVhbD4xPC9yZWFsPgoJCQkJPGtleT5jb20uYXBwbGUucHJpbnQudGlja2V0LnN0YXRlRmxhZzwva2V5PgoJCQkJPGludGVnZXI+MDwvaW50ZWdlcj4KCQkJPC9kaWN0PgoJCTwvYXJyYXk+Cgk8L2RpY3Q+Cgk8a2V5PmNvbS5hcHBsZS5wcmludC5zdWJUaWNrZXQucGFwZXJfaW5mb190aWNrZXQ8L2tleT4KCTxkaWN0PgoJCTxrZXk+UE1QUERQYXBlckNvZGVOYW1lPC9rZXk+CgkJPGRpY3Q+CgkJCTxrZXk+Y29tLmFwcGxlLnByaW50LnRpY2tldC5jcmVhdG9yPC9rZXk+CgkJCTxzdHJpbmc+Y29tLmFwcGxlLmpvYnRpY2tldDwvc3RyaW5nPgoJCQk8a2V5PmNvbS5hcHBsZS5wcmludC50aWNrZXQuaXRlbUFycmF5PC9rZXk+CgkJCTxhcnJheT4KCQkJCTxkaWN0PgoJCQkJCTxrZXk+UE1QUERQYXBlckNvZGVOYW1lPC9rZXk+CgkJCQkJPHN0cmluZz5MZXR0ZXI8L3N0cmluZz4KCQkJCQk8a2V5PmNvbS5hcHBsZS5wcmludC50aWNrZXQuc3RhdGVGbGFnPC9rZXk+CgkJCQkJPGludGVnZXI+MDwvaW50ZWdlcj4KCQkJCTwvZGljdD4KCQkJPC9hcnJheT4KCQk8L2RpY3Q+CgkJPGtleT5QTVBQRFRyYW5zbGF0aW9uU3RyaW5nUGFwZXJOYW1lPC9rZXk+CgkJPGRpY3Q+CgkJCTxrZXk+Y29tLmFwcGxlLnByaW50LnRpY2tldC5jcmVhdG9yPC9rZXk+CgkJCTxzdHJpbmc+Y29tLmFwcGxlLmpvYnRpY2tldDwvc3RyaW5nPgoJCQk8a2V5PmNvbS5hcHBsZS5wcmludC50aWNrZXQuaXRlbUFycmF5PC9rZXk+CgkJCTxhcnJheT4KCQkJCTxkaWN0PgoJCQkJCTxrZXk+UE1QUERUcmFuc2xhdGlvblN0cmluZ1BhcGVyTmFtZTwva2V5PgoJCQkJCTxzdHJpbmc+VVMgTGV0dGVyPC9zdHJpbmc+CgkJCQkJPGtleT5jb20uYXBwbGUucHJpbnQudGlja2V0LnN0YXRlRmxhZzwva2V5PgoJCQkJCTxpbnRlZ2VyPjA8L2ludGVnZXI+CgkJCQk8L2RpY3Q+CgkJCTwvYXJyYXk+CgkJPC9kaWN0PgoJCTxrZXk+UE1UaW9nYVBhcGVyTmFtZTwva2V5PgoJCTxkaWN0PgoJCQk8a2V5PmNvbS5hcHBsZS5wcmludC50aWNrZXQuY3JlYXRvcjwva2V5PgoJCQk8c3RyaW5nPmNvbS5hcHBsZS5qb2J0aWNrZXQ8L3N0cmluZz4KCQkJPGtleT5jb20uYXBwbGUucHJpbnQudGlja2V0Lml0ZW1BcnJheTwva2V5PgoJCQk8YXJyYXk+CgkJCQk8ZGljdD4KCQkJCQk8a2V5PlBNVGlvZ2FQYXBlck5hbWU8L2tleT4KCQkJCQk8c3RyaW5nPm5hLWxldHRlcjwvc3RyaW5nPgoJCQkJCTxrZXk+Y29tLmFwcGxlLnByaW50LnRpY2tldC5zdGF0ZUZsYWc8L2tleT4KCQkJCQk8aW50ZWdlcj4wPC9pbnRlZ2VyPgoJCQkJPC9kaWN0PgoJCQk8L2FycmF5PgoJCTwvZGljdD4KCQk8a2V5PmNvbS5hcHBsZS5wcmludC5QYWdlRm9ybWF0LlBNQWRqdXN0ZWRQYWdlUmVjdDwva2V5PgoJCTxkaWN0PgoJCQk8a2V5PmNvbS5hcHBsZS5wcmludC50aWNrZXQuY3JlYXRvcjwva2V5PgoJCQk8c3RyaW5nPmNvbS5hcHBsZS5qb2J0aWNrZXQ8L3N0cmluZz4KCQkJPGtleT5jb20uYXBwbGUucHJpbnQudGlja2V0Lml0ZW1BcnJheTwva2V5PgoJCQk8YXJyYXk+CgkJCQk8ZGljdD4KCQkJCQk8a2V5PmNvbS5hcHBsZS5wcmludC5QYWdlRm9ybWF0LlBNQWRqdXN0ZWRQYWdlUmVjdDwva2V5PgoJCQkJCTxhcnJheT4KCQkJCQkJPGludGVnZXI+MDwvaW50ZWdlcj4KCQkJCQkJPGludGVnZXI+MDwvaW50ZWdlcj4KCQkJCQkJPHJlYWw+NzM0PC9yZWFsPgoJCQkJCQk8cmVhbD41NzY8L3JlYWw+CgkJCQkJPC9hcnJheT4KCQkJCQk8a2V5PmNvbS5hcHBsZS5wcmludC50aWNrZXQuc3RhdGVGbGFnPC9rZXk+CgkJCQkJPGludGVnZXI+MDwvaW50ZWdlcj4KCQkJCTwvZGljdD4KCQkJPC9hcnJheT4KCQk8L2RpY3Q+CgkJPGtleT5jb20uYXBwbGUucHJpbnQuUGFnZUZvcm1hdC5QTUFkanVzdGVkUGFwZXJSZWN0PC9rZXk+CgkJPGRpY3Q+CgkJCTxrZXk+Y29tLmFwcGxlLnByaW50LnRpY2tldC5jcmVhdG9yPC9rZXk+CgkJCTxzdHJpbmc+Y29tLmFwcGxlLmpvYnRpY2tldDwvc3RyaW5nPgoJCQk8a2V5PmNvbS5hcHBsZS5wcmludC50aWNrZXQuaXRlbUFycmF5PC9rZXk+CgkJCTxhcnJheT4KCQkJCTxkaWN0PgoJCQkJCTxrZXk+Y29tLmFwcGxlLnByaW50LlBhZ2VGb3JtYXQuUE1BZGp1c3RlZFBhcGVyUmVjdDwva2V5PgoJCQkJCTxhcnJheT4KCQkJCQkJPHJlYWw+LTE4PC9yZWFsPgoJCQkJCQk8cmVhbD4tMTg8L3JlYWw+CgkJCQkJCTxyZWFsPjc3NDwvcmVhbD4KCQkJCQkJPHJlYWw+NTk0PC9yZWFsPgoJCQkJCTwvYXJyYXk+CgkJCQkJPGtleT5jb20uYXBwbGUucHJpbnQudGlja2V0LnN0YXRlRmxhZzwva2V5PgoJCQkJCTxpbnRlZ2VyPjA8L2ludGVnZXI+CgkJCQk8L2RpY3Q+CgkJCTwvYXJyYXk+CgkJPC9kaWN0PgoJCTxrZXk+Y29tLmFwcGxlLnByaW50LlBhcGVySW5mby5QTVBQRFBhcGVyRGltZW5zaW9uPC9rZXk+CgkJPGRpY3Q+CgkJCTxrZXk+Y29tLmFwcGxlLnByaW50LnRpY2tldC5jcmVhdG9yPC9rZXk+CgkJCTxzdHJpbmc+Y29tLmFwcGxlLmpvYnRpY2tldDwvc3RyaW5nPgoJCQk8a2V5PmNvbS5hcHBsZS5wcmludC50aWNrZXQuaXRlbUFycmF5PC9rZXk+CgkJCTxhcnJheT4KCQkJCTxkaWN0PgoJCQkJCTxrZXk+Y29tLmFwcGxlLnByaW50LlBhcGVySW5mby5QTVBQRFBhcGVyRGltZW5zaW9uPC9rZXk+CgkJCQkJPGFycmF5PgoJCQkJCQk8aW50ZWdlcj4wPC9pbnRlZ2VyPgoJCQkJCQk8aW50ZWdlcj4wPC9pbnRlZ2VyPgoJCQkJCQk8cmVhbD42MTI8L3JlYWw+CgkJCQkJCTxyZWFsPjc5MjwvcmVhbD4KCQkJCQk8L2FycmF5PgoJCQkJCTxrZXk+Y29tLmFwcGxlLnByaW50LnRpY2tldC5zdGF0ZUZsYWc8L2tleT4KCQkJCQk8aW50ZWdlcj4wPC9pbnRlZ2VyPgoJCQkJPC9kaWN0PgoJCQk8L2FycmF5PgoJCTwvZGljdD4KCQk8a2V5PmNvbS5hcHBsZS5wcmludC5QYXBlckluZm8uUE1QYXBlck5hbWU8L2tleT4KCQk8ZGljdD4KCQkJPGtleT5jb20uYXBwbGUucHJpbnQudGlja2V0LmNyZWF0b3I8L2tleT4KCQkJPHN0cmluZz5jb20uYXBwbGUuam9idGlja2V0PC9zdHJpbmc+CgkJCTxrZXk+Y29tLmFwcGxlLnByaW50LnRpY2tldC5pdGVtQXJyYXk8L2tleT4KCQkJPGFycmF5PgoJCQkJPGRpY3Q+CgkJCQkJPGtleT5jb20uYXBwbGUucHJpbnQuUGFwZXJJbmZvLlBNUGFwZXJOYW1lPC9rZXk+CgkJCQkJPHN0cmluZz5uYS1sZXR0ZXI8L3N0cmluZz4KCQkJCQk8a2V5PmNvbS5hcHBsZS5wcmludC50aWNrZXQuc3RhdGVGbGFnPC9rZXk+CgkJCQkJPGludGVnZXI+MDwvaW50ZWdlcj4KCQkJCTwvZGljdD4KCQkJPC9hcnJheT4KCQk8L2RpY3Q+CgkJPGtleT5jb20uYXBwbGUucHJpbnQuUGFwZXJJbmZvLlBNVW5hZGp1c3RlZFBhZ2VSZWN0PC9rZXk+CgkJPGRpY3Q+CgkJCTxrZXk+Y29tLmFwcGxlLnByaW50LnRpY2tldC5jcmVhdG9yPC9rZXk+CgkJCTxzdHJpbmc+Y29tLmFwcGxlLmpvYnRpY2tldDwvc3RyaW5nPgoJCQk8a2V5PmNvbS5hcHBsZS5wcmludC50aWNrZXQuaXRlbUFycmF5PC9rZXk+CgkJCTxhcnJheT4KCQkJCTxkaWN0PgoJCQkJCTxrZXk+Y29tLmFwcGxlLnByaW50LlBhcGVySW5mby5QTVVuYWRqdXN0ZWRQYWdlUmVjdDwva2V5PgoJCQkJCTxhcnJheT4KCQkJCQkJPGludGVnZXI+MDwvaW50ZWdlcj4KCQkJCQkJPGludGVnZXI+MDwvaW50ZWdlcj4KCQkJCQkJPHJlYWw+NzM0PC9yZWFsPgoJCQkJCQk8cmVhbD41NzY8L3JlYWw+CgkJCQkJPC9hcnJheT4KCQkJCQk8a2V5PmNvbS5hcHBsZS5wcmludC50aWNrZXQuc3RhdGVGbGFnPC9rZXk+CgkJCQkJPGludGVnZXI+MDwvaW50ZWdlcj4KCQkJCTwvZGljdD4KCQkJPC9hcnJheT4KCQk8L2RpY3Q+CgkJPGtleT5jb20uYXBwbGUucHJpbnQuUGFwZXJJbmZvLlBNVW5hZGp1c3RlZFBhcGVyUmVjdDwva2V5PgoJCTxkaWN0PgoJCQk8a2V5PmNvbS5hcHBsZS5wcmludC50aWNrZXQuY3JlYXRvcjwva2V5PgoJCQk8c3RyaW5nPmNvbS5hcHBsZS5qb2J0aWNrZXQ8L3N0cmluZz4KCQkJPGtleT5jb20uYXBwbGUucHJpbnQudGlja2V0Lml0ZW1BcnJheTwva2V5PgoJCQk8YXJyYXk+CgkJCQk8ZGljdD4KCQkJCQk8a2V5PmNvbS5hcHBsZS5wcmludC5QYXBlckluZm8uUE1VbmFkanVzdGVkUGFwZXJSZWN0PC9rZXk+CgkJCQkJPGFycmF5PgoJCQkJCQk8cmVhbD4tMTg8L3JlYWw+CgkJCQkJCTxyZWFsPi0xODwvcmVhbD4KCQkJCQkJPHJlYWw+Nzc0PC9yZWFsPgoJCQkJCQk8cmVhbD41OTQ8L3JlYWw+CgkJCQkJPC9hcnJheT4KCQkJCQk8a2V5PmNvbS5hcHBsZS5wcmludC50aWNrZXQuc3RhdGVGbGFnPC9rZXk+CgkJCQkJPGludGVnZXI+MDwvaW50ZWdlcj4KCQkJCTwvZGljdD4KCQkJPC9hcnJheT4KCQk8L2RpY3Q+CgkJPGtleT5jb20uYXBwbGUucHJpbnQuUGFwZXJJbmZvLnBwZC5QTVBhcGVyTmFtZTwva2V5PgoJCTxkaWN0PgoJCQk8a2V5PmNvbS5hcHBsZS5wcmludC50aWNrZXQuY3JlYXRvcjwva2V5PgoJCQk8c3RyaW5nPmNvbS5hcHBsZS5qb2J0aWNrZXQ8L3N0cmluZz4KCQkJPGtleT5jb20uYXBwbGUucHJpbnQudGlja2V0Lml0ZW1BcnJheTwva2V5PgoJCQk8YXJyYXk+CgkJCQk8ZGljdD4KCQkJCQk8a2V5PmNvbS5hcHBsZS5wcmludC5QYXBlckluZm8ucHBkLlBNUGFwZXJOYW1lPC9rZXk+CgkJCQkJPHN0cmluZz5MZXR0ZXI8L3N0cmluZz4KCQkJCQk8a2V5PmNvbS5hcHBsZS5wcmludC50aWNrZXQuc3RhdGVGbGFnPC9rZXk+CgkJCQkJPGludGVnZXI+MDwvaW50ZWdlcj4KCQkJCTwvZGljdD4KCQkJPC9hcnJheT4KCQk8L2RpY3Q+CgkJPGtleT5jb20uYXBwbGUucHJpbnQudGlja2V0LkFQSVZlcnNpb248L2tleT4KCQk8c3RyaW5nPjAwLjIwPC9zdHJpbmc+CgkJPGtleT5jb20uYXBwbGUucHJpbnQudGlja2V0LnR5cGU8L2tleT4KCQk8c3RyaW5nPmNvbS5hcHBsZS5wcmludC5QYXBlckluZm9UaWNrZXQ8L3N0cmluZz4KCTwvZGljdD4KCTxrZXk+Y29tLmFwcGxlLnByaW50LnRpY2tldC5BUElWZXJzaW9uPC9rZXk+Cgk8c3RyaW5nPjAwLjIwPC9zdHJpbmc+Cgk8a2V5PmNvbS5hcHBsZS5wcmludC50aWNrZXQudHlwZTwva2V5PgoJPHN0cmluZz5jb20uYXBwbGUucHJpbnQuUGFnZUZvcm1hdFRpY2tldDwvc3RyaW5nPgo8L2RpY3Q+CjwvcGxpc3Q+CoaShJmZC05TUGFwZXJTaXplhpKEhIQHTlNWYWx1ZQCUhAEqhIQLe0NHU2l6ZT1kZH2fgWQCgRgDhpKEmZkWTlNIb3Jpem9udGFsbHlDZW50ZXJlZIaShISECE5TTnVtYmVyAJ+ehIQBY6EBhpKEmZkUTlNWZXJ0aWNhbGx5Q2VudGVyZWSGkqKShJmZDE5TTGVmdE1hcmdpboaShKOehIQBZKIShpKEmZkNTlNSaWdodE1hcmdpboaSp5KEmZkLTlNUb3BNYXJnaW6GkoSjnqiiHoaShJmZDU5TT3JpZW50YXRpb26GkoSjnoSEAXGjAIaShJmZFU5TSG9yaXpvbmFsUGFnaW5hdGlvboaSrZKEmZkUTlNWZXJ0aWNhbFBhZ2luYXRpb26Gkq2ShJmZDk5TQm90dG9tTWFyZ2luhpKEo56oojSGkoSZmQ9OU1NjYWxpbmdGYWN0b3KGkoSjnqiiAYaShJmZC05TUGFwZXJOYW1lhpKEmZkJbmEtbGV0dGVyhoaG]]></encodedPrintInfo>
@@ -3187,23 +3187,23 @@
         <exportDialect><![CDATA[postgres]]></exportDialect>
         <fileversion><![CDATA[4]]></fileversion>
         <generator><![CDATA[com.malcolmhardie.sqleditor]]></generator>
-        <generatorVersion><![CDATA[3.3.11]]></generatorVersion>
+        <generatorVersion><![CDATA[3.3.12]]></generatorVersion>
         <hideFieldIcons><![CDATA[0]]></hideFieldIcons>
         <hideFieldTypes><![CDATA[0]]></hideFieldTypes>
         <overviewPanelHidden><![CDATA[0]]></overviewPanelHidden>
         <pageBoundariesVisible><![CDATA[0]]></pageBoundariesVisible>
         <PageGridVisible><![CDATA[0]]></PageGridVisible>
-        <RightSidebarWidth><![CDATA[1868.000000]]></RightSidebarWidth>
+        <RightSidebarWidth><![CDATA[1163.000000]]></RightSidebarWidth>
         <sidebarIndex><![CDATA[5]]></sidebarIndex>
         <snapToGrid><![CDATA[0]]></snapToGrid>
         <SourceSidebarWidth><![CDATA[312.000000]]></SourceSidebarWidth>
         <SQLEditorFileFormatVersion><![CDATA[4]]></SQLEditorFileFormatVersion>
-        <uid><![CDATA[4297A846-68F1-4309-A987-F325B23073C9]]></uid>
-        <windowHeight><![CDATA[1548.000000]]></windowHeight>
-        <windowLocationX><![CDATA[660.000000]]></windowLocationX>
-        <windowLocationY><![CDATA[121.000000]]></windowLocationY>
+        <uid><![CDATA[EFA0AA7B-C5CE-422F-AAC9-9A500D43EC50]]></uid>
+        <windowHeight><![CDATA[778.000000]]></windowHeight>
+        <windowLocationX><![CDATA[-1852.000000]]></windowLocationX>
+        <windowLocationY><![CDATA[267.000000]]></windowLocationY>
         <windowScrollOrigin><![CDATA[{0, 0}]]></windowScrollOrigin>
-        <windowWidth><![CDATA[1869.000000]]></windowWidth>
+        <windowWidth><![CDATA[1440.000000]]></windowWidth>
     </SQLDocumentInfo>
     <AllowsIndexRenamingOnInsert><![CDATA[1]]></AllowsIndexRenamingOnInsert>
     <defaultLabelExpanded><![CDATA[1]]></defaultLabelExpanded>

--- a/migrations/20180913211923_add_actual_pickup_date_to_shipment.up.fizz
+++ b/migrations/20180913211923_add_actual_pickup_date_to_shipment.up.fizz
@@ -1,1 +1,0 @@
-add_column("shipments", "actual_pickup_date", "datetime", {"null": true})

--- a/migrations/20180913211923_add_actual_pickup_date_to_shipment.up.fizz
+++ b/migrations/20180913211923_add_actual_pickup_date_to_shipment.up.fizz
@@ -1,0 +1,1 @@
+add_column("shipments", "actual_pickup_date", "datetime", {"null": true})

--- a/migrations/20180913211923_rename_pickup_date_on_shipment.up.fizz
+++ b/migrations/20180913211923_rename_pickup_date_on_shipment.up.fizz
@@ -1,0 +1,1 @@
+rename_column("shipments", "pickup_date", "actual_pickup_date")

--- a/pkg/awardqueue/awardqueue_test.go
+++ b/pkg/awardqueue/awardqueue_test.go
@@ -33,7 +33,7 @@ func (suite *AwardQueueSuite) Test_CheckAllTSPsBlackedOut() {
 	shipment := testdatagen.MakeShipment(suite.db, testdatagen.Assertions{
 		Shipment: models.Shipment{
 			RequestedPickupDate: &pickupDate,
-			PickupDate:          &pickupDate,
+			ActualPickupDate:    &pickupDate,
 			DeliveryDate:        &deliveryDate,
 			SourceGBLOC:         &sourceGBLOC,
 			Market:              &market,
@@ -87,7 +87,7 @@ func (suite *AwardQueueSuite) Test_CheckShipmentDuringBlackOut() {
 	blackoutShipment := testdatagen.MakeShipment(suite.db, testdatagen.Assertions{
 		Shipment: models.Shipment{
 			RequestedPickupDate: &blackoutPickupDate,
-			PickupDate:          &blackoutPickupDate,
+			ActualPickupDate:    &blackoutPickupDate,
 			DeliveryDate:        &blackoutDeliverDate,
 			SourceGBLOC:         &sourceGBLOC,
 			Market:              &market,
@@ -101,7 +101,7 @@ func (suite *AwardQueueSuite) Test_CheckShipmentDuringBlackOut() {
 	shipment := testdatagen.MakeShipment(suite.db, testdatagen.Assertions{
 		Shipment: models.Shipment{
 			RequestedPickupDate: &pickupDate,
-			PickupDate:          &pickupDate,
+			ActualPickupDate:    &pickupDate,
 			DeliveryDate:        &deliveryDate,
 			SourceGBLOC:         &sourceGBLOC,
 			Market:              &market,
@@ -185,7 +185,7 @@ func (suite *AwardQueueSuite) Test_ShipmentWithinBlackoutDates() {
 	testShipmentBetween := testdatagen.MakeShipment(suite.db, testdatagen.Assertions{
 		Shipment: models.Shipment{
 			RequestedPickupDate: &testPickupDateBetween,
-			PickupDate:          &testPickupDateBetween,
+			ActualPickupDate:    &testPickupDateBetween,
 			DeliveryDate:        &testEndDate,
 			SourceGBLOC:         &sourceGBLOC,
 			Market:              &market,
@@ -197,7 +197,7 @@ func (suite *AwardQueueSuite) Test_ShipmentWithinBlackoutDates() {
 	testShipmentAfter := testdatagen.MakeShipment(suite.db, testdatagen.Assertions{
 		Shipment: models.Shipment{
 			RequestedPickupDate: &testPickupDateAfter,
-			PickupDate:          &testPickupDateAfter,
+			ActualPickupDate:    &testPickupDateAfter,
 			DeliveryDate:        &testEndDate,
 			SourceGBLOC:         &sourceGBLOC,
 			Market:              &market,
@@ -275,7 +275,7 @@ func (suite *AwardQueueSuite) Test_OfferSingleShipment() {
 	shipment := testdatagen.MakeShipment(suite.db, testdatagen.Assertions{
 		Shipment: models.Shipment{
 			RequestedPickupDate: &pickupDate,
-			PickupDate:          &pickupDate,
+			ActualPickupDate:    &pickupDate,
 			DeliveryDate:        &deliveryDate,
 			SourceGBLOC:         &sourceGBLOC,
 			Market:              &market,
@@ -323,7 +323,7 @@ func (suite *AwardQueueSuite) Test_FailOfferingSingleShipment() {
 	shipment := testdatagen.MakeShipment(suite.db, testdatagen.Assertions{
 		Shipment: models.Shipment{
 			RequestedPickupDate: &pickupDate,
-			PickupDate:          &pickupDate,
+			ActualPickupDate:    &pickupDate,
 			DeliveryDate:        &deliveryDate,
 			SourceGBLOC:         &sourceGBLOC,
 			Market:              &market,
@@ -362,7 +362,7 @@ func (suite *AwardQueueSuite) TestAssignShipmentsSingleTSP() {
 		shipments[i] = testdatagen.MakeShipment(suite.db, testdatagen.Assertions{
 			Shipment: models.Shipment{
 				RequestedPickupDate: &pickupDate,
-				PickupDate:          &pickupDate,
+				ActualPickupDate:    &pickupDate,
 				DeliveryDate:        &deliveryDate,
 				SourceGBLOC:         &sourceGBLOC,
 				Market:              &market,
@@ -426,7 +426,7 @@ func (suite *AwardQueueSuite) TestAssignShipmentsToMultipleTSPs() {
 		shipments[i] = testdatagen.MakeShipment(suite.db, testdatagen.Assertions{
 			Shipment: models.Shipment{
 				RequestedPickupDate: &pickupDate,
-				PickupDate:          &pickupDate,
+				ActualPickupDate:    &pickupDate,
 				DeliveryDate:        &deliveryDate,
 				SourceGBLOC:         &sourceGBLOC,
 				Market:              &market,
@@ -563,7 +563,7 @@ func (suite *AwardQueueSuite) Test_AwardTSPsInDifferentRateCycles() {
 
 	shipmentPeak := models.Shipment{
 		TrafficDistributionListID: &tdl.ID,
-		PickupDate:                &testdatagen.DateInsidePeakRateCycle,
+		ActualPickupDate:          &testdatagen.DateInsidePeakRateCycle,
 		RequestedPickupDate:       &testdatagen.DateInsidePeakRateCycle,
 		DeliveryDate:              &twoMonthsLater,
 		BookDate:                  &testdatagen.PerformancePeriodStart,
@@ -602,7 +602,7 @@ func (suite *AwardQueueSuite) Test_AwardTSPsInDifferentRateCycles() {
 
 	shipmentNonPeak := models.Shipment{
 		TrafficDistributionListID: &tdl.ID,
-		PickupDate:                &testdatagen.DateInsideNonPeakRateCycle,
+		ActualPickupDate:          &testdatagen.DateInsideNonPeakRateCycle,
 		RequestedPickupDate:       &testdatagen.DateInsideNonPeakRateCycle,
 		DeliveryDate:              &twoMonthsLater,
 		BookDate:                  &testdatagen.PerformancePeriodStart,

--- a/pkg/handlers/internalapi/shipments.go
+++ b/pkg/handlers/internalapi/shipments.go
@@ -36,7 +36,7 @@ func payloadForShipmentModel(s models.Shipment) *internalmessages.Shipment {
 		Status:                              internalmessages.ShipmentStatus(s.Status),
 		BookDate:                            handlers.FmtDatePtr(s.BookDate),
 		RequestedPickupDate:                 handlers.FmtDatePtr(s.RequestedPickupDate),
-		PickupDate:                          handlers.FmtDatePtr(s.PickupDate),
+		ActualPickupDate:                    handlers.FmtDatePtr(s.ActualPickupDate),
 		DeliveryDate:                        handlers.FmtDatePtr(s.DeliveryDate),
 		CreatedAt:                           strfmt.DateTime(s.CreatedAt),
 		UpdatedAt:                           strfmt.DateTime(s.UpdatedAt),
@@ -145,8 +145,8 @@ func patchShipmentWithPremoveSurveyFields(shipment *models.Shipment, payload *in
 
 func patchShipmentWithPayload(shipment *models.Shipment, payload *internalmessages.Shipment) {
 
-	if payload.PickupDate != nil {
-		shipment.PickupDate = (*time.Time)(payload.PickupDate)
+	if payload.ActualPickupDate != nil {
+		shipment.ActualPickupDate = (*time.Time)(payload.ActualPickupDate)
 	}
 	if payload.RequestedPickupDate != nil {
 		shipment.RequestedPickupDate = (*time.Time)(payload.RequestedPickupDate)

--- a/pkg/handlers/publicapi/api.go
+++ b/pkg/handlers/publicapi/api.go
@@ -32,6 +32,7 @@ func NewPublicAPIHandler(context handlers.HandlerContext) http.Handler {
 	publicAPI.ShipmentsPatchShipmentHandler = PatchShipmentHandler{context}
 	publicAPI.ShipmentsAcceptShipmentHandler = AcceptShipmentHandler{context}
 	publicAPI.ShipmentsRejectShipmentHandler = RejectShipmentHandler{context}
+	publicAPI.ShipmentsTransportShipmentHandler = TransportShipmentHandler{context}
 
 	// Service Agents
 	publicAPI.ServiceAgentsIndexServiceAgentsHandler = IndexServiceAgentsHandler{context}

--- a/pkg/handlers/publicapi/shipments.go
+++ b/pkg/handlers/publicapi/shipments.go
@@ -19,7 +19,7 @@ func payloadForShipmentModel(s models.Shipment) *apimessages.Shipment {
 		ID: *handlers.FmtUUID(s.ID),
 		TrafficDistributionList:             payloadForTrafficDistributionListModel(s.TrafficDistributionList),
 		ServiceMember:                       payloadForServiceMemberModel(s.ServiceMember),
-		PickupDate:                          *handlers.FmtDateTimePtr(s.PickupDate),
+		ActualPickupDate:                    *handlers.FmtDateTimePtr(s.ActualPickupDate),
 		DeliveryDate:                        *handlers.FmtDateTimePtr(s.DeliveryDate),
 		CreatedAt:                           strfmt.DateTime(s.CreatedAt),
 		UpdatedAt:                           strfmt.DateTime(s.UpdatedAt),
@@ -200,6 +200,44 @@ func (h RejectShipmentHandler) Handle(params shipmentop.RejectShipmentParams) mi
 	return shipmentop.NewRejectShipmentOK().WithPayload(sp)
 }
 
+// TransportShipmentHandler allows a TSP to start transporting a particular shipment
+type TransportShipmentHandler struct {
+	handlers.HandlerContext
+}
+
+// Handle accepts the shipment - checks that currently logged in user is authorized to act for the TSP assigned the shipment
+func (h TransportShipmentHandler) Handle(params shipmentop.TransportShipmentParams) middleware.Responder {
+	session := auth.SessionFromRequestContext(params.HTTPRequest)
+
+	shipmentID, _ := uuid.FromString(params.ShipmentID.String())
+
+	// TODO: (cgilmer 2018_07_25) This is an extra query we don't need to run on every request. Put the
+	// TransportationServiceProviderID into the session object after refactoring the session code to be more readable.
+	// See original commits in https://github.com/transcom/mymove/pull/802
+	tspUser, err := models.FetchTspUserByID(h.DB(), session.TspUserID)
+	if err != nil {
+		h.Logger().Error("DB Query", zap.Error(err))
+		return shipmentop.NewGetShipmentForbidden()
+	}
+
+	shipment, err := models.FetchShipmentByTSP(h.DB(), tspUser.TransportationServiceProviderID, shipmentID)
+	if err != nil {
+		h.Logger().Error("DB Query", zap.Error(err))
+		return shipmentop.NewGetShipmentBadRequest()
+	}
+
+	err = shipment.Transport()
+	if err != nil {
+		return handlers.ResponseForError(h.Logger(), err)
+	}
+	verrs, err := h.DB().ValidateAndUpdate(shipment)
+	if err != nil || verrs.HasAny() {
+		return handlers.ResponseForVErrors(h.Logger(), verrs, err)
+	}
+	sp := payloadForShipmentModel(*shipment)
+	return shipmentop.NewTransportShipmentOK().WithPayload(sp)
+}
+
 func patchShipmentWithPayload(shipment *models.Shipment, payload *apimessages.Shipment) {
 	// Premove Survey values entered by TSP agent
 	requiredValue := payload.PmSurveyPlannedPackDate
@@ -219,6 +257,10 @@ func patchShipmentWithPayload(shipment *models.Shipment, payload *apimessages.Sh
 
 	if payload.ActualWeight != nil {
 		shipment.ActualWeight = handlers.PoundPtrFromInt64Ptr(payload.ActualWeight)
+	}
+
+	if &payload.ActualPickupDate != nil {
+		shipment.ActualPickupDate = (*time.Time)(&payload.ActualPickupDate)
 	}
 }
 

--- a/pkg/models/blackout_dates.go
+++ b/pkg/models/blackout_dates.go
@@ -29,7 +29,7 @@ type BlackoutDate struct {
 func FetchTSPBlackoutDates(tx *pop.Connection, tspID uuid.UUID, shipment Shipment) ([]BlackoutDate, error) {
 	blackoutDates := []BlackoutDate{}
 	var err error
-	query := tx.Where("transportation_service_provider_id = ?", tspID).Where("? BETWEEN start_blackout_date and end_blackout_date", shipment.PickupDate)
+	query := tx.Where("transportation_service_provider_id = ?", tspID).Where("? BETWEEN start_blackout_date and end_blackout_date", shipment.ActualPickupDate)
 
 	if shipment.Market != nil {
 		query = query.Where("market = ?", *shipment.Market)

--- a/pkg/models/blackout_dates_test.go
+++ b/pkg/models/blackout_dates_test.go
@@ -32,17 +32,17 @@ func (suite *ModelSuite) Test_FetchTSPBlackoutDates() {
 
 	shipmentDomesticMarket := testdatagen.MakeShipment(suite.db, testdatagen.Assertions{
 		Shipment: models.Shipment{
-			PickupDate: &pickupDate,
-			BookDate:   &testdatagen.DateInsidePerformancePeriod,
-			Status:     models.ShipmentStatusSUBMITTED,
+			ActualPickupDate: &pickupDate,
+			BookDate:         &testdatagen.DateInsidePerformancePeriod,
+			Status:           models.ShipmentStatusSUBMITTED,
 		},
 	})
 
 	shipmentInternationalMarket := testdatagen.MakeShipment(suite.db, testdatagen.Assertions{
 		Shipment: models.Shipment{
-			PickupDate: &pickupDate,
-			BookDate:   &testdatagen.DateInsidePerformancePeriod,
-			Status:     models.ShipmentStatusSUBMITTED,
+			ActualPickupDate: &pickupDate,
+			BookDate:         &testdatagen.DateInsidePerformancePeriod,
+			Status:           models.ShipmentStatusSUBMITTED,
 		},
 	})
 
@@ -87,20 +87,20 @@ func (suite *ModelSuite) Test_FetchTSPBlackoutDatesWithGBLOC() {
 
 	shipmentInGBLOC1 := testdatagen.MakeShipment(suite.db, testdatagen.Assertions{
 		Shipment: models.Shipment{
-			PickupDate:  &pickupDate,
-			SourceGBLOC: &sourceGBLOC1,
-			Market:      &market1,
-			BookDate:    &testdatagen.DateInsidePerformancePeriod,
-			Status:      models.ShipmentStatusSUBMITTED,
+			ActualPickupDate: &pickupDate,
+			SourceGBLOC:      &sourceGBLOC1,
+			Market:           &market1,
+			BookDate:         &testdatagen.DateInsidePerformancePeriod,
+			Status:           models.ShipmentStatusSUBMITTED,
 		},
 	})
 
 	shipmentInGBLOC2 := testdatagen.MakeShipment(suite.db, testdatagen.Assertions{
 		Shipment: models.Shipment{
-			PickupDate:  &pickupDate,
-			SourceGBLOC: &sourceGBLOC2,
-			BookDate:    &testdatagen.DateInsidePerformancePeriod,
-			Status:      models.ShipmentStatusSUBMITTED,
+			ActualPickupDate: &pickupDate,
+			SourceGBLOC:      &sourceGBLOC2,
+			BookDate:         &testdatagen.DateInsidePerformancePeriod,
+			Status:           models.ShipmentStatusSUBMITTED,
 		},
 	})
 

--- a/pkg/models/move_test.go
+++ b/pkg/models/move_test.go
@@ -63,7 +63,7 @@ func (suite *ModelSuite) TestFetchMove() {
 	shipment := testdatagen.MakeShipment(suite.db, testdatagen.Assertions{
 		Shipment: Shipment{
 			RequestedPickupDate:     &pickupDate,
-			PickupDate:              &pickupDate,
+			ActualPickupDate:        &pickupDate,
 			DeliveryDate:            &deliveryDate,
 			TrafficDistributionList: &tdl,
 			SourceGBLOC:             &sourceGBLOC,
@@ -155,7 +155,7 @@ func (suite *ModelSuite) TestMoveStateMachine() {
 			MoveID:                  move.ID,
 			Move:                    *move,
 			RequestedPickupDate:     &pickupDate,
-			PickupDate:              &pickupDate,
+			ActualPickupDate:        &pickupDate,
 			DeliveryDate:            &deliveryDate,
 			TrafficDistributionList: &tdl,
 			SourceGBLOC:             &sourceGBLOC,
@@ -275,7 +275,7 @@ func (suite *ModelSuite) TestSaveMoveDependenciesSetsGBLOCSuccess() {
 	shipment := testdatagen.MakeShipment(suite.db, testdatagen.Assertions{
 		Shipment: Shipment{
 			RequestedPickupDate:     &pickupDate,
-			PickupDate:              &pickupDate,
+			ActualPickupDate:        &pickupDate,
 			DeliveryDate:            &deliveryDate,
 			TrafficDistributionList: &tdl,
 			SourceGBLOC:             &sourceGBLOC,

--- a/pkg/models/shipment.go
+++ b/pkg/models/shipment.go
@@ -31,6 +31,8 @@ const (
 	ShipmentStatusACCEPTED ShipmentStatus = "ACCEPTED"
 	// ShipmentStatusAPPROVED captures enum value "APPROVED"
 	ShipmentStatusAPPROVED ShipmentStatus = "APPROVED"
+	// ShipmentStatusINTRANSIT captures enum value "INTRANSIT"
+	ShipmentStatusINTRANSIT ShipmentStatus = "IN_TRANSIT"
 )
 
 // Shipment represents a single shipment within a Service Member's move.
@@ -137,6 +139,15 @@ func (s *Shipment) Approve() error {
 		return errors.Wrap(ErrInvalidTransition, "Approve")
 	}
 	s.Status = ShipmentStatusAPPROVED
+	return nil
+}
+
+// Transport marks the Shipment request as In Transit. Must be in an Approved state.
+func (s *Shipment) Transport() error {
+	if s.Status != ShipmentStatusAPPROVED {
+		return errors.Wrap(ErrInvalidTransition, "In Transit")
+	}
+	s.Status = ShipmentStatusINTRANSIT
 	return nil
 }
 

--- a/pkg/models/shipment.go
+++ b/pkg/models/shipment.go
@@ -36,7 +36,7 @@ const (
 )
 
 // Shipment represents a single shipment within a Service Member's move.
-// PickupDate: when the shipment is currently scheduled to be picked up by the TSP
+// ActualPickupDate: when the shipment is currently scheduled to be picked up by the TSP
 // RequestedPickupDate: when the shipment was originally scheduled to be picked up
 // DeliveryDate: when the shipment is to be delivered
 // BookDate: when the shipment was most recently offered to a TSP
@@ -46,7 +46,7 @@ type Shipment struct {
 	TrafficDistributionList             *TrafficDistributionList `belongs_to:"traffic_distribution_list"`
 	ServiceMemberID                     uuid.UUID                `json:"service_member_id" db:"service_member_id"`
 	ServiceMember                       *ServiceMember           `belongs_to:"service_member"`
-	PickupDate                          *time.Time               `json:"pickup_date" db:"pickup_date"`
+	ActualPickupDate                    *time.Time               `json:"actual_pickup_date" db:"actual_pickup_date"`
 	DeliveryDate                        *time.Time               `json:"delivery_date" db:"delivery_date"`
 	CreatedAt                           time.Time                `json:"created_at" db:"created_at"`
 	UpdatedAt                           time.Time                `json:"updated_at" db:"updated_at"`
@@ -314,9 +314,9 @@ func FetchShipmentsByTSP(tx *pop.Connection, tspID uuid.UUID, status []string, o
 	if orderBy != nil {
 		switch *orderBy {
 		case "PICKUP_DATE_ASC":
-			*orderBy = "pickup_date ASC"
+			*orderBy = "actual_pickup_date ASC"
 		case "PICKUP_DATE_DESC":
-			*orderBy = "pickup_date DESC"
+			*orderBy = "actual_pickup_date DESC"
 		case "DELIVERY_DATE_ASC":
 			*orderBy = "delivery_date ASC"
 		case "DELIVERY_DATE_DESC":

--- a/pkg/models/shipment_offer_test.go
+++ b/pkg/models/shipment_offer_test.go
@@ -32,7 +32,7 @@ func (suite *ModelSuite) Test_CreateShipmentOffer() {
 	shipment := testdatagen.MakeShipment(suite.db, testdatagen.Assertions{
 		Shipment: Shipment{
 			RequestedPickupDate:     &pickupDate,
-			PickupDate:              &pickupDate,
+			ActualPickupDate:        &pickupDate,
 			DeliveryDate:            &deliveryDate,
 			TrafficDistributionList: &tdl,
 			SourceGBLOC:             &sourceGBLOC,

--- a/pkg/models/shipment_test.go
+++ b/pkg/models/shipment_test.go
@@ -48,7 +48,7 @@ func (suite *ModelSuite) Test_FetchUnofferedShipments() {
 	shipment := testdatagen.MakeShipment(suite.db, testdatagen.Assertions{
 		Shipment: Shipment{
 			RequestedPickupDate:     &pickupDate,
-			PickupDate:              &pickupDate,
+			ActualPickupDate:        &pickupDate,
 			DeliveryDate:            &deliveryDate,
 			TrafficDistributionList: &tdl,
 			SourceGBLOC:             &sourceGBLOC,
@@ -60,7 +60,7 @@ func (suite *ModelSuite) Test_FetchUnofferedShipments() {
 	shipment2 := testdatagen.MakeShipment(suite.db, testdatagen.Assertions{
 		Shipment: Shipment{
 			RequestedPickupDate:     &pickupDate,
-			PickupDate:              &pickupDate,
+			ActualPickupDate:        &pickupDate,
 			DeliveryDate:            &deliveryDate,
 			TrafficDistributionList: &tdl,
 			SourceGBLOC:             &sourceGBLOC,
@@ -104,6 +104,11 @@ func (suite *ModelSuite) TestShipmentStateMachine() {
 	err = shipment.Approve()
 	suite.Nil(err)
 	suite.Equal(ShipmentStatusAPPROVED, shipment.Status, "expected Approved")
+
+	// Can transport shipment
+	err = shipment.Transport()
+	suite.Nil(err)
+	suite.Equal(ShipmentStatusINTRANSIT, shipment.Status, "expected In Transit")
 }
 
 // TestAcceptShipmentForTSP tests that a shipment and shipment offer is correctly accepted

--- a/pkg/testdatagen/make_shipment_offer_records.go
+++ b/pkg/testdatagen/make_shipment_offer_records.go
@@ -166,7 +166,7 @@ func CreateShipmentOfferData(db *pop.Connection, numTspUsers int, numShipments i
 			},
 			Shipment: models.Shipment{
 				RequestedPickupDate:     &now,
-				PickupDate:              &nowPlusOne,
+				ActualPickupDate:        &nowPlusOne,
 				DeliveryDate:            &nowPlusTwo,
 				TrafficDistributionList: &tdl,
 				SourceGBLOC:             &sourceGBLOC,

--- a/pkg/testdatagen/make_shipment_records.go
+++ b/pkg/testdatagen/make_shipment_records.go
@@ -51,7 +51,7 @@ func MakeShipment(db *pop.Connection, assertions Assertions) models.Shipment {
 		TrafficDistributionList:      tdl,
 		ServiceMemberID:              serviceMember.ID,
 		ServiceMember:                serviceMember,
-		PickupDate:                   timePointer(DateInsidePerformancePeriod),
+		ActualPickupDate:             timePointer(DateInsidePerformancePeriod),
 		DeliveryDate:                 timePointer(DateOutsidePerformancePeriod),
 		SourceGBLOC:                  stringPointer(DefaultSrcGBLOC),
 		DestinationGBLOC:             stringPointer(DefaultSrcGBLOC),
@@ -114,7 +114,7 @@ func MakeShipmentData(db *pop.Connection) {
 	MakeShipment(db, Assertions{
 		Shipment: models.Shipment{
 			RequestedPickupDate:     &now,
-			PickupDate:              &now,
+			ActualPickupDate:        &now,
 			DeliveryDate:            &now,
 			TrafficDistributionList: &tdlList[0],
 			SourceGBLOC:             &sourceGBLOC,
@@ -125,7 +125,7 @@ func MakeShipmentData(db *pop.Connection) {
 	MakeShipment(db, Assertions{
 		Shipment: models.Shipment{
 			RequestedPickupDate:     &nowPlusOne,
-			PickupDate:              &nowPlusOne,
+			ActualPickupDate:        &nowPlusOne,
 			DeliveryDate:            &nowPlusOne,
 			TrafficDistributionList: &tdlList[1],
 			SourceGBLOC:             &sourceGBLOC,
@@ -136,7 +136,7 @@ func MakeShipmentData(db *pop.Connection) {
 	MakeShipment(db, Assertions{
 		Shipment: models.Shipment{
 			RequestedPickupDate:     &nowPlusTwo,
-			PickupDate:              &nowPlusTwo,
+			ActualPickupDate:        &nowPlusTwo,
 			DeliveryDate:            &nowPlusTwo,
 			TrafficDistributionList: &tdlList[2],
 			SourceGBLOC:             &sourceGBLOC,

--- a/pkg/testdatagen/scenario/awardqueue.go
+++ b/pkg/testdatagen/scenario/awardqueue.go
@@ -36,7 +36,7 @@ func RunAwardQueueScenario1(db *pop.Connection) {
 		testdatagen.MakeShipment(db, testdatagen.Assertions{
 			Shipment: models.Shipment{
 				RequestedPickupDate:     &now,
-				PickupDate:              &now,
+				ActualPickupDate:        &now,
 				DeliveryDate:            &now,
 				TrafficDistributionList: &tdl,
 				SourceGBLOC:             &sourceGBLOC,
@@ -93,7 +93,7 @@ func RunAwardQueueScenario2(db *pop.Connection) {
 		testdatagen.MakeShipment(db, testdatagen.Assertions{
 			Shipment: models.Shipment{
 				RequestedPickupDate:     &shipmentDate,
-				PickupDate:              &shipmentDate,
+				ActualPickupDate:        &shipmentDate,
 				DeliveryDate:            &shipmentDate,
 				TrafficDistributionList: &tdl,
 				SourceGBLOC:             &sourceGBLOC,
@@ -106,7 +106,7 @@ func RunAwardQueueScenario2(db *pop.Connection) {
 		testdatagen.MakeShipment(db, testdatagen.Assertions{
 			Shipment: models.Shipment{
 				RequestedPickupDate:     &shipmentDate,
-				PickupDate:              &shipmentDate,
+				ActualPickupDate:        &shipmentDate,
 				DeliveryDate:            &shipmentDate,
 				TrafficDistributionList: &tdl2,
 				SourceGBLOC:             &sourceGBLOC,

--- a/pkg/testdatagen/scenario/e2ebasic.go
+++ b/pkg/testdatagen/scenario/e2ebasic.go
@@ -533,4 +533,45 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader) {
 	hhg5.Move.Submit()
 	models.SaveMoveDependencies(db, &hhg5.Move)
 
+	/*
+	 * Service member with accepted shipment
+	 */
+	email = "hhg@in.transit"
+
+	offer6 := testdatagen.MakeShipmentOffer(db, testdatagen.Assertions{
+		User: models.User{
+			ID:            uuid.Must(uuid.FromString("1239dd2a-a23f-4967-a035-3bc9987c6848")),
+			LoginGovEmail: email,
+		},
+		ServiceMember: models.ServiceMember{
+			ID:            uuid.FromStringOrNil("2339dd2a-a23f-4967-a035-3bc9987c6824"),
+			FirstName:     models.StringPointer("HHG"),
+			LastName:      models.StringPointer("ReadyForApprove"),
+			Edipi:         models.StringPointer("4444567890"),
+			PersonalEmail: models.StringPointer(email),
+		},
+		Move: models.Move{
+			ID:               uuid.FromStringOrNil("3452270d-4a6f-44ea-82f6-ae3cf3277c5d"),
+			Locator:          "NINOPK",
+			SelectedMoveType: models.StringPointer("HHG"),
+		},
+		TrafficDistributionList: models.TrafficDistributionList{
+			ID:                uuid.FromStringOrNil("459f8b8b-67a6-4ce3-b5c3-bd48c82512fc"),
+			SourceRateArea:    "US62",
+			DestinationRegion: "11",
+			CodeOfService:     "D",
+		},
+		Shipment: models.Shipment{
+			Status: models.ShipmentStatusINTRANSIT,
+		},
+		ShipmentOffer: models.ShipmentOffer{
+			TransportationServiceProviderID: tspUser.TransportationServiceProviderID,
+			Accepted:                        models.BoolPointer(true),
+		},
+	})
+
+	hhg6 := offer6.Shipment
+	hhg6.Move.Submit()
+	models.SaveMoveDependencies(db, &hhg6.Move)
+
 }

--- a/src/scenes/Office/QueueList.jsx
+++ b/src/scenes/Office/QueueList.jsx
@@ -23,6 +23,11 @@ export default class QueueList extends Component {
             </NavLink>
           </li>
           <li>
+            <NavLink to="/queues/hhg_in_transit" activeClassName="usa-current">
+              <span>HHGs In Transit</span>
+            </NavLink>
+          </li>
+          <li>
             <NavLink to="/queues/all" activeClassName="usa-current">
               <span>All Moves</span>
             </NavLink>

--- a/src/scenes/Office/QueueTable.jsx
+++ b/src/scenes/Office/QueueTable.jsx
@@ -60,6 +60,7 @@ class QueueTable extends Component {
       troubleshooting: 'Troubleshooting',
       ppm: 'PPMs',
       hhg_accepted: 'Accepted HHGs',
+      hhg_in_transit: 'HHGs In Transit',
       all: 'All Moves',
     };
 

--- a/src/scenes/TransportationServiceProvider/api.js
+++ b/src/scenes/TransportationServiceProvider/api.js
@@ -5,6 +5,7 @@ import { formatPayload } from 'shared/utils';
 export async function RetrieveShipmentsForTSP(queueType) {
   const queueToStatus = {
     new: ['AWARDED'],
+    in_transit: ['IN_TRANSIT'],
     all: [],
   };
   /* eslint-disable security/detect-object-injection */

--- a/src/scenes/TransportationServiceProvider/index.jsx
+++ b/src/scenes/TransportationServiceProvider/index.jsx
@@ -51,12 +51,12 @@ class TspWrapper extends Component {
               <Switch>
                 <Redirect from="/" to="/queues/new" exact />
                 <PrivateRoute
-                  path="/queues/:queueType(new|all)/shipments/:shipmentId"
+                  path="/queues/:queueType(new|in_transit|all)/shipments/:shipmentId"
                   component={ShipmentInfo}
                 />
                 {/* Be specific about available routes by listing them */}
                 <PrivateRoute
-                  path="/queues/:queueType(new|all)"
+                  path="/queues/:queueType(new|in_transit|all)"
                   component={Queues}
                 />
                 {/* TODO: cgilmer (2018/07/31) Need a NotFound component to route to */}

--- a/swagger/api.yaml
+++ b/swagger/api.yaml
@@ -415,7 +415,7 @@ definitions:
       service_member:
         $ref: '#/definitions/ServiceMember'
         readOnly: true
-      pickup_date:
+      actual_pickup_date:
         type: string
         format: date-time
         example: 2018-04-21T17:32:28Z
@@ -734,7 +734,7 @@ definitions:
         type: string
         format: date
         example: 2018-03-15
-      actual_pickup:
+      actual_pickup_date:
         type: string
         format: date
         example: 2018-03-15
@@ -776,13 +776,13 @@ definitions:
       DELIVERED: Delivered
       COMPLETED: Completed
       CANCELED: Canceled
-  PickupDate:
+  ActualPickupDate:
     type: object
     properties:
       actual_pickup_date:
         type: string
         format: date
-        example: 2018-03-15
+        example: "2018-04-02"
         x-nullable: true
     required:
       - actual_pickup_date
@@ -1281,9 +1281,9 @@ paths:
             $ref: '#/definitions/Shipment'
         500:
           description: server error
-  /shipments/{shipmentId}/in_transit:
+  /shipments/{shipmentId}/transport:
     post:
-      summary: Places an accepted shipment in transit
+      summary: Places an accepted shipment into transit state
       description: Places a shipment accepted by a TSP in transit. The status of the shipment will be updated to IN_TRANSIT.
       operationId: transportShipment
       tags:
@@ -1299,7 +1299,7 @@ paths:
           name: actualPickupDate
           required: true
           schema:
-            $ref: '#/definitions/PickupDate'
+            $ref: '#/definitions/ActualPickupDate'
       responses:
         200:
           description: returns updated (in_transit) shipment object

--- a/swagger/api.yaml
+++ b/swagger/api.yaml
@@ -776,6 +776,16 @@ definitions:
       DELIVERED: Delivered
       COMPLETED: Completed
       CANCELED: Canceled
+  PickupDate:
+    type: object
+    properties:
+      actual_pickup_date:
+        type: string
+        format: date
+        example: 2018-03-15
+        x-nullable: true
+    required:
+      - actual_pickup_date
   TSP:
     type: object
     description: The primary definition of a Transport Service Provider
@@ -1257,6 +1267,42 @@ paths:
       responses:
         200:
           description: returns updated (accepted) shipment object
+          schema:
+            $ref: '#/definitions/Shipment'
+        400:
+          description: invalid request
+        401:
+          description: must be authenticated to use this endpoint
+        403:
+          description: not authorized to accept this shipment
+        409:
+          description: the shipment is not in a state to be accepted
+          schema:
+            $ref: '#/definitions/Shipment'
+        500:
+          description: server error
+  /shipments/{shipmentId}/in_transit:
+    post:
+      summary: Places an accepted shipment in transit
+      description: Places a shipment accepted by a TSP in transit. The status of the shipment will be updated to IN_TRANSIT.
+      operationId: transportShipment
+      tags:
+        - shipments
+      parameters:
+        - name: shipmentId
+          in: path
+          type: string
+          format: uuid
+          required: true
+          description: UUID of the shipment
+        - in: body
+          name: actualPickupDate
+          required: true
+          schema:
+            $ref: '#/definitions/PickupDate'
+      responses:
+        200:
+          description: returns updated (in_transit) shipment object
           schema:
             $ref: '#/definitions/Shipment'
         400:

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -1423,7 +1423,7 @@ definitions:
         format: date
         example: "2018-04-26"
         x-nullable: true
-      pickup_date:
+      actual_pickup_date:
         type: string
         format: date
         example: "2018-04-26"
@@ -3761,6 +3761,7 @@ paths:
           - troubleshooting
           - ppm
           - hhg_accepted
+          - hhg_in_transit
           - all
           required: true
           description: Queue type to show

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -1818,11 +1818,13 @@ definitions:
       - SUBMITTED
       - AWARDED
       - APPROVED
+      - IN_TRANSIT
     x-display-value:
       DRAFT: Draft
       SUBMITTED: Submitted
       AWARDED: Awarded
       APPROVED: Approved
+      IN_TRANSIT: In Transit
   PPMStatus:
     type: string
     title: PPM status


### PR DESCRIPTION
## Description

This PR changes Shipment's PickupDate to ActualPickupDate throughout the code, adds an In Transit state to Shipment, and implements the transition from Approved to In Transit on the backend.
It also makes the In Transit queue visible on the office side.
Includes end 2 end test update.

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```
make db_dev_reset && make db_dev_migrate && ./bin/generate-test-data -scenario=7
```
Go to http://tsplocal:3000/api/v1/docs#/shipments/transportShipment and try it out with a shipment that's in the Approved state.
Go to http://officelocal:3000/queues/hhg_in_transit and see that same shipment.

## Code Review Verification Steps

* [x] End to end tests pass (`make e2e_test`).
* [x] Any migrations/schema changes also update the diagram in docs/schema/dp3.sqs (see [Updating and changing the model](https://github.com/transcom/mymove/blob/master/docs/schema/README.md#updating-and-changing-the-model)
* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/160400191) for the backend changes
* [Pivotal story](https://www.pivotaltracker.com/story/show/160394779) for the queue changes

## Screenshots

<img width="1228" alt="screen shot 2018-09-13 at 5 24 48 pm" src="https://user-images.githubusercontent.com/7401870/45522792-22a60980-b77a-11e8-83dc-7ba72e9710a1.png">
