### PR TITLE
Only assign quality band numbers to TSPP records if the TSP is enrolled

### DIFF
--- a/pkg/models/transportation_service_provider_performance.go
+++ b/pkg/models/transportation_service_provider_performance.go
@@ -200,12 +200,15 @@ func sortedMapIntKeys(mapWithIntKeys map[int]TransportationServiceProviderPerfor
 func FetchTSPPerformancesForQualityBandAssignment(tx *pop.Connection, perfGroup TSPPerformanceGroup, mps float64) (TransportationServiceProviderPerformances, error) {
 	var perfs TransportationServiceProviderPerformances
 	err := tx.
+		Select("transportation_service_provider_performances.*").
+		Join("transportation_service_providers AS tsp", "tsp.id = transportation_service_provider_performances.transportation_service_provider_id").
 		Where("traffic_distribution_list_id = ?", perfGroup.TrafficDistributionListID).
 		Where("performance_period_start = ?", perfGroup.PerformancePeriodStart).
 		Where("performance_period_end = ?", perfGroup.PerformancePeriodEnd).
 		Where("rate_cycle_start = ?", perfGroup.RateCycleStart).
 		Where("rate_cycle_end = ?", perfGroup.RateCycleEnd).
 		Where("best_value_score > ?", mps).
+		Where("enrolled = true").
 		Order("best_value_score DESC").
 		All(&perfs)
 


### PR DESCRIPTION
## Description

Before shipments can be awarded, we assign quality bands to TSPPerformance records. This takes a long time, so we are narrowing down the work to only TSPP records for which the `tsp.enrolled = true`.

This PR extends the work of a previous PR. The previous PR would find TDLs that had enrolled TSPs, but then give _every_ TSP in that TDL a quality band number. This further refines the process to only giving quality band numbers to enrolled TSPs in those TDLs.
## Code Review Verification Steps

* [x] Code follows the guidelines for [Logging](./docs/backend.md#logging)
* [x] The requirements listed in
 [Querying the Database Safely](./docs/backend.md#querying-the-database-safely)
 have been satisfied.