### PR TITLE
Changed styling of edit links; changed section title

### DIFF
--- a/src/scenes/Review/Review.css
+++ b/src/scenes/Review/Review.css
@@ -1,6 +1,7 @@
 .edit-title {
   margin-top: 1.5rem;
 }
+
 .review-content {
   border-top: 1px solid black;
   border-bottom: 1px solid black;
@@ -36,20 +37,23 @@
   padding: 0.2rem 0rem 0.2rem 0rem;
   width: 50%;
 }
+
 .review-section td:first-child {
   color: grey;
   border: 0px;
 }
-.align-right a {
-  float: right;
-  text-align: right;
+
+.edit-section-link a {
+  margin-left: 20px;
   text-decoration: none;
   font-weight: normal;
 }
+
 .ppm-container {
   margin: 4rem 0rem 0rem 0rem;
   border: solid 1px;
 }
+
 .ppm-container h3 {
   background-color: rgb(209, 219, 233);
   padding: 1.5rem 1rem 1.5rem 1rem;
@@ -59,9 +63,11 @@
 .ppm-container img {
   height: 20px;
 }
+
 .ppm-review-section {
   padding: 2.5rem;
 }
+
 .review-todo {
   background-color: yellow;
 }
@@ -69,6 +75,7 @@
 .spacer {
   margin-top: 2em;
 }
+
 .approved-edit-warning {
   margin-top: 2em;
   color: gray;

--- a/src/scenes/Review/Summary.jsx
+++ b/src/scenes/Review/Summary.jsx
@@ -154,8 +154,8 @@ export class Summary extends Component {
               <tbody>
                 <tr>
                   <th>
-                    Profile{' '}
-                    <span className="align-right">
+                    Profile
+                    <span className="edit-section-link">
                       <Link to={editProfileAddress}>Edit</Link>
                     </span>
                   </th>
@@ -200,7 +200,7 @@ export class Summary extends Component {
                       Orders
                       {moveIsApproved && '*'}
                       {!moveIsApproved && (
-                        <span className="align-right">
+                        <span className="edit-section-link">
                           <Link to={editOrdersAddress}>Edit</Link>
                         </span>
                       )}
@@ -269,8 +269,8 @@ export class Summary extends Component {
               <tbody>
                 <tr>
                   <th>
-                    Contact Info{' '}
-                    <span className="align-right">
+                    Contact Info
+                    <span className="edit-section-link">
                       <Link to={editContactInfoAddress}>Edit</Link>
                     </span>
                   </th>
@@ -312,8 +312,8 @@ export class Summary extends Component {
                 <tbody>
                   <tr>
                     <th>
-                      Backup Contact{' '}
-                      <span className="align-right">
+                      Backup Contact Info
+                      <span className="edit-section-link">
                         <Link to={editBackupContactAddress}>Edit</Link>
                       </span>
                     </th>
@@ -351,7 +351,7 @@ export class Summary extends Component {
                     <tr>
                       <th>
                         Dates & Locations
-                        <span className="align-right">
+                        <span className="edit-section-link">
                           <Link to={editDateAndLocationAddress}>Edit</Link>
                         </span>
                       </th>
@@ -392,7 +392,7 @@ export class Summary extends Component {
                     <tr>
                       <th>
                         Weight
-                        <span className="align-right">
+                        <span className="edit-section-link">
                           <Link to={editWeightAddress}>Edit</Link>
                         </span>
                       </th>


### PR DESCRIPTION
## Description

This PR just changes some styles in the Summary component (aka Review page).  The `Edit` links are now moved over 20 pixels from the section titles and the `Backup Contact` section is now named `Backup Contact Info`.

## Reviewer Notes

To maintain consistency, note that I also changed the `Edit` links that show up on the same page for a PPM.  We will need to make sure the upcoming HHG shipment section does the same.

## Setup

`make server_run`
`make client_run`
Create either a PPM or HHG move to the point of the Review page and examine the styles mentioned above.

## Code Review Verification Steps

* [ ] End to end tests pass (`make e2e_test`).
* [ ] There are no aXe warnings for UI.
* [ ] This works in IE.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/160906453) for this change

## Screenshots

Before:
<img width="257" alt="screen shot 2018-10-08 at 3 38 39 pm" src="https://user-images.githubusercontent.com/4960757/46630092-1dd23c80-cb11-11e8-9887-5cc95ddd82ae.png">

After:
<img width="248" alt="screen shot 2018-10-08 at 3 36 09 pm" src="https://user-images.githubusercontent.com/4960757/46630077-0dba5d00-cb11-11e8-9d66-ed0d1106a9f6.png">
