### PR TITLE
Am 161491984 hhg flow produces entitlements

### DIFF
--- a/src/scenes/Review/EditOrders.jsx
+++ b/src/scenes/Review/EditOrders.jsx
@@ -15,7 +15,7 @@ import UploadsTable from 'shared/Uploader/UploadsTable';
 import SaveCancelButtons from './SaveCancelButtons';
 import { updateOrders, deleteUploads, addUploads } from 'scenes/Orders/ducks';
 import { moveIsApproved } from 'scenes/Moves/ducks';
-import { editBegin, editSuccessful, entitlementChangeBegin, entitlementChanged } from './ducks';
+import { editBegin, editSuccessful, entitlementChangeBegin, entitlementChanged, checkEntitlement } from './ducks';
 
 import './Review.css';
 import profileImage from './images/profile.png';
@@ -123,6 +123,7 @@ class EditOrders extends Component {
         if (!this.props.hasSubmitError) {
           this.props.editSuccessful();
           this.props.history.goBack();
+          this.props.checkEntitlement(this.props.match.params.moveId);
         } else {
           window.scrollTo(0, 0);
         }
@@ -197,6 +198,7 @@ function mapDispatchToProps(dispatch) {
       entitlementChangeBegin,
       editSuccessful,
       entitlementChanged,
+      checkEntitlement,
     },
     dispatch,
   );

--- a/src/scenes/Review/EditProfile.jsx
+++ b/src/scenes/Review/EditProfile.jsx
@@ -13,7 +13,7 @@ import SaveCancelButtons from './SaveCancelButtons';
 import { updateServiceMember } from 'scenes/ServiceMembers/ducks';
 import { moveIsApproved } from 'scenes/Moves/ducks';
 import DutyStationSearchBox from 'scenes/ServiceMembers/DutyStationSearchBox';
-import { editBegin, editSuccessful, entitlementChangeBegin, entitlementChanged } from './ducks';
+import { editBegin, editSuccessful, entitlementChangeBegin, entitlementChanged, checkEntitlement } from './ducks';
 
 import './Review.css';
 import profileImage from './images/profile.png';
@@ -85,11 +85,13 @@ class EditProfile extends Component {
     if (fieldValues.rank !== this.props.serviceMember.rank) {
       this.props.entitlementChanged();
     }
+    const moveId = this.props.move.id;
     return this.props.updateServiceMember(fieldValues).then(() => {
       // This promise resolves regardless of error.
       if (!this.props.hasSubmitError) {
         this.props.editSuccessful();
         this.props.history.goBack();
+        this.props.checkEntitlement(moveId);
       } else {
         window.scrollTo(0, 0);
       }
@@ -152,6 +154,7 @@ function mapDispatchToProps(dispatch) {
       entitlementChangeBegin,
       editSuccessful,
       entitlementChanged,
+      checkEntitlement,
     },
     dispatch,
   );

--- a/src/scenes/Review/EditWeight.jsx
+++ b/src/scenes/Review/EditWeight.jsx
@@ -13,7 +13,8 @@ import { SwaggerField } from 'shared/JsonSchemaForm/JsonSchemaField';
 import { createOrUpdatePpm, getPpmWeightEstimate } from 'scenes/Moves/Ppm/ducks';
 import { loadEntitlementsFromState } from 'shared/entitlements';
 import { formatCentsRange } from 'shared/formatters';
-import { editBegin, editSuccessful, entitlementChangeBegin } from './ducks';
+import { editBegin, editSuccessful, entitlementChangeBegin, checkEntitlement } from './ducks';
+
 import EntitlementBar from 'scenes/EntitlementBar';
 import './Review.css';
 import './EditWeight.css';
@@ -206,6 +207,7 @@ class EditWeight extends Component {
         if (!this.props.hasSubmitError) {
           this.props.editSuccessful();
           this.props.history.goBack();
+          this.props.checkEntitlement(moveId);
         } else {
           window.scrollTo(0, 0);
         }
@@ -275,6 +277,7 @@ function mapDispatchToProps(dispatch) {
       editBegin,
       editSuccessful,
       entitlementChangeBegin,
+      checkEntitlement,
     },
     dispatch,
   );

--- a/src/scenes/Review/Summary.jsx
+++ b/src/scenes/Review/Summary.jsx
@@ -27,6 +27,13 @@ export class Summary extends Component {
       this.props.onDidMount();
     }
   }
+  componentDidUpdate(prevProps) {
+    // if (get(this.props.reviewState, 'editSuccess', false)) {} ??????
+    if (prevProps.currentPpm !== this.props.currentPpm) {
+      this.props.onCheckEntitlement(this.props.match.params.moveId);
+    }
+  }
+
   render() {
     const {
       currentMove,
@@ -72,7 +79,7 @@ export class Summary extends Component {
         <ServiceMemberSummary
           orders={currentOrders}
           backupContacts={currentBackupContacts}
-          serviceMember={serviceMember}
+          serviceMember={serviceMember || {}}
           schemaRank={schemaRank}
           schemaAffiliation={schemaAffiliation}
           schemaOrdersType={schemaOrdersType}
@@ -97,7 +104,7 @@ export class Summary extends Component {
 
 Summary.propTypes = {
   currentBackupContacts: PropTypes.array,
-  currentMove: PropTypes.object,
+  currentMove: PropTypes.func,
   currentOrders: PropTypes.object,
   currentPpm: PropTypes.object,
   currentShipment: PropTypes.object,
@@ -134,7 +141,9 @@ function mapDispatchToProps(dispatch, ownProps) {
           dispatch(getShipment('Summary.getShipment', shipment.id));
         });
       });
-      dispatch(checkEntitlement(moveID));
+    },
+    onCheckEntitlement: moveId => {
+      dispatch(checkEntitlement(moveId));
     },
   };
 }

--- a/src/scenes/Review/Summary.jsx
+++ b/src/scenes/Review/Summary.jsx
@@ -28,7 +28,7 @@ export class Summary extends Component {
     }
   }
   componentDidUpdate(prevProps) {
-    // if (get(this.props.reviewState, 'editSuccess', false)) {} ??????
+    // Only check entitlement for PPMs, not HHGs
     if (prevProps.currentPpm !== this.props.currentPpm) {
       this.props.onCheckEntitlement(this.props.match.params.moveId);
     }


### PR DESCRIPTION
## Description

Fixes a bug where on the Review page for HHG moves, there's a 404 returned. This PR only validates that the ppm weight_estimate is below the SM's entitlement if there is a currentPpm in redux store and not on the HHG review page (there is a separate notification flow to check entitlements).

We also hit the check entitlement endpoint for the edit orders, profile and weight actions that are reachable from the review page (the parameters that will affect the entitlement).

Some issues/inconsistencies that were uncovered: 
* weight_estimate on the PPM and the HHG have separate meanings that could be a cause for confusion - the ppm weight_estimate represents the total allowance (i.e. the SM's weight, pro-gear and spouse progear weight), whereas the HHG stores these values separately and the hhg.weight_estimate represents just the Service Member's weight. 
* `weight_estimate` on the ppm model is of type int64, whereas on the shipment/hhg model it is `unit.pounds`.

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Setup

Log in as a Service Member with a ppm (e.g. ppm@incomple.te (mymove)). In your local DB, modify the weight_estimate to be above the entitlement (put in a high number like 9000000000) in order to trigger the alert on the review page for the PPM. Edit the orders, profile or weight, and verify that the alert disappears once the weight_estimate is below the entitlement.

Verify that the endpoint is not hit on review pages with hhgs.

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](./docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](./docs/backend.md#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](./docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
* [ ] There are no aXe warnings for UI.
* [ ] This works in IE.
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @willowbl00
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/161491984) for this change

## Screenshots
<img width="731" alt="screen shot 2018-10-31 at 3 48 49 pm" src="https://user-images.githubusercontent.com/8170735/47823228-7d90c180-dd24-11e8-9976-af52c5144ad5.png">
