### PR TITLE
Adds 226A create form [delivers #163829481]

### DIFF
--- a/src/shared/PreApprovalRequest/Code226Form.jsx
+++ b/src/shared/PreApprovalRequest/Code226Form.jsx
@@ -1,0 +1,25 @@
+import React, { Fragment } from 'react';
+import { SwaggerField } from 'shared/JsonSchemaForm/JsonSchemaField';
+
+export const Code226Form = props => {
+  const { ship_line_item_schema } = props;
+  return (
+    <Fragment>
+      <SwaggerField
+        className="textarea-half"
+        title="Description of charge"
+        fieldName="description"
+        swagger={ship_line_item_schema}
+        required
+      />
+      <SwaggerField
+        className="textarea-half"
+        title="Reason for charge"
+        fieldName="reason"
+        swagger={ship_line_item_schema}
+        required
+      />
+      <SwaggerField title="Amount" fieldName="actual_amount_cents" swagger={ship_line_item_schema} required />
+    </Fragment>
+  );
+};

--- a/src/shared/PreApprovalRequest/Code226Form.test.js
+++ b/src/shared/PreApprovalRequest/Code226Form.test.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { Code226Form } from './Code226Form';
+
+let wrapper;
+describe('code 35A details component', () => {
+  describe('renders', () => {
+    wrapper = shallow(<Code226Form ship_line_item_schema={{}} />);
+
+    it('without crashing', () => {
+      expect(wrapper.exists('SwaggerField')).toBe(true);
+    });
+  });
+});

--- a/src/shared/PreApprovalRequest/DetailsHelper.js
+++ b/src/shared/PreApprovalRequest/DetailsHelper.js
@@ -1,6 +1,7 @@
 import { DefaultForm } from './DefaultForm';
 import { Code105Form } from './Code105Form';
 import { Code35Form } from './Code35Form';
+import { Code226Form } from './Code226Form';
 import { get } from 'lodash';
 import { Code105Details } from './Code105Details';
 import { DefaultDetails } from './DefaultDetails';
@@ -13,6 +14,8 @@ export function getFormComponent(code, robustAccessorial, initialValues) {
     if (isNew || hasCrateDimensions) return Code105Form;
   } else if (robustAccessorial && code.startsWith('35')) {
     return Code35Form;
+  } else if (robustAccessorial && code.startsWith('226')) {
+    return Code226Form;
   }
   return DefaultForm;
 }

--- a/src/shared/PreApprovalRequest/DetailsHelper.test.js
+++ b/src/shared/PreApprovalRequest/DetailsHelper.test.js
@@ -2,6 +2,7 @@ import { getFormComponent } from './DetailsHelper';
 import { DefaultForm } from './DefaultForm';
 import { Code105Form } from './Code105Form';
 import { Code35Form } from './Code35Form';
+import { Code226Form } from './Code226Form';
 
 let featureFlag = false;
 let initialValuesWithoutCrateDimensions = {};
@@ -54,6 +55,11 @@ describe('testing getFormComponent()', () => {
     it('for code 35A', () => {
       expect(FormComponent).toBe(DefaultForm);
     });
+
+    FormComponent = getFormComponent('226A', featureFlag);
+    it('for code 226A', () => {
+      expect(FormComponent).toBe(DefaultForm);
+    });
   });
 
   describe('returns 105B/E form component with feature flag on', () => {
@@ -81,6 +87,15 @@ describe('testing getFormComponent()', () => {
     let FormComponent = getFormComponent('35A', featureFlag, initialValuesWithCrateDimensions);
     it('for code 35A', () => {
       expect(FormComponent).toBe(Code35Form);
+    });
+  });
+
+  describe('returns 226A form component with feature flag on', () => {
+    featureFlag = true;
+
+    let FormComponent = getFormComponent('226A', featureFlag, initialValuesWithCrateDimensions);
+    it('for code 226A', () => {
+      expect(FormComponent).toBe(Code226Form);
     });
   });
 


### PR DESCRIPTION
## Description

Adds a creation form specific to 226A, and puts that form behind the robust accessorial feature flag.

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/163829481) for this change

## Screenshots

![screen shot 2019-03-07 at 4 41 05 pm](https://user-images.githubusercontent.com/5151804/53999427-319dc100-40f8-11e9-9f61-de56748b0230.png)
