### PR TITLE
Adds pointer for weight entitlements.

### DIFF
--- a/src/scenes/EntitlementBar/index.css
+++ b/src/scenes/EntitlementBar/index.css
@@ -12,3 +12,11 @@
   margin-top: -1em;
   margin-bottom: 1em;
 }
+
+.entitlement-container a {
+  cursor: pointer;
+}
+
+.usa-alert a {
+  cursor: pointer;
+}


### PR DESCRIPTION
## Description

This PR fixes a pre-existing bug that did not display a pointer on the `hhg-ppm-size` page for the `What's this?` link and the `Close` link on the entitlement help bar text

## Setup

1. make server_run
1. make client_run
1. Log in, complete SM profile, HHG shipment
1. Add a PPM to the existing move, navigating to the
HHG PPM Size Page, available at `http://localhost:3000/moves/:moveId/hhg-ppm-size`.
1. Hover over `What's this?` link and, once opening it hover over the `Close` link to see the updated changes.

## Code Review Verification Steps

* [x] This works in IE.
* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/162392228)
