### PR TITLE
Fix e2e tests for TSP

### DIFF
--- a/cypress/integration/tsp/premoveSurvey.js
+++ b/cypress/integration/tsp/premoveSurvey.js
@@ -19,7 +19,7 @@ function tspUserEntersPremoveSurvey() {
   // Find shipment and open it
   cy
     .get('div')
-    .contains('BACON1')
+    .contains('PREMVE')
     .dblclick();
 
   cy.location().should(loc => {

--- a/pkg/models/shipment.go
+++ b/pkg/models/shipment.go
@@ -112,7 +112,7 @@ func (s *Shipment) Validate(tx *pop.Connection) (*validate.Errors, error) {
 
 // Submit marks the Shipment request for review
 func (s *Shipment) Submit() error {
-	if s.Status != ShipmentStatusDRAFT && s.Status != ShipmentStatusAWARDED {
+	if s.Status != ShipmentStatusDRAFT {
 		return errors.Wrap(ErrInvalidTransition, "Submit")
 	}
 	now := time.Now()
@@ -136,6 +136,15 @@ func (s *Shipment) Accept() error {
 		return errors.Wrap(ErrInvalidTransition, "Accept")
 	}
 	s.Status = ShipmentStatusACCEPTED
+	return nil
+}
+
+// Reject returns the Shipment to the Submitted state. Must be in an Awarded state.
+func (s *Shipment) Reject() error {
+	if s.Status != ShipmentStatusAWARDED {
+		return errors.Wrap(ErrInvalidTransition, "Reject")
+	}
+	s.Status = ShipmentStatusSUBMITTED
 	return nil
 }
 
@@ -540,7 +549,7 @@ func RejectShipmentForTSP(db *pop.Connection, tspID uuid.UUID, shipmentID uuid.U
 	}
 
 	// Move the shipment back to Submitted and Reject the shipment offer.
-	err = shipment.Submit()
+	err = shipment.Reject()
 	if err != nil {
 		return shipment, shipmentOffer, nil, err
 	}

--- a/pkg/testdatagen/scenario/e2ebasic.go
+++ b/pkg/testdatagen/scenario/e2ebasic.go
@@ -827,8 +827,50 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader) {
 	hhg12.Move.Submit()
 	models.SaveMoveDependencies(db, &hhg12.Move)
 
+	/*
+	 * Service member with uploaded orders and an approved shipment to be accepted & able to generate GBL
+	 */
 	MakeHhgFromAwardedToAcceptedGBLReady(db, tspUser)
 
+	/*
+	 * Service member with uploaded orders and an approved shipment
+	 */
+	email = "hhg@premo.ve"
+
+	offer13 := testdatagen.MakeShipmentOffer(db, testdatagen.Assertions{
+		User: models.User{
+			ID:            uuid.Must(uuid.FromString("8f6b87f1-20ad-4c50-a855-ab66e222c7c3")),
+			LoginGovEmail: email,
+		},
+		ServiceMember: models.ServiceMember{
+			ID:            uuid.FromStringOrNil("1a98be36-5c4c-4056-b16f-d5a6c65b8569"),
+			FirstName:     models.StringPointer("HHG"),
+			LastName:      models.StringPointer("Submitted"),
+			Edipi:         models.StringPointer("4444567890"),
+			PersonalEmail: models.StringPointer(email),
+		},
+		Move: models.Move{
+			ID:               uuid.FromStringOrNil("01d85649-18c2-44ad-854d-da8884579f42"),
+			Locator:          "PREMVE",
+			SelectedMoveType: models.StringPointer("HHG"),
+		},
+		TrafficDistributionList: models.TrafficDistributionList{
+			ID:                uuid.FromStringOrNil("fd76c4fc-a2fb-45b6-a3a6-7c35357ab79a"),
+			SourceRateArea:    "US62",
+			DestinationRegion: "11",
+			CodeOfService:     "D",
+		},
+		Shipment: models.Shipment{
+			Status: models.ShipmentStatusAWARDED,
+		},
+		ShipmentOffer: models.ShipmentOffer{
+			TransportationServiceProviderID: tspUser.TransportationServiceProviderID,
+		},
+	})
+
+	hhg13 := offer13.Shipment
+	hhg13.Move.Submit()
+	models.SaveMoveDependencies(db, &hhg13.Move)
 }
 
 // MakeHhgFromAwardedToAcceptedGBLReady creates a scenario for an approved shipment ready for GBL generation


### PR DESCRIPTION
## Description

TSP e2e tests appeared to be broken.  I tracked down two things that I thought might contribute:

1. Overloading `shipment.Submit()` to handle the rejection state
2. Overusing the `BACON1` test case in the e2e scenarios.

## Reviewer Notes

What actually happened here?

## Setup

```sh
make e2e_test
```

## Code Review Verification Steps

* [x] End to end tests pass (`make e2e_test`).
* [x] Request review from a member of a different team.