### PR TITLE
Restores absolute path usage, removes custom swagger spec

### DIFF
--- a/public/swagger-ui/api.html
+++ b/public/swagger-ui/api.html
@@ -82,14 +82,6 @@ window.onload = function() {
         console.warn('Unable to retrieve CSRF Token from cookie');
       }
     }
-    // Add check for protocol so that we know if someone tries to throw a non-relative path in the url parameter.
-    // This is here to prevent malicious actors using the parameter to execute arbitrary malicious code on an
-    // unsuspecting user (swagger-ui behavior causes this to happen otherwise).
-    var protocolRegex = /(http|https):*/;
-    var isNonRelativePath = protocolRegex.test(req['url']);
-    if (isNonRelativePath) {
-      req['url'] = null;
-    }
 
     return req;
   };
@@ -101,13 +93,11 @@ window.onload = function() {
     dom_id: '#swagger-ui',
     deepLinking: true,
     presets: [
-      SwaggerUIBundle.presets.apis,
-      SwaggerUIStandalonePreset
+      SwaggerUIBundle.presets.apis
     ],
     plugins: [
       SwaggerUIBundle.plugins.DownloadUrl
     ],
-    layout: "StandaloneLayout",
     validatorUrl: false
   })
 

--- a/public/swagger-ui/internal.html
+++ b/public/swagger-ui/internal.html
@@ -82,14 +82,6 @@ window.onload = function() {
         console.warn('Unable to retrieve CSRF Token from cookie');
       }
     }
-    // Add check for protocol so that we know if someone tries to throw a non-relative path in the url parameter.
-    // This is here to prevent malicious actors using the parameter to execute arbitrary malicious code on an
-    // unsuspecting user (swagger-ui behavior causes this to happen otherwise).
-    var protocolRegex = /(http|https):*/;
-    var isNonRelativePath = protocolRegex.test(req['url']);
-    if (isNonRelativePath) {
-      req['url'] = null;
-    }
 
     return req;
   };
@@ -101,13 +93,11 @@ window.onload = function() {
     dom_id: '#swagger-ui',
     deepLinking: true,
     presets: [
-      SwaggerUIBundle.presets.apis,
-      SwaggerUIStandalonePreset
+      SwaggerUIBundle.presets.apis
     ],
     plugins: [
       SwaggerUIBundle.plugins.DownloadUrl
     ],
-    layout: "StandaloneLayout",
     validatorUrl: false
   })
 


### PR DESCRIPTION
## Description

#1687 tried to prevent HTML injection by putting a check on all outgoing requests that killed any absolute URLs. This unintentionally borked all of the "Try it now" features, which all use absolute paths to our site.

My understanding is that the "Explore" box at the top was the main problem, so this PR removes the URL check and just removes the "Explore" box entirely

## Setup

You'll need to `client_build` so the new file is copied over

```sh
make client_build
```

## Screenshots

![screen shot 2019-02-12 at 11 08 47 am](https://user-images.githubusercontent.com/5151804/52661313-9af23180-2eb6-11e9-94ca-fe1fa673d7c0.png)
