### PR TITLE
Removes waits from Cypress tests

### DIFF
--- a/cypress/integration/mymove/mymoveCSRFProtect.js
+++ b/cypress/integration/mymove/mymoveCSRFProtect.js
@@ -36,8 +36,6 @@ describe('testing CSRF protection updating user profile', function() {
 
     cy.visit('/moves/review/edit-profile');
 
-    cy.wait(500);
-
     // update info
     cy
       .get('input[name="middle_name"]')
@@ -48,7 +46,9 @@ describe('testing CSRF protection updating user profile', function() {
     // save info
     cy.get('button[type="submit"]').click();
 
-    cy.wait(500);
+    cy.location().should(loc => {
+      expect(loc.pathname).to.match(/^\//);
+    });
 
     // reload page
     cy.visit('/moves/review/edit-profile');
@@ -63,8 +63,6 @@ describe('testing CSRF protection updating user profile', function() {
     cy.signIntoMyMoveAsUser(userId);
 
     cy.visit('/moves/review/edit-profile');
-
-    cy.wait(500);
 
     // update info
     cy

--- a/cypress/integration/office/officeCSRFProtect.js
+++ b/cypress/integration/office/officeCSRFProtect.js
@@ -56,7 +56,7 @@ describe('testing CSRF protection updating move info', function() {
       .should('be.enabled')
       .click();
 
-    cy.wait(100);
+    cy.get('div.orders_number').contains('CSRF Test');
 
     cy.patientReload();
 

--- a/cypress/integration/tsp/generateGBL.js
+++ b/cypress/integration/tsp/generateGBL.js
@@ -67,13 +67,6 @@ function tspUserGeneratesGBL() {
     .contains(gblButtonText)
     .should('be.enabled');
 
-  cy.location().should(loc => {
-    expect(loc.pathname).to.match(/^\/shipments\/[^/]+/);
-  });
-
-  // If clicked too soon, there's a server error
-  cy.wait(500);
-
   cy.get('.documents').should('not.contain', 'Government Bill Of Lading');
 
   cy

--- a/src/scenes/Office/OrdersPanel.jsx
+++ b/src/scenes/Office/OrdersPanel.jsx
@@ -40,7 +40,7 @@ const OrdersDisplay = props => {
     <React.Fragment>
       <div className="editable-panel-column">
         {props.orders.orders_number ? (
-          <PanelField title="Orders Number">
+          <PanelField title="Orders Number" className="orders_number">
             <Link to={`/moves/${props.move.id}/orders`} target="_blank">
               <SwaggerValue fieldName="orders_number" {...fieldProps} />
               &nbsp;
@@ -48,7 +48,7 @@ const OrdersDisplay = props => {
             </Link>
           </PanelField>
         ) : (
-          <PanelField title="Orders Number" className="missing">
+          <PanelField title="Orders Number" className="missing orders_number">
             missing
             <Link to={`/moves/${props.move.id}/orders`} target="_blank">
               <FontAwesomeIcon className="icon" icon={faExternalLinkAlt} />


### PR DESCRIPTION
## Description

This PR removes calls to `cy.wait` from our e2e tests. Where they were needed, I tried to replace them with checks that the page changed in ways we expected, but in about half the cases they didn't serve any purpose.

This should fix e2e failures like this one: https://circleci.com/gh/transcom/mymove/53202