### PR TITLE
Add isAInvoice boolean flag to handlers so that ediinvoice generator …

### DIFF
--- a/cmd/generate_shipment_edi/main.go
+++ b/cmd/generate_shipment_edi/main.go
@@ -70,7 +70,7 @@ func main() {
 		}
 		costsByShipments = append(costsByShipments, costByShipment)
 	}
-	edi, err := ediinvoice.Generate858C(costsByShipments, db)
+	edi, err := ediinvoice.Generate858C(costsByShipments, db, false)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/webserver/main.go
+++ b/cmd/webserver/main.go
@@ -146,7 +146,7 @@ func initFlags(flag *pflag.FlagSet) {
 	flag.String("here-maps-app-code", "", "HERE maps App API code")
 
 	// EDI Invoice Config
-	flag.Bool("invoice-is-a-test", true, "Flag (bool) for EDI Invoices to signify if they are tests")
+	flag.Bool("send-prod-invoice", false, "Flag (bool) for EDI Invoices to signify if they should go to production GEX")
 
 	flag.String("storage-backend", "filesystem", "Storage backend to use, either filesystem or s3.")
 	flag.String("email-backend", "local", "Email backend to use, either SES or local")
@@ -342,8 +342,8 @@ func main() {
 	routePlanner := initRoutePlanner(v, logger)
 	handlerContext.SetPlanner(routePlanner)
 
-	// Set InvoiceIsATest for ediinvoice
-	handlerContext.SetInvoiceIsATest(v.GetBool("invoice-is-a-test"))
+	// Set SendProductionInvoice for ediinvoice
+	handlerContext.SetSendProductionInvoice(v.GetBool("send-prod-invoice"))
 
 	storageBackend := v.GetString("storage-backend")
 

--- a/cmd/webserver/main.go
+++ b/cmd/webserver/main.go
@@ -145,6 +145,9 @@ func initFlags(flag *pflag.FlagSet) {
 	flag.String("here-maps-app-id", "", "HERE maps App ID for this application")
 	flag.String("here-maps-app-code", "", "HERE maps App API code")
 
+	// EDI Invoice Config
+	flag.Bool("invoice-is-a-test", true, "Flag (bool) for EDI Invoices to signify if they are tests")
+
 	flag.String("storage-backend", "filesystem", "Storage backend to use, either filesystem or s3.")
 	flag.String("email-backend", "local", "Email backend to use, either SES or local")
 	flag.String("aws-s3-bucket-name", "", "S3 bucket used for file storage")
@@ -338,6 +341,9 @@ func main() {
 	// routePlanner := route.NewBingPlanner(logger, bingMapsEndpoint, bingMapsKey)
 	routePlanner := initRoutePlanner(v, logger)
 	handlerContext.SetPlanner(routePlanner)
+
+	// Set InvoiceIsATest for ediinvoice
+	handlerContext.SetInvoiceIsATest(v.GetBool("invoice-is-a-test"))
 
 	storageBackend := v.GetString("storage-backend")
 

--- a/pkg/edi/invoice/generator.go
+++ b/pkg/edi/invoice/generator.go
@@ -21,15 +21,15 @@ const senderCode = "MYMOVE"
 const receiverCode = "8004171844" // Syncada
 
 // Generate858C generates an EDI X12 858C transaction set
-func Generate858C(shipmentsAndCosts []rateengine.CostByShipment, db *pop.Connection, invoiceIsATest bool) (string, error) {
+func Generate858C(shipmentsAndCosts []rateengine.CostByShipment, db *pop.Connection, sendProductionInvoice bool) (string, error) {
 	interchangeControlNumber := 1 //TODO: increment this
 	currentTime := time.Now()
 	var usageIndicator string
 
-	if invoiceIsATest == true {
-		usageIndicator = "T"
-	} else {
+	if sendProductionInvoice {
 		usageIndicator = "P"
+	} else {
+		usageIndicator = "T"
 	}
 
 	isa := edisegment.ISA{

--- a/pkg/edi/invoice/generator.go
+++ b/pkg/edi/invoice/generator.go
@@ -21,9 +21,17 @@ const senderCode = "MYMOVE"
 const receiverCode = "8004171844" // Syncada
 
 // Generate858C generates an EDI X12 858C transaction set
-func Generate858C(shipmentsAndCosts []rateengine.CostByShipment, db *pop.Connection) (string, error) {
+func Generate858C(shipmentsAndCosts []rateengine.CostByShipment, db *pop.Connection, invoiceIsATest bool) (string, error) {
 	interchangeControlNumber := 1 //TODO: increment this
 	currentTime := time.Now()
+	var usageIndicator string
+
+	if invoiceIsATest == true {
+		usageIndicator = "T"
+	} else {
+		usageIndicator = "P"
+	}
+
 	isa := edisegment.ISA{
 		AuthorizationInformationQualifier: "00", // No authorization information
 		AuthorizationInformation:          fmt.Sprintf("%010d", 0),
@@ -39,7 +47,7 @@ func Generate858C(shipmentsAndCosts []rateengine.CostByShipment, db *pop.Connect
 		InterchangeControlVersionNumber:   "00401",
 		InterchangeControlNumber:          interchangeControlNumber,
 		AcknowledgementRequested:          1,
-		UsageIndicator:                    "T", // T for test, P for production
+		UsageIndicator:                    usageIndicator, // T for test, P for production
 		ComponentElementSeparator:         "|",
 	}
 	gs := edisegment.GS{

--- a/pkg/edi/invoice/generator_test.go
+++ b/pkg/edi/invoice/generator_test.go
@@ -28,19 +28,14 @@ func (suite *InvoiceSuite) TestGenerate858C() {
 	var costsByShipments []rateengine.CostByShipment
 	costsByShipments = append(costsByShipments, costByShipment)
 
-	generatedResult, err := ediinvoice.Generate858C(costsByShipments, suite.db, true)
+	generatedResult, err := ediinvoice.Generate858C(costsByShipments, suite.db, false)
 	suite.NoError(err, "generates error")
 	suite.NotEmpty(generatedResult, "result is empty")
 
 	re := regexp.MustCompile("\\*" + "T" + "\\*")
 	suite.True(re.MatchString(generatedResult), "This fails if the EDI string does not have the environment flag set to T."+
-		" This is set by the if statement in Generate858C() that checks a boolean variable named invoiceIsATest")
+		" This is set by the if statement in Generate858C() that checks a boolean variable named sendProductionInvoice")
 
-	generatedResult, err = ediinvoice.Generate858C(costsByShipments, suite.db, false)
-
-	re = regexp.MustCompile("\\*" + "P" + "\\*")
-	suite.True(re.MatchString(generatedResult), "This fails if the EDI string does not have the environment flag set to P."+
-		" This is set by the if statement in Generate858C() that checks a boolean variable named invoiceIsATest")
 }
 
 type InvoiceSuite struct {

--- a/pkg/handlers/contexts.go
+++ b/pkg/handlers/contexts.go
@@ -27,8 +27,8 @@ type HandlerContext interface {
 	SetNoSessionTimeout()
 	IWSRealTimeBrokerService() iws.RealTimeBrokerService
 	SetIWSRealTimeBrokerService(rbs iws.RealTimeBrokerService)
-	InvoiceIsATest() bool
-	SetInvoiceIsATest(isATest bool)
+	SendProductionInvoice() bool
+	SetSendProductionInvoice(sendProductionInvoice bool)
 }
 
 // A single handlerContext is passed to each handler
@@ -41,7 +41,7 @@ type handlerContext struct {
 	storage                  storage.FileStorer
 	notificationSender       notifications.NotificationSender
 	iwsRealTimeBrokerService iws.RealTimeBrokerService
-	invoiceIsATest           bool
+	sendProductionInvoice    bool
 }
 
 // NewHandlerContext returns a new handlerContext with its required private fields set.
@@ -126,11 +126,11 @@ func (context *handlerContext) SetIWSRealTimeBrokerService(rbs iws.RealTimeBroke
 }
 
 // InvoiceIsATest is a flag to notify EDI invoice generation whether it should be sent as a test transaction
-func (context *handlerContext) InvoiceIsATest() bool {
-	return context.invoiceIsATest
+func (context *handlerContext) SendProductionInvoice() bool {
+	return context.sendProductionInvoice
 }
 
 // Set UsageIndicator flag for use in EDI invoicing (ediinvoice pkg)
-func (context *handlerContext) SetInvoiceIsATest(isATest bool) {
-	context.invoiceIsATest = isATest
+func (context *handlerContext) SetSendProductionInvoice(sendProductionInvoice bool) {
+	context.sendProductionInvoice = sendProductionInvoice
 }

--- a/pkg/handlers/contexts.go
+++ b/pkg/handlers/contexts.go
@@ -27,6 +27,8 @@ type HandlerContext interface {
 	SetNoSessionTimeout()
 	IWSRealTimeBrokerService() iws.RealTimeBrokerService
 	SetIWSRealTimeBrokerService(rbs iws.RealTimeBrokerService)
+	InvoiceIsATest() bool
+	SetInvoiceIsATest(isATest bool)
 }
 
 // A single handlerContext is passed to each handler
@@ -39,6 +41,7 @@ type handlerContext struct {
 	storage                  storage.FileStorer
 	notificationSender       notifications.NotificationSender
 	iwsRealTimeBrokerService iws.RealTimeBrokerService
+	invoiceIsATest           bool
 }
 
 // NewHandlerContext returns a new handlerContext with its required private fields set.
@@ -120,4 +123,14 @@ func (context *handlerContext) IWSRealTimeBrokerService() iws.RealTimeBrokerServ
 
 func (context *handlerContext) SetIWSRealTimeBrokerService(rbs iws.RealTimeBrokerService) {
 	context.iwsRealTimeBrokerService = rbs
+}
+
+// InvoiceIsATest is a flag to notify EDI invoice generation whether it should be sent as a test transaction
+func (context *handlerContext) InvoiceIsATest() bool {
+	return context.invoiceIsATest
+}
+
+// Set UsageIndicator flag for use in EDI invoicing (ediinvoice pkg)
+func (context *handlerContext) SetInvoiceIsATest(isATest bool) {
+	context.invoiceIsATest = isATest
 }

--- a/pkg/handlers/internalapi/shipments.go
+++ b/pkg/handlers/internalapi/shipments.go
@@ -492,7 +492,7 @@ func (h ShipmentInvoiceHandler) Handle(params shipmentop.SendHHGInvoiceParams) m
 	costsByShipments = append(costsByShipments, shipmentCost)
 
 	// pass value into generator --> edi string
-	edi, err := ediinvoice.Generate858C(costsByShipments, h.DB(), h.InvoiceIsATest())
+	edi, err := ediinvoice.Generate858C(costsByShipments, h.DB(), h.SendProductionInvoice())
 	if err != nil {
 		return handlers.ResponseForError(h.Logger(), err)
 	}

--- a/pkg/handlers/internalapi/shipments.go
+++ b/pkg/handlers/internalapi/shipments.go
@@ -492,7 +492,7 @@ func (h ShipmentInvoiceHandler) Handle(params shipmentop.SendHHGInvoiceParams) m
 	costsByShipments = append(costsByShipments, shipmentCost)
 
 	// pass value into generator --> edi string
-	edi, err := ediinvoice.Generate858C(costsByShipments, h.DB())
+	edi, err := ediinvoice.Generate858C(costsByShipments, h.DB(), h.InvoiceIsATest())
 	if err != nil {
 		return handlers.ResponseForError(h.Logger(), err)
 	}


### PR DESCRIPTION
…can add a P or T flag to designate testing/production for transactions as per client requirement doc

## Description

These changes are meant to add a command line flag to the webserver startup process so that it will be possible to pass a boolean value to the invoicing process. Doing so will allow us to pass a T (for testing) or P (for production) value within the invoice transaction so that the system on the other end is able to differentiate the two. The T and P values were chosen so that we can comply with expected EDI convention.

## Reviewer Notes

I would be particularly curious if there are thoughts on additional test conditions I should add to the generator test. I'm currently checking to make sure the boolean is translated properly into a P or T string, but I imagine there might be scenarios I'm not thinking of.

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

No special setup steps required. Tests will execute with the server_test make target.

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](./docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](./docs/backend.md#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](./docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
* [ ] There are no aXe warnings for UI.
* [ ] This works in IE.
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @willowbl00
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Toggle the ISA15 field on the EDI for staging / production](https://www.pivotaltracker.com/n/projects/2136865/stories/160362261) for this change