### PR TITLE
Rek add delivered queues

### DIFF
--- a/cmd/generate_test_data/main.go
+++ b/cmd/generate_test_data/main.go
@@ -73,7 +73,7 @@ func main() {
 		numTspUsers := 2
 		numShipments := 25
 		numShipmentOfferSplit := []int{15, 10}
-		status := []models.ShipmentStatus{"DRAFT", "AWARDED", "ACCEPTED", "IN_TRANSIT"}
+		status := []models.ShipmentStatus{"DRAFT", "AWARDED", "ACCEPTED", "APPROVED", "IN_TRANSIT", "DELIVERED"}
 		_, _, _, err := testdatagen.CreateShipmentOfferData(db, numTspUsers, numShipments, numShipmentOfferSplit, status)
 		if err != nil {
 			log.Panic(err)

--- a/cypress/integration/office/officeUserHHG.js
+++ b/cypress/integration/office/officeUserHHG.js
@@ -45,9 +45,9 @@ function officeUserViewsMoves() {
 
 function officeUserViewsDeliveredShipment() {
   // Open new moves queue
-  cy.visit('/queues/delivered');
+  cy.visit('/queues/hhg_delivered');
   cy.location().should(loc => {
-    expect(loc.pathname).to.match(/^\/queues\/delivered/);
+    expect(loc.pathname).to.match(/^\/queues\/hhg_delivered/);
   });
 
   // Find move (generated in e2ebasic.go) and open it

--- a/cypress/integration/office/officeUserHHG.js
+++ b/cypress/integration/office/officeUserHHG.js
@@ -9,6 +9,9 @@ describe('office user finds the shipment', function() {
   it('office user views accepted hhg moves in queue Accepted HHGs', function() {
     officeUserViewsAcceptedShipment();
   });
+  it('office user views delivered hhg moves in queue Delivered HHGs', function() {
+    officeUserViewsDeliveredShipment();
+  });
   it('office user approves basics for move, verifies and approves HHG shipment', function() {
     officeUserApprovesHHG();
   });
@@ -24,6 +27,33 @@ function officeUserViewsMoves() {
   cy
     .get('div')
     .contains('RLKBEM')
+    .dblclick();
+
+  cy.location().should(loc => {
+    expect(loc.pathname).to.match(/^\/queues\/new\/moves\/[^/]+\/basics/);
+  });
+
+  cy
+    .get('a')
+    .contains('HHG')
+    .click(); // navtab
+
+  cy.location().should(loc => {
+    expect(loc.pathname).to.match(/^\/queues\/new\/moves\/[^/]+\/hhg/);
+  });
+}
+
+function officeUserViewsDeliveredShipment() {
+  // Open new moves queue
+  cy.visit('/queues/delivered');
+  cy.location().should(loc => {
+    expect(loc.pathname).to.match(/^\/queues\/delivered/);
+  });
+
+  // Find move (generated in e2ebasic.go) and open it
+  cy
+    .get('div')
+    .contains('SCHNOO')
     .dblclick();
 
   cy.location().should(loc => {

--- a/cypress/integration/tsp/tspUser.js
+++ b/cypress/integration/tsp/tspUser.js
@@ -9,6 +9,9 @@ describe('TSP User Views Shipment', function() {
   it('tsp user views in transit hhg moves in queue HHGs In Transit', function() {
     tspUserViewsInTransitShipment();
   });
+  it('tsp user views delivered hhg moves in queue HHGs Delivered', function() {
+    tspUserViewsDeliveredShipment();
+  });
 });
 
 function tspUserViewsShipments() {
@@ -36,5 +39,23 @@ function tspUserViewsInTransitShipment() {
 
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/queues\/in_transit\/shipments\/[^/]+/);
+  });
+}
+
+function tspUserViewsDeliveredShipment() {
+  // Open new moves queue
+  cy.visit('/queues/delivered');
+  cy.location().should(loc => {
+    expect(loc.pathname).to.match(/^\/queues\/delivered/);
+  });
+
+  // Find move (generated in e2ebasic.go) and open it
+  cy
+    .get('div')
+    .contains('SCHNOO')
+    .dblclick();
+
+  cy.location().should(loc => {
+    expect(loc.pathname).to.match(/^\/queues\/delivered\/shipments\/[^/]+/);
   });
 }

--- a/cypress/integration/tsp/tspUser.js
+++ b/cypress/integration/tsp/tspUser.js
@@ -21,17 +21,24 @@ function tspUserViewsShipments() {
   });
 
   // Find shipment
-  cy.get('div').contains('BACON1');
+  cy
+    .get('div')
+    .contains('BACON1')
+    .dblclick();
+
+  cy.location().should(loc => {
+    expect(loc.pathname).to.match(/^\/queues\/new\/shipments\/[^/]+/);
+  });
 }
 
 function tspUserViewsInTransitShipment() {
-  // Open new moves queue
+  // Open new shipments queue
   cy.visit('/queues/in_transit');
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/queues\/in_transit/);
   });
 
-  // Find move (generated in e2ebasic.go) and open it
+  // Find in transit (generated in e2ebasic.go) and open it
   cy
     .get('div')
     .contains('NINOPK')
@@ -43,13 +50,13 @@ function tspUserViewsInTransitShipment() {
 }
 
 function tspUserViewsDeliveredShipment() {
-  // Open new moves queue
+  // Open new shipments queue
   cy.visit('/queues/delivered');
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/queues\/delivered/);
   });
 
-  // Find move (generated in e2ebasic.go) and open it
+  // Find delivered shipment (generated in e2ebasic.go) and open it
   cy
     .get('div')
     .contains('SCHNOO')

--- a/pkg/models/queue.go
+++ b/pkg/models/queue.go
@@ -91,8 +91,7 @@ func GetMoveQueueItems(db *pop.Connection, lifecycleState string) ([]MoveQueueIt
 			WHERE shipment.status = 'ACCEPTED'
 		`
 	} else if lifecycleState == "hhg_in_transit" {
-		// Move date is the Requested Pickup Date because accepted shipments haven't yet gone through the
-		// premove survey to set the actual Pickup Date.
+		// Move date is the Actual Pickup Date.
 		query = `
 			SELECT moves.ID,
 				COALESCE(sm.edipi, '*missing*') as edipi,
@@ -100,7 +99,7 @@ func GetMoveQueueItems(db *pop.Connection, lifecycleState string) ([]MoveQueueIt
 				CONCAT(COALESCE(sm.last_name, '*missing*'), ', ', COALESCE(sm.first_name, '*missing*')) AS customer_name,
 				moves.locator as locator,
 				ord.orders_type as orders_type,
-				shipment.requested_pickup_date as move_date,
+				shipment.actual_pickup_date as move_date,
 				moves.created_at as created_at,
 				moves.updated_at as last_modified_date,
 				moves.status as status,
@@ -110,6 +109,26 @@ func GetMoveQueueItems(db *pop.Connection, lifecycleState string) ([]MoveQueueIt
 			JOIN service_members AS sm ON ord.service_member_id = sm.id
 			LEFT JOIN shipments as shipment ON moves.id = shipment.move_id
 			WHERE shipment.status = 'IN_TRANSIT'
+		`
+	} else if lifecycleState == "hhg_delivered" {
+		// Move date is the Actual Pickup Date.
+		query = `
+			SELECT moves.ID,
+				COALESCE(sm.edipi, '*missing*') as edipi,
+				COALESCE(sm.rank, '*missing*') as rank,
+				CONCAT(COALESCE(sm.last_name, '*missing*'), ', ', COALESCE(sm.first_name, '*missing*')) AS customer_name,
+				moves.locator as locator,
+				ord.orders_type as orders_type,
+				shipment.actual_pickup_date as move_date,
+				moves.created_at as created_at,
+				moves.updated_at as last_modified_date,
+				moves.status as status,
+				shipment.status as hhg_status
+			FROM moves
+			JOIN orders as ord ON moves.orders_id = ord.id
+			JOIN service_members AS sm ON ord.service_member_id = sm.id
+			LEFT JOIN shipments as shipment ON moves.id = shipment.move_id
+			WHERE shipment.status = 'DELIVERED'
 		`
 	} else if lifecycleState == "all" {
 		query = `

--- a/pkg/models/shipment.go
+++ b/pkg/models/shipment.go
@@ -30,8 +30,10 @@ const (
 	ShipmentStatusACCEPTED ShipmentStatus = "ACCEPTED"
 	// ShipmentStatusAPPROVED captures enum value "APPROVED"
 	ShipmentStatusAPPROVED ShipmentStatus = "APPROVED"
-	// ShipmentStatusINTRANSIT captures enum value "INTRANSIT"
+	// ShipmentStatusINTRANSIT captures enum value "IN_TRANSIT"
 	ShipmentStatusINTRANSIT ShipmentStatus = "IN_TRANSIT"
+	// ShipmentStatusDELIVERED captures enum value "DELIVERED"
+	ShipmentStatusDELIVERED ShipmentStatus = "DELIVERED"
 )
 
 // Shipment represents a single shipment within a Service Member's move.

--- a/pkg/testdatagen/make_shipment_offer_records.go
+++ b/pkg/testdatagen/make_shipment_offer_records.go
@@ -136,6 +136,7 @@ func CreateShipmentOfferData(db *pop.Connection, numTspUsers int, numShipments i
 			models.ShipmentStatusSUBMITTED,
 			models.ShipmentStatusAWARDED,
 			models.ShipmentStatusACCEPTED,
+			models.ShipmentStatusAPPROVED,
 			models.ShipmentStatusINTRANSIT,
 			models.ShipmentStatusDELIVERED}
 	}

--- a/pkg/testdatagen/make_shipment_offer_records.go
+++ b/pkg/testdatagen/make_shipment_offer_records.go
@@ -135,7 +135,9 @@ func CreateShipmentOfferData(db *pop.Connection, numTspUsers int, numShipments i
 			models.ShipmentStatusDRAFT,
 			models.ShipmentStatusSUBMITTED,
 			models.ShipmentStatusAWARDED,
-			models.ShipmentStatusACCEPTED}
+			models.ShipmentStatusACCEPTED,
+			models.ShipmentStatusINTRANSIT,
+			models.ShipmentStatusDELIVERED}
 	}
 	for i := 1; i <= numShipments; i++ {
 		now := time.Now()

--- a/pkg/testdatagen/scenario/e2ebasic.go
+++ b/pkg/testdatagen/scenario/e2ebasic.go
@@ -527,7 +527,7 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader) {
 	models.SaveMoveDependencies(db, &hhg5.Move)
 
 	/*
-	 * Service member with accepted shipment
+	 * Service member with in transit shipment
 	 */
 	email = "hhg@in.transit"
 
@@ -655,4 +655,46 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader) {
 	})
 	hhg8.Move.Submit()
 	models.SaveMoveDependencies(db, &hhg8.Move)
+
+	/*
+	 * Service member with delivered shipment
+	 */
+	email = "hhg@de.livered"
+
+	offer8 := testdatagen.MakeShipmentOffer(db, testdatagen.Assertions{
+		User: models.User{
+			ID:            uuid.Must(uuid.FromString("3439dd2a-a23f-4967-a035-3bc9987c6848")),
+			LoginGovEmail: email,
+		},
+		ServiceMember: models.ServiceMember{
+			ID:            uuid.FromStringOrNil("4539dd2a-a23f-4967-a035-3bc9987c6824"),
+			FirstName:     models.StringPointer("HHG"),
+			LastName:      models.StringPointer("ReadyForApprove"),
+			Edipi:         models.StringPointer("4444567890"),
+			PersonalEmail: models.StringPointer(email),
+		},
+		Move: models.Move{
+			ID:               uuid.FromStringOrNil("5652270d-4a6f-44ea-82f6-ae3cf3277c5d"),
+			Locator:          "SCHNOO",
+			SelectedMoveType: models.StringPointer("HHG"),
+		},
+		TrafficDistributionList: models.TrafficDistributionList{
+			ID:                uuid.FromStringOrNil("679f8b8b-67a6-4ce3-b5c3-bd48c82512fc"),
+			SourceRateArea:    "US62",
+			DestinationRegion: "11",
+			CodeOfService:     "D",
+		},
+		Shipment: models.Shipment{
+			Status: models.ShipmentStatusDELIVERED,
+		},
+		ShipmentOffer: models.ShipmentOffer{
+			TransportationServiceProviderID: tspUser.TransportationServiceProviderID,
+			Accepted:                        models.BoolPointer(true),
+		},
+	})
+
+	hhg9 := offer8.Shipment
+	hhg9.Move.Submit()
+	models.SaveMoveDependencies(db, &hhg9.Move)
+
 }

--- a/pkg/testdatagen/scenario/e2ebasic.go
+++ b/pkg/testdatagen/scenario/e2ebasic.go
@@ -661,25 +661,25 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader) {
 	 */
 	email = "hhg@de.livered"
 
-	offer8 := testdatagen.MakeShipmentOffer(db, testdatagen.Assertions{
+	offer9 := testdatagen.MakeShipmentOffer(db, testdatagen.Assertions{
 		User: models.User{
-			ID:            uuid.Must(uuid.FromString("3439dd2a-a23f-4967-a035-3bc9987c6848")),
+			ID:            uuid.Must(uuid.FromString("3339dd2a-a23f-4967-a035-3bc9987c6848")),
 			LoginGovEmail: email,
 		},
 		ServiceMember: models.ServiceMember{
-			ID:            uuid.FromStringOrNil("4539dd2a-a23f-4967-a035-3bc9987c6824"),
+			ID:            uuid.FromStringOrNil("2559dd2a-a23f-4967-a035-3bc9987c6824"),
 			FirstName:     models.StringPointer("HHG"),
 			LastName:      models.StringPointer("ReadyForApprove"),
 			Edipi:         models.StringPointer("4444567890"),
 			PersonalEmail: models.StringPointer(email),
 		},
 		Move: models.Move{
-			ID:               uuid.FromStringOrNil("5652270d-4a6f-44ea-82f6-ae3cf3277c5d"),
+			ID:               uuid.FromStringOrNil("3442270d-4a6f-44ea-82f6-ae3cf3277c5d"),
 			Locator:          "SCHNOO",
 			SelectedMoveType: models.StringPointer("HHG"),
 		},
 		TrafficDistributionList: models.TrafficDistributionList{
-			ID:                uuid.FromStringOrNil("679f8b8b-67a6-4ce3-b5c3-bd48c82512fc"),
+			ID:                uuid.FromStringOrNil("466f8b8b-67a6-4ce3-b5c3-bd48c82512fc"),
 			SourceRateArea:    "US62",
 			DestinationRegion: "11",
 			CodeOfService:     "D",
@@ -693,8 +693,7 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader) {
 		},
 	})
 
-	hhg9 := offer8.Shipment
+	hhg9 := offer9.Shipment
 	hhg9.Move.Submit()
 	models.SaveMoveDependencies(db, &hhg9.Move)
-
 }

--- a/src/scenes/Office/QueueList.jsx
+++ b/src/scenes/Office/QueueList.jsx
@@ -23,6 +23,11 @@ export default class QueueList extends Component {
             </NavLink>
           </li>
           <li>
+            <NavLink to="/queues/hhg_delivered" activeClassName="usa-current">
+              <span>Delivered HHGs</span>
+            </NavLink>
+          </li>
+          <li>
             <NavLink to="/queues/all" activeClassName="usa-current">
               <span>All Moves</span>
             </NavLink>

--- a/src/scenes/Office/QueueTable.jsx
+++ b/src/scenes/Office/QueueTable.jsx
@@ -60,6 +60,7 @@ class QueueTable extends Component {
       troubleshooting: 'Troubleshooting',
       ppm: 'PPMs',
       hhg_accepted: 'Accepted HHGs',
+      hhg_delivered: 'Delivered HHGs',
       all: 'All Moves',
     };
 

--- a/src/scenes/TransportationServiceProvider/QueueList.jsx
+++ b/src/scenes/TransportationServiceProvider/QueueList.jsx
@@ -14,7 +14,12 @@ export default class QueueList extends Component {
           </li>
           <li>
             <NavLink to="/queues/in_transit" activeClassName="usa-current">
-              <span>HHGs In Transit</span>
+              <span>In Transit Shipments</span>
+            </NavLink>
+          </li>
+          <li>
+            <NavLink to="/queues/delivered" activeClassName="usa-current">
+              <span>Delivered Shipments</span>
             </NavLink>
           </li>
           <li>

--- a/src/scenes/TransportationServiceProvider/QueueTable.jsx
+++ b/src/scenes/TransportationServiceProvider/QueueTable.jsx
@@ -55,7 +55,8 @@ class QueueTable extends Component {
   render() {
     const titles = {
       new: 'New Shipments',
-      in_transit: 'HHGs In Transit',
+      in_transit: 'In Transit Shipments',
+      delivered: 'Delivered Shipments',
       all: 'All Shipments',
     };
 

--- a/src/scenes/TransportationServiceProvider/api.js
+++ b/src/scenes/TransportationServiceProvider/api.js
@@ -6,6 +6,7 @@ export async function RetrieveShipmentsForTSP(queueType) {
   const queueToStatus = {
     new: ['AWARDED'],
     in_transit: ['IN_TRANSIT'],
+    delivered: ['DELIVERED'],
     all: [],
   };
   /* eslint-disable security/detect-object-injection */

--- a/src/scenes/TransportationServiceProvider/index.jsx
+++ b/src/scenes/TransportationServiceProvider/index.jsx
@@ -51,12 +51,12 @@ class TspWrapper extends Component {
               <Switch>
                 <Redirect from="/" to="/queues/new" exact />
                 <PrivateRoute
-                  path="/queues/:queueType(new|in_transit|all)/shipments/:shipmentId"
+                  path="/queues/:queueType(new|in_transit|delivered|all)/shipments/:shipmentId"
                   component={ShipmentInfo}
                 />
                 {/* Be specific about available routes by listing them */}
                 <PrivateRoute
-                  path="/queues/:queueType(new|in_transit|all)"
+                  path="/queues/:queueType(new|in_transit|delivered|all)"
                   component={Queues}
                 />
                 {/* TODO: cgilmer (2018/07/31) Need a NotFound component to route to */}

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -3836,6 +3836,7 @@ paths:
           - troubleshooting
           - ppm
           - hhg_accepted
+          - hhg_delivered
           - all
           required: true
           description: Queue type to show


### PR DESCRIPTION
## Description

This makes the queues for DELIVERED shipments available on office and TSP sides. It includes E2E tests as well as the query to load the moves in DELIVERED state.

## Reviewer Notes

It's dependent on this work: https://www.pivotaltracker.com/story/show/160400320; without that, there won't be a way to see anything in the delivered queues in real life. However, you can run test data to view--that works fine. 

## Setup

```
make db_dev_reset && make db_dev_migrate && ./bin/generate-test-data -scenario=7
```

## Code Review Verification Steps

* [ ] End to end tests pass (`make e2e_test`).
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* [ ] There are no aXe warnings for UI.
* [ ] This works in IE.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/160394799) for this change
* [Pivotal story](https://www.pivotaltracker.com/story/show/159670591) for this change

## Screenshots

Office
<img width="843" alt="screen shot 2018-09-14 at 5 05 17 pm" src="https://user-images.githubusercontent.com/7401870/45579910-64998300-b840-11e8-9f78-933f2e3f44c8.png">
TSP
<img width="725" alt="screen shot 2018-09-14 at 5 04 46 pm" src="https://user-images.githubusercontent.com/7401870/45579911-64998300-b840-11e8-9094-3e602fdc6566.png">
