### PR TITLE
Stop saving GBLs in local app directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,7 +309,6 @@ The test DB commands all talk to the DB over localhost.  But in a docker-only en
 * `make db_test_create_docker`
 * `make db_test_reset_docker`
 * `make db_test_migrate_docker`
-* `make db_test_e2e_populate_docker`
 
 #### Migrations
 

--- a/cmd/generate_test_data/main.go
+++ b/cmd/generate_test_data/main.go
@@ -24,7 +24,7 @@ func main() {
 	flag.Parse()
 
 	//DB connection
-	err = pop.AddLookupPaths(*config)
+	err := pop.AddLookupPaths(*config)
 	if err != nil {
 		log.Panic(err)
 	}
@@ -75,6 +75,9 @@ func main() {
 	} else if *namedScenario == tdgs.E2eBasicScenario.Name {
 		// Initialize logger
 		logger, err := zap.NewDevelopment()
+		if err != nil {
+			log.Panic(err)
+		}
 
 		// Initialize storage and uploader
 		zap.L().Info("Using memory storage backend")

--- a/cmd/generate_test_data/main.go
+++ b/cmd/generate_test_data/main.go
@@ -23,8 +23,6 @@ func main() {
 	namedScenario := flag.String("named-scenario", "", "It's like a scenario, but more descriptive.")
 	flag.Parse()
 
-	logger, err := zap.NewDevelopment()
-
 	//DB connection
 	err = pop.AddLookupPaths(*config)
 	if err != nil {
@@ -34,12 +32,6 @@ func main() {
 	if err != nil {
 		log.Panic(err)
 	}
-
-	// Initialize storage and uploader
-	zap.L().Info("Using filesystem storage backend")
-	fsParams := storage.NewFilesystemParams("tmp", "testdata", logger)
-	storer := storage.NewFilesystem(fsParams)
-	loader := uploader.NewUploader(db, logger, storer)
 
 	if *scenario == 1 {
 		tdgs.RunAwardQueueScenario1(db)
@@ -81,6 +73,15 @@ func main() {
 		testdatagen.MakeDefaultOfficeUser(db)
 		log.Print("Success! Created TSP test data.")
 	} else if *namedScenario == tdgs.E2eBasicScenario.Name {
+		// Initialize logger
+		logger, err := zap.NewDevelopment()
+
+		// Initialize storage and uploader
+		zap.L().Info("Using memory storage backend")
+		fsParams := storage.NewMemoryParams("tmp", "testdata", logger)
+		storer := storage.NewMemory(fsParams)
+		loader := uploader.NewUploader(db, logger, storer)
+
 		tdgs.E2eBasicScenario.Run(db, loader, logger, storer)
 		log.Print("Success! Created e2e test data.")
 	} else {

--- a/cmd/generate_test_data/main.go
+++ b/cmd/generate_test_data/main.go
@@ -37,7 +37,7 @@ func main() {
 
 	// Initialize storage and uploader
 	zap.L().Info("Using filesystem storage backend")
-	fsParams := storage.NewFilesystemParams("tmp", "storage", logger)
+	fsParams := storage.NewFilesystemParams("tmp", "testdata", logger)
 	storer := storage.NewFilesystem(fsParams)
 	loader := uploader.NewUploader(db, logger, storer)
 

--- a/pkg/edi/invoice/generator_test.go
+++ b/pkg/edi/invoice/generator_test.go
@@ -3,13 +3,13 @@ package ediinvoice_test
 import (
 	"fmt"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/go-openapi/swag"
+	"github.com/spf13/afero"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 	"github.com/transcom/mymove/pkg/handlers"
@@ -153,7 +153,9 @@ func (suite *InvoiceSuite) TestEDIString() {
 		// Borrowed from https://about.sourcegraph.com/go/advanced-testing-in-go
 		update := suite.Viper.GetBool("update")
 		if update {
-			goldenFile, err := os.Create(filepath.Join("testdata", expectedEDI))
+			// Write to a temporary file system
+			fs := afero.NewMemMapFs()
+			goldenFile, err := fs.Create(filepath.Join("testdata", expectedEDI))
 			defer goldenFile.Close()
 			suite.NoError(err, "Failed to open EDI file for update")
 			writer := edi.NewWriter(goldenFile)

--- a/pkg/handlers/internalapi/uploads.go
+++ b/pkg/handlers/internalapi/uploads.go
@@ -69,8 +69,8 @@ func (h CreateUploadHandler) Handle(params uploadop.CreateUploadParams) middlewa
 		docID = &document.ID
 	}
 
-	// Read the incoming data into a new afero.File for consumption
-	aFile, err := h.FileStorer().Create(file.Header.Filename)
+	// Read the incoming data into a temporary afero.File for consumption
+	aFile, err := h.FileStorer().TempFileSystem().Create(file.Header.Filename)
 	if err != nil {
 		h.Logger().Error("Error opening afero file.", zap.Error(err))
 		return uploadop.NewCreateUploadInternalServerError()

--- a/pkg/handlers/internalapi/uploads.go
+++ b/pkg/handlers/internalapi/uploads.go
@@ -70,7 +70,7 @@ func (h CreateUploadHandler) Handle(params uploadop.CreateUploadParams) middlewa
 	}
 
 	// Read the incoming data into a new afero.File for consumption
-	aFile, err := h.FileStorer().FileSystem().Create(file.Header.Filename)
+	aFile, err := h.FileStorer().Create(file.Header.Filename)
 	if err != nil {
 		h.Logger().Error("Error opening afero file.", zap.Error(err))
 		return uploadop.NewCreateUploadInternalServerError()

--- a/pkg/handlers/publicapi/shipments.go
+++ b/pkg/handlers/publicapi/shipments.go
@@ -630,7 +630,7 @@ func (h CreateGovBillOfLadingHandler) Handle(params shipmentop.CreateGovBillOfLa
 		return shipmentop.NewCreateGovBillOfLadingInternalServerError()
 	}
 
-	aFile, err := h.FileStorer().FileSystem().Create(gbl.GBLNumber1)
+	aFile, err := h.FileStorer().Create(gbl.GBLNumber1)
 	if err != nil {
 		h.Logger().Error("Error creating a new afero file for GBL form.", zap.Error(err))
 		return shipmentop.NewCreateGovBillOfLadingInternalServerError()

--- a/pkg/handlers/publicapi/shipments.go
+++ b/pkg/handlers/publicapi/shipments.go
@@ -630,7 +630,8 @@ func (h CreateGovBillOfLadingHandler) Handle(params shipmentop.CreateGovBillOfLa
 		return shipmentop.NewCreateGovBillOfLadingInternalServerError()
 	}
 
-	aFile, err := h.FileStorer().Create(gbl.GBLNumber1)
+	// Read the incoming data into a temporary afero.File for consumption
+	aFile, err := h.FileStorer().TempFileSystem().Create(gbl.GBLNumber1)
 	if err != nil {
 		h.Logger().Error("Error creating a new afero file for GBL form.", zap.Error(err))
 		return shipmentop.NewCreateGovBillOfLadingInternalServerError()

--- a/pkg/storage/filesystem.go
+++ b/pkg/storage/filesystem.go
@@ -50,7 +50,7 @@ func NewFilesystemParams(localStorageRoot string, localStorageWebRoot string, lo
 // NewFilesystem creates a new Filesystem struct using the provided FilesystemParams
 func NewFilesystem(params FilesystemParams) *Filesystem {
 	var fs = afero.NewOsFs()
-	var tempFs = afero.NewOsFs()
+	var tempFs = afero.NewMemMapFs()
 
 	return &Filesystem{
 		root:    params.root,

--- a/pkg/storage/filesystem.go
+++ b/pkg/storage/filesystem.go
@@ -21,6 +21,7 @@ type Filesystem struct {
 	webRoot string
 	logger  *zap.Logger
 	fs      *afero.Afero
+	tempFs  *afero.Afero
 }
 
 // FilesystemParams contains parameter for instantiating a Filesystem storage backend
@@ -49,12 +50,14 @@ func NewFilesystemParams(localStorageRoot string, localStorageWebRoot string, lo
 // NewFilesystem creates a new Filesystem struct using the provided FilesystemParams
 func NewFilesystem(params FilesystemParams) *Filesystem {
 	var fs = afero.NewOsFs()
+	var tempFs = afero.NewOsFs()
 
 	return &Filesystem{
 		root:    params.root,
 		webRoot: params.webRoot,
 		logger:  params.logger,
 		fs:      &afero.Afero{Fs: fs},
+		tempFs:  &afero.Afero{Fs: tempFs},
 	}
 }
 
@@ -134,6 +137,11 @@ func (fs *Filesystem) Fetch(key string) (io.ReadCloser, error) {
 // FileSystem returns the underlying afero filesystem
 func (fs *Filesystem) FileSystem() *afero.Afero {
 	return fs.fs
+}
+
+// TempFileSystem returns the temporary afero filesystem
+func (fs *Filesystem) TempFileSystem() *afero.Afero {
+	return fs.tempFs
 }
 
 // NewFilesystemHandler returns an Handler that adds a Content-Type header so that

--- a/pkg/storage/filesystem.go
+++ b/pkg/storage/filesystem.go
@@ -58,6 +58,28 @@ func NewFilesystem(params FilesystemParams) *Filesystem {
 	}
 }
 
+// Create makes a new file with no content at the specified key.
+func (fs *Filesystem) Create(key string) (afero.File, error) {
+	if key == "" {
+		return nil, errors.New("A valid file name must be set before a file can be created")
+	}
+
+	joined := filepath.Join(fs.root, key)
+	dir := filepath.Dir(joined)
+
+	err := fs.fs.MkdirAll(dir, 0755)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not create parent directory")
+	}
+
+	file, err := fs.fs.Create(joined)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not open file")
+	}
+
+	return file, err
+}
+
 // Store stores the content from an io.ReadSeeker at the specified key.
 func (fs *Filesystem) Store(key string, data io.ReadSeeker, checksum string) (*StoreResult, error) {
 	if key == "" {

--- a/pkg/storage/filesystem.go
+++ b/pkg/storage/filesystem.go
@@ -61,28 +61,6 @@ func NewFilesystem(params FilesystemParams) *Filesystem {
 	}
 }
 
-// Create makes a new file with no content at the specified key.
-func (fs *Filesystem) Create(key string) (afero.File, error) {
-	if key == "" {
-		return nil, errors.New("A valid file name must be set before a file can be created")
-	}
-
-	joined := filepath.Join(fs.root, key)
-	dir := filepath.Dir(joined)
-
-	err := fs.fs.MkdirAll(dir, 0755)
-	if err != nil {
-		return nil, errors.Wrap(err, "could not create parent directory")
-	}
-
-	file, err := fs.fs.Create(joined)
-	if err != nil {
-		return nil, errors.Wrap(err, "could not open file")
-	}
-
-	return file, err
-}
-
 // Store stores the content from an io.ReadSeeker at the specified key.
 func (fs *Filesystem) Store(key string, data io.ReadSeeker, checksum string) (*StoreResult, error) {
 	if key == "" {

--- a/pkg/storage/memory.go
+++ b/pkg/storage/memory.go
@@ -61,28 +61,6 @@ func NewMemory(params MemoryParams) *Memory {
 	}
 }
 
-// Create makes a new file with no content at the specified key.
-func (fs *Memory) Create(key string) (afero.File, error) {
-	if key == "" {
-		return nil, errors.New("A valid file name must be set before a file can be created")
-	}
-
-	joined := filepath.Join(fs.root, key)
-	dir := filepath.Dir(joined)
-
-	err := fs.fs.MkdirAll(dir, 0755)
-	if err != nil {
-		return nil, errors.Wrap(err, "could not create parent directory")
-	}
-
-	file, err := fs.fs.Create(joined)
-	if err != nil {
-		return nil, errors.Wrap(err, "could not open file")
-	}
-
-	return file, err
-}
-
 // Store stores the content from an io.ReadSeeker at the specified key.
 func (fs *Memory) Store(key string, data io.ReadSeeker, checksum string) (*StoreResult, error) {
 	if key == "" {

--- a/pkg/storage/memory.go
+++ b/pkg/storage/memory.go
@@ -50,7 +50,7 @@ func NewMemoryParams(localStorageRoot string, localStorageWebRoot string, logger
 // NewMemory creates a new Memory struct using the provided MemoryParams
 func NewMemory(params MemoryParams) *Memory {
 	var fs = afero.NewMemMapFs()
-	var tempFs = afero.NewOsFs()
+	var tempFs = afero.NewMemMapFs()
 
 	return &Memory{
 		root:    params.root,

--- a/pkg/storage/memory.go
+++ b/pkg/storage/memory.go
@@ -21,6 +21,7 @@ type Memory struct {
 	webRoot string
 	logger  *zap.Logger
 	fs      *afero.Afero
+	tempFs  *afero.Afero
 }
 
 // MemoryParams contains parameter for instantiating a Memory storage backend
@@ -49,12 +50,14 @@ func NewMemoryParams(localStorageRoot string, localStorageWebRoot string, logger
 // NewMemory creates a new Memory struct using the provided MemoryParams
 func NewMemory(params MemoryParams) *Memory {
 	var fs = afero.NewMemMapFs()
+	var tempFs = afero.NewOsFs()
 
 	return &Memory{
 		root:    params.root,
 		webRoot: params.webRoot,
 		logger:  params.logger,
 		fs:      &afero.Afero{Fs: fs},
+		tempFs:  &afero.Afero{Fs: tempFs},
 	}
 }
 
@@ -134,6 +137,11 @@ func (fs *Memory) Fetch(key string) (io.ReadCloser, error) {
 // FileSystem returns the underlying afero filesystem
 func (fs *Memory) FileSystem() *afero.Afero {
 	return fs.fs
+}
+
+// TempFileSystem returns the temporary afero filesystem
+func (fs *Memory) TempFileSystem() *afero.Afero {
+	return fs.tempFs
 }
 
 // NewMemoryHandler returns an Handler that adds a Content-Type header so that

--- a/pkg/storage/memory.go
+++ b/pkg/storage/memory.go
@@ -58,6 +58,28 @@ func NewMemory(params MemoryParams) *Memory {
 	}
 }
 
+// Create makes a new file with no content at the specified key.
+func (fs *Memory) Create(key string) (afero.File, error) {
+	if key == "" {
+		return nil, errors.New("A valid file name must be set before a file can be created")
+	}
+
+	joined := filepath.Join(fs.root, key)
+	dir := filepath.Dir(joined)
+
+	err := fs.fs.MkdirAll(dir, 0755)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not create parent directory")
+	}
+
+	file, err := fs.fs.Create(joined)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not open file")
+	}
+
+	return file, err
+}
+
 // Store stores the content from an io.ReadSeeker at the specified key.
 func (fs *Memory) Store(key string, data io.ReadSeeker, checksum string) (*StoreResult, error) {
 	if key == "" {

--- a/pkg/storage/s3.go
+++ b/pkg/storage/s3.go
@@ -3,7 +3,6 @@ package storage
 import (
 	"io"
 	"path"
-	"path/filepath"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/session"

--- a/pkg/storage/s3.go
+++ b/pkg/storage/s3.go
@@ -38,29 +38,6 @@ func NewS3(bucket string, keyNamespace string, logger *zap.Logger, session *sess
 	}
 }
 
-// Create makes a new file with no content at the specified key.
-func (s *S3) Create(key string) (afero.File, error) {
-	if key == "" {
-		return nil, errors.New("A valid file name must be set before a file can be created")
-	}
-
-	namespacedKey := path.Join(s.keyNamespace, key)
-	joined := path.Join(s.bucket, namespacedKey)
-	dir := filepath.Dir(joined)
-
-	err := s.tempFs.MkdirAll(dir, 0755)
-	if err != nil {
-		return nil, errors.Wrap(err, "could not create parent directory")
-	}
-
-	file, err := s.tempFs.Create(joined)
-	if err != nil {
-		return nil, errors.Wrap(err, "could not open file")
-	}
-
-	return file, err
-}
-
 // Store stores the content from an io.ReadSeeker at the specified key.
 func (s *S3) Store(key string, data io.ReadSeeker, checksum string) (*StoreResult, error) {
 	if key == "" {

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -20,6 +20,7 @@ type StoreResult struct{}
 
 // FileStorer is the set of methods needed to store and retrieve objects.
 type FileStorer interface {
+	Create(string) (afero.File, error)
 	Store(string, io.ReadSeeker, string) (*StoreResult, error)
 	Fetch(string) (io.ReadCloser, error)
 	Delete(string) error

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -20,7 +20,6 @@ type StoreResult struct{}
 
 // FileStorer is the set of methods needed to store and retrieve objects.
 type FileStorer interface {
-	Create(string) (afero.File, error)
 	Store(string, io.ReadSeeker, string) (*StoreResult, error)
 	Fetch(string) (io.ReadCloser, error)
 	Delete(string) error

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -26,6 +26,7 @@ type FileStorer interface {
 	Delete(string) error
 	PresignedURL(string, string) (string, error)
 	FileSystem() *afero.Afero
+	TempFileSystem() *afero.Afero
 }
 
 // ComputeChecksum calculates the MD% checksum for the provided data. It expects that

--- a/pkg/storage/test/s3.go
+++ b/pkg/storage/test/s3.go
@@ -26,6 +26,20 @@ func (fake *FakeS3Storage) Delete(key string) error {
 	return f.Close()
 }
 
+// Create creates a file.
+func (fake *FakeS3Storage) Create(key string) (afero.File, error) {
+	if key == "" {
+		return nil, errors.New("A valid file name must be set before a file can be created")
+	}
+
+	file, err := fake.fs.Create(key)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not open file")
+	}
+
+	return file, err
+}
+
 // Store stores a file.
 func (fake *FakeS3Storage) Store(key string, data io.ReadSeeker, md5 string) (*storage.StoreResult, error) {
 	f, err := fake.fs.Create(key)

--- a/pkg/storage/test/s3.go
+++ b/pkg/storage/test/s3.go
@@ -27,20 +27,6 @@ func (fake *FakeS3Storage) Delete(key string) error {
 	return f.Close()
 }
 
-// Create creates a file.
-func (fake *FakeS3Storage) Create(key string) (afero.File, error) {
-	if key == "" {
-		return nil, errors.New("A valid file name must be set before a file can be created")
-	}
-
-	file, err := fake.fs.Create(key)
-	if err != nil {
-		return nil, errors.Wrap(err, "could not open file")
-	}
-
-	return file, err
-}
-
 // Store stores a file.
 func (fake *FakeS3Storage) Store(key string, data io.ReadSeeker, md5 string) (*storage.StoreResult, error) {
 	f, err := fake.fs.Create(key)

--- a/pkg/storage/test/s3.go
+++ b/pkg/storage/test/s3.go
@@ -14,6 +14,7 @@ import (
 type FakeS3Storage struct {
 	willSucceed bool
 	fs          *afero.Afero
+	tempFs      *afero.Afero
 }
 
 // Delete removes a file.
@@ -74,12 +75,19 @@ func (fake *FakeS3Storage) FileSystem() *afero.Afero {
 	return fake.fs
 }
 
+// TempFileSystem returns the underlying afero filesystem
+func (fake *FakeS3Storage) TempFileSystem() *afero.Afero {
+	return fake.tempFs
+}
+
 // NewFakeS3Storage creates a new FakeS3Storage for testing purposes.
 func NewFakeS3Storage(willSucceed bool) *FakeS3Storage {
 	var fs = afero.NewMemMapFs()
+	var tempFs = afero.NewMemMapFs()
 
 	return &FakeS3Storage{
 		willSucceed: willSucceed,
 		fs:          &afero.Afero{Fs: fs},
+		tempFs:      &afero.Afero{Fs: tempFs},
 	}
 }

--- a/pkg/testdatagen/scenario/e2ebasic.go
+++ b/pkg/testdatagen/scenario/e2ebasic.go
@@ -2455,7 +2455,7 @@ func MakeHhgWithGBL(db *pop.Connection, tspUser models.TspUser, logger *zap.Logg
 	formFiller := paperwork.NewFormFiller()
 	formFiller.AppendPage(f, formLayout.FieldsLayout, gbl)
 
-	aFile, _ := storer.FileSystem().Create(gbl.GBLNumber1)
+	aFile, _ := storer.Create(gbl.GBLNumber1)
 	formFiller.Output(aFile)
 
 	uploader := uploaderpkg.NewUploader(db, logger, storer)
@@ -2592,7 +2592,7 @@ func makeHhgReadyToInvoice(db *pop.Connection, tspUser models.TspUser, logger *z
 	formFiller := paperwork.NewFormFiller()
 	formFiller.AppendPage(f, formLayout.FieldsLayout, gbl)
 
-	aFile, _ := storer.FileSystem().Create(gbl.GBLNumber1)
+	aFile, _ := storer.Create(gbl.GBLNumber1)
 	formFiller.Output(aFile)
 
 	uploader := uploaderpkg.NewUploader(db, logger, storer)

--- a/pkg/testdatagen/scenario/e2ebasic.go
+++ b/pkg/testdatagen/scenario/e2ebasic.go
@@ -7,10 +7,10 @@ import (
 	"time"
 
 	"github.com/go-openapi/swag"
-	"go.uber.org/zap"
-
 	"github.com/gobuffalo/pop"
 	"github.com/gofrs/uuid"
+	"github.com/spf13/afero"
+	"go.uber.org/zap"
 
 	"github.com/transcom/mymove/pkg/assets"
 	"github.com/transcom/mymove/pkg/dates"
@@ -2455,7 +2455,9 @@ func MakeHhgWithGBL(db *pop.Connection, tspUser models.TspUser, logger *zap.Logg
 	formFiller := paperwork.NewFormFiller()
 	formFiller.AppendPage(f, formLayout.FieldsLayout, gbl)
 
-	aFile, _ := storer.Create(gbl.GBLNumber1)
+	// Write to a temporary file system
+	fs := afero.NewMemMapFs()
+	aFile, _ := fs.Create(gbl.GBLNumber1)
 	formFiller.Output(aFile)
 
 	uploader := uploaderpkg.NewUploader(db, logger, storer)
@@ -2592,7 +2594,9 @@ func makeHhgReadyToInvoice(db *pop.Connection, tspUser models.TspUser, logger *z
 	formFiller := paperwork.NewFormFiller()
 	formFiller.AppendPage(f, formLayout.FieldsLayout, gbl)
 
-	aFile, _ := storer.Create(gbl.GBLNumber1)
+	// Write to a temporary file system
+	fs := afero.NewMemMapFs()
+	aFile, _ := fs.Create(gbl.GBLNumber1)
 	formFiller.Output(aFile)
 
 	uploader := uploaderpkg.NewUploader(db, logger, storer)

--- a/pkg/testdatagen/scenario/e2ebasic.go
+++ b/pkg/testdatagen/scenario/e2ebasic.go
@@ -9,7 +9,6 @@ import (
 	"github.com/go-openapi/swag"
 	"github.com/gobuffalo/pop"
 	"github.com/gofrs/uuid"
-	"github.com/spf13/afero"
 	"go.uber.org/zap"
 
 	"github.com/transcom/mymove/pkg/assets"
@@ -2456,8 +2455,7 @@ func MakeHhgWithGBL(db *pop.Connection, tspUser models.TspUser, logger *zap.Logg
 	formFiller.AppendPage(f, formLayout.FieldsLayout, gbl)
 
 	// Write to a temporary file system
-	fs := afero.NewMemMapFs()
-	aFile, _ := fs.Create(gbl.GBLNumber1)
+	aFile, _ := storer.TempFileSystem().Create(gbl.GBLNumber1)
 	formFiller.Output(aFile)
 
 	uploader := uploaderpkg.NewUploader(db, logger, storer)
@@ -2595,8 +2593,7 @@ func makeHhgReadyToInvoice(db *pop.Connection, tspUser models.TspUser, logger *z
 	formFiller.AppendPage(f, formLayout.FieldsLayout, gbl)
 
 	// Write to a temporary file system
-	fs := afero.NewMemMapFs()
-	aFile, _ := fs.Create(gbl.GBLNumber1)
+	aFile, _ := storer.TempFileSystem().Create(gbl.GBLNumber1)
 	formFiller.Output(aFile)
 
 	uploader := uploaderpkg.NewUploader(db, logger, storer)

--- a/pkg/testdatagen/scenario/e2ebasic.go
+++ b/pkg/testdatagen/scenario/e2ebasic.go
@@ -50,7 +50,7 @@ var nowMinusFive = dates.NextValidMoveDate(nowTime.AddDate(0, 0, -5), cal)
 var nowMinusTen = dates.NextValidMoveDate(nowTime.AddDate(0, 0, -10), cal)
 
 // Run does that data load thing
-func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, logger *zap.Logger, storer *storage.Filesystem) {
+func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, logger *zap.Logger, storer *storage.Memory) {
 	/*
 	 * Basic user with tsp access
 	 */
@@ -2358,7 +2358,7 @@ func MakeHhgFromAwardedToAcceptedGBLReady(db *pop.Connection, tspUser models.Tsp
 }
 
 // MakeHhgWithGBL creates a scenario for an approved shipment with a GBL generated
-func MakeHhgWithGBL(db *pop.Connection, tspUser models.TspUser, logger *zap.Logger, storer *storage.Filesystem) models.Shipment {
+func MakeHhgWithGBL(db *pop.Connection, tspUser models.TspUser, logger *zap.Logger, storer *storage.Memory) models.Shipment {
 	/*
 	 * Service member with uploaded orders and an approved shipment to be accepted, able to generate GBL
 	 */
@@ -2475,7 +2475,7 @@ func MakeHhgWithGBL(db *pop.Connection, tspUser models.TspUser, logger *zap.Logg
 	return offer.Shipment
 }
 
-func makeHhgReadyToInvoice(db *pop.Connection, tspUser models.TspUser, logger *zap.Logger, storer *storage.Filesystem) models.Shipment {
+func makeHhgReadyToInvoice(db *pop.Connection, tspUser models.TspUser, logger *zap.Logger, storer *storage.Memory) models.Shipment {
 	/*
 	 * Service member with uploaded orders and a delivered shipment, able to generate GBL
 	 */


### PR DESCRIPTION
## Description

Before #1608 the storage structs all had an in-memory file system available as `FileStorer().FileSystem()`. What was weird about its usage is that instead of using `afero.NewOsFs()` we'd instead write out files directly using `os.MkdirAll()` and `os.Create()` and we used the memory store as a temp file system where we could drop data before uploading it.  #1608 changed this and used the `FileStorer().FileSystem()` directly instead of `os`, which mean any calls relying on temporary storage would now write out directly to the file system at the root of the application directory. Running e2e, client, or server tests would drop files like these:

```
LKNQ7000001
LKNQ7000002
QRED001234
top-secret.png
```

This PR adds a new `TempFileSystem()` method to all storage backends so we can be explicit about what we're doing with the files that are being created prior to upload.  Thus all calls to `FileStorer().FileSystem().Create()` were replaced with `FileStorer().TempFileSystem().Create()`. The only exception being PDF generation which requires we pass the original `FileStorer().FileSystem()`.

I've also transitioned the e2ebasic scenario to use an in-memory file storer.  This is essentially a no-op as it returns the code to the way it was before #1608.  It also prevents us filling out disk with a bunch of test files.

Finally, I modified one test to stop writing out a file to disk for `edi`. It now uses the afero in-memory store as well.

## Reviewer notes

The consequence to e2e testing is that the contents of files created by the `e2ebasic` scenario completely disappear after the test generation is finished.  This was happening in the past and no one noticed because we weren't actually testing the storage of PDFs (ie comparing that what we uploaded could be downloaded).  Also, it's `make server_test` which tests that PDFs are created with the correct data and number of pages.

Ultimately this PR doesn't change things for e2e tests but if we do ever want to test the content of PDFs then we'll want to set up a temporary S3 storage bucket for e2e tests.

## Setup

Try out both `make e2e_test` and `make e2e_test_docker`. Then try `make db_dev_e2e_populate` and  `make db_test_e2e_populate`.

Here's a specific test you can run if you want to see it work:

```
SPEC=./cypress/integration/tsp/invoicing.js make e2e_test_docker
```

or 

```
SPEC=cypress/integration/office/documentViewer.js make e2e_test_docker
```

Also try `make server_test`.

## Code Review Verification Steps

* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/n/projects/2181745/stories/163429128) for this change