### PR TITLE
ResponseForErrors should use Info logging per the logging guidelines.

### DIFF
--- a/pkg/handlers/errors.go
+++ b/pkg/handlers/errors.go
@@ -81,31 +81,31 @@ func responseForBaseError(logger Logger, err error) middleware.Responder {
 
 	switch errors.Cause(err) {
 	case models.ErrFetchNotFound:
-		skipLogger.Debug("not found", zap.Error(err))
+		skipLogger.Info("not found", zap.Error(err))
 		return newErrResponse(http.StatusNotFound, err)
 	case models.ErrFetchForbidden:
-		skipLogger.Debug("forbidden", zap.Error(err))
+		skipLogger.Info("forbidden", zap.Error(err))
 		return newErrResponse(http.StatusForbidden, err)
 	case models.ErrWriteForbidden:
-		skipLogger.Debug("forbidden", zap.Error(err))
+		skipLogger.Info("forbidden", zap.Error(err))
 		return newErrResponse(http.StatusForbidden, err)
 	case models.ErrWriteConflict:
-		skipLogger.Debug("conflict", zap.Error(err))
+		skipLogger.Info("conflict", zap.Error(err))
 		return newErrResponse(http.StatusConflict, err)
 	case models.ErrUserUnauthorized:
-		skipLogger.Debug("unauthorized", zap.Error(err))
+		skipLogger.Info("unauthorized", zap.Error(err))
 		return newErrResponse(http.StatusUnauthorized, err)
 	case uploaderpkg.ErrZeroLengthFile:
-		skipLogger.Debug("uploaded zero length file", zap.Error(err))
+		skipLogger.Info("uploaded zero length file", zap.Error(err))
 		return newErrResponse(http.StatusBadRequest, err)
 	case models.ErrInvalidPatchGate:
-		skipLogger.Debug("invalid patch gate", zap.Error(err))
+		skipLogger.Info("invalid patch gate", zap.Error(err))
 		return newErrResponse(http.StatusBadRequest, err)
 	case models.ErrInvalidTransition:
-		skipLogger.Debug("invalid transition", zap.Error(err))
+		skipLogger.Info("invalid transition", zap.Error(err))
 		return newErrResponse(http.StatusBadRequest, err)
 	case models.ErrDestroyForbidden:
-		skipLogger.Debug("invalid deletion", zap.Error(err))
+		skipLogger.Info("invalid deletion", zap.Error(err))
 		return newErrResponse(http.StatusBadRequest, err)
 	default:
 		skipLogger.Error("unexpected error", zap.Error(err))


### PR DESCRIPTION
## Description

These errors should be at the `Info` level instead of the `Debug` level per our own logging guidelines: https://github.com/transcom/mymove/blob/master/docs/backend.md#logging-levels


## Code Review Verification Steps

* [x] Code follows the guidelines for [Logging](./docs/backend.md#logging)
* [x] Request review from a member of a different team.

## References

* https://github.com/transcom/mymove/blob/master/docs/backend.md#logging-levels