### PR TITLE
Added available/unavailable move dates to calendar widget

### DIFF
--- a/cypress/integration/mymove/shipment.js
+++ b/cypress/integration/mymove/shipment.js
@@ -17,11 +17,31 @@ describe('completing the hhg flow', function() {
       expect(loc.pathname).to.match(/^\/moves\/[^/]+\/hhg-start/);
     });
     cy.get('button.next').should('be.disabled');
+
     // Calendar move date
     cy
-      .get('.DayPicker-Day--today') // gets today
+      .get('.DayPicker-Day--today') // gets today, which should be disabled even after clicked
       .click()
-      .should('have.class', 'DayPicker-Day--selected');
+      .should('have.class', 'DayPicker-Day--disabled');
+
+    // We may or may not have an available date in the current month.  If not, then
+    // we skip to the next month which should (at least at this point) have an available
+    // date.
+    cy
+      .get('body')
+      .then($body => {
+        if ($body.find('[class=DayPicker-Day]').length === 0) {
+          cy.get('.DayPicker-NavButton--next').click();
+        }
+      })
+      .then(() => {
+        cy
+          .get('[class=DayPicker-Day]')
+          .first()
+          .click()
+          .should('have.class', 'DayPicker-Day--selected');
+      });
+
     cy.nextPage();
 
     cy.location().should(loc => {

--- a/pkg/handlers/internalapi/calendar_test.go
+++ b/pkg/handlers/internalapi/calendar_test.go
@@ -11,9 +11,10 @@ import (
 func (suite *HandlerSuite) TestShowAvailableMoveDatesHandler() {
 	req := httptest.NewRequest("GET", "/calendar/available_move_dates", nil)
 
+	startDate := strfmt.Date(time.Date(2018, 9, 27, 0, 0, 0, 0, time.UTC))
 	params := calendarop.ShowAvailableMoveDatesParams{
 		HTTPRequest: req,
-		StartDate:   strfmt.Date(time.Date(2018, 9, 27, 0, 0, 0, 0, time.UTC)),
+		StartDate:   startDate,
 	}
 
 	availableDates := []strfmt.Date{
@@ -80,5 +81,6 @@ func (suite *HandlerSuite) TestShowAvailableMoveDatesHandler() {
 	suite.IsType(&calendarop.ShowAvailableMoveDatesOK{}, response)
 	okResponse := response.(*calendarop.ShowAvailableMoveDatesOK)
 
-	suite.Equal(availableDates, okResponse.Payload)
+	suite.Equal(startDate, *okResponse.Payload.StartDate)
+	suite.Equal(availableDates, okResponse.Payload.Available)
 }

--- a/pkg/handlers/internalapi/moves.go
+++ b/pkg/handlers/internalapi/moves.go
@@ -247,7 +247,10 @@ func (h ShowMoveDatesSummaryHandler) Handle(params moveop.ShowMoveDatesSummaryPa
 	deliveryDays := createMoveDates(firstPossibleDeliveryDay, 1, false)
 	reportDays := []strfmt.Date{strfmt.Date(move.Orders.ReportByDate.UTC())}
 
-	moveDatesSummaryPayload := &internalmessages.MoveDatesSummaryPayload{
+	moveDatesSummary := &internalmessages.MoveDatesSummary{
+		ID:       swag.String(params.MoveID.String() + ":" + params.MoveDate.String()),
+		MoveID:   &params.MoveID,
+		MoveDate: &params.MoveDate,
 		Pack:     packDays,
 		Pickup:   pickupDays,
 		Transit:  transitDays,
@@ -255,7 +258,7 @@ func (h ShowMoveDatesSummaryHandler) Handle(params moveop.ShowMoveDatesSummaryPa
 		Report:   reportDays,
 	}
 
-	return moveop.NewShowMoveDatesSummaryOK().WithPayload(moveDatesSummaryPayload)
+	return moveop.NewShowMoveDatesSummaryOK().WithPayload(moveDatesSummary)
 }
 
 func createMoveDates(startDate time.Time, numDays int, includeWeekendsAndHolidays bool) []strfmt.Date {

--- a/pkg/handlers/internalapi/moves_test.go
+++ b/pkg/handlers/internalapi/moves_test.go
@@ -328,10 +328,12 @@ func (suite *HandlerSuite) TestShowMoveDatesSummaryHandler() {
 	path := fmt.Sprintf("/moves/%s/move_dates", move.ID.String())
 	req := httptest.NewRequest("GET", path, nil)
 
+	moveID := strfmt.UUID(move.ID.String())
+	moveDate := strfmt.Date(time.Date(2018, 9, 27, 0, 0, 0, 0, time.UTC))
 	params := moveop.ShowMoveDatesSummaryParams{
 		HTTPRequest: req,
-		MoveID:      strfmt.UUID(move.ID.String()),
-		MoveDate:    strfmt.Date(time.Date(2018, 9, 27, 0, 0, 0, 0, time.UTC)),
+		MoveID:      moveID,
+		MoveDate:    moveDate,
 	}
 
 	context := handlers.NewHandlerContext(suite.TestDB(), suite.TestLogger())
@@ -343,33 +345,43 @@ func (suite *HandlerSuite) TestShowMoveDatesSummaryHandler() {
 	suite.IsType(&moveop.ShowMoveDatesSummaryOK{}, response)
 	okResponse := response.(*moveop.ShowMoveDatesSummaryOK)
 
-	moveDates := internalmessages.MoveDatesSummaryPayload{
-		Pack: []strfmt.Date{
-			strfmt.Date(time.Date(2018, 9, 27, 0, 0, 0, 0, time.UTC)),
-			strfmt.Date(time.Date(2018, 9, 28, 0, 0, 0, 0, time.UTC)),
-			strfmt.Date(time.Date(2018, 10, 1, 0, 0, 0, 0, time.UTC)),
-		},
-		Pickup: []strfmt.Date{
-			strfmt.Date(time.Date(2018, 10, 2, 0, 0, 0, 0, time.UTC)),
-		},
-		Transit: []strfmt.Date{
-			strfmt.Date(time.Date(2018, 10, 2, 0, 0, 0, 0, time.UTC)),
-			strfmt.Date(time.Date(2018, 10, 3, 0, 0, 0, 0, time.UTC)),
-			strfmt.Date(time.Date(2018, 10, 4, 0, 0, 0, 0, time.UTC)),
-			strfmt.Date(time.Date(2018, 10, 5, 0, 0, 0, 0, time.UTC)),
-			strfmt.Date(time.Date(2018, 10, 9, 0, 0, 0, 0, time.UTC)),
-			strfmt.Date(time.Date(2018, 10, 10, 0, 0, 0, 0, time.UTC)),
-			strfmt.Date(time.Date(2018, 10, 11, 0, 0, 0, 0, time.UTC)),
-			strfmt.Date(time.Date(2018, 10, 12, 0, 0, 0, 0, time.UTC)),
-			strfmt.Date(time.Date(2018, 10, 15, 0, 0, 0, 0, time.UTC)),
-		},
-		Delivery: []strfmt.Date{
-			strfmt.Date(time.Date(2018, 10, 16, 0, 0, 0, 0, time.UTC)),
-		},
-		Report: []strfmt.Date{
-			strfmt.Date(move.Orders.ReportByDate),
-		},
-	}
+	id := move.ID.String() + ":" + moveDate.String()
+	suite.Equal(id, *okResponse.Payload.ID)
+	suite.Equal(moveID, *okResponse.Payload.MoveID)
+	suite.Equal(moveDate, *okResponse.Payload.MoveDate)
 
-	suite.Equal(moveDates, *okResponse.Payload)
+	pack := []strfmt.Date{
+		strfmt.Date(time.Date(2018, 9, 27, 0, 0, 0, 0, time.UTC)),
+		strfmt.Date(time.Date(2018, 9, 28, 0, 0, 0, 0, time.UTC)),
+		strfmt.Date(time.Date(2018, 10, 1, 0, 0, 0, 0, time.UTC)),
+	}
+	suite.Equal(pack, okResponse.Payload.Pack)
+
+	pickup := []strfmt.Date{
+		strfmt.Date(time.Date(2018, 10, 2, 0, 0, 0, 0, time.UTC)),
+	}
+	suite.Equal(pickup, okResponse.Payload.Pickup)
+
+	transit := []strfmt.Date{
+		strfmt.Date(time.Date(2018, 10, 2, 0, 0, 0, 0, time.UTC)),
+		strfmt.Date(time.Date(2018, 10, 3, 0, 0, 0, 0, time.UTC)),
+		strfmt.Date(time.Date(2018, 10, 4, 0, 0, 0, 0, time.UTC)),
+		strfmt.Date(time.Date(2018, 10, 5, 0, 0, 0, 0, time.UTC)),
+		strfmt.Date(time.Date(2018, 10, 9, 0, 0, 0, 0, time.UTC)),
+		strfmt.Date(time.Date(2018, 10, 10, 0, 0, 0, 0, time.UTC)),
+		strfmt.Date(time.Date(2018, 10, 11, 0, 0, 0, 0, time.UTC)),
+		strfmt.Date(time.Date(2018, 10, 12, 0, 0, 0, 0, time.UTC)),
+		strfmt.Date(time.Date(2018, 10, 15, 0, 0, 0, 0, time.UTC)),
+	}
+	suite.Equal(transit, okResponse.Payload.Transit)
+
+	delivery := []strfmt.Date{
+		strfmt.Date(time.Date(2018, 10, 16, 0, 0, 0, 0, time.UTC)),
+	}
+	suite.Equal(delivery, okResponse.Payload.Delivery)
+
+	report := []strfmt.Date{
+		strfmt.Date(move.Orders.ReportByDate),
+	}
+	suite.Equal(report, okResponse.Payload.Report)
 }

--- a/src/scenes/Moves/Hhg/DatePicker.jsx
+++ b/src/scenes/Moves/Hhg/DatePicker.jsx
@@ -2,74 +2,105 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { DayPicker } from 'react-day-picker';
 import 'react-day-picker/lib/style.css';
+import moment from 'moment';
 
 import { formatSwaggerDate, parseSwaggerDate } from 'shared/formatters';
 import './DatePicker.css';
+import LoadingPlaceholder from 'shared/LoadingPlaceholder';
 
 export class HHGDatePicker extends Component {
   handleDayClick = day => {
     this.props.input.onChange(formatSwaggerDate(day));
   };
 
+  isDayDisabled = day => {
+    const availableMoveDates = this.props.availableMoveDates;
+    if (!availableMoveDates) {
+      return true;
+    }
+
+    const momentDay = moment(day);
+    if (
+      momentDay.isBefore(availableMoveDates.minDate, 'day') ||
+      momentDay.isAfter(availableMoveDates.maxDate, 'day')
+    ) {
+      return true;
+    }
+
+    return !availableMoveDates.available.find(element =>
+      momentDay.isSame(element, 'day'),
+    );
+  };
+
   render() {
     const selectedDay = this.props.input.value;
+    const availableMoveDates = this.props.availableMoveDates;
     return (
       <div className="form-section">
         <h3 className="instruction-heading">
           Great! Let's find a date for a moving company to move your stuff.
         </h3>
-        <div className="usa-grid">
-          <h4>Select a move date</h4>
-          <div className="usa-width-one-third">
-            <DayPicker
-              onDayClick={this.handleDayClick}
-              selectedDays={parseSwaggerDate(selectedDay)}
-            />
-          </div>
+        {availableMoveDates ? (
+          <div className="usa-grid">
+            <h4>Select a move date</h4>
+            <div className="usa-width-one-third">
+              <DayPicker
+                onDayClick={this.handleDayClick}
+                selectedDays={parseSwaggerDate(selectedDay)}
+                disabledDays={this.isDayDisabled}
+              />
+            </div>
 
-          <div className="usa-width-two-thirds">
-            {selectedDay && (
-              <table className="Todo-phase2">
-                <tbody>
-                  <tr>
-                    <th className="Todo-phase2">
-                      Preferred Moving Dates Summary
-                    </th>
-                  </tr>
-                  <tr>
-                    <td>Movers Packing</td>
-                    <td className="Todo-phase2">
-                      Wed, June 6 - Thur, June 7{' '}
-                      <span className="estimate">*estimated</span>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>Movers Loading Truck</td>
-                    <td className="Todo-phase2">Fri, June 8</td>
-                  </tr>
-                  <tr>
-                    <td>Moving Truck in Transit</td>
-                    <td className="Todo-phase2">Fri, June 8 - Mon, June 11</td>
-                  </tr>
-                  <tr>
-                    <td>Movers Delivering</td>
-                    <td className="Todo-phase2">
-                      Tues, June 12 <span className="estimate">*estimated</span>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>Report By Date</td>
-                    <td className="Todo-phase2">Monday, July 16</td>
-                  </tr>
-                </tbody>
-              </table>
-            )}
+            <div className="usa-width-two-thirds">
+              {selectedDay && (
+                <table className="Todo-phase2">
+                  <tbody>
+                    <tr>
+                      <th className="Todo-phase2">
+                        Preferred Moving Dates Summary
+                      </th>
+                    </tr>
+                    <tr>
+                      <td>Movers Packing</td>
+                      <td className="Todo-phase2">
+                        Wed, June 6 - Thur, June 7{' '}
+                        <span className="estimate">*estimated</span>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>Movers Loading Truck</td>
+                      <td className="Todo-phase2">Fri, June 8</td>
+                    </tr>
+                    <tr>
+                      <td>Moving Truck in Transit</td>
+                      <td className="Todo-phase2">
+                        Fri, June 8 - Mon, June 11
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>Movers Delivering</td>
+                      <td className="Todo-phase2">
+                        Tues, June 12
+                        <span className="estimate">*estimated</span>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>Report By Date</td>
+                      <td className="Todo-phase2">Monday, July 16</td>
+                    </tr>
+                  </tbody>
+                </table>
+              )}
+            </div>
           </div>
-        </div>
+        ) : (
+          <LoadingPlaceholder />
+        )}
       </div>
     );
   }
 }
+
 HHGDatePicker.propTypes = {
   input: PropTypes.object.isRequired,
 };

--- a/src/scenes/Moves/Hhg/DatePicker.jsx
+++ b/src/scenes/Moves/Hhg/DatePicker.jsx
@@ -9,7 +9,10 @@ import './DatePicker.css';
 import LoadingPlaceholder from 'shared/LoadingPlaceholder';
 
 export class HHGDatePicker extends Component {
-  handleDayClick = day => {
+  handleDayClick = (day, { disabled }) => {
+    if (disabled) {
+      return;
+    }
     this.props.input.onChange(formatSwaggerDate(day));
   };
 

--- a/src/scenes/Moves/Hhg/MoveDate.jsx
+++ b/src/scenes/Moves/Hhg/MoveDate.jsx
@@ -16,6 +16,10 @@ import {
   createOrUpdateShipment,
   getShipment,
 } from 'shared/Entities/modules/shipments';
+import {
+  getAvailableMoveDates,
+  selectAvailableMoveDates,
+} from 'shared/Entities/modules/calendar';
 
 import './ShipmentWizard.css';
 
@@ -26,11 +30,13 @@ const validateMoveDateForm = validateAdditionalFields([
 const formName = 'move_date_form';
 const getRequestLabel = 'MoveDate.getShipment';
 const createOrUpdateRequestLabel = 'MoveDate.createOrUpdateShipment';
+const availableMoveDatesLabel = 'MoveDate.getAvailableMoveDates';
 const MoveDateWizardForm = reduxifyWizardForm(formName, validateMoveDateForm);
 
 export class MoveDate extends Component {
   componentDidMount() {
     this.loadShipment();
+    this.props.getAvailableMoveDates(availableMoveDatesLabel, this.props.today);
   }
 
   componentDidUpdate(prevProps) {
@@ -104,7 +110,11 @@ export class MoveDate extends Component {
           <div className="usa-grid">
             <h3 className="form-title">Shipment 1 (HHG)</h3>
           </div>
-          <Field name="requested_pickup_date" component={DatePicker} />
+          <Field
+            name="requested_pickup_date"
+            component={DatePicker}
+            availableMoveDates={this.props.availableMoveDates}
+          />
         </div>
       </MoveDateWizardForm>
     );
@@ -117,17 +127,25 @@ MoveDate.propTypes = {
 
 function mapDispatchToProps(dispatch) {
   return bindActionCreators(
-    { createOrUpdateShipment, setCurrentShipment, getShipment },
+    {
+      createOrUpdateShipment,
+      setCurrentShipment,
+      getShipment,
+      getAvailableMoveDates,
+    },
     dispatch,
   );
 }
 function mapStateToProps(state) {
   const shipment = currentShipment(state);
+  const today = new Date().toISOString().split('T')[0];
   const props = {
     move: get(state, 'moves.currentMove', {}),
     formValues: getFormValues(formName)(state),
     currentShipment: shipment,
     initialValues: shipment,
+    today: today,
+    availableMoveDates: selectAvailableMoveDates(state, today),
     error: getLastError(state, getRequestLabel),
   };
   return props;

--- a/src/shared/Entities/modules/calendar.js
+++ b/src/shared/Entities/modules/calendar.js
@@ -1,0 +1,45 @@
+import { get } from 'lodash';
+import { swaggerRequest } from 'shared/Swagger/request';
+import { getClient } from 'shared/Swagger/api';
+import { parseSwaggerDate } from 'shared/formatters';
+
+export function getAvailableMoveDates(label, startDate) {
+  return swaggerRequest(
+    getClient,
+    'calendar.showAvailableMoveDates',
+    { startDate },
+    { label },
+  );
+}
+
+export function selectAvailableMoveDates(state, id) {
+  if (!id) {
+    return null;
+  }
+
+  const availableMoveDates = get(state, 'entities.availableMoveDates.' + id);
+  if (!availableMoveDates) {
+    return null;
+  }
+
+  const availableLength = availableMoveDates.available.length;
+  const convertedAvailable = new Array(availableLength);
+  let minDate, maxDate;
+  for (let i = 0; i < availableLength; i++) {
+    const convertedDate = parseSwaggerDate(availableMoveDates.available[i]); // eslint-disable-line security/detect-object-injection
+    if (!minDate || convertedDate < minDate) {
+      minDate = convertedDate;
+    }
+    if (!maxDate || convertedDate > maxDate) {
+      maxDate = convertedDate;
+    }
+    convertedAvailable[i] = convertedDate; // eslint-disable-line security/detect-object-injection
+  }
+
+  return {
+    startDate: parseSwaggerDate(availableMoveDates.start_date),
+    minDate: minDate,
+    maxDate: maxDate,
+    available: convertedAvailable,
+  };
+}

--- a/src/shared/Entities/schema.js
+++ b/src/shared/Entities/schema.js
@@ -70,3 +70,10 @@ export const moveDocuments = new schema.Array(moveDocument);
 moveDocument.define({
   move: move,
 });
+
+// AvailableMoveDates
+export const availableMoveDates = new schema.Entity(
+  'availableMoveDates',
+  {},
+  { idAttribute: 'start_date' },
+);

--- a/src/shared/Swagger/request.js
+++ b/src/shared/Swagger/request.js
@@ -87,6 +87,7 @@ export function swaggerRequest(getClient, operationPath, params, options = {}) {
         error,
         request: updatedRequestLog,
       });
+      // return Promise.reject(error);
     }
 
     return request

--- a/src/shared/Swagger/request.js
+++ b/src/shared/Swagger/request.js
@@ -87,7 +87,7 @@ export function swaggerRequest(getClient, operationPath, params, options = {}) {
         error,
         request: updatedRequestLog,
       });
-      // return Promise.reject(error);
+      return Promise.reject(error);
     }
 
     return request

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -2243,9 +2243,20 @@ definitions:
       - last_modified_date
       - last_modified_name
       - created_at
-  MoveDatesSummaryPayload:
+  MoveDatesSummary:
     type: object
     properties:
+      id:
+        type: string
+        example: "c56a4180-65aa-42ec-a945-5fd21dec0538:2018-09-25"
+      move_id:
+        type: string
+        format: uuid
+        example: c56a4180-65aa-42ec-a945-5fd21dec0538
+      move_date:
+        type: string
+        format: date
+        example: "2018-09-25"
       pack:
         type: array
         items:
@@ -2277,11 +2288,30 @@ definitions:
           format: date
           example: "2018-09-25"
     required:
+      - id
+      - move_id
+      - move_date
       - pack
       - pickup
       - transit
       - delivery
       - report
+  AvailableMoveDates:
+    type: object
+    properties:
+      start_date:
+        type: string
+        format: date
+        example: "2018-09-25"
+      available:
+        type: array
+        items:
+          type: string
+          format: date
+          example: "2018-09-25"
+    required:
+      - start_date
+      - available
 paths:
   /estimates/ppm:
     get:
@@ -3419,7 +3449,7 @@ paths:
           required: true
           description: UUID of the move
         - in: query
-          name: move_date
+          name: moveDate
           type: string
           format: date
           required: true
@@ -3428,7 +3458,7 @@ paths:
         200:
           description: List of projected move-related dates
           schema:
-            $ref: '#/definitions/MoveDatesSummaryPayload'
+            $ref: '#/definitions/MoveDatesSummary'
         400:
           description: invalid request
         401:
@@ -4075,7 +4105,7 @@ paths:
         - calendar
       parameters:
         - in: query
-          name: start_date
+          name: startDate
           type: string
           format: date
           required: true
@@ -4084,11 +4114,7 @@ paths:
         200:
           description: List of available dates
           schema:
-            type: array
-            items:
-              type: string
-              format: date
-              example: "2018-09-25"
+            $ref: '#/definitions/AvailableMoveDates'
         400:
           description: invalid request
         401:


### PR DESCRIPTION
## Description

This PR hooks up the available move dates endpoint to the calendar widget in the HHG move process, making some dates (weekends, holidays, short-fuse days) disabled in the calendar.

## Reviewer Notes

A few notes:

- I reworked the two calendar-related endpoints a bit so that the response shape fit a little better with our new way of calling swagger endpoints in React.
- While peering with @jim , we noticed a bug in `request.js` (part of the new endpoint calling code) related to a try/catch that didn't return on error.  That's fixed in this PR.

## Setup

- `make server_run`
- `make_client_run`
- Set up a service member (or go to an existing service member) and start the HHG move process.  The first screen of the process has a calendar on it.  You should see some dates now unavailable: weekends, federal holidays, and first 5 business days after today's date.  We also only go 90 days past the start date in our availability checks for now.

## Code Review Verification Steps

* [ ] End to end tests pass (`make e2e_test`).
* [ ] Code follows the guidelines for [Logging](./docs/backend.md#logging)
* [ ] There are no aXe warnings for UI.
* [x] This works in IE.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/160776526) for this change

## Screenshots

Calendar with disabled days:

![screen shot 2018-10-08 at 12 44 56 pm](https://user-images.githubusercontent.com/4960757/46622328-2bc79380-caf8-11e8-876d-29e50e737a25.png)
