### PR TITLE
Update DPS cookie prefix from mymove to milmove

### DIFF
--- a/pkg/dpsauth/cookie.go
+++ b/pkg/dpsauth/cookie.go
@@ -15,7 +15,7 @@ import (
 var cookieExpiresInMinutes = initCookieExpiration()
 var secretKey = initKey()
 
-const prefix = "mymove-"
+const prefix = "milmove-"
 
 // LoginGovIDToCookie takes the Login.gov UUID of the current user and returns the cookie.
 func LoginGovIDToCookie(userID string) (*http.Cookie, error) {


### PR DESCRIPTION
To match the new naming of the product. Tested locally:
<img width="392" alt="screen shot 2019-01-09 at 10 50 17 am" src="https://user-images.githubusercontent.com/29409348/50910753-76f58900-13fc-11e9-8d81-bbbf0c9a7dbe.png">
