### PR TITLE
Allow premove survey to be filled out while move in accepted state by tsp users

### DIFF
--- a/cypress/integration/tsp/premoveSurvey.js
+++ b/cypress/integration/tsp/premoveSurvey.js
@@ -1,36 +1,35 @@
 import { tspUserVerifiesShipmentStatus } from '../../support/testTspStatus';
 
 /* global cy */
-describe('TSP User Completes Premove Survey', function() {
+describe('TSP User And the Premove Survey Button', function() {
   beforeEach(() => {
     cy.signIntoTSP();
   });
 
-  it('tsp user uses action button to enter premove survey', function() {
+  it('tsp user uses action button to enter premove survey for accepted shipment', function() {
+    tspUserGoesToShipment('queues/accepted', 'ACC4PM');
     tspUserClicksEnterPreMoveSurvey();
     tspUserFillsInPreMoveSurveyWizard();
+    tspUserVerifiesPreMoveSurveyEntered();
+    tspUserVerifiesShipmentStatus('Shipment accepted');
+  });
+
+  it('tsp user uses action button to enter premove survey for approved shipment', function() {
+    tspUserGoesToShipment('queues/approved', 'ENTPMS');
+    tspUserClicksEnterPreMoveSurvey();
+    tspUserFillsInPreMoveSurveyWizard();
+    tspUserVerifiesPreMoveSurveyEntered();
+    tspUserVerifiesShipmentStatus('Pre-move survey complete');
+  });
+
+  it('tsp user does not see premove survey button if approved, but already completed', function() {
+    tspUserGoesToShipment('queues/approved', 'APPPMS');
     tspUserVerifiesPreMoveSurveyEntered();
     tspUserVerifiesShipmentStatus('Pre-move survey complete');
   });
 });
 
 function tspUserClicksEnterPreMoveSurvey() {
-  // Open approved shipments queue
-  cy.visit('/queues/approved');
-
-  // Find shipment and open it
-  cy
-    .get('div')
-    .contains('ENTPMS')
-    .dblclick();
-
-  cy.location().should(loc => {
-    expect(loc.pathname).to.match(/^\/shipments\/[^/]+/);
-  });
-
-  // Status should be Approved for "Enter pre-move survey" button to exist
-  tspUserVerifiesShipmentStatus('Awaiting pre-move survey');
-
   cy
     .get('button')
     .contains('Enter pre-move survey')
@@ -136,4 +135,18 @@ function tspUserFillsInPreMoveSurveyWizard() {
 
 function tspUserVerifiesPreMoveSurveyEntered() {
   cy.get('button').should('not.contain', 'Enter pre-move survey');
+}
+
+function tspUserGoesToShipment(queue, locator) {
+  cy.visit(queue);
+
+  // Find shipment and open it
+  cy
+    .get('div')
+    .contains(locator)
+    .dblclick();
+
+  cy.location().should(loc => {
+    expect(loc.pathname).to.match(/^\/shipments\/[^/]+/);
+  });
 }

--- a/pkg/testdatagen/scenario/e2ebasic.go
+++ b/pkg/testdatagen/scenario/e2ebasic.go
@@ -1642,6 +1642,114 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, log
 	hhg29 := offer29.Shipment
 	hhg29.Move.Submit()
 	models.SaveMoveDependencies(db, &hhg29.Move)
+
+	/*
+	 * Service member with accepted shipment
+	 */
+	email = "hhgnotyet@approv.ed"
+
+	offer30 := testdatagen.MakeShipmentOffer(db, testdatagen.Assertions{
+		User: models.User{
+			ID:            uuid.Must(uuid.FromString("edd11e8e-ebb3-4ed9-bd6c-69dd2ca2555f")),
+			LoginGovEmail: email,
+		},
+		ServiceMember: models.ServiceMember{
+			ID:            uuid.FromStringOrNil("547863b0-6757-4135-8e12-923a18a374ee"),
+			FirstName:     models.StringPointer("HHG"),
+			LastName:      models.StringPointer("NotYetApproved"),
+			Edipi:         models.StringPointer("4124567890"),
+			PersonalEmail: models.StringPointer(email),
+		},
+		Move: models.Move{
+			ID:               uuid.FromStringOrNil("8bd3488c-b846-49ee-8a95-ed2de7f2f618"),
+			Locator:          "ACC4PM",
+			SelectedMoveType: &selectedMoveTypeHHG,
+		},
+		TrafficDistributionList: models.TrafficDistributionList{
+			ID:                uuid.FromStringOrNil("1524b6b5-5608-41cb-a814-ac1d9a427f42"),
+			SourceRateArea:    "US62",
+			DestinationRegion: "11",
+			CodeOfService:     "D",
+		},
+		Shipment: models.Shipment{
+			Status:             models.ShipmentStatusACCEPTED,
+			HasDeliveryAddress: true,
+			SourceGBLOC:        &sourceOffice.Gbloc,
+			DestinationGBLOC:   &destOffice.Gbloc,
+		},
+		ShipmentOffer: models.ShipmentOffer{
+			TransportationServiceProviderID: tspUser.TransportationServiceProviderID,
+			Accepted:                        models.BoolPointer(true),
+		},
+	})
+
+	hhg30 := offer30.Shipment
+
+	testdatagen.MakeServiceAgent(db, testdatagen.Assertions{
+		ServiceAgent: models.ServiceAgent{
+			ShipmentID: hhg30.ID,
+		},
+	})
+	testdatagen.MakeServiceAgent(db, testdatagen.Assertions{
+		ServiceAgent: models.ServiceAgent{
+			ShipmentID: hhg30.ID,
+			Role:       models.RoleDESTINATION,
+		},
+	})
+	hhg30.Move.Submit()
+	models.SaveMoveDependencies(db, &hhg30.Move)
+
+	/*
+	 * Service member with approved shipment and pre move survey has already been filled out.
+	 */
+	email = "hhgalready@approv.ed"
+
+	weightEstimate := unit.Pound(5000)
+
+	offer31 := testdatagen.MakeShipmentOffer(db, testdatagen.Assertions{
+		User: models.User{
+			ID:            uuid.Must(uuid.FromString("f6cfe91f-c5f0-47dd-a796-5d9fb0f96289")),
+			LoginGovEmail: email,
+		},
+		ServiceMember: models.ServiceMember{
+			ID:            uuid.FromStringOrNil("c0abdde6-fe2c-4b0e-b0ed-860608eca04b"),
+			FirstName:     models.StringPointer("HHGApproved"),
+			LastName:      models.StringPointer("PMSurveyCompleted"),
+			Edipi:         models.StringPointer("4124337809"),
+			PersonalEmail: models.StringPointer(email),
+		},
+		Move: models.Move{
+			ID:               uuid.FromStringOrNil("8c03b5a5-2ca5-49c1-a5a0-12f56c5f15c7"),
+			Locator:          "APPPMS",
+			SelectedMoveType: &selectedMoveTypeHHG,
+		},
+		TrafficDistributionList: models.TrafficDistributionList{
+			ID:                uuid.FromStringOrNil("e2351f50-9b07-4e6a-85eb-7c622486e859"),
+			SourceRateArea:    "US62",
+			DestinationRegion: "11",
+			CodeOfService:     "D",
+		},
+		Shipment: models.Shipment{
+			Status:                      models.ShipmentStatusAPPROVED,
+			HasDeliveryAddress:          true,
+			PmSurveyConductedDate:       &packDate,
+			PmSurveyMethod:              "PHONE",
+			PmSurveyPlannedPackDate:     &packDate,
+			PmSurveyPlannedPickupDate:   &pickupDate,
+			PmSurveyPlannedDeliveryDate: &deliveryDate,
+			PmSurveyWeightEstimate:      &weightEstimate,
+			SourceGBLOC:                 &sourceOffice.Gbloc,
+			DestinationGBLOC:            &destOffice.Gbloc,
+		},
+		ShipmentOffer: models.ShipmentOffer{
+			TransportationServiceProviderID: tspUser.TransportationServiceProviderID,
+			Accepted:                        models.BoolPointer(true),
+		},
+	})
+
+	hhg31 := offer31.Shipment
+	hhg31.Move.Submit()
+	models.SaveMoveDependencies(db, &hhg31.Move)
 }
 
 // MakeHhgWithPpm creates an HHG user who has added a PPM

--- a/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
+++ b/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
@@ -206,8 +206,9 @@ class ShipmentInfo extends Component {
         shipment.pm_survey_planned_delivery_date &&
         shipment.pm_survey_weight_estimate,
     );
-    const canAssignServiceAgents = (approved || accepted) && !hasOriginServiceAgent(serviceAgents);
-    const canEnterPreMoveSurvey = approved && hasOriginServiceAgent(serviceAgents) && !hasPreMoveSurvey(shipment);
+    const canAssignServiceAgents = (accepted || approved) && !hasOriginServiceAgent(serviceAgents);
+    const canEnterPreMoveSurvey =
+      (accepted || approved) && hasOriginServiceAgent(serviceAgents) && !hasPreMoveSurvey(shipment);
     const canEnterPackAndPickup = approved && gblGenerated;
 
     // Some statuses are directly related to the shipment status and some to combo states


### PR DESCRIPTION
## Description

TSP users want the ability to fill out the premove survey before the office approves the move.

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make db_populate_e2e
```
Go to an accepted move that already has agents assigned. You should be able to fill out the premove survey

## Code Review Verification Steps

* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* https://www.pivotaltracker.com/story/show/162103174

## Screenshots

<img width="952" alt="screen shot 2018-11-27 at 5 20 20 pm" src="https://user-images.githubusercontent.com/5531789/49122457-5b2d8d80-f269-11e8-8fb4-41035dfc9180.png">

