### PR TITLE
Created new Go error for unsupported postal codes

### DIFF
--- a/pkg/handlers/errors.go
+++ b/pkg/handlers/errors.go
@@ -60,7 +60,7 @@ func ResponseForError(logger *zap.Logger, err error) middleware.Responder {
 	cause := errors.Cause(err)
 	switch cause.(type) {
 	case *route.UnsupportedPostalCode:
-		skipLogger.Debug("invalid postal code", zap.Error(err))
+		skipLogger.Debug("unsupported postal code", zap.Error(err))
 		return newErrResponse(http.StatusUnprocessableEntity, err)
 	default:
 		return responseForBaseError(skipLogger, err)

--- a/pkg/handlers/errors.go
+++ b/pkg/handlers/errors.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"encoding/json"
+	"github.com/transcom/mymove/pkg/route"
 	"net/http"
 	"strings"
 
@@ -55,6 +56,20 @@ func (o *ErrResponse) WriteResponse(rw http.ResponseWriter, producer runtime.Pro
 func ResponseForError(logger *zap.Logger, err error) middleware.Responder {
 	// AddCallerSkip(1) prevents log statements from listing this file and func as the caller
 	skipLogger := logger.WithOptions(zap.AddCallerSkip(1))
+
+	cause := errors.Cause(err)
+	switch cause.(type) {
+	case *route.UnsupportedPostalCode:
+		skipLogger.Debug("invalid postal code", zap.Error(err))
+		return newErrResponse(http.StatusUnprocessableEntity, err)
+	default:
+		return responseForBaseError(skipLogger, err)
+	}
+}
+
+func responseForBaseError(logger *zap.Logger, err error) middleware.Responder {
+	skipLogger := logger.WithOptions(zap.AddCallerSkip(1))
+
 	switch errors.Cause(err) {
 	case models.ErrFetchNotFound:
 		skipLogger.Debug("not found", zap.Error(err))

--- a/pkg/route/errors.go
+++ b/pkg/route/errors.go
@@ -1,0 +1,21 @@
+package route
+
+import (
+	"fmt"
+)
+
+// UnsupportedPostalCode represents a postal code that cannot be handled by the application.
+type UnsupportedPostalCode struct {
+	postalCode string
+}
+
+// NewUnsupportedPostalCodeError creates a new UnsupportedPostalCode error.
+func NewUnsupportedPostalCodeError(postalCode string) *UnsupportedPostalCode {
+	return &UnsupportedPostalCode{
+		postalCode: postalCode,
+	}
+}
+
+func (e *UnsupportedPostalCode) Error() string {
+	return fmt.Sprintf("Unsupported postal code (%s)", e.postalCode)
+}

--- a/pkg/route/zip_locale.go
+++ b/pkg/route/zip_locale.go
@@ -1,7 +1,6 @@
 package route
 
 import (
-	"fmt"
 	"strconv"
 )
 
@@ -13,7 +12,7 @@ func Zip5ToLatLong(zip5 string) (LatLong, error) {
 		var ok bool
 		ll, ok = zip5ToLatLongMap[zipAsInt]
 		if !ok {
-			err = fmt.Errorf("could not find zip code %s", zip5)
+			err = NewUnsupportedPostalCodeError(zip5)
 		}
 	}
 	return ll, err


### PR DESCRIPTION
## Description

This PR adds in a new custom Go error for unsupported postal codes.  It also ensures that our handlers return a status code of 422 (StatusUnprocessableEntity) in that situation.  Previously, these were being returned as a status code of 500 (StatusInternalServerError), which caused them to show up as alerts.

## Reviewer Notes

Note that I needed to create a custom error type (unlike some of the other ones we single out in `handlers/errors.go`) because I wanted to preserve the specific unsupported postal code in the error (the other types like `ErrFetchNotFound` aren't custom errors, but just constants that are the same for all errors of that type.

This PR should be considered a quick first step to clean up our alerts some.  I'm going to be creating a story soon about validating zip codes earlier in the process -- probably on initial submission.

## Setup

Create a PPM move in the system and give it a destination postal code of 93333 (which isn't a legit US postal code).  When you get to the page in the PPM wizard where you pick the size of your shipment, pick a size and hit "Next".  You should get an error on the page -- before this PR it was an internal server error, and now it's an unprocessable entity.  You can verify the 422 status code in the dev tools of your browser, as well as the fact the postal code is still noted in the response as before (even though we aren't using a base error type anymore).

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](./docs/backend.md#logging)
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/162257342) for this change
