### PR TITLE
Fixed reference to old uuid import

### DIFF
--- a/pkg/service/invoice/fetch_invoice_for_shipment.go
+++ b/pkg/service/invoice/fetch_invoice_for_shipment.go
@@ -2,7 +2,7 @@ package invoice
 
 import (
 	"github.com/gobuffalo/pop"
-	"github.com/gobuffalo/uuid"
+	"github.com/gofrs/uuid"
 	"github.com/transcom/mymove/pkg/models"
 )
 


### PR DESCRIPTION
## Description

This PR fixes a reference to an old uuid import: `github.com/gobuffalo/uuid` should be `github.com/gofrs/uuid`.  `dep` will complain otherwise.  See #1314 and #1262 for background.

## Setup

Run `dep check` and make sure there are no complaints.
