### PR TITLE
Remove 105B and 105E from behind the flag flag: 162850111

### DIFF
--- a/cypress/fixtures/preApprovals/requests/create105.js
+++ b/cypress/fixtures/preApprovals/requests/create105.js
@@ -1,0 +1,41 @@
+export function createItem({ shipmentId, csrfToken, code, quantity1 }) {
+  const tariff400ng = {
+    '105B': { item: 'Pack Reg Crate', id: 'deb28967-d52c-4f04-8a0b-a264c9d80457', location: 'ORIGIN' },
+    '105E': { item: 'UnPack Reg Crate', id: '6df4f1aa-a232-4eef-bbe8-f06bfb0b6d40', location: 'DESTINATION' },
+  };
+  let itemDetails;
+  if (code === '105B') {
+    itemDetails = tariff400ng['105B'];
+  } else if (code === '105E') {
+    itemDetails = tariff400ng['105E'];
+  } else {
+    itemDetails = { item: 'unknown', id: 'unknown', location: 'BOTH' };
+  }
+
+  return {
+    method: 'POST',
+    url: `/api/v1/shipments/${shipmentId}/accessorials`,
+    headers: {
+      'X-CSRF-TOKEN': csrfToken,
+    },
+    body: {
+      tariff400ng_item: {
+        code: code,
+        created_at: '2019-03-05T15:34:29.785Z',
+        discount_type: 'HHG',
+        id: 'deb28967-d52c-4f04-8a0b-a264c9d80457',
+        item: itemDetails.item,
+        location: itemDetails.location,
+        ref_code: 'NONE',
+        requires_pre_approval: true,
+        uom_1: 'CF',
+        uom_2: 'NONE',
+        updated_at: '2019-03-05T15:34:29.785Z',
+      },
+      location: 'ORIGIN',
+      quantity_1: quantity1 * 10000,
+      notes: `notes notes ${code}`,
+      tariff400ng_item_id: itemDetails.id,
+    },
+  };
+}

--- a/cypress/fixtures/preApprovals/requests/create105.js
+++ b/cypress/fixtures/preApprovals/requests/create105.js
@@ -1,4 +1,4 @@
-export function createItem({ shipmentId, csrfToken, code, quantity1 }) {
+export function createItemRequest({ shipmentId, csrfToken, code, quantity1 }) {
   const tariff400ng = {
     '105B': { item: 'Pack Reg Crate', id: 'deb28967-d52c-4f04-8a0b-a264c9d80457', location: 'ORIGIN' },
     '105E': { item: 'UnPack Reg Crate', id: '6df4f1aa-a232-4eef-bbe8-f06bfb0b6d40', location: 'DESTINATION' },

--- a/cypress/integration/tsp/preApprovalRequest.js
+++ b/cypress/integration/tsp/preApprovalRequest.js
@@ -19,10 +19,10 @@ describe('TSP user interacts with pre approval request panel', function() {
   it('TSP user deletes pre approval request', function() {
     tspUserDeletesPreApprovalRequest();
   });
-  it('TSP user creates origional 105B request', function() {
+  it('Add original 105B/E to verify they display correctly', function() {
     test105beOriginal();
   });
-  it('TSP user creates 105B request', function() {
+  it('TSP user creates 105B/E request', function() {
     test105be();
   });
 });
@@ -93,13 +93,19 @@ function tspUserDeletesPreApprovalRequest() {
 }
 
 function test105beOriginal() {
-  cy.setFeatureFlag('robustAccessorial=false');
   cy.selectQueueItemMoveLocator('DATESP');
 
-  addOriginal105({ code: '105B', quantity1: 12 });
-  cy.get('td[details-cy="105B-default-details"]').should('contain', '12.0000 notes notes 105B');
+  addOriginal105({ code: '105B', quantity1: 12 }).then(res => {
+    expect(res.status).to.equal(201);
+  });
 
-  addOriginal105({ code: '105E', quantity1: 90 });
+  addOriginal105({ code: '105E', quantity1: 90 }).then(res => {
+    expect(res.status).to.equal(201);
+  });
+
+  // must reload page because original 105B/E are added by cy.request()
+  cy.reload();
+  cy.get('td[details-cy="105B-default-details"]').should('contain', '12.0000 notes notes 105B');
   cy.get('td[details-cy="105E-default-details"]').should('contain', '90.0000 notes notes 105E');
 }
 

--- a/cypress/support/preapprovals/test105be.js
+++ b/cypress/support/preapprovals/test105be.js
@@ -1,10 +1,17 @@
+import { createItem } from '../../fixtures/preApprovals/requests/create105';
+
 /* global cy */
 export function addOriginal105({ code, quantity1 }) {
-  clickAddARequest();
-  cy.selectTariff400ngItem(code);
-  cy.typeInInput({ name: 'quantity_1', value: quantity1 });
-  cy.typeInTextarea({ name: 'notes', value: `notes notes ${code}` });
-  clickSaveAndClose();
+  return cy.location().then(loc => {
+    // eslint-disable-next-line security/detect-non-literal-regexp
+    const pattern = new RegExp(`^/shipments/(.*)`);
+    expect(loc.pathname).to.match(/^\/shipments\/[^/]+/);
+    const shipmentId = loc.pathname.match(pattern)[1];
+    return cy.getCookie('masked_gorilla_csrf').then(token => {
+      const csrfToken = token.value;
+      return createOriginal105(shipmentId, csrfToken, code, quantity1);
+    });
+  });
 }
 
 export function add105({ code, itemSize = 25, crateSize = 25 }) {
@@ -35,4 +42,14 @@ function clickSaveAndClose() {
     .get('button')
     .contains('Save & Close')
     .click();
+}
+
+function createOriginal105(shipmentId, csrfToken, code, quantity1) {
+  const item = createItem({
+    shipmentId: shipmentId,
+    csrfToken: csrfToken,
+    code: code,
+    quantity1: quantity1,
+  });
+  return cy.request(item);
 }

--- a/cypress/support/preapprovals/test105be.js
+++ b/cypress/support/preapprovals/test105be.js
@@ -1,4 +1,4 @@
-import { createItem } from '../../fixtures/preApprovals/requests/create105';
+import { createItemRequest } from '../../fixtures/preApprovals/requests/create105';
 
 /* global cy */
 export function addOriginal105({ code, quantity1 }) {
@@ -45,7 +45,7 @@ function clickSaveAndClose() {
 }
 
 function createOriginal105(shipmentId, csrfToken, code, quantity1) {
-  const item = createItem({
+  const item = createItemRequest({
     shipmentId: shipmentId,
     csrfToken: csrfToken,
     code: code,

--- a/src/shared/PreApprovalRequest/DetailsHelper.js
+++ b/src/shared/PreApprovalRequest/DetailsHelper.js
@@ -9,7 +9,7 @@ export function getFormComponent(code, robustAccessorial, initialValues) {
   code = code ? code.toLowerCase() : '';
   const hasCrateDimensions = get(initialValues, 'crate_dimensions', false);
   const isNew = !initialValues;
-  if (robustAccessorial && (code.startsWith('105b') || code.startsWith('105e'))) {
+  if (code.startsWith('105b') || code.startsWith('105e')) {
     if (isNew || hasCrateDimensions) return Code105Form;
   } else if (robustAccessorial && code.startsWith('35')) {
     return Code35Form;
@@ -18,7 +18,5 @@ export function getFormComponent(code, robustAccessorial, initialValues) {
 }
 
 export function getDetailsComponent(code, robustAccessorial, isNewAccessorial) {
-  return (code === '105B' || code === '105E') && robustAccessorial && isNewAccessorial
-    ? Code105Details
-    : DefaultDetails;
+  return (code === '105B' || code === '105E') && isNewAccessorial ? Code105Details : DefaultDetails;
 }

--- a/src/shared/PreApprovalRequest/PreApprovalForm.test.js
+++ b/src/shared/PreApprovalRequest/PreApprovalForm.test.js
@@ -205,7 +205,6 @@ describe('PreApprovalForm tests', () => {
             filteredLocations={['ORIGIN']}
             tariff400ng_item_code={'105B'}
             tariff400ngItem={simple105TariffItem}
-            context={{ flags: { robustAccessorial: true } }}
             initialValues={{ crate_dimensions: true }}
           />
         </Provider>,


### PR DESCRIPTION
## Description

Remove 105B && 105E from behind the `robustAccessorial` feature flag.
Modify the e2e test to create an old 105B and 105E item and ensure they display correctly.

## Reviewer Notes

Set up a way to pass variables into a function to get back a json object to use as a fixture.

## Setup

`make e2e_test`
run the tests in `TSP`/`preApprovalRequest.js`

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/162850111) for this change
