### PR TITLE
Fixes PPM View in Office App #162864945

### DIFF
--- a/cypress/integration/office/documentViewer.js
+++ b/cypress/integration/office/documentViewer.js
@@ -192,10 +192,7 @@ describe('The document viewer', function() {
       log: true,
     });
 
-    cy
-      .get('a[title="Home"]')
-      .first()
-      .click();
+    cy.visit('/');
 
     cy.location().should(loc => {
       expect(loc.pathname).to.match(/^\/queues\/new/);

--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -137,21 +137,28 @@ class MoveInfo extends Component {
   };
 
   componentDidMount() {
-    this.props.loadMoveDependencies(this.props.match.params.moveId).then(() => {
-      const shipmentId = this.props.officeShipment.id;
-      this.props.getMoveDocumentsForMove(this.props.match.params.moveId);
-      this.props.getTspForShipment(getTspForShipmentLabel, shipmentId);
-      this.props.getPublicShipment('Shipments.getPublicShipment', shipmentId);
-      this.props.getAllShipmentLineItems(getShipmentLineItemsLabel, shipmentId);
-      this.props.getAllInvoices(getShipmentInvoicesLabel, shipmentId);
-      this.props.loadShipmentDependencies(shipmentId);
-    });
+    this.props.loadMoveDependencies(this.props.match.params.moveId);
+    this.props.getMoveDocumentsForMove(this.props.match.params.moveId);
     this.props.getAllTariff400ngItems(true, getTariff400ngItemsLabel);
+  }
+
+  componentDidUpdate(prevProps) {
+    if (get(this.props, 'officeShipment.id') !== get(prevProps, 'officeShipment.id')) {
+      this.getAllShipmentInfo(this.props.officeShipment.id);
+    }
   }
 
   componentWillUnmount() {
     this.props.resetMove();
   }
+
+  getAllShipmentInfo = shipmentId => {
+    this.props.getTspForShipment(getTspForShipmentLabel, shipmentId);
+    this.props.getPublicShipment('Shipments.getPublicShipment', shipmentId);
+    this.props.getAllShipmentLineItems(getShipmentLineItemsLabel, shipmentId);
+    this.props.getAllInvoices(getShipmentInvoicesLabel, shipmentId);
+    this.props.loadShipmentDependencies(shipmentId);
+  };
 
   approveBasics = () => {
     this.props.approveBasics(this.props.match.params.moveId);


### PR DESCRIPTION
## Description

This PR fixes a bug viewing PPM moves in the Office app. The PPM move would throw an exception trying to load information for an HHG move. This fix refactors loading the HHG info into componentDidUpdate().

## Setup

1. Log in to office app
2. Open up any PPM move

Expected: Should be able to view PPM move

## Code Review Verification Steps

* [ ] There are no aXe warnings for UI.
* [ ] This works in IE.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/162864945) for this change