### PR TITLE
Update to latest goimports and run against project.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ build_callgraph: go_deps .build_callgraph.stamp
 
 get_goimports: go_deps .get_goimports.stamp
 .get_goimports.stamp:
-	go get golang.org/x/tools/cmd/goimports
+	go get -u golang.org/x/tools/cmd/goimports
 	touch .get_goimports.stamp
 
 server_deps: check_hosts go_deps build_chamber build_soda build_callgraph get_goimports .server_deps.stamp

--- a/bin/check_bash_version
+++ b/bin/check_bash_version
@@ -12,6 +12,7 @@ function check_shell () {
   if [ -z "${shell_line}" ]; then
     # shellcheck disable=SC1117
     echo -e "\033[0;33mPlease add ${shell} to your /etc/shells file using the command:\033[0m 'echo \"${shell}\" | sudo tee -a /etc/shells'"
+    # shellcheck disable=SC1117
     echo -e "\033[0;33mOptionally update your user's shell with the command:\033[0m 'sudo chsh -s /usr/local/bin/bash'"
     exit 1
   fi

--- a/bin/go-find-pattern
+++ b/bin/go-find-pattern
@@ -31,12 +31,12 @@ for pkg in "${pkgs[@]}"; do
     lines=$(cat "$parent/$file" | grep -inE "$pattern" | cut -d':' -f1 | tr '\n' ',')
     # shellcheck disable=SC1072
     if [[ "${lines// }" ]]; then
-      # shellcheck disable=SC2178,SC2128
+      # shellcheck disable=SC2178,SC2128,SC1117
       results="$results\n$import/$file | $lines"
     fi
     #exit 0
   done
 done
 
-# shellcheck disable=SC2128
+# shellcheck disable=SC2128,SC1117
 echo -e "package | lines\n$results" | column -t

--- a/pkg/handlers/publicapi/storage_in_transits.go
+++ b/pkg/handlers/publicapi/storage_in_transits.go
@@ -1,16 +1,18 @@
 package publicapi
 
 import (
+	"time"
+
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/gobuffalo/pop"
 	"github.com/gofrs/uuid"
+	"go.uber.org/zap"
+
 	"github.com/transcom/mymove/pkg/auth"
 	"github.com/transcom/mymove/pkg/gen/apimessages"
 	sitop "github.com/transcom/mymove/pkg/gen/restapi/apioperations/storage_in_transits"
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/models"
-	"go.uber.org/zap"
-	"time"
 )
 
 func payloadForStorageInTransitModel(s *models.StorageInTransit) *apimessages.StorageInTransit {

--- a/pkg/handlers/publicapi/storage_in_transits_test.go
+++ b/pkg/handlers/publicapi/storage_in_transits_test.go
@@ -2,14 +2,16 @@ package publicapi
 
 import (
 	"fmt"
+	"net/http/httptest"
+
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
+
 	"github.com/transcom/mymove/pkg/gen/apimessages"
 	sitop "github.com/transcom/mymove/pkg/gen/restapi/apioperations/storage_in_transits"
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"
-	"net/http/httptest"
 )
 
 func setupStorageInTransitHandlerTest(suite *HandlerSuite) (shipment models.Shipment, sit models.StorageInTransit, user models.OfficeUser) {

--- a/pkg/models/storage_in_transit_test.go
+++ b/pkg/models/storage_in_transit_test.go
@@ -1,9 +1,10 @@
 package models_test
 
 import (
+	"testing"
+
 	"github.com/go-openapi/swag"
 	"github.com/gofrs/uuid"
-	"testing"
 
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"


### PR DESCRIPTION
## Description

We weren't using `-u` when installing `goimports`, so folks were ending up with different versions. This caused some jovial confusion.