### PR TITLE
Move orders to entities reducers

### DIFF
--- a/src/scenes/Office/AccountingPanel.jsx
+++ b/src/scenes/Office/AccountingPanel.jsx
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { reduxForm, getFormValues } from 'redux-form';
 
-import { updateOrders } from 'shared/Entities/modules/orders';
+import { updateOrders, selectOrdersForMove } from 'shared/Entities/modules/orders';
 
 import { SwaggerField } from 'shared/JsonSchemaForm/JsonSchemaField';
 import { PanelSwaggerField, editablePanelify } from 'shared/EditablePanel';
@@ -56,12 +56,12 @@ AccountingPanel = reduxForm({
   keepDirtyOnReinitialize: true,
 })(AccountingPanel);
 
-function mapStateToProps(state) {
-  let orders = get(state, 'office.officeOrders', {});
+function mapStateToProps(state, ownProps) {
+  const orders = selectOrdersForMove(state, ownProps.moveId);
 
   return {
     // reduxForm
-    initialValues: state.office.officeOrders,
+    initialValues: orders,
 
     // Wrapper
     ordersSchema: get(state, 'swaggerInternal.spec.definitions.Orders', {}),

--- a/src/scenes/Office/AccountingPanel.jsx
+++ b/src/scenes/Office/AccountingPanel.jsx
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { reduxForm, getFormValues } from 'redux-form';
 
-import { updateOrders } from './ducks';
+import { updateOrders } from 'shared/Entities/modules/orders';
 
 import { SwaggerField } from 'shared/JsonSchemaForm/JsonSchemaField';
 import { PanelSwaggerField, editablePanelify } from 'shared/EditablePanel';

--- a/src/scenes/Office/DocumentViewer/index.jsx
+++ b/src/scenes/Office/DocumentViewer/index.jsx
@@ -11,6 +11,7 @@ import Alert from 'shared/Alert';
 import { PanelField } from 'shared/EditablePanel';
 import { loadMoveDependencies } from '../ducks.js';
 import { selectServiceMemberForOrders } from 'shared/Entities/modules/serviceMembers';
+import { selectOrdersForMove } from 'shared/Entities/modules/orders';
 import { Tab, Tabs, TabList, TabPanel } from 'react-tabs';
 import PrivateRoute from 'shared/User/PrivateRoute';
 import { Switch, Redirect, Link } from 'react-router-dom';
@@ -210,7 +211,7 @@ const mapStateToProps = state => {
     moveDocSchema: get(state, 'swaggerInternal.spec.definitions.MoveDocumentPayload', {}),
     currentPpm: selectPPMForMove(state, move.id),
     docTypes: get(state, 'swaggerInternal.spec.definitions.MoveDocumentType.enum', []),
-    orders: state.office.officeOrders || {},
+    orders: selectOrdersForMove(state, move.id),
     move,
     moveDocuments: selectAllDocumentsForMove(state, get(state, 'office.officeMove.id', '')),
     serviceMember,

--- a/src/scenes/Office/Hhg/LocationsContainer.js
+++ b/src/scenes/Office/Hhg/LocationsContainer.js
@@ -3,13 +3,15 @@ import { connect } from 'react-redux';
 import { getFormValues } from 'redux-form';
 
 import { getPublicSwaggerDefinition } from 'shared/Swagger/selectors';
+import { selectOrdersForMove } from 'shared/Entities/modules/orders';
 import { selectShipment } from 'shared/Entities/modules/shipments';
 import LocationsPanel from 'shared/LocationsPanel/LocationsPanel';
 
 const mapStateToProps = (state, ownProps) => {
   const shipment = selectShipment(state, ownProps.shipmentId);
   const formName = 'shipment_locations';
-  const newDutyStation = get(state, 'office.officeOrders.new_duty_station.address', {});
+  const orders = selectOrdersForMove(state, shipment.move_id);
+  const newDutyStation = get(orders, 'new_duty_station.address', {});
   const schema = getPublicSwaggerDefinition(state, 'Shipment');
   const formValues = getFormValues(formName)(state);
 

--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -210,9 +210,17 @@ class MoveInfo extends Component {
   };
 
   render() {
-    const { moveDocuments, moveStatus, ppm, shipment, shipmentStatus, serviceMember } = this.props;
+    const {
+      moveDocuments,
+      moveStatus,
+      orders,
+      ppm,
+      shipment,
+      shipmentStatus,
+      serviceMember,
+      upload,
+    } = this.props;
     const move = this.props.officeMove;
-    const orders = this.props.officeOrders;
     const isPPM = move.selected_move_type === 'PPM';
     const isHHG = move.selected_move_type === 'HHG';
     const isHHGPPM = move.selected_move_type === 'HHG_PPM';
@@ -220,7 +228,6 @@ class MoveInfo extends Component {
     const currentTab = pathnames[pathnames.length - 1];
     const showDocumentViewer = this.props.context.flags.documentViewer;
     const allowHhgInvoicePayment = this.props.context.flags.allowHhgInvoicePayment;
-    let upload = get(this.props, 'officeOrders.uploaded_orders.uploads.0'); // there can be only one
     let check = <FontAwesomeIcon className="icon" icon={faCheck} />;
     const ordersComplete = Boolean(
       orders.orders_number && orders.orders_type_detail && orders.department_indicator && orders.tac,
@@ -476,7 +483,7 @@ const mapStateToProps = (state, ownProps) => {
     moveId,
     moveStatus: selectMoveStatus(state, moveId),
     officeMove,
-    officeOrders: get(state, 'office.officeOrders', {}),
+    orders,
     officeShipment: get(state, 'office.officeShipment', {}),
     ppmAdvance: ppm.advance,
     serviceAgents: selectServiceAgentsForShipment(state, shipmentId),
@@ -488,6 +495,7 @@ const mapStateToProps = (state, ownProps) => {
     shipmentStatus: selectShipmentStatus(state, shipmentId),
     swaggerError: get(state, 'swagger.hasErrored'),
     tariff400ngItems: selectTariff400ngItems(state),
+    upload: get(orders, 'uploaded_orders.uploads.0', {}),
   };
 };
 

--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -75,7 +75,7 @@ const BasicsTabContent = props => {
       <OrdersPanel title="Orders" moveId={props.moveId} />
       <CustomerInfoPanel title="Customer Info" serviceMember={props.serviceMember} />
       <BackupInfoPanel title="Backup Info" serviceMember={props.serviceMember} />
-      <AccountingPanel title="Accounting" serviceMember={props.serviceMember} />
+      <AccountingPanel title="Accounting" serviceMember={props.serviceMember} moveId={props.moveId} />
     </div>
   );
 };

--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -210,16 +210,7 @@ class MoveInfo extends Component {
   };
 
   render() {
-    const {
-      moveDocuments,
-      moveStatus,
-      orders,
-      ppm,
-      shipment,
-      shipmentStatus,
-      serviceMember,
-      upload,
-    } = this.props;
+    const { moveDocuments, moveStatus, orders, ppm, shipment, shipmentStatus, serviceMember, upload } = this.props;
     const move = this.props.officeMove;
     const isPPM = move.selected_move_type === 'PPM';
     const isHHG = move.selected_move_type === 'HHG';

--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -72,7 +72,7 @@ import faExternalLinkAlt from '@fortawesome/fontawesome-free-solid/faExternalLin
 const BasicsTabContent = props => {
   return (
     <div className="office-tab">
-      <OrdersPanel title="Orders" />
+      <OrdersPanel title="Orders" moveId={props.moveId} />
       <CustomerInfoPanel title="Customer Info" serviceMember={props.serviceMember} />
       <BackupInfoPanel title="Backup Info" serviceMember={props.serviceMember} />
       <AccountingPanel title="Accounting" serviceMember={props.serviceMember} />
@@ -326,7 +326,7 @@ class MoveInfo extends Component {
                   render={() => <Redirect replace to={`${this.props.match.url}/basics`} />}
                 />
                 <PrivateRoute path={`${this.props.match.path}/basics`}>
-                  <BasicsTabContent serviceMember={this.props.serviceMember} />
+                  <BasicsTabContent moveId={this.props.moveId} serviceMember={this.props.serviceMember} />
                 </PrivateRoute>
                 <PrivateRoute path={`${this.props.match.path}/ppm`}>
                   <PPMTabContent moveId={this.props.moveId} />

--- a/src/scenes/Office/OrdersInfo.jsx
+++ b/src/scenes/Office/OrdersInfo.jsx
@@ -9,6 +9,7 @@ import Alert from 'shared/Alert';
 import DocumentContent from 'shared/DocumentViewer/DocumentContent';
 import OrdersViewerPanel from './OrdersViewerPanel';
 import { loadMoveDependencies } from './ducks.js';
+import { selectServiceMemberForMove } from 'shared/Entities/modules/orders';
 import { selectServiceMemberForOrders } from 'shared/Entities/modules/serviceMembers';
 import { stringifyName } from 'shared/utils/serviceMember';
 
@@ -66,8 +67,8 @@ OrdersInfo.propTypes = {
   loadMoveDependencies: PropTypes.func.isRequired,
 };
 
-const mapStateToProps = state => {
-  const orders = state.office.officeOrders || {};
+const mapStateToProps = (state, ownProps) => {
+  const orders = selectServiceMemberForMove(state, ownProps.moveId);
   const serviceMember = selectServiceMemberForOrders(state, orders.id);
 
   return {

--- a/src/scenes/Office/OrdersInfo.jsx
+++ b/src/scenes/Office/OrdersInfo.jsx
@@ -9,7 +9,7 @@ import Alert from 'shared/Alert';
 import DocumentContent from 'shared/DocumentViewer/DocumentContent';
 import OrdersViewerPanel from './OrdersViewerPanel';
 import { loadMoveDependencies } from './ducks.js';
-import { selectServiceMemberForMove } from 'shared/Entities/modules/orders';
+import { selectOrdersForMove, selectUplodsForOrders } from 'shared/Entities/modules/orders';
 import { selectServiceMemberForOrders } from 'shared/Entities/modules/serviceMembers';
 import { stringifyName } from 'shared/utils/serviceMember';
 
@@ -21,23 +21,8 @@ class OrdersInfo extends Component {
   }
 
   render() {
-    const orders = this.props.orders;
-    const serviceMember = this.props.serviceMember;
+    const { serviceMember, uploads } = this.props;
     const name = stringifyName(serviceMember);
-
-    let uploads;
-    if (orders && orders.uploaded_orders) {
-      uploads = orders.uploaded_orders.uploads.map(upload => (
-        <DocumentContent
-          key={upload.url}
-          url={upload.url}
-          filename={upload.filename}
-          contentType={upload.content_type}
-        />
-      ));
-    } else {
-      uploads = [];
-    }
 
     if (!this.props.loadDependenciesHasSuccess && !this.props.loadDependenciesHasError) return <LoadingPlaceholder />;
     if (this.props.loadDependenciesHasError)
@@ -53,7 +38,16 @@ class OrdersInfo extends Component {
     return (
       <div>
         <div className="usa-grid">
-          <div className="usa-width-two-thirds document-contents">{uploads}</div>
+          <div className="usa-width-two-thirds document-contents">
+            {uploads.map(upload => (
+              <DocumentContent
+                key={upload.url}
+                url={upload.url}
+                filename={upload.filename}
+                contentType={upload.content_type}
+              />
+            ))}
+          </div>
           <div className="usa-width-one-third orders-page-fields">
             <OrdersViewerPanel title={name} className="document-viewer" moveId={this.props.match.params.moveId} />
           </div>
@@ -68,14 +62,15 @@ OrdersInfo.propTypes = {
 };
 
 const mapStateToProps = (state, ownProps) => {
-  const orders = selectServiceMemberForMove(state, ownProps.moveId);
+  const orders = selectOrdersForMove(state, ownProps.match.params.moveId);
+  const uploads = selectUplodsForOrders(state, orders.id);
   const serviceMember = selectServiceMemberForOrders(state, orders.id);
 
   return {
     swaggerError: state.swaggerInternal.hasErrored,
     ordersSchema: get(state, 'swaggerInternal.spec.definitions.CreateUpdateOrders', {}),
-    orders,
     serviceMember,
+    uploads,
     loadDependenciesHasSuccess: state.office.loadDependenciesHasSuccess,
     loadDependenciesHasError: state.office.loadDependenciesHasError,
   };

--- a/src/scenes/Office/OrdersPanel.jsx
+++ b/src/scenes/Office/OrdersPanel.jsx
@@ -142,7 +142,7 @@ function mapStateToProps(state, ownProps) {
     ordersSchema: get(state, 'swaggerInternal.spec.definitions.Orders', {}),
     hasError: false,
     errorMessage: state.office.error,
-    entitlements: loadEntitlements(state),
+    entitlements: loadEntitlements(state, ownProps.moveId),
     isUpdating: false,
     orders,
     serviceMember,

--- a/src/scenes/Office/OrdersPanel.jsx
+++ b/src/scenes/Office/OrdersPanel.jsx
@@ -6,6 +6,7 @@ import { reduxForm, Field, FormSection, getFormValues } from 'redux-form';
 import { Link } from 'react-router-dom';
 
 import { loadEntitlements, updateOrdersInfo } from './ducks';
+import { selectServiceMemberForMove } from 'shared/Entities/modules/orders';
 import { selectServiceMemberForOrders } from 'shared/Entities/modules/serviceMembers';
 import { formatDate } from 'shared/formatters';
 
@@ -129,9 +130,9 @@ OrdersPanel = reduxForm({
   keepDirtyOnReinitialize: true,
 })(OrdersPanel);
 
-function mapStateToProps(state) {
+function mapStateToProps(state, ownProps) {
   let formValues = getFormValues(formName)(state);
-  const orders = get(state, 'office.officeOrders', {});
+  const orders = selectServiceMemberForMove(state, ownProps.moveId);
   const serviceMember = selectServiceMemberForOrders(state, orders.id);
 
   return {

--- a/src/scenes/Office/OrdersPanel.jsx
+++ b/src/scenes/Office/OrdersPanel.jsx
@@ -6,7 +6,7 @@ import { reduxForm, Field, FormSection, getFormValues } from 'redux-form';
 import { Link } from 'react-router-dom';
 
 import { loadEntitlements, updateOrdersInfo } from './ducks';
-import { selectServiceMemberForMove } from 'shared/Entities/modules/orders';
+import { selectOrdersForMove } from 'shared/Entities/modules/orders';
 import { selectServiceMemberForOrders } from 'shared/Entities/modules/serviceMembers';
 import { formatDate } from 'shared/formatters';
 
@@ -132,7 +132,7 @@ OrdersPanel = reduxForm({
 
 function mapStateToProps(state, ownProps) {
   let formValues = getFormValues(formName)(state);
-  const orders = selectServiceMemberForMove(state, ownProps.moveId);
+  const orders = selectOrdersForMove(state, ownProps.moveId);
   const serviceMember = selectServiceMemberForOrders(state, orders.id);
 
   return {

--- a/src/scenes/Office/OrdersViewerPanel.js
+++ b/src/scenes/Office/OrdersViewerPanel.js
@@ -5,6 +5,7 @@ import { get } from 'lodash';
 import { reduxForm, getFormValues, FormSection, Field } from 'redux-form';
 
 import { updateOrdersInfo } from './ducks.js';
+import { selectServiceMemberForMove } from 'shared/Entities/modules/orders';
 import { selectServiceMemberForOrders } from 'shared/Entities/modules/serviceMembers';
 import { formatDate, formatDateTime } from 'shared/formatters';
 import { PanelSwaggerField, PanelField, editablePanelify } from 'shared/EditablePanel';
@@ -116,8 +117,8 @@ const formName = 'orders_document_viewer';
 let OrdersViewerPanel = editablePanelify(OrdersViewerDisplay, OrdersViewerEdit);
 OrdersViewerPanel = reduxForm({ form: formName })(OrdersViewerPanel);
 
-function mapStateToProps(state) {
-  const orders = get(state, 'office.officeOrders', {});
+function mapStateToProps(state, ownProps) {
+  const orders = selectServiceMemberForMove(state, ownProps.moveId);
   const serviceMember = selectServiceMemberForOrders(state, orders.id);
 
   return {

--- a/src/scenes/Office/OrdersViewerPanel.js
+++ b/src/scenes/Office/OrdersViewerPanel.js
@@ -5,7 +5,7 @@ import { get } from 'lodash';
 import { reduxForm, getFormValues, FormSection, Field } from 'redux-form';
 
 import { updateOrdersInfo } from './ducks.js';
-import { selectServiceMemberForMove } from 'shared/Entities/modules/orders';
+import { selectOrdersForMove } from 'shared/Entities/modules/orders';
 import { selectServiceMemberForOrders } from 'shared/Entities/modules/serviceMembers';
 import { formatDate, formatDateTime } from 'shared/formatters';
 import { PanelSwaggerField, PanelField, editablePanelify } from 'shared/EditablePanel';
@@ -118,7 +118,7 @@ let OrdersViewerPanel = editablePanelify(OrdersViewerDisplay, OrdersViewerEdit);
 OrdersViewerPanel = reduxForm({ form: formName })(OrdersViewerPanel);
 
 function mapStateToProps(state, ownProps) {
-  const orders = selectServiceMemberForMove(state, ownProps.moveId);
+  const orders = selectOrdersForMove(state, ownProps.moveId);
   const serviceMember = selectServiceMemberForOrders(state, orders.id);
 
   return {

--- a/src/scenes/Office/Ppm/PPMEstimatesPanel.jsx
+++ b/src/scenes/Office/Ppm/PPMEstimatesPanel.jsx
@@ -105,7 +105,7 @@ function mapStateToProps(state, ownProps) {
     errorMessage: get(state, 'office.error'),
     PPMEstimate: PPMEstimate,
     isUpdating: false,
-    entitlement: loadEntitlements(state),
+    entitlement: loadEntitlements(state, ownProps.moveId),
 
     // editablePanelify
     getUpdateArgs: function() {

--- a/src/scenes/Office/ducks.js
+++ b/src/scenes/Office/ducks.js
@@ -8,7 +8,7 @@ import {
   loadBackupContacts,
   updateBackupContact,
 } from 'shared/Entities/modules/serviceMembers';
-import { loadOrders, updateOrders } from 'shared/Entities/modules/orders';
+import { loadOrders, updateOrders, selectOrdersForMove } from 'shared/Entities/modules/orders';
 import * as ReduxHelpers from 'shared/ReduxHelpers';
 
 // SINGLE RESOURCE ACTION TYPES
@@ -146,9 +146,10 @@ export function loadMoveDependencies(moveId) {
 }
 
 // Selectors
-export function loadEntitlements(state) {
-  const hasDependents = get(state, 'office.officeOrders.has_dependents', null);
-  const spouseHasProGear = get(state, 'office.officeOrders.spouse_has_pro_gear', null);
+export function loadEntitlements(state, moveId) {
+  const orders = selectOrdersForMove(state, moveId);
+  const hasDependents = orders.has_dependents;
+  const spouseHasProGear = orders.spouse_has_pro_gear;
   const rank = get(state, 'office.officeServiceMember.rank', null);
   if (isNull(hasDependents) || isNull(spouseHasProGear) || isNull(rank)) {
     return null;

--- a/src/scenes/Office/ducks.js
+++ b/src/scenes/Office/ducks.js
@@ -1,22 +1,18 @@
 import { isNull, get } from 'lodash';
 import { LoadMove, DownloadPPMAttachments, PatchShipment, SendHHGInvoice } from './api.js';
-
-import { UpdateOrders } from 'scenes/Orders/api.js';
 import { getEntitlements } from 'shared/entitlements.js';
 import { loadPPMs } from 'shared/Entities/modules/ppms';
-
 import {
   loadServiceMember,
   updateServiceMember,
   loadBackupContacts,
   updateBackupContact,
 } from 'shared/Entities/modules/serviceMembers';
-import { loadOrders } from 'shared/Entities/modules/orders';
+import { loadOrders, updateOrders } from 'shared/Entities/modules/orders';
 import * as ReduxHelpers from 'shared/ReduxHelpers';
 
 // SINGLE RESOURCE ACTION TYPES
 const loadMoveType = 'LOAD_MOVE';
-const updateOrdersType = 'UPDATE_ORDERS';
 const patchShipmentType = 'PATCH_SHIPMENT';
 const sendHHGInvoiceType = 'SEND_HHG_INVOICE';
 const downloadPPMAttachmentsType = 'DOWNLOAD_ATTACHMENTS';
@@ -47,8 +43,6 @@ export const resetInvoiceFlow = () => ({
 
 const LOAD_MOVE = ReduxHelpers.generateAsyncActionTypes(loadMoveType);
 
-const UPDATE_ORDERS = ReduxHelpers.generateAsyncActionTypes(updateOrdersType);
-
 const PATCH_SHIPMENT = ReduxHelpers.generateAsyncActionTypes(patchShipmentType);
 
 const SEND_HHG_INVOICE = ReduxHelpers.generateAsyncActionTypes(sendHHGInvoiceType);
@@ -66,8 +60,6 @@ const LOAD_DEPENDENCIES = ReduxHelpers.generateAsyncActionTypes(loadDependencies
 // SINGLE-RESOURCE ACTION CREATORS
 
 export const loadMove = ReduxHelpers.generateAsyncActionCreator(loadMoveType, LoadMove);
-
-export const updateOrders = ReduxHelpers.generateAsyncActionCreator(updateOrdersType, UpdateOrders);
 
 export const patchShipment = ReduxHelpers.generateAsyncActionCreator(patchShipmentType, PatchShipment);
 
@@ -214,27 +206,6 @@ export function officeReducer(state = initialState, action) {
         officeShipment: null,
         moveHasLoadSuccess: false,
         moveHasLoadError: true,
-        error: action.error.message,
-      });
-
-    // ORDERS
-    case UPDATE_ORDERS.start:
-      return Object.assign({}, state, {
-        ordersAreUpdating: true,
-        ordersHaveUpdateSuccess: false,
-      });
-    case UPDATE_ORDERS.success:
-      return Object.assign({}, state, {
-        ordersAreUpdating: false,
-        officeOrders: action.payload,
-        ordersHaveUpdateSuccess: true,
-        ordersHaveUpdateError: false,
-      });
-    case UPDATE_ORDERS.failure:
-      return Object.assign({}, state, {
-        ordersAreUpdating: false,
-        ordersHaveUpdateSuccess: false,
-        ordersHaveUpdateError: true,
         error: action.error.message,
       });
 

--- a/src/shared/Entities/modules/orders.js
+++ b/src/shared/Entities/modules/orders.js
@@ -1,8 +1,11 @@
 import { orders } from '../schema';
 import { ADD_ENTITIES } from '../actions';
 import { denormalize } from 'normalizr';
+import { swaggerRequest } from 'shared/Swagger/request';
+import { getClient } from 'shared/Swagger/api';
 
 export const STATE_KEY = 'orders';
+const loadOrdersLabel = 'Orders.loadOrders';
 
 export default function reducer(state = {}, action) {
   switch (action.type) {
@@ -15,6 +18,12 @@ export default function reducer(state = {}, action) {
     default:
       return state;
   }
+}
+
+export function loadOrders(ordersId) {
+  const label = loadOrdersLabel;
+  const swaggerTag = 'orders.showOrders';
+  return swaggerRequest(getClient, swaggerTag, { ordersId }, { label });
 }
 
 export const selectUpload = (state, id) => {

--- a/src/shared/Entities/modules/orders.js
+++ b/src/shared/Entities/modules/orders.js
@@ -3,6 +3,7 @@ import { ADD_ENTITIES } from '../actions';
 import { denormalize } from 'normalizr';
 import { swaggerRequest } from 'shared/Swagger/request';
 import { getClient } from 'shared/Swagger/api';
+import { get } from 'lodash';
 
 export const STATE_KEY = 'orders';
 const loadOrdersLabel = 'Orders.loadOrders';
@@ -29,3 +30,12 @@ export function loadOrders(ordersId) {
 export const selectUpload = (state, id) => {
   return denormalize([id], orders, state.entities)[0];
 };
+
+export function selectServiceMemberForMove(state, moveId) {
+  const ordersId = get(state, `entities.moves.${moveId}.orders_id`);
+  if (ordersId) {
+    return get(state, `entities.orders.${ordersId}`);
+  } else {
+    return {};
+  }
+}

--- a/src/shared/Entities/modules/orders.js
+++ b/src/shared/Entities/modules/orders.js
@@ -7,6 +7,7 @@ import { get } from 'lodash';
 
 export const STATE_KEY = 'orders';
 const loadOrdersLabel = 'Orders.loadOrders';
+const updateOrdersLabel = 'Orders.updateOrders';
 
 export default function reducer(state = {}, action) {
   switch (action.type) {
@@ -25,6 +26,12 @@ export function loadOrders(ordersId) {
   const label = loadOrdersLabel;
   const swaggerTag = 'orders.showOrders';
   return swaggerRequest(getClient, swaggerTag, { ordersId }, { label });
+}
+
+export function updateOrders(ordersId, orders) {
+  const label = updateOrdersLabel;
+  const swaggerTag = 'orders.updateOrders';
+  return swaggerRequest(getClient, swaggerTag, { ordersId, updateOrders: orders }, { label });
 }
 
 export const selectUpload = (state, id) => {

--- a/src/shared/Entities/modules/orders.js
+++ b/src/shared/Entities/modules/orders.js
@@ -31,11 +31,25 @@ export const selectUpload = (state, id) => {
   return denormalize([id], orders, state.entities)[0];
 };
 
-export function selectServiceMemberForMove(state, moveId) {
+export function selectOrders(state, ordersId) {
+  return get(state, `entities.orders.${ordersId}`) || {};
+}
+
+export function selectOrdersForMove(state, moveId) {
   const ordersId = get(state, `entities.moves.${moveId}.orders_id`);
   if (ordersId) {
-    return get(state, `entities.orders.${ordersId}`);
+    return selectOrders(state, ordersId);
   } else {
     return {};
+  }
+}
+
+export function selectUplodsForOrders(state, ordersId) {
+  const orders = selectOrders(state, ordersId);
+  const uploadedOrders = get(state, `entities.documents.${orders.uploaded_orders}`);
+  if (uploadedOrders) {
+    return uploadedOrders.uploads.map(uploadId => get(state, `entities.uploads.${uploadId}`));
+  } else {
+    return [];
   }
 }

--- a/src/shared/Entities/schema.js
+++ b/src/shared/Entities/schema.js
@@ -42,6 +42,7 @@ export const orders = new schema.Entity('orders');
 orders.define({
   moves: moves,
 });
+export const ordersArray = new schema.Array(orders);
 
 // ServiceMemberBackupContacts
 export const backupContact = new schema.Entity('backupContacts');
@@ -56,7 +57,6 @@ export const serviceMemberBackupContact = backupContact;
 export const serviceMember = new schema.Entity('serviceMembers', {
   backup_contacts: backupContacts,
   user: user,
-  // orders: new schema.Array(order),
 });
 
 // Documents

--- a/src/shared/Entities/schema.js
+++ b/src/shared/Entities/schema.js
@@ -38,11 +38,7 @@ personallyProcuredMove.define({
 });
 
 // Orders
-export const order = new schema.Entity('orders', {
-  moves: moves,
-});
-
-export const orders = new schema.Array(order);
+export const orders = new schema.Entity('orders');
 
 // ServiceMemberBackupContacts
 export const backupContact = new schema.Entity('backupContacts');
@@ -57,7 +53,7 @@ export const serviceMemberBackupContact = backupContact;
 export const serviceMember = new schema.Entity('serviceMembers', {
   backup_contacts: backupContacts,
   user: user,
-  orders: orders,
+  // orders: new schema.Array(order),
 });
 
 // Documents
@@ -65,7 +61,7 @@ export const documentModel = new schema.Entity('documents', {
   uploads: uploads,
   service_member: serviceMember,
 });
-order.define({
+orders.define({
   uploaded_orders: documentModel,
 });
 

--- a/src/shared/Entities/schema.js
+++ b/src/shared/Entities/schema.js
@@ -39,6 +39,9 @@ personallyProcuredMove.define({
 
 // Orders
 export const orders = new schema.Entity('orders');
+orders.define({
+  moves: moves,
+});
 
 // ServiceMemberBackupContacts
 export const backupContact = new schema.Entity('backupContacts');

--- a/src/shared/User/ducks.js
+++ b/src/shared/User/ducks.js
@@ -5,7 +5,7 @@ import { GetLoggedInUser } from './api.js';
 import { normalize } from 'normalizr';
 import { pick } from 'lodash';
 
-import { serviceMember } from 'shared/Entities/schema';
+import { ordersArray } from 'shared/Entities/schema';
 import { addEntities } from 'shared/Entities/actions';
 
 const getLoggedInUserType = 'GET_LOGGED_IN_USER';
@@ -21,7 +21,7 @@ export const loadLoggedInUser = () => {
     return GetLoggedInUser()
       .then(response => {
         if (response.service_member) {
-          const data = normalize(response.service_member, serviceMember);
+          const data = normalize(response.service_member.orders, ordersArray);
 
           // Only store shipments and addresses in a normalized way. This prevents
           // data duplication while we're using both Redux approaches.


### PR DESCRIPTION
## Description

On we trudge, slowly dismantling the office reducer. This time, the orders have fallen prey to being ported to the new paradigm.

## Reviewer Notes

I ran across an odd issue with normalizer because some of the nested objects in our payload responses don't get fully loaded, and therefore the sub-objects are null(ish). For example, the service member includes the orders payload, but we don't eager load everything for the orders, so the call to fetch the service member was stomping on the uploaded_orders in the orders object that lived in the reducer. I tried to do some better eager loading of the service member object, but that broke All The Things™️, and it seemed like a lot of additional scope for this ticket. For the time being, I've removed orders from the normalizer definition for a service member, and I'll file a story to do some additional API cleanup so that whatever payloads we do return are complete.

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/163597138) for this change