### PR TITLE
Entering a Move Date updates default calculator dates

### DIFF
--- a/cypress/integration/office/incentiveCalculator.js
+++ b/cypress/integration/office/incentiveCalculator.js
@@ -9,7 +9,7 @@ describe('office user uses incentive calculator', () => {
     // Click on PPM tab
     cy.get('.incentive-calc').within(() => {
       cy
-        .get('input[name="original_move_date"]')
+        .get('input[name="move_date"]')
         .first()
         .clear()
         .type('9/2/2018{enter}')

--- a/cypress/integration/office/storageReimbursementCalculator.js
+++ b/cypress/integration/office/storageReimbursementCalculator.js
@@ -9,7 +9,7 @@ describe('office user uses storage reimbursement calculator', () => {
     // Click on PPM tab
     cy.get('.storage-calc').within(() => {
       cy
-        .get('input[name="original_move_date"]')
+        .get('input[name="move_date"]')
         .first()
         .clear()
         .type('9/2/2018{enter}')

--- a/src/scenes/Office/Ppm/IncentiveCalculator.jsx
+++ b/src/scenes/Office/Ppm/IncentiveCalculator.jsx
@@ -14,15 +14,7 @@ import { getPpmIncentive, clearPpmIncentive } from './ducks';
 const formName = 'ppm_reimbursement_calc';
 const schema = {
   properties: {
-    original_move_date: {
-      type: 'string',
-      format: 'date',
-      example: '2018-04-26',
-      title: 'Move Date',
-      'x-nullable': true,
-      'x-always-required': true,
-    },
-    actual_move_date: {
+    move_date: {
       type: 'string',
       format: 'date',
       example: '2018-04-26',
@@ -59,9 +51,8 @@ const schema = {
 };
 export class IncentiveCalculator extends Component {
   calculate = values => {
-    const { pickup_postal_code, destination_postal_code, weight, original_move_date, actual_move_date } = values;
-    const moveDate = actual_move_date || original_move_date;
-    this.props.getPpmIncentive(moveDate, pickup_postal_code, destination_postal_code, weight);
+    const { pickup_postal_code, destination_postal_code, weight, move_date } = values;
+    this.props.getPpmIncentive(move_date, pickup_postal_code, destination_postal_code, weight);
   };
   reset = async () => {
     const { reset, clearPpmIncentive } = this.props;
@@ -72,8 +63,7 @@ export class IncentiveCalculator extends Component {
     this.reset();
   }
   render() {
-    const { handleSubmit, calculation, invalid, pristine, submitting, hasErrored, initialValues } = this.props;
-    const moveDateField = initialValues.actual_move_date ? 'actual_move_date' : 'original_move_date';
+    const { handleSubmit, calculation, invalid, pristine, submitting, hasErrored } = this.props;
     return (
       <div className="calculator-panel incentive-calc">
         <div className="calculator-panel-title">Incentive Calculator</div>
@@ -88,7 +78,7 @@ export class IncentiveCalculator extends Component {
             )}
 
             <div className="usa-width-one-half">
-              <SwaggerField className="date-field" fieldName={moveDateField} swagger={this.props.schema} required />
+              <SwaggerField className="date-field" fieldName="move_date" swagger={this.props.schema} required />
               <SwaggerField className="short-field" fieldName="weight" swagger={this.props.schema} required />
             </div>
             <div className="usa-width-one-half">
@@ -164,18 +154,15 @@ IncentiveCalculator.propTypes = {
 };
 
 function mapStateToProps(state, ownProps) {
-  const initialValues = pick(selectPPMForMove(state, ownProps.moveId), [
-    'original_move_date',
-    'actual_move_date',
-    'pickup_postal_code',
-    'destination_postal_code',
-  ]);
-  const props = {
+  let ppm = selectPPMForMove(state, ownProps.moveId);
+  let initialValues = pick(ppm, ['pickup_postal_code', 'destination_postal_code']);
+
+  initialValues.move_date = ppm.actual_move_date || ppm.original_move_date;
+  return {
     schema,
     ...state.ppmIncentive,
     initialValues,
   };
-  return props;
 }
 function mapDispatchToProps(dispatch) {
   return bindActionCreators({ getPpmIncentive, clearPpmIncentive }, dispatch);

--- a/src/scenes/Office/Ppm/StorageReimbursementCalculator.jsx
+++ b/src/scenes/Office/Ppm/StorageReimbursementCalculator.jsx
@@ -67,16 +67,8 @@ export class StorageReimbursementCalculator extends Component {
     this.reset();
   }
   calculate = values => {
-    const {
-      pickup_postal_code,
-      destination_postal_code,
-      days_in_storage,
-      weight,
-      actual_move_date,
-      original_move_date,
-    } = values;
-    const moveDate = actual_move_date || original_move_date;
-    this.props.getPpmSitEstimate(moveDate, days_in_storage, pickup_postal_code, destination_postal_code, weight);
+    const { pickup_postal_code, destination_postal_code, days_in_storage, weight, move_date } = values;
+    this.props.getPpmSitEstimate(move_date, days_in_storage, pickup_postal_code, destination_postal_code, weight);
   };
 
   render() {

--- a/src/scenes/Office/Ppm/StorageReimbursementCalculator.jsx
+++ b/src/scenes/Office/Ppm/StorageReimbursementCalculator.jsx
@@ -14,15 +14,7 @@ import { getPpmSitEstimate, clearPpmSitEstimate } from '../../Moves/Ppm/ducks';
 const formName = 'storage_reimbursement_calc';
 const schema = {
   properties: {
-    original_move_date: {
-      type: 'string',
-      format: 'date',
-      example: '2018-04-26',
-      title: 'Move Date',
-      'x-nullable': true,
-      'x-always-required': true,
-    },
-    actual_move_date: {
+    move_date: {
       type: 'string',
       format: 'date',
       example: '2018-04-26',
@@ -88,16 +80,7 @@ export class StorageReimbursementCalculator extends Component {
   };
 
   render() {
-    const {
-      handleSubmit,
-      sitReimbursement,
-      invalid,
-      pristine,
-      submitting,
-      hasEstimateError,
-      initialValues,
-    } = this.props;
-    const moveDateField = initialValues.actual_move_date ? 'actual_move_date' : 'original_move_date';
+    const { handleSubmit, sitReimbursement, invalid, pristine, submitting, hasEstimateError } = this.props;
 
     return (
       <div className="calculator-panel storage-calc">
@@ -112,7 +95,7 @@ export class StorageReimbursementCalculator extends Component {
               </div>
             )}
             <div className="usa-width-one-half">
-              <SwaggerField className="date-field" fieldName={moveDateField} swagger={this.props.schema} required />
+              <SwaggerField className="date-field" fieldName="move_date" swagger={this.props.schema} required />
               <SwaggerField className="short-field" fieldName="weight" swagger={this.props.schema} required />
             </div>
             <div className="usa-width-one-half">
@@ -169,20 +152,15 @@ StorageReimbursementCalculator.propTypes = {
 };
 
 function mapStateToProps(state, ownProps) {
-  const initialValues = pick(selectPPMForMove(state, ownProps.moveId), [
-    'original_move_date',
-    'actual_move_date',
-    'pickup_postal_code',
-    'destination_postal_code',
-    'days_in_storage',
-  ]);
-  const props = {
+  let ppm = selectPPMForMove(state, ownProps.moveId);
+  let initialValues = pick(ppm, ['pickup_postal_code', 'destination_postal_code', 'days_in_storage']);
+  initialValues.move_date = ppm.actual_move_date || ppm.original_move_date;
+  return {
     schema,
     hasEstimateError: state.ppm.hasEstimateError,
     sitReimbursement: state.ppm.sitReimbursement,
     initialValues,
   };
-  return props;
 }
 function mapDispatchToProps(dispatch) {
   return bindActionCreators({ getPpmSitEstimate, clearPpmSitEstimate }, dispatch);


### PR DESCRIPTION
## Description

Resolve an issue where entering a departure date wouldn't cause the Move Date fields in the calculators to be updated.

The cause of the issue is that we were dynamically naming a <Field>, which isn't handled
by redux-form by default. Setting a new name for the field caused it to not be considered
"registered" by that library, which prevented the field's value from being updated.

In this case, though, there wasn't a reason for the calculators to be aware of how the move
date they used was determined. By moving the derivation of the move date into mapStateToProps,
we can avoid the behavior of redux-form described above and have the updated move date
propagated as we would expect.

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Setup

1. Bootstrap

    ```sh
    $ make db_dev_e2e_populate
    $ make server_run
    $ make office_client_run
    ```

2. Login in as the first office user.
3. Go to the PPMs tab and select a move called "Approved, PPM". 
4. Go to the PPM tab.
5. Enter a Move Date in the Dates and Locations panel.

You should see the date update in both of the calculators above.


## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](tbd) for this change