### PR TITLE
Office app breaks when no advance

### DIFF
--- a/cypress/integration/office/officeUserPPM.js
+++ b/cypress/integration/office/officeUserPPM.js
@@ -7,13 +7,26 @@ describe('office user finds the move', function() {
     officeUserViewsMoves();
   });
   it('office user verifies the orders tab', function() {
-    officeUserVerifiesOrders();
+    officeUserVerifiesOrders('VGHEIS');
   });
   it('office user verifies the accounting tab', function() {
     officeUserVerifiesAccounting();
   });
   it('office user approves move, verifies and approves PPM', function() {
-    officeUserApprovesMoveAndVerifiesPPM();
+    officeUserApprovesMoveAndPPM('VGHEIS');
+    officeUserVerifiesPPM();
+  });
+  it('office user approves move, approves PPM with no advance', function() {
+    const moveLocator = 'NOADVC';
+    officeUserVerifiesOrders(moveLocator);
+    cy.patientVisit('/');
+    officeUserApprovesMoveAndPPM(moveLocator);
+
+    // Make sure the page hasn't exploded
+    cy
+      .get('button')
+      .contains('Approve PPM')
+      .should('have.class', 'btn__approve--green');
   });
 });
 
@@ -31,14 +44,14 @@ function officeUserViewsMoves() {
   });
 }
 
-function officeUserVerifiesOrders() {
+function officeUserVerifiesOrders(moveLocator) {
   // Open new moves queue
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/queues\/new/);
   });
 
   // Find move and open it
-  cy.selectQueueItemMoveLocator('VGHEIS');
+  cy.selectQueueItemMoveLocator(moveLocator);
 
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/queues\/new\/moves\/[^/]+\/basics/);
@@ -148,14 +161,14 @@ function officeUserVerifiesAccounting() {
   cy.get('span').contains('N002214CSW32Y9');
 }
 
-function officeUserApprovesMoveAndVerifiesPPM() {
+function officeUserApprovesMoveAndPPM(moveLocator) {
   // Open new moves queue
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/queues\/new/);
   });
 
   // Find move and open it
-  cy.selectQueueItemMoveLocator('VGHEIS');
+  cy.selectQueueItemMoveLocator(moveLocator);
 
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/queues\/new\/moves\/[^/]+\/basics/);
@@ -189,7 +202,7 @@ function officeUserApprovesMoveAndVerifiesPPM() {
     .click();
 
   // Find move and open it
-  cy.selectQueueItemMoveLocator('VGHEIS');
+  cy.selectQueueItemMoveLocator(moveLocator);
 
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/queues\/new\/moves\/[^/]+\/basics/);
@@ -204,14 +217,16 @@ function officeUserApprovesMoveAndVerifiesPPM() {
     expect(loc.pathname).to.match(/^\/queues\/new\/moves\/[^/]+\/ppm/);
   });
 
-  // Verify that the Estimates section contains expected data
-  cy.get('span').contains('8,000');
-
   // Approve PPM
   cy
     .get('button')
     .contains('Approve PPM')
     .click();
+}
+
+function officeUserVerifiesPPM() {
+  // Verify that the Estimates section contains expected data
+  cy.get('span').contains('8,000');
 
   // Approve advance
   cy.get('.payment-table').within(() => {

--- a/pkg/testdatagen/make_ppm.go
+++ b/pkg/testdatagen/make_ppm.go
@@ -10,8 +10,6 @@ import (
 // MakePPM creates a single Personally Procured Move and its associated Move and Orders
 func MakePPM(db *pop.Connection, assertions Assertions) models.PersonallyProcuredMove {
 	shirt := internalmessages.TShirtSizeM
-	defaultAdvance := models.BuildDraftReimbursement(1000, models.MethodOfReceiptMILPAY)
-	mustCreate(db, &defaultAdvance)
 
 	// Create new Move if not provided
 	move := assertions.PersonallyProcuredMove.Move
@@ -34,8 +32,6 @@ func MakePPM(db *pop.Connection, assertions Assertions) models.PersonallyProcure
 		DaysInStorage:                 nil,
 		Status:                        models.PPMStatusDRAFT,
 		HasRequestedAdvance:           true,
-		Advance:                       &defaultAdvance,
-		AdvanceID:                     &defaultAdvance.ID,
 		EstimatedStorageReimbursement: models.StringPointer("estimate sit"),
 	}
 
@@ -52,7 +48,13 @@ func MakePPM(db *pop.Connection, assertions Assertions) models.PersonallyProcure
 
 // MakeDefaultPPM makes a PPM with default values
 func MakeDefaultPPM(db *pop.Connection) models.PersonallyProcuredMove {
+	advance := models.BuildDraftReimbursement(1000, models.MethodOfReceiptMILPAY)
+	mustCreate(db, &advance)
 	return MakePPM(db, Assertions{
+		PersonallyProcuredMove: models.PersonallyProcuredMove{
+			Advance:   &advance,
+			AdvanceID: &advance.ID,
+		},
 		Order: models.Order{
 			HasDependents:    true,
 			SpouseHasProGear: true,

--- a/pkg/testdatagen/scenario/e2ebasic.go
+++ b/pkg/testdatagen/scenario/e2ebasic.go
@@ -114,6 +114,7 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, log
 			LoginGovEmail: email,
 		},
 	})
+	advance := models.BuildDraftReimbursement(1000, models.MethodOfReceiptMILPAY)
 	ppm0 := testdatagen.MakePPM(db, testdatagen.Assertions{
 		ServiceMember: models.ServiceMember{
 			ID:            uuid.FromStringOrNil("94ced723-fabc-42af-b9ee-87f8986bb5c9"),
@@ -129,6 +130,8 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, log
 		},
 		PersonallyProcuredMove: models.PersonallyProcuredMove{
 			PlannedMoveDate: &nowTime,
+			Advance:         &advance,
+			AdvanceID:       &advance.ID,
 		},
 		Uploader: loader,
 	})

--- a/pkg/testdatagen/scenario/e2ebasic.go
+++ b/pkg/testdatagen/scenario/e2ebasic.go
@@ -139,6 +139,38 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, log
 	models.SaveMoveDependencies(db, &ppm0.Move)
 
 	/*
+	 * Service member with uploaded orders, a new ppm and no advance
+	 */
+	email = "ppm@advance.no"
+	uuidStr = "f0ddc118-3f7e-476b-b8be-0f964a5feee2"
+	testdatagen.MakeUser(db, testdatagen.Assertions{
+		User: models.User{
+			ID:            uuid.Must(uuid.FromString(uuidStr)),
+			LoginGovEmail: email,
+		},
+	})
+	ppmNoAdvance := testdatagen.MakePPM(db, testdatagen.Assertions{
+		ServiceMember: models.ServiceMember{
+			ID:            uuid.FromStringOrNil("1a1aafde-df3b-4459-9dbd-27e9f6c1d2f6"),
+			UserID:        uuid.FromStringOrNil(uuidStr),
+			FirstName:     models.StringPointer("PPM"),
+			LastName:      models.StringPointer("No Advance"),
+			Edipi:         models.StringPointer("1234567890"),
+			PersonalEmail: models.StringPointer(email),
+		},
+		Move: models.Move{
+			ID:      uuid.FromStringOrNil("4f3f4bee-3719-4c17-8cf4-7e445a38d90e"),
+			Locator: "NOADVC",
+		},
+		PersonallyProcuredMove: models.PersonallyProcuredMove{
+			PlannedMoveDate: &nowTime,
+		},
+		Uploader: loader,
+	})
+	ppmNoAdvance.Move.Submit()
+	models.SaveMoveDependencies(db, &ppmNoAdvance.Move)
+
+	/*
 	 * A move, that will be canceled by the E2E test
 	 */
 	email = "ppm-to-cancel@example.com"

--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -41,7 +41,7 @@ import {
   getShipmentLineItemsLabel,
 } from 'shared/Entities/modules/shipmentLineItems';
 import { getAllInvoices, getShipmentInvoicesLabel } from 'shared/Entities/modules/invoices';
-import { approvePPM, selectPPMForMove } from 'shared/Entities/modules/ppms';
+import { approvePPM, selectPPMForMove, selectReimbursement } from 'shared/Entities/modules/ppms';
 import { selectServiceMember } from 'shared/Entities/modules/serviceMembers';
 import { selectMove } from 'shared/Entities/modules/moves';
 import {
@@ -486,7 +486,7 @@ const mapStateToProps = (state, ownProps) => {
     moveStatus: selectMoveStatus(state, moveId),
     orders,
     officeShipment: get(state, 'office.officeShipment', {}),
-    ppmAdvance: ppm.advance,
+    ppmAdvance: selectReimbursement(state, ppm.advance),
     serviceAgents: selectServiceAgentsForShipment(state, shipmentId),
     serviceMember,
     shipment: selectShipment(state, shipmentId),


### PR DESCRIPTION
## Description

Make it not do that

## Reviewer Notes

I removed setting up an advance as part of our default PPM creation, and only two tests broke. This proves that we don't really need it, and I hate to do more data setup than what is required for a test. But, if you differ in opinion, I'm all ears.

## Code Review Verification Steps

* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/163952994) for this change
