### PR TITLE
Skip a caller so that the logs contain something useful.

### DIFF
--- a/pkg/handlers/errors.go
+++ b/pkg/handlers/errors.go
@@ -53,27 +53,29 @@ func (o *ErrResponse) WriteResponse(rw http.ResponseWriter, producer runtime.Pro
 
 // ResponseForError logs an error and returns the expected error type
 func ResponseForError(logger *zap.Logger, err error) middleware.Responder {
+	// AddCallerSkip(1) prevents log statements from listing this file and func as the caller
+	skipLogger := logger.WithOptions(zap.AddCallerSkip(1))
 	switch errors.Cause(err) {
 	case models.ErrFetchNotFound:
-		logger.Debug("not found", zap.Error(err))
+		skipLogger.Debug("not found", zap.Error(err))
 		return newErrResponse(http.StatusNotFound, err)
 	case models.ErrFetchForbidden:
-		logger.Debug("forbidden", zap.Error(err))
+		skipLogger.Debug("forbidden", zap.Error(err))
 		return newErrResponse(http.StatusForbidden, err)
 	case models.ErrUserUnauthorized:
-		logger.Debug("unauthorized", zap.Error(err))
+		skipLogger.Debug("unauthorized", zap.Error(err))
 		return newErrResponse(http.StatusUnauthorized, err)
 	case uploaderpkg.ErrZeroLengthFile:
-		logger.Debug("uploaded zero length file", zap.Error(err))
+		skipLogger.Debug("uploaded zero length file", zap.Error(err))
 		return newErrResponse(http.StatusBadRequest, err)
 	case models.ErrInvalidPatchGate:
-		logger.Debug("invalid patch gate", zap.Error(err))
+		skipLogger.Debug("invalid patch gate", zap.Error(err))
 		return newErrResponse(http.StatusBadRequest, err)
 	case models.ErrInvalidTransition:
-		logger.Debug("invalid transition", zap.Error(err))
+		skipLogger.Debug("invalid transition", zap.Error(err))
 		return newErrResponse(http.StatusBadRequest, err)
 	default:
-		logger.Error("Unexpected error", zap.Error(err))
+		skipLogger.Error("Unexpected error", zap.Error(err))
 		return newErrResponse(http.StatusInternalServerError, err)
 	}
 }

--- a/pkg/handlers/errors.go
+++ b/pkg/handlers/errors.go
@@ -82,20 +82,22 @@ func ResponseForError(logger *zap.Logger, err error) middleware.Responder {
 
 // ResponseForVErrors checks for validation errors
 func ResponseForVErrors(logger *zap.Logger, verrs *validate.Errors, err error) middleware.Responder {
+	skipLogger := logger.WithOptions(zap.AddCallerSkip(1))
 	if verrs.HasAny() {
-		logger.Error("Encountered validation error", zap.Any("Validation errors", verrs.String()))
+		skipLogger.Error("Encountered validation error", zap.Any("Validation errors", verrs.String()))
 		errors := make(map[string]string)
 		for _, key := range verrs.Keys() {
 			errors[key] = strings.Join(verrs.Get(key), " ")
 		}
 		return newValidationErrorsResponse(errors)
 	}
-	return ResponseForError(logger, err)
+	return ResponseForError(skipLogger, err)
 }
 
 // ResponseForConflictErrors checks for conflict errors
 func ResponseForConflictErrors(logger *zap.Logger, err error) middleware.Responder {
-	logger.Error("Encountered conflict error", zap.Error(err))
+	skipLogger := logger.WithOptions(zap.AddCallerSkip(1))
+	skipLogger.WithOptions(zap.AddCallerSkip(1)).Error("Encountered conflict error", zap.Error(err))
 
 	return newErrResponse(http.StatusConflict, err)
 }

--- a/pkg/handlers/errors.go
+++ b/pkg/handlers/errors.go
@@ -97,7 +97,7 @@ func ResponseForVErrors(logger *zap.Logger, verrs *validate.Errors, err error) m
 // ResponseForConflictErrors checks for conflict errors
 func ResponseForConflictErrors(logger *zap.Logger, err error) middleware.Responder {
 	skipLogger := logger.WithOptions(zap.AddCallerSkip(1))
-	skipLogger.WithOptions(zap.AddCallerSkip(1)).Error("Encountered conflict error", zap.Error(err))
+	skipLogger.Error("Encountered conflict error", zap.Error(err))
 
 	return newErrResponse(http.StatusConflict, err)
 }


### PR DESCRIPTION
## Description

The default zap config for production includes the immediate caller for logger invocations. Here is an example of what you can find in the staging logs:

```json
{"level":"debug","ts":"2018-10-24T17:33:16.195-0500","caller":"handlers/errors.go:61","msg":"forbidden","error":"FETCH_FORBIDDEN"}
```

Unfortunately, `handlers/errors.go:61` is some general error-handling code. This makes it difficult to know where the logger was actually called for generic error messages such as one shown above. 

This PR configures the logger to ignore callers in shared code so that the caller logged points to the application code instead of shared error handling code.

Here is the output of the same log statement that was used above after this PR has been applied:

```json
{"level":"debug","ts":"2018-10-24T17:36:12.639-0500","caller":"internalapi/moves.go:102","msg":"forbidden","error":"FETCH_FORBIDDEN"}
```

`internalapi/moves.go:102` is the location within a handler where `ResponseForError` was originally called.

## Setup

The simplest way to test this is to replace `loggerConfig = zap.NewDevelopmentConfig()` on line 21 of `pkg/logger/log.go` with `loggerConfig = zap.NewProductionConfig()`.

I don't know why zap chose not to log the caller in its default development config.

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](./docs/backend.md#logging)
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/161162731) I was investigating when I discovered this issue