### PR TITLE
Default to empty object if ppm advance does not exist yet

### DIFF
--- a/src/scenes/Office/Ppm/PaymentsPanel.jsx
+++ b/src/scenes/Office/Ppm/PaymentsPanel.jsx
@@ -243,11 +243,11 @@ class PaymentsTable extends Component {
 const mapStateToProps = state => {
   const move = get(state, 'office.officeMove', {});
   const ppm = selectPPMForMove(state, move.id);
-
+  const advance = get(ppm, 'advance', {});
   return {
     ppm,
     move,
-    advance: selectReimbursement(state, ppm.advance.id) || ppm.advance,
+    advance: selectReimbursement(state, advance.id) || advance,
     hasError: false,
     errorMessage: state.office.error,
     attachmentsError: get(state, 'office.downloadAttachmentsHasError'),


### PR DESCRIPTION
## Description

Previously, we assumed there was always a ppm advance and pulled the id out of it. This would cause the app to crash in situations where there is no ppm advance yet (payment has not been requested). This PR adds a default object incase advance does not yet exist.

## Setup
`make db_dev_e2e_populate`
`make server_run`
SM App
`make client_run`
Create a PPM move
Office App
`make office_client_run`
View PPM move you just created

## Code Review Verification Steps
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/163910448) for this change

## Screenshots

![image](https://user-images.githubusercontent.com/13622298/52654238-71c9a500-2ea6-11e9-88f2-c9d4297e28df.png)
