### PR TITLE
Use valid GBLOC value in test data

### DIFF
--- a/cypress/integration/tsp/checkHeader.js
+++ b/cypress/integration/tsp/checkHeader.js
@@ -41,7 +41,7 @@ function tspUserViewsHHGHeaderInfo() {
   // Check the info bar
   cy
     .get('ul')
-    .contains('li', 'GBL# LKBM7123456')
+    .contains('li', 'GBL# LKNQ7123456')
     .parentsUntil('div')
     .contains('li', 'Locator# HHGPPM')
     .parentsUntil('div')
@@ -80,7 +80,7 @@ function tspUserViewsHHGPPMHeaderInfo() {
   // Check the info bar
   cy
     .get('ul')
-    .contains('li', 'GBL# LKBM7123456')
+    .contains('li', 'GBL# LKNQ7123456')
     .parentsUntil('div')
     .contains('li', 'Locator# HHGPPM')
     .parentsUntil('div')

--- a/cypress/integration/tsp/queues.js
+++ b/cypress/integration/tsp/queues.js
@@ -41,7 +41,7 @@ function tspUserViewsNewShipments() {
     .parentsUntil('div.rt-tr-group')
     .contains('div', 'Awarded')
     .parentsUntil('div.rt-tr-group')
-    .contains('div', 'LKBM7')
+    .contains('div', 'LKNQ7')
     .parentsUntil('div.rt-tr-group')
     .contains('div', 'Submitted, HHG')
     .parentsUntil('div.rt-tr-group')

--- a/pkg/testdatagen/make_transportation_office.go
+++ b/pkg/testdatagen/make_transportation_office.go
@@ -14,7 +14,7 @@ func MakeTransportationOffice(db *pop.Connection, assertions Assertions) models.
 		Name:      "JPPSO Testy McTest",
 		AddressID: address.ID,
 		Address:   address,
-		Gbloc:     "LKBM",
+		Gbloc:     "LKNQ",
 		Latitude:  1.23445,
 		Longitude: -23.34455,
 	}

--- a/pkg/testdatagen/scenario/e2ebasic.go
+++ b/pkg/testdatagen/scenario/e2ebasic.go
@@ -1836,7 +1836,7 @@ func MakeHhgWithPpm(db *pop.Connection, tspUser models.TspUser, loader *uploader
 		Shipment: models.Shipment{
 			Status:             models.ShipmentStatusAWARDED,
 			HasDeliveryAddress: true,
-			GBLNumber:          models.StringPointer("LKBM7123456"),
+			GBLNumber:          models.StringPointer("LKNQ7123456"),
 		},
 		ShipmentOffer: models.ShipmentOffer{
 			TransportationServiceProviderID: tspUser.TransportationServiceProviderID,


### PR DESCRIPTION
Replace GBLOC in test transportation office with a valid one to pass properly into Syncada

## Description

Invoices were failing on Syncada (not showing up) because the GBLOC (Buyer ID) is not a valid one in their system.  This changes the test transportation office GBLOC to a valid value.

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/162563222) for this change
