### PR TITLE
Support Editing Robust Accessorial 35A Pre-Approval Request [delivers #163403050]

### DIFF
--- a/pkg/handlers/publicapi/shipment_line_items.go
+++ b/pkg/handlers/publicapi/shipment_line_items.go
@@ -346,10 +346,23 @@ func (h UpdateShipmentLineItemHandler) Handle(params accessorialop.UpdateShipmen
 		}
 	}
 
+	var estAmtCents *unit.Cents
+	var actAmtCents *unit.Cents
+	if params.Payload.EstimateAmountCents != nil {
+		centsValue := unit.Cents(*params.Payload.EstimateAmountCents)
+		estAmtCents = &centsValue
+	}
+	if params.Payload.ActualAmountCents != nil {
+		centsValue := unit.Cents(*params.Payload.ActualAmountCents)
+		actAmtCents = &centsValue
+	}
 	additionalParams := models.AdditionalShipmentLineItemParams{
-		ItemDimensions:  itemDimensions,
-		CrateDimensions: crateDimensions,
-		Description:     params.Payload.Description,
+		ItemDimensions:      itemDimensions,
+		CrateDimensions:     crateDimensions,
+		Description:         params.Payload.Description,
+		Reason:              params.Payload.Reason,
+		EstimateAmountCents: estAmtCents,
+		ActualAmountCents:   actAmtCents,
 	}
 
 	verrs, err := shipment.UpdateShipmentLineItem(h.DB(),

--- a/pkg/models/shipment_test.go
+++ b/pkg/models/shipment_test.go
@@ -556,6 +556,64 @@ func (suite *ModelSuite) TestUpdateShipmentLineItemCode105BAndE() {
 	}
 }
 
+// TestUpdateShipmentLineItemCode35A tests that 35A line items are updated correctly
+func (suite *ModelSuite) TestUpdateShipmentLineItemCode35A() {
+	acc35A := testdatagen.MakeTariff400ngItem(suite.DB(), testdatagen.Assertions{
+		Tariff400ngItem: Tariff400ngItem{
+			Code: "35A",
+		},
+	})
+
+	shipment := testdatagen.MakeDefaultShipment(suite.DB())
+
+	desc := "This is a description"
+	reas := "This is the reason"
+	notes := "Notes"
+	loc := ShipmentLineItemLocationORIGIN
+	estAmt := unit.Cents(1000)
+	actAmt := unit.Cents(1000)
+	lineItem := testdatagen.MakeShipmentLineItem(suite.DB(), testdatagen.Assertions{
+		ShipmentLineItem: ShipmentLineItem{
+			Tariff400ngItemID:   acc35A.ID,
+			Location:            loc,
+			Notes:               notes,
+			Description:         &desc,
+			Reason:              &reas,
+			EstimateAmountCents: &estAmt,
+			ActualAmountCents:   &actAmt,
+		},
+	})
+
+	// Update values
+	baseParams := BaseShipmentLineItemParams{
+		Tariff400ngItemID:   acc35A.ID,
+		Tariff400ngItemCode: acc35A.Code,
+		Location:            "ORIGIN",
+	}
+	desc = "updated description"
+	reas = "updated reason"
+	estAmt = unit.Cents(2000)
+	actAmt = unit.Cents(2000)
+	additionalParams := AdditionalShipmentLineItemParams{
+		Description:         &desc,
+		Reason:              &reas,
+		EstimateAmountCents: &estAmt,
+		ActualAmountCents:   &actAmt,
+	}
+
+	verrs, err := shipment.UpdateShipmentLineItem(suite.DB(),
+		baseParams, additionalParams, &lineItem)
+	if suite.noValidationErrors(verrs, err) {
+		// ToDo: will need to update this when we calculate base quantity
+		suite.Equal(0, lineItem.Quantity1.ToUnitInt())
+		suite.Equal(acc35A.ID.String(), lineItem.Tariff400ngItem.ID.String())
+		suite.Equal(desc, *lineItem.Description)
+		suite.Equal(reas, *lineItem.Reason)
+		suite.Equal(estAmt, *lineItem.EstimateAmountCents)
+		suite.Equal(actAmt, *lineItem.ActualAmountCents)
+	}
+}
+
 // TestCreateShipmentLineItemCode105BAndEMissingDimensions tests that missing dimensions for 105B/E throws error
 func (suite *ModelSuite) TestCreateShipmentLineItemCode105BAndEMissingDimensions() {
 	acc105B := testdatagen.MakeTariff400ngItem(suite.DB(), testdatagen.Assertions{

--- a/src/shared/PreApprovalRequest/Editor.jsx
+++ b/src/shared/PreApprovalRequest/Editor.jsx
@@ -7,8 +7,11 @@ import {
   convertFromBaseQuantity,
   formatToDimensionsInches,
   formatDimensionsToThousandthInches,
+  formatCents,
 } from 'shared/formatters';
 import { submit, isValid, isDirty, isSubmitting, hasSubmitSucceeded } from 'redux-form';
+import { get } from 'lodash';
+import { convertDollarsToCents } from 'shared/utils';
 
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
@@ -22,6 +25,9 @@ export class Editor extends Component {
       values.quantity_1 = formatToBaseQuantity(values.quantity_1);
     }
     values.tariff400ng_item_id = values.tariff400ng_item.id;
+
+    values.estimate_amount_cents = convertDollarsToCents(get(values, 'estimate_amount_cents'));
+    values.actual_amount_cents = convertDollarsToCents(get(values, 'actual_amount_cents'));
 
     formatDimensionsToThousandthInches(values.item_dimensions);
     formatDimensionsToThousandthInches(values.crate_dimensions);
@@ -40,6 +46,8 @@ export class Editor extends Component {
       initialValues.quantity_1 = convertFromBaseQuantity(initialValues.quantity_1);
     }
 
+    initialValues.estimate_amount_cents = formatCents(initialValues.estimate_amount_cents);
+    initialValues.actual_amount_cents = formatCents(initialValues.actual_amount_cents);
     initialValues.item_dimensions = formatToDimensionsInches(initialValues.item_dimensions);
     initialValues.crate_dimensions = formatToDimensionsInches(initialValues.crate_dimensions);
 


### PR DESCRIPTION
## Description

This PR adds the ability to support editing robust accessorial 35A (Third Party Service) pre-approval requests. Pre-existing 35A items are also supported

## Setup

1. Open Office app
2. Open HHG move
3. Click on HHG tab
4. Create 35A pre-approval request with new form
5. Edit 35A pre-approval request
6. Check if new fields are saved

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](./docs/backend.md#logging)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers](./docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/163403051) for this change

## Screenshots

No UI changes just show that editing works:
![Mar-12-2019 15-28-28](https://user-images.githubusercontent.com/1522549/54240554-9d5aa200-44db-11e9-86d9-1604bdf2891c.gif)
