### PR TITLE
Adds ZIP logging on HERE API failure

### DIFF
--- a/pkg/route/here_planner.go
+++ b/pkg/route/here_planner.go
@@ -164,7 +164,12 @@ func (p *herePlanner) LatLongTransitDistance(source LatLong, dest LatLong) (int,
 }
 
 func (p *herePlanner) Zip5TransitDistance(source string, destination string) (int, error) {
-	return zip5TransitDistanceHelper(p, source, destination)
+	distanceMiles, err := zip5TransitDistanceHelper(p, source, destination)
+	if err != nil {
+		p.logger.Info("Failed to calculate HERE route between ZIPs", zap.String("source", source), zap.String("destination", destination))
+	}
+
+	return distanceMiles, err
 }
 
 func (p *herePlanner) TransitDistance(source *models.Address, destination *models.Address) (int, error) {

--- a/pkg/route/here_planner.go
+++ b/pkg/route/here_planner.go
@@ -166,7 +166,7 @@ func (p *herePlanner) LatLongTransitDistance(source LatLong, dest LatLong) (int,
 func (p *herePlanner) Zip5TransitDistance(source string, destination string) (int, error) {
 	distanceMiles, err := zip5TransitDistanceHelper(p, source, destination)
 	if err != nil {
-		p.logger.Info("Failed to calculate HERE route between ZIPs", zap.String("source", source), zap.String("destination", destination))
+		p.logger.Error("Failed to calculate HERE route between ZIPs", zap.String("source", source), zap.String("destination", destination))
 	}
 
 	return distanceMiles, err


### PR DESCRIPTION
## Description

When we get non-200 responses from HERE we currently have no insight into whether the inputs are bad or if something actually broke. This logs the high level inputs (ZIPs, not lat/long that we use later).