### PR TITLE
Fix bug for alert showing on successful backup info change

### DIFF
--- a/src/scenes/Office/CustomerInfoPanel.jsx
+++ b/src/scenes/Office/CustomerInfoPanel.jsx
@@ -136,18 +136,18 @@ CustomerInfoPanel = reduxForm({
 })(CustomerInfoPanel);
 
 function mapStateToProps(state, ownProps) {
-  let customerInfo = ownProps.serviceMember;
+  const customerInfo = ownProps.serviceMember;
   const loadServiceMemberStatus = getRequestStatus(state, loadServiceMemberLabel);
   const updateServiceMemberStatus = getRequestStatus(state, updateServiceMemberLabel);
   let hasError = false;
   let errorMessage = '';
 
-  if (loadServiceMemberStatus.isSuccess === false) {
+  if (loadServiceMemberStatus.error) {
     hasError = true;
     errorMessage = get(loadServiceMemberStatus, 'error.response.message', '');
   }
 
-  if (updateServiceMemberStatus.isSuccess === false) {
+  if (updateServiceMemberStatus.error) {
     hasError = true;
     errorMessage = get(updateServiceMemberStatus, 'error.response.message', '');
   }


### PR DESCRIPTION
## Description

Error alert no longer shows on successful backup info change

## Setup
`make db_dev_e2e_populate`
`make server_run`
`make office_client_run`
Go into any move
Edit backup info

## Code Review Verification Steps
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/163776084) for this change

## Screenshots

![bug gif](https://media.giphy.com/media/2Wg8J4nh6S0c7aDpMm/giphy.gif)
