### PR TITLE
[WIP] Config & Implementation to Drop Server Log Lines by Prefix

### DIFF
--- a/bin/prereqs
+++ b/bin/prereqs
@@ -15,7 +15,7 @@ function has() {
     fi
 }
 
-has go "brew install go"
+has go "brew install go@1.10"
 has yarn "brew install yarn"
 has dep "brew install dep"
 has pre-commit "brew install pre-commit"

--- a/cmd/webserver/main.go
+++ b/cmd/webserver/main.go
@@ -94,17 +94,22 @@ func main() {
 	config := flag.String("config-dir", "config", "The location of server config files")
 	env := flag.String("env", "development", "The environment to run in, which configures the database.")
 	listenInterface := flag.String("interface", "", "The interface spec to listen for connections on. Default is all.")
+
 	myHostname := flag.String("http_my_server_name", "localhost", "Hostname according to environment.")
 	officeHostname := flag.String("http_office_server_name", "officelocal", "Hostname according to environment.")
 	tspHostname := flag.String("http_tsp_server_name", "tsplocal", "Hostname according to environment.")
 	ordersHostname := flag.String("http_orders_server_name", "orderslocal", "Hostname according to environment.")
-	port := flag.String("port", "8080", "the HTTP `port` to listen on.")
-	internalSwagger := flag.String("internal-swagger", "swagger/internal.yaml", "The location of the internal API swagger definition")
-	apiSwagger := flag.String("swagger", "swagger/api.yaml", "The location of the public API swagger definition")
-	ordersSwagger := flag.String("orders-swagger", "swagger/orders.yaml", "The location of the Orders API swagger definition")
+
+	httpPort := flag.String("port", "8080", "the HTTP `port` to listen on.")
 	debugLogging := flag.Bool("debug_logging", false, "log messages at the debug level.")
 	clientAuthSecretKey := flag.String("client_auth_secret_key", "", "Client auth secret JWT key.")
 	noSessionTimeout := flag.Bool("no_session_timeout", false, "whether user sessions should timeout.")
+
+	httpServerLogLinePrefixDrop := flag.String("http_server_log_line_prefix_drop", "", "drop any log lines with this prefix")
+
+	internalSwagger := flag.String("internal-swagger", "swagger/internal.yaml", "The location of the internal API swagger definition")
+	apiSwagger := flag.String("swagger", "swagger/api.yaml", "The location of the public API swagger definition")
+	ordersSwagger := flag.String("orders-swagger", "swagger/orders.yaml", "The location of the Orders API swagger definition")
 
 	httpsClientAuthPort := flag.String("https_client_auth_port", "9443", "The `port` for the HTTPS listener requiring client authentication.")
 	httpsClientAuthCACert := flag.String("https_client_auth_ca_cert", "", "the CA certificate for the HTTPS listener requiring client authentication.")
@@ -356,7 +361,8 @@ func main() {
 			ListenAddress: *listenInterface,
 			HTTPHandler:   httpHandler,
 			Logger:        logger,
-			Port:          *port,
+			Port:          *httpPort,
+			PrefixToDrop:  *httpServerLogLinePrefixDrop,
 		}
 		errChan <- httpServer.ListenAndServe()
 	}()
@@ -368,6 +374,7 @@ func main() {
 			Logger:         logger,
 			Port:           *httpsPort,
 			TLSCerts:       []server.TLSCert{localhostCert},
+			PrefixToDrop:   *httpServerLogLinePrefixDrop,
 		}
 		errChan <- tlsServer.ListenAndServeTLS()
 	}()
@@ -382,6 +389,7 @@ func main() {
 			Logger:         logger,
 			Port:           *httpsClientAuthPort,
 			TLSCerts:       []server.TLSCert{localhostCert},
+			PrefixToDrop:   *httpServerLogLinePrefixDrop,
 		}
 		errChan <- mutualTLSServer.ListenAndServeTLS()
 	}()

--- a/config/app-client-tls.container-definition.json
+++ b/config/app-client-tls.container-definition.json
@@ -125,6 +125,10 @@
     {
       "name": "NEW_RELIC_LICENSE_KEY",
       "value": "{{ .NEW_RELIC_LICENSE_KEY }}"
+    },
+    {
+      "name": "HTTP_SERVER_LOG_LINE_PREFIX_DROP",
+      "value": "{{ .HTTP_SERVER_LOG_LINE_PREFIX_DROP }}"
     }
   ],
   "logConfiguration": {

--- a/config/app.container-definition.json
+++ b/config/app.container-definition.json
@@ -125,6 +125,10 @@
     {
       "name": "NEW_RELIC_LICENSE_KEY",
       "value": "{{ .NEW_RELIC_LICENSE_KEY }}"
+    },
+    {
+      "name": "HTTP_SERVER_LOG_LINE_PREFIX_DROP",
+      "value": "{{ .HTTP_SERVER_LOG_LINE_PREFIX_DROP }}"
     }
   ],
   "logConfiguration": {

--- a/config/env/experimental.env
+++ b/config/env/experimental.env
@@ -4,3 +4,4 @@ HONEYCOMB_DATASET=app-experimental
 # https://docs.newrelic.com/docs/browser/new-relic-browser/configuration/copy-browser-monitoring-license-key-app-id
 NEW_RELIC_APPLICATION_ID=
 NEW_RELIC_LICENSE_KEY=
+HTTP_SERVER_LOG_LINE_PREFIX_DROP=http: TLS handshake error from 172.20.

--- a/config/env/prod.env
+++ b/config/env/prod.env
@@ -4,3 +4,4 @@ HONEYCOMB_DATASET=
 # https://docs.newrelic.com/docs/browser/new-relic-browser/configuration/copy-browser-monitoring-license-key-app-id
 NEW_RELIC_APPLICATION_ID=145160140
 NEW_RELIC_LICENSE_KEY=bb72897f0d
+HTTP_SERVER_LOG_LINE_PREFIX_DROP=http: TLS handshake error from 172.20.

--- a/config/env/staging.env
+++ b/config/env/staging.env
@@ -4,3 +4,4 @@ HONEYCOMB_DATASET=app-staging
 # https://docs.newrelic.com/docs/browser/new-relic-browser/configuration/copy-browser-monitoring-license-key-app-id
 NEW_RELIC_APPLICATION_ID=145174093
 NEW_RELIC_LICENSE_KEY=bb72897f0d
+HTTP_SERVER_LOG_LINE_PREFIX_DROP=http: TLS handshake error from 172.20.


### PR DESCRIPTION
## Description

The ability to drop log lines by prefix is needed to stop NLB health checks from polluting our logs.  Since `http.Server` requires a `log.Logger` rather than an interface, our options are limited.  Having a function to intercept writing to the log was the only way I could think of to filter out the logs lines.  The functionality is configured using the environment variable `httpServerLogLinePrefixDrop`.

**Other changes**
- fixed `bin/prereqs` to explicitly install `go 1.10` 
- renamed `port` to `httpPort` to disambiguate, since we listen on multiple ports now