### PR TITLE
adding new office users [delivers ##160731022]

### DIFF
--- a/bin/generate-secure-migration
+++ b/bin/generate-secure-migration
@@ -86,8 +86,8 @@ Next:
     1. Edit the production migration to have the actual change you wish to deploy
     2. Copy the production migration into the local migration, scrubbing sensitive data
     3. If everything looks good, upload the migration to S3 with this utility:
-       upload-secure-migration \\
+       bin/upload-secure-migration \\
           ${prod_migration_name}
-    4. Run bin/run_prod_migrations to verify that the upload worked and that the migration can be applied successfully.
+    4. Run bin/run-prod-migrations to verify that the upload worked and that the migration can be applied successfully.
     5. Open a pull request for this change; when it is accepted, your migration will run on staging.
 EOM

--- a/local_migrations/20180924221215_office-users.sql
+++ b/local_migrations/20180924221215_office-users.sql
@@ -1,0 +1,14 @@
+-- Local test migration.
+-- This will be run on development environments. It should mirror what you
+-- intend to apply on production, but do not include any sensitive data.
+
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
+-- TNG Users
+INSERT INTO public.office_users VALUES (uuid_generate_v4(), NULL, 'Alyssa', 'Ogawa', NULL, 'alyssa@example.com', '(800) 555-1234', '0931a9dc-c1fd-444a-b138-6e1986b1714c', now(), now());
+INSERT INTO public.office_users VALUES (uuid_generate_v4(), NULL, 'Thadiun', 'Okona', NULL, 'thadiun@example.com', '(800) 555-1234', '0931a9dc-c1fd-444a-b138-6e1986b1714c', now(), now());
+INSERT INTO public.office_users VALUES (uuid_generate_v4(), NULL, 'Marie', 'Picard', NULL, 'marie@example.com', '(800) 555-1234', '0931a9dc-c1fd-444a-b138-6e1986b1714c', now(), now());
+
+-- DS9 users
+INSERT INTO public.office_users VALUES (uuid_generate_v4(), NULL, 'Miles', 'O''Brien', NULL, 'obrien@example.com', '(800) 555-5000', 'f50eb7f5-960a-46e8-aa64-6025b44132ab', now(), now());
+INSERT INTO public.office_users VALUES (uuid_generate_v4(), NULL, 'Julian', 'Bashir', NULL, 'bashir@example.com', '(800) 555-5000', 'f50eb7f5-960a-46e8-aa64-6025b44132ab', now(), now());

--- a/migrations/20180924221215_office-users.up.fizz
+++ b/migrations/20180924221215_office-users.up.fizz
@@ -1,0 +1,1 @@
+exec("./apply-secure-migration.sh 20180924221215_office-users.sql")


### PR DESCRIPTION
## Description

Adding new office users for Truss, SBD, and USMC.

## Reviewer Notes

You can test that it works by running: `bin/run-prod-migrations`

This will copy production data into your local database for inspection, and ensure that they run without errors. You should be able to connect to the `prod_migrations` database locally and see that there are new office users.