### PR TITLE
Adds pre-commit hook for dep check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -135,3 +135,12 @@ repos:
         name: dep version
         entry: bin/check_dep_version
         language: script
+
+  - repo: local
+    hooks:
+      - id: dep-check
+        name: dep check
+        entry: bin/pre-commit-dep-check
+        language: script
+        files: \.go$
+        pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -142,5 +142,5 @@ repos:
         name: dep check
         entry: bin/pre-commit-dep-check
         language: script
-        files: \.go$
+        files: (\.go|Gopkg\.toml|Gopkg\.lock)$
         pass_filenames: false

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1625,7 +1625,6 @@
     "github.com/spf13/afero",
     "github.com/spf13/pflag",
     "github.com/spf13/viper",
-    "github.com/stretchr/testify/assert",
     "github.com/stretchr/testify/mock",
     "github.com/stretchr/testify/suite",
     "github.com/tealeg/xlsx",

--- a/bin/pre-commit-dep-check
+++ b/bin/pre-commit-dep-check
@@ -1,0 +1,5 @@
+#! /usr/bin/env bash
+
+set -eu -o pipefail
+
+dep check


### PR DESCRIPTION
## Description

We seem to get out of sync with `dep` quite often (see #1826 for an example).  This PR adds in a pre-commit hook for `dep check` which should block commits that would put us out-of-sync.  It is currently set to run only on changes to `*.go`, `Gopkg.toml`, or `Gopkg.lock` files.

We had already gotten out-of-sync slightly again since #1826 landed, so this PR fixes that dep problem too.

## Reviewer Notes

If/when we land this, we'll need to make sure all existing branches merge from master so they don't accidentally put us out-of-sync again in master.

I'm curious if anybody sees significant delays from this check.  It seems to take 5 seconds or so on my machine (which seems acceptable), but YMMV.

## Setup

To test, grab this branch and try making changes to `*.go`, `Gopkg.toml`, or `Gopkg.lock` files and committing locally (don't push!) to see the pre-commit hook run.  Try taking something out of Gopkg.lock and see that it blocks the commit and reports the sync problem.  You can also try changing some other non-Go and non-dep file like a `*.jsx` file and note that the hook does not execute.
