### PR TITLE
Disable generate GBL until office approves shipment

### DIFF
--- a/cypress/integration/tsp/generateGBL.js
+++ b/cypress/integration/tsp/generateGBL.js
@@ -14,7 +14,34 @@ describe('TSP User generates GBL', function() {
   it('tsp user can open a GBL from the shipment info page', function() {
     tspUserViewsGBL();
   });
+
+  it('tsp user cannot generate gbl until office approves shipment', function() {
+    tspUserCannotGenerateGBL();
+  });
 });
+
+function tspUserCannotGenerateGBL() {
+  const gblButtonText = 'Generate the GBL';
+
+  cy.visit('/queues/accepted');
+  cy.location().should(loc => {
+    expect(loc.pathname).to.match(/^\/queues\/accepted/);
+  });
+
+  cy
+    .get('div')
+    .contains('GBLDIS')
+    .dblclick();
+
+  cy.location().should(loc => {
+    expect(loc.pathname).to.match(/^\/shipments\/[^/]+/);
+  });
+
+  cy
+    .get('button')
+    .contains(gblButtonText)
+    .should('be.disabled');
+}
 
 function tspUserGeneratesGBL() {
   const gblButtonText = 'Generate the GBL';

--- a/pkg/testdatagen/scenario/e2ebasic.go
+++ b/pkg/testdatagen/scenario/e2ebasic.go
@@ -1772,6 +1772,70 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, log
 	})
 	hhg31.Move.Submit()
 	models.SaveMoveDependencies(db, &hhg31.Move)
+
+	/*
+	 * Service member with approved basics and accepted shipment
+	 */
+	email = "hhg@gbl.disabled"
+
+	offer32 := testdatagen.MakeShipmentOffer(db, testdatagen.Assertions{
+		User: models.User{
+			ID:            uuid.Must(uuid.FromString("ab04735c-fc9c-40a3-8e46-73dc0ca163da")),
+			LoginGovEmail: email,
+		},
+		ServiceMember: models.ServiceMember{
+			ID:            uuid.FromStringOrNil("35e3f64d-5615-4c9d-acf3-b832404d5627"),
+			FirstName:     models.StringPointer("GBLDisabled"),
+			LastName:      models.StringPointer("Waiting for office"),
+			Edipi:         models.StringPointer("4444567890"),
+			PersonalEmail: models.StringPointer(email),
+		},
+		Move: models.Move{
+			ID:               uuid.FromStringOrNil("262d079b-1e18-48bc-8351-f6a092af67d9"),
+			Locator:          "GBLDIS",
+			SelectedMoveType: &selectedMoveTypeHHG,
+		},
+		Order: models.Order{
+			OrdersNumber:        models.StringPointer("54321"),
+			OrdersTypeDetail:    &typeDetail,
+			DepartmentIndicator: models.StringPointer("AIR_FORCE"),
+			TAC:                 models.StringPointer("99"),
+		},
+		TrafficDistributionList: models.TrafficDistributionList{
+			ID:                uuid.FromStringOrNil("440dfbf6-a9da-4d37-b3e1-7327424eda01"),
+			SourceRateArea:    "US62",
+			DestinationRegion: "11",
+			CodeOfService:     "D",
+		},
+		Shipment: models.Shipment{
+			ID:                          uuid.FromStringOrNil("53115e49-466e-42ee-85c6-9215add89cea"),
+			Status:                      models.ShipmentStatusACCEPTED,
+			PmSurveyConductedDate:       &packDate,
+			PmSurveyCompletedAt:         &packDate,
+			PmSurveyMethod:              "PHONE",
+			PmSurveyPlannedPackDate:     &packDate,
+			PmSurveyPlannedPickupDate:   &pickupDate,
+			PmSurveyPlannedDeliveryDate: &deliveryDate,
+			PmSurveyWeightEstimate:      &weightEstimate,
+			SourceGBLOC:                 &sourceOffice.Gbloc,
+			DestinationGBLOC:            &destOffice.Gbloc,
+		},
+		ShipmentOffer: models.ShipmentOffer{
+			TransportationServiceProviderID: tspUser.TransportationServiceProviderID,
+			Accepted:                        models.BoolPointer(true),
+		},
+	})
+
+	testdatagen.MakeServiceAgent(db, testdatagen.Assertions{
+		ServiceAgent: models.ServiceAgent{
+			Shipment:   &offer32.Shipment,
+			ShipmentID: offer32.ShipmentID,
+		},
+	})
+
+	hhg32 := offer32.Shipment
+	hhg32.Move.Submit()
+	models.SaveMoveDependencies(db, &hhg32.Move)
 }
 
 // MakeHhgWithPpm creates an HHG user who has added a PPM

--- a/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
+++ b/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
@@ -366,11 +366,10 @@ class ShipmentInfo extends Component {
                   </span>
                 </Alert>
               )}
-              {approved &&
-                pmSurveyComplete &&
+              {pmSurveyComplete &&
                 !gblGenerated && (
                   <div>
-                    <button onClick={this.generateGBL} disabled={generateGBLInProgress}>
+                    <button onClick={this.generateGBL} disabled={!approved || generateGBLInProgress}>
                       Generate the GBL
                     </button>
                   </div>


### PR DESCRIPTION
## Description

TSP user shows a disabled `Generate the GBL` button until the office approves the shipment
## Reviewer Notes


## Setup
`make db_populate_e2e`
`make server_run`
`make tsp_client_run`
Go to `Accepted` queue
Go into shipment with locator `GBLDIS`

## Code Review Verification Steps
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/162103259) for this change

## Screenshots

![image](https://user-images.githubusercontent.com/13622298/49897612-8a1c3580-fe0b-11e8-9961-5fb76471d2cf.png)
