### PR TITLE
Remove Air Force Orders certificate migration

### DIFF
--- a/local_migrations/20181219194544_add_air_force_orders_cert.sql
+++ b/local_migrations/20181219194544_add_air_force_orders_cert.sql
@@ -1,5 +1,0 @@
--- Local test migration.
--- This will be run on development environments. It should mirror what you
--- intend to apply on production, but do not include any sensitive data.
-
-INSERT INTO public.client_certs VALUES (uuid_generate_v4(), 'cb8ed5ed41787e84c5f01dc8599fb83b8397cdc0a5eda8f532eae52b5682c342', '/C=US/ST=DC/L=Washington/O=Faux Air Force/OU=Faux Orders/CN=localhost', false, true, now(), now());

--- a/local_migrations/20181219194552_add_marine_corps_orders_cert.sql
+++ b/local_migrations/20181219194552_add_marine_corps_orders_cert.sql
@@ -2,4 +2,4 @@
 -- This will be run on development environments. It should mirror what you
 -- intend to apply on production, but do not include any sensitive data.
 
-INSERT INTO public.client_certs VALUES (uuid_generate_v4(), '493ba2a4634b002d3f093e88bd182ce885e04d7efa6132b1fcfbb14055bf66e6', '/C=US/ST=DC/L=Washington/O=Faux Marine Corps/OU=Faux Orders/CN=localhost', false, true, now(), now());
+INSERT INTO public.client_certs VALUES ('f885b0d3-3df4-46b3-908e-c9c3fec9d2f4', '493ba2a4634b002d3f093e88bd182ce885e04d7efa6132b1fcfbb14055bf66e6', '/C=US/ST=DC/L=Washington/O=Faux Marine Corps/OU=Faux Orders/CN=localhost', false, true, now(), now());

--- a/local_migrations/20190102144741_add_dps_cert.sql
+++ b/local_migrations/20190102144741_add_dps_cert.sql
@@ -2,4 +2,4 @@
 -- This will be run on development environments. It should mirror what you
 -- intend to apply on production, but do not include any sensitive data.
 
-INSERT INTO public.client_certs VALUES (uuid_generate_v4(), '320c9dc085725aaa925ad1ab00261dc393264a78705bd6d5fc1c37bc33f285dd', '/C=US/ST=IL/L=Belleville/O=Not USTRANSCOM/OU=Not Defense Personal Property System/CN=localhost', true, false, now(), now());
+INSERT INTO public.client_certs VALUES ('ff001674-6a19-4f59-9417-fcfdfe071272', '320c9dc085725aaa925ad1ab00261dc393264a78705bd6d5fc1c37bc33f285dd', '/C=US/ST=IL/L=Belleville/O=Not USTRANSCOM/OU=Not Defense Personal Property System/CN=localhost', true, false, now(), now());

--- a/migrations/20181219194544_add_air_force_orders_cert.up.fizz
+++ b/migrations/20181219194544_add_air_force_orders_cert.up.fizz
@@ -1,1 +1,0 @@
-exec("./apply-secure-migration.sh 20181219194544_add_air_force_orders_cert.sql")


### PR DESCRIPTION
I don't have the production certificate for the Air Force orders system yet, so this PR removes the migration. I will create a future PR with a new migration when the Air Force sends its public certificates to us.