### PR TITLE
Remove references to HHG from PPM details.

### DIFF
--- a/src/scenes/Landing/MoveSummary.jsx
+++ b/src/scenes/Landing/MoveSummary.jsx
@@ -129,7 +129,7 @@ export const SubmittedPpmMoveSummary = props => {
                 </div>
               </div>
               <div className="usa-width-one-third">
-                <MoveDetails ppm={ppm} />
+                <PPMMoveDetails ppm={ppm} />
                 <div className="titled_block">
                   <div className="title">Documents</div>
                   <div className="details-links">
@@ -261,7 +261,7 @@ export const ApprovedMoveSummary = withContext(props => {
                 )}
               </div>
               <div className="usa-width-one-third">
-                <MoveDetails ppm={ppm} />
+                <PPMMoveDetails ppm={ppm} />
                 <div className="titled_block">
                   <div className="title">Documents</div>
                   <div className="details-links">
@@ -282,8 +282,8 @@ export const ApprovedMoveSummary = withContext(props => {
   );
 });
 
-const MoveDetails = props => {
-  const { ppm, hhg } = props;
+const PPMMoveDetails = props => {
+  const { ppm } = props;
   const privateStorageString = get(ppm, 'estimated_storage_reimbursement')
     ? `(up to ${ppm.estimated_storage_reimbursement})`
     : '';
@@ -292,18 +292,13 @@ const MoveDetails = props => {
     : '';
   const hasSitString = `Temp. Storage: ${ppm.days_in_storage} days ${privateStorageString}`;
 
-  return !isEmpty(ppm) ? (
+  return (
     <div className="titled_block">
       <div className="title">Details</div>
       <div>Weight (est.): {ppm.weight_estimate} lbs</div>
       <div>Incentive (est.): {formatCentsRange(ppm.incentive_estimate_min, ppm.incentive_estimate_max)}</div>
       {ppm.has_sit && <div>{hasSitString}</div>}
       {ppm.has_requested_advance && <div>{advanceString}</div>}
-    </div>
-  ) : (
-    <div className="titled_block">
-      <div className="title">Details</div>
-      <div>Weight (est.): {hhg.weight_estimate} lbs</div>
     </div>
   );
 };

--- a/src/scenes/Landing/MoveSummary.jsx
+++ b/src/scenes/Landing/MoveSummary.jsx
@@ -1,6 +1,6 @@
 import React, { Fragment } from 'react';
 
-import { get, includes, isEmpty } from 'lodash';
+import { get, includes } from 'lodash';
 import moment from 'moment';
 
 import TransportationOfficeContactInfo from 'shared/TransportationOffices/TransportationOfficeContactInfo';

--- a/src/scenes/Review/ProfileReview.jsx
+++ b/src/scenes/Review/ProfileReview.jsx
@@ -4,9 +4,11 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { push } from 'react-router-redux';
-import { selectedMoveType, lastMoveIsCanceled } from 'scenes/Moves/ducks';
 
-import Summary from './Summary';
+import { selectedMoveType, lastMoveIsCanceled } from 'scenes/Moves/ducks';
+import { getInternalSwaggerDefinition } from 'shared/Swagger/selectors';
+
+import ServiceMemberSummary from './ServiceMemberSummary';
 import { getNextIncompletePage as getNextIncompletePageInternal } from 'scenes/MyMove/getWorkflowRoutes';
 
 class ProfileReview extends Component {
@@ -30,6 +32,7 @@ class ProfileReview extends Component {
     });
   };
   render() {
+    const { backupContacts, serviceMember, schemaRank, schemaAffiliation, schemaOrdersType } = this.props;
     return (
       <WizardPage
         handleSubmit={this.resumeMove}
@@ -39,14 +42,20 @@ class ProfileReview extends Component {
       >
         <h1>Review your Profile</h1>
         <p>Has anything changed since your last move? Please check your info below, especially your Rank.</p>
-        <Summary />
+        <ServiceMemberSummary
+          backupContacts={backupContacts}
+          serviceMember={serviceMember}
+          schemaRank={schemaRank}
+          schemaAffiliation={schemaAffiliation}
+          schemaOrdersType={schemaOrdersType}
+        />
       </WizardPage>
     );
   }
 }
 
 ProfileReview.propTypes = {
-  currentServiceMember: PropTypes.object,
+  serviceMember: PropTypes.object,
 };
 
 function mapStateToProps(state) {
@@ -54,6 +63,10 @@ function mapStateToProps(state) {
     serviceMember: state.serviceMember.currentServiceMember,
     lastMoveIsCanceled: lastMoveIsCanceled(state),
     selectedMoveType: selectedMoveType(state),
+    schemaRank: getInternalSwaggerDefinition(state, 'ServiceMemberRank'),
+    schemaOrdersType: getInternalSwaggerDefinition(state, 'OrdersType'),
+    schemaAffiliation: getInternalSwaggerDefinition(state, 'Affiliation'),
+    backupContacts: state.serviceMember.currentBackupContacts,
   };
 }
 function mapDispatchToProps(dispatch) {

--- a/src/scenes/Review/ServiceMemberSummary.jsx
+++ b/src/scenes/Review/ServiceMemberSummary.jsx
@@ -1,0 +1,236 @@
+import React, { Fragment } from 'react';
+import { Link, withRouter } from 'react-router-dom';
+import { get } from 'lodash';
+import PropTypes from 'prop-types';
+
+import { formatDateSM } from 'shared/formatters';
+import Address from './Address';
+
+import './Review.css';
+
+function getFullName(serviceMember) {
+  if (!serviceMember) return;
+  return `${serviceMember.first_name} ${serviceMember.middle_name || ''} ${
+    serviceMember.last_name
+  } ${serviceMember.suffix || ''}`;
+}
+
+function getFullContactPreferences(serviceMember) {
+  if (!serviceMember) return;
+  const prefs = {
+    phone_is_preferred: 'Phone',
+    text_message_is_preferred: 'Text',
+    email_is_preferred: 'Email',
+  };
+  const preferredMethods = [];
+  Object.keys(prefs).forEach(propertyName => {
+    /* eslint-disable security/detect-object-injection */
+    if (serviceMember[propertyName]) {
+      preferredMethods.push(prefs[propertyName]);
+    }
+    /* eslint-enable security/detect-object-injection */
+  });
+  return preferredMethods.join(', ');
+}
+
+// TODO: Uncomment function below after backup contact auth is implemented.
+// function getFullBackupPermission(backup_contact) {
+//   const perms = {
+//     NONE: '',
+//     VIEW: 'View all aspects of this move',
+//     EDIT:
+//       'Authorized to represent me in all aspects of this move (letter of authorization)',
+//   };
+//   return `${perms[backup_contact.permission]}`;
+// }
+
+function ServiceMemberSummary(props) {
+  const {
+    backupContacts,
+    orders,
+    serviceMember,
+    schemaRank,
+    schemaAffiliation,
+    schemaOrdersType,
+    moveIsApproved,
+    editOrdersPath,
+  } = props;
+
+  const rootPath = `/moves/review`;
+  const editProfilePath = rootPath + '/edit-profile';
+  const editBackupContactPath = rootPath + '/edit-backup-contact';
+  const editContactInfoPath = rootPath + '/edit-contact-info';
+
+  const yesNoMap = { true: 'Yes', false: 'No' };
+
+  return (
+    <div>
+      <h3>Profile and Orders</h3>
+      <div className="usa-grid-full review-content">
+        <div className="usa-width-one-half review-section">
+          <p className="heading">
+            Profile
+            <span className="edit-section-link">
+              <Link to={editProfilePath}>Edit</Link>
+            </span>
+          </p>
+          <table>
+            <tbody>
+              <tr>
+                <td> Name: </td>
+                <td>{getFullName(serviceMember)}</td>
+              </tr>
+              <tr>
+                <td>Branch:</td>
+                <td>{get(schemaAffiliation['x-display-value'], get(serviceMember, 'affiliation'))}</td>
+              </tr>
+              <tr>
+                <td> Rank/Pay Grade: </td>
+                <td>{get(schemaRank['x-display-value'], get(serviceMember, 'rank'))}</td>
+              </tr>
+              <tr>
+                <td> DoD ID#: </td>
+                <td>{get(serviceMember, 'edipi')}</td>
+              </tr>
+              <tr>
+                <td> Current Duty Station: </td>
+                <td>{get(serviceMember, 'current_station.name')}</td>
+              </tr>
+            </tbody>
+          </table>
+          {orders && (
+            <Fragment>
+              <p className="heading">
+                Orders
+                {moveIsApproved && '*'}
+                {!moveIsApproved && (
+                  <span className="edit-section-link">
+                    <Link to={editOrdersPath}>Edit</Link>
+                  </span>
+                )}
+              </p>
+              <table>
+                <tbody>
+                  <tr>
+                    <td> Orders Type: </td>
+                    <td>{get(schemaOrdersType['x-display-value'], get(orders, 'orders_type'))}</td>
+                  </tr>
+                  <tr>
+                    <td> Orders Date: </td>
+                    <td> {formatDateSM(get(orders, 'issue_date'))}</td>
+                  </tr>
+                  <tr>
+                    <td> Report-by Date: </td>
+                    <td>{formatDateSM(get(orders, 'report_by_date'))}</td>
+                  </tr>
+                  <tr>
+                    <td> New Duty Station: </td>
+                    <td> {get(orders, 'new_duty_station.name')}</td>
+                  </tr>
+                  <tr>
+                    <td> Dependents?: </td>
+                    <td> {orders && yesNoMap[get(orders, 'has_dependents').toString()]}</td>
+                  </tr>
+                  {orders &&
+                    get(orders, 'spouse_has_pro_gear') && (
+                      <tr>
+                        <td> Spouse Pro Gear?: </td>
+                        <td>{orders && yesNoMap[get(orders, 'spouse_has_pro_gear').toString()]}</td>
+                      </tr>
+                    )}
+                  <tr>
+                    <td> Orders Uploaded: </td>
+                    <td>{get(orders, 'uploaded_orders.uploads') && get(orders, 'uploaded_orders.uploads').length}</td>
+                  </tr>
+                </tbody>
+              </table>
+            </Fragment>
+          )}
+        </div>
+
+        <div className="usa-width-one-half review-section">
+          <p className="heading">
+            Contact Info
+            <span className="edit-section-link">
+              <Link to={editContactInfoPath}>Edit</Link>
+            </span>
+          </p>
+          <table>
+            <tbody>
+              <tr>
+                <td> Best Contact Phone: </td>
+                <td>{get(serviceMember, 'telephone')}</td>
+              </tr>
+              <tr>
+                <td> Alt. Phone: </td>
+                <td>{get(serviceMember, 'secondary_telephone')}</td>
+              </tr>
+              <tr>
+                <td> Personal Email: </td>
+                <td>{get(serviceMember, 'personal_email')}</td>
+              </tr>
+              <tr>
+                <td> Preferred Contact Method: </td>
+                <td>{getFullContactPreferences(serviceMember)}</td>
+              </tr>
+              <tr>
+                <td> Current Mailing Address: </td>
+                <td>
+                  <Address address={get(serviceMember, 'residential_address')} />
+                </td>
+              </tr>
+              <tr>
+                <td> Backup Mailing Address: </td>
+                <td>
+                  <Address address={get(serviceMember, 'backup_mailing_address')} />
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          {backupContacts.map(contact => (
+            <Fragment key={contact.id}>
+              <p className="heading">
+                Backup Contact Info
+                <span className="edit-section-link">
+                  <Link to={editBackupContactPath}>Edit</Link>
+                </span>
+              </p>
+              <table key={contact.id}>
+                <tbody>
+                  <tr>
+                    <td> Backup Contact: </td>
+                    <td>
+                      {contact.name} <br />
+                      {/* getFullBackupPermission(contact) */}
+                    </td>
+                  </tr>
+                  <tr>
+                    <td> Email: </td>
+                    <td> {contact.email} </td>
+                  </tr>
+                  <tr>
+                    <td> Phone: </td>
+                    <td> {contact.telephone}</td>
+                  </tr>
+                </tbody>
+              </table>
+            </Fragment>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+ServiceMemberSummary.propTypes = {
+  backupContacts: PropTypes.array.isRequired,
+  serviceMember: PropTypes.object.isRequired,
+  schemaRank: PropTypes.object.isRequired,
+  schemaAffiliation: PropTypes.object.isRequired,
+  schemaOrdersType: PropTypes.object.isRequired,
+  orders: PropTypes.object,
+  moveIsApproved: PropTypes.bool,
+  editOrdersPath: PropTypes.string,
+};
+
+export default withRouter(ServiceMemberSummary);

--- a/src/scenes/Review/Summary.jsx
+++ b/src/scenes/Review/Summary.jsx
@@ -1,5 +1,4 @@
 import React, { Component, Fragment } from 'react';
-import { Link } from 'react-router-dom';
 import { forEach, get } from 'lodash';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
@@ -14,12 +13,11 @@ import { moveIsApproved, lastMoveIsCanceled } from 'scenes/Moves/ducks';
 import { loadEntitlementsFromState } from 'shared/entitlements';
 import Alert from 'shared/Alert';
 import { titleCase } from 'shared/constants.js';
-import { formatDateSM } from 'shared/formatters';
 
 import { checkEntitlement } from './ducks';
+import ServiceMemberSummary from './ServiceMemberSummary';
 import PPMShipmentSummary from './PPMShipmentSummary';
 import HHGShipmentSummary from './HHGShipmentSummary';
-import Address from './Address';
 
 import './Review.css';
 
@@ -40,54 +38,16 @@ export class Summary extends Component {
       schemaAffiliation,
       schemaOrdersType,
       moveIsApproved,
-      lastMoveIsCanceled,
       serviceMember,
       entitlement,
     } = this.props;
-    const yesNoMap = { true: 'Yes', false: 'No' };
-    function getFullName() {
-      if (!serviceMember) return;
-      return `${serviceMember.first_name} ${serviceMember.middle_name || ''} ${
-        serviceMember.last_name
-      } ${serviceMember.suffix || ''}`;
-    }
-    function getFullContactPreferences() {
-      if (!serviceMember) return;
-      const prefs = {
-        phone_is_preferred: 'Phone',
-        text_message_is_preferred: 'Text',
-        email_is_preferred: 'Email',
-      };
-      const preferredMethods = [];
-      Object.keys(prefs).forEach(propertyName => {
-        /* eslint-disable */
-        if (serviceMember[propertyName]) {
-          preferredMethods.push(prefs[propertyName]);
-        }
-        /* eslint-enable */
-      });
-      return preferredMethods.join(', ');
-    }
-    // TODO: Uncomment function below after backup contact auth is implemented.
-    // function getFullBackupPermission(backup_contact) {
-    //   const perms = {
-    //     NONE: '',
-    //     VIEW: 'View all aspects of this move',
-    //     EDIT:
-    //       'Authorized to represent me in all aspects of this move (letter of authorization)',
-    //   };
-    //   return `${perms[backup_contact.permission]}`;
-    // }
+
     const currentStation = get(serviceMember, 'current_station');
     const stationPhone = get(currentStation, 'transportation_office.phone_lines.0');
 
-    const rootAddress = `/moves/review`;
     const rootAddressWithMoveId = `/moves/${this.props.match.params.moveId}/review`;
-    const editProfileAddress = rootAddress + '/edit-profile';
-    const editBackupContactAddress = rootAddress + '/edit-backup-contact';
-    const editContactInfoAddress = rootAddress + '/edit-contact-info';
-    const editOrdersAddress = rootAddressWithMoveId + '/edit-orders';
     const editSuccessBlurb = this.props.reviewState.editSuccess ? 'Your changes have been saved. ' : '';
+    const editOrdersPath = rootAddressWithMoveId + '/edit-orders';
 
     return (
       <Fragment>
@@ -109,172 +69,21 @@ export class Summary extends Component {
             </Alert>
           )}
 
-        <h3>Profile and Orders</h3>
-        <div className="usa-grid-full review-content">
-          <div className="usa-width-one-half review-section">
-            <p className="heading">
-              Profile
-              <span className="edit-section-link">
-                <Link to={editProfileAddress}>Edit</Link>
-              </span>
-            </p>
-            <table>
-              <tbody>
-                <tr>
-                  <td> Name: </td>
-                  <td>{getFullName()}</td>
-                </tr>
-                <tr>
-                  <td>Branch:</td>
-                  <td>{get(schemaAffiliation['x-display-value'], get(serviceMember, 'affiliation'))}</td>
-                </tr>
-                <tr>
-                  <td> Rank/Pay Grade: </td>
-                  <td>{get(schemaRank['x-display-value'], get(serviceMember, 'rank'))}</td>
-                </tr>
-                <tr>
-                  <td> DoD ID#: </td>
-                  <td>{get(serviceMember, 'edipi')}</td>
-                </tr>
-                <tr>
-                  <td> Current Duty Station: </td>
-                  <td>{get(serviceMember, 'current_station.name')}</td>
-                </tr>
-              </tbody>
-            </table>
-            {!lastMoveIsCanceled && (
-              <Fragment>
-                <p className="heading">
-                  Orders
-                  {moveIsApproved && '*'}
-                  {!moveIsApproved && (
-                    <span className="edit-section-link">
-                      <Link to={editOrdersAddress}>Edit</Link>
-                    </span>
-                  )}
-                </p>
-                <table>
-                  <tbody>
-                    <tr>
-                      <td> Orders Type: </td>
-                      <td>{get(schemaOrdersType['x-display-value'], get(currentOrders, 'orders_type'))}</td>
-                    </tr>
-                    <tr>
-                      <td> Orders Date: </td>
-                      <td> {formatDateSM(get(currentOrders, 'issue_date'))}</td>
-                    </tr>
-                    <tr>
-                      <td> Report-by Date: </td>
-                      <td>{formatDateSM(get(currentOrders, 'report_by_date'))}</td>
-                    </tr>
-                    <tr>
-                      <td> New Duty Station: </td>
-                      <td> {get(currentOrders, 'new_duty_station.name')}</td>
-                    </tr>
-                    <tr>
-                      <td> Dependents?: </td>
-                      <td> {currentOrders && yesNoMap[get(currentOrders, 'has_dependents').toString()]}</td>
-                    </tr>
-                    {currentOrders &&
-                      get(currentOrders, 'spouse_has_pro_gear') && (
-                        <tr>
-                          <td> Spouse Pro Gear?: </td>
-                          <td>{currentOrders && yesNoMap[get(currentOrders, 'spouse_has_pro_gear').toString()]}</td>
-                        </tr>
-                      )}
-                    <tr>
-                      <td> Orders Uploaded: </td>
-                      <td>
-                        {get(currentOrders, 'uploaded_orders.uploads') &&
-                          get(currentOrders, 'uploaded_orders.uploads').length}
-                      </td>
-                    </tr>
-                  </tbody>
-                </table>
-              </Fragment>
-            )}
-          </div>
+        <ServiceMemberSummary
+          orders={currentOrders}
+          backupContacts={currentBackupContacts}
+          serviceMember={serviceMember}
+          schemaRank={schemaRank}
+          schemaAffiliation={schemaAffiliation}
+          schemaOrdersType={schemaOrdersType}
+          moveIsApproved={moveIsApproved}
+          editOrdersPath={editOrdersPath}
+        />
 
-          <div className="usa-width-one-half review-section">
-            <p className="heading">
-              Contact Info
-              <span className="edit-section-link">
-                <Link to={editContactInfoAddress}>Edit</Link>
-              </span>
-            </p>
-            <table>
-              <tbody>
-                <tr>
-                  <td> Best Contact Phone: </td>
-                  <td>{get(serviceMember, 'telephone')}</td>
-                </tr>
-                <tr>
-                  <td> Alt. Phone: </td>
-                  <td>{get(serviceMember, 'secondary_telephone')}</td>
-                </tr>
-                <tr>
-                  <td> Personal Email: </td>
-                  <td>{get(serviceMember, 'personal_email')}</td>
-                </tr>
-                <tr>
-                  <td> Preferred Contact Method: </td>
-                  <td>{getFullContactPreferences()}</td>
-                </tr>
-                <tr>
-                  <td> Current Mailing Address: </td>
-                  <td>
-                    <Address address={get(serviceMember, 'residential_address')} />
-                  </td>
-                </tr>
-                <tr>
-                  <td> Backup Mailing Address: </td>
-                  <td>
-                    <Address address={get(serviceMember, 'backup_mailing_address')} />
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-            {currentBackupContacts.map(contact => (
-              <Fragment key={contact.id}>
-                <p className="heading">
-                  Backup Contact Info
-                  <span className="edit-section-link">
-                    <Link to={editBackupContactAddress}>Edit</Link>
-                  </span>
-                </p>
-                <table key={contact.id}>
-                  <tbody>
-                    <tr>
-                      <td> Backup Contact: </td>
-                      <td>
-                        {contact.name} <br />
-                        {/* getFullBackupPermission(contact) */}
-                      </td>
-                    </tr>
-                    <tr>
-                      <td> Email: </td>
-                      <td> {contact.email} </td>
-                    </tr>
-                    <tr>
-                      <td> Phone: </td>
-                      <td> {contact.telephone}</td>
-                    </tr>
-                  </tbody>
-                </table>
-              </Fragment>
-            ))}
-          </div>
-        </div>
-
-        {currentPpm && !lastMoveIsCanceled && <PPMShipmentSummary ppm={currentPpm} movePath={rootAddressWithMoveId} />}
-        {currentShipment &&
-          !lastMoveIsCanceled && (
-            <HHGShipmentSummary
-              shipment={currentShipment}
-              movePath={rootAddressWithMoveId}
-              entitlements={entitlement}
-            />
-          )}
+        {currentPpm && <PPMShipmentSummary ppm={currentPpm} movePath={rootAddressWithMoveId} />}
+        {currentShipment && (
+          <HHGShipmentSummary shipment={currentShipment} movePath={rootAddressWithMoveId} entitlements={entitlement} />
+        )}
         {moveIsApproved && (
           <div className="approved-edit-warning">
             *To change these fields, contact your local PPPO office at {get(currentStation, 'name')}{' '}
@@ -287,10 +96,11 @@ export class Summary extends Component {
 }
 
 Summary.propTypes = {
+  currentBackupContacts: PropTypes.array,
+  currentMove: PropTypes.object,
+  currentOrders: PropTypes.object,
   currentPpm: PropTypes.object,
   currentShipment: PropTypes.object,
-  currentBackupContacts: PropTypes.array,
-  currentOrders: PropTypes.object,
   schemaRank: PropTypes.object,
   schemaOrdersType: PropTypes.object,
   moveIsApproved: PropTypes.bool,
@@ -304,7 +114,6 @@ function mapStateToProps(state, ownProps) {
     currentShipment: selectShipment(state, getCurrentShipmentID(state)),
     serviceMember: state.serviceMember.currentServiceMember,
     currentMove: getMove(state, ownProps.match.params.moveId),
-    // latestMove: state.moves.latestMove,
     currentBackupContacts: state.serviceMember.currentBackupContacts,
     currentOrders: state.orders.currentOrders,
     schemaRank: getInternalSwaggerDefinition(state, 'ServiceMemberRank'),


### PR DESCRIPTION
## Description

This removes an issue where we were attempting to display a value from a Shipment on a PPM, causing the app to break. It looks like we only pass a `ppm` prop into that component, so we can remove that branch and code.

## Reviewer Notes

I renamed the component to make its purpose slightly more clear.

## Setup

If you run `make populate_e2e_db` and then login as `hhg@approv.ed` on master, you can see the broken page. Then switch to this branch and it will render.

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](./docs/backend.md#logging)
* [ ] Request review from a member of a different team.