### PR TITLE
Add POVAuthorized to SSW

### DIFF
--- a/pkg/models/shipment_summary_worksheet.go
+++ b/pkg/models/shipment_summary_worksheet.go
@@ -49,6 +49,7 @@ type ShipmentSummaryWorksheetPage1Values struct {
 	WeightAllotmentProgear       string
 	WeightAllotmentProgearSpouse string
 	TotalWeightAllotment         string
+	POVAuthorized                string
 }
 
 // ShipmentSummaryWorksheetPage2Values is an object representing a Shipment Summary Worksheet
@@ -96,6 +97,8 @@ func FetchDataShipmentSummaryWorksFormData(db *pop.Connection, moveID uuid.UUID)
 func FormatValuesShipmentSummaryWorksheetFormPage1(data ShipmentSummaryFormData) ShipmentSummaryWorksheetPage1Values {
 	page1 := ShipmentSummaryWorksheetPage1Values{}
 	page1.MaxSITStorageEntitlement = "90 days per each shipment"
+	// We don't currently know what allows POV to be authorized, so we are hardcoding it to "No" to start
+	page1.POVAuthorized = "NO"
 
 	sm := data.ServiceMember
 	lastName := derefStringTypes(sm.LastName)

--- a/pkg/models/shipment_summary_worksheet_test.go
+++ b/pkg/models/shipment_summary_worksheet_test.go
@@ -110,6 +110,7 @@ func (suite *ModelSuite) TestFormatValuesShipmentSummaryWorksheetFormPage1() {
 
 	suite.Equal("Jenkins Jr., Marcus Joseph", sswPage1.ServiceMemberName)
 	suite.Equal("90 days per each shipment", sswPage1.MaxSITStorageEntitlement)
+	suite.Equal("NO", sswPage1.POVAuthorized)
 	suite.Equal("444-555-8888", sswPage1.PreferredPhone)
 	suite.Equal("michael+ppm-expansion_1@truss.works", sswPage1.PreferredEmail)
 	suite.Equal("1234567890", sswPage1.DODId)

--- a/pkg/paperwork/shipment_summary_worksheet.go
+++ b/pkg/paperwork/shipment_summary_worksheet.go
@@ -12,6 +12,7 @@ var ShipmentSummaryPage1Layout = FormLayout{
 		"WeightAllotmentProgear":       FormField(74, 110, 16, floatPtr(10), nil),
 		"WeightAllotmentProgearSpouse": FormField(74, 115, 16, floatPtr(10), nil),
 		"TotalWeightAllotment":         FormField(74, 120, 16, floatPtr(10), nil),
+		"POVAuthorized":                FormField(103, 115, 45, floatPtr(10), nil),
 	},
 }
 


### PR DESCRIPTION
## Description

We're hardcoding POV as unauthorized in the shipment summary worksheet, as we don't know how that's calculated yet and it won't need to be calculated during the pilot yet. Note that this will need a rebase after #1641 gets merged.

## Setup

```sh
make db_dev_e2e_populate
go run cmd/generate_shipment_summary/main.go  -move <uuid> -debug
```

## Code Review Verification Steps

* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* https://www.pivotaltracker.com/story/show/162897090

## Screenshots

<img width="1063" alt="screen shot 2019-01-23 at 4 26 38 pm" src="https://user-images.githubusercontent.com/5531789/51646183-61b84880-1f2c-11e9-9b9e-414a04248c11.png">

