### PR TITLE
Fixed nil pointer bug in tariff data generation

### DIFF
--- a/pkg/testdatagen/make_shipment_offer_records.go
+++ b/pkg/testdatagen/make_shipment_offer_records.go
@@ -132,7 +132,7 @@ func CreateShipmentOfferData(db *pop.Connection, numTspUsers int, numShipments i
 		},
 	})
 
-	shouldCreateTariffData := false
+	var tariffDataShipment *models.Shipment
 	for i := 1; i <= numShipments; i++ {
 		// Service Member Details
 		smEmail := fmt.Sprintf("leo_spaceman_sm_%d@example.com", i)
@@ -209,7 +209,7 @@ func CreateShipmentOfferData(db *pop.Connection, numTspUsers int, numShipments i
 
 			shipment.NetWeight = shipment.WeightEstimate
 
-			shouldCreateTariffData = true
+			tariffDataShipment = &shipment
 		}
 
 		if shipmentStatus == models.ShipmentStatusDELIVERED {
@@ -287,8 +287,8 @@ func CreateShipmentOfferData(db *pop.Connection, numTspUsers int, numShipments i
 		}
 	}
 
-	if shouldCreateTariffData {
-		createTariffDataForRateEngine(db, shipmentList[0])
+	if tariffDataShipment != nil {
+		createTariffDataForRateEngine(db, *tariffDataShipment)
 	}
 
 	return tspUserList, shipmentList, shipmentOfferList, nil


### PR DESCRIPTION
## Description

This PR fixes a nil pointer bug in the tariff test data generation code merged in PR #1342.  Previously, tariff data was being created based on the first shipment (many can be generated here).  However, that first shipment may be in a state where no `ActualPickupDate` is set yet, but the tariff data generation expects it to be set (leading to the nil pointer bug).  I now ensure we use one of the in-transit or delivered shipments instead.

## Setup

Test 1: `make db_dev_reset && make db_dev_migrate && go run ./cmd/generate_test_data/main.go -scenario=7`
Test 2: `make server_test`
