### PR TITLE
Sb dont alert pd on test failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ commands:
       - run:
           name: Announce failure
           command: |
-            [[ $CIRCLE_BRANCH = sb_dont_alert_pd_on_test_failures ]] || exit 0
+            [[ $CIRCLE_BRANCH = master ]] || exit 0
             bin/circleci-announce-broken-branch
           when: on_fail
   halt_workflow_if_older_sha:
@@ -263,7 +263,6 @@ jobs:
           environment:
             LOGIN_GOV_HOSTNAME: idp.int.identitysandbox.gov
             DOD_CA_PACKAGE: /home/circleci/go/src/github.com/transcom/mymove/config/tls/Certificates_PKCS7_v5.4_DoD.der.p7b
-      - run: exit 1
       - announce_failure
 
   # `integration_tests_mymove` runs integration tests using Cypress.  https://www.cypress.io/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ commands:
       - run:
           name: Announce failure
           command: |
-            [[ $CIRCLE_BRANCH = master ]] || exit 0
+            [[ $CIRCLE_BRANCH = sb_dont_alert_pd_on_test_failures ]] || exit 0
             bin/circleci-announce-broken-branch
           when: on_fail
   halt_workflow_if_older_sha:
@@ -263,6 +263,7 @@ jobs:
           environment:
             LOGIN_GOV_HOSTNAME: idp.int.identitysandbox.gov
             DOD_CA_PACKAGE: /home/circleci/go/src/github.com/transcom/mymove/config/tls/Certificates_PKCS7_v5.4_DoD.der.p7b
+      - run: exit 1
       - announce_failure
 
   # `integration_tests_mymove` runs integration tests using Cypress.  https://www.cypress.io/

--- a/bin/circleci-announce-broken-branch
+++ b/bin/circleci-announce-broken-branch
@@ -20,7 +20,7 @@ fi
 slack_payload=$(
 cat <<EOM
 {
-    "channel": "#dp3-engineering",
+    "channel": "#dp3-bat-team",
     "attachments": [
         {
             "fallback": "$message $CIRCLE_BUILD_URL",

--- a/bin/circleci-announce-broken-branch
+++ b/bin/circleci-announce-broken-branch
@@ -45,6 +45,13 @@ echo
 curl -X POST --data-urlencode payload="$slack_payload" "$SLACK_WEBHOOK_URL"
 
 #####
+## Exit and do nothing else unless a deploy job
+#####
+if [[ $CIRCLE_JOB != *"deploy"* ]]; then
+  exit 0
+fi
+
+#####
 ## Page the on-call via PagerDuty
 #####
 


### PR DESCRIPTION
## Description

Continue to send alerts in slack, but don't send pages to the on call team, for broken tests. Send both only if deploy steps are broken.

## Reviewer Notes

In the last turn on the bat team, there has been a lot of fatigue around being pinged in multiple channels that something is broken. The consensus @chrisgilmerproj and I came to is that deploys being broken is a page-able offense, but master build being broken due to failing tests can be a less noisy alert.

Is this a good solution? Maybe. It puts more onus on the bat team to remain aware of slack channels, etc. To counteract that, I've moved the slack alerts to the bat-team slack channel, and I will make a recommendation that the bat team change alert settings for that channel during their on-call duration.

This is meant to be an experiment. If things are falling through the cracks again, we can dial the intensity back up. The relevant code should be easy to revert/remove.

## Code Review Verification Steps

* [ ] Request review from a member of a different team.