### PR TITLE
[DNR] CSRF Error Handler Proof of Concept

### DIFF
--- a/cmd/webserver/main.go
+++ b/cmd/webserver/main.go
@@ -894,6 +894,7 @@ func main() {
 	noSessionTimeout := v.GetBool("no-session-timeout")
 	sessionCookieMiddleware := auth.SessionCookieMiddleware(logger, clientAuthSecretKey, noSessionTimeout, myHostname, officeHostname, tspHostname, useSecureCookie)
 	maskedCSRFMiddleware := auth.MaskedCSRFMiddleware(logger, noSessionTimeout, useSecureCookie)
+	csrfErrorHandler := auth.CSRFErrorHandler(logger, noSessionTimeout, useSecureCookie)
 	userAuthMiddleware := authentication.UserAuthMiddleware(logger)
 	clientCertMiddleware := authentication.ClientCertMiddleware(logger, dbConnection)
 
@@ -1193,7 +1194,7 @@ func main() {
 		logger.Fatal("Failed to decode csrf auth key", zap.Error(err))
 	}
 	logger.Info("Enabling CSRF protection")
-	root.Use(csrf.Protect(csrfAuthKey, csrf.Secure(!isDevOrTest), csrf.Path("/")))
+	root.Use(csrf.Protect(csrfAuthKey, csrf.Secure(!isDevOrTest), csrf.Path("/"), csrf.ErrorHandler(csrfErrorHandler)))
 	root.Use(maskedCSRFMiddleware)
 
 	// Sends build variables to honeycomb

--- a/pkg/auth/cookie.go
+++ b/pkg/auth/cookie.go
@@ -113,21 +113,21 @@ func sessionClaimsFromRequest(logger Logger, secret string, appName Application,
 // WriteMaskedCSRFCookie update the masked_gorilla_csrf cookie value
 func WriteMaskedCSRFCookie(w http.ResponseWriter, csrfToken string, noSessionTimeout bool, logger Logger, useSecureCookie bool) {
 
-	expiry := GetExpiryTimeFromMinutes(SessionExpiryInMinutes)
-	maxAge := sessionExpiryInSeconds
+	//expiry := GetExpiryTimeFromMinutes(SessionExpiryInMinutes)
+	//maxAge := sessionExpiryInSeconds
 	// Never expire token if in development
-	if noSessionTimeout {
-		expiry = likeForever
-		maxAge = likeForeverInSeconds
-	}
+	// if noSessionTimeout {
+	// 	expiry = likeForever
+	// 	maxAge = likeForeverInSeconds
+	// }
 
 	// New cookie
 	cookie := http.Cookie{
 		Name:     MaskedGorillaCSRFToken,
 		Value:    csrfToken,
 		Path:     "/",
-		Expires:  expiry,
-		MaxAge:   maxAge,
+		Expires:  time.Now(),
+		MaxAge:   60,
 		HttpOnly: false,                // must be false to be read by client for use in POST/PUT/PATCH/DELETE requests
 		SameSite: http.SameSiteLaxMode, // Using lax mode for now since strict is causing issues with Firefox/Safari
 		Secure:   useSecureCookie,


### PR DESCRIPTION
## Description

Proof of concept for passing in an error handler for CSRF middleware. 

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
echo "Code goes here"
```

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](./docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](./docs/backend.md#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](./docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
  * [ ] Secure migrations have been tested using `bin/run-prod-migrations`
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers](./docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @ntwyman
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](tbd) for this change
* [this article](tbd) explains more about the approach used.

## Screenshots

If this PR makes visible UI changes, an image of the finished UI can help reviewers and casual
observers understand the context of the changes. A before image is optional and
can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow instead of using multiple images. You may want to use GIPHY CAPTURE for this! 📸

_Please frame screenshots to show enough useful context but also highlight the affected regions._
