### PR TITLE
Integrate Honeycomb tracing and logging into the AwardQueue

### DIFF
--- a/cmd/tsp_award_queue/main.go
+++ b/cmd/tsp_award_queue/main.go
@@ -2,10 +2,11 @@ package main
 
 import (
 	"context"
+	"log"
+
 	"github.com/gobuffalo/pop"
 	"github.com/namsral/flag"
 	"go.uber.org/zap"
-	"log"
 
 	"github.com/transcom/mymove/pkg/awardqueue"
 )

--- a/cmd/tsp_award_queue/main.go
+++ b/cmd/tsp_award_queue/main.go
@@ -9,6 +9,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/transcom/mymove/pkg/awardqueue"
+	"github.com/transcom/mymove/pkg/logging/hnyzap"
 )
 
 var logger *zap.Logger
@@ -31,6 +32,7 @@ func main() {
 		log.Fatalf("Failed to initialize Zap logging due to %v", err)
 	}
 	zap.ReplaceGlobals(logger)
+	honeyZapLogger := hnyzap.Logger{Logger: logger}
 
 	// DB connection
 	err = pop.AddLookupPaths(*config)
@@ -42,7 +44,7 @@ func main() {
 		log.Panic(err)
 	}
 
-	awardQueue := awardqueue.NewAwardQueue(dbConnection, logger)
+	awardQueue := awardqueue.NewAwardQueue(dbConnection, &honeyZapLogger)
 	err = awardQueue.Run(context.Background())
 	if err != nil {
 		log.Panic(err)

--- a/cmd/tsp_award_queue/main.go
+++ b/cmd/tsp_award_queue/main.go
@@ -1,11 +1,11 @@
 package main
 
 import (
-	"log"
-
+	"context"
 	"github.com/gobuffalo/pop"
 	"github.com/namsral/flag"
 	"go.uber.org/zap"
+	"log"
 
 	"github.com/transcom/mymove/pkg/awardqueue"
 )
@@ -41,7 +41,8 @@ func main() {
 		log.Panic(err)
 	}
 
-	awardQueue := awardqueue.NewAwardQueue(dbConnection, logger)
+	var ctx context.Context
+	awardQueue := awardqueue.NewAwardQueue(ctx, dbConnection, logger)
 	err = awardQueue.Run()
 	if err != nil {
 		log.Panic(err)

--- a/cmd/tsp_award_queue/main.go
+++ b/cmd/tsp_award_queue/main.go
@@ -42,9 +42,8 @@ func main() {
 		log.Panic(err)
 	}
 
-	var ctx context.Context
-	awardQueue := awardqueue.NewAwardQueue(ctx, dbConnection, logger)
-	err = awardQueue.Run()
+	awardQueue := awardqueue.NewAwardQueue(dbConnection, logger)
+	err = awardQueue.Run(context.Background())
 	if err != nil {
 		log.Panic(err)
 	}

--- a/cmd/webserver/main.go
+++ b/cmd/webserver/main.go
@@ -97,6 +97,7 @@ func initFlags(flag *pflag.FlagSet) {
 	flag.String("config-dir", "config", "The location of server config files")
 	flag.String("env", "development", "The environment to run in, which configures the database.")
 	flag.String("interface", "", "The interface spec to listen for connections on. Default is all.")
+	flag.String("service-name", "app", "The service name identifies the application for instrumentation.")
 
 	flag.String("http-my-server-name", "localhost", "Hostname according to environment.")
 	flag.String("http-office-server-name", "officelocal", "Hostname according to environment.")
@@ -205,13 +206,15 @@ func initHoneycomb(v *viper.Viper, logger *zap.Logger) bool {
 
 	honeycombAPIKey := v.GetString("honeycomb-api-key")
 	honeycombDataset := v.GetString("honeycomb-dataset")
+	honeycombServiceName := v.GetString("service-name")
 
 	if v.GetBool("honeycomb-enabled") && len(honeycombAPIKey) > 0 && len(honeycombDataset) > 0 {
 		logger.Debug("Honeycomb Integration enabled", zap.String("honeycomb-dataset", honeycombDataset))
 		beeline.Init(beeline.Config{
-			WriteKey: honeycombAPIKey,
-			Dataset:  honeycombDataset,
-			Debug:    v.GetBool("honeycomb-debug"),
+			WriteKey:    honeycombAPIKey,
+			Dataset:     honeycombDataset,
+			Debug:       v.GetBool("honeycomb-debug"),
+			ServiceName: honeycombServiceName,
 		})
 		return true
 	}

--- a/config/app-client-tls.container-definition.json
+++ b/config/app-client-tls.container-definition.json
@@ -21,7 +21,11 @@
     "container",
     "--debug-logging"
   ],
-  "environment": [
+    "environment": [
+    {
+      "name": "SERVICE_NAME",
+      "value": "app-client-tls"
+    },
     {
       "name": "ENVIRONMENT",
       "value": "{{ .environment }}"

--- a/config/app.container-definition.json
+++ b/config/app.container-definition.json
@@ -23,6 +23,10 @@
   ],
   "environment": [
     {
+      "name": "SERVICE_NAME",
+      "value": "app"
+    },
+    {
       "name": "ENVIRONMENT",
       "value": "{{ .environment }}"
     },

--- a/pkg/auth/authentication/auth.go
+++ b/pkg/auth/authentication/auth.go
@@ -22,6 +22,7 @@ import (
 func UserAuthMiddleware(logger *zap.Logger) func(next http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		mw := func(w http.ResponseWriter, r *http.Request) {
+			_, span := beeline.StartSpan(r.Context(), "UserAuthMiddleware")
 			session := auth.SessionFromRequestContext(r)
 			// We must have a logged in session and a user
 			if session == nil || session.UserID == uuid.Nil {
@@ -44,11 +45,11 @@ func UserAuthMiddleware(logger *zap.Logger) func(next http.Handler) http.Handler
 			}
 
 			// Include session office, service member, tsp and user IDs to the beeline event
-			beeline.AddField(r.Context(), "session.office_user_id", session.OfficeUserID)
-			beeline.AddField(r.Context(), "session.service_member_id", session.ServiceMemberID)
-			beeline.AddField(r.Context(), "session.tsp_user_id", session.TspUserID)
-			beeline.AddField(r.Context(), "session.user_id", session.UserID)
-
+			span.AddField("auth.office_user_id", session.OfficeUserID)
+			span.AddField("auth.service_member_id", session.ServiceMemberID)
+			span.AddField("auth.tsp_user_id", session.TspUserID)
+			span.AddField("auth.user_id", session.UserID)
+			span.Send()
 			next.ServeHTTP(w, r)
 			return
 		}

--- a/pkg/awardqueue/awardqueue.go
+++ b/pkg/awardqueue/awardqueue.go
@@ -300,9 +300,9 @@ func waitForLock(ctx context.Context, db *pop.Connection, id int) error {
 }
 
 // NewAwardQueue creates a new AwardQueue
-func NewAwardQueue(db *pop.Connection, logger *zap.Logger) *AwardQueue {
+func NewAwardQueue(db *pop.Connection, logger *hnyzap.Logger) *AwardQueue {
 	return &AwardQueue{
 		db:     db,
-		logger: &hnyzap.Logger{Logger: logger},
+		logger: logger,
 	}
 }

--- a/pkg/awardqueue/awardqueue.go
+++ b/pkg/awardqueue/awardqueue.go
@@ -111,6 +111,8 @@ func (aq *AwardQueue) attemptShipmentOffer(ctx context.Context, shipment models.
 						aq.logger.Info("Shipment offered to TSP!",
 							zap.Int("quality_band", qb),
 							zap.Int("offer_count", tspPerformance.OfferCount))
+						span.AddField("quality_band", qb)
+						span.AddField("offer_count", tspPerformance.OfferCount)
 						foundAvailableTSP = true
 
 						// Award the shipment

--- a/pkg/awardqueue/awardqueue.go
+++ b/pkg/awardqueue/awardqueue.go
@@ -112,8 +112,7 @@ func (aq *AwardQueue) attemptShipmentOffer(ctx context.Context, shipment models.
 							zap.Int("quality_band", qb),
 							zap.Int("offer_count", tspPerformance.OfferCount))
 						foundAvailableTSP = true
-						// test Error
-						aq.logErrorAndTrace("Failed to offer to TSP", fmt.Errorf("it's all broken"), span)
+
 						// Award the shipment
 						if err := models.AwardShipment(aq.db, shipment.ID); err != nil {
 							aq.logErrorAndTrace("Failed to set shipment as awarded", err, span)
@@ -317,7 +316,7 @@ func waitForLock(ctx context.Context, db *pop.Connection, id int) error {
 
 // logErrorAndTrace logs and error message with zap and submits the error to a Honeycomb trace
 func (aq *AwardQueue) logErrorAndTrace(errorMessage string, err error, span *trace.Span) {
-	span.AddField("awardqueue.error", err)
+	span.AddField("awardqueue.error", err.Error())
 	span.AddField("awardqueue.error_message", errorMessage)
 	aq.logger.Error(errorMessage, zap.Error(err))
 }

--- a/pkg/awardqueue/awardqueue_test.go
+++ b/pkg/awardqueue/awardqueue_test.go
@@ -19,7 +19,7 @@ import (
 
 func (suite *AwardQueueSuite) Test_CheckAllTSPsBlackedOut() {
 	t := suite.T()
-	queue := NewAwardQueue(suite.ctx, suite.db, suite.logger)
+	queue := NewAwardQueue(suite.db, suite.logger)
 
 	tsp := testdatagen.MakeDefaultTSP(suite.db)
 
@@ -59,7 +59,7 @@ func (suite *AwardQueueSuite) Test_CheckAllTSPsBlackedOut() {
 	})
 
 	// Run the Award Queue
-	offer, err := queue.attemptShipmentOffer(suite.ctx, shipment)
+	offer, err := queue.attemptShipmentOffer(context.Background(), shipment)
 
 	expectedError := "could not find a TSP without blackout dates"
 	// See if shipment was offered
@@ -72,7 +72,7 @@ func (suite *AwardQueueSuite) Test_CheckAllTSPsBlackedOut() {
 
 func (suite *AwardQueueSuite) Test_CheckShipmentDuringBlackOut() {
 	t := suite.T()
-	queue := NewAwardQueue(suite.ctx, suite.db, suite.logger)
+	queue := NewAwardQueue(suite.db, suite.logger)
 
 	tsp := testdatagen.MakeDefaultTSP(suite.db)
 
@@ -126,7 +126,7 @@ func (suite *AwardQueueSuite) Test_CheckShipmentDuringBlackOut() {
 	})
 
 	// Run the Award Queue
-	queue.assignShipments(suite.ctx)
+	queue.assignShipments(context.Background())
 
 	shipmentOffer := models.ShipmentOffer{}
 	query := suite.db.Where("shipment_id = $1", shipment.ID)
@@ -169,7 +169,7 @@ func (suite *AwardQueueSuite) Test_CheckShipmentDuringBlackOut() {
 
 func (suite *AwardQueueSuite) Test_ShipmentWithinBlackoutDates() {
 	t := suite.T()
-	queue := NewAwardQueue(suite.ctx, suite.db, suite.logger)
+	queue := NewAwardQueue(suite.db, suite.logger)
 	// Creates a TSP with a blackout date connected to both.
 	testTSP1 := testdatagen.MakeDefaultTSP(suite.db)
 
@@ -253,7 +253,7 @@ func (suite *AwardQueueSuite) Test_ShipmentWithinBlackoutDates() {
 
 func (suite *AwardQueueSuite) Test_FindAllUnassignedShipments() {
 	t := suite.T()
-	queue := NewAwardQueue(suite.ctx, suite.db, suite.logger)
+	queue := NewAwardQueue(suite.db, suite.logger)
 	_, err := queue.findAllUnassignedShipments()
 
 	if err != nil {
@@ -265,7 +265,7 @@ func (suite *AwardQueueSuite) Test_FindAllUnassignedShipments() {
 // it actually gets offered.
 func (suite *AwardQueueSuite) Test_OfferSingleShipment() {
 	t := suite.T()
-	queue := NewAwardQueue(suite.ctx, suite.db, suite.logger)
+	queue := NewAwardQueue(suite.db, suite.logger)
 
 	// Make a shipment
 	market := testdatagen.DefaultMarket
@@ -292,7 +292,7 @@ func (suite *AwardQueueSuite) Test_OfferSingleShipment() {
 	suite.Nil(err)
 
 	// Run the Award Queue
-	offer, err := queue.attemptShipmentOffer(suite.ctx, shipment)
+	offer, err := queue.attemptShipmentOffer(context.Background(), shipment)
 
 	// See if shipment was offered
 	if err != nil {
@@ -317,7 +317,7 @@ func (suite *AwardQueueSuite) Test_OfferSingleShipment() {
 // any enabled TSPs.
 func (suite *AwardQueueSuite) Test_FailOfferingSingleShipment() {
 	t := suite.T()
-	queue := NewAwardQueue(suite.ctx, suite.db, suite.logger)
+	queue := NewAwardQueue(suite.db, suite.logger)
 
 	// Make a shipment in a new TDL, which inherently has no TSPs
 	market := "dHHG"
@@ -351,7 +351,7 @@ func (suite *AwardQueueSuite) Test_FailOfferingSingleShipment() {
 	suite.Nil(err)
 
 	// Run the Award Queue
-	offer, err := queue.attemptShipmentOffer(suite.ctx, shipment)
+	offer, err := queue.attemptShipmentOffer(context.Background(), shipment)
 
 	// See if shipment was offered
 	if err == nil {
@@ -364,7 +364,7 @@ func (suite *AwardQueueSuite) Test_FailOfferingSingleShipment() {
 
 func (suite *AwardQueueSuite) TestAssignShipmentsSingleTSP() {
 	t := suite.T()
-	queue := NewAwardQueue(suite.ctx, suite.db, suite.logger)
+	queue := NewAwardQueue(suite.db, suite.logger)
 
 	const shipmentsToMake = 10
 
@@ -398,7 +398,7 @@ func (suite *AwardQueueSuite) TestAssignShipmentsSingleTSP() {
 	testdatagen.MakeTSPPerformanceDeprecated(suite.db, tsp, tdl, swag.Int(1), mps+1, 0, .3, .3)
 
 	// Run the Award Queue
-	queue.assignShipments(suite.ctx)
+	queue.assignShipments(context.Background())
 
 	// Count the number of shipments offered to our TSP
 	query := suite.db.Where("transportation_service_provider_id = $1", tsp.ID)
@@ -428,7 +428,7 @@ func (suite *AwardQueueSuite) TestAssignShipmentsToMultipleTSPs() {
 
 	suite.db.TruncateAll()
 
-	queue := NewAwardQueue(suite.ctx, suite.db, suite.logger)
+	queue := NewAwardQueue(suite.db, suite.logger)
 
 	const shipmentsToMake = 17
 
@@ -470,7 +470,7 @@ func (suite *AwardQueueSuite) TestAssignShipmentsToMultipleTSPs() {
 	testdatagen.MakeTSPPerformanceDeprecated(suite.db, tsp5, tdl, swag.Int(4), mps+1, 0, .6, .6)
 
 	// Run the Award Queue
-	queue.assignShipments(suite.ctx)
+	queue.assignShipments(context.Background())
 
 	// TODO: revert to [6, 5, 3, 2, 1] after the B&M pilot
 	suite.verifyOfferCount(tsp1, 4)
@@ -513,7 +513,7 @@ func (suite *AwardQueueSuite) Test_GetTSPsPerBandNoRemainder() {
 
 func (suite *AwardQueueSuite) Test_AssignTSPsToBands() {
 	t := suite.T()
-	queue := NewAwardQueue(suite.ctx, suite.db, suite.logger)
+	queue := NewAwardQueue(suite.db, suite.logger)
 	tspsToMake := 5
 
 	tdl := testdatagen.MakeDefaultTDL(suite.db)
@@ -531,7 +531,7 @@ func (suite *AwardQueueSuite) Test_AssignTSPsToBands() {
 		}
 	}
 
-	err := queue.assignPerformanceBands(suite.ctx)
+	err := queue.assignPerformanceBands(context.Background())
 
 	if err != nil {
 		t.Errorf("Failed to assign to performance bands: %v", err)
@@ -566,7 +566,7 @@ func (suite *AwardQueueSuite) Test_AssignTSPsToBands() {
 // rate cycles get awarded shipments appropriately
 func (suite *AwardQueueSuite) Test_AwardTSPsInDifferentRateCycles() {
 	t := suite.T()
-	queue := NewAwardQueue(suite.ctx, suite.db, suite.logger)
+	queue := NewAwardQueue(suite.db, suite.logger)
 	sm := testdatagen.MakeDefaultServiceMember(suite.db)
 
 	twoMonths, _ := time.ParseDuration("2 months")
@@ -650,7 +650,7 @@ func (suite *AwardQueueSuite) Test_AwardTSPsInDifferentRateCycles() {
 		t.Error(err)
 	}
 
-	queue.assignShipments(suite.ctx)
+	queue.assignShipments(context.Background())
 
 	suite.verifyOfferCount(tspPeak, 1)
 	suite.verifyOfferCount(tspNonPeak, 1)
@@ -698,12 +698,13 @@ func (suite *AwardQueueSuite) verifyOfferCount(tsp models.TransportationServiceP
 }
 
 func (suite *AwardQueueSuite) Test_waitForLock() {
+	ctx := context.Background()
 	ret := make(chan int)
 	lockID := 1
 
 	go func() {
 		suite.db.Transaction(func(tx *pop.Connection) error {
-			suite.Nil(waitForLock(suite.ctx, tx, lockID))
+			suite.Nil(waitForLock(ctx, tx, lockID))
 			time.Sleep(time.Second)
 			ret <- 1
 			return nil
@@ -713,7 +714,7 @@ func (suite *AwardQueueSuite) Test_waitForLock() {
 	go func() {
 		suite.db.Transaction(func(tx *pop.Connection) error {
 			time.Sleep(time.Millisecond * 500)
-			suite.Nil(waitForLock(suite.ctx, tx, lockID))
+			suite.Nil(waitForLock(ctx, tx, lockID))
 			ret <- 2
 			return nil
 		})
@@ -740,7 +741,6 @@ func equalSlice(a []int, b []int) bool {
 
 type AwardQueueSuite struct {
 	suite.Suite
-	ctx    context.Context
 	db     *pop.Connection
 	logger *zap.Logger
 }

--- a/pkg/awardqueue/awardqueue_test.go
+++ b/pkg/awardqueue/awardqueue_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/zap"
 
+	"github.com/transcom/mymove/pkg/logging/hnyzap"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"
 	"github.com/transcom/mymove/pkg/unit"
@@ -742,7 +743,7 @@ func equalSlice(a []int, b []int) bool {
 type AwardQueueSuite struct {
 	suite.Suite
 	db     *pop.Connection
-	logger *zap.Logger
+	logger *hnyzap.Logger
 }
 
 func (suite *AwardQueueSuite) SetupTest() {
@@ -762,6 +763,9 @@ func TestAwardQueueSuite(t *testing.T) {
 		log.Panic(err)
 	}
 
-	hs := &AwardQueueSuite{db: db, logger: logger}
+	hs := &AwardQueueSuite{
+		db:     db,
+		logger: &hnyzap.Logger{Logger: logger},
+	}
 	suite.Run(t, hs)
 }

--- a/pkg/awardqueue/awardqueue_test.go
+++ b/pkg/awardqueue/awardqueue_test.go
@@ -1,6 +1,7 @@
 package awardqueue
 
 import (
+	"context"
 	"log"
 	"strings"
 	"testing"
@@ -8,6 +9,7 @@ import (
 
 	"github.com/go-openapi/swag"
 	"github.com/gobuffalo/pop"
+	//"github.com/honeycombio/libhoney-go"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/zap"
 
@@ -18,7 +20,7 @@ import (
 
 func (suite *AwardQueueSuite) Test_CheckAllTSPsBlackedOut() {
 	t := suite.T()
-	queue := NewAwardQueue(suite.db, suite.logger)
+	queue := NewAwardQueue(suite.ctx, suite.db, suite.logger)
 
 	tsp := testdatagen.MakeDefaultTSP(suite.db)
 
@@ -168,7 +170,7 @@ func (suite *AwardQueueSuite) Test_CheckShipmentDuringBlackOut() {
 
 func (suite *AwardQueueSuite) Test_ShipmentWithinBlackoutDates() {
 	t := suite.T()
-	queue := NewAwardQueue(suite.db, suite.logger)
+	queue := NewAwardQueue(suite.ctx, suite.db, suite.logger)
 	// Creates a TSP with a blackout date connected to both.
 	testTSP1 := testdatagen.MakeDefaultTSP(suite.db)
 
@@ -252,7 +254,7 @@ func (suite *AwardQueueSuite) Test_ShipmentWithinBlackoutDates() {
 
 func (suite *AwardQueueSuite) Test_FindAllUnassignedShipments() {
 	t := suite.T()
-	queue := NewAwardQueue(suite.db, suite.logger)
+	queue := NewAwardQueue(suite.ctx, suite.db, suite.logger)
 	_, err := queue.findAllUnassignedShipments()
 
 	if err != nil {
@@ -264,7 +266,7 @@ func (suite *AwardQueueSuite) Test_FindAllUnassignedShipments() {
 // it actually gets offered.
 func (suite *AwardQueueSuite) Test_OfferSingleShipment() {
 	t := suite.T()
-	queue := NewAwardQueue(suite.db, suite.logger)
+	queue := NewAwardQueue(suite.ctx, suite.db, suite.logger)
 
 	// Make a shipment
 	market := testdatagen.DefaultMarket
@@ -316,7 +318,7 @@ func (suite *AwardQueueSuite) Test_OfferSingleShipment() {
 // any enabled TSPs.
 func (suite *AwardQueueSuite) Test_FailOfferingSingleShipment() {
 	t := suite.T()
-	queue := NewAwardQueue(suite.db, suite.logger)
+	queue := NewAwardQueue(suite.ctx, suite.db, suite.logger)
 
 	// Make a shipment in a new TDL, which inherently has no TSPs
 	market := "dHHG"
@@ -363,7 +365,7 @@ func (suite *AwardQueueSuite) Test_FailOfferingSingleShipment() {
 
 func (suite *AwardQueueSuite) TestAssignShipmentsSingleTSP() {
 	t := suite.T()
-	queue := NewAwardQueue(suite.db, suite.logger)
+	queue := NewAwardQueue(suite.ctx, suite.db, suite.logger)
 
 	const shipmentsToMake = 10
 
@@ -427,7 +429,7 @@ func (suite *AwardQueueSuite) TestAssignShipmentsToMultipleTSPs() {
 
 	suite.db.TruncateAll()
 
-	queue := NewAwardQueue(suite.db, suite.logger)
+	queue := NewAwardQueue(suite.ctx, suite.db, suite.logger)
 
 	const shipmentsToMake = 17
 
@@ -512,7 +514,7 @@ func (suite *AwardQueueSuite) Test_GetTSPsPerBandNoRemainder() {
 
 func (suite *AwardQueueSuite) Test_AssignTSPsToBands() {
 	t := suite.T()
-	queue := NewAwardQueue(suite.db, suite.logger)
+	queue := NewAwardQueue(suite.ctx, suite.db, suite.logger)
 	tspsToMake := 5
 
 	tdl := testdatagen.MakeDefaultTDL(suite.db)
@@ -565,7 +567,7 @@ func (suite *AwardQueueSuite) Test_AssignTSPsToBands() {
 // rate cycles get awarded shipments appropriately
 func (suite *AwardQueueSuite) Test_AwardTSPsInDifferentRateCycles() {
 	t := suite.T()
-	queue := NewAwardQueue(suite.db, suite.logger)
+	queue := NewAwardQueue(suite.ctx, suite.db, suite.logger)
 	sm := testdatagen.MakeDefaultServiceMember(suite.db)
 
 	twoMonths, _ := time.ParseDuration("2 months")
@@ -739,6 +741,7 @@ func equalSlice(a []int, b []int) bool {
 
 type AwardQueueSuite struct {
 	suite.Suite
+	ctx    context.Context
 	db     *pop.Connection
 	logger *zap.Logger
 }

--- a/pkg/handlers/contexts.go
+++ b/pkg/handlers/contexts.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"github.com/gobuffalo/pop"
 	"github.com/transcom/mymove/pkg/iws"
+	"github.com/transcom/mymove/pkg/logging/hnyzap"
 	"github.com/transcom/mymove/pkg/notifications"
 	"github.com/transcom/mymove/pkg/route"
 	"github.com/transcom/mymove/pkg/storage"
@@ -13,6 +14,7 @@ import (
 type HandlerContext interface {
 	DB() *pop.Connection
 	Logger() *zap.Logger
+	HoneyZapLogger() *hnyzap.Logger
 	FileStorer() storage.FileStorer
 	SetFileStorer(storer storage.FileStorer)
 	NotificationSender() notifications.NotificationSender
@@ -55,6 +57,11 @@ func (context *handlerContext) DB() *pop.Connection {
 // Logger returns the logger to use in this context
 func (context *handlerContext) Logger() *zap.Logger {
 	return context.logger
+}
+
+// HoneyZapLogger returns the logger capable of writing to Honeycomb to use in this context
+func (context *handlerContext) HoneyZapLogger() *hnyzap.Logger {
+	return &hnyzap.Logger{Logger: context.logger}
 }
 
 // FileStorer returns the storage to use in the current context

--- a/pkg/handlers/errors.go
+++ b/pkg/handlers/errors.go
@@ -75,7 +75,7 @@ func ResponseForError(logger *zap.Logger, err error) middleware.Responder {
 		skipLogger.Debug("invalid transition", zap.Error(err))
 		return newErrResponse(http.StatusBadRequest, err)
 	default:
-		skipLogger.Error("Unexpected error", zap.Error(err))
+		skipLogger.Error("unexpected error", zap.Error(err))
 		return newErrResponse(http.StatusInternalServerError, err)
 	}
 }

--- a/pkg/handlers/internalapi/moves.go
+++ b/pkg/handlers/internalapi/moves.go
@@ -182,7 +182,9 @@ func (h SubmitMoveHandler) Handle(params moveop.SubmitMoveForApprovalParams) mid
 	err = move.Submit()
 	span.AddField("move-status", string(move.Status))
 	if err != nil {
-		h.Logger().Error("Failed to change move status to submit", zap.String("move_id", moveID.String()), zap.String("move_status", string(move.Status)))
+		h.HoneyZapLogger().TraceError(ctx, "Failed to change move status to submit",
+			zap.String("move_id", moveID.String()),
+			zap.String("move_status", string(move.Status)))
 		return handlers.ResponseForError(h.Logger(), err)
 	}
 
@@ -201,7 +203,7 @@ func (h SubmitMoveHandler) Handle(params moveop.SubmitMoveForApprovalParams) mid
 	}
 
 	if len(move.Shipments) > 0 {
-		go awardqueue.NewAwardQueue(h.DB(), h.Logger()).Run(ctx)
+		go awardqueue.NewAwardQueue(h.DB(), h.HoneyZapLogger()).Run(ctx)
 	}
 
 	movePayload, err := payloadForMoveModel(h.FileStorer(), move.Orders, *move)

--- a/pkg/handlers/internalapi/moves.go
+++ b/pkg/handlers/internalapi/moves.go
@@ -6,6 +6,7 @@ import (
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/go-openapi/swag"
 	"github.com/gofrs/uuid"
+	"github.com/honeycombio/beeline-go"
 	"go.uber.org/zap"
 
 	"github.com/transcom/mymove/pkg/auth"
@@ -165,9 +166,13 @@ type SubmitMoveHandler struct {
 // Handle ... submit a move for approval
 func (h SubmitMoveHandler) Handle(params moveop.SubmitMoveForApprovalParams) middleware.Responder {
 	session := auth.SessionFromRequestContext(params.HTTPRequest)
+	ctx := params.HTTPRequest.Context()
+	ctx, span := beeline.StartSpan(ctx, "SubmitMoveHandler")
+	defer span.Send()
 
 	/* #nosec UUID is pattern matched by swagger which checks the format */
 	moveID, _ := uuid.FromString(params.MoveID.String())
+	span.AddField("move_id", moveID)
 
 	move, err := models.FetchMove(h.DB(), session, moveID)
 	if err != nil {
@@ -175,6 +180,7 @@ func (h SubmitMoveHandler) Handle(params moveop.SubmitMoveForApprovalParams) mid
 	}
 
 	err = move.Submit()
+	span.AddField("move-status", string(move.Status))
 	if err != nil {
 		h.Logger().Error("Failed to change move status to submit", zap.String("move_id", moveID.String()), zap.String("move_status", string(move.Status)))
 		return handlers.ResponseForError(h.Logger(), err)
@@ -195,7 +201,7 @@ func (h SubmitMoveHandler) Handle(params moveop.SubmitMoveForApprovalParams) mid
 	}
 
 	if len(move.Shipments) > 0 {
-		go awardqueue.NewAwardQueue(params.HTTPRequest.Context(), h.DB(), h.Logger()).Run()
+		go awardqueue.NewAwardQueue(h.DB(), h.Logger()).Run(ctx)
 	}
 
 	movePayload, err := payloadForMoveModel(h.FileStorer(), move.Orders, *move)

--- a/pkg/handlers/internalapi/moves.go
+++ b/pkg/handlers/internalapi/moves.go
@@ -195,7 +195,7 @@ func (h SubmitMoveHandler) Handle(params moveop.SubmitMoveForApprovalParams) mid
 	}
 
 	if len(move.Shipments) > 0 {
-		go awardqueue.NewAwardQueue(h.DB(), h.Logger()).Run()
+		go awardqueue.NewAwardQueue(params.HTTPRequest.Context(), h.DB(), h.Logger()).Run()
 	}
 
 	movePayload, err := payloadForMoveModel(h.FileStorer(), move.Orders, *move)

--- a/pkg/handlers/publicapi/shipments.go
+++ b/pkg/handlers/publicapi/shipments.go
@@ -194,7 +194,7 @@ type RejectShipmentHandler struct {
 func (h RejectShipmentHandler) Handle(params shipmentop.RejectShipmentParams) middleware.Responder {
 	// set reason, set thing
 	session := auth.SessionFromRequestContext(params.HTTPRequest)
-
+	ctx := params.HTTPRequest.Context()
 	shipmentID, _ := uuid.FromString(params.ShipmentID.String())
 
 	// TODO: (cgilmer 2018_08_22) This is an extra query we don't need to run on every request. Put the
@@ -202,7 +202,7 @@ func (h RejectShipmentHandler) Handle(params shipmentop.RejectShipmentParams) mi
 	// See original commits in https://github.com/transcom/mymove/pull/802
 	tspUser, err := models.FetchTspUserByID(h.DB(), session.TspUserID)
 	if err != nil {
-		h.Logger().Error("DB Query", zap.Error(err))
+		h.HoneyZapLogger().TraceError(ctx, "DB Query", zap.Error(err))
 		return shipmentop.NewRejectShipmentForbidden()
 	}
 
@@ -210,19 +210,23 @@ func (h RejectShipmentHandler) Handle(params shipmentop.RejectShipmentParams) mi
 	shipment, shipmentOffer, verrs, err := models.RejectShipmentForTSP(h.DB(), tspUser.TransportationServiceProviderID, shipmentID, *params.Payload.Reason)
 	if err != nil || verrs.HasAny() {
 		if err == models.ErrFetchNotFound {
-			h.Logger().Error("DB Query", zap.Error(err))
+			h.HoneyZapLogger().TraceError(ctx, "DB Query", zap.Error(err))
 			return shipmentop.NewRejectShipmentBadRequest()
 		} else if err == models.ErrInvalidTransition {
-			h.Logger().Info("Attempted to reject shipment, got invalid transition", zap.Error(err), zap.String("shipment_status", string(shipment.Status)))
-			h.Logger().Info("Attempted to reject shipment offer, got invalid transition", zap.Error(err), zap.Bool("shipment_offer_accepted", *shipmentOffer.Accepted))
+			h.HoneyZapLogger().TraceInfo(ctx, "Attempted to reject shipment, got invalid transition",
+				zap.Error(err),
+				zap.String("shipment_status", string(shipment.Status)))
+			h.HoneyZapLogger().TraceInfo(ctx, "Attempted to reject shipment offer, got invalid transition",
+				zap.Error(err),
+				zap.Bool("shipment_offer_accepted", *shipmentOffer.Accepted))
 			return shipmentop.NewRejectShipmentConflict()
 		} else {
-			h.Logger().Error("Unknown Error", zap.Error(err))
+			h.HoneyZapLogger().TraceError(ctx, "Unknown Error", zap.Error(err))
 			return handlers.ResponseForVErrors(h.Logger(), verrs, err)
 		}
 	}
 
-	go awardqueue.NewAwardQueue(h.DB(), h.Logger()).Run(params.HTTPRequest.Context())
+	go awardqueue.NewAwardQueue(h.DB(), h.HoneyZapLogger()).Run(ctx)
 
 	sp := payloadForShipmentModel(*shipment)
 	return shipmentop.NewRejectShipmentOK().WithPayload(sp)

--- a/pkg/handlers/publicapi/shipments.go
+++ b/pkg/handlers/publicapi/shipments.go
@@ -221,7 +221,7 @@ func (h RejectShipmentHandler) Handle(params shipmentop.RejectShipmentParams) mi
 				zap.Bool("shipment_offer_accepted", *shipmentOffer.Accepted))
 			return shipmentop.NewRejectShipmentConflict()
 		} else {
-			h.HoneyZapLogger().TraceError(ctx, "Unknown Error", zap.Error(err))
+			h.Logger().Error("Unknown Error", zap.Error(err))
 			return handlers.ResponseForVErrors(h.Logger(), verrs, err)
 		}
 	}

--- a/pkg/handlers/publicapi/shipments.go
+++ b/pkg/handlers/publicapi/shipments.go
@@ -222,7 +222,7 @@ func (h RejectShipmentHandler) Handle(params shipmentop.RejectShipmentParams) mi
 		}
 	}
 
-	go awardqueue.NewAwardQueue(h.DB(), h.Logger()).Run()
+	go awardqueue.NewAwardQueue(params.HTTPRequest.Context(), h.DB(), h.Logger()).Run()
 
 	sp := payloadForShipmentModel(*shipment)
 	return shipmentop.NewRejectShipmentOK().WithPayload(sp)

--- a/pkg/handlers/publicapi/shipments.go
+++ b/pkg/handlers/publicapi/shipments.go
@@ -222,7 +222,7 @@ func (h RejectShipmentHandler) Handle(params shipmentop.RejectShipmentParams) mi
 		}
 	}
 
-	go awardqueue.NewAwardQueue(params.HTTPRequest.Context(), h.DB(), h.Logger()).Run()
+	go awardqueue.NewAwardQueue(h.DB(), h.Logger()).Run(params.HTTPRequest.Context())
 
 	sp := payloadForShipmentModel(*shipment)
 	return shipmentop.NewRejectShipmentOK().WithPayload(sp)

--- a/pkg/logging/hnyzap/hnyzap.go
+++ b/pkg/logging/hnyzap/hnyzap.go
@@ -1,0 +1,95 @@
+package hnyzap
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"strings"
+
+	"github.com/honeycombio/beeline-go"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+const fieldPrefix string = "logging"
+
+// Logger is a wrapped zap.Logger to extend zap logs into Honeycomb.
+type Logger struct {
+	*zap.Logger
+}
+
+// LogToHoneycombSpan translates zap.Fields into fields supported by Honeycomb's
+// tracing service. Honeycomb currently support bool, number, and string
+// types. zap.Field types not supported by Honeycomb will still be logged to
+// zap, but will be sent to Honeycomb with a string "unsupported field type".
+func LogToHoneycombSpan(ctx context.Context, level string, msg string, fields ...zap.Field) {
+	_, span := beeline.StartSpan(ctx, level)
+	defer span.Send()
+
+	span.AddField(fmt.Sprintf("%s.level", fieldPrefix), strings.ToLower(level))
+	span.AddField(fmt.Sprintf("%s.msg", fieldPrefix), msg)
+	for _, zapField := range fields {
+		fieldKey := fmt.Sprintf("%s.%s", fieldPrefix, zapField.Key)
+		switch zapField.Type {
+		case zapcore.BoolType:
+			val := false
+			if zapField.Integer >= 1 {
+				val = true
+			}
+			span.AddField(fieldKey, val)
+		case zapcore.Float32Type:
+			span.AddField(fieldKey, math.Float32frombits(uint32(zapField.Integer)))
+		case zapcore.Float64Type:
+			span.AddField(fieldKey, math.Float64frombits(uint64(zapField.Integer)))
+		case zapcore.Int64Type:
+			span.AddField(fieldKey, zapField.Integer)
+		case zapcore.Int32Type:
+			span.AddField(fieldKey, int32(zapField.Integer))
+		case zapcore.StringType:
+			span.AddField(fieldKey, zapField.String)
+		case zapcore.Uint64Type:
+			span.AddField(fieldKey, uint64(zapField.Integer))
+		case zapcore.Uint32Type:
+			span.AddField(fieldKey, uint32(zapField.Integer))
+		case zapcore.ErrorType:
+			span.AddField(fieldKey, zapField.Interface.(error).Error())
+		default:
+			span.AddField(fieldKey, "unsupported field type")
+		}
+	}
+}
+
+// TraceDebug logs a message at DebugLevel to a span within a Honeycomb trace as well as the configured zap logger.
+func (l *Logger) TraceDebug(ctx context.Context, msg string, fields ...zap.Field) {
+	LogToHoneycombSpan(ctx, "Debug", msg, fields...)
+	skipLogger := l.Logger.WithOptions(zap.AddCallerSkip(1))
+	skipLogger.Debug(msg, fields...)
+}
+
+// TraceInfo logs a message at InfoLevel to a span within a Honeycomb trace as well as the configured zap logger.
+func (l *Logger) TraceInfo(ctx context.Context, msg string, fields ...zap.Field) {
+	LogToHoneycombSpan(ctx, "Info", msg, fields...)
+	skipLogger := l.Logger.WithOptions(zap.AddCallerSkip(1))
+	skipLogger.Info(msg, fields...)
+}
+
+// TraceWarn logs a message at WarnLevel to a span within a Honeycomb trace as well as the configured zap logger.
+func (l *Logger) TraceWarn(ctx context.Context, msg string, fields ...zap.Field) {
+	LogToHoneycombSpan(ctx, "Warn", msg, fields...)
+	skipLogger := l.Logger.WithOptions(zap.AddCallerSkip(1))
+	skipLogger.Warn(msg, fields...)
+}
+
+// TraceError logs a message at ErrorLevel to a span within a Honeycomb trace as well as the configured zap logger.
+func (l *Logger) TraceError(ctx context.Context, msg string, fields ...zap.Field) {
+	LogToHoneycombSpan(ctx, "Error", msg, fields...)
+	skipLogger := l.Logger.WithOptions(zap.AddCallerSkip(1))
+	skipLogger.Error(msg, fields...)
+}
+
+// TraceFatal logs a message at FatalLevel to a span within a Honeycomb trace as well as the configured zap logger.
+func (l *Logger) TraceFatal(ctx context.Context, msg string, fields ...zap.Field) {
+	LogToHoneycombSpan(ctx, "Fatal", msg, fields...)
+	skipLogger := l.Logger.WithOptions(zap.AddCallerSkip(1))
+	skipLogger.Fatal(msg, fields...)
+}

--- a/pkg/logging/hnyzap/hnyzap_test.go
+++ b/pkg/logging/hnyzap/hnyzap_test.go
@@ -1,0 +1,99 @@
+package hnyzap
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+	"go.uber.org/zap"
+)
+
+type zapFieldSuite struct {
+	suite.Suite
+	bool    bool
+	float32 float32
+	float64 float64
+	int32   int32
+	int64   int64
+	string  string
+	uint32  uint32
+	uint64  uint64
+	error   error
+}
+
+func TestZapFieldSuite(t *testing.T) {
+	fs := &zapFieldSuite{
+		bool:    false,
+		float32: rand.Float32(),
+		float64: rand.Float64(),
+		int32:   rand.Int31(),
+		int64:   rand.Int63(),
+		uint32:  rand.Uint32(),
+		uint64:  rand.Uint64(),
+		string:  "zap me",
+		error:   fmt.Errorf("fail me"),
+	}
+	suite.Run(t, fs)
+}
+
+func (suite *zapFieldSuite) TestZapBoolean() {
+	zapField := zap.Bool("bool", suite.bool)
+	honeyField := ZapFieldToHoneycombField(zapField)
+	suite.Equal(suite.bool, honeyField)
+}
+
+func (suite *zapFieldSuite) TestZapFloat32() {
+	zapField := zap.Float32("float32", suite.float32)
+	honeyField := ZapFieldToHoneycombField(zapField)
+	suite.Equal(suite.float32, honeyField)
+}
+
+func (suite *zapFieldSuite) TestZapFloat64() {
+	zapField := zap.Float64("float64", suite.float64)
+	honeyField := ZapFieldToHoneycombField(zapField)
+	suite.Equal(suite.float64, honeyField)
+}
+
+func (suite *zapFieldSuite) TestZapInt32() {
+	zapField := zap.Int32("int32", suite.int32)
+	honeyField := ZapFieldToHoneycombField(zapField)
+	suite.Equal(suite.int32, honeyField)
+}
+
+func (suite *zapFieldSuite) TestZapInt64() {
+	zapField := zap.Int64("int64", suite.int64)
+	honeyField := ZapFieldToHoneycombField(zapField)
+	suite.Equal(suite.int64, honeyField)
+}
+
+func (suite *zapFieldSuite) TestZapUint32() {
+	zapField := zap.Uint32("unint32", suite.uint32)
+	honeyField := ZapFieldToHoneycombField(zapField)
+	suite.Equal(suite.uint32, honeyField)
+}
+
+func (suite *zapFieldSuite) TestZapUnint64() {
+	zapField := zap.Uint64("unint64", suite.uint64)
+	honeyField := ZapFieldToHoneycombField(zapField)
+	suite.Equal(suite.uint64, honeyField)
+}
+
+func (suite *zapFieldSuite) TestZapString() {
+	zapField := zap.String("string", suite.string)
+	honeyField := ZapFieldToHoneycombField(zapField)
+	suite.Equal(suite.string, honeyField)
+}
+
+func (suite *zapFieldSuite) TestZapError() {
+	zapField := zap.Error(suite.error)
+	honeyField := ZapFieldToHoneycombField(zapField)
+	suite.Equal(suite.error.Error(), honeyField)
+}
+
+func (suite *zapFieldSuite) TestZapUnsupported() {
+	zapField := zap.Duration("time", time.Second)
+	honeyField := ZapFieldToHoneycombField(zapField)
+	suite.Equal("unsupported field type", honeyField)
+}

--- a/pkg/models/models_test.go
+++ b/pkg/models/models_test.go
@@ -1,7 +1,6 @@
 package models_test
 
 import (
-	"context"
 	"log"
 	"reflect"
 	"sort"

--- a/pkg/models/models_test.go
+++ b/pkg/models/models_test.go
@@ -1,6 +1,7 @@
 package models_test
 
 import (
+	"context"
 	"log"
 	"reflect"
 	"sort"

--- a/pkg/models/transportation_service_provider_performance_test.go
+++ b/pkg/models/transportation_service_provider_performance_test.go
@@ -1,6 +1,7 @@
 package models_test
 
 import (
+	"context"
 	"time"
 
 	"github.com/go-openapi/swag"
@@ -135,7 +136,7 @@ func (suite *ModelSuite) Test_AssignQualityBandToTSPPerformance() {
 	perf, _ := testdatagen.MakeTSPPerformanceDeprecated(suite.db, tsp, tdl, nil, mps, 0, .2, .3)
 	band := 1
 
-	err := AssignQualityBandToTSPPerformance(suite.db, band, perf.ID)
+	err := AssignQualityBandToTSPPerformance(context.Background(), suite.db, band, perf.ID)
 	if err != nil {
 		t.Fatalf("Did not update quality band: %v", err)
 	}


### PR DESCRIPTION
## Description

This PR introduces two new methods for sending data to Honeycomb.  
1) It introduces the ability to trace calls within a given API request, which allows us to see where time is being spent. Each new segment within a request is called a span and it's mapped to the go function being called. 
2) It creates a wrapper logging library (`hnyzap`) around zap that allows the app to send zap logs along with the traces.
    a) New functions `TraceDebug`, `TraceInfo`, `TraceWarn`, `TraceError`, `TraceFatal` take an additional context parameter and will send a zap log line with the additional zap fields into Honeycomb as a distinct span in the trace.

This PR introduces the above functionality into the AwardQueue, but can be extended to other parts of the codebase. 

## Reviewer Notes

* Zap supports a much wider range of data types when compared to Honeycomb( bool, number, string). I've explicitly limited what data types we will send into Honeycomb to prevent accidentally leaking any PII (e.g, sending a user object `zap.Object("user", user)`)

## Code Review Verification Steps

* [x] Code follows the guidelines for [Logging](./docs/backend.md#logging)
* [x] Request review from a member of a different team.

## References

* [Pivotal story 1](https://www.pivotaltracker.com/story/show/161392994),  [Pivotal story 2](https://www.pivotaltracker.com/story/show/161436645)
* [Honeycomb Tracing](https://docs.honeycomb.io/working-with-data/tracing/) explains more about the approach used.

## Screenshots
![oct-29-2018 17-22-05](https://user-images.githubusercontent.com/675823/47687780-3a591600-db9f-11e8-8564-ce29af994a3d.gif)
