### PR TITLE
Allow absolute path from request in setting up SwaggerUI

### DIFF
--- a/public/swagger-ui/api.html
+++ b/public/swagger-ui/api.html
@@ -34,7 +34,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="position:absolute;width:0;height:0">
   <defs>
     <symbol viewBox="0 0 20 20" id="unlocked">
-          <path d="M15.8 8H14V5.6C14 2.703 12.665 1 10 1 7.334 1 6 2.703 6 5.6V6h2v-.801C8 3.754 8.797 3 10 3c1.203 0 2 .754 2 2.199V8H4c-.553 0-1 .646-1 1.199V17c0 .549.428 1.139.951 1.307l1.197.387C5.672 18.861 6.55 19 7.1 19h5.8c.549 0 1.428-.139 1.951-.307l1.196-.387c.524-.167.953-.757.953-1.306V9.199C17 8.646 16.352 8 15.8 8z"></path>
+      <path d="M15.8 8H14V5.6C14 2.703 12.665 1 10 1 7.334 1 6 2.703 6 5.6V6h2v-.801C8 3.754 8.797 3 10 3c1.203 0 2 .754 2 2.199V8H4c-.553 0-1 .646-1 1.199V17c0 .549.428 1.139.951 1.307l1.197.387C5.672 18.861 6.55 19 7.1 19h5.8c.549 0 1.428-.139 1.951-.307l1.196-.387c.524-.167.953-.757.953-1.306V9.199C17 8.646 16.352 8 15.8 8z"></path>
     </symbol>
 
     <symbol viewBox="0 0 20 20" id="locked">
@@ -73,7 +73,7 @@
 <script>
 window.onload = function() {
   // Intercept the request to add csrf token and only allow requests to the current domain.
-  const requestInterceptor = req => {
+  const requestInterceptor = function(req) {
     if (!req.loadSpec) {
       const token = Cookies.get('masked_gorilla_csrf');
       if (token) {
@@ -83,8 +83,14 @@ window.onload = function() {
       }
     }
 
+    // Get just the pathname whether an absolute or relative path
+    let location = document.createElement("a");
+    let url = req['url'];
+    location.href = url;
+
+    let path = location.pathname;
     // Ensure that we only load files from the current domain.
-    req.url = window.location.protocol + "//" + window.location.host + req['url'];
+    req.url = window.location.protocol + "//" + window.location.host + path;
     return req;
   };
 

--- a/public/swagger-ui/internal.html
+++ b/public/swagger-ui/internal.html
@@ -34,7 +34,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="position:absolute;width:0;height:0">
   <defs>
     <symbol viewBox="0 0 20 20" id="unlocked">
-          <path d="M15.8 8H14V5.6C14 2.703 12.665 1 10 1 7.334 1 6 2.703 6 5.6V6h2v-.801C8 3.754 8.797 3 10 3c1.203 0 2 .754 2 2.199V8H4c-.553 0-1 .646-1 1.199V17c0 .549.428 1.139.951 1.307l1.197.387C5.672 18.861 6.55 19 7.1 19h5.8c.549 0 1.428-.139 1.951-.307l1.196-.387c.524-.167.953-.757.953-1.306V9.199C17 8.646 16.352 8 15.8 8z"></path>
+      <path d="M15.8 8H14V5.6C14 2.703 12.665 1 10 1 7.334 1 6 2.703 6 5.6V6h2v-.801C8 3.754 8.797 3 10 3c1.203 0 2 .754 2 2.199V8H4c-.553 0-1 .646-1 1.199V17c0 .549.428 1.139.951 1.307l1.197.387C5.672 18.861 6.55 19 7.1 19h5.8c.549 0 1.428-.139 1.951-.307l1.196-.387c.524-.167.953-.757.953-1.306V9.199C17 8.646 16.352 8 15.8 8z"></path>
     </symbol>
 
     <symbol viewBox="0 0 20 20" id="locked">
@@ -73,7 +73,7 @@
 <script>
 window.onload = function() {
   // Intercept the request to add csrf token and only allow requests to the current domain.
-  const requestInterceptor = req => {
+  const requestInterceptor = function(req) {
     if (!req.loadSpec) {
       const token = Cookies.get('masked_gorilla_csrf');
       if (token) {
@@ -83,8 +83,14 @@ window.onload = function() {
       }
     }
 
+    // Get just the pathname whether an absolute or relative path
+    let location = document.createElement("a");
+    let url = req['url'];
+    location.href = url;
+
+    let path = location.pathname;
     // Ensure that we only load files from the current domain.
-    req.url = window.location.protocol + "//" + window.location.host + req['url'];
+    req.url = window.location.protocol + "//" + window.location.host + path;
     return req;
   };
 


### PR DESCRIPTION

## Description

Gets the pathname from the request regardless if it is an absolute o relative path.  Previously it was appending the entire url, even if it was absolute, to the window hostname.

## Reviewer Notes
I started making it IE compatible, which means not using ES6 like arrow function, but was running into more issues than it was worth trying to get it running in IE, where none of us will likely want to run it anyway.

## Setup

Go to SwaggerUI (`http://officelocal:3000/api/v1/docs#`) and run one of the api calls.  It should be successful and the pathname should not duplicate the hostname.

## Code Review Verification Steps

* [ ] This works in IE- could not get it to work in IE
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @ntwyman
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/164080608) for this change
