### PR TITLE
GBL generation error clarity

### DIFF
--- a/cypress/integration/tsp/generateGBL.js
+++ b/cypress/integration/tsp/generateGBL.js
@@ -75,7 +75,7 @@ function tspUserGeneratesGBL() {
     .contains(gblButtonText)
     .should('be.disabled');
 
-  cy.get('.usa-alert-warning').contains('There is already a GBL for this shipment. ');
+  cy.get('.usa-alert-text').contains('There is already a Bill of Lading for this shipment');
 }
 
 function tspUserViewsGBL() {

--- a/pkg/handlers/errors.go
+++ b/pkg/handlers/errors.go
@@ -101,3 +101,19 @@ func ResponseForConflictErrors(logger *zap.Logger, err error) middleware.Respond
 
 	return newErrResponse(http.StatusConflict, err)
 }
+
+// ResponseForFailedExpectationErrors checks for conflict errors
+func ResponseForFailedExpectationErrors(logger *zap.Logger, err error) middleware.Responder {
+	skipLogger := logger.WithOptions(zap.AddCallerSkip(1))
+	skipLogger.Error("Encountered failed expectation error", zap.Error(err))
+
+	return newErrResponse(http.StatusExpectationFailed, err)
+}
+
+// ResponseForBadRequestErrors checks for conflict errors
+func ResponseForBadRequestErrors(logger *zap.Logger, err error) middleware.Responder {
+	skipLogger := logger.WithOptions(zap.AddCallerSkip(1))
+	skipLogger.Error("Encountered bad request error", zap.Error(err))
+
+	return newErrResponse(http.StatusBadRequest, err)
+}

--- a/pkg/handlers/errors.go
+++ b/pkg/handlers/errors.go
@@ -94,7 +94,7 @@ func ResponseForVErrors(logger *zap.Logger, verrs *validate.Errors, err error) m
 	return ResponseForError(skipLogger, err)
 }
 
-// ResponseForCustomErrors checks for conflict errors
+// ResponseForCustomErrors checks for custom errors and returns a custom response body message
 func ResponseForCustomErrors(logger *zap.Logger, err error, httpStatus int) middleware.Responder {
 	skipLogger := logger.WithOptions(zap.AddCallerSkip(1))
 	skipLogger.Error("Encountered error", zap.Error(err))

--- a/pkg/handlers/errors.go
+++ b/pkg/handlers/errors.go
@@ -94,26 +94,18 @@ func ResponseForVErrors(logger *zap.Logger, verrs *validate.Errors, err error) m
 	return ResponseForError(skipLogger, err)
 }
 
+// ResponseForCustomErrors checks for conflict errors
+func ResponseForCustomErrors(logger *zap.Logger, err error, httpStatus int) middleware.Responder {
+	skipLogger := logger.WithOptions(zap.AddCallerSkip(1))
+	skipLogger.Error("Encountered error", zap.Error(err))
+
+	return newErrResponse(httpStatus, err)
+}
+
 // ResponseForConflictErrors checks for conflict errors
 func ResponseForConflictErrors(logger *zap.Logger, err error) middleware.Responder {
 	skipLogger := logger.WithOptions(zap.AddCallerSkip(1))
 	skipLogger.Error("Encountered conflict error", zap.Error(err))
 
 	return newErrResponse(http.StatusConflict, err)
-}
-
-// ResponseForFailedExpectationErrors checks for conflict errors
-func ResponseForFailedExpectationErrors(logger *zap.Logger, err error) middleware.Responder {
-	skipLogger := logger.WithOptions(zap.AddCallerSkip(1))
-	skipLogger.Error("Encountered failed expectation error", zap.Error(err))
-
-	return newErrResponse(http.StatusExpectationFailed, err)
-}
-
-// ResponseForBadRequestErrors checks for conflict errors
-func ResponseForBadRequestErrors(logger *zap.Logger, err error) middleware.Responder {
-	skipLogger := logger.WithOptions(zap.AddCallerSkip(1))
-	skipLogger.Error("Encountered bad request error", zap.Error(err))
-
-	return newErrResponse(http.StatusBadRequest, err)
 }

--- a/pkg/handlers/publicapi/shipments.go
+++ b/pkg/handlers/publicapi/shipments.go
@@ -2,6 +2,7 @@ package publicapi
 
 import (
 	"fmt"
+	"net/http"
 	"time"
 
 	"github.com/go-openapi/runtime/middleware"
@@ -575,7 +576,7 @@ func (h CreateGovBillOfLadingHandler) Handle(params shipmentop.CreateGovBillOfLa
 	if len(extantGBLS) > 0 {
 		// h.Logger().Error("There are already GBLs for this shipment.")
 		// return shipmentop.NewCreateGovBillOfLadingBadRequest()
-		return handlers.ResponseForBadRequestErrors(h.Logger(), fmt.Errorf("there is already a Bill of Lading for this shipment"))
+		return handlers.ResponseForCustomErrors(h.Logger(), fmt.Errorf("there is already a Bill of Lading for this shipment"), http.StatusBadRequest)
 	}
 
 	// Don't allow GBL generation for incomplete orders
@@ -583,8 +584,8 @@ func (h CreateGovBillOfLadingHandler) Handle(params shipmentop.CreateGovBillOfLa
 	if ordersErr != nil {
 		return handlers.ResponseForError(h.Logger(), ordersErr)
 	}
-	if orders.IsComplete() != true {
-		return handlers.ResponseForFailedExpectationErrors(h.Logger(), fmt.Errorf("the move is missing some information from the JPPSO. Please contact the JPPSO"))
+	if orders.IsCompleteForGBL() != true {
+		return handlers.ResponseForCustomErrors(h.Logger(), fmt.Errorf("the move is missing some information from the JPPSO. Please contact the JPPSO"), http.StatusExpectationFailed)
 	}
 
 	// Create PDF for GBL

--- a/pkg/handlers/publicapi/shipments.go
+++ b/pkg/handlers/publicapi/shipments.go
@@ -1,6 +1,7 @@
 package publicapi
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/go-openapi/runtime/middleware"
@@ -572,8 +573,18 @@ func (h CreateGovBillOfLadingHandler) Handle(params shipmentop.CreateGovBillOfLa
 	// Don't allow GBL generation for shipments that already have a GBL move document
 	extantGBLS, _ := models.FetchMoveDocumentsByTypeForShipment(h.DB(), session, models.MoveDocumentTypeGOVBILLOFLADING, shipmentID)
 	if len(extantGBLS) > 0 {
-		h.Logger().Error("There are already GBLs for this shipment.")
-		return shipmentop.NewCreateGovBillOfLadingBadRequest()
+		// h.Logger().Error("There are already GBLs for this shipment.")
+		// return shipmentop.NewCreateGovBillOfLadingBadRequest()
+		return handlers.ResponseForBadRequestErrors(h.Logger(), fmt.Errorf("there is already a Bill of Lading for this shipment"))
+	}
+
+	// Don't allow GBL generation for incomplete orders
+	orders, ordersErr := models.FetchOrder(h.DB(), shipment.Move.OrdersID)
+	if ordersErr != nil {
+		return handlers.ResponseForError(h.Logger(), ordersErr)
+	}
+	if orders.IsComplete() != true {
+		return handlers.ResponseForFailedExpectationErrors(h.Logger(), fmt.Errorf("the move is missing some information from the JPPSO. Please contact the JPPSO"))
 	}
 
 	// Create PDF for GBL

--- a/pkg/handlers/publicapi/shipments.go
+++ b/pkg/handlers/publicapi/shipments.go
@@ -574,8 +574,6 @@ func (h CreateGovBillOfLadingHandler) Handle(params shipmentop.CreateGovBillOfLa
 	// Don't allow GBL generation for shipments that already have a GBL move document
 	extantGBLS, _ := models.FetchMoveDocumentsByTypeForShipment(h.DB(), session, models.MoveDocumentTypeGOVBILLOFLADING, shipmentID)
 	if len(extantGBLS) > 0 {
-		// h.Logger().Error("There are already GBLs for this shipment.")
-		// return shipmentop.NewCreateGovBillOfLadingBadRequest()
 		return handlers.ResponseForCustomErrors(h.Logger(), fmt.Errorf("there is already a Bill of Lading for this shipment"), http.StatusBadRequest)
 	}
 

--- a/pkg/models/order.go
+++ b/pkg/models/order.go
@@ -229,15 +229,9 @@ func (o *Order) IsComplete() bool {
 	return true
 }
 
-// IsCompleteForGBL checks if orders have all fields necessary to approve a move
+// IsCompleteForGBL checks if orders have all fields necessary to generate a GBL
 func (o *Order) IsCompleteForGBL() bool {
 
-	if o.OrdersNumber == nil {
-		return false
-	}
-	if o.OrdersTypeDetail == nil {
-		return false
-	}
 	if o.DepartmentIndicator == nil {
 		return false
 	}

--- a/pkg/models/order.go
+++ b/pkg/models/order.go
@@ -226,6 +226,26 @@ func (o *Order) IsComplete() bool {
 	if o.TAC == nil {
 		return false
 	}
+	return true
+}
 
+// IsCompleteForGBL checks if orders have all fields necessary to approve a move
+func (o *Order) IsCompleteForGBL() bool {
+
+	if o.OrdersNumber == nil {
+		return false
+	}
+	if o.OrdersTypeDetail == nil {
+		return false
+	}
+	if o.DepartmentIndicator == nil {
+		return false
+	}
+	if o.TAC == nil {
+		return false
+	}
+	if o.SAC == nil {
+		return false
+	}
 	return true
 }

--- a/pkg/testdatagen/scenario/e2ebasic.go
+++ b/pkg/testdatagen/scenario/e2ebasic.go
@@ -1384,7 +1384,7 @@ func MakeHhgFromAwardedToAcceptedGBLReady(db *pop.Connection, tspUser models.Tsp
 	/*
 	 * Service member with uploaded orders and an approved shipment to be accepted, able to generate GBL
 	 */
-	email := "hhg@gov_bill_of_lading.ready"
+	email := "hhg@govbilloflading.ready"
 
 	packDate := time.Now().AddDate(0, 0, 1)
 	pickupDate := time.Now().AddDate(0, 0, 5)

--- a/pkg/testdatagen/scenario/e2ebasic.go
+++ b/pkg/testdatagen/scenario/e2ebasic.go
@@ -1413,7 +1413,7 @@ func MakeHhgFromAwardedToAcceptedGBLReady(db *pop.Connection, tspUser models.Tsp
 			PersonalEmail: models.StringPointer(email),
 		},
 		Order: models.Order{
-			DepartmentIndicator: models.StringPointer("17"),
+			DepartmentIndicator: models.StringPointer("AIR_FORCE"),
 			TAC:                 models.StringPointer("NTA4"),
 			SAC:                 models.StringPointer("1234567890 9876543210"),
 		},

--- a/src/scenes/Office/AccountingPanel.jsx
+++ b/src/scenes/Office/AccountingPanel.jsx
@@ -1,4 +1,4 @@
-import { get } from 'lodash';
+import { get, isEmpty } from 'lodash';
 import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
@@ -14,13 +14,13 @@ const AccountingDisplay = props => {
     schema: props.ordersSchema,
     values: props.orders,
   };
-
+  const isRequired = props.isHHG ? true : false;
   return (
     <React.Fragment>
       <div className="editable-panel-column">
         <PanelSwaggerField title="Department indicator" fieldName="department_indicator" required {...fieldProps} />
 
-        <PanelSwaggerField title="SAC" fieldName="sac" {...fieldProps} />
+        <PanelSwaggerField title="SAC" required={isRequired} fieldName="sac" {...fieldProps} />
       </div>
       <div className="editable-panel-column">
         <PanelSwaggerField title="TAC" required fieldName="tac" {...fieldProps} />
@@ -31,6 +31,7 @@ const AccountingDisplay = props => {
 
 const AccountingEdit = props => {
   const { ordersSchema } = props;
+  const isRequired = props.isHHG ? true : false;
   return (
     <React.Fragment>
       <div className="editable-panel-column">
@@ -40,7 +41,7 @@ const AccountingEdit = props => {
         <SwaggerField title="TAC" fieldName="tac" swagger={ordersSchema} required />
       </div>
       <div className="editable-panel-column">
-        <SwaggerField title="SAC" fieldName="sac" swagger={ordersSchema} />
+        <SwaggerField title="SAC" fieldName="sac" swagger={ordersSchema} required={isRequired} />
       </div>
     </React.Fragment>
   );
@@ -68,6 +69,7 @@ function mapStateToProps(state) {
     errorMessage: state.office.error,
 
     orders: orders,
+    isHHG: !isEmpty(get(state, 'office.officeMove.shipments.0', {})),
     isUpdating: state.office.ordersAreUpdating,
 
     // editablePanelify

--- a/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
+++ b/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
@@ -7,6 +7,7 @@ import { get, capitalize } from 'lodash';
 import { NavLink, Link } from 'react-router-dom';
 import { reduxForm } from 'redux-form';
 import faPlusCircle from '@fortawesome/fontawesome-free-solid/faPlusCircle';
+import { titleCase } from 'shared/constants.js';
 
 import LoadingPlaceholder from 'shared/LoadingPlaceholder';
 
@@ -58,8 +59,8 @@ import PickupForm from './PickupForm';
 import './tsp.css';
 
 const attachmentsErrorMessages = {
-  400: 'There is already a GBL for this shipment. ',
-  417: 'Missing data required to generate a GBL.',
+  400: 'An error occured',
+  417: 'Missing data required to generate a Bill of Lading.',
 };
 
 class AcceptShipmentPanel extends Component {
@@ -308,12 +309,16 @@ class ShipmentInfo extends Component {
 
               {generateGBLError && (
                 <p>
-                  <Alert type="warning" heading="An error occurred">
-                    {attachmentsErrorMessages[this.props.error.statusCode] ||
+                  <Alert
+                    type="warning"
+                    heading={attachmentsErrorMessages[this.props.generateGBLError.status] || 'An error occurred'}
+                  >
+                    {titleCase(get(generateGBLError.response, 'body.message', '')) ||
                       'Something went wrong contacting the server.'}
                   </Alert>
                 </p>
               )}
+
               {generateGBLSuccess && (
                 <p>
                   <Alert type="success" heading="GBL has been created">

--- a/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
+++ b/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
@@ -59,7 +59,7 @@ import PickupForm from './PickupForm';
 import './tsp.css';
 
 const attachmentsErrorMessages = {
-  400: 'An error occured',
+  400: 'An error occurred',
   417: 'Missing data required to generate a Bill of Lading.',
 };
 

--- a/src/scenes/TransportationServiceProvider/ducks.js
+++ b/src/scenes/TransportationServiceProvider/ducks.js
@@ -415,9 +415,8 @@ export function tspReducer(state = initialState, action) {
     case GENERATE_GBL.failure:
       return Object.assign({}, state, {
         generateGBLSuccess: false,
-        generateGBLError: true,
+        generateGBLError: action.error,
         generateGBLInProgress: false,
-        error: action.error,
         gblDocUrl: null,
       });
 

--- a/src/shared/JsonSchemaForm/JsonSchemaField.js
+++ b/src/shared/JsonSchemaForm/JsonSchemaField.js
@@ -225,6 +225,9 @@ export const SwaggerField = props => {
   if (required) {
     // eslint-disable-next-line security/detect-object-injection
     swaggerField[ALWAYS_REQUIRED_KEY] = true;
+  } else {
+    // eslint-disable-next-line security/detect-object-injection
+    swaggerField[ALWAYS_REQUIRED_KEY] = false;
   }
 
   return createSchemaField(


### PR DESCRIPTION
## Description

When the GBL fails to generate because of missing order information, then the user gets a message that says:
Header: Missing data required to generate a Bill of Lading.
Details: The move is missing some information from the JPPSO. Please contact the JPPSO.

Completion for GBL creation is defined as orders having a value for a TAC, SAC and DEPARTMENT INDICATOR. 

Until we verify whether the SAC is a necessary field for GBL generation, it will be required for an HHG move and not required for a PPM move in the office accounting panel.

## Setup

Use move GBLGBL - set the TAC, SAC or DEPARTMENT INDICATOR field to null for the corresponding orders. Try to generate a GBL - you should see the error outlined above, and a response of 417.

 Add the above orders values in the corresponding office view (or run `make db_dev_populate`), generate a GBL - verify success. 

Verify that the office accounting panel renders the SAC field as optional for moves with PPM, but REQUIRED for HHG moves.

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](./docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](./docs/backend.md#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](./docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
* [ ] There are no aXe warnings for UI.
* [ ] This works in IE.
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @willowbl00
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/161229884) for this change

## Screenshots

<img width="873" alt="screen shot 2018-10-29 at 4 20 11 pm" src="https://user-images.githubusercontent.com/8170735/47686084-aaaf6980-db96-11e8-943e-f598b01b9203.png">


