### PR TITLE
Add an api endpoint that allows automated testing to create devlocal users

### DIFF
--- a/cmd/webserver/main.go
+++ b/cmd/webserver/main.go
@@ -1082,7 +1082,8 @@ func main() {
 		root.Handle(pat.New("/devlocal-auth/*"), localAuthMux)
 		localAuthMux.Handle(pat.Get("/login"), authentication.NewUserListHandler(authContext, dbConnection))
 		localAuthMux.Handle(pat.Post("/login"), authentication.NewAssignUserHandler(authContext, dbConnection, clientAuthSecretKey, noSessionTimeout))
-		localAuthMux.Handle(pat.Post("/new"), authentication.NewCreateUserHandler(authContext, dbConnection, clientAuthSecretKey, noSessionTimeout))
+		localAuthMux.Handle(pat.Post("/new"), authentication.NewCreateAndLoginUserHandler(authContext, dbConnection, clientAuthSecretKey, noSessionTimeout))
+		localAuthMux.Handle(pat.Post("/create"), authentication.NewCreateUserHandler(authContext, dbConnection, clientAuthSecretKey, noSessionTimeout))
 
 		devlocalCa, err := ioutil.ReadFile(v.GetString("devlocal-ca")) // #nosec
 		if err != nil {

--- a/pkg/auth/authentication/devlocal_test.go
+++ b/pkg/auth/authentication/devlocal_test.go
@@ -1,0 +1,31 @@
+package authentication
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/transcom/mymove/pkg/models"
+)
+
+func (suite *AuthSuite) TestCreateUserHandler() {
+	t := suite.T()
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/devlocal-auth/create", nil)
+
+	authContext := NewAuthContext(suite.logger, fakeLoginGovProvider(suite.logger), "http", 1234)
+	handler := CreateUserHandler{authContext, suite.DB(), "fake key", false}
+	handler.ServeHTTP(rr, req)
+
+	suite.Equal(http.StatusOK, rr.Code, "handler returned wrong status code")
+	if status := rr.Code; status != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got %v wanted %v", status, http.StatusOK)
+	}
+
+	user := models.User{}
+	err := json.Unmarshal(rr.Body.Bytes(), &user)
+	if err != nil {
+		t.Error("Could not unmarshal json data into User model.", err)
+	}
+}


### PR DESCRIPTION
## Description

This change allows automated testing to create users via an api endpoint.  This will be handy for load testing which will want to make thousands of local users via api requests. 

See https://github.com/transcom/mymove/pull/1597

## Setup

```sh
go test ./pkg/auth/authentication/ -v -testify.m TestCreateUserHandler
```

## Code Review Verification Steps

* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/163239064) for this change