### PR TITLE
Lock CircleCI deploy jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,12 +38,12 @@ commands:
   deploy_migrations_steps:
     steps:
       - checkout
-      - run:
-          name: Snapshot database
-          command: bin/rds-snapshot-app-db $APP_ENVIRONMENT
+      #- run:
+      #    name: Snapshot database
+      #    command: bin/rds-snapshot-app-db $APP_ENVIRONMENT
       - run:
           name: Run database migrations
-          command: bin/do-exclusively --job-name deploy-${APP_ENVIRONMENT} ecs-run-app-migrations-container config/app-migrations.container-definition.json ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/app-migrations:git-${CIRCLE_SHA1} $APP_ENVIRONMENT
+          command: bin/do-exclusively ecs-run-app-migrations-container config/app-migrations.container-definition.json ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/app-migrations:git-${CIRCLE_SHA1} $APP_ENVIRONMENT
       - announce_failure
   deploy_app_steps:
     parameters:
@@ -54,7 +54,7 @@ commands:
       - setup_remote_docker
       - deploy:
           name: Deploy app service
-          command: bin/do-exclusively --job-name deploy-${APP_ENVIRONMENT} bin/ecs-deploy-service-container app config/app.container-definition.json ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/app:git-${CIRCLE_SHA1} $APP_ENVIRONMENT FARGATE
+          command: bin/ecs-deploy-service-container app config/app.container-definition.json ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/app:git-${CIRCLE_SHA1} $APP_ENVIRONMENT FARGATE
       - health_check:
           url: << parameters.health_check_url >>
       - announce_failure
@@ -67,7 +67,7 @@ commands:
       - setup_remote_docker
       - deploy:
           name: Deploy app-client-tls service
-          command: bin/do-exclusively --job-name deploy-${APP_ENVIRONMENT} bin/ecs-deploy-service-container app-client-tls config/app-client-tls.container-definition.json ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/app:git-${CIRCLE_SHA1} $APP_ENVIRONMENT FARGATE
+          command: deploy-${APP_ENVIRONMENT} bin/ecs-deploy-service-container app-client-tls config/app-client-tls.container-definition.json ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/app:git-${CIRCLE_SHA1} $APP_ENVIRONMENT FARGATE
       - health_check_tls:
           url: << parameters.health_check_url >>
       - announce_failure

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ commands:
       - checkout
       - run:
           name: Snapshot database and run migrations
-          command: bin/do-exclusively --branch ${CIRCLE_BRANCH} bin/rds-snapshot-app-db $APP_ENVIRONMENT && bin/ecs-run-app-migrations-container config/app-migrations.container-definition.json ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazon.aws.com/app-migrations:git-${CIRCLE_SHA1} $APP_ENVIRONMENT
+          command: bin/do-exclusively --branch ${CIRCLE_BRANCH} bin/rds-snapshot-app-db $APP_ENVIRONMENT && bin/ecs-run-app-migrations-container config/app-migrations.container-definition.json ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/app-migrations:git-${CIRCLE_SHA1} $APP_ENVIRONMENT
       - announce_failure
   deploy_app_steps:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ commands:
       - checkout
       - run:
           name: Snapshot database and run migrations
-          command: bin/do-exclusively --branch ${CIRCLE_BRANCH} bin/rds-snapshot-app-db $APP_ENVIRONMENT && bin/ecs-run-app-migrations-container config/app-migrations.container-definition.json ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/app-migrations:git-${CIRCLE_SHA1} $APP_ENVIRONMENT
+          command: bin/do-exclusively --job_name ${CIRCLE_JOB} bin/rds-snapshot-app-db $APP_ENVIRONMENT && bin/ecs-run-app-migrations-container config/app-migrations.container-definition.json ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/app-migrations:git-${CIRCLE_SHA1} $APP_ENVIRONMENT
       - announce_failure
   deploy_app_steps:
     parameters:
@@ -51,7 +51,7 @@ commands:
       - setup_remote_docker
       - deploy:
           name: Deploy app service
-          command: bin/do-exclusively --branch ${CIRCLE_BRANCH} bin/ecs-deploy-service-container app config/app.container-definition.json ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/app:git-${CIRCLE_SHA1} $APP_ENVIRONMENT FARGATE
+          command: bin/do-exclusively --job_name ${CIRCLE_JOB} bin/ecs-deploy-service-container app config/app.container-definition.json ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/app:git-${CIRCLE_SHA1} $APP_ENVIRONMENT FARGATE
       - health_check:
           url: << parameters.health_check_url >>
       - announce_failure
@@ -64,7 +64,7 @@ commands:
       - setup_remote_docker
       - deploy:
           name: Deploy app-client-tls service
-          command: bin/do-exclusively --branch ${CIRCLE_BRANCH} bin/ecs-deploy-service-container app-client-tls config/app-client-tls.container-definition.json ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/app:git-${CIRCLE_SHA1} $APP_ENVIRONMENT FARGATE
+          command: bin/do-exclusively --job_name ${CIRCLE_JOB} bin/ecs-deploy-service-container app-client-tls config/app-client-tls.container-definition.json ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/app:git-${CIRCLE_SHA1} $APP_ENVIRONMENT FARGATE
       - health_check_tls:
           url: << parameters.health_check_url >>
       - announce_failure

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ commands:
           command: bin/rds-snapshot-app-db $APP_ENVIRONMENT
       - run:
           name: Run database migrations
-          command: bin/ecs-run-app-migrations-container config/app-migrations.container-definition.json ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/app-migrations:git-${CIRCLE_SHA1} $APP_ENVIRONMENT
+          command: bin/do-exclusively --job-name deploy-${APP_ENVIRONMENT} ecs-run-app-migrations-container config/app-migrations.container-definition.json ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/app-migrations:git-${CIRCLE_SHA1} $APP_ENVIRONMENT
       - announce_failure
   deploy_app_steps:
     parameters:
@@ -54,7 +54,7 @@ commands:
       - setup_remote_docker
       - deploy:
           name: Deploy app service
-          command: bin/ecs-deploy-service-container app config/app.container-definition.json ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/app:git-${CIRCLE_SHA1} $APP_ENVIRONMENT FARGATE
+          command: bin/do-exclusively --job-name deploy-${APP_ENVIRONMENT} bin/ecs-deploy-service-container app config/app.container-definition.json ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/app:git-${CIRCLE_SHA1} $APP_ENVIRONMENT FARGATE
       - health_check:
           url: << parameters.health_check_url >>
       - announce_failure
@@ -67,7 +67,7 @@ commands:
       - setup_remote_docker
       - deploy:
           name: Deploy app-client-tls service
-          command: bin/ecs-deploy-service-container app-client-tls config/app-client-tls.container-definition.json ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/app:git-${CIRCLE_SHA1} $APP_ENVIRONMENT FARGATE
+          command: bin/do-exclusively --job-name deploy-${APP_ENVIRONMENT} bin/ecs-deploy-service-container app-client-tls config/app-client-tls.container-definition.json ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/app:git-${CIRCLE_SHA1} $APP_ENVIRONMENT FARGATE
       - health_check_tls:
           url: << parameters.health_check_url >>
       - announce_failure
@@ -573,21 +573,21 @@ workflows:
             - build_migrations
           filters:
             branches:
-              only: circleci_migrations
+              only: mk-serial-deploys
 
       - deploy_experimental_app:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: circleci_migrations
+              only: mk-serial-deploys
 
       - deploy_experimental_app_client_tls:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: circleci_migrations
+              only: mk-serial-deploys
 
       - deploy_staging_migrations:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ commands:
       #    command: bin/rds-snapshot-app-db $APP_ENVIRONMENT
       - run:
           name: Run database migrations
-          command: bin/do-exclusively ecs-run-app-migrations-container config/app-migrations.container-definition.json ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/app-migrations:git-${CIRCLE_SHA1} $APP_ENVIRONMENT
+          command: bin/do-exclusively --branch ${CIRCLE_BRANCH} ecs-run-app-migrations-container config/app-migrations.container-definition.json ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/app-migrations:git-${CIRCLE_SHA1} $APP_ENVIRONMENT
       - announce_failure
   deploy_app_steps:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,12 +38,12 @@ commands:
   deploy_migrations_steps:
     steps:
       - checkout
-      #- run:
-      #    name: Snapshot database
-      #    command: bin/rds-snapshot-app-db $APP_ENVIRONMENT
+      - run:
+          name: Snapshot database
+          command: bin/do-exclusively --branch ${CIRCLE_BRANCH} bin/rds-snapshot-app-db $APP_ENVIRONMENT
       - run:
           name: Run database migrations
-          command: bin/do-exclusively --branch ${CIRCLE_BRANCH} ecs-run-app-migrations-container config/app-migrations.container-definition.json ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/app-migrations:git-${CIRCLE_SHA1} $APP_ENVIRONMENT
+          command: bin/do-exclusively --branch ${CIRCLE_BRANCH} bin/ecs-run-app-migrations-container config/app-migrations.container-definition.json ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/app-migrations:git-${CIRCLE_SHA1} $APP_ENVIRONMENT
       - announce_failure
   deploy_app_steps:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,11 +39,8 @@ commands:
     steps:
       - checkout
       - run:
-          name: Snapshot database
-          command: bin/do-exclusively --branch ${CIRCLE_BRANCH} bin/rds-snapshot-app-db $APP_ENVIRONMENT
-      - run:
-          name: Run database migrations
-          command: bin/do-exclusively --branch ${CIRCLE_BRANCH} bin/ecs-run-app-migrations-container config/app-migrations.container-definition.json ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/app-migrations:git-${CIRCLE_SHA1} $APP_ENVIRONMENT
+          name: Snapshot database and run migrations
+          command: bin/do-exclusively --branch ${CIRCLE_BRANCH} bin/rds-snapshot-app-db $APP_ENVIRONMENT && bin/ecs-run-app-migrations-container config/app-migrations.container-definition.json ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazon.aws.com/app-migrations:git-${CIRCLE_SHA1} $APP_ENVIRONMENT
       - announce_failure
   deploy_app_steps:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ commands:
       - setup_remote_docker
       - deploy:
           name: Deploy app service
-          command: bin/ecs-deploy-service-container app config/app.container-definition.json ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/app:git-${CIRCLE_SHA1} $APP_ENVIRONMENT FARGATE
+          command: bin/do-exclusively --branch ${CIRCLE_BRANCH} bin/ecs-deploy-service-container app config/app.container-definition.json ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/app:git-${CIRCLE_SHA1} $APP_ENVIRONMENT FARGATE
       - health_check:
           url: << parameters.health_check_url >>
       - announce_failure
@@ -64,7 +64,7 @@ commands:
       - setup_remote_docker
       - deploy:
           name: Deploy app-client-tls service
-          command: bin/ecs-deploy-service-container app-client-tls config/app-client-tls.container-definition.json ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/app:git-${CIRCLE_SHA1} $APP_ENVIRONMENT FARGATE
+          command: bin/do-exclusively --branch ${CIRCLE_BRANCH} bin/ecs-deploy-service-container app-client-tls config/app-client-tls.container-definition.json ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/app:git-${CIRCLE_SHA1} $APP_ENVIRONMENT FARGATE
       - health_check_tls:
           url: << parameters.health_check_url >>
       - announce_failure

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,7 @@ commands:
       - setup_remote_docker
       - deploy:
           name: Deploy app-client-tls service
-          command: deploy-${APP_ENVIRONMENT} bin/ecs-deploy-service-container app-client-tls config/app-client-tls.container-definition.json ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/app:git-${CIRCLE_SHA1} $APP_ENVIRONMENT FARGATE
+          command: bin/ecs-deploy-service-container app-client-tls config/app-client-tls.container-definition.json ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/app:git-${CIRCLE_SHA1} $APP_ENVIRONMENT FARGATE
       - health_check_tls:
           url: << parameters.health_check_url >>
       - announce_failure

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ commands:
       - checkout
       - run:
           name: Snapshot database and run migrations
-          command: bin/do-exclusively --job_name ${CIRCLE_JOB} bin/rds-snapshot-app-db $APP_ENVIRONMENT && bin/ecs-run-app-migrations-container config/app-migrations.container-definition.json ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/app-migrations:git-${CIRCLE_SHA1} $APP_ENVIRONMENT
+          command: bin/do-exclusively --job-name ${CIRCLE_JOB} bin/rds-snapshot-app-db $APP_ENVIRONMENT && bin/ecs-run-app-migrations-container config/app-migrations.container-definition.json ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/app-migrations:git-${CIRCLE_SHA1} $APP_ENVIRONMENT
       - announce_failure
   deploy_app_steps:
     parameters:
@@ -51,7 +51,7 @@ commands:
       - setup_remote_docker
       - deploy:
           name: Deploy app service
-          command: bin/do-exclusively --job_name ${CIRCLE_JOB} bin/ecs-deploy-service-container app config/app.container-definition.json ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/app:git-${CIRCLE_SHA1} $APP_ENVIRONMENT FARGATE
+          command: bin/do-exclusively --job-name ${CIRCLE_JOB} bin/ecs-deploy-service-container app config/app.container-definition.json ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/app:git-${CIRCLE_SHA1} $APP_ENVIRONMENT FARGATE
       - health_check:
           url: << parameters.health_check_url >>
       - announce_failure
@@ -64,7 +64,7 @@ commands:
       - setup_remote_docker
       - deploy:
           name: Deploy app-client-tls service
-          command: bin/do-exclusively --job_name ${CIRCLE_JOB} bin/ecs-deploy-service-container app-client-tls config/app-client-tls.container-definition.json ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/app:git-${CIRCLE_SHA1} $APP_ENVIRONMENT FARGATE
+          command: bin/do-exclusively --job-name ${CIRCLE_JOB} bin/ecs-deploy-service-container app-client-tls config/app-client-tls.container-definition.json ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/app:git-${CIRCLE_SHA1} $APP_ENVIRONMENT FARGATE
       - health_check_tls:
           url: << parameters.health_check_url >>
       - announce_failure

--- a/bin/do-exclusively
+++ b/bin/do-exclusively
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+
+set -o xtrace -o errexit -o pipefail -o nounset
+
+########################################################################################
+# CircleCI's current recommendation for roughly serializing a subset
+# of build commands for a given branch
+#
+# circle discussion thread - https://discuss.circleci.com/t/serializing-deployments/153
+# Code from - https://github.com/bellkev/circle-lock-test
+########################################################################################
+
+
+# sets $branch, $job_name, $tag, $rest
+parse_args() {
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            -b|--branch) branch="$2" ;;
+            -j|--job-name) job_name="$2" ;;
+            -t|--tag) tag="$2" ;;
+            *) break ;;
+        esac
+        shift 2
+    done
+    rest=("$@")
+}
+
+# reads $branch, $tag, $commit_message
+should_skip() {
+    if [[ "$branch" && "$CIRCLE_BRANCH" != "$branch" ]]; then
+        echo "Not on branch $branch. Skipping..."
+        return 0
+    fi
+
+    if [[ "$job_name" && "$CIRCLE_JOB" != "$job_name" ]]; then
+        echo "Not running $job_name. Skipping..."
+        return 0
+    fi
+
+    if [[ "$tag" && "$commit_message" != *\[$tag\]* ]]; then
+        echo "No [$tag] commit tag found. Skipping..."
+        return 0
+    fi
+
+    return 1
+}
+
+# reads $branch, $job_name, $tag
+# sets $jq_prog
+make_jq_prog() {
+    local jq_filters=""
+
+    if [[ $branch ]]; then
+        jq_filters+=" and .branch == \"$branch\""
+    fi
+
+    if [[ $job_name ]]; then
+        jq_filters+=" and .workflows?.job_name? == \"$job_name\""
+    fi
+
+    if [[ $tag ]]; then
+        jq_filters+=" and (.subject | contains(\"[$tag]\"))"
+    fi
+
+    jq_prog=".[] | select(.build_num < $CIRCLE_BUILD_NUM and (.status | test(\"running|pending|queued\")) $jq_filters) | .build_num"
+}
+
+
+if [[ "$0" != *bats* ]]; then
+set -e
+set -u
+set -o pipefail
+
+    branch=""
+    tag=""
+    rest=()
+    api_url="https://circleci.com/api/v1/project/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME?circle-token=$CIRCLE_TOKEN&limit=100"
+
+    parse_args "$@"
+    commit_message=$(git log -1 --pretty=%B)
+    if should_skip; then exit 0; fi
+    make_jq_prog
+
+    echo "Checking for running builds..."
+
+    while true; do
+        builds=$(curl -s -H "Accept: application/json" "$api_url" | jq "$jq_prog")
+        if [[ $builds ]]; then
+            echo "Waiting on builds:"
+            echo "$builds"
+        else
+            break
+        fi
+        echo "Retrying in 10 seconds..."
+        sleep 10
+    done
+
+    echo "Acquired lock"
+
+    if [[ "${#rest[@]}" -ne 0 ]]; then
+        "${rest[@]}"
+    fi
+fi

--- a/bin/do-exclusively
+++ b/bin/do-exclusively
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-set -o xtrace -o errexit -o pipefail -o nounset
-
 ########################################################################################
 # CircleCI's current recommendation for roughly serializing a subset
 # of build commands for a given branch

--- a/bin/do-exclusively
+++ b/bin/do-exclusively
@@ -1,11 +1,22 @@
 #!/usr/bin/env bash
 
+set -o xtrace -o errexit -o pipefail -o nounset
 
-# sets $branch, $tag, $rest
+########################################################################################
+# CircleCI's current recommendation for roughly serializing a subset
+# of build commands for a given branch
+#
+# circle discussion thread - https://discuss.circleci.com/t/serializing-deployments/153
+# Code from - https://github.com/bellkev/circle-lock-test
+########################################################################################
+
+
+# sets $branch, $job_name, $tag, $rest
 parse_args() {
     while [[ $# -gt 0 ]]; do
         case $1 in
             -b|--branch) branch="$2" ;;
+            -j|--job-name) job_name="$2" ;;
             -t|--tag) tag="$2" ;;
             *) break ;;
         esac
@@ -21,6 +32,11 @@ should_skip() {
         return 0
     fi
 
+    if [[ "$job_name" && "$CIRCLE_JOB" != "$job_name" ]]; then
+        echo "Not running $job_name. Skipping..."
+        return 0
+    fi
+
     if [[ "$tag" && "$commit_message" != *\[$tag\]* ]]; then
         echo "No [$tag] commit tag found. Skipping..."
         return 0
@@ -29,13 +45,17 @@ should_skip() {
     return 1
 }
 
-# reads $branch, $tag
+# reads $branch, $job_name, $tag
 # sets $jq_prog
 make_jq_prog() {
     local jq_filters=""
 
     if [[ $branch ]]; then
         jq_filters+=" and .branch == \"$branch\""
+    fi
+
+    if [[ $job_name ]]; then
+        jq_filters+=" and .workflows?.job_name? == \"$job_name\""
     fi
 
     if [[ $tag ]]; then
@@ -71,8 +91,8 @@ set -o pipefail
         else
             break
         fi
-        echo "Retrying in 5 seconds..."
-        sleep 5
+        echo "Retrying in 10 seconds..."
+        sleep 10
     done
 
     echo "Acquired lock"

--- a/bin/do-exclusively
+++ b/bin/do-exclusively
@@ -1,22 +1,11 @@
 #!/usr/bin/env bash
 
-set -o xtrace -o errexit -o pipefail -o nounset
 
-########################################################################################
-# CircleCI's current recommendation for roughly serializing a subset
-# of build commands for a given branch
-#
-# circle discussion thread - https://discuss.circleci.com/t/serializing-deployments/153
-# Code from - https://github.com/bellkev/circle-lock-test
-########################################################################################
-
-
-# sets $branch, $job_name, $tag, $rest
+# sets $branch, $tag, $rest
 parse_args() {
     while [[ $# -gt 0 ]]; do
         case $1 in
             -b|--branch) branch="$2" ;;
-            -j|--job-name) job_name="$2" ;;
             -t|--tag) tag="$2" ;;
             *) break ;;
         esac
@@ -32,11 +21,6 @@ should_skip() {
         return 0
     fi
 
-    if [[ "$job_name" && "$CIRCLE_JOB" != "$job_name" ]]; then
-        echo "Not running $job_name. Skipping..."
-        return 0
-    fi
-
     if [[ "$tag" && "$commit_message" != *\[$tag\]* ]]; then
         echo "No [$tag] commit tag found. Skipping..."
         return 0
@@ -45,17 +29,13 @@ should_skip() {
     return 1
 }
 
-# reads $branch, $job_name, $tag
+# reads $branch, $tag
 # sets $jq_prog
 make_jq_prog() {
     local jq_filters=""
 
     if [[ $branch ]]; then
         jq_filters+=" and .branch == \"$branch\""
-    fi
-
-    if [[ $job_name ]]; then
-        jq_filters+=" and .workflows?.job_name? == \"$job_name\""
     fi
 
     if [[ $tag ]]; then
@@ -91,8 +71,8 @@ set -o pipefail
         else
             break
         fi
-        echo "Retrying in 10 seconds..."
-        sleep 10
+        echo "Retrying in 5 seconds..."
+        sleep 5
     done
 
     echo "Acquired lock"

--- a/bin/ecs-deploy-service-container
+++ b/bin/ecs-deploy-service-container
@@ -54,6 +54,8 @@ update_service() {
     local network_config
     network_config=$(aws ecs describe-services --services "$name" --cluster "$cluster" --query 'services[0].networkConfiguration')
 
+    echo "* Waiting for service to be stable before updating"
+    time aws ecs wait services-stable --services "$name" --cluster "$cluster"
     echo "* Updating $name service to use $arn"
     aws ecs update-service --cluster "$cluster" --service "$name" --task-definition "$arn" --query 'service.deployments' --network-configuration "$network_config" || return 1
     echo "* Waiting for service to stabilize (this takes a while)"


### PR DESCRIPTION
## Description
Now that we've turned off **Require  branches to be up to date before merging**, there can be multiple simultaneous deploys to staging. Unfortunately, CircleCI doesn't have a mechanism to prevent jobs from running concurrently. Their current [workaround](https://discuss.circleci.com/t/serializing-deployments/153) is to use the CircleCI API to check for running builds a job/branch/tag. This PR will but an exclusive lock around migration, and container deploys for each job name (e.g, deploy_staging_migrations).

## Reviewer Notes
I tested by kicking off simultaneous builds, that are configured to deploy to the experimental environments
* https://circleci.com/workflow-run/cafc6b33-6cc4-436b-a507-522b1aa88918
* https://circleci.com/workflow-run/90a8a205-a610-4852-9ef0-0d7b0a4d15e4

## Code Review Verification Steps
* [x] Request review from a member of a different team.
