### PR TITLE
Manually revert award queue changes for assuring pilot assignments

### DIFF
--- a/pkg/awardqueue/awardqueue_test.go
+++ b/pkg/awardqueue/awardqueue_test.go
@@ -484,12 +484,11 @@ func (suite *AwardQueueSuite) TestAssignShipmentsToMultipleTSPs() {
 	// Run the Award Queue
 	queue.assignShipments(context.Background())
 
-	// TODO: revert to [6, 5, 3, 2, 1] after the B&M pilot
-	suite.verifyOfferCount(tsp1, 4)
-	suite.verifyOfferCount(tsp2, 4)
+	suite.verifyOfferCount(tsp1, 6)
+	suite.verifyOfferCount(tsp2, 5)
 	suite.verifyOfferCount(tsp3, 3)
-	suite.verifyOfferCount(tsp4, 3)
-	suite.verifyOfferCount(tsp5, 3)
+	suite.verifyOfferCount(tsp4, 2)
+	suite.verifyOfferCount(tsp5, 1)
 
 	for _, shipment := range shipments {
 		if err := suite.DB().Find(&shipment, shipment.ID); err != nil {

--- a/pkg/models/transportation_service_provider_performance.go
+++ b/pkg/models/transportation_service_provider_performance.go
@@ -20,11 +20,10 @@ import (
 var qualityBands = []int{1, 2, 3, 4}
 
 // OffersPerQualityBand is a map of the number of shipments to be offered per round to each quality band
-// TODO: change these back to [5, 3, 2, 1] after the B&M pilot
 var OffersPerQualityBand = map[int]int{
-	1: 1,
-	2: 1,
-	3: 1,
+	1: 5,
+	2: 3,
+	3: 2,
 	4: 1,
 }
 

--- a/pkg/models/transportation_service_provider_performance_test.go
+++ b/pkg/models/transportation_service_provider_performance_test.go
@@ -256,7 +256,7 @@ func (suite *ModelSuite) Test_SelectNextTSPPerformanceOneAssigned() {
 
 	chosen := SelectNextTSPPerformance(choices)
 
-	if chosen != tspp2 {
+	if chosen != tspp1 {
 		t.Errorf("Wrong TSPPerformance selected: expected band %v, got %v", *tspp1.QualityBand, *chosen.QualityBand)
 	}
 }
@@ -276,7 +276,7 @@ func (suite *ModelSuite) Test_SelectNextTSPPerformanceOneFullRound() {
 
 	chosen := SelectNextTSPPerformance(choices)
 
-	if chosen != tspp2 {
+	if chosen != tspp1 {
 		t.Errorf("Wrong TSPPerformance selected: expected band %v, got %v", *tspp1.QualityBand, *chosen.QualityBand)
 	}
 }
@@ -296,7 +296,7 @@ func (suite *ModelSuite) Test_SelectNextTSPPerformanceTwoFullRounds() {
 
 	chosen := SelectNextTSPPerformance(choices)
 
-	if chosen != tspp2 {
+	if chosen != tspp1 {
 		t.Errorf("Wrong TSPPerformance selected: expected band %v, got %v", *tspp1.QualityBand, *chosen.QualityBand)
 	}
 }
@@ -354,7 +354,7 @@ func (suite *ModelSuite) Test_SelectNextTSPPerformanceHalfOffered() {
 
 	chosen := SelectNextTSPPerformance(choices)
 
-	if chosen != tspp2 {
+	if chosen != tspp3 {
 		t.Errorf("Wrong TSPPerformance selected: expected band %v, got %v", *tspp3.QualityBand, *chosen.QualityBand)
 	}
 }
@@ -374,7 +374,7 @@ func (suite *ModelSuite) Test_SelectNextTSPPerformancePartialRound() {
 
 	chosen := SelectNextTSPPerformance(choices)
 
-	if chosen != tspp2 {
+	if chosen != tspp3 {
 		t.Errorf("Wrong TSPPerformance selected: expected band %v, got %v", *tspp3.QualityBand, *chosen.QualityBand)
 	}
 }


### PR DESCRIPTION
## Description

Changes were made to award queue and the TSPP before the fall pilot to assure that 1 of the 3 pilot TSPs got the assignments.  This manually  reverts [those changes](https://github.com/transcom/mymove/pull/1248/files).

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/161495153) for this change
