### PR TITLE
Sb 162896935 dedupe alerts for broken master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ commands:
       - run:
           name: Announce failure
           command: |
-            [[ $CIRCLE_BRANCH = sb_162896935_dedupe_alerts_for_broken_master ]] || exit 0
+            [[ $CIRCLE_BRANCH = master ]] || exit 0
             bin/circleci-announce-broken-branch
           when: on_fail
   halt_workflow_if_older_sha:
@@ -263,7 +263,6 @@ jobs:
           environment:
             LOGIN_GOV_HOSTNAME: idp.int.identitysandbox.gov
             DOD_CA_PACKAGE: /home/circleci/go/src/github.com/transcom/mymove/config/tls/Certificates_PKCS7_v5.4_DoD.der.p7b
-      - run: exit 1
       - announce_failure
 
   # `integration_tests_mymove` runs integration tests using Cypress.  https://www.cypress.io/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ commands:
       - run:
           name: Announce failure
           command: |
-            [[ $CIRCLE_BRANCH = master ]] || exit 0
+            [[ $CIRCLE_BRANCH = sb_162896935_dedupe_alerts_for_broken_master ]] || exit 0
             bin/circleci-announce-broken-branch
           when: on_fail
   halt_workflow_if_older_sha:
@@ -263,6 +263,7 @@ jobs:
           environment:
             LOGIN_GOV_HOSTNAME: idp.int.identitysandbox.gov
             DOD_CA_PACKAGE: /home/circleci/go/src/github.com/transcom/mymove/config/tls/Certificates_PKCS7_v5.4_DoD.der.p7b
+      - run: exit 1
       - announce_failure
 
   # `integration_tests_mymove` runs integration tests using Cypress.  https://www.cypress.io/

--- a/bin/circleci-announce-broken-branch
+++ b/bin/circleci-announce-broken-branch
@@ -59,7 +59,7 @@ cat <<EOM
     "class": "cicd failure"
   },
   "routing_key": "$PD_ROUTING_KEY",
-  "dedup_key": "circle-$CIRCLE_WORKFLOW_ID",
+  "dedup_key": "circle-$CIRCLE_JOB",
   "links": [{
     "href": "$CIRCLE_BUILD_URL",
     "text": "CircleCI Build URL"


### PR DESCRIPTION
## Description

Group similar alerts so we don't get paged so much.

## Reviewer Notes

I made the decision to specifically use the `$CIRCLE_JOB` in our dedupe key, rather than the branch name. This means that alerts that fail in the same part of the test/build process will be grouped together, but failures that happen in different parts of the process will create separate alerts. This made the most sense to me because a) we suppress all alerts for branches other than master, and b) if one merge is breaking acceptance tests, but another is breaking migrations, that might be good to know.

Test results are available in slack history, plus I've included a screenshot from PagerDuty below.

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/162896935) for this change

## Screenshots

Grouping in pagerduty:
<img width="1402" alt="screen shot 2019-01-09 at 6 33 25 pm" src="https://user-images.githubusercontent.com/4434681/50942529-d9bb4480-143d-11e9-88e0-dc15a04d4e06.png">

