### PR TITLE
Add HERE planner to generate_shipment_edi [delivers #160352575]

### DIFF
--- a/cmd/generate_shipment_edi/main.go
+++ b/cmd/generate_shipment_edi/main.go
@@ -50,7 +50,7 @@ func main() {
 		log.Fatal(err)
 	}
 	if len(shipments) == 0 {
-		log.Fatal("No accepted shipments found")
+		log.Fatal("No shipments with accepted shipment offers found")
 	}
 	var logger = zap.NewNop()
 	planner := route.NewHEREPlanner(logger, hereGeoEndpoint, hereRouteEndpoint, hereAppID, hereAppCode)

--- a/cmd/generate_shipment_edi/main.go
+++ b/cmd/generate_shipment_edi/main.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"flag"
 	"fmt"
+	"github.com/namsral/flag"
 	"log"
 
 	"github.com/gobuffalo/pop"
@@ -18,6 +18,10 @@ import (
 func main() {
 	moveIDString := flag.String("moveID", "", "The ID of the move where shipments are found")
 	env := flag.String("env", "development", "The environment to run in, which configures the database.")
+	hereGeoEndpoint := flag.String("here_maps_geocode_endpoint", "", "URL for the HERE maps geocoder endpoint")
+	hereRouteEndpoint := flag.String("here_maps_routing_endpoint", "", "URL for the HERE maps routing endpoint")
+	hereAppID := flag.String("here_maps_app_id", "", "HERE maps App ID for this application")
+	hereAppCode := flag.String("here_maps_app_code", "", "HERE maps App API code")
 	flag.Parse()
 
 	if *moveIDString == "" {
@@ -49,10 +53,10 @@ func main() {
 		log.Fatal("No accepted shipments found")
 	}
 	var logger = zap.NewNop()
-
+	planner := route.NewHEREPlanner(logger, hereGeoEndpoint, hereRouteEndpoint, hereAppID, hereAppCode)
 	var costsByShipments []rateengine.CostByShipment
 
-	engine := rateengine.NewRateEngine(db, logger, route.NewTestingPlanner(362)) //TODO: create the proper route/planner
+	engine := rateengine.NewRateEngine(db, logger, planner)
 	for _, shipment := range shipments {
 		costByShipment, err := engine.HandleRunOnShipment(shipment)
 		if err != nil {


### PR DESCRIPTION
## Description

This adds a HERE planner inside the generate_shipment_edi command, replacing the test planner.

## Setup

1. run `make db_dev_reset && make db_dev_migrate && go run ./cmd/generate_test_data/main.go  -scenario=7`
2. Get the moveID of a move that has a shipment in the "accepted" state (actually the shipmentOffer).  (Note that for some reason the moves in the delivered or completed states aren't working for this- data issue)
3. run `go run cmd/generate_shipment_edi/main.go --moveID <UUID>`

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](./docs/backend.md#logging)
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/160352575) for this change
