### PR TITLE
Enforce bash version on milmove

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -755,9 +755,9 @@ workflows:
             - pre_deps_yarn
             - acceptance_tests_local
           # if testing on experimental, you can disable these tests by using the commented block below.
-          # filters:
-          #  branches:
-          #    ignore: placeholder_branch_name
+          filters:
+           branches:
+             ignore: cg_163884093_enforce_bash_on_milmove
 
       - integration_tests_office:
           requires:
@@ -765,9 +765,9 @@ workflows:
             - pre_deps_yarn
             - acceptance_tests_local
           # if testing on experimental, you can disable these tests by using the commented block below.
-          # filters:
-          #   branches:
-          #     ignore: placeholder_branch_name
+          filters:
+            branches:
+              ignore: cg_163884093_enforce_bash_on_milmove
 
       - integration_tests_tsp:
           requires:
@@ -775,9 +775,9 @@ workflows:
             - pre_deps_yarn
             - acceptance_tests_local
           # if testing on experimental, you can disable these tests by using the commented block below.
-          # filters:
-          #   branches:
-          #     ignore: placeholder_branch_name
+          filters:
+            branches:
+              ignore: cg_163884093_enforce_bash_on_milmove
 
       - client_test:
           requires:
@@ -821,21 +821,21 @@ workflows:
             - build_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: cg_163884093_enforce_bash_on_milmove
 
       - deploy_experimental_app:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: cg_163884093_enforce_bash_on_milmove
 
       - deploy_experimental_app_client_tls:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: cg_163884093_enforce_bash_on_milmove
 
       - check_circle_against_staging_sha:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -755,9 +755,9 @@ workflows:
             - pre_deps_yarn
             - acceptance_tests_local
           # if testing on experimental, you can disable these tests by using the commented block below.
-          filters:
-           branches:
-             ignore: cg_163884093_enforce_bash_on_milmove
+          # filters:
+          #  branches:
+          #    ignore: placeholder_branch_name
 
       - integration_tests_office:
           requires:
@@ -765,9 +765,9 @@ workflows:
             - pre_deps_yarn
             - acceptance_tests_local
           # if testing on experimental, you can disable these tests by using the commented block below.
-          filters:
-            branches:
-              ignore: cg_163884093_enforce_bash_on_milmove
+          # filters:
+          #   branches:
+          #     ignore: placeholder_branch_name
 
       - integration_tests_tsp:
           requires:
@@ -775,9 +775,9 @@ workflows:
             - pre_deps_yarn
             - acceptance_tests_local
           # if testing on experimental, you can disable these tests by using the commented block below.
-          filters:
-            branches:
-              ignore: cg_163884093_enforce_bash_on_milmove
+          # filters:
+          #   branches:
+          #     ignore: placeholder_branch_name
 
       - client_test:
           requires:
@@ -821,21 +821,21 @@ workflows:
             - build_migrations
           filters:
             branches:
-              only: cg_163884093_enforce_bash_on_milmove
+              only: placeholder_branch_name
 
       - deploy_experimental_app:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: cg_163884093_enforce_bash_on_milmove
+              only: placeholder_branch_name
 
       - deploy_experimental_app_client_tls:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: cg_163884093_enforce_bash_on_milmove
+              only: placeholder_branch_name
 
       - check_circle_against_staging_sha:
           requires:

--- a/.spelling
+++ b/.spelling
@@ -409,9 +409,14 @@ csrf
 Goji
 DD-Mon-YYYY
 29-Mar-2018
+bash
+zsh
+fish
+tcsh
+csh
 _Prevention_Cheat_Sheet#Double_Submit_Cookie
-- /usr/local
 # Put all custom terms BEFORE this comment, lest you end up in an mdspell pain cycle.
+ - /usr/local
  - docs/data/tspp-data-creation.md
  - docs/backend.md
  - docs/adr/0007-swagger-client.md

--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,15 @@ go_version: .go_version.stamp
 	bin/check_go_version
 	touch .go_version.stamp
 
+bash_version: .bash_version.stamp
+.bash_version.stamp: bin/check_bash_version
+ifndef CIRCLECI
+	bin/check_bash_version
+else
+	@echo "No need to check bash version on CircleCI"
+endif
+	touch .bash_version.stamp
+
 deps: prereqs check_hosts ensure_pre_commit client_deps server_deps
 test: client_test server_test e2e_test
 
@@ -157,7 +166,7 @@ server_run_debug:
 	INTERFACE=localhost DEBUG_LOGGING=true \
 	$(AWS_VAULT) dlv debug cmd/webserver/main.go
 
-build_tools: server_deps server_generate
+build_tools: bash_version server_deps server_generate
 	go build -i -ldflags "$(LDFLAGS)" -o bin/generate-1203-form ./cmd/generate_1203_form
 	go build -i -ldflags "$(LDFLAGS)" -o bin/generate-shipment-summary ./cmd/generate_shipment_summary
 	go build -i -ldflags "$(LDFLAGS)" -o bin/generate-test-data ./cmd/generate_test_data

--- a/README.md
+++ b/README.md
@@ -137,9 +137,9 @@ The following commands will get mymove running on your machine for the first tim
   * **Note**: If you have previously modified your PATH to point to a specific version of go, make sure to remove that. This would be either in your `.bash_profile` or `.bashrc`, and might look something like `PATH=$PATH:/usr/local/opt/go@1.11.4/bin`.
 * Ensure you are using the latest version of bash for this project:
   * Install it with Homebrew: `brew install bash`
-  * Update your shells: `[[ $(cat /etc/shells | grep /usr/local/bin/bash) ]] || echo "/usr/local/bin/bash" | sudo tee -a /etc/shells`
-  * Change your user's shell (optional): `chsh -s /usr/local/bin/bash`
-  * Ensure that `/usr/local/bin` comes before `/bin` on your `$PATH` by running `echo $PATH`.
+  * Update list of shells that users can choose from: `[[ $(cat /etc/shells | grep /usr/local/bin/bash) ]] || echo "/usr/local/bin/bash" | sudo tee -a /etc/shells`
+  * If you are using bash as your shell (and not zsh, fish, etc) and want to use the latest shell as well then change it (optional): `chsh -s /usr/local/bin/bash`
+  * Ensure that `/usr/local/bin` comes before `/bin` on your `$PATH` by running `echo $PATH`. Modify your path by editing `~/.bashrc` or `~/.bash_profile` and changing the `PATH`.  Then source your profile with `source ~/.bashrc` or `~/.bash_profile` to ensure that your terminal has it.
 * Run `bin/prereqs` and install everything it tells you to. _Do not configure PostgreSQL to automatically start at boot time or the DB commands will not work correctly!_
 * For managing local environment variables, we're using [direnv](https://direnv.net/). You need to [configure your shell to use it](https://direnv.net/). For bash, add the command `eval "$(direnv hook bash)"` to whichever file loads upon opening bash (likely `~./bash_profile`, though instructions say `~/.bashrc`).
 * Run `direnv allow` to load up the `.envrc` file. Add a `.envrc.local` file with any values it asks you to define.

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ The following commands will get mymove running on your machine for the first tim
   * **Note**: If you have previously modified your PATH to point to a specific version of go, make sure to remove that. This would be either in your `.bash_profile` or `.bashrc`, and might look something like `PATH=$PATH:/usr/local/opt/go@1.11.4/bin`.
 * Ensure you are using the latest version of bash for this project:
   * Install it with Homebrew: `brew install bash`
-  * Update your shells: `echo "/usr/local/bin/bash" | sudo tee -a /etc/shells`
+  * Update your shells: `[[ $(cat /etc/shells | grep /usr/local/bin/bash) ]] || echo "/usr/local/bin/bash" | sudo tee -a /etc/shells`
   * Change your user's shell (optional): `chsh -s /usr/local/bin/bash`
   * Ensure that `/usr/local/bin` comes before `/bin` on your `$PATH` by running `echo $PATH`.
 * Run `bin/prereqs` and install everything it tells you to. _Do not configure PostgreSQL to automatically start at boot time or the DB commands will not work correctly!_

--- a/README.md
+++ b/README.md
@@ -135,6 +135,10 @@ The following commands will get mymove running on your machine for the first tim
   * Pin it, so that you don't accidentally upgrade before we upgrade the project: `brew pin go`
   * When we upgrade the project's go version, unpin, upgrade, and then re-pin: `brew unpin go; brew upgrade go; brew pin go`
   * **Note**: If you have previously modified your PATH to point to a specific version of go, make sure to remove that. This would be either in your `.bash_profile` or `.bashrc`, and might look something like `PATH=$PATH:/usr/local/opt/go@1.11.4/bin`.
+* Ensure you are using the latest version of bash for this project:
+  * Install it with Homebrew: `brew install bash`
+  * Update your shells: `echo "/usr/local/bin/bash" | sudo tee -a /etc/shells`
+  * Change your user's shell (optional): `chsh -s /usr/local/bin/bash`
 * Run `bin/prereqs` and install everything it tells you to. _Do not configure PostgreSQL to automatically start at boot time or the DB commands will not work correctly!_
 * For managing local environment variables, we're using [direnv](https://direnv.net/). You need to [configure your shell to use it](https://direnv.net/). For bash, add the command `eval "$(direnv hook bash)"` to whichever file loads upon opening bash (likely `~./bash_profile`, though instructions say `~/.bashrc`).
 * Run `direnv allow` to load up the `.envrc` file. Add a `.envrc.local` file with any values it asks you to define.

--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ The following commands will get mymove running on your machine for the first tim
   * Install it with Homebrew: `brew install bash`
   * Update your shells: `echo "/usr/local/bin/bash" | sudo tee -a /etc/shells`
   * Change your user's shell (optional): `chsh -s /usr/local/bin/bash`
+  * Ensure that `/usr/local/bin` comes before `/bin` on your `$PATH` by running `echo $PATH`.
 * Run `bin/prereqs` and install everything it tells you to. _Do not configure PostgreSQL to automatically start at boot time or the DB commands will not work correctly!_
 * For managing local environment variables, we're using [direnv](https://direnv.net/). You need to [configure your shell to use it](https://direnv.net/). For bash, add the command `eval "$(direnv hook bash)"` to whichever file loads upon opening bash (likely `~./bash_profile`, though instructions say `~/.bashrc`).
 * Run `direnv allow` to load up the `.envrc` file. Add a `.envrc.local` file with any values it asks you to define.

--- a/bin/apply-secure-migration.sh
+++ b/bin/apply-secure-migration.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#! /usr/bin/env bash
 # Executes an SQL file from S3 against the environment's database.
 #
 # If `SECURE_MIGRATION_SOURCE=local` then we look for a similarly named file in the

--- a/bin/check-deployed-commit
+++ b/bin/check-deployed-commit
@@ -1,4 +1,4 @@
-#!/bin/bash
+#! /usr/bin/env bash
 set -euo pipefail
 
 HOSTS=$1

--- a/bin/check-hosts-file
+++ b/bin/check-hosts-file
@@ -1,4 +1,4 @@
-#! /bin/bash
+#! /usr/bin/env bash
 
 set -eu -o pipefail
 

--- a/bin/check-staging-app-sha
+++ b/bin/check-staging-app-sha
@@ -1,4 +1,4 @@
-#!/bin/bash
+#! /usr/bin/env bash
 set -euo pipefail
 
 circle_sha=$1

--- a/bin/check_bash_version
+++ b/bin/check_bash_version
@@ -1,0 +1,27 @@
+#! /usr/bin/env bash
+
+set -eu -o pipefail
+
+VERSION="5.0.2(1)-release"
+
+# Script helps ensure that /etc/shells has all the correct entries in it
+
+function check_shell () {
+  shell=$1
+  shell_line=$(grep "$shell" /etc/shells || true)
+  if [ -z "${shell_line}" ]; then
+    # shellcheck disable=SC1117
+    echo -e "\033[0;33mPlease add ${shell} to your /etc/shells file using the command:\033[0m 'echo \"${shell}\" | sudo tee -a /etc/shells'"
+    exit 1
+  fi
+}
+
+check_shell /usr/local/bin/bash
+
+if [[ $BASH_VERSION = *$VERSION* ]]; then
+  echo "$VERSION installed"
+else
+  echo "$VERSION is required to run this project! Found $BASH_VERSION"
+  echo "Run 'brew install bash', add '/usr/local/bin/bash' to your /etc/shells file, and restart your terminal"
+  exit 1
+fi

--- a/bin/check_bash_version
+++ b/bin/check_bash_version
@@ -12,6 +12,7 @@ function check_shell () {
   if [ -z "${shell_line}" ]; then
     # shellcheck disable=SC1117
     echo -e "\033[0;33mPlease add ${shell} to your /etc/shells file using the command:\033[0m 'echo \"${shell}\" | sudo tee -a /etc/shells'"
+    echo -e "\033[0;33mOptionally update your user's shell with the command:\033[0m 'sudo chsh -s /usr/local/bin/bash'"
     exit 1
   fi
 }

--- a/bin/check_dep_version
+++ b/bin/check_dep_version
@@ -1,4 +1,4 @@
-#! /bin/bash
+#! /usr/bin/env bash
 
 set -eu -o pipefail
 

--- a/bin/check_go_version
+++ b/bin/check_go_version
@@ -1,4 +1,4 @@
-#! /bin/bash
+#! /usr/bin/env bash
 
 set -eu -o pipefail
 

--- a/bin/check_gopath.sh
+++ b/bin/check_gopath.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#! /usr/bin/env bash
 
 gpath=$GOPATH
 if [ -z "$gpath" ]; then

--- a/bin/circleci-announce-broken-branch
+++ b/bin/circleci-announce-broken-branch
@@ -1,4 +1,4 @@
-#!/bin/bash
+#! /usr/bin/env bash
 set -euo pipefail
 
 NOW=$(date '+%s')

--- a/bin/circleci-push-dependency-updates
+++ b/bin/circleci-push-dependency-updates
@@ -1,4 +1,4 @@
-#!/bin/bash
+#! /usr/bin/env bash
 set -euxo pipefail
 
 readonly github_repo="transcom/mymove"

--- a/bin/copy_swagger_ui.sh
+++ b/bin/copy_swagger_ui.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#! /usr/bin/env bash
 
 # Copies the assets (other than xxx.html) into the public directory
 # internal.html & api.html are checked into public/swagger-ui and

--- a/bin/db-backup
+++ b/bin/db-backup
@@ -1,4 +1,4 @@
-#!/bin/bash
+#! /usr/bin/env bash
 # Backup the contents of the development database for later restore.
 
 set -eu -o pipefail

--- a/bin/db-restore
+++ b/bin/db-restore
@@ -1,4 +1,4 @@
-#!/bin/bash
+#! /usr/bin/env bash
 # Restore the contents of the development database from an earlier backup.
 
 set -eu -o pipefail

--- a/bin/do-exclusively
+++ b/bin/do-exclusively
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#! /usr/bin/env bash
 
 ########################################################################################
 # CircleCI's current recommendation for roughly serializing a subset

--- a/bin/dump-function-calls
+++ b/bin/dump-function-calls
@@ -1,4 +1,4 @@
-#!/bin/bash
+#! /usr/bin/env bash
 #
 #   Show all used functions in our codebase.
 #

--- a/bin/dump-packages
+++ b/bin/dump-packages
@@ -1,4 +1,4 @@
-#!/bin/bash
+#! /usr/bin/env bash
 #
 #   Show all used packges in our codebase.
 #

--- a/bin/ecs-deploy-service-container
+++ b/bin/ecs-deploy-service-container
@@ -1,4 +1,4 @@
-#!/bin/bash
+#! /usr/bin/env bash
 #
 #   Updates the named service with the given container definition template,
 #   image, and environment.

--- a/bin/ecs-restart-services
+++ b/bin/ecs-restart-services
@@ -1,4 +1,4 @@
-#!/bin/bash
+#! /usr/bin/env bash
 #
 #   Restarted the ECS services associated with the given environment.
 #

--- a/bin/ecs-run-app-migrations-container
+++ b/bin/ecs-run-app-migrations-container
@@ -1,4 +1,4 @@
-#!/bin/bash
+#! /usr/bin/env bash
 #
 #   Creates and runs a migration task using the given container definition
 #   template, image, and environment.

--- a/bin/ecs-show-service-logs
+++ b/bin/ecs-show-service-logs
@@ -1,4 +1,4 @@
-#!/bin/bash
+#! /usr/bin/env bash
 #
 #   Show logs from the containers running for the named service.
 #

--- a/bin/ecs-show-service-stopped-logs
+++ b/bin/ecs-show-service-stopped-logs
@@ -1,4 +1,4 @@
-#!/bin/bash
+#! /usr/bin/env bash
 #
 #   Show logs from the most recently stopped app tasks.
 #

--- a/bin/export-obfuscated-tspp-sample
+++ b/bin/export-obfuscated-tspp-sample
@@ -1,4 +1,4 @@
-#!/bin/bash
+#! /usr/bin/env bash
 #
 # Export a subset of rows from the transportation_service_provider_performances table:
 #   2 TSPs per TDL

--- a/bin/find-invoices
+++ b/bin/find-invoices
@@ -1,4 +1,4 @@
-#!/bin/bash
+#! /usr/bin/env bash
 #
 # This script will use available API endpoints to find invoices in whatever
 # environment you specify.

--- a/bin/gen_e2e_migration
+++ b/bin/gen_e2e_migration
@@ -1,4 +1,4 @@
-#!/bin/bash
+#! /usr/bin/env bash
 
 set -eu -o pipefail
 

--- a/bin/gen_model
+++ b/bin/gen_model
@@ -1,4 +1,4 @@
-#!/bin/bash
+#! /usr/bin/env bash
 
 # This file allows running soda from the top level directory, it
 # runs in the correct directory, with the right pointer to migrations.

--- a/bin/gen_server.sh
+++ b/bin/gen_server.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#! /usr/bin/env bash
 
 set -eu -o pipefail
 

--- a/bin/generate-devlocal-cert.sh
+++ b/bin/generate-devlocal-cert.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#! /usr/bin/env bash
 # Convenience script for creating a new certificate signed by the devlocal CA.
 
 set -eo pipefail

--- a/bin/generate-md-toc.sh
+++ b/bin/generate-md-toc.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#! /usr/bin/env bash
 # Wrapper script to generate table of contents on Markdown files.
 # Markdown files must have the `<!-- toc -->` tag in them in order to receive
 # a TOC.

--- a/bin/generate-secure-migration
+++ b/bin/generate-secure-migration
@@ -1,4 +1,4 @@
-#!/bin/bash
+#! /usr/bin/env bash
 #
 # A script to help manage the creation of secure migrations
 # https://github.com/transcom/mymove#secure-migrations

--- a/bin/merge-pr
+++ b/bin/merge-pr
@@ -1,4 +1,4 @@
-#!/bin/bash
+#! /usr/bin/env bash
 # A script to automate the landing of your GitHub pull requests.
 
 set -eu -o pipefail

--- a/bin/pre-commit-spellcheck
+++ b/bin/pre-commit-spellcheck
@@ -1,4 +1,4 @@
-#! /bin/bash
+#! /usr/bin/env bash
 
 # This wrapper exists because mdspell doesn't think that pre-commit supports colors.
 # markdown-spellcheck, the library we're using here, isn't doing a great job

--- a/bin/prereqs
+++ b/bin/prereqs
@@ -1,4 +1,4 @@
-#! /bin/bash
+#! /usr/bin/env bash
 
 set -eu -o pipefail
 

--- a/bin/prereqs
+++ b/bin/prereqs
@@ -16,6 +16,7 @@ function has() {
 }
 
 has go "brew install go"
+has bash "brew install bash"
 has yarn "brew install yarn"
 has dep "brew install dep"
 has pre-commit "brew install pre-commit"

--- a/bin/psql
+++ b/bin/psql
@@ -1,4 +1,4 @@
-#!/bin/bash
+#! /usr/bin/env bash
 
 set -eu -o pipefail
 

--- a/bin/psql-dev
+++ b/bin/psql-dev
@@ -1,4 +1,4 @@
-#!/bin/bash
+#! /usr/bin/env bash
 
 export DB_NAME=dev_db
 # shellcheck disable=SC1091,SC1090

--- a/bin/psql-test
+++ b/bin/psql-test
@@ -1,4 +1,4 @@
-#!/bin/bash
+#! /usr/bin/env bash
 
 export DB_NAME=test_db
 # shellcheck disable=SC1091,SC1090

--- a/bin/rds-snapshot-app-db
+++ b/bin/rds-snapshot-app-db
@@ -1,4 +1,4 @@
-#!/bin/bash
+#! /usr/bin/env bash
 #
 #   Creates a snapshot of the app database for the given environment.
 #

--- a/bin/run-e2e-test
+++ b/bin/run-e2e-test
@@ -1,4 +1,4 @@
-#!/bin/bash
+#! /usr/bin/env bash
 
 set -eu -o pipefail
 

--- a/bin/run-e2e-test-docker
+++ b/bin/run-e2e-test-docker
@@ -1,4 +1,4 @@
-#!/bin/bash
+#! /usr/bin/env bash
 
 set -eu -o pipefail
 

--- a/bin/run-prod-migrations
+++ b/bin/run-prod-migrations
@@ -1,4 +1,4 @@
-#!/bin/bash
+#! /usr/bin/env bash
 #
 # A script to apply all migrations, including secure migrations, to a local database.
 # https://github.com/transcom/mymove#secure-migrations

--- a/bin/upload-secure-migration
+++ b/bin/upload-secure-migration
@@ -1,4 +1,4 @@
-#!/bin/bash
+#! /usr/bin/env bash
 #
 # A script to upload secure migrations to all environments
 # https://github.com/transcom/mymove#secure-migrations

--- a/bin/wait-for-db
+++ b/bin/wait-for-db
@@ -1,4 +1,4 @@
-#!/bin/bash
+#! /usr/bin/env bash
 # This script waits for an available database connection, or until a timeout is
 # reached. Useful to test database connectivity, or wait for local Docker
 # instances to spin up.

--- a/bin/wait-for-db-docker
+++ b/bin/wait-for-db-docker
@@ -1,4 +1,4 @@
-#!/bin/bash
+#! /usr/bin/env bash
 # This script waits for an available database connection, or until a timeout is
 # reached. Useful to test database connectivity, or wait for local Docker
 # instances to spin up.


### PR DESCRIPTION
## Description

The bash that comes with OSX is version `3.2.57(1)-release` but modern bash is at version `5.0.2(1)-release`.  This causes issues when we use bash scripts using newer bash syntax like:

```
#! /bin/bash

export DB_NAME=dev_db
# shellcheck disable=SC1091,SC1090
. "$(dirname "$0")"/psql
```

One option is to make all scripts work with the older version, but that doesn't prevent newer issues.  The approach in this PR makes us version the bash we use for the project to be whatever is supplied by Homebrew.  This should ensure all users of scripts that call bash have the same results.

Because this touches all scripts and changes `#! /bin/bash` to `#! /usr/bin/env bash` we should verify that this works on the experimental environment first.  The change should be a noop, but verification is needed.

## Reviewer Notes

This PR doesn't enforce a person's shell to be bash or even a specific version of bash.  User's who want to use any shell locally or even the original `/bin/bash` can still do so.  What this does instead is enforce users to have the brew version installed and available at `/usr/local/bin/bash`.

## Setup

All users will need to install bash with `brew install bash`.  However, they can run `make bash_version` if they want and that will have instructions on how to proceed. They will also be warned the next time they run `make build_tools` that they must install it if they haven't already.

## Code Review Verification Steps

* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/163884093) for this change