### PR TITLE
Include a better failure message if the app container fails unexpectedly

### DIFF
--- a/bin/run-e2e-test-docker
+++ b/bin/run-e2e-test-docker
@@ -69,10 +69,24 @@ $DOCKER_RUN \
   --rm \
   ${CONTAINER}:latest
 
+# If your container is exiting unexpectedly try uncommenting this code to see the output:
+# docker logs -f ${CONTAINER}
+
+# Grab the IP address of the running container
 E2E_IP=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' ${CONTAINER})
 
 # Run the cypress tests
 docker build -f Dockerfile.cypress --tag ${CONTAINER_CYPRESS}:latest .
+
+# Confirm app container is still running before running tests
+# See note above about what to do if you need to debug
+DOCKER_PID=$(docker ps -qf name=${CONTAINER})
+if [ -z "${DOCKER_PID}" ]; then
+  echo
+  echo "Docker container ${CONTAINER} exited unexpectedly. No tests will be run. "
+  exit 1
+fi
+
 $DOCKER_RUN \
   -e CYPRESS_baseUrl=http://${MILMOVEHOST}:4000 \
   --add-host ${MILMOVEHOST}:"${E2E_IP}" \


### PR DESCRIPTION
## Description

Also include a commented out instruction on how to debug unexpected failures

## Reviewer Notes

Could the error message be better?

## Setup

Remove an environment variable from https://github.com/transcom/mymove/blob/master/bin/run-e2e-test-docker#L37-L63 and run this:

```sh
make e2e_test_docker
```

You should see the failure message appear.

## Code Review Verification Steps

* [x] Request review from a member of a different team.