### PR TITLE
Trade safety for speed on test database

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -393,7 +393,8 @@ endif
 			POSTGRES_PASSWORD=$(PGPASSWORD) \
 			-d \
 			-p $(DB_PORT_TEST):$(DB_PORT_DOCKER)\
-			$(DB_DOCKER_CONTAINER_IMAGE)
+			$(DB_DOCKER_CONTAINER_IMAGE)\
+			-c fsync=off
 
 .PHONY: db_test_create
 db_test_create:

--- a/Makefile
+++ b/Makefile
@@ -394,7 +394,8 @@ endif
 			-d \
 			-p $(DB_PORT_TEST):$(DB_PORT_DOCKER)\
 			$(DB_DOCKER_CONTAINER_IMAGE)\
-			-c fsync=off
+			-c fsync=off\
+			-c full_page_writes=off
 
 .PHONY: db_test_create
 db_test_create:


### PR DESCRIPTION
## Description

Postgres does a lot of work to make sure that data isn't lost in the event of a system failure. Some of this work comes at the expense of performance, however, and since our testing database is by definition ephemeral, we'd rather have things go as fast as possible.

This PR disables two settings on the `milmove-db-test` container, [fsync](https://www.postgresql.org/docs/10/runtime-config-wal.html#GUC-FSYNC) and [full_page_writes](https://www.postgresql.org/docs/10/runtime-config-wal.html#GUC-FULL-PAGE-WRITES). Here are a few before/after numbers:

## Before

```
$ env DB_PORT=$DB_PORT_TEST time go test -count=1 -test.v ./pkg/models
PASS
ok  	github.com/transcom/mymove/pkg/models	197.235s
      200.46 real        12.39 user         6.02 sys
```

```
$ time make server_test
...
      675.98 real        87.06 user        49.69 sys
```

## After

```
$ env DB_PORT=$DB_PORT_TEST time go test -count=1 -test.v ./pkg/models
PASS
ok  	github.com/transcom/mymove/pkg/models	87.881s
       90.85 real        12.06 user         5.76 sys
```

```
$ time make server_test
...
      425.64 real        87.45 user        51.49 sys
```

Docker desktop is set to 4 CPUs and 8 gig of RAM on my machine.

## Setup

You'll need to run `make db_test_reset` to destroy and recreate the test docker container if you already have one running.