### PR TITLE
[FOR B&M] Remove unused Special Items weight column

### DIFF
--- a/src/scenes/Office/Hhg/WeightAndInventoryPanel.jsx
+++ b/src/scenes/Office/Hhg/WeightAndInventoryPanel.jsx
@@ -22,12 +22,13 @@ const WeightAndInventoryDisplay = props => {
           {formatNumber(get(fieldProps, 'values.weight_estimate', ''))} lbs
         </PanelField>
       </div>
-      <div className="editable-panel-column">
+      {/* Add this section back in once we have content for it
+        <div className="editable-panel-column">
         <span className="column-subhead">Special Items</span>
         <PanelField title="Customer Entered" className="Todo-phase2">
           None
         </PanelField>
-      </div>
+      </div>*/}
     </React.Fragment>
   );
 };


### PR DESCRIPTION
## Description

This is not helpful for real users for B&M

## Setup

Visit Office app and see the hhg tab of a move. Look at the weights panel. There should be NO yellow.

## Code Review Verification Steps

* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* https://www.pivotaltracker.com/story/show/161513609

## Screenshots

<img width="1349" alt="screen shot 2018-10-26 at 10 47 49 am" src="https://user-images.githubusercontent.com/5531789/47583539-aa9c3900-d90c-11e8-9b88-4f5ada6d2e55.png">
