### PR TITLE
Fixing more dep sync issues

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -301,6 +301,7 @@
   name = "github.com/go-openapi/runtime"
   packages = [
     ".",
+    "flagext",
     "logger",
     "middleware",
     "middleware/denco",
@@ -1298,6 +1299,7 @@
     "html",
     "html/atom",
     "idna",
+    "netutil",
   ]
   pruneopts = ""
   revision = "e147a9138326bc0e9d4e179541ffd8af41cff8a9"
@@ -1451,11 +1453,16 @@
     "github.com/facebookgo/clock",
     "github.com/felixge/httpsnoop",
     "github.com/go-gomail/gomail",
+    "github.com/go-openapi/errors",
     "github.com/go-openapi/loads",
     "github.com/go-openapi/runtime",
+    "github.com/go-openapi/runtime/flagext",
     "github.com/go-openapi/runtime/middleware",
+    "github.com/go-openapi/runtime/security",
+    "github.com/go-openapi/spec",
     "github.com/go-openapi/strfmt",
     "github.com/go-openapi/swag",
+    "github.com/go-openapi/validate",
     "github.com/go-swagger/go-swagger/cmd/swagger",
     "github.com/gobuffalo/pop",
     "github.com/gobuffalo/pop/soda",
@@ -1467,6 +1474,7 @@
     "github.com/honeycombio/beeline-go",
     "github.com/honeycombio/beeline-go/wrappers/hnynethttp",
     "github.com/imdario/mergo",
+    "github.com/jessevdk/go-flags",
     "github.com/jmoiron/sqlx",
     "github.com/jung-kurt/gofpdf",
     "github.com/magiconair/properties/assert",
@@ -1490,6 +1498,7 @@
     "goji.io",
     "goji.io/pat",
     "golang.org/x/crypto/bcrypt",
+    "golang.org/x/net/netutil",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/pkg/models/fuel_eia_diesel_price.go
+++ b/pkg/models/fuel_eia_diesel_price.go
@@ -2,12 +2,14 @@ package models
 
 import (
 	"encoding/json"
+	"time"
+
 	"github.com/gobuffalo/pop"
-	"github.com/gobuffalo/uuid"
 	"github.com/gobuffalo/validate"
 	"github.com/gobuffalo/validate/validators"
+	"github.com/gofrs/uuid"
+
 	"github.com/transcom/mymove/pkg/unit"
-	"time"
 )
 
 // FuelEIADieselPrice used to hold data from the SDDC Fuel Surcharge information

--- a/pkg/models/fuel_eia_diesel_price_test.go
+++ b/pkg/models/fuel_eia_diesel_price_test.go
@@ -1,12 +1,14 @@
 package models_test
 
 import (
-	"github.com/gobuffalo/uuid"
+	"testing"
+	"time"
+
+	"github.com/gofrs/uuid"
+
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"
 	"github.com/transcom/mymove/pkg/unit"
-	"testing"
-	"time"
 )
 
 func (suite *ModelSuite) TestBasicFuelEIADieselPriceInstantiation() {

--- a/pkg/testdatagen/make_fuel_eia_diesel_price.go
+++ b/pkg/testdatagen/make_fuel_eia_diesel_price.go
@@ -1,11 +1,13 @@
 package testdatagen
 
 import (
+	"time"
+
 	"github.com/gobuffalo/pop"
-	"github.com/gobuffalo/uuid"
+	"github.com/gofrs/uuid"
+
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/unit"
-	"time"
 )
 
 func getFuelDefaultPrices() []unit.Millicents {


### PR DESCRIPTION
## Description

We had a few places where `dep` was complaining about sync problems.  One case was due to a few references to a deprecated UUID package.  The others were just missing from `Gopkg.lock` -- probably because `dep ensure` was run without the generated Go files present.

How I fixed `Gopkg.lock` (after correcting the UUID package references):
1) `make clean`
2) `make server_generate`
3) `dep check` (to see the issues)
4) `dep ensure` (to fix the issues)
5) `dep check` (to verify all is well)

## Setup

To test, follow the first 3 steps above and verify that `dep check` doesn't report any issues.
