### PR TITLE
Add Enter Delivery help text and component tests

### DIFF
--- a/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
+++ b/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
@@ -121,13 +121,18 @@ let PackDateForm = props => {
 
 PackDateForm = reduxForm({ form: 'pack_date_shipment' })(PackDateForm);
 
-let DeliveryDateForm = props => {
+const DeliveryDateFormView = props => {
   const { schema, onCancel, handleSubmit, submitting, valid } = props;
 
   return (
     <form className="infoPanel-wizard" onSubmit={handleSubmit}>
       <div className="infoPanel-wizard-header">Enter Delivery</div>
       <SwaggerField fieldName="actual_delivery_date" swagger={schema} required />
+      <p className="infoPanel-wizard-help">
+        After clicking "Done", please upload the <strong>destination docs</strong>. Use the "Upload new document" link
+        in the Documents panel at right.
+      </p>
+
       <div className="infoPanel-wizard-actions-container">
         <a className="infoPanel-wizard-cancel" onClick={onCancel}>
           Cancel
@@ -140,7 +145,7 @@ let DeliveryDateForm = props => {
   );
 };
 
-DeliveryDateForm = reduxForm({ form: 'deliver_shipment' })(DeliveryDateForm);
+const DeliveryDateForm = reduxForm({ form: 'deliver_shipment' })(DeliveryDateFormView);
 
 // Action Buttons Conditions
 const hasOriginServiceAgent = (serviceAgents = []) => serviceAgents.some(agent => agent.role === 'ORIGIN');
@@ -508,4 +513,6 @@ const mapDispatchToProps = dispatch =>
     dispatch,
   );
 
-export default withContext(connect(mapStateToProps, mapDispatchToProps)(ShipmentInfo));
+const connectedShipmentInfo = withContext(connect(mapStateToProps, mapDispatchToProps)(ShipmentInfo));
+
+export { DeliveryDateFormView, connectedShipmentInfo as default };

--- a/src/scenes/TransportationServiceProvider/index.test.js
+++ b/src/scenes/TransportationServiceProvider/index.test.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { SwaggerField } from 'shared/JsonSchemaForm/JsonSchemaField';
+import { DeliveryDateFormView } from './ShipmentInfo';
+
+const defaultProps = {
+  schema: {},
+  onCancel() {},
+  handleSubmit() {},
+  submitting: false,
+  valid: false,
+};
+
+describe('DeliveryDateForm component test', () => {
+  describe('renders with the correct fields', () => {
+    const wrapper = shallow(<DeliveryDateFormView {...defaultProps} />);
+    it('should have a header', () => {
+      expect(wrapper.find('.infoPanel-wizard-header').text()).toEqual('Enter Delivery');
+    });
+    it('should have an actual delivery date swagger field', () => {
+      expect(wrapper.find(SwaggerField).props()).toEqual({
+        fieldName: 'actual_delivery_date',
+        swagger: defaultProps.schema,
+        required: true,
+      });
+    });
+    it('should have upload origin documents help text', () => {
+      expect(wrapper.find('.infoPanel-wizard-help').text()).toEqual(
+        'After clicking "Done", please upload the destination docs. Use the "Upload new document" link in the Documents panel at right.',
+      );
+    });
+    it('should have a cancel link', () => {
+      expect(wrapper.find('.infoPanel-wizard-cancel').text()).toEqual('Cancel');
+    });
+    it('should have a done button', () => {
+      expect(wrapper.find('.usa-button-primary').text()).toEqual('Done');
+    });
+  });
+});

--- a/src/scenes/TransportationServiceProvider/tsp.css
+++ b/src/scenes/TransportationServiceProvider/tsp.css
@@ -184,3 +184,7 @@
   justify-content: space-between;
   align-items: baseline;
 }
+
+.infoPanel-wizard .infoPanel-wizard-help {
+  margin-bottom: 0px;
+}


### PR DESCRIPTION
## Description

Add the Enter Delivery help text to enter delivery form

## Setup
`make db_populate_e2e`
`make server_run`
`make tsp_client_run`
1. Go into an in transit shipment
2. Click the "Enter Delivery" button

## Code Review Verification Steps
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/161456741) for this change. Wireframe included in the card description

## Screenshots

![image](https://user-images.githubusercontent.com/13622298/47466262-4f036b80-d7a5-11e8-8748-813b263027aa.png)
