### PR TITLE
Fixed E2E test and time zone issue with move dates calendar

### DIFF
--- a/cypress/integration/mymove/shipment.js
+++ b/cypress/integration/mymove/shipment.js
@@ -23,7 +23,7 @@ describe('completing the hhg flow', function() {
     // Try to get today, which should be disabled even after clicked.  We may have to go back a month
     // to find today since the calendar scrolls to the month with the first available move date.
     cy
-      .get('body')
+      .get('.DayPicker-Body')
       .then($body => {
         if ($body.find('.DayPicker-Day--today').length === 0) {
           cy.get('.DayPicker-NavButton--prev').click();
@@ -41,7 +41,7 @@ describe('completing the hhg flow', function() {
     // we skip to the next month which should (at least at this point) have an available
     // date.
     cy
-      .get('body')
+      .get('.DayPicker-Body')
       .then($body => {
         if ($body.find('[class=DayPicker-Day]').length === 0) {
           cy.get('.DayPicker-NavButton--next').click();

--- a/src/scenes/Legalese/index.jsx
+++ b/src/scenes/Legalese/index.jsx
@@ -9,6 +9,7 @@ import { reduxifyWizardForm } from 'shared/WizardPage/Form';
 import CertificationText from './CertificationText';
 import Alert from 'shared/Alert';
 import { SwaggerField } from 'shared/JsonSchemaForm/JsonSchemaField';
+import { formatSwaggerDate } from 'shared/formatters';
 import './index.css';
 
 import { loadCertificationText, loadLatestCertification, signAndSubmitForApproval } from './ducks';
@@ -57,7 +58,7 @@ export class SignedCertification extends Component {
   }
   render() {
     const { hasSubmitError, pages, pageKey, latestSignedCertification } = this.props;
-    const today = new Date(Date.now()).toISOString().split('T')[0];
+    const today = formatSwaggerDate(new Date());
     const initialValues = {
       date: get(latestSignedCertification, 'date', today),
       signature: get(latestSignedCertification, 'signature', null),

--- a/src/scenes/Moves/Hhg/DatePicker.jsx
+++ b/src/scenes/Moves/Hhg/DatePicker.jsx
@@ -48,8 +48,8 @@ export class HHGDatePicker extends Component {
     if (disabled) {
       return;
     }
-    const moveDate = day.toISOString().split('T')[0];
-    this.props.input.onChange(formatSwaggerDate(day));
+    const moveDate = formatSwaggerDate(day);
+    this.props.input.onChange(moveDate);
     this.props.getMoveDatesSummary(getRequestLabel, this.props.match.params.moveId, moveDate);
     this.setState({
       selectedDay: moveDate,

--- a/src/scenes/Moves/Hhg/MoveDate.jsx
+++ b/src/scenes/Moves/Hhg/MoveDate.jsx
@@ -11,6 +11,7 @@ import Alert from 'shared/Alert';
 import { reduxifyWizardForm } from 'shared/WizardPage/Form';
 import DatePicker from 'scenes/Moves/Hhg/DatePicker';
 import { validateAdditionalFields } from 'shared/JsonSchemaForm';
+import { formatSwaggerDate } from 'shared/formatters';
 
 import { createOrUpdateShipment, getShipment } from 'shared/Entities/modules/shipments';
 import { getAvailableMoveDates, selectAvailableMoveDates } from 'shared/Entities/modules/calendar';
@@ -120,7 +121,7 @@ function mapDispatchToProps(dispatch) {
 }
 function mapStateToProps(state) {
   const shipment = getCurrentShipment(state);
-  const today = new Date().toISOString().split('T')[0];
+  const today = formatSwaggerDate(new Date());
   const props = {
     move: get(state, 'moves.currentMove', {}),
     formValues: getFormValues(formName)(state),


### PR DESCRIPTION
## Description

This PR addresses a failing E2E test related to the move dates calendar.  The failure started after 8 pm ET on Oct 31.  This was actually a symptom of two different issues:

1) The test failure seems to be caused by the DOM changing after Cypress has done a `get` on the `body` of the document (we have to do some fancier-than-normal test code to navigate the date-picking logic).  This seems to have been resolved by changing it to fetch a DOM element (`.DayPicker-body`) that's closer to the calendar data we're looking for.

2) The fact that this started failing prior to midnight local time may have indirectly been due to the use of JavaScript's `toISOString`.  This converts a date's current time zone to UTC, thus pushing the calendar to November even though there are still a few hours left in October in the current timezone.  We actually have a bug story already out there for this issue (linked below).  I was able to get around this in the calendar code (and found another case of it in the legalese page) by using our formatter `formatSwaggerDate`.  It uses the `moment` library instead, which preserves the timezone when formatting.

## Setup

- `make e2e_test` to see that the tests now pass
- Create or find an existing service member without a submitted HHG.  Verify that the date picker and legalese page still work and show the appropriate dates.

## Code Review Verification Steps

* [ ] There are no aXe warnings for UI.
* [ ] This works in IE.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/161436806) for the UTC problem
