### PR TITLE
Fixes logout method async issue

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -191,9 +191,10 @@ Cypress.Commands.add('logout', () => {
       method: 'POST',
       headers: { 'x-csrf-token': cookie.value },
     });
+
+    // In case of login redirect we once more go to the homepage
+    cy.patientVisit('/');
   });
-  // In case of login redirect we once more go to the homepage
-  cy.patientVisit('/');
 });
 
 Cypress.Commands.add('nextPage', () => {


### PR DESCRIPTION
## Description

In our Cypress `logout` helper function we were visiting a route outside of the `then` block that sends the logout request, and I think the two actions were stomping on each other. This PR nests the call to `visit` inside that block, after the request is made