### PR TITLE
els stop infinite calls to createServiceMember when it 500s [#161433372]

### DIFF
--- a/src/scenes/Landing/index.jsx
+++ b/src/scenes/Landing/index.jsx
@@ -23,12 +23,14 @@ export class Landing extends Component {
     const {
       serviceMember,
       createdServiceMemberIsLoading,
+      createdServiceMemberError,
       loggedInUserSuccess,
       createServiceMember,
       isProfileComplete,
     } = this.props;
+
     if (loggedInUserSuccess) {
-      if (!createdServiceMemberIsLoading && isEmpty(serviceMember)) {
+      if (!createdServiceMemberIsLoading && isEmpty(serviceMember) && !createdServiceMemberError) {
         // Once the logged in user loads, if the service member doesn't
         // exist we need to dispatch creating one, once.
         createServiceMember({});
@@ -107,7 +109,7 @@ export class Landing extends Component {
               )}
               {createdServiceMemberError && (
                 <Alert type="error" heading="An error occurred">
-                  There was an error creating your move.
+                  There was an error creating your profile information.
                 </Alert>
               )}
             </div>


### PR DESCRIPTION


## Description

The LandingPage `componentDidUpdate` function would hit the service member create endpoint endlessly if it did not create a service member because it wasn't listening to the error. This rarely happens, but we have seen it when the app server is getting an update.


## Setup

Since this is so dependent on timing (you need to be logged in and not have a service member created yet, I tested this by replacing the body of https://github.com/transcom/mymove/blob/c4397e44c3165ea35d76973c4073ee0b9afc3bc3/pkg/handlers/internalapi/service_members.go#L66 

with 
```
	responder := servicememberop.NewCreateServiceMemberInternalServerError()
	return handlers.NewCookieUpdateResponder(params.HTTPRequest, h.CookieSecret(), h.NoSessionTimeout(), h.Logger(), responder)
```


## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/161433372) for this change

## Screenshots
![image](https://user-images.githubusercontent.com/3142631/47474793-bbeb2580-d7e6-11e8-985e-4f2e22b055a8.png)
