### PR TITLE
Migrates existing invoices in limbo directly to the bad place [delivers #163101034]

### DIFF
--- a/migrations/20190125174356_fail-inprocess-invoices.up.sql
+++ b/migrations/20190125174356_fail-inprocess-invoices.up.sql
@@ -1,0 +1,9 @@
+-- With the first iteration of invoice submission code, submission failures left the
+-- invoice in an IN_PROCESS state and there was no way to clean it up. That code has been fixed,
+-- but this migration cleans up any remaining stragglers in the database.
+-- Theoretically this could run against invoices that are ACTUALLY in progress, so we don't run this
+-- against invoices that were created within the last 30 seconds.
+UPDATE invoices
+    SET status = 'SUBMISSION_FAILURE'
+    WHERE status = 'IN_PROCESS'
+    AND created_at < now() - INTERVAL '30 seconds';


### PR DESCRIPTION
## Description

When an EDI is sent to GEX and fails, it used to leave invoices in an IN_PROCESS state. That code is fixed, but we have some lingering invoices that need to be cleaned up. This PR fails any invoice that's been sitting in an IN_PROCESS state and has existed for more than 30 seconds, which works because we create invoices at the same moment we send the request to GEX

## Setup

```sh
make db_dev_migrate
```

## Code Review Verification Steps

* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](./docs/database.md#zero-downtime-migrations))
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/163101034) for this change