### PR TITLE
Fixed broken server test in invoice generator

### DIFF
--- a/pkg/edi/invoice/generator_test.go
+++ b/pkg/edi/invoice/generator_test.go
@@ -215,12 +215,10 @@ func TestInvoiceSuite(t *testing.T) {
 }
 
 func (suite *InvoiceSuite) TestMakeEDISegments() {
-	costsByShipments := helperCostsByShipment(suite)
+	shipment := helperShipment(suite)
 	var lineItems []models.ShipmentLineItem
 
-	for _, shipment := range costsByShipments {
-		lineItems = append(shipment.Shipment.ShipmentLineItems)
-	}
+	lineItems = append(shipment.ShipmentLineItems)
 
 	suite.T().Run("test EDI segments", func(t *testing.T) {
 		for _, lineItem := range lineItems {


### PR DESCRIPTION
## Description

This PR fixes a broken server test.  Looks like something happened in the merge and we have some references to old names/return values.

## Setup

`make server_test` and check that it runs cleanly.
