### PR TITLE
Service member sees progress during HHG+PPM setup [delivers #162128305]

### DIFF
--- a/cypress/integration/mymove/hhgPPM.js
+++ b/cypress/integration/mymove/hhgPPM.js
@@ -60,6 +60,11 @@ function serviceMemberFillsInDatesAndLocations() {
   });
 
   cy.get('.wizard-header').should('contain', 'Move Setup');
+  cy.get('.wizard-header .progress-timeline .current').should('contain', 'Move Setup');
+  cy
+    .get('.wizard-header .progress-timeline .step')
+    .last()
+    .should('contain', 'Review');
 
   cy
     .get('input[name="planned_move_date"]')
@@ -82,6 +87,11 @@ function serviceMemberSelectsWeightRange() {
   });
 
   cy.get('.wizard-header').should('contain', 'Move Setup');
+  cy.get('.wizard-header .progress-timeline .current').should('contain', 'Move Setup');
+  cy
+    .get('.wizard-header .progress-timeline .step')
+    .last()
+    .should('contain', 'Review');
 
   cy.get('.entitlement-container p:nth-child(2)').should($div => {
     const text = $div.text();
@@ -99,6 +109,11 @@ function serviceMemberCanCustomizeWeight() {
   });
 
   cy.get('.wizard-header').should('contain', 'Move Setup');
+  cy.get('.wizard-header .progress-timeline .current').should('contain', 'Move Setup');
+  cy
+    .get('.wizard-header .progress-timeline .step')
+    .last()
+    .should('contain', 'Review');
 
   cy.get('.rangeslider__handle').click();
 
@@ -112,8 +127,13 @@ function serviceMemberCanReviewMoveSummary() {
     expect(loc.pathname).to.match(/^\/moves\/[^/]+\/review/);
   });
 
-  cy.get('.wizard-header').should('not.contain', 'Move Setup');
-  cy.get('.wizard-header').should('not.contain', 'Review');
+  cy.get('.wizard-header .usa-width-one-third').should('not.contain', 'Move Setup');
+  cy.get('.wizard-header .usa-width-one-third').should('not.contain', 'Review');
+  cy
+    .get('.wizard-header .progress-timeline .step')
+    .first()
+    .should('contain', 'Move Setup');
+  cy.get('.wizard-header .progress-timeline .current').should('contain', 'Review');
 
   cy.get('body').should($div => expect($div.text()).not.to.include('Government moves all of your stuff (HHG)'));
   cy.get('.ppm-container').should($div => {
@@ -135,6 +155,11 @@ function serviceMemberCanSignAgreement() {
   });
 
   cy.get('.wizard-header').should('contain', 'Review');
+  cy
+    .get('.wizard-header .progress-timeline .step')
+    .first()
+    .should('contain', 'Move Setup');
+  cy.get('.wizard-header .progress-timeline .current').should('contain', 'Review');
 
   cy
     .get('body')

--- a/src/scenes/Legalese/index.jsx
+++ b/src/scenes/Legalese/index.jsx
@@ -11,6 +11,7 @@ import Alert from 'shared/Alert';
 import { SwaggerField } from 'shared/JsonSchemaForm/JsonSchemaField';
 import { formatSwaggerDate } from 'shared/formatters';
 import WizardHeader from 'scenes/Moves/WizardHeader';
+import { ProgressTimeline, ProgressTimelineStep } from 'shared/ProgressTimeline';
 import reviewGray from 'shared/icon/review-gray.svg';
 import './index.css';
 
@@ -57,7 +58,18 @@ export class SignedCertification extends Component {
     };
     return (
       <div>
-        {isHHGPPMComboMove && <WizardHeader icon={reviewGray} title="Review" right={<p>status tracker goes here</p>} />}
+        {isHHGPPMComboMove && (
+          <WizardHeader
+            icon={reviewGray}
+            title="Review"
+            right={
+              <ProgressTimeline>
+                <ProgressTimelineStep name="Move Setup" completed />
+                <ProgressTimelineStep name="Review" current />
+              </ProgressTimeline>
+            }
+          />
+        )}
         <div className="legalese">
           {this.props.certificationText && (
             <SignatureWizardForm

--- a/src/scenes/Moves/Ppm/DateAndLocation.jsx
+++ b/src/scenes/Moves/Ppm/DateAndLocation.jsx
@@ -97,9 +97,8 @@ export class DateAndLocation extends Component {
             title="Move Setup"
             right={
               <ProgressTimeline>
-                <ProgressTimelineStep name="Move Setup" completed />
-                <ProgressTimelineStep name="Review" current />
-                <ProgressTimelineStep name="Agreement" />
+                <ProgressTimelineStep name="Move Setup" current />
+                <ProgressTimelineStep name="Review" />
               </ProgressTimeline>
             }
           />

--- a/src/scenes/Moves/Ppm/DateAndLocation.jsx
+++ b/src/scenes/Moves/Ppm/DateAndLocation.jsx
@@ -19,6 +19,7 @@ import Alert from 'shared/Alert';
 import WizardHeader from '../WizardHeader';
 import ppmBlack from 'shared/icon/ppm-black.svg';
 import './DateAndLocation.css';
+import { ProgressTimeline, ProgressTimelineStep } from 'shared/ProgressTimeline';
 
 const sitEstimateDebounceTime = 300;
 const formName = 'ppp_date_and_location';
@@ -91,7 +92,17 @@ export class DateAndLocation extends Component {
     return (
       <div>
         {isHHGPPMComboMove && (
-          <WizardHeader icon={ppmBlack} title="Move Setup" right={<p>status tracker goes here</p>} />
+          <WizardHeader
+            icon={ppmBlack}
+            title="Move Setup"
+            right={
+              <ProgressTimeline>
+                <ProgressTimelineStep name="Move Setup" completed />
+                <ProgressTimelineStep name="Review" current />
+                <ProgressTimelineStep name="Agreement" />
+              </ProgressTimeline>
+            }
+          />
         )}
         <DateAndLocationWizardForm
           handleSubmit={this.handleSubmit}

--- a/src/scenes/Moves/Ppm/PPMSizeWizard.jsx
+++ b/src/scenes/Moves/Ppm/PPMSizeWizard.jsx
@@ -6,6 +6,7 @@ import PropTypes from 'prop-types';
 import { createOrUpdatePpm, getRawWeightInfo, isHHGPPMComboMove } from './ducks';
 import WizardHeader from '../WizardHeader';
 import WizardPage from 'shared/WizardPage';
+import { ProgressTimeline, ProgressTimelineStep } from 'shared/ProgressTimeline';
 import ppmBlack from 'shared/icon/ppm-black.svg';
 import PpmSize from './Size';
 
@@ -35,7 +36,16 @@ export class PpmSizeWizardPage extends Component {
     return (
       <div>
         {isHHGPPMComboMove && (
-          <WizardHeader icon={ppmBlack} title="Move Setup" right={<p>status tracker goes here</p>} />
+          <WizardHeader
+            icon={ppmBlack}
+            title="Move Setup"
+            right={
+              <ProgressTimeline>
+                <ProgressTimelineStep name="Move Setup" current />
+                <ProgressTimelineStep name="Review" />
+              </ProgressTimeline>
+            }
+          />
         )}
         <WizardPage
           handleSubmit={this.handleSubmit}

--- a/src/scenes/Moves/Ppm/Weight.jsx
+++ b/src/scenes/Moves/Ppm/Weight.jsx
@@ -15,6 +15,7 @@ import { formatCents, formatCentsRange, formatNumber } from 'shared/formatters';
 import { convertDollarsToCents } from 'shared/utils';
 import { getPpmWeightEstimate, createOrUpdatePpm, getSelectedWeightInfo, getMaxAdvance } from './ducks';
 import WizardHeader from '../WizardHeader';
+import { ProgressTimeline, ProgressTimelineStep } from 'shared/ProgressTimeline';
 import ppmBlack from 'shared/icon/ppm-black.svg';
 
 import 'react-rangeslider/lib/index.css';
@@ -236,7 +237,16 @@ export class PpmWeight extends Component {
     return (
       <div>
         {isHHGPPMComboMove && (
-          <WizardHeader icon={ppmBlack} title="Move Setup" right={<p>status tracker goes here</p>} />
+          <WizardHeader
+            icon={ppmBlack}
+            title="Move Setup"
+            right={
+              <ProgressTimeline>
+                <ProgressTimelineStep name="Move Setup" current />
+                <ProgressTimelineStep name="Review" />
+              </ProgressTimeline>
+            }
+          />
         )}
         <WeightWizardForm
           handleSubmit={this.handleSubmit}

--- a/src/scenes/Moves/WizardHeader.jsx
+++ b/src/scenes/Moves/WizardHeader.jsx
@@ -5,12 +5,12 @@ import './WizardHeader.css';
 const WizardHeader = ({ icon, right, title }) => (
   <div className="wizard-header">
     <div className="usa-grid">
-      <div className="usa-width-one-half">
+      <div className="usa-width-one-third">
         <img className="icon" src={icon} alt="" />
         <p>{title}</p>
       </div>
-      <div className="usa-width-one-half" style={{ textAlign: 'right' }}>
-        {right}
+      <div className="usa-width-two-thirds">
+        <div style={{ float: 'right', marginRight: '-17px' }}>{right}</div>
       </div>
     </div>
     <div className="usa-grid">

--- a/src/scenes/Review/Review.jsx
+++ b/src/scenes/Review/Review.jsx
@@ -5,6 +5,7 @@ import Summary from './Summary';
 import { connect } from 'react-redux';
 import { get } from 'lodash';
 import WizardHeader from 'scenes/Moves/WizardHeader';
+import { ProgressTimeline, ProgressTimelineStep } from 'shared/ProgressTimeline';
 
 class Review extends Component {
   componentDidMount() {
@@ -15,7 +16,16 @@ class Review extends Component {
 
     return (
       <div>
-        {isHHGPPMComboMove && <WizardHeader right={<p>status tracker goes here</p>} />}
+        {isHHGPPMComboMove && (
+          <WizardHeader
+            right={
+              <ProgressTimeline>
+                <ProgressTimelineStep name="Move Setup" completed />
+                <ProgressTimelineStep name="Review" current />
+              </ProgressTimeline>
+            }
+          />
+        )}
         <WizardPage handleSubmit={no_op} pageList={pages} pageKey={pageKey} pageIsValid={true}>
           <h1>Review</h1>
           <p>You're almost done! Please review your details before we finalize the move.</p>

--- a/src/shared/ProgressTimeline/index.css
+++ b/src/shared/ProgressTimeline/index.css
@@ -1,19 +1,13 @@
 .progress-timeline {
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
   text-align: center;
-  width: 300px;
   color: #adadad;
   font-size: 1.2rem;
 }
 
 .progress-timeline .step {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
   position: relative;
+  width: 80px;
+  float: left;
 }
 
 .progress-timeline .dot {
@@ -27,6 +21,7 @@
   -moz-border-radius: 50%;
   -webkit-border-radius: 50%;
   z-index: 10;
+  left: calc(50% - 10px);
 }
 
 .progress-timeline .step.completed,

--- a/src/shared/ProgressTimeline/index.css
+++ b/src/shared/ProgressTimeline/index.css
@@ -1,0 +1,96 @@
+.progress-timeline {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  text-align: center;
+  width: 300px;
+  color: #adadad;
+  font-size: 1.2rem;
+}
+
+.progress-timeline .step {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  position: relative;
+}
+
+.progress-timeline .dot {
+  display: block;
+  position: relative;
+  width: 19px;
+  height: 19px;
+  background: white;
+  border: solid 1px #adadad;
+  border-radius: 50%;
+  -moz-border-radius: 50%;
+  -webkit-border-radius: 50%;
+  z-index: 10;
+}
+
+.progress-timeline .step.completed,
+.progress-timeline .step.current {
+  color: #5c8652;
+}
+
+.progress-timeline .step.completed .dot,
+.progress-timeline .step.current .dot {
+  border-color: #5c8652;
+}
+
+.progress-timeline .step.completed .dot:after,
+.progress-timeline .step.current .dot:after {
+  display: block;
+  content: ' ';
+  position: absolute;
+}
+
+.progress-timeline .step.completed .dot:after {
+  border-style: solid;
+  border-color: #5c8652;
+  border-width: 0 0 3px 3px;
+  height: 6px;
+  width: 9px;
+  left: 4px;
+  top: 5px;
+  transform: rotate(-45deg);
+}
+
+.progress-timeline .step.current .dot:after {
+  background: #5c8652;
+  border-radius: 10px;
+  height: 9px;
+  width: 9px;
+  left: 4px;
+  top: 4px;
+}
+
+.progress-timeline .step:after {
+  display: block;
+  content: ' ';
+  width: 100%;
+  height: 1px;
+  background: #adadad;
+  position: absolute;
+  right: 50%;
+  top: 9px;
+  z-index: 1;
+}
+
+.progress-timeline .step:first-child:after {
+  display: none;
+}
+
+.progress-timeline .step.completed:after,
+.step.current:after {
+  background: #5c8652;
+}
+
+.progress-timeline .step.completed:first-child:after {
+  display: none;
+}
+
+.progress-timeline .name {
+  margin-top: 0.2em;
+}

--- a/src/shared/ProgressTimeline/index.jsx
+++ b/src/shared/ProgressTimeline/index.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+
+import './index.css';
+
+export const ProgressTimelineStep = function(props) {
+  let classes = classNames({
+    step: true,
+    completed: props.completed,
+    current: props.current,
+  });
+
+  return (
+    <div className={classes}>
+      <div className="dot" />
+      <div className="name">{props.name}</div>
+    </div>
+  );
+};
+
+ProgressTimelineStep.propTypes = {
+  completed: PropTypes.bool,
+  current: PropTypes.bool,
+};
+
+// ProgressTimeline renders a subway-map-style timeline. Use ProgressTimelineStep
+// components as children to declaritively define the "stops" and their status.
+export const ProgressTimeline = function(props) {
+  return <div className="progress-timeline">{props.children}</div>;
+};
+
+ProgressTimeline.propTypes = {
+  children: PropTypes.arrayOf(ProgressTimelineStep).isRequired,
+};


### PR DESCRIPTION
## Description

This PR adds a new component for displaying a user's progress on the HHG+PPM pages. We will eventually roll it out on the other flows as well.

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
echo "Code goes here"
```

## Code Review Verification Steps

* [ ] There are no aXe warnings for UI.
* [ ] This works in IE.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/162128305) for this change

## Screenshots

Chrome:
<img width="282" alt="screen shot 2018-12-05 at 10 32 50 am" src="https://user-images.githubusercontent.com/3331/49536513-5762c200-f88c-11e8-9e47-dc97115791a1.png">

Firefox:
<img width="283" alt="screen shot 2018-12-05 at 10 32 43 am" src="https://user-images.githubusercontent.com/3331/49536511-5598fe80-f88c-11e8-9a5f-6f1e784dbf04.png">

IE11:
<img width="291" alt="screen shot 2018-12-05 at 10 39 31 am" src="https://user-images.githubusercontent.com/3331/49536539-65184780-f88c-11e8-9183-a4eb0256155f.png">

Edge:
<img width="291" alt="screen shot 2018-12-05 at 10 38 45 am" src="https://user-images.githubusercontent.com/3331/49536533-621d5700-f88c-11e8-99e1-37e14a8a4694.png">

App Screenshots:
<img width="1008" alt="screen shot 2018-12-06 at 9 08 47 am" src="https://user-images.githubusercontent.com/4434681/49667585-67a3aa00-fa10-11e8-8a2e-192e452ac458.png">
<img width="1012" alt="screen shot 2018-12-06 at 9 08 38 am" src="https://user-images.githubusercontent.com/4434681/49667586-67a3aa00-fa10-11e8-99c7-1aeb84315edd.png">
