### PR TITLE
Modified zip-related functions to work with 9-digit zips

### DIFF
--- a/pkg/models/tariff400ng_zip3.go
+++ b/pkg/models/tariff400ng_zip3.go
@@ -43,11 +43,11 @@ func (t *Tariff400ngZip3) Validate(tx *pop.Connection) (*validate.Errors, error)
 }
 
 // FetchRateAreaForZip5 returns the rate area for a specified zip5.
-func FetchRateAreaForZip5(db *pop.Connection, zip5 string) (string, error) {
-	if len(zip5) != 5 {
-		return "", errors.Errorf("zip5 must have a length of 5, got '%s'", zip5)
+func FetchRateAreaForZip5(db *pop.Connection, zip string) (string, error) {
+	if len(zip) < 5 {
+		return "", errors.Errorf("zip must have a length of at least 5, got '%s'", zip)
 	}
-	zip3 := zip5[0:3]
+	zip3 := zip[0:3]
 
 	tariffZip3 := Tariff400ngZip3{}
 	if err := db.Where("zip3 = $1", zip3).First(&tariffZip3); err != nil {
@@ -55,6 +55,7 @@ func FetchRateAreaForZip5(db *pop.Connection, zip5 string) (string, error) {
 	}
 
 	if tariffZip3.RateArea == "ZIP" {
+		zip5 := zip[0:5]
 		zip5RateArea := Tariff400ngZip5RateArea{}
 		if err := db.Where("zip5 = $1", zip5).First(&zip5RateArea); err != nil {
 			return "", errors.Wrapf(err, "could not find zip5_rate_area for %s", zip5)
@@ -66,11 +67,11 @@ func FetchRateAreaForZip5(db *pop.Connection, zip5 string) (string, error) {
 }
 
 // FetchRegionForZip5 returns the region for a specified zip5.
-func FetchRegionForZip5(db *pop.Connection, zip5 string) (string, error) {
-	if len(zip5) != 5 {
-		return "", errors.Errorf("zip5 must have a length of 5, got '%s'", zip5)
+func FetchRegionForZip5(db *pop.Connection, zip string) (string, error) {
+	if len(zip) < 5 {
+		return "", errors.Errorf("zip must have a length of at least 5, got '%s'", zip)
 	}
-	zip3 := zip5[0:3]
+	zip3 := zip[0:3]
 
 	tariffZip3 := Tariff400ngZip3{}
 	if err := db.Where("zip3 = $1", zip3).First(&tariffZip3); err != nil {

--- a/pkg/models/tariff400ng_zip3_test.go
+++ b/pkg/models/tariff400ng_zip3_test.go
@@ -67,6 +67,15 @@ func (suite *ModelSuite) Test_FetchRateAreaForZip5() {
 	if rateArea != testdatagen.DefaultSrcRateArea {
 		t.Errorf("wrong rateArea: expected %s, got %s", testdatagen.DefaultSrcRateArea, rateArea)
 	}
+
+	rateArea, err = FetchRateAreaForZip5(suite.db, "72014-1234")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if rateArea != testdatagen.DefaultSrcRateArea {
+		t.Errorf("wrong rateArea: expected %s, got %s", testdatagen.DefaultSrcRateArea, rateArea)
+	}
 }
 
 func (suite *ModelSuite) Test_FetchRateAreaForZip5UsingZip5sTable() {
@@ -98,6 +107,15 @@ func (suite *ModelSuite) Test_FetchRateAreaForZip5UsingZip5sTable() {
 	if rateArea != testdatagen.DefaultSrcRateArea {
 		t.Errorf("wrong rateArea: expected %s, got %s", testdatagen.DefaultSrcRateArea, rateArea)
 	}
+
+	rateArea, err = FetchRateAreaForZip5(suite.db, "72014-1234")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if rateArea != testdatagen.DefaultSrcRateArea {
+		t.Errorf("wrong rateArea: expected %s, got %s", testdatagen.DefaultSrcRateArea, rateArea)
+	}
 }
 
 func (suite *ModelSuite) Test_FetchRegionForZip5() {
@@ -115,6 +133,15 @@ func (suite *ModelSuite) Test_FetchRegionForZip5() {
 	suite.mustSave(&zip3)
 
 	region, err := FetchRegionForZip5(suite.db, "72014")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if region != testdatagen.DefaultDstRegion {
+		t.Errorf("wrong region: expected %s, got %s", testdatagen.DefaultDstRegion, region)
+	}
+
+	region, err = FetchRegionForZip5(suite.db, "72014-1234")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## Description

We were getting errors upon updating a shipment when a user entered a 9-digit zip code.  Turns out there were a couple of functions that checked to make sure a 5-digit zip was being passed to them.  This PR loosens that restriction to allow 9-digit zips as well. 

## Setup

Create/edit a shipment's pickup address and use a 9-digit zip.  Make sure you are able to proceed OK.  A TDL should still be assigned to the shipment.

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](./docs/backend.md#logging)
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/161510039) for this change

