### PR TITLE
Change make target db_dev_migrate to allow users to change the DB_NAME.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -246,10 +246,9 @@ db_dev_run: db_run db_dev_create
 db_dev_reset: db_destroy db_dev_run
 
 db_dev_migrate: server_deps
-	@echo "Migrating the dev database..."
+	@echo "Migrating the ${DB_NAME} database..."
 	# We need to move to the bin/ directory so that the cwd contains `apply-secure-migration.sh`
 	cd bin && \
-		DB_HOST=localhost DB_PORT=5432 DB_NAME=dev_db \
 		./soda -c ../config/database.yml -p ../migrations migrate up
 
 db_test_create:
@@ -279,7 +278,7 @@ db_test_migrate: server_deps
 	@echo "Migrating the test database..."
 	# We need to move to the bin/ directory so that the cwd contains `apply-secure-migration.sh`
 	cd bin && \
-		DB_HOST=localhost DB_PORT=5432 DB_NAME=test_db \
+		DB_NAME=test_db \
 		./soda -c ../config/database.yml -p ../migrations migrate up
 
 db_test_migrate_docker: db_test_migrations_build

--- a/Makefile
+++ b/Makefile
@@ -178,7 +178,7 @@ else
 	go test -p 1 -count 1 -short $$(go list ./... | grep \\/cmd\\/webserver) 2> /dev/null
 endif
 
-server_test: server_deps server_generate db_test_run db_test_reset db_test_migrate
+server_test: server_deps server_generate db_test_reset db_test_migrate
 	# Don't run tests in /cmd or /pkg/gen & pass `-short` to exclude long running tests
 	# Use -test.parallel 1 to test packages serially and avoid database collisions
 	# Disable test caching with `-count 1` - caching was masking local test failures


### PR DESCRIPTION
## Description

This PR does two things:

- Change make target db_dev_migrate to allow users to change the DB_NAME.
- Fix make target server_test to ensure we don't create, destroy, and create the DB and cause a race condition.

For the first:

The script `bin/run-prod-migrations` relies on the ability to override `DB_NAME` env var when calling `make db_dev_migrate`.  This used to work and recent changes to the Makefile disabled it.  The assumption was that calling `db_dev_*` targets would only ever modify the `dev_db` database.  There are two ways to address, we could either make new `db_prod_migrations` targets to be more strict or we could revert to the old behavior.  I've gone with the latter since it's easier and creates minimal changes.

For the second:

`db_test_reset` calls `db_test_run` after `db_destroy`.  By calling run and then reset we essentially create, destroy, and create a DB and cause a race condition.  By removing the unneeded call to `db_test_run` we get fixed up.

For more information, we recently made `db_test_reset` call `db_destroy` because of the way in which we have three DB's on a single container that all need to be accessed via `localhost` while simultaneously needing to be able to reset those DBs without causing the web app or e2e tests to throw a runtime error when the DB disappears.

## Setup

### Run Prod Migrations

Try:

```sh
./bin/run-prod-migrations
```

Test that the migrations were actually applied to the `prod_migrations` DB and not `dev_db` by introspecting the `prod_migrations` DB with your tool of choice.

Then try `make db_dev_migrate` and you'll see that it uses env var defaults from `.envrc` and correctly migrates `dev_db`.

### Server Test

Try `make server_test` and it ought to work.

## Code Review Verification Steps

* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/162898668) for this change