### PR TITLE
Editing an HHG's move dates no longer requires additional review step after saving

### DIFF
--- a/cypress/integration/mymove/hhgPPM.js
+++ b/cypress/integration/mymove/hhgPPM.js
@@ -25,12 +25,30 @@ describe('service member adds a ppm to an hhg', function() {
     serviceMemberVerifiesContactInfoWasEdited();
     serviceMemberEditsBackupContactInfoSection();
     serviceMemberVerifiesBackupContactInfoWasEdited();
+    serviceMemberEditsHHGMoveDates();
     serviceMemberEditsPPMDatesAndLocations();
     serviceMemberVerifiesPPMDatesAndLocationsEdited();
     serviceMemberEditsPPMWeight();
     serviceMemberVerifiesPPMWeightsEdited();
   });
 });
+
+function serviceMemberEditsHHGMoveDates() {
+  cy
+    .get('.ppm-container .edit-section-link')
+    .eq(0)
+    .click();
+  // TODO: Currently does not support changing move dates for 2019. Add test to edit dates ewhen fixed
+
+  cy
+    .get('button')
+    .contains('Save')
+    .click();
+
+  cy.location().should(loc => {
+    expect(loc.pathname).to.match(/^\/moves\/[^/]+\/edit/);
+  });
+}
 
 function serviceMemberVerifiesHHGPPMSummary() {
   cy.location().should(loc => {

--- a/src/scenes/Review/EditShipment.jsx
+++ b/src/scenes/Review/EditShipment.jsx
@@ -102,7 +102,7 @@ function mapDispatchToProps(dispatch, ownProps) {
       dispatch(updateShipment(updateShipmentLabel, shipmentID, values)).then(function(action) {
         if (!action.error) {
           const moveID = Object.values(action.entities.shipments)[0].move_id;
-          dispatch(push(`/moves/${moveID}/review`));
+          dispatch(push(`/moves/${moveID}/edit`));
         }
       });
     },

--- a/src/scenes/Review/EditShipment.jsx
+++ b/src/scenes/Review/EditShipment.jsx
@@ -98,11 +98,15 @@ function mapDispatchToProps(dispatch, ownProps) {
     onDidMount: function() {
       dispatch(getShipment(getShipmentLabel, shipmentID));
     },
-    updateShipment: function(values) {
+    updateShipment: function(values, shipment) {
       dispatch(updateShipment(updateShipmentLabel, shipmentID, values)).then(function(action) {
         if (!action.error) {
           const moveID = Object.values(action.entities.shipments)[0].move_id;
-          dispatch(push(`/moves/${moveID}/edit`));
+          if (shipment.status !== 'DRAFT') {
+            dispatch(push(`/moves/${moveID}/edit`));
+          } else {
+            dispatch(push(`/moves/${moveID}/review`));
+          }
         }
       });
     },
@@ -116,7 +120,7 @@ function mergeProps(stateProps, dispatchProps, ownProps) {
   return Object.assign({}, stateProps, dispatchProps, ownProps, {
     updateShipment: function(event) {
       event.preventDefault();
-      dispatchProps.updateShipment(stateProps.formValues);
+      dispatchProps.updateShipment(stateProps.formValues, stateProps.shipment);
     },
     returnToReview: function(event) {
       event.preventDefault();

--- a/src/scenes/Review/ServiceMemberSummary.jsx
+++ b/src/scenes/Review/ServiceMemberSummary.jsx
@@ -224,7 +224,7 @@ function ServiceMemberSummary(props) {
 
 ServiceMemberSummary.propTypes = {
   backupContacts: PropTypes.array.isRequired,
-  serviceMember: PropTypes.object.isRequired,
+  serviceMember: PropTypes.object,
   schemaRank: PropTypes.object.isRequired,
   schemaAffiliation: PropTypes.object.isRequired,
   schemaOrdersType: PropTypes.object.isRequired,


### PR DESCRIPTION
## Description

Editing a submitted HHG's move dates should no longer take the service member to the review and legalese page

## Reviewer Notes
- Actually editing the move dates currently does not work because all available dates are next year. Will Add tests of changing the move dates when this is fixed.

## Setup
`make server_run`
`make client_run`
Log in to an account with a submitted HHG
Edit the HHG's move dates

## Code Review Verification Steps
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/162521754) for this change

