### PR TITLE
Consolidates DB_PORT_TEST, adds go-test script

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -56,10 +56,13 @@ export MYMOVE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # Configuration needed for secure migrations.
 export SECURE_MIGRATION_DIR="${MYMOVE_DIR}/local_migrations"
 export SECURE_MIGRATION_SOURCE="local"
+
+# Default DB configuration
 export DB_PASSWORD=mysecretpassword
 export DB_USER=postgres
 export DB_HOST=localhost
 export DB_PORT=5432
+export DB_PORT_TEST=5433
 export DB_NAME=dev_db
 
 # Login.gov configuration

--- a/Makefile
+++ b/Makefile
@@ -26,10 +26,7 @@ endif
 WEBSERVER_LDFLAGS=-X main.gitBranch=$(shell git branch | grep \* | cut -d ' ' -f2) -X main.gitCommit=$(shell git rev-list -1 HEAD)
 DB_PORT_DEV=5432
 DB_PORT_DOCKER=5432
-ifndef CIRCLECI
-	DB_PORT_TEST=5433
-	LDFLAGS=
-else
+ifdef CIRCLECI
 	DB_PORT_TEST=5432
 	LDFLAGS=-linkmode external -extldflags -static
 endif

--- a/bin/go-find-pattern
+++ b/bin/go-find-pattern
@@ -1,4 +1,4 @@
-#!/bin/bash
+#! /usr/bin/env bash
 #
 #   go-find-pattern searchs over all our go source code files for a regex pattern"
 #   For example: bin/go-find-pattern '[.]Info[(]"[^"]+\s+"'

--- a/bin/go-test
+++ b/bin/go-test
@@ -1,0 +1,7 @@
+#!/bin/bash
+#
+#   go-test runs go test but with the correct DB port
+#   For example: bin/go-test ./pkg/models
+#
+
+DB_PORT=$DB_PORT_TEST go test "$@"

--- a/bin/go-test
+++ b/bin/go-test
@@ -1,4 +1,4 @@
-#!/bin/bash
+#! /usr/bin/env bash
 #
 #   go-test runs go test but with the correct DB port
 #   For example: bin/go-test ./pkg/models

--- a/bin/psql-test
+++ b/bin/psql-test
@@ -1,6 +1,6 @@
 #! /usr/bin/env bash
 
 export DB_NAME=test_db
-export DB_PORT=5433
+export DB_PORT=$DB_PORT_TEST
 # shellcheck disable=SC1091,SC1090
 . "$(dirname "$0")"/psql

--- a/bin/run-e2e-test
+++ b/bin/run-e2e-test
@@ -4,7 +4,7 @@ set -eu -o pipefail
 
 # Runs both the webserver and Cypress in parallel
 trap "kill %1" SIGINT
-./bin/webserver --env test --db-port 5433 --login-gov-callback-port 4000 --no-tls-port 4000 &
+./bin/webserver --env test --db-port "$DB_PORT_TEST" --login-gov-callback-port 4000 --no-tls-port 4000 &
 npx cypress open || true
 
 # Terminate the background webserver

--- a/docs/how-to/run-go-tests.md
+++ b/docs/how-to/run-go-tests.md
@@ -33,7 +33,7 @@ $ TEST_ACC_ENV=staging TEST_ACC_DOD_CERTIFICATES=1 make webserver_test
 ### Run All Tests in a Single Package
 
 ```console
-$ DB_PORT=5433 go test ./pkg/handlers/internalapi/
+$ bin/go-test ./pkg/handlers/internalapi/
 ```
 
 ### Run Tests with Names Matching a String
@@ -41,7 +41,7 @@ $ DB_PORT=5433 go test ./pkg/handlers/internalapi/
 The following will run any Testify tests that have a name matching `Test_Name` in the `handlers/internalapi` package:
 
 ```console
-$ DB_PORT=5433 go test ./pkg/handlers/internalapi/ -testify.m Test_Name
+$ bin/go-test ./pkg/handlers/internalapi/ -testify.m Test_Name
 ```
 
 ## Run Tests when a File Changes


### PR DESCRIPTION
## Description

I'm lazy, and writing `DB_PORT=5433` before all my tests seemed like too much work. This PR takes DB_PORT_TEST out of `Makefile` and elsewhere and puts it into `.envrc`, then creates a thin wrapper around `go test` that sets the correct port for developers.