### PR TITLE
els restored proxy for auth handlers in react create app setup

### DIFF
--- a/src/setupProxy.js
+++ b/src/setupProxy.js
@@ -1,10 +1,11 @@
 const proxy = require('http-proxy-middleware');
 
 module.exports = function(app) {
-  app.use(proxy('/api', { target: 'http://localhost:8080/' }));
-  app.use(proxy('/internal', { target: 'http://localhost:8080/' }));
-  app.use(proxy('/storage', { target: 'http://localhost:8080/' }));
-  app.use(proxy('/devlocal-auth', { target: 'http://localhost:8080/' }));
-  app.use(proxy('/logout', { target: 'http://localhost:8080/' }));
-  app.use(proxy('/downloads', { target: 'http://localhost:8080/' }));
+  app.use(proxy('/api', { target: 'http://milmovelocal:8080/' }));
+  app.use(proxy('/internal', { target: 'http://milmovelocal:8080/' }));
+  app.use(proxy('/storage', { target: 'http://milmovelocal:8080/' }));
+  app.use(proxy('/devlocal-auth', { target: 'http://milmovelocal:8080/' }));
+  app.use(proxy('/auth/**', { target: 'http://milmovelocal:8080/' }));
+  app.use(proxy('/logout', { target: 'http://milmovelocal:8080/' }));
+  app.use(proxy('/downloads', { target: 'http://milmovelocal:8080/' }));
 };


### PR DESCRIPTION
## Description

The proxy for auth was missing from the initial upgrade to react-create-app.

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

