### PR TITLE
Added new office users and fixed typos in existing users

### DIFF
--- a/local_migrations/20181101153739_add_and_fix_office_users.sql
+++ b/local_migrations/20181101153739_add_and_fix_office_users.sql
@@ -1,0 +1,14 @@
+-- Local test migration.
+-- This will be run on development environments. It should mirror what you
+-- intend to apply on production, but do not include any sensitive data.
+
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
+-- ABC users
+UPDATE public.office_users SET first_name = 'test44', email = 'test44@example.com' WHERE email = 'test43@example.com';
+
+-- DEF users
+INSERT INTO public.office_users VALUES (uuid_generate_v4(), NULL, 'Gibbons', 'Peter', NULL, 'gibbons@example.com', '(800) 555-1234', '0931a9dc-c1fd-444a-b138-6e1986b1714c', now(), now());
+INSERT INTO public.office_users VALUES (uuid_generate_v4(), NULL, 'Lumbergh', 'Bill', NULL, 'lumbergh@example.com', '(800) 555-1234', '0931a9dc-c1fd-444a-b138-6e1986b1714c', now(), now());
+INSERT INTO public.office_users VALUES (uuid_generate_v4(), NULL, 'Waddams', 'Milton', NULL, 'waddams@example.com', '(800) 555-1234', '0931a9dc-c1fd-444a-b138-6e1986b1714c', now(), now());
+INSERT INTO public.office_users VALUES (uuid_generate_v4(), NULL, 'Smykowski', 'Tom', NULL, 'smykowski@example.com', '(800) 555-1234', '0931a9dc-c1fd-444a-b138-6e1986b1714c', now(), now());

--- a/migrations/20181101153739_add_and_fix_office_users.up.fizz
+++ b/migrations/20181101153739_add_and_fix_office_users.up.fizz
@@ -1,0 +1,1 @@
+exec("./apply-secure-migration.sh 20181101153739_add_and_fix_office_users.sql")


### PR DESCRIPTION
## Description

This PR adds new some new office users and fixes a typo in an existing office user.  Stories linked below.

## Setup

Run `bin/run-prod-migrations` and validate that the new/changed office users in your local `prod_migrations` database match what's listed in the stories below.

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/161559382) for this change
* [Another Pivotal story](https://www.pivotaltracker.com/story/show/161636648) for this change
