### PR TITLE
Hide Profile and Orders section during COMBO PPM flow

### DIFF
--- a/cypress/integration/mymove/hhgPPM.js
+++ b/cypress/integration/mymove/hhgPPM.js
@@ -427,7 +427,7 @@ function serviceMemberCanReviewMoveSummary() {
     .first()
     .should('contain', 'Move Setup');
   cy.get('.wizard-header .progress-timeline .current').should('contain', 'Review');
-
+  cy.get('h3').should('not.contain', 'Profile and Orders');
   cy.get('h2').should('contain', 'Review Move Details');
 
   cy.get('body').should($div => expect($div.text()).not.to.include('Government moves all of your stuff (HHG)'));

--- a/src/scenes/Review/Summary.jsx
+++ b/src/scenes/Review/Summary.jsx
@@ -66,6 +66,7 @@ export class Summary extends Component {
     const showHHGShipmentSummary =
       (currentShipment && !isHHGPPMComboMove) || (currentShipment && isHHGPPMComboMove && !isReviewPage);
 
+    const showProfileAndOrders = (isReviewPage && !isHHGPPMComboMove) || !isReviewPage;
     return (
       <Fragment>
         {get(this.props.reviewState.error, 'statusCode', false) === 409 && (
@@ -86,16 +87,18 @@ export class Summary extends Component {
             </Alert>
           )}
 
-        <ServiceMemberSummary
-          orders={currentOrders}
-          backupContacts={currentBackupContacts}
-          serviceMember={serviceMember}
-          schemaRank={schemaRank}
-          schemaAffiliation={schemaAffiliation}
-          schemaOrdersType={schemaOrdersType}
-          moveIsApproved={moveIsApproved}
-          editOrdersPath={editOrdersPath}
-        />
+        {showProfileAndOrders && (
+          <ServiceMemberSummary
+            orders={currentOrders}
+            backupContacts={currentBackupContacts}
+            serviceMember={serviceMember}
+            schemaRank={schemaRank}
+            schemaAffiliation={schemaAffiliation}
+            schemaOrdersType={schemaOrdersType}
+            moveIsApproved={moveIsApproved}
+            editOrdersPath={editOrdersPath}
+          />
+        )}
 
         {showHHGShipmentSummary && (
           <HHGShipmentSummary shipment={currentShipment} movePath={rootAddressWithMoveId} entitlements={entitlement} />


### PR DESCRIPTION
## Description

For a combo move, when a service member is reviewing their PPM information they should not see the profile and orders section

## Setup
`make server_run`
`make client_run`
Log into `hhgforppm@award.ed`
Go through Add a PPM flow

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/162797964) for this change

## Screenshots

![image](https://user-images.githubusercontent.com/13622298/50930613-4a01a000-1415-11e9-94a5-3f58af879f51.png)
