### PR TITLE
Filter out url parameter when a non-relative path is provided. Also a…

### DIFF
--- a/bin/copy_swagger_ui.sh
+++ b/bin/copy_swagger_ui.sh
@@ -6,4 +6,3 @@
 # if it ever changes.
 cp node_modules/swagger-ui-dist/{*.js,*.css,*.png} public/swagger-ui
 cp node_modules/js-cookie/src/js.cookie.js public/swagger-ui
-if [ -f "build/swagger-ui/" ]; then cp -rf public/swagger-ui/* build/swagger-ui/; fi

--- a/bin/copy_swagger_ui.sh
+++ b/bin/copy_swagger_ui.sh
@@ -6,4 +6,3 @@
 # if it ever changes.
 cp node_modules/swagger-ui-dist/{*.js,*.css,*.png} public/swagger-ui
 cp node_modules/js-cookie/src/js.cookie.js public/swagger-ui
-cp -rf public/swagger-ui/* build/swagger-ui

--- a/bin/copy_swagger_ui.sh
+++ b/bin/copy_swagger_ui.sh
@@ -6,3 +6,4 @@
 # if it ever changes.
 cp node_modules/swagger-ui-dist/{*.js,*.css,*.png} public/swagger-ui
 cp node_modules/js-cookie/src/js.cookie.js public/swagger-ui
+cp -rf public/swagger-ui/* build/swagger-ui

--- a/bin/copy_swagger_ui.sh
+++ b/bin/copy_swagger_ui.sh
@@ -6,3 +6,4 @@
 # if it ever changes.
 cp node_modules/swagger-ui-dist/{*.js,*.css,*.png} public/swagger-ui
 cp node_modules/js-cookie/src/js.cookie.js public/swagger-ui
+if [ -f "build/swagger-ui/" ]; then cp -rf public/swagger-ui/* build/swagger-ui/; fi

--- a/public/swagger-ui/api.html
+++ b/public/swagger-ui/api.html
@@ -88,7 +88,7 @@ window.onload = function() {
     var protocolRegex = /(http|https):*/;
     var isNonRelativePath = protocolRegex.test(req['url']);
     if (isNonRelativePath) {
-      req['url'] = '/api/v1/swagger.yaml';
+      req['url'] = null;
     }
 
     return req;

--- a/public/swagger-ui/api.html
+++ b/public/swagger-ui/api.html
@@ -88,7 +88,7 @@ window.onload = function() {
     var protocolRegex = /(http|https):*/;
     var isNonRelativePath = protocolRegex.test(req['url']);
     if (isNonRelativePath) {
-      req['url'] = '/internal/swagger.yaml';
+      req['url'] = '/api/v1/swagger.yaml';
     }
 
     return req;

--- a/public/swagger-ui/api.html
+++ b/public/swagger-ui/api.html
@@ -82,6 +82,15 @@ window.onload = function() {
         console.warn('Unable to retrieve CSRF Token from cookie');
       }
     }
+    // Add check for protocol so that we know if someone tries to throw a non-relative path in the url parameter.
+    // This is here to prevent malicious actors using the parameter to execute arbitrary malicious code on an
+    // unsuspecting user (swagger-ui behavior causes this to happen otherwise).
+    var protocolRegex = /(http|https):*/;
+    var isNonRelativePath = protocolRegex.test(req['url']);
+    if (isNonRelativePath) {
+      req['url'] = '/internal/swagger.yaml';
+    }
+
     return req;
   };
 

--- a/public/swagger-ui/internal.html
+++ b/public/swagger-ui/internal.html
@@ -88,7 +88,7 @@ window.onload = function() {
     var protocolRegex = /(http|https):*/;
     var isNonRelativePath = protocolRegex.test(req['url']);
     if (isNonRelativePath) {
-      req['url'] = '/internal/swagger.yaml';
+      req['url'] = null;
     }
 
     return req;

--- a/public/swagger-ui/internal.html
+++ b/public/swagger-ui/internal.html
@@ -82,6 +82,15 @@ window.onload = function() {
         console.warn('Unable to retrieve CSRF Token from cookie');
       }
     }
+    // Add check for protocol so that we know if someone tries to throw a non-relative path in the url parameter.
+    // This is here to prevent malicious actors using the parameter to execute arbitrary malicious code on an
+    // unsuspecting user (swagger-ui behavior causes this to happen otherwise).
+    var protocolRegex = /(http|https):*/;
+    var isNonRelativePath = protocolRegex.test(req['url']);
+    if (isNonRelativePath) {
+      req['url'] = '/internal/swagger.yaml';
+    }
+
     return req;
   };
 


### PR DESCRIPTION
…dds line to copy_swagger_ui.sh to copy the public/swagger-ui directory over to the build/swagger-ui directory for builds.

## Description

Filter out non-relative paths provided as the url parmeter within Swagger UI. This tool has a behavior will it will try to fetch the parameter for render, so we don't want to be doing this with external resources. There is a non-trivial risk that a malicious actor may take advantage.

## Setup

Go here: https://my.move.mil/api/v1/docs?url=[some external link]
See that it is loading external content.

In your local environment you can compare the same by going here while your environment is running:
http://milmovelocal:3000/api/v1/docs?url=[some external link]).

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](./docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](./docs/backend.md#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](./docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
  * [ ] Secure migrations have been tested using `bin/run-prod-migrations`
* [ ] There are no aXe warnings for UI.
* [ ] This works in IE.
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @willowbl00
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/163599170) for this change


## Screenshots
Bad situation:
![screen shot 2019-01-31 at 1 57 37 pm](https://user-images.githubusercontent.com/4325613/52081643-5a162680-2560-11e9-910a-9bce7934284f.png)

Not bad situation:
![screen shot 2019-01-31 at 1 58 19 pm](https://user-images.githubusercontent.com/4325613/52081647-5da9ad80-2560-11e9-89b0-b406b53b380b.png)

