### PR TITLE
Fixes dates in e2e tests

### DIFF
--- a/cypress/integration/mymove/hhgPPM.js
+++ b/cypress/integration/mymove/hhgPPM.js
@@ -78,10 +78,10 @@ function serviceMemberVerifiesHHGPPMSummary() {
 
     // HHG Panel
     expect(text).to.include('Shipment - Government moves all of your stuff (HHG)');
-    expect(text).to.include('Movers Packing: Mon, May 13 - Tue, May 14');
-    expect(text).to.include('Loading Truck: Wed, May 15');
-    expect(text).to.include('Move in Transit:Thu, May 16 - Sun, May 19');
-    expect(text).to.include('Delivery:Mon, May 20');
+    expect(text).to.include('Movers Packing: Fri, May 11 - Mon, May 14');
+    expect(text).to.include('Loading Truck: Tue, May 15');
+    expect(text).to.include('Move in Transit:Wed, May 16 - Sun, May 20');
+    expect(text).to.include('Delivery:Mon, May 21');
     expect(text).to.include(
       'Weight Estimate:2,000 lbs + 225 lbs pro-gear + 312 lbs spouse pro-gear Great! You appear within your weight allowance.',
     );

--- a/cypress/integration/tsp/queues.js
+++ b/cypress/integration/tsp/queues.js
@@ -49,7 +49,7 @@ function tspUserViewsNewShipments() {
     // Should figure out why this is happening
     // .contains('div', 'US88 to Region 2')
     // .parentsUntil('div.rt-tr-group')
-    .contains('div', '06-Dec-18');
+    .contains('div', '15-May-18');
 
   // Find and open shipment
   cy


### PR DESCRIPTION
## Description

#1377 was merged, which changed some default dates in generated test data. Another PR merged around the same time included e2e tests based on old data, so this PR fixes those dates where necessary

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](./docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](./docs/backend.md#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](./docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
* [ ] There are no aXe warnings for UI.
* [ ] This works in IE.
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @willowbl00
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?
