### PR TITLE
Sync payloads for internal and public shipment APIs

### DIFF
--- a/pkg/handlers/internalapi/moves.go
+++ b/pkg/handlers/internalapi/moves.go
@@ -42,7 +42,7 @@ func payloadForMoveModel(storer storage.FileStorer, order models.Order, move mod
 
 	var shipmentPayloads []*internalmessages.Shipment
 	for _, shipment := range move.Shipments {
-		payload, err := payloadForShipmentModel(shipment)
+		payload, err := payloadForShipmentModel(shipment, storer)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/handlers/internalapi/moves.go
+++ b/pkg/handlers/internalapi/moves.go
@@ -42,7 +42,7 @@ func payloadForMoveModel(storer storage.FileStorer, order models.Order, move mod
 
 	var shipmentPayloads []*internalmessages.Shipment
 	for _, shipment := range move.Shipments {
-		payload, err := payloadForShipmentModel(shipment, storer)
+		payload, err := payloadForShipmentModel(shipment)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/handlers/internalapi/shipments.go
+++ b/pkg/handlers/internalapi/shipments.go
@@ -16,7 +16,6 @@ import (
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/models"
 	invoiceop "github.com/transcom/mymove/pkg/service/invoice"
-	"github.com/transcom/mymove/pkg/storage"
 )
 
 func payloadForInvoiceModel(a *models.Invoice) *internalmessages.Invoice {
@@ -35,7 +34,7 @@ func payloadForInvoiceModel(a *models.Invoice) *internalmessages.Invoice {
 	}
 }
 
-func payloadForShipmentModel(s models.Shipment, storer storage.FileStorer) (*internalmessages.Shipment, error) {
+func payloadForShipmentModel(s models.Shipment) (*internalmessages.Shipment, error) {
 	// TODO: For now, we keep the Shipment structure the same but change where the CodeOfService
 	// TODO: is coming from.  Ultimately we should probably rework the structure below to more
 	// TODO: closely match the database structure.
@@ -78,7 +77,6 @@ func payloadForShipmentModel(s models.Shipment, storer storage.FileStorer) (*int
 		TrafficDistributionListID: handlers.FmtUUIDPtr(s.TrafficDistributionListID),
 		TrafficDistributionList:   payloadForTrafficDistributionListModel(s.TrafficDistributionList),
 		ServiceMemberID:           strfmt.UUID(s.ServiceMemberID.String()),
-		ServiceMember:             payloadForServiceMemberModel(storer, s.ServiceMember),
 		MoveID:                    strfmt.UUID(s.MoveID.String()),
 		ServiceAgents:             serviceAgentPayloads,
 
@@ -207,7 +205,7 @@ func (h CreateShipmentHandler) Handle(params shipmentop.CreateShipmentParams) mi
 		return handlers.ResponseForVErrors(h.Logger(), verrs, err)
 	}
 
-	shipmentPayload, err := payloadForShipmentModel(newShipment, h.FileStorer())
+	shipmentPayload, err := payloadForShipmentModel(newShipment)
 	if err != nil {
 		h.Logger().Error("Error in shipment payload: ", zap.Error(err))
 	}
@@ -348,7 +346,7 @@ func (h PatchShipmentHandler) Handle(params shipmentop.PatchShipmentParams) midd
 		return handlers.ResponseForVErrors(h.Logger(), verrs, err)
 	}
 
-	shipmentPayload, err := payloadForShipmentModel(*shipment, h.FileStorer())
+	shipmentPayload, err := payloadForShipmentModel(*shipment)
 	if err != nil {
 		h.Logger().Error("Error in shipment payload: ", zap.Error(err))
 	}
@@ -399,7 +397,7 @@ func (h GetShipmentHandler) Handle(params shipmentop.GetShipmentParams) middlewa
 		return handlers.ResponseForError(h.Logger(), err)
 	}
 
-	shipmentPayload, err := payloadForShipmentModel(*shipment, h.FileStorer())
+	shipmentPayload, err := payloadForShipmentModel(*shipment)
 	if err != nil {
 		h.Logger().Error("Error in shipment payload: ", zap.Error(err))
 	}
@@ -436,7 +434,7 @@ func (h ApproveHHGHandler) Handle(params shipmentop.ApproveHHGParams) middleware
 		return handlers.ResponseForVErrors(h.Logger(), verrs, err)
 	}
 
-	shipmentPayload, err := payloadForShipmentModel(*shipment, h.FileStorer())
+	shipmentPayload, err := payloadForShipmentModel(*shipment)
 	if err != nil {
 		h.Logger().Error("Error in shipment payload: ", zap.Error(err))
 	}
@@ -472,7 +470,7 @@ func (h CompleteHHGHandler) Handle(params shipmentop.CompleteHHGParams) middlewa
 		return handlers.ResponseForVErrors(h.Logger(), verrs, err)
 	}
 
-	shipmentPayload, err := payloadForShipmentModel(*shipment, h.FileStorer())
+	shipmentPayload, err := payloadForShipmentModel(*shipment)
 	if err != nil {
 		h.Logger().Error("Error in shipment payload: ", zap.Error(err))
 	}

--- a/pkg/handlers/internalapi/shipments.go
+++ b/pkg/handlers/internalapi/shipments.go
@@ -76,6 +76,7 @@ func payloadForShipmentModel(s models.Shipment) (*internalmessages.Shipment, err
 		// associations
 		TrafficDistributionListID: handlers.FmtUUIDPtr(s.TrafficDistributionListID),
 		ServiceMemberID:           strfmt.UUID(s.ServiceMemberID.String()),
+		TrafficDistributionList:   payloadForTrafficDistributionListModel(s.TrafficDistributionList),
 		MoveID:                    strfmt.UUID(s.MoveID.String()),
 		ServiceAgents:             serviceAgentPayloads,
 

--- a/pkg/handlers/internalapi/shipments.go
+++ b/pkg/handlers/internalapi/shipments.go
@@ -109,6 +109,7 @@ func payloadForShipmentModel(s models.Shipment, storer storage.FileStorer) (*int
 		WeightEstimate:              handlers.FmtPoundPtr(s.WeightEstimate),
 		ProgearWeightEstimate:       handlers.FmtPoundPtr(s.ProgearWeightEstimate),
 		SpouseProgearWeightEstimate: handlers.FmtPoundPtr(s.SpouseProgearWeightEstimate),
+		NetWeight:                   handlers.FmtPoundPtr(s.NetWeight),
 		GrossWeight:                 handlers.FmtPoundPtr(s.GrossWeight),
 		TareWeight:                  handlers.FmtPoundPtr(s.TareWeight),
 
@@ -123,6 +124,10 @@ func payloadForShipmentModel(s models.Shipment, storer storage.FileStorer) (*int
 		PmSurveySpouseProgearWeightEstimate: handlers.FmtPoundPtr(s.PmSurveySpouseProgearWeightEstimate),
 		PmSurveyNotes:                       s.PmSurveyNotes,
 		PmSurveyMethod:                      s.PmSurveyMethod,
+	}
+	tspID := s.CurrentTransportationServiceProviderID()
+	if tspID != uuid.Nil {
+		shipmentPayload.TransportationServiceProviderID = *handlers.FmtUUID(tspID)
 	}
 	return shipmentPayload, nil
 }

--- a/pkg/handlers/internalapi/traffic_distribution_list.go
+++ b/pkg/handlers/internalapi/traffic_distribution_list.go
@@ -1,0 +1,19 @@
+package internalapi
+
+import (
+	"github.com/go-openapi/swag"
+
+	"github.com/transcom/mymove/pkg/gen/internalmessages"
+	"github.com/transcom/mymove/pkg/models"
+)
+
+func payloadForTrafficDistributionListModel(tdl *models.TrafficDistributionList) *internalmessages.TrafficDistributionList {
+	if tdl == nil {
+		return nil
+	}
+	return &internalmessages.TrafficDistributionList{
+		SourceRateArea:    swag.String(tdl.SourceRateArea),
+		DestinationRegion: swag.String(tdl.DestinationRegion),
+		CodeOfService:     swag.String(tdl.CodeOfService),
+	}
+}

--- a/pkg/handlers/publicapi/shipments.go
+++ b/pkg/handlers/publicapi/shipments.go
@@ -36,9 +36,12 @@ func payloadForShipmentModel(s models.Shipment) *apimessages.Shipment {
 		UpdatedAt:        strfmt.DateTime(s.UpdatedAt),
 
 		// associations
-		TrafficDistributionList: payloadForTrafficDistributionListModel(s.TrafficDistributionList),
-		ServiceMember:           payloadForServiceMemberModel(&s.ServiceMember),
-		Move:                    payloadForMoveModel(&s.Move),
+		TrafficDistributionListID: handlers.FmtUUIDPtr(s.TrafficDistributionListID),
+		TrafficDistributionList:   payloadForTrafficDistributionListModel(s.TrafficDistributionList),
+		ServiceMemberID:           strfmt.UUID(s.ServiceMemberID.String()),
+		ServiceMember:             payloadForServiceMemberModel(&s.ServiceMember),
+		MoveID:                    strfmt.UUID(s.MoveID.String()),
+		Move:                      payloadForMoveModel(&s.Move),
 
 		// dates
 		ActualPickupDate:     handlers.FmtDatePtr(s.ActualPickupDate),

--- a/swagger/api.yaml
+++ b/swagger/api.yaml
@@ -980,11 +980,26 @@ definitions:
       updated_at:
         type: string
         format: date-time
+      traffic_distribution_list_id:
+        type: string
+        format: uuid
+        example: d56a4180-65aa-42ec-a945-5fd21dec0538
+        x-nullable: true
       traffic_distribution_list:
         $ref: '#/definitions/TrafficDistributionList'
         readOnly: true
+      service_member_id:
+        type: string
+        format: uuid
+        example: d56a4180-65aa-42ec-a945-5fd21dec0538
+        readOnly: true
       service_member:
         $ref: '#/definitions/ServiceMember'
+        readOnly: true
+      move_id:
+        type: string
+        format: uuid
+        example: d56a4180-65aa-42ec-a945-5fd21dec0538
         readOnly: true
       move:
         $ref: '#/definitions/Move'

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -1514,9 +1514,6 @@ definitions:
         format: uuid
         example: d56a4180-65aa-42ec-a945-5fd21dec0538
         readOnly: true
-      service_member:
-        $ref: '#/definitions/ServiceMemberPayload'
-        readOnly: true
       code_of_service:
         type: string
         x-nullable: true

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -1606,11 +1606,6 @@ definitions:
               type: string
               format: date
         x-nullable: true
-      pickup_address_id:
-        type: string
-        format: uuid
-        example: f56a4180-65aa-42ec-a945-5fd21dec0538
-        x-nullable: true
       pickup_address:
         $ref: '#/definitions/Address'
         title: Pickup Address
@@ -1618,11 +1613,6 @@ definitions:
         type: boolean
         default: false
         title: 'Do you have household goods at any other pickup location?'
-      secondary_pickup_address_id:
-        type: string
-        format: uuid
-        example: f56a4180-65aa-42ec-a945-5fd21dec0538
-        x-nullable: true
       secondary_pickup_address:
         $ref: '#/definitions/Address'
         title: Secondary Pickup Address
@@ -1631,11 +1621,6 @@ definitions:
         type: boolean
         default: false
         title: 'Do you know the delivery address at destination yet?'
-      delivery_address_id:
-        type: string
-        format: uuid
-        example: f56a4180-65aa-42ec-a945-5fd21dec0538
-        x-nullable: true
       delivery_address:
         $ref: '#/definitions/Address'
         title: Delivery Address
@@ -1644,11 +1629,6 @@ definitions:
         type: boolean
         default: false
         title: 'Will some of your items be stored in transit?'
-      partial_sit_delivery_address_id:
-        type: string
-        format: uuid
-        example: f56a4180-65aa-42ec-a945-5fd21dec0538
-        x-nullable: true
       partial_sit_delivery_address:
         $ref: '#/definitions/Address'
         title: Partial SIT Delivery Address

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -1452,6 +1452,25 @@ definitions:
     x-display-value:
       AIR_FORCE: 57 - United States Air Force
       MARINES: 17 - United States Marines
+  TrafficDistributionList:
+    type: object
+    properties:
+      source_rate_area:
+        type: string
+        example: US34
+      destination_region:
+        type: string
+        example: '5'
+      code_of_service:
+        type: string
+        example: D
+        enum:
+          - D
+          - '2'
+    required:
+      - source_rate_area
+      - destination_region
+      - code_of_service
   Shipment:
     type: object
     properties:
@@ -1460,21 +1479,8 @@ definitions:
         format: uuid
         example: c56a4180-65aa-42ec-a945-5fd21dec0538
         readOnly: true
-      move_id:
-        type: string
-        format: uuid
-        example: d56a4180-65aa-42ec-a945-5fd21dec0538
-        readOnly: true
-      traffic_distribution_list_id:
-        type: string
-        format: uuid
-        example: d56a4180-65aa-42ec-a945-5fd21dec0538
-        x-nullable: true
-        readOnly: true
-      service_member_id:
-        type: string
-        format: uuid
-        example: d56a4180-65aa-42ec-a945-5fd21dec0538
+      status:
+        $ref: '#/definitions/ShipmentStatus'
         readOnly: true
       source_gbloc:
         $ref: '#/definitions/GBLOC'
@@ -1483,13 +1489,42 @@ definitions:
         $ref: '#/definitions/GBLOC'
       market:
         $ref: '#/definitions/ShipmentMarket'
+        readOnly: true
+      created_at:
+        type: string
+        format: date-time
+      updated_at:
+        type: string
+        format: date-time
+      move_id:
+        type: string
+        format: uuid
+        example: d56a4180-65aa-42ec-a945-5fd21dec0538
+        readOnly: true
+      move:
+        $ref: '#/definitions/MovePayload'
+        x-nullable: true
+      traffic_distribution_list_id:
+        type: string
+        format: uuid
+        example: d56a4180-65aa-42ec-a945-5fd21dec0538
+        x-nullable: true
+      traffic_distribution_list:
+        $ref: '#/definitions/TrafficDistributionList'
+        readOnly: true
+      service_member_id:
+        type: string
+        format: uuid
+        example: d56a4180-65aa-42ec-a945-5fd21dec0538
+        readOnly: true
+      service_member:
+        $ref: '#/definitions/ServiceMemberPayload'
+        readOnly: true
       code_of_service:
         type: string
         x-nullable: true
         title: Code of service
         readOnly: true
-      status:
-        $ref: '#/definitions/ShipmentStatus'
       book_date:
         type: string
         format: date
@@ -1579,6 +1614,10 @@ definitions:
       pickup_address:
         $ref: '#/definitions/Address'
         title: Pickup Address
+      has_secondary_pickup_address:
+        type: boolean
+        default: false
+        title: 'Do you have household goods at any other pickup location?'
       secondary_pickup_address_id:
         type: string
         format: uuid
@@ -1588,6 +1627,10 @@ definitions:
         $ref: '#/definitions/Address'
         title: Secondary Pickup Address
         x-nullable: true
+      has_delivery_address:
+        type: boolean
+        default: false
+        title: 'Do you know the delivery address at destination yet?'
       delivery_address_id:
         type: string
         format: uuid
@@ -1597,6 +1640,10 @@ definitions:
         $ref: '#/definitions/Address'
         title: Delivery Address
         x-nullable: true
+      has_partial_sit_delivery_address:
+        type: boolean
+        default: false
+        title: 'Will some of your items be stored in transit?'
       partial_sit_delivery_address_id:
         type: string
         format: uuid
@@ -1606,32 +1653,6 @@ definitions:
         $ref: '#/definitions/Address'
         title: Partial SIT Delivery Address
         x-nullable: true
-      has_secondary_pickup_address:
-        type: boolean
-        default: false
-        title: 'Do you have household goods at any other pickup location?'
-      has_delivery_address:
-        type: boolean
-        default: false
-        title: 'Do you know your home address at your destination yet?'
-      has_partial_sit_delivery_address:
-        type: boolean
-        default: false
-        title: 'Do you know the delivery address at destination yet?'
-      gross_weight:
-        type: integer
-        minimum: 0
-        example: 10000
-        title: Gross Weight
-        x-nullable: true
-        x-formatting: weight
-      tare_weight:
-        type: integer
-        minimum: 0
-        example: 10000
-        title: Tare Weight
-        x-nullable: true
-        x-formatting: weight
       weight_estimate:
         type: integer
         minimum: 0
@@ -1651,6 +1672,28 @@ definitions:
         minimum: 0
         example: 200
         title: Spouse's Pro-Gear
+        x-nullable: true
+        x-formatting: weight
+      net_weight:
+        type: integer
+        description: Actual net weight of the shipment in lbs
+        minimum: 0
+        example: 10000
+        x-nullable: true
+        x-formatting: weight
+        title: Net
+      gross_weight:
+        type: integer
+        minimum: 0
+        example: 10000
+        title: Gross Weight
+        x-nullable: true
+        x-formatting: weight
+      tare_weight:
+        type: integer
+        minimum: 0
+        example: 10000
+        title: Tare Weight
         x-nullable: true
         x-formatting: weight
       pm_survey_completed_at:
@@ -1735,12 +1778,11 @@ definitions:
         type: array
         items:
           $ref: '#/definitions/ServiceAgent'
-      created_at:
+      transportation_service_provider_id:
         type: string
-        format: date-time
-      updated_at:
-        type: string
-        format: date-time
+        format: uuid
+        example: c56a4180-65aa-42ec-a945-5fd21dec0538
+        readOnly: true
   ServiceAgentRole:
     type: string
     title: Service Agent Role

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -1724,18 +1724,6 @@ definitions:
         example: '2018-04-26'
         title: 'Planned delivery date'
         x-nullable: true
-      pm_survey_earliest_delivery_date:
-        type: string
-        format: date
-        example: '2018-04-26'
-        title: 'Earliest delivery date'
-        x-nullable: true
-      pm_survey_latest_delivery_date:
-        type: string
-        format: date
-        example: '2018-04-26'
-        title: 'Latest delivery date'
-        x-nullable: true
       pm_survey_weight_estimate:
         type: integer
         minimum: 0

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -1501,9 +1501,6 @@ definitions:
         format: uuid
         example: d56a4180-65aa-42ec-a945-5fd21dec0538
         readOnly: true
-      move:
-        $ref: '#/definitions/MovePayload'
-        x-nullable: true
       traffic_distribution_list_id:
         type: string
         format: uuid


### PR DESCRIPTION
## Description

As much as possible, sync the payloads between the internal and public shipment APIs

## Reviewer Notes

There are a few things that I didn't clean up as part of this pull request, that I have created some spinoff stories for. All of the work below requires some non-trivial work on the front end, so it seemed out of scope to tackle it as part of this original story. Here are those stories:
- [Remove service_agents from the internal shipments API payload](https://www.pivotaltracker.com/story/show/163410753)
- [Remove code_of_service from internal shipments API payload](https://www.pivotaltracker.com/story/show/163410715)
- [Remove move from the public shipments API payload](https://www.pivotaltracker.com/story/show/163414119)
- [Remove service_member from the public shipments API payload](https://www.pivotaltracker.com/story/show/163432183)

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/n/projects/2181745/stories/163242009) for this change