### PR TITLE
Validate protocols, hostnames, and ports

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -256,7 +256,7 @@ jobs:
               # Env vars needed for the webserver to run
               SECURE_MIGRATION_DIR: /home/circleci/go/src/github.com/transcom/mymove/local_migrations
               SECURE_MIGRATION_SOURCE: local
-              LOGIN_GOV_CALLBACK_PROTOCOL: http://
+              LOGIN_GOV_CALLBACK_PROTOCOL: http
               LOGIN_GOV_MY_CLIENT_ID: urn:gov:gsa:openidconnect.profiles:sp:sso:dod:mymovemillocal
               LOGIN_GOV_OFFICE_CLIENT_ID: urn:gov:gsa:openidconnect.profiles:sp:sso:dod:officemovemillocal
               LOGIN_GOV_TSP_CLIENT_ID: urn:gov:gsa:openidconnect.profiles:sp:sso:dod:tspmovemillocal
@@ -545,21 +545,21 @@ workflows:
             - build_migrations
           filters:
             branches:
-              only: healthchecker_flush
+              only: placeholder
 
       - deploy_experimental_app:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: healthchecker_flush
+              only: placeholder
 
       - deploy_experimental_app_client_tls:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: healthchecker_flush
+              only: placeholder
 
       - deploy_staging_migrations:
           requires:

--- a/.envrc
+++ b/.envrc
@@ -63,7 +63,7 @@ export DB_PORT=5432
 export DB_NAME=dev_db
 
 # Login.gov configuration
-export LOGIN_GOV_CALLBACK_PROTOCOL="http://"
+export LOGIN_GOV_CALLBACK_PROTOCOL="http"
 export LOGIN_GOV_CALLBACK_PORT="3000"
 export LOGIN_GOV_MY_CLIENT_ID="urn:gov:gsa:openidconnect.profiles:sp:sso:dod:mymovemillocal"
 export LOGIN_GOV_OFFICE_CLIENT_ID="urn:gov:gsa:openidconnect.profiles:sp:sso:dod:officemovemillocal"

--- a/pkg/auth/authentication/auth.go
+++ b/pkg/auth/authentication/auth.go
@@ -73,7 +73,7 @@ func NewAuthContext(logger *zap.Logger, loginGovProvider LoginGovProvider, callb
 	context := Context{
 		logger:           logger,
 		loginGovProvider: loginGovProvider,
-		callbackTemplate: fmt.Sprintf("%s%%s:%d/", callbackProtocol, callbackPort),
+		callbackTemplate: fmt.Sprintf("%s://%%s:%d/", callbackProtocol, callbackPort),
 	}
 	return context
 }

--- a/pkg/auth/authentication/auth_test.go
+++ b/pkg/auth/authentication/auth_test.go
@@ -89,7 +89,7 @@ func (suite *AuthSuite) TestAuthorizationLogoutHandler() {
 	ctx := auth.SetSessionInRequestContext(req, &session)
 	req = req.WithContext(ctx)
 
-	authContext := NewAuthContext(suite.logger, fakeLoginGovProvider(suite.logger), "http://", callbackPort)
+	authContext := NewAuthContext(suite.logger, fakeLoginGovProvider(suite.logger), "http", callbackPort)
 	handler := LogoutHandler{authContext, "fake key", false}
 	wrappedHandler := auth.DetectorMiddleware(suite.logger, myMoveMil, officeMoveMil, tspMoveMil)(handler)
 

--- a/pkg/auth/authentication/login_gov.go
+++ b/pkg/auth/authentication/login_gov.go
@@ -55,7 +55,7 @@ func (p LoginGovProvider) getOpenIDProvider(hostname string, clientID string, ca
 	return openidConnect.New(
 		clientID,
 		p.secretKey,
-		fmt.Sprintf("%s%s:%d/auth/login-gov/callback", callbackProtocol, hostname, callbackPort),
+		fmt.Sprintf("%s://%s:%d/auth/login-gov/callback", callbackProtocol, hostname, callbackPort),
 		fmt.Sprintf("https://%s/.well-known/openid-configuration", p.hostname),
 	)
 }


### PR DESCRIPTION
## Description

This PR validates the protocols, hostnames, and port config variables used by our webserver.  Additionally, this changes the `LOGIN_GOV_CALLBACK_PROTOCOL` variable to only include the protocol and not the trailing `://`.