### PR TITLE
Fixing tests with time.Now

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -178,7 +178,7 @@ else
 	go test -p 1 -count 1 -short $$(go list ./... | grep \\/cmd\\/webserver) 2> /dev/null
 endif
 
-server_test: server_deps server_generate db_test_run db_test_reset db_test_migrate
+server_test: server_deps server_generate db_test_reset db_test_run db_test_migrate
 	# Don't run tests in /cmd or /pkg/gen & pass `-short` to exclude long running tests
 	# Use -test.parallel 1 to test packages serially and avoid database collisions
 	# Disable test caching with `-count 1` - caching was masking local test failures

--- a/Makefile
+++ b/Makefile
@@ -178,7 +178,7 @@ else
 	go test -p 1 -count 1 -short $$(go list ./... | grep \\/cmd\\/webserver) 2> /dev/null
 endif
 
-server_test: server_deps server_generate db_test_reset db_test_run db_test_migrate
+server_test: server_deps server_generate db_test_reset db_test_migrate
 	# Don't run tests in /cmd or /pkg/gen & pass `-short` to exclude long running tests
 	# Use -test.parallel 1 to test packages serially and avoid database collisions
 	# Disable test caching with `-count 1` - caching was masking local test failures
@@ -188,7 +188,7 @@ server_test_all: server_deps server_generate db_dev_reset db_dev_migrate
 	# Like server_test but runs extended tests that may hit external services.
 	go test -p 1 -count 1 $$(go list ./... | grep -v \\/pkg\\/gen\\/ | grep -v \\/cmd\\/)
 
-server_test_coverage: server_deps server_generate db_dev_run db_dev_reset db_dev_migrate
+server_test_coverage: server_deps server_generate db_dev_reset db_dev_migrate
 	# Don't run tests in /cmd or /pkg/gen
 	# Use -test.parallel 1 to test packages serially and avoid database collisions
 	# Disable test caching with `-count 1` - caching was masking local test failures

--- a/Makefile
+++ b/Makefile
@@ -184,7 +184,7 @@ server_test: server_deps server_generate db_test_reset db_test_run db_test_migra
 	# Disable test caching with `-count 1` - caching was masking local test failures
 	go test -p 1 -count 1 -short $$(go list ./... | grep -v \\/pkg\\/gen\\/ | grep -v \\/cmd\\/)
 
-server_test_all: server_deps server_generate db_dev_run db_dev_reset db_dev_migrate
+server_test_all: server_deps server_generate db_dev_reset db_dev_migrate
 	# Like server_test but runs extended tests that may hit external services.
 	go test -p 1 -count 1 $$(go list ./... | grep -v \\/pkg\\/gen\\/ | grep -v \\/cmd\\/)
 

--- a/pkg/handlers/internalapi/personally_procured_move_test.go
+++ b/pkg/handlers/internalapi/personally_procured_move_test.go
@@ -172,8 +172,9 @@ func (suite *HandlerSuite) TestPatchPPMHandler() {
 	initialWeight := swag.Int64(4100)
 	newWeight := swag.Int64(4105)
 
-	initialMoveDate := time.Now().Add(-2 * 24 * time.Hour)
-	newMoveDate := time.Now()
+	// Date picked essentialy at random, but needs to be within TestYear
+	newMoveDate := time.Date(testdatagen.TestYear, time.November, 10, 23, 0, 0, 0, time.UTC)
+	initialMoveDate := newMoveDate.Add(-2 * 24 * time.Hour)
 
 	hasAdditionalPostalCode := swag.Bool(true)
 	newHasAdditionalPostalCode := swag.Bool(false)
@@ -254,7 +255,8 @@ func (suite *HandlerSuite) TestPatchPPMHandlerSetWeightLater() {
 
 	weight := swag.Int64(4100)
 
-	moveDate := time.Now()
+	// Date picked essentialy at random, but needs to be within TestYear
+	moveDate := time.Date(testdatagen.TestYear, time.November, 10, 23, 0, 0, 0, time.UTC)
 
 	pickupPostalCode := swag.String("32168")
 	destinationPostalCode := swag.String("29401")
@@ -326,8 +328,10 @@ func (suite *HandlerSuite) TestPatchPPMHandlerWrongUser() {
 	newSize := internalmessages.TShirtSize("L")
 	initialWeight := swag.Int64(1)
 	newWeight := swag.Int64(5)
-	initialMoveDate := time.Now().Add(-2 * 24 * time.Hour)
-	newMoveDate := time.Now()
+
+	// Date picked essentialy at random, but needs to be within TestYear
+	newMoveDate := time.Date(testdatagen.TestYear, time.November, 10, 23, 0, 0, 0, time.UTC)
+	initialMoveDate := newMoveDate.Add(-2 * 24 * time.Hour)
 
 	user2 := testdatagen.MakeDefaultServiceMember(suite.TestDB())
 	move := testdatagen.MakeDefaultMove(suite.TestDB())


### PR DESCRIPTION
## Description

There were a couple things breaking server_test:

1. A test was using `time.Now`, which meant that the data it was creating slowly was leaving the window where other test data (performance period data, to be specific) existed to support it. Jan 1 was the cut off, and then the test started failing. I changed the test to use the Test Data Gen constants.
1. `make server_test` was failing because there was an order of operations problem in the make target. The test DB was getting created, then destroyed. It should be destroyed, then created.

