### PR TITLE
Prevents create/update/delete unless item requires pre-approval [delivers #161064883]

### DIFF
--- a/pkg/models/tariff400ng_item.go
+++ b/pkg/models/tariff400ng_item.go
@@ -110,3 +110,11 @@ func FetchTariff400ngItems(dbConnection *pop.Connection, onlyRequiresPreApproval
 
 	return items, err
 }
+
+// FetchTariff400ngItem returns a Tariff400ngItem for the given ID
+func FetchTariff400ngItem(dbConnection *pop.Connection, id uuid.UUID) (Tariff400ngItem, error) {
+	item := Tariff400ngItem{}
+	err := dbConnection.Find(&item, id)
+
+	return item, err
+}


### PR DESCRIPTION
## Description

Users should only be able to create/edit shipment line items if the underlying `Tariff400ngItem` requires pre-approval. Others will trigger a 403 forbidden response

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](./docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](./docs/backend.md#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](./docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
* [ ] There are no aXe warnings for UI.
* [ ] This works in IE.
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @willowbl00
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/161064883) for this change