### PR TITLE
Create HHG status bar image [delivers #161271728]

### DIFF
--- a/src/scenes/Landing/MoveSummary.css
+++ b/src/scenes/Landing/MoveSummary.css
@@ -6,12 +6,12 @@ h2 {
   border: 3px solid lightgrey;
   overflow: hidden;
   margin-top: 1em;
+  padding-bottom: 4rem;
+  position: relative;
 }
 
 img.move_sm {
-  height: 0.75em;
   display: inline;
-  margin-bottom: 0;
   margin-right: 0.3em;
   padding: 0rem 1.2rem 0rem 0rem;
 }
@@ -67,4 +67,3 @@ a {
 .contact_block .title {
   font-size: 2.2rem;
 }
-

--- a/src/scenes/Landing/MoveSummary.css
+++ b/src/scenes/Landing/MoveSummary.css
@@ -3,7 +3,7 @@ h2 {
 }
 
 .shipment_box {
-  border: 3px solid lightgrey;
+  border: 3px solid #f1f1f1;
   overflow: hidden;
   margin-top: 1em;
   padding-bottom: 4rem;
@@ -11,7 +11,9 @@ h2 {
 }
 
 img.move_sm {
+  height: 1em;
   display: inline;
+  margin-bottom: 0;
   margin-right: 0.3em;
   padding: 0rem 1.2rem 0rem 0rem;
 }
@@ -21,7 +23,7 @@ img.status_icon {
 }
 
 .shipment_type {
-  background-color: lightgrey;
+  background-color: #f1f1f1;
   font-size: 1.1em;
   font-weight: bold;
   padding: 0.7em;

--- a/src/scenes/Landing/MoveSummary.jsx
+++ b/src/scenes/Landing/MoveSummary.jsx
@@ -129,7 +129,7 @@ export const SubmittedPpmMoveSummary = props => {
                 </div>
               </div>
               <div className="usa-width-one-third">
-                <MoveDetails ppm={ppm} />
+                <PPMMoveDetails ppm={ppm} />
                 <div className="titled_block">
                   <div className="title">Documents</div>
                   <div className="details-links">
@@ -261,7 +261,7 @@ export const ApprovedMoveSummary = withContext(props => {
                 )}
               </div>
               <div className="usa-width-one-third">
-                <MoveDetails ppm={ppm} />
+                <PPMMoveDetails ppm={ppm} />
                 <div className="titled_block">
                   <div className="title">Documents</div>
                   <div className="details-links">
@@ -282,8 +282,8 @@ export const ApprovedMoveSummary = withContext(props => {
   );
 });
 
-const MoveDetails = props => {
-  const { ppm, hhg } = props;
+const PPMMoveDetails = props => {
+  const { ppm } = props;
   const privateStorageString = get(ppm, 'estimated_storage_reimbursement')
     ? `(up to ${ppm.estimated_storage_reimbursement})`
     : '';
@@ -292,18 +292,13 @@ const MoveDetails = props => {
     : '';
   const hasSitString = `Temp. Storage: ${ppm.days_in_storage} days ${privateStorageString}`;
 
-  return !isEmpty(ppm) ? (
+  return (
     <div className="titled_block">
       <div className="title">Details</div>
       <div>Weight (est.): {ppm.weight_estimate} lbs</div>
       <div>Incentive (est.): {formatCentsRange(ppm.incentive_estimate_min, ppm.incentive_estimate_max)}</div>
       {ppm.has_sit && <div>{hasSitString}</div>}
       {ppm.has_requested_advance && <div>{advanceString}</div>}
-    </div>
-  ) : (
-    <div className="titled_block">
-      <div className="title">Details</div>
-      <div>Weight (est.): {hhg.weight_estimate} lbs</div>
     </div>
   );
 };

--- a/src/scenes/Landing/MoveSummary.jsx
+++ b/src/scenes/Landing/MoveSummary.jsx
@@ -1,6 +1,6 @@
 import React, { Fragment } from 'react';
 
-import { get, includes, isEmpty } from 'lodash';
+import { get, includes } from 'lodash';
 import moment from 'moment';
 
 import TransportationOfficeContactInfo from 'shared/TransportationOffices/TransportationOfficeContactInfo';

--- a/src/scenes/Landing/StatusTimeline.css
+++ b/src/scenes/Landing/StatusTimeline.css
@@ -1,4 +1,4 @@
-.shipment_box_contents .status_timeline{
+.shipment_box_contents .status_timeline {
   display: flex;
   flex-direction: row;
   justify-content: space-between;
@@ -6,22 +6,16 @@
   text-align: center;
 }
 
-/*.shipment_box_contents .status_line{*/
-  /*flex: 1;*/
-  /*height: 3px;*/
-  /*background: #d6d7d9;*/
-  /*!*display: flex;*!*/
-  /*!*flex-direction: column;*!*/
-  /*align-items: center;*/
-/*}*/
-
-.shipment_box_contents .status_block{
+.shipment_box_contents .status_block {
   flex: 1;
   display: flex;
   flex-direction: column;
   align-items: center;
+  position: relative;
+  font-size: 0.9em;
 }
-.shipment_box_contents .status_dot{
+
+.shipment_box_contents .status_dot {
   display: block;
   width: 20px;
   height: 20px;
@@ -29,13 +23,67 @@
   border-radius: 50%;
   -moz-border-radius: 50%;
   -webkit-border-radius: 50%;
+  z-index: 10;
 }
 
-.shipment_box_contents .status_active{
+.status_block.status_completed,
+.status_block.status_current .status_name {
+  font-weight: bold;
+}
+
+.status_block.packed .status_dates,
+.status_block.delivered .status_dates {
+  font-style: italic;
+  color: #999;
+}
+.status_block.packed .status_dates:after,
+.status_block.delivered .status_dates:after {
+  content: ' *';
+}
+
+.status_block.status_completed .status_dot {
+  background: #102e51;
+  box-shadow: 0px 0px 0px 2px #102e51;
+}
+
+.status_block.status_current .status_dot {
   background: #102e51;
   box-shadow: 0px 0px 0px 4px #0270bc;
 }
 
-.shipment_box_contents .status_name{
-  margin: 1rem 0 .5rem 0;
+.status_block:after {
+  display: block;
+  content: ' ';
+  width: 100%;
+  height: 3px;
+  background: #d6d7d9;
+  position: absolute;
+  right: 50%;
+  top: 10px;
+  z-index: 1;
+}
+
+.status_block:first-child:after {
+  display: none;
+}
+
+.status_block.status_completed:after,
+.status_block.status_current:after {
+  background: #102e51;
+}
+
+.status_block.status_completed:first-child:after {
+  display: none;
+}
+
+.shipment_box_contents .status_name {
+  margin: 1rem 0 0.2rem 0;
+}
+
+.status_timeline .legend {
+  font-style: italic;
+  color: #999;
+  position: absolute;
+  bottom: 2rem;
+  left: 1rem;
 }

--- a/src/scenes/Landing/StatusTimeline.jsx
+++ b/src/scenes/Landing/StatusTimeline.jsx
@@ -23,17 +23,15 @@ export class StatusTimelineContainer extends PureComponent {
     const deliveryDates = get(moveDates, 'delivery', []);
     const transitDates = get(moveDates, 'transit', []);
     const formatType = 'condensed';
+
     return (
       <div className="status_timeline">
-        <StatusBlock name="Scheduled" dates={[this.props.bookDate]} formatType={formatType} active={true} />
-        <div className="status_line" />
-        <StatusBlock name="Packed" dates={packDates} formatType="condensed" />
-        <div className="status_line" />
+        <StatusBlock name="Scheduled" dates={[this.props.bookDate]} formatType={formatType} completed={true} />
+        <StatusBlock name="Packed" dates={packDates} formatType="condensed" current={true} />
         <StatusBlock name="Loaded" dates={pickupDates} formatType="condensed" />
-        <div className="status_line" />
         <StatusBlock name="In transit" dates={transitDates} formatType="condensed" />
-        <div className="status_line" />
         <StatusBlock name="Delivered" dates={deliveryDates} formatType="condensed" />
+        <div className="legend">* Estimated</div>
       </div>
     );
   }
@@ -61,12 +59,15 @@ function mapStateToProps(state, ownProps) {
 export default withRouter(connect(mapStateToProps, mapDispatchToProps)(StatusTimelineContainer));
 
 const StatusBlock = props => {
-  let active = props.active ? 'status_active' : '';
+  let classes = ['status_block', props.name.toLowerCase()];
+  if (props.completed) classes.push('status_completed');
+  if (props.current) classes.push('status_current');
+
   return (
-    <div className="status_block">
-      <div className={`status_dot ${active}`} />
+    <div className={classes.join(' ')}>
+      <div className="status_dot" />
       <div className="status_name">{props.name}</div>
-      {props.dates && <div>{displayDateRange(props.dates, props.formatType)}</div>}
+      {props.dates && <div className="status_dates">{displayDateRange(props.dates, props.formatType)}</div>}
     </div>
   );
 };


### PR DESCRIPTION
## Description

This PR adds some final touches to the HHG move timeline added in earlier work.

## Setup

You'll need to walk through and submit an HHG move to see the move status timeline. We don't have the logic in place to change what is highlighted based on the date. It seems like there is more work to do to use the real dates provided by the TSP when we have them as well.

## Code Review Verification Steps

* [ ] There are no aXe warnings for UI.
* [ ] This works in IE.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/161271728) for this change

## Screenshots

<img width="754" alt="screen shot 2018-10-22 at 10 40 37 am" src="https://user-images.githubusercontent.com/3331/47302487-406f5580-d5e7-11e8-8d29-53b8a63cdaa6.png">

IE11:

<img width="739" alt="screen shot 2018-10-22 at 11 15 50 am" src="https://user-images.githubusercontent.com/3331/47304328-e91fb400-d5eb-11e8-959c-332f369e2288.png">

