### PR TITLE
Add Approved queue to TSP

### DIFF
--- a/cypress/integration/tsp/tspUser.js
+++ b/cypress/integration/tsp/tspUser.js
@@ -6,6 +6,9 @@ describe('TSP User Views Shipment', function() {
   it('tsp user views shipments in queue new shipments', function() {
     tspUserViewsShipments();
   });
+  it('tsp user views shipments in queue new shipments', function() {
+    tspUserViewsApprovedShipments();
+  });
 });
 
 function tspUserViewsShipments() {
@@ -16,4 +19,23 @@ function tspUserViewsShipments() {
 
   // Find shipment
   cy.get('div').contains('BACON1');
+}
+
+function tspUserViewsApprovedShipments() {
+  // Open accepted shipments queue
+  cy
+    .get('div')
+    .contains('Approved Shipments')
+    .click();
+
+  cy.location().should(loc => {
+    expect(loc.pathname).to.match(/^\/queues\/approved/);
+  });
+
+  // Find shipment
+  cy.get('div').contains('APPRVD');
+  cy
+    .get('div')
+    .contains('BACON1')
+    .should('not.exist');
 }

--- a/pkg/testdatagen/scenario/e2ebasic.go
+++ b/pkg/testdatagen/scenario/e2ebasic.go
@@ -533,4 +533,45 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader) {
 	hhg5.Move.Submit()
 	models.SaveMoveDependencies(db, &hhg5.Move)
 
+	/*
+	 * Service member with accepted shipment
+	 */
+	email = "hhg@approv.ed"
+
+	offer6 := testdatagen.MakeShipmentOffer(db, testdatagen.Assertions{
+		User: models.User{
+			ID:            uuid.Must(uuid.FromString("68461d67-5385-4780-9cb6-417075343b0e")),
+			LoginGovEmail: email,
+		},
+		ServiceMember: models.ServiceMember{
+			ID:            uuid.FromStringOrNil("2825cadf-410f-4f82-aa0f-4caaf000e63e"),
+			FirstName:     models.StringPointer("HHG"),
+			LastName:      models.StringPointer("ReadyForApprove"),
+			Edipi:         models.StringPointer("4444567890"),
+			PersonalEmail: models.StringPointer(email),
+		},
+		Move: models.Move{
+			ID:               uuid.FromStringOrNil("616560f2-7e35-4504-b7e6-69038fb0c015"),
+			Locator:          "APPRVD",
+			SelectedMoveType: models.StringPointer("HHG"),
+		},
+		TrafficDistributionList: models.TrafficDistributionList{
+			ID:                uuid.FromStringOrNil("5fe59be4-45d0-47c7-b426-cf4db9882af7"),
+			SourceRateArea:    "US62",
+			DestinationRegion: "11",
+			CodeOfService:     "D",
+		},
+		Shipment: models.Shipment{
+			Status: models.ShipmentStatusAPPROVED,
+		},
+		ShipmentOffer: models.ShipmentOffer{
+			TransportationServiceProviderID: tspUser.TransportationServiceProviderID,
+			Accepted:                        models.BoolPointer(true),
+		},
+	})
+
+	hhg6 := offer6.Shipment
+	hhg6.Move.Submit()
+	models.SaveMoveDependencies(db, &hhg6.Move)
+
 }

--- a/src/scenes/TransportationServiceProvider/QueueList.jsx
+++ b/src/scenes/TransportationServiceProvider/QueueList.jsx
@@ -13,6 +13,11 @@ export default class QueueList extends Component {
             </NavLink>
           </li>
           <li>
+            <NavLink to="/queues/approved" activeClassName="usa-current">
+              <span>Approved Shipments</span>
+            </NavLink>
+          </li>
+          <li>
             <NavLink to="/queues/all" activeClassName="usa-current">
               <span>All Shipments</span>
             </NavLink>

--- a/src/scenes/TransportationServiceProvider/QueueTable.jsx
+++ b/src/scenes/TransportationServiceProvider/QueueTable.jsx
@@ -55,6 +55,7 @@ class QueueTable extends Component {
   render() {
     const titles = {
       new: 'New Shipments',
+      approved: 'Approved Shipments',
       in_transit: 'In Transit Shipments',
       delivered: 'Delivered Shipments',
       all: 'All Shipments',

--- a/src/scenes/TransportationServiceProvider/api.js
+++ b/src/scenes/TransportationServiceProvider/api.js
@@ -5,6 +5,7 @@ import { formatPayload } from 'shared/utils';
 export async function RetrieveShipmentsForTSP(queueType) {
   const queueToStatus = {
     new: ['AWARDED'],
+    approved: ['APPROVED'],
     all: [],
   };
   /* eslint-disable security/detect-object-injection */

--- a/src/scenes/TransportationServiceProvider/index.jsx
+++ b/src/scenes/TransportationServiceProvider/index.jsx
@@ -51,12 +51,12 @@ class TspWrapper extends Component {
               <Switch>
                 <Redirect from="/" to="/queues/new" exact />
                 <PrivateRoute
-                  path="/queues/:queueType(new|all)/shipments/:shipmentId"
+                  path="/queues/:queueType(new|approved|all)/shipments/:shipmentId"
                   component={ShipmentInfo}
                 />
                 {/* Be specific about available routes by listing them */}
                 <PrivateRoute
-                  path="/queues/:queueType(new|all)"
+                  path="/queues/:queueType(new|approved|all)"
                   component={Queues}
                 />
                 {/* TODO: cgilmer (2018/07/31) Need a NotFound component to route to */}

--- a/swagger/api.yaml
+++ b/swagger/api.yaml
@@ -761,6 +761,7 @@ definitions:
     enum: &SHIPMENTSTATUS
       - AWARDED
       - ACCEPTED
+      - APPROVED
       - REJECTED
       - IN_PROGRESS
       - IN_TRANSIT


### PR DESCRIPTION
## Description

Adds a new queue to the TSP site for approved shipments

## Code Review Verification Steps

* [x] End to end tests pass (`make e2e_test`).
* [x] There are no aXe warnings for UI.
* [ ] This works in IE.
* [ ] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/159670577) for this change
