### PR TITLE
Use pickup date when the move is an hhg move

### DIFF
--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -200,7 +200,6 @@ class MoveInfo extends Component {
     const pathnames = this.props.location.pathname.split('/');
     const invoiceSuccess = this.props.hhgInvoiceHasSendSuccess;
     const currentTab = pathnames[pathnames.length - 1];
-
     const showDocumentViewer = this.props.context.flags.documentViewer;
     let upload = get(this.props, 'officeOrders.uploaded_orders.uploads.0'); // there can be only one
     let check = <FontAwesomeIcon className="icon" icon={faCheck} />;
@@ -213,6 +212,8 @@ class MoveInfo extends Component {
     const hhgDelivered = hhg.status === 'DELIVERED';
     const hhgCompleted = hhg.status === 'COMPLETED';
     const moveApproved = move.status === 'APPROVED';
+
+    const moveDate = isPPM ? ppm.planned_move_date : hhg.requested_pickup_date;
     if (this.state.redirectToHome) {
       return <Redirect to="/" />;
     }
@@ -257,7 +258,7 @@ class MoveInfo extends Component {
                 &nbsp;
               </li>
               <li>Locator# {move.locator}&nbsp;</li>
-              <li>Move date {formatDate(ppm.planned_move_date)}&nbsp;</li>
+              <li>Move date {formatDate(moveDate)}&nbsp;</li>
             </ul>
           </div>
         </div>


### PR DESCRIPTION
## Description

Previously, HHG moves would have a blank move date because it was not using the pickup date. It now uses the pickup date

## Setup
`make db_populate_e2e`
`make server_run`
`make tsp_client_run`

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/161355751) for this change

## Screenshots

![image](https://user-images.githubusercontent.com/13622298/47522206-cab6f400-d849-11e8-8fc4-44c3851c7e94.png)
