### PR TITLE
Add loading state for Shipment Info

### DIFF
--- a/cypress/integration/tsp/premoveSurvey.js
+++ b/cypress/integration/tsp/premoveSurvey.js
@@ -54,8 +54,6 @@ function tspUserClicksEnterPreMoveSurvey() {
     .get('b')
     .contains('Approved');
 
-  cy.wait(5000);
-
   cy
     .get('button')
     .contains('Enter pre-move survey')

--- a/cypress/integration/tsp/shipShipment.js
+++ b/cypress/integration/tsp/shipShipment.js
@@ -21,7 +21,7 @@ describe('TSP User Ships a Shipment', function() {
 });
 
 function tspUserVerifiesShipmentStatus(status) {
-  cy.get('li').contains(`Status: ${status}`);
+  cy.get('.move-info-header-meta > li').contains(`Status: ${status}`);
 }
 
 function tspUserCancelsEnteringADeliveryDate() {

--- a/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
+++ b/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
@@ -8,6 +8,8 @@ import { NavLink, Link } from 'react-router-dom';
 import { reduxForm } from 'redux-form';
 import faPlusCircle from '@fortawesome/fontawesome-free-solid/faPlusCircle';
 
+import LoadingPlaceholder from 'shared/LoadingPlaceholder';
+
 import Alert from 'shared/Alert';
 import DocumentList from 'shared/DocumentViewer/DocumentList';
 import { withContext } from 'shared/AppContext';
@@ -226,6 +228,7 @@ class ShipmentInfo extends Component {
       generateGBLError,
       generateGBLInProgress,
       serviceAgents,
+      loadTspDependenciesHasSuccess,
     } = this.props;
     const {
       service_member: serviceMember = {},
@@ -257,6 +260,10 @@ class ShipmentInfo extends Component {
 
     if (this.state.redirectToHome) {
       return <Redirect to="/" />;
+    }
+
+    if (!loadTspDependenciesHasSuccess) {
+      return <LoadingPlaceholder />;
     }
 
     return (
@@ -366,16 +373,17 @@ class ShipmentInfo extends Component {
                     </button>
                   </div>
                 )}
-              {canAssignServiceAgents && (
-                <button className="usa-button-primary" onClick={this.toggleEditOriginServiceAgent}>
-                  Assign servicing agents
-                </button>
-              )}
               {canEnterPreMoveSurvey && (
                 <button className="usa-button-primary" onClick={this.toggleEditPreMoveSurvey}>
                   Enter pre-move survey
                 </button>
               )}
+              {canAssignServiceAgents && (
+                <button className="usa-button-primary" onClick={this.toggleEditOriginServiceAgent}>
+                  Assign servicing agents
+                </button>
+              )}
+
               {inTransit && (
                 <FormButton
                   FormComponent={DeliveryDateForm}


### PR DESCRIPTION
## Description

Add loading state to ShipmentInfo to have more predictable app snapshot states when testing and user no longer sees stub skeleton of ShipmentInfo page

## Setup
`make db_populate_e2e`
`make tsp_client_run`
`make server_run`
Go into any shipment

## Code Review Verification Steps
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/161465913) for this change

## Screenshots
![image](https://user-images.githubusercontent.com/13622298/47465256-0649b380-d7a1-11e8-88b6-cf7ee277c4fa.png)
