### PR TITLE
[WIP] Make session cookie HttpOnly

### DIFF
--- a/cypress/integration/mymove/homepage.js
+++ b/cypress/integration/mymove/homepage.js
@@ -25,5 +25,5 @@ function milmoveUserIsOnSignInPage() {
 
 function milmoveUserIsWelcomed() {
   cy.signIntoMyMoveAsUser('e10d5964-c070-49cb-9bd1-eaf9f7348eb7');
-  cy.get('strong').contains('Welcome, PPM');
+  cy.contains('Welcome, PPM');
 }

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -183,14 +183,18 @@ Cypress.Commands.add(
 );
 
 Cypress.Commands.add('logout', () => {
-  cy.clearCookies();
   cy.patientVisit('/');
+
   cy.getCookie('masked_gorilla_csrf').then(cookie => {
-    cy.request({
-      url: '/auth/logout',
-      method: 'POST',
-      headers: { 'x-csrf-token': cookie.value },
-    });
+    cy
+      .request({
+        url: '/auth/logout',
+        method: 'POST',
+        headers: { 'x-csrf-token': cookie.value },
+      })
+      .then(resp => {
+        expect(resp.status).to.equal(200);
+      });
 
     // In case of login redirect we once more go to the homepage
     cy.patientVisit('/');

--- a/pkg/auth/cookie.go
+++ b/pkg/auth/cookie.go
@@ -168,6 +168,7 @@ func WriteSessionCookie(w http.ResponseWriter, session *Session, secret string, 
 		Path:     "/",
 		Expires:  time.Unix(0, 0),
 		MaxAge:   -1,
+		HttpOnly: true,
 		SameSite: http.SameSiteLaxMode, // Using 'strict' breaks the use of the login.gov redirect
 		Secure:   useSecureCookie,
 	}

--- a/src/scenes/Landing/index.jsx
+++ b/src/scenes/Landing/index.jsx
@@ -113,7 +113,7 @@ export class Landing extends Component {
     return (
       <div className="usa-grid">
         {loggedInUserIsLoading && <LoadingPlaceholder />}
-        {!isLoggedIn && <SignIn location={this.props.location} />}
+        {!isLoggedIn && !loggedInUserIsLoading && <SignIn location={this.props.location} />}
         {loggedInUserSuccess && (
           <Fragment>
             <div>

--- a/src/shared/Swagger/api.js
+++ b/src/shared/Swagger/api.js
@@ -1,5 +1,6 @@
 import Swagger from 'swagger-client';
 import * as Cookies from 'js-cookie';
+import { setLoggedOut } from 'shared/Data/users';
 
 let client = null;
 let publicClient = null;
@@ -16,11 +17,19 @@ export const requestInterceptor = req => {
   return req;
 };
 
+export const responseInterceptor = res => {
+  if (res.status === 401) {
+    setLoggedOut();
+  }
+  return res;
+};
+
 export async function getClient() {
   if (!client) {
     client = await Swagger({
       url: '/internal/swagger.yaml',
       requestInterceptor: requestInterceptor,
+      responseInterceptor: responseInterceptor,
     });
   }
   return client;
@@ -31,6 +40,7 @@ export async function getPublicClient() {
     publicClient = await Swagger({
       url: '/api/v1/swagger.yaml',
       requestInterceptor: requestInterceptor,
+      responseInterceptor: responseInterceptor,
     });
   }
   return publicClient;


### PR DESCRIPTION
## Description

This PR changes the session cookie so that it has HttpOnly set to true (i.e., it can only be accessed through HTTP, not JavaScript).  We did previously read the cookie in JavaScript, so there is some refactoring included in this PR that instead uses the status of the `logged_in` and persists it to our Redux store.

## Reviewer Notes

This seems to work OK from my testing, but marking it as `WIP` for the following reasons:

- A lot of client tests are failing and it's not clear to me why yet, but may have something to do with the additional data we load at login.
- We have sort of a "chicken and egg" problem in that we don't know if someone is logged in without calling the `logged_in` endpoint.  But if they're not logged in, that endpoint responds with a `401` code because it's a protected endpoint.  If having a `401` is undesirable, we'll need to do some further refactoring.

## Setup

Run the application as usual and ensure you can log in and log out with the normal experience.  Look at the session cookie and ensure it's set to `httpOnly`.  Look at the network tab in the browser dev tools and note the status of the `logged_in` endpoint.  While logged in, delete your session cookie and note if the app properly redirects you to the login page.

## Code Review Verification Steps

* [ ] This works in [Supported Browsers](./docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/164585573) for this change
