### PR TITLE
Get list of local users details in single query

### DIFF
--- a/pkg/auth/authentication/devlocal.go
+++ b/pkg/auth/authentication/devlocal.go
@@ -39,29 +39,13 @@ func (h UserListHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, h.landingURL(session), http.StatusTemporaryRedirect)
 		return
 	}
-
-	// get list of users in system
-	var users []models.User
-	err := h.db.All(&users)
+	identities, err := models.FetchAllUserIdentities(h.db)
 	if err != nil {
 		h.logger.Error("Could not load list of users", zap.Error(err))
 		http.Error(w,
 			fmt.Sprintf("%s - Could not load list of users, try migrating the DB", http.StatusText(500)),
 			http.StatusInternalServerError)
 		return
-	}
-
-	// load user identities
-	var identities []*models.UserIdentity
-	for _, user := range users {
-		uuid := user.LoginGovUUID.String()
-		identity, err := models.FetchUserIdentity(h.db, uuid)
-		if err != nil {
-			h.logger.Error("Could not get user identity", zap.String("userID", uuid), zap.Error(err))
-			http.Error(w, http.StatusText(500), http.StatusInternalServerError)
-			return
-		}
-		identities = append(identities, identity)
 	}
 
 	// Grab the CSRF token from cookies set by the middleware

--- a/pkg/models/user.go
+++ b/pkg/models/user.go
@@ -151,7 +151,6 @@ func FetchAllUserIdentities(db *pop.Connection) ([]UserIdentity, error) {
 			LEFT OUTER JOIN office_users as ou on ou.user_id = users.id
 			LEFT OUTER JOIN tsp_users as tu on tu.user_id = users.id
 			LEFT OUTER JOIN dps_users as du on du.login_gov_email = users.login_gov_email
-			WHERE users.login_gov_uuid in (SELECT users.login_gov_uuid FROM users AS users)
 			ORDER BY users.created_at`
 
 	err := db.RawQuery(query).All(&identities)

--- a/pkg/models/user.go
+++ b/pkg/models/user.go
@@ -97,26 +97,26 @@ type UserIdentity struct {
 func FetchUserIdentity(db *pop.Connection, loginGovID string) (*UserIdentity, error) {
 	var identities []UserIdentity
 	query := `SELECT users.id,
-				users.login_gov_email as email,
-				users.disabled as disabled,
-				sm.id as sm_id,
-				sm.first_name as sm_fname,
-				sm.last_name as sm_lname,
-				sm.middle_name as sm_middle,
-				ou.id as ou_id,
-				ou.first_name as ou_fname,
-				ou.last_name as ou_lname,
-				ou.middle_initials as ou_middle,
-				tu.id as tu_id,
-				tu.first_name as tu_fname,
-				tu.last_name as tu_lname,
-				tu.middle_initials as tu_middle,
-				du.id as du_id
+				users.login_gov_email AS email,
+				users.disabled AS disabled,
+				sm.id AS sm_id,
+				sm.first_name AS sm_fname,
+				sm.last_name AS sm_lname,
+				sm.middle_name AS sm_middle,
+				ou.id AS ou_id,
+				ou.first_name AS ou_fname,
+				ou.last_name AS ou_lname,
+				ou.middle_initials AS ou_middle,
+				tu.id AS tu_id,
+				tu.first_name AS tu_fname,
+				tu.last_name AS tu_lname,
+				tu.middle_initials AS tu_middle,
+				du.id AS du_id
 			FROM users
-			LEFT OUTER JOIN service_members as sm on sm.user_id = users.id
-			LEFT OUTER JOIN office_users as ou on ou.user_id = users.id
-			LEFT OUTER JOIN tsp_users as tu on tu.user_id = users.id
-			LEFT OUTER JOIN dps_users as du on du.login_gov_email = users.login_gov_email
+			LEFT OUTER JOIN service_members AS sm on sm.user_id = users.id
+			LEFT OUTER JOIN office_users AS ou on ou.user_id = users.id
+			LEFT OUTER JOIN tsp_users AS tu on tu.user_id = users.id
+			LEFT OUTER JOIN dps_users AS du on du.login_gov_email = users.login_gov_email
 			WHERE users.login_gov_uuid  = $1`
 	err := db.RawQuery(query, loginGovID).All(&identities)
 	if err != nil {
@@ -131,26 +131,26 @@ func FetchUserIdentity(db *pop.Connection, loginGovID string) (*UserIdentity, er
 func FetchAllUserIdentities(db *pop.Connection) ([]UserIdentity, error) {
 	var identities []UserIdentity
 	query := `SELECT users.id,
-				users.login_gov_email as email,
-				users.disabled as disabled,
-				sm.id as sm_id,
-				sm.first_name as sm_fname,
-				sm.last_name as sm_lname,
-				sm.middle_name as sm_middle,
-				ou.id as ou_id,
-				ou.first_name as ou_fname,
-				ou.last_name as ou_lname,
-				ou.middle_initials as ou_middle,
-				tu.id as tu_id,
-				tu.first_name as tu_fname,
-				tu.last_name as tu_lname,
-				tu.middle_initials as tu_middle,
-				du.id as du_id
+				users.login_gov_email AS email,
+				users.disabled AS disabled,
+				sm.id AS sm_id,
+				sm.first_name AS sm_fname,
+				sm.last_name AS sm_lname,
+				sm.middle_name AS sm_middle,
+				ou.id AS ou_id,
+				ou.first_name AS ou_fname,
+				ou.last_name AS ou_lname,
+				ou.middle_initials AS ou_middle,
+				tu.id AS tu_id,
+				tu.first_name AS tu_fname,
+				tu.last_name AS tu_lname,
+				tu.middle_initials AS tu_middle,
+				du.id AS du_id
 			FROM users
-			LEFT OUTER JOIN service_members as sm on sm.user_id = users.id
-			LEFT OUTER JOIN office_users as ou on ou.user_id = users.id
-			LEFT OUTER JOIN tsp_users as tu on tu.user_id = users.id
-			LEFT OUTER JOIN dps_users as du on du.login_gov_email = users.login_gov_email
+			LEFT OUTER JOIN service_members AS sm on sm.user_id = users.id
+			LEFT OUTER JOIN office_users AS ou on ou.user_id = users.id
+			LEFT OUTER JOIN tsp_users AS tu on tu.user_id = users.id
+			LEFT OUTER JOIN dps_users AS du on du.login_gov_email = users.login_gov_email
 			ORDER BY users.created_at`
 
 	err := db.RawQuery(query).All(&identities)

--- a/pkg/models/user_test.go
+++ b/pkg/models/user_test.go
@@ -131,3 +131,13 @@ func (suite *ModelSuite) TestFetchUserIdentity() {
 	suite.Nil(identity.OfficeUserID)
 	suite.Equal(danielle.ID, *identity.TspUserID)
 }
+
+func (suite *ModelSuite) TestFetchAllUserIdentities() {
+	testdatagen.MakeDefaultUser(suite.DB())
+	testdatagen.MakeDefaultServiceMember(suite.DB())
+	identities, err := FetchAllUserIdentities(suite.DB())
+
+	suite.Nil(err)
+	suite.NotEmpty(identities)
+	suite.Equal(len(identities), 2)
+}

--- a/pkg/models/user_test.go
+++ b/pkg/models/user_test.go
@@ -135,9 +135,27 @@ func (suite *ModelSuite) TestFetchUserIdentity() {
 func (suite *ModelSuite) TestFetchAllUserIdentities() {
 	testdatagen.MakeDefaultUser(suite.DB())
 	testdatagen.MakeDefaultServiceMember(suite.DB())
-	identities, err := FetchAllUserIdentities(suite.DB())
+	testdatagen.MakeDefaultOfficeUser(suite.DB())
+	testdatagen.MakeDefaultTspUser(suite.DB())
 
+	identities, err := FetchAllUserIdentities(suite.DB())
 	suite.Nil(err)
 	suite.NotEmpty(identities)
-	suite.Equal(len(identities), 2)
+	suite.Equal(len(identities), 4)
+
+	suite.Nil(identities[0].ServiceMemberID)
+	suite.Nil(identities[0].OfficeUserID)
+	suite.Nil(identities[0].TspUserID)
+
+	suite.NotNil(identities[1].ServiceMemberID)
+	suite.Nil(identities[1].OfficeUserID)
+	suite.Nil(identities[1].TspUserID)
+
+	suite.Nil(identities[2].ServiceMemberID)
+	suite.NotNil(identities[2].OfficeUserID)
+	suite.Nil(identities[2].TspUserID)
+
+	suite.Nil(identities[3].ServiceMemberID)
+	suite.Nil(identities[3].OfficeUserID)
+	suite.NotNil(identities[3].TspUserID)
 }


### PR DESCRIPTION
## Description

Simplify the way we get the list of local users for the sign in process. 
The existing way selected a list of users, and then looped thru the `userIds` and selected `userDetails` but did one select for each userId found in the origional select.

This gets the `userDetails` in one select statement...

## Reviewer Notes

Not sure if this speeds up our tests... The main bottleneck is after logging in when loading the index page.

## Setup

add code to show the queries in `cmd/webserver/main.go` in the `main()` function: `pop.Debug = true`
run single e2e test and watch logs... It should only query the db once for the users when logging in.

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## Screenshots

### the current way: get a list of users and then run a select for each user...
<img width="871" alt="Screen Shot 2019-03-15 at 8 59 57 AM" src="https://user-images.githubusercontent.com/3099491/54437822-81394980-4703-11e9-9f0a-85e21267f0c2.png">

### this change: run a select w/ a sub query that returns all the users data in 1 trip to the db
<img width="957" alt="Screen Shot 2019-03-15 at 9 21 43 AM" src="https://user-images.githubusercontent.com/3099491/54438020-dffec300-4703-11e9-8d97-847d9ebc40e7.png">

