### PR TITLE
Pre Approval Request hook up to create redux

### DIFF
--- a/pkg/handlers/publicapi/shipment_accessorials.go
+++ b/pkg/handlers/publicapi/shipment_accessorials.go
@@ -36,7 +36,7 @@ func payloadForShipmentAccessorialModel(s *models.ShipmentAccessorial) *apimessa
 		ShipmentID:    *handlers.FmtUUID(s.ShipmentID),
 		Accessorial:   payloadForTariff400ngItemModel(&s.Accessorial),
 		AccessorialID: handlers.FmtUUID(s.AccessorialID),
-		Location:      apimessages.AccessorialLocation(s.Location),
+		Location:      apimessages.ShipmentAccessorialLocation(s.Location),
 		Notes:         s.Notes,
 		Quantity1:     handlers.FmtInt64(int64(s.Quantity1)),
 		Quantity2:     handlers.FmtInt64(int64(s.Quantity2)),

--- a/pkg/handlers/publicapi/shipment_accessorials.go
+++ b/pkg/handlers/publicapi/shipment_accessorials.go
@@ -32,8 +32,8 @@ func payloadForShipmentAccessorialModel(s *models.ShipmentAccessorial) *apimessa
 	}
 
 	return &apimessages.ShipmentAccessorial{
-		ID:            handlers.FmtUUID(s.ID),
-		ShipmentID:    handlers.FmtUUID(s.ShipmentID),
+		ID:            *handlers.FmtUUID(s.ID),
+		ShipmentID:    *handlers.FmtUUID(s.ShipmentID),
 		Accessorial:   payloadForTariff400ngItemModel(&s.Accessorial),
 		AccessorialID: handlers.FmtUUID(s.AccessorialID),
 		Location:      apimessages.AccessorialLocation(s.Location),
@@ -88,7 +88,6 @@ func (h CreateShipmentAccessorialHandler) Handle(params accessorialop.CreateShip
 	session := auth.SessionFromRequestContext(params.HTTPRequest)
 
 	shipmentID := uuid.Must(uuid.FromString(params.ShipmentID.String()))
-
 	var shipment *models.Shipment
 	var err error
 	// If TSP user, verify TSP has shipment

--- a/pkg/handlers/publicapi/shipment_accessorials_test.go
+++ b/pkg/handlers/publicapi/shipment_accessorials_test.go
@@ -150,8 +150,8 @@ func (suite *HandlerSuite) TestUpdateShipmentAccessorialTSPHandler() {
 	req := httptest.NewRequest("PUT", "/shipments", nil)
 	req = suite.AuthenticateTspRequest(req, tspUser)
 	updateShipmentAccessorial := apimessages.ShipmentAccessorial{
-		ID:            handlers.FmtUUID(shipAcc1.ID),
-		ShipmentID:    handlers.FmtUUID(shipAcc1.ShipmentID),
+		ID:            *handlers.FmtUUID(shipAcc1.ID),
+		ShipmentID:    *handlers.FmtUUID(shipAcc1.ShipmentID),
 		Location:      apimessages.AccessorialLocationORIGIN,
 		Quantity1:     handlers.FmtInt64(int64(1)),
 		Quantity2:     handlers.FmtInt64(int64(2)),
@@ -203,8 +203,8 @@ func (suite *HandlerSuite) TestUpdateShipmentAccessorialOfficeHandler() {
 	req := httptest.NewRequest("PUT", "/shipments", nil)
 	req = suite.AuthenticateOfficeRequest(req, officeUser)
 	updateShipmentAccessorial := apimessages.ShipmentAccessorial{
-		ID:            handlers.FmtUUID(shipAcc1.ID),
-		ShipmentID:    handlers.FmtUUID(shipAcc1.ShipmentID),
+		ID:            *handlers.FmtUUID(shipAcc1.ID),
+		ShipmentID:    *handlers.FmtUUID(shipAcc1.ShipmentID),
 		Location:      apimessages.AccessorialLocationORIGIN,
 		Quantity1:     handlers.FmtInt64(int64(1)),
 		Quantity2:     handlers.FmtInt64(int64(2)),

--- a/pkg/handlers/publicapi/shipment_accessorials_test.go
+++ b/pkg/handlers/publicapi/shipment_accessorials_test.go
@@ -97,7 +97,7 @@ func (suite *HandlerSuite) TestCreateShipmentAccessorialHandler() {
 
 	payload := apimessages.ShipmentAccessorial{
 		AccessorialID: handlers.FmtUUID(acc.ID),
-		Location:      apimessages.AccessorialLocationORIGIN,
+		Location:      apimessages.ShipmentAccessorialLocationORIGIN,
 		Notes:         "Some notes",
 		Quantity1:     handlers.FmtInt64(int64(5)),
 	}
@@ -152,7 +152,7 @@ func (suite *HandlerSuite) TestUpdateShipmentAccessorialTSPHandler() {
 	updateShipmentAccessorial := apimessages.ShipmentAccessorial{
 		ID:            *handlers.FmtUUID(shipAcc1.ID),
 		ShipmentID:    *handlers.FmtUUID(shipAcc1.ShipmentID),
-		Location:      apimessages.AccessorialLocationORIGIN,
+		Location:      apimessages.ShipmentAccessorialLocationORIGIN,
 		Quantity1:     handlers.FmtInt64(int64(1)),
 		Quantity2:     handlers.FmtInt64(int64(2)),
 		Notes:         "HELLO",
@@ -205,7 +205,7 @@ func (suite *HandlerSuite) TestUpdateShipmentAccessorialOfficeHandler() {
 	updateShipmentAccessorial := apimessages.ShipmentAccessorial{
 		ID:            *handlers.FmtUUID(shipAcc1.ID),
 		ShipmentID:    *handlers.FmtUUID(shipAcc1.ShipmentID),
-		Location:      apimessages.AccessorialLocationORIGIN,
+		Location:      apimessages.ShipmentAccessorialLocationORIGIN,
 		Quantity1:     handlers.FmtInt64(int64(1)),
 		Quantity2:     handlers.FmtInt64(int64(2)),
 		Notes:         "HELLO",

--- a/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
+++ b/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
@@ -222,11 +222,7 @@ class ShipmentInfo extends Component {
                     shipment={this.props.shipment}
                     update={this.props.patchShipment}
                   />
-                  <PreApprovalPanel
-                    shipment_accessorials={this.props.shipmentAccessorials}
-                    tariff400ngItems={this.props.tariff400ngItems}
-                    shipmentId={this.props.match.params.shipmentId}
-                  />
+                  <PreApprovalPanel shipmentId={this.props.match.params.shipmentId} />
                   <ServiceAgents
                     title="ServiceAgents"
                     shipment={this.props.shipment}

--- a/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
+++ b/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
@@ -222,6 +222,7 @@ class ShipmentInfo extends Component {
                   <PreApprovalPanel
                     shipment_accessorials={this.props.shipmentAccessorials}
                     tariff400ngItems={this.props.tariff400ngItems}
+                    shipmentId={this.props.match.params.shipmentId}
                   />
                   <ServiceAgents
                     title="ServiceAgents"

--- a/src/shared/Entities/modules/shipmentAccessorials.js
+++ b/src/shared/Entities/modules/shipmentAccessorials.js
@@ -3,24 +3,15 @@ import { getPublicClient } from 'shared/Swagger/api';
 import { shipmentAccessorials } from '../schema';
 import { denormalize } from 'normalizr';
 
-export function createShipmentAccessorial(label, shipmentId, createPayload) {
-  return swaggerRequest(
-    getPublicClient,
-    'accessorials.createShipmentAccessorial',
-    { shipmentId, createPayload },
-    { label },
-  );
+export function createShipmentAccessorial(label, shipmentId, payload) {
+  return swaggerRequest(getPublicClient, 'accessorials.createShipmentAccessorial', { shipmentId, payload }, { label });
 }
 
-export function updateShipmentAccessorial(
-  label,
-  shipmentAccessorialId,
-  updatePayload,
-) {
+export function updateShipmentAccessorial(label, shipmentAccessorialId, payload) {
   return swaggerRequest(
     getPublicClient,
     'accessorials.updateShipmentAccessorial',
-    { shipmentAccessorialId, updatePayload },
+    { shipmentAccessorialId, payload },
     { label },
   );
 }
@@ -44,27 +35,12 @@ export function approveShipmentAccessorial(label, shipmentAccessorialId) {
 }
 
 export function getAllShipmentAccessorials(label, shipmentId) {
-  return swaggerRequest(
-    getPublicClient,
-    'accessorials.getShipmentAccessorials',
-    { shipmentId },
-    { label },
-  );
+  return swaggerRequest(getPublicClient, 'accessorials.getShipmentAccessorials', { shipmentId }, { label });
 }
 
-export const selectShipmentAccessorials = state =>
-  Object.values(state.entities.shipmentAccessorials);
+export const selectShipmentAccessorials = state => Object.values(state.entities.shipmentAccessorials);
 
-export const getShipmentAccessorialsLabel =
-  'ShipmentAccessorials.getAllShipmentAccessorials';
+export const getShipmentAccessorialsLabel = 'ShipmentAccessorials.getAllShipmentAccessorials';
+export const createShipmentAccessorialLabel = 'ShipmentAccessorials.createShipmentAccessorial';
 
-// const defaultShipmentAccessorial = {
-//     accessorial: { uploads: [] },
-//     notes: '',
-//     status: '',
-//     title: '',
-//     type: '',
-// };
-
-export const selectShipmentAccessorial = (state, id) =>
-  denormalize([id], shipmentAccessorials, state.entities)[0];
+export const selectShipmentAccessorial = (state, id) => denormalize([id], shipmentAccessorials, state.entities)[0];

--- a/src/shared/Entities/modules/shipmentAccessorials.js
+++ b/src/shared/Entities/modules/shipmentAccessorials.js
@@ -42,5 +42,6 @@ export const selectShipmentAccessorials = state => Object.values(state.entities.
 
 export const getShipmentAccessorialsLabel = 'ShipmentAccessorials.getAllShipmentAccessorials';
 export const createShipmentAccessorialLabel = 'ShipmentAccessorials.createShipmentAccessorial';
+export const deleteShipmentAccessorialLabel = 'ShipmentAccessorials.deleteShipmentAccessorial';
 
 export const selectShipmentAccessorial = (state, id) => denormalize([id], shipmentAccessorials, state.entities)[0];

--- a/src/shared/Entities/modules/tariff400ngItems.js
+++ b/src/shared/Entities/modules/tariff400ngItems.js
@@ -4,20 +4,13 @@ import { tariff400ngItems } from '../schema';
 import { denormalize } from 'normalizr';
 
 export function getAllTariff400ngItems(label) {
-  return swaggerRequest(
-    getPublicClient,
-    'accessorials.getTariff400ngItems',
-    {},
-    { label },
-  );
+  return swaggerRequest(getPublicClient, 'accessorials.getTariff400ngItems', {}, { label });
 }
 
 export const selectTariff400ngItems = state => {
   return Object.values(state.entities.tariff400ngItems);
 };
 
-export const getTariff400ngItemsLabel =
-  'Tariff400ngItem.getAlltariff400ngItems';
+export const getTariff400ngItemsLabel = 'Tariff400ngItem.getAlltariff400ngItems';
 
-export const selectTariff400ngItem = (state, id) =>
-  denormalize([id], tariff400ngItems, state.entities)[0];
+export const selectTariff400ngItem = (state, id) => denormalize([id], tariff400ngItems, state.entities)[0];

--- a/src/shared/PreApprovalRequest/PreApprovalForm.jsx
+++ b/src/shared/PreApprovalRequest/PreApprovalForm.jsx
@@ -54,6 +54,23 @@ export class PreApprovalForm extends Component {
               swagger={this.props.ship_accessorial_schema}
               required
             />
+            <div className="bq-explanation">
+              <p>
+                Enter numbers only, no symbols or units. <em>Examples:</em>
+              </p>
+              <ul>
+                <li>
+                  Crating: enter "<strong>47.4</strong>" for crate size of 47.4 cu. ft.
+                </li>
+                <li>
+                  {' '}
+                  3rd-party service: enter "<strong>1299.99</strong>" for cost of $1,299.99.
+                </li>
+                <li>
+                  Bulky item: enter "<strong>1</strong>" for a single item.
+                </li>
+              </ul>
+            </div>
           </div>
           <div className="usa-width-one-half">
             <SwaggerField

--- a/src/shared/PreApprovalRequest/PreApprovalForm.jsx
+++ b/src/shared/PreApprovalRequest/PreApprovalForm.jsx
@@ -34,7 +34,7 @@ export class PreApprovalForm extends Component {
         <div className="usa-grid">
           <div className="usa-width-one-half">
             <SwaggerField
-              fieldName="accessorial"
+              fieldName="accessorial_id"
               title="Code & Item"
               className="rounded"
               component={Codes(this.props.tariff400ngItems)}

--- a/src/shared/PreApprovalRequest/PreApprovalForm.jsx
+++ b/src/shared/PreApprovalRequest/PreApprovalForm.jsx
@@ -69,7 +69,6 @@ export class PreApprovalForm extends Component {
 }
 
 PreApprovalForm.propTypes = {
-  schema: PropTypes.object,
   tariff400ngItems: PropTypes.array,
   onSubmit: PropTypes.func.isRequired,
 };

--- a/src/shared/PreApprovalRequest/PreApprovalForm.test.js
+++ b/src/shared/PreApprovalRequest/PreApprovalForm.test.js
@@ -89,7 +89,7 @@ beforeEach(() => {
   //mount appears to be necessary to get inner components to load (i.e. tests fail with shallow)
   wrapper = mount(
     <Provider store={store}>
-      <PreApprovalForm ship_accessorial_schema={simpleSchema} accessorials={accessorials} onSubmit={submit} />
+      <PreApprovalForm ship_accessorial_schema={simpleSchema} tariff400ngItems={accessorials} onSubmit={submit} />
     </Provider>,
   );
 });

--- a/src/shared/PreApprovalRequest/PreApprovalPanel.jsx
+++ b/src/shared/PreApprovalRequest/PreApprovalPanel.jsx
@@ -8,6 +8,13 @@ import Creator from 'shared/PreApprovalRequest/Creator';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 
+import {
+  createShipmentAccessorial,
+  createShipmentAccessorialLabel,
+} from 'shared/Entities/modules/shipmentAccessorials';
+import { selectShipmentAccessorials } from 'shared/Entities/modules/shipmentAccessorials';
+import { selectTariff400ngItems } from 'shared/Entities/modules/tariff400ngItems';
+
 export class PreApprovalPanel extends Component {
   constructor() {
     super();
@@ -15,17 +22,19 @@ export class PreApprovalPanel extends Component {
       isActionable: true,
     };
   }
-  onSubmit = values => {
-    return new Promise(function(resolve, reject) {
-      // do a thing, possibly async, then…
-      setTimeout(function() {
-        console.log('onSubmit async', values);
-        resolve('success');
-      }, 50);
-    });
+  onSubmit = createPayload => {
+    return new Promise(
+      function(resolve, reject) {
+        // do a thing, possibly async, then…
+        this.props.createShipmentAccessorial(createShipmentAccessorialLabel, this.props.shipmentId, createPayload);
+        setTimeout(function() {
+          resolve('success');
+        }, 50);
+      }.bind(this),
+    );
   };
   onEdit = () => {
-    console.log('onEdit hit');
+    console.log('onEdit hit', this.props);
   };
   onDelete = () => {
     console.log('onDelete hit');
@@ -61,13 +70,17 @@ export class PreApprovalPanel extends Component {
 PreApprovalPanel.propTypes = {
   shipment_accessorials: PropTypes.array,
   tariff400ngItems: PropTypes.array,
+  shipmentId: PropTypes.string,
 };
 
 function mapStateToProps(state) {
-  return {};
+  return {
+    shipmentAccessorials: selectShipmentAccessorials(state),
+    tariff400ngItems: selectTariff400ngItems(state),
+  };
 }
 
 function mapDispatchToProps(dispatch) {
-  return bindActionCreators({}, dispatch);
+  return bindActionCreators({ createShipmentAccessorial }, dispatch);
 }
 export default connect(mapStateToProps, mapDispatchToProps)(PreApprovalPanel);

--- a/src/shared/PreApprovalRequest/PreApprovalPanel.jsx
+++ b/src/shared/PreApprovalRequest/PreApprovalPanel.jsx
@@ -11,6 +11,8 @@ import { bindActionCreators } from 'redux';
 import {
   createShipmentAccessorial,
   createShipmentAccessorialLabel,
+  deleteShipmentAccessorial,
+  deleteShipmentAccessorialLabel,
 } from 'shared/Entities/modules/shipmentAccessorials';
 import { selectShipmentAccessorials } from 'shared/Entities/modules/shipmentAccessorials';
 import { selectTariff400ngItems } from 'shared/Entities/modules/tariff400ngItems';
@@ -18,9 +20,7 @@ import { selectTariff400ngItems } from 'shared/Entities/modules/tariff400ngItems
 export class PreApprovalPanel extends Component {
   constructor() {
     super();
-    this.state = {
-      isActionable: true,
-    };
+    this.state = { isActionable: true };
   }
   onSubmit = createPayload => {
     return new Promise(
@@ -36,8 +36,18 @@ export class PreApprovalPanel extends Component {
   onEdit = () => {
     console.log('onEdit hit');
   };
-  onDelete = () => {
-    console.log('onDelete hit');
+  onDelete = shipmentAccessorialId => {
+    if (window.confirm('Are you sure you want to delete this pre approval request?')) {
+      return new Promise(
+        function(resolve, reject) {
+          //  console.log(shipmentAccessorialId);
+          this.props.deleteShipmentAccessorial(deleteShipmentAccessorialLabel, shipmentAccessorialId);
+          setTimeout(function() {
+            resolve('success');
+          }, 50);
+        }.bind(this),
+      );
+    }
   };
   onApproval = () => {
     console.log('onApproval hit');
@@ -81,6 +91,6 @@ function mapStateToProps(state) {
 }
 
 function mapDispatchToProps(dispatch) {
-  return bindActionCreators({ createShipmentAccessorial }, dispatch);
+  return bindActionCreators({ createShipmentAccessorial, deleteShipmentAccessorial }, dispatch);
 }
 export default connect(mapStateToProps, mapDispatchToProps)(PreApprovalPanel);

--- a/src/shared/PreApprovalRequest/PreApprovalPanel.jsx
+++ b/src/shared/PreApprovalRequest/PreApprovalPanel.jsx
@@ -44,7 +44,7 @@ export class PreApprovalPanel extends Component {
       <div>
         <BasicPanel title={'Pre-Approval Requests'}>
           <PreApprovalTable
-            shipment_accessorials={this.props.shipment_accessorials}
+            shipmentAccessorials={this.props.shipmentAccessorials}
             isActionable={this.state.isActionable}
             onEdit={this.onEdit}
             onDelete={this.onDelete}
@@ -62,7 +62,7 @@ export class PreApprovalPanel extends Component {
 }
 
 PreApprovalPanel.propTypes = {
-  shipment_accessorials: PropTypes.array,
+  shipmentAccessorials: PropTypes.array,
   tariff400ngItems: PropTypes.array,
   shipmentId: PropTypes.string,
 };

--- a/src/shared/PreApprovalRequest/PreApprovalPanel.jsx
+++ b/src/shared/PreApprovalRequest/PreApprovalPanel.jsx
@@ -23,30 +23,14 @@ export class PreApprovalPanel extends Component {
     this.state = { isActionable: true };
   }
   onSubmit = createPayload => {
-    return new Promise(
-      function(resolve, reject) {
-        // do a thing, possibly async, then…
-        this.props.createShipmentAccessorial(createShipmentAccessorialLabel, this.props.shipmentId, createPayload);
-        setTimeout(function() {
-          resolve('success');
-        }, 50);
-      }.bind(this),
-    );
+    return this.props.createShipmentAccessorial(createShipmentAccessorialLabel, this.props.shipmentId, createPayload);
   };
   onEdit = () => {
     console.log('onEdit hit');
   };
   onDelete = shipmentAccessorialId => {
     if (window.confirm('Are you sure you want to delete this pre approval request?')) {
-      return new Promise(
-        function(resolve, reject) {
-          //  console.log(shipmentAccessorialId);
-          this.props.deleteShipmentAccessorial(deleteShipmentAccessorialLabel, shipmentAccessorialId);
-          setTimeout(function() {
-            resolve('success');
-          }, 50);
-        }.bind(this),
-      );
+      this.props.deleteShipmentAccessorial(deleteShipmentAccessorialLabel, shipmentAccessorialId);
     }
   };
   onApproval = () => {

--- a/src/shared/PreApprovalRequest/PreApprovalPanel.jsx
+++ b/src/shared/PreApprovalRequest/PreApprovalPanel.jsx
@@ -34,7 +34,7 @@ export class PreApprovalPanel extends Component {
     );
   };
   onEdit = () => {
-    console.log('onEdit hit', this.props);
+    console.log('onEdit hit');
   };
   onDelete = () => {
     console.log('onDelete hit');

--- a/src/shared/PreApprovalRequest/PreApprovalPanel.test.js
+++ b/src/shared/PreApprovalRequest/PreApprovalPanel.test.js
@@ -58,7 +58,7 @@ describe('PreApprovalPanel tests', () => {
     it('renders without crashing', () => {
       const icons = wrapper.find('.icon');
       expect(wrapper.find('.accessorial-panel').length).toEqual(1);
-      expect(icons.length).toBe(6);
+      expect(icons.length).toBe(2);
     });
   });
 });

--- a/src/shared/PreApprovalRequest/PreApprovalPanel.test.js
+++ b/src/shared/PreApprovalRequest/PreApprovalPanel.test.js
@@ -58,7 +58,7 @@ describe('PreApprovalPanel tests', () => {
     it('renders without crashing', () => {
       const icons = wrapper.find('.icon');
       expect(wrapper.find('.accessorial-panel').length).toEqual(1);
-      expect(icons.length).toBe(8);
+      expect(icons.length).toBe(6);
     });
   });
 });

--- a/src/shared/PreApprovalRequest/PreApprovalPanel.test.js
+++ b/src/shared/PreApprovalRequest/PreApprovalPanel.test.js
@@ -10,7 +10,7 @@ import { PreApprovalPanel } from './PreApprovalPanel';
 describe('PreApprovalPanel tests', () => {
   let wrapper, icons;
   const onEdit = jest.fn();
-  const shipment_accessorials = [
+  const shipmentAccessorials = [
     {
       id: 'sldkjf',
       accessorial: { code: '105D', item: 'Reg Shipping' },
@@ -49,7 +49,7 @@ describe('PreApprovalPanel tests', () => {
     //mount appears to be necessary to get inner components to load (i.e. tests fail with shallow)
     wrapper = mount(
       <Provider store={store}>
-        <PreApprovalPanel shipment_accessorials={shipment_accessorials} accessorials={accessorials} />
+        <PreApprovalPanel shipmentAccessorials={shipmentAccessorials} accessorials={accessorials} />
       </Provider>,
     );
   });

--- a/src/shared/PreApprovalRequest/PreApprovalRequest.css
+++ b/src/shared/PreApprovalRequest/PreApprovalRequest.css
@@ -13,10 +13,13 @@
 }
 
 /* Custom widths for columns in the preapproval request table */
-/*Code, Loc. */
-.accessorial-panel table > tbody > tr > th:nth-child(1),
-.accessorial-panel table > tbody > tr > th:nth-child(3) {
+/*Code */
+.accessorial-panel table > tbody > tr > th:nth-child(1) {
   width: 5%;
+}
+/* Loc. */
+.accessorial-panel table > tbody > tr > th:nth-child(3) {
+  width: 9%;
 }
 /*Base Quantity*/
 .accessorial-panel table > tbody > tr > th:nth-child(4) {

--- a/src/shared/PreApprovalRequest/PreApprovalRequest.css
+++ b/src/shared/PreApprovalRequest/PreApprovalRequest.css
@@ -23,7 +23,7 @@
 }
 /*Base Quantity*/
 .accessorial-panel table > tbody > tr > th:nth-child(4) {
-  width: 7%;
+  width: 10%;
 }
 /*Item*/
 .accessorial-panel table > tbody > tr > th:nth-child(2) {
@@ -118,6 +118,20 @@
   vertical-align: top;
 }
 
+.bq-explanation {
+  font-size: .8em;
+  padding: 0rem 0rem 3rem 0rem;
+}
+
+.bq-explanation p {
+  line-height: 1rem;
+  padding: 0rem 0rem 0rem 0rem;
+}
+
+.bq-explanation li {
+  line-height: 1.5em;
+  margin: 0rem 0rem 0rem 0rem;
+}
 
 
 

--- a/src/shared/PreApprovalRequest/PreApprovalTable.jsx
+++ b/src/shared/PreApprovalRequest/PreApprovalTable.jsx
@@ -28,9 +28,11 @@ export function renderActionIcons(status, onEdit, onApproval, onDelete, shipment
           <FontAwesomeIcon className="icon actionable" icon={faPencil} />
         </span>
       )}
-      <span onClick={() => onDelete(shipmentAccessorialId)}>
-        <FontAwesomeIcon className="icon actionable" icon={faTimes} />
-      </span>
+      {false && (
+        <span onClick={() => onDelete(shipmentAccessorialId)}>
+          <FontAwesomeIcon className="icon actionable" icon={faTimes} />
+        </span>
+      )}
     </Fragment>
   );
 }

--- a/src/shared/PreApprovalRequest/PreApprovalTable.jsx
+++ b/src/shared/PreApprovalRequest/PreApprovalTable.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { renderStatusIcon } from 'shared/utils';
 import { isOfficeSite } from 'shared/constants.js';
@@ -14,46 +14,25 @@ import './PreApprovalRequest.css';
 export function renderActionIcons(status, onEdit, onApproval, onDelete, shipmentAccessorialId) {
   // Only office users can approve requests.
   // If the request is approved/invoiced, they cannot be edited, only deleted.
-  if (status === 'APPROVED' || status === 'INVOICED') {
-    return (
-      <span>
-        <span onClick={onDelete}>
-          <FontAwesomeIcon className="icon actionable" icon={faTimes} />
-        </span>
-      </span>
-    );
-  } else if (onApproval) {
-    if (status === 'SUBMITTED') {
-      return (
-        <span>
+  //TODO: hiding edit action until we have implementation
+  return (
+    <Fragment>
+      {onApproval &&
+        status === 'SUBMITTED' && (
           <span onClick={onApproval}>
             <FontAwesomeIcon className="icon actionable" icon={faCheck} />
           </span>
-          <span onClick={onEdit}>
-            <FontAwesomeIcon className="icon actionable" icon={faPencil} />
-          </span>
-          <span
-            onClick={() => {
-              onDelete(shipmentAccessorialId);
-            }}
-          >
-            <FontAwesomeIcon className="icon actionable" icon={faTimes} />
-          </span>
-        </span>
-      );
-    }
-  } else {
-    return (
-      <span>
+        )}
+      {false && (
         <span onClick={onEdit}>
           <FontAwesomeIcon className="icon actionable" icon={faPencil} />
         </span>
-        <span onClick={onDelete}>
-          <FontAwesomeIcon className="icon actionable" icon={faTimes} />
-        </span>
+      )}
+      <span onClick={() => onDelete(shipmentAccessorialId)}>
+        <FontAwesomeIcon className="icon actionable" icon={faTimes} />
       </span>
-    );
-  }
+    </Fragment>
+  );
 }
 
 const PreApprovalTable = ({ shipment_accessorials, isActionable, onEdit, onApproval, onDelete }) => (

--- a/src/shared/PreApprovalRequest/PreApprovalTable.jsx
+++ b/src/shared/PreApprovalRequest/PreApprovalTable.jsx
@@ -37,7 +37,7 @@ export function renderActionIcons(status, onEdit, onApproval, onDelete, shipment
   );
 }
 
-const PreApprovalTable = ({ shipment_accessorials, isActionable, onEdit, onApproval, onDelete }) => (
+const PreApprovalTable = ({ shipmentAccessorials, isActionable, onEdit, onApproval, onDelete }) => (
   <div className="accessorial-panel">
     <table cellSpacing={0}>
       <tbody>
@@ -51,7 +51,7 @@ const PreApprovalTable = ({ shipment_accessorials, isActionable, onEdit, onAppro
           <th>Status</th>
           <th>&nbsp;</th>
         </tr>
-        {shipment_accessorials.map(row => {
+        {shipmentAccessorials.map(row => {
           let status = '';
           if (isOfficeSite) {
             status = renderStatusIcon(row.status);
@@ -78,7 +78,7 @@ const PreApprovalTable = ({ shipment_accessorials, isActionable, onEdit, onAppro
 );
 
 PreApprovalTable.propTypes = {
-  shipment_accessorials: PropTypes.array,
+  shipmentAccessorials: PropTypes.array,
   isActionable: PropTypes.bool,
   onEdit: PropTypes.func,
   onDelete: PropTypes.func,

--- a/src/shared/PreApprovalRequest/PreApprovalTable.jsx
+++ b/src/shared/PreApprovalRequest/PreApprovalTable.jsx
@@ -11,7 +11,7 @@ import faTimes from '@fortawesome/fontawesome-free-solid/faTimes';
 
 import './PreApprovalRequest.css';
 
-export function renderActionIcons(status, onEdit, onApproval, onDelete) {
+export function renderActionIcons(status, onEdit, onApproval, onDelete, shipmentAccessorialId) {
   // Only office users can approve requests.
   // If the request is approved/invoiced, they cannot be edited, only deleted.
   if (status === 'APPROVED' || status === 'INVOICED') {
@@ -32,7 +32,11 @@ export function renderActionIcons(status, onEdit, onApproval, onDelete) {
           <span onClick={onEdit}>
             <FontAwesomeIcon className="icon actionable" icon={faPencil} />
           </span>
-          <span onClick={onDelete}>
+          <span
+            onClick={() => {
+              onDelete(shipmentAccessorialId);
+            }}
+          >
             <FontAwesomeIcon className="icon actionable" icon={faTimes} />
           </span>
         </span>
@@ -83,7 +87,7 @@ const PreApprovalTable = ({ shipment_accessorials, isActionable, onEdit, onAppro
                 <span className="status">{status}</span>
                 {row.status[0].toUpperCase() + row.status.substring(1).toLowerCase()}
               </td>
-              <td>{isActionable && renderActionIcons(row.status, onEdit, onApproval, onDelete)}</td>
+              <td>{isActionable && renderActionIcons(row.status, onEdit, onApproval, onDelete, row.id)}</td>
             </tr>
           );
         })}

--- a/src/shared/PreApprovalRequest/PreApprovalTable.test.js
+++ b/src/shared/PreApprovalRequest/PreApprovalTable.test.js
@@ -38,7 +38,7 @@ describe('PreApprovalTable tests', () => {
       );
       const icons = wrapper.find('.icon');
       expect(wrapper.find('.accessorial-panel').length).toEqual(1);
-      expect(icons.length).toBe(6);
+      expect(icons.length).toBe(4);
     });
   });
   describe('When on approval is NOT passed in and status is SUBMITTED', () => {
@@ -54,7 +54,7 @@ describe('PreApprovalTable tests', () => {
     });
     it('it shows the appropriate number of icons.', () => {
       const icons = wrapper.find('.icon');
-      expect(icons.length).toBe(4);
+      expect(icons.length).toBe(2);
     });
   });
   describe('When on approval is passed in and status is APPROVED', () => {

--- a/src/shared/PreApprovalRequest/PreApprovalTable.test.js
+++ b/src/shared/PreApprovalRequest/PreApprovalTable.test.js
@@ -5,7 +5,7 @@ import PreApprovalTable from './PreApprovalTable';
 describe('PreApprovalTable tests', () => {
   let wrapper, icons;
   const onEdit = jest.fn();
-  const shipment_accessorials = [
+  const shipmentAccessorials = [
     {
       id: 'sldkjf',
       accessorial: { code: '105D', item: 'Reg Shipping' },
@@ -29,7 +29,7 @@ describe('PreApprovalTable tests', () => {
     it('renders without crashing', () => {
       wrapper = shallow(
         <PreApprovalTable
-          shipment_accessorials={shipment_accessorials}
+          shipmentAccessorials={shipmentAccessorials}
           isActionable={true}
           onEdit={onEdit}
           onDelete={onEdit}
@@ -45,7 +45,7 @@ describe('PreApprovalTable tests', () => {
     beforeEach(() => {
       wrapper = shallow(
         <PreApprovalTable
-          shipment_accessorials={shipment_accessorials}
+          shipmentAccessorials={shipmentAccessorials}
           isActionable={true}
           onEdit={onEdit}
           onDelete={onEdit}
@@ -59,11 +59,11 @@ describe('PreApprovalTable tests', () => {
   });
   describe('When on approval is passed in and status is APPROVED', () => {
     beforeEach(() => {
-      shipment_accessorials[0].status = 'APPROVED';
-      shipment_accessorials[1].status = 'APPROVED';
+      shipmentAccessorials[0].status = 'APPROVED';
+      shipmentAccessorials[1].status = 'APPROVED';
       wrapper = shallow(
         <PreApprovalTable
-          shipment_accessorials={shipment_accessorials}
+          shipmentAccessorials={shipmentAccessorials}
           isActionable={true}
           onEdit={onEdit}
           onDelete={onEdit}
@@ -78,11 +78,11 @@ describe('PreApprovalTable tests', () => {
   });
   describe('When on approval is NOT passed in and status is APPROVED', () => {
     beforeEach(() => {
-      shipment_accessorials[0].status = 'APPROVED';
-      shipment_accessorials[1].status = 'APPROVED';
+      shipmentAccessorials[0].status = 'APPROVED';
+      shipmentAccessorials[1].status = 'APPROVED';
       wrapper = shallow(
         <PreApprovalTable
-          shipment_accessorials={shipment_accessorials}
+          shipmentAccessorials={shipmentAccessorials}
           isActionable={true}
           onEdit={onEdit}
           onDelete={onEdit}

--- a/src/shared/PreApprovalRequest/PreApprovalTable.test.js
+++ b/src/shared/PreApprovalRequest/PreApprovalTable.test.js
@@ -38,7 +38,7 @@ describe('PreApprovalTable tests', () => {
       );
       const icons = wrapper.find('.icon');
       expect(wrapper.find('.accessorial-panel').length).toEqual(1);
-      expect(icons.length).toBe(4);
+      expect(icons.length).toBe(2);
     });
   });
   describe('When on approval is NOT passed in and status is SUBMITTED', () => {
@@ -54,7 +54,7 @@ describe('PreApprovalTable tests', () => {
     });
     it('it shows the appropriate number of icons.', () => {
       const icons = wrapper.find('.icon');
-      expect(icons.length).toBe(2);
+      expect(icons.length).toBe(0);
     });
   });
   describe('When on approval is passed in and status is APPROVED', () => {
@@ -73,7 +73,7 @@ describe('PreApprovalTable tests', () => {
     });
     it('it shows the appropriate number of icons.', () => {
       const icons = wrapper.find('.icon');
-      expect(icons.length).toBe(2);
+      expect(icons.length).toBe(0);
     });
   });
   describe('When on approval is NOT passed in and status is APPROVED', () => {
@@ -91,7 +91,7 @@ describe('PreApprovalTable tests', () => {
     });
     it('it shows the appropriate number of icons.', () => {
       const icons = wrapper.find('.icon');
-      expect(icons.length).toBe(2);
+      expect(icons.length).toBe(0);
     });
   });
 });

--- a/swagger/api.yaml
+++ b/swagger/api.yaml
@@ -145,12 +145,10 @@ definitions:
       - ORIGIN
       - DESTINATION
       - NEITHER
-      - EITHER
     x-display-value:
       ORIGIN: Origin
       DESTINATION: Destination
       NEITHER: Neither
-      EITHER: Either
   AccessorialStatus:
     type: string
     title: Status

--- a/swagger/api.yaml
+++ b/swagger/api.yaml
@@ -264,8 +264,6 @@ definitions:
         type: string
         format: date-time
     required:
-      - id
-      - shipment_id
       - accessorial_id
       - quantity_1
       - location

--- a/swagger/api.yaml
+++ b/swagger/api.yaml
@@ -145,6 +145,19 @@ definitions:
       - ORIGIN
       - DESTINATION
       - NEITHER
+      - EITHER
+    x-display-value:
+      ORIGIN: Origin
+      DESTINATION: Destination
+      NEITHER: Neither
+      EITHER: Either
+  ShipmentAccessorialLocation:
+    type: string
+    title: Location
+    enum:
+      - ORIGIN
+      - DESTINATION
+      - NEITHER
     x-display-value:
       ORIGIN: Origin
       DESTINATION: Destination
@@ -239,7 +252,7 @@ definitions:
         minimum: 0
         example: 10000
       location:
-        $ref: '#/definitions/AccessorialLocation'
+        $ref: '#/definitions/ShipmentAccessorialLocation'
       notes:
         type: string
         format: textarea


### PR DESCRIPTION
## Description

Hooks up the pre approval form to the create shipment accessorial endpoint. It also removes "EITHER" as a location option in the PreApprovalForm, and adds base quantity explanation text to the form.

## Setup

Go to a shipment info page in the TSP app - verify you're able to create a new pre approval request and it displays in the table.

## Code Review Verification Steps

* [ ] End to end tests pass (`make e2e_test`).
* [ ] Code follows the guidelines for [Logging](./docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](./docs/backend.md#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](./docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
* [ ] There are no aXe warnings for UI.
* [ ] This works in IE.
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @willowbl00
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/161064056) for this change

## Screenshots
![oct-17-2018 11-45-53](https://user-images.githubusercontent.com/8170735/47109115-48ec1880-d202-11e8-8d02-9fcf99b612e7.gif)
