### PR TITLE
Back to home link goes back to home after editing information

### DIFF
--- a/cypress/integration/mymove/hhgPPM.js
+++ b/cypress/integration/mymove/hhgPPM.js
@@ -30,8 +30,20 @@ describe('service member adds a ppm to an hhg', function() {
     serviceMemberVerifiesPPMDatesAndLocationsEdited();
     serviceMemberEditsPPMWeight();
     serviceMemberVerifiesPPMWeightsEdited();
+    serviceMemberGoesBackToHomepage();
   });
 });
+
+function serviceMemberGoesBackToHomepage() {
+  cy
+    .get('.back-to-home')
+    .contains('BACK TO HOME')
+    .click();
+
+  cy.location().should(loc => {
+    expect(loc.pathname).to.eq('/');
+  });
+}
 
 function serviceMemberEditsHHGMoveDates() {
   cy.get('[data-cy="edit-move"]').click();

--- a/src/scenes/Review/Edit.jsx
+++ b/src/scenes/Review/Edit.jsx
@@ -7,14 +7,16 @@ export class Edit extends React.Component {
   componentDidMount() {
     scrollToTop();
   }
-  goBack = () => {
-    this.props.history.goBack();
+
+  goHome = () => {
+    this.props.history.push('/');
   };
+
   render() {
     return (
       <div className="usa-grid">
         <div className="usa-width-one-whole">
-          <a className="back-to-home" onClick={this.goBack}>
+          <a className="back-to-home" onClick={this.goHome}>
             &lt;BACK TO HOME
           </a>
           <h1 className="edit-title">Edit Move</h1>


### PR DESCRIPTION
## Description

Back to home link now goes back to the home page all the time even after editing information

## Setup

Add any steps or code to run in this section to help others prepare to run your code:
`make db_dev_e2e_populate`
`make server_run`
`make client_run`
Log into a service member with an HHG
Edit HHG information and save
Click `BACK TO HOME`


## Code Review Verification Steps
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/163462795) for this change
