### PR TITLE
(Post B&M) Sb #161496029 hide gbl button after created

### DIFF
--- a/cypress/integration/tsp/generateGBL.js
+++ b/cypress/integration/tsp/generateGBL.js
@@ -68,14 +68,7 @@ function tspUserGeneratesGBL() {
   cy
     .get('button')
     .contains(gblButtonText)
-    .click();
-
-  cy
-    .get('button')
-    .contains(gblButtonText)
-    .should('be.disabled');
-
-  cy.get('.usa-alert-text').contains('There is already a Bill of Lading for this shipment');
+    .should('not.exist');
 }
 
 function tspUserViewsGBL() {

--- a/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
+++ b/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
@@ -317,20 +317,16 @@ class ShipmentInfo extends Component {
               )}
 
               {generateGBLSuccess && (
-                <p>
-                  <Alert type="success" heading="GBL has been created">
-                    <span className="usa-grid usa-alert-no-padding">
-                      <span className="usa-width-two-thirds">
-                        Click the button to view, print, or download the GBL.
-                      </span>
-                      <span className="usa-width-one-third">
-                        <Link to={`${this.props.gblDocUrl}`} className="usa-alert-right" target="_blank">
-                          <button>View GBL</button>
-                        </Link>
-                      </span>
+                <Alert type="success" heading="GBL has been created">
+                  <span className="usa-grid usa-alert-no-padding">
+                    <span className="usa-width-two-thirds">Click the button to view, print, or download the GBL.</span>
+                    <span className="usa-width-one-third">
+                      <Link to={`${this.props.gblDocUrl}`} className="usa-alert-right" target="_blank">
+                        <button>View GBL</button>
+                      </Link>
                     </span>
-                  </Alert>
-                </p>
+                  </span>
+                </Alert>
               )}
               {approved &&
                 pmSurveyComplete &&


### PR DESCRIPTION
## Description

Change how we check for if a GBL exists to fix a bug. This is a short-term fix. Longer term, we should be adding the returned GBL payload to the entities reducer.

## Code Review Verification Steps

* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/n/projects/2181745/stories/161496029) for this change

## Screenshots

![oct-25-2018 17-01-22](https://user-images.githubusercontent.com/4434681/47536932-c6093480-d877-11e8-8387-227798bfaa3f.gif)

