### PR TITLE
Update db-backup to take optional DB_PORT parameter

### DIFF
--- a/bin/db-backup
+++ b/bin/db-backup
@@ -5,6 +5,7 @@ set -eu -o pipefail
 
 
 readonly db=${DB_NAME:-db_dev}
+readonly port=${DB_PORT:-5432}
 export PGPASSWORD="mysecretpassword"
 
 function proceed() {
@@ -30,4 +31,4 @@ if [[ -f "$path" ]]; then
   proceed "There is already a backup named '$name'. Do you wish to overwrite it?"
 fi
 
-pg_dump -h localhost -U postgres -c --if-exists "$db" > "$path"
+pg_dump -h localhost -U postgres -p "$port" -c --if-exists "$db" > "$path"

--- a/bin/db-restore
+++ b/bin/db-restore
@@ -4,6 +4,7 @@
 set -eu -o pipefail
 
 readonly db=${DB_NAME:-db_dev}
+readonly port=${DB_PORT:-5432}
 export PGPASSWORD="mysecretpassword"
 
 function list() {
@@ -27,4 +28,4 @@ if [[ ! -f "$path" ]]; then
   exit 1
 fi
 
-psql -h localhost -U postgres -q -d "$db" < "$path" > /dev/null
+psql -h localhost -U postgres -p "$port" -q -d "$db" < "$path" > /dev/null


### PR DESCRIPTION
## Description

Since `test_db` now runs on a different port than dev, update `bin/db-backup` and `bin-db-restore` to take an optional `DB_PORT` parameter, so can backup `test_db` too.

## Setup
```sh
DB_NAME=test_db DB_PORT=5433 bin/db-backup test
DB_NAME=test_db DB_PORT=5433 bin/db-restore test

bin/db-backup dev
bin/db-restore dev
```