### PR TITLE
Added packing days info box to move date page.

### DIFF
--- a/src/scenes/Moves/Hhg/DatePicker.css
+++ b/src/scenes/Moves/Hhg/DatePicker.css
@@ -50,14 +50,3 @@ span.estimate {
   background-color: #000000;
   border-radius: 0;
 }
-
-.legend-square {
-  font-size: 1rem;
-  width: 22px;
-  height: 22px;
-  display: inline-block;
-}
-
-.legend-label {
-  padding-left: 0;
-}

--- a/src/scenes/Moves/Hhg/DatePicker.jsx
+++ b/src/scenes/Moves/Hhg/DatePicker.jsx
@@ -14,6 +14,7 @@ import DatesSummary from 'scenes/Moves/Hhg/DatesSummary.jsx';
 
 import './DatePicker.css';
 import LoadingPlaceholder from 'shared/LoadingPlaceholder';
+import { loadEntitlementsFromState } from 'shared/entitlements';
 
 const getRequestLabel = 'DatePicker.getMoveDatesSummary';
 
@@ -91,12 +92,12 @@ export class HHGDatePicker extends Component {
   render() {
     const availableMoveDates = this.props.availableMoveDates;
     const parsedSelectedDay = parseSwaggerDate(this.state.selectedDay);
+    const entitlementSum = get(this.props, 'entitlement.sum');
     return (
       <div className="form-section">
-        <h3 className="instruction-heading">Great! Let's find a date for a moving company to move your stuff.</h3>
         {availableMoveDates ? (
           <div className="usa-grid">
-            <h4>Select a move date</h4>
+            <h4 className="instruction-heading">Pick a moving date.</h4>
             <div className="usa-width-one-third">
               <DayPicker
                 onDayClick={this.handleDayClick}
@@ -107,7 +108,6 @@ export class HHGDatePicker extends Component {
                 showOutsideDays
               />
             </div>
-
             <div className="usa-width-two-thirds">
               {this.state.selectedDay && <DatesSummary moveDates={this.props.moveDates} />}
             </div>
@@ -115,6 +115,20 @@ export class HHGDatePicker extends Component {
         ) : (
           <LoadingPlaceholder />
         )}
+        <div className="usa-grid entitlement-alert">
+          <div className="usa-width-one-whole">
+            <p>Can't find a date that works? Talk with a move counselor in your local Transportation office (PPPO).</p>
+            {entitlementSum ? (
+              <div className="days-for-pounds">
+                * It takes 1 day for every 5,000 lbs of stuff movers need to pack. You have an allowance of{' '}
+                {entitlementSum.toLocaleString()} lbs, so we estimate it will take {Math.ceil(entitlementSum / 5000)}{' '}
+                days to pack.
+              </div>
+            ) : (
+              <LoadingPlaceholder />
+            )}
+          </div>
+        </div>
       </div>
     );
   }
@@ -132,6 +146,7 @@ function mapStateToProps(state, ownProps) {
   return {
     moveDates: moveDates,
     modifiers: createModifiers(moveDates),
+    entitlement: loadEntitlementsFromState(state),
   };
 }
 

--- a/src/scenes/Moves/Hhg/ShipmentWizard.css
+++ b/src/scenes/Moves/Hhg/ShipmentWizard.css
@@ -1,7 +1,28 @@
 .shipment-wizard .form-section {
-  margin-top: 7rem;
+  margin-top: 3rem;
 }
 
 .shipment-wizard h3.instruction-heading {
   font-size: 2rem;
+}
+
+.shipment-wizard .entitlement-alert {
+  padding-top: 3rem;
+}
+
+.shipment-wizard .legend-square {
+  font-size: 1rem;
+  width: 22px;
+  height: 22px;
+  display: inline-block;
+}
+
+.shipment-wizard .legend-label {
+  padding-left: 0;
+}
+
+.shipment-wizard .days-for-pounds {
+  background-color: #eff5fc;
+  padding: 1.5rem;
+  border: 1px solid #d1d1d1;
 }


### PR DESCRIPTION
## Description

This PR adds in an info box to the "Pick a move date" page in the shipment wizard that explains the calculation of packing days (using the SM's entitlement).

## Reviewer Notes

I moved some styles around to make them scoped under the shipment-wizard CSS class.  Open to advice on how we generally handle/scope styles so they don't leak elsewhere in the React app.

I also fixed some of the wording/spacing to more closely match the wireframes.

## Setup

`make server_run`
`make client_run`
Create or generate a SM and go to the first screen of the HHG shipment flow.

## Code Review Verification Steps

* [ ] End to end tests pass (`make e2e_test`).
* [ ] There are no aXe warnings for UI.
* [ ] This works in IE.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/160779462) for this change

## Screenshots

![screen shot 2018-10-16 at 3 24 12 pm](https://user-images.githubusercontent.com/4960757/47042038-4d5bf700-d158-11e8-94d7-564d26612e02.png)
