### PR TITLE
Add service member info to shipment summary worksheet

### DIFF
--- a/pkg/models/shipment_summary_worksheet.go
+++ b/pkg/models/shipment_summary_worksheet.go
@@ -32,11 +32,11 @@ func FormatValuesShipmentSummaryWorksheet(shipmentSummaryFormData ShipmentSummar
 type ShipmentSummaryWorksheetPage1Values struct {
 	ServiceMemberName               string
 	MaxSITStorageEntitlement        string
-	PreferredPhone                  string
+	PreferredPhoneNumber            string
 	PreferredEmail                  string
 	DODId                           string
 	ServiceBranch                   string
-	Rank                            string
+	RankGrade                       string
 	IssuingBranchOrAgency           string
 	OrdersIssueDate                 string
 	OrdersTypeAndOrdersNumber       string
@@ -195,9 +195,11 @@ func FormatValuesShipmentSummaryWorksheetFormPage1(data ShipmentSummaryFormData)
 
 	sm := data.ServiceMember
 	page1.ServiceMemberName = FormatServiceMemberFullName(sm)
-	page1.PreferredPhone = derefStringTypes(sm.Telephone)
+	page1.PreferredPhoneNumber = derefStringTypes(sm.Telephone)
+	page1.ServiceBranch = FormatServiceMemberAffiliation(sm.Affiliation)
 	page1.PreferredEmail = derefStringTypes(sm.PersonalEmail)
 	page1.DODId = derefStringTypes(sm.Edipi)
+	page1.RankGrade = FormatRank(data.ServiceMember.Rank)
 
 	page1.IssuingBranchOrAgency = FormatServiceMemberAffiliation(sm.Affiliation)
 	page1.OrdersIssueDate = FormatDate(data.Order.IssueDate)
@@ -223,6 +225,38 @@ func FormatValuesShipmentSummaryWorksheetFormPage1(data ShipmentSummaryFormData)
 	page1.GCC95 = FormatDollars(data.GCC.MultiplyFloat64(.95).ToDollarFloat())
 	page1.GCCMaxAdvance = FormatDollars(data.GCC.MultiplyFloat64(.60).ToDollarFloat())
 	return page1
+}
+
+//FormatRank formats the service member's rank for Shipment Summary Worksheet
+func FormatRank(rank *ServiceMemberRank) string {
+	var rankDisplayValue = map[ServiceMemberRank]string{
+		ServiceMemberRankE1:                     "E-1",
+		ServiceMemberRankE2:                     "E-2",
+		ServiceMemberRankE3:                     "E-3",
+		ServiceMemberRankE4:                     "E-4",
+		ServiceMemberRankE5:                     "E-5",
+		ServiceMemberRankE6:                     "E-6",
+		ServiceMemberRankE7:                     "E-7",
+		ServiceMemberRankE8:                     "E-8",
+		ServiceMemberRankE9:                     "E-9",
+		ServiceMemberRankO1W1ACADEMYGRADUATE:    "O-1/W-1/Service Academy Graduate",
+		ServiceMemberRankO2W2:                   "O-2/W-2",
+		ServiceMemberRankO3W3:                   "O-3/W-3",
+		ServiceMemberRankO4W4:                   "O-4/W-4",
+		ServiceMemberRankO5W5:                   "O-5/W-5",
+		ServiceMemberRankO6:                     "O-6",
+		ServiceMemberRankO7:                     "O-7",
+		ServiceMemberRankO8:                     "O-8",
+		ServiceMemberRankO9:                     "O-9",
+		ServiceMemberRankO10:                    "O-10",
+		ServiceMemberRankAVIATIONCADET:          "Aviation Cadet",
+		ServiceMemberRankCIVILIANEMPLOYEE:       "Civilian Employee",
+		ServiceMemberRankACADEMYCADETMIDSHIPMAN: "Service Academy Cadet/Midshipman",
+	}
+	if rank != nil {
+		return rankDisplayValue[*rank]
+	}
+	return ""
 }
 
 //FormatValuesShipmentSummaryWorksheetFormPage2 formats the data for page 2 of the Shipment Summary Worksheet

--- a/pkg/models/shipment_summary_worksheet_test.go
+++ b/pkg/models/shipment_summary_worksheet_test.go
@@ -191,11 +191,13 @@ func (suite *ModelSuite) TestFormatValuesShipmentSummaryWorksheetFormPage1() {
 	suite.Equal("01-Jan-2019", sswPage1.PreparationDate)
 
 	suite.Equal("Jenkins Jr., Marcus Joseph", sswPage1.ServiceMemberName)
+	suite.Equal("E-9", sswPage1.RankGrade)
+	suite.Equal("Air Force", sswPage1.ServiceBranch)
 	suite.Equal("90 days per each shipment", sswPage1.MaxSITStorageEntitlement)
 	suite.Equal("Yuma AFB, IA 50309", sswPage1.AuthorizedOrigin)
 	suite.Equal("Fort Gordon, GA 30813", sswPage1.AuthorizedDestination)
 	suite.Equal("NO", sswPage1.POVAuthorized)
-	suite.Equal("444-555-8888", sswPage1.PreferredPhone)
+	suite.Equal("444-555-8888", sswPage1.PreferredPhoneNumber)
 	suite.Equal("michael+ppm-expansion_1@truss.works", sswPage1.PreferredEmail)
 	suite.Equal("1234567890", sswPage1.DODId)
 
@@ -402,6 +404,14 @@ func (suite *ModelSuite) TestFormatCurrentPPMStatus() {
 
 	suite.Equal("At destination", models.FormatCurrentPPMStatus(paymentRequested))
 	suite.Equal("Completed", models.FormatCurrentPPMStatus(completed))
+}
+
+func (suite *ModelSuite) TestFormatRank() {
+	e9 := models.ServiceMemberRankE9
+	many := models.ServiceMemberRankO1W1ACADEMYGRADUATE
+
+	suite.Equal("E-9", models.FormatRank(&e9))
+	suite.Equal("O-1/W-1/Service Academy Graduate", models.FormatRank(&many))
 }
 
 func (suite *ModelSuite) TestFormatShipmentNumberAndType() {

--- a/pkg/models/shipment_summary_worksheet_test.go
+++ b/pkg/models/shipment_summary_worksheet_test.go
@@ -408,10 +408,10 @@ func (suite *ModelSuite) TestFormatCurrentPPMStatus() {
 
 func (suite *ModelSuite) TestFormatRank() {
 	e9 := models.ServiceMemberRankE9
-	many := models.ServiceMemberRankO1W1ACADEMYGRADUATE
+	multipleRanks := models.ServiceMemberRankO1W1ACADEMYGRADUATE
 
 	suite.Equal("E-9", models.FormatRank(&e9))
-	suite.Equal("O-1/W-1/Service Academy Graduate", models.FormatRank(&many))
+	suite.Equal("O-1/W-1/Service Academy Graduate", models.FormatRank(&multipleRanks))
 }
 
 func (suite *ModelSuite) TestFormatShipmentNumberAndType() {

--- a/pkg/paperwork/shipment_summary_worksheet.go
+++ b/pkg/paperwork/shipment_summary_worksheet.go
@@ -9,6 +9,11 @@ var ShipmentSummaryPage1Layout = FormLayout{
 	FieldsLayout: map[string]FieldPos{
 		"PreparationDate":                 FormField(155.5, 22, 46, floatPtr(10), nil, nil),
 		"ServiceMemberName":               FormField(10, 42, 105, floatPtr(10), nil, nil),
+		"DODId":                           FormField(10, 54, 40, floatPtr(10), nil, nil),
+		"ServiceBranch":                   FormField(54, 54, 44, floatPtr(10), nil, nil),
+		"RankGrade":                       FormField(102.5, 54, 47, floatPtr(10), nil, nil),
+		"PreferredEmail":                  FormField(153.5, 54, 60, floatPtr(10), nil, nil),
+		"PreferredPhoneNumber":            FormField(153.5, 42, 60, floatPtr(10), nil, nil),
 		"WeightAllotment":                 FormField(74, 92, 16, floatPtr(10), nil, stringPtr("RM")),
 		"WeightAllotmentProgear":          FormField(74, 98, 16, floatPtr(10), nil, stringPtr("RM")),
 		"WeightAllotmentProgearSpouse":    FormField(74, 103, 16, floatPtr(10), nil, stringPtr("RM")),


### PR DESCRIPTION
## Description

System populates the following member/employee information on Shipment Summary Worksheet: 

* DOD ID 
* Service Branch/Agency
* Rank/Grade
* Preferred phone number
* Preferred email

## Setup

`make server_test`

### Test in the office client
`make server_run`
`make office_client_run`
1) Log into the office app and select a move with a PPM
2) Click Create Paperwork -> Click Download worksheet

### Test with cmd line tool
` go run cmd/generate_shipment_summary/main.go -move 0db80bd6-de75-439e-bf89-deaafa1d0dc8 -debug`


## Code Review Verification Steps
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/n/projects/2181745/stories/163773509) 

## Screenshots

![screen shot 2019-02-25 at 11 07 22 am](https://user-images.githubusercontent.com/1036969/53358480-ba914d00-38ed-11e9-8244-5cc13321f042.png)