### PR TITLE
When deleting a shipment line item, also deletes associated dimensions items

### DIFF
--- a/pkg/handlers/publicapi/shipment_line_items_test.go
+++ b/pkg/handlers/publicapi/shipment_line_items_test.go
@@ -415,7 +415,7 @@ func (suite *HandlerSuite) TestDeleteShipmentLineItemCode105BE() {
 	numShipments := 1
 	numShipmentOfferSplit := []int{1}
 	status := []models.ShipmentStatus{models.ShipmentStatusSUBMITTED}
-	tspUsers, shipments, _, err := testdatagen.CreateShipmentOfferData(suite.DB(), numTspUsers, numShipments, numShipmentOfferSplit, status)
+	tspUsers, shipments, _, err := testdatagen.CreateShipmentOfferData(suite.DB(), numTspUsers, numShipments, numShipmentOfferSplit, status, models.SelectedMoveTypeHHG)
 	suite.NoError(err)
 
 	tspUser := tspUsers[0]

--- a/pkg/handlers/publicapi/shipment_line_items_test.go
+++ b/pkg/handlers/publicapi/shipment_line_items_test.go
@@ -409,6 +409,74 @@ func (suite *HandlerSuite) TestDeleteShipmentLineItemTSPHandler() {
 	}
 }
 
+func (suite *HandlerSuite) TestDeleteShipmentLineItemCode105BE() {
+
+	numTspUsers := 1
+	numShipments := 1
+	numShipmentOfferSplit := []int{1}
+	status := []models.ShipmentStatus{models.ShipmentStatusSUBMITTED}
+	tspUsers, shipments, _, err := testdatagen.CreateShipmentOfferData(suite.DB(), numTspUsers, numShipments, numShipmentOfferSplit, status)
+	suite.NoError(err)
+
+	tspUser := tspUsers[0]
+	shipment := shipments[0]
+
+	acc105B := testdatagen.MakeTariff400ngItem(suite.DB(), testdatagen.Assertions{
+		ShipmentLineItem: models.ShipmentLineItem{
+			ShipmentID: shipment.ID,
+		},
+		Tariff400ngItem: models.Tariff400ngItem{
+			Code:                "105B",
+			RequiresPreApproval: true,
+		},
+	})
+
+	notes := "It's a giant moose head named Fred he seemed rather pleasant"
+	baseParams := models.BaseShipmentLineItemParams{
+		Tariff400ngItemID:   acc105B.ID,
+		Tariff400ngItemCode: acc105B.Code,
+		Location:            "ORIGIN",
+		Notes:               &notes,
+	}
+	additionalParams := models.AdditionalShipmentLineItemParams{
+		ItemDimensions: &models.AdditionalLineItemDimensions{
+			Length: 100,
+			Width:  100,
+			Height: 100,
+		},
+		CrateDimensions: &models.AdditionalLineItemDimensions{
+			Length: 100,
+			Width:  100,
+			Height: 100,
+		},
+	}
+	// Given: Create 105B preapproval
+	shipmentLineItem, _, err := shipment.CreateShipmentLineItem(suite.DB(),
+		baseParams, additionalParams)
+
+	testdatagen.MakeDefaultShipmentLineItem(suite.DB())
+
+	// And: the context contains the auth values
+	req := httptest.NewRequest("DELETE", "/shipments", nil)
+	req = suite.AuthenticateTspRequest(req, tspUser)
+
+	params := accessorialop.DeleteShipmentLineItemParams{
+		HTTPRequest:        req,
+		ShipmentLineItemID: strfmt.UUID(shipmentLineItem.ID.String()),
+	}
+
+	// And: get shipment is returned
+	handler := DeleteShipmentLineItemHandler{handlers.NewHandlerContext(suite.DB(), suite.TestLogger())}
+	response := handler.Handle(params)
+
+	// Then: expect a 200 status code, and Crate Dimensions item should be deleted.
+	if suite.Assertions.IsType(&accessorialop.DeleteShipmentLineItemOK{}, response) {
+		// Check if we actually deleted the shipment line
+		err = suite.DB().Find(&shipmentLineItem.CrateDimensions, shipmentLineItem.CrateDimensions.ID)
+		suite.Error(err)
+	}
+}
+
 func (suite *HandlerSuite) TestDeleteShipmentLineItemOfficeHandler() {
 	officeUser := testdatagen.MakeDefaultOfficeUser(suite.DB())
 

--- a/pkg/models/shipment_line_item.go
+++ b/pkg/models/shipment_line_item.go
@@ -100,6 +100,25 @@ func (s *ShipmentLineItem) BeforeDestroy(tx *pop.Connection) error {
 	return nil
 }
 
+// AfterDestroy also destroys associated items in the dimensions table, if they exist
+func (s *ShipmentLineItem) AfterDestroy(tx *pop.Connection) error {
+
+	if s.ItemDimensionsID != nil {
+		err := tx.Destroy(&s.ItemDimensions)
+		if err != nil {
+			return ErrDestroyForbidden
+		}
+	}
+	if s.CrateDimensionsID != nil {
+		err := tx.Destroy(&s.CrateDimensions)
+		if err != nil {
+			return ErrDestroyForbidden
+		}
+	}
+
+	return nil
+}
+
 // FetchLineItemsByShipmentID returns a list of line items by shipment_id
 func FetchLineItemsByShipmentID(dbConnection *pop.Connection, shipmentID *uuid.UUID) ([]ShipmentLineItem, error) {
 	var err error


### PR DESCRIPTION
## Description

When a shipment line item is being deleted from the database, any items in the dimensions table associated with that shipment line item should also be deleted. 

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](./docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](./docs/backend.md#querying-the-database-safely)
 have been satisfied.
* [ ] There are no aXe warnings for UI.
* [ ] This works in IE.
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/163599575) for this change
