### PR TITLE
Use code of service from TDL instead of Shipment

### DIFF
--- a/pkg/handlers/internalapi/shipments.go
+++ b/pkg/handlers/internalapi/shipments.go
@@ -49,10 +49,6 @@ func payloadForShipmentModel(s models.Shipment) (*internalmessages.Shipment, err
 	// TODO: For now, we keep the Shipment structure the same but change where the CodeOfService
 	// TODO: is coming from.  Ultimately we should probably rework the structure below to more
 	// TODO: closely match the database structure.
-	var codeOfService *string
-	if s.TrafficDistributionList != nil {
-		codeOfService = &s.TrafficDistributionList.CodeOfService
-	}
 
 	var moveDatesSummary internalmessages.ShipmentMoveDatesSummary
 	if s.RequestedPickupDate != nil && s.EstimatedPackDays != nil && s.EstimatedTransitDays != nil {
@@ -74,7 +70,6 @@ func payloadForShipmentModel(s models.Shipment) (*internalmessages.Shipment, err
 		SourceGbloc:      payloadForGBLOC(s.SourceGBLOC),
 		DestinationGbloc: payloadForGBLOC(s.DestinationGBLOC),
 		Market:           payloadForMarkets(s.Market),
-		CodeOfService:    codeOfService,
 		CreatedAt:        strfmt.DateTime(s.CreatedAt),
 		UpdatedAt:        strfmt.DateTime(s.UpdatedAt),
 

--- a/pkg/handlers/internalapi/shipments_test.go
+++ b/pkg/handlers/internalapi/shipments_test.go
@@ -227,7 +227,6 @@ func (suite *HandlerSuite) TestCreateShipmentHandlerAllValues() {
 	suite.Equal(strfmt.UUID(move.ID.String()), createShipmentPayload.MoveID)
 	suite.Equal(strfmt.UUID(sm.ID.String()), createShipmentPayload.ServiceMemberID)
 	suite.Equal(internalmessages.ShipmentStatusDRAFT, createShipmentPayload.Status)
-	suite.Equal(swag.String("D"), createShipmentPayload.CodeOfService)
 	suite.Equal(internalmessages.ShipmentMarketDHHG, *createShipmentPayload.Market)
 	suite.EqualValues(3, *createShipmentPayload.EstimatedPackDays)
 	suite.EqualValues(12, *createShipmentPayload.EstimatedTransitDays)
@@ -285,7 +284,6 @@ func (suite *HandlerSuite) TestCreateShipmentHandlerEmpty() {
 	suite.Equal(strfmt.UUID(sm.ID.String()), unwrapped.Payload.ServiceMemberID)
 	suite.Equal(internalmessages.ShipmentStatusDRAFT, unwrapped.Payload.Status)
 	suite.Equal(internalmessages.ShipmentMarketDHHG, *unwrapped.Payload.Market)
-	suite.Nil(unwrapped.Payload.CodeOfService) // Won't be able to assign a TDL since we do not have a pickup address.
 	suite.Nil(unwrapped.Payload.EstimatedPackDays)
 	suite.Nil(unwrapped.Payload.EstimatedTransitDays)
 	suite.Nil(unwrapped.Payload.ActualPackDate)

--- a/src/scenes/Office/Hhg/RoutingPanel.jsx
+++ b/src/scenes/Office/Hhg/RoutingPanel.jsx
@@ -16,6 +16,10 @@ const RoutingPanelDisplay = props => {
     schema: props.shipmentSchema,
     values: props.shipment,
   };
+  const tdlFieldProps = {
+    schema: props.tdlSchema,
+    values: props.shipment.traffic_distribution_list,
+  };
   return (
     <div className="editable-panel-column">
       <PanelField title="Shipment type">HHG</PanelField>
@@ -24,20 +28,20 @@ const RoutingPanelDisplay = props => {
         <SwaggerValue fieldName="source_gbloc" {...fieldProps} /> -{' '}
         <SwaggerValue fieldName="destination_gbloc" {...fieldProps} />
       </PanelField>
-      <PanelSwaggerField title="Code of service" fieldName="code_of_service" {...fieldProps} />
+      <PanelSwaggerField title="Code of service" fieldName="code_of_service" {...tdlFieldProps} />
     </div>
   );
 };
 
 const RoutingPanelEdit = props => {
-  const { shipmentSchema } = props;
+  const { shipmentSchema, tdlSchema } = props;
   return (
     <div className="editable-panel-column">
       <PanelField title="Shipment type">HHG</PanelField>
       <PanelField title="Market">dHHG</PanelField>
       <SwaggerField title="Source GBLOC" fieldName="source_gbloc" swagger={shipmentSchema} required />
       <SwaggerField title="Destination GBLOC" fieldName="source_gbloc" swagger={shipmentSchema} required />
-      <SwaggerField title="Code of service" fieldName="code_of_service" swagger={shipmentSchema} required />
+      <SwaggerField title="Code of service" fieldName="code_of_service" swagger={tdlSchema} required />
     </div>
   );
 };
@@ -55,6 +59,7 @@ function mapStateToProps(state, ownProps) {
   return {
     initialValues: shipment,
     // Wrapper
+    tdlSchema: get(state, 'swaggerInternal.spec.definitions.TrafficDistributionList'),
     shipmentSchema: get(state, 'swaggerInternal.spec.definitions.Shipment', {}),
     hasError: state.office.shipmentHasLoadError || state.office.shipmentHasUpdateError,
     errorMessage: state.office.error,

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -1474,11 +1474,6 @@ definitions:
         format: uuid
         example: d56a4180-65aa-42ec-a945-5fd21dec0538
         readOnly: true
-      code_of_service:
-        type: string
-        x-nullable: true
-        title: Code of service
-        readOnly: true
       book_date:
         type: string
         format: date

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -1424,6 +1424,9 @@ definitions:
         enum:
           - D
           - '2'
+        x-display-value:
+          D: D
+          '2': '2'
     required:
       - source_rate_area
       - destination_region


### PR DESCRIPTION
## Description

Remove uses of code_of_service on the Shipment payload in favorite of code of service from tdl

## Reviewer Notes
- Code of service is arbitrary value D for now

## Setup
`make db_dev_e2e_populate`
`make server_run`
`make office_client_run`
View an HHG move, should have Code of Service: D

## Code Review Verification Steps
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/163410715) for this change

## Screenshots

![image](https://user-images.githubusercontent.com/13622298/53123186-5fd2ac80-350d-11e9-893f-ae0555b3f4b7.png)
