### PR TITLE
Returns error code from login.gov callback, displays in client [delivers #163470468]

### DIFF
--- a/src/scenes/Landing/index.jsx
+++ b/src/scenes/Landing/index.jsx
@@ -113,7 +113,7 @@ export class Landing extends Component {
     return (
       <div className="usa-grid">
         {loggedInUserIsLoading && <LoadingPlaceholder />}
-        {!isLoggedIn && <SignIn />}
+        {!isLoggedIn && <SignIn location={this.props.location} />}
         {loggedInUserSuccess && (
           <Fragment>
             <div>

--- a/src/scenes/Office/index.jsx
+++ b/src/scenes/Office/index.jsx
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { Redirect, Switch } from 'react-router-dom';
+import { Redirect, Switch, Route } from 'react-router-dom';
 import { ConnectedRouter } from 'react-router-redux';
 import { history } from 'shared/store';
 import { connect } from 'react-redux';
@@ -55,7 +55,19 @@ class OfficeWrapper extends Component {
             <div>
               <LogoutOnInactivity />
               <Switch>
-                <Redirect from="/" to="/queues/new" exact />
+                <Route
+                  exact
+                  path="/"
+                  component={({ location }) => (
+                    <Redirect
+                      from="/"
+                      to={{
+                        ...location,
+                        pathname: '/queues/new',
+                      }}
+                    />
+                  )}
+                />
                 <PrivateRoute path="/queues/:queueType/moves/:moveId" component={MoveInfo} />
                 <PrivateRoute path="/queues/:queueType" component={Queues} />
                 <PrivateRoute path="/moves/:moveId/orders" component={OrdersInfo} />

--- a/src/scenes/TransportationServiceProvider/index.jsx
+++ b/src/scenes/TransportationServiceProvider/index.jsx
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { Redirect, Switch } from 'react-router-dom';
+import { Redirect, Switch, Route } from 'react-router-dom';
 import { ConnectedRouter } from 'react-router-redux';
 import { history } from 'shared/store';
 import { connect } from 'react-redux';
@@ -54,7 +54,19 @@ class TspWrapper extends Component {
             <div>
               <LogoutOnInactivity />
               <Switch>
-                <Redirect from="/" to="/queues/new" exact />
+                <Route
+                  exact
+                  path="/"
+                  component={({ location }) => (
+                    <Redirect
+                      from="/"
+                      to={{
+                        ...location,
+                        pathname: '/queues/new',
+                      }}
+                    />
+                  )}
+                />
                 <PrivateRoute path="/shipments/:shipmentId/documents/new" component={NewDocument} />
                 <PrivateRoute path="/shipments/:shipmentId/documents/:moveDocumentId" component={DocumentViewer} />
                 <PrivateRoute path="/shipments/:shipmentId" component={ShipmentInfo} />

--- a/src/shared/User/PrivateRoute.jsx
+++ b/src/shared/User/PrivateRoute.jsx
@@ -5,19 +5,13 @@ import { connect } from 'react-redux';
 import { selectCurrentUser } from 'shared/Data/users';
 import SignIn from './SignIn';
 
-const NotAuthenticated = () => (
-  <div className="usa-grid">
-    <SignIn />
-  </div>
-);
-
 // this was adapted from https://github.com/ReactTraining/react-router/blob/master/packages/react-router-redux/examples/AuthExample.js
 // note that it does not work if the route is not inside a Switch
 class PrivateRouteContainer extends React.Component {
   render() {
     const { isLoggedIn, path, ...props } = this.props;
     if (isLoggedIn) return <Route {...props} />;
-    else return <Route path={path} component={NotAuthenticated} />;
+    else return <Route path={path} component={SignIn} />;
   }
 }
 const mapStateToProps = state => {

--- a/src/shared/User/SignIn.jsx
+++ b/src/shared/User/SignIn.jsx
@@ -1,28 +1,44 @@
 import React from 'react';
+import qs from 'query-string';
+
 import { withContext } from 'shared/AppContext';
-const SignIn = ({ context }) => (
-  <div className="usa-grid">
-    <div className="usa-width-one-sixth">&nbsp; </div>
-    <div className="usa-width-two-thirds">
-      <h2 className="align-center">Welcome to {context.siteName}!</h2>
-      <br />
-      <p>This is a new system from USTRANSCOM to support the relocation of families during PCS.</p>
-      {context.showLoginWarning && (
-        <div>
-          <p>
-            Right now, use of this system is by invitation only. If you haven't received an invitation, please go to{' '}
-            <a href="https://eta.sddc.army.mil/ETASSOPortal/default.aspx">DPS</a> to schedule your move.
-          </p>
-          <p>Over the coming months, we'll be rolling this new tool out to more and more people. Stay tuned.</p>
+import Alert from 'shared/Alert';
+
+const SignIn = ({ context, location }) => {
+  const error = qs.parse(location.search).error;
+  return (
+    <div className="usa-grid">
+      <div className="usa-width-one-sixth">&nbsp; </div>
+      <div className="usa-width-two-thirds">
+        {error && (
+          <div>
+            <Alert type="error" heading="An error occurred">
+              There was an error during your last sign in attempt. Please try again.<br />
+              Error code: {error}
+            </Alert>
+            <br />
+          </div>
+        )}
+        <h2 className="align-center">Welcome to {context.siteName}!</h2>
+        <br />
+        <p>This is a new system from USTRANSCOM to support the relocation of families during PCS.</p>
+        {context.showLoginWarning && (
+          <div>
+            <p>
+              Right now, use of this system is by invitation only. If you haven't received an invitation, please go to{' '}
+              <a href="https://eta.sddc.army.mil/ETASSOPortal/default.aspx">DPS</a> to schedule your move.
+            </p>
+            <p>Over the coming months, we'll be rolling this new tool out to more and more people. Stay tuned.</p>
+          </div>
+        )}
+        <div className="align-center">
+          <a href="/auth/login-gov" className="usa-button  usa-button-big ">
+            Sign in
+          </a>
         </div>
-      )}
-      <div className="align-center">
-        <a href="/auth/login-gov" className="usa-button  usa-button-big ">
-          Sign in
-        </a>
       </div>
     </div>
-  </div>
-);
+  );
+};
 
 export default withContext(SignIn);

--- a/src/shared/User/Signin.test.js
+++ b/src/shared/User/Signin.test.js
@@ -1,10 +1,18 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
+
 import SignIn from './SignIn';
+import Alert from 'shared/Alert';
 
 describe('SignIn tests', () => {
   it('renders without crashing', () => {
     const div = document.createElement('div');
     shallow(<SignIn />, div);
+  });
+  it('renders errors', () => {
+    const context = { siteName: 'TestMove' };
+    const location = { search: '?error=SOME_ERROR' };
+    const wrapper = mount(<SignIn location={location} />, { context });
+    expect(wrapper.find(Alert).text()).toContain('SOME_ERROR');
   });
 });


### PR DESCRIPTION
## Description

This essentially re-opens #1738. It was merged, there was a merge conflict build failure, and I reverted instead of pursuing a fix. Original PR text below:

If we get an error from Login.gov in our callback handler, we sometimes pass that to the user as an unhelpful 500 response. This PR redirects to the login page and shows an error message instructing the user to try again## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/163470468) for this change

## Screenshots

![screen shot 2019-02-14 at 12 09 57 am](https://user-images.githubusercontent.com/5151804/52772501-7a78c300-2fed-11e9-97e1-ec07914239fd.png)