### PR TITLE
Instrument service members handlers

### DIFF
--- a/docs/backend.md
+++ b/docs/backend.md
@@ -251,7 +251,7 @@ Some errors are predictable, such as those from the database that Pop returns to
 
 ```golang
 // FetchServiceMemberForUser returns a service member only if it is allowed for the given user to access that service member.
- func FetchServiceMemberForUser(db *pop.Connection, user User, id uuid.UUID) (ServiceMember, error) {
+ func FetchServiceMemberForUser(ctx context.Context, db *pop.Connection, user User, id uuid.UUID) (ServiceMember, error) {
   var serviceMember ServiceMember
   err := db.Eager().Find(&serviceMember, id)
   if err != nil {

--- a/docs/how-to/instrument-data-in-honeycomb.md
+++ b/docs/how-to/instrument-data-in-honeycomb.md
@@ -14,14 +14,23 @@ The standard HTTP fields are a good start, but Honeycomb is more useful when we 
 
 Honeycomb tracing is a powerful tool for breaking down an API request into individual segments/spans. Each new span will include a name (usually the calling function name), a duration specifying how much time was spent in the span, and a series of unique identifiers that act as breadcrumbs to drill down into a particular request. [Beeline-go](https://docs.honeycomb.io/getting-data-in/beelines/go-beeline/) has some simple methods for instrumenting traces into the MyMove codebase.
 
-An example of instrumenting SubmitMoveHandler, would be to to call `beeline.StartSpan(ctx, "SubmitMoveHandler")` in the beginning of the handler and immediately add a `defer span.Send()` to defer sending the span to honeycomb until after the handler completes.
+An example of instrumenting SubmitMoveHandler, would be to to call `beeline.StartSpan(ctx, reflect.TypeOf(h).Name())` in the beginning of the handler and immediately add a `defer span.Send()` to defer sending the span to honeycomb until after the handler completes.
 
 ```golang
 func (h SubmitMoveHandler) Handle(params moveop.SubmitMoveForApprovalParams) middleware.Responder {
-    ctx := params.HTTPRequest.Context()
-    ctx, span := beeline.StartSpan(ctx, "SubmitMoveHandler")
+    ctx, span := beeline.StartSpan(params.HTTPRequest.Context(), reflect.TypeOf(h).Name())
     defer span.Send()
 ```
+
+To instrument subordinate functions, add `ctx context.Context` as the first parameter and pass the function name as the span name.
+
+```golang
+func (s *SocialSecurityNumber) SetEncryptedHash(ctx context.Context, unencryptedSSN string) (*validate.Errors, error) {
+    ctx, span := beeline.StartSpan(ctx, "SetEncryptedHash")
+    defer span.Send()
+```
+
+Be sure to pass the derived context from `beeline.StartSpan(...)` rather than the original context when passing context deeper into the function stack.  Reuse the variable name `ctx` when possible rather than allocating a new variable.
 
 Useful fields can be added to the span that would help with debugging. To do this you can use [span.AddField](https://github.com/honeycombio/beeline-go/blob/master/trace/trace.go#L173)
 

--- a/pkg/handlers/contexts.go
+++ b/pkg/handlers/contexts.go
@@ -1,6 +1,8 @@
 package handlers
 
 import (
+	"context"
+	"github.com/go-openapi/runtime/middleware"
 	"github.com/gobuffalo/pop"
 	"github.com/transcom/mymove/pkg/dpsauth"
 	"github.com/transcom/mymove/pkg/iws"
@@ -32,6 +34,7 @@ type HandlerContext interface {
 	SetSendProductionInvoice(sendProductionInvoice bool)
 	DPSAuthParams() dpsauth.Params
 	SetDPSAuthParams(params dpsauth.Params)
+	RespondAndTraceError(ctx context.Context, err error, msg string, fields ...zap.Field) middleware.Responder
 }
 
 // A single handlerContext is passed to each handler
@@ -57,92 +60,98 @@ func NewHandlerContext(db *pop.Connection, logger *zap.Logger) HandlerContext {
 }
 
 // DB returns a POP db connection for the context
-func (context *handlerContext) DB() *pop.Connection {
-	return context.db
+func (hctx *handlerContext) DB() *pop.Connection {
+	return hctx.db
 }
 
 // Logger returns the logger to use in this context
-func (context *handlerContext) Logger() *zap.Logger {
-	return context.logger
+func (hctx *handlerContext) Logger() *zap.Logger {
+	return hctx.logger
 }
 
 // HoneyZapLogger returns the logger capable of writing to Honeycomb to use in this context
-func (context *handlerContext) HoneyZapLogger() *hnyzap.Logger {
-	return &hnyzap.Logger{Logger: context.logger}
+func (hctx *handlerContext) HoneyZapLogger() *hnyzap.Logger {
+	return &hnyzap.Logger{Logger: hctx.logger}
+}
+
+// HoneyZapLogger returns the logger capable of writing to Honeycomb to use in this context
+func (hctx *handlerContext) RespondAndTraceError(ctx context.Context, err error, msg string, fields ...zap.Field) middleware.Responder {
+	hctx.HoneyZapLogger().TraceError(ctx, msg, fields...)
+	return ResponseForError(hctx.Logger(), err)
 }
 
 // FileStorer returns the storage to use in the current context
-func (context *handlerContext) FileStorer() storage.FileStorer {
-	return context.storage
+func (hctx *handlerContext) FileStorer() storage.FileStorer {
+	return hctx.storage
 }
 
 // SetFileStorer is a simple setter for storage private field
-func (context *handlerContext) SetFileStorer(storer storage.FileStorer) {
-	context.storage = storer
+func (hctx *handlerContext) SetFileStorer(storer storage.FileStorer) {
+	hctx.storage = storer
 }
 
 // NotificationSender returns the sender to use in the current context
-func (context *handlerContext) NotificationSender() notifications.NotificationSender {
-	return context.notificationSender
+func (hctx *handlerContext) NotificationSender() notifications.NotificationSender {
+	return hctx.notificationSender
 }
 
 // SetNotificationSender is a simple setter for AWS SES private field
-func (context *handlerContext) SetNotificationSender(sender notifications.NotificationSender) {
-	context.notificationSender = sender
+func (hctx *handlerContext) SetNotificationSender(sender notifications.NotificationSender) {
+	hctx.notificationSender = sender
 }
 
 // Planner is a simple setter for the route.Planner private field
-func (context *handlerContext) Planner() route.Planner {
-	return context.planner
+func (hctx *handlerContext) Planner() route.Planner {
+	return hctx.planner
 }
 
 // SetPlanner is a simple setter for the route.Planner private field
-func (context *handlerContext) SetPlanner(planner route.Planner) {
-	context.planner = planner
+func (hctx *handlerContext) SetPlanner(planner route.Planner) {
+	hctx.planner = planner
 }
 
 // CookieSecret returns the secret key to use when signing cookies
-func (context *handlerContext) CookieSecret() string {
-	return context.cookieSecret
+func (hctx *handlerContext) CookieSecret() string {
+	return hctx.cookieSecret
 }
 
 // SetCookieSecret is a simple setter for the cookieSeecret private Field
-func (context *handlerContext) SetCookieSecret(cookieSecret string) {
-	context.cookieSecret = cookieSecret
+func (hctx *handlerContext) SetCookieSecret(cookieSecret string) {
+	hctx.cookieSecret = cookieSecret
 }
 
 // NoSessionTimeout is a flag which, when true, indicates that sessions should not timeout. Used in dev.
-func (context *handlerContext) NoSessionTimeout() bool {
-	return context.noSessionTimeout
+func (hctx *handlerContext) NoSessionTimeout() bool {
+	return hctx.noSessionTimeout
 }
 
 // SetNoSessionTimeout is a simple setter for the noSessionTimeout private Field
-func (context *handlerContext) SetNoSessionTimeout() {
-	context.noSessionTimeout = true
+func (hctx *handlerContext) SetNoSessionTimeout() {
+	hctx.noSessionTimeout = true
 }
 
-func (context *handlerContext) IWSRealTimeBrokerService() iws.RealTimeBrokerService {
-	return context.iwsRealTimeBrokerService
+func (hctx *handlerContext) IWSRealTimeBrokerService() iws.RealTimeBrokerService {
+	return hctx.iwsRealTimeBrokerService
 }
 
-func (context *handlerContext) SetIWSRealTimeBrokerService(rbs iws.RealTimeBrokerService) {
-	context.iwsRealTimeBrokerService = rbs
+func (hctx *handlerContext) SetIWSRealTimeBrokerService(rbs iws.RealTimeBrokerService) {
+	hctx.iwsRealTimeBrokerService = rbs
 }
 
 // InvoiceIsATest is a flag to notify EDI invoice generation whether it should be sent as a test transaction
-func (context *handlerContext) SendProductionInvoice() bool {
-	return context.sendProductionInvoice
+func (hctx *handlerContext) SendProductionInvoice() bool {
+	return hctx.sendProductionInvoice
 }
 
 // Set UsageIndicator flag for use in EDI invoicing (ediinvoice pkg)
-func (context *handlerContext) SetSendProductionInvoice(sendProductionInvoice bool) {
-	context.sendProductionInvoice = sendProductionInvoice
+func (hctx *handlerContext) SetSendProductionInvoice(sendProductionInvoice bool) {
+	hctx.sendProductionInvoice = sendProductionInvoice
 }
 
-func (context *handlerContext) DPSAuthParams() dpsauth.Params {
-	return context.dpsAuthParams
+func (hctx *handlerContext) DPSAuthParams() dpsauth.Params {
+	return hctx.dpsAuthParams
 }
 
-func (context *handlerContext) SetDPSAuthParams(params dpsauth.Params) {
-	context.dpsAuthParams = params
+func (hctx *handlerContext) SetDPSAuthParams(params dpsauth.Params) {
+	hctx.dpsAuthParams = params
 }

--- a/pkg/handlers/internalapi/backup_contacts.go
+++ b/pkg/handlers/internalapi/backup_contacts.go
@@ -1,8 +1,11 @@
 package internalapi
 
 import (
+	"reflect"
+
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/gofrs/uuid"
+	"github.com/honeycombio/beeline-go"
 	"github.com/transcom/mymove/pkg/auth"
 	backupop "github.com/transcom/mymove/pkg/gen/internalapi/internaloperations/backup_contacts"
 	"github.com/transcom/mymove/pkg/gen/internalmessages"
@@ -30,11 +33,14 @@ type CreateBackupContactHandler struct {
 
 // Handle ... creates a new BackupContact from a request payload
 func (h CreateBackupContactHandler) Handle(params backupop.CreateServiceMemberBackupContactParams) middleware.Responder {
+	ctx, span := beeline.StartSpan(params.HTTPRequest.Context(), reflect.TypeOf(h).Name())
+	defer span.Send()
+
 	// User should always be populated by middleware
 	session := auth.SessionFromRequestContext(params.HTTPRequest)
 	/* #nosec UUID is pattern matched by swagger which checks the format */
 	serviceMemberID, _ := uuid.FromString(params.ServiceMemberID.String())
-	serviceMember, err := models.FetchServiceMemberForUser(h.DB(), session, serviceMemberID)
+	serviceMember, err := models.FetchServiceMemberForUser(ctx, h.DB(), session, serviceMemberID)
 	if err != nil {
 		return handlers.ResponseForError(h.Logger(), err)
 	}
@@ -59,11 +65,14 @@ type IndexBackupContactsHandler struct {
 
 // Handle retrieves a list of all moves in the system belonging to the logged in user
 func (h IndexBackupContactsHandler) Handle(params backupop.IndexServiceMemberBackupContactsParams) middleware.Responder {
+	ctx, span := beeline.StartSpan(params.HTTPRequest.Context(), reflect.TypeOf(h).Name())
+	defer span.Send()
+
 	session := auth.SessionFromRequestContext(params.HTTPRequest)
 
 	/* #nosec UUID is pattern matched by swagger which checks the format */
 	serviceMemberID, _ := uuid.FromString(params.ServiceMemberID.String())
-	serviceMember, err := models.FetchServiceMemberForUser(h.DB(), session, serviceMemberID)
+	serviceMember, err := models.FetchServiceMemberForUser(ctx, h.DB(), session, serviceMemberID)
 	if err != nil {
 		return handlers.ResponseForError(h.Logger(), err)
 	}

--- a/pkg/handlers/internalapi/moves.go
+++ b/pkg/handlers/internalapi/moves.go
@@ -1,6 +1,7 @@
 package internalapi
 
 import (
+	"reflect"
 	"time"
 
 	"github.com/go-openapi/runtime/middleware"
@@ -137,10 +138,11 @@ type SubmitMoveHandler struct {
 
 // Handle ... submit a move for approval
 func (h SubmitMoveHandler) Handle(params moveop.SubmitMoveForApprovalParams) middleware.Responder {
-	session := auth.SessionFromRequestContext(params.HTTPRequest)
-	ctx := params.HTTPRequest.Context()
-	ctx, span := beeline.StartSpan(ctx, "SubmitMoveHandler")
+
+	ctx, span := beeline.StartSpan(params.HTTPRequest.Context(), reflect.TypeOf(h).Name())
 	defer span.Send()
+
+	session := auth.SessionFromRequestContext(params.HTTPRequest)
 
 	/* #nosec UUID is pattern matched by swagger which checks the format */
 	moveID, _ := uuid.FromString(params.MoveID.String())
@@ -167,6 +169,7 @@ func (h SubmitMoveHandler) Handle(params moveop.SubmitMoveForApprovalParams) mid
 	}
 
 	err = h.NotificationSender().SendNotification(
+		ctx,
 		notifications.NewMoveSubmitted(h.DB(), h.Logger(), session, moveID),
 	)
 	if err != nil {

--- a/pkg/handlers/internalapi/moving_expense_documents.go
+++ b/pkg/handlers/internalapi/moving_expense_documents.go
@@ -1,8 +1,11 @@
 package internalapi
 
 import (
+	"reflect"
+
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/gofrs/uuid"
+	"github.com/honeycombio/beeline-go"
 
 	"github.com/transcom/mymove/pkg/auth"
 	movedocop "github.com/transcom/mymove/pkg/gen/internalapi/internaloperations/move_docs"
@@ -43,6 +46,9 @@ type CreateMovingExpenseDocumentHandler struct {
 
 // Handle is the handler
 func (h CreateMovingExpenseDocumentHandler) Handle(params movedocop.CreateMovingExpenseDocumentParams) middleware.Responder {
+	ctx, span := beeline.StartSpan(params.HTTPRequest.Context(), reflect.TypeOf(h).Name())
+	defer span.Send()
+
 	session := auth.SessionFromRequestContext(params.HTTPRequest)
 	// #nosec UUID is pattern matched by swagger and will be ok
 	moveID, _ := uuid.FromString(params.MoveID.String())
@@ -64,7 +70,7 @@ func (h CreateMovingExpenseDocumentHandler) Handle(params movedocop.CreateMoving
 	uploads := models.Uploads{}
 	for _, id := range uploadIds {
 		converted := uuid.Must(uuid.FromString(id.String()))
-		upload, err := models.FetchUpload(h.DB(), session, converted)
+		upload, err := models.FetchUpload(ctx, h.DB(), session, converted)
 		if err != nil {
 			return handlers.ResponseForError(h.Logger(), err)
 		}

--- a/pkg/handlers/internalapi/orders.go
+++ b/pkg/handlers/internalapi/orders.go
@@ -1,10 +1,12 @@
 package internalapi
 
 import (
+	"reflect"
 	"time"
 
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/gofrs/uuid"
+	"github.com/honeycombio/beeline-go"
 	"github.com/transcom/mymove/pkg/auth"
 	ordersop "github.com/transcom/mymove/pkg/gen/internalapi/internaloperations/orders"
 	"github.com/transcom/mymove/pkg/gen/internalmessages"
@@ -61,6 +63,10 @@ type CreateOrdersHandler struct {
 
 // Handle ... creates new Orders from a request payload
 func (h CreateOrdersHandler) Handle(params ordersop.CreateOrdersParams) middleware.Responder {
+
+	ctx, span := beeline.StartSpan(params.HTTPRequest.Context(), reflect.TypeOf(h).Name())
+	defer span.Send()
+
 	session := auth.SessionFromRequestContext(params.HTTPRequest)
 
 	payload := params.CreateOrders
@@ -69,7 +75,7 @@ func (h CreateOrdersHandler) Handle(params ordersop.CreateOrdersParams) middlewa
 	if err != nil {
 		return handlers.ResponseForError(h.Logger(), err)
 	}
-	serviceMember, err := models.FetchServiceMemberForUser(h.DB(), session, serviceMemberID)
+	serviceMember, err := models.FetchServiceMemberForUser(ctx, h.DB(), session, serviceMemberID)
 	if err != nil {
 		return handlers.ResponseForError(h.Logger(), err)
 	}
@@ -78,7 +84,7 @@ func (h CreateOrdersHandler) Handle(params ordersop.CreateOrdersParams) middlewa
 	if err != nil {
 		return handlers.ResponseForError(h.Logger(), err)
 	}
-	dutyStation, err := models.FetchDutyStation(h.DB(), stationID)
+	dutyStation, err := models.FetchDutyStation(ctx, h.DB(), stationID)
 	if err != nil {
 		return handlers.ResponseForError(h.Logger(), err)
 	}
@@ -149,6 +155,10 @@ type UpdateOrdersHandler struct {
 
 // Handle ... updates an order from a request payload
 func (h UpdateOrdersHandler) Handle(params ordersop.UpdateOrdersParams) middleware.Responder {
+
+	ctx, span := beeline.StartSpan(params.HTTPRequest.Context(), reflect.TypeOf(h).Name())
+	defer span.Send()
+
 	session := auth.SessionFromRequestContext(params.HTTPRequest)
 
 	orderID, err := uuid.FromString(params.OrdersID.String())
@@ -165,7 +175,7 @@ func (h UpdateOrdersHandler) Handle(params ordersop.UpdateOrdersParams) middlewa
 	if err != nil {
 		return handlers.ResponseForError(h.Logger(), err)
 	}
-	dutyStation, err := models.FetchDutyStation(h.DB(), stationID)
+	dutyStation, err := models.FetchDutyStation(ctx, h.DB(), stationID)
 	if err != nil {
 		return handlers.ResponseForError(h.Logger(), err)
 	}

--- a/pkg/handlers/internalapi/service_member_test.go
+++ b/pkg/handlers/internalapi/service_member_test.go
@@ -1,6 +1,7 @@
 package internalapi
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -117,6 +118,8 @@ func (suite *HandlerSuite) TestSubmitServiceMemberHandlerAllValues() {
 }
 
 func (suite *HandlerSuite) TestSubmitServiceMemberSSN() {
+	ctx := context.Background()
+
 	// Given: A logged-in user
 	user := testdatagen.MakeDefaultUser(suite.TestDB())
 	session := &auth.Session{
@@ -158,7 +161,7 @@ func (suite *HandlerSuite) TestSubmitServiceMemberSSN() {
 	serviceMemberID, _ := uuid.FromString(okResponse.Payload.ID.String())
 
 	session.ServiceMemberID = serviceMemberID
-	serviceMember, err := models.FetchServiceMemberForUser(suite.TestDB(), session, serviceMemberID)
+	serviceMember, err := models.FetchServiceMemberForUser(ctx, suite.TestDB(), session, serviceMemberID)
 	suite.Assertions.NoError(err)
 
 	suite.Assertions.True(serviceMember.SocialSecurityNumber.Matches(ssn))

--- a/pkg/models/duty_station.go
+++ b/pkg/models/duty_station.go
@@ -1,14 +1,15 @@
 package models
 
 import (
+	"context"
 	"time"
 
 	"github.com/gobuffalo/pop"
 	"github.com/gobuffalo/validate"
 	"github.com/gobuffalo/validate/validators"
 	"github.com/gofrs/uuid"
+	"github.com/honeycombio/beeline-go"
 	"github.com/pkg/errors"
-
 	"github.com/transcom/mymove/pkg/gen/internalmessages"
 )
 
@@ -78,7 +79,9 @@ func FetchDSContactInfo(db *pop.Connection, dutyStationID *uuid.UUID) (*DutyStat
 }
 
 // FetchDutyStation returns a station for a given id
-func FetchDutyStation(tx *pop.Connection, id uuid.UUID) (DutyStation, error) {
+func FetchDutyStation(ctx context.Context, tx *pop.Connection, id uuid.UUID) (DutyStation, error) {
+	_, span := beeline.StartSpan(ctx, "FetchDutyStation")
+	defer span.Send()
 	var station DutyStation
 	err := tx.Q().Eager().Find(&station, id)
 	return station, err

--- a/pkg/models/social_security_number_test.go
+++ b/pkg/models/social_security_number_test.go
@@ -1,6 +1,7 @@
 package models_test
 
 import (
+	"context"
 	. "github.com/transcom/mymove/pkg/models"
 )
 
@@ -8,7 +9,7 @@ func (suite *ModelSuite) TestSSNEncryption() {
 	t := suite.T()
 	fakeSSN := "123-12-1234"
 
-	mySSN, verrs, err := BuildSocialSecurityNumber(fakeSSN)
+	mySSN, verrs, err := BuildSocialSecurityNumber(context.Background(), fakeSSN)
 	if err != nil || verrs.HasAny() {
 		t.Error("don't expect an error here")
 	}
@@ -43,7 +44,7 @@ func (suite *ModelSuite) TestSSNFormat() {
 	}
 
 	for _, sneakySSN := range sneakySSNs {
-		_, verrs, err := BuildSocialSecurityNumber(sneakySSN)
+		_, verrs, err := BuildSocialSecurityNumber(context.Background(), sneakySSN)
 		if err != nil || !verrs.HasAny() {
 			t.Error("Expected the bad formatter error.")
 		}
@@ -55,7 +56,7 @@ func (suite *ModelSuite) TestSSNSalt() {
 	t := suite.T()
 	fakeSSN := "123-12-1234"
 
-	mySSN, verrs, err := BuildSocialSecurityNumber(fakeSSN)
+	mySSN, verrs, err := BuildSocialSecurityNumber(context.Background(), fakeSSN)
 	if err != nil || verrs.HasAny() {
 		t.Error("don't expect an error here")
 	}
@@ -69,7 +70,7 @@ func (suite *ModelSuite) TestSSNSalt() {
 		t.Error("the source SSN should match the hash")
 	}
 
-	secondSSN, verrs, err := BuildSocialSecurityNumber(fakeSSN)
+	secondSSN, verrs, err := BuildSocialSecurityNumber(context.Background(), fakeSSN)
 	if err != nil || verrs.HasAny() {
 		t.Error("dont' expect an error here")
 	}

--- a/pkg/notifications/move_approved.go
+++ b/pkg/notifications/move_approved.go
@@ -1,6 +1,7 @@
 package notifications
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 
@@ -34,7 +35,7 @@ func NewMoveApproved(db *pop.Connection,
 	}
 }
 
-func (m MoveApproved) emails() ([]emailContent, error) {
+func (m MoveApproved) emails(ctx context.Context) ([]emailContent, error) {
 	var emails []emailContent
 
 	move, err := models.FetchMove(m.db, m.session, m.moveID)
@@ -47,7 +48,7 @@ func (m MoveApproved) emails() ([]emailContent, error) {
 		return emails, err
 	}
 
-	serviceMember, err := models.FetchServiceMemberForUser(m.db, m.session, orders.ServiceMemberID)
+	serviceMember, err := models.FetchServiceMemberForUser(ctx, m.db, m.session, orders.ServiceMemberID)
 	if err != nil {
 		return emails, err
 	}

--- a/pkg/notifications/move_canceled.go
+++ b/pkg/notifications/move_canceled.go
@@ -1,6 +1,7 @@
 package notifications
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/gobuffalo/pop"
@@ -33,7 +34,7 @@ func NewMoveCanceled(db *pop.Connection,
 	}
 }
 
-func (m MoveCanceled) emails() ([]emailContent, error) {
+func (m MoveCanceled) emails(ctx context.Context) ([]emailContent, error) {
 	var emails []emailContent
 
 	move, err := models.FetchMove(m.db, m.session, m.moveID)
@@ -46,7 +47,7 @@ func (m MoveCanceled) emails() ([]emailContent, error) {
 		return emails, err
 	}
 
-	serviceMember, err := models.FetchServiceMemberForUser(m.db, m.session, orders.ServiceMemberID)
+	serviceMember, err := models.FetchServiceMemberForUser(ctx, m.db, m.session, orders.ServiceMemberID)
 	if err != nil {
 		return emails, err
 	}

--- a/pkg/notifications/move_submitted.go
+++ b/pkg/notifications/move_submitted.go
@@ -1,6 +1,7 @@
 package notifications
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/gobuffalo/pop"
@@ -33,7 +34,7 @@ func NewMoveSubmitted(db *pop.Connection,
 	}
 }
 
-func (m MoveSubmitted) emails() ([]emailContent, error) {
+func (m MoveSubmitted) emails(ctx context.Context) ([]emailContent, error) {
 	var emails []emailContent
 
 	move, err := models.FetchMove(m.db, m.session, m.moveID)
@@ -46,7 +47,7 @@ func (m MoveSubmitted) emails() ([]emailContent, error) {
 		return emails, err
 	}
 
-	serviceMember, err := models.FetchServiceMemberForUser(m.db, m.session, orders.ServiceMemberID)
+	serviceMember, err := models.FetchServiceMemberForUser(ctx, m.db, m.session, orders.ServiceMemberID)
 	if err != nil {
 		return emails, err
 	}
@@ -64,7 +65,7 @@ func (m MoveSubmitted) emails() ([]emailContent, error) {
 		if err != nil {
 			return emails, err
 		}
-		destinationDutyStation, err := models.FetchDutyStation(m.db, orders.NewDutyStationID)
+		destinationDutyStation, err := models.FetchDutyStation(context.Background(), m.db, orders.NewDutyStationID)
 		if err != nil {
 			return emails, err
 		}

--- a/pkg/notifications/notification_sender.go
+++ b/pkg/notifications/notification_sender.go
@@ -2,6 +2,7 @@ package notifications
 
 import (
 	"bytes"
+	"context"
 	"os"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -13,7 +14,7 @@ import (
 )
 
 type notification interface {
-	emails() ([]emailContent, error)
+	emails(ctx context.Context) ([]emailContent, error)
 }
 
 type emailContent struct {
@@ -26,7 +27,7 @@ type emailContent struct {
 
 // NotificationSender is an interface for sending notifications
 type NotificationSender interface {
-	SendNotification(notification) error
+	SendNotification(ctx context.Context, notification notification) error
 }
 
 // NotificationSendingContext provides context to a notification sender
@@ -44,8 +45,8 @@ func NewNotificationSender(svc sesiface.SESAPI, logger *zap.Logger) Notification
 }
 
 // SendNotification sends a one or more notifications for all supported mediums
-func (n NotificationSendingContext) SendNotification(notification notification) error {
-	emails, err := notification.emails()
+func (n NotificationSendingContext) SendNotification(ctx context.Context, notification notification) error {
+	emails, err := notification.emails(ctx)
 	if err != nil {
 		return err
 	}

--- a/pkg/notifications/notification_stub.go
+++ b/pkg/notifications/notification_stub.go
@@ -1,6 +1,7 @@
 package notifications
 
 import (
+	"context"
 	"go.uber.org/zap"
 )
 
@@ -15,8 +16,8 @@ func NewStubNotificationSender(logger *zap.Logger) StubNotificationSender {
 }
 
 // SendNotification returns a dummy ID
-func (m StubNotificationSender) SendNotification(notification notification) error {
-	emails, err := notification.emails()
+func (m StubNotificationSender) SendNotification(ctx context.Context, notification notification) error {
+	emails, err := notification.emails(ctx)
 	if err != nil {
 		return err
 	}

--- a/pkg/notifications/notification_test.go
+++ b/pkg/notifications/notification_test.go
@@ -1,6 +1,7 @@
 package notifications
 
 import (
+	"context"
 	"log"
 	"testing"
 
@@ -27,6 +28,7 @@ func (n testNotification) emails() ([]emailContent, error) {
 }
 
 func (suite *NotificationSuite) TestMoveApproved() {
+	ctx := context.Background()
 	t := suite.T()
 
 	approver := testdatagen.MakeDefaultUser(suite.db)
@@ -41,7 +43,7 @@ func (suite *NotificationSuite) TestMoveApproved() {
 		},
 	}
 
-	emails, err := notification.emails()
+	emails, err := notification.emails(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -57,6 +59,7 @@ func (suite *NotificationSuite) TestMoveApproved() {
 }
 
 func (suite *NotificationSuite) TestMoveSubmitted() {
+	ctx := context.Background()
 	t := suite.T()
 
 	move := testdatagen.MakeDefaultMove(suite.db)
@@ -70,7 +73,7 @@ func (suite *NotificationSuite) TestMoveSubmitted() {
 		},
 	}
 
-	emails, err := notification.emails()
+	emails, err := notification.emails(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## Description

This PR adds some instrumentation to `CreateServiceMemberHandler`, `ShowServiceMemberHandler `, and `PatchServiceMemberHandler` so we can trace.

Also updates documentation to use `reflect.TypeOf(h).Name()` instead of manually re-writing the name of the handler.

- [x] tested on `experimental`