### PR TITLE
Allow combo moves in prod

### DIFF
--- a/src/shared/featureFlags.js
+++ b/src/shared/featureFlags.js
@@ -26,7 +26,6 @@ const environmentFlags = {
   staging: Object.assign({}, defaultFlags),
 
   production: Object.assign({}, defaultFlags, {
-    hhgAndPpm: false,
     allowHhgInvoicePayment: false,
   }),
 };


### PR DESCRIPTION
## Description

We're releasing combo moves, but we want the ability to reign it back in if something significant goes wrong. We have a follow up story to remove the code related to this flag.

## Setup

If you want to test this, you'll need to replace https://github.com/transcom/mymove/blob/master/src/shared/featureFlags.js#L74 with 
`return 'production';`

``` sh
make db_dev_e2e_populate
```

Then you should sign in as `hhgforppm@award.ed`. From the home page, you should be able to add a PPM (DITY) to your move.

## Code Review Verification Steps

* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* https://www.pivotaltracker.com/story/show/162772102
