### PR TITLE
Move locations panel to the correct spot in the page

### DIFF
--- a/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
+++ b/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
@@ -404,6 +404,7 @@ class ShipmentInfo extends Component {
                 <div className="office-tab">
                   <Dates title="Dates" shipment={this.props.shipment} update={this.props.patchShipment} />
                   <Weights title="Weights & Items" shipment={this.props.shipment} update={this.props.patchShipment} />
+                  <LocationsContainer update={this.props.patchShipment} />
                   <PreApprovalPanel shipmentId={this.props.match.params.shipmentId} />
                   <TspContainer
                     ref={this.assignTspServiceAgent}
@@ -413,7 +414,6 @@ class ShipmentInfo extends Component {
                     shipment={this.props.shipment}
                     serviceAgents={this.props.serviceAgents}
                   />
-                  <LocationsContainer update={this.props.patchShipment} />
                 </div>
               )}
             </div>


### PR DESCRIPTION
## Description

The locations panel is styled correctly but it was in the wrong spot on the page.  This puts it between the Weights and Preapprovals panels as in the wireframes.

## Code Review Verification Steps

* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/161597096) for this change