### PR TITLE
Fix address used for linehaul calculations

### DIFF
--- a/pkg/models/shipment.go
+++ b/pkg/models/shipment.go
@@ -1002,7 +1002,7 @@ func AcceptShipmentForTSP(db *pop.Connection, tspID uuid.UUID, shipmentID uuid.U
 	// by default we should use the address of duty station when a TSP accepts shipment unless actual delivery
 	// shipment address is available at the time
 	destAddOnAcceptance := shipment.Move.Orders.NewDutyStation.Address
-	if shipment.DeliveryAddress != nil {
+	if shipment.HasDeliveryAddress && shipment.DeliveryAddress != nil {
 		destAddOnAcceptance = *shipment.DeliveryAddress
 	}
 

--- a/pkg/models/shipment.go
+++ b/pkg/models/shipment.go
@@ -1006,8 +1006,14 @@ func AcceptShipmentForTSP(db *pop.Connection, tspID uuid.UUID, shipmentID uuid.U
 		destAddOnAcceptance = *shipment.DeliveryAddress
 	}
 
+	// setting id to nil to force a new Address in the db
+	destAddOnAcceptance.ID = uuid.Nil
 	shipment.DestinationAddressOnAcceptance = &destAddOnAcceptance
-	shipment.DestinationAddressOnAcceptanceID = &destAddOnAcceptance.ID
+
+	_, err = SaveDestinationAddress(db, shipment)
+	if err != nil {
+		return shipment, nil, nil, err
+	}
 
 	shipmentOffer, err := FetchShipmentOfferByTSP(db, tspID, shipmentID)
 	if err != nil {
@@ -1026,6 +1032,17 @@ func AcceptShipmentForTSP(db *pop.Connection, tspID uuid.UUID, shipmentID uuid.U
 	}
 
 	return saveShipmentAndOffer(db, shipment, shipmentOffer)
+}
+
+// SaveDestinationAddress saves a DestinationAddressOnAcceptance
+func SaveDestinationAddress(db *pop.Connection, shipment *Shipment) (*validate.Errors, error) {
+	verrs, err := db.ValidateAndSave(shipment.DestinationAddressOnAcceptance)
+	if verrs.HasAny() || err != nil {
+		saveError := errors.Wrap(err, "Error saving shipment")
+		return verrs, saveError
+	}
+	shipment.DestinationAddressOnAcceptanceID = &shipment.DestinationAddressOnAcceptance.ID
+	return verrs, nil
 }
 
 // SaveShipmentAndAddresses saves a Shipment and its Addresses atomically.

--- a/pkg/models/shipment_test.go
+++ b/pkg/models/shipment_test.go
@@ -196,7 +196,7 @@ func (suite *ModelSuite) TestAcceptShipmentForTSP() {
 	suite.Equal(ShipmentStatusACCEPTED, newShipment.Status, "expected Accepted")
 	suite.True(*newShipmentOffer.Accepted)
 	suite.Nil(newShipmentOffer.RejectionReason)
-	suite.Equal(shipment.Move.Orders.NewDutyStation.Address.ID, newShipment.DestinationAddressOnAcceptance.ID)
+	suite.Equal(shipment.Move.Orders.NewDutyStation.Address.City, newShipment.DestinationAddressOnAcceptance.City)
 }
 
 // TestAcceptShipmentForTSPWithDeliveryAddress tests that delivery address is used for a shipment when TSP accepts
@@ -232,7 +232,7 @@ func (suite *ModelSuite) TestAcceptShipmentForTSPWithDeliveryAddress() {
 
 	newShipment, _, _, err := AcceptShipmentForTSP(suite.DB(), tspUser.TransportationServiceProviderID, shipment.ID)
 	suite.NoError(err)
-	suite.Equal(shipment.DeliveryAddress.ID, newShipment.DestinationAddressOnAcceptance.ID)
+	suite.Equal(shipment.DeliveryAddress.City, newShipment.DestinationAddressOnAcceptance.City)
 }
 
 // TestAcceptShipmentForTSPWithDeliveryAddress tests that delivery address is used for a shipment when TSP accepts
@@ -268,7 +268,7 @@ func (suite *ModelSuite) TestAcceptShipmentForTSPWithDeliveryAddressHasDeliveryA
 
 	newShipment, _, _, err := AcceptShipmentForTSP(suite.DB(), tspUser.TransportationServiceProviderID, shipment.ID)
 	suite.NoError(err)
-	suite.Equal(shipment.Move.Orders.NewDutyStation.Address.ID, newShipment.DestinationAddressOnAcceptance.ID)
+	suite.Equal(shipment.Move.Orders.NewDutyStation.Address.City, newShipment.DestinationAddressOnAcceptance.City)
 }
 
 // TestCurrentTransportationServiceProviderID tests that a shipment returns the proper current tsp id


### PR DESCRIPTION
## Description

Store `destination_address_on_acceptance_id` in `shipments`. This address is set at the time the TSP accepts a shipment. If the shipment has a destination address, use the `destination address`. If the shipment doesn't have a `destination address` default the address to the `duty station`.


## Reviewer Notes

There was a bug in the original change for this. If there was an existing destination address, but we set that value to not be used, the address used for the calculation was set to the destinaion address, not the duty station.

Another thing to check... Have the tsp accept the shipment and before the tsp delivers the shipment, update the address. The address at the time of acceptance should be the address used to calculate the distance.

## Setup

`make db_dev_e2e_populate`
`make server_run`
`make tsp_client_run`
`make office_client_run`

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/163605913) for this change
* [the original pr](https://github.com/transcom/mymove/pull/1816) 
