### PR TITLE
Increase chamber retries to 20

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,6 +56,8 @@ commands:
       - run:
           name: Run migrations
           command: bin/do-exclusively --job-name ${CIRCLE_JOB} bin/ecs-run-app-migrations-container config/app-migrations.container-definition.json ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/app-migrations:git-${CIRCLE_SHA1} $APP_ENVIRONMENT
+          environment:
+            CHAMBER_RETRIES: 20
       - announce_failure
   deploy_app_steps:
     parameters:
@@ -76,6 +78,7 @@ commands:
       - deploy:
           name: Deploy app service
           command: bin/do-exclusively --job-name ${CIRCLE_JOB} bin/ecs-deploy-service-container app config/app.container-definition.json ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/app:git-${CIRCLE_SHA1} $APP_ENVIRONMENT FARGATE
+          no_output_timeout: 20m
       - run:
           name: Health Check
           command: go run cmd/health_checker/main.go --schemes http,https --hosts << parameters.health_check_hosts >> --tries 10 --backoff 3 --log-level info --timeout 15m
@@ -102,6 +105,7 @@ commands:
       - deploy:
           name: Deploy app-client-tls service
           command: bin/do-exclusively --job-name ${CIRCLE_JOB} bin/ecs-deploy-service-container app-client-tls config/app-client-tls.container-definition.json ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/app:git-${CIRCLE_SHA1} $APP_ENVIRONMENT FARGATE
+          no_output_timeout: 20m
       - run:
           name: Health Check
           command: |
@@ -588,6 +592,7 @@ jobs:
           name: Run acceptance tests
           command: make webserver_test
           environment:
+            CHAMBER_RETRIES: 20
             PWD: /home/circleci/go/src/github.com/transcom/mymove
             DOD_CA_PACKAGE: /home/circleci/go/src/github.com/transcom/mymove/config/tls/Certificates_PKCS7_v5.4_DoD.der.p7b
             TEST_ACC_ENV: experimental
@@ -650,6 +655,7 @@ jobs:
           name: Run acceptance tests
           command: make webserver_test
           environment:
+            CHAMBER_RETRIES: 20
             PWD: /home/circleci/go/src/github.com/transcom/mymove
             DOD_CA_PACKAGE: /home/circleci/go/src/github.com/transcom/mymove/config/tls/Certificates_PKCS7_v5.4_DoD.der.p7b
             TEST_ACC_ENV: staging

--- a/.envrc
+++ b/.envrc
@@ -53,6 +53,9 @@ check_required_variables() {
 # directly into a subdirectory.
 export MYMOVE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
+# Sets the number of retries for chamber to 20.
+export CHAMBER_RETRIES=20
+
 # Configuration needed for secure migrations.
 export SECURE_MIGRATION_DIR="${MYMOVE_DIR}/local_migrations"
 export SECURE_MIGRATION_SOURCE="local"

--- a/Makefile
+++ b/Makefile
@@ -276,13 +276,13 @@ ifndef CIRCLECI
 	TEST_ACC_CWD=$(PWD) \
 	DISABLE_AWS_VAULT_WRAPPER=1 \
 	aws-vault exec $(AWS_PROFILE) -- \
-	bin/chamber exec app-$(TEST_ACC_ENV) -- \
+	bin/chamber -r $(CHAMBER_RETRIES) exec app-$(TEST_ACC_ENV) -- \
 	go test -v -p 1 -count 1 -short $$(go list ./... | grep \\/cmd\\/webserver)
 else
 	@echo "Running acceptance tests for webserver with environment $$TEST_ACC_ENV."
 	TEST_ACC_DATABASE=0 TEST_ACC_HONEYCOMB=0 \
 	TEST_ACC_CWD=$(PWD) \
-	bin/chamber exec app-$(TEST_ACC_ENV) -- \
+	bin/chamber -r $(CHAMBER_RETRIES) exec app-$(TEST_ACC_ENV) -- \
 	go test -v -p 1 -count 1 -short $$(go list ./... | grep \\/cmd\\/webserver)
 endif
 endif

--- a/config/app-client-tls.container-definition.json
+++ b/config/app-client-tls.container-definition.json
@@ -11,6 +11,8 @@
   "essential": true,
   "entryPoint": [
     "/bin/chamber",
+    "-r",
+    "{{ .CHAMBER_RETRIES }}",
     "exec",
     "app-{{ .environment }}",
     "--",

--- a/config/app-migrations.container-definition.json
+++ b/config/app-migrations.container-definition.json
@@ -4,6 +4,8 @@
   "essential": true,
   "entryPoint": [
     "/bin/chamber",
+    "-r",
+    "{{ .CHAMBER_RETRIES }}",
     "exec",
     "app-{{ .environment }}",
     "--",

--- a/config/app.container-definition.json
+++ b/config/app.container-definition.json
@@ -11,6 +11,8 @@
   "essential": true,
   "entryPoint": [
     "/bin/chamber",
+    "-r",
+    "{{ .CHAMBER_RETRIES }}",
     "exec",
     "app-{{ .environment }}",
     "--",

--- a/config/env/experimental.env
+++ b/config/env/experimental.env
@@ -8,3 +8,4 @@ DPS_COOKIE_NAME=DPSIVV
 GEX_URL=https://gexweba.daas.dla.mil/msg_data/submit/
 SEND_PROD_INVOICE=false
 SERVE_SWAGGER_UI=true
+CHAMBER_RETRIES=20

--- a/config/env/prod.env
+++ b/config/env/prod.env
@@ -8,3 +8,4 @@ DPS_COOKIE_NAME=DPS
 GEX_URL=https://gexweba.daas.dla.mil/msg_data/submit/
 SEND_PROD_INVOICE=true
 SERVE_SWAGGER_UI=false
+CHAMBER_RETRIES=20

--- a/config/env/staging.env
+++ b/config/env/staging.env
@@ -8,3 +8,4 @@ DPS_COOKIE_NAME=DPSIVV
 GEX_URL=https://gexweba.daas.dla.mil/msg_data/submit/
 SEND_PROD_INVOICE=false
 SERVE_SWAGGER_UI=true
+CHAMBER_RETRIES=20


### PR DESCRIPTION
## Description

This PR increase the number of retries used by `chamber` to `20` from `10`.  It looks like `chamber` is already using exponential backoff, so this should make acceptance tests and deploys more reliable and less likely to be stopped by rate limits for SSM.

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Setup

None

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](./docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](./docs/backend.md#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](./docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
  * [ ] Secure migrations have been tested using `bin/run-prod-migrations`
* [ ] There are no aXe warnings for UI.
* [ ] This works in IE.
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @ntwyman
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/164475725) for this change

## Screenshots

N.A.