### PR TITLE
Make the has_ fields required for shipments

### DIFF
--- a/pkg/handlers/internalapi/shipments.go
+++ b/pkg/handlers/internalapi/shipments.go
@@ -66,11 +66,11 @@ func payloadForShipmentModel(s models.Shipment) *internalmessages.Shipment {
 
 		// addresses
 		PickupAddress:                payloadForAddressModel(s.PickupAddress),
-		HasSecondaryPickupAddress:    s.HasSecondaryPickupAddress,
+		HasSecondaryPickupAddress:    handlers.FmtBool(s.HasSecondaryPickupAddress),
 		SecondaryPickupAddress:       payloadForAddressModel(s.SecondaryPickupAddress),
-		HasDeliveryAddress:           s.HasDeliveryAddress,
+		HasDeliveryAddress:           handlers.FmtBool(s.HasDeliveryAddress),
 		DeliveryAddress:              payloadForAddressModel(s.DeliveryAddress),
-		HasPartialSitDeliveryAddress: s.HasPartialSITDeliveryAddress,
+		HasPartialSitDeliveryAddress: handlers.FmtBool(s.HasPartialSITDeliveryAddress),
 		PartialSitDeliveryAddress:    payloadForAddressModel(s.PartialSITDeliveryAddress),
 
 		// weights
@@ -134,11 +134,11 @@ func (h CreateShipmentHandler) Handle(params shipmentop.CreateShipmentParams) mi
 		ProgearWeightEstimate:        handlers.PoundPtrFromInt64Ptr(payload.ProgearWeightEstimate),
 		SpouseProgearWeightEstimate:  handlers.PoundPtrFromInt64Ptr(payload.SpouseProgearWeightEstimate),
 		PickupAddress:                pickupAddress,
-		HasSecondaryPickupAddress:    payload.HasSecondaryPickupAddress,
+		HasSecondaryPickupAddress:    *payload.HasSecondaryPickupAddress,
 		SecondaryPickupAddress:       secondaryPickupAddress,
-		HasDeliveryAddress:           payload.HasDeliveryAddress,
+		HasDeliveryAddress:           *payload.HasDeliveryAddress,
 		DeliveryAddress:              deliveryAddress,
-		HasPartialSITDeliveryAddress: payload.HasPartialSitDeliveryAddress,
+		HasPartialSITDeliveryAddress: *payload.HasPartialSitDeliveryAddress,
 		PartialSITDeliveryAddress:    partialSITDeliveryAddress,
 		Market: &market,
 	}
@@ -199,43 +199,51 @@ func patchShipmentWithPayload(shipment *models.Shipment, payload *internalmessag
 			updateAddressWithPayload(shipment.PickupAddress, payload.PickupAddress)
 		}
 	}
-	if payload.HasSecondaryPickupAddress == false {
-		shipment.SecondaryPickupAddress = nil
-	} else if payload.HasSecondaryPickupAddress == true {
-		if payload.SecondaryPickupAddress != nil {
-			if shipment.SecondaryPickupAddress == nil {
-				shipment.SecondaryPickupAddress = addressModelFromPayload(payload.SecondaryPickupAddress)
-			} else {
-				updateAddressWithPayload(shipment.SecondaryPickupAddress, payload.SecondaryPickupAddress)
-			}
-		}
-	}
-	shipment.HasSecondaryPickupAddress = payload.HasSecondaryPickupAddress
-	if payload.HasDeliveryAddress == false {
-		shipment.DeliveryAddress = nil
-	} else if payload.HasDeliveryAddress == true {
-		if payload.DeliveryAddress != nil {
-			if shipment.DeliveryAddress == nil {
-				shipment.DeliveryAddress = addressModelFromPayload(payload.DeliveryAddress)
-			} else {
-				updateAddressWithPayload(shipment.DeliveryAddress, payload.DeliveryAddress)
-			}
-		}
-	}
-	shipment.HasDeliveryAddress = payload.HasDeliveryAddress
 
-	if payload.HasPartialSitDeliveryAddress == false {
-		shipment.PartialSITDeliveryAddress = nil
-	} else if payload.HasPartialSitDeliveryAddress == true {
-		if payload.PartialSitDeliveryAddress != nil {
-			if shipment.PartialSITDeliveryAddress == nil {
-				shipment.PartialSITDeliveryAddress = addressModelFromPayload(payload.PartialSitDeliveryAddress)
-			} else {
-				updateAddressWithPayload(shipment.PartialSITDeliveryAddress, payload.PartialSitDeliveryAddress)
+	if payload.HasSecondaryPickupAddress != nil {
+		if *payload.HasSecondaryPickupAddress == false {
+			shipment.SecondaryPickupAddress = nil
+		} else if *payload.HasSecondaryPickupAddress == true {
+			if payload.SecondaryPickupAddress != nil {
+				if shipment.SecondaryPickupAddress == nil {
+					shipment.SecondaryPickupAddress = addressModelFromPayload(payload.SecondaryPickupAddress)
+				} else {
+					updateAddressWithPayload(shipment.SecondaryPickupAddress, payload.SecondaryPickupAddress)
+				}
 			}
 		}
+		shipment.HasSecondaryPickupAddress = *payload.HasSecondaryPickupAddress
 	}
-	shipment.HasPartialSITDeliveryAddress = payload.HasPartialSitDeliveryAddress
+
+	if payload.HasDeliveryAddress != nil {
+		if *payload.HasDeliveryAddress == false {
+			shipment.DeliveryAddress = nil
+		} else if *payload.HasDeliveryAddress == true {
+			if payload.DeliveryAddress != nil {
+				if shipment.DeliveryAddress == nil {
+					shipment.DeliveryAddress = addressModelFromPayload(payload.DeliveryAddress)
+				} else {
+					updateAddressWithPayload(shipment.DeliveryAddress, payload.DeliveryAddress)
+				}
+			}
+		}
+		shipment.HasDeliveryAddress = *payload.HasDeliveryAddress
+	}
+
+	if payload.HasPartialSitDeliveryAddress != nil {
+		if *payload.HasPartialSitDeliveryAddress == false {
+			shipment.PartialSITDeliveryAddress = nil
+		} else if *payload.HasPartialSitDeliveryAddress == true {
+			if payload.PartialSitDeliveryAddress != nil {
+				if shipment.PartialSITDeliveryAddress == nil {
+					shipment.PartialSITDeliveryAddress = addressModelFromPayload(payload.PartialSitDeliveryAddress)
+				} else {
+					updateAddressWithPayload(shipment.PartialSITDeliveryAddress, payload.PartialSitDeliveryAddress)
+				}
+			}
+		}
+		shipment.HasPartialSITDeliveryAddress = *payload.HasPartialSitDeliveryAddress
+	}
 
 	if payload.WeightEstimate != nil {
 		shipment.WeightEstimate = handlers.PoundPtrFromInt64Ptr(payload.WeightEstimate)

--- a/pkg/handlers/internalapi/shipments.go
+++ b/pkg/handlers/internalapi/shipments.go
@@ -123,6 +123,21 @@ func (h CreateShipmentHandler) Handle(params shipmentop.CreateShipmentParams) mi
 		requestedPickupDate = &date
 	}
 
+	hasSecondaryPickupAddress := false
+	if payload.HasSecondaryPickupAddress != nil {
+		hasSecondaryPickupAddress = *payload.HasSecondaryPickupAddress
+	}
+
+	hasDeliveryAddress := false
+	if payload.HasDeliveryAddress != nil {
+		hasDeliveryAddress = *payload.HasDeliveryAddress
+	}
+
+	hasPartialSitDeliveryAddress := false
+	if payload.HasPartialSitDeliveryAddress != nil {
+		hasPartialSitDeliveryAddress = *payload.HasPartialSitDeliveryAddress
+	}
+
 	newShipment := models.Shipment{
 		MoveID:                       move.ID,
 		ServiceMemberID:              session.ServiceMemberID,
@@ -134,11 +149,11 @@ func (h CreateShipmentHandler) Handle(params shipmentop.CreateShipmentParams) mi
 		ProgearWeightEstimate:        handlers.PoundPtrFromInt64Ptr(payload.ProgearWeightEstimate),
 		SpouseProgearWeightEstimate:  handlers.PoundPtrFromInt64Ptr(payload.SpouseProgearWeightEstimate),
 		PickupAddress:                pickupAddress,
-		HasSecondaryPickupAddress:    *payload.HasSecondaryPickupAddress,
+		HasSecondaryPickupAddress:    hasSecondaryPickupAddress,
 		SecondaryPickupAddress:       secondaryPickupAddress,
-		HasDeliveryAddress:           *payload.HasDeliveryAddress,
+		HasDeliveryAddress:           hasDeliveryAddress,
 		DeliveryAddress:              deliveryAddress,
-		HasPartialSITDeliveryAddress: *payload.HasPartialSitDeliveryAddress,
+		HasPartialSITDeliveryAddress: hasPartialSitDeliveryAddress,
 		PartialSITDeliveryAddress:    partialSITDeliveryAddress,
 		Market: &market,
 	}

--- a/pkg/handlers/internalapi/shipments_test.go
+++ b/pkg/handlers/internalapi/shipments_test.go
@@ -55,11 +55,11 @@ func (suite *HandlerSuite) TestCreateShipmentHandlerAllValues() {
 
 	newShipment := internalmessages.Shipment{
 		PickupAddress:                addressPayload,
-		HasSecondaryPickupAddress:    true,
+		HasSecondaryPickupAddress:    handlers.FmtBool(true),
 		SecondaryPickupAddress:       addressPayload,
-		HasDeliveryAddress:           true,
+		HasDeliveryAddress:           handlers.FmtBool(true),
 		DeliveryAddress:              addressPayload,
-		HasPartialSitDeliveryAddress: true,
+		HasPartialSitDeliveryAddress: handlers.FmtBool(true),
 		PartialSitDeliveryAddress:    addressPayload,
 		WeightEstimate:               swag.Int64(4500),
 		ProgearWeightEstimate:        swag.Int64(325),
@@ -94,11 +94,11 @@ func (suite *HandlerSuite) TestCreateShipmentHandlerAllValues() {
 	suite.EqualValues(3, *createShipmentPayload.EstimatedPackDays)
 	suite.EqualValues(12, *createShipmentPayload.EstimatedTransitDays)
 	suite.verifyAddressFields(addressPayload, createShipmentPayload.PickupAddress)
-	suite.Equal(true, createShipmentPayload.HasSecondaryPickupAddress)
+	suite.Equal(true, *createShipmentPayload.HasSecondaryPickupAddress)
 	suite.verifyAddressFields(addressPayload, createShipmentPayload.SecondaryPickupAddress)
-	suite.Equal(true, createShipmentPayload.HasDeliveryAddress)
+	suite.Equal(true, *createShipmentPayload.HasDeliveryAddress)
 	suite.verifyAddressFields(addressPayload, createShipmentPayload.DeliveryAddress)
-	suite.Equal(true, createShipmentPayload.HasPartialSitDeliveryAddress)
+	suite.Equal(true, *createShipmentPayload.HasPartialSitDeliveryAddress)
 	suite.verifyAddressFields(addressPayload, createShipmentPayload.PartialSitDeliveryAddress)
 	suite.Equal(swag.Int64(4500), createShipmentPayload.WeightEstimate)
 	suite.Equal(swag.Int64(325), createShipmentPayload.ProgearWeightEstimate)
@@ -154,11 +154,11 @@ func (suite *HandlerSuite) TestCreateShipmentHandlerEmpty() {
 	suite.Nil(unwrapped.Payload.ActualPickupDate)
 	suite.Nil(unwrapped.Payload.ActualDeliveryDate)
 	suite.Nil(unwrapped.Payload.PickupAddress)
-	suite.Equal(false, unwrapped.Payload.HasSecondaryPickupAddress)
+	suite.Equal(false, *unwrapped.Payload.HasSecondaryPickupAddress)
 	suite.Nil(unwrapped.Payload.SecondaryPickupAddress)
-	suite.Equal(false, unwrapped.Payload.HasDeliveryAddress)
+	suite.Equal(false, *unwrapped.Payload.HasDeliveryAddress)
 	suite.Nil(unwrapped.Payload.DeliveryAddress)
-	suite.Equal(false, unwrapped.Payload.HasPartialSitDeliveryAddress)
+	suite.Equal(false, *unwrapped.Payload.HasPartialSitDeliveryAddress)
 	suite.Nil(unwrapped.Payload.PartialSitDeliveryAddress)
 	suite.Nil(unwrapped.Payload.WeightEstimate)
 	suite.Nil(unwrapped.Payload.ProgearWeightEstimate)
@@ -207,8 +207,8 @@ func (suite *HandlerSuite) TestPatchShipmentsHandlerHappyPath() {
 	newAddress := otherFakeAddressPayload()
 
 	payload := internalmessages.Shipment{
-		HasSecondaryPickupAddress:   false,
-		HasDeliveryAddress:          true,
+		HasSecondaryPickupAddress:   handlers.FmtBool(false),
+		HasDeliveryAddress:          handlers.FmtBool(true),
 		DeliveryAddress:             newAddress,
 		SpouseProgearWeightEstimate: swag.Int64(100),
 	}
@@ -226,10 +226,10 @@ func (suite *HandlerSuite) TestPatchShipmentsHandlerHappyPath() {
 	okResponse := response.(*shipmentop.PatchShipmentOK)
 	patchShipmentPayload := okResponse.Payload
 
-	suite.Equal(patchShipmentPayload.HasDeliveryAddress, true, "HasDeliveryAddress should have been updated.")
+	suite.Equal(*patchShipmentPayload.HasDeliveryAddress, true, "HasDeliveryAddress should have been updated.")
 	suite.verifyAddressFields(newAddress, patchShipmentPayload.DeliveryAddress)
 
-	suite.Equal(patchShipmentPayload.HasSecondaryPickupAddress, false, "HasSecondaryPickupAddress should have been updated.")
+	suite.Equal(*patchShipmentPayload.HasSecondaryPickupAddress, false, "HasSecondaryPickupAddress should have been updated.")
 	suite.Nil(patchShipmentPayload.SecondaryPickupAddress, "SecondaryPickupAddress should have been updated to nil.")
 
 	suite.Equal(*patchShipmentPayload.SpouseProgearWeightEstimate, int64(100), "SpouseProgearWeightEstimate should have been set to 100")

--- a/pkg/handlers/publicapi/shipments.go
+++ b/pkg/handlers/publicapi/shipments.go
@@ -50,11 +50,11 @@ func payloadForShipmentModel(s models.Shipment) *apimessages.Shipment {
 
 		// addresses
 		PickupAddress:                payloadForAddressModel(s.PickupAddress),
-		HasSecondaryPickupAddress:    s.HasSecondaryPickupAddress,
+		HasSecondaryPickupAddress:    handlers.FmtBool(s.HasSecondaryPickupAddress),
 		SecondaryPickupAddress:       payloadForAddressModel(s.SecondaryPickupAddress),
-		HasDeliveryAddress:           s.HasDeliveryAddress,
+		HasDeliveryAddress:           handlers.FmtBool(s.HasDeliveryAddress),
 		DeliveryAddress:              payloadForAddressModel(s.DeliveryAddress),
-		HasPartialSitDeliveryAddress: s.HasPartialSITDeliveryAddress,
+		HasPartialSitDeliveryAddress: handlers.FmtBool(s.HasPartialSITDeliveryAddress),
 		PartialSitDeliveryAddress:    payloadForAddressModel(s.PartialSITDeliveryAddress),
 
 		// weights
@@ -447,30 +447,50 @@ func patchShipmentWithPayload(shipment *models.Shipment, payload *apimessages.Sh
 			updateAddressWithPayload(shipment.PickupAddress, payload.PickupAddress)
 		}
 	}
-	if payload.HasSecondaryPickupAddress == false {
-		shipment.SecondaryPickupAddress = nil
-	} else if payload.HasSecondaryPickupAddress == true {
-		if payload.SecondaryPickupAddress != nil {
-			if shipment.SecondaryPickupAddress == nil {
-				shipment.SecondaryPickupAddress = addressModelFromPayload(payload.SecondaryPickupAddress)
-			} else {
-				updateAddressWithPayload(shipment.SecondaryPickupAddress, payload.SecondaryPickupAddress)
+	if payload.HasSecondaryPickupAddress != nil {
+		if *payload.HasSecondaryPickupAddress == false {
+			shipment.SecondaryPickupAddress = nil
+		} else if *payload.HasSecondaryPickupAddress == true {
+			if payload.SecondaryPickupAddress != nil {
+				if shipment.SecondaryPickupAddress == nil {
+					shipment.SecondaryPickupAddress = addressModelFromPayload(payload.SecondaryPickupAddress)
+				} else {
+					updateAddressWithPayload(shipment.SecondaryPickupAddress, payload.SecondaryPickupAddress)
+				}
 			}
 		}
+		shipment.HasSecondaryPickupAddress = *payload.HasSecondaryPickupAddress
 	}
-	shipment.HasSecondaryPickupAddress = payload.HasSecondaryPickupAddress
-	if payload.HasDeliveryAddress == false {
-		shipment.DeliveryAddress = nil
-	} else if payload.HasDeliveryAddress == true {
-		if payload.DeliveryAddress != nil {
-			if shipment.DeliveryAddress == nil {
-				shipment.DeliveryAddress = addressModelFromPayload(payload.DeliveryAddress)
-			} else {
-				updateAddressWithPayload(shipment.DeliveryAddress, payload.DeliveryAddress)
+
+	if payload.HasDeliveryAddress != nil {
+		if *payload.HasDeliveryAddress == false {
+			shipment.DeliveryAddress = nil
+		} else if *payload.HasDeliveryAddress == true {
+			if payload.DeliveryAddress != nil {
+				if shipment.DeliveryAddress == nil {
+					shipment.DeliveryAddress = addressModelFromPayload(payload.DeliveryAddress)
+				} else {
+					updateAddressWithPayload(shipment.DeliveryAddress, payload.DeliveryAddress)
+				}
 			}
 		}
+		shipment.HasDeliveryAddress = *payload.HasDeliveryAddress
 	}
-	shipment.HasDeliveryAddress = payload.HasDeliveryAddress
+
+	if payload.HasPartialSitDeliveryAddress != nil {
+		if *payload.HasPartialSitDeliveryAddress == false {
+			shipment.PartialSITDeliveryAddress = nil
+		} else if *payload.HasPartialSitDeliveryAddress == true {
+			if payload.PartialSitDeliveryAddress != nil {
+				if shipment.PartialSITDeliveryAddress == nil {
+					shipment.PartialSITDeliveryAddress = addressModelFromPayload(payload.PartialSitDeliveryAddress)
+				} else {
+					updateAddressWithPayload(shipment.PartialSITDeliveryAddress, payload.PartialSitDeliveryAddress)
+				}
+			}
+		}
+		shipment.HasPartialSITDeliveryAddress = *payload.HasPartialSitDeliveryAddress
+	}
 }
 
 // PatchShipmentHandler allows a TSP to refuse a particular shipment

--- a/swagger/api.yaml
+++ b/swagger/api.yaml
@@ -933,7 +933,6 @@ definitions:
       has_secondary_pickup_address:
         type: boolean
         default: false
-        x-nullable: false
         title: 'Do you have household goods at any other pickup location?'
       secondary_pickup_address:
         $ref: '#/definitions/Address'
@@ -941,7 +940,6 @@ definitions:
       has_delivery_address:
         type: boolean
         default: false
-        x-nullable: false
         title: 'Do you know the delivery address at destination yet?'
       delivery_address:
         $ref: '#/definitions/Address'
@@ -949,7 +947,6 @@ definitions:
       has_partial_sit_delivery_address:
         type: boolean
         default: false
-        x-nullable: false
         title: 'Will some of your items be stored in transit?'
       partial_sit_delivery_address:
         $ref: '#/definitions/Address'
@@ -1064,10 +1061,6 @@ definitions:
           IN_PERSON: In person
           PHONE: Phone
           VIDEO: Video
-    required:
-      - has_secondary_pickup_address
-      - has_delivery_address
-      - has_partial_sit_delivery_address
   IndexServiceAgents:
     type: array
     items:

--- a/swagger/api.yaml
+++ b/swagger/api.yaml
@@ -1064,6 +1064,10 @@ definitions:
           IN_PERSON: In person
           PHONE: Phone
           VIDEO: Video
+    required:
+      - has_secondary_pickup_address
+      - has_delivery_address
+      - has_partial_sit_delivery_address
   IndexServiceAgents:
     type: array
     items:

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -1640,6 +1640,10 @@ definitions:
       updated_at:
         type: string
         format: date-time
+    required:
+      - has_secondary_pickup_address
+      - has_delivery_address
+      - has_partial_sit_delivery_address
   ServiceAgentRole:
     type: string
     title: Service Agent Role

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -1523,17 +1523,14 @@ definitions:
       has_secondary_pickup_address:
         type: boolean
         default: false
-        x-nullable: false
         title: 'Do you have household goods at any other pickup location?'
       has_delivery_address:
         type: boolean
         default: false
-        x-nullable: false
         title: 'Do you know your home address at your destination yet?'
       has_partial_sit_delivery_address:
         type: boolean
         default: false
-        x-nullable: false
         title: 'Do you know the delivery address at destination yet?'
       weight_estimate:
         type: integer
@@ -1640,10 +1637,6 @@ definitions:
       updated_at:
         type: string
         format: date-time
-    required:
-      - has_secondary_pickup_address
-      - has_delivery_address
-      - has_partial_sit_delivery_address
   ServiceAgentRole:
     type: string
     title: Service Agent Role


### PR DESCRIPTION
## Description

Apparently after #1207 the fields stopped showing up.  Probably because of `x-nullable: false` was added.  This should fix it.

## Setup

Use setup from #1207

## Code Review Verification Steps

* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?