### PR TITLE
Fix broken E2E test for move date calendar

### DIFF
--- a/cypress/integration/mymove/shipment.js
+++ b/cypress/integration/mymove/shipment.js
@@ -19,10 +19,23 @@ describe('completing the hhg flow', function() {
     cy.get('button.next').should('be.disabled');
 
     // Calendar move date
+
+    // Try to get today, which should be disabled even after clicked.  We may have to go back a month
+    // to find today since the calendar scrolls to the month with the first available move date.
     cy
-      .get('.DayPicker-Day--today') // gets today, which should be disabled even after clicked
-      .click()
-      .should('have.class', 'DayPicker-Day--disabled');
+      .get('body')
+      .then($body => {
+        if ($body.find('.DayPicker-Day--today').length === 0) {
+          cy.get('.DayPicker-NavButton--prev').click();
+        }
+      })
+      .then(() => {
+        cy
+          .get('.DayPicker-Day--today')
+          .first()
+          .click()
+          .should('have.class', 'DayPicker-Day--disabled');
+      });
 
     // We may or may not have an available date in the current month.  If not, then
     // we skip to the next month which should (at least at this point) have an available


### PR DESCRIPTION
## Description

This PR fixes a broken E2E test on the move date calendar.  It was looking to click today's date (October 24) but the calendar scrolls to the month with the first available date (which is November 1).  So, it failed because it couldn't find today's date (via a CSS class) on the current month's calendar.  To fix this, I go back a month if today's date isn't found on the current calendar.

## Setup

`make e2e_test`
Run `shipment.js`

## Code Review Verification Steps

* [ ] Request review from a member of a different team.

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/161439101) for this change
