### PR TITLE
Adds call out panel on landing page for adding a PPM move to an HHG.

### DIFF
--- a/cypress/integration/mymove/hhgPPM.js
+++ b/cypress/integration/mymove/hhgPPM.js
@@ -1,7 +1,7 @@
 /* global cy */
 
 describe('service member adds a ppm to an hhg', function() {
-  it('service member clicks on Add PPM Shipment', function() {
+  it('service member clicks on Add PPM (DITY) Move', function() {
     serviceMemberSignsIn('f83bc69f-10aa-48b7-b9fe-425b393d49b8');
     serviceMemberAddsPPMToHHG();
     serviceMemberCancelsAddPPMToHHG();
@@ -22,7 +22,7 @@ function serviceMemberSignsIn(uuid) {
 function serviceMemberAddsPPMToHHG() {
   cy
     .get('.sidebar > div > button')
-    .contains('Add PPM Shipment')
+    .contains('Add PPM (DITY) Move')
     .click();
 
   cy.location().should(loc => {
@@ -145,7 +145,7 @@ function serviceMemberViewsUpdatedHomePage() {
   cy.get('body').should($div => {
     expect($div.text()).to.include('Government Movers and Packers');
     expect($div.text()).to.include('Move your own stuff');
-    expect($div.text()).to.not.include('Add PPM Shipment');
+    expect($div.text()).to.not.include('Add PPM (DITY) Move');
   });
 
   cy.get('.usa-width-three-fourths').should($div => {

--- a/cypress/integration/mymove/landingPages.js
+++ b/cypress/integration/mymove/landingPages.js
@@ -88,7 +88,7 @@ function ppmSubmitted(userId) {
   cy.signInAsUser(userId);
   cy.contains('Move your own stuff (PPM)');
   cy.contains('Next Step: Wait for approval');
-  cy.should('not.contain', 'Add PPM Shipment');
+  cy.should('not.contain', 'Add PPM (DITY) Move');
   cy.logout();
 }
 
@@ -104,7 +104,7 @@ function hhgMoveSummary(userId) {
   cy.signInAsUser(userId);
   cy.contains('Government Movers and Packers (HHG)');
   cy.contains('Next Step: Prepare for move');
-  cy.contains('Add PPM Shipment');
+  cy.contains('Add PPM (DITY) Move');
   cy.logout();
 }
 

--- a/src/scenes/Landing/MoveSummary.css
+++ b/src/scenes/Landing/MoveSummary.css
@@ -86,6 +86,11 @@ a {
   color: #ffffff;
 }
 
+.ppm-panel button:hover {
+  background-color: #205493;
+  color: #ffffff;
+}
+
 .ppm-panel .shipment_box {
   padding-bottom: 0;
 }

--- a/src/scenes/Landing/MoveSummary.css
+++ b/src/scenes/Landing/MoveSummary.css
@@ -74,8 +74,26 @@ a {
   color: #0071bc;
   background: transparent;
   padding: 0;
+  font-weight: 400;
 }
 
 .move-summary button.link:hover {
   color: #205493;
+}
+
+.ppm-panel button {
+  background-color: #0071bc;
+  color: #ffffff;
+}
+
+.ppm-panel .shipment_box {
+  padding-bottom: 0;
+}
+
+.ppm-panel .shipment_type {
+  background-color: #E1F2F8;
+}
+
+.ppm-panel .shipment_box_contents {
+  background-color: #F5FBFD;
 }

--- a/src/scenes/Landing/MoveSummary.jsx
+++ b/src/scenes/Landing/MoveSummary.jsx
@@ -204,8 +204,15 @@ const showHhgLandingPageText = shipment => {
 };
 
 export const SubmittedHhgMoveSummary = props => {
-  const { shipment } = props;
+  const { shipment, move, addPPMShipment, hhgAndPpmEnabled } = props;
+  const selectedMoveType = get(move, 'selected_move_type');
+  const moveId = get(move, 'id');
+  const showAddShipmentLink =
+    selectedMoveType === 'HHG' &&
+    ['SUBMITTED', 'ACCEPTED', 'AWARDED', 'APPROVED', 'IN_TRANSIT', 'DELIVERED', 'COMPLETED'].includes(move.status);
+
   let today = moment();
+
   return (
     <Fragment>
       <div>
@@ -255,6 +262,32 @@ export const SubmittedHhgMoveSummary = props => {
           </div>
         </div>
       </div>
+      {showAddShipmentLink &&
+        hhgAndPpmEnabled && (
+          <div className="ppm-panel">
+            <div className="shipment_box">
+              <div className="shipment_type">
+                <img className="move_sm" src={ppmCar} alt="ppm-car" />
+                Move your own stuff (PPM)
+              </div>
+              <div className="shipment_box_contents">
+                <div className="step-contents">
+                  <div className="status_box">
+                    <div className="step">
+                      <div className="title">Are you moving any items yourself or hiring your own mover?</div>
+                      <div>Tell us about your move to see if you're eligible for additional payment.</div>
+                    </div>
+                    <div className="step">
+                      <button className="usa-button-secondary" onClick={() => addPPMShipment(moveId)}>
+                        <FontAwesomeIcon icon={faPlus} /> Add PPM (DITY) Move
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
     </Fragment>
   );
 };
@@ -451,6 +484,7 @@ export const MoveSummary = withContext(props => {
     resumeMove,
     reviewProfile,
     requestPaymentSuccess,
+    addPPMShipment,
   } = props;
   const moveStatus = get(move, 'status', 'DRAFT');
   const moveId = get(move, 'id');
@@ -497,6 +531,8 @@ export const MoveSummary = withContext(props => {
               resumeMove={resumeMove}
               reviewProfile={reviewProfile}
               requestPaymentSuccess={requestPaymentSuccess}
+              addPPMShipment={addPPMShipment}
+              hhgAndPpmEnabled={hhgAndPpmEnabled}
             />
           )}
           {showPPM && (
@@ -528,9 +564,9 @@ export const MoveSummary = withContext(props => {
           <div>
             {showAddShipmentLink &&
               hhgAndPpmEnabled && (
-                <button className="link" onClick={() => props.addPPMShipment(moveId)}>
+                <button className="link" onClick={() => addPPMShipment(moveId)}>
                   <FontAwesomeIcon icon={faPlus} />
-                  <span> Add PPM Shipment</span>
+                  <span> Add PPM (DITY) Move</span>
                 </button>
               )}
           </div>

--- a/src/scenes/Landing/MoveSummary.test.jsx
+++ b/src/scenes/Landing/MoveSummary.test.jsx
@@ -14,6 +14,7 @@ describe('MoveSummary', () => {
   let wrapper, div;
   const editMoveFn = jest.fn();
   const resumeMoveFn = jest.fn();
+  const addPPMShipmentFn = jest.fn();
   const entitlementObj = { sum: '10000' };
   const serviceMember = { current_station: { name: 'Ft Carson' } };
   const ordersObj = {};
@@ -26,6 +27,7 @@ describe('MoveSummary', () => {
     hhgObj,
     editMoveFn,
     resumeMoveFn,
+    addPPMShipmentFn,
   ) => {
     const componentWrapper = shallow(
       <MoveSummary
@@ -37,6 +39,7 @@ describe('MoveSummary', () => {
         shipment={hhgObj}
         editMove={editMoveFn}
         resumeMove={resumeMoveFn}
+        addPPMShipment={addPPMShipmentFn}
       />,
     );
     return shallow(componentWrapper.props().children());
@@ -254,6 +257,7 @@ describe('MoveSummary', () => {
         editMoveFn,
         resumeMoveFn,
       ).find(SubmittedHhgMoveSummary);
+
       expect(subComponent.find(SubmittedHhgMoveSummary).length).toBe(1);
       expect(
         subComponent
@@ -281,6 +285,7 @@ describe('MoveSummary', () => {
         hhgObj,
         editMoveFn,
         resumeMoveFn,
+        addPPMShipmentFn,
       ).find(SubmittedHhgMoveSummary);
       expect(subComponent.find(SubmittedHhgMoveSummary).length).toBe(1);
       expect(


### PR DESCRIPTION
## Description

This PR introduces new functionality to allow a service member to see a call out panel on the move summary landing page for adding a PPM shipment. This feature is primarily an aesthetic enhancement to the landing page for `HHG/PPM` combo moves.

## Setup

1. `make server_run`
1. `make client_run`
1. Log in, complete SM profile and HHG move.
1. Navigate to Move Summary Landing Page, available at `localhost:3000/`

## Code Review Verification Steps

* [x] Design Review, _[coming shortly](https://defensedigitalservice.slack.com/archives/G8MKQ1AJF/p1543859589010700)_
* [x] This works in IE.
* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/162105896)

## Screenshots
<img width="1680" alt="screen shot 2018-12-03 at 1 45 07 pm" src="https://user-images.githubusercontent.com/7574207/49391556-5a31ab80-f702-11e8-9ba3-60f3a7c28d01.png">
