### PR TITLE
Fixes documentViewer test by preventing initial sign in

### DIFF
--- a/cypress/integration/office/documentViewer.js
+++ b/cypress/integration/office/documentViewer.js
@@ -1,228 +1,236 @@
-import { fileUploadTimeout } from '../../support/constants';
+import { fileUploadTimeout, officeAppName } from '../../support/constants';
 
 /* global cy, Cypress */
 describe('The document viewer', function() {
-  beforeEach(() => {
-    // The document viewer is launched in a new tab, so prevent visiting home page first
-    cy.signIntoOffice(false);
-  });
-  it('redirects to sign in when not logged in', function() {
-    cy.visit('/');
-    cy.contains('Sign Out').click();
-    cy.visit('/moves/foo/documents');
-    cy.contains('Welcome');
-    cy.contains('Sign In');
-  });
-  it('produces error when move cannot be found', () => {
-    cy.visit('/moves/9bfa91d2-7a0c-4de0-ae02-b90988cf8b4b858b/documents');
-    cy.contains('An error occurred'); //todo: we want better messages when we are making custom call
-  });
-  it('loads basic information about the move', () => {
-    cy.visit('/moves/c9df71f2-334f-4f0e-b2e7-050ddb22efa1/documents');
-    cy.contains('In Progress, PPM');
-    cy.contains('GBXYUI');
-    cy.contains('1617033988');
-  });
-  it('can upload a new document', () => {
-    cy.visit('/moves/c9df71f2-334f-4f0e-b2e7-050ddb22efa1/documents/new');
-    cy.contains('Upload a new document');
-    cy.get('button.submit').should('be.disabled');
-    cy.get('input[name="title"]').type('super secret info document');
-    cy.get('select[name="move_document_type"]').select('Other document type');
-    cy.get('input[name="notes"]').type('burn after reading');
-    cy.get('button.submit').should('be.disabled');
-
-    cy.upload_file('.filepond--root', 'top-secret.png');
-    cy
-      .get('button.submit', { timeout: fileUploadTimeout })
-      .should('not.be.disabled')
-      .click();
-  });
-  it('shows the newly uploaded document in the document list tab', () => {
-    cy.visit('/moves/c9df71f2-334f-4f0e-b2e7-050ddb22efa1/documents');
-    cy.contains('All Documents (1)');
-    cy.contains('super secret info document');
-    cy
-      .get('.pad-ns')
-      .find('a')
-      .should('have.attr', 'href')
-      .and('match', /^\/moves\/[^/]+\/documents\/[^/]+/);
-  });
-  it('can upload an expense document', () => {
-    cy.visit('/moves/c9df71f2-334f-4f0e-b2e7-050ddb22efa1/documents/new');
-    cy.contains('Upload a new document');
-    cy.get('button.submit').should('be.disabled');
-    cy.get('select[name="move_document_type"]').select('Expense');
-    cy.get('input[name="title"]').type('expense document');
-    cy.get('select[name="moving_expense_type"]').select('Contracted Expense');
-    cy.get('input[name="requested_amount_cents"]').type('4,000.92');
-    cy.get('select[name="payment_method"]').select('Other account');
-
-    cy.get('button.submit').should('be.disabled');
-
-    cy.upload_file('.filepond--root', 'top-secret.png');
-    cy
-      .get('button.submit', { timeout: fileUploadTimeout })
-      .should('not.be.disabled')
-      .click();
-  });
-  it('can select and update newly-uploaded expense document', () => {
-    cy.visit('/moves/c9df71f2-334f-4f0e-b2e7-050ddb22efa1/documents');
-    cy.contains('expense document');
-    cy
-      .get('.pad-ns')
-      .find('a')
-      .should('have.attr', 'href')
-      .and('match', /^\/moves\/[^/]+\/documents\/[^/]+/);
-
-    cy.contains('expense document').click();
-    cy.contains('Details').click();
-
-    // Verify values have been stored correctly
-    cy.contains('4,000.92');
-    cy.contains('Contracted Expense');
-    cy.contains('Other account');
-
-    // Edit payment method
-    cy.contains('Edit').click();
-    cy.get('select[name="moveDocument.payment_method"]').select('GTCC');
-    cy.get('select[name="moveDocument.status"]').select('OK');
-
-    cy
-      .get('button')
-      .contains('Save')
-      .should('not.be.disabled')
-      .click();
-
-    cy.contains('GTCC');
-  });
-  it('can update expense document to other doc type', () => {
-    cy.visit('/moves/c9df71f2-334f-4f0e-b2e7-050ddb22efa1/documents');
-    cy.contains('expense document');
-    cy
-      .get('.pad-ns')
-      .find('a')
-      .should('have.attr', 'href')
-      .and('match', /^\/moves\/[^/]+\/documents\/[^/]+/);
-
-    cy.contains('expense document').click();
-    cy.contains('Details').click();
-    cy.contains('GTCC');
-    cy.contains('Edit').click();
-
-    cy.get('select[name="moveDocument.move_document_type"]').select('Other document type');
-
-    cy
-      .get('button')
-      .contains('Save')
-      .should('not.be.disabled')
-      .click();
-
-    cy.contains('Other document type');
-
-    cy
-      .get('.field-title')
-      .contains('Expense Type')
-      .should('not.exist');
-  });
-  it('can update other document type back to expense type', () => {
-    cy.visit('/moves/c9df71f2-334f-4f0e-b2e7-050ddb22efa1/documents');
-    cy.contains('expense document');
-    cy
-      .get('.pad-ns')
-      .find('a')
-      .should('have.attr', 'href')
-      .and('match', /^\/moves\/[^/]+\/documents\/[^/]+/);
-
-    cy.contains('expense document').click();
-    cy.contains('Details').click();
-    cy.contains('OK');
-    cy.contains('Edit').click();
-
-    cy.get('select[name="moveDocument.move_document_type"]').select('Expense');
-    cy.get('select[name="moveDocument.moving_expense_type"]').select('Contracted Expense');
-    cy.get('input[name="moveDocument.requested_amount_cents"]').type('4,999.92');
-    cy.get('select[name="moveDocument.payment_method"]').select('GTCC');
-    cy.get('select[name="moveDocument.status"]').select('OK');
-
-    cy
-      .get('button')
-      .contains('Save')
-      .should('not.be.disabled')
-      .click();
-
-    cy.contains('Expense');
-    cy.contains('4,999.92');
-    cy.contains('GTCC');
-  });
-  it('can upload documents to an HHG move', () => {
-    cy.visit('moves/533d176f-0bab-4c51-88cd-c899f6855b9d/documents/new');
-
-    cy.contains('Upload a new document');
-    cy.get('button.submit').should('be.disabled');
-    cy.get('select[name="move_document_type"]').select('Expense');
-    cy.get('input[name="title"]').type('expense document');
-    cy.get('select[name="moving_expense_type"]').select('Contracted Expense');
-    cy.get('input[name="requested_amount_cents"]').type('4,000.92');
-    cy.get('select[name="payment_method"]').select('Other account');
-
-    cy.get('button.submit').should('be.disabled');
-
-    cy.upload_file('.filepond--root', 'top-secret.png');
-    cy
-      .get('button.submit', { timeout: fileUploadTimeout })
-      .should('not.be.disabled')
-      .click();
-
-    cy.contains('All Documents (1)');
-
-    cy.get('select[name="move_document_type"]').select('Weight ticket');
-    cy.get('input[name="title"]').type('Wait ticket');
-    cy.get('input[name="notes"]').type('wait for this document');
-    cy.upload_file('.filepond--root', 'top-secret.png');
-    cy
-      .get('button.submit', { timeout: fileUploadTimeout })
-      .should('not.be.disabled')
-      .click();
-
-    cy.contains('All Documents (2)');
-  });
-  it('can navigate to the shipment info page and show line item info', () => {
-    cy.visit('/moves/fb4105cf-f5a5-43be-845e-d59fdb34f31c/documents/new', {
-      log: true,
+  describe('When not logged in', function() {
+    beforeEach(() => {
+      cy.setupBaseUrl(officeAppName);
+      cy.logout();
+      cy.clearCookies();
     });
-
-    cy.visit('/');
-
-    cy.location().should(loc => {
-      expect(loc.pathname).to.match(/^\/queues\/new/);
+    it('shows page not found', function() {
+      cy.visit('/moves/foo/documents');
+      cy.contains('Welcome');
+      cy.contains('Sign In');
     });
+  });
 
-    cy
-      .get('div')
-      .contains('Delivered HHGs')
-      .click();
-
-    cy
-      .get('div')
-      .contains('DOOB')
-      .dblclick();
-
-    cy.location().should(loc => {
-      expect(loc.pathname).to.match(/^\/queues\/new\/moves\/[^/]+\/basics/);
+  describe('When user is logged in', function() {
+    beforeEach(() => {
+      // The document viewer is launched in a new tab, so pass in false to prevent visiting home page first
+      cy.signIntoOffice(false);
     });
+    it('produces error when move cannot be found', () => {
+      cy.visit('/moves/9bfa91d2-7a0c-4de0-ae02-b90988cf8b4b858b/documents');
+      cy.contains('An error occurred'); //todo: we want better messages when we are making custom call
+    });
+    it('loads basic information about the move', () => {
+      cy.visit('/moves/c9df71f2-334f-4f0e-b2e7-050ddb22efa1/documents');
+      cy.contains('In Progress, PPM');
+      cy.contains('GBXYUI');
+      cy.contains('1617033988');
+    });
+    it('can upload a new document', () => {
+      cy.visit('/moves/c9df71f2-334f-4f0e-b2e7-050ddb22efa1/documents/new');
+      cy.contains('Upload a new document');
+      cy.get('button.submit').should('be.disabled');
+      cy.get('input[name="title"]').type('super secret info document');
+      cy.get('select[name="move_document_type"]').select('Other document type');
+      cy.get('input[name="notes"]').type('burn after reading');
+      cy.get('button.submit').should('be.disabled');
 
-    cy
-      .get('a')
-      .contains('HHG')
-      .click(); // navtab
+      cy.upload_file('.filepond--root', 'top-secret.png');
+      cy
+        .get('button.submit', { timeout: fileUploadTimeout })
+        .should('not.be.disabled')
+        .click();
+    });
+    it('shows the newly uploaded document in the document list tab', () => {
+      cy.visit('/moves/c9df71f2-334f-4f0e-b2e7-050ddb22efa1/documents');
+      cy.contains('All Documents (1)');
+      cy.contains('super secret info document');
+      cy
+        .get('.pad-ns')
+        .find('a')
+        .should('have.attr', 'href')
+        .and('match', /^\/moves\/[^/]+\/documents\/[^/]+/);
+    });
+    it('can upload an expense document', () => {
+      cy.visit('/moves/c9df71f2-334f-4f0e-b2e7-050ddb22efa1/documents/new');
+      cy.contains('Upload a new document');
+      cy.get('button.submit').should('be.disabled');
+      cy.get('select[name="move_document_type"]').select('Expense');
+      cy.get('input[name="title"]').type('expense document');
+      cy.get('select[name="moving_expense_type"]').select('Contracted Expense');
+      cy.get('input[name="requested_amount_cents"]').type('4,000.92');
+      cy.get('select[name="payment_method"]').select('Other account');
 
-    cy
-      .get('.invoice-panel')
-      .get('.invoice-panel-table-cont')
-      .find('tbody tr')
-      .should(rows => {
-        expect(rows).to.have.length.of.at.least(3);
+      cy.get('button.submit').should('be.disabled');
+
+      cy.upload_file('.filepond--root', 'top-secret.png');
+      cy
+        .get('button.submit', { timeout: fileUploadTimeout })
+        .should('not.be.disabled')
+        .click();
+    });
+    it('can select and update newly-uploaded expense document', () => {
+      cy.visit('/moves/c9df71f2-334f-4f0e-b2e7-050ddb22efa1/documents');
+      cy.contains('expense document');
+      cy
+        .get('.pad-ns')
+        .find('a')
+        .should('have.attr', 'href')
+        .and('match', /^\/moves\/[^/]+\/documents\/[^/]+/);
+
+      cy.contains('expense document').click();
+      cy.contains('Details').click();
+
+      // Verify values have been stored correctly
+      cy.contains('4,000.92');
+      cy.contains('Contracted Expense');
+      cy.contains('Other account');
+
+      // Edit payment method
+      cy.contains('Edit').click();
+      cy.get('select[name="moveDocument.payment_method"]').select('GTCC');
+      cy.get('select[name="moveDocument.status"]').select('OK');
+
+      cy
+        .get('button')
+        .contains('Save')
+        .should('not.be.disabled')
+        .click();
+
+      cy.contains('GTCC');
+    });
+    it('can update expense document to other doc type', () => {
+      cy.visit('/moves/c9df71f2-334f-4f0e-b2e7-050ddb22efa1/documents');
+      cy.contains('expense document');
+      cy
+        .get('.pad-ns')
+        .find('a')
+        .should('have.attr', 'href')
+        .and('match', /^\/moves\/[^/]+\/documents\/[^/]+/);
+
+      cy.contains('expense document').click();
+      cy.contains('Details').click();
+      cy.contains('GTCC');
+      cy.contains('Edit').click();
+
+      cy.get('select[name="moveDocument.move_document_type"]').select('Other document type');
+
+      cy
+        .get('button')
+        .contains('Save')
+        .should('not.be.disabled')
+        .click();
+
+      cy.contains('Other document type');
+
+      cy
+        .get('.field-title')
+        .contains('Expense Type')
+        .should('not.exist');
+    });
+    it('can update other document type back to expense type', () => {
+      cy.visit('/moves/c9df71f2-334f-4f0e-b2e7-050ddb22efa1/documents');
+      cy.contains('expense document');
+      cy
+        .get('.pad-ns')
+        .find('a')
+        .should('have.attr', 'href')
+        .and('match', /^\/moves\/[^/]+\/documents\/[^/]+/);
+
+      cy.contains('expense document').click();
+      cy.contains('Details').click();
+      cy.contains('OK');
+      cy.contains('Edit').click();
+
+      cy.get('select[name="moveDocument.move_document_type"]').select('Expense');
+      cy.get('select[name="moveDocument.moving_expense_type"]').select('Contracted Expense');
+      cy.get('input[name="moveDocument.requested_amount_cents"]').type('4,999.92');
+      cy.get('select[name="moveDocument.payment_method"]').select('GTCC');
+      cy.get('select[name="moveDocument.status"]').select('OK');
+
+      cy
+        .get('button')
+        .contains('Save')
+        .should('not.be.disabled')
+        .click();
+
+      cy.contains('Expense');
+      cy.contains('4,999.92');
+      cy.contains('GTCC');
+    });
+    it('can upload documents to an HHG move', () => {
+      cy.visit('moves/533d176f-0bab-4c51-88cd-c899f6855b9d/documents/new');
+
+      cy.contains('Upload a new document');
+      cy.get('button.submit').should('be.disabled');
+      cy.get('select[name="move_document_type"]').select('Expense');
+      cy.get('input[name="title"]').type('expense document');
+      cy.get('select[name="moving_expense_type"]').select('Contracted Expense');
+      cy.get('input[name="requested_amount_cents"]').type('4,000.92');
+      cy.get('select[name="payment_method"]').select('Other account');
+
+      cy.get('button.submit').should('be.disabled');
+
+      cy.upload_file('.filepond--root', 'top-secret.png');
+      cy
+        .get('button.submit', { timeout: fileUploadTimeout })
+        .should('not.be.disabled')
+        .click();
+
+      cy.contains('All Documents (1)');
+
+      cy.get('select[name="move_document_type"]').select('Weight ticket');
+      cy.get('input[name="title"]').type('Wait ticket');
+      cy.get('input[name="notes"]').type('wait for this document');
+      cy.upload_file('.filepond--root', 'top-secret.png');
+      cy
+        .get('button.submit', { timeout: fileUploadTimeout })
+        .should('not.be.disabled')
+        .click();
+
+      cy.contains('All Documents (2)');
+    });
+    it('can navigate to the shipment info page and show line item info', () => {
+      cy.visit('/moves/fb4105cf-f5a5-43be-845e-d59fdb34f31c/documents/new', {
+        log: true,
       });
+
+      cy.visit('/');
+
+      cy.location().should(loc => {
+        expect(loc.pathname).to.match(/^\/queues\/new/);
+      });
+
+      cy
+        .get('div')
+        .contains('Delivered HHGs')
+        .click();
+
+      cy
+        .get('div')
+        .contains('DOOB')
+        .dblclick();
+
+      cy.location().should(loc => {
+        expect(loc.pathname).to.match(/^\/queues\/new\/moves\/[^/]+\/basics/);
+      });
+
+      cy
+        .get('a')
+        .contains('HHG')
+        .click(); // navtab
+
+      cy
+        .get('.invoice-panel')
+        .get('.invoice-panel-table-cont')
+        .find('tbody tr')
+        .should(rows => {
+          expect(rows).to.have.length.of.at.least(3);
+        });
+    });
   });
 });


### PR DESCRIPTION
## Description

We were getting a lot of false errors around the "redirects to sign in when not logged in" test, during which it:
1. signs into app
2. visits home page
3. clicks sign out
4. immediately visits document viewer page
5. tests that we visit login page

Somewhere between steps 3 and 4 our application was erring and I think it's because how quickly we attempt to visit a page after logout.

This PR puts that test into its own `describe` block that never logs in at all, which should avoid the above issue.

Note: my first PR for this branch forgot to logout before running tests that assumed being logged out. This fixes that