### PR TITLE
Change layout of preapproval request to 3-column

### DIFF
--- a/src/shared/PreApprovalRequest/Creator.jsx
+++ b/src/shared/PreApprovalRequest/Creator.jsx
@@ -48,7 +48,7 @@ export class Creator extends Component {
         <div className="pre-approval-panel-modal">
           <div className="title">Add a request</div>
           <PreApprovalForm tariff400ngItems={this.props.tariff400ngItems} onSubmit={this.onSubmit} />
-          <div className="usa-grid">
+          <div className="usa-grid-full">
             <div className="usa-width-one-half">
               <p className="cancel-link">
                 <a className="usa-button-secondary" onClick={this.closeForm}>
@@ -59,13 +59,17 @@ export class Creator extends Component {
 
             <div className="usa-width-one-half align-right">
               <button
-                className="button button-secondary"
+                className="button usa-button-secondary"
                 disabled={!this.props.formEnabled}
                 onClick={this.saveAndClear}
               >
                 Save &amp; Add Another
               </button>
-              <button className="button button-primary" disabled={!this.props.formEnabled} onClick={this.saveAndClose}>
+              <button
+                className="button usa-button-primary"
+                disabled={!this.props.formEnabled}
+                onClick={this.saveAndClose}
+              >
                 Save &amp; Close
               </button>
             </div>

--- a/src/shared/PreApprovalRequest/Creator.test.js
+++ b/src/shared/PreApprovalRequest/Creator.test.js
@@ -52,8 +52,8 @@ describe('given a Creator', () => {
     });
     it('buttons are disabled', () => {
       wrapper.find('a').simulate('click');
-      expect(wrapper.find('button.button-primary').prop('disabled')).toBeTruthy();
-      expect(wrapper.find('button.button-secondary').prop('disabled')).toBeTruthy();
+      expect(wrapper.find('button.usa-button-primary').prop('disabled')).toBeTruthy();
+      expect(wrapper.find('button.usa-button-secondary').prop('disabled')).toBeTruthy();
     });
   });
   describe('when the form is enabled', () => {
@@ -91,19 +91,19 @@ describe('given a Creator', () => {
         expect(wrapper.exists('div.pre-approval-panel-modal')).toBe(false);
       });
       it('buttons are enabled', () => {
-        expect(wrapper.find('button.button-secondary').prop('disabled')).toBe(false);
-        expect(wrapper.find('button.button-primary').prop('disabled')).toBe(false);
+        expect(wrapper.find('button.usa-button-secondary').prop('disabled')).toBe(false);
+        expect(wrapper.find('button.usa-button-primary').prop('disabled')).toBe(false);
       });
       it('clicking save & add another calls submitForm', () => {
-        wrapper.find('button.button-secondary').simulate('click');
+        wrapper.find('button.usa-button-secondary').simulate('click');
         expect(submit.mock.calls.length).toBe(1);
       });
       it('clicking save & close calls submitForm', () => {
-        wrapper.find('button.button-primary').simulate('click');
+        wrapper.find('button.usa-button-primary').simulate('click');
         expect(submit.mock.calls.length).toBe(1);
       });
       it('after submission of click and add another, the form is cleared', () => {
-        wrapper.find('button.button-secondary').simulate('click');
+        wrapper.find('button.usa-button-secondary').simulate('click');
         //redux-form will be sending this prop
         wrapper.setProps({ hasSubmitSucceeded: true }, () => {
           expect(clear.mock.calls.length).toBe(1);
@@ -111,7 +111,7 @@ describe('given a Creator', () => {
         });
       });
       it('after submission of click and close, the form is closed', () => {
-        wrapper.find('button.button-primary').simulate('click');
+        wrapper.find('button.usa-button-primary').simulate('click');
         //redux-form will be sending this prop
         wrapper.setProps({ hasSubmitSucceeded: true }, () => {
           expect(wrapper.state().showForm).toBe(false);

--- a/src/shared/PreApprovalRequest/Editor.jsx
+++ b/src/shared/PreApprovalRequest/Editor.jsx
@@ -30,7 +30,7 @@ export class Editor extends Component {
           onSubmit={this.onSubmit}
           initialValues={initialValues}
         />
-        <div className="usa-grid">
+        <div className="usa-grid-full">
           <div className="usa-width-one-half">
             <p className="cancel-link">
               <a className="usa-button-secondary" onClick={this.props.cancelEdit}>
@@ -41,7 +41,7 @@ export class Editor extends Component {
 
           <div className="usa-width-one-half align-right">
             <button
-              className="button button-primary"
+              className="button usa-button-primary"
               disabled={!this.props.formEnabled}
               onClick={this.props.submitForm}
             >

--- a/src/shared/PreApprovalRequest/Editor.test.js
+++ b/src/shared/PreApprovalRequest/Editor.test.js
@@ -57,7 +57,7 @@ describe('given an Editor', () => {
       expect(cancel.mock.calls.length).toBe(1);
     });
     it('buttons are disabled', () => {
-      expect(wrapper.find('button.button-primary').prop('disabled')).toBeTruthy();
+      expect(wrapper.find('button.usa-button-primary').prop('disabled')).toBeTruthy();
     });
   });
   describe('when the form is enabled', () => {
@@ -87,10 +87,10 @@ describe('given an Editor', () => {
       expect(cancel.mock.calls.length).toBe(1);
     });
     it('buttons are enabled', () => {
-      expect(wrapper.find('button.button-primary').prop('disabled')).toBe(false);
+      expect(wrapper.find('button.usa-button-primary').prop('disabled')).toBe(false);
     });
     it('clicking save calls saveEdit', () => {
-      wrapper.find('button.button-primary').simulate('click');
+      wrapper.find('button.usa-button-primary').simulate('click');
       expect(submit.mock.calls.length).toBe(1);
     });
   });

--- a/src/shared/PreApprovalRequest/PreApprovalForm.jsx
+++ b/src/shared/PreApprovalRequest/PreApprovalForm.jsx
@@ -61,7 +61,7 @@ export class PreApprovalForm extends Component {
     return (
       <Form onSubmit={this.props.handleSubmit(this.props.onSubmit)}>
         <div className="usa-grid">
-          <div className="usa-width-one-half">
+          <div className="usa-width-one-third">
             <div className="tariff400-select">
               <Field
                 name="tariff400ng_item"
@@ -73,10 +73,12 @@ export class PreApprovalForm extends Component {
             {/* TODO andrea - set schema location enum array to tariff400ng_item selected location value */}
             <SwaggerField
               fieldName="location"
-              className="one-third-width rounded"
+              className="rounded"
               swagger={this.props.ship_line_item_schema}
               required
             />
+          </div>
+          <div className="usa-width-one-third">
             <SwaggerField
               fieldName="quantity_1"
               className="half-width"
@@ -101,7 +103,7 @@ export class PreApprovalForm extends Component {
               </ul>
             </div>
           </div>
-          <div className="usa-width-one-half">
+          <div className="usa-width-one-third">
             <SwaggerField
               fieldName="notes"
               className="three-quarter-width"

--- a/src/shared/PreApprovalRequest/PreApprovalForm.jsx
+++ b/src/shared/PreApprovalRequest/PreApprovalForm.jsx
@@ -60,7 +60,7 @@ export class PreApprovalForm extends Component {
   render() {
     return (
       <Form onSubmit={this.props.handleSubmit(this.props.onSubmit)}>
-        <div className="usa-grid">
+        <div className="usa-grid-full">
           <div className="usa-width-one-third">
             <div className="tariff400-select">
               <Field

--- a/src/shared/PreApprovalRequest/PreApprovalForm.test.js
+++ b/src/shared/PreApprovalRequest/PreApprovalForm.test.js
@@ -96,7 +96,7 @@ beforeEach(() => {
 
 it('renders without crashing', () => {
   // eslint-disable-next-line
-  expect(wrapper.exists('div.usa-grid')).toBe(true);
+  expect(wrapper.exists('div.usa-grid-full')).toBe(true);
   // Check that it renders swagger field content
   expect(wrapper.find('.half-width').length).toBe(6);
 });

--- a/src/shared/PreApprovalRequest/PreApprovalRequest.css
+++ b/src/shared/PreApprovalRequest/PreApprovalRequest.css
@@ -139,7 +139,7 @@
 }
 
 .bq-explanation p {
-  line-height: 1rem;
+  line-height: 2rem;
   padding: 0rem 0rem 0rem 0rem;
 }
 


### PR DESCRIPTION
## Description

Change the layout of the 'new preapproval request' panel to be 3-column rather than 2. 

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](./docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](./docs/backend.md#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](./docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
* [ ] There are no aXe warnings for UI.
* [ ] This works in IE.
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @willowbl00
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/162596652) for this change
