### PR TITLE
Update prefix from mymove- to milmove-

### DIFF
--- a/pkg/dpsauth/cookie.go
+++ b/pkg/dpsauth/cookie.go
@@ -10,7 +10,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-const prefix = "mymove-"
+const prefix = "milmove-"
 
 // LoginGovIDToCookie takes the Login.gov UUID of the current user and returns the cookie.
 func LoginGovIDToCookie(userID string, cookieSecret []byte, cookieExpires int) (*http.Cookie, error) {


### PR DESCRIPTION
Same PR as https://github.com/transcom/mymove/pull/1570
I had to revert that in https://github.com/transcom/mymove/pull/1572 because DPS couldn't deploy the change on their end quickly. Now they are making the change.