### PR TITLE
Fix inconstatant line items sort in invoice panel: 163407135

### DIFF
--- a/src/shared/Entities/modules/shipmentLineItems.js
+++ b/src/shared/Entities/modules/shipmentLineItems.js
@@ -30,20 +30,21 @@ export function getAllShipmentLineItems(label, shipmentId) {
   return swaggerRequest(getPublicClient, 'accessorials.getShipmentLineItems', { shipmentId }, { label });
 }
 
-function forceLinehaulSort(items) {
+// Show linehaul (and related) items before any accessorial items by adding isLinehaul property.
+function listLinehaulItemsBeforeAccessorials(items) {
   const linehaulRelatedItems = ['LHS', '135A', '135B', '105A', '105C', '16A'];
   return items.map(item => {
     return {
       ...item,
-      linehaulSort: linehaulRelatedItems.includes(item.tariff400ng_item.code) ? 1 : 10,
+      isLinehaul: linehaulRelatedItems.includes(item.tariff400ng_item.code) ? 1 : 10,
     };
   });
 }
 
 function orderItemsBy(items) {
   const sortOrder = {
-    fields: ['linehaulSort', 'status', 'approved_date', 'submitted_date', 'tariff400ng_item.code'],
-    order: ['asc', 'asc', 'desc', 'desc', 'asc'],
+    fields: ['isLinehaul', 'status', 'approved_date', 'submitted_date', 'tariff400ng_item.code'],
+    order: ['asc', 'asc', 'desc', 'desc', 'desc'],
   };
   return orderBy(items, sortOrder.fields, sortOrder.order);
 }
@@ -64,7 +65,7 @@ const selectShipmentLineItems = (state, shipmentId) => {
 };
 
 export const selectSortedShipmentLineItems = createSelector([selectShipmentLineItems], items =>
-  flow([forceLinehaulSort, orderItemsBy])(items),
+  flow([listLinehaulItemsBeforeAccessorials, orderItemsBy])(items),
 );
 
 export const selectSortedPreApprovalShipmentLineItems = createSelector(
@@ -102,11 +103,11 @@ const selectUnbilledShipmentLineItemsByShipmentId = (state, shipmentId) => {
 };
 
 export const selectUnbilledShipmentLineItems = createSelector([selectUnbilledShipmentLineItemsByShipmentId], items =>
-  flow([forceLinehaulSort, orderItemsBy])(items),
+  flow([listLinehaulItemsBeforeAccessorials, orderItemsBy])(items),
 );
 
 export const selectInvoiceShipmentLineItems = createSelector([selectInvoicesShipmentLineItemsByInvoiceId], items =>
-  flow([forceLinehaulSort, orderItemsBy])(items),
+  flow([listLinehaulItemsBeforeAccessorials, orderItemsBy])(items),
 );
 
 export const selectTotalFromUnbilledLineItems = createSelector([selectUnbilledShipmentLineItemsByShipmentId], items => {

--- a/src/shared/Entities/modules/shipmentLineItems.js
+++ b/src/shared/Entities/modules/shipmentLineItems.js
@@ -2,7 +2,7 @@ import { swaggerRequest } from 'shared/Swagger/request';
 import { getPublicClient } from 'shared/Swagger/api';
 import { shipmentLineItems as ShipmentLineItemsModel } from '../schema';
 import { denormalize } from 'normalizr';
-import { get, orderBy, filter, map, keys } from 'lodash';
+import { get, orderBy, filter, map, keys, flow } from 'lodash';
 import { createSelector } from 'reselect';
 
 export function createShipmentLineItem(label, shipmentId, payload) {
@@ -30,6 +30,24 @@ export function getAllShipmentLineItems(label, shipmentId) {
   return swaggerRequest(getPublicClient, 'accessorials.getShipmentLineItems', { shipmentId }, { label });
 }
 
+function forceLinehaulSort(items) {
+  const linehaulRelatedItems = ['LHS', '135A', '135B', '105A', '105C', '16A'];
+  return items.map(item => {
+    return {
+      ...item,
+      linehaulSort: linehaulRelatedItems.includes(item.tariff400ng_item.code) ? 1 : 10,
+    };
+  });
+}
+
+function orderItemsBy(items) {
+  const sortOrder = {
+    fields: ['linehaulSort', 'status', 'approved_date', 'submitted_date', 'tariff400ng_item.code'],
+    order: ['asc', 'asc', 'desc', 'desc', 'asc'],
+  };
+  return orderBy(items, sortOrder.fields, sortOrder.order);
+}
+
 const selectShipmentLineItems = (state, shipmentId) => {
   let filteredItems = denormalize(
     keys(get(state, 'entities.shipmentLineItems', {})),
@@ -45,8 +63,8 @@ const selectShipmentLineItems = (state, shipmentId) => {
   });
 };
 
-export const selectSortedShipmentLineItems = createSelector([selectShipmentLineItems], shipmentLineItems =>
-  orderBy(shipmentLineItems, ['status', 'approved_date', 'submitted_date'], ['asc', 'desc', 'desc']),
+export const selectSortedShipmentLineItems = createSelector([selectShipmentLineItems], items =>
+  flow([forceLinehaulSort, orderItemsBy])(items),
 );
 
 export const selectSortedPreApprovalShipmentLineItems = createSelector(
@@ -84,11 +102,11 @@ const selectUnbilledShipmentLineItemsByShipmentId = (state, shipmentId) => {
 };
 
 export const selectUnbilledShipmentLineItems = createSelector([selectUnbilledShipmentLineItemsByShipmentId], items =>
-  orderBy(items, ['status', 'approved_date', 'submitted_date'], ['asc', 'desc', 'desc']),
+  flow([forceLinehaulSort, orderItemsBy])(items),
 );
 
 export const selectInvoiceShipmentLineItems = createSelector([selectInvoicesShipmentLineItemsByInvoiceId], items =>
-  orderBy(items, ['status', 'approved_date', 'submitted_date'], ['asc', 'desc', 'desc']),
+  flow([forceLinehaulSort, orderItemsBy])(items),
 );
 
 export const selectTotalFromUnbilledLineItems = createSelector([selectUnbilledShipmentLineItemsByShipmentId], items => {


### PR DESCRIPTION
## Description

The sort order was inconsistent between the TSP and Office after clicking `Approve Payment` and reloading the TSP to show the approved line items.

New/additional sort criteria...
1. Show linehaul & related charges first before any accessorials.
2. Add orderBy `Code(desc)` to sort if all other orderBy fields are the same.

## Setup

Office side: add a few pre-approval items and click the approve checkmark.
TSP to view line items and make sure they match Office.
Click `Approve Payment` button in office and confirm. 
Once payment is approved, reload TSP page
Verify TSP and Office contain the line items in the same order

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/163407135) for this change

## Screenshots

![screen shot 2019-01-30 at 12 09 48 pm](https://user-images.githubusercontent.com/3099491/52004093-f4f10100-248b-11e9-9de6-fb6a6ca2435d.png)
