### PR TITLE
add email links to customer info panel

### DIFF
--- a/src/scenes/TransportationServiceProvider/CustomerInfo.jsx
+++ b/src/scenes/TransportationServiceProvider/CustomerInfo.jsx
@@ -26,7 +26,9 @@ export const CustomerInfo = ({ serviceMember, backupContact }) => {
               <span>- {serviceMember.secondary_telephone}</span>
             )}
             <br />
-            {serviceMember.personal_email}
+            <a href={`mailto:${serviceMember.personal_email}`}>
+              {serviceMember.personal_email}
+            </a>
             <br />
             Preferred contact method:{' '}
             {serviceMember.phone_is_preferred && (
@@ -58,7 +60,9 @@ export const CustomerInfo = ({ serviceMember, backupContact }) => {
                 )}
                 {backupContact.email && (
                   <span>
-                    {backupContact.email}
+                    <a href={`mailto:${backupContact.email}`}>
+                      {backupContact.email}
+                    </a>
                     <br />
                   </span>
                 )}


### PR DESCRIPTION
## Description

Adds email links to service member email and backup contact emails in the customer info panel on TSP side.

## Reviewer Notes

Am doing inline--happy to change if there's a better way.

## Setup


```
make db_dev_reset && make db_dev_migrate && go run ./cmd/generate_test_data/main.go -scenario=7
```

Use TSP user and select any shipment to view.

## Code Review Verification Steps

* [ ] End to end tests pass (`make e2e_test`).
* [ ] There are no aXe warnings for UI.
* [ ] This works in IE.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/161195362) for this change


## Screenshots

<img width="471" alt="screen shot 2018-10-15 at 10 29 36 am" src="https://user-images.githubusercontent.com/7401870/46957285-40aaa680-d065-11e8-942c-b4e2631e5253.png">
