### PR TITLE
Kl/SB 162280246 move public api shipment

### DIFF
--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -40,6 +40,7 @@ import {
   selectSortedShipmentLineItems,
   getShipmentLineItemsLabel,
 } from 'shared/Entities/modules/shipmentLineItems';
+import { getShipment } from 'shared/Entities/modules/shipments';
 
 import {
   loadMoveDependencies,
@@ -139,6 +140,7 @@ class MoveInfo extends Component {
 
   componentDidUpdate(prevProps) {
     if (get(this.props, 'officeShipment.id') !== get(prevProps, 'officeShipment.id')) {
+      this.props.getShipment('Shipments.getShipment', this.props.officeShipment.id);
       this.props.getAllShipmentLineItems(getShipmentLineItemsLabel, this.props.officeShipment.id);
       this.props.loadShipmentDependencies(this.props.officeShipment.id);
     }
@@ -442,31 +444,37 @@ MoveInfo.propTypes = {
   }).isRequired,
 };
 
-const mapStateToProps = state => ({
-  swaggerError: get(state, 'swagger.hasErrored'),
-  officeMove: get(state, 'office.officeMove', {}),
-  officeShipment: get(state, 'office.officeShipment', {}),
-  shipment: get(state, 'tsp.shipment', {}),
-  officeOrders: get(state, 'office.officeOrders', {}),
-  officeServiceMember: get(state, 'office.officeServiceMember', {}),
-  officeBackupContacts: get(state, 'office.officeBackupContacts', []),
-  officePPM: get(state, 'office.officePPMs.0', {}),
-  officeHHG: get(state, 'office.officeMove.shipments.0', {}),
-  ppmAdvance: get(state, 'office.officePPMs.0.advance', {}),
-  moveDocuments: selectAllDocumentsForMove(state, get(state, 'office.officeMove.id', '')),
-  tariff400ngItems: selectTariff400ngItems(state),
-  serviceAgents: get(state, 'tsp.serviceAgents', []),
-  shipmentLineItems: selectSortedShipmentLineItems(state),
-  loadDependenciesHasSuccess: get(state, 'office.loadDependenciesHasSuccess'),
-  loadDependenciesHasError: get(state, 'office.loadDependenciesHasError'),
-  shipmentPatchError: get(state, 'office.shipmentPatchError'),
-  approveMoveHasError: get(state, 'office.moveHasApproveError'),
-  errorMessage: get(state, 'office.error'),
-});
+const mapStateToProps = state => {
+  const officeMove = get(state, 'office.officeMove', {});
+  const shipmentId = get(officeMove, 'shipments.0.id');
+
+  return {
+    swaggerError: get(state, 'swagger.hasErrored'),
+    officeMove: get(state, 'office.officeMove', {}),
+    officeShipment: get(state, 'office.officeShipment', {}),
+    shipment: get(state, `entities.shipment.${shipmentId}`, {}),
+    officeOrders: get(state, 'office.officeOrders', {}),
+    officeServiceMember: get(state, 'office.officeServiceMember', {}),
+    officeBackupContacts: get(state, 'office.officeBackupContacts', []),
+    officePPM: get(state, 'office.officePPMs.0', {}),
+    officeHHG: get(state, 'office.officeMove.shipments.0', {}),
+    ppmAdvance: get(state, 'office.officePPMs.0.advance', {}),
+    moveDocuments: selectAllDocumentsForMove(state, get(state, 'office.officeMove.id', '')),
+    tariff400ngItems: selectTariff400ngItems(state),
+    serviceAgents: get(state, 'tsp.serviceAgents', []),
+    shipmentLineItems: selectSortedShipmentLineItems(state),
+    loadDependenciesHasSuccess: get(state, 'office.loadDependenciesHasSuccess'),
+    loadDependenciesHasError: get(state, 'office.loadDependenciesHasError'),
+    shipmentPatchError: get(state, 'office.shipmentPatchError'),
+    approveMoveHasError: get(state, 'office.moveHasApproveError'),
+    errorMessage: get(state, 'office.error'),
+  };
+};
 
 const mapDispatchToProps = dispatch =>
   bindActionCreators(
     {
+      getShipment,
       loadShipmentDependencies,
       loadMoveDependencies,
       getMoveDocumentsForMove,

--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -452,7 +452,7 @@ const mapStateToProps = state => {
     swaggerError: get(state, 'swagger.hasErrored'),
     officeMove: get(state, 'office.officeMove', {}),
     officeShipment: get(state, 'office.officeShipment', {}),
-    shipment: get(state, `entities.shipment.${shipmentId}`, {}),
+    shipment: get(state, `entities.shipments.${shipmentId}`, {}),
     officeOrders: get(state, 'office.officeOrders', {}),
     officeServiceMember: get(state, 'office.officeServiceMember', {}),
     officeBackupContacts: get(state, 'office.officeBackupContacts', []),

--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -40,7 +40,7 @@ import {
   selectSortedShipmentLineItems,
   getShipmentLineItemsLabel,
 } from 'shared/Entities/modules/shipmentLineItems';
-import { getShipment } from 'shared/Entities/modules/shipments';
+import { getShipment, updateShipment } from 'shared/Entities/modules/shipments';
 
 import {
   loadMoveDependencies,
@@ -100,7 +100,7 @@ const HHGTabContent = props => {
       <RoutingPanel title="Routing" moveId={props.moveId} />
       <Dates title="Dates" shipment={props.officeShipment} update={props.patchShipment} />
       <LocationsContainer update={props.patchShipment} />
-      <Weights title="Weights & Items" shipment={props.shipment} update={props.patchShipment} />
+      <Weights title="Weights & Items" shipment={props.shipment} update={props.updateShipment} />
       {props.officeShipment && (
         <PremoveSurvey
           title="Premove Survey"
@@ -316,6 +316,7 @@ class MoveInfo extends Component {
                     officeHHG={JSON.stringify(this.props.officeHHG)}
                     officeShipment={this.props.officeShipment}
                     patchShipment={this.props.patchShipment}
+                    updateShipment={this.props.updateShipment}
                     moveId={this.props.match.params.moveId}
                     shipment={this.props.shipment}
                     serviceAgents={this.props.serviceAgents}
@@ -475,6 +476,7 @@ const mapDispatchToProps = dispatch =>
   bindActionCreators(
     {
       getShipment,
+      updateShipment,
       loadShipmentDependencies,
       loadMoveDependencies,
       getMoveDocumentsForMove,

--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -40,7 +40,7 @@ import {
   selectSortedShipmentLineItems,
   getShipmentLineItemsLabel,
 } from 'shared/Entities/modules/shipmentLineItems';
-import { getShipment, updateShipment } from 'shared/Entities/modules/shipments';
+import { getPublicShipment, updatePublicShipment } from 'shared/Entities/modules/shipments';
 
 import {
   loadMoveDependencies,
@@ -100,7 +100,7 @@ const HHGTabContent = props => {
       <RoutingPanel title="Routing" moveId={props.moveId} />
       <Dates title="Dates" shipment={props.officeShipment} update={props.patchShipment} />
       <LocationsContainer update={props.patchShipment} />
-      <Weights title="Weights & Items" shipment={props.shipment} update={props.updateShipment} />
+      <Weights title="Weights & Items" shipment={props.shipment} update={props.updatePublicShipment} />
       {props.officeShipment && (
         <PremoveSurvey
           title="Premove Survey"
@@ -140,7 +140,7 @@ class MoveInfo extends Component {
 
   componentDidUpdate(prevProps) {
     if (get(this.props, 'officeShipment.id') !== get(prevProps, 'officeShipment.id')) {
-      this.props.getShipment('Shipments.getShipment', this.props.officeShipment.id);
+      this.props.getPublicShipment('Shipments.getPublicShipment', this.props.officeShipment.id);
       this.props.getAllShipmentLineItems(getShipmentLineItemsLabel, this.props.officeShipment.id);
       this.props.loadShipmentDependencies(this.props.officeShipment.id);
     }
@@ -316,7 +316,7 @@ class MoveInfo extends Component {
                     officeHHG={JSON.stringify(this.props.officeHHG)}
                     officeShipment={this.props.officeShipment}
                     patchShipment={this.props.patchShipment}
-                    updateShipment={this.props.updateShipment}
+                    updatePublicShipment={this.props.updatePublicShipment}
                     moveId={this.props.match.params.moveId}
                     shipment={this.props.shipment}
                     serviceAgents={this.props.serviceAgents}
@@ -475,8 +475,8 @@ const mapStateToProps = state => {
 const mapDispatchToProps = dispatch =>
   bindActionCreators(
     {
-      getShipment,
-      updateShipment,
+      getPublicShipment,
+      updatePublicShipment,
       loadShipmentDependencies,
       loadMoveDependencies,
       getMoveDocumentsForMove,

--- a/src/shared/Entities/modules/shipments.js
+++ b/src/shared/Entities/modules/shipments.js
@@ -13,6 +13,10 @@ export function createOrUpdateShipment(label, moveId, shipment, id) {
 }
 
 export function getShipment(label, shipmentId) {
+  return swaggerRequest(getClient, 'shipments.getShipment', { shipmentId }, { label });
+}
+
+export function getPublicShipment(label, shipmentId) {
   return swaggerRequest(getPublicClient, 'shipments.getShipment', { shipmentId }, { label });
 }
 
@@ -25,6 +29,14 @@ export function createShipment(
 }
 
 export function updateShipment(
+  label,
+  shipmentId,
+  shipment /*shape: {pickup_address, requested_pickup_date, weight_estimate}*/,
+) {
+  return swaggerRequest(getClient, 'shipments.patchShipment', { shipmentId, shipment }, { label });
+}
+
+export function updatePublicShipment(
   shipmentId,
   shipment /*shape: {pickup_address, requested_pickup_date, weight_estimate}*/,
 ) {

--- a/src/shared/Entities/modules/shipments.js
+++ b/src/shared/Entities/modules/shipments.js
@@ -25,11 +25,15 @@ export function createShipment(
 }
 
 export function updateShipment(
-  label,
   shipmentId,
   shipment /*shape: {pickup_address, requested_pickup_date, weight_estimate}*/,
 ) {
-  return swaggerRequest(getClient, 'shipments.patchShipment', { shipmentId, shipment }, { label });
+  return swaggerRequest(
+    getPublicClient,
+    'shipments.patchShipment',
+    { shipmentId, update: shipment },
+    { label: 'shipments.updateShipment' },
+  );
 }
 
 export function selectShipment(state, id) {

--- a/src/shared/Entities/modules/shipments.js
+++ b/src/shared/Entities/modules/shipments.js
@@ -2,7 +2,7 @@ import { denormalize } from 'normalizr';
 
 import { shipments } from '../schema';
 import { swaggerRequest } from 'shared/Swagger/request';
-import { getClient } from 'shared/Swagger/api';
+import { getClient, getPublicClient } from 'shared/Swagger/api';
 
 export function createOrUpdateShipment(label, moveId, shipment, id) {
   if (id) {
@@ -13,7 +13,7 @@ export function createOrUpdateShipment(label, moveId, shipment, id) {
 }
 
 export function getShipment(label, shipmentId) {
-  return swaggerRequest(getClient, 'shipments.getShipment', { shipmentId }, { label });
+  return swaggerRequest(getPublicClient, 'shipments.getShipment', { shipmentId }, { label });
 }
 
 export function createShipment(


### PR DESCRIPTION
## Description

Add the public API version of a shipment to the entities reducer and use it in the office app.

## Reviewer Notes

Our goal is to eventually remove the need to use the tsp reducer and actions/etc in the office app. Further stories will complete that process.

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/162395484) for this change

## Screenshots

No noticeable changes to the user should occur as a result of this PR.
