### PR TITLE
Port move actions to entities

### DIFF
--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -209,12 +209,11 @@ class MoveInfo extends Component {
   };
 
   render() {
-    const { moveDocuments, moveStatus, ppmStatus, shipmentStatus } = this.props;
+    const { moveDocuments, moveStatus, ppmStatus, shipment, shipmentStatus } = this.props;
     const move = this.props.officeMove;
     const serviceMember = this.props.officeServiceMember;
     const orders = this.props.officeOrders;
     const ppm = this.props.officePPM;
-    const hhg = this.props.officeHHG;
     const isPPM = move.selected_move_type === 'PPM';
     const isHHG = move.selected_move_type === 'HHG';
     const isHHGPPM = move.selected_move_type === 'HHG_PPM';
@@ -234,7 +233,7 @@ class MoveInfo extends Component {
     const hhgCompleted = shipmentStatus === 'COMPLETED';
     const moveApproved = moveStatus === 'APPROVED';
 
-    const moveDate = isPPM ? ppm.planned_move_date : hhg.requested_pickup_date;
+    const moveDate = isPPM ? ppm.planned_move_date : shipment && shipment.requested_pickup_date;
     if (this.state.redirectToHome) {
       return <Redirect to="/" />;
     }
@@ -325,7 +324,6 @@ class MoveInfo extends Component {
                 <PrivateRoute path={`${this.props.match.path}/hhg`}>
                   {this.props.shipment && (
                     <HHGTabContent
-                      officeHHG={JSON.stringify(this.props.officeHHG)}
                       updatePublicShipment={this.props.updatePublicShipment}
                       moveId={this.props.moveId}
                       ppmStatus={this.props.ppmStatus}
@@ -473,7 +471,6 @@ const mapStateToProps = (state, ownProps) => {
     moveId,
     moveStatus: selectMoveStatus(state, moveId),
     officeBackupContacts: get(state, 'office.officeBackupContacts', []),
-    officeHHG: get(state, 'office.officeMove.shipments.0', {}),
     officeMove,
     officeOrders: get(state, 'office.officeOrders', {}),
     officePPM,

--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -52,8 +52,8 @@ import {
 import { getTspForShipmentLabel, getTspForShipment } from 'shared/Entities/modules/transportationServiceProviders';
 import { getServiceAgentsForShipment, selectServiceAgentsForShipment } from 'shared/Entities/modules/serviceAgents';
 
-import { loadMoveDependencies, approvePPM, cancelMove, sendHHGInvoice, resetMove } from './ducks';
-import { selectMoveStatus, approveBasics } from 'shared/Entities/modules/moves';
+import { loadMoveDependencies, approvePPM, sendHHGInvoice, resetMove, showBanner, removeBanner } from './ducks';
+import { selectMoveStatus, approveBasics, cancelMove } from 'shared/Entities/modules/moves';
 import { formatDate } from 'shared/formatters';
 import { selectAllDocumentsForMove, getMoveDocumentsForMove } from 'shared/Entities/modules/moveDocuments';
 
@@ -172,8 +172,10 @@ class MoveInfo extends Component {
     this.props.completeShipment(this.props.shipmentId);
   };
 
-  cancelMove = cancelReason => {
+  cancelMoveAndRedirect = cancelReason => {
     this.props.cancelMove(this.props.officeMove.id, cancelReason).then(() => {
+      this.props.showBanner();
+      setTimeout(() => this.props.removeBanner(), 10000);
       this.setState({ redirectToHome: true });
     });
   };
@@ -395,7 +397,7 @@ class MoveInfo extends Component {
                 buttonTitle="Cancel Move"
                 reasonPrompt="Why is the move being canceled?"
                 warningPrompt="Are you sure you want to cancel the entire move?"
-                onConfirm={this.cancelMove}
+                onConfirm={this.cancelMoveAndRedirect}
               />
               {/* Disabling until features implemented
               <button>Troubleshoot</button>
@@ -505,6 +507,8 @@ const mapDispatchToProps = dispatch =>
       resetMove,
       getTspForShipment,
       getServiceAgentsForShipment,
+      showBanner,
+      removeBanner,
     },
     dispatch,
   );

--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -47,7 +47,6 @@ import { getServiceAgentsForShipment, selectServiceAgentsForShipment } from 'sha
 
 import {
   loadMoveDependencies,
-  approveBasics,
   approvePPM,
   approveHHG,
   completeHHG,
@@ -57,6 +56,7 @@ import {
 } from './ducks';
 import {
   selectMoveStatus,
+  approveBasics,
 } from 'shared/Entities/modules/moves'
 import { formatDate } from 'shared/formatters';
 import { selectAllDocumentsForMove, getMoveDocumentsForMove } from 'shared/Entities/modules/moveDocuments';

--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -45,13 +45,14 @@ import {
   getPublicShipment,
   updatePublicShipment,
   approveShipment,
+  completeShipment,
   selectShipment,
   selectShipmentStatus,
 } from 'shared/Entities/modules/shipments';
 import { getTspForShipmentLabel, getTspForShipment } from 'shared/Entities/modules/transportationServiceProviders';
 import { getServiceAgentsForShipment, selectServiceAgentsForShipment } from 'shared/Entities/modules/serviceAgents';
 
-import { loadMoveDependencies, approvePPM, completeHHG, cancelMove, sendHHGInvoice, resetMove } from './ducks';
+import { loadMoveDependencies, approvePPM, cancelMove, sendHHGInvoice, resetMove } from './ducks';
 import { selectMoveStatus, approveBasics } from 'shared/Entities/modules/moves';
 import { formatDate } from 'shared/formatters';
 import { selectAllDocumentsForMove, getMoveDocumentsForMove } from 'shared/Entities/modules/moveDocuments';
@@ -167,8 +168,8 @@ class MoveInfo extends Component {
     this.props.approveShipment(this.props.shipmentId);
   };
 
-  completeHHG = () => {
-    this.props.completeHHG(this.props.shipmentId);
+  completeShipment = () => {
+    this.props.completeShipment(this.props.shipmentId);
   };
 
   cancelMove = cancelReason => {
@@ -383,7 +384,7 @@ class MoveInfo extends Component {
               {(isHHG || isHHGPPM) && (
                 <button
                   className={`${hhgCompleted ? 'btn__approve--green' : ''}`}
-                  onClick={this.completeHHG}
+                  onClick={this.completeShipment}
                   disabled={!hhgDelivered || hhgCompleted || !moveApproved || !ordersComplete || currentTab !== 'hhg'}
                 >
                   Complete Shipments
@@ -495,7 +496,7 @@ const mapDispatchToProps = dispatch =>
       approveBasics,
       approvePPM,
       approveShipment,
-      completeHHG,
+      completeShipment,
       cancelMove,
       sendHHGInvoice,
       getAllTariff400ngItems,

--- a/src/scenes/Office/Ppm/PaymentsPanel.jsx
+++ b/src/scenes/Office/Ppm/PaymentsPanel.jsx
@@ -5,6 +5,7 @@ import { push } from 'react-router-redux';
 import { bindActionCreators } from 'redux';
 
 import { approveReimbursement, downloadPPMAttachments } from '../ducks';
+import { selectPpmStatus } from 'shared/Entities/modules/ppms';
 import { no_op } from 'shared/utils';
 import { formatCents, formatDate } from 'shared/formatters';
 import Alert from 'shared/Alert';
@@ -65,7 +66,7 @@ class PaymentsTable extends Component {
   };
 
   renderAdvanceAction = () => {
-    if (this.props.ppm.status === 'APPROVED') {
+    if (this.props.ppmStatus === 'APPROVED') {
       if (this.props.advance.status === 'APPROVED') {
         return <div>{/* Further actions to come*/}</div>;
       } else {
@@ -233,14 +234,19 @@ class PaymentsTable extends Component {
   }
 }
 
-const mapStateToProps = state => ({
-  ppm: get(state, 'office.officePPMs[0]', {}),
-  move: get(state, 'office.officeMove', {}),
-  advance: get(state, 'office.officePPMs[0].advance', {}),
-  hasError: false,
-  errorMessage: state.office.error,
-  attachmentsError: get(state, 'office.downloadAttachmentsHasError'),
-});
+const mapStateToProps = state => {
+  const ppm = get(state, 'office.officePPMs.0', {});
+
+  return {
+    ppm,
+    ppmStatus: selectPpmStatus(state, ppm.id),
+    move: get(state, 'office.officeMove', {}),
+    advance: get(state, 'office.officePPMs[0].advance', {}),
+    hasError: false,
+    errorMessage: state.office.error,
+    attachmentsError: get(state, 'office.downloadAttachmentsHasError'),
+  };
+};
 
 const mapDispatchToProps = dispatch =>
   bindActionCreators(

--- a/src/scenes/Office/api.js
+++ b/src/scenes/Office/api.js
@@ -93,17 +93,6 @@ export async function LoadPPMs(moveId) {
   return response.body;
 }
 
-// PPM status
-export async function ApprovePPM(moveId, ppmId) {
-  const client = await getClient();
-  const response = await client.apis.office.approvePPM({
-    moveId,
-    personallyProcuredMoveId: ppmId,
-  });
-  checkResponse(response, 'failed to approve ppm due to server error');
-  return response.body;
-}
-
 // HHG invoice
 export async function SendHHGInvoice(shipmentId) {
   const client = await getClient();

--- a/src/scenes/Office/api.js
+++ b/src/scenes/Office/api.js
@@ -105,15 +105,6 @@ export async function ApprovePPM(moveId, ppmId) {
 }
 
 // HHG status
-export async function ApproveHHG(shipmentId) {
-  const client = await getClient();
-  const response = await client.apis.shipments.approveHHG({
-    shipmentId,
-  });
-  checkResponse(response, 'failed to approve hhg due to server error');
-  return response.body;
-}
-
 export async function CompleteHHG(shipmentId) {
   const client = await getClient();
   const response = await client.apis.shipments.completeHHG({

--- a/src/scenes/Office/api.js
+++ b/src/scenes/Office/api.js
@@ -124,19 +124,6 @@ export async function ApproveReimbursement(reimbursementId) {
   return response.body;
 }
 
-// Move status
-export async function CancelMove(moveId, cancelReason) {
-  const client = await getClient();
-  const response = await client.apis.office.cancelMove({
-    moveId,
-    cancelMove: {
-      cancel_reason: cancelReason,
-    },
-  });
-  checkResponse(response, 'failed to cancel move and associated dependencies due to server error');
-  return response.body;
-}
-
 // PPM attachments
 export async function DownloadPPMAttachments(ppmId, docTypes) {
   const client = await getClient();

--- a/src/scenes/Office/api.js
+++ b/src/scenes/Office/api.js
@@ -93,16 +93,6 @@ export async function LoadPPMs(moveId) {
   return response.body;
 }
 
-// Move status
-export async function ApproveBasics(moveId) {
-  const client = await getClient();
-  const response = await client.apis.office.approveMove({
-    moveId,
-  });
-  checkResponse(response, 'failed to approve move due to server error');
-  return response.body;
-}
-
 // PPM status
 export async function ApprovePPM(moveId, ppmId) {
   const client = await getClient();

--- a/src/scenes/Office/api.js
+++ b/src/scenes/Office/api.js
@@ -104,16 +104,6 @@ export async function ApprovePPM(moveId, ppmId) {
   return response.body;
 }
 
-// HHG status
-export async function CompleteHHG(shipmentId) {
-  const client = await getClient();
-  const response = await client.apis.shipments.completeHHG({
-    shipmentId,
-  });
-  checkResponse(response, 'failed to complete hhg due to server error');
-  return response.body;
-}
-
 // HHG invoice
 export async function SendHHGInvoice(shipmentId) {
   const client = await getClient();

--- a/src/scenes/Office/ducks.js
+++ b/src/scenes/Office/ducks.js
@@ -226,7 +226,6 @@ const initialState = {
   backupContactsAreLoading: false,
   ppmsAreLoading: false,
   ppmIsUpdating: false,
-  moveIsCanceling: false,
   moveHasLoadError: null,
   moveHasLoadSuccess: false,
   officeMove: {},
@@ -251,9 +250,6 @@ const initialState = {
   hhgInvoiceInDraft: false,
   loadDependenciesHasError: null,
   loadDependenciesHasSuccess: false,
-  moveHasApproveError: false,
-  moveHasCancelError: false,
-  moveHasCancelSuccess: false,
   flashMessage: false,
 };
 

--- a/src/scenes/Office/ducks.js
+++ b/src/scenes/Office/ducks.js
@@ -7,7 +7,6 @@ import {
   LoadBackupContacts,
   UpdateBackupContact,
   LoadPPMs,
-  ApprovePPM,
   ApproveReimbursement,
   DownloadPPMAttachments,
   PatchShipment,
@@ -30,7 +29,6 @@ const loadBackupContactType = 'LOAD_BACKUP_CONTACT';
 const updateBackupContactType = 'UPDATE_BACKUP_CONTACT';
 const loadPPMsType = 'LOAD_PPMS';
 const updatePPMType = 'UPDATE_PPM';
-const approvePPMType = 'APPROVE_PPM';
 const sendHHGInvoiceType = 'SEND_HHG_INVOICE';
 const approveReimbursementType = 'APPROVE_REIMBURSEMENT';
 const downloadPPMAttachmentsType = 'DOWNLOAD_ATTACHMENTS';
@@ -79,8 +77,6 @@ const LOAD_PPMS = ReduxHelpers.generateAsyncActionTypes(loadPPMsType);
 
 const UPDATE_PPM = ReduxHelpers.generateAsyncActionTypes(updatePPMType);
 
-const APPROVE_PPM = ReduxHelpers.generateAsyncActionTypes(approvePPMType);
-
 const SEND_HHG_INVOICE = ReduxHelpers.generateAsyncActionTypes(sendHHGInvoiceType);
 
 export const APPROVE_REIMBURSEMENT = ReduxHelpers.generateAsyncActionTypes(approveReimbursementType);
@@ -122,8 +118,6 @@ export const updateBackupContact = ReduxHelpers.generateAsyncActionCreator(
 export const loadPPMs = ReduxHelpers.generateAsyncActionCreator(loadPPMsType, LoadPPMs);
 
 export const updatePPM = ReduxHelpers.generateAsyncActionCreator(updatePPMType, UpdatePpm);
-
-export const approvePPM = ReduxHelpers.generateAsyncActionCreator(approvePPMType, ApprovePPM);
 
 export const sendHHGInvoice = ReduxHelpers.generateAsyncActionCreator(sendHHGInvoiceType, SendHHGInvoice);
 
@@ -520,22 +514,6 @@ export function officeReducer(state = initialState, action) {
     case REMOVE_BANNER:
       return Object.assign({}, state, {
         flashMessage: false,
-      });
-
-    // PPM STATUS
-    case APPROVE_PPM.start:
-      return Object.assign({}, state, {
-        ppmIsApproving: true,
-      });
-    case APPROVE_PPM.success:
-      return Object.assign({}, state, {
-        ppmIsApproving: false,
-        officePPMs: [action.payload],
-      });
-    case APPROVE_PPM.failure:
-      return Object.assign({}, state, {
-        ppmIsApproving: false,
-        error: action.error.message,
       });
 
     // REIMBURSEMENT STATUS

--- a/src/scenes/Office/ducks.js
+++ b/src/scenes/Office/ducks.js
@@ -9,7 +9,6 @@ import {
   LoadPPMs,
   ApprovePPM,
   ApproveReimbursement,
-  CancelMove,
   DownloadPPMAttachments,
   PatchShipment,
   SendHHGInvoice,
@@ -35,8 +34,8 @@ const approvePPMType = 'APPROVE_PPM';
 const sendHHGInvoiceType = 'SEND_HHG_INVOICE';
 const approveReimbursementType = 'APPROVE_REIMBURSEMENT';
 const downloadPPMAttachmentsType = 'DOWNLOAD_ATTACHMENTS';
-const cancelMoveType = 'CANCEL_MOVE';
 const REMOVE_BANNER = 'REMOVE_BANNER';
+const SHOW_BANNER = 'SHOW_BANNER';
 const RESET_MOVE = 'RESET_MOVE';
 const DRAFT_HHG_INVOICE = 'DRAFT_INVOICE';
 const RESET_HHG_INVOICE = 'RESET_INVOICE';
@@ -83,8 +82,6 @@ const UPDATE_PPM = ReduxHelpers.generateAsyncActionTypes(updatePPMType);
 const APPROVE_PPM = ReduxHelpers.generateAsyncActionTypes(approvePPMType);
 
 const SEND_HHG_INVOICE = ReduxHelpers.generateAsyncActionTypes(sendHHGInvoiceType);
-
-export const CANCEL_MOVE = ReduxHelpers.generateAsyncActionTypes(cancelMoveType);
 
 export const APPROVE_REIMBURSEMENT = ReduxHelpers.generateAsyncActionTypes(approveReimbursementType);
 
@@ -140,24 +137,17 @@ export const downloadPPMAttachments = ReduxHelpers.generateAsyncActionCreator(
   DownloadPPMAttachments,
 );
 
-export const cancelMove = (moveId, changeReason) => {
-  const actions = ReduxHelpers.generateAsyncActions(cancelMoveType);
-  return async function(dispatch, getState) {
-    dispatch(actions.start());
-    return CancelMove(moveId, changeReason)
-      .then(item => dispatch(actions.success(item)), error => dispatch(actions.error(error)))
-      .then(() => {
-        setTimeout(() => dispatch(removeBanner()), 10000);
-      });
-  };
-};
-
 export const removeBanner = () => {
   return {
     type: REMOVE_BANNER,
   };
 };
 
+export const showBanner = () => {
+  return {
+    type: SHOW_BANNER,
+  };
+};
 // MULTIPLE-RESOURCE ACTION CREATORS
 //
 // These action types typically dispatch to other actions above to
@@ -523,22 +513,9 @@ export function officeReducer(state = initialState, action) {
         error: action.error.message,
       });
 
-    // MOVE STATUS
-    case CANCEL_MOVE.start:
+    case SHOW_BANNER:
       return Object.assign({}, state, {
-        moveIsCanceling: true,
-      });
-    case CANCEL_MOVE.success:
-      return Object.assign({}, state, {
-        moveIsCanceling: false,
-        officeMove: action.payload,
         flashMessage: true,
-      });
-    case CANCEL_MOVE.failure:
-      return Object.assign({}, state, {
-        moveIsCanceling: false,
-        error: action.error.message,
-        flashMessage: false,
       });
     case REMOVE_BANNER:
       return Object.assign({}, state, {

--- a/src/scenes/Office/ducks.js
+++ b/src/scenes/Office/ducks.js
@@ -8,7 +8,6 @@ import {
   UpdateBackupContact,
   LoadPPMs,
   ApprovePPM,
-  ApproveHHG,
   CompleteHHG,
   ApproveReimbursement,
   CancelMove,
@@ -34,7 +33,6 @@ const updateBackupContactType = 'UPDATE_BACKUP_CONTACT';
 const loadPPMsType = 'LOAD_PPMS';
 const updatePPMType = 'UPDATE_PPM';
 const approvePPMType = 'APPROVE_PPM';
-const approveHHGType = 'APPROVE_HHG';
 const sendHHGInvoiceType = 'SEND_HHG_INVOICE';
 const approveReimbursementType = 'APPROVE_REIMBURSEMENT';
 const completeHHGType = 'COMPLETE_HHG';
@@ -86,8 +84,6 @@ const UPDATE_PPM = ReduxHelpers.generateAsyncActionTypes(updatePPMType);
 
 const APPROVE_PPM = ReduxHelpers.generateAsyncActionTypes(approvePPMType);
 
-const APPROVE_HHG = ReduxHelpers.generateAsyncActionTypes(approveHHGType);
-
 const COMPLETE_HHG = ReduxHelpers.generateAsyncActionTypes(completeHHGType);
 
 const SEND_HHG_INVOICE = ReduxHelpers.generateAsyncActionTypes(sendHHGInvoiceType);
@@ -135,8 +131,6 @@ export const loadPPMs = ReduxHelpers.generateAsyncActionCreator(loadPPMsType, Lo
 export const updatePPM = ReduxHelpers.generateAsyncActionCreator(updatePPMType, UpdatePpm);
 
 export const approvePPM = ReduxHelpers.generateAsyncActionCreator(approvePPMType, ApprovePPM);
-
-export const approveHHG = ReduxHelpers.generateAsyncActionCreator(approveHHGType, ApproveHHG);
 
 export const completeHHG = ReduxHelpers.generateAsyncActionCreator(completeHHGType, CompleteHHG);
 
@@ -570,19 +564,6 @@ export function officeReducer(state = initialState, action) {
     case APPROVE_PPM.failure:
       return Object.assign({}, state, {
         ppmIsApproving: false,
-        error: action.error.message,
-      });
-
-    // HHG STATUS
-    case APPROVE_HHG.success:
-      return Object.assign({}, state, {
-        officeMove: {
-          ...state.officeMove,
-          shipments: [action.payload],
-        },
-      });
-    case APPROVE_HHG.failure:
-      return Object.assign({}, state, {
         error: action.error.message,
       });
 

--- a/src/scenes/Office/ducks.js
+++ b/src/scenes/Office/ducks.js
@@ -7,7 +7,6 @@ import {
   LoadBackupContacts,
   UpdateBackupContact,
   LoadPPMs,
-  ApproveBasics,
   ApprovePPM,
   ApproveHHG,
   CompleteHHG,
@@ -34,7 +33,6 @@ const loadBackupContactType = 'LOAD_BACKUP_CONTACT';
 const updateBackupContactType = 'UPDATE_BACKUP_CONTACT';
 const loadPPMsType = 'LOAD_PPMS';
 const updatePPMType = 'UPDATE_PPM';
-const approveBasicsType = 'APPROVE_BASICS';
 const approvePPMType = 'APPROVE_PPM';
 const approveHHGType = 'APPROVE_HHG';
 const sendHHGInvoiceType = 'SEND_HHG_INVOICE';
@@ -86,8 +84,6 @@ const LOAD_PPMS = ReduxHelpers.generateAsyncActionTypes(loadPPMsType);
 
 const UPDATE_PPM = ReduxHelpers.generateAsyncActionTypes(updatePPMType);
 
-const APPROVE_BASICS = ReduxHelpers.generateAsyncActionTypes(approveBasicsType);
-
 const APPROVE_PPM = ReduxHelpers.generateAsyncActionTypes(approvePPMType);
 
 const APPROVE_HHG = ReduxHelpers.generateAsyncActionTypes(approveHHGType);
@@ -137,8 +133,6 @@ export const updateBackupContact = ReduxHelpers.generateAsyncActionCreator(
 export const loadPPMs = ReduxHelpers.generateAsyncActionCreator(loadPPMsType, LoadPPMs);
 
 export const updatePPM = ReduxHelpers.generateAsyncActionCreator(updatePPMType, UpdatePpm);
-
-export const approveBasics = ReduxHelpers.generateAsyncActionCreator(approveBasicsType, ApproveBasics);
 
 export const approvePPM = ReduxHelpers.generateAsyncActionCreator(approvePPMType, ApprovePPM);
 
@@ -542,23 +536,6 @@ export function officeReducer(state = initialState, action) {
       });
 
     // MOVE STATUS
-    case APPROVE_BASICS.start:
-      return Object.assign({}, state, {
-        basicsIsApproving: true,
-        moveHasApproveError: false,
-      });
-    case APPROVE_BASICS.success:
-      return Object.assign({}, state, {
-        basicsIsApproving: false,
-        officeMove: action.payload,
-        moveHasApproveError: false,
-      });
-    case APPROVE_BASICS.failure:
-      return Object.assign({}, state, {
-        basicsIsApproving: false,
-        error: action.error.message,
-        moveHasApproveError: true,
-      });
     case CANCEL_MOVE.start:
       return Object.assign({}, state, {
         moveIsCanceling: true,

--- a/src/scenes/Office/ducks.js
+++ b/src/scenes/Office/ducks.js
@@ -8,7 +8,6 @@ import {
   UpdateBackupContact,
   LoadPPMs,
   ApprovePPM,
-  CompleteHHG,
   ApproveReimbursement,
   CancelMove,
   DownloadPPMAttachments,
@@ -35,7 +34,6 @@ const updatePPMType = 'UPDATE_PPM';
 const approvePPMType = 'APPROVE_PPM';
 const sendHHGInvoiceType = 'SEND_HHG_INVOICE';
 const approveReimbursementType = 'APPROVE_REIMBURSEMENT';
-const completeHHGType = 'COMPLETE_HHG';
 const downloadPPMAttachmentsType = 'DOWNLOAD_ATTACHMENTS';
 const cancelMoveType = 'CANCEL_MOVE';
 const REMOVE_BANNER = 'REMOVE_BANNER';
@@ -84,8 +82,6 @@ const UPDATE_PPM = ReduxHelpers.generateAsyncActionTypes(updatePPMType);
 
 const APPROVE_PPM = ReduxHelpers.generateAsyncActionTypes(approvePPMType);
 
-const COMPLETE_HHG = ReduxHelpers.generateAsyncActionTypes(completeHHGType);
-
 const SEND_HHG_INVOICE = ReduxHelpers.generateAsyncActionTypes(sendHHGInvoiceType);
 
 export const CANCEL_MOVE = ReduxHelpers.generateAsyncActionTypes(cancelMoveType);
@@ -131,8 +127,6 @@ export const loadPPMs = ReduxHelpers.generateAsyncActionCreator(loadPPMsType, Lo
 export const updatePPM = ReduxHelpers.generateAsyncActionCreator(updatePPMType, UpdatePpm);
 
 export const approvePPM = ReduxHelpers.generateAsyncActionCreator(approvePPMType, ApprovePPM);
-
-export const completeHHG = ReduxHelpers.generateAsyncActionCreator(completeHHGType, CompleteHHG);
 
 export const sendHHGInvoice = ReduxHelpers.generateAsyncActionCreator(sendHHGInvoiceType, SendHHGInvoice);
 
@@ -564,18 +558,6 @@ export function officeReducer(state = initialState, action) {
     case APPROVE_PPM.failure:
       return Object.assign({}, state, {
         ppmIsApproving: false,
-        error: action.error.message,
-      });
-
-    case COMPLETE_HHG.success:
-      return Object.assign({}, state, {
-        officeMove: {
-          ...state.officeMove,
-          shipments: [action.payload],
-        },
-      });
-    case COMPLETE_HHG.failure:
-      return Object.assign({}, state, {
         error: action.error.message,
       });
 

--- a/src/scenes/Office/ducks.test.js
+++ b/src/scenes/Office/ducks.test.js
@@ -1,4 +1,4 @@
-import { APPROVE_REIMBURSEMENT, CANCEL_MOVE, officeReducer } from './ducks';
+import { APPROVE_REIMBURSEMENT, officeReducer } from './ducks';
 
 function createAdvance(status) {
   return {
@@ -6,18 +6,6 @@ function createAdvance(status) {
     method_of_receipt: 'MIL_PAY',
     requested_amount: 1000,
     status,
-  };
-}
-
-function createMove(status, cancelReason) {
-  return {
-    id: '1224ba31c-0dca-4e6a-b0c0-a987d4fed32c',
-    locator: 'CAJ214',
-    orders_id: '4134b2a1c-0dca-4e6a-b0c0-a987d4fe55ab',
-    selected_move_type: 'PPM',
-    personally_procured_moves: [],
-    status,
-    cancelReason,
   };
 }
 
@@ -72,62 +60,6 @@ describe('office Reducer', () => {
         otherState: 1,
         officePPMs: [{ id: '1234', advance: createAdvance('DRAFT') }],
         reimbursementIsApproving: false,
-        error: 'something went wrong',
-      });
-    });
-  });
-  describe('CANCEL_MOVE', () => {
-    it('handles SUCCESS', () => {
-      const initialState = {
-        otherState: 1,
-        officeMove: createMove('SUBMITTED', ''),
-      };
-      const newState = officeReducer(initialState, {
-        type: CANCEL_MOVE.success,
-        payload: createMove('CANCELED', 'Got tired'),
-      });
-
-      expect(newState).toEqual({
-        otherState: 1,
-        officeMove: createMove('CANCELED', 'Got tired'),
-        moveIsCanceling: false,
-        flashMessage: true,
-      });
-    });
-
-    it('handles START', () => {
-      const initialState = {
-        otherState: 1,
-        officeMove: createMove('DRAFT', ''),
-      };
-      const newState = officeReducer(initialState, {
-        type: CANCEL_MOVE.start,
-      });
-
-      expect(newState).toEqual({
-        otherState: 1,
-        officeMove: createMove('DRAFT', ''),
-        moveIsCanceling: true,
-      });
-    });
-
-    it('handles FAILURE', () => {
-      const initialState = {
-        otherState: 1,
-        officeMove: createMove('DRAFT', ''),
-      };
-      const newState = officeReducer(initialState, {
-        type: CANCEL_MOVE.failure,
-        error: {
-          message: 'something went wrong',
-        },
-      });
-
-      expect(newState).toEqual({
-        otherState: 1,
-        officeMove: createMove('DRAFT', ''),
-        moveIsCanceling: false,
-        flashMessage: false,
         error: 'something went wrong',
       });
     });

--- a/src/shared/Entities/modules/moves.js
+++ b/src/shared/Entities/modules/moves.js
@@ -7,6 +7,7 @@ import { getClient } from 'shared/Swagger/api';
 
 export const STATE_KEY = 'moves';
 const approveBasicsLabel = 'Moves.ApproveBasics';
+const cancelMoveLabel = 'Moves.CancelMove';
 
 export default function reducer(state = {}, action) {
   switch (action.type) {
@@ -44,6 +45,13 @@ export function approveBasics(moveId) {
   const label = approveBasicsLabel;
   const swaggerTag = 'office.approveMove';
   return swaggerRequest(getClient, swaggerTag, { moveId }, { label });
+}
+
+export function cancelMove(moveId, cancelReason) {
+  const label = cancelMoveLabel;
+  const swaggerTag = 'office.cancelMove';
+  const cancelMove = { cancel_reason: cancelReason };
+  return swaggerRequest(getClient, swaggerTag, { moveId, cancelMove }, { label });
 }
 
 export function selectMoveStatus(state, moveId) {

--- a/src/shared/Entities/modules/moves.js
+++ b/src/shared/Entities/modules/moves.js
@@ -38,3 +38,12 @@ export function selectMoveDatesSummary(state, moveId, moveDate) {
   }
   return get(state, `entities.moveDatesSummaries.${moveId}:${moveDate}`);
 }
+
+export function selectMoveStatus(state, moveId) {
+  const entitiesMove = get(state, `entities.moves.${moveId}`);
+  if (entitiesMove) {
+    return entitiesMove.status;
+  } else {
+    return get(state, 'office.officeMove.status', '');
+  }
+}

--- a/src/shared/Entities/modules/moves.js
+++ b/src/shared/Entities/modules/moves.js
@@ -6,6 +6,7 @@ import { swaggerRequest } from 'shared/Swagger/request';
 import { getClient } from 'shared/Swagger/api';
 
 export const STATE_KEY = 'moves';
+const approveBasicsLabel = 'Moves.ApproveBasics';
 
 export default function reducer(state = {}, action) {
   switch (action.type) {
@@ -37,6 +38,12 @@ export function selectMoveDatesSummary(state, moveId, moveDate) {
     return null;
   }
   return get(state, `entities.moveDatesSummaries.${moveId}:${moveDate}`);
+}
+
+export function approveBasics(moveId) {
+  const label = approveBasicsLabel;
+  const swaggerTag = 'office.approveMove';
+  return swaggerRequest(getClient, swaggerTag, { moveId }, { label });
 }
 
 export function selectMoveStatus(state, moveId) {

--- a/src/shared/Entities/modules/ppms.js
+++ b/src/shared/Entities/modules/ppms.js
@@ -1,0 +1,20 @@
+import { get } from 'lodash';
+import { swaggerRequest } from 'shared/Swagger/request';
+import { getClient } from 'shared/Swagger/api';
+
+const approvePpmLabel = 'PPMs.approvePPM';
+
+export function approvePPM(personallyProcuredMoveId) {
+  const label = approvePpmLabel;
+  const swaggerTag = 'office.approvePPM';
+  return swaggerRequest(getClient, swaggerTag, { personallyProcuredMoveId }, { label });
+}
+
+export function selectPpmStatus(state, id) {
+  const ppm = get(state, `entities.personallyProcuredMove.${id}`);
+  if (ppm) {
+    return ppm.status;
+  } else {
+    return get(state, 'office.officePPMs.0.status', '');
+  }
+}

--- a/src/shared/Entities/modules/shipments.js
+++ b/src/shared/Entities/modules/shipments.js
@@ -1,8 +1,11 @@
 import { denormalize } from 'normalizr';
+import { get } from 'lodash';
 
 import { shipments } from '../schema';
 import { swaggerRequest } from 'shared/Swagger/request';
 import { getClient, getPublicClient } from 'shared/Swagger/api';
+
+const approveShipmentLabel = 'Shipments.approveShipment';
 
 export function createOrUpdateShipment(label, moveId, shipment, id) {
   if (id) {
@@ -48,9 +51,24 @@ export function updatePublicShipment(
   );
 }
 
+export function approveShipment(shipmentId) {
+  const label = approveShipmentLabel;
+  const swaggerTag = 'shipments.approveHHG';
+  return swaggerRequest(getClient, swaggerTag, { shipmentId }, { label });
+}
+
 export function selectShipment(state, id) {
   if (!id) {
     return null;
   }
   return denormalize([id], shipments, state.entities)[0];
+}
+
+export function selectShipmentStatus(state, id) {
+  const shipment = selectShipment(state, id);
+  if (shipment) {
+    return shipment.status;
+  } else {
+    return get(state, 'office.officeMove.shipments.0.status', '');
+  }
 }

--- a/src/shared/Entities/modules/shipments.js
+++ b/src/shared/Entities/modules/shipments.js
@@ -6,6 +6,7 @@ import { swaggerRequest } from 'shared/Swagger/request';
 import { getClient, getPublicClient } from 'shared/Swagger/api';
 
 const approveShipmentLabel = 'Shipments.approveShipment';
+const completeShipmentLabel = 'Shipments.completeShipment';
 
 export function createOrUpdateShipment(label, moveId, shipment, id) {
   if (id) {
@@ -54,6 +55,12 @@ export function updatePublicShipment(
 export function approveShipment(shipmentId) {
   const label = approveShipmentLabel;
   const swaggerTag = 'shipments.approveHHG';
+  return swaggerRequest(getClient, swaggerTag, { shipmentId }, { label });
+}
+
+export function completeShipment(shipmentId) {
+  const label = completeShipmentLabel;
+  const swaggerTag = 'shipments.completeHHG';
   return swaggerRequest(getClient, swaggerTag, { shipmentId }, { label });
 }
 


### PR DESCRIPTION
## Description

Begin the process of migrating office ducks to entities.

## Reviewer Notes

We've added a few supporting selectors to look in entities for objects first, and then defer to the old location if the object isn't in the new location. Once the entire group of stories is finished, the selectors will be modified to not reference the old location(s).

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/n/projects/2181745/stories/163244006) for this change
