### PR TITLE
ComboButton Add Approve Basics 

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,6 +4,7 @@
   "rules": {
     "no-debugger": "warn",
     "jsx-a11y/anchor-is-valid": "off",
-    "react/jsx-no-target-blank": "off"
+    "react/jsx-no-target-blank": "off",
+    "react/jsx-curly-brace-presence": ["warn", "never"]
   }
 }

--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -388,20 +388,18 @@ class MoveInfo extends Component {
                 <ToolTip
                   disabled={ordersComplete}
                   textStyle="tooltiptext-large"
-                  toolTipText={
-                    'Some information about the move is missing or contains errors. Please fix these problems before approving.'
-                  }
+                  toolTipText="Some information about the move is missing or contains errors. Please fix these problems before approving."
                 >
                   {moveInfoComboButton && (
-                    <ComboButton buttonText={'Approve'} disabled={!ordersComplete}>
+                    <ComboButton buttonText="Approve" disabled={!ordersComplete}>
                       <DropDown>
                         <DropDownItem
-                          value={'Approve Basics'}
+                          value="Approve Basics"
                           disabled={moveApproved || !ordersComplete}
                           onClick={this.approveBasics}
                         />
-                        {(isPPM || isHHGPPM) && <DropDownItem value={'Approve PPM'} disabled={true} />}
-                        {(isHHG || isHHGPPM) && <DropDownItem value={'Approve HHG'} disabled={true} />}
+                        {(isPPM || isHHGPPM) && <DropDownItem value="Approve PPM" disabled={true} />}
+                        {(isHHG || isHHGPPM) && <DropDownItem value="Approve HHG" disabled={true} />}
                       </DropDown>
                     </ComboButton>
                   )}

--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -395,7 +395,11 @@ class MoveInfo extends Component {
                   {moveInfoComboButton && (
                     <ComboButton buttonText={'Approve'} disabled={!ordersComplete}>
                       <DropDown>
-                        <DropDownItem value={'Approve Basics'} disabled={moveApproved || !ordersComplete} />
+                        <DropDownItem
+                          value={'Approve Basics'}
+                          disabled={moveApproved || !ordersComplete}
+                          onClick={this.approveBasics}
+                        />
                         {(isPPM || isHHGPPM) && <DropDownItem value={'Approve PPM'} disabled={true} />}
                         {(isHHG || isHHGPPM) && <DropDownItem value={'Approve HHG'} disabled={true} />}
                       </DropDown>

--- a/src/scenes/Office/Ppm/PaymentsPanel.jsx
+++ b/src/scenes/Office/Ppm/PaymentsPanel.jsx
@@ -85,7 +85,7 @@ class PaymentsTable extends Component {
       } else {
         return (
           <div onClick={this.approveReimbursement}>
-            <ToolTip disabled={false} text={'Approve'} textStyle={'tooltiptext-small'}>
+            <ToolTip disabled={false} text="Approve" textStyle="tooltiptext-small">
               <FontAwesomeIcon aria-hidden className="icon approval-ready" icon={faCheck} title="Approve" />
             </ToolTip>
           </div>
@@ -96,7 +96,7 @@ class PaymentsTable extends Component {
         <ToolTip
           disabled={false}
           text={"Can't approve payment until shipment is approved"}
-          textStyle={'tooltiptext-medium'}
+          textStyle="tooltiptext-medium"
         >
           <FontAwesomeIcon
             aria-hidden

--- a/src/scenes/StyleGuide/index.js
+++ b/src/scenes/StyleGuide/index.js
@@ -9,15 +9,15 @@ const StyleGuide = () => (
     <hr />
     <h2>This is a H2</h2>
     <h3>This is a H3</h3>
-    <ComboButton buttonText={'Approve'} disabled={false}>
+    <ComboButton buttonText="Approve" disabled={false}>
       <DropDown>
-        <DropDownItem disabled={false} value={'Enabled Menu Item'} />
-        <DropDownItem disabled={true} value={'Disabled Menu Item'} />
+        <DropDownItem disabled={false} value="Enabled Menu Item" />
+        <DropDownItem disabled={true} value="Disabled Menu Item" />
       </DropDown>
     </ComboButton>
     <span style={{ 'margin-left': '30px' }}>
-      <ToolTip textStyle={'tooltiptext-medium'} disabled={false} toolTipText={'Tooltip text'}>
-        <ComboButton disabled={true} buttonText={'Approve'} />
+      <ToolTip textStyle="tooltiptext-medium" disabled={false} toolTipText="Tooltip text">
+        <ComboButton disabled={true} buttonText="Approve" />
       </ToolTip>
     </span>
   </div>

--- a/src/shared/ComboButton/dropdown.css
+++ b/src/shared/ComboButton/dropdown.css
@@ -8,7 +8,7 @@
   display: block;
 }
 
-.dropdown > p {
+.dropdown > div {
   padding: 0.5em 1em;
   color: #0071bc;
   font-size: 0.85em;
@@ -18,16 +18,16 @@
   margin-top: 0;
 }
 
-.dropdown > p:hover {
+.dropdown > div:hover {
   color: white;
   background-color: #0071bc;
 }
 
-.dropdown > p.disabled {
+.dropdown > div.disabled {
   color: #aeb0b5;
 }
 
-.dropdown > p.disabled:hover {
+.dropdown > div.disabled:hover {
   color: #aeb0b5;
   background-color: white;
 }

--- a/src/shared/ComboButton/dropdown.jsx
+++ b/src/shared/ComboButton/dropdown.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import './dropdown.css';
@@ -7,21 +7,13 @@ export const DropDown = props => {
   return <div className="dropdown">{props.children}</div>;
 };
 
-export class DropDownItem extends Component {
-  handleClick = () => {
-    if (!this.props.disabled) {
-      this.props.onClick();
-    }
-  };
-
-  render() {
-    const liClasses = props => classNames({ disabled: props.disabled });
-    return (
-      <p className={liClasses(this.props)} onClick={this.handleClick}>
-        {this.props.value}
-      </p>
-    );
-  }
+export function DropDownItem(props) {
+  const dropdownItemClasses = classNames({ disabled: props.disabled });
+  return (
+    <div className={dropdownItemClasses} onClick={props.disabled ? null : props.onClick}>
+      {props.value}
+    </div>
+  );
 }
 
 DropDown.propTypes = {

--- a/src/shared/ComboButton/dropdown.jsx
+++ b/src/shared/ComboButton/dropdown.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import './dropdown.css';
@@ -7,16 +7,29 @@ export const DropDown = props => {
   return <div className="dropdown">{props.children}</div>;
 };
 
-export const DropDownItem = props => {
-  const liClasses = props => classNames({ disabled: props.disabled });
-  return <p className={liClasses(props)}>{props.value}</p>;
-};
+export class DropDownItem extends Component {
+  handleClick = () => {
+    if (!this.props.disabled) {
+      this.props.onClick();
+    }
+  };
+
+  render() {
+    const liClasses = props => classNames({ disabled: props.disabled });
+    return (
+      <p className={liClasses(this.props)} onClick={this.handleClick}>
+        {this.props.value}
+      </p>
+    );
+  }
+}
 
 DropDown.propTypes = {
-  children: PropTypes.arrayOf(DropDownItem),
+  children: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),
 };
 
 DropDownItem.propTypes = {
+  onClick: PropTypes.func,
   value: PropTypes.string,
   disabled: PropTypes.bool,
 };

--- a/src/shared/ComboButton/dropdown.test.js
+++ b/src/shared/ComboButton/dropdown.test.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { DropDownItem } from './dropdown';
+
+describe('DropdownItems', () => {
+  describe('DropDownItem is enabled', () => {
+    it('when clicked onClick is called', () => {
+      const onClick = jest.fn();
+      const wrapper = shallow(<DropDownItem disabled={false} onClick={onClick} />);
+
+      const dropDownItem = wrapper.find('p');
+      dropDownItem.simulate('click');
+
+      expect(onClick).toHaveBeenCalled();
+    });
+  });
+  describe('DropDownItem is disabled', () => {
+    it('when clicked onClick is not called', () => {
+      const onClick = jest.fn();
+      const wrapper = shallow(<DropDownItem disabled={true} onClick={onClick} />);
+
+      const dropDownItem = wrapper.find('p');
+      dropDownItem.simulate('click');
+
+      expect(onClick).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/shared/ComboButton/dropdown.test.js
+++ b/src/shared/ComboButton/dropdown.test.js
@@ -8,7 +8,7 @@ describe('DropdownItems', () => {
       const onClick = jest.fn();
       const wrapper = shallow(<DropDownItem disabled={false} onClick={onClick} />);
 
-      const dropDownItem = wrapper.find('p');
+      const dropDownItem = wrapper.find('div');
       dropDownItem.simulate('click');
 
       expect(onClick).toHaveBeenCalled();
@@ -19,7 +19,7 @@ describe('DropdownItems', () => {
       const onClick = jest.fn();
       const wrapper = shallow(<DropDownItem disabled={true} onClick={onClick} />);
 
-      const dropDownItem = wrapper.find('p');
+      const dropDownItem = wrapper.find('div');
       dropDownItem.simulate('click');
 
       expect(onClick).not.toHaveBeenCalled();

--- a/src/shared/Invoice/InvoicePanel.test.jsx
+++ b/src/shared/Invoice/InvoicePanel.test.jsx
@@ -12,7 +12,7 @@ describe('InvoicePanel tests', () => {
       <InvoicePanel
         unbilledShipmentLineItems={shipmentLineItems}
         lineItemsTotal={0}
-        shipmentStatus={'DELIVERED'}
+        shipmentStatus="DELIVERED"
         createInvoiceStatus={{
           error: null,
           isLoading: false,
@@ -49,7 +49,7 @@ describe('InvoicePanel tests', () => {
       <InvoicePanel
         unbilledShipmentLineItems={shipmentLineItems}
         lineItemsTotal={0}
-        shipmentStatus={'DELIVERED'}
+        shipmentStatus="DELIVERED"
         isShipmentDelivered={true}
         createInvoiceStatus={{
           error: null,
@@ -90,7 +90,7 @@ describe('InvoicePanel tests', () => {
       <InvoicePanel
         unbilledShipmentLineItems={shipmentLineItems}
         lineItemsTotal={0}
-        shipmentStatus={'DELIVERED'}
+        shipmentStatus="DELIVERED"
         isShipmentDelivered={true}
         createInvoiceStatus={{
           error: null,

--- a/src/shared/JsonSchemaForm/DimensionsField.test.js
+++ b/src/shared/JsonSchemaForm/DimensionsField.test.js
@@ -6,13 +6,11 @@ import React from 'react';
 describe('given a dimension input', () => {
   it('should render without crashing', () => {});
   let swagger = { a: 'test', b: 2 };
-  let wrapper = shallow(<DimensionsField isRequired={true} fieldName={'test'} labelText={'test'} swagger={swagger} />);
+  let wrapper = shallow(<DimensionsField isRequired={true} fieldName="test" labelText="test" swagger={swagger} />);
   expect(wrapper.find('.dimensions-form').length).toBe(1);
 
   it('should render SwaggerField with a required prop', () => {
-    let wrapper = shallow(
-      <DimensionsField isRequired={true} fieldName={'test'} labelText={'test'} swagger={swagger} />,
-    );
+    let wrapper = shallow(<DimensionsField isRequired={true} fieldName="test" labelText="test" swagger={swagger} />);
     // prettier-ignore
     expect(
       wrapper

--- a/src/shared/PreApprovalRequest/PreApprovalForm.test.js
+++ b/src/shared/PreApprovalRequest/PreApprovalForm.test.js
@@ -203,7 +203,7 @@ describe('PreApprovalForm tests', () => {
             tariff400ngItems={tariff400ng_items}
             onSubmit={submit}
             filteredLocations={['ORIGIN']}
-            tariff400ng_item_code={'105B'}
+            tariff400ng_item_code="105B"
             tariff400ngItem={simple105TariffItem}
             initialValues={{ crate_dimensions: true }}
           />

--- a/src/shared/PreApprovalRequest/PreApprovalPanel.jsx
+++ b/src/shared/PreApprovalRequest/PreApprovalPanel.jsx
@@ -54,7 +54,7 @@ export class PreApprovalPanel extends Component {
   render() {
     return (
       <div className="pre-approval-panel">
-        <BasicPanel title={'Pre-Approval Requests'}>
+        <BasicPanel title="Pre-Approval Requests">
           {this.state.error && (
             <Alert type="error" heading="Oops, something went wrong!" onRemove={this.closeError}>
               <span className="warning--header">Please refresh the page and try again.</span>

--- a/src/shared/StorageInTransit/StorageInTransitForm.jsx
+++ b/src/shared/StorageInTransit/StorageInTransitForm.jsx
@@ -18,7 +18,7 @@ export class StorageInTransitForm extends Component {
           <div className="editable-panel-column">
             <SwaggerField
               fieldName="location"
-              title={'SIT location'}
+              title="SIT location"
               swagger={storageInTransitSchema}
               className="storage-in-transit-location"
               required
@@ -39,12 +39,7 @@ export class StorageInTransitForm extends Component {
               className="storage-in-transit-warehouse-id"
               required
             />
-            <SwaggerField
-              title={'Warehouse name'}
-              fieldName="warehouse_name"
-              swagger={storageInTransitSchema}
-              required
-            />
+            <SwaggerField title="Warehouse name" fieldName="warehouse_name" swagger={storageInTransitSchema} required />
             <SwaggerField fieldName="warehouse_phone" swagger={storageInTransitSchema} />
             <SwaggerField fieldName="warehouse_email" swagger={storageInTransitSchema} />
           </div>

--- a/src/shared/StorageInTransit/StorageInTransitPanel.jsx
+++ b/src/shared/StorageInTransit/StorageInTransitPanel.jsx
@@ -60,7 +60,7 @@ export class StorageInTransitPanel extends Component {
                     {storageInTransit.location.charAt(0) + storageInTransit.location.slice(1).toLowerCase()} SIT
                     <span className="unbold">
                       {' '}
-                      <span id={'sit-status-text'}>Status:</span>{' '}
+                      <span id="sit-status-text">Status:</span>{' '}
                       <FontAwesomeIcon className="icon icon-grey" icon={faClock} />
                     </span>
                     <span>


### PR DESCRIPTION
## Description

ComboButton allow for office user to approve basic information for a move.

## Reviewer Notes

Select a move for which the Basics information has been completed. The "Approve Basics" section of the menu should be active. When you click the Menu the Basics tab should now be approved.

## Setup

```sh
make client_test

make server_run
make office_client_run
```

## Code Review Verification Steps
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/n/projects/2181745/stories/163307132)

## Screenshots

![Screen Shot 2019-03-18 at 2 17 06 PM](https://user-images.githubusercontent.com/1036969/54560703-8eb33580-4988-11e9-993e-74ecd6b055d0.png)
