### PR TITLE
Hide HHG review edit links.

### DIFF
--- a/src/scenes/Review/HHGShipmentSummary.jsx
+++ b/src/scenes/Review/HHGShipmentSummary.jsx
@@ -25,7 +25,7 @@ export default function HHGShipmentSummary(props) {
       <div className="usa-width-one-half review-section ppm-review-section">
         <p className="heading">
           Move Dates
-          <span className="edit-section-link">
+          <span className="not-implemented edit-section-link">
             {' '}
             <Link to={editDatePath}>Edit</Link>
           </span>
@@ -58,7 +58,7 @@ export default function HHGShipmentSummary(props) {
 
         <p className="heading">
           Your Stuff
-          <span className="edit-section-link">
+          <span className="not-implemented edit-section-link">
             {' '}
             <Link to={editWeightsPath}>Edit</Link>
           </span>
@@ -84,7 +84,7 @@ export default function HHGShipmentSummary(props) {
       <div className="usa-width-one-half review-section ppm-review-section">
         <p className="heading">
           Pickup &amp; Delivery Locations
-          <span className="edit-section-link">
+          <span className="not-implemented edit-section-link">
             {' '}
             <Link to={editLocationsPath}>Edit</Link>
           </span>

--- a/src/scenes/Review/HHGShipmentSummary.jsx
+++ b/src/scenes/Review/HHGShipmentSummary.jsx
@@ -18,9 +18,9 @@ export default function HHGShipmentSummary(props) {
   const editLocationsPath = movePath + '/edit-hhg-locations';
 
   return (
-    <div className="usa-grid-full ppm-container">
+    <div className="usa-grid-full ppm-container hhg-shipment-summary">
       <h3>
-        <img src={truckIcon} alt="PPM shipment" /> Shipment - Government moves all of your stuff (HHG)
+        <img src={truckIcon} alt="HHG shipment" /> Shipment - Government moves all of your stuff (HHG)
       </h3>
       <div className="usa-width-one-half review-section ppm-review-section">
         <p className="heading">

--- a/src/scenes/Review/Review.css
+++ b/src/scenes/Review/Review.css
@@ -89,6 +89,6 @@
   color: gray;
 }
 
-.not-implemented {
+.hhg-shipment-summary .not-implemented {
   display: none;
 }

--- a/src/scenes/Review/Review.css
+++ b/src/scenes/Review/Review.css
@@ -88,3 +88,7 @@
   margin-top: 2em;
   color: gray;
 }
+
+.not-implemented {
+  display: none;
+}


### PR DESCRIPTION
## Description

This PR hides the edit links in the HHG review panel. They will be added back when we have those edit screens complete.

## Setup

View the shipment review page for any HHG move.

## Code Review Verification Steps

* [ ] There are no aXe warnings for UI.
* [ ] This works in IE.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/161456532) for this change