### PR TITLE
Adding the truss TSP to production

### DIFF
--- a/local_migrations/20181026202620_truss_tsp_in_prod.sql
+++ b/local_migrations/20181026202620_truss_tsp_in_prod.sql
@@ -1,0 +1,5 @@
+-- Local test migration.
+-- This will be run on development environments. It should mirror what you
+-- intend to apply on production, but do not include any sensitive data.
+
+-- noop; we already have the truss TSP in dev.

--- a/migrations/20181026202620_truss_tsp_in_prod.up.fizz
+++ b/migrations/20181026202620_truss_tsp_in_prod.up.fizz
@@ -1,0 +1,1 @@
+exec("./apply-secure-migration.sh 20181026202620_truss_tsp_in_prod.sql")


### PR DESCRIPTION
## Description

This secure migration adds the Truss TSP to production; it already exists in Staging. This is done by only having the SQL to add the TSP in the production secure migration file:
```
$ for env in experimental staging prod; do \
    echo -en "${env}:\t"; \
    aws s3 ls s3://transcom-ppp-app-${env}-us-west-2/secure-migrations/20181026202620_truss_tsp_in_prod.sql; \
    done
experimental:	2018-10-26 13:31:01          0 20181026202620_truss_tsp_in_prod.sql
staging:	2018-10-26 13:30:53          0 20181026202620_truss_tsp_in_prod.sql
prod:		2018-10-26 14:49:55       3948 20181026202620_truss_tsp_in_prod.sql
```

This can be tested by running `bin/run-prod-migrations`, and then looking for the Truss TSP:
```
# select * from transportation_service_providers where standard_carrier_alpha_code='TRS1';
-[ RECORD 1 ]---------------+-------------------------------------
id                          | 5ce4045c-0821-42ec-9830-4ab3c605ea0a
standard_carrier_alpha_code | TRS1
created_at                  | 2018-10-26 21:56:25.62746
updated_at                  | 2018-10-26 21:56:25.62746
enrolled                    | t
name                        | Truss Transit Inc. (TEST TSP)
supplier_id                 | TRS1337
poc_general_name            | Truss Tester
poc_general_email           | test@example.com
poc_general_phone           | (415) 891-0828
poc_claims_name             | Truss Claims
poc_claims_email            | claims@example.com
```