### PR TITLE
Editing an HHG's move dates no longer requires additional review step after saving

### DIFF
--- a/cypress/integration/mymove/hhgPPM.js
+++ b/cypress/integration/mymove/hhgPPM.js
@@ -34,10 +34,7 @@ describe('service member adds a ppm to an hhg', function() {
 });
 
 function serviceMemberEditsHHGMoveDates() {
-  cy
-    .get('.ppm-container .edit-section-link')
-    .eq(0)
-    .click();
+  cy.get('[data-cy="edit-move"]').click();
   // TODO: Currently does not support changing move dates for 2019. Add test to edit dates ewhen fixed
 
   cy
@@ -125,10 +122,7 @@ function serviceMemberVerifiesPPMWeightsEdited() {
 }
 
 function serviceMemberEditsPPMWeight() {
-  cy
-    .get('.ppm-container .edit-section-link')
-    .last()
-    .click();
+  cy.get('[data-cy="edit-ppm-weight"]').click();
 
   typeInInput({ name: 'weight_estimate', value: '1700' });
 
@@ -150,10 +144,7 @@ function serviceMemberVerifiesPPMDatesAndLocationsEdited() {
   });
 }
 function serviceMemberEditsPPMDatesAndLocations() {
-  cy
-    .get('.ppm-container .edit-section-link')
-    .eq(-2)
-    .click();
+  cy.get('[data-cy="edit-ppm-dates"]').click();
 
   typeInInput({ name: 'planned_move_date', value: '5/28/2018' });
   typeInInput({ name: 'pickup_postal_code', value: '91206' });

--- a/cypress/integration/mymove/hhgPPM.js
+++ b/cypress/integration/mymove/hhgPPM.js
@@ -25,12 +25,30 @@ describe('service member adds a ppm to an hhg', function() {
     serviceMemberVerifiesContactInfoWasEdited();
     serviceMemberEditsBackupContactInfoSection();
     serviceMemberVerifiesBackupContactInfoWasEdited();
+    serviceMemberEditsHHGMoveDates();
     serviceMemberEditsPPMDatesAndLocations();
     serviceMemberVerifiesPPMDatesAndLocationsEdited();
     serviceMemberEditsPPMWeight();
     serviceMemberVerifiesPPMWeightsEdited();
   });
 });
+
+function serviceMemberEditsHHGMoveDates() {
+  cy
+    .get('.ppm-container .edit-section-link')
+    .eq(0)
+    .click();
+  // TODO: Currently does not support changing move dates for 2019. Add test to edit dates ewhen fixed
+
+  cy
+    .get('button')
+    .contains('Save')
+    .click();
+
+  cy.location().should(loc => {
+    expect(loc.pathname).to.match(/^\/moves\/[^/]+\/edit/);
+  });
+}
 
 function serviceMemberVerifiesHHGPPMSummary() {
   cy.location().should(loc => {

--- a/src/scenes/Review/EditShipment.jsx
+++ b/src/scenes/Review/EditShipment.jsx
@@ -102,7 +102,7 @@ function mapDispatchToProps(dispatch, ownProps) {
       dispatch(updateShipment(updateShipmentLabel, shipmentID, values)).then(function(action) {
         if (!action.error) {
           const moveID = Object.values(action.entities.shipments)[0].move_id;
-          dispatch(push(`/moves/${moveID}/review`));
+          dispatch(push(`/moves/${moveID}/edit`));
         }
       });
     },

--- a/src/scenes/Review/EditShipment.jsx
+++ b/src/scenes/Review/EditShipment.jsx
@@ -98,11 +98,15 @@ function mapDispatchToProps(dispatch, ownProps) {
     onDidMount: function() {
       dispatch(getShipment(getShipmentLabel, shipmentID));
     },
-    updateShipment: function(values) {
+    updateShipment: function(values, shipment) {
       dispatch(updateShipment(updateShipmentLabel, shipmentID, values)).then(function(action) {
         if (!action.error) {
           const moveID = Object.values(action.entities.shipments)[0].move_id;
-          dispatch(push(`/moves/${moveID}/edit`));
+          if (shipment.status !== 'DRAFT') {
+            dispatch(push(`/moves/${moveID}/edit`));
+          } else {
+            dispatch(push(`/moves/${moveID}/review`));
+          }
         }
       });
     },
@@ -116,7 +120,7 @@ function mergeProps(stateProps, dispatchProps, ownProps) {
   return Object.assign({}, stateProps, dispatchProps, ownProps, {
     updateShipment: function(event) {
       event.preventDefault();
-      dispatchProps.updateShipment(stateProps.formValues);
+      dispatchProps.updateShipment(stateProps.formValues, stateProps.shipment);
     },
     returnToReview: function(event) {
       event.preventDefault();

--- a/src/scenes/Review/HHGShipmentSummary.jsx
+++ b/src/scenes/Review/HHGShipmentSummary.jsx
@@ -35,7 +35,9 @@ export default function HHGShipmentSummary(props) {
             Move Dates
             <span className="edit-section-link">
               {' '}
-              <Link to={editDatePath}>Edit</Link>
+              <Link data-cy="edit-move" to={editDatePath}>
+                Edit
+              </Link>
             </span>
           </p>
 

--- a/src/scenes/Review/PPMShipmentSummary.jsx
+++ b/src/scenes/Review/PPMShipmentSummary.jsx
@@ -31,7 +31,9 @@ export default function PPMShipmentSummary(props) {
         <p className="heading">
           Dates & Locations
           <span className="edit-section-link">
-            <Link to={editDateAndLocationAddress}>Edit</Link>
+            <Link data-cy="edit-ppm-dates" to={editDateAndLocationAddress}>
+              Edit
+            </Link>
           </span>
         </p>
 
@@ -69,7 +71,9 @@ export default function PPMShipmentSummary(props) {
         <p className="heading">
           Weight
           <span className="edit-section-link">
-            <Link to={editWeightAddress}>Edit</Link>
+            <Link data-cy="edit-ppm-weight" to={editWeightAddress}>
+              Edit
+            </Link>
           </span>
         </p>
 

--- a/src/scenes/Review/ServiceMemberSummary.jsx
+++ b/src/scenes/Review/ServiceMemberSummary.jsx
@@ -224,7 +224,7 @@ function ServiceMemberSummary(props) {
 
 ServiceMemberSummary.propTypes = {
   backupContacts: PropTypes.array.isRequired,
-  serviceMember: PropTypes.object.isRequired,
+  serviceMember: PropTypes.object,
   schemaRank: PropTypes.object.isRequired,
   schemaAffiliation: PropTypes.object.isRequired,
   schemaOrdersType: PropTypes.object.isRequired,


### PR DESCRIPTION
## Description

This is an identical PR of [this](https://github.com/transcom/mymove/pull/1519) but now it is up to date with current master and has more reliable test cases

## Reviewer Notes
- Tests were failing because of use of brittle selectors (ex. `cy.get('button').eq(3)`). Changed to using cypress recommended data attributes to get more reliable test results
- Test cases that I did not covert to using cy data attributes (editing profile, order, contact info and backup contact info) are going to be removed in the near future

## Setup
`make server_run`
`make client_run`
Log in to an account with a submitted HHG
Edit the HHG's move dates

## Code Review Verification Steps
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/162521754) for this change
* [Cypress best practices](https://docs.cypress.io/guides/references/best-practices.html#Selecting-Elements)

