### PR TITLE
Allow service member to continue move after logging out

### DIFF
--- a/src/scenes/MyMove/getWorkflowRoutes.jsx
+++ b/src/scenes/MyMove/getWorkflowRoutes.jsx
@@ -175,7 +175,7 @@ const pages = {
   '/moves/:moveId/hhg-start': {
     isInFlow: hasHHG,
     isComplete: (sm, orders, move, hhg) => {
-      return every([hhg.requested_pickup_date]);
+      return hhg && every([hhg.requested_pickup_date]);
     },
     render: (key, pages) => ({ match }) => <MoveDate pages={pages} pageKey={key} match={match} />,
   },


### PR DESCRIPTION
## Description

Fix the issue that was preventing service members from using the "Continue Move" button for HHGs after logging out before completing an HHG.

## Reviewer Notes

* Create new service member profile
* Create an HHG move and continue to the point where they have to specify their pickup address
* Log out / Log back in
* Click "Continue Move"

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/n/projects/2181745/stories/163495152)

## Screenshots

![image](https://user-images.githubusercontent.com/1036969/52659610-ec9cbb00-2eba-11e9-8dda-d74ecb7561f8.png)
