### PR TITLE
Populate Preparation Date on the SSW

### DIFF
--- a/cmd/generate_shipment_summary/main.go
+++ b/cmd/generate_shipment_summary/main.go
@@ -54,7 +54,7 @@ func main() {
 		formFiller.Debug()
 	}
 
-	page1Data, page2Data, err := models.FetchShipmentSummaryWorksheetFormValues(db, &auth.Session{}, parsedID)
+	page1Data, page2Data, err := models.FetchShipmentSummaryWorksheetFormValues(db, &auth.Session{}, parsedID, time.Now())
 	noErr(err)
 
 	// page 1

--- a/pkg/handlers/internalapi/moves.go
+++ b/pkg/handlers/internalapi/moves.go
@@ -238,8 +238,10 @@ type ShowShipmentSummaryWorksheetHandler struct {
 func (h ShowShipmentSummaryWorksheetHandler) Handle(params moveop.ShowShipmentSummaryWorksheetParams) middleware.Responder {
 	session := auth.SessionFromRequestContext(params.HTTPRequest)
 	moveID, _ := uuid.FromString(params.MoveID.String())
+	preparationDate := time.Time(params.PreparationDate)
 
-	page1Data, page2Data, err := models.FetchShipmentSummaryWorksheetFormValues(h.DB(), session, moveID)
+	page1Data, page2Data, err := models.FetchShipmentSummaryWorksheetFormValues(h.DB(), session, moveID, preparationDate)
+
 	if err != nil {
 		return handlers.ResponseForError(h.Logger(), err)
 	}

--- a/pkg/handlers/internalapi/moves_test.go
+++ b/pkg/handlers/internalapi/moves_test.go
@@ -398,9 +398,11 @@ func (suite *HandlerSuite) TestShowShipmentSummaryWorksheet() {
 	req := httptest.NewRequest("GET", "/moves/some_id/shipment_summary_worksheet", nil)
 	req = suite.AuthenticateRequest(req, move.Orders.ServiceMember)
 
+	preparationDate := strfmt.Date(time.Date(2019, time.January, 1, 1, 1, 1, 1, time.UTC))
 	params := moveop.ShowShipmentSummaryWorksheetParams{
-		HTTPRequest: req,
-		MoveID:      strfmt.UUID(move.ID.String()),
+		HTTPRequest:     req,
+		MoveID:          strfmt.UUID(move.ID.String()),
+		PreparationDate: preparationDate,
 	}
 
 	context := handlers.NewHandlerContext(suite.DB(), suite.TestLogger())

--- a/pkg/models/shipment_summary_worksheet.go
+++ b/pkg/models/shipment_summary_worksheet.go
@@ -84,9 +84,9 @@ func FetchDataShipmentSummaryWorksheetFormData(db *pop.Connection, session *auth
 	move := Move{}
 	err = db.Q().Eager(
 		"Orders",
-		"Orders.NewDutyStation",
+		"Orders.NewDutyStation.Address",
 		"Orders.ServiceMember",
-		"Orders.ServiceMember.DutyStation",
+		"Orders.ServiceMember.DutyStation.Address",
 		"Shipments",
 	).Find(&move, moveID)
 

--- a/pkg/models/shipment_summary_worksheet.go
+++ b/pkg/models/shipment_summary_worksheet.go
@@ -5,26 +5,23 @@ import (
 	"strings"
 	"time"
 
-	"github.com/pkg/errors"
-	"github.com/transcom/mymove/pkg/auth"
-
-	"github.com/transcom/mymove/pkg/gen/internalmessages"
-
-	"golang.org/x/text/language"
-	"golang.org/x/text/message"
-
 	"github.com/gobuffalo/pop"
 	"github.com/gofrs/uuid"
+	"github.com/pkg/errors"
+	"github.com/transcom/mymove/pkg/auth"
+	"github.com/transcom/mymove/pkg/gen/internalmessages"
+	"golang.org/x/text/language"
+	"golang.org/x/text/message"
 )
 
 // FetchShipmentSummaryWorksheetFormValues fetches the pages for the Shipment Summary Worksheet for a given Shipment ID
-func FetchShipmentSummaryWorksheetFormValues(db *pop.Connection, session *auth.Session, moveID uuid.UUID) (ShipmentSummaryWorksheetPage1Values, ShipmentSummaryWorksheetPage2Values, error) {
+func FetchShipmentSummaryWorksheetFormValues(db *pop.Connection, session *auth.Session, moveID uuid.UUID, preparationDate time.Time) (ShipmentSummaryWorksheetPage1Values, ShipmentSummaryWorksheetPage2Values, error) {
 	var err error
-	var ssfd ShipmentSummaryFormData
 	var page1 ShipmentSummaryWorksheetPage1Values
 	page2 := ShipmentSummaryWorksheetPage2Values{}
 
-	ssfd, err = FetchDataShipmentSummaryWorksheetFormData(db, session, moveID)
+	ssfd, err := FetchDataShipmentSummaryWorksheetFormData(db, session, moveID)
+	ssfd.PreparationDate = preparationDate
 	if err != nil {
 		return page1, page2, err
 	}
@@ -56,6 +53,7 @@ type ShipmentSummaryWorksheetPage1Values struct {
 	Shipment1PickUpDate            string
 	Shipment1Weight                string
 	Shipment1CurrentShipmentStatus string
+	PreparationDate                string
 }
 
 //ShipmentSummaryWorkSheetShipments is and object representing shipment line items on Shipment Summary Worksheet
@@ -78,6 +76,7 @@ type ShipmentSummaryFormData struct {
 	NewDutyStation     DutyStation
 	WeightAllotment    WeightAllotment
 	Shipments          Shipments
+	PreparationDate    time.Time
 }
 
 // FetchDataShipmentSummaryWorksheetFormData fetches the pages for the Shipment Summary Worksheet for a given Move ID
@@ -127,6 +126,7 @@ func FormatValuesShipmentSummaryWorksheetFormPage1(data ShipmentSummaryFormData)
 	page1.MaxSITStorageEntitlement = "90 days per each shipment"
 	// We don't currently know what allows POV to be authorized, so we are hardcoding it to "No" to start
 	page1.POVAuthorized = "NO"
+	page1.PreparationDate = FormatDate(data.PreparationDate)
 
 	sm := data.ServiceMember
 	page1.ServiceMemberName = FormatServiceMemberFullName(sm)

--- a/pkg/models/shipment_summary_worksheet_test.go
+++ b/pkg/models/shipment_summary_worksheet_test.go
@@ -109,9 +109,11 @@ func (suite *ModelSuite) TestFormatValuesShipmentSummaryWorksheetFormPage1() {
 		NewDutyStation:     fortGordon,
 		WeightAllotment:    wtgEntitlements,
 		Shipments:          shipments,
+		PreparationDate:    time.Date(2019, 1, 1, 1, 1, 1, 1, time.UTC),
 	}
-
 	sswPage1 := models.FormatValuesShipmentSummaryWorksheetFormPage1(ssd)
+
+	suite.Equal("01-Jan-2019", sswPage1.PreparationDate)
 
 	suite.Equal("Jenkins Jr., Marcus Joseph", sswPage1.ServiceMemberName)
 	suite.Equal("90 days per each shipment", sswPage1.MaxSITStorageEntitlement)

--- a/pkg/models/shipment_summary_worksheet_test.go
+++ b/pkg/models/shipment_summary_worksheet_test.go
@@ -53,7 +53,9 @@ func (suite *ModelSuite) TestFetchDataShipmentSummaryWorksFormData() {
 	suite.Equal(shipment.ID, ssd.Shipments[0].ID)
 	suite.Equal(serviceMemberID, ssd.ServiceMember.ID)
 	suite.Equal(yuma.ID, ssd.CurrentDutyStation.ID)
+	suite.Equal(yuma.Address.ID, ssd.CurrentDutyStation.Address.ID)
 	suite.Equal(fortGordon.ID, ssd.NewDutyStation.ID)
+	suite.Equal(fortGordon.Address.ID, ssd.NewDutyStation.Address.ID)
 	rankWtgAllotment := models.GetWeightAllotment(rank)
 	suite.Equal(rankWtgAllotment, ssd.WeightAllotment)
 }

--- a/pkg/paperwork/shipment_summary_worksheet.go
+++ b/pkg/paperwork/shipment_summary_worksheet.go
@@ -7,6 +7,7 @@ var ShipmentSummaryPage1Layout = FormLayout{
 
 	// For now only lists a single shipment. Will need to update to accommodate multiple shipments
 	FieldsLayout: map[string]FieldPos{
+		"PreparationDate":                FormField(156, 22, 46, floatPtr(10), nil),
 		"ServiceMemberName":              FormField(45, 42, 105, floatPtr(10), nil),
 		"MaxSITStorageEntitlement":       FormField(153, 115, 49, floatPtr(10), nil),
 		"WeightAllotmentSelf":            FormField(74, 104, 16, floatPtr(10), nil),

--- a/src/scenes/Office/Ppm/PaymentsPanel.jsx
+++ b/src/scenes/Office/Ppm/PaymentsPanel.jsx
@@ -23,6 +23,10 @@ const attachmentsErrorMessages = {
   500: 'An unexpected error has occurred',
 };
 
+function getUserDate() {
+  return new Date().toISOString().split('T')[0];
+}
+
 class PaymentsTable extends Component {
   state = {
     showPaperwork: false,
@@ -60,8 +64,10 @@ class PaymentsTable extends Component {
 
   downloadShipmentSummary = () => {
     let moveID = get(this.props, 'move.id');
+    const userDate = getUserDate();
+
     // eslint-disable-next-line
-    window.open(`/internal/moves/${moveID}/shipment_summary_worksheet`);
+    window.open(`/internal/moves/${moveID}/shipment_summary_worksheet/?preparationDate=${userDate}`);
   };
 
   renderAdvanceAction = () => {

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -3407,6 +3407,12 @@ paths:
           format: uuid
           required: true
           description: UUID of the move
+        - in: query
+          name: preparationDate
+          type: string
+          format: date
+          required: true
+          description: The preparationDate of PDF
       produces:
         - application/pdf
       responses:


### PR DESCRIPTION
## Description

Populates the Preparation Date on the Shipments Summary Worksheet. 

Also, noticed that the nested `Address` association wasn't being captured on the `DutyStations`, so updated `FetchDataShipmentSummaryWorksheetFormData` and added test confirm `DutyStation.Address` is present.

## Reviewer Notes

The SSW PreparationDate is a required parameter for the `shipment_summary_worksheet` endpoint right now. I wasn't sure how reliably we can obtain this from the browser and if some sort of fallback should be used (i.e. server date).

## Setup
```sh
make server_test
```

Generate a sample pdf using test data: 
```
make db_populate_e2e
go run cmd/generate_shipment_summary/main.go  -move <uuid> -debug
```

Or navigate to the PPM page for a user that has requested payment, choose create paperwork, and then download the SSW ([for example](http://officelocal:3000/queues/new/moves/d6b8980d-6f88-41be-9ae2-1abcbd2574bc/ppm))

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/n/projects/2181745/stories/163411516) 