### PR TITLE
Add form to office to approve sit request

### DIFF
--- a/cypress/integration/office/storageInTransitPanel.js
+++ b/cypress/integration/office/storageInTransitPanel.js
@@ -6,6 +6,9 @@ describe('office user finds the shipment', function() {
   it('office user views storage in transit panel', function() {
     officeUserViewsSITPanel();
   });
+  it('office user starts and cancels sit approval', function() {
+    officeUserStartsAndCancelsSitApproval();
+  });
 });
 
 function officeUserViewsSITPanel() {
@@ -62,4 +65,36 @@ function officeUserViewsSITPanel() {
       .siblings()
       .contains('(713) 868-3497');
   });
+}
+
+function officeUserStartsAndCancelsSitApproval() {
+  cy.patientVisit('/queues/hhg_accepted');
+  cy.location().should(loc => {
+    expect(loc.pathname).to.match(/^\/queues\/hhg_accepted/);
+  });
+
+  cy.selectQueueItemMoveLocator('SITREQ');
+
+  cy.location().should(loc => {
+    expect(loc.pathname).to.match(/^\/queues\/new\/moves\/[^/]+\/basics/);
+  });
+
+  cy
+    .get('a')
+    .contains('HHG')
+    .click(); // navtab
+
+  cy.location().should(loc => {
+    expect(loc.pathname).to.match(/^\/queues\/new\/moves\/[^/]+\/hhg/);
+  });
+
+  cy
+    .get('.usa-button-secondary')
+    .contains('Cancel')
+    .click()
+    .get('.storage-in-transit-panel .add-request')
+    .should($div => {
+      const text = $div.text();
+      expect(text).to.not.include('Approve SIT Request');
+    });
 }

--- a/src/shared/StorageInTransit/ApproveSitRequest.jsx
+++ b/src/shared/StorageInTransit/ApproveSitRequest.jsx
@@ -1,0 +1,69 @@
+import React, { Component } from 'react';
+import FontAwesomeIcon from '@fortawesome/react-fontawesome';
+import faCheck from '@fortawesome/fontawesome-free-solid/faCheck';
+import './StorageInTransit.css';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import StorageInTransitOfficeApprovalForm from './StorageInTransitOfficeApprovalForm.jsx';
+import './StorageInTransit.css';
+
+export class ApproveSitRequest extends Component {
+  state = {
+    showForm: false,
+  };
+
+  openForm = () => {
+    this.setState({ showForm: true });
+  };
+
+  closeForm = () => {
+    this.setState({ showForm: false });
+  };
+
+  render() {
+    if (this.state.showForm)
+      return (
+        <div className="storage-in-transit-panel-modal">
+          <div className="title">Approve SIT Request</div>
+          <StorageInTransitOfficeApprovalForm />
+          <div className="usa-grid-full align-center-vertical">
+            <div className="usa-width-one-half">
+              <p className="cancel-link">
+                <a className="usa-button-secondary" onClick={this.closeForm}>
+                  Cancel
+                </a>
+              </p>
+            </div>
+            <div className="usa-width-one-half align-right">
+              <button
+                className="button usa-button-primary storage-in-transit-request-form-send-request-button"
+                disabled={!this.props.formEnabled}
+              >
+                Approve
+              </button>
+            </div>
+          </div>
+        </div>
+      );
+    return (
+      <span className="approve-sit">
+        <a className="approve-sit-link" onClick={this.openForm}>
+          <FontAwesomeIcon className="icon" icon={faCheck} />
+          Approve
+        </a>
+      </span>
+    );
+  }
+}
+
+ApproveSitRequest.propTypes = {};
+
+function mapStateToProps(state) {
+  return {};
+}
+function mapDispatchToProps(dispatch) {
+  // Bind an action, which submit the form by its name
+  return bindActionCreators({}, dispatch);
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(ApproveSitRequest);

--- a/src/shared/StorageInTransit/StorageInTransit.css
+++ b/src/shared/StorageInTransit/StorageInTransit.css
@@ -61,7 +61,6 @@
 .column-subhead {
   margin-bottom: 4px;
   line-height: 1.5em;
-
 }
 
 .sit-notes .field-title {
@@ -80,4 +79,18 @@
 .storage-in-transit-panel-modal .usa-grid-full {
   margin-top: 16px;
   margin-bottom: 16px;
+}
+
+.approve-sit-link {
+  text-decoration: none;
+  cursor: pointer;
+  font-weight: normal;
+}
+
+.storage-in-transit-office-approval-form textarea {
+  height: 9rem;
+}
+
+.sit-approval-field{
+  font-weight: normal;
 }

--- a/src/shared/StorageInTransit/StorageInTransit.jsx
+++ b/src/shared/StorageInTransit/StorageInTransit.jsx
@@ -11,7 +11,9 @@ import faPencil from '@fortawesome/fontawesome-free-solid/faPencilAlt';
 import './StorageInTransit.css';
 import { formatDate4DigitYear } from 'shared/formatters';
 import Editor from 'shared/StorageInTransit/Editor';
+import ApproveSitRequest from 'shared/StorageInTransit/ApproveSitRequest';
 import { updateStorageInTransit } from 'shared/Entities/modules/storageInTransits';
+import { isTspSite } from 'shared/constants.js';
 
 export class StorageInTransit extends Component {
   constructor() {
@@ -51,6 +53,7 @@ export class StorageInTransit extends Component {
             <FontAwesomeIcon className="icon icon-grey" icon={faClock} />
           </span>
           <span>SIT {storageInTransit.status.charAt(0) + storageInTransit.status.slice(1).toLowerCase()} </span>
+          {!isTspSite && <ApproveSitRequest />}
           {showEditForm ? (
             <Editor
               updateStorageInTransit={this.onSubmit}

--- a/src/shared/StorageInTransit/StorageInTransitOfficeApprovalForm.jsx
+++ b/src/shared/StorageInTransit/StorageInTransitOfficeApprovalForm.jsx
@@ -21,6 +21,7 @@ export class StorageInTransitOfficeApprovalForm extends Component {
               className="sit-approval-field"
               fieldName="authorized_start_date"
               swagger={storageInTransitSchema}
+              title="Earliest authorized start date"
               required
             />
           </div>

--- a/src/shared/StorageInTransit/StorageInTransitOfficeApprovalForm.jsx
+++ b/src/shared/StorageInTransit/StorageInTransitOfficeApprovalForm.jsx
@@ -1,0 +1,53 @@
+import { get } from 'lodash';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+import { reduxForm } from 'redux-form';
+import { SwaggerField } from 'shared/JsonSchemaForm/JsonSchemaField';
+
+export class StorageInTransitOfficeApprovalForm extends Component {
+  //form submission still to be implemented
+  handleSubmit = e => {
+    e.preventDefault();
+  };
+
+  render() {
+    const { storageInTransitSchema } = this.props;
+    return (
+      <form onSubmit={this.handleSubmit} className="storage-in-transit-office-approval-form">
+        <fieldset key="sit-approval-information">
+          <div className="editable-panel-column">
+            <SwaggerField
+              className="sit-approval-field"
+              fieldName="authorized_start_date"
+              swagger={storageInTransitSchema}
+              required
+            />
+          </div>
+          <div className="editable-panel-column">
+            <SwaggerField className="sit-approval-field" fieldName="notes" swagger={storageInTransitSchema} />
+          </div>
+        </fieldset>
+      </form>
+    );
+  }
+}
+
+StorageInTransitOfficeApprovalForm.propTypes = {
+  storageInTransitSchema: PropTypes.object.isRequired,
+};
+
+const formName = 'storage_in_transit_office_approval_form';
+StorageInTransitOfficeApprovalForm = reduxForm({
+  form: formName,
+  enableReinitialize: true,
+  keepDirtyOnReinitialize: true,
+})(StorageInTransitOfficeApprovalForm);
+
+function mapStateToProps(state) {
+  return {
+    storageInTransitSchema: get(state, 'swaggerPublic.spec.definitions.StorageInTransit', {}),
+  };
+}
+
+export default connect(mapStateToProps)(StorageInTransitOfficeApprovalForm);

--- a/src/shared/StorageInTransit/StorageInTransitOfficeApprovalForm.test.jsx
+++ b/src/shared/StorageInTransit/StorageInTransitOfficeApprovalForm.test.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import { StorageInTransitOfficeApprovalForm } from './StorageInTransitOfficeApprovalForm';
+
+let store;
+const mockStore = configureStore();
+const submit = jest.fn();
+
+const storageInTransitSchema = {
+  properties: {
+    estimate_start_date: {
+      type: 'string',
+      format: 'date',
+      example: '2018-04-26',
+      title: 'Estimated start date',
+    },
+  },
+};
+
+describe('StorageInTransitOfficeApprovalForm tests', () => {
+  describe('Empty form', () => {
+    let wrapper;
+    store = mockStore({});
+    wrapper = mount(
+      <Provider store={store}>
+        <StorageInTransitOfficeApprovalForm onSubmit={submit} storageInTransitSchema={storageInTransitSchema} />
+      </Provider>,
+    );
+
+    it('renders without crashing', () => {
+      expect(wrapper.find('.storage-in-transit-office-approval-form').length).toEqual(1);
+    });
+  });
+});

--- a/src/shared/StorageInTransit/StorageInTransitPanel.jsx
+++ b/src/shared/StorageInTransit/StorageInTransitPanel.jsx
@@ -61,11 +61,11 @@ export class StorageInTransitPanel extends Component {
             Entitlement: {storageInTransitEntitlement} days <span className="unbold">({daysRemaining} remaining)</span>
           </div>
           {storageInTransits !== undefined &&
-            storageInTransits.map(storageInTransit => {
-              return <StorageInTransit key={storageInTransit.id} storageInTransit={storageInTransit} />;
-            })}
+          storageInTransits.map(storageInTransit => {
+            return <StorageInTransit key={storageInTransit.id} storageInTransit={storageInTransit} />;
+          })}
           {isCreatorActionable &&
-            isTspSite && <Creator onFormActivation={this.onFormActivation} saveStorageInTransit={this.onSubmit} />}
+          isTspSite && <Creator onFormActivation={this.onFormActivation} saveStorageInTransit={this.onSubmit} />}
         </BasicPanel>
       </div>
     );

--- a/src/shared/StorageInTransit/StorageInTransitPanel.jsx
+++ b/src/shared/StorageInTransit/StorageInTransitPanel.jsx
@@ -61,11 +61,11 @@ export class StorageInTransitPanel extends Component {
             Entitlement: {storageInTransitEntitlement} days <span className="unbold">({daysRemaining} remaining)</span>
           </div>
           {storageInTransits !== undefined &&
-          storageInTransits.map(storageInTransit => {
-            return <StorageInTransit key={storageInTransit.id} storageInTransit={storageInTransit} />;
-          })}
+            storageInTransits.map(storageInTransit => {
+              return <StorageInTransit key={storageInTransit.id} storageInTransit={storageInTransit} />;
+            })}
           {isCreatorActionable &&
-          isTspSite && <Creator onFormActivation={this.onFormActivation} saveStorageInTransit={this.onSubmit} />}
+            isTspSite && <Creator onFormActivation={this.onFormActivation} saveStorageInTransit={this.onSubmit} />}
         </BasicPanel>
       </div>
     );


### PR DESCRIPTION
## Description

Adds the form that office users will use to approve a SIT request. This story only shows the form. There is another story for submitting the form.


## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make db_dev_e2e_populate
make server_run
make client_run
```
In the TSP app, select an HHG record and request a SIT. Next, go to the Office app and select the same record for which you added the SIT request. You will see the SIT panel, and an `Approve` link that opens up the form.


## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/164250435) for this change


## Screenshots


![ezgif com-optimize (3)](https://user-images.githubusercontent.com/3522044/55029898-74044080-4fc8-11e9-93f1-936fd7f825c0.gif)

