### PR TITLE
Prepopulate HHG pickup address with SM residential address

### DIFF
--- a/cypress/integration/mymove/shipment.js
+++ b/cypress/integration/mymove/shipment.js
@@ -111,13 +111,20 @@ function serviceMemberAddsLocations() {
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/moves\/[^/]+\/hhg-locations/);
   });
-  cy.get('button.next').should('be.disabled');
+
+  // Pickup address
+  cy.get('input[name="pickup_address.street_address_1"]').should('have.value', '123 Any Street');
+  cy.get('input[name="pickup_address.street_address_2"]').should('have.value', 'P.O. Box 12345');
+  cy.get('input[name="pickup_address.city"]').should('have.value', 'Beverly Hills');
+  cy.get('select[name="pickup_address.state"]').should('have.value', 'CA');
+  cy.get('input[name="pickup_address.postal_code"]').should('have.value', '90210');
 
   // Pickup address
   cy
     .get('input[name="pickup_address.street_address_1"]')
     .clear({ force: true })
     .type('123 Elm Street');
+  cy.get('input[name="pickup_address.street_address_2"]').clear({ force: true });
   cy
     .get('input[name="pickup_address.city"]')
     .clear()
@@ -150,7 +157,10 @@ function serviceMemberAddsLocations() {
     .clear()
     .type('Fremont');
   cy.get('select[name="delivery_address.state"]').select('CA');
-  cy.get('input[name="delivery_address.postal_code"]').type('94567');
+  cy
+    .get('input[name="delivery_address.postal_code"]')
+    .clear()
+    .type('94567');
 
   cy.nextPage();
 }

--- a/cypress/integration/mymove/shipment.js
+++ b/cypress/integration/mymove/shipment.js
@@ -111,6 +111,8 @@ function serviceMemberAddsLocations() {
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/moves\/[^/]+\/hhg-locations/);
   });
+  // Note that we are not checking for a disabled save button because we
+  // expect the pickup address to prefill with the SM residential address
 
   // Pickup address
   cy.get('input[name="pickup_address.street_address_1"]').should('have.value', '123 Any Street');

--- a/src/scenes/Moves/Hhg/Locations.jsx
+++ b/src/scenes/Moves/Hhg/Locations.jsx
@@ -99,12 +99,13 @@ function mapDispatchToProps(dispatch) {
 }
 function mapStateToProps(state) {
   const shipment = getCurrentShipment(state);
+  const smAddress = get(state, 'serviceMember.currentServiceMember.residential_address', {});
   const props = {
     schema: getInternalSwaggerDefinition(state, 'Shipment'),
     move: get(state, 'moves.currentMove', {}),
     formValues: getFormValues(formName)(state),
     currentShipment: shipment,
-    initialValues: shipment,
+    initialValues: { pickup_address: smAddress },
     error: getLastError(state, getShipmentLabel),
   };
   return props;


### PR DESCRIPTION
## Description

When we have HHG moves, we already have the SM residential address, which is very likely to be the pickup address of the HHG, so we prepopulate it on the locations page on HHG creation.

## Reviewer Notes

I struggled a lot with where form values were coming in, so there's a small chance I left in one of my changes to attempt to get it working. Turns out it was more straightforward than I had thought.

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make db_dev_e2e_populate
```
Get the server and milmove client running. Sign in as `sm_hhg_continue@example.com`. Continue move set up. On the locations page, there should be an address already filled in (123 Any St., Beverly Hills). If you change the values, all changes should be reflected on the review page properly.

## Code Review Verification Steps

* [x] User facing changes have been reviewed by design.
* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* https://www.pivotaltracker.com/story/show/163494937

## Screenshots

![prepopulatedaddress](https://user-images.githubusercontent.com/5531789/53916265-98e34480-4016-11e9-82d8-1f1a588b3ce8.gif)

