### PR TITLE
Fix editable panel styling so that headers are darker and borders are dashed while editing

### DIFF
--- a/src/shared/EditablePanel/index.css
+++ b/src/shared/EditablePanel/index.css
@@ -94,13 +94,13 @@
   text-decoration: none;
 }
 
-.office-tab.editable-panel.is-editable .editable-panel-header {
+.office-tab .editable-panel.is-editable .editable-panel-header {
   background: rgb(176,176,176);
   border-color: rgb(176,176,176);
   color: white;
 }
 
-.office-tab.editable-panel.is-editable .editable-panel-content {
+.office-tab .editable-panel.is-editable .editable-panel-content {
   border-style: dashed;
   border-color: rgb(176,176,176);
 }


### PR DESCRIPTION
## Description

Just like the title.  The wireframes showed this style, the style sheets appeared to have the correct styles, the class names were correct ... but it wasn't styled.  Turns out we lost some spaces somewhere.

## Setup

Add scenario 7 data.  Go to any record in the TSP or Office app and edit any panel.  You'll see the header get darker and the border become dashed.

## Code Review Verification Steps

* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/161739767) for this change

## Screenshots

Before:

<img width="948" alt="screen shot 2018-11-06 at 10 21 20 am" src="https://user-images.githubusercontent.com/219296/48084899-c2e24280-e1ad-11e8-9b48-45de471429b4.png">

After:

<img width="949" alt="screen shot 2018-11-06 at 10 21 34 am" src="https://user-images.githubusercontent.com/219296/48084908-c83f8d00-e1ad-11e8-9126-df5002ab424f.png">
