### PR TITLE
Upgrade dep version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,23 +15,23 @@ executors:
     resource_class: small
     working_directory: ~/go/src/github.com/transcom/mymove
     docker:
-      - image: trussworks/circleci-docker-primary:656d30cb106702a0ce7e4a9d2a74b409c121a8e8
+      - image: trussworks/circleci-docker-primary:9ad70927655a601580c036d53456c70061c76cba
   mymove_medium:
     resource_class: medium
     working_directory: ~/go/src/github.com/transcom/mymove
     docker:
-      - image: trussworks/circleci-docker-primary:656d30cb106702a0ce7e4a9d2a74b409c121a8e8
+      - image: trussworks/circleci-docker-primary:9ad70927655a601580c036d53456c70061c76cba
   mymove_large:
     resource_class: large
     working_directory: ~/go/src/github.com/transcom/mymove
     docker:
-      - image: trussworks/circleci-docker-primary:656d30cb106702a0ce7e4a9d2a74b409c121a8e8
+      - image: trussworks/circleci-docker-primary:9ad70927655a601580c036d53456c70061c76cba
   # `mymove_and_postgres_medium` adds a secondary postgres container to be used during testing.
   mymove_and_postgres_medium:
     resource_class: medium
     working_directory: ~/go/src/github.com/transcom/mymove
     docker:
-      - image: trussworks/circleci-docker-primary:656d30cb106702a0ce7e4a9d2a74b409c121a8e8
+      - image: trussworks/circleci-docker-primary:9ad70927655a601580c036d53456c70061c76cba
       - image: postgres:10.5
         environment:
           - POSTGRES_PASSWORD: mysecretpassword

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 # dependencies
 /vendor
 /node_modules
+/.vendor-new
 
 /pkg/gen
 /pkg/assets

--- a/bin/check_dep_version
+++ b/bin/check_dep_version
@@ -2,7 +2,7 @@
 
 set -eu -o pipefail
 
-TARGET_VERSION="v0.5.0"
+TARGET_VERSION="v0.5.1"
 CURRENT_VERSION=$(dep version | grep version | cut -f2 -d':' | awk '{$1=$1};1' | head -n 1)
 
 if [[ "$CURRENT_VERSION" = "$TARGET_VERSION" ]]; then


### PR DESCRIPTION
## Description

Upgrade dep to 0.5.1

## Reviewer Notes

It appears that dep now adds a `/.vendor-new` file. To keep in line with how we've ignored the vendor folder prior, I've done the same here. I'm unclear if I should also be removing the original `/vendor` folder from our .gitignore.

## Setup

n/a

## Code Review Verification Steps

* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* https://www.pivotaltracker.com/story/show/164713350
