### PR TITLE
Adding shipment validation to the AQ

### DIFF
--- a/pkg/awardqueue/awardqueue_test.go
+++ b/pkg/awardqueue/awardqueue_test.go
@@ -704,6 +704,42 @@ func (suite *AwardQueueSuite) verifyOfferCount(tsp models.TransportationServiceP
 	}
 }
 
+func (suite *AwardQueueSuite) Test_validateShipmentForAward() {
+	t := suite.T()
+	t.Helper()
+
+	// A default shipment, which has all valid fields on it
+	shipment := testdatagen.MakeShipment(suite.db, testdatagen.Assertions{
+		Shipment: models.Shipment{},
+	})
+	err := validateShipmentForAward(shipment)
+	suite.Nil(err)
+
+	// A shipment with a nil TDL ID
+	shipment = testdatagen.MakeShipment(suite.db, testdatagen.Assertions{
+		Shipment: models.Shipment{},
+	})
+	shipment.TrafficDistributionListID = nil
+	err = validateShipmentForAward(shipment)
+	suite.NotNil(err)
+
+	// A shipment with a nil BookDate
+	shipment = testdatagen.MakeShipment(suite.db, testdatagen.Assertions{
+		Shipment: models.Shipment{},
+	})
+	shipment.BookDate = nil
+	err = validateShipmentForAward(shipment)
+	suite.NotNil(err)
+
+	// A shipment with a nil RequestedPickupDate
+	shipment = testdatagen.MakeShipment(suite.db, testdatagen.Assertions{
+		Shipment: models.Shipment{},
+	})
+	shipment.RequestedPickupDate = nil
+	err = validateShipmentForAward(shipment)
+	suite.NotNil(err)
+}
+
 func (suite *AwardQueueSuite) Test_waitForLock() {
 	ctx := context.Background()
 	ret := make(chan int)


### PR DESCRIPTION
## Description

I discovered that the Award Queue was crashing on Staging because, somehow, a shipment had been created that didn't have a TDL. Not only does that one bad shipment not get awarded, but the entire queue of shipments behind it will never get awarded, because the entire AQ operation happens within a transaction that gets rolled back.

This PR is one part of a fix. It makes the AQ more resilient to bad data during a run. Shipments with bad data will get skipped. Unfortunately they will accumulate, but this shouldn't add much overhead for now. Eventually we will need a way to flag these shipments as invalid, or fix them.

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](./docs/backend.md#logging)
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/162750780) for this change