### PR TITLE
Change PM to pre-move

### DIFF
--- a/src/scenes/Office/PremoveSurvey.jsx
+++ b/src/scenes/Office/PremoveSurvey.jsx
@@ -199,7 +199,12 @@ const SurveyDisplay = props => {
         />
       </div>
       <div className="editable-panel-3-column">
-        <PanelSwaggerField title="PM survey conducted" fieldName="pm_survey_conducted_date" required {...fieldProps} />
+        <PanelSwaggerField
+          title="Pre-move survey conducted"
+          fieldName="pm_survey_conducted_date"
+          required
+          {...fieldProps}
+        />
         <PanelSwaggerField title="Survey Method" fieldName="pm_survey_method" required {...fieldProps} />
         <PanelSwaggerField title="Notes" fieldName="pm_survey_notes" className="notes" {...fieldProps} />
       </div>
@@ -223,7 +228,12 @@ const SurveyEdit = props => {
           <SwaggerField fieldName="pm_survey_progear_weight_estimate" swagger={schema} />
           <SwaggerField fieldName="pm_survey_spouse_progear_weight_estimate" swagger={schema} />
         </div>
-        <SwaggerField fieldName="pm_survey_conducted_date" title="PM survey conducted" swagger={schema} required />
+        <SwaggerField
+          fieldName="pm_survey_conducted_date"
+          title="Pre-move survey conducted"
+          swagger={schema}
+          required
+        />
         <SwaggerField fieldName="pm_survey_method" swagger={schema} required />
         <SwaggerField fieldName="pm_survey_notes" title="Notes about dates" swagger={schema} />
       </FormSection>

--- a/src/scenes/TransportationServiceProvider/PremoveSurveyForm.jsx
+++ b/src/scenes/TransportationServiceProvider/PremoveSurveyForm.jsx
@@ -9,10 +9,15 @@ let PremoveSurveyForm = props => {
 
   return (
     <form className="infoPanel-wizard" onSubmit={handleSubmit}>
-      <div className="infoPanel-wizard-header">PM Survey</div>
+      <div className="infoPanel-wizard-header">Pre-move Survey</div>
       <div className="editable-panel-column">
         <div className="column-subhead">Dates</div>
-        <SwaggerField fieldName="pm_survey_conducted_date" title="PM survey conducted" swagger={schema} required />
+        <SwaggerField
+          fieldName="pm_survey_conducted_date"
+          title="Pre-move survey conducted"
+          swagger={schema}
+          required
+        />
         <SwaggerField fieldName="pm_survey_method" swagger={schema} required />
         <SwaggerField
           fieldName="pm_survey_planned_pack_date"

--- a/src/shared/ShipmentDates/index.jsx
+++ b/src/shared/ShipmentDates/index.jsx
@@ -34,8 +34,13 @@ const DatesDisplay = props => {
   return (
     <Fragment>
       <div className="editable-panel-column">
-        <div className="column-subhead">PM Survey</div>
-        <PanelSwaggerField title="PM survey conducted" fieldName="pm_survey_conducted_date" required {...fieldProps} />
+        <div className="column-subhead">Pre-move Survey</div>
+        <PanelSwaggerField
+          title="Pre-move survey conducted"
+          fieldName="pm_survey_conducted_date"
+          required
+          {...fieldProps}
+        />
         <PanelSwaggerField title="Survey Method" fieldName="pm_survey_method" required {...fieldProps} />
         <div className="column-subhead">Packing</div>
         <PanelSwaggerField fieldName="original_pack_date" title="Original" required {...fieldProps} />
@@ -70,7 +75,7 @@ const DatesEdit = props => {
     <Fragment>
       <FormSection name="dates">
         <div className="editable-panel-column">
-          <div className="column-head">PM Survey</div>
+          <div className="column-head">Pre-move Survey</div>
           <SwaggerField fieldName="pm_survey_conducted_date" swagger={schema} />
           <SwaggerField fieldName="pm_survey_method" swagger={schema} />
           <div className="column-head">Packing</div>


### PR DESCRIPTION
## Description

PM was not understandable to TSPs, so we've un-acronymed it to Pre-move.

## Setup

View any shipment from the tsp or office app. Make sure all language in dates panel or pre-move survey wizard (in tsp only) use `Pre-move` instead of `PM`.

## Code Review Verification Steps

* [x] Design review
* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* https://www.pivotaltracker.com/story/show/162706946

## Screenshots

<img width="464" alt="screen shot 2018-12-28 at 3 27 14 pm" src="https://user-images.githubusercontent.com/5531789/50530713-2190b200-0ab5-11e9-88ff-cf2df4d0a823.png">
<img width="446" alt="screen shot 2018-12-28 at 3 27 02 pm" src="https://user-images.githubusercontent.com/5531789/50530714-22294880-0ab5-11e9-975f-f59866fefdc9.png">

