### PR TITLE
Show warning for 35A if actual is more than estimated amount: 163487135

### DIFF
--- a/src/shared/PreApprovalRequest/Code35Form.jsx
+++ b/src/shared/PreApprovalRequest/Code35Form.jsx
@@ -1,22 +1,9 @@
 import React, { Fragment } from 'react';
 import { SwaggerField } from 'shared/JsonSchemaForm/JsonSchemaField';
-import Alert from 'shared/Alert';
+import { Code35FormAlert } from './Code35FormAlert';
 
 export const Code35Form = props => {
   const { ship_line_item_schema } = props;
-  let warnMsg;
-
-  if (props.actualAmount > props.estimateAmount) {
-    const priceDifference = props.actualAmount - props.estimateAmount;
-    warnMsg = (
-      <Alert type="warning" heading="Oops– you appear to have exceeded your estimated cost!">
-        <span className="warning--header">
-          Your actual cost of {props.actualAmount} is {priceDifference} dollars over your estimated cost of{' '}
-          {props.estimateAmount}. You will not be paid for this difference. <a href="#">What are my options?</a>
-        </span>
-      </Alert>
-    );
-  }
   return (
     <Fragment>
       <SwaggerField
@@ -43,7 +30,7 @@ export const Code35Form = props => {
       <div className="bq-explanation">
         <p>Enter amount after service is completed</p>
       </div>
-      {warnMsg}
+      <Code35FormAlert showAlert={props.showAlert} />
     </Fragment>
   );
 };

--- a/src/shared/PreApprovalRequest/Code35Form.jsx
+++ b/src/shared/PreApprovalRequest/Code35Form.jsx
@@ -1,8 +1,22 @@
 import React, { Fragment } from 'react';
 import { SwaggerField } from 'shared/JsonSchemaForm/JsonSchemaField';
+import Alert from 'shared/Alert';
 
 export const Code35Form = props => {
   const { ship_line_item_schema } = props;
+  let warnMsg;
+
+  if (props.actualAmount > props.estimateAmount) {
+    const priceDifference = props.actualAmount - props.estimateAmount;
+    warnMsg = (
+      <Alert type="warning" heading="Oops– you appear to have exceeded your estimated cost!">
+        <span className="warning--header">
+          Your actual cost of {props.actualAmount} is {priceDifference} dollars over your estimated cost of{' '}
+          {props.estimateAmount}. You will not be paid for this difference. <a href="#">What are my options?</a>
+        </span>
+      </Alert>
+    );
+  }
   return (
     <Fragment>
       <SwaggerField
@@ -29,6 +43,7 @@ export const Code35Form = props => {
       <div className="bq-explanation">
         <p>Enter amount after service is completed</p>
       </div>
+      {warnMsg}
     </Fragment>
   );
 };

--- a/src/shared/PreApprovalRequest/Code35FormAlert.jsx
+++ b/src/shared/PreApprovalRequest/Code35FormAlert.jsx
@@ -6,7 +6,7 @@ export const Code35FormAlert = props => {
     <Fragment>
       {props.showAlert && (
         <Alert type="warning" heading="Amount exceeds approved estimate">
-          <span className="warning--header">
+          <span>
             If you continue, you'll only be paid the max approved amount. Submit a separate pre-approval request to
             cover any additional costs.
           </span>

--- a/src/shared/PreApprovalRequest/Code35FormAlert.jsx
+++ b/src/shared/PreApprovalRequest/Code35FormAlert.jsx
@@ -1,0 +1,17 @@
+import React, { Fragment } from 'react';
+import Alert from 'shared/Alert';
+
+export const Code35FormAlert = props => {
+  return (
+    <Fragment>
+      {props.showAlert && (
+        <Alert type="warning" heading="Oops– you appear to have exceeded your estimated cost!">
+          <span className="warning--header">
+            Amount exceeds approved estimate. If you continue, you'll only be paid the max approved amount. Submit a
+            separate pre-approval request to cover any additional costs.
+          </span>
+        </Alert>
+      )}
+    </Fragment>
+  );
+};

--- a/src/shared/PreApprovalRequest/Code35FormAlert.jsx
+++ b/src/shared/PreApprovalRequest/Code35FormAlert.jsx
@@ -5,10 +5,10 @@ export const Code35FormAlert = props => {
   return (
     <Fragment>
       {props.showAlert && (
-        <Alert type="warning" heading="Oops– you appear to have exceeded your estimated cost!">
+        <Alert type="warning" heading="Amount exceeds approved estimate">
           <span className="warning--header">
-            Amount exceeds approved estimate. If you continue, you'll only be paid the max approved amount. Submit a
-            separate pre-approval request to cover any additional costs.
+            If you continue, you'll only be paid the max approved amount. Submit a separate pre-approval request to
+            cover any additional costs.
           </span>
         </Alert>
       )}

--- a/src/shared/PreApprovalRequest/Code35FormAlert.test.js
+++ b/src/shared/PreApprovalRequest/Code35FormAlert.test.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { Code35FormAlert } from './Code35FormAlert';
+
+describe('code 35A Alert component', () => {
+  describe('renders an alert', () => {
+    let wrapper = shallow(<Code35FormAlert showAlert={true} />);
+
+    it('without crashing', () => {
+      expect(wrapper.exists('Alert')).toBe(true);
+    });
+  });
+
+  describe('does not render an alert', () => {
+    let wrapper = shallow(<Code35FormAlert showAlert={false} />);
+
+    it('without crashing', () => {
+      expect(wrapper.exists('Alert')).toBe(false);
+    });
+  });
+});

--- a/src/shared/PreApprovalRequest/PreApprovalForm.jsx
+++ b/src/shared/PreApprovalRequest/PreApprovalForm.jsx
@@ -175,16 +175,21 @@ PreApprovalForm = reduxForm({
 const selector = formValueSelector(formName);
 
 function mapStateToProps(state) {
-  const estimateAmount = get(state, 'form.preapproval_request_form.values.estimate_amount_cents');
-  const actualAmount = get(state, 'form.preapproval_request_form.values.actual_amount_cents');
   return {
     tariff400ng_item_code: get(state, 'form.preapproval_request_form.values.tariff400ng_item.code'),
     ship_line_item_schema: get(state, 'swaggerPublic.spec.definitions.ShipmentLineItem', {}),
     filteredLocations: selectLocationFromTariff400ngItem(state, selector(state, 'tariff400ng_item')),
     selectedLocation: selector(state, 'location'),
     tariff400ngItem: selector(state, 'tariff400ng_item'),
-    showAlert: actualAmount > estimateAmount,
+    showAlert: actualAmount(state) > estimateAmount(state),
   };
+}
+
+function estimateAmount(state) {
+  return get(state, 'form.preapproval_request_form.values.estimate_amount_cents');
+}
+function actualAmount(state) {
+  return get(state, 'form.preapproval_request_form.values.actual_amount_cents');
 }
 
 export default withContext(connect(mapStateToProps)(PreApprovalForm));

--- a/src/shared/PreApprovalRequest/PreApprovalForm.jsx
+++ b/src/shared/PreApprovalRequest/PreApprovalForm.jsx
@@ -181,6 +181,8 @@ function mapStateToProps(state) {
     filteredLocations: selectLocationFromTariff400ngItem(state, selector(state, 'tariff400ng_item')),
     selectedLocation: selector(state, 'location'),
     tariff400ngItem: selector(state, 'tariff400ng_item'),
+    estimateAmount: get(state, 'form.preapproval_request_form.values.estimate_amount_cents'),
+    actualAmount: get(state, 'form.preapproval_request_form.values.actual_amount_cents'),
   };
 }
 

--- a/src/shared/PreApprovalRequest/PreApprovalForm.jsx
+++ b/src/shared/PreApprovalRequest/PreApprovalForm.jsx
@@ -9,6 +9,7 @@ import { validateAdditionalFields } from 'shared/JsonSchemaForm';
 import { SwaggerField } from 'shared/JsonSchemaForm/JsonSchemaField';
 import { getFormComponent } from './DetailsHelper';
 import { selectLocationFromTariff400ngItem } from 'shared/Entities/modules/shipmentLineItems';
+import { convertDollarsToCents } from 'shared/utils';
 
 import './PreApprovalRequest.css';
 
@@ -181,15 +182,15 @@ function mapStateToProps(state) {
     filteredLocations: selectLocationFromTariff400ngItem(state, selector(state, 'tariff400ng_item')),
     selectedLocation: selector(state, 'location'),
     tariff400ngItem: selector(state, 'tariff400ng_item'),
-    showAlert: actualAmount(state) > estimateAmount(state),
+    showAlert: getActualAmount(state) > getEstimateAmount(state),
   };
 }
 
-function estimateAmount(state) {
-  return get(state, 'form.preapproval_request_form.values.estimate_amount_cents');
+function getEstimateAmount(state) {
+  return convertDollarsToCents(selector(state, 'estimate_amount_cents'));
 }
-function actualAmount(state) {
-  return get(state, 'form.preapproval_request_form.values.actual_amount_cents');
+function getActualAmount(state) {
+  return convertDollarsToCents(selector(state, 'actual_amount_cents'));
 }
 
 export default withContext(connect(mapStateToProps)(PreApprovalForm));

--- a/src/shared/PreApprovalRequest/PreApprovalForm.jsx
+++ b/src/shared/PreApprovalRequest/PreApprovalForm.jsx
@@ -175,14 +175,15 @@ PreApprovalForm = reduxForm({
 const selector = formValueSelector(formName);
 
 function mapStateToProps(state) {
+  const estimateAmount = get(state, 'form.preapproval_request_form.values.estimate_amount_cents');
+  const actualAmount = get(state, 'form.preapproval_request_form.values.actual_amount_cents');
   return {
     tariff400ng_item_code: get(state, 'form.preapproval_request_form.values.tariff400ng_item.code'),
     ship_line_item_schema: get(state, 'swaggerPublic.spec.definitions.ShipmentLineItem', {}),
     filteredLocations: selectLocationFromTariff400ngItem(state, selector(state, 'tariff400ng_item')),
     selectedLocation: selector(state, 'location'),
     tariff400ngItem: selector(state, 'tariff400ng_item'),
-    estimateAmount: get(state, 'form.preapproval_request_form.values.estimate_amount_cents'),
-    actualAmount: get(state, 'form.preapproval_request_form.values.actual_amount_cents'),
+    showAlert: actualAmount > estimateAmount,
   };
 }
 

--- a/src/shared/PreApprovalRequest/PreApprovalRequest.css
+++ b/src/shared/PreApprovalRequest/PreApprovalRequest.css
@@ -119,7 +119,6 @@
 
 .bq-explanation {
   font-size: 0.9em;
-  padding: 0rem 0rem 3rem 0rem;
 }
 
 .bq-explanation p {


### PR DESCRIPTION
## Description

Add warning for Pre-approval request `35A` if the cost of the `actual amount` of a service is greater than the `estimated amount`.

## Setup

`make db_dev_e2e_populate`
`make tsp_client_run`

add a `35A` pre-approval item.
enter values for `Estimate, not to exceed` and `Actual amount of service`. 
The alert should show if the `actual` is greater than `estimate`. If actual is less or equal to, the alert should not show.

## Code Review Verification Steps

* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/163487135) for this change

## Screenshots

<img width="1033" alt="Screen Shot 2019-03-13 at 4 20 32 PM" src="https://user-images.githubusercontent.com/3099491/54315436-14f80200-45ac-11e9-899c-8051960e6bd2.png">

<img width="1013" alt="Screen Shot 2019-03-13 at 4 20 44 PM" src="https://user-images.githubusercontent.com/3099491/54315443-188b8900-45ac-11e9-941e-003a0f68b10d.png">
