### PR TITLE
Format dates from the date widget to match what the API expects

### DIFF
--- a/src/scenes/TransportationServiceProvider/api.js
+++ b/src/scenes/TransportationServiceProvider/api.js
@@ -69,10 +69,9 @@ export async function DeliverShipment(shipmentId, payload) {
 
 export async function PatchShipment(shipmentId, shipment) {
   const client = await getPublicClient();
-  const payloadDef = client.spec.definitions.Shipment;
   const response = await client.apis.shipments.patchShipment({
     shipmentId,
-    update: formatPayload(shipment, payloadDef),
+    update: shipment,
   });
   checkResponse(response, 'failed to load shipment due to server error');
   return response.body;

--- a/src/shared/JsonSchemaForm/JsonSchemaField.js
+++ b/src/shared/JsonSchemaForm/JsonSchemaField.js
@@ -4,7 +4,7 @@ import validator from './validator';
 import { Field } from 'redux-form';
 import moment from 'moment';
 import SingleDatePicker from './SingleDatePicker';
-import { defaultDateFormat } from 'shared/utils';
+import { swaggerDateFormat } from 'shared/utils';
 export const ALWAYS_REQUIRED_KEY = 'x-always-required';
 
 // ---- Parsers -----
@@ -118,7 +118,7 @@ const configureZipField = (swaggerField, props, zipPattern) => {
 };
 
 const normalizeDates = value => {
-  return value ? moment(value).format(defaultDateFormat) : value;
+  return value ? moment(value).format(swaggerDateFormat) : value;
 };
 
 const configureDateField = (swaggerField, props) => {


### PR DESCRIPTION
## Description

Currently, we are massaging the date formats stored in the Redux Form reducer before we send the payload to the API. With the new entities pattern, this becomes more difficult, and also seems silly. Let's just store the version we want to send to the server in the forms reducer. The calendar module itself will still handle user-friendly date formats in all visible places.

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/163545021) for this change

