### PR TITLE
Fixed more references to deprecated uuid package

### DIFF
--- a/pkg/auth/session.go
+++ b/pkg/auth/session.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/gobuffalo/uuid"
+	"github.com/gofrs/uuid"
 )
 
 type authSessionKey string

--- a/pkg/models/dps_users.go
+++ b/pkg/models/dps_users.go
@@ -5,9 +5,9 @@ import (
 	"time"
 
 	"github.com/gobuffalo/pop"
-	"github.com/gobuffalo/uuid"
 	"github.com/gobuffalo/validate"
 	"github.com/gobuffalo/validate/validators"
+	"github.com/gofrs/uuid"
 )
 
 // DpsUser are users who have permission to access MyMove - DPS integration resources


### PR DESCRIPTION
## Description

Some more references to the deprecated `gobuffalo/uuid` package snuck in (looks like merges just crossed paths).  See #1314 and #1262 for background.  This PR updates them to `gofrs/uuid`.
