### PR TITLE
fix mismatch between yaml api endpoint and office api

### DIFF
--- a/src/scenes/Office/api.js
+++ b/src/scenes/Office/api.js
@@ -136,7 +136,7 @@ export async function CompleteHHG(shipmentId) {
 // HHG invoice
 export async function SendHHGInvoice(shipmentId) {
   const client = await getClient();
-  const response = await client.apis.shipments.sendHHGInvoice({
+  const response = await client.apis.shipments.createAndSendHHGInvoice({
     shipmentId,
   });
   checkResponse(response, 'failed to send invoice to server error');


### PR DESCRIPTION
## Description

We broke the connection between the js office api and yaml api mapping in the last few merges. This PR fixes that problem.

yaml endpoint: https://github.com/transcom/mymove/blob/master/swagger/internal.yaml#L3212

## Setup

Try to submit an invoice using approved requests and the application crashes with an invoid function call.

## Code Review Verification Steps

* [] User can submit invoices successfully 