### PR TITLE
Shipment Summary Worksheet - Actual Obligations PPM Weight 

### DIFF
--- a/pkg/models/shipment_summary_worksheet.go
+++ b/pkg/models/shipment_summary_worksheet.go
@@ -285,19 +285,15 @@ func formatActualObligationAdvance(data ShipmentSummaryFormData) string {
 
 //FormatActualObligationsWeight formats the service member's weight for the actual obligations im the Shipment Summary Worksheet
 func FormatActualObligationsWeight(totalWeightAllotment int, personallyProcuredMoves PersonallyProcuredMoves) string {
-	var actualWeightObligation int
-
-	if len(personallyProcuredMoves) > 0 && personallyProcuredMoves[0].NetWeight != nil {
-		ppmWeight := int(*personallyProcuredMoves[0].NetWeight)
-		weightAllotment := int(totalWeightAllotment)
-
-		if ppmWeight >= weightAllotment {
-			actualWeightObligation = weightAllotment
-		} else {
-			actualWeightObligation = ppmWeight
-		}
+	if len(personallyProcuredMoves) == 0 || personallyProcuredMoves[0].NetWeight == nil {
+		return ""
 	}
-	return FormatWeights(actualWeightObligation)
+	ppmWeight := int(*personallyProcuredMoves[0].NetWeight)
+	weightAllotment := int(totalWeightAllotment)
+	if ppmWeight >= weightAllotment {
+		return FormatWeights(weightAllotment)
+	}
+	return FormatWeights(ppmWeight)
 }
 
 //FormatRank formats the service member's rank for Shipment Summary Worksheet

--- a/pkg/models/shipment_summary_worksheet.go
+++ b/pkg/models/shipment_summary_worksheet.go
@@ -269,9 +269,8 @@ func FormatValuesShipmentSummaryWorksheetFormPage1(data ShipmentSummaryFormData)
 	page1.MaxObligationGCCMaxAdvance = FormatDollars(data.MaxObligation.MaxAdvance())
 
 	page1.ActualObligationGCC100 = FormatDollars(data.ActualObligation.GCC100())
-	page1.ActualWeight = formatActualWeight(data)
+	page1.ActualWeight = FormatActualObligationsWeight(data.TotalWeightAllotment, data.PersonallyProcuredMoves)
 	page1.ActualObligationAdvance = formatActualObligationAdvance(data)
-
 	page1.ActualObligationGCC95 = FormatDollars(data.ActualObligation.GCC95())
 	return page1
 }
@@ -284,11 +283,21 @@ func formatActualObligationAdvance(data ShipmentSummaryFormData) string {
 	return FormatDollars(0)
 }
 
-func formatActualWeight(data ShipmentSummaryFormData) string {
-	if len(data.PersonallyProcuredMoves) > 0 && data.PersonallyProcuredMoves[0].NetWeight != nil {
-		return FormatWeights(int(*(data.PersonallyProcuredMoves[0].NetWeight)))
+//FormatActualObligationsWeight formats the service member's weight for the actual obligations im the Shipment Summary Worksheet
+func FormatActualObligationsWeight(totalWeightAllotment int, personallyProcuredMoves PersonallyProcuredMoves) string {
+	var actualWeightObligation int
+
+	if len(personallyProcuredMoves) > 0 && personallyProcuredMoves[0].NetWeight != nil {
+		ppmWeight := int(*personallyProcuredMoves[0].NetWeight)
+		weightAllotment := int(totalWeightAllotment)
+
+		if ppmWeight >= weightAllotment {
+			actualWeightObligation = weightAllotment
+		} else {
+			actualWeightObligation = ppmWeight
+		}
 	}
-	return FormatWeights(0)
+	return FormatWeights(actualWeightObligation)
 }
 
 //FormatRank formats the service member's rank for Shipment Summary Worksheet

--- a/pkg/models/shipment_summary_worksheet_test.go
+++ b/pkg/models/shipment_summary_worksheet_test.go
@@ -434,6 +434,18 @@ func (suite *ModelSuite) TestFormatCurrentPPMStatus() {
 	suite.Equal("Completed", models.FormatCurrentPPMStatus(completed))
 }
 
+func (suite *ModelSuite) TestFormatActualObligationsWeight() {
+	suite.Equal("4,000", models.FormatActualObligationsWeight(7000,
+		[]models.PersonallyProcuredMove{
+			{NetWeight: models.Int64Pointer(4000)},
+		}))
+	suite.Equal("5,000", models.FormatActualObligationsWeight(5000,
+		[]models.PersonallyProcuredMove{
+			{NetWeight: models.Int64Pointer(10000)},
+		}))
+
+}
+
 func (suite *ModelSuite) TestFormatRank() {
 	e9 := models.ServiceMemberRankE9
 	multipleRanks := models.ServiceMemberRankO1W1ACADEMYGRADUATE

--- a/pkg/models/shipment_summary_worksheet_test.go
+++ b/pkg/models/shipment_summary_worksheet_test.go
@@ -443,6 +443,10 @@ func (suite *ModelSuite) TestFormatActualObligationsWeight() {
 		[]models.PersonallyProcuredMove{
 			{NetWeight: models.Int64Pointer(10000)},
 		}))
+	suite.Equal("", models.FormatActualObligationsWeight(5000,
+		[]models.PersonallyProcuredMove{
+			{NetWeight: nil},
+		}))
 
 }
 


### PR DESCRIPTION
## Description

System populates PPM shipment weight responsibility in the actual obligations compartment. If the remaining entitlement exceeds that of the PPM net weight, then the PPM net weight will be displayed. However, if the remaining entitlement is less than that of the PPM net weight, then the remaining entitlement weight will be displayed on the SSW. 

## Setup

`make server_test`

### Test in the office client
`make server_run`
`make office_client_run`

1) Log into the office app and select a move with a PPM
2) Make sure that the PPM has a "Net Weight" in the Weights panel
2) Click Create Paperwork -> Click Download worksheet

### Test with cmd line tool
` go run cmd/generate_shipment_summary/main.go -move 0db80bd6-de75-439e-bf89-deaafa1d0dc8 -debug`


## Code Review Verification Steps
* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References
* [Pivotal story](https://www.pivotaltracker.com/story/show/164283390) 

## Screenshots
<img width="1060" alt="ssw-ppm-actual-weight" src="https://user-images.githubusercontent.com/7574207/54213897-958b0580-44bb-11e9-940b-156370c30b56.png">

