### PR TITLE
Remove tsp reducer from office app

### DIFF
--- a/src/appReducer.js
+++ b/src/appReducer.js
@@ -45,7 +45,6 @@ export const appReducer = combineReducers({
   office: officeReducer,
   transportationOffices: transportationOfficeReducer,
   ppmIncentive: officePpmReducer,
-  tsp: tspReducer,
 });
 
 export const tspAppReducer = combineReducers({

--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -40,7 +40,6 @@ import {
   selectSortedShipmentLineItems,
   getShipmentLineItemsLabel,
 } from 'shared/Entities/modules/shipmentLineItems';
-import { patchShipment } from 'scenes/TransportationServiceProvider/ducks';
 import { getAllInvoices, getShipmentInvoicesLabel } from 'shared/Entities/modules/invoices';
 import { getPublicShipment, updatePublicShipment, selectShipment } from 'shared/Entities/modules/shipments';
 import { getTspForShipmentLabel, getTspForShipment } from 'shared/Entities/modules/transportationServiceProviders';
@@ -94,34 +93,34 @@ const PPMTabContent = props => {
 
 const HHGTabContent = props => {
   let shipmentStatus = '';
-  let shipment = props.officeMove.shipments.find(x => x.id === props.officeShipment.id);
+  const { shipment, updatePublicShipment } = props;
   if (shipment) {
     shipmentStatus = shipment.status;
   }
   return (
     <div className="office-tab">
       <RoutingPanel title="Routing" moveId={props.moveId} />
-      <Dates title="Dates" shipment={props.officeShipment} update={props.patchShipment} />
-      <LocationsContainer update={props.updatePublicShipment} shipmentId={props.shipment.id} />
-      <Weights title="Weights & Items" shipment={props.shipment} update={props.updatePublicShipment} />
-      {props.officeShipment && (
+      <Dates title="Dates" shipment={shipment} update={updatePublicShipment} />
+      <LocationsContainer update={updatePublicShipment} shipmentId={shipment.id} />
+      <Weights title="Weights & Items" shipment={shipment} update={updatePublicShipment} />
+      {shipment && (
         <PremoveSurvey
           title="Premove Survey"
-          shipment={props.officeShipment}
-          update={props.patchShipment}
+          shipment={shipment}
+          update={updatePublicShipment}
           error={props.surveyError}
         />
       )}
       <ServiceAgentsContainer
         title="TSP & Servicing Agents"
-        shipment={props.officeShipment}
+        shipment={shipment}
         serviceAgents={props.serviceAgents}
-        transportationServiceProviderId={props.shipment.transportation_service_provider_id}
+        transportationServiceProviderId={shipment.transportation_service_provider_id}
       />
-      {has(props, 'officeShipment.id') && <PreApprovalPanel shipmentId={props.officeShipment.id} />}
-      {has(props, 'officeShipment.id') && (
+      {has(props, 'shipment.id') && <PreApprovalPanel shipmentId={props.shipment.id} />}
+      {has(props, 'shipment.id') && (
         <InvoicePanel
-          shipmentId={props.officeShipment.id}
+          shipmentId={shipment.id}
           shipmentStatus={shipmentStatus}
           onApprovePayment={props.sendHHGInvoice}
           canApprove={props.canApprovePaymentInvoice}
@@ -507,7 +506,6 @@ const mapDispatchToProps = dispatch =>
       resetMove,
       getTspForShipment,
       getServiceAgentsForShipment,
-      patchShipment,
     },
     dispatch,
   );

--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
-import { get, capitalize, has, includes } from 'lodash';
+import { get, capitalize, includes } from 'lodash';
 
 import { RoutedTabs, NavTab } from 'react-router-tabs';
 import { NavLink, Switch, Redirect, Link } from 'react-router-dom';
@@ -103,30 +103,26 @@ const HHGTabContent = props => {
       <Dates title="Dates" shipment={shipment} update={updatePublicShipment} />
       <LocationsContainer update={updatePublicShipment} shipmentId={shipment.id} />
       <Weights title="Weights & Items" shipment={shipment} update={updatePublicShipment} />
-      {shipment && (
-        <PremoveSurvey
-          title="Premove Survey"
-          shipment={shipment}
-          update={updatePublicShipment}
-          error={props.surveyError}
-        />
-      )}
+      <PremoveSurvey
+        title="Premove Survey"
+        shipment={shipment}
+        update={updatePublicShipment}
+        error={props.surveyError}
+      />
       <ServiceAgentsContainer
         title="TSP & Servicing Agents"
         shipment={shipment}
         serviceAgents={props.serviceAgents}
         transportationServiceProviderId={shipment.transportation_service_provider_id}
       />
-      {has(props, 'shipment.id') && <PreApprovalPanel shipmentId={props.shipment.id} />}
-      {has(props, 'shipment.id') && (
-        <InvoicePanel
-          shipmentId={shipment.id}
-          shipmentStatus={shipmentStatus}
-          onApprovePayment={props.sendHHGInvoice}
-          canApprove={props.canApprovePaymentInvoice}
-          allowPayments={props.allowHhgInvoicePayment}
-        />
-      )}
+      <PreApprovalPanel shipmentId={shipment.id} />
+      <InvoicePanel
+        shipmentId={shipment.id}
+        shipmentStatus={shipmentStatus}
+        onApprovePayment={props.sendHHGInvoice}
+        canApprove={props.canApprovePaymentInvoice}
+        allowPayments={props.allowHhgInvoicePayment}
+      />
     </div>
   );
 };
@@ -143,8 +139,8 @@ class MoveInfo extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    if (get(this.props, 'officeShipment.id') !== get(prevProps, 'officeShipment.id')) {
-      this.getAllShipmentInfo(this.props.officeShipment.id);
+    if (this.props.shipmentId !== prevProps.shipmentId) {
+      this.getAllShipmentInfo(this.props.shipmentId);
     }
   }
 
@@ -169,11 +165,11 @@ class MoveInfo extends Component {
   };
 
   approveHHG = () => {
-    this.props.approveHHG(this.props.officeShipment.id);
+    this.props.approveHHG(this.props.shipmentId);
   };
 
   completeHHG = () => {
-    this.props.completeHHG(this.props.officeShipment.id);
+    this.props.completeHHG(this.props.shipmentId);
   };
 
   cancelMove = cancelReason => {
@@ -324,19 +320,19 @@ class MoveInfo extends Component {
                 <PrivateRoute path={`${this.props.match.path}/basics`} component={BasicsTabContent} />
                 <PrivateRoute path={`${this.props.match.path}/ppm`} component={PPMTabContent} />
                 <PrivateRoute path={`${this.props.match.path}/hhg`}>
-                  <HHGTabContent
-                    officeHHG={JSON.stringify(this.props.officeHHG)}
-                    officeShipment={this.props.officeShipment}
-                    patchShipment={this.props.patchShipment}
-                    updatePublicShipment={this.props.updatePublicShipment}
-                    moveId={this.props.match.params.moveId}
-                    shipment={this.props.shipment}
-                    serviceAgents={this.props.serviceAgents}
-                    surveyError={this.props.shipmentPatchError && this.props.errorMessage}
-                    canApprovePaymentInvoice={hhgDelivered}
-                    officeMove={this.props.officeMove}
-                    allowHhgInvoicePayment={allowHhgInvoicePayment}
-                  />
+                  {this.props.shipment && (
+                    <HHGTabContent
+                      officeHHG={JSON.stringify(this.props.officeHHG)}
+                      updatePublicShipment={this.props.updatePublicShipment}
+                      moveId={this.props.match.params.moveId}
+                      shipment={this.props.shipment}
+                      serviceAgents={this.props.serviceAgents}
+                      surveyError={this.props.shipmentPatchError && this.props.errorMessage}
+                      canApprovePaymentInvoice={hhgDelivered}
+                      officeMove={this.props.officeMove}
+                      allowHhgInvoicePayment={allowHhgInvoicePayment}
+                    />
+                  )}
                 </PrivateRoute>
               </Switch>
             </div>
@@ -467,7 +463,7 @@ const mapStateToProps = state => {
   return {
     swaggerError: get(state, 'swagger.hasErrored'),
     officeMove,
-    officeShipment: get(state, 'office.officeShipment', {}),
+    shipmentId,
     shipment: selectShipment(state, shipmentId),
     officeOrders: get(state, 'office.officeOrders', {}),
     officeServiceMember: get(state, 'office.officeServiceMember', {}),


### PR DESCRIPTION
## Description

We've finally done enough ground work to remove the tsp reducer from the office app. Let's do it!

## Reviewer Notes

We're also no longer using the shipment in the office reducer, but I might leave cleaning that up until we've ported the move information to the entities reducer. At that point, I think we can remove large chunks of unused code, rather than pick apart the current reducer setup.

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/163242097) for this change
