### PR TITLE
Removes ability to add SIT estimate in HHG/PPM combo flow

### DIFF
--- a/src/scenes/Moves/Ppm/DateAndLocation.jsx
+++ b/src/scenes/Moves/Ppm/DateAndLocation.jsx
@@ -5,7 +5,13 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { getFormValues } from 'redux-form';
 import YesNoBoolean from 'shared/Inputs/YesNoBoolean';
-import { createOrUpdatePpm, getDestinationPostalCode, getPpmSitEstimate, setInitialFormValues } from './ducks';
+import {
+  createOrUpdatePpm,
+  getDestinationPostalCode,
+  getPpmSitEstimate,
+  isHHGPPMComboMove,
+  setInitialFormValues,
+} from './ducks';
 import { reduxifyWizardForm } from 'shared/WizardPage/Form';
 import { SwaggerField } from 'shared/JsonSchemaForm/JsonSchemaField';
 import { loadEntitlementsFromState } from 'shared/entitlements';
@@ -190,7 +196,7 @@ function mapStateToProps(state) {
     formValues: getFormValues(formName)(state),
     entitlement: loadEntitlementsFromState(state),
     hasEstimateError: state.ppm.hasEstimateError,
-    isHHGPPMComboMove: state.moves.currentMove.selected_move_type === 'HHG_PPM',
+    isHHGPPMComboMove: isHHGPPMComboMove(state),
   };
   const defaultPickupZip = get(state.serviceMember, 'currentServiceMember.residential_address.postal_code');
   const currentOrders = state.orders.currentOrders;

--- a/src/scenes/Review/EditDateAndLocation.jsx
+++ b/src/scenes/Review/EditDateAndLocation.jsx
@@ -14,11 +14,21 @@ import { createOrUpdatePpm, getPpmSitEstimate } from 'scenes/Moves/Ppm/ducks';
 import { loadEntitlementsFromState } from 'shared/entitlements';
 import 'scenes/Moves/Ppm/DateAndLocation.css';
 import { editBegin, editSuccessful, entitlementChangeBegin } from './ducks';
+import { isHHGPPMComboMove } from '../Moves/Ppm/ducks';
 
 const sitEstimateDebounceTime = 300;
 
 let EditDateAndLocationForm = props => {
-  const { handleSubmit, currentOrders, getSitEstimate, schema, valid, sitReimbursement, submitting } = props;
+  const {
+    handleSubmit,
+    currentOrders,
+    getSitEstimate,
+    schema,
+    valid,
+    sitReimbursement,
+    submitting,
+    isHHGPPMComboMove,
+  } = props;
   return (
     <form onSubmit={handleSubmit}>
       <h1 className="sm-heading"> Edit PPM Dates & Locations </h1>
@@ -46,7 +56,7 @@ let EditDateAndLocationForm = props => {
         The ZIP code for {currentOrders && currentOrders.new_duty_station.name} is{' '}
         {currentOrders && currentOrders.new_duty_station.address.postal_code}{' '}
       </span>
-      <SwaggerField fieldName="has_sit" swagger={schema} component={YesNoBoolean} />
+      {!isHHGPPMComboMove && <SwaggerField fieldName="has_sit" swagger={schema} component={YesNoBoolean} />}
       {get(props, 'formValues.has_sit', false) && (
         <Fragment>
           <SwaggerField
@@ -123,7 +133,7 @@ class EditDateAndLocation extends Component {
   }
 
   render() {
-    const { initialValues, schema, formValues, sitReimbursement, currentOrders, error } = this.props;
+    const { initialValues, schema, formValues, sitReimbursement, currentOrders, error, isHHGPPMComboMove } = this.props;
     return (
       <div className="usa-grid">
         {error && (
@@ -144,6 +154,7 @@ class EditDateAndLocation extends Component {
             currentOrders={currentOrders}
             onCancel={this.returnToReview}
             createOrUpdatePpm={createOrUpdatePpm}
+            isHHGPPMComboMove={isHHGPPMComboMove}
           />
         </div>
       </div>
@@ -167,6 +178,7 @@ function mapStateToProps(state) {
     entitlement: loadEntitlementsFromState(state),
     error: get(state, 'ppm.error'),
     hasSubmitError: get(state, 'ppm.hasSubmitError'),
+    isHHGPPMComboMove: isHHGPPMComboMove(state),
   };
   const defaultPickupZip = get(state.serviceMember, 'currentServiceMember.residential_address.postal_code');
   props.initialValues = props.currentPpm


### PR DESCRIPTION
## Description

This PR fixes a pre-existing bug that allowed a service member to add a storage in transit estimate on the review page of the move. 

## Setup

1. `make server_run`
1. `make client_run`
1. Log in, complete SM profile, HHG shipment, and add a PPM to the existing move.
1. Navigate to Move Review Page, available at `localhost:3000/review/:moveId/review/edit-date-and-location`.

## Code Review Verification Steps

* [x] This works in IE.
* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/162217171) 

## Screenshots

<img width="1680" alt="screen shot 2018-12-04 at 3 35 50 pm" src="https://user-images.githubusercontent.com/7574207/49468264-ced81900-f7da-11e8-8cb7-58fc79233f68.png">
