### PR TITLE
Prevents duplicate baseline line items from being saved.

### DIFF
--- a/pkg/handlers/publicapi/shipments.go
+++ b/pkg/handlers/publicapi/shipments.go
@@ -348,7 +348,7 @@ func (h DeliverShipmentHandler) Handle(params shipmentop.DeliverShipmentParams) 
 		return handlers.ResponseForError(h.Logger(), err)
 	}
 
-	verrs, err := shipment.SaveShipmentAndLineItems(h.DB(), append(lineItems, preApprovals...))
+	verrs, err := shipment.SaveShipmentAndLineItems(h.DB(), lineItems, preApprovals)
 	if err != nil || verrs.HasAny() {
 		return handlers.ResponseForVErrors(h.Logger(), verrs, err)
 	}

--- a/pkg/models/shipment.go
+++ b/pkg/models/shipment.go
@@ -704,6 +704,13 @@ func SaveShipmentAndAddresses(db *pop.Connection, shipment *Shipment) (*validate
 	return responseVErrors, responseError
 }
 
+var baseLine400ngItems = map[string]bool{
+	"LHS":  true,
+	"135A": true,
+	"135B": true,
+	"105A": true,
+}
+
 // SaveShipmentAndLineItems saves a shipment and a slice of line items in a single transaction.
 func (s *Shipment) SaveShipmentAndLineItems(db *pop.Connection, lineItems []ShipmentLineItem) (*validate.Errors, error) {
 	responseVErrors := validate.NewErrors()
@@ -720,16 +727,50 @@ func (s *Shipment) SaveShipmentAndLineItems(db *pop.Connection, lineItems []Ship
 		}
 
 		for _, lineItem := range lineItems {
-			if verrs, err := tx.ValidateAndSave(&lineItem); err != nil || verrs.HasAny() {
-				responseVErrors.Append(verrs)
-				responseError = errors.Wrapf(err, "Error saving shipment line item for shipment %s and item %s",
-					lineItem.ShipmentID, lineItem.Tariff400ngItemID)
-				return transactionError
+			var verrs *validate.Errors
+			var err error
+			if _, okay := baseLine400ngItems[lineItem.Tariff400ngItem.Code]; okay {
+				verrs, err = s.createUniqueShipmentLineItem(tx, lineItem)
+			} else {
+				verrs, err = tx.ValidateAndSave(&lineItem)
 			}
+			responseVErrors.Append(verrs)
+			responseError = errors.Wrapf(err, "Error saving shipment line item for shipment %s and item %s",
+				lineItem.ShipmentID, lineItem.Tariff400ngItemID)
+			return transactionError
 		}
 
 		return nil
 	})
 
 	return responseVErrors, responseError
+}
+
+// createUniqueShipmentLineItem will create the given shipment line item,
+func (s *Shipment) createUniqueShipmentLineItem(tx *pop.Connection, lineItem ShipmentLineItem) (*validate.Errors, error) {
+	existingLineItems, err := s.FetchShipmentLineItemsByItemID(tx, lineItem.Tariff400ngItemID)
+	if err != nil {
+		return validate.NewErrors(), err
+	}
+	if len(existingLineItems) > 0 {
+		var whichCode string
+		if len(lineItem.Tariff400ngItem.Code) > 0 {
+			whichCode = lineItem.Tariff400ngItem.Code
+		} else {
+			whichCode = lineItem.Tariff400ngItemID.String()
+		}
+		return validate.NewErrors(), errors.New("Line item already exists for item " + whichCode)
+	}
+	return tx.ValidateAndCreate(&lineItem)
+}
+
+// FetchShipmentLineItemsByItemID attempts to find line items for this shipment that have a given line item code.
+// If no line items for this code exist yet, return an empty slice.
+func (s *Shipment) FetchShipmentLineItemsByItemID(db *pop.Connection, tariff400ngItemID uuid.UUID) ([]ShipmentLineItem, error) {
+	var lineItems []ShipmentLineItem
+	err := db.Q().
+		Where("shipment_id = ?", s.ID).
+		Where("tariff400ng_item_id = ?", tariff400ngItemID).
+		All(&lineItems)
+	return lineItems, err
 }

--- a/pkg/models/shipment.go
+++ b/pkg/models/shipment.go
@@ -734,10 +734,12 @@ func (s *Shipment) SaveShipmentAndLineItems(db *pop.Connection, lineItems []Ship
 			} else {
 				verrs, err = tx.ValidateAndSave(&lineItem)
 			}
-			responseVErrors.Append(verrs)
-			responseError = errors.Wrapf(err, "Error saving shipment line item for shipment %s and item %s",
-				lineItem.ShipmentID, lineItem.Tariff400ngItemID)
-			return transactionError
+			if err != nil || verrs.HasAny() {
+				responseVErrors.Append(verrs)
+				responseError = errors.Wrapf(err, "Error saving shipment line item for shipment %s and item %s",
+					lineItem.ShipmentID, lineItem.Tariff400ngItemID)
+				return transactionError
+			}
 		}
 
 		return nil

--- a/pkg/models/shipment_test.go
+++ b/pkg/models/shipment_test.go
@@ -243,3 +243,66 @@ func (suite *ModelSuite) TestSaveShipmentAndLineItems() {
 	suite.NoError(err)
 	suite.False(verrs.HasAny())
 }
+
+// TestSaveShipmentAndLineItemsDisallowDuplicates tests that duplicate baseline charges with the same
+// tariff 400ng codes cannot be saved.
+func (suite *ModelSuite) TestSaveShipmentAndLineItemsDisallowBaselineDuplicates() {
+	shipment := testdatagen.MakeDefaultShipment(suite.db)
+	var lineItems []ShipmentLineItem
+
+	item := testdatagen.MakeTariff400ngItem(suite.db, testdatagen.Assertions{
+		Tariff400ngItem: Tariff400ngItem{
+			Code: "LHS",
+		},
+	})
+	testdatagen.MakeShipmentLineItem(suite.db, testdatagen.Assertions{
+		ShipmentLineItem: ShipmentLineItem{
+			Tariff400ngItem:   item,
+			ShipmentID:        shipment.ID,
+			Tariff400ngItemID: item.ID,
+			Shipment:          shipment,
+		},
+	})
+	lineItem := ShipmentLineItem{
+		ShipmentID:        shipment.ID,
+		Tariff400ngItemID: item.ID,
+		Tariff400ngItem:   item,
+	}
+	lineItems = append(lineItems, lineItem)
+	verrs, err := shipment.SaveShipmentAndLineItems(suite.db, lineItems)
+
+	suite.Error(err)
+	suite.False(verrs.HasAny())
+}
+
+// TestSaveShipmentAndLineItemsDisallowDuplicates tests that duplicate baseline charges with the same
+// tariff 400ng codes cannot be saved.
+func (suite *ModelSuite) TestSaveShipmentAndLineItemsAllowOtherDuplicates() {
+	shipment := testdatagen.MakeDefaultShipment(suite.db)
+	var lineItems []ShipmentLineItem
+
+	item := testdatagen.MakeTariff400ngItem(suite.db, testdatagen.Assertions{
+		Tariff400ngItem: Tariff400ngItem{
+			Code: "105B",
+		},
+	})
+	testdatagen.MakeShipmentLineItem(suite.db, testdatagen.Assertions{
+		ShipmentLineItem: ShipmentLineItem{
+			Tariff400ngItem:   item,
+			ShipmentID:        shipment.ID,
+			Tariff400ngItemID: item.ID,
+			Shipment:          shipment,
+		},
+	})
+
+	lineItem := ShipmentLineItem{
+		ShipmentID:        shipment.ID,
+		Tariff400ngItemID: item.ID,
+		Tariff400ngItem:   item,
+	}
+	lineItems = append(lineItems, lineItem)
+	verrs, err := shipment.SaveShipmentAndLineItems(suite.db, lineItems)
+
+	suite.NoError(err)
+	suite.False(verrs.HasAny())
+}

--- a/pkg/models/shipment_test.go
+++ b/pkg/models/shipment_test.go
@@ -238,7 +238,7 @@ func (suite *ModelSuite) TestSaveShipmentAndLineItems() {
 		lineItems = append(lineItems, lineItem)
 	}
 
-	verrs, err := shipment.SaveShipmentAndLineItems(suite.db, lineItems)
+	verrs, err := shipment.SaveShipmentAndLineItems(suite.db, lineItems, []ShipmentLineItem{})
 
 	suite.NoError(err)
 	suite.False(verrs.HasAny())
@@ -269,7 +269,7 @@ func (suite *ModelSuite) TestSaveShipmentAndLineItemsDisallowBaselineDuplicates(
 		Tariff400ngItem:   item,
 	}
 	lineItems = append(lineItems, lineItem)
-	verrs, err := shipment.SaveShipmentAndLineItems(suite.db, lineItems)
+	verrs, err := shipment.SaveShipmentAndLineItems(suite.db, lineItems, []ShipmentLineItem{})
 
 	suite.Error(err)
 	suite.False(verrs.HasAny())
@@ -301,7 +301,7 @@ func (suite *ModelSuite) TestSaveShipmentAndLineItemsAllowOtherDuplicates() {
 		Tariff400ngItem:   item,
 	}
 	lineItems = append(lineItems, lineItem)
-	verrs, err := shipment.SaveShipmentAndLineItems(suite.db, lineItems)
+	verrs, err := shipment.SaveShipmentAndLineItems(suite.db, []ShipmentLineItem{}, lineItems)
 
 	suite.NoError(err)
 	suite.False(verrs.HasAny())


### PR DESCRIPTION
## Description

Duplicate line items with the same baseline 400ng code should not be allowed. Duplicate line items with other accessorial codes should be allowed. 

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](./docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](./docs/backend.md#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](./docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
* [ ] There are no aXe warnings for UI.
* [ ] This works in IE.
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @willowbl00
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/162139822) for this change