### PR TITLE
Clear the accessorial drop down value when PAR form is submitted

### DIFF
--- a/src/shared/PreApprovalRequest/PreApprovalForm.jsx
+++ b/src/shared/PreApprovalRequest/PreApprovalForm.jsx
@@ -9,7 +9,7 @@ import { SwaggerField } from 'shared/JsonSchemaForm/JsonSchemaField';
 
 import './PreApprovalRequest.css';
 
-const getOptionValue = option => (option ? option.id : '');
+const getOptionValue = option => (option ? option.id : null);
 const getOptionLabel = option => (option ? option.code + ' ' + option.item : '');
 const stringify = option => option.label;
 const filterOption = createFilter({ ignoreCase: true, stringify });
@@ -37,12 +37,13 @@ export class Tariff400ngItemSearch extends Component {
           options={this.props.tariff400ngItems}
           getOptionLabel={getOptionLabel}
           getOptionValue={getOptionValue}
+          value={this.props.input.value || null}
           onChange={this.localOnChange}
           placeholder="Select an item..."
           className="tariff400-select"
           classNamePrefix="tariff400"
           filterOption={filterOption}
-          defaultValue={this.props.meta.initial}
+          defaultValue={this.props.meta.initial || null}
         />
       </Fragment>
     );


### PR DESCRIPTION
## Description

Currently, the accessorial drop down selection doesn't clear and the form is not reset to disabled when the PAR form is submitted. This fixes that.

## Setup

Enter a Pre approval request in the office app. Confirm that the upon submission, all fields are cleared and the form submit button is disabled.

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](./docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](./docs/backend.md#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](./docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
* [ ] There are no aXe warnings for UI.
* [ ] This works in IE.
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @willowbl00
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/161400379) for this change

