### PR TITLE
Add form to office to deny sit request

### DIFF
--- a/cypress/integration/office/storageInTransitPanel.js
+++ b/cypress/integration/office/storageInTransitPanel.js
@@ -89,6 +89,18 @@ function officeUserStartsAndCancelsSitApproval() {
   });
 
   cy
+    .get('a')
+    .contains('Approve')
+    .click()
+    .get('.storage-in-transit')
+    .should($div => {
+      const text = $div.text();
+      expect(text).to.include('Approve SIT Request');
+      expect(text).to.not.include('Deny');
+      expect(text).to.not.include('Edit');
+    });
+
+  cy
     .get('.usa-button-secondary')
     .contains('Cancel')
     .click()

--- a/src/shared/StorageInTransit/ApproveSitRequest.jsx
+++ b/src/shared/StorageInTransit/ApproveSitRequest.jsx
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
-import FontAwesomeIcon from '@fortawesome/react-fontawesome';
-import faCheck from '@fortawesome/fontawesome-free-solid/faCheck';
+import PropTypes from 'prop-types';
 import './StorageInTransit.css';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
@@ -8,55 +7,40 @@ import StorageInTransitOfficeApprovalForm from './StorageInTransitOfficeApproval
 import './StorageInTransit.css';
 
 export class ApproveSitRequest extends Component {
-  state = {
-    showForm: false,
-  };
-
-  openForm = () => {
-    this.setState({ showForm: true });
-  };
-
   closeForm = () => {
-    this.setState({ showForm: false });
+    this.props.onClose();
   };
 
   render() {
-    if (this.state.showForm)
-      return (
-        <div className="storage-in-transit-panel-modal">
-          <div className="title">Approve SIT Request</div>
-          <StorageInTransitOfficeApprovalForm />
-          <div className="usa-grid-full align-center-vertical">
-            <div className="usa-width-one-half">
-              <p className="cancel-link">
-                <a className="usa-button-secondary" onClick={this.closeForm}>
-                  Cancel
-                </a>
-              </p>
-            </div>
-            <div className="usa-width-one-half align-right">
-              <button
-                className="button usa-button-primary storage-in-transit-request-form-send-request-button"
-                disabled={!this.props.formEnabled}
-              >
-                Approve
-              </button>
-            </div>
+    return (
+      <div className="storage-in-transit-panel-modal">
+        <div className="title">Approve SIT Request</div>
+        <StorageInTransitOfficeApprovalForm />
+        <div className="usa-grid-full align-center-vertical">
+          <div className="usa-width-one-half">
+            <p className="cancel-link">
+              <a className="usa-button-secondary" onClick={this.closeForm}>
+                Cancel
+              </a>
+            </p>
+          </div>
+          <div className="usa-width-one-half align-right">
+            <button
+              className="button usa-button-primary storage-in-transit-request-form-send-request-button"
+              disabled={!this.props.formEnabled}
+            >
+              Approve
+            </button>
           </div>
         </div>
-      );
-    return (
-      <span className="approve-sit">
-        <a className="approve-sit-link" onClick={this.openForm}>
-          <FontAwesomeIcon className="icon" icon={faCheck} />
-          Approve
-        </a>
-      </span>
+      </div>
     );
   }
 }
 
-ApproveSitRequest.propTypes = {};
+ApproveSitRequest.propTypes = {
+  onClose: PropTypes.func.isRequired,
+};
 
 function mapStateToProps(state) {
   return {};

--- a/src/shared/StorageInTransit/DenySitRequest.jsx
+++ b/src/shared/StorageInTransit/DenySitRequest.jsx
@@ -1,0 +1,68 @@
+import React, { Component } from 'react';
+import FontAwesomeIcon from '@fortawesome/react-fontawesome';
+import faBan from '@fortawesome/fontawesome-free-solid/faBan';
+import './StorageInTransit.css';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import StorageInTransitOfficeDenyForm from './StorageInTransitOfficeDenyForm.jsx';
+
+export class DenySitRequest extends Component {
+  state = {
+    showForm: false,
+  };
+
+  openForm = () => {
+    this.setState({ showForm: true });
+  };
+
+  closeForm = () => {
+    this.setState({ showForm: false });
+  };
+
+  render() {
+    if (this.state.showForm)
+      return (
+        <div className="storage-in-transit-panel-modal">
+          <div className="title">Deny SIT Request</div>
+          <StorageInTransitOfficeDenyForm />
+          <div className="usa-grid-full align-center-vertical">
+            <div className="usa-width-one-half">
+              <p className="cancel-link">
+                <a className="usa-button-secondary" onClick={this.closeForm}>
+                  Cancel
+                </a>
+              </p>
+            </div>
+            <div className="usa-width-one-half align-right">
+              <button
+                className="button usa-button-primary storage-in-transit-request-form-send-request-button"
+                disabled={!this.props.formEnabled}
+              >
+                Deny
+              </button>
+            </div>
+          </div>
+        </div>
+      );
+    return (
+      <span className="deny-sit">
+        <a className="deny-sit-link" onClick={this.openForm}>
+          <FontAwesomeIcon className="icon" icon={faBan} />
+          Deny
+        </a>
+      </span>
+    );
+  }
+}
+
+DenySitRequest.propTypes = {};
+
+function mapStateToProps(state) {
+  return {};
+}
+function mapDispatchToProps(dispatch) {
+  // Bind an action, which submit the form by its name
+  return bindActionCreators({}, dispatch);
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(DenySitRequest);

--- a/src/shared/StorageInTransit/DenySitRequest.jsx
+++ b/src/shared/StorageInTransit/DenySitRequest.jsx
@@ -1,61 +1,45 @@
 import React, { Component } from 'react';
-import FontAwesomeIcon from '@fortawesome/react-fontawesome';
-import faBan from '@fortawesome/fontawesome-free-solid/faBan';
+import PropTypes from 'prop-types';
 import './StorageInTransit.css';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import StorageInTransitOfficeDenyForm from './StorageInTransitOfficeDenyForm.jsx';
 
 export class DenySitRequest extends Component {
-  state = {
-    showForm: false,
-  };
-
-  openForm = () => {
-    this.setState({ showForm: true });
-  };
-
   closeForm = () => {
-    this.setState({ showForm: false });
+    this.props.onClose();
   };
 
   render() {
-    if (this.state.showForm)
-      return (
-        <div className="storage-in-transit-panel-modal">
-          <div className="title">Deny SIT Request</div>
-          <StorageInTransitOfficeDenyForm />
-          <div className="usa-grid-full align-center-vertical">
-            <div className="usa-width-one-half">
-              <p className="cancel-link">
-                <a className="usa-button-secondary" onClick={this.closeForm}>
-                  Cancel
-                </a>
-              </p>
-            </div>
-            <div className="usa-width-one-half align-right">
-              <button
-                className="button usa-button-primary storage-in-transit-request-form-send-request-button"
-                disabled={!this.props.formEnabled}
-              >
-                Deny
-              </button>
-            </div>
+    return (
+      <div className="storage-in-transit-panel-modal">
+        <div className="title">Deny SIT Request</div>
+        <StorageInTransitOfficeDenyForm />
+        <div className="usa-grid-full align-center-vertical">
+          <div className="usa-width-one-half">
+            <p className="cancel-link">
+              <a className="usa-button-secondary" onClick={this.closeForm}>
+                Cancel
+              </a>
+            </p>
+          </div>
+          <div className="usa-width-one-half align-right">
+            <button
+              className="button usa-button-primary storage-in-transit-request-form-send-request-button"
+              disabled={!this.props.formEnabled}
+            >
+              Deny
+            </button>
           </div>
         </div>
-      );
-    return (
-      <span className="deny-sit">
-        <a className="deny-sit-link" onClick={this.openForm}>
-          <FontAwesomeIcon className="icon" icon={faBan} />
-          Deny
-        </a>
-      </span>
+      </div>
     );
   }
 }
 
-DenySitRequest.propTypes = {};
+DenySitRequest.propTypes = {
+  onClose: PropTypes.func.isRequired,
+};
 
 function mapStateToProps(state) {
   return {};

--- a/src/shared/StorageInTransit/StorageInTransit.css
+++ b/src/shared/StorageInTransit/StorageInTransit.css
@@ -93,11 +93,24 @@
   font-weight: normal;
 }
 
+.storage-in-transit-office-approval-form {
+  font-weight: normal;
+}
+
 .storage-in-transit-office-approval-form textarea {
   height: 9rem;
+}
+
+.storage-in-transit-office-deny-form {
+  font-weight: normal;
 }
 
 .storage-in-transit-office-deny-form textarea {
   width: 45rem;
   height: 6rem;
 }
+
+.storage-in-transit-request-form {
+  font-weight: normal;
+}
+

--- a/src/shared/StorageInTransit/StorageInTransit.css
+++ b/src/shared/StorageInTransit/StorageInTransit.css
@@ -97,15 +97,7 @@
   height: 9rem;
 }
 
-.sit-approval-field{
-  font-weight: normal;
-}
-
 .storage-in-transit-office-deny-form textarea {
   width: 45rem;
   height: 6rem;
-}
-
-.sit-deny-field{
-  font-weight: normal;
 }

--- a/src/shared/StorageInTransit/StorageInTransit.css
+++ b/src/shared/StorageInTransit/StorageInTransit.css
@@ -87,10 +87,25 @@
   font-weight: normal;
 }
 
+.deny-sit-link {
+  text-decoration: none;
+  cursor: pointer;
+  font-weight: normal;
+}
+
 .storage-in-transit-office-approval-form textarea {
   height: 9rem;
 }
 
 .sit-approval-field{
+  font-weight: normal;
+}
+
+.storage-in-transit-office-deny-form textarea {
+  width: 45rem;
+  height: 6rem;
+}
+
+.sit-deny-field{
   font-weight: normal;
 }

--- a/src/shared/StorageInTransit/StorageInTransit.jsx
+++ b/src/shared/StorageInTransit/StorageInTransit.jsx
@@ -12,6 +12,7 @@ import './StorageInTransit.css';
 import { formatDate4DigitYear } from 'shared/formatters';
 import Editor from 'shared/StorageInTransit/Editor';
 import ApproveSitRequest from 'shared/StorageInTransit/ApproveSitRequest';
+import DenySitRequest from 'shared/StorageInTransit/DenySitRequest';
 import { updateStorageInTransit } from 'shared/Entities/modules/storageInTransits';
 import { isTspSite } from 'shared/constants.js';
 
@@ -54,6 +55,7 @@ export class StorageInTransit extends Component {
           </span>
           <span>SIT {storageInTransit.status.charAt(0) + storageInTransit.status.slice(1).toLowerCase()} </span>
           {!isTspSite && <ApproveSitRequest />}
+          {!isTspSite && <DenySitRequest />}
           {showEditForm ? (
             <Editor
               updateStorageInTransit={this.onSubmit}

--- a/src/shared/StorageInTransit/StorageInTransit.jsx
+++ b/src/shared/StorageInTransit/StorageInTransit.jsx
@@ -7,6 +7,8 @@ import { bindActionCreators } from 'redux';
 import FontAwesomeIcon from '@fortawesome/react-fontawesome';
 import faClock from '@fortawesome/fontawesome-free-solid/faClock';
 import faPencil from '@fortawesome/fontawesome-free-solid/faPencilAlt';
+import faCheck from '@fortawesome/fontawesome-free-solid/faCheck';
+import faBan from '@fortawesome/fontawesome-free-solid/faBan';
 
 import './StorageInTransit.css';
 import { formatDate4DigitYear } from 'shared/formatters';
@@ -14,13 +16,15 @@ import Editor from 'shared/StorageInTransit/Editor';
 import ApproveSitRequest from 'shared/StorageInTransit/ApproveSitRequest';
 import DenySitRequest from 'shared/StorageInTransit/DenySitRequest';
 import { updateStorageInTransit } from 'shared/Entities/modules/storageInTransits';
-import { isTspSite } from 'shared/constants.js';
+import { isOfficeSite } from 'shared/constants.js';
 
 export class StorageInTransit extends Component {
   constructor() {
     super();
     this.state = {
       showEditForm: false,
+      showApproveForm: false,
+      showDenyForm: false,
     };
   }
 
@@ -30,6 +34,22 @@ export class StorageInTransit extends Component {
 
   closeEditForm = () => {
     this.setState({ showEditForm: false });
+  };
+
+  openApproveForm = () => {
+    this.setState({ showApproveForm: true });
+  };
+
+  closeApproveForm = () => {
+    this.setState({ showApproveForm: false });
+  };
+
+  openDenyForm = () => {
+    this.setState({ showDenyForm: true });
+  };
+
+  closeDenyForm = () => {
+    this.setState({ showDenyForm: false });
   };
 
   onSubmit = updatePayload => {
@@ -42,7 +62,7 @@ export class StorageInTransit extends Component {
 
   render() {
     const { storageInTransit } = this.props;
-    const { showEditForm } = this.state;
+    const { showEditForm, showApproveForm, showDenyForm } = this.state;
 
     return (
       <div className="storage-in-transit">
@@ -54,8 +74,34 @@ export class StorageInTransit extends Component {
             <FontAwesomeIcon className="icon icon-grey" icon={faClock} />
           </span>
           <span>SIT {storageInTransit.status.charAt(0) + storageInTransit.status.slice(1).toLowerCase()} </span>
-          {!isTspSite && <ApproveSitRequest />}
-          {!isTspSite && <DenySitRequest />}
+          {showApproveForm ? (
+            <ApproveSitRequest onClose={this.closeApproveForm} />
+          ) : (
+            isOfficeSite &&
+            !showEditForm &&
+            !showDenyForm && (
+              <span className="sit-actions">
+                <a className="approve-sit-link" onClick={this.openApproveForm}>
+                  <FontAwesomeIcon className="icon" icon={faCheck} />
+                  Approve
+                </a>
+              </span>
+            )
+          )}
+          {showDenyForm ? (
+            <DenySitRequest onClose={this.closeDenyForm} />
+          ) : (
+            isOfficeSite &&
+            !showEditForm &&
+            !showApproveForm && (
+              <span className="sit-actions">
+                <a className="deny-sit-link" onClick={this.openDenyForm}>
+                  <FontAwesomeIcon className="icon" icon={faBan} />
+                  Deny
+                </a>
+              </span>
+            )
+          )}
           {showEditForm ? (
             <Editor
               updateStorageInTransit={this.onSubmit}
@@ -65,12 +111,14 @@ export class StorageInTransit extends Component {
           ) : (
             <span className="sit-actions">
               <span className="sit-edit actionable">
-                {storageInTransit.status !== 'APPROVED' && (
-                  <a onClick={this.openEditForm}>
-                    <FontAwesomeIcon className="icon" icon={faPencil} />
-                    Edit
-                  </a>
-                )}
+                {storageInTransit.status !== 'APPROVED' &&
+                  !showApproveForm &&
+                  !showDenyForm && (
+                    <a onClick={this.openEditForm}>
+                      <FontAwesomeIcon className="icon" icon={faPencil} />
+                      Edit
+                    </a>
+                  )}
               </span>
             </span>
           )}

--- a/src/shared/StorageInTransit/StorageInTransit.jsx
+++ b/src/shared/StorageInTransit/StorageInTransit.jsx
@@ -5,7 +5,6 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 
 import FontAwesomeIcon from '@fortawesome/react-fontawesome';
-import faClock from '@fortawesome/fontawesome-free-solid/faClock';
 import faPencil from '@fortawesome/fontawesome-free-solid/faPencilAlt';
 import faCheck from '@fortawesome/fontawesome-free-solid/faCheck';
 import faBan from '@fortawesome/fontawesome-free-solid/faBan';
@@ -16,7 +15,8 @@ import Editor from 'shared/StorageInTransit/Editor';
 import ApproveSitRequest from 'shared/StorageInTransit/ApproveSitRequest';
 import DenySitRequest from 'shared/StorageInTransit/DenySitRequest';
 import { updateStorageInTransit } from 'shared/Entities/modules/storageInTransits';
-import { isOfficeSite } from 'shared/constants.js';
+import { isOfficeSite, isTspSite } from 'shared/constants.js';
+import SitStatusIcon from './SitStatusIcon';
 
 export class StorageInTransit extends Component {
   constructor() {
@@ -71,7 +71,7 @@ export class StorageInTransit extends Component {
           <span className="unbold">
             {' '}
             <span className="sit-status-text">Status:</span>{' '}
-            <FontAwesomeIcon className="icon icon-grey" icon={faClock} />
+            {storageInTransit.status === 'REQUESTED' && <SitStatusIcon isTspSite={isTspSite} />}
           </span>
           <span>SIT {storageInTransit.status.charAt(0) + storageInTransit.status.slice(1).toLowerCase()} </span>
           {showApproveForm ? (

--- a/src/shared/StorageInTransit/StorageInTransit.jsx
+++ b/src/shared/StorageInTransit/StorageInTransit.jsx
@@ -108,10 +108,10 @@ export class StorageInTransit extends Component {
               onClose={this.closeEditForm}
               storageInTransit={storageInTransit}
             />
-          ) : (
+          ) : isOfficeSite ? (
             <span className="sit-actions">
               <span className="sit-edit actionable">
-                {storageInTransit.status !== 'APPROVED' &&
+                {storageInTransit.status === 'APPROVED' &&
                   !showApproveForm &&
                   !showDenyForm && (
                     <a onClick={this.openEditForm}>
@@ -119,6 +119,15 @@ export class StorageInTransit extends Component {
                       Edit
                     </a>
                   )}
+              </span>
+            </span>
+          ) : (
+            <span className="sit-actions">
+              <span className="sit-edit actionable">
+                <a onClick={this.openEditForm}>
+                  <FontAwesomeIcon className="icon" icon={faPencil} />
+                  Edit
+                </a>
               </span>
             </span>
           )}

--- a/src/shared/StorageInTransit/StorageInTransitOfficeApprovalForm.jsx
+++ b/src/shared/StorageInTransit/StorageInTransitOfficeApprovalForm.jsx
@@ -18,7 +18,6 @@ export class StorageInTransitOfficeApprovalForm extends Component {
         <fieldset key="sit-approval-information">
           <div className="editable-panel-column">
             <SwaggerField
-              className="sit-approval-field"
               fieldName="authorized_start_date"
               swagger={storageInTransitSchema}
               title="Earliest authorized start date"

--- a/src/shared/StorageInTransit/StorageInTransitOfficeApprovalForm.jsx
+++ b/src/shared/StorageInTransit/StorageInTransitOfficeApprovalForm.jsx
@@ -25,7 +25,12 @@ export class StorageInTransitOfficeApprovalForm extends Component {
             />
           </div>
           <div className="editable-panel-column">
-            <SwaggerField className="sit-approval-field" fieldName="notes" swagger={storageInTransitSchema} />
+            <SwaggerField
+              className="sit-approval-field"
+              fieldName="authorization_notes"
+              title="Note"
+              swagger={storageInTransitSchema}
+            />
           </div>
         </fieldset>
       </form>

--- a/src/shared/StorageInTransit/StorageInTransitOfficeDenyForm.jsx
+++ b/src/shared/StorageInTransit/StorageInTransitOfficeDenyForm.jsx
@@ -17,13 +17,7 @@ export class StorageInTransitOfficeDenyForm extends Component {
       <form onSubmit={this.handleSubmit} className="storage-in-transit-office-deny-form">
         <fieldset key="sit-deny-information">
           <div className="editable-panel-column">
-            <SwaggerField
-              className="sit-deny-field"
-              fieldName="notes"
-              swagger={storageInTransitSchema}
-              title="Reason for denial"
-              required
-            />
+            <SwaggerField fieldName="notes" swagger={storageInTransitSchema} title="Reason for denial" required />
           </div>
         </fieldset>
       </form>

--- a/src/shared/StorageInTransit/StorageInTransitOfficeDenyForm.jsx
+++ b/src/shared/StorageInTransit/StorageInTransitOfficeDenyForm.jsx
@@ -17,7 +17,12 @@ export class StorageInTransitOfficeDenyForm extends Component {
       <form onSubmit={this.handleSubmit} className="storage-in-transit-office-deny-form">
         <fieldset key="sit-deny-information">
           <div className="editable-panel-column">
-            <SwaggerField fieldName="notes" swagger={storageInTransitSchema} title="Reason for denial" required />
+            <SwaggerField
+              fieldName="authorization_notes"
+              swagger={storageInTransitSchema}
+              title="Reason for denial"
+              required
+            />
           </div>
         </fieldset>
       </form>

--- a/src/shared/StorageInTransit/StorageInTransitOfficeDenyForm.jsx
+++ b/src/shared/StorageInTransit/StorageInTransitOfficeDenyForm.jsx
@@ -1,0 +1,51 @@
+import { get } from 'lodash';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+import { reduxForm } from 'redux-form';
+import { SwaggerField } from 'shared/JsonSchemaForm/JsonSchemaField';
+
+export class StorageInTransitOfficeDenyForm extends Component {
+  //form submission still to be implemented
+  handleSubmit = e => {
+    e.preventDefault();
+  };
+
+  render() {
+    const { storageInTransitSchema } = this.props;
+    return (
+      <form onSubmit={this.handleSubmit} className="storage-in-transit-office-deny-form">
+        <fieldset key="sit-deny-information">
+          <div className="editable-panel-column">
+            <SwaggerField
+              className="sit-deny-field"
+              fieldName="notes"
+              swagger={storageInTransitSchema}
+              title="Reason for denial"
+              required
+            />
+          </div>
+        </fieldset>
+      </form>
+    );
+  }
+}
+
+StorageInTransitOfficeDenyForm.propTypes = {
+  storageInTransitSchema: PropTypes.object.isRequired,
+};
+
+const formName = 'storage_in_transit_office_deny_form';
+StorageInTransitOfficeDenyForm = reduxForm({
+  form: formName,
+  enableReinitialize: true,
+  keepDirtyOnReinitialize: true,
+})(StorageInTransitOfficeDenyForm);
+
+function mapStateToProps(state) {
+  return {
+    storageInTransitSchema: get(state, 'swaggerPublic.spec.definitions.StorageInTransit', {}),
+  };
+}
+
+export default connect(mapStateToProps)(StorageInTransitOfficeDenyForm);

--- a/src/shared/StorageInTransit/StorageInTransitOfficeDenyForm.test.jsx
+++ b/src/shared/StorageInTransit/StorageInTransitOfficeDenyForm.test.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import { StorageInTransitOfficeDenyForm } from './StorageInTransitOfficeDenyForm';
+
+let store;
+const mockStore = configureStore();
+const submit = jest.fn();
+
+const storageInTransitSchema = {
+  properties: {
+    notes: {
+      type: 'string',
+      format: 'textarea',
+      example: 'this is a note',
+      title: 'Reason for denial',
+    },
+  },
+};
+
+describe('StorageInTransitOfficeDenyForm tests', () => {
+  describe('Empty form', () => {
+    let wrapper;
+    store = mockStore({});
+    wrapper = mount(
+      <Provider store={store}>
+        <StorageInTransitOfficeDenyForm onSubmit={submit} storageInTransitSchema={storageInTransitSchema} />
+      </Provider>,
+    );
+
+    it('renders without crashing', () => {
+      expect(wrapper.find('.storage-in-transit-office-deny-form').length).toEqual(1);
+    });
+  });
+});


### PR DESCRIPTION
## Description

Adds the form that office users will use to deny a SIT request. This story only shows the form. There is another story for submitting the form.

## Setup

```sh
make db_dev_e2e_populate
make server_run
make client_run
```
In the TSP app, select an HHG record and request a SIT. Next, go to the Office app and select the same record for which you added the SIT request. You will see the SIT panel, and a `Deny` link that opens up the form.

* [Pivotal story](https://www.pivotaltracker.com/story/show/164251411) for this change
* [this article](tbd) explains more about the approach used.

## Screenshots

If this PR makes visible UI changes, an image of the finished UI can help reviewers and casual
observers understand the context of the changes. A before image is optional and
can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow instead of using multiple images. You may want to use GIPHY CAPTURE for this! 📸

_Please frame screenshots to show enough useful context but also highlight the affected regions._
