### PR TITLE
New make targets to allow users to run migrations without first checking server dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -267,11 +267,13 @@ db_dev_run: db_run db_dev_create
 
 db_dev_reset: db_destroy db_dev_run
 
-db_dev_migrate: server_deps
+db_dev_migrate_standalone:
 	@echo "Migrating the ${DB_NAME} database..."
 	# We need to move to the bin/ directory so that the cwd contains `apply-secure-migration.sh`
 	cd bin && \
 		./soda -c ../config/database.yml -p ../migrations migrate up
+
+db_dev_migrate: server_deps db_dev_migrate_standalone
 
 db_test_create:
 	@echo "Create the test database..."
@@ -296,12 +298,14 @@ db_test_migrations_build: .db_test_migrations_build.stamp
 	@echo "Build the docker migration container..."
 	docker build -f Dockerfile.migrations_local --tag e2e_migrations:latest .
 
-db_test_migrate: server_deps
+db_test_migrate_standalone:
 	@echo "Migrating the test database..."
 	# We need to move to the bin/ directory so that the cwd contains `apply-secure-migration.sh`
 	cd bin && \
 		DB_NAME=test_db \
 		./soda -c ../config/database.yml -p ../migrations migrate up
+
+db_test_migrate: server_deps db_test_migrate_standalone
 
 db_test_migrate_docker: db_test_migrations_build
 	@echo "Migrating the test database with docker command..."

--- a/README.md
+++ b/README.md
@@ -291,6 +291,7 @@ There are a few handy targets in the Makefile to help you interact with the dev 
 * `make db_dev_create`: Waits to connect to the DB and will create a DB if one doesn't already exist (run usually as part of `db_dev_run`).
 * `make db_dev_reset`: Destroys your database container. Useful if you want to start from scratch.
 * `make db_dev_migrate`: Applies database migrations against your running database container.
+* `make db_dev_migrate_standalone`: Applies database migrations against your running database container but will not check for server dependencies first.
 * `make db_dev_e2e_populate`: Populate data with data used to run e2e tests
 
 #### Test DB Commands
@@ -301,6 +302,7 @@ The Dev Commands are used to talk to the dev DB.  If you were working with the t
 * `make db_test_create`
 * `make db_test_reset`
 * `make db_test_migrate`
+* `make db_test_migrate_standalone`
 * `make db_test_e2e_populate`
 
 The test DB commands all talk to the DB over localhost.  But in a docker-only environment (like CircleCI) you may not be able to use those commands, which is why `*_docker` versions exist for all of them:


### PR DESCRIPTION
## Description

This eliminates the need for a working network when doing DB operations.  I was working with migrations when my internet stopped working.  I had no real way to do the migrations because I was stuck on `make server_deps` trying to do `dep ensure`. 

## Setup

```sh
make db_dev_reset db_dev_migrate_standalone
```