### PR TITLE
Support Creating Robust Accessorial 226A Pre-Approval Request [delivers #163829463]

### DIFF
--- a/pkg/models/shipment.go
+++ b/pkg/models/shipment.go
@@ -738,6 +738,8 @@ func upsertItemCodeDependency(db *pop.Connection, baseParams *BaseShipmentLineIt
 		responseVErrors, responseError = upsertItemCode105Dependency(db, baseParams, additionalParams, shipmentLineItem)
 	} else if is35AItem(itemCode, additionalParams) {
 		responseVErrors, responseError = upsertItemCode35ADependency(db, baseParams, additionalParams, shipmentLineItem)
+	} else if is226AItem(itemCode, additionalParams) {
+		responseVErrors, responseError = upsertItemCode226ADependency(db, baseParams, additionalParams, shipmentLineItem)
 	} else if baseParams.Quantity1 == nil {
 		// General pre-approval request
 		// Check if base quantity is filled out

--- a/pkg/models/shipment_test.go
+++ b/pkg/models/shipment_test.go
@@ -408,7 +408,7 @@ func (suite *ModelSuite) TestCreateShipmentLineItemCode35A() {
 		ActualAmountCents:   &actAmt,
 	}
 
-	// Create 105B preapproval
+	// Create 35A preapproval
 	shipmentLineItem, verrs, err := shipment.CreateShipmentLineItem(suite.DB(),
 		baseParams, additionalParams)
 
@@ -419,6 +419,43 @@ func (suite *ModelSuite) TestCreateShipmentLineItemCode35A() {
 		suite.Equal(desc, *shipmentLineItem.Description)
 		suite.Equal(reas, *shipmentLineItem.Reason)
 		suite.Equal(estAmt, *shipmentLineItem.EstimateAmountCents)
+		suite.Equal(actAmt, *shipmentLineItem.ActualAmountCents)
+	}
+}
+
+// TestCreateShipmentLineItemCode226A tests that 226A line items are created correctly
+func (suite *ModelSuite) TestCreateShipmentLineItemCode226A() {
+	acc226A := testdatagen.MakeTariff400ngItem(suite.DB(), testdatagen.Assertions{
+		Tariff400ngItem: Tariff400ngItem{
+			Code: "226A",
+		},
+	})
+
+	shipment := testdatagen.MakeDefaultShipment(suite.DB())
+
+	desc := "This is a description"
+	reas := "This is the reason"
+	actAmt := unit.Cents(1000)
+	baseParams := BaseShipmentLineItemParams{
+		Tariff400ngItemID:   acc226A.ID,
+		Tariff400ngItemCode: acc226A.Code,
+		Location:            "ORIGIN",
+	}
+	additionalParams := AdditionalShipmentLineItemParams{
+		Description:       &desc,
+		Reason:            &reas,
+		ActualAmountCents: &actAmt,
+	}
+
+	// Create 226A preapproval
+	shipmentLineItem, verrs, err := shipment.CreateShipmentLineItem(suite.DB(),
+		baseParams, additionalParams)
+
+	if suite.noValidationErrors(verrs, err) {
+		suite.Equal(unit.BaseQuantityFromCents(actAmt), shipmentLineItem.Quantity1)
+		suite.Equal(acc226A.ID.String(), shipmentLineItem.Tariff400ngItem.ID.String())
+		suite.Equal(desc, *shipmentLineItem.Description)
+		suite.Equal(reas, *shipmentLineItem.Reason)
 		suite.Equal(actAmt, *shipmentLineItem.ActualAmountCents)
 	}
 }

--- a/pkg/unit/base_quantity.go
+++ b/pkg/unit/base_quantity.go
@@ -35,6 +35,11 @@ func BaseQuantityFromThousandthInches(ti ThousandthInches) BaseQuantity {
 	return BaseQuantity(ti * 10)
 }
 
+// BaseQuantityFromCents creates a BaseQuantity for a provided Cents
+func BaseQuantityFromCents(c Cents) BaseQuantity {
+	return BaseQuantity(c * 100)
+}
+
 // String returns the value of self as string
 func (bq BaseQuantity) String() string {
 	return strconv.Itoa(int(bq))


### PR DESCRIPTION
## Description

This PR supports creating a pre-approval request (PAR) with a new form for 226A. Users will still be able to create PARs with the old base quantity form through the end point as well.

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](./docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](./docs/backend.md#querying-the-database-safely)
 have been satisfied.
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers](./docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/163829463) for this change