### PR TITLE
return empty object when office.officeMove is null

### DIFF
--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -458,12 +458,12 @@ MoveInfo.propTypes = {
 };
 
 const mapStateToProps = state => {
-  const officeMove = get(state, 'office.officeMove', {});
+  const officeMove = get(state, 'office.officeMove', {}) || {};
   const shipmentId = get(officeMove, 'shipments.0.id');
 
   return {
     swaggerError: get(state, 'swagger.hasErrored'),
-    officeMove: get(state, 'office.officeMove', {}),
+    officeMove,
     officeShipment: get(state, 'office.officeShipment', {}),
     shipment: get(state, `entities.shipments.${shipmentId}`, {}),
     officeOrders: get(state, 'office.officeOrders', {}),


### PR DESCRIPTION
## Description

While debugging https://www.pivotaltracker.com/story/show/163038889, we discovered that the move page wasn't displaying when there was a 500. This is because `office.officeMove` was not being set to the default of an empty object when there was a 500. 

Talked with @sarboc and we're going to create a separate story to handle default values when a 500 is returned.

## Setup

We tested this by forcing a 500 in the moves handler (there might be an easier way to do this...)then querying any move in the office UI.
```
func (h ShowMoveHandler) Handle(params moveop.ShowMoveParams) middleware.Responder {
	return handlers.ResponseForError(h.Logger(), errors.New("Error"))
```

http://officelocal:3000/queues/new/moves/0db80bd6-de75-439e-bf89-deaafa1d0dc8/basics

Before the change, this would have crashed the app. Now it shows that an error occured.

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/163038889)


## Screenshots

### Before

<img width="1240" alt="screen shot 2019-01-10 at 5 55 14 pm" src="https://user-images.githubusercontent.com/44583912/51008510-e94f9180-1500-11e9-9b0b-f1bc95d944ee.png">

### After

<img width="1267" alt="screen shot 2019-01-10 at 5 56 14 pm" src="https://user-images.githubusercontent.com/44583912/51008539-0b491400-1501-11e9-9dd7-30e523eac266.png">

