### PR TITLE
Implements GET handler for Tariff400ng items [delivers #160876387]

### DIFF
--- a/pkg/handlers/publicapi/api.go
+++ b/pkg/handlers/publicapi/api.go
@@ -46,6 +46,8 @@ func NewPublicAPIHandler(context handlers.HandlerContext) http.Handler {
 	publicAPI.AccessorialsCreateShipmentAccessorialHandler = CreateShipmentAccessorialHandler{context}
 	publicAPI.AccessorialsDeleteShipmentAccessorialHandler = DeleteShipmentAccessorialHandler{context}
 
+	publicAPI.AccessorialsGetTariff400ngItemsHandler = GetTariff400ngItemsHandler{context}
+
 	// Service Agents
 	publicAPI.ServiceAgentsIndexServiceAgentsHandler = IndexServiceAgentsHandler{context}
 	publicAPI.ServiceAgentsCreateServiceAgentHandler = CreateServiceAgentHandler{context}

--- a/pkg/handlers/publicapi/shipment_accessorials_test.go
+++ b/pkg/handlers/publicapi/shipment_accessorials_test.go
@@ -89,7 +89,7 @@ func (suite *HandlerSuite) TestCreateShipmentAccessorialHandler() {
 
 	// Two shipment accessorials tied to two different shipments
 	shipment := testdatagen.MakeDefaultShipment(suite.TestDB())
-	acc := testdatagen.MakeDummy400ngItem(suite.TestDB())
+	acc := testdatagen.MakeDefaultTariff400ngItem(suite.TestDB())
 
 	// And: the context contains the auth values
 	req := httptest.NewRequest("POST", "/shipments", nil)
@@ -145,7 +145,7 @@ func (suite *HandlerSuite) TestUpdateShipmentAccessorialTSPHandler() {
 
 	testdatagen.MakeDefaultShipmentAccessorial(suite.TestDB())
 	// create a new accessorial to test
-	updateAcc1 := testdatagen.MakeDummy400ngItem(suite.TestDB())
+	updateAcc1 := testdatagen.MakeDefaultTariff400ngItem(suite.TestDB())
 	// And: the context contains the auth values
 	req := httptest.NewRequest("PUT", "/shipments", nil)
 	req = suite.AuthenticateTspRequest(req, tspUser)
@@ -197,7 +197,7 @@ func (suite *HandlerSuite) TestUpdateShipmentAccessorialOfficeHandler() {
 	testdatagen.MakeDefaultShipmentAccessorial(suite.TestDB())
 
 	// create a new accessorial to test
-	updateAcc1 := testdatagen.MakeDummy400ngItem(suite.TestDB())
+	updateAcc1 := testdatagen.MakeDefaultTariff400ngItem(suite.TestDB())
 
 	// And: the context contains the auth values
 	req := httptest.NewRequest("PUT", "/shipments", nil)

--- a/pkg/handlers/publicapi/tariff400ng_items.go
+++ b/pkg/handlers/publicapi/tariff400ng_items.go
@@ -1,13 +1,17 @@
 package publicapi
 
 import (
+	"github.com/go-openapi/runtime/middleware"
+	"github.com/transcom/mymove/pkg/auth"
 	"github.com/transcom/mymove/pkg/gen/apimessages"
+	accessorialop "github.com/transcom/mymove/pkg/gen/restapi/apioperations/accessorials"
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/models"
+	"go.uber.org/zap"
 )
 
-func payloadForTariff400ngItemModels(s []models.Tariff400ngItem) apimessages.Accessorials {
-	payloads := make(apimessages.Accessorials, len(s))
+func payloadForTariff400ngItemModels(s []models.Tariff400ngItem) apimessages.Tariff400ngItems {
+	payloads := make(apimessages.Tariff400ngItems, len(s))
 
 	for i, acc := range s {
 		payloads[i] = payloadForTariff400ngItemModel(&acc)
@@ -16,12 +20,12 @@ func payloadForTariff400ngItemModels(s []models.Tariff400ngItem) apimessages.Acc
 	return payloads
 }
 
-func payloadForTariff400ngItemModel(a *models.Tariff400ngItem) *apimessages.Accessorial {
+func payloadForTariff400ngItemModel(a *models.Tariff400ngItem) *apimessages.Tariff400ngItem {
 	if a == nil {
 		return nil
 	}
 
-	return &apimessages.Accessorial{
+	return &apimessages.Tariff400ngItem{
 		ID:           *handlers.FmtUUID(a.ID),
 		Code:         *handlers.FmtString(a.Code),
 		DiscountType: *handlers.FmtString(string(a.DiscountType)),
@@ -33,4 +37,27 @@ func payloadForTariff400ngItemModel(a *models.Tariff400ngItem) *apimessages.Acce
 		CreatedAt:    *handlers.FmtDateTime(a.CreatedAt),
 		UpdatedAt:    *handlers.FmtDateTime(a.UpdatedAt),
 	}
+}
+
+// GetTariff400ngItemsHandler returns a particular shipment
+type GetTariff400ngItemsHandler struct {
+	handlers.HandlerContext
+}
+
+// Handle returns a specified shipment
+func (h GetTariff400ngItemsHandler) Handle(params accessorialop.GetTariff400ngItemsParams) middleware.Responder {
+	session := auth.SessionFromRequestContext(params.HTTPRequest)
+
+	if session == nil {
+		return accessorialop.NewGetTariff400ngItemsUnauthorized()
+	}
+
+	// params.RequiresPreApproval has a default so we don't need to nil-check it
+	items, err := models.FetchTariff400ngItems(h.DB(), *params.RequiresPreApproval)
+	if err != nil {
+		h.Logger().Error("Error fetching accessorials for shipment", zap.Error(err))
+		return accessorialop.NewGetTariff400ngItemsInternalServerError()
+	}
+	payload := payloadForTariff400ngItemModels(items)
+	return accessorialop.NewGetTariff400ngItemsOK().WithPayload(payload)
 }

--- a/pkg/handlers/publicapi/tariff400ng_items.go
+++ b/pkg/handlers/publicapi/tariff400ng_items.go
@@ -39,12 +39,12 @@ func payloadForTariff400ngItemModel(a *models.Tariff400ngItem) *apimessages.Tari
 	}
 }
 
-// GetTariff400ngItemsHandler returns a particular shipment
+// GetTariff400ngItemsHandler returns a list of 400ng items
 type GetTariff400ngItemsHandler struct {
 	handlers.HandlerContext
 }
 
-// Handle returns a specified shipment
+// Handle returns a list of 400ng items
 func (h GetTariff400ngItemsHandler) Handle(params accessorialop.GetTariff400ngItemsParams) middleware.Responder {
 	session := auth.SessionFromRequestContext(params.HTTPRequest)
 
@@ -55,7 +55,7 @@ func (h GetTariff400ngItemsHandler) Handle(params accessorialop.GetTariff400ngIt
 	// params.RequiresPreApproval has a default so we don't need to nil-check it
 	items, err := models.FetchTariff400ngItems(h.DB(), *params.RequiresPreApproval)
 	if err != nil {
-		h.Logger().Error("Error fetching accessorials for shipment", zap.Error(err))
+		h.Logger().Error("Error fetching 400ng items", zap.Error(err))
 		return accessorialop.NewGetTariff400ngItemsInternalServerError()
 	}
 	payload := payloadForTariff400ngItemModels(items)

--- a/pkg/handlers/publicapi/tariff400ng_items_test.go
+++ b/pkg/handlers/publicapi/tariff400ng_items_test.go
@@ -1,0 +1,60 @@
+package publicapi
+
+import (
+	"net/http/httptest"
+
+	accessorialop "github.com/transcom/mymove/pkg/gen/restapi/apioperations/accessorials"
+	"github.com/transcom/mymove/pkg/handlers"
+	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/testdatagen"
+)
+
+func (suite *HandlerSuite) getTariff400ngItemsParams(tspUser models.TspUser, requiresPreApproval bool) accessorialop.GetTariff400ngItemsParams {
+	// And: the context contains the auth values
+	req := httptest.NewRequest("GET", "/tariff400ng_items", nil)
+	req = suite.AuthenticateTspRequest(req, tspUser)
+
+	return accessorialop.GetTariff400ngItemsParams{
+		HTTPRequest:         req,
+		RequiresPreApproval: handlers.FmtBool(requiresPreApproval),
+	}
+}
+
+func (suite *HandlerSuite) TestGetTariff400ngItemsHandler() {
+	// Does not require pre-approval
+	testdatagen.MakeDefaultTariff400ngItem(suite.TestDB())
+	// Does require pre-approval
+	item2 := testdatagen.MakeTariff400ngItem(suite.TestDB(), testdatagen.Assertions{
+		Tariff400ngItem: models.Tariff400ngItem{
+			Code:                "9000",
+			RequiresPreApproval: true,
+		},
+	})
+
+	tspUser := testdatagen.MakeDefaultTspUser(suite.TestDB())
+
+	// Test that only pre-approval items are returned
+	requireParams := suite.getTariff400ngItemsParams(tspUser, true)
+	handler := GetTariff400ngItemsHandler{handlers.NewHandlerContext(suite.TestDB(), suite.TestLogger())}
+	response := handler.Handle(requireParams)
+
+	// Then: expect a 200 status code
+	suite.Assertions.IsType(&accessorialop.GetTariff400ngItemsOK{}, response)
+	okResponse := response.(*accessorialop.GetTariff400ngItemsOK)
+
+	// And: Payload returned is the one requiring pre-approval
+	suite.Len(okResponse.Payload, 1)
+	suite.Equal(okResponse.Payload[0].Code, item2.Code)
+
+	// Test that all items are returned
+	requireParams = suite.getTariff400ngItemsParams(tspUser, false)
+	handler = GetTariff400ngItemsHandler{handlers.NewHandlerContext(suite.TestDB(), suite.TestLogger())}
+	response = handler.Handle(requireParams)
+
+	// Then: expect a 200 status code
+	suite.Assertions.IsType(&accessorialop.GetTariff400ngItemsOK{}, response)
+	okResponse = response.(*accessorialop.GetTariff400ngItemsOK)
+
+	// And: Test that both items are returned
+	suite.Len(okResponse.Payload, 2)
+}

--- a/pkg/models/shipment_test.go
+++ b/pkg/models/shipment_test.go
@@ -190,7 +190,7 @@ func (suite *ModelSuite) TestShipmentAssignGBLNumber() {
 
 // TestShipmentAssignGBLNumber tests that a GBL number is created correctly
 func (suite *ModelSuite) TestCreateShipmentAccessorial() {
-	acc := testdatagen.MakeDummy400ngItem(suite.db)
+	acc := testdatagen.MakeDefaultTariff400ngItem(suite.db)
 	shipment := testdatagen.MakeDefaultShipment(suite.db)
 
 	q1 := int64(5)

--- a/pkg/models/tariff400ng_item.go
+++ b/pkg/models/tariff400ng_item.go
@@ -92,12 +92,18 @@ type Tariff400ngItem struct {
 }
 
 // FetchTariff400ngItems returns a list of 400ng items
-func FetchTariff400ngItems(dbConnection *pop.Connection) ([]Tariff400ngItem, error) {
+func FetchTariff400ngItems(dbConnection *pop.Connection, onlyRequiresPreApproval bool) ([]Tariff400ngItem, error) {
 	var err error
 
 	items := []Tariff400ngItem{}
 
-	err = dbConnection.All(&items)
+	query := dbConnection.Q()
+
+	if onlyRequiresPreApproval {
+		query = query.Where("requires_pre_approval = $1", true)
+	}
+
+	err = query.All(&items)
 	if err != nil {
 		return items, errors.Wrap(err, "400ng items query failed")
 	}

--- a/pkg/models/tariff400ng_item_test.go
+++ b/pkg/models/tariff400ng_item_test.go
@@ -6,10 +6,10 @@ import (
 )
 
 func (suite *ModelSuite) TestFetchAccessorials() {
-	accessorial := testdatagen.MakeDummy400ngItem(suite.db)
+	accessorial := testdatagen.MakeDefaultTariff400ngItem(suite.db)
 
 	//Do
-	accs, err := models.FetchTariff400ngItems(suite.db)
+	accs, err := models.FetchTariff400ngItems(suite.db, false)
 
 	//Test
 	suite.NoError(err)

--- a/pkg/testdatagen/make_accessorial_records.go
+++ b/pkg/testdatagen/make_accessorial_records.go
@@ -8,24 +8,6 @@ import (
 	"github.com/transcom/mymove/pkg/unit"
 )
 
-// MakeDummy400ngItem creates a hardcoded accessorial model
-// This should be deprecated quickly once we get the real codes into the db
-func MakeDummy400ngItem(db *pop.Connection) models.Tariff400ngItem {
-	item := models.Tariff400ngItem{
-		Code:             "105B",
-		Item:             "Pack Reg Crate",
-		DiscountType:     models.Tariff400ngItemDiscountTypeNONE,
-		AllowedLocation:  models.Tariff400ngItemAllowedLocationEITHER,
-		MeasurementUnit1: models.Tariff400ngItemMeasurementUnitEACH,
-		MeasurementUnit2: models.Tariff400ngItemMeasurementUnitNONE,
-		RateRefCode:      models.Tariff400ngItemRateRefCodeNONE,
-	}
-
-	mustCreate(db, &item)
-
-	return item
-}
-
 // MakeShipmentAccessorial creates a single accessorial record
 func MakeShipmentAccessorial(db *pop.Connection, assertions Assertions) models.ShipmentAccessorial {
 	shipmentID := assertions.ShipmentAccessorial.ShipmentID
@@ -36,7 +18,7 @@ func MakeShipmentAccessorial(db *pop.Connection, assertions Assertions) models.S
 
 	accessorial := assertions.ShipmentAccessorial.Accessorial
 	if isZeroUUID(accessorial.ID) {
-		accessorial = MakeDummy400ngItem(db)
+		accessorial = MakeDefaultTariff400ngItem(db)
 	}
 
 	//filled in dummy data

--- a/pkg/testdatagen/make_tariff400ng_items.go
+++ b/pkg/testdatagen/make_tariff400ng_items.go
@@ -1,0 +1,32 @@
+package testdatagen
+
+import (
+	"github.com/gobuffalo/pop"
+	"github.com/transcom/mymove/pkg/models"
+)
+
+// MakeTariff400ngItem creates a single accessorial record
+func MakeTariff400ngItem(db *pop.Connection, assertions Assertions) models.Tariff400ngItem {
+	item := models.Tariff400ngItem{
+		Code:                "105B",
+		Item:                "Pack Reg Crate",
+		DiscountType:        models.Tariff400ngItemDiscountTypeNONE,
+		AllowedLocation:     models.Tariff400ngItemAllowedLocationEITHER,
+		MeasurementUnit1:    models.Tariff400ngItemMeasurementUnitEACH,
+		MeasurementUnit2:    models.Tariff400ngItemMeasurementUnitNONE,
+		RateRefCode:         models.Tariff400ngItemRateRefCodeNONE,
+		RequiresPreApproval: false,
+	}
+
+	// Overwrite values with those from assertions
+	mergeModels(&item, assertions.Tariff400ngItem)
+
+	mustCreate(db, &item)
+
+	return item
+}
+
+// MakeDefaultTariff400ngItem makes a 400ng item with default values
+func MakeDefaultTariff400ngItem(db *pop.Connection) models.Tariff400ngItem {
+	return MakeTariff400ngItem(db, Assertions{})
+}

--- a/pkg/testdatagen/shared.go
+++ b/pkg/testdatagen/shared.go
@@ -38,6 +38,7 @@ type Assertions struct {
 	Shipment                                 models.Shipment
 	ShipmentAccessorial                      models.ShipmentAccessorial
 	ShipmentOffer                            models.ShipmentOffer
+	Tariff400ngItem                          models.Tariff400ngItem
 	Tariff400ngZip3                          models.Tariff400ngZip3
 	TrafficDistributionList                  models.TrafficDistributionList
 	TransportationOffice                     models.TransportationOffice

--- a/swagger/api.yaml
+++ b/swagger/api.yaml
@@ -160,11 +160,11 @@ definitions:
       SUBMITTED: Submitted
       APPROVED: Approved
       INVOICED: Invoiced
-  Accessorials:
+  Tariff400ngItems:
     type: array
     items:
-      $ref: '#/definitions/Accessorial'
-  Accessorial:
+      $ref: '#/definitions/Tariff400ngItem'
+  Tariff400ngItem:
     type: object
     properties:
       id:
@@ -219,7 +219,7 @@ definitions:
         format: uuid
         example: c56a4180-65aa-42ec-a945-5fd21dec0538
       accessorial:
-        $ref: '#/definitions/Accessorial'
+        $ref: '#/definitions/Tariff400ngItem'
       quantity_1:
         type: integer
         title: Base Quantity
@@ -1277,22 +1277,28 @@ definitions:
         additionalProperties:
           type: string
 paths:
-  /accessorials:
+  /tariff_400ng_items:
     get:
-      summary: Retrieve list of accessorials
-      description: Gets a list of all accessorials.
-      operationId: getAccessorials
+      summary: Retrieve list of 400ng items
+      description: Gets a list of all 400ng items.
+      operationId: getTariff400ngItems
       tags:
         - accessorials
+      parameters:
+        - in: query
+          name: requires_pre_approval
+          type: boolean
+          default: false
+          description: restricts the list to only items that require pre-approval
       responses:
         200:
-          description: list of accessorials
+          description: list of tariff 400ng items
           schema:
-            $ref: '#/definitions/Accessorials'
+            $ref: '#/definitions/Tariff400ngItems'
         400:
           description: invalid request
-        403:
-          description: not authorized to get list of accessorials
+        401:
+          description: not authorized to get list of tariff 400ng items
         500:
           description: server error
   /blackouts:


### PR DESCRIPTION
## Description

Adds handler that allows retrieval of 400ng items list. Optional query param for only returning items that require pre-approval

## Code Review Verification Steps

* [ ] End to end tests pass (`make e2e_test`).
* [ ] Code follows the guidelines for [Logging](./docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](./docs/backend.md#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Update the diagram in docs/schema/dp3.sqs (see [Updating and changing the model](./docs/schema/README.md#updating-and-changing-the-model))
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](./docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
* [ ] There are no aXe warnings for UI.
* [ ] This works in IE.
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @willowbl00
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/160876387) for this change