### PR TITLE
Only run codecov on go code.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -522,28 +522,6 @@ jobs:
       - run: make client_test
       - announce_failure
 
-  # `client_test_coverage` runs the client side Javascript tests and reports coverage to codecov
-  client_test_coverage:
-    executor: mymove_large
-    steps:
-      - checkout
-      - setup_remote_docker:
-          docker_layer_caching: true
-      - restore_cache:
-          keys:
-            - v1-cache-yarn-v2-{{ checksum "yarn.lock" }}
-      - restore_cache:
-          keys:
-            - v1-mymove-node-modules-{{ checksum "yarn.lock" }}
-      - run: make client_test_coverage
-      - run:
-          name: upload code coverage to codecov
-          command: |
-            curl -s https://codecov.io/bash > codecov
-            chmod +x codecov
-            ./codecov -F javascript -f coverage/coverage-final.json
-          working_directory: /home/circleci/go/src/github.com/transcom/mymove
-
   # `build_tools` builds the mymove-specific CLI tools in `mymove/cmd`
   build_tools:
     executor: mymove_small
@@ -846,10 +824,6 @@ workflows:
           #     ignore: placeholder_branch_name
 
       - client_test:
-          requires:
-            - pre_deps_yarn
-
-      - client_test_coverage:
           requires:
             - pre_deps_yarn
 

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -4,11 +4,14 @@ codecov:
 
 coverage:
   precision: 2
-  round: down
-  range: "70...100"
+  round: nearest
+  range: "50...70"
 
   status:
-    project: yes
+    project:
+      default: false     # disable the default status that measures entire project
+      go:                # declare a new status context "go"
+        paths: "pkg/"    # only include coverage in "pkg/" folder
     patch: yes
     changes: no
 
@@ -23,4 +26,4 @@ parsers:
 comment:
   layout: "header, diff"
   behavior: default
-  require_changes: no
+  require_changes: yes   # only post a comment if the coverage changes on a PR


### PR DESCRIPTION
## Description

This PR adjusts our codecov settings:
* We're only going to look at Go code coverage for now
* The range has been changed to fit the project's current level of coverage
* Codecov will only post a comment on a PR where the coverage changes