### PR TITLE
Fix shellcheck findings

### DIFF
--- a/bin/ecs-deploy-service-container
+++ b/bin/ecs-deploy-service-container
@@ -79,7 +79,7 @@ readonly db_host
 
 # Get the client auth CA certificate
 echo "* Looking up client auth CA certificate"
-https_client_auth_ca_cert=$(cat "$DIR"/../config/tls/dod-sw-ca-38.pem | awk '{printf "%s\\n", $0}')
+https_client_auth_ca_cert=$(awk '{printf "%s\\n", $0}' "$DIR"/../config/tls/dod-sw-ca-38.pem)
 
 # $DIR/../cmd/renderer/main.go builds its template context from (1) environment variables, (2) file at -v FILE, and (3) positional command line args.
 container_definition_json=$(go run "$DIR"/../cmd/renderer/main.go -t "$template" -v "$DIR"/../config/env/"${environment}".env environment="$environment" image="$image" db_host="$db_host" domain="$domain" https_client_auth_ca_cert="$https_client_auth_ca_cert")

--- a/bin/gen_model
+++ b/bin/gen_model
@@ -6,6 +6,6 @@
 # This does not appear to work for running migrations, just generating models.
 # To run migrations, use `make db_dev_migrate`
 
-cd pkg
+cd pkg || exit
 
 ../bin/soda generate model "$@" --path ../migrations -c ../config/database.yml

--- a/bin/pre-commit-spellcheck
+++ b/bin/pre-commit-spellcheck
@@ -12,7 +12,7 @@ GREEN='\033[0;32m'
 NC='\033[0m'
 export FORCE_COLOR=true
 
-node_modules/.bin/mdspell --ignore-numbers --ignore-acronyms --en-us -r $@
+node_modules/.bin/mdspell --ignore-numbers --ignore-acronyms --en-us -r "$@"
 
 exitCode=$?
 if [ ! ${exitCode} -eq 0 ]; then

--- a/bin/psql
+++ b/bin/psql
@@ -7,7 +7,7 @@ db_password="mysecretpassword"
 command="${*:-}"
 
 if [ -n "${command[*]}" ]; then
-  exec psql --variable "ON_ERROR_STOP=1" postgres://postgres:${db_password}@localhost/${DB_NAME} -c "${command}"
+  exec psql --variable "ON_ERROR_STOP=1" postgres://postgres:"${db_password}"@localhost/"${DB_NAME}" -c "${command}"
 else
-  exec psql --variable "ON_ERROR_STOP=1" postgres://postgres:${db_password}@localhost/${DB_NAME}
+  exec psql --variable "ON_ERROR_STOP=1" postgres://postgres:"${db_password}"@localhost/"${DB_NAME}"
 fi

--- a/bin/psql-dev
+++ b/bin/psql-dev
@@ -1,4 +1,5 @@
 #!/bin/bash
 
 export DB_NAME=dev_db
-. $(dirname "$0")/psql
+# shellcheck source=bin/psql
+. "$(dirname "$0")"/psql

--- a/bin/psql-test
+++ b/bin/psql-test
@@ -1,4 +1,5 @@
 #!/bin/bash
 
 export DB_NAME=test_db
-. $(dirname "$0")/psql
+# shellcheck source=bin/psql
+. "$(dirname "$0")"/psql

--- a/bin/run-prod-migrations
+++ b/bin/run-prod-migrations
@@ -49,8 +49,8 @@ aws s3 ls "${AWS_S3_BUCKET_NAME}/secure-migrations" > /dev/null
 proceed "Running production migrations against the ${DB_NAME} database. This will delete everything in that db."
 
 export PGPASSWORD=${DB_PASSWORD}
-dropdb -h localhost -U postgres -w --if-exists ${DB_NAME}
-createdb -h localhost -U postgres -w ${DB_NAME}
+dropdb -h localhost -U postgres -w --if-exists "${DB_NAME}"
+createdb -h localhost -U postgres -w "${DB_NAME}"
 run make db_dev_migrate || (
   echo "error: migrations failed!"
   exit 1


### PR DESCRIPTION
## Description

Turns out the the shellcheck pre-commit hook wasn't scanning shell script that didn't have a `.sh` suffix. @brainsik pushed a [fix](https://github.com/detailyang/pre-commit-shell/pull/6). This PR goes through and fixes all the shellcheck findings so we can merge https://github.com/transcom/mymove/commit/b7e458d761fa933b5f68d18f1367432bcf641dd1

## Reviewer Notes

It wasn't obvious how much `gen_model` is actually being used, maybe it can be deleted? 

## Code Review Verification Steps

* [x] Request review from a member of a different team.

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/160561056) for this change

