### PR TITLE
Bug fix: don't replace the queue table with the results of the most recent request to return

### DIFF
--- a/src/scenes/TransportationServiceProvider/QueueTable.jsx
+++ b/src/scenes/TransportationServiceProvider/QueueTable.jsx
@@ -28,21 +28,28 @@ class QueueTable extends Component {
   }
 
   async fetchData() {
+    const loadingQueueType = this.props.queueType;
+
     this.setState({
       data: [],
       pages: null,
       loading: true,
+      loadingQueue: loadingQueueType,
     });
 
     // Catch any errors here and render an empty queue
     try {
       const body = await RetrieveShipmentsForTSP(this.props.queueType);
 
-      this.setState({
-        data: body,
-        pages: 1,
-        loading: false,
-      });
+      // Only update the queue list if the request that is returning
+      // is for the same queue as the most recent request.
+      if (this.state.loadingQueue === loadingQueueType) {
+        this.setState({
+          data: body,
+          pages: 1,
+          loading: false,
+        });
+      }
     } catch (e) {
       this.setState({
         data: [],


### PR DESCRIPTION
## Description

We were seeing an intermittent bug in UI tests where a queue would be clicked but would display the table from the old queue. There was a race condition because our code for fetching data for the queue table setState whenever a request completed, regardless of the order the requests were created. 

## Reviewer Notes

What will this look like when we move this to redux?

## Code Review Verification Steps

* [ ] End to end tests pass (`make e2e_test`).
* [ ] Code follows the guidelines for [Logging](./docs/backend.md#logging)
* [ ] There are no aXe warnings for UI.
* [ ] This works in IE.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/160675681) for this change
