### PR TITLE
Populate actual obligations on SSW

### DIFF
--- a/pkg/handlers/internalapi/moves.go
+++ b/pkg/handlers/internalapi/moves.go
@@ -3,7 +3,6 @@ package internalapi
 import (
 	"bytes"
 	"io/ioutil"
-	"log"
 	"reflect"
 	"time"
 
@@ -24,7 +23,6 @@ import (
 	"github.com/transcom/mymove/pkg/paperwork"
 	"github.com/transcom/mymove/pkg/rateengine"
 	"github.com/transcom/mymove/pkg/storage"
-	"github.com/transcom/mymove/pkg/unit"
 )
 
 func payloadForMoveModel(storer storage.FileStorer, order models.Order, move models.Move) (*internalmessages.MovePayload, error) {
@@ -242,33 +240,30 @@ type ShowShipmentSummaryWorksheetHandler struct {
 func (h ShowShipmentSummaryWorksheetHandler) Handle(params moveop.ShowShipmentSummaryWorksheetParams) middleware.Responder {
 	session := auth.SessionFromRequestContext(params.HTTPRequest)
 	moveID, _ := uuid.FromString(params.MoveID.String())
-	engine := rateengine.NewRateEngine(h.DB(), h.Logger())
+	ppmComputer := paperwork.NewSSWPPMComputer(rateengine.NewRateEngine(h.DB(), h.Logger()))
 
 	ssfd, err := models.FetchDataShipmentSummaryWorksheetFormData(h.DB(), session, moveID)
 	ssfd.PreparationDate = time.Time(params.PreparationDate)
 	var firstPPM models.PersonallyProcuredMove
 	if len(ssfd.PersonallyProcuredMoves) > 0 {
 		firstPPM = ssfd.PersonallyProcuredMoves[0]
-	}
-	if firstPPM.PickupPostalCode != nil &&
-		firstPPM.DestinationPostalCode != nil &&
-		firstPPM.OriginalMoveDate != nil {
+		if firstPPM.PickupPostalCode == nil || firstPPM.DestinationPostalCode == nil {
+			h.Logger().Error("Error missing required address parameter")
+			return moveop.NewShowShipmentSummaryWorksheetInternalServerError()
+		}
 		distanceMiles, err := h.Planner().Zip5TransitDistance(*firstPPM.PickupPostalCode, *firstPPM.DestinationPostalCode)
 		if err != nil {
-			log.Fatalf("Error calculating distance %v", err)
+			h.Logger().Error("Error calculating distance", zap.Error(err))
+			return moveop.NewShowShipmentSummaryWorksheetInternalServerError()
 		}
-		cost, err := engine.ComputePPMIncludingLHDiscount(
-			unit.Pound(ssfd.TotalWeightAllotment),
-			*firstPPM.PickupPostalCode,
-			*firstPPM.DestinationPostalCode,
-			distanceMiles,
-			*firstPPM.OriginalMoveDate,
-			0, 0,
-		)
-		ssfd.GCC = cost.GCC
+		ssfd.MaxObligation, err = ppmComputer.ComputeObligations(firstPPM, distanceMiles, paperwork.MaxObligation)
 		if err != nil {
 			h.Logger().Error("Error calculating PPM max obligations ", zap.Error(err))
 			return moveop.NewShowShipmentSummaryWorksheetInternalServerError()
+		}
+		ssfd.ActualObligation, err = ppmComputer.ComputeObligations(firstPPM, distanceMiles, paperwork.ActualObligation)
+		if err != nil {
+			h.Logger().Error("Error calculating PPM actual obligations ", zap.Error(err))
 		}
 	}
 

--- a/pkg/handlers/internalapi/moves_test.go
+++ b/pkg/handlers/internalapi/moves_test.go
@@ -395,6 +395,9 @@ func (suite *HandlerSuite) TestShowMoveDatesSummaryForbiddenUser() {
 
 func (suite *HandlerSuite) TestShowShipmentSummaryWorksheet() {
 	move := testdatagen.MakeDefaultMove(suite.DB())
+	testdatagen.MakePPM(suite.DB(), testdatagen.Assertions{
+		PersonallyProcuredMove: models.PersonallyProcuredMove{},
+	})
 
 	req := httptest.NewRequest("GET", "/moves/some_id/shipment_summary_worksheet", nil)
 	req = suite.AuthenticateRequest(req, move.Orders.ServiceMember)

--- a/pkg/models/shipment_summary_worksheet.go
+++ b/pkg/models/shipment_summary_worksheet.go
@@ -153,7 +153,13 @@ func FetchDataShipmentSummaryWorksheetFormData(db *pop.Connection, session *auth
 		if err != nil {
 			return ShipmentSummaryFormData{}, err
 		}
-		move.PersonallyProcuredMoves[i].Advance = ppmDetails.Advance
+		if ppmDetails.Advance != nil {
+			switch ppmDetails.Advance.Status {
+			case ReimbursementStatusAPPROVED,
+				ReimbursementStatusPAID:
+				move.PersonallyProcuredMoves[i].Advance = ppmDetails.Advance
+			}
+		}
 	}
 
 	if err != nil {

--- a/pkg/models/shipment_summary_worksheet.go
+++ b/pkg/models/shipment_summary_worksheet.go
@@ -154,9 +154,8 @@ func FetchDataShipmentSummaryWorksheetFormData(db *pop.Connection, session *auth
 			return ShipmentSummaryFormData{}, err
 		}
 		if ppmDetails.Advance != nil {
-			switch ppmDetails.Advance.Status {
-			case ReimbursementStatusAPPROVED,
-				ReimbursementStatusPAID:
+			status := ppmDetails.Advance.Status
+			if status == ReimbursementStatusAPPROVED || status == ReimbursementStatusPAID {
 				move.PersonallyProcuredMoves[i].Advance = ppmDetails.Advance
 			}
 		}

--- a/pkg/models/shipment_summary_worksheet.go
+++ b/pkg/models/shipment_summary_worksheet.go
@@ -54,10 +54,14 @@ type ShipmentSummaryWorksheetPage1Values struct {
 	ShipmentWeights                 string
 	ShipmentCurrentShipmentStatuses string
 	PreparationDate                 string
-	GCC100                          string
+	MaxObligationGCC100             string
 	TotalWeightAllotmentRepeat      string
-	GCC95                           string
-	GCCMaxAdvance                   string
+	MaxObligationGCC95              string
+	MaxObligationGCCMaxAdvance      string
+	ActualWeight                    string
+	ActualObligationGCC100          string
+	ActualObligationGCC95           string
+	ActualObligationAdvance         string
 }
 
 //ShipmentSummaryWorkSheetShipments is and object representing shipment line items on Shipment Summary Worksheet
@@ -107,8 +111,29 @@ type ShipmentSummaryFormData struct {
 	Shipments               Shipments
 	PersonallyProcuredMoves PersonallyProcuredMoves
 	PreparationDate         time.Time
-	GCC                     unit.Cents
+	MaxObligation           Obligation
+	ActualObligation        Obligation
 	MovingExpenseDocuments  []MovingExpenseDocument
+}
+
+//Obligation an object representing the obligations section on the shipment summary worksheet
+type Obligation struct {
+	Gcc unit.Cents
+}
+
+//GCC100 calculates the 95% GCC on shipment summary worksheet
+func (obligation Obligation) GCC100() float64 {
+	return obligation.Gcc.ToDollarFloat()
+}
+
+//GCC95 calculates the 100% GCC on shipment summary worksheet
+func (obligation Obligation) GCC95() float64 {
+	return obligation.Gcc.MultiplyFloat64(.95).ToDollarFloat()
+}
+
+//MaxAdvance calculates the Max Advance on the shipment summary worksheet
+func (obligation Obligation) MaxAdvance() float64 {
+	return obligation.Gcc.MultiplyFloat64(.60).ToDollarFloat()
 }
 
 // FetchDataShipmentSummaryWorksheetFormData fetches the pages for the Shipment Summary Worksheet for a given Move ID
@@ -122,6 +147,14 @@ func FetchDataShipmentSummaryWorksheetFormData(db *pop.Connection, session *auth
 		"Shipments",
 		"PersonallyProcuredMoves",
 	).Find(&move, moveID)
+
+	for i, ppm := range move.PersonallyProcuredMoves {
+		ppmDetails, err := FetchPersonallyProcuredMove(db, session, ppm.ID)
+		if err != nil {
+			return ShipmentSummaryFormData{}, err
+		}
+		move.PersonallyProcuredMoves[i].Advance = ppmDetails.Advance
+	}
 
 	if err != nil {
 		if errors.Cause(err).Error() == recordNotFoundErrorString {
@@ -214,17 +247,39 @@ func FormatValuesShipmentSummaryWorksheetFormPage1(data ShipmentSummaryFormData)
 	page1.WeightAllotmentProgear = FormatWeights(data.WeightAllotment.ProGearWeight)
 	page1.WeightAllotmentProgearSpouse = FormatWeights(data.WeightAllotment.ProGearWeightSpouse)
 	page1.TotalWeightAllotment = FormatWeights(data.TotalWeightAllotment)
-	page1.TotalWeightAllotmentRepeat = page1.TotalWeightAllotment
 
 	formattedShipments := FormatAllShipments(data.PersonallyProcuredMoves, data.Shipments)
 	page1.ShipmentNumberAndTypes = formattedShipments.ShipmentNumberAndTypes
 	page1.ShipmentPickUpDates = formattedShipments.PickUpDates
 	page1.ShipmentCurrentShipmentStatuses = formattedShipments.CurrentShipmentStatuses
 	page1.ShipmentWeights = formattedShipments.ShipmentWeights
-	page1.GCC100 = FormatDollars(data.GCC.ToDollarFloat())
-	page1.GCC95 = FormatDollars(data.GCC.MultiplyFloat64(.95).ToDollarFloat())
-	page1.GCCMaxAdvance = FormatDollars(data.GCC.MultiplyFloat64(.60).ToDollarFloat())
+
+	page1.MaxObligationGCC100 = FormatDollars(data.MaxObligation.GCC100())
+	page1.TotalWeightAllotmentRepeat = page1.TotalWeightAllotment
+	page1.MaxObligationGCC95 = FormatDollars(data.MaxObligation.GCC95())
+	page1.MaxObligationGCCMaxAdvance = FormatDollars(data.MaxObligation.MaxAdvance())
+
+	page1.ActualObligationGCC100 = FormatDollars(data.ActualObligation.GCC100())
+	page1.ActualWeight = formatActualWeight(data)
+	page1.ActualObligationAdvance = formatActualObligationAdvance(data)
+
+	page1.ActualObligationGCC95 = FormatDollars(data.ActualObligation.GCC95())
 	return page1
+}
+
+func formatActualObligationAdvance(data ShipmentSummaryFormData) string {
+	if len(data.PersonallyProcuredMoves) > 0 && data.PersonallyProcuredMoves[0].Advance != nil {
+		advance := data.PersonallyProcuredMoves[0].Advance.RequestedAmount.ToDollarFloat()
+		return FormatDollars(advance)
+	}
+	return FormatDollars(0)
+}
+
+func formatActualWeight(data ShipmentSummaryFormData) string {
+	if len(data.PersonallyProcuredMoves) > 0 && data.PersonallyProcuredMoves[0].NetWeight != nil {
+		return FormatWeights(int(*(data.PersonallyProcuredMoves[0].NetWeight)))
+	}
+	return FormatWeights(0)
 }
 
 //FormatRank formats the service member's rank for Shipment Summary Worksheet

--- a/pkg/models/shipment_summary_worksheet_test.go
+++ b/pkg/models/shipment_summary_worksheet_test.go
@@ -49,7 +49,10 @@ func (suite *ModelSuite) TestFetchDataShipmentSummaryWorksheet() {
 			Advance:             &advance,
 		},
 	})
-	// Wasn't saving advance in reimbursements table w/o this step
+	// Only concerned w/ approved advances for ssw
+	ppm.Move.PersonallyProcuredMoves[0].Advance.Request()
+	ppm.Move.PersonallyProcuredMoves[0].Advance.Approve()
+	// Save advance in reimbursements table by saving ppm
 	models.SavePersonallyProcuredMove(suite.DB(), &ppm)
 	movedocuments := testdatagen.Assertions{
 		MoveDocument: models.MoveDocument{
@@ -107,6 +110,7 @@ func (suite *ModelSuite) TestFetchDataShipmentSummaryWorksheet() {
 	suite.NotNil(ssd.MovingExpenseDocuments[0].ID)
 	suite.NotNil(ssd.MovingExpenseDocuments[1].ID)
 	suite.Equal(ppm.NetWeight, ssd.PersonallyProcuredMoves[0].NetWeight)
+	suite.Require().NotNil(ssd.PersonallyProcuredMoves[0].Advance)
 	suite.Equal(ppm.Advance.ID, ssd.PersonallyProcuredMoves[0].Advance.ID)
 	suite.Equal(unit.Cents(1000), ssd.PersonallyProcuredMoves[0].Advance.RequestedAmount)
 }

--- a/pkg/models/shipment_summary_worksheet_test.go
+++ b/pkg/models/shipment_summary_worksheet_test.go
@@ -49,6 +49,8 @@ func (suite *ModelSuite) TestFetchDataShipmentSummaryWorksheet() {
 			Advance:             &advance,
 		},
 	})
+	// Wasn't saving advance in reimbursements table w/o this step
+	models.SavePersonallyProcuredMove(suite.DB(), &ppm)
 	movedocuments := testdatagen.Assertions{
 		MoveDocument: models.MoveDocument{
 			MoveID:                   ppm.Move.ID,
@@ -62,7 +64,6 @@ func (suite *ModelSuite) TestFetchDataShipmentSummaryWorksheet() {
 			ServiceMember:   move.Orders.ServiceMember,
 		},
 	}
-	models.SavePersonallyProcuredMove(suite.DB(), &ppm)
 	testdatagen.MakeMovingExpenseDocument(suite.DB(), movedocuments)
 	testdatagen.MakeMovingExpenseDocument(suite.DB(), movedocuments)
 	shipment := testdatagen.MakeShipment(suite.DB(), testdatagen.Assertions{

--- a/pkg/paperwork/shipment_summary_test.go
+++ b/pkg/paperwork/shipment_summary_test.go
@@ -1,0 +1,104 @@
+package paperwork
+
+import (
+	"errors"
+	"time"
+
+	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/rateengine"
+	"github.com/transcom/mymove/pkg/unit"
+)
+
+type mockPPMComputer struct {
+	costComputation   rateengine.CostComputation
+	err               error
+	ppmComputerParams ppmComputerParams
+}
+
+func (mppmc *mockPPMComputer) ComputePPMIncludingLHDiscount(weight unit.Pound, originZip5 string, destinationZip5 string, distanceMiles int, date time.Time, daysInSIT int, sitDiscount unit.DiscountRate) (cost rateengine.CostComputation, err error) {
+	mppmc.ppmComputerParams = ppmComputerParams{
+		Weight:          weight,
+		OriginZip5:      originZip5,
+		DestinationZip5: destinationZip5,
+		Date:            date,
+		DaysInSIT:       daysInSIT,
+		SitDiscount:     sitDiscount,
+	}
+	return mppmc.costComputation, mppmc.err
+}
+
+func (mppmc *mockPPMComputer) CalledWith() ppmComputerParams {
+	return mppmc.ppmComputerParams
+}
+
+func (suite *PaperworkSuite) TestComputeObligationsBadPPM() {
+	ppmComputer := NewSSWPPMComputer(&mockPPMComputer{})
+	badPpm := models.PersonallyProcuredMove{}
+	_, err1 := ppmComputer.ComputeObligations(badPpm, 0, MaxObligation)
+	_, err2 := ppmComputer.ComputeObligations(badPpm, 0, ActualObligation)
+	suite.NotNil(err1)
+	suite.NotNil(err2)
+}
+
+func (suite *PaperworkSuite) TestTestComputeObligations() {
+	mockComputer := mockPPMComputer{
+		costComputation: rateengine.CostComputation{GCC: 100},
+	}
+	ppmComputer := NewSSWPPMComputer(&mockComputer)
+	var wtgEstimate int64 = 1000
+	var netWeight int64 = 2000
+	origMoveDate := time.Date(2018, 12, 11, 0, 0, 0, 0, time.UTC)
+	actualDate := time.Date(2018, 12, 15, 0, 0, 0, 0, time.UTC)
+	pickupPostalCode := "85369"
+	destinationPostalCode := "31905"
+	ppm := models.PersonallyProcuredMove{
+		WeightEstimate:        &wtgEstimate,
+		NetWeight:             &netWeight,
+		OriginalMoveDate:      &origMoveDate,
+		ActualMoveDate:        &actualDate,
+		PickupPostalCode:      &pickupPostalCode,
+		DestinationPostalCode: &destinationPostalCode,
+	}
+	suite.Run("TestComputeMaxObligations", func() {
+
+		_, err := ppmComputer.ComputeObligations(ppm, 0, MaxObligation)
+
+		calledWith := mockComputer.CalledWith()
+		expectMaxObligationParams := ppmComputerParams{
+			Weight:          unit.Pound(wtgEstimate),
+			OriginZip5:      pickupPostalCode,
+			DestinationZip5: destinationPostalCode,
+			Date:            origMoveDate,
+			DaysInSIT:       0,
+			SitDiscount:     0,
+		}
+		suite.Equal(calledWith, expectMaxObligationParams)
+		suite.Nil(err)
+	})
+
+	suite.Run("TestComputeActualObligations", func() {
+
+		expectActualObligationParams := ppmComputerParams{
+			Weight:          unit.Pound(netWeight),
+			OriginZip5:      pickupPostalCode,
+			DestinationZip5: destinationPostalCode,
+			Date:            actualDate,
+			DaysInSIT:       0,
+			SitDiscount:     0,
+		}
+		_, err := ppmComputer.ComputeObligations(ppm, 0, ActualObligation)
+
+		calledWith := mockComputer.CalledWith()
+		suite.Equal(calledWith, expectActualObligationParams)
+		suite.Nil(err)
+	})
+
+	suite.Run("TestCalcError", func() {
+		mockComputer := mockPPMComputer{err: errors.New("ERROR")}
+		ppmComputer := SSWPPMComputer{&mockComputer}
+
+		_, err := ppmComputer.ComputeObligations(ppm, 0, ActualObligation)
+
+		suite.NotNil(err)
+	})
+}

--- a/pkg/paperwork/shipment_summary_test.go
+++ b/pkg/paperwork/shipment_summary_test.go
@@ -4,10 +4,22 @@ import (
 	"errors"
 	"time"
 
+	"github.com/transcom/mymove/pkg/route"
+
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/rateengine"
 	"github.com/transcom/mymove/pkg/unit"
 )
+
+type ppmComputerParams struct {
+	Weight          unit.Pound
+	OriginZip5      string
+	DestinationZip5 string
+	Miles           int
+	Date            time.Time
+	DaysInSIT       int
+	SitDiscount     unit.DiscountRate
+}
 
 type mockPPMComputer struct {
 	costComputation   rateengine.CostComputation
@@ -20,6 +32,7 @@ func (mppmc *mockPPMComputer) ComputePPMIncludingLHDiscount(weight unit.Pound, o
 		Weight:          weight,
 		OriginZip5:      originZip5,
 		DestinationZip5: destinationZip5,
+		Miles:           distanceMiles,
 		Date:            date,
 		DaysInSIT:       daysInSIT,
 		SitDiscount:     sitDiscount,
@@ -31,62 +44,85 @@ func (mppmc *mockPPMComputer) CalledWith() ppmComputerParams {
 	return mppmc.ppmComputerParams
 }
 
-func (suite *PaperworkSuite) TestComputeObligationsBadPPM() {
+func (suite *PaperworkSuite) TestComputeObligationsParams() {
 	ppmComputer := NewSSWPPMComputer(&mockPPMComputer{})
-	badPpm := models.PersonallyProcuredMove{}
-	_, err1 := ppmComputer.ComputeObligations(badPpm, 0, MaxObligation)
-	_, err2 := ppmComputer.ComputeObligations(badPpm, 0, ActualObligation)
+	pickupPostalCode := "85369"
+	destinationPostalCode := "31905"
+	ppm := models.PersonallyProcuredMove{
+		PickupPostalCode:      &pickupPostalCode,
+		DestinationPostalCode: &destinationPostalCode,
+	}
+	noPPM := models.ShipmentSummaryFormData{PersonallyProcuredMoves: models.PersonallyProcuredMoves{}}
+	missingZip := models.ShipmentSummaryFormData{PersonallyProcuredMoves: models.PersonallyProcuredMoves{{}}}
+	missingOrigMoveDate := models.ShipmentSummaryFormData{PersonallyProcuredMoves: models.PersonallyProcuredMoves{ppm}}
+	missingActualMoveDate := models.ShipmentSummaryFormData{PersonallyProcuredMoves: models.PersonallyProcuredMoves{ppm}}
+
+	_, err1 := ppmComputer.ComputeObligations(noPPM, route.NewTestingPlanner(10), MaxObligation)
+	_, err2 := ppmComputer.ComputeObligations(missingZip, route.NewTestingPlanner(10), MaxObligation)
+	_, err3 := ppmComputer.ComputeObligations(missingActualMoveDate, route.NewTestingPlanner(10), ActualObligation)
+	_, err4 := ppmComputer.ComputeObligations(missingOrigMoveDate, route.NewTestingPlanner(10), MaxObligation)
+
 	suite.NotNil(err1)
 	suite.NotNil(err2)
+	suite.NotNil(err3)
+	suite.NotNil(err4)
 }
 
 func (suite *PaperworkSuite) TestTestComputeObligations() {
-	mockComputer := mockPPMComputer{
-		costComputation: rateengine.CostComputation{GCC: 100},
-	}
-	ppmComputer := NewSSWPPMComputer(&mockComputer)
-	var wtgEstimate int64 = 1000
 	var netWeight int64 = 2000
+	miles := 100
+	maxObligation := 1000
+	planner := route.NewTestingPlanner(miles)
 	origMoveDate := time.Date(2018, 12, 11, 0, 0, 0, 0, time.UTC)
 	actualDate := time.Date(2018, 12, 15, 0, 0, 0, 0, time.UTC)
 	pickupPostalCode := "85369"
 	destinationPostalCode := "31905"
 	ppm := models.PersonallyProcuredMove{
-		WeightEstimate:        &wtgEstimate,
 		NetWeight:             &netWeight,
 		OriginalMoveDate:      &origMoveDate,
 		ActualMoveDate:        &actualDate,
 		PickupPostalCode:      &pickupPostalCode,
 		DestinationPostalCode: &destinationPostalCode,
 	}
+	params := models.ShipmentSummaryFormData{
+		PersonallyProcuredMoves: models.PersonallyProcuredMoves{ppm},
+		TotalWeightAllotment:    maxObligation,
+	}
+	mockComputer := mockPPMComputer{
+		costComputation: rateengine.CostComputation{GCC: 100},
+	}
+	ppmComputer := NewSSWPPMComputer(&mockComputer)
+
 	suite.Run("TestComputeMaxObligations", func() {
-
-		_, err := ppmComputer.ComputeObligations(ppm, 0, MaxObligation)
-
-		calledWith := mockComputer.CalledWith()
 		expectMaxObligationParams := ppmComputerParams{
-			Weight:          unit.Pound(wtgEstimate),
+			Weight:          unit.Pound(maxObligation),
 			OriginZip5:      pickupPostalCode,
 			DestinationZip5: destinationPostalCode,
+			Miles:           miles,
 			Date:            origMoveDate,
 			DaysInSIT:       0,
 			SitDiscount:     0,
 		}
+
+		_, err := ppmComputer.ComputeObligations(params, planner, MaxObligation)
+
+		calledWith := mockComputer.CalledWith()
 		suite.Equal(calledWith, expectMaxObligationParams)
 		suite.Nil(err)
 	})
 
 	suite.Run("TestComputeActualObligations", func() {
-
 		expectActualObligationParams := ppmComputerParams{
 			Weight:          unit.Pound(netWeight),
 			OriginZip5:      pickupPostalCode,
 			DestinationZip5: destinationPostalCode,
 			Date:            actualDate,
+			Miles:           miles,
 			DaysInSIT:       0,
 			SitDiscount:     0,
 		}
-		_, err := ppmComputer.ComputeObligations(ppm, 0, ActualObligation)
+
+		_, err := ppmComputer.ComputeObligations(params, planner, ActualObligation)
 
 		calledWith := mockComputer.CalledWith()
 		suite.Equal(calledWith, expectActualObligationParams)
@@ -97,7 +133,7 @@ func (suite *PaperworkSuite) TestTestComputeObligations() {
 		mockComputer := mockPPMComputer{err: errors.New("ERROR")}
 		ppmComputer := SSWPPMComputer{&mockComputer}
 
-		_, err := ppmComputer.ComputeObligations(ppm, 0, ActualObligation)
+		_, err := ppmComputer.ComputeObligations(params, planner, ActualObligation)
 
 		suite.NotNil(err)
 	})

--- a/pkg/paperwork/shipment_summary_worksheet.go
+++ b/pkg/paperwork/shipment_summary_worksheet.go
@@ -31,10 +31,14 @@ var ShipmentSummaryPage1Layout = FormLayout{
 		"ShipmentPickUpDates":             FormField(54, 122.5, 46, floatPtr(10), nil, nil),
 		"ShipmentWeights":                 FormField(103, 122.5, 41, floatPtr(10), nil, nil),
 		"ShipmentCurrentShipmentStatuses": FormField(153.5, 122.5, 41, floatPtr(10), nil, nil),
-		"GCC100":                          FormField(40, 182.5, 22, floatPtr(10), nil, stringPtr("RM")),
-		"TotalWeightAllotmentRepeat":      FormField(74, 182.5, 16, floatPtr(10), nil, stringPtr("RM")),
-		"GCC95":                           FormField(40, 188.5, 22, floatPtr(10), nil, stringPtr("RM")),
-		"GCCMaxAdvance":                   FormField(40, 201, 22, floatPtr(10), nil, stringPtr("RM")),
+		"MaxObligationGCC100":             FormField(40, 182.5, 22, floatPtr(10), nil, stringPtr("RM")),
+		"TotalWeightAllotmentRepeat":      FormField(74, 182.5, 16, floatPtr(10), nil,stringPtr("RM")),
+		"MaxObligationGCC95":              FormField(40, 188.5, 22, floatPtr(10), nil, stringPtr("RM")),
+		"MaxObligationGCCMaxAdvance":      FormField(40, 201, 22, floatPtr(10), nil, stringPtr("RM")),
+		"ActualObligationGCC100":          FormField(133, 182.5, 22, floatPtr(10), nil, stringPtr("RM")),
+		"ActualWeight":                    FormField(167, 182.5, 16, floatPtr(10), nil, stringPtr("RM")),
+		"ActualObligationGCC95":           FormField(133, 188.5, 22, floatPtr(10), nil, stringPtr("RM")),
+		"ActualObligationAdvance":         FormField(133, 201, 22, floatPtr(10), nil, stringPtr("RM")),
 	},
 }
 

--- a/pkg/paperwork/shipment_summary_worksheet.go
+++ b/pkg/paperwork/shipment_summary_worksheet.go
@@ -32,7 +32,7 @@ var ShipmentSummaryPage1Layout = FormLayout{
 		"ShipmentWeights":                 FormField(103, 122.5, 41, floatPtr(10), nil, nil),
 		"ShipmentCurrentShipmentStatuses": FormField(153.5, 122.5, 41, floatPtr(10), nil, nil),
 		"MaxObligationGCC100":             FormField(40, 182.5, 22, floatPtr(10), nil, stringPtr("RM")),
-		"TotalWeightAllotmentRepeat":      FormField(74, 182.5, 16, floatPtr(10), nil,stringPtr("RM")),
+		"TotalWeightAllotmentRepeat":      FormField(74, 182.5, 16, floatPtr(10), nil, stringPtr("RM")),
 		"MaxObligationGCC95":              FormField(40, 188.5, 22, floatPtr(10), nil, stringPtr("RM")),
 		"MaxObligationGCCMaxAdvance":      FormField(40, 201, 22, floatPtr(10), nil, stringPtr("RM")),
 		"ActualObligationGCC100":          FormField(133, 182.5, 22, floatPtr(10), nil, stringPtr("RM")),


### PR DESCRIPTION
## Description

System populates the Actual Obligations section of the PPM Shipment Summary Worksheet

## Reviewer Notes

Waiting on the answer to one question, but don't expect to materially change the code.

## Setup

`make server_test`

### Test in the office client
`make server_run`
`make office_client_run`
1) Log into the office app and select a move with a PPM
2) Click Create Paperwork -> Click Download worksheet

### Test with cmd line tool
` go run cmd/generate_shipment_summary/main.go -move 0db80bd6-de75-439e-bf89-deaafa1d0dc8 -debug`

**NOTE:** In order for the actual obligations to be calculated `net_weight` and `acutal_move_date` need to be populated on the ppm.

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/n/projects/2181745/stories/163411579) 

## Screenshots
![image](https://user-images.githubusercontent.com/1036969/53251872-e5c03600-367a-11e9-87d8-032f6acc4a83.png)

