### PR TITLE
Migration for deduplicating zip5 rows [delivers #157686253]

### DIFF
--- a/migrations/20190305233916_deduplicate_zip5.up.sql
+++ b/migrations/20190305233916_deduplicate_zip5.up.sql
@@ -1,0 +1,8 @@
+-- Deduplicate rows in tariff400ng_zip5_rate_areas table
+SELECT DISTINCT ON (zip5, rate_area) *
+INTO temp_zip5s
+FROM tariff400ng_zip5_rate_areas;
+
+DROP TABLE tariff400ng_zip5_rate_areas;
+
+ALTER TABLE temp_zip5s RENAME TO tariff400ng_zip5_rate_areas;


### PR DESCRIPTION
## Description

Some time ago Alexi discovered that we have duplicates in the `tariff400ng_zip5_rate_areas` table. SOME of these are complete duplicates, meaning nothing between duplicate rows is different. There are some others that are `zip5` duplicates, but have different rate area. This is a real, but separate concern from this PR which is tracked in the linked Pivotal Tracker story.

This PR only deduplicates rows which are complete duplicates, of which there were a handful.

## Setup

```sh
make db_dev_migrate
```

## Code Review Verification Steps

* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](./docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/157686253) for this change