### PR TITLE
Add the shipmentID to the genericMoveDocumentPayload

### DIFF
--- a/pkg/handlers/publicapi/generic_move_documents.go
+++ b/pkg/handlers/publicapi/generic_move_documents.go
@@ -41,7 +41,7 @@ func payloadForDocumentModel(storer storage.FileStorer, document models.Document
 	return documentPayload, nil
 }
 
-func payloadForGenericMoveDocumentModel(storer storage.FileStorer, moveDocument models.MoveDocument) (*apimessages.MoveDocumentPayload, error) {
+func payloadForGenericMoveDocumentModel(storer storage.FileStorer, moveDocument models.MoveDocument, shipmentID uuid.UUID) (*apimessages.MoveDocumentPayload, error) {
 
 	documentPayload, err := payloadForDocumentModel(storer, moveDocument.Document)
 	if err != nil {
@@ -50,6 +50,7 @@ func payloadForGenericMoveDocumentModel(storer storage.FileStorer, moveDocument 
 
 	genericMoveDocumentPayload := apimessages.MoveDocumentPayload{
 		ID:               handlers.FmtUUID(moveDocument.ID),
+		ShipmentID:       handlers.FmtUUID(shipmentID),
 		Document:         documentPayload,
 		Title:            &moveDocument.Title,
 		MoveDocumentType: apimessages.MoveDocumentType(moveDocument.MoveDocumentType),
@@ -120,7 +121,7 @@ func (h CreateGenericMoveDocumentHandler) Handle(params movedocop.CreateGenericM
 		return handlers.ResponseForVErrors(h.Logger(), verrs, err)
 	}
 
-	newPayload, err := payloadForGenericMoveDocumentModel(h.FileStorer(), *newMoveDocument)
+	newPayload, err := payloadForGenericMoveDocumentModel(h.FileStorer(), *newMoveDocument, shipmentID)
 	if err != nil {
 		return handlers.ResponseForError(h.Logger(), err)
 	}

--- a/pkg/handlers/publicapi/move_documents.go
+++ b/pkg/handlers/publicapi/move_documents.go
@@ -136,7 +136,7 @@ func (h UpdateMoveDocumentHandler) Handle(params movedocop.UpdateMoveDocumentPar
 		return handlers.ResponseForVErrors(h.Logger(), verrs, err)
 	}
 
-	moveDocPayload, err := payloadForGenericMoveDocumentModel(h.FileStorer(), *moveDoc)
+	moveDocPayload, err := payloadForGenericMoveDocumentModel(h.FileStorer(), *moveDoc, shipmentID)
 	if err != nil {
 		return handlers.ResponseForError(h.Logger(), err)
 	}


### PR DESCRIPTION
## Description

The payload was missing the shipmentID, which made it difficult to list the new document in real time in the document list.

## Setup

```sh
make db_dev_reset && make db_dev_migrate && go run ./cmd/generate_test_data/main.go -scenario=7
```

Open up a shipment, upload a document, notice that the document appears on the right side in the document list.

OR

visit http://tsplocal:3000/api/v1/docs#/move_docs/createGenericMoveDocument

Try using the API directly with a shipment ID that you can access and an upload document ID that exists.  The return value should include the `shipmentID`.

## Code Review Verification Steps

* [x] End to end tests pass (`make e2e_test`).
* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/161172426) for this change