### PR TITLE
Add clause for the neither location value. Add unit test for this and…

### DIFF
--- a/pkg/edi/invoice/generator.go
+++ b/pkg/edi/invoice/generator.go
@@ -365,6 +365,8 @@ func MakeHLSegment(lineItem models.ShipmentLineItem) *edisegment.HL {
 	case models.ShipmentLineItemLocationDESTINATION:
 		hierarchicalLevelID = "303"
 
+	case models.ShipmentLineItemLocationNEITHER:
+		hierarchicalLevelID = "303"
 	}
 	return &edisegment.HL{
 		HierarchicalIDNumber:  hierarchicalLevelID,

--- a/pkg/edi/invoice/generator_test.go
+++ b/pkg/edi/invoice/generator_test.go
@@ -114,7 +114,7 @@ func helperShipment(suite *InvoiceSuite) models.Shipment {
 
 	// Create some shipment line items.
 	var lineItems []models.ShipmentLineItem
-	codes := []string{"LHS", "135A", "135B", "105A", "16A", "105C", "125B", "105B", "130B"}
+	codes := []string{"LHS", "135A", "135B", "105A", "16A", "105C", "125B", "105B", "130B", "46A"}
 	amountCents := unit.Cents(12325)
 	for _, code := range codes {
 
@@ -144,6 +144,9 @@ func helperShipment(suite *InvoiceSuite) models.Shipment {
 		}
 		if code == "135B" {
 			location = models.ShipmentLineItemLocationDESTINATION
+		}
+		if code == "46A" {
+			location = models.ShipmentLineItemLocationNEITHER
 		}
 
 		item := testdatagen.MakeTariff400ngItem(suite.db, testdatagen.Assertions{
@@ -231,6 +234,10 @@ func (suite *InvoiceSuite) TestMakeEDISegments() {
 			}
 
 			if lineItem.Location == models.ShipmentLineItemLocationDESTINATION {
+				suite.Equal("303", hlSegment.HierarchicalIDNumber)
+			}
+
+			if lineItem.Location == models.ShipmentLineItemLocationNEITHER {
 				suite.Equal("303", hlSegment.HierarchicalIDNumber)
 			}
 


### PR DESCRIPTION
… test generation. Lastly, update golden with new line item.

## Description
Adding in a clause for the NEITHER location value for shipment_line_items. This is being done because its absence is causing a bug where we're missing the location field in HL segments for line items that need that code.

## Setup

No special steps.

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](./docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](./docs/backend.md#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](./docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
* [ ] There are no aXe warnings for UI.
* [ ] This works in IE.
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @willowbl00
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/n/projects/2136865/stories/162650645) for this change
