### PR TITLE
Made CSS selectors more restrictive for PaymentRequest

### DIFF
--- a/src/scenes/Moves/Ppm/PaymentRequest.css
+++ b/src/scenes/Moves/Ppm/PaymentRequest.css
@@ -22,12 +22,12 @@
   max-width: 500px;
 }
 
-p {
+.customer-agreement p {
   margin-top: 0;
   margin-bottom: 0;
 }
 
-label {
+.customer-agreement label {
   margin-top: 0;
   margin-bottom: 0;
 }


### PR DESCRIPTION
## Description

When testing staging before a deploy, I noticed that the Service Member profile seemed to have some spacing issues.  Compare what was in staging vs. what it was earlier this morning:

<img width="635" alt="Screen Shot 2019-03-20 at 2 00 07 PM" src="https://user-images.githubusercontent.com/4960757/54709044-1b8df880-4b1b-11e9-877a-18b36a6282ca.png">

<img width="630" alt="Screen Shot 2019-03-20 at 2 03 37 PM" src="https://user-images.githubusercontent.com/4960757/54709250-8f300580-4b1b-11e9-8b16-fb5d549b8e06.png">


It looks like we had a couple of CSS selectors for `p` and `label` come through in PR #1888 that were too broad and leaked to other pages.  This PR restricts the CSS for those to just the class in the PR.

## Setup

Create a new service member and verify that the initial wizard page looks like it did before.

Check the payment request component in PR #1888 (note setup instructions there) and make sure it still looks OK (it should look the same as it did in the PR).

