### PR TITLE
Preapproval form uses selector not get for form values

### DIFF
--- a/src/shared/PreApprovalRequest/PreApprovalForm.jsx
+++ b/src/shared/PreApprovalRequest/PreApprovalForm.jsx
@@ -177,7 +177,7 @@ const selector = formValueSelector(formName);
 
 function mapStateToProps(state) {
   return {
-    tariff400ng_item_code: get(state, 'form.preapproval_request_form.values.tariff400ng_item.code'),
+    tariff400ng_item_code: selector(state, 'tariff400ng_item.code'),
     ship_line_item_schema: get(state, 'swaggerPublic.spec.definitions.ShipmentLineItem', {}),
     filteredLocations: selectLocationFromTariff400ngItem(state, selector(state, 'tariff400ng_item')),
     selectedLocation: selector(state, 'location'),


### PR DESCRIPTION
## Description

Quick code cleanup... Use `selector` vs `get` to get form value.

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?
