### PR TITLE
Legacy 226a PARs edit using legacy form. 

### DIFF
--- a/src/shared/PreApprovalRequest/DetailsHelper.js
+++ b/src/shared/PreApprovalRequest/DetailsHelper.js
@@ -15,7 +15,7 @@ export function getFormComponent(code, robustAccessorial, initialValues) {
   } else if (robustAccessorial && code.startsWith('35')) {
     if (isNew || get(initialValues, 'estimate_amount_cents')) return Code35Form;
   } else if (robustAccessorial && code.startsWith('226')) {
-    return Code226Form;
+    if (isNew || get(initialValues, 'actual_amount_cents')) return Code226Form;
   }
   return DefaultForm;
 }

--- a/src/shared/PreApprovalRequest/DetailsHelper.test.js
+++ b/src/shared/PreApprovalRequest/DetailsHelper.test.js
@@ -93,7 +93,7 @@ describe('testing getFormComponent()', () => {
   describe('returns 226A form component with feature flag on', () => {
     featureFlag = true;
 
-    let FormComponent = getFormComponent('226A', featureFlag, initialValuesWithCrateDimensions);
+    let FormComponent = getFormComponent('226A', featureFlag, { actual_amount_cents: true });
     it('for code 226A', () => {
       expect(FormComponent).toBe(Code226Form);
     });
@@ -114,6 +114,11 @@ describe('testing getFormComponent()', () => {
 
     FormComponent = getFormComponent('105E', featureFlag, initialValuesWithoutCrateDimensions);
     it('for code 105E without crate dimensions', () => {
+      expect(FormComponent).toBe(DefaultForm);
+    });
+
+    FormComponent = getFormComponent('226A', featureFlag, initialValuesWithoutCrateDimensions);
+    it('for code 226A without crate dimensions', () => {
       expect(FormComponent).toBe(DefaultForm);
     });
   });


### PR DESCRIPTION
## Description

When a legacy 226A PAR is edited, the legacy form will be displayed. 

## Code Review Verification Steps

* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers](./docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/163829450) for this change
