### PR TITLE
Only assign TSPPs to bands when the TSP is enrolled.

### DIFF
--- a/pkg/models/transportation_service_provider_performance.go
+++ b/pkg/models/transportation_service_provider_performance.go
@@ -218,7 +218,9 @@ func FetchUnbandedTSPPerformanceGroups(db *pop.Connection) (TSPPerformanceGroups
 	var perfs TransportationServiceProviderPerformances
 	err := db.
 		Select("traffic_distribution_list_id", "performance_period_start", "performance_period_end", "rate_cycle_start", "rate_cycle_end").
-		Where("quality_band is NULL").
+		Join("transportation_service_providers AS tsp", "tsp.id = transportation_service_provider_performances.transportation_service_provider_id").
+		Where("quality_band IS NULL").
+		Where("enrolled = true").
 		GroupBy("traffic_distribution_list_id", "performance_period_start", "performance_period_end", "rate_cycle_start", "rate_cycle_end").
 		Order("traffic_distribution_list_id, performance_period_start, rate_cycle_start").
 		All(&perfs)

--- a/pkg/models/transportation_service_provider_performance_test.go
+++ b/pkg/models/transportation_service_provider_performance_test.go
@@ -514,6 +514,21 @@ func (suite *ModelSuite) Test_FetchUnbandedTSPPerformanceGroups() {
 	notFoundTSP := testdatagen.MakeDefaultTSP(suite.db)
 	testdatagen.MakeTSPPerformanceDeprecated(suite.db, notFoundTSP, notFoundTDL, swag.Int(1), float64(mps+1), 0, .4, .3)
 
+	unenrolledTDL := testdatagen.MakeTDL(suite.db, testdatagen.Assertions{
+		TrafficDistributionList: TrafficDistributionList{
+			SourceRateArea:    "US14",
+			DestinationRegion: "4",
+			CodeOfService:     "2",
+		},
+	})
+
+	unenrolledTSP := testdatagen.MakeTSP(suite.db, testdatagen.Assertions{
+		TransportationServiceProvider: TransportationServiceProvider{
+			Enrolled: false,
+		},
+	})
+	testdatagen.MakeTSPPerformanceDeprecated(suite.db, unenrolledTSP, unenrolledTDL, nil, float64(mps+1), 0, .4, .3)
+
 	perfGroups, err := FetchUnbandedTSPPerformanceGroups(suite.db)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
## Description

This change prevents us from attempting to assign every TSPP to a quality band.