### PR TITLE
Set TAC and Dept. Indicator As Required On Orders Viewer

### DIFF
--- a/src/scenes/Office/OrdersViewerPanel.js
+++ b/src/scenes/Office/OrdersViewerPanel.js
@@ -99,10 +99,10 @@ const OrdersViewerEdit = props => {
             <Field name="new_duty_station" component={DutyStationSearchBox} props={{ title: 'New Duty Station' }} />
           </div>
           <SwaggerField fieldName="has_dependents" swagger={schema} title="Dependents authorized" />
-          <SwaggerField title="Dept. Indicator" fieldName="department_indicator" swagger={schema} />
+          <SwaggerField title="Dept. Indicator" fieldName="department_indicator" swagger={schema} required />
           <SwaggerField title="Orders Issuing Agency" fieldName="orders_issuing_agency" swagger={schema} />
           <SwaggerField title="Paragraph Number" fieldName="paragraph_number" swagger={schema} />
-          <SwaggerField title="TAC" fieldName="tac" swagger={schema} />
+          <SwaggerField title="TAC" fieldName="tac" swagger={schema} required />
           <SwaggerField title="SAC" fieldName="sac" swagger={schema} />
         </FormSection>
       </div>


### PR DESCRIPTION
## Description

This PR sets the TAC and Dept. Indicator fields as required on the orders viewer page. They are currently optional on the orders viewer but are required on the basics tab.

## Setup

In the Office app, open the orders viewer page for any move. Click edit to make sure that `TAC` and `Dept. Indicator` are not optional.

## Code Review Verification Steps

* [ ] There are no aXe warnings for UI.
* [ ] This works in IE.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/160598056) for this change

## Screenshots

![image](https://user-images.githubusercontent.com/1522549/47130112-f7b54680-d24c-11e8-82a3-18f63c3984cd.png)
