### PR TITLE
Don't show SIT on HHG_PPM moves

### DIFF
--- a/cypress/integration/mymove/hhgPPM.js
+++ b/cypress/integration/mymove/hhgPPM.js
@@ -106,7 +106,7 @@ function serviceMemberCanReviewMoveSummary() {
     expect(text).to.include('Move Date: 09/02/2018');
     expect(text).to.include('Pickup ZIP Code:  80913');
     expect(text).to.include('Delivery ZIP Code:  76127');
-    expect(text).to.include('Storage: Not requested');
+    expect(text).not.to.include('Storage: Not requested');
     expect(text).to.include('Estimated Weight:  1,50');
     expect(text).to.include('Estimated PPM Incentive:  $2,032.89 - 2,246.87');
   });

--- a/cypress/integration/mymove/ppm.js
+++ b/cypress/integration/mymove/ppm.js
@@ -59,6 +59,7 @@ describe('completing the ppm flow', function() {
 
     // //todo: should probably have test suite for review and edit screens
     cy.contains('$1,333.91'); // Verify that the advance matches what was input
+    cy.contains('Storage: Not requested'); // Verify SIT on the ppm review page since it's optional on HHG_PPM
 
     cy.nextPage();
 

--- a/src/scenes/Review/PPMShipmentSummary.jsx
+++ b/src/scenes/Review/PPMShipmentSummary.jsx
@@ -10,7 +10,7 @@ import { formatDateSM } from 'shared/formatters';
 import './Review.css';
 
 export default function PPMShipmentSummary(props) {
-  const { movePath, ppm } = props;
+  const { movePath, ppm, isHHGPPMComboMove } = props;
 
   const editDateAndLocationAddress = movePath + '/edit-date-and-location';
   const editWeightAddress = movePath + '/edit-weight';
@@ -55,10 +55,12 @@ export default function PPMShipmentSummary(props) {
               <td> Delivery ZIP Code: </td>
               <td> {ppm && ppm.destination_postal_code}</td>
             </tr>
-            <tr>
-              <td> Storage: </td>
-              <td>{sitDisplay}</td>
-            </tr>
+            {!isHHGPPMComboMove && (
+              <tr>
+                <td> Storage: </td>
+                <td>{sitDisplay}</td>
+              </tr>
+            )}
           </tbody>
         </table>
       </div>

--- a/src/scenes/Review/Summary.jsx
+++ b/src/scenes/Review/Summary.jsx
@@ -90,7 +90,9 @@ export class Summary extends Component {
           />
         )}
 
-        {currentPpm && <PPMShipmentSummary ppm={currentPpm} movePath={rootAddressWithMoveId} />}
+        {currentPpm && (
+          <PPMShipmentSummary ppm={currentPpm} movePath={rootAddressWithMoveId} isHHGPPMComboMove={isHHGPPMComboMove} />
+        )}
         {currentShipment &&
           !isHHGPPMComboMove && (
             <HHGShipmentSummary


### PR DESCRIPTION
## Description

This corrects the design by not showing SIT since we don't give the option for it ahead of time. I've ensured that we check for that line on a PPM only move in e2e test.

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make db_populate_e2e
```
Run through `Add PPM Shipment` flow using the `hhgforppm@award.ed` user. On review page you should not see a line for storage.
Also you'll need to test this on a regular PPM move, which you can do with `profile@comple.te` by setting up a PPM move, and seeing a line for storage regardless of whether or not you've chosen to add Storage In Transit.

## Code Review Verification Steps

* [x] Design has approved
* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* https://www.pivotaltracker.com/story/show/162065759

## Screenshots

<img width="1037" alt="screen shot 2018-11-20 at 4 35 25 pm" src="https://user-images.githubusercontent.com/5531789/48811580-52760e00-ece3-11e8-9c08-92333c5d275a.png">

