### PR TITLE
Adds pre-commit hook for running eslint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,6 +45,14 @@ repos:
 
   - repo: local
     hooks:
+      - id: eslint
+        name: eslint
+        entry: node_modules/.bin/eslint --ext .js --ext .jsx --max-warnings=0
+        language: node
+        files: \.(js|jsx)$
+
+  - repo: local
+    hooks:
       - id: swagger
         name: API Swagger
         entry: bin/swagger validate swagger/api.yaml

--- a/src/scenes/Landing/MoveSummary.test.jsx
+++ b/src/scenes/Landing/MoveSummary.test.jsx
@@ -4,14 +4,12 @@ import {
   MoveSummary,
   CanceledMoveSummary,
   ApprovedMoveSummary,
-  DraftMoveSummary,
   SubmittedPpmMoveSummary,
   SubmittedHhgMoveSummary,
 } from './MoveSummary';
 import moment from 'moment';
 
 describe('MoveSummary', () => {
-  let wrapper, div;
   const editMoveFn = jest.fn();
   const resumeMoveFn = jest.fn();
   const addPPMShipmentFn = jest.fn();

--- a/src/scenes/Landing/index.test.js
+++ b/src/scenes/Landing/index.test.js
@@ -2,13 +2,12 @@ import 'raf/polyfill';
 import React from 'react';
 
 import { Provider } from 'react-redux';
-import ReactDOM from 'react-dom';
 import moment from 'moment';
 import configureStore from 'redux-mock-store';
 import { shallow, mount } from 'enzyme';
 
 import { Landing } from '.';
-import { MoveSummary, DraftMoveSummary } from './MoveSummary';
+import { MoveSummary } from './MoveSummary';
 
 describe('HomePage tests', () => {
   let wrapper;

--- a/src/scenes/Moves/Hhg/api.js
+++ b/src/scenes/Moves/Hhg/api.js
@@ -1,5 +1,4 @@
 import { getClient, checkResponse } from 'shared/Swagger/api';
-import { formatDateString } from 'shared/utils';
 
 export async function GetShipment(moveId, shipmentId) {
   const client = await getClient();

--- a/src/shared/AppContext/index.test.jsx
+++ b/src/shared/AppContext/index.test.jsx
@@ -1,4 +1,4 @@
-import { withContext, defaultMyMoveContext, AppContext } from '.';
+import { withContext } from '.';
 import React from 'react';
 import { shallow } from 'enzyme';
 const Dummy = withContext(({ context }) => {

--- a/src/shared/DocumentViewer/MoveDocumentView.test.jsx
+++ b/src/shared/DocumentViewer/MoveDocumentView.test.jsx
@@ -13,21 +13,6 @@ describe('MoveDocumentView', () => {
 
   it('calls onDidMount when the component mounts', () => {
     const onDidMountSpy = jest.fn();
-    const documentView = shallow(
-      <MoveDocumentView
-        documentDetailUrlPrefix=""
-        match={{ params: {} }}
-        moveDocument={defaultMoveDocument}
-        moveDocumentSchema={{}}
-        moveDocumentId=""
-        moveDocuments={[]}
-        moveLocator=""
-        newDocumentUrl=""
-        onDidMount={onDidMountSpy}
-        serviceMember={{ name: '', edipi: '' }}
-        uploads={[]}
-      />,
-    );
     expect(onDidMountSpy).toBeCalled();
   });
 

--- a/src/shared/Entities/modules/shipmentLineItems.test.js
+++ b/src/shared/Entities/modules/shipmentLineItems.test.js
@@ -1,6 +1,5 @@
 import {
   selectUnbilledShipmentLineItems,
-  selectTotalFromUnbilledLineItems,
   selectSortedPreApprovalShipmentLineItems,
 } from 'shared/Entities/modules/shipmentLineItems';
 

--- a/src/shared/ShipmentDates/index.test.js
+++ b/src/shared/ShipmentDates/index.test.js
@@ -1,10 +1,9 @@
 import React from 'react';
-import { shallow, mount } from 'enzyme';
+import { mount } from 'enzyme';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 
 import Dates from '.';
-import { DatesDisplay } from '.';
 
 describe('DatesPanel tests', () => {
   let wrapper;

--- a/src/shared/User/Authorization.test.js
+++ b/src/shared/User/Authorization.test.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
 import { mount } from 'enzyme';
 import configureStore from 'redux-mock-store';
 

--- a/src/shared/User/LoginButton.test.js
+++ b/src/shared/User/LoginButton.test.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
 import { mount } from 'enzyme';
 import configureStore from 'redux-mock-store';
 


### PR DESCRIPTION
## Description

This PR adds a pre-commit hook for running `eslint` on modified {js,jsx} files and fails for both errors and warnings. Previously warnings were only _warned_ about in local development but they do end up failing CI, meaning boneheads like me fail CI sometimes for silly reasons.

For whatever reason, running `eslint` against `src` manually showed 14 `no-unused-vars` warnings that were previously uncaught by the linting done under create-react-app's hood during a production build. I looked through create-react-app's codebase to try to find an explanation, but didn't really uncover much. They're valid linter errors, so it seems fine