### PR TITLE
Update aws scripts to use new arn format

### DIFF
--- a/bin/ecs-run-app-migrations-container
+++ b/bin/ecs-run-app-migrations-container
@@ -32,7 +32,7 @@ check_arn() {
 show_logs() {
     local arn=$1
     local task_id
-    task_id=$(echo "$arn" | grep -Eo ':task/([[:alnum:]-]+)$' | cut -d / -f 2)
+    task_id=$(echo "$arn" | grep -Eo ':task/([[:alnum:]-]+)/([[:alnum:]-]+)$' | cut -d / -f 3)
     echo
     echo "Attempting to get CloudWatch logs for ${arn}:"
     aws logs get-log-events --log-group-name "ecs-tasks-$cluster" --log-stream-name "$log_prefix/$container_name/$task_id" --query 'events[].message' || true

--- a/bin/ecs-show-service-logs
+++ b/bin/ecs-show-service-logs
@@ -25,7 +25,7 @@ for task_arn in $(aws ecs list-tasks --cluster "$cluster" --service-name "$name"
     [[ -z $task_arn ]] && { echo "Missing task ARN"; exit 1; }
 
     # Parse out the task ID
-    task_id=$(echo "$task_arn" | perl -ne 'm|^arn:aws:ecs:([^:]+:){2}task/([\S]+)|; print "$2\n";')
+    task_id=$(echo "$task_arn" | perl -ne 'm|^arn:aws:ecs:([^:]+:){2}task/([\S]+)/([\S]+)|; print "$3\n";')
     [[ -z $task_id ]] && { echo "Couldn't parse task ID: $task_arn"; exit 1; }
 
     # Display logs for this task

--- a/bin/ecs-show-service-stopped-logs
+++ b/bin/ecs-show-service-stopped-logs
@@ -22,7 +22,7 @@ readonly container=$name-$environment
 readonly log_group_name=ecs-tasks-$name-$environment
 
 # Get list of recently stopped tasks
-for task_id in $(aws ecs describe-services --cluster "$cluster" --services "$name" --query 'services[].events[].message' | grep stopped | grep -o 'task [0-9a-f-]*' | cut -f 2 -d ' '); do
+for task_id in $(aws ecs describe-services --cluster "$cluster" --services "$name" --query 'services[].events[].message' | grep stopped | grep -o 'task [0-9a-f-]*' | cut -f 3 -d ' '); do
     [[ -z $task_id ]] && { echo "Missing task ID"; exit 1; }
 
     # Display logs for this task


### PR DESCRIPTION
## Description

AWS is releasing a [new ECS ARN format](https://aws.amazon.com/ecs/faqs/#Transition_to_new_ARN_and_ID_format) that looks like `arn:aws:ecs:region:account-id:task/cluster-name/chrischrischris`.  It includes `cluster-name` which we didn't have in the old arn.  

## Deployment

I suggest we set aside time after this is accepted to deploy.

1. Take over pager from Bat-Team with override
1. Ask engineers to stop merging to master
1. Opt-in to new format at [the AWS opt-in site](https://us-west-2.console.aws.amazon.com/ecs/home?region=us-west-2#/clusters/optIn/resourceIdArnFormat)
1. Merge code and deploy to staging (This happens automatically)
1. Fix issues and deploy to experimental (This is where we can debug any issues)
1. Deploy to Production
1. Return pager to Bat-Team

## Reviewer Notes

Unfortunately this is a global opt-in and we can't do it piecemeal by environment.  Am I missing any other arn's that we should be fixing?

I'm also not a huge fan of using two different methods to regex the arn's.  I am reticent to make a big change here before proving the scripts still work.

## Setup

Try out some of the regex code on the command line:

```sh
$ echo "arn:aws:ecs:region:account-id:task/cluster-name/chrischrischris" | perl -ne 'm|^arn:aws:ecs:([^:]+:){2}task/([\S]+)/([\S]+)|; print "$3\n";'
chrischrischris
```

Or

```sh
$ echo "arn:aws:ecs:region:account-id:task/cluster-name/chrischrischris" | grep -Eo ':task/([[:alnum:]-]+)/([[:alnum:]-]+)$' | cut -d / -f 3
chrischrischris
```

## Code Review Verification Steps

* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/162023468) for this change