### PR TITLE
WIP Locations panel and Panel component

### DIFF
--- a/src/scenes/TransportationServiceProvider/Locations.jsx
+++ b/src/scenes/TransportationServiceProvider/Locations.jsx
@@ -1,27 +1,42 @@
 import React from 'react';
+import Panel from 'shared/Panel';
+import { AddressElementDisplay } from 'shared/Address';
 import PropTypes from 'prop-types';
 
-import { editablePanelify } from 'shared/EditablePanel';
-
-import { AddressElementDisplay } from 'shared/Address';
-
-const LocationsDisplay = ({ shipment }) => {
+const LocationsPanel = ({ shipment }) => {
   const {
     pickup_address,
     has_secondary_pickup_address,
     secondary_pickup_address,
   } = shipment;
   return (
-    <div className="editable-panel-column">
-      <span className="column-subhead">Pickup</span>
-      <AddressElementDisplay address={pickup_address} title="Primary" />
-      {has_secondary_pickup_address && (
-        <AddressElementDisplay
-          address={secondary_pickup_address}
-          title="Secondary"
-        />
+    <Panel>
+      {({ isEditing }) => (
+        <Panel.HalfRow>
+          <Panel.Title editLabel="Edit">Locations</Panel.Title>
+          {isEditing ? (
+            <Panel.Content>
+              <Panel.Header>Locations</Panel.Header>
+              <Panel.Subheader>Primary Address</Panel.Subheader>
+              <div>placeholder</div>
+              <Panel.CancelButton>Cancel</Panel.CancelButton>
+              <Panel.SaveButton>Save</Panel.SaveButton>
+            </Panel.Content>
+          ) : (
+            <Panel.Content>
+              <Panel.Subheader>Pickup</Panel.Subheader>
+              <AddressElementDisplay address={pickup_address} title="Primary" />
+              {has_secondary_pickup_address && (
+                <AddressElementDisplay
+                  address={secondary_pickup_address}
+                  title="Secondary"
+                />
+              )}
+            </Panel.Content>
+          )}
+        </Panel.HalfRow>
       )}
-    </div>
+    </Panel>
   );
 };
 
@@ -37,7 +52,7 @@ const address = shape({
   street_address_3: string,
 });
 
-LocationsDisplay.propTypes = {
+LocationsPanel.propTypes = {
   actual_delivery_date: string,
   actual_pickup_date: string,
   book_date: string,
@@ -79,7 +94,5 @@ LocationsDisplay.propTypes = {
   }),
   weight_estimate: number,
 };
-
-const LocationsPanel = editablePanelify(LocationsDisplay, null, false);
 
 export default LocationsPanel;

--- a/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
+++ b/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
@@ -110,6 +110,7 @@ let DeliveryDateForm = props => {
 DeliveryDateForm = reduxForm({ form: 'deliver_shipment' })(DeliveryDateForm);
 
 const getShipmentDocumentsLabel = 'Shipments.getAllShipmentDocuments';
+
 class ShipmentInfo extends Component {
   state = {
     redirectToHome: false,
@@ -241,13 +242,11 @@ class ShipmentInfo extends Component {
                       update={this.props.patchShipment}
                     />
                   </div>
-                  <div className="usa-width-one-half">
-                    <Locations
-                      title="Locations"
-                      shipment={this.props.shipment}
-                      update={this.props.patchShipment}
-                    />
-                  </div>
+                  <Locations
+                    title="Locations"
+                    shipment={this.props.shipment}
+                    update={this.props.patchShipment}
+                  />
                 </div>
               )}
             </div>

--- a/src/shared/Panel/index.jsx
+++ b/src/shared/Panel/index.jsx
@@ -1,0 +1,115 @@
+import React, { Component } from 'react';
+
+const PanelContext = React.createContext();
+
+const PanelConsumer = props => (
+  <PanelContext.Consumer {...props}>
+    {context => {
+      if (!context) {
+        throw new Error(
+          `Panel compound components cannot be rendered outside the Panel component`,
+        );
+      }
+      return props.children(context);
+    }}
+  </PanelContext.Consumer>
+);
+
+class Panel extends Component {
+  handleEditClick = () => {
+    this.setState(() => ({ isEditing: true }));
+  };
+
+  handleCancel = e => {
+    e.preventDefault();
+    this.setState(() => ({ isEditing: false }));
+  };
+
+  handleSave = e => {
+    e.preventDefault();
+  };
+
+  state = {
+    isEditing: false,
+    onEditClick: this.handleEditClick,
+    onCancel: this.handleCancel,
+    onSave: this.handleSave,
+  };
+
+  static HalfRow = ({ children }) => (
+    <div className="usa-width-one-half">{children}</div>
+  );
+
+  static Title = ({ children, editLabel, editEnabled = true }) => (
+    <PanelConsumer>
+      {({ isEditing, onEditClick, onCancel, onSave }) => (
+        <div className="editable-panel-header $">
+          <div className="title">{children}</div>
+          {editEnabled &&
+            !isEditing && (
+              <a className="editable-panel-edit" onClick={onEditClick}>
+                {editLabel}
+              </a>
+            )}
+        </div>
+      )}
+    </PanelConsumer>
+  );
+
+  static Header = ({ children }) => (
+    <div className="column-head">{children}</div>
+  );
+
+  static Subheader = ({ children }) => (
+    <div className="column-subhead">{children}</div>
+  );
+
+  static Content = ({ children }) => (
+    <div className="editable-panel-content">{children}</div>
+  );
+
+  static CancelButton = ({ children }) => (
+    <PanelConsumer>
+      {({ onCancel }) => (
+        <button
+          className="usa-button-secondary editable-panel-cancel"
+          onClick={onCancel}
+        >
+          {children}
+        </button>
+      )}
+    </PanelConsumer>
+  );
+
+  static SaveButton = ({ children }) => (
+    <PanelConsumer>
+      {({ onSave }) => (
+        <button className="usa-button editable-panel-save" onClick={onSave}>
+          {children}
+        </button>
+      )}
+    </PanelConsumer>
+  );
+
+  get getStateAndMethods() {
+    return {
+      ...this.state,
+      onEditClick: this.handleEditClick,
+      onCancel: this.handleCancel,
+      onSave: this.handleSave,
+    };
+  }
+
+  render() {
+    const { className } = this.props;
+    return (
+      <div className={`editable-panel ${className}`}>
+        <PanelContext.Provider value={this.state}>
+          {this.props.children(this.getStateAndMethods)}
+        </PanelContext.Provider>
+      </div>
+    );
+  }
+}
+
+export default Panel;


### PR DESCRIPTION
## Description

Add a locations panel to the shipment info with the pickup address and any additional addresses
 
## Reviewer Notes
- I added unit tests instead of an e2e test currently until we can have more pieces of the workflow so it provides more value
- Created a Panel component which makes use of the render props design pattern to make it more convenient to share behavior and have a more declarative api for creating a panel

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```
./bin/gen_sever.sh
make db_populate_e2e
make server_run
make tsp_client_run
```
In the database, to have an additional address:
1. Go to addresses table and choose any id
2. Go to shipments table and for a record
2a. make `has_secondary_pickup_address` true
2b. make `secondary_pickup_address_id` to be the id in the addresses table
3. Visit the shipmentID you edited in the TSP app and it should have an "Additional" field

## Code Review Verification Steps

* [x] End to end tests pass (`make e2e_test`).
* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/n/projects/2181745/stories/160733797) for this change
* [Context](https://reactjs.org/docs/context.html)
* [Render Props](https://reactjs.org/docs/render-props.html)
## Screenshots

![image](https://i.gyazo.com/4c3c6c114b315e650730e9296e53fda5.png)
![additional](https://user-images.githubusercontent.com/13622298/46220607-7f1f3200-c2ff-11e8-9078-953909d7db35.png)

