### PR TITLE
Manages payment request state locally instead of using redux [delivers #162064075]

### DIFF
--- a/src/shared/Invoice/InvoicePaymentAlert.jsx
+++ b/src/shared/Invoice/InvoicePaymentAlert.jsx
@@ -2,6 +2,8 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 
 import Alert from 'shared/Alert';
+import { isError, isLoading, isSuccess } from 'shared/constants';
+
 import './InvoicePanel.css';
 
 class InvoicePaymentAlert extends PureComponent {
@@ -9,19 +11,19 @@ class InvoicePaymentAlert extends PureComponent {
     let paymentAlert;
     const status = this.props.createInvoiceStatus;
 
-    if (status.error) {
+    if (status === isError) {
       paymentAlert = (
         <Alert type="error" heading="Oops, something went wrong!">
           <span className="warning--header">Please try again.</span>
         </Alert>
       );
-    } else if (status.isLoading) {
+    } else if (status === isLoading) {
       paymentAlert = (
         <Alert type="loading" heading="Creating invoice">
           <span className="warning--header">Sending information to USBank/Syncada.</span>
         </Alert>
       );
-    } else if (status.isSuccess) {
+    } else if (status === isSuccess) {
       paymentAlert = (
         <div>
           <Alert type="success" heading="Success!">
@@ -36,7 +38,7 @@ class InvoicePaymentAlert extends PureComponent {
 }
 
 InvoicePaymentAlert.propTypes = {
-  createInvoiceStatus: PropTypes.object,
+  createInvoiceStatus: PropTypes.string,
 };
 
 export default InvoicePaymentAlert;

--- a/src/shared/Invoice/UnbilledTable.jsx
+++ b/src/shared/Invoice/UnbilledTable.jsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import { isOfficeSite } from 'shared/constants.js';
 import LineItemTable from 'shared/Invoice/LineItemTable';
 import Alert from 'shared/Alert';
+import { isLoading } from 'shared/constants';
 
 import './InvoicePanel.css';
 
@@ -33,7 +34,7 @@ export class UnbilledTable extends PureComponent {
     const allowPayments =
       this.props.allowPayments &&
       isOfficeSite && //user is an office user
-      !this.props.createInvoiceStatus.isLoading;
+      this.props.createInvoiceStatus !== isLoading;
 
     // Table header, also contains buttons for initiating invoice payment
     let header;

--- a/src/shared/constants.js
+++ b/src/shared/constants.js
@@ -17,3 +17,8 @@ export const isTspSite = hostname.startsWith('tsp') || '';
 export const titleCase = str => {
   return str.charAt(0).toUpperCase() + str.slice(1);
 };
+
+// These constants are used to track network requests using component state
+export const isError = 'REQUEST_ERROR';
+export const isLoading = 'REQUEST_LOADING';
+export const isSuccess = 'REQUEST_SUCCESS';


### PR DESCRIPTION
## Description

Previously, we managed showing invoice payment alerts using `swaggerRequest` state in Redux. That led to alerts, like the Redux state it's based on, persisting across screens. This PR instead sets component state flags using the request call itself, and alerts no longer wear out their welcome.

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/162064075) for this change