### PR TITLE
Sets default invoice approver for existing data

### DIFF
--- a/migrations/20181208060817_add_invoice_approver.up.fizz
+++ b/migrations/20181208060817_add_invoice_approver.up.fizz
@@ -1,3 +1,5 @@
-add_column("invoices", "approver_id", "uuid", {})
+sql("ALTER TABLE invoices ADD COLUMN approver_id UUID;")
+sql("UPDATE invoices SET approver_id='709739d6-96b4-4e67-8fe6-28671e80a69a';")
+sql("ALTER TABLE invoices ALTER COLUMN approver_id SET NOT NULL;")
 
 add_foreign_key("invoices", "approver_id", {"office_users": ["id"]}, {})


### PR DESCRIPTION
## Description

This migration would break when there are existing invoices. Apparently we have existing invoices on staging!

Rather than wiping all invoices and shipment_line_items, this PR populates a default approver of, well, me. I grabbed my office_user ID from the secure migration and there's a matching ID in the insecure migration, so this should work everywhere.

**How to test this:**

If you haven't already run this migration:
- Make sure you have an invoice row in the `invoices` table (`insert into invoices (id,status,invoiced_date,invoice_number,created_at,updated_at) values (uuid_generate_v4(),'SUBMITTED',now(),1,now(),now());`)
- `make db_dev_migrate`

If you already ran this migration:
- Hide/delete this migration file
- `make db_populate_e2e`
- Insert an `invoice` as above
- Restore migration file
- `make db_dev_migrate`