### PR TITLE
Upgrade package merge to ^1.2.1 to CVE-2018-16469

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2394,7 +2394,7 @@ console-stamp@^0.2.6:
   dependencies:
     chalk "^1.1.1"
     dateformat "^1.0.11"
-    merge "^1.2.0"
+    merge "^1.2.1"
 
 constants-browserify@^1.0.0, constants-browserify@~1.0.0:
   version "1.0.0"
@@ -3692,7 +3692,7 @@ exec-sh@^0.2.0:
   resolved "https://registry.yarnpkg.com/exec-sh/-/exec-sh-0.2.2.tgz#2a5e7ffcbd7d0ba2755bdecb16e5a427dfbdec36"
   integrity sha512-FIUCJz1RbuS0FKTdaAafAByGS0CPvU3R0MeHxgtl+djzCc//F8HakL8GzmVNZanasTbTAY/3DRFA0KpVqj/eAw==
   dependencies:
-    merge "^1.2.0"
+    merge "^1.2.1"
 
 execa@0.10.0, execa@^0.10.0:
   version "0.10.0"
@@ -6450,7 +6450,7 @@ merge-descriptors@1.0.1:
   resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"
   integrity sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=
 
-merge@^1.2.0:
+merge@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/merge/-/merge-1.2.1.tgz#38bebf80c3220a8a487b6fcfb3941bb11720c145"
   integrity sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ==


### PR DESCRIPTION
## Description

We got an alert for CVE-2018-16469 via github here: https://github.com/transcom/mymove/network/alert/package-lock.json/merge/open

The weekly auto-dependency-upgrade actually fixed this for us but this PR just enforces the change.

## Reviewer Notes

I think I did the package update correctly but please check.

## Setup

```sh
yarn install
yarn list merge
```

You should see:

```
$ yarn list merge
yarn list v1.10.1
warning Filtering by arguments is deprecated. Please use the pattern option instead.
└─ merge@1.2.1
✨  Done in 0.67s.
```

## Code Review Verification Steps

* [x] Request review from a member of a different team.