### PR TITLE
Prices shipment line items when shipment is delivered [delivers #161269448]

### DIFF
--- a/pkg/handlers/internalapi/shipments_test.go
+++ b/pkg/handlers/internalapi/shipments_test.go
@@ -31,7 +31,7 @@ func (suite *HandlerSuite) TestCreateShipmentHandlerAllValues() {
 	sm := move.Orders.ServiceMember
 
 	// Make associated lookup table records.
-	testdatagen.MakeTariff400ngZip3(suite.TestDB(), testdatagen.Assertions{
+	testdatagen.FetchOrMakeTariff400ngZip3(suite.TestDB(), testdatagen.Assertions{
 		Tariff400ngZip3: models.Tariff400ngZip3{
 			Zip3:          "012",
 			BasepointCity: "Pittsfield",
@@ -194,7 +194,7 @@ func (suite *HandlerSuite) TestPatchShipmentsHandlerHappyPath() {
 	req = suite.AuthenticateRequest(req, sm)
 
 	// Make associated lookup table records.
-	testdatagen.MakeTariff400ngZip3(suite.TestDB(), testdatagen.Assertions{
+	testdatagen.FetchOrMakeTariff400ngZip3(suite.TestDB(), testdatagen.Assertions{
 		Tariff400ngZip3: models.Tariff400ngZip3{
 			Zip3:          "321",
 			BasepointCity: "Crescent City",

--- a/pkg/handlers/publicapi/shipment_line_items.go
+++ b/pkg/handlers/publicapi/shipment_line_items.go
@@ -31,6 +31,12 @@ func payloadForShipmentLineItemModel(s *models.ShipmentLineItem) *apimessages.Sh
 		return nil
 	}
 
+	var amt *int64
+	if s.AmountCents != nil {
+		int := s.AmountCents.Int64()
+		amt = &int
+	}
+
 	return &apimessages.ShipmentLineItem{
 		ID:                *handlers.FmtUUID(s.ID),
 		ShipmentID:        *handlers.FmtUUID(s.ShipmentID),
@@ -41,6 +47,7 @@ func payloadForShipmentLineItemModel(s *models.ShipmentLineItem) *apimessages.Sh
 		Quantity1:         handlers.FmtInt64(int64(s.Quantity1)),
 		Quantity2:         handlers.FmtInt64(int64(s.Quantity2)),
 		Status:            apimessages.ShipmentLineItemStatus(s.Status),
+		AmountCents:       amt,
 		SubmittedDate:     *handlers.FmtDateTime(s.SubmittedDate),
 		ApprovedDate:      *handlers.FmtDateTime(s.ApprovedDate),
 	}

--- a/pkg/models/shipment_line_item.go
+++ b/pkg/models/shipment_line_item.go
@@ -77,6 +77,27 @@ func FetchLineItemsByShipmentID(dbConnection *pop.Connection, shipmentID *uuid.U
 	return shipmentLineItems, err
 }
 
+// FetchApprovedPreapprovalRequestsByShipment fetches approved pre-approval requests for a shipment
+func FetchApprovedPreapprovalRequestsByShipment(dbConnection *pop.Connection, shipment Shipment) ([]ShipmentLineItem, error) {
+	var items []ShipmentLineItem
+
+	query := dbConnection.Q().
+		LeftJoin("tariff400ng_items", "shipment_line_items.tariff400ng_item_id=tariff400ng_items.id").
+		Where("shipment_id = ?", shipment.ID).
+		Where("status = ?", ShipmentLineItemStatusAPPROVED).
+		Where("tariff400ng_items.requires_pre_approval = true").
+		Eager("Tariff400ngItem")
+
+	err := query.All(&items)
+
+	// Add the shipment model
+	for _, item := range items {
+		item.Shipment = shipment
+	}
+
+	return items, err
+}
+
 // FetchShipmentLineItemByID returns a shipment line item by id
 func FetchShipmentLineItemByID(dbConnection *pop.Connection, shipmentLineItemID *uuid.UUID) (ShipmentLineItem, error) {
 	var err error

--- a/pkg/models/tariff400ng_item_rate_test.go
+++ b/pkg/models/tariff400ng_item_rate_test.go
@@ -1,8 +1,6 @@
 package models_test
 
 import (
-	"time"
-
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"
 	"github.com/transcom/mymove/pkg/unit"
@@ -32,7 +30,7 @@ func (suite *ModelSuite) TestFetchTariff400ngItemRateBySchedule() {
 		},
 	})
 
-	rate, err := models.FetchTariff400ngItemRate(suite.db, rate2.Code, *rate2.Schedule, 1000, time.Date(2018, time.August, 15, 0, 0, 0, 0, time.UTC))
+	rate, err := models.FetchTariff400ngItemRate(suite.db, rate2.Code, *rate2.Schedule, 1000, testdatagen.DateInsidePeakRateCycle)
 
 	// Ensure we get back rate2's rate and not one for a different schedule
 	if suite.NoError(err) {
@@ -48,7 +46,7 @@ func (suite *ModelSuite) TestFetchTariff400ngItemRateNullSchedule() {
 		},
 	})
 
-	rate, err := models.FetchTariff400ngItemRate(suite.db, rate1.Code, 3, 1000, time.Date(2018, time.August, 15, 0, 0, 0, 0, time.UTC))
+	rate, err := models.FetchTariff400ngItemRate(suite.db, rate1.Code, 3, 1000, testdatagen.DateInsidePeakRateCycle)
 
 	// Ensure we get back rate1's rate
 	if suite.NoError(err) {
@@ -87,7 +85,7 @@ func (suite *ModelSuite) TestFetchTariff400ngItemRateByWeight() {
 		},
 	})
 
-	rate, err := models.FetchTariff400ngItemRate(suite.db, rate2.Code, 2, 1150, time.Date(2018, time.August, 15, 0, 0, 0, 0, time.UTC))
+	rate, err := models.FetchTariff400ngItemRate(suite.db, rate2.Code, 2, 1150, testdatagen.DateInsidePeakRateCycle)
 
 	// Ensure we get back rate2's rate and not one for a different weight range
 	if suite.NoError(err) {

--- a/pkg/models/tariff400ng_service_area.go
+++ b/pkg/models/tariff400ng_service_area.go
@@ -65,7 +65,7 @@ func FetchTariff400ngServiceAreaForZip3(tx *pop.Connection, zip3 string, date ti
 			`
 	err := tx.RawQuery(sql, zip3, date).First(&serviceArea)
 	if err != nil {
-		return serviceArea, errors.Wrapf(err, "could not find a matching Tariff400ngServiceArea for zip3 %s", zip3)
+		return serviceArea, errors.Wrapf(err, "could not find a matching Tariff400ngServiceArea for zip3 %s and date %v", zip3, date)
 	}
 	return serviceArea, nil
 }

--- a/pkg/rateengine/accessorials_test.go
+++ b/pkg/rateengine/accessorials_test.go
@@ -27,8 +27,8 @@ func (suite *RateEngineSuite) createShipmentWithServiceArea(assertions testdatag
 		LinehaulFactor:     57,
 		ServiceChargeCents: 350,
 		ServicesSchedule:   1,
-		EffectiveDateLower: testdatagen.Tariff400ngItemRateEffectiveDateLower,
-		EffectiveDateUpper: testdatagen.Tariff400ngItemRateEffectiveDateUpper,
+		EffectiveDateLower: testdatagen.PeakRateCycleStart,
+		EffectiveDateUpper: testdatagen.NonPeakRateCycleEnd,
 		SIT185ARateCents:   unit.Cents(50),
 		SIT185BRateCents:   unit.Cents(50),
 		SITPDSchedule:      1,
@@ -44,7 +44,7 @@ func (suite *RateEngineSuite) TestAccessorialsPricingPackCrate() {
 	netWeight := unit.Pound(1000)
 	shipment := suite.createShipmentWithServiceArea(testdatagen.Assertions{
 		Shipment: models.Shipment{
-			BookDate:  &testdatagen.Tariff400ngItemRateDefaultValidDate,
+			BookDate:  &testdatagen.DateInsidePeakRateCycle,
 			NetWeight: &netWeight,
 		},
 	})
@@ -69,7 +69,7 @@ func (suite *RateEngineSuite) TestAccessorialsPricingPackCrate() {
 	})
 
 	engine := NewRateEngine(suite.db, suite.logger, suite.planner)
-	computedPrice, err := engine.ComputeShipmentLineItemCharge(item, item.Shipment)
+	computedPrice, err := engine.ComputeShipmentLineItemCharge(item)
 
 	if suite.NoError(err) {
 		suite.Equal(rateCents.Multiply(5), computedPrice)
@@ -82,7 +82,7 @@ func (suite *RateEngineSuite) TestAccessorialsSmokeTest() {
 	netWeight := unit.Pound(1000)
 	shipment := suite.createShipmentWithServiceArea(testdatagen.Assertions{
 		Shipment: models.Shipment{
-			BookDate:  &testdatagen.Tariff400ngItemRateDefaultValidDate,
+			BookDate:  &testdatagen.DateInsidePeakRateCycle,
 			NetWeight: &netWeight,
 		},
 	})
@@ -114,7 +114,7 @@ func (suite *RateEngineSuite) TestAccessorialsSmokeTest() {
 		})
 
 		engine := NewRateEngine(suite.db, suite.logger, suite.planner)
-		_, err := engine.ComputeShipmentLineItemCharge(item, item.Shipment)
+		_, err := engine.ComputeShipmentLineItemCharge(item)
 
 		// Make sure we don't error
 		if !suite.NoError(err) {

--- a/pkg/testdatagen/constants.go
+++ b/pkg/testdatagen/constants.go
@@ -7,6 +7,9 @@ import (
 // TestYear is the default year for testing.
 var TestYear = 2019
 
+// DefaultZip3 is the default zip3 for testing
+var DefaultZip3 = "902"
+
 // DefaultSrcGBLOC is the default GBLOC for testing.
 var DefaultSrcGBLOC = "KKFA"
 

--- a/pkg/testdatagen/make_address.go
+++ b/pkg/testdatagen/make_address.go
@@ -67,7 +67,7 @@ func MakeAddress3(db *pop.Connection, assertions Assertions) models.Address {
 // MakeDefaultAddress makes an Address with default values
 func MakeDefaultAddress(db *pop.Connection) models.Address {
 	// Make associated lookup table records.
-	MakeDefaultTariff400ngZip3(db)
+	FetchOrMakeDefaultTariff400ngZip3(db)
 
 	return MakeAddress(db, Assertions{})
 }

--- a/pkg/testdatagen/make_duty_station.go
+++ b/pkg/testdatagen/make_duty_station.go
@@ -20,8 +20,8 @@ func MakeDutyStation(db *pop.Connection, assertions Assertions) models.DutyStati
 		address = MakeAddress3(db, assertions)
 
 		// Make the required Tariff 400 NG Zip3 to correspond with the duty station address
-		MakeDefaultTariff400ngZip3(db)
-		MakeTariff400ngZip3(db, Assertions{
+		FetchOrMakeDefaultTariff400ngZip3(db)
+		FetchOrMakeTariff400ngZip3(db, Assertions{
 			Tariff400ngZip3: models.Tariff400ngZip3{
 				Zip3:          "503",
 				BasepointCity: "Des Moines",

--- a/pkg/testdatagen/make_shipment_line_items.go
+++ b/pkg/testdatagen/make_shipment_line_items.go
@@ -1,6 +1,7 @@
 package testdatagen
 
 import (
+	"log"
 	"time"
 
 	"github.com/gobuffalo/pop"
@@ -47,4 +48,37 @@ func MakeShipmentLineItem(db *pop.Connection, assertions Assertions) models.Ship
 // MakeDefaultShipmentLineItem makes a shipment line item with default values
 func MakeDefaultShipmentLineItem(db *pop.Connection) models.ShipmentLineItem {
 	return MakeShipmentLineItem(db, Assertions{})
+}
+
+// MakeCompleteShipmentLineItem makes a shipmentLineItem with all dependencies that "just works"
+func MakeCompleteShipmentLineItem(db *pop.Connection, assertions Assertions) models.ShipmentLineItem {
+	// First we need a shipment that has proper zip3, serviceArea, etc. set up
+	shipment := assertions.ShipmentLineItem.Shipment
+	if isZeroUUID(shipment.ID) {
+		var err error
+		shipment, err = MakeShipmentForPricing(db, assertions)
+		if err != nil {
+			log.Panic(err)
+		}
+		assertions.ShipmentLineItem.Shipment = shipment
+		assertions.ShipmentLineItem.ShipmentID = shipment.ID
+	}
+
+	// Then we need a 400ng item
+	tariff400ngItem := assertions.ShipmentLineItem.Tariff400ngItem
+	if isZeroUUID(tariff400ngItem.ID) {
+		tariff400ngItem = MakeTariff400ngItem(db, assertions)
+
+		assertions.ShipmentLineItem.Tariff400ngItem = tariff400ngItem
+		assertions.ShipmentLineItem.Tariff400ngItemID = tariff400ngItem.ID
+	}
+
+	// And lastly we need a valid rate for the item code
+	rateAssertions := assertions
+	rateAssertions.Tariff400ngItemRate = models.Tariff400ngItemRate{
+		Code: tariff400ngItem.Code,
+	}
+	MakeTariff400ngItemRate(db, rateAssertions)
+
+	return MakeShipmentLineItem(db, assertions)
 }

--- a/pkg/testdatagen/make_tariff400ng_item_rate.go
+++ b/pkg/testdatagen/make_tariff400ng_item_rate.go
@@ -1,21 +1,10 @@
 package testdatagen
 
 import (
-	"time"
-
 	"github.com/gobuffalo/pop"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/unit"
 )
-
-// Tariff400ngItemRateDefaultValidDate provides a date for which default item rates will be valid
-var Tariff400ngItemRateDefaultValidDate = time.Date(2018, time.August, 15, 0, 0, 0, 0, time.UTC)
-
-// Tariff400ngItemRateEffectiveDateLower provides a standard lower date
-var Tariff400ngItemRateEffectiveDateLower = time.Date(2018, time.March, 15, 0, 0, 0, 0, time.UTC)
-
-// Tariff400ngItemRateEffectiveDateUpper provides a standard upper date
-var Tariff400ngItemRateEffectiveDateUpper = time.Date(2019, time.March, 15, 0, 0, 0, 0, time.UTC)
 
 // MakeTariff400ngItemRate creates a single Tariff400ngItemRate record
 func MakeTariff400ngItemRate(db *pop.Connection, assertions Assertions) models.Tariff400ngItemRate {
@@ -25,8 +14,8 @@ func MakeTariff400ngItemRate(db *pop.Connection, assertions Assertions) models.T
 		WeightLbsLower:     unit.Pound(0),
 		WeightLbsUpper:     unit.Pound(2147483647),
 		RateCents:          unit.Cents(1000),
-		EffectiveDateLower: Tariff400ngItemRateEffectiveDateLower,
-		EffectiveDateUpper: Tariff400ngItemRateEffectiveDateUpper,
+		EffectiveDateLower: PeakRateCycleStart,
+		EffectiveDateUpper: NonPeakRateCycleEnd,
 	}
 
 	// Overwrite values with those from assertions

--- a/pkg/testdatagen/make_tariff400ng_service_area.go
+++ b/pkg/testdatagen/make_tariff400ng_service_area.go
@@ -1,0 +1,64 @@
+package testdatagen
+
+import (
+	"github.com/gobuffalo/pop"
+
+	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/unit"
+)
+
+// MakeTariff400ngServiceArea finds or makes a single service_area record
+func MakeTariff400ngServiceArea(db *pop.Connection, assertions Assertions) models.Tariff400ngServiceArea {
+	serviceArea := models.Tariff400ngServiceArea{
+		Name:               "Gulfport, MS",
+		ServiceArea:        DefaultServiceArea,
+		LinehaulFactor:     57,
+		ServiceChargeCents: 350,
+		ServicesSchedule:   1,
+		EffectiveDateLower: PeakRateCycleStart,
+		EffectiveDateUpper: NonPeakRateCycleEnd,
+		SIT185ARateCents:   unit.Cents(50),
+		SIT185BRateCents:   unit.Cents(50),
+		SITPDSchedule:      1,
+	}
+
+	mergeModels(&serviceArea, assertions.Tariff400ngServiceArea)
+
+	mustCreate(db, &serviceArea)
+
+	return serviceArea
+}
+
+// MakeDefaultTariff400ngServiceArea makes a ServiceArea with default values
+func MakeDefaultTariff400ngServiceArea(db *pop.Connection) models.Tariff400ngServiceArea {
+	return MakeTariff400ngServiceArea(db, Assertions{})
+}
+
+// GeoModelReturn contains origin and destination zip3 and service area models
+type GeoModelReturn struct {
+	originZip3        models.Tariff400ngZip3
+	destZip3          models.Tariff400ngZip3
+	originServiceArea models.Tariff400ngServiceArea
+	destServiceArea   models.Tariff400ngServiceArea
+}
+
+// MakeTariff400ngGeoModelsForShipment makes zip3 and service area records for a shipment's origin and destination addresses
+func MakeTariff400ngGeoModelsForShipment(db *pop.Connection, shipment models.Shipment) GeoModelReturn {
+	var result GeoModelReturn
+
+	originAddress := shipment.PickupAddress
+	originAssertions := Assertions{}
+	originAssertions.Tariff400ngZip3.Zip3 = zip5ToZip3(originAddress.PostalCode)
+	result.originZip3 = FetchOrMakeTariff400ngZip3(db, originAssertions)
+	originAssertions.Tariff400ngServiceArea.ServiceArea = result.originZip3.ServiceArea
+	result.originServiceArea = MakeTariff400ngServiceArea(db, originAssertions)
+
+	destAddress := shipment.Move.Orders.NewDutyStation.Address
+	destAssertions := Assertions{}
+	destAssertions.Tariff400ngZip3.Zip3 = zip5ToZip3(destAddress.PostalCode)
+	result.destZip3 = FetchOrMakeTariff400ngZip3(db, destAssertions)
+	destAssertions.Tariff400ngServiceArea.ServiceArea = result.destZip3.ServiceArea
+	result.destServiceArea = MakeTariff400ngServiceArea(db, destAssertions)
+
+	return result
+}

--- a/pkg/testdatagen/make_tariff400ng_zip3_records.go
+++ b/pkg/testdatagen/make_tariff400ng_zip3_records.go
@@ -1,15 +1,17 @@
 package testdatagen
 
 import (
+	"database/sql"
+	"log"
+
 	"github.com/gobuffalo/pop"
 	"github.com/transcom/mymove/pkg/models"
-	"log"
 )
 
 // MakeTariff400ngZip3 finds or makes a single Tariff400ngZip3 record
 func MakeTariff400ngZip3(db *pop.Connection, assertions Assertions) models.Tariff400ngZip3 {
 	zip3 := models.Tariff400ngZip3{
-		Zip3:          "902",
+		Zip3:          DefaultZip3,
 		BasepointCity: "Beverly Hills",
 		State:         "CA",
 		ServiceArea:   "56",
@@ -19,21 +21,31 @@ func MakeTariff400ngZip3(db *pop.Connection, assertions Assertions) models.Tarif
 
 	mergeModels(&zip3, assertions.Tariff400ngZip3)
 
-	var zip3s models.Tariff400ngZip3s
-	err := db.Where("zip3 = ?", zip3.Zip3).All(&zip3s)
-	if err != nil {
+	mustCreate(db, &zip3)
+
+	return zip3
+}
+
+// FetchOrMakeTariff400ngZip3 Tries fetching an existing zip3 first, then falls back to creating one
+func FetchOrMakeTariff400ngZip3(db *pop.Connection, assertions Assertions) models.Tariff400ngZip3 {
+	var existingZip3s models.Tariff400ngZip3s
+	zip3 := DefaultZip3
+	if assertions.Tariff400ngZip3.Zip3 != "" {
+		zip3 = assertions.Tariff400ngZip3.Zip3
+	}
+	err := db.Where("zip3 = ?", zip3).All(&existingZip3s)
+	if err != nil && err != sql.ErrNoRows {
 		log.Panic(err)
 	}
 
-	if len(zip3s) == 0 {
-		mustCreate(db, &zip3)
-		return zip3
+	if len(existingZip3s) == 0 {
+		return MakeTariff400ngZip3(db, assertions)
 	}
 
-	return zip3s[0]
+	return existingZip3s[0]
 }
 
-// MakeDefaultTariff400ngZip3 makes a Tariff400ngZip3 record with default values
-func MakeDefaultTariff400ngZip3(db *pop.Connection) models.Tariff400ngZip3 {
-	return MakeTariff400ngZip3(db, Assertions{})
+// FetchOrMakeDefaultTariff400ngZip3 makes a Tariff400ngZip3 record with default values
+func FetchOrMakeDefaultTariff400ngZip3(db *pop.Connection) models.Tariff400ngZip3 {
+	return FetchOrMakeTariff400ngZip3(db, Assertions{})
 }

--- a/pkg/testdatagen/scenario/e2ebasic.go
+++ b/pkg/testdatagen/scenario/e2ebasic.go
@@ -353,7 +353,7 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, log
 	 */
 	email = "hhg@incomple.te"
 
-	hhg0 := testdatagen.MakeShipment(db, testdatagen.Assertions{
+	hhg0, err := testdatagen.MakeShipmentForPricing(db, testdatagen.Assertions{
 		User: models.User{
 			ID:            uuid.Must(uuid.FromString("ebc176e0-bb34-47d4-ba37-ff13e2dd40b9")),
 			LoginGovEmail: email,
@@ -377,6 +377,9 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, log
 			CodeOfService:     "D",
 		},
 	})
+	if err != nil {
+		log.Panic(err)
+	}
 
 	hhg0.Move.Submit()
 	models.SaveMoveDependencies(db, &hhg0.Move)

--- a/pkg/testdatagen/shared.go
+++ b/pkg/testdatagen/shared.go
@@ -37,6 +37,7 @@ type Assertions struct {
 	Shipment                                 models.Shipment
 	ShipmentLineItem                         models.ShipmentLineItem
 	ShipmentOffer                            models.ShipmentOffer
+	Tariff400ngServiceArea                   models.Tariff400ngServiceArea
 	Tariff400ngItem                          models.Tariff400ngItem
 	Tariff400ngItemRate                      models.Tariff400ngItemRate
 	Tariff400ngZip3                          models.Tariff400ngZip3
@@ -90,6 +91,11 @@ func noErr(err error) {
 	if err != nil {
 		log.Panic(fmt.Errorf("Error encountered: %v", err))
 	}
+}
+
+// zip5ToZip3 takes a ZIP5 string and returns the ZIP3 representation of it.
+func zip5ToZip3(zip5 string) string {
+	return zip5[0:3]
 }
 
 // isZeroUUID determines whether a UUID is its zero value

--- a/swagger/api.yaml
+++ b/swagger/api.yaml
@@ -263,6 +263,13 @@ definitions:
         example: Mounted deer head measures 23" x 34" x 27"; crate will be 16.7 cu ft
       status:
         $ref: '#/definitions/ShipmentLineItemStatus'
+      amount_cents:
+        type: integer
+        format: cents
+        minimum: 1
+        title: Amount
+        description: unit is cents
+        x-nullable: true
       submitted_date:
         type: string
         title: Submitted Date


### PR DESCRIPTION
## Description

We recently decided that pre-approval requests should have their pricing calculated when a shipment is delivered. This is for a couple reasons: a number of the 400ng items depend on the final shipment weight, and we don't actually show invoice line items until a shipment is delivered anyway. This PR does that and more!

- 

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](./docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](./docs/backend.md#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](./docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
* [ ] There are no aXe warnings for UI.
* [ ] This works in IE.
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @willowbl00
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/161269448) for this change