### PR TITLE
Award TSPs 1 shipment per quality band

### DIFF
--- a/pkg/awardqueue/awardqueue_test.go
+++ b/pkg/awardqueue/awardqueue_test.go
@@ -471,11 +471,12 @@ func (suite *AwardQueueSuite) TestAssignShipmentsToMultipleTSPs() {
 	// Run the Award Queue
 	queue.assignShipments()
 
-	suite.verifyOfferCount(tsp1, 6)
-	suite.verifyOfferCount(tsp2, 5)
+	// TODO: revert to [6, 5, 3, 2, 1] after the B&M pilot
+	suite.verifyOfferCount(tsp1, 4)
+	suite.verifyOfferCount(tsp2, 4)
 	suite.verifyOfferCount(tsp3, 3)
-	suite.verifyOfferCount(tsp4, 2)
-	suite.verifyOfferCount(tsp5, 1)
+	suite.verifyOfferCount(tsp4, 3)
+	suite.verifyOfferCount(tsp5, 3)
 
 	for _, shipment := range shipments {
 		if err := suite.db.Find(&shipment, shipment.ID); err != nil {

--- a/pkg/models/transportation_service_provider_performance.go
+++ b/pkg/models/transportation_service_provider_performance.go
@@ -18,10 +18,11 @@ import (
 var qualityBands = []int{1, 2, 3, 4}
 
 // OffersPerQualityBand is a map of the number of shipments to be offered per round to each quality band
+// TODO: change these back to [5, 3, 2, 1] after the B&M pilot
 var OffersPerQualityBand = map[int]int{
-	1: 5,
-	2: 3,
-	3: 2,
+	1: 1,
+	2: 1,
+	3: 1,
 	4: 1,
 }
 

--- a/pkg/models/transportation_service_provider_performance_test.go
+++ b/pkg/models/transportation_service_provider_performance_test.go
@@ -246,7 +246,7 @@ func (suite *ModelSuite) Test_SelectNextTSPPerformanceOneAssigned() {
 
 	chosen := SelectNextTSPPerformance(choices)
 
-	if chosen != tspp1 {
+	if chosen != tspp2 {
 		t.Errorf("Wrong TSPPerformance selected: expected band %v, got %v", *tspp1.QualityBand, *chosen.QualityBand)
 	}
 }
@@ -266,7 +266,7 @@ func (suite *ModelSuite) Test_SelectNextTSPPerformanceOneFullRound() {
 
 	chosen := SelectNextTSPPerformance(choices)
 
-	if chosen != tspp1 {
+	if chosen != tspp2 {
 		t.Errorf("Wrong TSPPerformance selected: expected band %v, got %v", *tspp1.QualityBand, *chosen.QualityBand)
 	}
 }
@@ -286,7 +286,7 @@ func (suite *ModelSuite) Test_SelectNextTSPPerformanceTwoFullRounds() {
 
 	chosen := SelectNextTSPPerformance(choices)
 
-	if chosen != tspp1 {
+	if chosen != tspp2 {
 		t.Errorf("Wrong TSPPerformance selected: expected band %v, got %v", *tspp1.QualityBand, *chosen.QualityBand)
 	}
 }
@@ -344,7 +344,7 @@ func (suite *ModelSuite) Test_SelectNextTSPPerformanceHalfOffered() {
 
 	chosen := SelectNextTSPPerformance(choices)
 
-	if chosen != tspp3 {
+	if chosen != tspp2 {
 		t.Errorf("Wrong TSPPerformance selected: expected band %v, got %v", *tspp3.QualityBand, *chosen.QualityBand)
 	}
 }
@@ -364,7 +364,7 @@ func (suite *ModelSuite) Test_SelectNextTSPPerformancePartialRound() {
 
 	chosen := SelectNextTSPPerformance(choices)
 
-	if chosen != tspp3 {
+	if chosen != tspp2 {
 		t.Errorf("Wrong TSPPerformance selected: expected band %v, got %v", *tspp3.QualityBand, *chosen.QualityBand)
 	}
 }


### PR DESCRIPTION
## Description

Normally, the Award Queue should offer TSPs different numbers of shipments per quality band: 5 for the highest QB, 3 for the 2nd, 2 for the 3rd, and 1 for the lowest QB.

For the B&M pilot, that means that one TSP will likely get all the shipments, and that is not going to be a useful test for the other 2 TSPs.

This change awards 1 shipment to each TSP, regardless of which quality band it resides in.