### PR TITLE
rd/lt handle invoice flow when duplicates requests are received

### DIFF
--- a/pkg/handlers/internalapi/shipments.go
+++ b/pkg/handlers/internalapi/shipments.go
@@ -498,6 +498,20 @@ func (h ShipmentInvoiceHandler) Handle(params shipmentop.CreateAndSendHHGInvoice
 		return shipmentop.NewCreateAndSendHHGInvoiceConflict()
 	}
 
+	//for now we limit a shipment to 1 invoice
+	//if invoices exists and at least one is either in process or has succeeded then return 409
+	existingInvoices, err := models.FetchInvoicesForShipment(h.DB(), shipmentID)
+	if err != nil {
+		return handlers.ResponseForError(h.Logger(), err)
+	}
+	for _, invoice := range existingInvoices {
+		//if an invoice has started, is in process or has been submitted successfully then throw err
+		if invoice.Status != models.InvoiceStatusSUBMISSIONFAILURE {
+			payload := payloadForInvoiceModel(&invoice)
+			return shipmentop.NewCreateAndSendHHGInvoiceConflict().WithPayload(payload)
+		}
+	}
+
 	approver, err := models.FetchOfficeUserByID(h.DB(), session.OfficeUserID)
 	if err != nil {
 		return handlers.ResponseForError(h.Logger(), err)

--- a/src/shared/Invoice/InvoicePanel.jsx
+++ b/src/shared/Invoice/InvoicePanel.jsx
@@ -12,7 +12,13 @@ import {
   getAllShipmentLineItems,
   getShipmentLineItemsLabel,
 } from 'shared/Entities/modules/shipmentLineItems';
-import { selectSortedInvoices, createInvoice, createInvoiceLabel } from 'shared/Entities/modules/invoices';
+import {
+  selectSortedInvoices,
+  createInvoice,
+  createInvoiceLabel,
+  getShipmentInvoicesLabel,
+  getAllInvoices,
+} from 'shared/Entities/modules/invoices';
 import { getRequestStatus } from 'shared/Swagger/selectors';
 import UnbilledTable from 'shared/Invoice/UnbilledTable';
 import InvoiceTable from 'shared/Invoice/InvoiceTable';
@@ -22,9 +28,18 @@ import './InvoicePanel.css';
 
 export class InvoicePanel extends PureComponent {
   approvePayment = () => {
-    return this.props.createInvoice(createInvoiceLabel, this.props.shipmentId).then(() => {
-      return this.props.getAllShipmentLineItems(getShipmentLineItemsLabel, this.props.shipmentId);
-    });
+    return this.props
+      .createInvoice(createInvoiceLabel, this.props.shipmentId)
+      .then(() => {
+        return this.props.getAllShipmentLineItems(getShipmentLineItemsLabel, this.props.shipmentId);
+      })
+      .catch(err => {
+        let httpResCode = get(err, 'response.status');
+        if (httpResCode === 409) {
+          this.props.getAllInvoices(getShipmentInvoicesLabel, this.props.shipmentId);
+          return this.props.getAllShipmentLineItems(getShipmentLineItemsLabel, this.props.shipmentId);
+        }
+      });
   };
 
   render() {
@@ -81,6 +96,6 @@ const mapStateToProps = (state, ownProps) => {
 };
 
 function mapDispatchToProps(dispatch) {
-  return bindActionCreators({ createInvoice, getAllShipmentLineItems }, dispatch);
+  return bindActionCreators({ createInvoice, getAllShipmentLineItems, getAllInvoices }, dispatch);
 }
 export default connect(mapStateToProps, mapDispatchToProps)(InvoicePanel);

--- a/src/shared/Invoice/InvoicePaymentAlert.jsx
+++ b/src/shared/Invoice/InvoicePaymentAlert.jsx
@@ -1,6 +1,7 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { get } from 'lodash';
+import moment from 'moment';
 
 import Alert from 'shared/Alert';
 import './InvoicePanel.css';
@@ -16,12 +17,15 @@ class InvoicePaymentAlert extends PureComponent {
       let invoiceStatus = get(status, 'error.response.response.body.status');
       let aproverFirstName = get(status, 'error.response.response.body.approver_first_name');
       let aproverLastName = get(status, 'error.response.response.body.approver_last_name');
+      let invoiceDate = moment(get(status, 'error.response.response.body.invoiced_date'));
       if (httpResCode === 409 && invoiceStatus === 'SUBMITTED') {
         paymentAlert = (
           <div>
-            <Alert type="success" heading="Success!">
+            <Alert type="success" heading="Already approved">
               <span className="warning--header">
-                Counselor {aproverFirstName} {aproverLastName} already approved this invoice.
+                {aproverFirstName} {aproverLastName} approved this invoice on [{invoiceDate.format('DD-MMM-YYYY')}] at [{invoiceDate.format(
+                  'kk:mm',
+                )}].
               </span>
             </Alert>
           </div>
@@ -29,10 +33,10 @@ class InvoicePaymentAlert extends PureComponent {
       } else if (httpResCode === 409 && (invoiceStatus === 'IN_PROCESS' || invoiceStatus === 'DRAFT')) {
         paymentAlert = (
           <div>
-            <Alert type="success" heading="Success!">
+            <Alert type="success" heading="Already submitted">
               <span className="warning--header">
-                Counselor {aproverFirstName} {aproverLastName} already submitted this invoice. Please reload your screen
-                to see updated information.
+                {aproverFirstName} {aproverLastName} submitted this invoice on [{invoiceDate.format('DD-MMM-YYYY')}] at
+                [{invoiceDate.format('kk:mm')}].
               </span>
             </Alert>
           </div>

--- a/src/shared/Invoice/InvoicePaymentAlert.jsx
+++ b/src/shared/Invoice/InvoicePaymentAlert.jsx
@@ -1,5 +1,6 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
+import { get } from 'lodash';
 
 import Alert from 'shared/Alert';
 import './InvoicePanel.css';
@@ -10,11 +11,39 @@ class InvoicePaymentAlert extends PureComponent {
     const status = this.props.createInvoiceStatus;
 
     if (status.error) {
-      paymentAlert = (
-        <Alert type="error" heading="Oops, something went wrong!">
-          <span className="warning--header">Please try again.</span>
-        </Alert>
-      );
+      //handle 409 status: shipment invoice already processed
+      let httpResCode = get(status, 'error.response.status');
+      let invoiceStatus = get(status, 'error.response.response.body.status');
+      let aproverFirstName = get(status, 'error.response.response.body.approver_first_name');
+      let aproverLastName = get(status, 'error.response.response.body.approver_last_name');
+      if (httpResCode === 409 && invoiceStatus === 'SUBMITTED') {
+        paymentAlert = (
+          <div>
+            <Alert type="success" heading="Success!">
+              <span className="warning--header">
+                Counselor {aproverFirstName} {aproverLastName} already approved this invoice.
+              </span>
+            </Alert>
+          </div>
+        );
+      } else if (httpResCode === 409 && (invoiceStatus === 'IN_PROCESS' || invoiceStatus === 'DRAFT')) {
+        paymentAlert = (
+          <div>
+            <Alert type="success" heading="Success!">
+              <span className="warning--header">
+                Counselor {aproverFirstName} {aproverLastName} already submitted this invoice. Please reload your screen
+                to see updated information.
+              </span>
+            </Alert>
+          </div>
+        );
+      } else {
+        paymentAlert = (
+          <Alert type="error" heading="Oops, something went wrong!">
+            <span className="warning--header">Please try again.</span>
+          </Alert>
+        );
+      }
     } else if (status.isLoading) {
       paymentAlert = (
         <Alert type="loading" heading="Creating invoice">

--- a/src/shared/Invoice/InvoicePaymentAlert.test.js
+++ b/src/shared/Invoice/InvoicePaymentAlert.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import InvoicePaymentAlert from './InvoicePaymentAlert';
-import { get } from 'lodash';
+import moment from 'moment';
 
 describe('Invoice Payment Component tests', () => {
   let wrapper;
@@ -34,6 +34,8 @@ describe('Invoice Payment Component tests', () => {
       expect(wrapper.find('.warning--header').text()).toEqual('Please try again.');
     });
     describe('and the api response is 409 and invoice status is SUBMITTED', () => {
+      let invoiceDate = '12/12/2018 12:12:00z';
+      let momentDate = moment(invoiceDate);
       it('renders invoice already processed by another user', () => {
         wrapper = shallow(
           <InvoicePaymentAlert
@@ -46,6 +48,7 @@ describe('Invoice Payment Component tests', () => {
                       status: 'SUBMITTED',
                       approver_first_name: 'Leo',
                       approver_last_name: 'Spaceman',
+                      invoiced_date: invoiceDate,
                     },
                   },
                 },
@@ -56,11 +59,15 @@ describe('Invoice Payment Component tests', () => {
           />,
         );
         expect(wrapper.find('.warning--header').text()).toEqual(
-          'Counselor Leo Spaceman already approved this invoice.',
+          `Leo Spaceman approved this invoice on [${momentDate.format('DD-MMM-YYYY')}] at [${momentDate.format(
+            'kk:mm',
+          )}].`,
         );
       });
     });
     describe('and the api response is 409 and invoice status is IN_PROCESS', () => {
+      let invoiceDate = '12/12/2018 12:12:00z';
+      let momentDate = moment(invoiceDate);
       it('renders invoice already processed by another user', () => {
         wrapper = shallow(
           <InvoicePaymentAlert
@@ -73,6 +80,7 @@ describe('Invoice Payment Component tests', () => {
                       status: 'IN_PROCESS',
                       approver_first_name: 'Leo',
                       approver_last_name: 'Spaceman',
+                      invoiced_date: invoiceDate,
                     },
                   },
                 },
@@ -83,11 +91,15 @@ describe('Invoice Payment Component tests', () => {
           />,
         );
         expect(wrapper.find('.warning--header').text()).toEqual(
-          'Counselor Leo Spaceman already submitted this invoice. Please reload your screen to see updated information.',
+          `Leo Spaceman submitted this invoice on [${momentDate.format('DD-MMM-YYYY')}] at [${momentDate.format(
+            'kk:mm',
+          )}].`,
         );
       });
     });
     describe('and the api response is 409 and invoice status is DRAFT', () => {
+      let invoiceDate = '12/12/2018 12:12:00z';
+      let momentDate = moment(invoiceDate);
       it('renders invoice already processed by another user', () => {
         wrapper = shallow(
           <InvoicePaymentAlert
@@ -100,6 +112,7 @@ describe('Invoice Payment Component tests', () => {
                       status: 'DRAFT',
                       approver_first_name: 'Leo',
                       approver_last_name: 'Spaceman',
+                      invoiced_date: invoiceDate,
                     },
                   },
                 },
@@ -110,7 +123,9 @@ describe('Invoice Payment Component tests', () => {
           />,
         );
         expect(wrapper.find('.warning--header').text()).toEqual(
-          'Counselor Leo Spaceman already submitted this invoice. Please reload your screen to see updated information.',
+          `Leo Spaceman submitted this invoice on [${momentDate.format('DD-MMM-YYYY')}] at [${momentDate.format(
+            'kk:mm',
+          )}].`,
         );
       });
     });

--- a/src/shared/Invoice/InvoicePaymentAlert.test.js
+++ b/src/shared/Invoice/InvoicePaymentAlert.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import InvoicePaymentAlert from './InvoicePaymentAlert';
+import { get } from 'lodash';
 
 describe('Invoice Payment Component tests', () => {
   let wrapper;
@@ -31,6 +32,87 @@ describe('Invoice Payment Component tests', () => {
         />,
       );
       expect(wrapper.find('.warning--header').text()).toEqual('Please try again.');
+    });
+    describe('and the api response is 409 and invoice status is SUBMITTED', () => {
+      it('renders invoice already processed by another user', () => {
+        wrapper = shallow(
+          <InvoicePaymentAlert
+            createInvoiceStatus={{
+              error: {
+                response: {
+                  status: 409,
+                  response: {
+                    body: {
+                      status: 'SUBMITTED',
+                      approver_first_name: 'Leo',
+                      approver_last_name: 'Spaceman',
+                    },
+                  },
+                },
+              },
+              isLoading: false,
+              isSuccess: false,
+            }}
+          />,
+        );
+        expect(wrapper.find('.warning--header').text()).toEqual(
+          'Counselor Leo Spaceman already approved this invoice.',
+        );
+      });
+    });
+    describe('and the api response is 409 and invoice status is IN_PROCESS', () => {
+      it('renders invoice already processed by another user', () => {
+        wrapper = shallow(
+          <InvoicePaymentAlert
+            createInvoiceStatus={{
+              error: {
+                response: {
+                  status: 409,
+                  response: {
+                    body: {
+                      status: 'IN_PROCESS',
+                      approver_first_name: 'Leo',
+                      approver_last_name: 'Spaceman',
+                    },
+                  },
+                },
+              },
+              isLoading: false,
+              isSuccess: false,
+            }}
+          />,
+        );
+        expect(wrapper.find('.warning--header').text()).toEqual(
+          'Counselor Leo Spaceman already submitted this invoice. Please reload your screen to see updated information.',
+        );
+      });
+    });
+    describe('and the api response is 409 and invoice status is DRAFT', () => {
+      it('renders invoice already processed by another user', () => {
+        wrapper = shallow(
+          <InvoicePaymentAlert
+            createInvoiceStatus={{
+              error: {
+                response: {
+                  status: 409,
+                  response: {
+                    body: {
+                      status: 'DRAFT',
+                      approver_first_name: 'Leo',
+                      approver_last_name: 'Spaceman',
+                    },
+                  },
+                },
+              },
+              isLoading: false,
+              isSuccess: false,
+            }}
+          />,
+        );
+        expect(wrapper.find('.warning--header').text()).toEqual(
+          'Counselor Leo Spaceman already submitted this invoice. Please reload your screen to see updated information.',
+        );
+      });
     });
   });
   describe('When invoice status is approved', () => {

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -3206,7 +3206,7 @@ paths:
         403:
           description: not authorized to send this invoice
         409:
-          description: the shipment is not in a state to be invoiced
+          description: the shipment cannot be invoiced becuase of a data conflict
           schema:
             $ref: '#/definitions/Invoice'
         500:

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -3208,7 +3208,7 @@ paths:
         409:
           description: the shipment is not in a state to be invoiced
           schema:
-            $ref: '#/definitions/Shipment'
+            $ref: '#/definitions/Invoice'
         500:
           description: server error
   /reimbursement/{reimbursementId}/approve:


### PR DESCRIPTION
## Description

This PR adds extra checks to invoice submission for a given shipment. For now we only allow a single invoice per shipment. If another invoice is submitted while an invoice is already under process or completed the end point will return 409 error with a message which is consumed by front end.

## Reviewer Notes

Changes to the end point that handles invoice processing should draw scrutiny.
## Setup

* Have a shipment that has pre-approved requests and has already been delivered
* Ensure no invoice has been submitted for the shipment selected
* Open two browser tabs and navigate to HHG view as office user, you should see approve invoice button visible on both tabs
* Approve invoice in first tab
* Approve invoice in 2nd tab, second tab should come back with an alert indicating the invoice is already under process

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/162518251) for this change

## Screenshots:
What the first user who successfully submitted the invoice sees:
![image](https://user-images.githubusercontent.com/5003421/50492975-9d70f880-09e8-11e9-9729-67c40d1e5445.png)

What user 2 where invoice is already approved sees:
![image](https://user-images.githubusercontent.com/5003421/50648712-e75a6100-0f49-11e9-803a-b6056878aa96.png)
