### PR TITLE
Only show file a claim section when shipment is in delivered or compl…

### DIFF
--- a/src/scenes/Landing/MoveSummary.jsx
+++ b/src/scenes/Landing/MoveSummary.jsx
@@ -213,8 +213,6 @@ export const SubmittedHhgMoveSummary = props => {
     selectedMoveType === 'HHG' &&
     ['SUBMITTED', 'ACCEPTED', 'AWARDED', 'APPROVED', 'IN_TRANSIT', 'DELIVERED', 'COMPLETED'].includes(move.status);
 
-  let today = moment();
-
   return (
     <Fragment>
       <div>
@@ -233,7 +231,7 @@ export const SubmittedHhgMoveSummary = props => {
             <div className="step-contents">
               <div className="status_box usa-width-two-thirds">
                 {showHhgLandingPageText(shipment)}
-                {(shipment.actual_pack_date || today.isSameOrAfter(shipment.pm_survey_planned_pack_date)) && (
+                {(shipment.status === 'DELIVERED' || shipment.status === 'COMPLETED') && (
                   <TransportationServiceProviderContactInfo showFileAClaimInfo shipmentId={shipment.id} />
                 )}
               </div>

--- a/src/scenes/TransportationServiceProvider/ContactInfo.jsx
+++ b/src/scenes/TransportationServiceProvider/ContactInfo.jsx
@@ -21,7 +21,7 @@ export class TransportationServiceProviderContactInfo extends Component {
           <div className="title">File a Claim</div>
           <div>
             If you have household goods damaged or lost during the move, contact {transportationServiceProvider.name} to
-            file a claim: {transportationServiceProvider.poc_general_phone}. If, after attempting to work with them, you
+            file a claim: {transportationServiceProvider.poc_claims_phone}. If, after attempting to work with them, you
             do not feel that you are receiving adequate compensation, contact the Military Claims Office for help.
           </div>
         </div>

--- a/src/scenes/TransportationServiceProvider/ContactInfo.jsx
+++ b/src/scenes/TransportationServiceProvider/ContactInfo.jsx
@@ -15,14 +15,19 @@ export class TransportationServiceProviderContactInfo extends Component {
 
   render() {
     const { transportationServiceProvider, showFileAClaimInfo } = this.props;
+    const pocClaimsPhone = transportationServiceProvider.poc_claims_phone;
+    const pocGeneralPhone = transportationServiceProvider.poc_general_phone;
+
     if (showFileAClaimInfo) {
       return (
         <div className="step">
           <div className="title">File a Claim</div>
           <div>
             If you have household goods damaged or lost during the move, contact {transportationServiceProvider.name} to
-            file a claim: {transportationServiceProvider.poc_claims_phone}. If, after attempting to work with them, you
-            do not feel that you are receiving adequate compensation, contact the Military Claims Office for help.
+            file a claim:{' '}
+            {pocClaimsPhone ? pocClaimsPhone : pocGeneralPhone ? pocGeneralPhone : 'Contact info not available'}. If,
+            after attempting to work with them, you do not feel that you are receiving adequate compensation, contact
+            the Military Claims Office for help.
           </div>
         </div>
       );
@@ -32,7 +37,7 @@ export class TransportationServiceProviderContactInfo extends Component {
           <div>
             <strong>{transportationServiceProvider.name}</strong>
           </div>
-          <div>{transportationServiceProvider.poc_general_phone}</div>
+          <div>{pocGeneralPhone ? pocGeneralPhone : 'Contact info not available'}</div>
         </div>
       );
     }

--- a/src/scenes/TransportationServiceProvider/ContactInfo.test.jsx
+++ b/src/scenes/TransportationServiceProvider/ContactInfo.test.jsx
@@ -15,6 +15,7 @@ const transportationServiceProvider = {
   id: 'f21cfbfa-3735-4166-97fb-bbc069e52637',
   name: 'Best moving company',
   poc_general_phone: '222-333-4444',
+  poc_claims_phone: '555-666-7777',
 };
 
 const shipment = {
@@ -61,7 +62,7 @@ describe('ContactInfo tests', () => {
     it('renders the file a claim section', () => {
       expect(wrapper.contains('File a Claim')).toBe(true);
       expect(wrapper.contains(transportationServiceProvider.name)).toEqual(true);
-      expect(wrapper.contains(transportationServiceProvider.poc_general_phone)).toEqual(true);
+      expect(wrapper.contains(transportationServiceProvider.poc_claims_phone)).toEqual(true);
     });
   });
 });


### PR DESCRIPTION
…eted state and show claims phone number rather than general phone number

## Description

Design noticed that "File a Claim" section was showing when shipment was `Inbound`, which is incorrect. Fixed so that now the section is only seen when shipment is `Delivered` or `Completed`. Also, shows the claims phone number instead of the general phone number.

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make db_dev_e2e_populate
make server_run
make client_run
```
Go to a `DELIVERED` or `COMPLETED` move and you will see a section for "File a Claim" that includes the TSP name and phone number. Go to any move that is NOT in a `DELIVERED` or `COMPLETED` state, and you will NOT see the "File a Claim" section.

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/161797984) for this change
