### PR TITLE
[DPS Auth] Make DPS user email check case-insensitive

### DIFF
--- a/pkg/models/dps_users.go
+++ b/pkg/models/dps_users.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"encoding/json"
+	"strings"
 	"time"
 
 	"github.com/gobuffalo/pop"
@@ -55,7 +56,7 @@ func (d *DpsUser) ValidateUpdate(tx *pop.Connection) (*validate.Errors, error) {
 
 // IsDPSUser checks if a user is a DPS user given email
 func IsDPSUser(db *pop.Connection, email string) (bool, error) {
-	count, err := db.Q().Where("login_gov_email = ?", email).Count(DpsUser{})
+	count, err := db.Q().Where("LOWER(login_gov_email) = ?", strings.ToLower(email)).Count(DpsUser{})
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
## Description

Make email check case-insensitive. I double checked with Login.gov and they normalize all emails by converting to lowercase (and stripping beginning / ending whitespace). Email usernames can technically be case sensitive but they said they haven't run into issues with this yet.

