### PR TITLE
Honeycomb Tracing Improvement

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -377,6 +377,7 @@ TraceFatal
 SubmitMoveHandler
 auth.office_user_id
 span.AddField
+span.AddTraceField
 zap.Object
 - /usr/local
 # Put all custom terms BEFORE this comment, lest you end up in an mdspell pain cycle.

--- a/cmd/webserver/main.go
+++ b/cmd/webserver/main.go
@@ -614,11 +614,11 @@ func main() {
 	if len(gitBranch) > 0 && len(gitCommit) > 0 {
 		root.Use(func(next http.Handler) http.Handler {
 			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				_, span := beeline.StartSpan(r.Context(), "BuildVariablesMiddleware")
-				span.AddField("git.branch", gitBranch)
-				span.AddField("git.commit", gitCommit)
-				span.Send()
-				next.ServeHTTP(w, r)
+				ctx, span := beeline.StartSpan(r.Context(), "BuildVariablesMiddleware")
+				defer span.Send()
+				span.AddTraceField("git.branch", gitBranch)
+				span.AddTraceField("git.commit", gitCommit)
+				next.ServeHTTP(w, r.WithContext(ctx))
 			})
 		})
 	}

--- a/docs/how-to/instrument-data-in-honeycomb.md
+++ b/docs/how-to/instrument-data-in-honeycomb.md
@@ -32,11 +32,17 @@ func (s *SocialSecurityNumber) SetEncryptedHash(ctx context.Context, unencrypted
 
 Be sure to pass the derived context from `beeline.StartSpan(...)` rather than the original context when passing context deeper into the function stack.  Reuse the variable name `ctx` when possible rather than allocating a new variable.
 
-Useful fields can be added to the span that would help with debugging. To do this you can use [span.AddField](https://github.com/honeycombio/beeline-go/blob/master/trace/trace.go#L173)
+Useful fields can be added to the span that would help with debugging. To do this you can use [span.AddField](https://github.com/honeycombio/beeline-go/blob/master/trace/trace.go#L173).
 
 ```golang
     err = move.Submit()
     span.AddField("move-status", string(move.Status))
+```
+
+You can add fields that apply to the entire function stack using [span.AddTraceField](https://github.com/honeycombio/beeline-go/blob/master/trace/trace.go#L206).  For example, the application name should be traced down through all the function calls.
+
+```golang
+    span.AddTraceField("auth.application_name", session.ApplicationName)
 ```
 
 ## Adding Zap Logs

--- a/pkg/auth/app_detector.go
+++ b/pkg/auth/app_detector.go
@@ -39,8 +39,11 @@ func DetectorMiddleware(logger *zap.Logger, myHostname string, officeHostname st
 	logger.Info("Creating host detector", zap.String("myHost", myHostname), zap.String("officeHost", officeHostname), zap.String("tspHost", tspHostname))
 	return func(next http.Handler) http.Handler {
 		mw := func(w http.ResponseWriter, r *http.Request) {
-			_, span := beeline.StartSpan(r.Context(), "DetectorMiddleware")
+			ctx, span := beeline.StartSpan(r.Context(), "DetectorMiddleware")
+			defer span.Send()
+
 			session := SessionFromRequestContext(r)
+
 			parts := strings.Split(r.Host, ":")
 			var appName application
 			if strings.EqualFold(parts[0], myHostname) {
@@ -56,10 +59,11 @@ func DetectorMiddleware(logger *zap.Logger, myHostname string, officeHostname st
 			}
 			session.ApplicationName = appName
 			session.Hostname = strings.ToLower(parts[0])
-			span.AddField("auth.application_name", session.ApplicationName)
-			span.AddField("auth.hostname", session.Hostname)
-			span.Send()
-			next.ServeHTTP(w, r)
+
+			span.AddTraceField("auth.application_name", session.ApplicationName)
+			span.AddTraceField("auth.hostname", session.Hostname)
+
+			next.ServeHTTP(w, r.WithContext(ctx))
 			return
 		}
 		return http.HandlerFunc(mw)


### PR DESCRIPTION
## Description

This PR fixes an issue we were having with honeycomb traces.  Application name and build variables (git commit hash and branch name) are now traced down the stack, which will make data analysis much easier.

Essentially we need to use `r.WithContext(ctx)` when passing context through middleware instead of passing the previous context.