### PR TITLE
Sets base quantity if ActualAmountCents is set in 35A PAR.

### DIFF
--- a/pkg/models/shipment.go
+++ b/pkg/models/shipment.go
@@ -687,13 +687,17 @@ func upsertItemCode35ADependency(db *pop.Connection, baseParams *BaseShipmentLin
 	shipmentLineItem.EstimateAmountCents = additionalParams.EstimateAmountCents
 	shipmentLineItem.ActualAmountCents = additionalParams.ActualAmountCents
 
-	// ToDo: Another story to calculate base quantity
-	// if Quantity1 is nil then set it to 0
-	if baseParams.Quantity1 == nil {
+	if shipmentLineItem.ActualAmountCents != nil {
+		if *shipmentLineItem.ActualAmountCents <= *shipmentLineItem.EstimateAmountCents {
+			shipmentLineItem.Quantity1 = unit.BaseQuantityFromCents(*shipmentLineItem.ActualAmountCents)
+		} else {
+			shipmentLineItem.Quantity1 = unit.BaseQuantityFromCents(*shipmentLineItem.EstimateAmountCents)
+		}
+	} else {
+		// If ActualAmountCents is unset, set base quantity to 0.
 		quantity1 := unit.BaseQuantityFromInt(0)
 		shipmentLineItem.Quantity1 = quantity1
 	}
-
 	return responseVErrors, responseError
 }
 

--- a/pkg/models/shipment_test.go
+++ b/pkg/models/shipment_test.go
@@ -413,13 +413,12 @@ func (suite *ModelSuite) TestCreateShipmentLineItemCode35A() {
 		baseParams, additionalParams)
 
 	if suite.noValidationErrors(verrs, err) {
-		// ToDo: will need to update this when we calculate base quantity
-		suite.Equal(0, shipmentLineItem.Quantity1.ToUnitInt())
 		suite.Equal(acc35A.ID.String(), shipmentLineItem.Tariff400ngItem.ID.String())
 		suite.Equal(desc, *shipmentLineItem.Description)
 		suite.Equal(reas, *shipmentLineItem.Reason)
 		suite.Equal(estAmt, *shipmentLineItem.EstimateAmountCents)
 		suite.Equal(actAmt, *shipmentLineItem.ActualAmountCents)
+		suite.Equal(unit.BaseQuantity(100000), shipmentLineItem.Quantity1)
 	}
 }
 
@@ -594,7 +593,7 @@ func (suite *ModelSuite) TestUpdateShipmentLineItemCode35A() {
 	desc = "updated description"
 	reas = "updated reason"
 	estAmt = unit.Cents(2000)
-	actAmt = unit.Cents(2000)
+	actAmt = unit.Cents(1500)
 	additionalParams := AdditionalShipmentLineItemParams{
 		Description:         &desc,
 		Reason:              &reas,
@@ -605,8 +604,7 @@ func (suite *ModelSuite) TestUpdateShipmentLineItemCode35A() {
 	verrs, err := shipment.UpdateShipmentLineItem(suite.DB(),
 		baseParams, additionalParams, &lineItem)
 	if suite.noValidationErrors(verrs, err) {
-		// ToDo: will need to update this when we calculate base quantity
-		suite.Equal(0, lineItem.Quantity1.ToUnitInt())
+		suite.Equal(unit.BaseQuantity(150000), lineItem.Quantity1)
 		suite.Equal(acc35A.ID.String(), lineItem.Tariff400ngItem.ID.String())
 		suite.Equal(desc, *lineItem.Description)
 		suite.Equal(reas, *lineItem.Reason)

--- a/pkg/unit/base_quantity.go
+++ b/pkg/unit/base_quantity.go
@@ -35,6 +35,11 @@ func BaseQuantityFromThousandthInches(ti ThousandthInches) BaseQuantity {
 	return BaseQuantity(ti * 10)
 }
 
+// BaseQuantityFromCents creates a BaseQuantity for a provided Cents
+func BaseQuantityFromCents(c Cents) BaseQuantity {
+	return BaseQuantity(c * 100)
+}
+
 // String returns the value of self as string
 func (bq BaseQuantity) String() string {
 	return strconv.Itoa(int(bq))


### PR DESCRIPTION
## Description

If "Actual amount" is set when a 35A PAR is saved, the appropriate base quantity is set in the database.

## Code Review Verification Steps

* [ ] This works in IE.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/163487161) for this change
