### PR TITLE
Remove terraform pre-commit plugins

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,12 +35,6 @@ repos:
     hooks:
       - id: shell-lint
 
-  - repo: git://github.com/kintoandar/pre-commit.git
-    rev: v2.1.0
-    hooks:
-      - id: terraform_fmt
-      - id: terraform_validate
-
   - repo: local
     hooks:
       - id: prettier


### PR DESCRIPTION
## Description

Removes not-used pre-commit plugins: `terraform_fmt`, and `terraform_validate`.