### PR TITLE
Add SubmitPPM Handler

### DIFF
--- a/pkg/handlers/internalapi/api.go
+++ b/pkg/handlers/internalapi/api.go
@@ -29,6 +29,7 @@ func NewInternalAPIHandler(context handlers.HandlerContext) http.Handler {
 	internalAPI.PpmCreatePersonallyProcuredMoveHandler = CreatePersonallyProcuredMoveHandler{context}
 	internalAPI.PpmIndexPersonallyProcuredMovesHandler = IndexPersonallyProcuredMovesHandler{context}
 	internalAPI.PpmPatchPersonallyProcuredMoveHandler = PatchPersonallyProcuredMoveHandler{context}
+	internalAPI.PpmSubmitPersonallyProcuredMoveHandler = SubmitPersonallyProcuredMoveHandler{context}
 	internalAPI.PpmShowPPMEstimateHandler = ShowPPMEstimateHandler{context}
 	internalAPI.PpmShowPPMSitEstimateHandler = ShowPPMSitEstimateHandler{context}
 	internalAPI.PpmShowPPMIncentiveHandler = ShowPPMIncentiveHandler{context}

--- a/pkg/handlers/internalapi/personally_procured_move.go
+++ b/pkg/handlers/internalapi/personally_procured_move.go
@@ -255,6 +255,40 @@ func (h PatchPersonallyProcuredMoveHandler) Handle(params ppmop.PatchPersonallyP
 	return ppmop.NewPatchPersonallyProcuredMoveOK().WithPayload(ppmPayload)
 }
 
+// SubmitPersonallyProcuredMoveHandler Submits a PPM
+type SubmitPersonallyProcuredMoveHandler struct {
+	handlers.HandlerContext
+}
+
+// Handle is the handler
+func (h SubmitPersonallyProcuredMoveHandler) Handle(params ppmop.SubmitPersonallyProcuredMoveParams) middleware.Responder {
+	session := auth.SessionFromRequestContext(params.HTTPRequest)
+
+	// #nosec UUID is pattern matched by swagger and will be ok
+	ppmID, _ := uuid.FromString(params.PersonallyProcuredMoveID.String())
+
+	ppm, err := models.FetchPersonallyProcuredMove(h.DB(), session, ppmID)
+
+	if err != nil {
+		return handlers.ResponseForError(h.Logger(), err)
+	}
+
+	err = ppm.Submit()
+
+	verrs, err := models.SavePersonallyProcuredMove(h.DB(), ppm)
+	if err != nil || verrs.HasAny() {
+		return handlers.ResponseForVErrors(h.Logger(), verrs, err)
+	}
+
+	ppmPayload, err := payloadForPPMModel(h.FileStorer(), *ppm)
+
+	if err != nil {
+		return handlers.ResponseForError(h.Logger(), err)
+	}
+
+	return ppmop.NewSubmitPersonallyProcuredMoveOK().WithPayload(ppmPayload)
+}
+
 // ppmNeedsEstimatesRecalculated determines whether the fields that comprise
 // the PPM incentive and SIT estimate calculations have changed, necessitating a recalculation
 func (h PatchPersonallyProcuredMoveHandler) ppmNeedsEstimatesRecalculated(ppm *models.PersonallyProcuredMove, patch *internalmessages.PatchPersonallyProcuredMovePayload) bool {

--- a/pkg/handlers/internalapi/personally_procured_move_test.go
+++ b/pkg/handlers/internalapi/personally_procured_move_test.go
@@ -62,6 +62,90 @@ func (suite *HandlerSuite) TestCreatePPMHandler() {
 
 }
 
+func (suite *HandlerSuite) TestSubmitPPMHandler() {
+	scenario.RunRateEngineScenario1(suite.TestDB())
+
+	initialSize := internalmessages.TShirtSize("S")
+	newSize := internalmessages.TShirtSize("L")
+
+	initialWeight := swag.Int64(4100)
+	newWeight := swag.Int64(4105)
+
+	initialMoveDate := time.Now().Add(-2 * 24 * time.Hour)
+	newMoveDate := time.Now()
+
+	hasAdditionalPostalCode := swag.Bool(true)
+	newHasAdditionalPostalCode := swag.Bool(false)
+	additionalPickupPostalCode := swag.String("90210")
+
+	hasSit := swag.Bool(true)
+	newHasSit := swag.Bool(false)
+	daysInStorage := swag.Int64(3)
+	newPickupPostalCode := swag.String("32168")
+	newDestinationPostalCode := swag.String("29401")
+
+	move := testdatagen.MakeDefaultMove(suite.TestDB())
+
+	newAdvanceWorksheet := models.Document{
+		ServiceMember:   move.Orders.ServiceMember,
+		ServiceMemberID: move.Orders.ServiceMemberID,
+	}
+	suite.MustSave(&newAdvanceWorksheet)
+
+	ppm1 := models.PersonallyProcuredMove{
+		MoveID:                     move.ID,
+		Move:                       move,
+		Size:                       &initialSize,
+		WeightEstimate:             initialWeight,
+		PlannedMoveDate:            &initialMoveDate,
+		HasAdditionalPostalCode:    hasAdditionalPostalCode,
+		AdditionalPickupPostalCode: additionalPickupPostalCode,
+		HasSit:           hasSit,
+		DaysInStorage:    daysInStorage,
+		Status:           models.PPMStatusDRAFT,
+		AdvanceWorksheet: newAdvanceWorksheet,
+	}
+	suite.MustSave(&ppm1)
+
+	req := httptest.NewRequest("GET", "/fake/path", nil)
+	req = suite.AuthenticateRequest(req, move.Orders.ServiceMember)
+
+	payload := internalmessages.PatchPersonallyProcuredMovePayload{
+		Size:                    &newSize,
+		WeightEstimate:          newWeight,
+		PlannedMoveDate:         handlers.FmtDatePtr(&newMoveDate),
+		HasAdditionalPostalCode: newHasAdditionalPostalCode,
+		PickupPostalCode:        newPickupPostalCode,
+		DestinationPostalCode:   newDestinationPostalCode,
+		HasSit:                  newHasSit,
+	}
+
+	patchPPMParams := ppmop.PatchPersonallyProcuredMoveParams{
+		HTTPRequest: req,
+		MoveID:      strfmt.UUID(move.ID.String()),
+		PersonallyProcuredMoveID:           strfmt.UUID(ppm1.ID.String()),
+		PatchPersonallyProcuredMovePayload: &payload,
+	}
+
+	handler := PatchPersonallyProcuredMoveHandler{handlers.NewHandlerContext(suite.TestDB(), suite.TestLogger())}
+	handler.SetPlanner(route.NewTestingPlanner(900))
+	response := handler.Handle(patchPPMParams)
+
+	// assert we got back the 201 response
+	okResponse := response.(*ppmop.PatchPersonallyProcuredMoveOK)
+	patchPPMPayload := okResponse.Payload
+
+	suite.Equal(*patchPPMPayload.Size, newSize, "Size should have been updated.")
+	suite.Equal(patchPPMPayload.WeightEstimate, newWeight, "Weight should have been updated.")
+
+	suite.Equal(patchPPMPayload.PickupPostalCode, newPickupPostalCode, "PickupPostalCode should have been updated.")
+	suite.Equal(patchPPMPayload.DestinationPostalCode, newDestinationPostalCode, "DestinationPostalCode should have been updated.")
+	suite.Nil(patchPPMPayload.AdditionalPickupPostalCode, "AdditionalPickupPostalCode should have been updated to nil.")
+	suite.Equal(*(*time.Time)(patchPPMPayload.PlannedMoveDate), newMoveDate, "MoveDate should have been updated.")
+	suite.Nil(patchPPMPayload.DaysInStorage, "AdditionalPostalCode should have been updated to nil.")
+	suite.Equal(*patchPPMPayload.Mileage, int64(900), "Mileage should have been set to 900")
+}
+
 func (suite *HandlerSuite) TestIndexPPMHandler() {
 
 	t := suite.T()

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -2934,6 +2934,35 @@ paths:
           description: request requires user authentication
         403:
           description: user is not authorized
+  /personally_procured_move/{personallyProcuredMoveId}/submit:
+    post:
+      summary: Submits a PPM for approval
+      description: Submits a PPM for approval by the office. The status of the PPM will be updated to SUBMITTED
+      operationId: submitPersonallyProcuredMove
+      tags:
+        - ppm
+      parameters:
+        - in: path
+          name: personallyProcuredMoveId
+          type: string
+          format: uuid
+          required: true
+          description: UUID of the PPM being submitted
+      responses:
+        200:
+          description: updated instance of personally_procured_move
+          schema:
+            $ref: '#/definitions/PersonallyProcuredMovePayload'
+        400:
+          description: invalid request
+        401:
+          description: request requires user authentication
+        403:
+          description: user is not authorized
+        404:
+          description: ppm is not found
+        500:
+          description: internal server error
   /personally_procured_move/{personallyProcuredMoveId}/expense_summary:
     get:
       summary: Returns an expense summary organized by expense type
@@ -3528,6 +3557,7 @@ paths:
           description: no files to be processed into attachments PDF
         500:
           description: server error
+
   /personally_procured_moves/{personallyProcuredMoveId}/approve:
     post:
       summary: Approves the PPM


### PR DESCRIPTION
## Description

Add handler to change PPM's status to SUBMITTED for HHG_PPM flow

## Reviewer Notes
- Slowly separating the submission logic for PPMs, HHGs and moves. Currently the submission of an HHG is tied to also submitting a PPM and submitting a move. This handler will only submit a PPM to avoid any funky interactions that relied on the move being submitted

## Setup
`make server_run`
`make server_test`

## Code Review Verification Steps
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/161972310) for this change