### PR TITLE
Adjust hardcoded dates and add missing error check return to handler.

### DIFF
--- a/pkg/handlers/internalapi/personally_procured_move.go
+++ b/pkg/handlers/internalapi/personally_procured_move.go
@@ -239,6 +239,7 @@ func (h PatchPersonallyProcuredMoveHandler) Handle(params ppmop.PatchPersonallyP
 		err = h.updateEstimates(ppm)
 		if err != nil {
 			h.Logger().Error("Unable to set calculated fields on PPM", zap.Error(err))
+			return handlers.ResponseForError(h.Logger(), err)
 		}
 	}
 
@@ -252,7 +253,6 @@ func (h PatchPersonallyProcuredMoveHandler) Handle(params ppmop.PatchPersonallyP
 		return handlers.ResponseForError(h.Logger(), err)
 	}
 	return ppmop.NewPatchPersonallyProcuredMoveOK().WithPayload(ppmPayload)
-
 }
 
 // ppmNeedsEstimatesRecalculated determines whether the fields that comprise

--- a/pkg/handlers/internalapi/personally_procured_move_estimate_test.go
+++ b/pkg/handlers/internalapi/personally_procured_move_estimate_test.go
@@ -24,7 +24,7 @@ func (suite *HandlerSuite) TestShowPPMEstimateHandler() {
 
 	params := ppmop.ShowPPMEstimateParams{
 		HTTPRequest:     req,
-		PlannedMoveDate: *handlers.FmtDate(scenario.May15_2018),
+		PlannedMoveDate: *handlers.FmtDate(scenario.Oct1_2018),
 		OriginZip:       "94540",
 		DestinationZip:  "78626",
 		WeightEstimate:  7500,
@@ -58,7 +58,7 @@ func (suite *HandlerSuite) TestShowPPMEstimateHandlerLowWeight() {
 
 	params := ppmop.ShowPPMEstimateParams{
 		HTTPRequest:     req,
-		PlannedMoveDate: *handlers.FmtDate(scenario.May15_2018),
+		PlannedMoveDate: *handlers.FmtDate(scenario.Oct1_2018),
 		OriginZip:       "94540",
 		DestinationZip:  "78626",
 		WeightEstimate:  600,

--- a/pkg/handlers/internalapi/personally_procured_move_incentive_test.go
+++ b/pkg/handlers/internalapi/personally_procured_move_incentive_test.go
@@ -22,7 +22,7 @@ func (suite *HandlerSuite) TestShowPPMIncentiveHandlerForbidden() {
 
 	params := ppmop.ShowPPMIncentiveParams{
 		HTTPRequest:     req,
-		PlannedMoveDate: *handlers.FmtDate(scenario.May15_2018),
+		PlannedMoveDate: *handlers.FmtDate(scenario.Oct1_2018),
 		OriginZip:       "94540",
 		DestinationZip:  "78626",
 		Weight:          7500,
@@ -47,7 +47,7 @@ func (suite *HandlerSuite) TestShowPPMIncentiveHandler() {
 
 	params := ppmop.ShowPPMIncentiveParams{
 		HTTPRequest:     req,
-		PlannedMoveDate: *handlers.FmtDate(scenario.May15_2018),
+		PlannedMoveDate: *handlers.FmtDate(scenario.Oct1_2018),
 		OriginZip:       "94540",
 		DestinationZip:  "78626",
 		Weight:          7500,
@@ -76,7 +76,7 @@ func (suite *HandlerSuite) TestShowPPMIncentiveHandlerLowWeight() {
 
 	params := ppmop.ShowPPMIncentiveParams{
 		HTTPRequest:     req,
-		PlannedMoveDate: *handlers.FmtDate(scenario.May15_2018),
+		PlannedMoveDate: *handlers.FmtDate(scenario.Oct1_2018),
 		OriginZip:       "94540",
 		DestinationZip:  "78626",
 		Weight:          600,

--- a/pkg/testdatagen/scenario/estimate.go
+++ b/pkg/testdatagen/scenario/estimate.go
@@ -70,7 +70,7 @@ func RunPPMSITEstimateScenario1(db *pop.Connection) error {
 		LinehaulFactor:     unit.Cents(39),
 		ServiceChargeCents: unit.Cents(350),
 		EffectiveDateLower: May15_2018,
-		EffectiveDateUpper: May15_2019,
+		EffectiveDateUpper: May14_2019,
 		SIT185ARateCents:   unit.Cents(1402),
 		SIT185BRateCents:   unit.Cents(53),
 		SITPDSchedule:      3,
@@ -85,7 +85,7 @@ func RunPPMSITEstimateScenario1(db *pop.Connection) error {
 		LinehaulFactor:     unit.Cents(43),
 		ServiceChargeCents: unit.Cents(350),
 		EffectiveDateLower: May15_2018,
-		EffectiveDateUpper: May15_2019,
+		EffectiveDateUpper: May14_2019,
 		SIT185ARateCents:   unit.Cents(1292),
 		SIT185BRateCents:   unit.Cents(51),
 		SITPDSchedule:      2,
@@ -96,10 +96,10 @@ func RunPPMSITEstimateScenario1(db *pop.Connection) error {
 
 	band := 1
 	tspp := models.TransportationServiceProviderPerformance{
-		PerformancePeriodStart:          May15_2018,
-		PerformancePeriodEnd:            Oct15_2018,
-		RateCycleStart:                  May15_2018,
-		RateCycleEnd:                    Oct15_2018,
+		PerformancePeriodStart:          Oct1_2018,
+		PerformancePeriodEnd:            Dec31_2018,
+		RateCycleStart:                  Oct1_2018,
+		RateCycleEnd:                    May14_2019,
 		TrafficDistributionListID:       tdl.ID,
 		TransportationServiceProviderID: tsp.ID,
 		QualityBand:                     &band,

--- a/pkg/testdatagen/scenario/rateengine.go
+++ b/pkg/testdatagen/scenario/rateengine.go
@@ -66,7 +66,7 @@ func RunRateEngineScenario1(db *pop.Connection) error {
 		SIT185BRateCents:   unit.Cents(65),
 		SITPDSchedule:      3,
 		EffectiveDateLower: May15_2018,
-		EffectiveDateUpper: May15_2019,
+		EffectiveDateUpper: May14_2019,
 	}
 	if err := save(db, &originServiceArea); err != nil {
 		return err
@@ -82,7 +82,7 @@ func RunRateEngineScenario1(db *pop.Connection) error {
 		SIT185BRateCents:   unit.Cents(53),
 		SITPDSchedule:      2,
 		EffectiveDateLower: May15_2018,
-		EffectiveDateUpper: May15_2019,
+		EffectiveDateUpper: May14_2019,
 	}
 	if err := save(db, &destinationServiceArea); err != nil {
 		return err
@@ -96,7 +96,7 @@ func RunRateEngineScenario1(db *pop.Connection) error {
 		WeightLbsUpper:     4200,
 		RateCents:          unit.Cents(458300),
 		EffectiveDateLower: May15_2018,
-		EffectiveDateUpper: May15_2019,
+		EffectiveDateUpper: May14_2019,
 	}
 	if err := save(db, &linehaulRate); err != nil {
 		return err
@@ -107,7 +107,7 @@ func RunRateEngineScenario1(db *pop.Connection) error {
 		CwtMilesUpper:      16001,
 		RateCents:          32834,
 		EffectiveDateLower: May15_2018,
-		EffectiveDateUpper: May15_2019,
+		EffectiveDateUpper: May14_2019,
 	}
 	if err := save(db, &shorthaulRate); err != nil {
 		return err
@@ -119,7 +119,7 @@ func RunRateEngineScenario1(db *pop.Connection) error {
 		WeightLbsUpper:     unit.Pound(16001),
 		RateCents:          unit.Cents(6130),
 		EffectiveDateLower: May15_2018,
-		EffectiveDateUpper: May15_2019,
+		EffectiveDateUpper: May14_2019,
 	}
 	if err := save(db, &fullPackRate); err != nil {
 		return err
@@ -129,7 +129,7 @@ func RunRateEngineScenario1(db *pop.Connection) error {
 		Schedule:           2,
 		RateMillicents:     643650,
 		EffectiveDateLower: May15_2018,
-		EffectiveDateUpper: May15_2019,
+		EffectiveDateUpper: May14_2019,
 	}
 	if err := save(db, &fullUnpackRate); err != nil {
 		return err
@@ -137,10 +137,10 @@ func RunRateEngineScenario1(db *pop.Connection) error {
 
 	band := 1
 	tspp := models.TransportationServiceProviderPerformance{
-		PerformancePeriodStart:          May15_2018,
-		PerformancePeriodEnd:            Oct15_2018,
-		RateCycleStart:                  May15_2018,
-		RateCycleEnd:                    Oct15_2018,
+		PerformancePeriodStart:          Oct1_2018,
+		PerformancePeriodEnd:            Dec31_2018,
+		RateCycleStart:                  Oct1_2018,
+		RateCycleEnd:                    May14_2019,
 		TrafficDistributionListID:       tdl.ID,
 		TransportationServiceProviderID: tsp.ID,
 		QualityBand:                     &band,
@@ -209,7 +209,7 @@ func RunRateEngineScenario2(db *pop.Connection) error {
 		LinehaulFactor:     unit.Cents(263),
 		ServiceChargeCents: unit.Cents(489),
 		EffectiveDateLower: May15_2018,
-		EffectiveDateUpper: May15_2019,
+		EffectiveDateUpper: May14_2019,
 		SIT185ARateCents:   unit.Cents(1447),
 		SIT185BRateCents:   unit.Cents(51),
 		SITPDSchedule:      3,
@@ -225,7 +225,7 @@ func RunRateEngineScenario2(db *pop.Connection) error {
 		LinehaulFactor:     unit.Cents(78),
 		ServiceChargeCents: unit.Cents(452),
 		EffectiveDateLower: May15_2018,
-		EffectiveDateUpper: May15_2019,
+		EffectiveDateUpper: May14_2019,
 		SIT185ARateCents:   unit.Cents(1642),
 		SIT185BRateCents:   unit.Cents(70),
 		SITPDSchedule:      3,
@@ -242,7 +242,7 @@ func RunRateEngineScenario2(db *pop.Connection) error {
 		WeightLbsUpper:     7600,
 		RateCents:          unit.Cents(1277900),
 		EffectiveDateLower: May15_2018,
-		EffectiveDateUpper: May15_2019,
+		EffectiveDateUpper: May14_2019,
 	}
 	if err := save(db, &linehaulRate1); err != nil {
 		return err
@@ -256,7 +256,7 @@ func RunRateEngineScenario2(db *pop.Connection) error {
 		WeightLbsUpper:     1400,
 		RateCents:          unit.Cents(1277900),
 		EffectiveDateLower: May15_2018,
-		EffectiveDateUpper: May15_2019,
+		EffectiveDateUpper: May14_2019,
 	}
 	if err := save(db, &linehaulRate2); err != nil {
 		return err
@@ -267,7 +267,7 @@ func RunRateEngineScenario2(db *pop.Connection) error {
 		CwtMilesUpper:      128001,
 		RateCents:          18242,
 		EffectiveDateLower: May15_2018,
-		EffectiveDateUpper: May15_2019,
+		EffectiveDateUpper: May14_2019,
 	}
 	if err := save(db, &shorthaulRate); err != nil {
 		return err
@@ -279,7 +279,7 @@ func RunRateEngineScenario2(db *pop.Connection) error {
 		WeightLbsUpper:     unit.Pound(16001),
 		RateCents:          unit.Cents(6714),
 		EffectiveDateLower: May15_2018,
-		EffectiveDateUpper: May15_2019,
+		EffectiveDateUpper: May14_2019,
 	}
 	if err := save(db, &fullPackRate); err != nil {
 		return err
@@ -289,7 +289,7 @@ func RunRateEngineScenario2(db *pop.Connection) error {
 		Schedule:           3,
 		RateMillicents:     704970,
 		EffectiveDateLower: May15_2018,
-		EffectiveDateUpper: May15_2019,
+		EffectiveDateUpper: May14_2019,
 	}
 	if err := save(db, &fullUnpackRate); err != nil {
 		return err
@@ -297,10 +297,10 @@ func RunRateEngineScenario2(db *pop.Connection) error {
 
 	band := 1
 	tspp := models.TransportationServiceProviderPerformance{
-		PerformancePeriodStart:          May15_2018,
-		PerformancePeriodEnd:            Oct15_2018,
-		RateCycleStart:                  May15_2018,
-		RateCycleEnd:                    Oct15_2018,
+		PerformancePeriodStart:          Oct1_2018,
+		PerformancePeriodEnd:            Dec31_2018,
+		RateCycleStart:                  Oct1_2018,
+		RateCycleEnd:                    May14_2019,
 		TrafficDistributionListID:       tdl.ID,
 		TransportationServiceProviderID: tsp.ID,
 		QualityBand:                     &band,

--- a/pkg/testdatagen/scenario/shared.go
+++ b/pkg/testdatagen/scenario/shared.go
@@ -18,11 +18,14 @@ type NamedScenario struct {
 // May15_2018 is a date in May 2018
 var May15_2018 = time.Date(2018, time.May, 15, 0, 0, 0, 0, time.UTC)
 
-// Oct15_2018 is a date in October 2018
-var Oct15_2018 = time.Date(2018, time.October, 15, 0, 0, 0, 0, time.UTC)
+// Oct1_2018 is October 1, 2018
+var Oct1_2018 = time.Date(2018, time.October, 1, 0, 0, 0, 0, time.UTC)
 
-// May15_2019 is a date in May 2019
-var May15_2019 = time.Date(2019, time.May, 15, 0, 0, 0, 0, time.UTC)
+// Dec31_2018 is December 31, 2018
+var Dec31_2018 = time.Date(2018, time.December, 31, 0, 0, 0, 0, time.UTC)
+
+// May14_2019 is May 14, 2019
+var May14_2019 = time.Date(2019, time.May, 14, 0, 0, 0, 0, time.UTC)
 
 func save(db *pop.Connection, model interface{}) error {
 	verrs, err := db.ValidateAndSave(model)


### PR DESCRIPTION
## Description

This resolves the issues we are having with tests failing today: October 16, 2018.

**This is a stopgap solution! Things will break again on January 1st.**