### PR TITLE
Healthchecker flush

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -543,21 +543,21 @@ workflows:
             - build_migrations
           filters:
             branches:
-              only: am-161271399-possible-duty-stations-same
+              only: healthchecker_flush
 
       - deploy_experimental_app:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: am-161271399-possible-duty-stations-same
+              only: healthchecker_flush
 
       - deploy_experimental_app_client_tls:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: am-161271399-possible-duty-stations-same
+              only: healthchecker_flush
 
       - deploy_staging_migrations:
           requires:

--- a/cmd/health_checker/main.go
+++ b/cmd/health_checker/main.go
@@ -349,6 +349,8 @@ func main() {
 		log.Fatal(err.Error())
 	}
 
+	defer logger.Sync()
+
 	err = checkConfig(v)
 	if err != nil {
 		switch e := err.(type) {

--- a/cmd/health_checker/main.go
+++ b/cmd/health_checker/main.go
@@ -344,6 +344,13 @@ func main() {
 	v.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 	v.AutomaticEnv()
 
+	healthCheckErrors := make([]error, 0)
+	defer func() {
+		if len(healthCheckErrors) > 0 {
+			os.Exit(1)
+		}
+	}()
+
 	logger, err := createLogger(v.GetString("log-env"), v.GetString("log-level"))
 	if err != nil {
 		log.Fatal(err.Error())
@@ -379,7 +386,6 @@ func main() {
 	backoff := v.GetInt("backoff")
 	exitOnError := v.GetBool("exit-on-error")
 
-	healthCheckErrors := make([]error, 0)
 	for _, scheme := range schemes {
 		for _, host := range hosts {
 			for _, path := range paths {
@@ -416,10 +422,6 @@ func main() {
 				}
 			}
 		}
-	}
-
-	if len(healthCheckErrors) > 0 {
-		os.Exit(1)
 	}
 
 }


### PR DESCRIPTION
## Description

Flushes zap logs to stdout before closing.  Given that defers are called in LIFO order, had to move `os.Exit(1)` wrapper function up, so it executes last.

- [x] tested on `experimental`