### PR TITLE
Fixes nil issue that causes Service Member UI to fail at times

### DIFF
--- a/pkg/handlers/internalapi/signed_certifications.go
+++ b/pkg/handlers/internalapi/signed_certifications.go
@@ -14,9 +14,15 @@ import (
 )
 
 func payloadForSignedCertificationModel(cert models.SignedCertification) *internalmessages.SignedCertificationPayload {
+	var ptrCertificationType *internalmessages.SignedCertificationType
+	if cert.CertificationType != nil {
+		certificationType := internalmessages.SignedCertificationType(*cert.CertificationType)
+		ptrCertificationType = &certificationType
+	}
+
 	return &internalmessages.SignedCertificationPayload{
 		CertificationText:        handlers.FmtString(cert.CertificationText),
-		CertificationType:        internalmessages.SignedCertificationType(cert.CertificationType),
+		CertificationType:        ptrCertificationType,
 		CreatedAt:                handlers.FmtDateTime(cert.CreatedAt),
 		Date:                     handlers.FmtDate(cert.Date),
 		ID:                       handlers.FmtUUID(cert.ID),
@@ -59,7 +65,12 @@ func (h CreateSignedCertificationHandler) Handle(params certop.CreateSignedCerti
 			}
 		}
 	}
-	certType := models.SignedCertificationType(payload.CertificationType)
+
+	var ptrCertType *models.SignedCertificationType
+	if payload.CertificationType != nil {
+		certType := models.SignedCertificationType(*payload.CertificationType)
+		ptrCertType = &certType
+	}
 
 	move, err := models.FetchMove(h.DB(), session, moveID)
 	if err != nil {
@@ -73,7 +84,7 @@ func (h CreateSignedCertificationHandler) Handle(params certop.CreateSignedCerti
 		(time.Time)(*payload.Date),
 		ppmID,
 		shipmentID,
-		certType)
+		ptrCertType)
 	if verrs.HasAny() || err != nil {
 		return handlers.ResponseForVErrors(h.Logger(), verrs, err)
 	}

--- a/pkg/models/move.go
+++ b/pkg/models/move.go
@@ -461,7 +461,7 @@ func (m Move) CreateSignedCertification(db *pop.Connection,
 	date time.Time,
 	ppmID *uuid.UUID,
 	shipmentID *uuid.UUID,
-	certificationType SignedCertificationType) (*SignedCertification, *validate.Errors, error) {
+	certificationType *SignedCertificationType) (*SignedCertification, *validate.Errors, error) {
 
 	newSignedCertification := SignedCertification{
 		MoveID:                   m.ID,

--- a/pkg/models/signed_certification.go
+++ b/pkg/models/signed_certification.go
@@ -9,11 +9,10 @@ import (
 	"github.com/gofrs/uuid"
 )
 
-//SignedCertificationType represents the types of certificates
+// SignedCertificationType represents the types of certificates
 type SignedCertificationType string
 
 const (
-
 	// SignedCertificationTypePPM captures enum value "PPM"
 	SignedCertificationTypePPM SignedCertificationType = "PPM"
 
@@ -24,19 +23,25 @@ const (
 	SignedCertificationTypeHHG SignedCertificationType = "HHG"
 )
 
+var signedCertifications = []string{
+	string(SignedCertificationTypePPM),
+	string(SignedCertificationTypePPMPAYMENT),
+	string(SignedCertificationTypeHHG),
+}
+
 // SignedCertification represents users acceptance
 type SignedCertification struct {
-	ID                       uuid.UUID               `json:"id" db:"id"`
-	SubmittingUserID         uuid.UUID               `json:"submitting_user_id" db:"submitting_user_id"`
-	MoveID                   uuid.UUID               `json:"move_id" db:"move_id"`
-	PersonallyProcuredMoveID *uuid.UUID              `json:"personally_procured_move_id" db:"personally_procured_move_id"`
-	ShipmentID               *uuid.UUID              `json:"shipment_id" db:"shipment_id"`
-	CertificationType        SignedCertificationType `json:"certification_type" db:"certification_type"`
-	CreatedAt                time.Time               `json:"created_at" db:"created_at"`
-	UpdatedAt                time.Time               `json:"updated_at" db:"updated_at"`
-	CertificationText        string                  `json:"certification_text" db:"certification_text"`
-	Signature                string                  `json:"signature" db:"signature"`
-	Date                     time.Time               `json:"date" db:"date"`
+	ID                       uuid.UUID                `json:"id" db:"id"`
+	SubmittingUserID         uuid.UUID                `json:"submitting_user_id" db:"submitting_user_id"`
+	MoveID                   uuid.UUID                `json:"move_id" db:"move_id"`
+	PersonallyProcuredMoveID *uuid.UUID               `json:"personally_procured_move_id" db:"personally_procured_move_id"`
+	ShipmentID               *uuid.UUID               `json:"shipment_id" db:"shipment_id"`
+	CertificationType        *SignedCertificationType `json:"certification_type" db:"certification_type"`
+	CreatedAt                time.Time                `json:"created_at" db:"created_at"`
+	UpdatedAt                time.Time                `json:"updated_at" db:"updated_at"`
+	CertificationText        string                   `json:"certification_text" db:"certification_text"`
+	Signature                string                   `json:"signature" db:"signature"`
+	Date                     time.Time                `json:"date" db:"date"`
 }
 
 // SignedCertifications is not required by pop and may be deleted
@@ -45,9 +50,16 @@ type SignedCertifications []SignedCertification
 // Validate gets run every time you call a "pop.Validate*" (pop.ValidateAndSave, pop.ValidateAndCreate, pop.ValidateAndUpdate) method.
 // This method is not required and may be deleted.
 func (s *SignedCertification) Validate(tx *pop.Connection) (*validate.Errors, error) {
+	var ptrCertificationType *string
+	if s.CertificationType != nil {
+		certificationType := string(*s.CertificationType)
+		ptrCertificationType = &certificationType
+	}
+
 	return validate.Validate(
 		&validators.StringIsPresent{Field: s.CertificationText, Name: "CertificationText"},
 		&validators.StringIsPresent{Field: s.Signature, Name: "Signature"},
+		&OptionalStringInclusion{Field: ptrCertificationType, Name: "CertificationType", List: signedCertifications},
 	), nil
 }
 

--- a/pkg/models/validators.go
+++ b/pkg/models/validators.go
@@ -236,6 +236,28 @@ func (v *OptionalDateIsWorkday) IsValid(errors *validate.Errors) {
 	dateIsWorkday.IsValid(errors)
 }
 
+// OptionalStringInclusion validates that a field is in a list of strings if the field exists
+type OptionalStringInclusion struct {
+	Name    string
+	Field   *string
+	List    []string
+	Message string
+}
+
+// IsValid adds error if field is non-nil and not in the list of strings
+func (v *OptionalStringInclusion) IsValid(errors *validate.Errors) {
+	if v.Field == nil {
+		return
+	}
+	stringInclusion := validators.StringInclusion{
+		Name:    v.Name,
+		Field:   *v.Field,
+		List:    v.List,
+		Message: v.Message,
+	}
+	stringInclusion.IsValid(errors)
+}
+
 // ValidateableModel is here simply because `validateable` is private to `pop`
 type ValidateableModel interface {
 	Validate(*pop.Connection) (*validate.Errors, error)

--- a/pkg/models/validators_test.go
+++ b/pkg/models/validators_test.go
@@ -179,3 +179,49 @@ func TestOptionalDateIsWorkday_IsValid(t *testing.T) {
 		}
 	})
 }
+
+func TestOptionalStringInclusion_IsValid(t *testing.T) {
+	targetStrings := []string{"aaa", "bbb", "ccc"}
+	fieldName := "test_string"
+
+	t.Run("String in list", func(t *testing.T) {
+		testString := "bbb"
+		validator := models.OptionalStringInclusion{Name: fieldName, List: targetStrings, Field: &testString}
+		errs := validate.NewErrors()
+
+		validator.IsValid(errs)
+
+		if errs.Count() != 0 {
+			t.Fatal("There should be no errors")
+		}
+	})
+
+	t.Run("String not in list", func(t *testing.T) {
+		testString := "zzz"
+		validator := models.OptionalStringInclusion{Name: fieldName, List: targetStrings, Field: &testString}
+		errs := validate.NewErrors()
+
+		validator.IsValid(errs)
+
+		testErrors := errs.Get(fieldName)
+		if len(testErrors) != 1 {
+			t.Fatal("There should be an error")
+		}
+
+		expected := fmt.Sprintf("%s is not in the list [%s].", fieldName, strings.Join(targetStrings, ", "))
+		if testErrors[0] != expected {
+			t.Fatalf("wrong validation message; expected %s, got %s", expected, testErrors[0])
+		}
+	})
+
+	t.Run("String is nil", func(t *testing.T) {
+		validator := models.OptionalStringInclusion{Name: "test_string", List: targetStrings, Field: nil}
+		errs := validate.NewErrors()
+
+		validator.IsValid(errs)
+
+		if errs.Count() != 0 {
+			t.Fatal("There should be no errors")
+		}
+	})
+}

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -1353,6 +1353,7 @@ definitions:
       - PPM
       - PPM_PAYMENT
       - HHG
+    x-nullable: true
   DocumentPayload:
     type: object
     properties:


### PR DESCRIPTION
## Description

For context, start at this Slack message and look at the follow-on messages in the channel:
https://defensedigitalservice.slack.com/archives/G8P7UD05U/p1553706274109800

We were having cases where the Service Member UI would get stuck on "Loading, please wait..." at times.  The error that was being thrown led us to realize that the `CertificationType` field of the `SignedCertificationType` model was not able to accept nil values, even though the field was optional per the database schema.

This PR changes that field so it can accept nil values, as well as puts some validations/tests around it to prevent bad values in the model.

## Reviewer Notes

Interestingly, unless we made the enum definition in the `internal.yaml` file be nullable, the generated swagger-go code would not use a pointer for that field, even if the referencing definition marked the property using it as nullable.

## Setup

```sh
make db_dev_e2e_populate
make server_run
make client_run
```
#### Tests
```
make client_test
make server_test
make e2e_test
```
## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/164941904) for this change
