### PR TITLE
Fixes home page location patterns in Cypress

### DIFF
--- a/cypress/integration/mymove/hhgPPM.js
+++ b/cypress/integration/mymove/hhgPPM.js
@@ -332,7 +332,7 @@ function serviceMemberCancelsAddPPMToHHG() {
     .click();
 
   cy.location().should(loc => {
-    expect(loc.pathname).to.match(/^\//);
+    expect(loc.pathname).to.match(/^\/$/);
   });
 }
 

--- a/cypress/integration/mymove/mymoveCSRFProtect.js
+++ b/cypress/integration/mymove/mymoveCSRFProtect.js
@@ -47,7 +47,7 @@ describe('testing CSRF protection updating user profile', function() {
     cy.get('button[type="submit"]').click();
 
     cy.location().should(loc => {
-      expect(loc.pathname).to.match(/^\//);
+      expect(loc.pathname).to.match(/^\/$/);
     });
 
     // reload page

--- a/cypress/integration/mymove/ppm.js
+++ b/cypress/integration/mymove/ppm.js
@@ -77,7 +77,7 @@ describe('completing the ppm flow', function() {
     cy.nextPage();
 
     cy.location().should(loc => {
-      expect(loc.pathname).to.match(/^\//);
+      expect(loc.pathname).to.match(/^\/$/);
     });
 
     cy.contains('Success');

--- a/src/App/index.jsx
+++ b/src/App/index.jsx
@@ -1,27 +1,29 @@
 import React from 'react';
 import { Provider } from 'react-redux';
-import { isOfficeSite, isTspSite } from 'shared/constants.js';
-import { store } from 'shared/store';
-import './index.css';
 
 import Loadable from 'react-loadable';
 
+import LoadingPlaceholder from 'shared/LoadingPlaceholder';
+import { isOfficeSite, isTspSite } from 'shared/constants.js';
+import { store } from 'shared/store';
 import { AppContext, defaultTspContext, defaultOfficeContext, defaultMyMoveContext } from 'shared/AppContext';
 import { detectFlags } from 'shared/featureFlags.js';
 
+import './index.css';
+
 const Tsp = Loadable({
   loader: () => import('scenes/TransportationServiceProvider'),
-  loading: () => <div>Loading...</div>,
+  loading: () => <LoadingPlaceholder />,
 });
 
 const Office = Loadable({
   loader: () => import('scenes/Office'),
-  loading: () => <div>Loading...</div>,
+  loading: () => <LoadingPlaceholder />,
 });
 
 const MyMove = Loadable({
   loader: () => import('scenes/MyMove'),
-  loading: () => <div>Loading...</div>,
+  loading: () => <LoadingPlaceholder />,
 });
 
 const flags = detectFlags(process.env['NODE_ENV'], window.location.host, window.location.search);

--- a/src/scenes/Landing/index.jsx
+++ b/src/scenes/Landing/index.jsx
@@ -15,6 +15,7 @@ import { loadLoggedInUser } from 'shared/User/ducks';
 import { getNextIncompletePage as getNextIncompletePageInternal } from 'scenes/MyMove/getWorkflowRoutes';
 import Alert from 'shared/Alert';
 import SignIn from 'shared/User/SignIn';
+import LoadingPlaceholder from 'shared/LoadingPlaceholder';
 
 import { updateMove } from 'scenes/Moves/ducks';
 import { getPPM } from 'scenes/Moves/Ppm/ducks';
@@ -105,7 +106,7 @@ export class Landing extends Component {
     } = this.props;
     return (
       <div className="usa-grid">
-        {loggedInUserIsLoading && <span> Loading... </span>}
+        {loggedInUserIsLoading && <LoadingPlaceholder />}
         {!isLoggedIn && <SignIn />}
         {loggedInUserSuccess && (
           <Fragment>


### PR DESCRIPTION
## Description

This fixes the flaky e2e test as it failed [here](https://circleci.com/gh/transcom/mymove/54313#tests/containers/0). During a _previous_ fix, I had tried to check that we visited the home page by doing a location check using the pattern `^\/`, which as it turns out makes exactly _no_ assertions about anything really. This PR updates that pattern (and where it's used elsewhere)  to be `^\/$`.

I had initially thought that this was another loading screen timeout, so I had brought in our newer `LoadingPlaceholder` component into the older React code this test runs on and planned on using `cy.waitForLoadingScreen()`, but it ended up being the above regex thing. Still seems useful to standardize our loading screen though?