### PR TITLE
WIP - Replace hardcoded weights with actual netweight in edi generator

### DIFF
--- a/pkg/edi/invoice/generator.go
+++ b/pkg/edi/invoice/generator.go
@@ -173,6 +173,12 @@ func getHeadingSegments(shipmentWithCost rateengine.CostByShipment, sequenceNum 
 	if GBL == nil {
 		return segments, errors.New("GBL Number is missing for Shipment Identification Number (BX04)")
 	}
+	weightLbs := shipment.NetWeight
+	var netWeight float64
+	if weightLbs == nil {
+		return segments, errors.New("Shipment is missing the NetWeight")
+	}
+	netWeight = float64(*weightLbs)
 
 	return []edisegment.Segment{
 		&edisegment.BX{
@@ -239,9 +245,9 @@ func getHeadingSegments(shipmentWithCost rateengine.CostByShipment, sequenceNum 
 			FinancialInformationCode:     *tac,
 		},
 		&edisegment.L10{
-			Weight:          108.2, // TODO: real weight
-			WeightQualifier: "B",   // Billing weight
-			WeightUnitCode:  "L",   // Pounds
+			Weight:          netWeight,
+			WeightQualifier: "B", // Billing weight
+			WeightUnitCode:  "L", // Pounds
 		},
 	}, nil
 }
@@ -253,7 +259,16 @@ func getLineItemSegments(shipmentWithCost rateengine.CostByShipment) ([]edisegme
 	// L1 segment: p. 82
 	// TODO: These are sample line items, need to pull actual line items from shipment
 	// that are ready to be invoiced
+	shipment := shipmentWithCost.Shipment
+	segments := []edisegment.Segment{}
+
 	cost := shipmentWithCost.Cost
+	weightLbs := shipment.NetWeight
+	var netWeight float64
+	if weightLbs == nil {
+		return segments, errors.New("Shipment is missing the NetWeight")
+	}
+	netWeight = float64(*weightLbs)
 
 	return []edisegment.Segment{
 		// Linehaul. Not sure why this uses the 303 code, but that's what I saw from DPS
@@ -279,12 +294,12 @@ func getLineItemSegments(shipmentWithCost rateengine.CostByShipment) ([]edisegme
 		},
 		&edisegment.L0{
 			LadingLineItemNumber: 1,
-			Weight:               108.2,
+			Weight:               netWeight,
 			WeightQualifier:      "B", // Billed weight
 			WeightUnitCode:       "L", // Pounds
 		},
 		&edisegment.L1{
-			FreightRate:        65.77,
+			FreightRate:        67.14,
 			RateValueQualifier: "RC", // Rate
 			Charge:             cost.NonLinehaulCostComputation.PackFee.ToDollarFloat(),
 			SpecialChargeDescription: "105A", // Full pack
@@ -296,7 +311,7 @@ func getLineItemSegments(shipmentWithCost rateengine.CostByShipment) ([]edisegme
 		},
 		&edisegment.L0{
 			LadingLineItemNumber: 1,
-			Weight:               108.2,
+			Weight:               netWeight,
 			WeightQualifier:      "B", // Billed weight
 			WeightUnitCode:       "L", // Pounds
 		},
@@ -313,12 +328,12 @@ func getLineItemSegments(shipmentWithCost rateengine.CostByShipment) ([]edisegme
 		},
 		&edisegment.L0{
 			LadingLineItemNumber: 1,
-			Weight:               108.2,
+			Weight:               netWeight,
 			WeightQualifier:      "B", // Billed weight
 			WeightUnitCode:       "L", // Pounds
 		},
 		&edisegment.L1{
-			FreightRate:        4.07,
+			FreightRate:        7.59,
 			RateValueQualifier: "RC", // Rate
 			Charge:             cost.NonLinehaulCostComputation.OriginServiceFee.ToDollarFloat(),
 			SpecialChargeDescription: "135A", // Origin service charge
@@ -330,15 +345,15 @@ func getLineItemSegments(shipmentWithCost rateengine.CostByShipment) ([]edisegme
 		},
 		&edisegment.L0{
 			LadingLineItemNumber: 1,
-			Weight:               108.2,
+			Weight:               netWeight,
 			WeightQualifier:      "B", // Billed weight
 			WeightUnitCode:       "L", // Pounds
 		},
 		&edisegment.L1{
-			FreightRate:        4.07,
+			FreightRate:        5.31,
 			RateValueQualifier: "RC", // Rate
 			Charge:             cost.NonLinehaulCostComputation.DestinationServiceFee.ToDollarFloat(),
-			SpecialChargeDescription: "135B", // TODO: check if correct for Destination service charge
+			SpecialChargeDescription: "135B",
 		},
 		// Fuel surcharge - linehaul
 		&edisegment.HL{

--- a/pkg/edi/invoice/generator_test.go
+++ b/pkg/edi/invoice/generator_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/rateengine"
 	"github.com/transcom/mymove/pkg/testdatagen"
+	"github.com/transcom/mymove/pkg/unit"
 	"go.uber.org/zap"
 	"log"
 	"regexp"
@@ -15,14 +16,19 @@ import (
 
 func (suite *InvoiceSuite) TestGenerate858C() {
 	shipments := make([]models.Shipment, 1)
-	shipments[0] = testdatagen.MakeDefaultShipment(suite.db)
-	err := shipments[0].AssignGBLNumber(suite.db)
-	suite.mustSave(&shipments[0])
+	shipment := shipments[0]
+	shipment = testdatagen.MakeDefaultShipment(suite.db)
+	var weight unit.Pound
+	weight = 3000
+	shipment.NetWeight = &weight
+
+	err := shipment.AssignGBLNumber(suite.db)
+	suite.mustSave(&shipment)
 	suite.NoError(err, "could not assign GBLNumber")
 
 	var cost rateengine.CostComputation
 	costByShipment := rateengine.CostByShipment{
-		Shipment: shipments[0],
+		Shipment: shipment,
 		Cost:     cost,
 	}
 	var costsByShipments []rateengine.CostByShipment

--- a/pkg/edi/segment/l1.go
+++ b/pkg/edi/segment/l1.go
@@ -20,7 +20,7 @@ func (s *L1) String(delimiter string) string {
 	elements := []string{
 		"L1",
 		strconv.Itoa(s.LadingLineItemNumber),
-		strconv.FormatFloat(s.FreightRate, 'f', 4, 64),
+		strconv.FormatFloat(s.FreightRate, 'f', 2, 64),
 		s.RateValueQualifier,
 		FloatToNx(s.Charge, 2),
 		"",


### PR DESCRIPTION
## Description

Replace hard-coded weights with actual shipment NetWeight; change precision for L1 segment rate to 2.

## Reviewer Notes

I'm repeating code in the two functions- where would I put it if I didn't want to repeat it?  Do you recommend doing so?

## Setup

If you want to check that the values show up properly in in the edi file, you can build db from `make db_populate_e2e`
Then generate an invoice: 
`go run cmd/generate_shipment_edi/main.go --moveID fb4105cf-f5a5-43be-845e-d59fdb34f31c`
and you can find those weights

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/161768942) for this change

