### PR TITLE
Aggregates Shipment association parameters, fixes tests [delivers #163330054]

### DIFF
--- a/pkg/handlers/apitests.go
+++ b/pkg/handlers/apitests.go
@@ -79,6 +79,15 @@ func (suite *BaseHandlerTestSuite) CheckErrorResponse(resp middleware.Responder,
 	}
 }
 
+// CheckNotErrorResponse verifies there is no error response
+func (suite *BaseHandlerTestSuite) CheckNotErrorResponse(resp middleware.Responder) {
+	errResponse, ok := resp.(*ErrResponse)
+	if ok {
+		suite.NoError(errResponse.Err)
+		suite.FailNowf("Received error response", "Code: %v", errResponse.Code)
+	}
+}
+
 // CheckResponseBadRequest looks at BadRequest errors
 func (suite *BaseHandlerTestSuite) CheckResponseBadRequest(resp middleware.Responder) {
 	suite.CheckErrorResponse(resp, http.StatusBadRequest, "BadRequest")

--- a/pkg/handlers/publicapi/shipments.go
+++ b/pkg/handlers/publicapi/shipments.go
@@ -140,6 +140,10 @@ func (h GetShipmentHandler) Handle(params shipmentop.GetShipmentParams) middlewa
 	if session.IsTspUser() {
 		// Check that the TSP user can access the shipment
 		tspUser, err := models.FetchTspUserByID(h.DB(), session.TspUserID)
+		if err != nil {
+			h.Logger().Error("Error retrieving authenticated TSP user", zap.Error(err))
+			return shipmentop.NewGetShipmentForbidden()
+		}
 		shipment, err = models.FetchShipmentByTSP(h.DB(), tspUser.TransportationServiceProviderID, shipmentID)
 		if err != nil {
 			h.Logger().Error("Error fetching shipment for TSP user", zap.Error(err))
@@ -540,6 +544,10 @@ func (h PatchShipmentHandler) Handle(params shipmentop.PatchShipmentParams) midd
 	if session.IsTspUser() {
 		// Check that the TSP user can access the shipment
 		tspUser, err := models.FetchTspUserByID(h.DB(), session.TspUserID)
+		if err != nil {
+			h.Logger().Error("Error retrieving authenticated TSP user", zap.Error(err))
+			return shipmentop.NewGetShipmentForbidden()
+		}
 		shipment, err = models.FetchShipmentByTSP(h.DB(), tspUser.TransportationServiceProviderID, shipmentID)
 		if err != nil {
 			h.Logger().Error("Error fetching shipment for TSP user", zap.Error(err))

--- a/pkg/handlers/publicapi/shipments_test.go
+++ b/pkg/handlers/publicapi/shipments_test.go
@@ -816,6 +816,7 @@ func (suite *HandlerSuite) TestDeliverShipmentHandler() {
 	}
 
 	response := handler.Handle(params)
+	suite.CheckNotErrorResponse(response)
 	suite.Assertions.IsType(&shipmentop.DeliverShipmentOK{}, response)
 	okResponse := response.(*shipmentop.DeliverShipmentOK)
 	suite.Equal("DELIVERED", string(okResponse.Payload.Status))

--- a/pkg/models/models.go
+++ b/pkg/models/models.go
@@ -4,6 +4,9 @@ import (
 	"time"
 )
 
+// EagerAssociations are a collection of named associations
+type EagerAssociations []string
+
 // StringPointer allows you to take the address of a string literal.
 // It is useful for initializing string pointer fields in model construction
 func StringPointer(s string) *string {

--- a/pkg/rateengine/accessorials.go
+++ b/pkg/rateengine/accessorials.go
@@ -1,6 +1,7 @@
 package rateengine
 
 import (
+	"github.com/gofrs/uuid"
 	"github.com/pkg/errors"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/unit"
@@ -157,6 +158,12 @@ func (re *RateEngine) ComputeShipmentLineItemCharge(shipmentLineItem models.Ship
 			return FeeAndRate{}, errors.Wrap(err, "Fetching 400ng item rate from db")
 		}
 		rateCents = rate.RateCents
+	}
+
+	// Make sure we have a ShipmentOffer and TSPP if we need to apply a discount
+	hasTSPP := len(shipment.ShipmentOffers) == 0 || shipment.ShipmentOffers[0].TransportationServiceProviderPerformance.ID == uuid.Nil
+	if shipmentLineItem.Tariff400ngItem.DiscountType != models.Tariff400ngItemDiscountTypeNONE && hasTSPP {
+		return FeeAndRate{}, errors.New("No TSPP provided for Shipment, something is very wrong")
 	}
 
 	var discountRate *unit.DiscountRate

--- a/pkg/rateengine/accessorials_test.go
+++ b/pkg/rateengine/accessorials_test.go
@@ -8,49 +8,25 @@ import (
 	"github.com/transcom/mymove/pkg/unit"
 )
 
-func (suite *RateEngineSuite) createShipmentWithServiceArea(assertions testdatagen.Assertions) models.Shipment {
-	shipment := testdatagen.MakeShipment(suite.DB(), assertions)
+func (suite *RateEngineSuite) createShipmentWithServiceArea() models.Shipment {
+	numTspUsers := 1
+	numShipments := 1
+	numShipmentOfferSplit := []int{1}
+	status := []models.ShipmentStatus{models.ShipmentStatusDELIVERED}
+	_, shipments, _, err := testdatagen.CreateShipmentOfferData(suite.DB(), numTspUsers, numShipments, numShipmentOfferSplit, status)
+	suite.NoError(err)
 
-	zip3 := models.Tariff400ngZip3{
-		Zip3:          Zip5ToZip3(shipment.PickupAddress.PostalCode),
-		BasepointCity: "Saucier",
-		State:         "MS",
-		ServiceArea:   "428",
-		RateArea:      "US48",
-		Region:        "11",
-	}
-	suite.MustSave(&zip3)
-
-	serviceArea := models.Tariff400ngServiceArea{
-		Name:               "Gulfport, MS",
-		ServiceArea:        "428",
-		LinehaulFactor:     57,
-		ServiceChargeCents: 350,
-		ServicesSchedule:   1,
-		EffectiveDateLower: testdatagen.PeakRateCycleStart,
-		EffectiveDateUpper: testdatagen.NonPeakRateCycleEnd,
-		SIT185ARateCents:   unit.Cents(50),
-		SIT185BRateCents:   unit.Cents(50),
-		SITPDSchedule:      1,
-	}
-	suite.MustSave(&serviceArea)
-
-	return shipment
+	return shipments[0]
 }
 
 func (suite *RateEngineSuite) TestAccessorialsPricingPackCrate() {
 	itemCode := "105B"
 	rateCents := unit.Cents(2275)
-	netWeight := unit.Pound(1000)
-	shipment := suite.createShipmentWithServiceArea(testdatagen.Assertions{
-		Shipment: models.Shipment{
-			BookDate:  &testdatagen.DateInsidePeakRateCycle,
-			NetWeight: &netWeight,
-		},
-	})
+	shipment := suite.createShipmentWithServiceArea()
+	q1 := 5
 	item := testdatagen.MakeShipmentLineItem(suite.DB(), testdatagen.Assertions{
 		ShipmentLineItem: models.ShipmentLineItem{
-			Quantity1: unit.BaseQuantity(50000),
+			Quantity1: unit.BaseQuantityFromInt(q1),
 			Shipment:  shipment,
 			Status:    models.ShipmentLineItemStatusAPPROVED,
 			Location:  models.ShipmentLineItemLocationORIGIN,
@@ -58,6 +34,7 @@ func (suite *RateEngineSuite) TestAccessorialsPricingPackCrate() {
 		Tariff400ngItem: models.Tariff400ngItem{
 			Code:                itemCode,
 			RequiresPreApproval: true,
+			DiscountType:        models.Tariff400ngItemDiscountTypeHHG,
 		},
 	})
 
@@ -72,20 +49,15 @@ func (suite *RateEngineSuite) TestAccessorialsPricingPackCrate() {
 	computedPriceAndRate, err := engine.ComputeShipmentLineItemCharge(item)
 
 	if suite.NoError(err) {
-		suite.Equal(rateCents.Multiply(5), computedPriceAndRate.Fee)
+		discountRate := shipment.ShipmentOffers[0].TransportationServiceProviderPerformance.LinehaulRate
+		suite.Equal(discountRate.Apply(rateCents.Multiply(q1)), computedPriceAndRate.Fee)
 	}
 }
 
 // Iterates through all codes that have pricers and make sure they don't explode with sane values
 func (suite *RateEngineSuite) TestAccessorialsSmokeTest() {
 	rateCents := unit.Cents(100)
-	netWeight := unit.Pound(1000)
-	shipment := suite.createShipmentWithServiceArea(testdatagen.Assertions{
-		Shipment: models.Shipment{
-			BookDate:  &testdatagen.DateInsidePeakRateCycle,
-			NetWeight: &netWeight,
-		},
-	})
+	shipment := suite.createShipmentWithServiceArea()
 
 	for code := range tariff400ngItemPricing {
 		item := testdatagen.MakeShipmentLineItem(suite.DB(), testdatagen.Assertions{

--- a/pkg/rateengine/pricers.go
+++ b/pkg/rateengine/pricers.go
@@ -1,6 +1,8 @@
 package rateengine
 
-import "github.com/transcom/mymove/pkg/unit"
+import (
+	"github.com/transcom/mymove/pkg/unit"
+)
 
 type pricer interface {
 	price(rate unit.Cents, q1 unit.BaseQuantity, discount *unit.DiscountRate) unit.Cents

--- a/pkg/testdatagen/make_shipment_line_items.go
+++ b/pkg/testdatagen/make_shipment_line_items.go
@@ -77,9 +77,7 @@ func MakeCompleteShipmentLineItem(db *pop.Connection, assertions Assertions) mod
 
 	// And lastly we need a valid rate for the item code
 	rateAssertions := assertions
-	rateAssertions.Tariff400ngItemRate = models.Tariff400ngItemRate{
-		Code: tariff400ngItem.Code,
-	}
+	rateAssertions.Tariff400ngItemRate.Code = tariff400ngItem.Code
 	MakeTariff400ngItemRate(db, rateAssertions)
 
 	return MakeShipmentLineItem(db, assertions)


### PR DESCRIPTION
## Description

This PR fixes a bug where we were failing to apply a discount rate to ShipmentLineItems when they were priced _after_ the shipment is initially delivered. This was because the pathway for fetching the shipment in that handler is different than the one used in the DeliverShipmentHandler, and they each had different opinions about what associations on the shipment should be fetched. My solution is to use the same set of associations for `FetchShipmentsByTSP`, `FetchShipmentByTSP`, and `FetchShipment`. I left `FetchShipmentForInvoice` alone.

This also adds testing specifically around applying discount rates, which necessitated fixing some tests that weren't standing up enough data properly

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](./docs/backend.md#logging)
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/163330054) for this change