### PR TITLE
Updates shipment status in swagger to match model

### DIFF
--- a/pkg/handlers/internalapi/shipments.go
+++ b/pkg/handlers/internalapi/shipments.go
@@ -14,7 +14,7 @@ import (
 	"github.com/transcom/mymove/pkg/auth"
 	"github.com/transcom/mymove/pkg/edi"
 	"github.com/transcom/mymove/pkg/edi/gex"
-	"github.com/transcom/mymove/pkg/edi/invoice"
+	ediinvoice "github.com/transcom/mymove/pkg/edi/invoice"
 	shipmentop "github.com/transcom/mymove/pkg/gen/internalapi/internaloperations/shipments"
 	"github.com/transcom/mymove/pkg/gen/internalmessages"
 	"github.com/transcom/mymove/pkg/handlers"

--- a/swagger/api.yaml
+++ b/swagger/api.yaml
@@ -1440,24 +1440,23 @@ definitions:
     description: The stages in the lifecycle of a Shipment
     example: IN_PROGRESS
     enum: &SHIPMENTSTATUS
+      - DRAFT
+      - SUBMITTED
       - AWARDED
       - ACCEPTED
       - APPROVED
-      - REJECTED
-      - IN_PROGRESS
       - IN_TRANSIT
       - DELIVERED
       - COMPLETED
-      - CANCELED
     x-display-value:
+      DRAFT: Draft
+      SUBMITTED: Submitted
       AWARDED: Awarded
       ACCEPTED: Accepted
-      REJECTED: Rejected
-      IN_PROGRESS: In Progress
+      APPROVED: Approved
       IN_TRANSIT: In Transit
       DELIVERED: Delivered
       COMPLETED: Completed
-      CANCELED: Canceled
   TransportPayload:
     type: object
     properties:

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -2041,6 +2041,7 @@ definitions:
       - DRAFT
       - SUBMITTED
       - AWARDED
+      - ACCEPTED
       - APPROVED
       - IN_TRANSIT
       - DELIVERED
@@ -2049,6 +2050,7 @@ definitions:
       DRAFT: Draft
       SUBMITTED: Submitted
       AWARDED: Awarded
+      ACCEPTED: Accepted
       APPROVED: Approved
       IN_TRANSIT: In Transit
       DELIVERED: Delivered


### PR DESCRIPTION
## Description

While testing another PR, I noticed that I couldn't save a shipment because Swagger wasn't accepting a `status` that was set up in our test data. The types of allowed statuses between internal, public, and the model had become out of sync. This PR puts them all in line again