### PR TITLE
35A legacy requests are edited as legacy requests.

### DIFF
--- a/src/shared/PreApprovalRequest/DetailsHelper.js
+++ b/src/shared/PreApprovalRequest/DetailsHelper.js
@@ -8,12 +8,11 @@ import { DefaultDetails } from './DefaultDetails';
 
 export function getFormComponent(code, robustAccessorial, initialValues) {
   code = code ? code.toLowerCase() : '';
-  const hasCrateDimensions = get(initialValues, 'crate_dimensions', false);
   const isNew = !initialValues;
   if (code.startsWith('105b') || code.startsWith('105e')) {
-    if (isNew || hasCrateDimensions) return Code105Form;
+    if (isNew || get(initialValues, 'crate_dimensions', false)) return Code105Form;
   } else if (robustAccessorial && code.startsWith('35')) {
-    return Code35Form;
+    if (isNew || get(initialValues, 'estimate_amount_cents')) return Code35Form;
   } else if (robustAccessorial && code.startsWith('226')) {
     return Code226Form;
   }

--- a/src/shared/PreApprovalRequest/DetailsHelper.test.js
+++ b/src/shared/PreApprovalRequest/DetailsHelper.test.js
@@ -84,7 +84,7 @@ describe('testing getFormComponent()', () => {
   describe('returns 35A form component with feature flag on', () => {
     featureFlag = true;
 
-    let FormComponent = getFormComponent('35A', featureFlag, initialValuesWithCrateDimensions);
+    let FormComponent = getFormComponent('35A', featureFlag, { estimate_amount_cents: true });
     it('for code 35A', () => {
       expect(FormComponent).toBe(Code35Form);
     });


### PR DESCRIPTION
## Description

35A legacy preapproval requests will be edited with the simple edit form (that shows base quantity). 

## Setup

With the feature flag false, create a 35A PAR. Change the feature flag to true. Click edit on the PAR. It should show the legacy form. 

## Code Review Verification Steps
* [ ] There are no aXe warnings for UI.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/163438471) for this change
