### PR TITLE
Get review page up for combo moves

### DIFF
--- a/src/scenes/MyMove/getWorkflowRoutes.jsx
+++ b/src/scenes/MyMove/getWorkflowRoutes.jsx
@@ -242,7 +242,12 @@ const pages = {
 };
 
 // TODO currently an interim step for adding hhgPPM combo move pages
-const hhgPPMPages = ['/moves/:moveId/hhg-ppm-start', '/moves/:moveId/hhg-ppm-size', '/moves/:moveId/hhg-ppm-weight'];
+const hhgPPMPages = [
+  '/moves/:moveId/hhg-ppm-start',
+  '/moves/:moveId/hhg-ppm-size',
+  '/moves/:moveId/hhg-ppm-weight',
+  '/moves/:moveId/review',
+];
 
 export const getPagesInFlow = ({ selectedMoveType, lastMoveIsCanceled }) =>
   Object.keys(pages).filter(pageKey => {

--- a/src/scenes/Review/Summary.jsx
+++ b/src/scenes/Review/Summary.jsx
@@ -47,6 +47,7 @@ export class Summary extends Component {
       moveIsApproved,
       serviceMember,
       entitlement,
+      isHHGPPMComboMove,
     } = this.props;
 
     const currentStation = get(serviceMember, 'current_station');
@@ -76,27 +77,35 @@ export class Summary extends Component {
             </Alert>
           )}
 
-        <ServiceMemberSummary
-          orders={currentOrders}
-          backupContacts={currentBackupContacts}
-          serviceMember={serviceMember}
-          schemaRank={schemaRank}
-          schemaAffiliation={schemaAffiliation}
-          schemaOrdersType={schemaOrdersType}
-          moveIsApproved={moveIsApproved}
-          editOrdersPath={editOrdersPath}
-        />
+        {!isHHGPPMComboMove && (
+          <ServiceMemberSummary
+            orders={currentOrders}
+            backupContacts={currentBackupContacts}
+            serviceMember={serviceMember}
+            schemaRank={schemaRank}
+            schemaAffiliation={schemaAffiliation}
+            schemaOrdersType={schemaOrdersType}
+            moveIsApproved={moveIsApproved}
+            editOrdersPath={editOrdersPath}
+          />
+        )}
 
         {currentPpm && <PPMShipmentSummary ppm={currentPpm} movePath={rootAddressWithMoveId} />}
-        {currentShipment && (
-          <HHGShipmentSummary shipment={currentShipment} movePath={rootAddressWithMoveId} entitlements={entitlement} />
-        )}
-        {moveIsApproved && (
-          <div className="approved-edit-warning">
-            *To change these fields, contact your local PPPO office at {get(currentStation, 'name')}{' '}
-            {stationPhone ? ` at ${stationPhone}` : ''}.
-          </div>
-        )}
+        {currentShipment &&
+          !isHHGPPMComboMove && (
+            <HHGShipmentSummary
+              shipment={currentShipment}
+              movePath={rootAddressWithMoveId}
+              entitlements={entitlement}
+            />
+          )}
+        {moveIsApproved &&
+          !isHHGPPMComboMove && (
+            <div className="approved-edit-warning">
+              *To change these fields, contact your local PPPO office at {get(currentStation, 'name')}{' '}
+              {stationPhone ? ` at ${stationPhone}` : ''}.
+            </div>
+          )}
       </Fragment>
     );
   }
@@ -113,6 +122,7 @@ Summary.propTypes = {
   moveIsApproved: PropTypes.bool,
   lastMoveIsCanceled: PropTypes.bool,
   error: PropTypes.object,
+  isHHGPPMComboMove: PropTypes.bool,
 };
 
 function mapStateToProps(state, ownProps) {
@@ -130,6 +140,7 @@ function mapStateToProps(state, ownProps) {
     lastMoveIsCanceled: lastMoveIsCanceled(state),
     reviewState: state.review,
     entitlement: loadEntitlementsFromState(state),
+    isHHGPPMComboMove: get(state, 'moves.currentMove.selected_move_type') === 'HHG_PPM',
   };
 }
 function mapDispatchToProps(dispatch, ownProps) {


### PR DESCRIPTION
## Description

Edits the review page for the HHG_PPM move types.
Note: e2e tests will be written for this move type at another time so I can unblock upcoming work.

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make db_populate_e2e
make server_run
make client_run
```

Log into a SM with a completed HHG move set up
Click + Add PPM Shipment and go through the flow until you get to the review page.

## Code Review Verification Steps

* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* https://www.pivotaltracker.com/story/show/161727598

## Screenshots

<img width="1179" alt="screen shot 2018-11-14 at 12 49 01 pm" src="https://user-images.githubusercontent.com/5531789/48511488-b3957180-e80b-11e8-95e9-88467e4bd553.png">

