### PR TITLE
Fix off-by-one error with unavailable dates endpoint

### DIFF
--- a/pkg/handlers/internalapi/calendar.go
+++ b/pkg/handlers/internalapi/calendar.go
@@ -15,15 +15,19 @@ type ShowUnavailableMoveDatesHandler struct {
 
 // Handle returns the unavailable move dates.
 func (h ShowUnavailableMoveDatesHandler) Handle(params calendarop.ShowUnavailableMoveDatesParams) middleware.Responder {
-	var datesPayload []strfmt.Date
-
 	startDate := time.Time(params.StartDate)
+
+	var datesPayload []strfmt.Date
+	datesPayload = append(datesPayload, strfmt.Date(startDate)) // The start date is always unavailable.
+
 	const daysToCheck = 90
 	const shortFuseTotalDays = 5
 	daysChecked := 0
 	shortFuseDaysFound := 0
 
-	for d := startDate; daysChecked < daysToCheck; d = d.AddDate(0, 0, 1) {
+	// TODO: Handle holidays.
+	firstPossibleDate := startDate.AddDate(0, 0, 1)
+	for d := firstPossibleDate; daysChecked < daysToCheck; d = d.AddDate(0, 0, 1) {
 		if d.Weekday() == time.Saturday || d.Weekday() == time.Sunday {
 			datesPayload = append(datesPayload, strfmt.Date(d))
 		} else if shortFuseDaysFound < shortFuseTotalDays {

--- a/pkg/handlers/internalapi/calendar_test.go
+++ b/pkg/handlers/internalapi/calendar_test.go
@@ -25,6 +25,7 @@ func (suite *HandlerSuite) TestShowUnavailableMoveDatesHandler() {
 		strfmt.Date(time.Date(2018, 9, 30, 0, 0, 0, 0, time.UTC)),
 		strfmt.Date(time.Date(2018, 10, 1, 0, 0, 0, 0, time.UTC)),
 		strfmt.Date(time.Date(2018, 10, 2, 0, 0, 0, 0, time.UTC)),
+		strfmt.Date(time.Date(2018, 10, 3, 0, 0, 0, 0, time.UTC)),
 		strfmt.Date(time.Date(2018, 10, 6, 0, 0, 0, 0, time.UTC)),
 		strfmt.Date(time.Date(2018, 10, 7, 0, 0, 0, 0, time.UTC)),
 		strfmt.Date(time.Date(2018, 10, 13, 0, 0, 0, 0, time.UTC)),


### PR DESCRIPTION
## Description

This PR fixes an off-by-one error with the unavailable move dates endpoint.  Previously, this endpoint started the 5-day "short fuse" unavailable days at the start date.  That is incorrect per the wireframe notes; instead, the "short fuse" days should start the day *after* the start date.

## Setup

`make server_run`
`make client_run`
Visit `http://localhost:3000/internal/docs` and experiment with the `unavailable_move_dates` endpoint in the `calendar` section using the Swagger UI.

## Code Review Verification Steps

* [ ] End to end tests pass (`make e2e_test`).
* [ ] Request review from a member of a different team.

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/160740528) for this change
