### PR TITLE
els fix Authorization component and add tests

### DIFF
--- a/src/shared/User/Authorization.jsx
+++ b/src/shared/User/Authorization.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
+import { compose } from 'redux';
 // this is from https://hackernoon.com/role-based-authorization-in-react-c70bb7641db4
 // as of 3/8 we are not using this yet, but it seems like it would work once we have a need to include roles in user state
 const AuthorizationContainer = (WrappedComponent, allowedRoles) =>
@@ -16,7 +17,10 @@ const AuthorizationContainer = (WrappedComponent, allowedRoles) =>
     }
   };
 
-const Authorization = connect(state => ({
+const mapStateToProps = state => ({
   role: state.user.role,
-}))(AuthorizationContainer);
+});
+
+// see https://medium.com/practo-engineering/connected-higher-order-component-hoc-93ee63c91526
+const Authorization = compose(connect(mapStateToProps, null), AuthorizationContainer);
 export default Authorization;

--- a/src/shared/User/Authorization.test.js
+++ b/src/shared/User/Authorization.test.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { mount } from 'enzyme';
+import configureStore from 'redux-mock-store';
+
+import Authorization from './Authorization';
+
+const Groot = props => (
+  <div>
+    <span>I am groot</span>
+  </div>
+);
+describe('Authorization tests', () => {
+  describe('When the user is in the role', () => {
+    let mockStore = configureStore();
+    let initialState = {
+      user: {
+        role: 'fakeRole',
+      },
+    };
+    const RouteWithAuthorization = Authorization(Groot, ['fakeRole']);
+    it('the component is rendered', () => {
+      let store = mockStore(initialState);
+      let wrap = mount(<RouteWithAuthorization store={store} />);
+      expect(wrap.containsMatchingElement(<span>I am groot</span>)).toBeTruthy();
+    });
+  });
+  describe('When the user is not in the role', () => {
+    let mockStore = configureStore();
+    let initialState = {
+      user: {
+        role: 'somethingElse',
+      },
+    };
+    const RouteWithAuthorization = Authorization(Groot, ['fakeRole']);
+    it('an auth message is rendered', () => {
+      let store = mockStore(initialState);
+      let wrap = mount(<RouteWithAuthorization store={store} />);
+      expect(wrap.containsMatchingElement(<h1>You are not authorized to view this page</h1>)).toBeTruthy();
+    });
+  });
+});


### PR DESCRIPTION
## Description

I added a component a while back that would allow use to do role base authentication for routes. There is still some work that would need to be done to get the state in the shape needed, but @aileendds was trying to use it and discovered it wouldn't execute (see https://defensedigitalservice.slack.com/archives/G8P7UD05U/p1539726118000100). I did some noodling around and learned how to properly connect a HOC. This PR is the result.

## Setup

Right now there are just enzyme tests for this.