### PR TITLE
Adds goimports pre-commit hook in place of gofmt [delivers #164158191]

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -81,10 +81,18 @@ repos:
         language: script
         files: \.md$
 
+  - repo: local
+    hooks:
+      - id: go-imports
+        name: go imports
+        entry: bin/pre-commit-go-imports
+        language: script
+        files: \.go$
+        exclude: vendor/
+
   - repo: git://github.com/dnephin/pre-commit-golang
     rev: v0.3.2
     hooks:
-      - id: go-fmt
       - id: go-vet
       - id: go-lint
 

--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,12 @@ build_callgraph: go_deps .build_callgraph.stamp
 	go build -i -o bin/callgraph ./vendor/golang.org/x/tools/cmd/callgraph
 	touch .build_callgraph.stamp
 
-server_deps: check_hosts go_deps build_chamber build_soda build_callgraph .server_deps.stamp
+get_goimports: go_deps .get_goimports.stamp
+.get_goimports.stamp:
+	go get golang.org/x/tools/cmd/goimports
+	touch .get_goimports.stamp
+
+server_deps: check_hosts go_deps build_chamber build_soda build_callgraph get_goimports .server_deps.stamp
 .server_deps.stamp:
 	# Unfortunately, dep ensure blows away ./vendor every time so these builds always take a while
 	go install ./vendor/github.com/golang/lint/golint # golint needs to be accessible for the pre-commit task to run, so `install` it
@@ -414,7 +419,7 @@ clean:
 .PHONY: pre-commit deps test client_deps client_build client_run client_test prereqs check_hosts
 .PHONY: server_run_standalone server_run server_run_default server_test webserver_test
 .PHONY: go_deps_update server_go_bindata
-.PHONY: build_chamber build_soda build_callgraph
+.PHONY: build_chamber build_soda build_callgraph get_goimports
 .PHONY: server_generate server_deps server_build
 .PHONY: server_generate_linux server_deps_linux server_build_linux
 .PHONY: db_run db_destroy

--- a/bin/pre-commit-go-imports
+++ b/bin/pre-commit-go-imports
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+#
+# Capture and print stdout, since gofmt doesn't use proper exit codes
+#
+set -e
+
+exec 5>&1
+# -local flag ensures our local imports get their own group
+output=$(goimports -w -local github.com/transcom/mymove "$@" | tee /dev/fd/5)
+[[ -z "$output" ]]

--- a/cmd/demo/iws.go
+++ b/cmd/demo/iws.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/namsral/flag"
+
 	"github.com/transcom/mymove/pkg/iws"
 )
 

--- a/cmd/generate_1203_form/main.go
+++ b/cmd/generate_1203_form/main.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gobuffalo/pop"
 	"github.com/gofrs/uuid"
+
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/paperwork"
 )

--- a/cmd/generate_shipment_edi/main.go
+++ b/cmd/generate_shipment_edi/main.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/transcom/mymove/pkg/db/sequence"
 	"github.com/transcom/mymove/pkg/edi"
-	"github.com/transcom/mymove/pkg/edi/invoice"
+	ediinvoice "github.com/transcom/mymove/pkg/edi/invoice"
 	"github.com/transcom/mymove/pkg/logging"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/server"

--- a/cmd/generate_shipment_summary/main.go
+++ b/cmd/generate_shipment_summary/main.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/gobuffalo/pop"
 	"github.com/gofrs/uuid"
+
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/paperwork"
 )

--- a/cmd/generate_test_data/main.go
+++ b/cmd/generate_test_data/main.go
@@ -5,8 +5,9 @@ import (
 
 	"github.com/gobuffalo/pop"
 	"github.com/namsral/flag"
-	"github.com/transcom/mymove/pkg/models"
 	"go.uber.org/zap"
+
+	"github.com/transcom/mymove/pkg/models"
 
 	"github.com/transcom/mymove/pkg/storage"
 	"github.com/transcom/mymove/pkg/testdatagen"

--- a/cmd/load_office_data/main.go
+++ b/cmd/load_office_data/main.go
@@ -2,13 +2,15 @@ package main
 
 import (
 	"encoding/json"
-	"github.com/gobuffalo/pop"
-	"github.com/gobuffalo/validate"
-	"github.com/namsral/flag" // This flag package accepts ENV vars as well as cmd line flags
-	"github.com/transcom/mymove/pkg/models"
 	"io/ioutil"
 	"log"
 	"strings"
+
+	"github.com/gobuffalo/pop"
+	"github.com/gobuffalo/validate"
+	"github.com/namsral/flag" // This flag package accepts ENV vars as well as cmd line flags
+
+	"github.com/transcom/mymove/pkg/models"
 )
 
 /* load-office-data is a tool to load Transportation Office data into a local data base.

--- a/cmd/load_user_gen/main.go
+++ b/cmd/load_user_gen/main.go
@@ -3,14 +3,16 @@ package main
 import (
 	"encoding/csv"
 	"fmt"
-	"github.com/gobuffalo/pop"
-	"github.com/gofrs/uuid"
-	"github.com/namsral/flag" // This flag package accepts ENV vars as well as cmd line flags
-	"github.com/transcom/mymove/pkg/models"
 	"io"
 	"log"
 	"os"
 	"strings"
+
+	"github.com/gobuffalo/pop"
+	"github.com/gofrs/uuid"
+	"github.com/namsral/flag" // This flag package accepts ENV vars as well as cmd line flags
+
+	"github.com/transcom/mymove/pkg/models"
 )
 
 const (

--- a/cmd/make_dps_user/main.go
+++ b/cmd/make_dps_user/main.go
@@ -1,10 +1,12 @@
 package main
 
 import (
+	"log"
+
 	"github.com/gobuffalo/pop"
 	"github.com/namsral/flag"
+
 	"github.com/transcom/mymove/pkg/models"
-	"log"
 )
 
 func mustSave(db *pop.Connection, model interface{}) {

--- a/cmd/make_office_user/main.go
+++ b/cmd/make_office_user/main.go
@@ -1,11 +1,13 @@
 package main
 
 import (
+	"log"
+
 	"github.com/gobuffalo/pop"
 	"github.com/gofrs/uuid"
 	"github.com/namsral/flag"
+
 	"github.com/transcom/mymove/pkg/models"
-	"log"
 )
 
 func mustSave(db *pop.Connection, model interface{}) {

--- a/cmd/make_tsp_user/main.go
+++ b/cmd/make_tsp_user/main.go
@@ -1,11 +1,13 @@
 package main
 
 import (
+	"log"
+
 	"github.com/gobuffalo/pop"
 	"github.com/gofrs/uuid"
 	"github.com/namsral/flag"
+
 	"github.com/transcom/mymove/pkg/models"
-	"log"
 )
 
 func mustSave(db *pop.Connection, model interface{}) {

--- a/internal/pkg/dutystationsloader/duty_stations_loader.go
+++ b/internal/pkg/dutystationsloader/duty_stations_loader.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gofrs/uuid"
 	"github.com/pkg/errors"
 	"github.com/tealeg/xlsx"
+
 	"github.com/transcom/mymove/pkg/gen/internalmessages"
 	"github.com/transcom/mymove/pkg/models"
 )

--- a/pkg/auth/authentication/client_cert.go
+++ b/pkg/auth/authentication/client_cert.go
@@ -8,8 +8,9 @@ import (
 
 	"github.com/gobuffalo/pop"
 	beeline "github.com/honeycombio/beeline-go"
-	"github.com/transcom/mymove/pkg/models"
 	"go.uber.org/zap"
+
+	"github.com/transcom/mymove/pkg/models"
 )
 
 type authClientCertKey string

--- a/pkg/auth/authentication/devlocal.go
+++ b/pkg/auth/authentication/devlocal.go
@@ -12,6 +12,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/gorilla/csrf"
+
 	"github.com/transcom/mymove/pkg/auth"
 	"github.com/transcom/mymove/pkg/models"
 )

--- a/pkg/auth/authentication/login_gov.go
+++ b/pkg/auth/authentication/login_gov.go
@@ -12,8 +12,9 @@ import (
 	"github.com/dgrijalva/jwt-go"
 	"github.com/markbates/goth"
 	"github.com/markbates/goth/providers/openidConnect"
-	"github.com/transcom/mymove/pkg/auth"
 	"go.uber.org/zap"
+
+	"github.com/transcom/mymove/pkg/auth"
 )
 
 const milProviderName = "milProvider"

--- a/pkg/db/dbfmt/dbfmt_test.go
+++ b/pkg/db/dbfmt/dbfmt_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/suite"
+
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"
 	"github.com/transcom/mymove/pkg/testingsuite"

--- a/pkg/dpsauth/cookie_test.go
+++ b/pkg/dpsauth/cookie_test.go
@@ -7,8 +7,9 @@ import (
 
 	"github.com/gofrs/uuid"
 	"github.com/stretchr/testify/suite"
-	"github.com/transcom/mymove/pkg/testingsuite"
 	"go.uber.org/zap"
+
+	"github.com/transcom/mymove/pkg/testingsuite"
 )
 
 type dpsAuthSuite struct {

--- a/pkg/edi/invoice/generator.go
+++ b/pkg/edi/invoice/generator.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/transcom/mymove/pkg/db/sequence"
 	"github.com/transcom/mymove/pkg/edi"
-	"github.com/transcom/mymove/pkg/edi/segment"
+	edisegment "github.com/transcom/mymove/pkg/edi/segment"
 	"github.com/transcom/mymove/pkg/models"
 )
 

--- a/pkg/handlers/dpsapi/api.go
+++ b/pkg/handlers/dpsapi/api.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/go-openapi/loads"
+
 	"github.com/transcom/mymove/pkg/gen/dpsapi"
 	dpsops "github.com/transcom/mymove/pkg/gen/dpsapi/dpsoperations"
 	"github.com/transcom/mymove/pkg/handlers"

--- a/pkg/handlers/dpsapi/api_test.go
+++ b/pkg/handlers/dpsapi/api_test.go
@@ -5,9 +5,10 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/suite"
+	"go.uber.org/zap"
+
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/notifications"
-	"go.uber.org/zap"
 )
 
 // HandlerSuite is an abstraction of our original suite

--- a/pkg/handlers/dpsapi/authentication.go
+++ b/pkg/handlers/dpsapi/authentication.go
@@ -8,6 +8,8 @@ import (
 	"github.com/go-openapi/strfmt"
 	"github.com/gobuffalo/pop"
 	"github.com/pkg/errors"
+	"go.uber.org/zap"
+
 	"github.com/transcom/mymove/pkg/auth/authentication"
 	"github.com/transcom/mymove/pkg/dpsauth"
 	"github.com/transcom/mymove/pkg/gen/dpsapi/dpsoperations/dps"
@@ -15,7 +17,6 @@ import (
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/iws"
 	"github.com/transcom/mymove/pkg/models"
-	"go.uber.org/zap"
 )
 
 // GetUserHandler returns user information given an encrypted token

--- a/pkg/handlers/dpsapi/authentication_test.go
+++ b/pkg/handlers/dpsapi/authentication_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/go-openapi/strfmt"
+
 	"github.com/transcom/mymove/pkg/auth/authentication"
 	"github.com/transcom/mymove/pkg/dpsauth"
 	"github.com/transcom/mymove/pkg/gen/dpsapi/dpsoperations/dps"

--- a/pkg/handlers/internalapi/api.go
+++ b/pkg/handlers/internalapi/api.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-openapi/loads"
 	"github.com/go-openapi/runtime"
 	"github.com/pkg/errors"
+
 	"github.com/transcom/mymove/pkg/gen/internalapi"
 	internalops "github.com/transcom/mymove/pkg/gen/internalapi/internaloperations"
 	"github.com/transcom/mymove/pkg/handlers"

--- a/pkg/handlers/internalapi/backup_contacts.go
+++ b/pkg/handlers/internalapi/backup_contacts.go
@@ -6,6 +6,7 @@ import (
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/gofrs/uuid"
 	"github.com/honeycombio/beeline-go"
+
 	"github.com/transcom/mymove/pkg/auth"
 	backupop "github.com/transcom/mymove/pkg/gen/internalapi/internaloperations/backup_contacts"
 	"github.com/transcom/mymove/pkg/gen/internalmessages"

--- a/pkg/handlers/internalapi/calendar.go
+++ b/pkg/handlers/internalapi/calendar.go
@@ -1,13 +1,15 @@
 package internalapi
 
 import (
+	"time"
+
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/go-openapi/strfmt"
+
 	"github.com/transcom/mymove/pkg/dates"
 	calendarop "github.com/transcom/mymove/pkg/gen/internalapi/internaloperations/calendar"
 	"github.com/transcom/mymove/pkg/gen/internalmessages"
 	"github.com/transcom/mymove/pkg/handlers"
-	"time"
 )
 
 // ShowAvailableMoveDatesHandler returns the available move dates starting at a given date.

--- a/pkg/handlers/internalapi/calendar_test.go
+++ b/pkg/handlers/internalapi/calendar_test.go
@@ -1,11 +1,13 @@
 package internalapi
 
 import (
-	"github.com/go-openapi/strfmt"
-	calendarop "github.com/transcom/mymove/pkg/gen/internalapi/internaloperations/calendar"
-	"github.com/transcom/mymove/pkg/handlers"
 	"net/http/httptest"
 	"time"
+
+	"github.com/go-openapi/strfmt"
+
+	calendarop "github.com/transcom/mymove/pkg/gen/internalapi/internaloperations/calendar"
+	"github.com/transcom/mymove/pkg/handlers"
 )
 
 func (suite *HandlerSuite) TestShowAvailableMoveDatesHandler() {

--- a/pkg/handlers/internalapi/documents.go
+++ b/pkg/handlers/internalapi/documents.go
@@ -8,6 +8,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/honeycombio/beeline-go"
+
 	auth "github.com/transcom/mymove/pkg/auth"
 	documentop "github.com/transcom/mymove/pkg/gen/internalapi/internaloperations/documents"
 	"github.com/transcom/mymove/pkg/gen/internalmessages"

--- a/pkg/handlers/internalapi/dps_auth_cookie_url.go
+++ b/pkg/handlers/internalapi/dps_auth_cookie_url.go
@@ -7,13 +7,14 @@ import (
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/go-openapi/strfmt"
 	"github.com/gofrs/uuid"
+	"go.uber.org/zap"
+
 	"github.com/transcom/mymove/pkg/auth"
 	"github.com/transcom/mymove/pkg/dpsauth"
 	"github.com/transcom/mymove/pkg/gen/internalapi/internaloperations/dps_auth"
 	"github.com/transcom/mymove/pkg/gen/internalmessages"
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/models"
-	"go.uber.org/zap"
 )
 
 type errUserMissing struct {

--- a/pkg/handlers/internalapi/entitlements.go
+++ b/pkg/handlers/internalapi/entitlements.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gofrs/uuid"
 
 	"github.com/honeycombio/beeline-go"
+
 	"github.com/transcom/mymove/pkg/auth"
 	entitlementop "github.com/transcom/mymove/pkg/gen/internalapi/internaloperations/entitlements"
 	"github.com/transcom/mymove/pkg/handlers"

--- a/pkg/handlers/internalapi/entitlements_test.go
+++ b/pkg/handlers/internalapi/entitlements_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 	"github.com/gofrs/uuid"
+
 	entitlementop "github.com/transcom/mymove/pkg/gen/internalapi/internaloperations/entitlements"
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/testdatagen"

--- a/pkg/handlers/internalapi/generic_move_documents.go
+++ b/pkg/handlers/internalapi/generic_move_documents.go
@@ -1,10 +1,11 @@
 package internalapi
 
 import (
+	"reflect"
+
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/gofrs/uuid"
 	"github.com/honeycombio/beeline-go"
-	"reflect"
 
 	"github.com/transcom/mymove/pkg/auth"
 	movedocop "github.com/transcom/mymove/pkg/gen/internalapi/internaloperations/move_docs"

--- a/pkg/handlers/internalapi/move_dates_test.go
+++ b/pkg/handlers/internalapi/move_dates_test.go
@@ -1,10 +1,11 @@
 package internalapi
 
 import (
-	"github.com/transcom/mymove/pkg/dates"
-	"github.com/transcom/mymove/pkg/models"
 	"testing"
 	"time"
+
+	"github.com/transcom/mymove/pkg/dates"
+	"github.com/transcom/mymove/pkg/models"
 )
 
 func (suite *HandlerSuite) TestCalculateMoveDatesFromShipmentMissingPickupDate() {

--- a/pkg/handlers/internalapi/move_documents.go
+++ b/pkg/handlers/internalapi/move_documents.go
@@ -5,6 +5,7 @@ import (
 	"github.com/gofrs/uuid"
 
 	"github.com/pkg/errors"
+
 	"github.com/transcom/mymove/pkg/auth"
 	movedocop "github.com/transcom/mymove/pkg/gen/internalapi/internaloperations/move_docs"
 	"github.com/transcom/mymove/pkg/gen/internalmessages"

--- a/pkg/handlers/internalapi/move_queue_items.go
+++ b/pkg/handlers/internalapi/move_queue_items.go
@@ -4,12 +4,13 @@ import (
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/go-openapi/swag"
 
+	"go.uber.org/zap"
+
 	"github.com/transcom/mymove/pkg/auth"
 	queueop "github.com/transcom/mymove/pkg/gen/internalapi/internaloperations/queues"
 	"github.com/transcom/mymove/pkg/gen/internalmessages"
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/models"
-	"go.uber.org/zap"
 )
 
 func payloadForMoveQueueItem(MoveQueueItem models.MoveQueueItem) *internalmessages.MoveQueueItem {

--- a/pkg/handlers/internalapi/moves.go
+++ b/pkg/handlers/internalapi/moves.go
@@ -7,10 +7,6 @@ import (
 	"reflect"
 	"time"
 
-	"github.com/transcom/mymove/pkg/unit"
-
-	"github.com/transcom/mymove/pkg/rateengine"
-
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/go-openapi/swag"
 	"github.com/gofrs/uuid"
@@ -26,7 +22,9 @@ import (
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/notifications"
 	"github.com/transcom/mymove/pkg/paperwork"
+	"github.com/transcom/mymove/pkg/rateengine"
 	"github.com/transcom/mymove/pkg/storage"
+	"github.com/transcom/mymove/pkg/unit"
 )
 
 func payloadForMoveModel(storer storage.FileStorer, order models.Order, move models.Move) (*internalmessages.MovePayload, error) {

--- a/pkg/handlers/internalapi/moves_test.go
+++ b/pkg/handlers/internalapi/moves_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/go-openapi/swag"
+
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/route"
 

--- a/pkg/handlers/internalapi/orders.go
+++ b/pkg/handlers/internalapi/orders.go
@@ -7,6 +7,7 @@ import (
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/gofrs/uuid"
 	"github.com/honeycombio/beeline-go"
+
 	"github.com/transcom/mymove/pkg/auth"
 	ordersop "github.com/transcom/mymove/pkg/gen/internalapi/internaloperations/orders"
 	"github.com/transcom/mymove/pkg/gen/internalmessages"

--- a/pkg/handlers/internalapi/personally_procured_move_estimate_test.go
+++ b/pkg/handlers/internalapi/personally_procured_move_estimate_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http/httptest"
 
 	"github.com/gofrs/uuid"
+
 	ppmop "github.com/transcom/mymove/pkg/gen/internalapi/internaloperations/ppm"
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/models"

--- a/pkg/handlers/internalapi/service_members.go
+++ b/pkg/handlers/internalapi/service_members.go
@@ -8,13 +8,14 @@ import (
 	"github.com/gobuffalo/validate"
 	"github.com/gofrs/uuid"
 	"github.com/honeycombio/beeline-go"
+	"go.uber.org/zap"
+
 	"github.com/transcom/mymove/pkg/auth"
 	servicememberop "github.com/transcom/mymove/pkg/gen/internalapi/internaloperations/service_members"
 	"github.com/transcom/mymove/pkg/gen/internalmessages"
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/storage"
-	"go.uber.org/zap"
 )
 
 func payloadForServiceMemberModel(storer storage.FileStorer, serviceMember models.ServiceMember) *internalmessages.ServiceMemberPayload {

--- a/pkg/handlers/internalapi/shipments_test.go
+++ b/pkg/handlers/internalapi/shipments_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
+
 	shipmentop "github.com/transcom/mymove/pkg/gen/internalapi/internaloperations/shipments"
 	"github.com/transcom/mymove/pkg/gen/internalmessages"
 	"github.com/transcom/mymove/pkg/handlers"

--- a/pkg/handlers/internalapi/users.go
+++ b/pkg/handlers/internalapi/users.go
@@ -8,6 +8,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/honeycombio/beeline-go"
+
 	"github.com/transcom/mymove/pkg/auth"
 	userop "github.com/transcom/mymove/pkg/gen/internalapi/internaloperations/users"
 	"github.com/transcom/mymove/pkg/gen/internalmessages"

--- a/pkg/handlers/ordersapi/orders.go
+++ b/pkg/handlers/ordersapi/orders.go
@@ -2,6 +2,7 @@ package ordersapi
 
 import (
 	"github.com/go-openapi/runtime/middleware"
+
 	"github.com/transcom/mymove/pkg/auth/authentication"
 	"github.com/transcom/mymove/pkg/gen/ordersapi/ordersoperations"
 	"github.com/transcom/mymove/pkg/handlers"

--- a/pkg/handlers/publicapi/api.go
+++ b/pkg/handlers/publicapi/api.go
@@ -1,10 +1,11 @@
 package publicapi
 
 import (
-	"github.com/transcom/mymove/pkg/paperwork"
-	paperworkservice "github.com/transcom/mymove/pkg/services/paperwork"
 	"log"
 	"net/http"
+
+	"github.com/transcom/mymove/pkg/paperwork"
+	paperworkservice "github.com/transcom/mymove/pkg/services/paperwork"
 
 	"github.com/go-openapi/loads"
 

--- a/pkg/handlers/publicapi/blackouts.go
+++ b/pkg/handlers/publicapi/blackouts.go
@@ -2,6 +2,7 @@ package publicapi
 
 import (
 	"github.com/go-openapi/runtime/middleware"
+
 	blackoutsop "github.com/transcom/mymove/pkg/gen/restapi/apioperations/blackouts"
 	"github.com/transcom/mymove/pkg/handlers"
 )

--- a/pkg/handlers/publicapi/generic_move_documents.go
+++ b/pkg/handlers/publicapi/generic_move_documents.go
@@ -8,13 +8,14 @@ import (
 	"github.com/honeycombio/beeline-go"
 
 	"github.com/go-openapi/swag"
+	"go.uber.org/zap"
+
 	"github.com/transcom/mymove/pkg/auth"
 	"github.com/transcom/mymove/pkg/gen/apimessages"
 	movedocop "github.com/transcom/mymove/pkg/gen/restapi/apioperations/move_docs"
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/storage"
-	"go.uber.org/zap"
 )
 
 func payloadForDocumentModel(storer storage.FileStorer, document models.Document) (*apimessages.DocumentPayload, error) {

--- a/pkg/handlers/publicapi/generic_move_documents_test.go
+++ b/pkg/handlers/publicapi/generic_move_documents_test.go
@@ -1,10 +1,12 @@
 package publicapi
 
 import (
-	"github.com/gobuffalo/uuid"
 	"net/http/httptest"
 
+	"github.com/gobuffalo/uuid"
+
 	"github.com/go-openapi/strfmt"
+
 	"github.com/transcom/mymove/pkg/gen/apimessages"
 	movedocop "github.com/transcom/mymove/pkg/gen/restapi/apioperations/move_docs"
 	"github.com/transcom/mymove/pkg/handlers"

--- a/pkg/handlers/publicapi/invoices_test.go
+++ b/pkg/handlers/publicapi/invoices_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http/httptest"
 
 	"github.com/go-openapi/strfmt"
+
 	accessorialop "github.com/transcom/mymove/pkg/gen/restapi/apioperations/accessorials"
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/models"

--- a/pkg/handlers/publicapi/move_documents.go
+++ b/pkg/handlers/publicapi/move_documents.go
@@ -4,12 +4,13 @@ import (
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/gofrs/uuid"
 
+	"go.uber.org/zap"
+
 	"github.com/transcom/mymove/pkg/auth"
 	"github.com/transcom/mymove/pkg/gen/apimessages"
 	movedocop "github.com/transcom/mymove/pkg/gen/restapi/apioperations/move_docs"
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/models"
-	"go.uber.org/zap"
 )
 
 // IndexMoveDocumentsHandler returns a list of all the Move Documents associated with this move.

--- a/pkg/handlers/publicapi/shipments.go
+++ b/pkg/handlers/publicapi/shipments.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+
 	"github.com/transcom/mymove/pkg/services"
 
 	"github.com/go-openapi/runtime/middleware"

--- a/pkg/handlers/publicapi/shipments_test.go
+++ b/pkg/handlers/publicapi/shipments_test.go
@@ -2,10 +2,11 @@ package publicapi
 
 import (
 	"fmt"
-	"github.com/transcom/mymove/pkg/paperwork"
 	"net/http"
 	"net/http/httptest"
 	"time"
+
+	"github.com/transcom/mymove/pkg/paperwork"
 
 	"github.com/transcom/mymove/pkg/dates"
 	"github.com/transcom/mymove/pkg/route"

--- a/pkg/handlers/publicapi/tsps.go
+++ b/pkg/handlers/publicapi/tsps.go
@@ -2,6 +2,7 @@ package publicapi
 
 import (
 	"github.com/go-openapi/runtime/middleware"
+
 	tspsop "github.com/transcom/mymove/pkg/gen/restapi/apioperations/tsps"
 	"github.com/transcom/mymove/pkg/handlers"
 )

--- a/pkg/handlers/responders.go
+++ b/pkg/handlers/responders.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/runtime/middleware"
+
 	"github.com/transcom/mymove/pkg/auth"
 )
 

--- a/pkg/iws/iws_test.go
+++ b/pkg/iws/iws_test.go
@@ -5,8 +5,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/suite"
-	"github.com/transcom/mymove/pkg/testingsuite"
 	"go.uber.org/zap"
+
+	"github.com/transcom/mymove/pkg/testingsuite"
 )
 
 type iwsSuite struct {

--- a/pkg/logging/hnyzap/hnyzap_test.go
+++ b/pkg/logging/hnyzap/hnyzap_test.go
@@ -7,8 +7,9 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/suite"
-	"github.com/transcom/mymove/pkg/testingsuite"
 	"go.uber.org/zap"
+
+	"github.com/transcom/mymove/pkg/testingsuite"
 )
 
 type zapFieldSuite struct {

--- a/pkg/models/address_test.go
+++ b/pkg/models/address_test.go
@@ -2,6 +2,7 @@ package models_test
 
 import (
 	"github.com/go-openapi/swag"
+
 	. "github.com/transcom/mymove/pkg/models"
 )
 

--- a/pkg/models/distance_calculation_test.go
+++ b/pkg/models/distance_calculation_test.go
@@ -2,6 +2,7 @@ package models_test
 
 import (
 	"github.com/gofrs/uuid"
+
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/route"
 	"github.com/transcom/mymove/pkg/testdatagen"

--- a/pkg/models/document.go
+++ b/pkg/models/document.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gofrs/uuid"
 	"github.com/honeycombio/beeline-go"
 	"github.com/pkg/errors"
+
 	"github.com/transcom/mymove/pkg/auth"
 )
 

--- a/pkg/models/duty_station.go
+++ b/pkg/models/duty_station.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gofrs/uuid"
 	"github.com/honeycombio/beeline-go"
 	"github.com/pkg/errors"
+
 	"github.com/transcom/mymove/pkg/gen/internalmessages"
 )
 

--- a/pkg/models/models_test.go
+++ b/pkg/models/models_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/gobuffalo/validate"
 	"github.com/stretchr/testify/suite"
+
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testingsuite"
 )

--- a/pkg/models/move_document.go
+++ b/pkg/models/move_document.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gofrs/uuid"
 
 	"github.com/pkg/errors"
+
 	"github.com/transcom/mymove/pkg/auth"
 )
 

--- a/pkg/models/move_document_test.go
+++ b/pkg/models/move_document_test.go
@@ -2,6 +2,7 @@ package models_test
 
 import (
 	"github.com/gofrs/uuid"
+
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"
 

--- a/pkg/models/move_documents_extractor.go
+++ b/pkg/models/move_documents_extractor.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/gobuffalo/pop"
 	"github.com/gofrs/uuid"
+
 	"github.com/transcom/mymove/pkg/unit"
 )
 

--- a/pkg/models/moving_expense_document.go
+++ b/pkg/models/moving_expense_document.go
@@ -7,6 +7,7 @@ import (
 	"github.com/gobuffalo/validate"
 	"github.com/gobuffalo/validate/validators"
 	"github.com/gofrs/uuid"
+
 	"github.com/transcom/mymove/pkg/unit"
 )
 

--- a/pkg/models/office_user_test.go
+++ b/pkg/models/office_user_test.go
@@ -2,6 +2,7 @@ package models_test
 
 import (
 	"github.com/gofrs/uuid"
+
 	. "github.com/transcom/mymove/pkg/models"
 )
 

--- a/pkg/models/personally_procured_move.go
+++ b/pkg/models/personally_procured_move.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gofrs/uuid"
 
 	"github.com/pkg/errors"
+
 	"github.com/transcom/mymove/pkg/auth"
 	"github.com/transcom/mymove/pkg/gen/internalmessages"
 	"github.com/transcom/mymove/pkg/unit"

--- a/pkg/models/queue.go
+++ b/pkg/models/queue.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/gobuffalo/pop"
 	"github.com/gofrs/uuid"
+
 	"github.com/transcom/mymove/pkg/gen/internalmessages"
 )
 

--- a/pkg/models/shipment.go
+++ b/pkg/models/shipment.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gobuffalo/validate/validators"
 	"github.com/gofrs/uuid"
 	"github.com/pkg/errors"
+
 	"github.com/transcom/mymove/pkg/auth"
 	"github.com/transcom/mymove/pkg/dates"
 	"github.com/transcom/mymove/pkg/unit"

--- a/pkg/models/shipment_line_item.go
+++ b/pkg/models/shipment_line_item.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gobuffalo/validate/validators"
 	"github.com/gofrs/uuid"
 	"github.com/pkg/errors"
+
 	"github.com/transcom/mymove/pkg/unit"
 )
 

--- a/pkg/models/shipment_line_item_dimension.go
+++ b/pkg/models/shipment_line_item_dimension.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/gofrs/uuid"
+
 	"github.com/transcom/mymove/pkg/unit"
 )
 

--- a/pkg/models/shipment_recalculate.go
+++ b/pkg/models/shipment_recalculate.go
@@ -2,12 +2,13 @@ package models
 
 import (
 	"encoding/json"
+	"time"
+
 	"github.com/gobuffalo/pop"
 	"github.com/gobuffalo/uuid"
 	"github.com/gobuffalo/validate"
 	"github.com/gobuffalo/validate/validators"
 	"github.com/pkg/errors"
-	"time"
 )
 
 // ShipmentRecalculate model/struct is a record of the date range to use to determine if a Shipment is a candidate

--- a/pkg/models/shipment_recalculate_logs_test.go
+++ b/pkg/models/shipment_recalculate_logs_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/gofrs/uuid"
+
 	"github.com/transcom/mymove/pkg/testdatagen"
 
 	"github.com/transcom/mymove/pkg/models"

--- a/pkg/models/shipment_recalculate_test.go
+++ b/pkg/models/shipment_recalculate_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/gofrs/uuid"
+
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"
 )

--- a/pkg/models/shipment_summary_worksheet.go
+++ b/pkg/models/shipment_summary_worksheet.go
@@ -10,11 +10,12 @@ import (
 	"github.com/gobuffalo/pop"
 	"github.com/gofrs/uuid"
 	"github.com/pkg/errors"
+	"golang.org/x/text/language"
+	"golang.org/x/text/message"
+
 	"github.com/transcom/mymove/pkg/auth"
 	"github.com/transcom/mymove/pkg/gen/internalmessages"
 	"github.com/transcom/mymove/pkg/unit"
-	"golang.org/x/text/language"
-	"golang.org/x/text/message"
 )
 
 // FormatValuesShipmentSummaryWorksheet returns the formatted pages for the Shipment Summary Worksheet

--- a/pkg/models/shipment_summary_worksheet_test.go
+++ b/pkg/models/shipment_summary_worksheet_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/transcom/mymove/pkg/unit"
 
 	"github.com/gofrs/uuid"
+
 	"github.com/transcom/mymove/pkg/auth"
 	"github.com/transcom/mymove/pkg/gen/internalmessages"
 	"github.com/transcom/mymove/pkg/models"

--- a/pkg/models/shipment_test.go
+++ b/pkg/models/shipment_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/gofrs/uuid"
+
 	"github.com/transcom/mymove/pkg/dates"
 	. "github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"

--- a/pkg/models/tariff400ng_item_rate.go
+++ b/pkg/models/tariff400ng_item_rate.go
@@ -7,6 +7,7 @@ import (
 	"github.com/gobuffalo/validate"
 	"github.com/gobuffalo/validate/validators"
 	"github.com/gofrs/uuid"
+
 	"github.com/transcom/mymove/pkg/unit"
 )
 

--- a/pkg/models/transit_times.go
+++ b/pkg/models/transit_times.go
@@ -1,9 +1,11 @@
 package models
 
 import (
-	"github.com/pkg/errors"
-	"github.com/transcom/mymove/pkg/unit"
 	"math"
+
+	"github.com/pkg/errors"
+
+	"github.com/transcom/mymove/pkg/unit"
 )
 
 // PoundsPackedPerDay represents the number of pounds that can be packed in a single day.

--- a/pkg/models/transportation_service_provider.go
+++ b/pkg/models/transportation_service_provider.go
@@ -1,13 +1,14 @@
 package models
 
 import (
+	"time"
+
 	"github.com/gobuffalo/pop"
 	"github.com/gobuffalo/validate"
 	"github.com/gobuffalo/validate/validators"
 	"github.com/gofrs/uuid"
 	"github.com/pkg/errors"
 	"go.uber.org/zap/zapcore"
-	"time"
 )
 
 // TransportationServiceProvider models moving companies used to move

--- a/pkg/models/tsp_users.go
+++ b/pkg/models/tsp_users.go
@@ -1,12 +1,13 @@
 package models
 
 import (
+	"strings"
+	"time"
+
 	"github.com/gobuffalo/pop"
 	"github.com/gobuffalo/validate"
 	"github.com/gobuffalo/validate/validators"
 	"github.com/gofrs/uuid"
-	"strings"
-	"time"
 )
 
 // TspUser is someone who works for a Transportation Service Provider

--- a/pkg/models/tsp_users_test.go
+++ b/pkg/models/tsp_users_test.go
@@ -2,6 +2,7 @@ package models_test
 
 import (
 	"github.com/gofrs/uuid"
+
 	. "github.com/transcom/mymove/pkg/models"
 )
 

--- a/pkg/models/upload.go
+++ b/pkg/models/upload.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gofrs/uuid"
 	"github.com/honeycombio/beeline-go"
 	"github.com/pkg/errors"
+
 	"github.com/transcom/mymove/pkg/auth"
 )
 

--- a/pkg/models/user.go
+++ b/pkg/models/user.go
@@ -3,12 +3,13 @@ package models
 import (
 	"time"
 
+	"strings"
+
 	"github.com/gobuffalo/pop"
 	"github.com/gobuffalo/validate"
 	"github.com/gobuffalo/validate/validators"
 	"github.com/gofrs/uuid"
 	"github.com/pkg/errors"
-	"strings"
 )
 
 // User is an entity with a registered uuid and email at login.gov

--- a/pkg/notifications/notification_stub.go
+++ b/pkg/notifications/notification_stub.go
@@ -2,6 +2,7 @@ package notifications
 
 import (
 	"context"
+
 	"go.uber.org/zap"
 )
 

--- a/pkg/rateengine/accessorials.go
+++ b/pkg/rateengine/accessorials.go
@@ -3,6 +3,7 @@ package rateengine
 import (
 	"github.com/gofrs/uuid"
 	"github.com/pkg/errors"
+
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/unit"
 )

--- a/pkg/rateengine/line_items.go
+++ b/pkg/rateengine/line_items.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/gobuffalo/pop"
+
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/unit"
 )

--- a/pkg/rateengine/rateengine.go
+++ b/pkg/rateengine/rateengine.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/gofrs/uuid"
 	"github.com/pkg/errors"
+
 	"github.com/transcom/mymove/pkg/models"
 
 	"github.com/gobuffalo/pop"

--- a/pkg/route/bing_planner.go
+++ b/pkg/route/bing_planner.go
@@ -8,8 +8,9 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"github.com/transcom/mymove/pkg/models"
 	"go.uber.org/zap"
+
+	"github.com/transcom/mymove/pkg/models"
 )
 
 // bingRequestTimeout is how long to wait on Bing request before timing out (30 seconds).

--- a/pkg/route/planner_test.go
+++ b/pkg/route/planner_test.go
@@ -6,9 +6,10 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/suite"
+	"go.uber.org/zap"
+
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testingsuite"
-	"go.uber.org/zap"
 )
 
 type PlannerSuite struct {

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -10,8 +10,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/suite"
-	"github.com/transcom/mymove/pkg/testingsuite"
 	"go.uber.org/zap"
+
+	"github.com/transcom/mymove/pkg/testingsuite"
 )
 
 type serverSuite struct {

--- a/pkg/services/invoice/fetch_invoice_for_shipment.go
+++ b/pkg/services/invoice/fetch_invoice_for_shipment.go
@@ -3,6 +3,7 @@ package invoice
 import (
 	"github.com/gobuffalo/pop"
 	"github.com/gofrs/uuid"
+
 	"github.com/transcom/mymove/pkg/models"
 )
 

--- a/pkg/services/invoice/fetch_invoice_for_shipment_test.go
+++ b/pkg/services/invoice/fetch_invoice_for_shipment_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/gobuffalo/pop"
+
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"
 )

--- a/pkg/services/invoice/process_invoice.go
+++ b/pkg/services/invoice/process_invoice.go
@@ -8,7 +8,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/transcom/mymove/pkg/db/sequence"
-	"github.com/transcom/mymove/pkg/edi/invoice"
+	ediinvoice "github.com/transcom/mymove/pkg/edi/invoice"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services"
 )

--- a/pkg/services/invoice/process_invoice_test.go
+++ b/pkg/services/invoice/process_invoice_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/db/sequence"
-	"github.com/transcom/mymove/pkg/edi/invoice"
+	ediinvoice "github.com/transcom/mymove/pkg/edi/invoice"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"
 	"github.com/transcom/mymove/pkg/unit"

--- a/pkg/services/invoice/update_invoice_submitted.go
+++ b/pkg/services/invoice/update_invoice_submitted.go
@@ -2,8 +2,10 @@ package invoice
 
 import (
 	"errors"
+
 	"github.com/gobuffalo/pop"
 	"github.com/gobuffalo/validate"
+
 	"github.com/transcom/mymove/pkg/models"
 )
 

--- a/pkg/services/invoice/update_invoice_upload.go
+++ b/pkg/services/invoice/update_invoice_upload.go
@@ -6,6 +6,7 @@ import (
 	"github.com/gobuffalo/pop"
 	"github.com/gobuffalo/validate"
 	"github.com/pkg/errors"
+
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/uploader"
 )

--- a/pkg/services/invoice/update_invoice_upload_test.go
+++ b/pkg/services/invoice/update_invoice_upload_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gofrs/uuid"
 	"github.com/pkg/errors"
 	"github.com/spf13/afero"
+
 	"github.com/transcom/mymove/pkg/unit"
 
 	"github.com/transcom/mymove/pkg/models"
@@ -19,8 +20,9 @@ import (
 	storageTest "github.com/transcom/mymove/pkg/storage/test"
 	"github.com/transcom/mymove/pkg/testdatagen"
 
-	"github.com/transcom/mymove/pkg/uploader"
 	"go.uber.org/zap"
+
+	"github.com/transcom/mymove/pkg/uploader"
 )
 
 func (suite *InvoiceServiceSuite) openLocalFile(path string) (afero.File, error) {

--- a/pkg/services/paperwork.go
+++ b/pkg/services/paperwork.go
@@ -2,7 +2,9 @@ package services
 
 import (
 	"bytes"
+
 	"github.com/spf13/afero"
+
 	paperworkforms "github.com/transcom/mymove/pkg/paperwork"
 )
 

--- a/pkg/services/paperwork/create_form.go
+++ b/pkg/services/paperwork/create_form.go
@@ -3,12 +3,14 @@ package paperwork
 import (
 	"bytes"
 	"fmt"
+	"io"
+
 	"github.com/pkg/errors"
 	"github.com/spf13/afero"
+
 	"github.com/transcom/mymove/pkg/assets"
 	paperworkforms "github.com/transcom/mymove/pkg/paperwork"
 	"github.com/transcom/mymove/pkg/services"
-	"io"
 )
 
 // Storer is an interface for FileStorer

--- a/pkg/services/paperwork/create_form_test.go
+++ b/pkg/services/paperwork/create_form_test.go
@@ -1,11 +1,15 @@
 package paperwork
 
 import (
+	"testing"
+
 	"github.com/pkg/errors"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
+	"go.uber.org/zap"
+
 	"github.com/transcom/mymove/mocks"
 	"github.com/transcom/mymove/pkg/models"
 	paperworkforms "github.com/transcom/mymove/pkg/paperwork"
@@ -13,8 +17,6 @@ import (
 	"github.com/transcom/mymove/pkg/testdatagen"
 	"github.com/transcom/mymove/pkg/testdatagen/scenario"
 	"github.com/transcom/mymove/pkg/testingsuite"
-	"go.uber.org/zap"
-	"testing"
 )
 
 type CreateFormSuite struct {

--- a/pkg/services/shipment/deliver_and_price_shipment.go
+++ b/pkg/services/shipment/deliver_and_price_shipment.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/gobuffalo/pop"
 	"github.com/gobuffalo/validate"
+
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/rateengine"
 	"github.com/transcom/mymove/pkg/route"

--- a/pkg/services/shipment/price_shipment.go
+++ b/pkg/services/shipment/price_shipment.go
@@ -5,6 +5,7 @@ import (
 	"github.com/gobuffalo/validate"
 	"github.com/gofrs/uuid"
 	"github.com/pkg/errors"
+
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/rateengine"
 	"github.com/transcom/mymove/pkg/route"

--- a/pkg/services/shipment/process_recalculate_shipment.go
+++ b/pkg/services/shipment/process_recalculate_shipment.go
@@ -5,10 +5,11 @@ import (
 	"time"
 
 	"github.com/gobuffalo/pop"
+	"go.uber.org/zap"
+
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/rateengine"
 	"github.com/transcom/mymove/pkg/route"
-	"go.uber.org/zap"
 )
 
 // ProcessRecalculateShipment is a service object to recalculate a Shipment's Line Items

--- a/pkg/services/shipment/process_recalculate_shipment_test.go
+++ b/pkg/services/shipment/process_recalculate_shipment_test.go
@@ -6,12 +6,13 @@ import (
 
 	"github.com/gofrs/uuid"
 	"github.com/stretchr/testify/suite"
+	"go.uber.org/zap"
+
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/route"
 	"github.com/transcom/mymove/pkg/services/invoice"
 	"github.com/transcom/mymove/pkg/testdatagen"
 	"github.com/transcom/mymove/pkg/testingsuite"
-	"go.uber.org/zap"
 )
 
 // Deliver marks the Shipment request as Delivered. Must be IN TRANSIT state.

--- a/pkg/services/shipment/recalculate_shipment.go
+++ b/pkg/services/shipment/recalculate_shipment.go
@@ -3,10 +3,11 @@ package shipment
 import (
 	"github.com/gobuffalo/pop"
 	"github.com/gobuffalo/validate"
+	"go.uber.org/zap"
+
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/rateengine"
 	"github.com/transcom/mymove/pkg/route"
-	"go.uber.org/zap"
 )
 
 // RecalculateShipment is a service object to re-price a Shipment

--- a/pkg/services/shipment/recalculate_shipment_test.go
+++ b/pkg/services/shipment/recalculate_shipment_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/suite"
+	"go.uber.org/zap"
+
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/rateengine"
 	"github.com/transcom/mymove/pkg/route"
@@ -11,7 +13,6 @@ import (
 	"github.com/transcom/mymove/pkg/testdatagen"
 	"github.com/transcom/mymove/pkg/testingsuite"
 	"github.com/transcom/mymove/pkg/unit"
-	"go.uber.org/zap"
 )
 
 func (suite *RecalculateShipmentSuite) helperDeliverAndPriceShipment() *models.Shipment {

--- a/pkg/testdatagen/make_dps_user.go
+++ b/pkg/testdatagen/make_dps_user.go
@@ -2,6 +2,7 @@ package testdatagen
 
 import (
 	"github.com/gobuffalo/pop"
+
 	"github.com/transcom/mymove/pkg/models"
 )
 

--- a/pkg/testdatagen/make_moving_expense_document.go
+++ b/pkg/testdatagen/make_moving_expense_document.go
@@ -2,6 +2,7 @@ package testdatagen
 
 import (
 	"github.com/gobuffalo/pop"
+
 	"github.com/transcom/mymove/pkg/unit"
 
 	"github.com/transcom/mymove/pkg/models"

--- a/pkg/testdatagen/make_service_member.go
+++ b/pkg/testdatagen/make_service_member.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 
 	"github.com/gobuffalo/pop"
+
 	"github.com/transcom/mymove/pkg/models"
 )
 

--- a/pkg/testdatagen/make_shipment_line_item_dimensions.go
+++ b/pkg/testdatagen/make_shipment_line_item_dimensions.go
@@ -2,6 +2,7 @@ package testdatagen
 
 import (
 	"github.com/gobuffalo/pop"
+
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/unit"
 )

--- a/pkg/testdatagen/make_shipment_line_items.go
+++ b/pkg/testdatagen/make_shipment_line_items.go
@@ -4,6 +4,7 @@ import (
 	"log"
 
 	"github.com/gobuffalo/pop"
+
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/unit"
 )

--- a/pkg/testdatagen/make_tariff400ng_item_rate.go
+++ b/pkg/testdatagen/make_tariff400ng_item_rate.go
@@ -2,6 +2,7 @@ package testdatagen
 
 import (
 	"github.com/gobuffalo/pop"
+
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/unit"
 )

--- a/pkg/testdatagen/make_tariff400ng_items.go
+++ b/pkg/testdatagen/make_tariff400ng_items.go
@@ -2,6 +2,7 @@ package testdatagen
 
 import (
 	"github.com/gobuffalo/pop"
+
 	"github.com/transcom/mymove/pkg/models"
 )
 

--- a/pkg/testdatagen/make_tariff400ng_zip3_records.go
+++ b/pkg/testdatagen/make_tariff400ng_zip3_records.go
@@ -5,6 +5,7 @@ import (
 	"log"
 
 	"github.com/gobuffalo/pop"
+
 	"github.com/transcom/mymove/pkg/models"
 )
 

--- a/pkg/testdatagen/make_tsp_records.go
+++ b/pkg/testdatagen/make_tsp_records.go
@@ -6,6 +6,7 @@ import (
 	"math/rand"
 
 	"github.com/gobuffalo/pop"
+
 	"github.com/transcom/mymove/pkg/models"
 )
 

--- a/pkg/testdatagen/scenario/estimate.go
+++ b/pkg/testdatagen/scenario/estimate.go
@@ -2,6 +2,7 @@ package scenario
 
 import (
 	"github.com/gobuffalo/pop"
+
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/unit"
 )

--- a/pkg/testdatagen/scenario/rateengine.go
+++ b/pkg/testdatagen/scenario/rateengine.go
@@ -2,6 +2,7 @@ package scenario
 
 import (
 	"github.com/gobuffalo/pop"
+
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/unit"
 )


### PR DESCRIPTION
## Description

It was brought up that a few devs have IDEs that are modifying our import statements on save. This PR runs `goimports`, a wrapper around `gofmt` that also reformats import statements, during pre-commit.

### Why'd you write your own?
There is an existing pre-commit hook [here](https://github.com/troian/pre-commit-golang/blob/master/run-goimports.sh) but it doesn't accept filename arguments and running against vendor/ was timing out in CI. It was simple enough to adapt the gofmt hook from our [preferred repo](https://github.com/dnephin/pre-commit-golang).

### `go get`?
As far as I can tell installation of `goimports` is only doable with `go get`, which we usually try to avoid because we can't lock versions. In this case I think it's the right way to go because:
- The only other way I know of to install it is with `dep ensure -add` which, because `goimports` isn't _actually_ a dependency, will get wiped out by another `dep ensure`
- It's a tool maintained by golang and is [infrequently updated](https://github.com/golang/tools/tree/master/cmd/goimports).

The resulting format is:
```go
import (
  "standard library"

  "external libraries"

  "milmove libraries"
)
```

## Setup

Installation of `goimports` is handled through `make server_deps`, which should be run by most people pretty frequently

```sh
make server_deps
```

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/164158191) for this change