### PR TITLE
Contact icons should be grey and not black per user testing

### DIFF
--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -252,10 +252,12 @@ class MoveInfo extends Component {
               <li>
                 {serviceMember.telephone}
                 {serviceMember.phone_is_preferred && (
-                  <FontAwesomeIcon className="icon" icon={faPhone} flip="horizontal" />
+                  <FontAwesomeIcon className="icon icon-grey" icon={faPhone} flip="horizontal" />
                 )}
-                {serviceMember.text_message_is_preferred && <FontAwesomeIcon className="icon" icon={faComments} />}
-                {serviceMember.email_is_preferred && <FontAwesomeIcon className="icon" icon={faEmail} />}
+                {serviceMember.text_message_is_preferred && (
+                  <FontAwesomeIcon className="icon icon-grey" icon={faComments} />
+                )}
+                {serviceMember.email_is_preferred && <FontAwesomeIcon className="icon icon-grey" icon={faEmail} />}
                 &nbsp;
               </li>
               <li>Locator# {move.locator}&nbsp;</li>

--- a/src/scenes/Office/office.css
+++ b/src/scenes/Office/office.css
@@ -16,6 +16,10 @@
   margin: 0 0.3em 0 0.5em;
 }
 
+.icon-grey {
+  color: rgba(171,171,171,1.00);
+}
+
 .form-column {
   display: inline-block;
   width: 45%;

--- a/src/scenes/TransportationServiceProvider/CustomerInfo.jsx
+++ b/src/scenes/TransportationServiceProvider/CustomerInfo.jsx
@@ -43,9 +43,21 @@ export const CustomerInfo = ({ serviceMember, backupContact, entitlements }) => 
             <a href={`mailto:${serviceMember.personal_email}`}>{serviceMember.personal_email}</a>
             <br />
             Preferred contact method:{' '}
-            {serviceMember.phone_is_preferred && <FontAwesomeIcon className="icon" icon={faPhone} flip="horizontal" />}
-            {serviceMember.text_message_is_preferred && <FontAwesomeIcon className="icon" icon={faComments} />}
-            {serviceMember.email_is_preferred && <FontAwesomeIcon className="icon" icon={faEmail} />}
+            {serviceMember.phone_is_preferred && (
+              <span>
+                <FontAwesomeIcon className="icon icon-grey" icon={faPhone} flip="horizontal" /> <span>Phone</span>
+              </span>
+            )}
+            {serviceMember.text_message_is_preferred && (
+              <span>
+                <FontAwesomeIcon className="icon icon-grey" icon={faComments} /> <span>Text</span>
+              </span>
+            )}
+            {serviceMember.email_is_preferred && (
+              <span>
+                <FontAwesomeIcon className="icon icon-grey" icon={faEmail} /> <span>Email</span>
+              </span>
+            )}
           </p>
           <p>
             {backupContact.name && (

--- a/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
+++ b/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
@@ -317,10 +317,12 @@ class ShipmentInfo extends Component {
               <li>
                 {serviceMember.telephone}
                 {serviceMember.phone_is_preferred && (
-                  <FontAwesomeIcon className="icon" icon={faPhone} flip="horizontal" />
+                  <FontAwesomeIcon className="icon icon-grey" icon={faPhone} flip="horizontal" />
                 )}
-                {serviceMember.text_message_is_preferred && <FontAwesomeIcon className="icon" icon={faComments} />}
-                {serviceMember.email_is_preferred && <FontAwesomeIcon className="icon" icon={faEmail} />}
+                {serviceMember.text_message_is_preferred && (
+                  <FontAwesomeIcon className="icon icon-grey" icon={faComments} />
+                )}
+                {serviceMember.email_is_preferred && <FontAwesomeIcon className="icon icon-grey" icon={faEmail} />}
                 &nbsp;
               </li>
             </ul>

--- a/src/scenes/TransportationServiceProvider/tsp.css
+++ b/src/scenes/TransportationServiceProvider/tsp.css
@@ -16,6 +16,10 @@
   margin: 0 0.3em 0 0.3em;
 }
 
+.icon-grey {
+  color: rgba(171,171,171,1.00);
+}
+
 .form-column {
   display: inline-block;
   width: 45%;
@@ -256,8 +260,4 @@
   animation: shipmentStatusFade ease-in 1;
   animation-fill-mode: forwards;
   animation-duration: 2s;
-}
-
-.icon-grey {
-  color: rgba(171,171,171,1.00);
 }

--- a/src/scenes/TransportationServiceProvider/tsp.css
+++ b/src/scenes/TransportationServiceProvider/tsp.css
@@ -257,3 +257,7 @@
   animation-fill-mode: forwards;
   animation-duration: 2s;
 }
+
+.icon-grey {
+  color: rgba(171,171,171,1.00);
+}


### PR DESCRIPTION
## Description

Per user testing the contact icons need to be grey and not black.  Also, it was noted that in the customer info panel the icons need text next to them.

## Setup

View any shipment record to see the change.

## Code Review Verification Steps

* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/161738101) for this change

## Screenshots

Before:

<img width="142" alt="screen shot 2018-11-07 at 3 54 49 pm" src="https://user-images.githubusercontent.com/219296/48168754-7a0db500-e2a5-11e8-92ce-7bc777a7fd19.png">

After:

<img width="144" alt="screen shot 2018-11-07 at 3 54 38 pm" src="https://user-images.githubusercontent.com/219296/48168759-7da13c00-e2a5-11e8-8544-e2640077438a.png">

-----

Before:

<img width="258" alt="screen shot 2018-11-07 at 3 55 22 pm" src="https://user-images.githubusercontent.com/219296/48168773-8db91b80-e2a5-11e8-9c70-601ce7994b1f.png">

After:

<img width="252" alt="screen shot 2018-11-07 at 3 55 44 pm" src="https://user-images.githubusercontent.com/219296/48168783-9ad60a80-e2a5-11e8-83d7-61aaad4437d5.png">
