### PR TITLE
Better startup logs

### DIFF
--- a/cmd/webserver/main.go
+++ b/cmd/webserver/main.go
@@ -261,7 +261,7 @@ func initFlags(flag *pflag.FlagSet) {
 	flag.String("csrf-auth-key", "", "CSRF Auth Key, 32 byte long")
 }
 
-func initDODCertificates(v *viper.Viper, logger *zap.Logger) ([]tls.Certificate, *x509.CertPool, error) {
+func initDODCertificates(v *viper.Viper, logger *webserverLogger) ([]tls.Certificate, *x509.CertPool, error) {
 
 	// https://tools.ietf.org/html/rfc7468#section-2
 	//	- https://stackoverflow.com/questions/20173472/does-go-regexps-any-charcter-match-newline
@@ -367,7 +367,7 @@ func initRoutePlanner(v *viper.Viper, logger *zap.Logger) route.Planner {
 		v.GetString("here-maps-app-code"))
 }
 
-func initHoneycomb(v *viper.Viper, logger *zap.Logger) bool {
+func initHoneycomb(v *viper.Viper, logger *webserverLogger) bool {
 
 	honeycombAPIHost := v.GetString("honeycomb-api-host")
 	honeycombAPIKey := v.GetString("honeycomb-api-key")
@@ -392,7 +392,7 @@ func initHoneycomb(v *viper.Viper, logger *zap.Logger) bool {
 	return false
 }
 
-func initRBSPersonLookup(v *viper.Viper, logger *zap.Logger) (*iws.RBSPersonLookup, error) {
+func initRBSPersonLookup(v *viper.Viper, logger *webserverLogger) (*iws.RBSPersonLookup, error) {
 	return iws.NewRBSPersonLookup(
 		v.GetString("iws-rbs-host"),
 		v.GetString("dod-ca-package"),
@@ -400,7 +400,7 @@ func initRBSPersonLookup(v *viper.Viper, logger *zap.Logger) (*iws.RBSPersonLook
 		v.GetString("move-mil-dod-tls-key"))
 }
 
-func initDatabase(v *viper.Viper, logger *zap.Logger) (*pop.Connection, error) {
+func initDatabase(v *viper.Viper, logger *webserverLogger) (*pop.Connection, error) {
 
 	env := v.GetString("env")
 	dbName := v.GetString("db-name")
@@ -679,15 +679,15 @@ func main() {
 	env := v.GetString("env")
 	isDevOrTest := env == "development" || env == "test"
 
-	logger, err := logging.Config(env, v.GetBool("debug-logging"))
+	zapLogger, err := logging.Config(env, v.GetBool("debug-logging"))
 	if err != nil {
 		log.Fatalf("Failed to initialize Zap logging due to %v", err)
 	}
-	zap.ReplaceGlobals(logger)
+	zap.ReplaceGlobals(zapLogger)
 
-	logger.Debug("Build Variables",
-		zap.String("git.branch", gitBranch),
-		zap.String("git.commit", gitCommit))
+	logger := &webserverLogger{zapLogger}
+
+	logger.Debug("webserver starting up")
 
 	err = checkConfig(v)
 	if err != nil {
@@ -713,7 +713,7 @@ func main() {
 		logger.Fatal("Client auth private key", zap.Error(err))
 	}
 	if len(loginGovHostname) == 0 {
-		log.Fatal("Must provide the Login.gov hostname parameter, exiting")
+		logger.Fatal("Must provide the Login.gov hostname parameter, exiting")
 	}
 
 	// Create a connection to the DB
@@ -734,7 +734,7 @@ func main() {
 	tspHostname := v.GetString("http-tsp-server-name")
 
 	// Register Login.gov authentication provider for My.(move.mil)
-	loginGovProvider := authentication.NewLoginGovProvider(loginGovHostname, loginGovSecretKey, logger)
+	loginGovProvider := authentication.NewLoginGovProvider(loginGovHostname, loginGovSecretKey, zapLogger)
 	err = loginGovProvider.RegisterProvider(
 		myHostname,
 		v.GetString("login-gov-my-client-id"),
@@ -750,13 +750,13 @@ func main() {
 
 	// Session management and authentication middleware
 	noSessionTimeout := v.GetBool("no-session-timeout")
-	sessionCookieMiddleware := auth.SessionCookieMiddleware(logger, clientAuthSecretKey, noSessionTimeout)
-	maskedCSRFMiddleware := auth.MaskedCSRFMiddleware(logger, noSessionTimeout)
-	appDetectionMiddleware := auth.DetectorMiddleware(logger, myHostname, officeHostname, tspHostname)
-	userAuthMiddleware := authentication.UserAuthMiddleware(logger)
-	clientCertMiddleware := authentication.ClientCertMiddleware(logger, dbConnection)
+	sessionCookieMiddleware := auth.SessionCookieMiddleware(zapLogger, clientAuthSecretKey, noSessionTimeout)
+	maskedCSRFMiddleware := auth.MaskedCSRFMiddleware(zapLogger, noSessionTimeout)
+	appDetectionMiddleware := auth.DetectorMiddleware(zapLogger, myHostname, officeHostname, tspHostname)
+	userAuthMiddleware := authentication.UserAuthMiddleware(zapLogger)
+	clientCertMiddleware := authentication.ClientCertMiddleware(zapLogger, dbConnection)
 
-	handlerContext := handlers.NewHandlerContext(dbConnection, logger)
+	handlerContext := handlers.NewHandlerContext(dbConnection, zapLogger)
 	handlerContext.SetCookieSecret(clientAuthSecretKey)
 	if noSessionTimeout {
 		handlerContext.SetNoSessionTimeout()
@@ -768,7 +768,7 @@ func main() {
 		// below.
 		awsSESRegion := v.GetString("aws-ses-region")
 		awsSESDomain := v.GetString("aws-ses-domain")
-		zap.L().Info("Using ses email backend",
+		logger.Info("Using ses email backend",
 			zap.String("region", awsSESRegion),
 			zap.String("domain", awsSESDomain))
 		sesSession, err := awssession.NewSession(&aws.Config{
@@ -778,12 +778,11 @@ func main() {
 			logger.Fatal("Failed to create a new AWS client config provider", zap.Error(err))
 		}
 		sesService := ses.New(sesSession)
-		handlerContext.SetNotificationSender(notifications.NewNotificationSender(sesService, awsSESDomain, logger))
+		handlerContext.SetNotificationSender(notifications.NewNotificationSender(sesService, awsSESDomain, zapLogger))
 	} else {
 		domain := "milmovelocal"
-		zap.L().Info("Using local email backend",
-			zap.String("domain", domain))
-		handlerContext.SetNotificationSender(notifications.NewStubNotificationSender(domain, logger))
+		logger.Info("Using local email backend", zap.String("domain", domain))
+		handlerContext.SetNotificationSender(notifications.NewStubNotificationSender(domain, zapLogger))
 	}
 
 	build := v.GetString("build")
@@ -793,7 +792,7 @@ func main() {
 
 	// Get route planner for handlers to calculate transit distances
 	// routePlanner := route.NewBingPlanner(logger, bingMapsEndpoint, bingMapsKey)
-	routePlanner := initRoutePlanner(v, logger)
+	routePlanner := initRoutePlanner(v, zapLogger)
 	handlerContext.SetPlanner(routePlanner)
 
 	// Set SendProductionInvoice for ediinvoice
@@ -808,34 +807,34 @@ func main() {
 		awsS3Bucket := v.GetString("aws-s3-bucket-name")
 		awsS3Region := v.GetString("aws-s3-region")
 		awsS3KeyNamespace := v.GetString("aws-s3-key-namespace")
-		zap.L().Info("Using s3 storage backend",
+		logger.Info("Using s3 storage backend",
 			zap.String("bucket", awsS3Bucket),
 			zap.String("region", awsS3Region),
 			zap.String("key", awsS3KeyNamespace))
 		if len(awsS3Bucket) == 0 {
-			log.Fatalln(errors.New("must provide aws-s3-bucket-name parameter, exiting"))
+			logger.Fatal("must provide aws-s3-bucket-name parameter, exiting")
 		}
 		if len(awsS3Region) == 0 {
-			log.Fatalln(errors.New("Must provide aws-s3-region parameter, exiting"))
+			logger.Fatal("Must provide aws-s3-region parameter, exiting")
 		}
 		if len(awsS3KeyNamespace) == 0 {
-			log.Fatalln(errors.New("Must provide aws_s3_key_namespace parameter, exiting"))
+			logger.Fatal("Must provide aws_s3_key_namespace parameter, exiting")
 		}
 		aws := awssession.Must(awssession.NewSession(&aws.Config{
 			Region: aws.String(awsS3Region),
 		}))
-		storer = storage.NewS3(awsS3Bucket, awsS3KeyNamespace, logger, aws)
+		storer = storage.NewS3(awsS3Bucket, awsS3KeyNamespace, zapLogger, aws)
 	} else if storageBackend == "memory" {
-		zap.L().Info("Using memory storage backend",
+		logger.Info("Using memory storage backend",
 			zap.String("root", path.Join(localStorageRoot, localStorageWebRoot)),
 			zap.String("web root", localStorageWebRoot))
-		fsParams := storage.NewMemoryParams(localStorageRoot, localStorageWebRoot, logger)
+		fsParams := storage.NewMemoryParams(localStorageRoot, localStorageWebRoot, zapLogger)
 		storer = storage.NewMemory(fsParams)
 	} else {
-		zap.L().Info("Using local storage backend",
+		logger.Info("Using local storage backend",
 			zap.String("root", path.Join(localStorageRoot, localStorageWebRoot)),
 			zap.String("web root", localStorageWebRoot))
-		fsParams := storage.NewFilesystemParams(localStorageRoot, localStorageWebRoot, logger)
+		fsParams := storage.NewFilesystemParams(localStorageRoot, localStorageWebRoot, zapLogger)
 		storer = storage.NewFilesystem(fsParams)
 	}
 	handlerContext.SetFileStorer(storer)
@@ -945,7 +944,7 @@ func main() {
 		} else {
 			protocol = "https"
 		}
-		zap.L().Info("Request",
+		zapLogger.Info("Request",
 			zap.String("git-branch", gitBranch),
 			zap.String("git-commit", gitCommit),
 			zap.String("accepted-language", r.Header.Get("accepted-language")),
@@ -972,7 +971,7 @@ func main() {
 	site.Handle(pat.Get("/favicon.ico"), clientHandler)
 
 	ordersMux := goji.SubMux()
-	ordersDetectionMiddleware := auth.HostnameDetectorMiddleware(logger, v.GetString("http-orders-server-name"))
+	ordersDetectionMiddleware := auth.HostnameDetectorMiddleware(zapLogger, v.GetString("http-orders-server-name"))
 	ordersMux.Use(ordersDetectionMiddleware)
 	ordersMux.Use(noCacheMiddleware)
 	ordersMux.Use(clientCertMiddleware)
@@ -982,7 +981,7 @@ func main() {
 	site.Handle(pat.Get("/orders/v0/*"), ordersMux)
 
 	dpsMux := goji.SubMux()
-	dpsDetectionMiddleware := auth.HostnameDetectorMiddleware(logger, v.GetString("http-dps-server-name"))
+	dpsDetectionMiddleware := auth.HostnameDetectorMiddleware(zapLogger, v.GetString("http-dps-server-name"))
 	dpsMux.Use(dpsDetectionMiddleware)
 	dpsMux.Use(noCacheMiddleware)
 	dpsMux.Use(clientCertMiddleware)
@@ -992,12 +991,12 @@ func main() {
 	site.Handle(pat.New("/dps/v0/*"), dpsMux)
 
 	sddcDPSMux := goji.SubMux()
-	sddcDetectionMiddleware := auth.HostnameDetectorMiddleware(logger, sddcHostname)
+	sddcDetectionMiddleware := auth.HostnameDetectorMiddleware(zapLogger, sddcHostname)
 	sddcDPSMux.Use(sddcDetectionMiddleware)
 	sddcDPSMux.Use(noCacheMiddleware)
 	site.Handle(pat.New("/dps_auth/*"), sddcDPSMux)
 	sddcDPSMux.Handle(pat.Get("/set_cookie"),
-		dpsauth.NewSetCookieHandler(logger,
+		dpsauth.NewSetCookieHandler(zapLogger,
 			dpsAuthSecretKey,
 			dpsCookieDomain,
 			dpsCookieSecret,
@@ -1054,7 +1053,7 @@ func main() {
 	internalAPIMux.Use(noCacheMiddleware)
 	internalAPIMux.Handle(pat.New("/*"), internalapi.NewInternalAPIHandler(handlerContext))
 
-	authContext := authentication.NewAuthContext(logger, loginGovProvider, loginGovCallbackProtocol, loginGovCallbackPort)
+	authContext := authentication.NewAuthContext(zapLogger, loginGovProvider, loginGovCallbackProtocol, loginGovCallbackPort)
 	authMux := goji.SubMux()
 	root.Handle(pat.New("/auth/*"), authMux)
 	authMux.Handle(pat.Get("/login-gov"), authentication.RedirectHandler{Context: authContext})
@@ -1062,7 +1061,7 @@ func main() {
 	authMux.Handle(pat.Get("/logout"), authentication.NewLogoutHandler(authContext, clientAuthSecretKey, noSessionTimeout))
 
 	if isDevOrTest {
-		zap.L().Info("Enabling devlocal auth")
+		logger.Info("Enabling devlocal auth")
 		localAuthMux := goji.SubMux()
 		root.Handle(pat.New("/devlocal-auth/*"), localAuthMux)
 		localAuthMux.Handle(pat.Get("/login"), authentication.NewUserListHandler(authContext, dbConnection))
@@ -1084,7 +1083,7 @@ func main() {
 	}
 
 	// Serve index.html to all requests that haven't matches a previous route,
-	root.HandleFunc(pat.Get("/*"), indexHandler(build, logger))
+	root.HandleFunc(pat.Get("/*"), indexHandler(build, zapLogger))
 
 	var httpHandler http.Handler
 	if useHoneycomb {
@@ -1101,7 +1100,7 @@ func main() {
 		noTLSServer := server.Server{
 			ListenAddress: listenInterface,
 			HTTPHandler:   httpHandler,
-			Logger:        logger,
+			Logger:        zapLogger,
 			Port:          v.GetInt("no-tls-port"),
 		}
 		errChan <- noTLSServer.ListenAndServe()
@@ -1112,7 +1111,7 @@ func main() {
 			ClientAuthType: tls.NoClientCert,
 			ListenAddress:  listenInterface,
 			HTTPHandler:    httpHandler,
-			Logger:         logger,
+			Logger:         zapLogger,
 			Port:           v.GetInt("tls-port"),
 			TLSCerts:       certificates,
 		}
@@ -1127,7 +1126,7 @@ func main() {
 			ClientAuthType: tls.RequireAndVerifyClientCert,
 			ListenAddress:  listenInterface,
 			HTTPHandler:    httpHandler,
-			Logger:         logger,
+			Logger:         zapLogger,
 			Port:           v.GetInt("mutual-tls-port"),
 			TLSCerts:       certificates,
 		}

--- a/cmd/webserver/main_test.go
+++ b/cmd/webserver/main_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/suite"
-	"go.uber.org/zap"
 
 	"github.com/transcom/mymove/pkg/logging"
 )
@@ -19,7 +18,7 @@ import (
 type webServerSuite struct {
 	suite.Suite
 	viper  *viper.Viper
-	logger *zap.Logger
+	logger *webserverLogger
 }
 
 func TestWebServerSuite(t *testing.T) {
@@ -33,10 +32,12 @@ func TestWebServerSuite(t *testing.T) {
 	v.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 	v.AutomaticEnv()
 
-	logger, err := logging.Config(v.GetString("env"), v.GetBool("debug-logging"))
+	zapLogger, err := logging.Config(v.GetString("env"), v.GetBool("debug-logging"))
 	if err != nil {
 		log.Fatalf("Failed to initialize Zap logging due to %v", err)
 	}
+
+	logger := &webserverLogger{zapLogger}
 
 	ss := &webServerSuite{
 		viper:  v,

--- a/cmd/webserver/webserverLogger.go
+++ b/cmd/webserver/webserverLogger.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"go.uber.org/zap"
+)
+
+type webserverLogger struct {
+	*zap.Logger
+}
+
+func (wl *webserverLogger) expand(fields []zap.Field) []zap.Field {
+	if len(gitBranch) > 0 {
+		fields = append(fields, zap.String("git_branch", gitBranch))
+	}
+	if len(gitCommit) > 0 {
+		fields = append(fields, zap.String("git_commit", gitCommit))
+	}
+	return fields
+}
+
+func (wl *webserverLogger) Debug(msg string, fields ...zap.Field) {
+	wl.Logger.Info(msg, wl.expand(fields)...)
+}
+
+func (wl *webserverLogger) Info(msg string, fields ...zap.Field) {
+	wl.Logger.Info(msg, wl.expand(fields)...)
+}
+
+func (wl *webserverLogger) Warn(msg string, fields ...zap.Field) {
+	wl.Logger.Info(msg, wl.expand(fields)...)
+}
+
+func (wl *webserverLogger) Fatal(msg string, fields ...zap.Field) {
+	wl.Logger.Info(msg, wl.expand(fields)...)
+}


### PR DESCRIPTION
## Description

This commits creates a `webserverLogger` that wraps a `zap.Logger` to automatically add in our build variables.  This is a convenience method and will facilitate debugging deploys using CloudWatch Logs.  In the future, we can integrate it into our logging packages.

## Reviewer Notes

Deployed to experimental.  Can now search logs by git branch, e.g.,

```
{ $.git_branch = "startup_logging" }
```

## Setup

None

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](./docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](./docs/backend.md#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](./docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
  * [ ] Secure migrations have been tested using `bin/run-prod-migrations`
* [ ] There are no aXe warnings for UI.
* [ ] This works in IE.
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @willowbl00
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/163465783) for this change
## Screenshots

N.A.