### PR TITLE
Fix test data for TSPs (GBLOCs and Duty Stations)

### DIFF
--- a/pkg/awardqueue/awardqueue_test.go
+++ b/pkg/awardqueue/awardqueue_test.go
@@ -320,7 +320,8 @@ func (suite *AwardQueueSuite) Test_FailOfferingSingleShipment() {
 
 	// Make a shipment in a new TDL, which inherently has no TSPs
 	market := "dHHG"
-	sourceGBLOC := "OHAI"
+	sourceGBLOC := "KKFA"
+	destinationGBLOC := "HAFC"
 	pickupDate := testdatagen.DateInsidePeakRateCycle
 	deliveryDate := testdatagen.DateInsidePeakRateCycle
 
@@ -330,6 +331,7 @@ func (suite *AwardQueueSuite) Test_FailOfferingSingleShipment() {
 			ActualPickupDate:    &pickupDate,
 			ActualDeliveryDate:  &deliveryDate,
 			SourceGBLOC:         &sourceGBLOC,
+			DestinationGBLOC:    &destinationGBLOC,
 			Market:              &market,
 			BookDate:            &pickupDate,
 			Status:              models.ShipmentStatusSUBMITTED,

--- a/pkg/models/blackout_dates_test.go
+++ b/pkg/models/blackout_dates_test.go
@@ -18,7 +18,7 @@ func (suite *ModelSuite) Test_FetchTSPBlackoutDates() {
 	blackoutEndDate := blackoutStartDate.Add(time.Hour * 24 * 2)
 	pickupDate := blackoutStartDate.Add(time.Hour)
 	market1 := "dHHG"
-	sourceGBLOC := "OHAI"
+	sourceGBLOC := "KKFA"
 	testdatagen.MakeBlackoutDate(suite.db, testdatagen.Assertions{
 		BlackoutDate: models.BlackoutDate{
 			TransportationServiceProviderID: tsp.ID,
@@ -72,8 +72,10 @@ func (suite *ModelSuite) Test_FetchTSPBlackoutDatesWithGBLOC() {
 	blackoutEndDate := blackoutStartDate.Add(time.Hour * 24 * 2)
 	pickupDate := blackoutStartDate.Add(time.Hour)
 	market1 := "dHHG"
-	sourceGBLOC1 := "OHAI"
-	sourceGBLOC2 := "OHNO"
+	sourceGBLOC1 := "KKFA"
+	destinationGBLOC1 := "HAFC"
+	sourceGBLOC2 := "KKNO"
+	destinationGBLOC2 := "HANO"
 	testdatagen.MakeBlackoutDate(suite.db, testdatagen.Assertions{
 		BlackoutDate: models.BlackoutDate{
 			TransportationServiceProviderID: tsp.ID,
@@ -89,6 +91,7 @@ func (suite *ModelSuite) Test_FetchTSPBlackoutDatesWithGBLOC() {
 		Shipment: models.Shipment{
 			ActualPickupDate: &pickupDate,
 			SourceGBLOC:      &sourceGBLOC1,
+			DestinationGBLOC: &destinationGBLOC1,
 			Market:           &market1,
 			BookDate:         &testdatagen.DateInsidePerformancePeriod,
 			Status:           models.ShipmentStatusSUBMITTED,
@@ -99,6 +102,7 @@ func (suite *ModelSuite) Test_FetchTSPBlackoutDatesWithGBLOC() {
 		Shipment: models.Shipment{
 			ActualPickupDate: &pickupDate,
 			SourceGBLOC:      &sourceGBLOC2,
+			DestinationGBLOC: &destinationGBLOC2,
 			BookDate:         &testdatagen.DateInsidePerformancePeriod,
 			Status:           models.ShipmentStatusSUBMITTED,
 		},

--- a/pkg/models/move_test.go
+++ b/pkg/models/move_test.go
@@ -148,7 +148,8 @@ func (suite *ModelSuite) TestMoveStateMachine() {
 	deliveryDate := time.Now().AddDate(0, 0, 1)
 	tdl := testdatagen.MakeDefaultTDL(suite.db)
 	market := "dHHG"
-	sourceGBLOC := "OHAI"
+	sourceGBLOC := "KKFA"
+	destinationGBLOC := "HAFC"
 
 	shipment := testdatagen.MakeShipment(suite.db, testdatagen.Assertions{
 		Shipment: Shipment{
@@ -159,6 +160,7 @@ func (suite *ModelSuite) TestMoveStateMachine() {
 			ActualDeliveryDate:      &deliveryDate,
 			TrafficDistributionList: &tdl,
 			SourceGBLOC:             &sourceGBLOC,
+			DestinationGBLOC:        &destinationGBLOC,
 			Market:                  &market,
 			Status:                  ShipmentStatusDRAFT,
 		},

--- a/pkg/models/shipment_offer_test.go
+++ b/pkg/models/shipment_offer_test.go
@@ -28,7 +28,8 @@ func (suite *ModelSuite) Test_CreateShipmentOffer() {
 	tsp := testdatagen.MakeDefaultTSP(suite.db)
 	tspp := testdatagen.MakeDefaultTSPPerformance(suite.db)
 
-	sourceGBLOC := "OHAI"
+	sourceGBLOC := "KKFA"
+	destinationGBLOC := "HAFC"
 	market := "dHHG"
 
 	shipment := testdatagen.MakeShipment(suite.db, testdatagen.Assertions{
@@ -38,6 +39,7 @@ func (suite *ModelSuite) Test_CreateShipmentOffer() {
 			ActualDeliveryDate:      &deliveryDate,
 			TrafficDistributionList: &tdl,
 			SourceGBLOC:             &sourceGBLOC,
+			DestinationGBLOC:        &destinationGBLOC,
 			Market:                  &market,
 		},
 	})

--- a/pkg/models/shipment_test.go
+++ b/pkg/models/shipment_test.go
@@ -43,7 +43,8 @@ func (suite *ModelSuite) Test_FetchUnofferedShipments() {
 	deliveryDate := time.Now().AddDate(0, 0, 1)
 	tdl := testdatagen.MakeDefaultTDL(suite.db)
 	market := "dHHG"
-	sourceGBLOC := "OHAI"
+	sourceGBLOC := "KKFA"
+	destinationGBLOC := "HAFC"
 
 	shipment := testdatagen.MakeShipment(suite.db, testdatagen.Assertions{
 		Shipment: Shipment{
@@ -52,6 +53,7 @@ func (suite *ModelSuite) Test_FetchUnofferedShipments() {
 			ActualDeliveryDate:      &deliveryDate,
 			TrafficDistributionList: &tdl,
 			SourceGBLOC:             &sourceGBLOC,
+			DestinationGBLOC:        &destinationGBLOC,
 			Market:                  &market,
 			Status:                  ShipmentStatusSUBMITTED,
 		},

--- a/pkg/testdatagen/constants.go
+++ b/pkg/testdatagen/constants.go
@@ -8,7 +8,10 @@ import (
 var TestYear = 2019
 
 // DefaultSrcGBLOC is the default GBLOC for testing.
-var DefaultSrcGBLOC = "OHAI"
+var DefaultSrcGBLOC = "KKFA"
+
+// DefaultDstGBLOC is the default GBLOC for testing.
+var DefaultDstGBLOC = "HAFC"
 
 // DefaultMarket is the default market for testing.
 var DefaultMarket = "dHHG"

--- a/pkg/testdatagen/make_shipment_offer_records.go
+++ b/pkg/testdatagen/make_shipment_offer_records.go
@@ -148,6 +148,20 @@ func CreateShipmentOfferData(db *pop.Connection, numTspUsers int, numShipments i
 			models.ShipmentStatusINTRANSIT,
 			models.ShipmentStatusDELIVERED}
 	}
+
+	// Make the required Tariff 400 NG Zip3
+	MakeDefaultTariff400ngZip3(db)
+	MakeTariff400ngZip3(db, Assertions{
+		Tariff400ngZip3: models.Tariff400ngZip3{
+			Zip3:          "800",
+			BasepointCity: "Denver",
+			State:         "CO",
+			ServiceArea:   "145",
+			RateArea:      "US74",
+			Region:        "5",
+		},
+	})
+
 	for i := 1; i <= numShipments; i++ {
 		now := time.Now()
 		nowPlusOne := now.Add(oneWeek)

--- a/pkg/testdatagen/make_shipment_offer_records.go
+++ b/pkg/testdatagen/make_shipment_offer_records.go
@@ -134,7 +134,8 @@ func CreateShipmentOfferData(db *pop.Connection, numTspUsers int, numShipments i
 			},
 		})
 	market := "dHHG"
-	sourceGBLOC := "OHAI"
+	sourceGBLOC := "KKFA"
+	destinationGBLOC := "HAFC"
 	oneWeek, _ := time.ParseDuration("7d")
 	selectedMoveType := "HHG"
 	if len(statuses) == 0 {
@@ -158,6 +159,19 @@ func CreateShipmentOfferData(db *pop.Connection, numTspUsers int, numShipments i
 		// Shipment Details
 		shipmentStatus := statuses[rand.Intn(len(statuses))]
 
+		// New Duty Station
+		newDutyStationAssertions := Assertions{
+			Address: models.Address{
+				City:       "Aurora",
+				State:      "CO",
+				PostalCode: "80011",
+			},
+			DutyStation: models.DutyStation{
+				Name: "Buckley AFB CHRIS",
+			},
+		}
+		newDutyStation := MakeDutyStation(db, newDutyStationAssertions)
+
 		// Move Details
 		moveStatus := models.MoveStatusSUBMITTED
 		if shipmentStatus == models.ShipmentStatusAPPROVED {
@@ -167,6 +181,10 @@ func CreateShipmentOfferData(db *pop.Connection, numTspUsers int, numShipments i
 		shipmentAssertions := Assertions{
 			User: models.User{
 				LoginGovEmail: smEmail,
+			},
+			Order: models.Order{
+				NewDutyStationID: newDutyStation.ID,
+				NewDutyStation:   newDutyStation,
 			},
 			Move: models.Move{
 				SelectedMoveType: &selectedMoveType,
@@ -178,6 +196,7 @@ func CreateShipmentOfferData(db *pop.Connection, numTspUsers int, numShipments i
 				ActualDeliveryDate:      &nowPlusTwo,
 				TrafficDistributionList: &tdl,
 				SourceGBLOC:             &sourceGBLOC,
+				DestinationGBLOC:        &destinationGBLOC,
 				Market:                  &market,
 				Status:                  shipmentStatus,
 			},

--- a/pkg/testdatagen/make_shipment_offer_records.go
+++ b/pkg/testdatagen/make_shipment_offer_records.go
@@ -167,7 +167,7 @@ func CreateShipmentOfferData(db *pop.Connection, numTspUsers int, numShipments i
 				PostalCode: "80011",
 			},
 			DutyStation: models.DutyStation{
-				Name: "Buckley AFB CHRIS",
+				Name: "Buckley AFB",
 			},
 		}
 		newDutyStation := MakeDutyStation(db, newDutyStationAssertions)

--- a/pkg/testdatagen/make_shipment_records.go
+++ b/pkg/testdatagen/make_shipment_records.go
@@ -46,6 +46,16 @@ func MakeShipment(db *pop.Connection, assertions Assertions) models.Shipment {
 		status = models.ShipmentStatusDRAFT
 	}
 
+	sourceGBLOC := assertions.Shipment.SourceGBLOC
+	if sourceGBLOC == nil {
+		sourceGBLOC = stringPointer(DefaultSrcGBLOC)
+	}
+
+	destinationGBLOC := assertions.Shipment.DestinationGBLOC
+	if destinationGBLOC == nil {
+		destinationGBLOC = stringPointer(DefaultDstGBLOC)
+	}
+
 	shipment := models.Shipment{
 		TrafficDistributionListID:    uuidPointer(tdl.ID),
 		TrafficDistributionList:      tdl,
@@ -53,8 +63,8 @@ func MakeShipment(db *pop.Connection, assertions Assertions) models.Shipment {
 		ServiceMember:                serviceMember,
 		ActualPickupDate:             timePointer(DateInsidePerformancePeriod),
 		ActualDeliveryDate:           timePointer(DateOutsidePerformancePeriod),
-		SourceGBLOC:                  stringPointer(DefaultSrcGBLOC),
-		DestinationGBLOC:             stringPointer(DefaultSrcGBLOC),
+		SourceGBLOC:                  sourceGBLOC,
+		DestinationGBLOC:             destinationGBLOC,
 		Market:                       &DefaultMarket,
 		BookDate:                     timePointer(DateInsidePerformancePeriod),
 		RequestedPickupDate:          timePointer(PerformancePeriodStart),
@@ -111,7 +121,8 @@ func MakeShipmentData(db *pop.Connection) {
 	nowPlusOne := now.Add(oneWeek)
 	nowPlusTwo := now.Add(oneWeek * 2)
 	market := "dHHG"
-	sourceGBLOC := "OHAI"
+	sourceGBLOC := "KKFA"
+	destinationGBLOC := "HAFC"
 
 	MakeShipment(db, Assertions{
 		Shipment: models.Shipment{
@@ -120,6 +131,7 @@ func MakeShipmentData(db *pop.Connection) {
 			ActualDeliveryDate:      &now,
 			TrafficDistributionList: &tdlList[0],
 			SourceGBLOC:             &sourceGBLOC,
+			DestinationGBLOC:        &destinationGBLOC,
 			Market:                  &market,
 		},
 	})
@@ -131,6 +143,7 @@ func MakeShipmentData(db *pop.Connection) {
 			ActualDeliveryDate:      &nowPlusOne,
 			TrafficDistributionList: &tdlList[1],
 			SourceGBLOC:             &sourceGBLOC,
+			DestinationGBLOC:        &destinationGBLOC,
 			Market:                  &market,
 		},
 	})
@@ -142,6 +155,7 @@ func MakeShipmentData(db *pop.Connection) {
 			ActualDeliveryDate:      &nowPlusTwo,
 			TrafficDistributionList: &tdlList[2],
 			SourceGBLOC:             &sourceGBLOC,
+			DestinationGBLOC:        &destinationGBLOC,
 			Market:                  &market,
 		},
 	})

--- a/pkg/testdatagen/scenario/awardqueue.go
+++ b/pkg/testdatagen/scenario/awardqueue.go
@@ -28,7 +28,8 @@ func RunAwardQueueScenario1(db *pop.Connection) {
 	market := "dHHG"
 
 	// Make a source GBLOC
-	sourceGBLOC := "OHAI"
+	sourceGBLOC := "KKFA"
+	destinationGBLOC := "HAFC"
 
 	// Make shipments in this TDL
 	for i := 0; i < shipmentsToMake; i++ {
@@ -40,6 +41,7 @@ func RunAwardQueueScenario1(db *pop.Connection) {
 				ActualDeliveryDate:      &now,
 				TrafficDistributionList: &tdl,
 				SourceGBLOC:             &sourceGBLOC,
+				DestinationGBLOC:        &destinationGBLOC,
 				Market:                  &market,
 			},
 		})
@@ -86,7 +88,8 @@ func RunAwardQueueScenario2(db *pop.Connection) {
 	market := "dHHG"
 
 	// Make a source GBLOC
-	sourceGBLOC := "OHAI"
+	sourceGBLOC := "KKFA"
+	destinationGBLOC := "HAFC"
 
 	// Make shipments in first TDL
 	for i := 0; i < shipmentsToMake; i++ {
@@ -97,6 +100,7 @@ func RunAwardQueueScenario2(db *pop.Connection) {
 				ActualDeliveryDate:      &shipmentDate,
 				TrafficDistributionList: &tdl,
 				SourceGBLOC:             &sourceGBLOC,
+				DestinationGBLOC:        &destinationGBLOC,
 				Market:                  &market,
 			},
 		})


### PR DESCRIPTION
## Description

Ran into an issue while trying to get the moves dates summary where the move had 0 miles.  That's because the data was incorrect and I try to address it in this PR.

Two things here to make test data better:

- Separate the Source and Destination GBLOC's (and use realistic data)
- Make the New Duty Station a different zip code than the Service Member Duty Station

## Reviewer Notes

Nope.

## Setup

```sh
 make db_dev_reset && make db_dev_migrate && go run ./cmd/generate_test_data/main.go -scenario=7
```

Go to http://tsplocal:3000/internal/docs#/moves/showMoveDatesSummary

Enter a MoveID and a date (format like `2018-10-09`) and execute.  You should get a 200 response back.

## Code Review Verification Steps

* [x] End to end tests pass (`make e2e_test`).
* [x] Request review from a member of a different team.