### PR TITLE
Print out the arn before trying to parse it for the task_id. Use the cluster name because it appears to be coming back from api calls now

### DIFF
--- a/bin/ecs-run-app-migrations-container
+++ b/bin/ecs-run-app-migrations-container
@@ -32,9 +32,10 @@ check_arn() {
 show_logs() {
     local arn=$1
     local task_id
-    task_id=$(echo "$arn" | grep -Eo ':task/([[:alnum:]-]+)$' | cut -d / -f 2)
-    echo
     echo "Attempting to get CloudWatch logs for ${arn}:"
+    task_id=$(echo "${arn}" | grep -Eo ":task/${cluster}/([[:alnum:]-]+)$" | cut -d / -f 3)
+    echo "Found task_id ${task_id} for cluster ${cluster}"
+    echo
     aws logs get-log-events --log-group-name "ecs-tasks-$cluster" --log-stream-name "$log_prefix/$container_name/$task_id" --query 'events[].message' || true
     echo
 }


### PR DESCRIPTION
## Description

This change prints out the arn before we parse it which should allow us to do some debugging if the grep command is the issue here.  Also, debugging on my own machine shows that the cluster name is coming back from the api calls.  Going to include it here and see what we get when we deploy.