### PR TITLE
Allow null gblocs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,6 @@ cypress/results
 
 # SQLEditor
 *.sqs
+
+# Virtualenv
+.venv

--- a/.spelling
+++ b/.spelling
@@ -402,6 +402,7 @@ scss
 database.md
 transportation_service_provider_performances
 perf
+locust.io
 - /usr/local
 # Put all custom terms BEFORE this comment, lest you end up in an mdspell pain cycle.
  - docs/data/tspp-data-creation.md

--- a/load_testing/README.md
+++ b/load_testing/README.md
@@ -1,0 +1,23 @@
+# Load Testing
+
+## locust.io
+
+Getting started
+
+```sh
+brew install libev
+virtualenv .venv -p python3
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+In a separate window ensure that the app server is running with `make server_run`.
+
+Then run tests:
+
+```sh
+locust --host=http://milmovelocal:8080 -f load_testing/locustfile.py
+```
+
+Then open [http://localhost:8089](http://localhost:8089/) and enter the number of users to simulate and the hatch rate.
+Finally, hit the `Start swarming` button and wait for the tests to finish.

--- a/load_testing/demo.py
+++ b/load_testing/demo.py
@@ -1,0 +1,31 @@
+#! /usr/bin/env python3
+
+import urllib
+
+import requests
+
+MILMOVE = 'http://milmovelocal:8080'
+
+
+def get_csrf_token(client):
+    """
+    Pull the CSRF token from the website by hitting the root URL.
+
+    The token is set as a cookie with the name `masked_gorilla_csrf`
+    """
+    client.get(urllib.parse.urljoin(MILMOVE, '/'))
+    return client.cookies.get('masked_gorilla_csrf')
+
+
+def create_user(client, csrf):
+    """
+    Create a new user for local testing using the CSRF token in the header
+    """
+    resp = client.post(urllib.parse.urljoin(MILMOVE, 'devlocal-auth/new'), headers={'x-csrf-token': csrf})
+    print(resp.content)
+
+
+if __name__ == "__main__":
+    client = requests.session()
+    csrf = get_csrf_token(client)
+    create_user(client, csrf)

--- a/load_testing/locustfile.py
+++ b/load_testing/locustfile.py
@@ -1,0 +1,27 @@
+from locust import HttpLocust, TaskSet, task
+
+
+class UserBehavior(TaskSet):
+    def on_start(self):
+        """ on_start is called when a Locust start before any task is scheduled """
+        self.login()
+
+    def on_stop(self):
+        """ on_stop is called when the TaskSet is stopping """
+        self.logout()
+
+    def login(self):
+        self.client.post("/devlocal-auth/new")
+
+    def logout(self):
+        self.client.post("/auth/logout")
+
+    @task(1)
+    def index(self):
+        self.client.get("/")
+
+
+class WebsiteUser(HttpLocust):
+    task_set = UserBehavior
+    min_wait = 5000
+    max_wait = 9000

--- a/load_testing/requirements.txt
+++ b/load_testing/requirements.txt
@@ -1,0 +1,17 @@
+certifi==2018.11.29
+chardet==3.0.4
+Click==7.0
+Flask==1.0.2
+gevent==1.4.0
+greenlet==0.4.15
+idna==2.8
+itsdangerous==1.1.0
+Jinja2==2.10
+locustio==0.9.0
+MarkupSafe==1.1.0
+msgpack==0.6.0
+pyzmq==17.1.2
+requests==2.21.0
+six==1.12.0
+urllib3==1.24.1
+Werkzeug==0.14.1

--- a/pkg/handlers/publicapi/gblocs.go
+++ b/pkg/handlers/publicapi/gblocs.go
@@ -1,0 +1,13 @@
+package publicapi
+
+import (
+	"github.com/transcom/mymove/pkg/gen/apimessages"
+)
+
+func payloadForGBLOC(gbloc *string) *apimessages.GBLOC {
+	if gbloc == nil {
+		return nil
+	}
+	g := apimessages.GBLOC(*gbloc)
+	return &g
+}

--- a/pkg/handlers/publicapi/shipments.go
+++ b/pkg/handlers/publicapi/shipments.go
@@ -27,8 +27,8 @@ func payloadForShipmentModel(s models.Shipment) *apimessages.Shipment {
 	shipmentpayload := &apimessages.Shipment{
 		ID:               *handlers.FmtUUID(s.ID),
 		Status:           apimessages.ShipmentStatus(s.Status),
-		SourceGbloc:      apimessages.GBLOC(*s.SourceGBLOC),
-		DestinationGbloc: apimessages.GBLOC(*s.DestinationGBLOC),
+		SourceGbloc:      payloadForGBLOC(s.SourceGBLOC),
+		DestinationGbloc: payloadForGBLOC(s.DestinationGBLOC),
 		GblNumber:        s.GBLNumber,
 		Market:           apimessages.ShipmentMarket(*s.Market),
 		CreatedAt:        strfmt.DateTime(s.CreatedAt),

--- a/swagger/api.yaml
+++ b/swagger/api.yaml
@@ -597,6 +597,7 @@ definitions:
     description: Office Codes for Transcom offices originating GBLs
     pattern: '^[A-Z]{4}$'
     example: LHNQ
+    x-nullable: true
   IndexShipments:
     type: array
     items:


### PR DESCRIPTION
## Description

GBLOCs on the Shipment model are allowed to be null.  This updates the payload for the public shipment api to allow for that and to avoid null dereferencing like we're seeing in staging.

## Reviewer Notes

Are there other fields where this is an issue?

## Setup

First populate the DB:

```sh
make db_dev_e2e_populate
```

Log into the TSP app and find a shipment you have access to.  With the shipment ID in hand modify the DB:

```
./bin/psql-dev
```

```sql
update shipments set destination_gbloc=NULL where id='76e4e692-fb7d-46a2-ab00-16482dcc6f1a';
```

Then try to get the shipment from the API: http://tsplocal:3000/api/v1/docs#/shipments/getShipment


## Code Review Verification Steps

* [x] Request review from a member of a different team.

## References

* [Pivotal story](tbd) for this change