### PR TITLE
Refactored script to only remove shipment data with no gbl_number

### DIFF
--- a/migrations/20180914223726_trucate_shipments.up.sql
+++ b/migrations/20180914223726_trucate_shipments.up.sql
@@ -1,8 +1,9 @@
--- Delete all moves that have shipments associated
-DELETE FROM moves WHERE id IN (SELECT DISTINCT move_id FROM shipments);
 -- Delete all move_documents that have moves associated
-DELETE FROM move_documents WHERE move_id IN (SELECT DISTINCT move_id FROM shipments);
--- Delete all
-DELETE FROM service_agents;
-DELETE FROM shipment_offers;
-DELETE FROM shipments;
+DELETE FROM move_documents WHERE move_id IN (SELECT DISTINCT move_id FROM shipments WHERE gbl_number is NULL);
+-- Delete all moves that have shipments without gbl numbers associated
+DELETE FROM moves WHERE id IN (SELECT DISTINCT move_id FROM shipments WHERE gbl_number is NULL);
+-- Delete all service_agents and shipment_offers that have shipments associated
+DELETE FROM service_agents WHERE shipment_id IN (SELECT DISTINCT id FROM shipments WHERE gbl_number is NULL);
+DELETE FROM shipment_offers WHERE shipment_id IN (SELECT DISTINCT id FROM shipments WHERE gbl_number is NULL);
+-- Delete all shipments without a gbl_number
+DELETE FROM shipments WHERE gbl_number is NULL;


### PR DESCRIPTION
## Description

This PR fixes the sql script to delete shipment data that does not have gbl_numbers.

Related data that will be deleted:
- move_documents
- moves
- service_agents
- shipment_offers
- shipments

## Reviewer Notes

- Only shipments without a gbl_number should be removed.

## Setup

```sh
make db_dev_migrate
```

## Code Review Verification Steps

* [ ] End to end tests pass (`make e2e_test`).
* [ ] Code follows the guidelines for [Logging](./docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](./docs/backend.md#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Update the diagram in docs/schema/dp3.sqs (see [Updating and changing the model](./docs/schema/README.md#updating-and-changing-the-model))
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](./docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
* [ ] There are no aXe warnings for UI.
* [ ] This works in IE.
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @willowbl00
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/160635760) for this change