### PR TITLE
Support Editing Pre-Approval Robust Accessorial 105B/E #162846573

### DIFF
--- a/pkg/handlers/publicapi/shipment_line_items.go
+++ b/pkg/handlers/publicapi/shipment_line_items.go
@@ -235,29 +235,51 @@ func (h UpdateShipmentLineItemHandler) Handle(params accessorialop.UpdateShipmen
 
 	tariff400ngItemID := uuid.Must(uuid.FromString(params.Payload.Tariff400ngItemID.String()))
 	tariff400ngItem, err := models.FetchTariff400ngItem(h.DB(), tariff400ngItemID)
+	shipment := shipmentLineItem.Shipment
 
 	if !tariff400ngItem.RequiresPreApproval {
 		return accessorialop.NewUpdateShipmentLineItemForbidden()
 	}
 
-	// update
-	shipmentLineItem.Tariff400ngItemID = tariff400ngItemID
-	shipmentLineItem.Quantity1 = unit.BaseQuantity(*params.Payload.Quantity1)
-	if params.Payload.Quantity2 != nil {
-		shipmentLineItem.Quantity2 = unit.BaseQuantity(*params.Payload.Quantity2)
+	baseParams := models.BaseShipmentLineItemParams{
+		Tariff400ngItemID:   tariff400ngItemID,
+		Tariff400ngItemCode: tariff400ngItem.Code,
+		Quantity1:           unit.IntToBaseQuantity(params.Payload.Quantity1),
+		Quantity2:           unit.IntToBaseQuantity(params.Payload.Quantity2),
+		Location:            string(params.Payload.Location),
+		Notes:               handlers.FmtString(params.Payload.Notes),
+		Description:         params.Payload.Description,
 	}
-	shipmentLineItem.Location = models.ShipmentLineItemLocation(params.Payload.Location)
-	shipmentLineItem.Notes = params.Payload.Notes
 
-	verrs, err := h.DB().ValidateAndUpdate(&shipmentLineItem)
+	var itemDimensions, crateDimensions *models.AdditionalLineItemDimensions
+	if params.Payload.ItemDimensions != nil {
+		itemDimensions = &models.AdditionalLineItemDimensions{
+			Length: unit.ThousandthInches(*params.Payload.ItemDimensions.Length),
+			Width:  unit.ThousandthInches(*params.Payload.ItemDimensions.Width),
+			Height: unit.ThousandthInches(*params.Payload.ItemDimensions.Height),
+		}
+	}
+	if params.Payload.CrateDimensions != nil {
+		crateDimensions = &models.AdditionalLineItemDimensions{
+			Length: unit.ThousandthInches(*params.Payload.CrateDimensions.Length),
+			Width:  unit.ThousandthInches(*params.Payload.CrateDimensions.Width),
+			Height: unit.ThousandthInches(*params.Payload.CrateDimensions.Height),
+		}
+	}
+
+	additionalParams := models.AdditionalShipmentLineItemParams{
+		ItemDimensions:  itemDimensions,
+		CrateDimensions: crateDimensions,
+	}
+
+	verrs, err := shipment.UpdateShipmentLineItem(h.DB(),
+		baseParams,
+		additionalParams,
+		&shipmentLineItem,
+	)
 	if verrs.HasAny() || err != nil {
-		h.Logger().Error("Error updating shipment line item for shipment", zap.Error(err))
-		return handlers.ResponseForError(h.Logger(), err)
-	}
-
-	err = h.DB().Load(&shipmentLineItem)
-	if err != nil {
-		return handlers.ResponseForError(h.Logger(), err)
+		h.Logger().Error("Error fetching shipment line items for shipment", zap.Error(err))
+		return handlers.ResponseForVErrors(h.Logger(), verrs, err)
 	}
 
 	payload := payloadForShipmentLineItemModel(&shipmentLineItem)

--- a/pkg/models/shipment.go
+++ b/pkg/models/shipment.go
@@ -477,6 +477,7 @@ func (s *Shipment) UpdateShipmentLineItem(db *pop.Connection, baseParams BaseShi
 		if baseParams.Notes != nil {
 			shipmentLineItem.Notes = *baseParams.Notes
 		}
+		shipmentLineItem.Description = baseParams.Description
 
 		verrs, err = connection.ValidateAndUpdate(shipmentLineItem)
 		if verrs.HasAny() || err != nil {

--- a/pkg/models/shipment.go
+++ b/pkg/models/shipment.go
@@ -599,7 +599,7 @@ func UpdateShipmentLineItemDimensions(db *pop.Connection, baseParams *BaseShipme
 	return responseVErrors, responseError
 }
 
-// UpsertItemCodeDependency applies specific validation and creates or updates additional objects/fields for item codes
+// UpsertItemCodeDependency applies specific validation, creates or updates additional objects/fields for item codes
 func UpsertItemCodeDependency(db *pop.Connection, baseParams *BaseShipmentLineItemParams, additionalParams *AdditionalShipmentLineItemParams, shipmentLineItem *ShipmentLineItem) (*validate.Errors, error) {
 	var responseError error
 	responseVErrors := validate.NewErrors()

--- a/pkg/models/shipment.go
+++ b/pkg/models/shipment.go
@@ -603,9 +603,10 @@ func UpdateShipmentLineItemDimensions(db *pop.Connection, baseParams *BaseShipme
 func CreateOrUpdateItemCodeDependency(db *pop.Connection, baseParams *BaseShipmentLineItemParams, additionalParams *AdditionalShipmentLineItemParams, shipmentLineItem *ShipmentLineItem) (*validate.Errors, error) {
 	var responseError error
 	responseVErrors := validate.NewErrors()
+	hasDimension := additionalParams.ItemDimensions != nil || additionalParams.CrateDimensions != nil
 
 	// Backwards compatible with "Old school" 105B/E
-	if (baseParams.Tariff400ngItemCode == "105B" || baseParams.Tariff400ngItemCode == "105E") && baseParams.Quantity1 == nil {
+	if (baseParams.Tariff400ngItemCode == "105B" || baseParams.Tariff400ngItemCode == "105E") && hasDimension {
 		//Additional validation check if item and crate dimensions exist
 		if additionalParams.ItemDimensions == nil || additionalParams.CrateDimensions == nil {
 			responseError = errors.New("Must have both item and crate dimensions params for tariff400ngItemCode: " + baseParams.Tariff400ngItemCode)

--- a/pkg/models/shipment.go
+++ b/pkg/models/shipment.go
@@ -447,7 +447,7 @@ func (s *Shipment) CreateShipmentLineItem(db *pop.Connection, baseParams BaseShi
 	db.Transaction(func(connection *pop.Connection) error {
 		transactionError := errors.New("Rollback the transaction")
 
-		verrs, err := CreateOrUpdateItemCodeDependency(connection, &baseParams, &additionalParams, &shipmentLineItem)
+		verrs, err := UpsertItemCodeDependency(connection, &baseParams, &additionalParams, &shipmentLineItem)
 		if verrs.HasAny() || err != nil {
 			responseVErrors.Append(verrs)
 			responseError = errors.Wrap(err, "Error setting up item code dependency: "+baseParams.Tariff400ngItemCode)
@@ -493,7 +493,7 @@ func (s *Shipment) UpdateShipmentLineItem(db *pop.Connection, baseParams BaseShi
 	db.Transaction(func(connection *pop.Connection) error {
 		transactionError := errors.New("Rollback the transaction")
 
-		verrs, err := CreateOrUpdateItemCodeDependency(connection, &baseParams, &additionalParams, shipmentLineItem)
+		verrs, err := UpsertItemCodeDependency(connection, &baseParams, &additionalParams, shipmentLineItem)
 		if verrs.HasAny() || err != nil {
 			responseVErrors.Append(verrs)
 			responseError = errors.Wrap(err, "Error setting up item code dependency: "+baseParams.Tariff400ngItemCode)
@@ -599,8 +599,8 @@ func UpdateShipmentLineItemDimensions(db *pop.Connection, baseParams *BaseShipme
 	return responseVErrors, responseError
 }
 
-// CreateOrUpdateItemCodeDependency applies specific validation and creates or updates additional objects for item codes
-func CreateOrUpdateItemCodeDependency(db *pop.Connection, baseParams *BaseShipmentLineItemParams, additionalParams *AdditionalShipmentLineItemParams, shipmentLineItem *ShipmentLineItem) (*validate.Errors, error) {
+// UpsertItemCodeDependency applies specific validation and creates or updates additional objects/fields for item codes
+func UpsertItemCodeDependency(db *pop.Connection, baseParams *BaseShipmentLineItemParams, additionalParams *AdditionalShipmentLineItemParams, shipmentLineItem *ShipmentLineItem) (*validate.Errors, error) {
 	var responseError error
 	responseVErrors := validate.NewErrors()
 	hasDimension := additionalParams.ItemDimensions != nil || additionalParams.CrateDimensions != nil

--- a/pkg/models/shipment.go
+++ b/pkg/models/shipment.go
@@ -414,10 +414,10 @@ func (s *Shipment) CreateShipmentLineItem(db *pop.Connection, baseParams BaseShi
 	db.Transaction(func(connection *pop.Connection) error {
 		transactionError := errors.New("Rollback the transaction")
 
-		verrs, err := SetupAndCreateItemCodePrequiste(connection, &baseParams, &additionalParams, &shipmentLineItem)
+		verrs, err := CreateOrUpdateItemCodeDependency(connection, &baseParams, &additionalParams, &shipmentLineItem)
 		if verrs.HasAny() || err != nil {
 			responseVErrors.Append(verrs)
-			responseError = errors.Wrap(err, "Error setting up item code prequiste: "+baseParams.Tariff400ngItemCode)
+			responseError = errors.Wrap(err, "Error setting up item code dependency: "+baseParams.Tariff400ngItemCode)
 			return transactionError
 		}
 
@@ -452,8 +452,121 @@ func (s *Shipment) CreateShipmentLineItem(db *pop.Connection, baseParams BaseShi
 	return &shipmentLineItem, responseVErrors, responseError
 }
 
-// SetupAndCreateItemCodePrequiste applies specific validation and creates additional objects for item codes
-func SetupAndCreateItemCodePrequiste(db *pop.Connection, baseParams *BaseShipmentLineItemParams, additionalParams *AdditionalShipmentLineItemParams, shipmentLineItem *ShipmentLineItem) (*validate.Errors, error) {
+// UpdateShipmentLineItem updates a ShipmentLineItem tied to the Shipment
+func (s *Shipment) UpdateShipmentLineItem(db *pop.Connection, baseParams BaseShipmentLineItemParams, additionalParams AdditionalShipmentLineItemParams, shipmentLineItem *ShipmentLineItem) (*validate.Errors, error) {
+	var responseError error
+	responseVErrors := validate.NewErrors()
+
+	db.Transaction(func(connection *pop.Connection) error {
+		transactionError := errors.New("Rollback the transaction")
+
+		verrs, err := CreateOrUpdateItemCodeDependency(connection, &baseParams, &additionalParams, shipmentLineItem)
+		if verrs.HasAny() || err != nil {
+			responseVErrors.Append(verrs)
+			responseError = errors.Wrap(err, "Error setting up item code dependency: "+baseParams.Tariff400ngItemCode)
+			return transactionError
+		}
+
+		// Non-specified item code
+		shipmentLineItem.Tariff400ngItemID = baseParams.Tariff400ngItemID
+		shipmentLineItem.Quantity1 = unit.BaseQuantity(*baseParams.Quantity1)
+		if baseParams.Quantity2 != nil {
+			shipmentLineItem.Quantity2 = unit.BaseQuantity(*baseParams.Quantity2)
+		}
+		shipmentLineItem.Location = ShipmentLineItemLocation(baseParams.Location)
+		if baseParams.Notes != nil {
+			shipmentLineItem.Notes = *baseParams.Notes
+		}
+
+		verrs, err = connection.ValidateAndUpdate(shipmentLineItem)
+		if verrs.HasAny() || err != nil {
+			responseVErrors.Append(verrs)
+			responseError = errors.Wrap(err, "Error updating shipment line item")
+			return transactionError
+		}
+
+		// Loads line item information
+		err = connection.Load(shipmentLineItem)
+		if err != nil {
+			responseError = errors.Wrap(err, "Error loading shipment line item")
+			return transactionError
+		}
+
+		return nil
+	})
+
+	return responseVErrors, responseError
+}
+
+// CreateShipmentLineItemDimensions creates new item and crate dimensions for shipment line item
+func CreateShipmentLineItemDimensions(db *pop.Connection, baseParams *BaseShipmentLineItemParams, additionalParams *AdditionalShipmentLineItemParams, shipmentLineItem *ShipmentLineItem) (*validate.Errors, error) {
+	var responseError error
+	responseVErrors := validate.NewErrors()
+
+	// save dimensions to shipmentLineItem
+	shipmentLineItem.ItemDimensions = ShipmentLineItemDimensions{
+		Length: unit.ThousandthInches(additionalParams.ItemDimensions.Length),
+		Width:  unit.ThousandthInches(additionalParams.ItemDimensions.Width),
+		Height: unit.ThousandthInches(additionalParams.ItemDimensions.Height),
+	}
+	verrs, err := db.ValidateAndCreate(&shipmentLineItem.ItemDimensions)
+	if verrs.HasAny() || err != nil {
+		responseVErrors.Append(verrs)
+		responseError = errors.Wrap(err, "Error creating item dimensions for shipment line item")
+		return responseVErrors, responseError
+	}
+
+	shipmentLineItem.CrateDimensions = ShipmentLineItemDimensions{
+		Length: unit.ThousandthInches(additionalParams.CrateDimensions.Length),
+		Width:  unit.ThousandthInches(additionalParams.CrateDimensions.Width),
+		Height: unit.ThousandthInches(additionalParams.CrateDimensions.Height),
+	}
+	verrs, err = db.ValidateAndCreate(&shipmentLineItem.CrateDimensions)
+	if verrs.HasAny() || err != nil {
+		responseVErrors.Append(verrs)
+		responseError = errors.Wrap(err, "Error creating crate dimensions for shipment line item")
+		return responseVErrors, responseError
+	}
+
+	shipmentLineItem.ItemDimensionsID = &shipmentLineItem.ItemDimensions.ID
+	shipmentLineItem.CrateDimensionsID = &shipmentLineItem.CrateDimensions.ID
+
+	return responseVErrors, responseError
+}
+
+// UpdateShipmentLineItemDimensions updates existing shipment line item dimensions
+func UpdateShipmentLineItemDimensions(db *pop.Connection, baseParams *BaseShipmentLineItemParams, additionalParams *AdditionalShipmentLineItemParams, shipmentLineItem *ShipmentLineItem) (*validate.Errors, error) {
+	var responseError error
+	responseVErrors := validate.NewErrors()
+
+	// save dimensions to shipmentLineItem
+	shipmentLineItem.ItemDimensions.Length = unit.ThousandthInches(additionalParams.ItemDimensions.Length)
+	shipmentLineItem.ItemDimensions.Width = unit.ThousandthInches(additionalParams.ItemDimensions.Width)
+	shipmentLineItem.ItemDimensions.Height = unit.ThousandthInches(additionalParams.ItemDimensions.Height)
+
+	verrs, err := db.ValidateAndUpdate(&shipmentLineItem.ItemDimensions)
+	if verrs.HasAny() || err != nil {
+		responseVErrors.Append(verrs)
+		responseError = errors.Wrap(err, "Error updating item dimensions for shipment line item")
+		return responseVErrors, responseError
+	}
+
+	shipmentLineItem.CrateDimensions.Length = unit.ThousandthInches(additionalParams.CrateDimensions.Length)
+	shipmentLineItem.CrateDimensions.Width = unit.ThousandthInches(additionalParams.CrateDimensions.Width)
+	shipmentLineItem.CrateDimensions.Height = unit.ThousandthInches(additionalParams.CrateDimensions.Height)
+
+	verrs, err = db.ValidateAndUpdate(&shipmentLineItem.CrateDimensions)
+	if verrs.HasAny() || err != nil {
+		responseVErrors.Append(verrs)
+		responseError = errors.Wrap(err, "Error updating crate dimensions for shipment line item")
+		return responseVErrors, responseError
+	}
+
+	return responseVErrors, responseError
+}
+
+// CreateOrUpdateItemCodeDependency applies specific validation and creates or updates additional objects for item codes
+func CreateOrUpdateItemCodeDependency(db *pop.Connection, baseParams *BaseShipmentLineItemParams, additionalParams *AdditionalShipmentLineItemParams, shipmentLineItem *ShipmentLineItem) (*validate.Errors, error) {
 	var responseError error
 	responseVErrors := validate.NewErrors()
 
@@ -465,33 +578,21 @@ func SetupAndCreateItemCodePrequiste(db *pop.Connection, baseParams *BaseShipmen
 			return responseVErrors, responseError
 		}
 
-		// save dimensions to shipmentLineItem
-		shipmentLineItem.ItemDimensions = ShipmentLineItemDimensions{
-			Length: unit.ThousandthInches(additionalParams.ItemDimensions.Length),
-			Width:  unit.ThousandthInches(additionalParams.ItemDimensions.Width),
-			Height: unit.ThousandthInches(additionalParams.ItemDimensions.Height),
+		if shipmentLineItem.ItemDimensions.ID == uuid.Nil || shipmentLineItem.CrateDimensions.ID == uuid.Nil {
+			verrs, err := CreateShipmentLineItemDimensions(db, baseParams, additionalParams, shipmentLineItem)
+			if verrs.HasAny() || err != nil {
+				responseVErrors.Append(verrs)
+				responseError = errors.Wrap(err, "Error creating shipment line item dimensions")
+				return responseVErrors, responseError
+			}
+		} else {
+			verrs, err := UpdateShipmentLineItemDimensions(db, baseParams, additionalParams, shipmentLineItem)
+			if verrs.HasAny() || err != nil {
+				responseVErrors.Append(verrs)
+				responseError = errors.Wrap(err, "Error updating shipment line item dimensions")
+				return responseVErrors, responseError
+			}
 		}
-		verrs, err := db.ValidateAndCreate(&shipmentLineItem.ItemDimensions)
-		if verrs.HasAny() || err != nil {
-			responseVErrors.Append(verrs)
-			responseError = errors.Wrap(err, "Error creating item dimensions for shipment line item")
-			return responseVErrors, responseError
-		}
-
-		shipmentLineItem.CrateDimensions = ShipmentLineItemDimensions{
-			Length: unit.ThousandthInches(additionalParams.CrateDimensions.Length),
-			Width:  unit.ThousandthInches(additionalParams.CrateDimensions.Width),
-			Height: unit.ThousandthInches(additionalParams.CrateDimensions.Height),
-		}
-		verrs, err = db.ValidateAndCreate(&shipmentLineItem.CrateDimensions)
-		if verrs.HasAny() || err != nil {
-			responseVErrors.Append(verrs)
-			responseError = errors.Wrap(err, "Error creating crate dimensions for shipment line item")
-			return responseVErrors, responseError
-		}
-
-		shipmentLineItem.ItemDimensionsID = &shipmentLineItem.ItemDimensions.ID
-		shipmentLineItem.CrateDimensionsID = &shipmentLineItem.CrateDimensions.ID
 
 		// ToDo: For another story
 		/*

--- a/pkg/models/shipment_test.go
+++ b/pkg/models/shipment_test.go
@@ -246,7 +246,7 @@ func (suite *ModelSuite) TestShipmentAssignGBLNumber() {
 	}
 }
 
-// TestShipmentAssignGBLNumber tests that a GBL number is created correctly
+// TestCreateShipmentLineItem tests that a shipment line item is created correctly
 func (suite *ModelSuite) TestCreateShipmentLineItem() {
 	acc := testdatagen.MakeDefaultTariff400ngItem(suite.DB())
 	shipment := testdatagen.MakeDefaultShipment(suite.DB())
@@ -344,7 +344,7 @@ func (suite *ModelSuite) TestCreateShipmentLineItemCode105BAndE() {
 	}
 }
 
-// TestCreateShipmentLineItemCode105BAndE tests that 105B/E line items are updated correctly
+// TestUpdateShipmentLineItem tests that line items are updated correctly
 func (suite *ModelSuite) TestUpdateShipmentLineItem() {
 	shipment := testdatagen.MakeDefaultShipment(suite.DB())
 	notes := "It's a giant moose head named Fred he seemed rather pleasant"
@@ -386,7 +386,7 @@ func (suite *ModelSuite) TestUpdateShipmentLineItem() {
 	}
 }
 
-// TestCreateShipmentLineItemCode105BAndE tests that 105B/E line items are updated correctly
+// TestUpdateShipmentLineItemCode105BAndE tests that 105B/E line items are updated correctly
 func (suite *ModelSuite) TestUpdateShipmentLineItemCode105BAndE() {
 	acc105B := testdatagen.MakeTariff400ngItem(suite.DB(), testdatagen.Assertions{
 		Tariff400ngItem: Tariff400ngItem{
@@ -479,7 +479,7 @@ func (suite *ModelSuite) TestUpdateShipmentLineItemCode105BAndE() {
 	}
 }
 
-// TestShipmentAssignGBLNumber tests that a GBL number is created correctly
+// TestCreateShipmentLineItemCode105BAndEMissingDimensions tests that missing dimensions for 105B/E throws error
 func (suite *ModelSuite) TestCreateShipmentLineItemCode105BAndEMissingDimensions() {
 	acc105B := testdatagen.MakeTariff400ngItem(suite.DB(), testdatagen.Assertions{
 		Tariff400ngItem: Tariff400ngItem{

--- a/pkg/testdatagen/make_shipment_line_item_dimensions.go
+++ b/pkg/testdatagen/make_shipment_line_item_dimensions.go
@@ -1,0 +1,28 @@
+package testdatagen
+
+import (
+	"github.com/gobuffalo/pop"
+	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/unit"
+)
+
+// MakeShipmentLineItemDimensions creates a ShipmentLineItemDimensions record
+func MakeShipmentLineItemDimensions(db *pop.Connection, assertions Assertions) models.ShipmentLineItemDimensions {
+	dimensions := models.ShipmentLineItemDimensions{
+		Length: unit.ThousandthInches(1000),
+		Width:  unit.ThousandthInches(1000),
+		Height: unit.ThousandthInches(1000),
+	}
+
+	// Overwrite values with those from assertions
+	mergeModels(&dimensions, assertions.ShipmentLineItemDimensions)
+
+	mustCreate(db, &dimensions)
+
+	return dimensions
+}
+
+// MakeDefaultShipmentLineItemDimensions makes a ShipmentLineItemDimensions with default values
+func MakeDefaultShipmentLineItemDimensions(db *pop.Connection) models.ShipmentLineItemDimensions {
+	return MakeShipmentLineItemDimensions(db, Assertions{})
+}

--- a/pkg/testdatagen/shared.go
+++ b/pkg/testdatagen/shared.go
@@ -39,6 +39,7 @@ type Assertions struct {
 	ServiceMember                            models.ServiceMember
 	Shipment                                 models.Shipment
 	ShipmentLineItem                         models.ShipmentLineItem
+	ShipmentLineItemDimensions               models.ShipmentLineItemDimensions
 	ShipmentOffer                            models.ShipmentOffer
 	StorageInTransit                         models.StorageInTransit
 	Tariff400ngServiceArea                   models.Tariff400ngServiceArea

--- a/src/shared/PreApprovalRequest/Editor.jsx
+++ b/src/shared/PreApprovalRequest/Editor.jsx
@@ -31,6 +31,7 @@ export class Editor extends Component {
   render() {
     let initialValues = cloneDeep(this.props.shipmentLineItem);
 
+    // Leaving quantity_2 alone in the swagger definition until we know for sure we won't use
     // Delete quantities so we don't unnecessarily send them back
     delete initialValues.quantity_2;
     if (!initialValues.quantity_1 || initialValues.quantity_1 <= 0) {

--- a/src/shared/PreApprovalRequest/Editor.jsx
+++ b/src/shared/PreApprovalRequest/Editor.jsx
@@ -2,7 +2,12 @@ import { cloneDeep } from 'lodash';
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import PreApprovalForm, { formName as PreApprovalFormName } from 'shared/PreApprovalRequest/PreApprovalForm.jsx';
-import { formatToBaseQuantity, convertFromBaseQuantity } from 'shared/formatters';
+import {
+  formatToBaseQuantity,
+  convertFromBaseQuantity,
+  formatToDimensionsInches,
+  formatDimensionsToThousandthInches,
+} from 'shared/formatters';
 import { submit, isValid, isDirty, isSubmitting, hasSubmitSucceeded } from 'redux-form';
 
 import { connect } from 'react-redux';
@@ -17,11 +22,26 @@ export class Editor extends Component {
       values.quantity_1 = formatToBaseQuantity(values.quantity_1);
     }
     values.tariff400ng_item_id = values.tariff400ng_item.id;
+
+    formatDimensionsToThousandthInches(values.item_dimensions);
+    formatDimensionsToThousandthInches(values.crate_dimensions);
+
     this.props.saveEdit(this.props.shipmentLineItem.id, values);
   };
   render() {
     let initialValues = cloneDeep(this.props.shipmentLineItem);
-    initialValues.quantity_1 = convertFromBaseQuantity(initialValues.quantity_1);
+
+    // Delete quantities so we don't unnecessarily send them back
+    delete initialValues.quantity_2;
+    if (!initialValues.quantity_1 || initialValues.quantity_1 <= 0) {
+      delete initialValues.quantity_1;
+    } else {
+      initialValues.quantity_1 = convertFromBaseQuantity(initialValues.quantity_1);
+    }
+
+    initialValues.item_dimensions = formatToDimensionsInches(initialValues.item_dimensions);
+    initialValues.crate_dimensions = formatToDimensionsInches(initialValues.crate_dimensions);
+
     return (
       <div className="pre-approval-panel-modal pre-approval-edit">
         <div className="title">Edit request</div>


### PR DESCRIPTION
## Description

This PR adds the ability to edit more robust accessorial 105B/E items in pre-approvals. The dimension units are converted from ThousandthInches to Inches (1000 => 1.00) on the UI. 

## Reviewer Notes

See comments in the code.

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](./docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](./docs/backend.md#querying-the-database-safely)
 have been satisfied.
* [ ] There are no aXe warnings for UI.
* [ ] This works in IE.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/162846573) for this change

## Screenshots

![feb-13-2019 16-29-33](https://user-images.githubusercontent.com/1522549/52753715-a45dc580-2fac-11e9-9e86-878c2cd15745.gif)
