### PR TITLE
More work on preventing e2e failures from slow office/tsp app page load

### DIFF
--- a/cypress/integration/mymove/shipment.js
+++ b/cypress/integration/mymove/shipment.js
@@ -1,4 +1,4 @@
-/* global cy, Cypress*/
+/* global cy, Cypress */
 
 describe('completing the hhg flow', function() {
   beforeEach(() => {

--- a/cypress/integration/office/cancelAndStartNewMove.js
+++ b/cypress/integration/office/cancelAndStartNewMove.js
@@ -4,7 +4,7 @@ describe('office user finds the move', () => {
     cy.signIntoOffice();
 
     // Open the move
-    cy.visit('/queues/new/moves/0db80bd6-de75-439e-bf89-deaafa1d0dc9/ppm');
+    cy.patientVisit('/queues/new/moves/0db80bd6-de75-439e-bf89-deaafa1d0dc9/ppm');
 
     // Find the Cancel Move button
     cy

--- a/cypress/integration/office/documentViewer.js
+++ b/cypress/integration/office/documentViewer.js
@@ -1,6 +1,6 @@
 import { fileUploadTimeout, officeAppName } from '../../support/constants';
 
-/* global cy, Cypress */
+/* global cy */
 describe('The document viewer', function() {
   describe('When not logged in', function() {
     beforeEach(() => {

--- a/cypress/integration/office/documentViewer.js
+++ b/cypress/integration/office/documentViewer.js
@@ -9,7 +9,7 @@ describe('The document viewer', function() {
       cy.clearCookies();
     });
     it('shows page not found', function() {
-      cy.visit('/moves/foo/documents');
+      cy.patientVisit('/moves/foo/documents');
       cy.contains('Welcome');
       cy.contains('Sign In');
     });
@@ -21,17 +21,17 @@ describe('The document viewer', function() {
       cy.signIntoOffice(false);
     });
     it('produces error when move cannot be found', () => {
-      cy.visit('/moves/9bfa91d2-7a0c-4de0-ae02-b90988cf8b4b858b/documents');
+      cy.patientVisit('/moves/9bfa91d2-7a0c-4de0-ae02-b90988cf8b4b858b/documents');
       cy.contains('An error occurred'); //todo: we want better messages when we are making custom call
     });
     it('loads basic information about the move', () => {
-      cy.visit('/moves/c9df71f2-334f-4f0e-b2e7-050ddb22efa1/documents');
+      cy.patientVisit('/moves/c9df71f2-334f-4f0e-b2e7-050ddb22efa1/documents');
       cy.contains('In Progress, PPM');
       cy.contains('GBXYUI');
       cy.contains('1617033988');
     });
     it('can upload a new document', () => {
-      cy.visit('/moves/c9df71f2-334f-4f0e-b2e7-050ddb22efa1/documents/new');
+      cy.patientVisit('/moves/c9df71f2-334f-4f0e-b2e7-050ddb22efa1/documents/new');
       cy.contains('Upload a new document');
       cy.get('button.submit').should('be.disabled');
       cy.get('input[name="title"]').type('super secret info document');
@@ -46,7 +46,7 @@ describe('The document viewer', function() {
         .click();
     });
     it('shows the newly uploaded document in the document list tab', () => {
-      cy.visit('/moves/c9df71f2-334f-4f0e-b2e7-050ddb22efa1/documents');
+      cy.patientVisit('/moves/c9df71f2-334f-4f0e-b2e7-050ddb22efa1/documents');
       cy.contains('All Documents (1)');
       cy.contains('super secret info document');
       cy
@@ -56,7 +56,7 @@ describe('The document viewer', function() {
         .and('match', /^\/moves\/[^/]+\/documents\/[^/]+/);
     });
     it('can upload an expense document', () => {
-      cy.visit('/moves/c9df71f2-334f-4f0e-b2e7-050ddb22efa1/documents/new');
+      cy.patientVisit('/moves/c9df71f2-334f-4f0e-b2e7-050ddb22efa1/documents/new');
       cy.contains('Upload a new document');
       cy.get('button.submit').should('be.disabled');
       cy.get('select[name="move_document_type"]').select('Expense');
@@ -74,7 +74,7 @@ describe('The document viewer', function() {
         .click();
     });
     it('can select and update newly-uploaded expense document', () => {
-      cy.visit('/moves/c9df71f2-334f-4f0e-b2e7-050ddb22efa1/documents');
+      cy.patientVisit('/moves/c9df71f2-334f-4f0e-b2e7-050ddb22efa1/documents');
       cy.contains('expense document');
       cy
         .get('.pad-ns')
@@ -104,7 +104,7 @@ describe('The document viewer', function() {
       cy.contains('GTCC');
     });
     it('can update expense document to other doc type', () => {
-      cy.visit('/moves/c9df71f2-334f-4f0e-b2e7-050ddb22efa1/documents');
+      cy.patientVisit('/moves/c9df71f2-334f-4f0e-b2e7-050ddb22efa1/documents');
       cy.contains('expense document');
       cy
         .get('.pad-ns')
@@ -133,7 +133,7 @@ describe('The document viewer', function() {
         .should('not.exist');
     });
     it('can update other document type back to expense type', () => {
-      cy.visit('/moves/c9df71f2-334f-4f0e-b2e7-050ddb22efa1/documents');
+      cy.patientVisit('/moves/c9df71f2-334f-4f0e-b2e7-050ddb22efa1/documents');
       cy.contains('expense document');
       cy
         .get('.pad-ns')
@@ -163,7 +163,7 @@ describe('The document viewer', function() {
       cy.contains('GTCC');
     });
     it('can upload documents to an HHG move', () => {
-      cy.visit('moves/533d176f-0bab-4c51-88cd-c899f6855b9d/documents/new');
+      cy.patientVisit('moves/533d176f-0bab-4c51-88cd-c899f6855b9d/documents/new');
 
       cy.contains('Upload a new document');
       cy.get('button.submit').should('be.disabled');
@@ -195,11 +195,11 @@ describe('The document viewer', function() {
       cy.contains('All Documents (2)');
     });
     it('can navigate to the shipment info page and show line item info', () => {
-      cy.visit('/moves/fb4105cf-f5a5-43be-845e-d59fdb34f31c/documents/new', {
+      cy.patientVisit('/moves/fb4105cf-f5a5-43be-845e-d59fdb34f31c/documents/new', {
         log: true,
       });
 
-      cy.visit('/');
+      cy.patientVisit('/');
 
       cy.location().should(loc => {
         expect(loc.pathname).to.match(/^\/queues\/new/);

--- a/cypress/integration/office/incentiveCalculator.js
+++ b/cypress/integration/office/incentiveCalculator.js
@@ -5,7 +5,7 @@ describe('office user uses incentive calculator', () => {
   });
   it('finds calculator and executes it', () => {
     // Open move ppm tab
-    cy.visit('/queues/new/moves/0db80bd6-de75-439e-bf89-deaafa1d0dc8/ppm');
+    cy.patientVisit('/queues/new/moves/0db80bd6-de75-439e-bf89-deaafa1d0dc8/ppm');
     // Click on PPM tab
     cy.get('.incentive-calc').within(() => {
       cy

--- a/cypress/integration/office/incentiveCalculator.js
+++ b/cypress/integration/office/incentiveCalculator.js
@@ -1,4 +1,4 @@
-/* global cy, */
+/* global cy */
 describe('office user uses incentive calculator', () => {
   beforeEach(() => {
     cy.signIntoOffice();

--- a/cypress/integration/office/invoicing.js
+++ b/cypress/integration/office/invoicing.js
@@ -14,7 +14,7 @@ describe('Office user looks at the invoice tab to view unbilled line items', () 
 
 function checkNoUnbilledLineItems() {
   // Open the shipments tab.
-  cy.visit('/queues/new/moves/6eee3663-1973-40c5-b49e-e70e9325b895/hhg');
+  cy.patientVisit('/queues/new/moves/6eee3663-1973-40c5-b49e-e70e9325b895/hhg');
 
   // The invoice table should be empty.
   cy
@@ -25,7 +25,7 @@ function checkNoUnbilledLineItems() {
 
 function checkExistUnbilledLineItems() {
   // Open the shipments tab.
-  cy.visit('/queues/new/moves/fb4105cf-f5a5-43be-845e-d59fdb34f31c/hhg');
+  cy.patientVisit('/queues/new/moves/fb4105cf-f5a5-43be-845e-d59fdb34f31c/hhg');
 
   // The invoice table should display the unbilled line items.
   cy
@@ -50,13 +50,13 @@ function checkExistUnbilledLineItems() {
 
 function checkApproveButton() {
   // Open the shipments tab.
-  cy.visit('/queues/new/moves/fb4105cf-f5a5-43be-845e-d59fdb34f31c/hhg');
+  cy.patientVisit('/queues/new/moves/fb4105cf-f5a5-43be-845e-d59fdb34f31c/hhg');
 
   // The invoice tab should have a button with the correct text.
   cy.get('.invoice-panel-header-cont button').should('have.text', 'Approve Payment');
 
   // Open shipments tab of move with no unbilled line items.
-  cy.visit('/queues/new/moves/6eee3663-1973-40c5-b49e-e70e9325b895/hhg');
+  cy.patientVisit('/queues/new/moves/6eee3663-1973-40c5-b49e-e70e9325b895/hhg');
 
   // The invoice tab should not have a button.
   cy.get('.invoice-panel-header-cont button').should('not.exist');
@@ -64,7 +64,7 @@ function checkApproveButton() {
 
 function checkConfirmationDialogue() {
   // Open the shipments tab.
-  cy.visit('/queues/new/moves/fb4105cf-f5a5-43be-845e-d59fdb34f31c/hhg');
+  cy.patientVisit('/queues/new/moves/fb4105cf-f5a5-43be-845e-d59fdb34f31c/hhg');
 
   cy.get('.invoice-panel').within(() => {
     cy

--- a/cypress/integration/office/invoicing.js
+++ b/cypress/integration/office/invoicing.js
@@ -1,3 +1,4 @@
+/* global cy */
 describe('Office user looks at the invoice tab to view unbilled line items', () => {
   beforeEach(() => {
     cy.signIntoOffice();

--- a/cypress/integration/office/officeCSRFProtect.js
+++ b/cypress/integration/office/officeCSRFProtect.js
@@ -58,7 +58,7 @@ describe('testing CSRF protection updating move info', function() {
 
     cy.wait(100);
 
-    cy.reload();
+    cy.patientReload();
 
     cy.contains('CSRF Test');
   });

--- a/cypress/integration/office/officePremoveSurvey.js
+++ b/cypress/integration/office/officePremoveSurvey.js
@@ -12,7 +12,7 @@ describe('office user interacts with premove survey', function() {
 
 function officeUserEntersPreMoveSurvey() {
   // Open new moves queue
-  cy.visit('/queues/all');
+  cy.patientVisit('/queues/all');
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/queues\/all/);
   });

--- a/cypress/integration/office/officeServiceAgents.js
+++ b/cypress/integration/office/officeServiceAgents.js
@@ -42,7 +42,7 @@ describe('office user can view service agents', function() {
 
 function officeUserOpensHhgPanelForMove(moveLocator) {
   // Open all moves queue
-  cy.visit('/queues/all');
+  cy.patientVisit('/queues/all');
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/queues\/all/);
   });

--- a/cypress/integration/office/officeUserHHG.js
+++ b/cypress/integration/office/officeUserHHG.js
@@ -58,7 +58,7 @@ function officeUserViewsMoves() {
 
 function officeUserViewsDeliveredShipment() {
   // Open new moves queue
-  cy.visit('/queues/hhg_delivered');
+  cy.patientVisit('/queues/hhg_delivered');
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/queues\/hhg_delivered/);
   });
@@ -85,7 +85,7 @@ function officeUserViewsDeliveredShipment() {
 
 function officeUserViewsCompletedShipment() {
   // Open new moves queue
-  cy.visit('/queues/hhg_completed');
+  cy.patientVisit('/queues/hhg_completed');
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/queues\/hhg_completed/);
   });
@@ -112,7 +112,7 @@ function officeUserViewsCompletedShipment() {
 
 function officeUserViewsAcceptedShipment() {
   // Open new moves queue
-  cy.visit('/queues/hhg_accepted');
+  cy.patientVisit('/queues/hhg_accepted');
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/queues\/hhg_accepted/);
   });
@@ -139,7 +139,7 @@ function officeUserViewsAcceptedShipment() {
 
 function officeUserApprovesOnlyBasicsHHG() {
   // Open accepted hhg queue
-  cy.visit('/queues/new');
+  cy.patientVisit('/queues/new');
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/queues\/new/);
   });
@@ -203,7 +203,7 @@ function officeUserApprovesOnlyBasicsHHG() {
 
 function officeUserApprovesHHG() {
   // Open accepted hhg queue
-  cy.visit('/queues/hhg_accepted');
+  cy.patientVisit('/queues/hhg_accepted');
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/queues\/hhg_accepted/);
   });
@@ -267,7 +267,7 @@ function officeUserApprovesHHG() {
 
 function officeUserCompletesHHG() {
   // Open delivered hhg queue
-  cy.visit('/queues/hhg_delivered');
+  cy.patientVisit('/queues/hhg_delivered');
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/queues\/hhg_delivered/);
   });
@@ -313,7 +313,7 @@ function officeUserCompletesHHG() {
 
 function officeUserApprovePaymentInvoice() {
   // Open completed hhg queue
-  cy.visit('/queues/hhg_delivered');
+  cy.patientVisit('/queues/hhg_delivered');
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/queues\/hhg_delivered/);
   });

--- a/cypress/integration/office/officeUserPPM.js
+++ b/cypress/integration/office/officeUserPPM.js
@@ -189,7 +189,7 @@ function officeUserApprovesMoveAndVerifiesPPM() {
     .should('be.enabled');
 
   // Open new moves queue
-  cy.visit('/');
+  cy.patientVisit('/');
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/queues\/new/);
   });

--- a/cypress/integration/office/officeUserPPM.js
+++ b/cypress/integration/office/officeUserPPM.js
@@ -89,7 +89,7 @@ function officeUserVerifiesOrders() {
   cy.get('span').contains('FP-TP');
 
   // Refresh browser and make sure changes persist
-  cy.reload();
+  cy.patientReload();
   cy
     .get('button')
     .contains('Approve PPM')
@@ -146,7 +146,7 @@ function officeUserVerifiesAccounting() {
   cy.get('span').contains('N002214CSW32Y9');
 
   // Refresh browser and make sure changes persist
-  cy.reload();
+  cy.patientReload();
   cy
     .get('button')
     .contains('Approve PPM')

--- a/cypress/integration/office/preApprovalRequest.js
+++ b/cypress/integration/office/preApprovalRequest.js
@@ -26,7 +26,7 @@ describe('office user interacts with pre approval request panel', function() {
 
 function officeUserCreatesPreApprovalRequest() {
   // Open new moves queue
-  cy.visit('/queues/all');
+  cy.patientVisit('/queues/all');
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/queues\/all/);
   });
@@ -59,7 +59,7 @@ function officeUserCreatesPreApprovalRequest() {
 }
 function officeUserEditsPreApprovalRequest() {
   // Open new moves queue
-  cy.visit('/queues/all');
+  cy.patientVisit('/queues/all');
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/queues\/all/);
   });
@@ -93,7 +93,7 @@ function officeUserEditsPreApprovalRequest() {
 
 function officeUserApprovesPreApprovalRequest() {
   // Open new moves queue
-  cy.visit('/queues/all');
+  cy.patientVisit('/queues/all');
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/queues\/all/);
   });
@@ -126,7 +126,7 @@ function officeUserApprovesPreApprovalRequest() {
 
 function officeUserDeletesPreApprovalRequest() {
   // Open new moves queue
-  cy.visit('/queues/all');
+  cy.patientVisit('/queues/all');
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/queues\/all/);
   });

--- a/cypress/integration/office/storageReimbursementCalculator.js
+++ b/cypress/integration/office/storageReimbursementCalculator.js
@@ -5,7 +5,7 @@ describe('office user uses storage reimbursement calculator', () => {
   });
   it('finds calculator and executes it', () => {
     // Open move ppm tab
-    cy.visit('/queues/new/moves/0db80bd6-de75-439e-bf89-deaafa1d0dc8/ppm');
+    cy.patientVisit('/queues/new/moves/0db80bd6-de75-439e-bf89-deaafa1d0dc8/ppm');
     // Click on PPM tab
     cy.get('.storage-calc').within(() => {
       cy

--- a/cypress/integration/tsp/documentViewer.js
+++ b/cypress/integration/tsp/documentViewer.js
@@ -1,5 +1,5 @@
 import { fileUploadTimeout } from '../../support/constants';
-/* global cy, Cypress */
+/* global cy */
 
 describe('The document viewer', function() {
   beforeEach(() => {

--- a/cypress/integration/tsp/documentViewer.js
+++ b/cypress/integration/tsp/documentViewer.js
@@ -8,7 +8,7 @@ describe('The document viewer', function() {
   });
 
   it('has a new document links', () => {
-    cy.visit('/');
+    cy.patientVisit('/');
 
     cy.location().should(loc => {
       expect(loc.pathname).to.match(/^\/queues\/new/);
@@ -43,7 +43,7 @@ describe('The document viewer', function() {
 
   it('shows current shipment docs after viewing a shipment with no docs', () => {
     // Find a shipment with no docs
-    cy.visit('/shipments/65e00326-420e-436a-89fc-6aeb3f90b870', {
+    cy.patientVisit('/shipments/65e00326-420e-436a-89fc-6aeb3f90b870', {
       log: true,
     });
 
@@ -53,7 +53,7 @@ describe('The document viewer', function() {
       .should('have.attr', 'href')
       .and('match', /^\/shipments\/[^/]+\/documents\/new/);
 
-    cy.visit('/queues/approved/', {
+    cy.patientVisit('/queues/approved/', {
       log: true,
     });
 
@@ -74,7 +74,7 @@ describe('The document viewer', function() {
   });
 
   it('can upload a new document', () => {
-    cy.visit('/shipments/65e00326-420e-436a-89fc-6aeb3f90b870/documents/new', {
+    cy.patientVisit('/shipments/65e00326-420e-436a-89fc-6aeb3f90b870/documents/new', {
       log: true,
     });
 
@@ -93,7 +93,7 @@ describe('The document viewer', function() {
   });
 
   it('can navigate to the shipment info page and show line item info', () => {
-    cy.visit('/shipments/67a3cbe7-4ae3-4f6a-9f9a-4f312e7458b9/documents/new', {
+    cy.patientVisit('/shipments/67a3cbe7-4ae3-4f6a-9f9a-4f312e7458b9/documents/new', {
       log: true,
     });
 

--- a/cypress/integration/tsp/generateGBL.js
+++ b/cypress/integration/tsp/generateGBL.js
@@ -23,7 +23,7 @@ describe('TSP User generates GBL', function() {
 function tspUserCannotGenerateGBL() {
   const gblButtonText = 'Generate the GBL';
 
-  cy.visit('/queues/accepted');
+  cy.patientVisit('/queues/accepted');
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/queues\/accepted/);
   });
@@ -47,7 +47,7 @@ function tspUserGeneratesGBL() {
   const gblButtonText = 'Generate the GBL';
 
   // Open approved shipments queue
-  cy.visit('/queues/approved');
+  cy.patientVisit('/queues/approved');
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/queues\/approved/);
   });
@@ -107,7 +107,7 @@ function tspUserGeneratesGBL() {
 
 function tspUserViewsGBL() {
   // Open approved shipments queue
-  cy.visit('/queues/approved');
+  cy.patientVisit('/queues/approved');
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/queues\/approved/);
   });

--- a/cypress/integration/tsp/homepage.js
+++ b/cypress/integration/tsp/homepage.js
@@ -17,7 +17,7 @@ describe('TSP Home Page', function() {
 function tspUserLogsOut() {
   // Logs out any users
   cy.logout();
-  cy.visit('/');
+  cy.patientVisit('/');
 }
 
 function tspUserIsOnSignInPage() {

--- a/cypress/integration/tsp/homepage.js
+++ b/cypress/integration/tsp/homepage.js
@@ -1,7 +1,9 @@
-/* global cy, Cypress */
+/* global cy */
+import { tspAppName } from '../../support/constants';
+
 describe('TSP Home Page', function() {
   beforeEach(() => {
-    Cypress.config('baseUrl', 'http://tsplocal:4000');
+    cy.setupBaseUrl(tspAppName);
   });
   it('successfully loads when not logged in', function() {
     tspUserLogsOut();

--- a/cypress/integration/tsp/invoicing.js
+++ b/cypress/integration/tsp/invoicing.js
@@ -1,3 +1,4 @@
+/* global cy */
 describe('TSP user looks at the invoice panel to view unbilled line items', () => {
   beforeEach(() => {
     cy.signIntoTSP();

--- a/cypress/integration/tsp/invoicing.js
+++ b/cypress/integration/tsp/invoicing.js
@@ -11,7 +11,7 @@ describe('TSP user looks at the invoice panel to view unbilled line items', () =
 
 function checkNoUnbilledLineItems() {
   // Open the shipment with no unbilled line items.
-  cy.visit('/shipments/0851706a-997f-46fb-84e4-2525a444ade0');
+  cy.patientVisit('/shipments/0851706a-997f-46fb-84e4-2525a444ade0');
 
   // The invoice table should be empty.
   cy
@@ -22,7 +22,7 @@ function checkNoUnbilledLineItems() {
 
 function checkExistUnbilledLineItems() {
   // Open the shipment with unbilled line items.
-  cy.visit('shipments/67a3cbe7-4ae3-4f6a-9f9a-4f312e7458b9');
+  cy.patientVisit('shipments/67a3cbe7-4ae3-4f6a-9f9a-4f312e7458b9');
 
   // The invoice table should display the unbilled line items.
   cy

--- a/cypress/integration/tsp/locationsPanel.js
+++ b/cypress/integration/tsp/locationsPanel.js
@@ -291,7 +291,7 @@ function tspUserEntersLocations() {
     .click();
 
   // Refresh browser and make sure changes persist
-  cy.reload();
+  cy.patientReload();
 
   cy
     .contains('Locations')
@@ -369,7 +369,7 @@ function tspUserEntersLocations() {
     .click();
 
   // Refresh browser and make sure changes persist
-  cy.reload();
+  cy.patientReload();
 
   cy
     .contains('Locations')

--- a/cypress/integration/tsp/premoveSurvey.js
+++ b/cypress/integration/tsp/premoveSurvey.js
@@ -138,7 +138,7 @@ function tspUserVerifiesPreMoveSurveyEntered() {
 }
 
 function tspUserGoesToShipment(queue, locator) {
-  cy.visit(queue);
+  cy.patientVisit(queue);
 
   // Find shipment and open it
   cy

--- a/cypress/integration/tsp/queues.js
+++ b/cypress/integration/tsp/queues.js
@@ -64,7 +64,7 @@ function tspUserViewsNewShipments() {
 
 function tspUserViewsInTransitShipments() {
   // Open in transit shipments queue
-  cy.visit('/queues/in_transit');
+  cy.patientVisit('/queues/in_transit');
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/queues\/in_transit/);
   });
@@ -90,7 +90,7 @@ function tspUserViewsInTransitShipments() {
 
 function tspUserViewsDeliveredShipments() {
   // Open delivered shipments queue
-  cy.visit('/queues/delivered');
+  cy.patientVisit('/queues/delivered');
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/queues\/delivered/);
   });

--- a/cypress/integration/tsp/routes.js
+++ b/cypress/integration/tsp/routes.js
@@ -1,4 +1,6 @@
-/* global cy, Cypress */
+import { tspAppName } from '../../support/constants';
+
+/* global cy */
 describe('TSP User Navigating the App', function() {
   it('unauthorized user tries to access an authorized route', function() {
     unauthorizedTspUserGoesToAuthorizedRoute();
@@ -12,7 +14,7 @@ describe('TSP User Navigating the App', function() {
 });
 
 function unauthorizedTspUserGoesToAuthorizedRoute() {
-  Cypress.config('baseUrl', 'http://tsplocal:4000');
+  cy.setupBaseUrl(tspAppName);
   cy.logout();
   cy.visit('/queues/new');
   cy.contains('Welcome to tsp.move.mil');

--- a/cypress/integration/tsp/routes.js
+++ b/cypress/integration/tsp/routes.js
@@ -16,7 +16,7 @@ describe('TSP User Navigating the App', function() {
 function unauthorizedTspUserGoesToAuthorizedRoute() {
   cy.setupBaseUrl(tspAppName);
   cy.logout();
-  cy.visit('/queues/new');
+  cy.patientVisit('/queues/new');
   cy.contains('Welcome to tsp.move.mil');
   cy.contains('Sign In');
 }
@@ -29,7 +29,7 @@ function tspUserViewsInvalidShipment() {
   });
 
   // visit an invalid url
-  cy.visit('/shipments/some-invalid-uuid');
+  cy.patientVisit('/shipments/some-invalid-uuid');
 
   // redirected to the queues page due to invalid shipment
   cy.location().should(loc => {
@@ -46,7 +46,7 @@ function tspUserNavigatesToInvalidRoute() {
   });
 
   // visits an invalid url
-  cy.visit('/i-do-not-exist');
+  cy.patientVisit('/i-do-not-exist');
 
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/queues\/new/);

--- a/cypress/integration/tsp/serviceAgents.js
+++ b/cypress/integration/tsp/serviceAgents.js
@@ -145,7 +145,7 @@ function tspUserAcceptsShipment() {
 }
 
 function tspUserClicksAssignServiceAgent(locator) {
-  cy.visit('/queues/all');
+  cy.patientVisit('/queues/all');
 
   // Find shipment and open it
   cy

--- a/cypress/integration/tsp/serviceAgents.js
+++ b/cypress/integration/tsp/serviceAgents.js
@@ -206,7 +206,7 @@ function userSavesServiceAgentsWizard() {
     .contains(origin.Phone);
 
   // Refresh browser and make sure changes persist
-  cy.reload();
+  cy.patientReload();
 
   cy
     .get('div.company')

--- a/cypress/integration/tsp/shipShipment.js
+++ b/cypress/integration/tsp/shipShipment.js
@@ -65,7 +65,7 @@ function tspUserEntersADeliveryDate() {
 }
 
 function tspUserVisitsAnInTransitShipment(locator) {
-  cy.visit('/queues/in_transit');
+  cy.patientVisit('/queues/in_transit');
 
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/queues\/in_transit/);
@@ -145,7 +145,7 @@ function tspUserPacksShipment() {
   cy.get('div.actual_pack_date').contains('10');
 }
 function tspUserEntersPackAndPickUpInfo() {
-  cy.visit('/queues/new');
+  cy.patientVisit('/queues/new');
 
   // Open approved shipments queue
   cy

--- a/cypress/integration/tsp/shipShipment.js
+++ b/cypress/integration/tsp/shipShipment.js
@@ -1,4 +1,3 @@
-import { testPremoveSurvey } from '../../support/testPremoveSurvey';
 import { tspUserVerifiesShipmentStatus } from '../../support/testTspStatus';
 
 /* global cy */

--- a/cypress/integration/tsp/tspCSRFProtect.js
+++ b/cypress/integration/tsp/tspCSRFProtect.js
@@ -54,7 +54,7 @@ describe('testing CSRF protection updating shipment info', function() {
       .should('be.enabled')
       .click();
 
-    cy.reload();
+    cy.patientReload();
 
     cy.contains('CSRF Test');
   });
@@ -89,7 +89,7 @@ describe('testing CSRF protection updating shipment info', function() {
       .should('be.enabled')
       .click();
 
-    cy.reload();
+    cy.patientReload();
 
     // No error pops up so we check the value
     cy

--- a/cypress/integration/tsp/weightsAndItemsPanel.js
+++ b/cypress/integration/tsp/weightsAndItemsPanel.js
@@ -1,5 +1,3 @@
-import { selectPreMoveSurveyPanel, fillAndSavePremoveSurvey } from '../../support/testPremoveSurvey';
-
 /* global cy */
 describe('TSP Interacts With the Weights & Items Panel', function() {
   beforeEach(() => {

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -65,7 +65,18 @@ Cypress.Commands.add('signInAsUser', userId => {
 // Reloads the page but makes an attempt to wait for the loading screen to disappear
 Cypress.Commands.add('patientReload', () => {
   cy.reload();
-  cy.get('h2[data-name="loading-placeholder"]').should('not.exist', { timeout: 10000 });
+  cy.waitForLoadingScreen(10000);
+});
+
+// Visits a given URL but makes an attempt to wait for the loading screen to disappear
+Cypress.Commands.add('patientVisit', url => {
+  cy.visit(url);
+  cy.waitForLoadingScreen(10000);
+});
+
+// Waits for the loading screen to disappear for a given amount of milliseconds
+Cypress.Commands.add('waitForLoadingScreen', ms => {
+  cy.get('h2[data-name="loading-placeholder"]', { timeout: ms }).should('not.exist');
 });
 
 Cypress.Commands.add(

--- a/cypress/support/datesPanel.js
+++ b/cypress/support/datesPanel.js
@@ -18,7 +18,7 @@ export function userEntersDates() {
     .contains('Save')
     .click();
 
-  cy.reload();
+  cy.patientReload();
 
   cy.get('div.pm_survey_conducted_date').contains('20-Jul-18');
   cy.get('div.pm_survey_method').contains('Phone');
@@ -51,7 +51,7 @@ export function userEntersDates() {
     .contains('Save')
     .click();
 
-  cy.reload();
+  cy.patientReload();
 
   cy.get('div.original_pack_date').contains('11-May-18');
   cy.get('div.pm_survey_planned_pack_date').contains('01-Aug-18');
@@ -85,7 +85,7 @@ export function userEntersDates() {
     .contains('Save')
     .click();
 
-  cy.reload();
+  cy.patientReload();
 
   cy.get('div.requested_pickup_date').contains('15-May-18');
   cy.get('div.pm_survey_planned_pickup_date').contains('02-Aug-18');
@@ -118,7 +118,7 @@ export function userEntersDates() {
     .contains('Save')
     .click();
 
-  cy.reload();
+  cy.patientReload();
 
   cy.get('div.original_delivery_date').contains('21-May-18');
   cy.get('div.pm_survey_planned_delivery_date').contains('07-Oct-18');
@@ -149,7 +149,7 @@ export function userEntersDates() {
     .contains('Save')
     .click();
 
-  cy.reload();
+  cy.patientReload();
 
   cy.get('div.pm_survey_notes').contains('Notes notes notes for dates');
 }
@@ -221,7 +221,7 @@ export function userEntersAndRemovesDates() {
     .contains('Save')
     .click();
 
-  cy.reload();
+  cy.patientReload();
 
   cy.get('div.pm_survey_conducted_date').contains('20-Jul-18');
   cy.get('div.pm_survey_method').contains('Phone');
@@ -310,7 +310,7 @@ export function userEntersAndRemovesDates() {
     .contains('Save')
     .click();
 
-  cy.reload();
+  cy.patientReload();
 
   cy.get('div.pm_survey_conducted_date').contains('missing');
   cy.get('div.original_pack_date').contains('11-May-18');

--- a/cypress/support/testPremoveSurvey.js
+++ b/cypress/support/testPremoveSurvey.js
@@ -76,7 +76,7 @@ export function testPremoveSurvey() {
   cy.get('span').contains('4,000 lbs');
 
   // Refresh browser and make sure changes persist
-  cy.reload();
+  cy.patientReload();
 
   cy
     .get('div.pm_survey_planned_delivery_date')

--- a/cypress/support/testTspServiceAgents.js
+++ b/cypress/support/testTspServiceAgents.js
@@ -131,7 +131,7 @@ export function userSavesServiceAgent(role) {
     .contains(fixture.Phone);
 
   // Refresh browser and make sure changes persist
-  cy.reload();
+  cy.patientReload();
 
   cy
     .get('div.company')


### PR DESCRIPTION
## Description

We're failing e2e tests somewhat frequently for loading the app too slowly. I previously added a command `patientReload` for trying to mitigate this by explicitly waiting for the loading screen to disappear, but didn't apply the timeout correctly so it wasn't buying us much.

This PR fixes that timeout usage, and adds `patientVisit` to use when loading the app initially, giving the e2e app more time to finish loading data.

@tinyels previously expressed concern that this kind of bandaid would cover up the fact that our app is loading slowly, and that signal is important. And I agree! But sporadically failing e2e tests isn't the best way to get that signal I think. We should decide on an acceptable length of loading time (keeping in mind running inside an e2e test isn't representative of a real user's experience), and write a test specifically for keeping page load under that loading time. The rest of the tests should do their own thing.