### PR TITLE
Don't return a nil duty station when creating a new service member

### DIFF
--- a/pkg/handlers/internalapi/duty_stations.go
+++ b/pkg/handlers/internalapi/duty_stations.go
@@ -3,6 +3,7 @@ package internalapi
 import (
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/go-openapi/swag"
+	"github.com/gofrs/uuid"
 	"go.uber.org/zap"
 
 	stationop "github.com/transcom/mymove/pkg/gen/internalapi/internaloperations/duty_stations"
@@ -12,6 +13,11 @@ import (
 )
 
 func payloadForDutyStationModel(station models.DutyStation) *internalmessages.DutyStationPayload {
+	// If the station ID has no UUID then it isn't real data
+	// Unlike other payloads the
+	if station.ID == uuid.Nil {
+		return nil
+	}
 	payload := internalmessages.DutyStationPayload{
 		ID:          handlers.FmtUUID(station.ID),
 		CreatedAt:   handlers.FmtDateTime(station.CreatedAt),

--- a/pkg/handlers/internalapi/service_members.go
+++ b/pkg/handlers/internalapi/service_members.go
@@ -19,8 +19,6 @@ import (
 )
 
 func payloadForServiceMemberModel(storer storage.FileStorer, serviceMember models.ServiceMember) *internalmessages.ServiceMemberPayload {
-	var dutyStationPayload *internalmessages.DutyStationPayload
-	dutyStationPayload = payloadForDutyStationModel(serviceMember.DutyStation)
 	orders := make([]*internalmessages.Orders, len(serviceMember.Orders))
 	for i, order := range serviceMember.Orders {
 		orderPayload, _ := payloadForOrdersModel(storer, order)
@@ -57,7 +55,7 @@ func payloadForServiceMemberModel(storer storage.FileStorer, serviceMember model
 		BackupContacts:          contactPayloads,
 		HasSocialSecurityNumber: handlers.FmtBool(serviceMember.SocialSecurityNumberID != nil),
 		IsProfileComplete:       handlers.FmtBool(serviceMember.IsProfileComplete()),
-		CurrentStation:          dutyStationPayload,
+		CurrentStation:          payloadForDutyStationModel(serviceMember.DutyStation),
 	}
 	return &serviceMemberPayload
 }

--- a/pkg/handlers/internalapi/service_members_test.go
+++ b/pkg/handlers/internalapi/service_members_test.go
@@ -71,6 +71,56 @@ func (suite *HandlerSuite) TestShowServiceMemberWrongUser() {
 	suite.Assertions.Equal(http.StatusForbidden, errResponse.Code)
 }
 
+func (suite *HandlerSuite) TestSubmitServiceMemberHandlerNoValues() {
+	// Given: A logged-in user
+	user := testdatagen.MakeDefaultUser(suite.DB())
+
+	// When: a new ServiceMember is posted
+	newServiceMemberPayload := internalmessages.CreateServiceMemberPayload{}
+
+	req := httptest.NewRequest("POST", "/service_members", nil)
+	req = suite.AuthenticateUserRequest(req, user)
+
+	params := servicememberop.CreateServiceMemberParams{
+		CreateServiceMemberPayload: &newServiceMemberPayload,
+		HTTPRequest:                req,
+	}
+
+	handler := CreateServiceMemberHandler{handlers.NewHandlerContext(suite.DB(), suite.TestLogger())}
+	response := handler.Handle(params)
+
+	suite.Assertions.IsType(&handlers.CookieUpdateResponder{}, response)
+
+	unwrappedResponse := response.(*handlers.CookieUpdateResponder).Responder
+	suite.Assertions.IsType(&servicememberop.CreateServiceMemberCreated{}, unwrappedResponse)
+
+	// Then: we expect a servicemember to have been created for the user
+	query := suite.DB().Where(fmt.Sprintf("user_id='%v'", user.ID))
+	var serviceMembers models.ServiceMembers
+	query.All(&serviceMembers)
+
+	suite.Assertions.Len(serviceMembers, 1)
+
+	serviceMemberPayload := unwrappedResponse.(*servicememberop.CreateServiceMemberCreated).Payload
+
+	suite.Assertions.NotEqual(*serviceMemberPayload.ID, uuid.Nil)
+	suite.Assertions.NotEqual(*serviceMemberPayload.UserID, uuid.Nil)
+	suite.Assertions.Equal(*serviceMemberPayload.HasSocialSecurityNumber, false)
+	suite.Assertions.Equal(*serviceMemberPayload.IsProfileComplete, false)
+	suite.Assertions.Equal(len((*serviceMemberPayload).Orders), 0)
+	fmt.Println((*serviceMemberPayload).CurrentStation)
+
+	// These shouldn't return any value or Swagger clients will complain during validation
+	// because the payloads for these objects are defined to require non-null values for most fields
+	// which can't be handled in OpenAPI Spec 2.0. Therefore we don't return them at all.
+	suite.Assertions.Equal((*serviceMemberPayload).Rank, (*internalmessages.ServiceMemberRank)(nil))
+	suite.Assertions.Equal((*serviceMemberPayload).Affiliation, (*internalmessages.Affiliation)(nil))
+	suite.Assertions.Equal((*serviceMemberPayload).CurrentStation, (*internalmessages.DutyStationPayload)(nil))
+	suite.Assertions.Equal((*serviceMemberPayload).ResidentialAddress, (*internalmessages.Address)(nil))
+	suite.Assertions.Equal((*serviceMemberPayload).BackupMailingAddress, (*internalmessages.Address)(nil))
+	suite.Assertions.Equal((*serviceMemberPayload).BackupContacts, internalmessages.IndexServiceMemberBackupContactsPayload{})
+}
+
 func (suite *HandlerSuite) TestSubmitServiceMemberHandlerAllValues() {
 	// Given: A logged-in user
 	user := testdatagen.MakeDefaultUser(suite.DB())


### PR DESCRIPTION
## Description

If you try to create a service member right now you'll get this:

```json
{
  "created_at": "2019-03-04T23:59:45.870Z",
  "current_station": {
    "address": {
      "city": "",
      "id": "00000000-0000-0000-0000-000000000000",
      "postal_code": "",
      "state": "",
      "street_address_1": ""
    },
    "affiliation": "",
    "created_at": null,
    "id": "00000000-0000-0000-0000-000000000000",
    "name": "",
    "updated_at": null
  },
  "has_social_security_number": false,
  "id": "9907f6de-9292-4c71-81eb-ed2ea78ad4a3",
  "is_profile_complete": false,
  "orders": [],
  "updated_at": "2019-03-04T23:59:45.870Z",
  "user_id": "c3ddf806-87bc-4933-ac47-5db81524f4b1"
}
```

The `current_station` is nil because the user is just starting to fill out their profile and nothing is known about them yet.  Returning this structure causes issues because its not OpenAPI Spec compliant with our `internal.yaml` which says some of those fields are required (like `updated_at` and `created_at`).  This breaks Swagger Clients attempting to use our api.  Instead we should be returning this:


```json
{
  "created_at": "2019-03-04T23:59:45.870Z",
  "has_social_security_number": false,
  "id": "9907f6de-9292-4c71-81eb-ed2ea78ad4a3",
  "is_profile_complete": false,
  "orders": [],
  "updated_at": "2019-03-04T23:59:45.870Z",
  "user_id": "c3ddf806-87bc-4933-ac47-5db81524f4b1"
}
```

## Reviewer Notes

Honestly the real fix here is to make `models.ServiceMember.CurrentStation` a pointer instead of a value because we allow it to be `NULL` in the DB.  But modifying this breaks a lot of Eager loading in our app that rely on `Orders.ServiceMember.CurrentStation.Address` and that fight wasn't worth fighting here.  Instead I've opted to return nothing if the ID (or ForeignKey reference) is empty.  I'm pretty certain this is ok for the app and I don't see tests failing.

## Setup

1. Create a new local user
2. Find the local user's service member ID, go to the DB and delete the row from the `service_members` table.
3. Use the swagger docs and try out http://milmovelocal:3000/internal/docs#/service_members/createServiceMember with the payload `{}` (an empty map)
4. A user should be created.

## Code Review Verification Steps

* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/164418251) for this change