### PR TITLE
Split out server/client tests from build_app. 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -605,21 +605,21 @@ workflows:
             - build_migrations
           filters:
             branches:
-              only: mutual_tls_health_check
+              only: mk-split-jobs
 
       - deploy_experimental_app:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: mutual_tls_health_check
+              only: mk-split-jobs
 
       - deploy_experimental_app_client_tls:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: mutual_tls_health_check
+              only: mk-split-jobs
 
       - deploy_staging_migrations:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -340,6 +340,55 @@ jobs:
           command: npx snyk test --file=Gopkg.lock || exit 0 # needs to run after server_generate, so gen files exist
       - announce_failure
 
+  # `server_test` runs the server side Go tests
+  server_test:
+    executor: mymove_and_postgres
+    steps:
+      - checkout
+      - setup_remote_docker:
+          docker_layer_caching: true
+      - restore_cache:
+          keys:
+            - go-pkg-dep-sources-{{ checksum "Gopkg.lock" }}
+      - restore_cache:
+          keys:
+            - mymove-vendor-{{ checksum "Gopkg.lock" }}
+      - run:
+          # This is needed to use `psql` to test DB connectivity, until the app
+          # itself starts making database connections.
+          name: Install postgres client
+          command: |
+            sudo apt-get -qq update
+            sudo apt-get -qq -y install postgresql-client-9.6
+      - run: echo 'export PATH=${PATH}:~/go/bin' >> $BASH_ENV
+      - run:
+          name: make server_test
+          command: make server_test
+          environment:
+            # Env vars needed by the `bin/apply-secure-migrations.sh` script
+            DB_PASSWORD: mysecretpassword
+            DB_USER: postgres
+            DB_HOST: localhost
+            DB_PORT: 5432
+            DB_NAME: test_db
+            SECURE_MIGRATION_DIR: /home/circleci/go/src/github.com/transcom/mymove/local_migrations
+            SECURE_MIGRATION_SOURCE: local
+
+  # `client_test` runs the client side Javascript tests
+  client_test:
+    executor: mymove
+    steps:
+      - checkout
+      - setup_remote_docker:
+          docker_layer_caching: true
+      - restore_cache:
+          keys:
+            - v1-cache-yarn-v2-{{ checksum "yarn.lock" }}
+      - restore_cache:
+          keys:
+            - v1-mymove-node-modules-{{ checksum "yarn.lock" }}
+      - run: make client_test
+
   # `build_tools` builds the mymove-specific CLI tools in `mymove/cmd`
   build_tools:
     executor: mymove
@@ -372,30 +421,9 @@ jobs:
       - restore_cache:
           keys:
             - v1-mymove-node-modules-{{ checksum "yarn.lock" }}
-      - run:
-          # This is needed to use `psql` to test DB connectivity, until the app
-          # itself starts making database connections.
-          name: Install postgres client
-          command: |
-            sudo apt-get -qq update
-            sudo apt-get -qq -y install postgresql-client-9.6
-
-      - run: echo 'export PATH=${PATH}:~/go/bin' >> $BASH_ENV
-      - run: make deps
-      - run: make client_build
-      - run: make client_test
-      - run:
-          name: make server_test
-          command: make server_test
-          environment:
-            # Env vars needed by the `bin/apply-secure-migrations.sh` script
-            DB_PASSWORD: mysecretpassword
-            DB_USER: postgres
-            DB_HOST: localhost
-            DB_PORT: 5432
-            DB_NAME: test_db
-            SECURE_MIGRATION_DIR: /home/circleci/go/src/github.com/transcom/mymove/local_migrations
-            SECURE_MIGRATION_SOURCE: local
+      # TODO (dynamike): Move the building chamber binary into the Makefile
+      - run: go build -o bin/chamber -ldflags "-linkmode external -extldflags -static" ./vendor/github.com/segmentio/chamber
+      - run: make build
       - build_tag_push:
           dockerfile: Dockerfile
           tag: ppp:web-dev
@@ -493,6 +521,8 @@ jobs:
       - deploy_app_client_tls_steps:
           health_check_url: "https://office.move.mil/health"
 
+  # `update_dependencies` periodically updates pre-commit, yarn, and Go dependencies.
+  # The changes are submitted as a pull request for review.
   update_dependencies:
     executor: mymove
     steps:
@@ -542,6 +572,14 @@ workflows:
             - pre_deps_golang
             - pre_deps_yarn
 
+      - client_test:
+          requires:
+            - pre_deps_yarn
+
+      - server_test:
+          requires:
+            - pre_deps_golang
+
       - build_app:
           requires:
             - pre_deps_golang
@@ -559,6 +597,8 @@ workflows:
       - deploy_experimental_migrations:
           requires:
             - pre_test
+            - client_test
+            - server_test
             #- vuln_scan # keep disabled until we work out new process
             - build_app
             # - build_tools # tools don't need to build to deploy to experimental
@@ -584,6 +624,8 @@ workflows:
       - deploy_staging_migrations:
           requires:
             - pre_test
+            - client_test
+            - server_test
             #- vuln_scan # keep disabled until we work out new process
             - build_app
             - build_tools

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,33 +1,14 @@
-# Start from a Debian image with the latest version of Go installed
-# and a workspace (GOPATH) configured at /go.
-FROM golang:1.10.0 AS build
-
-# Install tools required to build the project
-# We will need to run `docker build --no-cache .` to update those dependencies
-RUN apt-get install git
-RUN go get github.com/golang/dep/cmd/dep
-
-# Copy all project and build it
-# This layer will be rebuilt when ever a file has changed in the project directory
-COPY ./ /go/src/github.com/transcom/mymove/
-WORKDIR /go/src/github.com/transcom/mymove/
-RUN rm -f .*.stamp
-RUN make server_deps
-RUN make server_generate
-# These linker flags create a standalone binary that will run in scratch.
-RUN go build -o /bin/mymove-server -ldflags "-linkmode external -extldflags -static" ./cmd/webserver
-RUN go build -o /bin/chamber -ldflags "-linkmode external -extldflags -static" ./vendor/github.com/segmentio/chamber
-
-# This results in a single layer image
-# https://github.com/GoogleCloudPlatform/distroless
-# This google maintained image is scratch plus some basic necessities like a tmp dir and root certs.
 FROM gcr.io/distroless/base
-COPY --from=build /bin/mymove-server /bin/mymove-server
-COPY --from=build /go/src/github.com/transcom/mymove/config /config
-COPY --from=build /go/src/github.com/transcom/mymove/swagger/* /swagger/
-COPY --from=build /bin/chamber /bin/chamber
-COPY /build /build
+
+COPY bin/webserver /bin/mymove-server
+COPY bin/chamber /bin/chamber
+
+COPY config /config
+COPY swagger/* /swagger/
+COPY build /build
+
 ENTRYPOINT ["/bin/mymove-server"]
+
 CMD ["-debug_logging"]
 
 EXPOSE 8080


### PR DESCRIPTION
## Description
This should speed up PR CircleCI jobs by around 2-3 minutes. It splits out `client_test`, `server_test` as separate jobs. It also simplifies how we builds the app Docker container. Instead of rebuilding the client and server artifacts in the Docker container, we build in CircleCI and copy into the Docker container.  

![image](https://user-images.githubusercontent.com/675823/46773103-7b50bf80-ccb0-11e8-8940-9e2dc1d2c9f5.png)


## Code Review Verification Steps

* [x] End to end tests pass (`make e2e_test`).
* [x] Request review from a member of a different team.
