### PR TITLE
ComboButton Approve Basics active when Basic move information is available

### DIFF
--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -32,7 +32,9 @@ import { withContext } from 'shared/AppContext';
 import ConfirmWithReasonButton from 'shared/ConfirmWithReasonButton';
 import PreApprovalPanel from 'shared/PreApprovalRequest/PreApprovalPanel.jsx';
 import InvoicePanel from 'shared/Invoice/InvoicePanel.jsx';
-import ComboButton from 'shared/ComboButton';
+import ComboButton from 'shared/ComboButton/index.jsx';
+import ToolTip from 'shared/ToolTip';
+import { DropDown, DropDownItem } from 'shared/ComboButton/dropdown';
 
 import { getRequestStatus } from 'shared/Swagger/selectors';
 import { resetRequests } from 'shared/Swagger/request';
@@ -387,20 +389,23 @@ class MoveInfo extends Component {
                 </Alert>
               )}
               <div>
-                {moveInfoComboButton && (
-                  <ComboButton
-                    items={[
-                      { value: 'Approve Basics', disabled: true },
-                      { value: 'Approve HHG', disabled: true },
-                      { value: 'Approve PPM', disabled: true },
-                    ]}
-                    buttonText={'Approve'}
-                    disabled={!ordersComplete}
-                    toolTipText={
-                      'Some information about the move is missing or contains errors. Please fix these problems before approving.'
-                    }
-                  />
-                )}
+                <ToolTip
+                  disabled={ordersComplete}
+                  textStyle={'tooltiptext-large'}
+                  toolTipText={
+                    'Some information about the move is missing or contains errors. Please fix these problems before approving.'
+                  }
+                >
+                  {moveInfoComboButton && (
+                    <ComboButton buttonText={'Approve'} disabled={!ordersComplete}>
+                      <DropDown>
+                        <DropDownItem value={'Approve Basics'} disabled={moveApproved || !ordersComplete} />
+                        {(isPPM || isHHGPPM) && <DropDownItem value={'Approve PPM'} disabled={true} />}
+                        {(isHHG || isHHGPPM) && <DropDownItem value={'Approve HHG'} disabled={true} />}
+                      </DropDown>
+                    </ComboButton>
+                  )}
+                </ToolTip>
               </div>
               <button
                 className={`${moveApproved ? 'btn__approve--green' : ''}`}

--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -391,7 +391,7 @@ class MoveInfo extends Component {
               <div>
                 <ToolTip
                   disabled={ordersComplete}
-                  textStyle={'tooltiptext-large'}
+                  textStyle="tooltiptext-large"
                   toolTipText={
                     'Some information about the move is missing or contains errors. Please fix these problems before approving.'
                   }

--- a/src/scenes/StyleGuide/index.js
+++ b/src/scenes/StyleGuide/index.js
@@ -1,5 +1,7 @@
 import React from 'react';
 import ComboButton from 'shared/ComboButton/index.jsx';
+import { DropDown, DropDownItem } from 'shared/ComboButton/dropdown';
+import ToolTip from 'shared/ToolTip';
 
 const StyleGuide = () => (
   <div style={{ 'margin-left': '20px' }}>
@@ -7,9 +9,17 @@ const StyleGuide = () => (
     <hr />
     <h2>This is a H2</h2>
     <h3>This is a H3</h3>
-    <div>
-      <ComboButton buttonText={'Approve'} disabled={false} />
-    </div>
+    <ComboButton buttonText={'Approve'} disabled={false}>
+      <DropDown>
+        <DropDownItem disabled={false} value={'Enabled Menu Item'} />
+        <DropDownItem disabled={true} value={'Disabled Menu Item'} />
+      </DropDown>
+    </ComboButton>
+    <span style={{ 'margin-left': '30px' }}>
+      <ToolTip textStyle={'tooltiptext-medium'} disabled={false} toolTipText={'Tooltip text'}>
+        <ComboButton disabled={true} buttonText={'Approve'} />
+      </ToolTip>
+    </span>
   </div>
 );
 

--- a/src/scenes/StyleGuide/index.js
+++ b/src/scenes/StyleGuide/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import ComboButton from 'shared/ComboButton';
+import ComboButton from 'shared/ComboButton/index.jsx';
 
 const StyleGuide = () => (
   <div style={{ 'margin-left': '20px' }}>
@@ -8,7 +8,7 @@ const StyleGuide = () => (
     <h2>This is a H2</h2>
     <h3>This is a H3</h3>
     <div>
-      <ComboButton buttonText={'Approve'} disabled={false} toolTipText={'tooltiptext'} />
+      <ComboButton buttonText={'Approve'} disabled={false} />
     </div>
   </div>
 );

--- a/src/shared/ComboButton/dropdown.css
+++ b/src/shared/ComboButton/dropdown.css
@@ -1,0 +1,33 @@
+.dropdown {
+  position: absolute;
+  top: 31px;
+  border: 2px solid #0071bc;
+  background-color: white;
+  border-radius: 5px;
+  width: 200px;
+  display: block;
+}
+
+.dropdown > p {
+  padding: 0.5em 1em;
+  color: #0071bc;
+  font-size: 0.85em;
+  cursor: pointer;
+  line-height: normal;
+  margin-bottom: 0;
+  margin-top: 0;
+}
+
+.dropdown > p:hover {
+  color: white;
+  background-color: #0071bc;
+}
+
+.dropdown > p.disabled {
+  color: #aeb0b5;
+}
+
+.dropdown > p.disabled:hover {
+  color: #aeb0b5;
+  background-color: white;
+}

--- a/src/shared/ComboButton/dropdown.jsx
+++ b/src/shared/ComboButton/dropdown.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import './dropdown.css';
+
+export const DropDown = props => {
+  return <div className="dropdown">{props.children}</div>;
+};
+
+export const DropDownItem = props => {
+  const liClasses = props => classNames({ disabled: props.disabled });
+  return <p className={liClasses(props)}>{props.value}</p>;
+};
+
+DropDown.propTypes = {
+  children: PropTypes.arrayOf(DropDownItem),
+};
+
+DropDownItem.propTypes = {
+  value: PropTypes.string,
+  disabled: PropTypes.bool,
+};

--- a/src/shared/ComboButton/index.css
+++ b/src/shared/ComboButton/index.css
@@ -1,37 +1,3 @@
-.dropdown {
-  position: absolute;
-  top: 31px;
-  border: 2px solid #0071bc;
-  background-color: white;
-  border-radius: 5px;
-  width: 200px;
-  display: block;
-}
-
-.dropdown > p {
-  padding: 0.5em 1em;
-  color: #0071bc;
-  font-size: 0.85em;
-  cursor: pointer;
-  line-height: normal;
-  margin-bottom: 0;
-  margin-top: 0;
-}
-
-.dropdown > p:hover {
-  color: white;
-  background-color: #0071bc;
-}
-
-.dropdown > p.disabled {
-  color: #aeb0b5;
-}
-
-.dropdown > p.disabled:hover {
-  color: #aeb0b5;
-  background-color: white;
-}
-
 .combo-button-icon {
   margin-left: 20px;
 }

--- a/src/shared/ComboButton/index.css
+++ b/src/shared/ComboButton/index.css
@@ -1,3 +1,7 @@
+.combo-button {
+  position: relative;
+}
+
 .combo-button-icon {
   margin-left: 20px;
 }

--- a/src/shared/ComboButton/index.jsx
+++ b/src/shared/ComboButton/index.jsx
@@ -1,9 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import classNames from 'classnames';
 import FontAwesomeIcon from '@fortawesome/react-fontawesome';
 import faCaretDown from '@fortawesome/fontawesome-free-solid/faCaretDown';
-import ToolTip from 'shared/ToolTip';
 import './index.css';
 
 class ComboButton extends Component {
@@ -23,6 +21,7 @@ class ComboButton extends Component {
   componentDidMount() {
     document.addEventListener('mousedown', this.handleClickOutside);
   }
+
   componentWillUnmount() {
     document.removeEventListener('mousedown', this.handleClickOutside);
   }
@@ -36,34 +35,18 @@ class ComboButton extends Component {
   };
 
   render() {
-    let { buttonText, toolTipText, disabled, items = [] } = this.props;
+    let { buttonText, disabled, children } = this.props;
     return (
       <span className="container combo-button" ref={this.container}>
-        <ToolTip text={toolTipText} disabled={!disabled} textStyle={'tooltiptext-large'}>
-          <button disabled={disabled} onClick={this.handleButtonClick}>
-            {buttonText}
-            <FontAwesomeIcon className="combo-button-icon" icon={faCaretDown} />
-          </button>
-          {this.state.displayDropDown && <DropDown items={items} />}
-        </ToolTip>
+        <button disabled={disabled} onClick={this.handleButtonClick}>
+          {buttonText}
+          <FontAwesomeIcon className="combo-button-icon" icon={faCaretDown} />
+        </button>
+        {this.state.displayDropDown && children}
       </span>
     );
   }
 }
-
-const styleListItems = items => {
-  const liClasses = item => classNames({ disabled: item.disabled });
-  return items.map(item => <p className={liClasses(item)}>{item.value}</p>);
-};
-
-const DropDown = props => {
-  let { items } = props;
-  return <div className="dropdown">{styleListItems(items)}</div>;
-};
-
-DropDown.propTypes = {
-  items: PropTypes.array,
-};
 
 ComboButton.propTypes = {
   buttonText: PropTypes.string,

--- a/src/shared/ComboButton/index.test.js
+++ b/src/shared/ComboButton/index.test.js
@@ -3,11 +3,15 @@ import { mount } from 'enzyme';
 import ComboButton from './index';
 
 describe('ComboButton tests', () => {
-  const renderComboButton = ({ buttonText = '', disabled = false, toolTipText = undefined }) =>
-    mount(<ComboButton buttonText={buttonText} disabled={disabled} toolTipText={toolTipText} />);
+  const renderComboButton = ({ buttonText = '', disabled = false }) =>
+    mount(
+      <ComboButton buttonText={buttonText} disabled={disabled}>
+        <div className="dropdown">dropDownText</div>
+      </ComboButton>,
+    );
 
   describe('when the button is disabled', () => {
-    const buttonProps = { toolTipText: 'toolTipText', buttonText: 'buttonText', disabled: true };
+    const buttonProps = { buttonText: 'buttonText', disabled: true };
     const disabledComboButton = renderComboButton(buttonProps);
 
     describe('button', () => {
@@ -21,25 +25,10 @@ describe('ComboButton tests', () => {
         expect(button.props().disabled).toBe(true);
       });
     });
-
-    describe('tool tip', () => {
-      it('renders with toolTipText', () => {
-        const tooltipText = disabledComboButton.find('.tooltiptext');
-
-        expect(tooltipText.text()).toBe(buttonProps.toolTipText);
-      });
-
-      it('does not render when toolTipText is null', () => {
-        const comboButton = renderComboButton({ toolTipText: null });
-        const tooltipText = comboButton.find('.tooltiptext');
-
-        expect(tooltipText.exists()).toBe(false);
-      });
-    });
   });
 
   describe('when the button is enabled', () => {
-    const buttonProps = { toolTipText: 'toolTipText', disabled: false, buttonText: 'buttonText' };
+    const buttonProps = { disabled: false, buttonText: 'buttonText' };
     const defaultEnabledComboButton = renderComboButton(buttonProps);
 
     describe('button', () => {
@@ -47,14 +36,6 @@ describe('ComboButton tests', () => {
         const button = defaultEnabledComboButton.find('button');
 
         expect(button.props().disabled).toBe(false);
-      });
-    });
-
-    describe('tooltip', () => {
-      it('does not render', () => {
-        const tooltipText = defaultEnabledComboButton.find('.tooltiptext');
-
-        expect(tooltipText.exists()).toBe(false);
       });
     });
 
@@ -84,28 +65,14 @@ describe('ComboButton tests', () => {
         expect(dropDownAfterSecondClick.exists()).toBe(false);
       });
 
-      it('disappears on second click outside of component', () => {
-        // registering event outside of component in enzyme
-        // adapted from https://github.com/airbnb/enzyme/issues/426
-        const map = {
-          mousedown: null,
-        };
-        /* eslint-disable security/detect-object-injection */
-        document.addEventListener = jest.fn((event, cb) => {
-          map[event] = cb;
-        });
-        /* eslint-enable security/detect-object-injection */
+      it('state.displayDropDown is false after click outside', () => {
         const newButtonProps = { toolTipText: 'toolTipText', disabled: false, buttonText: 'buttonText' };
-        const comboButton = renderComboButton(newButtonProps);
-        comboButton.find('button').simulate('click');
-        const dropDown = comboButton.find('.dropdown');
-        expect(dropDown.exists()).toBe(true);
-        map.mousedown({ pageX: 100, pageY: 100 });
-        // have to call update to force a re-rerender of enzyme wrapper
-        comboButton.update();
+        const enabledComboButton = renderComboButton(newButtonProps);
+        enabledComboButton.setState({ displayDropDown: true });
+        const enabledComboButtonInstance = enabledComboButton.instance();
+        enabledComboButtonInstance.handleClickOutside({});
 
-        const dropDownAfterSecondClick = comboButton.find('.dropdown');
-        expect(dropDownAfterSecondClick.exists()).toBe(false);
+        expect(enabledComboButton.state().displayDropDown).toBe(false);
       });
 
       it('state.displayDropDown is toggled on click', function() {
@@ -113,6 +80,7 @@ describe('ComboButton tests', () => {
         const enabledComboButton = renderComboButton(newButtonProps);
         enabledComboButton.setState({ displayDropDown: true });
         enabledComboButton.find('button').simulate('click');
+
         expect(enabledComboButton.state().displayDropDown).toBe(false);
       });
     });

--- a/src/shared/ToolTip/index.jsx
+++ b/src/shared/ToolTip/index.jsx
@@ -2,13 +2,13 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import './index.css';
 
-export class ToolTip extends Component {
+class ToolTip extends Component {
   render() {
-    let { children, text, disabled, textStyle } = this.props;
+    let { children, toolTipText, disabled, textStyle } = this.props;
     return (
       <span className="tooltip">
+        {!disabled && toolTipText && <span className={`tooltiptext ${textStyle}`}>{toolTipText}</span>}
         {children}
-        {text && !disabled && <span className={`tooltiptext ${textStyle}`}>{text}</span>}
       </span>
     );
   }

--- a/src/shared/ToolTip/index.test.js
+++ b/src/shared/ToolTip/index.test.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import ToolTip from './index';
+
+describe('ToolTip tests', () => {
+  const renderToolTip = ({ disabled = false, toolTipText = 'toolTipText', textStyle = 'tooltip-style' }) =>
+    mount(<ToolTip disabled={disabled} toolTipText={toolTipText} textStyle={textStyle} />);
+
+  describe('when ToolTip is disabled', () => {
+    const toolTipProps = { toolTipText: 'toolTipText', buttonText: 'buttonText', disabled: true };
+    const disabledToolTip = renderToolTip(toolTipProps);
+
+    it('does not render toolTipText', () => {
+      const tooltipText = disabledToolTip.find('.tooltiptext');
+
+      expect(tooltipText.exists()).toBe(false);
+    });
+  });
+
+  describe('when ToolTip is enabled', () => {
+    it('renders toolTipText', () => {
+      const toolTipProps = { toolTipText: 'toolTipText', buttonText: 'buttonText', disabled: false };
+      const enabledToolTip = renderToolTip(toolTipProps);
+      const tooltipText = enabledToolTip.find('.tooltiptext');
+
+      expect(tooltipText.exists()).toBe(true);
+    });
+
+    it('does not render when toolTipText is null', () => {
+      const toolTipProps = { toolTipText: null, buttonText: 'buttonText', disabled: false };
+      const enabledToolTip = renderToolTip(toolTipProps);
+      const tooltipText = enabledToolTip.find('.tooltiptext');
+
+      expect(tooltipText.exists()).toBe(false);
+    });
+  });
+});

--- a/src/shared/ToolTip/index.test.js
+++ b/src/shared/ToolTip/index.test.js
@@ -24,6 +24,7 @@ describe('ToolTip tests', () => {
       const tooltipText = enabledToolTip.find('.tooltiptext');
 
       expect(tooltipText.exists()).toBe(true);
+      expect(tooltipText.text()).toBe(toolTipProps.toolTipText);
     });
 
     it('does not render when toolTipText is null', () => {


### PR DESCRIPTION
## Description

Button is active when Basic move information is complete (PPM and HHG approvals are not yet active).

## Setup

```
make client_test
make server_run
make office_client_run
```

## Code Review Verification Steps
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/n/projects/2181745/stories/163275468) 

## Screenshots

### HHG 
![Screen Shot 2019-03-12 at 9 50 42 AM](https://user-images.githubusercontent.com/1036969/54214701-586b4700-44ac-11e9-82e4-f6c8d15a8988.png)

### PPM
![Screen Shot 2019-03-12 at 9 47 44 AM](https://user-images.githubusercontent.com/1036969/54214719-602aeb80-44ac-11e9-872e-9efa352dbbe0.png)
