### PR TITLE
Include an error message if the ppp-infra directory is not linked correctly

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -166,6 +166,8 @@ fi
 if [ -e "$PPP_INFRA_PATH"/transcom-ppp/.envrc ]
 then
     source_env "$PPP_INFRA_PATH"/transcom-ppp/.envrc
+else
+    log_error "Unable to find the transcom-ppp/.envrc file. Please check $$PPP_INFRA_PATH if aws commands don't work"
 fi
 
 # Check that all required environment variables are set

--- a/.envrc
+++ b/.envrc
@@ -128,7 +128,7 @@ require HERE_MAPS_APP_ID "See https://docs.google.com/document/d/16ZomLuR6BPEIK4
 require HERE_MAPS_APP_CODE "See https://docs.google.com/document/d/16ZomLuR6BPEIK4enfMcqu31oiJYZWNDe9Znyf9e88dg"
 
 # Transcom ppp-infra repo path
-require PPP_INFRA_PATH "Set to your local checkout of https://github.com/transcom/ppp-infra (e.g., ~/git/ppp-infra)."
+require PPP_INFRA_PATH "Set to your local checkout of https://github.com/transcom/ppp-infra (e.g., ~/your-personal-repo-directory/ppp-infra)."
 
 # GEX integration config
 export GEX_BASIC_AUTH_USERNAME="mymovet"

--- a/.envrc
+++ b/.envrc
@@ -167,7 +167,7 @@ if [ -e "$PPP_INFRA_PATH"/transcom-ppp/.envrc ]
 then
     source_env "$PPP_INFRA_PATH"/transcom-ppp/.envrc
 else
-    log_error "Unable to find the transcom-ppp/.envrc file. Please check $$PPP_INFRA_PATH if aws commands don't work"
+    log_error "Unable to find the transcom-ppp/.envrc file. Please check PPP_INFRA_PATH if aws commands don't work."
 fi
 
 # Check that all required environment variables are set


### PR DESCRIPTION
## Description

Sometimes the transcom/ppp-infra repo location is either changed or not set and there is no error when calling `direnv allow`.  This adds some text to help people figure out what's wrong.

## Reviewer Notes

Is the message clear enough?

## Setup

Change your `PPP_INFRA_PATH` location in `.envrc.local` and run `direnv allow`.  The error should say:

```sh
direnv: loading .envrc
direnv: loading .envrc.local
direnv: Unable to find the transcom-ppp/.envrc file. Please check PPP_INFRA_PATH if aws commands don't work
direnv: export +AWS_PROFILE +AWS_S3_BUCKET_NAME +AWS_S3_KEY_NAMESPACE +AWS_S3_REGION +AWS_SES_DOMAIN +AWS_SES_REGION +CLIENT_AUTH_SECRET_KEY +CLIENT_TLS_CERT +CLIENT_TLS_KEY +CSRF_AUTH_KEY +DANGEROUSLY_DISABLE_HOST_CHECK +DB_HOST +DB_NAME +DB_PASSWORD +DB_PORT +DB_USER +DOD_CA_PACKAGE +DPS_AUTH_COOKIE_SECRET_KEY +DPS_AUTH_SECRET_KEY +DPS_COOKIE_EXPIRES_IN_MINUTES +DPS_COOKIE_NAME +DPS_REDIRECT_URL +GEX_BASIC_AUTH_PASSWORD +GEX_BASIC_AUTH_USERNAME +GEX_DOD_CA +HERE_MAPS_APP_CODE +HERE_MAPS_APP_ID +HERE_MAPS_GEOCODE_ENDPOINT +HERE_MAPS_ROUTING_ENDPOINT +HONEYCOMB_API_HOST +HONEYCOMB_API_KEY +HONEYCOMB_DATASET +HONEYCOMB_DEBUG +HONEYCOMB_ENABLED +HTTP_SDDC_PORT +HTTP_SDDC_PROTOCOL +IWS_RBS_HOST +LOGIN_GOV_CALLBACK_PORT +LOGIN_GOV_CALLBACK_PROTOCOL +LOGIN_GOV_HOSTNAME +LOGIN_GOV_MY_CLIENT_ID +LOGIN_GOV_OFFICE_CLIENT_ID +LOGIN_GOV_SECRET_KEY +LOGIN_GOV_TSP_CLIENT_ID +MOVE_MIL_DOD_CA_CERT +MOVE_MIL_DOD_TLS_CERT +MOVE_MIL_DOD_TLS_KEY +MYMOVE_DIR +NO_SESSION_TIMEOUT +PPP_INFRA_PATH +SECURE_MIGRATION_DIR +SECURE_MIGRATION_SOURCE +TZ
```

## Code Review Verification Steps

* [x] Request review from a member of a different team.