### PR TITLE
Revert "Update aws scripts to use new arn format"

### DIFF
--- a/bin/ecs-run-app-migrations-container
+++ b/bin/ecs-run-app-migrations-container
@@ -32,7 +32,7 @@ check_arn() {
 show_logs() {
     local arn=$1
     local task_id
-    task_id=$(echo "$arn" | grep -Eo ':task/([[:alnum:]-]+)/([[:alnum:]-]+)$' | cut -d / -f 3)
+    task_id=$(echo "$arn" | grep -Eo ':task/([[:alnum:]-]+)$' | cut -d / -f 2)
     echo
     echo "Attempting to get CloudWatch logs for ${arn}:"
     aws logs get-log-events --log-group-name "ecs-tasks-$cluster" --log-stream-name "$log_prefix/$container_name/$task_id" --query 'events[].message' || true

--- a/bin/ecs-show-service-logs
+++ b/bin/ecs-show-service-logs
@@ -25,7 +25,7 @@ for task_arn in $(aws ecs list-tasks --cluster "$cluster" --service-name "$name"
     [[ -z $task_arn ]] && { echo "Missing task ARN"; exit 1; }
 
     # Parse out the task ID
-    task_id=$(echo "$task_arn" | perl -ne 'm|^arn:aws:ecs:([^:]+:){2}task/([\S]+)/([\S]+)|; print "$3\n";')
+    task_id=$(echo "$task_arn" | perl -ne 'm|^arn:aws:ecs:([^:]+:){2}task/([\S]+)|; print "$2\n";')
     [[ -z $task_id ]] && { echo "Couldn't parse task ID: $task_arn"; exit 1; }
 
     # Display logs for this task

--- a/bin/ecs-show-service-stopped-logs
+++ b/bin/ecs-show-service-stopped-logs
@@ -22,7 +22,7 @@ readonly container=$name-$environment
 readonly log_group_name=ecs-tasks-$name-$environment
 
 # Get list of recently stopped tasks
-for task_id in $(aws ecs describe-services --cluster "$cluster" --services "$name" --query 'services[].events[].message' | grep stopped | grep -o 'task [0-9a-f-]*' | cut -f 3 -d ' '); do
+for task_id in $(aws ecs describe-services --cluster "$cluster" --services "$name" --query 'services[].events[].message' | grep stopped | grep -o 'task [0-9a-f-]*' | cut -f 2 -d ' '); do
     [[ -z $task_id ]] && { echo "Missing task ID"; exit 1; }
 
     # Display logs for this task


### PR DESCRIPTION
Reverts transcom/mymove#1621

Found this note hidden in the [Transition to new ARN and ID format](https://aws.amazon.com/ecs/faqs/#Transition_to_new_ARN_and_ID_format) doc: 

```text
Note: Tasks launched by an Amazon ECS Service can only receive the new ARN and resource ID format if the service was created on or after November 16th, 2018 and the user or role who created the service was opted in for the new format for tasks at the task launch time.
```

Our tasks were all created before that date.  This puts us in a weird position for next year on 12-31-2019.