### PR TITLE
Add new office users secure migration

### DIFF
--- a/local_migrations/20181023231419_add_new_office_users_prod.sql
+++ b/local_migrations/20181023231419_add_new_office_users_prod.sql
@@ -1,0 +1,15 @@
+-- Local test migration.
+-- This will be run on development environments. It should mirror what you
+-- intend to apply on production, but do not include any sensitive data.
+
+INSERT INTO public.office_users VALUES (uuid_generate_v4(), NULL, 'Test', 'test33', NULL, 'test33@example.com', '', '0931a9dc-c1fd-444a-b138-6e1986b1714c', now(), now());
+INSERT INTO public.office_users VALUES (uuid_generate_v4(), NULL, 'Test', 'test34', NULL, 'test34@example.com', '', '0931a9dc-c1fd-444a-b138-6e1986b1714c', now(), now());
+INSERT INTO public.office_users VALUES (uuid_generate_v4(), NULL, 'Test', 'test35', NULL, 'test35@example.com', '', '0931a9dc-c1fd-444a-b138-6e1986b1714c', now(), now());
+INSERT INTO public.office_users VALUES (uuid_generate_v4(), NULL, 'Test', 'test36', NULL, 'test36@example.com', '', '0931a9dc-c1fd-444a-b138-6e1986b1714c', now(), now());
+INSERT INTO public.office_users VALUES (uuid_generate_v4(), NULL, 'Test', 'test37', NULL, 'test37@example.com', '', '0931a9dc-c1fd-444a-b138-6e1986b1714c', now(), now());
+INSERT INTO public.office_users VALUES (uuid_generate_v4(), NULL, 'Test', 'test38', NULL, 'test38@example.com', '', '0931a9dc-c1fd-444a-b138-6e1986b1714c', now(), now());
+INSERT INTO public.office_users VALUES (uuid_generate_v4(), NULL, 'Test', 'test39', NULL, 'test39@example.com', '', '0931a9dc-c1fd-444a-b138-6e1986b1714c', now(), now());
+INSERT INTO public.office_users VALUES (uuid_generate_v4(), NULL, 'Test', 'test40', NULL, 'test40@example.com', '', '0931a9dc-c1fd-444a-b138-6e1986b1714c', now(), now());
+INSERT INTO public.office_users VALUES (uuid_generate_v4(), NULL, 'Test', 'test41', NULL, 'test41@example.com', '', '0931a9dc-c1fd-444a-b138-6e1986b1714c', now(), now());
+INSERT INTO public.office_users VALUES (uuid_generate_v4(), NULL, 'Test', 'test42', NULL, 'test42@example.com', '', '525af4ce-3656-4ec6-a23d-2df6b4f39b64', now(), now());
+INSERT INTO public.office_users VALUES (uuid_generate_v4(), NULL, 'Test', 'test43', NULL, 'test43@example.com', '', '525af4ce-3656-4ec6-a23d-2df6b4f39b64', now(), now());

--- a/migrations/20181023231419_add_new_office_users_prod.up.fizz
+++ b/migrations/20181023231419_add_new_office_users_prod.up.fizz
@@ -1,0 +1,1 @@
+exec("./apply-secure-migration.sh 20181023231419_add_new_office_users_prod.sql")


### PR DESCRIPTION
## Description

This adds new office users per `https://defensedigitalservice.slack.com/archives/G8P7UD05U/p1540323822000100`.

## Setup

To run these migrations on your database and verify the data, run:

bin/run-prod-migrations, then inspect the prod_migrations database that was created in your local postgres.
You should see office_users for every person's last name, first name, and email from the slack message.

## Code Review Verification Steps

* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](./docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/161431933) for this change