### PR TITLE
Move building of chamber and soda in circleci to the makefile

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -595,9 +595,9 @@ workflows:
             - pre_deps_yarn
             - acceptance_tests
           # if testing on experimental, you can disable these tests by using the commented block below.
-          #filters:
-          #  branches:
-          #    ignore: YOUR BRANCH NAME HERE
+          filters:
+            branches:
+              ignore: cg_162931822_build_chamber_and_soda_separately
 
       - integration_tests_office:
           requires:
@@ -605,9 +605,9 @@ workflows:
             - pre_deps_yarn
             - acceptance_tests
           # if testing on experimental, you can disable these tests by using the commented block below.
-          #filters:
-          #  branches:
-          #    ignore: YOUR BRANCH NAME HERE
+          filters:
+            branches:
+              ignore: cg_162931822_build_chamber_and_soda_separately
 
       - integration_tests_tsp:
           requires:
@@ -615,9 +615,9 @@ workflows:
             - pre_deps_yarn
             - acceptance_tests
           # if testing on experimental, you can disable these tests by using the commented block below.
-          #filters:
-          #  branches:
-          #    ignore: YOUR BRANCH NAME HERE
+          filters:
+            branches:
+              ignore: cg_162931822_build_chamber_and_soda_separately
 
       - client_test:
           requires:
@@ -651,21 +651,21 @@ workflows:
             - build_migrations
           filters:
             branches:
-              only: placeholder
+              only: cg_162931822_build_chamber_and_soda_separately
 
       - deploy_experimental_app:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: placeholder
+              only: cg_162931822_build_chamber_and_soda_separately
 
       - deploy_experimental_app_client_tls:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: placeholder
+              only: cg_162931822_build_chamber_and_soda_separately
 
       - check_circle_against_staging_sha:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -434,8 +434,7 @@ jobs:
       - restore_cache:
           keys:
             - v1-mymove-node-modules-{{ checksum "yarn.lock" }}
-      # TODO (dynamike): Move the building chamber binary into the Makefile
-      - run: go build -o bin/chamber -ldflags "-linkmode external -extldflags -static" ./vendor/github.com/segmentio/chamber
+      - run: make build_chamber
       - run: make build
       - build_tag_push:
           dockerfile: Dockerfile
@@ -453,12 +452,7 @@ jobs:
       - restore_cache:
           keys:
             - mymove-vendor-{{ checksum "Gopkg.lock" }}
-      # TODO (pjdufour-truss): Move the building of soda and chamber binaries into the Makefile
-      - run:
-          name: Build Chamber and Soda
-          command: |
-            go build -o bin/chamber -ldflags "-linkmode external -extldflags -static" ./vendor/github.com/segmentio/chamber
-            go build -o bin/soda -ldflags "-linkmode external -extldflags -static" ./vendor/github.com/gobuffalo/pop/soda
+      - run: make build_chamber build_soda
       - build_tag_push:
           dockerfile: Dockerfile.migrations
           tag: ppp-migrations:dev

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -595,9 +595,9 @@ workflows:
             - pre_deps_yarn
             - acceptance_tests
           # if testing on experimental, you can disable these tests by using the commented block below.
-          filters:
-            branches:
-              ignore: cg_162931822_build_chamber_and_soda_separately
+          # filters:
+          #  branches:
+          #    ignore: placeholder_branch_name
 
       - integration_tests_office:
           requires:
@@ -605,9 +605,9 @@ workflows:
             - pre_deps_yarn
             - acceptance_tests
           # if testing on experimental, you can disable these tests by using the commented block below.
-          filters:
-            branches:
-              ignore: cg_162931822_build_chamber_and_soda_separately
+          # filters:
+          #   branches:
+          #     ignore: placeholder_branch_name
 
       - integration_tests_tsp:
           requires:
@@ -615,9 +615,9 @@ workflows:
             - pre_deps_yarn
             - acceptance_tests
           # if testing on experimental, you can disable these tests by using the commented block below.
-          filters:
-            branches:
-              ignore: cg_162931822_build_chamber_and_soda_separately
+          # filters:
+          #   branches:
+          #     ignore: placeholder_branch_name
 
       - client_test:
           requires:
@@ -651,21 +651,21 @@ workflows:
             - build_migrations
           filters:
             branches:
-              only: cg_162931822_build_chamber_and_soda_separately
+              only: placeholder_branch_name
 
       - deploy_experimental_app:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: cg_162931822_build_chamber_and_soda_separately
+              only: placeholder_branch_name
 
       - deploy_experimental_app_client_tls:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: cg_162931822_build_chamber_and_soda_separately
+              only: placeholder_branch_name
 
       - check_circle_against_staging_sha:
           requires:

--- a/Makefile
+++ b/Makefile
@@ -90,14 +90,22 @@ go_deps: go_version .go_deps.stamp
 	bin/check_gopath.sh
 	dep ensure -vendor-only
 
-server_deps: check_hosts go_deps .server_deps.stamp
+build_chamber: go_deps .build_chamber.stamp
+.build_chamber.stamp:
+	go build -i -ldflags "$(LDFLAGS)" -o bin/chamber ./vendor/github.com/segmentio/chamber
+	touch .build_chamber.stamp
+
+build_soda: go_deps .build_soda.stamp
+.build_soda.stamp:
+	go build -i -ldflags "$(LDFLAGS)" -o bin/soda ./vendor/github.com/gobuffalo/pop/soda
+	touch .build_soda.stamp
+
+server_deps: check_hosts go_deps build_chamber build_soda .server_deps.stamp
 .server_deps.stamp:
 	# Unfortunately, dep ensure blows away ./vendor every time so these builds always take a while
 	go install ./vendor/github.com/golang/lint/golint # golint needs to be accessible for the pre-commit task to run, so `install` it
-	go build -i -ldflags "$(LDFLAGS)" -o bin/chamber ./vendor/github.com/segmentio/chamber
 	go build -i -ldflags "$(LDFLAGS)" -o bin/gosec ./vendor/github.com/securego/gosec/cmd/gosec
 	go build -i -ldflags "$(LDFLAGS)" -o bin/gin ./vendor/github.com/codegangsta/gin
-	go build -i -ldflags "$(LDFLAGS)" -o bin/soda ./vendor/github.com/gobuffalo/pop/soda
 	go build -i -ldflags "$(LDFLAGS)" -o bin/swagger ./vendor/github.com/go-swagger/go-swagger/cmd/swagger
 	touch .server_deps.stamp
 server_deps_linux: go_deps .server_deps_linux.stamp

--- a/Makefile
+++ b/Makefile
@@ -381,6 +381,7 @@ clean:
 .PHONY: pre-commit deps test client_deps client_build client_run client_test prereqs check_hosts
 .PHONY: server_run_standalone server_run server_run_default server_test webserver_test
 .PHONY: go_deps_update server_go_bindata
+.PHONY: build_chamber build_soda
 .PHONY: server_generate server_deps server_build
 .PHONY: server_generate_linux server_deps_linux server_build_linux
 .PHONY: db_run db_destroy


### PR DESCRIPTION
## Description

Found some TODOs in the CircleCI config file.  These were easy to pull out into separate targets to be used in by CircleCI.

## Setup

This should work as usual:

```sh
make server_deps
```

But also try:

```
make clean build_chamber build_soda
```

## Code Review Verification Steps

* [x] Request review from a member of a different team.

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/162931822) for this change