### PR TITLE
Use gin for e2e tests locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ __snapshots__
 /bin/swagger
 /bin/tsp-award-queue
 /bin/webserver
+/bin/webserver_e2e
 
 /bin/rds-combined-ca-bundle.pem
 

--- a/Makefile
+++ b/Makefile
@@ -562,6 +562,10 @@ db_test_e2e_backup:
 db_test_e2e_restore:
 	DB_NAME=$(DB_NAME_TEST) DB_PORT=$(DB_PORT_TEST) ./bin/db-restore e2e_test
 
+.PHONY: db_test_e2e_cleanup
+db_test_e2e_cleanup:
+	./bin/db-cleanup e2e_test
+
 
 #
 # ----- END E2E TARGETS -----

--- a/Makefile
+++ b/Makefile
@@ -554,6 +554,15 @@ db_dev_e2e_populate: db_dev_reset db_dev_migrate build_tools
 .PHONY: db_test_e2e_populate
 db_test_e2e_populate: db_test_reset_docker db_test_migrate_docker build_tools db_e2e_up_docker
 
+.PHONY: db_test_e2e_backup
+db_test_e2e_backup:
+	DB_NAME=$(DB_NAME_TEST) DB_PORT=$(DB_PORT_TEST) ./bin/db-backup e2e_test
+
+.PHONY: db_test_e2e_restore
+db_test_e2e_restore:
+	DB_NAME=$(DB_NAME_TEST) DB_PORT=$(DB_PORT_TEST) ./bin/db-restore e2e_test
+
+
 #
 # ----- END E2E TARGETS -----
 #

--- a/README.md
+++ b/README.md
@@ -316,6 +316,9 @@ The Dev Commands are used to talk to the dev DB.  If you were working with the t
 * `make db_test_migrate`
 * `make db_test_migrate_standalone`
 * `make db_test_e2e_populate`
+* `make db_test_e2e_backup`
+* `make db_test_e2e_restore`
+* `make db_test_e2e_cleanup`
 
 The test DB commands all talk to the DB over localhost.  But in a docker-only environment (like CircleCI) you may not be able to use those commands, which is why `*_docker` versions exist for all of them:
 

--- a/bin/db-cleanup
+++ b/bin/db-cleanup
@@ -1,0 +1,27 @@
+#! /usr/bin/env bash
+# Remove the database backup.
+
+set -eu -o pipefail
+
+function list() {
+  echo "Available backups are:"
+  # shellcheck disable=SC2012
+  ls -lctohT tmp/db | awk '{printf "%20s %6s %5s %2s %s\n", $9, $4, $5, $6, $7, $8}'
+  echo
+}
+
+readonly name=${1:-}
+if [[ -z "$name" ]]; then
+  echo "usage: $0 <name of backup to cleanup>"
+  list
+  exit 1
+fi
+
+readonly path="tmp/db/$name"
+if [[ ! -f "$path" ]]; then
+  echo "No backup found with name '$name'."
+  list
+  exit 1
+fi
+
+rm -f "tmp/db/$name"

--- a/bin/run-e2e-test
+++ b/bin/run-e2e-test
@@ -19,3 +19,6 @@ npx cypress open || true
 
 # Terminate the background webserver
 kill %1
+
+# Remvoe the backup of the e2e DB
+make db_test_e2e_cleanup

--- a/bin/run-e2e-test
+++ b/bin/run-e2e-test
@@ -4,7 +4,12 @@ set -eu -o pipefail
 
 # Runs both the webserver and Cypress in parallel
 trap "kill %1" SIGINT
-./bin/webserver --env test --db-port "$DB_PORT_TEST" --login-gov-callback-port 4000 --no-tls-port 4000 &
+
+ENV=test DB_PORT=5433 LOGIN_GOV_CALLBACK_PORT=4000 NO_TLS_PORT=4000 ./bin/gin --build cmd/webserver \
+		--bin /bin/webserver \
+		--port 8080 --appPort 8081 \
+		--excludeDir vendor --excludeDir node_modules \
+		-i --buildArgs "-i" &
 npx cypress open || true
 
 # Terminate the background webserver

--- a/bin/run-e2e-test
+++ b/bin/run-e2e-test
@@ -5,12 +5,12 @@ set -eu -o pipefail
 # Runs both the webserver and Cypress in parallel
 trap "kill %1" SIGINT
 
-DB_NAME=test_db DB_PORT="$DB_PORT_TEST" bin/db-backup e2e_test
+DB_NAME=test_db DB_PORT="$DB_PORT_TEST" ./bin/db-backup e2e_test
 
 CYPRESS_PORT=4000
 ENV=test DB_PORT="$DB_PORT_TEST" LOGIN_GOV_CALLBACK_PORT="$CYPRESS_PORT" NO_TLS_PORT="$CYPRESS_PORT" \
     ./bin/gin --build cmd/webserver \
-		--bin /bin/webserver \
+		--bin /bin/webserver_e2e \
 		--port 8090 --appPort 8091 \
 		--excludeDir vendor --excludeDir node_modules \
 		-i --buildArgs "-i" &

--- a/bin/run-e2e-test
+++ b/bin/run-e2e-test
@@ -5,7 +5,9 @@ set -eu -o pipefail
 # Runs both the webserver and Cypress in parallel
 trap "kill %1" SIGINT
 
-ENV=test DB_PORT=5433 LOGIN_GOV_CALLBACK_PORT=4000 NO_TLS_PORT=4000 ./bin/gin --build cmd/webserver \
+CYPRESS_PORT=4000
+ENV=test DB_PORT="$DB_PORT_TEST" LOGIN_GOV_CALLBACK_PORT="$CYPRESS_PORT" NO_TLS_PORT="$CYPRESS_PORT" \
+    ./bin/gin --build cmd/webserver \
 		--bin /bin/webserver \
 		--port 8080 --appPort 8081 \
 		--excludeDir vendor --excludeDir node_modules \

--- a/bin/run-e2e-test
+++ b/bin/run-e2e-test
@@ -11,7 +11,7 @@ CYPRESS_PORT=4000
 ENV=test DB_PORT="$DB_PORT_TEST" LOGIN_GOV_CALLBACK_PORT="$CYPRESS_PORT" NO_TLS_PORT="$CYPRESS_PORT" \
     ./bin/gin --build cmd/webserver \
 		--bin /bin/webserver \
-		--port 8080 --appPort 8081 \
+		--port 8090 --appPort 8091 \
 		--excludeDir vendor --excludeDir node_modules \
 		-i --buildArgs "-i" &
 npx cypress open || true

--- a/bin/run-e2e-test
+++ b/bin/run-e2e-test
@@ -5,7 +5,7 @@ set -eu -o pipefail
 # Runs both the webserver and Cypress in parallel
 trap "kill %1" SIGINT
 
-DB_NAME=test_db DB_PORT="$DB_PORT_TEST" bin/db-backup test
+DB_NAME=test_db DB_PORT="$DB_PORT_TEST" bin/db-backup e2e_test
 
 CYPRESS_PORT=4000
 ENV=test DB_PORT="$DB_PORT_TEST" LOGIN_GOV_CALLBACK_PORT="$CYPRESS_PORT" NO_TLS_PORT="$CYPRESS_PORT" \

--- a/bin/run-e2e-test
+++ b/bin/run-e2e-test
@@ -5,6 +5,8 @@ set -eu -o pipefail
 # Runs both the webserver and Cypress in parallel
 trap "kill %1" SIGINT
 
+DB_NAME=test_db DB_PORT="$DB_PORT_TEST" bin/db-backup test
+
 CYPRESS_PORT=4000
 ENV=test DB_PORT="$DB_PORT_TEST" LOGIN_GOV_CALLBACK_PORT="$CYPRESS_PORT" NO_TLS_PORT="$CYPRESS_PORT" \
     ./bin/gin --build cmd/webserver \

--- a/bin/run-e2e-test
+++ b/bin/run-e2e-test
@@ -5,7 +5,8 @@ set -eu -o pipefail
 # Runs both the webserver and Cypress in parallel
 trap "kill %1" SIGINT
 
-DB_NAME=test_db DB_PORT="$DB_PORT_TEST" ./bin/db-backup e2e_test
+# Make a backup of the e2e DB
+make db_test_e2e_backup
 
 CYPRESS_PORT=4000
 ENV=test DB_PORT="$DB_PORT_TEST" LOGIN_GOV_CALLBACK_PORT="$CYPRESS_PORT" NO_TLS_PORT="$CYPRESS_PORT" \


### PR DESCRIPTION
## Description

We want the webserver server to auto reload when we make go changes while debugging with e2e tests. This swaps out using the webserver binary directly for using gin like we do in the Makefile.

## Reviewer Notes

Run this locally and see if it works for you like it did for me.

## Setup

```sh
make e2e_test
```

## Code Review Verification Steps

* [x] Request review from a member of a different team.