### PR TITLE
add disabled as prop on ConfirmWithReasonButton

### DIFF
--- a/cypress/integration/tsp/declineShipment.js
+++ b/cypress/integration/tsp/declineShipment.js
@@ -5,12 +5,12 @@ describe('TSP User Rejects a Shipment', function() {
   beforeEach(() => {
     cy.signIntoTSP();
   });
-  it('tsp user rejects a shipment', function() {
-    tspUserRejectsShipment();
+  it('tsp user cannot reject a shipment', function() {
+    tspUserCannotRejectShipment();
   });
 });
 
-function tspUserRejectsShipment() {
+function tspUserCannotRejectShipment() {
   // Open new shipments queue
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/queues\/new/);
@@ -26,62 +26,86 @@ function tspUserRejectsShipment() {
     expect(loc.pathname).to.match(/^\/queues\/new\/shipments\/[^/]+/);
   });
 
-  // Click the Reject button
+  // Reject button is disabled
   cy
     .get('.usa-button-secondary')
     .contains('Reject Shipment')
-    .click();
-
-  // New button should be disabled.
-  cy
-    .get('button')
-    .contains('Reject Shipment')
     .should('be.disabled');
-
-  // Give a reason
-  cy.get('textarea').type('End to End test.');
-  cy
-    .get('button')
-    .contains('Reject Shipment')
-    .click();
-
-  // Cancel
-  cy
-    .get('div')
-    .contains('No, never mind')
-    .click();
-
-  // Wash, Rinse, Repeat
-  // Click the Reject button
-  cy
-    .get('button')
-    .contains('Reject Shipment')
-    .click();
-
-  // New button should be disabled.
-  cy
-    .get('button')
-    .contains('Reject Shipment')
-    .should('be.disabled');
-
-  // Give a reason
-  cy.get('textarea').type('End to End test.');
-  cy
-    .get('button')
-    .contains('Reject Shipment')
-    .click();
-
-  cy
-    .get('button')
-    .contains('Reject Shipment')
-    .click();
-
-  cy.location().should(loc => {
-    expect(loc.pathname).to.match(/^\/queues\/new/);
-  });
-
-  cy
-    .get('div')
-    .contains('REJECT')
-    .should('not.exist');
 }
+
+// TODO (rebecca): Reenable when we have Reject Shipment an option
+// function tspUserRejectsShipment() {
+//   // Open new shipments queue
+//   cy.location().should(loc => {
+//     expect(loc.pathname).to.match(/^\/queues\/new/);
+//   });
+
+//   // Find shipment and open it
+//   cy
+//     .get('div')
+//     .contains('REJECT')
+//     .dblclick();
+
+//   cy.location().should(loc => {
+//     expect(loc.pathname).to.match(/^\/queues\/new\/shipments\/[^/]+/);
+//   });
+
+//   // Click the Reject button
+//   cy
+//     .get('.usa-button-secondary')
+//     .contains('Reject Shipment')
+//     .click();
+
+//   // New button should be disabled.
+//   cy
+//     .get('button')
+//     .contains('Reject Shipment')
+//     .should('be.disabled');
+
+//   // Give a reason
+//   cy.get('textarea').type('End to End test.');
+//   cy
+//     .get('button')
+//     .contains('Reject Shipment')
+//     .click();
+
+//   // Cancel
+//   cy
+//     .get('div')
+//     .contains('No, never mind')
+//     .click();
+
+//   // Wash, Rinse, Repeat
+//   // Click the Reject button
+//   cy
+//     .get('button')
+//     .contains('Reject Shipment')
+//     .click();
+
+//   // New button should be disabled.
+//   cy
+//     .get('button')
+//     .contains('Reject Shipment')
+//     .should('be.disabled');
+
+//   // Give a reason
+//   cy.get('textarea').type('End to End test.');
+//   cy
+//     .get('button')
+//     .contains('Reject Shipment')
+//     .click();
+
+//   cy
+//     .get('button')
+//     .contains('Reject Shipment')
+//     .click();
+
+//   cy.location().should(loc => {
+//     expect(loc.pathname).to.match(/^\/queues\/new/);
+//   });
+
+//   cy
+//     .get('div')
+//     .contains('REJECT')
+//     .should('not.exist');
+// }

--- a/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
+++ b/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
@@ -51,6 +51,7 @@ class AcceptShipmentPanel extends Component {
           reasonPrompt="Why are you rejecting this shipment?"
           warningPrompt="Are you sure you want to reject this shipment?"
           onConfirm={this.rejectShipment}
+          buttonDisabled={true}
         />
       </div>
     );

--- a/src/shared/ConfirmWithReasonButton/index.jsx
+++ b/src/shared/ConfirmWithReasonButton/index.jsx
@@ -28,7 +28,12 @@ export default class ConfirmWithReasonButton extends Component {
   };
 
   render() {
-    const { buttonTitle, reasonPrompt, warningPrompt } = this.props;
+    const {
+      buttonTitle,
+      reasonPrompt,
+      warningPrompt,
+      buttonDisabled,
+    } = this.props;
 
     const reasonPresent = this.state.cancelReason !== '';
 
@@ -73,7 +78,11 @@ export default class ConfirmWithReasonButton extends Component {
       );
     } else if (this.state.displayState === 'BUTTON') {
       return (
-        <button className="usa-button-secondary" onClick={this.setConfirmState}>
+        <button
+          className="usa-button-secondary"
+          onClick={this.setConfirmState}
+          disabled={buttonDisabled}
+        >
           {buttonTitle}
         </button>
       );


### PR DESCRIPTION
## Description

This prop allows the ConfirmWithReasonButton component button to be disabled, and then disables it for the Reject Shipment flow on the TSP side.

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```
make db_dev_reset db_dev_migrate && go run cmd/generate_test_data/main.go -scenario 7
```

login as tsp user, select any shipment, see reject button disabled. 

## Code Review Verification Steps

* [ ] End to end tests pass (`make e2e_test`).
* [x] There are no aXe warnings for UI.
* [ ] This works in IE.
* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/160601815) for this change

## Screenshots

<img width="459" alt="screen shot 2018-09-21 at 2 16 55 pm" src="https://user-images.githubusercontent.com/7401870/45906456-096c1100-bda9-11e8-9cc9-9c803699d6fc.png">
