### PR TITLE
Standardize header styles for HHG+PPM SM flow

### DIFF
--- a/cypress/integration/mymove/hhgPPM.js
+++ b/cypress/integration/mymove/hhgPPM.js
@@ -418,12 +418,14 @@ function serviceMemberCanReviewMoveSummary() {
   });
 
   cy.get('.wizard-header .usa-width-one-third').should('not.contain', 'Move Setup');
-  cy.get('.wizard-header .usa-width-one-third').should('not.contain', 'Review');
+  cy.get('.wizard-header .usa-width-one-third').should('contain', 'Review');
   cy
     .get('.wizard-header .progress-timeline .step')
     .first()
     .should('contain', 'Move Setup');
   cy.get('.wizard-header .progress-timeline .current').should('contain', 'Review');
+
+  cy.get('h2').should('contain', 'Review Move Details');
 
   cy.get('body').should($div => expect($div.text()).not.to.include('Government moves all of your stuff (HHG)'));
   cy.get('.ppm-container').should($div => {

--- a/src/scenes/Legalese/index.css
+++ b/src/scenes/Legalese/index.css
@@ -3,6 +3,10 @@
   justify-content: space-between;
 }
 
+h2 {
+  margin-top: 1em;
+}
+
 .instructions {
   margin: 0;
 }

--- a/src/scenes/Legalese/index.css
+++ b/src/scenes/Legalese/index.css
@@ -7,8 +7,11 @@
   margin: 0;
 }
 
+.usa-width-one-whole > h3 {
+  margin-top: 1em;
+}
+
 .signature-form {
-  padding: 2rem;
   margin-top: 1em;
 }
 

--- a/src/scenes/Legalese/index.jsx
+++ b/src/scenes/Legalese/index.jsx
@@ -80,8 +80,8 @@ export class SignedCertification extends Component {
               initialValues={initialValues}
               discardOnBack
             >
-              <div className="usa-grid">
-                <div className="usa-width-one-whole">
+              <div className="usa-width-one-whole">
+                <div>
                   <h2>Now for the official part...</h2>
                   <span className="box_top">
                     <p className="instructions">

--- a/src/scenes/Legalese/index.jsx
+++ b/src/scenes/Legalese/index.jsx
@@ -81,47 +81,49 @@ export class SignedCertification extends Component {
               discardOnBack
             >
               <div className="usa-grid">
-                <h2>Now for the official part...</h2>
-                <span className="box_top">
-                  <p className="instructions">
-                    Before officially booking your move, please carefully read and then sign the following.
-                  </p>
-                  <a className="pdf" onClick={this.print}>
-                    Print
-                  </a>
-                </span>
+                <div className="usa-width-one-whole">
+                  <h2>Now for the official part...</h2>
+                  <span className="box_top">
+                    <p className="instructions">
+                      Before officially booking your move, please carefully read and then sign the following.
+                    </p>
+                    <a className="pdf" onClick={this.print}>
+                      Print
+                    </a>
+                  </span>
 
-                <CertificationText certificationText={this.props.certificationText} />
+                  <CertificationText certificationText={this.props.certificationText} />
 
-                <div className="signature-box">
-                  <h3>SIGNATURE</h3>
-                  <p>
-                    In consideration of said household goods or mobile homes being shipped at Government expense,{' '}
-                    <strong>I hereby agree to the certifications stated above.</strong>
-                  </p>
-                  <div className="signature-fields">
-                    <SwaggerField
-                      className="signature"
-                      fieldName="signature"
-                      swagger={this.props.schema}
-                      required
-                      disabled={!!initialValues.signature}
-                    />
-                    <SwaggerField
-                      className="signature-date"
-                      fieldName="date"
-                      swagger={this.props.schema}
-                      required
-                      disabled
-                    />
+                  <div className="signature-box">
+                    <h3>SIGNATURE</h3>
+                    <p>
+                      In consideration of said household goods or mobile homes being shipped at Government expense,{' '}
+                      <strong>I hereby agree to the certifications stated above.</strong>
+                    </p>
+                    <div className="signature-fields">
+                      <SwaggerField
+                        className="signature"
+                        fieldName="signature"
+                        swagger={this.props.schema}
+                        required
+                        disabled={!!initialValues.signature}
+                      />
+                      <SwaggerField
+                        className="signature-date"
+                        fieldName="date"
+                        swagger={this.props.schema}
+                        required
+                        disabled
+                      />
+                    </div>
                   </div>
-                </div>
 
-                {hasSubmitError && (
-                  <Alert type="error" heading="Server Error">
-                    There was a problem saving your signature. Please reload the page.
-                  </Alert>
-                )}
+                  {hasSubmitError && (
+                    <Alert type="error" heading="Server Error">
+                      There was a problem saving your signature. Please reload the page.
+                    </Alert>
+                  )}
+                </div>
               </div>
             </SignatureWizardForm>
           )}

--- a/src/scenes/Moves/Ppm/DateAndLocation.css
+++ b/src/scenes/Moves/Ppm/DateAndLocation.css
@@ -3,6 +3,10 @@ label.inline_radio {
 	margin-bottom: 1px;
 }
 
+h2 {
+  margin-top: 1em;
+}
+
 .grey {
 	color: rgb(100, 100, 100);
 }

--- a/src/scenes/Moves/Ppm/DateAndLocation.jsx
+++ b/src/scenes/Moves/Ppm/DateAndLocation.jsx
@@ -111,7 +111,7 @@ export class DateAndLocation extends Component {
           initialValues={initialValues}
           enableReinitialize={true} //this is needed as the pickup_postal_code value needs to be initialized to the users residential address
         >
-          <h2 className="sm-heading">PPM Dates & Locations</h2>
+          <h2>PPM Dates & Locations</h2>
           {isHHGPPMComboMove && <div>Great! Let's review your pickup and destination information.</div>}
           <h3> Move Date </h3>
           <SwaggerField

--- a/src/scenes/Moves/Ppm/Size.css
+++ b/src/scenes/Moves/Ppm/Size.css
@@ -1,5 +1,6 @@
-.ppm-size-content h3 {
-  margin-bottom: 3rem;
+.ppm-size-content h2 {
+  margin-bottom: 1em;
+  margin-top: 1em;
   font-weight: bold;
   font-size: 2.5rem;
 }

--- a/src/scenes/Moves/Ppm/Size.jsx
+++ b/src/scenes/Moves/Ppm/Size.jsx
@@ -136,14 +136,20 @@ export class PpmSize extends Component {
     };
 
     return (
-      <div className="usa-grid-full ppm-size-content">
-        {weightInfo && (
-          <Fragment>
-            <h3>How much will you move?</h3>
-            {<EntitlementBar hhgPPMEntitlementMessage={weightRemainingEntitlementMsg()} entitlement={entitlement} />}
-            <BigButtonGroup selectedOption={selectedOption} onClick={this.onMoveTypeSelected} weightInfo={weightInfo} />
-          </Fragment>
-        )}
+      <div className="usa-grid-full">
+        <div className="ppm-size-content">
+          {weightInfo && (
+            <Fragment>
+              <h2>How much will you move?</h2>
+              {<EntitlementBar hhgPPMEntitlementMessage={weightRemainingEntitlementMsg()} entitlement={entitlement} />}
+              <BigButtonGroup
+                selectedOption={selectedOption}
+                onClick={this.onMoveTypeSelected}
+                weightInfo={weightInfo}
+              />
+            </Fragment>
+          )}
+        </div>
       </div>
     );
   }

--- a/src/scenes/Moves/Ppm/Weight.css
+++ b/src/scenes/Moves/Ppm/Weight.css
@@ -6,6 +6,10 @@ div.info {
   border-radius: 7px;
 }
 
+form > h2 {
+  margin-top: 1em;
+}
+
 .info > h3 {
   margin-top: 0;
 }

--- a/src/scenes/Moves/WizardHeader.css
+++ b/src/scenes/Moves/WizardHeader.css
@@ -4,6 +4,11 @@
   max-width: 75px;
 }
 
-.wizard-header p {
+.wizard-header h3 {
   display: inline;
+}
+
+.icon {
+  height: 75;
+  width: auto;
 }

--- a/src/scenes/Moves/WizardHeader.jsx
+++ b/src/scenes/Moves/WizardHeader.jsx
@@ -7,7 +7,7 @@ const WizardHeader = ({ icon, right, title }) => (
     <div className="usa-grid">
       <div className="usa-width-one-third">
         <img className="icon" src={icon} alt="" />
-        <p>{title}</p>
+        <h3>{title}</h3>
       </div>
       <div className="usa-width-two-thirds">
         <div style={{ float: 'right', marginRight: '-17px' }}>{right}</div>

--- a/src/scenes/Review/Review.css
+++ b/src/scenes/Review/Review.css
@@ -2,6 +2,10 @@
   margin-top: 1.5rem;
 }
 
+.review-title > h2 {
+  margin-top: 1.5em;
+}
+
 .review-content {
   border-top: 1px solid black;
   padding-bottom: 2.5rem;

--- a/src/scenes/Review/Review.jsx
+++ b/src/scenes/Review/Review.jsx
@@ -6,6 +6,8 @@ import { connect } from 'react-redux';
 import { get } from 'lodash';
 import WizardHeader from 'scenes/Moves/WizardHeader';
 import { ProgressTimeline, ProgressTimelineStep } from 'shared/ProgressTimeline';
+import reviewGray from 'shared/icon/review-gray.svg';
+import './Review.css';
 
 class Review extends Component {
   componentDidMount() {
@@ -18,6 +20,8 @@ class Review extends Component {
       <div>
         {isHHGPPMComboMove && (
           <WizardHeader
+            icon={reviewGray}
+            title="Review"
             right={
               <ProgressTimeline>
                 <ProgressTimelineStep name="Move Setup" completed />
@@ -27,8 +31,10 @@ class Review extends Component {
           />
         )}
         <WizardPage handleSubmit={no_op} pageList={pages} pageKey={pageKey} pageIsValid={true}>
-          <h1>Review</h1>
-          <p>You're almost done! Please review your details before we finalize the move.</p>
+          <div className="edit-title">
+            <h2>Review move details</h2>
+            <p>You're almost done! Please review your details before we finalize the move.</p>
+          </div>
           <Summary />
         </WizardPage>
       </div>

--- a/src/scenes/Review/Review.jsx
+++ b/src/scenes/Review/Review.jsx
@@ -32,7 +32,7 @@ class Review extends Component {
         )}
         <WizardPage handleSubmit={no_op} pageList={pages} pageKey={pageKey} pageIsValid={true}>
           <div className="edit-title">
-            <h2>Review move details</h2>
+            <h2>Review Move Details</h2>
             <p>You're almost done! Please review your details before we finalize the move.</p>
           </div>
           <Summary />


### PR DESCRIPTION
## Description

Made some tweaks to standardize the header styles for the HHG + PPM Service member flow.

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make db_populate_e2e
```

You can test the flow as the the hhgforppm@award.ed. Check that the spacing between the horizontal line and the title header are the same on each page, and the text for the wizard header is an h3 and the title header is an h2 on each page through the flow.

## Code Review Verification Steps

* [x] Design review approved
* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* 

## Screenshots
New:
<img width="980" alt="screen shot 2018-12-21 at 3 48 07 pm" src="https://user-images.githubusercontent.com/5531789/50367885-2810ae00-0538-11e9-82e0-1bc534384a7e.png">
Old:
<img width="1022" alt="screen shot 2018-12-21 at 3 59 13 pm" src="https://user-images.githubusercontent.com/5531789/50368025-90ac5a80-0539-11e9-989f-9b7639afc813.png">

New:
<img width="963" alt="screen shot 2018-12-21 at 3 48 13 pm" src="https://user-images.githubusercontent.com/5531789/50367884-2810ae00-0538-11e9-8d6d-d75163d6751c.png">
Old:
<img width="1026" alt="screen shot 2018-12-21 at 3 59 20 pm" src="https://user-images.githubusercontent.com/5531789/50368029-9c981c80-0539-11e9-8566-da937616559b.png">

New:
<img width="1000" alt="screen shot 2018-12-21 at 3 48 20 pm" src="https://user-images.githubusercontent.com/5531789/50367883-2810ae00-0538-11e9-80c3-9f6e00a72722.png">
Old:
<img width="1009" alt="screen shot 2018-12-21 at 3 59 36 pm" src="https://user-images.githubusercontent.com/5531789/50368037-a9b50b80-0539-11e9-85cd-f95362794d2f.png">

New:
<img width="973" alt="screen shot 2018-12-21 at 3 48 27 pm" src="https://user-images.githubusercontent.com/5531789/50367882-2810ae00-0538-11e9-9dbb-77de3e5be020.png">
Old:
<img width="1083" alt="screen shot 2018-12-21 at 3 59 42 pm" src="https://user-images.githubusercontent.com/5531789/50368038-b5083700-0539-11e9-9798-05b792e3f1e5.png">

New:
<img width="985" alt="screen shot 2018-12-21 at 3 48 37 pm" src="https://user-images.githubusercontent.com/5531789/50367881-2810ae00-0538-11e9-8c61-8814e2f8c5a8.png">
Old:
<img width="1017" alt="screen shot 2018-12-21 at 3 59 50 pm" src="https://user-images.githubusercontent.com/5531789/50368041-bd607200-0539-11e9-8ca5-6baf100862d7.png">



