### PR TITLE
CircleCI Wait for Snapshots

### DIFF
--- a/bin/rds-snapshot-app-db
+++ b/bin/rds-snapshot-app-db
@@ -18,5 +18,6 @@ readonly db_instance_identifer=app-$environment
 readonly db_snapshot_identifer=$db_instance_identifer-$(date +%s)
 readonly tags=("Key=Environment,Value=$environment" "Key=Tool,Value=$(basename "$0")")
 
+time aws rds wait db-snapshot-completed --db-instance-identifier "$db_instance_identifer" # Wait for concurrent databse snapshots to complete before continuing
 aws rds create-db-snapshot --db-instance-identifier "$db_instance_identifer" --db-snapshot-identifier "$db_snapshot_identifer" --tags "${tags[@]}"
-time aws rds wait db-snapshot-completed --db-instance-identifier "$db_instance_identifer" --db-snapshot-identifier "$db_snapshot_identifer"
+time aws rds wait db-snapshot-completed --db-snapshot-identifier "$db_snapshot_identifer"


### PR DESCRIPTION
## Description

This PR should make concurrent snapshot errors much less likely (https://circleci.com/gh/transcom/mymove/23064).  Database snapshots now wait until there are no other snapshots in progress before attempting a snapshot.

 Also fixes the post-snapshot waiter, as according to AWS docs, you can't use `--db-instance-identifier` and `--db-snapshot-identifier` at the same time.

https://docs.aws.amazon.com/cli/latest/reference/rds/wait/db-snapshot-completed.html