### PR TITLE
Restrict TLS versions and Ciphersuites

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -319,21 +319,21 @@ workflows:
             - build_migrations
           filters:
             branches:
-              only: mk-deploy-app-client-tls
+              only: mk-tls-ciphers
 
       - deploy_experimental_app:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: mk-deploy-app-client-tls
+              only: mk-tls-ciphers
 
       - deploy_experimental_app_client_tls:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: mk-deploy-app-client-tls
+              only: mk-tls-ciphers
 
       - deploy_staging_migrations:
           requires:

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -118,25 +118,24 @@ func (s Server) tlsConfig() (*tls.Config, error) {
 
 	// Follow Mozilla's "modern" server side TLS recommendations
 	// https://wiki.mozilla.org/Security/Server_Side_TLS#Modern_compatibility
-	// https://statics.tls.security.mozilla.org/server-side-tls-conf.json
+	// https://statics.tls.security.mozilla.org/server-side-tls-conf-4.0.json
 	// This configuration is compatible with Firefox 27, Chrome 30, IE 11 on
 	// Windows 7, Edge, Opera 17, Safari 9, Android 5.0, and Java 8
 	tlsConfig := &tls.Config{
 		CipherSuites: []uint16{
 			tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
 			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+			tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
+			tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
 			tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
 			tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-			tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,
-			tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,
 		},
 		Certificates: tlsCerts,
 		ClientAuth:   s.ClientAuthType,
 		ClientCAs:    caCerts,
 		CurvePreferences: []tls.CurveID{
 			tls.CurveP256,
-			tls.CurveP384,
-			tls.CurveP521,
+			tls.X25519,
 		},
 		MinVersion:               tls.VersionTLS12,
 		NextProtos:               []string{"h2"},


### PR DESCRIPTION
## Description
This PR follows Mozilla's [recommendations](https://wiki.mozilla.org/Security/Server_Side_TLS) for a `modern` server side TLS configuration and will apply to the server TLS listener(port 8443) and the mutual TLS listener(port 9443).

## Code Review Verification Steps

* [x] End to end tests pass (`make e2e_test`).
* [x] Request review from a member of a different team.

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/160435694) for this change
* [this article](https://wiki.mozilla.org/Security/Server_Side_TLS) explains more about the approach used.
