### PR TITLE
Writes selectors for filtering non-preapproval items [delivers #161829779]

### DIFF
--- a/src/shared/Entities/modules/shipmentLineItems.js
+++ b/src/shared/Entities/modules/shipmentLineItems.js
@@ -2,7 +2,7 @@ import { swaggerRequest } from 'shared/Swagger/request';
 import { getPublicClient } from 'shared/Swagger/api';
 import { shipmentLineItems as ShipmentLineItemsModel } from '../schema';
 import { denormalize } from 'normalizr';
-import { get, orderBy, filter, map } from 'lodash';
+import { get, orderBy, filter, map, keys } from 'lodash';
 import { createSelector } from 'reselect';
 
 export function createShipmentLineItem(label, shipmentId, payload) {
@@ -30,9 +30,16 @@ export function getAllShipmentLineItems(label, shipmentId) {
   return swaggerRequest(getPublicClient, 'accessorials.getShipmentLineItems', { shipmentId }, { label });
 }
 
-const selectShipmentLineItems = state => get(state, 'entities.shipmentLineItems', {});
+const selectShipmentLineItems = state => {
+  return denormalize(keys(get(state, 'entities.shipmentLineItems', {})), ShipmentLineItemsModel, state.entities);
+};
+
 export const selectSortedShipmentLineItems = createSelector([selectShipmentLineItems], shipmentLineItems =>
-  orderBy(Object.values(shipmentLineItems), ['status', 'approved_date', 'submitted_date'], ['asc', 'desc', 'desc']),
+  orderBy(shipmentLineItems, ['status', 'approved_date', 'submitted_date'], ['asc', 'desc', 'desc']),
+);
+
+export const selectSortedPreApprovalShipmentLineItems = createSelector([selectShipmentLineItems], shipmentLineItems =>
+  filter(shipmentLineItems, lineItem => lineItem.tariff400ng_item.requires_pre_approval),
 );
 
 export const getShipmentLineItemsLabel = 'ShipmentLineItems.getAllShipmentLineItems';

--- a/src/shared/Entities/modules/shipmentLineItems.js
+++ b/src/shared/Entities/modules/shipmentLineItems.js
@@ -38,8 +38,9 @@ export const selectSortedShipmentLineItems = createSelector([selectShipmentLineI
   orderBy(shipmentLineItems, ['status', 'approved_date', 'submitted_date'], ['asc', 'desc', 'desc']),
 );
 
-export const selectSortedPreApprovalShipmentLineItems = createSelector([selectShipmentLineItems], shipmentLineItems =>
-  filter(shipmentLineItems, lineItem => lineItem.tariff400ng_item.requires_pre_approval),
+export const selectSortedPreApprovalShipmentLineItems = createSelector(
+  [selectSortedShipmentLineItems],
+  shipmentLineItems => filter(shipmentLineItems, lineItem => lineItem.tariff400ng_item.requires_pre_approval),
 );
 
 export const getShipmentLineItemsLabel = 'ShipmentLineItems.getAllShipmentLineItems';

--- a/src/shared/Entities/modules/tariff400ngItems.js
+++ b/src/shared/Entities/modules/tariff400ngItems.js
@@ -1,15 +1,25 @@
+import { filter, keys, sortBy, parseInt } from 'lodash';
 import { swaggerRequest } from 'shared/Swagger/request';
 import { getPublicClient } from 'shared/Swagger/api';
 import { tariff400ngItems } from '../schema';
 import { denormalize } from 'normalizr';
+import { createSelector } from 'reselect';
 
 export function getAllTariff400ngItems(requires_pre_approval, label) {
   return swaggerRequest(getPublicClient, 'accessorials.getTariff400ngItems', { requires_pre_approval }, { label });
 }
 
-export const selectTariff400ngItems = state => {
-  return Object.values(state.entities.tariff400ngItems);
-};
+export const selectTariff400ngItems = state =>
+  denormalize(keys(state.entities.tariff400ngItems), tariff400ngItems, state.entities);
+
+export const selectSortedTariff400ngItems = createSelector([selectTariff400ngItems], items =>
+  // Sorts by the numeric part of code, e.g. "256A" -> 256
+  sortBy(items, item => parseInt(item.code.match(/[0-9]+/g))),
+);
+
+export const selectSortedPreApprovalTariff400ngItems = createSelector([selectSortedTariff400ngItems], items =>
+  filter(items, item => item.requires_pre_approval),
+);
 
 export const getTariff400ngItemsLabel = 'Tariff400ngItem.getAlltariff400ngItems';
 

--- a/src/shared/Entities/schema.js
+++ b/src/shared/Entities/schema.js
@@ -79,11 +79,7 @@ export const tariff400ngItems = new schema.Array(tariff400ngItem);
 export const shipmentLineItem = new schema.Entity('shipmentLineItems', {
   tariff400ngItem: tariff400ngItem,
 });
-
 export const shipmentLineItems = new schema.Array(shipmentLineItem);
-shipmentLineItem.define({
-  tariff400ngItem: tariff400ngItem,
-});
 
 // AvailableMoveDates
 export const availableMoveDates = new schema.Entity('availableMoveDates', {}, { idAttribute: 'start_date' });

--- a/src/shared/PreApprovalRequest/PreApprovalPanel.jsx
+++ b/src/shared/PreApprovalRequest/PreApprovalPanel.jsx
@@ -19,8 +19,8 @@ import {
   updateShipmentLineItem,
   updateShipmentLineItemLabel,
 } from 'shared/Entities/modules/shipmentLineItems';
-import { selectSortedShipmentLineItems } from 'shared/Entities/modules/shipmentLineItems';
-import { selectTariff400ngItems } from 'shared/Entities/modules/tariff400ngItems';
+import { selectSortedPreApprovalShipmentLineItems } from 'shared/Entities/modules/shipmentLineItems';
+import { selectSortedPreApprovalTariff400ngItems } from 'shared/Entities/modules/tariff400ngItems';
 
 export class PreApprovalPanel extends Component {
   constructor() {
@@ -82,8 +82,8 @@ PreApprovalPanel.propTypes = {
 
 function mapStateToProps(state) {
   return {
-    shipmentLineItems: selectSortedShipmentLineItems(state),
-    tariff400ngItems: selectTariff400ngItems(state),
+    shipmentLineItems: selectSortedPreApprovalShipmentLineItems(state),
+    tariff400ngItems: selectSortedPreApprovalTariff400ngItems(state),
   };
 }
 


### PR DESCRIPTION
## Description

Currently we're relying on the getTariff400ngItems endpoint to only give us items that have `requires_pre_approval` set to true, but that won't always be the case. This adds selectors for doing that filtering client site and hooks them up to the pre-approval panel.

Also filters tariff400ngItems properly by increasing numeric value because it was slowly killing me.

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](./docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](./docs/backend.md#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](./docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
* [ ] There are no aXe warnings for UI.
* [ ] This works in IE.
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @willowbl00
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/161829779) for this change