### PR TITLE
Fixed HHG status timeline to show scheduled instead of packed for now

### DIFF
--- a/src/scenes/Landing/StatusTimeline.jsx
+++ b/src/scenes/Landing/StatusTimeline.jsx
@@ -16,8 +16,8 @@ export class StatusTimelineContainer extends PureComponent {
 
     return (
       <div className="status_timeline">
-        <StatusBlock name="Scheduled" dates={[this.props.bookDate]} formatType={formatType} completed={true} />
-        <StatusBlock name="Packed" dates={packDates} formatType="condensed" current={true} />
+        <StatusBlock name="Scheduled" dates={[this.props.bookDate]} formatType={formatType} current={true} />
+        <StatusBlock name="Packed" dates={packDates} formatType="condensed" />
         <StatusBlock name="Loaded" dates={pickupDates} formatType="condensed" />
         <StatusBlock name="In transit" dates={transitDates} formatType="condensed" />
         <StatusBlock name="Delivered" dates={deliveryDates} formatType="condensed" />


### PR DESCRIPTION
## Description

This PR adjusts the HHG status timeline on the landing page (after submission) to show the initial status to be scheduled instead of packed as it did before. 

## Setup

Create (or find) a user with a submitted HHG shipment and go their landing page.

## Code Review Verification Steps

* [x] There are no aXe warnings for UI.
* [x] This works in IE.
* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## Screenshots

![screen shot 2018-10-25 at 2 01 24 pm](https://user-images.githubusercontent.com/4960757/47520801-33f53200-d85f-11e8-8d65-a01e9a85bd32.png)
