### PR TITLE
Added new endpoint for determining unavailable move dates

### DIFF
--- a/pkg/handlers/internalapi/api.go
+++ b/pkg/handlers/internalapi/api.go
@@ -90,5 +90,7 @@ func NewInternalAPIHandler(context handlers.HandlerContext) http.Handler {
 
 	internalAPI.GexSendGexRequestHandler = SendGexRequestHandler{context}
 
+	internalAPI.CalendarShowUnavailableMoveDatesHandler = ShowUnavailableMoveDatesHandler{context}
+
 	return internalAPI.Serve(nil)
 }

--- a/pkg/handlers/internalapi/calendar.go
+++ b/pkg/handlers/internalapi/calendar.go
@@ -1,0 +1,37 @@
+package internalapi
+
+import (
+	"github.com/go-openapi/runtime/middleware"
+	"github.com/go-openapi/strfmt"
+	calendarop "github.com/transcom/mymove/pkg/gen/internalapi/internaloperations/calendar"
+	"github.com/transcom/mymove/pkg/handlers"
+	"time"
+)
+
+// ShowUnavailableMoveDatesHandler returns the unavailable move dates starting at a given date.
+type ShowUnavailableMoveDatesHandler struct {
+	handlers.HandlerContext
+}
+
+// Handle returns the unavailable move dates.
+func (h ShowUnavailableMoveDatesHandler) Handle(params calendarop.ShowUnavailableMoveDatesParams) middleware.Responder {
+	var datesPayload []strfmt.Date
+
+	startDate := time.Time(params.StartDate)
+	const daysToCheck = 90
+	const shortFuseTotalDays = 5
+	daysChecked := 0
+	shortFuseDaysFound := 0
+
+	for d := startDate; daysChecked < daysToCheck; d = d.AddDate(0, 0, 1) {
+		if d.Weekday() == time.Saturday || d.Weekday() == time.Sunday {
+			datesPayload = append(datesPayload, strfmt.Date(d))
+		} else if shortFuseDaysFound < shortFuseTotalDays {
+			datesPayload = append(datesPayload, strfmt.Date(d))
+			shortFuseDaysFound++
+		}
+		daysChecked++
+	}
+
+	return calendarop.NewShowUnavailableMoveDatesOK().WithPayload(datesPayload)
+}

--- a/pkg/handlers/internalapi/calendar_test.go
+++ b/pkg/handlers/internalapi/calendar_test.go
@@ -1,0 +1,61 @@
+package internalapi
+
+import (
+	"github.com/go-openapi/strfmt"
+	calendarop "github.com/transcom/mymove/pkg/gen/internalapi/internaloperations/calendar"
+	"github.com/transcom/mymove/pkg/handlers"
+	"net/http/httptest"
+	"time"
+)
+
+func (suite *HandlerSuite) TestShowUnavailableMoveDatesHandler() {
+
+	req := httptest.NewRequest("GET", "/calendar/unavailable_move_dates", nil)
+
+	params := calendarop.ShowUnavailableMoveDatesParams{
+		HTTPRequest: req,
+		StartDate:   strfmt.Date(time.Date(2018, 9, 26, 0, 0, 0, 0, time.UTC)),
+	}
+
+	unavailableDates := []strfmt.Date{
+		strfmt.Date(time.Date(2018, 9, 26, 0, 0, 0, 0, time.UTC)),
+		strfmt.Date(time.Date(2018, 9, 27, 0, 0, 0, 0, time.UTC)),
+		strfmt.Date(time.Date(2018, 9, 28, 0, 0, 0, 0, time.UTC)),
+		strfmt.Date(time.Date(2018, 9, 29, 0, 0, 0, 0, time.UTC)),
+		strfmt.Date(time.Date(2018, 9, 30, 0, 0, 0, 0, time.UTC)),
+		strfmt.Date(time.Date(2018, 10, 1, 0, 0, 0, 0, time.UTC)),
+		strfmt.Date(time.Date(2018, 10, 2, 0, 0, 0, 0, time.UTC)),
+		strfmt.Date(time.Date(2018, 10, 6, 0, 0, 0, 0, time.UTC)),
+		strfmt.Date(time.Date(2018, 10, 7, 0, 0, 0, 0, time.UTC)),
+		strfmt.Date(time.Date(2018, 10, 13, 0, 0, 0, 0, time.UTC)),
+		strfmt.Date(time.Date(2018, 10, 14, 0, 0, 0, 0, time.UTC)),
+		strfmt.Date(time.Date(2018, 10, 20, 0, 0, 0, 0, time.UTC)),
+		strfmt.Date(time.Date(2018, 10, 21, 0, 0, 0, 0, time.UTC)),
+		strfmt.Date(time.Date(2018, 10, 27, 0, 0, 0, 0, time.UTC)),
+		strfmt.Date(time.Date(2018, 10, 28, 0, 0, 0, 0, time.UTC)),
+		strfmt.Date(time.Date(2018, 11, 3, 0, 0, 0, 0, time.UTC)),
+		strfmt.Date(time.Date(2018, 11, 4, 0, 0, 0, 0, time.UTC)),
+		strfmt.Date(time.Date(2018, 11, 10, 0, 0, 0, 0, time.UTC)),
+		strfmt.Date(time.Date(2018, 11, 11, 0, 0, 0, 0, time.UTC)),
+		strfmt.Date(time.Date(2018, 11, 17, 0, 0, 0, 0, time.UTC)),
+		strfmt.Date(time.Date(2018, 11, 18, 0, 0, 0, 0, time.UTC)),
+		strfmt.Date(time.Date(2018, 11, 24, 0, 0, 0, 0, time.UTC)),
+		strfmt.Date(time.Date(2018, 11, 25, 0, 0, 0, 0, time.UTC)),
+		strfmt.Date(time.Date(2018, 12, 1, 0, 0, 0, 0, time.UTC)),
+		strfmt.Date(time.Date(2018, 12, 2, 0, 0, 0, 0, time.UTC)),
+		strfmt.Date(time.Date(2018, 12, 8, 0, 0, 0, 0, time.UTC)),
+		strfmt.Date(time.Date(2018, 12, 9, 0, 0, 0, 0, time.UTC)),
+		strfmt.Date(time.Date(2018, 12, 15, 0, 0, 0, 0, time.UTC)),
+		strfmt.Date(time.Date(2018, 12, 16, 0, 0, 0, 0, time.UTC)),
+		strfmt.Date(time.Date(2018, 12, 22, 0, 0, 0, 0, time.UTC)),
+		strfmt.Date(time.Date(2018, 12, 23, 0, 0, 0, 0, time.UTC)),
+	}
+
+	showHandler := ShowUnavailableMoveDatesHandler{handlers.NewHandlerContext(suite.TestDB(), suite.TestLogger())}
+	response := showHandler.Handle(params)
+
+	suite.IsType(&calendarop.ShowUnavailableMoveDatesOK{}, response)
+	okResponse := response.(*calendarop.ShowUnavailableMoveDatesOK)
+
+	suite.Equal(unavailableDates, okResponse.Payload)
+}

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -3981,3 +3981,34 @@ paths:
           description: invalid request
         500:
           description: internal server error
+  /calendar/unavailable_move_dates:
+    get:
+      summary: Returns unavailable dates for the move calendar
+      description: Returns unavailable dates for the move calendar
+      operationId: showUnavailableMoveDates
+      tags:
+        - calendar
+      parameters:
+        - in: query
+          name: start_date
+          type: string
+          format: date
+          required: true
+          description: Look for future unavailable dates starting from (and including) this date
+      responses:
+        200:
+          description: List of unavailable dates
+          schema:
+            type: array
+            items:
+              type: string
+              format: date
+              example: "2018-09-25"
+        400:
+          description: invalid request
+        401:
+          description: request requires user authentication
+        403:
+          description: user is not authorized
+        500:
+          description: internal server error


### PR DESCRIPTION
## Description

This PR creates a new endpoint for determining unavailable move dates.  These unavailable dates will eventually be used to style the front-end calendar UI for picking a move date.

## Reviewer Notes

For now, we are just restricting short-fuse moves (first 5 business days from the given date) and weekends.  Holidays will be added as part of a future story.

We also only return unavailable dates in the 90 days from (and including) the start date passed in to the endpoint.

## Setup

`make server_run`
`make client_run`
Visit `http://localhost:3000/internal/docs` and experiment with the `calendar` section using the Swagger UI.

## Code Review Verification Steps

* [ ] End to end tests pass (`make e2e_test`).
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/160740528) for this change
