### PR TITLE
Check if office shipment exists before getting dependencies

### DIFF
--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -125,7 +125,7 @@ class MoveInfo extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    if (get(this.props, 'officeShipment.id') !== get(prevProps, 'officeShipment.id')) {
+    if (this.props.officeShipment && get(this.props, 'officeShipment.id') !== get(prevProps, 'officeShipment.id')) {
       this.props.getAllShipmentLineItems(getShipmentLineItemsLabel, this.props.officeShipment.id);
     }
   }

--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -49,6 +49,7 @@ import {
   cancelMove,
   patchShipment,
   sendHHGInvoice,
+  resetMove,
 } from './ducks';
 import { formatDate } from 'shared/formatters';
 import { selectAllDocumentsForMove, getMoveDocumentsForMove } from 'shared/Entities/modules/moveDocuments';
@@ -125,9 +126,13 @@ class MoveInfo extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    if (this.props.officeShipment && get(this.props, 'officeShipment.id') !== get(prevProps, 'officeShipment.id')) {
+    if (get(this.props, 'officeShipment.id') !== get(prevProps, 'officeShipment.id')) {
       this.props.getAllShipmentLineItems(getShipmentLineItemsLabel, this.props.officeShipment.id);
     }
+  }
+
+  componentWillUnmount() {
+    this.props.resetMove();
   }
 
   approveBasics = () => {
@@ -484,6 +489,7 @@ const mapDispatchToProps = dispatch =>
       sendHHGInvoice,
       getAllTariff400ngItems,
       getAllShipmentLineItems,
+      resetMove,
     },
     dispatch,
   );

--- a/src/scenes/Office/ducks.js
+++ b/src/scenes/Office/ducks.js
@@ -43,6 +43,7 @@ const completeHHGType = 'COMPLETE_HHG';
 const downloadPPMAttachmentsType = 'DOWNLOAD_ATTACHMENTS';
 const cancelMoveType = 'CANCEL_MOVE';
 const REMOVE_BANNER = 'REMOVE_BANNER';
+const RESET_MOVE = 'RESET_MOVE';
 
 // MULTIPLE-RESOURCE ACTION TYPES
 const updateBackupInfoType = 'UPDATE_BACKUP_INFO';
@@ -50,6 +51,10 @@ const updateOrdersInfoType = 'UPDATE_ORDERS_INFO';
 const loadDependenciesType = 'LOAD_DEPENDENCIES';
 
 // SINGLE RESOURCE ACTION TYPES
+
+export const resetMove = () => ({
+  type: RESET_MOVE,
+});
 
 const LOAD_MOVE = ReduxHelpers.generateAsyncActionTypes(loadMoveType);
 
@@ -248,6 +253,7 @@ const initialState = {
   moveIsCanceling: false,
   moveHasLoadError: null,
   moveHasLoadSuccess: false,
+  officeMove: {},
   ordersHaveLoadError: null,
   ordersHaveLoadSuccess: false,
   ordersHaveUploadError: null,
@@ -676,6 +682,10 @@ export function officeReducer(state = initialState, action) {
     case DOWNLOAD_ATTACHMENTS.failure:
       return Object.assign({}, state, {
         downloadAttachmentsHasError: action.error,
+      });
+    case RESET_MOVE:
+      return Object.assign({}, state, {
+        officeShipment: {},
       });
     default:
       return state;


### PR DESCRIPTION
## Description

Fixes a bug where the app was getting a type error when switching from an HHG move to a PPM move but not vice versa 

## Reviewer Notes
- currently trying to write an e2e test for the test case but I can't get it to fail 

Setup
- visit an HHG move
- go back to queues using logo
- visit a PPM move

## Code Review Verification Steps
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/161483826) for this change

## Screenshots

The following should not happen anymore:
![hhg-to-ppm](https://user-images.githubusercontent.com/13622298/47517652-be2c9e80-d83d-11e8-9bff-fd1c6a546b9f.gif)
