### PR TITLE
Add Authorized Origin and Authorized Destination to Shipment Summary Worksheet

### DIFF
--- a/pkg/models/shipment_summary_worksheet.go
+++ b/pkg/models/shipment_summary_worksheet.go
@@ -86,9 +86,9 @@ func FetchDataShipmentSummaryWorksheetFormData(db *pop.Connection, session *auth
 	move := Move{}
 	err = db.Q().Eager(
 		"Orders",
-		"Orders.NewDutyStation",
+		"Orders.NewDutyStation.Address",
 		"Orders.ServiceMember",
-		"Orders.ServiceMember.DutyStation",
+		"Orders.ServiceMember.DutyStation.Address",
 		"Shipments",
 	).Find(&move, moveID)
 

--- a/pkg/models/shipment_summary_worksheet.go
+++ b/pkg/models/shipment_summary_worksheet.go
@@ -44,7 +44,8 @@ type ShipmentSummaryWorksheetPage1Values struct {
 	IssuingBranchOrAgency          string
 	OrdersIssueDate                string
 	OrdersTypeAndOrdersNumber      string
-	AuthorizedOrigin               DutyStation
+	AuthorizedOrigin               string
+	AuthorizedDestination          string
 	NewDutyAssignment              string
 	WeightAllotmentSelf            string
 	WeightAllotmentProgear         string
@@ -139,7 +140,8 @@ func FormatValuesShipmentSummaryWorksheetFormPage1(data ShipmentSummaryFormData)
 	page1.OrdersTypeAndOrdersNumber = FormatOrdersTypeAndOrdersNumber(data.Order)
 	page1.TAC = derefStringTypes(data.Order.TAC)
 
-	page1.AuthorizedOrigin = data.CurrentDutyStation
+	page1.AuthorizedOrigin = FormatAuthorizedLocation(data.CurrentDutyStation)
+	page1.AuthorizedDestination = FormatAuthorizedLocation(data.NewDutyStation)
 	page1.NewDutyAssignment = FormatDutyStation(data.NewDutyStation)
 
 	page1.WeightAllotmentSelf = FormatWeights(data.WeightAllotment.TotalWeightSelf)
@@ -159,6 +161,11 @@ func FormatValuesShipmentSummaryWorksheetFormPage1(data ShipmentSummaryFormData)
 		page1.Shipment1Weight = formattedShipments[0].ShipmentWeight
 	}
 	return page1
+}
+
+//FormatAuthorizedLocation formats AuthorizedOrigin and AuthorizedDestination for Shipment Summary Worksheet
+func FormatAuthorizedLocation(dutyStation DutyStation) string {
+	return fmt.Sprintf("%s, %s %s", dutyStation.Name, dutyStation.Address.State, dutyStation.Address.PostalCode)
 }
 
 //FormatServiceMemberFullName formats ServiceMember full name for Shipment Summary Worksheet

--- a/pkg/models/shipment_summary_worksheet_test.go
+++ b/pkg/models/shipment_summary_worksheet_test.go
@@ -115,6 +115,8 @@ func (suite *ModelSuite) TestFormatValuesShipmentSummaryWorksheetFormPage1() {
 
 	suite.Equal("Jenkins Jr., Marcus Joseph", sswPage1.ServiceMemberName)
 	suite.Equal("90 days per each shipment", sswPage1.MaxSITStorageEntitlement)
+	suite.Equal("Fort Bragg, NC 28310", sswPage1.AuthorizedOrigin)
+	suite.Equal("Fort Benning, GA 31905", sswPage1.AuthorizedDestination)
 	suite.Equal("NO", sswPage1.POVAuthorized)
 	suite.Equal("444-555-8888", sswPage1.PreferredPhone)
 	suite.Equal("michael+ppm-expansion_1@truss.works", sswPage1.PreferredEmail)
@@ -124,11 +126,6 @@ func (suite *ModelSuite) TestFormatValuesShipmentSummaryWorksheetFormPage1() {
 	suite.Equal("21-Dec-2018", sswPage1.OrdersIssueDate)
 	suite.Equal("PCS/012345", sswPage1.OrdersTypeAndOrdersNumber)
 	suite.Equal("NTA4", sswPage1.TAC)
-
-	suite.Equal(yuma.ID, sswPage1.AuthorizedOrigin.ID)
-	suite.Equal(yuma.Address.State, sswPage1.AuthorizedOrigin.Address.State)
-	suite.Equal(yuma.Address.City, sswPage1.AuthorizedOrigin.Address.City)
-	suite.Equal(yuma.Address.PostalCode, sswPage1.AuthorizedOrigin.Address.PostalCode)
 
 	suite.Equal("Fort Gordon, GA", sswPage1.NewDutyAssignment)
 
@@ -142,6 +139,14 @@ func (suite *ModelSuite) TestFormatValuesShipmentSummaryWorksheetFormPage1() {
 	suite.Equal("5,000 lbs - FINAL", sswPage1.Shipment1Weight)
 	suite.Equal("Delivered", sswPage1.Shipment1CurrentShipmentStatus)
 
+}
+
+func (suite *ModelSuite) FormatAuthorizedLocation() {
+	fortGordon := models.DutyStation{Name: "Fort Gordon", Address: models.Address{State: "GA", PostalCode: "30813"}}
+	yuma := models.DutyStation{Name: "Yuma AFB", Address: models.Address{State: "IA", PostalCode: "50309"}}
+
+	suite.Equal("Fort Gordon, GA 30813", models.FormatDutyStation(fortGordon))
+	suite.Equal("Yuma AFB, IA 50309", models.FormatDutyStation(yuma))
 }
 
 func (suite *ModelSuite) TestFormatServiceMemberFullName() {

--- a/pkg/models/shipment_summary_worksheet_test.go
+++ b/pkg/models/shipment_summary_worksheet_test.go
@@ -115,8 +115,8 @@ func (suite *ModelSuite) TestFormatValuesShipmentSummaryWorksheetFormPage1() {
 
 	suite.Equal("Jenkins Jr., Marcus Joseph", sswPage1.ServiceMemberName)
 	suite.Equal("90 days per each shipment", sswPage1.MaxSITStorageEntitlement)
-	suite.Equal("Fort Bragg, NC 28310", sswPage1.AuthorizedOrigin)
-	suite.Equal("Fort Benning, GA 31905", sswPage1.AuthorizedDestination)
+	suite.Equal("Yuma AFB, IA 50309", sswPage1.AuthorizedOrigin)
+	suite.Equal("Fort Gordon, GA 30813", sswPage1.AuthorizedDestination)
 	suite.Equal("NO", sswPage1.POVAuthorized)
 	suite.Equal("444-555-8888", sswPage1.PreferredPhone)
 	suite.Equal("michael+ppm-expansion_1@truss.works", sswPage1.PreferredEmail)

--- a/pkg/paperwork/shipment_summary_worksheet.go
+++ b/pkg/paperwork/shipment_summary_worksheet.go
@@ -14,6 +14,8 @@ var ShipmentSummaryPage1Layout = FormLayout{
 		"WeightAllotmentProgearSpouse":   FormField(74, 115, 16, floatPtr(10), nil),
 		"TotalWeightAllotment":           FormField(74, 120, 16, floatPtr(10), nil),
 		"POVAuthorized":                  FormField(103, 115, 45, floatPtr(10), nil),
+		"AuthorizedOrigin":               FormField(103, 104, 45, floatPtr(10), nil),
+		"AuthorizedDestination":          FormField(153, 104, 45, floatPtr(10), nil),
 		"OrdersIssueDate":                FormField(10, 85, 40, floatPtr(10), nil),
 		"OrdersTypeAndOrdersNumber":      FormField(54, 85, 44, floatPtr(10), nil),
 		"IssuingBranchOrAgency":          FormField(103, 85, 47, floatPtr(10), nil),


### PR DESCRIPTION
## Description

Adding `Authorized Origin` and `Authorized Destination` fields to the Shipment Summary worksheet

## Reviewer Notes

## Setup
`make db_dev_e2e_populate`
`make server_run`
`make office_client_run`
Log in to office user
Go into PPM shipment with locator `GBXYUI`
Click on PPM tab
Click on `Create payment paperwork`
Click `Download Worksheet (PDF)`

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/162902401) for this change

## Screenshots

![image](https://user-images.githubusercontent.com/13622298/51871759-25119600-230c-11e9-9e1b-a69797fabb51.png)
