### PR TITLE
Add weight and distance units to LHS and 16A: 163331256

### DIFF
--- a/src/shared/lineItems.js
+++ b/src/shared/lineItems.js
@@ -12,30 +12,41 @@ export const displayBaseQuantityUnits = (item, scale) => {
   const itemCode = item.tariff400ng_item.code;
   const itemQuantity1 = item.quantity_1;
   const itemQuantity2 = item.quantity_2;
-  const lbsItems = ['105A', '105C', '135A', '135B'];
-  const cuFtItems = ['105B', '105E'];
-  const lbsMiItems = ['LHS', '16A'];
 
-  if (lbsItems.includes(itemCode)) {
+  if (isWeight(itemCode)) {
     const decimalPlaces = 0;
-    const convertedItemQuantity1 = convertFromBaseQuantity(itemQuantity1);
-    const weight = truncateNumber(convertedItemQuantity1, decimalPlaces);
-    return `${addCommasToNumberString(weight, decimalPlaces)} lbs`;
-  } else if (lbsMiItems.includes(itemCode)) {
+    const weight = convertTruncateAddCommas(itemQuantity1, decimalPlaces);
+    return `${weight} lbs`;
+  } else if (isWeightDistance(itemCode)) {
     const decimalPlaces = 0;
-    const convertedItemQuantity1 = convertFromBaseQuantity(itemQuantity1);
-    const convertedItemQuantity2 = convertFromBaseQuantity(itemQuantity2);
-    const weight = truncateNumber(convertedItemQuantity1, decimalPlaces);
-    const milage = truncateNumber(convertedItemQuantity2, decimalPlaces);
-    return `${addCommasToNumberString(weight, decimalPlaces)} lbs, ${addCommasToNumberString(
-      milage,
-      decimalPlaces,
-    )} mi`;
-  } else if (cuFtItems.includes(itemCode) && isNewAccessorial(item)) {
+    const weight = convertTruncateAddCommas(itemQuantity1, decimalPlaces);
+    const milage = convertTruncateAddCommas(itemQuantity2, decimalPlaces);
+    return `${weight} lbs, ${milage} mi`;
+  } else if (isVolume(itemCode) && isNewAccessorial(item)) {
     const decimalPlaces = 2;
-    const convertedItemQuantity1 = convertFromBaseQuantity(itemQuantity1);
-    const volume = truncateNumber(convertedItemQuantity1, decimalPlaces);
-    return `${addCommasToNumberString(volume, decimalPlaces)} cu ft`;
+    const volume = convertTruncateAddCommas(itemQuantity1, decimalPlaces);
+    return `${volume} cu ft`;
   }
   return formatFromBaseQuantity(itemQuantity1);
 };
+
+function isWeight(itemCode) {
+  const lbsItems = ['105A', '105C', '135A', '135B'];
+  return lbsItems.includes(itemCode);
+}
+
+function isVolume(itemCode) {
+  const cuFtItems = ['105B', '105E'];
+  return cuFtItems.includes(itemCode);
+}
+
+function isWeightDistance(itemCode) {
+  const lbsMiItems = ['LHS', '16A'];
+  return lbsMiItems.includes(itemCode);
+}
+
+function convertTruncateAddCommas(value, decimalPlaces) {
+  const convertedValue = convertFromBaseQuantity(value);
+  const formattedValue = truncateNumber(convertedValue, decimalPlaces);
+  return addCommasToNumberString(formattedValue, decimalPlaces);
+}

--- a/src/shared/lineItems.js
+++ b/src/shared/lineItems.js
@@ -10,20 +10,32 @@ export const displayBaseQuantityUnits = (item, scale) => {
   if (!item) return;
 
   const itemCode = item.tariff400ng_item.code;
-  const itemQuantity = item.quantity_1;
+  const itemQuantity1 = item.quantity_1;
+  const itemQuantity2 = item.quantity_2;
   const lbsItems = ['105A', '105C', '135A', '135B'];
   const cuFtItems = ['105B', '105E'];
+  const lbsMiItems = ['LHS', '16A'];
 
   if (lbsItems.includes(itemCode)) {
     const decimalPlaces = 0;
-    const convertedItemQuantity = convertFromBaseQuantity(itemQuantity);
-    const baseQuantity = truncateNumber(convertedItemQuantity, decimalPlaces);
-    return `${addCommasToNumberString(baseQuantity, decimalPlaces)} lbs`;
+    const convertedItemQuantity1 = convertFromBaseQuantity(itemQuantity1);
+    const weight = truncateNumber(convertedItemQuantity1, decimalPlaces);
+    return `${addCommasToNumberString(weight, decimalPlaces)} lbs`;
+  } else if (lbsMiItems.includes(itemCode)) {
+    const decimalPlaces = 0;
+    const convertedItemQuantity1 = convertFromBaseQuantity(itemQuantity1);
+    const convertedItemQuantity2 = convertFromBaseQuantity(itemQuantity2);
+    const weight = truncateNumber(convertedItemQuantity1, decimalPlaces);
+    const milage = truncateNumber(convertedItemQuantity2, decimalPlaces);
+    return `${addCommasToNumberString(weight, decimalPlaces)} lbs, ${addCommasToNumberString(
+      milage,
+      decimalPlaces,
+    )} mi`;
   } else if (cuFtItems.includes(itemCode) && isNewAccessorial(item)) {
     const decimalPlaces = 2;
-    const convertedItemQuantity = convertFromBaseQuantity(itemQuantity);
-    const baseQuantity = truncateNumber(convertedItemQuantity, decimalPlaces);
-    return `${addCommasToNumberString(baseQuantity, decimalPlaces)} cu ft`;
+    const convertedItemQuantity1 = convertFromBaseQuantity(itemQuantity1);
+    const volume = truncateNumber(convertedItemQuantity1, decimalPlaces);
+    return `${addCommasToNumberString(volume, decimalPlaces)} cu ft`;
   }
-  return formatFromBaseQuantity(itemQuantity);
+  return formatFromBaseQuantity(itemQuantity1);
 };

--- a/src/shared/lineItems.test.js
+++ b/src/shared/lineItems.test.js
@@ -54,5 +54,20 @@ describe('lineItems', () => {
         });
       });
     });
+    describe('for Linehaul Transportation(LHS) and 105E Fule Surcharge-LHS(16A)', () => {
+      it('should display weight and milage', () => {
+        const itemLHS = { tariff400ng_item: { code: 'LHS' }, quantity_1: 5000000, quantity_2: 55550000 };
+        const item16A = {
+          tariff400ng_item: { code: 'LHS' },
+          quantity_1: Number.MAX_SAFE_INTEGER,
+          quantity_2: Number.MAX_SAFE_INTEGER,
+        };
+        const itemNull = null;
+
+        expect(lineItems.displayBaseQuantityUnits(itemLHS)).toEqual('500 lbs, 5,555 mi');
+        expect(lineItems.displayBaseQuantityUnits(item16A)).toEqual('900,719,925,474 lbs, 900,719,925,474 mi');
+        expect(lineItems.displayBaseQuantityUnits(itemNull)).toEqual(undefined);
+      });
+    });
   });
 });

--- a/src/shared/lineItems.test.js
+++ b/src/shared/lineItems.test.js
@@ -1,84 +1,80 @@
 import * as lineItems from './lineItems';
 
-function runTests(items) {
-  for (let item of items) {
-    expect(lineItems.displayBaseQuantityUnits(item.test)).toEqual(item.expected);
-  }
+function runTest(input, expected) {
+  expect(lineItems.displayBaseQuantityUnits(input)).toEqual(expected);
 }
 
 describe('lineItems', () => {
   describe('displayBaseQuantityUnits', () => {
     describe('for full pack(205A), full unpack(105C), origin service charge(135A), destination service charge(135B)', () => {
       it('should display fee weight truncated to 0 decimal places', () => {
-        const items = [
-          { test: { tariff400ng_item: { code: '105A' }, quantity_1: 5000000 }, expected: '500 lbs' },
+        const tests = [
+          { input: { tariff400ng_item: { code: '105A' }, quantity_1: 5000000 }, expected: '500 lbs' },
           {
-            test: { tariff400ng_item: { code: '105C' }, quantity_1: Number.MAX_SAFE_INTEGER },
+            input: { tariff400ng_item: { code: '105C' }, quantity_1: Number.MAX_SAFE_INTEGER },
             expected: '900,719,925,474 lbs',
           },
-          { test: { tariff400ng_item: { code: '135A' }, quantity_1: 50000 }, expected: '5 lbs' },
-          { test: { tariff400ng_item: { code: '135B' }, quantity_1: 51111 }, expected: '5 lbs' },
-          { test: { tariff400ng_item: { code: '105A' }, quantity_1: null }, expected: '0 lbs' },
-          { test: null, expected: undefined },
-          { test: { tariff400ng_item: { code: '105A' }, quantity_1: '5000000' }, expected: '0 lbs' }, // doesn't work w/ strings
+          { input: { tariff400ng_item: { code: '135A' }, quantity_1: 50000 }, expected: '5 lbs' },
+          { input: { tariff400ng_item: { code: '135B' }, quantity_1: 51111 }, expected: '5 lbs' },
+          { input: { tariff400ng_item: { code: '105A' }, quantity_1: null }, expected: '0 lbs' },
+          { input: null, expected: undefined },
+          { input: { tariff400ng_item: { code: '105A' }, quantity_1: '5000000' }, expected: '0 lbs' }, // doesn't work w/ strings
           // negitives act funny due to floor() - but we shouldn't have negitive quantities so meh
-          { test: { tariff400ng_item: { code: '105A' }, quantity_1: -55000 }, expected: '-6 lbs' },
+          { input: { tariff400ng_item: { code: '105A' }, quantity_1: -55000 }, expected: '-6 lbs' },
         ];
-        runTests(items);
+        tests.forEach(test => runTest(test.input, test.expected));
       });
     });
     describe('for Pack Reg Crate(105B) and UnPack Reg Crate(105E)', () => {
       describe('for original accessorials', () => {
         it('should display value in quantity_1', () => {
-          const items = [
-            { test: { tariff400ng_item: { code: '105B' }, quantity_1: 5000000 }, expected: '500.0000' },
+          const tests = [
+            { input: { tariff400ng_item: { code: '105B' }, quantity_1: 5000000 }, expected: '500.0000' },
             {
-              test: { tariff400ng_item: { code: '105E' }, quantity_1: Number.MAX_SAFE_INTEGER },
+              input: { tariff400ng_item: { code: '105E' }, quantity_1: Number.MAX_SAFE_INTEGER },
               expected: '900,719,925,474.0991',
             },
-            { test: null, expected: undefined },
+            { input: null, expected: undefined },
           ];
-
-          runTests(items);
+          tests.forEach(test => runTest(test.input, test.expected));
         });
       });
 
       describe('for robust accessorials', () => {
         it('should dispaly volume in cubic feet truncated to 2 decimal places', () => {
-          const items = [
+          const tests = [
             {
-              test: { tariff400ng_item: { code: '105B' }, quantity_1: 5000000, crate_dimensions: {} },
+              input: { tariff400ng_item: { code: '105B' }, quantity_1: 5000000, crate_dimensions: {} },
               expected: '500.00 cu ft',
             },
             {
-              test: { tariff400ng_item: { code: '105E' }, quantity_1: Number.MAX_SAFE_INTEGER, crate_dimensions: {} },
+              input: { tariff400ng_item: { code: '105E' }, quantity_1: Number.MAX_SAFE_INTEGER, crate_dimensions: {} },
               expected: '900,719,925,474.09 cu ft',
             },
-            { test: null, expected: undefined },
+            { input: null, expected: undefined },
           ];
-
-          runTests(items);
+          tests.forEach(test => runTest(test.input, test.expected));
         });
       });
     });
     describe('for Linehaul Transportation(LHS) and 105E Fule Surcharge-LHS(16A)', () => {
       it('should display weight and milage', () => {
-        const items = [
+        const tests = [
           {
-            test: { tariff400ng_item: { code: 'LHS' }, quantity_1: 5000000, quantity_2: 55550000 },
+            input: { tariff400ng_item: { code: 'LHS' }, quantity_1: 5000000, quantity_2: 55550000 },
             expected: '500 lbs, 5,555 mi',
           },
           {
-            test: {
+            input: {
               tariff400ng_item: { code: 'LHS' },
               quantity_1: Number.MAX_SAFE_INTEGER,
               quantity_2: Number.MAX_SAFE_INTEGER,
             },
             expected: '900,719,925,474 lbs, 900,719,925,474 mi',
           },
-          { test: null, expected: undefined },
+          { input: null, expected: undefined },
         ];
-        runTests(items);
+        tests.forEach(test => runTest(test.input, test.expected));
       });
     });
   });

--- a/src/shared/lineItems.test.js
+++ b/src/shared/lineItems.test.js
@@ -2,49 +2,57 @@ import * as lineItems from './lineItems';
 
 describe('lineItems', () => {
   describe('displayBaseQuantityUnits', () => {
-    it('display full pack, full unpack, origin and dest fee weight truncated to 0 decimal places', () => {
-      const item105A = { tariff400ng_item: { code: '105A' }, quantity_1: 5000000 };
-      const item105C = { tariff400ng_item: { code: '105C' }, quantity_1: Number.MAX_SAFE_INTEGER };
+    describe('for full pack(205A), full unpack(105C), origin service charge(135A), destination service charge(135B)', () => {
+      it('should display fee weight truncated to 0 decimal places', () => {
+        const item105A = { tariff400ng_item: { code: '105A' }, quantity_1: 5000000 };
+        const item105C = { tariff400ng_item: { code: '105C' }, quantity_1: Number.MAX_SAFE_INTEGER };
 
-      const item135A = { tariff400ng_item: { code: '135A' }, quantity_1: 50000 };
-      const item135B = { tariff400ng_item: { code: '135B' }, quantity_1: 51111 };
-      const itemQuantityNull = { tariff400ng_item: { code: '105A' }, quantity_1: null };
-      const itemNegitive = { tariff400ng_item: { code: '105A' }, quantity_1: -55000 };
-      const item105AString = { tariff400ng_item: { code: '105A' }, quantity_1: '5000000' };
-      const itemNull = null;
+        const item135A = { tariff400ng_item: { code: '135A' }, quantity_1: 50000 };
+        const item135B = { tariff400ng_item: { code: '135B' }, quantity_1: 51111 };
+        const itemQuantityNull = { tariff400ng_item: { code: '105A' }, quantity_1: null };
+        const itemNegitive = { tariff400ng_item: { code: '105A' }, quantity_1: -55000 };
+        const item105AString = { tariff400ng_item: { code: '105A' }, quantity_1: '5000000' };
+        const itemNull = null;
 
-      expect(lineItems.displayBaseQuantityUnits(item105A)).toEqual('500 lbs');
-      expect(lineItems.displayBaseQuantityUnits(item105C)).toEqual('900,719,925,474 lbs');
-      expect(lineItems.displayBaseQuantityUnits(item135A)).toEqual('5 lbs');
-      expect(lineItems.displayBaseQuantityUnits(item135B)).toEqual('5 lbs');
-      expect(lineItems.displayBaseQuantityUnits(itemQuantityNull)).toEqual('0 lbs');
-      expect(lineItems.displayBaseQuantityUnits(itemNull)).toEqual(undefined);
-      expect(lineItems.displayBaseQuantityUnits(item105AString)).toEqual('0 lbs'); // doesn't work w/ strings
-      // negitives act funny due to floor() - but we shouldn't have negitive quantities so meh
-      expect(lineItems.displayBaseQuantityUnits(itemNegitive)).toEqual('-6 lbs');
+        expect(lineItems.displayBaseQuantityUnits(item105A)).toEqual('500 lbs');
+        expect(lineItems.displayBaseQuantityUnits(item105C)).toEqual('900,719,925,474 lbs');
+        expect(lineItems.displayBaseQuantityUnits(item135A)).toEqual('5 lbs');
+        expect(lineItems.displayBaseQuantityUnits(item135B)).toEqual('5 lbs');
+        expect(lineItems.displayBaseQuantityUnits(itemQuantityNull)).toEqual('0 lbs');
+        expect(lineItems.displayBaseQuantityUnits(itemNull)).toEqual(undefined);
+        expect(lineItems.displayBaseQuantityUnits(item105AString)).toEqual('0 lbs'); // doesn't work w/ strings
+        // negitives act funny due to floor() - but we shouldn't have negitive quantities so meh
+        expect(lineItems.displayBaseQuantityUnits(itemNegitive)).toEqual('-6 lbs');
+      });
     });
-    it('display 105B/E for original accessorials', () => {
-      const item105B = { tariff400ng_item: { code: '105B' }, quantity_1: 5000000 };
-      const item105E = { tariff400ng_item: { code: '105E' }, quantity_1: Number.MAX_SAFE_INTEGER };
-      const itemNull = null;
+    describe('for Pack Reg Crate(105B) and UnPack Reg Crate(105E)', () => {
+      describe('for original accessorials', () => {
+        it('should display value in quantity_1', () => {
+          const item105B = { tariff400ng_item: { code: '105B' }, quantity_1: 5000000 };
+          const item105E = { tariff400ng_item: { code: '105E' }, quantity_1: Number.MAX_SAFE_INTEGER };
+          const itemNull = null;
 
-      expect(lineItems.displayBaseQuantityUnits(item105B)).toEqual('500.0000');
-      expect(lineItems.displayBaseQuantityUnits(item105E)).toEqual('900,719,925,474.0991');
-      expect(lineItems.displayBaseQuantityUnits(itemNull)).toEqual(undefined);
-    });
+          expect(lineItems.displayBaseQuantityUnits(item105B)).toEqual('500.0000');
+          expect(lineItems.displayBaseQuantityUnits(item105E)).toEqual('900,719,925,474.0991');
+          expect(lineItems.displayBaseQuantityUnits(itemNull)).toEqual(undefined);
+        });
+      });
 
-    it('display 105B/E cu ft for robust accessorials', () => {
-      const item105B = { tariff400ng_item: { code: '105B' }, quantity_1: 5000000, crate_dimensions: {} };
-      const item105E = {
-        tariff400ng_item: { code: '105E' },
-        quantity_1: Number.MAX_SAFE_INTEGER,
-        crate_dimensions: {},
-      };
-      const itemNull = null;
+      describe('for robust accessorials', () => {
+        it('should dispaly volume in cubic feet truncated to 2 decimal places', () => {
+          const item105B = { tariff400ng_item: { code: '105B' }, quantity_1: 5000000, crate_dimensions: {} };
+          const item105E = {
+            tariff400ng_item: { code: '105E' },
+            quantity_1: Number.MAX_SAFE_INTEGER,
+            crate_dimensions: {},
+          };
+          const itemNull = null;
 
-      expect(lineItems.displayBaseQuantityUnits(item105B)).toEqual('500.00 cu ft');
-      expect(lineItems.displayBaseQuantityUnits(item105E)).toEqual('900,719,925,474.09 cu ft');
-      expect(lineItems.displayBaseQuantityUnits(itemNull)).toEqual(undefined);
+          expect(lineItems.displayBaseQuantityUnits(item105B)).toEqual('500.00 cu ft');
+          expect(lineItems.displayBaseQuantityUnits(item105E)).toEqual('900,719,925,474.09 cu ft');
+          expect(lineItems.displayBaseQuantityUnits(itemNull)).toEqual(undefined);
+        });
+      });
     });
   });
 });

--- a/src/shared/lineItems.test.js
+++ b/src/shared/lineItems.test.js
@@ -6,7 +6,6 @@ describe('lineItems', () => {
       it('should display fee weight truncated to 0 decimal places', () => {
         const item105A = { tariff400ng_item: { code: '105A' }, quantity_1: 5000000 };
         const item105C = { tariff400ng_item: { code: '105C' }, quantity_1: Number.MAX_SAFE_INTEGER };
-
         const item135A = { tariff400ng_item: { code: '135A' }, quantity_1: 50000 };
         const item135B = { tariff400ng_item: { code: '135B' }, quantity_1: 51111 };
         const itemQuantityNull = { tariff400ng_item: { code: '105A' }, quantity_1: null };

--- a/src/shared/lineItems.test.js
+++ b/src/shared/lineItems.test.js
@@ -1,71 +1,84 @@
 import * as lineItems from './lineItems';
 
+function runTests(items) {
+  for (let item of items) {
+    expect(lineItems.displayBaseQuantityUnits(item.test)).toEqual(item.expected);
+  }
+}
+
 describe('lineItems', () => {
   describe('displayBaseQuantityUnits', () => {
     describe('for full pack(205A), full unpack(105C), origin service charge(135A), destination service charge(135B)', () => {
       it('should display fee weight truncated to 0 decimal places', () => {
-        const item105A = { tariff400ng_item: { code: '105A' }, quantity_1: 5000000 };
-        const item105C = { tariff400ng_item: { code: '105C' }, quantity_1: Number.MAX_SAFE_INTEGER };
-        const item135A = { tariff400ng_item: { code: '135A' }, quantity_1: 50000 };
-        const item135B = { tariff400ng_item: { code: '135B' }, quantity_1: 51111 };
-        const itemQuantityNull = { tariff400ng_item: { code: '105A' }, quantity_1: null };
-        const itemNegitive = { tariff400ng_item: { code: '105A' }, quantity_1: -55000 };
-        const item105AString = { tariff400ng_item: { code: '105A' }, quantity_1: '5000000' };
-        const itemNull = null;
-
-        expect(lineItems.displayBaseQuantityUnits(item105A)).toEqual('500 lbs');
-        expect(lineItems.displayBaseQuantityUnits(item105C)).toEqual('900,719,925,474 lbs');
-        expect(lineItems.displayBaseQuantityUnits(item135A)).toEqual('5 lbs');
-        expect(lineItems.displayBaseQuantityUnits(item135B)).toEqual('5 lbs');
-        expect(lineItems.displayBaseQuantityUnits(itemQuantityNull)).toEqual('0 lbs');
-        expect(lineItems.displayBaseQuantityUnits(itemNull)).toEqual(undefined);
-        expect(lineItems.displayBaseQuantityUnits(item105AString)).toEqual('0 lbs'); // doesn't work w/ strings
-        // negitives act funny due to floor() - but we shouldn't have negitive quantities so meh
-        expect(lineItems.displayBaseQuantityUnits(itemNegitive)).toEqual('-6 lbs');
+        const items = [
+          { test: { tariff400ng_item: { code: '105A' }, quantity_1: 5000000 }, expected: '500 lbs' },
+          {
+            test: { tariff400ng_item: { code: '105C' }, quantity_1: Number.MAX_SAFE_INTEGER },
+            expected: '900,719,925,474 lbs',
+          },
+          { test: { tariff400ng_item: { code: '135A' }, quantity_1: 50000 }, expected: '5 lbs' },
+          { test: { tariff400ng_item: { code: '135B' }, quantity_1: 51111 }, expected: '5 lbs' },
+          { test: { tariff400ng_item: { code: '105A' }, quantity_1: null }, expected: '0 lbs' },
+          { test: null, expected: undefined },
+          { test: { tariff400ng_item: { code: '105A' }, quantity_1: '5000000' }, expected: '0 lbs' }, // doesn't work w/ strings
+          // negitives act funny due to floor() - but we shouldn't have negitive quantities so meh
+          { test: { tariff400ng_item: { code: '105A' }, quantity_1: -55000 }, expected: '-6 lbs' },
+        ];
+        runTests(items);
       });
     });
     describe('for Pack Reg Crate(105B) and UnPack Reg Crate(105E)', () => {
       describe('for original accessorials', () => {
         it('should display value in quantity_1', () => {
-          const item105B = { tariff400ng_item: { code: '105B' }, quantity_1: 5000000 };
-          const item105E = { tariff400ng_item: { code: '105E' }, quantity_1: Number.MAX_SAFE_INTEGER };
-          const itemNull = null;
+          const items = [
+            { test: { tariff400ng_item: { code: '105B' }, quantity_1: 5000000 }, expected: '500.0000' },
+            {
+              test: { tariff400ng_item: { code: '105E' }, quantity_1: Number.MAX_SAFE_INTEGER },
+              expected: '900,719,925,474.0991',
+            },
+            { test: null, expected: undefined },
+          ];
 
-          expect(lineItems.displayBaseQuantityUnits(item105B)).toEqual('500.0000');
-          expect(lineItems.displayBaseQuantityUnits(item105E)).toEqual('900,719,925,474.0991');
-          expect(lineItems.displayBaseQuantityUnits(itemNull)).toEqual(undefined);
+          runTests(items);
         });
       });
 
       describe('for robust accessorials', () => {
         it('should dispaly volume in cubic feet truncated to 2 decimal places', () => {
-          const item105B = { tariff400ng_item: { code: '105B' }, quantity_1: 5000000, crate_dimensions: {} };
-          const item105E = {
-            tariff400ng_item: { code: '105E' },
-            quantity_1: Number.MAX_SAFE_INTEGER,
-            crate_dimensions: {},
-          };
-          const itemNull = null;
+          const items = [
+            {
+              test: { tariff400ng_item: { code: '105B' }, quantity_1: 5000000, crate_dimensions: {} },
+              expected: '500.00 cu ft',
+            },
+            {
+              test: { tariff400ng_item: { code: '105E' }, quantity_1: Number.MAX_SAFE_INTEGER, crate_dimensions: {} },
+              expected: '900,719,925,474.09 cu ft',
+            },
+            { test: null, expected: undefined },
+          ];
 
-          expect(lineItems.displayBaseQuantityUnits(item105B)).toEqual('500.00 cu ft');
-          expect(lineItems.displayBaseQuantityUnits(item105E)).toEqual('900,719,925,474.09 cu ft');
-          expect(lineItems.displayBaseQuantityUnits(itemNull)).toEqual(undefined);
+          runTests(items);
         });
       });
     });
     describe('for Linehaul Transportation(LHS) and 105E Fule Surcharge-LHS(16A)', () => {
       it('should display weight and milage', () => {
-        const itemLHS = { tariff400ng_item: { code: 'LHS' }, quantity_1: 5000000, quantity_2: 55550000 };
-        const item16A = {
-          tariff400ng_item: { code: 'LHS' },
-          quantity_1: Number.MAX_SAFE_INTEGER,
-          quantity_2: Number.MAX_SAFE_INTEGER,
-        };
-        const itemNull = null;
-
-        expect(lineItems.displayBaseQuantityUnits(itemLHS)).toEqual('500 lbs, 5,555 mi');
-        expect(lineItems.displayBaseQuantityUnits(item16A)).toEqual('900,719,925,474 lbs, 900,719,925,474 mi');
-        expect(lineItems.displayBaseQuantityUnits(itemNull)).toEqual(undefined);
+        const items = [
+          {
+            test: { tariff400ng_item: { code: 'LHS' }, quantity_1: 5000000, quantity_2: 55550000 },
+            expected: '500 lbs, 5,555 mi',
+          },
+          {
+            test: {
+              tariff400ng_item: { code: 'LHS' },
+              quantity_1: Number.MAX_SAFE_INTEGER,
+              quantity_2: Number.MAX_SAFE_INTEGER,
+            },
+            expected: '900,719,925,474 lbs, 900,719,925,474 mi',
+          },
+          { test: null, expected: undefined },
+        ];
+        runTests(items);
       });
     });
   });


### PR DESCRIPTION
## Description

Add weight(lb) and distance(mi) units to `Linehaul Transportation(LHS)` and `Fuel Surcharge-LHS(16A)` in the invoice table. This change affects both the TSP and the Office.

## Setup

`make db_dev_e2e_populate`
`make server_run`
`make office_client_run`
`make tsp_client_run`

Check invoice panel for `LHS` and `16A` code and ensure they show weight and milage in the `Base quantity` column.

## Code Review Verification Steps

* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/163331256) for this change
The TSP side came along for free
* [Pivotal story](https://www.pivotaltracker.com/story/show/163331256) for this change

## Screenshots
### Office
<img width="1130" alt="office after approving" src="https://user-images.githubusercontent.com/3099491/53969771-fcc14800-40be-11e9-96f4-f35c665bcf3b.png">
<img width="1135" alt="office" src="https://user-images.githubusercontent.com/3099491/53969772-fcc14800-40be-11e9-8cb5-a99ac73fb37d.png">

### TSP
<img width="1006" alt="tsp after approval" src="https://user-images.githubusercontent.com/3099491/53969782-021e9280-40bf-11e9-8d01-486b3c59c2a7.png">
<img width="998" alt="tsp" src="https://user-images.githubusercontent.com/3099491/53969784-021e9280-40bf-11e9-88f4-593063286dc1.png">
