### PR TITLE
Cg disable samesite cookie

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -779,9 +779,9 @@ workflows:
             - pre_deps_yarn
             - acceptance_tests_local
           # if testing on experimental, you can disable these tests by using the commented block below.
-          filters:
-           branches:
-             ignore: cg_disable_samesite_cookie
+          # filters:
+          #  branches:
+          #    ignore: placeholder_branch_name
 
       - integration_tests_office:
           requires:
@@ -789,9 +789,9 @@ workflows:
             - pre_deps_yarn
             - acceptance_tests_local
           # if testing on experimental, you can disable these tests by using the commented block below.
-          filters:
-            branches:
-              ignore: cg_disable_samesite_cookie
+          # filters:
+          #   branches:
+          #     ignore: placeholder_branch_name
 
       - integration_tests_tsp:
           requires:
@@ -799,9 +799,9 @@ workflows:
             - pre_deps_yarn
             - acceptance_tests_local
           # if testing on experimental, you can disable these tests by using the commented block below.
-          filters:
-            branches:
-              ignore: cg_disable_samesite_cookie
+          # filters:
+          #   branches:
+          #     ignore: placeholder_branch_name
 
       - client_test:
           requires:
@@ -845,21 +845,21 @@ workflows:
             - build_migrations
           filters:
             branches:
-              only: cg_disable_samesite_cookie
+              only: placeholder_branch_name
 
       - deploy_experimental_app:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: cg_disable_samesite_cookie
+              only: placeholder_branch_name
 
       - deploy_experimental_app_client_tls:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: cg_disable_samesite_cookie
+              only: placeholder_branch_name
 
       - check_circle_against_staging_sha:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -779,9 +779,9 @@ workflows:
             - pre_deps_yarn
             - acceptance_tests_local
           # if testing on experimental, you can disable these tests by using the commented block below.
-          # filters:
-          #  branches:
-          #    ignore: placeholder_branch_name
+          filters:
+           branches:
+             ignore: cg_disable_samesite_cookie
 
       - integration_tests_office:
           requires:
@@ -789,9 +789,9 @@ workflows:
             - pre_deps_yarn
             - acceptance_tests_local
           # if testing on experimental, you can disable these tests by using the commented block below.
-          # filters:
-          #   branches:
-          #     ignore: placeholder_branch_name
+          filters:
+            branches:
+              ignore: cg_disable_samesite_cookie
 
       - integration_tests_tsp:
           requires:
@@ -799,9 +799,9 @@ workflows:
             - pre_deps_yarn
             - acceptance_tests_local
           # if testing on experimental, you can disable these tests by using the commented block below.
-          # filters:
-          #   branches:
-          #     ignore: placeholder_branch_name
+          filters:
+            branches:
+              ignore: cg_disable_samesite_cookie
 
       - client_test:
           requires:
@@ -845,21 +845,21 @@ workflows:
             - build_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: cg_disable_samesite_cookie
 
       - deploy_experimental_app:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: cg_disable_samesite_cookie
 
       - deploy_experimental_app_client_tls:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: cg_disable_samesite_cookie
 
       - check_circle_against_staging_sha:
           requires:

--- a/pkg/auth/cookie.go
+++ b/pkg/auth/cookie.go
@@ -143,13 +143,13 @@ func WriteSessionCookie(w http.ResponseWriter, session *Session, secret string, 
 	// Delete the cookie
 	cookieName := fmt.Sprintf("%s_%s", string(session.ApplicationName), UserSessionCookieName)
 	cookie := http.Cookie{
-		Name:    cookieName,
-		Value:   "blank",
-		Path:    "/",
-		Expires: time.Unix(0, 0),
-		MaxAge:  -1,
-		// SameSite: http.SameSiteStrictMode,
-		Secure: useSecureCookie,
+		Name:     cookieName,
+		Value:    "blank",
+		Path:     "/",
+		Expires:  time.Unix(0, 0),
+		MaxAge:   -1,
+		SameSite: http.SameSiteLaxMode, // Using 'strict' breaks the use of the login.gov redirect
+		Secure:   useSecureCookie,
 	}
 
 	// unless we have a valid session

--- a/pkg/auth/cookie.go
+++ b/pkg/auth/cookie.go
@@ -143,13 +143,13 @@ func WriteSessionCookie(w http.ResponseWriter, session *Session, secret string, 
 	// Delete the cookie
 	cookieName := fmt.Sprintf("%s_%s", string(session.ApplicationName), UserSessionCookieName)
 	cookie := http.Cookie{
-		Name:     cookieName,
-		Value:    "blank",
-		Path:     "/",
-		Expires:  time.Unix(0, 0),
-		MaxAge:   -1,
-		SameSite: http.SameSiteStrictMode,
-		Secure:   useSecureCookie,
+		Name:    cookieName,
+		Value:   "blank",
+		Path:    "/",
+		Expires: time.Unix(0, 0),
+		MaxAge:  -1,
+		// SameSite: http.SameSiteStrictMode,
+		Secure: useSecureCookie,
 	}
 
 	// unless we have a valid session


### PR DESCRIPTION
## Description

Follow on to #1852 

SameSite `'strict'` mode on our session cookie doesn't work with the Login.gov redirect cycle. Using `'lax'` instead gives us better security while still allowing us to use Login.gov appropriately.

## Code Review Verification Steps

* [x] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [x] Request review from a member of a different team.

## References

* https://www.owasp.org/index.php/SameSite
* https://golang.org/src/net/http/cookie.go
* https://tools.ietf.org/html/draft-ietf-httpbis-cookie-same-site-00