### PR TITLE
Fix references to old gobuffalo/uuid import

### DIFF
--- a/pkg/handlers/dpsapi/errors.go
+++ b/pkg/handlers/dpsapi/errors.go
@@ -1,6 +1,6 @@
 package dpsapi
 
-import "github.com/gobuffalo/uuid"
+import "github.com/gofrs/uuid"
 
 type errUserMissingData struct {
 	userID     uuid.UUID

--- a/pkg/models/invoice.go
+++ b/pkg/models/invoice.go
@@ -4,9 +4,9 @@ import (
 	"time"
 
 	"github.com/gobuffalo/pop"
-	"github.com/gobuffalo/uuid"
 	"github.com/gobuffalo/validate"
 	"github.com/gobuffalo/validate/validators"
+	"github.com/gofrs/uuid"
 )
 
 // Invoice is a collection of line item charges to be sent for payment

--- a/pkg/models/tariff400ng_item_rate.go
+++ b/pkg/models/tariff400ng_item_rate.go
@@ -4,9 +4,9 @@ import (
 	"time"
 
 	"github.com/gobuffalo/pop"
-	"github.com/gobuffalo/uuid"
 	"github.com/gobuffalo/validate"
 	"github.com/gobuffalo/validate/validators"
+	"github.com/gofrs/uuid"
 	"github.com/transcom/mymove/pkg/unit"
 )
 


### PR DESCRIPTION
## Description

It looks like some references to the (now deprecated) `gobuffalo/uuid` package got merged back in around the time @akostibas did the changes in #1262 to move us to the `gofrs/uuid` package instead.  Noticed this because GoLand said things were out of sync and to do a `dep check`:

```
$ dep check
# Gopkg.lock is out of sync:
github.com/gobuffalo/uuid: imported or required, but missing from Gopkg.lock's input-imports
```

This PR updates those references.
