### PR TITLE
Gather env vars for DPS cookie in main.go and pass them down

### DIFF
--- a/bin/run-e2e-test-docker
+++ b/bin/run-e2e-test-docker
@@ -35,12 +35,15 @@ docker build --tag e2e:latest .
 # Run the image with the ports changed
 $DOCKER_RUN \
   -e CLIENT_AUTH_SECRET_KEY \
+  -e CSRF_AUTH_KEY \
   -e DB_HOST="database" \
   -e DB_NAME \
   -e DB_PASSWORD \
   -e DB_PORT \
   -e DB_USER \
   -e DOD_CA_PACKAGE="/config/tls/Certificates_PKCS7_v5.4_DoD.der.p7b" \
+  -e DPS_AUTH_COOKIE_SECRET_KEY \
+  -e DPS_COOKIE_EXPIRES_IN_MINUTES \
   -e ENV="test" \
   -e HERE_MAPS_APP_CODE \
   -e HERE_MAPS_APP_ID \
@@ -61,7 +64,6 @@ $DOCKER_RUN \
   -e NO_TLS_PORT="${HTTP_PORT}" \
   -e SECURE_MIGRATION_DIR \
   -e SECURE_MIGRATION_SOURCE \
-  -e CSRF_AUTH_KEY \
   -p "${HTTP_PORT}:${HTTP_PORT}" \
   --expose="${HTTP_PORT}" \
   --name="${CONTAINER}" \

--- a/cmd/webserver/main.go
+++ b/cmd/webserver/main.go
@@ -178,7 +178,7 @@ func initFlags(flag *pflag.FlagSet) {
 	flag.String("dps-redirect-url", "", "DPS url to redirect to")
 	flag.String("dps-cookie-name", "", "Name of the DPS cookie")
 	flag.String("dps-cookie-domain", "sddclocal", "Domain of the DPS cookie")
-	flag.String("dps-auth-cookie-secret-key", "", "DPS auth cookie secret key")
+	flag.String("dps-auth-cookie-secret-key", "", "DPS auth cookie secret key, 32 byte long")
 	flag.Int("dps-cookie-expires-in-minutes", 240, "DPS cookie expiration in minutes")
 
 	// Initialize Swagger
@@ -480,6 +480,11 @@ func checkConfig(v *viper.Viper) error {
 		return err
 	}
 
+	err = checkDPS(v)
+	if err != nil {
+		return err
+	}
+
 	err = checkCSRF(v)
 	if err != nil {
 		return err
@@ -557,6 +562,16 @@ func checkPorts(v *viper.Viper) error {
 		if p := v.GetInt(c); p <= 0 || p > 65535 {
 			return errors.Wrap(&errInvalidPort{Port: p}, fmt.Sprintf("%s is invalid", c))
 		}
+	}
+
+	return nil
+}
+
+func checkDPS(v *viper.Viper) error {
+
+	dpsCookieSecret := []byte(v.GetString("dps-auth-cookie-secret-key"))
+	if len(dpsCookieSecret) != 32 {
+		return errors.New("DPS Cookie Secret Key is not 32 bytes. Cookie Secret Key length: " + strconv.Itoa(len(dpsCookieSecret)))
 	}
 
 	return nil

--- a/cmd/webserver/main_test.go
+++ b/cmd/webserver/main_test.go
@@ -93,6 +93,10 @@ func (suite *webServerSuite) TestConfigPorts() {
 	suite.Nil(checkPorts(suite.viper))
 }
 
+func (suite *webServerSuite) TestConfigDPS() {
+	suite.Nil(checkDPS(suite.viper))
+}
+
 func (suite *webServerSuite) TestConfigCSRF() {
 	suite.Nil(checkCSRF(suite.viper))
 }

--- a/pkg/dpsauth/auth_test.go
+++ b/pkg/dpsauth/auth_test.go
@@ -9,7 +9,9 @@ func (suite *dpsAuthSuite) TestSetCookieHandler() {
 	secretKey := "secret"
 	dpsCookieName := "DPS_COOKIE"
 	cookieDomain := "sddctest"
-	handler := NewSetCookieHandler(suite.logger, secretKey, cookieDomain)
+	cookieSecret := []byte("j-7oWD_dOnhVf$PpQLRkMxaLmFDj!aE$")
+	cookieExpires := 240
+	handler := NewSetCookieHandler(suite.logger, secretKey, cookieDomain, cookieSecret, cookieExpires)
 
 	rr := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", "/dps_auth/set_cookie", nil)

--- a/pkg/dpsauth/cookie_test.go
+++ b/pkg/dpsauth/cookie_test.go
@@ -3,7 +3,6 @@ package dpsauth
 import (
 	"log"
 	"net/url"
-	"os"
 	"testing"
 
 	"github.com/gofrs/uuid"
@@ -17,27 +16,19 @@ type dpsAuthSuite struct {
 	logger *zap.Logger
 }
 
-func (suite *dpsAuthSuite) SetupSuite() {
-	key := os.Getenv("DPS_AUTH_COOKIE_SECRET_KEY")
-	exp := os.Getenv("DPS_COOKIE_EXPIRES_IN_MINUTES")
-	if len(key) == 0 || len(exp) == 0 {
-		suite.T().Fatal("You must set the DPS_AUTH_COOKIE_SECRET_KEY and DPS_COOKIE_EXPIRES_IN_MINUTES environment variables to run this test")
-	}
-}
-
 func (suite *dpsAuthSuite) TestCookie() {
 	t := suite.T()
 	userID := uuid.Must(uuid.NewV4()).String()
-	key := os.Getenv("DPS_AUTH_COOKIE_SECRET_KEY")
-	exp := os.Getenv("DPS_COOKIE_EXPIRES_IN_MINUTES")
-	cookie, err := LoginGovIDToCookie(userID, key, exp)
+	cookieSecret := []byte("j-7oWD_dOnhVf$PpQLRkMxaLmFDj!aE$")
+	cookieExpires := 240
+	cookie, err := LoginGovIDToCookie(userID, cookieSecret, cookieExpires)
 	if err != nil {
 		t.Error("Error generating cookie value from user ID", err)
 	}
 
 	// Mimic cookie being passed back in an API call via query param
 	escaped := url.QueryEscape(cookie.Value)
-	userIDFromCookie, err := CookieToLoginGovID(escaped)
+	userIDFromCookie, err := CookieToLoginGovID(escaped, cookieSecret)
 	if err != nil {
 		t.Error("Error extracting user ID from cookie value", err)
 	}

--- a/pkg/dpsauth/cookie_test.go
+++ b/pkg/dpsauth/cookie_test.go
@@ -28,7 +28,9 @@ func (suite *dpsAuthSuite) SetupSuite() {
 func (suite *dpsAuthSuite) TestCookie() {
 	t := suite.T()
 	userID := uuid.Must(uuid.NewV4()).String()
-	cookie, err := LoginGovIDToCookie(userID)
+	key := os.Getenv("DPS_AUTH_COOKIE_SECRET_KEY")
+	exp := os.Getenv("DPS_COOKIE_EXPIRES_IN_MINUTES")
+	cookie, err := LoginGovIDToCookie(userID, key, exp)
 	if err != nil {
 		t.Error("Error generating cookie value from user ID", err)
 	}

--- a/pkg/dpsauth/params.go
+++ b/pkg/dpsauth/params.go
@@ -8,4 +8,7 @@ type Params struct {
 	SecretKey      string
 	DPSRedirectURL string
 	CookieName     string
+	CookieDomain   string
+	CookieSecret   []byte
+	CookieExpires  int
 }

--- a/pkg/handlers/dpsapi/authentication.go
+++ b/pkg/handlers/dpsapi/authentication.go
@@ -39,8 +39,9 @@ func (h GetUserHandler) Handle(params dps.GetUserParams) middleware.Responder {
 		return dps.NewGetUserUnauthorized()
 	}
 
+	dpsParams := h.DPSAuthParams()
 	token := params.Token
-	loginGovID, err := dpsauth.CookieToLoginGovID(token)
+	loginGovID, err := dpsauth.CookieToLoginGovID(token, dpsParams.CookieSecret)
 	if err != nil {
 		h.Logger().Error("Extracting user ID from token", zap.Error(err))
 


### PR DESCRIPTION
## Description

Doing an audit of the code to find places where we use the `os` package I came across the DPS cookie logic.  We should be getting and verifying environment variables in the `webserver/main.go` instead of in lower level libraries.  This should fix the issue.

## Setup

```sh
go test ./pkg/dpsauth/ -v -testify.m Test
```

## Code Review Verification Steps

* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/163267464) for this change