### PR TITLE
Updates app to allow office user to set origin and destination zip.

### DIFF
--- a/src/scenes/Office/Ppm/DatesAndLocationsPanel.jsx
+++ b/src/scenes/Office/Ppm/DatesAndLocationsPanel.jsx
@@ -16,6 +16,8 @@ const DatesAndLocationDisplay = props => {
   return (
     <div className="editable-panel-column">
       <PanelSwaggerField fieldName="actual_move_date" title="Departure date" required {...fieldProps} />
+      <PanelSwaggerField title="Pickup zip code" fieldName="pickup_postal_code" required {...fieldProps} />
+      <PanelSwaggerField title="Destination zip code" fieldName="destination_postal_code" required {...fieldProps} />
     </div>
   );
 };
@@ -24,10 +26,18 @@ const DatesAndLocationEdit = props => {
   const schema = props.ppmSchema;
   return (
     <div className="editable-panel-column">
+      <SwaggerField className="short-field" fieldName="actual_move_date" title="Departure date" swagger={schema} />
       <SwaggerField
         className="short-field"
-        fieldName="actual_move_date"
-        title="Departure date"
+        title="Pickup zip code"
+        fieldName="pickup_postal_code"
+        swagger={schema}
+        required
+      />
+      <SwaggerField
+        className="short-field"
+        title="Destination zip code"
+        fieldName="destination_postal_code"
         swagger={schema}
         required
       />
@@ -53,6 +63,8 @@ function mapStateToProps(state, props) {
     formValues,
     initialValues: {
       actual_move_date: ppm.actual_move_date,
+      pickup_postal_code: ppm.pickup_postal_code,
+      destination_postal_code: ppm.destination_postal_code,
     },
 
     ppmSchema: get(state, 'swaggerInternal.spec.definitions.PersonallyProcuredMovePayload'),

--- a/src/shared/EditablePanel/index.jsx
+++ b/src/shared/EditablePanel/index.jsx
@@ -144,6 +144,7 @@ export class EditablePanel extends Component {
       {
         'is-editable': this.props.isEditable,
       },
+      this.props.title.toLowerCase(),
       this.props.className,
     );
 


### PR DESCRIPTION
## Description

This PR introduces changes that allow an office user to set the origin and destination zip codes for a PPM. A user is now able to enter the origin and destination zip codes in the `Estimates` panel and see these saved changes reflect in the `Storage Calculator` and `Incentive Calculator` panels. 

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Setup

1. Run the API - `make server_run`
1. Run the office app - `make office_client_run`
1. Choose any PPM in the queue at `http://officelocal:3000/queues/ppm`
1. Edit the chosen PPM at `http://officelocal:3000/queues/new/moves/:moveId/basics`
- Change the origin and/or destination zip codes in the `Estimates` panel 
- Ensure that the updated changes to the zip code(s) have been properly reflected in the `StorageCalculator` and the `IncentiveCalculator`.

## Code Review Verification Steps

* [x] There are no aXe warnings for UI.
* [x] This works in IE.
* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/163770174) for this change
* [Redux Form Documentation explaining change](https://redux-form.com/6.0.2/examples/initializefromstate/)
