### PR TITLE
Populate Orders Account SSW

### DIFF
--- a/pkg/models/shipment_summary_worksheet.go
+++ b/pkg/models/shipment_summary_worksheet.go
@@ -151,6 +151,8 @@ func FormatOrdersTypeAndOrdersNumber(order Order) string {
 
 //FormatIssuingBranchOrAgency formats OrdersIssuingAgency for Shipment Summary Worksheet
 func FormatIssuingBranchOrAgency(order Order) string {
+	//TODO when look at test cases in orders table none have orders_issuing_agency,
+	//TODO should this field be derived elsewhere
 	if order.OrdersIssuingAgency != nil {
 		words := strings.Split(strings.ToLower(*order.OrdersIssuingAgency), "_")
 		return strings.Title(strings.Join(words, " "))

--- a/pkg/models/shipment_summary_worksheet.go
+++ b/pkg/models/shipment_summary_worksheet.go
@@ -131,9 +131,7 @@ func FormatValuesShipmentSummaryWorksheetFormPage1(data ShipmentSummaryFormData)
 
 //FormatDutyStation formats DutyStation for Shipment Summary Worksheet
 func FormatDutyStation(dutyStation DutyStation) string {
-	//TODO confirm how we want to handle short names e.g. Fort -> Ft.
-	newDutyStationShortName := strings.Replace(dutyStation.Name, "Fort", "Ft.", 1)
-	return fmt.Sprintf("%s, %s", newDutyStationShortName, dutyStation.Address.State)
+	return fmt.Sprintf("%s, %s", dutyStation.Name, dutyStation.Address.State)
 }
 
 //FormatOrdersIssueDate formats Order.IssueDate for Shipment Summary Worksheet
@@ -151,8 +149,6 @@ func FormatOrdersTypeAndOrdersNumber(order Order) string {
 
 //FormatIssuingBranchOrAgency formats OrdersIssuingAgency for Shipment Summary Worksheet
 func FormatIssuingBranchOrAgency(order Order) string {
-	//TODO when look at test cases in orders table none have orders_issuing_agency,
-	//TODO should this field be derived elsewhere
 	if order.OrdersIssuingAgency != nil {
 		words := strings.Split(strings.ToLower(*order.OrdersIssuingAgency), "_")
 		return strings.Title(strings.Join(words, " "))
@@ -165,7 +161,6 @@ func FormatOrdersType(order Order) string {
 	switch order.OrdersType {
 	case internalmessages.OrdersTypePERMANENTCHANGEOFSTATION:
 		return "PCS"
-		// TODO determine what abbr are for other order types
 	default:
 		return ""
 	}

--- a/pkg/models/shipment_summary_worksheet.go
+++ b/pkg/models/shipment_summary_worksheet.go
@@ -36,7 +36,6 @@ type ShipmentSummaryWorksheetPage1Values struct {
 	PreferredPhone               string
 	PreferredEmail               string
 	DODId                        string
-	ServiceBranch                string
 	Rank                         string
 	IssuingBranchOrAgency        string
 	OrdersIssueDate              string
@@ -109,10 +108,9 @@ func FormatValuesShipmentSummaryWorksheetFormPage1(data ShipmentSummaryFormData)
 	page1.PreferredPhone = derefStringTypes(sm.Telephone)
 	page1.PreferredEmail = derefStringTypes(sm.PersonalEmail)
 	page1.DODId = derefStringTypes(sm.Edipi)
-	page1.ServiceBranch = derefStringTypes(sm.Affiliation)
 	page1.Rank = derefStringTypes(sm.Rank)
 
-	page1.IssuingBranchOrAgency = FormatIssuingBranchOrAgency(data.Order)
+	page1.IssuingBranchOrAgency = FormatServiceMemberAffiliation(sm.Affiliation)
 	page1.OrdersIssueDate = FormatOrdersIssueDate(data.Order)
 	page1.OrdersTypeAndOrdersNumber = FormatOrdersTypeAndOrdersNumber(data.Order)
 
@@ -147,10 +145,10 @@ func FormatOrdersTypeAndOrdersNumber(order Order) string {
 	return fmt.Sprintf("%s/%s", issuingBranch, ordersNumber)
 }
 
-//FormatIssuingBranchOrAgency formats OrdersIssuingAgency for Shipment Summary Worksheet
-func FormatIssuingBranchOrAgency(order Order) string {
-	if order.OrdersIssuingAgency != nil {
-		words := strings.Split(strings.ToLower(*order.OrdersIssuingAgency), "_")
+//FormatServiceMemberAffiliation formats ServiceMemberAffiliation in human friendly format
+func FormatServiceMemberAffiliation(affiliation *ServiceMemberAffiliation) string {
+	if affiliation != nil {
+		words := strings.Split(strings.ToLower(string(*affiliation)), "_")
 		return strings.Title(strings.Join(words, " "))
 	}
 	return ""
@@ -204,11 +202,6 @@ func derefStringTypes(st interface{}) string {
 	case string:
 		return v
 	case *ServiceMemberRank:
-		if v != nil {
-			return string(*v)
-		}
-		return ""
-	case *ServiceMemberAffiliation:
 		if v != nil {
 			return string(*v)
 		}

--- a/pkg/models/shipment_summary_worksheet.go
+++ b/pkg/models/shipment_summary_worksheet.go
@@ -3,14 +3,15 @@ package models
 import (
 	"context"
 	"fmt"
-	"time"
+	"strings"
+
+	"github.com/transcom/mymove/pkg/gen/internalmessages"
 
 	"golang.org/x/text/language"
 	"golang.org/x/text/message"
 
 	"github.com/gobuffalo/pop"
 	"github.com/gofrs/uuid"
-	"github.com/transcom/mymove/pkg/gen/internalmessages"
 )
 
 // FetchShipmentSummaryWorksheetFormValues fetches the pages for the Shipment Summary Worksheet for a given Shipment ID
@@ -37,14 +38,12 @@ type ShipmentSummaryWorksheetPage1Values struct {
 	DODId                        string
 	ServiceBranch                string
 	Rank                         string
-	OrdersNumber                 string
-	IssuingAgency                string
-	OrderIssueDate               time.Time
-	OrdersType                   internalmessages.OrdersType
+	IssuingBranchOrAgency        string
+	OrdersIssueDate              string
+	OrdersTypeAndOrdersNumber    string
 	DutyStationID                uuid.UUID
 	AuthorizedOrigin             DutyStation
-	NewDutyStationID             uuid.UUID
-	AuthorizedDestination        DutyStation
+	NewDutyAssignment            string
 	WeightAllotmentSelf          string
 	WeightAllotmentProgear       string
 	WeightAllotmentProgearSpouse string
@@ -113,14 +112,13 @@ func FormatValuesShipmentSummaryWorksheetFormPage1(data ShipmentSummaryFormData)
 	page1.ServiceBranch = derefStringTypes(sm.Affiliation)
 	page1.Rank = derefStringTypes(sm.Rank)
 
-	o := data.Order
-	page1.OrdersNumber = derefStringTypes(o.OrdersNumber)
-	page1.IssuingAgency = derefStringTypes(o.OrdersIssuingAgency)
-	page1.OrderIssueDate = o.IssueDate
-	page1.OrdersType = o.OrdersType
+	page1.IssuingBranchOrAgency = FormatIssuingBranchOrAgency(data.Order)
+	page1.OrdersIssueDate = FormatOrdersIssueDate(data.Order)
+	page1.OrdersTypeAndOrdersNumber = FormatOrdersTypeAndOrdersNumber(data.Order)
 
 	page1.AuthorizedOrigin = data.CurrentDutyStation
-	page1.AuthorizedDestination = data.NewDutyStation
+	page1.NewDutyAssignment = FormatDutyStation(data.NewDutyStation)
+
 	page1.WeightAllotmentSelf = FormatWeights(data.WeightAllotment.TotalWeightSelf)
 	page1.WeightAllotmentProgear = FormatWeights(data.WeightAllotment.ProGearWeight)
 	page1.WeightAllotmentProgearSpouse = FormatWeights(data.WeightAllotment.ProGearWeightSpouse)
@@ -129,6 +127,46 @@ func FormatValuesShipmentSummaryWorksheetFormPage1(data ShipmentSummaryFormData)
 		data.WeightAllotment.ProGearWeightSpouse
 	page1.TotalWeightAllotment = FormatWeights(total)
 	return page1
+}
+
+//FormatDutyStation formats DutyStation for Shipment Summary Worksheet
+func FormatDutyStation(dutyStation DutyStation) string {
+	//TODO confirm how we want to handle short names e.g. Fort -> Ft.
+	newDutyStationShortName := strings.Replace(dutyStation.Name, "Fort", "Ft.", 1)
+	return fmt.Sprintf("%s, %s", newDutyStationShortName, dutyStation.Address.State)
+}
+
+//FormatOrdersIssueDate formats Order.IssueDate for Shipment Summary Worksheet
+func FormatOrdersIssueDate(order Order) string {
+	dateLayout := "2-Jan-2006"
+	return order.IssueDate.Format(dateLayout)
+}
+
+//FormatOrdersTypeAndOrdersNumber formats OrdersTypeAndOrdersNumber for Shipment Summary Worksheet
+func FormatOrdersTypeAndOrdersNumber(order Order) string {
+	issuingBranch := FormatOrdersType(order)
+	ordersNumber := derefStringTypes(order.OrdersNumber)
+	return fmt.Sprintf("%s/%s", issuingBranch, ordersNumber)
+}
+
+//FormatIssuingBranchOrAgency formats OrdersIssuingAgency for Shipment Summary Worksheet
+func FormatIssuingBranchOrAgency(order Order) string {
+	if order.OrdersIssuingAgency != nil {
+		words := strings.Split(strings.ToLower(*order.OrdersIssuingAgency), "_")
+		return strings.Title(strings.Join(words, " "))
+	}
+	return ""
+}
+
+//FormatOrdersType formats OrdersType for Shipment Summary Worksheet
+func FormatOrdersType(order Order) string {
+	switch order.OrdersType {
+	case internalmessages.OrdersTypePERMANENTCHANGEOFSTATION:
+		return "PCS"
+		// TODO determine what abbr are for other order types
+	default:
+		return "?"
+	}
 }
 
 //FormatWeights formats an int using 000s separator

--- a/pkg/models/shipment_summary_worksheet.go
+++ b/pkg/models/shipment_summary_worksheet.go
@@ -165,7 +165,7 @@ func FormatOrdersType(order Order) string {
 		return "PCS"
 		// TODO determine what abbr are for other order types
 	default:
-		return "?"
+		return ""
 	}
 }
 

--- a/pkg/models/shipment_summary_worksheet_test.go
+++ b/pkg/models/shipment_summary_worksheet_test.go
@@ -161,10 +161,11 @@ func (suite *ModelSuite) TestFormatOrdersIssueDate() {
 
 func (suite *ModelSuite) TestFormatOrdersType() {
 	pcsOrder := models.Order{OrdersType: internalmessages.OrdersTypePERMANENTCHANGEOFSTATION}
-	localMoveOrder := models.Order{OrdersType: internalmessages.OrdersTypeLOCALMOVE}
+	var unknownOrdersType internalmessages.OrdersType = "UNKNOWN_ORDERS_TYPE"
+	localMoveOrder := models.Order{OrdersType: unknownOrdersType}
 
 	suite.Equal("PCS", models.FormatOrdersType(pcsOrder))
-	suite.Equal("?", models.FormatOrdersType(localMoveOrder))
+	suite.Equal("", models.FormatOrdersType(localMoveOrder))
 }
 
 func (suite *ModelSuite) TestFormatIssuingBranchOrAgency() {

--- a/pkg/models/shipment_summary_worksheet_test.go
+++ b/pkg/models/shipment_summary_worksheet_test.go
@@ -117,20 +117,16 @@ func (suite *ModelSuite) TestFormatValuesShipmentSummaryWorksheetFormPage1() {
 	suite.Equal(string(serviceBranch), sswPage1.ServiceBranch)
 	suite.Equal(string(rank), sswPage1.Rank)
 
-	suite.Equal("012345", sswPage1.OrdersNumber)
-	suite.Equal(string(serviceBranch), sswPage1.IssuingAgency)
-	suite.True(orderIssueDate.Equal(sswPage1.OrderIssueDate))
-	suite.Equal(internalmessages.OrdersTypePERMANENTCHANGEOFSTATION, sswPage1.OrdersType)
+	suite.Equal("Air Force", sswPage1.IssuingBranchOrAgency)
+	suite.Equal("21-Dec-2018", sswPage1.OrdersIssueDate)
+	suite.Equal("PCS/012345", sswPage1.OrdersTypeAndOrdersNumber)
 
 	suite.Equal(fortBragg.ID, sswPage1.AuthorizedOrigin.ID)
 	suite.Equal(fortBragg.Address.State, sswPage1.AuthorizedOrigin.Address.State)
 	suite.Equal(fortBragg.Address.City, sswPage1.AuthorizedOrigin.Address.City)
 	suite.Equal(fortBragg.Address.PostalCode, sswPage1.AuthorizedOrigin.Address.PostalCode)
 
-	suite.Equal(fortBenning.ID, sswPage1.AuthorizedDestination.ID)
-	suite.Equal(fortBenning.Address.State, sswPage1.AuthorizedDestination.Address.State)
-	suite.Equal(fortBenning.Address.City, sswPage1.AuthorizedDestination.Address.City)
-	suite.Equal(fortBenning.Address.PostalCode, sswPage1.AuthorizedDestination.Address.PostalCode)
+	suite.Equal("Ft. Benning, GA", sswPage1.NewDutyAssignment)
 
 	suite.Equal("13,000", sswPage1.WeightAllotmentSelf)
 	suite.Equal("2,000", sswPage1.WeightAllotmentProgear)
@@ -143,4 +139,40 @@ func (suite *ModelSuite) TestFormatWeights() {
 	suite.Equal("10", models.FormatWeights(10))
 	suite.Equal("1,000", models.FormatWeights(1000))
 	suite.Equal("1,000,000", models.FormatWeights(1000000))
+}
+
+func (suite *ModelSuite) TestFormatDutyStation() {
+	fortBenning := models.DutyStation{Name: "Fort Benning", Address: models.Address{State: "GA"}}
+	yuma := models.DutyStation{Name: "Yuma AFB", Address: models.Address{State: "AZ"}}
+
+	suite.Equal("Ft. Benning, GA", models.FormatDutyStation(fortBenning))
+	suite.Equal("Yuma AFB, AZ", models.FormatDutyStation(yuma))
+}
+
+func (suite *ModelSuite) TestFormatOrdersIssueDate() {
+	orderIssueDate1 := time.Date(2018, time.December, 21, 0, 0, 0, 0, time.UTC)
+	dec212018 := models.Order{IssueDate: orderIssueDate1}
+	orderIssueDate2 := time.Date(2019, time.January, 1, 0, 0, 0, 0, time.UTC)
+	jan012019 := models.Order{IssueDate: orderIssueDate2}
+
+	suite.Equal("21-Dec-2018", models.FormatOrdersIssueDate(dec212018))
+	suite.Equal("1-Jan-2019", models.FormatOrdersIssueDate(jan012019))
+}
+
+func (suite *ModelSuite) TestFormatOrdersType() {
+	pcsOrder := models.Order{OrdersType: internalmessages.OrdersTypePERMANENTCHANGEOFSTATION}
+	localMoveOrder := models.Order{OrdersType: internalmessages.OrdersTypeLOCALMOVE}
+
+	suite.Equal("PCS", models.FormatOrdersType(pcsOrder))
+	suite.Equal("?", models.FormatOrdersType(localMoveOrder))
+}
+
+func (suite *ModelSuite) TestFormatIssuingBranchOrAgency() {
+	airForce := models.Order{OrdersIssuingAgency: models.StringPointer("AIR_FORCE")}
+	other := models.Order{OrdersIssuingAgency: models.StringPointer("OTHER")}
+	missing := models.Order{OrdersIssuingAgency: nil}
+
+	suite.Equal("Air Force", models.FormatIssuingBranchOrAgency(airForce))
+	suite.Equal("Other", models.FormatIssuingBranchOrAgency(other))
+	suite.Equal("", models.FormatIssuingBranchOrAgency(missing))
 }

--- a/pkg/models/shipment_summary_worksheet_test.go
+++ b/pkg/models/shipment_summary_worksheet_test.go
@@ -126,7 +126,7 @@ func (suite *ModelSuite) TestFormatValuesShipmentSummaryWorksheetFormPage1() {
 	suite.Equal(fortBragg.Address.City, sswPage1.AuthorizedOrigin.Address.City)
 	suite.Equal(fortBragg.Address.PostalCode, sswPage1.AuthorizedOrigin.Address.PostalCode)
 
-	suite.Equal("Ft. Benning, GA", sswPage1.NewDutyAssignment)
+	suite.Equal("Fort Benning, GA", sswPage1.NewDutyAssignment)
 
 	suite.Equal("13,000", sswPage1.WeightAllotmentSelf)
 	suite.Equal("2,000", sswPage1.WeightAllotmentProgear)
@@ -145,7 +145,7 @@ func (suite *ModelSuite) TestFormatDutyStation() {
 	fortBenning := models.DutyStation{Name: "Fort Benning", Address: models.Address{State: "GA"}}
 	yuma := models.DutyStation{Name: "Yuma AFB", Address: models.Address{State: "AZ"}}
 
-	suite.Equal("Ft. Benning, GA", models.FormatDutyStation(fortBenning))
+	suite.Equal("Fort Benning, GA", models.FormatDutyStation(fortBenning))
 	suite.Equal("Yuma AFB, AZ", models.FormatDutyStation(yuma))
 }
 

--- a/pkg/models/shipment_summary_worksheet_test.go
+++ b/pkg/models/shipment_summary_worksheet_test.go
@@ -114,7 +114,6 @@ func (suite *ModelSuite) TestFormatValuesShipmentSummaryWorksheetFormPage1() {
 	suite.Equal("444-555-8888", sswPage1.PreferredPhone)
 	suite.Equal("michael+ppm-expansion_1@truss.works", sswPage1.PreferredEmail)
 	suite.Equal("1234567890", sswPage1.DODId)
-	suite.Equal(string(serviceBranch), sswPage1.ServiceBranch)
 	suite.Equal(string(rank), sswPage1.Rank)
 
 	suite.Equal("Air Force", sswPage1.IssuingBranchOrAgency)
@@ -168,12 +167,10 @@ func (suite *ModelSuite) TestFormatOrdersType() {
 	suite.Equal("", models.FormatOrdersType(localMoveOrder))
 }
 
-func (suite *ModelSuite) TestFormatIssuingBranchOrAgency() {
-	airForce := models.Order{OrdersIssuingAgency: models.StringPointer("AIR_FORCE")}
-	other := models.Order{OrdersIssuingAgency: models.StringPointer("OTHER")}
-	missing := models.Order{OrdersIssuingAgency: nil}
+func (suite *ModelSuite) TestFormatServiceMemberAffilation() {
+	airForce := models.AffiliationAIRFORCE
+	marines := models.AffiliationMARINES
 
-	suite.Equal("Air Force", models.FormatIssuingBranchOrAgency(airForce))
-	suite.Equal("Other", models.FormatIssuingBranchOrAgency(other))
-	suite.Equal("", models.FormatIssuingBranchOrAgency(missing))
+	suite.Equal("Air Force", models.FormatServiceMemberAffiliation(&airForce))
+	suite.Equal("Marines", models.FormatServiceMemberAffiliation(&marines))
 }

--- a/pkg/paperwork/shipment_summary_worksheet.go
+++ b/pkg/paperwork/shipment_summary_worksheet.go
@@ -13,6 +13,10 @@ var ShipmentSummaryPage1Layout = FormLayout{
 		"WeightAllotmentProgearSpouse": FormField(74, 115, 16, floatPtr(10), nil),
 		"TotalWeightAllotment":         FormField(74, 120, 16, floatPtr(10), nil),
 		"POVAuthorized":                FormField(103, 115, 45, floatPtr(10), nil),
+		"OrdersIssueDate":              FormField(10, 85, 40, floatPtr(10), nil),
+		"OrdersTypeAndOrdersNumber":    FormField(54, 85, 44, floatPtr(10), nil),
+		"IssuingBranchOrAgency":        FormField(103, 85, 47, floatPtr(10), nil),
+		"NewDutyAssignment":            FormField(154, 85, 60, floatPtr(10), nil),
 	},
 }
 


### PR DESCRIPTION
## Description

Populates values for "Orders/Accounting information" in Shipment Summary Worksheet

## Setup
```sh
make server_test
```

Generate a sample pdf using test data: 
```
make db_populate_e2e
go run cmd/generate_shipment_summary/main.go  -move <uuid> -debug
```

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/n/projects/2181745/stories/162898094) 