### PR TITLE
Refactor Server

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -4,7 +4,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"log"
 	"net/http"
 	"time"
 
@@ -22,172 +21,98 @@ const (
 // certificate verification, but is missing a CA certificate
 var ErrMissingCACert = errors.New("missing required CA certificate")
 
-// ErrUnparseableCACert represents an error cause by a misconfigured CA certificate
-// that was unable to be parsed.
-var ErrUnparseableCACert = errors.New("unable to parse CA certificate")
+var cipherSuites = []uint16{
+	tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+	tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+	tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
+	tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
+	tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+	tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+}
 
-type serverFunc func(server *http.Server) error
+var curvePreferences = []tls.CurveID{
+	tls.CurveP256,
+	tls.X25519,
+}
 
-// Server represents an http or https listening server. HTTPS listeners support
-// requiring client authentication with a provided CA.
+// CreateServerInput contains the input for the CreateServer function.
+type CreateServerInput struct {
+	Host         string
+	Port         int
+	Logger       *zap.Logger
+	HTTPHandler  http.Handler
+	ClientAuth   tls.ClientAuthType
+	Certificates []tls.Certificate
+	ClientCAs    *x509.CertPool // CaCertPool
+}
+
+// Server wraps *http.Server to override the definition of ListenAndServeTLS, but bypasses some restrictions.
 type Server struct {
-	CaCertPool     *x509.CertPool
-	ClientAuthType tls.ClientAuthType
-	HTTPHandler    http.Handler
-	ListenAddress  string
-	Logger         *zap.Logger
-	Port           int
-	TLSCerts       []tls.Certificate
+	*http.Server
 }
 
-// addr generates an address:port string to be used in defining an http.Server
-func addr(listenAddress string, port int) string {
-	return fmt.Sprintf("%s:%d", listenAddress, port)
-}
-
-// stdLogError creates a *log.logger based off an existing zap.Logger instance.
-// Some libraries call log.logger directly, which isn't structured as JSON. This method
-// Will reformat log calls as zap.Error logs.
-func stdLogError(logger *zap.Logger) (*log.Logger, error) {
-	standardLog, err := zap.NewStdLogAt(logger, zapcore.ErrorLevel)
+// ListenAndServeTLS is similar to (*http.Server).ListenAndServeTLS, but bypasses some restrictions.
+func (s *Server) ListenAndServeTLS() error {
+	listener, err := tls.Listen("tcp", s.Addr, s.TLSConfig)
 	if err != nil {
-		return nil, err
-
+		return err
 	}
-	return standardLog, nil
+	defer listener.Close()
+	return s.Serve(listener)
 }
 
-// serverConfig generates a *http.Server with a structured error logger.
-func (s Server) serverConfig(tlsConfig *tls.Config) (*http.Server, error) {
-	// By detault http.Server will use the standard logging library which isn't
-	// structured JSON. This will pass zap.Logger with log level error
-	standardLog, err := stdLogError(s.Logger)
+// CreateServer returns a no-tls, tls, or mutual-tls Server based on the input given and an error, if any.
+func CreateServer(input *CreateServerInput) (*Server, error) {
+
+	address := fmt.Sprintf("%s:%d", input.Host, input.Port)
+
+	// Creates a *log.logger based off an existing zap.Logger instance.
+	// Some libraries call log.logger directly, which isn't structured as JSON. This method
+	// Will reformat log calls as zap.Error logs.
+	standardLog, err := zap.NewStdLogAt(input.Logger, zapcore.ErrorLevel)
 	if err != nil {
-		s.Logger.Error("failed to create an error logger", zap.Error(err))
-		return nil, errors.Wrap(err, "Faile")
+		return nil, errors.Wrap(err, "failed to create an error logger")
 	}
 
-	serverConfig := &http.Server{
-		Addr:           addr(s.ListenAddress, s.Port),
+	var tlsConfig *tls.Config
+	if len(input.Certificates) > 0 {
+
+		if input.ClientAuth == tls.VerifyClientCertIfGiven || input.ClientAuth == tls.RequireAndVerifyClientCert {
+			if input.ClientCAs == nil || len(input.ClientCAs.Subjects()) == 0 {
+				return nil, ErrMissingCACert
+			}
+		}
+
+		// Follow Mozilla's "modern" server side TLS recommendations
+		// https://wiki.mozilla.org/Security/Server_Side_TLS#Modern_compatibility
+		// https://statics.tls.security.mozilla.org/server-side-tls-conf-4.0.json
+		// This configuration is compatible with Firefox 27, Chrome 30, IE 11 on
+		// Windows 7, Edge, Opera 17, Safari 9, Android 5.0, and Java 8
+		tlsConfig = &tls.Config{
+			CipherSuites:             cipherSuites,
+			Certificates:             input.Certificates,
+			ClientAuth:               input.ClientAuth,
+			ClientCAs:                input.ClientCAs,
+			CurvePreferences:         curvePreferences,
+			MinVersion:               tls.VersionTLS12,
+			NextProtos:               []string{"h2"},
+			PreferServerCipherSuites: true,
+		}
+
+		// Map certificates with the CommonName / DNSNames to support
+		// Server Name Indication (SNI). In other words this will tell
+		// the TLS listener to sever the appropriate certificate matching
+		// the requested hostname.
+		tlsConfig.BuildNameToCertificate()
+	}
+
+	return &Server{Server: &http.Server{
+		Addr:           address,
 		ErrorLog:       standardLog,
-		Handler:        s.HTTPHandler,
+		Handler:        input.HTTPHandler,
 		IdleTimeout:    idleTimeout,
 		MaxHeaderBytes: maxHeaderSize,
 		TLSConfig:      tlsConfig,
-	}
-	return serverConfig, err
-}
+	}}, nil
 
-// tlsConfig generates a new *tls.Config based on Mozilla's recommendations and returns an error, if any.
-func (s Server) tlsConfig() (*tls.Config, error) {
-
-	// Load client Certificate Authority (CA) if we are requiring client
-	// cert authentication.
-	if s.ClientAuthType == tls.VerifyClientCertIfGiven ||
-		s.ClientAuthType == tls.RequireAndVerifyClientCert {
-		if s.CaCertPool == nil || len(s.CaCertPool.Subjects()) == 0 {
-			return nil, ErrMissingCACert
-		}
-	}
-
-	// Follow Mozilla's "modern" server side TLS recommendations
-	// https://wiki.mozilla.org/Security/Server_Side_TLS#Modern_compatibility
-	// https://statics.tls.security.mozilla.org/server-side-tls-conf-4.0.json
-	// This configuration is compatible with Firefox 27, Chrome 30, IE 11 on
-	// Windows 7, Edge, Opera 17, Safari 9, Android 5.0, and Java 8
-	tlsConfig := &tls.Config{
-		CipherSuites: []uint16{
-			tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
-			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-			tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
-			tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
-			tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
-			tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-		},
-		Certificates: s.TLSCerts,
-		ClientAuth:   s.ClientAuthType,
-		ClientCAs:    s.CaCertPool,
-		CurvePreferences: []tls.CurveID{
-			tls.CurveP256,
-			tls.X25519,
-		},
-		MinVersion:               tls.VersionTLS12,
-		NextProtos:               []string{"h2"},
-		PreferServerCipherSuites: true,
-	}
-
-	// Map certificates with the CommonName / DNSNames to support
-	// Server Name Indication (SNI). In other words this will tell
-	// the TLS listener to sever the appropriate certificate matching
-	// the requested hostname.
-	tlsConfig.BuildNameToCertificate()
-
-	return tlsConfig, nil
-}
-
-// ListenAndServeTLS returns a TLS Listener function for serving HTTPS requests
-func (s Server) ListenAndServeTLS() error {
-	var serverFunc serverFunc
-	var server *http.Server
-	var tlsConfig *tls.Config
-	var err error
-
-	tlsConfig, err = s.tlsConfig()
-	if err != nil {
-		s.Logger.Error("failed to generate a TLS config", zap.Error(err))
-		return err
-	}
-
-	server, err = s.serverConfig(tlsConfig)
-	if err != nil {
-		s.Logger.Error("failed to generate a TLS server config", zap.Error(err))
-		return err
-	}
-
-	s.Logger.Info("start https listener",
-		zap.Duration("idle-timeout", server.IdleTimeout),
-		zap.Any("listen-address", s.ListenAddress),
-		zap.Int("max-header-bytes", server.MaxHeaderBytes),
-		zap.Int("port", s.Port),
-	)
-
-	serverFunc = func(httpServer *http.Server) error {
-		tlsListener, err := tls.Listen("tcp",
-			server.Addr,
-			tlsConfig)
-		if err != nil {
-			return err
-		}
-		defer tlsListener.Close()
-		return server.Serve(tlsListener)
-	}
-
-	return serverFunc(server)
-}
-
-// ListenAndServe returns an HTTP ListenAndServe function for serving HTTP requests
-func (s Server) ListenAndServe() error {
-	var serverFunc serverFunc
-	var server *http.Server
-	var tlsConfig *tls.Config
-	var err error
-
-	server, err = s.serverConfig(tlsConfig)
-	if err != nil {
-		s.Logger.Error("failed to generate a server config", zap.Error(err))
-		return err
-	}
-
-	s.Logger.Info("start http listener",
-		zap.Duration("idle-timeout", server.IdleTimeout),
-		zap.Any("listen-address", s.ListenAddress),
-		zap.Int("max-header-bytes", server.MaxHeaderBytes),
-		zap.Int("port", s.Port),
-	)
-
-	serverFunc = func(httpServer *http.Server) error {
-		return httpServer.ListenAndServe()
-	}
-
-	return serverFunc(server)
 }

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -54,19 +54,17 @@ func (suite *serverSuite) TestParseSingleTLSCert() {
 
 	suite.Nil(err)
 
-	httpsServer := Server{
-		ClientAuthType: tls.NoClientCert,
-		ListenAddress:  "127.0.0.1",
-		HTTPHandler:    suite.httpHandler,
-		Logger:         suite.logger,
-		Port:           8443,
-		TLSCerts:       []tls.Certificate{keyPair},
-	}
-
-	tlsConfig, err := httpsServer.tlsConfig()
+	httpsServer, err := CreateServer(&CreateServerInput{
+		Host:         "127.0.0.1",
+		Port:         8443,
+		ClientAuth:   tls.NoClientCert,
+		HTTPHandler:  suite.httpHandler,
+		Logger:       suite.logger,
+		Certificates: []tls.Certificate{keyPair},
+	})
 	suite.Nil(err)
-	suite.Equal(len(tlsConfig.Certificates), 1)
-	suite.Contains(tlsConfig.NameToCertificate, "localhost")
+	suite.Equal(len(httpsServer.TLSConfig.Certificates), 1)
+	suite.Contains(httpsServer.TLSConfig.NameToCertificate, "localhost")
 }
 
 func (suite *serverSuite) TestParseBadTLSCert() {
@@ -92,22 +90,21 @@ func (suite *serverSuite) TestParseMultipleTLSCerts() {
 
 	suite.Nil(err)
 
-	httpsServer := Server{
-		ClientAuthType: tls.NoClientCert,
-		ListenAddress:  "127.0.0.1",
-		HTTPHandler:    suite.httpHandler,
-		Logger:         suite.logger,
-		Port:           8443,
-		TLSCerts: []tls.Certificate{
+	httpsServer, err := CreateServer(&CreateServerInput{
+		Host:        "127.0.0.1",
+		Port:        8443,
+		ClientAuth:  tls.NoClientCert,
+		HTTPHandler: suite.httpHandler,
+		Logger:      suite.logger,
+		Certificates: []tls.Certificate{
 			keyPairLocalhost,
-			keyPairOffice},
-	}
-
-	tlsConfig, err := httpsServer.tlsConfig()
+			keyPairOffice,
+		},
+	})
 	suite.Nil(err)
-	suite.Equal(len(tlsConfig.Certificates), 2)
-	suite.Contains(tlsConfig.NameToCertificate, "localhost")
-	suite.Contains(tlsConfig.NameToCertificate, "officelocal")
+	suite.Equal(len(httpsServer.TLSConfig.Certificates), 2)
+	suite.Contains(httpsServer.TLSConfig.NameToCertificate, "localhost")
+	suite.Contains(httpsServer.TLSConfig.NameToCertificate, "officelocal")
 }
 
 func (suite *serverSuite) TestTLSConfigWithClientAuth() {
@@ -122,17 +119,15 @@ func (suite *serverSuite) TestTLSConfigWithClientAuth() {
 	caCertPool := x509.NewCertPool()
 	caCertPool.AppendCertsFromPEM(caFile)
 
-	httpsServer := Server{
-		ClientAuthType: tls.RequireAndVerifyClientCert,
-		CaCertPool:     caCertPool,
-		ListenAddress:  "127.0.0.1",
-		HTTPHandler:    suite.httpHandler,
-		Logger:         suite.logger,
-		Port:           8443,
-		TLSCerts:       []tls.Certificate{keyPair},
-	}
-
-	_, err = httpsServer.tlsConfig()
+	_, err = CreateServer(&CreateServerInput{
+		Host:         "127.0.0.1",
+		Port:         8443,
+		ClientAuth:   tls.RequireAndVerifyClientCert,
+		ClientCAs:    caCertPool,
+		HTTPHandler:  suite.httpHandler,
+		Logger:       suite.logger,
+		Certificates: []tls.Certificate{keyPair},
+	})
 	suite.Nil(err)
 }
 
@@ -144,16 +139,14 @@ func (suite *serverSuite) TestTLSConfigWithMissingCA() {
 
 	suite.Nil(err)
 
-	httpsServer := Server{
-		ClientAuthType: tls.RequireAndVerifyClientCert,
-		ListenAddress:  "127.0.0.1",
-		HTTPHandler:    suite.httpHandler,
-		Logger:         suite.logger,
-		Port:           8443,
-		TLSCerts:       []tls.Certificate{keyPair},
-	}
-
-	_, err = httpsServer.tlsConfig()
+	_, err = CreateServer(&CreateServerInput{
+		Host:         "127.0.0.1",
+		Port:         8443,
+		ClientAuth:   tls.RequireAndVerifyClientCert,
+		HTTPHandler:  suite.httpHandler,
+		Logger:       suite.logger,
+		Certificates: []tls.Certificate{keyPair},
+	})
 	suite.Equal(ErrMissingCACert, err)
 }
 
@@ -170,33 +163,26 @@ func (suite *serverSuite) TestTLSConfigWithMisconfiguredCA() {
 	certOk := caCertPool.AppendCertsFromPEM(caFile)
 	suite.False(certOk)
 
-	httpsServer := Server{
-		ClientAuthType: tls.RequireAndVerifyClientCert,
-		CaCertPool:     caCertPool,
-		ListenAddress:  "127.0.0.1",
-		HTTPHandler:    suite.httpHandler,
-		Logger:         suite.logger,
-		Port:           8443,
-		TLSCerts:       []tls.Certificate{keyPair},
-	}
-
-	_, err = httpsServer.tlsConfig()
+	_, err = CreateServer(&CreateServerInput{
+		Host:         "127.0.0.1",
+		Port:         8443,
+		ClientAuth:   tls.RequireAndVerifyClientCert,
+		ClientCAs:    caCertPool,
+		HTTPHandler:  suite.httpHandler,
+		Logger:       suite.logger,
+		Certificates: []tls.Certificate{keyPair},
+	})
 	suite.Equal(ErrMissingCACert, err)
 }
 
 func (suite *serverSuite) TestHTTPServerConfig() {
-	var tlsConfig *tls.Config
-
-	httpServer := Server{
-		ListenAddress: "127.0.0.1",
-		HTTPHandler:   suite.httpHandler,
-		Logger:        suite.logger,
-		Port:          8080,
-	}
-
-	config, err := httpServer.serverConfig(tlsConfig)
-
+	httpsServer, err := CreateServer(&CreateServerInput{
+		Host:        "127.0.0.1",
+		Port:        8080,
+		HTTPHandler: suite.httpHandler,
+		Logger:      suite.logger,
+	})
 	suite.Nil(err)
-	suite.Equal(config.Addr, "127.0.0.1:8080")
-	suite.Equal(suite.httpHandler, config.Handler)
+	suite.Equal(httpsServer.Addr, "127.0.0.1:8080")
+	suite.Equal(suite.httpHandler, httpsServer.Handler)
 }


### PR DESCRIPTION
## Description

This PR refactors the `server` package to support graceful shutdown (#1799).  This PR thins the differential between our custom server and the `http.Server` by aligning variables names and adding a `server.CreateServer(input *CreateServerInput)` func.  The server now only overrides `(*http.Server).ListenAndServeTLS()` and moves config to `const` variables when possible.

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Setup

None

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](./docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](./docs/backend.md#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](./docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
  * [ ] Secure migrations have been tested using `bin/run-prod-migrations`
* [ ] There are no aXe warnings for UI.
* [ ] This works in IE.
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @ntwyman
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/160428223) for this change

## Screenshots

N.A.