### PR TITLE
Health Checker

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,66 +44,39 @@ commands:
       - announce_failure
   deploy_app_steps:
     parameters:
-      health_check_url:
+      health_check_hosts:
         type: string
     steps:
       - checkout
+      - restore_cache:
+          keys:
+            - mymove-vendor-{{ checksum "Gopkg.lock" }}
       - setup_remote_docker
       - deploy:
           name: Deploy app service
           command: bin/do-exclusively --job-name ${CIRCLE_JOB} bin/ecs-deploy-service-container app config/app.container-definition.json ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/app:git-${CIRCLE_SHA1} $APP_ENVIRONMENT FARGATE
-      - health_check:
-          url: << parameters.health_check_url >>
+      - run:
+          name: Health Check
+          command: go run cmd/health_checker/main.go --schemes http,https --hosts << parameters.health_check_hosts >> --tries 10 --backoff 3 --log-level info
       - announce_failure
   deploy_app_client_tls_steps:
     parameters:
-      health_check_url:
+      health_check_hosts:
         type: string
     steps:
       - checkout
+      - restore_cache:
+          keys:
+            - mymove-vendor-{{ checksum "Gopkg.lock" }}
       - setup_remote_docker
       - deploy:
           name: Deploy app-client-tls service
           command: bin/do-exclusively --job-name ${CIRCLE_JOB} bin/ecs-deploy-service-container app-client-tls config/app-client-tls.container-definition.json ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/app:git-${CIRCLE_SHA1} $APP_ENVIRONMENT FARGATE
-      - health_check_tls:
-          url: << parameters.health_check_url >>
+      - run:
+          name: Health Check
+          command: |
+            go run cmd/health_checker/main.go --schemes https --hosts << parameters.health_check_hosts >> --key ${EXPERIMENTAL_MOVE_MIL_DOD_TLS_KEY} --cert ${EXPERIMENTAL_MOVE_MIL_DOD_TLS_CERT} --ca ${EXPERIMENTAL_MOVE_MIL_DOD_TLS_CA} --tries 10 --backoff 3 --log-level info
       - announce_failure
-  health_check:
-    parameters:
-      url:
-        type: string
-    steps:
-      - run:
-          name: Health check app site
-          command: |
-            for retry in `seq 1 10`; do
-              if curl -f -sS -o /dev/null << parameters.url >>; then
-                echo Passed.;
-                exit 0;
-              else
-                sleep $(($retry*3));
-              fi;
-            done;
-            exit 1
-  health_check_tls:
-    parameters:
-      url:
-        type: string
-    steps:
-      - run:
-          name: Health check app site
-          command: |
-            for retry in `seq 1 10`; do
-              httpResponse=$(curl << parameters.url >> --key <(echo "$EXPERIMENTAL_MOVE_MIL_DOD_TLS_KEY" | base64 --decode) --cert <(echo "$EXPERIMENTAL_MOVE_MIL_DOD_TLS_CERT" | base64 --decode) --cacert <(echo "$EXPERIMENTAL_MOVE_MIL_DOD_TLS_CA" | base64 --decode) -I)
-              statusCode=$(echo "$httpResponse" | grep HTTP/2 | awk {'print $2'})
-              if [[ "$statusCode" == "200" ]]; then
-                echo Passed.;
-                exit 0;
-              else
-                sleep $(($retry*3));
-              fi;
-            done;
-            exit 1
   build_tag_push:
     parameters:
       dockerfile:
@@ -430,7 +403,7 @@ jobs:
       - APP_ENVIRONMENT: "experimental"
     steps:
       - deploy_app_steps:
-          health_check_url: "https://my.experimental.move.mil/health"
+          health_check_hosts: my.experimental.move.mil,office.experimental.move.mil,tsp.experimental.move.mil
 
   # `deploy_experimental_app_client_tls` updates the mutual-TLS service in the experimental environment
   deploy_experimental_app_client_tls:
@@ -439,7 +412,7 @@ jobs:
       - APP_ENVIRONMENT: "experimental"
     steps:
       - deploy_app_client_tls_steps:
-          health_check_url: "https://office.experimental.move.mil/health"
+          health_check_hosts: gex.experimental.move.mil,dps.experimental.move.mil,orders.experimental.move.mil
 
   # `deploy_staging_migrations` deploys migrations to the staging environment
   deploy_staging_migrations:
@@ -456,7 +429,7 @@ jobs:
       - APP_ENVIRONMENT: "staging"
     steps:
       - deploy_app_steps:
-          health_check_url: "https://my.staging.move.mil/health"
+          health_check_hosts: my.staging.move.mil,office.staging.move.mil,tsp.staging.move.mil
 
   # `deploy_staging_app_client_tls` updates the mutual-TLS service in the staging environment
   deploy_staging_app_client_tls:
@@ -465,7 +438,7 @@ jobs:
       - APP_ENVIRONMENT: "staging"
     steps:
       - deploy_app_client_tls_steps:
-          health_check_url: "https://office.staging.move.mil/health"
+          health_check_hosts: gex.staging.move.mil,dps.staging.move.mil,orders.staging.move.mil
 
   # `deploy_prod_migrations` deploys migrations to the staging environment
   deploy_prod_migrations:
@@ -482,7 +455,7 @@ jobs:
       - APP_ENVIRONMENT: "prod"
     steps:
       - deploy_app_steps:
-          health_check_url: "https://my.move.mil/health"
+          health_check_hosts: my.move.mil,office.move.mil,tsp.move.mil
 
   # `deploy_prod_app_client_tls` updates the mutual-TLS service in the prod environment
   deploy_prod_app_client_tls:
@@ -491,7 +464,7 @@ jobs:
       - APP_ENVIRONMENT: "prod"
     steps:
       - deploy_app_client_tls_steps:
-          health_check_url: "https://office.move.mil/health"
+          health_check_hosts: gex.move.mil,dps.move.mil,orders.move.mil
 
   # `update_dependencies` periodically updates pre-commit, yarn, and Go dependencies.
   # The changes are submitted as a pull request for review.
@@ -570,21 +543,21 @@ workflows:
             - build_migrations
           filters:
             branches:
-              only: mk-serial-deploys
+              only: healthchecker
 
       - deploy_experimental_app:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: mk-serial-deploys
+              only: healthchecker
 
       - deploy_experimental_app_client_tls:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: mk-serial-deploys
+              only: healthchecker
 
       - deploy_staging_migrations:
           requires:

--- a/Makefile
+++ b/Makefile
@@ -119,6 +119,7 @@ build_tools: server_deps server_generate
 	go build -i -o bin/load-user-gen ./cmd/load_user_gen
 	go build -i -o bin/paperwork ./cmd/paperwork
 	go build -i -o bin/iws ./cmd/demo/iws.go
+	go build -i -o bin/health_checker ./cmd/health_checker
 
 tsp_run: build_tools db_dev_run
 	./bin/tsp-award-queue

--- a/cmd/health_checker/main.go
+++ b/cmd/health_checker/main.go
@@ -1,0 +1,385 @@
+package main
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/base64"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+import (
+	"github.com/pkg/errors"
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+type stringSlice []string
+
+func (s stringSlice) Contains(value string) bool {
+	for _, x := range s {
+		if value == x {
+			return true
+		}
+	}
+	return false
+}
+
+type intSlice []int
+
+func (s intSlice) Contains(value int) bool {
+	for _, x := range s {
+		if value == x {
+			return true
+		}
+	}
+	return false
+}
+
+func stringSliceToIntSlice(strs []string) (intSlice, error) {
+	ints := intSlice(make([]int, 0, len(strs)))
+	for _, s := range strs {
+		i, err := strconv.Atoi(s)
+		if err != nil {
+			return ints, err
+		}
+		ints = append(ints, i)
+	}
+	return ints, nil
+}
+
+type errInvalidScheme struct {
+	Scheme string
+}
+
+func (e *errInvalidScheme) Error() string {
+	return "invalid scheme " + e.Scheme + ", only http and https are supported"
+}
+
+type errInvalidPath struct {
+	Path string
+}
+
+func (e *errInvalidPath) Error() string {
+	return "invalid path " + e.Path
+}
+
+type errInvalidStatusCode struct {
+	Code int
+}
+
+func (e *errInvalidStatusCode) Error() string {
+	return "invalid status code " + strconv.Itoa(e.Code)
+}
+
+func checkConfig(v *viper.Viper) error {
+	schemesString := strings.TrimSpace(v.GetString("schemes"))
+
+	if len(schemesString) == 0 {
+		return errors.New("missing schemes")
+	}
+
+	schemes := stringSlice(strings.Split(schemesString, ","))
+
+	for _, scheme := range schemes {
+		if scheme != "http" && scheme != "https" {
+			return &errInvalidScheme{Scheme: scheme}
+		}
+	}
+
+	hosts := v.GetString("hosts")
+
+	if len(hosts) == 0 {
+		return errors.New("missing hosts")
+	}
+
+	pathsString := v.GetString("paths")
+
+	if len(pathsString) == 0 {
+		return errors.New("missing paths")
+	}
+
+	paths := stringSlice(strings.Split(pathsString, ","))
+
+	for _, path := range paths {
+		if !strings.HasPrefix(path, "/") {
+			return &errInvalidPath{Path: path}
+		}
+	}
+
+	statusCodesString := strings.TrimSpace(v.GetString("status-codes"))
+	if len(statusCodesString) == 0 {
+		return errors.New("missing status codes")
+	}
+
+	statusCodes, err := stringSliceToIntSlice(strings.Split(statusCodesString, ","))
+	if err != nil {
+		return errors.Wrap(err, "invalid status codes")
+	}
+
+	for _, statusCode := range statusCodes {
+		if len(http.StatusText(statusCode)) == 0 {
+			return &errInvalidStatusCode{Code: statusCode}
+		}
+	}
+
+	clientKeyEncoded := v.GetString("key")
+	clientCertEncoded := v.GetString("cert")
+	clientKeyFile := v.GetString("key-file")
+	clientCertFile := v.GetString("cert-file")
+
+	if len(clientKeyEncoded) > 0 || len(clientCertEncoded) > 0 || len(clientKeyFile) > 0 || len(clientCertFile) > 0 {
+		if schemes.Contains("http") {
+			return errors.New("cannot use scheme http with client certificate, can only use https")
+		}
+	}
+
+	tries := v.GetInt("tries")
+	if tries == 0 {
+		return errors.New("tries is 0, but must be greater than zero")
+	}
+
+	if tries > 1 {
+		backoff := v.GetInt("backoff")
+		if backoff == 0 {
+			return errors.New("backoff is 0, but must be greater than zero")
+		}
+	}
+
+	return nil
+}
+
+func createTLSConfig(clientKey []byte, clientCert []byte, ca []byte, insecureSkipVerify bool) (*tls.Config, error) {
+
+	keyPair, err := tls.X509KeyPair(clientCert, clientKey)
+	if err != nil {
+		return nil, err
+	}
+
+	// #nosec b/c gosec triggers on InsecureSkipVerify
+	tlsConfig := &tls.Config{
+		Certificates:       []tls.Certificate{keyPair},
+		InsecureSkipVerify: insecureSkipVerify,
+	}
+
+	if len(ca) > 0 {
+		rootCAs := x509.NewCertPool()
+		rootCAs.AppendCertsFromPEM(ca)
+		tlsConfig.RootCAs = rootCAs
+	}
+
+	return tlsConfig, nil
+}
+
+func createHTTPClient(v *viper.Viper, log *zap.Logger) (*http.Client, error) {
+
+	verbose := v.GetBool("verbose")
+
+	clientKeyEncoded := v.GetString("key")
+	clientCertEncoded := v.GetString("cert")
+	skipVerify := v.GetBool("skip-verify")
+
+	if verbose {
+		if skipVerify {
+			log.Info("Skipping client-side certificate validation")
+		}
+	}
+
+	tlsConfig := &tls.Config{}
+
+	if len(clientKeyEncoded) > 0 && len(clientCertEncoded) > 0 {
+
+		clientKey, err := base64.StdEncoding.DecodeString(clientKeyEncoded)
+		if err != nil {
+			return nil, errors.Wrap(err, "error decoding client key")
+		}
+
+		clientCert, err := base64.StdEncoding.DecodeString(clientCertEncoded)
+		if err != nil {
+			return nil, errors.Wrap(err, "error decoding client cert")
+		}
+
+		caBytes := make([]byte, 0)
+		if caEncoded := v.GetString("ca"); len(caEncoded) > 0 {
+			caString, err := base64.StdEncoding.DecodeString(caEncoded)
+			if err != nil {
+				return nil, errors.Wrap(err, "error decoding certificate authority")
+			}
+			caBytes = []byte(caString)
+		}
+
+		tlsConfig, err = createTLSConfig([]byte(clientKey), []byte(clientCert), caBytes, false)
+		if err != nil {
+			return nil, errors.Wrap(err, "error creating TLS config")
+		}
+
+	} else {
+
+		clientKeyFile := v.GetString("key-file")
+		clientCertFile := v.GetString("cert-file")
+
+		if len(clientKeyFile) > 0 && len(clientCertFile) > 0 {
+
+			clientKey, err := ioutil.ReadFile(clientKeyFile) // #nosec b/c we need to read a file from a user-defined path
+			if err != nil {
+				return nil, errors.Wrap(err, "error reading client key file at "+clientKeyFile)
+			}
+
+			clientCert, err := ioutil.ReadFile(clientCertFile) // #nosec b/c we need to read a file from a user-defined path
+			if err != nil {
+				return nil, errors.Wrap(err, "error reading client cert file at "+clientKeyFile)
+			}
+
+			caBytes := make([]byte, 0)
+			if caFile := v.GetString("ca-file"); len(caFile) > 0 {
+				content, err := ioutil.ReadFile(caFile) // #nosec b/c we need to read a file from a user-defined path
+				if err != nil {
+					return nil, errors.Wrap(err, "error reading ca file at "+caFile)
+				}
+				caBytes = content
+			}
+
+			tlsConfig, err = createTLSConfig(clientKey, clientCert, caBytes, false)
+			if err != nil {
+				return nil, errors.Wrap(err, "error creating TLS config")
+			}
+		}
+	}
+
+	httpTransport := &http.Transport{TLSClientConfig: tlsConfig}
+	httpClient := &http.Client{Transport: httpTransport}
+	return httpClient, nil
+
+}
+
+func checkURL(httpClient *http.Client, url string, validStatusCodes intSlice, maxTries int, backoff int, log *zap.Logger) error {
+	for tries := 0; tries < maxTries; tries++ {
+		resp, err := httpClient.Get(url)
+		if err != nil {
+			return errors.Wrap(err, "error calling GET on url "+url)
+		}
+		log.Info(
+			"HTTP GET request completed",
+			zap.Int("try", tries),
+			zap.String("url", url),
+			zap.Int("code", resp.StatusCode))
+		if validStatusCodes.Contains(resp.StatusCode) {
+			break
+		} else {
+			if tries < maxTries-1 {
+				sleepPeriod := time.Duration((tries+1)*backoff) * time.Second
+				log.Info("sleeping", zap.Duration("period", sleepPeriod))
+				time.Sleep(sleepPeriod)
+				continue
+			}
+			log.Fatal(
+				"request returned invalid status code on last try",
+				zap.String("url", url),
+				zap.Int("maxTries", maxTries),
+				zap.Int("code", resp.StatusCode))
+		}
+	}
+	return nil
+}
+
+func createLogger(env string, level string) (*zap.Logger, error) {
+	loglevel := zapcore.Level(uint8(0))
+	err := (&loglevel).UnmarshalText([]byte(level))
+	if err != nil {
+		return nil, err
+	}
+	atomicLevel := zap.NewAtomicLevel()
+	atomicLevel.SetLevel(loglevel)
+	var loggerConfig zap.Config
+	if env == "production" || env == "prod" {
+		loggerConfig = zap.NewProductionConfig()
+	} else {
+		loggerConfig = zap.NewDevelopmentConfig()
+	}
+	loggerConfig.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
+	loggerConfig.Level = atomicLevel
+	return loggerConfig.Build()
+}
+
+func main() {
+
+	flag := pflag.CommandLine
+
+	flag.StringP("schemes", "s", "http,https", "slice of schemes to check")
+	flag.String("hosts", "", "comma-separated list of host names to check")
+	flag.StringP("paths", "p", "/health", "slice of paths to check on each host")
+	flag.String("key", "", "path to file of base64-encoded private key for client TLS")
+	flag.String("key-file", "", "path to file of base64-encoded private key for client TLS")
+	flag.String("cert", "", "base64-encoded public key for client TLS")
+	flag.String("cert-file", "", "path to file of base64-encoded public key for client TLS")
+	flag.String("ca", "", "base64-encoded certificate authority for mutual TLS")
+	flag.String("ca-file", "", "path to file of base64-encoded certificate authority for mutual TLS")
+	flag.String("status-codes", "200", "valid response status codes")
+	flag.Bool("skip-verify", false, "skip certifiate validation")
+	flag.Int("tries", 5, "number of tries")
+	flag.Int("backoff", 1, "backoff in seconds")
+	flag.String("log-env", "development", "logging config: development or production")
+	flag.String("log-level", "error", "log level: debug, info, warn, error, dpanic, panic, or fatal")
+
+	flag.Parse(os.Args[1:])
+
+	v := viper.New()
+	v.BindPFlags(flag)
+	v.SetEnvPrefix("HEALTHCHECKER")
+	v.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
+	v.AutomaticEnv()
+
+	log, err := createLogger(v.GetString("log-env"), v.GetString("log-level"))
+	if err != nil {
+		log.Fatal(err.Error())
+	}
+
+	err = checkConfig(v)
+	if err != nil {
+		switch e := err.(type) {
+		case *errInvalidPath:
+			log.Fatal(e.Error(), zap.String("path", e.Path))
+		case *errInvalidScheme:
+			log.Fatal(e.Error(), zap.String("scheme", e.Scheme))
+		case *errInvalidStatusCode:
+			log.Fatal(e.Error(), zap.Int("code", e.Code))
+		}
+		log.Fatal(err.Error())
+	}
+
+	verbose := v.GetBool("verbose")
+	schemes := strings.Split(strings.TrimSpace(v.GetString("schemes")), ",")
+	hosts := strings.Split(strings.TrimSpace(v.GetString("hosts")), ",")
+	paths := strings.Split(strings.TrimSpace(v.GetString("paths")), ",")
+	statusCodes, _ := stringSliceToIntSlice(strings.Split(strings.TrimSpace(v.GetString("status-codes")), ","))
+
+	httpClient, err := createHTTPClient(v, log)
+	if err != nil {
+		log.Fatal(errors.Wrap(err, "error creating http client").Error())
+	}
+
+	maxTries := v.GetInt("tries")
+	backoff := v.GetInt("backoff")
+
+	for _, scheme := range schemes {
+		for _, host := range hosts {
+			for _, path := range paths {
+				url := scheme + "://" + host + path
+				if verbose {
+					log.Info("checking url", zap.String("url", url))
+				}
+				err := checkURL(httpClient, url, statusCodes, maxTries, backoff, log)
+				if err != nil {
+					log.Fatal(err.Error())
+				}
+			}
+		}
+	}
+
+}


### PR DESCRIPTION
## Description

Adds `healthchecker` command for health checks. This replaces our bash scripts.  Can be run with `go run mymove/cmd/healthchecker/main.go ARGS`.  Usage below.

```
Usage of healthchecker:
      --backoff int           backoff in seconds (default 1)
      --ca string             base64-encoded certificate authority for mutual TLS
      --ca-file string        path to file of base64-encoded certificate authority for mutual TLS
      --cert string           base64-encoded public key for client TLS
      --cert-file string      path to file of base64-encoded public key for client TLS
      --exit-on-error         exit on first health check error
      --hosts string          comma-separated list of host names to check
      --key string            path to file of base64-encoded private key for client TLS
      --key-file string       path to file of base64-encoded private key for client TLS
      --log-env string        logging config: development or production (default "development")
      --log-level string      log level: debug, info, warn, error, dpanic, panic, or fatal (default "error")
  -p, --paths string          slice of paths to check on each host (default "/health")
  -s, --schemes string        slice of schemes to check (default "http,https")
      --skip-verify           skip certifiate validation
      --status-codes string   valid response status codes (default "200")
      --tries int             number of tries (default 5)
```

The healthchecker supports permuting over a list of schemes, hosts, and paths to enable simple integration with services support multiple domain names, e.g.,

```
--schemes http,https --hosts my.experimental.move.mil,office.experimental.move.mil,tsp.experimental.move.mil
```

The `healthchecker` also supports environment variables with the `HEALTHCHECKER_` prefix, e.g., 
```
HEALTHCHECKER_VERBOSE=1 HEALTHCHECKER_HOSTS=gex.move.mil,orders.move.mil,dps.move.mil HEALTHCHECKER_SCHEMES=https HEALTHCHECHKER_PATHS=/health go run main.go  --ca-file ~/experimental.ca --key-file ~/experimental.key --cert-file ~/experimental.crt  --backoff 2
```