### PR TITLE
Add test for confirmation dialogue for invoice.

### DIFF
--- a/cypress/integration/office/invoicing.js
+++ b/cypress/integration/office/invoicing.js
@@ -6,6 +6,8 @@ describe('Office user looks at the invoice tab to view unbilled line items', () 
   it('there are no unbilled line items', checkNoUnbilledLineItems);
 
   it('there are unbilled line items', checkExistUnbilledLineItems);
+
+  it('the confirmation dialogue appears', checkConfirmationDialogue);
 });
 
 function checkNoUnbilledLineItems() {
@@ -43,4 +45,33 @@ function checkExistUnbilledLineItems() {
           cy.wrap(cell).should('not.have.text', '');
         });
     });
+}
+
+function checkConfirmationDialogue() {
+  // Open the shipments tab.
+  cy.visit('/queues/new/moves/fb4105cf-f5a5-43be-845e-d59fdb34f31c/hhg');
+
+  cy.get('.invoice-panel').within(() => {
+    cy
+      .get('button')
+      .first()
+      .click();
+
+    cy
+      .get('.usa-button-primary')
+      .first()
+      .should('have.text', 'Approve');
+
+    cy
+      .get('.usa-button-secondary')
+      .first()
+      .should('have.text', 'Cancel');
+
+    cy
+      .get('.usa-button-secondary')
+      .first()
+      .click();
+
+    cy.get('button').should('have.text', 'Approve Payment');
+  });
 }


### PR DESCRIPTION
## Description

Adds a test that the confirmation dialogue for invoice submission works correctly:

Clicking the approve button yields a confirmation page with Approve and Cancel buttons. 
Clicking the Cancel buttons returns to the previous view. 

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](./docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](./docs/backend.md#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](./docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
* [ ] There are no aXe warnings for UI.
* [ ] This works in IE.
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @willowbl00
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/162773385) for this change
