### PR TITLE
changes to fix some Axe complaints in day picker about contrast

### DIFF
--- a/cypress/integration/mymove/shipment.js
+++ b/cypress/integration/mymove/shipment.js
@@ -52,7 +52,7 @@ describe('completing the hhg flow', function() {
           .get('[class=DayPicker-Day]')
           .first()
           .click()
-          .should('have.class', 'DayPicker-Day--selected');
+          .should('have.class', 'DayPicker-Day--pickup');
       });
 
     // Check for calendar move dates summary and color-coding of calendar.
@@ -205,7 +205,7 @@ describe('completing the hhg flow', function() {
       .get('.DayPicker-Day--transit[aria-disabled=false]') // pick the first transit day that is selectable
       .first()
       .click()
-      .should('have.class', 'DayPicker-Day--selected')
+      .should('have.class', 'DayPicker-Day--pickup')
       .invoke('attr', 'aria-label')
       .as('dateLabel');
 

--- a/src/scenes/Moves/Hhg/DatePicker.css
+++ b/src/scenes/Moves/Hhg/DatePicker.css
@@ -36,6 +36,7 @@ span.estimate {
 .DayPicker-Day--pickup {
   background-color: #0071bc;
   border-radius: 0;
+  color: white;
 }
 
 .DayPicker-Day--transit {

--- a/src/scenes/Moves/Hhg/DatePicker.css
+++ b/src/scenes/Moves/Hhg/DatePicker.css
@@ -19,9 +19,10 @@ th {
 }
 
 span.estimate {
-  color: gray;
+  color: #5b616b;
   margin-left: 0.5rem;
 }
+
 
 .DayPicker-Day:focus {
   outline: none;
@@ -33,7 +34,7 @@ span.estimate {
 }
 
 .DayPicker-Day--pickup {
-  background-color: #497abf;
+  background-color: #0071bc;
   border-radius: 0;
 }
 
@@ -54,6 +55,11 @@ span.estimate {
   background-color: #000000;
   border-radius: 0;
 }
+
+.DayPicker-Weekday {
+  color: #5b616b
+}
+
 
 .hhg-date-picker .instruction-heading {
   padding: 1rem 0 3rem;

--- a/src/scenes/Moves/Hhg/DatePicker.jsx
+++ b/src/scenes/Moves/Hhg/DatePicker.jsx
@@ -115,7 +115,6 @@ export class HHGDatePicker extends Component {
                 <DayPicker
                   onDayClick={this.handleDayClick}
                   month={parsedSelectedDay || (availableMoveDates && availableMoveDates.minDate)}
-                  selectedDays={parsedSelectedDay}
                   disabledDays={this.isDayDisabled}
                   modifiers={this.props.modifiers}
                   showOutsideDays


### PR DESCRIPTION
## Description

Axe Chrome plugin report several impact "serious" issues in the category "Elements must have sufficient color contrast". There are about 15 being reported. I used both the Axe website and the US Web Standards sites to get rid of the bulk of these issues. After making the changes to the CSS to correct the reported issues, the remaining issues are on average 5. These issues are complaining about the height of the text. (No longer complaining about the contrast). The message is the following: 
```
We are not sure this is an issue, because:

Element content is too short to determine if it is actual text content
```

## Reviewer Notes

There is also one "violation" being reported. The code that Axe is complaining about seems to be part of the Day Picker widget itself and I'm not sure if we can or should change it? It has to do with missing an aria role. I think this is a separate issue from the contrast and CSS fix that was intended for this story/PR. 

```
Issue description

Ensures elements with ARIA roles have all required ARIA attributes

Impact: critical
```

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

The changes are seen as part of the HHG move selection. Then enter the information needed until you get to the screen where you "Pick a moving date".

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](./docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](./docs/backend.md#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](./docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
* [ ] There are no aXe warnings for UI.
* [ ] This works in IE.
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @willowbl00
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/n/projects/2136865) for this change
* [this article 1](https://designsystem.digital.gov/components/colors/) explains more about the approach used. 
* [this article 2](https://dequeuniversity.com/rules/axe/3.1/color-contrast?application=AxeChrome) explains more about the approach used.
* I created a [Google Doc](https://docs.google.com/document/d/16JTHX4C8SmiLHkNAXrVzJYJSLXyGJHLewQhZcziZzXk/edit#) with more detailed information if anyone wants to see it. Just more comments and screenshots (nothing special)

## Screenshots

If this PR makes visible UI changes, an image of the finished UI can help reviewers and casual
observers understand the context of the changes. A before image is optional and
can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow instead of using multiple images. You may want to use GIPHY CAPTURE for this! 📸

_Please frame screenshots to show enough useful context but also highlight the affected regions._

### Before (1)
<img width="877" alt="screen shot 2018-11-16 at 11 11 24 am" src="https://user-images.githubusercontent.com/1359520/48639002-da80ae80-e997-11e8-8486-10088fb1a8dc.png">

### After (1)
<img width="846" alt="screen shot 2018-11-16 at 11 15 28 am" src="https://user-images.githubusercontent.com/1359520/48639023-eb312480-e997-11e8-855a-2515382577be.png">

### Before (2)
<img width="829" alt="screen shot 2018-11-16 at 10 37 26 am" src="https://user-images.githubusercontent.com/1359520/48639065-0f8d0100-e998-11e8-8290-d2be13839883.png">

### After (2)
<img width="836" alt="screen shot 2018-11-16 at 10 34 10 am" src="https://user-images.githubusercontent.com/1359520/48639058-0a2fb680-e998-11e8-8501-10f703b0b1ec.png">




