### PR TITLE
Reset requests on unmount in the office app

### DIFF
--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -52,7 +52,14 @@ import { getTspForShipment } from 'shared/Entities/modules/transportationService
 import { getServiceAgentsForShipment, selectServiceAgentsForShipment } from 'shared/Entities/modules/serviceAgents';
 
 import { showBanner, removeBanner } from './ducks';
-import { loadMove, selectMove, selectMoveStatus, approveBasics, cancelMove } from 'shared/Entities/modules/moves';
+import {
+  loadMove,
+  loadMoveLabel,
+  selectMove,
+  selectMoveStatus,
+  approveBasics,
+  cancelMove,
+} from 'shared/Entities/modules/moves';
 import { formatDate } from 'shared/formatters';
 import { selectAllDocumentsForMove, getMoveDocumentsForMove } from 'shared/Entities/modules/moveDocuments';
 
@@ -142,9 +149,16 @@ class MoveInfo extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    const { loadBackupContacts, loadOrders, loadServiceMember, ordersId, serviceMemberId, shipmentId } = this.props;
-    // Once we can get one of the ids, they all should be present
-    if (ordersId !== prevProps.ordersId) {
+    const {
+      loadBackupContacts,
+      loadOrders,
+      loadMoveIsSuccess,
+      loadServiceMember,
+      ordersId,
+      serviceMemberId,
+      shipmentId,
+    } = this.props;
+    if (loadMoveIsSuccess !== prevProps.loadMoveIsSuccess && loadMoveIsSuccess) {
       loadOrders(ordersId);
       loadServiceMember(serviceMemberId);
       loadBackupContacts(serviceMemberId);
@@ -487,12 +501,14 @@ const mapStateToProps = (state, ownProps) => {
   const serviceMemberId = move.service_member_id;
   const serviceMember = selectServiceMember(state, serviceMemberId);
   const loadOrdersStatus = getRequestStatus(state, loadOrdersLabel);
+  const loadMoveIsSuccess = getRequestStatus(state, loadMoveLabel).isSuccess;
 
   return {
     approveMoveHasError: get(state, 'office.moveHasApproveError'),
     errorMessage: get(state, 'office.error'),
     loadDependenciesHasError: loadOrdersStatus.error,
     loadDependenciesHasSuccess: loadOrdersStatus.isSuccess,
+    loadMoveIsSuccess,
     moveDocuments: selectAllDocumentsForMove(state, moveId),
     ppm,
     move,

--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -33,6 +33,7 @@ import PreApprovalPanel from 'shared/PreApprovalRequest/PreApprovalPanel.jsx';
 import InvoicePanel from 'shared/Invoice/InvoicePanel.jsx';
 
 import { getRequestStatus } from 'shared/Swagger/selectors';
+import { resetRequests } from 'shared/Swagger/request';
 import { getAllTariff400ngItems, selectTariff400ngItems } from 'shared/Entities/modules/tariff400ngItems';
 import { getAllShipmentLineItems, selectSortedShipmentLineItems } from 'shared/Entities/modules/shipmentLineItems';
 import { getAllInvoices } from 'shared/Entities/modules/invoices';
@@ -151,6 +152,10 @@ class MoveInfo extends Component {
         this.getAllShipmentInfo(shipmentId);
       }
     }
+  }
+
+  componentWillUnmount() {
+    this.props.resetRequests();
   }
 
   getAllShipmentInfo = shipmentId => {
@@ -533,6 +538,7 @@ const mapDispatchToProps = dispatch =>
       loadServiceMember,
       loadBackupContacts,
       loadOrders,
+      resetRequests,
     },
     dispatch,
   );


### PR DESCRIPTION
## Description

Now that we're using the requests to track if the move is loading, make sure we wipe them when we unmount so the requests we see are relevant to the current move.

## Reviewer Notes

This opens up a larger discussion with product around showing stale data while we make network requests, but let's fix this bug for now and address our overall strategy elsewhere.

## Code Review Verification Steps

* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/164173908) for this change

## Screenshots
Before code changes:
![before_change](https://user-images.githubusercontent.com/4434681/53453292-88104e80-39d8-11e9-93af-5b2a0e2b213f.gif)

After code changes:
![after_change](https://user-images.githubusercontent.com/4434681/53453308-8e062f80-39d8-11e9-84b7-3f52f75876fe.gif)