### PR TITLE
Add migration for office users that need to be added

### DIFF
--- a/local_migrations/20181128160411_add-office-users.sql
+++ b/local_migrations/20181128160411_add-office-users.sql
@@ -1,0 +1,8 @@
+-- Local test migration.
+-- This will be run on development environments. It should mirror what you
+-- intend to apply on production, but do not include any sensitive data.
+INSERT INTO public.office_users VALUES ('c16e65cc-0587-4bd8-a43d-db3b584c2383', NULL, 'Boy', 'Danny', NULL, 'daniel@example.com', '(555) 555-5555', '0931a9dc-c1fd-444a-b138-6e1986b1714c', now(), now());
+INSERT INTO public.office_users VALUES ('a3df3add-cfe2-4179-bf61-23b05a5affbf', NULL, 'Busters', 'Dave', NULL, 'davenbusters7@test.com', '(555) 555-5555', '0931a9dc-c1fd-444a-b138-6e1986b1714c', now(), now());
+INSERT INTO public.office_users VALUES ('326400d4-56fd-498c-8144-ca6e7b09ced5', NULL, 'Son', 'Danny', NULL, 'dannybegood@example.com', '(555) 555-5555', '0931a9dc-c1fd-444a-b138-6e1986b1714c', now(), now());
+INSERT INTO public.office_users VALUES ('89aaf3bb-c245-4f9e-b8e4-e4cd041be908', NULL, 'Berry', 'Sherri', NULL, 'sherriberry@example.com', '(555) 555-5555', '0931a9dc-c1fd-444a-b138-6e1986b1714c', now(), now());
+INSERT INTO public.office_users VALUES ('afaaf129-6b16-4fd3-aad9-8b831ec297e9', NULL, 'Bear', 'Rosia', NULL, 'rosia@mail.com', '(555) 555-5555', '0931a9dc-c1fd-444a-b138-6e1986b1714c', now(), now());

--- a/migrations/20181128160411_add-office-users.up.fizz
+++ b/migrations/20181128160411_add-office-users.up.fizz
@@ -1,0 +1,1 @@
+exec("./apply-secure-migration.sh 20181128160411_add-office-users.sql")


### PR DESCRIPTION
## Description

Migration for adding office users

## Setup
`./bin/run-prod-migrations`
Look in DB under `office_users` for list of names and phone numbers in this [zendesk ticket](https://mymovemil.zendesk.com/agent/tickets/154)

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](./docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](./docs/backend.md#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](./docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
* [ ] There are no aXe warnings for UI.
* [ ] This works in IE.
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @willowbl00
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/162273528) for this change
