### PR TITLE
Allow individual dates in the dates panel to be updated

### DIFF
--- a/cypress/integration/tsp/datesPanel.js
+++ b/cypress/integration/tsp/datesPanel.js
@@ -24,22 +24,45 @@ function tspUserEntersDates() {
     expect(loc.pathname).to.match(/^\/shipments\/[^/]+/);
   });
 
+  // Enter details in form and save dates
+  // Do these in separate passes to ensure we can always update parts of this panel separately
+
+  // Conducted Date
   cy
     .get('.editable-panel-header')
     .contains('Dates')
     .siblings()
     .click();
 
-  // Enter details in form and save dates
-
-  // Conducted Date
   cy
     .get('input[name="dates.pm_survey_conducted_date"]')
     .first()
     .type('7/20/2018')
     .blur();
   cy.get('select[name="dates.pm_survey_method"]').select('PHONE');
+
+  cy
+    .get('button')
+    .contains('Save')
+    .should('be.enabled');
+
+  cy
+    .get('button')
+    .contains('Save')
+    .click();
+
+  cy.reload();
+
+  cy.get('div.pm_survey_conducted_date').contains('20-Jul-18');
+  cy.get('div.pm_survey_method').contains('Phone');
+
   // Pack Dates
+  cy
+    .get('.editable-panel-header')
+    .contains('Dates')
+    .siblings()
+    .click();
+
   // TODO: ADD original_pack_date
   cy
     .get('input[name="dates.pm_survey_planned_pack_date"]')
@@ -51,7 +74,30 @@ function tspUserEntersDates() {
     .first()
     .type('8/2/2018')
     .blur();
+
+  cy
+    .get('button')
+    .contains('Save')
+    .should('be.enabled');
+
+  cy
+    .get('button')
+    .contains('Save')
+    .click();
+
+  cy.reload();
+
+  cy.get('div.original_pack_date').contains('TODO');
+  cy.get('div.pm_survey_planned_pack_date').contains('01-Aug-18');
+  cy.get('div.actual_pack_date').contains('02-Aug-18');
+
   // Pickup Dates
+  cy
+    .get('.editable-panel-header')
+    .contains('Dates')
+    .siblings()
+    .click();
+
   cy
     .get('input[name="dates.pm_survey_planned_pickup_date"]')
     .first()
@@ -62,7 +108,30 @@ function tspUserEntersDates() {
     .first()
     .type('8/3/2018')
     .blur();
+
+  cy
+    .get('button')
+    .contains('Save')
+    .should('be.enabled');
+
+  cy
+    .get('button')
+    .contains('Save')
+    .click();
+
+  cy.reload();
+
+  cy.get('div.requested_pickup_date').contains('15-May-19');
+  cy.get('div.pm_survey_planned_pickup_date').contains('02-Aug-18');
+  cy.get('div.actual_pickup_date').contains('03-Aug-18');
+
   // Delivery Dates
+  cy
+    .get('.editable-panel-header')
+    .contains('Dates')
+    .siblings()
+    .click();
+
   // TODO: Add original_delivery_date
   cy
     .get('input[name="dates.pm_survey_planned_delivery_date"]')
@@ -73,7 +142,31 @@ function tspUserEntersDates() {
     .get('input[name="dates.actual_delivery_date"]')
     .first()
     .type('10/8/2018');
+
+  cy
+    .get('button')
+    .contains('Save')
+    .should('be.enabled');
+
+  cy
+    .get('button')
+    .contains('Save')
+    .click();
+
+  cy.reload();
+
+  cy.get('div.original_delivery_date').contains('TODO');
+  cy.get('div.pm_survey_planned_delivery_date').contains('07-Oct-18');
+  cy.get('div.actual_delivery_date').contains('08-Oct-18');
+  cy.get('div.rdd').contains('08-Oct-18');
+
   // Notes
+  cy
+    .get('.editable-panel-header')
+    .contains('Dates')
+    .siblings()
+    .click();
+
   cy
     .get('textarea[name="dates.pm_survey_notes"]')
     .first()
@@ -90,23 +183,9 @@ function tspUserEntersDates() {
     .contains('Save')
     .click();
 
-  // Verify data has been saved in the UI
-  cy.get('span').contains('Notes notes notes for dates');
-
-  // Refresh browser and make sure changes persist
   cy.reload();
 
-  cy.get('div.pm_survey_conducted_date').contains('20-Jul-18');
-  cy.get('div.original_pack_date').contains('TODO');
-  cy.get('div.pm_survey_planned_pack_date').contains('01-Aug-18');
-  cy.get('div.actual_pack_date').contains('02-Aug-18');
-  cy.get('div.requested_pickup_date').contains('15-May-19');
-  cy.get('div.pm_survey_planned_pickup_date').contains('02-Aug-18');
-  cy.get('div.actual_pickup_date').contains('03-Aug-18');
-  cy.get('div.original_delivery_date').contains('TODO');
-  cy.get('div.pm_survey_planned_delivery_date').contains('07-Oct-18');
-  cy.get('div.actual_delivery_date').contains('08-Oct-18');
-  cy.get('div.rdd').contains('08-Oct-18');
+  cy.get('div.pm_survey_notes').contains('Notes notes notes for dates');
 
   // Verify Premove Survey contains the same data
   cy

--- a/pkg/handlers/publicapi/shipments.go
+++ b/pkg/handlers/publicapi/shipments.go
@@ -293,16 +293,25 @@ func (h DeliverShipmentHandler) Handle(params shipmentop.DeliverShipmentParams) 
 }
 
 func patchShipmentWithPayload(shipment *models.Shipment, payload *apimessages.Shipment) {
-	// Premove Survey values entered by TSP agent
-	requiredValue := payload.PmSurveyPlannedPackDate
 
-	// If any PmSurvey data was sent, update all fields
-	// This takes advantage of the fact that all PmSurvey data is updated at once and allows us to null out optional fields
-	if requiredValue != nil {
+	// PM Survey fields may be updated individually in the Dates panel and so cannot be lumped into one update
+	if payload.PmSurveyConductedDate != nil {
 		shipment.PmSurveyConductedDate = (*time.Time)(payload.PmSurveyConductedDate)
+	}
+
+	if payload.PmSurveyPlannedDeliveryDate != nil {
 		shipment.PmSurveyPlannedDeliveryDate = (*time.Time)(payload.PmSurveyPlannedDeliveryDate)
+	}
+
+	if payload.PmSurveyMethod != "" {
 		shipment.PmSurveyMethod = payload.PmSurveyMethod
+	}
+
+	if payload.PmSurveyPlannedPackDate != nil {
 		shipment.PmSurveyPlannedPackDate = (*time.Time)(payload.PmSurveyPlannedPackDate)
+	}
+
+	if payload.PmSurveyPlannedPickupDate != nil {
 		shipment.PmSurveyPlannedPickupDate = (*time.Time)(payload.PmSurveyPlannedPickupDate)
 	}
 

--- a/src/scenes/TransportationServiceProvider/Dates.jsx
+++ b/src/scenes/TransportationServiceProvider/Dates.jsx
@@ -69,22 +69,22 @@ const DatesEdit = props => {
       <FormSection name="dates">
         <div className="editable-panel-column">
           <div className="column-head">PM Survey</div>
-          <SwaggerField fieldName="pm_survey_conducted_date" swagger={schema} required />
-          <SwaggerField fieldName="pm_survey_method" swagger={schema} required />
+          <SwaggerField fieldName="pm_survey_conducted_date" swagger={schema} />
+          <SwaggerField fieldName="pm_survey_method" swagger={schema} />
           <div className="column-head">Packing</div>
           <PanelField title="Original" value="TODO" />
-          <SwaggerField fieldName="pm_survey_planned_pack_date" title="Planned" swagger={schema} required />
-          <SwaggerField fieldName="actual_pack_date" required title="Actual" swagger={schema} />
+          <SwaggerField fieldName="pm_survey_planned_pack_date" title="Planned" swagger={schema} />
+          <SwaggerField fieldName="actual_pack_date" title="Actual" swagger={schema} />
         </div>
         <div className="editable-panel-column">
           <div className="column-head">Pickup</div>
-          <PanelSwaggerField fieldName="requested_pickup_date" required title="Original" {...fieldProps} />
-          <SwaggerField fieldName="pm_survey_planned_pickup_date" required title="Planned" swagger={schema} />
-          <SwaggerField fieldName="actual_pickup_date" required title="Actual" swagger={schema} />
+          <PanelSwaggerField fieldName="requested_pickup_date" title="Original" {...fieldProps} />
+          <SwaggerField fieldName="pm_survey_planned_pickup_date" title="Planned" swagger={schema} />
+          <SwaggerField fieldName="actual_pickup_date" title="Actual" swagger={schema} />
           <div className="column-head">Delivery</div>
           <PanelField title="Original" value="TODO" />
-          <SwaggerField fieldName="pm_survey_planned_delivery_date" required title="Planned" swagger={schema} />
-          <SwaggerField fieldName="actual_delivery_date" required title="Actual" swagger={schema} />
+          <SwaggerField fieldName="pm_survey_planned_delivery_date" title="Planned" swagger={schema} />
+          <SwaggerField fieldName="actual_delivery_date" title="Actual" swagger={schema} />
           <PanelField title="Current RDD" value="TODO" />
           <SwaggerField fieldName="pm_survey_notes" title="Notes about dates" swagger={schema} />
         </div>


### PR DESCRIPTION
## Description

In the dates panel you'll want to be able to add one date or set of dates at a time without filling in the entire form.  This PR fixes that.

## Reviewers

This leaves the display panel with `required` elements but removes `required` from all of the fields in the editable panel.  I also finally broke out all the `PmSurvey...` PATCH updates on the server side to get this to work.

## Setup

```sh
make db_dev_reset && make db_dev_migrate && go run ./cmd/generate_test_data/main.go -scenario=7
```

Open a shipment and edit dates in the dates panel.  Add only one field at a time and save it to ensure it works.

## Code Review Verification Steps

* [x] End to end tests pass (`make e2e_test`).
* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/161186664) for this change