### PR TITLE
Implement new selected move types

### DIFF
--- a/pkg/handlers/internalapi/moves.go
+++ b/pkg/handlers/internalapi/moves.go
@@ -74,7 +74,8 @@ func (h CreateMoveHandler) Handle(params moveop.CreateMoveParams) middleware.Res
 		return handlers.ResponseForError(h.Logger(), err)
 	}
 
-	move, verrs, err := orders.CreateNewMove(h.DB(), params.CreateMovePayload.SelectedMoveType)
+	selectedMoveType := models.SelectedMoveType(*params.CreateMovePayload.SelectedMoveType)
+	move, verrs, err := orders.CreateNewMove(h.DB(), &selectedMoveType)
 	if verrs.HasAny() || err != nil {
 		if err == models.ErrCreateViolatesUniqueConstraint {
 			h.Logger().Error("Failed to create Unique Record Locator")
@@ -143,9 +144,8 @@ func (h PatchMoveHandler) Handle(params moveop.PatchMoveParams) middleware.Respo
 	newSelectedMoveType := payload.SelectedMoveType
 
 	if newSelectedMoveType != nil {
-		stringSelectedMoveType := ""
 		if newSelectedMoveType != nil {
-			stringSelectedMoveType = string(*newSelectedMoveType)
+			stringSelectedMoveType := models.SelectedMoveType(*newSelectedMoveType)
 			move.SelectedMoveType = &stringSelectedMoveType
 		}
 	}

--- a/pkg/handlers/internalapi/moves_test.go
+++ b/pkg/handlers/internalapi/moves_test.go
@@ -53,7 +53,7 @@ func (suite *HandlerSuite) TestPatchMoveHandler() {
 	req := httptest.NewRequest("PATCH", "/moves/some_id", nil)
 	req = suite.AuthenticateRequest(req, move.Orders.ServiceMember)
 
-	var newType = internalmessages.SelectedMoveTypeCOMBO
+	var newType = internalmessages.SelectedMoveTypeHHGPPM
 	patchPayload := internalmessages.PatchMovePayload{
 		SelectedMoveType: &newType,
 	}
@@ -84,7 +84,7 @@ func (suite *HandlerSuite) TestPatchMoveHandlerWrongUser() {
 	req := httptest.NewRequest("PATCH", "/moves/some_id", nil)
 	req = suite.AuthenticateRequest(req, anotherUser)
 
-	var newType = internalmessages.SelectedMoveTypeCOMBO
+	var newType = internalmessages.SelectedMoveTypeHHGPPM
 	patchPayload := internalmessages.PatchMovePayload{
 		SelectedMoveType: &newType,
 	}
@@ -111,7 +111,7 @@ func (suite *HandlerSuite) TestPatchMoveHandlerNoMove() {
 	req := httptest.NewRequest("PATCH", "/moves/some_id", nil)
 	req = suite.AuthenticateRequest(req, user)
 
-	var newType = internalmessages.SelectedMoveTypeCOMBO
+	var newType = internalmessages.SelectedMoveTypeHHGPPM
 	patchPayload := internalmessages.PatchMovePayload{
 		SelectedMoveType: &newType,
 	}

--- a/pkg/handlers/internalapi/office_test.go
+++ b/pkg/handlers/internalapi/office_test.go
@@ -107,8 +107,8 @@ func (suite *HandlerSuite) TestCancelMoveHandler() {
 	// Orders has service member with transportation office and phone nums
 	orders := testdatagen.MakeDefaultOrder(suite.TestDB())
 
-	var selectedType = internalmessages.SelectedMoveTypePPM
-	move, verrs, err := orders.CreateNewMove(suite.TestDB(), &selectedType)
+	selectedMoveType := models.SelectedMoveTypePPM
+	move, verrs, err := orders.CreateNewMove(suite.TestDB(), &selectedMoveType)
 	suite.Nil(err)
 	suite.False(verrs.HasAny(), "failed to validate move")
 	officeUser := testdatagen.MakeDefaultOfficeUser(suite.TestDB())

--- a/pkg/handlers/internalapi/personally_procured_move_test.go
+++ b/pkg/handlers/internalapi/personally_procured_move_test.go
@@ -20,9 +20,9 @@ import (
 func (suite *HandlerSuite) TestCreatePPMHandler() {
 	user1 := testdatagen.MakeDefaultServiceMember(suite.TestDB())
 	orders := testdatagen.MakeDefaultOrder(suite.TestDB())
-	var selectedType = internalmessages.SelectedMoveTypeCOMBO
+	selectedMoveType := models.SelectedMoveTypeHHGPPM
 
-	move, verrs, locErr := orders.CreateNewMove(suite.TestDB(), &selectedType)
+	move, verrs, locErr := orders.CreateNewMove(suite.TestDB(), &selectedMoveType)
 	suite.False(verrs.HasAny(), "failed to create new move")
 	suite.Nil(locErr)
 
@@ -340,14 +340,14 @@ func (suite *HandlerSuite) TestPatchPPMHandlerWrongMoveID() {
 	orders := testdatagen.MakeDefaultOrder(suite.TestDB())
 	orders1 := testdatagen.MakeDefaultOrder(suite.TestDB())
 
-	var selectedType = internalmessages.SelectedMoveTypeCOMBO
+	selectedMoveType := models.SelectedMoveTypeHHGPPM
 
-	move, verrs, err := orders.CreateNewMove(suite.TestDB(), &selectedType)
+	move, verrs, err := orders.CreateNewMove(suite.TestDB(), &selectedMoveType)
 	suite.Nil(err, "Failed to save move")
 	suite.False(verrs.HasAny(), "failed to validate move")
 	move.Orders = orders
 
-	move2, verrs, err := orders1.CreateNewMove(suite.TestDB(), &selectedType)
+	move2, verrs, err := orders1.CreateNewMove(suite.TestDB(), &selectedMoveType)
 	suite.Nil(err, "Failed to save move")
 	suite.False(verrs.HasAny(), "failed to validate move")
 	move2.Orders = orders1

--- a/pkg/handlers/publicapi/shipments.go
+++ b/pkg/handlers/publicapi/shipments.go
@@ -623,7 +623,7 @@ func (h CreateGovBillOfLadingHandler) Handle(params shipmentop.CreateGovBillOfLa
 		models.MoveDocumentTypeGOVBILLOFLADING,
 		string("Government Bill Of Lading"),
 		swag.String(""),
-		string(apimessages.SelectedMoveTypeHHG),
+		models.SelectedMoveType(apimessages.SelectedMoveTypeHHG),
 	)
 	if err != nil || verrs.HasAny() {
 		return handlers.ResponseForVErrors(h.Logger(), verrs, err)

--- a/pkg/models/move.go
+++ b/pkg/models/move.go
@@ -32,6 +32,27 @@ const (
 	MoveStatusCANCELED MoveStatus = "CANCELED"
 )
 
+// SelectedMoveType represents the type of move being represented
+type SelectedMoveType string
+
+// This lists available move types in the system
+// Combination move types like HHG+PPM should be added as an underscore separated list
+// The list should be lexigraphically sorted. Ex: UB + PPM will always be 'PPM_UB'
+const (
+	// MoveStatusHHG captures enum value "HHG" for House Hold Goods
+	SelectedMoveTypeHHG SelectedMoveType = "HHG"
+	// MoveStatusPPM captures enum value "PPM" for Personally Procured Move
+	SelectedMoveTypePPM SelectedMoveType = "PPM"
+	// MoveStatusUB captures enum value "UB" for Unaccompanied Baggage
+	SelectedMoveTypeUB SelectedMoveType = "UB"
+	// MoveStatusPOV captures enum value "POV" for Privately-Owned Vehicle
+	SelectedMoveTypePOV SelectedMoveType = "POV"
+	// MoveStatusNTS captures enum value "NTS" for Non-Temporary Storage
+	SelectedMoveTypeNTS SelectedMoveType = "NTS"
+	// MoveStatusHHGPPM captures enum value "HHG_PPM" for combination move HHG + PPM
+	SelectedMoveTypeHHGPPM SelectedMoveType = "HHG_PPM"
+)
+
 const maxLocatorAttempts = 3
 const locatorLength = 6
 
@@ -46,7 +67,7 @@ type Move struct {
 	UpdatedAt               time.Time               `json:"updated_at" db:"updated_at"`
 	OrdersID                uuid.UUID               `json:"orders_id" db:"orders_id"`
 	Orders                  Order                   `belongs_to:"orders"`
-	SelectedMoveType        *string                 `json:"selected_move_type" db:"selected_move_type"`
+	SelectedMoveType        *SelectedMoveType       `json:"selected_move_type" db:"selected_move_type"`
 	PersonallyProcuredMoves PersonallyProcuredMoves `has_many:"personally_procured_moves" order_by:"created_at desc"`
 	Shipments               Shipments               `has_many:"shipments"`
 	MoveDocuments           MoveDocuments           `has_many:"move_documents" order_by:"created_at desc"`
@@ -233,7 +254,7 @@ func (m Move) createMoveDocumentWithoutTransaction(
 	moveDocumentType MoveDocumentType,
 	title string,
 	notes *string,
-	moveType string) (*MoveDocument, *validate.Errors, error) {
+	moveType SelectedMoveType) (*MoveDocument, *validate.Errors, error) {
 
 	var responseError error
 	responseVErrors := validate.NewErrors()
@@ -306,7 +327,7 @@ func (m Move) CreateMoveDocument(
 	moveDocumentType MoveDocumentType,
 	title string,
 	notes *string,
-	moveType string) (*MoveDocument, *validate.Errors, error) {
+	moveType SelectedMoveType) (*MoveDocument, *validate.Errors, error) {
 
 	var newMoveDocument *MoveDocument
 	var responseError error
@@ -346,7 +367,7 @@ func (m Move) CreateMovingExpenseDocument(
 	requestedAmountCents unit.Cents,
 	paymentMethod string,
 	movingExpenseType MovingExpenseType,
-	moveType string) (*MovingExpenseDocument, *validate.Errors, error) {
+	moveType SelectedMoveType) (*MovingExpenseDocument, *validate.Errors, error) {
 
 	var newMovingExpenseDocument *MovingExpenseDocument
 	var responseError error
@@ -485,11 +506,11 @@ func GenerateLocator() string {
 // retry with a new record locator.
 func createNewMove(db *pop.Connection,
 	orders Order,
-	selectedType *internalmessages.SelectedMoveType) (*Move, *validate.Errors, error) {
+	selectedType *SelectedMoveType) (*Move, *validate.Errors, error) {
 
-	var stringSelectedType string
+	var stringSelectedType SelectedMoveType
 	if selectedType != nil {
-		stringSelectedType = string(*selectedType)
+		stringSelectedType = SelectedMoveType(*selectedType)
 	}
 	for i := 0; i < maxLocatorAttempts; i++ {
 		move := Move{

--- a/pkg/models/move_test.go
+++ b/pkg/models/move_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/auth"
-	"github.com/transcom/mymove/pkg/gen/internalmessages"
 	. "github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"
 )
@@ -24,9 +23,9 @@ func (suite *ModelSuite) TestBasicMoveInstantiation() {
 
 func (suite *ModelSuite) TestCreateNewMoveValidLocatorString() {
 	orders := testdatagen.MakeDefaultOrder(suite.db)
-	var selectedType = internalmessages.SelectedMoveTypeHHG
+	selectedMoveType := SelectedMoveTypeHHG
 
-	move, verrs, err := orders.CreateNewMove(suite.db, &selectedType)
+	move, verrs, err := orders.CreateNewMove(suite.db, &selectedMoveType)
 
 	suite.Nil(err)
 	suite.False(verrs.HasAny(), "failed to validate move")
@@ -53,9 +52,9 @@ func (suite *ModelSuite) TestFetchMove() {
 		ServiceMemberID: order1.ServiceMemberID,
 		ApplicationName: auth.MyApp,
 	}
-	var selectedType = internalmessages.SelectedMoveTypeHHG
+	selectedMoveType := SelectedMoveTypeHHG
 
-	move, verrs, err := order1.CreateNewMove(suite.db, &selectedType)
+	move, verrs, err := order1.CreateNewMove(suite.db, &selectedMoveType)
 	suite.Nil(err)
 	suite.False(verrs.HasAny(), "failed to validate move")
 	suite.Equal(6, len(move.Locator))
@@ -96,9 +95,9 @@ func (suite *ModelSuite) TestMoveCancellationWithReason() {
 	orders.Status = OrderStatusSUBMITTED // NEVER do this outside of a test.
 	suite.mustSave(&orders)
 
-	var selectedType = internalmessages.SelectedMoveTypeCOMBO
+	selectedMoveType := SelectedMoveTypeHHGPPM
 
-	move, verrs, err := orders.CreateNewMove(suite.db, &selectedType)
+	move, verrs, err := orders.CreateNewMove(suite.db, &selectedMoveType)
 	suite.Nil(err)
 	suite.False(verrs.HasAny(), "failed to validate move")
 	move.Orders = orders
@@ -122,9 +121,9 @@ func (suite *ModelSuite) TestMoveStateMachine() {
 	orders.Status = OrderStatusSUBMITTED // NEVER do this outside of a test.
 	suite.mustSave(&orders)
 
-	var selectedType = internalmessages.SelectedMoveTypeCOMBO
+	selectedMoveType := SelectedMoveTypeHHGPPM
 
-	move, verrs, err := orders.CreateNewMove(suite.db, &selectedType)
+	move, verrs, err := orders.CreateNewMove(suite.db, &selectedMoveType)
 	suite.Nil(err)
 	suite.False(verrs.HasAny(), "failed to validate move")
 	reason := ""
@@ -189,9 +188,9 @@ func (suite *ModelSuite) TestCancelMoveCancelsOrdersPPM() {
 	orders.Status = OrderStatusSUBMITTED // NEVER do this outside of a test.
 	suite.mustSave(&orders)
 
-	var selectedType = internalmessages.SelectedMoveTypeCOMBO
+	selectedMoveType := SelectedMoveTypeHHGPPM
 
-	move, verrs, err := orders.CreateNewMove(suite.db, &selectedType)
+	move, verrs, err := orders.CreateNewMove(suite.db, &selectedMoveType)
 	suite.Nil(err)
 	suite.False(verrs.HasAny(), "failed to validate move")
 	move.Orders = orders
@@ -223,9 +222,9 @@ func (suite *ModelSuite) TestSaveMoveDependenciesFail() {
 	orders := testdatagen.MakeDefaultOrder(suite.db)
 	orders.Status = ""
 
-	var selectedType = internalmessages.SelectedMoveTypeCOMBO
+	selectedMoveType := SelectedMoveTypeHHGPPM
 
-	move, verrs, err := orders.CreateNewMove(suite.db, &selectedType)
+	move, verrs, err := orders.CreateNewMove(suite.db, &selectedMoveType)
 	suite.Nil(err)
 	suite.False(verrs.HasAny(), "failed to validate move")
 	move.Orders = orders
@@ -239,9 +238,9 @@ func (suite *ModelSuite) TestSaveMoveDependenciesSuccess() {
 	orders := testdatagen.MakeDefaultOrder(suite.db)
 	orders.Status = OrderStatusSUBMITTED
 
-	var selectedType = internalmessages.SelectedMoveTypeCOMBO
+	selectedMoveType := SelectedMoveTypeHHGPPM
 
-	move, verrs, err := orders.CreateNewMove(suite.db, &selectedType)
+	move, verrs, err := orders.CreateNewMove(suite.db, &selectedMoveType)
 	suite.Nil(err)
 	suite.False(verrs.HasAny(), "failed to validate move")
 	move.Orders = orders
@@ -269,8 +268,8 @@ func (suite *ModelSuite) TestSaveMoveDependenciesSetsGBLOCSuccess() {
 	orders := testdatagen.MakeDefaultOrder(suite.db)
 	orders.Status = OrderStatusSUBMITTED
 
-	var selectedType = internalmessages.SelectedMoveTypeCOMBO
-	move, verrs, err := orders.CreateNewMove(suite.db, &selectedType)
+	selectedMoveType := SelectedMoveTypeHHGPPM
+	move, verrs, err := orders.CreateNewMove(suite.db, &selectedMoveType)
 	suite.Nil(err)
 	suite.False(verrs.HasAny(), "failed to validate move")
 

--- a/pkg/models/order.go
+++ b/pkg/models/order.go
@@ -207,7 +207,7 @@ func FetchOrderForPDFConversion(db *pop.Connection, id uuid.UUID) (Order, error)
 }
 
 // CreateNewMove creates a move associated with these Orders
-func (o *Order) CreateNewMove(db *pop.Connection, moveType *internalmessages.SelectedMoveType) (*Move, *validate.Errors, error) {
+func (o *Order) CreateNewMove(db *pop.Connection, moveType *SelectedMoveType) (*Move, *validate.Errors, error) {
 	return createNewMove(db, *o, moveType)
 }
 

--- a/pkg/models/order_test.go
+++ b/pkg/models/order_test.go
@@ -210,7 +210,6 @@ func (suite *ModelSuite) TestCanceledMoveCancelsOrder() {
 	}
 	deptIndicator := testdatagen.DefaultDepartmentIndicator
 	TAC := testdatagen.DefaultTransportationAccountingCode
-	selectedType := internalmessages.SelectedMoveTypeCOMBO
 	suite.mustSave(&uploadedOrder)
 	orders := Order{
 		ServiceMemberID:     serviceMember1.ID,
@@ -230,7 +229,8 @@ func (suite *ModelSuite) TestCanceledMoveCancelsOrder() {
 	}
 	suite.mustSave(&orders)
 
-	move, verrs, err := orders.CreateNewMove(suite.db, &selectedType)
+	selectedMoveType := SelectedMoveTypeHHGPPM
+	move, verrs, err := orders.CreateNewMove(suite.db, &selectedMoveType)
 	suite.Nil(err)
 	suite.False(verrs.HasAny(), "failed to validate move")
 	move.Orders = orders

--- a/pkg/models/personally_procured_move_test.go
+++ b/pkg/models/personally_procured_move_test.go
@@ -2,7 +2,6 @@ package models_test
 
 import (
 	"github.com/transcom/mymove/pkg/auth"
-	"github.com/transcom/mymove/pkg/gen/internalmessages"
 	. "github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"
 )
@@ -55,9 +54,9 @@ func (suite *ModelSuite) TestPPMStateMachine() {
 	orders.Status = OrderStatusSUBMITTED // NEVER do this outside of a test.
 	suite.mustSave(&orders)
 
-	var selectedType = internalmessages.SelectedMoveTypeCOMBO
+	selectedMoveType := SelectedMoveTypeHHGPPM
 
-	move, verrs, err := orders.CreateNewMove(suite.db, &selectedType)
+	move, verrs, err := orders.CreateNewMove(suite.db, &selectedMoveType)
 	suite.Nil(err)
 	suite.False(verrs.HasAny(), "failed to validate move")
 	move.Orders = orders

--- a/pkg/testdatagen/make_move.go
+++ b/pkg/testdatagen/make_move.go
@@ -16,7 +16,7 @@ func MakeMove(db *pop.Connection, assertions Assertions) models.Move {
 		orders = MakeOrder(db, assertions)
 	}
 
-	defaultMoveType := "PPM"
+	defaultMoveType := models.SelectedMoveTypePPM
 	selectedMoveType := assertions.Move.SelectedMoveType
 	if selectedMoveType == nil {
 		selectedMoveType = &defaultMoveType

--- a/pkg/testdatagen/make_shipment_offer_records.go
+++ b/pkg/testdatagen/make_shipment_offer_records.go
@@ -137,7 +137,7 @@ func CreateShipmentOfferData(db *pop.Connection, numTspUsers int, numShipments i
 	market := "dHHG"
 	sourceGBLOC := "KKFA"
 	destinationGBLOC := "HAFC"
-	selectedMoveType := "HHG"
+	selectedMoveType := models.SelectedMoveTypeHHG
 	if len(statuses) == 0 {
 		// Statuses for shipments attached to a shipment offer should not be DRAFT or SUBMITTED
 		// because this should be after the award queue has run and SUBMITTED shipments have been awarded

--- a/pkg/testdatagen/scenario/e2ebasic.go
+++ b/pkg/testdatagen/scenario/e2ebasic.go
@@ -9,7 +9,6 @@ import (
 	"github.com/gobuffalo/pop"
 	"github.com/gofrs/uuid"
 	"github.com/transcom/mymove/pkg/assets"
-	"github.com/transcom/mymove/pkg/gen/apimessages"
 	"github.com/transcom/mymove/pkg/paperwork"
 	"github.com/transcom/mymove/pkg/storage"
 	uploaderpkg "github.com/transcom/mymove/pkg/uploader"
@@ -27,6 +26,9 @@ type e2eBasicScenario NamedScenario
 
 // E2eBasicScenario Is the thing
 var E2eBasicScenario = e2eBasicScenario{"e2e_basic"}
+
+var selectedMoveTypeHHG = models.SelectedMoveTypeHHG
+var selectedMoveTypePPM = models.SelectedMoveTypePPM
 
 // Run does that data load thing
 func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, logger *zap.Logger, storer *storage.Filesystem) {
@@ -368,7 +370,7 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, log
 		Move: models.Move{
 			ID:               uuid.FromStringOrNil("2ed0b5a2-26d9-49a3-a775-5220055e8ffe"),
 			Locator:          "RLKBEM",
-			SelectedMoveType: models.StringPointer("HHG"),
+			SelectedMoveType: &selectedMoveTypeHHG,
 		},
 		TrafficDistributionList: models.TrafficDistributionList{
 			ID:                uuid.FromStringOrNil("0dfdbdda-c57e-4b29-994a-09fb8641fc75"),
@@ -401,7 +403,7 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, log
 		Move: models.Move{
 			ID:               uuid.FromStringOrNil("56b8ef45-8145-487b-9b59-0e30d0d465fa"),
 			Locator:          "BACON1",
-			SelectedMoveType: models.StringPointer("HHG"),
+			SelectedMoveType: &selectedMoveTypeHHG,
 		},
 		TrafficDistributionList: models.TrafficDistributionList{
 			ID:                uuid.FromStringOrNil("776b5a23-2830-4de0-bb6a-7698a25865cb"),
@@ -460,7 +462,7 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, log
 		Move: models.Move{
 			ID:               uuid.FromStringOrNil("849a7880-4a82-4f76-acb4-63cf481e786b"),
 			Locator:          "BACON2",
-			SelectedMoveType: models.StringPointer("HHG"),
+			SelectedMoveType: &selectedMoveTypeHHG,
 		},
 		TrafficDistributionList: models.TrafficDistributionList{
 			ID:                uuid.FromStringOrNil("5f86c201-1abf-4f9d-8dcb-d039cb1c6bfc"),
@@ -520,7 +522,7 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, log
 		Move: models.Move{
 			ID:               uuid.FromStringOrNil("4752270d-4a6f-44ea-82f6-ae3cf3277c5d"),
 			Locator:          "BACON3",
-			SelectedMoveType: models.StringPointer("HHG"),
+			SelectedMoveType: &selectedMoveTypeHHG,
 		},
 		TrafficDistributionList: models.TrafficDistributionList{
 			ID:                uuid.FromStringOrNil("e09f8b8b-67a6-4ce3-b5c3-bd48c82512fc"),
@@ -561,7 +563,7 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, log
 		Move: models.Move{
 			ID:               uuid.FromStringOrNil("94739ee0-664c-47c5-afe9-0f5067a2e151"),
 			Locator:          "BACON4",
-			SelectedMoveType: models.StringPointer("HHG"),
+			SelectedMoveType: &selectedMoveTypeHHG,
 		},
 		TrafficDistributionList: models.TrafficDistributionList{
 			ID:                uuid.FromStringOrNil("9ebc891b-f629-4ea1-9ebf-eef1971d69a3"),
@@ -602,7 +604,7 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, log
 		Move: models.Move{
 			ID:               uuid.FromStringOrNil("7fca3fd0-08a6-480a-8a9c-16a65a100db9"),
 			Locator:          "REJECT",
-			SelectedMoveType: models.StringPointer("HHG"),
+			SelectedMoveType: &selectedMoveTypeHHG,
 		},
 		TrafficDistributionList: models.TrafficDistributionList{
 			ID:                uuid.FromStringOrNil("1731c3e6-b510-43d0-be46-13e5a2032bad"),
@@ -642,7 +644,7 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, log
 		Move: models.Move{
 			ID:               uuid.FromStringOrNil("3452270d-4a6f-44ea-82f6-ae3cf3277c5d"),
 			Locator:          "NINOPK",
-			SelectedMoveType: models.StringPointer("HHG"),
+			SelectedMoveType: &selectedMoveTypeHHG,
 		},
 		TrafficDistributionList: models.TrafficDistributionList{
 			ID:                uuid.FromStringOrNil("459f8b8b-67a6-4ce3-b5c3-bd48c82512fc"),
@@ -683,7 +685,7 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, log
 		Move: models.Move{
 			ID:               uuid.FromStringOrNil("616560f2-7e35-4504-b7e6-69038fb0c015"),
 			Locator:          "APPRVD",
-			SelectedMoveType: models.StringPointer("HHG"),
+			SelectedMoveType: &selectedMoveTypeHHG,
 		},
 		TrafficDistributionList: models.TrafficDistributionList{
 			ID:                uuid.FromStringOrNil("5fe59be4-45d0-47c7-b426-cf4db9882af7"),
@@ -724,7 +726,7 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, log
 		Move: models.Move{
 			ID:               uuid.FromStringOrNil("29cd6b2f-9ef2-48be-b4ee-1c1e0a1456ef"),
 			Locator:          "BACON5",
-			SelectedMoveType: models.StringPointer("HHG"),
+			SelectedMoveType: &selectedMoveTypeHHG,
 		},
 		Order: models.Order{
 			OrdersNumber:        models.StringPointer("54321"),
@@ -770,7 +772,7 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, log
 		Move: models.Move{
 			ID:               uuid.FromStringOrNil("1a3eb5a2-26d9-49a3-a775-5220055e8ffe"),
 			Locator:          "LRKREK",
-			SelectedMoveType: models.StringPointer("HHG"),
+			SelectedMoveType: &selectedMoveTypeHHG,
 		},
 		TrafficDistributionList: models.TrafficDistributionList{
 			ID:                uuid.FromStringOrNil("873dbdda-c57e-4b29-994a-09fb8641fc75"),
@@ -813,7 +815,7 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, log
 		Move: models.Move{
 			ID:               uuid.FromStringOrNil("3442270d-4a6f-44ea-82f6-ae3cf3277c5d"),
 			Locator:          "SCHNOO",
-			SelectedMoveType: models.StringPointer("HHG"),
+			SelectedMoveType: &selectedMoveTypeHHG,
 		},
 		TrafficDistributionList: models.TrafficDistributionList{
 			ID:                uuid.FromStringOrNil("466f8b8b-67a6-4ce3-b5c3-bd48c82512fc"),
@@ -854,7 +856,7 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, log
 		Move: models.Move{
 			ID:               uuid.FromStringOrNil("9992270d-4a6f-44ea-82f6-ae3cf3277c5d"),
 			Locator:          "NOCHKA",
-			SelectedMoveType: models.StringPointer("HHG"),
+			SelectedMoveType: &selectedMoveTypeHHG,
 		},
 		TrafficDistributionList: models.TrafficDistributionList{
 			ID:                uuid.FromStringOrNil("777f8b8b-67a6-4ce3-b5c3-bd48c82512fc"),
@@ -895,7 +897,7 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, log
 		Move: models.Move{
 			ID:               uuid.FromStringOrNil("abcd6b2f-9ef2-48be-b4ee-1c1e0a1456ef"),
 			Locator:          "SSETZN",
-			SelectedMoveType: models.StringPointer("HHG"),
+			SelectedMoveType: &selectedMoveTypeHHG,
 			Status:           models.MoveStatusAPPROVED,
 		},
 		Order: models.Order{
@@ -953,7 +955,7 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, log
 		Move: models.Move{
 			ID:               uuid.FromStringOrNil("01d85649-18c2-44ad-854d-da8884579f42"),
 			Locator:          "PREMVE",
-			SelectedMoveType: models.StringPointer("HHG"),
+			SelectedMoveType: &selectedMoveTypeHHG,
 		},
 		TrafficDistributionList: models.TrafficDistributionList{
 			ID:                uuid.FromStringOrNil("fd76c4fc-a2fb-45b6-a3a6-7c35357ab79a"),
@@ -993,7 +995,7 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, log
 		Move: models.Move{
 			ID:               uuid.FromStringOrNil("11185649-18c2-44ad-854d-da8884579f42"),
 			Locator:          "DATESP",
-			SelectedMoveType: models.StringPointer("HHG"),
+			SelectedMoveType: &selectedMoveTypeHHG,
 		},
 		TrafficDistributionList: models.TrafficDistributionList{
 			ID:                uuid.FromStringOrNil("feeec4fc-a2fb-45b6-a3a6-7c35357ab79a"),
@@ -1033,7 +1035,7 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, log
 		Move: models.Move{
 			ID:               uuid.FromStringOrNil("ccd45bd4-660c-4ddd-b6c6-062da0a647f9"),
 			Locator:          "DOCVWR",
-			SelectedMoveType: models.StringPointer("HHG"),
+			SelectedMoveType: &selectedMoveTypeHHG,
 		},
 		TrafficDistributionList: models.TrafficDistributionList{
 			ID:                uuid.FromStringOrNil("7ad595da-9b34-4914-aeaa-9a540d13872f"),
@@ -1073,7 +1075,7 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, log
 		Move: models.Move{
 			ID:               uuid.FromStringOrNil("761743d9-2259-4bee-b144-3bda29311446"),
 			Locator:          "DTYSTN",
-			SelectedMoveType: models.StringPointer("HHG"),
+			SelectedMoveType: &selectedMoveTypeHHG,
 		},
 		TrafficDistributionList: models.TrafficDistributionList{
 			ID:                uuid.FromStringOrNil("a36a58b4-51ab-4d39-bcdc-b3ca3a59a4a1"),
@@ -1114,7 +1116,7 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, log
 		Move: models.Move{
 			ID:               uuid.FromStringOrNil("787c0921-7696-400e-86f5-c1bcb8bb88a3"),
 			Locator:          "DOCUPL",
-			SelectedMoveType: models.StringPointer("HHG"),
+			SelectedMoveType: &selectedMoveTypeHHG,
 		},
 		TrafficDistributionList: models.TrafficDistributionList{
 			ID:                uuid.FromStringOrNil("ad3ee670-6978-46e1-bcfc-686cdd4ffa87"),
@@ -1156,7 +1158,7 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, log
 		Move: models.Move{
 			ID:               uuid.FromStringOrNil("57e9275b-b433-474c-99f2-ac64966b3c9b"),
 			Locator:          "BACON6",
-			SelectedMoveType: models.StringPointer("HHG"),
+			SelectedMoveType: &selectedMoveTypeHHG,
 		},
 		Order: models.Order{
 			OrdersNumber:        models.StringPointer("54321"),
@@ -1202,7 +1204,7 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, log
 		Move: models.Move{
 			ID:               uuid.FromStringOrNil("533d176f-0bab-4c51-88cd-c899f6855b9d"),
 			Locator:          "BACON7",
-			SelectedMoveType: models.StringPointer("HHG"),
+			SelectedMoveType: &selectedMoveTypeHHG,
 		},
 		TrafficDistributionList: models.TrafficDistributionList{
 			ID:                uuid.FromStringOrNil("60e65f0c-aa21-4d95-a825-9d323a3dc4f1"),
@@ -1243,7 +1245,7 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, log
 		Move: models.Move{
 			ID:               uuid.FromStringOrNil("da9af941-253a-45e0-b012-8ee0385e28f8"),
 			Locator:          "DATESZ",
-			SelectedMoveType: models.StringPointer("HHG"),
+			SelectedMoveType: &selectedMoveTypeHHG,
 		},
 		TrafficDistributionList: models.TrafficDistributionList{
 			ID:                uuid.FromStringOrNil("9728e6a1-0469-4718-9ba1-5d7baace1191"),
@@ -1283,7 +1285,7 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, log
 		Move: models.Move{
 			ID:               uuid.FromStringOrNil("60098ff1-8dc9-4318-a2e8-47bc8aac11a4"),
 			Locator:          "GOTDOC",
-			SelectedMoveType: models.StringPointer("HHG"),
+			SelectedMoveType: &selectedMoveTypeHHG,
 		},
 		TrafficDistributionList: models.TrafficDistributionList{
 			ID:                uuid.FromStringOrNil("7ad595da-9b34-4914-aeaa-9a540d13872f"),
@@ -1337,7 +1339,7 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, log
 		Move: models.Move{
 			ID:               uuid.FromStringOrNil("42d85649-18c2-44ad-854d-da8884579f42"),
 			Locator:          "ENTPMS",
-			SelectedMoveType: models.StringPointer("HHG"),
+			SelectedMoveType: &selectedMoveTypeHHG,
 		},
 		TrafficDistributionList: models.TrafficDistributionList{
 			ID:                uuid.FromStringOrNil("f426c4fc-a2fb-45b6-a3a6-7c35357ab79a"),
@@ -1383,7 +1385,7 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, log
 		Move: models.Move{
 			ID:               uuid.FromStringOrNil("33686dbe-cd64-4786-8aaa-a93dda278683"),
 			Locator:          "ASSIGN",
-			SelectedMoveType: models.StringPointer("HHG"),
+			SelectedMoveType: &selectedMoveTypeHHG,
 		},
 		TrafficDistributionList: models.TrafficDistributionList{
 			ID:                uuid.FromStringOrNil("d40edb7e-24c9-4a21-8e4b-2e473471263e"),
@@ -1422,7 +1424,7 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, log
 		Move: models.Move{
 			ID:               uuid.FromStringOrNil("135af727-f570-4c7e-bf5b-878d717ef83c"),
 			Locator:          "ENTDEL",
-			SelectedMoveType: models.StringPointer("HHG"),
+			SelectedMoveType: &selectedMoveTypeHHG,
 		},
 		TrafficDistributionList: models.TrafficDistributionList{
 			ID:                uuid.FromStringOrNil("ebfac7dc-acfa-4a88-bbbf-a2dd1a7f2657"),
@@ -1463,7 +1465,7 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, log
 		Move: models.Move{
 			ID:               uuid.FromStringOrNil("da6bf1f4-a810-486d-befe-ddf8e9a4e2ef"),
 			Locator:          "HHGCAN",
-			SelectedMoveType: models.StringPointer("HHG"),
+			SelectedMoveType: &selectedMoveTypeHHG,
 		},
 		TrafficDistributionList: models.TrafficDistributionList{
 			ID:                uuid.FromStringOrNil("d89dba9c-5ee9-40ee-8430-2e3eb13eedeb"),
@@ -1498,7 +1500,7 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, log
 		Move: models.Move{
 			ID:               uuid.FromStringOrNil("2be4f6a3-82f5-4919-a257-39a24859058f"),
 			Locator:          "WTSPNL",
-			SelectedMoveType: models.StringPointer("HHG"),
+			SelectedMoveType: &selectedMoveTypeHHG,
 		},
 		TrafficDistributionList: models.TrafficDistributionList{
 			ID:                uuid.FromStringOrNil("d2c24faf-3439-451f-b020-fc1492f6b4bf"),
@@ -1538,7 +1540,7 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, log
 		Move: models.Move{
 			ID:               uuid.FromStringOrNil("47e9c534-a93c-4986-ae8f-41fddefaa618"),
 			Locator:          "ODATES",
-			SelectedMoveType: models.StringPointer("HHG"),
+			SelectedMoveType: &selectedMoveTypeHHG,
 		},
 		TrafficDistributionList: models.TrafficDistributionList{
 			ID:                uuid.FromStringOrNil("51004395-ecbf-4ab2-9edc-ec5041bbe390"),
@@ -1571,7 +1573,7 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, log
 		Move: models.Move{
 			ID:               uuid.FromStringOrNil("762f2ec2-f362-4c14-b601-d7178c4862fe"),
 			Locator:          "ODATE0",
-			SelectedMoveType: models.StringPointer("HHG"),
+			SelectedMoveType: &selectedMoveTypeHHG,
 		},
 		TrafficDistributionList: models.TrafficDistributionList{
 			ID:                uuid.FromStringOrNil("12e17ea7-9c94-4b61-a28d-5a81744a355c"),
@@ -1625,7 +1627,7 @@ func MakeHhgFromAwardedToAcceptedGBLReady(db *pop.Connection, tspUser models.Tsp
 		Move: models.Move{
 			ID:               uuid.FromStringOrNil("05a58b2e-07da-4b41-b4f8-d18ab68dddd5"),
 			Locator:          "GBLGBL",
-			SelectedMoveType: models.StringPointer("HHG"),
+			SelectedMoveType: &selectedMoveTypeHHG,
 		},
 		TrafficDistributionList: models.TrafficDistributionList{
 			ID:                uuid.FromStringOrNil("b15fdc2b-52cd-4b3e-91ba-a36d6ab94a16"),
@@ -1715,7 +1717,7 @@ func MakeHhgWithGBL(db *pop.Connection, tspUser models.TspUser, logger *zap.Logg
 		Move: models.Move{
 			ID:               uuid.FromStringOrNil("6eee3663-1973-40c5-b49e-e70e9325b895"),
 			Locator:          "CONGBL",
-			SelectedMoveType: models.StringPointer("HHG"),
+			SelectedMoveType: &selectedMoveTypeHHG,
 		},
 		TrafficDistributionList: models.TrafficDistributionList{
 			ID:                uuid.FromStringOrNil("87fcebf6-63b8-40cb-bc40-b553f5b91b9c"),
@@ -1791,7 +1793,7 @@ func MakeHhgWithGBL(db *pop.Connection, tspUser models.TspUser, logger *zap.Logg
 		models.MoveDocumentTypeGOVBILLOFLADING,
 		string("Government Bill Of Lading"),
 		swag.String(""),
-		string(apimessages.SelectedMoveTypeHHG),
+		models.SelectedMoveTypeHHG,
 	)
 
 	return offer.Shipment

--- a/swagger/api.yaml
+++ b/swagger/api.yaml
@@ -622,12 +622,18 @@ definitions:
     enum:
       - HHG
       - PPM
-      - COMBO
+      - UB
+      - POV
+      - NTS
+      - HHG_PPM
     x-nullable: true
     x-display-value:
       HHG: Household Goods Move
       PPM: Personal Procured Move
-      COMBO: Both HHG and PPM
+      UB: Unaccompanied Baggage
+      POV: Privately-Owned Vehicle
+      NTS: Non-Temporary Storage
+      HHG_PPM: Both HHG and PPM
   ServiceAgentRole:
     type: string
     title: Service Agent Role

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -538,12 +538,18 @@ definitions:
     enum:
       - HHG
       - PPM
-      - COMBO
+      - UB
+      - POV
+      - NTS
+      - HHG_PPM
     x-nullable: true
     x-display-value:
       HHG: Household Goods Move
       PPM: Personal Procured Move
-      COMBO: Both HHG and PPM
+      UB: Unaccompanied Baggage
+      POV: Privately-Owned Vehicle
+      NTS: Non-Temporary Storage
+      HHG_PPM: Both HHG and PPM
   IndexMovesPayload:
     type: array
     items:


### PR DESCRIPTION
## Description

Previously we had a move type named `COMBO` that was supposed to represent PPM + HHG moves.  However, there could be lots of combo moves and they could include more or different types.  This change lists the moves we know about and creates a new move type `HHG_PPM` following a set of rules listed in the code.

In addition, I've removed instances of `internalmessages.SelectedMoveType` from our DB's model layer since it's not a good practice and instead created a new SelectedMoveType that is 1:1 with our API.

## Reviewer Notes

Make sure the documentation around combo moves makes sense to you please.

## Setup

Run server tests or e2e tests, there should be no noticeable difference.

## Code Review Verification Steps

* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/161796830) for this change