### PR TITLE
Adds wait for DatePicker loading screen

### DIFF
--- a/cypress/integration/mymove/shipment.js
+++ b/cypress/integration/mymove/shipment.js
@@ -252,22 +252,29 @@ function serviceMemberEditsDates() {
     .contains('Edit')
     .click();
 
-  cy.contains('Pick a moving date');
-  cy.get('.DayPicker-Body').then($body => {
-    if ($body.find('.DayPicker-Day--transit[aria-disabled=false]').length === 0) {
-      cy.get('.DayPicker-NavButton--next').click();
-    }
-  });
-  cy
-    .get('.DayPicker-Day--transit[aria-disabled=false]') // pick the first transit day that is selectable
-    .first()
-    .click()
-    .should('have.class', 'DayPicker-Day--pickup')
-    .invoke('attr', 'aria-label')
-    .as('dateLabel');
+  // Wait for valid move dates to be loaded from the server
+  cy.waitForLoadingScreen();
 
-  cy.contains('Save').click();
-  checkLoadingDate();
+  cy.contains('Pick a moving date');
+  cy
+    .get('.DayPicker-Body')
+    .then($body => {
+      if ($body.find('.DayPicker-Day--transit[aria-disabled=false]').length === 0) {
+        cy.get('.DayPicker-NavButton--next').click();
+      }
+    })
+    .then(() => {
+      cy
+        .get('.DayPicker-Day--transit[aria-disabled=false]') // pick the first transit day that is selectable
+        .first()
+        .click()
+        .should('have.class', 'DayPicker-Day--pickup')
+        .invoke('attr', 'aria-label')
+        .as('dateLabel');
+
+      cy.contains('Save').click();
+      checkLoadingDate();
+    });
 }
 
 function serviceMemberCancelsDateEdit() {


### PR DESCRIPTION
## Description

This fixes an e2e bug that surfaced in [this run](https://circleci.com/gh/transcom/mymove/77405#artifacts/containers/0) where DatePicker tests were timing out before available dates could be loaded from the server.

Added is a call to `waitForLoadingScreen`, which looks at the `LoadingPlaceholder` component. I also put the rest of the test in a `then` block so it is run after potential nav buttons are clicked