### PR TITLE
Refractor of CircleCI build_app job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,3 +1,29 @@
+
+############
+#
+# Executors
+#
+# All jobs in this config use one of 2 executors:
+# * `mymove` uses the `trussworks/circleci-docker-primary` docker image with a checkout of the mymove code
+# * `mymove_and_postgres` adds a secondary `postgres:10.1` container and is used during testing.
+#
+# Caches
+#
+# Caches have a `v1-` prefix, since caches in CircleCI 2.0 are immutable.
+# A prefix provides an easy way to invalidate a cache.  See https://circleci.com/docs/2.0/caching/#clearing-cache
+#
+# The following caches are used in this config.
+# * `v1-go-pkg-dep-sources-{{ checksum "Gopkg.lock" }}` is used to caches sources for dep, the Go dependency manager.
+# * `v1-mymove-vendor-{{ checksum "Gopkg.lock" }}` is used for caching the vendor directory for mymove.
+# * `v1-cache-yarn-v2-{{ checksum "yarn.lock" }}` is used to cache yarn sources
+# * `v1-mymove-node-modules-{{ checksum "yarn.lock" }}` is used to cache installed node modules
+# * `v1-cache-cypress-3.1.0` is used to cache the Cypress binary
+# * `v1-mymove-pkg-gen-{{ .Environment.CIRCLE_SHA1 }}` is used to cache the code generated from swagger documents.
+# * `v1-cache-precommit-{{ checksum ".pre-commit-config.yaml" }}` is used to cache pre-commit plugins.
+#
+#
+############
+
 version: "2.1"
 
 executors:
@@ -121,19 +147,19 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - go-pkg-dep-sources-{{ checksum "Gopkg.lock" }}
+            - v1-go-pkg-dep-sources-{{ checksum "Gopkg.lock" }}
       - restore_cache:
           keys:
-            - mymove-vendor-{{ checksum "Gopkg.lock" }}
+            - v1-mymove-vendor-{{ checksum "Gopkg.lock" }}
       - run:
           name: Install dependencies
           command: dep ensure -vendor-only
       - save_cache:
-          key: go-pkg-dep-sources-{{ checksum "Gopkg.lock" }}
+          key: v1-go-pkg-dep-sources-{{ checksum "Gopkg.lock" }}
           paths:
             - ~/go/pkg/dep/sources
       - save_cache:
-          key: mymove-vendor-{{ checksum "Gopkg.lock" }}
+          key: v1-mymove-vendor-{{ checksum "Gopkg.lock" }}
           paths:
             - ~/go/src/github.com/transcom/mymove/vendor
       - announce_failure
@@ -144,14 +170,21 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - yarn-node-modules-cache-{{ checksum "yarn.lock" }}
+            - v1-cache-yarn-v2-{{ checksum "yarn.lock" }}
+      - restore_cache:
+          keys:
+            - v1-mymove-node-modules-{{ checksum "yarn.lock" }}
       - run:
           name: Install YARN dependencies
           command: yarn install
       - save_cache:
-          key: yarn-node-modules-cache-{{ checksum "yarn.lock" }}
+          key: v1-cache-yarn-v2-{{ checksum "yarn.lock" }}
           paths:
-            - node_modules
+            - ~/.cache/yarn/v2
+      - save_cache:
+          key: v1-mymove-node-modules-{{ checksum "yarn.lock" }}
+          paths:
+            - ~/go/src/github.com/transcom/mymove/node_modules
       - announce_failure
 
   pre_test:
@@ -160,31 +193,34 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - go-pkg-dep-sources-{{ checksum "Gopkg.lock" }}
+            - v1-mymove-vendor-{{ checksum "Gopkg.lock" }}
       - restore_cache:
           keys:
-            - mymove-vendor-{{ checksum "Gopkg.lock" }}
+            - v1-mymove-pkg-gen-{{ .Environment.CIRCLE_SHA1 }}
       - restore_cache:
           keys:
-            - pre-commit-dot-cache-{{ checksum ".pre-commit-config.yaml" }}
+            - v1-cache-precommit-{{ checksum ".pre-commit-config.yaml" }}
+      - run:
+          name: Add Go binaries to path
+          command: echo 'export PATH=${PATH}:~/go/bin' >> $BASH_ENV
       - run:
           name: Install prettier
-          command: npm install prettier@~1.12.0
+          command: yarn add prettier@~1.12.0
       - run:
           name: Install markdown-spellcheck
-          command: npm install markdown-spellcheck
+          command: yarn add markdown-spellcheck
       - run:
           name: Install markdown-toc
-          command: npm install markdown-toc
-      - run: echo 'export PATH=${PATH}:~/go/bin' >> $BASH_ENV
+          command: yarn add markdown-toc
       - run:
-          name: Run make server_generate
-          command: make server_generate
-      - run:
-          name: Run pre-commit tests
-          command: pre-commit run --all-files
+          name: Run Tests
+          command: |
+            go build -i -o bin/swagger ./vendor/github.com/go-swagger/go-swagger/cmd/swagger
+            go build -i -o bin/gosec ./vendor/github.com/securego/gosec/cmd/gosec
+            go install ./vendor/github.com/golang/lint/golint # golint needs to be accessible for the pre-commit task to run, so `install` it
+            pre-commit run --all-files
       - save_cache:
-          key: pre-commit-dot-cache-{{ checksum ".pre-commit-config.yaml" }}
+          key: v1-cache-precommit-{{ checksum ".pre-commit-config.yaml" }}
           paths:
             - ~/.cache/pre-commit
       - announce_failure
@@ -197,14 +233,22 @@ jobs:
           docker_layer_caching: true
       - restore_cache:
           keys:
-            - go-pkg-dep-sources-{{ checksum "Gopkg.lock" }}
+            - v1-go-pkg-dep-sources-{{ checksum "Gopkg.lock" }}
       - restore_cache:
           keys:
-            - mymove-vendor-{{ checksum "Gopkg.lock" }}
+            - v1-mymove-vendor-{{ checksum "Gopkg.lock" }}
       - restore_cache:
           keys:
-            - client-deps-cache-{{ checksum "yarn.lock" }}
-
+            - v1-mymove-pkg-gen-{{ .Environment.CIRCLE_SHA1 }}
+      - restore_cache:
+          keys:
+            - v1-cache-yarn-v2-{{ checksum "yarn.lock" }}
+      - restore_cache:
+          keys:
+            - v1-cache-cypress-3.1.0
+      - restore_cache:
+          keys:
+            - v1-mymove-node-modules-{{ checksum "yarn.lock" }}
       - run:
           # This is needed to use `psql` to test DB connectivity, until the app
           # itself starts making database connections.
@@ -218,7 +262,7 @@ jobs:
             sudo apt-get -qq -y install xvfb libgtk2.0-0 libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2
       - run:
           name: Install cypress
-          command: npm install cypress@~3.1.0
+          command: yarn add cypress@~3.1.0
       - run:
           name: Setup hostnames
           command: |
@@ -261,11 +305,10 @@ jobs:
           path: cypress/screenshots
       - store_test_results:
           path: cypress/results
-
       - save_cache:
-          key: client-deps-cache-{{ checksum "yarn.lock" }}
+          key: v1-cache-cypress-3.1.0
           paths:
-            - ~/.cache
+            - ~/.cache/Cypress/3.1.0
       - announce_failure
 
   vuln_scan:
@@ -274,13 +317,16 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - go-pkg-dep-sources-{{ checksum "Gopkg.lock" }}
+            - v1-go-pkg-dep-sources-{{ checksum "Gopkg.lock" }}
       - restore_cache:
           keys:
-            - mymove-vendor-{{ checksum "Gopkg.lock" }}
+            - v1-mymove-vendor-{{ checksum "Gopkg.lock" }}
       - restore_cache:
           keys:
-            - yarn-node-modules-cache-{{ checksum "yarn.lock" }}
+            - v1-mymove-pkg-gen-{{ .Environment.CIRCLE_SHA1 }}
+      - restore_cache:
+          keys:
+            - v1-cache-yarn-v2-{{ checksum "yarn.lock" }}
       - run:
           name: Authenticate with Snyk
           command: npx snyk auth $SNYK_API_TOKEN
@@ -298,16 +344,38 @@ jobs:
           command: npx snyk test --file=Gopkg.lock || exit 0 # needs to run after server_generate, so gen files exist
       - announce_failure
 
+  build_gen:
+    executor: mymove
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - v1-go-pkg-dep-sources-{{ checksum "Gopkg.lock" }}
+      - restore_cache:
+          keys:
+            - v1-mymove-vendor-{{ checksum "Gopkg.lock" }}
+      - restore_cache:
+          keys:
+            - v1-mymove-pkg-gen-{{ .Environment.CIRCLE_SHA1 }}
+      - run: make server_generate
+      - save_cache:
+          key: v1-mymove-pkg-gen-{{ .Environment.CIRCLE_SHA1 }}
+          paths:
+            - ~/go/src/github.com/transcom/mymove/pkg/gen
+
   build_tools:
     executor: mymove
     steps:
       - checkout
       - restore_cache:
           keys:
-            - go-pkg-dep-sources-{{ checksum "Gopkg.lock" }}
+            - v1-go-pkg-dep-sources-{{ checksum "Gopkg.lock" }}
       - restore_cache:
           keys:
-            - mymove-vendor-{{ checksum "Gopkg.lock" }}
+            - v1-mymove-vendor-{{ checksum "Gopkg.lock" }}
+      - restore_cache:
+          keys:
+            - v1-mymove-pkg-gen-{{ .Environment.CIRCLE_SHA1 }}
       - run: make build_tools
 
   build_app:
@@ -318,14 +386,16 @@ jobs:
           docker_layer_caching: true
       - restore_cache:
           keys:
-            - go-pkg-dep-sources-{{ checksum "Gopkg.lock" }}
+            - v1-mymove-vendor-{{ checksum "Gopkg.lock" }}
       - restore_cache:
           keys:
-            - mymove-vendor-{{ checksum "Gopkg.lock" }}
+            - v1-mymove-pkg-gen-{{ .Environment.CIRCLE_SHA1 }}
       - restore_cache:
           keys:
-            - yarn-node-modules-cache-{{ checksum "yarn.lock" }}
-
+            - v1-cache-yarn-v2-{{ checksum "yarn.lock" }}
+      - restore_cache:
+          keys:
+            - v1-mymove-node-modules-{{ checksum "yarn.lock" }}
       - run:
           # This is needed to use `psql` to test DB connectivity, until the app
           # itself starts making database connections.
@@ -333,11 +403,8 @@ jobs:
           command: |
             sudo apt-get -qq update
             sudo apt-get -qq -y install postgresql-client-9.6
-
-      - run: echo 'export PATH=${PATH}:~/go/bin' >> $BASH_ENV
-      - run: make deps
-      - run: make client_build
-      - run: make client_test
+      #- run: echo 'export PATH=${PATH}:~/go/bin' >> $BASH_ENV
+      - run: make ci_build_app
       - run:
           name: make server_test
           command: make server_test
@@ -362,6 +429,14 @@ jobs:
       - checkout
       - setup_remote_docker:
           docker_layer_caching: true
+      - restore_cache:
+          keys:
+            - v1-mymove-vendor-{{ checksum "Gopkg.lock" }}
+      - run:
+          name: Install dependencies
+          command: |
+            go build -o bin/soda -ldflags "-linkmode external -extldflags -static" ./vendor/github.com/gobuffalo/pop/soda
+            go build -o bin/chamber -ldflags "-linkmode external -extldflags -static" ./vendor/github.com/segmentio/chamber
       - build_tag_push:
           dockerfile: Dockerfile.migrations
           tag: ppp-migrations:dev
@@ -443,10 +518,10 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - go-pkg-dep-sources-{{ checksum "Gopkg.lock" }}
+            - v1-go-pkg-dep-sources-{{ checksum "Gopkg.lock" }}
       - restore_cache:
           keys:
-            - mymove-vendor-{{ checksum "Gopkg.lock" }}
+            - v1-mymove-vendor-{{ checksum "Gopkg.lock" }}
       - run:
           name: Add ~/go/bin to path for golint
           command: echo 'export PATH=${PATH}:~/go/bin' >> $BASH_ENV
@@ -467,14 +542,10 @@ workflows:
 
   app:
     jobs:
+
       - pre_deps_golang
 
       - pre_deps_yarn
-
-      - pre_test:
-          requires:
-            - pre_deps_golang
-            - pre_deps_yarn
 
       #- vuln_scan # keep disabled until we work out new process
       #  requires:
@@ -485,11 +556,22 @@ workflows:
           requires:
             - pre_deps_golang
             - pre_deps_yarn
+            - build_gen
+
+      - build_gen:
+          requires:
+            - pre_deps_golang
+
+      - build_tools:
+          requires:
+            - pre_deps_golang
+            - build_gen
 
       - build_app:
           requires:
             - pre_deps_golang
             - pre_deps_yarn
+            - build_gen
 
       - build_tools:
           requires:
@@ -498,15 +580,22 @@ workflows:
       - build_migrations:
           requires:
             - pre_deps_golang
+
+      - pre_test:
+          requires:
+            - pre_deps_golang
             - pre_deps_yarn
+            - build_gen
 
       - deploy_experimental_migrations:
           requires:
             - pre_test
             #- vuln_scan # keep disabled until we work out new process
+            # - build_tools # not required for experimental deployments
             - build_app
             # - build_tools # tools don't need to build to deploy to experimental
             - build_migrations
+            # - integration_tests # not required for experimental deployments
           filters:
             branches:
               only: mutual_tls_health_check
@@ -529,6 +618,7 @@ workflows:
           requires:
             - pre_test
             #- vuln_scan # keep disabled until we work out new process
+            - build_tools
             - build_app
             - build_tools
             - build_migrations

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,33 +1,14 @@
-# Start from a Debian image with the latest version of Go installed
-# and a workspace (GOPATH) configured at /go.
-FROM golang:1.10.0 AS build
-
-# Install tools required to build the project
-# We will need to run `docker build --no-cache .` to update those dependencies
-RUN apt-get install git
-RUN go get github.com/golang/dep/cmd/dep
-
-# Copy all project and build it
-# This layer will be rebuilt when ever a file has changed in the project directory
-COPY ./ /go/src/github.com/transcom/mymove/
-WORKDIR /go/src/github.com/transcom/mymove/
-RUN rm -f .*.stamp
-RUN make server_deps
-RUN make server_generate
-# These linker flags create a standalone binary that will run in scratch.
-RUN go build -o /bin/mymove-server -ldflags "-linkmode external -extldflags -static" ./cmd/webserver
-RUN go build -o /bin/chamber -ldflags "-linkmode external -extldflags -static" ./vendor/github.com/segmentio/chamber
-
-# This results in a single layer image
-# https://github.com/GoogleCloudPlatform/distroless
-# This google maintained image is scratch plus some basic necessities like a tmp dir and root certs.
 FROM gcr.io/distroless/base
-COPY --from=build /bin/mymove-server /bin/mymove-server
-COPY --from=build /go/src/github.com/transcom/mymove/config /config
-COPY --from=build /go/src/github.com/transcom/mymove/swagger/* /swagger/
-COPY --from=build /bin/chamber /bin/chamber
-COPY /build /build
+
+COPY bin/mymove-server /bin/mymove-server
+COPY bin/chamber /bin/chamber
+
+COPY config /config
+COPY swagger/* /swagger/
+COPY build /build
+
 ENTRYPOINT ["/bin/mymove-server"]
+
 CMD ["-debug_logging"]
 
 EXPOSE 8080

--- a/Dockerfile.migrations
+++ b/Dockerfile.migrations
@@ -1,27 +1,6 @@
-# This container will be used by the CI system to run migrations in the Staging
-# and Production environments.
-
-# Start from a Debian image with the latest version of Go installed
-# and a workspace (GOPATH) configured at /go.
-FROM golang:1.10.0 AS build
-
-RUN go get github.com/golang/dep/cmd/dep
-
-COPY ./ /go/src/github.com/transcom/mymove/
-WORKDIR /go/src/github.com/transcom/mymove/
-RUN dep ensure -vendor-only
-
-# Install tools required to build the project
-# These linker flags create a standalone binary that will run in scratch.
-RUN go build -o /bin/soda -ldflags "-linkmode external -extldflags -static" ./vendor/github.com/gobuffalo/pop/soda
-RUN go build -o /bin/chamber -ldflags "-linkmode external -extldflags -static" ./vendor/github.com/segmentio/chamber
-
-# Copy build artifacts into a new container with a minimal Linux distro.
-# We need to have something with minimal tooling as the migrations container runs shell scripts
-# and uses AWS tools.
 FROM alpine:3.7
-COPY --from=build /bin/soda /bin/soda
-COPY --from=build /bin/chamber /bin/chamber
+COPY bin/soda /bin/soda
+COPY bin/chamber /bin/chamber
 COPY bin/apply-secure-migration.sh /bin
 COPY migrations /migrate/migrations
 COPY config/database.yml /migrate

--- a/Makefile
+++ b/Makefile
@@ -217,6 +217,19 @@ pretty:
 	npx prettier --write --loglevel warn "src/**/*.{js,jsx}"
 	gofmt pkg/ >> /dev/null
 
+ci_build_app:
+	bin/copy_swagger_ui.sh
+	go install ./vendor/github.com/golang/lint/golint # golint needs to be accessible for the pre-commit task to run, so `install` it
+	go build -i -o bin/gosec ./vendor/github.com/securego/gosec/cmd/gosec
+	go build -i -o bin/gin ./vendor/github.com/codegangsta/gin
+	go build -i -o bin/soda ./vendor/github.com/gobuffalo/pop/soda
+	go build -i -o bin/swagger ./vendor/github.com/go-swagger/go-swagger/cmd/swagger
+	go-bindata -o pkg/assets/assets.go -pkg assets pkg/paperwork/formtemplates/
+	go build -o bin/mymove-server -ldflags "-linkmode external -extldflags -static" ./cmd/webserver
+	go build -o bin/chamber -ldflags "-linkmode external -extldflags -static" ./vendor/github.com/segmentio/chamber  # used by deployable container
+	yarn build # creates build/static/[css|js|media]
+	yarn test
+
 clean:
 	rm .*.stamp || true
 	rm -rf ./node_modules


### PR DESCRIPTION
## Description

- Cache `~/.cache/yarn/v2` and `mymove/node_modules` for each `yarn.lock`.
- Cache Cypress Binary for `integration_tests`
- Separate swagger code generation into its own job `build_gen`
- Separate building `mymove/cmd/*` CLI tools into its own job `build_tools` (saves ~20 seconds)
- New dockerfile (`Dockerfile.ci`) for `build_app` that doesn't use intermediate container (saves 3 - 5 minutes)
- New dockerfile (`Dockerfile.migrations.ci`) for `build_migrations` that doesn't use intermediate container (saves ~ 2 minutes)
- Create new `build_tag_push` command.
- Remove `terraform_fmt` and `terraform_validate` from pre-commit

<img width="728" alt="screen shot 2018-10-08 at 6 27 45 pm" src="https://user-images.githubusercontent.com/40467706/46636936-0c485f00-cb28-11e8-8a6a-bf6c5ef41600.png">

