### PR TITLE
Display debug labels beneath field cells to improve legibility

### DIFF
--- a/pkg/paperwork/forms.go
+++ b/pkg/paperwork/forms.go
@@ -190,7 +190,7 @@ func (f *FormFiller) drawDebugOverlay(xPos, yPos, width, lineHeight float64, lab
 	f.pdf.MoveTo(xPos, yPos)
 	f.pdf.CellFormat(width, lineHeight, "", "1", 0, "R", false, 0, "")
 
-	f.pdf.MoveTo(xPos+1.2, yPos+1.8)
+	f.pdf.MoveTo(xPos+1.2, yPos-2.9)
 	f.pdf.CellFormat(width, 4, label, "0", 0, "R", false, 0, "")
 
 	// Restore settings

--- a/pkg/paperwork/forms.go
+++ b/pkg/paperwork/forms.go
@@ -188,7 +188,10 @@ func (f *FormFiller) drawDebugOverlay(xPos, yPos, width, lineHeight float64, lab
 	f.pdf.SetFontSize(4)
 
 	f.pdf.MoveTo(xPos, yPos)
-	f.pdf.CellFormat(width, lineHeight, label, "1", 0, "R", false, 0, "")
+	f.pdf.CellFormat(width, lineHeight, "", "1", 0, "R", false, 0, "")
+
+	f.pdf.MoveTo(xPos+1, yPos+2)
+	f.pdf.CellFormat(width, 4, label, "0", 0, "R", false, 0, "")
 
 	// Restore settings
 	f.pdf.SetTextColor(tr, tg, tb)

--- a/pkg/paperwork/forms.go
+++ b/pkg/paperwork/forms.go
@@ -190,7 +190,7 @@ func (f *FormFiller) drawDebugOverlay(xPos, yPos, width, lineHeight float64, lab
 	f.pdf.MoveTo(xPos, yPos)
 	f.pdf.CellFormat(width, lineHeight, "", "1", 0, "R", false, 0, "")
 
-	f.pdf.MoveTo(xPos+1, yPos+2)
+	f.pdf.MoveTo(xPos+1.2, yPos+1.8)
 	f.pdf.CellFormat(width, 4, label, "0", 0, "R", false, 0, "")
 
 	// Restore settings


### PR DESCRIPTION
## Description

The debug info is pretty hard to read when it's printed on top of actual values. This PR moves it to beneath the cell so that it can be read more easily.

## Setup

```sh
$ make db_dev_e2e_populate
$ go run cmd/generate_shipment_summary/main.go  -move 25fb9bf6-2a38-4463-8247-fce2a5571ab7 -debug true
```

Then open the resulting PDF in Preview.

## Screenshots

Before:
<img width="617" alt="Screen Shot 2019-03-14 at 10 21 27 AM" src="https://user-images.githubusercontent.com/3331/54368920-04469b00-4643-11e9-9fc3-6e0ea52c5e9f.png">

After:
<img width="610" alt="Screen Shot 2019-03-14 at 10 21 35 AM" src="https://user-images.githubusercontent.com/3331/54368932-07da2200-4643-11e9-9f26-dfa9e3e8f0a1.png">

