### PR TITLE
Fix ecs-show-service-logs to work with app and app-client-tls ECS services

### DIFF
--- a/bin/ecs-show-service-logs
+++ b/bin/ecs-show-service-logs
@@ -11,12 +11,12 @@ usage() {
 [[ -z $1 || -z $2 ]] && usage
 set -u
 
+readonly prefix="app"
 readonly name=$1
 readonly environment=$2
-readonly cluster=app-$environment
+readonly cluster=$prefix-$environment
 
 # awslogs-stream-prefix settings
-readonly prefix=$name
 readonly container=$name-$environment
 readonly log_group_name=ecs-tasks-$name-$environment
 


### PR DESCRIPTION
This fix will allow us to pull the logs from the `app` and `app-client-tls` ECS services.

* `bin/ecs-show-service-logs app-client-tls staging`
* `bin/ecs-show-service-logs app staging`



