### PR TITLE
Fixing duty stations whose addresses had leading zeros truncated

### DIFF
--- a/migrations/20181017002454_add-leading-zeros-to-addresses.up.sql
+++ b/migrations/20181017002454_add-leading-zeros-to-addresses.up.sql
@@ -1,0 +1,11 @@
+-- There were a few duty stations whose addresses were invalid. They had leading zeros truncated.
+-- Given that the address values were generated randomly, we can't update by address ID. This
+-- query only will change postal_codes that are both: less that 5 characters long, and are in the
+-- same city as the affected duty stations.
+
+UPDATE addresses
+SET postal_code = concat('0', postal_code)
+WHERE
+	char_length(postal_code) < 5
+	AND
+	city IN ('Buzzards Bay', 'Groton', 'Kittery', 'Naval Station Newport', 'Hanscom AFB');


### PR DESCRIPTION
## Description

It looks like when we imported duty stations, we truncated some leading zeros:

```
dev_db=# select d.name,a.street_address_1,a.city,a.state,a.postal_code FROM addresses AS a LEFT JOIN duty_stations AS d ON d.address_id = a.id WHERE char_length(a.postal_code) < 5;
              name              | street_address_1 |         city          | state | postal_code 
--------------------------------+------------------+-----------------------+-------+-------------
 US Coast Guard Buzzards Bay    |                  | Buzzards Bay          | MA    | 2542
 Navy Submarine Base New London |                  | Groton                | CT    | 6349
 Portsmouth Navy Shipyard       |                  | Kittery               | ME    | 3904
 Naval Station Newport          |                  | Naval Station Newport | RI    | 2841
 Hanscom AFB                    |                  | Hanscom AFB           | MA    | 1731
```

This PR fixes that.

Note: since we randomly generate UUIDs for addresses, I had to selectively query for addresses that were likely to be the affected ones. Since we're only doing CONUS moves, it's unlikely that we have postal codes that aren't 5 digits anyway, but I added the city to the query just to be safe.

After the migration, there should be no ZIPs shorter than 5 characters:

```
dev_db=# select id,street_address_1,city,state,postal_code from addresses where char_length(postal_code) < 5;
 id | street_address_1 | city | state | postal_code 
----+------------------+------+-------+-------------
(0 rows)
```

## Code Review Verification Steps

* Any new migrations/schema changes:
  * [x] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](./docs/database.md#zero-downtime-migrations))
  * [x] Have been communicated to #dp3-engineering

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/161271918) for this change
