### PR TITLE
Log requests sent to the health check

### DIFF
--- a/cmd/webserver/main.go
+++ b/cmd/webserver/main.go
@@ -759,6 +759,32 @@ func main() {
 		if err != nil {
 			logger.Error("Failed encoding health check response", zap.Error(err))
 		}
+
+		// We are not using request middleware here so logging directly in the check
+		var protocol string
+		if r.TLS == nil {
+			protocol = "http"
+		} else {
+			protocol = "https"
+		}
+		zap.L().Info("Request",
+			zap.String("git-branch", gitBranch),
+			zap.String("git-commit", gitCommit),
+			zap.String("accepted-language", r.Header.Get("accepted-language")),
+			zap.Int64("content-length", r.ContentLength),
+			zap.String("host", r.Host),
+			zap.String("method", r.Method),
+			zap.String("protocol", protocol),
+			zap.String("protocol-version", r.Proto),
+			zap.String("referer", r.Header.Get("referer")),
+			zap.String("source", r.RemoteAddr),
+			zap.String("url", r.URL.String()),
+			zap.String("user-agent", r.UserAgent()),
+			zap.String("x-amzn-trace-id", r.Header.Get("x-amzn-trace-id")),
+			zap.String("x-forwarded-for", r.Header.Get("x-forwarded-for")),
+			zap.String("x-forwarded-host", r.Header.Get("x-forwarded-host")),
+			zap.String("x-forwarded-proto", r.Header.Get("x-forwarded-proto")),
+		)
 	})
 
 	// Allow public content through without any auth or app checks


### PR DESCRIPTION
## Description

We weren't using the request logging middleware on this endpoint.  And because we aren't using middleware we need to log directly.

## Reviewer Notes

This is a trimmed down version of the request info because we may not have a session to reference or metrics.

## Setup

Navigate to http://milmovelocal:8080/health and you should see this log:

```
2019-01-10T22:11:15.609Z        INFO    webserver/main.go:768   Request {"git-branch": "master", "git-commit": "f817390f727985f53738609740347076a2530a77", "accepted-language": "", "content-length": 0, "host": "milmovelocal:8080", "method": "GET", "protocol": "http", "protocol-version": "HTTP/1.1", "referer": "", "source": "127.0.0.1:49587", "url": "/health", "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.98 Safari/537.36", "x-amzn-trace-id": "", "x-forwarded-for": "", "x-forwarded-host": "", "x-forwarded-proto": ""}
```

## Code Review Verification Steps

* [x] Code follows the guidelines for [Logging](./docs/backend.md#logging)
* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/162877640) for this change