### PR TITLE
CreateForm Service Object PR updates

### DIFF
--- a/pkg/handlers/publicapi/api.go
+++ b/pkg/handlers/publicapi/api.go
@@ -44,7 +44,7 @@ func NewPublicAPIHandler(context handlers.HandlerContext) http.Handler {
 	publicAPI.ShipmentsGetShipmentInvoicesHandler = GetShipmentInvoicesHandler{context}
 
 	publicAPI.ShipmentsCompletePmSurveyHandler = CompletePmSurveyHandler{context}
-	publicAPI.ShipmentsCreateGovBillOfLadingHandler = CreateGovBillOfLadingHandler{context, paperworkservice.NewCreateForm(context.FileStorer().TempFileSystem(), paperwork.NewFormFiller())}
+	publicAPI.ShipmentsCreateGovBillOfLadingHandler = CreateGovBillOfLadingHandler{context, paperworkservice.NewFormCreator(context.FileStorer().TempFileSystem(), paperwork.NewFormFiller())}
 
 	// Accessorials
 	publicAPI.AccessorialsGetShipmentLineItemsHandler = GetShipmentLineItemsHandler{context}

--- a/pkg/handlers/publicapi/shipments.go
+++ b/pkg/handlers/publicapi/shipments.go
@@ -605,7 +605,7 @@ func (h PatchShipmentHandler) Handle(params shipmentop.PatchShipmentParams) midd
 // CreateGovBillOfLadingHandler creates a GBL PDF & uploads it as a document associated to a move doc, shipment and move
 type CreateGovBillOfLadingHandler struct {
 	handlers.HandlerContext
-	formCreator services.FormCreator
+	pdfFormCreator services.FormCreator
 }
 
 // Handle generates the GBL PDF & uploads it as a document associated to a move doc, shipment and move
@@ -655,7 +655,7 @@ func (h CreateGovBillOfLadingHandler) Handle(params shipmentop.CreateGovBillOfLa
 		h.Logger().Error(errors.Cause(err).Error(), zap.Error(errors.Cause(err)))
 	}
 
-	gblFile, err := h.formCreator.CreateForm(template)
+	gblFile, err := h.pdfFormCreator.CreateForm(template)
 	if err != nil {
 		h.Logger().Error(errors.Cause(err).Error(), zap.Error(errors.Cause(err)))
 		return shipmentop.NewCreateGovBillOfLadingInternalServerError()

--- a/pkg/handlers/publicapi/shipments.go
+++ b/pkg/handlers/publicapi/shipments.go
@@ -605,7 +605,7 @@ func (h PatchShipmentHandler) Handle(params shipmentop.PatchShipmentParams) midd
 // CreateGovBillOfLadingHandler creates a GBL PDF & uploads it as a document associated to a move doc, shipment and move
 type CreateGovBillOfLadingHandler struct {
 	handlers.HandlerContext
-	createForm services.FormCreator
+	formCreator services.FormCreator
 }
 
 // Handle generates the GBL PDF & uploads it as a document associated to a move doc, shipment and move
@@ -655,7 +655,7 @@ func (h CreateGovBillOfLadingHandler) Handle(params shipmentop.CreateGovBillOfLa
 		h.Logger().Error(errors.Cause(err).Error(), zap.Error(errors.Cause(err)))
 	}
 
-	gblFile, err := h.createForm.CreateForm(template)
+	gblFile, err := h.formCreator.CreateForm(template)
 	if err != nil {
 		h.Logger().Error(errors.Cause(err).Error(), zap.Error(errors.Cause(err)))
 		return shipmentop.NewCreateGovBillOfLadingInternalServerError()

--- a/pkg/handlers/publicapi/shipments_test.go
+++ b/pkg/handlers/publicapi/shipments_test.go
@@ -379,7 +379,7 @@ func (suite *HandlerSuite) TestCreateGovBillOfLadingHandler() {
 	shipment.Move.Orders.TAC = nil
 	suite.MustSave(&shipment.Move.Orders)
 
-	formCreator := paperworkservice.NewCreateForm(context.FileStorer().TempFileSystem(), paperwork.NewFormFiller())
+	formCreator := paperworkservice.NewFormCreator(context.FileStorer().TempFileSystem(), paperwork.NewFormFiller())
 	// And: the create gbl handler is called
 	handler := CreateGovBillOfLadingHandler{context, formCreator}
 	response := handler.Handle(params)

--- a/pkg/handlers/publicapi/shipments_test.go
+++ b/pkg/handlers/publicapi/shipments_test.go
@@ -379,9 +379,9 @@ func (suite *HandlerSuite) TestCreateGovBillOfLadingHandler() {
 	shipment.Move.Orders.TAC = nil
 	suite.MustSave(&shipment.Move.Orders)
 
-	createForm := paperworkservice.NewCreateForm(context.FileStorer().TempFileSystem(), paperwork.NewFormFiller())
+	formCreator := paperworkservice.NewCreateForm(context.FileStorer().TempFileSystem(), paperwork.NewFormFiller())
 	// And: the create gbl handler is called
-	handler := CreateGovBillOfLadingHandler{context, createForm}
+	handler := CreateGovBillOfLadingHandler{context, formCreator}
 	response := handler.Handle(params)
 
 	// Then: expect a 417 status code
@@ -394,14 +394,14 @@ func (suite *HandlerSuite) TestCreateGovBillOfLadingHandler() {
 	suite.MustSave(&shipment.Move.Orders)
 
 	// And: the create gbl handler is called
-	handler = CreateGovBillOfLadingHandler{context, createForm}
+	handler = CreateGovBillOfLadingHandler{context, formCreator}
 	response = handler.Handle(params)
 
 	// Then: expect a 200 status code
 	suite.Assertions.IsType(&shipmentop.CreateGovBillOfLadingCreated{}, response)
 
 	// When: there is an existing GBL for a shipment and handler is called
-	handler = CreateGovBillOfLadingHandler{handlers.NewHandlerContext(suite.DB(), suite.TestLogger()), createForm}
+	handler = CreateGovBillOfLadingHandler{handlers.NewHandlerContext(suite.DB(), suite.TestLogger()), formCreator}
 	response = handler.Handle(params)
 
 	// Then: expect a 400 status code

--- a/pkg/services/paperwork/create_form.go
+++ b/pkg/services/paperwork/create_form.go
@@ -13,25 +13,25 @@ import (
 	"github.com/transcom/mymove/pkg/services"
 )
 
-// Storer is an interface for FileStorer
-type Storer interface {
+// FileStorer is an interface for pdfFileStorer implementation
+type FileStorer interface {
 	Create(string) (afero.File, error)
 }
 
-// Filler is an interface for FormFiller
-type Filler interface {
+// FormFiller is an interface for pdfFormFiller implementation
+type FormFiller interface {
 	AppendPage(io.ReadSeeker, map[string]paperworkforms.FieldPos, interface{}) error
 	Output(io.Writer) error
 }
 
-// CreateForm is a service object to create a form with data
+// createForm is a service object to create a form with data
 type createForm struct {
-	FileStorer Storer
-	FormFiller Filler
+	pdfFileStorer FileStorer
+	pdfFormFiller FormFiller
 }
 
-// CreateAssetByteReader creates a new byte reader based on the TemplateImagePath of the formLayout
-func CreateAssetByteReader(path string) (*bytes.Reader, error) {
+// createAssetByteReader creates a new byte reader based on the TemplateImagePath of the formLayout
+func createAssetByteReader(path string) (*bytes.Reader, error) {
 	asset, err := assets.Asset(path)
 	if err != nil {
 		return nil, errors.Wrap(err, "Error creating asset from path. Check image path.")
@@ -44,7 +44,7 @@ func CreateAssetByteReader(path string) (*bytes.Reader, error) {
 // MakeFormTemplate creates form template with all needed parameters from handler
 func MakeFormTemplate(data interface{}, fileName string, formLayout paperworkforms.FormLayout, formType services.FormType) (services.FormTemplate, error) {
 	// Read in bytes from Asset pkg
-	templateBuffer, err := CreateAssetByteReader(formLayout.TemplateImagePath)
+	templateBuffer, err := createAssetByteReader(formLayout.TemplateImagePath)
 	if err != nil {
 		return services.FormTemplate{}, errors.Wrap(err, "Error reading template file and creating form template")
 	}
@@ -52,26 +52,26 @@ func MakeFormTemplate(data interface{}, fileName string, formLayout paperworkfor
 }
 
 // NewCreateForm creates a new struct with service dependencies
-func NewCreateForm(FileStorer Storer, FormFiller Filler) services.FormCreator {
-	return &createForm{FileStorer: FileStorer, FormFiller: FormFiller}
+func NewCreateForm(fileStorer FileStorer, formFiller FormFiller) services.FormCreator {
+	return &createForm{fileStorer, formFiller}
 }
 
 // Call creates a form with the given data
 func (c createForm) CreateForm(template services.FormTemplate) (afero.File, error) {
 	// Populate form fields with data
-	err := c.FormFiller.AppendPage(template.Buffer, template.FieldsLayout, template.Data)
+	err := c.pdfFormFiller.AppendPage(template.Buffer, template.FieldsLayout, template.Data)
 	if err != nil {
 		return nil, errors.Wrap(err, fmt.Sprintf("Failure writing %s data to form.", template.FormType.String()))
 	}
 
 	// Read the incoming data into a temporary afero.File for consumption
-	file, err := c.FileStorer.Create(template.FileName)
+	file, err := c.pdfFileStorer.Create(template.FileName)
 	if err != nil {
 		return nil, errors.Wrap(err, fmt.Sprintf("Error creating a new afero file for %s form.", template.FormType.String()))
 	}
 
 	// Export file from form filler
-	err = c.FormFiller.Output(file)
+	err = c.pdfFormFiller.Output(file)
 	if err != nil {
 		return nil, errors.Wrap(err, fmt.Sprintf("Failure exporting %s form to file.", template.FormType.String()))
 	}

--- a/pkg/services/paperwork/create_form_test.go
+++ b/pkg/services/paperwork/create_form_test.go
@@ -72,7 +72,7 @@ func (suite *CreateFormSuite) TestCreateFormServiceSuccess() {
 		f,
 	).Return(nil)
 
-	formCreator := NewCreateForm(FileStorer, FormFiller)
+	formCreator := NewFormCreator(FileStorer, FormFiller)
 	template, _ := MakeFormTemplate(gbl, "some-file-name", paperworkforms.Form1203Layout, services.GBL)
 	file, err := formCreator.CreateForm(template)
 
@@ -93,7 +93,7 @@ func (suite *CreateFormSuite) TestCreateFormServiceFormFillerAppendPageFailure()
 		mock.AnythingOfType("models.GovBillOfLadingFormValues"),
 	).Return(errors.New("Error for FormFiller.AppendPage()")).Times(1)
 
-	formCreator := NewCreateForm(FileStorer, FormFiller)
+	formCreator := NewFormCreator(FileStorer, FormFiller)
 	template, _ := MakeFormTemplate(gbl, "some-file-name", paperworkforms.Form1203Layout, services.GBL)
 	file, err := formCreator.CreateForm(template)
 
@@ -121,7 +121,7 @@ func (suite *CreateFormSuite) TestCreateFormServiceFileStorerCreateFailure() {
 		mock.AnythingOfType("string"),
 	).Return(nil, errors.New("Error for FileStorer.Create()"))
 
-	formCreator := NewCreateForm(FileStorer, FormFiller)
+	formCreator := NewFormCreator(FileStorer, FormFiller)
 	template, _ := MakeFormTemplate(gbl, "some-file-name", paperworkforms.Form1203Layout, services.GBL)
 	file, err := formCreator.CreateForm(template)
 
@@ -156,7 +156,7 @@ func (suite *CreateFormSuite) TestCreateFormServiceFormFillerOutputFailure() {
 		f,
 	).Return(errors.New("Error for FormFiller.Output()"))
 
-	formCreator := NewCreateForm(FileStorer, FormFiller)
+	formCreator := NewFormCreator(FileStorer, FormFiller)
 	template, _ := MakeFormTemplate(gbl, "some-file-name", paperworkforms.Form1203Layout, services.GBL)
 	file, err := formCreator.CreateForm(template)
 

--- a/pkg/services/paperwork/create_form_test.go
+++ b/pkg/services/paperwork/create_form_test.go
@@ -72,9 +72,9 @@ func (suite *CreateFormSuite) TestCreateFormServiceSuccess() {
 		f,
 	).Return(nil)
 
-	createForm := NewCreateForm(FileStorer, FormFiller)
+	formCreator := NewCreateForm(FileStorer, FormFiller)
 	template, _ := MakeFormTemplate(gbl, "some-file-name", paperworkforms.Form1203Layout, services.GBL)
-	file, err := createForm.CreateForm(template)
+	file, err := formCreator.CreateForm(template)
 
 	assert.NotNil(suite.T(), file)
 	assert.Nil(suite.T(), err)
@@ -93,9 +93,9 @@ func (suite *CreateFormSuite) TestCreateFormServiceFormFillerAppendPageFailure()
 		mock.AnythingOfType("models.GovBillOfLadingFormValues"),
 	).Return(errors.New("Error for FormFiller.AppendPage()")).Times(1)
 
-	createForm := NewCreateForm(FileStorer, FormFiller)
+	formCreator := NewCreateForm(FileStorer, FormFiller)
 	template, _ := MakeFormTemplate(gbl, "some-file-name", paperworkforms.Form1203Layout, services.GBL)
-	file, err := createForm.CreateForm(template)
+	file, err := formCreator.CreateForm(template)
 
 	assert.NotNil(suite.T(), err)
 	assert.Nil(suite.T(), file)
@@ -121,9 +121,9 @@ func (suite *CreateFormSuite) TestCreateFormServiceFileStorerCreateFailure() {
 		mock.AnythingOfType("string"),
 	).Return(nil, errors.New("Error for FileStorer.Create()"))
 
-	createForm := NewCreateForm(FileStorer, FormFiller)
+	formCreator := NewCreateForm(FileStorer, FormFiller)
 	template, _ := MakeFormTemplate(gbl, "some-file-name", paperworkforms.Form1203Layout, services.GBL)
-	file, err := createForm.CreateForm(template)
+	file, err := formCreator.CreateForm(template)
 
 	assert.Nil(suite.T(), file)
 	assert.NotNil(suite.T(), err)
@@ -156,9 +156,9 @@ func (suite *CreateFormSuite) TestCreateFormServiceFormFillerOutputFailure() {
 		f,
 	).Return(errors.New("Error for FormFiller.Output()"))
 
-	createForm := NewCreateForm(FileStorer, FormFiller)
+	formCreator := NewCreateForm(FileStorer, FormFiller)
 	template, _ := MakeFormTemplate(gbl, "some-file-name", paperworkforms.Form1203Layout, services.GBL)
-	file, err := createForm.CreateForm(template)
+	file, err := formCreator.CreateForm(template)
 
 	assert.Nil(suite.T(), file)
 	assert.NotNil(suite.T(), err)
@@ -170,7 +170,7 @@ func (suite *CreateFormSuite) TestCreateFormServiceFormFillerOutputFailure() {
 
 func (suite *CreateFormSuite) TestCreateFormServiceCreateAssetByteReaderFailure() {
 	badAssetPath := "pkg/paperwork/formtemplates/someUndefinedTemplatePath.png"
-	templateBuffer, err := CreateAssetByteReader(badAssetPath)
+	templateBuffer, err := createAssetByteReader(badAssetPath)
 	assert.Nil(suite.T(), templateBuffer)
 	assert.NotNil(suite.T(), err)
 	assert.Equal(suite.T(), "Error creating asset from path. Check image path.: Asset pkg/paperwork/formtemplates/someUndefinedTemplatePath.png not found", err.Error(), "should be equal")

--- a/pkg/services/paperwork/create_form_test.go
+++ b/pkg/services/paperwork/create_form_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/spf13/afero"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/zap"
@@ -76,8 +75,8 @@ func (suite *CreateFormSuite) TestCreateFormServiceSuccess() {
 	template, _ := MakeFormTemplate(gbl, "some-file-name", paperworkforms.Form1203Layout, services.GBL)
 	file, err := formCreator.CreateForm(template)
 
-	assert.NotNil(suite.T(), file)
-	assert.Nil(suite.T(), err)
+	suite.NotNil(suite.T(), file)
+	suite.Nil(suite.T(), err)
 	FormFiller.AssertExpectations(suite.T())
 }
 
@@ -97,11 +96,11 @@ func (suite *CreateFormSuite) TestCreateFormServiceFormFillerAppendPageFailure()
 	template, _ := MakeFormTemplate(gbl, "some-file-name", paperworkforms.Form1203Layout, services.GBL)
 	file, err := formCreator.CreateForm(template)
 
-	assert.NotNil(suite.T(), err)
-	assert.Nil(suite.T(), file)
+	suite.NotNil(suite.T(), err)
+	suite.Nil(suite.T(), file)
 	serviceErrMsg := errors.Cause(err)
-	assert.Equal(suite.T(), "Error for FormFiller.AppendPage()", serviceErrMsg.Error(), "should be equal")
-	assert.Equal(suite.T(), "Failure writing GBL data to form.: Error for FormFiller.AppendPage()", err.Error(), "should be equal")
+	suite.Equal(suite.T(), "Error for FormFiller.AppendPage()", serviceErrMsg.Error(), "should be equal")
+	suite.Equal(suite.T(), "Failure writing GBL data to form.: Error for FormFiller.AppendPage()", err.Error(), "should be equal")
 	FormFiller.AssertExpectations(suite.T())
 }
 
@@ -125,11 +124,11 @@ func (suite *CreateFormSuite) TestCreateFormServiceFileStorerCreateFailure() {
 	template, _ := MakeFormTemplate(gbl, "some-file-name", paperworkforms.Form1203Layout, services.GBL)
 	file, err := formCreator.CreateForm(template)
 
-	assert.Nil(suite.T(), file)
-	assert.NotNil(suite.T(), err)
+	suite.Nil(suite.T(), file)
+	suite.NotNil(suite.T(), err)
 	serviceErrMsg := errors.Cause(err)
-	assert.Equal(suite.T(), "Error for FileStorer.Create()", serviceErrMsg.Error(), "should be equal")
-	assert.Equal(suite.T(), "Error creating a new afero file for GBL form.: Error for FileStorer.Create()", err.Error(), "should be equal")
+	suite.Equal(suite.T(), "Error for FileStorer.Create()", serviceErrMsg.Error(), "should be equal")
+	suite.Equal(suite.T(), "Error creating a new afero file for GBL form.: Error for FileStorer.Create()", err.Error(), "should be equal")
 	FormFiller.AssertExpectations(suite.T())
 }
 
@@ -160,18 +159,18 @@ func (suite *CreateFormSuite) TestCreateFormServiceFormFillerOutputFailure() {
 	template, _ := MakeFormTemplate(gbl, "some-file-name", paperworkforms.Form1203Layout, services.GBL)
 	file, err := formCreator.CreateForm(template)
 
-	assert.Nil(suite.T(), file)
-	assert.NotNil(suite.T(), err)
+	suite.Nil(suite.T(), file)
+	suite.NotNil(suite.T(), err)
 	serviceErrMsg := errors.Cause(err)
-	assert.Equal(suite.T(), "Error for FormFiller.Output()", serviceErrMsg.Error(), "should be equal")
-	assert.Equal(suite.T(), "Failure exporting GBL form to file.: Error for FormFiller.Output()", err.Error(), "should be equal")
+	suite.Equal(suite.T(), "Error for FormFiller.Output()", serviceErrMsg.Error(), "should be equal")
+	suite.Equal(suite.T(), "Failure exporting GBL form to file.: Error for FormFiller.Output()", err.Error(), "should be equal")
 	FormFiller.AssertExpectations(suite.T())
 }
 
 func (suite *CreateFormSuite) TestCreateFormServiceCreateAssetByteReaderFailure() {
 	badAssetPath := "pkg/paperwork/formtemplates/someUndefinedTemplatePath.png"
 	templateBuffer, err := createAssetByteReader(badAssetPath)
-	assert.Nil(suite.T(), templateBuffer)
-	assert.NotNil(suite.T(), err)
-	assert.Equal(suite.T(), "Error creating asset from path. Check image path.: Asset pkg/paperwork/formtemplates/someUndefinedTemplatePath.png not found", err.Error(), "should be equal")
+	suite.Nil(suite.T(), templateBuffer)
+	suite.NotNil(suite.T(), err)
+	suite.Equal(suite.T(), "Error creating asset from path. Check image path.: Asset pkg/paperwork/formtemplates/someUndefinedTemplatePath.png not found", err.Error(), "should be equal")
 }

--- a/pkg/services/paperwork/create_form_test.go
+++ b/pkg/services/paperwork/create_form_test.go
@@ -75,8 +75,8 @@ func (suite *CreateFormSuite) TestCreateFormServiceSuccess() {
 	template, _ := MakeFormTemplate(gbl, "some-file-name", paperworkforms.Form1203Layout, services.GBL)
 	file, err := formCreator.CreateForm(template)
 
-	suite.NotNil(suite.T(), file)
-	suite.Nil(suite.T(), err)
+	suite.NotNil(file)
+	suite.Nil(err)
 	FormFiller.AssertExpectations(suite.T())
 }
 
@@ -96,11 +96,11 @@ func (suite *CreateFormSuite) TestCreateFormServiceFormFillerAppendPageFailure()
 	template, _ := MakeFormTemplate(gbl, "some-file-name", paperworkforms.Form1203Layout, services.GBL)
 	file, err := formCreator.CreateForm(template)
 
-	suite.NotNil(suite.T(), err)
-	suite.Nil(suite.T(), file)
+	suite.NotNil(err)
+	suite.Nil(file)
 	serviceErrMsg := errors.Cause(err)
-	suite.Equal(suite.T(), "Error for FormFiller.AppendPage()", serviceErrMsg.Error(), "should be equal")
-	suite.Equal(suite.T(), "Failure writing GBL data to form.: Error for FormFiller.AppendPage()", err.Error(), "should be equal")
+	suite.Equal("Error for FormFiller.AppendPage()", serviceErrMsg.Error())
+	suite.Equal("Failure writing GBL data to form.: Error for FormFiller.AppendPage()", err.Error())
 	FormFiller.AssertExpectations(suite.T())
 }
 
@@ -124,11 +124,11 @@ func (suite *CreateFormSuite) TestCreateFormServiceFileStorerCreateFailure() {
 	template, _ := MakeFormTemplate(gbl, "some-file-name", paperworkforms.Form1203Layout, services.GBL)
 	file, err := formCreator.CreateForm(template)
 
-	suite.Nil(suite.T(), file)
-	suite.NotNil(suite.T(), err)
+	suite.Nil(file)
+	suite.NotNil(err)
 	serviceErrMsg := errors.Cause(err)
-	suite.Equal(suite.T(), "Error for FileStorer.Create()", serviceErrMsg.Error(), "should be equal")
-	suite.Equal(suite.T(), "Error creating a new afero file for GBL form.: Error for FileStorer.Create()", err.Error(), "should be equal")
+	suite.Equal("Error for FileStorer.Create()", serviceErrMsg.Error())
+	suite.Equal("Error creating a new afero file for GBL form.: Error for FileStorer.Create()", err.Error())
 	FormFiller.AssertExpectations(suite.T())
 }
 
@@ -159,18 +159,18 @@ func (suite *CreateFormSuite) TestCreateFormServiceFormFillerOutputFailure() {
 	template, _ := MakeFormTemplate(gbl, "some-file-name", paperworkforms.Form1203Layout, services.GBL)
 	file, err := formCreator.CreateForm(template)
 
-	suite.Nil(suite.T(), file)
-	suite.NotNil(suite.T(), err)
+	suite.Nil(file)
+	suite.NotNil(err)
 	serviceErrMsg := errors.Cause(err)
-	suite.Equal(suite.T(), "Error for FormFiller.Output()", serviceErrMsg.Error(), "should be equal")
-	suite.Equal(suite.T(), "Failure exporting GBL form to file.: Error for FormFiller.Output()", err.Error(), "should be equal")
+	suite.Equal("Error for FormFiller.Output()", serviceErrMsg.Error())
+	suite.Equal("Failure exporting GBL form to file.: Error for FormFiller.Output()", err.Error())
 	FormFiller.AssertExpectations(suite.T())
 }
 
 func (suite *CreateFormSuite) TestCreateFormServiceCreateAssetByteReaderFailure() {
 	badAssetPath := "pkg/paperwork/formtemplates/someUndefinedTemplatePath.png"
 	templateBuffer, err := createAssetByteReader(badAssetPath)
-	suite.Nil(suite.T(), templateBuffer)
-	suite.NotNil(suite.T(), err)
-	suite.Equal(suite.T(), "Error creating asset from path. Check image path.: Asset pkg/paperwork/formtemplates/someUndefinedTemplatePath.png not found", err.Error(), "should be equal")
+	suite.Nil(templateBuffer)
+	suite.NotNil(err)
+	suite.Equal("Error creating asset from path. Check image path.: Asset pkg/paperwork/formtemplates/someUndefinedTemplatePath.png not found", err.Error())
 }


### PR DESCRIPTION
## Description

Addresses @mikena-truss's [PR requests](https://github.com/transcom/mymove/pull/1679) on CreateForm Service Object.

## Reviewer Notes

Inline notes. 

Additionally, this code introduces a new directory `/mocks`. This directory is where all generated mocks go for testing purposes. In order to generate mocks you must use the mockery cli tool to do so. `$GOPATH/bin/mockery -name <nameOfInterface> -dir /Users/chriscoles/Development/go/src/github.com/transcom/mymove/<dirInterfaceIsLocated>`

## Setup

**_Ensure Functionality is Still Working_**
1. Ensure dev DB is set up properly, with all tables migrated. `make db_dev_reset && make_db_dev_migrate`
2. Populate dev DB with test data. `make_db_dev_e2e_populate`
3. Run API `make server_run`
4. Run TSP Client `make tsp_client_run`
5. Log in to TSP client and click the **Approved Shipments Queue**
6. Choose the move with GBL _#LKNQ7000001_ and Customer Name, _ReadyForGBL, HHG_ and go to the [move details page](http://tsplocal:3000/shipments/192ced4a-ad29-4cbc-b5fa-4ee38c6de586).
7. Click `Generate the GBL` call to action button and GBL will be generated.
8. Click `View GBL` call to action button to view the generated GBL.

**_Run Paperwork Service Tests_**
`go test ./pkg/service/paperwork -v`

## Code Review Verification Steps

 * [x] Have been communicated to #dp3-engineering
* [x] There are no aXe warnings for UI.
* [x] This works in IE.
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/163032722) 
* [Google Doc](https://docs.google.com/document/d/1xlqgVSTf9JUhZfWR18rvzaGPg2iHcF7uKRahGvrO45E/edit#heading=h.mi78nqcd6ivx) that outlines contet 

## Screenshots

![screen shot 2019-01-30 at 2 54 55 pm](https://user-images.githubusercontent.com/7574207/52008650-13acc300-249f-11e9-8664-218a0ea08f95.png)

