### PR TITLE
Redirect invalid routes to queues/new

### DIFF
--- a/cypress/integration/tsp/routes.js
+++ b/cypress/integration/tsp/routes.js
@@ -6,6 +6,9 @@ describe('TSP User Navigating the App', function() {
   it('tsp user navigates to an invalid shipment', function() {
     tspUserViewsInvalidShipment();
   });
+  it('tsp user enters an invalid url route', function() {
+    tspUserNavigatesToInvalidRoute();
+  });
 });
 
 function unauthorizedTspUserGoesToAuthorizedRoute() {
@@ -27,6 +30,22 @@ function tspUserViewsInvalidShipment() {
   cy.visit('/shipments/some-invalid-uuid');
 
   // redirected to the queues page due to invalid shipment
+  cy.location().should(loc => {
+    expect(loc.pathname).to.match(/^\/queues\/new/);
+  });
+}
+
+function tspUserNavigatesToInvalidRoute() {
+  cy.signIntoTSP();
+
+  // Open new shipments queue
+  cy.location().should(loc => {
+    expect(loc.pathname).to.match(/^\/queues\/new/);
+  });
+
+  // visits an invalid url
+  cy.visit('/i-do-not-exist');
+
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/queues\/new/);
   });

--- a/src/scenes/TransportationServiceProvider/index.jsx
+++ b/src/scenes/TransportationServiceProvider/index.jsx
@@ -61,6 +61,7 @@ class TspWrapper extends Component {
                 <PrivateRoute path="/queues/:queueType(new|approved|in_transit|delivered|all)" component={Queues} />
                 {!isProduction && <PrivateRoute path="/playground" component={ScratchPad} />}
                 {/* TODO: cgilmer (2018/07/31) Need a NotFound component to route to */}
+                <Redirect from="*" to="/queues/new" component={Queues} />
               </Switch>
             </div>
           </main>


### PR DESCRIPTION
## Description

Redirect user to queues/new if they visit an invalid route

## Setup
`make server_run`
`make tsp_client_run`

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/161323290) for this change
