### PR TITLE
Alert PagerDuty if master is broken on CircleCI

### DIFF
--- a/bin/circleci-announce-broken-branch
+++ b/bin/circleci-announce-broken-branch
@@ -1,7 +1,14 @@
 #!/bin/bash
 set -euo pipefail
 
-payload=$(
+GIT_TEXT=$(git --no-pager show --format=format:'%s')
+NOW=$(date '+%s')
+NOW_ISO8601=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+#####
+## Announce in Slack channel
+#####
+slack_payload=$(
 cat <<EOM
 {
     "channel": "#dp3-engineering",
@@ -12,11 +19,46 @@ cat <<EOM
             "pretext": "The $CIRCLE_PROJECT_REPONAME $CIRCLE_BRANCH branch is broken!",
             "title": "CircleCI job #$CIRCLE_BUILD_NUM",
             "title_link": "$CIRCLE_BUILD_URL",
-            "text": "$(git --no-pager show --format=format:'%s')",
-            "ts": $(date '+%s')
+            "text": "$GIT_TEXT",
+            "ts": $NOW
         }
     ]
 }
 EOM
 )
-curl -X POST --data-urlencode payload="$payload" "$SLACK_WEBHOOK_URL"
+curl -X POST --data-urlencode payload="$slack_payload" "$SLACK_WEBHOOK_URL"
+
+#####
+## Page the on-call via PagerDuty
+#####
+
+pd_payload=$(
+cat <<EOM
+{
+  "payload": {
+    "summary": "The $CIRCLE_PROJECT_REPONAME $CIRCLE_BRANCH branch is broken",
+    "timestamp": "$NOW_ISO8601",
+    "source": "CircleCI job #$CIRCLE_BUILD_NUM",
+    "severity": "info",
+    "class": "cicd failure"
+  },
+  "routing_key": "$PD_ROUTING_KEY",
+  "dedup_key": "circle-$CIRCLE_BUILD_NUM",
+  "links": [{
+    "href": "$CIRCLE_BUILD_URL",
+    "text": "CircleCI Build URL"
+  }],
+  "event_action": "trigger"
+}
+EOM
+)
+
+echo "$pd_payload"
+echo
+
+curl -XPOST \
+  -H "Authorization: Token token=$PD_AUTH_TOKEN" \
+  -H "Accept: application/vnd.pagerduty+json;version=2" \
+  -H "Content-Type: application/json" \
+  --data "$pd_payload" \
+  "https://events.pagerduty.com/v2/enqueue"


### PR DESCRIPTION
## Description

This will alert the Bat Team that master is broken.  It's essentially the same data as is sent by the Slack notification but sent over PagerDuty.

## Reviewer Notes

Double check that the messages include what we want.

## Setup

You really can't test this locally since all the env vars are in CircleCI.  It is possible to test locally but you'll have to set those variables and put an override in the PD schedules so that it won't affect those on-call people.

## Code Review Verification Steps

* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/161727776) for this change