### PR TITLE
disallows entrance of letters into decimal fields

### DIFF
--- a/src/shared/JsonSchemaForm/validator.js
+++ b/src/shared/JsonSchemaForm/validator.js
@@ -113,14 +113,14 @@ const createDecimalNormalizer = decimalDigits => {
     if (!value) {
       return value;
     }
-    const onlyNumsAndDots = value.replace(/[^\d.]/g, '');
+    value = value.replace(/[^\d.]/g, '');
 
-    if (onlyNumsAndDots.indexOf('.') >= 0) {
+    if (value.indexOf('.') >= 0) {
       value =
-        onlyNumsAndDots.substr(0, onlyNumsAndDots.indexOf('.')) +
+        value.substr(0, value.indexOf('.')) +
         '.' +
-        onlyNumsAndDots
-          .substr(onlyNumsAndDots.indexOf('.') + 1)
+        value
+          .substr(value.indexOf('.') + 1)
           .replace(/[^\d]/g, '')
           .substr(0, decimalDigits);
     }


### PR DESCRIPTION
## Description

Previously, letters could be entered into decimal fields in preapproval requests (base quantity fields or dimensions fields). If letters were entered, an error would be returned on submission. This disallows the entrance of letters into those fields. 

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](./docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](./docs/backend.md#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](./docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
  * [ ] Secure migrations have been tested using `bin/run-prod-migrations`
* [ ] There are no aXe warnings for UI.
* [ ] This works in IE.
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @willowbl00
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/163707021) for this change
