### PR TITLE
Make a script for adding a DPS user

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ __snapshots__
 /bin/make-office-user
 /bin/load-office-data
 /bin/make-tsp-user
+/bin/make-dps-user
 /bin/load-user-gen
 /bin/paperwork
 /bin/rateengine

--- a/Makefile
+++ b/Makefile
@@ -116,6 +116,7 @@ build_tools: server_deps server_generate
 	go build -i -o bin/make-office-user ./cmd/make_office_user
 	go build -i -o bin/load-office-data ./cmd/load_office_data
 	go build -i -o bin/make-tsp-user ./cmd/make_tsp_user
+	go build -i -o bin/make-dps-user ./cmd/make_dps_user
 	go build -i -o bin/load-user-gen ./cmd/load_user_gen
 	go build -i -o bin/paperwork ./cmd/paperwork
 	go build -i -o bin/iws ./cmd/demo/iws.go

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ This prototype was built by a [Defense Digital Service](https://www.dds.mil/) te
   * [Setup: Client](#setup-client)
   * [Setup: Office/admin client](#setup-officeadmin-client)
   * [Setup: TSP/admin client](#setup-tspadmin-client)
+  * [Setup: DPS user](#setup-dps-user)
   * [Setup: Orders Gateway](#setup-orders-gateway)
   * [Setup: S3](#setup-s3)
   * [TSP Award Queue](#tsp-award-queue)
@@ -187,6 +188,12 @@ Dependencies are managed by yarn. To add a new dependency, use `yarn add`
     * run `bin/make-tsp-user -email <email>` to set up a TSP user associated with that email address
 3. `make tsp_client_run`
 4. Login with the email used above to access the TSP
+
+### Setup: DPS user
+
+1. Ensure that you have a login.gov test account
+    * `make build_tools` to build the tools
+    * run `bin/make-dps-user -email <email>` to set up a DPS user associated with that email address
 
 ### Setup: Orders Gateway
 

--- a/cmd/make_dps_user/main.go
+++ b/cmd/make_dps_user/main.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"github.com/gobuffalo/pop"
+	"github.com/namsral/flag"
+	"github.com/transcom/mymove/pkg/models"
+	"log"
+)
+
+func mustSave(db *pop.Connection, model interface{}) {
+	verrs, err := db.ValidateAndSave(model)
+	if verrs.HasAny() {
+		log.Fatalf("validation Errors %v", verrs)
+	}
+	if err != nil {
+		log.Fatalf("Failed to save %v", err)
+	}
+}
+
+func main() {
+	config := flag.String("config-dir", "config", "The location of server config files")
+	env := flag.String("env", "development", "The environment to run in, which configures the database.")
+	email := flag.String("email", "", "The email of the TSP user to create")
+	flag.Parse()
+
+	//DB connection
+	err := pop.AddLookupPaths(*config)
+	if err != nil {
+		log.Fatal(err)
+	}
+	db, err := pop.Connect(*env)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if *email == "" {
+		log.Fatal("Usage: make_dps_user -email <my_email@example.com>")
+	}
+
+	newUser := models.DpsUser{
+		LoginGovEmail: *email,
+	}
+
+	mustSave(db, &newUser)
+}


### PR DESCRIPTION
## Description

A utility script to make DPS users.  Have to run `bin/make-dps-user -email <email>`.  This mirrors the scripts for office and tsp users.

This would have been helpful in testing https://github.com/transcom/mymove/pull/1401.

## Code Review Verification Steps

* [x] Request review from a member of a different team.