### PR TITLE
Allow TSP to delete dates in dates panel

### DIFF
--- a/cypress/integration/tsp/datesPanel.js
+++ b/cypress/integration/tsp/datesPanel.js
@@ -6,6 +6,9 @@ describe('TSP User Completes Dates Panel', function() {
   it('tsp user completes dates panel', function() {
     tspUserEntersDates();
   });
+  it('tsp user completes dates panel and zeroes it out', function() {
+    tspUserEntersAndRemovesDates();
+  });
 });
 
 function tspUserEntersDates() {
@@ -170,6 +173,7 @@ function tspUserEntersDates() {
   cy
     .get('textarea[name="dates.pm_survey_notes"]')
     .first()
+    .clear()
     .type('Notes notes notes for dates')
     .blur();
 
@@ -194,4 +198,200 @@ function tspUserEntersDates() {
     .parent()
     .parent()
     .contains('07-Oct-18');
+}
+
+function tspUserEntersAndRemovesDates() {
+  // Open new shipments queue
+  cy.location().should(loc => {
+    expect(loc.pathname).to.match(/^\/queues\/new/);
+  });
+
+  // Find shipment and open it
+  cy
+    .get('div')
+    .contains('DATESZ')
+    .dblclick();
+
+  cy.location().should(loc => {
+    expect(loc.pathname).to.match(/^\/shipments\/[^/]+/);
+  });
+
+  cy
+    .get('.editable-panel-header')
+    .contains('Dates')
+    .siblings()
+    .click();
+
+  // Enter details in form and save dates
+
+  // Conducted Date
+
+  cy
+    .get('input[name="dates.pm_survey_conducted_date"]')
+    .first()
+    .type('7/20/2018')
+    .blur();
+  cy.get('select[name="dates.pm_survey_method"]').select('PHONE');
+
+  // Pack Dates
+  // TODO: ADD original_pack_date
+  cy
+    .get('input[name="dates.pm_survey_planned_pack_date"]')
+    .first()
+    .type('8/1/2018')
+    .blur();
+  cy
+    .get('input[name="dates.actual_pack_date"]')
+    .first()
+    .type('8/2/2018')
+    .blur();
+
+  // Pickup Dates
+  cy
+    .get('input[name="dates.pm_survey_planned_pickup_date"]')
+    .first()
+    .type('8/2/2018')
+    .blur();
+  cy
+    .get('input[name="dates.actual_pickup_date"]')
+    .first()
+    .type('8/3/2018')
+    .blur();
+
+  // Delivery Dates
+  // TODO: Add original_delivery_date
+  cy
+    .get('input[name="dates.pm_survey_planned_delivery_date"]')
+    .first()
+    .type('10/7/2018')
+    .blur();
+  cy
+    .get('input[name="dates.actual_delivery_date"]')
+    .first()
+    .type('10/8/2018')
+    .blur();
+
+  // Notes
+
+  cy
+    .get('textarea[name="dates.pm_survey_notes"]')
+    .first()
+    .clear()
+    .type('Notes notes notes for dates')
+    .blur();
+
+  cy
+    .get('button')
+    .contains('Save')
+    .should('be.enabled');
+
+  cy
+    .get('button')
+    .contains('Save')
+    .click();
+
+  cy.reload();
+
+  cy.get('div.pm_survey_conducted_date').contains('20-Jul-18');
+  cy.get('div.pm_survey_method').contains('Phone');
+  cy.get('div.original_pack_date').contains('TODO');
+  cy.get('div.pm_survey_planned_pack_date').contains('01-Aug-18');
+  cy.get('div.actual_pack_date').contains('02-Aug-18');
+  cy.get('div.requested_pickup_date').contains('15-May-19');
+  cy.get('div.pm_survey_planned_pickup_date').contains('02-Aug-18');
+  cy.get('div.actual_pickup_date').contains('03-Aug-18');
+  cy.get('div.original_delivery_date').contains('TODO');
+  cy.get('div.pm_survey_planned_delivery_date').contains('07-Oct-18');
+  cy.get('div.actual_delivery_date').contains('08-Oct-18');
+  cy.get('div.rdd').contains('08-Oct-18');
+  cy.get('div.pm_survey_notes').contains('Notes notes notes for dates');
+
+  // Now remove all the dates
+  const zeroTime = '{selectall}01/01/0001{enter}';
+
+  cy
+    .get('.editable-panel-header')
+    .contains('Dates')
+    .siblings()
+    .click();
+
+  // Enter details in form and save dates
+
+  // Conducted Date
+
+  cy
+    .get('input[name="dates.pm_survey_conducted_date"]')
+    .first()
+    .clear()
+    .type(zeroTime)
+    .blur();
+  cy.get('select[name="dates.pm_survey_method"]').select('PHONE');
+
+  // Pack Dates
+  // TODO: ADD original_pack_date
+  cy
+    .get('input[name="dates.pm_survey_planned_pack_date"]')
+    .first()
+    .clear()
+    .type(zeroTime)
+    .blur();
+  cy
+    .get('input[name="dates.actual_pack_date"]')
+    .first()
+    .clear()
+    .type(zeroTime)
+    .blur();
+
+  // Pickup Dates
+  cy
+    .get('input[name="dates.pm_survey_planned_pickup_date"]')
+    .first()
+    .clear()
+    .type(zeroTime)
+    .blur();
+  cy
+    .get('input[name="dates.actual_pickup_date"]')
+    .first()
+    .clear()
+    .type(zeroTime)
+    .blur();
+
+  // Delivery Dates
+  // TODO: Add original_delivery_date
+  cy
+    .get('input[name="dates.pm_survey_planned_delivery_date"]')
+    .first()
+    .clear()
+    .type(zeroTime)
+    .blur();
+  cy
+    .get('input[name="dates.actual_delivery_date"]')
+    .first()
+    .clear()
+    .type(zeroTime)
+    .blur();
+
+  cy
+    .get('button')
+    .contains('Save')
+    .should('be.enabled');
+
+  cy
+    .get('button')
+    .contains('Save')
+    .click();
+
+  cy.reload();
+
+  cy.get('div.pm_survey_conducted_date').contains('missing');
+  cy.get('div.original_pack_date').contains('TODO');
+  cy.get('div.pm_survey_planned_pack_date').contains('missing');
+  cy.get('div.actual_pack_date').contains('missing');
+  cy.get('div.requested_pickup_date').contains('15-May-19');
+  cy.get('div.pm_survey_planned_pickup_date').contains('missing');
+  cy.get('div.actual_pickup_date').contains('missing');
+  cy.get('div.original_delivery_date').contains('TODO');
+  cy.get('div.pm_survey_planned_delivery_date').contains('missing');
+  cy.get('div.actual_delivery_date').contains('missing');
+  cy.get('div.rdd').contains('ORIGINAL');
 }

--- a/pkg/handlers/publicapi/shipments.go
+++ b/pkg/handlers/publicapi/shipments.go
@@ -294,13 +294,24 @@ func (h DeliverShipmentHandler) Handle(params shipmentop.DeliverShipmentParams) 
 
 func patchShipmentWithPayload(shipment *models.Shipment, payload *apimessages.Shipment) {
 
+	// Comparint against the zero time allows users to set dates to nil via PATCH
+	zeroTime := time.Time{}
+
 	// PM Survey fields may be updated individually in the Dates panel and so cannot be lumped into one update
 	if payload.PmSurveyConductedDate != nil {
-		shipment.PmSurveyConductedDate = (*time.Time)(payload.PmSurveyConductedDate)
+		if zeroTime == (time.Time)(*payload.PmSurveyConductedDate) {
+			shipment.PmSurveyConductedDate = nil
+		} else {
+			shipment.PmSurveyConductedDate = (*time.Time)(payload.PmSurveyConductedDate)
+		}
 	}
 
 	if payload.PmSurveyPlannedDeliveryDate != nil {
-		shipment.PmSurveyPlannedDeliveryDate = (*time.Time)(payload.PmSurveyPlannedDeliveryDate)
+		if zeroTime == (time.Time)(*payload.PmSurveyPlannedDeliveryDate) {
+			shipment.PmSurveyPlannedDeliveryDate = nil
+		} else {
+			shipment.PmSurveyPlannedDeliveryDate = (*time.Time)(payload.PmSurveyPlannedDeliveryDate)
+		}
 	}
 
 	if payload.PmSurveyMethod != "" {
@@ -308,11 +319,19 @@ func patchShipmentWithPayload(shipment *models.Shipment, payload *apimessages.Sh
 	}
 
 	if payload.PmSurveyPlannedPackDate != nil {
-		shipment.PmSurveyPlannedPackDate = (*time.Time)(payload.PmSurveyPlannedPackDate)
+		if zeroTime == (time.Time)(*payload.PmSurveyPlannedPackDate) {
+			shipment.PmSurveyPlannedPackDate = nil
+		} else {
+			shipment.PmSurveyPlannedPackDate = (*time.Time)(payload.PmSurveyPlannedPackDate)
+		}
 	}
 
 	if payload.PmSurveyPlannedPickupDate != nil {
-		shipment.PmSurveyPlannedPickupDate = (*time.Time)(payload.PmSurveyPlannedPickupDate)
+		if zeroTime == (time.Time)(*payload.PmSurveyPlannedPickupDate) {
+			shipment.PmSurveyPlannedPickupDate = nil
+		} else {
+			shipment.PmSurveyPlannedPickupDate = (*time.Time)(payload.PmSurveyPlannedPickupDate)
+		}
 	}
 
 	if payload.PmSurveyNotes != nil {
@@ -344,15 +363,27 @@ func patchShipmentWithPayload(shipment *models.Shipment, payload *apimessages.Sh
 	}
 
 	if payload.ActualPickupDate != nil {
-		shipment.ActualPickupDate = (*time.Time)(payload.ActualPickupDate)
+		if zeroTime == (time.Time)(*payload.ActualPickupDate) {
+			shipment.ActualPickupDate = nil
+		} else {
+			shipment.ActualPickupDate = (*time.Time)(payload.ActualPickupDate)
+		}
 	}
 
 	if payload.ActualPackDate != nil {
-		shipment.ActualPackDate = (*time.Time)(payload.ActualPackDate)
+		if zeroTime == (time.Time)(*payload.ActualPackDate) {
+			shipment.ActualPackDate = nil
+		} else {
+			shipment.ActualPackDate = (*time.Time)(payload.ActualPackDate)
+		}
 	}
 
 	if payload.ActualDeliveryDate != nil {
-		shipment.ActualDeliveryDate = (*time.Time)(payload.ActualDeliveryDate)
+		if zeroTime == (time.Time)(*payload.ActualDeliveryDate) {
+			shipment.ActualDeliveryDate = nil
+		} else {
+			shipment.ActualDeliveryDate = (*time.Time)(payload.ActualDeliveryDate)
+		}
 	}
 
 	if payload.PickupAddress != nil {

--- a/pkg/testdatagen/scenario/e2ebasic.go
+++ b/pkg/testdatagen/scenario/e2ebasic.go
@@ -1187,6 +1187,47 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader) {
 	hhg19 := offer19.Shipment
 	hhg19.Move.Submit()
 	models.SaveMoveDependencies(db, &hhg19.Move)
+
+	/*
+	 * Service member with uploaded orders and an approved shipment. Use this to test zeroing dates.
+	 */
+	email = "hhg@dates.panel"
+
+	offer20 := testdatagen.MakeShipmentOffer(db, testdatagen.Assertions{
+		User: models.User{
+			ID:            uuid.Must(uuid.FromString("cf1b1f09-8ea2-4f68-872e-a056c3a5f22f")),
+			LoginGovEmail: email,
+		},
+		ServiceMember: models.ServiceMember{
+			ID:            uuid.FromStringOrNil("6c4bc296-927c-4c6b-a01e-1f064c5d5f9b"),
+			FirstName:     models.StringPointer("HHG"),
+			LastName:      models.StringPointer("Submitted"),
+			Edipi:         models.StringPointer("4444567890"),
+			PersonalEmail: models.StringPointer(email),
+		},
+		Move: models.Move{
+			ID:               uuid.FromStringOrNil("da9af941-253a-45e0-b012-8ee0385e28f8"),
+			Locator:          "DATESZ",
+			SelectedMoveType: models.StringPointer("HHG"),
+		},
+		TrafficDistributionList: models.TrafficDistributionList{
+			ID:                uuid.FromStringOrNil("9728e6a1-0469-4718-9ba1-5d7baace1191"),
+			SourceRateArea:    "US62",
+			DestinationRegion: "11",
+			CodeOfService:     "D",
+		},
+		Shipment: models.Shipment{
+			Status:             models.ShipmentStatusAWARDED,
+			ActualDeliveryDate: nil,
+		},
+		ShipmentOffer: models.ShipmentOffer{
+			TransportationServiceProviderID: tspUser.TransportationServiceProviderID,
+		},
+	})
+
+	hhg20 := offer20.Shipment
+	hhg20.Move.Submit()
+	models.SaveMoveDependencies(db, &hhg20.Move)
 }
 
 // MakeHhgFromAwardedToAcceptedGBLReady creates a scenario for an approved shipment ready for GBL generation


### PR DESCRIPTION
## Description

This change allows users to nil out dates after having added them and submitted them.

## Reviewer Notes

This works by comparing the entered date against the zero time (`time.Time{}`).  If it matches then the PATCH request can set the value in the DB to `nil`.  The zero date to enter is `01/01/0001`.

I cannot figure out how to get the field to remain empty if you select a date and hit the delete key until all the digits are gone.  It just refreshes to the old value if you do that.  I believe its a weird interaction between the react-day-picker and react-form that is doing this.

## Setup

```sh
make db_dev_reset && make db_dev_migrate && go run ./cmd/generate_test_data/main.go -scenario=7
```

Now go to the dates panel and enter a date, save the date, and now go back and type `01/01/0001` into that same field and save.  The result should be that the field was nulled out an you now see `nil`.  This is what the e2e tests do.

## Code Review Verification Steps

* [ ] End to end tests pass (`make e2e_test`).
* [x] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/161186603) for this change