### PR TITLE
add deliver button to TSP shipments

### DIFF
--- a/cypress/integration/tsp/shipShipment.js
+++ b/cypress/integration/tsp/shipShipment.js
@@ -7,6 +7,7 @@ describe('TSP User Ships a Shipment', function() {
   });
   it('tsp user Picks Up a shipment', function() {
     tspUserPicksUpShipment();
+    tspUserDeliversShipment();
   });
 });
 
@@ -92,4 +93,72 @@ function tspUserPicksUpShipment() {
     .click();
 
   cy.get('li').contains('In_transit');
+}
+
+function tspUserDeliversShipment() {
+  cy.location().should(loc => {
+    expect(loc.pathname).to.match(/^\/queues\/approved\/shipments\/[^/]+/);
+  });
+
+  // Click the Transport button
+  cy
+    .get('div')
+    .contains('Enter Delivery')
+    .click();
+
+  // Done button should be disabled.
+  cy
+    .get('button')
+    .contains('Done')
+    .should('be.disabled');
+
+  // Pick a date!
+  cy
+    .get('div')
+    .contains('Actual Delivery Date')
+    .get('input')
+    .click();
+
+  cy
+    .get('div')
+    .contains('13')
+    .click();
+
+  // Cancel
+  cy
+    .get('button')
+    .contains('Cancel')
+    .click();
+
+  // Wash, Rinse, Repeat
+  // Click the Transport button
+  cy
+    .get('div')
+    .contains('Enter Delivery')
+    .click();
+
+  // Done button should be disabled.
+  cy
+    .get('button')
+    .contains('Done')
+    .should('be.disabled');
+
+  // Pick a date!
+  cy
+    .get('div')
+    .contains('Actual Delivery Date')
+    .get('input')
+    .click();
+
+  cy
+    .get('div')
+    .contains('13')
+    .click();
+
+  cy
+    .get('button')
+    .contains('Done')
+    .click();
+
+  cy.get('li').contains('Delivered');
 }

--- a/docs/schema/dp3.sqs
+++ b/docs/schema/dp3.sqs
@@ -1,426 +1,190 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SQLContainer>
     <SQLTable>
-        <name><![CDATA[public.duty_stations]]></name>
+        <name><![CDATA[public.shipment_offers]]></name>
         <schema><![CDATA[public]]></schema>
         <location>
-            <x>1363.00</x>
-            <y>10.00</y>
-        </location>
-        <size>
-            <width>317.00</width>
-            <height>160.00</height>
-        </size>
-        <zorder>32</zorder>
-        <SQLField>
-            <name><![CDATA[id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <primaryKey>1</primaryKey>
-            <forcedUnique><![CDATA[1]]></forcedUnique>
-            <notNull><![CDATA[1]]></notNull>
-            <PK_NAME><![CDATA[duty_stations_pkey]]></PK_NAME>
-            <uid><![CDATA[0A85848D-FADC-4719-AB44-8F9E673234AD]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[name]]></name>
-            <type><![CDATA[CHARACTER VARYING(255)]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[6F46D506-9527-4FEB-9831-698169AD0A17]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[affiliation]]></name>
-            <type><![CDATA[CHARACTER VARYING(255)]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[F3F801BC-420B-4459-96E4-05698C093046]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[address_id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <referencesField>id</referencesField>
-            <referencesTable>public.addresses</referencesTable>
-            <deleteAction>4</deleteAction>
-            <updateAction>4</updateAction>
-            <referencesField><![CDATA[id]]></referencesField>
-            <referencesTable><![CDATA[public.addresses]]></referencesTable>
-            <sourceCardinality>0</sourceCardinality>
-            <destinationCardinality>0</destinationCardinality>
-            <referencesFieldUID><![CDATA[C9896DD5-D713-409E-B542-3BD4A00AAEE3]]></referencesFieldUID>
-            <referencesTableUID><![CDATA[41CC786C-E6D2-4FEA-992E-2F5DCDD20124]]></referencesTableUID>
-            <foreignKeyName><![CDATA[duty_stations_address_id_fkey]]></foreignKeyName>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[433A0B41-8846-4083-B693-79A419FF2083]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[created_at]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[718D255D-3445-4652-BE9E-E1F7BBBEBA09]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[updated_at]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[B45D0C63-2680-4E5D-A88A-91D1BA96F8AD]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[transportation_office_id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <uid><![CDATA[44DE1A8E-9800-4C1F-A62B-452888B45DB4]]></uid>
-        </SQLField>
-        <labelWindowIndex><![CDATA[32]]></labelWindowIndex>
-        <PK_KEY_NAME><![CDATA[duty_stations_pkey]]></PK_KEY_NAME>
-        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
-        <uid><![CDATA[03D89D85-6A21-4730-AEDE-A6BB16BFE135]]></uid>
-    </SQLTable>
-    <SQLTable>
-        <name><![CDATA[public.backup_contacts]]></name>
-        <schema><![CDATA[public]]></schema>
-        <location>
-            <x>337.00</x>
-            <y>10.00</y>
+            <x>1657.00</x>
+            <y>670.00</y>
         </location>
         <size>
             <width>317.00</width>
             <height>180.00</height>
         </size>
-        <zorder>35</zorder>
+        <zorder>17</zorder>
         <SQLField>
             <name><![CDATA[id]]></name>
             <type><![CDATA[UUID]]></type>
             <primaryKey>1</primaryKey>
             <notNull><![CDATA[1]]></notNull>
-            <PK_NAME><![CDATA[backup_contacts_pkey]]></PK_NAME>
-            <uid><![CDATA[F0F8803E-BDC8-433F-B5AD-1A5FDFE89A06]]></uid>
+            <PK_NAME><![CDATA[awarded_shipments_pkey]]></PK_NAME>
+            <uid><![CDATA[9565F5B0-8D16-4DC8-AC00-3699AF907302]]></uid>
         </SQLField>
         <SQLField>
-            <name><![CDATA[service_member_id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[C7D16A8F-19D8-4C79-ACA0-4F71BC781D66]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[name]]></name>
-            <type><![CDATA[CHARACTER VARYING(255)]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[F0F3557E-8599-41E8-BC90-EF2655CF1A87]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[email]]></name>
-            <type><![CDATA[CHARACTER VARYING(255)]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[BA4E05DB-206A-44E9-B5A8-77D2931DA82C]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[phone]]></name>
-            <type><![CDATA[CHARACTER VARYING(255)]]></type>
-            <uid><![CDATA[A9F3E005-A270-490D-AF3C-F7CF3E356354]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[permission]]></name>
-            <type><![CDATA[CHARACTER VARYING(255)]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[7CC300AB-9E16-4683-9505-DDA08C6AD2E5]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[created_at]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[EC827D1E-AF5A-41EF-92E8-C7BA4FCF699A]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[updated_at]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[1C97654E-5527-4B0B-BADC-779D9D1CDF4E]]></uid>
-        </SQLField>
-        <labelWindowIndex><![CDATA[35]]></labelWindowIndex>
-        <PK_KEY_NAME><![CDATA[backup_contacts_pkey]]></PK_KEY_NAME>
-        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
-        <uid><![CDATA[0E1B1F4E-7CB2-4262-B60A-6B5DA54E0710]]></uid>
-    </SQLTable>
-    <SQLTable>
-        <name><![CDATA[public.reimbursements]]></name>
-        <schema><![CDATA[public]]></schema>
-        <location>
-            <x>406.00</x>
-            <y>670.00</y>
-        </location>
-        <size>
-            <width>319.00</width>
-            <height>160.00</height>
-        </size>
-        <zorder>21</zorder>
-        <SQLField>
-            <name><![CDATA[id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <primaryKey>1</primaryKey>
-            <notNull><![CDATA[1]]></notNull>
-            <PK_NAME><![CDATA[reimbursements_pkey]]></PK_NAME>
-            <uid><![CDATA[8A1E1402-CFB1-4E2A-88DF-59F2743EFDF9]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[requested_amount]]></name>
-            <type><![CDATA[INTEGER]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[EBB634D5-E1BA-463B-9FA2-43D1E628E45E]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[method_of_receipt]]></name>
-            <type><![CDATA[CHARACTER VARYING(255)]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[240D3CD8-1CFF-414F-A6BF-B8C41E0540FE]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[status]]></name>
-            <type><![CDATA[CHARACTER VARYING(255)]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[FB01096A-B113-40FB-8FA9-82E9ED4A4D86]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[requested_date]]></name>
-            <type><![CDATA[DATE]]></type>
-            <uid><![CDATA[0DAA845D-D23F-4938-B8D1-0600F52BF8BB]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[created_at]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[5A453F25-29B8-4814-B954-2995ABFD0E20]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[updated_at]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[73D436B4-93B6-4D3D-BA2E-B325D4738A2E]]></uid>
-        </SQLField>
-        <labelWindowIndex><![CDATA[21]]></labelWindowIndex>
-        <PK_KEY_NAME><![CDATA[reimbursements_pkey]]></PK_KEY_NAME>
-        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
-        <uid><![CDATA[1B7A8AFD-D011-4A24-B885-5E073ED0E388]]></uid>
-    </SQLTable>
-    <SQLTable>
-        <name><![CDATA[public.gbl_number_trackers]]></name>
-        <schema><![CDATA[public]]></schema>
-        <location>
-            <x>1690.00</x>
-            <y>10.00</y>
-        </location>
-        <size>
-            <width>229.00</width>
-            <height>80.00</height>
-        </size>
-        <zorder>31</zorder>
-        <SQLField>
-            <name><![CDATA[sequence_number]]></name>
-            <type><![CDATA[INTEGER]]></type>
-            <uid><![CDATA[FD7D97BE-1C20-4067-B8EB-FA481E4F8EDF]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[gbloc]]></name>
-            <type><![CDATA[CHARACTER VARYING(255)]]></type>
-            <uid><![CDATA[855A4FFF-C4B9-47BB-B6DB-64D102B83DCD]]></uid>
-        </SQLField>
-        <SQLConstraint>
-            <name><![CDATA[gbl_number_trackers_gbloc_key]]></name>
-            <fieldName><![CDATA[gbloc]]></fieldName>
-            <SQLIndexEntry>
-                <name><![CDATA[gbloc]]></name>
-                <prefixSize><![CDATA[]]></prefixSize>
-                <fieldUid><![CDATA[855A4FFF-C4B9-47BB-B6DB-64D102B83DCD]]></fieldUid>
-            </SQLIndexEntry>
-            <deferrable><![CDATA[0]]></deferrable>
-            <indexType><![CDATA[UNIQUE]]></indexType>
-            <initiallyDeferred><![CDATA[0]]></initiallyDeferred>
-            <uid><![CDATA[BCCF93FE-1C53-4983-8C7B-4B8B7A686F6B]]></uid>
-        </SQLConstraint>
-        <labelWindowIndex><![CDATA[31]]></labelWindowIndex>
-        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
-        <uid><![CDATA[32B3CFDB-2CE9-4D87-A649-DA2C5EFB5E62]]></uid>
-    </SQLTable>
-    <SQLTable>
-        <name><![CDATA[public.tariff400ng_linehaul_rates]]></name>
-        <schema><![CDATA[public]]></schema>
-        <location>
-            <x>1280.00</x>
-            <y>1420.00</y>
-        </location>
-        <size>
-            <width>298.00</width>
-            <height>240.00</height>
-        </size>
-        <zorder>11</zorder>
-        <SQLField>
-            <name><![CDATA[id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <uid><![CDATA[481E8829-1F63-415E-AD20-D6278172C810]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[distance_miles_lower]]></name>
-            <type><![CDATA[INTEGER]]></type>
-            <uid><![CDATA[78CB8DDC-4844-44E5-A1A3-73ABCCF78081]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[distance_miles_upper]]></name>
-            <type><![CDATA[INTEGER]]></type>
-            <uid><![CDATA[8C72036E-D693-4819-8954-D0E884667BDC]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[weight_lbs_lower]]></name>
-            <type><![CDATA[INTEGER]]></type>
-            <uid><![CDATA[6B834EC5-B0E2-4A8B-921A-E9EB91239CD1]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[weight_lbs_upper]]></name>
-            <type><![CDATA[INTEGER]]></type>
-            <uid><![CDATA[623D536A-8CEF-4F8F-988A-89164E665D00]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[rate_cents]]></name>
-            <type><![CDATA[INTEGER]]></type>
-            <uid><![CDATA[F515BDA2-EF8C-4577-9B8A-3C79905FF31A]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[effective_date_lower]]></name>
-            <type><![CDATA[DATE]]></type>
-            <uid><![CDATA[6236F5DE-7347-43D5-BF78-7C13E180F0F0]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[effective_date_upper]]></name>
-            <type><![CDATA[DATE]]></type>
-            <uid><![CDATA[6B0B715F-3821-4B95-B91E-8741A4E1EB31]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[type]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <uid><![CDATA[94329317-4CAF-4EBA-A80B-5B1D614307CB]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[created_at]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <uid><![CDATA[36997888-CC20-42EE-9ED5-D354BBBF1882]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[updated_at]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <uid><![CDATA[9A4AEA02-40C9-4DF0-8BFE-53D9BAC850D7]]></uid>
-        </SQLField>
-        <labelWindowIndex><![CDATA[11]]></labelWindowIndex>
-        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
-        <uid><![CDATA[38466B9A-BC1D-4EC0-A88E-13C0CA763C3E]]></uid>
-    </SQLTable>
-    <SQLTable>
-        <name><![CDATA[public.documents]]></name>
-        <schema><![CDATA[public]]></schema>
-        <location>
-            <x>1036.00</x>
-            <y>10.00</y>
-        </location>
-        <size>
-            <width>317.00</width>
-            <height>100.00</height>
-        </size>
-        <zorder>33</zorder>
-        <SQLField>
-            <name><![CDATA[id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <primaryKey>1</primaryKey>
-            <forcedUnique><![CDATA[1]]></forcedUnique>
-            <notNull><![CDATA[1]]></notNull>
-            <PK_NAME><![CDATA[documents_pkey]]></PK_NAME>
-            <uid><![CDATA[167D75CF-9133-40DD-BD58-F582EAF9D9A6]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[created_at]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[B48F67A9-A063-4540-B289-34259D82EAB8]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[updated_at]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[8ADC3351-538F-4C2C-8BE4-F3A8928927F4]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[service_member_id]]></name>
+            <name><![CDATA[shipment_id]]></name>
             <type><![CDATA[UUID]]></type>
             <referencesField>id</referencesField>
-            <referencesTable>public.service_members</referencesTable>
+            <referencesTable>public.shipments</referencesTable>
             <deleteAction>4</deleteAction>
             <updateAction>4</updateAction>
             <referencesField><![CDATA[id]]></referencesField>
-            <referencesTable><![CDATA[public.service_members]]></referencesTable>
+            <referencesTable><![CDATA[public.shipments]]></referencesTable>
             <sourceCardinality>0</sourceCardinality>
             <destinationCardinality>0</destinationCardinality>
-            <referencesFieldUID><![CDATA[B6A911EF-81A8-4479-8FC5-38247FC132C3]]></referencesFieldUID>
-            <referencesTableUID><![CDATA[65F9FB8D-D6CB-491B-BFAF-02DEFD105FF1]]></referencesTableUID>
-            <foreignKeyName><![CDATA[documents_service_members_id_fk]]></foreignKeyName>
+            <referencesFieldUID><![CDATA[BA3E4A6D-9773-475D-BEA9-80241DAD83E4]]></referencesFieldUID>
+            <referencesTableUID><![CDATA[8F47E188-572A-4DD3-9A39-5ECD41CC9C7E]]></referencesTableUID>
+            <foreignKeyName><![CDATA[awarded_shipments_shipment_id_fkey]]></foreignKeyName>
             <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[2A02ABAD-37ED-42A6-B1C1-845FB281D477]]></uid>
+            <uid><![CDATA[A2324641-5B71-46DD-A01B-A3B8AC261746]]></uid>
         </SQLField>
-        <labelWindowIndex><![CDATA[33]]></labelWindowIndex>
-        <PK_KEY_NAME><![CDATA[documents_pkey]]></PK_KEY_NAME>
-        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
-        <uid><![CDATA[3C465223-A109-4B66-A28C-1C3790F6BE2B]]></uid>
-    </SQLTable>
-    <SQLTable>
-        <name><![CDATA[public.moving_expense_documents]]></name>
-        <schema><![CDATA[public]]></schema>
-        <location>
-            <x>685.00</x>
-            <y>260.00</y>
-        </location>
-        <size>
-            <width>340.00</width>
-            <height>160.00</height>
-        </size>
-        <zorder>27</zorder>
         <SQLField>
-            <name><![CDATA[id]]></name>
+            <name><![CDATA[transportation_service_provider_id]]></name>
             <type><![CDATA[UUID]]></type>
-            <primaryKey>1</primaryKey>
+            <referencesField>id</referencesField>
+            <referencesTable>public.transportation_service_providers</referencesTable>
+            <deleteAction>4</deleteAction>
+            <updateAction>4</updateAction>
+            <referencesField><![CDATA[id]]></referencesField>
+            <referencesTable><![CDATA[public.transportation_service_providers]]></referencesTable>
+            <sourceCardinality>0</sourceCardinality>
+            <destinationCardinality>0</destinationCardinality>
+            <referencesFieldUID><![CDATA[093BF0ED-A127-4BA8-B389-1FA79F673331]]></referencesFieldUID>
+            <referencesTableUID><![CDATA[342FBF63-1DB7-4D4F-9801-9F04DC431050]]></referencesTableUID>
+            <foreignKeyName><![CDATA[awarded_shipments_transportation_service_provider_id_fkey]]></foreignKeyName>
             <notNull><![CDATA[1]]></notNull>
-            <PK_NAME><![CDATA[moving_expense_documents_pkey]]></PK_NAME>
-            <uid><![CDATA[D1F1621B-F085-45DB-8D9B-803FF2FFE46E]]></uid>
+            <uid><![CDATA[26B91FBB-908E-4453-8D94-F558D4B0258D]]></uid>
         </SQLField>
         <SQLField>
-            <name><![CDATA[move_document_id]]></name>
-            <type><![CDATA[UUID]]></type>
+            <name><![CDATA[administrative_shipment]]></name>
+            <type><![CDATA[BOOLEAN]]></type>
             <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[69453603-9BC0-47DF-AA20-39D7FB8C349B]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[moving_expense_type]]></name>
-            <type><![CDATA[CHARACTER VARYING(255)]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[D444A93B-897D-4371-84CE-9B9B543A8098]]></uid>
+            <uid><![CDATA[37A91B51-AF55-431A-9E94-06A205852ED3]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[created_at]]></name>
             <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
             <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[F5E5F907-D8C1-469D-9D72-C962F4F0E864]]></uid>
+            <uid><![CDATA[D8A219BC-1554-472F-B6E0-F4E35125129E]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[updated_at]]></name>
             <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
             <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[405D83F9-6273-487C-BBF0-54362504286C]]></uid>
+            <uid><![CDATA[E0CEC507-B5D0-40C5-A49E-B08B43A3DF87]]></uid>
         </SQLField>
         <SQLField>
-            <name><![CDATA[requested_amount_cents]]></name>
-            <type><![CDATA[INTEGER]]></type>
-            <uid><![CDATA[3E9A867F-46AF-4544-A8DD-B51E511F5443]]></uid>
+            <name><![CDATA[accepted]]></name>
+            <type><![CDATA[BOOLEAN]]></type>
+            <uid><![CDATA[00D4DB65-C370-4CAF-9160-09C555E416D9]]></uid>
         </SQLField>
         <SQLField>
-            <name><![CDATA[payment_method]]></name>
-            <type><![CDATA[CHARACTER VARYING]]></type>
-            <uid><![CDATA[67F9FB4C-F003-455D-A2E0-34EF7EE68406]]></uid>
+            <name><![CDATA[rejection_reason]]></name>
+            <type><![CDATA[CHARACTER VARYING(255)]]></type>
+            <uid><![CDATA[CDC29024-6AF6-49D0-9C60-BF962C5EE929]]></uid>
         </SQLField>
-        <labelWindowIndex><![CDATA[27]]></labelWindowIndex>
-        <PK_KEY_NAME><![CDATA[moving_expense_documents_pkey]]></PK_KEY_NAME>
+        <labelWindowIndex><![CDATA[17]]></labelWindowIndex>
+        <PK_KEY_NAME><![CDATA[awarded_shipments_pkey]]></PK_KEY_NAME>
         <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
-        <uid><![CDATA[3CCFBB41-E147-4DCF-9B8C-D8CA819F0750]]></uid>
+        <uid><![CDATA[13F4CA93-BFB9-400A-99CA-253590882DEC]]></uid>
+    </SQLTable>
+    <SQLTable>
+        <name><![CDATA[public.office_users]]></name>
+        <schema><![CDATA[public]]></schema>
+        <location>
+            <x>1689.00</x>
+            <y>260.00</y>
+        </location>
+        <size>
+            <width>317.00</width>
+            <height>220.00</height>
+        </size>
+        <zorder>24</zorder>
+        <SQLField>
+            <name><![CDATA[id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <primaryKey>1</primaryKey>
+            <notNull><![CDATA[1]]></notNull>
+            <PK_NAME><![CDATA[office_users_pkey]]></PK_NAME>
+            <uid><![CDATA[439E5F0E-653B-47AB-BB42-6F9F48D8CE7E]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[user_id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <referencesField>id</referencesField>
+            <referencesTable>public.users</referencesTable>
+            <deleteAction>4</deleteAction>
+            <updateAction>4</updateAction>
+            <referencesField><![CDATA[id]]></referencesField>
+            <referencesTable><![CDATA[public.users]]></referencesTable>
+            <sourceCardinality>0</sourceCardinality>
+            <destinationCardinality>0</destinationCardinality>
+            <referencesFieldUID><![CDATA[DCD39A12-ABD0-4ABE-9E63-3738507BE8B3]]></referencesFieldUID>
+            <referencesTableUID><![CDATA[BB175DB0-D2A9-4C32-92B8-B4F0FDD56488]]></referencesTableUID>
+            <foreignKeyName><![CDATA[office_users_user_id_fkey]]></foreignKeyName>
+            <uid><![CDATA[3D5F3AFA-6D32-44F0-B3A3-42CEEE87C586]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[last_name]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[EA363184-34FD-430B-9581-DB35367B116A]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[first_name]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[864C9D6F-22E6-425A-8D6B-ADBB56CA75A5]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[middle_initials]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <uid><![CDATA[9E18DD37-C391-4813-9D88-2543692EBCC3]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[email]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[C0E0136A-6C94-4EAC-A956-EFD2562152E1]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[telephone]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[BEE07CFC-3072-4287-8738-F24B4DCA5CB2]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[transportation_office_id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <referencesField>id</referencesField>
+            <referencesTable>public.transportation_offices</referencesTable>
+            <deleteAction>4</deleteAction>
+            <updateAction>4</updateAction>
+            <referencesField><![CDATA[id]]></referencesField>
+            <referencesTable><![CDATA[public.transportation_offices]]></referencesTable>
+            <sourceCardinality>0</sourceCardinality>
+            <destinationCardinality>0</destinationCardinality>
+            <referencesFieldUID><![CDATA[55C4ABEE-BFFC-4BC0-ABCC-92594F606CAB]]></referencesFieldUID>
+            <referencesTableUID><![CDATA[7F3EB14E-A0C7-4A01-8FC7-990D4A6DD8D4]]></referencesTableUID>
+            <foreignKeyName><![CDATA[office_users_transportation_office_id_fkey]]></foreignKeyName>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[266B35F3-761F-40DD-A299-726F7F4295AE]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[created_at]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[3CE8C38B-E436-441C-8921-0B9743E03B28]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[updated_at]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[0E31F24E-9352-44AA-9F30-E76A1BD54F81]]></uid>
+        </SQLField>
+        <labelWindowIndex><![CDATA[24]]></labelWindowIndex>
+        <PK_KEY_NAME><![CDATA[office_users_pkey]]></PK_KEY_NAME>
+        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
+        <uid><![CDATA[1E497323-FE72-48C0-B7FD-0FE2F1C3F1F2]]></uid>
     </SQLTable>
     <SQLTable>
         <name><![CDATA[public.office_phone_lines]]></name>
@@ -440,7 +204,7 @@
             <primaryKey>1</primaryKey>
             <notNull><![CDATA[1]]></notNull>
             <PK_NAME><![CDATA[office_phone_lines_pkey]]></PK_NAME>
-            <uid><![CDATA[DE31C1D9-DCC9-482E-B079-6C4625F36402]]></uid>
+            <uid><![CDATA[E12B7F0D-6125-4921-B89B-15F565ED0E5C]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[transportation_office_id]]></name>
@@ -453,1148 +217,53 @@
             <referencesTable><![CDATA[public.transportation_offices]]></referencesTable>
             <sourceCardinality>0</sourceCardinality>
             <destinationCardinality>0</destinationCardinality>
-            <referencesFieldUID><![CDATA[9FEEEABA-006F-4DBB-B9F6-015D52A9711E]]></referencesFieldUID>
-            <referencesTableUID><![CDATA[6E73DEA2-0F0A-4966-982B-9097EB58B20C]]></referencesTableUID>
+            <referencesFieldUID><![CDATA[55C4ABEE-BFFC-4BC0-ABCC-92594F606CAB]]></referencesFieldUID>
+            <referencesTableUID><![CDATA[7F3EB14E-A0C7-4A01-8FC7-990D4A6DD8D4]]></referencesTableUID>
             <foreignKeyName><![CDATA[office_phone_lines_transportation_office_id_fkey]]></foreignKeyName>
             <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[0FBA6B8A-DF79-4709-A7DD-978D44CFF017]]></uid>
+            <uid><![CDATA[028DB99A-C43E-4531-A053-585706C88EAA]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[number]]></name>
             <type><![CDATA[TEXT]]></type>
             <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[FCAFE649-98A6-4D12-B09F-97D976C03092]]></uid>
+            <uid><![CDATA[200D1CAD-D168-4330-860F-5251DD1EF5F6]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[label]]></name>
             <type><![CDATA[TEXT]]></type>
-            <uid><![CDATA[79B554BE-434B-4A0D-8E31-1E468C8227D7]]></uid>
+            <uid><![CDATA[29F31E21-6153-4BC0-B372-4F1191E9E10A]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[is_dsn_number]]></name>
             <type><![CDATA[BOOLEAN]]></type>
             <defaultValue><![CDATA[false]]></defaultValue>
             <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[48124486-D0FA-4F48-A187-34968DF5DBAC]]></uid>
+            <uid><![CDATA[737EC452-4464-435D-8000-AA6673FA1DA0]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[type]]></name>
             <type><![CDATA[TEXT]]></type>
             <defaultValue><![CDATA['voice'::text]]></defaultValue>
             <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[C466463E-F24E-4889-AE98-234289A52A72]]></uid>
+            <uid><![CDATA[99840D33-C14D-48CA-8933-EABF13963599]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[created_at]]></name>
             <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
             <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[C3F22013-90F3-46CE-8ECF-CECF7F2F2EAB]]></uid>
+            <uid><![CDATA[8AE98591-9A29-476A-A843-0E9C76C05C9B]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[updated_at]]></name>
             <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
             <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[94D4E0AC-975A-44DA-9875-B02BABDD4658]]></uid>
+            <uid><![CDATA[C7B0717D-78E6-44C9-B28F-34844E894489]]></uid>
         </SQLField>
         <labelWindowIndex><![CDATA[25]]></labelWindowIndex>
         <PK_KEY_NAME><![CDATA[office_phone_lines_pkey]]></PK_KEY_NAME>
         <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
-        <uid><![CDATA[40D4622B-A9D9-45A7-B4C1-243A1F7D6024]]></uid>
-    </SQLTable>
-    <SQLTable>
-        <name><![CDATA[public.addresses]]></name>
-        <schema><![CDATA[public]]></schema>
-        <location>
-            <x>10.00</x>
-            <y>10.00</y>
-        </location>
-        <size>
-            <width>317.00</width>
-            <height>220.00</height>
-        </size>
-        <zorder>36</zorder>
-        <SQLField>
-            <name><![CDATA[id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <primaryKey>1</primaryKey>
-            <forcedUnique><![CDATA[1]]></forcedUnique>
-            <notNull><![CDATA[1]]></notNull>
-            <PK_NAME><![CDATA[addresses_pkey]]></PK_NAME>
-            <uid><![CDATA[C9896DD5-D713-409E-B542-3BD4A00AAEE3]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[street_address_1]]></name>
-            <type><![CDATA[CHARACTER VARYING(255)]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[5D0A3A02-B948-4E27-BFE8-2AE85054F5DE]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[street_address_2]]></name>
-            <type><![CDATA[CHARACTER VARYING(255)]]></type>
-            <uid><![CDATA[AB4BD871-1ABC-417C-85FE-F867202C3A9B]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[city]]></name>
-            <type><![CDATA[CHARACTER VARYING(255)]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[7EE31B74-7083-42DF-8E86-1BC44EB9FAAF]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[state]]></name>
-            <type><![CDATA[CHARACTER VARYING(255)]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[C648BD0B-2F68-429A-BA2E-46C794B1A70E]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[postal_code]]></name>
-            <type><![CDATA[CHARACTER VARYING(255)]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[4D3D7795-12F8-472E-B87C-8BA50BF9780B]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[created_at]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[D315D329-E1B5-4AEB-A058-3948101C9E5E]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[updated_at]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[90232FF8-D6A1-4A6F-887E-ED923BE800BF]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[street_address_3]]></name>
-            <type><![CDATA[CHARACTER VARYING(255)]]></type>
-            <uid><![CDATA[051137B6-440A-478C-B251-4BCC3D567EC4]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[country]]></name>
-            <type><![CDATA[CHARACTER VARYING(255)]]></type>
-            <defaultValue><![CDATA['United States'::character varying]]></defaultValue>
-            <uid><![CDATA[76B09B25-4136-46AD-9EF2-1782CD73CEFF]]></uid>
-        </SQLField>
-        <labelWindowIndex><![CDATA[36]]></labelWindowIndex>
-        <PK_KEY_NAME><![CDATA[addresses_pkey]]></PK_KEY_NAME>
-        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
-        <uid><![CDATA[41CC786C-E6D2-4FEA-992E-2F5DCDD20124]]></uid>
-    </SQLTable>
-    <SQLTable>
-        <name><![CDATA[public.social_security_numbers]]></name>
-        <schema><![CDATA[public]]></schema>
-        <location>
-            <x>337.00</x>
-            <y>1420.00</y>
-        </location>
-        <size>
-            <width>317.00</width>
-            <height>100.00</height>
-        </size>
-        <zorder>14</zorder>
-        <SQLField>
-            <name><![CDATA[id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <primaryKey>1</primaryKey>
-            <forcedUnique><![CDATA[1]]></forcedUnique>
-            <notNull><![CDATA[1]]></notNull>
-            <PK_NAME><![CDATA[social_security_numbers_pkey]]></PK_NAME>
-            <uid><![CDATA[8D2EF9B5-29DF-4BB6-8E65-19422BD0363C]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[encrypted_hash]]></name>
-            <type><![CDATA[CHARACTER VARYING(255)]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[E1F68B03-0291-4513-960D-F7E0ABB7F2B7]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[created_at]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[4F812E0C-52DB-4788-8A16-E9EB0588AEE6]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[updated_at]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[FDC2C68B-F408-4791-8170-FED362F312FC]]></uid>
-        </SQLField>
-        <labelWindowIndex><![CDATA[14]]></labelWindowIndex>
-        <PK_KEY_NAME><![CDATA[social_security_numbers_pkey]]></PK_KEY_NAME>
-        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
-        <uid><![CDATA[47635741-B6F3-4318-8B0D-48675587BF8A]]></uid>
-    </SQLTable>
-    <SQLTable>
-        <name><![CDATA[public.shipments]]></name>
-        <schema><![CDATA[public]]></schema>
-        <location>
-            <x>1996.00</x>
-            <y>670.00</y>
-        </location>
-        <size>
-            <width>424.00</width>
-            <height>740.00</height>
-        </size>
-        <zorder>16</zorder>
-        <SQLField>
-            <name><![CDATA[id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <primaryKey>1</primaryKey>
-            <forcedUnique><![CDATA[1]]></forcedUnique>
-            <notNull><![CDATA[1]]></notNull>
-            <PK_NAME><![CDATA[shipments_pkey]]></PK_NAME>
-            <uid><![CDATA[444DF8FF-1B94-44BC-AF1E-9535B4AE7E8D]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[traffic_distribution_list_id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <referencesField>id</referencesField>
-            <referencesTable>public.traffic_distribution_lists</referencesTable>
-            <deleteAction>4</deleteAction>
-            <updateAction>4</updateAction>
-            <referencesField><![CDATA[id]]></referencesField>
-            <referencesTable><![CDATA[public.traffic_distribution_lists]]></referencesTable>
-            <sourceCardinality>0</sourceCardinality>
-            <destinationCardinality>0</destinationCardinality>
-            <referencesFieldUID><![CDATA[FEBF637A-361A-4BE0-92F2-40CE87A7F022]]></referencesFieldUID>
-            <referencesTableUID><![CDATA[B9904F5A-2E70-4B7F-A129-74F7A096DAC8]]></referencesTableUID>
-            <foreignKeyName><![CDATA[shipments_traffic_distribution_list_id_fkey]]></foreignKeyName>
-            <uid><![CDATA[AF37AC5C-9FDC-4AD5-AE17-1146A8FA3B5F]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[actual_pickup_date]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <uid><![CDATA[47E7BBBA-115A-43C7-95F4-6DE6EAD4CE61]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[delivery_date]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <uid><![CDATA[AAE48563-8150-40DA-B885-979908A76414]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[created_at]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[87D9FAB0-0E53-4332-A102-0337F7B5CB71]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[updated_at]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[81831DBA-83DA-4D43-9478-75BBA0D204D5]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[source_gbloc]]></name>
-            <type><![CDATA[CHARACTER VARYING(255)]]></type>
-            <uid><![CDATA[B1A97AA5-A991-404C-897D-33EBF8116200]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[market]]></name>
-            <type><![CDATA[CHARACTER VARYING(255)]]></type>
-            <uid><![CDATA[2583CCD5-A825-4265-A63B-C80ABA45D804]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[book_date]]></name>
-            <type><![CDATA[DATE]]></type>
-            <uid><![CDATA[4586AC44-E0E5-4B3A-B242-12869ED38A10]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[requested_pickup_date]]></name>
-            <type><![CDATA[DATE]]></type>
-            <uid><![CDATA[5DCF7C72-3F08-4312-AC6A-6396FA164964]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[move_id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[69199B8F-F528-4396-A685-9689823484E3]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[status]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <defaultValue><![CDATA['DRAFT'::text]]></defaultValue>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[1D0B2EBE-19D8-4687-AAE8-95C7F08AE150]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[estimated_pack_days]]></name>
-            <type><![CDATA[INTEGER]]></type>
-            <uid><![CDATA[6A26B4BA-D179-4659-9E2D-43265D6C412D]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[estimated_transit_days]]></name>
-            <type><![CDATA[INTEGER]]></type>
-            <uid><![CDATA[042A4E32-BAB6-4316-B3F3-24F8BE7B0A04]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[pickup_address_id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <referencesField>id</referencesField>
-            <referencesTable>public.addresses</referencesTable>
-            <deleteAction>4</deleteAction>
-            <updateAction>4</updateAction>
-            <referencesField><![CDATA[id]]></referencesField>
-            <referencesTable><![CDATA[public.addresses]]></referencesTable>
-            <sourceCardinality>0</sourceCardinality>
-            <destinationCardinality>0</destinationCardinality>
-            <referencesFieldUID><![CDATA[C9896DD5-D713-409E-B542-3BD4A00AAEE3]]></referencesFieldUID>
-            <referencesTableUID><![CDATA[41CC786C-E6D2-4FEA-992E-2F5DCDD20124]]></referencesTableUID>
-            <foreignKeyName><![CDATA[shipments_address_id_fk]]></foreignKeyName>
-            <uid><![CDATA[11224DAA-4B45-43DC-AF8B-96476B5DE0A7]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[has_secondary_pickup_address]]></name>
-            <type><![CDATA[BOOLEAN]]></type>
-            <defaultValue><![CDATA[false]]></defaultValue>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[03629D30-A0FD-43F3-921D-829D1E89D7B2]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[secondary_pickup_address_id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <referencesField>id</referencesField>
-            <referencesTable>public.addresses</referencesTable>
-            <deleteAction>4</deleteAction>
-            <updateAction>4</updateAction>
-            <referencesField><![CDATA[id]]></referencesField>
-            <referencesTable><![CDATA[public.addresses]]></referencesTable>
-            <sourceCardinality>0</sourceCardinality>
-            <destinationCardinality>0</destinationCardinality>
-            <referencesFieldUID><![CDATA[C9896DD5-D713-409E-B542-3BD4A00AAEE3]]></referencesFieldUID>
-            <referencesTableUID><![CDATA[41CC786C-E6D2-4FEA-992E-2F5DCDD20124]]></referencesTableUID>
-            <foreignKeyName><![CDATA[shipments_secondary_address_id_fk]]></foreignKeyName>
-            <uid><![CDATA[899D5448-05A2-48C1-936E-C99C9F867A1B]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[has_delivery_address]]></name>
-            <type><![CDATA[BOOLEAN]]></type>
-            <defaultValue><![CDATA[false]]></defaultValue>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[54EEDDE8-EAC2-4ECF-880D-FCF453B58E55]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[delivery_address_id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <referencesField>id</referencesField>
-            <referencesTable>public.addresses</referencesTable>
-            <deleteAction>4</deleteAction>
-            <updateAction>4</updateAction>
-            <referencesField><![CDATA[id]]></referencesField>
-            <referencesTable><![CDATA[public.addresses]]></referencesTable>
-            <sourceCardinality>0</sourceCardinality>
-            <destinationCardinality>0</destinationCardinality>
-            <referencesFieldUID><![CDATA[C9896DD5-D713-409E-B542-3BD4A00AAEE3]]></referencesFieldUID>
-            <referencesTableUID><![CDATA[41CC786C-E6D2-4FEA-992E-2F5DCDD20124]]></referencesTableUID>
-            <foreignKeyName><![CDATA[delivery_address_id_fk]]></foreignKeyName>
-            <uid><![CDATA[2912D3A4-FF7D-4E87-8854-02ACC5B12A54]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[has_partial_sit_delivery_address]]></name>
-            <type><![CDATA[BOOLEAN]]></type>
-            <defaultValue><![CDATA[false]]></defaultValue>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[9326D194-3D82-4324-8735-57D85E8A6A61]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[partial_sit_delivery_address_id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <referencesField>id</referencesField>
-            <referencesTable>public.addresses</referencesTable>
-            <deleteAction>4</deleteAction>
-            <updateAction>4</updateAction>
-            <referencesField><![CDATA[id]]></referencesField>
-            <referencesTable><![CDATA[public.addresses]]></referencesTable>
-            <sourceCardinality>0</sourceCardinality>
-            <destinationCardinality>0</destinationCardinality>
-            <referencesFieldUID><![CDATA[C9896DD5-D713-409E-B542-3BD4A00AAEE3]]></referencesFieldUID>
-            <referencesTableUID><![CDATA[41CC786C-E6D2-4FEA-992E-2F5DCDD20124]]></referencesTableUID>
-            <foreignKeyName><![CDATA[partial_sit_delivery_address_id_fk]]></foreignKeyName>
-            <uid><![CDATA[63BD0D68-D80F-4F35-9A8A-7E68F2CED72D]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[weight_estimate]]></name>
-            <type><![CDATA[INTEGER]]></type>
-            <uid><![CDATA[BF09A678-0060-4980-BDFE-6D93B15DDBAE]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[progear_weight_estimate]]></name>
-            <type><![CDATA[INTEGER]]></type>
-            <uid><![CDATA[450002AC-66C6-4E25-ADA8-B34C4D9E4B22]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[spouse_progear_weight_estimate]]></name>
-            <type><![CDATA[INTEGER]]></type>
-            <uid><![CDATA[BCC71D99-00FC-4E86-9382-F628D3F1E153]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[destination_gbloc]]></name>
-            <type><![CDATA[CHARACTER VARYING(255)]]></type>
-            <uid><![CDATA[DDE13914-B2DF-44ED-A3F3-DCCF7BE271D7]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[service_member_id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <referencesField>id</referencesField>
-            <referencesTable>public.service_members</referencesTable>
-            <deleteAction>4</deleteAction>
-            <updateAction>4</updateAction>
-            <referencesField><![CDATA[id]]></referencesField>
-            <referencesTable><![CDATA[public.service_members]]></referencesTable>
-            <sourceCardinality>0</sourceCardinality>
-            <destinationCardinality>0</destinationCardinality>
-            <referencesFieldUID><![CDATA[B6A911EF-81A8-4479-8FC5-38247FC132C3]]></referencesFieldUID>
-            <referencesTableUID><![CDATA[65F9FB8D-D6CB-491B-BFAF-02DEFD105FF1]]></referencesTableUID>
-            <foreignKeyName><![CDATA[shipments_service_member_id_fk]]></foreignKeyName>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[AEE2932D-E25D-4A1F-BC14-7D974C9C9162]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[pm_survey_planned_pack_date]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <uid><![CDATA[39E37F05-B1D9-40AD-9895-156B0806EBB7]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[pm_survey_planned_pickup_date]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <uid><![CDATA[8571CCBB-4827-4AB8-9535-7A73A29C4A4F]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[pm_survey_planned_delivery_date]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <uid><![CDATA[D220145D-6D95-4229-B96B-D78586C6FE93]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[pm_survey_weight_estimate]]></name>
-            <type><![CDATA[INTEGER]]></type>
-            <uid><![CDATA[B36ACFA2-B15A-4470-B72B-883409147B5C]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[pm_survey_progear_weight_estimate]]></name>
-            <type><![CDATA[INTEGER]]></type>
-            <uid><![CDATA[48C79712-49AC-4E90-8EF8-8A4251F866F4]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[pm_survey_spouse_progear_weight_estimate]]></name>
-            <type><![CDATA[INTEGER]]></type>
-            <uid><![CDATA[0C0CB500-72DC-4958-A50F-C0F0F21C437A]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[pm_survey_notes]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <uid><![CDATA[28DCCA2F-3317-4661-9A66-0C5A4ED8A09C]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[pm_survey_method]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[A93B59C0-704C-4CAE-BBB3-A725CF661293]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[actual_weight]]></name>
-            <type><![CDATA[INTEGER]]></type>
-            <uid><![CDATA[F8D55B16-2204-4D67-91D0-61D14E74B48A]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[gbl_number]]></name>
-            <type><![CDATA[CHARACTER VARYING(255)]]></type>
-            <uid><![CDATA[E261C6DD-68AB-4E8F-BB27-C3C85CB6843D]]></uid>
-        </SQLField>
-        <labelWindowIndex><![CDATA[16]]></labelWindowIndex>
-        <PK_KEY_NAME><![CDATA[shipments_pkey]]></PK_KEY_NAME>
-        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
-        <uid><![CDATA[4ACF24EB-68A1-460A-97CD-EC9A3D9BF4CC]]></uid>
-    </SQLTable>
-    <SQLTable>
-        <name><![CDATA[public.tariff400ng_service_areas]]></name>
-        <schema><![CDATA[public]]></schema>
-        <location>
-            <x>1588.00</x>
-            <y>1420.00</y>
-        </location>
-        <size>
-            <width>298.00</width>
-            <height>280.00</height>
-        </size>
-        <zorder>10</zorder>
-        <SQLField>
-            <name><![CDATA[id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <uid><![CDATA[14C887CE-91B1-4411-A855-A8CF89C530B9]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[service_area]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <uid><![CDATA[531FC8A5-D0ED-4FB7-8160-9D3AD8C432D5]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[name]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <uid><![CDATA[8A68A784-FDB7-4286-9B2F-543796B83A47]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[services_schedule]]></name>
-            <type><![CDATA[INTEGER]]></type>
-            <uid><![CDATA[29772E5B-3FE0-4B1E-A37A-D2AF53F22767]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[linehaul_factor]]></name>
-            <type><![CDATA[INTEGER]]></type>
-            <uid><![CDATA[357086E7-CABA-4E53-9BEB-3C0CA5A0B74A]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[service_charge_cents]]></name>
-            <type><![CDATA[INTEGER]]></type>
-            <uid><![CDATA[B808DDCA-790D-4809-B5F0-2B8F7ED0EFBB]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[effective_date_lower]]></name>
-            <type><![CDATA[DATE]]></type>
-            <uid><![CDATA[BFF07218-6FE1-43C3-8676-CDDB8001F44E]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[effective_date_upper]]></name>
-            <type><![CDATA[DATE]]></type>
-            <uid><![CDATA[2A3AD996-AD38-41D6-B57A-8AAB5579DFC7]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[created_at]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <uid><![CDATA[E6EB3C9C-ACCE-4F8A-8D41-65C39B00B392]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[updated_at]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <uid><![CDATA[C0A39A99-9E68-4841-A77A-01FC18224048]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[sit_185a_rate_cents]]></name>
-            <type><![CDATA[INTEGER]]></type>
-            <uid><![CDATA[C1C3F30F-7AB1-447E-BA56-10C89475A98B]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[sit_185b_rate_cents]]></name>
-            <type><![CDATA[INTEGER]]></type>
-            <uid><![CDATA[F448C301-C9C2-42CA-BCC6-E9408DF8A369]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[sit_pd_schedule]]></name>
-            <type><![CDATA[INTEGER]]></type>
-            <uid><![CDATA[07A69D86-4F56-41F8-9B7B-EE37EE69F3F6]]></uid>
-        </SQLField>
-        <labelWindowIndex><![CDATA[10]]></labelWindowIndex>
-        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
-        <uid><![CDATA[5F423CF9-356D-473F-9509-D7AA9B573DD1]]></uid>
-    </SQLTable>
-    <SQLTable>
-        <name><![CDATA[public.personally_procured_moves]]></name>
-        <schema><![CDATA[public]]></schema>
-        <location>
-            <x>10.00</x>
-            <y>670.00</y>
-        </location>
-        <size>
-            <width>386.00</width>
-            <height>480.00</height>
-        </size>
-        <zorder>22</zorder>
-        <SQLField>
-            <name><![CDATA[id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <primaryKey>1</primaryKey>
-            <forcedUnique><![CDATA[1]]></forcedUnique>
-            <notNull><![CDATA[1]]></notNull>
-            <PK_NAME><![CDATA[personally_procured_moves_pkey]]></PK_NAME>
-            <uid><![CDATA[2BD3FB6C-215F-464C-BE54-354AC83D63C6]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[move_id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <referencesField>id</referencesField>
-            <referencesTable>public.moves</referencesTable>
-            <deleteAction>4</deleteAction>
-            <updateAction>4</updateAction>
-            <referencesField><![CDATA[id]]></referencesField>
-            <referencesTable><![CDATA[public.moves]]></referencesTable>
-            <sourceCardinality>0</sourceCardinality>
-            <destinationCardinality>0</destinationCardinality>
-            <referencesFieldUID><![CDATA[53E01484-FFCD-4FBC-9485-729CEBA02C23]]></referencesFieldUID>
-            <referencesTableUID><![CDATA[C8C105E2-3679-4B84-BC12-B7A46073F848]]></referencesTableUID>
-            <foreignKeyName><![CDATA[personally_procured_moves_move_id_fkey]]></foreignKeyName>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[8A0CE841-AF36-408A-8D5B-138B9D43BA72]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[size]]></name>
-            <type><![CDATA[CHARACTER VARYING(255)]]></type>
-            <uid><![CDATA[95A70373-CA20-4F54-BDAF-44EE170009BF]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[weight_estimate]]></name>
-            <type><![CDATA[INTEGER]]></type>
-            <uid><![CDATA[DEF47E83-D892-4775-B41E-22EC84BA7D59]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[created_at]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[7AAAF4C6-69E7-46AE-9A5E-8514B599A476]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[updated_at]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[EF6E9A01-DCF1-4A5B-A9B8-D9387B244D30]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[planned_move_date]]></name>
-            <type><![CDATA[DATE]]></type>
-            <uid><![CDATA[A5E18528-A075-4EE0-B22B-EC5830311F76]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[pickup_postal_code]]></name>
-            <type><![CDATA[CHARACTER VARYING(255)]]></type>
-            <uid><![CDATA[27F430E5-5B26-4EF9-89DC-229BA12DC3F6]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[additional_pickup_postal_code]]></name>
-            <type><![CDATA[CHARACTER VARYING(255)]]></type>
-            <uid><![CDATA[ED68B42C-F755-4946-9515-A3E27D3017E7]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[destination_postal_code]]></name>
-            <type><![CDATA[CHARACTER VARYING(255)]]></type>
-            <uid><![CDATA[DAF0B588-F54E-46B9-A4B9-CC2EB50D3243]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[days_in_storage]]></name>
-            <type><![CDATA[INTEGER]]></type>
-            <uid><![CDATA[F6B22D45-2116-49AF-BAB9-C811F70C56FD]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[status]]></name>
-            <type><![CDATA[CHARACTER VARYING(255)]]></type>
-            <defaultValue><![CDATA['DRAFT'::character varying]]></defaultValue>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[CDC152C6-1FF2-4A41-A084-67D3DE388205]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[has_additional_postal_code]]></name>
-            <type><![CDATA[BOOLEAN]]></type>
-            <uid><![CDATA[546199FB-3E51-4D73-A80F-0BF3A02EB92D]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[has_sit]]></name>
-            <type><![CDATA[BOOLEAN]]></type>
-            <uid><![CDATA[BB8566BE-C9D9-44C6-9FD7-1F1289B306A8]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[has_requested_advance]]></name>
-            <type><![CDATA[BOOLEAN]]></type>
-            <defaultValue><![CDATA[false]]></defaultValue>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[06B0EA47-973E-4C55-88F2-B83DF878A4CB]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[advance_id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <uid><![CDATA[C3D4BB52-EB94-4636-9802-4349B600D234]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[estimated_storage_reimbursement]]></name>
-            <type><![CDATA[CHARACTER VARYING(255)]]></type>
-            <uid><![CDATA[967B3E5F-D213-4A4F-B442-47F1B03761ED]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[mileage]]></name>
-            <type><![CDATA[INTEGER]]></type>
-            <uid><![CDATA[EAA518ED-FFD9-4ED6-9033-E75C4F790A26]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[planned_sit_max]]></name>
-            <type><![CDATA[INTEGER]]></type>
-            <uid><![CDATA[24FB2DDF-8EAD-40C9-83D2-E3F70EAA0FDC]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[sit_max]]></name>
-            <type><![CDATA[INTEGER]]></type>
-            <uid><![CDATA[75702624-2CA1-4641-B84E-64D1D0C3D489]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[incentive_estimate_min]]></name>
-            <type><![CDATA[INTEGER]]></type>
-            <uid><![CDATA[D7EF2AC8-FA48-4653-B5DA-CDD8E79B980C]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[incentive_estimate_max]]></name>
-            <type><![CDATA[INTEGER]]></type>
-            <uid><![CDATA[946FE560-C654-411F-A063-D494C009335E]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[advance_worksheet_id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <referencesField>id</referencesField>
-            <referencesTable>public.documents</referencesTable>
-            <deleteAction>4</deleteAction>
-            <updateAction>4</updateAction>
-            <referencesField><![CDATA[id]]></referencesField>
-            <referencesTable><![CDATA[public.documents]]></referencesTable>
-            <sourceCardinality>0</sourceCardinality>
-            <destinationCardinality>0</destinationCardinality>
-            <referencesFieldUID><![CDATA[167D75CF-9133-40DD-BD58-F582EAF9D9A6]]></referencesFieldUID>
-            <referencesTableUID><![CDATA[3C465223-A109-4B66-A28C-1C3790F6BE2B]]></referencesTableUID>
-            <foreignKeyName><![CDATA[personally_procured_moves_documents_id_fk]]></foreignKeyName>
-            <uid><![CDATA[B90AEEA0-4245-4D72-9D03-A306CDFBE896]]></uid>
-        </SQLField>
-        <labelWindowIndex><![CDATA[22]]></labelWindowIndex>
-        <PK_KEY_NAME><![CDATA[personally_procured_moves_pkey]]></PK_KEY_NAME>
-        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
-        <uid><![CDATA[638BAF7C-21D1-4C84-B039-993B235E1BA2]]></uid>
-    </SQLTable>
-    <SQLTable>
-        <name><![CDATA[public.service_members]]></name>
-        <schema><![CDATA[public]]></schema>
-        <location>
-            <x>1330.00</x>
-            <y>670.00</y>
-        </location>
-        <size>
-            <width>317.00</width>
-            <height>440.00</height>
-        </size>
-        <zorder>18</zorder>
-        <SQLField>
-            <name><![CDATA[id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <primaryKey>1</primaryKey>
-            <forcedUnique><![CDATA[1]]></forcedUnique>
-            <notNull><![CDATA[1]]></notNull>
-            <PK_NAME><![CDATA[service_members_pkey]]></PK_NAME>
-            <uid><![CDATA[B6A911EF-81A8-4479-8FC5-38247FC132C3]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[user_id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <referencesField>id</referencesField>
-            <referencesTable>public.users</referencesTable>
-            <deleteAction>4</deleteAction>
-            <updateAction>4</updateAction>
-            <referencesField><![CDATA[id]]></referencesField>
-            <referencesTable><![CDATA[public.users]]></referencesTable>
-            <sourceCardinality>0</sourceCardinality>
-            <destinationCardinality>0</destinationCardinality>
-            <referencesFieldUID><![CDATA[CA49F042-645E-4AE3-98FE-5121B010AD74]]></referencesFieldUID>
-            <referencesTableUID><![CDATA[80C4B16B-6F69-48C0-A736-49B448DA3F05]]></referencesTableUID>
-            <foreignKeyName><![CDATA[service_members_user_id_fkey]]></foreignKeyName>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[6C617243-4BE0-4352-AD65-5626974A240F]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[edipi]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <uid><![CDATA[B6FD5DE4-3AB3-42A8-9D7A-8E3C9290ABE1]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[affiliation]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <uid><![CDATA[80C14462-6FF7-4B16-A5A7-F877A6BDE067]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[rank]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <uid><![CDATA[F4D52ED5-2C25-46FA-AFFC-AC8368E635D9]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[first_name]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <uid><![CDATA[AF7B3504-8CC3-4634-B4D0-815B99608DF7]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[middle_name]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <uid><![CDATA[390B5F0D-CE2B-4797-AF13-6A2E5A8CF1F5]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[last_name]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <uid><![CDATA[F451E524-4D7B-4679-86BE-9634440602BE]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[suffix]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <uid><![CDATA[38F07A40-3E1E-4A07-93FB-E55073D7FC77]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[telephone]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <uid><![CDATA[A92CB2C6-6872-4842-AAEA-5168B284F3E0]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[secondary_telephone]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <uid><![CDATA[686BFCA7-368C-48AB-8835-F0BFEE36E5DC]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[personal_email]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <uid><![CDATA[2CF8D3A4-1A88-4842-A053-060C3C0B85A9]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[phone_is_preferred]]></name>
-            <type><![CDATA[BOOLEAN]]></type>
-            <uid><![CDATA[39D85BAE-BA3B-42B8-8906-8D9AEDDDCC0B]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[text_message_is_preferred]]></name>
-            <type><![CDATA[BOOLEAN]]></type>
-            <uid><![CDATA[B83B3632-FDB1-4D79-868E-E5D40D67FA5B]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[email_is_preferred]]></name>
-            <type><![CDATA[BOOLEAN]]></type>
-            <uid><![CDATA[82A4B5AE-CEE9-4F53-BB21-5E86057AC4AC]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[residential_address_id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <referencesField>id</referencesField>
-            <referencesTable>public.addresses</referencesTable>
-            <deleteAction>4</deleteAction>
-            <updateAction>4</updateAction>
-            <referencesField><![CDATA[id]]></referencesField>
-            <referencesTable><![CDATA[public.addresses]]></referencesTable>
-            <sourceCardinality>0</sourceCardinality>
-            <destinationCardinality>0</destinationCardinality>
-            <referencesFieldUID><![CDATA[C9896DD5-D713-409E-B542-3BD4A00AAEE3]]></referencesFieldUID>
-            <referencesTableUID><![CDATA[41CC786C-E6D2-4FEA-992E-2F5DCDD20124]]></referencesTableUID>
-            <foreignKeyName><![CDATA[service_members_residential_address_id_fkey]]></foreignKeyName>
-            <uid><![CDATA[6FA204BF-333A-4B3B-9D0A-4AA028E57B17]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[backup_mailing_address_id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <referencesField>id</referencesField>
-            <referencesTable>public.addresses</referencesTable>
-            <deleteAction>4</deleteAction>
-            <updateAction>4</updateAction>
-            <referencesField><![CDATA[id]]></referencesField>
-            <referencesTable><![CDATA[public.addresses]]></referencesTable>
-            <sourceCardinality>0</sourceCardinality>
-            <destinationCardinality>0</destinationCardinality>
-            <referencesFieldUID><![CDATA[C9896DD5-D713-409E-B542-3BD4A00AAEE3]]></referencesFieldUID>
-            <referencesTableUID><![CDATA[41CC786C-E6D2-4FEA-992E-2F5DCDD20124]]></referencesTableUID>
-            <foreignKeyName><![CDATA[service_members_backup_mailing_address_id_fkey]]></foreignKeyName>
-            <uid><![CDATA[2F4A2377-3E41-4DB7-BAA3-D0F12E4E902A]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[created_at]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[158FA3C5-EF98-416A-A816-B9E66A8BE8A4]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[updated_at]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[170DBD37-AC3E-4F27-AB93-BDBDDF5D4645]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[social_security_number_id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <referencesField>id</referencesField>
-            <referencesTable>public.social_security_numbers</referencesTable>
-            <deleteAction>3</deleteAction>
-            <updateAction>4</updateAction>
-            <referencesField><![CDATA[id]]></referencesField>
-            <referencesTable><![CDATA[public.social_security_numbers]]></referencesTable>
-            <sourceCardinality>0</sourceCardinality>
-            <destinationCardinality>0</destinationCardinality>
-            <referencesFieldUID><![CDATA[8D2EF9B5-29DF-4BB6-8E65-19422BD0363C]]></referencesFieldUID>
-            <referencesTableUID><![CDATA[47635741-B6F3-4318-8B0D-48675587BF8A]]></referencesTableUID>
-            <foreignKeyName><![CDATA[sm_ssn_fk]]></foreignKeyName>
-            <uid><![CDATA[EB6D0680-1BD9-4690-AC4A-F072AF8FBB39]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[duty_station_id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <referencesField>id</referencesField>
-            <referencesTable>public.duty_stations</referencesTable>
-            <deleteAction>3</deleteAction>
-            <updateAction>4</updateAction>
-            <referencesField><![CDATA[id]]></referencesField>
-            <referencesTable><![CDATA[public.duty_stations]]></referencesTable>
-            <sourceCardinality>0</sourceCardinality>
-            <destinationCardinality>0</destinationCardinality>
-            <referencesFieldUID><![CDATA[0A85848D-FADC-4719-AB44-8F9E673234AD]]></referencesFieldUID>
-            <referencesTableUID><![CDATA[03D89D85-6A21-4730-AEDE-A6BB16BFE135]]></referencesTableUID>
-            <foreignKeyName><![CDATA[sm_duty_station_fk]]></foreignKeyName>
-            <uid><![CDATA[3EA808D7-5AFC-4661-9B00-EAD1514F8A87]]></uid>
-        </SQLField>
-        <labelWindowIndex><![CDATA[18]]></labelWindowIndex>
-        <PK_KEY_NAME><![CDATA[service_members_pkey]]></PK_KEY_NAME>
-        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
-        <uid><![CDATA[65F9FB8D-D6CB-491B-BFAF-02DEFD105FF1]]></uid>
-    </SQLTable>
-    <SQLTable>
-        <name><![CDATA[public.transportation_offices]]></name>
-        <schema><![CDATA[public]]></schema>
-        <location>
-            <x>1008.00</x>
-            <y>1710.00</y>
-        </location>
-        <size>
-            <width>317.00</width>
-            <height>260.00</height>
-        </size>
-        <zorder>5</zorder>
-        <SQLField>
-            <name><![CDATA[id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <primaryKey>1</primaryKey>
-            <forcedUnique><![CDATA[1]]></forcedUnique>
-            <notNull><![CDATA[1]]></notNull>
-            <PK_NAME><![CDATA[transportation_offices_pkey]]></PK_NAME>
-            <uid><![CDATA[9FEEEABA-006F-4DBB-B9F6-015D52A9711E]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[shipping_office_id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <referencesField>id</referencesField>
-            <referencesTable>public.transportation_offices</referencesTable>
-            <deleteAction>4</deleteAction>
-            <updateAction>4</updateAction>
-            <referencesField><![CDATA[id]]></referencesField>
-            <referencesTable><![CDATA[public.transportation_offices]]></referencesTable>
-            <sourceCardinality>0</sourceCardinality>
-            <destinationCardinality>0</destinationCardinality>
-            <referencesFieldUID><![CDATA[9FEEEABA-006F-4DBB-B9F6-015D52A9711E]]></referencesFieldUID>
-            <referencesTableUID><![CDATA[6E73DEA2-0F0A-4966-982B-9097EB58B20C]]></referencesTableUID>
-            <foreignKeyName><![CDATA[transportation_offices_shipping_office_id_fkey]]></foreignKeyName>
-            <uid><![CDATA[C1938C0E-7221-45A7-8BC0-D56AB582CCAC]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[name]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[608A5941-E529-4F62-BFBD-A5FE1590A8A0]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[address_id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <referencesField>id</referencesField>
-            <referencesTable>public.addresses</referencesTable>
-            <deleteAction>4</deleteAction>
-            <updateAction>4</updateAction>
-            <referencesField><![CDATA[id]]></referencesField>
-            <referencesTable><![CDATA[public.addresses]]></referencesTable>
-            <sourceCardinality>0</sourceCardinality>
-            <destinationCardinality>0</destinationCardinality>
-            <referencesFieldUID><![CDATA[C9896DD5-D713-409E-B542-3BD4A00AAEE3]]></referencesFieldUID>
-            <referencesTableUID><![CDATA[41CC786C-E6D2-4FEA-992E-2F5DCDD20124]]></referencesTableUID>
-            <foreignKeyName><![CDATA[transportation_offices_address_id_fkey]]></foreignKeyName>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[7EBBB842-C772-479F-90F3-EA23837BDA83]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[latitude]]></name>
-            <type><![CDATA[REAL]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[CE87BBB7-2DFF-44A1-832F-2A20EC5C7D96]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[longitude]]></name>
-            <type><![CDATA[REAL]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[5CC6D39D-EB5A-4E6C-A3A3-18C2E2DF27FA]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[hours]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <uid><![CDATA[7493FC96-A828-4453-932F-2BEC2B102E4B]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[services]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <uid><![CDATA[1517A022-80CA-463E-97B6-819E988A853C]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[note]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <uid><![CDATA[2CD85C7F-0D40-4B03-B605-2D96F51B2C4E]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[created_at]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[7F197A88-0581-45D8-8744-9B3EDF4064DE]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[updated_at]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[D0D89AD1-5725-4A73-B502-753CBBF293F7]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[gbloc]]></name>
-            <type><![CDATA[CHARACTER VARYING(255)]]></type>
-            <defaultValue><![CDATA['XXXX'::character varying]]></defaultValue>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[04787F33-7BD0-46BB-B892-AFE9A1B8C119]]></uid>
-        </SQLField>
-        <labelWindowIndex><![CDATA[5]]></labelWindowIndex>
-        <PK_KEY_NAME><![CDATA[transportation_offices_pkey]]></PK_KEY_NAME>
-        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
-        <uid><![CDATA[6E73DEA2-0F0A-4966-982B-9097EB58B20C]]></uid>
-    </SQLTable>
-    <SQLTable>
-        <name><![CDATA[public.tariff400ng_shorthaul_rates]]></name>
-        <schema><![CDATA[public]]></schema>
-        <location>
-            <x>1896.00</x>
-            <y>1420.00</y>
-        </location>
-        <size>
-            <width>298.00</width>
-            <height>180.00</height>
-        </size>
-        <zorder>9</zorder>
-        <SQLField>
-            <name><![CDATA[id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <uid><![CDATA[32C4DCF7-ECA6-4D6E-A830-1BA0AEEB5CB5]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[cwt_miles_lower]]></name>
-            <type><![CDATA[INTEGER]]></type>
-            <uid><![CDATA[0BEB26BF-971E-4590-8EE2-74CC3CE0E92E]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[cwt_miles_upper]]></name>
-            <type><![CDATA[INTEGER]]></type>
-            <uid><![CDATA[9E14CD28-F24D-4795-91E9-AFB7AEE9CC89]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[rate_cents]]></name>
-            <type><![CDATA[INTEGER]]></type>
-            <uid><![CDATA[508EA424-D2A3-4864-9BF4-1CF70D30FDF8]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[effective_date_lower]]></name>
-            <type><![CDATA[DATE]]></type>
-            <uid><![CDATA[8418364E-7FF0-476E-A87F-0CE07EB96B5E]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[effective_date_upper]]></name>
-            <type><![CDATA[DATE]]></type>
-            <uid><![CDATA[B6E6861E-75F9-4CED-B9B1-8E61ED817B90]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[created_at]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <uid><![CDATA[96F1B0EC-7A2D-4322-83B3-B43FB3BBDCB3]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[updated_at]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <uid><![CDATA[A2ABDB6B-20E7-480C-98D3-FA612ADF53D8]]></uid>
-        </SQLField>
-        <labelWindowIndex><![CDATA[9]]></labelWindowIndex>
-        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
-        <uid><![CDATA[719E78C9-8966-4B7F-92A3-ECE2B287D5A1]]></uid>
-    </SQLTable>
-    <SQLTable>
-        <name><![CDATA[public.service_agents]]></name>
-        <schema><![CDATA[public]]></schema>
-        <location>
-            <x>1003.00</x>
-            <y>670.00</y>
-        </location>
-        <size>
-            <width>317.00</width>
-            <height>260.00</height>
-        </size>
-        <zorder>19</zorder>
-        <SQLField>
-            <name><![CDATA[id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <primaryKey>1</primaryKey>
-            <notNull><![CDATA[1]]></notNull>
-            <PK_NAME><![CDATA[service_agents_pkey]]></PK_NAME>
-            <uid><![CDATA[E23737FE-810C-4F40-BA5A-676C5AA656A4]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[shipment_id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <referencesField>id</referencesField>
-            <referencesTable>public.shipments</referencesTable>
-            <deleteAction>4</deleteAction>
-            <updateAction>4</updateAction>
-            <referencesField><![CDATA[id]]></referencesField>
-            <referencesTable><![CDATA[public.shipments]]></referencesTable>
-            <sourceCardinality>0</sourceCardinality>
-            <destinationCardinality>0</destinationCardinality>
-            <referencesFieldUID><![CDATA[444DF8FF-1B94-44BC-AF1E-9535B4AE7E8D]]></referencesFieldUID>
-            <referencesTableUID><![CDATA[4ACF24EB-68A1-460A-97CD-EC9A3D9BF4CC]]></referencesTableUID>
-            <foreignKeyName><![CDATA[service_agents_shipment_id_fkey]]></foreignKeyName>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[5B64259A-E6E6-491B-8571-157A47DA73FF]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[role]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[58F553AD-A7E9-4F31-BA6D-717AA2DC965E]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[email]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <uid><![CDATA[5349826A-4C62-4424-BB20-D34E27A258AD]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[phone_number]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <uid><![CDATA[2CA379AE-EC11-44A8-8859-56AA9B6C9C8B]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[fax_number]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <uid><![CDATA[4A5DAAFD-788D-4568-AD6A-2CDD779D43FE]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[email_is_preferred]]></name>
-            <type><![CDATA[BOOLEAN]]></type>
-            <uid><![CDATA[643B5748-D5E2-47B1-854D-48CA996E231F]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[phone_is_preferred]]></name>
-            <type><![CDATA[BOOLEAN]]></type>
-            <uid><![CDATA[00E5365E-13E1-4CB0-BA69-711474AB221A]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[notes]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <uid><![CDATA[21A93169-0802-4E1E-B373-661CA9826DF6]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[created_at]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[3415BA58-9399-4147-8A33-9661E460B18D]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[updated_at]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[B59BB805-B248-4A22-B280-C0C0C3D3396C]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[company]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[0239EA06-44E3-4238-ADDA-266F1A615645]]></uid>
-        </SQLField>
-        <labelWindowIndex><![CDATA[19]]></labelWindowIndex>
-        <PK_KEY_NAME><![CDATA[service_agents_pkey]]></PK_KEY_NAME>
-        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
-        <uid><![CDATA[720A24B5-CE9B-44B7-9D68-C03B45616DB1]]></uid>
+        <uid><![CDATA[200FAC1E-616C-4A2E-8E47-7C9D38CBFBED]]></uid>
     </SQLTable>
     <SQLTable>
         <name><![CDATA[public.schema_migration]]></name>
@@ -1612,463 +281,11 @@
             <name><![CDATA[version]]></name>
             <type><![CDATA[CHARACTER VARYING(255)]]></type>
             <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[6D888192-58DB-473C-A132-2C8952B1D29D]]></uid>
+            <uid><![CDATA[0A52C77A-6C5E-4C23-B148-ADFE6D102C33]]></uid>
         </SQLField>
         <labelWindowIndex><![CDATA[20]]></labelWindowIndex>
         <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
-        <uid><![CDATA[745C7610-29F3-4F45-8925-855B313132F3]]></uid>
-    </SQLTable>
-    <SQLTable>
-        <name><![CDATA[public.signed_certifications]]></name>
-        <schema><![CDATA[public]]></schema>
-        <location>
-            <x>10.00</x>
-            <y>1420.00</y>
-        </location>
-        <size>
-            <width>317.00</width>
-            <height>180.00</height>
-        </size>
-        <zorder>15</zorder>
-        <SQLField>
-            <name><![CDATA[id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <primaryKey>1</primaryKey>
-            <notNull><![CDATA[1]]></notNull>
-            <PK_NAME><![CDATA[signed_certifications_pkey]]></PK_NAME>
-            <uid><![CDATA[A801D809-9E93-4934-9F79-EB3F6FB4136D]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[submitting_user_id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <referencesField>id</referencesField>
-            <referencesTable>public.users</referencesTable>
-            <deleteAction>4</deleteAction>
-            <updateAction>4</updateAction>
-            <referencesField><![CDATA[id]]></referencesField>
-            <referencesTable><![CDATA[public.users]]></referencesTable>
-            <sourceCardinality>0</sourceCardinality>
-            <destinationCardinality>0</destinationCardinality>
-            <referencesFieldUID><![CDATA[CA49F042-645E-4AE3-98FE-5121B010AD74]]></referencesFieldUID>
-            <referencesTableUID><![CDATA[80C4B16B-6F69-48C0-A736-49B448DA3F05]]></referencesTableUID>
-            <foreignKeyName><![CDATA[signed_certifications_submitting_user_id_fkey]]></foreignKeyName>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[37E2CDE7-BC57-49E2-832B-37A56FA91692]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[move_id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[19D1EBEF-19EB-4A2A-B47A-AA6DCAA8E036]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[certification_text]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[931A5C50-7052-4E77-BBFF-61CD4D86DF85]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[signature]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[A4E754B4-3DBE-4946-A2F7-CA5ECE1C6E23]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[date]]></name>
-            <type><![CDATA[DATE]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[5A79D258-BDC8-453D-8286-1C12E92221FE]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[created_at]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[69647E23-246D-4C2E-83F6-7E288D41BB9B]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[updated_at]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[EEC1A162-3CF2-4D7E-97BB-679645D56382]]></uid>
-        </SQLField>
-        <labelWindowIndex><![CDATA[15]]></labelWindowIndex>
-        <PK_KEY_NAME><![CDATA[signed_certifications_pkey]]></PK_KEY_NAME>
-        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
-        <uid><![CDATA[7CBB4F51-DDE1-4F49-A70E-963861FA3BB9]]></uid>
-    </SQLTable>
-    <SQLTable>
-        <name><![CDATA[public.office_emails]]></name>
-        <schema><![CDATA[public]]></schema>
-        <location>
-            <x>1035.00</x>
-            <y>260.00</y>
-        </location>
-        <size>
-            <width>317.00</width>
-            <height>140.00</height>
-        </size>
-        <zorder>26</zorder>
-        <SQLField>
-            <name><![CDATA[id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <primaryKey>1</primaryKey>
-            <notNull><![CDATA[1]]></notNull>
-            <PK_NAME><![CDATA[office_emails_pkey]]></PK_NAME>
-            <uid><![CDATA[9560CE95-B7F6-48B0-8D06-4C3456B2EEB2]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[transportation_office_id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <referencesField>id</referencesField>
-            <referencesTable>public.transportation_offices</referencesTable>
-            <deleteAction>4</deleteAction>
-            <updateAction>4</updateAction>
-            <referencesField><![CDATA[id]]></referencesField>
-            <referencesTable><![CDATA[public.transportation_offices]]></referencesTable>
-            <sourceCardinality>0</sourceCardinality>
-            <destinationCardinality>0</destinationCardinality>
-            <referencesFieldUID><![CDATA[9FEEEABA-006F-4DBB-B9F6-015D52A9711E]]></referencesFieldUID>
-            <referencesTableUID><![CDATA[6E73DEA2-0F0A-4966-982B-9097EB58B20C]]></referencesTableUID>
-            <foreignKeyName><![CDATA[office_emails_transportation_office_id_fkey]]></foreignKeyName>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[88122BE3-ECDA-44BB-9538-C064A85AD7DD]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[email]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[E131EBB8-2C0B-4F43-A7FE-721C62B31A81]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[label]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <uid><![CDATA[97562534-86DF-477E-A6AC-B5B8E78046C2]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[created_at]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[7D6D668A-78E9-4EBD-875F-2AF56D6EC7FB]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[updated_at]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[07E80A84-5477-4D36-B90C-A01D8C352F24]]></uid>
-        </SQLField>
-        <labelWindowIndex><![CDATA[26]]></labelWindowIndex>
-        <PK_KEY_NAME><![CDATA[office_emails_pkey]]></PK_KEY_NAME>
-        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
-        <uid><![CDATA[7D6B48DE-C504-4D0F-AD02-38785605DCF2]]></uid>
-    </SQLTable>
-    <SQLTable>
-        <name><![CDATA[public.users]]></name>
-        <schema><![CDATA[public]]></schema>
-        <location>
-            <x>337.00</x>
-            <y>2020.00</y>
-        </location>
-        <size>
-            <width>317.00</width>
-            <height>140.00</height>
-        </size>
-        <zorder>0</zorder>
-        <SQLField>
-            <name><![CDATA[id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <primaryKey>1</primaryKey>
-            <forcedUnique><![CDATA[1]]></forcedUnique>
-            <notNull><![CDATA[1]]></notNull>
-            <PK_NAME><![CDATA[users_pkey]]></PK_NAME>
-            <uid><![CDATA[CA49F042-645E-4AE3-98FE-5121B010AD74]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[login_gov_uuid]]></name>
-            <type><![CDATA[UUID]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[E2295E92-7EB3-4F0F-9A81-2D8666272F80]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[login_gov_email]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[AE15A348-60B2-44B2-ACE9-F801414F311E]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[created_at]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[49D73217-9637-48C6-92BB-B7DAFD51C6F7]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[updated_at]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[2AE1B849-00D2-4E1E-8B48-B9A797F29620]]></uid>
-        </SQLField>
-        <SQLConstraint>
-            <name><![CDATA[constraint_name]]></name>
-            <fieldName><![CDATA[login_gov_uuid]]></fieldName>
-            <SQLIndexEntry>
-                <name><![CDATA[login_gov_uuid]]></name>
-                <prefixSize><![CDATA[]]></prefixSize>
-                <fieldUid><![CDATA[E2295E92-7EB3-4F0F-9A81-2D8666272F80]]></fieldUid>
-            </SQLIndexEntry>
-            <deferrable><![CDATA[0]]></deferrable>
-            <indexType><![CDATA[UNIQUE]]></indexType>
-            <initiallyDeferred><![CDATA[0]]></initiallyDeferred>
-            <uid><![CDATA[87776E17-9C37-4506-B18F-CA5A230877BF]]></uid>
-        </SQLConstraint>
-        <labelWindowIndex><![CDATA[0]]></labelWindowIndex>
-        <PK_KEY_NAME><![CDATA[users_pkey]]></PK_KEY_NAME>
-        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
-        <uid><![CDATA[80C4B16B-6F69-48C0-A736-49B448DA3F05]]></uid>
-    </SQLTable>
-    <SQLTable>
-        <name><![CDATA[public.transportation_service_provider_performances]]></name>
-        <schema><![CDATA[public]]></schema>
-        <location>
-            <x>1335.00</x>
-            <y>1710.00</y>
-        </location>
-        <size>
-            <width>342.00</width>
-            <height>300.00</height>
-        </size>
-        <zorder>4</zorder>
-        <SQLField>
-            <name><![CDATA[id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <primaryKey>1</primaryKey>
-            <notNull><![CDATA[1]]></notNull>
-            <PK_NAME><![CDATA[transportation_service_provider_performances_pkey]]></PK_NAME>
-            <uid><![CDATA[42112A3D-D8E4-405E-A552-063A4A826B71]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[performance_period_start]]></name>
-            <type><![CDATA[DATE]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[AB44163C-0B6C-485B-86D3-C2931A5215EC]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[performance_period_end]]></name>
-            <type><![CDATA[DATE]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[6C640999-31BC-4364-BA55-B4C7E5415180]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[traffic_distribution_list_id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <referencesField>id</referencesField>
-            <referencesTable>public.traffic_distribution_lists</referencesTable>
-            <deleteAction>4</deleteAction>
-            <updateAction>4</updateAction>
-            <referencesField><![CDATA[id]]></referencesField>
-            <referencesTable><![CDATA[public.traffic_distribution_lists]]></referencesTable>
-            <sourceCardinality>0</sourceCardinality>
-            <destinationCardinality>0</destinationCardinality>
-            <referencesFieldUID><![CDATA[FEBF637A-361A-4BE0-92F2-40CE87A7F022]]></referencesFieldUID>
-            <referencesTableUID><![CDATA[B9904F5A-2E70-4B7F-A129-74F7A096DAC8]]></referencesTableUID>
-            <foreignKeyName><![CDATA[transportation_service_provid_traffic_distribution_list_id_fkey]]></foreignKeyName>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[66E3E8A7-5950-41A9-AE8A-CC291210AEA3]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[quality_band]]></name>
-            <type><![CDATA[INTEGER]]></type>
-            <uid><![CDATA[B097AD96-54B5-4E93-8415-131573D284E3]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[offer_count]]></name>
-            <type><![CDATA[INTEGER]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[054BA0D9-5510-43B9-BF53-ECD4507704BE]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[best_value_score]]></name>
-            <type><![CDATA[DOUBLE PRECISION]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[551BDEDE-2FE3-44E1-A513-5D6B090C6AD9]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[transportation_service_provider_id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <referencesField>id</referencesField>
-            <referencesTable>public.transportation_service_providers</referencesTable>
-            <deleteAction>4</deleteAction>
-            <updateAction>4</updateAction>
-            <referencesField><![CDATA[id]]></referencesField>
-            <referencesTable><![CDATA[public.transportation_service_providers]]></referencesTable>
-            <sourceCardinality>0</sourceCardinality>
-            <destinationCardinality>0</destinationCardinality>
-            <referencesFieldUID><![CDATA[A2D863BD-8C57-43C8-8BAE-0C9C34CF256D]]></referencesFieldUID>
-            <referencesTableUID><![CDATA[8E1A9983-4596-4C6A-B7CF-984C412C5DAB]]></referencesTableUID>
-            <foreignKeyName><![CDATA[transportation_service_provid_transportation_service_provi_fkey]]></foreignKeyName>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[B82E30EE-AF2C-4BF1-A476-6301BCF053E0]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[created_at]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[8FB170A2-E9DB-41F9-AB2C-A9013A78B657]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[updated_at]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[F355312F-EFBC-481C-86F4-66C3EAAFF928]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[rate_cycle_start]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[ED3332D6-B81A-4DFE-919E-A4C13D320A33]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[rate_cycle_end]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[874B70F3-6FAE-4D3A-B45F-A0F35D2E0BDF]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[linehaul_rate]]></name>
-            <type><![CDATA[DOUBLE PRECISION]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[E0F0CC86-2B7F-41DB-A2CD-4C5DC40A975D]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[sit_rate]]></name>
-            <type><![CDATA[DOUBLE PRECISION]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[09A4E958-1BE3-46FF-9AC2-186B016D9B52]]></uid>
-        </SQLField>
-        <labelWindowIndex><![CDATA[4]]></labelWindowIndex>
-        <PK_KEY_NAME><![CDATA[transportation_service_provider_performances_pkey]]></PK_KEY_NAME>
-        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
-        <uid><![CDATA[82BCAE49-D26F-488C-B34C-B67DFEB6979A]]></uid>
-    </SQLTable>
-    <SQLTable>
-        <name><![CDATA[public.tariff400ng_zip3s]]></name>
-        <schema><![CDATA[public]]></schema>
-        <location>
-            <x>10.00</x>
-            <y>1710.00</y>
-        </location>
-        <size>
-            <width>298.00</width>
-            <height>200.00</height>
-        </size>
-        <zorder>8</zorder>
-        <SQLField>
-            <name><![CDATA[id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <uid><![CDATA[2456414B-FABB-408A-BAE0-B9F261349890]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[zip3]]></name>
-            <type><![CDATA[CHARACTER VARYING(3)]]></type>
-            <uid><![CDATA[0A2391C2-1951-4C95-8095-D47D39407E2F]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[basepoint_city]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <uid><![CDATA[3BF2B96C-654A-441E-85E8-F69730D3E1AB]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[state]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <uid><![CDATA[153C92EF-3E58-4E85-A47C-B3F5C38902CC]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[service_area]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <uid><![CDATA[00A70203-073C-4A22-B208-75927A1D58D3]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[rate_area]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <uid><![CDATA[8ACE86FC-632C-4C89-A06A-6D747344FAEE]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[region]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <uid><![CDATA[505070FD-D8C4-4E11-B5E8-D4417A29DD64]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[created_at]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <uid><![CDATA[927F54CA-80AE-4742-BFAB-54805DC8F340]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[updated_at]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <uid><![CDATA[B7063451-B155-4EC2-83C2-4BDB9FB485DC]]></uid>
-        </SQLField>
-        <labelWindowIndex><![CDATA[8]]></labelWindowIndex>
-        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
-        <uid><![CDATA[878DF656-F82B-4896-BEF3-406C035E9F94]]></uid>
-    </SQLTable>
-    <SQLTable>
-        <name><![CDATA[public.tariff400ng_full_pack_rates]]></name>
-        <schema><![CDATA[public]]></schema>
-        <location>
-            <x>664.00</x>
-            <y>1420.00</y>
-        </location>
-        <size>
-            <width>298.00</width>
-            <height>200.00</height>
-        </size>
-        <zorder>13</zorder>
-        <SQLField>
-            <name><![CDATA[id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <uid><![CDATA[12196B33-8058-4D68-AFB4-8E33B7634B24]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[schedule]]></name>
-            <type><![CDATA[INTEGER]]></type>
-            <uid><![CDATA[FA2D945D-1AF1-4C7B-BA2C-53DB6BFC7F87]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[weight_lbs_lower]]></name>
-            <type><![CDATA[INTEGER]]></type>
-            <uid><![CDATA[AF2A4333-5EB4-45B8-BCC0-441245FB4B70]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[weight_lbs_upper]]></name>
-            <type><![CDATA[INTEGER]]></type>
-            <uid><![CDATA[A8C3D36D-46C8-49FA-9200-637AA9F7FED1]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[rate_cents]]></name>
-            <type><![CDATA[INTEGER]]></type>
-            <uid><![CDATA[85E919DB-33A7-46A2-B769-6DF6310A45E6]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[effective_date_lower]]></name>
-            <type><![CDATA[DATE]]></type>
-            <uid><![CDATA[92209059-9B95-4CF8-958A-2300F9F234E6]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[effective_date_upper]]></name>
-            <type><![CDATA[DATE]]></type>
-            <uid><![CDATA[10263AF5-E60C-4AC6-8056-7250EDFC78CF]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[created_at]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <uid><![CDATA[C52EF283-17C7-44A8-93B5-4307D90E76CE]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[updated_at]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <uid><![CDATA[F0C166DA-C98D-410A-81F8-7C2EB8045AFD]]></uid>
-        </SQLField>
-        <labelWindowIndex><![CDATA[13]]></labelWindowIndex>
-        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
-        <uid><![CDATA[8C569614-32EF-4EE9-A06D-B245BF9D93AB]]></uid>
+        <uid><![CDATA[2FD18A97-97EC-4CBF-86E1-562DCBC985F9]]></uid>
     </SQLTable>
     <SQLTable>
         <name><![CDATA[public.transportation_service_providers]]></name>
@@ -2089,309 +306,30 @@
             <forcedUnique><![CDATA[1]]></forcedUnique>
             <notNull><![CDATA[1]]></notNull>
             <PK_NAME><![CDATA[transportation_service_providers_pkey]]></PK_NAME>
-            <uid><![CDATA[A2D863BD-8C57-43C8-8BAE-0C9C34CF256D]]></uid>
+            <uid><![CDATA[093BF0ED-A127-4BA8-B389-1FA79F673331]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[standard_carrier_alpha_code]]></name>
             <type><![CDATA[TEXT]]></type>
             <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[F402227F-0403-44C1-8A68-06A73AFC6115]]></uid>
+            <uid><![CDATA[4D851285-94FE-41BD-8BC9-D041A22F72C4]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[created_at]]></name>
             <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
             <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[3B4823B1-5AC0-4CDE-A11F-C593EF956F0D]]></uid>
+            <uid><![CDATA[A37EE15C-F39F-4B7A-9A4C-CD0E574D8E91]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[updated_at]]></name>
             <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
             <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[86399424-6F08-4595-B1B0-4838B8B0E1C1]]></uid>
+            <uid><![CDATA[3E90FD4F-CE61-4319-BCF6-DE36FD3D2DDB]]></uid>
         </SQLField>
         <labelWindowIndex><![CDATA[3]]></labelWindowIndex>
         <PK_KEY_NAME><![CDATA[transportation_service_providers_pkey]]></PK_KEY_NAME>
         <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
-        <uid><![CDATA[8E1A9983-4596-4C6A-B7CF-984C412C5DAB]]></uid>
-    </SQLTable>
-    <SQLTable>
-        <name><![CDATA[public.office_users]]></name>
-        <schema><![CDATA[public]]></schema>
-        <location>
-            <x>1689.00</x>
-            <y>260.00</y>
-        </location>
-        <size>
-            <width>317.00</width>
-            <height>220.00</height>
-        </size>
-        <zorder>24</zorder>
-        <SQLField>
-            <name><![CDATA[id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <primaryKey>1</primaryKey>
-            <notNull><![CDATA[1]]></notNull>
-            <PK_NAME><![CDATA[office_users_pkey]]></PK_NAME>
-            <uid><![CDATA[EFB4AC92-BDA8-4291-A6D1-686626FE4135]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[user_id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <referencesField>id</referencesField>
-            <referencesTable>public.users</referencesTable>
-            <deleteAction>4</deleteAction>
-            <updateAction>4</updateAction>
-            <referencesField><![CDATA[id]]></referencesField>
-            <referencesTable><![CDATA[public.users]]></referencesTable>
-            <sourceCardinality>0</sourceCardinality>
-            <destinationCardinality>0</destinationCardinality>
-            <referencesFieldUID><![CDATA[CA49F042-645E-4AE3-98FE-5121B010AD74]]></referencesFieldUID>
-            <referencesTableUID><![CDATA[80C4B16B-6F69-48C0-A736-49B448DA3F05]]></referencesTableUID>
-            <foreignKeyName><![CDATA[office_users_user_id_fkey]]></foreignKeyName>
-            <uid><![CDATA[698A02C9-66D2-43BB-9BC3-96E9CD599C96]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[last_name]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[B28AB765-3CFB-4391-B102-9ACF3052FFCE]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[first_name]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[A1991B52-468A-4154-B500-082F66BA6716]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[middle_initials]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <uid><![CDATA[A3294294-62AD-4530-B2F2-2152C2ADEA3C]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[email]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[DE16EE9E-8960-4BEA-890A-BB32FFEE4DC0]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[telephone]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[9852C9E9-B66E-4504-B449-0AAF664992E3]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[transportation_office_id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <referencesField>id</referencesField>
-            <referencesTable>public.transportation_offices</referencesTable>
-            <deleteAction>4</deleteAction>
-            <updateAction>4</updateAction>
-            <referencesField><![CDATA[id]]></referencesField>
-            <referencesTable><![CDATA[public.transportation_offices]]></referencesTable>
-            <sourceCardinality>0</sourceCardinality>
-            <destinationCardinality>0</destinationCardinality>
-            <referencesFieldUID><![CDATA[9FEEEABA-006F-4DBB-B9F6-015D52A9711E]]></referencesFieldUID>
-            <referencesTableUID><![CDATA[6E73DEA2-0F0A-4966-982B-9097EB58B20C]]></referencesTableUID>
-            <foreignKeyName><![CDATA[office_users_transportation_office_id_fkey]]></foreignKeyName>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[ED90AC74-9604-40D7-B634-9065A13B1EBB]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[created_at]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[22ADF02A-D106-4C8F-B5D1-1F5A94192DEC]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[updated_at]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[83EFD3DC-A01C-48C5-9694-4F9ED26A41F4]]></uid>
-        </SQLField>
-        <labelWindowIndex><![CDATA[24]]></labelWindowIndex>
-        <PK_KEY_NAME><![CDATA[office_users_pkey]]></PK_KEY_NAME>
-        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
-        <uid><![CDATA[AC8711E4-1E00-4432-81EB-BFE3F9A80BBD]]></uid>
-    </SQLTable>
-    <SQLTable>
-        <name><![CDATA[public.traffic_distribution_lists]]></name>
-        <schema><![CDATA[public]]></schema>
-        <location>
-            <x>626.00</x>
-            <y>1710.00</y>
-        </location>
-        <size>
-            <width>372.00</width>
-            <height>160.00</height>
-        </size>
-        <zorder>6</zorder>
-        <SQLField>
-            <name><![CDATA[id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <primaryKey>1</primaryKey>
-            <forcedUnique><![CDATA[1]]></forcedUnique>
-            <notNull><![CDATA[1]]></notNull>
-            <PK_NAME><![CDATA[traffic_distribution_lists_pkey]]></PK_NAME>
-            <uid><![CDATA[FEBF637A-361A-4BE0-92F2-40CE87A7F022]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[source_rate_area]]></name>
-            <type><![CDATA[CHARACTER VARYING(255)]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[45B9D9BC-065F-4EEC-B9EA-DA3FA8D1BDDE]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[destination_region]]></name>
-            <type><![CDATA[CHARACTER VARYING(255)]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[6321683E-51D5-4A62-B96D-6BFDC98820ED]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[code_of_service]]></name>
-            <type><![CDATA[CHARACTER VARYING(255)]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[4EE8F96E-806A-4BD6-BCA4-E9BBEA1688A9]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[created_at]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[1A934A77-DCE7-4A45-B2F1-C7B621724AEE]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[updated_at]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[14AE19AB-CE54-44A2-A08F-BE98A6B96A47]]></uid>
-        </SQLField>
-        <SQLConstraint>
-            <name><![CDATA[unique_channel_cos]]></name>
-            <fieldName><![CDATA[source_rate_area]]></fieldName>
-            <fieldName><![CDATA[destination_region]]></fieldName>
-            <fieldName><![CDATA[code_of_service]]></fieldName>
-            <SQLIndexEntry>
-                <name><![CDATA[source_rate_area]]></name>
-                <prefixSize><![CDATA[]]></prefixSize>
-                <fieldUid><![CDATA[45B9D9BC-065F-4EEC-B9EA-DA3FA8D1BDDE]]></fieldUid>
-            </SQLIndexEntry>
-            <SQLIndexEntry>
-                <name><![CDATA[destination_region]]></name>
-                <prefixSize><![CDATA[]]></prefixSize>
-                <fieldUid><![CDATA[6321683E-51D5-4A62-B96D-6BFDC98820ED]]></fieldUid>
-            </SQLIndexEntry>
-            <SQLIndexEntry>
-                <name><![CDATA[code_of_service]]></name>
-                <prefixSize><![CDATA[]]></prefixSize>
-                <fieldUid><![CDATA[4EE8F96E-806A-4BD6-BCA4-E9BBEA1688A9]]></fieldUid>
-            </SQLIndexEntry>
-            <deferrable><![CDATA[0]]></deferrable>
-            <indexType><![CDATA[UNIQUE]]></indexType>
-            <initiallyDeferred><![CDATA[0]]></initiallyDeferred>
-            <uid><![CDATA[F6AD88FC-E808-4971-86FD-CFBEE7421B33]]></uid>
-        </SQLConstraint>
-        <labelWindowIndex><![CDATA[6]]></labelWindowIndex>
-        <PK_KEY_NAME><![CDATA[traffic_distribution_lists_pkey]]></PK_KEY_NAME>
-        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
-        <uid><![CDATA[B9904F5A-2E70-4B7F-A129-74F7A096DAC8]]></uid>
-    </SQLTable>
-    <SQLTable>
-        <name><![CDATA[public.tsp_users]]></name>
-        <schema><![CDATA[public]]></schema>
-        <location>
-            <x>2014.00</x>
-            <y>1710.00</y>
-        </location>
-        <size>
-            <width>317.00</width>
-            <height>220.00</height>
-        </size>
-        <zorder>2</zorder>
-        <SQLField>
-            <name><![CDATA[id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <primaryKey>1</primaryKey>
-            <notNull><![CDATA[1]]></notNull>
-            <PK_NAME><![CDATA[tsp_users_pkey]]></PK_NAME>
-            <uid><![CDATA[B0CF2A46-C83E-443D-BD96-895A21B9FE7B]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[user_id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <referencesField>id</referencesField>
-            <referencesTable>public.users</referencesTable>
-            <deleteAction>4</deleteAction>
-            <updateAction>4</updateAction>
-            <referencesField><![CDATA[id]]></referencesField>
-            <referencesTable><![CDATA[public.users]]></referencesTable>
-            <sourceCardinality>0</sourceCardinality>
-            <destinationCardinality>0</destinationCardinality>
-            <referencesFieldUID><![CDATA[CA49F042-645E-4AE3-98FE-5121B010AD74]]></referencesFieldUID>
-            <referencesTableUID><![CDATA[80C4B16B-6F69-48C0-A736-49B448DA3F05]]></referencesTableUID>
-            <foreignKeyName><![CDATA[tsp_users_user_id_fkey]]></foreignKeyName>
-            <uid><![CDATA[A5FCA712-2ACE-43D8-861F-A1CE9A1A74AF]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[last_name]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[62DE0EC3-C1F1-44A0-8756-3DEA08F19035]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[first_name]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[A2571964-B4DC-4BF1-8240-5DD2E826FC93]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[middle_initials]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <uid><![CDATA[0DDB2D4A-FE41-4F24-8029-44AE65E10F2B]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[email]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[0853A95E-D0EB-4DE9-9DB4-993EC2D83D8D]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[telephone]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[54DC7B0A-9ED2-46DE-A590-14BBC6FAFF66]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[transportation_service_provider_id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <referencesField>id</referencesField>
-            <referencesTable>public.transportation_service_providers</referencesTable>
-            <deleteAction>4</deleteAction>
-            <updateAction>4</updateAction>
-            <referencesField><![CDATA[id]]></referencesField>
-            <referencesTable><![CDATA[public.transportation_service_providers]]></referencesTable>
-            <sourceCardinality>0</sourceCardinality>
-            <destinationCardinality>0</destinationCardinality>
-            <referencesFieldUID><![CDATA[A2D863BD-8C57-43C8-8BAE-0C9C34CF256D]]></referencesFieldUID>
-            <referencesTableUID><![CDATA[8E1A9983-4596-4C6A-B7CF-984C412C5DAB]]></referencesTableUID>
-            <foreignKeyName><![CDATA[tsp_users_transportation_service_provider_id_fkey]]></foreignKeyName>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[B9BA998E-A189-4E46-AA4E-1713B3A5F33F]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[created_at]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[41C1A2B0-2E37-41F2-99C5-8C4850F23753]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[updated_at]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[70B4120F-A02A-4074-A75D-5A5A46341AC3]]></uid>
-        </SQLField>
-        <labelWindowIndex><![CDATA[2]]></labelWindowIndex>
-        <PK_KEY_NAME><![CDATA[tsp_users_pkey]]></PK_KEY_NAME>
-        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
-        <uid><![CDATA[C6A7E0FB-9A7B-4964-B440-B6F820415923]]></uid>
+        <uid><![CDATA[342FBF63-1DB7-4D4F-9801-9F04DC431050]]></uid>
     </SQLTable>
     <SQLTable>
         <name><![CDATA[public.moves]]></name>
@@ -2412,24 +350,24 @@
             <forcedUnique><![CDATA[1]]></forcedUnique>
             <notNull><![CDATA[1]]></notNull>
             <PK_NAME><![CDATA[moves_pkey]]></PK_NAME>
-            <uid><![CDATA[53E01484-FFCD-4FBC-9485-729CEBA02C23]]></uid>
+            <uid><![CDATA[976D74A1-8C1A-417A-B491-251673CFAC90]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[selected_move_type]]></name>
             <type><![CDATA[CHARACTER VARYING(255)]]></type>
-            <uid><![CDATA[FB9C6B36-2A8B-4BC7-BC52-E64D4468E027]]></uid>
+            <uid><![CDATA[BB08A076-AC99-442B-AAC7-8B73217A005C]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[created_at]]></name>
             <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
             <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[143660CB-23E0-4535-B6E9-6CD464E3A40F]]></uid>
+            <uid><![CDATA[422CAC82-55D8-4782-8B77-F74D6407801A]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[updated_at]]></name>
             <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
             <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[4F5A1454-55BF-4749-900C-6D4A27D22B23]]></uid>
+            <uid><![CDATA[7A7DC87C-2C51-4352-AAEC-6DB04C169CDB]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[orders_id]]></name>
@@ -2442,285 +380,89 @@
             <referencesTable><![CDATA[public.orders]]></referencesTable>
             <sourceCardinality>0</sourceCardinality>
             <destinationCardinality>0</destinationCardinality>
-            <referencesFieldUID><![CDATA[92DD14FA-F23C-4ABF-B777-0B5543D6F459]]></referencesFieldUID>
-            <referencesTableUID><![CDATA[D4AFD9A1-67A2-473F-A087-63B26B8034B9]]></referencesTableUID>
+            <referencesFieldUID><![CDATA[0A300203-302D-41F4-9CA5-BB45E663C260]]></referencesFieldUID>
+            <referencesTableUID><![CDATA[4C003849-8BD2-4591-B4CB-0C371A997836]]></referencesTableUID>
             <foreignKeyName><![CDATA[moves_orders_id_fk]]></foreignKeyName>
             <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[0ADB49A5-8078-4465-AFC0-A70EA48D5557]]></uid>
+            <uid><![CDATA[6ACFEC31-5384-4915-8422-8EE23A5C9E6E]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[status]]></name>
             <type><![CDATA[CHARACTER VARYING(255)]]></type>
             <defaultValue><![CDATA['DRAFT'::character varying]]></defaultValue>
             <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[F26CC75A-B71F-4899-96EA-0374A0818447]]></uid>
+            <uid><![CDATA[C047B5BB-42B7-467C-9B04-55852FA45769]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[locator]]></name>
             <type><![CDATA[CHARACTER(6)]]></type>
-            <uid><![CDATA[4DF4895B-7E56-4BB3-8CE8-8223ABD10219]]></uid>
+            <uid><![CDATA[83B032CF-1A51-4C70-A546-3EAEACBA6574]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[cancel_reason]]></name>
             <type><![CDATA[CHARACTER VARYING(255)]]></type>
-            <uid><![CDATA[3F6627D0-B711-4278-86ED-1E7547417C0D]]></uid>
+            <uid><![CDATA[80C5DA9E-FBFB-428E-9B9C-1B3DFE8E574A]]></uid>
         </SQLField>
         <labelWindowIndex><![CDATA[28]]></labelWindowIndex>
         <PK_KEY_NAME><![CDATA[moves_pkey]]></PK_KEY_NAME>
         <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
-        <uid><![CDATA[C8C105E2-3679-4B84-BC12-B7A46073F848]]></uid>
+        <uid><![CDATA[381553F0-FCC2-4A44-A4B0-ECAEF0033E72]]></uid>
     </SQLTable>
     <SQLTable>
-        <name><![CDATA[public.tariff400ng_full_unpack_rates]]></name>
+        <name><![CDATA[public.tariff400ng_shorthaul_rates]]></name>
         <schema><![CDATA[public]]></schema>
         <location>
-            <x>972.00</x>
+            <x>1896.00</x>
             <y>1420.00</y>
         </location>
         <size>
             <width>298.00</width>
-            <height>160.00</height>
+            <height>180.00</height>
         </size>
-        <zorder>12</zorder>
+        <zorder>9</zorder>
         <SQLField>
             <name><![CDATA[id]]></name>
             <type><![CDATA[UUID]]></type>
-            <uid><![CDATA[56B19A83-A96A-44F8-A18F-364C90AD5A81]]></uid>
+            <uid><![CDATA[B9AACE79-C2F8-4124-8AE1-52345B4F0F6B]]></uid>
         </SQLField>
         <SQLField>
-            <name><![CDATA[schedule]]></name>
+            <name><![CDATA[cwt_miles_lower]]></name>
             <type><![CDATA[INTEGER]]></type>
-            <uid><![CDATA[0873F5C9-D699-4B37-8DE4-763C149FC22E]]></uid>
+            <uid><![CDATA[5C83B406-FF86-4B44-9B82-660C4FB61623]]></uid>
         </SQLField>
         <SQLField>
-            <name><![CDATA[rate_millicents]]></name>
+            <name><![CDATA[cwt_miles_upper]]></name>
             <type><![CDATA[INTEGER]]></type>
-            <uid><![CDATA[C7F756D2-2E6F-4C1F-804E-F335C98BD9B2]]></uid>
+            <uid><![CDATA[8149D950-35C9-4C32-A46A-D1D7A1C00278]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[rate_cents]]></name>
+            <type><![CDATA[INTEGER]]></type>
+            <uid><![CDATA[CDBD105C-0BE0-4113-9582-8B83B600495D]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[effective_date_lower]]></name>
             <type><![CDATA[DATE]]></type>
-            <uid><![CDATA[E8C788A3-A405-48E2-BB3D-285B2A8C0EF0]]></uid>
+            <uid><![CDATA[FF0A605A-7E67-4CF8-8D4B-33E859AF36E4]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[effective_date_upper]]></name>
             <type><![CDATA[DATE]]></type>
-            <uid><![CDATA[1068FFA6-8695-4CA2-8EF4-97E6CD8964C9]]></uid>
+            <uid><![CDATA[9491A8BA-9A58-4FD3-9E2B-5060BD428D1E]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[created_at]]></name>
             <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <uid><![CDATA[C27251F5-268E-4DA3-8268-F7546613787D]]></uid>
+            <uid><![CDATA[0B30958F-1AEE-48A3-AECA-86A5C106A6D0]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[updated_at]]></name>
             <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <uid><![CDATA[155AAACE-5AD1-4C1F-9B47-62FFBB3D1891]]></uid>
+            <uid><![CDATA[BDD57811-89E8-4EA5-B0BD-45A86ECADCF3]]></uid>
         </SQLField>
-        <labelWindowIndex><![CDATA[12]]></labelWindowIndex>
+        <labelWindowIndex><![CDATA[9]]></labelWindowIndex>
         <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
-        <uid><![CDATA[CBD3F9BE-D173-4DA3-8BCA-6942BA7CA911]]></uid>
-    </SQLTable>
-    <SQLTable>
-        <name><![CDATA[public.blackout_dates]]></name>
-        <schema><![CDATA[public]]></schema>
-        <location>
-            <x>664.00</x>
-            <y>10.00</y>
-        </location>
-        <size>
-            <width>362.00</width>
-            <height>240.00</height>
-        </size>
-        <zorder>34</zorder>
-        <SQLField>
-            <name><![CDATA[id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <primaryKey>1</primaryKey>
-            <notNull><![CDATA[1]]></notNull>
-            <PK_NAME><![CDATA[blackout_dates_pkey]]></PK_NAME>
-            <uid><![CDATA[5D16360E-FA63-417B-BFAA-5006FBFBB946]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[transportation_service_provider_id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <referencesField>id</referencesField>
-            <referencesTable>public.transportation_service_providers</referencesTable>
-            <deleteAction>4</deleteAction>
-            <updateAction>4</updateAction>
-            <referencesField><![CDATA[id]]></referencesField>
-            <referencesTable><![CDATA[public.transportation_service_providers]]></referencesTable>
-            <sourceCardinality>0</sourceCardinality>
-            <destinationCardinality>0</destinationCardinality>
-            <referencesFieldUID><![CDATA[A2D863BD-8C57-43C8-8BAE-0C9C34CF256D]]></referencesFieldUID>
-            <referencesTableUID><![CDATA[8E1A9983-4596-4C6A-B7CF-984C412C5DAB]]></referencesTableUID>
-            <foreignKeyName><![CDATA[blackout_dates_transportation_service_provider_id_fkey]]></foreignKeyName>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[6FF0F74E-EE2E-4839-80D0-4F87E718E30D]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[start_blackout_date]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[20AFCA7A-CAC6-41F9-87F6-EF92F6041207]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[end_blackout_date]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[E49C7A91-812E-4ED6-B220-1DC871099C71]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[traffic_distribution_list_id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <referencesField>id</referencesField>
-            <referencesTable>public.traffic_distribution_lists</referencesTable>
-            <deleteAction>4</deleteAction>
-            <updateAction>4</updateAction>
-            <referencesField><![CDATA[id]]></referencesField>
-            <referencesTable><![CDATA[public.traffic_distribution_lists]]></referencesTable>
-            <sourceCardinality>0</sourceCardinality>
-            <destinationCardinality>0</destinationCardinality>
-            <referencesFieldUID><![CDATA[FEBF637A-361A-4BE0-92F2-40CE87A7F022]]></referencesFieldUID>
-            <referencesTableUID><![CDATA[B9904F5A-2E70-4B7F-A129-74F7A096DAC8]]></referencesTableUID>
-            <foreignKeyName><![CDATA[blackout_dates_traffic_distribution_list_id_fkey]]></foreignKeyName>
-            <uid><![CDATA[6BAFA9BB-8C29-406A-B896-DD62B26341B0]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[created_at]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[6A2610AC-D94B-4FFA-A4DE-6065289E10F3]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[updated_at]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[65E352C6-5E67-4AA4-949C-33BAE0B80356]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[source_gbloc]]></name>
-            <type><![CDATA[CHARACTER VARYING(255)]]></type>
-            <uid><![CDATA[5C4A825C-F234-4E06-A07A-54D3E2676DD8]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[market]]></name>
-            <type><![CDATA[CHARACTER VARYING(255)]]></type>
-            <uid><![CDATA[D3CB2FB1-FD4D-43E1-A535-2EF3288F35E9]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[zip3]]></name>
-            <type><![CDATA[INTEGER]]></type>
-            <uid><![CDATA[7FB047DE-2A19-413E-B9CA-2EEF52C5BC74]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[volume_move]]></name>
-            <type><![CDATA[BOOLEAN]]></type>
-            <uid><![CDATA[02C1606B-323D-4663-9D48-6744CA4E953E]]></uid>
-        </SQLField>
-        <labelWindowIndex><![CDATA[34]]></labelWindowIndex>
-        <PK_KEY_NAME><![CDATA[blackout_dates_pkey]]></PK_KEY_NAME>
-        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
-        <uid><![CDATA[CF273CEC-261D-4AAC-AF3A-750859306B35]]></uid>
-    </SQLTable>
-    <SQLTable>
-        <name><![CDATA[public.uploads]]></name>
-        <schema><![CDATA[public]]></schema>
-        <location>
-            <x>10.00</x>
-            <y>2020.00</y>
-        </location>
-        <size>
-            <width>317.00</width>
-            <height>220.00</height>
-        </size>
-        <zorder>1</zorder>
-        <SQLField>
-            <name><![CDATA[id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <primaryKey>1</primaryKey>
-            <notNull><![CDATA[1]]></notNull>
-            <PK_NAME><![CDATA[uploads_pkey]]></PK_NAME>
-            <uid><![CDATA[3C9D8A6B-DA76-473E-ACA7-DA714E27FE65]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[document_id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <referencesField>id</referencesField>
-            <referencesTable>public.documents</referencesTable>
-            <deleteAction>4</deleteAction>
-            <updateAction>4</updateAction>
-            <referencesField><![CDATA[id]]></referencesField>
-            <referencesTable><![CDATA[public.documents]]></referencesTable>
-            <sourceCardinality>0</sourceCardinality>
-            <destinationCardinality>0</destinationCardinality>
-            <referencesFieldUID><![CDATA[167D75CF-9133-40DD-BD58-F582EAF9D9A6]]></referencesFieldUID>
-            <referencesTableUID><![CDATA[3C465223-A109-4B66-A28C-1C3790F6BE2B]]></referencesTableUID>
-            <foreignKeyName><![CDATA[uploads_document_id_fkey]]></foreignKeyName>
-            <uid><![CDATA[C5F21800-0CFE-43BE-B900-9D4B356E9B6E]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[uploader_id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <referencesField>id</referencesField>
-            <referencesTable>public.users</referencesTable>
-            <deleteAction>4</deleteAction>
-            <updateAction>4</updateAction>
-            <referencesField><![CDATA[id]]></referencesField>
-            <referencesTable><![CDATA[public.users]]></referencesTable>
-            <sourceCardinality>0</sourceCardinality>
-            <destinationCardinality>0</destinationCardinality>
-            <referencesFieldUID><![CDATA[CA49F042-645E-4AE3-98FE-5121B010AD74]]></referencesFieldUID>
-            <referencesTableUID><![CDATA[80C4B16B-6F69-48C0-A736-49B448DA3F05]]></referencesTableUID>
-            <foreignKeyName><![CDATA[uploads_uploader_id_fkey]]></foreignKeyName>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[E017E243-73D4-4CC1-9D25-BFC4A75BDD5A]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[filename]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[0F6C9168-5B0D-4300-8D54-5F707AD720B1]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[bytes]]></name>
-            <type><![CDATA[BIGINT]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[95E3BAF1-AC54-448C-ADB3-282457DA6DF5]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[content_type]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[7E027998-A513-4389-B00C-C42514911972]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[checksum]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[FCE3C605-4719-494A-A27D-AF5D8C8F00BB]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[created_at]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[4343A15A-FFB6-4A39-9AB5-3535762A3CE3]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[updated_at]]></name>
-            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[EC3490D0-C504-47CD-BCA1-92F6D376F561]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[storage_key]]></name>
-            <type><![CDATA[CHARACTER VARYING(1024)]]></type>
-            <uid><![CDATA[026DEEF7-D36A-42A8-BC9B-29BBAC3427BC]]></uid>
-        </SQLField>
-        <labelWindowIndex><![CDATA[1]]></labelWindowIndex>
-        <PK_KEY_NAME><![CDATA[uploads_pkey]]></PK_KEY_NAME>
-        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
-        <uid><![CDATA[D44E0047-5A06-49D7-9355-04DFF029B730]]></uid>
+        <uid><![CDATA[4A54175F-0045-4423-B850-6489BD5B7EF5]]></uid>
     </SQLTable>
     <SQLTable>
         <name><![CDATA[public.orders]]></name>
@@ -2741,7 +483,7 @@
             <forcedUnique><![CDATA[1]]></forcedUnique>
             <notNull><![CDATA[1]]></notNull>
             <PK_NAME><![CDATA[orders_pkey]]></PK_NAME>
-            <uid><![CDATA[92DD14FA-F23C-4ABF-B777-0B5543D6F459]]></uid>
+            <uid><![CDATA[0A300203-302D-41F4-9CA5-BB45E663C260]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[service_member_id]]></name>
@@ -2754,35 +496,35 @@
             <referencesTable><![CDATA[public.service_members]]></referencesTable>
             <sourceCardinality>0</sourceCardinality>
             <destinationCardinality>0</destinationCardinality>
-            <referencesFieldUID><![CDATA[B6A911EF-81A8-4479-8FC5-38247FC132C3]]></referencesFieldUID>
-            <referencesTableUID><![CDATA[65F9FB8D-D6CB-491B-BFAF-02DEFD105FF1]]></referencesTableUID>
+            <referencesFieldUID><![CDATA[7967F1E4-E9D1-49FA-A1F6-7DF0FD0914DE]]></referencesFieldUID>
+            <referencesTableUID><![CDATA[A7CC0F5A-7321-40A0-88C5-44CBB41D57E4]]></referencesTableUID>
             <foreignKeyName><![CDATA[orders_service_member_id_fkey]]></foreignKeyName>
             <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[EECF8E16-E4D8-498C-AC11-20F0AD482B7B]]></uid>
+            <uid><![CDATA[500C3977-5CAF-4A1A-9EDE-C417C27BF6EB]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[issue_date]]></name>
             <type><![CDATA[DATE]]></type>
             <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[8DDC8ABB-00BD-464D-BCA3-AD0D39C4E542]]></uid>
+            <uid><![CDATA[06EB5EB6-2929-4574-8E52-D674939953E9]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[report_by_date]]></name>
             <type><![CDATA[DATE]]></type>
             <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[3A66C78A-A8B3-4851-8C01-7F5F1FA471AC]]></uid>
+            <uid><![CDATA[1D966944-FAD6-4CC6-B8D7-C1DFCF6E2B7E]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[orders_type]]></name>
             <type><![CDATA[CHARACTER VARYING(255)]]></type>
             <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[6D852EB1-2BDB-4796-999B-7125D4883BF2]]></uid>
+            <uid><![CDATA[E9071ADB-837F-4716-909E-F7246146BB49]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[has_dependents]]></name>
             <type><![CDATA[BOOLEAN]]></type>
             <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[F96632F4-394E-4B9C-9BB9-7246EE88E265]]></uid>
+            <uid><![CDATA[54D18370-B67A-47FB-B339-48735E474BA5]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[new_duty_station_id]]></name>
@@ -2795,23 +537,23 @@
             <referencesTable><![CDATA[public.duty_stations]]></referencesTable>
             <sourceCardinality>0</sourceCardinality>
             <destinationCardinality>0</destinationCardinality>
-            <referencesFieldUID><![CDATA[0A85848D-FADC-4719-AB44-8F9E673234AD]]></referencesFieldUID>
-            <referencesTableUID><![CDATA[03D89D85-6A21-4730-AEDE-A6BB16BFE135]]></referencesTableUID>
+            <referencesFieldUID><![CDATA[37FE07DF-F33E-40D8-97B0-59DC061255C8]]></referencesFieldUID>
+            <referencesTableUID><![CDATA[521C4498-C168-438F-BD6C-8E836E1C5A64]]></referencesTableUID>
             <foreignKeyName><![CDATA[orders_new_duty_station_id_fkey]]></foreignKeyName>
             <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[2D022136-EEEE-4FBF-8C21-6D75B1560553]]></uid>
+            <uid><![CDATA[A57A073C-3D8D-4208-9906-A5C316E660F0]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[created_at]]></name>
             <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
             <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[4A68FC62-F165-4FC9-9694-D7E46509D1E7]]></uid>
+            <uid><![CDATA[93F5BED9-0FCD-4E74-A736-89F62FFFFD15]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[updated_at]]></name>
             <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
             <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[DCDD9103-73F7-4B77-A6B3-335D2952F905]]></uid>
+            <uid><![CDATA[86F11866-369B-4C3A-8A5B-C59DAE46DBF2]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[uploaded_orders_id]]></name>
@@ -2824,102 +566,322 @@
             <referencesTable><![CDATA[public.documents]]></referencesTable>
             <sourceCardinality>0</sourceCardinality>
             <destinationCardinality>0</destinationCardinality>
-            <referencesFieldUID><![CDATA[167D75CF-9133-40DD-BD58-F582EAF9D9A6]]></referencesFieldUID>
-            <referencesTableUID><![CDATA[3C465223-A109-4B66-A28C-1C3790F6BE2B]]></referencesTableUID>
+            <referencesFieldUID><![CDATA[6A6C4B63-5FE7-4E8C-808F-15FA64262003]]></referencesFieldUID>
+            <referencesTableUID><![CDATA[A85C394A-A5E7-49C2-8229-83D781C9B552]]></referencesTableUID>
             <foreignKeyName><![CDATA[orders_documents_id_fk]]></foreignKeyName>
             <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[840805F9-2EBD-42ED-A9D7-A752626EB8A6]]></uid>
+            <uid><![CDATA[BE9BAF25-0B12-492F-8B2C-EAD7C763C520]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[orders_number]]></name>
             <type><![CDATA[CHARACTER VARYING(255)]]></type>
-            <uid><![CDATA[AB42684C-7D92-47B5-BF83-419218F95314]]></uid>
+            <uid><![CDATA[063FC4AB-91C9-4289-B9CE-C1373EE89E23]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[orders_type_detail]]></name>
             <type><![CDATA[CHARACTER VARYING(255)]]></type>
-            <uid><![CDATA[6964E8DE-D94D-4E4F-B59A-09C5F3644CBC]]></uid>
+            <uid><![CDATA[BE8D34A4-0055-4403-BCEA-9B4D6D10C0FA]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[status]]></name>
             <type><![CDATA[CHARACTER VARYING(255)]]></type>
             <defaultValue><![CDATA['DRAFT'::character varying]]></defaultValue>
             <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[5128726E-1E00-4CD1-924A-57A72C69F64C]]></uid>
+            <uid><![CDATA[5E791CD7-C92F-4833-B1ED-D933024BA347]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[tac]]></name>
             <type><![CDATA[CHARACTER VARYING(255)]]></type>
-            <uid><![CDATA[13B77BCC-E2CB-4276-B13B-DE5428D40B5C]]></uid>
+            <uid><![CDATA[7AD63962-F6C8-4020-9303-9E5FD1B50D6D]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[department_indicator]]></name>
             <type><![CDATA[CHARACTER VARYING(255)]]></type>
-            <uid><![CDATA[D564024F-1BD5-46BE-B6FF-0E608A7359BD]]></uid>
+            <uid><![CDATA[A8396404-76EB-4434-9E48-D4FD4AF0A1DA]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[spouse_has_pro_gear]]></name>
             <type><![CDATA[BOOLEAN]]></type>
             <defaultValue><![CDATA[false]]></defaultValue>
             <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[8F62299E-D6DF-4434-939F-7ABBA7429279]]></uid>
+            <uid><![CDATA[DD0921C9-869C-41B3-A729-EB32F8966D30]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[orders_issuing_agency]]></name>
             <type><![CDATA[TEXT]]></type>
-            <uid><![CDATA[6DD71426-3DCA-413D-A8B1-B342A24B29A8]]></uid>
+            <uid><![CDATA[1205E59A-0176-4CE7-97CA-6CEBC099C71D]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[paragraph_number]]></name>
             <type><![CDATA[TEXT]]></type>
-            <uid><![CDATA[0F865A50-05D6-4960-AC36-29EBF3B9BBE0]]></uid>
+            <uid><![CDATA[B7749C69-1F21-45C3-B1C5-6CE1D3B11343]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[sac]]></name>
             <type><![CDATA[TEXT]]></type>
-            <uid><![CDATA[04EAD885-A29A-463B-8595-EF4D8941860B]]></uid>
+            <uid><![CDATA[FD35E035-12CB-498D-939B-043C1FED6F53]]></uid>
         </SQLField>
         <labelWindowIndex><![CDATA[23]]></labelWindowIndex>
         <PK_KEY_NAME><![CDATA[orders_pkey]]></PK_KEY_NAME>
         <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
-        <uid><![CDATA[D4AFD9A1-67A2-473F-A087-63B26B8034B9]]></uid>
+        <uid><![CDATA[4C003849-8BD2-4591-B4CB-0C371A997836]]></uid>
     </SQLTable>
     <SQLTable>
-        <name><![CDATA[public.shipment_offers]]></name>
+        <name><![CDATA[public.personally_procured_moves]]></name>
         <schema><![CDATA[public]]></schema>
         <location>
-            <x>1657.00</x>
+            <x>10.00</x>
             <y>670.00</y>
         </location>
         <size>
-            <width>329.00</width>
-            <height>200.00</height>
+            <width>386.00</width>
+            <height>480.00</height>
         </size>
-        <zorder>17</zorder>
+        <zorder>22</zorder>
+        <SQLField>
+            <name><![CDATA[id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <primaryKey>1</primaryKey>
+            <forcedUnique><![CDATA[1]]></forcedUnique>
+            <notNull><![CDATA[1]]></notNull>
+            <PK_NAME><![CDATA[personally_procured_moves_pkey]]></PK_NAME>
+            <uid><![CDATA[44E2249F-C5AC-423B-81AE-A40C91EBE058]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[move_id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <referencesField>id</referencesField>
+            <referencesTable>public.moves</referencesTable>
+            <deleteAction>4</deleteAction>
+            <updateAction>4</updateAction>
+            <referencesField><![CDATA[id]]></referencesField>
+            <referencesTable><![CDATA[public.moves]]></referencesTable>
+            <sourceCardinality>0</sourceCardinality>
+            <destinationCardinality>0</destinationCardinality>
+            <referencesFieldUID><![CDATA[976D74A1-8C1A-417A-B491-251673CFAC90]]></referencesFieldUID>
+            <referencesTableUID><![CDATA[381553F0-FCC2-4A44-A4B0-ECAEF0033E72]]></referencesTableUID>
+            <foreignKeyName><![CDATA[personally_procured_moves_move_id_fkey]]></foreignKeyName>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[54D3BD34-53FD-4B04-9465-8D4024D75B2F]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[size]]></name>
+            <type><![CDATA[CHARACTER VARYING(255)]]></type>
+            <uid><![CDATA[1CA12FE8-3D17-43C9-B0D1-E3D900479E72]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[weight_estimate]]></name>
+            <type><![CDATA[INTEGER]]></type>
+            <uid><![CDATA[E4DD8651-7217-4A44-B08E-0248F8879651]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[created_at]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[83ACD986-D69B-465C-89DD-406AA3C58F19]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[updated_at]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[1C309B84-C14A-4CAA-91D9-A5970E43EEC2]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[planned_move_date]]></name>
+            <type><![CDATA[DATE]]></type>
+            <uid><![CDATA[77E64626-9339-47D3-B968-11AF819B808B]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[pickup_postal_code]]></name>
+            <type><![CDATA[CHARACTER VARYING(255)]]></type>
+            <uid><![CDATA[FF33B002-59A8-4254-984E-74E995E7A75F]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[additional_pickup_postal_code]]></name>
+            <type><![CDATA[CHARACTER VARYING(255)]]></type>
+            <uid><![CDATA[E23E250D-17C3-4E7F-949D-BE375A1689F5]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[destination_postal_code]]></name>
+            <type><![CDATA[CHARACTER VARYING(255)]]></type>
+            <uid><![CDATA[F2716E81-60C4-4A77-B7D6-4EF4F019751D]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[days_in_storage]]></name>
+            <type><![CDATA[INTEGER]]></type>
+            <uid><![CDATA[BB931852-31DF-490E-A6D5-678A645219B2]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[status]]></name>
+            <type><![CDATA[CHARACTER VARYING(255)]]></type>
+            <defaultValue><![CDATA['DRAFT'::character varying]]></defaultValue>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[09BFFE98-1814-4CFA-8E5C-0A7DB1E16758]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[has_additional_postal_code]]></name>
+            <type><![CDATA[BOOLEAN]]></type>
+            <uid><![CDATA[3E573D0E-1E10-49D3-ACDA-93F149AF7E34]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[has_sit]]></name>
+            <type><![CDATA[BOOLEAN]]></type>
+            <uid><![CDATA[14727558-BACD-49D7-AA43-A36BF404AB17]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[has_requested_advance]]></name>
+            <type><![CDATA[BOOLEAN]]></type>
+            <defaultValue><![CDATA[false]]></defaultValue>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[25951ACA-4CF0-4D3B-9CDE-FBE38F0D4F32]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[advance_id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <uid><![CDATA[8BA7D987-A7FE-4F8B-9506-F4FBB59EE903]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[estimated_storage_reimbursement]]></name>
+            <type><![CDATA[CHARACTER VARYING(255)]]></type>
+            <uid><![CDATA[6BFF3412-1FF4-4A3F-B2B8-60D471AB287A]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[mileage]]></name>
+            <type><![CDATA[INTEGER]]></type>
+            <uid><![CDATA[CC02722F-2090-485E-860C-31F2CC79C9F6]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[planned_sit_max]]></name>
+            <type><![CDATA[INTEGER]]></type>
+            <uid><![CDATA[8979B28F-1EDD-4720-8712-09082D05B4A5]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[sit_max]]></name>
+            <type><![CDATA[INTEGER]]></type>
+            <uid><![CDATA[4328859D-B2A2-4117-964D-135D22AC35C4]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[incentive_estimate_min]]></name>
+            <type><![CDATA[INTEGER]]></type>
+            <uid><![CDATA[81A88130-6494-49CA-A78C-2D7590F3209F]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[incentive_estimate_max]]></name>
+            <type><![CDATA[INTEGER]]></type>
+            <uid><![CDATA[D4DB85C9-9421-4802-9779-4CBF5F722244]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[advance_worksheet_id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <referencesField>id</referencesField>
+            <referencesTable>public.documents</referencesTable>
+            <deleteAction>4</deleteAction>
+            <updateAction>4</updateAction>
+            <referencesField><![CDATA[id]]></referencesField>
+            <referencesTable><![CDATA[public.documents]]></referencesTable>
+            <sourceCardinality>0</sourceCardinality>
+            <destinationCardinality>0</destinationCardinality>
+            <referencesFieldUID><![CDATA[6A6C4B63-5FE7-4E8C-808F-15FA64262003]]></referencesFieldUID>
+            <referencesTableUID><![CDATA[A85C394A-A5E7-49C2-8229-83D781C9B552]]></referencesTableUID>
+            <foreignKeyName><![CDATA[personally_procured_moves_documents_id_fk]]></foreignKeyName>
+            <uid><![CDATA[890DF674-1B90-4096-AD7C-22A131F65DCC]]></uid>
+        </SQLField>
+        <labelWindowIndex><![CDATA[22]]></labelWindowIndex>
+        <PK_KEY_NAME><![CDATA[personally_procured_moves_pkey]]></PK_KEY_NAME>
+        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
+        <uid><![CDATA[4C0EF661-70F6-4A31-9F20-53C0937083A5]]></uid>
+    </SQLTable>
+    <SQLTable>
+        <name><![CDATA[public.duty_stations]]></name>
+        <schema><![CDATA[public]]></schema>
+        <location>
+            <x>1363.00</x>
+            <y>10.00</y>
+        </location>
+        <size>
+            <width>317.00</width>
+            <height>160.00</height>
+        </size>
+        <zorder>32</zorder>
+        <SQLField>
+            <name><![CDATA[id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <primaryKey>1</primaryKey>
+            <forcedUnique><![CDATA[1]]></forcedUnique>
+            <notNull><![CDATA[1]]></notNull>
+            <PK_NAME><![CDATA[duty_stations_pkey]]></PK_NAME>
+            <uid><![CDATA[37FE07DF-F33E-40D8-97B0-59DC061255C8]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[name]]></name>
+            <type><![CDATA[CHARACTER VARYING(255)]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[D26EEDF9-FABA-49AB-8A9A-F859F17308D5]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[affiliation]]></name>
+            <type><![CDATA[CHARACTER VARYING(255)]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[D6873290-FA28-42A7-B364-E7A1337323C8]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[address_id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <referencesField>id</referencesField>
+            <referencesTable>public.addresses</referencesTable>
+            <deleteAction>4</deleteAction>
+            <updateAction>4</updateAction>
+            <referencesField><![CDATA[id]]></referencesField>
+            <referencesTable><![CDATA[public.addresses]]></referencesTable>
+            <sourceCardinality>0</sourceCardinality>
+            <destinationCardinality>0</destinationCardinality>
+            <referencesFieldUID><![CDATA[35D03B0A-6A2C-4D68-87ED-C89BC8D491EA]]></referencesFieldUID>
+            <referencesTableUID><![CDATA[F68EC060-7139-422A-AD7C-A948A70CEA8B]]></referencesTableUID>
+            <foreignKeyName><![CDATA[duty_stations_address_id_fkey]]></foreignKeyName>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[65DD3A14-DACF-4D7A-81EF-80C84A77636C]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[created_at]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[A6E9D08D-50FD-4BFF-A354-68AD15ADBDE0]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[updated_at]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[68EEF9DC-7DC2-4D3A-BFBB-80E0B564D234]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[transportation_office_id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <uid><![CDATA[7966C7E1-2041-4A52-8E1A-1ADE2AD74F08]]></uid>
+        </SQLField>
+        <labelWindowIndex><![CDATA[32]]></labelWindowIndex>
+        <PK_KEY_NAME><![CDATA[duty_stations_pkey]]></PK_KEY_NAME>
+        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
+        <uid><![CDATA[521C4498-C168-438F-BD6C-8E836E1C5A64]]></uid>
+    </SQLTable>
+    <SQLTable>
+        <name><![CDATA[public.blackout_dates]]></name>
+        <schema><![CDATA[public]]></schema>
+        <location>
+            <x>664.00</x>
+            <y>10.00</y>
+        </location>
+        <size>
+            <width>362.00</width>
+            <height>240.00</height>
+        </size>
+        <zorder>34</zorder>
         <SQLField>
             <name><![CDATA[id]]></name>
             <type><![CDATA[UUID]]></type>
             <primaryKey>1</primaryKey>
             <notNull><![CDATA[1]]></notNull>
-            <PK_NAME><![CDATA[awarded_shipments_pkey]]></PK_NAME>
-            <uid><![CDATA[CC78851A-A856-4658-832B-DC49C19FE376]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[shipment_id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <referencesField>id</referencesField>
-            <referencesTable>public.shipments</referencesTable>
-            <deleteAction>4</deleteAction>
-            <updateAction>4</updateAction>
-            <referencesField><![CDATA[id]]></referencesField>
-            <referencesTable><![CDATA[public.shipments]]></referencesTable>
-            <sourceCardinality>0</sourceCardinality>
-            <destinationCardinality>0</destinationCardinality>
-            <referencesFieldUID><![CDATA[444DF8FF-1B94-44BC-AF1E-9535B4AE7E8D]]></referencesFieldUID>
-            <referencesTableUID><![CDATA[4ACF24EB-68A1-460A-97CD-EC9A3D9BF4CC]]></referencesTableUID>
-            <foreignKeyName><![CDATA[awarded_shipments_shipment_id_fkey]]></foreignKeyName>
-            <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[7EBCB807-06F6-43AD-B49A-D7D3E77AD5F5]]></uid>
+            <PK_NAME><![CDATA[blackout_dates_pkey]]></PK_NAME>
+            <uid><![CDATA[AA92720E-B284-4011-B3EB-C9410E5D29AC]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[transportation_service_provider_id]]></name>
@@ -2932,90 +894,341 @@
             <referencesTable><![CDATA[public.transportation_service_providers]]></referencesTable>
             <sourceCardinality>0</sourceCardinality>
             <destinationCardinality>0</destinationCardinality>
-            <referencesFieldUID><![CDATA[A2D863BD-8C57-43C8-8BAE-0C9C34CF256D]]></referencesFieldUID>
-            <referencesTableUID><![CDATA[8E1A9983-4596-4C6A-B7CF-984C412C5DAB]]></referencesTableUID>
-            <foreignKeyName><![CDATA[awarded_shipments_transportation_service_provider_id_fkey]]></foreignKeyName>
+            <referencesFieldUID><![CDATA[093BF0ED-A127-4BA8-B389-1FA79F673331]]></referencesFieldUID>
+            <referencesTableUID><![CDATA[342FBF63-1DB7-4D4F-9801-9F04DC431050]]></referencesTableUID>
+            <foreignKeyName><![CDATA[blackout_dates_transportation_service_provider_id_fkey]]></foreignKeyName>
             <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[EE04C274-B93A-490B-BE22-C4DBA639BC6F]]></uid>
+            <uid><![CDATA[DAA17549-11D8-4A4C-9EE1-AAFCABCE9656]]></uid>
         </SQLField>
         <SQLField>
-            <name><![CDATA[administrative_shipment]]></name>
-            <type><![CDATA[BOOLEAN]]></type>
+            <name><![CDATA[start_blackout_date]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
             <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[1015F487-1FC9-4186-A129-BE88AED9EEA4]]></uid>
+            <uid><![CDATA[196EC9F3-D28F-4B04-B252-71DF5B03EDF9]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[end_blackout_date]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[C7813366-011C-4DAB-BC52-40F1C62D6FF1]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[traffic_distribution_list_id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <referencesField>id</referencesField>
+            <referencesTable>public.traffic_distribution_lists</referencesTable>
+            <deleteAction>4</deleteAction>
+            <updateAction>4</updateAction>
+            <referencesField><![CDATA[id]]></referencesField>
+            <referencesTable><![CDATA[public.traffic_distribution_lists]]></referencesTable>
+            <sourceCardinality>0</sourceCardinality>
+            <destinationCardinality>0</destinationCardinality>
+            <referencesFieldUID><![CDATA[7BC12309-9507-47E3-A92C-A72C67DA0E69]]></referencesFieldUID>
+            <referencesTableUID><![CDATA[5663C001-22E3-4BA5-9ED4-AD4FAA73BFE7]]></referencesTableUID>
+            <foreignKeyName><![CDATA[blackout_dates_traffic_distribution_list_id_fkey]]></foreignKeyName>
+            <uid><![CDATA[51C0FE60-4C35-43D6-AE91-493AC92950E0]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[created_at]]></name>
             <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
             <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[3B1B66BD-320A-4588-8427-13E98B935D46]]></uid>
+            <uid><![CDATA[537E5622-DB30-4C80-8003-C0A0C861FBC2]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[updated_at]]></name>
             <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
             <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[0B467C35-D671-49C7-92DF-9ACDDAC4B205]]></uid>
+            <uid><![CDATA[85A3503C-703B-4CCD-A624-4A6F48A812B9]]></uid>
         </SQLField>
         <SQLField>
-            <name><![CDATA[accepted]]></name>
-            <type><![CDATA[BOOLEAN]]></type>
-            <uid><![CDATA[8985BB15-DDDD-41D8-94CB-BCB695D8E517]]></uid>
-        </SQLField>
-        <SQLField>
-            <name><![CDATA[rejection_reason]]></name>
+            <name><![CDATA[source_gbloc]]></name>
             <type><![CDATA[CHARACTER VARYING(255)]]></type>
-            <uid><![CDATA[5BF60E41-5EBB-4C44-97E4-6FCBFC049C77]]></uid>
+            <uid><![CDATA[0ECDBE82-57B8-48BA-8090-11AD9A422294]]></uid>
         </SQLField>
         <SQLField>
-            <name><![CDATA[transportation_service_provider_performance_id]]></name>
-            <type><![CDATA[UUID]]></type>
-            <uid><![CDATA[FBB8EFAC-7701-4AFA-9EAE-E75F655C2CDA]]></uid>
+            <name><![CDATA[market]]></name>
+            <type><![CDATA[CHARACTER VARYING(255)]]></type>
+            <uid><![CDATA[1257E737-5C56-49ED-8B89-443B2EB5D39A]]></uid>
         </SQLField>
-        <labelWindowIndex><![CDATA[17]]></labelWindowIndex>
-        <PK_KEY_NAME><![CDATA[awarded_shipments_pkey]]></PK_KEY_NAME>
+        <SQLField>
+            <name><![CDATA[zip3]]></name>
+            <type><![CDATA[INTEGER]]></type>
+            <uid><![CDATA[A22C3D36-9B76-4A32-8640-8B4CE152E9F7]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[volume_move]]></name>
+            <type><![CDATA[BOOLEAN]]></type>
+            <uid><![CDATA[813092F0-914B-495E-A28A-5AEC9E6AD0A0]]></uid>
+        </SQLField>
+        <labelWindowIndex><![CDATA[34]]></labelWindowIndex>
+        <PK_KEY_NAME><![CDATA[blackout_dates_pkey]]></PK_KEY_NAME>
         <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
-        <uid><![CDATA[DC066E32-2F40-4A45-8B3C-FF16D284357A]]></uid>
+        <uid><![CDATA[52B3314B-A5AF-43E6-B210-F6B39948184B]]></uid>
     </SQLTable>
     <SQLTable>
-        <name><![CDATA[public.tariff400ng_zip5_rate_areas]]></name>
+        <name><![CDATA[public.traffic_distribution_lists]]></name>
         <schema><![CDATA[public]]></schema>
         <location>
-            <x>318.00</x>
+            <x>626.00</x>
             <y>1710.00</y>
         </location>
         <size>
-            <width>298.00</width>
-            <height>120.00</height>
+            <width>372.00</width>
+            <height>160.00</height>
         </size>
-        <zorder>7</zorder>
+        <zorder>6</zorder>
         <SQLField>
             <name><![CDATA[id]]></name>
             <type><![CDATA[UUID]]></type>
-            <uid><![CDATA[919F7700-34CD-4E28-93C7-796B49FB12EC]]></uid>
+            <primaryKey>1</primaryKey>
+            <forcedUnique><![CDATA[1]]></forcedUnique>
+            <notNull><![CDATA[1]]></notNull>
+            <PK_NAME><![CDATA[traffic_distribution_lists_pkey]]></PK_NAME>
+            <uid><![CDATA[7BC12309-9507-47E3-A92C-A72C67DA0E69]]></uid>
         </SQLField>
         <SQLField>
-            <name><![CDATA[zip5]]></name>
-            <type><![CDATA[CHARACTER VARYING(5)]]></type>
-            <uid><![CDATA[B2CC8CE5-EA46-4ED8-A7DF-D4412D87C7F6]]></uid>
+            <name><![CDATA[source_rate_area]]></name>
+            <type><![CDATA[CHARACTER VARYING(255)]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[7E41E179-8BCF-47E2-9F1B-1960A7596432]]></uid>
         </SQLField>
         <SQLField>
-            <name><![CDATA[rate_area]]></name>
-            <type><![CDATA[TEXT]]></type>
-            <uid><![CDATA[41092BEA-DC7D-4EB2-B52E-CCA3760FD010]]></uid>
+            <name><![CDATA[destination_region]]></name>
+            <type><![CDATA[CHARACTER VARYING(255)]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[0D9CC473-EACF-4390-BB37-160947BA6538]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[code_of_service]]></name>
+            <type><![CDATA[CHARACTER VARYING(255)]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[4B1BF6DB-2007-47EF-B9ED-EA98607988A8]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[created_at]]></name>
             <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <uid><![CDATA[2F9A999E-0FBC-485D-9F1D-3E66FC90B4A5]]></uid>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[3E71305A-F7B7-4D72-9B6F-D2CB0758FBD0]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[updated_at]]></name>
             <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
-            <uid><![CDATA[2D3B7312-0E2B-4234-954C-B54FC3A65852]]></uid>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[5AD7C6E3-F0AF-475C-A896-99CE1B141E14]]></uid>
         </SQLField>
-        <labelWindowIndex><![CDATA[7]]></labelWindowIndex>
+        <SQLConstraint>
+            <name><![CDATA[unique_channel_cos]]></name>
+            <fieldName><![CDATA[source_rate_area]]></fieldName>
+            <fieldName><![CDATA[destination_region]]></fieldName>
+            <fieldName><![CDATA[code_of_service]]></fieldName>
+            <SQLIndexEntry>
+                <name><![CDATA[source_rate_area]]></name>
+                <prefixSize><![CDATA[]]></prefixSize>
+                <fieldUid><![CDATA[7E41E179-8BCF-47E2-9F1B-1960A7596432]]></fieldUid>
+            </SQLIndexEntry>
+            <SQLIndexEntry>
+                <name><![CDATA[destination_region]]></name>
+                <prefixSize><![CDATA[]]></prefixSize>
+                <fieldUid><![CDATA[0D9CC473-EACF-4390-BB37-160947BA6538]]></fieldUid>
+            </SQLIndexEntry>
+            <SQLIndexEntry>
+                <name><![CDATA[code_of_service]]></name>
+                <prefixSize><![CDATA[]]></prefixSize>
+                <fieldUid><![CDATA[4B1BF6DB-2007-47EF-B9ED-EA98607988A8]]></fieldUid>
+            </SQLIndexEntry>
+            <deferrable><![CDATA[0]]></deferrable>
+            <indexType><![CDATA[UNIQUE]]></indexType>
+            <initiallyDeferred><![CDATA[0]]></initiallyDeferred>
+            <uid><![CDATA[45B23BA6-C54F-4422-8AE5-A072CE54D335]]></uid>
+        </SQLConstraint>
+        <labelWindowIndex><![CDATA[6]]></labelWindowIndex>
+        <PK_KEY_NAME><![CDATA[traffic_distribution_lists_pkey]]></PK_KEY_NAME>
         <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
-        <uid><![CDATA[E93E01F1-C9C2-48D9-8966-D694CD81A57A]]></uid>
+        <uid><![CDATA[5663C001-22E3-4BA5-9ED4-AD4FAA73BFE7]]></uid>
+    </SQLTable>
+    <SQLTable>
+        <name><![CDATA[public.transportation_service_provider_performances]]></name>
+        <schema><![CDATA[public]]></schema>
+        <location>
+            <x>1335.00</x>
+            <y>1710.00</y>
+        </location>
+        <size>
+            <width>342.00</width>
+            <height>300.00</height>
+        </size>
+        <zorder>4</zorder>
+        <SQLField>
+            <name><![CDATA[id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <primaryKey>1</primaryKey>
+            <notNull><![CDATA[1]]></notNull>
+            <PK_NAME><![CDATA[transportation_service_provider_performances_pkey]]></PK_NAME>
+            <uid><![CDATA[66A47235-A96B-430B-BA61-28CA15EC792D]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[performance_period_start]]></name>
+            <type><![CDATA[DATE]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[5A6ADCBB-A67D-479D-8D93-EF4C0A52DB30]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[performance_period_end]]></name>
+            <type><![CDATA[DATE]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[277AB1CB-FC71-45BB-906D-B33337AAAE76]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[traffic_distribution_list_id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <referencesField>id</referencesField>
+            <referencesTable>public.traffic_distribution_lists</referencesTable>
+            <deleteAction>4</deleteAction>
+            <updateAction>4</updateAction>
+            <referencesField><![CDATA[id]]></referencesField>
+            <referencesTable><![CDATA[public.traffic_distribution_lists]]></referencesTable>
+            <sourceCardinality>0</sourceCardinality>
+            <destinationCardinality>0</destinationCardinality>
+            <referencesFieldUID><![CDATA[7BC12309-9507-47E3-A92C-A72C67DA0E69]]></referencesFieldUID>
+            <referencesTableUID><![CDATA[5663C001-22E3-4BA5-9ED4-AD4FAA73BFE7]]></referencesTableUID>
+            <foreignKeyName><![CDATA[transportation_service_provid_traffic_distribution_list_id_fkey]]></foreignKeyName>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[AC34C5BD-A4F4-4DDD-8C88-0B713A0612CE]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[quality_band]]></name>
+            <type><![CDATA[INTEGER]]></type>
+            <uid><![CDATA[EA3353E7-2412-4B93-BBF6-FDA74A075BCA]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[offer_count]]></name>
+            <type><![CDATA[INTEGER]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[AD626981-6039-4822-B701-4E6F487851C9]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[best_value_score]]></name>
+            <type><![CDATA[DOUBLE PRECISION]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[38788F58-0542-4DE8-AFAF-34FB9916C687]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[transportation_service_provider_id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <referencesField>id</referencesField>
+            <referencesTable>public.transportation_service_providers</referencesTable>
+            <deleteAction>4</deleteAction>
+            <updateAction>4</updateAction>
+            <referencesField><![CDATA[id]]></referencesField>
+            <referencesTable><![CDATA[public.transportation_service_providers]]></referencesTable>
+            <sourceCardinality>0</sourceCardinality>
+            <destinationCardinality>0</destinationCardinality>
+            <referencesFieldUID><![CDATA[093BF0ED-A127-4BA8-B389-1FA79F673331]]></referencesFieldUID>
+            <referencesTableUID><![CDATA[342FBF63-1DB7-4D4F-9801-9F04DC431050]]></referencesTableUID>
+            <foreignKeyName><![CDATA[transportation_service_provid_transportation_service_provi_fkey]]></foreignKeyName>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[791CE716-F9FF-4471-8A43-0661BFE0327A]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[created_at]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[3258A399-7188-46EF-9AFF-2BA729D2B16C]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[updated_at]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[FFC568AE-6217-4EAB-9153-65BD452ACE7D]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[rate_cycle_start]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[51A05D20-33B2-4D2A-A9EC-1E37A0D3C41B]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[rate_cycle_end]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[A7E43964-6055-4898-B581-544482539933]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[linehaul_rate]]></name>
+            <type><![CDATA[DOUBLE PRECISION]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[0C7C682C-F34C-42C2-AAD3-711B2C4ED5F8]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[sit_rate]]></name>
+            <type><![CDATA[DOUBLE PRECISION]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[AA91FD15-5938-421C-BBE9-4EC577ECBDF4]]></uid>
+        </SQLField>
+        <labelWindowIndex><![CDATA[4]]></labelWindowIndex>
+        <PK_KEY_NAME><![CDATA[transportation_service_provider_performances_pkey]]></PK_KEY_NAME>
+        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
+        <uid><![CDATA[582976F4-9F0E-401E-A661-0AD3AD6CFF3D]]></uid>
+    </SQLTable>
+    <SQLTable>
+        <name><![CDATA[public.reimbursements]]></name>
+        <schema><![CDATA[public]]></schema>
+        <location>
+            <x>406.00</x>
+            <y>670.00</y>
+        </location>
+        <size>
+            <width>319.00</width>
+            <height>160.00</height>
+        </size>
+        <zorder>21</zorder>
+        <SQLField>
+            <name><![CDATA[id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <primaryKey>1</primaryKey>
+            <notNull><![CDATA[1]]></notNull>
+            <PK_NAME><![CDATA[reimbursements_pkey]]></PK_NAME>
+            <uid><![CDATA[550459D9-DE05-4ABE-98D0-35B2CD3F8051]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[requested_amount]]></name>
+            <type><![CDATA[INTEGER]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[606715A4-EF29-4D80-8830-468D68419F0B]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[method_of_receipt]]></name>
+            <type><![CDATA[CHARACTER VARYING(255)]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[1ECE8970-D932-4626-AE36-AE34194654AD]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[status]]></name>
+            <type><![CDATA[CHARACTER VARYING(255)]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[3B0D7EE9-BA14-4AFB-BCD9-C038B8EC3519]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[requested_date]]></name>
+            <type><![CDATA[DATE]]></type>
+            <uid><![CDATA[0675758D-ECDC-41E6-A692-CCC7A61A021D]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[created_at]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[7791188E-81AD-4C22-8E9B-8D14EFB84013]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[updated_at]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[F707A488-4CF9-495E-A2BE-67CA4175563E]]></uid>
+        </SQLField>
+        <labelWindowIndex><![CDATA[21]]></labelWindowIndex>
+        <PK_KEY_NAME><![CDATA[reimbursements_pkey]]></PK_KEY_NAME>
+        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
+        <uid><![CDATA[67A2BA48-F799-489A-9177-7C6F026F0930]]></uid>
     </SQLTable>
     <SQLTable>
         <name><![CDATA[public.issues]]></name>
@@ -3035,40 +1248,739 @@
             <primaryKey>1</primaryKey>
             <notNull><![CDATA[1]]></notNull>
             <PK_NAME><![CDATA[issues_pkey]]></PK_NAME>
-            <uid><![CDATA[13EA1408-E775-4F7D-8081-E644CBD2E3DB]]></uid>
+            <uid><![CDATA[B92DE0F5-D893-4027-90B1-EB561ABB7157]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[description]]></name>
             <type><![CDATA[TEXT]]></type>
             <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[109BDA52-B3BA-4CC9-8CD7-A86AEA1ACC02]]></uid>
+            <uid><![CDATA[472A3CE3-0B6A-4D9C-B799-3DA3F692C34C]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[created_at]]></name>
             <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
             <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[C16B903A-5069-4A07-9E94-0702A98A9C72]]></uid>
+            <uid><![CDATA[CFEFE255-9A73-4D60-BF54-1153B2F8BA23]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[updated_at]]></name>
             <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
             <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[FACCF019-5F77-4DCB-84E0-C6E3BA336210]]></uid>
+            <uid><![CDATA[79C33B8F-D3DF-4B42-8926-84689ECCDBDE]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[reporter_name]]></name>
             <type><![CDATA[CHARACTER VARYING(255)]]></type>
-            <uid><![CDATA[688B78AD-DA0E-4CE0-B14A-8A4BFFB20F24]]></uid>
+            <uid><![CDATA[3920BC4B-7B2D-4174-87D5-8D2172B8A1B4]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[due_date]]></name>
             <type><![CDATA[DATE]]></type>
-            <uid><![CDATA[E6845C96-D6AF-4D50-8406-81407F14951C]]></uid>
+            <uid><![CDATA[1D0E23C3-2CE7-45D4-8F54-8681EFE1A5B8]]></uid>
         </SQLField>
         <labelWindowIndex><![CDATA[30]]></labelWindowIndex>
         <PK_KEY_NAME><![CDATA[issues_pkey]]></PK_KEY_NAME>
         <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
-        <uid><![CDATA[EEFCAFE1-679B-4A20-953A-84E446A8C966]]></uid>
+        <uid><![CDATA[6B1E1A42-76C9-4D41-B9B2-99367B755AB3]]></uid>
+    </SQLTable>
+    <SQLTable>
+        <name><![CDATA[public.backup_contacts]]></name>
+        <schema><![CDATA[public]]></schema>
+        <location>
+            <x>337.00</x>
+            <y>10.00</y>
+        </location>
+        <size>
+            <width>317.00</width>
+            <height>180.00</height>
+        </size>
+        <zorder>35</zorder>
+        <SQLField>
+            <name><![CDATA[id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <primaryKey>1</primaryKey>
+            <notNull><![CDATA[1]]></notNull>
+            <PK_NAME><![CDATA[backup_contacts_pkey]]></PK_NAME>
+            <uid><![CDATA[FA07DDD3-374C-45F8-8C1A-B44571C3851C]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[service_member_id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[6312E0E8-8CB5-46D0-B94B-F36D74D2E182]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[name]]></name>
+            <type><![CDATA[CHARACTER VARYING(255)]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[AD5BC806-5EF7-4B93-A147-8325A43A92ED]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[email]]></name>
+            <type><![CDATA[CHARACTER VARYING(255)]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[070F5C8C-FA4A-4BC4-814C-5B97A9F898D3]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[phone]]></name>
+            <type><![CDATA[CHARACTER VARYING(255)]]></type>
+            <uid><![CDATA[A8C738A5-36F3-431E-B0E7-79DFF5B74497]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[permission]]></name>
+            <type><![CDATA[CHARACTER VARYING(255)]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[459DE1A2-CDE3-4848-A8EF-9840F282A695]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[created_at]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[540948FD-3C14-4B7B-832E-8EB1E079D159]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[updated_at]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[62E4709B-7E7B-4785-96FE-4C5E78667504]]></uid>
+        </SQLField>
+        <labelWindowIndex><![CDATA[35]]></labelWindowIndex>
+        <PK_KEY_NAME><![CDATA[backup_contacts_pkey]]></PK_KEY_NAME>
+        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
+        <uid><![CDATA[709CFFFC-441A-4932-B490-85035E5A3AE4]]></uid>
+    </SQLTable>
+    <SQLTable>
+        <name><![CDATA[public.service_agents]]></name>
+        <schema><![CDATA[public]]></schema>
+        <location>
+            <x>1003.00</x>
+            <y>670.00</y>
+        </location>
+        <size>
+            <width>317.00</width>
+            <height>260.00</height>
+        </size>
+        <zorder>19</zorder>
+        <SQLField>
+            <name><![CDATA[id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <primaryKey>1</primaryKey>
+            <notNull><![CDATA[1]]></notNull>
+            <PK_NAME><![CDATA[service_agents_pkey]]></PK_NAME>
+            <uid><![CDATA[6506D4E0-9423-4450-8160-BFF03C193F25]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[shipment_id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <referencesField>id</referencesField>
+            <referencesTable>public.shipments</referencesTable>
+            <deleteAction>4</deleteAction>
+            <updateAction>4</updateAction>
+            <referencesField><![CDATA[id]]></referencesField>
+            <referencesTable><![CDATA[public.shipments]]></referencesTable>
+            <sourceCardinality>0</sourceCardinality>
+            <destinationCardinality>0</destinationCardinality>
+            <referencesFieldUID><![CDATA[BA3E4A6D-9773-475D-BEA9-80241DAD83E4]]></referencesFieldUID>
+            <referencesTableUID><![CDATA[8F47E188-572A-4DD3-9A39-5ECD41CC9C7E]]></referencesTableUID>
+            <foreignKeyName><![CDATA[service_agents_shipment_id_fkey]]></foreignKeyName>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[9D261E7A-E3DA-45AC-8916-2FFB4E3C33E4]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[role]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[9C18A61B-DF03-462C-B016-AB2E7D80B16D]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[email]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <uid><![CDATA[4CB7C860-C8CD-4AD2-8F46-9E286AE2C2A1]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[phone_number]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <uid><![CDATA[CE5A014C-A65F-40BA-8051-32F7E7E67A07]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[fax_number]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <uid><![CDATA[EFB101BF-6C62-4F12-90B7-2A7437BCA0F9]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[email_is_preferred]]></name>
+            <type><![CDATA[BOOLEAN]]></type>
+            <uid><![CDATA[10745A90-8DBC-4F33-90B1-6EFB7E4CB240]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[phone_is_preferred]]></name>
+            <type><![CDATA[BOOLEAN]]></type>
+            <uid><![CDATA[7B9C62A6-9AD8-4E46-947F-FD3721101A81]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[notes]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <uid><![CDATA[E2E6829B-B5F4-4907-93D1-5276F83EAC32]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[created_at]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[0F3FD48B-3EDC-4641-837E-279712F28FEA]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[updated_at]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[2B6CF6CE-49F3-439A-9128-31F7F1D39969]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[company]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[7ECA9029-8759-49E7-A038-42C0222D042C]]></uid>
+        </SQLField>
+        <labelWindowIndex><![CDATA[19]]></labelWindowIndex>
+        <PK_KEY_NAME><![CDATA[service_agents_pkey]]></PK_KEY_NAME>
+        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
+        <uid><![CDATA[758FE12C-98F8-4DC0-A501-13FDBA4225A2]]></uid>
+    </SQLTable>
+    <SQLTable>
+        <name><![CDATA[public.tariff400ng_service_areas]]></name>
+        <schema><![CDATA[public]]></schema>
+        <location>
+            <x>1588.00</x>
+            <y>1420.00</y>
+        </location>
+        <size>
+            <width>298.00</width>
+            <height>280.00</height>
+        </size>
+        <zorder>10</zorder>
+        <SQLField>
+            <name><![CDATA[id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <uid><![CDATA[9284F220-F661-4C09-9BE4-5D8780A8058F]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[service_area]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <uid><![CDATA[14125903-19FC-42D2-90CD-471FE40BC3A9]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[name]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <uid><![CDATA[9D4C0DA2-B73E-45B5-B87F-FA7319E73D9A]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[services_schedule]]></name>
+            <type><![CDATA[INTEGER]]></type>
+            <uid><![CDATA[0D065383-67B4-4646-A780-66F3EE91AE03]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[linehaul_factor]]></name>
+            <type><![CDATA[INTEGER]]></type>
+            <uid><![CDATA[AB48D10C-A15E-431D-8052-F027C4A5CD74]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[service_charge_cents]]></name>
+            <type><![CDATA[INTEGER]]></type>
+            <uid><![CDATA[427C94C2-3FAD-4F20-BF53-5A9E491A1C2A]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[effective_date_lower]]></name>
+            <type><![CDATA[DATE]]></type>
+            <uid><![CDATA[2C34A8B4-F0D0-4205-8202-F82FE6D17B23]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[effective_date_upper]]></name>
+            <type><![CDATA[DATE]]></type>
+            <uid><![CDATA[9A598BEA-FD76-45C8-8949-B0782389E4B8]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[created_at]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <uid><![CDATA[827962AD-E59C-4606-AA29-45E8C71C3ADD]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[updated_at]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <uid><![CDATA[17200D57-3D4D-407D-8C97-5588098D477C]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[sit_185a_rate_cents]]></name>
+            <type><![CDATA[INTEGER]]></type>
+            <uid><![CDATA[71ECF94A-3178-4CB8-B441-547B159824FD]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[sit_185b_rate_cents]]></name>
+            <type><![CDATA[INTEGER]]></type>
+            <uid><![CDATA[3E0C05A4-1512-4D82-AD1E-BF7B3EF006EA]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[sit_pd_schedule]]></name>
+            <type><![CDATA[INTEGER]]></type>
+            <uid><![CDATA[DB5FA662-9639-4C30-85FB-60BDDABCA8AC]]></uid>
+        </SQLField>
+        <labelWindowIndex><![CDATA[10]]></labelWindowIndex>
+        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
+        <uid><![CDATA[7DC31030-2014-461C-B3EF-549341D721CA]]></uid>
+    </SQLTable>
+    <SQLTable>
+        <name><![CDATA[public.transportation_offices]]></name>
+        <schema><![CDATA[public]]></schema>
+        <location>
+            <x>1008.00</x>
+            <y>1710.00</y>
+        </location>
+        <size>
+            <width>317.00</width>
+            <height>260.00</height>
+        </size>
+        <zorder>5</zorder>
+        <SQLField>
+            <name><![CDATA[id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <primaryKey>1</primaryKey>
+            <forcedUnique><![CDATA[1]]></forcedUnique>
+            <notNull><![CDATA[1]]></notNull>
+            <PK_NAME><![CDATA[transportation_offices_pkey]]></PK_NAME>
+            <uid><![CDATA[55C4ABEE-BFFC-4BC0-ABCC-92594F606CAB]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[shipping_office_id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <referencesField>id</referencesField>
+            <referencesTable>public.transportation_offices</referencesTable>
+            <deleteAction>4</deleteAction>
+            <updateAction>4</updateAction>
+            <referencesField><![CDATA[id]]></referencesField>
+            <referencesTable><![CDATA[public.transportation_offices]]></referencesTable>
+            <sourceCardinality>0</sourceCardinality>
+            <destinationCardinality>0</destinationCardinality>
+            <referencesFieldUID><![CDATA[55C4ABEE-BFFC-4BC0-ABCC-92594F606CAB]]></referencesFieldUID>
+            <referencesTableUID><![CDATA[7F3EB14E-A0C7-4A01-8FC7-990D4A6DD8D4]]></referencesTableUID>
+            <foreignKeyName><![CDATA[transportation_offices_shipping_office_id_fkey]]></foreignKeyName>
+            <uid><![CDATA[CBE5ED82-B737-424F-B285-91F4051ED449]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[name]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[B2AFBAD7-95F1-477C-8615-2F90989CA3B1]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[address_id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <referencesField>id</referencesField>
+            <referencesTable>public.addresses</referencesTable>
+            <deleteAction>4</deleteAction>
+            <updateAction>4</updateAction>
+            <referencesField><![CDATA[id]]></referencesField>
+            <referencesTable><![CDATA[public.addresses]]></referencesTable>
+            <sourceCardinality>0</sourceCardinality>
+            <destinationCardinality>0</destinationCardinality>
+            <referencesFieldUID><![CDATA[35D03B0A-6A2C-4D68-87ED-C89BC8D491EA]]></referencesFieldUID>
+            <referencesTableUID><![CDATA[F68EC060-7139-422A-AD7C-A948A70CEA8B]]></referencesTableUID>
+            <foreignKeyName><![CDATA[transportation_offices_address_id_fkey]]></foreignKeyName>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[34207F6E-7B24-4712-922A-63369FBFF7CC]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[latitude]]></name>
+            <type><![CDATA[REAL]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[C66E3D3D-6EE8-4C0B-9DCC-C70E7101F075]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[longitude]]></name>
+            <type><![CDATA[REAL]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[E3DE2A1B-6F70-42C4-B497-85D2CE96E460]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[hours]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <uid><![CDATA[A8503D82-5B7A-4BE9-9F88-924B63E1CCC4]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[services]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <uid><![CDATA[BB9F39F5-339A-4DE3-A886-5394C7B02A43]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[note]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <uid><![CDATA[FE088BC1-400F-484C-B023-7933680C7117]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[created_at]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[C0C09B09-698F-4A93-B4FE-C4B454642950]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[updated_at]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[DE7C0975-462E-4DDA-B651-E4699D55C63F]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[gbloc]]></name>
+            <type><![CDATA[CHARACTER VARYING(255)]]></type>
+            <defaultValue><![CDATA['XXXX'::character varying]]></defaultValue>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[F0FE5851-EAE5-4576-8BB3-5AE4ECC502FE]]></uid>
+        </SQLField>
+        <labelWindowIndex><![CDATA[5]]></labelWindowIndex>
+        <PK_KEY_NAME><![CDATA[transportation_offices_pkey]]></PK_KEY_NAME>
+        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
+        <uid><![CDATA[7F3EB14E-A0C7-4A01-8FC7-990D4A6DD8D4]]></uid>
+    </SQLTable>
+    <SQLTable>
+        <name><![CDATA[public.office_emails]]></name>
+        <schema><![CDATA[public]]></schema>
+        <location>
+            <x>1035.00</x>
+            <y>260.00</y>
+        </location>
+        <size>
+            <width>317.00</width>
+            <height>140.00</height>
+        </size>
+        <zorder>26</zorder>
+        <SQLField>
+            <name><![CDATA[id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <primaryKey>1</primaryKey>
+            <notNull><![CDATA[1]]></notNull>
+            <PK_NAME><![CDATA[office_emails_pkey]]></PK_NAME>
+            <uid><![CDATA[3A52FF73-0EF7-4AA7-BD2B-E241DDEAFA32]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[transportation_office_id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <referencesField>id</referencesField>
+            <referencesTable>public.transportation_offices</referencesTable>
+            <deleteAction>4</deleteAction>
+            <updateAction>4</updateAction>
+            <referencesField><![CDATA[id]]></referencesField>
+            <referencesTable><![CDATA[public.transportation_offices]]></referencesTable>
+            <sourceCardinality>0</sourceCardinality>
+            <destinationCardinality>0</destinationCardinality>
+            <referencesFieldUID><![CDATA[55C4ABEE-BFFC-4BC0-ABCC-92594F606CAB]]></referencesFieldUID>
+            <referencesTableUID><![CDATA[7F3EB14E-A0C7-4A01-8FC7-990D4A6DD8D4]]></referencesTableUID>
+            <foreignKeyName><![CDATA[office_emails_transportation_office_id_fkey]]></foreignKeyName>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[2FD2118C-AFE4-44DF-99CC-B8C1D310E7BA]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[email]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[BCFB222C-3436-4992-A137-96E0C59C544F]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[label]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <uid><![CDATA[674D214C-F91B-423F-B702-B19FECCC1C72]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[created_at]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[49F6D906-E61E-4E60-BCDC-A126067C575C]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[updated_at]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[2A5E6080-BBD3-448D-886A-8D6BADC2F54A]]></uid>
+        </SQLField>
+        <labelWindowIndex><![CDATA[26]]></labelWindowIndex>
+        <PK_KEY_NAME><![CDATA[office_emails_pkey]]></PK_KEY_NAME>
+        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
+        <uid><![CDATA[8772CB2C-53D8-43AE-AD84-891EF2C92081]]></uid>
+    </SQLTable>
+    <SQLTable>
+        <name><![CDATA[public.shipments]]></name>
+        <schema><![CDATA[public]]></schema>
+        <location>
+            <x>1984.00</x>
+            <y>670.00</y>
+        </location>
+        <size>
+            <width>424.00</width>
+            <height>740.00</height>
+        </size>
+        <zorder>16</zorder>
+        <SQLField>
+            <name><![CDATA[id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <primaryKey>1</primaryKey>
+            <forcedUnique><![CDATA[1]]></forcedUnique>
+            <notNull><![CDATA[1]]></notNull>
+            <PK_NAME><![CDATA[shipments_pkey]]></PK_NAME>
+            <uid><![CDATA[BA3E4A6D-9773-475D-BEA9-80241DAD83E4]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[traffic_distribution_list_id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <referencesField>id</referencesField>
+            <referencesTable>public.traffic_distribution_lists</referencesTable>
+            <deleteAction>4</deleteAction>
+            <updateAction>4</updateAction>
+            <referencesField><![CDATA[id]]></referencesField>
+            <referencesTable><![CDATA[public.traffic_distribution_lists]]></referencesTable>
+            <sourceCardinality>0</sourceCardinality>
+            <destinationCardinality>0</destinationCardinality>
+            <referencesFieldUID><![CDATA[7BC12309-9507-47E3-A92C-A72C67DA0E69]]></referencesFieldUID>
+            <referencesTableUID><![CDATA[5663C001-22E3-4BA5-9ED4-AD4FAA73BFE7]]></referencesTableUID>
+            <foreignKeyName><![CDATA[shipments_traffic_distribution_list_id_fkey]]></foreignKeyName>
+            <uid><![CDATA[0D0C0137-38B2-40BB-BDE5-147E4ED604C3]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[actual_pickup_date]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <uid><![CDATA[7DF42196-38C2-4100-B5B8-8278D1778416]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[delivery_date]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <uid><![CDATA[CE9E6D29-98FA-45CC-B100-EE1A948A0517]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[created_at]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[9553D4D8-10A6-45A4-B15C-5231B89667F0]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[updated_at]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[857F36DF-8E6C-4E0A-B166-9034EAF4F2BB]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[source_gbloc]]></name>
+            <type><![CDATA[CHARACTER VARYING(255)]]></type>
+            <uid><![CDATA[87F7B460-99C6-4A4E-BE5A-3352DA959452]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[market]]></name>
+            <type><![CDATA[CHARACTER VARYING(255)]]></type>
+            <uid><![CDATA[0B008C84-9E5B-440B-8268-BAF8BC806231]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[book_date]]></name>
+            <type><![CDATA[DATE]]></type>
+            <uid><![CDATA[1136F15C-2CAA-4703-B6E3-37746C0BA307]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[requested_pickup_date]]></name>
+            <type><![CDATA[DATE]]></type>
+            <uid><![CDATA[7BAE13B1-BA1B-4DBA-9F57-2C6DA61270FC]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[move_id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[80CB7612-7513-49C9-8E45-3D664551AEF1]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[status]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <defaultValue><![CDATA['DRAFT'::text]]></defaultValue>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[0FA37B45-BDFD-43C5-B51E-F9746EAAB5AB]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[estimated_pack_days]]></name>
+            <type><![CDATA[INTEGER]]></type>
+            <uid><![CDATA[6AFA9996-4599-4C4C-9EA9-C0DD27B76DB7]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[estimated_transit_days]]></name>
+            <type><![CDATA[INTEGER]]></type>
+            <uid><![CDATA[C815E46D-E1BE-4EDD-A28C-195E12342483]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[pickup_address_id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <referencesField>id</referencesField>
+            <referencesTable>public.addresses</referencesTable>
+            <deleteAction>4</deleteAction>
+            <updateAction>4</updateAction>
+            <referencesField><![CDATA[id]]></referencesField>
+            <referencesTable><![CDATA[public.addresses]]></referencesTable>
+            <sourceCardinality>0</sourceCardinality>
+            <destinationCardinality>0</destinationCardinality>
+            <referencesFieldUID><![CDATA[35D03B0A-6A2C-4D68-87ED-C89BC8D491EA]]></referencesFieldUID>
+            <referencesTableUID><![CDATA[F68EC060-7139-422A-AD7C-A948A70CEA8B]]></referencesTableUID>
+            <foreignKeyName><![CDATA[shipments_address_id_fk]]></foreignKeyName>
+            <uid><![CDATA[DC03444C-3495-4AF0-A943-50BA7B914779]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[has_secondary_pickup_address]]></name>
+            <type><![CDATA[BOOLEAN]]></type>
+            <defaultValue><![CDATA[false]]></defaultValue>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[46ED1AE5-CA55-4447-A053-A9D8CE9E5E02]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[secondary_pickup_address_id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <referencesField>id</referencesField>
+            <referencesTable>public.addresses</referencesTable>
+            <deleteAction>4</deleteAction>
+            <updateAction>4</updateAction>
+            <referencesField><![CDATA[id]]></referencesField>
+            <referencesTable><![CDATA[public.addresses]]></referencesTable>
+            <sourceCardinality>0</sourceCardinality>
+            <destinationCardinality>0</destinationCardinality>
+            <referencesFieldUID><![CDATA[35D03B0A-6A2C-4D68-87ED-C89BC8D491EA]]></referencesFieldUID>
+            <referencesTableUID><![CDATA[F68EC060-7139-422A-AD7C-A948A70CEA8B]]></referencesTableUID>
+            <foreignKeyName><![CDATA[shipments_secondary_address_id_fk]]></foreignKeyName>
+            <uid><![CDATA[C18DD82C-8E41-4022-900B-076C79137046]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[has_delivery_address]]></name>
+            <type><![CDATA[BOOLEAN]]></type>
+            <defaultValue><![CDATA[false]]></defaultValue>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[EFDABDD4-88ED-4B7D-9AE9-C24F3F0BB0DC]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[delivery_address_id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <referencesField>id</referencesField>
+            <referencesTable>public.addresses</referencesTable>
+            <deleteAction>4</deleteAction>
+            <updateAction>4</updateAction>
+            <referencesField><![CDATA[id]]></referencesField>
+            <referencesTable><![CDATA[public.addresses]]></referencesTable>
+            <sourceCardinality>0</sourceCardinality>
+            <destinationCardinality>0</destinationCardinality>
+            <referencesFieldUID><![CDATA[35D03B0A-6A2C-4D68-87ED-C89BC8D491EA]]></referencesFieldUID>
+            <referencesTableUID><![CDATA[F68EC060-7139-422A-AD7C-A948A70CEA8B]]></referencesTableUID>
+            <foreignKeyName><![CDATA[delivery_address_id_fk]]></foreignKeyName>
+            <uid><![CDATA[D51AF481-2D0F-4D27-B33C-3D4F5E52560F]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[has_partial_sit_delivery_address]]></name>
+            <type><![CDATA[BOOLEAN]]></type>
+            <defaultValue><![CDATA[false]]></defaultValue>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[9B057755-CDCD-47C6-B306-C9A8D810EBBE]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[partial_sit_delivery_address_id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <referencesField>id</referencesField>
+            <referencesTable>public.addresses</referencesTable>
+            <deleteAction>4</deleteAction>
+            <updateAction>4</updateAction>
+            <referencesField><![CDATA[id]]></referencesField>
+            <referencesTable><![CDATA[public.addresses]]></referencesTable>
+            <sourceCardinality>0</sourceCardinality>
+            <destinationCardinality>0</destinationCardinality>
+            <referencesFieldUID><![CDATA[35D03B0A-6A2C-4D68-87ED-C89BC8D491EA]]></referencesFieldUID>
+            <referencesTableUID><![CDATA[F68EC060-7139-422A-AD7C-A948A70CEA8B]]></referencesTableUID>
+            <foreignKeyName><![CDATA[partial_sit_delivery_address_id_fk]]></foreignKeyName>
+            <uid><![CDATA[F5C624F9-FD18-4FE4-A2FA-52BE5296045E]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[weight_estimate]]></name>
+            <type><![CDATA[INTEGER]]></type>
+            <uid><![CDATA[F01C4E4B-383A-44B4-8031-0748DB6333D9]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[progear_weight_estimate]]></name>
+            <type><![CDATA[INTEGER]]></type>
+            <uid><![CDATA[68A0FFEE-EED1-453C-8E3C-108A1BB6F212]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[spouse_progear_weight_estimate]]></name>
+            <type><![CDATA[INTEGER]]></type>
+            <uid><![CDATA[BA192617-230F-4670-9D66-B3DEA7E19956]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[destination_gbloc]]></name>
+            <type><![CDATA[CHARACTER VARYING(255)]]></type>
+            <uid><![CDATA[BED1629C-36EC-4C04-A801-EAB7F4755FE6]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[service_member_id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <referencesField>id</referencesField>
+            <referencesTable>public.service_members</referencesTable>
+            <deleteAction>4</deleteAction>
+            <updateAction>4</updateAction>
+            <referencesField><![CDATA[id]]></referencesField>
+            <referencesTable><![CDATA[public.service_members]]></referencesTable>
+            <sourceCardinality>0</sourceCardinality>
+            <destinationCardinality>0</destinationCardinality>
+            <referencesFieldUID><![CDATA[7967F1E4-E9D1-49FA-A1F6-7DF0FD0914DE]]></referencesFieldUID>
+            <referencesTableUID><![CDATA[A7CC0F5A-7321-40A0-88C5-44CBB41D57E4]]></referencesTableUID>
+            <foreignKeyName><![CDATA[shipments_service_member_id_fk]]></foreignKeyName>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[DA5149D4-7ABB-47A8-AFD8-25CE314F76A4]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[pm_survey_planned_pack_date]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <uid><![CDATA[A93B4094-4F56-46E2-99CE-6822D8A45EA7]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[pm_survey_planned_pickup_date]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <uid><![CDATA[13BE6778-C594-4A88-8477-810F15B2D6A1]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[pm_survey_planned_delivery_date]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <uid><![CDATA[0158E8D8-7F02-4EC9-B9FC-1212ABF6C16D]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[pm_survey_weight_estimate]]></name>
+            <type><![CDATA[INTEGER]]></type>
+            <uid><![CDATA[E422650D-CE41-4B5B-BEE9-CF46527D60A4]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[pm_survey_progear_weight_estimate]]></name>
+            <type><![CDATA[INTEGER]]></type>
+            <uid><![CDATA[81964857-7CC2-485C-B71D-061AEFA0B39C]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[pm_survey_spouse_progear_weight_estimate]]></name>
+            <type><![CDATA[INTEGER]]></type>
+            <uid><![CDATA[E5A43FC0-1AD3-4677-87B1-B6B66AFE3536]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[pm_survey_notes]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <uid><![CDATA[F8722098-F168-4366-A1A9-B4346D001CBF]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[pm_survey_method]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[5C70710C-85E9-44D5-B901-28C7DEE48B32]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[actual_weight]]></name>
+            <type><![CDATA[INTEGER]]></type>
+            <uid><![CDATA[0532F31A-0152-44E7-AFA4-8DD051195798]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[gbl_number]]></name>
+            <type><![CDATA[CHARACTER VARYING(255)]]></type>
+            <uid><![CDATA[B72A2072-83A0-499C-8539-69B75733321C]]></uid>
+        </SQLField>
+        <labelWindowIndex><![CDATA[16]]></labelWindowIndex>
+        <PK_KEY_NAME><![CDATA[shipments_pkey]]></PK_KEY_NAME>
+        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
+        <uid><![CDATA[8F47E188-572A-4DD3-9A39-5ECD41CC9C7E]]></uid>
     </SQLTable>
     <SQLTable>
         <name><![CDATA[public.move_documents]]></name>
@@ -3088,7 +2000,7 @@
             <primaryKey>1</primaryKey>
             <notNull><![CDATA[1]]></notNull>
             <PK_NAME><![CDATA[move_documents_pkey]]></PK_NAME>
-            <uid><![CDATA[4D71E261-FBA1-44E9-8D4A-CF242F767812]]></uid>
+            <uid><![CDATA[539A1C5D-8E73-451B-A1A2-91DAD1B3BB9D]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[move_id]]></name>
@@ -3101,11 +2013,11 @@
             <referencesTable><![CDATA[public.moves]]></referencesTable>
             <sourceCardinality>0</sourceCardinality>
             <destinationCardinality>0</destinationCardinality>
-            <referencesFieldUID><![CDATA[53E01484-FFCD-4FBC-9485-729CEBA02C23]]></referencesFieldUID>
-            <referencesTableUID><![CDATA[C8C105E2-3679-4B84-BC12-B7A46073F848]]></referencesTableUID>
+            <referencesFieldUID><![CDATA[976D74A1-8C1A-417A-B491-251673CFAC90]]></referencesFieldUID>
+            <referencesTableUID><![CDATA[381553F0-FCC2-4A44-A4B0-ECAEF0033E72]]></referencesTableUID>
             <foreignKeyName><![CDATA[move_documents_move_id_fkey]]></foreignKeyName>
             <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[3D8BA6DC-5220-41A1-AE42-AB52A869BE79]]></uid>
+            <uid><![CDATA[A8A87325-A25E-4776-AEF4-3B84F281D121]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[document_id]]></name>
@@ -3118,46 +2030,46 @@
             <referencesTable><![CDATA[public.documents]]></referencesTable>
             <sourceCardinality>0</sourceCardinality>
             <destinationCardinality>0</destinationCardinality>
-            <referencesFieldUID><![CDATA[167D75CF-9133-40DD-BD58-F582EAF9D9A6]]></referencesFieldUID>
-            <referencesTableUID><![CDATA[3C465223-A109-4B66-A28C-1C3790F6BE2B]]></referencesTableUID>
+            <referencesFieldUID><![CDATA[6A6C4B63-5FE7-4E8C-808F-15FA64262003]]></referencesFieldUID>
+            <referencesTableUID><![CDATA[A85C394A-A5E7-49C2-8229-83D781C9B552]]></referencesTableUID>
             <foreignKeyName><![CDATA[move_documents_document_id_fkey]]></foreignKeyName>
             <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[73F5BA25-69DB-4422-B402-5FF124714629]]></uid>
+            <uid><![CDATA[C3F20B87-014F-4214-8DC8-766A597AF556]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[move_document_type]]></name>
             <type><![CDATA[CHARACTER VARYING(255)]]></type>
             <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[CF497ECE-1AC7-43CF-AC63-BD4E89FFAEFF]]></uid>
+            <uid><![CDATA[F9489D93-BF32-48A5-98E2-E07D66F199FB]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[status]]></name>
             <type><![CDATA[CHARACTER VARYING(255)]]></type>
             <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[89E8C423-366F-4421-A91C-30D36A673B51]]></uid>
+            <uid><![CDATA[876F2B49-5539-4FE0-AB84-8061EEA4D341]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[notes]]></name>
             <type><![CDATA[TEXT]]></type>
-            <uid><![CDATA[A8C34D4A-8A49-4517-823D-D92AE4C811E0]]></uid>
+            <uid><![CDATA[A9294F3D-FD7A-4423-885C-FFFDEEADDA09]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[created_at]]></name>
             <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
             <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[34BD1D13-FAAE-47FD-B712-FC8C6737C54B]]></uid>
+            <uid><![CDATA[07489E67-B445-4779-BF2C-4F7299500E4B]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[updated_at]]></name>
             <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
             <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[0951F16B-3718-4C1B-8D11-CF604B1E9AAA]]></uid>
+            <uid><![CDATA[7A10085D-0A67-486D-AFEA-B028C508DA42]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[title]]></name>
             <type><![CDATA[CHARACTER VARYING(255)]]></type>
             <notNull><![CDATA[1]]></notNull>
-            <uid><![CDATA[65691CE1-7A87-41DB-83B2-40DB35BF290C]]></uid>
+            <uid><![CDATA[79A9638C-04B1-425B-AF61-910EBC15CDF3]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[personally_procured_move_id]]></name>
@@ -3170,10 +2082,10 @@
             <referencesTable><![CDATA[public.personally_procured_moves]]></referencesTable>
             <sourceCardinality>0</sourceCardinality>
             <destinationCardinality>0</destinationCardinality>
-            <referencesFieldUID><![CDATA[2BD3FB6C-215F-464C-BE54-354AC83D63C6]]></referencesFieldUID>
-            <referencesTableUID><![CDATA[638BAF7C-21D1-4C84-B039-993B235E1BA2]]></referencesTableUID>
+            <referencesFieldUID><![CDATA[44E2249F-C5AC-423B-81AE-A40C91EBE058]]></referencesFieldUID>
+            <referencesTableUID><![CDATA[4C0EF661-70F6-4A31-9F20-53C0937083A5]]></referencesTableUID>
             <foreignKeyName><![CDATA[move_documents_personally_procured_move_id_fkey]]></foreignKeyName>
-            <uid><![CDATA[42DC9366-CF54-4545-B494-CAD4D764EFE8]]></uid>
+            <uid><![CDATA[DCF50C53-E80D-401A-A6B4-A16DCD86AF1A]]></uid>
         </SQLField>
         <SQLField>
             <name><![CDATA[shipment_id]]></name>
@@ -3186,15 +2098,1098 @@
             <referencesTable><![CDATA[public.shipments]]></referencesTable>
             <sourceCardinality>0</sourceCardinality>
             <destinationCardinality>0</destinationCardinality>
-            <referencesFieldUID><![CDATA[444DF8FF-1B94-44BC-AF1E-9535B4AE7E8D]]></referencesFieldUID>
-            <referencesTableUID><![CDATA[4ACF24EB-68A1-460A-97CD-EC9A3D9BF4CC]]></referencesTableUID>
+            <referencesFieldUID><![CDATA[BA3E4A6D-9773-475D-BEA9-80241DAD83E4]]></referencesFieldUID>
+            <referencesTableUID><![CDATA[8F47E188-572A-4DD3-9A39-5ECD41CC9C7E]]></referencesTableUID>
             <foreignKeyName><![CDATA[move_documents_shipment_id_fkey]]></foreignKeyName>
-            <uid><![CDATA[02EE087F-3747-4484-A3CF-E14DFF2A72AE]]></uid>
+            <uid><![CDATA[80199771-766E-4171-9525-A459C8C7A41A]]></uid>
         </SQLField>
         <labelWindowIndex><![CDATA[29]]></labelWindowIndex>
         <PK_KEY_NAME><![CDATA[move_documents_pkey]]></PK_KEY_NAME>
         <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
-        <uid><![CDATA[EF7A2CB8-4DF2-46E0-A265-25FD91709CCC]]></uid>
+        <uid><![CDATA[900FEE22-E03C-46F5-9D81-6479CD261559]]></uid>
+    </SQLTable>
+    <SQLTable>
+        <name><![CDATA[public.gbl_number_trackers]]></name>
+        <schema><![CDATA[public]]></schema>
+        <location>
+            <x>1690.00</x>
+            <y>10.00</y>
+        </location>
+        <size>
+            <width>229.00</width>
+            <height>80.00</height>
+        </size>
+        <zorder>31</zorder>
+        <SQLField>
+            <name><![CDATA[sequence_number]]></name>
+            <type><![CDATA[INTEGER]]></type>
+            <uid><![CDATA[0A7D39E9-9928-46AC-8163-AF471B015615]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[gbloc]]></name>
+            <type><![CDATA[CHARACTER VARYING(255)]]></type>
+            <uid><![CDATA[802C988E-18CF-46A6-8B9C-D9DD5955F53A]]></uid>
+        </SQLField>
+        <SQLConstraint>
+            <name><![CDATA[gbl_number_trackers_gbloc_key]]></name>
+            <fieldName><![CDATA[gbloc]]></fieldName>
+            <SQLIndexEntry>
+                <name><![CDATA[gbloc]]></name>
+                <prefixSize><![CDATA[]]></prefixSize>
+                <fieldUid><![CDATA[802C988E-18CF-46A6-8B9C-D9DD5955F53A]]></fieldUid>
+            </SQLIndexEntry>
+            <deferrable><![CDATA[0]]></deferrable>
+            <indexType><![CDATA[UNIQUE]]></indexType>
+            <initiallyDeferred><![CDATA[0]]></initiallyDeferred>
+            <uid><![CDATA[3DEE91D7-0513-466F-88CF-9C02584275A8]]></uid>
+        </SQLConstraint>
+        <labelWindowIndex><![CDATA[31]]></labelWindowIndex>
+        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
+        <uid><![CDATA[963629A8-5C5A-44DE-A9DF-1EBD9F36D764]]></uid>
+    </SQLTable>
+    <SQLTable>
+        <name><![CDATA[public.tariff400ng_full_unpack_rates]]></name>
+        <schema><![CDATA[public]]></schema>
+        <location>
+            <x>972.00</x>
+            <y>1420.00</y>
+        </location>
+        <size>
+            <width>298.00</width>
+            <height>160.00</height>
+        </size>
+        <zorder>12</zorder>
+        <SQLField>
+            <name><![CDATA[id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <uid><![CDATA[2499EC60-9D1A-4E14-93BD-828099B232E1]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[schedule]]></name>
+            <type><![CDATA[INTEGER]]></type>
+            <uid><![CDATA[A2ABFEF1-4F66-47D2-A7CD-26BBAC9E2052]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[rate_millicents]]></name>
+            <type><![CDATA[INTEGER]]></type>
+            <uid><![CDATA[A6E66D45-2074-4AE1-8905-58CD51458A5D]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[effective_date_lower]]></name>
+            <type><![CDATA[DATE]]></type>
+            <uid><![CDATA[26A34537-70C6-4B64-AC91-C917D718CDB8]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[effective_date_upper]]></name>
+            <type><![CDATA[DATE]]></type>
+            <uid><![CDATA[D5CD7C9B-74D3-4759-A9D7-2D9F2CB94A1F]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[created_at]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <uid><![CDATA[65234BF0-BB77-40FE-9D4C-21F02146B4C6]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[updated_at]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <uid><![CDATA[D04DFDFA-ED8F-4D8E-95AA-10A4897DF58B]]></uid>
+        </SQLField>
+        <labelWindowIndex><![CDATA[12]]></labelWindowIndex>
+        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
+        <uid><![CDATA[9D6B1C7E-76D6-4EDD-837C-9B304C23F7DC]]></uid>
+    </SQLTable>
+    <SQLTable>
+        <name><![CDATA[public.tsp_users]]></name>
+        <schema><![CDATA[public]]></schema>
+        <location>
+            <x>2014.00</x>
+            <y>1710.00</y>
+        </location>
+        <size>
+            <width>317.00</width>
+            <height>220.00</height>
+        </size>
+        <zorder>2</zorder>
+        <SQLField>
+            <name><![CDATA[id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <primaryKey>1</primaryKey>
+            <notNull><![CDATA[1]]></notNull>
+            <PK_NAME><![CDATA[tsp_users_pkey]]></PK_NAME>
+            <uid><![CDATA[F7EF6DDC-FAD6-4CA8-8944-036A8C065404]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[user_id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <referencesField>id</referencesField>
+            <referencesTable>public.users</referencesTable>
+            <deleteAction>4</deleteAction>
+            <updateAction>4</updateAction>
+            <referencesField><![CDATA[id]]></referencesField>
+            <referencesTable><![CDATA[public.users]]></referencesTable>
+            <sourceCardinality>0</sourceCardinality>
+            <destinationCardinality>0</destinationCardinality>
+            <referencesFieldUID><![CDATA[DCD39A12-ABD0-4ABE-9E63-3738507BE8B3]]></referencesFieldUID>
+            <referencesTableUID><![CDATA[BB175DB0-D2A9-4C32-92B8-B4F0FDD56488]]></referencesTableUID>
+            <foreignKeyName><![CDATA[tsp_users_user_id_fkey]]></foreignKeyName>
+            <uid><![CDATA[ED3FE0D1-F2A8-4FCD-A93C-8F42521E4DA9]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[last_name]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[1E626E8D-316C-43B5-82B1-FD602789EE62]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[first_name]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[0D731521-54A1-4D61-B013-B4652A66AD7A]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[middle_initials]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <uid><![CDATA[26008DE7-D705-4624-B8D2-A17BBA0BAFE7]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[email]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[DF9533AE-AA2D-440A-917D-4A9A84A814BB]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[telephone]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[F7477529-1FCA-429F-82FF-FB756339A8BA]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[transportation_service_provider_id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <referencesField>id</referencesField>
+            <referencesTable>public.transportation_service_providers</referencesTable>
+            <deleteAction>4</deleteAction>
+            <updateAction>4</updateAction>
+            <referencesField><![CDATA[id]]></referencesField>
+            <referencesTable><![CDATA[public.transportation_service_providers]]></referencesTable>
+            <sourceCardinality>0</sourceCardinality>
+            <destinationCardinality>0</destinationCardinality>
+            <referencesFieldUID><![CDATA[093BF0ED-A127-4BA8-B389-1FA79F673331]]></referencesFieldUID>
+            <referencesTableUID><![CDATA[342FBF63-1DB7-4D4F-9801-9F04DC431050]]></referencesTableUID>
+            <foreignKeyName><![CDATA[tsp_users_transportation_service_provider_id_fkey]]></foreignKeyName>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[954951A9-4478-4554-AE46-C78F29417621]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[created_at]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[42E16EE4-2DD2-4FCE-88ED-E1BDFBEB4F10]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[updated_at]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[58C4CE56-6932-42CC-AAB7-0CFFEF7E2D6A]]></uid>
+        </SQLField>
+        <labelWindowIndex><![CDATA[2]]></labelWindowIndex>
+        <PK_KEY_NAME><![CDATA[tsp_users_pkey]]></PK_KEY_NAME>
+        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
+        <uid><![CDATA[9FF4732F-E73D-4A02-8A49-2FBB018A7515]]></uid>
+    </SQLTable>
+    <SQLTable>
+        <name><![CDATA[public.service_members]]></name>
+        <schema><![CDATA[public]]></schema>
+        <location>
+            <x>1330.00</x>
+            <y>670.00</y>
+        </location>
+        <size>
+            <width>317.00</width>
+            <height>440.00</height>
+        </size>
+        <zorder>18</zorder>
+        <SQLField>
+            <name><![CDATA[id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <primaryKey>1</primaryKey>
+            <forcedUnique><![CDATA[1]]></forcedUnique>
+            <notNull><![CDATA[1]]></notNull>
+            <PK_NAME><![CDATA[service_members_pkey]]></PK_NAME>
+            <uid><![CDATA[7967F1E4-E9D1-49FA-A1F6-7DF0FD0914DE]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[user_id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <referencesField>id</referencesField>
+            <referencesTable>public.users</referencesTable>
+            <deleteAction>4</deleteAction>
+            <updateAction>4</updateAction>
+            <referencesField><![CDATA[id]]></referencesField>
+            <referencesTable><![CDATA[public.users]]></referencesTable>
+            <sourceCardinality>0</sourceCardinality>
+            <destinationCardinality>0</destinationCardinality>
+            <referencesFieldUID><![CDATA[DCD39A12-ABD0-4ABE-9E63-3738507BE8B3]]></referencesFieldUID>
+            <referencesTableUID><![CDATA[BB175DB0-D2A9-4C32-92B8-B4F0FDD56488]]></referencesTableUID>
+            <foreignKeyName><![CDATA[service_members_user_id_fkey]]></foreignKeyName>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[43FBE37D-031E-4FC5-9CEA-82FBEA4E4F31]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[edipi]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <uid><![CDATA[3BED9537-9BE4-48BD-BE69-13260A521A95]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[affiliation]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <uid><![CDATA[B8DCEBE2-EA71-482E-979B-FD263ACFFC13]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[rank]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <uid><![CDATA[C2CA6068-153E-4BE3-AEB1-85FD9ACCB3C1]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[first_name]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <uid><![CDATA[9749F37B-A7E9-49C1-9419-304AA2188CF2]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[middle_name]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <uid><![CDATA[B4E5BE87-6AB0-47EC-A9FA-F78C45634E5C]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[last_name]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <uid><![CDATA[35B78413-FE91-4980-A685-89A4D6FB0069]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[suffix]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <uid><![CDATA[52DE40C8-3E29-4FEB-8E06-F1A009BAD90E]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[telephone]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <uid><![CDATA[C95BF232-70ED-4469-BDAC-46055E42EF74]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[secondary_telephone]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <uid><![CDATA[76AED65A-A30A-4CA5-963E-77132620660B]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[personal_email]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <uid><![CDATA[958DDEC6-80A0-4FEA-8BCC-F93D6E2A3321]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[phone_is_preferred]]></name>
+            <type><![CDATA[BOOLEAN]]></type>
+            <uid><![CDATA[A47A5285-7190-4E11-B691-0583229E757F]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[text_message_is_preferred]]></name>
+            <type><![CDATA[BOOLEAN]]></type>
+            <uid><![CDATA[06A3D5C7-0DA5-4C96-9DE9-35AF19543BD8]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[email_is_preferred]]></name>
+            <type><![CDATA[BOOLEAN]]></type>
+            <uid><![CDATA[985F5499-F9DC-40DD-9842-C0CE3ABAA7B1]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[residential_address_id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <referencesField>id</referencesField>
+            <referencesTable>public.addresses</referencesTable>
+            <deleteAction>4</deleteAction>
+            <updateAction>4</updateAction>
+            <referencesField><![CDATA[id]]></referencesField>
+            <referencesTable><![CDATA[public.addresses]]></referencesTable>
+            <sourceCardinality>0</sourceCardinality>
+            <destinationCardinality>0</destinationCardinality>
+            <referencesFieldUID><![CDATA[35D03B0A-6A2C-4D68-87ED-C89BC8D491EA]]></referencesFieldUID>
+            <referencesTableUID><![CDATA[F68EC060-7139-422A-AD7C-A948A70CEA8B]]></referencesTableUID>
+            <foreignKeyName><![CDATA[service_members_residential_address_id_fkey]]></foreignKeyName>
+            <uid><![CDATA[A07B0012-2CBB-4F65-8229-9C4206ED81F1]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[backup_mailing_address_id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <referencesField>id</referencesField>
+            <referencesTable>public.addresses</referencesTable>
+            <deleteAction>4</deleteAction>
+            <updateAction>4</updateAction>
+            <referencesField><![CDATA[id]]></referencesField>
+            <referencesTable><![CDATA[public.addresses]]></referencesTable>
+            <sourceCardinality>0</sourceCardinality>
+            <destinationCardinality>0</destinationCardinality>
+            <referencesFieldUID><![CDATA[35D03B0A-6A2C-4D68-87ED-C89BC8D491EA]]></referencesFieldUID>
+            <referencesTableUID><![CDATA[F68EC060-7139-422A-AD7C-A948A70CEA8B]]></referencesTableUID>
+            <foreignKeyName><![CDATA[service_members_backup_mailing_address_id_fkey]]></foreignKeyName>
+            <uid><![CDATA[6CEBB534-761F-46C3-B8C6-6D4D479CA7DB]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[created_at]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[40ABEE44-F151-45F3-8949-6625A9A7DEB9]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[updated_at]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[0FB56F07-C556-4EA1-85DC-44C46D59AE71]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[social_security_number_id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <referencesField>id</referencesField>
+            <referencesTable>public.social_security_numbers</referencesTable>
+            <deleteAction>3</deleteAction>
+            <updateAction>4</updateAction>
+            <referencesField><![CDATA[id]]></referencesField>
+            <referencesTable><![CDATA[public.social_security_numbers]]></referencesTable>
+            <sourceCardinality>0</sourceCardinality>
+            <destinationCardinality>0</destinationCardinality>
+            <referencesFieldUID><![CDATA[88782F22-C280-458F-8090-F8F57CDE151B]]></referencesFieldUID>
+            <referencesTableUID><![CDATA[DF44E0C3-E539-4060-B89F-850EE28C40D3]]></referencesTableUID>
+            <foreignKeyName><![CDATA[sm_ssn_fk]]></foreignKeyName>
+            <uid><![CDATA[A0A8A63A-AC6C-4004-BFE6-F40FD207A3E4]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[duty_station_id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <referencesField>id</referencesField>
+            <referencesTable>public.duty_stations</referencesTable>
+            <deleteAction>3</deleteAction>
+            <updateAction>4</updateAction>
+            <referencesField><![CDATA[id]]></referencesField>
+            <referencesTable><![CDATA[public.duty_stations]]></referencesTable>
+            <sourceCardinality>0</sourceCardinality>
+            <destinationCardinality>0</destinationCardinality>
+            <referencesFieldUID><![CDATA[37FE07DF-F33E-40D8-97B0-59DC061255C8]]></referencesFieldUID>
+            <referencesTableUID><![CDATA[521C4498-C168-438F-BD6C-8E836E1C5A64]]></referencesTableUID>
+            <foreignKeyName><![CDATA[sm_duty_station_fk]]></foreignKeyName>
+            <uid><![CDATA[C36FCE07-EEF4-461A-81FB-668A877FEEEE]]></uid>
+        </SQLField>
+        <labelWindowIndex><![CDATA[18]]></labelWindowIndex>
+        <PK_KEY_NAME><![CDATA[service_members_pkey]]></PK_KEY_NAME>
+        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
+        <uid><![CDATA[A7CC0F5A-7321-40A0-88C5-44CBB41D57E4]]></uid>
+    </SQLTable>
+    <SQLTable>
+        <name><![CDATA[public.documents]]></name>
+        <schema><![CDATA[public]]></schema>
+        <location>
+            <x>1036.00</x>
+            <y>10.00</y>
+        </location>
+        <size>
+            <width>317.00</width>
+            <height>100.00</height>
+        </size>
+        <zorder>33</zorder>
+        <SQLField>
+            <name><![CDATA[id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <primaryKey>1</primaryKey>
+            <forcedUnique><![CDATA[1]]></forcedUnique>
+            <notNull><![CDATA[1]]></notNull>
+            <PK_NAME><![CDATA[documents_pkey]]></PK_NAME>
+            <uid><![CDATA[6A6C4B63-5FE7-4E8C-808F-15FA64262003]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[created_at]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[9BA7B4D8-3B28-456F-8707-C5DDDFC969BD]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[updated_at]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[E3FC4C95-BB87-48EC-867D-32495DD27E93]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[service_member_id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <referencesField>id</referencesField>
+            <referencesTable>public.service_members</referencesTable>
+            <deleteAction>4</deleteAction>
+            <updateAction>4</updateAction>
+            <referencesField><![CDATA[id]]></referencesField>
+            <referencesTable><![CDATA[public.service_members]]></referencesTable>
+            <sourceCardinality>0</sourceCardinality>
+            <destinationCardinality>0</destinationCardinality>
+            <referencesFieldUID><![CDATA[7967F1E4-E9D1-49FA-A1F6-7DF0FD0914DE]]></referencesFieldUID>
+            <referencesTableUID><![CDATA[A7CC0F5A-7321-40A0-88C5-44CBB41D57E4]]></referencesTableUID>
+            <foreignKeyName><![CDATA[documents_service_members_id_fk]]></foreignKeyName>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[57353161-F632-4A7B-8AAD-1BD074D978CE]]></uid>
+        </SQLField>
+        <labelWindowIndex><![CDATA[33]]></labelWindowIndex>
+        <PK_KEY_NAME><![CDATA[documents_pkey]]></PK_KEY_NAME>
+        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
+        <uid><![CDATA[A85C394A-A5E7-49C2-8229-83D781C9B552]]></uid>
+    </SQLTable>
+    <SQLTable>
+        <name><![CDATA[public.users]]></name>
+        <schema><![CDATA[public]]></schema>
+        <location>
+            <x>337.00</x>
+            <y>2020.00</y>
+        </location>
+        <size>
+            <width>317.00</width>
+            <height>140.00</height>
+        </size>
+        <zorder>0</zorder>
+        <SQLField>
+            <name><![CDATA[id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <primaryKey>1</primaryKey>
+            <forcedUnique><![CDATA[1]]></forcedUnique>
+            <notNull><![CDATA[1]]></notNull>
+            <PK_NAME><![CDATA[users_pkey]]></PK_NAME>
+            <uid><![CDATA[DCD39A12-ABD0-4ABE-9E63-3738507BE8B3]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[login_gov_uuid]]></name>
+            <type><![CDATA[UUID]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[18B709BF-D1CA-4A0C-AC42-98C29489E98B]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[login_gov_email]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[65B29E35-876B-46E1-90FA-F76E9BD67F87]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[created_at]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[2A737B7D-7B7A-466B-8C03-719CA7AFA623]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[updated_at]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[5BF108CC-93D3-4FAE-87E4-FECD028B07DD]]></uid>
+        </SQLField>
+        <SQLConstraint>
+            <name><![CDATA[constraint_name]]></name>
+            <fieldName><![CDATA[login_gov_uuid]]></fieldName>
+            <SQLIndexEntry>
+                <name><![CDATA[login_gov_uuid]]></name>
+                <prefixSize><![CDATA[]]></prefixSize>
+                <fieldUid><![CDATA[18B709BF-D1CA-4A0C-AC42-98C29489E98B]]></fieldUid>
+            </SQLIndexEntry>
+            <deferrable><![CDATA[0]]></deferrable>
+            <indexType><![CDATA[UNIQUE]]></indexType>
+            <initiallyDeferred><![CDATA[0]]></initiallyDeferred>
+            <uid><![CDATA[36316A59-4020-4D09-A473-8C5D2A2AB8C6]]></uid>
+        </SQLConstraint>
+        <labelWindowIndex><![CDATA[0]]></labelWindowIndex>
+        <PK_KEY_NAME><![CDATA[users_pkey]]></PK_KEY_NAME>
+        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
+        <uid><![CDATA[BB175DB0-D2A9-4C32-92B8-B4F0FDD56488]]></uid>
+    </SQLTable>
+    <SQLTable>
+        <name><![CDATA[public.signed_certifications]]></name>
+        <schema><![CDATA[public]]></schema>
+        <location>
+            <x>10.00</x>
+            <y>1420.00</y>
+        </location>
+        <size>
+            <width>317.00</width>
+            <height>180.00</height>
+        </size>
+        <zorder>15</zorder>
+        <SQLField>
+            <name><![CDATA[id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <primaryKey>1</primaryKey>
+            <notNull><![CDATA[1]]></notNull>
+            <PK_NAME><![CDATA[signed_certifications_pkey]]></PK_NAME>
+            <uid><![CDATA[95547738-1529-4E9F-8A13-F9CFA9B82064]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[submitting_user_id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <referencesField>id</referencesField>
+            <referencesTable>public.users</referencesTable>
+            <deleteAction>4</deleteAction>
+            <updateAction>4</updateAction>
+            <referencesField><![CDATA[id]]></referencesField>
+            <referencesTable><![CDATA[public.users]]></referencesTable>
+            <sourceCardinality>0</sourceCardinality>
+            <destinationCardinality>0</destinationCardinality>
+            <referencesFieldUID><![CDATA[DCD39A12-ABD0-4ABE-9E63-3738507BE8B3]]></referencesFieldUID>
+            <referencesTableUID><![CDATA[BB175DB0-D2A9-4C32-92B8-B4F0FDD56488]]></referencesTableUID>
+            <foreignKeyName><![CDATA[signed_certifications_submitting_user_id_fkey]]></foreignKeyName>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[EE27BCBB-CCB6-487E-B523-4F5F3B23F8AF]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[move_id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[65EE3ADB-B063-47A6-A736-8605443D7AEE]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[certification_text]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[A59588A2-C1EC-4215-9138-87119968F065]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[signature]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[AAC86B35-3A7C-46A7-8EB8-9C1F17A296C8]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[date]]></name>
+            <type><![CDATA[DATE]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[CFFFF79C-F875-47A2-AEA0-E7E0B543B7E3]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[created_at]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[93852E47-8E0A-4408-913B-786AFECDCB56]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[updated_at]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[797E8365-42F4-4CE4-AA62-49178BB582E3]]></uid>
+        </SQLField>
+        <labelWindowIndex><![CDATA[15]]></labelWindowIndex>
+        <PK_KEY_NAME><![CDATA[signed_certifications_pkey]]></PK_KEY_NAME>
+        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
+        <uid><![CDATA[C2F72D4B-CD8C-4828-80A0-F095BCF28430]]></uid>
+    </SQLTable>
+    <SQLTable>
+        <name><![CDATA[public.moving_expense_documents]]></name>
+        <schema><![CDATA[public]]></schema>
+        <location>
+            <x>685.00</x>
+            <y>260.00</y>
+        </location>
+        <size>
+            <width>340.00</width>
+            <height>160.00</height>
+        </size>
+        <zorder>27</zorder>
+        <SQLField>
+            <name><![CDATA[id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <primaryKey>1</primaryKey>
+            <notNull><![CDATA[1]]></notNull>
+            <PK_NAME><![CDATA[moving_expense_documents_pkey]]></PK_NAME>
+            <uid><![CDATA[723FB317-18DC-4FCE-A3AD-444A6CB44A17]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[move_document_id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[34B1D577-46D3-4629-B68A-648EECE72CFD]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[moving_expense_type]]></name>
+            <type><![CDATA[CHARACTER VARYING(255)]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[1242614A-3F56-491C-B9E0-72F14397C269]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[created_at]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[6CACFFD5-A721-4BD9-8ECF-047314CA80C3]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[updated_at]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[820F3F68-421C-4761-9200-AF91D2F64EB3]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[requested_amount_cents]]></name>
+            <type><![CDATA[INTEGER]]></type>
+            <uid><![CDATA[AD4E1DFD-1812-4134-9681-39CC4EFD1E1B]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[payment_method]]></name>
+            <type><![CDATA[CHARACTER VARYING]]></type>
+            <uid><![CDATA[1BFCF32A-9661-41FE-9176-CE020CDB7C47]]></uid>
+        </SQLField>
+        <labelWindowIndex><![CDATA[27]]></labelWindowIndex>
+        <PK_KEY_NAME><![CDATA[moving_expense_documents_pkey]]></PK_KEY_NAME>
+        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
+        <uid><![CDATA[C70FEBCA-53A9-4ADA-9D6E-288AC5F8AFC9]]></uid>
+    </SQLTable>
+    <SQLTable>
+        <name><![CDATA[public.uploads]]></name>
+        <schema><![CDATA[public]]></schema>
+        <location>
+            <x>10.00</x>
+            <y>2020.00</y>
+        </location>
+        <size>
+            <width>317.00</width>
+            <height>220.00</height>
+        </size>
+        <zorder>1</zorder>
+        <SQLField>
+            <name><![CDATA[id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <primaryKey>1</primaryKey>
+            <notNull><![CDATA[1]]></notNull>
+            <PK_NAME><![CDATA[uploads_pkey]]></PK_NAME>
+            <uid><![CDATA[D78DE4E3-637A-461C-A2A1-E127D6E1DE78]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[document_id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <referencesField>id</referencesField>
+            <referencesTable>public.documents</referencesTable>
+            <deleteAction>4</deleteAction>
+            <updateAction>4</updateAction>
+            <referencesField><![CDATA[id]]></referencesField>
+            <referencesTable><![CDATA[public.documents]]></referencesTable>
+            <sourceCardinality>0</sourceCardinality>
+            <destinationCardinality>0</destinationCardinality>
+            <referencesFieldUID><![CDATA[6A6C4B63-5FE7-4E8C-808F-15FA64262003]]></referencesFieldUID>
+            <referencesTableUID><![CDATA[A85C394A-A5E7-49C2-8229-83D781C9B552]]></referencesTableUID>
+            <foreignKeyName><![CDATA[uploads_document_id_fkey]]></foreignKeyName>
+            <uid><![CDATA[BD814B40-9F54-464E-A9D4-614F4C1E56C4]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[uploader_id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <referencesField>id</referencesField>
+            <referencesTable>public.users</referencesTable>
+            <deleteAction>4</deleteAction>
+            <updateAction>4</updateAction>
+            <referencesField><![CDATA[id]]></referencesField>
+            <referencesTable><![CDATA[public.users]]></referencesTable>
+            <sourceCardinality>0</sourceCardinality>
+            <destinationCardinality>0</destinationCardinality>
+            <referencesFieldUID><![CDATA[DCD39A12-ABD0-4ABE-9E63-3738507BE8B3]]></referencesFieldUID>
+            <referencesTableUID><![CDATA[BB175DB0-D2A9-4C32-92B8-B4F0FDD56488]]></referencesTableUID>
+            <foreignKeyName><![CDATA[uploads_uploader_id_fkey]]></foreignKeyName>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[214C6D01-1DBE-4FE7-9843-D350F89B7A65]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[filename]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[CEFA3593-2880-4BA8-B451-36781BE41114]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[bytes]]></name>
+            <type><![CDATA[BIGINT]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[5F0979B5-B5C4-43A3-BA19-6BC860EC9B62]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[content_type]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[BE2FB3B7-696E-411F-9968-9634A14606B1]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[checksum]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[C50ACF2B-CF08-4311-A1AD-EA3BA0BB3B96]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[created_at]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[E920A9E7-0988-446F-81DD-F9280FA1C2E2]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[updated_at]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[DDF25E7E-EA68-4705-8EA8-9B2030DAC3A8]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[storage_key]]></name>
+            <type><![CDATA[CHARACTER VARYING(1024)]]></type>
+            <uid><![CDATA[E59E46A2-4CF2-4D8D-A77E-24E5979733E0]]></uid>
+        </SQLField>
+        <labelWindowIndex><![CDATA[1]]></labelWindowIndex>
+        <PK_KEY_NAME><![CDATA[uploads_pkey]]></PK_KEY_NAME>
+        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
+        <uid><![CDATA[C91631BD-8FF8-48EF-8897-CF6007A6FD9B]]></uid>
+    </SQLTable>
+    <SQLTable>
+        <name><![CDATA[public.social_security_numbers]]></name>
+        <schema><![CDATA[public]]></schema>
+        <location>
+            <x>337.00</x>
+            <y>1420.00</y>
+        </location>
+        <size>
+            <width>317.00</width>
+            <height>100.00</height>
+        </size>
+        <zorder>14</zorder>
+        <SQLField>
+            <name><![CDATA[id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <primaryKey>1</primaryKey>
+            <forcedUnique><![CDATA[1]]></forcedUnique>
+            <notNull><![CDATA[1]]></notNull>
+            <PK_NAME><![CDATA[social_security_numbers_pkey]]></PK_NAME>
+            <uid><![CDATA[88782F22-C280-458F-8090-F8F57CDE151B]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[encrypted_hash]]></name>
+            <type><![CDATA[CHARACTER VARYING(255)]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[F3B362CB-44AA-44DD-8C29-675FE9290C50]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[created_at]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[A00249FE-A07B-45B5-942C-FACF4B4FA930]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[updated_at]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[E59EB37D-01F2-4C5C-B09D-55E409D67037]]></uid>
+        </SQLField>
+        <labelWindowIndex><![CDATA[14]]></labelWindowIndex>
+        <PK_KEY_NAME><![CDATA[social_security_numbers_pkey]]></PK_KEY_NAME>
+        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
+        <uid><![CDATA[DF44E0C3-E539-4060-B89F-850EE28C40D3]]></uid>
+    </SQLTable>
+    <SQLTable>
+        <name><![CDATA[public.tariff400ng_zip5_rate_areas]]></name>
+        <schema><![CDATA[public]]></schema>
+        <location>
+            <x>318.00</x>
+            <y>1710.00</y>
+        </location>
+        <size>
+            <width>298.00</width>
+            <height>120.00</height>
+        </size>
+        <zorder>7</zorder>
+        <SQLField>
+            <name><![CDATA[id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <uid><![CDATA[7AB27E7A-1B8B-45E5-8511-E403260CC16C]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[zip5]]></name>
+            <type><![CDATA[CHARACTER VARYING(5)]]></type>
+            <uid><![CDATA[D7F4BA0B-4ECD-4C6E-BFD3-A15ABE0F9BC4]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[rate_area]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <uid><![CDATA[EF12B5AB-90EB-4BC1-B791-C8EE9F3A3A32]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[created_at]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <uid><![CDATA[5C8D6294-3CA0-4C24-91AC-81BFDCE9211B]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[updated_at]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <uid><![CDATA[44DF8D39-9EE1-4C52-AA1F-780C0EF67D84]]></uid>
+        </SQLField>
+        <labelWindowIndex><![CDATA[7]]></labelWindowIndex>
+        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
+        <uid><![CDATA[F0CB994E-2580-4365-A789-32496BF93ED3]]></uid>
+    </SQLTable>
+    <SQLTable>
+        <name><![CDATA[public.tariff400ng_full_pack_rates]]></name>
+        <schema><![CDATA[public]]></schema>
+        <location>
+            <x>664.00</x>
+            <y>1420.00</y>
+        </location>
+        <size>
+            <width>298.00</width>
+            <height>200.00</height>
+        </size>
+        <zorder>13</zorder>
+        <SQLField>
+            <name><![CDATA[id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <uid><![CDATA[7B4288C9-9591-40C0-A4E1-0C0781C9CDB1]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[schedule]]></name>
+            <type><![CDATA[INTEGER]]></type>
+            <uid><![CDATA[645BB550-05AB-48F7-8DC1-E4102C7632BA]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[weight_lbs_lower]]></name>
+            <type><![CDATA[INTEGER]]></type>
+            <uid><![CDATA[2704A6FC-4E8C-4110-A283-0546A5C6F771]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[weight_lbs_upper]]></name>
+            <type><![CDATA[INTEGER]]></type>
+            <uid><![CDATA[47FC9C94-801E-42EB-B309-678404BE1A9C]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[rate_cents]]></name>
+            <type><![CDATA[INTEGER]]></type>
+            <uid><![CDATA[804AEF78-CEF6-480D-A1D0-B41BAF78E30B]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[effective_date_lower]]></name>
+            <type><![CDATA[DATE]]></type>
+            <uid><![CDATA[18024746-10B5-4289-AC4E-1F6015D046FC]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[effective_date_upper]]></name>
+            <type><![CDATA[DATE]]></type>
+            <uid><![CDATA[DF876E24-CB30-4C38-B7E3-094184FEB64B]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[created_at]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <uid><![CDATA[2BD82219-0DF0-4D59-9065-D6BC87DA2A89]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[updated_at]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <uid><![CDATA[B75B134C-75EF-4EE4-BF32-69A6922267D3]]></uid>
+        </SQLField>
+        <labelWindowIndex><![CDATA[13]]></labelWindowIndex>
+        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
+        <uid><![CDATA[F3F76981-9D78-4821-8E76-A2CCA225E2FC]]></uid>
+    </SQLTable>
+    <SQLTable>
+        <name><![CDATA[public.addresses]]></name>
+        <schema><![CDATA[public]]></schema>
+        <location>
+            <x>10.00</x>
+            <y>10.00</y>
+        </location>
+        <size>
+            <width>317.00</width>
+            <height>220.00</height>
+        </size>
+        <zorder>36</zorder>
+        <SQLField>
+            <name><![CDATA[id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <primaryKey>1</primaryKey>
+            <forcedUnique><![CDATA[1]]></forcedUnique>
+            <notNull><![CDATA[1]]></notNull>
+            <PK_NAME><![CDATA[addresses_pkey]]></PK_NAME>
+            <uid><![CDATA[35D03B0A-6A2C-4D68-87ED-C89BC8D491EA]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[street_address_1]]></name>
+            <type><![CDATA[CHARACTER VARYING(255)]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[D277997A-707A-46F0-9BE2-CBA24AA7DEE7]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[street_address_2]]></name>
+            <type><![CDATA[CHARACTER VARYING(255)]]></type>
+            <uid><![CDATA[A6968861-0D65-42D3-8AF2-D06C09531B39]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[city]]></name>
+            <type><![CDATA[CHARACTER VARYING(255)]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[4F836D54-6A31-4D93-9090-3604BDAA4176]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[state]]></name>
+            <type><![CDATA[CHARACTER VARYING(255)]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[91BF64AE-6556-418D-86FB-E457540C3EA2]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[postal_code]]></name>
+            <type><![CDATA[CHARACTER VARYING(255)]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[8DFBDE84-EB7C-4A5D-8CAC-953C31AE4882]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[created_at]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[5B6652BB-2030-49DE-8ADB-AB7578116659]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[updated_at]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <notNull><![CDATA[1]]></notNull>
+            <uid><![CDATA[27DA1DA9-ED73-4FEB-9EFC-954B9713CED3]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[street_address_3]]></name>
+            <type><![CDATA[CHARACTER VARYING(255)]]></type>
+            <uid><![CDATA[42050EA0-26C9-4F00-AF85-6BE838CEEF3E]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[country]]></name>
+            <type><![CDATA[CHARACTER VARYING(255)]]></type>
+            <defaultValue><![CDATA['United States'::character varying]]></defaultValue>
+            <uid><![CDATA[8DBD5D41-5658-45E6-A61D-67CE29BFD883]]></uid>
+        </SQLField>
+        <labelWindowIndex><![CDATA[36]]></labelWindowIndex>
+        <PK_KEY_NAME><![CDATA[addresses_pkey]]></PK_KEY_NAME>
+        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
+        <uid><![CDATA[F68EC060-7139-422A-AD7C-A948A70CEA8B]]></uid>
+    </SQLTable>
+    <SQLTable>
+        <name><![CDATA[public.tariff400ng_linehaul_rates]]></name>
+        <schema><![CDATA[public]]></schema>
+        <location>
+            <x>1280.00</x>
+            <y>1420.00</y>
+        </location>
+        <size>
+            <width>298.00</width>
+            <height>240.00</height>
+        </size>
+        <zorder>11</zorder>
+        <SQLField>
+            <name><![CDATA[id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <uid><![CDATA[E99ABC58-9D40-4A54-A219-D2CD1A7682D7]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[distance_miles_lower]]></name>
+            <type><![CDATA[INTEGER]]></type>
+            <uid><![CDATA[C79722E5-A0D5-49F2-8438-0A3AEFA16694]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[distance_miles_upper]]></name>
+            <type><![CDATA[INTEGER]]></type>
+            <uid><![CDATA[D311A7F8-84EB-4A1D-B1E7-D5EB7CF0D5FF]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[weight_lbs_lower]]></name>
+            <type><![CDATA[INTEGER]]></type>
+            <uid><![CDATA[58ABF3A7-71D8-4908-9C43-5CFC9B0D7F27]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[weight_lbs_upper]]></name>
+            <type><![CDATA[INTEGER]]></type>
+            <uid><![CDATA[4A0FF0EA-D197-46FD-BFB1-DD9E04409D2B]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[rate_cents]]></name>
+            <type><![CDATA[INTEGER]]></type>
+            <uid><![CDATA[368EF65D-9579-42C0-904C-134E82953258]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[effective_date_lower]]></name>
+            <type><![CDATA[DATE]]></type>
+            <uid><![CDATA[87DA946C-A8F2-4A90-95B8-98260E00924C]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[effective_date_upper]]></name>
+            <type><![CDATA[DATE]]></type>
+            <uid><![CDATA[E65925E1-67C4-4D66-B294-3FF1F74634B1]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[type]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <uid><![CDATA[1091DB98-2DE2-4008-80F7-BEA46CF84B11]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[created_at]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <uid><![CDATA[901A1EAA-66B6-4AE5-AE0A-7CD862E2BB5B]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[updated_at]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <uid><![CDATA[7010D364-3B6F-4582-A07A-F08AC5891155]]></uid>
+        </SQLField>
+        <labelWindowIndex><![CDATA[11]]></labelWindowIndex>
+        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
+        <uid><![CDATA[FCD1E045-A496-457C-ABC4-09AE53026578]]></uid>
+    </SQLTable>
+    <SQLTable>
+        <name><![CDATA[public.tariff400ng_zip3s]]></name>
+        <schema><![CDATA[public]]></schema>
+        <location>
+            <x>10.00</x>
+            <y>1710.00</y>
+        </location>
+        <size>
+            <width>298.00</width>
+            <height>200.00</height>
+        </size>
+        <zorder>8</zorder>
+        <SQLField>
+            <name><![CDATA[id]]></name>
+            <type><![CDATA[UUID]]></type>
+            <uid><![CDATA[6EAEA65E-AECE-4558-B2EA-77FE0CEBF354]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[zip3]]></name>
+            <type><![CDATA[CHARACTER VARYING(3)]]></type>
+            <uid><![CDATA[B8819139-29C6-427F-B9ED-5B649A7D4417]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[basepoint_city]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <uid><![CDATA[B22CC575-52F0-447D-BB38-BE91932F9C38]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[state]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <uid><![CDATA[4E4C6424-6E4A-4649-864D-962EA14A470F]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[service_area]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <uid><![CDATA[1912201B-011C-4223-B849-CE07202BF41D]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[rate_area]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <uid><![CDATA[C036712E-1A37-443D-9419-F4706A7BCD71]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[region]]></name>
+            <type><![CDATA[TEXT]]></type>
+            <uid><![CDATA[0E7EC57F-4E94-42FD-BEC5-572AB4396473]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[created_at]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <uid><![CDATA[CA6332BF-0EBD-4B47-ABB4-E9A260702C23]]></uid>
+        </SQLField>
+        <SQLField>
+            <name><![CDATA[updated_at]]></name>
+            <type><![CDATA[TIMESTAMP WITHOUT TIME ZONE]]></type>
+            <uid><![CDATA[094D50F7-7E97-475C-89C8-5F107383B7E1]]></uid>
+        </SQLField>
+        <labelWindowIndex><![CDATA[8]]></labelWindowIndex>
+        <ui.treeExpanded><![CDATA[1]]></ui.treeExpanded>
+        <uid><![CDATA[FFE00B26-E6B1-40E4-943E-4A6133F1045C]]></uid>
     </SQLTable>
     <SQLDocumentInfo>
         <encodedPrintInfo><![CDATA[BAtzdHJlYW10eXBlZIHoA4QBQISEhAtOU1ByaW50SW5mbwGEhAhOU09iamVjdACFkoSEhBNOU011dGFibGVEaWN0aW9uYXJ5AISEDE5TRGljdGlvbmFyeQCUhAFpDZKEhIQITlNTdHJpbmcBlIQBKw5OU1BNUGFnZUZvcm1hdIaShISEDU5TTXV0YWJsZURhdGEAhIQGTlNEYXRhAJSXgbIbhAdbNzA5MGNdPD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPCFET0NUWVBFIHBsaXN0IFBVQkxJQyAiLS8vQXBwbGUvL0RURCBQTElTVCAxLjAvL0VOIiAiaHR0cDovL3d3dy5hcHBsZS5jb20vRFREcy9Qcm9wZXJ0eUxpc3QtMS4wLmR0ZCI+CjxwbGlzdCB2ZXJzaW9uPSIxLjAiPgo8ZGljdD4KCTxrZXk+Y29tLmFwcGxlLnByaW50LlBhZ2VGb3JtYXQuUE1Ib3Jpem9udGFsUmVzPC9rZXk+Cgk8ZGljdD4KCQk8a2V5PmNvbS5hcHBsZS5wcmludC50aWNrZXQuY3JlYXRvcjwva2V5PgoJCTxzdHJpbmc+Y29tLmFwcGxlLmpvYnRpY2tldDwvc3RyaW5nPgoJCTxrZXk+Y29tLmFwcGxlLnByaW50LnRpY2tldC5pdGVtQXJyYXk8L2tleT4KCQk8YXJyYXk+CgkJCTxkaWN0PgoJCQkJPGtleT5jb20uYXBwbGUucHJpbnQuUGFnZUZvcm1hdC5QTUhvcml6b250YWxSZXM8L2tleT4KCQkJCTxyZWFsPjcyPC9yZWFsPgoJCQkJPGtleT5jb20uYXBwbGUucHJpbnQudGlja2V0LnN0YXRlRmxhZzwva2V5PgoJCQkJPGludGVnZXI+MDwvaW50ZWdlcj4KCQkJPC9kaWN0PgoJCTwvYXJyYXk+Cgk8L2RpY3Q+Cgk8a2V5PmNvbS5hcHBsZS5wcmludC5QYWdlRm9ybWF0LlBNT3JpZW50YXRpb248L2tleT4KCTxkaWN0PgoJCTxrZXk+Y29tLmFwcGxlLnByaW50LnRpY2tldC5jcmVhdG9yPC9rZXk+CgkJPHN0cmluZz5jb20uYXBwbGUuam9idGlja2V0PC9zdHJpbmc+CgkJPGtleT5jb20uYXBwbGUucHJpbnQudGlja2V0Lml0ZW1BcnJheTwva2V5PgoJCTxhcnJheT4KCQkJPGRpY3Q+CgkJCQk8a2V5PmNvbS5hcHBsZS5wcmludC5QYWdlRm9ybWF0LlBNT3JpZW50YXRpb248L2tleT4KCQkJCTxpbnRlZ2VyPjE8L2ludGVnZXI+CgkJCQk8a2V5PmNvbS5hcHBsZS5wcmludC50aWNrZXQuc3RhdGVGbGFnPC9rZXk+CgkJCQk8aW50ZWdlcj4wPC9pbnRlZ2VyPgoJCQk8L2RpY3Q+CgkJPC9hcnJheT4KCTwvZGljdD4KCTxrZXk+Y29tLmFwcGxlLnByaW50LlBhZ2VGb3JtYXQuUE1TY2FsaW5nPC9rZXk+Cgk8ZGljdD4KCQk8a2V5PmNvbS5hcHBsZS5wcmludC50aWNrZXQuY3JlYXRvcjwva2V5PgoJCTxzdHJpbmc+Y29tLmFwcGxlLmpvYnRpY2tldDwvc3RyaW5nPgoJCTxrZXk+Y29tLmFwcGxlLnByaW50LnRpY2tldC5pdGVtQXJyYXk8L2tleT4KCQk8YXJyYXk+CgkJCTxkaWN0PgoJCQkJPGtleT5jb20uYXBwbGUucHJpbnQuUGFnZUZvcm1hdC5QTVNjYWxpbmc8L2tleT4KCQkJCTxyZWFsPjE8L3JlYWw+CgkJCQk8a2V5PmNvbS5hcHBsZS5wcmludC50aWNrZXQuc3RhdGVGbGFnPC9rZXk+CgkJCQk8aW50ZWdlcj4wPC9pbnRlZ2VyPgoJCQk8L2RpY3Q+CgkJPC9hcnJheT4KCTwvZGljdD4KCTxrZXk+Y29tLmFwcGxlLnByaW50LlBhZ2VGb3JtYXQuUE1WZXJ0aWNhbFJlczwva2V5PgoJPGRpY3Q+CgkJPGtleT5jb20uYXBwbGUucHJpbnQudGlja2V0LmNyZWF0b3I8L2tleT4KCQk8c3RyaW5nPmNvbS5hcHBsZS5qb2J0aWNrZXQ8L3N0cmluZz4KCQk8a2V5PmNvbS5hcHBsZS5wcmludC50aWNrZXQuaXRlbUFycmF5PC9rZXk+CgkJPGFycmF5PgoJCQk8ZGljdD4KCQkJCTxrZXk+Y29tLmFwcGxlLnByaW50LlBhZ2VGb3JtYXQuUE1WZXJ0aWNhbFJlczwva2V5PgoJCQkJPHJlYWw+NzI8L3JlYWw+CgkJCQk8a2V5PmNvbS5hcHBsZS5wcmludC50aWNrZXQuc3RhdGVGbGFnPC9rZXk+CgkJCQk8aW50ZWdlcj4wPC9pbnRlZ2VyPgoJCQk8L2RpY3Q+CgkJPC9hcnJheT4KCTwvZGljdD4KCTxrZXk+Y29tLmFwcGxlLnByaW50LlBhZ2VGb3JtYXQuUE1WZXJ0aWNhbFNjYWxpbmc8L2tleT4KCTxkaWN0PgoJCTxrZXk+Y29tLmFwcGxlLnByaW50LnRpY2tldC5jcmVhdG9yPC9rZXk+CgkJPHN0cmluZz5jb20uYXBwbGUuam9idGlja2V0PC9zdHJpbmc+CgkJPGtleT5jb20uYXBwbGUucHJpbnQudGlja2V0Lml0ZW1BcnJheTwva2V5PgoJCTxhcnJheT4KCQkJPGRpY3Q+CgkJCQk8a2V5PmNvbS5hcHBsZS5wcmludC5QYWdlRm9ybWF0LlBNVmVydGljYWxTY2FsaW5nPC9rZXk+CgkJCQk8cmVhbD4xPC9yZWFsPgoJCQkJPGtleT5jb20uYXBwbGUucHJpbnQudGlja2V0LnN0YXRlRmxhZzwva2V5PgoJCQkJPGludGVnZXI+MDwvaW50ZWdlcj4KCQkJPC9kaWN0PgoJCTwvYXJyYXk+Cgk8L2RpY3Q+Cgk8a2V5PmNvbS5hcHBsZS5wcmludC5zdWJUaWNrZXQucGFwZXJfaW5mb190aWNrZXQ8L2tleT4KCTxkaWN0PgoJCTxrZXk+UE1QUERQYXBlckNvZGVOYW1lPC9rZXk+CgkJPGRpY3Q+CgkJCTxrZXk+Y29tLmFwcGxlLnByaW50LnRpY2tldC5jcmVhdG9yPC9rZXk+CgkJCTxzdHJpbmc+Y29tLmFwcGxlLmpvYnRpY2tldDwvc3RyaW5nPgoJCQk8a2V5PmNvbS5hcHBsZS5wcmludC50aWNrZXQuaXRlbUFycmF5PC9rZXk+CgkJCTxhcnJheT4KCQkJCTxkaWN0PgoJCQkJCTxrZXk+UE1QUERQYXBlckNvZGVOYW1lPC9rZXk+CgkJCQkJPHN0cmluZz5MZXR0ZXI8L3N0cmluZz4KCQkJCQk8a2V5PmNvbS5hcHBsZS5wcmludC50aWNrZXQuc3RhdGVGbGFnPC9rZXk+CgkJCQkJPGludGVnZXI+MDwvaW50ZWdlcj4KCQkJCTwvZGljdD4KCQkJPC9hcnJheT4KCQk8L2RpY3Q+CgkJPGtleT5QTVBQRFRyYW5zbGF0aW9uU3RyaW5nUGFwZXJOYW1lPC9rZXk+CgkJPGRpY3Q+CgkJCTxrZXk+Y29tLmFwcGxlLnByaW50LnRpY2tldC5jcmVhdG9yPC9rZXk+CgkJCTxzdHJpbmc+Y29tLmFwcGxlLmpvYnRpY2tldDwvc3RyaW5nPgoJCQk8a2V5PmNvbS5hcHBsZS5wcmludC50aWNrZXQuaXRlbUFycmF5PC9rZXk+CgkJCTxhcnJheT4KCQkJCTxkaWN0PgoJCQkJCTxrZXk+UE1QUERUcmFuc2xhdGlvblN0cmluZ1BhcGVyTmFtZTwva2V5PgoJCQkJCTxzdHJpbmc+VVMgTGV0dGVyPC9zdHJpbmc+CgkJCQkJPGtleT5jb20uYXBwbGUucHJpbnQudGlja2V0LnN0YXRlRmxhZzwva2V5PgoJCQkJCTxpbnRlZ2VyPjA8L2ludGVnZXI+CgkJCQk8L2RpY3Q+CgkJCTwvYXJyYXk+CgkJPC9kaWN0PgoJCTxrZXk+UE1UaW9nYVBhcGVyTmFtZTwva2V5PgoJCTxkaWN0PgoJCQk8a2V5PmNvbS5hcHBsZS5wcmludC50aWNrZXQuY3JlYXRvcjwva2V5PgoJCQk8c3RyaW5nPmNvbS5hcHBsZS5qb2J0aWNrZXQ8L3N0cmluZz4KCQkJPGtleT5jb20uYXBwbGUucHJpbnQudGlja2V0Lml0ZW1BcnJheTwva2V5PgoJCQk8YXJyYXk+CgkJCQk8ZGljdD4KCQkJCQk8a2V5PlBNVGlvZ2FQYXBlck5hbWU8L2tleT4KCQkJCQk8c3RyaW5nPm5hLWxldHRlcjwvc3RyaW5nPgoJCQkJCTxrZXk+Y29tLmFwcGxlLnByaW50LnRpY2tldC5zdGF0ZUZsYWc8L2tleT4KCQkJCQk8aW50ZWdlcj4wPC9pbnRlZ2VyPgoJCQkJPC9kaWN0PgoJCQk8L2FycmF5PgoJCTwvZGljdD4KCQk8a2V5PmNvbS5hcHBsZS5wcmludC5QYWdlRm9ybWF0LlBNQWRqdXN0ZWRQYWdlUmVjdDwva2V5PgoJCTxkaWN0PgoJCQk8a2V5PmNvbS5hcHBsZS5wcmludC50aWNrZXQuY3JlYXRvcjwva2V5PgoJCQk8c3RyaW5nPmNvbS5hcHBsZS5qb2J0aWNrZXQ8L3N0cmluZz4KCQkJPGtleT5jb20uYXBwbGUucHJpbnQudGlja2V0Lml0ZW1BcnJheTwva2V5PgoJCQk8YXJyYXk+CgkJCQk8ZGljdD4KCQkJCQk8a2V5PmNvbS5hcHBsZS5wcmludC5QYWdlRm9ybWF0LlBNQWRqdXN0ZWRQYWdlUmVjdDwva2V5PgoJCQkJCTxhcnJheT4KCQkJCQkJPGludGVnZXI+MDwvaW50ZWdlcj4KCQkJCQkJPGludGVnZXI+MDwvaW50ZWdlcj4KCQkJCQkJPHJlYWw+NzM0PC9yZWFsPgoJCQkJCQk8cmVhbD41NzY8L3JlYWw+CgkJCQkJPC9hcnJheT4KCQkJCQk8a2V5PmNvbS5hcHBsZS5wcmludC50aWNrZXQuc3RhdGVGbGFnPC9rZXk+CgkJCQkJPGludGVnZXI+MDwvaW50ZWdlcj4KCQkJCTwvZGljdD4KCQkJPC9hcnJheT4KCQk8L2RpY3Q+CgkJPGtleT5jb20uYXBwbGUucHJpbnQuUGFnZUZvcm1hdC5QTUFkanVzdGVkUGFwZXJSZWN0PC9rZXk+CgkJPGRpY3Q+CgkJCTxrZXk+Y29tLmFwcGxlLnByaW50LnRpY2tldC5jcmVhdG9yPC9rZXk+CgkJCTxzdHJpbmc+Y29tLmFwcGxlLmpvYnRpY2tldDwvc3RyaW5nPgoJCQk8a2V5PmNvbS5hcHBsZS5wcmludC50aWNrZXQuaXRlbUFycmF5PC9rZXk+CgkJCTxhcnJheT4KCQkJCTxkaWN0PgoJCQkJCTxrZXk+Y29tLmFwcGxlLnByaW50LlBhZ2VGb3JtYXQuUE1BZGp1c3RlZFBhcGVyUmVjdDwva2V5PgoJCQkJCTxhcnJheT4KCQkJCQkJPHJlYWw+LTE4PC9yZWFsPgoJCQkJCQk8cmVhbD4tMTg8L3JlYWw+CgkJCQkJCTxyZWFsPjc3NDwvcmVhbD4KCQkJCQkJPHJlYWw+NTk0PC9yZWFsPgoJCQkJCTwvYXJyYXk+CgkJCQkJPGtleT5jb20uYXBwbGUucHJpbnQudGlja2V0LnN0YXRlRmxhZzwva2V5PgoJCQkJCTxpbnRlZ2VyPjA8L2ludGVnZXI+CgkJCQk8L2RpY3Q+CgkJCTwvYXJyYXk+CgkJPC9kaWN0PgoJCTxrZXk+Y29tLmFwcGxlLnByaW50LlBhcGVySW5mby5QTVBQRFBhcGVyRGltZW5zaW9uPC9rZXk+CgkJPGRpY3Q+CgkJCTxrZXk+Y29tLmFwcGxlLnByaW50LnRpY2tldC5jcmVhdG9yPC9rZXk+CgkJCTxzdHJpbmc+Y29tLmFwcGxlLmpvYnRpY2tldDwvc3RyaW5nPgoJCQk8a2V5PmNvbS5hcHBsZS5wcmludC50aWNrZXQuaXRlbUFycmF5PC9rZXk+CgkJCTxhcnJheT4KCQkJCTxkaWN0PgoJCQkJCTxrZXk+Y29tLmFwcGxlLnByaW50LlBhcGVySW5mby5QTVBQRFBhcGVyRGltZW5zaW9uPC9rZXk+CgkJCQkJPGFycmF5PgoJCQkJCQk8aW50ZWdlcj4wPC9pbnRlZ2VyPgoJCQkJCQk8aW50ZWdlcj4wPC9pbnRlZ2VyPgoJCQkJCQk8cmVhbD42MTI8L3JlYWw+CgkJCQkJCTxyZWFsPjc5MjwvcmVhbD4KCQkJCQk8L2FycmF5PgoJCQkJCTxrZXk+Y29tLmFwcGxlLnByaW50LnRpY2tldC5zdGF0ZUZsYWc8L2tleT4KCQkJCQk8aW50ZWdlcj4wPC9pbnRlZ2VyPgoJCQkJPC9kaWN0PgoJCQk8L2FycmF5PgoJCTwvZGljdD4KCQk8a2V5PmNvbS5hcHBsZS5wcmludC5QYXBlckluZm8uUE1QYXBlck5hbWU8L2tleT4KCQk8ZGljdD4KCQkJPGtleT5jb20uYXBwbGUucHJpbnQudGlja2V0LmNyZWF0b3I8L2tleT4KCQkJPHN0cmluZz5jb20uYXBwbGUuam9idGlja2V0PC9zdHJpbmc+CgkJCTxrZXk+Y29tLmFwcGxlLnByaW50LnRpY2tldC5pdGVtQXJyYXk8L2tleT4KCQkJPGFycmF5PgoJCQkJPGRpY3Q+CgkJCQkJPGtleT5jb20uYXBwbGUucHJpbnQuUGFwZXJJbmZvLlBNUGFwZXJOYW1lPC9rZXk+CgkJCQkJPHN0cmluZz5uYS1sZXR0ZXI8L3N0cmluZz4KCQkJCQk8a2V5PmNvbS5hcHBsZS5wcmludC50aWNrZXQuc3RhdGVGbGFnPC9rZXk+CgkJCQkJPGludGVnZXI+MDwvaW50ZWdlcj4KCQkJCTwvZGljdD4KCQkJPC9hcnJheT4KCQk8L2RpY3Q+CgkJPGtleT5jb20uYXBwbGUucHJpbnQuUGFwZXJJbmZvLlBNVW5hZGp1c3RlZFBhZ2VSZWN0PC9rZXk+CgkJPGRpY3Q+CgkJCTxrZXk+Y29tLmFwcGxlLnByaW50LnRpY2tldC5jcmVhdG9yPC9rZXk+CgkJCTxzdHJpbmc+Y29tLmFwcGxlLmpvYnRpY2tldDwvc3RyaW5nPgoJCQk8a2V5PmNvbS5hcHBsZS5wcmludC50aWNrZXQuaXRlbUFycmF5PC9rZXk+CgkJCTxhcnJheT4KCQkJCTxkaWN0PgoJCQkJCTxrZXk+Y29tLmFwcGxlLnByaW50LlBhcGVySW5mby5QTVVuYWRqdXN0ZWRQYWdlUmVjdDwva2V5PgoJCQkJCTxhcnJheT4KCQkJCQkJPGludGVnZXI+MDwvaW50ZWdlcj4KCQkJCQkJPGludGVnZXI+MDwvaW50ZWdlcj4KCQkJCQkJPHJlYWw+NzM0PC9yZWFsPgoJCQkJCQk8cmVhbD41NzY8L3JlYWw+CgkJCQkJPC9hcnJheT4KCQkJCQk8a2V5PmNvbS5hcHBsZS5wcmludC50aWNrZXQuc3RhdGVGbGFnPC9rZXk+CgkJCQkJPGludGVnZXI+MDwvaW50ZWdlcj4KCQkJCTwvZGljdD4KCQkJPC9hcnJheT4KCQk8L2RpY3Q+CgkJPGtleT5jb20uYXBwbGUucHJpbnQuUGFwZXJJbmZvLlBNVW5hZGp1c3RlZFBhcGVyUmVjdDwva2V5PgoJCTxkaWN0PgoJCQk8a2V5PmNvbS5hcHBsZS5wcmludC50aWNrZXQuY3JlYXRvcjwva2V5PgoJCQk8c3RyaW5nPmNvbS5hcHBsZS5qb2J0aWNrZXQ8L3N0cmluZz4KCQkJPGtleT5jb20uYXBwbGUucHJpbnQudGlja2V0Lml0ZW1BcnJheTwva2V5PgoJCQk8YXJyYXk+CgkJCQk8ZGljdD4KCQkJCQk8a2V5PmNvbS5hcHBsZS5wcmludC5QYXBlckluZm8uUE1VbmFkanVzdGVkUGFwZXJSZWN0PC9rZXk+CgkJCQkJPGFycmF5PgoJCQkJCQk8cmVhbD4tMTg8L3JlYWw+CgkJCQkJCTxyZWFsPi0xODwvcmVhbD4KCQkJCQkJPHJlYWw+Nzc0PC9yZWFsPgoJCQkJCQk8cmVhbD41OTQ8L3JlYWw+CgkJCQkJPC9hcnJheT4KCQkJCQk8a2V5PmNvbS5hcHBsZS5wcmludC50aWNrZXQuc3RhdGVGbGFnPC9rZXk+CgkJCQkJPGludGVnZXI+MDwvaW50ZWdlcj4KCQkJCTwvZGljdD4KCQkJPC9hcnJheT4KCQk8L2RpY3Q+CgkJPGtleT5jb20uYXBwbGUucHJpbnQuUGFwZXJJbmZvLnBwZC5QTVBhcGVyTmFtZTwva2V5PgoJCTxkaWN0PgoJCQk8a2V5PmNvbS5hcHBsZS5wcmludC50aWNrZXQuY3JlYXRvcjwva2V5PgoJCQk8c3RyaW5nPmNvbS5hcHBsZS5qb2J0aWNrZXQ8L3N0cmluZz4KCQkJPGtleT5jb20uYXBwbGUucHJpbnQudGlja2V0Lml0ZW1BcnJheTwva2V5PgoJCQk8YXJyYXk+CgkJCQk8ZGljdD4KCQkJCQk8a2V5PmNvbS5hcHBsZS5wcmludC5QYXBlckluZm8ucHBkLlBNUGFwZXJOYW1lPC9rZXk+CgkJCQkJPHN0cmluZz5MZXR0ZXI8L3N0cmluZz4KCQkJCQk8a2V5PmNvbS5hcHBsZS5wcmludC50aWNrZXQuc3RhdGVGbGFnPC9rZXk+CgkJCQkJPGludGVnZXI+MDwvaW50ZWdlcj4KCQkJCTwvZGljdD4KCQkJPC9hcnJheT4KCQk8L2RpY3Q+CgkJPGtleT5jb20uYXBwbGUucHJpbnQudGlja2V0LkFQSVZlcnNpb248L2tleT4KCQk8c3RyaW5nPjAwLjIwPC9zdHJpbmc+CgkJPGtleT5jb20uYXBwbGUucHJpbnQudGlja2V0LnR5cGU8L2tleT4KCQk8c3RyaW5nPmNvbS5hcHBsZS5wcmludC5QYXBlckluZm9UaWNrZXQ8L3N0cmluZz4KCTwvZGljdD4KCTxrZXk+Y29tLmFwcGxlLnByaW50LnRpY2tldC5BUElWZXJzaW9uPC9rZXk+Cgk8c3RyaW5nPjAwLjIwPC9zdHJpbmc+Cgk8a2V5PmNvbS5hcHBsZS5wcmludC50aWNrZXQudHlwZTwva2V5PgoJPHN0cmluZz5jb20uYXBwbGUucHJpbnQuUGFnZUZvcm1hdFRpY2tldDwvc3RyaW5nPgo8L2RpY3Q+CjwvcGxpc3Q+CoaShJmZC05TUGFwZXJTaXplhpKEhIQHTlNWYWx1ZQCUhAEqhIQLe0NHU2l6ZT1kZH2fgWQCgRgDhpKEmZkWTlNIb3Jpem9udGFsbHlDZW50ZXJlZIaShISECE5TTnVtYmVyAJ+ehIQBY6EBhpKEmZkUTlNWZXJ0aWNhbGx5Q2VudGVyZWSGkqKShJmZDE5TTGVmdE1hcmdpboaShKOehIQBZKIShpKEmZkNTlNSaWdodE1hcmdpboaSp5KEmZkLTlNUb3BNYXJnaW6GkoSjnqiiHoaShJmZDU5TT3JpZW50YXRpb26GkoSjnoSEAXGjAIaShJmZFU5TSG9yaXpvbmFsUGFnaW5hdGlvboaSrZKEmZkUTlNWZXJ0aWNhbFBhZ2luYXRpb26Gkq2ShJmZDk5TQm90dG9tTWFyZ2luhpKEo56oojSGkoSZmQ9OU1NjYWxpbmdGYWN0b3KGkoSjnqiiAYaShJmZC05TUGFwZXJOYW1lhpKEmZkJbmEtbGV0dGVyhoaG]]></encodedPrintInfo>
@@ -3209,17 +3204,17 @@
         <overviewPanelHidden><![CDATA[0]]></overviewPanelHidden>
         <pageBoundariesVisible><![CDATA[0]]></pageBoundariesVisible>
         <PageGridVisible><![CDATA[0]]></PageGridVisible>
-        <RightSidebarWidth><![CDATA[1985.000000]]></RightSidebarWidth>
+        <RightSidebarWidth><![CDATA[1439.000000]]></RightSidebarWidth>
         <sidebarIndex><![CDATA[5]]></sidebarIndex>
         <snapToGrid><![CDATA[0]]></snapToGrid>
-        <SourceSidebarWidth><![CDATA[0.000000]]></SourceSidebarWidth>
+        <SourceSidebarWidth><![CDATA[312.000000]]></SourceSidebarWidth>
         <SQLEditorFileFormatVersion><![CDATA[4]]></SQLEditorFileFormatVersion>
-        <uid><![CDATA[5D58D6A0-C0F2-4B58-9AE6-69E5FE910EB4]]></uid>
-        <windowHeight><![CDATA[1306.000000]]></windowHeight>
-        <windowLocationX><![CDATA[222.000000]]></windowLocationX>
-        <windowLocationY><![CDATA[28.000000]]></windowLocationY>
+        <uid><![CDATA[36539673-D728-4BBC-A42F-8D306B2B1590]]></uid>
+        <windowHeight><![CDATA[877.000000]]></windowHeight>
+        <windowLocationX><![CDATA[0.000000]]></windowLocationX>
+        <windowLocationY><![CDATA[0.000000]]></windowLocationY>
         <windowScrollOrigin><![CDATA[{0, 0}]]></windowScrollOrigin>
-        <windowWidth><![CDATA[2262.000000]]></windowWidth>
+        <windowWidth><![CDATA[1440.000000]]></windowWidth>
     </SQLDocumentInfo>
     <AllowsIndexRenamingOnInsert><![CDATA[1]]></AllowsIndexRenamingOnInsert>
     <defaultLabelExpanded><![CDATA[1]]></defaultLabelExpanded>

--- a/migrations/20180917233210_make_delivery_date_actual.up.fizz
+++ b/migrations/20180917233210_make_delivery_date_actual.up.fizz
@@ -1,0 +1,1 @@
+rename_column("shipments", "delivery_date", "actual_delivery_date")

--- a/pkg/awardqueue/awardqueue_test.go
+++ b/pkg/awardqueue/awardqueue_test.go
@@ -34,7 +34,7 @@ func (suite *AwardQueueSuite) Test_CheckAllTSPsBlackedOut() {
 		Shipment: models.Shipment{
 			RequestedPickupDate: &pickupDate,
 			ActualPickupDate:    &pickupDate,
-			DeliveryDate:        &deliveryDate,
+			ActualDeliveryDate:  &deliveryDate,
 			SourceGBLOC:         &sourceGBLOC,
 			Market:              &market,
 			BookDate:            &testdatagen.DateInsidePerformancePeriod,
@@ -88,7 +88,7 @@ func (suite *AwardQueueSuite) Test_CheckShipmentDuringBlackOut() {
 		Shipment: models.Shipment{
 			RequestedPickupDate: &blackoutPickupDate,
 			ActualPickupDate:    &blackoutPickupDate,
-			DeliveryDate:        &blackoutDeliverDate,
+			ActualDeliveryDate:  &blackoutDeliverDate,
 			SourceGBLOC:         &sourceGBLOC,
 			Market:              &market,
 			Status:              models.ShipmentStatusSUBMITTED,
@@ -102,7 +102,7 @@ func (suite *AwardQueueSuite) Test_CheckShipmentDuringBlackOut() {
 		Shipment: models.Shipment{
 			RequestedPickupDate: &pickupDate,
 			ActualPickupDate:    &pickupDate,
-			DeliveryDate:        &deliveryDate,
+			ActualDeliveryDate:  &deliveryDate,
 			SourceGBLOC:         &sourceGBLOC,
 			Market:              &market,
 			Status:              models.ShipmentStatusSUBMITTED,
@@ -186,7 +186,7 @@ func (suite *AwardQueueSuite) Test_ShipmentWithinBlackoutDates() {
 		Shipment: models.Shipment{
 			RequestedPickupDate: &testPickupDateBetween,
 			ActualPickupDate:    &testPickupDateBetween,
-			DeliveryDate:        &testEndDate,
+			ActualDeliveryDate:  &testEndDate,
 			SourceGBLOC:         &sourceGBLOC,
 			Market:              &market,
 			BookDate:            &testdatagen.DateInsidePerformancePeriod,
@@ -198,7 +198,7 @@ func (suite *AwardQueueSuite) Test_ShipmentWithinBlackoutDates() {
 		Shipment: models.Shipment{
 			RequestedPickupDate: &testPickupDateAfter,
 			ActualPickupDate:    &testPickupDateAfter,
-			DeliveryDate:        &testEndDate,
+			ActualDeliveryDate:  &testEndDate,
 			SourceGBLOC:         &sourceGBLOC,
 			Market:              &market,
 			BookDate:            &testdatagen.DateInsidePerformancePeriod,
@@ -276,7 +276,7 @@ func (suite *AwardQueueSuite) Test_OfferSingleShipment() {
 		Shipment: models.Shipment{
 			RequestedPickupDate: &pickupDate,
 			ActualPickupDate:    &pickupDate,
-			DeliveryDate:        &deliveryDate,
+			ActualDeliveryDate:  &deliveryDate,
 			SourceGBLOC:         &sourceGBLOC,
 			Market:              &market,
 			Status:              models.ShipmentStatusSUBMITTED,
@@ -328,7 +328,7 @@ func (suite *AwardQueueSuite) Test_FailOfferingSingleShipment() {
 		Shipment: models.Shipment{
 			RequestedPickupDate: &pickupDate,
 			ActualPickupDate:    &pickupDate,
-			DeliveryDate:        &deliveryDate,
+			ActualDeliveryDate:  &deliveryDate,
 			SourceGBLOC:         &sourceGBLOC,
 			Market:              &market,
 			BookDate:            &pickupDate,
@@ -367,7 +367,7 @@ func (suite *AwardQueueSuite) TestAssignShipmentsSingleTSP() {
 			Shipment: models.Shipment{
 				RequestedPickupDate: &pickupDate,
 				ActualPickupDate:    &pickupDate,
-				DeliveryDate:        &deliveryDate,
+				ActualDeliveryDate:  &deliveryDate,
 				SourceGBLOC:         &sourceGBLOC,
 				Market:              &market,
 				Status:              models.ShipmentStatusSUBMITTED,
@@ -431,7 +431,7 @@ func (suite *AwardQueueSuite) TestAssignShipmentsToMultipleTSPs() {
 			Shipment: models.Shipment{
 				RequestedPickupDate: &pickupDate,
 				ActualPickupDate:    &pickupDate,
-				DeliveryDate:        &deliveryDate,
+				ActualDeliveryDate:  &deliveryDate,
 				SourceGBLOC:         &sourceGBLOC,
 				Market:              &market,
 				Status:              models.ShipmentStatusSUBMITTED,
@@ -582,7 +582,7 @@ func (suite *AwardQueueSuite) Test_AwardTSPsInDifferentRateCycles() {
 		TrafficDistributionListID: &tdl.ID,
 		ActualPickupDate:          &testdatagen.DateInsidePeakRateCycle,
 		RequestedPickupDate:       &testdatagen.DateInsidePeakRateCycle,
-		DeliveryDate:              &twoMonthsLater,
+		ActualDeliveryDate:        &twoMonthsLater,
 		BookDate:                  &testdatagen.PerformancePeriodStart,
 		SourceGBLOC:               &testdatagen.DefaultSrcGBLOC,
 		Market:                    &testdatagen.DefaultMarket,
@@ -621,7 +621,7 @@ func (suite *AwardQueueSuite) Test_AwardTSPsInDifferentRateCycles() {
 		TrafficDistributionListID: &tdl.ID,
 		ActualPickupDate:          &testdatagen.DateInsideNonPeakRateCycle,
 		RequestedPickupDate:       &testdatagen.DateInsideNonPeakRateCycle,
-		DeliveryDate:              &twoMonthsLater,
+		ActualDeliveryDate:        &twoMonthsLater,
 		BookDate:                  &testdatagen.PerformancePeriodStart,
 		SourceGBLOC:               &testdatagen.DefaultSrcGBLOC,
 		Market:                    &testdatagen.DefaultMarket,

--- a/pkg/handlers/internalapi/shipments.go
+++ b/pkg/handlers/internalapi/shipments.go
@@ -43,7 +43,7 @@ func payloadForShipmentModel(s models.Shipment) *internalmessages.Shipment {
 		BookDate:                            handlers.FmtDatePtr(s.BookDate),
 		RequestedPickupDate:                 handlers.FmtDatePtr(s.RequestedPickupDate),
 		ActualPickupDate:                    handlers.FmtDatePtr(s.ActualPickupDate),
-		DeliveryDate:                        handlers.FmtDatePtr(s.DeliveryDate),
+		ActualDeliveryDate:                  handlers.FmtDatePtr(s.ActualDeliveryDate),
 		CreatedAt:                           strfmt.DateTime(s.CreatedAt),
 		UpdatedAt:                           strfmt.DateTime(s.UpdatedAt),
 		EstimatedPackDays:                   s.EstimatedPackDays,

--- a/pkg/handlers/publicapi/api.go
+++ b/pkg/handlers/publicapi/api.go
@@ -33,6 +33,7 @@ func NewPublicAPIHandler(context handlers.HandlerContext) http.Handler {
 	publicAPI.ShipmentsAcceptShipmentHandler = AcceptShipmentHandler{context}
 	publicAPI.ShipmentsRejectShipmentHandler = RejectShipmentHandler{context}
 	publicAPI.ShipmentsTransportShipmentHandler = TransportShipmentHandler{context}
+	publicAPI.ShipmentsDeliverShipmentHandler = DeliverShipmentHandler{context}
 
 	publicAPI.ShipmentsCreateGovBillOfLadingHandler = CreateGovBillOfLadingHandler{context}
 

--- a/pkg/handlers/publicapi/shipments.go
+++ b/pkg/handlers/publicapi/shipments.go
@@ -233,7 +233,7 @@ func (h TransportShipmentHandler) Handle(params shipmentop.TransportShipmentPara
 		return shipmentop.NewTransportShipmentBadRequest()
 	}
 
-	actualPickupDate := (time.Time)(*params.ActualPickupDate.ActualPickupDate)
+	actualPickupDate := (time.Time)(*params.Payload.ActualPickupDate)
 
 	err = shipment.Transport(actualPickupDate)
 	if err != nil {
@@ -273,7 +273,7 @@ func (h DeliverShipmentHandler) Handle(params shipmentop.DeliverShipmentParams) 
 		return shipmentop.NewDeliverShipmentBadRequest()
 	}
 
-	actualDeliveryDate := (time.Time)(*params.ActualDeliveryDate.ActualDeliveryDate)
+	actualDeliveryDate := (time.Time)(*params.Payload.ActualDeliveryDate)
 
 	err = shipment.Deliver(actualDeliveryDate)
 	if err != nil {

--- a/pkg/handlers/publicapi/shipments.go
+++ b/pkg/handlers/publicapi/shipments.go
@@ -25,7 +25,7 @@ func payloadForShipmentModel(s models.Shipment) *apimessages.Shipment {
 		TrafficDistributionList:             payloadForTrafficDistributionListModel(s.TrafficDistributionList),
 		ServiceMember:                       payloadForServiceMemberModel(s.ServiceMember),
 		ActualPickupDate:                    *handlers.FmtDateTimePtr(s.ActualPickupDate),
-		DeliveryDate:                        *handlers.FmtDateTimePtr(s.DeliveryDate),
+		ActualDeliveryDate:                  *handlers.FmtDateTimePtr(s.ActualDeliveryDate),
 		CreatedAt:                           strfmt.DateTime(s.CreatedAt),
 		UpdatedAt:                           strfmt.DateTime(s.UpdatedAt),
 		SourceGbloc:                         apimessages.GBLOC(*s.SourceGBLOC),
@@ -224,16 +224,18 @@ func (h TransportShipmentHandler) Handle(params shipmentop.TransportShipmentPara
 	tspUser, err := models.FetchTspUserByID(h.DB(), session.TspUserID)
 	if err != nil {
 		h.Logger().Error("DB Query", zap.Error(err))
-		return shipmentop.NewGetShipmentForbidden()
+		return shipmentop.NewTransportShipmentForbidden()
 	}
 
 	shipment, err := models.FetchShipmentByTSP(h.DB(), tspUser.TransportationServiceProviderID, shipmentID)
 	if err != nil {
 		h.Logger().Error("DB Query", zap.Error(err))
-		return shipmentop.NewGetShipmentBadRequest()
+		return shipmentop.NewTransportShipmentBadRequest()
 	}
 
-	err = shipment.Transport()
+	actualPickupDate := (time.Time)(*params.ActualPickupDate.ActualPickupDate)
+
+	err = shipment.Transport(actualPickupDate)
 	if err != nil {
 		return handlers.ResponseForError(h.Logger(), err)
 	}
@@ -243,6 +245,46 @@ func (h TransportShipmentHandler) Handle(params shipmentop.TransportShipmentPara
 	}
 	sp := payloadForShipmentModel(*shipment)
 	return shipmentop.NewTransportShipmentOK().WithPayload(sp)
+}
+
+// DeliverShipmentHandler allows a TSP to start transporting a particular shipment
+type DeliverShipmentHandler struct {
+	handlers.HandlerContext
+}
+
+// Handle delivers the shipment - checks that currently logged in user is authorized to act for the TSP assigned the shipment
+func (h DeliverShipmentHandler) Handle(params shipmentop.DeliverShipmentParams) middleware.Responder {
+	session := auth.SessionFromRequestContext(params.HTTPRequest)
+
+	shipmentID, _ := uuid.FromString(params.ShipmentID.String())
+
+	// TODO: (cgilmer 2018_07_25) This is an extra query we don't need to run on every request. Put the
+	// TransportationServiceProviderID into the session object after refactoring the session code to be more readable.
+	// See original commits in https://github.com/transcom/mymove/pull/802
+	tspUser, err := models.FetchTspUserByID(h.DB(), session.TspUserID)
+	if err != nil {
+		h.Logger().Error("DB Query", zap.Error(err))
+		return shipmentop.NewDeliverShipmentForbidden()
+	}
+
+	shipment, err := models.FetchShipmentByTSP(h.DB(), tspUser.TransportationServiceProviderID, shipmentID)
+	if err != nil {
+		h.Logger().Error("DB Query", zap.Error(err))
+		return shipmentop.NewDeliverShipmentBadRequest()
+	}
+
+	actualDeliveryDate := (time.Time)(*params.ActualDeliveryDate.ActualDeliveryDate)
+
+	err = shipment.Deliver(actualDeliveryDate)
+	if err != nil {
+		return handlers.ResponseForError(h.Logger(), err)
+	}
+	verrs, err := h.DB().ValidateAndUpdate(shipment)
+	if err != nil || verrs.HasAny() {
+		return handlers.ResponseForVErrors(h.Logger(), verrs, err)
+	}
+	sp := payloadForShipmentModel(*shipment)
+	return shipmentop.NewDeliverShipmentOK().WithPayload(sp)
 }
 
 func patchShipmentWithPayload(shipment *models.Shipment, payload *apimessages.Shipment) {

--- a/pkg/handlers/publicapi/shipments_test.go
+++ b/pkg/handlers/publicapi/shipments_test.go
@@ -457,9 +457,9 @@ func (suite *HandlerSuite) TestIndexShipmentsHandlerSortShipmentsDeliveryAsc() {
 	empty := time.Time{}
 	for _, responsePayload := range okResponse.Payload {
 		if deliveryDate == empty {
-			deliveryDate = time.Time(responsePayload.DeliveryDate)
+			deliveryDate = time.Time(responsePayload.ActualDeliveryDate)
 		} else {
-			newDT := time.Time(responsePayload.DeliveryDate)
+			newDT := time.Time(responsePayload.ActualDeliveryDate)
 			suite.True(newDT.After(deliveryDate))
 			deliveryDate = newDT
 		}
@@ -506,9 +506,9 @@ func (suite *HandlerSuite) TestIndexShipmentsHandlerSortShipmentsDeliveryDesc() 
 	empty := time.Time{}
 	for _, responsePayload := range okResponse.Payload {
 		if deliveryDate == empty {
-			deliveryDate = time.Time(responsePayload.DeliveryDate)
+			deliveryDate = time.Time(responsePayload.ActualDeliveryDate)
 		} else {
-			newDT := time.Time(responsePayload.DeliveryDate)
+			newDT := time.Time(responsePayload.ActualDeliveryDate)
 			suite.True(newDT.Before(deliveryDate))
 			deliveryDate = newDT
 		}
@@ -679,4 +679,41 @@ func (suite *HandlerSuite) TestTransportShipmentHandler() {
 	suite.Assertions.IsType(&shipmentop.TransportShipmentOK{}, response)
 	okResponse := response.(*shipmentop.TransportShipmentOK)
 	suite.Equal("IN_TRANSIT", string(okResponse.Payload.Status))
+	suite.Equal(actualPickupDate, time.Time(okResponse.Payload.ActualPickupDate))
+}
+
+// TestDeliverShipmentHandler tests the api endpoint that delivers a shipment
+func (suite *HandlerSuite) TestDeliverShipmentHandler() {
+	numTspUsers := 1
+	numShipments := 1
+	numShipmentOfferSplit := []int{1}
+	status := []models.ShipmentStatus{models.ShipmentStatusINTRANSIT}
+	tspUsers, shipments, _, err := testdatagen.CreateShipmentOfferData(suite.TestDB(), numTspUsers, numShipments, numShipmentOfferSplit, status)
+	suite.NoError(err)
+
+	tspUser := tspUsers[0]
+	shipment := shipments[0]
+
+	// Handler to Test
+	handler := DeliverShipmentHandler{handlers.NewHandlerContext(suite.TestDB(), suite.TestLogger())}
+
+	// Test query with first user
+	path := fmt.Sprintf("/shipments/%s/deliver", shipment.ID.String())
+	req := httptest.NewRequest("POST", path, nil)
+	req = suite.AuthenticateTspRequest(req, tspUser)
+	actualDeliveryDate := time.Now()
+	body := apimessages.ActualDeliveryDate{
+		ActualDeliveryDate: handlers.FmtDatePtr(&actualDeliveryDate),
+	}
+	params := shipmentop.DeliverShipmentParams{
+		HTTPRequest:        req,
+		ShipmentID:         *handlers.FmtUUID(shipment.ID),
+		ActualDeliveryDate: &body,
+	}
+
+	response := handler.Handle(params)
+	suite.Assertions.IsType(&shipmentop.DeliverShipmentOK{}, response)
+	okResponse := response.(*shipmentop.DeliverShipmentOK)
+	suite.Equal("DELIVERED", string(okResponse.Payload.Status))
+	suite.Equal(actualDeliveryDate, time.Time(okResponse.Payload.ActualDeliveryDate))
 }

--- a/pkg/handlers/publicapi/shipments_test.go
+++ b/pkg/handlers/publicapi/shipments_test.go
@@ -706,9 +706,9 @@ func (suite *HandlerSuite) TestDeliverShipmentHandler() {
 		ActualDeliveryDate: handlers.FmtDatePtr(&actualDeliveryDate),
 	}
 	params := shipmentop.DeliverShipmentParams{
-		HTTPRequest:        req,
-		ShipmentID:         *handlers.FmtUUID(shipment.ID),
-		ActualDeliveryDate: &body,
+		HTTPRequest: req,
+		ShipmentID:  *handlers.FmtUUID(shipment.ID),
+		Payload:     &body,
 	}
 
 	response := handler.Handle(params)

--- a/pkg/models/move_test.go
+++ b/pkg/models/move_test.go
@@ -64,7 +64,7 @@ func (suite *ModelSuite) TestFetchMove() {
 		Shipment: Shipment{
 			RequestedPickupDate:     &pickupDate,
 			ActualPickupDate:        &pickupDate,
-			DeliveryDate:            &deliveryDate,
+			ActualDeliveryDate:      &deliveryDate,
 			TrafficDistributionList: &tdl,
 			SourceGBLOC:             &sourceGBLOC,
 			Market:                  &market,
@@ -156,7 +156,7 @@ func (suite *ModelSuite) TestMoveStateMachine() {
 			Move:                    *move,
 			RequestedPickupDate:     &pickupDate,
 			ActualPickupDate:        &pickupDate,
-			DeliveryDate:            &deliveryDate,
+			ActualDeliveryDate:      &deliveryDate,
 			TrafficDistributionList: &tdl,
 			SourceGBLOC:             &sourceGBLOC,
 			Market:                  &market,
@@ -276,7 +276,7 @@ func (suite *ModelSuite) TestSaveMoveDependenciesSetsGBLOCSuccess() {
 		Shipment: Shipment{
 			RequestedPickupDate:     &pickupDate,
 			ActualPickupDate:        &pickupDate,
-			DeliveryDate:            &deliveryDate,
+			ActualDeliveryDate:      &deliveryDate,
 			TrafficDistributionList: &tdl,
 			SourceGBLOC:             &sourceGBLOC,
 			Market:                  &market,

--- a/pkg/models/shipment.go
+++ b/pkg/models/shipment.go
@@ -51,7 +51,7 @@ type Shipment struct {
 	ServiceMemberID                     uuid.UUID                `json:"service_member_id" db:"service_member_id"`
 	ServiceMember                       *ServiceMember           `belongs_to:"service_member"`
 	ActualPickupDate                    *time.Time               `json:"actual_pickup_date" db:"actual_pickup_date"`
-	DeliveryDate                        *time.Time               `json:"delivery_date" db:"delivery_date"`
+	ActualDeliveryDate                  *time.Time               `json:"actual_delivery_date" db:"actual_delivery_date"`
 	CreatedAt                           time.Time                `json:"created_at" db:"created_at"`
 	UpdatedAt                           time.Time                `json:"updated_at" db:"updated_at"`
 	SourceGBLOC                         *string                  `json:"source_gbloc" db:"source_gbloc"`
@@ -149,20 +149,22 @@ func (s *Shipment) Approve() error {
 }
 
 // Transport marks the Shipment request as In Transit. Must be in an Approved state.
-func (s *Shipment) Transport() error {
+func (s *Shipment) Transport(actualPickupDate time.Time) error {
 	if s.Status != ShipmentStatusAPPROVED {
 		return errors.Wrap(ErrInvalidTransition, "In Transit")
 	}
 	s.Status = ShipmentStatusINTRANSIT
+	s.ActualPickupDate = &actualPickupDate
 	return nil
 }
 
-// Deliver marks the Shipment request as Delivered. Must be in a Delivered state.
-func (s *Shipment) Deliver() error {
+// Deliver marks the Shipment request as Delivered. Must be IN TRANSIT state.
+func (s *Shipment) Deliver(actualDeliveryDate time.Time) error {
 	if s.Status != ShipmentStatusINTRANSIT {
-		return errors.Wrap(ErrInvalidTransition, "Delivered")
+		return errors.Wrap(ErrInvalidTransition, "Deliver")
 	}
 	s.Status = ShipmentStatusDELIVERED
+	s.ActualDeliveryDate = &actualDeliveryDate
 	return nil
 }
 
@@ -186,10 +188,10 @@ func (s *Shipment) BeforeSave(tx *pop.Connection) error {
 		if s.EstimatedTransitDays == nil {
 			s.EstimatedTransitDays = swag.Int64(10)
 		}
-		if s.DeliveryDate == nil {
+		if s.ActualDeliveryDate == nil {
 			if s.RequestedPickupDate != nil {
 				newDate := s.RequestedPickupDate.AddDate(0, 0, int(*s.EstimatedTransitDays))
-				s.DeliveryDate = &newDate
+				s.ActualDeliveryDate = &newDate
 			}
 		}
 		if s.ActualPickupDate == nil {
@@ -362,9 +364,9 @@ func FetchShipmentsByTSP(tx *pop.Connection, tspID uuid.UUID, status []string, o
 		case "PICKUP_DATE_DESC":
 			*orderBy = "actual_pickup_date DESC"
 		case "DELIVERY_DATE_ASC":
-			*orderBy = "delivery_date ASC"
+			*orderBy = "actual_delivery_date ASC"
 		case "DELIVERY_DATE_DESC":
-			*orderBy = "delivery_date DESC"
+			*orderBy = "actual_delivery_date DESC"
 		default:
 			// Any other input is ignored
 			*orderBy = ""

--- a/pkg/models/shipment_offer_test.go
+++ b/pkg/models/shipment_offer_test.go
@@ -35,7 +35,7 @@ func (suite *ModelSuite) Test_CreateShipmentOffer() {
 		Shipment: Shipment{
 			RequestedPickupDate:     &pickupDate,
 			ActualPickupDate:        &pickupDate,
-			DeliveryDate:            &deliveryDate,
+			ActualDeliveryDate:      &deliveryDate,
 			TrafficDistributionList: &tdl,
 			SourceGBLOC:             &sourceGBLOC,
 			Market:                  &market,

--- a/pkg/models/shipment_test.go
+++ b/pkg/models/shipment_test.go
@@ -49,7 +49,7 @@ func (suite *ModelSuite) Test_FetchUnofferedShipments() {
 		Shipment: Shipment{
 			RequestedPickupDate:     &pickupDate,
 			ActualPickupDate:        &pickupDate,
-			DeliveryDate:            &deliveryDate,
+			ActualDeliveryDate:      &deliveryDate,
 			TrafficDistributionList: &tdl,
 			SourceGBLOC:             &sourceGBLOC,
 			Market:                  &market,
@@ -61,7 +61,7 @@ func (suite *ModelSuite) Test_FetchUnofferedShipments() {
 		Shipment: Shipment{
 			RequestedPickupDate:     &pickupDate,
 			ActualPickupDate:        &pickupDate,
-			DeliveryDate:            &deliveryDate,
+			ActualDeliveryDate:      &deliveryDate,
 			TrafficDistributionList: &tdl,
 			SourceGBLOC:             &sourceGBLOC,
 			Market:                  &market,
@@ -105,13 +105,15 @@ func (suite *ModelSuite) TestShipmentStateMachine() {
 	suite.Nil(err)
 	suite.Equal(ShipmentStatusAPPROVED, shipment.Status, "expected Approved")
 
+	shipDate := time.Now()
+
 	// Can transport shipment
-	err = shipment.Transport()
+	err = shipment.Transport(shipDate)
 	suite.Nil(err)
 	suite.Equal(ShipmentStatusINTRANSIT, shipment.Status, "expected In Transit")
 
 	// Can deliver shipment
-	err = shipment.Deliver()
+	err = shipment.Deliver(shipDate)
 	suite.Nil(err)
 	suite.Equal(ShipmentStatusDELIVERED, shipment.Status, "expected Delivered")
 
@@ -119,7 +121,6 @@ func (suite *ModelSuite) TestShipmentStateMachine() {
 	err = shipment.Complete()
 	suite.Nil(err)
 	suite.Equal(ShipmentStatusCOMPLETED, shipment.Status, "expected Completed")
-
 }
 
 func (suite *ModelSuite) TestSetBookDateWhenSubmitted() {

--- a/pkg/testdatagen/make_shipment_offer_records.go
+++ b/pkg/testdatagen/make_shipment_offer_records.go
@@ -175,7 +175,7 @@ func CreateShipmentOfferData(db *pop.Connection, numTspUsers int, numShipments i
 			Shipment: models.Shipment{
 				RequestedPickupDate:     &now,
 				ActualPickupDate:        &nowPlusOne,
-				DeliveryDate:            &nowPlusTwo,
+				ActualDeliveryDate:      &nowPlusTwo,
 				TrafficDistributionList: &tdl,
 				SourceGBLOC:             &sourceGBLOC,
 				Market:                  &market,

--- a/pkg/testdatagen/make_shipment_records.go
+++ b/pkg/testdatagen/make_shipment_records.go
@@ -52,7 +52,7 @@ func MakeShipment(db *pop.Connection, assertions Assertions) models.Shipment {
 		ServiceMemberID:              serviceMember.ID,
 		ServiceMember:                serviceMember,
 		ActualPickupDate:             timePointer(DateInsidePerformancePeriod),
-		DeliveryDate:                 timePointer(DateOutsidePerformancePeriod),
+		ActualDeliveryDate:           timePointer(DateOutsidePerformancePeriod),
 		SourceGBLOC:                  stringPointer(DefaultSrcGBLOC),
 		DestinationGBLOC:             stringPointer(DefaultSrcGBLOC),
 		Market:                       &DefaultMarket,
@@ -117,7 +117,7 @@ func MakeShipmentData(db *pop.Connection) {
 		Shipment: models.Shipment{
 			RequestedPickupDate:     &now,
 			ActualPickupDate:        &now,
-			DeliveryDate:            &now,
+			ActualDeliveryDate:      &now,
 			TrafficDistributionList: &tdlList[0],
 			SourceGBLOC:             &sourceGBLOC,
 			Market:                  &market,
@@ -128,7 +128,7 @@ func MakeShipmentData(db *pop.Connection) {
 		Shipment: models.Shipment{
 			RequestedPickupDate:     &nowPlusOne,
 			ActualPickupDate:        &nowPlusOne,
-			DeliveryDate:            &nowPlusOne,
+			ActualDeliveryDate:      &nowPlusOne,
 			TrafficDistributionList: &tdlList[1],
 			SourceGBLOC:             &sourceGBLOC,
 			Market:                  &market,
@@ -139,7 +139,7 @@ func MakeShipmentData(db *pop.Connection) {
 		Shipment: models.Shipment{
 			RequestedPickupDate:     &nowPlusTwo,
 			ActualPickupDate:        &nowPlusTwo,
-			DeliveryDate:            &nowPlusTwo,
+			ActualDeliveryDate:      &nowPlusTwo,
 			TrafficDistributionList: &tdlList[2],
 			SourceGBLOC:             &sourceGBLOC,
 			Market:                  &market,

--- a/pkg/testdatagen/scenario/awardqueue.go
+++ b/pkg/testdatagen/scenario/awardqueue.go
@@ -37,7 +37,7 @@ func RunAwardQueueScenario1(db *pop.Connection) {
 			Shipment: models.Shipment{
 				RequestedPickupDate:     &now,
 				ActualPickupDate:        &now,
-				DeliveryDate:            &now,
+				ActualDeliveryDate:      &now,
 				TrafficDistributionList: &tdl,
 				SourceGBLOC:             &sourceGBLOC,
 				Market:                  &market,
@@ -94,7 +94,7 @@ func RunAwardQueueScenario2(db *pop.Connection) {
 			Shipment: models.Shipment{
 				RequestedPickupDate:     &shipmentDate,
 				ActualPickupDate:        &shipmentDate,
-				DeliveryDate:            &shipmentDate,
+				ActualDeliveryDate:      &shipmentDate,
 				TrafficDistributionList: &tdl,
 				SourceGBLOC:             &sourceGBLOC,
 				Market:                  &market,
@@ -107,7 +107,7 @@ func RunAwardQueueScenario2(db *pop.Connection) {
 			Shipment: models.Shipment{
 				RequestedPickupDate:     &shipmentDate,
 				ActualPickupDate:        &shipmentDate,
-				DeliveryDate:            &shipmentDate,
+				ActualDeliveryDate:      &shipmentDate,
 				TrafficDistributionList: &tdl2,
 				SourceGBLOC:             &sourceGBLOC,
 				Market:                  &market,

--- a/src/scenes/TransportationServiceProvider/FormButton.jsx
+++ b/src/scenes/TransportationServiceProvider/FormButton.jsx
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 export default class FormButton extends Component {
   state = {

--- a/src/scenes/TransportationServiceProvider/FormButton.jsx
+++ b/src/scenes/TransportationServiceProvider/FormButton.jsx
@@ -1,0 +1,46 @@
+import React, { Component } from 'react';
+
+export default class FormButton extends Component {
+  state = {
+    displayState: 'BUTTON',
+  };
+
+  setButtonState = () => {
+    this.setState({ displayState: 'BUTTON' });
+  };
+
+  setFormState = () => {
+    this.setState({ displayState: 'FORM' });
+  };
+
+  buttonView = () => {
+    const { buttonTitle } = this.props;
+    return <button onClick={this.setFormState}>{buttonTitle}</button>;
+  };
+
+  enterFormView = () => {
+    const { schema, onSubmit, formComponent } = this.props;
+
+    const formProps = {
+      onCancel: this.setButtonState,
+      schema: schema,
+      onSubmit: onSubmit,
+    };
+    return React.createElement(formComponent, formProps, null);
+  };
+
+  render() {
+    const viewStates = {
+      BUTTON: this.buttonView(),
+      FORM: this.enterFormView(),
+    };
+    return viewStates[this.state.displayState];
+  }
+}
+
+FormButton.propTypes = {
+  formComponent: PropTypes.element.isRequired,
+  schema: PropTypes.object.isRequired,
+  onSubmit: PropTypes.func.isRequired,
+  buttonTitle: PropTypes.string.isRequired,
+};

--- a/src/scenes/TransportationServiceProvider/api.js
+++ b/src/scenes/TransportationServiceProvider/api.js
@@ -68,6 +68,17 @@ export async function TransportShipment(shipmentId, payload) {
   return response.body;
 }
 
+export async function DeliverShipment(shipmentId, payload) {
+  const client = await getPublicClient();
+  const payloadDef = client.spec.definitions.ActualDeliveryDate;
+  const response = await client.apis.shipments.deliverShipment({
+    shipmentId,
+    payload: formatPayload(payload, payloadDef),
+  });
+  checkResponse(response, 'failed to pick up shipment due to server error');
+  return response.body;
+}
+
 export async function PatchShipment(shipmentId, shipment) {
   const client = await getPublicClient();
   const payloadDef = client.spec.definitions.Shipment;

--- a/src/scenes/TransportationServiceProvider/ducks.js
+++ b/src/scenes/TransportationServiceProvider/ducks.js
@@ -4,6 +4,7 @@ import {
   AcceptShipment,
   RejectShipment,
   TransportShipment,
+  DeliverShipment,
   CreateServiceAgent,
   IndexServiceAgents,
   UpdateServiceAgent,
@@ -19,6 +20,7 @@ const acceptShipmentType = 'ACCEPT_SHIPMENT';
 const generateGBLType = 'GENERATE_GBL';
 const rejectShipmentType = 'REJECT_SHIPMENT';
 const transportShipmentType = 'TRANSPORT_SHIPMENT';
+const deliverShipmentType = 'TRANSPORT_SHIPMENT';
 
 const indexServiceAgentsType = 'INDEX_SERVICE_AGENTS';
 const createServiceAgentsType = 'CREATE_SERVICE_AGENTS';
@@ -38,6 +40,9 @@ const REJECT_SHIPMENT = ReduxHelpers.generateAsyncActionTypes(
 );
 const TRANSPORT_SHIPMENT = ReduxHelpers.generateAsyncActionTypes(
   transportShipmentType,
+);
+const DELIVER_SHIPMENT = ReduxHelpers.generateAsyncActionTypes(
+  deliverShipmentType,
 );
 
 const GENERATE_GBL = ReduxHelpers.generateAsyncActionTypes(generateGBLType);
@@ -90,6 +95,11 @@ export const rejectShipment = ReduxHelpers.generateAsyncActionCreator(
 export const transportShipment = ReduxHelpers.generateAsyncActionCreator(
   transportShipmentType,
   TransportShipment,
+);
+
+export const deliverShipment = ReduxHelpers.generateAsyncActionCreator(
+  deliverShipmentType,
+  DeliverShipment,
 );
 
 export const indexServiceAgents = ReduxHelpers.generateAsyncActionCreator(
@@ -157,6 +167,9 @@ const initialState = {
   shipmentIsSendingTransport: false,
   shipmentHasTransportError: null,
   shipmentHasTransportSuccess: false,
+  shipmentIsDelivering: false,
+  shipmentHasDeliverError: null,
+  shipmentHasDeliverSuccess: false,
   serviceAgentsAreLoading: false,
   serviceAgentsHasLoadSucces: false,
   serviceAgentsHasLoadError: null,
@@ -270,6 +283,25 @@ export function tspReducer(state = initialState, action) {
         shipmentIsSendingTransport: false,
         shipmentHasTransportSuccess: false,
         shipmentHasTransportError: null,
+        error: action.error.message,
+      });
+    case DELIVER_SHIPMENT.start:
+      return Object.assign({}, state, {
+        shipmentIsDelivering: true,
+        shipmentHasDeliverSuccess: false,
+      });
+    case DELIVER_SHIPMENT.success:
+      return Object.assign({}, state, {
+        shipmentIsDelivering: false,
+        shipmentHasDeliverSuccess: true,
+        shipmentHasDeliverError: false,
+        shipment: action.payload,
+      });
+    case DELIVER_SHIPMENT.failure:
+      return Object.assign({}, state, {
+        shipmentIsDelivering: false,
+        shipmentHasDeliverSuccess: false,
+        shipmentHasDeliverError: null,
         error: action.error.message,
       });
 

--- a/swagger/api.yaml
+++ b/swagger/api.yaml
@@ -837,6 +837,7 @@ definitions:
         format: date
         example: "2018-04-02"
         x-nullable: true
+        title: Actual Delivery Date
     required:
       - actual_delivery_date
   TSP:
@@ -1385,7 +1386,7 @@ paths:
           required: true
           description: UUID of the shipment
         - in: body
-          name: actualDeliveryDate
+          name: payload
           required: true
           schema:
             $ref: '#/definitions/ActualDeliveryDate'

--- a/swagger/api.yaml
+++ b/swagger/api.yaml
@@ -460,7 +460,7 @@ definitions:
         type: string
         format: date-time
         example: 2018-04-21T17:32:28Z
-      delivery_date:
+      actual_delivery_date:
         type: string
         format: date-time
         example: 2018-04-27T17:32:28Z
@@ -829,6 +829,16 @@ definitions:
         x-nullable: true
     required:
       - actual_pickup_date
+  ActualDeliveryDate:
+    type: object
+    properties:
+      actual_delivery_date:
+        type: string
+        format: date
+        example: "2018-04-02"
+        x-nullable: true
+    required:
+      - actual_delivery_date
   TSP:
     type: object
     description: The primary definition of a Transport Service Provider
@@ -1360,6 +1370,42 @@ paths:
             $ref: '#/definitions/Shipment'
         500:
           description: server error
+  /shipments/{shipmentId}/deliver:
+    post:
+      summary: Places an in transit shipment to delivered state
+      description: The status of the shipment will be updated to DELIVERED.
+      operationId: deliverShipment
+      tags:
+        - shipments
+      parameters:
+        - name: shipmentId
+          in: path
+          type: string
+          format: uuid
+          required: true
+          description: UUID of the shipment
+        - in: body
+          name: actualDeliveryDate
+          required: true
+          schema:
+            $ref: '#/definitions/ActualDeliveryDate'
+      responses:
+        200:
+          description: returns updated (delivered) shipment object
+          schema:
+            $ref: '#/definitions/Shipment'
+        400:
+          description: invalid request
+        401:
+          description: must be authenticated to use this endpoint
+        403:
+          description: not authorized to accept this shipment
+        409:
+          description: the shipment is not in a state to be accepted
+          schema:
+            $ref: '#/definitions/Shipment'
+        500:
+          description: server error
   /shipments/{shipmentId}/claims:
     get:
       summary: Gets the list of claims associated with a shipment
@@ -1391,7 +1437,7 @@ paths:
   /shipments/{shipmentId}/contact_details:
     get:
       summary: Gets the detailed contact information for a move
-      description: Accepts a shipment awarded to a TSP
+      description: Gets the detailed contact information for a move
       operationId: getShipmentContactDetails
       tags:
         - shipments

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -1429,7 +1429,7 @@ definitions:
         example: "2018-04-26"
         readOnly: true
         x-nullable: true
-      delivery_date:
+      actual_delivery_date:
         type: string
         format: date
         example: "2018-04-26"


### PR DESCRIPTION
## Description

Adds a button for TSPs to DELIVER a shipment. 

## Reviewer Notes

FormButton seems like a pattern we are using in a bunch of places. I could have preemptively put it in Shared but figured I'd wait till someone wants it. 

This PR has two others merged into it. Depending on if we are trying to get all this in for the demo we can just merge this one or do them all in order. 

https://github.com/transcom/mymove/pull/1023
https://github.com/transcom/mymove/pull/1005

## Code Review Verification Steps

* [ ] End to end tests pass (`make e2e_test`).
* [ ] Code follows the guidelines for [Logging](./docs/backend.md#logging)
* [ ] There are no aXe warnings for UI.
* [ ] This works in IE.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/160394695) for this change

## Screenshots
<img width="273" alt="screen shot 2018-09-21 at 8 47 12 am" src="https://user-images.githubusercontent.com/55759/45891647-f5111f80-bd7a-11e8-9e64-c266ca4b7497.png">