### PR TITLE
Updated HHG weight estimate screen UI

### DIFF
--- a/cypress/integration/mymove/shipment.js
+++ b/cypress/integration/mymove/shipment.js
@@ -97,11 +97,21 @@ describe('completing the hhg flow', function() {
       expect(loc.pathname).to.match(/^\/moves\/[^/]+\/hhg-weight/);
     });
 
+    // Weight over entitlement
+    cy
+      .get('input[name="weight_estimate"]')
+      .clear()
+      .type('50000');
+
+    cy.contains('Entitlement exceeded');
+
     // Weight
     cy
       .get('input[name="weight_estimate"]')
       .clear()
       .type('3000');
+
+    cy.contains('Entitlement exceeded').should('not.exist');
 
     cy.nextPage();
 

--- a/src/scenes/Moves/Hhg/ShipmentWizard.css
+++ b/src/scenes/Moves/Hhg/ShipmentWizard.css
@@ -1,7 +1,33 @@
 .shipment-wizard .form-section {
-  margin-top: 7rem;
+  margin-top: 3rem;
 }
 
 .shipment-wizard h3.instruction-heading {
   font-size: 2rem;
+}
+
+.shipment-wizard .weight-info-box {
+  background-color: #eff5fc;
+  padding: 1.5rem;
+  border: 1px solid #d1d1d1;
+}
+
+.shipment-wizard .weight-estimate-hr {
+  color: #ccc;
+  background-color: #ccc;
+  height: 1px;
+  border: none;
+}
+
+.shipment-wizard .weight-estimate label {
+  font-weight: bold;
+}
+
+.shipment-wizard .weight-estimate input {
+  width: 80px;
+}
+
+.shipment-wizard .weight-estimate-help {
+  padding-top: 0.5rem;
+  color: gray;
 }

--- a/src/scenes/Moves/Hhg/WeightEstimate.jsx
+++ b/src/scenes/Moves/Hhg/WeightEstimate.jsx
@@ -9,7 +9,9 @@ import { setCurrentShipmentID, getCurrentShipment } from 'shared/UI/ducks';
 import { SwaggerField } from 'shared/JsonSchemaForm/JsonSchemaField';
 import { getLastError, getInternalSwaggerDefinition } from 'shared/Swagger/selectors';
 import Alert from 'shared/Alert';
+import LoadingPlaceholder from 'shared/LoadingPlaceholder';
 import { reduxifyWizardForm } from 'shared/WizardPage/Form';
+import { loadEntitlementsFromState } from 'shared/entitlements';
 
 import { createOrUpdateShipment, getShipment } from 'shared/Entities/modules/shipments';
 
@@ -22,6 +24,21 @@ const createOrUpdateRequestLabel = 'WeightForm.createOrUpdateShipment';
 const ShipmentFormWizardForm = reduxifyWizardForm(formName);
 
 export class WeightEstimate extends Component {
+  constructor(props) {
+    super(props);
+    this.state = { showInfo: false };
+  }
+
+  openInfo = e => {
+    e.preventDefault();
+    this.setState({ showInfo: true });
+  };
+
+  closeInfo = e => {
+    e.preventDefault();
+    this.setState({ showInfo: false });
+  };
+
   componentDidMount() {
     this.loadShipment();
   }
@@ -58,7 +75,8 @@ export class WeightEstimate extends Component {
   };
 
   render() {
-    const { pages, pageKey, error, initialValues } = this.props;
+    const { pages, pageKey, error, initialValues, entitlement } = this.props;
+    const weight_estimate = get(this.props, 'formValues.weight_estimate');
 
     // Shipment Wizard
     return (
@@ -86,10 +104,52 @@ export class WeightEstimate extends Component {
             <h3 className="form-title">Shipment 1 (HHG)</h3>
           </div>
           <div className="form-section">
-            <h3 className="instruction-heading">Enter the weight of your stuff here if you already know it</h3>
             <div className="usa-grid">
+              <h3 className="instruction-heading">Estimate Weight</h3>
               <div className="usa-width-one-whole">
-                <SwaggerField fieldName="weight_estimate" swagger={this.props.schema} required />
+                {entitlement ? (
+                  <div className="weight-info-box">
+                    <b>How much are you entitled to move?</b>
+                    <br />
+                    {entitlement.weight.toLocaleString()} lbs. + {entitlement.pro_gear.toLocaleString()} lbs. of
+                    pro-gear + {entitlement.pro_gear_spouse.toLocaleString()} lbs. of spouse's pro-gear.{' '}
+                    <a href="" onClick={this.openInfo}>
+                      What's this?
+                    </a>
+                  </div>
+                ) : (
+                  <LoadingPlaceholder />
+                )}
+                {this.state.showInfo && (
+                  <Alert type="info" heading="">
+                    Your entitlement represents the weight the military is willing to move for you. If you exceed this
+                    weight, you'll have to pay for the excess out of pocket. Pro-gear is any gear you need to perform
+                    your official duties at your next or later destination, such as reference materials, tools for a
+                    technician or mechanic or specialized clothing that's not a typical uniform (such as diving or
+                    astronaut suits.{' '}
+                    <a href="" onClick={this.closeInfo}>
+                      Close
+                    </a>
+                  </Alert>
+                )}
+                <p className="review-todo">TODO</p>
+                <hr className="weight-estimate-hr" />
+                <SwaggerField
+                  title="Your estimated weight (in pounds):"
+                  className="weight-estimate"
+                  fieldName="weight_estimate"
+                  swagger={this.props.schema}
+                  required
+                />
+                <div className="weight-estimate-help">
+                  If you already know the weight of your stuff, type it in the box.
+                </div>
+                {entitlement &&
+                  (weight_estimate && weight_estimate > entitlement.weight) && (
+                    <Alert type="warning" heading="Entitlement exceeded">
+                      You have exceeded your entitlement weight of {entitlement.weight.toLocaleString()} lbs.
+                    </Alert>
+                  )}
               </div>
             </div>
           </div>
@@ -116,6 +176,7 @@ function mapStateToProps(state) {
     currentShipment: shipment,
     initialValues: shipment,
     error: getLastError(state, getRequestLabel),
+    entitlement: loadEntitlementsFromState(state),
   };
   return props;
 }


### PR DESCRIPTION
## Description

This PR adjust the weight estimate screen UI to do the following:

- Text/style changes to match wireframes.
- Added entitlement block and info alert at top of page.
- Added warning if exceeding entitlement.

See wireframes in Pivotal story linked below.

## Reviewer Notes

This is phase 1 in updating the weight estimate screen UI.  There is a phase 2 (the "TODO" currently on the page) that is covered in another story.

## Setup

`make db_dev_migrate`
`make server_run`
`make client_run`
Create or generate a SM and go to the weight estimate page of the HHG shipment flow.

## Code Review Verification Steps

* [ ] End to end tests pass (`make e2e_test`).
* [ ] There are no aXe warnings for UI.
* [ ] This works in IE.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/160779834) for this change
* [Another pivotal story](https://www.pivotaltracker.com/story/show/160779968)for phase 2 UI updates that's still to come.

## Screenshots

![oct-17-2018 15-33-18](https://user-images.githubusercontent.com/4960757/47111683-29fd7e80-d222-11e8-898c-40ffada01f18.gif)
