### PR TITLE
Office sees sit request(s) made by TSP

### DIFF
--- a/cypress/integration/office/storageInTransitPanel.js
+++ b/cypress/integration/office/storageInTransitPanel.js
@@ -34,7 +34,7 @@ function officeUserViewsSITPanel() {
   cy.get('.storage-in-transit').within(() => {
     cy.contains('Destination SIT');
     cy
-      .get('#sit-status-text')
+      .get('.sit-status-text')
       .contains('Status')
       .parent()
       .siblings()

--- a/cypress/integration/office/storageInTransitPanel.js
+++ b/cypress/integration/office/storageInTransitPanel.js
@@ -1,0 +1,65 @@
+/* global cy */
+describe('office user finds the shipment', function() {
+  beforeEach(() => {
+    cy.signIntoOffice();
+  });
+  it('office user views storage in transit panel', function() {
+    officeUserViewsSITPanel();
+  });
+});
+
+function officeUserViewsSITPanel() {
+  // Open new moves queue
+  cy.patientVisit('/queues/hhg_accepted');
+  cy.location().should(loc => {
+    expect(loc.pathname).to.match(/^\/queues\/hhg_accepted/);
+  });
+
+  // Find move (generated in e2ebasic.go) and open it
+  cy.selectQueueItemMoveLocator('SITREQ');
+
+  cy.location().should(loc => {
+    expect(loc.pathname).to.match(/^\/queues\/new\/moves\/[^/]+\/basics/);
+  });
+
+  cy
+    .get('a')
+    .contains('HHG')
+    .click(); // navtab
+
+  cy.location().should(loc => {
+    expect(loc.pathname).to.match(/^\/queues\/new\/moves\/[^/]+\/hhg/);
+  });
+  cy.get('.storage-in-transit-panel').contains('Storage in Transit');
+  cy.get('.storage-in-transit').within(() => {
+    cy.contains('Destination SIT');
+    cy
+      .get('#sit-status-text')
+      .contains('Status')
+      .parent()
+      .siblings()
+      .contains('SIT Requested');
+    cy
+      .contains('Dates')
+      .siblings()
+      .contains('Est. start date')
+      .siblings()
+      .contains('25-Mar-2019');
+    cy
+      .contains('Note')
+      .siblings()
+      .contains('Shipper phoned to let us know he is delayed until next week.');
+    cy
+      .contains('Warehouse')
+      .siblings()
+      .contains('Warehouse ID')
+      .siblings()
+      .contains('000383');
+    cy
+      .contains('Warehouse')
+      .siblings()
+      .contains('Contact info')
+      .siblings()
+      .contains('(713) 868-3497');
+  });
+}

--- a/cypress/integration/office/storageInTransitPanel.js
+++ b/cypress/integration/office/storageInTransitPanel.js
@@ -44,7 +44,7 @@ function officeUserViewsSITPanel() {
       .siblings()
       .contains('Est. start date')
       .siblings()
-      .contains('25-Mar-2019');
+      .contains('22-Mar-2019');
     cy
       .contains('Note')
       .siblings()

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "lodash": "^4.17.5",
     "marked": "^0.3.17",
     "moment": "^2.22.1",
+    "node-sass": "^4.11.0",
     "normalizr": "^3.2.4",
     "path-to-regexp": "^2.2.0",
     "query-string": "5",

--- a/pkg/testdatagen/make_storage_in_transit.go
+++ b/pkg/testdatagen/make_storage_in_transit.go
@@ -22,6 +22,7 @@ func MakeStorageInTransit(db *pop.Connection, assertions Assertions) models.Stor
 	// Filled in dummy data.
 	storageInTransit := models.StorageInTransit{
 		ShipmentID:         shipment.ID,
+		Shipment:           shipment,
 		Status:             models.StorageInTransitStatusREQUESTED,
 		Location:           models.StorageInTransitLocationDESTINATION,
 		EstimatedStartDate: NextValidMoveDate,
@@ -29,6 +30,7 @@ func MakeStorageInTransit(db *pop.Connection, assertions Assertions) models.Stor
 		WarehouseID:        "000383",
 		WarehouseName:      "Hercules Hauling",
 		WarehouseAddressID: address.ID,
+		WarehouseAddress:   address,
 		WarehousePhone:     swag.String("(713) 868-3497"),
 		WarehouseEmail:     swag.String("joe@herculeshauling.com"),
 	}

--- a/pkg/testdatagen/scenario/e2ebasic.go
+++ b/pkg/testdatagen/scenario/e2ebasic.go
@@ -2190,6 +2190,52 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, log
 	models.SaveMoveDependencies(db, &hhg35.Move)
 
 	/*
+	 * Service member with accepted move for use in testing SIT panel with existing SIT request from TSP
+	 */
+	email = "hhg@sit.requested.panel"
+	offer36 := testdatagen.MakeShipmentOffer(db, testdatagen.Assertions{
+		User: models.User{
+			ID:            uuid.Must(uuid.FromString("05796fb0-3f9b-42bf-9873-ba60f23b50e2")),
+			LoginGovEmail: email,
+		},
+		ServiceMember: models.ServiceMember{
+			ID:            uuid.FromStringOrNil("dcd26e48-18a0-465a-ba36-1f71f6e5cccc"),
+			FirstName:     models.StringPointer("SIT"),
+			LastName:      models.StringPointer("Panel"),
+			Edipi:         models.StringPointer("1357924680"),
+			PersonalEmail: models.StringPointer(email),
+		},
+		Move: models.Move{
+			ID:               uuid.FromStringOrNil("34ab47e2-334e-423c-9b24-1d9ce118b1cb"),
+			Locator:          "SITREQ",
+			SelectedMoveType: &selectedMoveTypeHHG,
+		},
+		TrafficDistributionList: models.TrafficDistributionList{
+			ID:                uuid.FromStringOrNil("84d3a303-9b8b-4f95-8af4-d45e16aeb5c6"),
+			SourceRateArea:    "US62",
+			DestinationRegion: "11",
+			CodeOfService:     "D",
+		},
+		Shipment: models.Shipment{
+			Status: models.ShipmentStatusACCEPTED,
+		},
+		ShipmentOffer: models.ShipmentOffer{
+			TransportationServiceProviderID: tspUser.TransportationServiceProviderID,
+			Accepted:                        models.BoolPointer(true),
+		},
+	})
+
+	testdatagen.MakeStorageInTransit(db, testdatagen.Assertions{
+		StorageInTransit: models.StorageInTransit{
+			ShipmentID: offer36.ShipmentID,
+			Shipment:   offer36.Shipment,
+		},
+	})
+	hhg36 := offer36.Shipment
+	hhg36.Move.Submit()
+	models.SaveMoveDependencies(db, &hhg36.Move)
+
+	/*
 	 * Service member with a ppm ready to request payment
 	 */
 	email = "ppm@requestingpay.ment"

--- a/pkg/testdatagen/scenario/e2ebasic.go
+++ b/pkg/testdatagen/scenario/e2ebasic.go
@@ -2227,8 +2227,9 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, log
 
 	testdatagen.MakeStorageInTransit(db, testdatagen.Assertions{
 		StorageInTransit: models.StorageInTransit{
-			ShipmentID: offer36.ShipmentID,
-			Shipment:   offer36.Shipment,
+			ShipmentID:         offer36.ShipmentID,
+			Shipment:           offer36.Shipment,
+			EstimatedStartDate: time.Date(2019, time.Month(3), 22, 0, 0, 0, 0, time.UTC),
 		},
 	})
 	hhg36 := offer36.Shipment

--- a/pkg/testdatagen/scenario/e2ebasic.go
+++ b/pkg/testdatagen/scenario/e2ebasic.go
@@ -2201,7 +2201,7 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, log
 		ServiceMember: models.ServiceMember{
 			ID:            uuid.FromStringOrNil("dcd26e48-18a0-465a-ba36-1f71f6e5cccc"),
 			FirstName:     models.StringPointer("SIT"),
-			LastName:      models.StringPointer("Panel"),
+			LastName:      models.StringPointer("Requested"),
 			Edipi:         models.StringPointer("1357924680"),
 			PersonalEmail: models.StringPointer(email),
 		},

--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -7,6 +7,7 @@ import { capitalize, get, includes } from 'lodash';
 import { NavTab, RoutedTabs } from 'react-router-tabs';
 import { Link, NavLink, Redirect, Switch } from 'react-router-dom';
 import LoadingPlaceholder from 'shared/LoadingPlaceholder';
+import { getStorageInTransitsForShipment } from 'shared/Entities/modules/storageInTransits';
 import PrivateRoute from 'shared/User/PrivateRoute';
 import LocationsContainer from './Hhg/LocationsContainer';
 import Alert from 'shared/Alert'; // eslint-disable-line
@@ -184,6 +185,7 @@ class MoveInfo extends Component {
     this.props.getAllShipmentLineItems(shipmentId);
     this.props.getAllInvoices(shipmentId);
     this.props.getServiceAgentsForShipment(shipmentId);
+    this.props.getStorageInTransitsForShipment(shipmentId);
   };
 
   approveBasics = () => {
@@ -593,6 +595,7 @@ const mapDispatchToProps = dispatch =>
       getAllInvoices,
       getTspForShipment,
       getServiceAgentsForShipment,
+      getStorageInTransitsForShipment,
       showBanner,
       removeBanner,
       loadMove,

--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -496,7 +496,7 @@ class MoveInfo extends Component {
                 Documents
                 {!showDocumentViewer && <FontAwesomeIcon className="icon" icon={faExternalLinkAlt} />}
                 {showDocumentViewer && (
-                  <Link to={`/moves/${move.id}/documents`} target="_blank">
+                  <Link to={`/moves/${move.id}/documents`} target="_blank" aria-label="Documents">
                     <FontAwesomeIcon className="icon" icon={faExternalLinkAlt} />
                   </Link>
                 )}

--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -66,6 +66,7 @@ import {
 } from 'shared/Entities/modules/moves';
 import { formatDate } from 'shared/formatters';
 import { getMoveDocumentsForMove, selectAllDocumentsForMove } from 'shared/Entities/modules/moveDocuments';
+import SitStatusIcon from 'shared/StorageInTransit/SitStatusIcon';
 
 import FontAwesomeIcon from '@fortawesome/react-fontawesome';
 import faPhone from '@fortawesome/fontawesome-free-solid/faPhone';
@@ -76,9 +77,6 @@ import faCheck from '@fortawesome/fontawesome-free-solid/faCheck';
 import faExclamationCircle from '@fortawesome/fontawesome-free-solid/faExclamationCircle';
 import faPlayCircle from '@fortawesome/fontawesome-free-solid/faPlayCircle';
 import faExternalLinkAlt from '@fortawesome/fontawesome-free-solid/faExternalLinkAlt';
-import classnames from 'classnames';
-
-import iconStyles from 'shared/styles/icons.module.scss';
 
 const BasicsTabContent = props => {
   return (
@@ -115,7 +113,6 @@ const HHGTabContent = props => {
     shipment,
     updatePublicShipment,
     showSitPanel,
-    setStatusIcon,
   } = props;
   if (shipment) {
     shipmentStatus = shipment.status;
@@ -135,9 +132,7 @@ const HHGTabContent = props => {
         transportationServiceProviderId={shipment.transportation_service_provider_id}
       />
       <PreApprovalPanel shipmentId={shipment.id} />
-      {showSitPanel && (
-        <StorageInTransitPanel shipmentId={shipmentId} moveId={moveId} setSitStatusIcon={setStatusIcon} />
-      )}
+      {showSitPanel && <StorageInTransitPanel shipmentId={shipmentId} moveId={moveId} />}
       <InvoicePanel
         shipmentId={shipment.id}
         shipmentStatus={shipmentStatus}
@@ -285,16 +280,7 @@ class MoveInfo extends Component {
     const hhgCantBeCanceled = includes(['IN_TRANSIT', 'DELIVERED', 'COMPLETED'], shipmentStatus);
 
     const hasRequestedSIT = !isEmpty(storageInTransits) && some(storageInTransits, sit => sit.status === 'REQUESTED');
-    const setStatusIcon = isTspSite => (
-      <FontAwesomeIcon
-        className={classnames(
-          iconStyles.statusIcon,
-          { [iconStyles.statusDefaultColor]: isTspSite },
-          { [iconStyles.statusAttention]: !isTspSite },
-        )}
-        icon={faClock}
-      />
-    );
+
     const moveDate = isPPM ? ppm.original_move_date : shipment && shipment.requested_pickup_date;
     if (this.state.redirectToHome) {
       return <Redirect to="/" />;
@@ -368,7 +354,7 @@ class MoveInfo extends Component {
                   <span className="title">HHG</span>
                   <span className="status">
                     {hasRequestedSIT ? (
-                      setStatusIcon(false)
+                      <SitStatusIcon isTspSite={false} />
                     ) : (
                       <FontAwesomeIcon className="icon approval-waiting" icon={faClock} />
                     )}
@@ -402,7 +388,6 @@ class MoveInfo extends Component {
                       shipmentStatus={this.props.shipmentStatus}
                       updatePublicShipment={this.props.updatePublicShipment}
                       showSitPanel={this.props.context.flags.sitPanel}
-                      setStatusIcon={setStatusIcon}
                     />
                   )}
                 </PrivateRoute>

--- a/src/shared/BasicPanel/index.jsx
+++ b/src/shared/BasicPanel/index.jsx
@@ -6,10 +6,12 @@ import './index.css';
 
 class BasicPanel extends Component {
   render() {
-    const { title, children, className } = this.props;
+    const { title, titleExtension, children, className } = this.props;
     return (
       <div className="basic-panel">
-        <div className="basic-panel-title">{title}</div>
+        <div className="basic-panel-title">
+          {title} {titleExtension}
+        </div>
         <div className={classnames('basic-panel-content', className)}>{children}</div>
       </div>
     );
@@ -20,6 +22,7 @@ BasicPanel.propTypes = {
   title: PropTypes.string.isRequired,
   children: PropTypes.node,
   className: PropTypes.string,
+  titleExtension: PropTypes.object,
 };
 
 export default BasicPanel;

--- a/src/shared/StorageInTransit/SitStatusIcon.jsx
+++ b/src/shared/StorageInTransit/SitStatusIcon.jsx
@@ -10,9 +10,9 @@ const SitStatusIcon = props => {
   return (
     <FontAwesomeIcon
       className={classnames(
-        iconStyles.statusIcon,
-        { [iconStyles.statusDefaultColor]: isTspSite },
-        { [iconStyles.statusAttention]: !isTspSite },
+        iconStyles['status-icon'],
+        { [iconStyles['status-default-color']]: isTspSite },
+        { [iconStyles['status-attention']]: !isTspSite },
       )}
       icon={faClock}
     />

--- a/src/shared/StorageInTransit/SitStatusIcon.jsx
+++ b/src/shared/StorageInTransit/SitStatusIcon.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import classnames from 'classnames';
+
+import iconStyles from 'shared/styles/icons.module.scss';
+import faClock from '@fortawesome/fontawesome-free-solid/faClock';
+import FontAwesomeIcon from '../../scenes/Office/MoveInfo';
+
+const SitStatusIcon = props => {
+  const { isTspSite } = props;
+  return (
+    <FontAwesomeIcon
+      className={classnames(
+        iconStyles.statusIcon,
+        { [iconStyles.statusDefaultColor]: isTspSite },
+        { [iconStyles.statusAttention]: !isTspSite },
+      )}
+      icon={faClock}
+    />
+  );
+};
+
+export default SitStatusIcon;

--- a/src/shared/StorageInTransit/SitStatusIcon.jsx
+++ b/src/shared/StorageInTransit/SitStatusIcon.jsx
@@ -3,7 +3,7 @@ import classnames from 'classnames';
 
 import iconStyles from 'shared/styles/icons.module.scss';
 import faClock from '@fortawesome/fontawesome-free-solid/faClock';
-import FontAwesomeIcon from '../../scenes/Office/MoveInfo';
+import FontAwesomeIcon from '@fortawesome/react-fontawesome';
 
 const SitStatusIcon = props => {
   const { isTspSite } = props;

--- a/src/shared/StorageInTransit/StorageInTransit.css
+++ b/src/shared/StorageInTransit/StorageInTransit.css
@@ -30,7 +30,7 @@
   width: calc(60% + 1.9rem);
 }
 
-#sit-status-text {
+.sit-status-text {
   margin-left: 1.8em;
 }
 

--- a/src/shared/StorageInTransit/StorageInTransitPanel.jsx
+++ b/src/shared/StorageInTransit/StorageInTransitPanel.jsx
@@ -70,7 +70,7 @@ export class StorageInTransitPanel extends Component {
                         <FontAwesomeIcon
                           className={classnames(
                             iconStyles.statusIcon,
-                            { 'icon-grey': isTspSite },
+                            { [iconStyles.statusDefaultColor]: isTspSite },
                             { [iconStyles.statusAttention]: !isTspSite },
                           )}
                           icon={faClock}

--- a/src/shared/StorageInTransit/StorageInTransitPanel.jsx
+++ b/src/shared/StorageInTransit/StorageInTransitPanel.jsx
@@ -3,10 +3,7 @@ import PropTypes from 'prop-types';
 
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
-
-import FontAwesomeIcon from '@fortawesome/react-fontawesome';
-import faClock from '@fortawesome/fontawesome-free-solid/faClock';
-import classnames from 'classnames';
+import { some } from 'lodash';
 
 import BasicPanel from 'shared/BasicPanel';
 import Alert from 'shared/Alert';
@@ -17,7 +14,6 @@ import { formatDate4DigitYear } from 'shared/formatters';
 import { calculateEntitlementsForMove } from 'shared/Entities/modules/moves';
 
 import { isTspSite } from 'shared/constants.js';
-import iconStyles from 'shared/styles/icons.module.scss';
 
 export class StorageInTransitPanel extends Component {
   constructor() {
@@ -42,13 +38,15 @@ export class StorageInTransitPanel extends Component {
   };
 
   render() {
-    const { storageInTransitEntitlement, storageInTransits } = this.props;
+    const { storageInTransitEntitlement, storageInTransits, setSitStatusIcon } = this.props;
     const { error, isCreatorActionable } = this.state;
     const daysUsed = 0; // placeholder
     const daysRemaining = storageInTransitEntitlement - daysUsed;
+    const hasRequestedSIT = some(storageInTransits, sit => sit.status === 'REQUESTED');
+
     return (
       <div className="storage-in-transit-panel">
-        <BasicPanel title="Storage in Transit (SIT)">
+        <BasicPanel title="Storage in Transit (SIT)" titleExtension={hasRequestedSIT && setSitStatusIcon(isTspSite)}>
           {error && (
             <Alert type="error" heading="Oops, something went wrong!" onRemove={this.closeError}>
               <span className="warning--header">Please refresh the page and try again.</span>
@@ -66,16 +64,7 @@ export class StorageInTransitPanel extends Component {
                     <span className="unbold">
                       {' '}
                       <span id="sit-status-text">Status:</span>{' '}
-                      {storageInTransit.status === 'REQUESTED' && (
-                        <FontAwesomeIcon
-                          className={classnames(
-                            iconStyles.statusIcon,
-                            { [iconStyles.statusDefaultColor]: isTspSite },
-                            { [iconStyles.statusAttention]: !isTspSite },
-                          )}
-                          icon={faClock}
-                        />
-                      )}
+                      {storageInTransit.status === 'REQUESTED' && setSitStatusIcon(isTspSite)}
                     </span>
                     <span>
                       SIT {storageInTransit.status.charAt(0) + storageInTransit.status.slice(1).toLowerCase()}{' '}

--- a/src/shared/StorageInTransit/StorageInTransitPanel.jsx
+++ b/src/shared/StorageInTransit/StorageInTransitPanel.jsx
@@ -67,7 +67,7 @@ export class StorageInTransitPanel extends Component {
                     {storageInTransit.location.charAt(0) + storageInTransit.location.slice(1).toLowerCase()} SIT
                     <span className="unbold">
                       {' '}
-                      <span id="sit-status-text">Status:</span>{' '}
+                      <span className="sit-status-text">Status:</span>{' '}
                       {storageInTransit.status === 'REQUESTED' && <SitStatusIcon isTspSite={isTspSite} />}
                     </span>
                     <span>

--- a/src/shared/StorageInTransit/StorageInTransitPanel.jsx
+++ b/src/shared/StorageInTransit/StorageInTransitPanel.jsx
@@ -6,6 +6,7 @@ import { bindActionCreators } from 'redux';
 
 import FontAwesomeIcon from '@fortawesome/react-fontawesome';
 import faClock from '@fortawesome/fontawesome-free-solid/faClock';
+import classnames from 'classnames';
 
 import BasicPanel from 'shared/BasicPanel';
 import Alert from 'shared/Alert';
@@ -16,6 +17,7 @@ import { formatDate4DigitYear } from 'shared/formatters';
 import { calculateEntitlementsForMove } from 'shared/Entities/modules/moves';
 
 import { isTspSite } from 'shared/constants.js';
+import iconStyles from 'shared/styles/icons.module.scss';
 
 export class StorageInTransitPanel extends Component {
   constructor() {
@@ -64,7 +66,16 @@ export class StorageInTransitPanel extends Component {
                     <span className="unbold">
                       {' '}
                       <span id="sit-status-text">Status:</span>{' '}
-                      <FontAwesomeIcon className="icon icon-grey" icon={faClock} />
+                      {storageInTransit.status === 'REQUESTED' && (
+                        <FontAwesomeIcon
+                          className={classnames(
+                            iconStyles.statusIcon,
+                            { 'icon-grey': isTspSite },
+                            { [iconStyles.statusAttention]: !isTspSite },
+                          )}
+                          icon={faClock}
+                        />
+                      )}
                     </span>
                     <span>
                       SIT {storageInTransit.status.charAt(0) + storageInTransit.status.slice(1).toLowerCase()}{' '}

--- a/src/shared/StorageInTransit/StorageInTransitPanel.jsx
+++ b/src/shared/StorageInTransit/StorageInTransitPanel.jsx
@@ -14,6 +14,7 @@ import { formatDate4DigitYear } from 'shared/formatters';
 import { calculateEntitlementsForMove } from 'shared/Entities/modules/moves';
 
 import { isTspSite } from 'shared/constants.js';
+import SitStatusIcon from './SitStatusIcon';
 
 export class StorageInTransitPanel extends Component {
   constructor() {
@@ -38,7 +39,7 @@ export class StorageInTransitPanel extends Component {
   };
 
   render() {
-    const { storageInTransitEntitlement, storageInTransits, setSitStatusIcon } = this.props;
+    const { storageInTransitEntitlement, storageInTransits } = this.props;
     const { error, isCreatorActionable } = this.state;
     const daysUsed = 0; // placeholder
     const daysRemaining = storageInTransitEntitlement - daysUsed;
@@ -46,7 +47,10 @@ export class StorageInTransitPanel extends Component {
 
     return (
       <div className="storage-in-transit-panel">
-        <BasicPanel title="Storage in Transit (SIT)" titleExtension={hasRequestedSIT && setSitStatusIcon(isTspSite)}>
+        <BasicPanel
+          title="Storage in Transit (SIT)"
+          titleExtension={!isTspSite && hasRequestedSIT && <SitStatusIcon isTspSite={isTspSite} />}
+        >
           {error && (
             <Alert type="error" heading="Oops, something went wrong!" onRemove={this.closeError}>
               <span className="warning--header">Please refresh the page and try again.</span>
@@ -64,7 +68,7 @@ export class StorageInTransitPanel extends Component {
                     <span className="unbold">
                       {' '}
                       <span id="sit-status-text">Status:</span>{' '}
-                      {storageInTransit.status === 'REQUESTED' && setSitStatusIcon(isTspSite)}
+                      {storageInTransit.status === 'REQUESTED' && <SitStatusIcon isTspSite={isTspSite} />}
                     </span>
                     <span>
                       SIT {storageInTransit.status.charAt(0) + storageInTransit.status.slice(1).toLowerCase()}{' '}

--- a/src/shared/StorageInTransit/StorageInTransitPanel.test.jsx
+++ b/src/shared/StorageInTransit/StorageInTransitPanel.test.jsx
@@ -43,7 +43,7 @@ describe('StorageInTransit tests', () => {
       expect(wrapper.find('.add-request').length).toEqual(1);
     });
   });
-  describe('When no items exists and Request SIT does not appears on Office app', () => {
+  describe('When no items exists and Request SIT appears on Office app', () => {
     CONSTANTS.isTspSite = false;
     let wrapper;
     const sitRequests = [];

--- a/src/shared/styles/colors.scss
+++ b/src/shared/styles/colors.scss
@@ -1,0 +1,1 @@
+$color-gold: #fdb81e;

--- a/src/shared/styles/colors.scss
+++ b/src/shared/styles/colors.scss
@@ -1,1 +1,4 @@
+//colors should primarily come from https://designsystem.digital.gov/components/colors/
+
 $color-gold: #fdb81e;
+$color-icon-gray: #ababab;

--- a/src/shared/styles/icons.module.scss
+++ b/src/shared/styles/icons.module.scss
@@ -4,6 +4,10 @@
   color: $color-gold;
 }
 
+.statusDefaultColor {
+  color: $color-icon-gray;
+}
+
 .statusIcon {
   margin: 0 0.3em 0 0.3em;
 }

--- a/src/shared/styles/icons.module.scss
+++ b/src/shared/styles/icons.module.scss
@@ -1,13 +1,13 @@
 @import 'shared/styles/colors.scss';
 
-.statusAttention {
+.status-attention {
   color: $color-gold;
 }
 
-.statusDefaultColor {
+.status-default-color {
   color: $color-icon-gray;
 }
 
-.statusIcon {
+.status-icon {
   margin: 0 0.3em 0 0.3em;
 }

--- a/src/shared/styles/icons.module.scss
+++ b/src/shared/styles/icons.module.scss
@@ -1,0 +1,9 @@
+@import 'shared/styles/colors.scss';
+
+.statusAttention {
+  color: $color-gold;
+}
+
+.statusIcon {
+  margin: 0 0.3em 0 0.3em;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1460,6 +1460,11 @@ alphanum-sort@^1.0.0:
   resolved "https://registry.yarnpkg.com/alphanum-sort/-/alphanum-sort-1.0.2.tgz#97a1119649b211ad33691d9f9f486a8ec9fbe0a3"
   integrity sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM=
 
+amdefine@>=0.0.4:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
+  integrity sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=
+
 ansi-colors@^3.0.0:
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-3.2.3.tgz#57d35b8686e851e2cc04c403f1c00203976a1813"
@@ -1733,6 +1738,11 @@ async-each@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/async-each/-/async-each-1.0.1.tgz#19d386a1d9edc6e7c1c85d388aedbcc56d33602d"
   integrity sha1-GdOGodntxufByF04iu28xW0zYC0=
+
+async-foreach@^0.1.3:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/async-foreach/-/async-foreach-0.1.3.tgz#36121f845c0578172de419a97dbeb1d16ec34542"
+  integrity sha1-NhIfhFwFeBct5Bmpfb6x0W7DRUI=
 
 async-limiter@~1.0.0:
   version "1.0.0"
@@ -2154,6 +2164,13 @@ binary-extensions@^1.0.0:
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.13.0.tgz#9523e001306a32444b907423f1de2164222f6ab1"
   integrity sha512-EgmjVLMn22z7eGGv3kcnHwSnJXmFHjISTY9E/S5lIcTD3Oxw05QTcBLNkJFzcb3cNueUdF/IN4U+d78V0zO8Hw==
+
+block-stream@*:
+  version "0.0.9"
+  resolved "https://registry.yarnpkg.com/block-stream/-/block-stream-0.0.9.tgz#13ebfe778a03205cfe03751481ebb4b3300c126a"
+  integrity sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=
+  dependencies:
+    inherits "~2.0.0"
 
 bluebird@3.5.0:
   version "3.5.0"
@@ -2599,6 +2616,11 @@ camelcase@^2.0.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-2.1.1.tgz#7c1d16d679a1bbe59ca02cacecfb011e201f5a1f"
   integrity sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=
 
+camelcase@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-3.0.0.tgz#32fc4b9fcdaf845fcdf7e73bb97cac2261f0ab0a"
+  integrity sha1-MvxLn82vhF/N9+c7uXysImHwqwo=
+
 camelcase@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
@@ -2820,6 +2842,15 @@ cli-width@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.2.0.tgz#ff19ede8a9a5e579324147b0c11f0fbcbabed639"
   integrity sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=
+
+cliui@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-3.2.0.tgz#120601537a916d29940f934da3b48d585a39213d"
+  integrity sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=
+  dependencies:
+    string-width "^1.0.1"
+    strip-ansi "^3.0.1"
+    wrap-ansi "^2.0.0"
 
 cliui@^4.0.0:
   version "4.1.0"
@@ -3242,6 +3273,14 @@ cross-spawn@6.0.5, cross-spawn@^6.0.0, cross-spawn@^6.0.5:
     path-key "^2.0.1"
     semver "^5.5.0"
     shebang-command "^1.2.0"
+    which "^1.2.9"
+
+cross-spawn@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-3.0.1.tgz#1256037ecb9f0c5f79e3d6ef135e30770184b982"
+  integrity sha1-ElYDfsufDF9549bvE14wdwGEuYI=
+  dependencies:
+    lru-cache "^4.0.1"
     which "^1.2.9"
 
 cross-spawn@^5.0.1:
@@ -5087,6 +5126,16 @@ fsevents@^1.2.2, fsevents@^1.2.3:
     nan "^2.9.2"
     node-pre-gyp "^0.10.0"
 
+fstream@^1.0.0, fstream@^1.0.2:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/fstream/-/fstream-1.0.11.tgz#5c1fb1f117477114f0632a0eb4b71b3cb0fd3171"
+  integrity sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=
+  dependencies:
+    graceful-fs "^4.1.2"
+    inherits "~2.0.0"
+    mkdirp ">=0.5 0"
+    rimraf "2"
+
 function-bind@^1.0.2, function-bind@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
@@ -5119,6 +5168,13 @@ gauge@~2.7.3:
     string-width "^1.0.1"
     strip-ansi "^3.0.1"
     wide-align "^1.1.0"
+
+gaze@^1.0.0:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/gaze/-/gaze-1.1.3.tgz#c441733e13b927ac8c0ff0b4c3b033f28812924a"
+  integrity sha512-BRdNm8hbWzFzWHERTrejLqwHDfS4GibPoq5wjTPIoJHoBtKGPg3xAFfxmM+9ztbXelxcf2hwQcaz1PtmFeue8g==
+  dependencies:
+    globule "^1.0.0"
 
 get-assigned-identifiers@^1.2.0:
   version "1.2.0"
@@ -5211,7 +5267,7 @@ glob@7.1.2:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.0.3, glob@^7.1.0, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3:
+glob@^7.0.0, glob@^7.0.3, glob@^7.1.0, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@~7.1.1:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.3.tgz#3960832d3f1574108342dafd3a67b332c0969df1"
   integrity sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==
@@ -5283,6 +5339,15 @@ globby@^6.1.0:
     object-assign "^4.0.1"
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
+
+globule@^1.0.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/globule/-/globule-1.2.1.tgz#5dffb1b191f22d20797a9369b49eab4e9839696d"
+  integrity sha512-g7QtgWF4uYSL5/dn71WxubOrS7JVGCnFPEnoeChJmBnyR9Mw8nGoEwOgJL/RC2Te0WhbsEUCejfH8SZNJ+adYQ==
+  dependencies:
+    glob "~7.1.1"
+    lodash "~4.17.10"
+    minimatch "~3.0.2"
 
 graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6:
   version "4.1.15"
@@ -5852,6 +5917,11 @@ imurmurhash@^0.1.4:
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
 
+in-publish@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/in-publish/-/in-publish-2.0.0.tgz#e20ff5e3a2afc2690320b6dc552682a9c7fadf51"
+  integrity sha1-4g/146KvwmkDILbcVSaCqcf631E=
+
 indent-string@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-2.1.0.tgz#8e2d48348742121b4a8218b7a137e9a52049dc80"
@@ -5882,7 +5952,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@2.0.3, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.1, inherits@~2.0.3:
+inherits@2, inherits@2.0.3, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.0, inherits@~2.0.1, inherits@~2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
   integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
@@ -6844,6 +6914,11 @@ joi@^11.1.1:
     isemail "3.x.x"
     topo "2.x.x"
 
+js-base64@^2.1.8:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.5.1.tgz#1efa39ef2c5f7980bb1784ade4a8af2de3291121"
+  integrity sha512-M7kLczedRMYX4L8Mdh4MzyAMM9O5osx+4FcOQuTvr3A9F2D9S5JXheN0ewNbrvK2UatkTRhL5ejGmGSjNMiZuw==
+
 js-cookie@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-2.2.0.tgz#1b2c279a6eece380a12168b92485265b35b1effb"
@@ -7344,10 +7419,20 @@ lodash._reinterpolate@~3.0.0:
   resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
   integrity sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=
 
+lodash.assign@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.assign/-/lodash.assign-4.2.0.tgz#0d99f3ccd7a6d261d19bdaeb9245005d285808e7"
+  integrity sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=
+
 lodash.camelcase@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
   integrity sha1-soqmKIorn8ZRA1x3EfZathkDMaY=
+
+lodash.clonedeep@^4.3.2:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
+  integrity sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=
 
 lodash.debounce@^4.0.7, lodash.debounce@^4.0.8:
   version "4.0.8"
@@ -7384,6 +7469,11 @@ lodash.memoize@~3.0.3:
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-3.0.4.tgz#2dcbd2c287cbc0a55cc42328bd0c736150d53e3f"
   integrity sha1-LcvSwofLwKVcxCMovQxzYVDVPj8=
 
+lodash.mergewith@^4.6.0:
+  version "4.6.1"
+  resolved "https://registry.yarnpkg.com/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz#639057e726c3afbdb3e7d42741caa8d6e4335927"
+  integrity sha512-eWw5r+PYICtEBgrBE5hhlT6aAa75f411bgDz/ZL2KZqYV03USvucsxcHUIlGTDTECs1eunpI7HOV7U+WLDvNdQ==
+
 lodash.once@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
@@ -7419,7 +7509,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@4.17.11, "lodash@>=3.5 <5", lodash@^4.13.1, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.16.2, lodash@^4.16.4, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.1, lodash@^4.3.0:
+lodash@4.17.11, "lodash@>=3.5 <5", lodash@^4.0.0, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.16.2, lodash@^4.16.4, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.1, lodash@^4.3.0, lodash@~4.17.10:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
@@ -7639,7 +7729,7 @@ memory-fs@^0.4.0, memory-fs@~0.4.1:
     errno "^0.1.3"
     readable-stream "^2.0.1"
 
-meow@^3.3.0:
+meow@^3.3.0, meow@^3.7.0:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/meow/-/meow-3.7.0.tgz#72cb668b425228290abbfa856892587308a801fb"
   integrity sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=
@@ -7783,7 +7873,7 @@ minimalistic-crypto-utils@^1.0.0, minimalistic-crypto-utils@^1.0.1:
   resolved "https://registry.yarnpkg.com/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
   integrity sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=
 
-minimatch@3.0.4, minimatch@^3.0.3, minimatch@^3.0.4:
+minimatch@3.0.4, minimatch@^3.0.3, minimatch@^3.0.4, minimatch@~3.0.2:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
@@ -7875,7 +7965,7 @@ mkdirp@0.5.0:
   dependencies:
     minimist "0.0.8"
 
-mkdirp@0.5.1, mkdirp@0.5.x, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@~0.5.1:
+mkdirp@0.5.1, mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@~0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
@@ -7999,6 +8089,11 @@ mute-stream@0.0.7:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
   integrity sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=
 
+nan@^2.10.0:
+  version "2.13.1"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.13.1.tgz#a15bee3790bde247e8f38f1d446edcdaeb05f2dd"
+  integrity sha512-I6YB/YEuDeUZMmhscXKxGgZlFnhsn5y0hgOZBadkzfTRrZBtJDZeg6eQf7PYMIEclwmorTKK8GztsyOUSVBREA==
+
 nan@^2.9.2:
   version "2.12.1"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.12.1.tgz#7b1aa193e9aa86057e3c7bbd0ac448e770925552"
@@ -8086,6 +8181,24 @@ node-forge@0.7.5:
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.7.5.tgz#6c152c345ce11c52f465c2abd957e8639cd674df"
   integrity sha512-MmbQJ2MTESTjt3Gi/3yG1wGpIMhUfcIypUCGtTizFR9IiccFwxSpfp0vtIZlkFclEqERemxfnSdZEMR9VqqEFQ==
 
+node-gyp@^3.8.0:
+  version "3.8.0"
+  resolved "https://registry.yarnpkg.com/node-gyp/-/node-gyp-3.8.0.tgz#540304261c330e80d0d5edce253a68cb3964218c"
+  integrity sha512-3g8lYefrRRzvGeSowdJKAKyks8oUpLEd/DyPV4eMhVlhJ0aNaZqIrNUIPuEWWTAoPqyFkfGrM67MC69baqn6vA==
+  dependencies:
+    fstream "^1.0.0"
+    glob "^7.0.3"
+    graceful-fs "^4.1.2"
+    mkdirp "^0.5.0"
+    nopt "2 || 3"
+    npmlog "0 || 1 || 2 || 3 || 4"
+    osenv "0"
+    request "^2.87.0"
+    rimraf "2"
+    semver "~5.3.0"
+    tar "^2.0.0"
+    which "1"
+
 node-int64@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
@@ -8154,6 +8267,38 @@ node-releases@^1.0.0-alpha.11, node-releases@^1.1.3:
   dependencies:
     semver "^5.3.0"
 
+node-sass@^4.11.0:
+  version "4.11.0"
+  resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.11.0.tgz#183faec398e9cbe93ba43362e2768ca988a6369a"
+  integrity sha512-bHUdHTphgQJZaF1LASx0kAviPH7sGlcyNhWade4eVIpFp6tsn7SV8xNMTbsQFpEV9VXpnwTTnNYlfsZXgGgmkA==
+  dependencies:
+    async-foreach "^0.1.3"
+    chalk "^1.1.1"
+    cross-spawn "^3.0.0"
+    gaze "^1.0.0"
+    get-stdin "^4.0.1"
+    glob "^7.0.3"
+    in-publish "^2.0.0"
+    lodash.assign "^4.2.0"
+    lodash.clonedeep "^4.3.2"
+    lodash.mergewith "^4.6.0"
+    meow "^3.7.0"
+    mkdirp "^0.5.1"
+    nan "^2.10.0"
+    node-gyp "^3.8.0"
+    npmlog "^4.0.0"
+    request "^2.88.0"
+    sass-graph "^2.2.4"
+    stdout-stream "^1.4.0"
+    "true-case-path" "^1.0.2"
+
+"nopt@2 || 3":
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/nopt/-/nopt-3.0.6.tgz#c6465dbf08abcd4db359317f79ac68a646b28ff9"
+  integrity sha1-xkZdvwirzU2zWTF/eaxopkayj/k=
+  dependencies:
+    abbrev "1"
+
 nopt@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/nopt/-/nopt-4.0.1.tgz#d0d4685afd5415193c8c7505602d0d17cd64474d"
@@ -8221,7 +8366,7 @@ npm-run-path@^2.0.0:
   dependencies:
     path-key "^2.0.0"
 
-npmlog@^4.0.2:
+"npmlog@0 || 1 || 2 || 3 || 4", npmlog@^4.0.0, npmlog@^4.0.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
   integrity sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==
@@ -8470,6 +8615,13 @@ os-homedir@^1.0.0, os-homedir@^1.0.1:
   resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
   integrity sha1-/7xJiDNuDoM94MFox+8VISGqf7M=
 
+os-locale@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/os-locale/-/os-locale-1.4.0.tgz#20f9f17ae29ed345e8bde583b13d2009803c14d9"
+  integrity sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=
+  dependencies:
+    lcid "^1.0.0"
+
 os-locale@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/os-locale/-/os-locale-2.1.0.tgz#42bc2900a6b5b8bd17376c8e882b65afccf24bf2"
@@ -8498,7 +8650,7 @@ os-tmpdir@^1.0.0, os-tmpdir@^1.0.1, os-tmpdir@~1.0.1, os-tmpdir@~1.0.2:
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
   integrity sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=
 
-osenv@^0.1.4:
+osenv@0, osenv@^0.1.4:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/osenv/-/osenv-0.1.5.tgz#85cdfafaeb28e8677f416e287592b5f3f49ea410"
   integrity sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==
@@ -10628,7 +10780,7 @@ rgba-regex@^1.0.0:
   resolved "https://registry.yarnpkg.com/rgba-regex/-/rgba-regex-1.0.0.tgz#43374e2e2ca0968b0ef1523460b7d730ff22eeb3"
   integrity sha1-QzdOLiyglosO8VI0YLfXMP8i7rM=
 
-rimraf@^2.2.8, rimraf@^2.4.4, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2, rimraf@~2.6.2:
+rimraf@2, rimraf@^2.2.8, rimraf@^2.4.4, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2, rimraf@~2.6.2:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
   integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
@@ -10722,6 +10874,16 @@ sane@^2.0.0:
   optionalDependencies:
     fsevents "^1.2.3"
 
+sass-graph@^2.2.4:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/sass-graph/-/sass-graph-2.2.4.tgz#13fbd63cd1caf0908b9fd93476ad43a51d1e0b49"
+  integrity sha1-E/vWPNHK8JCLn9k0dq1DpR0eC0k=
+  dependencies:
+    glob "^7.0.0"
+    lodash "^4.0.0"
+    scss-tokenizer "^0.2.3"
+    yargs "^7.0.0"
+
 sass-loader@7.1.0:
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/sass-loader/-/sass-loader-7.1.0.tgz#16fd5138cb8b424bf8a759528a1972d72aad069d"
@@ -10771,6 +10933,14 @@ schema-utils@^1.0.0:
     ajv-errors "^1.0.0"
     ajv-keywords "^3.1.0"
 
+scss-tokenizer@^0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz#8eb06db9a9723333824d3f5530641149847ce5d1"
+  integrity sha1-jrBtualyMzOCTT9VMGQRSYR85dE=
+  dependencies:
+    js-base64 "^2.1.8"
+    source-map "^0.4.2"
+
 select-hose@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/select-hose/-/select-hose-2.0.0.tgz#625d8658f865af43ec962bfc376a37359a4994ca"
@@ -10797,6 +10967,11 @@ selfsigned@^1.9.1:
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
   integrity sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==
+
+semver@~5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
+  integrity sha1-myzl094C0XxgEq0yaqa00M9U+U8=
 
 send@0.16.2:
   version "0.16.2"
@@ -11094,6 +11269,13 @@ source-map-url@^0.4.0:
   resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.0.tgz#3e935d7ddd73631b97659956d55128e87b5084a3"
   integrity sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=
 
+source-map@^0.4.2:
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.4.4.tgz#eba4f5da9c0dc999de68032d8b4f76173652036b"
+  integrity sha1-66T12pwNyZneaAMti092FzZSA2s=
+  dependencies:
+    amdefine ">=0.0.4"
+
 source-map@^0.5.0, source-map@^0.5.3, source-map@^0.5.6, source-map@^0.5.7, source-map@~0.5.3:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
@@ -11235,6 +11417,13 @@ statuses@~1.4.0:
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.4.0.tgz#bb73d446da2796106efcc1b601a253d6c46bd087"
   integrity sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==
 
+stdout-stream@^1.4.0:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/stdout-stream/-/stdout-stream-1.4.1.tgz#5ac174cdd5cd726104aa0c0b2bd83815d8d535de"
+  integrity sha512-j4emi03KXqJWcIeF8eIXkjMFN1Cmb8gUlDYGeBALLPo5qdyTfA9bOtl8m33lRoC+vFMkP3gl0WsDr6+gzxbbTA==
+  dependencies:
+    readable-stream "^2.0.1"
+
 stealthy-require@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
@@ -11306,7 +11495,7 @@ string-length@^2.0.0:
     astral-regex "^1.0.0"
     strip-ansi "^4.0.0"
 
-string-width@^1.0.1:
+string-width@^1.0.1, string-width@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-1.0.2.tgz#118bdf5b8cdc51a2a7e70d211e07e2b0b9b107d3"
   integrity sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=
@@ -11584,6 +11773,15 @@ tapable@^1.0.0, tapable@^1.1.0:
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-1.1.1.tgz#4d297923c5a72a42360de2ab52dadfaaec00018e"
   integrity sha512-9I2ydhj8Z9veORCw5PRm4u9uebCn0mcCa6scWoNcbZ6dAtoo2618u9UUzxgmsCOreJpqDDuv61LvwofW7hLcBA==
 
+tar@^2.0.0:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-2.2.1.tgz#8e4d2a256c0e2185c6b18ad694aec968b83cb1d1"
+  integrity sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=
+  dependencies:
+    block-stream "*"
+    fstream "^1.0.2"
+    inherits "2"
+
 tar@^4:
   version "4.4.8"
   resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.8.tgz#b19eec3fde2a96e64666df9fdb40c5ca1bc3747d"
@@ -11823,6 +12021,13 @@ trim-right@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
   integrity sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=
+
+"true-case-path@^1.0.2":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/true-case-path/-/true-case-path-1.0.3.tgz#f813b5a8c86b40da59606722b144e3225799f47d"
+  integrity sha512-m6s2OdQe5wgpFMC+pAJ+q9djG82O2jcHPOI6RNg1yy9rCYR+WD6Nbpl32fDpfC56nirdRy+opFa/Vk7HYhqaew==
+  dependencies:
+    glob "^7.1.2"
 
 tryer@^1.0.0:
   version "1.0.1"
@@ -12421,12 +12626,17 @@ whatwg-url@^7.0.0:
     tr46 "^1.0.1"
     webidl-conversions "^4.0.2"
 
+which-module@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/which-module/-/which-module-1.0.0.tgz#bba63ca861948994ff307736089e3b96026c2a4f"
+  integrity sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=
+
 which-module@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
   integrity sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=
 
-which@^1.2.12, which@^1.2.14, which@^1.2.9, which@^1.3.0:
+which@1, which@^1.2.12, which@^1.2.14, which@^1.2.9, which@^1.3.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
   integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
@@ -12700,6 +12910,13 @@ yargs-parser@^11.1.1:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
 
+yargs-parser@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-5.0.0.tgz#275ecf0d7ffe05c77e64e7c86e4cd94bf0e1228a"
+  integrity sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=
+  dependencies:
+    camelcase "^3.0.0"
+
 yargs-parser@^9.0.2:
   version "9.0.2"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-9.0.2.tgz#9ccf6a43460fe4ed40a9bb68f48d43b8a68cc077"
@@ -12760,6 +12977,25 @@ yargs@^12.0.2, yargs@^12.0.5:
     which-module "^2.0.0"
     y18n "^3.2.1 || ^4.0.0"
     yargs-parser "^11.1.1"
+
+yargs@^7.0.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-7.1.0.tgz#6ba318eb16961727f5d284f8ea003e8d6154d0c8"
+  integrity sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=
+  dependencies:
+    camelcase "^3.0.0"
+    cliui "^3.2.0"
+    decamelize "^1.1.1"
+    get-caller-file "^1.0.1"
+    os-locale "^1.4.0"
+    read-pkg-up "^1.0.1"
+    require-directory "^2.1.1"
+    require-main-filename "^1.0.1"
+    set-blocking "^2.0.0"
+    string-width "^1.0.2"
+    which-module "^1.0.0"
+    y18n "^3.2.1"
+    yargs-parser "^5.0.0"
 
 yauzl@2.4.1:
   version "2.4.1"


### PR DESCRIPTION
## Description

This allows SIT info to be seen by the office user, including status icon (in HHG tab, sit panel title, and for each SIT status), dates, notes, and warehouse info.

This also implements usage of SCSS and CSS Modules.

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

As office user, go to "Accepted HHGs" and choose user SITREQ, click on HHG panel

## Code Review Verification Steps

* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers](./docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

Addresses two stories:
* [Pivotal story](https://www.pivotaltracker.com/story/show/163338380) for this change
* [Pivotal story](https://www.pivotaltracker.com/story/show/163914887) for this change

## Screenshots
![image](https://user-images.githubusercontent.com/13249580/54861627-93118280-4ce9-11e9-9dec-54f68a935157.png)
![image](https://user-images.githubusercontent.com/13249580/54861629-ade3f700-4ce9-11e9-9e13-7a45aadd8861.png)
![image](https://user-images.githubusercontent.com/13249580/54861660-25198b00-4cea-11e9-9772-4a14d118f27f.png)


