### PR TITLE
Assign servicing agent header

### DIFF
--- a/cypress/integration/tsp/serviceAgents.js
+++ b/cypress/integration/tsp/serviceAgents.js
@@ -166,6 +166,8 @@ function tspUserClicksAssignServiceAgent(locator) {
     .get('button')
     .contains('Assign servicing agents')
     .click();
+
+  cy.get('.infoPanel-wizard-header').contains('Assign servicing agents');
 }
 
 function tspUserVerifiesServiceAgentAssigned() {

--- a/src/scenes/TransportationServiceProvider/ServiceAgentForm.jsx
+++ b/src/scenes/TransportationServiceProvider/ServiceAgentForm.jsx
@@ -13,6 +13,7 @@ let ServiceAgentForm = props => {
 
   return (
     <form className="infoPanel-wizard" onSubmit={handleSubmit}>
+      <div className="infoPanel-wizard-header">Assign servicing agents</div>
       <FormSection name="origin_service_agent">
         <ServiceAgentEdit
           serviceAgentProps={{


### PR DESCRIPTION
## Description

Add back missing header for Assign servicing agents wizard

## Setup
`make server_run`
`make tsp_client_run`
Accept a new shipment and `Assign servicing agents` should appear, click on `Assign servicing agents`

## Code Review Verification Steps
* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/162327650) for this change

## Screenshots
![image](https://user-images.githubusercontent.com/13622298/49538624-bde1e300-f880-11e8-82ef-040e3baa9348.png)

