### PR TITLE
Change CSRF cookie from strict to lax mode

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -779,9 +779,9 @@ workflows:
             - pre_deps_yarn
             - acceptance_tests_local
           # if testing on experimental, you can disable these tests by using the commented block below.
-          # filters:
-          #  branches:
-          #    ignore: placeholder_branch_name
+          filters:
+            branches:
+              ignore: rr-csrf-samesite-lax
 
       - integration_tests_office:
           requires:
@@ -789,9 +789,9 @@ workflows:
             - pre_deps_yarn
             - acceptance_tests_local
           # if testing on experimental, you can disable these tests by using the commented block below.
-          # filters:
-          #   branches:
-          #     ignore: placeholder_branch_name
+          filters:
+            branches:
+              ignore: rr-csrf-samesite-lax
 
       - integration_tests_tsp:
           requires:
@@ -799,9 +799,9 @@ workflows:
             - pre_deps_yarn
             - acceptance_tests_local
           # if testing on experimental, you can disable these tests by using the commented block below.
-          # filters:
-          #   branches:
-          #     ignore: placeholder_branch_name
+          filters:
+            branches:
+              ignore: rr-csrf-samesite-lax
 
       - client_test:
           requires:
@@ -845,21 +845,21 @@ workflows:
             - build_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: rr-csrf-samesite-lax
 
       - deploy_experimental_app:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: rr-csrf-samesite-lax
 
       - deploy_experimental_app_client_tls:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: rr-csrf-samesite-lax
 
       - check_circle_against_staging_sha:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -779,9 +779,9 @@ workflows:
             - pre_deps_yarn
             - acceptance_tests_local
           # if testing on experimental, you can disable these tests by using the commented block below.
-          filters:
-            branches:
-              ignore: rr-csrf-samesite-lax
+          # filters:
+          #  branches:
+          #    ignore: placeholder_branch_name
 
       - integration_tests_office:
           requires:
@@ -789,9 +789,9 @@ workflows:
             - pre_deps_yarn
             - acceptance_tests_local
           # if testing on experimental, you can disable these tests by using the commented block below.
-          filters:
-            branches:
-              ignore: rr-csrf-samesite-lax
+          # filters:
+          #   branches:
+          #     ignore: placeholder_branch_name
 
       - integration_tests_tsp:
           requires:
@@ -799,9 +799,9 @@ workflows:
             - pre_deps_yarn
             - acceptance_tests_local
           # if testing on experimental, you can disable these tests by using the commented block below.
-          filters:
-            branches:
-              ignore: rr-csrf-samesite-lax
+          # filters:
+          #   branches:
+          #     ignore: placeholder_branch_name
 
       - client_test:
           requires:
@@ -845,21 +845,21 @@ workflows:
             - build_migrations
           filters:
             branches:
-              only: rr-csrf-samesite-lax
+              only: placeholder_branch_name
 
       - deploy_experimental_app:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: rr-csrf-samesite-lax
+              only: placeholder_branch_name
 
       - deploy_experimental_app_client_tls:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: rr-csrf-samesite-lax
+              only: placeholder_branch_name
 
       - check_circle_against_staging_sha:
           requires:

--- a/pkg/auth/cookie.go
+++ b/pkg/auth/cookie.go
@@ -119,7 +119,7 @@ func WriteMaskedCSRFCookie(w http.ResponseWriter, csrfToken string, noSessionTim
 		Expires:  expiry,
 		MaxAge:   maxAge,
 		HttpOnly: false,                // must be false to be read by client for use in POST/PUT/PATCH/DELETE requests
-		SameSite: http.SameSiteLaxMode, // Trying lax mode since strict is causing issues with Firefox/Safari.
+		SameSite: http.SameSiteLaxMode, // Using lax mode for now since strict is causing issues with Firefox/Safari
 		Secure:   useSecureCookie,
 	}
 

--- a/pkg/auth/cookie.go
+++ b/pkg/auth/cookie.go
@@ -118,8 +118,8 @@ func WriteMaskedCSRFCookie(w http.ResponseWriter, csrfToken string, noSessionTim
 		Path:     "/",
 		Expires:  expiry,
 		MaxAge:   maxAge,
-		HttpOnly: false, // must be false to be read by client for use in POST/PUT/PATCH/DELETE requests
-		SameSite: http.SameSiteStrictMode,
+		HttpOnly: false,                // must be false to be read by client for use in POST/PUT/PATCH/DELETE requests
+		SameSite: http.SameSiteLaxMode, // Trying lax mode since strict is causing issues with Firefox/Safari.
 		Secure:   useSecureCookie,
 	}
 


### PR DESCRIPTION
## Description

Using Firefox, we were seeing 403 errors on staging when changing data (but not in Chrome).  The endpoints were returning `Forbidden - CSRF token invalid`.  This PR explicitly sets the CSRF cookie to be in "lax" mode rather than the "strict" mode we set it to recently.  I deployed to experimental and this change seemed to fix the problem.

I added a [story](https://www.pivotaltracker.com/story/show/164748749) to investigate this further to see if we can figure out if the root cause is a browser incompatibility or something we're doing in code.

More background in Slack:
https://defensedigitalservice.slack.com/archives/GEDH7P70E/p1553026280188600

## Setup

Check out the experimental office site with Firefox and try changing some data like the service member's name on the move.  On experimental it should work; on staging it will fail.

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/164748749) for the follow-up research.
