### PR TITLE
Fixes naming of 400ng item in normalizr schema [delivers #161829706]

### DIFF
--- a/src/shared/Entities/schema.js
+++ b/src/shared/Entities/schema.js
@@ -77,7 +77,7 @@ export const tariff400ngItems = new schema.Array(tariff400ngItem);
 
 // ShipmentLineItem
 export const shipmentLineItem = new schema.Entity('shipmentLineItems', {
-  tariff400ngItem: tariff400ngItem,
+  tariff400ng_item: tariff400ngItem,
 });
 export const shipmentLineItems = new schema.Array(shipmentLineItem);
 


### PR DESCRIPTION
## Description

The naming was off in the schema so this piece of data wasn't being denormalized properly

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](./docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](./docs/backend.md#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](./docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
* [ ] There are no aXe warnings for UI.
* [ ] This works in IE.
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @willowbl00
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/161829706) for this change

## Screenshots

![image](https://user-images.githubusercontent.com/5151804/48813066-0f6b6900-ecea-11e8-9d5f-03c5f09b26fe.png)
