### PR TITLE
Revert "Update DPS cookie prefix from mymove to milmove"

### DIFF
--- a/pkg/dpsauth/cookie.go
+++ b/pkg/dpsauth/cookie.go
@@ -15,7 +15,7 @@ import (
 var cookieExpiresInMinutes = initCookieExpiration()
 var secretKey = initKey()
 
-const prefix = "milmove-"
+const prefix = "mymove-"
 
 // LoginGovIDToCookie takes the Login.gov UUID of the current user and returns the cookie.
 func LoginGovIDToCookie(userID string) (*http.Cookie, error) {


### PR DESCRIPTION
Reverts transcom/mymove#1570
DPS can't push this change to prod until 2/1, so reverting for now so we can test. Will un-revert on 2/1.