### PR TITLE
Populate Expenses on Shipment Summary Worksheet

### DIFF
--- a/pkg/models/shipment_summary_worksheet.go
+++ b/pkg/models/shipment_summary_worksheet.go
@@ -98,6 +98,8 @@ type FormattedMovingExpenses struct {
 	OtherGTCCPaid               string
 	TotalMemberPaid             string
 	TotalGTCCPaid               string
+	TotalMemberPaidRepeated     string
+	TotalGTCCPaidRepeated       string
 }
 
 // ShipmentSummaryFormData is a container for the various objects required for the a Shipment Summary Worksheet
@@ -416,6 +418,10 @@ func FormatMovingExpenses(movingExpenseDocuments MovingExpenseDocuments) (Format
 	for key, value := range subTotals {
 		formattedExpenses[key] = FormatDollars(value)
 	}
+
+	formattedExpenses["TotalMemberPaidRepeated"] = formattedExpenses["TotalMemberPaid"]
+	formattedExpenses["TotalGTCCPaidRepeated"] = formattedExpenses["TotalGTCCPaid"]
+
 	err := mapstructure.Decode(formattedExpenses, &expenses)
 	if err != nil {
 		return expenses, err

--- a/pkg/models/shipment_summary_worksheet.go
+++ b/pkg/models/shipment_summary_worksheet.go
@@ -327,6 +327,8 @@ func FormatValuesShipmentSummaryWorksheetFormPage2(data ShipmentSummaryFormData)
 	page2 := ShipmentSummaryWorksheetPage2Values{}
 	page2.PreparationDate = FormatDate(data.PreparationDate)
 	page2.FormattedMovingExpenses, err = FormatMovingExpenses(data.MovingExpenseDocuments)
+	page2.TotalMemberPaidRepeated = page2.TotalMemberPaid
+	page2.TotalGTCCPaidRepeated = page2.TotalGTCCPaid
 	if err != nil {
 		return page2, err
 	}
@@ -418,9 +420,6 @@ func FormatMovingExpenses(movingExpenseDocuments MovingExpenseDocuments) (Format
 	for key, value := range subTotals {
 		formattedExpenses[key] = FormatDollars(value)
 	}
-
-	formattedExpenses["TotalMemberPaidRepeated"] = formattedExpenses["TotalMemberPaid"]
-	formattedExpenses["TotalGTCCPaidRepeated"] = formattedExpenses["TotalGTCCPaid"]
 
 	err := mapstructure.Decode(formattedExpenses, &expenses)
 	if err != nil {

--- a/pkg/models/shipment_summary_worksheet_test.go
+++ b/pkg/models/shipment_summary_worksheet_test.go
@@ -283,10 +283,12 @@ func (suite *ModelSuite) TestFormatValuesShipmentSummaryWorksheetFormPage2() {
 
 	suite.Equal("$300.00", sswPage2.ContractedExpenseGTCCPaid)
 	suite.Equal("$300.00", sswPage2.TotalGTCCPaid)
+	suite.Equal("$300.00", sswPage2.TotalGTCCPaidRepeated)
 
 	suite.Equal("$100.00", sswPage2.TollsMemberPaid)
 	suite.Equal("$100.00", sswPage2.GasMemberPaid)
 	suite.Equal("$200.00", sswPage2.TotalMemberPaid)
+	suite.Equal("$200.00", sswPage2.TotalMemberPaidRepeated)
 }
 
 func (suite *ModelSuite) TestGroupExpenses() {

--- a/pkg/paperwork/shipment_summary_worksheet.go
+++ b/pkg/paperwork/shipment_summary_worksheet.go
@@ -68,5 +68,7 @@ var ShipmentSummaryPage2Layout = FormLayout{
 		"OilGTCCPaid":                 FormField(181.5, 86.5, 20, floatPtr(10), nil, stringPtr("RM")),
 		"OtherGTCCPaid":               FormField(181.5, 93, 20, floatPtr(10), nil, stringPtr("RM")),
 		"TotalGTCCPaid":               FormField(181.5, 99.5, 20, floatPtr(10), nil, stringPtr("RM")),
+		"TotalMemberPaidRepeated":     FormField(74, 42, 30, floatPtr(10), nil, stringPtr("RM")),
+		"TotalGTCCPaidRepeated":       FormField(74, 53, 30, floatPtr(10), nil, stringPtr("RM")),
 	},
 }


### PR DESCRIPTION
## Description

Populates the Current Payment Request, Member-Paid and GTCC-Paid Expenses, section on the Shipment Summary Worksheet

## Setup

1) Log into the office app and select a move with a PPM
2) Click the documents link and add an "Expense"
3) After you upload a document you'll see it's red on the right hand side. Select the document go to the details tab and set the document status to "OK".
4) Go back to the PPM on the move summary page and there should be some expenses now
5) Click Create Paperwork -> Click Download worksheet

## Code Review Verification Steps
* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?
* [x] Design Review

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/163954473) 

## Screenshots
<img width="828" alt="ssw-expenses" src="https://user-images.githubusercontent.com/7574207/53841402-af33c680-3f6a-11e9-830a-b96294417e89.png">


