### PR TITLE
CircleCI build_tag_push command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,6 +96,22 @@ commands:
               fi;
             done;
             exit 1
+  build_tag_push:
+    parameters:
+      dockerfile:
+        type: string
+      tag:
+        type: string
+      repo:
+        type: string
+    steps:
+      - run:
+          name: "Build, tag, and push docker image << parameters.tag >> from Dockerfile << parameters.dockerfile >>"
+          command: |
+            docker build -f << parameters.dockerfile >> -t << parameters.tag >> .
+            bash -c "$(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION)"
+            docker tag << parameters.tag >> ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/<< parameters.repo >>:git-${CIRCLE_SHA1}
+            docker push ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/<< parameters.repo >>:git-${CIRCLE_SHA1}
 
 jobs:
 
@@ -323,14 +339,10 @@ jobs:
             SECURE_MIGRATION_DIR: /home/circleci/go/src/github.com/transcom/mymove/local_migrations
             SECURE_MIGRATION_SOURCE: local
       - run: make tools_build
-      - run: make server_build_docker
-      - run:
-          name: Tag and push image
-          command: |
-            bash -c "$(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION)"
-            docker tag ppp:web-dev ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/app:git-${CIRCLE_SHA1}
-            docker push ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/app:git-${CIRCLE_SHA1}
-
+      - build_tag_push:
+          dockerfile: Dockerfile
+          tag: ppp:web-dev
+          repo: app
       - announce_failure
 
   build_migrations:
@@ -339,13 +351,10 @@ jobs:
       - checkout
       - setup_remote_docker:
           docker_layer_caching: true
-      - run: make db_build_docker
-      - run:
-          name: Tag and push migrations image
-          command: |
-            bash -c "$(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION)"
-            docker tag ppp-migrations:dev ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/app-migrations:git-${CIRCLE_SHA1}
-            docker push ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/app-migrations:git-${CIRCLE_SHA1}
+      - build_tag_push:
+          dockerfile: Dockerfile.migrations
+          tag: ppp-migrations:dev
+          repo: app-migrations
       - announce_failure
 
   deploy_experimental_migrations:

--- a/Makefile
+++ b/Makefile
@@ -122,14 +122,6 @@ tools_build: server_deps
 tsp_run: tools_build db_dev_run
 	./bin/tsp-award-queue
 
-tsp_build_docker:
-	docker build . -f Dockerfile.tsp -t ppp:tsp-dev
-
-tsp_run_only_docker: db_dev_run
-	docker stop tsp || true
-	docker rm tsp || true
-	docker run --name tsp ppp:tsp-dev
-
 build: server_build tools_build client_build
 
 server_test: server_deps server_generate db_dev_run db_test_reset

--- a/Makefile
+++ b/Makefile
@@ -109,13 +109,6 @@ server_run_debug:
 	INTERFACE=localhost DEBUG_LOGGING=true \
 	$(AWS_VAULT) dlv debug cmd/webserver/main.go
 
-server_build_docker:
-	docker build . -t ppp:web-dev
-server_run_only_docker: db_dev_run
-	docker stop web || true
-	docker rm web || true
-	docker run --name web -p 8080:8080 ppp:web-dev
-
 tools_build: server_deps
 	go build -i -o bin/tsp-award-queue ./cmd/tsp_award_queue
 	go build -i -o bin/generate-test-data ./cmd/generate_test_data
@@ -131,6 +124,7 @@ tsp_run: tools_build db_dev_run
 
 tsp_build_docker:
 	docker build . -f Dockerfile.tsp -t ppp:tsp-dev
+
 tsp_run_only_docker: db_dev_run
 	docker stop tsp || true
 	docker rm tsp || true
@@ -194,8 +188,6 @@ db_dev_migrate_down: server_deps db_dev_run
 	# We need to move to the bin/ directory so that the cwd contains `apply-secure-migration.sh`
 	cd bin && \
 		./soda -c ../config/database.yml -p ../migrations migrate down
-db_build_docker:
-	docker build -f Dockerfile.migrations -t ppp-migrations:dev .
 
 db_e2e_init: tools_build db_dev_run db_test_reset
 	DB_HOST=localhost DB_PORT=5432 DB_NAME=test_db \
@@ -241,6 +233,6 @@ clean:
 	rm -rf $$GOPATH/pkg/dep/sources
 
 .PHONY: pre-commit deps test client_deps client_build client_run client_test prereqs
-.PHONY: server_deps_update server_generate server_go_bindata server_deps server_build server_run_standalone server_run server_run_default server_build_docker server_run_only_docker server_test
+.PHONY: server_deps_update server_generate server_go_bindata server_deps server_build server_run_standalone server_run server_run_default server_test
 .PHONY: db_dev_init db_dev_run db_dev_reset db_dev_migrate db_dev_migrate_down db_test_reset
 .PHONY: clean pretty


### PR DESCRIPTION
## Description

This PR uses the new `command` syntax in CircleCI 2.1 (https://circleci.com/docs/2.0/reusing-config/#authoring-reusable-commands) to consolidate  docker build, tag, and push steps into one parameterized command.   Additionally, this PR removes: `server_build_docker`, `server_run_only_docker`, and `db_build_docker` from the Makefile, as they are not used and duplicative.