### PR TITLE
Remove dep status check from pre-commit.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -115,12 +115,3 @@ repos:
         name: dep version
         entry: bin/check_dep_version
         language: script
-
-  - repo: local
-    hooks:
-      - id: dep-status
-        name: dep status
-        entry: dep status -v
-        language: system
-        description: If this hook fails, try running `dep ensure`
-        files: \.go$


### PR DESCRIPTION
## Description

This causes a lot of unwanted developer pain.  If we rely simply on checking the dep version in our pre-commit and the makefile for other vendoring steps then I think we'll be fine.

## Reviewer Notes

I don't think this breaks anything but would it cause problems for developers to not have?