### PR TITLE
Kma 161770407 add rate to shipment line items

### DIFF
--- a/migrations/20181116002353_add_applied_rate_to_shipment_line_items.up.fizz
+++ b/migrations/20181116002353_add_applied_rate_to_shipment_line_items.up.fizz
@@ -1,0 +1,1 @@
+add_column("shipment_line_items", "applied_rate", "integer", {"default": 0})

--- a/migrations/20181116002353_add_applied_rate_to_shipment_line_items.up.fizz
+++ b/migrations/20181116002353_add_applied_rate_to_shipment_line_items.up.fizz
@@ -1,1 +1,1 @@
-add_column("shipment_line_items", "applied_rate", "integer", {"default": 0})
+add_column("shipment_line_items", "applied_rate", "integer", {"null": true})

--- a/pkg/models/shipment_line_item.go
+++ b/pkg/models/shipment_line_item.go
@@ -51,6 +51,7 @@ type ShipmentLineItem struct {
 	Status        ShipmentLineItemStatus `json:"status" db:"status"`
 	InvoiceID     *uuid.UUID             `json:"invoice_id" db:"invoice_id"`
 	AmountCents   *unit.Cents            `json:"amount_cents" db:"amount_cents"`
+	AppliedRate   *unit.Cents            `json:"applied_rate" db:"applied_rate"`
 	SubmittedDate time.Time              `json:"submitted_date" db:"submitted_date"`
 	ApprovedDate  time.Time              `json:"approved_date" db:"approved_date"`
 	CreatedAt     time.Time              `json:"created_at" db:"created_at"`

--- a/pkg/testdatagen/make_shipment_line_items.go
+++ b/pkg/testdatagen/make_shipment_line_items.go
@@ -19,7 +19,8 @@ func MakeShipmentLineItem(db *pop.Connection, assertions Assertions) models.Ship
 	if isZeroUUID(tariff400ngItem.ID) {
 		tariff400ngItem = MakeTariff400ngItem(db, assertions)
 	}
-
+	var rate unit.Cents
+	rate = 2354
 	//filled in dummy data
 	shipmentLineItem := models.ShipmentLineItem{
 		ShipmentID:        shipment.ID,
@@ -29,6 +30,7 @@ func MakeShipmentLineItem(db *pop.Connection, assertions Assertions) models.Ship
 		Location:          models.ShipmentLineItemLocationDESTINATION,
 		Notes:             "Mounted deer head measures 23\" x 34\" x 27\"; crate will be 16.7 cu ft",
 		Quantity1:         unit.BaseQuantity(1670),
+		AppliedRate:       &rate,
 		Status:            models.ShipmentLineItemStatusSUBMITTED,
 		SubmittedDate:     time.Now(),
 		ApprovedDate:      time.Now(),

--- a/swagger/api.yaml
+++ b/swagger/api.yaml
@@ -254,6 +254,9 @@ definitions:
         description: 2nd Tariff400ngItem base quantity
         minimum: 0
         example: 10000
+      applied_rate:
+        type: integer
+        minimum: 0
       location:
         $ref: '#/definitions/ShipmentLineItemLocation'
       notes:


### PR DESCRIPTION
## Description

Adds "applied_rate" to the ShipmentLineItems table and model.  It defaults to value 0, following pattern of other attributes of ShipmentLineItems.  This refers to the actual rate that was applied to get quantity1, which includes the discount.

## Reviewer Notes

I added it to the swagger file, not sure if I should leave that to some other task.

## Code Review Verification Steps

* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](./docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/161770407) for this change
