### PR TITLE
Sb 162627070 entitlements missing

### DIFF
--- a/cypress/integration/tsp/customerInfoPanel.js
+++ b/cypress/integration/tsp/customerInfoPanel.js
@@ -4,11 +4,18 @@ describe('TSP User Checks Customer Info Panel', function() {
     cy.signIntoTSP();
   });
   it('tsp user sees customer info', function() {
-    tspUserViewsCustomerInfo();
+    tspUserOpensAShipment('BACON1');
+    tspUserViewsCustomerContactInfo();
+    tspUserViewsBackupContactInfo();
+    tspUserViewsEntitlementInfo({ weight: '8,000', progear: '2,000', spouse: '500' });
+  });
+  it('tsp user sees customer info', function() {
+    tspUserOpensAShipment('NDNSPG');
+    tspUserViewsEntitlementInfo({ weight: '5,000', progear: '2,000', spouse: '0' });
   });
 });
 
-function tspUserOpensAShipment() {
+function tspUserOpensAShipment(shipment) {
   // Open new shipments queue
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/queues\/new/);
@@ -17,7 +24,7 @@ function tspUserOpensAShipment() {
   // Find a shipment and open it
   cy
     .get('div')
-    .contains('BACON1')
+    .contains(shipment)
     .dblclick();
 
   cy.location().should(loc => {
@@ -64,20 +71,13 @@ function tspUserViewsBackupContactInfo() {
     .and('match', /mailto:email@example.com/);
 }
 
-function tspUserViewsEntitlementInfo() {
+function tspUserViewsEntitlementInfo({ weight, progear, spouse }) {
   // Check Entitlements is bolded
   cy.get('.customer-info').contains('b', 'Entitlements');
 
   // Check the hhg entitlements
-  cy.get('.customer-info').contains('8,000 lbs');
+  cy.get('.customer-info').contains(`${weight} lbs`);
 
   // Check for pro-gear and spouse pro-gear
-  cy.get('.customer-info').contains('Pro-gear: 2,000 lbs / Spouse: 500 ');
-}
-
-function tspUserViewsCustomerInfo() {
-  tspUserOpensAShipment();
-  tspUserViewsCustomerContactInfo();
-  tspUserViewsBackupContactInfo();
-  tspUserViewsEntitlementInfo();
+  cy.get('.customer-info').contains(`Pro-gear: ${progear} lbs / Spouse: ${spouse} lbs`);
 }

--- a/pkg/handlers/internalapi/moves_test.go
+++ b/pkg/handlers/internalapi/moves_test.go
@@ -296,6 +296,8 @@ func (suite *HandlerSuite) TestShowMoveDatesSummaryHandler() {
 			ReportByDate:     time.Date(2018, 10, 31, 0, 0, 0, 0, time.UTC),
 			NewDutyStationID: newDutyStation.ID,
 			NewDutyStation:   newDutyStation,
+			HasDependents:    true,
+			SpouseHasProGear: true,
 		},
 	})
 

--- a/pkg/handlers/internalapi/shipments_test.go
+++ b/pkg/handlers/internalapi/shipments_test.go
@@ -26,7 +26,12 @@ func (suite *HandlerSuite) verifyAddressFields(expected, actual *internalmessage
 }
 
 func (suite *HandlerSuite) TestCreateShipmentHandlerAllValues() {
-	move := testdatagen.MakeMove(suite.TestDB(), testdatagen.Assertions{})
+	move := testdatagen.MakeMove(suite.TestDB(), testdatagen.Assertions{
+		Order: models.Order{
+			HasDependents:    true,
+			SpouseHasProGear: true,
+		},
+	})
 	sm := move.Orders.ServiceMember
 
 	// Make associated lookup table records.
@@ -236,7 +241,12 @@ func (suite *HandlerSuite) TestPatchShipmentsHandlerHappyPath() {
 }
 
 func (suite *HandlerSuite) TestSetShipmentDates() {
-	move := testdatagen.MakeMove(suite.TestDB(), testdatagen.Assertions{})
+	move := testdatagen.MakeMove(suite.TestDB(), testdatagen.Assertions{
+		Order: models.Order{
+			HasDependents:    true,
+			SpouseHasProGear: true,
+		},
+	})
 	sm := move.Orders.ServiceMember
 	shipment := testdatagen.MakeShipment(suite.TestDB(), testdatagen.Assertions{
 		Shipment: models.Shipment{

--- a/pkg/handlers/publicapi/moves.go
+++ b/pkg/handlers/publicapi/moves.go
@@ -25,8 +25,8 @@ func payloadForMoveModel(move *models.Move) *apimessages.Move {
 	return &apimessages.Move{
 		SelectedMoveType: &SelectedMoveType,
 		OrdersID:         handlers.FmtUUID(move.OrdersID),
-		HasDependents:    *handlers.FmtBool(move.Orders.HasDependents),
-		SpouseHasProGear: *handlers.FmtBool(move.Orders.SpouseHasProGear),
+		HasDependents:    handlers.FmtBool(move.Orders.HasDependents),
+		SpouseHasProGear: handlers.FmtBool(move.Orders.SpouseHasProGear),
 		Status:           apimessages.MoveStatus(move.Status),
 		Locator:          swag.String(move.Locator),
 		CancelReason:     swag.String(cancelReason),

--- a/pkg/testdatagen/make_order.go
+++ b/pkg/testdatagen/make_order.go
@@ -48,6 +48,8 @@ func MakeOrder(db *pop.Connection, assertions Assertions) models.Order {
 	TAC := "F8E1"
 	SAC := "SAC"
 	departmentIndicator := "AIR_FORCE"
+	hasDependents := assertions.Order.HasDependents || false
+	spouseHasProGear := assertions.Order.SpouseHasProGear || false
 
 	order := models.Order{
 		ServiceMember:       sm,
@@ -60,8 +62,8 @@ func MakeOrder(db *pop.Connection, assertions Assertions) models.Order {
 		ReportByDate:        time.Date(2018, time.August, 1, 0, 0, 0, 0, time.UTC),
 		OrdersType:          internalmessages.OrdersTypePERMANENTCHANGEOFSTATION,
 		OrdersNumber:        &ordersNumber,
-		HasDependents:       true,
-		SpouseHasProGear:    true,
+		HasDependents:       hasDependents,
+		SpouseHasProGear:    spouseHasProGear,
 		Status:              models.OrderStatusDRAFT,
 		TAC:                 &TAC,
 		SAC:                 &SAC,

--- a/pkg/testdatagen/make_ppm.go
+++ b/pkg/testdatagen/make_ppm.go
@@ -52,5 +52,10 @@ func MakePPM(db *pop.Connection, assertions Assertions) models.PersonallyProcure
 
 // MakeDefaultPPM makes a PPM with default values
 func MakeDefaultPPM(db *pop.Connection) models.PersonallyProcuredMove {
-	return MakePPM(db, Assertions{})
+	return MakePPM(db, Assertions{
+		Order: models.Order{
+			HasDependents:    true,
+			SpouseHasProGear: true,
+		},
+	})
 }

--- a/pkg/testdatagen/make_shipment_offer_records.go
+++ b/pkg/testdatagen/make_shipment_offer_records.go
@@ -183,6 +183,8 @@ func CreateShipmentOfferData(db *pop.Connection, numTspUsers int, numShipments i
 				NewDutyStation:   newDutyStation,
 				Status:           orderStatus,
 				OrdersTypeDetail: &ordTypeDetHHGPermit,
+				HasDependents:    true,
+				SpouseHasProGear: true,
 			},
 			Move: models.Move{
 				SelectedMoveType: &selectedMoveType,

--- a/pkg/testdatagen/scenario/e2ebasic.go
+++ b/pkg/testdatagen/scenario/e2ebasic.go
@@ -301,6 +301,10 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, log
 			Edipi:         models.StringPointer("8893308161"),
 			PersonalEmail: models.StringPointer(email),
 		},
+		Order: models.Order{
+			HasDependents:    true,
+			SpouseHasProGear: true,
+		},
 		Move: models.Move{
 			ID:      uuid.FromStringOrNil("173da49c-fcec-4d01-a622-3651e81c654e"),
 			Locator: "BLABLA",
@@ -348,6 +352,10 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, log
 			PersonalEmail: models.StringPointer(email),
 			DutyStationID: &fortGordon.ID,
 			DutyStation:   fortGordon,
+		},
+		Order: models.Order{
+			HasDependents:    true,
+			SpouseHasProGear: true,
 		},
 		Move: models.Move{
 			ID:      uuid.FromStringOrNil("8718c8ac-e0c6-423b-bdc6-af971ee05b9a"),
@@ -437,6 +445,10 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, log
 			LastName:      models.StringPointer("Submitted"),
 			Edipi:         models.StringPointer("4444567890"),
 			PersonalEmail: models.StringPointer(email),
+		},
+		Order: models.Order{
+			HasDependents:    true,
+			SpouseHasProGear: true,
 		},
 		Move: models.Move{
 			ID:               uuid.FromStringOrNil("56b8ef45-8145-487b-9b59-0e30d0d465fa"),
@@ -1667,7 +1679,9 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, log
 			SelectedMoveType: &selectedMoveTypeHHG,
 		},
 		Order: models.Order{
-			IssueDate: time.Date(2018, time.May, 20, 0, 0, 0, 0, time.UTC),
+			IssueDate:        time.Date(2018, time.May, 20, 0, 0, 0, 0, time.UTC),
+			HasDependents:    true,
+			SpouseHasProGear: true,
 		},
 		TrafficDistributionList: models.TrafficDistributionList{
 			ID:                uuid.FromStringOrNil("115f14f2-c982-4a54-a293-78935b61305d"),
@@ -1872,6 +1886,52 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, log
 	hhg32 := offer32.Shipment
 	hhg32.Move.Submit()
 	models.SaveMoveDependencies(db, &hhg32.Move)
+
+	/*
+	 * Service member with awarded shipment with no dependents and no spouse progear
+	 */
+	email = "nodepdents@nospousepro.gear"
+
+	offer33 := testdatagen.MakeShipmentOffer(db, testdatagen.Assertions{
+		User: models.User{
+			ID:            uuid.Must(uuid.FromString("9a292af8-0e2e-4140-8bd2-165aa24d5071")),
+			LoginGovEmail: email,
+		},
+		ServiceMember: models.ServiceMember{
+			ID:            uuid.FromStringOrNil("9672cf74-bbe6-4cb2-97c8-f4c342d310a1"),
+			FirstName:     models.StringPointer("No Dependents"),
+			LastName:      models.StringPointer("No Spouse Progear"),
+			Edipi:         models.StringPointer("4444567890"),
+			PersonalEmail: models.StringPointer(email),
+		},
+		Order: models.Order{
+			HasDependents:    false,
+			SpouseHasProGear: false,
+		},
+		Move: models.Move{
+			ID:               uuid.FromStringOrNil("3f8db9d7-db14-4f5c-a50b-0ae67ca3a225"),
+			Locator:          "NDNSPG",
+			SelectedMoveType: &selectedMoveTypeHHG,
+		},
+		TrafficDistributionList: models.TrafficDistributionList{
+			ID:                uuid.FromStringOrNil("89a1fe5a-0735-4d9f-8637-f1ec34081827"),
+			SourceRateArea:    "US62",
+			DestinationRegion: "11",
+			CodeOfService:     "D",
+		},
+		Shipment: models.Shipment{
+			Status:   models.ShipmentStatusAWARDED,
+			BookDate: &nowTime,
+		},
+		ShipmentOffer: models.ShipmentOffer{
+			TransportationServiceProviderID: tspUser.TransportationServiceProviderID,
+			Accepted:                        models.BoolPointer(true),
+		},
+	})
+
+	hhg33 := offer33.Shipment
+	hhg33.Move.Submit()
+	models.SaveMoveDependencies(db, &hhg33.Move)
 }
 
 // MakeHhgWithPpm creates an HHG user who has added a PPM

--- a/src/scenes/TransportationServiceProvider/CustomerInfo.jsx
+++ b/src/scenes/TransportationServiceProvider/CustomerInfo.jsx
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 import { get } from 'lodash';
 
 import { loadEntitlements } from './ducks';
+import { formatWeight } from 'shared/formatters';
 
 import FontAwesomeIcon from '@fortawesome/react-fontawesome';
 import faPhone from '@fortawesome/fontawesome-free-solid/faPhone';
@@ -11,16 +12,16 @@ import faComments from '@fortawesome/fontawesome-free-solid/faComments';
 import faEmail from '@fortawesome/fontawesome-free-solid/faEnvelope';
 
 function renderEntitlements(entitlements) {
-  const weightEntitlement = get(entitlements, 'weight', '0').toLocaleString();
-  const proGearEntitlement = get(entitlements, 'pro_gear', '0').toLocaleString();
-  const spouseProGearEntitlement = get(entitlements, 'pro_gear_spouse', '0').toLocaleString();
+  const weightEntitlement = formatWeight(get(entitlements, 'weight', '0'));
+  const proGearEntitlement = formatWeight(get(entitlements, 'pro_gear', '0'));
+  const spouseProGearEntitlement = formatWeight(get(entitlements, 'pro_gear_spouse', '0'));
 
   return (
     <React.Fragment>
       <b>Entitlements</b>
       <br />
-      {weightEntitlement} lbs <br />
-      Pro-gear: {proGearEntitlement} lbs / Spouse: {spouseProGearEntitlement} <br />
+      {weightEntitlement} <br />
+      Pro-gear: {proGearEntitlement} / Spouse: {spouseProGearEntitlement} <br />
     </React.Fragment>
   );
 }

--- a/swagger/api.yaml
+++ b/swagger/api.yaml
@@ -613,9 +613,11 @@ definitions:
       has_dependents:
         type: boolean
         title: Are dependents included in your orders?
+        default: false
       spouse_has_pro_gear:
         type: boolean
         title: Do you have a spouse who will need to move items related to their occupation (also known as spouse pro-gear)?
+        default: false
       status:
         $ref: '#/definitions/MoveStatus'
       locator:


### PR DESCRIPTION
## Description

Fix an API bug so that both `true` and `false` get returned from the API for specific data points. Without the default value, swagger will not include a `false` in the JSON payload.

Also, change the default values for our test objects since `false` is easier to override than `true`.

## Code Review Verification Steps
* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/n/projects/2181745/stories/162627070) for this change