### PR TITLE
SSW Destination Layout bug

### DIFF
--- a/pkg/handlers/internalapi/moves.go
+++ b/pkg/handlers/internalapi/moves.go
@@ -265,9 +265,19 @@ func (h ShowShipmentSummaryWorksheetHandler) Handle(params moveop.ShowShipmentSu
 	// page 1
 	page1Layout := paperwork.ShipmentSummaryPage1Layout
 	page1Template, err := assets.Asset(page1Layout.TemplateImagePath)
+	smallerFontSize := float64(8)
+
 	if err != nil {
 		h.Logger().Error("Error reading template file", zap.String("asset", page1Layout.TemplateImagePath), zap.Error(err))
 		return moveop.NewShowShipmentSummaryWorksheetInternalServerError()
+	}
+
+	if len(page1Data.NewDutyAssignment) >= 30 {
+		page1Layout.FieldsLayout["NewDutyAssignment"] = paperwork.FormField(153, 72, 48, &smallerFontSize, nil)
+	}
+
+	if len(page1Data.AuthorizedDestination) >= 30 {
+		page1Layout.FieldsLayout["AuthorizedDestination"] = paperwork.FormField(153.5, 90, 48, &smallerFontSize, nil)
 	}
 
 	page1Reader := bytes.NewReader(page1Template)
@@ -280,6 +290,7 @@ func (h ShowShipmentSummaryWorksheetHandler) Handle(params moveop.ShowShipmentSu
 	// page 2
 	page2Layout := paperwork.ShipmentSummaryPage2Layout
 	page2Template, err := assets.Asset(page2Layout.TemplateImagePath)
+
 	if err != nil {
 		h.Logger().Error("Error reading template file", zap.String("asset", page2Layout.TemplateImagePath), zap.Error(err))
 		return moveop.NewShowShipmentSummaryWorksheetInternalServerError()

--- a/pkg/handlers/internalapi/moves.go
+++ b/pkg/handlers/internalapi/moves.go
@@ -273,11 +273,11 @@ func (h ShowShipmentSummaryWorksheetHandler) Handle(params moveop.ShowShipmentSu
 	}
 
 	if len(page1Data.NewDutyAssignment) >= 30 {
-		page1Layout.FieldsLayout["NewDutyAssignment"] = paperwork.FormField(153, 72, 48, &smallerFontSize, nil)
+		page1Layout.FieldsLayout["NewDutyAssignment"] = paperwork.FormField(153, 72, 48, &smallerFontSize, nil, nil)
 	}
 
 	if len(page1Data.AuthorizedDestination) >= 30 {
-		page1Layout.FieldsLayout["AuthorizedDestination"] = paperwork.FormField(153.5, 90, 48, &smallerFontSize, nil)
+		page1Layout.FieldsLayout["AuthorizedDestination"] = paperwork.FormField(153.5, 90, 48, &smallerFontSize, nil, nil)
 	}
 
 	page1Reader := bytes.NewReader(page1Template)

--- a/pkg/handlers/internalapi/moves.go
+++ b/pkg/handlers/internalapi/moves.go
@@ -265,19 +265,10 @@ func (h ShowShipmentSummaryWorksheetHandler) Handle(params moveop.ShowShipmentSu
 	// page 1
 	page1Layout := paperwork.ShipmentSummaryPage1Layout
 	page1Template, err := assets.Asset(page1Layout.TemplateImagePath)
-	smallerFontSize := float64(8)
 
 	if err != nil {
 		h.Logger().Error("Error reading template file", zap.String("asset", page1Layout.TemplateImagePath), zap.Error(err))
 		return moveop.NewShowShipmentSummaryWorksheetInternalServerError()
-	}
-
-	if len(page1Data.NewDutyAssignment) >= 30 {
-		page1Layout.FieldsLayout["NewDutyAssignment"] = paperwork.FormField(153, 72, 48, &smallerFontSize, nil, nil)
-	}
-
-	if len(page1Data.AuthorizedDestination) >= 30 {
-		page1Layout.FieldsLayout["AuthorizedDestination"] = paperwork.FormField(153.5, 90, 48, &smallerFontSize, nil, nil)
 	}
 
 	page1Reader := bytes.NewReader(page1Template)

--- a/pkg/models/shipment_summary_worksheet.go
+++ b/pkg/models/shipment_summary_worksheet.go
@@ -255,9 +255,9 @@ func FormatValuesShipmentSummaryWorksheetFormPage1(data ShipmentSummaryFormData)
 	page1.TAC = derefStringTypes(data.Order.TAC)
 	page1.SAC = derefStringTypes(data.Order.SAC)
 
-	page1.AuthorizedOrigin = FormatAuthorizedLocation(data.CurrentDutyStation)
-	page1.AuthorizedDestination = FormatAuthorizedLocation(data.NewDutyStation)
-	page1.NewDutyAssignment = FormatDutyStation(data.NewDutyStation)
+	page1.AuthorizedOrigin = FormatLocation(data.CurrentDutyStation)
+	page1.AuthorizedDestination = FormatLocation(data.NewDutyStation)
+	page1.NewDutyAssignment = FormatLocation(data.NewDutyStation)
 
 	page1.WeightAllotment = FormatWeightAllotment(data)
 	page1.WeightAllotmentProgear = FormatWeights(data.WeightAllotment.ProGearWeight)
@@ -358,8 +358,8 @@ func FormatWeightAllotment(data ShipmentSummaryFormData) string {
 	return FormatWeights(data.WeightAllotment.TotalWeightSelf)
 }
 
-//FormatAuthorizedLocation formats AuthorizedOrigin and AuthorizedDestination for Shipment Summary Worksheet
-func FormatAuthorizedLocation(dutyStation DutyStation) string {
+//FormatLocation formats AuthorizedOrigin and AuthorizedDestination for Shipment Summary Worksheet
+func FormatLocation(dutyStation DutyStation) string {
 	return fmt.Sprintf("%s, %s %s", dutyStation.Name, dutyStation.Address.State, dutyStation.Address.PostalCode)
 }
 
@@ -527,11 +527,6 @@ func FormatPPMPickupDate(ppm PersonallyProcuredMove) string {
 		return FormatDate(*ppm.OriginalMoveDate)
 	}
 	return ""
-}
-
-//FormatDutyStation formats DutyStation for Shipment Summary Worksheet
-func FormatDutyStation(dutyStation DutyStation) string {
-	return fmt.Sprintf("%s, %s", dutyStation.Name, dutyStation.Address.State)
 }
 
 //FormatOrdersTypeAndOrdersNumber formats OrdersTypeAndOrdersNumber for Shipment Summary Worksheet

--- a/pkg/models/shipment_summary_worksheet_test.go
+++ b/pkg/models/shipment_summary_worksheet_test.go
@@ -228,7 +228,7 @@ func (suite *ModelSuite) TestFormatValuesShipmentSummaryWorksheetFormPage1() {
 	suite.Equal("NTA4", sswPage1.TAC)
 	suite.Equal("SAC", sswPage1.SAC)
 
-	suite.Equal("Fort Gordon, GA", sswPage1.NewDutyAssignment)
+	suite.Equal("Fort Gordon, GA 30813", sswPage1.NewDutyAssignment)
 
 	suite.Equal("15,000", sswPage1.WeightAllotment)
 	suite.Equal("2,000", sswPage1.WeightAllotmentProgear)

--- a/pkg/models/shipment_summary_worksheet_test.go
+++ b/pkg/models/shipment_summary_worksheet_test.go
@@ -395,12 +395,12 @@ func (suite *ModelSuite) TestFormatWeightAllotment() {
 	suite.Equal("1,000", models.FormatWeightAllotment(noDependant))
 }
 
-func (suite *ModelSuite) TestFormatAuthorizedLocation() {
+func (suite *ModelSuite) TestFormatLocation() {
 	fortGordon := models.DutyStation{Name: "Fort Gordon", Address: models.Address{State: "GA", PostalCode: "30813"}}
 	yuma := models.DutyStation{Name: "Yuma AFB", Address: models.Address{State: "IA", PostalCode: "50309"}}
 
-	suite.Equal("Fort Gordon, GA 30813", models.FormatAuthorizedLocation(fortGordon))
-	suite.Equal("Yuma AFB, IA 50309", models.FormatAuthorizedLocation(yuma))
+	suite.Equal("Fort Gordon, GA 30813", models.FormatLocation(fortGordon))
+	suite.Equal("Yuma AFB, IA 50309", models.FormatLocation(yuma))
 }
 
 func (suite *ModelSuite) TestFormatServiceMemberFullName() {
@@ -504,14 +504,6 @@ func (suite *ModelSuite) TestFormatWeights() {
 	suite.Equal("10", models.FormatWeights(10))
 	suite.Equal("1,000", models.FormatWeights(1000))
 	suite.Equal("1,000,000", models.FormatWeights(1000000))
-}
-
-func (suite *ModelSuite) TestFormatDutyStation() {
-	fortBenning := models.DutyStation{Name: "Fort Benning", Address: models.Address{State: "GA"}}
-	yuma := models.DutyStation{Name: "Yuma AFB", Address: models.Address{State: "AZ"}}
-
-	suite.Equal("Fort Benning, GA", models.FormatDutyStation(fortBenning))
-	suite.Equal("Yuma AFB, AZ", models.FormatDutyStation(yuma))
 }
 
 func (suite *ModelSuite) TestFormatOrdersIssueDate() {

--- a/pkg/paperwork/forms.go
+++ b/pkg/paperwork/forms.go
@@ -250,6 +250,8 @@ func (f *FormFiller) drawData(fields map[string]FieldPos, data interface{}) erro
 		// Apply custom formatting options
 		if formField.fontSize != nil {
 			f.pdf.SetFontSize(*formField.fontSize)
+			fs, _ := f.pdf.GetFontSize()
+			f.ScaleText(displayValue, fs, formField.width)
 		} else {
 			f.pdf.SetFontSize(fontSize)
 		}
@@ -273,6 +275,20 @@ func (f *FormFiller) drawData(fields map[string]FieldPos, data interface{}) erro
 	}
 
 	return f.pdf.Error()
+}
+
+// ScaleText scales the text down to fit the cell if it is too long to fit in one line
+func (f *FormFiller) ScaleText(displayValue string, fontsize float64, width float64) {
+	stringWidth := f.pdf.GetStringWidth(displayValue)
+	for f.isMoreThanOneLine(stringWidth, width) {
+		ptSize, _ := f.pdf.GetFontSize()
+		f.pdf.SetFontSize(ptSize * .95)
+		stringWidth = f.pdf.GetStringWidth(displayValue)
+	}
+}
+
+func (f *FormFiller) isMoreThanOneLine(stringWidth float64, width float64) bool {
+	return stringWidth > (width - 2*f.pdf.GetCellMargin())
 }
 
 // Output outputs the form to the provided file

--- a/pkg/paperwork/forms.go
+++ b/pkg/paperwork/forms.go
@@ -250,11 +250,12 @@ func (f *FormFiller) drawData(fields map[string]FieldPos, data interface{}) erro
 		// Apply custom formatting options
 		if formField.fontSize != nil {
 			f.pdf.SetFontSize(*formField.fontSize)
-			fs, _ := f.pdf.GetFontSize()
-			f.ScaleText(displayValue, fs, formField.width)
 		} else {
 			f.pdf.SetFontSize(fontSize)
 		}
+
+		fs, _ := f.pdf.GetFontSize()
+		f.ScaleText(displayValue, fs, formField.width)
 
 		tempLineHeight := lineHeight
 		if formField.lineHeight != nil {

--- a/pkg/paperwork/forms.go
+++ b/pkg/paperwork/forms.go
@@ -282,10 +282,11 @@ func (f *FormFiller) ScaleText(displayValue string, fontsize float64, width floa
 	stringWidth := f.pdf.GetStringWidth(displayValue)
 	for f.isMoreThanOneLine(stringWidth, width) {
 		ptSize, _ := f.pdf.GetFontSize()
-		if ptSize*.95 <= 5 {
+		newFontSize := ptSize * .95
+		if newFontSize <= 5 {
 			break
 		}
-		f.pdf.SetFontSize(ptSize * .95)
+		f.pdf.SetFontSize(newFontSize)
 		stringWidth = f.pdf.GetStringWidth(displayValue)
 	}
 }

--- a/pkg/paperwork/forms.go
+++ b/pkg/paperwork/forms.go
@@ -282,6 +282,9 @@ func (f *FormFiller) ScaleText(displayValue string, fontsize float64, width floa
 	stringWidth := f.pdf.GetStringWidth(displayValue)
 	for f.isMoreThanOneLine(stringWidth, width) {
 		ptSize, _ := f.pdf.GetFontSize()
+		if ptSize*.95 <= 5 {
+			break
+		}
 		f.pdf.SetFontSize(ptSize * .95)
 		stringWidth = f.pdf.GetStringWidth(displayValue)
 	}

--- a/pkg/paperwork/forms_test.go
+++ b/pkg/paperwork/forms_test.go
@@ -38,3 +38,21 @@ func (suite *PaperworkSuite) TestFormFillerSmokeTest() {
 	err = formFiller.Output(output)
 	suite.FatalNil(err)
 }
+
+func (suite *PaperworkSuite) TestFormScaleFont() {
+	formFiller := NewFormFiller()
+	formFiller.pdf.SetFontSize(10)
+	var cellWidth float64 = 60
+	value := "Joint Base McGuire-Dix-Lakehurst, NJ  08641"
+	stringWidth := formFiller.pdf.GetStringWidth(value)
+	tooLong := formFiller.isMoreThanOneLine(stringWidth, cellWidth)
+
+	suite.True(tooLong)
+	ptSize, _ := formFiller.pdf.GetFontSize()
+	formFiller.ScaleText(value, ptSize, cellWidth)
+
+	stringWidth = formFiller.pdf.GetStringWidth(value)
+	tooLong = formFiller.isMoreThanOneLine(stringWidth, cellWidth)
+	suite.False(tooLong)
+
+}

--- a/pkg/paperwork/shipment_summary_worksheet.go
+++ b/pkg/paperwork/shipment_summary_worksheet.go
@@ -21,7 +21,7 @@ var ShipmentSummaryPage1Layout = FormLayout{
 		"POVAuthorized":                   FormField(102.25, 104, 45, floatPtr(10), nil, nil),
 		"AuthorizedOrigin":                FormField(102.25, 91, 45, floatPtr(10), nil, nil),
 		"MaxSITStorageEntitlement":        FormField(153.5, 104, 49, floatPtr(10), nil, nil),
-		"AuthorizedDestination":           FormField(153.5, 91, 45, floatPtr(10), nil, nil),
+		"AuthorizedDestination":           FormField(153.5, 91, 60, floatPtr(10), nil, nil),
 		"OrdersIssueDate":                 FormField(9.5, 73, 40, floatPtr(10), nil, nil),
 		"OrdersTypeAndOrdersNumber":       FormField(54, 73, 44, floatPtr(10), nil, nil),
 		"IssuingBranchOrAgency":           FormField(102.5, 73, 47, floatPtr(10), nil, nil),


### PR DESCRIPTION
## Description

Have a smaller font size when it is a very long duty station name

## Reviewer Notes
- considered having a dynamic way to lower font size/reposition it based on the coordinates but ended up going with the more simple solution because it was more reliable and I'm not sure if there is ever going to be a case of a super long value unless its the name

## Setup
`make db_dev_e2e_populate`
`make office_client_run`
`make server_run`
Visit a PPM
Download a Worksheet

## Code Review Verification Steps
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/163954022) for this change

## Screenshots
![image](https://user-images.githubusercontent.com/13622298/53500523-5393a580-3a5f-11e9-8cd3-15a170444221.png)
