### PR TITLE
Replace calls to time.Now() with non-holiday times.

### DIFF
--- a/pkg/dates/calculators.go
+++ b/pkg/dates/calculators.go
@@ -63,9 +63,5 @@ func CreateValidDatesBetweenTwoDates(startDate time.Time, endDate time.Time, inc
 // NextValidMoveDate returns next subsequent non-holiday weekday
 // This is mostly used for testing purposes
 func NextValidMoveDate(d time.Time, calendar *cal.Calendar) time.Time {
-	// Add days until we get a non-holiday weekday
-	for !calendar.IsWorkday(d) {
-		d = d.AddDate(0, 0, 1)
-	}
-	return d
+	return NextWorkday(*calendar, d)
 }

--- a/pkg/testdatagen/constants.go
+++ b/pkg/testdatagen/constants.go
@@ -89,5 +89,5 @@ var OneWeek = time.Hour * 168
 // Often weekends and holidays are not allowable dates
 var cal = dates.NewUSCalendar()
 
-// Now is the next valid move date
-var Now = dates.NextValidMoveDate(time.Now(), cal)
+// NextValidMoveDate is the next valid move date
+var NextValidMoveDate = dates.NextValidMoveDate(time.Now(), cal)

--- a/pkg/testdatagen/constants.go
+++ b/pkg/testdatagen/constants.go
@@ -2,6 +2,8 @@ package testdatagen
 
 import (
 	"time"
+
+	"github.com/transcom/mymove/pkg/dates"
 )
 
 // TestYear is the default year for testing.
@@ -83,3 +85,9 @@ var OneDay = time.Hour * 24
 
 // OneWeek creates a 1 week period
 var OneWeek = time.Hour * 168
+
+// Often weekends and holidays are not allowable dates
+var cal = dates.NewUSCalendar()
+
+// Now is the next valid move date
+var Now = dates.NextValidMoveDate(time.Now(), cal)

--- a/pkg/testdatagen/make_blackout_date_records.go
+++ b/pkg/testdatagen/make_blackout_date_records.go
@@ -38,8 +38,8 @@ func MakeBlackoutDate(db *pop.Connection, assertions Assertions) models.Blackout
 
 	blackoutDate := models.BlackoutDate{
 		TransportationServiceProviderID: tspID,
-		StartBlackoutDate:               Now,
-		EndBlackoutDate:                 Now,
+		StartBlackoutDate:               NextValidMoveDate,
+		EndBlackoutDate:                 NextValidMoveDate,
 		TrafficDistributionListID:       tdlID,
 		SourceGBLOC:                     stringPointer("PORK"),
 		Market:                          stringPointer("dHHG"),

--- a/pkg/testdatagen/make_blackout_date_records.go
+++ b/pkg/testdatagen/make_blackout_date_records.go
@@ -3,7 +3,6 @@ package testdatagen
 import (
 	"log"
 	"math/rand"
-	"time"
 
 	"github.com/gobuffalo/pop"
 
@@ -39,8 +38,8 @@ func MakeBlackoutDate(db *pop.Connection, assertions Assertions) models.Blackout
 
 	blackoutDate := models.BlackoutDate{
 		TransportationServiceProviderID: tspID,
-		StartBlackoutDate:               time.Now(),
-		EndBlackoutDate:                 time.Now(),
+		StartBlackoutDate:               Now,
+		EndBlackoutDate:                 Now,
 		TrafficDistributionListID:       tdlID,
 		SourceGBLOC:                     stringPointer("PORK"),
 		Market:                          stringPointer("dHHG"),

--- a/pkg/testdatagen/make_fuel_eia_diesel_price.go
+++ b/pkg/testdatagen/make_fuel_eia_diesel_price.go
@@ -21,9 +21,8 @@ func getFuelDefaultBaselines() []int64 {
 // getFuelDefaultDateRange returns the default start date and end year to use for
 // creating fuel prices
 func getFuelDefaultDateRange() (start time.Time, end time.Time) {
-	now := Now
 	// Set the end date as 1 year out
-	endDate := now.AddDate(1, 0, 0)
+	endDate := NextValidMoveDate.AddDate(1, 0, 0)
 	// Create rates starting with oldestStartDate
 	oldestYear := 2018
 	oldestMonth := time.January

--- a/pkg/testdatagen/make_fuel_eia_diesel_price.go
+++ b/pkg/testdatagen/make_fuel_eia_diesel_price.go
@@ -21,7 +21,7 @@ func getFuelDefaultBaselines() []int64 {
 // getFuelDefaultDateRange returns the default start date and end year to use for
 // creating fuel prices
 func getFuelDefaultDateRange() (start time.Time, end time.Time) {
-	now := time.Now()
+	now := Now
 	// Set the end date as 1 year out
 	endDate := now.AddDate(1, 0, 0)
 	// Create rates starting with oldestStartDate

--- a/pkg/testdatagen/make_invoice.go
+++ b/pkg/testdatagen/make_invoice.go
@@ -35,11 +35,11 @@ func MakeInvoice(db *pop.Connection, assertions Assertions) models.Invoice {
 		ApproverID:    approver.ID,
 		Approver:      approver,
 		InvoiceNumber: invoiceNumber,
-		InvoicedDate:  Now,
+		InvoicedDate:  NextValidMoveDate,
 		ShipmentID:    shipment.ID,
 		Shipment:      shipment,
-		CreatedAt:     Now,
-		UpdatedAt:     Now,
+		CreatedAt:     NextValidMoveDate,
+		UpdatedAt:     NextValidMoveDate,
 	}
 
 	// Overwrite values with those from assertions

--- a/pkg/testdatagen/make_invoice.go
+++ b/pkg/testdatagen/make_invoice.go
@@ -3,7 +3,6 @@ package testdatagen
 import (
 	"fmt"
 	"math/rand"
-	"time"
 
 	"github.com/gobuffalo/pop"
 	"github.com/pkg/errors"
@@ -36,11 +35,11 @@ func MakeInvoice(db *pop.Connection, assertions Assertions) models.Invoice {
 		ApproverID:    approver.ID,
 		Approver:      approver,
 		InvoiceNumber: invoiceNumber,
-		InvoicedDate:  time.Now(),
+		InvoicedDate:  Now,
 		ShipmentID:    shipment.ID,
 		Shipment:      shipment,
-		CreatedAt:     time.Now(),
-		UpdatedAt:     time.Now(),
+		CreatedAt:     Now,
+		UpdatedAt:     Now,
 	}
 
 	// Overwrite values with those from assertions

--- a/pkg/testdatagen/make_shipment_line_items.go
+++ b/pkg/testdatagen/make_shipment_line_items.go
@@ -2,7 +2,6 @@ package testdatagen
 
 import (
 	"log"
-	"time"
 
 	"github.com/gobuffalo/pop"
 	"github.com/transcom/mymove/pkg/models"
@@ -33,10 +32,10 @@ func MakeShipmentLineItem(db *pop.Connection, assertions Assertions) models.Ship
 		Quantity1:         unit.BaseQuantity(1670),
 		AppliedRate:       &rate,
 		Status:            models.ShipmentLineItemStatusSUBMITTED,
-		SubmittedDate:     time.Now(),
-		ApprovedDate:      time.Now(),
-		CreatedAt:         time.Now(),
-		UpdatedAt:         time.Now(),
+		SubmittedDate:     Now,
+		ApprovedDate:      Now,
+		CreatedAt:         Now,
+		UpdatedAt:         Now,
 	}
 
 	// Overwrite values with those from assertions

--- a/pkg/testdatagen/make_shipment_line_items.go
+++ b/pkg/testdatagen/make_shipment_line_items.go
@@ -32,10 +32,10 @@ func MakeShipmentLineItem(db *pop.Connection, assertions Assertions) models.Ship
 		Quantity1:         unit.BaseQuantity(1670),
 		AppliedRate:       &rate,
 		Status:            models.ShipmentLineItemStatusSUBMITTED,
-		SubmittedDate:     Now,
-		ApprovedDate:      Now,
-		CreatedAt:         Now,
-		UpdatedAt:         Now,
+		SubmittedDate:     NextValidMoveDate,
+		ApprovedDate:      NextValidMoveDate,
+		CreatedAt:         NextValidMoveDate,
+		UpdatedAt:         NextValidMoveDate,
 	}
 
 	// Overwrite values with those from assertions

--- a/pkg/testdatagen/make_storage_in_transit.go
+++ b/pkg/testdatagen/make_storage_in_transit.go
@@ -24,7 +24,7 @@ func MakeStorageInTransit(db *pop.Connection, assertions Assertions) models.Stor
 		ShipmentID:         shipment.ID,
 		Status:             models.StorageInTransitStatusREQUESTED,
 		Location:           models.StorageInTransitLocationDESTINATION,
-		EstimatedStartDate: Now,
+		EstimatedStartDate: NextValidMoveDate,
 		Notes:              swag.String("Shipper phoned to let us know he is delayed until next week."),
 		WarehouseID:        "000383",
 		WarehouseName:      "Hercules Hauling",

--- a/pkg/testdatagen/make_storage_in_transit.go
+++ b/pkg/testdatagen/make_storage_in_transit.go
@@ -1,8 +1,6 @@
 package testdatagen
 
 import (
-	"time"
-
 	"github.com/go-openapi/swag"
 	"github.com/gobuffalo/pop"
 
@@ -26,7 +24,7 @@ func MakeStorageInTransit(db *pop.Connection, assertions Assertions) models.Stor
 		ShipmentID:         shipment.ID,
 		Status:             models.StorageInTransitStatusREQUESTED,
 		Location:           models.StorageInTransitLocationDESTINATION,
-		EstimatedStartDate: time.Now(),
+		EstimatedStartDate: Now,
 		Notes:              swag.String("Shipper phoned to let us know he is delayed until next week."),
 		WarehouseID:        "000383",
 		WarehouseName:      "Hercules Hauling",

--- a/pkg/testdatagen/scenario/e2ebasic.go
+++ b/pkg/testdatagen/scenario/e2ebasic.go
@@ -38,15 +38,15 @@ var selectedMoveTypeHHGPPM = models.SelectedMoveTypeHHGPPM
 
 // Often weekends and holidays are not allowable dates
 var cal = dates.NewUSCalendar()
-var nowTime = dates.NextValidMoveDate(time.Now(), cal)
+var nextValidMoveDate = dates.NextValidMoveDate(time.Now(), cal)
 
-var nowPlusOne = dates.NextValidMoveDate(nowTime.AddDate(0, 0, 1), cal)
-var nowPlusFive = dates.NextValidMoveDate(nowTime.AddDate(0, 0, 5), cal)
-var nowPlusTen = dates.NextValidMoveDate(nowTime.AddDate(0, 0, 10), cal)
+var nextValidMoveDatePlusOne = dates.NextValidMoveDate(nextValidMoveDate.AddDate(0, 0, 1), cal)
+var nextValidMoveDatePlusFive = dates.NextValidMoveDate(nextValidMoveDate.AddDate(0, 0, 5), cal)
+var nextValidMoveDatePlusTen = dates.NextValidMoveDate(nextValidMoveDate.AddDate(0, 0, 10), cal)
 
-var nowMinusOne = dates.NextValidMoveDate(nowTime.AddDate(0, 0, -1), cal)
-var nowMinusFive = dates.NextValidMoveDate(nowTime.AddDate(0, 0, -5), cal)
-var nowMinusTen = dates.NextValidMoveDate(nowTime.AddDate(0, 0, -10), cal)
+var nextValidMoveDateMinusOne = dates.NextValidMoveDate(nextValidMoveDate.AddDate(0, 0, -1), cal)
+var nextValidMoveDateMinusFive = dates.NextValidMoveDate(nextValidMoveDate.AddDate(0, 0, -5), cal)
+var nextVAlidMoveDateMinusTen = dates.NextValidMoveDate(nextValidMoveDate.AddDate(0, 0, -10), cal)
 
 // Run does that data load thing
 func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, logger *zap.Logger, storer *storage.Memory) {
@@ -129,7 +129,7 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, log
 			Locator: "VGHEIS",
 		},
 		PersonallyProcuredMove: models.PersonallyProcuredMove{
-			PlannedMoveDate: &nowTime,
+			PlannedMoveDate: &nextValidMoveDate,
 			Advance:         &advance,
 			AdvanceID:       &advance.ID,
 		},
@@ -163,7 +163,7 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, log
 			Locator: "NOADVC",
 		},
 		PersonallyProcuredMove: models.PersonallyProcuredMove{
-			PlannedMoveDate: &nowTime,
+			PlannedMoveDate: &nextValidMoveDate,
 		},
 		Uploader: loader,
 	})
@@ -195,7 +195,7 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, log
 			Locator: "CANCEL",
 		},
 		PersonallyProcuredMove: models.PersonallyProcuredMove{
-			PlannedMoveDate: &nowTime,
+			PlannedMoveDate: &nextValidMoveDate,
 		},
 		Uploader: loader,
 	})
@@ -213,7 +213,7 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, log
 			LoginGovEmail: email,
 		},
 	})
-	pastTime := nowMinusTen
+	pastTime := nextVAlidMoveDateMinusTen
 	ppm1 := testdatagen.MakePPM(db, testdatagen.Assertions{
 		ServiceMember: models.ServiceMember{
 			ID:            uuid.FromStringOrNil("466c41b9-50bf-462c-b3cd-1ae33a2dad9b"),
@@ -247,7 +247,7 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, log
 			LoginGovEmail: email,
 		},
 	})
-	futureTime := nowPlusTen
+	futureTime := nextValidMoveDatePlusTen
 	typeDetail := internalmessages.OrdersTypeDetailPCSTDY
 	ppm2 := testdatagen.MakePPM(db, testdatagen.Assertions{
 		ServiceMember: models.ServiceMember{
@@ -353,7 +353,7 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, log
 			Locator: "PPMCAN",
 		},
 		PersonallyProcuredMove: models.PersonallyProcuredMove{
-			PlannedMoveDate: &nowTime,
+			PlannedMoveDate: &nextValidMoveDate,
 		},
 		Uploader: loader,
 	})
@@ -581,11 +581,11 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, log
 		Shipment: models.Shipment{
 			ID:                          uuid.FromStringOrNil("53ebebef-be58-41ce-9635-a4930149190d"),
 			Status:                      models.ShipmentStatusAWARDED,
-			PmSurveyPlannedPackDate:     &nowPlusOne,
-			PmSurveyConductedDate:       &nowPlusOne,
-			PmSurveyCompletedAt:         &nowPlusOne,
-			PmSurveyPlannedPickupDate:   &nowPlusFive,
-			PmSurveyPlannedDeliveryDate: &nowPlusTen,
+			PmSurveyPlannedPackDate:     &nextValidMoveDatePlusOne,
+			PmSurveyConductedDate:       &nextValidMoveDatePlusOne,
+			PmSurveyCompletedAt:         &nextValidMoveDatePlusOne,
+			PmSurveyPlannedPickupDate:   &nextValidMoveDatePlusFive,
+			PmSurveyPlannedDeliveryDate: &nextValidMoveDatePlusTen,
 			SourceGBLOC:                 &sourceOffice.Gbloc,
 			DestinationGBLOC:            &destOffice.Gbloc,
 		},
@@ -642,12 +642,12 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, log
 		Shipment: models.Shipment{
 			Status:                      models.ShipmentStatusACCEPTED,
 			HasDeliveryAddress:          true,
-			BookDate:                    &nowTime,
-			PmSurveyPlannedPackDate:     &nowPlusOne,
-			PmSurveyConductedDate:       &nowPlusOne,
-			PmSurveyCompletedAt:         &nowPlusOne,
-			PmSurveyPlannedPickupDate:   &nowPlusFive,
-			PmSurveyPlannedDeliveryDate: &nowPlusTen,
+			BookDate:                    &nextValidMoveDate,
+			PmSurveyPlannedPackDate:     &nextValidMoveDatePlusOne,
+			PmSurveyConductedDate:       &nextValidMoveDatePlusOne,
+			PmSurveyCompletedAt:         &nextValidMoveDatePlusOne,
+			PmSurveyPlannedPickupDate:   &nextValidMoveDatePlusFive,
+			PmSurveyPlannedDeliveryDate: &nextValidMoveDatePlusTen,
 		},
 		ShipmentOffer: models.ShipmentOffer{
 			TransportationServiceProviderID: tspUser.TransportationServiceProviderID,
@@ -689,12 +689,12 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, log
 		},
 		Shipment: models.Shipment{
 			Status:                      models.ShipmentStatusAWARDED,
-			BookDate:                    &nowTime,
-			PmSurveyPlannedPackDate:     &nowPlusOne,
-			PmSurveyConductedDate:       &nowPlusOne,
-			PmSurveyCompletedAt:         &nowPlusOne,
-			PmSurveyPlannedPickupDate:   &nowPlusFive,
-			PmSurveyPlannedDeliveryDate: &nowPlusTen,
+			BookDate:                    &nextValidMoveDate,
+			PmSurveyPlannedPackDate:     &nextValidMoveDatePlusOne,
+			PmSurveyConductedDate:       &nextValidMoveDatePlusOne,
+			PmSurveyCompletedAt:         &nextValidMoveDatePlusOne,
+			PmSurveyPlannedPickupDate:   &nextValidMoveDatePlusFive,
+			PmSurveyPlannedDeliveryDate: &nextValidMoveDatePlusTen,
 		},
 		ShipmentOffer: models.ShipmentOffer{
 			TransportationServiceProviderID: tspUser.TransportationServiceProviderID,
@@ -735,12 +735,12 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, log
 		},
 		Shipment: models.Shipment{
 			Status:                      models.ShipmentStatusAWARDED,
-			BookDate:                    &nowTime,
-			PmSurveyPlannedPackDate:     &nowPlusOne,
-			PmSurveyConductedDate:       &nowPlusOne,
-			PmSurveyCompletedAt:         &nowPlusOne,
-			PmSurveyPlannedPickupDate:   &nowPlusFive,
-			PmSurveyPlannedDeliveryDate: &nowPlusTen,
+			BookDate:                    &nextValidMoveDate,
+			PmSurveyPlannedPackDate:     &nextValidMoveDatePlusOne,
+			PmSurveyConductedDate:       &nextValidMoveDatePlusOne,
+			PmSurveyCompletedAt:         &nextValidMoveDatePlusOne,
+			PmSurveyPlannedPickupDate:   &nextValidMoveDatePlusFive,
+			PmSurveyPlannedDeliveryDate: &nextValidMoveDatePlusTen,
 		},
 		ShipmentOffer: models.ShipmentOffer{
 			TransportationServiceProviderID: tspUser.TransportationServiceProviderID,
@@ -781,11 +781,11 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, log
 		},
 		Shipment: models.Shipment{
 			Status:                      models.ShipmentStatusINTRANSIT,
-			BookDate:                    &nowMinusTen,
-			PmSurveyPlannedPackDate:     &nowMinusFive,
-			PmSurveyConductedDate:       &nowMinusFive,
-			PmSurveyPlannedPickupDate:   &nowMinusOne,
-			PmSurveyPlannedDeliveryDate: &nowPlusFive,
+			BookDate:                    &nextVAlidMoveDateMinusTen,
+			PmSurveyPlannedPackDate:     &nextValidMoveDateMinusFive,
+			PmSurveyConductedDate:       &nextValidMoveDateMinusFive,
+			PmSurveyPlannedPickupDate:   &nextValidMoveDateMinusOne,
+			PmSurveyPlannedDeliveryDate: &nextValidMoveDatePlusFive,
 		},
 		ShipmentOffer: models.ShipmentOffer{
 			TransportationServiceProviderID: tspUser.TransportationServiceProviderID,
@@ -827,7 +827,7 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, log
 		},
 		Shipment: models.Shipment{
 			Status:   models.ShipmentStatusAPPROVED,
-			BookDate: &nowTime,
+			BookDate: &nextValidMoveDate,
 		},
 		ShipmentOffer: models.ShipmentOffer{
 			TransportationServiceProviderID: tspUser.TransportationServiceProviderID,
@@ -1538,7 +1538,7 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, log
 	email = "enter@delivery.date"
 
 	netWeight := unit.Pound(2000)
-	actualPickupDate := nowTime
+	actualPickupDate := nextValidMoveDate
 	offer24 := testdatagen.MakeShipmentOffer(db, testdatagen.Assertions{
 		User: models.User{
 			ID:            uuid.Must(uuid.FromString("1af7ca19-8511-4c6e-a93b-144811c0fa7c")),
@@ -1854,10 +1854,10 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, log
 			HasDeliveryAddress: true,
 
 			PmSurveyMethod:              "PHONE",
-			PmSurveyPlannedPackDate:     &nowPlusOne,
-			PmSurveyPlannedPickupDate:   &nowPlusFive,
-			PmSurveyCompletedAt:         &nowPlusOne,
-			PmSurveyPlannedDeliveryDate: &nowPlusTen,
+			PmSurveyPlannedPackDate:     &nextValidMoveDatePlusOne,
+			PmSurveyPlannedPickupDate:   &nextValidMoveDatePlusFive,
+			PmSurveyCompletedAt:         &nextValidMoveDatePlusOne,
+			PmSurveyPlannedDeliveryDate: &nextValidMoveDatePlusTen,
 			PmSurveyWeightEstimate:      &weightEstimate,
 			SourceGBLOC:                 &sourceOffice.Gbloc,
 			DestinationGBLOC:            &destOffice.Gbloc,
@@ -1921,12 +1921,12 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, log
 		Shipment: models.Shipment{
 			ID:                          uuid.FromStringOrNil("53115e49-466e-42ee-85c6-9215add89cea"),
 			Status:                      models.ShipmentStatusACCEPTED,
-			PmSurveyConductedDate:       &nowPlusOne,
-			PmSurveyCompletedAt:         &nowPlusOne,
+			PmSurveyConductedDate:       &nextValidMoveDatePlusOne,
+			PmSurveyCompletedAt:         &nextValidMoveDatePlusOne,
 			PmSurveyMethod:              "PHONE",
-			PmSurveyPlannedPackDate:     &nowPlusOne,
-			PmSurveyPlannedPickupDate:   &nowPlusOne,
-			PmSurveyPlannedDeliveryDate: &nowPlusOne,
+			PmSurveyPlannedPackDate:     &nextValidMoveDatePlusOne,
+			PmSurveyPlannedPickupDate:   &nextValidMoveDatePlusOne,
+			PmSurveyPlannedDeliveryDate: &nextValidMoveDatePlusOne,
 			PmSurveyWeightEstimate:      &weightEstimate,
 			SourceGBLOC:                 &sourceOffice.Gbloc,
 			DestinationGBLOC:            &destOffice.Gbloc,
@@ -1982,7 +1982,7 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, log
 		},
 		Shipment: models.Shipment{
 			Status:   models.ShipmentStatusAWARDED,
-			BookDate: &nowTime,
+			BookDate: &nextValidMoveDate,
 		},
 		ShipmentOffer: models.ShipmentOffer{
 			TransportationServiceProviderID: tspUser.TransportationServiceProviderID,
@@ -2123,7 +2123,7 @@ func MakeHhgWithPpm(db *pop.Connection, tspUser models.TspUser, loader *uploader
 			ID: moveID,
 		},
 		PersonallyProcuredMove: models.PersonallyProcuredMove{
-			PlannedMoveDate: &nowTime,
+			PlannedMoveDate: &nextValidMoveDate,
 			MoveID:          moveID,
 		},
 		Uploader: loader,
@@ -2183,7 +2183,7 @@ func MakeHhgWithPpm(db *pop.Connection, tspUser models.TspUser, loader *uploader
 			ID: moveID2,
 		},
 		PersonallyProcuredMove: models.PersonallyProcuredMove{
-			PlannedMoveDate: &nowTime,
+			PlannedMoveDate: &nextValidMoveDate,
 			MoveID:          moveID2,
 		},
 		Uploader: loader,
@@ -2239,13 +2239,13 @@ func MakeHhgWithPpm(db *pop.Connection, tspUser models.TspUser, loader *uploader
 			HasDeliveryAddress: true,
 			GBLNumber:          models.StringPointer("LKNQ7123456"),
 
-			ActualPickupDate:            &nowMinusFive,
+			ActualPickupDate:            &nextValidMoveDateMinusFive,
 			PmSurveyMethod:              "PHONE",
-			PmSurveyPlannedPackDate:     &nowPlusOne,
-			PmSurveyPlannedPickupDate:   &nowPlusFive,
-			PmSurveyConductedDate:       &nowPlusOne,
-			PmSurveyCompletedAt:         &nowPlusOne,
-			PmSurveyPlannedDeliveryDate: &nowPlusTen,
+			PmSurveyPlannedPackDate:     &nextValidMoveDatePlusOne,
+			PmSurveyPlannedPickupDate:   &nextValidMoveDatePlusFive,
+			PmSurveyConductedDate:       &nextValidMoveDatePlusOne,
+			PmSurveyCompletedAt:         &nextValidMoveDatePlusOne,
+			PmSurveyPlannedDeliveryDate: &nextValidMoveDatePlusTen,
 			PmSurveyWeightEstimate:      &weightEstimate,
 			SourceGBLOC:                 &sourceOffice.Gbloc,
 			DestinationGBLOC:            &destOffice.Gbloc,
@@ -2263,7 +2263,7 @@ func MakeHhgWithPpm(db *pop.Connection, tspUser models.TspUser, loader *uploader
 			ID: moveID3,
 		},
 		PersonallyProcuredMove: models.PersonallyProcuredMove{
-			PlannedMoveDate: &nowTime,
+			PlannedMoveDate: &nextValidMoveDate,
 			MoveID:          moveID3,
 		},
 		Uploader: loader,
@@ -2309,13 +2309,13 @@ func MakeHhgWithPpm(db *pop.Connection, tspUser models.TspUser, loader *uploader
 			HasDeliveryAddress: true,
 			GBLNumber:          models.StringPointer("LKNQ7123456"),
 
-			ActualPickupDate:            &nowMinusFive,
+			ActualPickupDate:            &nextValidMoveDateMinusFive,
 			PmSurveyMethod:              "PHONE",
-			PmSurveyPlannedPackDate:     &nowPlusOne,
-			PmSurveyPlannedPickupDate:   &nowPlusFive,
-			PmSurveyConductedDate:       &nowPlusOne,
-			PmSurveyCompletedAt:         &nowPlusOne,
-			PmSurveyPlannedDeliveryDate: &nowPlusTen,
+			PmSurveyPlannedPackDate:     &nextValidMoveDatePlusOne,
+			PmSurveyPlannedPickupDate:   &nextValidMoveDatePlusFive,
+			PmSurveyConductedDate:       &nextValidMoveDatePlusOne,
+			PmSurveyCompletedAt:         &nextValidMoveDatePlusOne,
+			PmSurveyPlannedDeliveryDate: &nextValidMoveDatePlusTen,
 			PmSurveyWeightEstimate:      &weightEstimate,
 			SourceGBLOC:                 &sourceOffice.Gbloc,
 			DestinationGBLOC:            &destOffice.Gbloc,
@@ -2333,7 +2333,7 @@ func MakeHhgWithPpm(db *pop.Connection, tspUser models.TspUser, loader *uploader
 			ID: moveID4,
 		},
 		PersonallyProcuredMove: models.PersonallyProcuredMove{
-			PlannedMoveDate: &nowTime,
+			PlannedMoveDate: &nextValidMoveDate,
 			MoveID:          moveID4,
 		},
 		Uploader: loader,
@@ -2392,10 +2392,10 @@ func MakeHhgFromAwardedToAcceptedGBLReady(db *pop.Connection, tspUser models.Tsp
 			ID:                          uuid.FromStringOrNil("a4013cee-aa0a-41a3-b5f5-b9eed0758e1d 0xc42022c070"),
 			Status:                      models.ShipmentStatusAPPROVED,
 			PmSurveyMethod:              "PHONE",
-			PmSurveyPlannedPackDate:     &nowPlusOne,
-			PmSurveyPlannedPickupDate:   &nowPlusFive,
-			PmSurveyCompletedAt:         &nowPlusOne,
-			PmSurveyPlannedDeliveryDate: &nowPlusTen,
+			PmSurveyPlannedPackDate:     &nextValidMoveDatePlusOne,
+			PmSurveyPlannedPickupDate:   &nextValidMoveDatePlusFive,
+			PmSurveyCompletedAt:         &nextValidMoveDatePlusOne,
+			PmSurveyPlannedDeliveryDate: &nextValidMoveDatePlusTen,
 			PmSurveyWeightEstimate:      &weightEstimate,
 			SourceGBLOC:                 &sourceOffice.Gbloc,
 			DestinationGBLOC:            &destOffice.Gbloc,
@@ -2480,10 +2480,10 @@ func MakeHhgWithGBL(db *pop.Connection, tspUser models.TspUser, logger *zap.Logg
 			Status: models.ShipmentStatusAPPROVED,
 
 			PmSurveyMethod:              "PHONE",
-			PmSurveyPlannedPackDate:     &nowPlusOne,
-			PmSurveyPlannedPickupDate:   &nowPlusFive,
-			PmSurveyCompletedAt:         &nowPlusOne,
-			PmSurveyPlannedDeliveryDate: &nowPlusTen,
+			PmSurveyPlannedPackDate:     &nextValidMoveDatePlusOne,
+			PmSurveyPlannedPickupDate:   &nextValidMoveDatePlusFive,
+			PmSurveyCompletedAt:         &nextValidMoveDatePlusOne,
+			PmSurveyPlannedDeliveryDate: &nextValidMoveDatePlusTen,
 			PmSurveyWeightEstimate:      &weightEstimate,
 			SourceGBLOC:                 &sourceOffice.Gbloc,
 			DestinationGBLOC:            &destOffice.Gbloc,
@@ -2600,12 +2600,12 @@ func makeHhgReadyToInvoice(db *pop.Connection, tspUser models.TspUser, logger *z
 			ID:                          uuid.FromStringOrNil("67a3cbe7-4ae3-4f6a-9f9a-4f312e7458b9"),
 			Status:                      models.ShipmentStatusINTRANSIT,
 			PmSurveyMethod:              "PHONE",
-			PmSurveyPlannedPackDate:     &nowMinusTen,
-			PmSurveyPlannedPickupDate:   &nowMinusFive,
-			PmSurveyPlannedDeliveryDate: &nowMinusOne,
+			PmSurveyPlannedPackDate:     &nextVAlidMoveDateMinusTen,
+			PmSurveyPlannedPickupDate:   &nextValidMoveDateMinusFive,
+			PmSurveyPlannedDeliveryDate: &nextValidMoveDateMinusOne,
 			NetWeight:                   &netWeight,
-			ActualPickupDate:            &nowMinusFive,
-			OriginalDeliveryDate:        &nowMinusOne,
+			ActualPickupDate:            &nextValidMoveDateMinusFive,
+			OriginalDeliveryDate:        &nextValidMoveDateMinusOne,
 			PmSurveyWeightEstimate:      &weightEstimate,
 			SourceGBLOC:                 &sourceOffice.Gbloc,
 			DestinationGBLOC:            &destOffice.Gbloc,
@@ -2623,7 +2623,7 @@ func makeHhgReadyToInvoice(db *pop.Connection, tspUser models.TspUser, logger *z
 	verrs, err := shipmentservice.DeliverAndPriceShipment{
 		DB:     db,
 		Engine: engine,
-	}.Call(nowMinusOne, &offer.Shipment)
+	}.Call(nextValidMoveDateMinusOne, &offer.Shipment)
 
 	if verrs.HasAny() || err != nil {
 		fmt.Println(verrs.String())

--- a/pkg/testdatagen/scenario/e2ebasic.go
+++ b/pkg/testdatagen/scenario/e2ebasic.go
@@ -213,7 +213,7 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, log
 			LoginGovEmail: email,
 		},
 	})
-	pastTime := time.Now().AddDate(0, 0, -10)
+	pastTime := nowMinusTen
 	ppm1 := testdatagen.MakePPM(db, testdatagen.Assertions{
 		ServiceMember: models.ServiceMember{
 			ID:            uuid.FromStringOrNil("466c41b9-50bf-462c-b3cd-1ae33a2dad9b"),
@@ -247,7 +247,7 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, log
 			LoginGovEmail: email,
 		},
 	})
-	futureTime := time.Now().AddDate(0, 0, 10)
+	futureTime := nowPlusTen
 	typeDetail := internalmessages.OrdersTypeDetailPCSTDY
 	ppm2 := testdatagen.MakePPM(db, testdatagen.Assertions{
 		ServiceMember: models.ServiceMember{
@@ -1538,7 +1538,7 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, log
 	email = "enter@delivery.date"
 
 	netWeight := unit.Pound(2000)
-	actualPickupDate := time.Now()
+	actualPickupDate := nowTime
 	offer24 := testdatagen.MakeShipmentOffer(db, testdatagen.Assertions{
 		User: models.User{
 			ID:            uuid.Must(uuid.FromString("1af7ca19-8511-4c6e-a93b-144811c0fa7c")),


### PR DESCRIPTION
## Description

The integration tests are broken because we have some references to `time.Now()`, which happens to be a holiday today. This PR addresses the immediate issue but makes no attempt to resolve the underlying problem of needing a better way to access the current time in our code.