### PR TITLE
GBL user interaction cleanup fix #161324250

### DIFF
--- a/pkg/handlers/publicapi/shipments.go
+++ b/pkg/handlers/publicapi/shipments.go
@@ -541,7 +541,7 @@ func (h CreateGovBillOfLadingHandler) Handle(params shipmentop.CreateGovBillOfLa
 	uploads := []models.Upload{*upload}
 
 	// Create GBL move document associated to the shipment
-	_, verrs, err = shipment.Move.CreateMoveDocument(h.DB(),
+	doc, verrs, err := shipment.Move.CreateMoveDocument(h.DB(),
 		uploads,
 		&shipmentID,
 		models.MoveDocumentTypeGOVBILLOFLADING,
@@ -552,25 +552,24 @@ func (h CreateGovBillOfLadingHandler) Handle(params shipmentop.CreateGovBillOfLa
 	if err != nil || verrs.HasAny() {
 		return handlers.ResponseForVErrors(h.Logger(), verrs, err)
 	}
-	url, err := uploader.PresignedURL(upload)
+
+	documentPayload, err := payloadForDocumentModel(h.FileStorer(), doc.Document)
 	if err != nil {
-		h.Logger().Error("failed to get presigned url", zap.Error(err))
+		h.Logger().Error("Error fetching document for gbl doc", zap.Error(err))
 		return shipmentop.NewCreateGovBillOfLadingInternalServerError()
 	}
 
-	// TODO: (andrea) Return a document payload instead, once the HHG document is defined in public swagger
-	// This one is copy pasted from internal.yaml to api.yaml :/
-	uploadPayload := &apimessages.UploadPayload{
-		ID:          handlers.FmtUUID(upload.ID),
-		Filename:    swag.String(upload.Filename),
-		ContentType: swag.String(upload.ContentType),
-		URL:         handlers.FmtURI(url),
-		Bytes:       &upload.Bytes,
-		CreatedAt:   handlers.FmtDateTime(upload.CreatedAt),
-		UpdatedAt:   handlers.FmtDateTime(upload.UpdatedAt),
+	moveDocumentPayload := &apimessages.MoveDocumentPayload{
+		ID:               handlers.FmtUUID(doc.ID),
+		ShipmentID:       handlers.FmtUUIDPtr(doc.ShipmentID),
+		Document:         documentPayload,
+		Title:            handlers.FmtStringPtr(&doc.Title),
+		MoveDocumentType: apimessages.MoveDocumentType(doc.MoveDocumentType),
+		Status:           apimessages.MoveDocumentStatus(doc.Status),
+		Notes:            handlers.FmtStringPtr(doc.Notes),
 	}
-	return shipmentop.NewCreateGovBillOfLadingCreated().WithPayload(uploadPayload)
 
+	return shipmentop.NewCreateGovBillOfLadingCreated().WithPayload(moveDocumentPayload)
 }
 
 // GetShipmentContactDetailsHandler allows a TSP to accept a particular shipment

--- a/src/scenes/TransportationServiceProvider/ducks.js
+++ b/src/scenes/TransportationServiceProvider/ducks.js
@@ -379,11 +379,12 @@ export function tspReducer(state = initialState, action) {
         gblDocUrl: null,
       });
     case GENERATE_GBL.success:
+      const gblDocumentUrl = '/shipments/' + action.payload.shipment_id + '/documents/' + action.payload.id;
       return Object.assign({}, state, {
         generateGBLSuccess: true,
         generateGBLError: false,
         generateGBLInProgress: false,
-        gblDocUrl: action.payload.url,
+        gblDocUrl: gblDocumentUrl,
       });
     case GENERATE_GBL.failure:
       return Object.assign({}, state, {

--- a/swagger/api.yaml
+++ b/swagger/api.yaml
@@ -2094,7 +2094,7 @@ paths:
         201:
           description: successfully created GBL move document for shipment
           schema:
-            $ref: '#/definitions/UploadPayload'
+            $ref: '#/definitions/MoveDocumentPayload'
         400:
           description: invalid request
         401:


### PR DESCRIPTION
## Description

This PR changes the payload return type to a MoveDocument after successfully creating a GBL document so that the `View GBL` button will open the document viewer instead of the PDF.

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](./docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](./docs/backend.md#querying-the-database-safely)
 have been satisfied.
* [ ] There are no aXe warnings for UI.
* [ ] This works in IE.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/n/projects/2136867/stories/161324250) for this change

## Screenshots

![oct-19-2018 10-59-26](https://user-images.githubusercontent.com/1522549/47235527-2b4bba00-d38e-11e8-890a-e2369725f41b.gif)
