### PR TITLE
Add migration hackerone office and tsp users on staging (values on staging only)

### DIFF
--- a/local_migrations/20181205002335_add-hackerone-users-to-staging.sql
+++ b/local_migrations/20181205002335_add-hackerone-users-to-staging.sql
@@ -1,0 +1,4 @@
+-- Local test migration.
+-- This will be run on development environments. It should mirror what you
+-- intend to apply on production, but do not include any sensitive data.
+-- Leaving empty since these users are going to be removed in the near future.

--- a/migrations/20181205002335_add-hackerone-users-to-staging.up.fizz
+++ b/migrations/20181205002335_add-hackerone-users-to-staging.up.fizz
@@ -1,0 +1,1 @@
+exec("./apply-secure-migration.sh 20181205002335_add-hackerone-users-to-staging.sql")


### PR DESCRIPTION
## Description

This secure migration adds 60 hacker office_users and 20 hacker tsp_users to each of 3 TSPs to staging.  Only the staging S3 bucket adds users; prod and experimental have empty files uploaded to S3.

## Setup

1) `bin/run-prod-migrations` and then check the office_users and tsp_users tables. They should not contain any of the hackerone emails (first name 'hacker')
2) In the bin/run-prod-migrations file, replace line 11 with `export AWS_S3_BUCKET_NAME=transcom-ppp-app-staging-us-west-2`
Then run `bin/run-prod-migrations` (which is really running the staging migrations).  Check the office_users and tsp_users tables.  They should each contain 60 users with the first name 'hacker'.
Be sure to undo the changes on `bin/run-prod-migrations` when done.

## Code Review Verification Steps

* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](./docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/162357282) for this change

