### PR TITLE
SM sees add shipment link if hhg submitted and not in prod

### DIFF
--- a/cypress/integration/mymove/landingPages.js
+++ b/cypress/integration/mymove/landingPages.js
@@ -88,7 +88,7 @@ function ppmSubmitted(userId) {
   cy.signInAsUser(userId);
   cy.contains('Move your own stuff (PPM)');
   cy.contains('Next Step: Awaiting approval');
-  cy.should('not.contain', 'Add Shipment');
+  cy.should('not.contain', 'Add PPM Shipment');
   cy.logout();
 }
 
@@ -104,7 +104,7 @@ function hhgMoveSummary(userId) {
   cy.signInAsUser(userId);
   cy.contains('Government Movers and Packers (HHG)');
   cy.contains('Next Step: Prepare for move');
-  cy.contains('Add Shipment');
+  cy.contains('Add PPM Shipment');
   cy.logout();
 }
 

--- a/cypress/integration/mymove/landingPages.js
+++ b/cypress/integration/mymove/landingPages.js
@@ -88,6 +88,7 @@ function ppmSubmitted(userId) {
   cy.signInAsUser(userId);
   cy.contains('Move your own stuff (PPM)');
   cy.contains('Next Step: Awaiting approval');
+  cy.should('not.contain', 'Add Shipment');
   cy.logout();
 }
 
@@ -103,6 +104,7 @@ function hhgMoveSummary(userId) {
   cy.signInAsUser(userId);
   cy.contains('Government Movers and Packers (HHG)');
   cy.contains('Next Step: Prepare for move');
+  cy.contains('Add Shipment');
   cy.logout();
 }
 

--- a/src/scenes/Landing/MoveSummary.jsx
+++ b/src/scenes/Landing/MoveSummary.jsx
@@ -264,7 +264,7 @@ export const SubmittedHhgMoveSummary = props => {
   );
 };
 
-export const ApprovedMoveSummary = withContext(props => {
+export const ApprovedMoveSummary = props => {
   const { ppm, orders, profile, move, entitlement, requestPaymentSuccess } = props;
   const paymentRequested = ppm.status === 'PAYMENT_REQUESTED';
   const moveInProgress = moment(ppm.planned_move_date, 'YYYY-MM-DD').isSameOrBefore();
@@ -346,7 +346,7 @@ export const ApprovedMoveSummary = withContext(props => {
       </div>
     </Fragment>
   );
-});
+};
 
 const PPMMoveDetails = props => {
   const { ppm } = props;

--- a/src/scenes/Landing/MoveSummary.jsx
+++ b/src/scenes/Landing/MoveSummary.jsx
@@ -508,7 +508,7 @@ export const MoveSummary = withContext(props => {
               hhgAndPpmEnabled && (
                 <a href="">
                   <FontAwesomeIcon icon={faPlus} />
-                  Add PPM Shipment
+                  <span> Add PPM Shipment</span>
                 </a>
               )}
           </div>

--- a/src/scenes/Landing/MoveSummary.jsx
+++ b/src/scenes/Landing/MoveSummary.jsx
@@ -442,7 +442,7 @@ const getStatus = (moveStatus, moveType, ppm, shipment) => {
   return status;
 };
 
-export const MoveSummary = props => {
+export const MoveSummary = withContext(props => {
   const {
     profile,
     move,
@@ -459,6 +459,10 @@ export const MoveSummary = props => {
   const status = getStatus(moveStatus, move.selected_move_type, ppm, shipment);
   const StatusComponent =
     move.selected_move_type === 'PPM' ? ppmSummaryStatusComponents[status] : hhgSummaryStatusComponents[status]; // eslint-disable-line security/detect-object-injection
+  const hhgAndPpmEnabled = props.context.flags.hhgAndPpm;
+  const showAddShipmentLink =
+    move.selected_move_type === 'HHG' &&
+    ['SUBMITTED', 'ACCEPTED', 'APPROVED', 'IN_TRANSIT', 'DELIVERED', 'COMPLETED'].includes(move.status);
   const showTsp =
     move.selected_move_type !== 'PPM' &&
     ['ACCEPTED', 'APPROVED', 'IN_TRANSIT', 'DELIVERED', 'COMPLETED'].includes(status);
@@ -486,14 +490,19 @@ export const MoveSummary = props => {
         />
 
         <div className="sidebar usa-width-one-fourth">
-          <button
-            className="usa-button-secondary"
-            onClick={() => editMove(move)}
-            disabled={includes(['DRAFT', 'CANCELED'], status)}
-          >
-            Edit Move
-          </button>
-
+          <div>
+            <button
+              className="usa-button-secondary"
+              onClick={() => editMove(move)}
+              disabled={includes(['DRAFT', 'CANCELED'], status)}
+            >
+              Edit Move
+            </button>
+          </div>
+          <div>
+            {/* ToDo: Replace this url */}
+            {showAddShipmentLink && hhgAndPpmEnabled && <a href="#">Add Shipment</a>}
+          </div>
           <div className="contact_block">
             <div className="title">Contacts</div>
             <TransportationOfficeContactInfo dutyStation={profile.current_station} isOrigin={true} />
@@ -509,4 +518,4 @@ export const MoveSummary = props => {
       </div>
     </Fragment>
   );
-};
+});

--- a/src/scenes/Landing/MoveSummary.jsx
+++ b/src/scenes/Landing/MoveSummary.jsx
@@ -462,7 +462,7 @@ export const MoveSummary = withContext(props => {
   const status = getStatus(moveStatus, move.selected_move_type, ppm, shipment);
   const StatusComponent =
     move.selected_move_type === 'PPM' ? ppmSummaryStatusComponents[status] : hhgSummaryStatusComponents[status]; // eslint-disable-line security/detect-object-injection
-  const hhgAndPpmEnabled = props.context.flags.hhgAndPpm;
+  const hhgAndPpmEnabled = get(props, 'context.flags.hhgAndPpm', false);
   const showAddShipmentLink =
     move.selected_move_type === 'HHG' &&
     ['SUBMITTED', 'ACCEPTED', 'APPROVED', 'IN_TRANSIT', 'DELIVERED', 'COMPLETED'].includes(move.status);

--- a/src/scenes/Landing/MoveSummary.jsx
+++ b/src/scenes/Landing/MoveSummary.jsx
@@ -19,6 +19,9 @@ import { Link } from 'react-router-dom';
 import { withContext } from 'shared/AppContext';
 import StatusTimelineContainer from './StatusTimeline';
 
+import FontAwesomeIcon from '@fortawesome/react-fontawesome';
+import faPlus from '@fortawesome/fontawesome-free-solid/faPlus';
+
 export const CanceledMoveSummary = props => {
   const { profile, reviewProfile } = props;
   const currentStation = get(profile, 'current_station');
@@ -501,7 +504,13 @@ export const MoveSummary = withContext(props => {
           </div>
           <div>
             {/* ToDo: Replace this url */}
-            {showAddShipmentLink && hhgAndPpmEnabled && <a href="#">Add Shipment</a>}
+            {showAddShipmentLink &&
+              hhgAndPpmEnabled && (
+                <a href="#">
+                  <FontAwesomeIcon icon={faPlus} />
+                  Add PPM Shipment
+                </a>
+              )}
           </div>
           <div className="contact_block">
             <div className="title">Contacts</div>

--- a/src/scenes/Landing/MoveSummary.jsx
+++ b/src/scenes/Landing/MoveSummary.jsx
@@ -506,7 +506,7 @@ export const MoveSummary = withContext(props => {
             {/* ToDo: Replace this url */}
             {showAddShipmentLink &&
               hhgAndPpmEnabled && (
-                <a href="#">
+                <a href="">
                   <FontAwesomeIcon icon={faPlus} />
                   Add PPM Shipment
                 </a>

--- a/src/scenes/Landing/MoveSummary.test.jsx
+++ b/src/scenes/Landing/MoveSummary.test.jsx
@@ -27,7 +27,7 @@ describe('MoveSummary', () => {
     editMoveFn,
     resumeMoveFn,
   ) => {
-    return shallow(
+    const componentWrapper = shallow(
       <MoveSummary
         entitlement={entitlementObj}
         profile={serviceMember}
@@ -39,6 +39,7 @@ describe('MoveSummary', () => {
         resumeMove={resumeMoveFn}
       />,
     );
+    return shallow(componentWrapper.props().children());
   };
 
   // PPM

--- a/src/scenes/Landing/index.test.js
+++ b/src/scenes/Landing/index.test.js
@@ -88,10 +88,15 @@ describe('HomePage tests', () => {
           />,
           div,
         );
-        expect(
+        const moveSummary = shallow(
           wrapper
             .find(MoveSummary)
             .dive()
+            .props()
+            .children(),
+        );
+        expect(
+          moveSummary
             .find('.status-component')
             .dive()
             .find('.step')
@@ -129,10 +134,15 @@ describe('HomePage tests', () => {
           />,
           div,
         );
-        expect(
+        const moveSummary = shallow(
           wrapper
             .find(MoveSummary)
             .dive()
+            .props()
+            .children(),
+        );
+        expect(
+          moveSummary
             .find('.status-component')
             .dive()
             .find('.step')

--- a/src/shared/featureFlags.js
+++ b/src/shared/featureFlags.js
@@ -11,6 +11,7 @@ import { forEach } from 'lodash';
 const defaultFlags = {
   ppm: true,
   hhg: true,
+  hhgAndPpm: true,
   documentViewer: true,
 };
 
@@ -23,7 +24,9 @@ const environmentFlags = {
 
   staging: Object.assign({}, defaultFlags),
 
-  production: Object.assign({}, defaultFlags),
+  production: Object.assign({}, defaultFlags, {
+    hhgAndPpm: false,
+  }),
 };
 
 export function flagsFromURL(search) {


### PR DESCRIPTION
## Description

This adds a link that goes nowhere currently. The link is for adding a PPM to an HHG move. This is behind a feature flag that is disabled in production. 

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make db_populate_e2e
```
Then log in as any SM that has a HHG submitted to see the link.
Log in as a SM that has a PPM to verify that it's not there.

## Code Review Verification Steps

* [x] Get design sign off from Mia and Jenny.
* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* https://www.pivotaltracker.com/story/show/161466898

## Screenshots

<img width="1020" alt="screen shot 2018-11-06 at 6 18 56 pm" src="https://user-images.githubusercontent.com/5531789/48106504-7c620780-e1f0-11e8-9c7c-fc8872e1998c.png">

