### PR TITLE
Do not show welcome greeting during setup process

### DIFF
--- a/cypress/integration/mymove/serviceMemberProfile.js
+++ b/cypress/integration/mymove/serviceMemberProfile.js
@@ -13,6 +13,12 @@ describe('setting up service member profile', function() {
 
 function serviceMemberProfile(reloadAfterEveryPage) {
   //dod info
+  // does not have welcome message throughout setup
+  cy
+    .get('span')
+    .contains('Welcome,')
+    .should('not.exist');
+
   cy.get('button.next').should('be.disabled');
   cy.get('select[name="affiliation"]').select('Army');
   cy.get('input[name="edipi"]').type('1234567890');

--- a/src/shared/User/UserGreeting.jsx
+++ b/src/shared/User/UserGreeting.jsx
@@ -3,7 +3,8 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 const UserGreeting = ({ isLoggedIn, firstName }) =>
-  isLoggedIn && (
+  isLoggedIn &&
+  firstName && (
     <span>
       <strong>Welcome, {firstName}</strong>
     </span>


### PR DESCRIPTION
## Description

Only show welcome greeting when first name exists

## Setup
`make server_run`
`make client_run`
Create new user

## Code Review Verification Steps

* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/161608272) for this change
