### PR TITLE
slim down editable panels

### DIFF
--- a/src/shared/EditablePanel/index.css
+++ b/src/shared/EditablePanel/index.css
@@ -22,12 +22,13 @@
 
 .column-head{
   font-weight: 700;
-  margin: 1.5em 0.8em 0.8em 0;
+  margin: 1em 0.8em 0em 0;
+  font-size: 1em;
 }
 
 .column-subhead{
   display: block;
-  margin: 1.5em 0.8em 0.8em 0em;
+  margin: 1.3em 0.8em 0em 0em;
   font-size: 0.8em;
   font-weight: bold;
 }
@@ -160,26 +161,38 @@
 .editable-panel.is-editable .field-value {
   display: block;
   margin-left: 0;
-  font-size: 1.5rem;
+  font-size: 1.4rem;
 }
 
 .editable-panel.is-editable .field-title {
   display: block;
-  font-size: 1.6rem;
-  margin: 1rem 0;
+  font-size: 1.4rem;
+  margin: .8rem 0;
 }
 
 .editable-panel.is-editable .panel-field {
   border: 0;
-  margin: 1rem 0 1rem;
+  margin: .8rem 0 .8rem;
 }
 
 .editable-panel.is-editable .panel-subhead {
-  margin-top: 3rem;
+  margin-top: 2rem;
   display: block;
-  font-size: 1.7rem;
+  font-size: 1.5rem;
+}
+
+.editable-panel.is-editable .field-with-units {
+  font-size: 1.4rem;
 }
 
 .disable-edit .editable-panel-edit {
   display: none;
+}
+
+.editable-panel.is-editable label {
+  margin-top: 1rem;
+}
+
+.editable-panel.is-editable .usa-input-label {
+  font-size: 1.4rem;
 }

--- a/src/shared/ShipmentWeights/index.jsx
+++ b/src/shared/ShipmentWeights/index.jsx
@@ -62,24 +62,32 @@ const WeightsEdit = props => {
         <div className="editable-panel-column">
           <div className="column-head">Weights</div>
           <PanelSwaggerField fieldName="weight_estimate" required title="Customer estimate" {...fieldProps} />
-          <SwaggerField
-            className="short-field"
-            fieldName="pm_survey_weight_estimate"
-            title="TSP estimate"
-            swagger={schema}
-          />{' '}
-          lbs
+          <div className="field-with-units">
+            <SwaggerField
+              className="short-field"
+              fieldName="pm_survey_weight_estimate"
+              title="TSP estimate"
+              swagger={schema}
+            />{' '}
+            lbs
+          </div>
           <div className="column-subhead">Actual Weights</div>
-          <SwaggerField className="short-field" fieldName="gross_weight" swagger={schema} required /> lbs
-          <SwaggerField className="short-field" fieldName="tare_weight" swagger={schema} required /> lbs
-          <SwaggerField
-            title="Net (Gross - Tare)"
-            className="short-field"
-            fieldName="net_weight"
-            swagger={schema}
-            required
-          />{' '}
-          lbs
+          <div className="field-with-units">
+            <SwaggerField className="short-field" fieldName="gross_weight" swagger={schema} required /> lbs
+          </div>
+          <div className="field-with-units">
+            <SwaggerField className="short-field" fieldName="tare_weight" swagger={schema} required /> lbs
+          </div>
+          <div className="field-with-units">
+            <SwaggerField
+              title="Net (Gross - Tare)"
+              className="short-field"
+              fieldName="net_weight"
+              swagger={schema}
+              required
+            />{' '}
+            lbs
+          </div>
         </div>
         <div className="editable-panel-column">
           <div className="column-head">Pro-gear (Service member + spouse)</div>
@@ -91,20 +99,24 @@ const WeightsEdit = props => {
             </span>
           </PanelField>
           <div className="column-subhead">TSP Estimate</div>
-          <SwaggerField
-            className="short-field"
-            fieldName="pm_survey_progear_weight_estimate"
-            title="Service member"
-            swagger={schema}
-          />{' '}
-          lbs
-          <SwaggerField
-            className="short-field"
-            fieldName="pm_survey_spouse_progear_weight_estimate"
-            title="Spouse"
-            swagger={schema}
-          />{' '}
-          lbs
+          <div className="field-with-units">
+            <SwaggerField
+              className="short-field"
+              fieldName="pm_survey_progear_weight_estimate"
+              title="Service member"
+              swagger={schema}
+            />{' '}
+            lbs
+          </div>
+          <div className="field-with-units">
+            <SwaggerField
+              className="short-field"
+              fieldName="pm_survey_spouse_progear_weight_estimate"
+              title="Spouse"
+              swagger={schema}
+            />{' '}
+            lbs
+          </div>
         </div>
       </FormSection>
     </Fragment>


### PR DESCRIPTION
## Description

Editable panels getting too big. Made fields smaller with less margin.

## Reviewer Notes

Small enough?

## Setup

```
make db_populate_e2e
make server_run
make office_client_run
```
Log into office or tsp client and select an HHG move. Edit any of the editable panels.

## Code Review Verification Steps

* [ ] There are no aXe warnings for UI.
* [ ] This works in IE.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/161563745) for this change

## Screenshots

Before:
<img width="919" alt="screen shot 2018-11-06 at 9 42 59 am" src="https://user-images.githubusercontent.com/7401870/48082969-caebb380-e1a8-11e8-840a-c25126a7fb89.png">
<img width="894" alt="screen shot 2018-11-06 at 9 42 11 am" src="https://user-images.githubusercontent.com/7401870/48082972-cde6a400-e1a8-11e8-9476-5418ae67e2e5.png">

After:
<img width="878" alt="screen shot 2018-11-06 at 9 42 40 am" src="https://user-images.githubusercontent.com/7401870/48082985-d6d77580-e1a8-11e8-80e0-9a417d31d6d4.png">
<img width="877" alt="screen shot 2018-11-06 at 9 41 49 am" src="https://user-images.githubusercontent.com/7401870/48082986-d6d77580-e1a8-11e8-8d0f-1669b40b0a30.png">
