### PR TITLE
The GBL number is required for shipments that are generated

### DIFF
--- a/pkg/testdatagen/make_shipment_offer_records.go
+++ b/pkg/testdatagen/make_shipment_offer_records.go
@@ -216,6 +216,11 @@ func CreateShipmentOfferData(db *pop.Connection, numTspUsers int, numShipments i
 			},
 		}
 		shipment := MakeShipment(db, shipmentAssertions)
+
+		// Assign a new unique GBL number using source GBLOC
+		shipment.AssignGBLNumber(db)
+		mustSave(db, &shipment)
+
 		shipmentList = append(shipmentList, shipment)
 
 		// Accepted shipments must have an OSA and DSA

--- a/pkg/testdatagen/make_shipment_records.go
+++ b/pkg/testdatagen/make_shipment_records.go
@@ -92,9 +92,6 @@ func MakeShipment(db *pop.Connection, assertions Assertions) models.Shipment {
 	// Overwrite values with those from assertions
 	mergeModels(&shipment, assertions.Shipment)
 
-	// Assign a GBL Number
-	shipment.AssignGBLNumber(db)
-
 	mustCreate(db, &shipment)
 
 	shipment.Move.Shipments = append(shipment.Move.Shipments, shipment)

--- a/pkg/testdatagen/make_shipment_records.go
+++ b/pkg/testdatagen/make_shipment_records.go
@@ -92,6 +92,9 @@ func MakeShipment(db *pop.Connection, assertions Assertions) models.Shipment {
 	// Overwrite values with those from assertions
 	mergeModels(&shipment, assertions.Shipment)
 
+	// Assign a GBL Number
+	shipment.AssignGBLNumber(db)
+
 	mustCreate(db, &shipment)
 
 	shipment.Move.Shipments = append(shipment.Move.Shipments, shipment)


### PR DESCRIPTION
## Description

The testdata generator was not creating GBL numbers for shipments. This fixes it so we can do things like generate the GBL.

## Setup

```sh
make db_dev_reset && make db_dev_migrate && go run ./cmd/generate_test_data/main.go -scenario=7
```
Now open up the DB and see that `gbl_number_trackers` table has the value `25` in it.  Also see that all the shipments have a GBL number assigned to them.

## Code Review Verification Steps

* [x] End to end tests pass (`make e2e_test`).
* [x] Request review from a member of a different team.