### PR TITLE
Make sure test dates don't fall on a weekend or holiday

### DIFF
--- a/pkg/dates/calculators.go
+++ b/pkg/dates/calculators.go
@@ -63,3 +63,13 @@ func CreateValidDatesBetweenTwoDates(startDate time.Time, endDate time.Time, inc
 	}
 	return dates, nil
 }
+
+// NextValidMoveDate returns next subsequent non-holiday weekday
+// This is mostly used for testing purposes
+func NextValidMoveDate(d time.Time, calendar *cal.Calendar) time.Time {
+	// Add days until we get a non-holiday weekday
+	for !calendar.IsWorkday(d) {
+		d = d.AddDate(0, 0, 1)
+	}
+	return d
+}

--- a/pkg/dates/calculators_test.go
+++ b/pkg/dates/calculators_test.go
@@ -108,6 +108,22 @@ func (suite *DatesSuite) TestCreateValidDatesBetweenTwoDatesEndDateMustBeLater()
 	suite.Error(err)
 }
 
+func (suite *DatesSuite) TestNextValidMoveDate() {
+	invalidMoveDates := []time.Time{
+		time.Date(2018, 12, 8, 0, 0, 0, 0, time.UTC),  // Saturday
+		time.Date(2018, 12, 9, 0, 0, 0, 0, time.UTC),  // Sunday
+		time.Date(2018, 12, 25, 0, 0, 0, 0, time.UTC), // Christmas
+	}
+
+	usCalendar := NewUSCalendar()
+	for _, d := range invalidMoveDates {
+		validDate := NextValidMoveDate(d, usCalendar)
+		// The date should be a different, valid workday
+		suite.False(validDate.Equal(d))
+		suite.True(usCalendar.IsWorkday(validDate))
+	}
+}
+
 type DatesSuite struct {
 	suite.Suite
 	db     *pop.Connection

--- a/pkg/testdatagen/scenario/e2ebasic.go
+++ b/pkg/testdatagen/scenario/e2ebasic.go
@@ -31,15 +31,16 @@ var selectedMoveTypeHHG = models.SelectedMoveTypeHHG
 var selectedMoveTypePPM = models.SelectedMoveTypePPM
 var selectedMoveTypeHHGPPM = models.SelectedMoveTypeHHGPPM
 
-var nowTime = time.Now()
+// Often weekends and holidays are not allowable dates, so ensure weekdays
+var nowTime = testdatagen.NextWeekday(time.Now())
 
-var nowPlusOne = nowTime.AddDate(0, 0, 1)
-var nowPlusFive = nowTime.AddDate(0, 0, 5)
-var nowPlusTen = nowTime.AddDate(0, 0, 10)
+var nowPlusOne = testdatagen.NextWeekday(nowTime.AddDate(0, 0, 1))
+var nowPlusFive = testdatagen.NextWeekday(nowTime.AddDate(0, 0, 5))
+var nowPlusTen = testdatagen.NextWeekday(nowTime.AddDate(0, 0, 10))
 
-var nowMinusOne = nowTime.AddDate(0, 0, -1)
-var nowMinusFive = nowTime.AddDate(0, 0, -5)
-var nowMinusTen = nowTime.AddDate(0, 0, -10)
+var nowMinusOne = testdatagen.NextWeekday(nowTime.AddDate(0, 0, -1))
+var nowMinusFive = testdatagen.NextWeekday(nowTime.AddDate(0, 0, -5))
+var nowMinusTen = testdatagen.NextWeekday(nowTime.AddDate(0, 0, -10))
 
 // Run does that data load thing
 func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, logger *zap.Logger, storer *storage.Filesystem) {

--- a/pkg/testdatagen/scenario/e2ebasic.go
+++ b/pkg/testdatagen/scenario/e2ebasic.go
@@ -14,6 +14,7 @@ import (
 	uploaderpkg "github.com/transcom/mymove/pkg/uploader"
 	"go.uber.org/zap"
 
+	"github.com/transcom/mymove/pkg/dates"
 	"github.com/transcom/mymove/pkg/gen/internalmessages"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"
@@ -31,16 +32,17 @@ var selectedMoveTypeHHG = models.SelectedMoveTypeHHG
 var selectedMoveTypePPM = models.SelectedMoveTypePPM
 var selectedMoveTypeHHGPPM = models.SelectedMoveTypeHHGPPM
 
-// Often weekends and holidays are not allowable dates, so ensure weekdays
-var nowTime = testdatagen.NextWeekday(time.Now())
+// Often weekends and holidays are not allowable dates
+var cal = dates.NewUSCalendar()
+var nowTime = dates.NextValidMoveDate(time.Now(), cal)
 
-var nowPlusOne = testdatagen.NextWeekday(nowTime.AddDate(0, 0, 1))
-var nowPlusFive = testdatagen.NextWeekday(nowTime.AddDate(0, 0, 5))
-var nowPlusTen = testdatagen.NextWeekday(nowTime.AddDate(0, 0, 10))
+var nowPlusOne = dates.NextValidMoveDate(nowTime.AddDate(0, 0, 1), cal)
+var nowPlusFive = dates.NextValidMoveDate(nowTime.AddDate(0, 0, 5), cal)
+var nowPlusTen = dates.NextValidMoveDate(nowTime.AddDate(0, 0, 10), cal)
 
-var nowMinusOne = testdatagen.NextWeekday(nowTime.AddDate(0, 0, -1))
-var nowMinusFive = testdatagen.NextWeekday(nowTime.AddDate(0, 0, -5))
-var nowMinusTen = testdatagen.NextWeekday(nowTime.AddDate(0, 0, -10))
+var nowMinusOne = dates.NextValidMoveDate(nowTime.AddDate(0, 0, -1), cal)
+var nowMinusFive = dates.NextValidMoveDate(nowTime.AddDate(0, 0, -5), cal)
+var nowMinusTen = dates.NextValidMoveDate(nowTime.AddDate(0, 0, -10), cal)
 
 // Run does that data load thing
 func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, logger *zap.Logger, storer *storage.Filesystem) {

--- a/pkg/testdatagen/shared.go
+++ b/pkg/testdatagen/shared.go
@@ -94,6 +94,17 @@ func noErr(err error) {
 	}
 }
 
+// NextWeekday returns next subsequent weekday if date falls on a weekend
+func NextWeekday(d time.Time) time.Time {
+	currentDay := d.Weekday()
+	if currentDay == 0 || currentDay == 6 {
+		// 1 day if Sunday (0), 2 if Saturday (6)
+		daysToAdd := 1 + int(currentDay)/6
+		return d.AddDate(0, 0, daysToAdd)
+	}
+	return d
+}
+
 // zip5ToZip3 takes a ZIP5 string and returns the ZIP3 representation of it.
 func zip5ToZip3(zip5 string) string {
 	return zip5[0:3]

--- a/pkg/testdatagen/shared.go
+++ b/pkg/testdatagen/shared.go
@@ -94,17 +94,6 @@ func noErr(err error) {
 	}
 }
 
-// NextWeekday returns next subsequent weekday if date falls on a weekend
-func NextWeekday(d time.Time) time.Time {
-	currentDay := d.Weekday()
-	if currentDay == 0 || currentDay == 6 {
-		// 1 day if Sunday (0), 2 if Saturday (6)
-		daysToAdd := 1 + int(currentDay)/6
-		return d.AddDate(0, 0, daysToAdd)
-	}
-	return d
-}
-
 // zip5ToZip3 takes a ZIP5 string and returns the ZIP3 representation of it.
 func zip5ToZip3(zip5 string) string {
 	return zip5[0:3]


### PR DESCRIPTION
## Description

The rate engine has trouble pricing things using dates that fall on a weekend, so this PR makes sure that none of the dates provided in `e2e_basic.go` fall on a weekend.