### PR TITLE
Disable cancel button if hhg is picked up

### DIFF
--- a/cypress/integration/office/officeUserHHG.js
+++ b/cypress/integration/office/officeUserHHG.js
@@ -119,6 +119,12 @@ function officeUserViewsAcceptedShipment() {
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/queues\/new\/moves\/[^/]+\/hhg/);
   });
+
+  // Since the shipment hasn't been picked up yet, it can be cancelled
+  cy
+    .get('button')
+    .contains('Cancel Move')
+    .should('not.be.disabled');
 }
 
 function officeUserApprovesOnlyBasicsHHG() {
@@ -272,6 +278,12 @@ function officeUserCompletesHHG() {
 
   // Complete HHG
   cy.get('.status').contains('Delivered');
+
+  // Since the shipment has been picked up by TSP, it can't be cancelled.
+  cy
+    .get('button')
+    .contains('Cancel Move')
+    .should('be.disabled');
 
   cy
     .get('button')

--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -273,6 +273,7 @@ class MoveInfo extends Component {
     const hhgDelivered = shipmentStatus === 'DELIVERED';
     const hhgCompleted = shipmentStatus === 'COMPLETED';
     const moveApproved = moveStatus === 'APPROVED';
+    const hhgCantBeCanceled = includes(['IN_TRANSIT', 'DELIVERED', 'COMPLETED'], shipmentStatus);
 
     const moveDate = isPPM ? ppm.original_move_date : shipment && shipment.requested_pickup_date;
     if (this.state.redirectToHome) {
@@ -474,6 +475,7 @@ class MoveInfo extends Component {
                 reasonPrompt="Why is the move being canceled?"
                 warningPrompt="Are you sure you want to cancel the entire move?"
                 onConfirm={this.cancelMoveAndRedirect}
+                buttonDisabled={hhgCantBeCanceled}
               />
               {/* Disabling until features implemented
               <button>Troubleshoot</button>


### PR DESCRIPTION
## Description

If the HHG has been picked up already, it should not be able to be cancelled by the office via the UI.

## Reviewer Notes

I added a check to some of the existing e2e tests to prevent regression, but was unsure if we wanted to add it to all of them or make up a separate test specifically for this.

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make db_dev_e2e_populate
```
Open the office client and view an HHG that is Submitted or Approved. The `Cancel Move` button should still be enabled. Visit an HHG that is In Transit, Delivered or Completed. The `Cancel Move` button should disabled.

## Code Review Verification Steps

* [ ] User facing changes have been reviewed by design.
* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* https://www.pivotaltracker.com/story/show/163530952

## Screenshots

### Pre-pickup cancel move is still enabled:
<img width="1506" alt="Screen Shot 2019-03-20 at 4 37 44 PM" src="https://user-images.githubusercontent.com/5531789/54726053-93b1e980-4b2e-11e9-8caf-ec33dd84e56a.png">

### Post-pickup cancel move is disabled:

<img width="1567" alt="Screen Shot 2019-03-20 at 4 37 30 PM" src="https://user-images.githubusercontent.com/5531789/54726076-a9bfaa00-4b2e-11e9-94b6-2fa9cf529798.png">
