### PR TITLE
Waits for ReactTable on app login for office, tsp

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -46,10 +46,12 @@ Cypress.Commands.add('signIntoMyMoveAsUser', userId => {
 Cypress.Commands.add('signIntoOffice', () => {
   cy.setupBaseUrl(officeAppName);
   cy.signInAsUser('9bfa91d2-7a0c-4de0-ae02-b8cf8b4b858b');
+  cy.waitForReactTableLoad();
 });
 Cypress.Commands.add('signIntoTSP', () => {
   cy.setupBaseUrl(tspAppName);
   cy.signInAsUser('6cd03e5b-bee8-4e97-a340-fecb8f3d5465');
+  cy.waitForReactTableLoad();
 });
 Cypress.Commands.add('signInAsUser', userId => {
   // make sure we log out first before sign in
@@ -80,11 +82,16 @@ Cypress.Commands.add('waitForLoadingScreen', (ms = longPageLoadTimeout) => {
 });
 
 // Attempts to double-click a given move locator in a shipment queue list
-Cypress.Commands.add('selectQueueItemMoveLocator', moveLocator => {
+Cypress.Commands.add('waitForReactTableLoad', () => {
   // Wait for ReactTable loading to be completed
   cy.get('.ReactTable').within(() => {
     cy.get('.-loading.-active', { timeout: longPageLoadTimeout }).should('not.exist');
   });
+});
+
+// Attempts to double-click a given move locator in a shipment queue list
+Cypress.Commands.add('selectQueueItemMoveLocator', moveLocator => {
+  cy.waitForReactTableLoad();
 
   cy
     .get('div')


### PR DESCRIPTION
## Description

More flaky e2e-ness around ReactTable loading. This time it spawned from just running `signIntoTSP` and trying to load the default queue page. This PR pulls out `waitForReactTableLoad` to be its own thing and calls in `signIntoOffice` and `signIntoTSP`.

It seems we've hit some critical slowness around loading `ReactTable`, so I expect we'll need to start putting `waitForReactTableLoad` in other places soon, too.