### PR TITLE
GBL user interaction cleanup #161324250

### DIFF
--- a/cypress/integration/tsp/generateGBL.js
+++ b/cypress/integration/tsp/generateGBL.js
@@ -53,7 +53,12 @@ function tspUserGeneratesGBL() {
 
   // I have seen this take anywhere from 8s - 18s. Until we optimize it, giving the test a long
   // timeout.
-  cy.get('.usa-alert-success', { timeout: 20000 }).contains('GBL generated successfully.');
+  cy.get('.usa-alert-success', { timeout: 20000 }).contains('GBL has been created');
+
+  cy
+    .get('button')
+    .contains('View GBL')
+    .should('be.enabled');
 
   cy
     .get('button')

--- a/cypress/integration/tsp/generateGBL.js
+++ b/cypress/integration/tsp/generateGBL.js
@@ -55,6 +55,8 @@ function tspUserGeneratesGBL() {
   // timeout.
   cy.get('.usa-alert-success', { timeout: 20000 }).contains('GBL has been created');
 
+  cy.get('.usa-alert-success').contains('Click the button to view, print, or download the GBL.');
+
   cy
     .get('button')
     .contains('View GBL')

--- a/pkg/handlers/publicapi/shipments.go
+++ b/pkg/handlers/publicapi/shipments.go
@@ -489,7 +489,7 @@ func (h CreateGovBillOfLadingHandler) Handle(params shipmentop.CreateGovBillOfLa
 		return shipmentop.NewCreateGovBillOfLadingInternalServerError()
 	}
 
-	aFile, err := h.FileStorer().FileSystem().Create("some name")
+	aFile, err := h.FileStorer().FileSystem().Create(gbl.GBLNumber1)
 	if err != nil {
 		h.Logger().Error("Error creating a new afero file for GBL form.", zap.Error(err))
 		return shipmentop.NewCreateGovBillOfLadingInternalServerError()

--- a/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
+++ b/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
@@ -268,7 +268,7 @@ class ShipmentInfo extends Component {
                   <div className="usa-grid usa-alert-no-padding">
                     <div className="usa-width-one-half">Click the button to view, print, or download the GBL.</div>
                     <div className="usa-width-one-half">
-                      <Link to={`${this.props.gblDoc}`} className="usa-alert-right" target="_blank">
+                      <Link to={`${this.props.gblDocUrl}`} className="usa-alert-right" target="_blank">
                         <button>View GBL</button>
                       </Link>
                     </div>
@@ -327,7 +327,7 @@ const mapStateToProps = state => {
     generateGBLError: get(state, 'tsp.generateGBLError'),
     generateGBLSuccess: get(state, 'tsp.generateGBLSuccess'),
     generateGBLInProgress: get(state, 'tsp.generateGBLInProgress'),
-    gblDoc: get(state, 'tsp.gblDoc'),
+    gblDocUrl: get(state, 'tsp.gblDocUrl'),
     error: get(state, 'tsp.error'),
     pickupSchema: get(state, 'swaggerPublic.spec.definitions.ActualPickupDate', {}),
     deliverSchema: get(state, 'swaggerPublic.spec.definitions.ActualDeliveryDate', {}),

--- a/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
+++ b/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
@@ -265,10 +265,10 @@ class ShipmentInfo extends Component {
               )}
               {this.props.generateGBLSuccess && (
                 <Alert type="success" heading="GBL has been created">
-                  <div className="usa-grid">
+                  <div className="usa-grid usa-alert-no-padding">
                     <div className="usa-width-one-half">Click the button to view, print, or download the GBL.</div>
                     <div className="usa-width-one-half">
-                      <button className="right">View GBL</button>
+                      <button className="usa-alert-right">View GBL</button>
                     </div>
                   </div>
                 </Alert>

--- a/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
+++ b/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
@@ -265,14 +265,14 @@ class ShipmentInfo extends Component {
               )}
               {this.props.generateGBLSuccess && (
                 <Alert type="success" heading="GBL has been created">
-                  <div className="usa-grid usa-alert-no-padding">
-                    <div className="usa-width-one-half">Click the button to view, print, or download the GBL.</div>
-                    <div className="usa-width-one-half">
+                  <span className="usa-grid usa-alert-no-padding">
+                    <span className="usa-width-one-half">Click the button to view, print, or download the GBL.</span>
+                    <span className="usa-width-one-half">
                       <Link to={`${this.props.gblDocUrl}`} className="usa-alert-right" target="_blank">
                         <button>View GBL</button>
                       </Link>
-                    </div>
-                  </div>
+                    </span>
+                  </span>
                 </Alert>
               )}
               <div>

--- a/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
+++ b/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
@@ -264,8 +264,13 @@ class ShipmentInfo extends Component {
                 </Alert>
               )}
               {this.props.generateGBLSuccess && (
-                <Alert type="success" heading="Success!">
-                  GBL generated successfully.
+                <Alert type="success" heading="GBL has been created">
+                  <div className="usa-grid">
+                    <div className="usa-width-one-half">Click the button to view, print, or download the GBL.</div>
+                    <div className="usa-width-one-half">
+                      <button className="right">View GBL</button>
+                    </div>
+                  </div>
                 </Alert>
               )}
               <div>

--- a/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
+++ b/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
@@ -268,7 +268,9 @@ class ShipmentInfo extends Component {
                   <div className="usa-grid usa-alert-no-padding">
                     <div className="usa-width-one-half">Click the button to view, print, or download the GBL.</div>
                     <div className="usa-width-one-half">
-                      <button className="usa-alert-right">View GBL</button>
+                      <Link to={`${this.props.gblDoc}`} className="usa-alert-right" target="_blank">
+                        <button>View GBL</button>
+                      </Link>
                     </div>
                   </div>
                 </Alert>
@@ -325,6 +327,7 @@ const mapStateToProps = state => {
     generateGBLError: get(state, 'tsp.generateGBLError'),
     generateGBLSuccess: get(state, 'tsp.generateGBLSuccess'),
     generateGBLInProgress: get(state, 'tsp.generateGBLInProgress'),
+    gblDoc: get(state, 'tsp.gblDoc'),
     error: get(state, 'tsp.error'),
     pickupSchema: get(state, 'swaggerPublic.spec.definitions.ActualPickupDate', {}),
     deliverSchema: get(state, 'swaggerPublic.spec.definitions.ActualDeliveryDate', {}),

--- a/src/scenes/TransportationServiceProvider/ducks.js
+++ b/src/scenes/TransportationServiceProvider/ducks.js
@@ -145,6 +145,7 @@ const initialState = {
   generateGBLSuccess: false,
   generateGBLError: null,
   generateGBLInProgress: false,
+  gblDoc: null,
 };
 
 export function tspReducer(state = initialState, action) {
@@ -374,12 +375,14 @@ export function tspReducer(state = initialState, action) {
         generateGBLSuccess: false,
         generateGBLError: null,
         generateGBLInProgress: true,
+        gblDoc: null,
       });
     case GENERATE_GBL.success:
       return Object.assign({}, state, {
         generateGBLSuccess: true,
         generateGBLError: false,
         generateGBLInProgress: false,
+        gblDoc: action.payload.url,
       });
     case GENERATE_GBL.failure:
       return Object.assign({}, state, {
@@ -387,6 +390,7 @@ export function tspReducer(state = initialState, action) {
         generateGBLError: true,
         generateGBLInProgress: false,
         error: action.error,
+        gblDoc: null,
       });
 
     // MULTIPLE-RESOURCE ACTION TYPES

--- a/src/scenes/TransportationServiceProvider/ducks.js
+++ b/src/scenes/TransportationServiceProvider/ducks.js
@@ -145,7 +145,7 @@ const initialState = {
   generateGBLSuccess: false,
   generateGBLError: null,
   generateGBLInProgress: false,
-  gblDoc: null,
+  gblDocUrl: null,
 };
 
 export function tspReducer(state = initialState, action) {
@@ -375,14 +375,14 @@ export function tspReducer(state = initialState, action) {
         generateGBLSuccess: false,
         generateGBLError: null,
         generateGBLInProgress: true,
-        gblDoc: null,
+        gblDocUrl: null,
       });
     case GENERATE_GBL.success:
       return Object.assign({}, state, {
         generateGBLSuccess: true,
         generateGBLError: false,
         generateGBLInProgress: false,
-        gblDoc: action.payload.url,
+        gblDocUrl: action.payload.url,
       });
     case GENERATE_GBL.failure:
       return Object.assign({}, state, {
@@ -390,7 +390,7 @@ export function tspReducer(state = initialState, action) {
         generateGBLError: true,
         generateGBLInProgress: false,
         error: action.error,
-        gblDoc: null,
+        gblDocUrl: null,
       });
 
     // MULTIPLE-RESOURCE ACTION TYPES

--- a/src/shared/Alert/index.css
+++ b/src/shared/Alert/index.css
@@ -2,6 +2,14 @@
 	white-space: pre-wrap;
 }
 
-.usa-alert.usa-alert-success p{
+.usa-alert.usa-alert-success p {
 	margin-bottom: 1rem;
+}
+
+.usa-alert .usa-alert-no-padding {
+  padding: 0em;
+}
+
+.usa-alert .usa-alert-right {
+  float: right;
 }


### PR DESCRIPTION
## Description

This PR changes the success alert message after generating a GBL document and adds a button for the user to click on to open a GBL document pdf.

# Reviewer Notes

- Decided not to work on reloading the move documents after generating a gbl document since it took more time than expected.

## Code Review Verification Steps

* [ ] There are no aXe warnings for UI.
* [ ] This works in IE.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/161324250) for this change

## Screenshots

![oct-18-2018 18-07-03](https://user-images.githubusercontent.com/1522549/47192206-b2525100-d300-11e8-9e05-1e87f11a4336.gif)
