### PR TITLE
Action Button: Generate the GBL

### DIFF
--- a/cypress/integration/tsp/generateGBL.js
+++ b/cypress/integration/tsp/generateGBL.js
@@ -14,9 +14,12 @@ describe('TSP User generates GBL', function() {
 });
 
 function tspUserGeneratesGBL() {
-  // Open new shipments queue
+  const gblButtonText = 'Generate the GBL';
+
+  // Open approved shipments queue
+  cy.visit('/queues/approved');
   cy.location().should(loc => {
-    expect(loc.pathname).to.match(/^\/queues\/new/);
+    expect(loc.pathname).to.match(/^\/queues\/approved/);
   });
 
   // Find shipment
@@ -31,7 +34,7 @@ function tspUserGeneratesGBL() {
 
   cy
     .get('button')
-    .contains('Generate the GBL')
+    .contains(gblButtonText)
     .should('be.enabled');
 
   cy.location().should(loc => {
@@ -43,12 +46,12 @@ function tspUserGeneratesGBL() {
 
   cy
     .get('button')
-    .contains('Generate the GBL')
+    .contains(gblButtonText)
     .click();
 
   cy
     .get('button')
-    .contains('Generate the GBL')
+    .contains(gblButtonText)
     .should('be.disabled');
 
   // I have seen this take anywhere from 8s - 18s. Until we optimize it, giving the test a long
@@ -64,21 +67,22 @@ function tspUserGeneratesGBL() {
 
   cy
     .get('button')
-    .contains('Generate the GBL')
+    .contains(gblButtonText)
     .click();
 
   cy
     .get('button')
-    .contains('Generate the GBL')
+    .contains(gblButtonText)
     .should('be.disabled');
 
   cy.get('.usa-alert-warning').contains('There is already a GBL for this shipment. ');
 }
 
 function tspUserViewsGBL() {
-  // Open new shipments queue
+  // Open approved shipments queue
+  cy.visit('/queues/approved');
   cy.location().should(loc => {
-    expect(loc.pathname).to.match(/^\/queues\/new/);
+    expect(loc.pathname).to.match(/^\/queues\/approved/);
   });
 
   // Find shipment

--- a/cypress/integration/tsp/generateGBL.js
+++ b/cypress/integration/tsp/generateGBL.js
@@ -31,7 +31,7 @@ function tspUserGeneratesGBL() {
 
   cy
     .get('button')
-    .contains('Generate Bill of Lading')
+    .contains('Generate the GBL')
     .should('be.enabled');
 
   cy.location().should(loc => {
@@ -43,12 +43,12 @@ function tspUserGeneratesGBL() {
 
   cy
     .get('button')
-    .contains('Generate Bill of Lading')
+    .contains('Generate the GBL')
     .click();
 
   cy
     .get('button')
-    .contains('Generate Bill of Lading')
+    .contains('Generate the GBL')
     .should('be.disabled');
 
   // I have seen this take anywhere from 8s - 18s. Until we optimize it, giving the test a long
@@ -64,12 +64,12 @@ function tspUserGeneratesGBL() {
 
   cy
     .get('button')
-    .contains('Generate Bill of Lading')
+    .contains('Generate the GBL')
     .click();
 
   cy
     .get('button')
-    .contains('Generate Bill of Lading')
+    .contains('Generate the GBL')
     .should('be.disabled');
 
   cy.get('.usa-alert-warning').contains('There is already a GBL for this shipment. ');

--- a/pkg/edi/invoice/generator.go
+++ b/pkg/edi/invoice/generator.go
@@ -173,7 +173,7 @@ func getHeadingSegments(shipmentWithCost rateengine.CostByShipment, sequenceNum 
 			ShipmentMethodOfPayment:      "PP", // Prepaid by seller
 			ShipmentIdentificationNumber: *GBL,
 			StandardCarrierAlphaCode:     "MCCG", // TODO: real SCAC
-			ShipmentQualifier:            "4",    // HHG Bill of Lading
+			ShipmentQualifier:            "4",    // HHG Government Bill of Lading
 		},
 		&edisegment.N9{
 			ReferenceIdentificationQualifier: "DY", // DoD transportation service code #

--- a/pkg/testdatagen/scenario/e2ebasic.go
+++ b/pkg/testdatagen/scenario/e2ebasic.go
@@ -1240,6 +1240,7 @@ func MakeHhgFromAwardedToAcceptedGBLReady(db *pop.Connection, tspUser models.Tsp
 	packDate := time.Now().AddDate(0, 0, 1)
 	pickupDate := time.Now().AddDate(0, 0, 5)
 	deliveryDate := time.Now().AddDate(0, 0, 10)
+	weightEstimate := unit.Pound(5000)
 	sourceOffice := testdatagen.MakeTransportationOffice(db, testdatagen.Assertions{
 		TransportationOffice: models.TransportationOffice{
 			Gbloc: "ABCD",
@@ -1280,17 +1281,20 @@ func MakeHhgFromAwardedToAcceptedGBLReady(db *pop.Connection, tspUser models.Tsp
 		},
 		Shipment: models.Shipment{
 			ID:                          uuid.FromStringOrNil("a4013cee-aa0a-41a3-b5f5-b9eed0758e1d 0xc42022c070"),
-			Status:                      models.ShipmentStatusAWARDED,
-			PmSurveyPlannedPackDate:     &packDate,
+			Status:                      models.ShipmentStatusAPPROVED,
 			PmSurveyConductedDate:       &packDate,
+			PmSurveyMethod:              "PHONE",
+			PmSurveyPlannedPackDate:     &packDate,
 			PmSurveyPlannedPickupDate:   &pickupDate,
 			PmSurveyPlannedDeliveryDate: &deliveryDate,
+			PmSurveyWeightEstimate:      &weightEstimate,
 			SourceGBLOC:                 &sourceOffice.Gbloc,
 			DestinationGBLOC:            &destOffice.Gbloc,
 		},
 		ShipmentOffer: models.ShipmentOffer{
 			TransportationServiceProviderID: tspUser.TransportationServiceProviderID,
 			TransportationServiceProvider:   tspUser.TransportationServiceProvider,
+			Accepted:                        models.BoolPointer(true),
 		},
 	})
 

--- a/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
+++ b/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
@@ -178,7 +178,14 @@ class ShipmentInfo extends Component {
   deliverShipment = values => this.props.deliverShipment(this.props.shipment.id, values);
 
   render() {
-    const { context, shipment, shipmentDocuments } = this.props;
+    const {
+      context,
+      shipment,
+      shipmentDocuments,
+      generateGBLSuccess,
+      generateGBLError,
+      generateGBLInProgress,
+    } = this.props;
     const {
       service_member: serviceMember = {},
       move = {},
@@ -281,7 +288,7 @@ class ShipmentInfo extends Component {
                   shipmentStatus={this.props.shipment.status}
                 />
               )}
-              {this.props.generateGBLError && (
+              {generateGBLError && (
                 <p>
                   <Alert type="warning" heading="An error occurred">
                     {attachmentsErrorMessages[this.props.error.statusCode] ||
@@ -289,7 +296,7 @@ class ShipmentInfo extends Component {
                   </Alert>
                 </p>
               )}
-              {this.props.generateGBLSuccess && (
+              {generateGBLSuccess && (
                 <p>
                   <Alert type="success" heading="GBL has been created">
                     <span className="usa-grid usa-alert-no-padding">
@@ -309,7 +316,7 @@ class ShipmentInfo extends Component {
                 pmSurveyComplete &&
                 !gblGenerated && (
                   <div>
-                    <button onClick={this.generateGBL} disabled={this.props.generateGBLInProgress}>
+                    <button onClick={this.generateGBL} disabled={generateGBLInProgress}>
                       Generate the GBL
                     </button>
                   </div>

--- a/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
+++ b/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
@@ -57,7 +57,7 @@ import './tsp.css';
 
 const attachmentsErrorMessages = {
   400: 'There is already a GBL for this shipment. ',
-  417: 'Missing data required to generate a Bill of Lading.',
+  417: 'Missing data required to generate a GBL.',
 };
 
 class AcceptShipmentPanel extends Component {
@@ -332,7 +332,7 @@ class ShipmentInfo extends Component {
               )}
               <div>
                 <button onClick={this.generateGBL} disabled={this.props.generateGBLInProgress}>
-                  Generate Bill of Lading
+                  Generate the GBL
                 </button>
               </div>
               <div className="customer-info">

--- a/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
+++ b/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
@@ -223,11 +223,17 @@ class ShipmentInfo extends Component {
                 <span>New Shipments Queue</span>
               </NavLink>
             )}
-            {!awarded && (
-              <NavLink to="/queues/all" activeClassName="usa-current">
-                <span>All Shipments Queue</span>
+            {approved && (
+              <NavLink to="/queues/approved" activeClassName="usa-current">
+                <span>Approved Shipments Queue</span>
               </NavLink>
             )}
+            {!awarded &&
+              !approved && (
+                <NavLink to="/queues/all" activeClassName="usa-current">
+                  <span>All Shipments Queue</span>
+                </NavLink>
+              )}
           </div>
         </div>
         <div className="usa-grid grid-wide">

--- a/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
+++ b/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
@@ -282,22 +282,28 @@ class ShipmentInfo extends Component {
                 />
               )}
               {this.props.generateGBLError && (
-                <Alert type="warning" heading="An error occurred">
-                  {attachmentsErrorMessages[this.props.error.statusCode] ||
-                    'Something went wrong contacting the server.'}
-                </Alert>
+                <p>
+                  <Alert type="warning" heading="An error occurred">
+                    {attachmentsErrorMessages[this.props.error.statusCode] ||
+                      'Something went wrong contacting the server.'}
+                  </Alert>
+                </p>
               )}
               {this.props.generateGBLSuccess && (
-                <Alert type="success" heading="GBL has been created">
-                  <span className="usa-grid usa-alert-no-padding">
-                    <span className="usa-width-one-half">Click the button to view, print, or download the GBL.</span>
-                    <span className="usa-width-one-half">
-                      <Link to={`${this.props.gblDocUrl}`} className="usa-alert-right" target="_blank">
-                        <button>View GBL</button>
-                      </Link>
+                <p>
+                  <Alert type="success" heading="GBL has been created">
+                    <span className="usa-grid usa-alert-no-padding">
+                      <span className="usa-width-two-thirds">
+                        Click the button to view, print, or download the GBL.
+                      </span>
+                      <span className="usa-width-one-third">
+                        <Link to={`${this.props.gblDocUrl}`} className="usa-alert-right" target="_blank">
+                          <button>View GBL</button>
+                        </Link>
+                      </span>
                     </span>
-                  </span>
-                </Alert>
+                  </Alert>
+                </p>
               )}
               {approved &&
                 pmSurveyComplete &&

--- a/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
+++ b/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
@@ -193,6 +193,16 @@ class ShipmentInfo extends Component {
     const awarded = shipment.status === 'AWARDED';
     const approved = shipment.status === 'APPROVED';
     const inTransit = shipment.status === 'IN_TRANSIT';
+    const pmSurveyComplete = Boolean(
+      shipment.pm_survey_conducted_date &&
+        shipment.pm_survey_method &&
+        shipment.pm_survey_planned_pack_date &&
+        shipment.pm_survey_planned_pickup_date &&
+        shipment.pm_survey_planned_delivery_date &&
+        shipment.pm_survey_weight_estimate,
+    );
+    const gblGenerated =
+      shipmentDocuments && shipmentDocuments.find(element => element.move_document_type === 'GOV_BILL_OF_LADING');
 
     if (this.state.redirectToHome) {
       return <Redirect to="/" />;
@@ -265,6 +275,33 @@ class ShipmentInfo extends Component {
                   shipmentStatus={this.props.shipment.status}
                 />
               )}
+              {this.props.generateGBLError && (
+                <Alert type="warning" heading="An error occurred">
+                  {attachmentsErrorMessages[this.props.error.statusCode] ||
+                    'Something went wrong contacting the server.'}
+                </Alert>
+              )}
+              {this.props.generateGBLSuccess && (
+                <Alert type="success" heading="GBL has been created">
+                  <span className="usa-grid usa-alert-no-padding">
+                    <span className="usa-width-one-half">Click the button to view, print, or download the GBL.</span>
+                    <span className="usa-width-one-half">
+                      <Link to={`${this.props.gblDocUrl}`} className="usa-alert-right" target="_blank">
+                        <button>View GBL</button>
+                      </Link>
+                    </span>
+                  </span>
+                </Alert>
+              )}
+              {approved &&
+                pmSurveyComplete &&
+                !gblGenerated && (
+                  <div>
+                    <button onClick={this.generateGBL} disabled={this.props.generateGBLInProgress}>
+                      Generate the GBL
+                    </button>
+                  </div>
+                )}
               {this.props.loadTspDependenciesHasSuccess && (
                 <div className="office-tab">
                   <Dates title="Dates" shipment={this.props.shipment} update={this.props.patchShipment} />
@@ -312,29 +349,6 @@ class ShipmentInfo extends Component {
                   buttonTitle="Enter Delivery"
                 />
               )}
-              {this.props.generateGBLError && (
-                <Alert type="warning" heading="An error occurred">
-                  {attachmentsErrorMessages[this.props.error.statusCode] ||
-                    'Something went wrong contacting the server.'}
-                </Alert>
-              )}
-              {this.props.generateGBLSuccess && (
-                <Alert type="success" heading="GBL has been created">
-                  <span className="usa-grid usa-alert-no-padding">
-                    <span className="usa-width-one-half">Click the button to view, print, or download the GBL.</span>
-                    <span className="usa-width-one-half">
-                      <Link to={`${this.props.gblDocUrl}`} className="usa-alert-right" target="_blank">
-                        <button>View GBL</button>
-                      </Link>
-                    </span>
-                  </span>
-                </Alert>
-              )}
-              <div>
-                <button onClick={this.generateGBL} disabled={this.props.generateGBLInProgress}>
-                  Generate the GBL
-                </button>
-              </div>
               <div className="customer-info">
                 <h2 className="extras usa-heading">Customer Info</h2>
                 <CustomerInfo />


### PR DESCRIPTION
## Description

Making the GBL button match the wireframes.

- http://slicedbreadclient.com/dds/dp3/wireframes/TSP/round6/tsp_4-edit-agents.html
- http://slicedbreadclient.com/dds/dp3/wireframes/TSP/round6/tsp_5-enter-pickup.html

## Reviewer Notes

Refreshing the page will reveal the GBL button briefly.  I wish this wasn't the case, but our page loads in a wonky way.

I can't get the button for viewing the GBL to the right of the alert in a way that works when resizing the page.  I've left it alone for now.

## Setup

```sh
make db_dev_reset && make db_dev_migrate && go run ./cmd/generate_test_data/main.go -scenario=7
```

Then find an approved move.  Make sure the missing data in the office app has been filled in.  The required PM Survey fields must be completed.  Then the button should appear.

After the button has been clicked the success (or error) message should appear.  The button should then disappear (if it doesn't then refresh the page, we have an open bug about the fact that redux isn't being updated on GBL update).  The button should then be missing.

## Code Review Verification Steps

* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/161066137) for this change

## Screenshots

The button:

<img width="1300" alt="screen shot 2018-10-22 at 2 49 36 pm" src="https://user-images.githubusercontent.com/219296/47321547-f8155f00-d609-11e8-9bf9-9eabee796201.png">

Success message:

<img width="1300" alt="screen shot 2018-10-22 at 2 50 13 pm" src="https://user-images.githubusercontent.com/219296/47321552-f9df2280-d609-11e8-991b-8b3157b607df.png">

Error message:

<img width="1299" alt="screen shot 2018-10-22 at 2 50 53 pm" src="https://user-images.githubusercontent.com/219296/47321555-fc417c80-d609-11e8-8e0a-5820b053dab3.png">
