### PR TITLE
Improve CircleCI branch failure messaging

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ commands:
       - run:
           name: Announce failure
           command: |
-            [[ $CIRCLE_BRANCH = cg_162974053_improve_slack_failure_message ]] || exit 0
+            [[ $CIRCLE_BRANCH = master ]] || exit 0
             bin/circleci-announce-broken-branch
           when: on_fail
   halt_workflow_if_older_sha:
@@ -406,7 +406,6 @@ jobs:
     executor: mymove_small
     steps:
       - checkout
-      - run: exit 1
       - restore_cache:
           keys:
             - go-pkg-dep-sources-{{ checksum "Gopkg.lock" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -251,6 +251,7 @@ jobs:
       - restore_cache:
           keys:
             - mymove-vendor-{{ checksum "Gopkg.lock" }}
+      - run: exit 1
       - run:
           name: Run make server_generate
           command: make server_generate
@@ -260,7 +261,6 @@ jobs:
           environment:
             LOGIN_GOV_HOSTNAME: idp.int.identitysandbox.gov
             DOD_CA_PACKAGE: /home/circleci/go/src/github.com/transcom/mymove/config/tls/Certificates_PKCS7_v5.4_DoD.der.p7b
-      - run: exit 1
       - announce_failure
 
   # `integration_tests_mymove` runs integration tests using Cypress.  https://www.cypress.io/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -251,7 +251,6 @@ jobs:
       - restore_cache:
           keys:
             - mymove-vendor-{{ checksum "Gopkg.lock" }}
-      - run: exit 1
       - run:
           name: Run make server_generate
           command: make server_generate
@@ -407,6 +406,7 @@ jobs:
     executor: mymove_small
     steps:
       - checkout
+      - run: exit 1
       - restore_cache:
           keys:
             - go-pkg-dep-sources-{{ checksum "Gopkg.lock" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ commands:
       - run:
           name: Announce failure
           command: |
-            [[ $CIRCLE_BRANCH = master ]] || exit 0
+            [[ $CIRCLE_BRANCH = cg_162974053_improve_slack_failure_message ]] || exit 0
             bin/circleci-announce-broken-branch
           when: on_fail
   halt_workflow_if_older_sha:
@@ -260,6 +260,7 @@ jobs:
           environment:
             LOGIN_GOV_HOSTNAME: idp.int.identitysandbox.gov
             DOD_CA_PACKAGE: /home/circleci/go/src/github.com/transcom/mymove/config/tls/Certificates_PKCS7_v5.4_DoD.der.p7b
+      - run: exit 1
       - announce_failure
 
   # `integration_tests_mymove` runs integration tests using Cypress.  https://www.cypress.io/

--- a/bin/circleci-announce-broken-branch
+++ b/bin/circleci-announce-broken-branch
@@ -10,9 +10,10 @@ message="The $CIRCLE_PROJECT_REPONAME $CIRCLE_BRANCH branch broke on job $CIRCLE
 #####
 ## Announce in Slack channel
 #####
-color="#ffa500"
+# 'color' can be any hex code or the key words 'good', 'warning', or 'danger'
+color="warning"
 if [[ $CIRCLE_JOB == *"deploy"* ]]; then
-  color="#ff0000"
+  color="danger"
 fi
 
 slack_payload=$(

--- a/bin/circleci-announce-broken-branch
+++ b/bin/circleci-announce-broken-branch
@@ -13,6 +13,7 @@ message="The $CIRCLE_PROJECT_REPONAME $CIRCLE_BRANCH branch broke on job $CIRCLE
 #####
 # 'color' can be any hex code or the key words 'good', 'warning', or 'danger'
 color="warning"
+CIRCLE_JOB=deploy_fake_cgilmer
 if [[ $CIRCLE_JOB == *"deploy"* ]]; then
   color="danger"
 fi

--- a/bin/circleci-announce-broken-branch
+++ b/bin/circleci-announce-broken-branch
@@ -1,7 +1,8 @@
 #!/bin/bash
 set -euo pipefail
 
-GIT_TEXT=$(git --no-pager show --format=format:'%s')
+# Get git diff from last commit and escape double quotes
+GIT_TEXT=$(git --no-pager show --format=format:'%s' | sed 's/"/\\"/g')
 NOW=$(date '+%s')
 NOW_ISO8601=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 

--- a/bin/circleci-announce-broken-branch
+++ b/bin/circleci-announce-broken-branch
@@ -4,8 +4,8 @@ set -euo pipefail
 NOW=$(date '+%s')
 NOW_ISO8601=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
-title="CircleCI $CIRCLE_BRANCH branch failure"
-pretext="$CIRCLE_JOB #$CIRCLE_BUILD_NUM"
+pretext="CircleCI $CIRCLE_BRANCH branch failure!"
+title="CircleCI build #$CIRCLE_BUILD_NUM failed on job $CIRCLE_JOB"
 message="The $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME $CIRCLE_BRANCH branch broke on job $CIRCLE_JOB! Contact $CIRCLE_USERNAME for more information."
 
 #####
@@ -54,7 +54,7 @@ cat <<EOM
   "payload": {
     "summary": "$message",
     "timestamp": "$NOW_ISO8601",
-    "source": "$title for $pretext",
+    "source": "$pretext $title",
     "severity": "info",
     "class": "cicd failure"
   },

--- a/bin/circleci-announce-broken-branch
+++ b/bin/circleci-announce-broken-branch
@@ -74,9 +74,9 @@ echo "Pager Duty Payload:"
 echo "$pd_payload"
 echo
 
-# curl -XPOST \
-#   -H "Authorization: Token token=$PD_AUTH_TOKEN" \
-#   -H "Accept: application/vnd.pagerduty+json;version=2" \
-#   -H "Content-Type: application/json" \
-#   --data "$pd_payload" \
-#   "https://events.pagerduty.com/v2/enqueue"
+curl -XPOST \
+  -H "Authorization: Token token=$PD_AUTH_TOKEN" \
+  -H "Accept: application/vnd.pagerduty+json;version=2" \
+  -H "Content-Type: application/json" \
+  --data "$pd_payload" \
+  "https://events.pagerduty.com/v2/enqueue"

--- a/bin/circleci-announce-broken-branch
+++ b/bin/circleci-announce-broken-branch
@@ -64,9 +64,9 @@ EOM
 echo "$pd_payload"
 echo
 
-curl -XPOST \
-  -H "Authorization: Token token=$PD_AUTH_TOKEN" \
-  -H "Accept: application/vnd.pagerduty+json;version=2" \
-  -H "Content-Type: application/json" \
-  --data "$pd_payload" \
-  "https://events.pagerduty.com/v2/enqueue"
+# curl -XPOST \
+#   -H "Authorization: Token token=$PD_AUTH_TOKEN" \
+#   -H "Accept: application/vnd.pagerduty+json;version=2" \
+#   -H "Content-Type: application/json" \
+#   --data "$pd_payload" \
+#   "https://events.pagerduty.com/v2/enqueue"

--- a/bin/circleci-announce-broken-branch
+++ b/bin/circleci-announce-broken-branch
@@ -1,19 +1,18 @@
 #!/bin/bash
 set -euo pipefail
 
-# Get git diff from last commit and escape double quotes
-GIT_TEXT=$(git --no-pager show --format=format:'%s' | sed 's/"/\\"/g')
 NOW=$(date '+%s')
 NOW_ISO8601=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
-message="The $CIRCLE_PROJECT_REPONAME $CIRCLE_BRANCH branch broke on job $CIRCLE_JOB! Contact $CIRCLE_USERNAME for more information."
+title="CircleCI $CIRCLE_BRANCH branch failure"
+pretext="$CIRCLE_JOB #$CIRCLE_BUILD_NUM"
+message="The $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME $CIRCLE_BRANCH branch broke on job $CIRCLE_JOB! Contact $CIRCLE_USERNAME for more information."
 
 #####
 ## Announce in Slack channel
 #####
 # 'color' can be any hex code or the key words 'good', 'warning', or 'danger'
 color="warning"
-CIRCLE_JOB=deploy_fake_cgilmer
 if [[ $CIRCLE_JOB == *"deploy"* ]]; then
   color="danger"
 fi
@@ -26,10 +25,11 @@ cat <<EOM
         {
             "fallback": "$message $CIRCLE_BUILD_URL",
             "color": "$color",
-            "pretext": "$message",
-            "title": "CircleCI job $CIRCLE_JOB #$CIRCLE_BUILD_NUM",
+            "pretext": "$pretext",
+            "author_name": "$CIRCLE_USERNAME",
+            "title": "$title",
             "title_link": "$CIRCLE_BUILD_URL",
-            "text": "$GIT_TEXT",
+            "text": "$message",
             "ts": $NOW
         }
     ]
@@ -54,7 +54,7 @@ cat <<EOM
   "payload": {
     "summary": "$message",
     "timestamp": "$NOW_ISO8601",
-    "source": "CircleCI job $CIRCLE_JOB #$CIRCLE_BUILD_NUM",
+    "source": "$title for $pretext",
     "severity": "info",
     "class": "cicd failure"
   },

--- a/bin/circleci-announce-broken-branch
+++ b/bin/circleci-announce-broken-branch
@@ -5,19 +5,26 @@ GIT_TEXT=$(git --no-pager show --format=format:'%s')
 NOW=$(date '+%s')
 NOW_ISO8601=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
+message="The $CIRCLE_PROJECT_REPONAME $CIRCLE_BRANCH branch broke on job $CIRCLE_JOB! Contact $CIRCLE_USERNAME for more information."
+
 #####
 ## Announce in Slack channel
 #####
+color="#ffa500"
+if [[ $CIRCLE_JOB == *"deploy"* ]]; then
+  color="#ff0000"
+fi
+
 slack_payload=$(
 cat <<EOM
 {
     "channel": "#dp3-engineering",
     "attachments": [
         {
-            "fallback": "The $CIRCLE_PROJECT_REPONAME $CIRCLE_BRANCH branch is broken: $CIRCLE_BUILD_URL",
-            "color": "#ff0000",
-            "pretext": "The $CIRCLE_PROJECT_REPONAME $CIRCLE_BRANCH branch is broken!",
-            "title": "CircleCI job #$CIRCLE_BUILD_NUM",
+            "fallback": "$message $CIRCLE_BUILD_URL",
+            "color": "$color",
+            "pretext": "$message",
+            "title": "CircleCI job $CIRCLE_JOB #$CIRCLE_BUILD_NUM",
             "title_link": "$CIRCLE_BUILD_URL",
             "text": "$GIT_TEXT",
             "ts": $NOW
@@ -36,14 +43,14 @@ pd_payload=$(
 cat <<EOM
 {
   "payload": {
-    "summary": "The $CIRCLE_PROJECT_REPONAME $CIRCLE_BRANCH branch is broken",
+    "summary": "$message",
     "timestamp": "$NOW_ISO8601",
-    "source": "CircleCI job #$CIRCLE_BUILD_NUM",
+    "source": "CircleCI job $CIRCLE_JOB #$CIRCLE_BUILD_NUM",
     "severity": "info",
     "class": "cicd failure"
   },
   "routing_key": "$PD_ROUTING_KEY",
-  "dedup_key": "circle-$CIRCLE_BUILD_NUM",
+  "dedup_key": "circle-$CIRCLE_WORKFLOW_ID",
   "links": [{
     "href": "$CIRCLE_BUILD_URL",
     "text": "CircleCI Build URL"

--- a/bin/circleci-announce-broken-branch
+++ b/bin/circleci-announce-broken-branch
@@ -34,6 +34,12 @@ cat <<EOM
 }
 EOM
 )
+
+echo
+echo "Slack Payload:"
+echo "$slack_payload"
+echo
+
 curl -X POST --data-urlencode payload="$slack_payload" "$SLACK_WEBHOOK_URL"
 
 #####
@@ -61,6 +67,8 @@ cat <<EOM
 EOM
 )
 
+echo
+echo "Pager Duty Payload:"
 echo "$pd_payload"
 echo
 


### PR DESCRIPTION
## Description

The current CircleCI messaging to slack and pager duty is inadequate in that there isn't enough context.  This update should improve the context we see around build failures in CircleCI.

New message will look like this:

<img width="733" alt="screen shot 2019-01-03 at 5 05 27 pm" src="https://user-images.githubusercontent.com/219296/50669391-d0336780-0f79-11e9-8a38-02f6a4d2a5b3.png">

Also, if a job has the word `deploy` in it then the color will change to red.

## Reviewer Notes

Please review the messaging to ensure it meets our expectations.

## Setup

The way I tested this was to comment out the code that sends notifications to PagerDuty.  Then I modified the `.circleci/config.yml` so that `build_tools` would fail early and `announce_failures` would trigger only on my branch.  I let people in #dp3-engineering know that this was happening in advance and then pushed my work.  That helped me create the image above.

All of this work will have to be reverted before merging.

## Code Review Verification Steps

* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/162974053) for this change
* [Slack Attachment Guide](https://api.slack.com/docs/message-attachments)