### PR TITLE
Fixes cost calculation for third party service charge

### DIFF
--- a/pkg/rateengine/accessorials.go
+++ b/pkg/rateengine/accessorials.go
@@ -28,8 +28,10 @@ var tariff400ngItemPricing = map[string]pricer{
 	"28B": newBasicQuantityPricer(),
 	"28C": newBasicQuantityPricer(),
 
-	// Key west service charge
-	"35A": newFlatRatePricer(),
+	// Third Party Service (TPS) charge
+	"35A": newBasicQuantityPricer(),
+	// Key West service charge
+	"35B": newFlatRatePricer(),
 
 	// Crating - subject to a minimum charge of 4 cu. ft.
 	"105B": newMinimumQuantityPricer(4),
@@ -131,7 +133,10 @@ func (re *RateEngine) ComputeShipmentLineItemCharge(shipmentLineItem models.Ship
 	} else if itemCode == "185B" {
 		rateCents = serviceArea.SIT185BRateCents
 	} else if itemCode == "226A" {
-		// 226A is Misc charge, which has a rate of $1 per unit of quantity entered
+		// 226A is Misc charge, allow user to enter dollar amount as quantity
+		rateCents = unit.Cents(100)
+	} else if itemCode == "35A" {
+		// 35A is a Third Party Service (TPS) charge, allow user to enter dollar amount as quantity
 		rateCents = unit.Cents(100)
 	} else {
 		// Most rates should be in the tariff400ngItemRates table though


### PR DESCRIPTION
## Description

This fixes a couple mistakes:
1. We allowed item 35A (third party service) to be chosen without there being a corresponding rate in the db
2. I accidentally listed 35B (key west charge) as 35A in the rate engine. We DO have a rate for 35B, but it's not currently able to be selected in the pre-approval panel

So this PR allows 35A to be priced by assuming the quantity field is a dollar amount, and correctly lists the code for the Key West charge as 35B in the accessorials pricer