### PR TITLE
Els fix e2e and unbreak master

### DIFF
--- a/cypress/integration/mymove/shipment.js
+++ b/cypress/integration/mymove/shipment.js
@@ -17,7 +17,7 @@ describe('completing the hhg flow', function() {
     });
     // Calendar move date
     cy
-      .get('div[class="DayPicker-Day"][tabindex="0"]') // get's the 1st of the month
+      .get('.DayPicker-Day--today') // gets today
       .click()
       .should('have.class', 'DayPicker-Day--selected');
 

--- a/cypress/integration/office/incentiveCalculator.js
+++ b/cypress/integration/office/incentiveCalculator.js
@@ -8,6 +8,13 @@ describe('office user uses incentive calculator', () => {
     cy.visit('/queues/new/moves/0db80bd6-de75-439e-bf89-deaafa1d0dc8/ppm');
     // Click on PPM tab
     cy.get('.incentive-calc').within(() => {
+      cy
+        .get('input[name="planned_move_date"]')
+        .first()
+        .clear()
+        .type('9/2/2018{enter}')
+        .blur();
+
       cy.get('input[name="weight"]').type('3141');
 
       cy.get('[data-cy=calc]').click();

--- a/cypress/integration/office/incentiveCalculator.js
+++ b/cypress/integration/office/incentiveCalculator.js
@@ -1,9 +1,9 @@
 /* global cy, */
-describe('office user finds the move', () => {
+describe('office user uses incentive calculator', () => {
   beforeEach(() => {
     cy.signIntoOffice();
   });
-  it('office user uses calculator', () => {
+  it('finds calculator and executes it', () => {
     // Open move ppm tab
     cy.visit('/queues/new/moves/0db80bd6-de75-439e-bf89-deaafa1d0dc8/ppm');
     // Click on PPM tab

--- a/cypress/integration/office/storageReimbursementCalculator.js
+++ b/cypress/integration/office/storageReimbursementCalculator.js
@@ -1,9 +1,9 @@
 /* global cy, */
-describe('office user finds the move', () => {
+describe('office user uses storage reimbursement calculator', () => {
   beforeEach(() => {
     cy.signIntoOffice();
   });
-  it('office user uses calculator', () => {
+  it('finds calculator and executes it', () => {
     // Open move ppm tab
     cy.visit('/queues/new/moves/0db80bd6-de75-439e-bf89-deaafa1d0dc8/ppm');
     // Click on PPM tab

--- a/cypress/integration/office/storageReimbursementCalculator.js
+++ b/cypress/integration/office/storageReimbursementCalculator.js
@@ -8,6 +8,13 @@ describe('office user uses storage reimbursement calculator', () => {
     cy.visit('/queues/new/moves/0db80bd6-de75-439e-bf89-deaafa1d0dc8/ppm');
     // Click on PPM tab
     cy.get('.storage-calc').within(() => {
+      cy
+        .get('input[name="planned_move_date"]')
+        .first()
+        .clear()
+        .type('9/2/2018{enter}')
+        .blur();
+
       cy.get('input[name="days_in_storage"]').type('30');
       cy.get('input[name="weight"]').type('3141');
 


### PR DESCRIPTION
This should resolve tests that broke because of new month and end of peak season. I'm not super happy about testing rate engine with fixed dates--we may want to revert those changes and make sure we have current test data. But this gets master unbroken now.