### PR TITLE
Fix bug to view docs in second shipment

### DIFF
--- a/cypress/integration/tsp/documentViewer.js
+++ b/cypress/integration/tsp/documentViewer.js
@@ -38,11 +38,44 @@ describe('The document viewer', function() {
       .and('match', /^\/shipments\/[^/]+\/documents\/new/);
   });
 
+  it('shows current shipment docs after viewing a shipment with no docs', () => {
+    // Find a shipment with no docs
+    cy.visit('/shipments/65e00326-420e-436a-89fc-6aeb3f90b870', {
+      log: true,
+    });
+
+    cy
+      .get('.documents > .status')
+      .contains('Upload new document')
+      .should('have.attr', 'href')
+      .and('match', /^\/shipments\/[^/]+\/documents\/new/);
+
+    cy.visit('/queues/approved/'),
+      {
+        log: true,
+      };
+
+    // Find a shipment with a doc
+    cy
+      .get('div')
+      .contains('GOTDOC')
+      .dblclick();
+
+    cy.location().should(loc => {
+      expect(loc.pathname).to.match(/^\/shipments\/[^/]+/);
+    });
+
+    cy
+      .get('.documents > .status')
+      .should('have.attr', 'href')
+      .and('match', /^\/shipments\/[^/]+\/documents\/[^/]+/);
+  });
+
   it('can upload a new document', () => {
     cy.visit('/shipments/65e00326-420e-436a-89fc-6aeb3f90b870/documents/new', {
       log: true,
     });
-    cy.contains('Upload a new document');
+
     cy.get('button.submit').should('be.disabled');
     cy.get('input[name="title"]').type('super secret info document');
     cy.get('select[name="move_document_type"]').select('Other document type');

--- a/pkg/testdatagen/scenario/e2ebasic.go
+++ b/pkg/testdatagen/scenario/e2ebasic.go
@@ -1228,6 +1228,59 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader) {
 	hhg20 := offer20.Shipment
 	hhg20.Move.Submit()
 	models.SaveMoveDependencies(db, &hhg20.Move)
+
+	/* Service member with a doc for testing on TSP side
+	 */
+	email = "doc.owner@tsp.org"
+
+	offer21 := testdatagen.MakeShipmentOffer(db, testdatagen.Assertions{
+		User: models.User{
+			ID:            uuid.Must(uuid.FromString("99bdaeed-a8a8-492e-9e28-7d0da6b1c907")),
+			LoginGovEmail: email,
+		},
+		ServiceMember: models.ServiceMember{
+			ID:            uuid.FromStringOrNil("61473913-36b8-425d-b46a-cee488a4ae71"),
+			FirstName:     models.StringPointer("HHG"),
+			LastName:      models.StringPointer("Submitted"),
+			Edipi:         models.StringPointer("2232332334"),
+			PersonalEmail: models.StringPointer(email),
+		},
+		Move: models.Move{
+			ID:               uuid.FromStringOrNil("60098ff1-8dc9-4318-a2e8-47bc8aac11a4"),
+			Locator:          "GOTDOC",
+			SelectedMoveType: models.StringPointer("HHG"),
+		},
+		TrafficDistributionList: models.TrafficDistributionList{
+			ID:                uuid.FromStringOrNil("7ad595da-9b34-4914-aeaa-9a540d13872f"),
+			SourceRateArea:    "US62",
+			DestinationRegion: "11",
+			CodeOfService:     "D",
+		},
+		Shipment: models.Shipment{
+			Status:             models.ShipmentStatusAPPROVED,
+			ActualDeliveryDate: nil,
+		},
+		ShipmentOffer: models.ShipmentOffer{
+			TransportationServiceProviderID: tspUser.TransportationServiceProviderID,
+			Accepted:                        models.BoolPointer(true),
+		},
+		Document: models.Document{
+			ID:              uuid.FromStringOrNil("06886210-b151-4b15-951a-783d3d58f042"),
+			ServiceMemberID: uuid.FromStringOrNil("61473913-36b8-425d-b46a-cee488a4ae71"),
+		},
+		MoveDocument: models.MoveDocument{
+			ID:               uuid.FromStringOrNil("b660080d-0158-4214-99ca-216f82b26b3c"),
+			DocumentID:       uuid.FromStringOrNil("06886210-b151-4b15-951a-783d3d58f042"),
+			MoveDocumentType: "WEIGHT_TICKET",
+			Status:           "OK",
+			MoveID:           uuid.FromStringOrNil("60098ff1-8dc9-4318-a2e8-47bc8aac11a4"),
+			Title:            "document_title",
+		},
+	})
+
+	hhg21 := offer21.Shipment
+	hhg21.Move.Submit()
+	models.SaveMoveDependencies(db, &hhg21.Move)
 }
 
 // MakeHhgFromAwardedToAcceptedGBLReady creates a scenario for an approved shipment ready for GBL generation

--- a/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
+++ b/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
@@ -150,7 +150,7 @@ class ShipmentInfo extends Component {
   }
 
   componentDidUpdate(prevProps, prevState) {
-    if (!prevProps.shipment.id && this.props.shipment.id) {
+    if ((!prevProps.shipment.id && this.props.shipment.id) || prevProps.shipment.id !== this.props.shipment.id) {
       this.props.getAllShipmentDocuments(getShipmentDocumentsLabel, this.props.shipment.id);
       this.props.getAllTariff400ngItems(true, getTariff400ngItemsLabel);
       this.props.getAllShipmentAccessorials(getShipmentAccessorialsLabel, this.props.shipment.id);


### PR DESCRIPTION
## Description

Previously when viewing a shipment with documents after viewing a shipment without documents as a tsp user, the documents wouldn't show up in the document list.

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make db_dev_reset && make db_dev_run && make db_dev_migrate && go run cmd/generate_test_data/main.go -scenario=7
```

## Code Review Verification Steps

* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* [Load docs for different shipment](https://www.pivotaltracker.com/story/show/161358315) for this change

## Screenshots

![movedocsshowup](https://user-images.githubusercontent.com/5531789/47385912-366d5580-d6c0-11e8-9e32-0e3a4db566ff.gif)

