### PR TITLE
Adding New Office Users via secure migration #162914248

### DIFF
--- a/local_migrations/20190104165135_add-office-users-#162914248.sql
+++ b/local_migrations/20190104165135_add-office-users-#162914248.sql
@@ -1,5 +1,4 @@
 -- Local test migration.
 -- This will be run on development environments. It should mirror what you
 -- intend to apply on production, but do not include any sensitive data.
-INSERT INTO public.office_users VALUES (uuid_generate_v4(), NULL, 'Person1', 'Ima', NULL, 'ot1@test.test', '415-555-5555', '0931a9dc-c1fd-444a-b138-6e1986b1714c', now(), now());
-INSERT INTO public.office_users VALUES (uuid_generate_v4(), NULL, 'Person2', 'Ima', NULL, 'ot2@test.test', '415-555-5555', '0931a9dc-c1fd-444a-b138-6e1986b1714c', now(), now());
+-- * Leaving empty- new users not needed on development *

--- a/local_migrations/20190104165135_add-office-users-#162914248.sql
+++ b/local_migrations/20190104165135_add-office-users-#162914248.sql
@@ -1,0 +1,5 @@
+-- Local test migration.
+-- This will be run on development environments. It should mirror what you
+-- intend to apply on production, but do not include any sensitive data.
+INSERT INTO public.office_users VALUES (uuid_generate_v4(), NULL, 'Person1', 'Ima', NULL, 'ot1@test.test', '415-555-5555', '0931a9dc-c1fd-444a-b138-6e1986b1714c', now(), now());
+INSERT INTO public.office_users VALUES (uuid_generate_v4(), NULL, 'Person2', 'Ima', NULL, 'ot2@test.test', '415-555-5555', '0931a9dc-c1fd-444a-b138-6e1986b1714c', now(), now());

--- a/migrations/20190104165135_add-office-users-#162914248.up.fizz
+++ b/migrations/20190104165135_add-office-users-#162914248.up.fizz
@@ -1,0 +1,1 @@
+exec("./apply-secure-migration.sh 20190104165135_add-office-users-#162914248.sql")


### PR DESCRIPTION
## Description

Adds new office users according to story: https://www.pivotaltracker.com/story/show/162914248
Note: @kimallen looked users already already in production and it appears that Deep and Mathew were already added, so didn't add them to the list of inserts here. 

## Setup

Run migrations on local database to verify data: `bin/run-prod-migrations`

Check the local db for correct insertion of data.

## Code Review Verification Steps

* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](./docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/162914248) for this change
