### PR TITLE
remove unused column and use actual dates in calculators if we have them

### DIFF
--- a/migrations/20190225165937_remove_planned_move_date.up.fizz
+++ b/migrations/20190225165937_remove_planned_move_date.up.fizz
@@ -1,0 +1,1 @@
+drop_column("personally_procured_moves", "planned_move_date")

--- a/src/scenes/Office/Ppm/IncentiveCalculator.jsx
+++ b/src/scenes/Office/Ppm/IncentiveCalculator.jsx
@@ -59,8 +59,8 @@ const schema = {
 };
 export class IncentiveCalculator extends Component {
   calculate = values => {
-    const { pickup_postal_code, destination_postal_code, weight } = values;
-    const moveDate = values.actual_move_date || values.original_move_date;
+    const { pickup_postal_code, destination_postal_code, weight, original_move_date, actual_move_date } = values;
+    const moveDate = actual_move_date || original_move_date;
     this.props.getPpmIncentive(moveDate, pickup_postal_code, destination_postal_code, weight);
   };
   reset = async () => {
@@ -180,4 +180,6 @@ function mapStateToProps(state, ownProps) {
 function mapDispatchToProps(dispatch) {
   return bindActionCreators({ getPpmIncentive, clearPpmIncentive }, dispatch);
 }
-export default connect(mapStateToProps, mapDispatchToProps)(reduxForm({ form: formName })(IncentiveCalculator));
+export default connect(mapStateToProps, mapDispatchToProps)(
+  reduxForm({ form: formName, enableReinitialize: true, keepDirtyOnReinitialize: true })(IncentiveCalculator),
+);

--- a/src/scenes/Office/Ppm/IncentiveCalculator.jsx
+++ b/src/scenes/Office/Ppm/IncentiveCalculator.jsx
@@ -22,6 +22,14 @@ const schema = {
       'x-nullable': true,
       'x-always-required': true,
     },
+    actual_move_date: {
+      type: 'string',
+      format: 'date',
+      example: '2018-04-26',
+      title: 'Move Date',
+      'x-nullable': true,
+      'x-always-required': false,
+    },
     pickup_postal_code: {
       type: 'string',
       format: 'zip',
@@ -51,8 +59,9 @@ const schema = {
 };
 export class IncentiveCalculator extends Component {
   calculate = values => {
-    const { original_move_date, pickup_postal_code, destination_postal_code, weight } = values;
-    this.props.getPpmIncentive(original_move_date, pickup_postal_code, destination_postal_code, weight);
+    const { pickup_postal_code, destination_postal_code, weight } = values;
+    const moveDate = values.actual_move_date || values.original_move_date;
+    this.props.getPpmIncentive(moveDate, pickup_postal_code, destination_postal_code, weight);
   };
   reset = async () => {
     const { reset, clearPpmIncentive } = this.props;
@@ -63,7 +72,8 @@ export class IncentiveCalculator extends Component {
     this.reset();
   }
   render() {
-    const { handleSubmit, calculation, invalid, pristine, submitting, hasErrored } = this.props;
+    const { handleSubmit, calculation, invalid, pristine, submitting, hasErrored, initialValues } = this.props;
+    const moveDateField = initialValues.actual_move_date ? 'actual_move_date' : 'original_move_date';
     return (
       <div className="calculator-panel incentive-calc">
         <div className="calculator-panel-title">Incentive Calculator</div>
@@ -78,12 +88,7 @@ export class IncentiveCalculator extends Component {
             )}
 
             <div className="usa-width-one-half">
-              <SwaggerField
-                className="date-field"
-                fieldName="original_move_date"
-                swagger={this.props.schema}
-                required
-              />
+              <SwaggerField className="date-field" fieldName={moveDateField} swagger={this.props.schema} required />
               <SwaggerField className="short-field" fieldName="weight" swagger={this.props.schema} required />
             </div>
             <div className="usa-width-one-half">
@@ -161,6 +166,7 @@ IncentiveCalculator.propTypes = {
 function mapStateToProps(state, ownProps) {
   const initialValues = pick(selectPPMForMove(state, ownProps.moveId), [
     'original_move_date',
+    'actual_move_date',
     'pickup_postal_code',
     'destination_postal_code',
   ]);

--- a/src/scenes/Office/Ppm/StorageReimbursementCalculator.jsx
+++ b/src/scenes/Office/Ppm/StorageReimbursementCalculator.jsx
@@ -22,6 +22,14 @@ const schema = {
       'x-nullable': true,
       'x-always-required': true,
     },
+    actual_move_date: {
+      type: 'string',
+      format: 'date',
+      example: '2018-04-26',
+      title: 'Move Date',
+      'x-nullable': true,
+      'x-always-required': false,
+    },
     pickup_postal_code: {
       type: 'string',
       format: 'zip',
@@ -67,18 +75,23 @@ export class StorageReimbursementCalculator extends Component {
     this.reset();
   }
   calculate = values => {
-    const { original_move_date, pickup_postal_code, destination_postal_code, days_in_storage, weight } = values;
-    this.props.getPpmSitEstimate(
-      original_move_date,
-      days_in_storage,
-      pickup_postal_code,
-      destination_postal_code,
-      weight,
-    );
+    const { pickup_postal_code, destination_postal_code, days_in_storage, weight } = values;
+    const moveDate = values.actual_move_date || values.original_move_date;
+    this.props.getPpmSitEstimate(moveDate, days_in_storage, pickup_postal_code, destination_postal_code, weight);
   };
 
   render() {
-    const { handleSubmit, sitReimbursement, invalid, pristine, submitting, hasEstimateError } = this.props;
+    const {
+      handleSubmit,
+      sitReimbursement,
+      invalid,
+      pristine,
+      submitting,
+      hasEstimateError,
+      initialValues,
+    } = this.props;
+    const moveDateField = initialValues.actual_move_date ? 'actual_move_date' : 'original_move_date';
+
     return (
       <div className="calculator-panel storage-calc">
         <div className="calculator-panel-title">Storage Calculator</div>
@@ -92,12 +105,7 @@ export class StorageReimbursementCalculator extends Component {
               </div>
             )}
             <div className="usa-width-one-half">
-              <SwaggerField
-                className="date-field"
-                fieldName="original_move_date"
-                swagger={this.props.schema}
-                required
-              />
+              <SwaggerField className="date-field" fieldName={moveDateField} swagger={this.props.schema} required />
               <SwaggerField className="short-field" fieldName="weight" swagger={this.props.schema} required />
             </div>
             <div className="usa-width-one-half">
@@ -156,6 +164,7 @@ StorageReimbursementCalculator.propTypes = {
 function mapStateToProps(state, ownProps) {
   const initialValues = pick(selectPPMForMove(state, ownProps.moveId), [
     'original_move_date',
+    'actual_move_date',
     'pickup_postal_code',
     'destination_postal_code',
     'days_in_storage',

--- a/src/scenes/Office/Ppm/StorageReimbursementCalculator.jsx
+++ b/src/scenes/Office/Ppm/StorageReimbursementCalculator.jsx
@@ -75,8 +75,15 @@ export class StorageReimbursementCalculator extends Component {
     this.reset();
   }
   calculate = values => {
-    const { pickup_postal_code, destination_postal_code, days_in_storage, weight } = values;
-    const moveDate = values.actual_move_date || values.original_move_date;
+    const {
+      pickup_postal_code,
+      destination_postal_code,
+      days_in_storage,
+      weight,
+      actual_move_date,
+      original_move_date,
+    } = values;
+    const moveDate = actual_move_date || original_move_date;
     this.props.getPpmSitEstimate(moveDate, days_in_storage, pickup_postal_code, destination_postal_code, weight);
   };
 
@@ -182,5 +189,7 @@ function mapDispatchToProps(dispatch) {
 }
 
 export default connect(mapStateToProps, mapDispatchToProps)(
-  reduxForm({ form: formName })(StorageReimbursementCalculator),
+  reduxForm({ form: formName, enableReinitialize: true, keepDirtyOnReinitialize: true })(
+    StorageReimbursementCalculator,
+  ),
 );


### PR DESCRIPTION
## Description

Display the actual dates in the calculators if we have them and remove the planned move date since it's been backfilled to original move date and is no longer being used.

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make db_dev_e2e_populate
```
Start the server and office client
Visit a ppm as an office user. See the ppm tab should have that ppm's original move date in both calculators. In the dates and locations panel, edit them and you should see that the dates in the panels switch to using the actual move date.

## Code Review Verification Steps

* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* 2nd half of https://www.pivotaltracker.com/story/show/163713620
