### PR TITLE
Removes patchOrders from internal.yaml 

### DIFF
--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -2233,10 +2233,6 @@ definitions:
         type: string
         format: uuid
         example: c56a4180-65aa-42ec-a945-5fd21dec0538
-      current_duty_station_id:
-        type: string
-        format: uuid
-        example: c53a4180-65aa-42ec-a945-5fd21dec0538
       orders_number:
         type: string
         title: Orders Number
@@ -2648,39 +2644,6 @@ paths:
           description: user is not authorized
         404:
           description: order is not found
-        500:
-          description: internal server error
-    patch:
-      summary: Updates orders information
-      description: All fields sent in this request will be set on the orders referenced
-      operationId: patchOrders
-      tags:
-        - orders
-      parameters:
-        - in: path
-          name: ordersId
-          type: string
-          format: uuid
-          required: true
-          description: UUID of the orders model
-        - in: body
-          name: patchOrders
-          required: true
-          schema:
-            $ref: '#/definitions/CreateUpdateOrders'
-      responses:
-        200:
-          description: updated instance of orders
-          schema:
-            $ref: '#/definitions/Orders'
-        400:
-          description: invalid request
-        401:
-          description: request requires user authentication
-        403:
-          description: user is not authorized
-        404:
-          description: move not found
         500:
           description: internal server error
   /moves:


### PR DESCRIPTION
## Description

Removes patchOrders from internal.yaml and the current_duty_station_id field from CreateUpdateOrders, neither of which were being used. 

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](./docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](./docs/backend.md#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](./docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
* [ ] There are no aXe warnings for UI.
* [ ] This works in IE.
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @willowbl00
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/160107902) for this change
* [this article](tbd) explains more about the approach used.

