### PR TITLE
Adds padding left and bottom to review section for hhg shipment summary

### DIFF
--- a/src/scenes/Review/Review.css
+++ b/src/scenes/Review/Review.css
@@ -8,7 +8,8 @@
 }
 
 .review-section {
-  padding-top: 1.5rem;
+  padding-left: 1.5rem;
+  padding-bottom: 1rem;
 }
 
 .review-section .notice {


### PR DESCRIPTION
## Description

This PR fixes a pre-existing bug that did not display the proper hhg shipment summary with proper surrounding spacing (padding).

## Setup

1. make server_run
1. make client_run
1. Log in, complete SM profile, 
1. HHG shipment
1. Nagivate and review shipment at `http://localhost:3000/moves/:moveId/review`

## Code Review Verification Steps

* [x] This works in IE.
* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/162392236)

## Screenshots
<img width="758" alt="screen shot 2018-12-04 at 4 09 52 pm" src="https://user-images.githubusercontent.com/5531789/49481286-21b3cf80-f7df-11e8-8b8f-eb2a4e18ff00.png">
