### PR TITLE
Fix time format to match 'DD-Mon-YYYY' in GBL document

### DIFF
--- a/pkg/paperwork/forms.go
+++ b/pkg/paperwork/forms.go
@@ -159,7 +159,7 @@ func (f *FormFiller) DrawData(data interface{}) error {
 		case int64:
 			displayValue = strconv.FormatInt(v, 10)
 		case time.Time:
-			displayValue = v.Format("01-Mon-2006")
+			displayValue = v.Format("02-Jan-2006")
 		case internalmessages.ServiceMemberRank:
 			displayValue = rankDisplayValue[v]
 		case *internalmessages.ServiceMemberRank:


### PR DESCRIPTION
## Description

This PR changes the time format to match 'DD-Mon-YYYY' so that it is consistent with the Office/Tsp application. 

Example: `25-Jan-2018`

## Code Review Verification Steps

* [ ] End to end tests pass (`make e2e_test`).
* [ ] This works in IE.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/161225221) for this change

## Screenshots

![image](https://user-images.githubusercontent.com/1522549/46975652-0bf61980-d07c-11e8-9048-af3d2b85e1e7.png)
