### PR TITLE
Fix bug where warnings appeared if weight estimates were not entered.

### DIFF
--- a/src/scenes/Review/HHGWeightWarning.jsx
+++ b/src/scenes/Review/HHGWeightWarning.jsx
@@ -4,6 +4,9 @@ import { formatNumber } from 'shared/formatters';
 import Alert from 'shared/Alert';
 
 function warning(name, estimatedWeight, allowedWeight) {
+  if (!estimatedWeight) {
+    return null;
+  }
   const remaining = allowedWeight - estimatedWeight;
 
   if (remaining >= 0) {

--- a/src/scenes/Review/HHGWeightWarning.test.jsx
+++ b/src/scenes/Review/HHGWeightWarning.test.jsx
@@ -27,8 +27,18 @@ describe('HHG with too high a weight estimate', function() {
   });
 });
 
-describe('With valid weights', function() {
+describe('with valid weights', function() {
   const shipment = { weight_estimate: 1000, progear_weight_estimate: 200, spouse_progear_weight_estimate: 200 };
+  const entitlements = { weight: 2000, pro_gear: 300, pro_gear_spouse: 300 };
+  const wrapper = shallow(<HHGWeightWarning shipment={shipment} entitlements={entitlements} />);
+
+  it('shows no alerts', function() {
+    expect(wrapper.containsMatchingElement(Alert)).toEqual(false);
+  });
+});
+
+describe('with no estimates', function() {
+  const shipment = {};
   const entitlements = { weight: 2000, pro_gear: 300, pro_gear_spouse: 300 };
   const wrapper = shallow(<HHGWeightWarning shipment={shipment} entitlements={entitlements} />);
 


### PR DESCRIPTION
## Description

This PR fixes a bug where the app incorrectly showed a warning if a SM didn't enter estimated pro-gear weights.

## Setup

You can run through the SM flow and create an HHG move, leaving all pro-gear fields blank.

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/161328999) for this change