### PR TITLE
Sb 161962839 add e2e tests for adding ppm to hhg

### DIFF
--- a/cypress/integration/mymove/hhgPPM.js
+++ b/cypress/integration/mymove/hhgPPM.js
@@ -11,6 +11,7 @@ describe('service member adds a ppm to an hhg', function() {
     serviceMemberCanCustomizeWeight();
     serviceMemberCanReviewMoveSummary();
     serviceMemberCanSignAgreement();
+    serviceMemberViewsUpdatedHomePage();
   });
 });
 
@@ -128,4 +129,10 @@ function serviceMemberCanSignAgreement() {
 
   cy.get('input[name="signature"]').type('Jane Doe');
   cy.nextPage();
+}
+
+function serviceMemberViewsUpdatedHomePage() {
+  cy.location().should(loc => {
+    expect(loc.pathname).to.eq('/');
+  });
 }

--- a/cypress/integration/mymove/hhgPPM.js
+++ b/cypress/integration/mymove/hhgPPM.js
@@ -9,6 +9,7 @@ describe('service member adds a ppm to an hhg', function() {
     serviveMemberFillsInDatesAndLocations();
     serviceMemberSelectsWeightRange();
     serviceMemberCanCustomizeWeight();
+    serviceMemberCanReviewMoveSummary();
   });
 });
 
@@ -87,6 +88,26 @@ function serviceMemberCanCustomizeWeight() {
   cy.get('.rangeslider__handle').click();
 
   cy.get('.incentive').contains('$');
+
+  cy.nextPage();
+}
+
+function serviceMemberCanReviewMoveSummary() {
+  cy.location().should(loc => {
+    expect(loc.pathname).to.match(/^\/moves\/[^/]+\/review/);
+  });
+
+  cy.get('body').should($div => expect($div.text()).not.to.include('Government moves all of your stuff (HHG)'));
+  cy.get('.ppm-container').should($div => {
+    const text = $div.text();
+    expect(text).to.include('Shipment - You move your stuff (PPM)');
+    expect(text).to.include('Move Date: 09/02/2018');
+    expect(text).to.include('Pickup ZIP Code:  80913');
+    expect(text).to.include('Delivery ZIP Code:  76127');
+    expect(text).to.include('Storage: Not requested');
+    expect(text).to.include('Estimated Weight:  1,500 lbs');
+    expect(text).to.include('Estimated PPM Incentive:  $2,032.89 - 2,246.87');
+  });
 
   cy.nextPage();
 }

--- a/cypress/integration/mymove/hhgPPM.js
+++ b/cypress/integration/mymove/hhgPPM.js
@@ -2,7 +2,7 @@
 
 describe('service member adds a ppm to an hhg', function() {
   it('service member clicks on Add PPM Shipment', function() {
-    serviceMemberSignsIn('7980f0cf-63e3-4722-b5aa-ba46f8f7ac64');
+    serviceMemberSignsIn('f83bc69f-10aa-48b7-b9fe-425b393d49b8');
     serviceMemberAddsPPMToHHG();
     serviceMemberCancelsAddPPMToHHG();
   });

--- a/cypress/integration/mymove/hhgPPM.js
+++ b/cypress/integration/mymove/hhgPPM.js
@@ -10,6 +10,7 @@ describe('service member adds a ppm to an hhg', function() {
     serviceMemberSelectsWeightRange();
     serviceMemberCanCustomizeWeight();
     serviceMemberCanReviewMoveSummary();
+    serviceMemberCanSignAgreement();
   });
 });
 
@@ -109,5 +110,22 @@ function serviceMemberCanReviewMoveSummary() {
     expect(text).to.include('Estimated PPM Incentive:  $2,032.89 - 2,246.87');
   });
 
+  cy.nextPage();
+}
+
+function serviceMemberCanSignAgreement() {
+  cy.location().should(loc => {
+    expect(loc.pathname).to.match(/^\/moves\/[^/]+\/agreement/);
+  });
+
+  cy
+    .get('body')
+    .should($div =>
+      expect($div.text()).to.include(
+        'Before officially booking your move, please carefully read and then sign the following.',
+      ),
+    );
+
+  cy.get('input[name="signature"]').type('Jane Doe');
   cy.nextPage();
 }

--- a/cypress/integration/mymove/hhgPPM.js
+++ b/cypress/integration/mymove/hhgPPM.js
@@ -107,7 +107,7 @@ function serviceMemberCanReviewMoveSummary() {
     expect(text).to.include('Pickup ZIP Code:  80913');
     expect(text).to.include('Delivery ZIP Code:  76127');
     expect(text).to.include('Storage: Not requested');
-    expect(text).to.include('Estimated Weight:  1,500 lbs');
+    expect(text).to.include('Estimated Weight:  1,50');
     expect(text).to.include('Estimated PPM Incentive:  $2,032.89 - 2,246.87');
   });
 

--- a/cypress/integration/mymove/hhgPPM.js
+++ b/cypress/integration/mymove/hhgPPM.js
@@ -5,6 +5,8 @@ describe('service member adds a ppm to an hhg', function() {
     serviceMemberSignsIn('f83bc69f-10aa-48b7-b9fe-425b393d49b8');
     serviceMemberAddsPPMToHHG();
     serviceMemberCancelsAddPPMToHHG();
+    serviceMemberAddsPPMToHHG();
+    serviveMemberFillsInDatesAndLocations();
   });
 });
 
@@ -38,4 +40,28 @@ function serviceMemberCancelsAddPPMToHHG() {
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\//);
   });
+}
+
+function serviveMemberFillsInDatesAndLocations() {
+  cy.location().should(loc => {
+    expect(loc.pathname).to.match(/^\/moves\/[^/]+\/hhg-ppm-start/);
+  });
+
+  cy
+    .get('input[name="planned_move_date"]')
+    .first()
+    .type('9/2/2018{enter}')
+    .blur();
+
+  cy
+    .get('input[name="pickup_postal_code"]')
+    .clear()
+    .type('80913');
+
+  cy
+    .get('input[name="destination_postal_code"]')
+    .clear()
+    .type('76127');
+
+  cy.nextPage();
 }

--- a/cypress/integration/mymove/hhgPPM.js
+++ b/cypress/integration/mymove/hhgPPM.js
@@ -8,6 +8,7 @@ describe('service member adds a ppm to an hhg', function() {
     serviceMemberAddsPPMToHHG();
     serviveMemberFillsInDatesAndLocations();
     serviceMemberSelectsWeightRange();
+    serviceMemberCanCustomizeWeight();
   });
 });
 
@@ -74,6 +75,18 @@ function serviceMemberSelectsWeightRange() {
 
   //todo verify entitlement
   cy.contains('A trailer').click();
+
+  cy.nextPage();
+}
+
+function serviceMemberCanCustomizeWeight() {
+  cy.location().should(loc => {
+    expect(loc.pathname).to.match(/^\/moves\/[^/]+\/hhg-ppm-weight/);
+  });
+
+  cy.get('.rangeslider__handle').click();
+
+  cy.get('.incentive').contains('$');
 
   cy.nextPage();
 }

--- a/cypress/integration/mymove/hhgPPM.js
+++ b/cypress/integration/mymove/hhgPPM.js
@@ -7,6 +7,7 @@ describe('service member adds a ppm to an hhg', function() {
     serviceMemberCancelsAddPPMToHHG();
     serviceMemberAddsPPMToHHG();
     serviveMemberFillsInDatesAndLocations();
+    serviceMemberSelectsWeightRange();
   });
 });
 
@@ -62,6 +63,17 @@ function serviveMemberFillsInDatesAndLocations() {
     .get('input[name="destination_postal_code"]')
     .clear()
     .type('76127');
+
+  cy.nextPage();
+}
+
+function serviceMemberSelectsWeightRange() {
+  cy.location().should(loc => {
+    expect(loc.pathname).to.match(/^\/moves\/[^/]+\/hhg-ppm-size/);
+  });
+
+  //todo verify entitlement
+  cy.contains('A trailer').click();
 
   cy.nextPage();
 }

--- a/pkg/testdatagen/scenario/e2ebasic.go
+++ b/pkg/testdatagen/scenario/e2ebasic.go
@@ -1594,6 +1594,47 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, log
 	})
 	hhg28.Move.Submit()
 	models.SaveMoveDependencies(db, &hhg28.Move)
+
+	/*
+	 * Service member with uploaded orders and an approved shipment for adding a ppm
+	 */
+	email = "hhgforppm@award.ed"
+
+	offer29 := testdatagen.MakeShipmentOffer(db, testdatagen.Assertions{
+		User: models.User{
+			ID:            uuid.Must(uuid.FromString("f83bc69f-10aa-48b7-b9fe-425b393d49b8")),
+			LoginGovEmail: email,
+		},
+		ServiceMember: models.ServiceMember{
+			ID:            uuid.FromStringOrNil("234960a6-2ccb-4914-8092-db58fc5d1d89"),
+			FirstName:     models.StringPointer("HHG Ready"),
+			LastName:      models.StringPointer("For PPM"),
+			Edipi:         models.StringPointer("7777567890"),
+			PersonalEmail: models.StringPointer(email),
+		},
+		Move: models.Move{
+			ID:               uuid.FromStringOrNil("3a98bf2e-fcca-4832-953b-022d4dd3814d"),
+			Locator:          "COMBO1",
+			SelectedMoveType: &selectedMoveTypeHHG,
+		},
+		TrafficDistributionList: models.TrafficDistributionList{
+			ID:                uuid.FromStringOrNil("115f14f2-c982-4a54-a293-78935b61305d"),
+			SourceRateArea:    "US62",
+			DestinationRegion: "11",
+			CodeOfService:     "D",
+		},
+		Shipment: models.Shipment{
+			Status:             models.ShipmentStatusAWARDED,
+			HasDeliveryAddress: true,
+		},
+		ShipmentOffer: models.ShipmentOffer{
+			TransportationServiceProviderID: tspUser.TransportationServiceProviderID,
+		},
+	})
+
+	hhg29 := offer29.Shipment
+	hhg29.Move.Submit()
+	models.SaveMoveDependencies(db, &hhg29.Move)
 }
 
 // MakeHhgWithPpm creates an HHG user who has added a PPM


### PR DESCRIPTION
## Description

Add an e2e test for covering the flow for adding a ppm move to an existing hhg move. Just happy path for now. We can add additional scenarios as needed.

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/161962839) for this change
