### PR TITLE
Sb standardize request pattern

### DIFF
--- a/src/scenes/Moves/Hhg/DatePicker.jsx
+++ b/src/scenes/Moves/Hhg/DatePicker.jsx
@@ -17,7 +17,6 @@ import LoadingPlaceholder from 'shared/LoadingPlaceholder';
 import { loadEntitlementsFromState } from 'shared/entitlements';
 import { getAvailableMoveDates, selectAvailableMoveDates } from 'shared/Entities/modules/calendar';
 
-const getMoveDatesSummaryLabel = 'DatePicker.getMoveDatesSummary';
 const getAvailableMoveDatesLabel = 'MoveDate.getAvailableMoveDates';
 
 function createModifiers(moveDates) {
@@ -52,7 +51,7 @@ export class HHGDatePicker extends Component {
     }
     const moveDate = formatSwaggerDate(day);
     this.props.input.onChange(moveDate);
-    this.props.getMoveDatesSummary(getMoveDatesSummaryLabel, this.props.moveID, moveDate);
+    this.props.getMoveDatesSummary(this.props.moveID, moveDate);
     this.setState({
       selectedDay: moveDate,
     });
@@ -78,11 +77,7 @@ export class HHGDatePicker extends Component {
       this.props.currentShipment.requested_pickup_date === this.props.input.value;
     if (this.props.currentShipment !== prevProps.currentShipment && this.props.currentShipment.requested_pickup_date) {
       if (!moveDateIsSavedDate) {
-        this.props.getMoveDatesSummary(
-          getMoveDatesSummaryLabel,
-          this.props.moveID,
-          this.props.currentShipment.requested_pickup_date,
-        );
+        this.props.getMoveDatesSummary(this.props.moveID, this.props.currentShipment.requested_pickup_date);
       }
       this.setState({
         selectedDay: this.props.input.value || this.props.currentShipment.requested_pickup_date,

--- a/src/scenes/Moves/Hhg/Locations.jsx
+++ b/src/scenes/Moves/Hhg/Locations.jsx
@@ -11,13 +11,11 @@ import Alert from 'shared/Alert';
 import { reduxifyWizardForm } from 'shared/WizardPage/Form';
 import Address from 'scenes/Moves/Hhg/Address';
 
-import { createOrUpdateShipment, getShipment } from 'shared/Entities/modules/shipments';
+import { createOrUpdateShipment, getShipment, getShipmentLabel } from 'shared/Entities/modules/shipments';
 
 import './ShipmentWizard.css';
 
 const formName = 'locations_form';
-const getRequestLabel = 'Locations.getShipment';
-const createOrUpdateRequestLabel = 'Locations.createOrUpdateShipment';
 
 const LocationsWizardForm = reduxifyWizardForm(formName);
 
@@ -35,7 +33,7 @@ export class Locations extends Component {
   loadShipment() {
     const shipmentID = get(this.props, 'currentShipment.id');
     if (shipmentID) {
-      this.props.getShipment(getRequestLabel, shipmentID, this.props.currentShipment.move_id);
+      this.props.getShipment(shipmentID, this.props.currentShipment.move_id);
     }
   }
 
@@ -45,7 +43,7 @@ export class Locations extends Component {
     const currentShipmentId = get(this.props, 'currentShipment.id');
 
     return this.props
-      .createOrUpdateShipment(createOrUpdateRequestLabel, moveId, shipment, currentShipmentId)
+      .createOrUpdateShipment(moveId, shipment, currentShipmentId)
       .then(action => {
         return this.props.setCurrentShipmentID(Object.keys(action.entities.shipments)[0]);
       })
@@ -107,7 +105,7 @@ function mapStateToProps(state) {
     formValues: getFormValues(formName)(state),
     currentShipment: shipment,
     initialValues: shipment,
-    error: getLastError(state, getRequestLabel),
+    error: getLastError(state, getShipmentLabel),
   };
   return props;
 }

--- a/src/scenes/Moves/Hhg/MoveDate.jsx
+++ b/src/scenes/Moves/Hhg/MoveDate.jsx
@@ -12,15 +12,13 @@ import { reduxifyWizardForm } from 'shared/WizardPage/Form';
 import DatePicker from 'scenes/Moves/Hhg/DatePicker';
 import { validateAdditionalFields } from 'shared/JsonSchemaForm';
 
-import { createOrUpdateShipment, getShipment } from 'shared/Entities/modules/shipments';
+import { createOrUpdateShipment, getShipment, getShipmentLabel } from 'shared/Entities/modules/shipments';
 
 import './ShipmentWizard.css';
 
 const validateMoveDateForm = validateAdditionalFields(['requested_pickup_date']);
 
 const formName = 'move_date_form';
-const getRequestLabel = 'MoveDate.getShipment';
-const createOrUpdateRequestLabel = 'MoveDate.createOrUpdateShipment';
 const MoveDateWizardForm = reduxifyWizardForm(formName, validateMoveDateForm);
 
 export class MoveDate extends Component {
@@ -37,7 +35,7 @@ export class MoveDate extends Component {
   loadShipment() {
     const shipmentID = get(this.props, 'currentShipment.id');
     if (shipmentID) {
-      this.props.getShipment(getRequestLabel, shipmentID, this.props.currentShipment.move_id);
+      this.props.getShipment(shipmentID, this.props.currentShipment.move_id);
     }
   }
 
@@ -47,7 +45,7 @@ export class MoveDate extends Component {
     const currentShipmentId = get(this.props, 'currentShipment.id');
 
     return this.props
-      .createOrUpdateShipment(createOrUpdateRequestLabel, moveId, shipment, currentShipmentId)
+      .createOrUpdateShipment(moveId, shipment, currentShipmentId)
       .then(action => {
         const id = Object.keys(action.entities.shipments)[0];
         return this.props.setCurrentShipmentID(id);
@@ -123,7 +121,7 @@ function mapStateToProps(state) {
     formValues: getFormValues(formName)(state),
     currentShipment: shipment,
     initialValues: shipment,
-    error: getLastError(state, getRequestLabel),
+    error: getLastError(state, getShipmentLabel),
   };
   return props;
 }

--- a/src/scenes/Moves/Hhg/Progear.jsx
+++ b/src/scenes/Moves/Hhg/Progear.jsx
@@ -10,7 +10,7 @@ import { getLastError, getInternalSwaggerDefinition } from 'shared/Swagger/selec
 import Alert from 'shared/Alert';
 import { reduxifyWizardForm } from 'shared/WizardPage/Form';
 
-import { createOrUpdateShipment, getShipment } from 'shared/Entities/modules/shipments';
+import { createOrUpdateShipment, getShipment, getShipmentLabel } from 'shared/Entities/modules/shipments';
 
 import './ShipmentWizard.css';
 import LoadingPlaceholder from 'shared/LoadingPlaceholder';
@@ -19,9 +19,6 @@ import { SwaggerField } from 'shared/JsonSchemaForm/JsonSchemaField';
 import { loadEntitlementsFromState } from 'shared/entitlements';
 
 const formName = 'progear_form';
-const getRequestLabel = 'progear.getShipment';
-const createOrUpdateRequestLabel = 'progear.createOrUpdateShipment';
-
 const ProgearWizardForm = reduxifyWizardForm(formName);
 
 export class Progear extends Component {
@@ -55,7 +52,7 @@ export class Progear extends Component {
   loadShipment() {
     const shipmentID = get(this.props, 'currentShipment.id');
     if (shipmentID) {
-      this.props.getShipment(getRequestLabel, shipmentID, this.props.currentShipment.move_id);
+      this.props.getShipment(shipmentID, this.props.currentShipment.move_id);
     }
   }
 
@@ -80,7 +77,7 @@ export class Progear extends Component {
     }
 
     return this.props
-      .createOrUpdateShipment(createOrUpdateRequestLabel, moveId, shipment, currentShipmentId)
+      .createOrUpdateShipment(moveId, shipment, currentShipmentId)
       .then(action => {
         const id = Object.keys(action.entities.shipments)[0];
         return this.props.setCurrentShipmentID(id);
@@ -234,7 +231,7 @@ function mapStateToProps(state) {
     formValues: getFormValues(formName)(state),
     currentShipment: shipment,
     initialValues: Object.assign({}, shipment, { has_pro_gear: initialHasProgear }),
-    error: getLastError(state, getRequestLabel),
+    error: getLastError(state, getShipmentLabel),
     entitlement: loadEntitlementsFromState(state),
   };
   return props;

--- a/src/scenes/Moves/Hhg/WeightEstimate.jsx
+++ b/src/scenes/Moves/Hhg/WeightEstimate.jsx
@@ -14,14 +14,11 @@ import { reduxifyWizardForm } from 'shared/WizardPage/Form';
 import { loadEntitlementsFromState } from 'shared/entitlements';
 import WeightCalculator from 'scenes/Moves/Hhg/WeightCalculator';
 
-import { createOrUpdateShipment, getShipment } from 'shared/Entities/modules/shipments';
+import { createOrUpdateShipment, getShipment, getShipmentLabel } from 'shared/Entities/modules/shipments';
 
 import './ShipmentWizard.css';
 
 const formName = 'weight_form';
-const getRequestLabel = 'WeightForm.getShipment';
-const createOrUpdateRequestLabel = 'WeightForm.createOrUpdateShipment';
-
 const ShipmentFormWizardForm = reduxifyWizardForm(formName);
 
 export class WeightEstimate extends Component {
@@ -53,7 +50,7 @@ export class WeightEstimate extends Component {
   loadShipment() {
     const shipmentID = get(this.props, 'currentShipment.id');
     if (shipmentID) {
-      this.props.getShipment(getRequestLabel, shipmentID, this.props.currentShipment.move_id);
+      this.props.getShipment(shipmentID, this.props.currentShipment.move_id);
     }
   }
 
@@ -63,7 +60,7 @@ export class WeightEstimate extends Component {
     const currentShipmentId = get(this.props, 'currentShipment.id');
 
     return this.props
-      .createOrUpdateShipment(createOrUpdateRequestLabel, moveId, shipment, currentShipmentId)
+      .createOrUpdateShipment(moveId, shipment, currentShipmentId)
       .then(action => {
         return this.props.setCurrentShipmentID(Object.keys(action.entities.shipments)[0]);
       })
@@ -192,7 +189,7 @@ function mapStateToProps(state) {
     formValues: getFormValues(formName)(state),
     currentShipment: shipment,
     initialValues: shipment,
-    error: getLastError(state, getRequestLabel),
+    error: getLastError(state, getShipmentLabel),
     entitlement: loadEntitlementsFromState(state),
   };
   return props;

--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -43,7 +43,7 @@ import {
   selectSortedShipmentLineItems,
   getShipmentLineItemsLabel,
 } from 'shared/Entities/modules/shipmentLineItems';
-import { getAllInvoices, getShipmentInvoicesLabel } from 'shared/Entities/modules/invoices';
+import { getAllInvoices } from 'shared/Entities/modules/invoices';
 import { loadPPMs, approvePPM, selectPPMForMove, selectReimbursement } from 'shared/Entities/modules/ppms';
 import { loadServiceMember, loadBackupContacts, selectServiceMember } from 'shared/Entities/modules/serviceMembers';
 import { loadOrders, loadOrdersLabel, selectOrders } from 'shared/Entities/modules/orders';
@@ -165,7 +165,7 @@ class MoveInfo extends Component {
     this.props.getTspForShipment(getTspForShipmentLabel, shipmentId);
     this.props.getPublicShipment('Shipments.getPublicShipment', shipmentId);
     this.props.getAllShipmentLineItems(getShipmentLineItemsLabel, shipmentId);
-    this.props.getAllInvoices(getShipmentInvoicesLabel, shipmentId);
+    this.props.getAllInvoices(shipmentId);
     this.props.getServiceAgentsForShipment(shipmentId);
   };
 

--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -159,7 +159,7 @@ class MoveInfo extends Component {
 
   getAllShipmentInfo = shipmentId => {
     this.props.getTspForShipment(getTspForShipmentLabel, shipmentId);
-    this.props.getPublicShipment('Shipments.getPublicShipment', shipmentId);
+    this.props.getPublicShipment(shipmentId);
     this.props.getAllShipmentLineItems(shipmentId);
     this.props.getAllInvoices(shipmentId);
     this.props.getServiceAgentsForShipment(shipmentId);

--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -38,11 +38,7 @@ import {
   selectTariff400ngItems,
   getTariff400ngItemsLabel,
 } from 'shared/Entities/modules/tariff400ngItems';
-import {
-  getAllShipmentLineItems,
-  selectSortedShipmentLineItems,
-  getShipmentLineItemsLabel,
-} from 'shared/Entities/modules/shipmentLineItems';
+import { getAllShipmentLineItems, selectSortedShipmentLineItems } from 'shared/Entities/modules/shipmentLineItems';
 import { getAllInvoices } from 'shared/Entities/modules/invoices';
 import { loadPPMs, approvePPM, selectPPMForMove, selectReimbursement } from 'shared/Entities/modules/ppms';
 import { loadServiceMember, loadBackupContacts, selectServiceMember } from 'shared/Entities/modules/serviceMembers';
@@ -164,7 +160,7 @@ class MoveInfo extends Component {
   getAllShipmentInfo = shipmentId => {
     this.props.getTspForShipment(getTspForShipmentLabel, shipmentId);
     this.props.getPublicShipment('Shipments.getPublicShipment', shipmentId);
-    this.props.getAllShipmentLineItems(getShipmentLineItemsLabel, shipmentId);
+    this.props.getAllShipmentLineItems(shipmentId);
     this.props.getAllInvoices(shipmentId);
     this.props.getServiceAgentsForShipment(shipmentId);
   };

--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -33,11 +33,7 @@ import PreApprovalPanel from 'shared/PreApprovalRequest/PreApprovalPanel.jsx';
 import InvoicePanel from 'shared/Invoice/InvoicePanel.jsx';
 
 import { getRequestStatus } from 'shared/Swagger/selectors';
-import {
-  getAllTariff400ngItems,
-  selectTariff400ngItems,
-  getTariff400ngItemsLabel,
-} from 'shared/Entities/modules/tariff400ngItems';
+import { getAllTariff400ngItems, selectTariff400ngItems } from 'shared/Entities/modules/tariff400ngItems';
 import { getAllShipmentLineItems, selectSortedShipmentLineItems } from 'shared/Entities/modules/shipmentLineItems';
 import { getAllInvoices } from 'shared/Entities/modules/invoices';
 import { loadPPMs, approvePPM, selectPPMForMove, selectReimbursement } from 'shared/Entities/modules/ppms';
@@ -140,7 +136,7 @@ class MoveInfo extends Component {
     const { moveId } = this.props;
     this.props.loadMove(moveId);
     this.props.getMoveDocumentsForMove(moveId);
-    this.props.getAllTariff400ngItems(true, getTariff400ngItemsLabel);
+    this.props.getAllTariff400ngItems(true);
     this.props.loadPPMs(moveId);
   }
 

--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -47,7 +47,7 @@ import {
   selectShipment,
   selectShipmentStatus,
 } from 'shared/Entities/modules/shipments';
-import { getTspForShipmentLabel, getTspForShipment } from 'shared/Entities/modules/transportationServiceProviders';
+import { getTspForShipment } from 'shared/Entities/modules/transportationServiceProviders';
 import { getServiceAgentsForShipment, selectServiceAgentsForShipment } from 'shared/Entities/modules/serviceAgents';
 
 import { showBanner, removeBanner } from './ducks';
@@ -154,7 +154,7 @@ class MoveInfo extends Component {
   }
 
   getAllShipmentInfo = shipmentId => {
-    this.props.getTspForShipment(getTspForShipmentLabel, shipmentId);
+    this.props.getTspForShipment(shipmentId);
     this.props.getPublicShipment(shipmentId);
     this.props.getAllShipmentLineItems(shipmentId);
     this.props.getAllInvoices(shipmentId);

--- a/src/scenes/Office/PremoveSurvey.jsx
+++ b/src/scenes/Office/PremoveSurvey.jsx
@@ -1,7 +1,6 @@
 // eslint-disable-next-line no-unused-vars
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
 import PropTypes from 'prop-types';
 import { get, pick } from 'lodash';
 import classNames from 'classnames';
@@ -292,8 +291,4 @@ function mapStateToProps(state, props) {
   };
 }
 
-function mapDispatchToProps(dispatch) {
-  return bindActionCreators({}, dispatch);
-}
-
-export default connect(mapStateToProps, mapDispatchToProps)(PremoveSurveyPanel);
+export default connect(mapStateToProps)(PremoveSurveyPanel);

--- a/src/scenes/Review/EditShipment.jsx
+++ b/src/scenes/Review/EditShipment.jsx
@@ -91,7 +91,6 @@ function mapStateToProps(state, ownProps) {
 }
 
 const getShipmentLabel = 'EditShipment.getShipment';
-const updateShipmentLabel = 'EditShipment.updateShipment';
 function mapDispatchToProps(dispatch, ownProps) {
   const shipmentID = ownProps.match.params.shipmentId;
   return {
@@ -99,7 +98,7 @@ function mapDispatchToProps(dispatch, ownProps) {
       dispatch(getShipment(getShipmentLabel, shipmentID));
     },
     updateShipment: function(values, shipment) {
-      dispatch(updateShipment(updateShipmentLabel, shipmentID, values)).then(function(action) {
+      dispatch(updateShipment(shipmentID, values)).then(function(action) {
         if (!action.error) {
           const moveID = Object.values(action.entities.shipments)[0].move_id;
           if (shipment.status !== 'DRAFT') {

--- a/src/scenes/TransportationServiceProvider/ContactInfo.jsx
+++ b/src/scenes/TransportationServiceProvider/ContactInfo.jsx
@@ -2,7 +2,6 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import {
-  getTspForShipmentLabel,
   getTspForShipment,
   selectTransportationServiceProviderForShipment,
 } from 'shared/Entities/modules/transportationServiceProviders';
@@ -11,8 +10,8 @@ import { getPublicShipment } from 'shared/Entities/modules/shipments';
 export class TransportationServiceProviderContactInfo extends Component {
   componentDidMount() {
     const shipmentId = this.props.shipmentId;
-    this.props.getTspForShipment(getTspForShipmentLabel, shipmentId);
-    this.props.getPublicShipment('Shipments.getPublicShipment', shipmentId);
+    this.props.getTspForShipment(shipmentId);
+    this.props.getPublicShipment(shipmentId);
   }
 
   render() {

--- a/src/scenes/TransportationServiceProvider/DocumentViewerContainer.jsx
+++ b/src/scenes/TransportationServiceProvider/DocumentViewerContainer.jsx
@@ -3,7 +3,6 @@ import { loadShipmentDependencies } from './ducks';
 import MoveDocumentView from 'shared/DocumentViewer/MoveDocumentView';
 import {
   getAllShipmentDocuments,
-  getShipmentDocumentsLabel,
   selectShipmentDocument,
   selectShipmentDocuments,
 } from 'shared/Entities/modules/shipmentDocuments';
@@ -42,7 +41,7 @@ const mapDispatchToProps = (dispatch, ownProps) => {
   return {
     onDidMount: () => {
       dispatch(loadShipmentDependencies(shipmentId));
-      dispatch(getAllShipmentDocuments(getShipmentDocumentsLabel, shipmentId));
+      dispatch(getAllShipmentDocuments(shipmentId));
     },
   };
 };

--- a/src/scenes/TransportationServiceProvider/NewDocumentContainer.jsx
+++ b/src/scenes/TransportationServiceProvider/NewDocumentContainer.jsx
@@ -3,8 +3,6 @@ import { loadShipmentDependencies } from './ducks';
 import NewDocumentView from 'shared/DocumentViewer/NewDocumentView';
 import {
   getAllShipmentDocuments,
-  getShipmentDocumentsLabel,
-  createShipmentDocumentLabel,
   createShipmentDocument,
   selectShipmentDocuments,
 } from 'shared/Entities/modules/shipmentDocuments';
@@ -38,10 +36,9 @@ const mapDispatchToProps = (dispatch, ownProps) => {
   return {
     onDidMount: () => {
       dispatch(loadShipmentDependencies(shipmentId));
-      dispatch(getAllShipmentDocuments(getShipmentDocumentsLabel, shipmentId));
+      dispatch(getAllShipmentDocuments(shipmentId));
     },
-    createShipmentDocument: (shipmentId, body) =>
-      dispatch(createShipmentDocument(createShipmentDocumentLabel, shipmentId, body)),
+    createShipmentDocument: (shipmentId, body) => dispatch(createShipmentDocument(shipmentId, body)),
   };
 };
 

--- a/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
+++ b/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
@@ -25,11 +25,7 @@ import {
   selectTariff400ngItems,
   getTariff400ngItemsLabel,
 } from 'shared/Entities/modules/tariff400ngItems';
-import {
-  getAllShipmentLineItems,
-  selectSortedShipmentLineItems,
-  getShipmentLineItemsLabel,
-} from 'shared/Entities/modules/shipmentLineItems';
+import { getAllShipmentLineItems, selectSortedShipmentLineItems } from 'shared/Entities/modules/shipmentLineItems';
 import { getAllInvoices } from 'shared/Entities/modules/invoices';
 import { getTspForShipmentLabel, getTspForShipment } from 'shared/Entities/modules/transportationServiceProviders';
 import { selectSitRequests } from 'shared/Entities/modules/sitRequests';
@@ -136,7 +132,7 @@ class ShipmentInfo extends Component {
         this.props.getTspForShipment(getTspForShipmentLabel, shipmentId);
         this.props.getAllShipmentDocuments(shipmentId);
         this.props.getAllTariff400ngItems(true, getTariff400ngItemsLabel);
-        this.props.getAllShipmentLineItems(getShipmentLineItemsLabel, shipmentId);
+        this.props.getAllShipmentLineItems(shipmentId);
         this.props.getAllInvoices(shipmentId);
       })
       .catch(err => {
@@ -178,7 +174,7 @@ class ShipmentInfo extends Component {
 
   deliverShipment = values => {
     this.props.deliverShipment(this.props.shipment.id, values).then(() => {
-      this.props.getAllShipmentLineItems(getShipmentLineItemsLabel, this.props.shipment.id);
+      this.props.getAllShipmentLineItems(this.props.shipment.id);
     });
   };
 

--- a/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
+++ b/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
@@ -17,8 +17,8 @@ import { SwaggerField } from 'shared/JsonSchemaForm/JsonSchemaField';
 import {
   getAllShipmentDocuments,
   selectShipmentDocuments,
-  getShipmentDocumentsLabel,
   generateGBL,
+  generateGBLLabel,
 } from 'shared/Entities/modules/shipmentDocuments';
 import {
   getAllTariff400ngItems,
@@ -65,8 +65,6 @@ import PremoveSurveyForm from './PremoveSurveyForm';
 import ServiceAgentForm from './ServiceAgentForm';
 
 import './tsp.css';
-
-const generateGblLabel = 'Shipments.createGovBillOfLading';
 
 const attachmentsErrorMessages = {
   400: 'An error occurred',
@@ -136,7 +134,7 @@ class ShipmentInfo extends Component {
       .then(() => {
         const shipmentId = this.props.shipment.id;
         this.props.getTspForShipment(getTspForShipmentLabel, shipmentId);
-        this.props.getAllShipmentDocuments(getShipmentDocumentsLabel, shipmentId);
+        this.props.getAllShipmentDocuments(shipmentId);
         this.props.getAllTariff400ngItems(true, getTariff400ngItemsLabel);
         this.props.getAllShipmentLineItems(getShipmentLineItemsLabel, shipmentId);
         this.props.getAllInvoices(shipmentId);
@@ -155,7 +153,7 @@ class ShipmentInfo extends Component {
   };
 
   generateGBL = () => {
-    return this.props.generateGBL(generateGblLabel, this.props.shipment.id);
+    return this.props.generateGBL(this.props.shipment.id);
   };
 
   enterPreMoveSurvey = values => {
@@ -479,9 +477,9 @@ const mapStateToProps = state => {
     loadTspDependenciesHasSuccess: get(state, 'tsp.loadTspDependenciesHasSuccess'),
     loadTspDependenciesHasError: get(state, 'tsp.loadTspDependenciesHasError'),
     acceptError: get(state, 'tsp.shipmentHasAcceptError'),
-    generateGBLSuccess: getLastRequestIsSuccess(state, generateGblLabel),
     generateGBLError: get(state, 'tsp.generateGBLError'),
-    generateGBLInProgress: getLastRequestIsLoading(state, generateGblLabel),
+    generateGBLInProgress: getLastRequestIsLoading(state, generateGBLLabel),
+    generateGBLSuccess: getLastRequestIsSuccess(state, generateGBLLabel),
     gblDocUrl: `/shipments/${shipment.id}/documents/${get(gbl, 'id')}`,
     error: get(state, 'tsp.error'),
     shipmentSchema: get(state, 'swaggerPublic.spec.definitions.Shipment', {}),

--- a/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
+++ b/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
@@ -23,7 +23,7 @@ import {
 import { getAllTariff400ngItems, selectTariff400ngItems } from 'shared/Entities/modules/tariff400ngItems';
 import { getAllShipmentLineItems, selectSortedShipmentLineItems } from 'shared/Entities/modules/shipmentLineItems';
 import { getAllInvoices } from 'shared/Entities/modules/invoices';
-import { getTspForShipmentLabel, getTspForShipment } from 'shared/Entities/modules/transportationServiceProviders';
+import { getTspForShipment } from 'shared/Entities/modules/transportationServiceProviders';
 import { selectSitRequests } from 'shared/Entities/modules/sitRequests';
 
 import FontAwesomeIcon from '@fortawesome/react-fontawesome';
@@ -125,7 +125,7 @@ class ShipmentInfo extends Component {
       .loadShipmentDependencies(this.props.match.params.shipmentId)
       .then(() => {
         const shipmentId = this.props.shipment.id;
-        this.props.getTspForShipment(getTspForShipmentLabel, shipmentId);
+        this.props.getTspForShipment(shipmentId);
         this.props.getAllShipmentDocuments(shipmentId);
         this.props.getAllTariff400ngItems(true);
         this.props.getAllShipmentLineItems(shipmentId);

--- a/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
+++ b/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
@@ -30,7 +30,7 @@ import {
   selectSortedShipmentLineItems,
   getShipmentLineItemsLabel,
 } from 'shared/Entities/modules/shipmentLineItems';
-import { getAllInvoices, getShipmentInvoicesLabel } from 'shared/Entities/modules/invoices';
+import { getAllInvoices } from 'shared/Entities/modules/invoices';
 import { getTspForShipmentLabel, getTspForShipment } from 'shared/Entities/modules/transportationServiceProviders';
 import { selectSitRequests } from 'shared/Entities/modules/sitRequests';
 
@@ -139,7 +139,7 @@ class ShipmentInfo extends Component {
         this.props.getAllShipmentDocuments(getShipmentDocumentsLabel, shipmentId);
         this.props.getAllTariff400ngItems(true, getTariff400ngItemsLabel);
         this.props.getAllShipmentLineItems(getShipmentLineItemsLabel, shipmentId);
-        this.props.getAllInvoices(getShipmentInvoicesLabel, shipmentId);
+        this.props.getAllInvoices(shipmentId);
       })
       .catch(err => {
         this.props.history.replace('/');

--- a/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
+++ b/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
@@ -20,11 +20,7 @@ import {
   generateGBL,
   generateGBLLabel,
 } from 'shared/Entities/modules/shipmentDocuments';
-import {
-  getAllTariff400ngItems,
-  selectTariff400ngItems,
-  getTariff400ngItemsLabel,
-} from 'shared/Entities/modules/tariff400ngItems';
+import { getAllTariff400ngItems, selectTariff400ngItems } from 'shared/Entities/modules/tariff400ngItems';
 import { getAllShipmentLineItems, selectSortedShipmentLineItems } from 'shared/Entities/modules/shipmentLineItems';
 import { getAllInvoices } from 'shared/Entities/modules/invoices';
 import { getTspForShipmentLabel, getTspForShipment } from 'shared/Entities/modules/transportationServiceProviders';
@@ -131,7 +127,7 @@ class ShipmentInfo extends Component {
         const shipmentId = this.props.shipment.id;
         this.props.getTspForShipment(getTspForShipmentLabel, shipmentId);
         this.props.getAllShipmentDocuments(shipmentId);
-        this.props.getAllTariff400ngItems(true, getTariff400ngItemsLabel);
+        this.props.getAllTariff400ngItems(true);
         this.props.getAllShipmentLineItems(shipmentId);
         this.props.getAllInvoices(shipmentId);
       })

--- a/src/shared/Entities/modules/invoices.js
+++ b/src/shared/Entities/modules/invoices.js
@@ -8,11 +8,11 @@ import { createSelector } from 'reselect';
 export const getShipmentInvoicesLabel = 'Shipments.getShipmentInvoices';
 export const createInvoiceLabel = 'Shipments.createAndSendHHGInvoice';
 
-export function createInvoice(label, shipmentId) {
+export function createInvoice(shipmentId, label = createInvoiceLabel) {
   return swaggerRequest(getClient, 'shipments.createAndSendHHGInvoice', { shipmentId }, { label });
 }
 
-export function getAllInvoices(label, shipmentId) {
+export function getAllInvoices(shipmentId, label = getShipmentInvoicesLabel) {
   return swaggerRequest(getPublicClient, 'shipments.getShipmentInvoices', { shipmentId }, { label });
 }
 

--- a/src/shared/Entities/modules/moves.js
+++ b/src/shared/Entities/modules/moves.js
@@ -34,8 +34,7 @@ export function getMoveDatesSummary(moveId, moveDate, label = getMoveDatesSummar
   return swaggerRequest(getClient, 'moves.showMoveDatesSummary', { moveId, moveDate }, { label });
 }
 
-export function approveBasics(moveId) {
-  const label = approveBasicsLabel;
+export function approveBasics(moveId, label = approveBasicsLabel) {
   const swaggerTag = 'office.approveMove';
   return swaggerRequest(getClient, swaggerTag, { moveId }, { label });
 }

--- a/src/shared/Entities/modules/moves.js
+++ b/src/shared/Entities/modules/moves.js
@@ -11,6 +11,7 @@ export const STATE_KEY = 'moves';
 const approveBasicsLabel = 'Moves.ApproveBasics';
 const cancelMoveLabel = 'Moves.CancelMove';
 export const loadMoveLabel = 'Moves.loadMove';
+export const getMoveDatesSummaryLabel = 'Moves.getMoveDatesSummary';
 
 export default function reducer(state = {}, action) {
   switch (action.type) {
@@ -29,7 +30,7 @@ export function loadMove(moveId, label = loadMoveLabel) {
   return swaggerRequest(getClient, 'moves.showMove', { moveId }, { label });
 }
 
-export function getMoveDatesSummary(label, moveId, moveDate) {
+export function getMoveDatesSummary(moveId, moveDate, label = getMoveDatesSummaryLabel) {
   return swaggerRequest(getClient, 'moves.showMoveDatesSummary', { moveId, moveDate }, { label });
 }
 
@@ -39,8 +40,7 @@ export function approveBasics(moveId) {
   return swaggerRequest(getClient, swaggerTag, { moveId }, { label });
 }
 
-export function cancelMove(moveId, cancelReason) {
-  const label = cancelMoveLabel;
+export function cancelMove(moveId, cancelReason, label = cancelMoveLabel) {
   const swaggerTag = 'office.cancelMove';
   const cancelMove = { cancel_reason: cancelReason };
   return swaggerRequest(getClient, swaggerTag, { moveId, cancelMove }, { label });

--- a/src/shared/Entities/modules/orders.js
+++ b/src/shared/Entities/modules/orders.js
@@ -22,14 +22,12 @@ export default function reducer(state = {}, action) {
   }
 }
 
-export function loadOrders(ordersId) {
-  const label = loadOrdersLabel;
+export function loadOrders(ordersId, label = loadOrdersLabel) {
   const swaggerTag = 'orders.showOrders';
   return swaggerRequest(getClient, swaggerTag, { ordersId }, { label });
 }
 
-export function updateOrders(ordersId, orders) {
-  const label = updateOrdersLabel;
+export function updateOrders(ordersId, orders, label = updateOrdersLabel) {
   const swaggerTag = 'orders.updateOrders';
   return swaggerRequest(getClient, swaggerTag, { ordersId, updateOrders: orders }, { label });
 }

--- a/src/shared/Entities/modules/ppms.js
+++ b/src/shared/Entities/modules/ppms.js
@@ -4,15 +4,16 @@ import { getClient } from 'shared/Swagger/api';
 
 const approvePpmLabel = 'PPMs.approvePPM';
 export const downloadPPMAttachmentsLabel = 'PPMs.downloadAttachments';
+const loadPPMsLabel = 'office.loadPPMs';
+const updatePPMLabel = 'office.updatePPM';
+const approveReimbursementLabel = 'office.approveReimbursement';
 
-export function approvePPM(personallyProcuredMoveId) {
-  const label = approvePpmLabel;
+export function approvePPM(personallyProcuredMoveId, label = approvePpmLabel) {
   const swaggerTag = 'office.approvePPM';
   return swaggerRequest(getClient, swaggerTag, { personallyProcuredMoveId }, { label });
 }
 
-export function loadPPMs(moveId) {
-  const label = 'office.loadPPMs';
+export function loadPPMs(moveId, label = loadPPMsLabel) {
   const swaggerTag = 'ppm.indexPersonallyProcuredMoves';
   return swaggerRequest(getClient, swaggerTag, { moveId }, { label });
 }
@@ -21,8 +22,8 @@ export function updatePPM(
   moveId,
   personallyProcuredMoveId,
   payload /*shape: {size, weightEstimate, estimatedIncentive}*/,
+  label = updatePPMLabel,
 ) {
-  const label = 'office.updatePPM';
   const swaggerTag = 'ppm.patchPersonallyProcuredMove';
   return swaggerRequest(
     getClient,
@@ -42,8 +43,7 @@ export function downloadPPMAttachments(ppmId, docTypes, label = downloadPPMAttac
   return swaggerRequest(getClient, swaggerTag, payload, { label });
 }
 
-export function approveReimbursement(reimbursementId) {
-  const label = 'office.approveReimbursement';
+export function approveReimbursement(reimbursementId, label = approveReimbursementLabel) {
   const swaggerTag = 'office.approveReimbursement';
   return swaggerRequest(getClient, swaggerTag, { reimbursementId }, { label });
 }

--- a/src/shared/Entities/modules/serviceAgents.js
+++ b/src/shared/Entities/modules/serviceAgents.js
@@ -4,22 +4,25 @@ import { getPublicClient } from 'shared/Swagger/api';
 const getServiceAgentsForShipmentLabel = 'ServiceAgents.getServiceAgentsForShipment';
 const updateServiceAgentForShipmentLabel = 'ServiceAgents.updateServiceAgentForShipment';
 
-export function getServiceAgentsForShipment(shipmentId) {
-  const label = getServiceAgentsForShipmentLabel;
+export function getServiceAgentsForShipment(shipmentId, label = getServiceAgentsForShipmentLabel) {
   const swaggerTag = 'service_agents.indexServiceAgents';
   return swaggerRequest(getPublicClient, swaggerTag, { shipmentId }, { label });
 }
 
-export function updateServiceAgentForShipment(shipmentId, serviceAgentId, serviceAgent) {
-  const label = updateServiceAgentForShipmentLabel;
+export function updateServiceAgentForShipment(
+  shipmentId,
+  serviceAgentId,
+  serviceAgent,
+  label = updateServiceAgentForShipmentLabel,
+) {
   const swaggerTag = 'service_agents.patchServiceAgent';
   return swaggerRequest(getPublicClient, swaggerTag, { shipmentId, serviceAgentId, serviceAgent }, { label });
 }
 
-export function updateServiceAgentsForShipment(shipmentId, serviceAgents) {
+export function updateServiceAgentsForShipment(shipmentId, serviceAgents, label = updateServiceAgentForShipmentLabel) {
   return async function(dispatch) {
     Object.values(serviceAgents).map(serviceAgent =>
-      dispatch(updateServiceAgentForShipment(shipmentId, serviceAgent.id, serviceAgent)),
+      dispatch(updateServiceAgentForShipment(shipmentId, serviceAgent.id, serviceAgent, label)),
     );
   };
 }

--- a/src/shared/Entities/modules/serviceMembers.js
+++ b/src/shared/Entities/modules/serviceMembers.js
@@ -6,14 +6,12 @@ const updateBackupContactLabel = 'ServiceMember.updateBackupContact';
 export const loadServiceMemberLabel = 'ServiceMember.loadServiceMember';
 export const updateServiceMemberLabel = 'ServiceMember.updateServiceMember';
 
-export function loadBackupContacts(serviceMemberId) {
-  const label = loadBackupContactsLabel;
+export function loadBackupContacts(serviceMemberId, label = loadBackupContactsLabel) {
   const swaggerTag = 'backup_contacts.indexServiceMemberBackupContacts';
   return swaggerRequest(getClient, swaggerTag, { serviceMemberId }, { label });
 }
 
-export function updateBackupContact(backupContactId, backupContact) {
-  const label = updateBackupContactLabel;
+export function updateBackupContact(backupContactId, backupContact, label = updateBackupContactLabel) {
   const swaggerTag = 'backup_contacts.updateServiceMemberBackupContact';
   return swaggerRequest(
     getClient,
@@ -23,14 +21,12 @@ export function updateBackupContact(backupContactId, backupContact) {
   );
 }
 
-export function loadServiceMember(serviceMemberId) {
-  const label = loadServiceMemberLabel;
+export function loadServiceMember(serviceMemberId, label = loadServiceMemberLabel) {
   const swaggerTag = 'service_members.showServiceMember';
   return swaggerRequest(getClient, swaggerTag, { serviceMemberId }, { label });
 }
 
-export function updateServiceMember(serviceMemberId, serviceMember) {
-  const label = updateServiceMemberLabel;
+export function updateServiceMember(serviceMemberId, serviceMember, label = updateServiceMemberLabel) {
   const swaggerTag = 'service_members.patchServiceMember';
   return swaggerRequest(
     getClient,

--- a/src/shared/Entities/modules/shipmentDocuments.js
+++ b/src/shared/Entities/modules/shipmentDocuments.js
@@ -4,14 +4,18 @@ import { moveDocuments } from '../schema';
 import { denormalize } from 'normalizr';
 
 export const getShipmentDocumentsLabel = 'Shipments.getAllShipmentDocuments';
+export const createShipmentDocumentLabel = 'MoveDocs.createShipmentDocuments';
+export const generateGBLLabel = 'Shipments.generateGBL';
 
-export function getAllShipmentDocuments(label, shipmentId) {
+export function getAllShipmentDocuments(shipmentId, label = getShipmentDocumentsLabel) {
   return swaggerRequest(getPublicClient, 'move_docs.indexMoveDocuments', { shipmentId }, { label });
 }
 
-export const createShipmentDocumentLabel = 'MoveDocs.createShipmentDocuments';
-
-export function createShipmentDocument(label, shipmentId, createGenericMoveDocumentPayload) {
+export function createShipmentDocument(
+  shipmentId,
+  createGenericMoveDocumentPayload,
+  label = createShipmentDocumentLabel,
+) {
   return swaggerRequest(
     getPublicClient,
     'move_docs.createGenericMoveDocument',
@@ -20,7 +24,7 @@ export function createShipmentDocument(label, shipmentId, createGenericMoveDocum
   );
 }
 
-export function generateGBL(label, shipmentId) {
+export function generateGBL(shipmentId, label = generateGBLLabel) {
   return swaggerRequest(getPublicClient, 'shipments.createGovBillOfLading', { shipmentId }, { label });
 }
 

--- a/src/shared/Entities/modules/shipmentLineItems.js
+++ b/src/shared/Entities/modules/shipmentLineItems.js
@@ -5,11 +5,17 @@ import { denormalize } from 'normalizr';
 import { get, orderBy, filter, map, keys, flow } from 'lodash';
 import { createSelector } from 'reselect';
 
-export function createShipmentLineItem(label, shipmentId, payload) {
+export const getShipmentLineItemsLabel = 'ShipmentLineItems.getAllShipmentLineItems';
+export const createShipmentLineItemLabel = 'ShipmentLineItems.createShipmentLineItem';
+export const deleteShipmentLineItemLabel = 'ShipmentLineItems.deleteShipmentLineItem';
+export const approveShipmentLineItemLabel = 'ShipmentLineItems.approveShipmentLineItem';
+export const updateShipmentLineItemLabel = 'ShipmentLineItems.updateShipmentLineItem';
+
+export function createShipmentLineItem(shipmentId, payload, label = createShipmentLineItemLabel) {
   return swaggerRequest(getPublicClient, 'accessorials.createShipmentLineItem', { shipmentId, payload }, { label });
 }
 
-export function updateShipmentLineItem(label, shipmentLineItemId, payload) {
+export function updateShipmentLineItem(shipmentLineItemId, payload, label = updateShipmentLineItemLabel) {
   return swaggerRequest(
     getPublicClient,
     'accessorials.updateShipmentLineItem',
@@ -18,15 +24,15 @@ export function updateShipmentLineItem(label, shipmentLineItemId, payload) {
   );
 }
 
-export function deleteShipmentLineItem(label, shipmentLineItemId) {
+export function deleteShipmentLineItem(shipmentLineItemId, label = deleteShipmentLineItemLabel) {
   return swaggerRequest(getPublicClient, 'accessorials.deleteShipmentLineItem', { shipmentLineItemId }, { label });
 }
 
-export function approveShipmentLineItem(label, shipmentLineItemId) {
+export function approveShipmentLineItem(shipmentLineItemId, label = approveShipmentLineItemLabel) {
   return swaggerRequest(getPublicClient, 'accessorials.approveShipmentLineItem', { shipmentLineItemId }, { label });
 }
 
-export function getAllShipmentLineItems(label, shipmentId) {
+export function getAllShipmentLineItems(shipmentId, label = getShipmentLineItemsLabel) {
   return swaggerRequest(getPublicClient, 'accessorials.getShipmentLineItems', { shipmentId }, { label });
 }
 
@@ -72,12 +78,6 @@ export const selectSortedPreApprovalShipmentLineItems = createSelector(
   [selectSortedShipmentLineItems],
   shipmentLineItems => filter(shipmentLineItems, lineItem => lineItem.tariff400ng_item.requires_pre_approval),
 );
-
-export const getShipmentLineItemsLabel = 'ShipmentLineItems.getAllShipmentLineItems';
-export const createShipmentLineItemLabel = 'ShipmentLineItems.createShipmentLineItem';
-export const deleteShipmentLineItemLabel = 'ShipmentLineItems.deleteShipmentLineItem';
-export const approveShipmentLineItemLabel = 'ShipmentLineItems.approveShipmentLineItem';
-export const updateShipmentLineItemLabel = 'ShipmentLineItems.updateShipmentLineItem';
 
 export const selectShipmentLineItem = (state, id) => denormalize([id], ShipmentLineItemsModel, state.entities)[0];
 

--- a/src/shared/Entities/modules/shipments.js
+++ b/src/shared/Entities/modules/shipments.js
@@ -6,35 +6,40 @@ import { getClient, getPublicClient } from 'shared/Swagger/api';
 
 const approveShipmentLabel = 'Shipments.approveShipment';
 const completeShipmentLabel = 'Shipments.completeShipment';
+export const getShipmentLabel = 'Shipments.getShipment';
+const getPublicShipmentLabel = 'Shipments.getPublicShipment';
+const createShipmentLabel = 'Shipments.createShipment';
+const updateShipmentLabel = 'shipments.updateShipment';
+const updatePublicShipmentLabel = 'shipments.updatePublicShipment';
 
-export function createOrUpdateShipment(label, moveId, shipment, id) {
+export function createOrUpdateShipment(moveId, shipment, id, label) {
   if (id) {
-    return updateShipment(label, id, shipment);
+    return updateShipment(id, shipment, label);
   } else {
-    return createShipment(label, moveId, shipment);
+    return createShipment(moveId, shipment, label);
   }
 }
 
-export function getShipment(label, shipmentId) {
+export function getShipment(shipmentId, label = getShipmentLabel) {
   return swaggerRequest(getClient, 'shipments.getShipment', { shipmentId }, { label });
 }
 
-export function getPublicShipment(label, shipmentId) {
+export function getPublicShipment(shipmentId, label = getPublicShipmentLabel) {
   return swaggerRequest(getPublicClient, 'shipments.getShipment', { shipmentId }, { label });
 }
 
 export function createShipment(
-  label,
   moveId,
   shipment /*shape: {pickup_address, requested_pickup_date, weight_estimate}*/,
+  label = createShipmentLabel,
 ) {
   return swaggerRequest(getClient, 'shipments.createShipment', { moveId, shipment }, { label });
 }
 
 export function updateShipment(
-  label,
   shipmentId,
   shipment /*shape: {pickup_address, requested_pickup_date, weight_estimate}*/,
+  label = updateShipmentLabel,
 ) {
   return swaggerRequest(getClient, 'shipments.patchShipment', { shipmentId, shipment }, { label });
 }
@@ -42,19 +47,17 @@ export function updateShipment(
 export function updatePublicShipment(
   shipmentId,
   shipment /*shape: {pickup_address, requested_pickup_date, weight_estimate}*/,
-  label = 'shipments.updateShipment',
+  label = updatePublicShipmentLabel,
 ) {
   return swaggerRequest(getPublicClient, 'shipments.patchShipment', { shipmentId, update: shipment }, { label });
 }
 
-export function approveShipment(shipmentId) {
-  const label = approveShipmentLabel;
+export function approveShipment(shipmentId, label = approveShipmentLabel) {
   const swaggerTag = 'shipments.approveHHG';
   return swaggerRequest(getClient, swaggerTag, { shipmentId }, { label });
 }
 
-export function completeShipment(shipmentId) {
-  const label = completeShipmentLabel;
+export function completeShipment(shipmentId, label = completeShipmentLabel) {
   const swaggerTag = 'shipments.completeHHG';
   return swaggerRequest(getClient, swaggerTag, { shipmentId }, { label });
 }

--- a/src/shared/Entities/modules/tariff400ngItems.js
+++ b/src/shared/Entities/modules/tariff400ngItems.js
@@ -5,7 +5,9 @@ import { tariff400ngItems } from '../schema';
 import { denormalize } from 'normalizr';
 import { createSelector } from 'reselect';
 
-export function getAllTariff400ngItems(requires_pre_approval, label) {
+export const getTariff400ngItemsLabel = 'Tariff400ngItem.getAlltariff400ngItems';
+
+export function getAllTariff400ngItems(requires_pre_approval, label = getTariff400ngItemsLabel) {
   return swaggerRequest(getPublicClient, 'accessorials.getTariff400ngItems', { requires_pre_approval }, { label });
 }
 
@@ -20,7 +22,5 @@ export const selectSortedTariff400ngItems = createSelector([selectTariff400ngIte
 export const selectSortedPreApprovalTariff400ngItems = createSelector([selectSortedTariff400ngItems], items =>
   filter(items, item => item.requires_pre_approval),
 );
-
-export const getTariff400ngItemsLabel = 'Tariff400ngItem.getAlltariff400ngItems';
 
 export const selectTariff400ngItem = (state, id) => denormalize([id], tariff400ngItems, state.entities)[0];

--- a/src/shared/Entities/modules/transportationServiceProviders.js
+++ b/src/shared/Entities/modules/transportationServiceProviders.js
@@ -4,7 +4,7 @@ import { get } from 'lodash';
 
 export const getTspForShipmentLabel = 'Shipments.getTspForShipment';
 
-export function getTspForShipment(label, shipmentId) {
+export function getTspForShipment(shipmentId, label = getTspForShipmentLabel) {
   return swaggerRequest(
     getPublicClient,
     'transportation_service_provider.getTransportationServiceProvider',

--- a/src/shared/Entities/modules/uploads.js
+++ b/src/shared/Entities/modules/uploads.js
@@ -21,7 +21,7 @@ export default function reducer(state = {}, action) {
 
 export const createShipmentDocumentLabel = 'Uploads.createShipmentDocument';
 
-export function createShipmentDocument(label, shipmentId, createGenericMoveDocument) {
+export function createShipmentDocument(shipmentId, createGenericMoveDocument, label = createShipmentDocumentLabel) {
   return swaggerRequest(
     getPublicClient,
     'move_docs.createGenericMoveDocument',

--- a/src/shared/Invoice/InvoicePanel.jsx
+++ b/src/shared/Invoice/InvoicePanel.jsx
@@ -16,7 +16,6 @@ import {
   selectSortedInvoices,
   createInvoice,
   createInvoiceLabel,
-  getShipmentInvoicesLabel,
   getAllInvoices,
 } from 'shared/Entities/modules/invoices';
 import UnbilledTable from 'shared/Invoice/UnbilledTable';
@@ -39,7 +38,7 @@ export class InvoicePanel extends PureComponent {
   approvePayment = () => {
     this.setState({ createInvoiceRequestStatus: isLoading });
     return this.props
-      .createInvoice(createInvoiceLabel, this.props.shipmentId)
+      .createInvoice(this.props.shipmentId)
       .then(() => {
         this.setState({ createInvoiceRequestStatus: isSuccess });
         return this.props.getAllShipmentLineItems(getShipmentLineItemsLabel, this.props.shipmentId);
@@ -48,7 +47,7 @@ export class InvoicePanel extends PureComponent {
         this.setState({ createInvoiceRequestStatus: isError });
         let httpResCode = get(err, 'response.status');
         if (httpResCode === 409) {
-          this.props.getAllInvoices(getShipmentInvoicesLabel, this.props.shipmentId);
+          this.props.getAllInvoices(this.props.shipmentId);
           return this.props.getAllShipmentLineItems(getShipmentLineItemsLabel, this.props.shipmentId);
         }
       });

--- a/src/shared/Invoice/InvoicePanel.jsx
+++ b/src/shared/Invoice/InvoicePanel.jsx
@@ -10,7 +10,6 @@ import {
   selectUnbilledShipmentLineItems,
   selectTotalFromUnbilledLineItems,
   getAllShipmentLineItems,
-  getShipmentLineItemsLabel,
 } from 'shared/Entities/modules/shipmentLineItems';
 import {
   selectSortedInvoices,
@@ -41,14 +40,14 @@ export class InvoicePanel extends PureComponent {
       .createInvoice(this.props.shipmentId)
       .then(() => {
         this.setState({ createInvoiceRequestStatus: isSuccess });
-        return this.props.getAllShipmentLineItems(getShipmentLineItemsLabel, this.props.shipmentId);
+        return this.props.getAllShipmentLineItems(this.props.shipmentId);
       })
       .catch(err => {
         this.setState({ createInvoiceRequestStatus: isError });
         let httpResCode = get(err, 'response.status');
         if (httpResCode === 409) {
           this.props.getAllInvoices(this.props.shipmentId);
-          return this.props.getAllShipmentLineItems(getShipmentLineItemsLabel, this.props.shipmentId);
+          return this.props.getAllShipmentLineItems(this.props.shipmentId);
         }
       });
   };

--- a/src/shared/PreApprovalRequest/PreApprovalPanel.jsx
+++ b/src/shared/PreApprovalRequest/PreApprovalPanel.jsx
@@ -12,13 +12,9 @@ import Creator from 'shared/PreApprovalRequest/Creator';
 
 import {
   createShipmentLineItem,
-  createShipmentLineItemLabel,
   deleteShipmentLineItem,
-  deleteShipmentLineItemLabel,
   approveShipmentLineItem,
-  approveShipmentLineItemLabel,
   updateShipmentLineItem,
-  updateShipmentLineItemLabel,
 } from 'shared/Entities/modules/shipmentLineItems';
 import { selectSortedPreApprovalShipmentLineItems } from 'shared/Entities/modules/shipmentLineItems';
 import { selectSortedPreApprovalTariff400ngItems } from 'shared/Entities/modules/tariff400ngItems';
@@ -36,18 +32,18 @@ export class PreApprovalPanel extends Component {
     this.setState({ error: null });
   };
   onSubmit = createPayload => {
-    return this.props.createShipmentLineItem(createShipmentLineItemLabel, this.props.shipmentId, createPayload);
+    return this.props.createShipmentLineItem(this.props.shipmentId, createPayload);
   };
   onEdit = (shipmentLineItemId, editPayload) => {
-    this.props.updateShipmentLineItem(updateShipmentLineItemLabel, shipmentLineItemId, editPayload);
+    this.props.updateShipmentLineItem(shipmentLineItemId, editPayload);
   };
   onDelete = shipmentLineItemId => {
-    this.props.deleteShipmentLineItem(deleteShipmentLineItemLabel, shipmentLineItemId).catch(err => {
+    this.props.deleteShipmentLineItem(shipmentLineItemId).catch(err => {
       this.setState({ error: true });
     });
   };
   onApproval = shipmentLineItemId => {
-    this.props.approveShipmentLineItem(approveShipmentLineItemLabel, shipmentLineItemId);
+    this.props.approveShipmentLineItem(shipmentLineItemId);
   };
   onFormActivation = isFormActive => {
     this.setState({ isRequestActionable: !isFormActive });

--- a/src/shared/User/ducks.js
+++ b/src/shared/User/ducks.js
@@ -26,7 +26,7 @@ export const loadLoggedInUser = () => {
           const data = normalize(response.service_member.orders, ordersArray);
           if (data.entities.shipments) {
             const shipmentIds = Object.keys(data.entities.shipments);
-            shipmentIds.map(id => dispatch(getShipment('Shipments.GetShipment', id)));
+            shipmentIds.map(id => dispatch(getShipment(id)));
           }
 
           // Only store addresses in a normalized way. This prevents


### PR DESCRIPTION
## Description

As we've built out the functions we use to dispatch swagger requests, we've made some improvements. This meant that the format for all we call these requests varied between older code and newer code. Standardize on the pattern of making the label optional.

## Reviewer Notes

In most cases, it would seem like the label doesn't matter and we could just hardcode it for all requests. However, there were a few minor edge cases where two panels on the same page interact with the same data object, and therefore being able to specify which request belongs to which panel (for error handling) is beneficial.

## Code Review Verification Steps


* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/164122193) for this change