### PR TITLE
Use remaining Entitlement for Shipment Summary worksheet Actual Obligations

### DIFF
--- a/pkg/models/shipment_summary_worksheet.go
+++ b/pkg/models/shipment_summary_worksheet.go
@@ -60,7 +60,7 @@ type ShipmentSummaryWorksheetPage1Values struct {
 	MaxObligationGCC95              string
 	MaxObligationSIT                string
 	MaxObligationGCCMaxAdvance      string
-	ActualWeight                    string
+	PPMRemainingEntitlement         string
 	ActualObligationGCC100          string
 	ActualObligationGCC95           string
 	ActualObligationAdvance         string
@@ -112,12 +112,13 @@ type ShipmentSummaryFormData struct {
 	CurrentDutyStation      DutyStation
 	NewDutyStation          DutyStation
 	WeightAllotment         WeightAllotment
-	TotalWeightAllotment    int
+	TotalWeightAllotment    unit.Pound
 	Shipments               Shipments
 	PersonallyProcuredMoves PersonallyProcuredMoves
 	PreparationDate         time.Time
 	Obligations             Obligations
 	MovingExpenseDocuments  []MovingExpenseDocument
+	PPMRemainingEntitlement unit.Pound
 }
 
 //Obligations an object representing the Max Obligation and Actual Obligation sections of the shipment summary worksheet
@@ -192,11 +193,12 @@ func FetchDataShipmentSummaryWorksheetFormData(db *pop.Connection, session *auth
 	serviceMember := move.Orders.ServiceMember
 	var rank ServiceMemberRank
 	var weightAllotment WeightAllotment
-	var totalEntitlement int
+	var totalEntitlement unit.Pound
 	if serviceMember.Rank != nil {
 		rank = ServiceMemberRank(*serviceMember.Rank)
 		weightAllotment = GetWeightAllotment(rank)
-		totalEntitlement, err = GetEntitlement(rank, move.Orders.HasDependents, move.Orders.SpouseHasProGear)
+		te, err := GetEntitlement(rank, move.Orders.HasDependents, move.Orders.SpouseHasProGear)
+		totalEntitlement = unit.Pound(te)
 		if err != nil {
 			return ShipmentSummaryFormData{}, err
 		}
@@ -207,6 +209,8 @@ func FetchDataShipmentSummaryWorksheetFormData(db *pop.Connection, session *auth
 		return ShipmentSummaryFormData{}, err
 	}
 
+	ppmRemainingEntitlement := CalculateRemainingPPMEntitlement(move, totalEntitlement)
+
 	ssd := ShipmentSummaryFormData{
 		ServiceMember:           serviceMember,
 		Order:                   move.Orders,
@@ -216,9 +220,31 @@ func FetchDataShipmentSummaryWorksheetFormData(db *pop.Connection, session *auth
 		TotalWeightAllotment:    totalEntitlement,
 		Shipments:               move.Shipments,
 		PersonallyProcuredMoves: move.PersonallyProcuredMoves,
+		PPMRemainingEntitlement: ppmRemainingEntitlement,
 		MovingExpenseDocuments:  movingExpenses,
 	}
 	return ssd, nil
+}
+
+// CalculateRemainingPPMEntitlement calculates the remaining PPM entitlement for PPM moves
+// a PPMs remaining entitlement weight is equal to total entitlement - hhg weight
+func CalculateRemainingPPMEntitlement(move Move, totalEntitlement unit.Pound) unit.Pound {
+	var hhgActualWeight unit.Pound
+	if len(move.Shipments) > 0 && move.Shipments[0].NetWeight != nil {
+		hhgActualWeight = *move.Shipments[0].NetWeight
+	}
+	var ppmActualWeight unit.Pound
+	if len(move.PersonallyProcuredMoves) > 0 {
+		ppmActualWeight = unit.Pound(*move.PersonallyProcuredMoves[0].NetWeight)
+	}
+	switch ppmRemainingEntitlement := totalEntitlement - hhgActualWeight; {
+	case ppmActualWeight < ppmRemainingEntitlement:
+		return ppmActualWeight
+	case ppmRemainingEntitlement < 0:
+		return 0
+	default:
+		return ppmRemainingEntitlement
+	}
 }
 
 // FetchMovingExpensesShipmentSummaryWorksheet fetches moving expenses for the Shipment Summary Worksheet
@@ -266,8 +292,8 @@ func FormatValuesShipmentSummaryWorksheetFormPage1(data ShipmentSummaryFormData)
 	page1.NewDutyAssignment = FormatDutyStation(data.NewDutyStation)
 
 	page1.WeightAllotment = FormatWeightAllotment(data)
-	page1.WeightAllotmentProgear = FormatWeights(data.WeightAllotment.ProGearWeight)
-	page1.WeightAllotmentProgearSpouse = FormatWeights(data.WeightAllotment.ProGearWeightSpouse)
+	page1.WeightAllotmentProgear = FormatWeights(unit.Pound(data.WeightAllotment.ProGearWeight))
+	page1.WeightAllotmentProgearSpouse = FormatWeights(unit.Pound(data.WeightAllotment.ProGearWeightSpouse))
 	page1.TotalWeightAllotment = FormatWeights(data.TotalWeightAllotment)
 
 	formattedShipments := FormatAllShipments(data.PersonallyProcuredMoves, data.Shipments)
@@ -285,11 +311,10 @@ func FormatValuesShipmentSummaryWorksheetFormPage1(data ShipmentSummaryFormData)
 
 	actualObligations := data.Obligations.ActualObligation
 	page1.ActualObligationGCC100 = FormatDollars(actualObligations.GCC100())
-	page1.ActualWeight = FormatActualObligationsWeight(data.TotalWeightAllotment, data.PersonallyProcuredMoves)
+	page1.PPMRemainingEntitlement = FormatWeights(data.PPMRemainingEntitlement)
 	page1.ActualObligationGCC95 = FormatDollars(actualObligations.GCC95())
 	page1.ActualObligationSIT = FormatDollars(actualObligations.FormatSIT())
 	page1.ActualObligationAdvance = formatActualObligationAdvance(data)
-
 	return page1
 }
 
@@ -299,19 +324,6 @@ func formatActualObligationAdvance(data ShipmentSummaryFormData) string {
 		return FormatDollars(advance)
 	}
 	return FormatDollars(0)
-}
-
-//FormatActualObligationsWeight formats the service member's weight for the actual obligations im the Shipment Summary Worksheet
-func FormatActualObligationsWeight(totalWeightAllotment int, personallyProcuredMoves PersonallyProcuredMoves) string {
-	if len(personallyProcuredMoves) == 0 || personallyProcuredMoves[0].NetWeight == nil {
-		return ""
-	}
-	ppmWeight := int(*personallyProcuredMoves[0].NetWeight)
-	weightAllotment := int(totalWeightAllotment)
-	if ppmWeight >= weightAllotment {
-		return FormatWeights(weightAllotment)
-	}
-	return FormatWeights(ppmWeight)
 }
 
 //FormatRank formats the service member's rank for Shipment Summary Worksheet
@@ -369,9 +381,9 @@ func FormatValuesShipmentSummaryWorksheetFormPage2(data ShipmentSummaryFormData)
 //FormatWeightAllotment formats the weight allotment for Shipment Summary Worksheet
 func FormatWeightAllotment(data ShipmentSummaryFormData) string {
 	if data.Order.HasDependents {
-		return FormatWeights(data.WeightAllotment.TotalWeightSelfPlusDependents)
+		return FormatWeights(unit.Pound(data.WeightAllotment.TotalWeightSelfPlusDependents))
 	}
-	return FormatWeights(data.WeightAllotment.TotalWeightSelf)
+	return FormatWeights(unit.Pound(data.WeightAllotment.TotalWeightSelf))
 }
 
 //FormatAuthorizedLocation formats AuthorizedOrigin and AuthorizedDestination for Shipment Summary Worksheet
@@ -514,7 +526,7 @@ func FormatPPMNumberAndType(i int) string {
 //FormatShipmentWeight formats a shipments ShipmentWeight for the Shipment Summary Worksheet
 func FormatShipmentWeight(shipment Shipment) string {
 	if shipment.NetWeight != nil {
-		wtg := FormatWeights(int(*shipment.NetWeight))
+		wtg := FormatWeights(*shipment.NetWeight)
 		return fmt.Sprintf("%s lbs - FINAL", wtg)
 	}
 	return ""
@@ -531,7 +543,7 @@ func FormatShipmentPickupDate(shipment Shipment) string {
 //FormatPPMWeight formats a ppms NetWeight for the Shipment Summary Worksheet
 func FormatPPMWeight(ppm PersonallyProcuredMove) string {
 	if ppm.NetWeight != nil {
-		wtg := FormatWeights(int(*ppm.NetWeight))
+		wtg := FormatWeights(unit.Pound(*ppm.NetWeight))
 		return fmt.Sprintf("%s lbs - FINAL", wtg)
 	}
 	return ""
@@ -588,8 +600,8 @@ func FormatEnum(s string, outSep string) string {
 	return strings.Replace(strings.Title(words), " ", outSep, -1)
 }
 
-//FormatWeights formats an int using 000s separator
-func FormatWeights(wtg int) string {
+//FormatWeights formats a unit.Pound using 000s separator
+func FormatWeights(wtg unit.Pound) string {
 	p := message.NewPrinter(language.English)
 	return p.Sprintf("%d", wtg)
 }

--- a/pkg/models/shipment_summary_worksheet_test.go
+++ b/pkg/models/shipment_summary_worksheet_test.go
@@ -105,7 +105,7 @@ func (suite *ModelSuite) TestFetchDataShipmentSummaryWorksheet() {
 	suite.Require().NotNil(ssd.ServiceMember.Rank)
 	totalEntitlement, err := models.GetEntitlement(*ssd.ServiceMember.Rank, ssd.Order.HasDependents, ssd.Order.SpouseHasProGear)
 	suite.Require().Nil(err)
-	suite.Equal(totalEntitlement, ssd.TotalWeightAllotment)
+	suite.Equal(unit.Pound(totalEntitlement), ssd.TotalWeightAllotment)
 	suite.Require().Len(ssd.MovingExpenseDocuments, 2)
 	suite.NotNil(ssd.MovingExpenseDocuments[0].ID)
 	suite.NotNil(ssd.MovingExpenseDocuments[1].ID)
@@ -199,6 +199,7 @@ func (suite *ModelSuite) TestFormatValuesShipmentSummaryWorksheetFormPage1() {
 		Order:                   order,
 		CurrentDutyStation:      yuma,
 		NewDutyStation:          fortGordon,
+		PPMRemainingEntitlement: 3000,
 		WeightAllotment:         wtgEntitlements,
 		TotalWeightAllotment:    17500,
 		Shipments:               shipments,
@@ -248,7 +249,7 @@ func (suite *ModelSuite) TestFormatValuesShipmentSummaryWorksheetFormPage1() {
 	suite.Equal("$530.00", sswPage1.MaxObligationSIT)
 	suite.Equal("$3,600.00", sswPage1.MaxObligationGCCMaxAdvance)
 
-	suite.Equal("4,000", sswPage1.ActualWeight)
+	suite.Equal("3,000", sswPage1.PPMRemainingEntitlement)
 	suite.Equal("$5,000.00", sswPage1.ActualObligationGCC100)
 	suite.Equal("$4,750.00", sswPage1.ActualObligationGCC95)
 	suite.Equal("$300.00", sswPage1.ActualObligationSIT)
@@ -438,22 +439,6 @@ func (suite *ModelSuite) TestFormatCurrentPPMStatus() {
 	suite.Equal("Completed", models.FormatCurrentPPMStatus(completed))
 }
 
-func (suite *ModelSuite) TestFormatActualObligationsWeight() {
-	suite.Equal("4,000", models.FormatActualObligationsWeight(7000,
-		[]models.PersonallyProcuredMove{
-			{NetWeight: models.Int64Pointer(4000)},
-		}))
-	suite.Equal("5,000", models.FormatActualObligationsWeight(5000,
-		[]models.PersonallyProcuredMove{
-			{NetWeight: models.Int64Pointer(10000)},
-		}))
-	suite.Equal("", models.FormatActualObligationsWeight(5000,
-		[]models.PersonallyProcuredMove{
-			{NetWeight: nil},
-		}))
-
-}
-
 func (suite *ModelSuite) TestFormatRank() {
 	e9 := models.ServiceMemberRankE9
 	multipleRanks := models.ServiceMemberRankO1ACADEMYGRADUATE
@@ -549,4 +534,56 @@ func (suite *ModelSuite) TestFormatPPMWeight() {
 
 	suite.Equal("1,000 lbs - FINAL", models.FormatPPMWeight(ppm))
 	suite.Equal("", models.FormatPPMWeight(noWtg))
+}
+
+func (suite *ModelSuite) TestCalculatePPMEntitlementNoHHGPPMLessThanMaxEntitlement() {
+	ppmWeight := int64(900)
+	totalEntitlement := unit.Pound(1000)
+	move := models.Move{
+		PersonallyProcuredMoves: models.PersonallyProcuredMoves{models.PersonallyProcuredMove{NetWeight: &ppmWeight}},
+	}
+
+	ppmRemainingEntitlement := models.CalculateRemainingPPMEntitlement(move, totalEntitlement)
+
+	suite.Equal(unit.Pound(ppmWeight), ppmRemainingEntitlement)
+}
+
+func (suite *ModelSuite) TestCalculatePPMEntitlementNoHHGPPMGreaterThanMaxEntitlement() {
+	ppmWeight := int64(1100)
+	totalEntitlement := unit.Pound(1000)
+	move := models.Move{
+		PersonallyProcuredMoves: models.PersonallyProcuredMoves{models.PersonallyProcuredMove{NetWeight: &ppmWeight}},
+	}
+
+	ppmRemainingEntitlement := models.CalculateRemainingPPMEntitlement(move, totalEntitlement)
+
+	suite.Equal(totalEntitlement, ppmRemainingEntitlement)
+}
+
+func (suite *ModelSuite) TestCalculatePPMEntitlementPPMGreaterThanRemainingEntitlement() {
+	ppmWeight := int64(1100)
+	totalEntitlement := unit.Pound(1000)
+	hhg := unit.Pound(100)
+	move := models.Move{
+		PersonallyProcuredMoves: models.PersonallyProcuredMoves{models.PersonallyProcuredMove{NetWeight: &ppmWeight}},
+		Shipments:               models.Shipments{models.Shipment{NetWeight: &hhg}},
+	}
+
+	ppmRemainingEntitlement := models.CalculateRemainingPPMEntitlement(move, totalEntitlement)
+
+	suite.Equal(totalEntitlement-hhg, ppmRemainingEntitlement)
+}
+
+func (suite *ModelSuite) TestCalculatePPMEntitlementPPMLessThanRemainingEntitlement() {
+	ppmWeight := int64(500)
+	totalEntitlement := unit.Pound(1000)
+	hhg := unit.Pound(100)
+	move := models.Move{
+		PersonallyProcuredMoves: models.PersonallyProcuredMoves{models.PersonallyProcuredMove{NetWeight: &ppmWeight}},
+		Shipments:               models.Shipments{models.Shipment{NetWeight: &hhg}},
+	}
+
+	ppmRemainingEntitlement := models.CalculateRemainingPPMEntitlement(move, totalEntitlement)
+
+	suite.Equal(unit.Pound(ppmWeight), ppmRemainingEntitlement)
 }

--- a/pkg/paperwork/shipment_summary.go
+++ b/pkg/paperwork/shipment_summary.go
@@ -257,6 +257,7 @@ type ObligationType int
 //ComputeObligations is helper function for computing the obligations section of the shipment summary worksheet
 func (sswPpmComputer *SSWPPMComputer) ComputeObligations(ssfd models.ShipmentSummaryFormData, planner route.Planner) (obligation models.Obligations, err error) {
 	firstPPM, err := sswPpmComputer.nilCheckPPM(ssfd)
+
 	if err != nil {
 		return models.Obligations{}, err
 	}
@@ -276,7 +277,7 @@ func (sswPpmComputer *SSWPPMComputer) ComputeObligations(ssfd models.ShipmentSum
 		return models.Obligations{}, errors.New("error calculating PPM max obligations")
 	}
 	actualCost, err := sswPpmComputer.ComputePPMIncludingLHDiscount(
-		unit.Pound(*firstPPM.NetWeight),
+		unit.Pound(ssfd.PPMRemainingEntitlement),
 		*firstPPM.PickupPostalCode,
 		*firstPPM.DestinationPostalCode,
 		distanceMiles,
@@ -309,9 +310,6 @@ func (sswPpmComputer *SSWPPMComputer) nilCheckPPM(ssfd models.ShipmentSummaryFor
 	}
 	if firstPPM.ActualMoveDate == nil {
 		return models.PersonallyProcuredMove{}, errors.New("missing required actual move date parameter")
-	}
-	if firstPPM.NetWeight == nil {
-		return models.PersonallyProcuredMove{}, errors.New("missing required move net weight parameter")
 	}
 	return firstPPM, nil
 }

--- a/pkg/paperwork/shipment_summary_worksheet.go
+++ b/pkg/paperwork/shipment_summary_worksheet.go
@@ -38,7 +38,7 @@ var ShipmentSummaryPage1Layout = FormLayout{
 		"MaxObligationSIT":                FormField(40, 194.75, 22, floatPtr(10), nil, stringPtr("RM")),
 		"MaxObligationGCCMaxAdvance":      FormField(40, 201, 22, floatPtr(10), nil, stringPtr("RM")),
 		"ActualObligationGCC100":          FormField(133, 182.5, 22, floatPtr(10), nil, stringPtr("RM")),
-		"ActualWeight":                    FormField(167, 182.5, 16, floatPtr(10), nil, stringPtr("RM")),
+		"PPMRemainingEntitlement":         FormField(167, 182.5, 16, floatPtr(10), nil, stringPtr("RM")),
 		"ActualObligationGCC95":           FormField(133, 188.5, 22, floatPtr(10), nil, stringPtr("RM")),
 		"ActualObligationSIT":             FormField(133, 194.75, 22, floatPtr(10), nil, stringPtr("RM")),
 		"ActualObligationAdvance":         FormField(133, 201, 22, floatPtr(10), nil, stringPtr("RM")),


### PR DESCRIPTION
## Description

In the case of a combo move (HHG + PPM), the HHG's weight is deducted from the PPMs max entitlement weight. This remaining entitlement weight is submitted to the rate engine and used to complete the Actual Obligations section of the shipment summary worksheet.

## Setup

`make server_test`

### Test in the office client
`make server_run`
`make office_client_run`

1) Log into the office app and select a move with a PPM
2) Make sure that the PPM has all the various required parameters: "Net Weight", "Pickup zip code", "Destination zip code", "Total costs". _**For this story it's best if you choose a combo move, and experiment with changing the various "Net Weight"'s on both the hhg and ppm**_
3) Click Create Paperwork -> Click Download worksheet 

### Test with cmd line tool
` go run cmd/generate_shipment_summary/main.go -move fbde058b-fed7-4612-8f48-5cf6d17c8ded-debug`

## Code Review Verification Steps
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References
* [Pivotal story](https://www.pivotaltracker.com/n/projects/2181745/stories/164282281) 

## Screenshots
![Screen Shot 2019-03-14 at 3 51 38 PM](https://user-images.githubusercontent.com/1036969/54393936-1b9c7d00-4671-11e9-8686-01b65cf5d4b5.png)
