### PR TITLE
Get the SES email domain in main.go instead of using os.Getenv

### DIFF
--- a/cmd/webserver/main.go
+++ b/cmd/webserver/main.go
@@ -91,14 +91,6 @@ func (e *errInvalidRegion) Error() string {
 	return fmt.Sprintf("invalid region %s", e.Region)
 }
 
-type errInvalidDomain struct {
-	Domain string
-}
-
-func (e *errInvalidDomain) Error() string {
-	return fmt.Sprintf("invalid domain %s", e.Domain)
-}
-
 type errInvalidPKCS7 struct {
 	Path string
 }
@@ -594,8 +586,8 @@ func checkEmail(v *viper.Viper) error {
 		if r := v.GetString("aws-ses-region"); len(r) == 0 || !stringSliceContains([]string{"us-east-1", "us-west-2", "eu-west-1"}, r) {
 			return errors.Wrap(&errInvalidRegion{Region: r}, fmt.Sprintf("%s is invalid", "aws-ses-region"))
 		}
-		if d := v.GetString("aws-ses-domain"); len(d) == 0 {
-			return errors.Wrap(&errInvalidDomain{Domain: d}, fmt.Sprintf("%s is invalid", "aws-ses-domain"))
+		if h := v.GetString("aws-ses-domain"); len(h) == 0 {
+			return errors.Wrap(&errInvalidHost{Host: h}, fmt.Sprintf("%s is invalid", "aws-ses-domain"))
 		}
 	}
 

--- a/pkg/handlers/internalapi/api_test.go
+++ b/pkg/handlers/internalapi/api_test.go
@@ -36,7 +36,7 @@ func TestHandlerSuite(t *testing.T) {
 	}
 
 	hs := &HandlerSuite{
-		BaseHandlerTestSuite: handlers.NewBaseHandlerTestSuite(logger, notifications.NewStubNotificationSender(logger)),
+		BaseHandlerTestSuite: handlers.NewBaseHandlerTestSuite(logger, notifications.NewStubNotificationSender("milmovelocal", logger)),
 	}
 
 	suite.Run(t, hs)

--- a/pkg/handlers/internalapi/moves_test.go
+++ b/pkg/handlers/internalapi/moves_test.go
@@ -190,7 +190,7 @@ func (suite *HandlerSuite) TestSubmitPPMMoveForApprovalHandler() {
 	}
 	// And: a move is submitted
 	context := handlers.NewHandlerContext(suite.DB(), suite.TestLogger())
-	context.SetNotificationSender(notifications.NewStubNotificationSender(suite.TestLogger()))
+	context.SetNotificationSender(notifications.NewStubNotificationSender("milmovelocal", suite.TestLogger()))
 	handler := SubmitMoveHandler{context}
 	response := handler.Handle(params)
 
@@ -228,7 +228,7 @@ func (suite *HandlerSuite) TestSubmitHHGMoveForApprovalHandler() {
 
 	// And: a move is submitted
 	context := handlers.NewHandlerContext(suite.DB(), suite.TestLogger())
-	context.SetNotificationSender(notifications.NewStubNotificationSender(suite.TestLogger()))
+	context.SetNotificationSender(notifications.NewStubNotificationSender("milmovelocal", suite.TestLogger()))
 	handler := SubmitMoveHandler{context}
 	response := handler.Handle(params)
 

--- a/pkg/handlers/publicapi/api_test.go
+++ b/pkg/handlers/publicapi/api_test.go
@@ -36,7 +36,7 @@ func TestHandlerSuite(t *testing.T) {
 	}
 
 	hs := &HandlerSuite{
-		BaseHandlerTestSuite: handlers.NewBaseHandlerTestSuite(logger, notifications.NewStubNotificationSender(logger)),
+		BaseHandlerTestSuite: handlers.NewBaseHandlerTestSuite(logger, notifications.NewStubNotificationSender("milmovelocal", logger)),
 	}
 
 	suite.Run(t, hs)

--- a/pkg/notifications/notification_stub.go
+++ b/pkg/notifications/notification_stub.go
@@ -9,8 +9,9 @@ import (
 type StubNotificationSender NotificationSendingContext
 
 // NewStubNotificationSender returns a new StubNotificationSender
-func NewStubNotificationSender(logger *zap.Logger) StubNotificationSender {
+func NewStubNotificationSender(domain string, logger *zap.Logger) StubNotificationSender {
 	return StubNotificationSender{
+		domain: domain,
 		logger: logger,
 	}
 }
@@ -23,12 +24,12 @@ func (m StubNotificationSender) SendNotification(ctx context.Context, notificati
 	}
 
 	for _, email := range emails {
-		rawMessage, err := formatRawEmailMessage(email)
+		rawMessage, err := formatRawEmailMessage(email, m.domain)
 		if err != nil {
 			return err
 		}
 
-		m.logger.Info("Not sending this email",
+		m.logger.Debug("Not sending this email",
 			zap.String("destinations", email.recipientEmail),
 			zap.String("raw message", string(rawMessage[:])))
 	}


### PR DESCRIPTION
## Description

Looking to remove direct calls to `os.Getenv` I found this and have moved the variables to `main.go`.  I've tried to add in some error checking.

The Stub email uses the domain `milmovelocal`.

I've also reduced the Stub email sender logging level to Debug so it won't fill up our CircleCI logs.

## Code Review Verification Steps

* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/163267464) for this change