### PR TITLE
Make a default order duty station

### DIFF
--- a/cypress/integration/mymove/hhgPPM.js
+++ b/cypress/integration/mymove/hhgPPM.js
@@ -108,7 +108,7 @@ function serviceMemberVerifiesHHGPPMSummary() {
     expect(text).to.include('Delivery ZIP Code:  30813');
     expect(text).not.to.include('Storage: Not requested');
     expect(text).to.include('Estimated Weight:  1,50');
-    expect(text).to.include('Estimated PPM Incentive:  $4,36');
+    expect(text).to.include('Estimated PPM Incentive:  $4,362.66 - 4,821.88');
   });
 }
 
@@ -117,7 +117,7 @@ function serviceMemberVerifiesPPMWeightsEdited() {
     const text = $div.text();
 
     expect(text).to.include('Estimated Weight:  1,700 lbs');
-    expect(text).to.include('Estimated PPM Incentive:  $4,736.63 - 5,235.23');
+    expect(text).to.include('Estimated PPM Incentive:  $4,858.82 - 5,370.28');
   });
 }
 
@@ -126,8 +126,8 @@ function serviceMemberEditsPPMWeight() {
 
   typeInInput({ name: 'weight_estimate', value: '1700' });
 
-  cy.get('strong').contains('$4,736.63 - 5,235.23');
-  cy.get('.subtext').contains('Originally $4,36');
+  cy.get('strong').contains('$4,858.82 - 5,370.28');
+  cy.get('.subtext').contains('Originally $4,362.66 - 4,821.88');
 
   cy
     .get('button')
@@ -137,7 +137,6 @@ function serviceMemberEditsPPMWeight() {
 function serviceMemberVerifiesPPMDatesAndLocationsEdited() {
   cy.get('.ppm-container').should($div => {
     const text = $div.text();
-    console.log(text);
     expect(text).to.include('Move Date: 05/28/2018');
     expect(text).to.include('Pickup ZIP Code:  91206');
     expect(text).to.include('Delivery ZIP Code:  30813');
@@ -439,7 +438,7 @@ function serviceMemberCanReviewMoveSummary() {
     expect(text).to.include('Delivery ZIP Code:  30813');
     expect(text).not.to.include('Storage: Not requested');
     expect(text).to.include('Estimated Weight:  1,50');
-    expect(text).to.include('Estimated PPM Incentive:  $4,36');
+    expect(text).to.include('Estimated PPM Incentive:  $4,362.66 - 4,821.88');
   });
 
   cy.nextPage();
@@ -489,6 +488,6 @@ function serviceMemberViewsUpdatedHomePage() {
     // PPM information and details
     expect(text).to.include('Next Step: Wait for approval');
     expect(text).to.include('Weight (est.): 150');
-    expect(text).to.include('Incentive (est.): $4,36');
+    expect(text).to.include('Incentive (est.): $4,362.66 - 4,821.88');
   });
 }

--- a/cypress/integration/mymove/hhgPPM.js
+++ b/cypress/integration/mymove/hhgPPM.js
@@ -365,7 +365,7 @@ function serviceMemberFillsInDatesAndLocations() {
 
   cy.get('input[name="pickup_postal_code"]').should('have.value', '90210');
 
-  cy.get('input[name="destination_postal_code"]').should('have.value', '50309');
+  cy.get('input[name="destination_postal_code"]').should('have.value', '30813');
 
   cy.nextPage();
 }

--- a/cypress/integration/mymove/hhgPPM.js
+++ b/cypress/integration/mymove/hhgPPM.js
@@ -65,7 +65,7 @@ function serviceMemberVerifiesHHGPPMSummary() {
     expect(text).to.include('Orders Type: Permanent Change Of Station');
     expect(text).to.include('Orders Date:  05/20/2018');
     expect(text).to.include('Report-by Date: 08/01/2018');
-    expect(text).to.include('New Duty Station:  Yuma AFB');
+    expect(text).to.include('New Duty Station:  Fort Gordon');
     expect(text).to.include('Dependents?:  Yes');
     expect(text).to.include('Spouse Pro Gear?: Yes');
     expect(text).to.include('Orders Uploaded: 1');
@@ -105,10 +105,10 @@ function serviceMemberVerifiesHHGPPMSummary() {
     expect(text).to.include('Shipment - You move your stuff (PPM)');
     expect(text).to.include('Move Date: 05/20/2018');
     expect(text).to.include('Pickup ZIP Code:  90210');
-    expect(text).to.include('Delivery ZIP Code:  50309');
+    expect(text).to.include('Delivery ZIP Code:  30813');
     expect(text).not.to.include('Storage: Not requested');
     expect(text).to.include('Estimated Weight:  1,50');
-    expect(text).to.include('Estimated PPM Incentive:  $4,255.80 - 4,703.78');
+    expect(text).to.include('Estimated PPM Incentive:  $4,36');
   });
 }
 
@@ -127,7 +127,7 @@ function serviceMemberEditsPPMWeight() {
   typeInInput({ name: 'weight_estimate', value: '1700' });
 
   cy.get('strong').contains('$4,736.63 - 5,235.23');
-  cy.get('.subtext').contains('Originally $4,255.80 - 4,255.80');
+  cy.get('.subtext').contains('Originally $4,36');
 
   cy
     .get('button')
@@ -140,7 +140,7 @@ function serviceMemberVerifiesPPMDatesAndLocationsEdited() {
     console.log(text);
     expect(text).to.include('Move Date: 05/28/2018');
     expect(text).to.include('Pickup ZIP Code:  91206');
-    expect(text).to.include('Delivery ZIP Code:  50308');
+    expect(text).to.include('Delivery ZIP Code:  30813');
   });
 }
 function serviceMemberEditsPPMDatesAndLocations() {
@@ -148,7 +148,7 @@ function serviceMemberEditsPPMDatesAndLocations() {
 
   typeInInput({ name: 'planned_move_date', value: '5/28/2018' });
   typeInInput({ name: 'pickup_postal_code', value: '91206' });
-  typeInInput({ name: 'destination_postal_code', value: '50308' });
+  typeInInput({ name: 'destination_postal_code', value: '30813' });
 
   cy
     .get('button')
@@ -436,10 +436,10 @@ function serviceMemberCanReviewMoveSummary() {
     expect(text).to.include('Shipment - You move your stuff (PPM)');
     expect(text).to.include('Move Date: 05/20/2018');
     expect(text).to.include('Pickup ZIP Code:  90210');
-    expect(text).to.include('Delivery ZIP Code:  50309');
+    expect(text).to.include('Delivery ZIP Code:  30813');
     expect(text).not.to.include('Storage: Not requested');
     expect(text).to.include('Estimated Weight:  1,50');
-    expect(text).to.include('Estimated PPM Incentive:  $4,255.80 - 4,703.78');
+    expect(text).to.include('Estimated PPM Incentive:  $4,36');
   });
 
   cy.nextPage();
@@ -489,6 +489,6 @@ function serviceMemberViewsUpdatedHomePage() {
     // PPM information and details
     expect(text).to.include('Next Step: Wait for approval');
     expect(text).to.include('Weight (est.): 150');
-    expect(text).to.include('Incentive (est.): $4,255.80 - 4,703.78');
+    expect(text).to.include('Incentive (est.): $4,36');
   });
 }

--- a/cypress/integration/mymove/ppm.js
+++ b/cypress/integration/mymove/ppm.js
@@ -11,7 +11,7 @@ describe('completing the ppm flow', function() {
   //update moves set status='DRAFT';
   //delete from personally_procured_moves
   it('progresses thru forms', function() {
-    cy.contains('Yuma AFB (from Yuma AFB)');
+    cy.contains('Fort Gordon (from Yuma AFB)');
     cy.get('.whole_box > div > :nth-child(3) > span').contains('10,500 lbs');
     cy.contains('Continue Move Setup').click();
 

--- a/cypress/integration/office/locationsPanel.js
+++ b/cypress/integration/office/locationsPanel.js
@@ -48,9 +48,9 @@ describe('Office User Checks Shipment Locations', function() {
 
   it('office user primary delivery location when delivery address does not exist', function() {
     const address = {
-      city: 'Des Moines',
-      state: 'IA',
-      postal_code: '50309',
+      city: 'Augusta',
+      state: 'GA',
+      postal_code: '30813',
     };
     const expectation = text => {
       expect(text).to.equal(`${address.city}, ${address.state} ${address.postal_code}`);
@@ -130,9 +130,9 @@ function officeUserEntersLocations() {
     postal_code: '66666-6666',
   };
   const newDutyStation = {
-    city: 'Des Moines',
-    state: 'IA',
-    postal_code: '50309',
+    city: 'Augusta',
+    state: 'GA',
+    postal_code: '30813',
   };
 
   // Open new shipments queue

--- a/cypress/integration/tsp/locationsPanel.js
+++ b/cypress/integration/tsp/locationsPanel.js
@@ -122,11 +122,6 @@ function tspUserEntersLocations() {
     state: 'NJ',
     postal_code: '66666-6666',
   };
-  const newDutyStation = {
-    city: 'Augusta',
-    state: 'GA',
-    postal_code: '30813',
-  };
 
   // Open new shipments queue
   cy.location().should(loc => {

--- a/cypress/integration/tsp/locationsPanel.js
+++ b/cypress/integration/tsp/locationsPanel.js
@@ -122,6 +122,11 @@ function tspUserEntersLocations() {
     state: 'NJ',
     postal_code: '66666-6666',
   };
+  const newDutyStationAddress = {
+    city: 'Augusta',
+    state: 'GA',
+    postal_code: '30813',
+  };
 
   // Open new shipments queue
   cy.location().should(loc => {
@@ -377,7 +382,9 @@ function tspUserEntersLocations() {
         .children('.field-value')
         .should($div => {
           const text = $div.text();
-          expect(text).to.include(`${deliveryAddress.city}, ${deliveryAddress.state} ${deliveryAddress.postal_code}`);
+          expect(text).to.include(
+            `${newDutyStationAddress.city}, ${newDutyStationAddress.state} ${newDutyStationAddress.postal_code}`,
+          );
         });
     });
 }

--- a/cypress/integration/tsp/locationsPanel.js
+++ b/cypress/integration/tsp/locationsPanel.js
@@ -46,9 +46,9 @@ describe('TSP User Checks Shipment Locations', function() {
   });
   it('tsp user primary delivery location when delivery address does not exist', function() {
     const address = {
-      city: 'Des Moines',
-      state: 'IA',
-      postal_code: '50309',
+      city: 'Augusta',
+      state: 'GA',
+      postal_code: '30813',
     };
     const expectation = text => {
       expect(text).to.equal(`${address.city}, ${address.state} ${address.postal_code}`);
@@ -123,9 +123,9 @@ function tspUserEntersLocations() {
     postal_code: '66666-6666',
   };
   const newDutyStation = {
-    city: 'Des Moines',
-    state: 'IA',
-    postal_code: '50309',
+    city: 'Augusta',
+    state: 'GA',
+    postal_code: '30813',
   };
 
   // Open new shipments queue
@@ -382,7 +382,7 @@ function tspUserEntersLocations() {
         .children('.field-value')
         .should($div => {
           const text = $div.text();
-          expect(text).to.include(`${newDutyStation.city}, ${newDutyStation.state} ${newDutyStation.postal_code}`);
+          expect(text).to.include(`${deliveryAddress.city}, ${deliveryAddress.state} ${deliveryAddress.postal_code}`);
         });
     });
 }

--- a/pkg/handlers/internalapi/orders_test.go
+++ b/pkg/handlers/internalapi/orders_test.go
@@ -16,7 +16,7 @@ import (
 
 func (suite *HandlerSuite) TestCreateOrder() {
 	sm := testdatagen.MakeDefaultServiceMember(suite.DB())
-	station := testdatagen.FetchOrMakeDefaultDutyStation(suite.DB())
+	station := testdatagen.FetchOrMakeDefaultCurrentDutyStation(suite.DB())
 
 	req := httptest.NewRequest("POST", "/orders", nil)
 	req = suite.AuthenticateRequest(req, sm)

--- a/pkg/handlers/internalapi/transportation_offices_test.go
+++ b/pkg/handlers/internalapi/transportation_offices_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func (suite *HandlerSuite) TestShowDutyStationTransportationOfficeHandler() {
-	station := testdatagen.FetchOrMakeDefaultDutyStation(suite.DB())
+	station := testdatagen.FetchOrMakeDefaultCurrentDutyStation(suite.DB())
 
 	path := fmt.Sprintf("/duty_stations/%v/transportation_offices", station.ID.String())
 	req := httptest.NewRequest("GET", path, nil)
@@ -33,7 +33,7 @@ func (suite *HandlerSuite) TestShowDutyStationTransportationOfficeHandler() {
 }
 
 func (suite *HandlerSuite) TestShowDutyStationTransportationOfficeHandlerNoOffice() {
-	station := testdatagen.FetchOrMakeDefaultDutyStation(suite.DB())
+	station := testdatagen.FetchOrMakeDefaultCurrentDutyStation(suite.DB())
 	station.TransportationOffice = models.TransportationOffice{}
 	station.TransportationOfficeID = nil
 	suite.MustSave(&station)

--- a/pkg/models/duty_station_test.go
+++ b/pkg/models/duty_station_test.go
@@ -62,7 +62,7 @@ func (suite *ModelSuite) Test_DutyStationValidations() {
 }
 func (suite *ModelSuite) Test_FetchDutyStationTransportationOffice() {
 	t := suite.T()
-	dutyStation := testdatagen.FetchOrMakeDefaultDutyStation(suite.DB())
+	dutyStation := testdatagen.FetchOrMakeDefaultCurrentDutyStation(suite.DB())
 
 	office, err := models.FetchDutyStationTransportationOffice(suite.DB(), dutyStation.ID)
 	if err != nil {

--- a/pkg/models/move_test.go
+++ b/pkg/models/move_test.go
@@ -253,7 +253,7 @@ func (suite *ModelSuite) TestSaveMoveDependenciesSuccess() {
 func (suite *ModelSuite) TestSaveMoveDependenciesSetsGBLOCSuccess() {
 	// Given: A shipment's move with orders in acceptable status
 
-	dutyStation := testdatagen.FetchOrMakeDefaultDutyStation(suite.DB())
+	dutyStation := testdatagen.FetchOrMakeDefaultCurrentDutyStation(suite.DB())
 	serviceMember := testdatagen.MakeDefaultServiceMember(suite.DB())
 	serviceMember.DutyStationID = &dutyStation.ID
 	serviceMember.DutyStation = dutyStation

--- a/pkg/models/order_test.go
+++ b/pkg/models/order_test.go
@@ -31,7 +31,7 @@ func (suite *ModelSuite) TestFetchOrderForUser() {
 	serviceMember1 := testdatagen.MakeDefaultServiceMember(suite.DB())
 	serviceMember2 := testdatagen.MakeDefaultServiceMember(suite.DB())
 
-	dutyStation := testdatagen.FetchOrMakeDefaultDutyStation(suite.DB())
+	dutyStation := testdatagen.FetchOrMakeDefaultCurrentDutyStation(suite.DB())
 	issueDate := time.Date(2018, time.March, 10, 0, 0, 0, 0, time.UTC)
 	reportByDate := time.Date(2018, time.August, 1, 0, 0, 0, 0, time.UTC)
 	ordersType := internalmessages.OrdersTypePERMANENTCHANGEOFSTATION
@@ -107,7 +107,7 @@ func (suite *ModelSuite) TestFetchOrderNotForUser() {
 
 	serviceMember1 := testdatagen.MakeDefaultServiceMember(suite.DB())
 
-	dutyStation := testdatagen.FetchOrMakeDefaultDutyStation(suite.DB())
+	dutyStation := testdatagen.FetchOrMakeDefaultCurrentDutyStation(suite.DB())
 	issueDate := time.Date(2018, time.March, 10, 0, 0, 0, 0, time.UTC)
 	reportByDate := time.Date(2018, time.August, 1, 0, 0, 0, 0, time.UTC)
 	ordersType := internalmessages.OrdersTypePERMANENTCHANGEOFSTATION
@@ -153,7 +153,7 @@ func (suite *ModelSuite) TestFetchOrderNotForUser() {
 func (suite *ModelSuite) TestOrderStateMachine() {
 	serviceMember1 := testdatagen.MakeDefaultServiceMember(suite.DB())
 
-	dutyStation := testdatagen.FetchOrMakeDefaultDutyStation(suite.DB())
+	dutyStation := testdatagen.FetchOrMakeDefaultCurrentDutyStation(suite.DB())
 	issueDate := time.Date(2018, time.March, 10, 0, 0, 0, 0, time.UTC)
 	reportByDate := time.Date(2018, time.August, 1, 0, 0, 0, 0, time.UTC)
 	ordersType := internalmessages.OrdersTypePERMANENTCHANGEOFSTATION
@@ -198,7 +198,7 @@ func (suite *ModelSuite) TestOrderStateMachine() {
 func (suite *ModelSuite) TestCanceledMoveCancelsOrder() {
 	serviceMember1 := testdatagen.MakeDefaultServiceMember(suite.DB())
 
-	dutyStation := testdatagen.FetchOrMakeDefaultDutyStation(suite.DB())
+	dutyStation := testdatagen.FetchOrMakeDefaultCurrentDutyStation(suite.DB())
 	issueDate := time.Date(2018, time.March, 10, 0, 0, 0, 0, time.UTC)
 	reportByDate := time.Date(2018, time.August, 1, 0, 0, 0, 0, time.UTC)
 	ordersType := internalmessages.OrdersTypePERMANENTCHANGEOFSTATION

--- a/pkg/models/service_member_test.go
+++ b/pkg/models/service_member_test.go
@@ -44,7 +44,7 @@ func (suite *ModelSuite) TestIsProfileCompleteWithIncompleteSM() {
 	email := "bobsally@gmail.com"
 	fakeAddress := testdatagen.MakeDefaultAddress(suite.DB())
 	fakeBackupAddress := testdatagen.MakeDefaultAddress(suite.DB())
-	station := testdatagen.FetchOrMakeDefaultDutyStation(suite.DB())
+	station := testdatagen.FetchOrMakeDefaultCurrentDutyStation(suite.DB())
 
 	serviceMember := ServiceMember{
 		UserID:                 user1.ID,

--- a/pkg/testdatagen/make_duty_station.go
+++ b/pkg/testdatagen/make_duty_station.go
@@ -75,6 +75,16 @@ func FetchOrMakeDefaultNewOrdersDutyStation(db *pop.Connection) models.DutyStati
 				Name: "Fort Gordon",
 			},
 		}
+		FetchOrMakeTariff400ngZip3(db, Assertions{
+			Tariff400ngZip3: models.Tariff400ngZip3{
+				Zip3:          "308",
+				BasepointCity: "Harlem",
+				State:         "GA",
+				ServiceArea:   "208",
+				RateArea:      "US45",
+				Region:        "12",
+			},
+		})
 		return MakeDutyStation(db, fortGordonAssertions)
 	}
 	return fortGordon

--- a/pkg/testdatagen/make_duty_station.go
+++ b/pkg/testdatagen/make_duty_station.go
@@ -49,12 +49,33 @@ func MakeDutyStation(db *pop.Connection, assertions Assertions) models.DutyStati
 	return station
 }
 
-// FetchOrMakeDefaultDutyStation returns a default duty station - Yuma AFB
-func FetchOrMakeDefaultDutyStation(db *pop.Connection) models.DutyStation {
+// FetchOrMakeDefaultCurrentDutyStation returns a default duty station - Yuma AFB
+func FetchOrMakeDefaultCurrentDutyStation(db *pop.Connection) models.DutyStation {
 	// Check if Yuma Duty Station exists, if not, create it.
 	defaultStation, err := models.FetchDutyStationByName(db, "Yuma AFB")
 	if err != nil {
 		return MakeDutyStation(db, Assertions{})
 	}
 	return defaultStation
+}
+
+// FetchOrMakeDefaultNewOrdersDutyStation returns a default duty station - Yuma AFB
+func FetchOrMakeDefaultNewOrdersDutyStation(db *pop.Connection) models.DutyStation {
+	// Check if Fort Gordon exists, if not, create
+	// Move date picker for this test case only works with an address of street name "Fort Gordon"
+	fortGordon, err := models.FetchDutyStationByName(db, "Fort Gordon")
+	if err != nil {
+		fortGordonAssertions := Assertions{
+			Address: models.Address{
+				City:       "Augusta",
+				State:      "GA",
+				PostalCode: "30813",
+			},
+			DutyStation: models.DutyStation{
+				Name: "Fort Gordon",
+			},
+		}
+		return MakeDutyStation(db, fortGordonAssertions)
+	}
+	return fortGordon
 }

--- a/pkg/testdatagen/make_order.go
+++ b/pkg/testdatagen/make_order.go
@@ -21,7 +21,7 @@ func MakeOrder(db *pop.Connection, assertions Assertions) models.Order {
 	station := assertions.Order.NewDutyStation
 	// Note above
 	if isZeroUUID(assertions.Order.NewDutyStationID) {
-		station = FetchOrMakeDefaultDutyStation(db)
+		station = FetchOrMakeDefaultNewOrdersDutyStation(db)
 	}
 
 	document := assertions.Order.UploadedOrders

--- a/pkg/testdatagen/make_service_member.go
+++ b/pkg/testdatagen/make_service_member.go
@@ -61,7 +61,7 @@ func MakeExtendedServiceMember(db *pop.Connection, assertions Assertions) models
 	Army := models.AffiliationARMY
 	E1 := models.ServiceMemberRankE1
 
-	station := FetchOrMakeDefaultDutyStation(db)
+	station := FetchOrMakeDefaultCurrentDutyStation(db)
 	emailPreferred := true
 	// Combine extended SM defaults with assertions
 	smDefaults := models.ServiceMember{

--- a/pkg/testdatagen/scenario/e2ebasic.go
+++ b/pkg/testdatagen/scenario/e2ebasic.go
@@ -373,23 +373,6 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, log
 		},
 	})
 
-	// Check if Fort Gordon exists, if not, create
-	// Move date picker for this test case only works with an address of street name "Fort Gordon"
-	fortGordon, err := models.FetchDutyStationByName(db, "Fort Gordon")
-	if err != nil {
-		fortGordonAssertions := testdatagen.Assertions{
-			Address: models.Address{
-				City:       "Augusta",
-				State:      "GA",
-				PostalCode: "30813",
-			},
-			DutyStation: models.DutyStation{
-				Name: "Fort Gordon",
-			},
-		}
-		fortGordon = testdatagen.MakeDutyStation(db, fortGordonAssertions)
-	}
-
 	testdatagen.MakeMoveWithoutMoveType(db, testdatagen.Assertions{
 		ServiceMember: models.ServiceMember{
 			ID:            uuid.FromStringOrNil("b5d1f44b-5ceb-4a0e-9119-5687808996ff"),
@@ -398,8 +381,6 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, log
 			LastName:      models.StringPointer("UserPerson"),
 			Edipi:         models.StringPointer("6833908163"),
 			PersonalEmail: models.StringPointer(email),
-			DutyStationID: &fortGordon.ID,
-			DutyStation:   fortGordon,
 		},
 		Order: models.Order{
 			HasDependents:    true,
@@ -432,8 +413,6 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, log
 			LastName:      models.StringPointer("UserPerson2"),
 			Edipi:         models.StringPointer("6833908164"),
 			PersonalEmail: models.StringPointer(email),
-			DutyStationID: &fortGordon.ID,
-			DutyStation:   fortGordon,
 		},
 		Move: models.Move{
 			ID:      uuid.FromStringOrNil("b2ecbbe5-36ad-49fc-86c8-66e55e0697a7"),

--- a/src/scenes/Review/EditWeight.jsx
+++ b/src/scenes/Review/EditWeight.jsx
@@ -129,7 +129,7 @@ let EditWeightForm = props => {
               initialValues.incentive_estimate_min !== incentive_estimate_min && (
                 <p className="subtext">
                   Originally{' '}
-                  {formatCentsRange(initialValues.incentive_estimate_min, initialValues.incentive_estimate_min)}
+                  {formatCentsRange(initialValues.incentive_estimate_min, initialValues.incentive_estimate_max)}
                 </p>
               )}
           </div>


### PR DESCRIPTION
## Description

Local testing was failing for some moves because the default duty station was the same for the origin duty station and the new duty station (traveling 0 miles).

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make db_dev_e2e_populate
```

You should be able to add a ppm to any hhg now that the distance calculation will actually work.

## Code Review Verification Steps

* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* https://www.pivotaltracker.com/story/show/163098269
