### PR TITLE
go-find-pattern

### DIFF
--- a/bin/go-find-pattern
+++ b/bin/go-find-pattern
@@ -1,6 +1,7 @@
 #!/bin/bash
 #
 #   go-find-pattern searchs over all our go source code files for a regex pattern"
+#   For example: bin/go-find-pattern '[.]Info[(]"[^"]+\s+"'
 #
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"

--- a/bin/go-find-pattern
+++ b/bin/go-find-pattern
@@ -1,0 +1,41 @@
+#!/bin/bash
+#
+#   go-find-pattern searchs over all our go source code files for a regex pattern"
+#
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+readonly DIR
+
+usage() {
+    echo "$0 <pattern"
+    exit 1
+}
+[[ -z $1  ]] && usage
+
+pattern=$1
+
+# shellcheck disable=SC2207
+pkgs=($(go list -e -json github.com/transcom/mymove/... 2> /dev/null | jq -c '{import: .ImportPath, dir: .Dir, files: .GoFiles}'))
+
+results=()
+# shellcheck disable=SC1072
+for pkg in "${pkgs[@]}"; do
+  import=$(echo "$pkg" | jq -r ".import")
+  parent=$(echo "$pkg" | jq -r ".dir")
+  # shellcheck disable=SC2207
+  files=($(echo "$pkg" | jq -r ".files[]"))
+  # shellcheck disable=SC1072
+  for file in "${files[@]}"; do
+    # shellcheck disable=SC2002
+    lines=$(cat "$parent/$file" | grep -inE "$pattern" | cut -d':' -f1 | tr '\n' ',')
+    # shellcheck disable=SC1072
+    if [[ "${lines// }" ]]; then
+      # shellcheck disable=SC2178,SC2128
+      results="$results\n$import/$file | $lines"
+    fi
+    #exit 0
+  done
+done
+
+# shellcheck disable=SC2128
+echo -e "package | lines\n$results" | column -t


### PR DESCRIPTION
## Description

Simple bash script for regex search over our go source code.  For example:

```
bin/go-find-pattern '[.]Info[(]"[^"]+\s+"'
```

Returns

```
package                                                                   |  lines
github.com/transcom/mymove/pkg/handlers/internalapi/documents.go          |  75,
github.com/transcom/mymove/pkg/handlers/internalapi/uploads.go            |  51,
github.com/transcom/mymove/pkg/services/shipment/recalculate_shipment.go  |  20,
github.com/transcom/mymove/pkg/uploader/uploader.go                       |  108,
```

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Setup

None

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](./docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](./docs/backend.md#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](./docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
  * [ ] Secure migrations have been tested using `bin/run-prod-migrations`
* [ ] There are no aXe warnings for UI.
* [ ] This works in IE.
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @willowbl00
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

N.A.

## Screenshots

N.A.