### PR TITLE
Fix a bug if a pre-approval is not approved

### DIFF
--- a/src/shared/Entities/schema.js
+++ b/src/shared/Entities/schema.js
@@ -91,7 +91,6 @@ export const invoices = new schema.Array(invoice);
 
 // ShipmentLineItem
 export const shipmentLineItem = new schema.Entity('shipmentLineItems', {
-  tariff400ng_item: tariff400ngItem,
   invoice: invoice,
 });
 export const shipmentLineItems = new schema.Array(shipmentLineItem);


### PR DESCRIPTION
## Description

We have a bug when a pre-approval is not approved. 
1. If pre-approval is not approved, the corresponding item code is removed from the `code & item` drop-down
2. If more than 1 pre-approval is of the same type, and one of the pre-approvals is not approved, we see a `js` error.

(See pivotal story for 2 vids of what happens)

Note: this undoes this pr which denormalizes tariff400ng_item from shipment line items:
https://github.com/transcom/mymove/pull/1368

## Setup

`make db_dev_e2e_populate`
`make server_run`
`make office_client_run`

* add any pre-approval request (or multiple of the same type).
* click on the `x` next to one of the pre-approvals in the table and verify that no error is shown in the browser.
* ensure you can create another pre-approval request of the same type you just deleted.

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/164212898) for this change

## Screenshots

![feb-25-2019 14-20-39](https://user-images.githubusercontent.com/3099491/53366176-97c06200-3908-11e9-9481-06d6200cedda.gif)

