### PR TITLE
Adds Cypress test that office user sees unbilled line items when they exist

### DIFF
--- a/cypress/integration/office/invoicing.js
+++ b/cypress/integration/office/invoicing.js
@@ -1,19 +1,50 @@
 describe(
   'As an office user, I want to keep track of HHG shipment costs before they are billed, ' +
-    'so if there are no pre-approved, unbilled charges, I should see none',
+    'so if there are pre-approved, unbilled charges, I should see them.',
   () => {
     beforeEach(() => {
       cy.signIntoOffice();
     });
-    it('opens the shipment tab', () => {
-      cy.visit('/queues/new/moves/6eee3663-1973-40c5-b49e-e70e9325b895/hhg');
 
-      // The invoice table should be empty.
-      cy
-        .get('.invoice-panel .basic-panel-content')
-        .children()
-        .first()
-        .should('have.text', 'No line items');
-    });
+    it('there are no unbilled line items', checkNoUnbilledLineItems);
+
+    it('there are unbilled line items', checkExistUnbilledLineItems);
   },
 );
+
+function checkNoUnbilledLineItems() {
+  // Open the shipments tab.
+  cy.visit('/queues/new/moves/6eee3663-1973-40c5-b49e-e70e9325b895/hhg');
+
+  // The invoice table should be empty.
+  cy
+    .get('.invoice-panel .basic-panel-content')
+    .children()
+    .first()
+    .should('have.text', 'No line items');
+}
+
+function checkExistUnbilledLineItems() {
+  // Open the shipments tab.
+  cy.visit('/queues/new/moves/fb4105cf-f5a5-43be-845e-d59fdb34f31c/hhg');
+
+  // The invoice table should display unbilled line items.
+  cy
+    .get('.invoice-panel .basic-panel-content tbody')
+    .children()
+    // For each line item, I should see item code, description, etc.
+    .each((row, index, lst) => {
+      // Last line is the Totals line.
+      if (index === lst.length - 1) {
+        return;
+      }
+
+      cy
+        .wrap(row)
+        .children()
+        .each(cell => {
+          // Each cell should have a value present.
+          cy.wrap(cell).should('not.have.text', '');
+        });
+    });
+}


### PR DESCRIPTION
## Description

A Cypress test for this scenario:

*Context*
Given I am an authenticated office worker
And there is an HHG shipment in a move

*Scenario 1*: Office worker sees unbilled line items for an HHG shipment
And there are unbilled line items for that shipment
When I look at the HHG Tab on the "Move Info" page
Then I should see each unbilled line item listed in the invoice panel
And for each line item, I should see
1. Item code
2. Item description
3. Location (origin or destination or neither)
4. Base quantity (this can be empty)
5. Amount

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](./docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](./docs/backend.md#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](./docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
* [ ] There are no aXe warnings for UI.
* [ ] This works in IE.
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @willowbl00
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/162642911) for this change
