### PR TITLE
Adds default values for DateAndLocation page for HHG/PPM move and tes…

### DIFF
--- a/cypress/integration/mymove/hhgPPM.js
+++ b/cypress/integration/mymove/hhgPPM.js
@@ -106,12 +106,12 @@ function serviceMemberCanReviewMoveSummary() {
   cy.get('.ppm-container').should($div => {
     const text = $div.text();
     expect(text).to.include('Shipment - You move your stuff (PPM)');
-    expect(text).to.include('Move Date: 09/02/2018');
+    expect(text).to.include('Move Date: 05/20/2018');
     expect(text).to.include('Pickup ZIP Code:  90210');
     expect(text).to.include('Delivery ZIP Code:  50309');
     expect(text).not.to.include('Storage: Not requested');
     expect(text).to.include('Estimated Weight:  1,50');
-    expect(text).to.include('Estimated PPM Incentive:  $2,032.89 - 2,246.87');
+    expect(text).to.include('Estimated PPM Incentive:  $4,255.80 - 4,703.78');
   });
 
   cy.nextPage();

--- a/cypress/integration/mymove/hhgPPM.js
+++ b/cypress/integration/mymove/hhgPPM.js
@@ -61,7 +61,7 @@ function serviceMemberFillsInDatesAndLocations() {
 
   cy
     .get('input[name="planned_move_date"]')
-    .should('have.value', '3/15/2018')
+    .should('have.value', '5/20/2018')
     .clear()
     .first()
     .type('9/2/2018{enter}')

--- a/cypress/integration/mymove/hhgPPM.js
+++ b/cypress/integration/mymove/hhgPPM.js
@@ -61,19 +61,15 @@ function serviveMemberFillsInDatesAndLocations() {
 
   cy
     .get('input[name="planned_move_date"]')
+    .should('have.value', '3/15/2018')
+    .clear()
     .first()
     .type('9/2/2018{enter}')
     .blur();
 
-  cy
-    .get('input[name="pickup_postal_code"]')
-    .clear()
-    .type('80913');
+  cy.get('input[name="pickup_postal_code"]').should('have.value', '80913');
 
-  cy
-    .get('input[name="destination_postal_code"]')
-    .clear()
-    .type('76127');
+  cy.get('input[name="destination_postal_code"]').should('have.value', '50309');
 
   cy.nextPage();
 }

--- a/cypress/integration/mymove/hhgPPM.js
+++ b/cypress/integration/mymove/hhgPPM.js
@@ -6,7 +6,7 @@ describe('service member adds a ppm to an hhg', function() {
     serviceMemberAddsPPMToHHG();
     serviceMemberCancelsAddPPMToHHG();
     serviceMemberContinuesPPMSetup();
-    serviveMemberFillsInDatesAndLocations();
+    serviceMemberFillsInDatesAndLocations();
     serviceMemberSelectsWeightRange();
     serviceMemberCanCustomizeWeight();
     serviceMemberCanReviewMoveSummary();
@@ -54,7 +54,7 @@ function serviceMemberContinuesPPMSetup() {
     .click();
 }
 
-function serviveMemberFillsInDatesAndLocations() {
+function serviceMemberFillsInDatesAndLocations() {
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/moves\/[^/]+\/hhg-ppm-start/);
   });
@@ -109,14 +109,13 @@ function serviceMemberCanReviewMoveSummary() {
     expect(text).to.include('Move Date: 09/02/2018');
     expect(text).to.include('Pickup ZIP Code:  90210');
     expect(text).to.include('Delivery ZIP Code:  50309');
-    expect(text).to.include('Storage: Not requested');
+    expect(text).not.to.include('Storage: Not requested');
     expect(text).to.include('Estimated Weight:  1,50');
     expect(text).to.include('Estimated PPM Incentive:  $2,032.89 - 2,246.87');
   });
 
   cy.nextPage();
 }
-
 function serviceMemberCanSignAgreement() {
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/moves\/[^/]+\/hhg-ppm-agreement/);

--- a/cypress/integration/mymove/hhgPPM.js
+++ b/cypress/integration/mymove/hhgPPM.js
@@ -67,7 +67,7 @@ function serviveMemberFillsInDatesAndLocations() {
     .type('9/2/2018{enter}')
     .blur();
 
-  cy.get('input[name="pickup_postal_code"]').should('have.value', '80913');
+  cy.get('input[name="pickup_postal_code"]').should('have.value', '90210');
 
   cy.get('input[name="destination_postal_code"]').should('have.value', '50309');
 
@@ -107,9 +107,9 @@ function serviceMemberCanReviewMoveSummary() {
     const text = $div.text();
     expect(text).to.include('Shipment - You move your stuff (PPM)');
     expect(text).to.include('Move Date: 09/02/2018');
-    expect(text).to.include('Pickup ZIP Code:  80913');
-    expect(text).to.include('Delivery ZIP Code:  76127');
-    expect(text).not.to.include('Storage: Not requested');
+    expect(text).to.include('Pickup ZIP Code:  90210');
+    expect(text).to.include('Delivery ZIP Code:  50309');
+    expect(text).to.include('Storage: Not requested');
     expect(text).to.include('Estimated Weight:  1,50');
     expect(text).to.include('Estimated PPM Incentive:  $2,032.89 - 2,246.87');
   });

--- a/pkg/testdatagen/scenario/e2ebasic.go
+++ b/pkg/testdatagen/scenario/e2ebasic.go
@@ -1663,6 +1663,9 @@ func MakeHhgWithPpm(db *pop.Connection, tspUser models.TspUser, loader *uploader
 			Edipi:         models.StringPointer("4224567890"),
 			PersonalEmail: models.StringPointer(email),
 		},
+		Order: models.Order{
+			IssueDate: time.Date(2018, time.May, 20, 0, 0, 0, 0, time.UTC),
+		},
 		Move: models.Move{
 			ID:               moveID,
 			Locator:          "HHGPPM",

--- a/pkg/testdatagen/scenario/e2ebasic.go
+++ b/pkg/testdatagen/scenario/e2ebasic.go
@@ -1624,6 +1624,9 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, log
 			Locator:          "COMBO1",
 			SelectedMoveType: &selectedMoveTypeHHG,
 		},
+		Order: models.Order{
+			IssueDate: time.Date(2018, time.May, 20, 0, 0, 0, 0, time.UTC),
+		},
 		TrafficDistributionList: models.TrafficDistributionList{
 			ID:                uuid.FromStringOrNil("115f14f2-c982-4a54-a293-78935b61305d"),
 			SourceRateArea:    "US62",

--- a/src/scenes/Moves/Ppm/DateAndLocation.jsx
+++ b/src/scenes/Moves/Ppm/DateAndLocation.jsx
@@ -5,7 +5,7 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { getFormValues } from 'redux-form';
 import YesNoBoolean from 'shared/Inputs/YesNoBoolean';
-import { createOrUpdatePpm, getDestinationPostalCode, getPpmSitEstimate } from './ducks';
+import { createOrUpdatePpm, getDestinationPostalCode, getPpmSitEstimate, setInitialFormValues } from './ducks';
 import { reduxifyWizardForm } from 'shared/WizardPage/Form';
 import { SwaggerField } from 'shared/JsonSchemaForm/JsonSchemaField';
 import { loadEntitlementsFromState } from 'shared/entitlements';
@@ -18,6 +18,13 @@ const DateAndLocationWizardForm = reduxifyWizardForm(formName);
 
 export class DateAndLocation extends Component {
   state = { showInfo: false };
+
+  componentDidMount() {
+    if (!this.props.currentPpm) {
+      const { plannedMoveDate, pickupPostalCode, destinationPostalCode } = this.props.defaultValues;
+      this.props.setInitialFormValues(plannedMoveDate, pickupPostalCode, destinationPostalCode);
+    }
+  }
 
   openInfo = () => {
     this.setState({ showInfo: true });
@@ -197,11 +204,11 @@ function mapStateToProps(state) {
       : null;
 
   if (props.isHHGPPMComboMove) {
-    props.initialValues = {
-      ...props.initialValues,
-      planned_move_date: currentOrders.issue_date,
+    props.defaultValues = {
+      pickupPostalCode: defaultPickupZip,
+      plannedMoveDate: currentOrders.issue_date,
       // defaults to SM's destination address, if none, uses destination duty station zip
-      destination_postal_code: getDestinationPostalCode(state),
+      destinationPostalCode: getDestinationPostalCode(state),
     };
   }
 
@@ -209,7 +216,7 @@ function mapStateToProps(state) {
 }
 
 function mapDispatchToProps(dispatch) {
-  return bindActionCreators({ createOrUpdatePpm, getPpmSitEstimate }, dispatch);
+  return bindActionCreators({ createOrUpdatePpm, getPpmSitEstimate, setInitialFormValues }, dispatch);
 }
 
 export default connect(mapStateToProps, mapDispatchToProps)(DateAndLocation);

--- a/src/scenes/Moves/Ppm/DateAndLocation.jsx
+++ b/src/scenes/Moves/Ppm/DateAndLocation.jsx
@@ -199,17 +199,19 @@ function mapStateToProps(state) {
       : null;
 
   const currentShipment = selectShipment(state, getCurrentShipmentID(state));
-  props.isHHGPPMComboMove
-    ? (props.initialValues = {
-        ...props.initialValues,
-        planned_move_date: currentOrders.issue_date,
-        // defaults to SM's destination address, if none, uses destination duty station zip
-        destination_postal_code:
-          currentShipment.has_delivery_address && state.entities.addresses
-            ? state.entities.addresses[currentShipment.delivery_address].postal_code
-            : currentOrders.new_duty_station.address.postal_code,
-      })
-    : null;
+  const addresses = state.entities.addresses;
+
+  if (props.isHHGPPMComboMove) {
+    props.initialValues = {
+      ...props.initialValues,
+      planned_move_date: currentOrders.issue_date,
+      // defaults to SM's destination address, if none, uses destination duty station zip
+      destination_postal_code:
+        currentShipment.has_delivery_address && addresses
+          ? addresses[currentShipment.delivery_address].postal_code
+          : currentOrders.new_duty_station.address.postal_code,
+    };
+  }
 
   return props;
 }

--- a/src/scenes/Moves/Ppm/DateAndLocation.jsx
+++ b/src/scenes/Moves/Ppm/DateAndLocation.jsx
@@ -5,13 +5,11 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { getFormValues } from 'redux-form';
 import YesNoBoolean from 'shared/Inputs/YesNoBoolean';
-import { createOrUpdatePpm, getPpmSitEstimate } from './ducks';
+import { createOrUpdatePpm, getDestinationPostalCode, getPpmSitEstimate } from './ducks';
 import { reduxifyWizardForm } from 'shared/WizardPage/Form';
 import { SwaggerField } from 'shared/JsonSchemaForm/JsonSchemaField';
 import { loadEntitlementsFromState } from 'shared/entitlements';
 import Alert from 'shared/Alert';
-import { selectShipment } from 'shared/Entities/modules/shipments';
-import { getCurrentShipmentID } from 'shared/UI/ducks';
 import './DateAndLocation.css';
 
 const sitEstimateDebounceTime = 300;
@@ -198,23 +196,18 @@ function mapStateToProps(state) {
         }
       : null;
 
-  const currentShipment = selectShipment(state, getCurrentShipmentID(state));
-  const addresses = state.entities.addresses;
-
   if (props.isHHGPPMComboMove) {
     props.initialValues = {
       ...props.initialValues,
       planned_move_date: currentOrders.issue_date,
       // defaults to SM's destination address, if none, uses destination duty station zip
-      destination_postal_code:
-        currentShipment.has_delivery_address && addresses
-          ? addresses[currentShipment.delivery_address].postal_code
-          : currentOrders.new_duty_station.address.postal_code,
+      destination_postal_code: getDestinationPostalCode(state),
     };
   }
 
   return props;
 }
+
 function mapDispatchToProps(dispatch) {
   return bindActionCreators({ createOrUpdatePpm, getPpmSitEstimate }, dispatch);
 }

--- a/src/scenes/Moves/Ppm/DateAndLocation.jsx
+++ b/src/scenes/Moves/Ppm/DateAndLocation.jsx
@@ -20,7 +20,7 @@ export class DateAndLocation extends Component {
   state = { showInfo: false };
 
   componentDidMount() {
-    if (!this.props.currentPpm) {
+    if (!this.props.currentPpm && this.props.isHHGPPMComboMove) {
       const { plannedMoveDate, pickupPostalCode, destinationPostalCode } = this.props.defaultValues;
       this.props.setInitialFormValues(plannedMoveDate, pickupPostalCode, destinationPostalCode);
     }

--- a/src/scenes/Moves/Ppm/ducks.js
+++ b/src/scenes/Moves/Ppm/ducks.js
@@ -7,6 +7,7 @@ import { loadEntitlementsFromState } from 'shared/entitlements';
 import { formatCents } from 'shared/formatters';
 import { selectShipment } from 'shared/Entities/modules/shipments';
 import { getCurrentShipmentID } from 'shared/UI/ducks';
+import { change } from 'redux-form';
 
 // Types
 export const SET_PENDING_PPM_SIZE = 'SET_PENDING_PPM_SIZE';
@@ -69,6 +70,14 @@ export function createOrUpdatePpm(moveId, ppm) {
         .then(item => dispatch(action.success(item)))
         .catch(error => dispatch(action.error(error)));
     }
+  };
+}
+
+export function setInitialFormValues(plannedMoveDate, pickupPostalCode, destinationPostalCode) {
+  return function(dispatch) {
+    dispatch(change('ppp_date_and_location', 'planned_move_date', plannedMoveDate));
+    dispatch(change('ppp_date_and_location', 'pickup_postal_code', pickupPostalCode));
+    dispatch(change('ppp_date_and_location', 'destination_postal_code', destinationPostalCode));
   };
 }
 

--- a/src/scenes/Moves/Ppm/ducks.js
+++ b/src/scenes/Moves/Ppm/ducks.js
@@ -5,6 +5,8 @@ import { GET_LOGGED_IN_USER } from 'shared/User/ducks';
 import { fetchActive } from 'shared/utils';
 import { loadEntitlementsFromState } from 'shared/entitlements';
 import { formatCents } from 'shared/formatters';
+import { selectShipment } from 'shared/Entities/modules/shipments';
+import { getCurrentShipmentID } from 'shared/UI/ducks';
 
 // Types
 export const SET_PENDING_PPM_SIZE = 'SET_PENDING_PPM_SIZE';
@@ -149,6 +151,16 @@ export function getSelectedWeightInfo(state) {
 
   const size = ppm ? ppm.size : 'L';
   return weightInfo[size]; // eslint-disable-line security/detect-object-injection
+}
+
+export function getDestinationPostalCode(state) {
+  const currentShipment = selectShipment(state, getCurrentShipmentID(state));
+  const addresses = state.entities.addresses;
+  const currentOrders = state.orders.currentOrders;
+
+  return currentShipment.has_delivery_address && addresses
+    ? addresses[currentShipment.delivery_address].postal_code
+    : currentOrders.new_duty_station.address.postal_code;
 }
 
 // Reducer


### PR DESCRIPTION
## Description

This PR updates the Add Date and Location page for **_HHG/PPM combo_** by adding default values to the page upon initial load. 

## Reviewer Notes

Currently, test is failing given `/^\/moves\/[^/]+\/hhg-ppm-size/` has been implemented before `/^\/moves\/[^/]+\/hhg-ppm-weight/`. Once [feature](https://www.pivotaltracker.com/story/show/162018003) has been implemented, the test will be passing. 

## Setup

1. `make server_run`
2. `make client_run`
3. Complete HHG + PPM combo move flow

## Code Review Verification Steps
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/161767800) for this change
