### PR TITLE
Els create pre approval request component 160705077

### DIFF
--- a/src/shared/PreApprovalRequest/Creator.jsx
+++ b/src/shared/PreApprovalRequest/Creator.jsx
@@ -1,29 +1,72 @@
 import React, { Component } from 'react';
 import FontAwesomeIcon from '@fortawesome/react-fontawesome';
 import faPlusCircle from '@fortawesome/fontawesome-free-solid/faPlusCircle';
-export default class Creator extends Component {
-  state = { showForm: false };
+import PropTypes from 'prop-types';
+import PreApprovalRequestForm, {
+  formName as PreApprovalRequestFormName,
+} from 'shared/PreApprovalRequestForm';
+import {
+  submit,
+  isValid,
+  isSubmitting,
+  reset,
+  hasSubmitSucceeded,
+} from 'redux-form';
+
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+export class Creator extends Component {
+  state = { showForm: false, closeOnSubmit: true };
+  componentDidUpdate(prevProps, prevState, snapshot) {
+    if (this.props.hasSubmitSucceeded && !prevProps.hasSubmitSucceeded)
+      if (this.state.closeOnSubmit) this.setState({ showForm: false });
+      else this.props.clearForm();
+  }
   openForm = () => {
     this.setState({ showForm: true });
   };
   closeForm = () => {
     this.setState({ showForm: false });
   };
+  onSubmit = values => {
+    this.props.savePreApprovalRequest(values);
+  };
+  saveAndClear = () => {
+    this.setState({ closeOnSubmit: false }, () => {
+      this.props.submitForm();
+    });
+  };
+  saveAndClose = () => {
+    this.setState({ closeOnSubmit: true }, () => {
+      this.props.submitForm();
+    });
+  };
   render() {
     if (this.state.showForm)
       return (
         <div className="accessorial-panel-modal">
           <div className="title">Add a request</div>
-          <div>Form goes here</div>
+          <PreApprovalRequestForm
+            accessorials={this.props.accessorials}
+            onSubmit={this.onSubmit}
+          />
           <div className="usa-grid-full ">
             <div className="usa-width-one-half">
               <a onClick={this.closeForm}>Cancel</a>
             </div>
             <div className="usa-width-one-half align-right">
-              <button className="button button-secondary">
+              <button
+                className="button button-secondary"
+                disabled={!this.props.formEnabled}
+                onClick={this.saveAndClear}
+              >
                 Save &amp; Add Another
-              </button>&nbsp;&nbsp;&nbsp;&nbsp;
-              <button className="button button-primary">
+              </button>
+              <button
+                className="button button-primary"
+                disabled={!this.props.formEnabled}
+                onClick={this.saveAndClose}
+              >
                 Save &amp; Close
               </button>
             </div>
@@ -38,3 +81,28 @@ export default class Creator extends Component {
     );
   }
 }
+Creator.propTypes = {
+  accessorials: PropTypes.array,
+  savePreApprovalRequest: PropTypes.func.isRequired,
+};
+
+function mapStateToProps(state) {
+  return {
+    formEnabled:
+      isValid(PreApprovalRequestFormName)(state) &&
+      !isSubmitting(PreApprovalRequestFormName)(state),
+    hasSubmitSucceeded: hasSubmitSucceeded(PreApprovalRequestFormName)(state),
+  };
+}
+
+function mapDispatchToProps(dispatch) {
+  // Bind an action, which submit the form by its name
+  return bindActionCreators(
+    {
+      submitForm: () => submit(PreApprovalRequestFormName),
+      clearForm: () => reset(PreApprovalRequestFormName),
+    },
+    dispatch,
+  );
+}
+export default connect(mapStateToProps, mapDispatchToProps)(Creator);

--- a/src/shared/PreApprovalRequest/Creator.jsx
+++ b/src/shared/PreApprovalRequest/Creator.jsx
@@ -1,0 +1,40 @@
+import React, { Component } from 'react';
+import FontAwesomeIcon from '@fortawesome/react-fontawesome';
+import faPlusCircle from '@fortawesome/fontawesome-free-solid/faPlusCircle';
+export default class Creator extends Component {
+  state = { showForm: false };
+  openForm = () => {
+    this.setState({ showForm: true });
+  };
+  closeForm = () => {
+    this.setState({ showForm: false });
+  };
+  render() {
+    if (this.state.showForm)
+      return (
+        <div className="accessorial-panel-modal">
+          <div className="title">Add a request</div>
+          <div>Form goes here</div>
+          <div className="usa-grid-full ">
+            <div className="usa-width-one-half">
+              <a onClick={this.closeForm}>Cancel</a>
+            </div>
+            <div className="usa-width-one-half align-right">
+              <button className="button button-secondary">
+                Save &amp; Add Another
+              </button>&nbsp;&nbsp;&nbsp;&nbsp;
+              <button className="button button-primary">
+                Save &amp; Close
+              </button>
+            </div>
+          </div>
+        </div>
+      );
+    return (
+      <a onClick={this.openForm}>
+        <FontAwesomeIcon className="icon link-blue" icon={faPlusCircle} />
+        Add a request
+      </a>
+    );
+  }
+}

--- a/src/shared/PreApprovalRequest/Creator.jsx
+++ b/src/shared/PreApprovalRequest/Creator.jsx
@@ -84,6 +84,10 @@ export class Creator extends Component {
 Creator.propTypes = {
   accessorials: PropTypes.array,
   savePreApprovalRequest: PropTypes.func.isRequired,
+  formEnabled: PropTypes.bool.isRequired,
+  hasSubmitSucceeded: PropTypes.bool.isRequired,
+  submitForm: PropTypes.func.isRequired,
+  clearForm: PropTypes.func.isRequired,
 };
 
 function mapStateToProps(state) {

--- a/src/shared/PreApprovalRequest/Creator.test.js
+++ b/src/shared/PreApprovalRequest/Creator.test.js
@@ -1,0 +1,123 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+
+import configureStore from 'redux-mock-store';
+import { mount } from 'enzyme';
+
+import { Creator } from './Creator';
+import { no_op } from 'shared/utils';
+
+const accessorials = [
+  {
+    id: 'sdlfkj',
+    code: 'F9D',
+    item: 'Long Haul',
+  },
+  {
+    id: 'badfka',
+    code: '19D',
+    item: 'Crate',
+  },
+];
+const submit = jest.fn();
+const clear = jest.fn();
+const mockStore = configureStore();
+let store;
+let wrapper;
+describe('given a Creator', () => {
+  describe('when the form is disabled', () => {
+    beforeEach(() => {
+      store = mockStore({});
+      //mount appears to be necessary to get inner components to load (i.e. tests fail with shallow)
+      wrapper = mount(
+        <Provider store={store}>
+          <Creator
+            accessorials={accessorials}
+            submitForm={submit}
+            formEnabled={false}
+            hasSubmitSucceeded={false}
+            savePreApprovalRequest={no_op}
+            clearForm={clear}
+          />
+        </Provider>,
+      );
+    });
+
+    it('renders without crashing', () => {
+      // eslint-disable-next-line
+      expect(wrapper.exists('a')).toBe(true);
+    });
+    it('can toggle to show the form', () => {
+      wrapper.find('a').simulate('click');
+      expect(wrapper.exists('div.accessorial-panel-modal')).toBe(true);
+    });
+    it('cancel closes the form', () => {
+      wrapper.find('a').simulate('click');
+      expect(wrapper.exists('div.accessorial-panel-modal')).toBe(true);
+      wrapper.find('a').simulate('click');
+      expect(wrapper.exists('div.accessorial-panel-modal')).toBe(false);
+    });
+    it('buttons are disabled', () => {
+      wrapper.find('a').simulate('click');
+      expect(
+        wrapper.find('button.button-primary').prop('disabled'),
+      ).toBeTruthy();
+      expect(
+        wrapper.find('button.button-secondary').prop('disabled'),
+      ).toBeTruthy();
+    });
+  });
+  describe('when the form is enabled', () => {
+    beforeEach(() => {
+      submit.mockClear();
+      store = mockStore({});
+      //mount appears to be necessary to get inner components to load (i.e. tests fail with shallow)
+      wrapper = mount(
+        <Provider store={store}>
+          <Creator
+            accessorials={accessorials}
+            submitForm={submit}
+            formEnabled={true}
+            hasSubmitSucceeded={false}
+            savePreApprovalRequest={no_op}
+            clearForm={clear}
+          />
+        </Provider>,
+      );
+    });
+
+    it('renders without crashing', () => {
+      // eslint-disable-next-line
+      expect(wrapper.exists('a')).toBe(true);
+    });
+    it('can toggle to show the form', () => {
+      wrapper.find('a').simulate('click');
+      expect(wrapper.exists('div.accessorial-panel-modal')).toBe(true);
+    });
+    it('cancel closes the form', () => {
+      wrapper.find('a').simulate('click');
+      expect(wrapper.exists('div.accessorial-panel-modal')).toBe(true);
+      wrapper.find('a').simulate('click');
+      expect(wrapper.exists('div.accessorial-panel-modal')).toBe(false);
+    });
+    it('buttons are enabled', () => {
+      wrapper.find('a').simulate('click');
+      expect(wrapper.find('button.button-secondary').prop('disabled')).toBe(
+        false,
+      );
+      expect(wrapper.find('button.button-primary').prop('disabled')).toBe(
+        false,
+      );
+    });
+    it('clicking save & add another calls submitForm', () => {
+      wrapper.find('a').simulate('click');
+      wrapper.find('button.button-secondary').simulate('click');
+      expect(submit.mock.calls.length).toBe(1);
+    });
+    it('clicking save & close calls submitForm', () => {
+      wrapper.find('a').simulate('click');
+      wrapper.find('button.button-primary').simulate('click');
+      expect(submit.mock.calls.length).toBe(1);
+    });
+  });
+});

--- a/src/shared/PreApprovalRequest/index.css
+++ b/src/shared/PreApprovalRequest/index.css
@@ -1,4 +1,3 @@
-
 .accessorial-panel {
   border-width: 3px;
   empty-cells: hide;
@@ -64,3 +63,18 @@
   cursor: pointer;
 }
 
+.accessorial-panel-modal {
+  border: 3px dashed #00a6d2;
+  padding-left: 1.7rem;
+  padding-right: 1.7rem;
+  padding-top: 8px;
+  padding-bottom: 9px;
+}
+
+.accessorial-panel-modal .title {
+  font-size: 2rem;
+  font-weight: bold;
+}
+.accessorial-panel .align-right {
+  text-align: right !important;
+}

--- a/src/shared/ScratchPad/index.jsx
+++ b/src/shared/ScratchPad/index.jsx
@@ -6,8 +6,8 @@ import PreApprovalRequestForm, {
 import { submit, isValid, isSubmitting } from 'redux-form';
 import PreApprovalRequest from 'shared/PreApprovalRequest';
 import { connect } from 'react-redux';
+import Creator from 'shared/PreApprovalRequest/Creator';
 import { bindActionCreators } from 'redux';
-
 class ScratchPad extends Component {
   onSubmit = values => {
     console.log('onSubmit', values);
@@ -71,6 +71,9 @@ class ScratchPad extends Component {
               >
                 Submit
               </button>
+            </BasicPanel>
+            <BasicPanel title="Creator Test">
+                <Creator />
             </BasicPanel>
           </div>
           <div className="usa-width-one-third">

--- a/src/shared/ScratchPad/index.jsx
+++ b/src/shared/ScratchPad/index.jsx
@@ -10,13 +10,30 @@ import Creator from 'shared/PreApprovalRequest/Creator';
 import { bindActionCreators } from 'redux';
 class ScratchPad extends Component {
   onSubmit = values => {
-    console.log('onSubmit', values);
+    return new Promise(function(resolve, reject) {
+      // do a thing, possibly async, then…
+      setTimeout(function() {
+        console.log('onSubmit async', values);
+        resolve('success');
+      }, 50);
+    });
   };
   onEdit = () => {};
   onDelete = () => {};
   onApproval = () => {};
-
   render() {
+    const accessorials = [
+      {
+        id: 'sdlfkj',
+        code: 'F9D',
+        item: 'Long Haul',
+      },
+      {
+        id: 'badfka',
+        code: '19D',
+        item: 'Crate',
+      },
+    ];
     const shipment_accessorials = [
       {
         code: '105D',
@@ -51,18 +68,7 @@ class ScratchPad extends Component {
                 onApproval={this.onApproval}
               />
               <PreApprovalRequestForm
-                accessorials={[
-                  {
-                    id: 'sdlfkj',
-                    code: 'F9D',
-                    item: 'Long Haul',
-                  },
-                  {
-                    id: 'badfka',
-                    code: '19D',
-                    item: 'Crate',
-                  },
-                ]}
+                accessorials={accessorials}
                 onSubmit={this.onSubmit}
               />
               <button
@@ -73,7 +79,10 @@ class ScratchPad extends Component {
               </button>
             </BasicPanel>
             <BasicPanel title="Creator Test">
-                <Creator />
+              <Creator
+                accessorials={accessorials}
+                savePreApprovalRequest={this.onSubmit}
+              />
             </BasicPanel>
           </div>
           <div className="usa-width-one-third">


### PR DESCRIPTION
## Description
This creates a component for creating Pre Approval Requests
See the high-level component breakdown plan here: docs.google.com/document/d/1-J1IgE9we1k0Y95VqP1gTPSSwOkvVkV0GW7y3WSZVa8/edit#heading=h.d3cwrkv1qmmf

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Setup

Setup
go to tsplocal:3000/playground and look for "Creator Test"

## Code Review Verification Steps

* [ ] End to end tests pass (`make e2e_test`).
* [ ] Code follows the guidelines for [Logging](./docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](./docs/backend.md#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Update the diagram in docs/schema/dp3.sqs (see [Updating and changing the model](./docs/schema/README.md#updating-and-changing-the-model))
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](./docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
* [ ] There are no aXe warnings for UI.
* [ ] This works in IE.
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @willowbl00
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](tbd) for this change
* [this article](tbd) explains more about the approach used.

## Screenshots

If this PR makes visible UI changes, an image of the finished UI can help reviewers and casual
observers understand the context of the changes. A before image is optional and
can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow instead of using multiple images. You may want to use GIPHY CAPTURE for this! 📸

_Please frame screenshots to show enough useful context but also highlight the affected regions._
