### PR TITLE
Make all dates on Shipment optional in public API

### DIFF
--- a/pkg/handlers/publicapi/shipments.go
+++ b/pkg/handlers/publicapi/shipments.go
@@ -39,10 +39,10 @@ func payloadForShipmentModel(s models.Shipment) *apimessages.Shipment {
 		ActualPickupDate:     handlers.FmtDatePtr(s.ActualPickupDate),
 		ActualPackDate:       handlers.FmtDatePtr(s.ActualPackDate),
 		ActualDeliveryDate:   handlers.FmtDatePtr(s.ActualDeliveryDate),
-		BookDate:             *handlers.FmtDatePtr(s.BookDate),
-		RequestedPickupDate:  *handlers.FmtDatePtr(s.RequestedPickupDate),
-		OriginalDeliveryDate: *handlers.FmtDatePtr(s.OriginalDeliveryDate),
-		OriginalPackDate:     *handlers.FmtDatePtr(s.OriginalPackDate),
+		BookDate:             handlers.FmtDatePtr(s.BookDate),
+		RequestedPickupDate:  handlers.FmtDatePtr(s.RequestedPickupDate),
+		OriginalDeliveryDate: handlers.FmtDatePtr(s.OriginalDeliveryDate),
+		OriginalPackDate:     handlers.FmtDatePtr(s.OriginalPackDate),
 
 		// calculated durations
 		EstimatedPackDays:    s.EstimatedPackDays,

--- a/swagger/api.yaml
+++ b/swagger/api.yaml
@@ -884,48 +884,58 @@ definitions:
       move:
         $ref: '#/definitions/Move'
         x-nullable: true
+      book_date:
+        type: string
+        format: date
+        example: '2018-04-26'
+        readOnly: true
+        x-nullable: true
+      requested_pickup_date:
+        type: string
+        format: date
+        example: '2018-04-26'
+        x-nullable: true
+      original_delivery_date:
+        type: string
+        format: date
+        example: '2018-04-26'
+        readOnly: true
+        x-nullable: true
+      original_pack_date:
+        type: string
+        format: date
+        example: '2018-04-26'
+        readOnly: true
+        x-nullable: true
       actual_pickup_date:
         type: string
         format: date
-        example: '2018-04-21'
+        example: '2018-04-26'
+        readOnly: true
         x-nullable: true
       actual_pack_date:
         type: string
         format: date
-        example: '2018-04-21'
+        example: '2018-04-26'
+        readOnly: true
         x-nullable: true
       actual_delivery_date:
         type: string
         format: date
-        example: '2018-04-27'
+        example: '2018-04-26'
+        readOnly: true
         x-nullable: true
-      book_date:
-        type: string
-        format: date
-        example: '2018-03-15'
-      requested_pickup_date:
-        type: string
-        format: date
-        example: '2018-04-19'
-      original_delivery_date:
-        type: string
-        format: date
-        example: '2018-04-19'
-      original_pack_date:
-        type: string
-        format: date
-        example: '2018-04-19'
       estimated_pack_days:
         type: integer
-        description: Estimated days packing
         minimum: 0
-        example: 2
+        example: 3
+        readOnly: true
         x-nullable: true
       estimated_transit_days:
         type: integer
-        description: Estimated days in transit
         minimum: 0
         example: 30
+        readOnly: true
         x-nullable: true
       pickup_address:
         $ref: '#/definitions/Address'

--- a/swagger/api.yaml
+++ b/swagger/api.yaml
@@ -926,12 +926,14 @@ definitions:
         readOnly: true
         x-nullable: true
       estimated_pack_days:
+        description: Estimated days packing
         type: integer
         minimum: 0
         example: 3
         readOnly: true
         x-nullable: true
       estimated_transit_days:
+        description: Estimated days in transit
         type: integer
         minimum: 0
         example: 30


### PR DESCRIPTION
## Description

This allows the TSP Shipments endpoint to work with old data that might be missing date fields.

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](./docs/backend.md#logging)
* [ ] The requirements listed in [Querying the Database Safely](./docs/backend.md#querying-the-database-safely) have been satisfied.
* [ ] Request review from a member of a different team.

[Pivotal story](https://www.pivotaltracker.com/n/projects/2181745/stories/161381506)