### PR TITLE
Update docs with actual make commands

### DIFF
--- a/docs/how-to/run-e2e-tests.md
+++ b/docs/how-to/run-e2e-tests.md
@@ -23,7 +23,7 @@ To run a single test, use `make e2e_test` and choose the tests you wish to run f
 If you have already run tests in the current database, you will need to reset the database to known good state:
 
 ```console
-$ make db_e2e_reset
+$ make db_test_e2e_populate
 ```
 
 ### Run End to End Tests in a File
@@ -35,7 +35,7 @@ $ yarn cypress run --spec cypress/integration/path/to/file.jsx
 If you have already run tests in the current database, you will need to reset the database to known good state:
 
 ```console
-$ make db_e2e_reset
+$ make db_test_e2e_populate
 ```
 
 ### Run End to End Tests with Docker

--- a/docs/how-to/run-go-tests.md
+++ b/docs/how-to/run-go-tests.md
@@ -11,7 +11,7 @@ $ make server_test
 All of the commands in this section assume that `test_db` is setup properly. This can be done using:
 
 ```console
-$ make db_test_reset
+$ make db_test_migrate
 ```
 
 ## Run Acceptance Tests

--- a/docs/how-to/run-go-tests.md
+++ b/docs/how-to/run-go-tests.md
@@ -11,7 +11,7 @@ $ make server_test
 All of the commands in this section assume that `test_db` is setup properly. This can be done using:
 
 ```console
-$ make db_test_migrate
+$ make db_test_reset && make db_test_migrate
 ```
 
 ## Run Acceptance Tests


### PR DESCRIPTION
## Description

I noticed that the docs had gotten a bit out of date, and this should fix them.

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

Run a server test individually. Run it again to see it fail. Then run the following bash command:

```sh
make db_test_migrate
```
And run the same server test to see it pass.

Run an e2e test that updates the db individually. Run it again to see it fail. Then run the following bash command:

```sh
make db_test_e2e_populate
```
And run the same e2e test to see it pass.

## Code Review Verification Steps

* [x] Request review from a member of a different team.