### PR TITLE
reduce top margin in invoice panel for .invoice-panel-header-cont

### DIFF
--- a/src/shared/Invoice/InvoicePanel.css
+++ b/src/shared/Invoice/InvoicePanel.css
@@ -75,7 +75,7 @@
 }
 
 .invoice-panel-header-cont {
-  margin-top: 2em;
+  margin-top: .2em;
   display: flex;
   align-items: center;
 }


### PR DESCRIPTION
## Description

There was too much top padding in the invoice panel above the Invoice Approved message. This reduced the margin-top from 2em to .2em.

This affects the invoice view in both TSP and Office.

Ran the padding results by Kim Ladin and got an approval.

* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/163407239) for this change

## Screenshots
### Old padding
![image](https://user-images.githubusercontent.com/3099491/51639371-5c57ff80-1f26-11e9-883f-b7ffb6d65a58.png)

### New padding
![screen shot 2019-01-23 at 3 47 44 pm](https://user-images.githubusercontent.com/3099491/51639386-611cb380-1f26-11e9-8733-e43e983f97ec.png)

