### PR TITLE
Removes unused test data generators

### DIFF
--- a/cmd/generate_test_data/main.go
+++ b/cmd/generate_test_data/main.go
@@ -19,8 +19,6 @@ import (
 func main() {
 	config := flag.String("config-dir", "config", "The location of server config files")
 	env := flag.String("env", "development", "The environment to run in, which configures the database.")
-	rounds := flag.String("rounds", "none", "If not using premade scenarios: Specify none (no awards), full (1 full round of awards), or half (partial round of awards)")
-	numTSP := flag.Int("numTSP", 15, "If not using premade scenarios: Specify the number of TSPs you'd like to create")
 	scenario := flag.Int("scenario", 0, "Specify which scenario you'd like to run. Current options: 1, 2, 3, 4, 5, 6, 7.")
 	namedScenario := flag.String("named-scenario", "", "It's like a scenario, but more descriptive.")
 	flag.Parse()
@@ -86,19 +84,7 @@ func main() {
 		tdgs.E2eBasicScenario.Run(db, loader, logger, storer)
 		log.Print("Success! Created e2e test data.")
 	} else {
-		// Can this be less repetitive without being overly clever?
-		testdatagen.MakeDefaultServiceMember(db)
-		testdatagen.MakeDefaultOfficeUser(db)
-		testdatagen.MakeDefaultTspUser(db)
-		testdatagen.MakeTDLData(db)
-		testdatagen.MakeTSPs(db, *numTSP)
-		testdatagen.MakeShipmentData(db)
-		testdatagen.MakeShipmentOfferData(db)
-		testdatagen.MakeTSPPerformanceDataDeprecated(db, *rounds)
-		testdatagen.MakeBlackoutDateData(db)
-		testdatagen.MakePPMData(db)
-		testdatagen.MakeReimbursementData(db)
-		testdatagen.MakeExtendedServiceMember(db, testdatagen.Assertions{})
+		flag.PrintDefaults()
 	}
 	if err != nil {
 		log.Panic(err)

--- a/pkg/testdatagen/make_blackout_date_records.go
+++ b/pkg/testdatagen/make_blackout_date_records.go
@@ -57,20 +57,3 @@ func MakeBlackoutDate(db *pop.Connection, assertions Assertions) models.Blackout
 func MakeDefaultBlackoutDate(db *pop.Connection) models.BlackoutDate {
 	return MakeBlackoutDate(db, Assertions{})
 }
-
-// MakeBlackoutDateData creates three blackoutDate objects and commits them to the blackout_dates table.
-func MakeBlackoutDateData(db *pop.Connection) {
-	// Make a blackout date with market.
-	date1 := MakeDefaultBlackoutDate(db)
-	date1.SourceGBLOC = nil
-	mustSave(db, &date1)
-
-	// Make a blackout date with a channel.
-	date2 := MakeDefaultBlackoutDate(db)
-	date2.SourceGBLOC = nil
-	date2.Market = nil
-	mustSave(db, &date2)
-
-	// Make a blackout date with market and source gbloc.
-	MakeDefaultBlackoutDate(db)
-}

--- a/pkg/testdatagen/make_ppm.go
+++ b/pkg/testdatagen/make_ppm.go
@@ -54,10 +54,3 @@ func MakePPM(db *pop.Connection, assertions Assertions) models.PersonallyProcure
 func MakeDefaultPPM(db *pop.Connection) models.PersonallyProcuredMove {
 	return MakePPM(db, Assertions{})
 }
-
-// MakePPMData creates 3 PPMs (and in turn a move and set of orders for each)
-func MakePPMData(db *pop.Connection) {
-	for i := 0; i < 3; i++ {
-		MakeDefaultPPM(db)
-	}
-}

--- a/pkg/testdatagen/make_reimbursement.go
+++ b/pkg/testdatagen/make_reimbursement.go
@@ -25,13 +25,3 @@ func MakeRequestedReimbursement(db *pop.Connection) (models.Reimbursement, error
 
 	return reimbursement, nil
 }
-
-// MakeReimbursementData creates 3 draft Reimbursements and 2 requested Reimbursements
-func MakeReimbursementData(db *pop.Connection) {
-	for i := 0; i < 3; i++ {
-		MakeDraftReimbursement(db)
-	}
-	for i := 0; i < 2; i++ {
-		MakeRequestedReimbursement(db)
-	}
-}

--- a/pkg/testdatagen/make_shipment_offer_records.go
+++ b/pkg/testdatagen/make_shipment_offer_records.go
@@ -56,37 +56,6 @@ func MakeDefaultShipmentOffer(db *pop.Connection) models.ShipmentOffer {
 	return MakeShipmentOffer(db, Assertions{})
 }
 
-// MakeShipmentOfferData creates one offered shipment record
-func MakeShipmentOfferData(db *pop.Connection) {
-	// Get a shipment ID
-	shipmentList := []models.Shipment{}
-	err := db.All(&shipmentList)
-	if err != nil {
-		fmt.Println("Shipment ID import failed.")
-	}
-
-	// Get a TSP ID
-	tspList := []models.TransportationServiceProvider{}
-	err = db.All(&tspList)
-	if err != nil {
-		fmt.Println("TSP ID import failed.")
-	}
-
-	// Add one offered shipment record for each shipment and a random TSP IDs
-	for _, shipment := range shipmentList {
-		shipmentOfferAssertions := Assertions{
-			ShipmentOffer: models.ShipmentOffer{
-				ShipmentID:                      shipment.ID,
-				TransportationServiceProviderID: tspList[rand.Intn(len(tspList))].ID,
-				AdministrativeShipment:          false,
-				Accepted:                        nil, // See note about Tri-state above
-				RejectionReason:                 nil,
-			},
-		}
-		MakeShipmentOffer(db, shipmentOfferAssertions)
-	}
-}
-
 // CreateShipmentOfferData creates a list of TSP Users, Shipments, and Shipment Offers
 // Must pass in the number of tsp users to create and number of shipments.
 // The split of shipment offers should be the length of TSP users and the sum should equal the number of shipments

--- a/pkg/testdatagen/make_shipment_records.go
+++ b/pkg/testdatagen/make_shipment_records.go
@@ -1,9 +1,6 @@
 package testdatagen
 
 import (
-	"fmt"
-	"time"
-
 	"github.com/gobuffalo/pop"
 
 	"github.com/transcom/mymove/pkg/dates"
@@ -144,61 +141,4 @@ func MakeShipment(db *pop.Connection, assertions Assertions) models.Shipment {
 // MakeDefaultShipment makes a Shipment with default values
 func MakeDefaultShipment(db *pop.Connection) models.Shipment {
 	return MakeShipment(db, Assertions{})
-}
-
-// MakeShipmentData creates three shipment records
-func MakeShipmentData(db *pop.Connection) {
-	// Grab three UUIDs for individual TDLs
-	// TODO: should this query be made in main, between creation functions,
-	// and then sourced from one central place?
-	tdlList := []models.TrafficDistributionList{}
-	err := db.All(&tdlList)
-	if err != nil {
-		fmt.Println("TDL ID import failed.")
-	}
-
-	// Add three shipment table records using UUIDs from TDLs
-	oneWeek := time.Hour * 168
-	now := time.Now()
-	nowPlusOne := now.Add(oneWeek)
-	nowPlusTwo := now.Add(oneWeek * 2)
-	market := "dHHG"
-	sourceGBLOC := "KKFA"
-	destinationGBLOC := "HAFC"
-
-	MakeShipment(db, Assertions{
-		Shipment: models.Shipment{
-			RequestedPickupDate:     &now,
-			ActualPickupDate:        &now,
-			ActualDeliveryDate:      &now,
-			TrafficDistributionList: &tdlList[0],
-			SourceGBLOC:             &sourceGBLOC,
-			DestinationGBLOC:        &destinationGBLOC,
-			Market:                  &market,
-		},
-	})
-
-	MakeShipment(db, Assertions{
-		Shipment: models.Shipment{
-			RequestedPickupDate:     &nowPlusOne,
-			ActualPickupDate:        &nowPlusOne,
-			ActualDeliveryDate:      &nowPlusOne,
-			TrafficDistributionList: &tdlList[1],
-			SourceGBLOC:             &sourceGBLOC,
-			DestinationGBLOC:        &destinationGBLOC,
-			Market:                  &market,
-		},
-	})
-
-	MakeShipment(db, Assertions{
-		Shipment: models.Shipment{
-			RequestedPickupDate:     &nowPlusTwo,
-			ActualPickupDate:        &nowPlusTwo,
-			ActualDeliveryDate:      &nowPlusTwo,
-			TrafficDistributionList: &tdlList[2],
-			SourceGBLOC:             &sourceGBLOC,
-			DestinationGBLOC:        &destinationGBLOC,
-			Market:                  &market,
-		},
-	})
 }

--- a/pkg/testdatagen/make_tdl_records.go
+++ b/pkg/testdatagen/make_tdl_records.go
@@ -56,29 +56,3 @@ func MakeTDL(db *pop.Connection, assertions Assertions) models.TrafficDistributi
 func MakeDefaultTDL(db *pop.Connection) models.TrafficDistributionList {
 	return MakeTDL(db, Assertions{})
 }
-
-// MakeTDLData creates three TDL records
-func MakeTDLData(db *pop.Connection) {
-	// It would be nice to make this less repetitive
-	MakeTDL(db, Assertions{
-		TrafficDistributionList: models.TrafficDistributionList{
-			SourceRateArea:    "US1",
-			DestinationRegion: "2",
-			CodeOfService:     "2",
-		},
-	})
-	MakeTDL(db, Assertions{
-		TrafficDistributionList: models.TrafficDistributionList{
-			SourceRateArea:    "US10",
-			DestinationRegion: "9",
-			CodeOfService:     "2",
-		},
-	})
-	MakeTDL(db, Assertions{
-		TrafficDistributionList: models.TrafficDistributionList{
-			SourceRateArea:    "US4964400",
-			DestinationRegion: "4",
-			CodeOfService:     "D",
-		},
-	})
-}

--- a/pkg/testdatagen/make_tsp_performance_records.go
+++ b/pkg/testdatagen/make_tsp_performance_records.go
@@ -3,7 +3,6 @@ package testdatagen
 import (
 	"fmt"
 	"log"
-	"math/rand"
 	"time"
 
 	"github.com/gobuffalo/pop"
@@ -112,63 +111,4 @@ func MakeTSPPerformanceDeprecated(db *pop.Connection,
 	}
 
 	return tspPerformance, err
-}
-
-// MakeTSPPerformanceDataDeprecated creates three best value score records
-// Variable rounds describes how many rounds should have already been offered
-// `none` indicates no rounds have been offered, `half` indicates half a round, and `full` a full round.
-//
-// Deprecated: This function creates test data with random values, which can cause confusion during testing.
-// Use MakeTSPPerformance and explicitely define values or use MakeDefaultTSPPerformance if you really
-// don't care about them instead.
-func MakeTSPPerformanceDataDeprecated(db *pop.Connection, rounds string) {
-	// These two queries duplicate ones in other testdatagen files; not optimal
-	tspList := []models.TransportationServiceProvider{}
-	err := db.All(&tspList)
-	if err != nil {
-		fmt.Println("TSP ID import failed.")
-	}
-
-	tdlList := []models.TrafficDistributionList{}
-	err = db.All(&tdlList)
-	if err != nil {
-		fmt.Println("TDL ID import failed.")
-	}
-
-	// Make 4 TspPerformances with random TSPs, random TDLs, different quality bands, and random scores
-	for qualityBand := 1; qualityBand < 5; qualityBand++ {
-		// For quality band 1, generate a random number between 75 - 100,
-		// for quality band 2 between 50-75, etc.
-		var offers int
-		minBvs := (qualityBand - 1) * 25
-		bvs := float64(100 - (rand.Intn(25) + minBvs))
-		// Make linehaul and SIT rates a percentage of BVS
-		// lhRate should end up between 0 and 1
-		lhRate := unit.DiscountRate(float64(bvs) * .006)
-
-		// Set rounds according to the flag passed in
-		if rounds == "half" {
-			if qualityBand == 1 || qualityBand == 2 {
-				offers = models.OffersPerQualityBand[qualityBand]
-			} else {
-				offers = 0
-			}
-		} else if rounds == "full" {
-			offers = models.OffersPerQualityBand[qualityBand]
-		} else {
-			// default case, no offers
-			offers = 0
-		}
-
-		MakeTSPPerformanceDeprecated(
-			db,
-			tspList[rand.Intn(len(tspList))],
-			tdlList[rand.Intn(len(tdlList))],
-			&qualityBand,
-			bvs,
-			offers,
-			lhRate,
-			lhRate,
-		)
-	}
 }


### PR DESCRIPTION
## Description

As part of my work with another story, I noticed that there are some test data generators lying around that aren't well used anymore. Thought I'd break it into its own PR to remove them

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](./docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](./docs/backend.md#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](./docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
* [ ] There are no aXe warnings for UI.
* [ ] This works in IE.
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @willowbl00
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?