### PR TITLE
Sb 162279364 add public tsp route

### DIFF
--- a/cypress/integration/office/officeServiceAgents.js
+++ b/cypress/integration/office/officeServiceAgents.js
@@ -13,23 +13,34 @@ describe('office user can view service agents', function() {
   });
 
   it('office user opens and cancels service agent panel', function() {
-    officeUserEntersServiceAgents();
+    officeUserOpensHhgPanelForMove('LRKREK');
+    officeUserVerifiesServiceAgent();
+    officeUserEditsServiceAgentPanel();
     userCancelsServiceAgent();
   });
 
   it('office user views and edits service agent panels', function() {
-    officeUserEntersServiceAgents();
-    userVerifiesTspAssigned();
+    officeUserOpensHhgPanelForMove('LRKREK');
+    officeUserVerifiesServiceAgent();
+    officeUserEditsServiceAgentPanel();
+    officeUserSeesBlankTspData();
     userClearsServiceAgent('Origin');
     userInputsServiceAgent('OriginUpdate');
     userClearsServiceAgent('Destination');
     userInputsServiceAgent('DestinationUpdate');
     userSavesServiceAgent('OriginUpdate');
+    officeUserSeesBlankTspData();
+  });
+
+  it('office user views tsp for awarded move', function() {
+    officeUserOpensHhgPanelForMove('BACON1');
+    userVerifiesTspAssigned();
+    officeUserEditsServiceAgentPanel();
     userVerifiesTspAssigned();
   });
 });
 
-function officeUserEntersServiceAgents() {
+function officeUserOpensHhgPanelForMove(moveLocator) {
   // Open all moves queue
   cy.visit('/queues/all');
   cy.location().should(loc => {
@@ -39,7 +50,7 @@ function officeUserEntersServiceAgents() {
   // Find move and open it
   cy
     .get('div')
-    .contains('LRKREK')
+    .contains(moveLocator)
     .dblclick();
 
   cy.location().should(loc => {
@@ -54,14 +65,42 @@ function officeUserEntersServiceAgents() {
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/queues\/new\/moves\/[^/]+\/hhg/);
   });
+}
 
+function officeUserVerifiesServiceAgent() {
   // Verify that the Service Agent Panel contains expected data
   cy.get('span').contains('ACME Movers');
+}
 
+function officeUserEditsServiceAgentPanel() {
   // Click on edit Service Agent
   cy
     .get('.editable-panel-header')
     .contains('TSP & Servicing Agents')
     .siblings()
     .click();
+}
+
+function officeUserSeesBlankTspData() {
+  const tspFields = cy
+    .get('.editable-panel-3-column')
+    .contains('TSP')
+    .parent()
+    .within(() => {
+      cy
+        .get('.panel-field')
+        .contains('Name')
+        .parent()
+        .should('not.contain', 'undefined');
+      cy
+        .get('.panel-field')
+        .contains('Email')
+        .parent()
+        .should('not.contain', 'undefined');
+      cy
+        .get('.panel-field')
+        .contains('Phone number')
+        .parent()
+        .should('not.contain', 'undefined');
+    });
 }

--- a/cypress/integration/office/officeServiceAgents.js
+++ b/cypress/integration/office/officeServiceAgents.js
@@ -3,6 +3,7 @@ import {
   userInputsServiceAgent,
   userSavesServiceAgent,
   userCancelsServiceAgent,
+  userVerifiesTspAssigned,
 } from '../../support/testTspServiceAgents';
 
 /* global cy */
@@ -18,11 +19,13 @@ describe('office user can view service agents', function() {
 
   it('office user views and edits service agent panels', function() {
     officeUserEntersServiceAgents();
+    userVerifiesTspAssigned();
     userClearsServiceAgent('Origin');
     userInputsServiceAgent('OriginUpdate');
     userClearsServiceAgent('Destination');
     userInputsServiceAgent('DestinationUpdate');
     userSavesServiceAgent('OriginUpdate');
+    userVerifiesTspAssigned();
   });
 });
 

--- a/cypress/integration/tsp/serviceAgents.js
+++ b/cypress/integration/tsp/serviceAgents.js
@@ -4,6 +4,7 @@ import {
   userCancelsServiceAgent,
   userInputsServiceAgent,
   userSavesServiceAgent,
+  userVerifiesTspAssigned,
 } from '../../support/testTspServiceAgents';
 import { tspUserVerifiesShipmentStatus } from '../../support/testTspStatus';
 
@@ -36,13 +37,13 @@ describe('TSP User enters and updates Service Agents', function() {
   });
   it('tsp user updates origin and destination service agents', function() {
     tspUserEntersServiceAgent();
-    tspUserVerifiesTspAssigned();
+    userVerifiesTspAssigned();
     userClearsServiceAgent('Origin');
     userInputsServiceAgent('OriginUpdate');
     userClearsServiceAgent('Destination');
     userInputsServiceAgent('DestinationUpdate');
     userSavesServiceAgent('OriginUpdate');
-    tspUserVerifiesTspAssigned();
+    userVerifiesTspAssigned();
   });
   it('tsp user accepts a shipment', function() {
     tspUserAcceptsShipment();
@@ -104,30 +105,6 @@ function tspUserEntersServiceAgent() {
     .contains('TSP & Servicing Agents')
     .siblings()
     .click();
-}
-
-function tspUserVerifiesTspAssigned() {
-  const tspFields = cy
-    .get('.editable-panel-3-column')
-    .contains('TSP')
-    .parent()
-    .within(() => {
-      cy
-        .get('.panel-field')
-        .contains('Name')
-        .parent()
-        .should('contain', 'Truss Transport LLC (J12K)');
-      cy
-        .get('.panel-field')
-        .contains('Email')
-        .parent()
-        .should('contain', 'joey.j@example.com');
-      cy
-        .get('.panel-field')
-        .contains('Phone number')
-        .parent()
-        .should('contain', '(555) 101-0101');
-    });
 }
 
 function tspUserAcceptsShipment() {

--- a/cypress/integration/tsp/serviceAgents.js
+++ b/cypress/integration/tsp/serviceAgents.js
@@ -36,11 +36,13 @@ describe('TSP User enters and updates Service Agents', function() {
   });
   it('tsp user updates origin and destination service agents', function() {
     tspUserEntersServiceAgent();
+    tspUserVerifiesTspAssigned();
     userClearsServiceAgent('Origin');
     userInputsServiceAgent('OriginUpdate');
     userClearsServiceAgent('Destination');
     userInputsServiceAgent('DestinationUpdate');
     userSavesServiceAgent('OriginUpdate');
+    tspUserVerifiesTspAssigned();
   });
   it('tsp user accepts a shipment', function() {
     tspUserAcceptsShipment();
@@ -102,6 +104,30 @@ function tspUserEntersServiceAgent() {
     .contains('TSP & Servicing Agents')
     .siblings()
     .click();
+}
+
+function tspUserVerifiesTspAssigned() {
+  const tspFields = cy
+    .get('.editable-panel-3-column')
+    .contains('TSP')
+    .parent()
+    .within(() => {
+      cy
+        .get('.panel-field')
+        .contains('Name')
+        .parent()
+        .should('contain', 'Truss Transport LLC (J12K)');
+      cy
+        .get('.panel-field')
+        .contains('Email')
+        .parent()
+        .should('contain', 'joey.j@example.com');
+      cy
+        .get('.panel-field')
+        .contains('Phone number')
+        .parent()
+        .should('contain', '(555) 101-0101');
+    });
 }
 
 function tspUserAcceptsShipment() {

--- a/cypress/support/testTspServiceAgents.js
+++ b/cypress/support/testTspServiceAgents.js
@@ -29,6 +29,29 @@ export function getFixture(role) {
   }[role];
 }
 
+export function userVerifiesTspAssigned() {
+  const tspFields = cy
+    .get('.editable-panel-3-column')
+    .contains('TSP')
+    .parent()
+    .within(() => {
+      cy
+        .get('.panel-field')
+        .contains('Name')
+        .parent()
+        .should('contain', 'Truss Transport LLC (J12K)');
+      cy
+        .get('.panel-field')
+        .contains('Email')
+        .parent()
+        .should('contain', 'joey.j@example.com');
+      cy
+        .get('.panel-field')
+        .contains('Phone number')
+        .parent()
+        .should('contain', '(555) 101-0101');
+    });
+}
 export function userInputsServiceAgent(role) {
   const fixture = getFixture(role);
 

--- a/pkg/handlers/publicapi/api.go
+++ b/pkg/handlers/publicapi/api.go
@@ -60,6 +60,7 @@ func NewPublicAPIHandler(context handlers.HandlerContext) http.Handler {
 	publicAPI.ServiceAgentsPatchServiceAgentHandler = PatchServiceAgentHandler{context}
 
 	// TSPs
+	publicAPI.TransportationServiceProviderGetTransportationServiceProviderHandler = GetTransportationServiceProviderHandler{context}
 	publicAPI.TspsIndexTSPsHandler = TspsIndexTSPsHandler{context}
 	publicAPI.TspsGetTspShipmentsHandler = TspsGetTspShipmentsHandler{context}
 

--- a/pkg/handlers/publicapi/shipments.go
+++ b/pkg/handlers/publicapi/shipments.go
@@ -36,10 +36,9 @@ func payloadForShipmentModel(s models.Shipment) *apimessages.Shipment {
 		UpdatedAt:        strfmt.DateTime(s.UpdatedAt),
 
 		// associations
-		TrafficDistributionList:         payloadForTrafficDistributionListModel(s.TrafficDistributionList),
-		ServiceMember:                   payloadForServiceMemberModel(&s.ServiceMember),
-		Move:                            payloadForMoveModel(&s.Move),
-		TransportationServiceProviderID: *handlers.FmtUUID(s.CurrentTransportationServiceProviderID()),
+		TrafficDistributionList: payloadForTrafficDistributionListModel(s.TrafficDistributionList),
+		ServiceMember:           payloadForServiceMemberModel(&s.ServiceMember),
+		Move:                    payloadForMoveModel(&s.Move),
 
 		// dates
 		ActualPickupDate:     handlers.FmtDatePtr(s.ActualPickupDate),
@@ -82,6 +81,10 @@ func payloadForShipmentModel(s models.Shipment) *apimessages.Shipment {
 		PmSurveySpouseProgearWeightEstimate: handlers.FmtPoundPtr(s.PmSurveySpouseProgearWeightEstimate),
 		PmSurveyNotes:                       s.PmSurveyNotes,
 		PmSurveyMethod:                      s.PmSurveyMethod,
+	}
+	tspID := s.CurrentTransportationServiceProviderID()
+	if tspID != uuid.Nil {
+		shipmentpayload.TransportationServiceProviderID = *handlers.FmtUUID(tspID)
 	}
 	return shipmentpayload
 }

--- a/pkg/handlers/publicapi/shipments.go
+++ b/pkg/handlers/publicapi/shipments.go
@@ -25,6 +25,7 @@ import (
 )
 
 func payloadForShipmentModel(s models.Shipment) *apimessages.Shipment {
+	tspID, _ := s.CurrentTransportationServiceProviderID()
 	shipmentpayload := &apimessages.Shipment{
 		ID:               *handlers.FmtUUID(s.ID),
 		Status:           apimessages.ShipmentStatus(s.Status),
@@ -36,9 +37,10 @@ func payloadForShipmentModel(s models.Shipment) *apimessages.Shipment {
 		UpdatedAt:        strfmt.DateTime(s.UpdatedAt),
 
 		// associations
-		TrafficDistributionList: payloadForTrafficDistributionListModel(s.TrafficDistributionList),
-		ServiceMember:           payloadForServiceMemberModel(&s.ServiceMember),
-		Move:                    payloadForMoveModel(&s.Move),
+		TrafficDistributionList:         payloadForTrafficDistributionListModel(s.TrafficDistributionList),
+		ServiceMember:                   payloadForServiceMemberModel(&s.ServiceMember),
+		Move:                            payloadForMoveModel(&s.Move),
+		TransportationServiceProviderID: *handlers.FmtUUID(tspID),
 
 		// dates
 		ActualPickupDate:     handlers.FmtDatePtr(s.ActualPickupDate),

--- a/pkg/handlers/publicapi/shipments.go
+++ b/pkg/handlers/publicapi/shipments.go
@@ -25,7 +25,6 @@ import (
 )
 
 func payloadForShipmentModel(s models.Shipment) *apimessages.Shipment {
-	tspID, _ := s.CurrentTransportationServiceProviderID()
 	shipmentpayload := &apimessages.Shipment{
 		ID:               *handlers.FmtUUID(s.ID),
 		Status:           apimessages.ShipmentStatus(s.Status),
@@ -40,7 +39,7 @@ func payloadForShipmentModel(s models.Shipment) *apimessages.Shipment {
 		TrafficDistributionList:         payloadForTrafficDistributionListModel(s.TrafficDistributionList),
 		ServiceMember:                   payloadForServiceMemberModel(&s.ServiceMember),
 		Move:                            payloadForMoveModel(&s.Move),
-		TransportationServiceProviderID: *handlers.FmtUUID(tspID),
+		TransportationServiceProviderID: *handlers.FmtUUID(s.CurrentTransportationServiceProviderID()),
 
 		// dates
 		ActualPickupDate:     handlers.FmtDatePtr(s.ActualPickupDate),

--- a/pkg/handlers/publicapi/shipments_test.go
+++ b/pkg/handlers/publicapi/shipments_test.go
@@ -35,7 +35,8 @@ func (suite *HandlerSuite) TestPayloadForShipmentModelWhenTspIDIsPresent() {
 			ShipmentID:                      shipment.ID,
 		},
 	})
-	reloadShipment, _ := models.FetchShipmentByTSP(suite.TestDB(), tsp.ID, shipment.ID)
+	reloadShipment, err := models.FetchShipmentByTSP(suite.TestDB(), tsp.ID, shipment.ID)
+	suite.Nil(err)
 
 	shipmentPayload := payloadForShipmentModel(*reloadShipment)
 	expectedTspID := *handlers.FmtUUID(tsp.ID)

--- a/pkg/handlers/publicapi/transportation_service_provider.go
+++ b/pkg/handlers/publicapi/transportation_service_provider.go
@@ -67,10 +67,11 @@ func (h GetTransportationServiceProviderHandler) Handle(params tspop.GetTranspor
 		return tspop.NewGetTransportationServiceProviderForbidden()
 	}
 
-	// Assume that the last shipmentOffer contains the current TSP
-	// This might be a bad assumption, but TSPs can't currently reject offers
-	lastItemIndex := len(shipment.ShipmentOffers) - 1
-	transportationServiceProviderID := shipment.ShipmentOffers[lastItemIndex].TransportationServiceProviderID
+	transportationServiceProviderID, err := shipment.CurrentTransportationServiceProviderID()
+	if err != nil {
+		return handlers.ResponseForError(h.Logger(), err)
+	}
+
 	transportationServiceProvider, err := models.FetchTransportationServiceProvider(h.DB(), transportationServiceProviderID)
 	if err != nil {
 		return handlers.ResponseForError(h.Logger(), err)

--- a/pkg/handlers/publicapi/transportation_service_provider.go
+++ b/pkg/handlers/publicapi/transportation_service_provider.go
@@ -67,8 +67,8 @@ func (h GetTransportationServiceProviderHandler) Handle(params tspop.GetTranspor
 		return tspop.NewGetTransportationServiceProviderForbidden()
 	}
 
-	transportationServiceProviderID, err := shipment.CurrentTransportationServiceProviderID()
-	if err != nil {
+	transportationServiceProviderID := shipment.CurrentTransportationServiceProviderID()
+	if &transportationServiceProviderID == nil {
 		return handlers.ResponseForError(h.Logger(), err)
 	}
 

--- a/pkg/handlers/publicapi/transportation_service_provider.go
+++ b/pkg/handlers/publicapi/transportation_service_provider.go
@@ -1,0 +1,42 @@
+package publicapi
+
+import (
+	"github.com/go-openapi/runtime/middleware"
+	"github.com/go-openapi/strfmt"
+	// "github.com/gofrs/uuid"
+	// "go.uber.org/zap"
+
+	// "github.com/transcom/mymove/pkg/auth"
+	"github.com/transcom/mymove/pkg/gen/apimessages"
+	transportationserviceproviderop "github.com/transcom/mymove/pkg/gen/restapi/apioperations/transportation_service_provider"
+	"github.com/transcom/mymove/pkg/handlers"
+	"github.com/transcom/mymove/pkg/models"
+)
+
+func payloadForTransportationServieAgentModel(t models.TransportationServiceProvider) *apimessages.TransportationServiceProvider {
+	transporationServiceProviderPayload := &apimessages.TransportationServiceProvider{
+		ID:                       *handlers.FmtUUID(t.ID),
+		StandardCarrierAlphaCode: handlers.FmtString(t.StandardCarrierAlphaCode),
+		CreatedAt:                strfmt.DateTime(t.CreatedAt),
+		UpdatedAt:                strfmt.DateTime(t.UpdatedAt),
+		Enrolled:                 t.Enrolled,
+		Name:                     t.Name,
+		PocGeneralName:           t.PocGeneralName,
+		PocGeneralEmail:          t.PocGeneralEmail,
+		PocGeneralPhone:          t.PocGeneralPhone,
+		PocClaimsName:            t.PocClaimsName,
+		PocClaimsEmail:           t.PocClaimsEmail,
+		PocClaimsPhone:           t.PocClaimsPhone,
+	}
+	return transporationServiceProviderPayload
+}
+
+// ShipmentGetTSPHandler returns a TSP for a shipment
+type ShipmentGetTSPHandler struct {
+	handlers.HandlerContext
+}
+
+// Handle getting the tsp for a shipment
+func (h ShipmentGetTSPHandler) Handle(params transportationserviceproviderop.GetTransportationServiceProviderParams) middleware.Responder {
+	return middleware.NotImplemented("operation .getTSP has not yet been implemented")
+}

--- a/pkg/handlers/publicapi/transportation_service_provider.go
+++ b/pkg/handlers/publicapi/transportation_service_provider.go
@@ -13,7 +13,7 @@ import (
 	"github.com/transcom/mymove/pkg/models"
 )
 
-func payloadForTransportationServieProviderModel(t models.TransportationServiceProvider) *apimessages.TransportationServiceProvider {
+func payloadForTransportationServiceProviderModel(t models.TransportationServiceProvider) *apimessages.TransportationServiceProvider {
 	transporationServiceProviderPayload := &apimessages.TransportationServiceProvider{
 		ID:                       *handlers.FmtUUID(t.ID),
 		StandardCarrierAlphaCode: handlers.FmtString(t.StandardCarrierAlphaCode),
@@ -53,13 +53,13 @@ func (h GetTransportationServiceProviderHandler) Handle(params tspop.GetTranspor
 
 		shipment, err = models.FetchShipmentByTSP(h.DB(), tspUser.TransportationServiceProviderID, shipmentID)
 		if err != nil {
-			h.Logger().Error("DB Query", zap.Error(err))
+			handlers.ResponseForError(h.Logger(), err)
 			return tspop.NewGetTransportationServiceProviderBadRequest()
 		}
 	} else if session.IsOfficeUser() {
 		shipment, err = models.FetchShipment(h.DB(), session, shipmentID)
 		if err != nil {
-			h.Logger().Error("DB Query", zap.Error(err))
+			handlers.ResponseForError(h.Logger(), err)
 			return tspop.NewGetTransportationServiceProviderBadRequest()
 		}
 
@@ -77,6 +77,6 @@ func (h GetTransportationServiceProviderHandler) Handle(params tspop.GetTranspor
 		return handlers.ResponseForError(h.Logger(), err)
 	}
 
-	transportationServiceProviderPayload := payloadForTransportationServieProviderModel(*transportationServiceProvider)
+	transportationServiceProviderPayload := payloadForTransportationServiceProviderModel(*transportationServiceProvider)
 	return tspop.NewGetTransportationServiceProviderOK().WithPayload(transportationServiceProviderPayload)
 }

--- a/pkg/handlers/publicapi/transportation_service_provider_test.go
+++ b/pkg/handlers/publicapi/transportation_service_provider_test.go
@@ -1,0 +1,46 @@
+package publicapi
+
+import (
+	"fmt"
+	"net/http/httptest"
+
+	"github.com/go-openapi/strfmt"
+
+	tspop "github.com/transcom/mymove/pkg/gen/restapi/apioperations/transportation_service_provider"
+	"github.com/transcom/mymove/pkg/handlers"
+	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/testdatagen"
+)
+
+func (suite *HandlerSuite) TestGetTransportationServiceProviderHandler() {
+	numTspUsers := 1
+	numShipments := 1
+	numShipmentOfferSplit := []int{1}
+	status := []models.ShipmentStatus{models.ShipmentStatusSUBMITTED}
+	tspUsers, shipments, _, err := testdatagen.CreateShipmentOfferData(suite.TestDB(), numTspUsers, numShipments, numShipmentOfferSplit, status)
+	suite.NoError(err)
+
+	tspUser := tspUsers[0]
+	shipment := shipments[0]
+	path := fmt.Sprintf("/shipments/%s/transportation_service_provider", shipment.ID.String())
+
+	// And: the context contains the auth values
+	req := httptest.NewRequest("GET", path, nil)
+	req = suite.AuthenticateTspRequest(req, tspUser)
+
+	params := tspop.GetTransportationServiceProviderParams{
+		HTTPRequest: req,
+		ShipmentID:  strfmt.UUID(shipment.ID.String()),
+	}
+
+	// And: get shipment is returned
+	handler := GetTransportationServiceProviderHandler{handlers.NewHandlerContext(suite.TestDB(), suite.TestLogger())}
+	response := handler.Handle(params)
+
+	// Then: expect a 200 status code
+	suite.Assertions.IsType(&tspop.GetTransportationServiceProviderOK{}, response)
+	okResponse := response.(*tspop.GetTransportationServiceProviderOK)
+
+	// And: Payload is equivalent to original shipment
+	suite.Equal(strfmt.UUID(tspUser.TransportationServiceProviderID.String()), okResponse.Payload.ID)
+}

--- a/pkg/models/shipment.go
+++ b/pkg/models/shipment.go
@@ -124,6 +124,22 @@ func (s *Shipment) Validate(tx *pop.Connection) (*validate.Errors, error) {
 	), nil
 }
 
+// CurrentTransportationServiceProviderID returns the id for the current TSP for a shipment
+// Assume that the last shipmentOffer contains the current TSP
+// This might be a bad assumption, but TSPs can't currently reject offers
+func (s *Shipment) CurrentTransportationServiceProviderID() (uuid.UUID, error) {
+	var id uuid.UUID
+	var err error
+	shipmentOffersLen := len(s.ShipmentOffers)
+	if shipmentOffersLen > 0 {
+		lastItemIndex := shipmentOffersLen - 1
+		id = s.ShipmentOffers[lastItemIndex].TransportationServiceProviderID
+	} else {
+		err = ErrFetchNotFound
+	}
+	return id, err
+}
+
 // State Machinery
 // Avoid calling Shipment.Status = ... ever. Use these methods to change the state.
 

--- a/pkg/models/shipment.go
+++ b/pkg/models/shipment.go
@@ -127,17 +127,14 @@ func (s *Shipment) Validate(tx *pop.Connection) (*validate.Errors, error) {
 // CurrentTransportationServiceProviderID returns the id for the current TSP for a shipment
 // Assume that the last shipmentOffer contains the current TSP
 // This might be a bad assumption, but TSPs can't currently reject offers
-func (s *Shipment) CurrentTransportationServiceProviderID() (uuid.UUID, error) {
+func (s *Shipment) CurrentTransportationServiceProviderID() uuid.UUID {
 	var id uuid.UUID
-	var err error
 	shipmentOffersLen := len(s.ShipmentOffers)
 	if shipmentOffersLen > 0 {
 		lastItemIndex := shipmentOffersLen - 1
 		id = s.ShipmentOffers[lastItemIndex].TransportationServiceProviderID
-	} else {
-		err = ErrFetchNotFound
 	}
-	return id, err
+	return id
 }
 
 // State Machinery

--- a/pkg/models/shipment_test.go
+++ b/pkg/models/shipment_test.go
@@ -191,7 +191,7 @@ func (suite *ModelSuite) TestCurrentTransportationServiceProviderID() {
 	// CurrentTransportationServiceProviderID looks at the shipment offers on a shipment
 	// Since it doesn't re-fetch the shipment, if the offers have changed
 	// We need to re-fetch the shipment to reload the offers
-	reloadShipment, err := models.FetchShipmentByTSP(suite.TestDB(), tsp.ID, shipment.ID)
+	reloadShipment, err := FetchShipmentByTSP(suite.db, tsp.ID, shipment.ID)
 	suite.Nil(err)
 	suite.Equal(tsp.ID, reloadShipment.CurrentTransportationServiceProviderID(), "expected ids to be equal")
 }

--- a/pkg/models/shipment_test.go
+++ b/pkg/models/shipment_test.go
@@ -3,6 +3,7 @@ package models_test
 import (
 	"time"
 
+	"github.com/gofrs/uuid"
 	. "github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"
 	"github.com/transcom/mymove/pkg/unit"
@@ -170,6 +171,28 @@ func (suite *ModelSuite) TestAcceptShipmentForTSP() {
 	suite.Equal(ShipmentStatusACCEPTED, newShipment.Status, "expected Accepted")
 	suite.True(*newShipmentOffer.Accepted)
 	suite.Nil(newShipmentOffer.RejectionReason)
+}
+
+// TestCurrentTransportationServiceProviderID tests that a shipment returns the proper current tsp id
+func (suite *ModelSuite) TestCurrentTransportationServiceProviderID() {
+	tsp := testdatagen.MakeTSP(suite.db, testdatagen.Assertions{})
+	shipment := testdatagen.MakeDefaultShipment(suite.db)
+	var emptyUUID uuid.UUID
+
+	suite.Equal(shipment.CurrentTransportationServiceProviderID(), emptyUUID)
+
+	testdatagen.MakeShipmentOffer(suite.db, testdatagen.Assertions{
+		ShipmentOffer: ShipmentOffer{
+			TransportationServiceProviderID: tsp.ID,
+			ShipmentID:                      shipment.ID,
+		},
+	})
+
+	// CurrentTransportationServiceProviderID looks at the shipment offers on a shipment
+	// Since it doesn't re-fetch the shipment, if the offers have changed
+	// We need to re-fetch the shipment to reload the offers
+	reloadShipment, _ := FetchShipmentByTSP(suite.db, tsp.ID, shipment.ID)
+	suite.Equal(tsp.ID, reloadShipment.CurrentTransportationServiceProviderID(), "expected ids to be equal")
 }
 
 // TestShipmentAssignGBLNumber tests that a GBL number is created correctly

--- a/pkg/models/shipment_test.go
+++ b/pkg/models/shipment_test.go
@@ -191,7 +191,8 @@ func (suite *ModelSuite) TestCurrentTransportationServiceProviderID() {
 	// CurrentTransportationServiceProviderID looks at the shipment offers on a shipment
 	// Since it doesn't re-fetch the shipment, if the offers have changed
 	// We need to re-fetch the shipment to reload the offers
-	reloadShipment, _ := FetchShipmentByTSP(suite.db, tsp.ID, shipment.ID)
+	reloadShipment, err := models.FetchShipmentByTSP(suite.TestDB(), tsp.ID, shipment.ID)
+	suite.Nil(err)
 	suite.Equal(tsp.ID, reloadShipment.CurrentTransportationServiceProviderID(), "expected ids to be equal")
 }
 

--- a/pkg/models/transportation_service_provider.go
+++ b/pkg/models/transportation_service_provider.go
@@ -1,13 +1,13 @@
 package models
 
 import (
-	"time"
-
 	"github.com/gobuffalo/pop"
 	"github.com/gobuffalo/validate"
 	"github.com/gobuffalo/validate/validators"
 	"github.com/gofrs/uuid"
+	"github.com/pkg/errors"
 	"go.uber.org/zap/zapcore"
+	"time"
 )
 
 // TransportationServiceProvider models moving companies used to move
@@ -58,4 +58,20 @@ func (t *TransportationServiceProvider) Validate(tx *pop.Connection) (*validate.
 func (t TransportationServiceProvider) MarshalLogObject(encoder zapcore.ObjectEncoder) error {
 	encoder.AddString("id", t.ID.String())
 	return nil
+}
+
+// FetchTransportationServiceProvider Fetches a TSP model
+func FetchTransportationServiceProvider(db *pop.Connection, id uuid.UUID) (*TransportationServiceProvider, error) {
+	var transportationServiceProvider TransportationServiceProvider
+	err := db.Find(&transportationServiceProvider, id)
+
+	if err != nil {
+		if errors.Cause(err).Error() == recordNotFoundErrorString {
+			return nil, ErrFetchNotFound
+		}
+		// Otherwise, it's an unexpected err so we return that.
+		return nil, err
+	}
+
+	return &transportationServiceProvider, nil
 }

--- a/pkg/testdatagen/make_tsp_user.go
+++ b/pkg/testdatagen/make_tsp_user.go
@@ -22,7 +22,15 @@ func MakeTspUser(db *pop.Connection, assertions Assertions) models.TspUser {
 		email = assertions.User.LoginGovEmail
 	}
 
-	tsp := MakeDefaultTSP(db)
+	var tsp models.TransportationServiceProvider
+	var tspAssertions = assertions.TransportationServiceProvider
+	if &tspAssertions == nil {
+		tsp = MakeDefaultTSP(db)
+	} else {
+		tsp = MakeTSP(db, Assertions{
+			TransportationServiceProvider: tspAssertions,
+		})
+	}
 
 	tspUser := models.TspUser{
 		UserID:                          &user.ID,

--- a/pkg/testdatagen/scenario/e2ebasic.go
+++ b/pkg/testdatagen/scenario/e2ebasic.go
@@ -63,6 +63,9 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, log
 			ID:    uuid.FromStringOrNil("1fb58b82-ab60-4f55-a654-0267200473a4"),
 			Email: email,
 		},
+		TransportationServiceProvider: models.TransportationServiceProvider{
+			StandardCarrierAlphaCode: "J12K",
+		},
 	})
 
 	/*

--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -42,6 +42,7 @@ import {
 } from 'shared/Entities/modules/shipmentLineItems';
 import { getAllInvoices, getShipmentInvoicesLabel } from 'shared/Entities/modules/invoices';
 import { getPublicShipment, updatePublicShipment } from 'shared/Entities/modules/shipments';
+import { getTspForShipmentLabel, getTspForShipment } from 'shared/Entities/modules/transportationServiceProviders';
 
 import {
   loadMoveDependencies,
@@ -142,10 +143,12 @@ class MoveInfo extends Component {
 
   componentDidUpdate(prevProps) {
     if (get(this.props, 'officeShipment.id') !== get(prevProps, 'officeShipment.id')) {
-      this.props.getPublicShipment('Shipments.getPublicShipment', this.props.officeShipment.id);
-      this.props.getAllShipmentLineItems(getShipmentLineItemsLabel, this.props.officeShipment.id);
-      this.props.getAllInvoices(getShipmentInvoicesLabel, this.props.officeShipment.id);
-      this.props.loadShipmentDependencies(this.props.officeShipment.id);
+      const shipmentId = this.props.officeShipment.id;
+      this.props.getTspForShipment(getTspForShipmentLabel, shipmentId);
+      this.props.getPublicShipment('Shipments.getPublicShipment', shipmentId);
+      this.props.getAllShipmentLineItems(getShipmentLineItemsLabel, shipmentId);
+      this.props.getAllInvoices(getShipmentInvoicesLabel, shipmentId);
+      this.props.loadShipmentDependencies(shipmentId);
     }
   }
 
@@ -496,6 +499,7 @@ const mapDispatchToProps = dispatch =>
       getAllShipmentLineItems,
       getAllInvoices,
       resetMove,
+      getTspForShipment,
     },
     dispatch,
   );

--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -115,6 +115,7 @@ const HHGTabContent = props => {
         title="TSP & Servicing Agents"
         shipment={props.officeShipment}
         serviceAgents={props.serviceAgents}
+        transportationServiceProviderId={props.shipment.transportation_service_provider_id}
       />
       {has(props, 'officeShipment.id') && <PreApprovalPanel shipmentId={props.officeShipment.id} />}
       {has(props, 'officeShipment.id') && (

--- a/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
+++ b/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
@@ -32,6 +32,7 @@ import {
   getShipmentLineItemsLabel,
 } from 'shared/Entities/modules/shipmentLineItems';
 import { getAllInvoices, getShipmentInvoicesLabel } from 'shared/Entities/modules/invoices';
+import { getTspForShipmentLabel, getTspForShipment } from 'shared/Entities/modules/transportationServiceProviders';
 
 import FontAwesomeIcon from '@fortawesome/react-fontawesome';
 import faPhone from '@fortawesome/fontawesome-free-solid/faPhone';
@@ -146,10 +147,12 @@ class ShipmentInfo extends Component {
 
   componentDidUpdate(prevProps, prevState) {
     if ((!prevProps.shipment.id && this.props.shipment.id) || prevProps.shipment.id !== this.props.shipment.id) {
-      this.props.getAllShipmentDocuments(getShipmentDocumentsLabel, this.props.shipment.id);
+      const shipmentId = this.props.shipment.id;
+      this.props.getTspForShipment(getTspForShipmentLabel, shipmentId);
+      this.props.getAllShipmentDocuments(getShipmentDocumentsLabel, shipmentId);
       this.props.getAllTariff400ngItems(true, getTariff400ngItemsLabel);
-      this.props.getAllShipmentLineItems(getShipmentLineItemsLabel, this.props.shipment.id);
-      this.props.getAllInvoices(getShipmentInvoicesLabel, this.props.shipment.id);
+      this.props.getAllShipmentLineItems(getShipmentLineItemsLabel, shipmentId);
+      this.props.getAllInvoices(getShipmentInvoicesLabel, shipmentId);
     }
   }
 
@@ -507,6 +510,7 @@ const mapDispatchToProps = dispatch =>
       getAllTariff400ngItems,
       getAllShipmentLineItems,
       getAllInvoices,
+      getTspForShipment,
     },
     dispatch,
   );

--- a/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
+++ b/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
@@ -426,6 +426,7 @@ class ShipmentInfo extends Component {
                     title="TSP & Servicing Agents"
                     shipment={this.props.shipment}
                     serviceAgents={this.props.serviceAgents}
+                    transportationServiceProviderId={this.props.shipment.transportation_service_provider_id}
                   />
                 </div>
               )}

--- a/src/shared/Entities/modules/transportationServiceProviders.js
+++ b/src/shared/Entities/modules/transportationServiceProviders.js
@@ -1,0 +1,13 @@
+import { swaggerRequest } from 'shared/Swagger/request';
+import { getPublicClient } from 'shared/Swagger/api';
+
+export const getTspForShipmentLabel = 'Shipments.getTspForShipment';
+
+export function getTspForShipment(label, shipmentId) {
+  return swaggerRequest(
+    getPublicClient,
+    'transportation_service_provider.getTransportationServiceProvider',
+    { shipmentId },
+    { label },
+  );
+}

--- a/src/shared/Entities/modules/transportationServiceProviders.js
+++ b/src/shared/Entities/modules/transportationServiceProviders.js
@@ -11,3 +11,10 @@ export function getTspForShipment(label, shipmentId) {
     { label },
   );
 }
+
+// Selectors
+
+export function selectTspForShipment(state, shipmentId) {
+  const tsp = Object.values(state.entities.transportationServiceProviders).find(tsp => tsp.shipment_id === shipmentId);
+  return tsp || {};
+}

--- a/src/shared/Entities/modules/transportationServiceProviders.js
+++ b/src/shared/Entities/modules/transportationServiceProviders.js
@@ -14,7 +14,4 @@ export function getTspForShipment(label, shipmentId) {
 
 // Selectors
 
-export function selectTspForShipment(state, shipmentId) {
-  const tsp = Object.values(state.entities.transportationServiceProviders).find(tsp => tsp.shipment_id === shipmentId);
-  return tsp || {};
-}
+export const selectTspById = (state, tspId) => state.entities.transportationServiceProviders[tspId] || {}; // eslint-disable-line security/detect-object-injection

--- a/src/shared/Entities/reducer.js
+++ b/src/shared/Entities/reducer.js
@@ -34,6 +34,7 @@ const initialState = {
   tariff400ngItems: {},
   shipmentLineItems: {},
   invoices: {},
+  transportationServiceProviders: {},
 };
 
 // Actions of either of these types will be merged into the store:

--- a/src/shared/Entities/schema.js
+++ b/src/shared/Entities/schema.js
@@ -91,3 +91,6 @@ export const availableMoveDates = new schema.Entity('availableMoveDates', {}, { 
 
 // MoveDatesSummary
 export const moveDatesSummary = new schema.Entity('moveDatesSummaries');
+
+// TransportationServiceProviders
+export const transportationServiceProvider = new schema.Entity('transportationServiceProviders');

--- a/src/shared/TspPanel/ServiceAgentViews.jsx
+++ b/src/shared/TspPanel/ServiceAgentViews.jsx
@@ -1,13 +1,13 @@
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 
-import { PanelSwaggerField } from 'shared/EditablePanel';
+import { PanelSwaggerField, PanelField } from 'shared/EditablePanel';
 import { SwaggerField } from 'shared/JsonSchemaForm/JsonSchemaField';
 
 export const ServiceAgentDisplay = ({ serviceAgentProps, saRole }) => {
   return (
-    <div className="editable-panel-column">
-      <span className="column-subhead">{saRole}</span>
+    <div className="editable-panel-3-column">
+      <span className="column-subhead">{saRole} agent</span>
       <PanelSwaggerField fieldName="company" {...serviceAgentProps} />
       <PanelSwaggerField fieldName="email" {...serviceAgentProps} />
       <PanelSwaggerField fieldName="phone_number" {...serviceAgentProps} />
@@ -26,8 +26,8 @@ ServiceAgentDisplay.propTypes = {
 export const ServiceAgentEdit = ({ serviceAgentProps, saRole }) => {
   return (
     <Fragment>
-      <div className="editable-panel-column">
-        <span className="column-subhead">{saRole}</span>
+      <div className="editable-panel-3-column">
+        <span className="column-subhead">{saRole} agent</span>
         <SwaggerField fieldName="company" required {...serviceAgentProps} />
         <SwaggerField fieldName="email" required {...serviceAgentProps} />
         <SwaggerField fieldName="phone_number" required {...serviceAgentProps} />
@@ -36,11 +36,15 @@ export const ServiceAgentEdit = ({ serviceAgentProps, saRole }) => {
   );
 };
 
-export const TransportationServiceProviderDisplay = ({ tspProps }) => (
-  <div className="editable-panel-column">
-    <span className="column-subhead">Transportation Service Provider</span>
-    <PanelSwaggerField fieldName="name" {...tspProps} />
-    <PanelSwaggerField fieldName="poc_general_email" {...tspProps} />
-    <PanelSwaggerField fieldName="poc_general_phone" {...tspProps} />
-  </div>
-);
+export const TransportationServiceProviderDisplay = ({ tsp }) => {
+  const { name, standard_carrier_alpha_code, poc_general_email, poc_general_phone } = tsp;
+  const nameWithScac = `${name} (${standard_carrier_alpha_code})`;
+  return (
+    <div className="editable-panel-3-column">
+      <span className="column-subhead">TSP</span>
+      <PanelField title="Name" value={nameWithScac} />
+      <PanelField title="Email" value={poc_general_email} />
+      <PanelField title="Phone number" value={poc_general_phone} />
+    </div>
+  );
+};

--- a/src/shared/TspPanel/ServiceAgentViews.jsx
+++ b/src/shared/TspPanel/ServiceAgentViews.jsx
@@ -35,3 +35,12 @@ export const ServiceAgentEdit = ({ serviceAgentProps, saRole }) => {
     </Fragment>
   );
 };
+
+export const TransportationServiceProviderDisplay = ({ tspProps }) => (
+  <div className="editable-panel-column">
+    <span className="column-subhead">Transportation Service Provider</span>
+    <PanelSwaggerField fieldName="name" {...tspProps} />
+    <PanelSwaggerField fieldName="poc_general_email" {...tspProps} />
+    <PanelSwaggerField fieldName="poc_general_phone" {...tspProps} />
+  </div>
+);

--- a/src/shared/TspPanel/ServiceAgentViews.jsx
+++ b/src/shared/TspPanel/ServiceAgentViews.jsx
@@ -38,7 +38,7 @@ export const ServiceAgentEdit = ({ serviceAgentProps, saRole }) => {
 
 export const TransportationServiceProviderDisplay = ({ tsp }) => {
   const { name, standard_carrier_alpha_code, poc_general_email, poc_general_phone } = tsp;
-  const nameWithScac = `${name} (${standard_carrier_alpha_code})`;
+  const nameWithScac = name ? `${name} (${standard_carrier_alpha_code})` : '';
   return (
     <div className="editable-panel-3-column">
       <span className="column-subhead">TSP</span>

--- a/src/shared/TspPanel/TspContainer.jsx
+++ b/src/shared/TspPanel/TspContainer.jsx
@@ -22,7 +22,6 @@ function mapStateToProps(state, props) {
   return {
     // reduxForm
     saSchema: getPublicSwaggerDefinition(state, 'ServiceAgent', null),
-    tspSchema: getPublicSwaggerDefinition(state, 'TransportationServiceProvider', null),
     transportationServiceProvider: selectTspForShipment(state, props.shipment.id),
     formValues,
     initialValues: {

--- a/src/shared/TspPanel/TspContainer.jsx
+++ b/src/shared/TspPanel/TspContainer.jsx
@@ -7,7 +7,7 @@ import TspServiceAgents from './TspServiceAgents';
 import { handleServiceAgents } from 'scenes/TransportationServiceProvider/ducks';
 
 import { getPublicSwaggerDefinition } from 'shared/Swagger/selectors';
-import { selectTspForShipment } from 'shared/Entities/modules/transportationServiceProviders';
+import { selectTspById } from 'shared/Entities/modules/transportationServiceProviders';
 
 function mapStateToProps(state, props) {
   let serviceAgents = props.serviceAgents;
@@ -22,7 +22,7 @@ function mapStateToProps(state, props) {
   return {
     // reduxForm
     saSchema: getPublicSwaggerDefinition(state, 'ServiceAgent', null),
-    transportationServiceProvider: selectTspForShipment(state, props.shipment.id),
+    transportationServiceProvider: selectTspById(state, props.shipment.transportation_service_provider_id),
     formValues,
     initialValues: {
       origin_service_agent,

--- a/src/shared/TspPanel/TspContainer.jsx
+++ b/src/shared/TspPanel/TspContainer.jsx
@@ -7,6 +7,7 @@ import TspServiceAgents from './TspServiceAgents';
 import { handleServiceAgents } from 'scenes/TransportationServiceProvider/ducks';
 
 import { getPublicSwaggerDefinition } from 'shared/Swagger/selectors';
+import { selectTspForShipment } from 'shared/Entities/modules/transportationServiceProviders';
 
 function mapStateToProps(state, props) {
   let serviceAgents = props.serviceAgents;
@@ -21,6 +22,8 @@ function mapStateToProps(state, props) {
   return {
     // reduxForm
     saSchema: getPublicSwaggerDefinition(state, 'ServiceAgent', null),
+    tspSchema: getPublicSwaggerDefinition(state, 'TransportationServiceProvider', null),
+    transportationServiceProvider: selectTspForShipment(state, props.shipment.id),
     formValues,
     initialValues: {
       origin_service_agent,

--- a/src/shared/TspPanel/TspContainer.jsx
+++ b/src/shared/TspPanel/TspContainer.jsx
@@ -22,7 +22,7 @@ function mapStateToProps(state, props) {
   return {
     // reduxForm
     saSchema: getPublicSwaggerDefinition(state, 'ServiceAgent', null),
-    transportationServiceProvider: selectTspById(state, props.shipment.transportation_service_provider_id),
+    transportationServiceProvider: selectTspById(state, props.transportationServiceProviderId),
     formValues,
     initialValues: {
       origin_service_agent,

--- a/src/shared/TspPanel/TspServiceAgents.jsx
+++ b/src/shared/TspPanel/TspServiceAgents.jsx
@@ -160,7 +160,7 @@ ServiceAgentEditablePanel.defaultProps = {
 };
 
 const TSPDisplay = props => {
-  const { saSchema, tspSchema, transportationServiceProvider } = props;
+  const { saSchema, transportationServiceProvider } = props;
   const originSAProps = {
     schema: saSchema,
     values: props.origin_service_agent,
@@ -171,13 +171,9 @@ const TSPDisplay = props => {
     values: props.destination_service_agent,
   };
 
-  const tspProps = {
-    values: transportationServiceProvider,
-    schema: tspSchema,
-  };
   return (
     <Fragment>
-      <TransportationServiceProviderDisplay tspProps={tspProps} />
+      <TransportationServiceProviderDisplay tsp={transportationServiceProvider} />
       <ServiceAgentDisplay serviceAgentProps={originSAProps} saRole="Origin" />
       <ServiceAgentDisplay serviceAgentProps={destinationSAProps} saRole="Destination" />
     </Fragment>
@@ -185,17 +181,13 @@ const TSPDisplay = props => {
 };
 
 const TSPEdit = props => {
-  const { saSchema, tspSchema, transportationServiceProvider } = props;
+  const { saSchema, transportationServiceProvider } = props;
   const originValues = get(props, 'formValues.ORIGIN', {});
   const destinationValues = get(props, 'formValues.DESTINATION', {});
-  const tspProps = {
-    values: transportationServiceProvider,
-    schema: tspSchema,
-  };
   return (
     <Fragment>
       <FormSection name="transportation_service_provider">
-        <TransportationServiceProviderDisplay tspProps={tspProps} />
+        <TransportationServiceProviderDisplay tsp={transportationServiceProvider} />
       </FormSection>
       <FormSection name="origin_service_agent">
         <ServiceAgentEdit

--- a/src/shared/TspPanel/TspServiceAgents.jsx
+++ b/src/shared/TspPanel/TspServiceAgents.jsx
@@ -5,7 +5,7 @@ import { reduxForm, FormSection } from 'redux-form';
 import PropTypes from 'prop-types';
 
 import Alert from 'shared/Alert';
-import { ServiceAgentDisplay, ServiceAgentEdit } from './ServiceAgentViews';
+import { ServiceAgentDisplay, ServiceAgentEdit, TransportationServiceProviderDisplay } from './ServiceAgentViews';
 
 // TODO: Refactor when we switch to using a wizard
 // Editable panel specific to Assign Service Agents. Due to not using a wizard to assign the service agents this
@@ -160,17 +160,24 @@ ServiceAgentEditablePanel.defaultProps = {
 };
 
 const TSPDisplay = props => {
+  const { saSchema, tspSchema, transportationServiceProvider } = props;
   const originSAProps = {
-    schema: props.saSchema,
+    schema: saSchema,
     values: props.origin_service_agent,
   };
 
   const destinationSAProps = {
-    schema: props.saSchema,
+    schema: saSchema,
     values: props.destination_service_agent,
+  };
+
+  const tspProps = {
+    values: transportationServiceProvider,
+    schema: tspSchema,
   };
   return (
     <Fragment>
+      <TransportationServiceProviderDisplay tspProps={tspProps} />
       <ServiceAgentDisplay serviceAgentProps={originSAProps} saRole="Origin" />
       <ServiceAgentDisplay serviceAgentProps={destinationSAProps} saRole="Destination" />
     </Fragment>
@@ -178,12 +185,18 @@ const TSPDisplay = props => {
 };
 
 const TSPEdit = props => {
-  const saSchema = props.saSchema;
+  const { saSchema, tspSchema, transportationServiceProvider } = props;
   const originValues = get(props, 'formValues.ORIGIN', {});
   const destinationValues = get(props, 'formValues.DESTINATION', {});
-
+  const tspProps = {
+    values: transportationServiceProvider,
+    schema: tspSchema,
+  };
   return (
     <Fragment>
+      <FormSection name="transportation_service_provider">
+        <TransportationServiceProviderDisplay tspProps={tspProps} />
+      </FormSection>
       <FormSection name="origin_service_agent">
         <ServiceAgentEdit
           serviceAgentProps={{

--- a/swagger/api.yaml
+++ b/swagger/api.yaml
@@ -1199,6 +1199,7 @@ definitions:
         type: string
         example: 'EXTRA Good TSP'
         x-nullable: true
+        title: Name
       poc_general_name:
         type: string
         example: 'Jon Bon Jovi'

--- a/swagger/api.yaml
+++ b/swagger/api.yaml
@@ -1180,6 +1180,11 @@ definitions:
           IN_PERSON: In person
           PHONE: Phone
           VIDEO: Video
+      transportation_service_provider_id:
+        type: string
+        format: uuid
+        example: c56a4180-65aa-42ec-a945-5fd21dec0538
+        readOnly: true
   TransportationServiceProvider:
     type: object
     properties:

--- a/swagger/api.yaml
+++ b/swagger/api.yaml
@@ -2147,6 +2147,35 @@ paths:
           description: no service agent found with that UUID
         500:
           description: server error
+  /shipments/{shipmentId}/transportation_service_provider:
+    get:
+      summary: Gets transportation service provider for shipment
+      description: Allows a user to retrieve the transportation service provider for a shipment.
+      operationId: getTransportationServiceProvider
+      tags:
+        - transportation_service_provider
+      parameters:
+        - name: shipmentId
+          in: path
+          type: string
+          format: uuid
+          required: true
+          description: UUID of the shipment
+      responses:
+        200:
+          description: returns a Transporation Service Provider
+          schema:
+            $ref: '#/definitions/TransportationServiceProvider'
+        400:
+          description: invalid request
+        401:
+          description: must be authenticated to use this endpoint
+        403:
+          description: not authorized to list these shipments
+        422:
+          description: cannot process request with given information
+        500:
+          description: server error
   /shipment/{shipmentId}/completePmSurvey:
     post:
       summary: Completes a pre-move survey on a shipment

--- a/swagger/api.yaml
+++ b/swagger/api.yaml
@@ -1192,6 +1192,7 @@ definitions:
         type: string
         example: '51980581983'
         x-nullable: true
+        title: SCAC
       enrolled:
         type: boolean
         default: false


### PR DESCRIPTION
## Description

Add the TSP information to the TSP & Service Agents panel

## Reviewer Notes

- I am super new to golang, so any/all help there is much appreciated. Be brutal.
- We need a way to search for related items in the entities reducer. Rather than have the API return the id of the related record (ie return the shipment_id with a tsp record), I think we can add this to the reducer on the front end. To that end, I made a change to the `swaggerRequest` function. Happy to discuss different/better ways to tackle this.
- Unit testing the new handler is still in process (thus the WIP)

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/162279364) for this change

## Screenshots

<img width="1217" alt="screen shot 2018-12-17 at 4 10 52 pm" src="https://user-images.githubusercontent.com/4434681/50123747-cf2ed600-0216-11e9-9311-c112dc65fa7b.png">
<img width="1213" alt="screen shot 2018-12-17 at 4 10 46 pm" src="https://user-images.githubusercontent.com/4434681/50123749-cfc76c80-0216-11e9-80ab-41ac069ad9a3.png">

