### PR TITLE
Redirect to queues if invalid shipment

### DIFF
--- a/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
+++ b/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
@@ -125,10 +125,17 @@ class ShipmentInfo extends Component {
   };
 
   componentDidMount() {
-    this.props.loadShipmentDependencies(this.props.match.params.shipmentId);
-    this.props.getAllShipmentDocuments(getShipmentDocumentsLabel, this.props.match.params.shipmentId);
-    this.props.getAllTariff400ngItems(getTariff400ngItemsLabel);
-    this.props.getAllShipmentAccessorials(getShipmentAccessorialsLabel, this.props.match.params.shipmentId);
+    this.props.loadShipmentDependencies(this.props.match.params.shipmentId).catch(err => {
+      this.props.history.replace('/');
+    });
+  }
+
+  componentDidUpdate(prevProps, prevState) {
+    if (!prevProps.shipment.id && this.props.shipment.id) {
+      this.props.getAllShipmentDocuments(getShipmentDocumentsLabel, this.props.shipment.id);
+      this.props.getAllTariff400ngItems(getTariff400ngItemsLabel);
+      this.props.getAllShipmentAccessorials(getShipmentAccessorialsLabel, this.props.shipment.id);
+    }
   }
 
   acceptShipment = () => {

--- a/src/scenes/TransportationServiceProvider/ducks.js
+++ b/src/scenes/TransportationServiceProvider/ducks.js
@@ -103,7 +103,8 @@ export function loadShipmentDependencies(shipmentId) {
       await Promise.all([dispatch(loadShipment(shipmentId)), dispatch(indexServiceAgents(shipmentId))]);
       return dispatch(actions.success());
     } catch (ex) {
-      return dispatch(actions.error(ex));
+      dispatch(actions.error(ex));
+      throw new Error(ex);
     }
   };
 }
@@ -138,6 +139,9 @@ const initialState = {
   serviceAgentIsUpdating: false,
   serviceAgentHasUpdatedSucces: false,
   serviceAgentHasUpdatedError: null,
+  shipment: {
+    address: {},
+  },
   loadTspDependenciesHasSuccess: false,
   loadTspDependenciesHasError: null,
   flashMessage: false,
@@ -169,7 +173,6 @@ export function tspReducer(state = initialState, action) {
         shipmentIsLoading: false,
         shipmentHasLoadSuccess: false,
         shipmentHasLoadError: null,
-        shipment: null,
         error: action.error.message,
       });
     case PATCH_SHIPMENT.start:

--- a/src/shared/Address/index.jsx
+++ b/src/shared/Address/index.jsx
@@ -28,6 +28,10 @@ export const AddressElementDisplay = ({ address, title }) => (
   </PanelField>
 );
 
+AddressElementDisplay.defaultProps = {
+  address: {},
+};
+
 AddressElementDisplay.propTypes = {
   address: PropTypes.shape({
     street_address_1: PropTypes.string,

--- a/src/shared/ReduxHelpers/index.js
+++ b/src/shared/ReduxHelpers/index.js
@@ -60,7 +60,10 @@ export function generateAsyncActionCreator(resourceName, asyncAction) {
       dispatch(actions.start());
       return asyncAction(...args)
         .then(item => dispatch(actions.success(item)))
-        .catch(error => dispatch(actions.error(error)));
+        .catch(error => {
+          dispatch(actions.error(error));
+          return Promise.reject(error);
+        });
     };
   };
 }


### PR DESCRIPTION
## Description

Redirects to queues if it is an invalid shipment and stops random errors of valid shipments not loading correctly

## Setup
- go to `http://tsplocal:3000/shipments/some-invalid-id`
```sh
make server_run
make tsp_client_run
```

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/n/projects/2181745/stories/161187132) for this change
