### PR TITLE
Add the DPSETAROLE cookie

### DIFF
--- a/pkg/dpsauth/auth.go
+++ b/pkg/dpsauth/auth.go
@@ -47,7 +47,16 @@ func (h SetCookieHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	cookie.Name = claims.CookieName
 	cookie.Domain = h.cookieDomain
 	cookie.Path = "/"
-	w.Header().Set("Set-Cookie", cookie.String())
+	http.SetCookie(w, cookie)
+
+	roleCookie := http.Cookie{
+		Domain:  h.cookieDomain,
+		Expires: cookie.Expires,
+		Name:    "DPSETAROLE",
+		Path:    "/",
+		Value:   "dodcustomer",
+	}
+	http.SetCookie(w, &roleCookie)
 
 	http.Redirect(w, r, claims.DPSRedirectURL, http.StatusSeeOther)
 }

--- a/pkg/dpsauth/auth_test.go
+++ b/pkg/dpsauth/auth_test.go
@@ -1,0 +1,31 @@
+package dpsauth
+
+import (
+	"net/http"
+	"net/http/httptest"
+)
+
+func (suite *dpsAuthSuite) TestSetCookieHandler() {
+	secretKey := "secret"
+	dpsCookieName := "DPS_COOKIE"
+	cookieDomain := "sddctest"
+	handler := NewSetCookieHandler(suite.logger, secretKey, cookieDomain)
+
+	rr := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/dps_auth/set_cookie", nil)
+	token, _ := GenerateToken("uuid", dpsCookieName, "www.example.com", secretKey)
+	q := req.URL.Query()
+	q.Add("token", token)
+	req.URL.RawQuery = q.Encode()
+
+	handler.ServeHTTP(rr, req)
+	suite.Equal(http.StatusSeeOther, rr.Code)
+
+	cookies := rr.HeaderMap["Set-Cookie"]
+	suite.Equal(2, len(cookies))
+
+	suite.Contains(cookies[0], dpsCookieName)
+	suite.Contains(cookies[0], cookieDomain)
+	suite.Contains(cookies[1], "DPSETAROLE=dodcustomer")
+	suite.Contains(cookies[1], cookieDomain)
+}

--- a/pkg/dpsauth/cookie_test.go
+++ b/pkg/dpsauth/cookie_test.go
@@ -1,16 +1,19 @@
 package dpsauth
 
 import (
+	"log"
 	"net/url"
 	"os"
 	"testing"
 
 	"github.com/gofrs/uuid"
 	"github.com/stretchr/testify/suite"
+	"go.uber.org/zap"
 )
 
 type dpsAuthSuite struct {
 	suite.Suite
+	logger *zap.Logger
 }
 
 func (suite *dpsAuthSuite) SetupSuite() {
@@ -39,6 +42,10 @@ func (suite *dpsAuthSuite) TestCookie() {
 }
 
 func TestDPSAuthSuite(t *testing.T) {
-	s := &dpsAuthSuite{}
+	logger, err := zap.NewDevelopment()
+	if err != nil {
+		log.Panic(err)
+	}
+	s := &dpsAuthSuite{logger: logger}
 	suite.Run(t, s)
 }


### PR DESCRIPTION
This cookie is also necessary for DPS authentication. Since DPS authentication is only for service members, the role is hardcoded to "dodcustomer", which is a service member (as opposed to back office / TSP). 

Tested in experimental.