### PR TITLE
Pre-Approval Request Panel Style Clean Up [delivers #164389307]

### DIFF
--- a/src/App/index.css
+++ b/src/App/index.css
@@ -76,16 +76,11 @@ img._fix-ie-11-height {
   display: inline-block;
 }
 
-/* Forms inside a basic-panel */
-.basic-panel form {
-  padding: 0 0 1rem 0;
-}
-
-.basic-panel .cancel-link {
-  padding: 1em 1em 1em 0;
-  cursor: pointer;
-}
-
 .align-right {
   text-align: right !important;
+}
+
+.align-center-vertical {
+  display: flex;
+  align-items: center;
 }

--- a/src/App/index.css
+++ b/src/App/index.css
@@ -75,3 +75,17 @@ img._fix-ie-11-height {
 .address_inline {
   display: inline-block;
 }
+
+/* Forms inside a basic-panel */
+.basic-panel form {
+  padding: 0 0 1rem 0;
+}
+
+.align-right {
+  text-align: right !important;
+}
+
+.cancel-link {
+  padding: 1em 1em 1em 0;
+  cursor: pointer;
+}

--- a/src/App/index.css
+++ b/src/App/index.css
@@ -81,11 +81,11 @@ img._fix-ie-11-height {
   padding: 0 0 1rem 0;
 }
 
-.align-right {
-  text-align: right !important;
-}
-
-.cancel-link {
+.basic-panel .cancel-link {
   padding: 1em 1em 1em 0;
   cursor: pointer;
+}
+
+.align-right {
+  text-align: right !important;
 }

--- a/src/shared/BasicPanel/index.css
+++ b/src/shared/BasicPanel/index.css
@@ -4,6 +4,15 @@
   width: 100%;
   empty-cells: hide;
   margin-bottom: 18px;
+  font-size: 0.8em;
+}
+
+.basic-panel form {
+  padding: 0 0 1rem 0;
+}
+
+.basic-panel .cancel-link {
+  cursor: pointer;
 }
 
 .basic-panel-title {
@@ -15,12 +24,11 @@
   width: 100%;
 }
 
-
 .basic-panel-content {
   padding-left: 1.7rem;
   padding-right: 1.7rem;
   border: solid #f1f1f1;
-  border-width: 0 .1rem .1rem .1rem;
+  border-width: 0 0.1rem 0.1rem 0.1rem;
   padding-top: 8px;
   padding-bottom: 9px;
   background: white;

--- a/src/shared/JsonSchemaForm/DimensionsField.jsx
+++ b/src/shared/JsonSchemaForm/DimensionsField.jsx
@@ -9,7 +9,7 @@ export class DimensionsField extends Component {
     return (
       <FormSection name={this.props.fieldName}>
         <label htmlFor={this.props.fieldName} className="usa-input-label">
-          <b>{this.props.labelText}</b>
+          {this.props.labelText}
         </label>
         <table className="dimensions-form">
           <tbody>

--- a/src/shared/JsonSchemaForm/DimensionsField.jsx
+++ b/src/shared/JsonSchemaForm/DimensionsField.jsx
@@ -9,7 +9,7 @@ export class DimensionsField extends Component {
     return (
       <FormSection name={this.props.fieldName}>
         <label htmlFor={this.props.fieldName} className="usa-input-label">
-          {this.props.labelText}
+          <b>{this.props.labelText}</b>
         </label>
         <table className="dimensions-form">
           <tbody>

--- a/src/shared/PreApprovalRequest/Code105Form.jsx
+++ b/src/shared/PreApprovalRequest/Code105Form.jsx
@@ -10,13 +10,13 @@ export const Code105Form = props => {
       <DimensionsField
         fieldName="item_dimensions"
         swagger={ship_line_item_schema}
-        labelText="Item Dimensions (inches)"
+        labelText="Item dimensions (inches)"
         isRequired={true}
       />
       <DimensionsField
         fieldName="crate_dimensions"
         swagger={ship_line_item_schema}
-        labelText="Crate Dimensions (inches)"
+        labelText="Crate dimensions (inches)"
         isRequired={true}
       />
       <div className="bq-explanation">

--- a/src/shared/PreApprovalRequest/Creator.jsx
+++ b/src/shared/PreApprovalRequest/Creator.jsx
@@ -71,7 +71,7 @@ export class Creator extends Component {
         <div className="pre-approval-panel-modal">
           <div className="title">Add a request</div>
           <PreApprovalForm tariff400ngItems={this.props.tariff400ngItems} onSubmit={this.onSubmit} />
-          <div className="usa-grid-full">
+          <div className="usa-grid-full align-center-vertical">
             <div className="usa-width-one-half">
               <p className="cancel-link">
                 <a className="usa-button-secondary" onClick={this.closeForm}>

--- a/src/shared/PreApprovalRequest/Editor.jsx
+++ b/src/shared/PreApprovalRequest/Editor.jsx
@@ -51,7 +51,7 @@ export class Editor extends Component {
           onSubmit={this.onSubmit}
           initialValues={initialValues}
         />
-        <div className="usa-grid-full">
+        <div className="usa-grid-full align-center-vertical">
           <div className="usa-width-one-half">
             <p className="cancel-link">
               <a className="usa-button-secondary" onClick={this.props.cancelEdit}>

--- a/src/shared/PreApprovalRequest/PreApprovalForm.jsx
+++ b/src/shared/PreApprovalRequest/PreApprovalForm.jsx
@@ -118,7 +118,7 @@ export class PreApprovalForm extends Component {
             <div className="tariff400-select usa-input">
               <Field
                 name="tariff400ng_item"
-                title="Code & Item"
+                title="Code & item"
                 component={Tariff400ngItemSearch}
                 tariff400ngItems={this.props.tariff400ngItems}
               />

--- a/src/shared/PreApprovalRequest/PreApprovalRequest.css
+++ b/src/shared/PreApprovalRequest/PreApprovalRequest.css
@@ -69,6 +69,10 @@
   cursor: pointer;
 }
 
+.pre-approval-edit {
+  font-size: 1.7rem;
+}
+
 /*Creator styles*/
 .add-request {
   margin: 1.5rem 0rem 1.5rem 0rem;

--- a/src/shared/PreApprovalRequest/PreApprovalRequest.css
+++ b/src/shared/PreApprovalRequest/PreApprovalRequest.css
@@ -180,6 +180,14 @@ td.delete-confirm strong {
   border-radius: 7px !important;
 }
 
+.tariff400__value-container {
+  height: 5rem;
+}
+
+.tariff400__input input {
+  height: 2rem;
+}
+
 .location__control {
   height: 5rem;
   border-color: #5b616b !important;

--- a/src/shared/PreApprovalRequest/PreApprovalRequest.css
+++ b/src/shared/PreApprovalRequest/PreApprovalRequest.css
@@ -51,13 +51,13 @@
 .pre-approval-panel-table-cont th {
   font-weight: bold;
   font-size: 0.8em;
-  border: none;
+  border-bottom: solid 1px #a2a2a2;
   text-align: left;
   padding: 0rem 2rem 1rem 0rem;
 }
 
 .pre-approval-panel-table-cont table > tbody > tr > td {
-  border: none;
+  border-bottom: 1px solid #f1f1f1;
   font-size: 0.8em;
   padding: 1rem 1rem 1rem 0rem;
   text-align: left;
@@ -213,4 +213,8 @@ td.delete-confirm strong {
 
 .dimensions-form .dimensions-form-header {
   padding: 0;
+}
+
+.dimensions-form td {
+  border: none !important;
 }

--- a/src/shared/PreApprovalRequest/PreApprovalRequest.css
+++ b/src/shared/PreApprovalRequest/PreApprovalRequest.css
@@ -42,10 +42,6 @@
   width: 9%;
 }
 
-.cancel-link {
-  padding: 1em 1em 1em 0;
-  cursor: pointer;
-}
 .pre-approval-panel th,
 .pre-approval-panel td {
   border: none;
@@ -102,13 +98,6 @@
 .pre-approval-panel-modal .title {
   font-size: 2rem;
   font-weight: bold;
-}
-.pre-approval-panel .align-right {
-  text-align: right !important;
-}
-
-.pre-approval-form {
-  padding: 0 0 1rem 0;
 }
 
 .cancel button {

--- a/src/shared/PreApprovalRequest/PreApprovalRequest.css
+++ b/src/shared/PreApprovalRequest/PreApprovalRequest.css
@@ -50,7 +50,6 @@
 
 .pre-approval-panel-table-cont th {
   font-weight: bold;
-  font-size: 0.8em;
   border-bottom: solid 1px #a2a2a2;
   text-align: left;
   padding: 0rem 2rem 1rem 0rem;
@@ -58,7 +57,6 @@
 
 .pre-approval-panel-table-cont table > tbody > tr > td {
   border-bottom: 1px solid #f1f1f1;
-  font-size: 0.8em;
   padding: 1rem 1rem 1rem 0rem;
   text-align: left;
   vertical-align: top;
@@ -67,10 +65,6 @@
 .actionable {
   color: #0071bc;
   cursor: pointer;
-}
-
-.pre-approval-edit {
-  font-size: 1.7rem;
 }
 
 /*Creator styles*/

--- a/src/shared/PreApprovalRequest/PreApprovalRequest.css
+++ b/src/shared/PreApprovalRequest/PreApprovalRequest.css
@@ -182,6 +182,10 @@ td.delete-confirm strong {
   height: 2rem;
 }
 
+.tariff400ng_item {
+  font-size: 1.7rem;
+}
+
 .location__control {
   height: 5rem;
   border-color: #5b616b !important;

--- a/src/shared/PreApprovalRequest/PreApprovalRequest.css
+++ b/src/shared/PreApprovalRequest/PreApprovalRequest.css
@@ -118,7 +118,7 @@
 }
 
 .bq-explanation {
-  font-size: 0.8em;
+  font-size: 0.9em;
   padding: 0rem 0rem 3rem 0rem;
 }
 

--- a/src/shared/PreApprovalRequest/PreApprovalRequest.css
+++ b/src/shared/PreApprovalRequest/PreApprovalRequest.css
@@ -51,13 +51,13 @@
 .pre-approval-panel-table-cont th {
   font-weight: bold;
   font-size: 0.8em;
-  border-bottom: solid 1px #a2a2a2;
+  border: none;
   text-align: left;
   padding: 0rem 2rem 1rem 0rem;
 }
 
 .pre-approval-panel-table-cont table > tbody > tr > td {
-  border-bottom: 1px solid #f1f1f1;
+  border: none;
   font-size: 0.8em;
   padding: 1rem 1rem 1rem 0rem;
   text-align: left;
@@ -89,10 +89,6 @@
 
 .pre-approval-panel-modal .textarea-half textarea {
   height: 8rem;
-}
-
-.pre-approval-edit {
-  background-color: #f6fdfe;
 }
 
 .pre-approval-panel-modal .title {

--- a/src/shared/PreApprovalRequest/PreApprovalRequest.jsx
+++ b/src/shared/PreApprovalRequest/PreApprovalRequest.jsx
@@ -135,7 +135,7 @@ export class PreApprovalRequest extends Component {
           </tr>
           {this.state.showDeleteForm && (
             <tr className="delete-confirm-row">
-              <td colSpan="8" className="delete-confirm">
+              <td colSpan="7" className="delete-confirm">
                 <strong>Are you sure you want to delete?</strong>
                 <button
                   className="usa-button usa-button-secondary"

--- a/src/shared/StorageInTransit/Creator.jsx
+++ b/src/shared/StorageInTransit/Creator.jsx
@@ -48,7 +48,7 @@ export class Creator extends Component {
         <div className="storage-in-transit-panel-modal">
           <div className="title">Request SIT</div>
           <StorageInTransitForm onSubmit={this.onSubmit} />
-          <div className="usa-grid-full">
+          <div className="usa-grid-full align-center-vertical">
             <div className="usa-width-one-half">
               <p className="cancel-link">
                 <a className="usa-button-secondary" onClick={this.closeForm}>

--- a/src/shared/StorageInTransit/StorageInTransit.css
+++ b/src/shared/StorageInTransit/StorageInTransit.css
@@ -30,15 +30,6 @@
   width: calc(60% + 1.9rem);
 }
 
-.storage-in-transit-request-form-send-request-button {
-  float: right;
-  margin-top: 2.5em !important;
-}
-
-.cancel-link {
-  margin-top: 2.5em !important;
-}
-
 #sit-status-text {
   margin-left: 1.8em;
 }


### PR DESCRIPTION
## Description

This PR cleans up css style issues in the pre-approval request panel. As we continue to add custom forms for each accessorial code aka robust accessorials, we want styling to be consistent.

## Reviewer Notes

- Didn't get to address the "Other CSS changes in the story". Those changes require their own stories.

## Code Review Verification Steps

* [ ] There are no aXe warnings for UI.
* [ ] This works in IE.
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/164389307) for this change

## Screenshots

Changes:
- Labels are now "Sentence format"
- Height issue with selector input fixed
- Link and buttons now line up properly in TSP side

<img width="1165" alt="105 Preapproval" src="https://user-images.githubusercontent.com/1522549/54315681-03a6f980-459c-11e9-9c77-e050758f5317.png">

Changes:
- Removed blue background for edit panel
- Font size in edit panel is now the same in create panel

![image](https://user-images.githubusercontent.com/1522549/54316222-6e0c6980-459d-11e9-99fd-5ff71a2aacf3.png)
