### PR TITLE
Add import of css file to fix missing legend

### DIFF
--- a/src/scenes/Moves/Hhg/DatesSummary.jsx
+++ b/src/scenes/Moves/Hhg/DatesSummary.jsx
@@ -4,6 +4,7 @@ import { get, isNil } from 'lodash';
 
 import { displayDateRange } from 'shared/formatters';
 import LoadingPlaceholder from 'shared/LoadingPlaceholder';
+import 'scenes/Moves/Hhg/DatesSummary.css';
 
 export class DatesSummary extends Component {
   render() {


### PR DESCRIPTION
## Description

The legend went missing on the HHG datepicker page.  Now it's back.

## Setup

From db_populate_e2e data, sign in as local user `sm_hhg@example.com`.  Choose an HHG and go to the datepicker page.  Choose a date from the calendar.  See the legend next to the dates summary.

## Reviewer Notes

I couldn't test it in IE- couldn't get the app to run.

## Code Review Verification Steps

* [ ] This works in IE.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/161971643) for this change

## Screenshots

<img width="781" alt="screen shot 2018-11-21 at 2 40 33 pm" src="https://user-images.githubusercontent.com/13249580/48871992-06d36b00-ed9c-11e8-8c85-3cad1cca6abe.png">
