### PR TITLE
Allow disabling database check at health endpoint with query param

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -643,9 +643,9 @@ workflows:
             - pre_deps_yarn
             - acceptance_tests_local
           # if testing on experimental, you can disable these tests by using the commented block below.
-          # filters:
-          #  branches:
-          #    ignore: placeholder_branch_name
+          filters:
+           branches:
+             ignore: cg_162877562_disable_db_check_with_query_string
 
       - integration_tests_office:
           requires:
@@ -653,9 +653,9 @@ workflows:
             - pre_deps_yarn
             - acceptance_tests_local
           # if testing on experimental, you can disable these tests by using the commented block below.
-          # filters:
-          #   branches:
-          #     ignore: placeholder_branch_name
+          filters:
+            branches:
+              ignore: cg_162877562_disable_db_check_with_query_string
 
       - integration_tests_tsp:
           requires:
@@ -663,9 +663,9 @@ workflows:
             - pre_deps_yarn
             - acceptance_tests_local
           # if testing on experimental, you can disable these tests by using the commented block below.
-          # filters:
-          #   branches:
-          #     ignore: placeholder_branch_name
+          filters:
+            branches:
+              ignore: cg_162877562_disable_db_check_with_query_string
 
       - client_test:
           requires:
@@ -700,21 +700,21 @@ workflows:
             - build_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: cg_162877562_disable_db_check_with_query_string
 
       - deploy_experimental_app:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: cg_162877562_disable_db_check_with_query_string
 
       - deploy_experimental_app_client_tls:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: cg_162877562_disable_db_check_with_query_string
 
       - check_circle_against_staging_sha:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -643,9 +643,9 @@ workflows:
             - pre_deps_yarn
             - acceptance_tests_local
           # if testing on experimental, you can disable these tests by using the commented block below.
-          filters:
-           branches:
-             ignore: cg_162877562_disable_db_check_with_query_string
+          # filters:
+          #  branches:
+          #    ignore: placeholder_branch_name
 
       - integration_tests_office:
           requires:
@@ -653,9 +653,9 @@ workflows:
             - pre_deps_yarn
             - acceptance_tests_local
           # if testing on experimental, you can disable these tests by using the commented block below.
-          filters:
-            branches:
-              ignore: cg_162877562_disable_db_check_with_query_string
+          # filters:
+          #   branches:
+          #     ignore: placeholder_branch_name
 
       - integration_tests_tsp:
           requires:
@@ -663,9 +663,9 @@ workflows:
             - pre_deps_yarn
             - acceptance_tests_local
           # if testing on experimental, you can disable these tests by using the commented block below.
-          filters:
-            branches:
-              ignore: cg_162877562_disable_db_check_with_query_string
+          # filters:
+          #   branches:
+          #     ignore: placeholder_branch_name
 
       - client_test:
           requires:
@@ -700,21 +700,21 @@ workflows:
             - build_migrations
           filters:
             branches:
-              only: cg_162877562_disable_db_check_with_query_string
+              only: placeholder_branch_name
 
       - deploy_experimental_app:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: cg_162877562_disable_db_check_with_query_string
+              only: placeholder_branch_name
 
       - deploy_experimental_app_client_tls:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: cg_162877562_disable_db_check_with_query_string
+              only: placeholder_branch_name
 
       - check_circle_against_staging_sha:
           requires:

--- a/cmd/webserver/main.go
+++ b/cmd/webserver/main.go
@@ -919,6 +919,9 @@ func main() {
 		}
 
 		// Check and see if we should disable DB query with '?database=false'
+		// Disabling the DB is useful for Route53 health checks which require the TLS
+		// handshake be less than 4 seconds and the status code return in less than
+		// two seconds. https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dns-failover-determining-health-of-endpoints.html
 		showDB, ok := r.URL.Query()["database"]
 
 		// Always show DB unless key set to "false"


### PR DESCRIPTION
## Description

Route53 health checks may be unable to check SDDC endpoints because of a delay caused by the DB health check.  This change allows us to disable the db check explicitly by passing `?database=false` as a query string parameter.

## Setup

Only this query should disable the database check:

- http://milmovelocal:8080/health?database=false

These will not affect the database check:

- http://milmovelocal:8080/health
- http://milmovelocal:8080/health?database
- http://milmovelocal:8080/health?database=a
- http://milmovelocal:8080/health?database=true


## Code Review Verification Steps

* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/162877562) for this change