### PR TITLE
Fix expiring masked CSRF cookie

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -811,9 +811,9 @@ workflows:
             - pre_deps_yarn
             - acceptance_tests_local
           # if testing on experimental, you can disable these tests by using the commented block below.
-          # filters:
-          #  branches:
-          #    ignore: placeholder_branch_name
+          filters:
+            branches:
+              ignore: rr-164812764-maskedgorillacsrf-cookie
 
       - integration_tests_office:
           requires:
@@ -821,9 +821,9 @@ workflows:
             - pre_deps_yarn
             - acceptance_tests_local
           # if testing on experimental, you can disable these tests by using the commented block below.
-          # filters:
-          #   branches:
-          #     ignore: placeholder_branch_name
+          filters:
+            branches:
+              ignore: rr-164812764-maskedgorillacsrf-cookie
 
       - integration_tests_tsp:
           requires:
@@ -831,9 +831,9 @@ workflows:
             - pre_deps_yarn
             - acceptance_tests_local
           # if testing on experimental, you can disable these tests by using the commented block below.
-          # filters:
-          #   branches:
-          #     ignore: placeholder_branch_name
+          filters:
+            branches:
+              ignore: rr-164812764-maskedgorillacsrf-cookie
 
       - integration_tests_api:
           requires:
@@ -841,9 +841,9 @@ workflows:
             - pre_deps_yarn
             - acceptance_tests_local
           # if testing on experimental, you can disable these tests by using the commented block below.
-          # filters:
-          #   branches:
-          #     ignore: placeholder_branch_name
+          filters:
+            branches:
+              ignore: rr-164812764-maskedgorillacsrf-cookie
 
       - client_test:
           requires:
@@ -887,21 +887,21 @@ workflows:
             - build_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: rr-164812764-maskedgorillacsrf-cookie
 
       - deploy_experimental_app:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: rr-164812764-maskedgorillacsrf-cookie
 
       - deploy_experimental_app_client_tls:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: rr-164812764-maskedgorillacsrf-cookie
 
       - check_circle_against_staging_sha:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -811,9 +811,9 @@ workflows:
             - pre_deps_yarn
             - acceptance_tests_local
           # if testing on experimental, you can disable these tests by using the commented block below.
-          filters:
-            branches:
-              ignore: rr-164812764-maskedgorillacsrf-cookie
+          # filters:
+          #  branches:
+          #    ignore: placeholder_branch_name
 
       - integration_tests_office:
           requires:
@@ -821,9 +821,9 @@ workflows:
             - pre_deps_yarn
             - acceptance_tests_local
           # if testing on experimental, you can disable these tests by using the commented block below.
-          filters:
-            branches:
-              ignore: rr-164812764-maskedgorillacsrf-cookie
+          # filters:
+          #   branches:
+          #     ignore: placeholder_branch_name
 
       - integration_tests_tsp:
           requires:
@@ -831,9 +831,9 @@ workflows:
             - pre_deps_yarn
             - acceptance_tests_local
           # if testing on experimental, you can disable these tests by using the commented block below.
-          filters:
-            branches:
-              ignore: rr-164812764-maskedgorillacsrf-cookie
+          # filters:
+          #   branches:
+          #     ignore: placeholder_branch_name
 
       - integration_tests_api:
           requires:
@@ -841,9 +841,9 @@ workflows:
             - pre_deps_yarn
             - acceptance_tests_local
           # if testing on experimental, you can disable these tests by using the commented block below.
-          filters:
-            branches:
-              ignore: rr-164812764-maskedgorillacsrf-cookie
+          # filters:
+          #   branches:
+          #     ignore: placeholder_branch_name
 
       - client_test:
           requires:
@@ -887,21 +887,21 @@ workflows:
             - build_migrations
           filters:
             branches:
-              only: rr-164812764-maskedgorillacsrf-cookie
+              only: placeholder_branch_name
 
       - deploy_experimental_app:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: rr-164812764-maskedgorillacsrf-cookie
+              only: placeholder_branch_name
 
       - deploy_experimental_app_client_tls:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: rr-164812764-maskedgorillacsrf-cookie
+              only: placeholder_branch_name
 
       - check_circle_against_staging_sha:
           requires:

--- a/cmd/webserver/main.go
+++ b/cmd/webserver/main.go
@@ -894,7 +894,6 @@ func main() {
 	noSessionTimeout := v.GetBool("no-session-timeout")
 	sessionCookieMiddleware := auth.SessionCookieMiddleware(logger, clientAuthSecretKey, noSessionTimeout, myHostname, officeHostname, tspHostname, useSecureCookie)
 	maskedCSRFMiddleware := auth.MaskedCSRFMiddleware(logger, useSecureCookie)
-	csrfErrorHandler := auth.CSRFErrorHandler(logger, useSecureCookie)
 	userAuthMiddleware := authentication.UserAuthMiddleware(logger)
 	clientCertMiddleware := authentication.ClientCertMiddleware(logger, dbConnection)
 
@@ -1194,7 +1193,7 @@ func main() {
 		logger.Fatal("Failed to decode csrf auth key", zap.Error(err))
 	}
 	logger.Info("Enabling CSRF protection")
-	root.Use(csrf.Protect(csrfAuthKey, csrf.Secure(!isDevOrTest), csrf.Path("/"), csrf.CookieName(auth.GorillaCSRFToken), csrf.ErrorHandler(csrfErrorHandler)))
+	root.Use(csrf.Protect(csrfAuthKey, csrf.Secure(!isDevOrTest), csrf.Path("/"), csrf.CookieName(auth.GorillaCSRFToken)))
 	root.Use(maskedCSRFMiddleware)
 
 	// Sends build variables to honeycomb

--- a/pkg/auth/authentication/auth.go
+++ b/pkg/auth/authentication/auth.go
@@ -121,6 +121,7 @@ func (h LogoutHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			session.IDToken = ""
 			session.UserID = uuid.Nil
 			auth.WriteSessionCookie(w, session, h.clientAuthSecretKey, h.noSessionTimeout, h.logger, h.useSecureCookie)
+			auth.DeleteCSRFCookies(w)
 			fmt.Fprint(w, logoutURL)
 		} else {
 			// Can't log out of login.gov without a token, redirect and let them re-auth

--- a/pkg/auth/cookie.go
+++ b/pkg/auth/cookie.go
@@ -144,18 +144,6 @@ func DeleteCSRFCookies(w http.ResponseWriter) {
 	DeleteCookie(w, GorillaCSRFToken)
 }
 
-// CSRFErrorHandler handles errors that occur within the CSRF library
-func CSRFErrorHandler(logger Logger, useSecureCookie bool) http.Handler {
-	handler := func(w http.ResponseWriter, r *http.Request) {
-		msg := fmt.Sprintf("%s - %s",
-			http.StatusText(http.StatusForbidden), csrf.FailureReason(r))
-		http.Error(w, msg, http.StatusForbidden)
-		logger.Error(msg)
-	}
-
-	return http.HandlerFunc(handler)
-}
-
 // MaskedCSRFMiddleware handles setting the CSRF Token cookie
 func MaskedCSRFMiddleware(logger Logger, useSecureCookie bool) func(next http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {

--- a/pkg/auth/cookie.go
+++ b/pkg/auth/cookie.go
@@ -28,6 +28,9 @@ func (e *errInvalidHostname) Error() string {
 // UserSessionCookieName is the key suffix at which we're storing our token cookie
 const UserSessionCookieName = "session_token"
 
+// GorillaCSRFToken is the name of the base CSRF token
+const GorillaCSRFToken = "_gorilla_csrf" // #nosec G101
+
 // MaskedGorillaCSRFToken is the masked CSRF token used to send back in the 'X-CSRF-Token' request header
 const MaskedGorillaCSRFToken = "masked_gorilla_csrf"
 
@@ -53,6 +56,16 @@ func GetCookie(name string, r *http.Request) (*http.Cookie, error) {
 		}
 	}
 	return nil, errors.Errorf("Unable to find cookie: %s", name)
+}
+
+// DeleteCookie sends a delete request for the named cookie
+func DeleteCookie(w http.ResponseWriter, name string) {
+	c := http.Cookie{
+		Name:   name,
+		Value:  "blank",
+		MaxAge: -1,
+	}
+	http.SetCookie(w, &c)
 }
 
 // SessionClaims wraps StandardClaims with some Session info
@@ -111,23 +124,12 @@ func sessionClaimsFromRequest(logger Logger, secret string, appName Application,
 }
 
 // WriteMaskedCSRFCookie update the masked_gorilla_csrf cookie value
-func WriteMaskedCSRFCookie(w http.ResponseWriter, csrfToken string, noSessionTimeout bool, logger Logger, useSecureCookie bool) {
-
-	expiry := GetExpiryTimeFromMinutes(SessionExpiryInMinutes)
-	maxAge := sessionExpiryInSeconds
-	// Never expire token if in development
-	if noSessionTimeout {
-		expiry = likeForever
-		maxAge = likeForeverInSeconds
-	}
-
-	// New cookie
+func WriteMaskedCSRFCookie(w http.ResponseWriter, csrfToken string, logger Logger, useSecureCookie bool) {
+	// Match expiration settings of the _gorilla_csrf cookie (a session cookie); don't set Expires or MaxAge.
 	cookie := http.Cookie{
 		Name:     MaskedGorillaCSRFToken,
 		Value:    csrfToken,
 		Path:     "/",
-		Expires:  expiry,
-		MaxAge:   maxAge,
 		HttpOnly: false,                // must be false to be read by client for use in POST/PUT/PATCH/DELETE requests
 		SameSite: http.SameSiteLaxMode, // Using lax mode for now since strict is causing issues with Firefox/Safari
 		Secure:   useSecureCookie,
@@ -136,14 +138,30 @@ func WriteMaskedCSRFCookie(w http.ResponseWriter, csrfToken string, noSessionTim
 	http.SetCookie(w, &cookie)
 }
 
+// DeleteCSRFCookies deletes the base and masked CSRF cookies
+func DeleteCSRFCookies(w http.ResponseWriter) {
+	DeleteCookie(w, MaskedGorillaCSRFToken)
+	DeleteCookie(w, GorillaCSRFToken)
+}
+
+// CSRFErrorHandler handles errors that occur within the CSRF library
+func CSRFErrorHandler(logger Logger, useSecureCookie bool) http.Handler {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		msg := fmt.Sprintf("%s - %s",
+			http.StatusText(http.StatusForbidden), csrf.FailureReason(r))
+		http.Error(w, msg, http.StatusForbidden)
+		logger.Error(msg)
+	}
+
+	return http.HandlerFunc(handler)
+}
+
 // MaskedCSRFMiddleware handles setting the CSRF Token cookie
-func MaskedCSRFMiddleware(logger Logger, noSessionTimeout bool, useSecureCookie bool) func(next http.Handler) http.Handler {
+func MaskedCSRFMiddleware(logger Logger, useSecureCookie bool) func(next http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		mw := func(w http.ResponseWriter, r *http.Request) {
-			// Write a CSRF cookie if none exists
-			if _, err := GetCookie(MaskedGorillaCSRFToken, r); err != nil {
-				WriteMaskedCSRFCookie(w, csrf.Token(r), noSessionTimeout, logger, useSecureCookie)
-			}
+			// Write a masked CSRF cookie (creates a new one with each request)
+			WriteMaskedCSRFCookie(w, csrf.Token(r), logger, useSecureCookie)
 			next.ServeHTTP(w, r)
 		}
 		return http.HandlerFunc(mw)
@@ -152,7 +170,6 @@ func MaskedCSRFMiddleware(logger Logger, noSessionTimeout bool, useSecureCookie 
 
 // WriteSessionCookie update the cookie for the session
 func WriteSessionCookie(w http.ResponseWriter, session *Session, secret string, noSessionTimeout bool, logger Logger, useSecureCookie bool) {
-
 	// Delete the cookie
 	cookieName := fmt.Sprintf("%s_%s", string(session.ApplicationName), UserSessionCookieName)
 	cookie := http.Cookie{

--- a/pkg/auth/cookie.go
+++ b/pkg/auth/cookie.go
@@ -160,7 +160,9 @@ func CSRFErrorHandler(logger Logger, useSecureCookie bool) http.Handler {
 func MaskedCSRFMiddleware(logger Logger, useSecureCookie bool) func(next http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		mw := func(w http.ResponseWriter, r *http.Request) {
-			// Write a masked CSRF cookie (creates a new one with each request)
+			// Write a masked CSRF cookie (creates a new one with each request).  Per the gorilla/csrf docs:
+			// "This library generates unique-per-request (masked) tokens as a mitigation against the BREACH attack."
+			// https://github.com/gorilla/csrf#design-notes
 			WriteMaskedCSRFCookie(w, csrf.Token(r), logger, useSecureCookie)
 			next.ServeHTTP(w, r)
 		}

--- a/pkg/auth/cookie_test.go
+++ b/pkg/auth/cookie_test.go
@@ -215,7 +215,7 @@ func (suite *authSuite) TestMaskedCSRFMiddleware() {
 	req, _ := http.NewRequest("GET", "/", nil)
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
-	middleware := MaskedCSRFMiddleware(suite.logger, false, false)(handler)
+	middleware := MaskedCSRFMiddleware(suite.logger, false)(handler)
 	middleware.ServeHTTP(rr, req)
 
 	// We should get a 200 OK
@@ -226,7 +226,7 @@ func (suite *authSuite) TestMaskedCSRFMiddleware() {
 	suite.Equal(1, len(setCookies), "expected cookie to be set")
 }
 
-func (suite *authSuite) TestMaskedCSRFMiddlewareCreatesOneToken() {
+func (suite *authSuite) TestMaskedCSRFMiddlewareCreatesNewToken() {
 	expiry := GetExpiryTimeFromMinutes(SessionExpiryInMinutes)
 
 	rr := httptest.NewRecorder()
@@ -242,7 +242,7 @@ func (suite *authSuite) TestMaskedCSRFMiddlewareCreatesOneToken() {
 	req.AddCookie(&cookie)
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
-	middleware := MaskedCSRFMiddleware(suite.logger, false, false)(handler)
+	middleware := MaskedCSRFMiddleware(suite.logger, false)(handler)
 
 	middleware.ServeHTTP(rr, req)
 
@@ -251,7 +251,7 @@ func (suite *authSuite) TestMaskedCSRFMiddlewareCreatesOneToken() {
 
 	// No new cookie should be added to the session
 	setCookies := rr.HeaderMap["Set-Cookie"]
-	suite.Equal(0, len(setCookies), "expected no new cookie to be set")
+	suite.Equal(1, len(setCookies), "expected a new cookie to be set")
 }
 
 func (suite *authSuite) TestMiddlewareConstructor() {


### PR DESCRIPTION
## Description

Our current masked CSRF cookie expires after 15 minutes in our deployed environments and does not appear to get regenerated or extended within the same browser session.  When the cookie expires, the system starts to throw CSRF errors.  This PR addresses several aspects of our CSRF cookie handling:

- To avoid expiring CSRF cookies, makes `masked_gorilla_csrf` cookie a (browser) session cookie, just like the base `_gorilla_csrf` cookie
- Generates a new `masked_gorilla_csrf` cookie per request (like what we were previously doing) to mitigate against the BREACH attack (http://breachattack.com/)
- Deletes both CSRF cookies upon logout (we were previously wiping the `Set-Cookie` header, but that doesn't force the browser to delete the existing cookies)
- ~~Adds an error handler to the CSRF middleware to log any CSRF issues~~

## Reviewer Notes

I have marked this as a `WIP` because I still want to deploy this branch to experimental for testing, but wanted to go ahead and get some eyes on it.

## Setup

Run the app normally and try logging in and logging out, both with dev local login and login.gov login.  Follow the cookies in your browser's dev tools panel.

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/164812764) for this change
* [Design notes](https://github.com/gorilla/csrf#design-notes) from the Gorilla CSRF library explaining the approach
