### PR TITLE
fix a use case where if a shipment line item description is null

### DIFF
--- a/pkg/handlers/publicapi/shipment_line_items.go
+++ b/pkg/handlers/publicapi/shipment_line_items.go
@@ -162,7 +162,7 @@ func (h CreateShipmentLineItemHandler) Handle(params accessorialop.CreateShipmen
 		Quantity2:           unit.IntToBaseQuantity(params.Payload.Quantity2),
 		Location:            string(params.Payload.Location),
 		Notes:               handlers.FmtString(params.Payload.Notes),
-		Description:         handlers.FmtString(params.Payload.Description),
+		Description:         params.Payload.Description,
 	}
 
 	var itemDimensions, crateDimensions *models.AdditionalLineItemDimensions

--- a/pkg/models/shipment.go
+++ b/pkg/models/shipment.go
@@ -367,11 +367,6 @@ func (s *Shipment) CreateShipmentLineItem(db *pop.Connection, baseParams BaseShi
 		notesVal = *baseParams.Notes
 	}
 
-	var description string
-	if baseParams.Description != nil {
-		description = *baseParams.Description
-	}
-
 	//We can do validation for specific item codes here
 	// Example: 105B/E
 	var responseError error
@@ -397,7 +392,7 @@ func (s *Shipment) CreateShipmentLineItem(db *pop.Connection, baseParams BaseShi
 		shipmentLineItem.Notes = notesVal
 		shipmentLineItem.SubmittedDate = time.Now()
 		shipmentLineItem.Status = ShipmentLineItemStatusSUBMITTED
-		shipmentLineItem.Description = description
+		shipmentLineItem.Description = baseParams.Description
 
 		verrs, err = connection.ValidateAndCreate(&shipmentLineItem)
 		if verrs.HasAny() || err != nil {

--- a/pkg/models/shipment_line_item.go
+++ b/pkg/models/shipment_line_item.go
@@ -58,7 +58,7 @@ type ShipmentLineItem struct {
 	ItemDimensions    ShipmentLineItemDimensions `belongs_to:"shipment_line_item_dimensions"`
 	CrateDimensionsID *uuid.UUID                 `json:"crate_dimensions_id" db:"crate_dimensions_id"`
 	CrateDimensions   ShipmentLineItemDimensions `belongs_to:"shipment_line_item_dimensions"`
-	Description       string                     `json:"description" db:"description"`
+	Description       *string                    `json:"description" db:"description"`
 	CreatedAt         time.Time                  `json:"created_at" db:"created_at"`
 	UpdatedAt         time.Time                  `json:"updated_at" db:"updated_at"`
 }

--- a/swagger/api.yaml
+++ b/swagger/api.yaml
@@ -341,6 +341,7 @@ definitions:
         format: textarea
         title: Description
         example: Mounted deer head
+        x-nullable: true
       crate_dimensions:
         $ref: '#/definitions/Dimensions'
       item_dimensions:


### PR DESCRIPTION
## Description

We noticed that staging was throwing 500 errors when trying to pull details regarding a shipment line items. on further investigation we determined that we were not gracefully handling null references. This PR addresses that concern. 
