### PR TITLE
Add NetWeight for ppms on shipment summary worksheet

### DIFF
--- a/pkg/models/shipment_summary_worksheet.go
+++ b/pkg/models/shipment_summary_worksheet.go
@@ -376,8 +376,7 @@ func FormatAllShipments(ppms PersonallyProcuredMoves, shipments Shipments) Shipm
 	for _, ppm := range ppms {
 		formattedNumberAndTypes[shipmentNumber] = FormatPPMNumberAndType(shipmentNumber)
 		formattedPickUpDates[shipmentNumber] = FormatPPMPickupDate(ppm)
-		// We don't have an actual weight for ppms yet, so we're leaving it blank for now
-		formattedShipmentWeights[shipmentNumber] = ""
+		formattedShipmentWeights[shipmentNumber] = FormatPPMWeight(ppm)
 		formattedShipmentStatuses[shipmentNumber] = FormatCurrentPPMStatus(ppm)
 		shipmentNumber++
 	}
@@ -489,6 +488,15 @@ func FormatShipmentWeight(shipment Shipment) string {
 func FormatShipmentPickupDate(shipment Shipment) string {
 	if shipment.ActualPickupDate != nil {
 		return FormatDate(*shipment.ActualPickupDate)
+	}
+	return ""
+}
+
+//FormatPPMWeight formats a ppms NetWeight for the Shipment Summary Worksheet
+func FormatPPMWeight(ppm PersonallyProcuredMove) string {
+	if ppm.NetWeight != nil {
+		wtg := FormatWeights(int(*ppm.NetWeight))
+		return fmt.Sprintf("%s lbs - FINAL", wtg)
 	}
 	return ""
 }

--- a/pkg/models/shipment_summary_worksheet_test.go
+++ b/pkg/models/shipment_summary_worksheet_test.go
@@ -235,7 +235,7 @@ func (suite *ModelSuite) TestFormatValuesShipmentSummaryWorksheetFormPage1() {
 
 	suite.Equal("01 - HHG (GBL)\n\n02 - PPM", sswPage1.ShipmentNumberAndTypes)
 	suite.Equal("11-Jan-2019\n\n11-Jan-2019", sswPage1.ShipmentPickUpDates)
-	suite.Equal("5,000 lbs - FINAL\n\n", sswPage1.ShipmentWeights)
+	suite.Equal("5,000 lbs - FINAL\n\n4,000 lbs - FINAL", sswPage1.ShipmentWeights)
 	suite.Equal("Delivered\n\nAt destination", sswPage1.ShipmentCurrentShipmentStatuses)
 
 	suite.Equal("17,500", sswPage1.TotalWeightAllotmentRepeat)
@@ -516,4 +516,13 @@ func (suite *ModelSuite) TestFormatServiceMemberAffiliation() {
 
 	suite.Equal("Air Force", models.FormatServiceMemberAffiliation(&airForce))
 	suite.Equal("Marines", models.FormatServiceMemberAffiliation(&marines))
+}
+
+func (suite *ModelSuite) TestFormatPPMWeight() {
+	var pounds int64 = 1000
+	ppm := models.PersonallyProcuredMove{NetWeight: &pounds}
+	noWtg := models.PersonallyProcuredMove{NetWeight: nil}
+
+	suite.Equal("1,000 lbs - FINAL", models.FormatPPMWeight(ppm))
+	suite.Equal("", models.FormatPPMWeight(noWtg))
 }


### PR DESCRIPTION
## Description

System populates net PPM shipment weight

## Setup

`make server_test`

### Test in the office client
`make server_run`
`make office_client_run`

1) Log into the office app and select a move with a PPM
2) Make sure that the PPM has a "Net Weight" in the Weights panel
2) Click Create Paperwork -> Click Download worksheet

### Test with cmd line tool
` go run cmd/generate_shipment_summary/main.go -move 0db80bd6-de75-439e-bf89-deaafa1d0dc8 -debug`


## Code Review Verification Steps
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References
* [Pivotal story](https://www.pivotaltracker.com/n/projects/2181745/stories/164259008) 

## Screenshots
![image](https://user-images.githubusercontent.com/1036969/53652545-64325000-3c06-11e9-8798-9054d85869a2.png)
