### PR TITLE
Fix proptype warnings on homepage

### DIFF
--- a/src/shared/User/UserGreeting.jsx
+++ b/src/shared/User/UserGreeting.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
-const UserGreeting = ({ isLoggedIn, firstName, email }) =>
+export const UserGreeting = ({ isLoggedIn, firstName, email }) =>
   isLoggedIn && (
     <span>
       <strong>{firstName ? `Welcome, ${firstName}` : email}</strong>

--- a/src/shared/User/UserGreeting.jsx
+++ b/src/shared/User/UserGreeting.jsx
@@ -10,9 +10,9 @@ const UserGreeting = ({ isLoggedIn, firstName, email }) =>
   );
 
 UserGreeting.propTypes = {
-  isLoggedIn: PropTypes.bool.isRequired,
-  firstName: PropTypes.string.isRequired,
   email: PropTypes.string.isRequired,
+  firstName: PropTypes.string,
+  isLoggedIn: PropTypes.bool.isRequired,
 };
 
 const mapStateToProps = ({ user }) => ({

--- a/src/shared/User/UserGreeting.test.jsx
+++ b/src/shared/User/UserGreeting.test.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { UserGreeting } from './UserGreeting';
+
+describe('UserGreeting tests', () => {
+  describe('User is not authenticated', () => {
+    it('should not render if the user is not logged in', () => {
+      const wrapper = shallow(<UserGreeting isLoggedIn={false} email="" />);
+      expect(wrapper.children().length).toBe(0);
+    });
+  });
+  describe('User is authenticated', () => {
+    it('should render the Welcome message if the user provides a firstName', () => {
+      const wrapper = shallow(<UserGreeting isLoggedIn={true} firstName="Kevin" email="kevin@test.com" />);
+      expect(wrapper.find('strong').text()).toBe('Welcome, Kevin');
+    });
+    it('should render the email if the user does not have a first name yet', () => {
+      const wrapper = shallow(<UserGreeting isLoggedIn={true} email="kevin@test.com" />);
+      expect(wrapper.find('strong').text()).toBe('kevin@test.com');
+    });
+  });
+});

--- a/src/shared/User/ducks.js
+++ b/src/shared/User/ducks.js
@@ -66,7 +66,7 @@ export const loggedInUserReducer = (state = {}, action) => {
 
 const loggedOutUser = {
   isLoggedIn: false,
-  email: null,
+  email: '',
   userId: null,
 };
 


### PR DESCRIPTION
## Description

Fix proptype warnings on homepage

## Reviewer Notes
- firstName isn't required because it doesn't exist when not logged in or during the service member setup
- changed the initial state of email in user reducer to match the type that propTypes is expecting

## Setup
`make server_run`
`make client_run`

## Code Review Verification Steps
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/162125696) for this change

## Screenshots

![image](https://user-images.githubusercontent.com/13622298/48857241-433ba280-ed6d-11e8-969c-5437394a10f6.png)

