### PR TITLE
Added holiday detection using calendar library

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -772,6 +772,14 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:d6b12a14e66a2ab1ef788252f0d547ad6f641a2824bf54b1af5e4109b405ff39"
+  name = "github.com/rickar/cal"
+  packages = ["."]
+  pruneopts = ""
+  revision = "dbf7e8f9712c5536d29455e1461af2227eb20692"
+
+[[projects]]
+  branch = "master"
   digest = "1:98891c206223fa262569ea196faad59d2c169de675e74796030524eea327ed7d"
   name = "github.com/ryanuber/go-glob"
   packages = ["."]
@@ -1237,6 +1245,7 @@
     "github.com/markbates/goth/providers/openidConnect",
     "github.com/namsral/flag",
     "github.com/pkg/errors",
+    "github.com/rickar/cal",
     "github.com/securego/gosec/cmd/gosec",
     "github.com/segmentio/chamber",
     "github.com/spf13/afero",

--- a/pkg/handlers/calendar.go
+++ b/pkg/handlers/calendar.go
@@ -1,0 +1,12 @@
+package handlers
+
+import "github.com/rickar/cal"
+
+// NewUSCalendar returns a new Calendar object initialized with standard US Federal Holidays.
+func NewUSCalendar() *cal.Calendar {
+	// NOTE: For now, we are returning a new calendar object for each call.  Could consider
+	// caching this in the future.
+	usCalendar := cal.NewCalendar()
+	cal.AddUsHolidays(usCalendar)
+	return usCalendar
+}

--- a/pkg/handlers/internalapi/calendar.go
+++ b/pkg/handlers/internalapi/calendar.go
@@ -25,10 +25,10 @@ func (h ShowUnavailableMoveDatesHandler) Handle(params calendarop.ShowUnavailabl
 	daysChecked := 0
 	shortFuseDaysFound := 0
 
-	// TODO: Handle holidays.
+	usCalendar := handlers.NewUSCalendar()
 	firstPossibleDate := startDate.AddDate(0, 0, 1)
 	for d := firstPossibleDate; daysChecked < daysToCheck; d = d.AddDate(0, 0, 1) {
-		if d.Weekday() == time.Saturday || d.Weekday() == time.Sunday {
+		if !usCalendar.IsWorkday(d) {
 			datesPayload = append(datesPayload, strfmt.Date(d))
 		} else if shortFuseDaysFound < shortFuseTotalDays {
 			datesPayload = append(datesPayload, strfmt.Date(d))

--- a/pkg/handlers/internalapi/calendar_test.go
+++ b/pkg/handlers/internalapi/calendar_test.go
@@ -27,6 +27,7 @@ func (suite *HandlerSuite) TestShowUnavailableMoveDatesHandler() {
 		strfmt.Date(time.Date(2018, 10, 3, 0, 0, 0, 0, time.UTC)),
 		strfmt.Date(time.Date(2018, 10, 6, 0, 0, 0, 0, time.UTC)),
 		strfmt.Date(time.Date(2018, 10, 7, 0, 0, 0, 0, time.UTC)),
+		strfmt.Date(time.Date(2018, 10, 8, 0, 0, 0, 0, time.UTC)),
 		strfmt.Date(time.Date(2018, 10, 13, 0, 0, 0, 0, time.UTC)),
 		strfmt.Date(time.Date(2018, 10, 14, 0, 0, 0, 0, time.UTC)),
 		strfmt.Date(time.Date(2018, 10, 20, 0, 0, 0, 0, time.UTC)),
@@ -37,8 +38,10 @@ func (suite *HandlerSuite) TestShowUnavailableMoveDatesHandler() {
 		strfmt.Date(time.Date(2018, 11, 4, 0, 0, 0, 0, time.UTC)),
 		strfmt.Date(time.Date(2018, 11, 10, 0, 0, 0, 0, time.UTC)),
 		strfmt.Date(time.Date(2018, 11, 11, 0, 0, 0, 0, time.UTC)),
+		strfmt.Date(time.Date(2018, 11, 12, 0, 0, 0, 0, time.UTC)),
 		strfmt.Date(time.Date(2018, 11, 17, 0, 0, 0, 0, time.UTC)),
 		strfmt.Date(time.Date(2018, 11, 18, 0, 0, 0, 0, time.UTC)),
+		strfmt.Date(time.Date(2018, 11, 22, 0, 0, 0, 0, time.UTC)),
 		strfmt.Date(time.Date(2018, 11, 24, 0, 0, 0, 0, time.UTC)),
 		strfmt.Date(time.Date(2018, 11, 25, 0, 0, 0, 0, time.UTC)),
 		strfmt.Date(time.Date(2018, 12, 1, 0, 0, 0, 0, time.UTC)),
@@ -49,6 +52,7 @@ func (suite *HandlerSuite) TestShowUnavailableMoveDatesHandler() {
 		strfmt.Date(time.Date(2018, 12, 16, 0, 0, 0, 0, time.UTC)),
 		strfmt.Date(time.Date(2018, 12, 22, 0, 0, 0, 0, time.UTC)),
 		strfmt.Date(time.Date(2018, 12, 23, 0, 0, 0, 0, time.UTC)),
+		strfmt.Date(time.Date(2018, 12, 25, 0, 0, 0, 0, time.UTC)),
 	}
 
 	showHandler := ShowUnavailableMoveDatesHandler{handlers.NewHandlerContext(suite.TestDB(), suite.TestLogger())}

--- a/pkg/handlers/internalapi/moves.go
+++ b/pkg/handlers/internalapi/moves.go
@@ -261,10 +261,10 @@ func (h ShowMoveDatesSummaryHandler) Handle(params moveop.ShowMoveDatesSummaryPa
 func createMoveDates(startDate time.Time, numDays int, includeWeekendsAndHolidays bool) []strfmt.Date {
 	var dates []strfmt.Date
 
-	// TODO: Handle holidays.
+	usCalendar := handlers.NewUSCalendar()
 	daysAdded := 0
 	for d := startDate; daysAdded < numDays; d = d.AddDate(0, 0, 1) {
-		if includeWeekendsAndHolidays || (d.Weekday() != time.Saturday && d.Weekday() != time.Sunday) {
+		if includeWeekendsAndHolidays || usCalendar.IsWorkday(d) {
 			dates = append(dates, strfmt.Date(d))
 			daysAdded++
 		}

--- a/pkg/handlers/internalapi/moves_test.go
+++ b/pkg/handlers/internalapi/moves_test.go
@@ -357,14 +357,14 @@ func (suite *HandlerSuite) TestShowMoveDatesSummaryHandler() {
 			strfmt.Date(time.Date(2018, 10, 3, 0, 0, 0, 0, time.UTC)),
 			strfmt.Date(time.Date(2018, 10, 4, 0, 0, 0, 0, time.UTC)),
 			strfmt.Date(time.Date(2018, 10, 5, 0, 0, 0, 0, time.UTC)),
-			strfmt.Date(time.Date(2018, 10, 8, 0, 0, 0, 0, time.UTC)),
 			strfmt.Date(time.Date(2018, 10, 9, 0, 0, 0, 0, time.UTC)),
 			strfmt.Date(time.Date(2018, 10, 10, 0, 0, 0, 0, time.UTC)),
 			strfmt.Date(time.Date(2018, 10, 11, 0, 0, 0, 0, time.UTC)),
 			strfmt.Date(time.Date(2018, 10, 12, 0, 0, 0, 0, time.UTC)),
+			strfmt.Date(time.Date(2018, 10, 15, 0, 0, 0, 0, time.UTC)),
 		},
 		Delivery: []strfmt.Date{
-			strfmt.Date(time.Date(2018, 10, 15, 0, 0, 0, 0, time.UTC)),
+			strfmt.Date(time.Date(2018, 10, 16, 0, 0, 0, 0, time.UTC)),
 		},
 		Report: []strfmt.Date{
 			strfmt.Date(move.Orders.ReportByDate),


### PR DESCRIPTION
## Description

This PR introduces a [calendar library](https://github.com/rickar/cal) for determining US Federal Holidays so we can mark them as unavailable for moves and certain move activities.  Specifically, it adjusts the handlers for the current `/calendar/unavailable_move_dates` and `/moves/{moveId}/move_dates_summary` endpoints so that holidays are detected.

## Reviewer Notes

Note that we are currently creating a new calendar struct every time the NewUSCalendar function is called.  We could consider caching that in the future if appropriate.  Also, I have put this function in the `handlers` package for now.  We can refactor this to another location if this functionality is more broadly needed.

## Setup

Refer to setup instructions for the endpoint PRs in #1044 and #1056.

## Code Review Verification Steps

* [ ] End to end tests pass (`make e2e_test`).
* [ ] Code follows the guidelines for [Logging](./docs/backend.md#logging)
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/160741047) for this change
