### PR TITLE
Fix the document index handler to return correct titles and notes

### DIFF
--- a/pkg/handlers/converters.go
+++ b/pkg/handlers/converters.go
@@ -117,6 +117,14 @@ func FmtString(s string) *string {
 	return &s
 }
 
+// FmtStringPtr converts pop type to go-swagger type
+func FmtStringPtr(s *string) *string {
+	if s == nil {
+		return nil
+	}
+	return FmtString(*s)
+}
+
 // FmtSSN converts pop type to go-swagger type
 func FmtSSN(s string) *strfmt.SSN {
 	ssn := strfmt.SSN(s)

--- a/pkg/handlers/publicapi/move_documents.go
+++ b/pkg/handlers/publicapi/move_documents.go
@@ -1,7 +1,6 @@
 package publicapi
 
 import (
-	// "fmt"
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/gobuffalo/uuid"
 
@@ -58,10 +57,10 @@ func (h IndexMoveDocumentsHandler) Handle(params movedocop.IndexMoveDocumentsPar
 			ID:               handlers.FmtUUID(doc.ID),
 			ShipmentID:       handlers.FmtUUIDPtr(doc.ShipmentID),
 			Document:         documentPayload,
-			Title:            &doc.Title,
+			Title:            handlers.FmtStringPtr(&doc.Title),
 			MoveDocumentType: apimessages.MoveDocumentType(doc.MoveDocumentType),
 			Status:           apimessages.MoveDocumentStatus(doc.Status),
-			Notes:            doc.Notes,
+			Notes:            handlers.FmtStringPtr(doc.Notes),
 		}
 		if err != nil {
 			return handlers.ResponseForError(h.Logger(), err)


### PR DESCRIPTION
## Description

The documents index handler was returning the same title and notes for all documents based on the last document it processed.  This fixes the problem by managing the pointers better.

## Setup

Upload several docs with different titles and notes.

Visit http://tsplocal:3000/api/v1/docs#/move_docs/indexMoveDocuments and execute the query.

Notice that all the document names and notes returned are different.

## Code Review Verification Steps

* [x] End to end tests pass (`make e2e_test`).
* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/161133431) for this change