### PR TITLE
Update README for Go installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,9 +130,10 @@ The following commands will get mymove running on your machine for the first tim
 
 ### Setup: Prerequisites
 
-* Install Go version 1.11.5 with Homebrew. Make sure you do not have other installations.
-  * `brew install go@1.11.5`
-  * If a later Go version exists, Brew will warn you that "go@1.11.5 is keg-only, which means it was not symlinked". If that happens, add the following to your bash config: `export PATH="/usr/local/opt/go@1.11.5/bin:$PATH"`. This line needs to appear in the file before your Go paths are declared.
+* We tend to use the latest version of Go.
+  * Install it with Homebrew: `brew install go`
+  * Pin it, so that you don't accidentally upgrade before we upgrade the project: `brew pin go`
+  * When we upgrade the project's go version, unpin, upgrade, and then re-pin: `brew unpin go; brew upgrade go; brew pin go`
 * Run `bin/prereqs` and install everything it tells you to. _Do not configure PostgreSQL to automatically start at boot time or the DB commands will not work correctly!_
 * For managing local environment variables, we're using [direnv](https://direnv.net/). You need to [configure your shell to use it](https://direnv.net/). For bash, add the command `eval "$(direnv hook bash)"` to whichever file loads upon opening bash (likely `~./bash_profile`, though instructions say `~/.bashrc`).
 * Run `direnv allow` to load up the `.envrc` file. Add a `.envrc.local` file with any values it asks you to define.

--- a/README.md
+++ b/README.md
@@ -130,9 +130,9 @@ The following commands will get mymove running on your machine for the first tim
 
 ### Setup: Prerequisites
 
-* Install Go version 1.11.4 with Homebrew. Make sure you do not have other installations.
-  * `brew install go@1.11.4`
-  * If a later Go version exists, Brew will warn you that "go@1.11.4 is keg-only, which means it was not symlinked". If that happens, add the following to your bash config: `export PATH="/usr/local/opt/go@1.11.4/bin:$PATH"`. This line needs to appear in the file before your Go paths are declared.
+* Install Go version 1.11.5 with Homebrew. Make sure you do not have other installations.
+  * `brew install go@1.11.5`
+  * If a later Go version exists, Brew will warn you that "go@1.11.5 is keg-only, which means it was not symlinked". If that happens, add the following to your bash config: `export PATH="/usr/local/opt/go@1.11.5/bin:$PATH"`. This line needs to appear in the file before your Go paths are declared.
 * Run `bin/prereqs` and install everything it tells you to. _Do not configure PostgreSQL to automatically start at boot time or the DB commands will not work correctly!_
 * For managing local environment variables, we're using [direnv](https://direnv.net/). You need to [configure your shell to use it](https://direnv.net/). For bash, add the command `eval "$(direnv hook bash)"` to whichever file loads upon opening bash (likely `~./bash_profile`, though instructions say `~/.bashrc`).
 * Run `direnv allow` to load up the `.envrc` file. Add a `.envrc.local` file with any values it asks you to define.

--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ The following commands will get mymove running on your machine for the first tim
   * Install it with Homebrew: `brew install go`
   * Pin it, so that you don't accidentally upgrade before we upgrade the project: `brew pin go`
   * When we upgrade the project's go version, unpin, upgrade, and then re-pin: `brew unpin go; brew upgrade go; brew pin go`
+  * **Note**: If you have previously modified your PATH to point to a specific version of go, make sure to remove that. This would be either in your `.bash_profile` or `.bashrc`, and might look something like `PATH=$PATH:/usr/local/opt/go@1.11.4/bin`.
 * Run `bin/prereqs` and install everything it tells you to. _Do not configure PostgreSQL to automatically start at boot time or the DB commands will not work correctly!_
 * For managing local environment variables, we're using [direnv](https://direnv.net/). You need to [configure your shell to use it](https://direnv.net/). For bash, add the command `eval "$(direnv hook bash)"` to whichever file loads upon opening bash (likely `~./bash_profile`, though instructions say `~/.bashrc`).
 * Run `direnv allow` to load up the `.envrc` file. Add a `.envrc.local` file with any values it asks you to define.


### PR DESCRIPTION
## Description

Updating the README to be in line with how installing Go from brew works.

Brew seems to have removed the ability to install specific go versions:
```
$ brew install go@1.11.5
Error: No available formula with the name "go@1.11.5" 
==> Searching for a previously deleted formula (in the last month)...
Warning: homebrew/core is shallow clone. To get complete history run:
  git -C "$(brew --repo homebrew/core)" fetch --unshallow

Error: No previously deleted formula found.
==> Searching for similarly named formulae...
Error: No similarly named formulae found.
==> Searching taps...
==> Searching taps on GitHub...
Error: No formulae found in taps.
```

Thus, the best we can do right now is install the latest version and pin it.
[EDIT: actually, the only versions it provides are minor versions, such as `go@1.9`, `go@1.8`, etc. Which leaves us in the same place.]

I did look into using `goenv` (https://github.com/syndbg/goenv) which seems like a nice alternative. However, the version of goenv in brew doesn't support installing go1.11.5... so, 🔥.