### PR TITLE
HHG+PPM Weights page

### DIFF
--- a/src/scenes/Moves/Ppm/Weight.jsx
+++ b/src/scenes/Moves/Ppm/Weight.jsx
@@ -210,6 +210,7 @@ export class PpmWeight extends Component {
       ppmAdvanceSchema,
       advanceFormValues,
       selectedWeightInfo,
+      isHHGPPMComboMove,
     } = this.props;
     const hasRequestedAdvance = get(advanceFormValues, 'has_requested_advance', false);
     let advanceInitialValues = null;
@@ -280,10 +281,12 @@ export class PpmWeight extends Component {
             )}
             <table className="numeric-info">
               <tbody>
-                <tr>
-                  <th>Your PPM Weight Estimate:</th>
-                  <td className="current-weight"> {formatNumber(this.state.pendingPpmWeight)} lbs.</td>
-                </tr>
+                {!isHHGPPMComboMove && (
+                  <tr>
+                    <th>Your PPM Weight Estimate:</th>
+                    <td className="current-weight"> {formatNumber(this.state.pendingPpmWeight)} lbs.</td>
+                  </tr>
+                )}
                 <tr>
                   <th>Your PPM Incentive:</th>
                   <td className="incentive">{formatCentsRange(incentive_estimate_min, incentive_estimate_max)}</td>
@@ -291,12 +294,14 @@ export class PpmWeight extends Component {
               </tbody>
             </table>
 
-            <RequestAdvanceForm
-              ppmAdvanceSchema={ppmAdvanceSchema}
-              hasRequestedAdvance={hasRequestedAdvance}
-              maxAdvance={maxAdvance}
-              initialValues={advanceInitialValues}
-            />
+            {!isHHGPPMComboMove && (
+              <RequestAdvanceForm
+                ppmAdvanceSchema={ppmAdvanceSchema}
+                hasRequestedAdvance={hasRequestedAdvance}
+                maxAdvance={maxAdvance}
+                initialValues={advanceInitialValues}
+              />
+            )}
 
             <div className="info">
               <h3> How is my PPM Incentive calculated?</h3>
@@ -350,6 +355,7 @@ function mapStateToProps(state) {
     schema: schema,
     ppmAdvanceSchema: ppmAdvanceSchema,
     advanceFormValues: getFormValues(requestAdvanceFormName)(state),
+    isHHGPPMComboMove: get(state, 'moves.currentMove.selected_move_type') === 'HHG_PPM',
   };
 
   return props;

--- a/src/scenes/MyMove/getWorkflowRoutes.jsx
+++ b/src/scenes/MyMove/getWorkflowRoutes.jsx
@@ -207,9 +207,7 @@ const pages = {
   },
   '/moves/:moveId/hhg-ppm-weight': {
     isInFlow: hasHHGPPM,
-    isComplete: (sm, orders, move, ppm) => {
-      return every([ppm.planned_move_date, ppm.pickup_postal_code, ppm.destination_postal_code]);
-    },
+    isComplete: (sm, orders, move, ppm) => get(ppm, 'weight_estimate', null),
     render: (key, pages) => ({ match }) => <PpmWeight pages={hhgPPMPages} pageKey={key} match={match} />,
   },
   '/moves/:moveId/ppm-start': {

--- a/src/scenes/MyMove/getWorkflowRoutes.jsx
+++ b/src/scenes/MyMove/getWorkflowRoutes.jsx
@@ -205,6 +205,13 @@ const pages = {
     isComplete: (sm, orders, move, ppm) => !!ppm.size,
     render: (key, pages) => ({ match }) => <PpmSize pages={hhgPPMPages} pageKey={key} match={match} />,
   },
+  '/moves/:moveId/hhg-ppm-weight': {
+    isInFlow: hasHHGPPM,
+    isComplete: (sm, orders, move, ppm) => {
+      return every([ppm.planned_move_date, ppm.pickup_postal_code, ppm.destination_postal_code]);
+    },
+    render: (key, pages) => ({ match }) => <PpmWeight pages={hhgPPMPages} pageKey={key} match={match} />,
+  },
   '/moves/:moveId/ppm-start': {
     isInFlow: state => state.selectedMoveType === 'PPM',
     isComplete: (sm, orders, move, ppm) => {
@@ -237,7 +244,7 @@ const pages = {
 };
 
 // TODO currently an interim step for adding hhgPPM combo move pages
-const hhgPPMPages = ['/moves/:moveId/hhg-ppm-start', '/moves/:moveId/hhg-ppm-size'];
+const hhgPPMPages = ['/moves/:moveId/hhg-ppm-start', '/moves/:moveId/hhg-ppm-size', '/moves/:moveId/hhg-ppm-weight'];
 
 export const getPagesInFlow = ({ selectedMoveType, lastMoveIsCanceled }) =>
   Object.keys(pages).filter(pageKey => {

--- a/src/scenes/MyMove/getWorkflowRoutes.test.js
+++ b/src/scenes/MyMove/getWorkflowRoutes.test.js
@@ -49,6 +49,7 @@ describe('when getting the routes for the current workflow', () => {
           '/moves/:moveId',
           '/moves/:moveId/hhg-ppm-start',
           '/moves/:moveId/hhg-ppm-size',
+          '/moves/:moveId/hhg-ppm-weight',
           '/moves/:moveId/review',
           '/moves/:moveId/agreement',
         ]);


### PR DESCRIPTION
## Description

Add PPM customize weight page to the HHG+PPM flow

## Reviewer Notes
- At this point, the button will say `Complete` instead of`Next` until we have the next page in the flow set up

## Setup
`make db_populate_e2e`
`make server_run`
`make client_run`
1. Log into a SM with a completed HHG move set up
2. Click `+ Add PPM Shipment` and go through the flow

## Code Review Verification Steps
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/161727274) for this change

## Screenshots
![image](https://user-images.githubusercontent.com/13622298/48498522-4bcf2e80-e7eb-11e8-92a3-a218a4d0b258.png)
