### PR TITLE
On Edit Move page only show details relevant to move type

### DIFF
--- a/cypress/integration/mymove/ppm.js
+++ b/cypress/integration/mymove/ppm.js
@@ -85,3 +85,18 @@ describe('completing the ppm flow', function() {
     cy.contains('Advance Requested: $1,333.91');
   });
 });
+
+describe('editing ppm only move', () => {
+  it('sees only details relevant to PPM only move', () => {
+    cy.signInAsUser('e10d5964-c070-49cb-9bd1-eaf9f7348eb6');
+    cy
+      .get('.sidebar button')
+      .contains('Edit Move')
+      .click();
+
+    cy.get('.ppm-container').should(ppmContainer => {
+      expect(ppmContainer).to.have.length(1);
+      expect(ppmContainer[0]).to.not.have.class('hhg-shipment-summary');
+    });
+  });
+});

--- a/cypress/integration/mymove/ppm.js
+++ b/cypress/integration/mymove/ppm.js
@@ -96,7 +96,7 @@ describe('editing ppm only move', () => {
 
     cy.get('.ppm-container').should(ppmContainer => {
       expect(ppmContainer).to.have.length(1);
-      expect(ppmContainer[0]).to.not.have.class('hhg-shipment-summary');
+      expect(ppmContainer).to.not.have.class('hhg-shipment-summary');
     });
   });
 });

--- a/src/scenes/Review/Summary.jsx
+++ b/src/scenes/Review/Summary.jsx
@@ -1,5 +1,5 @@
 import React, { Component, Fragment } from 'react';
-import { forEach, get } from 'lodash';
+import { forEach, get, isEmpty } from 'lodash';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 import PropTypes from 'prop-types';
@@ -64,7 +64,7 @@ export class Summary extends Component {
     const showPPMShipmentSummary =
       (isReviewPage && currentPpm) || (!isReviewPage && currentPpm && currentPpm.status !== 'DRAFT');
     const showHHGShipmentSummary =
-      (currentShipment && !isHHGPPMComboMove) || (currentShipment && isHHGPPMComboMove && !isReviewPage);
+      (!isEmpty(currentShipment) && !isHHGPPMComboMove) || (currentShipment && isHHGPPMComboMove && !isReviewPage);
 
     const showProfileAndOrders = (isReviewPage && !isHHGPPMComboMove) || !isReviewPage;
     return (


### PR DESCRIPTION
## Description

On the Edit Move page service members should only see information relevant to their move type.

## Setup

* Login a service member with a PPM only move.
* Select "Edit Move".
* In the box at the bottom you should only see details relevant to your move type.

The same should be true for HHG only moves and PPM+HHG moves.

## Code Review Verification Steps
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/n/projects/2181745/stories/164347854) 

## Screenshots
![Screen Shot 2019-03-20 at 8 51 01 AM](https://user-images.githubusercontent.com/1036969/54694105-4feac000-4aed-11e9-96aa-b3fa741ef02e.png)
