### PR TITLE
Migrate the DB config from yaml template to viper

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -543,21 +543,21 @@ workflows:
             - build_migrations
           filters:
             branches:
-              only: viper_fix
+              only: cg_161272729_migrate_db_config_to_viper
 
       - deploy_experimental_app:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: viper_fix
+              only: cg_161272729_migrate_db_config_to_viper
 
       - deploy_experimental_app_client_tls:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: viper_fix
+              only: cg_161272729_migrate_db_config_to_viper
 
       - deploy_staging_migrations:
           requires:

--- a/cmd/webserver/main.go
+++ b/cmd/webserver/main.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/tls"
 	"crypto/x509"
+	"fmt"
 	"html/template"
 	"io/ioutil"
 	"log"
@@ -259,6 +260,11 @@ func initDatabase(v *viper.Viper, logger *zap.Logger) (*pop.Connection, error) {
 		dbOptions["sslmode"] = "require"
 	}
 
+	// Construct a safe URL and log it
+	s := "postgres://%s:%s@%s:%s/%s?sslmode=%s"
+	dbURL := fmt.Sprintf(s, dbUser, "*****", dbHost, dbPort, dbName, dbOptions["sslmode"])
+	logger.Debug("Connecting to the database", zap.String("url", dbURL))
+
 	// Configure DB connection details
 	dbConnectionDetails := pop.ConnectionDetails{
 		Dialect:  "postgres",
@@ -280,12 +286,6 @@ func initDatabase(v *viper.Viper, logger *zap.Logger) (*pop.Connection, error) {
 	if err != nil {
 		logger.Error("Failed create DB conection", zap.Error(err))
 		return nil, err
-	}
-
-	if env == "development" || env == "test" {
-		logger.Debug("Connecting to the database", zap.String("connection", connection.String()))
-	} else {
-		logger.Debug("Connecting to the database")
 	}
 
 	// Open the connection

--- a/cmd/webserver/main.go
+++ b/cmd/webserver/main.go
@@ -285,7 +285,7 @@ func initDatabase(v *viper.Viper, logger *zap.Logger) (*pop.Connection, error) {
 	// Set up the connection
 	connection, err := pop.NewConnection(&dbConnectionDetails)
 	if err != nil {
-		logger.Error("Failed create DB conection", zap.Error(err))
+		logger.Error("Failed create DB connection", zap.Error(err))
 		return nil, err
 	}
 

--- a/cmd/webserver/main.go
+++ b/cmd/webserver/main.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"os"
 	"path"
+	"strconv"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -169,7 +170,7 @@ func initFlags(flag *pflag.FlagSet) {
 	// DB Config
 	flag.String("db-name", "dev_db", "Database Name")
 	flag.String("db-host", "localhost", "Database Hostname")
-	flag.String("db-port", "5432", "Database Port")
+	flag.Int("db-port", 5432, "Database Port")
 	flag.String("db-user", "postgres", "Database Username")
 	flag.String("db-password", "", "Database Password")
 }
@@ -244,7 +245,7 @@ func initDatabase(v *viper.Viper, logger *zap.Logger) (*pop.Connection, error) {
 	env := v.GetString("env")
 	dbName := v.GetString("db-name")
 	dbHost := v.GetString("db-host")
-	dbPort := v.GetString("db-port")
+	dbPort := strconv.Itoa(v.GetInt("db-port"))
 	dbUser := v.GetString("db-user")
 	dbPassword := v.GetString("db-password")
 

--- a/config/README.md
+++ b/config/README.md
@@ -6,10 +6,12 @@ The `*container-definition*` files define how the ECS containers are configured.
 
 ## Database
 
-The database is configured using environment variables. The environments "development", "test", and "container" each
-have specific modifications to the database connection. Specifically, "test" environment will always use the database
-name `test_db` no matter what the value of `$DB_NAME` is set to. The "container" environment will require that SSL
-mode is required.
+The `database.yaml` file is for configuring how to connect to the database. In the app the database is configured using
+environment variables. The environments "development", "test", and "container" each have specific modifications to the
+database connection. Specifically, "test" environment will always use the database name `test_db` no matter what the
+value of `$DB_NAME` is set to. The "container" environment will require that SSL mode is required.
+
+Note: This file is critical for use with the `soda` command to initialize and migrate the DB.
 
 ## TLS cert/key (optional)
 

--- a/config/README.md
+++ b/config/README.md
@@ -6,7 +6,10 @@ The `*container-definition*` files define how the ECS containers are configured.
 
 ## Database
 
-The `database.yaml` file is for configuring how to connect to the database. The key called "container" is for configuring how the deployed app will connect.
+The database is configured using environment variables. The environments "development", "test", and "container" each
+have specific modifications to the database connection. Specifically, "test" environment will always use the database
+name `test_db` no matter what the value of `$DB_NAME` is set to. The "container" environment will require that SSL
+mode is required.
 
 ## TLS cert/key (optional)
 


### PR DESCRIPTION
## Description

Pop currently uses a YAML config file that is a go template to load environment variables. This indirect approach should be changed to manually creating a connection on startup while using viper to capture the configuration values.

## Reviewer Notes

I'm a bit worried that I'm overly verbose with error messages and would love input about it.

## Setup

Start the server and the app.  You should be able to get any db query to work.

## Code Review Verification Steps

* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/161272729) for this change