### PR TITLE
Changed log level to error on PPMDiscountFetch failure

### DIFF
--- a/pkg/handlers/internalapi/estimate_helper.go
+++ b/pkg/handlers/internalapi/estimate_helper.go
@@ -48,7 +48,7 @@ func PPMDiscountFetch(db *pop.Connection, logger *zap.Logger, originZip string, 
 		return lhDiscount, sitDiscount, err
 	}
 
-	logger.Info("Couldn't find Discount for COS D or 2.",
+	logger.Error("Couldn't find Discount for COS D or 2.",
 		zap.String("origin_zip", originZip),
 		zap.String("destination_zip", destZip),
 		zap.Time("move_date", moveDate),


### PR DESCRIPTION
## Description

This PR changes a log level from info to error when a discount rate can't be found in `PPMDiscountFetch`.

## Reviewer Notes

This was originally noticed because a move from zip 32225 to 32225 was failing.  That's rate code US49 to region 13, and we don't have a TDL record for that combination (and thus no TSPP records that reference it).  I opened up a new Pivotal story (linked below) to investigate that problem.

## Setup

Create a PPM move from zip 32225 to zip 32225.  When clicking next on the "pick a size" part of the PPM wizard, an error level log should be made instead of an info level one.

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](./docs/backend.md#logging)
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/162522327) for this change
* [Pivotal story](https://www.pivotaltracker.com/story/show/162702947) for the underlying problem of missing TDL/TSPP records for this zip combination.
