### PR TITLE
Style the weights panel 

### DIFF
--- a/cypress/integration/office/weightsAndItemsPanel.js
+++ b/cypress/integration/office/weightsAndItemsPanel.js
@@ -112,11 +112,7 @@ function officeUserEntersNetWeight() {
   openMoveHhgPanel();
   // Check that the initial display view for net weight is correct
   withinWeightsAndItemsPanel(() => {
-    cy.get('.net_weight').should($div => {
-      const text = $div.text();
-      expect(text).to.include('Actual');
-      expect(text).to.include('missing');
-    });
+    cy.get('.net_weight').should('not.exist');
   });
 
   cy

--- a/cypress/integration/tsp/weightsAndItemsPanel.js
+++ b/cypress/integration/tsp/weightsAndItemsPanel.js
@@ -118,11 +118,7 @@ function tspUserEntersNetWeight() {
 
   // Check that the initial display view for net weight is correct
   withinWeightsAndItemsPanel(() => {
-    cy.get('.net_weight').should($div => {
-      const text = $div.text();
-      expect(text).to.include('Actual');
-      expect(text).to.include('missing');
-    });
+    cy.get('.net_weight').should('not.exist');
   });
 
   cy

--- a/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
+++ b/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
@@ -393,6 +393,7 @@ class ShipmentInfo extends Component {
               {this.props.loadTspDependenciesHasSuccess && (
                 <div className="office-tab">
                   <Dates title="Dates" shipment={this.props.shipment} update={this.props.patchShipment} />
+                  <Weights title="Weights & Items" shipment={this.props.shipment} update={this.props.patchShipment} />
                   <PremoveSurvey
                     ref={this.enterPreMoveSurvey}
                     editPreMoveSurvey={this.state.editPreMoveSurvey}
@@ -410,7 +411,6 @@ class ShipmentInfo extends Component {
                     shipment={this.props.shipment}
                     serviceAgents={this.props.serviceAgents}
                   />
-                  <Weights title="Weights & Items" shipment={this.props.shipment} update={this.props.patchShipment} />
                   <LocationsContainer update={this.props.patchShipment} />
                 </div>
               )}

--- a/src/shared/ShipmentWeights/index.css
+++ b/src/shared/ShipmentWeights/index.css
@@ -1,0 +1,1 @@
+.unbold { font-weight: normal; }

--- a/src/shared/ShipmentWeights/index.jsx
+++ b/src/shared/ShipmentWeights/index.jsx
@@ -7,6 +7,8 @@ import { SwaggerField } from 'shared/JsonSchemaForm/JsonSchemaField';
 import { PanelSwaggerField, editablePanelify, PanelField } from 'shared/EditablePanel';
 import { formatWeight } from 'shared/formatters';
 
+import './index.css';
+
 const weightsFields = [
   'net_weight',
   'gross_weight',
@@ -27,23 +29,30 @@ const WeightsDisplay = props => {
       <div className="editable-panel-column">
         <div className="column-subhead">Weight</div>
         <PanelSwaggerField fieldName="weight_estimate" required title="Customer estimate" {...fieldProps} />
-        <PanelSwaggerField fieldName="pm_survey_weight_estimate" required title="TSP estimate" {...fieldProps} />
-        <PanelSwaggerField title="Actual" fieldName="net_weight" required {...fieldProps} />
+        {fieldProps.values.pm_survey_weight_estimate && (
+          <PanelSwaggerField fieldName="pm_survey_weight_estimate" title="TSP estimate" {...fieldProps} />
+        )}
+        {fieldProps.values.net_weight && <PanelSwaggerField title="Actual" fieldName="net_weight" {...fieldProps} />}
       </div>
       <div className="editable-panel-column">
-        <div className="column-subhead">Pro-gear (Service member + spouse)</div>
+        <div className="column-subhead">
+          Pro-gear <span className="unbold">(Service member + spouse)</span>
+        </div>
         <PanelField title="Customer estimate">
           <span>
             {`${formatWeight(values.progear_weight_estimate)} + ${formatWeight(values.spouse_progear_weight_estimate)}`}
           </span>
         </PanelField>
-        <PanelField title="TSP estimate">
-          <span>
-            {`${formatWeight(values.pm_survey_progear_weight_estimate)} + ${formatWeight(
-              values.pm_survey_spouse_progear_weight_estimate,
-            )}`}
-          </span>
-        </PanelField>
+        {(fieldProps.values.pm_survey_progear_weight_estimate ||
+          fieldProps.values.pm_survey_spouse_progear_weight_estimate) && (
+          <PanelField title="TSP estimate">
+            <span>
+              {`${formatWeight(values.pm_survey_progear_weight_estimate)} + ${formatWeight(
+                values.pm_survey_spouse_progear_weight_estimate,
+              )}`}
+            </span>
+          </PanelField>
+        )}
       </div>
     </Fragment>
   );
@@ -82,7 +91,9 @@ const WeightsEdit = props => {
           lbs
         </div>
         <div className="editable-panel-column">
-          <div className="column-head">Pro-gear (Service member + spouse)</div>
+          <div className="column-head">
+            Pro-gear <span className="unbold">(Service member + spouse)</span>
+          </div>
           <PanelField title="Customer estimate">
             <span>
               {`${formatWeight(values.progear_weight_estimate)} + ${formatWeight(


### PR DESCRIPTION
## Description

Style the weights panel:

- removing fields that have no data
- Move weights panel underneath the dates panel
- Unbold a section of text in a header (both in the display and edit parts)

I have not worked on changing the border style of the editable panel since that is a global issue.

## Reviewer Notes

I created a class to unbold the header text.  Is that a good pattern?

## Setup

Use scenario 7 data.  Look at any shipment and check out the weights panel.  Edit the premove survey and look again.  Edit the actuals and look again.

## Code Review Verification Steps

* [x] There are no aXe warnings for UI.
* [x] This works in IE.
* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/161597074) for this change

## Screenshots

Before:

<img width="949" alt="screen shot 2018-11-05 at 4 08 27 pm" src="https://user-images.githubusercontent.com/219296/48034630-0d63b080-e115-11e8-8ba9-9d835008cab4.png">

After:

<img width="947" alt="screen shot 2018-11-05 at 4 04 01 pm" src="https://user-images.githubusercontent.com/219296/48034599-f02ee200-e114-11e8-9ba0-a13ed387c381.png">
