### PR TITLE
Fix double clicking selected next element by adding a non breaking space

### DIFF
--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -221,7 +221,7 @@ class MoveInfo extends Component {
         <div className="usa-grid grid-wide">
           <div className="usa-width-one-whole">
             <ul className="move-info-header-meta">
-              <li>ID# {serviceMember.edipi}</li>
+              <li>ID# {serviceMember.edipi}&nbsp;</li>
               <li>
                 {serviceMember.telephone}
                 {serviceMember.phone_is_preferred && (
@@ -229,9 +229,10 @@ class MoveInfo extends Component {
                 )}
                 {serviceMember.text_message_is_preferred && <FontAwesomeIcon className="icon" icon={faComments} />}
                 {serviceMember.email_is_preferred && <FontAwesomeIcon className="icon" icon={faEmail} />}
+                &nbsp;
               </li>
-              <li>Locator# {move.locator}</li>
-              <li>Move date {formatDate(ppm.planned_move_date)}</li>
+              <li>Locator# {move.locator}&nbsp;</li>
+              <li>Move date {formatDate(ppm.planned_move_date)}&nbsp;</li>
             </ul>
           </div>
         </div>

--- a/src/scenes/TransportationServiceProvider/CustomerInfo.jsx
+++ b/src/scenes/TransportationServiceProvider/CustomerInfo.jsx
@@ -23,9 +23,7 @@ export const CustomerInfo = ({ serviceMember, backupContact }) => {
             {serviceMember.telephone}
             {serviceMember.secondary_telephone && <span>- {serviceMember.secondary_telephone}</span>}
             <br />
-            <a href={`mailto:${serviceMember.personal_email}`}>
-              {serviceMember.personal_email}
-            </a>
+            <a href={`mailto:${serviceMember.personal_email}`}>{serviceMember.personal_email}</a>
             <br />
             Preferred contact method:{' '}
             {serviceMember.phone_is_preferred && <FontAwesomeIcon className="icon" icon={faPhone} flip="horizontal" />}
@@ -47,9 +45,7 @@ export const CustomerInfo = ({ serviceMember, backupContact }) => {
                 )}
                 {backupContact.email && (
                   <span>
-                    <a href={`mailto:${backupContact.email}`}>
-                      {backupContact.email}
-                    </a>
+                    <a href={`mailto:${backupContact.email}`}>{backupContact.email}</a>
                     <br />
                   </span>
                 )}

--- a/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
+++ b/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
@@ -177,12 +177,13 @@ class ShipmentInfo extends Component {
         <div className="usa-grid grid-wide">
           <div className="usa-width-one-whole">
             <ul className="move-info-header-meta">
-              <li>GBL# {gbl}</li>
-              <li>Locator# {move.locator}</li>
+              <li>GBL# {gbl}&nbsp;</li>
+              <li>Locator# {move.locator}&nbsp;</li>
               <li>
                 {this.props.shipment.source_gbloc} to {this.props.shipment.destination_gbloc}
+                &nbsp;
               </li>
-              <li>DoD ID# {serviceMember.edipi}</li>
+              <li>DoD ID# {serviceMember.edipi}&nbsp;</li>
               <li>
                 {serviceMember.telephone}
                 {serviceMember.phone_is_preferred && (
@@ -190,9 +191,11 @@ class ShipmentInfo extends Component {
                 )}
                 {serviceMember.text_message_is_preferred && <FontAwesomeIcon className="icon" icon={faComments} />}
                 {serviceMember.email_is_preferred && <FontAwesomeIcon className="icon" icon={faEmail} />}
+                &nbsp;
               </li>
               <li>
                 Status: <b>{capitalize(this.props.shipment.status)}</b>
+                &nbsp;
               </li>
             </ul>
           </div>


### PR DESCRIPTION
## Description

Double clicking the header elements was really annoying.  This fixes it.

## Setup

Open up the TSP or Office apps, try to double click an element in the header like the Locator.  Notice it doesn't select the element next to it as well.

## Code Review Verification Steps

* [x] End to end tests pass (`make e2e_test`).
* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/161164356) for this change