### PR TITLE
Explicitly set the resource classes for circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,18 +21,9 @@ executors:
     working_directory: ~/go/src/github.com/transcom/mymove
     docker:
       - image: trussworks/circleci-docker-primary:4bf3060cd9f47be0adb819ded630aa1848055ffe
-  # `mymove_and_postgres_medium` and `mymove_and_postgres_large` add a secondary postgres container to be used during testing.
+  # `mymove_and_postgres_medium` adds a secondary postgres container to be used during testing.
   mymove_and_postgres_medium:
     resource_class: medium
-    working_directory: ~/go/src/github.com/transcom/mymove
-    docker:
-      - image: trussworks/circleci-docker-primary:4bf3060cd9f47be0adb819ded630aa1848055ffe
-      - image: postgres:10.5
-        environment:
-          - POSTGRES_PASSWORD: mysecretpassword
-          - POSTGRES_DB: test_db
-  mymove_and_postgres_large:
-    resource_class: large
     working_directory: ~/go/src/github.com/transcom/mymove
     docker:
       - image: trussworks/circleci-docker-primary:4bf3060cd9f47be0adb819ded630aa1848055ffe
@@ -209,7 +200,7 @@ jobs:
 
   # `integration_tests` runs integration tests using Cypress.  https://www.cypress.io/
   integration_tests:
-    executor: mymove_and_postgres_large
+    executor: mymove_and_postgres_medium
     steps:
       - checkout
       - setup_remote_docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,8 +11,13 @@ version: "2.1"
 
 executors:
   # `mymove` uses the `trussworks/circleci-docker-primary` docker image with a checkout of the mymove code
-  mymove:
+  mymove_small:
     resource_class: small
+    working_directory: ~/go/src/github.com/transcom/mymove
+    docker:
+      - image: trussworks/circleci-docker-primary:4bf3060cd9f47be0adb819ded630aa1848055ffe
+  mymove_medium:
+    resource_class: medium
     working_directory: ~/go/src/github.com/transcom/mymove
     docker:
       - image: trussworks/circleci-docker-primary:4bf3060cd9f47be0adb819ded630aa1848055ffe
@@ -100,7 +105,7 @@ jobs:
 
   # `pre_deps_golang` is used for cache dep soruces and the vendor directory for mymove.
   pre_deps_golang:
-    executor: mymove
+    executor: mymove_small
     steps:
       - checkout
       - restore_cache:
@@ -126,7 +131,7 @@ jobs:
 
   # `pre_deps_yarn` is used to cache yarn sources and installed node modules.
   pre_deps_yarn:
-    executor: mymove
+    executor: mymove_small
     steps:
       - checkout
       - restore_cache:
@@ -152,7 +157,7 @@ jobs:
 
   # `pre_test` runs pre-commit against all files.
   pre_test:
-    executor: mymove
+    executor: mymove_small
     steps:
       - checkout
       - restore_cache:
@@ -316,7 +321,7 @@ jobs:
 
   # `client_test` runs the client side Javascript tests
   client_test:
-    executor: mymove
+    executor: mymove_medium
     steps:
       - checkout
       - setup_remote_docker:
@@ -331,7 +336,7 @@ jobs:
 
   # `build_tools` builds the mymove-specific CLI tools in `mymove/cmd`
   build_tools:
-    executor: mymove
+    executor: mymove_small
     steps:
       - checkout
       - restore_cache:
@@ -372,7 +377,7 @@ jobs:
 
   # `build_migrations` builds the migrations container and pushes to the container repository
   build_migrations:
-    executor: mymove
+    executor: mymove_small
     steps:
       - checkout
       - setup_remote_docker:
@@ -394,7 +399,7 @@ jobs:
 
   # `deploy_experimental_migrations` deploys migrations to the experimental environment
   deploy_experimental_migrations:
-    executor: mymove
+    executor: mymove_small
     environment:
       - APP_ENVIRONMENT: "experimental"
     steps:
@@ -402,7 +407,7 @@ jobs:
 
   # `deploy_experimental_app` updates the server-TLS app service in the experimental environment
   deploy_experimental_app:
-    executor: mymove
+    executor: mymove_small
     environment:
       - APP_ENVIRONMENT: "experimental"
     steps:
@@ -411,7 +416,7 @@ jobs:
 
   # `deploy_experimental_app_client_tls` updates the mutual-TLS service in the experimental environment
   deploy_experimental_app_client_tls:
-    executor: mymove
+    executor: mymove_small
     environment:
       - APP_ENVIRONMENT: "experimental"
     steps:
@@ -420,7 +425,7 @@ jobs:
 
   # `deploy_staging_migrations` deploys migrations to the staging environment
   deploy_staging_migrations:
-    executor: mymove
+    executor: mymove_small
     environment:
       - APP_ENVIRONMENT: "staging"
     steps:
@@ -428,7 +433,7 @@ jobs:
 
   # `deploy_staging_app` updates the server-TLS app service in staging environment
   deploy_staging_app:
-    executor: mymove
+    executor: mymove_small
     environment:
       - APP_ENVIRONMENT: "staging"
     steps:
@@ -437,7 +442,7 @@ jobs:
 
   # `deploy_staging_app_client_tls` updates the mutual-TLS service in the staging environment
   deploy_staging_app_client_tls:
-    executor: mymove
+    executor: mymove_small
     environment:
       - APP_ENVIRONMENT: "staging"
     steps:
@@ -446,7 +451,7 @@ jobs:
 
   # `deploy_prod_migrations` deploys migrations to the staging environment
   deploy_prod_migrations:
-    executor: mymove
+    executor: mymove_small
     environment:
       - APP_ENVIRONMENT: "prod"
     steps:
@@ -454,7 +459,7 @@ jobs:
 
   # `deploy_prod_app` updates the server-TLS app service in the prod environment
   deploy_prod_app:
-    executor: mymove
+    executor: mymove_small
     environment:
       - APP_ENVIRONMENT: "prod"
     steps:
@@ -463,7 +468,7 @@ jobs:
 
   # `deploy_prod_app_client_tls` updates the mutual-TLS service in the prod environment
   deploy_prod_app_client_tls:
-    executor: mymove
+    executor: mymove_small
     environment:
       - APP_ENVIRONMENT: "prod"
     steps:
@@ -473,7 +478,7 @@ jobs:
   # `update_dependencies` periodically updates pre-commit, yarn, and Go dependencies.
   # The changes are submitted as a pull request for review.
   update_dependencies:
-    executor: mymove
+    executor: mymove_small
     steps:
       - checkout
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@
 version: "2.1"
 
 executors:
-  # `mymove` uses the `trussworks/circleci-docker-primary` docker image with a checkout of the mymove code
+  # `mymove_small` and `mymove_medium` use the `trussworks/circleci-docker-primary` docker image with a checkout of the mymove code
   mymove_small:
     resource_class: small
     working_directory: ~/go/src/github.com/transcom/mymove
@@ -21,9 +21,18 @@ executors:
     working_directory: ~/go/src/github.com/transcom/mymove
     docker:
       - image: trussworks/circleci-docker-primary:4bf3060cd9f47be0adb819ded630aa1848055ffe
-  # `mymove_and_postgres` adds a secondary postgres container to be used during testing.
-  mymove_and_postgres:
+  # `mymove_and_postgres_medium` and `mymove_and_postgres_large` add a secondary postgres container to be used during testing.
+  mymove_and_postgres_medium:
     resource_class: medium
+    working_directory: ~/go/src/github.com/transcom/mymove
+    docker:
+      - image: trussworks/circleci-docker-primary:4bf3060cd9f47be0adb819ded630aa1848055ffe
+      - image: postgres:10.5
+        environment:
+          - POSTGRES_PASSWORD: mysecretpassword
+          - POSTGRES_DB: test_db
+  mymove_and_postgres_large:
+    resource_class: large
     working_directory: ~/go/src/github.com/transcom/mymove
     docker:
       - image: trussworks/circleci-docker-primary:4bf3060cd9f47be0adb819ded630aa1848055ffe
@@ -157,7 +166,7 @@ jobs:
 
   # `pre_test` runs pre-commit against all files.
   pre_test:
-    executor: mymove_small
+    executor: mymove_medium
     steps:
       - checkout
       - restore_cache:
@@ -200,7 +209,7 @@ jobs:
 
   # `integration_tests` runs integration tests using Cypress.  https://www.cypress.io/
   integration_tests:
-    executor: mymove_and_postgres
+    executor: mymove_and_postgres_large
     steps:
       - checkout
       - setup_remote_docker:
@@ -286,7 +295,7 @@ jobs:
 
   # `server_test` runs the server side Go tests
   server_test:
-    executor: mymove_and_postgres
+    executor: mymove_and_postgres_medium
     steps:
       - checkout
       - setup_remote_docker:
@@ -349,7 +358,7 @@ jobs:
 
   # `build_app` builds the application container and pushes to the container repository
   build_app:
-    executor: mymove_and_postgres
+    executor: mymove_and_postgres_medium
     steps:
       - checkout
       - setup_remote_docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,11 +12,13 @@ version: "2.1"
 executors:
   # `mymove` uses the `trussworks/circleci-docker-primary` docker image with a checkout of the mymove code
   mymove:
+    resource_class: small
     working_directory: ~/go/src/github.com/transcom/mymove
     docker:
       - image: trussworks/circleci-docker-primary:4bf3060cd9f47be0adb819ded630aa1848055ffe
   # `mymove_and_postgres` adds a secondary postgres container to be used during testing.
   mymove_and_postgres:
+    resource_class: medium
     working_directory: ~/go/src/github.com/transcom/mymove
     docker:
       - image: trussworks/circleci-docker-primary:4bf3060cd9f47be0adb819ded630aa1848055ffe


### PR DESCRIPTION
## Description

During our trial of CircleCI's Performance Plan we can use `docker_layer_caching` and `resource_class`.  This set's up the `resource_class` on our config and use it during the trial.  Outside of the trial these will revert to be no-op and we can take our time removing them if we don't choose to upgrade our plan.

## Reviewer Notes

Most of the executors now use `mymove_small` because they are doing small tasks or builds and I'm *guessing* that this will not dramatically impact performance times but will also save money (if we were paying for this plan).  I've left the remaining resource classes as the default `medium` type but I've called it out by using `mymove_medium` or `mymove_and_postgres_medium`.  I'll post some build time pictures below in the comments.

## Code Review Verification Steps

* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/162585120) for this change
* [this article about resource_class](https://circleci.com/docs/2.0/configuration-reference/#resource_class) explains more about the approach used.