### PR TITLE
postgres - add indexes to foreign keys

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -811,9 +811,9 @@ workflows:
             - pre_deps_yarn
             - acceptance_tests_local
           # if testing on experimental, you can disable these tests by using the commented block below.
-          filters:
-           branches:
-             ignore: lt-add-table-indexes
+          # filters:
+          #  branches:
+          #    ignore: placeholder_branch_name
 
       - integration_tests_office:
           requires:
@@ -821,9 +821,9 @@ workflows:
             - pre_deps_yarn
             - acceptance_tests_local
           # if testing on experimental, you can disable these tests by using the commented block below.
-          filters:
-            branches:
-              ignore: lt-add-table-indexes
+          # filters:
+          #   branches:
+          #     ignore: placeholder_branch_name
 
       - integration_tests_tsp:
           requires:
@@ -831,9 +831,9 @@ workflows:
             - pre_deps_yarn
             - acceptance_tests_local
           # if testing on experimental, you can disable these tests by using the commented block below.
-          filters:
-            branches:
-              ignore: lt-add-table-indexes
+          # filters:
+          #   branches:
+          #     ignore: placeholder_branch_name
 
       - integration_tests_api:
           requires:
@@ -841,9 +841,9 @@ workflows:
             - pre_deps_yarn
             - acceptance_tests_local
           # if testing on experimental, you can disable these tests by using the commented block below.
-          filters:
-            branches:
-              ignore: lt-add-table-indexes
+          # filters:
+          #   branches:
+          #     ignore: placeholder_branch_name
 
       - client_test:
           requires:
@@ -887,21 +887,21 @@ workflows:
             - build_migrations
           filters:
             branches:
-              only: lt-add-table-indexes
+              only: placeholder_branch_name
 
       - deploy_experimental_app:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: lt-add-table-indexes
+              only: placeholder_branch_name
 
       - deploy_experimental_app_client_tls:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: lt-add-table-indexes
+              only: placeholder_branch_name
 
       - check_circle_against_staging_sha:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -811,9 +811,9 @@ workflows:
             - pre_deps_yarn
             - acceptance_tests_local
           # if testing on experimental, you can disable these tests by using the commented block below.
-          # filters:
-          #  branches:
-          #    ignore: placeholder_branch_name
+          filters:
+           branches:
+             ignore: lt-add-table-indexes
 
       - integration_tests_office:
           requires:
@@ -821,9 +821,9 @@ workflows:
             - pre_deps_yarn
             - acceptance_tests_local
           # if testing on experimental, you can disable these tests by using the commented block below.
-          # filters:
-          #   branches:
-          #     ignore: placeholder_branch_name
+          filters:
+            branches:
+              ignore: lt-add-table-indexes
 
       - integration_tests_tsp:
           requires:
@@ -831,9 +831,9 @@ workflows:
             - pre_deps_yarn
             - acceptance_tests_local
           # if testing on experimental, you can disable these tests by using the commented block below.
-          # filters:
-          #   branches:
-          #     ignore: placeholder_branch_name
+          filters:
+            branches:
+              ignore: lt-add-table-indexes
 
       - integration_tests_api:
           requires:
@@ -841,9 +841,9 @@ workflows:
             - pre_deps_yarn
             - acceptance_tests_local
           # if testing on experimental, you can disable these tests by using the commented block below.
-          # filters:
-          #   branches:
-          #     ignore: placeholder_branch_name
+          filters:
+            branches:
+              ignore: lt-add-table-indexes
 
       - client_test:
           requires:
@@ -887,21 +887,21 @@ workflows:
             - build_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: lt-add-table-indexes
 
       - deploy_experimental_app:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: lt-add-table-indexes
 
       - deploy_experimental_app_client_tls:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: lt-add-table-indexes
 
       - check_circle_against_staging_sha:
           requires:

--- a/migrations/20190306205302_add-indexes-for-foreign-keys.up.fizz
+++ b/migrations/20190306205302_add-indexes-for-foreign-keys.up.fizz
@@ -1,0 +1,92 @@
+add_index("blackout_dates", "transportation_service_provider_id", {});
+add_index("blackout_dates", "traffic_distribution_list_id", {});
+
+add_index("distance_calculations", "origin_address_id", {});
+add_index("distance_calculations", "destination_address_id", {});
+
+add_index("documents", "service_member_id", {});
+
+add_index("duty_stations", "address_id", {});
+add_index("duty_stations", "transportation_office_id", {});
+
+
+add_index("invoices", "shipment_id", {});
+add_index("invoices", "approver_id", {});
+add_index("invoices", "upload_id", {});
+
+
+add_index("move_documents", "document_id", {});
+add_index("move_documents", "personally_procured_move_id", {});
+add_index("move_documents", "shipment_id", {});
+
+add_index("moves", "orders_id", {});
+
+add_index("moving_expense_documents", "move_document_id", {});
+
+add_index("office_emails", "transportation_office_id", {});
+
+add_index("office_phone_lines", "transportation_office_id", {});
+
+add_index("office_users", "user_id", {});
+add_index("office_users", "transportation_office_id", {});
+
+add_index("orders", "service_member_id", {});
+add_index("orders", "new_duty_station_id", {});
+add_index("orders", "uploaded_orders_id", {});
+
+add_index("personally_procured_moves", "move_id", {});
+add_index("personally_procured_moves", "advance_worksheet_id", {});
+
+add_index("service_agents", "shipment_id", {});
+
+add_index("service_members", "user_id", {});
+add_index("service_members", "social_security_number_id", {});
+add_index("service_members", "duty_station_id", {});
+add_index("service_members", "backup_mailing_address_id", {});
+add_index("service_members", "residential_address_id", {});
+
+add_index("shipment_line_items", "tariff400ng_item_id", {});
+add_index("shipment_line_items", "shipment_id", {});
+add_index("shipment_line_items", "item_dimensions_id", {});
+add_index("shipment_line_items", "crate_dimensions_id", {});
+add_index("shipment_line_items", "invoice_id", {});
+
+add_index("shipment_offers", "transportation_service_provider_id", {});
+add_index("shipment_offers", "transportation_service_provider_performance_id", {});
+add_index("shipment_offers", "shipment_id", {});
+
+add_index("shipment_recalculate_logs", "shipment_id", {});
+
+add_index("shipments", "traffic_distribution_list_id", {});
+add_index("shipments", "service_member_id", {});
+add_index("shipments", "move_id", {});
+add_index("shipments", "shipping_distance_id", {});
+add_index("shipments", "pickup_address_id", {});
+add_index("shipments", "secondary_pickup_address_id", {});
+add_index("shipments", "delivery_address_id", {});
+add_index("shipments", "partial_sit_delivery_address_id", {});
+add_index("shipments", "destination_address_on_acceptance_id", {});
+
+add_index("signed_certifications", "submitting_user_id", {});
+add_index("signed_certifications", "move_id", {});
+
+add_index("storage_in_transits", "shipment_id", {});
+add_index("storage_in_transits", "warehouse_address_id", {});
+
+add_index("transportation_offices", "shipping_office_id", {});
+add_index("transportation_offices", "address_id", {});
+
+add_index("transportation_service_provider_performances", "transportation_service_provider_id", {});
+add_index("transportation_service_provider_performances", "traffic_distribution_list_id", {});
+
+add_index("tsp_users", "user_id", {});
+add_index("tsp_users", "transportation_service_provider_id", {});
+
+add_index("uploads", "uploader_id", {});
+
+
+
+
+add_index("shipments", "status", {});
+add_index("shipments", "actual_pickup_date", {});
+add_index("shipments", "actual_delivery_date", {});

--- a/migrations/20190306205302_add-indexes-for-foreign-keys.up.fizz
+++ b/migrations/20190306205302_add-indexes-for-foreign-keys.up.fizz
@@ -31,6 +31,8 @@ add_index("office_phone_lines", "transportation_office_id", {});
 
 add_index("office_users", "user_id", {});
 add_index("office_users", "transportation_office_id", {});
+add_index("office_users", "email", {});
+
 
 add_index("orders", "service_member_id", {});
 add_index("orders", "new_duty_station_id", {});
@@ -46,6 +48,7 @@ add_index("service_members", "social_security_number_id", {});
 add_index("service_members", "duty_station_id", {});
 add_index("service_members", "backup_mailing_address_id", {});
 add_index("service_members", "residential_address_id", {});
+add_index("service_members", "personal_email", {});
 
 add_index("shipment_line_items", "tariff400ng_item_id", {});
 add_index("shipment_line_items", "shipment_id", {});
@@ -81,9 +84,12 @@ add_index("transportation_offices", "address_id", {});
 
 add_index("transportation_service_provider_performances", "transportation_service_provider_id", {});
 add_index("transportation_service_provider_performances", "traffic_distribution_list_id", {});
+add_index("transportation_service_provider", "poc_general_email", {});
+add_index("transportation_service_provider", "poc_claims_eamil", {});
 
 add_index("tsp_users", "user_id", {});
 add_index("tsp_users", "transportation_service_provider_id", {});
+add_index("tsp_users", "email", {});
 
 add_index("uploads", "uploader_id", {});
 add_index("uploads", "document_id", {});

--- a/migrations/20190306205302_add-indexes-for-foreign-keys.up.fizz
+++ b/migrations/20190306205302_add-indexes-for-foreign-keys.up.fizz
@@ -31,8 +31,6 @@ add_index("office_phone_lines", "transportation_office_id", {});
 
 add_index("office_users", "user_id", {});
 add_index("office_users", "transportation_office_id", {});
-add_index("office_users", "email", {});
-
 
 add_index("orders", "service_member_id", {});
 add_index("orders", "new_duty_station_id", {});
@@ -84,12 +82,11 @@ add_index("transportation_offices", "address_id", {});
 
 add_index("transportation_service_provider_performances", "transportation_service_provider_id", {});
 add_index("transportation_service_provider_performances", "traffic_distribution_list_id", {});
-add_index("transportation_service_provider", "poc_general_email", {});
-add_index("transportation_service_provider", "poc_claims_eamil", {});
+
+add_index("transportation_service_providers", "poc_general_email", {});
 
 add_index("tsp_users", "user_id", {});
 add_index("tsp_users", "transportation_service_provider_id", {});
-add_index("tsp_users", "email", {});
 
 add_index("uploads", "uploader_id", {});
 add_index("uploads", "document_id", {});

--- a/migrations/20190306205302_add-indexes-for-foreign-keys.up.fizz
+++ b/migrations/20190306205302_add-indexes-for-foreign-keys.up.fizz
@@ -1,14 +1,16 @@
-add_index("blackout_dates", "transportation_service_provider_id", {});
-add_index("blackout_dates", "traffic_distribution_list_id", {});
+add_index("backup_contacts", "email", {});
 
 add_index("distance_calculations", "origin_address_id", {});
 add_index("distance_calculations", "destination_address_id", {});
 
 add_index("documents", "service_member_id", {});
 
+add_index("dps_users", "login_gov_email", {});
+
 add_index("duty_stations", "address_id", {});
 add_index("duty_stations", "transportation_office_id", {});
 
+add_index("electronic_orders_revisions", ["electronic_order_id", "seq_num"], {});
 
 add_index("invoices", "shipment_id", {});
 add_index("invoices", "approver_id", {});
@@ -57,7 +59,6 @@ add_index("shipment_offers", "shipment_id", {});
 
 add_index("shipment_recalculate_logs", "shipment_id", {});
 
-add_index("shipments", "traffic_distribution_list_id", {});
 add_index("shipments", "service_member_id", {});
 add_index("shipments", "move_id", {});
 add_index("shipments", "shipping_distance_id", {});
@@ -66,6 +67,9 @@ add_index("shipments", "secondary_pickup_address_id", {});
 add_index("shipments", "delivery_address_id", {});
 add_index("shipments", "partial_sit_delivery_address_id", {});
 add_index("shipments", "destination_address_on_acceptance_id", {});
+add_index("shipments", "status", {});
+add_index("shipments", "actual_pickup_date", {});
+add_index("shipments", "actual_delivery_date", {});
 
 add_index("signed_certifications", "submitting_user_id", {});
 add_index("signed_certifications", "move_id", {});
@@ -73,7 +77,6 @@ add_index("signed_certifications", "move_id", {});
 add_index("storage_in_transits", "shipment_id", {});
 add_index("storage_in_transits", "warehouse_address_id", {});
 
-add_index("transportation_offices", "shipping_office_id", {});
 add_index("transportation_offices", "address_id", {});
 
 add_index("transportation_service_provider_performances", "transportation_service_provider_id", {});
@@ -83,10 +86,6 @@ add_index("tsp_users", "user_id", {});
 add_index("tsp_users", "transportation_service_provider_id", {});
 
 add_index("uploads", "uploader_id", {});
+add_index("uploads", "document_id", {});
 
-
-
-
-add_index("shipments", "status", {});
-add_index("shipments", "actual_pickup_date", {});
-add_index("shipments", "actual_delivery_date", {});
+add_index("users", "login_gov_email", {});


### PR DESCRIPTION
## Description

We don't have indexes on foreign keys in our postgres db. This adds indexes to our foreign keys.

## Reviewer Notes

I think I caught them all, but worth a double check?

## Setup

`make db_dev_e2e_populate`
`make db_test_e2e_populate`

Ensure no errors and check for indexes on table columns.

## Code Review Verification Steps

* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](./docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
  * [ ] Secure migrations have been tested using `bin/run-prod-migrations`
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/164870225) for this change
* [this article](https://sqlperformance.com/2012/11/t-sql-queries/benefits-indexing-foreign-keys) explains more about the approach used.
