### PR TITLE
Adds optional destination service agent to wizard

### DIFF
--- a/cypress/integration/tsp/serviceAgents.js
+++ b/cypress/integration/tsp/serviceAgents.js
@@ -49,11 +49,22 @@ describe('TSP User enters and updates Service Agents', function() {
     tspUserAcceptsShipment();
   });
 
+  it('tsp user assigns only origin service agent using action button', function() {
+    tspUserClicksAssignServiceAgent('ASNORG');
+    userInputsServiceAgent('Origin');
+    userSavesServiceAgentsWizard();
+    userVerifiesServiceAgentInfo('Origin');
+    tspUserVerifiesServiceAgentAssigned();
+  });
+
   it('tsp user assigns origin and destination service agents using action button', function() {
     tspUserClicksAssignServiceAgent('ASSIGN');
     userInputsServiceAgent('Origin');
+    userAllowsDestinationAgentBeSelected();
     userInputsServiceAgent('Destination');
     userSavesServiceAgentsWizard();
+    userVerifiesServiceAgentInfo('Origin');
+    userVerifiesServiceAgentInfo('Destination');
     tspUserVerifiesServiceAgentAssigned();
   });
 });
@@ -145,7 +156,11 @@ function tspUserAcceptsShipment() {
 }
 
 function tspUserClicksAssignServiceAgent(locator) {
+<<<<<<< HEAD
   cy.patientVisit('/queues/all');
+=======
+  cy.visit('/queues/accepted');
+>>>>>>> Adds optional destination service agent to wizard
 
   // Find shipment and open it
   cy
@@ -178,9 +193,6 @@ function tspUserVerifiesServiceAgentAssigned() {
 }
 
 function userSavesServiceAgentsWizard() {
-  const origin = getFixture('Origin');
-  const destination = getFixture('Destination');
-
   cy
     .get('button')
     .contains('Done')
@@ -190,20 +202,23 @@ function userSavesServiceAgentsWizard() {
     .get('button')
     .contains('Done')
     .click();
+}
 
+function userVerifiesServiceAgentInfo(role) {
+  const agent = getFixture(role);
   // Verify data has been saved in the UI
   cy
     .get('div.company')
     .get('span')
-    .contains(origin.Company);
+    .contains(agent.Company);
   cy
     .get('div.email')
     .get('span')
-    .contains(origin.Email);
+    .contains(agent.Email);
   cy
     .get('div.phone_number')
     .get('span')
-    .contains(origin.Phone);
+    .contains(agent.Phone);
 
   // Refresh browser and make sure changes persist
   cy.patientReload();
@@ -211,26 +226,20 @@ function userSavesServiceAgentsWizard() {
   cy
     .get('div.company')
     .get('span')
-    .contains(origin.Company);
+    .contains(agent.Company);
   cy
     .get('div.email')
     .get('span')
-    .contains(origin.Email);
+    .contains(agent.Email);
   cy
     .get('div.phone_number')
     .get('span')
-    .contains(origin.Phone);
+    .contains(agent.Phone);
+}
 
+function userAllowsDestinationAgentBeSelected() {
   cy
-    .get('div.company')
-    .get('span')
-    .contains(destination.Company);
-  cy
-    .get('div.email')
-    .get('span')
-    .contains(destination.Email);
-  cy
-    .get('div.phone_number')
-    .get('span')
-    .contains(destination.Phone);
+    .get('[type="radio"]')
+    .first()
+    .check({ force: true });
 }

--- a/cypress/integration/tsp/serviceAgents.js
+++ b/cypress/integration/tsp/serviceAgents.js
@@ -156,11 +156,7 @@ function tspUserAcceptsShipment() {
 }
 
 function tspUserClicksAssignServiceAgent(locator) {
-<<<<<<< HEAD
-  cy.patientVisit('/queues/all');
-=======
-  cy.visit('/queues/accepted');
->>>>>>> Adds optional destination service agent to wizard
+  cy.patientVisit('/queues/accepted');
 
   // Find shipment and open it
   cy

--- a/pkg/testdatagen/scenario/e2ebasic.go
+++ b/pkg/testdatagen/scenario/e2ebasic.go
@@ -1979,6 +1979,45 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, log
 	hhg33 := offer33.Shipment
 	hhg33.Move.Submit()
 	models.SaveMoveDependencies(db, &hhg33.Move)
+
+	/*
+	 * Service member with accepted move but needs to be assigned an origin service agent
+	 */
+	email = "hhg@assignorigin.serviceagent"
+	offer34 := testdatagen.MakeShipmentOffer(db, testdatagen.Assertions{
+		User: models.User{
+			ID:            uuid.Must(uuid.FromString("2a14af24-5448-414b-a114-e943d695a371")),
+			LoginGovEmail: email,
+		},
+		ServiceMember: models.ServiceMember{
+			ID:            uuid.FromStringOrNil("95ca8bc7-2fbd-46f7-871d-ddb3f8472b8d"),
+			FirstName:     models.StringPointer("AssignOrigin"),
+			LastName:      models.StringPointer("ServiceAgent"),
+			Edipi:         models.StringPointer("4444512345"),
+			PersonalEmail: models.StringPointer(email),
+		},
+		Move: models.Move{
+			ID:               uuid.FromStringOrNil("5bd2eb88-ca20-4678-8253-04da76db0a52"),
+			Locator:          "ASNORG",
+			SelectedMoveType: &selectedMoveTypeHHG,
+		},
+		TrafficDistributionList: models.TrafficDistributionList{
+			ID:                uuid.FromStringOrNil("0a93b301-1b66-4a22-ab0e-027ec19d81d9"),
+			SourceRateArea:    "US62",
+			DestinationRegion: "11",
+			CodeOfService:     "D",
+		},
+		Shipment: models.Shipment{
+			Status: models.ShipmentStatusACCEPTED,
+		},
+		ShipmentOffer: models.ShipmentOffer{
+			TransportationServiceProviderID: tspUser.TransportationServiceProviderID,
+		},
+	})
+	hhg34 := offer34.Shipment
+	hhg34.Move.Submit()
+	models.SaveMoveDependencies(db, &hhg34.Move)
+
 }
 
 // MakeHhgWithPpm creates an HHG user who has added a PPM

--- a/src/scenes/TransportationServiceProvider/ServiceAgentForm.jsx
+++ b/src/scenes/TransportationServiceProvider/ServiceAgentForm.jsx
@@ -21,6 +21,7 @@ let ServiceAgentForm = props => {
             values: originValues,
           }}
           saRole="Origin"
+          columnSize="editable-panel-column"
         />
       </FormSection>
       <FormSection name="destination_service_agent">
@@ -30,6 +31,7 @@ let ServiceAgentForm = props => {
             values: destinationValues,
           }}
           saRole="Destination"
+          columnSize="editable-panel-column"
         />
       </FormSection>
 

--- a/src/scenes/TransportationServiceProvider/ServiceAgentForm.jsx
+++ b/src/scenes/TransportationServiceProvider/ServiceAgentForm.jsx
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 import { get } from 'lodash';
 import { reduxForm, FormSection } from 'redux-form';
 
-import { ServiceAgentEdit } from 'shared/TspPanel/ServiceAgentViews';
+import { ServiceAgentEdit, OptionalServiceAgentEdit } from 'shared/TspPanel/ServiceAgentViews';
 
 let ServiceAgentForm = props => {
   const { schema, onCancel, handleSubmit, submitting, valid } = props;
@@ -24,7 +24,13 @@ let ServiceAgentForm = props => {
         />
       </FormSection>
       <FormSection name="destination_service_agent">
-        <ServiceAgentEdit serviceAgentProps={{ swagger: schema, values: destinationValues }} saRole="Destination" />
+        <OptionalServiceAgentEdit
+          serviceAgentProps={{
+            swagger: schema,
+            values: destinationValues,
+          }}
+          saRole="Destination"
+        />
       </FormSection>
 
       <div className="infoPanel-wizard-actions-container">

--- a/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
+++ b/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
@@ -159,8 +159,12 @@ class ShipmentInfo extends Component {
   };
 
   editServiceAgents = values => {
-    values['destination_service_agent']['role'] = 'DESTINATION';
-    values['origin_service_agent']['role'] = 'ORIGIN';
+    if (values['destination_service_agent']) {
+      values['destination_service_agent']['role'] = 'DESTINATION';
+    }
+    if (values['origin_service_agent']) {
+      values['origin_service_agent']['role'] = 'ORIGIN';
+    }
     this.props.handleServiceAgents(this.props.shipment.id, values);
   };
 

--- a/src/scenes/TransportationServiceProvider/ducks.js
+++ b/src/scenes/TransportationServiceProvider/ducks.js
@@ -92,13 +92,12 @@ export function handleServiceAgents(shipmentId, serviceAgents) {
 
 export function createOrUpdateServiceAgent(shipmentId, serviceAgent) {
   return async function(dispatch, getState) {
-    if (!serviceAgent.company || !serviceAgent.email || !serviceAgent.phone_number) {
+    if (serviceAgent.id) {
+      return dispatch(updateServiceAgent(serviceAgent));
+    } else if (!serviceAgent.company || !serviceAgent.email || !serviceAgent.phone_number) {
       // Don't send the service agent if it's not got enough details
       // Currently, it should only be the destination agent that gets skipped
       return;
-    }
-    if (serviceAgent.id) {
-      return dispatch(updateServiceAgent(serviceAgent));
     } else {
       return dispatch(createServiceAgent(shipmentId, serviceAgent));
     }

--- a/src/scenes/TransportationServiceProvider/ducks.js
+++ b/src/scenes/TransportationServiceProvider/ducks.js
@@ -92,6 +92,11 @@ export function handleServiceAgents(shipmentId, serviceAgents) {
 
 export function createOrUpdateServiceAgent(shipmentId, serviceAgent) {
   return async function(dispatch, getState) {
+    if (!serviceAgent.company || !serviceAgent.email || !serviceAgent.phone_number) {
+      // Don't send the service agent if it's not got enough details
+      // Currently, it should only be the destination agent that gets skipped
+      return;
+    }
     if (serviceAgent.id) {
       return dispatch(updateServiceAgent(serviceAgent));
     } else {

--- a/src/scenes/TransportationServiceProvider/tsp.css
+++ b/src/scenes/TransportationServiceProvider/tsp.css
@@ -270,3 +270,12 @@
   animation-fill-mode: forwards;
   animation-duration: 2s;
 }
+
+.optional-destination-agent-question {
+  margin-top: 3rem;
+}
+
+label.inline_radio {
+	margin-top: 1px;
+	margin-bottom: 1px;
+}

--- a/src/scenes/TransportationServiceProvider/tsp.css
+++ b/src/scenes/TransportationServiceProvider/tsp.css
@@ -193,6 +193,15 @@
   font-weight: bold;
 }
 
+.infoPanel-wizard .infoPanel-wizard-form-container {
+  display: flex;
+  flex-direction: row;
+}
+
+.infoPanel-wizard-form-container .infoPanel-wizard-column {
+  flex-direction: column;
+}
+
 .infoPanel-wizard .infoPanel-wizard-cancel {
   text-decoration: none;
   cursor: pointer;

--- a/src/shared/TspPanel/ServiceAgentViews.jsx
+++ b/src/shared/TspPanel/ServiceAgentViews.jsx
@@ -1,8 +1,9 @@
-import React, { Fragment } from 'react';
+import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 
 import { PanelSwaggerField, PanelField } from 'shared/EditablePanel';
 import { SwaggerField } from 'shared/JsonSchemaForm/JsonSchemaField';
+import YesNoBoolean from 'shared/Inputs/YesNoBoolean';
 
 export const ServiceAgentDisplay = ({ serviceAgentProps, saRole }) => {
   return (
@@ -35,6 +36,41 @@ export const ServiceAgentEdit = ({ serviceAgentProps, saRole }) => {
     </Fragment>
   );
 };
+
+export class OptionalServiceAgentEdit extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      showOptionalServiceAgent: false,
+    };
+
+    this.setShowOptionalServiceAgent = this.setShowOptionalServiceAgent.bind(this);
+  }
+
+  setShowOptionalServiceAgent(show) {
+    this.setState({ showOptionalServiceAgent: show });
+  }
+
+  render() {
+    const { serviceAgentProps, saRole } = this.props;
+    return (
+      <Fragment>
+        <div className="editable-panel-3-column">
+          <span className="column-subhead">{saRole} agent</span>
+          <YesNoBoolean value={this.state.showOptionalServiceAgent} onChange={this.setShowOptionalServiceAgent} />
+          {this.state.showOptionalServiceAgent && (
+            <div>
+              <SwaggerField fieldName="company" required {...serviceAgentProps} />
+              <SwaggerField fieldName="email" required {...serviceAgentProps} />
+              <SwaggerField fieldName="phone_number" required {...serviceAgentProps} />
+            </div>
+          )}
+        </div>
+      </Fragment>
+    );
+  }
+}
 
 export const TransportationServiceProviderDisplay = ({ tsp }) => {
   const { name, standard_carrier_alpha_code, poc_general_email, poc_general_phone } = tsp;

--- a/src/shared/TspPanel/ServiceAgentViews.jsx
+++ b/src/shared/TspPanel/ServiceAgentViews.jsx
@@ -24,10 +24,10 @@ ServiceAgentDisplay.propTypes = {
   }),
 };
 
-export const ServiceAgentEdit = ({ serviceAgentProps, saRole }) => {
+export const ServiceAgentEdit = ({ serviceAgentProps, saRole, columnSize }) => {
   return (
     <Fragment>
-      <div className="editable-panel-3-column">
+      <div className={columnSize}>
         <span className="column-subhead">{saRole} agent</span>
         <SwaggerField fieldName="company" required {...serviceAgentProps} />
         <SwaggerField fieldName="email" required {...serviceAgentProps} />
@@ -53,11 +53,12 @@ export class OptionalServiceAgentEdit extends Component {
   }
 
   render() {
-    const { serviceAgentProps, saRole } = this.props;
+    const { serviceAgentProps, saRole, columnSize } = this.props;
     return (
       <Fragment>
-        <div className="editable-panel-3-column">
+        <div className={columnSize}>
           <span className="column-subhead">{saRole} agent</span>
+          <p className="optional-destination-agent-question">Have you assigned a destination servicing agent yet?</p>
           <YesNoBoolean value={this.state.showOptionalServiceAgent} onChange={this.setShowOptionalServiceAgent} />
           {this.state.showOptionalServiceAgent && (
             <div>

--- a/src/shared/TspPanel/ServiceAgentViews.jsx
+++ b/src/shared/TspPanel/ServiceAgentViews.jsx
@@ -42,11 +42,9 @@ export class OptionalServiceAgentEdit extends Component {
     showOptionalServiceAgent: false,
   };
 
-  setShowOptionalServiceAgent(show) {
-    this.setState(() => {
-      show;
-    });
-  }
+  setShowOptionalServiceAgent = showOptionalServiceAgent => {
+    this.setState({ showOptionalServiceAgent });
+  };
 
   render() {
     const { serviceAgentProps, saRole, columnSize } = this.props;

--- a/src/shared/TspPanel/ServiceAgentViews.jsx
+++ b/src/shared/TspPanel/ServiceAgentViews.jsx
@@ -38,15 +38,9 @@ export const ServiceAgentEdit = ({ serviceAgentProps, saRole, columnSize }) => {
 };
 
 export class OptionalServiceAgentEdit extends Component {
-  constructor(props) {
-    super(props);
-
-    this.state = {
-      showOptionalServiceAgent: false,
-    };
-
-    this.setShowOptionalServiceAgent = this.setShowOptionalServiceAgent.bind(this);
-  }
+  state = {
+    showOptionalServiceAgent: false,
+  };
 
   setShowOptionalServiceAgent(show) {
     this.setState({ showOptionalServiceAgent: show });

--- a/src/shared/TspPanel/ServiceAgentViews.jsx
+++ b/src/shared/TspPanel/ServiceAgentViews.jsx
@@ -43,7 +43,9 @@ export class OptionalServiceAgentEdit extends Component {
   };
 
   setShowOptionalServiceAgent(show) {
-    this.setState({ showOptionalServiceAgent: show });
+    this.setState(() => {
+      show;
+    });
   }
 
   render() {

--- a/src/shared/TspPanel/TspServiceAgents.jsx
+++ b/src/shared/TspPanel/TspServiceAgents.jsx
@@ -196,10 +196,18 @@ const TSPEdit = props => {
             values: originValues,
           }}
           saRole="Origin"
+          columnSize="editable-panel-3-column"
         />
       </FormSection>
       <FormSection name="destination_service_agent">
-        <ServiceAgentEdit serviceAgentProps={{ swagger: saSchema, values: destinationValues }} saRole="Destination" />
+        <ServiceAgentEdit
+          serviceAgentProps={{
+            swagger: saSchema,
+            values: destinationValues,
+          }}
+          saRole="Destination"
+          columnSize="editable-panel-3-column"
+        />
       </FormSection>
     </Fragment>
   );


### PR DESCRIPTION
## Description

Many tsps don't have the destination service agent at the assign service agent wizard time, so make it optional.

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make db_dev_e2e_populate
```
Sign in as `tspuser1@example.com` and click on move with ASNORG locator in the accepted shipments queue. Click assign service agents button. Submit only an origin agent. You should see the origin agent in the TSP & servicing agent panel.

Go back to the accepted shipments queue and click on the ASSIGN locator. Click assign service agents button. This time click yes on the destination agent radio button. You should now be required to include all fields for origin and destination agents. When you submit, it should still be verifiable in the TSP & Servicing agent panel.

## Code Review Verification Steps

* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* https://www.pivotaltracker.com/story/show/162707533

## Screenshots

<img width="1221" alt="screen shot 2019-01-08 at 2 46 18 pm" src="https://user-images.githubusercontent.com/5531789/50863656-3b9f7f80-1354-11e9-8774-01e5e7b27e39.png">
<img width="1227" alt="screen shot 2019-01-08 at 2 46 27 pm" src="https://user-images.githubusercontent.com/5531789/50863661-40643380-1354-11e9-9f17-31cc1e89cc4a.png">

