### PR TITLE
Office PPM Weights panel

### DIFF
--- a/cypress/integration/office/officeUserPPM.js
+++ b/cypress/integration/office/officeUserPPM.js
@@ -54,7 +54,47 @@ describe('office user finds the move', function() {
       expect(text).to.include('20-Nov-18');
     });
   });
+
+  it('office user edits ppm net weight', function() {
+    officeUserEditsNetWeight();
+  });
 });
+
+function officeUserEditsNetWeight() {
+  cy.patientVisit('/queues/ppm');
+
+  cy.location().should(loc => {
+    expect(loc.pathname).to.match(/^\/queues\/ppm/);
+  });
+
+  cy.selectQueueItemMoveLocator('VGHEIS');
+
+  cy.location().should(loc => {
+    expect(loc.pathname).to.match(/^\/queues\/new\/moves\/[^/]+\/basics/);
+  });
+
+  cy
+    .get('span')
+    .contains('PPM')
+    .click();
+
+  cy.get('.net_weight').contains('missing');
+
+  cy
+    .get('.editable-panel-header')
+    .contains('Weights')
+    .siblings()
+    .click();
+
+  cy.get('input[name="net_weight"]').type('6000');
+
+  cy
+    .get('button')
+    .contains('Save')
+    .click();
+
+  cy.get('.net_weight').contains('6,000');
+}
 
 function officeUserViewsMoves() {
   // Open new moves queue

--- a/migrations/20190212181259_add_net_weight_column.up.fizz
+++ b/migrations/20190212181259_add_net_weight_column.up.fizz
@@ -1,0 +1,1 @@
+add_column("personally_procured_moves", "net_weight", "int", {"null": true})

--- a/pkg/handlers/internalapi/personally_procured_move.go
+++ b/pkg/handlers/internalapi/personally_procured_move.go
@@ -34,6 +34,7 @@ func payloadForPPMModel(storer storage.FileStorer, personallyProcuredMove models
 		WeightEstimate:                personallyProcuredMove.WeightEstimate,
 		OriginalMoveDate:              handlers.FmtDatePtr(personallyProcuredMove.OriginalMoveDate),
 		ActualMoveDate:                handlers.FmtDatePtr(personallyProcuredMove.ActualMoveDate),
+		NetWeight:                     personallyProcuredMove.NetWeight,
 		PickupPostalCode:              personallyProcuredMove.PickupPostalCode,
 		HasAdditionalPostalCode:       personallyProcuredMove.HasAdditionalPostalCode,
 		AdditionalPickupPostalCode:    personallyProcuredMove.AdditionalPickupPostalCode,
@@ -155,6 +156,9 @@ func patchPPMWithPayload(ppm *models.PersonallyProcuredMove, payload *internalme
 	}
 	if payload.WeightEstimate != nil {
 		ppm.WeightEstimate = payload.WeightEstimate
+	}
+	if payload.NetWeight != nil {
+		ppm.NetWeight = payload.NetWeight
 	}
 	if payload.OriginalMoveDate != nil {
 		ppm.OriginalMoveDate = (*time.Time)(payload.OriginalMoveDate)

--- a/pkg/models/personally_procured_move.go
+++ b/pkg/models/personally_procured_move.go
@@ -43,6 +43,7 @@ type PersonallyProcuredMove struct {
 	WeightEstimate                *int64                       `json:"weight_estimate" db:"weight_estimate"`
 	OriginalMoveDate              *time.Time                   `json:"original_move_date" db:"original_move_date"`
 	ActualMoveDate                *time.Time                   `json:"actual_move_date" db:"actual_move_date"`
+	NetWeight                     *int64                       `json:"net_weight" db:"net_weight"`
 	PickupPostalCode              *string                      `json:"pickup_postal_code" db:"pickup_postal_code"`
 	HasAdditionalPostalCode       *bool                        `json:"has_additional_postal_code" db:"has_additional_postal_code"`
 	AdditionalPickupPostalCode    *string                      `json:"additional_pickup_postal_code" db:"additional_pickup_postal_code"`

--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -91,8 +91,8 @@ const PPMTabContent = props => {
       <IncentiveCalculator moveId={props.moveId} />
       <StorageReimbursementCalculator moveId={props.moveId} />
       <DatesAndLocationPanel title="Dates & Locations" moveId={props.moveId} />
-      <PPMEstimatesPanel title="Estimates" moveId={props.moveId} />
       <NetWeightPanel title="Weights" moveId={props.moveId} />
+      <PPMEstimatesPanel title="Estimates" moveId={props.moveId} />
     </div>
   );
 };

--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -21,6 +21,7 @@ import PPMEstimatesPanel from './Ppm/PPMEstimatesPanel';
 import StorageReimbursementCalculator from './Ppm/StorageReimbursementCalculator';
 import IncentiveCalculator from './Ppm/IncentiveCalculator';
 import ExpensesPanel from './Ppm/ExpensesPanel';
+import NetWeightPanel from './Ppm/NetWeightPanel';
 import Dates from 'shared/ShipmentDates';
 import RoutingPanel from './Hhg/RoutingPanel';
 import ServiceAgentsContainer from './Hhg/ServiceAgentsContainer';
@@ -91,6 +92,7 @@ const PPMTabContent = props => {
       <StorageReimbursementCalculator moveId={props.moveId} />
       <DatesAndLocationPanel title="Dates & Locations" moveId={props.moveId} />
       <PPMEstimatesPanel title="Estimates" moveId={props.moveId} />
+      <NetWeightPanel title="Weights" moveId={props.moveId} />
     </div>
   );
 };

--- a/src/scenes/Office/Ppm/NetWeightPanel.jsx
+++ b/src/scenes/Office/Ppm/NetWeightPanel.jsx
@@ -14,22 +14,18 @@ const NetWeightDisplay = props => {
     values: props.ppm,
   };
   return (
-    <React.Fragment>
-      <div className="editable-panel-column">
-        <PanelSwaggerField title="Net Weight" fieldName="net_weight" required {...fieldProps} />
-      </div>
-    </React.Fragment>
+    <div className="editable-panel-column">
+      <PanelSwaggerField title="Net Weight" fieldName="net_weight" required {...fieldProps} />
+    </div>
   );
 };
 
 const NetWeightEdit = props => {
   const { ppmSchema } = props;
   return (
-    <React.Fragment>
-      <div className="editable-panel-column">
-        <SwaggerField title="Net Weight" fieldName="net_weight" swagger={ppmSchema} required />
-      </div>
-    </React.Fragment>
+    <div className="editable-panel-column net-weight">
+      <SwaggerField className="short-field" title="Net Weight" fieldName="net_weight" swagger={ppmSchema} required />lbs
+    </div>
   );
 };
 

--- a/src/scenes/Office/Ppm/NetWeightPanel.jsx
+++ b/src/scenes/Office/Ppm/NetWeightPanel.jsx
@@ -3,12 +3,10 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { reduxForm, getFormValues } from 'redux-form';
-import { selectPPMForMove } from 'shared/Entities/modules/ppms';
+import { selectPPMForMove, updatePPM } from 'shared/Entities/modules/ppms';
 
 import { SwaggerField } from 'shared/JsonSchemaForm/JsonSchemaField';
 import { PanelSwaggerField, editablePanelify } from 'shared/EditablePanel';
-
-import { updateOrders } from '../ducks';
 
 const NetWeightDisplay = props => {
   const fieldProps = {
@@ -35,7 +33,7 @@ const NetWeightEdit = props => {
   );
 };
 
-const formName = 'office_move_info_accounting';
+const formName = 'ppm_net_weight';
 
 let NetWeightPanel = editablePanelify(NetWeightDisplay, NetWeightEdit);
 NetWeightPanel = reduxForm({
@@ -56,18 +54,17 @@ function mapStateToProps(state, ownProps) {
     ppmSchema: get(state, 'swaggerInternal.spec.definitions.PersonallyProcuredMovePayload'),
     ppm,
     // editablePanelify
-    // getUpdateArgs: function() {
-    //   let values = getFormValues(formName)(state);
-    //   values.new_duty_station_id = values.new_duty_station.id;
-    //   return [orders.id, values];
-    // },
+    getUpdateArgs: function() {
+      const values = getFormValues(formName)(state);
+      return [ownProps.moveId, ppm.id, values];
+    },
   };
 }
 
 function mapDispatchToProps(dispatch) {
   return bindActionCreators(
     {
-      update: updateOrders,
+      update: updatePPM,
     },
     dispatch,
   );

--- a/src/scenes/Office/Ppm/NetWeightPanel.jsx
+++ b/src/scenes/Office/Ppm/NetWeightPanel.jsx
@@ -1,4 +1,4 @@
-import { get } from 'lodash';
+import { get, pick } from 'lodash';
 import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
@@ -43,7 +43,7 @@ function mapStateToProps(state, ownProps) {
   const ppm = selectPPMForMove(state, ownProps.moveId);
   return {
     // reduxForm
-    initialValues: ppm,
+    initialValues: pick(ppm, 'net_weight'),
     formValues,
 
     // Wrapper

--- a/src/scenes/Office/Ppm/NetWeightPanel.jsx
+++ b/src/scenes/Office/Ppm/NetWeightPanel.jsx
@@ -1,0 +1,76 @@
+import { get } from 'lodash';
+import React from 'react';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import { reduxForm, getFormValues } from 'redux-form';
+import { selectPPMForMove } from 'shared/Entities/modules/ppms';
+
+import { SwaggerField } from 'shared/JsonSchemaForm/JsonSchemaField';
+import { PanelSwaggerField, editablePanelify } from 'shared/EditablePanel';
+
+import { updateOrders } from '../ducks';
+
+const NetWeightDisplay = props => {
+  const fieldProps = {
+    schema: props.ppmSchema,
+    values: props.ppm,
+  };
+  return (
+    <React.Fragment>
+      <div className="editable-panel-column">
+        <PanelSwaggerField title="Net Weight" fieldName="net_weight" required {...fieldProps} />
+      </div>
+    </React.Fragment>
+  );
+};
+
+const NetWeightEdit = props => {
+  const { ppmSchema } = props;
+  return (
+    <React.Fragment>
+      <div className="editable-panel-column">
+        <SwaggerField title="Net Weight" fieldName="net_weight" swagger={ppmSchema} required />
+      </div>
+    </React.Fragment>
+  );
+};
+
+const formName = 'office_move_info_accounting';
+
+let NetWeightPanel = editablePanelify(NetWeightDisplay, NetWeightEdit);
+NetWeightPanel = reduxForm({
+  form: formName,
+  enableReinitialize: true,
+  keepDirtyOnReinitialize: true,
+})(NetWeightPanel);
+
+function mapStateToProps(state, ownProps) {
+  const formValues = getFormValues(formName)(state);
+  const ppm = selectPPMForMove(state, ownProps.moveId);
+  return {
+    // reduxForm
+    initialValues: ppm,
+    formValues,
+
+    // Wrapper
+    ppmSchema: get(state, 'swaggerInternal.spec.definitions.PersonallyProcuredMovePayload'),
+    ppm,
+    // editablePanelify
+    // getUpdateArgs: function() {
+    //   let values = getFormValues(formName)(state);
+    //   values.new_duty_station_id = values.new_duty_station.id;
+    //   return [orders.id, values];
+    // },
+  };
+}
+
+function mapDispatchToProps(dispatch) {
+  return bindActionCreators(
+    {
+      update: updateOrders,
+    },
+    dispatch,
+  );
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(NetWeightPanel);

--- a/src/shared/EditablePanel/index.css
+++ b/src/shared/EditablePanel/index.css
@@ -54,6 +54,10 @@
   display: inline-block;
 }
 
+.net-weight .short-field {
+  margin-right: 0.5rem;
+}
+
 .office-tab .editable-panel-content {
   padding-left: 1.7rem;
   padding-right: 1.7rem;

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -195,6 +195,11 @@ definitions:
         minimum: 1
         title: Weight Estimate
         x-nullable: true
+      net_weight:
+        type: integer
+        minimum: 1
+        title: Net Weight
+        x-nullable: true
       has_requested_advance:
         type: boolean
         title: Would you like an advance of up to 60% of your PPM incentive?
@@ -263,6 +268,11 @@ definitions:
         minimum: 1
         title: Weight Estimate
         x-nullable: true
+      net_weight:
+        type: integer
+        minimum: 1
+        title: Net Weight
+        x-nullable: true
       has_requested_advance:
         type: boolean
         default: false
@@ -327,6 +337,11 @@ definitions:
         type: integer
         minimum: 1
         title: Weight Estimate
+        x-nullable: true
+      net_weight:
+        type: integer
+        minimum: 1
+        title: Net Weight
         x-nullable: true
       has_requested_advance:
         type: boolean

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -406,6 +406,12 @@ definitions:
         title: Weight Estimate
         x-nullable: true
         x-formatting: weight
+      net_weight:
+        type: integer
+        minimum: 1
+        title: Net Weight
+        x-nullable: true
+        x-formatting: weight
       mileage:
         type: integer
         title: Distance between origin and destination in miles


### PR DESCRIPTION
## Description

Create Weights panel for PPM to save net weight for future use on SSW

## Setup
`make db_dev_e2e_populate`
`make office_client_run`
`make server_run`
Go into a PPM move
Edit Weights panel
Save Net Weight

## Code Review Verification Steps
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/163578943) for this change

## Screenshots

![image](https://user-images.githubusercontent.com/13622298/52816198-a334a300-3055-11e9-8407-ab6f50f9477d.png)
![image](https://user-images.githubusercontent.com/13622298/52816174-94e68700-3055-11e9-94cc-059c062d0e85.png)
![image](https://user-images.githubusercontent.com/13622298/52816208-a7f95700-3055-11e9-999d-2300d2076308.png)
