### PR TITLE
Move invoice panel below tsp panel: 162705954

### DIFF
--- a/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
+++ b/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
@@ -395,7 +395,6 @@ class ShipmentInfo extends Component {
                   <Weights title="Weights & Items" shipment={this.props.shipment} update={this.props.patchShipment} />
                   <LocationsContainer update={this.props.patchShipment} />
                   <PreApprovalPanel shipmentId={this.props.match.params.shipmentId} />
-                  <InvoicePanel shipmentId={this.props.match.params.shipmentId} shipmentStatus={shipment.status} />
 
                   <TspContainer
                     title="TSP & Servicing Agents"
@@ -403,6 +402,8 @@ class ShipmentInfo extends Component {
                     serviceAgents={this.props.serviceAgents}
                     transportationServiceProviderId={this.props.shipment.transportation_service_provider_id}
                   />
+
+                  <InvoicePanel shipmentId={this.props.match.params.shipmentId} shipmentStatus={shipment.status} />
                 </div>
               )}
             </div>


### PR DESCRIPTION
## Description

When logged in as a TSP, move the Invoice panel below the TSP & Servicing Agents panel

## Setup

Setup the TSPLocal client: https://github.com/transcom/mymove#setup-tsplocal-client
I used `local sign in` user: leo_spaceman_tsp_1@example.com (tsp)

## Code Review Verification Steps
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/162705954) for this change

## Screenshots

![screen shot 2019-01-10 at 2 33 51 pm](https://user-images.githubusercontent.com/3099491/50996440-88678f80-14e7-11e9-9e3f-46ae92646794.jpg)

