### PR TITLE
add confirmation alert gate to invoice approval flow

### DIFF
--- a/src/shared/Invoice/InvoicePanel.css
+++ b/src/shared/Invoice/InvoicePanel.css
@@ -66,3 +66,8 @@
   display: flex;
   align-items: center;
 }
+
+.warning--header {
+  font-size: 1.2em;
+  display: block;
+}

--- a/src/shared/Invoice/InvoiceTable.jsx
+++ b/src/shared/Invoice/InvoiceTable.jsx
@@ -2,24 +2,54 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 
 import { formatFromBaseQuantity, formatCents } from 'shared/formatters';
+import Alert from 'shared/Alert';
+
 import { isOfficeSite, isDevelopment } from 'shared/constants.js';
 import './InvoicePanel.css';
 
 class InvoiceTable extends PureComponent {
+  state = {
+    isConfirmationFlowVisible: this.props.isConfirmationFlowVisible,
+  };
+
+  static defaultProps = {
+    isConfirmationFlowVisible: false,
+  };
+
+  approvePayment = () => {
+    this.setState({ isConfirmationFlowVisible: true });
+  };
+
+  cancelPayment = () => {
+    this.setState({ isConfirmationFlowVisible: false });
+  };
+
   render() {
     return (
       <div className="invoice-panel-table-cont">
+        {isOfficeSite && this.state.isConfirmationFlowVisible ? (
+          <div>
+            <Alert type="warning" heading="Approve payment?">
+              <span className="warning--header">Please make sure you've double-checked everything.</span>
+              <button className="button usa-button-secondary" onClick={this.cancelPayment}>
+                Cancel
+              </button>
+              <button className="button usa-button-primary"> Approve</button>
+            </Alert>
+          </div>
+        ) : null}
         <div className="usa-grid-full invoice-panel-header-cont">
           <div className="usa-width-one-half">
             <h5>Unbilled line items</h5>
           </div>
           <div className="usa-width-one-half align-right">
             {isOfficeSite &&
+              !this.state.isConfirmationFlowVisible &&
               this.props.shipmentStatus.toUpperCase() === 'DELIVERED' && (
                 <button
                   className="button button-secondary"
                   disabled={!this.props.canApprove || !isDevelopment}
-                  onClick={this.props.approvePayment}
+                  onClick={this.approvePayment}
                 >
                   Approve Payment
                 </button>


### PR DESCRIPTION
## Description
Office user should see a confirmation alert when approve button is invoked. The confirmation alert can either be approved or canceled. Upon cancelation user should be returned to the pre confirmation flow with approve button back in place.

## Code Review Verification Steps

* [ ] This works in IE.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/161689729)

## Screenshots

![](https://media.giphy.com/media/3CWUedkwRx5AzAk37O/giphy.gif)
