### PR TITLE
Fix proptype warning for the InvoiceTable: 163090350

### DIFF
--- a/src/shared/Invoice/UnbilledTable.jsx
+++ b/src/shared/Invoice/UnbilledTable.jsx
@@ -88,7 +88,7 @@ UnbilledTable.propTypes = {
   lineItemsTotal: PropTypes.number,
   approvePayment: PropTypes.func,
   allowPayments: PropTypes.bool,
-  createInvoiceStatus: PropTypes.object,
+  createInvoiceStatus: PropTypes.string,
 };
 
 export default UnbilledTable;


### PR DESCRIPTION
## Description

Clicking on the `Approve Payment` button throws a propType warning. Update `UnbilledTable.jsx` to  expect a string instead of an object.

## Setup

go to: http://officelocal:3000/queues/new/moves/fb4105cf-f5a5-43be-845e-d59fdb34f31c/basics
click the `HGG` tab
click the `Approve Payment` button and the confirm `Approve` button.
Watch for the warning (lack of warning) in the console.

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/n/projects/2136867/stories/163090350) for this change

## Screenshots

![approvepayment](https://user-images.githubusercontent.com/3099491/51207797-7879f200-18d1-11e9-9b24-4b1b7f9baf84.gif)