### PR TITLE
fix missing prop

### DIFF
--- a/cypress/integration/office/officeServiceAgents.js
+++ b/cypress/integration/office/officeServiceAgents.js
@@ -2,6 +2,7 @@ import {
   userClearsServiceAgent,
   userInputsServiceAgent,
   userSavesServiceAgent,
+  userCancelsServiceAgent,
 } from '../../support/testTspServiceAgents';
 
 /* global cy */
@@ -9,6 +10,12 @@ describe('office user can view service agents', function() {
   beforeEach(() => {
     cy.signIntoOffice();
   });
+
+  it('office user opens and cancels service agent panel', function() {
+    officeUserEntersServiceAgents();
+    userCancelsServiceAgent();
+  });
+
   it('office user views and edits service agent panels', function() {
     officeUserEntersServiceAgents();
     userClearsServiceAgent('Origin');

--- a/cypress/integration/tsp/serviceAgents.js
+++ b/cypress/integration/tsp/serviceAgents.js
@@ -16,12 +16,14 @@ describe('TSP User enters and updates Service Agents', function() {
     tspUserSeesNoServiceAgent('Origin');
     userInputsServiceAgent('Origin');
     userCancelsServiceAgent('Origin');
+    tspUserViewsBlankServiceAgent();
   });
   it('tsp user enters and cancels destination service agent', function() {
     tspUserEntersServiceAgent();
     tspUserSeesNoServiceAgent('Destination');
     userInputsServiceAgent('Destination');
     userCancelsServiceAgent('Destination');
+    tspUserViewsBlankServiceAgent();
   });
   it('tsp user enters origin and destination service agents', function() {
     tspUserEntersServiceAgent();
@@ -59,6 +61,22 @@ function tspUserSeesNoServiceAgent(role) {
   cy.get('input[name="' + fixture.Role + '.company"]').should('have.value', '');
   cy.get('input[name="' + fixture.Role + '.email"]').should('have.value', '');
   cy.get('input[name="' + fixture.Role + '.phone_number"]').should('have.value', '');
+}
+
+function tspUserViewsBlankServiceAgent() {
+  // Verify data has been saved in the UI
+  cy
+    .get('div.company')
+    .get('span')
+    .contains('missing');
+  cy
+    .get('div.email')
+    .get('span')
+    .contains('missing');
+  cy
+    .get('div.phone_number')
+    .get('span')
+    .contains('missing');
 }
 
 function tspUserEntersServiceAgent() {

--- a/cypress/support/testTspServiceAgents.js
+++ b/cypress/support/testTspServiceAgents.js
@@ -69,8 +69,6 @@ export function userClearsServiceAgent(role) {
 }
 
 export function userCancelsServiceAgent(role) {
-  const fixture = getFixture(role);
-
   cy
     .get('button')
     .contains('Cancel')
@@ -80,20 +78,6 @@ export function userCancelsServiceAgent(role) {
     .get('button')
     .contains('Cancel')
     .click();
-
-  // Verify data has been saved in the UI
-  cy
-    .get('div.company')
-    .get('span')
-    .contains('missing');
-  cy
-    .get('div.email')
-    .get('span')
-    .contains('missing');
-  cy
-    .get('div.phone_number')
-    .get('span')
-    .contains('missing');
 }
 
 export function userSavesServiceAgent(role) {

--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -63,6 +63,7 @@ import faCheck from '@fortawesome/fontawesome-free-solid/faCheck';
 import faExclamationCircle from '@fortawesome/fontawesome-free-solid/faExclamationCircle';
 import faPlayCircle from '@fortawesome/fontawesome-free-solid/faPlayCircle';
 import faExternalLinkAlt from '@fortawesome/fontawesome-free-solid/faExternalLinkAlt';
+import { no_op_action } from '../../shared/utils';
 
 const BasicsTabContent = props => {
   return (
@@ -103,6 +104,7 @@ const HHGTabContent = props => {
         />
       )}
       <TspContainer
+        setEditTspServiceAgent={no_op_action}
         title="TSP & Servicing Agents"
         shipment={props.officeShipment}
         serviceAgents={props.serviceAgents}


### PR DESCRIPTION
## Description

Addresses a bug I found due to a missing prop in the MoveInfo (office side) page for the TspContainer (i.e. TSP & Servicing Agent panel). Previously, when you opened the TSP & Servicing Panel to edit, then selected cancel on the Office side, an error would occur. This handles the missing prop (which is only necessary on the TSP side) so no error occurs.
I made changes to E2E tests to make sure this issue would be caught if it occurred again.

## Reviewer Notes

Note: This prop `setEditTspServiceAgent` exists on the TSP side for scrolling/panel opening.

## Setup


```
make db_populate_e2e
make server_run
make office_client_run
```

Log into office client and select an HHG move. Try to cancel changes to the TSP & Servicing Agents panel.

## Code Review Verification Steps
* [x] There are no aXe warnings for UI.
* [x] This works in IE.
* [ ] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/161756839) for this change
