### PR TITLE
rd single invoice flow #162518251

### DIFF
--- a/pkg/handlers/internalapi/shipments.go
+++ b/pkg/handlers/internalapi/shipments.go
@@ -1,7 +1,6 @@
 package internalapi
 
 import (
-	"errors"
 	"os"
 	"time"
 
@@ -511,9 +510,9 @@ func (h ShipmentInvoiceHandler) Handle(params shipmentop.CreateAndSendHHGInvoice
 		if element.Status == models.InvoiceStatusDRAFT ||
 			element.Status == models.InvoiceStatusINPROCESS ||
 			element.Status == models.InvoiceStatusSUBMITTED {
-			return handlers.ResponseForCustomErrors(h.Logger(), errors.New("invoice is processing or already processed for this shipment"), 409)
+			payload := payloadForInvoiceModel(&element)
+			return shipmentop.NewCreateAndSendHHGInvoiceConflict().WithPayload(payload)
 		}
-
 	}
 
 	approver, err := models.FetchOfficeUserByID(h.DB(), session.OfficeUserID)

--- a/pkg/handlers/internalapi/shipments.go
+++ b/pkg/handlers/internalapi/shipments.go
@@ -499,6 +499,18 @@ func (h ShipmentInvoiceHandler) Handle(params shipmentop.CreateAndSendHHGInvoice
 		return shipmentop.NewCreateAndSendHHGInvoiceConflict()
 	}
 
+	//for now we limit a shipment to 1 invoice
+	//if invoices exists and at least one is either in process or has succeeded then return 409
+	existingInvoices, err := models.FetchInvoicesForShipment(h.DB(), shipmentID)
+	if err != nil {
+		return handlers.ResponseForError(h.Logger(), err)
+	}
+	for _, element := range existingInvoices {
+		if element.Status != models.InvoiceStatusSUBMISSIONFAILURE {
+			return shipmentop.NewCreateAndSendHHGInvoiceConflict().WithPayload("Invoice is processing for this shipment")
+		}
+	}
+
 	approver, err := models.FetchOfficeUserByID(h.DB(), session.OfficeUserID)
 	if err != nil {
 		return handlers.ResponseForError(h.Logger(), err)

--- a/pkg/handlers/internalapi/shipments_test.go
+++ b/pkg/handlers/internalapi/shipments_test.go
@@ -455,9 +455,6 @@ func (suite *HandlerSuite) TestShipmentInvoiceHandlerMultipleInvoiceRequests() {
 	suite.Equal(shipmentop.ApproveHHGOKCode, response)
 
 	//assert the second request returns a 409 error
-	failedResponse := shipmentop.CreateAndSendHHGInvoiceParams{
-		HTTPRequest: req,
-		ShipmentID:  strfmt.UUID(shipment.ID.String()),
-	}
-	suite.Equal(shipmentop.NewCreateAndSendHHGInvoiceConflict(), response)
+	failedResponse := handler.Handle(params)
+	suite.Equal(shipmentop.NewCreateAndSendHHGInvoiceConflict(), failedResponse)
 }

--- a/pkg/handlers/internalapi/shipments_test.go
+++ b/pkg/handlers/internalapi/shipments_test.go
@@ -436,6 +436,7 @@ func (suite *HandlerSuite) TestShipmentInvoiceHandlerMultipleInvoiceRequests() {
 			ShipmentID: shipment.ID,
 		},
 	})
+	shipmentOffer.Accept()
 	suite.MustSave(&shipment)
 	suite.MustSave(&shipmentOffer)
 
@@ -456,5 +457,5 @@ func (suite *HandlerSuite) TestShipmentInvoiceHandlerMultipleInvoiceRequests() {
 
 	//assert the second request returns a 409 error
 	failedResponse := handler.Handle(params)
-	suite.Equal(shipmentop.NewCreateAndSendHHGInvoiceConflict(), failedResponse)
+	suite.Equal(shipmentop.NewCreateAndSendHHGInvoiceConflict().WithPayload("Invoice is processing for this shipment"), failedResponse)
 }

--- a/src/shared/Invoice/InvoicePanel.jsx
+++ b/src/shared/Invoice/InvoicePanel.jsx
@@ -12,7 +12,13 @@ import {
   getAllShipmentLineItems,
   getShipmentLineItemsLabel,
 } from 'shared/Entities/modules/shipmentLineItems';
-import { selectSortedInvoices, createInvoice, createInvoiceLabel } from 'shared/Entities/modules/invoices';
+import {
+  selectSortedInvoices,
+  createInvoice,
+  createInvoiceLabel,
+  getAllInvoices,
+  getShipmentInvoicesLabel,
+} from 'shared/Entities/modules/invoices';
 import { getRequestStatus } from 'shared/Swagger/selectors';
 import UnbilledTable from 'shared/Invoice/UnbilledTable';
 import InvoiceTable from 'shared/Invoice/InvoiceTable';
@@ -21,9 +27,18 @@ import './InvoicePanel.css';
 
 export class InvoicePanel extends PureComponent {
   approvePayment = () => {
-    return this.props.createInvoice(createInvoiceLabel, this.props.shipmentId).then(() => {
-      return this.props.getAllShipmentLineItems(getShipmentLineItemsLabel, this.props.shipmentId);
-    });
+    return this.props
+      .createInvoice(createInvoiceLabel, this.props.shipmentId)
+      .then(() => {
+        return this.props.getAllShipmentLineItems(getShipmentLineItemsLabel, this.props.shipmentId);
+      })
+      .catch(err => {
+        let httpResCode = get(err, 'response.status');
+        if (httpResCode === 409) {
+          this.props.getAllInvoices(getShipmentInvoicesLabel, this.props.shipmentId);
+          return this.props.getAllShipmentLineItems(getShipmentLineItemsLabel, this.props.shipmentId);
+        }
+      });
   };
 
   render() {
@@ -78,6 +93,6 @@ const mapStateToProps = (state, ownProps) => {
 };
 
 function mapDispatchToProps(dispatch) {
-  return bindActionCreators({ createInvoice, getAllShipmentLineItems }, dispatch);
+  return bindActionCreators({ createInvoice, getAllShipmentLineItems, getAllInvoices }, dispatch);
 }
 export default connect(mapStateToProps, mapDispatchToProps)(InvoicePanel);

--- a/src/shared/Invoice/InvoicePayment.jsx
+++ b/src/shared/Invoice/InvoicePayment.jsx
@@ -30,8 +30,7 @@ class InvoicePayment extends PureComponent {
   render() {
     let paymentAlert;
     const status = this.props.createInvoiceStatus;
-    const allowPayments = true;
-    //const allowPayments = this.props.allowPayments && !status.isLoading;
+    const allowPayments = this.props.allowPayments && !status.isLoading;
 
     let header = (
       <div className="invoice-panel-header-cont">
@@ -65,13 +64,26 @@ class InvoicePayment extends PureComponent {
     if (status.error) {
       //handle 409 status: shipment invoice already processed
       let httpResCode = get(status, 'error.response.status');
-      let errMessage = get(status, 'error.response.response.body.message');
-      if (httpResCode === 409 && errMessage === 'invoice is processing or already processed for this shipment') {
+      let invoiceStatus = get(status, 'error.response.response.body.status');
+      let aproverFirstName = get(status, 'error.response.response.body.approver_first_name');
+      let aproverLastName = get(status, 'error.response.response.body.approver_last_name');
+      if (httpResCode === 409 && invoiceStatus === 'SUBMITTED') {
         paymentAlert = (
           <div>
             <Alert type="success" heading="Success!">
               <span className="warning--header">
-                Invoice already processing, please reload page for updated information.
+                Counselor {aproverFirstName} {aproverLastName} already approved this invoice.
+              </span>
+            </Alert>
+          </div>
+        );
+      } else if (httpResCode === 409 && (invoiceStatus === 'IN_PROCESS' || invoiceStatus === 'DRAFT')) {
+        paymentAlert = (
+          <div>
+            <Alert type="success" heading="Success!">
+              <span className="warning--header">
+                Counselor {aproverFirstName} {aproverLastName} already submitted this invoice. Please reload your screen
+                to see updated information.
               </span>
             </Alert>
           </div>

--- a/src/shared/Invoice/InvoicePayment.jsx
+++ b/src/shared/Invoice/InvoicePayment.jsx
@@ -1,5 +1,6 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
+import { get } from 'lodash';
 
 import Alert from 'shared/Alert';
 import './InvoicePanel.css';
@@ -29,7 +30,7 @@ class InvoicePayment extends PureComponent {
   render() {
     let paymentAlert;
     const status = this.props.createInvoiceStatus;
-    const allowPayments = this.props.allowPayments && !status.isLoading;
+    const allowPayments = true; // this.props.allowPayments && !status.isLoading;
 
     let header = (
       <div className="invoice-panel-header-cont">
@@ -61,11 +62,26 @@ class InvoicePayment extends PureComponent {
     }
 
     if (status.error) {
-      paymentAlert = (
-        <Alert type="error" heading="Oops, something went wrong!">
-          <span className="warning--header">Please try again.</span>
-        </Alert>
-      );
+      //handle 409 status: shipment invoice already processed
+      let httpResCode = get(status, 'error.response.status');
+      let errMessage = get(status, 'error.response.response.body');
+      if (httpResCode === 409 && errMessage === 'Invoice has already been approved for this shipment.') {
+        paymentAlert = (
+          <div>
+            <Alert type="success" heading="Success!">
+              <span className="warning--header">
+                Invoice already processing, please reload page for updated information.
+              </span>
+            </Alert>
+          </div>
+        );
+      } else {
+        paymentAlert = (
+          <Alert type="error" heading="Oops, something went wrong!">
+            <span className="warning--header">Please try again.</span>
+          </Alert>
+        );
+      }
     } else if (status.isLoading) {
       paymentAlert = (
         <Alert type="loading" heading="Creating invoice">

--- a/src/shared/Invoice/InvoicePayment.jsx
+++ b/src/shared/Invoice/InvoicePayment.jsx
@@ -30,7 +30,7 @@ class InvoicePayment extends PureComponent {
   render() {
     let paymentAlert;
     const status = this.props.createInvoiceStatus;
-    const allowPayments = true; // this.props.allowPayments && !status.isLoading;
+    const allowPayments = this.props.allowPayments && !status.isLoading;
 
     let header = (
       <div className="invoice-panel-header-cont">
@@ -65,7 +65,7 @@ class InvoicePayment extends PureComponent {
       //handle 409 status: shipment invoice already processed
       let httpResCode = get(status, 'error.response.status');
       let errMessage = get(status, 'error.response.response.body');
-      if (httpResCode === 409 && errMessage === 'Invoice has already been approved for this shipment.') {
+      if (httpResCode === 409 && errMessage === 'Invoice is processing for this shipment') {
         paymentAlert = (
           <div>
             <Alert type="success" heading="Success!">

--- a/src/shared/Invoice/InvoicePayment.jsx
+++ b/src/shared/Invoice/InvoicePayment.jsx
@@ -30,7 +30,8 @@ class InvoicePayment extends PureComponent {
   render() {
     let paymentAlert;
     const status = this.props.createInvoiceStatus;
-    const allowPayments = this.props.allowPayments && !status.isLoading;
+    const allowPayments = true;
+    //const allowPayments = this.props.allowPayments && !status.isLoading;
 
     let header = (
       <div className="invoice-panel-header-cont">
@@ -64,8 +65,8 @@ class InvoicePayment extends PureComponent {
     if (status.error) {
       //handle 409 status: shipment invoice already processed
       let httpResCode = get(status, 'error.response.status');
-      let errMessage = get(status, 'error.response.response.body');
-      if (httpResCode === 409 && errMessage === 'Invoice is processing for this shipment') {
+      let errMessage = get(status, 'error.response.response.body.message');
+      if (httpResCode === 409 && errMessage === 'invoice is processing or already processed for this shipment') {
         paymentAlert = (
           <div>
             <Alert type="success" heading="Success!">

--- a/src/shared/Invoice/InvoicePayment.test.js
+++ b/src/shared/Invoice/InvoicePayment.test.js
@@ -71,7 +71,9 @@ describe('Invoice Payment Component tests', () => {
               response: {
                 status: 409,
                 response: {
-                  body: 'Invoice is processing for this shipment',
+                  body: {
+                    message: 'invoice is processing or already processed for this shipment',
+                  },
                 },
               },
             },

--- a/src/shared/Invoice/InvoicePayment.test.js
+++ b/src/shared/Invoice/InvoicePayment.test.js
@@ -43,7 +43,7 @@ describe('Invoice Payment Component tests', () => {
   //   });
   // });
   describe('When invoice status is in failed condition', () => {
-    it('renders under invoice failed view ', () => {
+    it('renders under invoice failed view', () => {
       wrapper = shallow(
         <InvoicePayment
           approvePayment={confirm}
@@ -57,6 +57,30 @@ describe('Invoice Payment Component tests', () => {
         />,
       );
       expect(wrapper.find('.warning--header').text()).toEqual('Please try again.');
+    });
+  });
+  describe('When invoice has already been approved by another user', () => {
+    it('renders warning letting user know that invoice is already in process', () => {
+      wrapper = shallow(
+        <InvoicePayment
+          approvePayment={confirm}
+          cancelPayment={cancel}
+          allowPayments={false}
+          createInvoiceStatus={{
+            error: {
+              response: {
+                status: 409,
+                response: {
+                  body: 'Invoice has already been approved for this shipment.',
+                },
+              },
+            },
+          }}
+        />,
+      );
+      expect(wrapper.find('.warning--header').text()).toEqual(
+        'Invoice already processing, please reload page for updated information.',
+      );
     });
   });
   describe('When invoice status is approved', () => {

--- a/src/shared/Invoice/InvoicePayment.test.js
+++ b/src/shared/Invoice/InvoicePayment.test.js
@@ -60,29 +60,89 @@ describe('Invoice Payment Component tests', () => {
     });
   });
   describe('When invoice has already been approved by another user', () => {
-    it('renders warning letting user know that invoice is already in process', () => {
-      wrapper = shallow(
-        <InvoicePayment
-          approvePayment={confirm}
-          cancelPayment={cancel}
-          allowPayments={false}
-          createInvoiceStatus={{
-            error: {
-              response: {
-                status: 409,
+    describe('and successfully processed', () => {
+      it('renders warning letting user know that invoice is already in process', () => {
+        wrapper = shallow(
+          <InvoicePayment
+            approvePayment={confirm}
+            cancelPayment={cancel}
+            allowPayments={false}
+            createInvoiceStatus={{
+              error: {
                 response: {
-                  body: {
-                    message: 'invoice is processing or already processed for this shipment',
+                  status: 409,
+                  response: {
+                    body: {
+                      status: 'SUBMITTED',
+                      approver_first_name: 'Leo',
+                      approver_last_name: 'Spaceman',
+                    },
                   },
                 },
               },
-            },
-          }}
-        />,
-      );
-      expect(wrapper.find('.warning--header').text()).toEqual(
-        'Invoice already processing, please reload page for updated information.',
-      );
+            }}
+          />,
+        );
+        expect(wrapper.find('.warning--header').text()).toEqual(
+          'Counselor Leo Spaceman already approved this invoice.',
+        );
+      });
+    });
+    describe('and is in draft', () => {
+      it('renders warning letting user know that invoice is already in process', () => {
+        wrapper = shallow(
+          <InvoicePayment
+            approvePayment={confirm}
+            cancelPayment={cancel}
+            allowPayments={false}
+            createInvoiceStatus={{
+              error: {
+                response: {
+                  status: 409,
+                  response: {
+                    body: {
+                      status: 'DRAFT',
+                      approver_first_name: 'Leo',
+                      approver_last_name: 'Spaceman',
+                    },
+                  },
+                },
+              },
+            }}
+          />,
+        );
+        expect(wrapper.find('.warning--header').text()).toEqual(
+          'Counselor Leo Spaceman already submitted this invoice. Please reload your screen to see updated information.',
+        );
+      });
+    });
+    describe('and is in process', () => {
+      it('renders warning letting user know that invoice is already in process', () => {
+        wrapper = shallow(
+          <InvoicePayment
+            approvePayment={confirm}
+            cancelPayment={cancel}
+            allowPayments={false}
+            createInvoiceStatus={{
+              error: {
+                response: {
+                  status: 409,
+                  response: {
+                    body: {
+                      status: 'IN_PROCESS',
+                      approver_first_name: 'Leo',
+                      approver_last_name: 'Spaceman',
+                    },
+                  },
+                },
+              },
+            }}
+          />,
+        );
+        expect(wrapper.find('.warning--header').text()).toEqual(
+          'Counselor Leo Spaceman already submitted this invoice. Please reload your screen to see updated information.',
+        );
+      });
     });
   });
   describe('When invoice status is approved', () => {

--- a/src/shared/Invoice/InvoicePayment.test.js
+++ b/src/shared/Invoice/InvoicePayment.test.js
@@ -71,7 +71,7 @@ describe('Invoice Payment Component tests', () => {
               response: {
                 status: 409,
                 response: {
-                  body: 'Invoice has already been approved for this shipment.',
+                  body: 'Invoice is processing for this shipment',
                 },
               },
             },

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -3205,6 +3205,8 @@ paths:
           description: not authorized to send this invoice
         409:
           description: the shipment is not in a state to be invoiced
+          schema:
+            $ref: '#/definitions/Invoice'
         500:
           description: server error
   /reimbursement/{reimbursementId}/approve:

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -3205,8 +3205,6 @@ paths:
           description: not authorized to send this invoice
         409:
           description: the shipment is not in a state to be invoiced
-          schema:
-            type: string
         500:
           description: server error
   /reimbursement/{reimbursementId}/approve:

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -3206,7 +3206,7 @@ paths:
         409:
           description: the shipment is not in a state to be invoiced
           schema:
-            $ref: '#/definitions/Shipment'
+            type: string
         500:
           description: server error
   /reimbursement/{reimbursementId}/approve:


### PR DESCRIPTION
## Description

This PR adds extra checks to invoice submission for a given shipment. For now we only allow a single invoice per shipment. If another invoice is submitted while an invoice is already under process or completed the end point will return 409 error with a message which is consumed by front end.

## Reviewer Notes

Changes to the end point that handles invoice processing and the associated tests should draw scrutiny.
## Setup

* Have a shipment that has pre-approved requests and has already been delivered
* Ensure no invoice has been submitted for the shipment selected
* Open two browser tabs and navigate to HHG view as office user, you should see approve invoice button visible on both tabs
* Approve invoice in first tab
* Approve invoice in 2nd tab, second tab should come back with an alert indicating the invoice is already under process

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/162518251) for this change