### PR TITLE
CircleCI build_tools job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -298,6 +298,18 @@ jobs:
           command: npx snyk test --file=Gopkg.lock || exit 0 # needs to run after server_generate, so gen files exist
       - announce_failure
 
+  build_tools:
+    executor: mymove
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - go-pkg-dep-sources-{{ checksum "Gopkg.lock" }}
+      - restore_cache:
+          keys:
+            - mymove-vendor-{{ checksum "Gopkg.lock" }}
+      - run: make build_tools
+
   build_app:
     executor: mymove_and_postgres
     steps:
@@ -338,7 +350,6 @@ jobs:
             DB_NAME: test_db
             SECURE_MIGRATION_DIR: /home/circleci/go/src/github.com/transcom/mymove/local_migrations
             SECURE_MIGRATION_SOURCE: local
-      - run: make tools_build
       - build_tag_push:
           dockerfile: Dockerfile
           tag: ppp:web-dev
@@ -480,6 +491,10 @@ workflows:
             - pre_deps_golang
             - pre_deps_yarn
 
+      - build_tools:
+          requires:
+            - pre_deps_golang
+
       - build_migrations:
           requires:
             - pre_deps_golang
@@ -490,6 +505,7 @@ workflows:
             - pre_test
             #- vuln_scan # keep disabled until we work out new process
             - build_app
+            # - build_tools # tools don't need to build to deploy to experimental
             - build_migrations
           filters:
             branches:
@@ -514,6 +530,7 @@ workflows:
             - pre_test
             #- vuln_scan # keep disabled until we work out new process
             - build_app
+            - build_tools
             - build_migrations
             - integration_tests
           filters:

--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,7 @@ server_run_debug:
 	INTERFACE=localhost DEBUG_LOGGING=true \
 	$(AWS_VAULT) dlv debug cmd/webserver/main.go
 
-tools_build: server_deps
+build_tools: server_deps server_generate
 	go build -i -o bin/tsp-award-queue ./cmd/tsp_award_queue
 	go build -i -o bin/generate-test-data ./cmd/generate_test_data
 	go build -i -o bin/rateengine ./cmd/demo/rateengine.go
@@ -119,10 +119,10 @@ tools_build: server_deps
 	go build -i -o bin/load-user-gen ./cmd/load_user_gen
 	go build -i -o bin/paperwork ./cmd/paperwork
 
-tsp_run: tools_build db_dev_run
+tsp_run: build_tools db_dev_run
 	./bin/tsp-award-queue
 
-build: server_build tools_build client_build
+build: server_build build_tools client_build
 
 server_test: server_deps server_generate db_dev_run db_test_reset
 	# Don't run tests in /cmd or /pkg/gen & pass `-short` to exclude long running tests
@@ -149,7 +149,7 @@ e2e_test: server_deps server_generate server_build client_build db_e2e_init
 e2e_test_ci: server_deps server_generate server_build client_build db_e2e_init
 	$(AWS_VAULT) ./bin/run-e2e-test-ci
 
-db_populate_e2e: db_dev_reset db_dev_migrate tools_build
+db_populate_e2e: db_dev_reset db_dev_migrate build_tools
 	bin/generate-test-data -named-scenario="e2e_basic"
 
 db_dev_run:
@@ -181,7 +181,7 @@ db_dev_migrate_down: server_deps db_dev_run
 	cd bin && \
 		./soda -c ../config/database.yml -p ../migrations migrate down
 
-db_e2e_init: tools_build db_dev_run db_test_reset
+db_e2e_init: build_tools db_dev_run db_test_reset
 	DB_HOST=localhost DB_PORT=5432 DB_NAME=test_db \
 		./bin/soda -e test migrate -c config/database.yml -p cypress/migrations up
 


### PR DESCRIPTION
## Description

Separate out building of tools aka `movemove/cmd/*` into its own job, since go build must run in serial.  The `build_tools` job will finish before the `build_app` job is done shaving 30 seconds - 1 minute off total run time.