### PR TITLE
Import trial TSPs

### DIFF
--- a/local_migrations/20181023003944_import_trial_tsps.sql
+++ b/local_migrations/20181023003944_import_trial_tsps.sql
@@ -2,6 +2,20 @@
 -- This will be run on development environments. It should mirror what you
 -- intend to apply on production, but do not include any sensitive data.
 
+-- Update the Truss TSP contact info
+
+UPDATE transportation_service_providers
+SET
+    name = 'Truss Transit Services',
+    supplier_id = 'TRS1337',
+    poc_general_name = 'Curt Trussel',
+    poc_general_email = 'test@example.com',
+    poc_general_phone = '(555) 123-4567',
+    poc_claims_name = 'Party Parrot',
+    poc_claims_email = 'test@example.com',
+    poc_claims_phone = '(555) 321-4321'
+WHERE standard_carrier_alpha_code = 'TRS1';
+
 -- Enroll TSPs in the HHG program and add data
 -- "supplier_id" fields do not match production fields
 

--- a/local_migrations/20181023003944_import_trial_tsps.sql
+++ b/local_migrations/20181023003944_import_trial_tsps.sql
@@ -1,0 +1,47 @@
+-- Local test migration.
+-- This will be run on development environments. It should mirror what you
+-- intend to apply on production, but do not include any sensitive data.
+
+-- Enroll TSPs in the HHG program and add data
+-- "supplier_id" fields do not match production fields
+
+UPDATE transportation_service_providers
+SET
+	enrolled = true,
+	name = 'Planetary Van Lines, LLC',
+	supplier_id = 'PYVL1234',
+	poc_general_name = 'Joey Jupiter',
+	poc_general_email = 'j.jupiter@example.com',
+	poc_general_phone = '(555) 123-4567',
+	poc_claims_name = 'Chaim Calypso',
+	poc_claims_email = 'claims@example.com',
+	poc_claims_phone = '(555) 765-4321'
+WHERE standard_carrier_alpha_code = 'PYVL';
+
+UPDATE transportation_service_providers
+SET
+	enrolled = true,
+	name = 'Green Chip LLC dba D’Lux Moving and Storage',
+	supplier_id = 'DLXM1234',
+	poc_general_name = 'Gary Green',
+	poc_general_email = 'g.green@example.com',
+	poc_general_phone = '(555) 124-8163',
+	poc_claims_name = 'Cassandra Gregory',
+	poc_claims_email = 'claims@example.com',
+	poc_claims_phone = '(555) 264-1282'
+WHERE standard_carrier_alpha_code = 'DLXM';
+
+UPDATE transportation_service_providers
+SET
+	enrolled = true,
+	name = 'Secure Storage Company of Washington, LLC',
+	supplier_id = 'SSOW1234',
+	poc_general_name = 'Seth Stallone',
+	poc_general_email = 's.stallone@example.com',
+	poc_general_phone = '(555) 101-0101',
+	poc_claims_name = 'Charlotte Salsbury',
+	poc_claims_email = 'claims@example.com',
+	poc_claims_phone = '(555) 111-0000'
+WHERE standard_carrier_alpha_code = 'SSOW';
+
+

--- a/migrations/20181023002728_add_tsp_fields.up.fizz
+++ b/migrations/20181023002728_add_tsp_fields.up.fizz
@@ -1,0 +1,10 @@
+add_column("transportation_service_providers", "name", "text", {null: true})
+add_column("transportation_service_providers", "supplier_id", "text", {null: true})
+
+add_column("transportation_service_providers", "poc_general_name", "text", {null: true})
+add_column("transportation_service_providers", "poc_general_email", "text", {null: true})
+add_column("transportation_service_providers", "poc_general_phone", "text", {null: true})
+
+add_column("transportation_service_providers", "poc_claims_name", "text", {null: true})
+add_column("transportation_service_providers", "poc_claims_email", "text", {null: true})
+add_column("transportation_service_providers", "poc_claims_phone", "text", {null: true})

--- a/migrations/20181023003944_import_trial_tsps.up.fizz
+++ b/migrations/20181023003944_import_trial_tsps.up.fizz
@@ -1,0 +1,1 @@
+exec("./apply-secure-migration.sh 20181023003944_import_trial_tsps.sql")


### PR DESCRIPTION
## Description

This is a [secure migration](https://github.com/transcom/mymove/blob/master/docs/database.md#secure-migrations) to import the three HHG trial TSPs. It also adds contact fields to the TSP model.

To test:
* Run `bin/run-prod-migrations` to load the production data set into your local postgres
* Connect to the `prod_migrations` database locally, and verify the data against what's in the [TSP info spreadsheet](https://docs.google.com/spreadsheets/d/1093jnF_IjxoEXrXLmwGI5ycm6LcyaQx4Q2ug5bt361w/edit#gid=0).
* Run `make db_dev_reset && make db_dev_migrate` and ensure that the test database doesn't contain real data.

## Code Review Verification Steps

* Any new migrations/schema changes:
  * [x] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](./docs/database.md#zero-downtime-migrations))
  * [x] Have been communicated to #dp3-engineering
* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/161271375) for this change
