### PR TITLE
Use final destination (if known) to calculate distance: 163605913

### DIFF
--- a/migrations/20190301165102_update_shipment_with_destination_on_acceptance.up.fizz
+++ b/migrations/20190301165102_update_shipment_with_destination_on_acceptance.up.fizz
@@ -1,0 +1,2 @@
+add_column("shipments", "destination_address_on_acceptance_id", "uuid", {"null": true})
+add_foreign_key("shipments", "destination_address_on_acceptance_id", {"addresses": ["id"]}, {"name": "destination_address_on_acceptance_id_fk"})

--- a/pkg/models/shipment.go
+++ b/pkg/models/shipment.go
@@ -48,6 +48,7 @@ var (
 		"PickupAddress",
 		"SecondaryPickupAddress",
 		"DeliveryAddress",
+		"DestinationAddressOnAcceptance",
 		"PartialSITDeliveryAddress",
 		"ShipmentOffers.TransportationServiceProviderPerformance.TransportationServiceProvider",
 		"ShippingDistance.OriginAddress",

--- a/pkg/models/shipment_test.go
+++ b/pkg/models/shipment_test.go
@@ -196,6 +196,42 @@ func (suite *ModelSuite) TestAcceptShipmentForTSP() {
 	suite.Equal(ShipmentStatusACCEPTED, newShipment.Status, "expected Accepted")
 	suite.True(*newShipmentOffer.Accepted)
 	suite.Nil(newShipmentOffer.RejectionReason)
+	suite.Equal(shipment.Move.Orders.NewDutyStation.Address.ID, newShipment.DestinationAddressOnAcceptance.ID)
+}
+
+// TestAcceptShipmentForTSPWithDeliveryAddress tests that delivery address is used for a shipment when TSP accepts
+// a offer and delivery address is available instead of duty station
+func (suite *ModelSuite) TestAcceptShipmentForTSPWithDeliveryAddress() {
+	numTspUsers := 1
+	numShipments := 1
+	numShipmentOfferSplit := []int{1}
+	status := []ShipmentStatus{ShipmentStatusAWARDED}
+	tspUsers, shipments, _, err := testdatagen.CreateShipmentOfferData(suite.DB(), numTspUsers, numShipments, numShipmentOfferSplit, status, SelectedMoveTypeHHG)
+	suite.NoError(err)
+
+	tspUser := tspUsers[0]
+	shipment := shipments[0]
+	unitedStates := "United States"
+
+	addressAssertions := testdatagen.Assertions{
+		Address: Address{
+			StreetAddress1: "Fort Gordon",
+			City:           "Augusta",
+			State:          "GA",
+			PostalCode:     "30813",
+			Country:        &unitedStates,
+		},
+	}
+
+	//address doesn't matter, as long as we have a valid value
+	deliveryAddress := testdatagen.MakeAddress3(suite.DB(), addressAssertions)
+	shipment.DeliveryAddress = &deliveryAddress
+	shipment.DeliveryAddressID = &deliveryAddress.ID
+	suite.DB().ValidateAndSave(&shipment)
+
+	newShipment, _, _, err := AcceptShipmentForTSP(suite.DB(), tspUser.TransportationServiceProviderID, shipment.ID)
+	suite.NoError(err)
+	suite.Equal(shipment.DeliveryAddress.ID, newShipment.DestinationAddressOnAcceptance.ID)
 }
 
 // TestCurrentTransportationServiceProviderID tests that a shipment returns the proper current tsp id


### PR DESCRIPTION
## Description

Currently, we always use duty station to calculate distance. Change this behavior to use the final destination address if known at the time of TSP acceptance. If the final destination is not known when the TSP accepts the move, fallback and use the duty station address for distance calculation.

We added `destination_address_on_acceptance_id` in the `shipments` table that will store the address at the time of TSP acceptance. We use that address to calculate the distance once the shipment has been delivered. We didn't move the calculating of the distance because we'd be moving logic sooner in the process and some shipments would be left with no distance calculation (if they were accepted, but not delivered). To get around this, we check if `destination_address_on_acceptance_id` == `nil and if so, fallback to use the duty station address. This is because we don't know if the final address was entered at the time of TSP acceptance and this is the current behavior.

## Setup

`make db_test_e2e_populate`
`DB_PORT=5433 go test ./pkg/models/ -v -testify.m TestAcceptShipmentForTSP`

## Code Review Verification Steps

* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](./docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/163605913) for this change

## Screenshots
![hhg_no_delivery_add](https://user-images.githubusercontent.com/5003421/53818515-2dc24100-3f36-11e9-8351-dca91b789936.png)
![no_delivery_add_db](https://user-images.githubusercontent.com/5003421/53818521-3155c800-3f36-11e9-9357-fcf7cfe24292.png)
![with_delivery_address](https://user-images.githubusercontent.com/5003421/53818533-3581e580-3f36-11e9-877e-67680351a407.png)
![with_delivery_add_db](https://user-images.githubusercontent.com/5003421/53818540-387cd600-3f36-11e9-99ac-76d3cfe577f3.png)

Ping us if you would like us to walk you through in realtime about above screenshots.
