### PR TITLE
ComboButton Add Approve HHG

### DIFF
--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -405,7 +405,13 @@ class MoveInfo extends Component {
                             value="Approve PPM"
                           />
                         )}
-                        {(isHHG || isHHGPPM) && <DropDownItem value="Approve HHG" disabled={true} />}
+                        {(isHHG || isHHGPPM) && (
+                          <DropDownItem
+                            value="Approve HHG"
+                            onClick={this.approveShipment}
+                            disabled={!hhgAccepted || hhgApproved || hhgCompleted || !moveApproved || !ordersComplete}
+                          />
+                        )}
                       </DropDown>
                     </ComboButton>
                   )}


### PR DESCRIPTION
## Description

ComboButton allow for office user to approve basic information for a move.

## Reviewer Notes

Select a HHG move for which the Basics information has been approved. The "Approve HHG" section of the menu should be active. After clicking the Approve HHG option the HHG should now be approved.

## Setup

```sh
make server_run
make office_client_run
```

## Code Review Verification Steps
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/n/projects/2181745/stories/163307702)

## Screenshots
![Screen Shot 2019-03-18 at 4 10 30 PM](https://user-images.githubusercontent.com/1036969/54567121-6a5f5500-4998-11e9-85f1-92e7dad507a8.png)

