### PR TITLE
Populate Max. SIT Storage Entitlement in SSW

### DIFF
--- a/pkg/models/shipment_summary_worksheet.go
+++ b/pkg/models/shipment_summary_worksheet.go
@@ -8,7 +8,8 @@ import (
 // ShipmentSummaryWorksheetPage1Values is an object representing a Shipment Summary Worksheet
 // Convert dates to strings in order to avoid automatic formatting within forms.go
 type ShipmentSummaryWorksheetPage1Values struct {
-	ServiceMemberName string `db:"service_member_name"`
+	ServiceMemberName        string `db:"service_member_name"`
+	MaxSITStorageEntitlement string
 }
 
 // ShipmentSummaryWorksheetPage2Values is an object representing a Shipment Summary Worksheet
@@ -27,10 +28,11 @@ func FetchShipmentSummaryWorksheetFormValues(db *pop.Connection, moveID uuid.UUI
 				INNER JOIN service_members sm ON o.service_member_id = sm.id
 				WHERE m.id = $1
 				`
-	err := db.RawQuery(sql, moveID).Eager().First(&page1)
+	err := db.RawQuery(sql, moveID).First(&page1)
 	if err != nil {
 		return page1, page2, err
 	}
+	page1.MaxSITStorageEntitlement = "90 days per each shipment"
 
 	return page1, page2, nil
 }

--- a/pkg/models/shipment_summary_worksheet_test.go
+++ b/pkg/models/shipment_summary_worksheet_test.go
@@ -18,4 +18,5 @@ func (suite *ModelSuite) TestFetchShipmentSummaryWorksheetFormValues() {
 	suite.NoError(err)
 
 	suite.Equal("Jenkins Jr., Marcus Joseph", sswPage1.ServiceMemberName)
+	suite.Equal("90 days per each shipment", sswPage1.MaxSITStorageEntitlement)
 }

--- a/pkg/paperwork/shipment_summary_worksheet.go
+++ b/pkg/paperwork/shipment_summary_worksheet.go
@@ -6,7 +6,8 @@ var ShipmentSummaryPage1Layout = FormLayout{
 	TemplateImagePath: "pkg/paperwork/formtemplates/shipment_summary_worksheet_page1.png",
 
 	FieldsLayout: map[string]FieldPos{
-		"ServiceMemberName": FormField(45, 42, 105, floatPtr(10), nil),
+		"ServiceMemberName":        FormField(45, 42, 105, floatPtr(10), nil),
+		"MaxSITStorageEntitlement": FormField(153, 115, 49, floatPtr(10), nil),
 	},
 }
 


### PR DESCRIPTION
## Description

Pre-fill the Shipment Summary Worksheet with the default for "Max. SIT Storage Entitlement"

## Reviewer Notes
* The executable, `generate_shipment_summary`, can be run to generate a PDF for development purposes.

## Setup
Use `make db_populate_e2e` and then can use one of the generated shipment IDs for testing. 

Generate a SSW PDF using:

```
$ go run cmd/generate_shipment_summary/main.go  -move <move-id>
```

Add `-debug` to get debug output:

```
$ go run cmd/generate_shipment_summary/main.go  -move <move-id> -debug
```

## Code Review Verification Steps
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/162902417) for this change