### PR TITLE
Acceptance Tests for Webserver

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -240,6 +240,28 @@ jobs:
             - ~/.cache/pre-commit
       - announce_failure
 
+  # `acceptance_tests` runs acceptance tests for the webserver against a local environment.
+  acceptance_tests:
+    executor: mymove_medium
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - go-pkg-dep-sources-{{ checksum "Gopkg.lock" }}
+      - restore_cache:
+          keys:
+            - mymove-vendor-{{ checksum "Gopkg.lock" }}
+      - run:
+          name: Run make server_generate
+          command: make server_generate
+      - run:
+          name: Run acceptance tests
+          command: make webserver_test
+          environment:
+            LOGIN_GOV_HOSTNAME: idp.int.identitysandbox.gov
+            DOD_CA_PACKAGE: /home/circleci/go/src/github.com/transcom/mymove/config/tls/Certificates_PKCS7_v5.4_DoD.der.p7b
+      - announce_failure
+
   # `integration_tests_mymove` runs integration tests using Cypress.  https://www.cypress.io/
   integration_tests_mymove:
     executor: mymove_medium
@@ -268,6 +290,8 @@ jobs:
       - store_test_results:
           path: cypress/results
       - announce_failure
+
+  # `integration_tests_office` runs integration tests using Cypress.  https://www.cypress.io/
   integration_tests_office:
     executor: mymove_medium
     steps:
@@ -295,6 +319,8 @@ jobs:
       - store_test_results:
           path: cypress/results
       - announce_failure
+
+  # `integration_tests_tsp` runs integration tests using Cypress.  https://www.cypress.io/
   integration_tests_tsp:
     executor: mymove_medium
     steps:
@@ -564,10 +590,16 @@ workflows:
             - pre_deps_golang
             - pre_deps_yarn
 
+      - acceptance_tests:
+          requires:
+            - pre_deps_golang
+            - pre_deps_yarn
+
       - integration_tests_mymove:
           requires:
             - pre_deps_golang
             - pre_deps_yarn
+            - acceptance_tests
           # if testing on experimental, you can disable these tests by using the commented block below.
           #filters:
           #  branches:
@@ -577,6 +609,7 @@ workflows:
           requires:
             - pre_deps_golang
             - pre_deps_yarn
+            - acceptance_tests
           # if testing on experimental, you can disable these tests by using the commented block below.
           #filters:
           #  branches:
@@ -586,6 +619,7 @@ workflows:
           requires:
             - pre_deps_golang
             - pre_deps_yarn
+            - acceptance_tests
           # if testing on experimental, you can disable these tests by using the commented block below.
           #filters:
           #  branches:
@@ -617,6 +651,7 @@ workflows:
             - pre_test
             - client_test
             - server_test
+            - acceptance_tests
             - build_app
             # - build_tools # tools don't need to build to deploy to experimental
             - build_migrations
@@ -646,6 +681,7 @@ workflows:
             - build_app
             - build_tools
             - build_migrations
+            - acceptance_tests
             - integration_tests_mymove
             - integration_tests_office
             - integration_tests_tsp

--- a/bin/check_gopath.sh
+++ b/bin/check_gopath.sh
@@ -18,11 +18,19 @@ if [ ! "$PWD" -ef "$goodpath" ]; then
   exit 1
 fi
 
-binpath=${gpath}/bin
-
-if [[ ! ":$PATH:" == *":$binpath:"* ]]; then
-  echo "In order for go dependencies to be runnable, \$GOPATH/bin must be in your \$PATH"
-  echo "Please add $gpath/bin to your \$PATH in your .bash_profile"
-  echo "Expected: $binpath"
-  echo "Actual: $PATH"
+# shellcheck disable=SC2154
+if [[ "$gpath" == *"$home" ]]; then
+  if [[ ! ":$PATH:" == *":$gpath/bin:"* ]] && [[ ! ":$PATH:" == *":~${gpath#$HOME}/bin:"* ]]; then
+    echo "In order for go dependencies to be runnable, \$GOPATH/bin must be in your \$PATH"
+    echo "Please add $gpath/bin to your \$PATH in your .bash_profile"
+    echo "Expected: $gpath/bin"
+    echo "Actual: $PATH"
+  fi
+else
+  if [[ ! ":$PATH:" == *":$gpath/bin:"* ]]; then
+    echo "In order for go dependencies to be runnable, \$GOPATH/bin must be in your \$PATH"
+    echo "Please add $gpath/bin to your \$PATH in your .bash_profile"
+    echo "Expected: $gpath/bin"
+    echo "Actual: $PATH"
+  fi
 fi

--- a/cmd/webserver/main_test.go
+++ b/cmd/webserver/main_test.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/suite"
+	"go.uber.org/zap"
+
+	"github.com/transcom/mymove/pkg/logging"
+)
+
+type webServerSuite struct {
+	suite.Suite
+	viper  *viper.Viper
+	logger *zap.Logger
+}
+
+func TestWebServerSuite(t *testing.T) {
+
+	flag := pflag.CommandLine
+	initFlags(flag)
+	flag.Parse([]string{})
+
+	v := viper.New()
+	v.BindPFlags(flag)
+	v.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
+	v.AutomaticEnv()
+
+	logger, err := logging.Config(v.GetString("env"), v.GetBool("debug-logging"))
+	if err != nil {
+		log.Fatalf("Failed to initialize Zap logging due to %v", err)
+	}
+
+	ss := &webServerSuite{
+		viper:  v,
+		logger: logger,
+	}
+
+	if testEnv := os.Getenv("TEST_ACC_ENV"); len(testEnv) > 0 {
+		filename := fmt.Sprintf("%s/config/env/%s.env", os.Getenv("TEST_ACC_CWD"), testEnv)
+		logger.Info(fmt.Sprintf("Loading environment variables from file %s", filename))
+		ss.applyContext(ss.loadContext(filename))
+	}
+
+	suite.Run(t, ss)
+}
+
+func (suite *webServerSuite) loadContext(variablesFile string) map[string]string {
+	ctx := map[string]string{}
+	if len(variablesFile) > 0 {
+		// Read contents of variables file into vars
+		vars, err := ioutil.ReadFile(variablesFile)
+		if err != nil {
+			suite.logger.Fatal(fmt.Sprintf("error reading variables from file %s", variablesFile))
+		}
+
+		// Adds variables from file into context
+		for _, x := range strings.Split(string(vars), "\n") {
+			// If a line is empty or starts with #, then skip.
+			if len(x) > 0 && x[0] != '#' {
+				// Split each line on the first equals sign into []string{name, value}
+				pair := strings.SplitAfterN(x, "=", 2)
+				ctx[pair[0][0:len(pair[0])-1]] = pair[1]
+			}
+		}
+	}
+	return ctx
+}
+
+func (suite *webServerSuite) applyContext(ctx map[string]string) {
+	for k, v := range ctx {
+		suite.logger.Info("Overriding " + k)
+		suite.viper.Set(strings.Replace(strings.ToLower(k), "_", "-", -1), v)
+	}
+}
+
+func (suite *webServerSuite) TestConfigProtocols() {
+	suite.Nil(checkProtocols(suite.viper))
+}
+
+func (suite *webServerSuite) TestConfigHosts() {
+	suite.Nil(checkHosts(suite.viper))
+}
+
+func (suite *webServerSuite) TestConfigPorts() {
+	suite.Nil(checkPorts(suite.viper))
+}
+
+func (suite *webServerSuite) TestConfigCSRF() {
+	suite.Nil(checkCSRF(suite.viper))
+}
+
+func (suite *webServerSuite) TestConfigEmail() {
+	suite.Nil(checkEmail(suite.viper))
+}
+
+func (suite *webServerSuite) TestConfigStorage() {
+	suite.Nil(checkStorage(suite.viper))
+}
+
+func (suite *webServerSuite) TestDODCertificates() {
+	_, _, err := initDODCertificates(suite.viper, suite.logger)
+	suite.Nil(err)
+}
+
+func (suite *webServerSuite) TestHoneycomb() {
+
+	if os.Getenv("TEST_ACC_HONEYCOMB") != "1" {
+		suite.logger.Info("Skipping TestHoneycomb")
+		return
+	}
+
+	enabled := initHoneycomb(suite.viper, suite.logger)
+	suite.True(enabled)
+}
+
+func (suite *webServerSuite) TestDatabase() {
+
+	if os.Getenv("TEST_ACC_DATABASE") != "1" {
+		suite.logger.Info("Skipping TestDatabase")
+		return
+	}
+
+	_, err := initDatabase(suite.viper, suite.logger)
+	suite.Nil(err)
+}

--- a/docs/how-to/run-go-tests.md
+++ b/docs/how-to/run-go-tests.md
@@ -14,6 +14,16 @@ All of the commands in this section assume that `test_db` is setup properly. Thi
 $ make db_test_reset
 ```
 
+## Run Acceptance Tests
+
+If you're adding a feature that requires new or modified configuration, it's a good idea to run acceptance tests against our environments before you merge into master.  You can run acceptance tests against an environment with:
+
+```console
+$ TEST_ACC_ENV=experimental make webserver_test
+```
+
+This command will first load the variables from the `config/env/*.env` file and then run `chamber exec` to pull the environments from AWS.  You can run acceptance tests for the database and honeycomb through environment variables with `TEST_ACC_DATABASE=1` and `TEST_ACC_HONEYCOMB=1`.
+
 ### Run All Tests in a Single Package
 
 ```console


### PR DESCRIPTION
## Description

Adds acceptance tests for webserver config, so we can essentially smoke test an environment context before deploying.  By default testing the database and honeycomb integrations is disabled, since it makes external connections.

Acceptance tests run before integration tests, since what's the point of running integration tests if the server won't even start properly.

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

- How to integrate into workflow?
- Update Deploy docs?
- How to integrate into CI/CD? Run against local environment before integration tests.

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
TEST_ACC_ENV=experimental make webserver_test
```

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](./docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](./docs/backend.md#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](./docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
* [ ] There are no aXe warnings for UI.
* [ ] This works in IE.
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @willowbl00
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/161134452) for this change

## Screenshots

<img width="801" alt="screen shot 2018-12-28 at 3 55 13 pm" src="https://user-images.githubusercontent.com/40467706/50531034-058f0f80-0ab9-11e9-9282-4a5e74688c28.png">
