### PR TITLE
Removing dead code

### DIFF
--- a/pkg/edi/invoice/generator.go
+++ b/pkg/edi/invoice/generator.go
@@ -172,16 +172,6 @@ func generate858CShipment(shipment models.Shipment, sequenceNum int) ([]edisegme
 
 func getHeadingSegments(shipment models.Shipment, sequenceNum int) ([]edisegment.Segment, error) {
 	segments := []edisegment.Segment{}
-	/* for bx
-	if shipment.TransportationServiceProviderID == nil {
-		return "", errors.New("Shipment is missing TSP ID")
-	}
-	var tsp models.TransportationServiceProvider
-	err := db.Find(&tsp, shipment.TransportationServiceProviderID)
-	if err != nil {
-		return "", err
-	}
-	*/
 
 	name := ""
 	if shipment.ServiceMember.LastName != nil {

--- a/pkg/handlers/internalapi/shipments.go
+++ b/pkg/handlers/internalapi/shipments.go
@@ -19,7 +19,6 @@ import (
 	"github.com/transcom/mymove/pkg/gen/internalmessages"
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/models"
-	"github.com/transcom/mymove/pkg/rateengine"
 )
 
 func payloadForInvoiceModel(a *models.Invoice) *internalmessages.Invoice {
@@ -511,15 +510,8 @@ func (h ShipmentInvoiceHandler) Handle(params shipmentop.CreateAndSendHHGInvoice
 		return handlers.ResponseForVErrors(h.Logger(), verrs, err)
 	}
 
-	engine := rateengine.NewRateEngine(h.DB(), h.Logger(), h.Planner())
-	// Run rate engine on shipment --> returns CostByShipment Struct
-	costByShipment, err := engine.HandleRunOnShipment(shipment)
-	if err != nil {
-		return handlers.ResponseForError(h.Logger(), err)
-	}
-
 	// pass value into generator --> edi string
-	invoice858C, err := ediinvoice.Generate858C(costByShipment.Shipment, h.DB(), h.SendProductionInvoice(), clock.New())
+	invoice858C, err := ediinvoice.Generate858C(shipment, h.DB(), h.SendProductionInvoice(), clock.New())
 	if err != nil {
 		return handlers.ResponseForError(h.Logger(), err)
 	}


### PR DESCRIPTION
## Description

While doing some code reviews, I found two places that appeared to have dead code / comments.

1. There was some commented out code that tries to find the TSP for the shipment when generating the EDI. This appears to have been a placeholder. That is now being done further down in the EDI generation, where we grab the SCAC and SupplierID
1. We were calling the RateEngine in the Invoice handler. That doesn't seem necessary anymore, because we price the shipment earlier in the process. In fact, from the code that I've deleted, it looks like we just send `Shipment` into the rate engine, and then extract the shipment again out of the pricing data that we get back... aka, a no-op.

Let me know if there's a reason either of these should be kept.