### PR TITLE
Added March diesel fuel data to the db

### DIFF
--- a/migrations/20190304234525_add_march_fuel_eia_prices.up.fizz
+++ b/migrations/20190304234525_add_march_fuel_eia_prices.up.fizz
@@ -1,0 +1,3 @@
+sql("INSERT INTO public.fuel_eia_diesel_prices (id, pub_date, rate_start_date, rate_end_date, eia_price_per_gallon_millicents, baseline_rate, created_at, updated_at)
+     VALUES
+     ('95f53fe6-7143-4b56-97c2-992d688744eb', '2019-03-04', '2019-03-15', '2019-04-14', 307600, 5, now(), now());")


### PR DESCRIPTION
## Description

Added the data for March's fuel surcharge to the PostgreSQL db

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make db_dev_migrate
bin/psql-dev
SELECT * FROM fuel_eia_diesel_prices;
```

Look for the entry with pub_date 2019-03-04

## Code Review Verification Steps

* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* The [Pivotal story](https://www.pivotaltracker.com/story/show/162629086) for this change
* On the [US Energy Information Administration website](https://www.eia.gov/petroleum/gasdiesel/) please see the second table titled "U.S. On-Highway Diesel Fuel Prices"
  * We want the data for the first Monday of March which is 03/04/2019
