### PR TITLE
Allow gblocs and markets to be null in the DB

### DIFF
--- a/pkg/handlers/internalapi/gblocs.go
+++ b/pkg/handlers/internalapi/gblocs.go
@@ -1,0 +1,13 @@
+package internalapi
+
+import (
+	"github.com/transcom/mymove/pkg/gen/internalmessages"
+)
+
+func payloadForGBLOC(gbloc *string) *internalmessages.GBLOC {
+	if gbloc == nil {
+		return nil
+	}
+	g := internalmessages.GBLOC(*gbloc)
+	return &g
+}

--- a/pkg/handlers/internalapi/markets.go
+++ b/pkg/handlers/internalapi/markets.go
@@ -1,0 +1,13 @@
+package internalapi
+
+import (
+	"github.com/transcom/mymove/pkg/gen/internalmessages"
+)
+
+func payloadForMarkets(market *string) *internalmessages.ShipmentMarket {
+	if market == nil {
+		return nil
+	}
+	m := internalmessages.ShipmentMarket(*market)
+	return &m
+}

--- a/pkg/handlers/internalapi/shipments.go
+++ b/pkg/handlers/internalapi/shipments.go
@@ -68,9 +68,9 @@ func payloadForShipmentModel(s models.Shipment) (*internalmessages.Shipment, err
 	shipmentPayload := &internalmessages.Shipment{
 		ID:               strfmt.UUID(s.ID.String()),
 		Status:           internalmessages.ShipmentStatus(s.Status),
-		SourceGbloc:      s.SourceGBLOC,
-		DestinationGbloc: s.DestinationGBLOC,
-		Market:           s.Market,
+		SourceGbloc:      payloadForGBLOC(s.SourceGBLOC),
+		DestinationGbloc: payloadForGBLOC(s.DestinationGBLOC),
+		Market:           payloadForMarkets(s.Market),
 		CodeOfService:    codeOfService,
 		CreatedAt:        strfmt.DateTime(s.CreatedAt),
 		UpdatedAt:        strfmt.DateTime(s.UpdatedAt),

--- a/pkg/handlers/internalapi/shipments_test.go
+++ b/pkg/handlers/internalapi/shipments_test.go
@@ -14,6 +14,71 @@ import (
 	"github.com/transcom/mymove/pkg/testdatagen"
 )
 
+func (suite *HandlerSuite) TestPayloadForShipmentWithNullValues() {
+	shipment := testdatagen.MakeDefaultShipment(suite.DB())
+
+	// Set all values that can be nil to nil
+	shipment.SourceGBLOC = nil
+	shipment.DestinationGBLOC = nil
+	shipment.GBLNumber = nil
+	shipment.Market = nil
+	shipment.TrafficDistributionListID = nil
+	shipment.TrafficDistributionList = nil
+	shipment.ActualPickupDate = nil
+	shipment.ActualPackDate = nil
+	shipment.ActualDeliveryDate = nil
+	shipment.BookDate = nil
+	shipment.RequestedPickupDate = nil
+	shipment.OriginalDeliveryDate = nil
+	shipment.OriginalPackDate = nil
+	shipment.EstimatedPackDays = nil
+	shipment.EstimatedTransitDays = nil
+	shipment.PickupAddressID = nil
+	shipment.PickupAddress = nil
+	shipment.SecondaryPickupAddressID = nil
+	shipment.SecondaryPickupAddress = nil
+	shipment.DeliveryAddressID = nil
+	shipment.DeliveryAddress = nil
+	shipment.PartialSITDeliveryAddressID = nil
+	shipment.PartialSITDeliveryAddress = nil
+	shipment.PmSurveyConductedDate = nil
+	shipment.PmSurveyCompletedAt = nil
+	shipment.PmSurveyPlannedPackDate = nil
+	shipment.PmSurveyPlannedPickupDate = nil
+	shipment.PmSurveyPlannedDeliveryDate = nil
+	shipment.PmSurveyWeightEstimate = nil
+	shipment.PmSurveyProgearWeightEstimate = nil
+	shipment.PmSurveySpouseProgearWeightEstimate = nil
+	shipment.PmSurveyNotes = nil
+
+	shipmentPayload, _ := payloadForShipmentModel(shipment)
+	suite.Nil(shipmentPayload.SourceGbloc)
+	suite.Nil(shipmentPayload.DestinationGbloc)
+	suite.Nil(shipmentPayload.Market)
+	suite.Nil(shipmentPayload.ActualPickupDate)
+	suite.Nil(shipmentPayload.ActualPackDate)
+	suite.Nil(shipmentPayload.ActualDeliveryDate)
+	suite.Nil(shipmentPayload.BookDate)
+	suite.Nil(shipmentPayload.RequestedPickupDate)
+	suite.Nil(shipmentPayload.OriginalDeliveryDate)
+	suite.Nil(shipmentPayload.OriginalPackDate)
+	suite.Nil(shipmentPayload.EstimatedPackDays)
+	suite.Nil(shipmentPayload.EstimatedTransitDays)
+	suite.Nil(shipmentPayload.PickupAddress)
+	suite.Nil(shipmentPayload.SecondaryPickupAddress)
+	suite.Nil(shipmentPayload.DeliveryAddress)
+	suite.Nil(shipmentPayload.PartialSitDeliveryAddress)
+	suite.Nil(shipmentPayload.PmSurveyConductedDate)
+	suite.Nil(shipmentPayload.PmSurveyCompletedAt)
+	suite.Nil(shipmentPayload.PmSurveyPlannedPackDate)
+	suite.Nil(shipmentPayload.PmSurveyPlannedPickupDate)
+	suite.Nil(shipmentPayload.PmSurveyPlannedDeliveryDate)
+	suite.Nil(shipmentPayload.PmSurveyWeightEstimate)
+	suite.Nil(shipmentPayload.PmSurveyProgearWeightEstimate)
+	suite.Nil(shipmentPayload.PmSurveySpouseProgearWeightEstimate)
+	suite.Nil(shipmentPayload.PmSurveyNotes)
+}
+
 func (suite *HandlerSuite) verifyAddressFields(expected, actual *internalmessages.Address) {
 	suite.T().Helper()
 	suite.Equal(expected.StreetAddress1, actual.StreetAddress1, "Street1 did not match")

--- a/pkg/handlers/internalapi/shipments_test.go
+++ b/pkg/handlers/internalapi/shipments_test.go
@@ -159,7 +159,7 @@ func (suite *HandlerSuite) TestCreateShipmentHandlerAllValues() {
 	suite.Equal(strfmt.UUID(sm.ID.String()), createShipmentPayload.ServiceMemberID)
 	suite.Equal(internalmessages.ShipmentStatusDRAFT, createShipmentPayload.Status)
 	suite.Equal(swag.String("D"), createShipmentPayload.CodeOfService)
-	suite.Equal(internalmessages.ShipmentMarketDHHG, createShipmentPayload.Market)
+	suite.Equal(internalmessages.ShipmentMarketDHHG, *createShipmentPayload.Market)
 	suite.EqualValues(3, *createShipmentPayload.EstimatedPackDays)
 	suite.EqualValues(12, *createShipmentPayload.EstimatedTransitDays)
 	suite.verifyAddressFields(addressPayload, createShipmentPayload.PickupAddress)
@@ -215,7 +215,7 @@ func (suite *HandlerSuite) TestCreateShipmentHandlerEmpty() {
 	suite.Equal(strfmt.UUID(move.ID.String()), unwrapped.Payload.MoveID)
 	suite.Equal(strfmt.UUID(sm.ID.String()), unwrapped.Payload.ServiceMemberID)
 	suite.Equal(internalmessages.ShipmentStatusDRAFT, unwrapped.Payload.Status)
-	suite.Equal(internalmessages.ShipmentMarketDHHG, unwrapped.Payload.Market)
+	suite.Equal(internalmessages.ShipmentMarketDHHG, *unwrapped.Payload.Market)
 	suite.Nil(unwrapped.Payload.CodeOfService) // Won't be able to assign a TDL since we do not have a pickup address.
 	suite.Nil(unwrapped.Payload.EstimatedPackDays)
 	suite.Nil(unwrapped.Payload.EstimatedTransitDays)

--- a/pkg/handlers/internalapi/shipments_test.go
+++ b/pkg/handlers/internalapi/shipments_test.go
@@ -159,7 +159,7 @@ func (suite *HandlerSuite) TestCreateShipmentHandlerAllValues() {
 	suite.Equal(strfmt.UUID(sm.ID.String()), createShipmentPayload.ServiceMemberID)
 	suite.Equal(internalmessages.ShipmentStatusDRAFT, createShipmentPayload.Status)
 	suite.Equal(swag.String("D"), createShipmentPayload.CodeOfService)
-	suite.Equal(swag.String("dHHG"), createShipmentPayload.Market)
+	suite.Equal(internalmessages.ShipmentMarketDHHG, createShipmentPayload.Market)
 	suite.EqualValues(3, *createShipmentPayload.EstimatedPackDays)
 	suite.EqualValues(12, *createShipmentPayload.EstimatedTransitDays)
 	suite.verifyAddressFields(addressPayload, createShipmentPayload.PickupAddress)
@@ -215,7 +215,7 @@ func (suite *HandlerSuite) TestCreateShipmentHandlerEmpty() {
 	suite.Equal(strfmt.UUID(move.ID.String()), unwrapped.Payload.MoveID)
 	suite.Equal(strfmt.UUID(sm.ID.String()), unwrapped.Payload.ServiceMemberID)
 	suite.Equal(internalmessages.ShipmentStatusDRAFT, unwrapped.Payload.Status)
-	suite.Equal(swag.String("dHHG"), unwrapped.Payload.Market)
+	suite.Equal(internalmessages.ShipmentMarketDHHG, unwrapped.Payload.Market)
 	suite.Nil(unwrapped.Payload.CodeOfService) // Won't be able to assign a TDL since we do not have a pickup address.
 	suite.Nil(unwrapped.Payload.EstimatedPackDays)
 	suite.Nil(unwrapped.Payload.EstimatedTransitDays)

--- a/pkg/handlers/publicapi/gblocs.go
+++ b/pkg/handlers/publicapi/gblocs.go
@@ -1,0 +1,13 @@
+package publicapi
+
+import (
+	"github.com/transcom/mymove/pkg/gen/apimessages"
+)
+
+func payloadForGBLOC(gbloc *string) *apimessages.GBLOC {
+	if gbloc == nil {
+		return nil
+	}
+	g := apimessages.GBLOC(*gbloc)
+	return &g
+}

--- a/pkg/handlers/publicapi/markets.go
+++ b/pkg/handlers/publicapi/markets.go
@@ -1,0 +1,13 @@
+package publicapi
+
+import (
+	"github.com/transcom/mymove/pkg/gen/apimessages"
+)
+
+func payloadForMarkets(market *string) *apimessages.ShipmentMarket {
+	if market == nil {
+		return nil
+	}
+	m := apimessages.ShipmentMarket(*market)
+	return &m
+}

--- a/pkg/handlers/publicapi/shipments.go
+++ b/pkg/handlers/publicapi/shipments.go
@@ -30,7 +30,7 @@ func payloadForShipmentModel(s models.Shipment) *apimessages.Shipment {
 		SourceGbloc:      payloadForGBLOC(s.SourceGBLOC),
 		DestinationGbloc: payloadForGBLOC(s.DestinationGBLOC),
 		GblNumber:        s.GBLNumber,
-		Market:           apimessages.ShipmentMarket(*s.Market),
+		Market:           payloadForMarkets(s.Market),
 		CreatedAt:        strfmt.DateTime(s.CreatedAt),
 		UpdatedAt:        strfmt.DateTime(s.UpdatedAt),
 

--- a/pkg/handlers/publicapi/shipments.go
+++ b/pkg/handlers/publicapi/shipments.go
@@ -27,8 +27,8 @@ func payloadForShipmentModel(s models.Shipment) *apimessages.Shipment {
 	shipmentpayload := &apimessages.Shipment{
 		ID:               *handlers.FmtUUID(s.ID),
 		Status:           apimessages.ShipmentStatus(s.Status),
-		SourceGbloc:      apimessages.GBLOC(*s.SourceGBLOC),
-		DestinationGbloc: apimessages.GBLOC(*s.DestinationGBLOC),
+		SourceGbloc:      payloadForGBLOC(s.SourceGBLOC),
+		DestinationGbloc: payloadForGBLOC(s.DestinationGBLOC),
 		GblNumber:        s.GBLNumber,
 		Market:           apimessages.ShipmentMarket(*s.Market),
 		CreatedAt:        strfmt.DateTime(s.CreatedAt),

--- a/pkg/handlers/publicapi/shipments_test.go
+++ b/pkg/handlers/publicapi/shipments_test.go
@@ -43,6 +43,73 @@ func (suite *HandlerSuite) TestPayloadForShipmentModelWhenTspIDIsPresent() {
 	suite.Equal(shipmentPayload.TransportationServiceProviderID, expectedTspID)
 }
 
+func (suite *HandlerSuite) TestPayloadForShipmentWithNullValues() {
+	shipment := testdatagen.MakeDefaultShipment(suite.DB())
+
+	// Set all values that can be nil to nil
+	shipment.SourceGBLOC = nil
+	shipment.DestinationGBLOC = nil
+	shipment.GBLNumber = nil
+	shipment.Market = nil
+	shipment.TrafficDistributionListID = nil
+	shipment.TrafficDistributionList = nil
+	shipment.ActualPickupDate = nil
+	shipment.ActualPackDate = nil
+	shipment.ActualDeliveryDate = nil
+	shipment.BookDate = nil
+	shipment.RequestedPickupDate = nil
+	shipment.OriginalDeliveryDate = nil
+	shipment.OriginalPackDate = nil
+	shipment.EstimatedPackDays = nil
+	shipment.EstimatedTransitDays = nil
+	shipment.PickupAddressID = nil
+	shipment.PickupAddress = nil
+	shipment.SecondaryPickupAddressID = nil
+	shipment.SecondaryPickupAddress = nil
+	shipment.DeliveryAddressID = nil
+	shipment.DeliveryAddress = nil
+	shipment.PartialSITDeliveryAddressID = nil
+	shipment.PartialSITDeliveryAddress = nil
+	shipment.PmSurveyConductedDate = nil
+	shipment.PmSurveyCompletedAt = nil
+	shipment.PmSurveyPlannedPackDate = nil
+	shipment.PmSurveyPlannedPickupDate = nil
+	shipment.PmSurveyPlannedDeliveryDate = nil
+	shipment.PmSurveyWeightEstimate = nil
+	shipment.PmSurveyProgearWeightEstimate = nil
+	shipment.PmSurveySpouseProgearWeightEstimate = nil
+	shipment.PmSurveyNotes = nil
+
+	shipmentPayload := payloadForShipmentModel(shipment)
+	suite.Nil(shipmentPayload.SourceGbloc)
+	suite.Nil(shipmentPayload.DestinationGbloc)
+	suite.Nil(shipmentPayload.GblNumber)
+	suite.Nil(shipmentPayload.Market)
+	suite.Nil(shipmentPayload.TrafficDistributionList)
+	suite.Nil(shipmentPayload.ActualPickupDate)
+	suite.Nil(shipmentPayload.ActualPackDate)
+	suite.Nil(shipmentPayload.ActualDeliveryDate)
+	suite.Nil(shipmentPayload.BookDate)
+	suite.Nil(shipmentPayload.RequestedPickupDate)
+	suite.Nil(shipmentPayload.OriginalDeliveryDate)
+	suite.Nil(shipmentPayload.OriginalPackDate)
+	suite.Nil(shipmentPayload.EstimatedPackDays)
+	suite.Nil(shipmentPayload.EstimatedTransitDays)
+	suite.Nil(shipmentPayload.PickupAddress)
+	suite.Nil(shipmentPayload.SecondaryPickupAddress)
+	suite.Nil(shipmentPayload.DeliveryAddress)
+	suite.Nil(shipmentPayload.PartialSitDeliveryAddress)
+	suite.Nil(shipmentPayload.PmSurveyConductedDate)
+	suite.Nil(shipmentPayload.PmSurveyCompletedAt)
+	suite.Nil(shipmentPayload.PmSurveyPlannedPackDate)
+	suite.Nil(shipmentPayload.PmSurveyPlannedPickupDate)
+	suite.Nil(shipmentPayload.PmSurveyPlannedDeliveryDate)
+	suite.Nil(shipmentPayload.PmSurveyWeightEstimate)
+	suite.Nil(shipmentPayload.PmSurveyProgearWeightEstimate)
+	suite.Nil(shipmentPayload.PmSurveySpouseProgearWeightEstimate)
+	suite.Nil(shipmentPayload.PmSurveyNotes)
+}
+
 func (suite *HandlerSuite) TestGetShipmentHandler() {
 	numTspUsers := 1
 	numShipments := 1

--- a/swagger/api.yaml
+++ b/swagger/api.yaml
@@ -974,7 +974,6 @@ definitions:
       market:
         $ref: '#/definitions/ShipmentMarket'
         readOnly: true
-        x-nullable: true
       created_at:
         type: string
         format: date-time
@@ -1430,6 +1429,7 @@ definitions:
       dHHG: Domestic HHG
       iHHG: International HHG
       iUB: International unaccompanied baggage
+    x-nullable: true
   ShipmentStatus:
     type: string
     description: The stages in the lifecycle of a Shipment

--- a/swagger/api.yaml
+++ b/swagger/api.yaml
@@ -597,6 +597,7 @@ definitions:
     description: Office Codes for Transcom offices originating GBLs
     pattern: '^[A-Z]{4}$'
     example: LHNQ
+    x-nullable: true
   IndexShipments:
     type: array
     items:

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -14,6 +14,25 @@ consumes:
 produces:
   - application/json
 definitions:
+  ShipmentMarket:
+    type: string
+    description: One of the possible 'Markets' for a shipment
+    example: dHHG
+    enum:
+      - dHHG
+      - iHHG
+      - iUB
+    x-display-value:
+      dHHG: Domestic HHG
+      iHHG: International HHG
+      iUB: International unaccompanied baggage
+    x-nullable: true
+  GBLOC:
+    type: string
+    description: Office Codes for Transcom offices originating GBLs
+    pattern: '^[A-Z]{4}$'
+    example: LHNQ
+    x-nullable: true
   LoggedInUserPayload:
     type: object
     properties:
@@ -1458,25 +1477,12 @@ definitions:
         example: d56a4180-65aa-42ec-a945-5fd21dec0538
         readOnly: true
       source_gbloc:
-        type: string
-        pattern: '^[A-Z]{4}$'
-        example: LHNQ
+        $ref: '#/definitions/GBLOC'
         title: Channel
-        format: string
-        x-nullable: true
-        readOnly: true
       destination_gbloc:
-        type: string
-        pattern: '^[A-Z]{4}$'
-        example: LHNQ
-        format: string
-        x-nullable: true
-        readOnly: true
+        $ref: '#/definitions/GBLOC'
       market:
-        type: string
-        x-nullable: true
-        title: Shipment market
-        readOnly: true
+        $ref: '#/definitions/ShipmentMarket'
       code_of_service:
         type: string
         x-nullable: true


### PR DESCRIPTION
## Description

GBLOCs and Markets on the Shipment model are allowed to be null.  This updates the payload for the public and internal shipment api's to allow for that and to avoid null dereferencing like we're seeing in staging.

## Reviewer Notes

Are there other models where this is an issue?

## Setup

First populate the DB:

```sh
make db_dev_e2e_populate
```

Log into the TSP app and find a shipment you have access to.  With the shipment ID in hand modify the DB:

```
./bin/psql-dev
```

```sql
update shipments set destination_gbloc=NULL where id='76e4e692-fb7d-46a2-ab00-16482dcc6f1a';
```

Then try to get the shipment from the API: http://tsplocal:3000/api/v1/docs#/shipments/getShipment


## Code Review Verification Steps

* [x] Request review from a member of a different team.

## References

* [Pivotal story](tbd) for this change