### PR TITLE
Adding even more hackerone users to staging

### DIFF
--- a/docs/database.md
+++ b/docs/database.md
@@ -54,6 +54,7 @@ To create a secure migration:
 * Copy the production migration into the local test migration.
 * Scrub the test migration of sensitive data, but use it to test the gist of the production migration operation.
 * Test the local migration by running `make db_dev_migrate`. You should see it run your local migration.
+* If you are wanting to run a secure migration for a specific non-production environment, then **please read the next section first**.
 * Upload the migration to S3 with: `bin/upload-secure-migration <production_migration_file>`
 * Run `bin/run-prod-migrations` to verify that the upload worked and that the migration can be applied successfully
 * Open a pull request!

--- a/local_migrations/20181210210031_even-more-hackerone-users.sql
+++ b/local_migrations/20181210210031_even-more-hackerone-users.sql
@@ -1,0 +1,1 @@
+-- This migration only applies to staging so using empty file everywhere else

--- a/migrations/20181210210031_even-more-hackerone-users.up.fizz
+++ b/migrations/20181210210031_even-more-hackerone-users.up.fizz
@@ -1,0 +1,1 @@
+exec("./apply-secure-migration.sh 20181210210031_even-more-hackerone-users.sql")


### PR DESCRIPTION
## Description

This secure migration is applied to **staging only**.  It adds two hackerone office users and two hackerone TSP users (each associated to a different TSP).

## Reviewer Notes

The prod and experimental environments have empty migration files in S3 since we only want these users in the staging environment.

## Setup

1. Run `bin/run-prod-migrations`, then verify that no hackerone users are in the `office_users` or `tsp_users` tables in the `prod_migrations` database (look for lastname "hacker" or "hackerone")
2. Change the `AWS_S3_BUCKET_NAME` in the `bin/run-prod-migrations` file to `transcom-ppp-app-staging-us-west-2`, then run `bin/run-prod-migrations` again.  You should have the users noted in the Pivotal story in the `prod_migrations` database in the `office_users` and `tsp_users` tables.
3. Undo your local changes to `bin/run-prod-migrations`.

## Code Review Verification Steps

* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](./docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/162560452) for this change
