### PR TITLE
Add Actual SIT to SSW

### DIFF
--- a/cmd/generate_shipment_summary/main.go
+++ b/cmd/generate_shipment_summary/main.go
@@ -76,13 +76,9 @@ func main() {
 	ppmComputer := paperwork.NewSSWPPMComputer(rateengine.NewRateEngine(db, logger))
 
 	ssfd, err := models.FetchDataShipmentSummaryWorksheetFormData(db, &auth.Session{}, parsedID)
-	ssfd.MaxObligation, err = ppmComputer.ComputeObligations(ssfd, planner, paperwork.MaxObligation)
+	ssfd.Obligations, err = ppmComputer.ComputeObligations(ssfd, planner)
 	if err != nil {
-		log.Println("Error calculating PPM max obligations ")
-	}
-	ssfd.ActualObligation, err = ppmComputer.ComputeObligations(ssfd, planner, paperwork.ActualObligation)
-	if err != nil {
-		log.Println("Error calculating PPM actual obligations ")
+		log.Println("Error calculating obligations ")
 	}
 
 	page1Data, page2Data, err := models.FormatValuesShipmentSummaryWorksheet(ssfd)

--- a/pkg/handlers/internalapi/moves.go
+++ b/pkg/handlers/internalapi/moves.go
@@ -245,13 +245,9 @@ func (h ShowShipmentSummaryWorksheetHandler) Handle(params moveop.ShowShipmentSu
 
 	ssfd, err := models.FetchDataShipmentSummaryWorksheetFormData(h.DB(), session, moveID)
 	ssfd.PreparationDate = time.Time(params.PreparationDate)
-	ssfd.MaxObligation, err = ppmComputer.ComputeObligations(ssfd, h.Planner(), paperwork.MaxObligation)
+	ssfd.Obligations, err = ppmComputer.ComputeObligations(ssfd, h.Planner())
 	if err != nil {
-		h.Logger().Error("Error calculating PPM max obligations ", zap.Error(err))
-	}
-	ssfd.ActualObligation, err = ppmComputer.ComputeObligations(ssfd, h.Planner(), paperwork.ActualObligation)
-	if err != nil {
-		h.Logger().Error("Error calculating PPM actual obligations ", zap.Error(err))
+		h.Logger().Error("Error calculating obligations ", zap.Error(err))
 	}
 
 	page1Data, page2Data, err := models.FormatValuesShipmentSummaryWorksheet(ssfd)

--- a/pkg/models/shipment_summary_worksheet_test.go
+++ b/pkg/models/shipment_summary_worksheet_test.go
@@ -204,8 +204,8 @@ func (suite *ModelSuite) TestFormatValuesShipmentSummaryWorksheetFormPage1() {
 		Shipments:               shipments,
 		PreparationDate:         time.Date(2019, 1, 1, 1, 1, 1, 1, time.UTC),
 		PersonallyProcuredMoves: personallyProcuredMoves,
-		MaxObligation:           models.Obligation{Gcc: unit.Cents(600000), SITMax: unit.Cents(53000)},
-		ActualObligation:        models.Obligation{Gcc: unit.Cents(500000)},
+		MaxObligation:           models.Obligation{Gcc: unit.Cents(600000), SIT: unit.Cents(53000)},
+		ActualObligation:        models.Obligation{Gcc: unit.Cents(500000), SIT: unit.Cents(30000)},
 	}
 	sswPage1 := models.FormatValuesShipmentSummaryWorksheetFormPage1(ssd)
 
@@ -249,6 +249,7 @@ func (suite *ModelSuite) TestFormatValuesShipmentSummaryWorksheetFormPage1() {
 	suite.Equal("4,000", sswPage1.ActualWeight)
 	suite.Equal("$5,000.00", sswPage1.ActualObligationGCC100)
 	suite.Equal("$4,750.00", sswPage1.ActualObligationGCC95)
+	suite.Equal("$300.00", sswPage1.ActualObligationSIT)
 	suite.Equal("$10.00", sswPage1.ActualObligationAdvance)
 }
 

--- a/pkg/models/shipment_summary_worksheet_test.go
+++ b/pkg/models/shipment_summary_worksheet_test.go
@@ -204,8 +204,10 @@ func (suite *ModelSuite) TestFormatValuesShipmentSummaryWorksheetFormPage1() {
 		Shipments:               shipments,
 		PreparationDate:         time.Date(2019, 1, 1, 1, 1, 1, 1, time.UTC),
 		PersonallyProcuredMoves: personallyProcuredMoves,
-		MaxObligation:           models.Obligation{Gcc: unit.Cents(600000), SIT: unit.Cents(53000)},
-		ActualObligation:        models.Obligation{Gcc: unit.Cents(500000), SIT: unit.Cents(30000)},
+		Obligations: models.Obligations{
+			MaxObligation:    models.Obligation{Gcc: unit.Cents(600000), SIT: unit.Cents(53000)},
+			ActualObligation: models.Obligation{Gcc: unit.Cents(500000), SIT: unit.Cents(30000)},
+		},
 	}
 	sswPage1 := models.FormatValuesShipmentSummaryWorksheetFormPage1(ssd)
 

--- a/pkg/paperwork/shipment_summary.go
+++ b/pkg/paperwork/shipment_summary.go
@@ -268,7 +268,6 @@ func (sswPpmComputer *SSWPPMComputer) ComputeObligations(ssfd models.ShipmentSum
 	if err != nil {
 		return models.Obligations{}, errors.New("error calculating distance")
 	}
-
 	var valid bool
 	var maxCost, actualCost rateengine.CostComputation
 	if valid = firstPPM.ActualMoveDate != nil; valid {
@@ -298,9 +297,7 @@ func (sswPpmComputer *SSWPPMComputer) ComputeObligations(ssfd models.ShipmentSum
 		return models.Obligations{}, errors.New("error calculating PPM actual obligations")
 	}
 	var actualSIT unit.Cents
-	if firstPPM.TotalSITCost == nil {
-		actualSIT = unit.Cents(0)
-	} else {
+	if firstPPM.TotalSITCost != nil {
 		actualSIT = *firstPPM.TotalSITCost
 	}
 	if actualSIT > maxCost.SITMax {

--- a/pkg/paperwork/shipment_summary_worksheet.go
+++ b/pkg/paperwork/shipment_summary_worksheet.go
@@ -40,6 +40,7 @@ var ShipmentSummaryPage1Layout = FormLayout{
 		"ActualObligationGCC100":          FormField(133, 182.5, 22, floatPtr(10), nil, stringPtr("RM")),
 		"ActualWeight":                    FormField(167, 182.5, 16, floatPtr(10), nil, stringPtr("RM")),
 		"ActualObligationGCC95":           FormField(133, 188.5, 22, floatPtr(10), nil, stringPtr("RM")),
+		"ActualObligationSIT":             FormField(133, 194.75, 22, floatPtr(10), nil, stringPtr("RM")),
 		"ActualObligationAdvance":         FormField(133, 201, 22, floatPtr(10), nil, stringPtr("RM")),
 	},
 }


### PR DESCRIPTION
## Description

Add the actual SIT obligation to the SSW.

## Setup

`make server_test`

### Test in the office client
`make server_run`
`make office_client_run`

1) Log into the office app and select a move with a PPM
2) Make sure that the PPM has all the various required parameters: "Net Weight", "Pickup zip code", "Destination zip code", "Total costs".
2) Click Create Paperwork -> Click Download worksheet 

### Test with cmd line tool
` go run cmd/generate_shipment_summary/main.go -move 0db80bd6-de75-439e-bf89-deaafa1d0dc8 -debug`

## Code Review Verification Steps
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References
* [Pivotal story](https://www.pivotaltracker.com/story/show/164384295) 

## Screenshots
![Screen Shot 2019-03-13 at 4 12 43 PM](https://user-images.githubusercontent.com/1036969/54318119-e4fc2f00-45aa-11e9-8387-65557cad0331.png)