### PR TITLE
Service member sees way to accept payment legalese

### DIFF
--- a/cypress/integration/mymove/ppm.js
+++ b/cypress/integration/mymove/ppm.js
@@ -1,16 +1,9 @@
 /* global cy */
 
 describe('completing the ppm flow', function() {
-  beforeEach(() => {
-    //profile@comple.te
-    // cy.resetDb();
-    cy.signInAsUser('13f3949d-0d53-4be4-b1b1-ae4314793f34');
-  });
-
-  //tear down currently means doing this:
-  //update moves set status='DRAFT';
-  //delete from personally_procured_moves
   it('progresses thru forms', function() {
+    //profile@comple.te
+    cy.signInAsUser('13f3949d-0d53-4be4-b1b1-ae4314793f34');
     cy.contains('Fort Gordon (from Yuma AFB)');
     cy.get('.whole_box > div > :nth-child(3) > span').contains('10,500 lbs');
     cy.contains('Continue Move Setup').click();
@@ -83,5 +76,29 @@ describe('completing the ppm flow', function() {
     cy.contains('Success');
     cy.contains('Next Step: Wait for approval');
     cy.contains('Advance Requested: $1,333.91');
+  });
+
+  it('allows a SM to request payment', function() {
+    cy.logout();
+    //profile@comple.te
+    cy.signInAsUser('8e0d7e98-134e-4b28-bdd1-7d6b1ff34f9e');
+    cy.contains('Fort Gordon (from Yuma AFB)');
+    cy.contains('Request Payment').click();
+
+    cy.location().should(loc => {
+      expect(loc.pathname).to.match(/^\/moves\/[^/]+\/request-payment/);
+    });
+    cy.get('input[type="checkbox"]').should('not.be.checked');
+    const stub = cy.stub();
+    cy.on('window:alert', stub);
+
+    cy
+      .contains('Legal Agreement / Privacy Act')
+      .click()
+      .then(() => {
+        expect(stub.getCall(0)).to.be.calledWithMatch('LEGAL AGREEMENT / PRIVACY ACT');
+      });
+    cy.get('input[type="checkbox"]').should('not.be.checked');
+    cy.get('input[type="checkbox"]').check({ force: true });
   });
 });

--- a/pkg/testdatagen/scenario/e2ebasic.go
+++ b/pkg/testdatagen/scenario/e2ebasic.go
@@ -2188,6 +2188,49 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, log
 	hhg35 := offer35.Shipment
 	hhg35.Move.Submit()
 	models.SaveMoveDependencies(db, &hhg35.Move)
+
+	/*
+	 * Service member with a ppm ready to request payment
+	 */
+	email = "ppm@requestingpay.ment"
+	uuidStr = "8e0d7e98-134e-4b28-bdd1-7d6b1ff34f9e"
+	testdatagen.MakeUser(db, testdatagen.Assertions{
+		User: models.User{
+			ID:            uuid.Must(uuid.FromString(uuidStr)),
+			LoginGovEmail: email,
+		},
+	})
+	ppm5 := testdatagen.MakePPM(db, testdatagen.Assertions{
+		ServiceMember: models.ServiceMember{
+			ID:            uuid.FromStringOrNil("ff1f56c0-544e-4109-8168-f91ebcbbb878"),
+			UserID:        uuid.FromStringOrNil(uuidStr),
+			FirstName:     models.StringPointer("PPM"),
+			LastName:      models.StringPointer("RequestingPay"),
+			Edipi:         models.StringPointer("6737033988"),
+			PersonalEmail: models.StringPointer(email),
+		},
+		// These values should be populated for an approved move
+		Order: models.Order{
+			OrdersNumber:        models.StringPointer("62341"),
+			OrdersTypeDetail:    &typeDetail,
+			DepartmentIndicator: models.StringPointer("AIR_FORCE"),
+			TAC:                 models.StringPointer("99"),
+		},
+		Move: models.Move{
+			ID:      uuid.FromStringOrNil("946a5d40-0636-418f-b457-474915fb0149"),
+			Locator: "REQPAY",
+		},
+		PersonallyProcuredMove: models.PersonallyProcuredMove{
+			OriginalMoveDate: &pastTime,
+		},
+		Uploader: loader,
+	})
+	ppm5.Move.Submit()
+	ppm5.Move.Approve()
+	// This is the same PPM model as ppm5, but this is the one that will be saved by SaveMoveDependencies
+	ppm5.Move.PersonallyProcuredMoves[0].Submit()
+	ppm5.Move.PersonallyProcuredMoves[0].Approve()
+	models.SaveMoveDependencies(db, &ppm5.Move)
 }
 
 // MakeHhgWithPpm creates an HHG user who has added a PPM

--- a/src/scenes/Moves/Ppm/PaymentRequest.css
+++ b/src/scenes/Moves/Ppm/PaymentRequest.css
@@ -15,3 +15,19 @@
     border-right-width: 0;
   }
 }
+
+.customer-agreement {
+  background-color: #ededed;
+  padding: 1em;
+  max-width: 500px;
+}
+
+p {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+label {
+  margin-top: 0;
+  margin-bottom: 0;
+}

--- a/src/scenes/Moves/Ppm/PaymentRequest.jsx
+++ b/src/scenes/Moves/Ppm/PaymentRequest.jsx
@@ -18,6 +18,33 @@ import scrollToTop from 'shared/scrollToTop';
 
 import './PaymentRequest.css';
 
+function openLegalese(event) {
+  // Prevent this from checking the box after opening the alert.
+  event.preventDefault();
+
+  const legalese = `\
+LEGAL AGREEMENT / PRIVACY ACT
+
+FINANCIAL LIABILITY:
+If this shipment(s) incurs costs above the allowance I am entitled to, I will pay the difference to the government, \
+or consent to the collection from my pay as necessary to cover all excess costs associated by this shipment(s).
+
+ADVANCE OBLIGATION:
+I understand that the maximum advance allowed is based on the estimated weight and scheduled departure date of my \
+shipment(s). In the event, less weight is moved or my move occurs on a different scheduled departure date, I may have \
+to remit the difference with the balance of my incentive disbursement and/or from the collection of my pay as may be \
+necessary.
+
+I understand that the maximum advance allowed is based on the estimated weight and scheduled departure date of my \
+shipment(s). In the event, less weight is moved or my move occurs on a different scheduled departure date, I may \
+have to remit the difference with the balance of my incentive disbursement and/or from the collection of my pay as may \
+be necessary. If I receive an advance for my PPM shipment, I agree to furnish weight tickets within 45 days of final \
+delivery to my desintation. I understand that failure to furnish weight tickets within this timeframe may lead to the \
+collection of my pay as necessary to cover the cost of the advance.`;
+
+  alert(legalese);
+}
+
 function RequestPaymentSection(props) {
   const { ppm, updatingPPM, submitDocs, disableSubmit } = props;
 
@@ -29,6 +56,16 @@ function RequestPaymentSection(props) {
     return (
       <Fragment>
         <h4>Done uploading documents?</h4>
+        <div className="customer-agreement">
+          <p>
+            <strong>Customer Agreement</strong>
+          </p>
+          <input id="agree-checkbox" type="checkbox" />
+          <label for="agree-checkbox">
+            I agree to the
+            <a onClick={openLegalese}> Legal Agreement / Privacy Act</a>
+          </label>
+        </div>
         <button onClick={submitDocs} className="usa-button" disabled={updatingPPM || disableSubmit}>
           Submit Payment Request
         </button>

--- a/src/scenes/Moves/Ppm/PaymentRequest.jsx
+++ b/src/scenes/Moves/Ppm/PaymentRequest.jsx
@@ -39,7 +39,7 @@ I understand that the maximum advance allowed is based on the estimated weight a
 shipment(s). In the event, less weight is moved or my move occurs on a different scheduled departure date, I may \
 have to remit the difference with the balance of my incentive disbursement and/or from the collection of my pay as may \
 be necessary. If I receive an advance for my PPM shipment, I agree to furnish weight tickets within 45 days of final \
-delivery to my desintation. I understand that failure to furnish weight tickets within this timeframe may lead to the \
+delivery to my destination. I understand that failure to furnish weight tickets within this timeframe may lead to the \
 collection of my pay as necessary to cover the cost of the advance.`;
 
   alert(legalese);


### PR DESCRIPTION
## Description

This allows service members to see the legal text for requesting a payment.

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make db_dev_e2e_populate
```
Log in to milmovelocal as `ppm@requestingpay.ment`. Click on request payment. You should see an alert with the legalese. Note that the checkbox doesn't actually do anything yet.

## Code Review Verification Steps

* [x] User facing changes have been reviewed by design.
* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* https://www.pivotaltracker.com/story/show/164380861

## Screenshots

What I can click on:
<img width="900" alt="Screen Shot 2019-03-19 at 3 26 05 PM" src="https://user-images.githubusercontent.com/5531789/54646139-6b0cef80-4a5b-11e9-9280-3953e2c09194.png">
The legalese alert:
<img width="497" alt="Screen Shot 2019-03-19 at 3 26 13 PM" src="https://user-images.githubusercontent.com/5531789/54646146-6f390d00-4a5b-11e9-8054-f778b12d70a8.png">

