### PR TITLE
Check AWS config on startup

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -105,7 +105,7 @@ export TZ="UTC"
 #
 # The default and equivalent to not being set is:
 #
-#   export STORAGE_BACKEND=filesystem
+#   export STORAGE_BACKEND=local
 #   export EMAIL_BACKEND=local
 #
 # Your AWS credentials should be setup in the transcom-ppp profile using

--- a/cmd/paperwork/shipment_summary.go
+++ b/cmd/paperwork/shipment_summary.go
@@ -20,7 +20,7 @@ import (
 func main() {
 	config := flag.String("config-dir", "config", "The location of server config files")
 	env := flag.String("env", "development", "The environment to run in, which configures the database.")
-	storageBackend := flag.String("storage_backend", "filesystem", "Storage backend to use, either filesystem or s3.")
+	storageBackend := flag.String("storage_backend", "local", "Storage backend to use, either filesystem or s3.")
 	s3Bucket := flag.String("aws_s3_bucket_name", "", "S3 bucket used for file storage")
 	s3Region := flag.String("aws_s3_region", "", "AWS region used for S3 file storage")
 	s3KeyNamespace := flag.String("aws_s3_key_namespace", "", "Key prefix for all objects written to S3")

--- a/cmd/webserver/main.go
+++ b/cmd/webserver/main.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
 	awssession "github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ses"
 	"github.com/dgrijalva/jwt-go"
@@ -25,6 +26,10 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
+	"go.uber.org/zap"
+	"goji.io"
+	"goji.io/pat"
+
 	"github.com/transcom/mymove/pkg/auth"
 	"github.com/transcom/mymove/pkg/auth/authentication"
 	"github.com/transcom/mymove/pkg/dpsauth"
@@ -39,9 +44,6 @@ import (
 	"github.com/transcom/mymove/pkg/route"
 	"github.com/transcom/mymove/pkg/server"
 	"github.com/transcom/mymove/pkg/storage"
-	"go.uber.org/zap"
-	"goji.io"
-	"goji.io/pat"
 )
 
 // GitCommit is empty unless set as a build flag
@@ -74,6 +76,23 @@ type errInvalidHost struct {
 
 func (e *errInvalidHost) Error() string {
 	return fmt.Sprintf("invalid host %s, must not contain whitespace, :, /, or \\", e.Host)
+}
+
+type errInvalidRegion struct {
+	Region string
+}
+
+func (e *errInvalidRegion) Error() string {
+	return fmt.Sprintf("invalid region %s", e.Region)
+}
+
+func stringSliceContains(stringSlice []string, value string) bool {
+	for _, x := range stringSlice {
+		if value == x {
+			return true
+		}
+	}
+	return false
 }
 
 func limitBodySizeMiddleware(inner http.Handler) http.Handler {
@@ -190,7 +209,7 @@ func initFlags(flag *pflag.FlagSet) {
 	// EDI Invoice Config
 	flag.Bool("send-prod-invoice", false, "Flag (bool) for EDI Invoices to signify if they should go to production GEX")
 
-	flag.String("storage-backend", "filesystem", "Storage backend to use, either filesystem or s3.")
+	flag.String("storage-backend", "local", "Storage backend to use, either filesystem or s3.")
 	flag.String("email-backend", "local", "Email backend to use, either SES or local")
 	flag.String("aws-s3-bucket-name", "", "S3 bucket used for file storage")
 	flag.String("aws-s3-region", "", "AWS region used for S3 file storage")
@@ -397,6 +416,40 @@ func checkConfig(v *viper.Viper) error {
 	for _, c := range portVars {
 		if p := v.GetInt(c); p <= 0 || p > 65535 {
 			return errors.Wrap(&errInvalidPort{Port: p}, fmt.Sprintf("%s is invalid", c))
+		}
+	}
+
+	emailBackend := v.GetString("email-backend")
+	if !stringSliceContains([]string{"local", "ses"}, emailBackend) {
+		return fmt.Errorf("invalid email-backend %s, expecting local or ses", emailBackend)
+	}
+
+	if emailBackend == "ses" {
+		// SES is only available in 3 regions: us-east-1, us-west-2, and eu-west-1
+		// - see https://docs.aws.amazon.com/ses/latest/DeveloperGuide/regions.html#region-endpoints
+		if r := v.GetString("aws-ses-region"); len(r) == 0 || !stringSliceContains([]string{"us-east-1", "us-west-2", "eu-west-1"}, r) {
+			return errors.Wrap(&errInvalidRegion{Region: r}, fmt.Sprintf("%s is invalid", "aws-ses-region"))
+		}
+	}
+
+	storageBackend := v.GetString("storage-backend")
+	if !stringSliceContains([]string{"local", "s3"}, storageBackend) {
+		return fmt.Errorf("invalid storage-backend %s, expecting local or s3", storageBackend)
+	}
+
+	if storageBackend == "s3" {
+		regions, ok := endpoints.RegionsForService(endpoints.DefaultPartitions(), endpoints.AwsPartitionID, endpoints.S3ServiceID)
+		if !ok {
+			return fmt.Errorf("could not find regions for service %s", endpoints.S3ServiceID)
+		}
+
+		r := v.GetString("aws-s3-region")
+		if len(r) == 0 {
+			return errors.Wrap(&errInvalidRegion{Region: r}, fmt.Sprintf("%s is invalid", "aws-s3-region"))
+		}
+
+		if _, ok := regions[r]; !ok {
+			return errors.Wrap(&errInvalidRegion{Region: r}, fmt.Sprintf("%s is invalid", "aws-s3-region"))
 		}
 	}
 


### PR DESCRIPTION
## Description

This PR adds checks for the following on startup, including: `storage-backend`, `email-backend`, `aws-s3-region`, and `ses-region`.  This PR also changes `storage-backend` default to `local`, which is actually a no-op since it's only implicitly used used as `if storage-backend == s3 else XYZ`

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?  I'll test on experimental to ensure it works.

## Setup

N.A.

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](./docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](./docs/backend.md#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](./docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
* [ ] There are no aXe warnings for UI.
* [ ] This works in IE.
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @willowbl00
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/161935602) for this change
