### PR TITLE
Remove repeated service agent email and phone number

### DIFF
--- a/src/scenes/TransportationServiceProvider/ServiceAgents.jsx
+++ b/src/scenes/TransportationServiceProvider/ServiceAgents.jsx
@@ -25,8 +25,6 @@ const ServiceAgentDisplay = props => {
         <PanelSwaggerField fieldName="company" required {...fieldProps} />
         <PanelSwaggerField fieldName="email" required {...fieldProps} />
         <PanelSwaggerField fieldName="phone_number" required {...fieldProps} />
-        <PanelSwaggerField fieldName="email" required {...fieldProps} />
-        <PanelSwaggerField fieldName="phone_number" required {...fieldProps} />
       </div>
     </Fragment>
   );


### PR DESCRIPTION
## Description

The email and phone number in the service agent panel showed up twice, [probably because of a merge conflict](https://github.com/transcom/mymove/commit/2e210dfe01928cc66e83d6d364f5611ac3aa61e6#r30514067).  

<img width="955" alt="screen shot 2018-09-14 at 3 19 21 pm" src="https://user-images.githubusercontent.com/219296/45577714-314ff780-b832-11e8-93a1-c04d62ef5e1b.png">

## Code Review Verification Steps

* [x] End to end tests pass (`make e2e_test`).
* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/160529714) for this change