### PR TITLE
fixes the compiler error in wallabyjs run step

### DIFF
--- a/wallaby.js
+++ b/wallaby.js
@@ -23,7 +23,6 @@ module.exports = function(wallaby) {
 
     compilers: {
       '**/*.js?(x)': wallaby.compilers.babel({
-        babel: require('babel-core'),
         presets: ['react-app'],
       }),
     },


### PR DESCRIPTION
## Description

Wallabyjs suddenly started failing to compile the es6 code and the console would warn about invalid values and compiler step failure.

![image](https://user-images.githubusercontent.com/5003421/52762678-9dec3f80-2fe6-11e9-9097-07828c2f5415.png)

## Reviewer Notes

Try running wallaby.js, you should see this in wallaby console:
![image](https://user-images.githubusercontent.com/5003421/52762774-f4f21480-2fe6-11e9-8dcf-855c2c269150.png)

