### PR TITLE
Changing hardcoded SourceGBLOC and DestinationGBLOC to the informatio…

### DIFF
--- a/pkg/edi/invoice/generator.go
+++ b/pkg/edi/invoice/generator.go
@@ -221,14 +221,14 @@ func getHeadingSegments(shipmentWithCost rateengine.CostByShipment, sequenceNum 
 			EntityIdentifierCode: "RG",   // Issuing office name qualifier
 			Name:                 "LKNQ", // TODO: pull from TransportationOffice
 			IdentificationCodeQualifier: "27", // GBLOC
-			IdentificationCode:          "LKNQ",
+			IdentificationCode:          *shipment.SourceGBLOC,
 		},
 		// Destination installation information
 		&edisegment.N1{
 			EntityIdentifierCode: "RH",   // Destination name qualifier
 			Name:                 "MLNQ", // TODO: pull from TransportationOffice
 			IdentificationCodeQualifier: "27", // GBLOC
-			IdentificationCode:          "MLNQ",
+			IdentificationCode:          *shipment.DestinationGBLOC,
 		},
 		// Accounting info
 		&edisegment.FA1{

--- a/pkg/edi/invoice/generator_test.go
+++ b/pkg/edi/invoice/generator_test.go
@@ -36,6 +36,10 @@ func (suite *InvoiceSuite) TestGenerate858C() {
 	suite.True(re.MatchString(generatedResult), "This fails if the EDI string does not have the environment flag set to T."+
 		" This is set by the if statement in Generate858C() that checks a boolean variable named sendProductionInvoice")
 
+	re = regexp.MustCompile("((\\*)(27)(\\*)[A-Z]{4})") // The 27 value in here as it stands is a fixed value in the EDI string.
+	suite.Equal(2, len(re.FindAllString(generatedResult, -1)), "This fails if the EDI string does not have a SourceGBLOC and/or DestinationGBLOC. "+
+		"This is set in getHeadingSegments() in the ediinvoice pkg.")
+
 }
 
 type InvoiceSuite struct {


### PR DESCRIPTION
…n provided in the shipment. Added to TestGenerate858C() to validate the presence of both the source and destination values.

## Description

The purpose of this change is to take two hard coded values in invoices and instead make use of what we have coming in on the shipment. The action for this happens in getHeadingSegments() within the ediinvoice package.

## Reviewer Notes

I added a test case in that matches for a specific number of matches of a pattern within the EDI transaction string that's generated. Have I done this in a way that makes sense and is 'golang acceptable?'

This is the snippet where that happens:
```	
re = regexp.MustCompile("((\\*)(27)(\\*)[A-Z]{4})") // The 27 value in here as it stands is a fixed value in the EDI string.

suite.Equal(2, len(re.FindAllString(generatedResult, -1)), "This fails if the EDI string does not have a SourceGBLOC and/or DestinationGBLOC. "+
		"This is set in getHeadingSegments() in the ediinvoice pkg.")
```
This is found in generator_test.go at line 39 in this commit.

## Setup

No special steps needed. Running the standard test battery will invoke the added test condition.

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](./docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](./docs/backend.md#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](./docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
* [ ] There are no aXe warnings for UI.
* [ ] This works in IE.
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @willowbl00
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/n/projects/2136865/stories/160911192) for this change

