### PR TITLE
Cg 161595705 show tdl code of service

### DIFF
--- a/cypress/integration/tsp/checkHeader.js
+++ b/cypress/integration/tsp/checkHeader.js
@@ -1,0 +1,47 @@
+/* global cy */
+describe('TSP User Checks Shipment Info Header', function() {
+  beforeEach(() => {
+    cy.signIntoTSP();
+  });
+  it('tsp user sees header info', function() {
+    tspUserViewsHeaderInfo();
+  });
+});
+
+function tspUserViewsHeaderInfo() {
+  // Open new shipments queue
+  cy.location().should(loc => {
+    expect(loc.pathname).to.match(/^\/queues\/new/);
+  });
+
+  // Find a shipment and open it
+  cy
+    .get('div')
+    .contains('BACON1')
+    .dblclick();
+
+  cy.location().should(loc => {
+    expect(loc.pathname).to.match(/^\/shipments\/[^/]+/);
+  });
+
+  // Check the move type and code
+  cy.contains('MOVE INFO - HHG CODE D');
+
+  // Check the name is correct
+  cy.get('h1').contains('Submitted, HHG');
+
+  // Check the info bar
+  cy
+    .get('ul')
+    .contains('li', 'GBL# LKBM7000002')
+    .parentsUntil('div')
+    .contains('li', 'Locator# BACON1')
+    .parentsUntil('div')
+    .contains('li', 'LKBM to LKBM')
+    .parentsUntil('div')
+    .contains('li', 'DoD ID# 4444567890')
+    .parentsUntil('div')
+    .contains('li', 'Status: Awarded')
+    .parentsUntil('div')
+    .contains('li', '555-555-5555');
+}

--- a/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
+++ b/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
@@ -235,7 +235,7 @@ class ShipmentInfo extends Component {
       <div>
         <div className="usa-grid grid-wide">
           <div className="usa-width-two-thirds">
-            MOVE INFO - {move.selected_move_type} CODE D
+            MOVE INFO &mdash; {move.selected_move_type} CODE {shipment.traffic_distribution_list.code_of_service}
             <h1>
               {serviceMember.last_name}, {serviceMember.first_name}
             </h1>


### PR DESCRIPTION
## Description

Previously we hard coded the TDL CoS.  Now it's data driven.  Note that this change didn't do anything visible since all codes of service are currently "D".  I also added tests for the header.

## Setup

Use Scenario 7 data and look at a TSP shipment.  You'll see the code of service.  

## Code Review Verification Steps

* [x] There are no aXe warnings for UI.
* [x] This works in IE.
* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/161595705) for this change