### PR TITLE
Office Approves Shipment for an HHG_PPM move

### DIFF
--- a/cypress/integration/office/officeUserHHG.js
+++ b/cypress/integration/office/officeUserHHG.js
@@ -163,7 +163,7 @@ function officeUserApprovesOnlyBasicsHHG() {
   // disabled because not on hhg tab
   cy
     .get('button')
-    .contains('Approve Shipment')
+    .contains('Approve HHG')
     .should('be.disabled');
   cy
     .get('button')
@@ -185,13 +185,13 @@ function officeUserApprovesOnlyBasicsHHG() {
   // disabled because shipment not yet accepted
   cy
     .get('button')
-    .contains('Approve Shipment')
+    .contains('Approve HHG')
     .should('be.disabled');
 
   // Disabled because already approved and not delivered
   cy
     .get('button')
-    .contains('Approve Shipment')
+    .contains('Approve HHG')
     .should('be.disabled');
   cy
     .get('button')
@@ -227,7 +227,7 @@ function officeUserApprovesHHG() {
   // disabled because not on hhg tab
   cy
     .get('button')
-    .contains('Approve Shipment')
+    .contains('Approve HHG')
     .should('be.disabled');
   cy
     .get('button')
@@ -249,13 +249,13 @@ function officeUserApprovesHHG() {
   // Approve HHG
   cy
     .get('button')
-    .contains('Approve Shipment')
+    .contains('Approve HHG')
     .click();
 
   // Disabled because already approved and not delivered
   cy
     .get('button')
-    .contains('Approve Shipment')
+    .contains('Approve HHG')
     .should('be.disabled');
   cy
     .get('button')
@@ -305,7 +305,7 @@ function officeUserCompletesHHG() {
 
   cy
     .get('button')
-    .contains('Approve Shipment')
+    .contains('Approve HHG')
     .should('be.disabled');
 
   cy.get('.status').contains('Completed');

--- a/cypress/integration/office/officeUserHHGPPM.js
+++ b/cypress/integration/office/officeUserHHGPPM.js
@@ -13,7 +13,7 @@ describe('office user finds the shipment', function() {
 });
 
 function officeUserApprovesShipment() {
-  const ApproveShipmentButton = cy.get('button').contains('Approve Shipment');
+  const ApproveShipmentButton = cy.get('button').contains('Approve HHG');
 
   ApproveShipmentButton.should('be.enabled');
 

--- a/cypress/integration/office/officeUserHHGPPM.js
+++ b/cypress/integration/office/officeUserHHGPPM.js
@@ -1,0 +1,36 @@
+/* global cy */
+describe('office user finds the shipment', function() {
+  beforeEach(() => {
+    cy.signIntoOffice();
+  });
+  it('office user views hhg moves in queue new moves', function() {
+    officeUserViewsMove();
+  });
+});
+
+function officeUserViewsMove() {}
+function officeUserViewsMoves() {
+  // Open new moves queue
+  cy.location().should(loc => {
+    expect(loc.pathname).to.match(/^\/queues\/new/);
+  });
+
+  // Find move (generated in e2ebasic.go) and open it
+  cy
+    .get('div')
+    .contains('RLKBEM')
+    .dblclick();
+
+  cy.location().should(loc => {
+    expect(loc.pathname).to.match(/^\/queues\/new\/moves\/[^/]+\/basics/);
+  });
+
+  cy
+    .get('a')
+    .contains('HHG')
+    .click(); // navtab
+
+  cy.location().should(loc => {
+    expect(loc.pathname).to.match(/^\/queues\/new\/moves\/[^/]+\/hhg/);
+  });
+}

--- a/cypress/integration/office/officeUserHHGPPM.js
+++ b/cypress/integration/office/officeUserHHGPPM.js
@@ -3,34 +3,67 @@ describe('office user finds the shipment', function() {
   beforeEach(() => {
     cy.signIntoOffice();
   });
-  it('office user views hhg moves in queue new moves', function() {
+  it('office user approves shipment', function() {
+    officeUserVisitsAllMovesQueue();
     officeUserViewsMove();
+    officeUserVisitsPPMTab();
+    officeUserVisitsHHGTab();
+    officeUserApprovesShipment();
   });
 });
 
-function officeUserViewsMove() {}
-function officeUserViewsMoves() {
-  // Open new moves queue
-  cy.location().should(loc => {
-    expect(loc.pathname).to.match(/^\/queues\/new/);
-  });
+function officeUserApprovesShipment() {
+  const ApproveShipmentButton = cy.get('button').contains('Approve Shipment');
 
+  ApproveShipmentButton.should('be.enabled');
+
+  ApproveShipmentButton.click();
+
+  ApproveShipmentButton.should('be.disabled');
+
+  cy.get('.status').contains('Approved');
+}
+
+function officeUserVisitsAllMovesQueue() {
+  cy.patientVisit('/queues/all');
+
+  cy.location().should(loc => {
+    expect(loc.pathname).to.match(/^\/queues\/all/);
+  });
+}
+
+function officeUserVisitsPPMTab() {
+  // navtab
+  cy
+    .get('a')
+    .contains('PPM')
+    .click();
+
+  cy.location().should(loc => {
+    expect(loc.pathname).to.match(/^\/queues\/new\/moves\/[^/]+\/ppm/);
+  });
+}
+
+function officeUserVisitsHHGTab() {
+  // navtab
+  cy
+    .get('a')
+    .contains('HHG')
+    .click();
+
+  cy.location().should(loc => {
+    expect(loc.pathname).to.match(/^\/queues\/new\/moves\/[^/]+\/hhg/);
+  });
+}
+
+function officeUserViewsMove() {
   // Find move (generated in e2ebasic.go) and open it
   cy
     .get('div')
-    .contains('RLKBEM')
+    .contains('COMBO2')
     .dblclick();
 
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/queues\/new\/moves\/[^/]+\/basics/);
-  });
-
-  cy
-    .get('a')
-    .contains('HHG')
-    .click(); // navtab
-
-  cy.location().should(loc => {
-    expect(loc.pathname).to.match(/^\/queues\/new\/moves\/[^/]+\/hhg/);
   });
 }

--- a/pkg/models/shipment_test.go
+++ b/pkg/models/shipment_test.go
@@ -103,7 +103,7 @@ func (suite *ModelSuite) TestShipmentStateMachine() {
 	suite.Nil(err)
 	suite.Equal(ShipmentStatusACCEPTED, shipment.Status, "expected Accepted")
 
-	// Can approve shipment
+	// Can approve shipment (HHG)
 	err = shipment.Approve()
 	suite.Nil(err)
 	suite.Equal(ShipmentStatusAPPROVED, shipment.Status, "expected Approved")

--- a/pkg/testdatagen/scenario/e2ebasic.go
+++ b/pkg/testdatagen/scenario/e2ebasic.go
@@ -2039,6 +2039,63 @@ func MakeHhgWithPpm(db *pop.Connection, tspUser models.TspUser, loader *uploader
 	})
 	ppm.Move.Submit()
 	models.SaveMoveDependencies(db, &ppm.Move)
+
+	email2 := "hhgwithppm@approve.shipment"
+	userID2 := uuid.Must(uuid.FromString("144f63c5-676f-4c36-a849-5588bd60c33f"))
+	moveID2 := uuid.FromStringOrNil("27266e89-df79-4469-8843-05b45741a818")
+	smID2 := uuid.FromStringOrNil("f753c28f-5da4-4924-9955-dba90b1b3011")
+
+	testdatagen.MakeShipmentOffer(db, testdatagen.Assertions{
+		User: models.User{
+			ID:            userID2,
+			LoginGovEmail: email2,
+		},
+		ServiceMember: models.ServiceMember{
+			ID:            smID2,
+			FirstName:     models.StringPointer("HHGPPM"),
+			LastName:      models.StringPointer("ApproveShipment"),
+			Edipi:         models.StringPointer("4224567890"),
+			PersonalEmail: models.StringPointer(email2),
+		},
+		Order: models.Order{
+			IssueDate: time.Date(2018, time.May, 20, 0, 0, 0, 0, time.UTC),
+		},
+		Move: models.Move{
+			ID:               moveID2,
+			Locator:          "COMBO2",
+			SelectedMoveType: &selectedMoveTypeHHGPPM,
+		},
+		TrafficDistributionList: models.TrafficDistributionList{
+			ID:                uuid.FromStringOrNil("ceb40c74-41a4-48cd-a53b-f7f5a81c7ebc"),
+			SourceRateArea:    "US62",
+			DestinationRegion: "11",
+			CodeOfService:     "D",
+		},
+		Shipment: models.Shipment{
+			Status:             models.ShipmentStatusAWARDED,
+			HasDeliveryAddress: true,
+			GBLNumber:          models.StringPointer("LKNQ7123456"),
+		},
+		ShipmentOffer: models.ShipmentOffer{
+			TransportationServiceProviderID: tspUser.TransportationServiceProviderID,
+		},
+	})
+
+	ppm2 := testdatagen.MakePPM(db, testdatagen.Assertions{
+		ServiceMember: models.ServiceMember{
+			ID: smID2,
+		},
+		Move: models.Move{
+			ID: moveID2,
+		},
+		PersonallyProcuredMove: models.PersonallyProcuredMove{
+			PlannedMoveDate: &nowTime,
+			MoveID:          moveID2,
+		},
+		Uploader: loader,
+	})
+	ppm2.Move.Submit()
+	models.SaveMoveDependencies(db, &ppm2.Move)
 }
 
 // MakeHhgFromAwardedToAcceptedGBLReady creates a scenario for an approved shipment ready for GBL generation

--- a/pkg/testdatagen/scenario/e2ebasic.go
+++ b/pkg/testdatagen/scenario/e2ebasic.go
@@ -2044,6 +2044,7 @@ func MakeHhgWithPpm(db *pop.Connection, tspUser models.TspUser, loader *uploader
 	userID2 := uuid.Must(uuid.FromString("144f63c5-676f-4c36-a849-5588bd60c33f"))
 	moveID2 := uuid.FromStringOrNil("27266e89-df79-4469-8843-05b45741a818")
 	smID2 := uuid.FromStringOrNil("f753c28f-5da4-4924-9955-dba90b1b3011")
+	ordersTypeDetail := internalmessages.OrdersTypeDetailPCSTDY
 
 	testdatagen.MakeShipmentOffer(db, testdatagen.Assertions{
 		User: models.User{
@@ -2058,12 +2059,14 @@ func MakeHhgWithPpm(db *pop.Connection, tspUser models.TspUser, loader *uploader
 			PersonalEmail: models.StringPointer(email2),
 		},
 		Order: models.Order{
-			IssueDate: time.Date(2018, time.May, 20, 0, 0, 0, 0, time.UTC),
+			IssueDate:        time.Date(2018, time.May, 20, 0, 0, 0, 0, time.UTC),
+			OrdersTypeDetail: &ordersTypeDetail,
 		},
 		Move: models.Move{
 			ID:               moveID2,
 			Locator:          "COMBO2",
 			SelectedMoveType: &selectedMoveTypeHHGPPM,
+			Status:           models.MoveStatusAPPROVED,
 		},
 		TrafficDistributionList: models.TrafficDistributionList{
 			ID:                uuid.FromStringOrNil("ceb40c74-41a4-48cd-a53b-f7f5a81c7ebc"),
@@ -2072,7 +2075,7 @@ func MakeHhgWithPpm(db *pop.Connection, tspUser models.TspUser, loader *uploader
 			CodeOfService:     "D",
 		},
 		Shipment: models.Shipment{
-			Status:             models.ShipmentStatusAWARDED,
+			Status:             models.ShipmentStatusACCEPTED,
 			HasDeliveryAddress: true,
 			GBLNumber:          models.StringPointer("LKNQ7123456"),
 		},

--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
-import { get, capitalize, has, isEmpty, includes } from 'lodash';
+import { get, capitalize, has, includes } from 'lodash';
 
 import { RoutedTabs, NavTab } from 'react-router-tabs';
 import { NavLink, Switch, Redirect, Link } from 'react-router-dom';
@@ -216,8 +216,9 @@ class MoveInfo extends Component {
     const orders = this.props.officeOrders;
     const ppm = this.props.officePPM;
     const hhg = this.props.officeHHG;
-    const isPPM = !isEmpty(this.props.officePPM);
-    const isHHG = !isEmpty(this.props.officeHHG);
+    const isPPM = move.selected_move_type === 'PPM';
+    const isHHG = move.selected_move_type === 'HHG';
+    const isHHGPPM = move.selected_move_type === 'HHG_PPM';
     const pathnames = this.props.location.pathname.split('/');
     const currentTab = pathnames[pathnames.length - 1];
     const showDocumentViewer = this.props.context.flags.documentViewer;
@@ -296,13 +297,13 @@ class MoveInfo extends Component {
                   {capitalize(move.status)}
                 </span>
               </NavTab>
-              {isPPM && (
+              {(isPPM || isHHGPPM) && (
                 <NavTab to="/ppm">
                   <span className="title">PPM</span>
                   {this.renderPPMTabStatus()}
                 </NavTab>
               )}
-              {isHHG && (
+              {(isHHG || isHHGPPM) && (
                 <NavTab to="/hhg">
                   <span className="title">HHG</span>
                   <span className="status">
@@ -355,7 +356,8 @@ class MoveInfo extends Component {
                 Approve Basics
                 {moveApproved && check}
               </button>
-              {isPPM ? (
+
+              {(isPPM || isHHGPPM) && (
                 <button
                   className={`${ppmApproved ? 'btn__approve--green' : ''}`}
                   onClick={this.approvePPM}
@@ -364,7 +366,8 @@ class MoveInfo extends Component {
                   Approve PPM
                   {ppmApproved && check}
                 </button>
-              ) : (
+              )}
+              {(isHHG || isHHGPPM) && (
                 <button
                   className={`${hhgApproved ? 'btn__approve--green' : ''}`}
                   onClick={this.approveHHG}
@@ -381,7 +384,7 @@ class MoveInfo extends Component {
                   {hhgApproved && check}
                 </button>
               )}
-              {isHHG && (
+              {(isHHG || isHHGPPM) && (
                 <button
                   className={`${hhgCompleted ? 'btn__approve--green' : ''}`}
                   onClick={this.completeHHG}

--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -380,7 +380,7 @@ class MoveInfo extends Component {
                     currentTab !== 'hhg'
                   }
                 >
-                  Approve Shipments
+                  Approve HHG
                   {hhgApproved && check}
                 </button>
               )}


### PR DESCRIPTION
## Description

An Office User should be able to view HHG/PPM tabs and Approve Shipments for an HHG_PPM move

## Setup
`make db_dev_e2e_populate`
`make server_run`
`make office_client_run`
Log in to `officeuser1`
Go to `All Moves` queue
Visit COMBO2 move
Switch to HHG tab

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/163100025) for this change

## Screenshots

![image](https://user-images.githubusercontent.com/13622298/51127217-d88d6d00-17d9-11e9-8a85-e231c0de1bed.png)

