### PR TITLE
Kma 162271667 bug prevent view move dates summary

### DIFF
--- a/pkg/handlers/internalapi/moves.go
+++ b/pkg/handlers/internalapi/moves.go
@@ -200,9 +200,9 @@ func (h ShowMoveDatesSummaryHandler) Handle(params moveop.ShowMoveDatesSummaryPa
 	moveDate := time.Time(params.MoveDate)
 	moveID, _ := uuid.FromString(params.MoveID.String())
 
-	// Validate that this move belongs to the current user, an office user, or a tsp user
+	// Validate that this move belongs to the current user
 	_, err := models.FetchMove(h.DB(), session, moveID)
-	if !session.IsOfficeUser() && !session.IsTspUser() && err != nil {
+	if err != nil {
 		return handlers.ResponseForError(h.Logger(), err)
 	}
 


### PR DESCRIPTION
## Description

This fixes a bug where a logged in user is able to view the move dates summary of another SM's move.

## Reviewer Notes

I made it so that only SM's connected to the move can access the api.  I checked and I don't think the office or tsp needs access to it, but let me know if I'm wrong.

## Setup

Log in as a SM.  Go to `/internal/moves/<move_id_of_other_SM>/move_dates_summary?moveDate=2018-11-05`
You should get a 403

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/162271667) for this change
