### PR TITLE
Add test to start a new move after previous one is canceled

### DIFF
--- a/cypress/integration/office/cancelAndStartNewMove.js
+++ b/cypress/integration/office/cancelAndStartNewMove.js
@@ -25,7 +25,7 @@ describe('office user finds the move', () => {
     cy.get('.usa-alert-success').contains('Move #CANCEL for Submitted, PPM has been canceled');
   });
   it('Service Member starts a new move after previous move is canceled.', () => {
-    cy.signInAsUser('e10d5964-c070-49cb-9bd1-eaf9f7348eb7');
+    cy.signIntoMyMoveAsUser('e10d5964-c070-49cb-9bd1-eaf9f7348eb7');
 
     // Landing page contains move canceled alert message
     cy.contains('Your move was canceled');

--- a/cypress/integration/office/cancelAndStartNewMove.js
+++ b/cypress/integration/office/cancelAndStartNewMove.js
@@ -1,9 +1,8 @@
 /* global cy, */
 describe('office user finds the move', () => {
-  beforeEach(() => {
-    cy.signIntoOffice();
-  });
   it('office user cancels the move', () => {
+    cy.signIntoOffice();
+
     // Open the move
     cy.visit('/queues/new/moves/0db80bd6-de75-439e-bf89-deaafa1d0dc9/ppm');
 
@@ -24,5 +23,23 @@ describe('office user finds the move', () => {
       .contains('Yes, Cancel Move')
       .click();
     cy.get('.usa-alert-success').contains('Move #CANCEL for Submitted, PPM has been canceled');
+  });
+  it('Service Member starts a new move after previous move is canceled.', () => {
+    cy.signInAsUser('e10d5964-c070-49cb-9bd1-eaf9f7348eb7');
+
+    // Landing page contains move canceled alert message
+    cy.contains('Your move was canceled');
+
+    // User clicks on Start a new move and proceeds to orders page
+    cy
+      .get('button')
+      .contains('Start')
+      .click();
+
+    cy.get('h1').contains('Review your Profile');
+
+    cy.nextPage();
+
+    cy.get('h1').contains('Tell Us About Your Move Orders');
   });
 });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -33,6 +33,10 @@ Cypress.Commands.add('signInAsNewUser', () => {
   //  cy.contains('Login as New User').click();
 });
 
+Cypress.Commands.add('signIntoMyMoveAsUser', userId => {
+  Cypress.config('baseUrl', 'http://localhost:4000');
+  cy.signInAsUser(userId);
+});
 Cypress.Commands.add('signIntoOffice', () => {
   Cypress.config('baseUrl', 'http://officelocal:4000');
   cy.signInAsUser('9bfa91d2-7a0c-4de0-ae02-b8cf8b4b858b');


### PR DESCRIPTION
## Description

Add test to start a new move after previous one is canceled.

## Setup

Run e2e tests.

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](./docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](./docs/backend.md#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](./docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
* [ ] There are no aXe warnings for UI.
* [ ] This works in IE.
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @willowbl00
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/161357383) for this change

