### PR TITLE
Sb #161350072 enter pickup button

### DIFF
--- a/cmd/generate_test_data/main.go
+++ b/cmd/generate_test_data/main.go
@@ -83,7 +83,7 @@ func main() {
 		testdatagen.MakeDefaultOfficeUser(db)
 		log.Print("Success! Created TSP test data.")
 	} else if *namedScenario == tdgs.E2eBasicScenario.Name {
-		tdgs.E2eBasicScenario.Run(db, loader)
+		tdgs.E2eBasicScenario.Run(db, loader, logger, storer)
 		log.Print("Success! Created e2e test data.")
 	} else {
 		// Can this be less repetitive without being overly clever?

--- a/cypress/integration/tsp/shipShipment.js
+++ b/cypress/integration/tsp/shipShipment.js
@@ -197,7 +197,7 @@ function tspUserEntersPackAndPickUpInfo() {
 
   // Cancel
   cy
-    .get('button')
+    .get('a')
     .contains('Cancel')
     .click();
 

--- a/pkg/handlers/publicapi/shipments.go
+++ b/pkg/handlers/publicapi/shipments.go
@@ -231,7 +231,7 @@ type TransportShipmentHandler struct {
 	handlers.HandlerContext
 }
 
-// Handle accepts the shipment - checks that currently logged in user is authorized to act for the TSP assigned the shipment
+// Handle updates the shipment with pack and pickup dates and weights and puts it in-transit - checks that currently logged in user is authorized to act for the TSP assigned the shipment
 func (h TransportShipmentHandler) Handle(params shipmentop.TransportShipmentParams) middleware.Responder {
 	session := auth.SessionFromRequestContext(params.HTTPRequest)
 

--- a/pkg/handlers/publicapi/shipments_test.go
+++ b/pkg/handlers/publicapi/shipments_test.go
@@ -707,9 +707,15 @@ func (suite *HandlerSuite) TestTransportShipmentHandler() {
 	path := fmt.Sprintf("/shipments/%s/transport", shipment.ID.String())
 	req := httptest.NewRequest("POST", path, nil)
 	req = suite.AuthenticateTspRequest(req, tspUser)
-	actualPickupDate := time.Now()
-	body := apimessages.ActualPickupDate{
+	actualPackDate := testdatagen.Now
+	actualPickupDate := testdatagen.NowPlusTwoDays
+
+	body := apimessages.TransportPayload{
+		ActualPackDate:   handlers.FmtDatePtr(&actualPackDate),
 		ActualPickupDate: handlers.FmtDatePtr(&actualPickupDate),
+		NetWeight:        swag.Int64(2000),
+		GrossWeight:      swag.Int64(3000),
+		TareWeight:       swag.Int64(1000),
 	}
 	params := shipmentop.TransportShipmentParams{
 		HTTPRequest: req,
@@ -722,6 +728,10 @@ func (suite *HandlerSuite) TestTransportShipmentHandler() {
 	okResponse := response.(*shipmentop.TransportShipmentOK)
 	suite.Equal("IN_TRANSIT", string(okResponse.Payload.Status))
 	suite.Equal(actualPickupDate, time.Time(*okResponse.Payload.ActualPickupDate))
+	suite.Equal(actualPackDate, time.Time(*okResponse.Payload.ActualPackDate))
+	suite.Equal(int64(2000), *okResponse.Payload.NetWeight)
+	suite.Equal(int64(3000), *okResponse.Payload.GrossWeight)
+	suite.Equal(int64(1000), *okResponse.Payload.TareWeight)
 }
 
 // TestDeliverShipmentHandler tests the api endpoint that delivers a shipment

--- a/pkg/testdatagen/scenario/e2ebasic.go
+++ b/pkg/testdatagen/scenario/e2ebasic.go
@@ -8,6 +8,12 @@ import (
 
 	"github.com/gobuffalo/pop"
 	"github.com/gobuffalo/uuid"
+	"github.com/transcom/mymove/pkg/assets"
+	"github.com/transcom/mymove/pkg/gen/apimessages"
+	"github.com/transcom/mymove/pkg/paperwork"
+	"github.com/transcom/mymove/pkg/storage"
+	uploaderpkg "github.com/transcom/mymove/pkg/uploader"
+	"go.uber.org/zap"
 
 	"github.com/transcom/mymove/pkg/gen/internalmessages"
 	"github.com/transcom/mymove/pkg/models"
@@ -23,7 +29,7 @@ type e2eBasicScenario NamedScenario
 var E2eBasicScenario = e2eBasicScenario{"e2e_basic"}
 
 // Run does that data load thing
-func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader) {
+func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, logger *zap.Logger, storer *storage.Filesystem) {
 
 	/*
 	 * Basic user with tsp access
@@ -899,6 +905,11 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader) {
 	MakeHhgFromAwardedToAcceptedGBLReady(db, tspUser)
 
 	/*
+	 * Service member with uploaded orders and an approved shipment to be accepted & GBL generated
+	 */
+	MakeHhgWithGBL(db, tspUser, logger, storer)
+
+	/*
 	 * Service member with uploaded orders and an approved shipment
 	 */
 	email = "hhg@premo.ve"
@@ -1497,4 +1508,127 @@ func MakeHhgFromAwardedToAcceptedGBLReady(db *pop.Connection, tspUser models.Tsp
 	hhg2.Move.Submit()
 	models.SaveMoveDependencies(db, &hhg2.Move)
 	return offer9.Shipment
+}
+
+// MakeHhgWithGBL creates a scenario for an approved shipment with a GBL generated
+func MakeHhgWithGBL(db *pop.Connection, tspUser models.TspUser, logger *zap.Logger, storer *storage.Filesystem) models.Shipment {
+	/*
+	 * Service member with uploaded orders and an approved shipment to be accepted, able to generate GBL
+	 */
+	email := "hhg@gov_bill_of_lading.created"
+
+	packDate := time.Now().AddDate(0, 0, 1)
+	pickupDate := time.Now().AddDate(0, 0, 5)
+	deliveryDate := time.Now().AddDate(0, 0, 10)
+	weightEstimate := unit.Pound(5000)
+	sourceOffice := testdatagen.MakeTransportationOffice(db, testdatagen.Assertions{
+		TransportationOffice: models.TransportationOffice{
+			Gbloc: "ABCD",
+		},
+	})
+	destOffice := testdatagen.MakeTransportationOffice(db, testdatagen.Assertions{
+		TransportationOffice: models.TransportationOffice{
+			Gbloc: "QRED",
+		},
+	})
+	offer := testdatagen.MakeShipmentOffer(db, testdatagen.Assertions{
+		User: models.User{
+			ID:            uuid.Must(uuid.FromString("b7dccea1-d052-4a66-aed9-2fdacf461023")),
+			LoginGovEmail: email,
+		},
+		ServiceMember: models.ServiceMember{
+			ID:            uuid.FromStringOrNil("8a1a86c7-78d6-4897-806e-0e4c5546fdec"),
+			FirstName:     models.StringPointer("HHG"),
+			LastName:      models.StringPointer("HasGBL"),
+			Edipi:         models.StringPointer("4444567890"),
+			PersonalEmail: models.StringPointer(email),
+		},
+		Order: models.Order{
+			DepartmentIndicator: models.StringPointer("17"),
+			TAC:                 models.StringPointer("NTA4"),
+			SAC:                 models.StringPointer("1234567890 9876543210"),
+		},
+		Move: models.Move{
+			ID:               uuid.FromStringOrNil("6eee3663-1973-40c5-b49e-e70e9325b895"),
+			Locator:          "CONGBL",
+			SelectedMoveType: models.StringPointer("HHG"),
+		},
+		TrafficDistributionList: models.TrafficDistributionList{
+			ID:                uuid.FromStringOrNil("87fcebf6-63b8-40cb-bc40-b553f5b91b9c"),
+			SourceRateArea:    "US62",
+			DestinationRegion: "11",
+			CodeOfService:     "D",
+		},
+		Shipment: models.Shipment{
+			ID:                          uuid.FromStringOrNil("0851706a-997f-46fb-84e4-2525a444ade0"),
+			Status:                      models.ShipmentStatusAPPROVED,
+			PmSurveyConductedDate:       &packDate,
+			PmSurveyMethod:              "PHONE",
+			PmSurveyPlannedPackDate:     &packDate,
+			PmSurveyPlannedPickupDate:   &pickupDate,
+			PmSurveyPlannedDeliveryDate: &deliveryDate,
+			PmSurveyWeightEstimate:      &weightEstimate,
+			SourceGBLOC:                 &sourceOffice.Gbloc,
+			DestinationGBLOC:            &destOffice.Gbloc,
+		},
+		ShipmentOffer: models.ShipmentOffer{
+			TransportationServiceProviderID: tspUser.TransportationServiceProviderID,
+			TransportationServiceProvider:   tspUser.TransportationServiceProvider,
+			Accepted:                        models.BoolPointer(true),
+		},
+	})
+
+	testdatagen.MakeTSPPerformanceDeprecated(db,
+		tspUser.TransportationServiceProvider,
+		*offer.Shipment.TrafficDistributionList,
+		models.IntPointer(3),
+		0.40,
+		5,
+		unit.DiscountRate(0.50),
+		unit.DiscountRate(0.55))
+
+	testdatagen.MakeServiceAgent(db, testdatagen.Assertions{
+		ServiceAgent: models.ServiceAgent{
+			Shipment:   &offer.Shipment,
+			ShipmentID: offer.ShipmentID,
+		},
+	})
+
+	hhg := offer.Shipment
+	hhgID := offer.ShipmentID
+	hhg.Move.Submit()
+	models.SaveMoveDependencies(db, &hhg.Move)
+
+	// Create PDF for GBL
+	gbl, _ := models.FetchGovBillOfLadingExtractor(db, hhgID)
+	formLayout := paperwork.Form1203Layout
+
+	// Read in bytes from Asset pkg
+	data, _ := assets.Asset(formLayout.TemplateImagePath)
+	f, _ := storer.FileSystem().Create("something.png")
+	f.Write(data)
+	f.Seek(0, 0)
+
+	form, _ := paperwork.NewTemplateForm(f, formLayout.FieldsLayout)
+
+	// Populate form fields with GBL data
+	form.DrawData(gbl)
+	aFile, _ := storer.FileSystem().Create(gbl.GBLNumber1)
+	form.Output(aFile)
+
+	uploader := uploaderpkg.NewUploader(db, logger, storer)
+	upload, _, _ := uploader.CreateUpload(nil, *tspUser.UserID, aFile)
+	uploads := []models.Upload{*upload}
+
+	// Create GBL move document associated to the shipment
+	hhg.Move.CreateMoveDocument(db,
+		uploads,
+		&hhgID,
+		models.MoveDocumentTypeGOVBILLOFLADING,
+		string("Government Bill Of Lading"),
+		swag.String(""),
+		string(apimessages.SelectedMoveTypeHHG),
+	)
+
+	return offer.Shipment
 }

--- a/pkg/testdatagen/scenario/e2ebasic.go
+++ b/pkg/testdatagen/scenario/e2ebasic.go
@@ -640,47 +640,6 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, log
 	models.SaveMoveDependencies(db, &hhg7.Move)
 
 	/*
-	 * Service member with approved shipment ready to be shipped.
-	 */
-	email = "hhg@ship.me"
-
-	shippingOffer := testdatagen.MakeShipmentOffer(db, testdatagen.Assertions{
-		User: models.User{
-			ID:            uuid.Must(uuid.FromString("86ee8f4b-d5e3-49a3-a09b-f639db9ac9f7")),
-			LoginGovEmail: email,
-		},
-		ServiceMember: models.ServiceMember{
-			ID:            uuid.FromStringOrNil("7091e1d6-f007-474c-a401-3b31f32c1648"),
-			FirstName:     models.StringPointer("HHG"),
-			LastName:      models.StringPointer("So Approved"),
-			Edipi:         models.StringPointer("4444567890"),
-			PersonalEmail: models.StringPointer(email),
-		},
-		Move: models.Move{
-			ID:               uuid.FromStringOrNil("9fd22c81-7f5b-419e-bf73-738abf8fb353"),
-			Locator:          "SHIPME",
-			SelectedMoveType: models.StringPointer("HHG"),
-		},
-		TrafficDistributionList: models.TrafficDistributionList{
-			ID:                uuid.FromStringOrNil("1f363629-ddf2-4d0d-9939-f32dab0ec3d2"),
-			SourceRateArea:    "US62",
-			DestinationRegion: "11",
-			CodeOfService:     "D",
-		},
-		Shipment: models.Shipment{
-			Status: models.ShipmentStatusAPPROVED,
-		},
-		ShipmentOffer: models.ShipmentOffer{
-			TransportationServiceProviderID: tspUser.TransportationServiceProviderID,
-			Accepted:                        models.BoolPointer(true),
-		},
-	})
-
-	shippingShipment := shippingOffer.Shipment
-	shippingShipment.Move.Submit()
-	models.SaveMoveDependencies(db, &shippingShipment.Move)
-
-	/*
 	 * Service member with approved basics and accepted shipment
 	 */
 	email = "hhg@accept.ed"

--- a/src/scenes/TransportationServiceProvider/PickupForm.jsx
+++ b/src/scenes/TransportationServiceProvider/PickupForm.jsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { SwaggerField } from 'shared/JsonSchemaForm/JsonSchemaField';
+import { reduxForm } from 'redux-form';
+
+let PickupForm = props => {
+  const { schema, onCancel, handleSubmit, submitting, valid } = props;
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <div className="usa-width-one-whole">
+        <h2 className="extras usa-heading">Enter Pack & Pickup</h2>
+      </div>
+      <div className="editable-panel-column">
+        <div className="column-subhead">Dates</div>
+        <SwaggerField fieldName="actual_pack_date" swagger={schema} title="Actual packing (first day)" required />
+        <SwaggerField fieldName="actual_pickup_date" swagger={schema} title="Actual pickup" required />
+      </div>
+
+      <div className="editable-panel-column">
+        <div className="column-subhead">Actual weights</div>
+        <SwaggerField className="short-field" fieldName="gross_weight" swagger={schema} /> lbs
+        <SwaggerField className="short-field" fieldName="tare_weight" swagger={schema} /> lbs
+        <SwaggerField title="Net" className="short-field" fieldName="net_weight" swagger={schema} required /> lbs
+      </div>
+
+      <button onClick={onCancel}>Cancel</button>
+      <button type="submit" disabled={submitting || !valid}>
+        Done
+      </button>
+    </form>
+  );
+};
+
+PickupForm = reduxForm({ form: 'pickup_shipment' })(PickupForm);
+
+PickupForm.propTypes = {
+  schema: PropTypes.object,
+  onCancel: PropTypes.func,
+  handleSubmit: PropTypes.func,
+  submitting: PropTypes.bool,
+  valid: PropTypes.bool,
+};
+
+const mapStateToProps = (state, ownProps) => {
+  const { shipment } = state.tsp;
+  return {
+    ...ownProps,
+    initialValues: shipment,
+  };
+};
+
+export default connect(mapStateToProps)(PickupForm);

--- a/src/scenes/TransportationServiceProvider/PickupForm.jsx
+++ b/src/scenes/TransportationServiceProvider/PickupForm.jsx
@@ -8,10 +8,8 @@ let PickupForm = props => {
   const { schema, onCancel, handleSubmit, submitting, valid } = props;
 
   return (
-    <form onSubmit={handleSubmit}>
-      <div className="usa-width-one-whole">
-        <h2 className="extras usa-heading">Enter Pack & Pickup</h2>
-      </div>
+    <form className="infoPanel-wizard" onSubmit={handleSubmit}>
+      <div className="infoPanel-wizard-header">Enter Pack & Pickup</div>
       <div className="editable-panel-column">
         <div className="column-subhead">Dates</div>
         <SwaggerField fieldName="actual_pack_date" swagger={schema} title="Actual packing (first day)" required />
@@ -25,10 +23,19 @@ let PickupForm = props => {
         <SwaggerField title="Net" className="short-field" fieldName="net_weight" swagger={schema} required /> lbs
       </div>
 
-      <button onClick={onCancel}>Cancel</button>
-      <button type="submit" disabled={submitting || !valid}>
-        Done
-      </button>
+      <p>
+        After clicking "Done", please upload the origin docs. Use the "Upload new document" link in the Documents panel
+        at right.
+      </p>
+
+      <div className="infoPanel-wizard-actions-container">
+        <a className="infoPanel-wizard-cancel" onClick={onCancel}>
+          Cancel
+        </a>
+        <button type="submit" disabled={submitting || !valid}>
+          Done
+        </button>
+      </div>
     </form>
   );
 };

--- a/src/scenes/TransportationServiceProvider/api.js
+++ b/src/scenes/TransportationServiceProvider/api.js
@@ -55,7 +55,7 @@ export async function RejectShipment(shipmentId, reason) {
 
 export async function TransportShipment(shipmentId, payload) {
   const client = await getPublicClient();
-  const payloadDef = client.spec.definitions.ActualPickupDate;
+  const payloadDef = client.spec.definitions.TransportPayload;
   const response = await client.apis.shipments.transportShipment({
     shipmentId,
     payload: formatPayload(payload, payloadDef),

--- a/swagger/api.yaml
+++ b/swagger/api.yaml
@@ -1277,7 +1277,7 @@ definitions:
         x-nullable: true
     required:
       - actual_pack_date
-  ActualPickupDate:
+  TransportPayload:
     type: object
     properties:
       actual_pickup_date:
@@ -1286,8 +1286,40 @@ definitions:
         example: '2018-04-02'
         title: Actual Pickup Date
         x-nullable: true
+      actual_pack_date:
+        type: string
+        format: date
+        example: '2018-04-02'
+        title: Actual Pack Date
+        x-nullable: true
+      net_weight:
+        type: integer
+        description: Actual net weight of the shipment in lbs
+        minimum: 0
+        example: 10000
+        x-nullable: true
+        x-formatting: weight
+        title: Net
+      gross_weight:
+        type: integer
+        description: Gross weight of the shipment in lbs
+        minimum: 0
+        example: 10000
+        x-nullable: true
+        x-formatting: weight
+        title: Gross
+      tare_weight:
+        type: integer
+        description: Tare weight of the shipment in lbs
+        minimum: 0
+        example: 10000
+        x-nullable: true
+        x-formatting: weight
+        title: Tare
     required:
       - actual_pickup_date
+      - actual_pack_date
+      - net_weight
   ActualDeliveryDate:
     type: object
     properties:
@@ -2026,7 +2058,7 @@ paths:
           name: payload
           required: true
           schema:
-            $ref: '#/definitions/ActualPickupDate'
+            $ref: '#/definitions/TransportPayload'
       responses:
         200:
           description: returns updated (in_transit) shipment object


### PR DESCRIPTION
## Description

Combine the current Pack and Pickup forms into one and add weights.

## Notes for the Reviewer

This PR makes some code obsolete, but I wanted the dif to be as clean as possible. I spun off a new story (#161485555) to address deleting the now unused code.

## Setup

You can only add pack and pickup info for a shipment that already has a GBL created. Running the e2e data setup will create a shipment with the locator 'CONGBL' if you don't want to go through the hassle of creating a test shipment yourself.

## Code Review Verification Steps

* [x] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/n/projects/2181745/stories/161350072) for this change

## Screenshots

![oct-25-2018 09-28-13](https://user-images.githubusercontent.com/4434681/47515688-65a6d280-d838-11e8-8447-9c5dcdff7144.gif)
