### PR TITLE
use transaction connection for transaction...

### DIFF
--- a/pkg/service/invoice/update_invoice_submitted.go
+++ b/pkg/service/invoice/update_invoice_submitted.go
@@ -23,7 +23,7 @@ func (u UpdateInvoiceSubmitted) Call(invoice *models.Invoice, shipmentLineItems 
 		// and violating pk unique constraints (the docs say it shouldn't)
 		// https://gobuffalo.io/en/docs/db/relations#eager-creation
 		// verrs, err := c.db.Eager().ValidateAndSave(&invoice)
-		verrs, err := u.DB.ValidateAndSave(invoice)
+		verrs, err := connection.ValidateAndSave(invoice)
 		if err != nil || verrs.HasAny() {
 			return errors.New("error saving invoice")
 		}
@@ -31,7 +31,7 @@ func (u UpdateInvoiceSubmitted) Call(invoice *models.Invoice, shipmentLineItems 
 			shipmentLineItems[liIndex].InvoiceID = &invoice.ID
 			shipmentLineItems[liIndex].Invoice = *invoice
 		}
-		verrs, err = u.DB.ValidateAndSave(&shipmentLineItems)
+		verrs, err = connection.ValidateAndSave(&shipmentLineItems)
 		if err != nil || verrs.HasAny() {
 			return errors.New("error saving shipment line items")
 		}


### PR DESCRIPTION
## Description

A bug where I used the DB store instead of transaction inside the transaction block. @stangah noticed this when we were doing some debugging awhile back and I forgot to patch it.

## Reviewer Notes

Should we have a test for this? Just wrote this PR on a cusp, but it seems reasonable to break the line item foreign constraint or something and test that the invoice gets rolled back. Happy to write that up, just wanted to make this appear before I forgot again

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](./docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](./docs/backend.md#querying-the-database-safely)
 have been satisfied.
