### PR TITLE
Jm 162792858 set envt variable sendprodinvoice

### DIFF
--- a/cmd/webserver/main.go
+++ b/cmd/webserver/main.go
@@ -454,6 +454,11 @@ func checkConfig(v *viper.Viper) error {
 		return err
 	}
 
+	err = checkSendProductionEDI(v)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -563,6 +568,17 @@ func checkGEX(v *viper.Viper) error {
 	}
 
 	return nil
+}
+
+func checkSendProductionEDI(v *viper.Viper) error {
+	sendProdEDI := v.GetBool("send-prod-invoice")
+
+	if sendProdEDI == true || sendProdEDI == false {
+		// passed
+		return nil
+	}
+
+	return fmt.Errorf("Failed to initialize SEND_PROD_INVOICE +%v", sendProdEDI)
 }
 
 func checkStorage(v *viper.Viper) error {

--- a/cmd/webserver/main.go
+++ b/cmd/webserver/main.go
@@ -222,7 +222,7 @@ func initFlags(flag *pflag.FlagSet) {
 	// EDI Invoice Config
 	flag.String("gex-basic-auth-username", "", "GEX api auth username")
 	flag.String("gex-basic-auth-password", "", "GEX api auth password")
-	flag.Bool("send-prod-invoice", false, "Flag (bool) for EDI Invoices to signify if they should go to production GEX")
+	flag.Bool("send-prod-invoice", false, "Flag (bool) for EDI Invoices to signify if they should be sent with Production or Test indicator")
 	flag.String("gex-url", "", "URL for sending an HTTP POST request to GEX")
 
 	flag.String("storage-backend", "local", "Storage backend to use, either filesystem or s3.")

--- a/cmd/webserver/main.go
+++ b/cmd/webserver/main.go
@@ -454,11 +454,6 @@ func checkConfig(v *viper.Viper) error {
 		return err
 	}
 
-	err = checkSendProductionEDI(v)
-	if err != nil {
-		return err
-	}
-
 	return nil
 }
 
@@ -568,17 +563,6 @@ func checkGEX(v *viper.Viper) error {
 	}
 
 	return nil
-}
-
-func checkSendProductionEDI(v *viper.Viper) error {
-	sendProdEDI := v.GetBool("send-prod-invoice")
-
-	if sendProdEDI == true || sendProdEDI == false {
-		// passed
-		return nil
-	}
-
-	return fmt.Errorf("Failed to initialize SEND_PROD_INVOICE +%v", sendProdEDI)
 }
 
 func checkStorage(v *viper.Viper) error {

--- a/cmd/webserver/main_test.go
+++ b/cmd/webserver/main_test.go
@@ -105,10 +105,6 @@ func (suite *webServerSuite) TestConfigGEX() {
 	suite.Nil(checkGEX(suite.viper))
 }
 
-func (suite *webServerSuite) TestSendProductionEDI() {
-	suite.Nil(checkSendProductionEDI(suite.viper))
-}
-
 func (suite *webServerSuite) TestConfigStorage() {
 	suite.Nil(checkStorage(suite.viper))
 }

--- a/cmd/webserver/main_test.go
+++ b/cmd/webserver/main_test.go
@@ -105,6 +105,15 @@ func (suite *webServerSuite) TestConfigGEX() {
 	suite.Nil(checkGEX(suite.viper))
 }
 
+func (suite *webServerSuite) TestSendProductionEDI() {
+
+	// TODO: compare to this function SendProductionInvoice
+
+	// TODO: copy from Generate858C tests to generate and EDI and check for P/T indicator
+
+	suite.Nil(checkSendProductionEDI(suite.viper))
+}
+
 func (suite *webServerSuite) TestConfigStorage() {
 	suite.Nil(checkStorage(suite.viper))
 }

--- a/cmd/webserver/main_test.go
+++ b/cmd/webserver/main_test.go
@@ -107,9 +107,9 @@ func (suite *webServerSuite) TestConfigGEX() {
 
 func (suite *webServerSuite) TestSendProductionEDI() {
 
-	// TODO: compare to this function SendProductionInvoice
+	// TODO: compare to this function SendProductionInvoice?
 
-	// TODO: copy from Generate858C tests to generate and EDI and check for P/T indicator
+	// TODO: copy from Generate858C tests to generate an EDI and check for P/T indicator?
 
 	suite.Nil(checkSendProductionEDI(suite.viper))
 }

--- a/cmd/webserver/main_test.go
+++ b/cmd/webserver/main_test.go
@@ -106,11 +106,6 @@ func (suite *webServerSuite) TestConfigGEX() {
 }
 
 func (suite *webServerSuite) TestSendProductionEDI() {
-
-	// TODO: compare to this function SendProductionInvoice?
-
-	// TODO: copy from Generate858C tests to generate an EDI and check for P/T indicator?
-
 	suite.Nil(checkSendProductionEDI(suite.viper))
 }
 

--- a/config/app-client-tls.container-definition.json
+++ b/config/app-client-tls.container-definition.json
@@ -137,6 +137,10 @@
     {
       "name": "GEX_URL",
       "value": "https://gexweba.daas.dla.mil/msg_data/submit/"
+    },
+    {
+      "name": "SEND_PROD_INVOICE",
+      "value": "{{ .SEND_PROD_INVOICE }}"
     }
   ],
   "logConfiguration": {

--- a/config/app.container-definition.json
+++ b/config/app.container-definition.json
@@ -157,6 +157,10 @@
     {
       "name": "GEX_URL",
       "value": "https://gexweba.daas.dla.mil/msg_data/submit/"
+    },
+    {
+      "name": "SEND_PROD_INVOICE",
+      "value": "{{ .SEND_PROD_INVOICE }}"
     }
   ],
   "logConfiguration": {

--- a/config/env/experimental.env
+++ b/config/env/experimental.env
@@ -6,3 +6,4 @@ HTTP_SDDC_SERVER_NAME=mymove-experimental.sddc.army.mil
 DPS_REDIRECT_URL=https://dpstest.sddc.army.mil/cust
 DPS_COOKIE_NAME=DPSIVV
 GEX_URL=https://gexweba.daas.dla.mil/msg_data/submit/
+SEND_PROD_INVOICE=false

--- a/config/env/prod.env
+++ b/config/env/prod.env
@@ -6,3 +6,4 @@ HTTP_SDDC_SERVER_NAME=mymove.sddc.army.mil
 DPS_REDIRECT_URL=https://dps.sddc.army.mil/cust
 DPS_COOKIE_NAME=DPS
 GEX_URL=https://gexweba.daas.dla.mil/msg_data/submit/
+SEND_PROD_INVOICE=true

--- a/config/env/staging.env
+++ b/config/env/staging.env
@@ -6,3 +6,4 @@ HTTP_SDDC_SERVER_NAME=mymove-staging.sddc.army.mil
 DPS_REDIRECT_URL=https://dpstest.sddc.army.mil/cust
 DPS_COOKIE_NAME=DPSIVV
 GEX_URL=https://gexweba.daas.dla.mil/msg_data/submit/
+SEND_PROD_INVOICE=false


### PR DESCRIPTION
## Description

This change sets the default for `env` `SEND_PROD_INVOICE`. The file `prod.env` is the only file where `SEND_PROD_INVOICE=true`. When `SEND_PROD_INVOICE=true`, a `P` usage indicator will be used in the generated Invoice (858C EDI). When `SEND_PROD_INVOICE=false`, a `T` usage indicator will be used.

## Reviewer Notes

none.

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
go test ./pkg/edi/invoice -testify.m TestGenerate858C
```

## Code Review Verification Steps

* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/162792858) for this change

## Screenshots

none.
