### PR TITLE
Some .gitignore cleanups for binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,9 +21,14 @@ __snapshots__
 /tmp
 
 # built binaries
+/bin/callgraph
+/bin/chamber
+/bin/ecs-service-logs
 /bin/generate-1203-form
 /bin/generate-shipment-summary
 /bin/generate-test-data
+/bin/gin
+/bin/gosec
 /bin/health_checker
 /bin/iws
 /bin/load-office-data
@@ -32,18 +37,11 @@ __snapshots__
 /bin/make-office-user
 /bin/make-tsp-user
 /bin/paperwork
-/bin/rateengine
+/bin/save-fuel-price-data
+/bin/soda
+/bin/swagger
 /bin/tsp-award-queue
 /bin/webserver
-
-/bin/callgraph
-/bin/chamber
-/bin/ecs-service-logs
-/bin/soda
-/bin/golint
-/bin/swagger
-/bin/gin
-/bin/gosec
 
 # Special bin folder for e2e test binaries
 /bin_linux/

--- a/.gitignore
+++ b/.gitignore
@@ -23,8 +23,10 @@ __snapshots__
 # built binaries
 /bin/callgraph
 /bin/chamber
+/bin/compare-secure-migrations
 /bin/ecs-service-logs
 /bin/generate-1203-form
+/bin/generate-shipment-edi
 /bin/generate-shipment-summary
 /bin/generate-test-data
 /bin/gin
@@ -38,6 +40,7 @@ __snapshots__
 /bin/make-tsp-user
 /bin/paperwork
 /bin/save-fuel-price-data
+/bin/send-to-gex
 /bin/soda
 /bin/swagger
 /bin/tsp-award-queue

--- a/Makefile
+++ b/Makefile
@@ -240,6 +240,7 @@ server_run_debug:
 
 .PHONY: build_tools
 build_tools: bash_version server_deps server_generate build_generate_test_data
+	go build -i -ldflags "$(LDFLAGS)" -o bin/ecs-service-logs ./cmd/ecs-service-logs
 	go build -i -ldflags "$(LDFLAGS)" -o bin/generate-1203-form ./cmd/generate_1203_form
 	go build -i -ldflags "$(LDFLAGS)" -o bin/generate-shipment-summary ./cmd/generate_shipment_summary
 	go build -i -ldflags "$(LDFLAGS)" -o bin/health_checker ./cmd/health_checker
@@ -250,9 +251,8 @@ build_tools: bash_version server_deps server_generate build_generate_test_data
 	go build -i -ldflags "$(LDFLAGS)" -o bin/make-office-user ./cmd/make_office_user
 	go build -i -ldflags "$(LDFLAGS)" -o bin/make-tsp-user ./cmd/make_tsp_user
 	go build -i -ldflags "$(LDFLAGS)" -o bin/paperwork ./cmd/paperwork
-	go build -i -ldflags "$(LDFLAGS)" -o bin/tsp-award-queue ./cmd/tsp_award_queue
-	go build -i -ldflags "$(LDFLAGS)" -o bin/ecs-service-logs ./cmd/ecs-service-logs
 	go build -i -ldflags "$(LDFLAGS)" -o bin/save-fuel-price-data ./cmd/save_fuel_price_data
+	go build -i -ldflags "$(LDFLAGS)" -o bin/tsp-award-queue ./cmd/tsp_award_queue
 
 .PHONY: build
 build: server_build build_tools client_build

--- a/Makefile
+++ b/Makefile
@@ -240,8 +240,10 @@ server_run_debug:
 
 .PHONY: build_tools
 build_tools: bash_version server_deps server_generate build_generate_test_data
+	go build -i -ldflags "$(LDFLAGS)" -o bin/compare-secure-migrations ./cmd/compare_secure_migrations
 	go build -i -ldflags "$(LDFLAGS)" -o bin/ecs-service-logs ./cmd/ecs-service-logs
 	go build -i -ldflags "$(LDFLAGS)" -o bin/generate-1203-form ./cmd/generate_1203_form
+	go build -i -ldflags "$(LDFLAGS)" -o bin/generate-shipment-edi ./cmd/generate_shipment_edi
 	go build -i -ldflags "$(LDFLAGS)" -o bin/generate-shipment-summary ./cmd/generate_shipment_summary
 	go build -i -ldflags "$(LDFLAGS)" -o bin/health_checker ./cmd/health_checker
 	go build -i -ldflags "$(LDFLAGS)" -o bin/iws ./cmd/demo/iws.go
@@ -252,6 +254,7 @@ build_tools: bash_version server_deps server_generate build_generate_test_data
 	go build -i -ldflags "$(LDFLAGS)" -o bin/make-tsp-user ./cmd/make_tsp_user
 	go build -i -ldflags "$(LDFLAGS)" -o bin/paperwork ./cmd/paperwork
 	go build -i -ldflags "$(LDFLAGS)" -o bin/save-fuel-price-data ./cmd/save_fuel_price_data
+	go build -i -ldflags "$(LDFLAGS)" -o bin/send-to-gex ./cmd/send_to_gex
 	go build -i -ldflags "$(LDFLAGS)" -o bin/tsp-award-queue ./cmd/tsp_award_queue
 
 .PHONY: build


### PR DESCRIPTION
## Description

I noticed that I had an untracked file for `bin/save-fuel-price-data` (the code for that command got merged yesterday).  This PR adds a .gitignore for that, but I also went through and audited our bin directory against the Makefile and removed `bin/rateengine` (that command was deleted a while back) and `bin/golint` (think that's old too).  While I was at it, I re-alphabetized the bin stuff in .gitignore and the `build_tools` Makefile target.

