### PR TITLE
Use SIT discount and populate max sit obligation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ __snapshots__
 /bin/make-office-user
 /bin/make-tsp-user
 /bin/paperwork
+/bin/rateengine
 /bin/save-fuel-price-data
 /bin/send-to-gex
 /bin/soda

--- a/.gitignore
+++ b/.gitignore
@@ -39,7 +39,6 @@ __snapshots__
 /bin/make-office-user
 /bin/make-tsp-user
 /bin/paperwork
-/bin/rateengine
 /bin/save-fuel-price-data
 /bin/send-to-gex
 /bin/soda

--- a/pkg/models/shipment_summary_worksheet.go
+++ b/pkg/models/shipment_summary_worksheet.go
@@ -58,6 +58,7 @@ type ShipmentSummaryWorksheetPage1Values struct {
 	MaxObligationGCC100             string
 	TotalWeightAllotmentRepeat      string
 	MaxObligationGCC95              string
+	MaxObligationSIT                string
 	MaxObligationGCCMaxAdvance      string
 	ActualWeight                    string
 	ActualObligationGCC100          string
@@ -121,17 +122,23 @@ type ShipmentSummaryFormData struct {
 
 //Obligation an object representing the obligations section on the shipment summary worksheet
 type Obligation struct {
-	Gcc unit.Cents
+	Gcc    unit.Cents
+	SITMax unit.Cents
 }
 
-//GCC100 calculates the 95% GCC on shipment summary worksheet
+//GCC100 calculates the 100% GCC on shipment summary worksheet
 func (obligation Obligation) GCC100() float64 {
 	return obligation.Gcc.ToDollarFloat()
 }
 
-//GCC95 calculates the 100% GCC on shipment summary worksheet
+//GCC95 calculates the 95% GCC on shipment summary worksheet
 func (obligation Obligation) GCC95() float64 {
 	return obligation.Gcc.MultiplyFloat64(.95).ToDollarFloat()
+}
+
+// FormatMaxSIT formats the SITMax into a readable dollar format for the shipment summary worksheet
+func (obligation Obligation) FormatMaxSIT() float64 {
+	return obligation.SITMax.ToDollarFloat()
 }
 
 //MaxAdvance calculates the Max Advance on the shipment summary worksheet
@@ -266,6 +273,7 @@ func FormatValuesShipmentSummaryWorksheetFormPage1(data ShipmentSummaryFormData)
 	page1.MaxObligationGCC100 = FormatDollars(data.MaxObligation.GCC100())
 	page1.TotalWeightAllotmentRepeat = page1.TotalWeightAllotment
 	page1.MaxObligationGCC95 = FormatDollars(data.MaxObligation.GCC95())
+	page1.MaxObligationSIT = FormatDollars(data.MaxObligation.FormatMaxSIT())
 	page1.MaxObligationGCCMaxAdvance = FormatDollars(data.MaxObligation.MaxAdvance())
 
 	page1.ActualObligationGCC100 = FormatDollars(data.ActualObligation.GCC100())

--- a/pkg/models/shipment_summary_worksheet.go
+++ b/pkg/models/shipment_summary_worksheet.go
@@ -136,7 +136,7 @@ func (obligation Obligation) GCC95() float64 {
 	return obligation.Gcc.MultiplyFloat64(.95).ToDollarFloat()
 }
 
-// FormatMaxSIT formats the SITMax into a readable dollar format for the shipment summary worksheet
+// FormatMaxSIT formats the SITMax into a dollar float for the shipment summary worksheet
 func (obligation Obligation) FormatMaxSIT() float64 {
 	return obligation.SITMax.ToDollarFloat()
 }

--- a/pkg/models/shipment_summary_worksheet_test.go
+++ b/pkg/models/shipment_summary_worksheet_test.go
@@ -204,7 +204,7 @@ func (suite *ModelSuite) TestFormatValuesShipmentSummaryWorksheetFormPage1() {
 		Shipments:               shipments,
 		PreparationDate:         time.Date(2019, 1, 1, 1, 1, 1, 1, time.UTC),
 		PersonallyProcuredMoves: personallyProcuredMoves,
-		MaxObligation:           models.Obligation{Gcc: unit.Cents(600000)},
+		MaxObligation:           models.Obligation{Gcc: unit.Cents(600000), SITMax: unit.Cents(53000)},
 		ActualObligation:        models.Obligation{Gcc: unit.Cents(500000)},
 	}
 	sswPage1 := models.FormatValuesShipmentSummaryWorksheetFormPage1(ssd)
@@ -243,6 +243,7 @@ func (suite *ModelSuite) TestFormatValuesShipmentSummaryWorksheetFormPage1() {
 	suite.Equal("17,500", sswPage1.TotalWeightAllotmentRepeat)
 	suite.Equal("$6,000.00", sswPage1.MaxObligationGCC100)
 	suite.Equal("$5,700.00", sswPage1.MaxObligationGCC95)
+	suite.Equal("$530.00", sswPage1.MaxObligationSIT)
 	suite.Equal("$3,600.00", sswPage1.MaxObligationGCCMaxAdvance)
 
 	suite.Equal("4,000", sswPage1.ActualWeight)

--- a/pkg/paperwork/shipment_summary_test.go
+++ b/pkg/paperwork/shipment_summary_test.go
@@ -18,7 +18,6 @@ type ppmComputerParams struct {
 	Miles           int
 	Date            time.Time
 	DaysInSIT       int
-	SitDiscount     unit.DiscountRate
 }
 
 type mockPPMComputer struct {
@@ -27,7 +26,7 @@ type mockPPMComputer struct {
 	ppmComputerParams ppmComputerParams
 }
 
-func (mppmc *mockPPMComputer) ComputePPMIncludingLHDiscount(weight unit.Pound, originZip5 string, destinationZip5 string, distanceMiles int, date time.Time, daysInSIT int, sitDiscount unit.DiscountRate) (cost rateengine.CostComputation, err error) {
+func (mppmc *mockPPMComputer) ComputePPMIncludingLHDiscount(weight unit.Pound, originZip5 string, destinationZip5 string, distanceMiles int, date time.Time, daysInSIT int) (cost rateengine.CostComputation, err error) {
 	mppmc.ppmComputerParams = ppmComputerParams{
 		Weight:          weight,
 		OriginZip5:      originZip5,
@@ -35,7 +34,6 @@ func (mppmc *mockPPMComputer) ComputePPMIncludingLHDiscount(weight unit.Pound, o
 		Miles:           distanceMiles,
 		Date:            date,
 		DaysInSIT:       daysInSIT,
-		SitDiscount:     sitDiscount,
 	}
 	return mppmc.costComputation, mppmc.err
 }

--- a/pkg/paperwork/shipment_summary_test.go
+++ b/pkg/paperwork/shipment_summary_test.go
@@ -97,9 +97,8 @@ func (suite *PaperworkSuite) TestTestComputeObligations() {
 			OriginZip5:      pickupPostalCode,
 			DestinationZip5: destinationPostalCode,
 			Miles:           miles,
-			Date:            origMoveDate,
+			Date:            actualDate,
 			DaysInSIT:       0,
-			SitDiscount:     0,
 		}
 
 		_, err := ppmComputer.ComputeObligations(params, planner, MaxObligation)
@@ -117,7 +116,6 @@ func (suite *PaperworkSuite) TestTestComputeObligations() {
 			Date:            actualDate,
 			Miles:           miles,
 			DaysInSIT:       0,
-			SitDiscount:     0,
 		}
 
 		_, err := ppmComputer.ComputeObligations(params, planner, ActualObligation)

--- a/pkg/paperwork/shipment_summary_worksheet.go
+++ b/pkg/paperwork/shipment_summary_worksheet.go
@@ -35,6 +35,7 @@ var ShipmentSummaryPage1Layout = FormLayout{
 		"MaxObligationGCC100":             FormField(40, 182.5, 22, floatPtr(10), nil, stringPtr("RM")),
 		"TotalWeightAllotmentRepeat":      FormField(74, 182.5, 16, floatPtr(10), nil, stringPtr("RM")),
 		"MaxObligationGCC95":              FormField(40, 188.5, 22, floatPtr(10), nil, stringPtr("RM")),
+		"MaxObligationSIT":                FormField(40, 194.75, 22, floatPtr(10), nil, stringPtr("RM")),
 		"MaxObligationGCCMaxAdvance":      FormField(40, 201, 22, floatPtr(10), nil, stringPtr("RM")),
 		"ActualObligationGCC100":          FormField(133, 182.5, 22, floatPtr(10), nil, stringPtr("RM")),
 		"ActualWeight":                    FormField(167, 182.5, 16, floatPtr(10), nil, stringPtr("RM")),

--- a/pkg/rateengine/rateengine.go
+++ b/pkg/rateengine/rateengine.go
@@ -165,9 +165,9 @@ func (re *RateEngine) ComputePPM(
 }
 
 //ComputePPMIncludingLHDiscount Calculates the cost of a PPM move using zip + date derived linehaul discount
-func (re *RateEngine) ComputePPMIncludingLHDiscount(weight unit.Pound, originZip5 string, destinationZip5 string, distanceMiles int, date time.Time, daysInSIT int, sitDiscount unit.DiscountRate) (cost CostComputation, err error) {
+func (re *RateEngine) ComputePPMIncludingLHDiscount(weight unit.Pound, originZip5 string, destinationZip5 string, distanceMiles int, date time.Time, daysInSIT int) (cost CostComputation, err error) {
 
-	lhDiscount, _, err := models.PPMDiscountFetch(re.db,
+	lhDiscount, sitDiscount, err := models.PPMDiscountFetch(re.db,
 		re.logger,
 		originZip5,
 		destinationZip5,

--- a/pkg/rateengine/rateengine_test.go
+++ b/pkg/rateengine/rateengine_test.go
@@ -139,7 +139,7 @@ func (suite *RateEngineSuite) computePPMIncludingLHRates(originZip string, desti
 		SITRate:                         unit.NewDiscountRateFromPercent(50.0),
 	}
 	suite.MustSave(&tspPerformance)
-	lhDiscount, _, err := models.PPMDiscountFetch(suite.DB(),
+	lhDiscount, sitDiscount, err := models.PPMDiscountFetch(suite.DB(),
 		logger,
 		originZip,
 		destinationZip, testdatagen.RateEngineDate,
@@ -154,7 +154,7 @@ func (suite *RateEngineSuite) computePPMIncludingLHRates(originZip string, desti
 		testdatagen.RateEngineDate,
 		0,
 		lhDiscount,
-		0,
+		sitDiscount,
 	)
 	suite.Require().Nil(err)
 	suite.Require().True(cost.GCC > 0)

--- a/pkg/rateengine/rateengine_test.go
+++ b/pkg/rateengine/rateengine_test.go
@@ -201,7 +201,6 @@ func (suite *RateEngineSuite) TestComputePPMWithLHDiscount() {
 		1044,
 		testdatagen.RateEngineDate,
 		0,
-		0,
 	)
 	suite.Require().Nil(err)
 


### PR DESCRIPTION
## Description

Turns out we were already fetching SIT Discount (although not saving it to use), and already applying it to calculate the Max SIT Entitlement. Due to this, I'm actually holding onto that SIT Discount rate and using it.

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make db_dev_e2e_populate
bin/generate-shipment-summary -move d6b8980d-6f88-41be-9ae2-1abcbd2574bc -debug
```
You should get an error related to actual obligations, but it should include a Max SIT obligation.

## Code Review Verification Steps

* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* https://www.pivotaltracker.com/story/show/164382728

## Screenshots

<img width="492" alt="Screen Shot 2019-03-12 at 10 37 37 AM" src="https://user-images.githubusercontent.com/5531789/54227938-41355500-44be-11e9-80b0-45535ab7baab.png">

