### PR TITLE
Added discount rate logging; changed addition to use AddCents method

### DIFF
--- a/pkg/models/estimate_helper.go
+++ b/pkg/models/estimate_helper.go
@@ -24,6 +24,8 @@ func PPMDiscountFetch(db *pop.Connection, logger *zap.Logger, originZip string, 
 			zap.String("origin_zip", originZip),
 			zap.String("destination_zip", destZip),
 			zap.Time("move_date", moveDate),
+			zap.Float64("lh_discount", lhDiscount.Float64()),
+			zap.Float64("sit_discount", sitDiscount.Float64()),
 		)
 		return lhDiscount, sitDiscount, err
 	}
@@ -43,6 +45,8 @@ func PPMDiscountFetch(db *pop.Connection, logger *zap.Logger, originZip string, 
 			zap.String("origin_zip", originZip),
 			zap.String("destination_zip", destZip),
 			zap.Time("move_date", moveDate),
+			zap.Float64("lh_discount", lhDiscount.Float64()),
+			zap.Float64("sit_discount", sitDiscount.Float64()),
 		)
 		return lhDiscount, sitDiscount, err
 	}

--- a/pkg/rateengine/nonlinehaul.go
+++ b/pkg/rateengine/nonlinehaul.go
@@ -43,7 +43,7 @@ func (c *NonLinehaulCostComputation) Scale(factor float64) {
 
 // ApplyDiscount will apply the linehaul and SIT discounts to the appropriate parts of the SIT computation.
 func (s SITComputation) ApplyDiscount(linehaulDiscount unit.DiscountRate, sitDiscount unit.DiscountRate) unit.Cents {
-	return sitDiscount.Apply(s.SITPart) + linehaulDiscount.Apply(s.LinehaulPart)
+	return sitDiscount.Apply(s.SITPart).AddCents(linehaulDiscount.Apply(s.LinehaulPart))
 }
 
 // MarshalLogObject allows SITComputation to be logged by Zap.


### PR DESCRIPTION
## Description

I'm adding some discount rate logging to try to figure out why I'm getting different calculations from the Incentive Calculator and Storage Calculator on multiple button presses in staging.  See https://defensedigitalservice.slack.com/archives/G8P7UD05U/p1552000474139900 for more details.

I also changed an addition of `unit.Cents` values to use `AddCents` instead of `+` just to be more in line with other places we add `unit.Cents` together (doesn't seem to affect the addition at all).

## References

No associated Pivotal story, but relates to #1756 (although it happens for the Incentive Calculator too, which wasn't involved in that PR).