### PR TITLE
Filter service logs by git branch and commit

### DIFF
--- a/bin/ecs-show-service-logs
+++ b/bin/ecs-show-service-logs
@@ -7,12 +7,13 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 readonly DIR
 
 usage() {
-    echo "$0 <name> <environment> | less"
+    echo "$0 <name> <environment> [git-branch [git-commit]] | less"
     exit 1
 }
-[[ -z $1 || -z $2 ]] && usage
+
+[[ $# -lt 2 || $# -gt 4 ]] && usage
 set -u
 
 [[ -f "$DIR/ecs-service-logs" ]] || (echo "Missing bin/ecs-service-logs. Run make build_tools" && exit 1)
 
-"$DIR/ecs-service-logs" --cluster "app-${2}" --service "${1}" --status "RUNNING" --verbose
+"$DIR/ecs-service-logs" --cluster "app-${2}" --service "${1}" --git-branch "${3:-}" --git-commit "${4:-}" --status "RUNNING" --verbose

--- a/bin/ecs-show-service-stopped-logs
+++ b/bin/ecs-show-service-stopped-logs
@@ -8,12 +8,12 @@ readonly DIR
 readonly LIMIT=${LIMIT:-25}
 
 usage() {
-    echo "LIMIT=$LIMIT $0 <name> <environment> | less"
+    echo "LIMIT=$LIMIT $0 <name> <environment> [git-branch [git-commit]] | less"
     exit 1
 }
-[[ -z $1 || -z $2 ]] && usage
+[[ $# -lt 2 || $# -gt 4 ]] && usage
 set -u
 
 [[ -f "$DIR/ecs-service-logs" ]] || (echo "Missing bin/ecs-service-logs. Run make build_tools" && exit 1)
 
-"$DIR/ecs-service-logs" --cluster "app-${2}" --service "${1}" --environment "${2}" --status "STOPPED" --verbose
+"$DIR/ecs-service-logs" --cluster "app-${2}" --service "${1}" --environment "${2}" --git-branch "${3:-}" --git-commit "${4:-}" --status "STOPPED" --verbose


### PR DESCRIPTION
## Description

This PR adds the ability to optionally filter service logs by git branch and commit.  With the new logging improvements almost every log line from MyMove should include a git branch and commit now.  For example,

```
bin/ecs-show-service-stopped-logs app experimental graceful_shutdown e68bf2ea55db75b5fb2a8a4b99bff39fbbaff2a6
```

Or just by the branch

```
bin/ecs-show-service-stopped-logs app experimental graceful_shutdown
```

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Setup

None

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](./docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](./docs/backend.md#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](./docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
  * [ ] Secure migrations have been tested using `bin/run-prod-migrations`
* [ ] There are no aXe warnings for UI.
* [ ] This works in IE.
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @ntwyman
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](tbd) for this change
* [this article](tbd) explains more about the approach used.

## Screenshots

None