### PR TITLE
Add missing queues in the TSP app to ensure all statuses have a queue

### DIFF
--- a/cypress/integration/tsp/serviceAgents.js
+++ b/cypress/integration/tsp/serviceAgents.js
@@ -257,7 +257,7 @@ function tspUserAcceptsShipment() {
     .get('b')
     .contains('Accepted');
 
-  cy.get('a').contains('All Shipments Queue');
+  cy.get('a').contains('Accepted Shipments Queue');
 }
 
 function tspUserClicksAssignServiceAgent(locator) {

--- a/cypress/integration/tsp/tspUser.js
+++ b/cypress/integration/tsp/tspUser.js
@@ -3,21 +3,27 @@ describe('TSP User Views Shipment', function() {
   beforeEach(() => {
     cy.signIntoTSP();
   });
-  it('tsp user views shipments in queue new shipments', function() {
-    tspUserViewsShipments();
+  it('tsp user views shipments in new shipments queue', function() {
+    tspUserViewsNewShipments();
   });
-  it('tsp user views shipments in queue new shipments', function() {
+  it('tsp user views shipments in accepted shipments queue', function() {
+    tspUserViewsAcceptedShipments();
+  });
+  it('tsp user views shipments in approved shipments queue', function() {
     tspUserViewsApprovedShipments();
   });
-  it('tsp user views in transit hhg moves in queue HHGs In Transit', function() {
-    tspUserViewsInTransitShipment();
+  it('tsp user views shipments in in_transit shipments queue', function() {
+    tspUserViewsInTransitShipments();
   });
-  it('tsp user views delivered hhg moves in queue HHGs Delivered', function() {
-    tspUserViewsDeliveredShipment();
+  it('tsp user views shipments in delivered shipments queue', function() {
+    tspUserViewsDeliveredShipments();
+  });
+  it('tsp user views shipments in completed shipments queue', function() {
+    tspUserViewsCompletedShipments();
   });
 });
 
-function tspUserViewsShipments() {
+function tspUserViewsNewShipments() {
   // Open new shipments queue
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/queues\/new/);
@@ -51,8 +57,8 @@ function tspUserViewsShipments() {
   });
 }
 
-function tspUserViewsInTransitShipment() {
-  // Open new shipments queue
+function tspUserViewsInTransitShipments() {
+  // Open in transit shipments queue
   cy.visit('/queues/in_transit');
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/queues\/in_transit/);
@@ -67,10 +73,18 @@ function tspUserViewsInTransitShipment() {
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/shipments\/[^/]+/);
   });
+
+  // Status should be In Transit
+  cy
+    .get('li')
+    .get('b')
+    .contains('In_transit');
+
+  cy.get('a').contains('In Transit Shipments Queue');
 }
 
-function tspUserViewsDeliveredShipment() {
-  // Open new shipments queue
+function tspUserViewsDeliveredShipments() {
+  // Open delivered shipments queue
   cy.visit('/queues/delivered');
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/queues\/delivered/);
@@ -85,10 +99,44 @@ function tspUserViewsDeliveredShipment() {
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/shipments\/[^/]+/);
   });
+
+  // Status should be Delivered
+  cy
+    .get('li')
+    .get('b')
+    .contains('Delivered');
+
+  cy.get('a').contains('Delivered Shipments Queue');
+}
+
+function tspUserViewsAcceptedShipments() {
+  // Open accepted shipments queue
+  cy
+    .get('div')
+    .contains('Accepted Shipments')
+    .click();
+
+  cy.location().should(loc => {
+    expect(loc.pathname).to.match(/^\/queues\/accepted/);
+  });
+
+  // Find shipment
+  cy
+    .get('div')
+    .contains('BACON3')
+    .dblclick();
+
+  // Status should be Delivered
+  cy
+    .get('li')
+    .get('b')
+    .contains('Accepted');
+
+  cy.get('a').contains('Accepted Shipments Queue');
 }
 
 function tspUserViewsApprovedShipments() {
-  // Open accepted shipments queue
+  // Open approved shipments queue
   cy
     .get('div')
     .contains('Approved Shipments')
@@ -99,9 +147,46 @@ function tspUserViewsApprovedShipments() {
   });
 
   // Find shipment
-  cy.get('div').contains('APPRVD');
   cy
     .get('div')
     .contains('BACON1')
     .should('not.exist');
+  cy
+    .get('div')
+    .contains('APPRVD')
+    .dblclick();
+
+  // Status should be Delivered
+  cy
+    .get('li')
+    .get('b')
+    .contains('Approved');
+
+  cy.get('a').contains('Approved Shipments Queue');
+}
+
+function tspUserViewsCompletedShipments() {
+  // Open completed shipments queue
+  cy
+    .get('div')
+    .contains('Completed Shipments')
+    .click();
+
+  cy.location().should(loc => {
+    expect(loc.pathname).to.match(/^\/queues\/completed/);
+  });
+
+  // Find shipment
+  cy
+    .get('div')
+    .contains('NOCHKA')
+    .dblclick();
+
+  // Status should be Delivered
+  cy
+    .get('li')
+    .get('b')
+    .contains('Completed');
+
+  cy.get('a').contains('Completed Shipments Queue');
 }

--- a/src/scenes/TransportationServiceProvider/QueueList.jsx
+++ b/src/scenes/TransportationServiceProvider/QueueList.jsx
@@ -13,6 +13,11 @@ export default class QueueList extends Component {
             </NavLink>
           </li>
           <li>
+            <NavLink to="/queues/accepted" activeClassName="usa-current">
+              <span>Accepted Shipments</span>
+            </NavLink>
+          </li>
+          <li>
             <NavLink to="/queues/approved" activeClassName="usa-current">
               <span>Approved Shipments</span>
             </NavLink>
@@ -25,6 +30,11 @@ export default class QueueList extends Component {
           <li>
             <NavLink to="/queues/delivered" activeClassName="usa-current">
               <span>Delivered Shipments</span>
+            </NavLink>
+          </li>
+          <li>
+            <NavLink to="/queues/completed" activeClassName="usa-current">
+              <span>Completed Shipments</span>
             </NavLink>
           </li>
           <li>

--- a/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
+++ b/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
@@ -205,9 +205,11 @@ class ShipmentInfo extends Component {
     const newDocumentUrl = `/shipments/${shipmentId}/documents/new`;
     const showDocumentViewer = context.flags.documentViewer;
     const awarded = shipment.status === 'AWARDED';
-    const approved = shipment.status === 'APPROVED';
     const accepted = shipment.status === 'ACCEPTED';
+    const approved = shipment.status === 'APPROVED';
     const inTransit = shipment.status === 'IN_TRANSIT';
+    const delivered = shipment.status === 'DELIVERED';
+    const completed = shipment.status === 'COMPLETED';
     const pmSurveyComplete = Boolean(
       shipment.pm_survey_conducted_date &&
         shipment.pm_survey_method &&
@@ -245,13 +247,37 @@ class ShipmentInfo extends Component {
                 <span>New Shipments Queue</span>
               </NavLink>
             )}
+            {accepted && (
+              <NavLink to="/queues/accepted" activeClassName="usa-current">
+                <span>Accepted Shipments Queue</span>
+              </NavLink>
+            )}
             {approved && (
               <NavLink to="/queues/approved" activeClassName="usa-current">
                 <span>Approved Shipments Queue</span>
               </NavLink>
             )}
+            {inTransit && (
+              <NavLink to="/queues/in_transit" activeClassName="usa-current">
+                <span>In Transit Shipments Queue</span>
+              </NavLink>
+            )}
+            {delivered && (
+              <NavLink to="/queues/delivered" activeClassName="usa-current">
+                <span>Delivered Shipments Queue</span>
+              </NavLink>
+            )}
+            {completed && (
+              <NavLink to="/queues/completed" activeClassName="usa-current">
+                <span>Completed Shipments Queue</span>
+              </NavLink>
+            )}
             {!awarded &&
-              !approved && (
+              !accepted &&
+              !approved &&
+              !inTransit &&
+              !delivered &&
+              !completed && (
                 <NavLink to="/queues/all" activeClassName="usa-current">
                   <span>All Shipments Queue</span>
                 </NavLink>

--- a/src/scenes/TransportationServiceProvider/api.js
+++ b/src/scenes/TransportationServiceProvider/api.js
@@ -5,9 +5,11 @@ import { formatPayload } from 'shared/utils';
 export async function RetrieveShipmentsForTSP(queueType) {
   const queueToStatus = {
     new: ['AWARDED'],
-    in_transit: ['IN_TRANSIT'],
+    accepted: ['ACCEPTED'],
     approved: ['APPROVED'],
+    in_transit: ['IN_TRANSIT'],
     delivered: ['DELIVERED'],
+    completed: ['COMPLETED'],
     all: [],
   };
   /* eslint-disable security/detect-object-injection */

--- a/src/scenes/TransportationServiceProvider/index.jsx
+++ b/src/scenes/TransportationServiceProvider/index.jsx
@@ -58,7 +58,10 @@ class TspWrapper extends Component {
                 <PrivateRoute path="/shipments/:shipmentId/documents/:moveDocumentId" component={DocumentViewer} />
                 <PrivateRoute path="/shipments/:shipmentId" component={ShipmentInfo} />
                 {/* Be specific about available routes by listing them */}
-                <PrivateRoute path="/queues/:queueType(new|approved|in_transit|delivered|all)" component={Queues} />
+                <PrivateRoute
+                  path="/queues/:queueType(new|accepted|approved|in_transit|delivered|completed|all)"
+                  component={Queues}
+                />
                 {!isProduction && <PrivateRoute path="/playground" component={ScratchPad} />}
                 {/* TODO: cgilmer (2018/07/31) Need a NotFound component to route to */}
                 <Redirect from="*" to="/queues/new" component={Queues} />


### PR DESCRIPTION
## Description

Each shipment status should have its own queue in the TSP app.  This change ensures that its easier to filter by types of shipments while we wait on user testing from design and more direction on queue and queue layout.  It also solves the immediate need of TSPs of helping them find the shipments they are looking for.

## Setup

Run scenario 7 and then go to the queues page.  You will see one for each status.

## Code Review Verification Steps

* [x] There are no aXe warnings for UI.
* [x] This works in IE.
* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/161571902) for this change