### PR TITLE
Installs Docker e2e dependencies using our package.json [delivers #164096469]

### DIFF
--- a/Dockerfile.cypress
+++ b/Dockerfile.cypress
@@ -1,5 +1,11 @@
 FROM cypress/base:10
-RUN yarn add cypress@~3.1.0 mocha mocha-multi-reporters mocha-junit-reporter
+
+
+# We use `npm install` here because you can't selectively `yarn install` packages and we don't care about a lockfile and
+# `yarn add` won't read from our existing package.json
+COPY package.json /package.json
+RUN npm install --save-dev mocha mocha-multi-reporters mocha-junit-reporter
+RUN npm install --save-dev --silent cypress
 
 COPY cypress/ /cypress
 COPY cypress.json /cypress.json


### PR DESCRIPTION
## Description

We've been `yarn add`ing our Cypress Docker dependencies which has let them drift out of sync from our locked down package versions. This PR imports our current package.json file and installs using those versions.

As stated in the comment, I didn't use `yarn` because
- `yarn add` won't read any of your lock files
- `yarn install` won't let you specify particular packages

I also silenced the Cypress output because it spit out 9000 lines from its installation/unzipping. The output is now something like
```
Step 4/9 : RUN npm install --save-dev --silent cypress
 ---> Running in b5c6ee9712e0
+ cypress@3.1.5
```