### PR TITLE
Removed click call on today in calendar test

### DIFF
--- a/cypress/integration/mymove/shipment.js
+++ b/cypress/integration/mymove/shipment.js
@@ -20,8 +20,8 @@ describe('completing the hhg flow', function() {
 
     // Calendar move date
 
-    // Try to get today, which should be disabled even after clicked.  We may have to go back a month
-    // to find today since the calendar scrolls to the month with the first available move date.
+    // Try to get today, which should be disabled.  We may have to go back a month to find
+    // today since the calendar scrolls to the month with the first available move date.
     cy
       .get('.DayPicker-Body')
       .then($body => {
@@ -33,7 +33,6 @@ describe('completing the hhg flow', function() {
         cy
           .get('.DayPicker-Day--today')
           .first()
-          .click()
           .should('have.class', 'DayPicker-Day--disabled');
       });
 


### PR DESCRIPTION
## Description

This PR removes a call to "click" on today's date in the calendar.  In some scenarios (like right now), this was causing the calendar to go back a month if today was "outside" the current month.  That seems to be causing some intermittent test failures because the DOM is changing while the test is running.  For now, we can take the "click" out and just test that today has the disabled style without clicking on it.
