### PR TITLE
Whitespace fix for master

### DIFF
--- a/pkg/uploader/allowed_file_types_test.go
+++ b/pkg/uploader/allowed_file_types_test.go
@@ -2,6 +2,7 @@ package uploader_test
 
 import (
 	"fmt"
+
 	"github.com/transcom/mymove/pkg/uploader"
 )
 


### PR DESCRIPTION
## Description

I forgot to run `goimports` and broke master as a result.