### PR TITLE
Use wizard with assign agents button on tsp

### DIFF
--- a/cypress/integration/tsp/serviceAgents.js
+++ b/cypress/integration/tsp/serviceAgents.js
@@ -46,11 +46,11 @@ describe('TSP User enters and updates Service Agents', function() {
     tspUserAcceptsShipment();
   });
 
-  it('tsp user assigns origin and destination service agents', function() {
+  it('tsp user assigns origin and destination service agents using action button', function() {
     tspUserClicksAssignServiceAgent('ASSIGN');
     userInputsServiceAgent('Origin');
     userInputsServiceAgent('Destination');
-    userSavesServiceAgent('Origin');
+    userSavesServiceAgentsWizard();
     tspUserVerifiesServiceAgentAssigned();
   });
 });
@@ -170,4 +170,62 @@ function tspUserClicksAssignServiceAgent(locator) {
 
 function tspUserVerifiesServiceAgentAssigned() {
   cy.get('button').should('not.contain', 'Assign servicing agents');
+}
+
+function userSavesServiceAgentsWizard() {
+  const origin = getFixture('Origin');
+  const destination = getFixture('Destination');
+
+  cy
+    .get('button')
+    .contains('Done')
+    .should('be.enabled');
+
+  cy
+    .get('button')
+    .contains('Done')
+    .click();
+
+  // Verify data has been saved in the UI
+  cy
+    .get('div.company')
+    .get('span')
+    .contains(origin.Company);
+  cy
+    .get('div.email')
+    .get('span')
+    .contains(origin.Email);
+  cy
+    .get('div.phone_number')
+    .get('span')
+    .contains(origin.Phone);
+
+  // Refresh browser and make sure changes persist
+  cy.reload();
+
+  cy
+    .get('div.company')
+    .get('span')
+    .contains(origin.Company);
+  cy
+    .get('div.email')
+    .get('span')
+    .contains(origin.Email);
+  cy
+    .get('div.phone_number')
+    .get('span')
+    .contains(origin.Phone);
+
+  cy
+    .get('div.company')
+    .get('span')
+    .contains(destination.Company);
+  cy
+    .get('div.email')
+    .get('span')
+    .contains(destination.Email);
+  cy
+    .get('div.phone_number')
+    .get('span')
+    .contains(destination.Phone);
 }

--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -106,7 +106,6 @@ const HHGTabContent = props => {
         />
       )}
       <TspContainer
-        setEditTspServiceAgent={no_op_action}
         title="TSP & Servicing Agents"
         shipment={props.officeShipment}
         serviceAgents={props.serviceAgents}

--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -65,7 +65,6 @@ import faCheck from '@fortawesome/fontawesome-free-solid/faCheck';
 import faExclamationCircle from '@fortawesome/fontawesome-free-solid/faExclamationCircle';
 import faPlayCircle from '@fortawesome/fontawesome-free-solid/faPlayCircle';
 import faExternalLinkAlt from '@fortawesome/fontawesome-free-solid/faExternalLinkAlt';
-import { no_op_action } from '../../shared/utils';
 
 const BasicsTabContent = props => {
   return (

--- a/src/scenes/TransportationServiceProvider/ServiceAgentForm.jsx
+++ b/src/scenes/TransportationServiceProvider/ServiceAgentForm.jsx
@@ -2,8 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { get } from 'lodash';
-// import { SwaggerField } from 'shared/JsonSchemaForm/JsonSchemaField';
 import { reduxForm, FormSection } from 'redux-form';
+
 import { ServiceAgentEdit } from 'shared/TspPanel/ServiceAgentViews';
 
 let ServiceAgentForm = props => {

--- a/src/scenes/TransportationServiceProvider/ServiceAgentForm.jsx
+++ b/src/scenes/TransportationServiceProvider/ServiceAgentForm.jsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { get } from 'lodash';
+// import { SwaggerField } from 'shared/JsonSchemaForm/JsonSchemaField';
+import { reduxForm, FormSection } from 'redux-form';
+import { ServiceAgentEdit } from 'shared/TspPanel/ServiceAgentViews';
+
+let ServiceAgentForm = props => {
+  const { schema, onCancel, handleSubmit, submitting, valid } = props;
+  const originValues = get(props, 'formValues.ORIGIN');
+  const destinationValues = get(props, 'formValues.DESTINATION');
+
+  return (
+    <form className="infoPanel-wizard" onSubmit={handleSubmit}>
+      <FormSection name="origin_service_agent">
+        <ServiceAgentEdit
+          serviceAgentProps={{
+            swagger: schema,
+            values: originValues,
+          }}
+          saRole="Origin"
+        />
+      </FormSection>
+      <FormSection name="destination_service_agent">
+        <ServiceAgentEdit serviceAgentProps={{ swagger: schema, values: destinationValues }} saRole="Destination" />
+      </FormSection>
+
+      <div className="infoPanel-wizard-actions-container">
+        <a className="infoPanel-wizard-cancel" onClick={onCancel}>
+          Cancel
+        </a>
+        <button type="submit" disabled={submitting || !valid}>
+          Done
+        </button>
+      </div>
+    </form>
+  );
+};
+
+ServiceAgentForm = reduxForm({ form: 'tsp_service_agents' })(ServiceAgentForm);
+
+ServiceAgentForm.propTypes = {
+  schema: PropTypes.object,
+  onCancel: PropTypes.func,
+  handleSubmit: PropTypes.func,
+  submitting: PropTypes.bool,
+  valid: PropTypes.bool,
+};
+
+const mapStateToProps = (state, ownProps) => {
+  const { shipment } = state.tsp;
+  return {
+    ...ownProps,
+    initialValues: shipment,
+  };
+};
+
+export default connect(mapStateToProps)(ServiceAgentForm);

--- a/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
+++ b/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
@@ -45,6 +45,7 @@ import {
   rejectShipment,
   transportShipment,
   deliverShipment,
+  handleServiceAgents,
 } from './ducks';
 import TspContainer from 'shared/TspPanel/TspContainer';
 import Weights from 'shared/ShipmentWeights';
@@ -55,6 +56,7 @@ import CustomerInfo from './CustomerInfo';
 import PreApprovalPanel from 'shared/PreApprovalRequest/PreApprovalPanel.jsx';
 import PickupForm from './PickupForm';
 import PremoveSurveyForm from './PremoveSurveyForm';
+import ServiceAgentForm from './ServiceAgentForm';
 import { getLastRequestIsSuccess, getLastRequestIsLoading } from 'shared/Swagger/selectors';
 
 import './tsp.css';
@@ -163,6 +165,12 @@ class ShipmentInfo extends Component {
   };
 
   enterPreMoveSurvey = values => this.props.patchShipment(this.props.shipment.id, values);
+
+  editServiceAgents = values => {
+    values['destination_service_agent']['role'] = 'DESTINATION';
+    values['origin_service_agent']['role'] = 'ORIGIN';
+    this.props.handleServiceAgents(this.props.shipment.id, values);
+  };
 
   transportShipment = values => this.props.transportShipment(this.props.shipment.id, values);
 
@@ -384,9 +392,13 @@ class ShipmentInfo extends Component {
                 />
               )}
               {canAssignServiceAgents && (
-                <button className="usa-button-primary" onClick={this.toggleEditTspServiceAgent}>
-                  Assign servicing agents
-                </button>
+                <FormButton
+                  serviceAgents={this.props.serviceAgents}
+                  FormComponent={ServiceAgentForm}
+                  schema={this.props.serviceAgentSchema}
+                  onSubmit={this.editServiceAgents}
+                  buttonTitle="Assign servicing agents"
+                />
               )}
 
               {inTransit && (
@@ -480,6 +492,7 @@ const mapStateToProps = state => {
     gblDocUrl: `/shipments/${shipment.id}/documents/${get(gbl, 'id')}`,
     error: get(state, 'tsp.error'),
     shipmentSchema: get(state, 'swaggerPublic.spec.definitions.Shipment', {}),
+    serviceAgentSchema: get(state, 'swaggerPublic.spec.definitions.ServiceAgent', {}),
     transportSchema: get(state, 'swaggerPublic.spec.definitions.TransportPayload', {}),
     deliverSchema: get(state, 'swaggerPublic.spec.definitions.ActualDeliveryDate', {}),
   };
@@ -493,6 +506,7 @@ const mapDispatchToProps = dispatch =>
       acceptShipment,
       generateGBL,
       rejectShipment,
+      handleServiceAgents,
       transportShipment,
       deliverShipment,
       getAllShipmentDocuments,

--- a/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
+++ b/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
@@ -1,4 +1,3 @@
-import ReactDOM from 'react-dom';
 import React, { Component } from 'react';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';

--- a/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
+++ b/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
@@ -176,18 +176,6 @@ class ShipmentInfo extends Component {
 
   deliverShipment = values => this.props.deliverShipment(this.props.shipment.id, values);
 
-  // Access Service Agent Panels
-  setEditTspServiceAgent = editTspServiceAgent => this.setState({ editTspServiceAgent });
-
-  scrollToTspServiceAgentPanel = () => {
-    const domNode = ReactDOM.findDOMNode(this.assignTspServiceAgent.current);
-    domNode.scrollIntoView();
-  };
-  toggleEditTspServiceAgent = () => {
-    this.scrollToTspServiceAgentPanel();
-    this.setEditTspServiceAgent(true);
-  };
-
   render() {
     const {
       context,
@@ -424,9 +412,6 @@ class ShipmentInfo extends Component {
                   <LocationsContainer update={this.props.patchShipment} />
                   <PreApprovalPanel shipmentId={this.props.match.params.shipmentId} />
                   <TspContainer
-                    ref={this.assignTspServiceAgent}
-                    editTspServiceAgent={this.state.editTspServiceAgent}
-                    setEditTspServiceAgent={this.setEditTspServiceAgent}
                     title="TSP & Servicing Agents"
                     shipment={this.props.shipment}
                     serviceAgents={this.props.serviceAgents}

--- a/src/shared/TspPanel/TspServiceAgents.jsx
+++ b/src/shared/TspPanel/TspServiceAgents.jsx
@@ -103,7 +103,6 @@ export function TspEditablePanelify(DisplayComponent, EditComponent, editEnabled
     cancel = () => {
       this.props.reset();
       this.setIsEditable(false);
-      this.props.setEditTspServiceAgent(false);
     };
 
     setIsEditable = isEditable => this.setState({ isEditable });

--- a/src/shared/TspPanel/TspServiceAgents.jsx
+++ b/src/shared/TspPanel/TspServiceAgents.jsx
@@ -3,8 +3,8 @@ import React, { Component, Fragment } from 'react';
 import classNames from 'classnames';
 import { reduxForm, FormSection } from 'redux-form';
 import PropTypes from 'prop-types';
-import Alert from 'shared/Alert';
 
+import Alert from 'shared/Alert';
 import { ServiceAgentDisplay, ServiceAgentEdit } from './ServiceAgentViews';
 
 // TODO: Refactor when we switch to using a wizard
@@ -85,7 +85,7 @@ export function TspEditablePanelify(DisplayComponent, EditComponent, editEnabled
       isEditable: false,
     };
 
-    componentDidUpdate = (prevProps, prevState) => {
+    componentDidUpdate = prevProps => {
       if (!prevProps.editTspServiceAgent && this.props.editTspServiceAgent) {
         this.setIsEditable(true);
       }


### PR DESCRIPTION
## Description

Previously the button was redirecting to the TSP service agent panel. Design would rather 

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make db_populate_e2e
```
Use the locator `ASSIGN` to enter the servicing agents for the shipment using the action button.

## Code Review Verification Steps

* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* https://www.pivotaltracker.com/story/show/161571965

## Screenshots

<img width="1284" alt="screen shot 2018-11-13 at 11 41 06 am" src="https://user-images.githubusercontent.com/5531789/48438551-123deb00-e739-11e8-97d1-c84b9a8461ee.png">

