### PR TITLE
Restrict access to dps_auth_cookie_url

### DIFF
--- a/pkg/handlers/internalapi/dps_auth_cookie_url.go
+++ b/pkg/handlers/internalapi/dps_auth_cookie_url.go
@@ -32,12 +32,17 @@ type DPSAuthGetCookieURLHandler struct {
 
 // Handle generates the URL to redirect to that begins the authentication process for DPS
 func (h DPSAuthGetCookieURLHandler) Handle(params dps_auth.GetCookieURLParams) middleware.Responder {
-	// Only DPS users can set the cookie name and redirect URL for testing purposes
-	if params.CookieName != nil || params.DpsRedirectURL != nil {
-		session := auth.SessionFromRequestContext(params.HTTPRequest)
-		if !session.IsDpsUser() {
-			return dps_auth.NewGetCookieURLForbidden()
-		}
+	// TODO: Currently, only whitelisted DPS users can access this endpoint because
+	//   1. The /dps_cookie page is ungated on the front-end. The restriction here will prevent
+	//      people from actually doing anything useful with that page.
+	//   2. This feature is in testing and isn't open to service members yet.
+	// However, when we're able to gate the /dps_cookie page on the front end and/or we're ready to
+	// launch this feature, all service members should be able to access this endpoint.
+	// Important: Only DPS users should ever be allowed to set parameters though (for testing).
+	// Service members should never be allowed to set params and only be allowed to use the default params.
+	session := auth.SessionFromRequestContext(params.HTTPRequest)
+	if !session.IsDpsUser() {
+		return dps_auth.NewGetCookieURLForbidden()
 	}
 
 	dpsParams := h.DPSAuthParams()

--- a/pkg/handlers/internalapi/dps_auth_cookie_url_test.go
+++ b/pkg/handlers/internalapi/dps_auth_cookie_url_test.go
@@ -33,17 +33,16 @@ func (suite *HandlerSuite) TestDPSAuthCookieURLHandler() {
 	params.HTTPRequest = request
 
 	response := handler.Handle(params)
-	okResponse := response.(*dps_auth.GetCookieURLOK)
-	url, _ := url.Parse(okResponse.Payload.CookieURL.String())
-	suite.Equal(url.Scheme, dpsAuthParams.SDDCProtocol)
-	suite.Equal(url.Host, fmt.Sprintf("%s:%s", dpsAuthParams.SDDCHostname, dpsAuthParams.SDDCPort))
-	suite.Contains(url.Query(), "token")
+	// TODO: Once the TODO is resolved in DPSAuthGetCookieURLHandler::Handle,
+	// this should be changed to GetCookieURLOK
+	_, ok := response.(*dps_auth.GetCookieURLForbidden)
+	suite.True(ok)
 
 	// Normal service member (not a DPS user) permission error
 	dpsRedirectURL := "http://example.com"
 	params.DpsRedirectURL = &dpsRedirectURL
 	response = handler.Handle(params)
-	_, ok := response.(*dps_auth.GetCookieURLForbidden)
+	_, ok = response.(*dps_auth.GetCookieURLForbidden)
 	suite.True(ok)
 
 	// Make the service member a DPS user, should no longer get a permission error when setting params
@@ -51,6 +50,10 @@ func (suite *HandlerSuite) TestDPSAuthCookieURLHandler() {
 	request = suite.AuthenticateDpsRequest(request, serviceMember, dpsUser)
 	params.HTTPRequest = request
 	response = handler.Handle(params)
-	_, ok = response.(*dps_auth.GetCookieURLOK)
+	okResponse := response.(*dps_auth.GetCookieURLOK)
+	url, _ := url.Parse(okResponse.Payload.CookieURL.String())
+	suite.Equal(url.Scheme, dpsAuthParams.SDDCProtocol)
+	suite.Equal(url.Host, fmt.Sprintf("%s:%s", dpsAuthParams.SDDCHostname, dpsAuthParams.SDDCPort))
+	suite.Contains(url.Query(), "token")
 	suite.True(ok)
 }


### PR DESCRIPTION
Preventing everyone except whitelisted DPS users from accessing this endpoint. This is because we now allow all users to access the /dps_cookie page (which is not ideal and should be fixed ASAP). This change will prevent them from doing anything useful with that page. Eventually though we'll want to revert this to the previous state.