### PR TITLE
Add data for February to fuel_eia_diesel_price

### DIFF
--- a/migrations/20190205015958_add_february_fuel_eia_diesel_prices.up.fizz
+++ b/migrations/20190205015958_add_february_fuel_eia_diesel_prices.up.fizz
@@ -1,0 +1,3 @@
+sql("INSERT INTO public.fuel_eia_diesel_prices (id, pub_date, rate_start_date, rate_end_date, eia_price_per_gallon_millicents, baseline_rate, created_at, updated_at)
+     VALUES
+     ('042d1a74-bfc8-4fc6-83fe-8267779c65a4', '2019-02-04', '2019-02-15', '2019-03-14', 296600, 4, now(), now());")


### PR DESCRIPTION
## Description

Added the data for February's fuel surcharge to the PostgreSQL db


## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make db_dev_migrate
bin/psql-dev
SELECT * FROM fuel_eia_diesel_prices;
```
Open the PostgreSQL db and look for the entry with `pub_date` 2019-02-04

## Code Review Verification Steps

* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* Please see the Pivotal story: [Manually import fuel surcharge: FEBRUARY](https://www.pivotaltracker.com/story/show/162629083) 
* On the [US Energy Information Administration website](https://www.eia.gov/petroleum/gasdiesel/) please see the second table titled "U.S. On-Highway Diesel Fuel Prices"
  * We want the data for the first Monday of February which is 02/04/2019 