### PR TITLE
fix to set upload storgekey path for invoice upload, add test to chec…

### DIFF
--- a/pkg/edi/invoice/store_invoice.go
+++ b/pkg/edi/invoice/store_invoice.go
@@ -50,6 +50,8 @@ func StoreInvoice858C(edi string, invoice *models.Invoice, storer *storage.FileS
 
 	// Create Upload'r
 	loader := uploader.NewUploader(db, logger, *storer)
+	// Set Storagekey path for S3
+	loader.SetUploadStorageKey(ediTmpFile)
 
 	// Delete of previous upload, if it exist
 	// If Delete of Upload fails, ignoring this error because we still have a new Upload that needs to be saved

--- a/pkg/edi/invoice/store_invoice.go
+++ b/pkg/edi/invoice/store_invoice.go
@@ -34,13 +34,13 @@ func StoreInvoice858C(edi string, invoice *models.Invoice, storer *storage.FileS
 
 	f, err := fs.Create(ediTmpFile)
 	if err != nil {
-		return verrs, errors.Wrapf(err, "afero.Create Failed in StoreInvoice858C() invoice number: %s", invoiceID)
+		return verrs, errors.Wrapf(err, "afero.Create Failed in StoreInvoice858C() invoice ID: %s", invoiceID)
 	}
 	defer f.Close()
 
 	_, err = io.WriteString(f, edi)
 	if err != nil {
-		return verrs, errors.Wrapf(err, "io.WriteString(edi) Failed in StoreInvoice858C() invoice number: %s", invoiceID)
+		return verrs, errors.Wrapf(err, "io.WriteString(edi) Failed in StoreInvoice858C() invoice ID: %s", invoiceID)
 	}
 
 	err = f.Sync()
@@ -70,11 +70,11 @@ func StoreInvoice858C(edi string, invoice *models.Invoice, storer *storage.FileS
 	upload, verrs2, err := loader.CreateUploadNoDocument(userID, &f)
 	verrs.Append(verrs2)
 	if err != nil {
-		return verrs, errors.Wrapf(err, "Failed to Create Upload for StoreInvoice858C(), invoice number: %s", invoiceID)
+		return verrs, errors.Wrapf(err, "Failed to Create Upload for StoreInvoice858C(), invoice ID: %s", invoiceID)
 	}
 
 	if upload == nil {
-		return verrs, errors.New("Failed to Create and Save new Upload object in database, invoice number: " + invoiceID)
+		return verrs, errors.New("Failed to Create and Save new Upload object in database, invoice ID: " + invoiceID)
 	}
 
 	// Save Upload to Invoice

--- a/pkg/edi/invoice/store_invoice.go
+++ b/pkg/edi/invoice/store_invoice.go
@@ -25,8 +25,8 @@ func StoreInvoice858C(edi string, invoice *models.Invoice, storer *storage.FileS
 
 	// Create path for EDI file
 	// {application-bucket}/app/invoice/{invoice_id}.edi
-	invoiceNumber := invoice.ID.String()
-	ediFilename := invoiceNumber + ".edi"
+	invoiceID := invoice.ID.String()
+	ediFilename := invoiceID + ".edi"
 	ediFilePath := "/app/invoice/"
 	ediTmpFile := path.Join(ediFilePath, ediFilename)
 
@@ -34,13 +34,13 @@ func StoreInvoice858C(edi string, invoice *models.Invoice, storer *storage.FileS
 
 	f, err := fs.Create(ediTmpFile)
 	if err != nil {
-		return verrs, errors.Wrapf(err, "afero.Create Failed in StoreInvoice858C() invoice number: %s", invoiceNumber)
+		return verrs, errors.Wrapf(err, "afero.Create Failed in StoreInvoice858C() invoice number: %s", invoiceID)
 	}
 	defer f.Close()
 
 	_, err = io.WriteString(f, edi)
 	if err != nil {
-		return verrs, errors.Wrapf(err, "io.WriteString(edi) Failed in StoreInvoice858C() invoice number: %s", invoiceNumber)
+		return verrs, errors.Wrapf(err, "io.WriteString(edi) Failed in StoreInvoice858C() invoice number: %s", invoiceID)
 	}
 
 	err = f.Sync()
@@ -70,18 +70,18 @@ func StoreInvoice858C(edi string, invoice *models.Invoice, storer *storage.FileS
 	upload, verrs2, err := loader.CreateUploadNoDocument(userID, &f)
 	verrs.Append(verrs2)
 	if err != nil {
-		return verrs, errors.Wrapf(err, "Failed to Create Upload for StoreInvoice858C(), invoice number: %s", invoiceNumber)
+		return verrs, errors.Wrapf(err, "Failed to Create Upload for StoreInvoice858C(), invoice number: %s", invoiceID)
 	}
 
 	if upload == nil {
-		return verrs, errors.New("Failed to Create and Save new Upload object in database, invoice number: " + invoiceNumber)
+		return verrs, errors.New("Failed to Create and Save new Upload object in database, invoice number: " + invoiceID)
 	}
 
 	// Save Upload to Invoice
 	verrs2, err = invoiceop.UpdateInvoiceUpload{DB: db, Uploader: loader}.Call(invoice, upload)
 	verrs.Append(verrs2)
 	if err != nil {
-		return verrs, errors.New("Failed to save Upload to Invoice: " + invoiceNumber)
+		return verrs, errors.New("Failed to save Upload to Invoice: " + invoiceID)
 	}
 
 	if verrs.HasAny() {

--- a/pkg/edi/invoice/store_invoice_test.go
+++ b/pkg/edi/invoice/store_invoice_test.go
@@ -116,4 +116,7 @@ func (suite *StoreInvoiceSuite) TestStoreInvoice858C() {
 	suite.NotNil(invoice)
 	suite.NotNil(invoice.Upload)
 	suite.NotNil(invoice.UploadID)
+	// Check that StoragKey matches expected filepath name
+	// {application-bucket}/app/invoice/{invoice_id}.edi
+	suite.Regexp("^/app/invoice/([a-z|0-9|-])+.edi$", invoice.Upload.StorageKey)
 }

--- a/pkg/edi/invoice/store_invoice_test.go
+++ b/pkg/edi/invoice/store_invoice_test.go
@@ -118,5 +118,5 @@ func (suite *StoreInvoiceSuite) TestStoreInvoice858C() {
 	suite.NotNil(invoice.UploadID)
 	// Check that StoragKey matches expected filepath name
 	// {application-bucket}/app/invoice/{invoice_id}.edi
-	suite.Regexp("^/app/invoice/([a-z|0-9|-])+.edi$", invoice.Upload.StorageKey)
+	suite.Regexp("^/app/invoice/([a-z0-9-])+\\.edi$", invoice.Upload.StorageKey)
 }

--- a/pkg/uploader/uploader.go
+++ b/pkg/uploader/uploader.go
@@ -20,18 +20,25 @@ var ErrZeroLengthFile = errors.New("File has length of 0")
 // Uploader encapsulates a few common processes: creating Uploads for a Document,
 // generating pre-signed URLs for file access, and deleting Uploads.
 type Uploader struct {
-	db     *pop.Connection
-	logger *zap.Logger
-	Storer storage.FileStorer
+	db               *pop.Connection
+	logger           *zap.Logger
+	Storer           storage.FileStorer
+	UploadStorageKey string
 }
 
 // NewUploader creates and returns a new uploader
 func NewUploader(db *pop.Connection, logger *zap.Logger, storer storage.FileStorer) *Uploader {
 	return &Uploader{
-		db:     db,
-		logger: logger,
-		Storer: storer,
+		db:               db,
+		logger:           logger,
+		Storer:           storer,
+		UploadStorageKey: "",
 	}
+}
+
+// SetUploadStorageKey set the Upload.StorageKey member
+func (u *Uploader) SetUploadStorageKey(key string) {
+	u.UploadStorageKey = key
 }
 
 // CreateUpload creates a new Upload by performing validations, storing the specified
@@ -72,6 +79,11 @@ func (u *Uploader) CreateUpload(documentID *uuid.UUID, userID uuid.UUID, file af
 		Bytes:       info.Size(),
 		ContentType: contentType,
 		Checksum:    checksum,
+	}
+
+	// Set the Upload.StorageKey if set
+	if u.UploadStorageKey != "" {
+		newUpload.StorageKey = u.UploadStorageKey
 	}
 
 	u.db.Transaction(func(db *pop.Connection) error {


### PR DESCRIPTION
Set `StorageKey` path for `Invoice.Upload.StorageKey`.

## Description
The Invoice 858C EDI archive should reside on S3 at path: `{application-bucket}/app/invoice/{invoice_id}.edi`. 

This is PR to fix the path that was being used by default. By default when using the `uploader` package with the `Upload` model, the default path is something like `user/f25d4c14-5ce0-4126-8f49-371e0ed83ce1/uploads/f8ff9f56-bad2-4db6-9447-7f96c111599e`. The new path for with this PR for Invoice uploads will be something like: `/app/invoice/61f00645-8462-46f8-be2e-0daeb3cb7fab.edi`. 

The test was updated to verify this filepath location is being used.

## Reviewer Notes

Storage to `s3`.

## Setup

In your terminal run:

Edit `.envrc.local` to:
```
export STORAGE_BACKEND=s3
```
Run the commands
```
$ make db_dev_e2e_populate
$ make server_run
$ make tsp_client_run
```
Go to tsp-local, login as the TSP user.
Go to In Transit shipments, click on shipment with locator ENTDEL.
Click on Delivered and enter an "Actual Pickup Date"

To send to GEX:
```
$ ctrl-c # If you wish to use the same terminal window, or you make skip this and go to new terminal window

$ make office_client_run
```

Login in using the local login as an office user (e.g. officeuser1@example.com (office) works)
Go to Delivered HHGs and select the shipment with locator ENTDEL
Go to the HHG Delivered tab and scroll down and click Approve Payment

In `s3` look for the output using your username `echo $AWS_S3_KEY_NAMESPACE`

```
$ aws s3 ls s3://transcom-ppp-app-devlocal-us-west-2/$AWS_S3_KEY_NAMESPACE/app/invoice/
2019-01-18 02:56:43        878 a29cd49f-46fa-4abe-9371-080b75da797d.edi
```

After you have run your test remove the file from `s3`. 
```
$ aws s3 rm s3://transcom-ppp-app-devlocal-us-west-2/$AWS_S3_KEY_NAMESPACE/app/invoice/a29cd49f-46fa-4abe-9371-080b75da797d.edi
```

Verify that the file is removed:
```
$ aws s3 ls s3://transcom-ppp-app-devlocal-us-west-2/$AWS_S3_KEY_NAMESPACE/app/invoice/

```

### Work around for `make server_run` failing to run `aws-vault` run this:
```
INTERFACE=localhost DEBUG_LOGGING=true \
    aws-vault exec transcom-ppp -- ./bin/gin --build ./cmd/webserver \
        --bin /bin/webserver \
        --port 8080 --appPort 8081 \
        --excludeDir vendor --excludeDir node_modules \
        -i --buildArgs "-i -ldflags=\"-X main.gitBranch=jm-160569091-store-edis-s3-improve-ability-2 -X main.gitCommit=e49ef800609c01335155e5838ab927342332d50f\""
```

## Code Review Verification Steps

* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/160569091) for this change

## Screenshots

Screenshot of getting archived Invoice from `s3`

<img width="1432" alt="screen shot 2019-01-18 at 4 03 09 pm" src="https://user-images.githubusercontent.com/1359520/51415199-9f872c80-1b3a-11e9-89a8-c4b2f7ce0f38.png">

