### PR TITLE
Add test that TSP sees unbilled line items when they exist.

### DIFF
--- a/cypress/integration/tsp/invoicing.js
+++ b/cypress/integration/tsp/invoicing.js
@@ -1,0 +1,46 @@
+describe('TSP user looks at the invoice panel to view unbilled line items', () => {
+  beforeEach(() => {
+    cy.signIntoTSP();
+  });
+
+  it('there are no unbilled line items', checkNoUnbilledLineItems);
+
+  it('there are unbilled line items', checkExistUnbilledLineItems);
+});
+
+function checkNoUnbilledLineItems() {
+  // Open the shipment with no unbilled line items.
+  cy.visit('/shipments/0851706a-997f-46fb-84e4-2525a444ade0');
+
+  // The invoice table should be empty.
+  cy
+    .get('.invoice-panel .basic-panel-content')
+    .children()
+    .first()
+    .should('have.text', 'No line items');
+}
+
+function checkExistUnbilledLineItems() {
+  // Open the shipment with unbilled line items.
+  cy.visit('shipments/67a3cbe7-4ae3-4f6a-9f9a-4f312e7458b9');
+
+  // The invoice table should display the unbilled line items.
+  cy
+    .get('.invoice-panel .basic-panel-content tbody')
+    .children()
+    // For each line item, I should see item code, description, etc.
+    .each((row, index, lst) => {
+      // Last line is the Totals line.
+      if (index === lst.length - 1) {
+        return;
+      }
+
+      cy
+        .wrap(row)
+        .children()
+        .each(cell => {
+          // Each cell should have a value present.
+          cy.wrap(cell).should('not.have.text', '');
+        });
+    });
+}


### PR DESCRIPTION
## Description

Adds a Cypress test to check that when there are unbilled line items, the TSP can see them in a shipment. When there are no unbilled line items, the TSP should see this. 

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](./docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](./docs/backend.md#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](./docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
* [ ] There are no aXe warnings for UI.
* [ ] This works in IE.
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @willowbl00
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/162645626) for this change
