### PR TITLE
Sb 160605623 add entities reducer and document view

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "e2e-test": "NODE_PATH=./e2e jest ./e2e.test.js --env=jsdom",
     "prettier": "prettier --loglevel warn 'src/**/*.{js,jsx}'",
     "adr-log": "adr-log -d ./docs/adr -i ./docs/adr/readme.md",
-    "lint": "eslint src/"
+    "lint": "eslint --ext .js --ext .jsx src"
   },
   "proxy": {
     "/api": {

--- a/src/appReducer.js
+++ b/src/appReducer.js
@@ -35,28 +35,26 @@ const defaultReducers = {
   entities: entitiesReducer,
 };
 
-export const appReducer = combineReducers(
-  Object.assign({}, defaultReducers, {
-    submittedIssues: issuesReducer,
-    moves: moveReducer,
-    ppm: ppmReducer,
-    serviceMember: serviceMemberReducer,
-    orders: ordersReducer,
-    shipments: shipmentsReducer,
-    feedback: feedbackReducer,
-    signedCertification: signedCertificationReducer,
-    upload: documentReducer,
-    review: reviewReducer,
-    office: officeReducer,
-    transportationOffices: transportationOfficeReducer,
-    ppmIncentive: officePpmReducer,
-  }),
-);
+export const appReducer = combineReducers({
+  ...defaultReducers,
+  submittedIssues: issuesReducer,
+  moves: moveReducer,
+  ppm: ppmReducer,
+  serviceMember: serviceMemberReducer,
+  orders: ordersReducer,
+  shipments: shipmentsReducer,
+  feedback: feedbackReducer,
+  signedCertification: signedCertificationReducer,
+  upload: documentReducer,
+  review: reviewReducer,
+  office: officeReducer,
+  transportationOffices: transportationOfficeReducer,
+  ppmIncentive: officePpmReducer,
+});
 
-export const tspAppReducer = combineReducers(
-  Object.assign({}, defaultReducers, {
-    tsp: tspReducer,
-  }),
-);
+export const tspAppReducer = combineReducers({
+  ...defaultReducers,
+  tsp: tspReducer,
+});
 
 export default appReducer;

--- a/src/scenes/Office/CustomerInfoPanel.jsx
+++ b/src/scenes/Office/CustomerInfoPanel.jsx
@@ -1,4 +1,4 @@
-import { get, compact } from 'lodash';
+import { get } from 'lodash';
 import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
@@ -15,6 +15,7 @@ import {
   SwaggerValue,
   editablePanelify,
 } from 'shared/EditablePanel';
+import { stringifyName } from 'shared/utils/serviceMember';
 
 import FontAwesomeIcon from '@fortawesome/react-fontawesome';
 import faPhone from '@fortawesome/fontawesome-free-solid/faPhone';
@@ -27,7 +28,7 @@ const CustomerInfoDisplay = props => {
     values: props.serviceMember,
   };
   const values = props.serviceMember;
-  const name = compact([values.last_name, values.first_name]).join(', ');
+  const name = stringifyName(values);
   const address = get(values, 'residential_address', {});
 
   return (

--- a/src/scenes/Office/DocumentViewer/index.jsx
+++ b/src/scenes/Office/DocumentViewer/index.jsx
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
-import { compact, get } from 'lodash';
+import { get } from 'lodash';
 import qs from 'query-string';
 
 import LoadingPlaceholder from 'shared/LoadingPlaceholder';
@@ -22,6 +22,7 @@ import {
   selectAllDocumentsForMove,
   getMoveDocumentsForMove,
 } from 'shared/Entities/modules/moveDocuments';
+import { stringifyName } from 'shared/utils/serviceMember';
 
 import FontAwesomeIcon from '@fortawesome/react-fontawesome';
 import faPlusCircle from '@fortawesome/fontawesome-free-solid/faPlusCircle';
@@ -39,10 +40,7 @@ class DocumentViewer extends Component {
   render() {
     const { serviceMember, move, moveDocuments } = this.props;
     const numMoveDocs = moveDocuments ? moveDocuments.length : 0;
-    const name = compact([
-      serviceMember.last_name,
-      serviceMember.first_name,
-    ]).join(', ');
+    const name = stringifyName(serviceMember);
 
     // urls: has full url with IDs
     const defaultUrl = move ? `/moves/${move.id}/documents` : '';

--- a/src/scenes/Office/OrdersInfo.jsx
+++ b/src/scenes/Office/OrdersInfo.jsx
@@ -2,13 +2,14 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
-import { compact, get } from 'lodash';
+import { get } from 'lodash';
 
 import LoadingPlaceholder from 'shared/LoadingPlaceholder';
 import Alert from 'shared/Alert';
 import DocumentContent from 'shared/DocumentViewer/DocumentContent';
 import OrdersViewerPanel from './OrdersViewerPanel';
 import { loadMoveDependencies } from './ducks.js';
+import { stringifyName } from 'shared/utils/serviceMember';
 
 import './office.css';
 
@@ -20,10 +21,7 @@ class OrdersInfo extends Component {
   render() {
     const orders = this.props.orders;
     const serviceMember = this.props.serviceMember;
-    const name = compact([
-      serviceMember.last_name,
-      serviceMember.first_name,
-    ]).join(', ');
+    const name = stringifyName(serviceMember);
 
     let uploads;
     if (orders && orders.uploaded_orders) {

--- a/src/scenes/TransportationServiceProvider/DocumentViewerContainer.jsx
+++ b/src/scenes/TransportationServiceProvider/DocumentViewerContainer.jsx
@@ -6,19 +6,38 @@ import {
   getShipmentDocumentsLabel,
 } from 'shared/Entities/modules/shipmentDocuments';
 
-const mapStateToProps = state => {
+const mapStateToProps = (state, ownProps) => {
+  const { shipmentId } = ownProps.match.params;
   const {
-    tsp: { shipment = {} },
-    entities: { moveDocuments = [] },
+    tsp: { shipment: { move = {}, service_member: serviceMember = {} } = {} },
+    entities: { moveDocuments = {}, uploads = {} },
   } = state;
-  return { shipment, moveDocuments };
+  const { locator: moveLocator } = move;
+  const {
+    edipi = '',
+    last_name: lastName = '',
+    first_name: firstName = '',
+  } = serviceMember;
+  const name = [lastName, firstName].filter(name => !!name).join(', ');
+
+  return {
+    documentDetailUrlPrefix: `/shipments/${shipmentId}/documents`,
+    moveDocuments: Object.values(moveDocuments),
+    moveLocator: moveLocator || '',
+    newDocumentUrl: `/shipments/${shipmentId}/documents/new`,
+    serviceMember: { edipi, name },
+    uploads: Object.values(uploads),
+  };
 };
 
-const mapDispatchToProps = dispatch => ({
-  onDidMount: shipmentId => {
-    dispatch(loadShipmentDependencies(shipmentId));
-    dispatch(getAllShipmentDocuments(getShipmentDocumentsLabel, shipmentId));
-  },
-});
+const mapDispatchToProps = (dispatch, ownProps) => {
+  const { shipmentId } = ownProps.match.params;
+  return {
+    onDidMount: () => {
+      dispatch(loadShipmentDependencies(shipmentId));
+      dispatch(getAllShipmentDocuments(getShipmentDocumentsLabel, shipmentId));
+    },
+  };
+};
 
 export default connect(mapStateToProps, mapDispatchToProps)(MoveDocumentView);

--- a/src/scenes/TransportationServiceProvider/DocumentViewerContainer.jsx
+++ b/src/scenes/TransportationServiceProvider/DocumentViewerContainer.jsx
@@ -1,0 +1,18 @@
+import { connect } from 'react-redux';
+import { loadShipmentDependencies } from './ducks';
+import MoveDocumentView from 'shared/DocumentViewer/MoveDocumentView';
+
+const mapStateToProps = state => {
+  const {
+    tsp: { shipment = {} },
+  } = state;
+  return { shipment: shipment };
+};
+
+const mapDispatchToProps = dispatch => ({
+  onDidMount: shipmentId => {
+    dispatch(loadShipmentDependencies(shipmentId));
+  },
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(MoveDocumentView);

--- a/src/scenes/TransportationServiceProvider/DocumentViewerContainer.jsx
+++ b/src/scenes/TransportationServiceProvider/DocumentViewerContainer.jsx
@@ -1,17 +1,23 @@
 import { connect } from 'react-redux';
 import { loadShipmentDependencies } from './ducks';
 import MoveDocumentView from 'shared/DocumentViewer/MoveDocumentView';
+import {
+  getAllShipmentDocuments,
+  getShipmentDocumentsLabel,
+} from 'shared/Entities/modules/shipmentDocuments';
 
 const mapStateToProps = state => {
   const {
     tsp: { shipment = {} },
+    entities: { moveDocuments = [] },
   } = state;
-  return { shipment: shipment };
+  return { shipment, moveDocuments };
 };
 
 const mapDispatchToProps = dispatch => ({
   onDidMount: shipmentId => {
     dispatch(loadShipmentDependencies(shipmentId));
+    dispatch(getAllShipmentDocuments(getShipmentDocumentsLabel, shipmentId));
   },
 });
 

--- a/src/scenes/TransportationServiceProvider/DocumentViewerContainer.jsx
+++ b/src/scenes/TransportationServiceProvider/DocumentViewerContainer.jsx
@@ -5,6 +5,7 @@ import {
   getAllShipmentDocuments,
   getShipmentDocumentsLabel,
 } from 'shared/Entities/modules/shipmentDocuments';
+import { stringifyName } from 'shared/utils/serviceMember';
 
 const mapStateToProps = (state, ownProps) => {
   const { shipmentId } = ownProps.match.params;
@@ -13,12 +14,8 @@ const mapStateToProps = (state, ownProps) => {
     entities: { moveDocuments = {}, uploads = {} },
   } = state;
   const { locator: moveLocator } = move;
-  const {
-    edipi = '',
-    last_name: lastName = '',
-    first_name: firstName = '',
-  } = serviceMember;
-  const name = [lastName, firstName].filter(name => !!name).join(', ');
+  const { edipi = '' } = serviceMember;
+  const name = stringifyName(serviceMember);
 
   return {
     documentDetailUrlPrefix: `/shipments/${shipmentId}/documents`,

--- a/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
+++ b/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
@@ -15,6 +15,7 @@ import { SwaggerField } from 'shared/JsonSchemaForm/JsonSchemaField';
 import {
   getAllShipmentDocuments,
   selectShipmentDocuments,
+  getShipmentDocumentsLabel,
 } from 'shared/Entities/modules/shipmentDocuments';
 
 import FontAwesomeIcon from '@fortawesome/react-fontawesome';
@@ -110,7 +111,6 @@ let DeliveryDateForm = props => {
 
 DeliveryDateForm = reduxForm({ form: 'deliver_shipment' })(DeliveryDateForm);
 
-const getShipmentDocumentsLabel = 'Shipments.getAllShipmentDocuments';
 class ShipmentInfo extends Component {
   state = {
     redirectToHome: false,

--- a/src/scenes/TransportationServiceProvider/index.jsx
+++ b/src/scenes/TransportationServiceProvider/index.jsx
@@ -54,6 +54,10 @@ class TspWrapper extends Component {
               <Switch>
                 <Redirect from="/" to="/queues/new" exact />
                 <PrivateRoute
+                  path="/shipments/:shipmentId/documents/new"
+                  render={() => <div>Placeholder for new doc</div>}
+                />
+                <PrivateRoute
                   path="/shipments/:shipmentId/documents/:moveDocumentId"
                   component={DocumentViewer}
                 />

--- a/src/scenes/TransportationServiceProvider/index.jsx
+++ b/src/scenes/TransportationServiceProvider/index.jsx
@@ -8,7 +8,6 @@ import { bindActionCreators } from 'redux';
 import TspHeader from 'shared/Header/Tsp';
 import QueueList from './QueueList';
 import QueueTable from './QueueTable';
-import ShipmentInfo from './ShipmentInfo';
 import { loadLoggedInUser } from 'shared/User/ducks';
 import { loadPublicSchema } from 'shared/Swagger/ducks';
 import { no_op } from 'shared/utils';
@@ -16,6 +15,8 @@ import LogoutOnInactivity from 'shared/User/LogoutOnInactivity';
 import PrivateRoute from 'shared/User/PrivateRoute';
 import ScratchPad from 'shared/ScratchPad';
 import { isProduction } from 'shared/constants';
+import ShipmentInfo from './ShipmentInfo';
+import DocumentViewer from './DocumentViewerContainer';
 
 import './tsp.css';
 
@@ -52,6 +53,10 @@ class TspWrapper extends Component {
               <LogoutOnInactivity />
               <Switch>
                 <Redirect from="/" to="/queues/new" exact />
+                <PrivateRoute
+                  path="/shipments/:shipmentId/documents/:moveDocumentId"
+                  component={DocumentViewer}
+                />
                 <PrivateRoute
                   path="/shipments/:shipmentId"
                   component={ShipmentInfo}

--- a/src/shared/DocumentViewer/MoveDocumentView.jsx
+++ b/src/shared/DocumentViewer/MoveDocumentView.jsx
@@ -1,32 +1,103 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import DocumentContent from './DocumentContent';
+import DocumentList from './DocumentList';
+import DocumentDetailPanel from './DocumentDetailPanel';
+import { PanelField } from 'shared/EditablePanel';
+import { Tab, Tabs, TabList, TabPanel } from 'react-tabs';
+import { Link } from 'react-router-dom';
+import FontAwesomeIcon from '@fortawesome/react-fontawesome';
+import faPlusCircle from '@fortawesome/fontawesome-free-solid/faPlusCircle';
 
 class MoveDocumentView extends Component {
   componentDidMount() {
-    const {
-      onDidMount,
-      match: {
-        params: { shipmentId },
-      },
-    } = this.props;
-    onDidMount(shipmentId);
+    const { onDidMount } = this.props;
+    onDidMount();
   }
 
   render() {
-    const { moveDocuments, shipment } = this.props;
+    const {
+      documentDetailUrlPrefix,
+      moveDocuments,
+      moveLocator,
+      newDocumentUrl,
+      serviceMember: { edipi, name },
+      uploads,
+    } = this.props;
     return (
-      <div>
-        <p>{JSON.stringify(shipment)}</p>
-        <p>{JSON.stringify(moveDocuments)}</p>
+      <div className="usa-grid doc-viewer">
+        <div className="usa-width-two-thirds">
+          <div className="tab-content">
+            <div className="document-contents">
+              {uploads.map(({ url, filename, content_type }) => (
+                <DocumentContent
+                  key={url}
+                  url={url}
+                  filename={filename}
+                  contentType={content_type}
+                />
+              ))}
+            </div>
+          </div>
+        </div>
+        <div className="usa-width-one-third">
+          <h3>{name}</h3>
+          <PanelField title="Move Locator">{moveLocator}</PanelField>
+          <PanelField title="DoD ID">{edipi}</PanelField>
+          <div className="tab-content">
+            <Tabs defaultIndex={0}>
+              <TabList className="doc-viewer-tabs">
+                <Tab className="title nav-tab">
+                  All Documents ({moveDocuments.length})
+                </Tab>
+                <Tab className="title nav-tab">Details</Tab>
+              </TabList>
+
+              <TabPanel>
+                <div className="pad-ns">
+                  <span className="status">
+                    <FontAwesomeIcon
+                      className="icon link-blue"
+                      icon={faPlusCircle}
+                    />
+                  </span>
+                  <Link to={newDocumentUrl}>Upload new document</Link>
+                </div>
+                <div>
+                  {' '}
+                  <DocumentList
+                    detailUrlPrefix={documentDetailUrlPrefix}
+                    moveDocuments={moveDocuments}
+                  />
+                </div>
+              </TabPanel>
+
+              <TabPanel>
+                <DocumentDetailPanel
+                  className="document-viewer"
+                  moveDocumentId={moveDocumentId}
+                  title=""
+                />
+              </TabPanel>
+            </Tabs>
+          </div>
+        </div>
       </div>
     );
   }
 }
 
 MoveDocumentView.propTypes = {
+  documentDetailUrlPrefix: PropTypes.string.isRequired,
   moveDocuments: PropTypes.array.isRequired,
+  moveLocator: PropTypes.string.isRequired,
+  newDocumentUrl: PropTypes.string.isRequired,
   onDidMount: PropTypes.func.isRequired,
-  shipment: PropTypes.object.isRequired,
+  serviceMember: PropTypes.shape({
+    edipi: PropTypes.string.isRequired,
+    name: PropTypes.string.isRequired,
+  }),
+  uploads: PropTypes.array.isRequired,
 };
 
 export default MoveDocumentView;

--- a/src/shared/DocumentViewer/MoveDocumentView.jsx
+++ b/src/shared/DocumentViewer/MoveDocumentView.jsx
@@ -13,12 +13,18 @@ class MoveDocumentView extends Component {
   }
 
   render() {
-    const { shipment } = this.props;
-    return <div>{JSON.stringify(shipment)}</div>;
+    const { moveDocuments, shipment } = this.props;
+    return (
+      <div>
+        <p>{JSON.stringify(shipment)}</p>
+        <p>{JSON.stringify(moveDocuments)}</p>
+      </div>
+    );
   }
 }
 
 MoveDocumentView.propTypes = {
+  moveDocuments: PropTypes.array.isRequired,
   onDidMount: PropTypes.func.isRequired,
   shipment: PropTypes.object.isRequired,
 };

--- a/src/shared/DocumentViewer/MoveDocumentView.jsx
+++ b/src/shared/DocumentViewer/MoveDocumentView.jsx
@@ -8,6 +8,7 @@ import { Tab, Tabs, TabList, TabPanel } from 'react-tabs';
 import { Link } from 'react-router-dom';
 import FontAwesomeIcon from '@fortawesome/react-fontawesome';
 import faPlusCircle from '@fortawesome/fontawesome-free-solid/faPlusCircle';
+import './index.css';
 
 class MoveDocumentView extends Component {
   componentDidMount() {

--- a/src/shared/DocumentViewer/MoveDocumentView.jsx
+++ b/src/shared/DocumentViewer/MoveDocumentView.jsx
@@ -1,0 +1,26 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+
+class MoveDocumentView extends Component {
+  componentDidMount() {
+    const {
+      onDidMount,
+      match: {
+        params: { shipmentId },
+      },
+    } = this.props;
+    onDidMount(shipmentId);
+  }
+
+  render() {
+    const { shipment } = this.props;
+    return <div>{JSON.stringify(shipment)}</div>;
+  }
+}
+
+MoveDocumentView.propTypes = {
+  onDidMount: PropTypes.func.isRequired,
+  shipment: PropTypes.object.isRequired,
+};
+
+export default MoveDocumentView;

--- a/src/shared/DocumentViewer/MoveDocumentView.jsx
+++ b/src/shared/DocumentViewer/MoveDocumentView.jsx
@@ -2,7 +2,6 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import DocumentContent from './DocumentContent';
 import DocumentList from './DocumentList';
-import DocumentDetailPanel from './DocumentDetailPanel';
 import { PanelField } from 'shared/EditablePanel';
 import { Tab, Tabs, TabList, TabPanel } from 'react-tabs';
 import { Link } from 'react-router-dom';
@@ -74,11 +73,7 @@ class MoveDocumentView extends Component {
               </TabPanel>
 
               <TabPanel>
-                <DocumentDetailPanel
-                  className="document-viewer"
-                  moveDocumentId={moveDocumentId}
-                  title=""
-                />
+                <p>Placeholder for document details</p>
               </TabPanel>
             </Tabs>
           </div>

--- a/src/shared/DocumentViewer/MoveDocumentView.test.jsx
+++ b/src/shared/DocumentViewer/MoveDocumentView.test.jsx
@@ -136,19 +136,5 @@ describe('MoveDocumentView', () => {
           .text(),
       ).toEqual('Details');
     });
-
-    it('renders the DocumentDetailPanel with the appropriate props', () => {
-      const moveDocumentId = '123-456-789';
-      const documentView = renderMoveDocumentView({ moveDocumentId });
-      const documentDetailPanel = documentView
-        .find('TabPanel')
-        .at(1)
-        .find('Connect(ReduxForm)');
-      expect(documentDetailPanel.prop('className')).toEqual('document-viewer');
-      expect(documentDetailPanel.prop('moveDocumentId')).toEqual(
-        moveDocumentId,
-      );
-      expect(documentDetailPanel.prop('title')).toEqual('');
-    });
   });
 });

--- a/src/shared/DocumentViewer/MoveDocumentView.test.jsx
+++ b/src/shared/DocumentViewer/MoveDocumentView.test.jsx
@@ -1,0 +1,154 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import MoveDocumentView from './MoveDocumentView';
+
+describe('MoveDocumentView', () => {
+  it('calls onDidMount when the component mounts', () => {
+    const onDidMountSpy = jest.fn();
+    const documentView = shallow(
+      <MoveDocumentView
+        documentDetailUrlPrefix=""
+        moveDocumentId=""
+        moveDocuments={[]}
+        moveLocator=""
+        newDocumentUrl=""
+        onDidMount={onDidMountSpy}
+        serviceMember={{ name: '', edipi: '' }}
+        uploads={[]}
+      />,
+    );
+    expect(onDidMountSpy).toBeCalled();
+  });
+
+  const renderMoveDocumentView = ({
+    documentDetailUrlPrefix = '',
+    moveDocumentId = '',
+    moveDocuments = [],
+    moveLocator = '',
+    newDocumentUrl = '',
+    serviceMember = { name: '', edipi: '' },
+    uploads = [],
+  }) =>
+    shallow(
+      <MoveDocumentView
+        documentDetailUrlPrefix={documentDetailUrlPrefix}
+        moveDocumentId={moveDocumentId}
+        moveDocuments={moveDocuments}
+        moveLocator={moveLocator}
+        newDocumentUrl={newDocumentUrl}
+        onDidMount={() => {}}
+        serviceMember={serviceMember}
+        uploads={uploads}
+      />,
+      { disableLifecycleMethods: true },
+    );
+
+  it('renders DocumentContent for each upload', () => {
+    const uploads = [
+      { url: 'http://test.pdf', filename: 'test.pdf', content_type: 'PDF' },
+      { url: 'http://test2.pdf', filename: 'test2.pdf', content_type: 'PDF' },
+    ];
+
+    const documentView = renderMoveDocumentView({ uploads });
+    expect(documentView.find('DocumentContent').length).toEqual(2);
+  });
+
+  it('renders the service member name', () => {
+    const name = 'Doe, Jane';
+    const serviceMember = { name, edipi: '' };
+    const documentView = renderMoveDocumentView({ serviceMember });
+    expect(
+      documentView
+        .find('.usa-width-one-third')
+        .find('h3')
+        .text(),
+    ).toEqual(name);
+  });
+
+  it('renders the move locator', () => {
+    const moveLocator = 'FBXY3M';
+    const documentView = renderMoveDocumentView({ moveLocator });
+    expect(
+      documentView.find({ title: 'Move Locator' }).prop('children'),
+    ).toEqual(moveLocator);
+  });
+
+  it('renders the serviceMember edipi', () => {
+    const edipi = '999999999';
+    const serviceMember = { edipi, name: '' };
+    const documentView = renderMoveDocumentView({ serviceMember });
+    expect(documentView.find({ title: 'DoD ID' }).prop('children')).toEqual(
+      edipi,
+    );
+  });
+
+  describe('All Documents tab', () => {
+    const moveDocument = { id: '', status: '', title: '' };
+    const moveDocuments = [moveDocument, moveDocument, moveDocument];
+
+    it('renders the All Documents tab header', () => {
+      const documentView = renderMoveDocumentView({ moveDocuments });
+      expect(
+        documentView
+          .find('Tab')
+          .at(0)
+          .dive()
+          .text(),
+      ).toEqual('All Documents (3)');
+    });
+
+    it('has a link to upload a new document', () => {
+      const newDocumentUrl = 'test-url-new';
+      const documentView = renderMoveDocumentView({ newDocumentUrl });
+      const newDocumentLink = documentView
+        .find('TabPanel')
+        .at(0)
+        .find('Link');
+      expect(newDocumentLink.prop('to')).toEqual(newDocumentUrl);
+      expect(newDocumentLink.prop('children')).toEqual('Upload new document');
+    });
+
+    it('renders a DocumentList with the appropriate props', () => {
+      const documentDetailUrlPrefix = 'test-doc-prefix';
+      const documentView = renderMoveDocumentView({
+        documentDetailUrlPrefix,
+        moveDocuments,
+      });
+      const documentList = documentView
+        .find('TabPanel')
+        .at(0)
+        .find('DocumentList');
+      expect(documentList.prop('detailUrlPrefix')).toEqual(
+        documentDetailUrlPrefix,
+      );
+      expect(documentList.prop('moveDocuments')).toEqual(moveDocuments);
+    });
+  });
+
+  describe('Details tab', () => {
+    it('renders the Details tab', () => {
+      const documentView = renderMoveDocumentView({});
+      expect(
+        documentView
+          .find('Tab')
+          .at(1)
+          .dive()
+          .text(),
+      ).toEqual('Details');
+    });
+
+    it('renders the DocumentDetailPanel with the appropriate props', () => {
+      const moveDocumentId = '123-456-789';
+      const documentView = renderMoveDocumentView({ moveDocumentId });
+      const documentDetailPanel = documentView
+        .find('TabPanel')
+        .at(1)
+        .find('Connect(ReduxForm)');
+      expect(documentDetailPanel.prop('className')).toEqual('document-viewer');
+      expect(documentDetailPanel.prop('moveDocumentId')).toEqual(
+        moveDocumentId,
+      );
+      expect(documentDetailPanel.prop('title')).toEqual('');
+    });
+  });
+});

--- a/src/shared/DocumentViewer/index.css
+++ b/src/shared/DocumentViewer/index.css
@@ -1,0 +1,40 @@
+.doc-viewer .doc-viewer-tabs {
+  border-bottom: 1px solid #d7d7d7;
+  width: 100%;
+  margin-top: 2em;
+  position: relative;
+  left: -1.5em;
+  padding-left: 1.5em;
+}
+
+.doc-viewer .nav-tab {
+  display: inline-block;
+  font-weight: bold;
+  color: #5b616b;
+  border-bottom: 6px solid #fff;
+  margin-right: 1.5em;
+  margin-bottom: 0;
+  cursor: pointer;
+  text-decoration: none;
+}
+.doc-viewer .react-tabs__tab-list {
+  padding-left: 0;
+}
+.doc-viewer .react-tabs__tab--selected {
+  color: black;
+  border-bottom-color: #0070bd;
+  cursor: auto;
+}
+
+.doc-viewer .tab-content {
+  border-top: none;
+}
+
+.doc-viewer .tab-content a {
+  text-decoration: none;
+  color: #0071bc;
+}
+
+.pad-ns {
+  padding: 2rem 0rem 2rem 0rem;
+}

--- a/src/shared/Entities/modules/shipmentDocuments.js
+++ b/src/shared/Entities/modules/shipmentDocuments.js
@@ -12,3 +12,5 @@ export function getAllShipmentDocuments(label, shipmentId) {
 
 export const selectShipmentDocuments = state =>
   Object.values(state.entities.moveDocuments);
+
+export const getShipmentDocumentsLabel = 'Shipments.getAllShipmentDocuments';

--- a/src/shared/utils/serviceMember.js
+++ b/src/shared/utils/serviceMember.js
@@ -1,0 +1,2 @@
+export const stringifyName = ({ first_name: firstName, last_name: lastName }) =>
+  [lastName, firstName].filter(name => !!name).join(', ');

--- a/src/shared/utils/serviceMember.test.js
+++ b/src/shared/utils/serviceMember.test.js
@@ -1,0 +1,37 @@
+import { stringifyName } from './serviceMember';
+
+describe('serviceMember utils', () => {
+  describe('stringifyName', () => {
+    describe('when first and last name are not null', () => {
+      it('returns last name and first name separated by a comma', () => {
+        const first_name = 'Jane';
+        const last_name = 'Smith';
+        expect(stringifyName({ first_name, last_name })).toEqual('Smith, Jane');
+      });
+    });
+
+    describe('when first name is null and last name is not null', () => {
+      it('returns just the last name', () => {
+        const first_name = null;
+        const last_name = 'Smith';
+        expect(stringifyName({ first_name, last_name })).toEqual('Smith');
+      });
+    });
+
+    describe('when first name is not null and last name is null', () => {
+      it('returns just the first name', () => {
+        const first_name = 'Jane';
+        const last_name = null;
+        expect(stringifyName({ first_name, last_name })).toEqual('Jane');
+      });
+    });
+
+    describe('when both first and last name are null', () => {
+      it('returns an empty string', () => {
+        const first_name = '';
+        const last_name = '';
+        expect(stringifyName({ first_name, last_name })).toEqual('');
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Description

Add a new document viewer page on the TSP side of the app

## Reviewer Notes

- Need to add the `DocumentDetailPanel` in order for this page to be fully functioning. The existing panel won't let us hide the edit view and still a bit too tightly coupled to the office side of the app.
- Why are the doc titles repeating? Need to investigate why the API is returning bunk data.

## Code Review Verification Steps

* [x] End to end tests pass (`make e2e_test`).
* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/160112121) for this change
* [Pivotal story](https://www.pivotaltracker.com/n/projects/2181745/stories/160605623) for this change

## Screenshots
<img width="1672" alt="screen shot 2018-09-26 at 5 06 39 pm" src="https://user-images.githubusercontent.com/4434681/46116000-a0bcd400-c1ae-11e8-8a9a-900f223153c2.png">
