### PR TITLE
Added E2E tests for PPM/HHG landing pages

### DIFF
--- a/cypress/integration/mymove/landingPages.js
+++ b/cypress/integration/mymove/landingPages.js
@@ -1,0 +1,114 @@
+/* global cy */
+
+describe('testing landing pages', function() {
+  // Submitted draft move/orders but no move type yet.
+  it('tests pre-move type', function() {
+    // sm_no_move_type@example.com
+    draftMove('9ceb8321-6a82-4f6d-8bb3-a1d85922a202');
+  });
+
+  // PPM: SUBMITTED
+  it('tests submitted PPM', function() {
+    // ppm@incomple.te
+    ppmSubmitted('e10d5964-c070-49cb-9bd1-eaf9f7348eb6');
+  });
+
+  // PPM: APPROVED
+  it('tests approved PPM', function() {
+    // ppm@approv.ed
+    ppmApproved('1842091b-b9a0-4d4a-ba22-1e2f38f26317');
+  });
+
+  // PPM: COMPLETED
+  // Not seeing a path to a COMPLETED PPM move at this time.
+
+  // PPM: CANCELED
+  it('tests canceled PPM', function() {
+    // ppm-canceled@example.com
+    canceledMove('20102768-4d45-449c-a585-81bc386204b1');
+  });
+
+  // HHG: SUBMITTED
+  it('tests submitted HHG', function() {
+    // hhg@incomplete.serviceagent
+    hhgMoveSummary('412e76e0-bb34-47d4-ba37-ff13e2dd40b9');
+  });
+
+  // HHG: AWARDED
+  it('tests awarded HHG', function() {
+    // hhg@reject.ing
+    hhgMoveSummary('76bdcff3-ade4-41ff-bf09-0b2474cec751');
+  });
+
+  // HHG: ACCEPTED
+  it('tests accepted HHG', function() {
+    // hhg@accept.ed
+    hhgMoveSummary('6a39dd2a-a23f-4967-a035-3bc9987c6848');
+  });
+
+  // HHG: APPROVED
+  it('tests approved HHG', function() {
+    // hhg@approv.ed
+    hhgMoveSummary('68461d67-5385-4780-9cb6-417075343b0e');
+  });
+
+  // HHG: IN_TRANSIT
+  it('tests in-transit HHG', function() {
+    // hhg@in.transit
+    hhgMoveSummary('1239dd2a-a23f-4967-a035-3bc9987c6848');
+  });
+
+  // HHG: DELIVERED
+  it('tests delivered HHG', function() {
+    // hhg@de.livered
+    hhgMoveSummary('3339dd2a-a23f-4967-a035-3bc9987c6848');
+  });
+
+  // HHG: COMPLETED
+  it('tests completed HHG', function() {
+    // hhg@com.pleted
+    hhgMoveSummary('4449dd2a-a23f-4967-a035-3bc9987c6848');
+  });
+
+  // HHG: CANCELED
+  it('tests canceled HHG', function() {
+    // hhg@cancel.ed
+    canceledMove('05ea5bc3-fd77-4f42-bdc5-a984a81b3829');
+  });
+});
+
+function draftMove(userId) {
+  cy.signInAsUser(userId);
+  cy.contains('Move to be scheduled');
+  cy.contains('Next Step: Finish setting up your move');
+  cy.logout();
+}
+
+function ppmSubmitted(userId) {
+  cy.signInAsUser(userId);
+  cy.contains('Move your own stuff (PPM)');
+  cy.contains('Next Step: Awaiting approval');
+  cy.logout();
+}
+
+function ppmApproved(userId) {
+  cy.signInAsUser(userId);
+  cy.contains('Move your own stuff (PPM)');
+  cy.contains('Next Step: Get ready to move');
+  cy.contains('Next Step: Request payment');
+  cy.logout();
+}
+
+function hhgMoveSummary(userId) {
+  cy.signInAsUser(userId);
+  cy.contains('Government Movers and Packers (HHG)');
+  cy.contains('Next Step: Prepare for move');
+  cy.logout();
+}
+
+function canceledMove(userId) {
+  cy.signInAsUser(userId);
+  cy.contains('New move');
+  cy.contains('Start here');
+  cy.logout();
+}


### PR DESCRIPTION
## Description

This PR adds some basic tests to make sure the SM landing pages for various states are appearing as expected.  We share some common React components for both PPM and HHG moves right now, so tests are useful to make sure we're not accidentally displaying PPM info on an HHG move, and vice versa.

A document with screen shots of our various landing pages and states is linked below.

## Reviewer Notes

I added a few more E2E users to make sure I didn't use any scenarios already in use by another E2E test.

## Setup

`make e2e_test`
Verify that all tests are successful.  The tests I added are in `landingPages.js`.

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/161432932) for this change
* [Our landing pages/states](https://docs.google.com/document/d/1WcajfTAWYWuZfqk6J8Qd8Pasa8DpFkkMULZ18hQpH6s/edit)