### PR TITLE
Add better error message (using Wrap) and fix bug that caused gex cer…

### DIFF
--- a/cmd/generate_shipment_edi/main.go
+++ b/cmd/generate_shipment_edi/main.go
@@ -28,7 +28,7 @@ func main() {
 	flag.Parse()
 
 	if *moveIDString == "" {
-		log.Fatal("Usage: cmd/generate_shipment_edi/main.go --moveID <29cb984e-c70d-46f0-926d-cd89e07a6ec3> --gex false")
+		log.Fatal("Usage: go run cmd/generate_shipment_edi/main.go --moveID <29cb984e-c70d-46f0-926d-cd89e07a6ec3> --gex false")
 	}
 
 	db, err := pop.Connect(*env)
@@ -75,11 +75,10 @@ func main() {
 		log.Fatal(err)
 	}
 	fmt.Println(edi)
-	fmt.Println("Sending to GEX. . .")
 
 	if *sendToGex == true {
+		fmt.Println("Sending to GEX. . .")
 		statusCode, err := gex.SendInvoiceToGex(logger, edi, *transactionName)
-
 		fmt.Printf("status code: %v, error: %v", statusCode, err)
 	}
 

--- a/pkg/edi/gex/invoice.go
+++ b/pkg/edi/gex/invoice.go
@@ -2,6 +2,7 @@ package gex
 
 import (
 	"crypto/tls"
+	"github.com/pkg/errors"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -53,11 +54,11 @@ func GetTLSConfig() (*tls.Config, error) {
 	clientCert := os.Getenv("MOVE_MIL_DOD_TLS_CERT")
 	clientKey := os.Getenv("MOVE_MIL_DOD_TLS_KEY")
 	// At this time, GEX does not already trust the intermediate CA that signed our certs; so include it with our cert
-	clientCertPlusCA := strings.Join([]string{clientCert, clientCA}, "")
+	clientCertPlusCA := strings.Join([]string{clientCert, clientCA}, "\n")
 
 	certificate, err := tls.X509KeyPair([]byte(clientCertPlusCA), []byte(clientKey))
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "error creating key pair")
 	}
 
 	// Load DOD CA certs so that we can validate GEX's server cert


### PR DESCRIPTION
…ts to fail (use \n) and move print statement and improve help text

## Description

TLS certs were failing.  This adds a newline instead of an empty string as a separator.  Also adds a couple print changes to the `generate_shipement_edi` command.
## Reviewer Notes

`make db_populate_e2e`
`go run cmd/generate_shipment_edi/main.go --moveID fb4105cf-f5a5-43be-845e-d59fdb34f31c --gex true`
It should return a 200 status response

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* No pivotal story for this change - is a fix encountered in debugging the invoice generator
