### PR TITLE
Update "Continue Move"  button to redirect to last page not completed

### DIFF
--- a/cypress/integration/mymove/shipment.js
+++ b/cypress/integration/mymove/shipment.js
@@ -19,17 +19,11 @@ describe('shipments', function() {
   });
   describe('continuing a hhg move after logging out before completion', function() {
     it('resumes where service member left off', function() {
-      // cypress server/route/wait currently does not support window.fetch api
-      // https://github.com/cypress-io/cypress/issues/95#issuecomment-347607198
-      // delete window.fetch so fallback to xhr
-      // https://github.com/cypress-io/cypress-example-recipes/tree/master/examples/stubbing-spying__window-fetch
-      cy.on('window:before:load', win => {
-        delete win.fetch;
-      });
       // sm_hhg_continue@example.com
       const serviceMemberId = '1256a6ea-27cc-4d60-92df-1bc2a5c39028';
       const firstIncompletePage = /^\/moves\/[^/]+\/hhg-weight/;
 
+      cy.removeFetch();
       cy.signInAsUser(serviceMemberId);
       serviceMemberAddsHHG();
       serviceMemberAddsMoveDates();

--- a/cypress/integration/mymove/shipment.js
+++ b/cypress/integration/mymove/shipment.js
@@ -1,238 +1,303 @@
 /* global cy, Cypress */
 
-describe('completing the hhg flow', function() {
-  beforeEach(() => {
-    // sm_hhg@example.com
-    cy.signInAsUser('4b389406-9258-4695-a091-0bf97b5a132f');
+describe('shipments', function() {
+  describe('completing the hhg flow', function() {
+    it('selects hhg and progresses thru form', function() {
+      // sm_hhg@example.com
+      cy.signInAsUser('4b389406-9258-4695-a091-0bf97b5a132f');
+      serviceMemberAddsHHG();
+      serviceMemberAddsMoveDates();
+      serviceMemberAddsLocations();
+      serviceMemberAddsWeight();
+      serviceMemberAddsProGear();
+      serviceMemberEditsDates();
+      serviceMemberCancelsDateEdit();
+      serviceMemberReviewsMove();
+      serivceMemberSigns();
+      moveIsSuccessfullyCreated();
+    });
   });
-
-  it('selects hhg and progresses thru form', function() {
-    cy.contains('Continue Move Setup').click();
-    cy
-      .contains('Household Goods Move')
-      .click()
-      .nextPage();
-
-    cy.location().should(loc => {
-      expect(loc.pathname).to.match(/^\/moves\/[^/]+\/hhg-start/);
-    });
-    cy.get('button.next').should('be.disabled');
-
-    // Calendar move date
-
-    // Try to get today, which should be disabled.  We may have to go back a month to find
-    // today since the calendar scrolls to the month with the first available move date.
-    cy
-      .get('.DayPicker-Body')
-      .then($body => {
-        if ($body.find('.DayPicker-Day--today').length === 0) {
-          cy.get('.DayPicker-NavButton--prev').click();
-        }
-      })
-      .then(() => {
-        cy
-          .get('.DayPicker-Day--today')
-          .first()
-          .should('have.class', 'DayPicker-Day--disabled');
+  describe('continuing a hhg move after logging out before completion', function() {
+    it('resumes where service member left off', function() {
+      // cypress server/route/wait currently does not support window.fetch api
+      // https://github.com/cypress-io/cypress/issues/95#issuecomment-347607198
+      // delete window.fetch so fallback to xhr
+      // https://github.com/cypress-io/cypress-example-recipes/tree/master/examples/stubbing-spying__window-fetch
+      cy.on('window:before:load', win => {
+        delete win.fetch;
       });
+      // sm_hhg_continue@example.com
+      const serviceMemberId = '1256a6ea-27cc-4d60-92df-1bc2a5c39028';
+      const firstIncompletePage = /^\/moves\/[^/]+\/hhg-weight/;
 
-    // We may or may not have an available date in the current month.  If not, then
-    // we skip to the next month which should (at least at this point) have an available
-    // date.
-    cy
-      .get('.DayPicker-Body')
-      .then($body => {
-        if ($body.find('[class=DayPicker-Day]').length === 0) {
-          cy.get('.DayPicker-NavButton--next').click();
-        }
-      })
-      .then(() => {
-        cy
-          .get('[class=DayPicker-Day]')
-          .first()
-          .click()
-          .should('have.class', 'DayPicker-Day--pickup');
+      cy.signInAsUser(serviceMemberId);
+      serviceMemberAddsHHG();
+      serviceMemberAddsMoveDates();
+      serviceMemberAddsLocations();
+      cy.location().should(loc => {
+        expect(loc.pathname).to.match(firstIncompletePage);
       });
+      serviceMemberLogsOutThenContinues(serviceMemberId);
 
-    // Check for calendar move dates summary and color-coding of calendar.
-    cy.contains('Movers Packing');
-    cy.get('.DayPicker-Day.DayPicker-Day--pickup');
-    cy.nextPage();
-
-    cy.location().should(loc => {
-      expect(loc.pathname).to.match(/^\/moves\/[^/]+\/hhg-locations/);
+      cy.location().should(loc => {
+        expect(loc.pathname).to.match(firstIncompletePage);
+      });
     });
-    cy.get('button.next').should('be.disabled');
-
-    // Pickup address
-    cy
-      .get('input[name="pickup_address.street_address_1"]')
-      .clear({ force: true })
-      .type('123 Elm Street');
-    cy
-      .get('input[name="pickup_address.city"]')
-      .clear()
-      .type('Alameda');
-    cy.get('select[name="pickup_address.state"]').select('CA');
-    cy.get('input[name="pickup_address.postal_code"]').type('94607');
-
-    // Check yes for radios
-    cy.get('input[type="radio"]').check('yes', { force: true }); // checks yes for both radios on form
-
-    // Secondary pickup address
-    cy
-      .get('input[name="secondary_pickup_address.street_address_1"]')
-      .clear({ force: true })
-      .type('543 Oak Street');
-    cy
-      .get('input[name="secondary_pickup_address.city"]')
-      .clear()
-      .type('Oakland');
-    cy.get('select[name="secondary_pickup_address.state"]').select('CA');
-    cy.get('input[name="secondary_pickup_address.postal_code"]').type('94609');
-
-    // Destination address
-    cy
-      .get('input[name="delivery_address.street_address_1"]')
-      .clear({ force: true })
-      .type('678 Madrone Street');
-    cy
-      .get('input[name="delivery_address.city"]')
-      .clear()
-      .type('Fremont');
-    cy.get('select[name="delivery_address.state"]').select('CA');
-    cy.get('input[name="delivery_address.postal_code"]').type('94567');
-
-    cy.nextPage();
-
-    cy.location().should(loc => {
-      expect(loc.pathname).to.match(/^\/moves\/[^/]+\/hhg-weight/);
-    });
-
-    // Weight calculator
-    cy
-      .get('input[name="rooms"]')
-      .clear()
-      .type('9');
-
-    cy.get('select[name="stuff"]').select('more');
-
-    cy.get('input[name="weight_estimate"]').should('have.value', '13500');
-
-    // Weight over entitlement
-    cy
-      .get('input[name="weight_estimate"]')
-      .clear()
-      .type('50000');
-
-    cy.contains('Entitlement exceeded');
-
-    // Weight
-    cy
-      .get('input[name="weight_estimate"]')
-      .clear()
-      .type('3000');
-
-    cy.contains('Entitlement exceeded').should('not.exist');
-
-    cy.nextPage();
-
-    cy.location().should(loc => {
-      expect(loc.pathname).to.match(/^\/moves\/[^/]+\/hhg-progear/);
-    });
-
-    // Progear Weights
-
-    // Check yes for radios
-    cy.get('input[type="radio"]').check('yes', { force: true }); // checks yes for both radios on form
-
-    cy
-      .get('input[name="progear_weight_estimate"]')
-      .clear()
-      .type('2500');
-
-    cy.contains('Entitlement exceeded');
-
-    cy
-      .get('input[name="progear_weight_estimate"]')
-      .clear()
-      .type('250');
-
-    cy.contains('Entitlement exceeded').should('not.exist');
-
-    cy
-      .get('input[name="spouse_progear_weight_estimate"]')
-      .clear()
-      .type('1580');
-
-    cy.contains('Entitlement exceeded');
-
-    cy
-      .get('input[name="spouse_progear_weight_estimate"]')
-      .clear()
-      .type('158');
-
-    cy.contains('Entitlement exceeded').should('not.exist');
-
-    // Review page
-    cy.nextPage();
-    cy.location().should(loc => {
-      expect(loc.pathname).to.match(/^\/moves\/[^/]+\/review/);
-    });
-    cy.contains('Government moves all of your stuff (HHG)');
-
-    cy.contains('123 Elm Street'); // pickup address
-    cy.contains('543 Oak Street'); // secondary pickup address
-    cy.contains('678 Madrone Street'); // destination address
-
-    cy.contains('3,000 lbs + 250 lbs pro-gear + 158 lbs spouse pro-gear');
-    cy.contains('Great! You appear within your weight allowance.');
-
-    // Go back and edit dates
-    cy
-      .get('.hhg-shipment-summary .hhg-dates a')
-      .contains('Edit')
-      .click();
-
-    cy.contains('Pick a moving date');
-    cy.get('.DayPicker-Body').then($body => {
-      if ($body.find('.DayPicker-Day--transit[aria-disabled=false]').length === 0) {
-        cy.get('.DayPicker-NavButton--next').click();
-      }
-    });
-    cy
-      .get('.DayPicker-Day--transit[aria-disabled=false]') // pick the first transit day that is selectable
-      .first()
-      .click()
-      .should('have.class', 'DayPicker-Day--pickup')
-      .invoke('attr', 'aria-label')
-      .as('dateLabel');
-
-    cy.contains('Save').click();
-
-    // verify new date is shown
-    checkLoadingDate();
-
-    // click edit again and then click cancel
-    cy
-      .get('.hhg-shipment-summary .hhg-dates a')
-      .contains('Edit')
-      .click();
-    cy.contains('Cancel').click();
-
-    // verify loading date hasn't changed
-    checkLoadingDate();
-
-    cy.nextPage();
-    cy.contains('SIGNATURE');
-    cy.get('input[name="signature"]').type('SM Signature');
-
-    // Status summary page
-    cy.nextPage();
-    cy.contains('Success');
-    cy.contains('Government Movers and Packers');
   });
 });
+
+function serviceMemberLogsOutThenContinues(serviceMemberId) {
+  cy.logout();
+  // wait returns after the 1st call to getShipments, so if multiple calls
+  // placement of server and route are important
+  cy.server();
+  cy.route({ url: '**/internal/shipments/*' }).as('getShipments');
+  cy.signInAsUser(serviceMemberId);
+  cy.wait('@getShipments');
+  cy.contains('Continue Move Setup').click();
+}
+
+function serviceMemberAddsHHG() {
+  cy.contains('Continue Move Setup').click();
+  cy
+    .contains('Household Goods Move')
+    .click()
+    .nextPage();
+}
+
+function serviceMemberAddsMoveDates() {
+  cy.location().should(loc => {
+    expect(loc.pathname).to.match(/^\/moves\/[^/]+\/hhg-start/);
+  });
+  cy.get('button.next').should('be.disabled');
+
+  // Calendar move date
+
+  // Try to get today, which should be disabled.  We may have to go back a month to find
+  // today since the calendar scrolls to the month with the first available move date.
+  cy
+    .get('.DayPicker-Body')
+    .then($body => {
+      if ($body.find('.DayPicker-Day--today').length === 0) {
+        cy.get('.DayPicker-NavButton--prev').click();
+      }
+    })
+    .then(() => {
+      cy
+        .get('.DayPicker-Day--today')
+        .first()
+        .should('have.class', 'DayPicker-Day--disabled');
+    });
+
+  // We may or may not have an available date in the current month.  If not, then
+  // we skip to the next month which should (at least at this point) have an available
+  // date.
+  cy
+    .get('.DayPicker-Body')
+    .then($body => {
+      if ($body.find('[class=DayPicker-Day]').length === 0) {
+        cy.get('.DayPicker-NavButton--next').click();
+      }
+    })
+    .then(() => {
+      cy
+        .get('[class=DayPicker-Day]')
+        .first()
+        .click()
+        .should('have.class', 'DayPicker-Day--pickup');
+    });
+
+  // Check for calendar move dates summary and color-coding of calendar.
+  cy.contains('Movers Packing');
+  cy.get('.DayPicker-Day.DayPicker-Day--pickup');
+  cy.nextPage();
+}
+
+function serviceMemberAddsLocations() {
+  cy.location().should(loc => {
+    expect(loc.pathname).to.match(/^\/moves\/[^/]+\/hhg-locations/);
+  });
+  cy.get('button.next').should('be.disabled');
+
+  // Pickup address
+  cy
+    .get('input[name="pickup_address.street_address_1"]')
+    .clear({ force: true })
+    .type('123 Elm Street');
+  cy
+    .get('input[name="pickup_address.city"]')
+    .clear()
+    .type('Alameda');
+  cy.get('select[name="pickup_address.state"]').select('CA');
+  cy.get('input[name="pickup_address.postal_code"]').type('94607');
+
+  // Check yes for radios
+  cy.get('input[type="radio"]').check('yes', { force: true }); // checks yes for both radios on form
+
+  // Secondary pickup address
+  cy
+    .get('input[name="secondary_pickup_address.street_address_1"]')
+    .clear({ force: true })
+    .type('543 Oak Street');
+  cy
+    .get('input[name="secondary_pickup_address.city"]')
+    .clear()
+    .type('Oakland');
+  cy.get('select[name="secondary_pickup_address.state"]').select('CA');
+  cy.get('input[name="secondary_pickup_address.postal_code"]').type('94609');
+
+  // Destination address
+  cy
+    .get('input[name="delivery_address.street_address_1"]')
+    .clear({ force: true })
+    .type('678 Madrone Street');
+  cy
+    .get('input[name="delivery_address.city"]')
+    .clear()
+    .type('Fremont');
+  cy.get('select[name="delivery_address.state"]').select('CA');
+  cy.get('input[name="delivery_address.postal_code"]').type('94567');
+
+  cy.nextPage();
+}
+
+function serviceMemberAddsWeight() {
+  cy.location().should(loc => {
+    expect(loc.pathname).to.match(/^\/moves\/[^/]+\/hhg-weight/);
+  });
+
+  // Weight calculator
+  cy
+    .get('input[name="rooms"]')
+    .clear()
+    .type('9');
+
+  cy.get('select[name="stuff"]').select('more');
+
+  cy.get('input[name="weight_estimate"]').should('have.value', '13500');
+
+  // Weight over entitlement
+  cy
+    .get('input[name="weight_estimate"]')
+    .clear()
+    .type('50000');
+
+  cy.contains('Entitlement exceeded');
+
+  // Weight
+  cy
+    .get('input[name="weight_estimate"]')
+    .clear()
+    .type('3000');
+
+  cy.contains('Entitlement exceeded').should('not.exist');
+
+  cy.nextPage();
+}
+
+function serviceMemberAddsProGear() {
+  cy.location().should(loc => {
+    expect(loc.pathname).to.match(/^\/moves\/[^/]+\/hhg-progear/);
+  });
+
+  // Progear Weights
+
+  // Check yes for radios
+  cy.get('input[type="radio"]').check('yes', { force: true }); // checks yes for both radios on form
+
+  cy
+    .get('input[name="progear_weight_estimate"]')
+    .clear()
+    .type('2500');
+
+  cy.contains('Entitlement exceeded');
+
+  cy
+    .get('input[name="progear_weight_estimate"]')
+    .clear()
+    .type('250');
+
+  cy.contains('Entitlement exceeded').should('not.exist');
+
+  cy
+    .get('input[name="spouse_progear_weight_estimate"]')
+    .clear()
+    .type('1580');
+
+  cy.contains('Entitlement exceeded');
+
+  cy
+    .get('input[name="spouse_progear_weight_estimate"]')
+    .clear()
+    .type('158');
+
+  cy.contains('Entitlement exceeded').should('not.exist');
+  cy.nextPage();
+}
+
+function serviceMemberReviewsMove() {
+  // Review page
+  cy.location().should(loc => {
+    expect(loc.pathname).to.match(/^\/moves\/[^/]+\/review/);
+  });
+  cy.contains('Government moves all of your stuff (HHG)');
+
+  cy.contains('123 Elm Street'); // pickup address
+  cy.contains('543 Oak Street'); // secondary pickup address
+  cy.contains('678 Madrone Street'); // destination address
+
+  cy.contains('3,000 lbs + 250 lbs pro-gear + 158 lbs spouse pro-gear');
+  cy.contains('Great! You appear within your weight allowance.');
+  cy.nextPage();
+}
+
+function serviceMemberEditsDates() {
+  // Go back and edit dates
+  cy
+    .get('.hhg-shipment-summary .hhg-dates a')
+    .contains('Edit')
+    .click();
+
+  cy.contains('Pick a moving date');
+  cy.get('.DayPicker-Body').then($body => {
+    if ($body.find('.DayPicker-Day--transit[aria-disabled=false]').length === 0) {
+      cy.get('.DayPicker-NavButton--next').click();
+    }
+  });
+  cy
+    .get('.DayPicker-Day--transit[aria-disabled=false]') // pick the first transit day that is selectable
+    .first()
+    .click()
+    .should('have.class', 'DayPicker-Day--pickup')
+    .invoke('attr', 'aria-label')
+    .as('dateLabel');
+
+  cy.contains('Save').click();
+  checkLoadingDate();
+}
+
+function serviceMemberCancelsDateEdit() {
+  // click edit again and then click cancel
+  cy
+    .get('.hhg-shipment-summary .hhg-dates a')
+    .contains('Edit')
+    .click();
+  cy.contains('Cancel').click();
+  checkLoadingDate();
+}
+
+function serivceMemberSigns() {
+  cy.contains('SIGNATURE');
+  cy.get('input[name="signature"]').type('SM Signature');
+
+  // Status summary page
+  cy.nextPage();
+}
+
+function moveIsSuccessfullyCreated() {
+  cy.contains('Success');
+  cy.contains('Government Movers and Packers');
+}
 
 // Verify that the date shown on the review page for loading is the same date
 // that dateLabel was most recently set to.

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -272,3 +272,13 @@ Cypress.Commands.add('setupBaseUrl', appname => {
       break;
   }
 });
+
+Cypress.Commands.add('removeFetch', () => {
+  // cypress server/route/wait currently does not support window.fetch api
+  // https://github.com/cypress-io/cypress/issues/95#issuecomment-347607198
+  // delete window.fetch to force fallback to supported xhr.
+  // https://github.com/cypress-io/cypress-example-recipes/tree/master/examples/stubbing-spying__window-fetch
+  cy.on('window:before:load', win => {
+    delete win.fetch;
+  });
+});

--- a/pkg/testdatagen/scenario/e2ebasic.go
+++ b/pkg/testdatagen/scenario/e2ebasic.go
@@ -430,6 +430,38 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, log
 	})
 
 	/*
+	 * Service member with orders and a move, but no move type selected to select HHG
+	 */
+	email = "sm_hhg_continue@example.com"
+	uuidStr = "1256a6ea-27cc-4d60-92df-1bc2a5c39028"
+
+	testdatagen.MakeUser(db, testdatagen.Assertions{
+		User: models.User{
+			ID:            uuid.Must(uuid.FromString(uuidStr)),
+			LoginGovEmail: email,
+		},
+	})
+
+	testdatagen.MakeMoveWithoutMoveType(db, testdatagen.Assertions{
+		ServiceMember: models.ServiceMember{
+			ID:            uuid.FromStringOrNil("2dac8695-b4d8-40ad-aa84-2b03b6bec960"),
+			UserID:        uuid.FromStringOrNil(uuidStr),
+			FirstName:     models.StringPointer("HHG"),
+			LastName:      models.StringPointer("Continue"),
+			Edipi:         models.StringPointer("2553282188"),
+			PersonalEmail: models.StringPointer(email),
+		},
+		Order: models.Order{
+			HasDependents:    true,
+			SpouseHasProGear: true,
+		},
+		Move: models.Move{
+			ID:      uuid.FromStringOrNil("209ecba8-f99d-446f-b649-06a0da613aa7"),
+			Locator: "HHGCON",
+		},
+	})
+
+	/*
 	 * Another service member with orders and a move, but no move type selected
 	 */
 	email = "sm_no_move_type@example.com"

--- a/src/scenes/Landing/index.jsx
+++ b/src/scenes/Landing/index.jsx
@@ -19,6 +19,7 @@ import LoadingPlaceholder from 'shared/LoadingPlaceholder';
 import scrollToTop from 'shared/scrollToTop';
 import { updateMove } from 'scenes/Moves/ducks';
 import { getPPM } from 'scenes/Moves/Ppm/ducks';
+import { selectShipment } from 'shared/Entities/modules/shipments';
 
 export class Landing extends Component {
   componentDidMount() {
@@ -160,7 +161,7 @@ export class Landing extends Component {
 }
 
 const mapStateToProps = state => {
-  const shipment = getCurrentShipment(state);
+  const shipmentId = getCurrentShipment(state);
   const props = {
     lastMoveIsCanceled: lastMoveIsCanceled(state),
     selectedMoveType: selectedMoveType(state),
@@ -171,8 +172,9 @@ const mapStateToProps = state => {
     backupContacts: state.serviceMember.currentBackupContacts || [],
     orders: state.orders.currentOrders || {},
     move: state.moves.currentMove || state.moves.latestMove || {},
+    hhg: selectShipment(state, shipmentId),
     ppm: getPPM(state),
-    currentShipment: shipment || {},
+    currentShipment: shipmentId || {},
     loggedInUser: state.loggedInUser.loggedInUser,
     loggedInUserIsLoading: state.loggedInUser.isLoading,
     loggedInUserError: state.loggedInUser.error,

--- a/src/scenes/MyMove/getWorkflowRoutes.jsx
+++ b/src/scenes/MyMove/getWorkflowRoutes.jsx
@@ -82,17 +82,17 @@ const isCurrentMoveSubmitted = ({ move, ppm }) => {
 const pages = {
   '/service-member/:serviceMemberId/create': {
     isInFlow: myFirstRodeo,
-    isComplete: sm => sm.is_profile_complete || every([sm.rank, sm.edipi, sm.affiliation]),
+    isComplete: ({ sm }) => sm.is_profile_complete || every([sm.rank, sm.edipi, sm.affiliation]),
     render: (key, pages) => ({ match }) => <DodInfo pages={pages} pageKey={key} match={match} />,
   },
   '/service-member/:serviceMemberId/name': {
     isInFlow: myFirstRodeo,
-    isComplete: sm => sm.is_profile_complete || every([sm.first_name, sm.last_name]),
+    isComplete: ({ sm }) => sm.is_profile_complete || every([sm.first_name, sm.last_name]),
     render: (key, pages) => ({ match }) => <SMName pages={pages} pageKey={key} match={match} />,
   },
   '/service-member/:serviceMemberId/contact-info': {
     isInFlow: myFirstRodeo,
-    isComplete: sm =>
+    isComplete: ({ sm }) =>
       sm.is_profile_complete ||
       (every([sm.telephone, sm.personal_email]) &&
         some([sm.phone_is_preferred, sm.email_is_preferred, sm.text_message_is_preferred])),
@@ -103,24 +103,24 @@ const pages = {
 
     // api for duty station always returns an object, even when duty station is not set
     // if there is no duty station, that object will have a null uuid
-    isComplete: sm => sm.is_profile_complete || get(sm, 'current_station.id', NULL_UUID) !== NULL_UUID,
+    isComplete: ({ sm }) => sm.is_profile_complete || get(sm, 'current_station.id', NULL_UUID) !== NULL_UUID,
     render: (key, pages) => ({ match }) => <DutyStation pages={pages} pageKey={key} match={match} />,
     description: 'current duty station',
   },
   '/service-member/:serviceMemberId/residence-address': {
     isInFlow: myFirstRodeo,
-    isComplete: sm => sm.is_profile_complete || Boolean(sm.residential_address),
+    isComplete: ({ sm }) => sm.is_profile_complete || Boolean(sm.residential_address),
     render: (key, pages) => ({ match }) => <ResidentialAddress pages={pages} pageKey={key} match={match} />,
   },
   '/service-member/:serviceMemberId/backup-mailing-address': {
     isInFlow: myFirstRodeo,
-    isComplete: sm => sm.is_profile_complete || Boolean(sm.backup_mailing_address),
+    isComplete: ({ sm }) => sm.is_profile_complete || Boolean(sm.backup_mailing_address),
     render: (key, pages) => ({ match }) => <BackupMailingAddress pages={pages} pageKey={key} match={match} />,
   },
   '/service-member/:serviceMemberId/backup-contacts': {
     isInFlow: myFirstRodeo,
-    isComplete: (sm, orders, move, ppm, hhg, backup_contacts) => {
-      return sm.is_profile_complete || backup_contacts.length > 0;
+    isComplete: ({ sm, orders, move, ppm, hhg, backupContacts }) => {
+      return sm.is_profile_complete || backupContacts.length > 0;
     },
     render: (key, pages) => ({ match }) => <BackupContact pages={pages} pageKey={key} match={match} />,
     description: 'Backup contacts',
@@ -141,7 +141,7 @@ const pages = {
   },
   '/orders/': {
     isInFlow: always,
-    isComplete: (sm, orders) =>
+    isComplete: ({ sm, orders }) =>
       every([
         orders.orders_type,
         orders.issue_date,
@@ -152,7 +152,7 @@ const pages = {
   },
   '/orders/upload': {
     isInFlow: always,
-    isComplete: (sm, orders, move, ppm) => get(orders, 'uploaded_orders.uploads', []).length > 0,
+    isComplete: ({ sm, orders }) => get(orders, 'uploaded_orders.uploads', []).length > 0,
     render: (key, pages) => ({ match }) => <UploadOrders pages={pages} pageKey={key} match={match} />,
     description: 'Upload your orders',
   },
@@ -169,86 +169,86 @@ const pages = {
   },
   '/moves/:moveId': {
     isInFlow: always,
-    isComplete: (sm, orders, move, ppm) => get(move, 'selected_move_type', null),
+    isComplete: ({ sm, orders, move }) => get(move, 'selected_move_type', null),
     render: (key, pages) => ({ match }) => <MoveType pages={pages} pageKey={key} match={match} />,
   },
   '/moves/:moveId/hhg-start': {
     isInFlow: hasHHG,
-    isComplete: (sm, orders, move, hhg) => {
-      return hhg && every([hhg.requested_pickup_date]);
+    isComplete: ({ sm, orders, move, hhg }) => {
+      return every([hhg.requested_pickup_date]);
     },
     render: (key, pages) => ({ match }) => <MoveDate pages={pages} pageKey={key} match={match} />,
   },
   '/moves/:moveId/hhg-locations': {
     isInFlow: hasHHG,
-    isComplete: (sm, orders, move, hhg) => {
+    isComplete: ({ sm, orders, move, hhg }) => {
       return every([hhg.pickup_address]);
     },
     render: (key, pages) => ({ match }) => <Locations pages={pages} pageKey={key} match={match} />,
   },
   '/moves/:moveId/hhg-weight': {
     isInFlow: hasHHG,
-    isComplete: (sm, orders, move, hhg) => {
+    isComplete: ({ sm, orders, move, hhg }) => {
       return every([hhg.weight_estimate]);
     },
     render: (key, pages) => ({ match }) => <WeightEstimate pages={pages} pageKey={key} match={match} />,
   },
   '/moves/:moveId/hhg-progear': {
     isInFlow: hasHHG,
-    isComplete: (sm, orders, move, hhg) => {
+    isComplete: ({ sm, orders, move, hhg }) => {
       return every([hhg.pickup_address]);
     },
     render: (key, pages) => ({ match }) => <Progear pages={pages} pageKey={key} match={match} />,
   },
   '/moves/:moveId/hhg-ppm-start': {
     isInFlow: hasHHGPPM,
-    isComplete: (sm, orders, move, ppm) => {
+    isComplete: ({ sm, orders, move, ppm }) => {
       return ppm && every([ppm.original_move_date, ppm.pickup_postal_code, ppm.destination_postal_code]);
     },
     render: key => ({ match }) => <PpmDateAndLocations pages={hhgPPMPages} pageKey={key} match={match} />,
   },
   '/moves/:moveId/hhg-ppm-size': {
     isInFlow: hasHHGPPM,
-    isComplete: (sm, orders, move, ppm) => !!ppm.size,
+    isComplete: ({ sm, orders, move, ppm }) => !!ppm.size,
     render: (key, pages) => ({ match }) => <PpmSize pages={hhgPPMPages} pageKey={key} match={match} />,
   },
   '/moves/:moveId/hhg-ppm-weight': {
     isInFlow: hasHHGPPM,
-    isComplete: (sm, orders, move, ppm) => get(ppm, 'weight_estimate', null),
+    isComplete: ({ sm, orders, move, ppm }) => get(ppm, 'weight_estimate', null),
     render: (key, pages) => ({ match }) => <PpmWeight pages={hhgPPMPages} pageKey={key} match={match} />,
   },
   '/moves/:moveId/ppm-start': {
     isInFlow: state => state.selectedMoveType === 'PPM',
-    isComplete: (sm, orders, move, ppm) => {
+    isComplete: ({ sm, orders, move, ppm }) => {
       return ppm && every([ppm.original_move_date, ppm.pickup_postal_code, ppm.destination_postal_code]);
     },
     render: (key, pages) => ({ match }) => <PpmDateAndLocations pages={pages} pageKey={key} match={match} />,
   },
   '/moves/:moveId/ppm-size': {
     isInFlow: hasPPM,
-    isComplete: (sm, orders, move, ppm) => get(ppm, 'size', null),
+    isComplete: ({ sm, orders, move, ppm }) => get(ppm, 'size', null),
     render: (key, pages) => ({ match }) => <PpmSize pages={pages} pageKey={key} match={match} />,
   },
   '/moves/:moveId/ppm-incentive': {
     isInFlow: hasPPM,
-    isComplete: (sm, orders, move, ppm) => get(ppm, 'weight_estimate', null),
+    isComplete: ({ sm, orders, move, ppm }) => get(ppm, 'weight_estimate', null),
     render: (key, pages) => ({ match }) => <PpmWeight pages={pages} pageKey={key} match={match} />,
   },
   '/moves/:moveId/review': {
     isInFlow: always,
-    isComplete: (sm, orders, move, ppm) => isCurrentMoveSubmitted(move, ppm),
+    isComplete: ({ sm, orders, move, ppm }) => isCurrentMoveSubmitted(move, ppm),
     render: (key, pages) => ({ match }) => <Review pages={pages} pageKey={key} match={match} />,
   },
   '/moves/:moveId/hhg-ppm-agreement': {
     isInFlow: hasHHGPPM,
-    isComplete: (sm, orders, move, ppm) => get(move, 'status', 'DRAFT') === 'SUBMITTED',
+    isComplete: ({ sm, orders, move }) => get(move, 'status', 'DRAFT') === 'SUBMITTED',
     render: (key, pages, description, props) => ({ match }) => {
       return <PpmAgreement pages={hhgPPMPages} pageKey={key} match={match} />;
     },
   },
   '/moves/:moveId/agreement': {
     isInFlow: ({ selectedMoveType }) => !hasHHGPPM({ selectedMoveType }),
-    isComplete: (sm, orders, move, ppm) => isCurrentMoveSubmitted(move, ppm),
+    isComplete: ({ sm, orders, move, ppm }) => isCurrentMoveSubmitted(move, ppm),
     render: (key, pages, description, props) => ({ match }) => {
       return <Agreement pages={pages} pageKey={key} match={match} />;
     },
@@ -285,7 +285,7 @@ export const getNextIncompletePage = ({
     pages,
     p =>
       p.isInFlow({ selectedMoveType, lastMoveIsCanceled }) &&
-      !p.isComplete(serviceMember, orders, move, ppm, hhg, backupContacts),
+      !p.isComplete({ sm: serviceMember, orders, move, ppm, hhg, backupContacts }),
   );
   const compiledPath = generatePath(rawPath, {
     serviceMemberId: get(serviceMember, 'id'),

--- a/src/shared/User/ducks.js
+++ b/src/shared/User/ducks.js
@@ -8,6 +8,7 @@ import { pick } from 'lodash';
 
 import { ordersArray } from 'shared/Entities/schema';
 import { addEntities } from 'shared/Entities/actions';
+import { getShipment } from 'shared/Entities/modules/shipments';
 
 const getLoggedInUserType = 'GET_LOGGED_IN_USER';
 
@@ -23,10 +24,14 @@ export const loadLoggedInUser = () => {
       .then(response => {
         if (response.service_member) {
           const data = normalize(response.service_member.orders, ordersArray);
+          if (data.entities.shipments) {
+            const shipmentIds = Object.keys(data.entities.shipments);
+            shipmentIds.map(id => dispatch(getShipment('Shipments.GetShipment', id)));
+          }
 
           // Only store shipments and addresses in a normalized way. This prevents
           // data duplication while we're using both Redux approaches.
-          const filtered = pick(data.entities, ['shipments', 'addresses']);
+          const filtered = pick(data.entities, ['addresses']);
           dispatch(addEntities(filtered));
         }
         return dispatch(getLoggedInActions.success(response));

--- a/src/shared/User/ducks.js
+++ b/src/shared/User/ducks.js
@@ -29,7 +29,7 @@ export const loadLoggedInUser = () => {
             shipmentIds.map(id => dispatch(getShipment('Shipments.GetShipment', id)));
           }
 
-          // Only store shipments and addresses in a normalized way. This prevents
+          // Only store addresses in a normalized way. This prevents
           // data duplication while we're using both Redux approaches.
           const filtered = pick(data.entities, ['addresses']);
           dispatch(addEntities(filtered));


### PR DESCRIPTION
## Description

The "Continue Move" button was not redirecting to the last part completed in the HHG flow. Update to redirect to the last page that the user did not completed in the flow.

## Setup

```sh
make client_test
make e2e_test
```

1) Login to the system as a new service member
2) Create a profile
3) Create an HHG move and complete at least one part the flow (i.e through pickup address).
4) Log out
5) Log back in and click "Continue Move". You should be taken to the last page in flow that is not complete.

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/163926386) 