### PR TITLE
CircleCI fix to yarn caching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,14 +144,21 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - yarn-node-modules-cache-{{ checksum "yarn.lock" }}
+            - v1-cache-yarn-v2-{{ checksum "yarn.lock" }}
+      - restore_cache:
+          keys:
+            - v1-mymove-node-modules-{{ checksum "yarn.lock" }}
       - run:
           name: Install YARN dependencies
           command: yarn install
       - save_cache:
-          key: yarn-node-modules-cache-{{ checksum "yarn.lock" }}
+          key: v1-cache-yarn-v2-{{ checksum "yarn.lock" }}
           paths:
-            - node_modules
+            - ~/.cache/yarn/v2
+      - save_cache:
+          key: v1-mymove-node-modules-{{ checksum "yarn.lock" }}
+          paths:
+            - ~/go/src/github.com/transcom/mymove/node_modules
       - announce_failure
 
   pre_test:
@@ -166,16 +173,22 @@ jobs:
             - mymove-vendor-{{ checksum "Gopkg.lock" }}
       - restore_cache:
           keys:
+            - v1-cache-yarn-v2-{{ checksum "yarn.lock" }}
+      - restore_cache:
+          keys:
+            - v1-mymove-node-modules-{{ checksum "yarn.lock" }}
+      - restore_cache:
+          keys:
             - pre-commit-dot-cache-{{ checksum ".pre-commit-config.yaml" }}
       - run:
           name: Install prettier
-          command: npm install prettier@~1.12.0
+          command: yarn add prettier@~1.12.0
       - run:
           name: Install markdown-spellcheck
-          command: npm install markdown-spellcheck
+          command: yarn add markdown-spellcheck
       - run:
           name: Install markdown-toc
-          command: npm install markdown-toc
+          command: yarn add markdown-toc
       - run: echo 'export PATH=${PATH}:~/go/bin' >> $BASH_ENV
       - run:
           name: Run make server_generate
@@ -203,8 +216,13 @@ jobs:
             - mymove-vendor-{{ checksum "Gopkg.lock" }}
       - restore_cache:
           keys:
-            - client-deps-cache-{{ checksum "yarn.lock" }}
-
+            - v1-cache-yarn-v2-{{ checksum "yarn.lock" }}
+      - restore_cache:
+          keys:
+            - v1-cache-cypress-3.1.0
+      - restore_cache:
+          keys:
+            - v1-mymove-node-modules-{{ checksum "yarn.lock" }}
       - run:
           # This is needed to use `psql` to test DB connectivity, until the app
           # itself starts making database connections.
@@ -218,7 +236,7 @@ jobs:
             sudo apt-get -qq -y install xvfb libgtk2.0-0 libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2
       - run:
           name: Install cypress
-          command: npm install cypress@~3.1.0
+          command: yarn add cypress@~3.1.0
       - run:
           name: Setup hostnames
           command: |
@@ -261,11 +279,10 @@ jobs:
           path: cypress/screenshots
       - store_test_results:
           path: cypress/results
-
       - save_cache:
-          key: client-deps-cache-{{ checksum "yarn.lock" }}
+          key: v1-cache-cypress-3.1.0
           paths:
-            - ~/.cache
+            - ~/.cache/Cypress/3.1.0
       - announce_failure
 
   vuln_scan:
@@ -280,7 +297,10 @@ jobs:
             - mymove-vendor-{{ checksum "Gopkg.lock" }}
       - restore_cache:
           keys:
-            - yarn-node-modules-cache-{{ checksum "yarn.lock" }}
+            - v1-cache-yarn-v2-{{ checksum "yarn.lock" }}
+      - restore_cache:
+          keys:
+            - v1-mymove-node-modules-{{ checksum "yarn.lock" }}
       - run:
           name: Authenticate with Snyk
           command: npx snyk auth $SNYK_API_TOKEN
@@ -324,8 +344,10 @@ jobs:
             - mymove-vendor-{{ checksum "Gopkg.lock" }}
       - restore_cache:
           keys:
-            - yarn-node-modules-cache-{{ checksum "yarn.lock" }}
-
+            - v1-cache-yarn-v2-{{ checksum "yarn.lock" }}
+      - restore_cache:
+          keys:
+            - v1-mymove-node-modules-{{ checksum "yarn.lock" }}
       - run:
           # This is needed to use `psql` to test DB connectivity, until the app
           # itself starts making database connections.


### PR DESCRIPTION
## Description

- Caches `~/.cache/yarn/v2`, `~/go/src/github.com/transcom/mymove/node_modules`, and `~/.cache/Cypress/3.1.0`
- Uses yarn to install Cypress rather than npm