### PR TITLE
Allow the database to be specified for db-backup and db-restore

### DIFF
--- a/bin/db-backup
+++ b/bin/db-backup
@@ -3,7 +3,8 @@
 
 set -eu -o pipefail
 
-export DB_NAME=dev_db
+
+readonly db=${DB_NAME:-db_dev}
 export PGPASSWORD="mysecretpassword"
 
 function proceed() {
@@ -29,4 +30,4 @@ if [[ -f "$path" ]]; then
   proceed "There is already a backup named '$name'. Do you wish to overwrite it?"
 fi
 
-pg_dump -h localhost -U postgres -c dev_db > "$path"
+pg_dump -h localhost -U postgres -c --if-exists "$db" > "$path"

--- a/bin/db-restore
+++ b/bin/db-restore
@@ -3,7 +3,7 @@
 
 set -eu -o pipefail
 
-export DB_NAME=dev_db
+readonly db=${DB_NAME:-db_dev}
 export PGPASSWORD="mysecretpassword"
 
 function list() {
@@ -27,4 +27,4 @@ if [[ ! -f "$path" ]]; then
   exit 1
 fi
 
-psql -h localhost -U postgres -q < "$path" > /dev/null
+psql -h localhost -U postgres -q -d "$db" < "$path" > /dev/null

--- a/docs/how-to/backup-and-restore-dev-database.md
+++ b/docs/how-to/backup-and-restore-dev-database.md
@@ -8,6 +8,12 @@ Run `bin/db-backup` to backup the `dev_db` to a file on the filesystem. The back
 $ bin/db-backup clean-state
 ```
 
+If you'd like to backup a database other than `dev_db`, specify it by setting the value of the `DB_NAME` environment variable. In bash, the following command will backup `test_db`:
+
+```console
+$ DB_NAME=test_db bin/db-backup clean-slate
+```
+
 ## Restore a Backup
 
 Run `bin/db-restore` to overwrite the `dev_db` database with the contents of the named backup:
@@ -17,6 +23,12 @@ $ bin/db-restore clean-state
 ```
 
 **This is a destructive command!** All data currently in `dev_db` will be removed when this command is run.
+
+If you'd like to restore to a database other than `dev_db`, specify it by setting the value of the `DB_NAME` environment variable. In bash, that looks like this:
+
+```console
+$ DB_NAME=test_db bin/db-restore clean-slate
+```
 
 ## List Existing Backups
 


### PR DESCRIPTION
## Description

This PR allows the database being backed up/restored to be specified using the `DB_NAME` environment variable. Check out the included doc changes for more context.