### PR TITLE
Add error handling to getEntitlements func

### DIFF
--- a/pkg/handlers/internalapi/move_dates.go
+++ b/pkg/handlers/internalapi/move_dates.go
@@ -38,9 +38,12 @@ func calculateMoveDatesFromMove(db *pop.Connection, planner route.Planner, moveI
 		return summary, err
 	}
 
-	entitlementWeight := unit.Pound(models.GetEntitlement(*move.Orders.ServiceMember.Rank, move.Orders.HasDependents,
-		move.Orders.SpouseHasProGear))
-
+	entitlement, err := models.GetEntitlement(*move.Orders.ServiceMember.Rank, move.Orders.HasDependents,
+		move.Orders.SpouseHasProGear)
+	if err != nil {
+		return summary, err
+	}
+	entitlementWeight := unit.Pound(entitlement)
 	estimatedPackDays := models.PackDays(entitlementWeight)
 	estimatedTransitDays, err := models.TransitDays(entitlementWeight, transitDistance)
 	if err != nil {

--- a/pkg/models/entitlements.go
+++ b/pkg/models/entitlements.go
@@ -1,5 +1,9 @@
 package models
 
+import (
+	"fmt"
+)
+
 // WeightAllotment represents the weights allotted for a rank
 type WeightAllotment struct {
 	TotalWeightSelf               int
@@ -197,21 +201,26 @@ func GetWeightAllotment(rank ServiceMemberRank) WeightAllotment {
 }
 
 // GetEntitlement calculates the entitlement for a rank, has dependents and has spouseprogear
-func GetEntitlement(rank ServiceMemberRank, hasDependents bool, spouseHasProGear bool) int {
+func GetEntitlement(rank ServiceMemberRank, hasDependents bool, spouseHasProGear bool) (int, error) {
 
 	entitlements := makeEntitlements()
 	spouseProGear := 0
 	weight := 0
 
+	selfEntitlement, ok := entitlements[rank]
+	if !ok {
+		return 0, fmt.Errorf("Rank %s not found in entitlement map", rank)
+	}
+
 	if hasDependents {
 		if spouseHasProGear {
-			spouseProGear = entitlements[rank].ProGearWeightSpouse
+			spouseProGear = selfEntitlement.ProGearWeightSpouse
 		}
-		weight = entitlements[rank].TotalWeightSelfPlusDependents
+		weight = selfEntitlement.TotalWeightSelfPlusDependents
 	} else {
-		weight = entitlements[rank].TotalWeightSelf
+		weight = selfEntitlement.TotalWeightSelf
 	}
-	proGear := entitlements[rank].ProGearWeight
+	proGear := selfEntitlement.ProGearWeight
 
-	return weight + proGear + spouseProGear
+	return weight + proGear + spouseProGear, nil
 }

--- a/pkg/models/entitlements_test.go
+++ b/pkg/models/entitlements_test.go
@@ -8,15 +8,19 @@ func (suite *ModelSuite) TestGetEntitlementWithValidValues() {
 	E1 := models.ServiceMemberRankE1
 
 	// When: E1 has dependents and spouse gear
-	E1FullLoad, _ := models.GetEntitlement(E1, true, true)
+	E1FullLoad, err := models.GetEntitlement(E1, true, true)
+	suite.Nil(err)
 	suite.Assertions.Equal(10500, E1FullLoad)
 	// When: E1 doesn't have dependents or spouse gear
-	E1Solo, _ := models.GetEntitlement(E1, false, false)
+	E1Solo, err := models.GetEntitlement(E1, false, false)
+	suite.Nil(err)
 	suite.Assertions.Equal(7000, E1Solo)
 	// When: E1 doesn't have dependents but has spouse gear - impossible state
-	E1FakeSpouse, _ := models.GetEntitlement(E1, false, true)
+	E1FakeSpouse, err := models.GetEntitlement(E1, false, true)
+	suite.Nil(err)
 	suite.Assertions.Equal(7000, E1FakeSpouse)
 	// When: E1 has dependents but no spouse gear
-	E1DivorcedWithKids, _ := models.GetEntitlement(E1, true, false)
+	E1DivorcedWithKids, err := models.GetEntitlement(E1, true, false)
+	suite.Nil(err)
 	suite.Assertions.Equal(10000, E1DivorcedWithKids)
 }

--- a/pkg/models/entitlements_test.go
+++ b/pkg/models/entitlements_test.go
@@ -8,11 +8,15 @@ func (suite *ModelSuite) TestGetEntitlementWithValidValues() {
 	E1 := models.ServiceMemberRankE1
 
 	// When: E1 has dependents and spouse gear
-	suite.Assertions.Equal(10500, models.GetEntitlement(E1, true, true))
+	E1FullLoad, _ := models.GetEntitlement(E1, true, true)
+	suite.Assertions.Equal(10500, E1FullLoad)
 	// When: E1 doesn't have dependents or spouse gear
-	suite.Assertions.Equal(7000, models.GetEntitlement(E1, false, false))
+	E1Solo, _ := models.GetEntitlement(E1, false, false)
+	suite.Assertions.Equal(7000, E1Solo)
 	// When: E1 doesn't have dependents but has spouse gear - impossible state
-	suite.Assertions.Equal(7000, models.GetEntitlement(E1, false, true))
+	E1FakeSpouse, _ := models.GetEntitlement(E1, false, true)
+	suite.Assertions.Equal(7000, E1FakeSpouse)
 	// When: E1 has dependents but no spouse gear
-	suite.Assertions.Equal(10000, models.GetEntitlement(E1, true, false))
+	E1DivorcedWithKids, _ := models.GetEntitlement(E1, true, false)
+	suite.Assertions.Equal(10000, E1DivorcedWithKids)
 }


### PR DESCRIPTION
## Description

If a rank is not found in the entitlements map (e.g. due to a typo), the entitlement is evaluated to 0 rather than an error related to a lookup with an absent key (because Go). This adds a check for whether the key/value pair exists in the map and returns an error if so.

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](./docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](./docs/backend.md#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](./docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
* [ ] There are no aXe warnings for UI.
* [ ] This works in IE.
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @willowbl00
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?
