### PR TITLE
Update orders info for TSP Scenarios

### DIFF
--- a/pkg/testdatagen/make_order.go
+++ b/pkg/testdatagen/make_order.go
@@ -48,22 +48,26 @@ func MakeOrder(db *pop.Connection, assertions Assertions) models.Order {
 
 	ordersNumber := "ORDER" + strconv.Itoa(rand.Intn(100))
 	TAC := "F8E1"
+	SAC := "SAC"
+	departmentIndicator := "AIR_FORCE"
 
 	order := models.Order{
-		ServiceMember:    sm,
-		ServiceMemberID:  sm.ID,
-		NewDutyStation:   station,
-		NewDutyStationID: station.ID,
-		UploadedOrders:   document,
-		UploadedOrdersID: document.ID,
-		IssueDate:        time.Date(2018, time.March, 15, 0, 0, 0, 0, time.UTC),
-		ReportByDate:     time.Date(2018, time.August, 1, 0, 0, 0, 0, time.UTC),
-		OrdersType:       internalmessages.OrdersTypePERMANENTCHANGEOFSTATION,
-		OrdersNumber:     &ordersNumber,
-		HasDependents:    true,
-		SpouseHasProGear: true,
-		Status:           models.OrderStatusDRAFT,
-		TAC:              &TAC,
+		ServiceMember:       sm,
+		ServiceMemberID:     sm.ID,
+		NewDutyStation:      station,
+		NewDutyStationID:    station.ID,
+		UploadedOrders:      document,
+		UploadedOrdersID:    document.ID,
+		IssueDate:           time.Date(2018, time.March, 15, 0, 0, 0, 0, time.UTC),
+		ReportByDate:        time.Date(2018, time.August, 1, 0, 0, 0, 0, time.UTC),
+		OrdersType:          internalmessages.OrdersTypePERMANENTCHANGEOFSTATION,
+		OrdersNumber:        &ordersNumber,
+		HasDependents:       true,
+		SpouseHasProGear:    true,
+		Status:              models.OrderStatusDRAFT,
+		TAC:                 &TAC,
+		SAC:                 &SAC,
+		DepartmentIndicator: &departmentIndicator,
 	}
 
 	// Overwrite values with those from assertions

--- a/pkg/testdatagen/make_shipment_offer_records.go
+++ b/pkg/testdatagen/make_shipment_offer_records.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gobuffalo/pop"
 	"github.com/pkg/errors"
 
+	"github.com/transcom/mymove/pkg/gen/internalmessages"
 	"github.com/transcom/mymove/pkg/models"
 )
 
@@ -181,10 +182,13 @@ func CreateShipmentOfferData(db *pop.Connection, numTspUsers int, numShipments i
 		}
 		newDutyStation := MakeDutyStation(db, newDutyStationAssertions)
 
-		// Move Details
+		// Move and Order Details
 		moveStatus := models.MoveStatusSUBMITTED
+		orderStatus := models.OrderStatusSUBMITTED
+		ordTypeDetHHGPermit := internalmessages.OrdersTypeDetailHHGPERMITTED
 		if shipmentStatus == models.ShipmentStatusAPPROVED {
 			moveStatus = models.MoveStatusAPPROVED
+			orderStatus = models.OrderStatusAPPROVED
 		}
 
 		shipmentAssertions := Assertions{
@@ -194,6 +198,8 @@ func CreateShipmentOfferData(db *pop.Connection, numTspUsers int, numShipments i
 			Order: models.Order{
 				NewDutyStationID: newDutyStation.ID,
 				NewDutyStation:   newDutyStation,
+				Status:           orderStatus,
+				OrdersTypeDetail: &ordTypeDetHHGPermit,
 			},
 			Move: models.Move{
 				SelectedMoveType: &selectedMoveType,

--- a/pkg/testdatagen/make_shipment_offer_records.go
+++ b/pkg/testdatagen/make_shipment_offer_records.go
@@ -186,7 +186,10 @@ func CreateShipmentOfferData(db *pop.Connection, numTspUsers int, numShipments i
 		moveStatus := models.MoveStatusSUBMITTED
 		orderStatus := models.OrderStatusSUBMITTED
 		ordTypeDetHHGPermit := internalmessages.OrdersTypeDetailHHGPERMITTED
-		if shipmentStatus == models.ShipmentStatusAPPROVED {
+		if shipmentStatus == models.ShipmentStatusAPPROVED ||
+			shipmentStatus == models.ShipmentStatusINTRANSIT ||
+			shipmentStatus == models.ShipmentStatusDELIVERED ||
+			shipmentStatus == models.ShipmentStatusCOMPLETED {
 			moveStatus = models.MoveStatusAPPROVED
 			orderStatus = models.OrderStatusAPPROVED
 		}


### PR DESCRIPTION
## Description

Set the order status, orders type detail, SAC, and department indicator for orders used in the TSP scenarios.  I have been a bit tired of having to use the office app for moves that should be approved.  This is especially an issue around using the "Generate the GBL" button.

## Setup

Run scenario 7.  Any move that is in the APPROVED or later state should now have the completed office information.  So pick an approved move, enter service agent info, enter pm survey info, and then try to generate a GBL.  It should "just work" ™️ .

The real reason I wanted this is so I could do some manual testing to accept pivotal stories a bit faster.

## Code Review Verification Steps

* [ ] Request review from a member of a different team.