### PR TITLE
Office View Details for Robust Accessorial 35A [delivers #163403049]

### DIFF
--- a/cypress/support/preapprovals/test35a.js
+++ b/cypress/support/preapprovals/test35a.js
@@ -32,5 +32,5 @@ export function test35A() {
   add35A({});
   cy
     .get('td[details-cy="35A-details"]')
-    .should('contain', 'description description 35A reason reason 35A Est. not to exceed: $250.00 Actual Amount: --');
+    .should('contain', 'description description 35A reason reason 35A Est. not to exceed: $250.00 Actual amount: --');
 }

--- a/src/shared/PreApprovalRequest/Code35Details.jsx
+++ b/src/shared/PreApprovalRequest/Code35Details.jsx
@@ -3,12 +3,14 @@ import { formatCents } from 'shared/formatters';
 
 export const Code35Details = props => {
   const row = props.shipmentLineItem;
+  const actAmtValue = formatCents(row.actual_amount_cents);
+  const actAmtText = actAmtValue ? '$' + actAmtValue : '--';
   return (
     <td details-cy={`${row.tariff400ng_item.code}-details`}>
       {row.description} <br />
       {row.reason} <br />
       Est. not to exceed: ${formatCents(row.estimate_amount_cents)} <br />
-      Actual Amount: ${`${formatCents(row.actual_amount_cents)}` || `--`} <br />
+      Actual Amount: {actAmtText} <br />
       {row.notes}
     </td>
   );

--- a/src/shared/PreApprovalRequest/Code35Details.jsx
+++ b/src/shared/PreApprovalRequest/Code35Details.jsx
@@ -4,13 +4,12 @@ import { formatCents } from 'shared/formatters';
 export const Code35Details = props => {
   const row = props.shipmentLineItem;
   const actAmtValue = formatCents(row.actual_amount_cents);
-  const actAmtText = actAmtValue ? '$' + actAmtValue : '--';
   return (
     <td details-cy={`${row.tariff400ng_item.code}-details`}>
       {row.description} <br />
       {row.reason} <br />
       Est. not to exceed: ${formatCents(row.estimate_amount_cents)} <br />
-      Actual amount: {actAmtText} <br />
+      Actual amount: {`${actAmtValue ? `$${actAmtValue}` : `--`}`} <br />
       {row.notes}
     </td>
   );

--- a/src/shared/PreApprovalRequest/Code35Details.jsx
+++ b/src/shared/PreApprovalRequest/Code35Details.jsx
@@ -8,7 +8,7 @@ export const Code35Details = props => {
       {row.description} <br />
       {row.reason} <br />
       Est. not to exceed: ${formatCents(row.estimate_amount_cents)} <br />
-      Actual Amount: {`${formatCents(row.actual_amount_cents)}` || `--`} <br />
+      Actual Amount: ${`${formatCents(row.actual_amount_cents)}` || `--`} <br />
       {row.notes}
     </td>
   );

--- a/src/shared/PreApprovalRequest/Code35Details.jsx
+++ b/src/shared/PreApprovalRequest/Code35Details.jsx
@@ -10,7 +10,7 @@ export const Code35Details = props => {
       {row.description} <br />
       {row.reason} <br />
       Est. not to exceed: ${formatCents(row.estimate_amount_cents)} <br />
-      Actual Amount: {actAmtText} <br />
+      Actual amount: {actAmtText} <br />
       {row.notes}
     </td>
   );


### PR DESCRIPTION
## Description

Most of the acceptance criteria have been met already.

This PR adds a dollar sign ($) to the actual amount detail for robust accessorial 35A and changes the text format to sentence format. See screenshot for more details.

## Code Review Verification Steps

* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers](./docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/163403049) for this change

## Screenshots

![image](https://user-images.githubusercontent.com/1522549/54721937-986fa100-4b20-11e9-980d-6bfc63a60e09.png)

