### PR TITLE
FetchTSPPerformanceForQualityBandAssignment should operate within PerformancePeriods and RateCycles

### DIFF
--- a/pkg/awardqueue/awardqueue.go
+++ b/pkg/awardqueue/awardqueue.go
@@ -184,7 +184,7 @@ func (aq *AwardQueue) assignPerformanceBands() error {
 //
 // This assumes that all TransportationServiceProviderPerformances have been properly created and
 // have a valid BestValueScore.
-func (aq *AwardQueue) assignPerformanceBandsForTSPPerformanceGroup(perfGroup models.TransportationServiceProviderPerformance) error {
+func (aq *AwardQueue) assignPerformanceBandsForTSPPerformanceGroup(perfGroup models.TSPPerformanceGroup) error {
 	aq.logger.Info("Assigning performance bands",
 		zap.Any("traffic_distribution_list_id", perfGroup.TrafficDistributionListID),
 		zap.Any("performance_period_start", perfGroup.PerformancePeriodStart),

--- a/pkg/awardqueue/awardqueue.go
+++ b/pkg/awardqueue/awardqueue.go
@@ -161,33 +161,39 @@ func getTSPsPerBand(count int) []int {
 	return bands
 }
 
-// assignPerformanceBands loops through each TDL and assigns any
-// TransportationServiceProviderPerformances without a quality band to a band.
+// assignPerformanceBands loops through each unique TransportationServiceProviderPerformances group
+// and assigns any unbanded TransportationServiceProviderPerformances to a band.
 func (aq *AwardQueue) assignPerformanceBands() error {
 
-	// for each TDL with pending performances
-	tdls, err := models.FetchTDLsAwaitingBandAssignment(aq.db)
+	perfGroups, err := models.FetchUnbandedTSPPerformanceGroups(aq.db)
 	if err != nil {
 		return err
 	}
 
-	for _, tdl := range tdls {
-		if err := aq.assignPerformanceBandsForTDL(tdl); err != nil {
+	for _, perfGroup := range perfGroups {
+		if err := aq.assignPerformanceBandsForTSPPerformanceGroup(perfGroup); err != nil {
 			return err
 		}
 	}
+
 	return nil
 }
 
-// assignPerformanceBandsForTDL loops through a TDL's TransportationServiceProviderPerformances
+// assignPerformanceBandsForTSPPerformanceGroup loops through the TSPPs for a given TSPP grouping
 // and assigns a QualityBand to each one.
 //
-// This assumes that all TransportationServiceProviderPerformances have been properly
-// created and have a valid BestValueScore.
-func (aq *AwardQueue) assignPerformanceBandsForTDL(tdl models.TrafficDistributionList) error {
-	aq.logger.Info("Assigning performance bands", zap.Object("tdl", tdl))
+// This assumes that all TransportationServiceProviderPerformances have been properly created and
+// have a valid BestValueScore.
+func (aq *AwardQueue) assignPerformanceBandsForTSPPerformanceGroup(perfGroup models.TransportationServiceProviderPerformance) error {
+	aq.logger.Info("Assigning performance bands",
+		zap.Any("traffic_distribution_list_id", perfGroup.TrafficDistributionListID),
+		zap.Any("performance_period_start", perfGroup.PerformancePeriodStart),
+		zap.Any("performance_period_end", perfGroup.PerformancePeriodEnd),
+		zap.Any("rate_cycle_start", perfGroup.RateCycleStart),
+		zap.Any("rate_cycle_end", perfGroup.RateCycleEnd),
+	)
 
-	perfs, err := models.FetchTSPPerformanceForQualityBandAssignment(aq.db, tdl.ID, mps)
+	perfs, err := models.FetchTSPPerformancesForQualityBandAssignment(aq.db, perfGroup, mps)
 	if err != nil {
 		return err
 	}

--- a/pkg/awardqueue/awardqueue_test.go
+++ b/pkg/awardqueue/awardqueue_test.go
@@ -518,7 +518,7 @@ func (suite *AwardQueueSuite) Test_AssignTSPsToBands() {
 		t.Errorf("Failed to assign to performance bands: %v", err)
 	}
 
-	perfGroup := models.TransportationServiceProviderPerformance{
+	perfGroup := models.TSPPerformanceGroup{
 		TrafficDistributionListID: lastTSPP.TrafficDistributionListID,
 		PerformancePeriodStart:    lastTSPP.PerformancePeriodStart,
 		PerformancePeriodEnd:      lastTSPP.PerformancePeriodEnd,

--- a/pkg/models/traffic_distribution_list.go
+++ b/pkg/models/traffic_distribution_list.go
@@ -38,30 +38,6 @@ func (t *TrafficDistributionList) Validate(tx *pop.Connection) (*validate.Errors
 	), nil
 }
 
-// FetchTDLsAwaitingBandAssignment returns TDLs with at least one TransportationServiceProviderPerformance containing a null QualityBand.
-func FetchTDLsAwaitingBandAssignment(db *pop.Connection) (TrafficDistributionLists, error) {
-	tdls := TrafficDistributionLists{}
-
-	sql := `SELECT
-				tdl.*
-			FROM
-				traffic_distribution_lists AS tdl
-			LEFT JOIN
-				transportation_service_provider_performances AS tspp ON
-					tspp.traffic_distribution_list_id = tdl.id
-			WHERE
-				tspp.quality_band IS NULL
-			GROUP BY
-				tdl.id
-			ORDER BY
-				tdl.id
-			`
-
-	err := db.RawQuery(sql).All(&tdls)
-
-	return tdls, err
-}
-
 // MarshalLogObject is required to be able to zap.Object log TDLs
 func (t TrafficDistributionList) MarshalLogObject(encoder zapcore.ObjectEncoder) error {
 	encoder.AddString("src", t.SourceRateArea)

--- a/pkg/models/traffic_distribution_list_test.go
+++ b/pkg/models/traffic_distribution_list_test.go
@@ -19,43 +19,6 @@ func (suite *ModelSuite) Test_TrafficDistributionList() {
 	suite.verifyValidationErrors(tdl, expErrors)
 }
 
-func (suite *ModelSuite) Test_FetchTDLsAwaitingBandAssignment() {
-	t := suite.T()
-
-	foundTDL := testdatagen.MakeTDL(suite.db, testdatagen.Assertions{
-		TrafficDistributionList: TrafficDistributionList{
-			SourceRateArea:    "US14",
-			DestinationRegion: "3",
-			CodeOfService:     "2",
-		},
-	})
-	foundTSP := testdatagen.MakeDefaultTSP(suite.db)
-	testdatagen.MakeTSPPerformance(suite.db, foundTSP, foundTDL, nil, float64(mps+1), 0, .2, .3)
-
-	notFoundTDL := testdatagen.MakeTDL(suite.db, testdatagen.Assertions{
-		TrafficDistributionList: TrafficDistributionList{
-			SourceRateArea:    "US14",
-			DestinationRegion: "5",
-			CodeOfService:     "2",
-		},
-	})
-	notFoundTSP := testdatagen.MakeDefaultTSP(suite.db)
-	testdatagen.MakeTSPPerformance(suite.db, notFoundTSP, notFoundTDL, swag.Int(1), float64(mps+1), 0, .4, .3)
-
-	tdls, err := FetchTDLsAwaitingBandAssignment(suite.db)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if len(tdls) != 1 {
-		t.Errorf("Got wrong number of TDLs; expected: 1, got: %d", len(tdls))
-	}
-
-	if tdls[0].ID != foundTDL.ID {
-		t.Errorf("Got wrong TDL; expected: %s, got: %s", foundTDL.ID, tdls[0].ID)
-	}
-}
-
 func (suite *ModelSuite) Test_FetchTDL() {
 	t := suite.T()
 

--- a/pkg/models/transportation_service_provider_performance.go
+++ b/pkg/models/transportation_service_provider_performance.go
@@ -174,20 +174,12 @@ func FetchTSPPerformanceForQualityBandAssignment(tx *pop.Connection, tdlID uuid.
 
 	// TODO: bookDate and requestedPickupDate should also be qualifiers here. BVSs from different
 	// performance periods and rate areas should be broken up into separate quality bands.
-	sql := `SELECT
-			*
-		FROM
-			transportation_service_provider_performances
-		WHERE
-			traffic_distribution_list_id = $1
-			AND
-			best_value_score > $2
-		ORDER BY
-			best_value_score DESC
-		`
-
-	tsps := TransportationServiceProviderPerformances{}
-	err := tx.RawQuery(sql, tdlID, mps).All(&tsps)
+	var tsps TransportationServiceProviderPerformances
+	err := tx.
+		Where("traffic_distribution_list_id = ?", tdlID).
+		Where("best_value_score > ?", mps).
+		Order("best_value_score DESC").
+		All(&tsps)
 
 	return tsps, err
 }

--- a/pkg/models/transportation_service_provider_performance.go
+++ b/pkg/models/transportation_service_provider_performance.go
@@ -47,6 +47,19 @@ type TransportationServiceProviderPerformance struct {
 // TransportationServiceProviderPerformances is a handy type for multiple TransportationServiceProviderPerformance structs
 type TransportationServiceProviderPerformances []TransportationServiceProviderPerformance
 
+// TSPPerformanceGroup contains the fields required to uniquely identify a TransportationServiceProviderPerformances
+// grouping for quality band assignment (currently done in the award queue).
+type TSPPerformanceGroup struct {
+	TrafficDistributionListID uuid.UUID
+	PerformancePeriodStart    time.Time
+	PerformancePeriodEnd      time.Time
+	RateCycleStart            time.Time
+	RateCycleEnd              time.Time
+}
+
+// TSPPerformanceGroups is a handy type for multiple TSPPerformanceGroup structs
+type TSPPerformanceGroups []TSPPerformanceGroup
+
 // Validate gets run every time you call a "pop.Validate*" (pop.ValidateAndSave, pop.ValidateAndCreate, pop.ValidateAndUpdate) method.
 func (t *TransportationServiceProviderPerformance) Validate(tx *pop.Connection) (*validate.Errors, error) {
 	// Pop can't validate pointers to ints, so turn the pointer into an integer.
@@ -170,7 +183,7 @@ func sortedMapIntKeys(mapWithIntKeys map[int]TransportationServiceProviderPerfor
 
 // FetchTSPPerformancesForQualityBandAssignment returns TSPPs in the given TSPP grouping in the order
 // that they should be assigned quality bands.
-func FetchTSPPerformancesForQualityBandAssignment(tx *pop.Connection, perfGroup TransportationServiceProviderPerformance, mps float64) (TransportationServiceProviderPerformances, error) {
+func FetchTSPPerformancesForQualityBandAssignment(tx *pop.Connection, perfGroup TSPPerformanceGroup, mps float64) (TransportationServiceProviderPerformances, error) {
 	var perfs TransportationServiceProviderPerformances
 	err := tx.
 		Where("traffic_distribution_list_id = ?", perfGroup.TrafficDistributionListID).
@@ -187,14 +200,25 @@ func FetchTSPPerformancesForQualityBandAssignment(tx *pop.Connection, perfGroup 
 
 // FetchUnbandedTSPPerformanceGroups gets all groupings of TSPPs that have at least one entry with
 // an unassigned quality band.
-func FetchUnbandedTSPPerformanceGroups(db *pop.Connection) (TransportationServiceProviderPerformances, error) {
-	var perfGroups TransportationServiceProviderPerformances
+func FetchUnbandedTSPPerformanceGroups(db *pop.Connection) (TSPPerformanceGroups, error) {
+	var perfs TransportationServiceProviderPerformances
 	err := db.
 		Select("traffic_distribution_list_id", "performance_period_start", "performance_period_end", "rate_cycle_start", "rate_cycle_end").
 		Where("quality_band is NULL").
 		GroupBy("traffic_distribution_list_id", "performance_period_start", "performance_period_end", "rate_cycle_start", "rate_cycle_end").
 		Order("traffic_distribution_list_id, performance_period_start, rate_cycle_start").
-		All(&perfGroups)
+		All(&perfs)
+
+	perfGroups := make(TSPPerformanceGroups, len(perfs))
+	for i, perf := range perfs {
+		perfGroups[i] = TSPPerformanceGroup{
+			TrafficDistributionListID: perf.TrafficDistributionListID,
+			PerformancePeriodStart:    perf.PerformancePeriodStart,
+			PerformancePeriodEnd:      perf.PerformancePeriodEnd,
+			RateCycleStart:            perf.RateCycleStart,
+			RateCycleEnd:              perf.RateCycleEnd,
+		}
+	}
 
 	return perfGroups, err
 }

--- a/pkg/models/transportation_service_provider_performance_test.go
+++ b/pkg/models/transportation_service_provider_performance_test.go
@@ -160,7 +160,7 @@ func (suite *ModelSuite) Test_BVSWithLowMPS() {
 	mpsTSP := testdatagen.MakeDefaultTSP(suite.db)
 	lastTSPP, _ := testdatagen.MakeTSPPerformance(suite.db, mpsTSP, tdl, nil, mps-1, 0, .2, .9)
 
-	perfGroup := TransportationServiceProviderPerformance{
+	perfGroup := TSPPerformanceGroup{
 		TrafficDistributionListID: lastTSPP.TrafficDistributionListID,
 		PerformancePeriodStart:    lastTSPP.PerformancePeriodStart,
 		PerformancePeriodEnd:      lastTSPP.PerformancePeriodEnd,
@@ -419,7 +419,7 @@ func (suite *ModelSuite) Test_FetchTSPPerformancesForQualityBandAssignment() {
 	testdatagen.MakeTSPPerformance(suite.db, tsp2, tdl, nil, 50, 1, .3, .9)
 	lastTSPP, _ := testdatagen.MakeTSPPerformance(suite.db, tsp3, tdl, nil, 15, 1, .1, .3)
 
-	perfGroup := TransportationServiceProviderPerformance{
+	perfGroup := TSPPerformanceGroup{
 		TrafficDistributionListID: lastTSPP.TrafficDistributionListID,
 		PerformancePeriodStart:    lastTSPP.PerformancePeriodStart,
 		PerformancePeriodEnd:      lastTSPP.PerformancePeriodEnd,
@@ -457,7 +457,7 @@ func (suite *ModelSuite) Test_MinimumPerformanceScore() {
 	testdatagen.MakeTSPPerformance(suite.db, tsp1, tdl, nil, mps+1, 0, .3, .4)
 	lastTSPP, _ := testdatagen.MakeTSPPerformance(suite.db, tsp2, tdl, nil, mps-1, 1, .9, .7)
 
-	perfGroup := TransportationServiceProviderPerformance{
+	perfGroup := TSPPerformanceGroup{
 		TrafficDistributionListID: lastTSPP.TrafficDistributionListID,
 		PerformancePeriodStart:    lastTSPP.PerformancePeriodStart,
 		PerformancePeriodEnd:      lastTSPP.PerformancePeriodEnd,

--- a/pkg/models/transportation_service_provider_performance_test.go
+++ b/pkg/models/transportation_service_provider_performance_test.go
@@ -158,10 +158,18 @@ func (suite *ModelSuite) Test_BVSWithLowMPS() {
 	}
 	// Make 1 TSP in this TDL with BVS below the MPS threshold
 	mpsTSP := testdatagen.MakeDefaultTSP(suite.db)
-	testdatagen.MakeTSPPerformance(suite.db, mpsTSP, tdl, nil, mps-1, 0, .2, .9)
+	lastTSPP, _ := testdatagen.MakeTSPPerformance(suite.db, mpsTSP, tdl, nil, mps-1, 0, .2, .9)
+
+	perfGroup := TransportationServiceProviderPerformance{
+		TrafficDistributionListID: lastTSPP.TrafficDistributionListID,
+		PerformancePeriodStart:    lastTSPP.PerformancePeriodStart,
+		PerformancePeriodEnd:      lastTSPP.PerformancePeriodEnd,
+		RateCycleStart:            lastTSPP.RateCycleStart,
+		RateCycleEnd:              lastTSPP.RateCycleEnd,
+	}
 
 	// Fetch TSPs in TDL
-	tspsbb, err := FetchTSPPerformanceForQualityBandAssignment(suite.db, tdl.ID, mps)
+	tspsbb, err := FetchTSPPerformancesForQualityBandAssignment(suite.db, perfGroup, mps)
 
 	// Then: Expect to find TSPs in TDL
 	if err != nil {
@@ -397,9 +405,9 @@ func (suite *ModelSuite) Test_GatherNextEligibleTSPPerformances() {
 	}
 }
 
-// Test_FetchTSPPerformanceForQualityBandAssignment ensures that TSPs are returned in the expected
+// Test_FetchTSPPerformancesForQualityBandAssignment ensures that TSPs are returned in the expected
 // order for the division into quality bands.
-func (suite *ModelSuite) Test_FetchTSPPerformanceForQualityBandAssignment() {
+func (suite *ModelSuite) Test_FetchTSPPerformancesForQualityBandAssignment() {
 	t := suite.T()
 
 	tdl := testdatagen.MakeDefaultTDL(suite.db)
@@ -409,9 +417,17 @@ func (suite *ModelSuite) Test_FetchTSPPerformanceForQualityBandAssignment() {
 	// What matter is the BVS score order; offer count has no influence.
 	testdatagen.MakeTSPPerformance(suite.db, tsp1, tdl, nil, 90, 0, .5, .5)
 	testdatagen.MakeTSPPerformance(suite.db, tsp2, tdl, nil, 50, 1, .3, .9)
-	testdatagen.MakeTSPPerformance(suite.db, tsp3, tdl, nil, 15, 1, .1, .3)
+	lastTSPP, _ := testdatagen.MakeTSPPerformance(suite.db, tsp3, tdl, nil, 15, 1, .1, .3)
 
-	tsps, err := FetchTSPPerformanceForQualityBandAssignment(suite.db, tdl.ID, mps)
+	perfGroup := TransportationServiceProviderPerformance{
+		TrafficDistributionListID: lastTSPP.TrafficDistributionListID,
+		PerformancePeriodStart:    lastTSPP.PerformancePeriodStart,
+		PerformancePeriodEnd:      lastTSPP.PerformancePeriodEnd,
+		RateCycleStart:            lastTSPP.RateCycleStart,
+		RateCycleEnd:              lastTSPP.RateCycleEnd,
+	}
+
+	tsps, err := FetchTSPPerformancesForQualityBandAssignment(suite.db, perfGroup, mps)
 
 	if err != nil {
 		t.Errorf("Failed to find TSP: %v", err)
@@ -439,9 +455,17 @@ func (suite *ModelSuite) Test_MinimumPerformanceScore() {
 	tsp2 := testdatagen.MakeDefaultTSP(suite.db)
 	// Make 2 TSPs, one with a BVS above the MPS and one below the MPS.
 	testdatagen.MakeTSPPerformance(suite.db, tsp1, tdl, nil, mps+1, 0, .3, .4)
-	testdatagen.MakeTSPPerformance(suite.db, tsp2, tdl, nil, mps-1, 1, .9, .7)
+	lastTSPP, _ := testdatagen.MakeTSPPerformance(suite.db, tsp2, tdl, nil, mps-1, 1, .9, .7)
 
-	tsps, err := FetchTSPPerformanceForQualityBandAssignment(suite.db, tdl.ID, mps)
+	perfGroup := TransportationServiceProviderPerformance{
+		TrafficDistributionListID: lastTSPP.TrafficDistributionListID,
+		PerformancePeriodStart:    lastTSPP.PerformancePeriodStart,
+		PerformancePeriodEnd:      lastTSPP.PerformancePeriodEnd,
+		RateCycleStart:            lastTSPP.RateCycleStart,
+		RateCycleEnd:              lastTSPP.RateCycleEnd,
+	}
+
+	tsps, err := FetchTSPPerformancesForQualityBandAssignment(suite.db, perfGroup, mps)
 
 	if err != nil {
 		t.Errorf("Failed to find TSP: %v", err)
@@ -452,6 +476,59 @@ func (suite *ModelSuite) Test_MinimumPerformanceScore() {
 			tsp1.ID,
 			tsps[0].TransportationServiceProviderID)
 	}
+}
+
+func (suite *ModelSuite) Test_FetchUnbandedTSPPerformanceGroups() {
+	t := suite.T()
+
+	foundTDL := testdatagen.MakeTDL(suite.db, testdatagen.Assertions{
+		TrafficDistributionList: TrafficDistributionList{
+			SourceRateArea:    "US14",
+			DestinationRegion: "3",
+			CodeOfService:     "2",
+		},
+	})
+	foundTSP := testdatagen.MakeDefaultTSP(suite.db)
+	foundTSPP, err := testdatagen.MakeTSPPerformance(suite.db, foundTSP, foundTDL, nil, float64(mps+1), 0, .2, .3)
+	if err != nil {
+		t.Errorf("Failed to MakeTSPPerformance for found TSPP: %v", err)
+	}
+	foundPerfGroup := TransportationServiceProviderPerformance{
+		TrafficDistributionListID: foundTSPP.TrafficDistributionListID,
+		PerformancePeriodStart:    foundTSPP.PerformancePeriodStart,
+		PerformancePeriodEnd:      foundTSPP.PerformancePeriodEnd,
+		RateCycleStart:            foundTSPP.RateCycleStart,
+		RateCycleEnd:              foundTSPP.RateCycleEnd,
+	}
+
+	notFoundTDL := testdatagen.MakeTDL(suite.db, testdatagen.Assertions{
+		TrafficDistributionList: TrafficDistributionList{
+			SourceRateArea:    "US14",
+			DestinationRegion: "5",
+			CodeOfService:     "2",
+		},
+	})
+	notFoundTSP := testdatagen.MakeDefaultTSP(suite.db)
+	testdatagen.MakeTSPPerformance(suite.db, notFoundTSP, notFoundTDL, swag.Int(1), float64(mps+1), 0, .4, .3)
+
+	perfGroups, err := FetchUnbandedTSPPerformanceGroups(suite.db)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	suite.Len(perfGroups, 1, "Got wrong number of TSPP groups; expected: 1, got: %d",
+		len(perfGroups))
+
+	suite.Equal(perfGroups[0].TrafficDistributionListID, foundPerfGroup.TrafficDistributionListID,
+		"TrafficDistributionListID in TSPP group did not match")
+	suite.True(perfGroups[0].PerformancePeriodStart.Equal(foundPerfGroup.PerformancePeriodStart),
+		"PerformancePeriodStart in TSPP group did not match")
+	suite.True(perfGroups[0].PerformancePeriodEnd.Equal(foundPerfGroup.PerformancePeriodEnd),
+		"PerformancePeriodEnd in TSPP group did not match")
+	suite.True(perfGroups[0].RateCycleStart.Equal(foundPerfGroup.RateCycleStart),
+		"RateCycleStart in TSPP group did not match")
+	suite.True(perfGroups[0].RateCycleEnd.Equal(foundPerfGroup.RateCycleEnd),
+		"RateCycleEnd in TSPP group did not match")
 }
 
 // Test_FetchDiscountRates tests that the discount rate for the TSP with the best BVS


### PR DESCRIPTION
## Description

In the Award Queue (AQ), we currently group TransportationServiceProviderPerformance (TSPP) records by TDL and then assign quality bands to the records within each grouping.  The quality bands are then used to determine the order in which TSPs are awarded shipments.  This PR adjusts that TSPP grouping so that it also includes the performance period start/end and the rate cycle start/end.  In other words, with this PR, all TSPPs that go through a quality band assignment algorithm will be in the same TDL as well as have the same performance period and rate cycle dates.

## Reviewer Notes

Some method names were changed to better reflect their purpose.  I also converted some raw SQL calls to use Pop query methods.

## Setup

In addition to the server tests, you can also run the AQ manually from the command line:

```
make tsp_run
```

Every TSPP record in the baseline data has a null quality band.  After running the AQ, you should see an appropriate quality band assigned to every TSPP record.

## Code Review Verification Steps

* [ ] End to end tests pass (`make e2e_test`).
* [ ] Code follows the guidelines for [Logging](./docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](./docs/backend.md#querying-the-database-safely)
 have been satisfied.
* [ ] Request review from a member of a different team.

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/156361948) for this change