### PR TITLE
Add more data to award queue logging

### DIFF
--- a/pkg/awardqueue/awardqueue.go
+++ b/pkg/awardqueue/awardqueue.go
@@ -42,7 +42,9 @@ func (aq *AwardQueue) findAllUnassignedShipments() (models.Shipments, error) {
 // a TSP.
 // TODO: refactor this method to ensure the transaction is wrapping what it needs to
 func (aq *AwardQueue) attemptShipmentOffer(shipment models.Shipment) (*models.ShipmentOffer, error) {
-	aq.logger.Info("Attempting to offer shipment", zap.Any("shipment_id", shipment.ID))
+	aq.logger.Info("Attempting to offer shipment",
+		zap.Any("shipment_id", shipment.ID),
+		zap.Any("traffic_distribution_list_id", shipment.TrafficDistributionListID))
 
 	// Query the shipment's TDL
 	tdl := models.TrafficDistributionList{}
@@ -92,7 +94,7 @@ func (aq *AwardQueue) attemptShipmentOffer(shipment models.Shipment) (*models.Sh
 					if isAdministrativeShipment == true {
 						aq.logger.Info("Shipment pickup date is during a blackout period. Awarding Administrative Shipment to TSP.")
 					} else {
-						aq.logger.Info("Shipment offered to TSP!", zap.Int("current_count", tspPerformance.OfferCount))
+						aq.logger.Info("Shipment offered to TSP!", zap.Int("current offer_count", tspPerformance.OfferCount))
 						foundAvailableTSP = true
 
 						// Award the shipment

--- a/pkg/awardqueue/awardqueue.go
+++ b/pkg/awardqueue/awardqueue.go
@@ -94,7 +94,9 @@ func (aq *AwardQueue) attemptShipmentOffer(shipment models.Shipment) (*models.Sh
 					if isAdministrativeShipment == true {
 						aq.logger.Info("Shipment pickup date is during a blackout period. Awarding Administrative Shipment to TSP.")
 					} else {
-						aq.logger.Info("Shipment offered to TSP!", zap.Int("current offer_count", tspPerformance.OfferCount))
+						aq.logger.Info("Shipment offered to TSP!",
+							zap.Int("quality_band", tspPerformance.QualityBand),
+							zap.Int("offer_count", tspPerformance.OfferCount))
 						foundAvailableTSP = true
 
 						// Award the shipment

--- a/pkg/awardqueue/awardqueue.go
+++ b/pkg/awardqueue/awardqueue.go
@@ -94,8 +94,13 @@ func (aq *AwardQueue) attemptShipmentOffer(shipment models.Shipment) (*models.Sh
 					if isAdministrativeShipment == true {
 						aq.logger.Info("Shipment pickup date is during a blackout period. Awarding Administrative Shipment to TSP.")
 					} else {
+						qb := -1
+						if tspPerformance.QualityBand != nil {
+							qb = *tspPerformance.QualityBand
+						}
+
 						aq.logger.Info("Shipment offered to TSP!",
-							zap.Int("quality_band", tspPerformance.QualityBand),
+							zap.Int("quality_band", qb),
 							zap.Int("offer_count", tspPerformance.OfferCount))
 						foundAvailableTSP = true
 

--- a/pkg/models/transportation_service_provider_performance_test.go
+++ b/pkg/models/transportation_service_provider_performance_test.go
@@ -96,6 +96,7 @@ func (suite *ModelSuite) Test_IncrementTSPPerformanceOfferCount() {
 	tsp := testdatagen.MakeDefaultTSP(suite.db)
 	perf, _ := testdatagen.MakeTSPPerformanceDeprecated(suite.db, tsp, tdl, nil, mps, 0, .2, .1)
 
+	// Increment offer count twice
 	performance, err := IncrementTSPPerformanceOfferCount(suite.db, perf.ID)
 	if err != nil {
 		t.Fatalf("Could not increment offer_count: %v", err)
@@ -104,13 +105,21 @@ func (suite *ModelSuite) Test_IncrementTSPPerformanceOfferCount() {
 		t.Errorf("Wrong OfferCount returned: expected %d, got %d", 1, performance.OfferCount)
 	}
 
+	performance, err = IncrementTSPPerformanceOfferCount(suite.db, perf.ID)
+	if err != nil {
+		t.Fatalf("Could not increment offer_count: %v", err)
+	}
+	if performance.OfferCount != 2 {
+		t.Errorf("Wrong OfferCount returned: expected %d, got %d", 2, performance.OfferCount)
+	}
+
 	performance = TransportationServiceProviderPerformance{}
 	if err := suite.db.Find(&performance, perf.ID); err != nil {
 		t.Fatalf("could not find perf: %v", err)
 	}
 
-	if performance.OfferCount != 1 {
-		t.Errorf("Wrong OfferCount: expected %d, got %d", 1, performance.OfferCount)
+	if performance.OfferCount != 2 {
+		t.Errorf("Wrong OfferCount: expected %d, got %d", 2, performance.OfferCount)
 	}
 }
 


### PR DESCRIPTION
## Description

The Award Queue takes a Shipment and looks for TSPs that have filed rates in the same TDL to award it to. Nowhere were we logging the TDL that the shipment was in. This makes it difficult to know if a TSP should (or shouldn't) have been awarded a shipment, assuming we know which TDLs it is in.

This change adds the TDL ID and quality bands info to the AQ logging.

## Code Review Verification Steps

* [x] Code follows the guidelines for [Logging](./docs/backend.md#logging)
* [x] The requirements listed in
 [Querying the Database Safely](./docs/backend.md#querying-the-database-safely)
 have been satisfied.
* [x] Request review from a member of a different team.
* [xx] Have the Pivotal acceptance criteria been met for this change?
