### PR TITLE
Clean out generated or copied swagger files when running

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -218,6 +218,7 @@ clean:
 	rm -rf ./node_modules
 	rm -rf ./vendor
 	rm -rf ./pkg/gen
+	rm -rf ./public/swagger-ui/*.{css,js,png}
 	rm -rf $$GOPATH/pkg/dep/sources
 
 .PHONY: pre-commit deps test client_deps client_build client_run client_test prereqs


### PR DESCRIPTION
## Description

I had a little trouble grep'ing this morning because the compiled swagger files were in the way.  Then it turned out I couldn't just clean them up.  This PR removes the files added by `./bin/copy_swagger_ui.sh` when you run `make clean`.

## Setup

```sh
make client_build
# check for swagger files
make clean
# see swagger files are missing
```

## Code Review Verification Steps

* [x] Request review from a member of a different team.