### PR TITLE
Remove non-PCS move types

### DIFF
--- a/cypress/integration/mymove/hhgPPM.js
+++ b/cypress/integration/mymove/hhgPPM.js
@@ -228,7 +228,7 @@ function serviceMemberEditsContactInfoSection() {
 function serviceMemberVerifiesOrderWasEdited() {
   cy.get('.review-content').should($div => {
     const text = $div.text();
-    expect(text).to.include('Orders Type: Local Move');
+    expect(text).to.include('Orders Type: Permanent Change Of Station');
     expect(text).to.include('Orders Date:  05/26/2018');
     expect(text).to.include('Report-by Date: 09/01/2018');
     expect(text).to.include('New Duty Station:  NAS Fort Worth');
@@ -243,7 +243,7 @@ function serviceMemberEditsOrdersSection() {
     .eq(1)
     .click();
 
-  cy.get('select[name="orders_type"]').select('Local Move');
+  cy.get('select[name="orders_type"]').select('Permanent Change Of Station');
   typeInInput({ name: 'issue_date', value: '5/26/2018' });
   typeInInput({ name: 'report_by_date', value: '9/1/2018' });
   cy.get('input[type="radio"]').check('no', { force: true }); // checks yes for both radios on form

--- a/cypress/integration/mymove/orders.js
+++ b/cypress/integration/mymove/orders.js
@@ -17,6 +17,7 @@ describe('orders entry', function() {
     });
 
     cy.get('select[name="orders_type"]').select('Permanent Change Of Station');
+
     cy
       .get('input[name="issue_date"]')
       .first()

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -2096,13 +2096,6 @@ definitions:
     title: Orders type
     enum:
       - PERMANENT_CHANGE_OF_STATION
-      - SEPARATION
-      - RETIREMENT
-      - LOCAL_MOVE
-      - TEMPORARY_DUTY
-      - DEPENDENT_TRAVEL
-      - BLUEBARK
-      - VARIOUS
     x-display-value:
       PERMANENT_CHANGE_OF_STATION: Permanent Change Of Station
       SEPARATION: Separation


### PR DESCRIPTION
## Description

Permanent change of station is the only move type we support currently. Remove all other move type options from dropdown.

## Setup
`make db_dev_e2e_populate`
`make server_run`
`make client_run`
Create new account and go through normal workflow

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/162931792) for this change

## Screenshots

![image 1-22-19 at 1 02 pm](https://user-images.githubusercontent.com/13622298/51565182-1fb4d700-1e46-11e9-844f-fd71a25d8946.jpg)
