### PR TITLE
Adds rate for accessorial 130J

### DIFF
--- a/migrations/20190110211301_add_130J_accessorial_rate.up.sql
+++ b/migrations/20190110211301_add_130J_accessorial_rate.up.sql
@@ -1,0 +1,1 @@
+INSERT INTO tariff400ng_item_rates (id, created_at, updated_at, code, rate_cents, effective_date_lower, effective_date_upper) VALUES ('b3b0de94-eb1b-4a19-a623-d5cb9590dfcc', now(), now(), '130J', 21892, '2018-05-15', '2019-05-15');


### PR DESCRIPTION
## Description

@rdhariwal and @lynzt have been doing work on testing that we can price all the accessorials we allow to be added to a shipment, and they learned that 130J fails that test. Turns out I forgot to add a row for 130J (it's the same rate as all the other 130s). Oops.

AFAIK this is the only known missing rate issue at the moment.

I tested this by running `make db_populate_e2e` and manually adding and pricing a 130J item in a local dev environment

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make db_dev_migrate
```

## Code Review Verification Steps

* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](./docs/database.md#zero-downtime-migrations))
* [ ] Request review from a member of a different team.

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/163131082) for this change