### PR TITLE
Cg 163599170 use only absolute pathnames not null

### DIFF
--- a/public/swagger-ui/api.html
+++ b/public/swagger-ui/api.html
@@ -88,7 +88,9 @@ window.onload = function() {
     var protocolRegex = /(http|https):*/;
     var isNonRelativePath = protocolRegex.test(req['url']);
     if (isNonRelativePath) {
-      req['url'] = null;
+      // Convert to relative path
+      url = new URL(req['url'])
+      req['url'] = url.pathname;
     }
 
     return req;

--- a/public/swagger-ui/api.html
+++ b/public/swagger-ui/api.html
@@ -103,13 +103,11 @@ window.onload = function() {
     dom_id: '#swagger-ui',
     deepLinking: true,
     presets: [
-      SwaggerUIBundle.presets.apis,
-      SwaggerUIStandalonePreset
+      SwaggerUIBundle.presets.apis
     ],
     plugins: [
       SwaggerUIBundle.plugins.DownloadUrl
     ],
-    layout: "StandaloneLayout",
     validatorUrl: false
   })
 

--- a/public/swagger-ui/internal.html
+++ b/public/swagger-ui/internal.html
@@ -88,7 +88,9 @@ window.onload = function() {
     var protocolRegex = /(http|https):*/;
     var isNonRelativePath = protocolRegex.test(req['url']);
     if (isNonRelativePath) {
-      req['url'] = null;
+      // Convert to relative path
+      url = new URL(req['url'])
+      req['url'] = url.pathname;
     }
 
     return req;

--- a/public/swagger-ui/internal.html
+++ b/public/swagger-ui/internal.html
@@ -103,13 +103,11 @@ window.onload = function() {
     dom_id: '#swagger-ui',
     deepLinking: true,
     presets: [
-      SwaggerUIBundle.presets.apis,
-      SwaggerUIStandalonePreset
+      SwaggerUIBundle.presets.apis
     ],
     plugins: [
       SwaggerUIBundle.plugins.DownloadUrl
     ],
-    layout: "StandaloneLayout",
     validatorUrl: false
   })
 


### PR DESCRIPTION
## Description

This updates https://github.com/transcom/mymove/pull/1687 to allow us to still use the request url.  It simply converts the url to a pathname only value.  It also removes the Explore bar.

Based some of this work from @stangah 's PR https://github.com/transcom/mymove/pull/1727

## Setup

Try out swagger queries like this one from the UI: http://milmovelocal:3000/internal/docs#/service_members/createServiceMember

## Code Review Verification Steps

* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/163599170) for this change