### PR TITLE
els adding additional hackerone users to staging [delivers #162478956]

### DIFF
--- a/docs/database.md
+++ b/docs/database.md
@@ -64,7 +64,8 @@ To run a secure migration on ONLY staging (or other chosen environment), upload 
 * Instead of the "Upload the migration" step above, run `aws s3 cp --sse AES256 $YOUR_TMP_MIGRATION_FILE s3://transcom-ppp-app-staging-us-west-2/secure-migrations/`
 * Check that it is listed in the S3 staging secure-migrations folder: `aws s3 ls s3://transcom-ppp-app-staging-us-west-2/secure-migrations/`
 * Check that it is NOT listed in the S3 production folder: `aws s3 ls s3://transcom-ppp-app-prod-us-west-2/secure-migrations/`
-* Now upload empty files of the same name to the prod and experimental environments: `aws s3 cp --sse AES256 $YOUR_EMPTY_TMP_MIGRATION_FILE s3://transcom-ppp-app-prod-us-west-2/secure-migrations/`
+* Now upload empty files of the same name to the prod environment: `aws s3 cp --sse AES256 $YOUR_EMPTY_TMP_MIGRATION_FILE s3://transcom-ppp-app-prod-us-west-2/secure-migrations/`
+* Now upload empty files of the same name to the experimental environment: `aws s3 cp --sse AES256 $YOUR_EMPTY_TMP_MIGRATION_FILE s3://transcom-ppp-app-experimental-us-west-2/secure-migrations/`
 * To verify upload and that the migration can be applied, temporarily change the S3 bucket to the staging bucket in the run-prod-migration file and then run `bin/run-prod-migrations`
 
 Gory Details:

--- a/local_migrations/20181206143208_more-hackerone-users.sql
+++ b/local_migrations/20181206143208_more-hackerone-users.sql
@@ -1,0 +1,1 @@
+-- This migration only applies to staging so using empty file everywhere else

--- a/migrations/20181206143208_more-hackerone-users.up.fizz
+++ b/migrations/20181206143208_more-hackerone-users.up.fizz
@@ -1,0 +1,1 @@
+exec("./apply-secure-migration.sh 20181206143208_more-hackerone-users.sql")


### PR DESCRIPTION
## Description

This secure migration adds 3 hackerone office_users and 1 hackerone tsp_user to each of 3 TSPs to staging.  Only the staging S3 bucket adds users; prod and experimental have empty files uploaded to S3.

## Setup

1) `bin/run-prod-migrations` and then check the office_users and tsp_users tables. They should not contain any of the hackerone emails (last name name 'hackerone')
2) In the bin/run-prod-migrations file, replace line 11 with `export AWS_S3_BUCKET_NAME=transcom-ppp-app-staging-us-west-2`
Then run `bin/run-prod-migrations` (which is really running the staging migrations).  Check the office_users and tsp_users tables.  They should each contain 60 users with the first name 'hacker'.
Be sure to undo the changes on `bin/run-prod-migrations` when done.

## Code Review Verification Steps

* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](./docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/162478956) for this change
