### PR TITLE
Stop brew services postgresql from running locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -215,6 +215,9 @@ e2e_clean:
 	docker rm -f e2e_migrations || true
 
 db_run:
+ifndef CIRCLECI
+	brew services stop postgresql 2> /dev/null || true
+endif
 	@echo "Starting the local docker database container..."
 	# The version of the postgres container should match production as closely
 	# as possible.


### PR DESCRIPTION
## Description

It sometimes happens that brew is running postgresql locally as a service and it interferes with the docker container running postgresql because they both are listening on localhost on port 5432.  This turns out to be pretty hard to debug because we so rarely expect brew to be the issue.  This PR quietly stops the brew postgresql process whenever the docker posgres service is run or reset.

## Setup

First start the brew service:

```sh
brew services run postgresql
==> Successfully ran `postgresql` (label: homebrew.mxcl.postgresql)
```

Then run the docker psql container:

```sh
make db_run
brew services stop postgresql 2> /dev/null || true
Stopping `postgresql`... (might take a while)
Starting the local docker database container...
# The version of the postgres container should match production as closely
# as possible.
# https://github.com/transcom/ppp-infra/blob/7ba2e1086ab1b2a0d4f917b407890817327ffb3d/modules/aws-app-environment/database/variables.tf#L48
docker start db-dev || \
                docker run --name db-dev \
                        -e \
                        POSTGRES_PASSWORD=mysecretpassword \
                        -d \
                        -p 5432:5432 \
                        postgres:10.5
db-dev
```

This will also get called on `make db_dev_reset` because that will call `make db_destroy db_run db_dev_create` and the `db_run` step will catch the brew service running.

## Code Review Verification Steps

* [x] Request review from a member of a different team.