### PR TITLE
Remove shipment_accessorials table

### DIFF
--- a/migrations/20181025214755_remove-shipment-accessorials.up.fizz
+++ b/migrations/20181025214755_remove-shipment-accessorials.up.fizz
@@ -1,0 +1,1 @@
+drop_table("shipment_accessorials")


### PR DESCRIPTION
## Description

As the 2nd part of renaming shipment_accessorials to shipment_line_items (https://github.com/transcom/mymove/pull/1221), this PR removes the shipment_accessorials table.

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](./docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](./docs/backend.md#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](./docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
* [ ] There are no aXe warnings for UI.
* [ ] This works in IE.
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @willowbl00
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/161487590) for this change
* [this article](tbd) explains more about the approach used.

