### PR TITLE
Implements handler for approving shipment_accessorials [delivers #160705009]

### DIFF
--- a/pkg/handlers/publicapi/api.go
+++ b/pkg/handlers/publicapi/api.go
@@ -48,6 +48,8 @@ func NewPublicAPIHandler(context handlers.HandlerContext) http.Handler {
 
 	publicAPI.AccessorialsGetTariff400ngItemsHandler = GetTariff400ngItemsHandler{context}
 
+	publicAPI.AccessorialsGetTariff400ngItemsHandler = GetTariff400ngItemsHandler{context}
+
 	// Service Agents
 	publicAPI.ServiceAgentsIndexServiceAgentsHandler = IndexServiceAgentsHandler{context}
 	publicAPI.ServiceAgentsCreateServiceAgentHandler = CreateServiceAgentHandler{context}

--- a/pkg/handlers/publicapi/shipment_accessorials_test.go
+++ b/pkg/handlers/publicapi/shipment_accessorials_test.go
@@ -313,3 +313,127 @@ func (suite *HandlerSuite) TestDeleteShipmentAccessorialOfficeHandler() {
 	err := suite.TestDB().Find(&shipAcc1, shipAcc1.ID)
 	suite.Error(err)
 }
+
+func (suite *HandlerSuite) TestApproveShipmentAccessorialHandler() {
+	officeUser := testdatagen.MakeDefaultOfficeUser(suite.TestDB())
+
+	// A shipment accessorial with an item that requires pre-approval
+	acc1 := testdatagen.MakeShipmentAccessorial(suite.TestDB(), testdatagen.Assertions{
+		Tariff400ngItem: models.Tariff400ngItem{
+			RequiresPreApproval: true,
+		},
+	})
+
+	// And: the context contains the auth values
+	req := httptest.NewRequest("POST", "/shipments/accessorials/some_id/approve", nil)
+	req = suite.AuthenticateOfficeRequest(req, officeUser)
+
+	params := accessorialop.ApproveShipmentAccessorialParams{
+		HTTPRequest:           req,
+		ShipmentAccessorialID: strfmt.UUID(acc1.ID.String()),
+	}
+
+	// And: get shipment is returned
+	handler := ApproveShipmentAccessorialHandler{handlers.NewHandlerContext(suite.TestDB(), suite.TestLogger())}
+	response := handler.Handle(params)
+
+	// Then: expect a 200 status code
+	suite.Assertions.IsType(&accessorialop.ApproveShipmentAccessorialOK{}, response)
+	okResponse := response.(*accessorialop.ApproveShipmentAccessorialOK)
+
+	// And: Payload is equivalent to original shipment accessorial
+	suite.Equal(acc1.ID.String(), okResponse.Payload.ID.String())
+	suite.Equal(apimessages.AccessorialStatusAPPROVED, okResponse.Payload.Status)
+}
+
+func (suite *HandlerSuite) TestApproveShipmentAccessorialNotRequired() {
+	officeUser := testdatagen.MakeDefaultOfficeUser(suite.TestDB())
+
+	// A shipment accessorial with an item that requires pre-approval
+	acc1 := testdatagen.MakeShipmentAccessorial(suite.TestDB(), testdatagen.Assertions{
+		Tariff400ngItem: models.Tariff400ngItem{
+			RequiresPreApproval: false,
+		},
+	})
+
+	// And: the context contains the auth values
+	req := httptest.NewRequest("POST", "/shipments/accessorials/some_id/approve", nil)
+	req = suite.AuthenticateOfficeRequest(req, officeUser)
+
+	params := accessorialop.ApproveShipmentAccessorialParams{
+		HTTPRequest:           req,
+		ShipmentAccessorialID: strfmt.UUID(acc1.ID.String()),
+	}
+
+	handler := ApproveShipmentAccessorialHandler{handlers.NewHandlerContext(suite.TestDB(), suite.TestLogger())}
+	response := handler.Handle(params)
+
+	// Then: expect user to be forbidden from approving an item that doesn't require pre-approval
+	suite.Assertions.IsType(&accessorialop.ApproveShipmentAccessorialForbidden{}, response)
+}
+
+func (suite *HandlerSuite) TestApproveShipmentAccessorialAlreadyApproved() {
+	officeUser := testdatagen.MakeDefaultOfficeUser(suite.TestDB())
+
+	// A shipment accessorial with an item that requires pre-approval
+	acc1 := testdatagen.MakeShipmentAccessorial(suite.TestDB(), testdatagen.Assertions{
+		ShipmentAccessorial: models.ShipmentAccessorial{
+			Status: models.ShipmentAccessorialStatusAPPROVED,
+		},
+		Tariff400ngItem: models.Tariff400ngItem{
+			RequiresPreApproval: true,
+		},
+	})
+
+	// And: the context contains the auth values
+	req := httptest.NewRequest("POST", "/shipments/accessorials/some_id/approve", nil)
+	req = suite.AuthenticateOfficeRequest(req, officeUser)
+
+	params := accessorialop.ApproveShipmentAccessorialParams{
+		HTTPRequest:           req,
+		ShipmentAccessorialID: strfmt.UUID(acc1.ID.String()),
+	}
+
+	handler := ApproveShipmentAccessorialHandler{handlers.NewHandlerContext(suite.TestDB(), suite.TestLogger())}
+	response := handler.Handle(params)
+
+	// Then: expect user to be forbidden from approving an item that is already approved
+	suite.Assertions.IsType(&accessorialop.ApproveShipmentAccessorialForbidden{}, response)
+}
+
+func (suite *HandlerSuite) TestApproveShipmentAccessorialTSPUser() {
+	numTspUsers := 1
+	numShipments := 1
+	numShipmentOfferSplit := []int{1}
+	status := []models.ShipmentStatus{models.ShipmentStatusSUBMITTED}
+	tspUsers, shipments, _, err := testdatagen.CreateShipmentOfferData(suite.TestDB(), numTspUsers, numShipments, numShipmentOfferSplit, status)
+	suite.NoError(err)
+
+	tspUser := tspUsers[0]
+	shipment := shipments[0]
+
+	// A shipment accessorial claimed by the tspUser's TSP, and item requires pre-approval
+	acc1 := testdatagen.MakeShipmentAccessorial(suite.TestDB(), testdatagen.Assertions{
+		ShipmentAccessorial: models.ShipmentAccessorial{
+			ShipmentID: shipment.ID,
+		},
+		Tariff400ngItem: models.Tariff400ngItem{
+			RequiresPreApproval: true,
+		},
+	})
+
+	// And: the context contains the auth values
+	req := httptest.NewRequest("POST", "/shipments/accessorials/some_id/approve", nil)
+	req = suite.AuthenticateTspRequest(req, tspUser)
+
+	params := accessorialop.ApproveShipmentAccessorialParams{
+		HTTPRequest:           req,
+		ShipmentAccessorialID: strfmt.UUID(acc1.ID.String()),
+	}
+
+	handler := ApproveShipmentAccessorialHandler{handlers.NewHandlerContext(suite.TestDB(), suite.TestLogger())}
+	response := handler.Handle(params)
+
+	// Then: expect TSP user to be forbidden from approving
+	suite.Assertions.IsType(&accessorialop.ApproveShipmentAccessorialForbidden{}, response)
+}

--- a/pkg/handlers/publicapi/tariff400ng_items.go
+++ b/pkg/handlers/publicapi/tariff400ng_items.go
@@ -2,12 +2,13 @@ package publicapi
 
 import (
 	"github.com/go-openapi/runtime/middleware"
+	"go.uber.org/zap"
+
 	"github.com/transcom/mymove/pkg/auth"
 	"github.com/transcom/mymove/pkg/gen/apimessages"
 	accessorialop "github.com/transcom/mymove/pkg/gen/restapi/apioperations/accessorials"
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/models"
-	"go.uber.org/zap"
 )
 
 func payloadForTariff400ngItemModels(s []models.Tariff400ngItem) apimessages.Tariff400ngItems {

--- a/pkg/models/shipment_accessorial.go
+++ b/pkg/models/shipment_accessorial.go
@@ -91,3 +91,12 @@ func FetchShipmentAccessorialByID(dbConnection *pop.Connection, shipmentAccessor
 
 	return shipmentAccessorial, err
 }
+
+// Approve marks the ShipmentAccessorial request as Approved. Must be in a submitted state.
+func (s *ShipmentAccessorial) Approve() error {
+	if s.Status != ShipmentAccessorialStatusSUBMITTED {
+		return errors.Wrap(ErrInvalidTransition, "Approve")
+	}
+	s.Status = ShipmentAccessorialStatusAPPROVED
+	return nil
+}

--- a/pkg/testdatagen/make_accessorial_records.go
+++ b/pkg/testdatagen/make_accessorial_records.go
@@ -18,7 +18,7 @@ func MakeShipmentAccessorial(db *pop.Connection, assertions Assertions) models.S
 
 	accessorial := assertions.ShipmentAccessorial.Accessorial
 	if isZeroUUID(accessorial.ID) {
-		accessorial = MakeDefaultTariff400ngItem(db)
+		accessorial = MakeTariff400ngItem(db, assertions)
 	}
 
 	//filled in dummy data

--- a/swagger/api.yaml
+++ b/swagger/api.yaml
@@ -2196,7 +2196,7 @@ paths:
         500:
           description: server error
   /shipments/accessorials/{shipment_accessorial_id}/approve:
-    put:
+    post:
       summary: Updates a shipment accessorial item to approve status
       description: Update a shipment accessorial with approve status
       operationId: approveShipmentAccessorial
@@ -2212,6 +2212,8 @@ paths:
       responses:
         200:
           description: shipment accessorial approved
+          schema:
+            $ref: '#/definitions/ShipmentAccessorial'
         400:
           description: invalid request
         401:


### PR DESCRIPTION
## Description

Adds a handler that allows office users to move `ShipmentAccessorials` that require pre-approval from the SUBMITTED state to the APPROVED state. Only office users are allowed to perform this action.

## Code Review Verification Steps

* [ ] End to end tests pass (`make e2e_test`).
* [ ] Code follows the guidelines for [Logging](./docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](./docs/backend.md#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Update the diagram in docs/schema/dp3.sqs (see [Updating and changing the model](./docs/schema/README.md#updating-and-changing-the-model))
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](./docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
* [ ] There are no aXe warnings for UI.
* [ ] This works in IE.
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @willowbl00
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/160705009) for this change