### PR TITLE
bring back go vet

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -107,14 +107,14 @@ repos:
         files: \.go$
         exclude: vendor/
 
-#  - repo: local
-#    hooks:
-#    - id: go-vet
-#      name: go vet
-#      entry: bin/pre-commit-go-vet
-#      language: script
-#      files: \.go$
-#      exclude: vendor/
+  - repo: local
+    hooks:
+    - id: go-vet
+      name: go vet
+      entry: bin/pre-commit-go-vet
+      language: script
+      files: \.go$
+      exclude: vendor/
 
   - repo: local
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -115,6 +115,7 @@ repos:
       language: script
       files: \.go$
       exclude: vendor/
+      pass_filenames: false
 
   - repo: local
     hooks:

--- a/bin/pre-commit-go-vet
+++ b/bin/pre-commit-go-vet
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -e
 
+# skip analyzing dutystationsloader until repeated tags from embedded types are fixed in Go1.12.2
+# https://github.com/golang/go/issues/30465
 go_vet_pkgs=$(go list ./... | grep -v /vendor/ | grep -v internal/pkg/dutystationsloader | tr "\n" " ")
 
 # shellcheck disable=SC2086

--- a/bin/pre-commit-go-vet
+++ b/bin/pre-commit-go-vet
@@ -1,7 +1,4 @@
 #!/usr/bin/env bash
-#
-# Capture and print stdout/stderr, since golint doesn't use proper exit codes
-#
 set -e
 
 for file in $(go list ./... | grep -v /vendor/)

--- a/bin/pre-commit-go-vet
+++ b/bin/pre-commit-go-vet
@@ -4,8 +4,7 @@
 #
 set -e
 
-exec 5>&1
-for file in "$@"; do
-    output="$(go vet "$file" 2>&1 | tee /dev/fd/5)"
-    [[ -z "$output" ]]
+for file in $(go list ./... | grep -v /vendor/)
+do
+    go vet "$file"
 done

--- a/bin/pre-commit-go-vet
+++ b/bin/pre-commit-go-vet
@@ -3,5 +3,11 @@ set -e
 
 for file in $(go list ./... | grep -v /vendor/)
 do
+    # skip analyzing dutystationsloader until repeated tags from embedded types are fixed in Go1.12.2
+    if [[ "$file" == *"dutystationsloader"* ]]; then
+      echo "skipping: $file"
+      continue
+    fi
+    echo "processing: $file"
     go vet "$file"
 done

--- a/bin/pre-commit-go-vet
+++ b/bin/pre-commit-go-vet
@@ -1,13 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-for file in $(go list ./... | grep -v /vendor/)
-do
-    # skip analyzing dutystationsloader until repeated tags from embedded types are fixed in Go1.12.2
-    if [[ "$file" == *"dutystationsloader"* ]]; then
-      echo "skipping: $file"
-      continue
-    fi
-    echo "processing: $file"
-    go vet "$file"
-done
+go_vet_pkgs=$(go list ./... | grep -v /vendor/ | grep -v internal/pkg/dutystationsloader | tr "\n" " ")
+
+# shellcheck disable=SC2086
+go vet $go_vet_pkgs


### PR DESCRIPTION
## Description

We removed go vet when we upgraded to go 1.12. This PR adds go vet back into pre-commit hooks with an exception for `dutystationloader` package because of a known [issue](https://github.com/golang/go/issues/30465).

## Reviewer Notes
You can test go vet by changing a go file like `server.go` and running `pre-commit run go-vet -a`

## Setup

Checkout branch and run
```sh
pre-commit run go-vet -a 
```

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/164639267) for this change