### PR TITLE
Remove 'Shipment Info:' from header of Shipment Info page

### DIFF
--- a/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
+++ b/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
@@ -236,7 +236,7 @@ class ShipmentInfo extends Component {
           <div className="usa-width-two-thirds">
             MOVE INFO - {move.selected_move_type} CODE D
             <h1>
-              Shipment Info: {serviceMember.last_name}, {serviceMember.first_name}
+              {serviceMember.last_name}, {serviceMember.first_name}
             </h1>
           </div>
           <div className="usa-width-one-third nav-controls">


### PR DESCRIPTION
## Description

Tiny change to remove unnecessary text from the shipment info page.

## Setup

Load scenario 7 data and then go to any shipment info page to see the header gone.

## Code Review Verification Steps

* [x] There are no aXe warnings for UI.
* [x] This works in IE.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/161571804) for this change