### PR TITLE
Make move dates calendar widget bigger

### DIFF
--- a/src/scenes/Moves/Hhg/ShipmentWizard.css
+++ b/src/scenes/Moves/Hhg/ShipmentWizard.css
@@ -90,3 +90,7 @@
   padding-top: 0.5rem;
   color: gray;
 }
+
+.shipment-wizard .DayPicker-wrapper {
+  font-size: 1.3rem;
+}


### PR DESCRIPTION
## Description

This PR increases the size of the move dates calendar.  Previously, it was the default size which was too small.

## Reviewer Notes

I have scoped the style to a class on this page so it doesn't leak to other calendar usages.

## Setup

Go to the first page of the HHG wizard and you'll see the calendar.

## Code Review Verification Steps

* [ ] There are no aXe warnings for UI.
* [ ] This works in IE.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/161228836) for this change

## Screenshots

![screen shot 2018-10-25 at 1 31 06 pm](https://user-images.githubusercontent.com/4960757/47519112-cb0bbb00-d85a-11e8-8e55-d219c7912417.png)
