### PR TITLE
Replaces route-specific 404 page with generic one

### DIFF
--- a/src/scenes/MyMove/index.jsx
+++ b/src/scenes/MyMove/index.jsx
@@ -4,7 +4,7 @@ import { LastLocationProvider } from 'react-router-last-location';
 
 import PrivateRoute from 'shared/User/PrivateRoute';
 import { Route, Switch } from 'react-router-dom';
-import { ConnectedRouter, push } from 'react-router-redux';
+import { ConnectedRouter, push, goBack } from 'react-router-redux';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 
@@ -36,13 +36,6 @@ import FailWhale from 'shared/FailWhale';
 import { no_op } from 'shared/utils';
 import DPSAuthCookie from 'scenes/DPSAuthCookie';
 
-const NoMatch = ({ location }) => (
-  <div className="usa-grid">
-    <h3>
-      No match for <code>{location.pathname}</code>
-    </h3>
-  </div>
-);
 export class AppWrapper extends Component {
   state = { hasError: false };
   componentDidMount() {
@@ -55,6 +48,15 @@ export class AppWrapper extends Component {
       hasError: true,
     });
   }
+
+  noMatch = () => (
+    <div className="usa-grid">
+      <h2>Page not found</h2>
+      <p>Looks like you've followed a broken link or entered a URL that doesn't exist on this site.</p>
+      <button onClick={this.props.goBack}>Go Back</button>
+    </div>
+  );
+
   render() {
     const props = this.props;
     return (
@@ -96,7 +98,7 @@ export class AppWrapper extends Component {
 
                     <PrivateRoute path="/moves/:moveId/request-payment" component={PaymentRequest} />
                     <PrivateRoute path="/dps_cookie" component={Authorization(DPSAuthCookie, 'dps')} />
-                    <Route component={NoMatch} />
+                    <Route component={this.noMatch} />
                   </Switch>
                 )}
             </main>
@@ -122,6 +124,7 @@ const mapStateToProps = state => {
     latestMove: get(state, 'moves.latestMove'),
   };
 };
-const mapDispatchToProps = dispatch => bindActionCreators({ push, loadInternalSchema, loadLoggedInUser }, dispatch);
+const mapDispatchToProps = dispatch =>
+  bindActionCreators({ goBack, push, loadInternalSchema, loadLoggedInUser }, dispatch);
 
 export default connect(mapStateToProps, mapDispatchToProps)(AppWrapper);


### PR DESCRIPTION
## Description

Previously on our 404 page we were printing the mistaken route on the page, which counts as text injection. This replaces that with a generic message and adds a back button.

Zendesk ticket: https://mymovemil.zendesk.com/agent/tickets/116

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](./docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](./docs/backend.md#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](./docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
* [ ] There are no aXe warnings for UI.
* [ ] This works in IE.
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @willowbl00
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/162229190) for this change

## Screenshots

<img width="739" alt="screen shot 2018-11-26 at 11 47 17 pm" src="https://user-images.githubusercontent.com/5151804/49059251-f412c900-f1d5-11e8-82e6-d4fdc1c000d0.png">
