### PR TITLE
Generate GBL notification only shows once

### DIFF
--- a/cypress/integration/tsp/generateGBL.js
+++ b/cypress/integration/tsp/generateGBL.js
@@ -90,6 +90,15 @@ function tspUserGeneratesGBL() {
     .should('not.exist');
 
   cy.get('.documents').should('contain', 'Government Bill Of Lading');
+
+  cy.patientVisit('/queues/approved');
+  cy.location().should(loc => {
+    expect(loc.pathname).to.match(/^\/queues\/approved/);
+  });
+
+  cy.selectQueueItemMoveLocator('GBLGBL');
+
+  cy.get('.usa-alert-success').should('not.exist');
 }
 
 function tspUserViewsGBL() {

--- a/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
+++ b/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
@@ -61,7 +61,7 @@ import InvoicePanel from 'shared/Invoice/InvoicePanel.jsx';
 import PickupForm from './PickupForm';
 import PremoveSurveyForm from './PremoveSurveyForm';
 import ServiceAgentForm from './ServiceAgentForm';
-import { getLastRequestIsSuccess, getLastRequestIsLoading } from 'shared/Swagger/selectors';
+import { getLastRequestIsLoading } from 'shared/Swagger/selectors';
 
 import './tsp.css';
 
@@ -127,6 +127,7 @@ class ShipmentInfo extends Component {
   state = {
     redirectToHome: false,
     editTspServiceAgent: false,
+    showGblCreatedNotification: false,
   };
 
   componentDidMount() {
@@ -150,7 +151,9 @@ class ShipmentInfo extends Component {
   };
 
   generateGBL = () => {
-    return this.props.generateGBL(generateGblLabel, this.props.shipment.id);
+    return this.props
+      .generateGBL(generateGblLabel, this.props.shipment.id)
+      .then(() => this.setState({ showGblCreatedNotification: true }));
   };
 
   enterPreMoveSurvey = values => {
@@ -180,11 +183,11 @@ class ShipmentInfo extends Component {
   };
 
   render() {
+    const { showGblCreatedNotification } = this.state;
     const {
       context,
       shipment,
       shipmentDocuments,
-      generateGBLSuccess,
       generateGBLError,
       generateGBLInProgress,
       serviceAgents,
@@ -343,7 +346,7 @@ class ShipmentInfo extends Component {
                 </p>
               )}
 
-              {generateGBLSuccess && (
+              {showGblCreatedNotification && (
                 <Alert type="success" heading="GBL has been created">
                   <span className="usa-grid usa-alert-no-padding">
                     <span className="usa-width-two-thirds">Click the button to view, print, or download the GBL.</span>
@@ -475,7 +478,6 @@ const mapStateToProps = state => {
     loadTspDependenciesHasError: get(state, 'tsp.loadTspDependenciesHasError'),
     acceptError: get(state, 'tsp.shipmentHasAcceptError'),
     generateGBLError: get(state, 'tsp.generateGBLError'),
-    generateGBLSuccess: getLastRequestIsSuccess(state, generateGblLabel),
     generateGBLInProgress: getLastRequestIsLoading(state, generateGblLabel),
     gblDocUrl: `/shipments/${shipment.id}/documents/${get(gbl, 'id')}`,
     error: get(state, 'tsp.error'),

--- a/src/shared/Swagger/request.js
+++ b/src/shared/Swagger/request.js
@@ -155,3 +155,9 @@ export function swaggerRequest(getClient, operationPath, params, options = {}) {
 function normalizePayload(body, schema) {
   return normalize(body, schema);
 }
+
+export function resetRequests() {
+  return {
+    type: '@@swagger/RESET',
+  };
+}

--- a/src/shared/Swagger/requestsReducer.js
+++ b/src/shared/Swagger/requestsReducer.js
@@ -42,6 +42,7 @@ export function requestsReducer(state = initialState, action) {
       case 'RESET':
         return Object.assign({}, state, {
           lastErrors: omit(state.lastErrors, [action.label]),
+          byID: {},
         });
       default:
         return state;


### PR DESCRIPTION
## Description

For the TSP app, only show the `GBL created` notification once after creation. Also does not show the notification on other moves

## Setup
`make db_dev_e2e_populate`
`make server_run`
`make tsp_client_run`
Go to `Approved` queue
Go to move with locator `GBLGBL`
Generate GBL
Leave move
View another move

## Code Review Verification Steps
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/163470475) for this change
