### PR TITLE
Added color-coding of move dates to calendar and legend

### DIFF
--- a/cypress/integration/mymove/shipment.js
+++ b/cypress/integration/mymove/shipment.js
@@ -42,8 +42,9 @@ describe('completing the hhg flow', function() {
           .should('have.class', 'DayPicker-Day--selected');
       });
 
-    // Check for calendar move dates summary
+    // Check for calendar move dates summary and color-coding of calendar.
     cy.contains('Movers Packing');
+    cy.get('.DayPicker-Day.DayPicker-Day--pickup');
     cy.nextPage();
 
     cy.location().should(loc => {

--- a/src/scenes/Moves/Hhg/DatePicker.css
+++ b/src/scenes/Moves/Hhg/DatePicker.css
@@ -23,29 +23,29 @@ span.estimate {
   margin-left: 0.5rem;
 }
 
-.DayPicker-Day--pack {
+.DayPicker-Day--pack:not(.DayPicker-Day--outside) {
   background-color: #a3bddf;
   border-radius: 0;
 }
 
-.DayPicker-Day--pickup {
+.DayPicker-Day--pickup:not(.DayPicker-Day--outside) {
   background-color: #497abf;
   border-radius: 0;
 }
 
-.DayPicker-Day--transit {
+.DayPicker-Day--transit:not(.DayPicker-Day--outside) {
   background: repeating-linear-gradient(45deg, transparent, transparent 0.5em, #a3bddf 0.5em, #a3bddf 0.75em);
   border-radius: 0;
 }
 
-.DayPicker-Day--delivery {
+.DayPicker-Day--delivery:not(.DayPicker-Day--outside) {
   background-color: #a3bddf;
   border-radius: 0;
   outline: 0.25em solid #497abf;
   outline-offset: -0.25em;
 }
 
-.DayPicker-Day--report {
+.DayPicker-Day--report:not(.DayPicker-Day--outside) {
   color: white;
   background-color: #000000;
   border-radius: 0;

--- a/src/scenes/Moves/Hhg/DatePicker.css
+++ b/src/scenes/Moves/Hhg/DatePicker.css
@@ -6,8 +6,6 @@ h3.form-title {
   font-size: 2rem;
 }
 
-
-
 table th,
 table td {
   border: none;
@@ -23,4 +21,43 @@ th {
 span.estimate {
   color: gray;
   margin-left: 0.5rem;
+}
+
+.DayPicker-Day--pack {
+  background-color: #a3bddf;
+  border-radius: 0;
+}
+
+.DayPicker-Day--pickup {
+  background-color: #497abf;
+  border-radius: 0;
+}
+
+.DayPicker-Day--transit {
+  background: repeating-linear-gradient(45deg, transparent, transparent 0.5em, #a3bddf 0.5em, #a3bddf 0.75em);
+  border-radius: 0;
+}
+
+.DayPicker-Day--delivery {
+  background-color: #a3bddf;
+  border-radius: 0;
+  outline: 0.25em solid #497abf;
+  outline-offset: -0.25em;
+}
+
+.DayPicker-Day--report {
+  color: white;
+  background-color: #000000;
+  border-radius: 0;
+}
+
+.legend-square {
+  font-size: 1rem;
+  width: 22px;
+  height: 22px;
+  display: inline-block;
+}
+
+.legend-label {
+  padding-left: 0;
 }

--- a/src/scenes/Moves/Hhg/DatePicker.css
+++ b/src/scenes/Moves/Hhg/DatePicker.css
@@ -23,29 +23,29 @@ span.estimate {
   margin-left: 0.5rem;
 }
 
-.DayPicker-Day--pack:not(.DayPicker-Day--outside) {
+.DayPicker-Day--pack {
   background-color: #a3bddf;
   border-radius: 0;
 }
 
-.DayPicker-Day--pickup:not(.DayPicker-Day--outside) {
+.DayPicker-Day--pickup {
   background-color: #497abf;
   border-radius: 0;
 }
 
-.DayPicker-Day--transit:not(.DayPicker-Day--outside) {
+.DayPicker-Day--transit {
   background: repeating-linear-gradient(45deg, transparent, transparent 0.5em, #a3bddf 0.5em, #a3bddf 0.75em);
   border-radius: 0;
 }
 
-.DayPicker-Day--delivery:not(.DayPicker-Day--outside) {
+.DayPicker-Day--delivery {
   background-color: #a3bddf;
   border-radius: 0;
   outline: 0.25em solid #497abf;
   outline-offset: -0.25em;
 }
 
-.DayPicker-Day--report:not(.DayPicker-Day--outside) {
+.DayPicker-Day--report {
   color: white;
   background-color: #000000;
   border-radius: 0;

--- a/src/scenes/Moves/Hhg/DatePicker.jsx
+++ b/src/scenes/Moves/Hhg/DatePicker.jsx
@@ -104,6 +104,7 @@ export class HHGDatePicker extends Component {
                 selectedDays={parsedSelectedDay}
                 disabledDays={this.isDayDisabled}
                 modifiers={this.props.modifiers}
+                showOutsideDays
               />
             </div>
 

--- a/src/scenes/Moves/Hhg/DatePicker.jsx
+++ b/src/scenes/Moves/Hhg/DatePicker.jsx
@@ -35,17 +35,9 @@ function createModifiers(moveDates) {
 }
 
 function convertDateStringArray(dateStrings) {
-  if (!dateStrings) {
-    return null;
-  }
-
-  const dateStringsLen = dateStrings.length;
-  const convertedArray = new Array(dateStringsLen);
-  for (let i = 0; i < dateStringsLen; i++) {
-    convertedArray[i] = parseSwaggerDate(dateStrings[i]); // eslint-disable-line security/detect-object-injection
-  }
-
-  return convertedArray;
+  return (
+    dateStrings && dateStrings.map(dateString => parseSwaggerDate(dateString))
+  );
 }
 
 export class HHGDatePicker extends Component {

--- a/src/scenes/Moves/Hhg/DatesSummary.jsx
+++ b/src/scenes/Moves/Hhg/DatesSummary.jsx
@@ -2,10 +2,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import moment from 'moment';
 import { get, isNil } from 'lodash';
-import { connect } from 'react-redux';
-import { withRouter } from 'react-router-dom';
 
-import { selectMoveDatesSummary } from 'shared/Entities/modules/moves';
 import LoadingPlaceholder from 'shared/LoadingPlaceholder';
 
 export class DatesSummary extends Component {
@@ -41,33 +38,48 @@ export class DatesSummary extends Component {
       <table>
         <tbody>
           <tr>
-            <th colSpan="2">Preferred Moving Dates Summary</th>
+            <th colSpan="3">Preferred Moving Dates Summary</th>
           </tr>
 
           <tr>
-            <td>Movers Packing</td>
+            <td aria-label="pattern">
+              <div className="legend-square DayPicker-Day--pack" />
+            </td>
+            <td className="legend-label">Movers Packing</td>
             <td>
               {this.displayDateRange(packDates)}
               <span className="estimate">(estimated)</span>
             </td>
           </tr>
           <tr>
-            <td> Movers Loading Truck</td>
+            <td aria-label="pattern">
+              <div className="legend-square DayPicker-Day--pickup" />
+            </td>
+            <td className="legend-label"> Movers Loading Truck</td>
             <td>{this.displayDateRange(pickupDates)}</td>
           </tr>
           <tr>
-            <td>Moving Truck in Transit</td>
+            <td aria-label="pattern">
+              <div className="legend-square DayPicker-Day--transit" />
+            </td>
+            <td className="legend-label">Moving Truck in Transit</td>
             <td>{this.displayDateRange(transitDates)}</td>
           </tr>
           <tr>
-            <td>Movers Delivering</td>
+            <td aria-label="pattern">
+              <div className="legend-square DayPicker-Day--delivery" />
+            </td>
+            <td className="legend-label">Movers Delivering</td>
             <td>
               {this.displayDateRange(deliveryDates)}
               <span className="estimate">(estimated)</span>
             </td>
           </tr>
           <tr>
-            <td>Report By Date</td>
+            <td aria-label="pattern">
+              <div className="legend-square DayPicker-Day--report" />
+            </td>
+            <td className="legend-label">Report By Date</td>
             <td>{this.displayDateRange(reportDates)}</td>
           </tr>
         </tbody>
@@ -77,17 +89,7 @@ export class DatesSummary extends Component {
 }
 
 DatesSummary.propTypes = {
-  moveDate: PropTypes.string.isRequired,
+  moveDates: PropTypes.object,
 };
 
-function mapStateToProps(state, ownProps) {
-  const props = {
-    moveDates: selectMoveDatesSummary(
-      state,
-      `${ownProps.match.params.moveId}:${ownProps.moveDate}`,
-    ),
-  };
-  return props;
-}
-
-export default withRouter(connect(mapStateToProps)(DatesSummary));
+export default DatesSummary;

--- a/src/shared/Entities/modules/moves.js
+++ b/src/shared/Entities/modules/moves.js
@@ -33,9 +33,9 @@ export function getMoveDatesSummary(label, moveId, moveDate) {
   );
 }
 
-export function selectMoveDatesSummary(state, id) {
-  if (!id) {
+export function selectMoveDatesSummary(state, moveId, moveDate) {
+  if (!moveId || !moveDate) {
     return null;
   }
-  return get(state, `entities.moveDatesSummaries.${id}`);
+  return get(state, `entities.moveDatesSummaries.${moveId}:${moveDate}`);
 }


### PR DESCRIPTION
## Description

This PR adds color-coding to the move date calendar widget for packing days, the pickup day, transit days, the delivery date, and the report date.  A legend is also included noting the various colors/patterns.  As you click around the calendar, the dates and the colors change accordingly.

## Reviewer Notes

Note that the initial month of the calendar widget will be set to the month with the first available move date, or to the month of the previously set move date if one has already been picked and the SM is revisiting the page.

## Setup

- `make server_run`
- `make client_run`
- Create (or populate through generate-test-data) a SM and start the HHG move process.  The calendar is the first page of that process.

## Code Review Verification Steps

* [ ] End to end tests pass (`make e2e_test`).
* [ ] There are no aXe warnings for UI.
* [ ] This works in IE.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/160777797) for this change

## Screenshots

![calendar_colors](https://user-images.githubusercontent.com/4960757/46956266-e27cc400-d062-11e8-92d0-f35353640525.gif)
