### PR TITLE
Use document viewer shared css for document content

### DIFF
--- a/src/scenes/Office/office.css
+++ b/src/scenes/Office/office.css
@@ -162,27 +162,6 @@
   margin-top: 1em;
 }
 
-.document-contents {
-  background: lightgray;
-}
-
-.document-contents .pdf-placeholder {
-  padding: 1em;
-  background: white;
-  font-style: italic;
-  text-align: right;
-}
-
-.document-contents .pdf-placeholder .filename {
-  font-weight: bold;
-  font-style: normal;
-  float: left;
-}
-
-.document-contents .page {
-  padding: 1em;
-}
-
 .orders-page-fields h3 {
   margin-bottom: 0;
 }

--- a/src/shared/DocumentViewer/DocumentContent.jsx
+++ b/src/shared/DocumentViewer/DocumentContent.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import './index.css';
+
 const DocumentContent = ({ contentType, filename, url }) => (
   <div className="page">
     {contentType === 'application/pdf' ? (

--- a/src/shared/DocumentViewer/index.css
+++ b/src/shared/DocumentViewer/index.css
@@ -38,3 +38,24 @@
 .pad-ns {
   padding: 2rem 0rem 2rem 0rem;
 }
+
+.document-contents {
+  background: lightgray;
+}
+
+.document-contents .pdf-placeholder {
+  padding: 1em;
+  background: white;
+  font-style: italic;
+  text-align: right;
+}
+
+.document-contents .pdf-placeholder .filename {
+  font-weight: bold;
+  font-style: normal;
+  float: left;
+}
+
+.document-contents .page {
+  padding: 1em;
+}


### PR DESCRIPTION
## Description

Use document viewer css file for document content page. TSP document viewer and Office viewer now have styling parity for pdf file type.

## Reviewer Notes
- We're currently importing the documentViewer/index.css file for every file that needs it inside that folder. Since we don't have css bundling I'd like to have all files be exported from `shared/documentViewer/index.js` and have just a single `import './index.css` so we don't have to import the css file individually each time
- Icon is currently black, it will be blue when https://github.com/transcom/mymove/pull/1175 is merged in

## Setup

```sh
make tsp_client_run
make server_run
```

## Code Review Verification Steps
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/n/projects/2181745/stories/161325163) for this change

## Screenshots

![office viewer](https://user-images.githubusercontent.com/13622298/47176227-eeb68a80-d2c9-11e8-8d01-f4509317d010.png)

![tsp viewer](https://user-images.githubusercontent.com/13622298/47176252-fe35d380-d2c9-11e8-99a8-415339945a83.png)

