### PR TITLE
Renders "Invoiced" status in preapproval panel

### DIFF
--- a/src/shared/PreApprovalRequest/PreApprovalRequest.jsx
+++ b/src/shared/PreApprovalRequest/PreApprovalRequest.jsx
@@ -9,6 +9,15 @@ import faCheck from '@fortawesome/fontawesome-free-solid/faCheck';
 import faPencil from '@fortawesome/fontawesome-free-solid/faPencilAlt';
 import faTimes from '@fortawesome/fontawesome-free-solid/faTimes';
 
+function formatStatus(lineItem) {
+  let formattedStatus = lineItem.status;
+  if (lineItem.invoice_id) {
+    formattedStatus = 'Invoiced';
+  }
+
+  return formattedStatus[0].toUpperCase() + formattedStatus.substring(1).toLowerCase();
+}
+
 export function renderActionIcons(status, onEdit, onApproval, onDelete, shipmentLineItemId) {
   // Only office users can approve requests.
   // If the request is approved/invoiced, they cannot be edited, only deleted.
@@ -74,7 +83,8 @@ export class PreApprovalRequest extends Component {
   };
   render() {
     const row = this.props.shipmentLineItem;
-    const showButtons = this.props.isActionable && !this.state.showDeleteForm && !this.state.showEditForm;
+    const showButtons =
+      this.props.isActionable && !this.state.showDeleteForm && !this.state.showEditForm && !row.invoice_id;
     if (this.state.showEditForm) {
       return (
         <tr>
@@ -91,7 +101,7 @@ export class PreApprovalRequest extends Component {
       );
     } else {
       let status = '';
-      if (isOfficeSite) {
+      if (isOfficeSite && !row.invoice_id) {
         status = renderStatusIcon(row.status);
       }
       const deleteActiveClass = this.state.showDeleteForm ? 'delete-active' : '';
@@ -106,7 +116,7 @@ export class PreApprovalRequest extends Component {
             <td align="left">{formatDate(row.submitted_date)}</td>
             <td align="left">
               <span className="status">{status}</span>
-              {row.status[0].toUpperCase() + row.status.substring(1).toLowerCase()}
+              {formatStatus(row)}
             </td>
             <td>
               {showButtons && renderActionIcons(row.status, this.onEdit, this.props.onApproval, this.onDelete, row.id)}


### PR DESCRIPTION
## Description

Renders "Invoiced" as description after line items have been invoiced. Also prevents rendering of action icons after being invoided

## Code Review Verification Steps
* [ ] Request review from a member of a different team.

## Screenshots
<img width="818" alt="screen shot 2018-12-21 at 9 13 15 pm" src="https://user-images.githubusercontent.com/5151804/50369550-80aa7000-0565-11e9-97d9-f6e6beec3172.png">