### PR TITLE
Fix some "dep check" issues

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1608,6 +1608,7 @@
     "github.com/gorilla/csrf",
     "github.com/hashicorp/go-multierror",
     "github.com/honeycombio/beeline-go",
+    "github.com/honeycombio/beeline-go/trace",
     "github.com/honeycombio/beeline-go/wrappers/hnynethttp",
     "github.com/imdario/mergo",
     "github.com/jessevdk/go-flags",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1293,7 +1293,7 @@
   version = "v0.1.1"
 
 [[projects]]
-  digest = "1:c587772fb8ad29ad4db67575dad25ba17a51f072ff18a22b4f0257a4d9c24f75"
+  digest = "1:381bcbeb112a51493d9d998bbba207a529c73dbb49b3fd789e48c63fac1f192c"
   name = "github.com/stretchr/testify"
   packages = [
     "assert",
@@ -1615,6 +1615,7 @@
     "github.com/jung-kurt/gofpdf",
     "github.com/markbates/goth",
     "github.com/markbates/goth/providers/openidConnect",
+    "github.com/mitchellh/mapstructure",
     "github.com/namsral/flag",
     "github.com/pkg/errors",
     "github.com/rickar/cal",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -25,13 +25,5 @@ required = [
   name = "go.mozilla.org/pkcs7"
 
 [[constraint]]
-  name = "github.com/stretchr/testify"
-  version = "1.2.2"
-
-[[constraint]]
-  name = "github.com/stretchr/objx"
-  version = "0.1.1"
-
-[[constraint]]
   name = "github.com/99designs/aws-vault"
   branch = "master"

--- a/pkg/handlers/publicapi/generic_move_documents_test.go
+++ b/pkg/handlers/publicapi/generic_move_documents_test.go
@@ -3,9 +3,8 @@ package publicapi
 import (
 	"net/http/httptest"
 
-	"github.com/gobuffalo/uuid"
-
 	"github.com/go-openapi/strfmt"
+	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/gen/apimessages"
 	movedocop "github.com/transcom/mymove/pkg/gen/restapi/apioperations/move_docs"

--- a/pkg/models/shipment_recalculate.go
+++ b/pkg/models/shipment_recalculate.go
@@ -5,9 +5,9 @@ import (
 	"time"
 
 	"github.com/gobuffalo/pop"
-	"github.com/gobuffalo/uuid"
 	"github.com/gobuffalo/validate"
 	"github.com/gobuffalo/validate/validators"
+	"github.com/gofrs/uuid"
 	"github.com/pkg/errors"
 )
 

--- a/pkg/models/shipment_recalculate_logs.go
+++ b/pkg/models/shipment_recalculate_logs.go
@@ -5,9 +5,9 @@ import (
 	"time"
 
 	"github.com/gobuffalo/pop"
-	"github.com/gobuffalo/uuid"
 	"github.com/gobuffalo/validate"
 	"github.com/gobuffalo/validate/validators"
+	"github.com/gofrs/uuid"
 	"github.com/pkg/errors"
 )
 


### PR DESCRIPTION
## Description

I hooked up the dep integration in GoLand this morning and it started complaining to me about a few `dep` things.  Ran a `dep check` and it noted we were out of sync on `gobuffalo/uuid` and `mitchellh/mapstructure`.  The former actually is deprecated, so I've fixed the references to it.  The latter was added recently, but the `Gopkg.lock` wasn't updated.  Those have been fixed by running `dep ensure` (after `make clean` and `make server_generate`).

There was another issue it noted:

> \# vendor is out of sync:
> github.com/stretchr/testify: hash of vendored tree not equal to digest in Gopkg.lock

That hash was fixed by the `dep ensure`, but I noticed that `/stretchr/testify` shows version `1.3.0` in the Gopkg.lock file but version `1.2.2` in the Gopkg.toml file.  Maybe that was just a timing issue between when the updater changed the version in `Gopkg.lock` and the explicit version was added to `Gopkg.toml`.

In addition, I get this warning when running `dep ensure`:

> Warning: the following project(s) have [[constraint]] stanzas in Gopkg.toml:
> 
>   ✗  github.com/stretchr/objx
> 
> However, these projects are not direct dependencies of the current project:
> they are not imported in any .go files, nor are they in the 'required' list in
> Gopkg.toml. Dep only applies [[constraint]] rules to direct dependencies, so
> these rules will have no effect.
> 
> Either import/require packages from these projects so that they become direct
> dependencies, or convert each [[constraint]] to an [[override]] to enforce rules
> on these projects, if they happen to be transitive dependencies.

I don't see any direct usages of `objx` in the codebase.  @chrisrcoles, do you have any insight into this `stretchr` stuff?  It looks like you added the `Gopkg.toml` constraints.
 