### PR TITLE
Flipping unavailable move dates endpoint to show available dates instead

### DIFF
--- a/pkg/handlers/internalapi/api.go
+++ b/pkg/handlers/internalapi/api.go
@@ -91,7 +91,7 @@ func NewInternalAPIHandler(context handlers.HandlerContext) http.Handler {
 
 	internalAPI.GexSendGexRequestHandler = SendGexRequestHandler{context}
 
-	internalAPI.CalendarShowUnavailableMoveDatesHandler = ShowUnavailableMoveDatesHandler{context}
+	internalAPI.CalendarShowAvailableMoveDatesHandler = ShowAvailableMoveDatesHandler{context}
 
 	return internalAPI.Serve(nil)
 }

--- a/pkg/handlers/internalapi/calendar.go
+++ b/pkg/handlers/internalapi/calendar.go
@@ -8,34 +8,33 @@ import (
 	"time"
 )
 
-// ShowUnavailableMoveDatesHandler returns the unavailable move dates starting at a given date.
-type ShowUnavailableMoveDatesHandler struct {
+// ShowAvailableMoveDatesHandler returns the available move dates starting at a given date.
+type ShowAvailableMoveDatesHandler struct {
 	handlers.HandlerContext
 }
 
-// Handle returns the unavailable move dates.
-func (h ShowUnavailableMoveDatesHandler) Handle(params calendarop.ShowUnavailableMoveDatesParams) middleware.Responder {
+// Handle returns the available move dates.
+func (h ShowAvailableMoveDatesHandler) Handle(params calendarop.ShowAvailableMoveDatesParams) middleware.Responder {
 	startDate := time.Time(params.StartDate)
 
 	var datesPayload []strfmt.Date
-	datesPayload = append(datesPayload, strfmt.Date(startDate)) // The start date is always unavailable.
-
 	const daysToCheck = 90
 	const shortFuseTotalDays = 5
 	daysChecked := 0
 	shortFuseDaysFound := 0
 
 	usCalendar := handlers.NewUSCalendar()
-	firstPossibleDate := startDate.AddDate(0, 0, 1)
+	firstPossibleDate := startDate.AddDate(0, 0, 1) // We never include the start date.
 	for d := firstPossibleDate; daysChecked < daysToCheck; d = d.AddDate(0, 0, 1) {
-		if !usCalendar.IsWorkday(d) {
-			datesPayload = append(datesPayload, strfmt.Date(d))
-		} else if shortFuseDaysFound < shortFuseTotalDays {
-			datesPayload = append(datesPayload, strfmt.Date(d))
-			shortFuseDaysFound++
+		if usCalendar.IsWorkday(d) {
+			if shortFuseDaysFound < shortFuseTotalDays {
+				shortFuseDaysFound++
+			} else {
+				datesPayload = append(datesPayload, strfmt.Date(d))
+			}
 		}
 		daysChecked++
 	}
 
-	return calendarop.NewShowUnavailableMoveDatesOK().WithPayload(datesPayload)
+	return calendarop.NewShowAvailableMoveDatesOK().WithPayload(datesPayload)
 }

--- a/pkg/handlers/internalapi/calendar_test.go
+++ b/pkg/handlers/internalapi/calendar_test.go
@@ -8,58 +8,77 @@ import (
 	"time"
 )
 
-func (suite *HandlerSuite) TestShowUnavailableMoveDatesHandler() {
-	req := httptest.NewRequest("GET", "/calendar/unavailable_move_dates", nil)
+func (suite *HandlerSuite) TestShowAvailableMoveDatesHandler() {
+	req := httptest.NewRequest("GET", "/calendar/available_move_dates", nil)
 
-	params := calendarop.ShowUnavailableMoveDatesParams{
+	params := calendarop.ShowAvailableMoveDatesParams{
 		HTTPRequest: req,
-		StartDate:   strfmt.Date(time.Date(2018, 9, 26, 0, 0, 0, 0, time.UTC)),
+		StartDate:   strfmt.Date(time.Date(2018, 9, 27, 0, 0, 0, 0, time.UTC)),
 	}
 
-	unavailableDates := []strfmt.Date{
-		strfmt.Date(time.Date(2018, 9, 26, 0, 0, 0, 0, time.UTC)),
-		strfmt.Date(time.Date(2018, 9, 27, 0, 0, 0, 0, time.UTC)),
-		strfmt.Date(time.Date(2018, 9, 28, 0, 0, 0, 0, time.UTC)),
-		strfmt.Date(time.Date(2018, 9, 29, 0, 0, 0, 0, time.UTC)),
-		strfmt.Date(time.Date(2018, 9, 30, 0, 0, 0, 0, time.UTC)),
-		strfmt.Date(time.Date(2018, 10, 1, 0, 0, 0, 0, time.UTC)),
-		strfmt.Date(time.Date(2018, 10, 2, 0, 0, 0, 0, time.UTC)),
-		strfmt.Date(time.Date(2018, 10, 3, 0, 0, 0, 0, time.UTC)),
-		strfmt.Date(time.Date(2018, 10, 6, 0, 0, 0, 0, time.UTC)),
-		strfmt.Date(time.Date(2018, 10, 7, 0, 0, 0, 0, time.UTC)),
-		strfmt.Date(time.Date(2018, 10, 8, 0, 0, 0, 0, time.UTC)),
-		strfmt.Date(time.Date(2018, 10, 13, 0, 0, 0, 0, time.UTC)),
-		strfmt.Date(time.Date(2018, 10, 14, 0, 0, 0, 0, time.UTC)),
-		strfmt.Date(time.Date(2018, 10, 20, 0, 0, 0, 0, time.UTC)),
-		strfmt.Date(time.Date(2018, 10, 21, 0, 0, 0, 0, time.UTC)),
-		strfmt.Date(time.Date(2018, 10, 27, 0, 0, 0, 0, time.UTC)),
-		strfmt.Date(time.Date(2018, 10, 28, 0, 0, 0, 0, time.UTC)),
-		strfmt.Date(time.Date(2018, 11, 3, 0, 0, 0, 0, time.UTC)),
-		strfmt.Date(time.Date(2018, 11, 4, 0, 0, 0, 0, time.UTC)),
-		strfmt.Date(time.Date(2018, 11, 10, 0, 0, 0, 0, time.UTC)),
-		strfmt.Date(time.Date(2018, 11, 11, 0, 0, 0, 0, time.UTC)),
-		strfmt.Date(time.Date(2018, 11, 12, 0, 0, 0, 0, time.UTC)),
-		strfmt.Date(time.Date(2018, 11, 17, 0, 0, 0, 0, time.UTC)),
-		strfmt.Date(time.Date(2018, 11, 18, 0, 0, 0, 0, time.UTC)),
-		strfmt.Date(time.Date(2018, 11, 22, 0, 0, 0, 0, time.UTC)),
-		strfmt.Date(time.Date(2018, 11, 24, 0, 0, 0, 0, time.UTC)),
-		strfmt.Date(time.Date(2018, 11, 25, 0, 0, 0, 0, time.UTC)),
-		strfmt.Date(time.Date(2018, 12, 1, 0, 0, 0, 0, time.UTC)),
-		strfmt.Date(time.Date(2018, 12, 2, 0, 0, 0, 0, time.UTC)),
-		strfmt.Date(time.Date(2018, 12, 8, 0, 0, 0, 0, time.UTC)),
-		strfmt.Date(time.Date(2018, 12, 9, 0, 0, 0, 0, time.UTC)),
-		strfmt.Date(time.Date(2018, 12, 15, 0, 0, 0, 0, time.UTC)),
-		strfmt.Date(time.Date(2018, 12, 16, 0, 0, 0, 0, time.UTC)),
-		strfmt.Date(time.Date(2018, 12, 22, 0, 0, 0, 0, time.UTC)),
-		strfmt.Date(time.Date(2018, 12, 23, 0, 0, 0, 0, time.UTC)),
-		strfmt.Date(time.Date(2018, 12, 25, 0, 0, 0, 0, time.UTC)),
+	availableDates := []strfmt.Date{
+		strfmt.Date(time.Date(2018, 10, 5, 0, 0, 0, 0, time.UTC)),
+		strfmt.Date(time.Date(2018, 10, 9, 0, 0, 0, 0, time.UTC)),
+		strfmt.Date(time.Date(2018, 10, 10, 0, 0, 0, 0, time.UTC)),
+		strfmt.Date(time.Date(2018, 10, 11, 0, 0, 0, 0, time.UTC)),
+		strfmt.Date(time.Date(2018, 10, 12, 0, 0, 0, 0, time.UTC)),
+		strfmt.Date(time.Date(2018, 10, 15, 0, 0, 0, 0, time.UTC)),
+		strfmt.Date(time.Date(2018, 10, 16, 0, 0, 0, 0, time.UTC)),
+		strfmt.Date(time.Date(2018, 10, 17, 0, 0, 0, 0, time.UTC)),
+		strfmt.Date(time.Date(2018, 10, 18, 0, 0, 0, 0, time.UTC)),
+		strfmt.Date(time.Date(2018, 10, 19, 0, 0, 0, 0, time.UTC)),
+		strfmt.Date(time.Date(2018, 10, 22, 0, 0, 0, 0, time.UTC)),
+		strfmt.Date(time.Date(2018, 10, 23, 0, 0, 0, 0, time.UTC)),
+		strfmt.Date(time.Date(2018, 10, 24, 0, 0, 0, 0, time.UTC)),
+		strfmt.Date(time.Date(2018, 10, 25, 0, 0, 0, 0, time.UTC)),
+		strfmt.Date(time.Date(2018, 10, 26, 0, 0, 0, 0, time.UTC)),
+		strfmt.Date(time.Date(2018, 10, 29, 0, 0, 0, 0, time.UTC)),
+		strfmt.Date(time.Date(2018, 10, 30, 0, 0, 0, 0, time.UTC)),
+		strfmt.Date(time.Date(2018, 10, 31, 0, 0, 0, 0, time.UTC)),
+		strfmt.Date(time.Date(2018, 11, 1, 0, 0, 0, 0, time.UTC)),
+		strfmt.Date(time.Date(2018, 11, 2, 0, 0, 0, 0, time.UTC)),
+		strfmt.Date(time.Date(2018, 11, 5, 0, 0, 0, 0, time.UTC)),
+		strfmt.Date(time.Date(2018, 11, 6, 0, 0, 0, 0, time.UTC)),
+		strfmt.Date(time.Date(2018, 11, 7, 0, 0, 0, 0, time.UTC)),
+		strfmt.Date(time.Date(2018, 11, 8, 0, 0, 0, 0, time.UTC)),
+		strfmt.Date(time.Date(2018, 11, 9, 0, 0, 0, 0, time.UTC)),
+		strfmt.Date(time.Date(2018, 11, 13, 0, 0, 0, 0, time.UTC)),
+		strfmt.Date(time.Date(2018, 11, 14, 0, 0, 0, 0, time.UTC)),
+		strfmt.Date(time.Date(2018, 11, 15, 0, 0, 0, 0, time.UTC)),
+		strfmt.Date(time.Date(2018, 11, 16, 0, 0, 0, 0, time.UTC)),
+		strfmt.Date(time.Date(2018, 11, 19, 0, 0, 0, 0, time.UTC)),
+		strfmt.Date(time.Date(2018, 11, 20, 0, 0, 0, 0, time.UTC)),
+		strfmt.Date(time.Date(2018, 11, 21, 0, 0, 0, 0, time.UTC)),
+		strfmt.Date(time.Date(2018, 11, 23, 0, 0, 0, 0, time.UTC)),
+		strfmt.Date(time.Date(2018, 11, 26, 0, 0, 0, 0, time.UTC)),
+		strfmt.Date(time.Date(2018, 11, 27, 0, 0, 0, 0, time.UTC)),
+		strfmt.Date(time.Date(2018, 11, 28, 0, 0, 0, 0, time.UTC)),
+		strfmt.Date(time.Date(2018, 11, 29, 0, 0, 0, 0, time.UTC)),
+		strfmt.Date(time.Date(2018, 11, 30, 0, 0, 0, 0, time.UTC)),
+		strfmt.Date(time.Date(2018, 12, 3, 0, 0, 0, 0, time.UTC)),
+		strfmt.Date(time.Date(2018, 12, 4, 0, 0, 0, 0, time.UTC)),
+		strfmt.Date(time.Date(2018, 12, 5, 0, 0, 0, 0, time.UTC)),
+		strfmt.Date(time.Date(2018, 12, 6, 0, 0, 0, 0, time.UTC)),
+		strfmt.Date(time.Date(2018, 12, 7, 0, 0, 0, 0, time.UTC)),
+		strfmt.Date(time.Date(2018, 12, 10, 0, 0, 0, 0, time.UTC)),
+		strfmt.Date(time.Date(2018, 12, 11, 0, 0, 0, 0, time.UTC)),
+		strfmt.Date(time.Date(2018, 12, 12, 0, 0, 0, 0, time.UTC)),
+		strfmt.Date(time.Date(2018, 12, 13, 0, 0, 0, 0, time.UTC)),
+		strfmt.Date(time.Date(2018, 12, 14, 0, 0, 0, 0, time.UTC)),
+		strfmt.Date(time.Date(2018, 12, 17, 0, 0, 0, 0, time.UTC)),
+		strfmt.Date(time.Date(2018, 12, 18, 0, 0, 0, 0, time.UTC)),
+		strfmt.Date(time.Date(2018, 12, 19, 0, 0, 0, 0, time.UTC)),
+		strfmt.Date(time.Date(2018, 12, 20, 0, 0, 0, 0, time.UTC)),
+		strfmt.Date(time.Date(2018, 12, 21, 0, 0, 0, 0, time.UTC)),
+		strfmt.Date(time.Date(2018, 12, 24, 0, 0, 0, 0, time.UTC)),
+		strfmt.Date(time.Date(2018, 12, 26, 0, 0, 0, 0, time.UTC)),
 	}
 
-	showHandler := ShowUnavailableMoveDatesHandler{handlers.NewHandlerContext(suite.TestDB(), suite.TestLogger())}
+	showHandler := ShowAvailableMoveDatesHandler{handlers.NewHandlerContext(suite.TestDB(), suite.TestLogger())}
 	response := showHandler.Handle(params)
 
-	suite.IsType(&calendarop.ShowUnavailableMoveDatesOK{}, response)
-	okResponse := response.(*calendarop.ShowUnavailableMoveDatesOK)
+	suite.IsType(&calendarop.ShowAvailableMoveDatesOK{}, response)
+	okResponse := response.(*calendarop.ShowAvailableMoveDatesOK)
 
-	suite.Equal(unavailableDates, okResponse.Payload)
+	suite.Equal(availableDates, okResponse.Payload)
 }

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -4053,11 +4053,11 @@ paths:
           description: invalid request
         500:
           description: internal server error
-  /calendar/unavailable_move_dates:
+  /calendar/available_move_dates:
     get:
-      summary: Returns unavailable dates for the move calendar
-      description: Returns unavailable dates for the move calendar
-      operationId: showUnavailableMoveDates
+      summary: Returns available dates for the move calendar
+      description: Returns available dates for the move calendar
+      operationId: showAvailableMoveDates
       tags:
         - calendar
       parameters:
@@ -4066,10 +4066,10 @@ paths:
           type: string
           format: date
           required: true
-          description: Look for future unavailable dates starting from (and including) this date
+          description: Look for future available dates starting from (and including) this date
       responses:
         200:
-          description: List of unavailable dates
+          description: List of available dates
           schema:
             type: array
             items:


### PR DESCRIPTION
## Description

In our recent sprint planning, we decided that it made more sense to have the move dates endpoint return the `available` dates instead of the `unavailable` dates given how we plan to use it with the calendar widget (the widget will start with all dates as unclickable and then just make the allowed move dates clickable).

## Setup

See setup/background in #1044 (the original endpoint PR).

## Code Review Verification Steps

* [ ] End to end tests pass (`make e2e_test`).
* [ ] Code follows the guidelines for [Logging](./docs/backend.md#logging)
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/160909390) for this change
