### PR TITLE
Adds Cypress command for selecting a move locator

### DIFF
--- a/cypress/integration/office/datesPanel.js
+++ b/cypress/integration/office/datesPanel.js
@@ -22,10 +22,7 @@ function officeUserGoesToDatesPanel(locator) {
   });
 
   // Find shipment and open it
-  cy
-    .get('div')
-    .contains(locator)
-    .dblclick();
+  cy.selectQueueItemMoveLocator(locator);
 
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/queues\/new\/moves\/[^/]+\/basics/);

--- a/cypress/integration/office/documentViewer.js
+++ b/cypress/integration/office/documentViewer.js
@@ -210,10 +210,7 @@ describe('The document viewer', function() {
         .contains('Delivered HHGs')
         .click();
 
-      cy
-        .get('div')
-        .contains('DOOB')
-        .dblclick();
+      cy.selectQueueItemMoveLocator('DOOB');
 
       cy.location().should(loc => {
         expect(loc.pathname).to.match(/^\/queues\/new\/moves\/[^/]+\/basics/);

--- a/cypress/integration/office/locationsPanel.js
+++ b/cypress/integration/office/locationsPanel.js
@@ -71,10 +71,7 @@ function officeUserViewsLocation({ shipmentId, type, expectation }) {
   });
 
   // Find a shipment and open it
-  cy
-    .get('div')
-    .contains(shipmentId)
-    .dblclick();
+  cy.selectQueueItemMoveLocator(shipmentId);
 
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/queues\/new\/moves\/[^/]+\/basics/);
@@ -141,10 +138,7 @@ function officeUserEntersLocations() {
   });
 
   // Find shipment and open it
-  cy
-    .get('div')
-    .contains('BACON3')
-    .dblclick();
+  cy.selectQueueItemMoveLocator('BACON3');
 
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/queues\/new\/moves\/[^/]+\/basics/);

--- a/cypress/integration/office/officePremoveSurvey.js
+++ b/cypress/integration/office/officePremoveSurvey.js
@@ -18,10 +18,7 @@ function officeUserEntersPreMoveSurvey() {
   });
 
   // Find move and open it
-  cy
-    .get('div')
-    .contains('RLKBEM')
-    .dblclick();
+  cy.selectQueueItemMoveLocator('RLKBEM');
 
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/queues\/new\/moves\/[^/]+\/basics/);

--- a/cypress/integration/office/officeServiceAgents.js
+++ b/cypress/integration/office/officeServiceAgents.js
@@ -48,10 +48,7 @@ function officeUserOpensHhgPanelForMove(moveLocator) {
   });
 
   // Find move and open it
-  cy
-    .get('div')
-    .contains(moveLocator)
-    .dblclick();
+  cy.selectQueueItemMoveLocator(moveLocator);
 
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/queues\/new\/moves\/[^/]+\/basics/);

--- a/cypress/integration/office/officeUserHHG.js
+++ b/cypress/integration/office/officeUserHHG.js
@@ -33,10 +33,7 @@ function officeUserViewsMoves() {
   });
 
   // Find move (generated in e2ebasic.go) and open it
-  cy
-    .get('div')
-    .contains('RLKBEM')
-    .dblclick();
+  cy.selectQueueItemMoveLocator('RLKBEM');
 
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/queues\/new\/moves\/[^/]+\/basics/);
@@ -60,10 +57,7 @@ function officeUserViewsDeliveredShipment() {
   });
 
   // Find move (generated in e2ebasic.go) and open it
-  cy
-    .get('div')
-    .contains('SCHNOO')
-    .dblclick();
+  cy.selectQueueItemMoveLocator('SCHNOO');
 
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/queues\/new\/moves\/[^/]+\/basics/);
@@ -87,10 +81,7 @@ function officeUserViewsCompletedShipment() {
   });
 
   // Find move (generated in e2ebasic.go) and open it
-  cy
-    .get('div')
-    .contains('NOCHKA')
-    .dblclick();
+  cy.selectQueueItemMoveLocator('NOCHKA');
 
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/queues\/new\/moves\/[^/]+\/basics/);
@@ -114,10 +105,7 @@ function officeUserViewsAcceptedShipment() {
   });
 
   // Find move (generated in e2ebasic.go) and open it
-  cy
-    .get('div')
-    .contains('BACON3')
-    .dblclick();
+  cy.selectQueueItemMoveLocator('BACON3');
 
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/queues\/new\/moves\/[^/]+\/basics/);
@@ -141,10 +129,7 @@ function officeUserApprovesOnlyBasicsHHG() {
   });
 
   // Find move and open it
-  cy
-    .get('div')
-    .contains('BACON6')
-    .dblclick();
+  cy.selectQueueItemMoveLocator('BACON6');
 
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/queues\/new\/moves\/[^/]+\/basics/);
@@ -205,10 +190,7 @@ function officeUserApprovesHHG() {
   });
 
   // Find move and open it
-  cy
-    .get('div')
-    .contains('BACON5')
-    .dblclick();
+  cy.selectQueueItemMoveLocator('BACON5');
 
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/queues\/new\/moves\/[^/]+\/basics/);
@@ -269,10 +251,7 @@ function officeUserCompletesHHG() {
   });
 
   // Find move and open it
-  cy
-    .get('div')
-    .contains('SSETZN')
-    .dblclick();
+  cy.selectQueueItemMoveLocator('SSETZN');
 
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/queues\/new\/moves\/[^/]+\/basics/);

--- a/cypress/integration/office/officeUserHHGPPM.js
+++ b/cypress/integration/office/officeUserHHGPPM.js
@@ -81,11 +81,7 @@ function officeUserVisitsHHGTab() {
 }
 
 function officeUserViewsMove(locator) {
-  cy
-    .get('div')
-    .contains(locator)
-    .should('exist')
-    .dblclick();
+  cy.selectQueueItemMoveLocator(locator);
 
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/queues\/new\/moves\/[^/]+\/basics/);

--- a/cypress/integration/office/officeUserPPM.js
+++ b/cypress/integration/office/officeUserPPM.js
@@ -24,10 +24,7 @@ function officeUserViewsMoves() {
   });
 
   // Find move and open it
-  cy
-    .get('div')
-    .contains('VGHEIS')
-    .dblclick();
+  cy.selectQueueItemMoveLocator('VGHEIS');
 
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/queues\/new\/moves\/[^/]+\/basics/);
@@ -41,10 +38,7 @@ function officeUserVerifiesOrders() {
   });
 
   // Find move and open it
-  cy
-    .get('div')
-    .contains('VGHEIS')
-    .dblclick();
+  cy.selectQueueItemMoveLocator('VGHEIS');
 
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/queues\/new\/moves\/[^/]+\/basics/);
@@ -109,10 +103,7 @@ function officeUserVerifiesAccounting() {
   });
 
   // Find move and open it
-  cy
-    .get('div')
-    .contains('VGHEIS')
-    .dblclick();
+  cy.selectQueueItemMoveLocator('VGHEIS');
 
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/queues\/new\/moves\/[^/]+\/basics/);
@@ -164,10 +155,7 @@ function officeUserApprovesMoveAndVerifiesPPM() {
   });
 
   // Find move and open it
-  cy
-    .get('div')
-    .contains('VGHEIS')
-    .dblclick();
+  cy.selectQueueItemMoveLocator('VGHEIS');
 
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/queues\/new\/moves\/[^/]+\/basics/);
@@ -201,10 +189,7 @@ function officeUserApprovesMoveAndVerifiesPPM() {
     .click();
 
   // Find move and open it
-  cy
-    .get('div')
-    .contains('VGHEIS')
-    .dblclick();
+  cy.selectQueueItemMoveLocator('VGHEIS');
 
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/queues\/new\/moves\/[^/]+\/basics/);

--- a/cypress/integration/office/preApprovalRequest.js
+++ b/cypress/integration/office/preApprovalRequest.js
@@ -32,10 +32,7 @@ function officeUserCreatesPreApprovalRequest() {
   });
 
   // Find move and open it
-  cy
-    .get('div')
-    .contains('RLKBEM')
-    .dblclick();
+  cy.selectQueueItemMoveLocator('RLKBEM');
 
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/queues\/new\/moves\/[^/]+\/basics/);
@@ -65,10 +62,7 @@ function officeUserEditsPreApprovalRequest() {
   });
 
   // Find move and open it
-  cy
-    .get('div')
-    .contains('RLKBEM')
-    .dblclick();
+  cy.selectQueueItemMoveLocator('RLKBEM');
 
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/queues\/new\/moves\/[^/]+\/basics/);
@@ -99,10 +93,7 @@ function officeUserApprovesPreApprovalRequest() {
   });
 
   // Find move and open it
-  cy
-    .get('div')
-    .contains('RLKBEM')
-    .dblclick();
+  cy.selectQueueItemMoveLocator('RLKBEM');
 
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/queues\/new\/moves\/[^/]+\/basics/);
@@ -132,10 +123,7 @@ function officeUserDeletesPreApprovalRequest() {
   });
 
   // Find move and open it
-  cy
-    .get('div')
-    .contains('RLKBEM')
-    .dblclick();
+  cy.selectQueueItemMoveLocator('RLKBEM');
 
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/queues\/new\/moves\/[^/]+\/basics/);

--- a/cypress/integration/office/weightsAndItemsPanel.js
+++ b/cypress/integration/office/weightsAndItemsPanel.js
@@ -64,10 +64,7 @@ function openMoveHhgPanel() {
   });
 
   // Find shipment and open it
-  cy
-    .get('div')
-    .contains('WTSPNL')
-    .dblclick();
+  cy.selectQueueItemMoveLocator('WTSPNL');
 
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/queues\/new\/moves\/[^/]+\/basics/);

--- a/cypress/integration/tsp/checkBasics.js
+++ b/cypress/integration/tsp/checkBasics.js
@@ -15,10 +15,7 @@ function tspUserViewsCustomerInfo() {
   });
 
   // Find a shipment and open it
-  cy
-    .get('div')
-    .contains('BACON4')
-    .dblclick();
+  cy.selectQueueItemMoveLocator('BACON4');
 
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/shipments\/[^/]+/);

--- a/cypress/integration/tsp/checkHeader.js
+++ b/cypress/integration/tsp/checkHeader.js
@@ -20,10 +20,7 @@ function tspUserViewsHHGHeaderInfo() {
   });
 
   // Find a shipment and open it
-  cy
-    .get('div')
-    .contains('HHGPPM')
-    .dblclick();
+  cy.selectQueueItemMoveLocator('HHGPPM');
 
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/shipments\/[^/]+/);
@@ -59,10 +56,7 @@ function tspUserViewsHHGPPMHeaderInfo() {
   });
 
   // Find a shipment and open it
-  cy
-    .get('div')
-    .contains('HHGPPM')
-    .dblclick();
+  cy.selectQueueItemMoveLocator('HHGPPM');
 
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/shipments\/[^/]+/);

--- a/cypress/integration/tsp/customerInfoPanel.js
+++ b/cypress/integration/tsp/customerInfoPanel.js
@@ -22,10 +22,7 @@ function tspUserOpensAShipment(shipment) {
   });
 
   // Find a shipment and open it
-  cy
-    .get('div')
-    .contains(shipment)
-    .dblclick();
+  cy.selectQueueItemMoveLocator(shipment);
 
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/shipments\/[^/]+/);

--- a/cypress/integration/tsp/datesPanel.js
+++ b/cypress/integration/tsp/datesPanel.js
@@ -22,10 +22,7 @@ function tspUserGoesToDatesPanel(locator) {
   });
 
   // Find shipment and open it
-  cy
-    .get('div')
-    .contains(locator)
-    .dblclick();
+  cy.selectQueueItemMoveLocator(locator);
 
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/shipments\/[^/]+/);

--- a/cypress/integration/tsp/documentViewer.js
+++ b/cypress/integration/tsp/documentViewer.js
@@ -15,10 +15,7 @@ describe('The document viewer', function() {
     });
 
     // Find a shipment and open it
-    cy
-      .get('div')
-      .contains('DOCVWR')
-      .dblclick();
+    cy.selectQueueItemMoveLocator('DOCVWR');
 
     cy.location().should(loc => {
       expect(loc.pathname).to.match(/^\/shipments\/[^/]+/);
@@ -58,10 +55,7 @@ describe('The document viewer', function() {
     });
 
     // Find a shipment with a doc
-    cy
-      .get('div')
-      .contains('GOTDOC')
-      .dblclick();
+    cy.selectQueueItemMoveLocator('GOTDOC');
 
     cy.location().should(loc => {
       expect(loc.pathname).to.match(/^\/shipments\/[^/]+/);
@@ -110,10 +104,7 @@ describe('The document viewer', function() {
       .contains('Delivered Shipments')
       .click();
 
-    cy
-      .get('div')
-      .contains('DOOB')
-      .dblclick();
+    cy.selectQueueItemMoveLocator('DOOB');
 
     cy
       .get('.invoice-panel')

--- a/cypress/integration/tsp/generateGBL.js
+++ b/cypress/integration/tsp/generateGBL.js
@@ -28,10 +28,7 @@ function tspUserCannotGenerateGBL() {
     expect(loc.pathname).to.match(/^\/queues\/accepted/);
   });
 
-  cy
-    .get('div')
-    .contains('GBLDIS')
-    .dblclick();
+  cy.selectQueueItemMoveLocator('GBLDIS');
 
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/shipments\/[^/]+/);
@@ -53,10 +50,7 @@ function tspUserGeneratesGBL() {
   });
 
   // Find shipment
-  cy
-    .get('div')
-    .contains('GBLGBL')
-    .dblclick();
+  cy.selectQueueItemMoveLocator('GBLGBL');
 
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/shipments\/[^/]+/);
@@ -106,10 +100,7 @@ function tspUserViewsGBL() {
   });
 
   // Find shipment
-  cy
-    .get('div')
-    .contains('GBLGBL')
-    .dblclick();
+  cy.selectQueueItemMoveLocator('GBLGBL');
 
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/shipments\/[^/]+/);

--- a/cypress/integration/tsp/locationsPanel.js
+++ b/cypress/integration/tsp/locationsPanel.js
@@ -69,10 +69,7 @@ function tspUserViewsLocation({ shipmentId, type, expectation }) {
   });
 
   // Find a shipment and open it
-  cy
-    .get('div')
-    .contains(shipmentId)
-    .dblclick();
+  cy.selectQueueItemMoveLocator(shipmentId);
 
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/shipments\/[^/]+/);
@@ -134,10 +131,7 @@ function tspUserEntersLocations() {
   });
 
   // Find shipment and open it
-  cy
-    .get('div')
-    .contains('BACON1')
-    .dblclick();
+  cy.selectQueueItemMoveLocator('BACON1');
 
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/shipments\/[^/]+/);

--- a/cypress/integration/tsp/preApprovalRequest.js
+++ b/cypress/integration/tsp/preApprovalRequest.js
@@ -27,10 +27,7 @@ function tspUserCreatesPreApprovalRequest() {
   });
 
   // Find shipment and open it
-  cy
-    .get('div')
-    .contains('DATESP')
-    .dblclick();
+  cy.selectQueueItemMoveLocator('DATESP');
 
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/shipments\/[^/]+/);
@@ -51,10 +48,7 @@ function tspUserEditsPreApprovalRequest() {
   });
 
   // Find shipment and open it
-  cy
-    .get('div')
-    .contains('DATESP')
-    .dblclick();
+  cy.selectQueueItemMoveLocator('DATESP');
 
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/shipments\/[^/]+/);
@@ -72,10 +66,7 @@ function tspUserDeletesPreApprovalRequest() {
   });
 
   // Find shipment and open it
-  cy
-    .get('div')
-    .contains('DATESP')
-    .dblclick();
+  cy.selectQueueItemMoveLocator('DATESP');
 
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/shipments\/[^/]+/);

--- a/cypress/integration/tsp/premoveSurvey.js
+++ b/cypress/integration/tsp/premoveSurvey.js
@@ -141,10 +141,7 @@ function tspUserGoesToShipment(queue, locator) {
   cy.patientVisit(queue);
 
   // Find shipment and open it
-  cy
-    .get('div')
-    .contains(locator)
-    .dblclick();
+  cy.selectQueueItemMoveLocator(locator);
 
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/shipments\/[^/]+/);

--- a/cypress/integration/tsp/queues.js
+++ b/cypress/integration/tsp/queues.js
@@ -52,10 +52,7 @@ function tspUserViewsNewShipments() {
     .contains('div', '15-May-18');
 
   // Find and open shipment
-  cy
-    .get('div')
-    .contains('BACON1')
-    .dblclick();
+  cy.selectQueueItemMoveLocator('BACON1');
 
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/shipments\/[^/]+/);
@@ -73,10 +70,7 @@ function tspUserViewsInTransitShipments() {
   cy.get('h1').contains('Queue: In Transit Shipments');
 
   // Find in transit (generated in e2ebasic.go) and open it
-  cy
-    .get('div')
-    .contains('NINOPK')
-    .dblclick();
+  cy.selectQueueItemMoveLocator('NINOPK');
 
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/shipments\/[^/]+/);
@@ -99,10 +93,7 @@ function tspUserViewsDeliveredShipments() {
   cy.get('h1').contains('Queue: Delivered Shipments');
 
   // Find delivered shipment (generated in e2ebasic.go) and open it
-  cy
-    .get('div')
-    .contains('SCHNOO')
-    .dblclick();
+  cy.selectQueueItemMoveLocator('SCHNOO');
 
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/shipments\/[^/]+/);
@@ -129,10 +120,7 @@ function tspUserViewsAcceptedShipments() {
   cy.get('h1').contains('Queue: Accepted Shipments');
 
   // Find shipment
-  cy
-    .get('div')
-    .contains('BACON3')
-    .dblclick();
+  cy.selectQueueItemMoveLocator('BACON3');
 
   // Status
   tspUserVerifiesShipmentStatus('Shipment accepted');
@@ -159,10 +147,7 @@ function tspUserViewsApprovedShipments() {
     .get('div')
     .contains('BACON1')
     .should('not.exist');
-  cy
-    .get('div')
-    .contains('APPRVD')
-    .dblclick();
+  cy.selectQueueItemMoveLocator('APPRVD');
 
   // Status
   tspUserVerifiesShipmentStatus('Awaiting pre-move survey');
@@ -185,10 +170,7 @@ function tspUserViewsCompletedShipments() {
   cy.get('h1').contains('Queue: Completed Shipments');
 
   // Find shipment
-  cy
-    .get('div')
-    .contains('NOCHKA')
-    .dblclick();
+  cy.selectQueueItemMoveLocator('NOCHKA');
 
   // Status
   tspUserVerifiesShipmentStatus('Delivered');

--- a/cypress/integration/tsp/serviceAgents.js
+++ b/cypress/integration/tsp/serviceAgents.js
@@ -101,10 +101,7 @@ function tspUserEntersServiceAgent() {
   });
 
   // Find shipment and open it
-  cy
-    .get('div')
-    .contains('BACON2')
-    .dblclick();
+  cy.selectQueueItemMoveLocator('BACON2');
 
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/shipments\/[^/]+/);
@@ -125,10 +122,7 @@ function tspUserAcceptsShipment() {
   });
 
   // Find shipment and open it
-  cy
-    .get('div')
-    .contains('BACON2')
-    .dblclick();
+  cy.selectQueueItemMoveLocator('BACON2');
 
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/shipments\/[^/]+/);
@@ -159,10 +153,7 @@ function tspUserClicksAssignServiceAgent(locator) {
   cy.patientVisit('/queues/accepted');
 
   // Find shipment and open it
-  cy
-    .get('div')
-    .contains(locator)
-    .dblclick();
+  cy.selectQueueItemMoveLocator(locator);
 
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/shipments\/[^/]+/);

--- a/cypress/integration/tsp/shipShipment.js
+++ b/cypress/integration/tsp/shipShipment.js
@@ -71,10 +71,7 @@ function tspUserVisitsAnInTransitShipment(locator) {
     expect(loc.pathname).to.match(/^\/queues\/in_transit/);
   });
 
-  cy
-    .get('div')
-    .contains(locator)
-    .dblclick();
+  cy.selectQueueItemMoveLocator(locator);
 }
 
 function tspUserEntersPackAndPickUpInfo() {
@@ -91,10 +88,7 @@ function tspUserEntersPackAndPickUpInfo() {
   });
 
   // Find shipment and open it
-  cy
-    .get('div')
-    .contains('CONGBL')
-    .dblclick();
+  cy.selectQueueItemMoveLocator('CONGBL');
 
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/shipments\/[^/]+/);

--- a/cypress/integration/tsp/weightsAndItemsPanel.js
+++ b/cypress/integration/tsp/weightsAndItemsPanel.js
@@ -62,10 +62,7 @@ function tspUserSeesEstimatedWeights() {
   });
 
   // Find shipment and open it
-  cy
-    .get('div')
-    .contains('BACON4')
-    .dblclick();
+  cy.selectQueueItemMoveLocator('BACON4');
 
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/shipments\/[^/]+/);
@@ -102,10 +99,7 @@ function tspUserEntersNetWeight() {
   });
 
   // Find shipment and open it
-  cy
-    .get('div')
-    .contains('BACON4')
-    .dblclick();
+  cy.selectQueueItemMoveLocator('BACON4');
 
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/shipments\/[^/]+/);

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -1,5 +1,5 @@
 import * as mime from 'mime-types';
-import { milmoveAppName, officeAppName, tspAppName } from './constants';
+import { milmoveAppName, officeAppName, tspAppName, longPageLoadTimeout } from './constants';
 
 /* global Cypress, cy */
 // ***********************************************
@@ -65,18 +65,31 @@ Cypress.Commands.add('signInAsUser', userId => {
 // Reloads the page but makes an attempt to wait for the loading screen to disappear
 Cypress.Commands.add('patientReload', () => {
   cy.reload();
-  cy.waitForLoadingScreen(10000);
+  cy.waitForLoadingScreen();
 });
 
 // Visits a given URL but makes an attempt to wait for the loading screen to disappear
 Cypress.Commands.add('patientVisit', url => {
   cy.visit(url);
-  cy.waitForLoadingScreen(10000);
+  cy.waitForLoadingScreen();
 });
 
 // Waits for the loading screen to disappear for a given amount of milliseconds
-Cypress.Commands.add('waitForLoadingScreen', ms => {
+Cypress.Commands.add('waitForLoadingScreen', (ms = longPageLoadTimeout) => {
   cy.get('h2[data-name="loading-placeholder"]', { timeout: ms }).should('not.exist');
+});
+
+// Attempts to double-click a given move locator in a shipment queue list
+Cypress.Commands.add('selectQueueItemMoveLocator', moveLocator => {
+  // Wait for ReactTable loading to be completed
+  cy.get('.ReactTable').within(() => {
+    cy.get('.-loading -active', { timeout: longPageLoadTimeout }).should('not.exist');
+  });
+
+  cy
+    .get('div')
+    .contains(moveLocator)
+    .dblclick();
 });
 
 Cypress.Commands.add(

--- a/cypress/support/constants.js
+++ b/cypress/support/constants.js
@@ -1,3 +1,4 @@
+export const longPageLoadTimeout = 10000;
 export const fileUploadTimeout = 10000;
 export const milmoveAppName = 'milmove';
 export const officeAppName = 'office';


### PR DESCRIPTION
## Description

We started getting flaky failures recently around e2e tests that loaded either a TSP or office queue. Turns out our queues use a `ReactTable`, which implements its _own_ loading UI that we make use of. We have some Cypress workarounds for the loading screen we invented, but not this ReactTable one. So this PR creates an abstraction around selecting a move by moveLocator and adds a check that the table's loading UI is gone