### PR TITLE
Revert "Editing an HHG's move dates no longer requires additional review step after saving"

### DIFF
--- a/cypress/integration/mymove/hhgPPM.js
+++ b/cypress/integration/mymove/hhgPPM.js
@@ -25,30 +25,12 @@ describe('service member adds a ppm to an hhg', function() {
     serviceMemberVerifiesContactInfoWasEdited();
     serviceMemberEditsBackupContactInfoSection();
     serviceMemberVerifiesBackupContactInfoWasEdited();
-    serviceMemberEditsHHGMoveDates();
     serviceMemberEditsPPMDatesAndLocations();
     serviceMemberVerifiesPPMDatesAndLocationsEdited();
     serviceMemberEditsPPMWeight();
     serviceMemberVerifiesPPMWeightsEdited();
   });
 });
-
-function serviceMemberEditsHHGMoveDates() {
-  cy
-    .get('.ppm-container .edit-section-link')
-    .eq(0)
-    .click();
-  // TODO: Currently does not support changing move dates for 2019. Add test to edit dates ewhen fixed
-
-  cy
-    .get('button')
-    .contains('Save')
-    .click();
-
-  cy.location().should(loc => {
-    expect(loc.pathname).to.match(/^\/moves\/[^/]+\/edit/);
-  });
-}
 
 function serviceMemberVerifiesHHGPPMSummary() {
   cy.location().should(loc => {

--- a/src/scenes/Review/EditShipment.jsx
+++ b/src/scenes/Review/EditShipment.jsx
@@ -98,15 +98,11 @@ function mapDispatchToProps(dispatch, ownProps) {
     onDidMount: function() {
       dispatch(getShipment(getShipmentLabel, shipmentID));
     },
-    updateShipment: function(values, shipment) {
+    updateShipment: function(values) {
       dispatch(updateShipment(updateShipmentLabel, shipmentID, values)).then(function(action) {
         if (!action.error) {
           const moveID = Object.values(action.entities.shipments)[0].move_id;
-          if (shipment.status !== 'DRAFT') {
-            dispatch(push(`/moves/${moveID}/edit`));
-          } else {
-            dispatch(push(`/moves/${moveID}/review`));
-          }
+          dispatch(push(`/moves/${moveID}/review`));
         }
       });
     },
@@ -120,7 +116,7 @@ function mergeProps(stateProps, dispatchProps, ownProps) {
   return Object.assign({}, stateProps, dispatchProps, ownProps, {
     updateShipment: function(event) {
       event.preventDefault();
-      dispatchProps.updateShipment(stateProps.formValues, stateProps.shipment);
+      dispatchProps.updateShipment(stateProps.formValues);
     },
     returnToReview: function(event) {
       event.preventDefault();

--- a/src/scenes/Review/ServiceMemberSummary.jsx
+++ b/src/scenes/Review/ServiceMemberSummary.jsx
@@ -224,7 +224,7 @@ function ServiceMemberSummary(props) {
 
 ServiceMemberSummary.propTypes = {
   backupContacts: PropTypes.array.isRequired,
-  serviceMember: PropTypes.object,
+  serviceMember: PropTypes.object.isRequired,
   schemaRank: PropTypes.object.isRequired,
   schemaAffiliation: PropTypes.object.isRequired,
   schemaOrdersType: PropTypes.object.isRequired,


### PR DESCRIPTION
Reverts PR in order to be up to date with master