### PR TITLE
Changed default country to USA from United States

### DIFF
--- a/pkg/route/planner_test.go
+++ b/pkg/route/planner_test.go
@@ -36,17 +36,23 @@ func (suite *PlannerSuite) TestUrlencodeAddress() {
 	}
 }
 
+var usaStr = "USA"
+
 var realAddressSource = models.Address{
-	StreetAddress1: "1333 Minna St",
-	City:           "San Francisco",
-	State:          "CA",
-	PostalCode:     "94103"}
+	StreetAddress1: "",
+	City:           "Joint Base Lewis-McChord",
+	State:          "WA",
+	PostalCode:     "98438",
+	Country:        &usaStr,
+}
 
 var realAddressDestination = models.Address{
-	StreetAddress1: "1000 Defense Pentagon",
+	StreetAddress1: "100 Maple St. NW",
 	City:           "Washington",
 	State:          "DC",
-	PostalCode:     "20301-1000"}
+	PostalCode:     "20001",
+	Country:        &usaStr,
+}
 
 // TestAddressPlanner is an expensive test which calls out to the Bing API.
 func (suite *PlannerFullSuite) TestAddressPlanner() {

--- a/swagger/api.yaml
+++ b/swagger/api.yaml
@@ -316,8 +316,8 @@ definitions:
         type: string
         title: Country
         x-nullable: true
-        example: 'United States'
-        default: United States
+        example: 'USA'
+        default: USA
     required:
       - street_address_1
       - state

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -1884,8 +1884,8 @@ definitions:
         type: string
         title: Country
         x-nullable: true
-        example: 'United States'
-        default: United States
+        example: 'USA'
+        default: USA
     required:
       - street_address_1
       - city


### PR DESCRIPTION
## Description

Using "United States" as the country field can cause HERE to have a hard time locating an address, see https://mymovemil.zendesk.com/agent/tickets/131.

As we are only dealing with CONUS now, the swagger defaults are the only way countries are being added to addresses. This changes the default to one which is less likely to cause problems with HERE.

## Reviewer Notes

NOTE: This does not address the issues (https://mymovemil.zendesk.com/agent/tickets/131) where we handle bad addresses badly, e.g. if someone were able to add United States manually as the country. However, it removes the chances of hitting this until that time.

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](./docs/backend.md#logging)
* [ ] Request review from a member of a different team.

## References

* [Bug](https://mymovemil.zendesk.com/agent/tickets/132) for this change
