### PR TITLE
Fixing the GBL test

### DIFF
--- a/cypress/integration/tsp/generateGBL.js
+++ b/cypress/integration/tsp/generateGBL.js
@@ -36,12 +36,17 @@ function tspUserGeneratesGBL() {
 
   // If clicked too soon, there's a server error
   cy.wait(500);
+
   cy
     .get('button')
     .contains('Generate Bill of Lading')
     .click();
 
-  cy.get('.usa-alert-success').contains('GBL generated successfully.');
+  // I have seen this take anywhere from 8s - 18s. Until we optimize it, giving the test a long
+  // timeout.
+  cy
+    .get('.usa-alert-success', { timeout: 20000 })
+    .contains('GBL generated successfully.');
 
   cy
     .get('button')

--- a/cypress/integration/tsp/generateGBL.js
+++ b/cypress/integration/tsp/generateGBL.js
@@ -41,10 +41,7 @@ function tspUserGeneratesGBL() {
     .contains('Generate Bill of Lading')
     .click();
 
-  cy
-    .get('div')
-    .get('p')
-    .contains('GBL generated successfully.');
+  cy.get('.usa-alert-success').contains('GBL generated successfully.');
 
   cy
     .get('button')
@@ -52,7 +49,6 @@ function tspUserGeneratesGBL() {
     .click();
 
   cy
-    .get('div')
-    .get('p')
+    .get('.usa-alert-warning')
     .contains('There is already a GBL for this shipment. ');
 }


### PR DESCRIPTION
## Description

The TSP's "GenerateGBL" E2E test was failing to run. I found 2 problems:

1. The locator for the Success/Error messages was not correct.
2. The GBL generation can take longer than the given timeout.

I fixed the locator, and increased the timeout to 20s, a few seconds longer than the longest run I've seen it take in my dev environment (18s.)

Test failure screenshot:
![screen shot 2018-09-27 at 5 59 24 pm](https://user-images.githubusercontent.com/859429/46182579-9e777a00-c281-11e8-90a1-ab644f76c705.png)


* [ ] End to end tests pass (`make e2e_test`)