### PR TITLE
Accessorial Model and MIgration

### DIFF
--- a/migrations/20180925065510_create-accessorials-table.down.fizz
+++ b/migrations/20180925065510_create-accessorials-table.down.fizz
@@ -1,0 +1,1 @@
+drop_table("accessorials")

--- a/migrations/20180925065510_create-accessorials-table.up.fizz
+++ b/migrations/20180925065510_create-accessorials-table.up.fizz
@@ -1,0 +1,10 @@
+create_table("accessorials") {
+	t.Column("id", "uuid", {"primary": true})
+	t.Column("shipment_id", "uuid", {})
+	t.Column("code", "string", {})
+	t.Column("location", "string", {})
+	t.Column("quantity", "integer", {})
+	t.Column("notes", "text", {})
+	t.Column("status", "string", {})
+	t.ForeignKey("shipment_id", {"shipments": ["id"]}, {"on_delete": "restrict"})
+}

--- a/migrations/20180925065510_create-accessorials-table.up.fizz
+++ b/migrations/20180925065510_create-accessorials-table.up.fizz
@@ -6,5 +6,7 @@ create_table("accessorials") {
 	t.Column("quantity", "integer", {})
 	t.Column("notes", "text", {})
 	t.Column("status", "string", {})
+	t.Column("submitted_date", "datetime", {})
+	t.Column("approved_date", "datetime", {})
 	t.ForeignKey("shipment_id", {"shipments": ["id"]}, {"on_delete": "restrict"})
 }

--- a/pkg/models/accessorial.go
+++ b/pkg/models/accessorial.go
@@ -1,0 +1,76 @@
+package models
+
+import (
+	"time"
+
+	"github.com/gobuffalo/pop"
+	"github.com/gobuffalo/uuid"
+	"github.com/pkg/errors"
+	"github.com/transcom/mymove/pkg/unit"
+)
+
+// AccessorialStatus represents the status of an accessorial's lifecycle
+type AccessorialStatus string
+
+// AccessorialLocation represents the location of the accessorial item
+type AccessorialLocation string
+
+const (
+	// AccessorialStatusSUBMITTED captures enum value "SUBMITTED"
+	AccessorialStatusSUBMITTED AccessorialStatus = "SUBMITTED"
+	// AccessorialStatusAPPROVED captures enum value "APPROVED"
+	AccessorialStatusAPPROVED AccessorialStatus = "APPROVED"
+	// AccessorialStatusINVOICED captures enum value "INVOICED"
+	AccessorialStatusINVOICED AccessorialStatus = "INVOICED"
+
+	// AccessorialLocationORIGIN captures enum value "ORIGIN"
+	AccessorialLocationORIGIN AccessorialLocation = "ORIGIN"
+	// AccessorialLocationDESTINATION captures enum value "DESTINATION"
+	AccessorialLocationDESTINATION AccessorialLocation = "DESTINATION"
+	// AccessorialLocationNEITHER captures enum value "NEITHER"
+	AccessorialLocationNEITHER AccessorialLocation = "NEITHER"
+)
+
+// Accessorial is an object representing an accessorial item in a pre-approval request
+type Accessorial struct {
+	ID         uuid.UUID `json:"id" db:"id"`
+	ShipmentID uuid.UUID `json:"shipment_id" db:"shipment_id"`
+
+	//Code and Item description are linked, how should we store that information? What gets stored in the database?
+	//for now, code is a string. It will become a reference to code table once that is designed.
+	Code     string              `json:"code" db:"code"`
+	Location AccessorialLocation `json:"location" db:"location"`
+
+	// Enter numbers only, no symbols or units. Examples:
+	// Crating: enter "47.4" for crate size of 47.4 cu. ft.
+	// 3rd-party service: enter "1299.99" for cost of $1,299.99.
+	// Bulky item: enter "1" for a single item.
+
+	Quantity      unit.BaseQuantity `json:"quantity" db:"quantity"`
+	Notes         string            `json:"notes" db:"notes"`
+	Status        AccessorialStatus `json:"status" db:"status"`
+	SubmittedDate time.Time         `json:"submitted_date" db:"submitted_date"`
+	ApprovedDate  time.Time         `json:"approved_date" db:"approved_date"`
+	CreatedAt     time.Time         `json:"created_at" db:"created_at"`
+	UpdatedAt     time.Time         `json:"updated_at" db:"updated_at"`
+}
+
+// FetchAccessorialsByShipmentID returns a list of accessorials by shipment_id
+func FetchAccessorialsByShipmentID(dbConnection *pop.Connection, shipmentID *uuid.UUID) ([]Accessorial, error) {
+	var err error
+
+	if shipmentID == nil {
+		return nil, errors.Wrap(err, "Missing shipmentID")
+	}
+
+	accessorials := []Accessorial{}
+
+	query := dbConnection.Where("shipment_id = ?", *shipmentID)
+
+	err = query.All(&accessorials)
+	if err != nil {
+		return accessorials, errors.Wrap(err, "Accessorials query failed")
+	}
+
+	return accessorials, err
+}

--- a/pkg/models/accessorial_test.go
+++ b/pkg/models/accessorial_test.go
@@ -1,0 +1,22 @@
+package models_test
+
+import (
+	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/testdatagen"
+)
+
+func (suite *ModelSuite) TestFetchAccessorial() {
+	//Setup
+	accessorial := testdatagen.MakeDefaultAccessorial(suite.db)
+	//make more items that don't relate to the first
+	testdatagen.MakeDefaultAccessorial(suite.db)
+	testdatagen.MakeDefaultAccessorial(suite.db)
+
+	//Do
+	accs, err := models.FetchAccessorialsByShipmentID(suite.db, &accessorial.ShipmentID)
+
+	//Test
+	suite.NoError(err)
+	suite.Equal(1, len(accs))
+	suite.Equal(accessorial.ID, accs[0].ID)
+}

--- a/pkg/testdatagen/make_accessorial_records.go
+++ b/pkg/testdatagen/make_accessorial_records.go
@@ -1,0 +1,40 @@
+package testdatagen
+
+import (
+	"time"
+
+	"github.com/gobuffalo/pop"
+	"github.com/transcom/mymove/pkg/models"
+)
+
+// MakeAccessorial creates a single accessorial record
+func MakeAccessorial(db *pop.Connection, assertions Assertions) models.Accessorial {
+	shipment := MakeShipment(db, assertions)
+
+	//filled in dummy data
+	accessorial := models.Accessorial{
+		ShipmentID: shipment.ID,
+		Code: "105B	Pack Reg Crate",
+		Location: models.AccessorialLocationDESTINATION,
+		// ToDo: FIND OUT IF WE HAVE A TEXT SANITIZER
+		Notes:         "Mounted deer head measures 23\" x 34\" x 27\"; crate will be 16.7 cu ft",
+		Quantity:      1670,
+		Status:        models.AccessorialStatusSUBMITTED,
+		SubmittedDate: time.Now(),
+		ApprovedDate:  time.Now(),
+		CreatedAt:     time.Now(),
+		UpdatedAt:     time.Now(),
+	}
+
+	// Overwrite values with those from assertions
+	mergeModels(&accessorial, assertions.Accessorial)
+
+	mustCreate(db, &accessorial)
+
+	return accessorial
+}
+
+// MakeDefaultAccessorial makes an Accessorial with default values
+func MakeDefaultAccessorial(db *pop.Connection) models.Accessorial {
+	return MakeAccessorial(db, Assertions{})
+}

--- a/pkg/testdatagen/shared.go
+++ b/pkg/testdatagen/shared.go
@@ -20,6 +20,7 @@ import (
 
 // Assertions defines assertions about what the data contains
 type Assertions struct {
+	Accessorial                              models.Accessorial
 	Address                                  models.Address
 	BackupContact                            models.BackupContact
 	BlackoutDate                             models.BlackoutDate

--- a/pkg/unit/base_quantity.go
+++ b/pkg/unit/base_quantity.go
@@ -1,0 +1,57 @@
+package unit
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+)
+
+// BaseQuantity represents a value in the 10,000ths of a unit measurement for accessorial items.
+// Eg. 10000 BQ = 1.0000 unit or 1 BQ = .0001
+// A unit of measurement can be below or more:
+// BW = Net Billing Weight
+// CF = Cubic Foot
+// EA = Each
+// FR = Flat Rate
+// FP = Fuel Percentage
+// NR = Container
+// MV = Monetary Value
+// TD = Days
+// TH = Hours
+type BaseQuantity int
+
+// String returns the value of self as string
+func (bq BaseQuantity) String() string {
+	return strconv.Itoa(int(bq))
+}
+
+// ToUnitFloatString returns a unit string representation of this value
+// Eg. 10000 BQ -> "1.0000"
+func (bq BaseQuantity) ToUnitFloatString() string {
+	d := float64(bq) / 10000.0
+	s := fmt.Sprintf("%.4f", d)
+	return s
+}
+
+// ToUnitDollarString returns a dollar string representation of this value
+func (bq BaseQuantity) ToUnitDollarString() string {
+	// drop the numbers after two decimal points to make sure Sprintf doesn't round up
+	// then convert to dollars
+	d := math.Floor(float64(bq)/100.0) / 100.0
+	s := fmt.Sprintf("$%.2f", d)
+	return s
+}
+
+// ToUnitInt returns a unit int representation of this value
+// Eg. 10000 BQ -> 1
+func (bq BaseQuantity) ToUnitInt() int {
+	d := float64(bq) / 10000.0
+	return int(d)
+}
+
+// ToUnitFloat returns a unit float representation of this value
+// Eg. 10000 BQ -> 1.0000
+func (bq BaseQuantity) ToUnitFloat() float64 {
+	d := float64(bq) / 10000.0
+	return d
+}

--- a/pkg/unit/base_quantity_test.go
+++ b/pkg/unit/base_quantity_test.go
@@ -1,0 +1,55 @@
+package unit
+
+import (
+	"testing"
+)
+
+func TestStringConversion(t *testing.T) {
+	BaseQuantity := BaseQuantity(10000)
+	result := BaseQuantity.String()
+
+	expected := "10000"
+	if result != expected {
+		t.Errorf("wrong string of BaseQuantity: expected %s, got %s", expected, result)
+	}
+}
+
+func TestToUnitString(t *testing.T) {
+	BaseQuantity := BaseQuantity(19999999)
+	result := BaseQuantity.ToUnitFloatString()
+
+	expected := "1999.9999"
+	if result != expected {
+		t.Errorf("wrong string of BaseQuantity: expected %s, got %s", expected, result)
+	}
+}
+
+func TestToUnitFloat64(t *testing.T) {
+	BaseQuantity := BaseQuantity(199999)
+	result := BaseQuantity.ToUnitFloat()
+
+	expected := float64(19.9999)
+	if result != expected {
+		t.Errorf("wrong number of BaseQuantity: expected %.4f, got %.4f", expected, result)
+	}
+}
+
+func TestToUnitInt(t *testing.T) {
+	BaseQuantity := BaseQuantity(19999)
+	result := BaseQuantity.ToUnitInt()
+
+	expected := 1
+	if result != expected {
+		t.Errorf("wrong number of BaseQuantity: expected %d, got %d", expected, result)
+	}
+}
+
+func TestToUnitDollarString(t *testing.T) {
+	BaseQuantity := BaseQuantity(19999999)
+	result := BaseQuantity.ToUnitDollarString()
+
+	expected := "$1999.99"
+	if result != expected {
+		t.Errorf("wrong string of BaseQuantity: expected %s, got %s", expected, result)
+	}
+}


### PR DESCRIPTION
## Description

This PR creates a new `accessorials` table and model to represent pre-approve/invoice items.

## Reviewer Notes

- Noticed `created_at` and `updated_at` were created automatically using the fizz syntax. Wondering if I should just remove the `submitted_date` column?
- Only added a fetcher for the accessorial, should I add a create as well?
- Added a few functions in the new `BaseQuantity` type that I thought we would need later. Missing anything?

## Setup

```sh
make db_dev_migrate
make server_build
```

## Code Review Verification Steps

* [ ] End to end tests pass (`make e2e_test`).
* [ ] Code follows the guidelines for [Logging](./docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](./docs/backend.md#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Update the diagram in docs/schema/dp3.sqs (see [Updating and changing the model](./docs/schema/README.md#updating-and-changing-the-model))
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](./docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
* [ ] There are no aXe warnings for UI.
* [ ] This works in IE.
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @willowbl00
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/160704846) for this change