### PR TITLE
TSP sees existing 105B/E with base quantity on edit

### DIFF
--- a/src/shared/PreApprovalRequest/DetailsHelper.js
+++ b/src/shared/PreApprovalRequest/DetailsHelper.js
@@ -1,9 +1,11 @@
 import { DefaultDetails } from './DefaultDetails';
 import { Code105Details } from './Code105Details';
+import { has } from 'lodash';
 
 export function getDetailComponent(code, robustAccessorial, initialValues) {
   code = code ? code.toLowerCase() : '';
   if (initialValues && !initialValues.crate_dimensions) return DefaultDetails;
-  if ((code && code.startsWith('105b')) || (code.startsWith('105e') && robustAccessorial)) return Code105Details;
+  const hasDimensions = has(initialValues, 'crate_dimensions');
+  if ((code.startsWith('105b') || code.startsWith('105e')) && hasDimensions && robustAccessorial) return Code105Details;
   return DefaultDetails;
 }

--- a/src/shared/PreApprovalRequest/DetailsHelper.js
+++ b/src/shared/PreApprovalRequest/DetailsHelper.js
@@ -1,8 +1,9 @@
 import { DefaultDetails } from './DefaultDetails';
 import { Code105Details } from './Code105Details';
 
-export function getDetailComponent(code, robustAccessorial) {
+export function getDetailComponent(code, robustAccessorial, initialValues) {
   code = code ? code.toLowerCase() : '';
-  if (code && code.startsWith('105') && !code.startsWith('105d') && robustAccessorial) return Code105Details;
+  if (initialValues && !initialValues.crate_dimensions) return DefaultDetails;
+  if ((code && code.startsWith('105b')) || (code.startsWith('105e') && robustAccessorial)) return Code105Details;
   return DefaultDetails;
 }

--- a/src/shared/PreApprovalRequest/DetailsHelper.js
+++ b/src/shared/PreApprovalRequest/DetailsHelper.js
@@ -4,8 +4,7 @@ import { has } from 'lodash';
 
 export function getDetailComponent(code, robustAccessorial, initialValues) {
   code = code ? code.toLowerCase() : '';
-  if (initialValues && !initialValues.crate_dimensions) return DefaultDetails;
-  const hasDimensions = has(initialValues, 'crate_dimensions');
+  const hasDimensions = !initialValues || has(initialValues, 'crate_dimensions');
   if ((code.startsWith('105b') || code.startsWith('105e')) && hasDimensions && robustAccessorial) return Code105Details;
   return DefaultDetails;
 }

--- a/src/shared/PreApprovalRequest/DetailsHelper.test.js
+++ b/src/shared/PreApprovalRequest/DetailsHelper.test.js
@@ -3,6 +3,8 @@ import { DefaultDetails } from './DefaultDetails';
 import { Code105Details } from './Code105Details';
 
 let featureFlag = false;
+let initialValuesWithoutCrateDimensions = {};
+let initialValuesWithCrateDimensions = { crate_dimensions: true };
 describe('testing getDetailComponent()', () => {
   describe('returns default details component', () => {
     const DetailComponent = getDetailComponent();
@@ -16,28 +18,28 @@ describe('testing getDetailComponent()', () => {
     //pass in known code item with feature flag off
     featureFlag = false;
 
-    let DetailComponent = getDetailComponent('105', featureFlag);
+    let DetailComponent = getDetailComponent('105', featureFlag, initialValuesWithCrateDimensions);
     it('for code 105', () => {
       expect(DetailComponent).toBe(DefaultDetails);
     });
 
-    DetailComponent = getDetailComponent('105B', featureFlag);
+    DetailComponent = getDetailComponent('105B', featureFlag, initialValuesWithCrateDimensions);
     it('for code 105B', () => {
       expect(DetailComponent).toBe(DefaultDetails);
     });
 
-    DetailComponent = getDetailComponent('105E', featureFlag);
+    DetailComponent = getDetailComponent('105E', featureFlag, initialValuesWithCrateDimensions);
     it('for code 105E', () => {
       expect(DetailComponent).toBe(DefaultDetails);
     });
 
     //testing for non-existing code
-    DetailComponent = getDetailComponent('4A', featureFlag);
+    DetailComponent = getDetailComponent('4A', featureFlag, initialValuesWithCrateDimensions);
     it('for code 4A', () => {
       expect(DetailComponent).toBe(DefaultDetails);
     });
 
-    DetailComponent = getDetailComponent('105D', featureFlag);
+    DetailComponent = getDetailComponent('105D', featureFlag, initialValuesWithCrateDimensions);
     it('for code 105D', () => {
       expect(DetailComponent).toBe(DefaultDetails);
     });
@@ -46,17 +48,17 @@ describe('testing getDetailComponent()', () => {
   describe('returns 105B/E details component with feature flag on', () => {
     featureFlag = true;
 
-    let DetailComponent = getDetailComponent('105', featureFlag);
+    let DetailComponent = getDetailComponent('105', featureFlag, initialValuesWithCrateDimensions);
     it('for code 105', () => {
       expect(DetailComponent).toBe(Code105Details);
     });
 
-    DetailComponent = getDetailComponent('105B', featureFlag);
+    DetailComponent = getDetailComponent('105B', featureFlag, initialValuesWithCrateDimensions);
     it('for code 105B', () => {
       expect(DetailComponent).toBe(Code105Details);
     });
 
-    DetailComponent = getDetailComponent('105E', featureFlag);
+    DetailComponent = getDetailComponent('105E', featureFlag, initialValuesWithCrateDimensions);
     it('for code 105E', () => {
       expect(DetailComponent).toBe(Code105Details);
     });
@@ -67,6 +69,16 @@ describe('testing getDetailComponent()', () => {
 
     let DetailComponent = getDetailComponent('105D', featureFlag);
     it('for code 105D', () => {
+      expect(DetailComponent).toBe(DefaultDetails);
+    });
+
+    DetailComponent = getDetailComponent('105B', featureFlag, initialValuesWithoutCrateDimensions);
+    it('for code 105B without crate dimensions', () => {
+      expect(DetailComponent).toBe(DefaultDetails);
+    });
+
+    DetailComponent = getDetailComponent('105E', featureFlag, initialValuesWithoutCrateDimensions);
+    it('for code 105E without crate dimensions', () => {
       expect(DetailComponent).toBe(DefaultDetails);
     });
   });

--- a/src/shared/PreApprovalRequest/DetailsHelper.test.js
+++ b/src/shared/PreApprovalRequest/DetailsHelper.test.js
@@ -91,10 +91,5 @@ describe('testing getDetailComponent()', () => {
     it('for code 105E without crate dimensions', () => {
       expect(DetailComponent).toBe(DefaultDetails);
     });
-
-    DetailComponent = getDetailComponent('105E', featureFlag, null);
-    it('for code 105E without crate dimensions', () => {
-      expect(DetailComponent).toBe(DefaultDetails);
-    });
   });
 });

--- a/src/shared/PreApprovalRequest/DetailsHelper.test.js
+++ b/src/shared/PreApprovalRequest/DetailsHelper.test.js
@@ -43,6 +43,11 @@ describe('testing getDetailComponent()', () => {
     it('for code 105D', () => {
       expect(DetailComponent).toBe(DefaultDetails);
     });
+
+    DetailComponent = getDetailComponent('105D', featureFlag, null);
+    it('for code 105D', () => {
+      expect(DetailComponent).toBe(DefaultDetails);
+    });
   });
 
   describe('returns 105B/E details component with feature flag on', () => {
@@ -62,6 +67,11 @@ describe('testing getDetailComponent()', () => {
     it('for code 105E', () => {
       expect(DetailComponent).toBe(Code105Details);
     });
+
+    DetailComponent = getDetailComponent('105E', featureFlag, null);
+    it('for code 105E', () => {
+      expect(DetailComponent).toBe(Code105Details);
+    });
   });
 
   describe('returns default details component with feature flag on', () => {
@@ -78,6 +88,11 @@ describe('testing getDetailComponent()', () => {
     });
 
     DetailComponent = getDetailComponent('105E', featureFlag, initialValuesWithoutCrateDimensions);
+    it('for code 105E without crate dimensions', () => {
+      expect(DetailComponent).toBe(DefaultDetails);
+    });
+
+    DetailComponent = getDetailComponent('105E', featureFlag, null);
     it('for code 105E without crate dimensions', () => {
       expect(DetailComponent).toBe(DefaultDetails);
     });

--- a/src/shared/PreApprovalRequest/PreApprovalForm.jsx
+++ b/src/shared/PreApprovalRequest/PreApprovalForm.jsx
@@ -105,7 +105,11 @@ export class LocationSearch extends Component {
 export class PreApprovalForm extends Component {
   render() {
     const robustAccessorial = get(this.props, 'context.flags.robustAccessorial', false);
-    const DetailComponent = getDetailComponent(this.props.tariff400ng_item_code, robustAccessorial);
+    const DetailComponent = getDetailComponent(
+      this.props.tariff400ng_item_code,
+      robustAccessorial,
+      this.props.initialValues,
+    );
 
     return (
       <Form className="pre-approval-form" onSubmit={this.props.handleSubmit(this.props.onSubmit)}>

--- a/src/shared/PreApprovalRequest/PreApprovalForm.test.js
+++ b/src/shared/PreApprovalRequest/PreApprovalForm.test.js
@@ -206,6 +206,7 @@ describe('PreApprovalForm tests', () => {
             tariff400ng_item_code={'105B'}
             tariff400ngItem={simple105TariffItem}
             context={{ flags: { robustAccessorial: true } }}
+            initialValues={{ crate_dimensions: true }}
           />
         </Provider>,
       );


### PR DESCRIPTION
## Description

When a TSP edits an old 105B/E preapproval request, the old form (with base quantity instead of dimensions) is shown. 

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](./docs/backend.md#logging)
* [ ] There are no aXe warnings for UI.
* [ ] This works in IE.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/163438418) for this change