### PR TITLE
Add validation to 105B and 105E pre approval requests so item and crate dimension are required 

### DIFF
--- a/src/shared/JsonSchemaForm/DimensionsField.jsx
+++ b/src/shared/JsonSchemaForm/DimensionsField.jsx
@@ -33,6 +33,7 @@ export class DimensionsField extends Component {
                   swagger={get(this.props, 'swagger.properties.' + this.props.fieldName)}
                   hideLabel={true}
                   className="dimensions-form-input"
+                  required={this.props.isRequired}
                 />
               </td>
               <td width="11%" className="multiplication-sign">
@@ -44,6 +45,7 @@ export class DimensionsField extends Component {
                   swagger={get(this.props, 'swagger.properties.' + this.props.fieldName)}
                   hideLabel={true}
                   className="dimensions-form-input"
+                  required={this.props.isRequired}
                 />
               </td>
               <td width="11%" className="multiplication-sign">
@@ -55,6 +57,7 @@ export class DimensionsField extends Component {
                   swagger={get(this.props, 'swagger.properties.' + this.props.fieldName)}
                   hideLabel={true}
                   className="dimensions-form-input"
+                  required={this.props.isRequired}
                 />
               </td>
             </tr>
@@ -69,4 +72,5 @@ DimensionsField.propTypes = {
   fieldName: PropTypes.string.isRequired,
   labelText: PropTypes.string.isRequired,
   swagger: PropTypes.object.isRequired,
+  isRequired: PropTypes.bool.isRequired,
 };

--- a/src/shared/JsonSchemaForm/DimensionsField.jsx
+++ b/src/shared/JsonSchemaForm/DimensionsField.jsx
@@ -36,9 +36,7 @@ export class DimensionsField extends Component {
                   required={this.props.isRequired}
                 />
               </td>
-              <td width="11%" className="multiplication-sign">
-                x
-              </td>
+              <td width="11%" className="multiplication-sign" />
               <td width="26%" className="dimensions-form-input-cell">
                 <SwaggerField
                   fieldName="width"
@@ -48,9 +46,7 @@ export class DimensionsField extends Component {
                   required={this.props.isRequired}
                 />
               </td>
-              <td width="11%" className="multiplication-sign">
-                x
-              </td>
+              <td width="11%" className="multiplication-sign" />
               <td width="26%" className="dimensions-form-input-cell">
                 <SwaggerField
                   fieldName="height"

--- a/src/shared/JsonSchemaForm/DimensionsField.test.js
+++ b/src/shared/JsonSchemaForm/DimensionsField.test.js
@@ -3,13 +3,8 @@ import { shallow } from 'enzyme/build';
 import React from 'react';
 
 describe('given a dimension input', () => {
-  describe('and there are no values entered', () => {
-    it('should display an error', () => {});
-    let swagger = { a: 'test', b: 2 };
-    let wrapper = shallow(
-      <DimensionsField isRequired={true} fieldName={'test'} labelText={'test'} swagger={swagger} />,
-    );
-    wrapper.props();
-    //expect(wrapper.props().isRequired).toBe(true);
-  });
+  it('should render without crashing', () => {});
+  let swagger = { a: 'test', b: 2 };
+  let wrapper = shallow(<DimensionsField isRequired={true} fieldName={'test'} labelText={'test'} swagger={swagger} />);
+  expect(wrapper.find('.dimensions-form').length).toBe(1);
 });

--- a/src/shared/JsonSchemaForm/DimensionsField.test.js
+++ b/src/shared/JsonSchemaForm/DimensionsField.test.js
@@ -1,0 +1,15 @@
+import { DimensionsField } from 'shared/JsonSchemaForm/DimensionsField';
+import { shallow } from 'enzyme/build';
+import React from 'react';
+
+describe('given a dimension input', () => {
+  describe('and there are no values entered', () => {
+    it('should display an error', () => {});
+    let swagger = { a: 'test', b: 2 };
+    let wrapper = shallow(
+      <DimensionsField isRequired={true} fieldName={'test'} labelText={'test'} swagger={swagger} />,
+    );
+    wrapper.props();
+    //expect(wrapper.props().isRequired).toBe(true);
+  });
+});

--- a/src/shared/JsonSchemaForm/DimensionsField.test.js
+++ b/src/shared/JsonSchemaForm/DimensionsField.test.js
@@ -1,4 +1,5 @@
 import { DimensionsField } from 'shared/JsonSchemaForm/DimensionsField';
+import { SwaggerField } from 'shared/JsonSchemaForm/JsonSchemaField';
 import { shallow } from 'enzyme/build';
 import React from 'react';
 
@@ -7,4 +8,17 @@ describe('given a dimension input', () => {
   let swagger = { a: 'test', b: 2 };
   let wrapper = shallow(<DimensionsField isRequired={true} fieldName={'test'} labelText={'test'} swagger={swagger} />);
   expect(wrapper.find('.dimensions-form').length).toBe(1);
+
+  it('should render SwaggerField with a required prop', () => {
+    let wrapper = shallow(
+      <DimensionsField isRequired={true} fieldName={'test'} labelText={'test'} swagger={swagger} />,
+    );
+    // prettier-ignore
+    expect(
+      wrapper
+        .find(SwaggerField)
+        .at(0)
+        .props().required
+    ).toBe(true);
+  });
 });

--- a/src/shared/PreApprovalRequest/Code105Details.jsx
+++ b/src/shared/PreApprovalRequest/Code105Details.jsx
@@ -11,11 +11,13 @@ export const Code105Details = props => {
         fieldName="item_dimensions"
         swagger={ship_line_item_schema}
         labelText="Item Dimensions (inches)"
+        isRequired={true}
       />
       <DimensionsField
         fieldName="crate_dimensions"
         swagger={ship_line_item_schema}
         labelText="Crate Dimensions (inches)"
+        isRequired={true}
       />
       <div className="bq-explanation">
         <p>Crate can only exceed item size by:</p>

--- a/src/shared/PreApprovalRequest/Code105Details.test.js
+++ b/src/shared/PreApprovalRequest/Code105Details.test.js
@@ -79,11 +79,19 @@ const simpleSchema = {
 let wrapper;
 describe('code 105B/E details component', () => {
   describe('renders', () => {
-    wrapper = shallow(<Code105Details swagger={simpleSchema} />);
+    wrapper = shallow(<Code105Details ship_line_item_schema={simpleSchema} />);
 
     it('without crashing', () => {
       // eslint-disable-next-line
       expect(wrapper.exists('SwaggerField')).toBe(true);
+    });
+
+    it('contains crate dimension', () => {
+      expect(wrapper.exists('DimensionsField[fieldName="crate_dimensions"]')).toBe(true);
+    });
+
+    it('contains item dimension', () => {
+      expect(wrapper.exists('DimensionsField[fieldName="item_dimensions"]')).toBe(true);
     });
   });
 });


### PR DESCRIPTION
## Description

This PR adds additional validation to 105B and 105E PAR's jsx components so item and crate dimensions are required fields and throw validation error's client side if they are left empty

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/162706516) for this change

## Screenshots
![image](https://user-images.githubusercontent.com/5003421/52505373-4c444f00-2bb9-11e9-8997-468fe3592114.png)

