### PR TITLE
Ensure that calling WriteSessionCookie twice only sets the cookie to the last value

### DIFF
--- a/pkg/auth/cookie.go
+++ b/pkg/auth/cookie.go
@@ -105,12 +105,14 @@ func WriteSessionCookie(w http.ResponseWriter, session *Session, secret string, 
 		if err != nil {
 			logger.Error("Generating signed token string", zap.Error(err))
 		} else {
+			logger.Info("Cookie", zap.Int("Size", len(ss)))
 			cookie.Value = ss
 			cookie.Expires = expiry
 			cookie.MaxAge = maxAge
 		}
 	}
-	http.SetCookie(w, &cookie)
+	// http.Cookie does this but Header().Add()
+	w.Header().Set("Set-Cookie", cookie.String())
 }
 
 // SessionCookieMiddleware handle serializing and de-serializing the session betweem the user_session cookie and the request context

--- a/pkg/auth/cookie_test.go
+++ b/pkg/auth/cookie_test.go
@@ -159,3 +159,47 @@ func (suite *authSuite) TestSessionCookieMiddlewareWithExpiredToken() {
 	setCookies := rr.HeaderMap["Set-Cookie"]
 	suite.Equal(1, len(setCookies), "expected cookie to be set")
 }
+
+func (suite *authSuite) TestSessionCookiePR161162731() {
+	t := suite.T()
+	email := "some_email@domain.com"
+	idToken := "fake_id_token"
+	fakeUUID, _ := uuid.FromString("39b28c92-0506-4bef-8b57-e39519f42dc2")
+
+	pem, err := createRandomRSAPEM()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expiry := GetExpiryTimeFromMinutes(SessionExpiryInMinutes)
+	incomingSession := Session{
+		UserID:  fakeUUID,
+		Email:   email,
+		IDToken: idToken,
+	}
+	ss, err := signTokenStringWithUserInfo(expiry, &incomingSession, pem)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rr, req := getHandlerParamsWithToken(ss, expiry)
+
+	var resultingSession *Session
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resultingSession = SessionFromRequestContext(r)
+		WriteSessionCookie(w, resultingSession, "freddy", false, suite.logger)
+	})
+	middleware := SessionCookieMiddleware(suite.logger, pem, false)(handler)
+
+	middleware.ServeHTTP(rr, req)
+
+	// We should get a 200 OK
+	suite.Equal(http.StatusOK, rr.Code, "handler returned wrong status code")
+
+	// And there should be an ID token in the request context
+	suite.NotNil(resultingSession)
+	suite.Equal(idToken, resultingSession.IDToken, "handler returned wrong id_token")
+
+	// And the cookie should be renewed
+	setCookies := rr.HeaderMap["Set-Cookie"]
+	suite.Equal(1, len(setCookies), "expected cookie to be set")
+}


### PR DESCRIPTION

## Description

The code to WriteSessionCookie was using http.SetCookie to set the value of the cookie. Under the covers this does Header().Add(), so if called twice will result in two header lines to set the value. The order of these headers is not deterministic as they are written out by iterating over the values of a Map.

For most requests, WriteSessionCookie is called before the handlers in the SessionCookieMiddleware. However, some requests which change the state of the session, e.g. creating a new ServiceMember, need to update the Session value after this. This is done, currently by wrapping the handler via a NewCookieUpdateResponder, which calls WriteSessionCookie a second time.

This change makes WriteSessionCookie directly user Header().Set() rather than Header().Add() to replace rather than add to the earlier value.

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](./docs/backend.md#logging)
* [ ] This works in IE.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/161162731) 
