### PR TITLE
Check DOD certs on startup

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -224,14 +224,6 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:e048ea497a949a07065a2076746a43629df92f2439ae5e2c476d1eb700052fa7"
-  name = "github.com/fullsailor/pkcs7"
-  packages = ["."]
-  pruneopts = ""
-  revision = "8306686428a5fe132eac8cb7c4848af725098bd4"
-
-[[projects]]
-  branch = "master"
   digest = "1:e9ffb9315dce0051beb757d0f0fc25db57c4da654efc4eada4ea109c2d9da815"
   name = "github.com/globalsign/mgo"
   packages = [
@@ -309,7 +301,6 @@
   name = "github.com/go-openapi/runtime"
   packages = [
     ".",
-    "flagext",
     "logger",
     "middleware",
     "middleware/denco",
@@ -1234,6 +1225,14 @@
   revision = "a0b114877d4caeffbd7f87e3757c17fce570fea7"
 
 [[projects]]
+  branch = "master"
+  digest = "1:6678ceacadc5683147f2391aab89037eb03cdda275919adcaf90e455788b9fba"
+  name = "go.mozilla.org/pkcs7"
+  packages = ["."]
+  pruneopts = ""
+  revision = "3cffc6fbfe837a6fe43e8e336153379a69ef02bd"
+
+[[projects]]
   digest = "1:74f86c458e82e1c4efbab95233e0cf51b7cc02dc03193be9f62cd81224e10401"
   name = "go.uber.org/atomic"
   packages = ["."]
@@ -1299,7 +1298,6 @@
     "html",
     "html/atom",
     "idna",
-    "netutil",
   ]
   pruneopts = ""
   revision = "e147a9138326bc0e9d4e179541ffd8af41cff8a9"
@@ -1452,18 +1450,12 @@
     "github.com/dustin/go-humanize",
     "github.com/facebookgo/clock",
     "github.com/felixge/httpsnoop",
-    "github.com/fullsailor/pkcs7",
     "github.com/go-gomail/gomail",
-    "github.com/go-openapi/errors",
     "github.com/go-openapi/loads",
     "github.com/go-openapi/runtime",
-    "github.com/go-openapi/runtime/flagext",
     "github.com/go-openapi/runtime/middleware",
-    "github.com/go-openapi/runtime/security",
-    "github.com/go-openapi/spec",
     "github.com/go-openapi/strfmt",
     "github.com/go-openapi/swag",
-    "github.com/go-openapi/validate",
     "github.com/go-swagger/go-swagger/cmd/swagger",
     "github.com/gobuffalo/pop",
     "github.com/gobuffalo/pop/soda",
@@ -1475,7 +1467,6 @@
     "github.com/honeycombio/beeline-go",
     "github.com/honeycombio/beeline-go/wrappers/hnynethttp",
     "github.com/imdario/mergo",
-    "github.com/jessevdk/go-flags",
     "github.com/jmoiron/sqlx",
     "github.com/jung-kurt/gofpdf",
     "github.com/magiconair/properties/assert",
@@ -1493,12 +1484,12 @@
     "github.com/tealeg/xlsx",
     "github.com/trussworks/pdfcpu/pkg/api",
     "github.com/trussworks/pdfcpu/pkg/pdfcpu",
+    "go.mozilla.org/pkcs7",
     "go.uber.org/zap",
     "go.uber.org/zap/zapcore",
     "goji.io",
     "goji.io/pat",
     "golang.org/x/crypto/bcrypt",
-    "golang.org/x/net/netutil",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -19,3 +19,7 @@ required = [
  [[constraint]]
   name = "github.com/trussworks/pdfcpu"
   branch = "afero"
+
+[[constraint]]
+  branch = "master"
+  name = "go.mozilla.org/pkcs7"

--- a/Makefile
+++ b/Makefile
@@ -176,11 +176,11 @@ webserver_test: server_generate
 ifndef TEST_ACC_ENV
 	@echo "Running acceptance tests for webserver using local environment."
 	@echo "* Use environment XYZ by setting environment variable to TEST_ACC_ENV=XYZ."
-	TEST_ACC_DATABASE=0 TEST_ACC_HONEYCOMB=0 \
+	TEST_ACC_DATABASE=0 TEST_ACC_DOD_CERTIFICATES=0 TEST_ACC_HONEYCOMB=0 \
 	go test -p 1 -count 1 -short $$(go list ./... | grep \\/cmd\\/webserver) 2> /dev/null
 else
 	@echo "Running acceptance tests for webserver with environment $$TEST_ACC_ENV."
-	TEST_ACC_DATABASE=0 TEST_ACC_HONEYCOMB=0 TEST_ACC_CWD=$$(PWD) \
+	TEST_ACC_DATABASE=0 TEST_ACC_DOD_CERTIFICATES=0 TEST_ACC_HONEYCOMB=0 TEST_ACC_CWD=$$(PWD) \
 	aws-vault exec $$AWS_PROFILE -- \
 	chamber exec app-$$TEST_ACC_ENV -- \
 	go test -p 1 -count 1 -short $$(go list ./... | grep \\/cmd\\/webserver) 2> /dev/null

--- a/cmd/webserver/main.go
+++ b/cmd/webserver/main.go
@@ -88,6 +88,14 @@ func (e *errInvalidRegion) Error() string {
 	return fmt.Sprintf("invalid region %s", e.Region)
 }
 
+type errInvalidPKCS7 struct {
+	Path string
+}
+
+func (e *errInvalidPKCS7) Error() string {
+	return fmt.Sprintf("invalid DER encoded PKCS7 package: %s", e.Path)
+}
+
 func stringSliceContains(stringSlice []string, value string) bool {
 	for _, x := range stringSlice {
 		if value == x {
@@ -239,31 +247,58 @@ func initFlags(flag *pflag.FlagSet) {
 	flag.String("csrf-auth-key", "", "CSRF Auth Key, 32 byte long")
 }
 
-func initDODCertificates(v *viper.Viper, logger *zap.Logger) ([]server.TLSCert, *x509.CertPool, error) {
+func initDODCertificates(v *viper.Viper, logger *zap.Logger) ([]tls.Certificate, *x509.CertPool, error) {
 
-	moveMilCerts := []server.TLSCert{
-		server.TLSCert{
-			//Append move.mil cert with CA certificate chain
-			CertPEMBlock: bytes.Join([][]byte{
-				[]byte(v.GetString("move-mil-dod-tls-cert")),
-				[]byte(v.GetString("move-mil-dod-ca-cert"))},
-				[]byte("\n"),
-			),
-			KeyPEMBlock: []byte(v.GetString("move-mil-dod-tls-key")),
-		},
+	tlsCert := v.GetString("move-mil-dod-tls-cert")
+	if len(tlsCert) == 0 {
+		return make([]tls.Certificate, 0), nil, errors.Errorf("%s is missing", "move-mil-dod-tls-cert")
 	}
 
-	pkcs7Package, err := ioutil.ReadFile(v.GetString("dod-ca-package")) // #nosec
+	caCert := v.GetString("move-mil-dod-ca-cert")
+	if len(caCert) == 0 {
+		return make([]tls.Certificate, 0), nil, errors.Errorf("%s is missing", "move-mil-dod-ca-cert")
+	}
+
+	//Append move.mil cert with CA certificate chain
+	cert := bytes.Join(
+		[][]byte{
+			[]byte(tlsCert),
+			[]byte(caCert),
+		},
+		[]byte("\n"),
+	)
+
+	key := []byte(v.GetString("move-mil-dod-tls-key"))
+	if len(key) == 0 {
+		return make([]tls.Certificate, 0), nil, errors.Errorf("%s is missing", "move-mil-dod-tls-key")
+	}
+
+	keyPair, err := tls.X509KeyPair(cert, key)
 	if err != nil {
-		return moveMilCerts, nil, errors.Wrap(err, "Failed to read DoD CA certificate package")
+		return make([]tls.Certificate, 0), nil, errors.Wrap(err, "failed to parse DOD keypair for server")
+	}
+
+	pathToPackage := v.GetString("dod-ca-package")
+	if len(pathToPackage) == 0 {
+		return make([]tls.Certificate, 0), nil, errors.Wrap(&errInvalidPKCS7{Path: pathToPackage}, fmt.Sprintf("%s is missing", "dod-ca-package"))
+	}
+
+	pkcs7Package, err := ioutil.ReadFile(pathToPackage) // #nosec
+	if err != nil {
+		return make([]tls.Certificate, 0), nil, errors.Wrap(err, fmt.Sprintf("%s is invalid", "dod-ca-package"))
+	}
+
+	if len(pkcs7Package) == 0 {
+		return make([]tls.Certificate, 0), nil, errors.Wrap(&errInvalidPKCS7{Path: pathToPackage}, fmt.Sprintf("%s is an empty file", "dod-ca-package"))
 	}
 
 	dodCACertPool, err := server.LoadCertPoolFromPkcs7Package(pkcs7Package)
 	if err != nil {
-		return moveMilCerts, dodCACertPool, errors.Wrap(err, "Failed to parse DoD CA certificate package")
+		return make([]tls.Certificate, 0), dodCACertPool, errors.Wrap(err, "Failed to parse DoD CA certificate package")
 	}
 
-	return moveMilCerts, dodCACertPool, nil
+	return []tls.Certificate{keyPair}, dodCACertPool, nil
+
 }
 
 func initRoutePlanner(v *viper.Viper, logger *zap.Logger) route.Planner {
@@ -844,6 +879,9 @@ func main() {
 	if err != nil {
 		logger.Fatal("Failed to initialize DOD certificates", zap.Error(err))
 	}
+
+	logger.Debug("Server DOD Key Pair Loaded")
+	logger.Debug("DOD Certificate Authorities", zap.Any("subjects", dodCACertPool.Subjects()))
 
 	listenInterface := v.GetString("interface")
 

--- a/cmd/webserver/main_test.go
+++ b/cmd/webserver/main_test.go
@@ -106,6 +106,12 @@ func (suite *webServerSuite) TestConfigStorage() {
 }
 
 func (suite *webServerSuite) TestDODCertificates() {
+
+	if os.Getenv("TEST_ACC_DOD_CERTIFICATES") != "1" {
+		suite.logger.Info("Skipping TestDODCertificates")
+		return
+	}
+
 	_, _, err := initDODCertificates(suite.viper, suite.logger)
 	suite.Nil(err)
 }

--- a/docs/how-to/run-go-tests.md
+++ b/docs/how-to/run-go-tests.md
@@ -22,7 +22,7 @@ If you're adding a feature that requires new or modified configuration, it's a g
 $ TEST_ACC_ENV=experimental make webserver_test
 ```
 
-This command will first load the variables from the `config/env/*.env` file and then run `chamber exec` to pull the environments from AWS.  You can run acceptance tests for the database and honeycomb through environment variables with `TEST_ACC_DATABASE=1` and `TEST_ACC_HONEYCOMB=1`.
+This command will first load the variables from the `config/env/*.env` file and then run `chamber exec` to pull the environments from AWS.  You can run acceptance tests for the database, DOD certificates, honeycomb through environment variables with `TEST_ACC_DATABASE=1`, `TEST_ACC_DOD_CERTIFICATES=1`, and `TEST_ACC_HONEYCOMB=1`, respectively.
 
 ### Run All Tests in a Single Package
 

--- a/pkg/server/certificates.go
+++ b/pkg/server/certificates.go
@@ -3,7 +3,7 @@ package server
 import (
 	"crypto/x509"
 
-	"github.com/fullsailor/pkcs7"
+	"go.mozilla.org/pkcs7"
 )
 
 // LoadCertPoolFromPkcs7Package reads the certificates in a DER-encoded PKCS7

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -45,17 +45,20 @@ func (suite *serverSuite) readFile(filename string) []byte {
 }
 
 func (suite *serverSuite) TestParseSingleTLSCert() {
-	tlsCert := TLSCert{
-		CertPEMBlock: suite.readFile("localhost.pem"),
-		KeyPEMBlock:  suite.readFile("localhost.key"),
-	}
+
+	keyPair, err := tls.X509KeyPair(
+		suite.readFile("localhost.pem"),
+		suite.readFile("localhost.key"))
+
+	suite.Nil(err)
+
 	httpsServer := Server{
 		ClientAuthType: tls.NoClientCert,
 		ListenAddress:  "127.0.0.1",
 		HTTPHandler:    suite.httpHandler,
 		Logger:         suite.logger,
 		Port:           8443,
-		TLSCerts:       []TLSCert{tlsCert},
+		TLSCerts:       []tls.Certificate{keyPair},
 	}
 
 	tlsConfig, err := httpsServer.tlsConfig()
@@ -65,35 +68,27 @@ func (suite *serverSuite) TestParseSingleTLSCert() {
 }
 
 func (suite *serverSuite) TestParseBadTLSCert() {
-	tlsCert1 := TLSCert{
-		CertPEMBlock: suite.readFile("localhost-bad.pem"),
-		KeyPEMBlock:  suite.readFile("localhost.key"),
-	}
 
-	httpsServer := Server{
-		ClientAuthType: tls.NoClientCert,
-		ListenAddress:  "127.0.0.1",
-		HTTPHandler:    suite.httpHandler,
-		Logger:         suite.logger,
-		Port:           8443,
-		TLSCerts:       []TLSCert{tlsCert1},
-	}
+	_, err := tls.X509KeyPair(
+		suite.readFile("localhost-bad.pem"),
+		suite.readFile("localhost.key"))
 
-	tlsConfig, err := httpsServer.tlsConfig()
 	suite.NotNil(err)
-	suite.Nil(tlsConfig)
 }
 
 func (suite *serverSuite) TestParseMultipleTLSCerts() {
-	tlsLocalhost := TLSCert{
-		CertPEMBlock: suite.readFile("localhost.pem"),
-		KeyPEMBlock:  suite.readFile("localhost.key"),
-	}
 
-	tlsOfficelocal := TLSCert{
-		CertPEMBlock: suite.readFile("officelocal.pem"),
-		KeyPEMBlock:  suite.readFile("officelocal.key"),
-	}
+	keyPairLocalhost, err := tls.X509KeyPair(
+		suite.readFile("localhost.pem"),
+		suite.readFile("localhost.key"))
+
+	suite.Nil(err)
+
+	keyPairOffice, err := tls.X509KeyPair(
+		suite.readFile("officelocal.pem"),
+		suite.readFile("officelocal.key"))
+
+	suite.Nil(err)
 
 	httpsServer := Server{
 		ClientAuthType: tls.NoClientCert,
@@ -101,9 +96,9 @@ func (suite *serverSuite) TestParseMultipleTLSCerts() {
 		HTTPHandler:    suite.httpHandler,
 		Logger:         suite.logger,
 		Port:           8443,
-		TLSCerts: []TLSCert{
-			tlsLocalhost,
-			tlsOfficelocal},
+		TLSCerts: []tls.Certificate{
+			keyPairLocalhost,
+			keyPairOffice},
 	}
 
 	tlsConfig, err := httpsServer.tlsConfig()
@@ -114,10 +109,13 @@ func (suite *serverSuite) TestParseMultipleTLSCerts() {
 }
 
 func (suite *serverSuite) TestTLSConfigWithClientAuth() {
-	tlsCert := TLSCert{
-		CertPEMBlock: suite.readFile("localhost.pem"),
-		KeyPEMBlock:  suite.readFile("localhost.key"),
-	}
+
+	keyPair, err := tls.X509KeyPair(
+		suite.readFile("localhost.pem"),
+		suite.readFile("localhost.key"))
+
+	suite.Nil(err)
+
 	caFile := suite.readFile("ca.pem")
 	caCertPool := x509.NewCertPool()
 	caCertPool.AppendCertsFromPEM(caFile)
@@ -129,36 +127,42 @@ func (suite *serverSuite) TestTLSConfigWithClientAuth() {
 		HTTPHandler:    suite.httpHandler,
 		Logger:         suite.logger,
 		Port:           8443,
-		TLSCerts:       []TLSCert{tlsCert},
+		TLSCerts:       []tls.Certificate{keyPair},
 	}
 
-	_, err := httpsServer.tlsConfig()
+	_, err = httpsServer.tlsConfig()
 	suite.Nil(err)
 }
 
 func (suite *serverSuite) TestTLSConfigWithMissingCA() {
-	tlsCert := TLSCert{
-		CertPEMBlock: suite.readFile("localhost.pem"),
-		KeyPEMBlock:  suite.readFile("localhost.key"),
-	}
+
+	keyPair, err := tls.X509KeyPair(
+		suite.readFile("localhost.pem"),
+		suite.readFile("localhost.key"))
+
+	suite.Nil(err)
+
 	httpsServer := Server{
 		ClientAuthType: tls.RequireAndVerifyClientCert,
 		ListenAddress:  "127.0.0.1",
 		HTTPHandler:    suite.httpHandler,
 		Logger:         suite.logger,
 		Port:           8443,
-		TLSCerts:       []TLSCert{tlsCert},
+		TLSCerts:       []tls.Certificate{keyPair},
 	}
 
-	_, err := httpsServer.tlsConfig()
+	_, err = httpsServer.tlsConfig()
 	suite.Equal(ErrMissingCACert, err)
 }
 
 func (suite *serverSuite) TestTLSConfigWithMisconfiguredCA() {
-	tlsCert := TLSCert{
-		CertPEMBlock: suite.readFile("localhost.pem"),
-		KeyPEMBlock:  suite.readFile("localhost.key"),
-	}
+
+	keyPair, err := tls.X509KeyPair(
+		suite.readFile("localhost.pem"),
+		suite.readFile("localhost.key"))
+
+	suite.Nil(err)
+
 	caFile := suite.readFile("localhost-bad.pem")
 	caCertPool := x509.NewCertPool()
 	certOk := caCertPool.AppendCertsFromPEM(caFile)
@@ -171,10 +175,10 @@ func (suite *serverSuite) TestTLSConfigWithMisconfiguredCA() {
 		HTTPHandler:    suite.httpHandler,
 		Logger:         suite.logger,
 		Port:           8443,
-		TLSCerts:       []TLSCert{tlsCert},
+		TLSCerts:       []tls.Certificate{keyPair},
 	}
 
-	_, err := httpsServer.tlsConfig()
+	_, err = httpsServer.tlsConfig()
 	suite.Equal(ErrMissingCACert, err)
 }
 


### PR DESCRIPTION
## Description

This PR makes a few minor improvements to DOD certificate management.

- migrates from `github.com/fullsailor/pkcs7` to `go.mozilla.org/pkcs7`
- checks and parses DOD server keypair within webserver and passes `tls.Certificate` directly instead of using intermediate struct
- Outputs additional debug information

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

DOD certs aren't currently checked in CI/CD, since they require real values.  You can test with a 
`.envrc.local` or load certs from chamber as below.

```
TEST_ACC_DOD_CERTIFICATES=1 TEST_ACC_ENV=experimental make webserver_test
```

## Setup

No external changes

## Code Review Verification Steps


## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/161134221) for this change