### PR TITLE
Switch migrations templating from perl to go

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -513,6 +513,10 @@ workflows:
           requires:
             - pre_deps_golang
             - pre_deps_yarn
+          # if testing on experimental, you can disable these tests by using the commented block below.
+          #filters:
+          #  branches:
+          #    ignore: YOUR BRANCH NAME HERE
 
       - client_test:
           requires:

--- a/bin/ecs-run-app-migrations-container
+++ b/bin/ecs-run-app-migrations-container
@@ -4,6 +4,8 @@
 #   template, image, and environment.
 #
 set -eo pipefail
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+readonly DIR
 
 usage() {
     echo "$0 <template> <image> <environment>"
@@ -44,8 +46,8 @@ readonly network_configuration
 db_host=$(aws rds describe-db-instances --db-instance-identifier "app-$environment" --query 'DBInstances[0].Endpoint.Address' | jq -r .)
 readonly db_host
 
-# create the container definition from the json template
-container_definition_json=$(perl -pe "s|{{environment}}|$environment|g; s|{{image}}|$image|g; s|{{db_host}}|$db_host|g;" "$template")
+# $DIR/../cmd/renderer/main.go builds its template context from (1) environment variables, (2) file at -v FILE, and (3) positional command line args.
+container_definition_json=$(go run "$DIR"/../cmd/renderer/main.go -t "$template" environment="$environment" image="$image" db_host="$db_host")
 readonly container_definition_json
 
 # create new task definition with the given image

--- a/cmd/renderer/main.go
+++ b/cmd/renderer/main.go
@@ -31,21 +31,23 @@ func main() {
 		log.Fatal(errors.New("error reading template file"))
 	}
 
-	// Read contents of variables file into vars
-	vars, err := ioutil.ReadFile(variablesFile)
-	if err != nil {
-		log.Fatal(errors.New("error reading variables file"))
-	}
-
 	ctx := map[string]string{}
 
-	// Adds variables from file into context
-	for _, x := range strings.Split(string(vars), "\n") {
-		// If a line is empty or starts with #, then skip.
-		if len(x) > 0 && x[0] != '#' {
-			// Split each line on the first equals sign into [name, value]
-			pair := strings.SplitAfterN(x, "=", 2)
-			ctx[pair[0][0:len(pair[0])-1]] = pair[1]
+	if len(variablesFile) > 0 {
+		// Read contents of variables file into vars
+		vars, err := ioutil.ReadFile(variablesFile)
+		if err != nil {
+			log.Fatal(errors.New("error reading variables file"))
+		}
+
+		// Adds variables from file into context
+		for _, x := range strings.Split(string(vars), "\n") {
+			// If a line is empty or starts with #, then skip.
+			if len(x) > 0 && x[0] != '#' {
+				// Split each line on the first equals sign into [name, value]
+				pair := strings.SplitAfterN(x, "=", 2)
+				ctx[pair[0][0:len(pair[0])-1]] = pair[1]
+			}
 		}
 	}
 

--- a/config/app-migrations.container-definition.json
+++ b/config/app-migrations.container-definition.json
@@ -1,11 +1,11 @@
 {
-  "name": "app-migrations-{{environment}}",
-  "image": "{{image}}",
+  "name": "app-migrations-{{ .environment }}",
+  "image": "{{ .image }}",
   "essential": true,
   "entryPoint": [
     "/bin/chamber",
     "exec",
-    "app-{{environment}}",
+    "app-{{ .environment }}",
     "--",
     "/bin/soda"
   ],
@@ -20,7 +20,7 @@
   "environment": [
     {
       "name": "ENVIRONMENT",
-      "value": "{{environment}}"
+      "value": "{{ .environment }}"
     },
     {
       "name": "SECURE_MIGRATION_SOURCE",
@@ -32,7 +32,7 @@
     },
     {
       "name": "DB_HOST",
-      "value": "{{db_host}}"
+      "value": "{{ .db_host }}"
     },
     {
       "name": "DB_PORT",
@@ -56,13 +56,13 @@
     },
     {
       "name": "AWS_S3_BUCKET_NAME",
-      "value": "transcom-ppp-app-{{environment}}-us-west-2"
+      "value": "transcom-ppp-app-{{ .environment }}-us-west-2"
     }
   ],
   "logConfiguration": {
     "logDriver": "awslogs",
     "options": {
-      "awslogs-group": "ecs-tasks-app-{{environment}}",
+      "awslogs-group": "ecs-tasks-app-{{ .environment }}",
       "awslogs-region": "us-west-2",
       "awslogs-stream-prefix": "app-migrations"
     }


### PR DESCRIPTION
## Description

Rendering of the task definition for the migrations now use the `renderer` go program rather than perl.
