### PR TITLE
Remove gbl number from public api

### DIFF
--- a/cypress/integration/office/officeUserHHG.js
+++ b/cypress/integration/office/officeUserHHG.js
@@ -1,5 +1,5 @@
 /* global cy */
-describe('office user finds the shipment', function() {
+describe('office user finds the hhg shipment', function() {
   beforeEach(() => {
     cy.signIntoOffice();
   });

--- a/cypress/integration/office/officeUserHHGPPM.js
+++ b/cypress/integration/office/officeUserHHGPPM.js
@@ -1,6 +1,6 @@
 /* global cy */
 
-describe('office user finds the shipment', function() {
+describe('office user finds the combo shipment', function() {
   beforeEach(() => {
     cy.signIntoOffice();
   });

--- a/pkg/handlers/publicapi/shipments.go
+++ b/pkg/handlers/publicapi/shipments.go
@@ -45,7 +45,6 @@ func payloadForShipmentModel(s models.Shipment) *apimessages.Shipment {
 		Status:           apimessages.ShipmentStatus(s.Status),
 		SourceGbloc:      payloadForGBLOC(s.SourceGBLOC),
 		DestinationGbloc: payloadForGBLOC(s.DestinationGBLOC),
-		GblNumber:        s.GBLNumber,
 		Market:           payloadForMarkets(s.Market),
 		CreatedAt:        strfmt.DateTime(s.CreatedAt),
 		UpdatedAt:        strfmt.DateTime(s.UpdatedAt),

--- a/pkg/handlers/publicapi/shipments_test.go
+++ b/pkg/handlers/publicapi/shipments_test.go
@@ -55,7 +55,6 @@ func (suite *HandlerSuite) TestPayloadForShipmentWithNullValues() {
 	// Set all values that can be nil to nil
 	shipment.SourceGBLOC = nil
 	shipment.DestinationGBLOC = nil
-	shipment.GBLNumber = nil
 	shipment.Market = nil
 	shipment.TrafficDistributionListID = nil
 	shipment.TrafficDistributionList = nil
@@ -89,7 +88,6 @@ func (suite *HandlerSuite) TestPayloadForShipmentWithNullValues() {
 	shipmentPayload := payloadForShipmentModel(shipment)
 	suite.Nil(shipmentPayload.SourceGbloc)
 	suite.Nil(shipmentPayload.DestinationGbloc)
-	suite.Nil(shipmentPayload.GblNumber)
 	suite.Nil(shipmentPayload.Market)
 	suite.Nil(shipmentPayload.TrafficDistributionList)
 	suite.Nil(shipmentPayload.ActualPickupDate)

--- a/swagger/api.yaml
+++ b/swagger/api.yaml
@@ -1023,11 +1023,6 @@ definitions:
       destination_gbloc:
         $ref: '#/definitions/GBLOC'
         readOnly: true
-      gbl_number:
-        type: string
-        example: 'KKFA9999999'
-        x-nullable: true
-        title: GBL Number
       market:
         $ref: '#/definitions/ShipmentMarket'
         readOnly: true


### PR DESCRIPTION
## Description

Removes GBL number from the public api shipment payload since it wasn't being used anywhere.

Side note: I also renamed two e2e test names since they were identical, and that was confusing to me.

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

Just make sure all the tests still pass to make sure that removing this didn't break anything.

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* https://www.pivotaltracker.com/story/show/163410725
