### PR TITLE
Fixing dep sync issues

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1441,6 +1441,7 @@
   analyzer-version = 1
   input-imports = [
     "github.com/aws/aws-sdk-go/aws",
+    "github.com/aws/aws-sdk-go/aws/endpoints",
     "github.com/aws/aws-sdk-go/aws/session",
     "github.com/aws/aws-sdk-go/service/s3",
     "github.com/aws/aws-sdk-go/service/ses",
@@ -1475,6 +1476,7 @@
     "github.com/honeycombio/beeline-go/wrappers/hnynethttp",
     "github.com/imdario/mergo",
     "github.com/jessevdk/go-flags",
+    "github.com/jmoiron/sqlx",
     "github.com/jung-kurt/gofpdf",
     "github.com/magiconair/properties/assert",
     "github.com/markbates/goth",

--- a/pkg/service/invoice/update_invoice_submitted_test.go
+++ b/pkg/service/invoice/update_invoice_submitted_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/facebookgo/clock"
-	"github.com/gobuffalo/uuid"
+	"github.com/gofrs/uuid"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"
 )


### PR DESCRIPTION
## Description

We had a few places where `dep` was complaining about sync problems.  One was due to a reference to the deprecated UUID package.  The others were just missing from `Gopkg.lock`.

How I fixed `Gopkg.lock` (after correcting the UUID package reference):
1) `make clean`
2) `make server_generate`
3) `dep check` (to see the issues)
4) `dep ensure` (to fix the issues)
5) `dep check` (to verify all is well)

## Setup

To test, run `make deps` followed by a `dep check` on this branch and verify that there are no issues reported.
