### PR TITLE
Storage Panel Updates

### DIFF
--- a/cypress/support/storagePanel.js
+++ b/cypress/support/storagePanel.js
@@ -25,7 +25,7 @@ export function userSavesStorageDetails() {
 
   cy.patientReload();
 
-  cy.get('div.panel-field.total_sit_cost').contains('600.00');
+  cy.get('div.panel-field.total_sit_cost').contains('$600.00');
   cy.get('div.panel-field.days_in_storage').contains('60');
 }
 
@@ -52,7 +52,6 @@ export function userCancelsStorageDetails() {
     .contains('Cancel')
     .click();
 
-  cy.get('.total_sit_cost .field-value').should('be.empty');
-
-  cy.get('.days_in_storage .field-value').should('be.empty');
+  cy.get('.total_sit_cost .field-value').contains('$0');
+  cy.get('.days_in_storage .field-value').contains('0');
 }

--- a/src/scenes/Office/Ppm/StoragePanel.js
+++ b/src/scenes/Office/Ppm/StoragePanel.js
@@ -11,18 +11,34 @@ import { formatCents } from '../../../shared/formatters';
 import { convertDollarsToCents } from '../../../shared/utils';
 
 const StorageDisplay = props => {
+  let cost = props.ppm && props.ppm.total_sit_cost ? formatCents(props.ppm.total_sit_cost) : 0;
+  let days = props.ppm && props.ppm.days_in_storage ? props.ppm.days_in_storage : 0;
+
   const fieldProps = {
-    schema: props.ppmSchema,
+    schema: {
+      properties: {
+        days_in_storage: {
+          maximum: 90,
+          minimum: 0,
+          title: 'How many days do you plan to put your stuff in storage?',
+          type: 'integer',
+          'x-nullable': true,
+        },
+        total_sit_cost: {
+          type: 'string',
+        },
+      },
+    },
     values: {
-      total_sit_cost: formatCents(props.ppm.total_sit_cost),
-      days_in_storage: props.ppm.days_in_storage,
+      total_sit_cost: `$${cost}`,
+      days_in_storage: `${days}`,
     },
   };
 
   return (
     <div className="editable-panel-column">
-      <PanelSwaggerField fieldName="total_sit_cost" title="Total cost" {...fieldProps} />
-      <PanelSwaggerField fieldName="days_in_storage" title="Total days in storage" {...fieldProps} />
+      <PanelSwaggerField fieldName="total_sit_cost" title="Total storage cost" {...fieldProps} />
+      <PanelSwaggerField fieldName="days_in_storage" title="Days in storage" {...fieldProps} />
     </div>
   );
 };
@@ -32,11 +48,16 @@ const StorageEdit = props => {
 
   return (
     <div className="editable-panel-column">
-      <SwaggerField className="short-field storage" fieldName="total_sit_cost" title="Total cost" swagger={schema} />
+      <SwaggerField
+        className="short-field storage"
+        fieldName="total_sit_cost"
+        title="Total storage cost"
+        swagger={schema}
+      />
       <SwaggerField
         className="short-field storage"
         fieldName="days_in_storage"
-        title="Total days in storage"
+        title="Days in storage"
         swagger={schema}
       />
     </div>
@@ -59,7 +80,7 @@ function mapStateToProps(state, props) {
     // reduxForm
     formValues,
     initialValues: {
-      total_sit_cost: ppm.total_sit_cost,
+      total_sit_cost: formatCents(ppm.total_sit_cost),
       days_in_storage: ppm.days_in_storage,
     },
 

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -457,6 +457,7 @@ definitions:
         x-nullable: true
       total_sit_cost:
         type: integer
+        format: cents
         title: Total cost for the planned SIT duration
         x-nullable: true
       sit_max:


### PR DESCRIPTION
## Description

This PR addresses some of the issues found in the original implementation of the Storage Panel. 
_(From Jim)_
1. The default values aren't showing up (it should show $0 for the cost and 0 for the days). This was on staging on a recent move.
1. There isn't a $ shown for the storage cost.
1. I saw the same issue that @mattkrump described above. It looks like we're displaying the raw cents value in the input instead of converting it to dollars.
1. Not sure if this is a problem, but the labels in the UI don't match those in the story.

See [this story](https://www.pivotaltracker.com/story/show/163713591) for additional reference.

## Reviewer Notes

Fixes addressed as noted above. 

Desired Behavior _(from Jenny, SBD)_:
"i’d expect for the office to be able to type either 20 or 20.00 for $20. we shouldn’t require the user to type a decimal. a decimal should be added upon save, if the user didn’t type one themselves (like 20 becomes 20.00 on save, but we don’t make any changes if they type 20.00)."

## Setup

1. Run the API - `make server_run`
2. Run migrations - `make db_dev_migrate`
3. Run the office app - `make office_client_run`
4. Choose any PPM in the queue at `http://officelocal:3000/queues/ppm`
5. Edit the chosen PPM at `http://officelocal:3000/queues/new/moves/:moveId/basics`

* Update the total storage cost and the days in storage fields in the `Storage` panel by clicking save
* Ensure that the Storage Panel that is non-editable displays the entered values for total storage cost and days in storage

## Code Review Verification Steps

* [x] There are no aXe warnings for UI.
* [x] This works in IE.
* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/163713591) for this change

## Screenshots

### Display Storage Panel
<img width="1103" alt="Screen Shot 2019-03-18 at 2 25 25 PM" src="https://user-images.githubusercontent.com/7574207/54553938-b1921980-4989-11e9-8161-d92da102226f.png">

### Edit Storage Panel
<img width="1099" alt="Screen Shot 2019-03-18 at 2 25 18 PM" src="https://user-images.githubusercontent.com/7574207/54553949-b525a080-4989-11e9-9896-13b8808ee458.png">

### Default Storage Panel
<img width="1111" alt="Screen Shot 2019-03-18 at 2 24 55 PM" src="https://user-images.githubusercontent.com/7574207/54553960-ba82eb00-4989-11e9-94ab-d0459c41f2ca.png">


