### PR TITLE
Create test to check no unbilled charges show up in invoice panel when there are no unbilled charges

### DIFF
--- a/cypress/integration/office/invoicing.js
+++ b/cypress/integration/office/invoicing.js
@@ -1,0 +1,19 @@
+describe(
+  'As an office user, I want to keep track of HHG shipment costs before they are billed, ' +
+    'so if there are no pre-approved, unbilled charges, I should see none',
+  () => {
+    beforeEach(() => {
+      cy.signIntoOffice();
+    });
+    it('opens the shipment tab', () => {
+      cy.visit('/queues/new/moves/fb4105cf-f5a5-43be-845e-d59fdb34f31c/hhg');
+
+      // The invoice table should be empty.
+      cy
+        .get('.invoice-panel .basic-panel-content')
+        .children()
+        .first()
+        .should('have.class', 'empty-content');
+    });
+  },
+);

--- a/cypress/integration/office/invoicing.js
+++ b/cypress/integration/office/invoicing.js
@@ -13,7 +13,7 @@ describe(
         .get('.invoice-panel .basic-panel-content')
         .children()
         .first()
-        .should('have.class', 'empty-content');
+        .should('have.text', 'No line items');
     });
   },
 );


### PR DESCRIPTION
## Description

Context
Given I am an authenticated office worker
And there is an HHG shipment in a move

Scenario 0: Office worker sees there are no unbilled line items for a shipment
And there are no unbilled line items for the HHG shipment
When I navigate to the HHG tab in the "Move Info" page for that shipment
Then I see an invoice panel
And the panel should show me that there are no unbilled invoices


## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](./docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](./docs/backend.md#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](./docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
* [ ] There are no aXe warnings for UI.
* [ ] This works in IE.
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @willowbl00
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/162642829) for this change
* [this article](tbd) explains more about the approach used.
