### PR TITLE
Adds foreign key constraints to tables, fixes duty station references [delivers #161103353]

### DIFF
--- a/migrations/20181127202431_add_foreign_key_constraints.up.fizz
+++ b/migrations/20181127202431_add_foreign_key_constraints.up.fizz
@@ -1,0 +1,8 @@
+add_foreign_key("signed_certifications", "move_id", {"moves": ["id"]}, {})
+
+add_foreign_key("moving_expense_documents", "move_document_id", {"move_documents": ["id"]}, {})
+
+sql("UPDATE duty_stations SET transportation_office_id='fab58a38-ee1f-4adf-929a-2dd246fc5e67' WHERE transportation_office_id='f4b95759-0f4c-475a-95a6-34e6c119e39d';")
+sql("UPDATE duty_stations SET transportation_office_id='cc107598-3d72-4679-a4aa-c28d1fd2a016' WHERE transportation_office_id='a468eb8d-79c5-4c01-93d7-9c0f557b7b9f';")
+
+add_foreign_key("duty_stations", "transportation_office_id", {"transportation_offices": ["id"]}, {})


### PR DESCRIPTION
## Description

This sets up some foreign key constraints that were missing on initial table creation. Two duty stations had `transportation_office_id` set to the ID of the _address_ of the office, instead of the office. Those were updated.

I debated whether to write a really defensive migration that maybe deletes rows that have broken references, but decided against it.

If we wrote it defensively then:
- bad data is purged
- migration should always be successful
- we don't learn if/why data is bad

If we let it explode then:
- We can roll back or fix the migration in the short term
- We learn that we have bad data in staging/prod for some reason, and can start to figure out why
- We don't lose an unknown amount of data
- I get to write less code

## Setup

```sh
make db_dev_migrate
```

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](./docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](./docs/backend.md#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](./docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
* [ ] There are no aXe warnings for UI.
* [ ] This works in IE.
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @willowbl00
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/161103353) for this change