### PR TITLE
Set Shipment.BookDate when it is submitted [delivers #160498349]

### DIFF
--- a/pkg/models/shipment.go
+++ b/pkg/models/shipment.go
@@ -109,6 +109,8 @@ func (s *Shipment) Submit() error {
 	if s.Status != ShipmentStatusDRAFT && s.Status != ShipmentStatusAWARDED {
 		return errors.Wrap(ErrInvalidTransition, "Submit")
 	}
+	now := time.Now()
+	s.BookDate = &now
 	s.Status = ShipmentStatusSUBMITTED
 	return nil
 }

--- a/pkg/models/shipment_test.go
+++ b/pkg/models/shipment_test.go
@@ -106,12 +106,12 @@ func (suite *ModelSuite) TestShipmentStateMachine() {
 	suite.Equal(ShipmentStatusAPPROVED, shipment.Status, "expected Approved")
 }
 
-func (suite *ModelSuite) TestSetBookDateWhenSubmittted() {
-	shipment := testdatagen.MakeShipment(suite.db, testdatagen.Assertions{
-		Shipment: {
-			BookDate: nil,
-		},
-	})
+func (suite *ModelSuite) TestSetBookDateWhenSubmitted() {
+	shipment := testdatagen.MakeDefaultShipment(suite.db)
+
+	// There is not a way to set a field to nil using testdatagen.Assertions
+	shipment.BookDate = nil
+	suite.mustSave(&shipment)
 	suite.Nil(shipment.BookDate)
 
 	// Can submit shipment

--- a/pkg/models/shipment_test.go
+++ b/pkg/models/shipment_test.go
@@ -106,6 +106,20 @@ func (suite *ModelSuite) TestShipmentStateMachine() {
 	suite.Equal(ShipmentStatusAPPROVED, shipment.Status, "expected Approved")
 }
 
+func (suite *ModelSuite) TestSetBookDateWhenSubmittted() {
+	shipment := testdatagen.MakeShipment(suite.db, testdatagen.Assertions{
+		Shipment: {
+			BookDate: nil,
+		},
+	})
+	suite.Nil(shipment.BookDate)
+
+	// Can submit shipment
+	err := shipment.Submit()
+	suite.Nil(err)
+	suite.NotNil(shipment.BookDate)
+}
+
 // TestAcceptShipmentForTSP tests that a shipment and shipment offer is correctly accepted
 func (suite *ModelSuite) TestAcceptShipmentForTSP() {
 	numTspUsers := 1


### PR DESCRIPTION
## Description

`Shipment` models now set their `BookDate` to the current time when `Submit()` is called on them.

## Reviewer Notes

I had to manually set the `BookDate` field to `nil` in the tests as there is no way to set a field to nil using `testdatagen.MakeShipment()`.

## Code Review Verification Steps

* [ ] End to end tests pass (`make e2e_test`).
* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/blob/master/docs/backend.md#logging)
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/160498349) for this change