### PR TITLE
Show SIT entitlement and remaining entitlement placeholder

### DIFF
--- a/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
+++ b/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
@@ -406,8 +406,7 @@ class ShipmentInfo extends Component {
                     <StorageInTransitPanel
                       sitRequests={this.props.sitRequests}
                       shipmentId={this.props.match.params.shipmentId}
-                      /* TODO: use property to set entitlement SITEntitlement={this.props.entitlement.storage_in_transit} */
-                      sitEntitlement={90}
+                      sitEntitlement={this.props.entitlement.storage_in_transit}
                     />
                   )}
 

--- a/src/scenes/TransportationServiceProvider/ducks.js
+++ b/src/scenes/TransportationServiceProvider/ducks.js
@@ -126,8 +126,6 @@ export function loadEntitlements(state) {
   if (isNull(hasDependents) || isNull(spouseHasProGear) || isNull(rank)) {
     return null;
   }
-  /* TODO: const sit = 90;
-  *  return getEntitlements(rank, hasDependents, spouseHasProGear, sit); */
   return getEntitlements(rank, hasDependents, spouseHasProGear);
 }
 // Reducer

--- a/src/shared/StorageInTransit/StorageInTransitPanel.jsx
+++ b/src/shared/StorageInTransit/StorageInTransitPanel.jsx
@@ -23,6 +23,8 @@ export class StorageInTransitPanel extends Component {
   render() {
     const { sitEntitlement } = this.props;
     const { error, isCreatorActionable } = this.state;
+    const daysUsed = 0; // placeholder
+    const daysRemaining = sitEntitlement - daysUsed;
     return (
       <div className="storage-in-transit-panel">
         <BasicPanel title="Storage in Transit (SIT)">
@@ -31,7 +33,9 @@ export class StorageInTransitPanel extends Component {
               <span className="warning--header">Please refresh the page and try again.</span>
             </Alert>
           )}
-          <div className="column-subhead">Entitlement: {sitEntitlement} days</div>
+          <div className="column-subhead">
+            Entitlement: {sitEntitlement} days <span className="unbold">({daysRemaining} remaining)</span>
+          </div>
           {isCreatorActionable && <Creator />}
         </BasicPanel>
       </div>

--- a/src/shared/entitlements.js
+++ b/src/shared/entitlements.js
@@ -1,10 +1,8 @@
 import { get, has, isNull, sum } from 'lodash';
 
-export function getEntitlements(
-  rank,
-  hasDependents = false,
-  spouseHasProGear = false /*TODO , storage_in_transit = 90 */,
-) {
+const defaultStorageInTransitDays = 90;
+
+export function getEntitlements(rank, hasDependents = false, spouseHasProGear = false) {
   if (!has(entitlements, rank)) {
     return null;
   }
@@ -17,7 +15,7 @@ export function getEntitlements(
     weight: rankEntitlement[totalKey],
     pro_gear: rankEntitlement.pro_gear_weight,
     pro_gear_spouse: spouseHasProGear ? rankEntitlement.pro_gear_weight_spouse : 0,
-    /* TODO: storage_in_transit: storage_in_transit, */
+    storage_in_transit: defaultStorageInTransitDays,
   };
   entitlement.sum = sum([entitlement.weight, entitlement.pro_gear, entitlement.pro_gear_spouse]);
   return entitlement;
@@ -30,8 +28,7 @@ export function loadEntitlementsFromState(state) {
   if (isNull(hasDependents) || isNull(spouseHasProGear) || isNull(rank)) {
     return null;
   }
-  /* TODO: const sit = 90; */
-  return getEntitlements(rank, hasDependents, spouseHasProGear /*TODO: , sit */);
+  return getEntitlements(rank, hasDependents, spouseHasProGear);
 }
 
 /*


### PR DESCRIPTION
## Description

This PR adds the default 90 day entitlement to our JavaScript entitlements calculation and adds a placeholder for remaining days of entitlement (this will be properly tracked as we build out the back end).

## Setup

- `make db_dev_e2e_populate` to put some test data in your DB.
- `make server_run`
- `make tsp_client_run`
- Log in as the TSP user and pick a move with an HHG shipment.  The SIT panel should show the default 90-day entitlement as well as a placeholder for days remaining.

## Code Review Verification Steps

* [ ] There are no aXe warnings for UI.
* [ ] This works in IE.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/162737178) for this change

## Screenshots

![screen shot 2019-01-28 at 5 57 58 pm](https://user-images.githubusercontent.com/4960757/51872782-ae36c600-2328-11e9-96cc-b086d0a0f811.png)