### PR TITLE
Add notes to details column for PARs 105be: 162820562

### DIFF
--- a/src/shared/PreApprovalRequest/Code105Details.jsx
+++ b/src/shared/PreApprovalRequest/Code105Details.jsx
@@ -18,7 +18,8 @@ export const Code105Details = props => {
     <td>
       {row.description} <br />
       {crateDetails} <br />
-      {ItemDetails}
+      {ItemDetails} <br />
+      {row.notes}
     </td>
   );
 };


### PR DESCRIPTION
## Description

Adding notes to the `details` column for 105b/e pre-approval items.

More info: Forgot to add the `notes` field in the `details` column when we did our big pull request: https://github.com/transcom/mymove/pull/1750

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

`make db_dev_e2e_populate`
`make server_run`
`make tsp_client_run`

## Code Review Verification Steps
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/162820562) for this change

## Screenshots
The 2nd 105B item in this screen shot doesn't have any data in the `notes` field since that's not a required field...

<img width="826" alt="screen shot 2019-02-25 at 9 09 58 pm" src="https://user-images.githubusercontent.com/3099491/53384803-bee75580-3941-11e9-8fef-65a00a3a6072.png">
