### PR TITLE
HHG+PPM Edit Page

### DIFF
--- a/cypress/integration/mymove/hhgPPM.js
+++ b/cypress/integration/mymove/hhgPPM.js
@@ -1,77 +1,179 @@
 /* global cy */
 
 describe('service member adds a ppm to an hhg', function() {
-  it('service member clicks on Add PPM Shipment', function() {
-    serviceMemberSignsIn('f83bc69f-10aa-48b7-b9fe-425b393d49b8');
-    serviceMemberAddsPPMToHHG();
-    serviceMemberCancelsAddPPMToHHG();
-    serviceMemberContinuesPPMSetup();
-    serviceMemberFillsInDatesAndLocations();
-    serviceMemberSelectsWeightRange();
-    serviceMemberCanCustomizeWeight();
-    serviceMemberCanReviewMoveSummary();
-    serviceMemberCanSignAgreement();
-    serviceMemberViewsUpdatedHomePage();
-  });
+  // it('service member clicks on Add PPM Shipment', function() {
+  //   serviceMemberSignsIn('f83bc69f-10aa-48b7-b9fe-425b393d49b8');
+  //   serviceMemberAddsPPMToHHG();
+  //   serviceMemberCancelsAddPPMToHHG();
+  //   serviceMemberContinuesPPMSetup();
+  //   serviceMemberFillsInDatesAndLocations();
+  //   serviceMemberSelectsWeightRange();
+  //   serviceMemberCanCustomizeWeight();
+  //   serviceMemberCanReviewMoveSummary();
+  //   serviceMemberCanSignAgreement();
+  //   serviceMemberViewsUpdatedHomePage();
+  // });
   it('service member edits an HHG_PPM Shipment', function() {
     serviceMemberSignsIn('f83bc69f-10aa-48b7-b9fe-425b393d49b8');
     serviceMemberClicksEditMove();
-    serviceMemberVerifiesHHGPPMSummary();
+    // serviceMemberVerifiesHHGPPMSummary();
+    serviceMemberEditsProfileSection();
+    serviceMemberVerifiesProfileWasEditted();
+    serviceMemberEditsOrdersSection();
+    serviceMemberVerifiesOrderWasEditted();
+    serviceMemberEditsContactInfoSection();
+    serviceMemberVerifiesContactInfoWasEditted();
+    serviceMemberEditsBackupContactInfoSection();
+    serviceMemberVerifiesBackupContactInfoWasEditted();
   });
 });
 
-function serviceMemberVerifiesHHGPPMSummary() {
-  cy.location().should(loc => {
-    expect(loc.pathname).to.match(/^\/moves\/[^/]+\/edit/);
-  });
-
+function serviceMemberVerifiesBackupContactInfoWasEditted() {
   cy.get('.review-content').should($div => {
     const text = $div.text();
-    // Profile section
-    expect(text).to.include('Name: HHG Ready  For PPM');
-    expect(text).to.include('Branch:Army');
-    expect(text).to.include('Rank/Pay Grade: E-1');
-    expect(text).to.include('DoD ID#: 7777567890');
-    expect(text).to.include('Current Duty Station: Yuma AFB');
-
-    // Orders section
-    expect(text).to.include('Orders Type: Permanent Change Of Station');
-    expect(text).to.include('Orders Date:  05/20/2018');
-    expect(text).to.include('Report-by Date: 08/01/2018');
-    expect(text).to.include('New Duty Station:  Yuma AFB');
-    expect(text).to.include('Dependents?:  Yes');
-    expect(text).to.include('Spouse Pro Gear?: Yes');
-    expect(text).to.include('Orders Uploaded: 1');
-
-    // Contact Info
-    expect(text).to.include('Best Contact Phone: 555-555-5555');
-    expect(text).to.include('Alt. Phone:');
-    expect(text).to.include('Personal Email: hhgforppm@award.ed');
-    expect(text).to.include('Preferred Contact Method: Email');
-    expect(text).to.include('Current Mailing Address: 123 Any Street');
-    expect(text).to.include('P.O. Box 12345');
-    expect(text).to.include('Beverly Hills, CA 90210');
-    expect(text).to.include('Backup Mailing Address: 123 Any Street');
-    expect(text).to.include('P.O. Box 12345');
-    expect(text).to.include('Beverly Hills, CA 90210');
-
-    // Backup Contact info
-    expect(text).to.include('Backup Contact: name');
-    expect(text).to.include('Email:  email@example.com');
-    expect(text).to.include('Phone:  555-555-5555');
+    console.log(text);
+    expect(text).to.include('Backup Contact: Backup Name');
+    expect(text).to.include('Email:  backup@example.com');
+    expect(text).to.include('Phone:  323-111-1111');
   });
+}
 
-  cy.get('body').should($div => expect($div.text()).not.to.include('Government moves all of your stuff (HHG)'));
-  cy.get('.ppm-container').should($div => {
+function serviceMemberEditsBackupContactInfoSection() {
+  cy
+    .get('.review-content .edit-section-link')
+    .eq(3)
+    .click();
+
+  typeInInput({ name: 'name', value: 'Backup Name' });
+  typeInInput({ name: 'email', value: 'backup@example.com' });
+  typeInInput({ name: 'telephone', value: '323-111-1111' });
+
+  cy
+    .get('button')
+    .contains('Save')
+    .click();
+}
+
+function serviceMemberVerifiesContactInfoWasEditted() {
+  cy.get('.review-content').should($div => {
     const text = $div.text();
-    expect(text).to.include('Shipment - You move your stuff (PPM)');
-    expect(text).to.include('Move Date: 05/20/2018');
-    expect(text).to.include('Pickup ZIP Code:  90210');
-    expect(text).to.include('Delivery ZIP Code:  50309');
-    expect(text).not.to.include('Storage: Not requested');
-    expect(text).to.include('Estimated Weight:  1,50');
-    expect(text).to.include('Estimated PPM Incentive:  $4,255.80 - 4,703.78');
+    expect(text).to.include('Best Contact Phone: 213-111-1111');
+    expect(text).to.include('Alt. Phone: 222-222-2222');
+    expect(text).to.include('Personal Email: hhgforppm@awarded.com');
+    expect(text).to.include('Preferred Contact Method: Phone, Text, Email');
+    expect(text).to.include('Current Mailing Address: 321 Any Street');
+    expect(text).to.include('Los Angeles, CO 91206');
+
+    expect(text).to.include('Backup Mailing Address: 333 Any Street');
+    expect(text).to.include('P.O Box 54321');
+    expect(text).to.include('Los Angeles, CT 91206');
   });
+}
+
+function serviceMemberEditsContactInfoSection() {
+  cy
+    .get('.review-content .edit-section-link')
+    .eq(2)
+    .click();
+
+  typeInInput({ name: 'serviceMember.telephone', value: '213-111-1111' });
+  typeInInput({ name: 'serviceMember.secondary_telephone', value: '222-222-2222' });
+  typeInInput({ name: 'serviceMember.personal_email', value: 'hhgforppm@awarded.com' });
+  cy.get('[type="checkbox"]').check({ force: true });
+  typeInInput({ name: 'resAddress.street_address_1', value: '321 Any Street' });
+  typeInInput({ name: 'resAddress.street_address_2', value: 'P.O Box 54321' });
+  typeInInput({ name: 'resAddress.city', value: 'Los Angeles' });
+  cy.get('select[name="resAddress.state"]').select('CO');
+  typeInInput({ name: 'resAddress.postal_code', value: '91206' });
+
+  typeInInput({ name: 'backupAddress.street_address_1', value: '333 Any Street' });
+  typeInInput({ name: 'backupAddress.street_address_2', value: 'P.O Box 54321' });
+  typeInInput({ name: 'backupAddress.city', value: 'Los Angeles' });
+  cy.get('select[name="backupAddress.state"]').select('CT');
+  typeInInput({ name: 'backupAddress.postal_code', value: '91206' });
+
+  cy
+    .get('button')
+    .contains('Save')
+    .click();
+}
+
+function serviceMemberVerifiesOrderWasEditted() {
+  cy.get('.review-content').should($div => {
+    const text = $div.text();
+    expect(text).to.include('Orders Type: Local Move');
+    expect(text).to.include('Orders Date:  05/26/2018');
+    expect(text).to.include('Report-by Date: 09/01/2018');
+    expect(text).to.include('New Duty Station:  NAS Fort Worth');
+    expect(text).to.include('Dependents?:  No');
+    expect(text).to.include('Orders Uploaded: 1');
+  });
+}
+
+function serviceMemberEditsOrdersSection() {
+  cy
+    .get('.review-content .edit-section-link')
+    .eq(1)
+    .click();
+
+  cy.get('select[name="orders_type"]').select('Local Move');
+  typeInInput({ name: 'issue_date', value: '5/26/2018' });
+  typeInInput({ name: 'report_by_date', value: '9/1/2018' });
+  cy.get('input[type="radio"]').check('no', { force: true }); // checks yes for both radios on form
+  cy
+    .get('.duty-input-box #react-select-3-input')
+    .first()
+    .type('NAS Fort Worth{downarrow}{enter}', { force: true, delay: 150 });
+  cy
+    .get('button')
+    .contains('Save')
+    .click();
+}
+
+function typeInInput({ name, value }) {
+  cy
+    .get(`input[name="${name}"]`)
+    .clear()
+    .type(value)
+    .blur();
+}
+
+function serviceMemberVerifiesProfileWasEditted() {
+  cy.get('.review-content').should($div => {
+    const text = $div.text();
+    console.log(text);
+    expect(text).to.include('Name: Harry James Potter Sr');
+    expect(text).to.include('Branch:Air Force');
+    expect(text).to.include('Rank/Pay Grade: E-9');
+    expect(text).to.include('DoD ID#: 9876543210');
+    expect(text).to.include('Current Duty Station: NAS Fort Worth');
+  });
+}
+
+function serviceMemberEditsProfileSection() {
+  cy
+    .get('.review-content .edit-section-link')
+    .first()
+    .click();
+
+  typeInInput({ name: 'first_name', value: 'Harry' });
+  typeInInput({ name: 'middle_name', value: 'James' });
+  typeInInput({ name: 'last_name', value: 'Potter' });
+  typeInInput({ name: 'suffix', value: 'Sr' });
+  cy.get('select[name="affiliation"]').select('Air Force');
+  cy.get('select[name="rank"]').select('E-9');
+  cy
+    .get('input[name="edipi"]')
+    .clear()
+    .type('9876543210');
+  cy
+    .get('.duty-input-box #react-select-2-input')
+    .first()
+    .type('NAS Fort Worth{downarrow}{enter}', { force: true, delay: 150 });
+  cy
+    .get('button')
+    .contains('Save')
+    .click();
 }
 
 function serviceMemberClicksEditMove() {
@@ -220,5 +322,59 @@ function serviceMemberViewsUpdatedHomePage() {
     expect(text).to.include('Next Step: Wait for approval');
     expect(text).to.include('Weight (est.): 150');
     expect(text).to.include('Incentive (est.): $4,255.80 - 4,703.78');
+  });
+}
+
+function serviceMemberVerifiesHHGPPMSummary() {
+  cy.location().should(loc => {
+    expect(loc.pathname).to.match(/^\/moves\/[^/]+\/edit/);
+  });
+
+  cy.get('.review-content').should($div => {
+    const text = $div.text();
+    // Profile section
+    expect(text).to.include('Name: HHG Ready  For PPM');
+    expect(text).to.include('Branch:Army');
+    expect(text).to.include('Rank/Pay Grade: E-1');
+    expect(text).to.include('DoD ID#: 7777567890');
+    expect(text).to.include('Current Duty Station: Yuma AFB');
+
+    // Orders section
+    expect(text).to.include('Orders Type: Permanent Change Of Station');
+    expect(text).to.include('Orders Date:  05/20/2018');
+    expect(text).to.include('Report-by Date: 08/01/2018');
+    expect(text).to.include('New Duty Station:  Yuma AFB');
+    expect(text).to.include('Dependents?:  Yes');
+    expect(text).to.include('Spouse Pro Gear?: Yes');
+    expect(text).to.include('Orders Uploaded: 1');
+
+    // Contact Info
+    expect(text).to.include('Best Contact Phone: 555-555-5555');
+    expect(text).to.include('Alt. Phone:');
+    expect(text).to.include('Personal Email: hhgforppm@award.ed');
+    expect(text).to.include('Preferred Contact Method: Email');
+    expect(text).to.include('Current Mailing Address: 123 Any Street');
+    expect(text).to.include('P.O. Box 12345');
+    expect(text).to.include('Beverly Hills, CA 90210');
+    expect(text).to.include('Backup Mailing Address: 123 Any Street');
+    expect(text).to.include('P.O. Box 12345');
+    expect(text).to.include('Beverly Hills, CA 90210');
+
+    // Backup Contact info
+    expect(text).to.include('Backup Contact: name');
+    expect(text).to.include('Email:  email@example.com');
+    expect(text).to.include('Phone:  555-555-5555');
+  });
+
+  cy.get('body').should($div => expect($div.text()).not.to.include('Government moves all of your stuff (HHG)'));
+  cy.get('.ppm-container').should($div => {
+    const text = $div.text();
+    expect(text).to.include('Shipment - You move your stuff (PPM)');
+    expect(text).to.include('Move Date: 05/20/2018');
+    expect(text).to.include('Pickup ZIP Code:  90210');
+    expect(text).to.include('Delivery ZIP Code:  50309');
+    expect(text).not.to.include('Storage: Not requested');
+    expect(text).to.include('Estimated Weight:  1,50');
+    expect(text).to.include('Estimated PPM Incentive:  $4,255.80 - 4,703.78');
   });
 }

--- a/cypress/integration/mymove/hhgPPM.js
+++ b/cypress/integration/mymove/hhgPPM.js
@@ -1,22 +1,21 @@
 /* global cy */
 
 describe('service member adds a ppm to an hhg', function() {
-  // it('service member clicks on Add PPM Shipment', function() {
-  //   serviceMemberSignsIn('f83bc69f-10aa-48b7-b9fe-425b393d49b8');
-  //   serviceMemberAddsPPMToHHG();
-  //   serviceMemberCancelsAddPPMToHHG();
-  //   serviceMemberContinuesPPMSetup();
-  //   serviceMemberFillsInDatesAndLocations();
-  //   serviceMemberSelectsWeightRange();
-  //   serviceMemberCanCustomizeWeight();
-  //   serviceMemberCanReviewMoveSummary();
-  //   serviceMemberCanSignAgreement();
-  //   serviceMemberViewsUpdatedHomePage();
-  // });
+  it('service member clicks on Add PPM Shipment', function() {
+    serviceMemberSignsIn('f83bc69f-10aa-48b7-b9fe-425b393d49b8');
+    serviceMemberAddsPPMToHHG();
+    serviceMemberCancelsAddPPMToHHG();
+    serviceMemberContinuesPPMSetup();
+    serviceMemberFillsInDatesAndLocations();
+    serviceMemberSelectsWeightRange();
+    serviceMemberCanCustomizeWeight();
+    serviceMemberCanReviewMoveSummary();
+    serviceMemberCanSignAgreement();
+    serviceMemberViewsUpdatedHomePage();
+  });
   it('service member edits an HHG_PPM Shipment', function() {
     serviceMemberSignsIn('f83bc69f-10aa-48b7-b9fe-425b393d49b8');
     serviceMemberClicksEditMove();
-    // serviceMemberVerifiesHHGPPMSummary();
     serviceMemberEditsProfileSection();
     serviceMemberVerifiesProfileWasEditted();
     serviceMemberEditsOrdersSection();
@@ -25,13 +24,71 @@ describe('service member adds a ppm to an hhg', function() {
     serviceMemberVerifiesContactInfoWasEditted();
     serviceMemberEditsBackupContactInfoSection();
     serviceMemberVerifiesBackupContactInfoWasEditted();
+    serviceMemberEditsPPMDatesAndLocations();
+    serviceMemberVerifiesPPMDatesAndLocationsEditted();
+    serviceMemberEditsPPMWeight();
+    serviceMemberVerifiesPPMWeightsEditted();
   });
 });
+
+function serviceMemberVerifiesPPMWeightsEditted() {
+  cy.get('.ppm-container').should($div => {
+    const text = $div.text();
+
+    expect(text).to.include('Estimated Weight:  1,700 lbs');
+    expect(text).to.include('Estimated PPM Incentive:  $4,736.63 - 5,235.23');
+  });
+}
+
+function serviceMemberEditsPPMWeight() {
+  cy
+    .get('.ppm-container .edit-section-link')
+    .last()
+    .click();
+
+  typeInInput({ name: 'weight_estimate', value: '1700' });
+
+  cy.get('strong').contains('$4,736.63 - 5,235.23');
+  cy.get('.subtext').contains('Originally $4,255.80 - 4,255.80');
+
+  cy
+    .get('button')
+    .contains('Save')
+    .click();
+}
+function serviceMemberVerifiesPPMDatesAndLocationsEditted() {
+  cy.get('.ppm-container').should($div => {
+    const text = $div.text();
+    console.log(text);
+    expect(text).to.include('Move Date: 05/28/2018');
+    expect(text).to.include('Pickup ZIP Code:  91206');
+    expect(text).to.include('Additional Pickup:  90042');
+    expect(text).to.include('Delivery ZIP Code:  50308');
+  });
+}
+function serviceMemberEditsPPMDatesAndLocations() {
+  cy
+    .get('.ppm-container .edit-section-link')
+    .first()
+    .click();
+
+  typeInInput({ name: 'planned_move_date', value: '5/28/2018' });
+  typeInInput({ name: 'pickup_postal_code', value: '91206' });
+  cy.get('input[type="radio"]').check('yes', { force: true }); // checks yes for both radios on form
+  typeInInput({ name: 'additional_pickup_postal_code', value: '90042' });
+  typeInInput({ name: 'destination_postal_code', value: '50308' });
+  cy.get('input[type="radio"]').check('yes', { force: true }); // checks yes for both radios on form
+  typeInInput({ name: 'days_in_storage', value: '60' });
+
+  cy
+    .get('button')
+    .contains('Save')
+    .click();
+}
 
 function serviceMemberVerifiesBackupContactInfoWasEditted() {
   cy.get('.review-content').should($div => {
     const text = $div.text();
-    console.log(text);
     expect(text).to.include('Backup Contact: Backup Name');
     expect(text).to.include('Email:  backup@example.com');
     expect(text).to.include('Phone:  323-111-1111');
@@ -322,59 +379,5 @@ function serviceMemberViewsUpdatedHomePage() {
     expect(text).to.include('Next Step: Wait for approval');
     expect(text).to.include('Weight (est.): 150');
     expect(text).to.include('Incentive (est.): $4,255.80 - 4,703.78');
-  });
-}
-
-function serviceMemberVerifiesHHGPPMSummary() {
-  cy.location().should(loc => {
-    expect(loc.pathname).to.match(/^\/moves\/[^/]+\/edit/);
-  });
-
-  cy.get('.review-content').should($div => {
-    const text = $div.text();
-    // Profile section
-    expect(text).to.include('Name: HHG Ready  For PPM');
-    expect(text).to.include('Branch:Army');
-    expect(text).to.include('Rank/Pay Grade: E-1');
-    expect(text).to.include('DoD ID#: 7777567890');
-    expect(text).to.include('Current Duty Station: Yuma AFB');
-
-    // Orders section
-    expect(text).to.include('Orders Type: Permanent Change Of Station');
-    expect(text).to.include('Orders Date:  05/20/2018');
-    expect(text).to.include('Report-by Date: 08/01/2018');
-    expect(text).to.include('New Duty Station:  Yuma AFB');
-    expect(text).to.include('Dependents?:  Yes');
-    expect(text).to.include('Spouse Pro Gear?: Yes');
-    expect(text).to.include('Orders Uploaded: 1');
-
-    // Contact Info
-    expect(text).to.include('Best Contact Phone: 555-555-5555');
-    expect(text).to.include('Alt. Phone:');
-    expect(text).to.include('Personal Email: hhgforppm@award.ed');
-    expect(text).to.include('Preferred Contact Method: Email');
-    expect(text).to.include('Current Mailing Address: 123 Any Street');
-    expect(text).to.include('P.O. Box 12345');
-    expect(text).to.include('Beverly Hills, CA 90210');
-    expect(text).to.include('Backup Mailing Address: 123 Any Street');
-    expect(text).to.include('P.O. Box 12345');
-    expect(text).to.include('Beverly Hills, CA 90210');
-
-    // Backup Contact info
-    expect(text).to.include('Backup Contact: name');
-    expect(text).to.include('Email:  email@example.com');
-    expect(text).to.include('Phone:  555-555-5555');
-  });
-
-  cy.get('body').should($div => expect($div.text()).not.to.include('Government moves all of your stuff (HHG)'));
-  cy.get('.ppm-container').should($div => {
-    const text = $div.text();
-    expect(text).to.include('Shipment - You move your stuff (PPM)');
-    expect(text).to.include('Move Date: 05/20/2018');
-    expect(text).to.include('Pickup ZIP Code:  90210');
-    expect(text).to.include('Delivery ZIP Code:  50309');
-    expect(text).not.to.include('Storage: Not requested');
-    expect(text).to.include('Estimated Weight:  1,50');
-    expect(text).to.include('Estimated PPM Incentive:  $4,255.80 - 4,703.78');
   });
 }

--- a/cypress/integration/mymove/hhgPPM.js
+++ b/cypress/integration/mymove/hhgPPM.js
@@ -13,7 +13,73 @@ describe('service member adds a ppm to an hhg', function() {
     serviceMemberCanSignAgreement();
     serviceMemberViewsUpdatedHomePage();
   });
+  it('service member edits an HHG_PPM Shipment', function() {
+    serviceMemberSignsIn('f83bc69f-10aa-48b7-b9fe-425b393d49b8');
+    serviceMemberClicksEditMove();
+    serviceMemberVerifiesHHGPPMSummary();
+  });
 });
+
+function serviceMemberVerifiesHHGPPMSummary() {
+  cy.location().should(loc => {
+    expect(loc.pathname).to.match(/^\/moves\/[^/]+\/edit/);
+  });
+
+  cy.get('.review-content').should($div => {
+    const text = $div.text();
+    // Profile section
+    expect(text).to.include('Name: HHG Ready  For PPM');
+    expect(text).to.include('Branch:Army');
+    expect(text).to.include('Rank/Pay Grade: E-1');
+    expect(text).to.include('DoD ID#: 7777567890');
+    expect(text).to.include('Current Duty Station: Yuma AFB');
+
+    // Orders section
+    expect(text).to.include('Orders Type: Permanent Change Of Station');
+    expect(text).to.include('Orders Date:  05/20/2018');
+    expect(text).to.include('Report-by Date: 08/01/2018');
+    expect(text).to.include('New Duty Station:  Yuma AFB');
+    expect(text).to.include('Dependents?:  Yes');
+    expect(text).to.include('Spouse Pro Gear?: Yes');
+    expect(text).to.include('Orders Uploaded: 1');
+
+    // Contact Info
+    expect(text).to.include('Best Contact Phone: 555-555-5555');
+    expect(text).to.include('Alt. Phone:');
+    expect(text).to.include('Personal Email: hhgforppm@award.ed');
+    expect(text).to.include('Preferred Contact Method: Email');
+    expect(text).to.include('Current Mailing Address: 123 Any Street');
+    expect(text).to.include('P.O. Box 12345');
+    expect(text).to.include('Beverly Hills, CA 90210');
+    expect(text).to.include('Backup Mailing Address: 123 Any Street');
+    expect(text).to.include('P.O. Box 12345');
+    expect(text).to.include('Beverly Hills, CA 90210');
+
+    // Backup Contact info
+    expect(text).to.include('Backup Contact: name');
+    expect(text).to.include('Email:  email@example.com');
+    expect(text).to.include('Phone:  555-555-5555');
+  });
+
+  cy.get('body').should($div => expect($div.text()).not.to.include('Government moves all of your stuff (HHG)'));
+  cy.get('.ppm-container').should($div => {
+    const text = $div.text();
+    expect(text).to.include('Shipment - You move your stuff (PPM)');
+    expect(text).to.include('Move Date: 05/20/2018');
+    expect(text).to.include('Pickup ZIP Code:  90210');
+    expect(text).to.include('Delivery ZIP Code:  50309');
+    expect(text).not.to.include('Storage: Not requested');
+    expect(text).to.include('Estimated Weight:  1,50');
+    expect(text).to.include('Estimated PPM Incentive:  $4,255.80 - 4,703.78');
+  });
+}
+
+function serviceMemberClicksEditMove() {
+  cy
+    .get('.usa-button-secondary')
+    .contains('Edit Move')
+    .click();
+}
 
 function serviceMemberSignsIn(uuid) {
   cy.signInAsUser(uuid);

--- a/src/scenes/Review/Summary.jsx
+++ b/src/scenes/Review/Summary.jsx
@@ -77,18 +77,16 @@ export class Summary extends Component {
             </Alert>
           )}
 
-        {!isHHGPPMComboMove && (
-          <ServiceMemberSummary
-            orders={currentOrders}
-            backupContacts={currentBackupContacts}
-            serviceMember={serviceMember}
-            schemaRank={schemaRank}
-            schemaAffiliation={schemaAffiliation}
-            schemaOrdersType={schemaOrdersType}
-            moveIsApproved={moveIsApproved}
-            editOrdersPath={editOrdersPath}
-          />
-        )}
+        <ServiceMemberSummary
+          orders={currentOrders}
+          backupContacts={currentBackupContacts}
+          serviceMember={serviceMember}
+          schemaRank={schemaRank}
+          schemaAffiliation={schemaAffiliation}
+          schemaOrdersType={schemaOrdersType}
+          moveIsApproved={moveIsApproved}
+          editOrdersPath={editOrdersPath}
+        />
 
         {currentPpm && (
           <PPMShipmentSummary ppm={currentPpm} movePath={rootAddressWithMoveId} isHHGPPMComboMove={isHHGPPMComboMove} />

--- a/src/scenes/Review/Summary.jsx
+++ b/src/scenes/Review/Summary.jsx
@@ -62,6 +62,9 @@ export class Summary extends Component {
 
     const showPPMShipmentSummary =
       (isReviewPage && currentPpm) || (!isReviewPage && currentPpm && currentPpm.status !== 'DRAFT');
+    const showHHGShipmentSummary =
+      (currentShipment && !isHHGPPMComboMove) ||
+      (currentShipment && isHHGPPMComboMove && currentPpm.status === 'DRAFT' && !isReviewPage);
 
     return (
       <Fragment>
@@ -97,14 +100,9 @@ export class Summary extends Component {
         {showPPMShipmentSummary && (
           <PPMShipmentSummary ppm={currentPpm} movePath={rootAddressWithMoveId} isHHGPPMComboMove={isHHGPPMComboMove} />
         )}
-        {currentShipment &&
-          !isHHGPPMComboMove && (
-            <HHGShipmentSummary
-              shipment={currentShipment}
-              movePath={rootAddressWithMoveId}
-              entitlements={entitlement}
-            />
-          )}
+        {showHHGShipmentSummary && (
+          <HHGShipmentSummary shipment={currentShipment} movePath={rootAddressWithMoveId} entitlements={entitlement} />
+        )}
         {moveIsApproved &&
           !isHHGPPMComboMove && (
             <div className="approved-edit-warning">

--- a/src/scenes/Review/Summary.jsx
+++ b/src/scenes/Review/Summary.jsx
@@ -48,14 +48,20 @@ export class Summary extends Component {
       serviceMember,
       entitlement,
       isHHGPPMComboMove,
+      match,
     } = this.props;
 
     const currentStation = get(serviceMember, 'current_station');
     const stationPhone = get(currentStation, 'transportation_office.phone_lines.0');
 
     const rootAddressWithMoveId = `/moves/${this.props.match.params.moveId}/review`;
+    // isReviewPage being false is the same thing as being in the /edit route
+    const isReviewPage = rootAddressWithMoveId === match.url;
     const editSuccessBlurb = this.props.reviewState.editSuccess ? 'Your changes have been saved. ' : '';
     const editOrdersPath = rootAddressWithMoveId + '/edit-orders';
+
+    const showPPMShipmentSummary =
+      (isReviewPage && currentPpm) || (!isReviewPage && currentPpm && currentPpm.status !== 'DRAFT');
 
     return (
       <Fragment>
@@ -88,7 +94,7 @@ export class Summary extends Component {
           editOrdersPath={editOrdersPath}
         />
 
-        {currentPpm && (
+        {showPPMShipmentSummary && (
           <PPMShipmentSummary ppm={currentPpm} movePath={rootAddressWithMoveId} isHHGPPMComboMove={isHHGPPMComboMove} />
         )}
         {currentShipment &&


### PR DESCRIPTION
## Description

Service member sees both HHG and PPM information editable when it is a combo move

## Reviewer Notes
- I also handled an additional edge case where editing a move while the HHG+PPM  PPM is still in `DRAFT` would show the PPM panel

## Setup
`make server_run`
`make client_run`
Log into `hhgforppm@award.ed (mymove)`
Edit Move

## Code Review Verification Steps
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References
* [Pivotal story](https://www.pivotaltracker.com/story/show/162129146) for this change

## Screenshots

![image](https://user-images.githubusercontent.com/13622298/49531063-5753c980-f86e-11e8-9f02-240ce5599451.png)

