### PR TITLE
weights and locations panel full width

### DIFF
--- a/src/scenes/TransportationServiceProvider/Dates.jsx
+++ b/src/scenes/TransportationServiceProvider/Dates.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { get, pick } from 'lodash';
@@ -31,7 +31,7 @@ const DatesDisplay = props => {
     values: props.shipment,
   };
   return (
-    <React.Fragment>
+    <Fragment>
       <div className="editable-panel-column">
         <div className="column-subhead">PM Survey</div>
         <PanelSwaggerField
@@ -97,7 +97,7 @@ const DatesDisplay = props => {
           {...fieldProps}
         />
       </div>
-    </React.Fragment>
+    </Fragment>
   );
 };
 
@@ -108,7 +108,7 @@ const DatesEdit = props => {
     values: props.shipment,
   };
   return (
-    <React.Fragment>
+    <Fragment>
       <FormSection name="dates">
         <div className="editable-panel-column">
           <div className="column-head">PM Survey</div>
@@ -173,7 +173,7 @@ const DatesEdit = props => {
           />
         </div>
       </FormSection>
-    </React.Fragment>
+    </Fragment>
   );
 };
 

--- a/src/scenes/TransportationServiceProvider/Locations.jsx
+++ b/src/scenes/TransportationServiceProvider/Locations.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 
 import { editablePanelify } from 'shared/EditablePanel';
@@ -13,18 +13,22 @@ const LocationsDisplay = ({
     secondary_pickup_address: secondaryPickupAddress,
   },
 }) => (
-  <div className="editable-panel-column">
-    <span className="column-subhead">Pickup</span>
-    <AddressElementDisplay address={pickupAddress} title="Primary" />
-    {hasSecondaryPickupAddress && (
-      <AddressElementDisplay
-        address={secondaryPickupAddress}
-        title="Secondary"
-      />
-    )}
-    <span className="column-subhead">Delivery</span>
-    <AddressElementDisplay address={deliveryAddress} title="Primary" />
-  </div>
+  <Fragment>
+    <div className="editable-panel-column">
+      <span className="column-subhead">Pickup</span>
+      <AddressElementDisplay address={pickupAddress} title="Primary" />
+      {hasSecondaryPickupAddress && (
+        <AddressElementDisplay
+          address={secondaryPickupAddress}
+          title="Secondary"
+        />
+      )}
+    </div>
+    <div className="editable-panel-column">
+      <span className="column-subhead">Delivery</span>
+      <AddressElementDisplay address={deliveryAddress} title="Primary" />
+    </div>
+  </Fragment>
 );
 
 const { shape, string, bool } = PropTypes;

--- a/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
+++ b/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
@@ -245,22 +245,17 @@ class ShipmentInfo extends Component {
                     shipment={this.props.shipment}
                     serviceAgents={this.props.serviceAgents}
                   />
-
-                  <div className="usa-width-one-half">
-                    <Weights
-                      title="Weights & Items"
-                      shipment={this.props.shipment}
-                      update={this.props.patchShipment}
-                    />
-                  </div>
-                  <div className="usa-width-one-half">
-                    <Locations
-                      deliveryAddress={deliveryAddress}
-                      title="Locations"
-                      shipment={this.props.shipment}
-                      update={this.props.patchShipment}
-                    />
-                  </div>
+                  <Weights
+                    title="Weights & Items"
+                    shipment={this.props.shipment}
+                    update={this.props.patchShipment}
+                  />
+                  <Locations
+                    deliveryAddress={deliveryAddress}
+                    title="Locations"
+                    shipment={this.props.shipment}
+                    update={this.props.patchShipment}
+                  />
                 </div>
               )}
             </div>

--- a/src/scenes/TransportationServiceProvider/Weights.jsx
+++ b/src/scenes/TransportationServiceProvider/Weights.jsx
@@ -31,6 +31,8 @@ const WeightsDisplay = props => {
           {...fieldProps}
         />
         <PanelSwaggerField fieldName="actual_weight" required {...fieldProps} />
+      </div>
+      <div className="editable-panel-column">
         <div className="column-subhead">Pro-gear</div>
         <PanelSwaggerField
           fieldName="progear_weight_estimate"
@@ -87,6 +89,8 @@ const WeightsEdit = props => {
             {...fieldProps}
           />
           <SwaggerField fieldName="actual_weight" swagger={schema} required />
+        </div>
+        <div className="editable-panel-column">
           <div className="column-subhead">Pro-gear</div>
           <PanelSwaggerField
             fieldName="progear_weight_estimate"


### PR DESCRIPTION
## Description

This should make the locations and weights panels full screen width rather than half width.


## Setup

`make db_dev_reset && make db_dev_migrate && go run ./cmd/generate_test_data/main.go -scenario=7`

## Code Review Verification Steps

* [x] End to end tests pass (`make e2e_test`).
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/161030173) for this change

## Screenshots

<img width="982" alt="screen shot 2018-10-08 at 2 17 52 pm" src="https://user-images.githubusercontent.com/7401870/46626314-f83f3600-cb04-11e8-9658-ab1973afdc9f.png">
<img width="989" alt="screen shot 2018-10-08 at 2 17 40 pm" src="https://user-images.githubusercontent.com/7401870/46626315-f83f3600-cb04-11e8-8a9e-c33f93ee355b.png">
