### PR TITLE
Sb 161899339 use proper ppm status

### DIFF
--- a/cypress/integration/mymove/hhgPPM.js
+++ b/cypress/integration/mymove/hhgPPM.js
@@ -143,23 +143,16 @@ function serviceMemberViewsUpdatedHomePage() {
   });
 
   cy.get('body').should($div => {
-    expect($div.text()).to.include('Government Movers and Packers (HHG)');
-    // TODO We should uncomment next line and delete this
-    // and the line following the commented line once ppms can be submitted
-    // expect($div.text()).to.include('Move your own stuff (PPM)');
-    expect($div.text()).to.include('Move to be scheduled');
+    expect($div.text()).to.include('Government Movers and Packers');
+    expect($div.text()).to.include('Move your own stuff');
     expect($div.text()).to.not.include('Add PPM Shipment');
   });
 
   cy.get('.usa-width-three-fourths').should($div => {
     const text = $div.text();
-    // HHG information and details
-    expect(text).to.include('Next Step: Prepare for move');
-    expect(text).to.include('Weight (est.): 2000 lbs');
-    // TODO Once PPM can be submitted, the following 4 lines should be uncommented and this removed.
-    // // PPM information and details
-    // expect(text).to.include('Next Step: Wait for approval');
-    // expect(text).to.include('Weight (est.): 150');
-    // expect(text).to.include('Incentive (est.): $2,032.89 - 2,246.87');
+    // PPM information and details
+    expect(text).to.include('Next Step: Wait for approval');
+    expect(text).to.include('Weight (est.): 150');
+    expect(text).to.include('Incentive (est.): $4,255.80 - 4,703.78');
   });
 }

--- a/pkg/handlers/internalapi/personally_procured_move.go
+++ b/pkg/handlers/internalapi/personally_procured_move.go
@@ -27,6 +27,7 @@ func payloadForPPMModel(storer storage.FileStorer, personallyProcuredMove models
 
 	ppmPayload := internalmessages.PersonallyProcuredMovePayload{
 		ID:                            handlers.FmtUUID(personallyProcuredMove.ID),
+		MoveID:                        *handlers.FmtUUID(personallyProcuredMove.MoveID),
 		CreatedAt:                     handlers.FmtDateTime(personallyProcuredMove.CreatedAt),
 		UpdatedAt:                     handlers.FmtDateTime(personallyProcuredMove.UpdatedAt),
 		Size:                          personallyProcuredMove.Size,

--- a/src/scenes/Landing/index.jsx
+++ b/src/scenes/Landing/index.jsx
@@ -16,6 +16,7 @@ import Alert from 'shared/Alert';
 import SignIn from 'shared/User/SignIn';
 
 import { updateMove } from 'scenes/Moves/ducks';
+import { getPPM } from 'scenes/Moves/Ppm/ducks';
 
 export class Landing extends Component {
   componentDidMount() {
@@ -159,7 +160,7 @@ const mapStateToProps = state => {
     backupContacts: state.serviceMember.currentBackupContacts || [],
     orders: state.orders.currentOrders || {},
     move: state.moves.currentMove || state.moves.latestMove || {},
-    ppm: state.ppm.currentPpm || {},
+    ppm: getPPM(state),
     currentShipment: shipment || {},
     loggedInUser: state.loggedInUser.loggedInUser,
     loggedInUserIsLoading: state.loggedInUser.isLoading,

--- a/src/scenes/Moves/Ppm/ducks.js
+++ b/src/scenes/Moves/Ppm/ducks.js
@@ -220,6 +220,17 @@ export function getDestinationPostalCode(state) {
     : currentOrders.new_duty_station.address.postal_code;
 }
 
+export function getPPM(state) {
+  const move = state.moves.currentMove || state.moves.latestMove || {};
+  const moveId = move.id;
+  const ppmsFromEntities = state.entities.personallyProcuredMove;
+  if (moveId && ppmsFromEntities) {
+    return Object.values(state.entities.personallyProcuredMove).find(ppm => ppm.move_id === moveId);
+  } else {
+    return state.ppm.currentPpm || {};
+  }
+}
+
 // Reducer
 const initialState = {
   pendingPpmSize: null,

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -312,6 +312,10 @@ definitions:
         type: string
         format: uuid
         example: c56a4180-65aa-42ec-a945-5fd21dec0538
+      move_id:
+        type: string
+        format: uuid
+        example: c56a4180-65aa-42ec-a945-5fd21dec0538
       size:
         $ref: '#/definitions/TShirtSize'
       planned_move_date:


### PR DESCRIPTION
## Description

Fixes a bug where after submitting the PPM the proper status is not shown

## Reviewer Notes

Eventually, we are going to be using the PPM that exists in the entities reducer. This is a stepping stone toward getting us there, but using the entities version if it exists, and falling back to the current reducer location if the new one does not exist.

## Code Review Verification Steps

* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/161899339) for this change
* [this article](tbd) explains more about the approach used.

