### PR TITLE
Trim GOPATH from debug symbols

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ pkg/assets/assets.go: pkg/paperwork/formtemplates/*
 	go-bindata -o pkg/assets/assets.go -pkg assets pkg/paperwork/formtemplates/
 
 server_build: server_deps server_generate
-	go build -i -o bin/webserver ./cmd/webserver
+	go build -gcflags=-trimpath=$(GOPATH) -asmflags=-trimpath=$(GOPATH) -i -o bin/webserver ./cmd/webserver
 # This command is for running the server by itself, it will serve the compiled frontend on its own
 server_run_standalone: client_build server_build db_dev_run
 	DEBUG_LOGGING=true $(AWS_VAULT) ./bin/webserver


### PR DESCRIPTION
## Description

Trim's the `$GOPATH` of the user that calls  `make server_build`.  In CircleCI, this leads to `.../circleci/go/...` showing up in our `cloudwatch` logs.