### PR TITLE
update docs for go server tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,11 +267,9 @@ You can view the API's documentation (powered by Swagger UI) at <http://localhos
 There are a few handy targets in the Makefile to help you run tests:
 
 * `make client_test`: Run front-end testing suites.
-* `make server_test`: Run back-end testing suites.
+* `make server_test`: Run back-end testing suites. [Additional info for running go tests](https://github.com/transcom/mymove/blob/master/docs/how-to/run-go-tests.md)
 * `make e2e_test`: Run e2e testing suite. To run locally, add an environment variable called SAUCE_ACCESS_KEY, which you can find in team DP3 Engineering Vault of 1Password under Sauce Labs or by logging in to Sauce itself. In 1Password, the access key is labeled SAUCE_ACCESS_KEY. This will run against our staging environment. If you want to point to another instance, add an environment variable called E2E_BASE with the base url for the instance. Note that to test a development instance, you must run `make server_run_standalone` and set up a tunnel (via ngrok or localtunnel).
 * `make test`: Run e2e, client- and server-side testing suites.
-
-To run an individual test: `go test ./pkg/rateengine/ -testify.m Test_Scenario1`
 
 ### Logging
 

--- a/docs/how-to/run-go-tests.md
+++ b/docs/how-to/run-go-tests.md
@@ -33,7 +33,7 @@ $ TEST_ACC_ENV=staging TEST_ACC_DOD_CERTIFICATES=1 make webserver_test
 ### Run All Tests in a Single Package
 
 ```console
-$ go test ./pkg/handlers/internalapi/
+$ DB_PORT=5433 go test ./pkg/handlers/internalapi/
 ```
 
 ### Run Tests with Names Matching a String
@@ -41,7 +41,7 @@ $ go test ./pkg/handlers/internalapi/
 The following will run any Testify tests that have a name matching `Test_Name` in the `handlers/internalapi` package:
 
 ```console
-$ go test ./pkg/handlers/internalapi/ -testify.m Test_Name
+$ DB_PORT=5433 go test ./pkg/handlers/internalapi/ -testify.m Test_Name
 ```
 
 ## Run Tests when a File Changes


### PR DESCRIPTION
## Description

Due to this pr: https://github.com/transcom/mymove/pull/1770, we updated the test_db port number to 5433. Update the docs to explain how to run 1 off server tests by passing in the port number.

## Setup

`make db_test_e2e_populate`
Run any individual server test described here: https://github.com/transcom/mymove/blob/master/docs/how-to/run-go-tests.md

## Screenshots

The error: `pq: database "test_db" does not exist`
<img width="846" alt="screen shot 2019-03-04 at 3 23 59 pm" src="https://user-images.githubusercontent.com/3099491/53763942-9e635200-3e91-11e9-9f72-90fa89ff119c.png">
