### PR TITLE
Adds new field ApproveDate to ppm. Save ApproveDate when move is appr…

### DIFF
--- a/migrations/20190328200919_add_approve_date_to_ppm.up.fizz
+++ b/migrations/20190328200919_add_approve_date_to_ppm.up.fizz
@@ -1,0 +1,1 @@
+add_column("personally_procured_moves", "approve_date", "timestamptz", {"null": true})

--- a/pkg/handlers/internalapi/office.go
+++ b/pkg/handlers/internalapi/office.go
@@ -2,6 +2,7 @@ package internalapi
 
 import (
 	"reflect"
+	"time"
 
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/gofrs/uuid"
@@ -123,7 +124,6 @@ type ApprovePPMHandler struct {
 
 // Handle ... approves a Personally Procured Move from a request payload
 func (h ApprovePPMHandler) Handle(params officeop.ApprovePPMParams) middleware.Responder {
-
 	ctx, span := beeline.StartSpan(params.HTTPRequest.Context(), reflect.TypeOf(h).Name())
 	defer span.Send()
 
@@ -140,7 +140,8 @@ func (h ApprovePPMHandler) Handle(params officeop.ApprovePPMParams) middleware.R
 		return handlers.ResponseForError(h.Logger(), err)
 	}
 	moveID := ppm.MoveID
-	err = ppm.Approve()
+	approveDate := time.Time(params.ApprovePersonallyProcuredMovePayload.ApproveDate)
+	err = ppm.Approve(approveDate)
 	if err != nil {
 		h.Logger().Error("Attempted to approve PPM, got invalid transition", zap.Error(err), zap.String("move_status", string(ppm.Status)))
 		return handlers.ResponseForError(h.Logger(), err)

--- a/pkg/handlers/internalapi/office_test.go
+++ b/pkg/handlers/internalapi/office_test.go
@@ -2,6 +2,7 @@ package internalapi
 
 import (
 	"net/http/httptest"
+	"time"
 
 	"github.com/go-openapi/strfmt"
 
@@ -198,9 +199,13 @@ func (suite *HandlerSuite) TestApprovePPMHandler() {
 	req := httptest.NewRequest("POST", "/personally_procured_moves/some_id/approve", nil)
 	req = suite.AuthenticateOfficeRequest(req, officeUser)
 
+	newApprovePersonallyProcuredMovePayload := internalmessages.ApprovePersonallyProcuredMovePayload{
+		ApproveDate: strfmt.DateTime(time.Now()),
+	}
 	params := officeop.ApprovePPMParams{
-		HTTPRequest:              req,
-		PersonallyProcuredMoveID: strfmt.UUID(ppm.ID.String()),
+		HTTPRequest:                          req,
+		PersonallyProcuredMoveID:             strfmt.UUID(ppm.ID.String()),
+		ApprovePersonallyProcuredMovePayload: &newApprovePersonallyProcuredMovePayload,
 	}
 
 	// And: a ppm is approved
@@ -226,9 +231,13 @@ func (suite *HandlerSuite) TestApprovePPMHandlerForbidden() {
 	req := httptest.NewRequest("POST", "/personally_procured_moves/some_id/approve", nil)
 	req = suite.AuthenticateRequest(req, user)
 
+	newApprovePersonallyProcuredMovePayload := internalmessages.ApprovePersonallyProcuredMovePayload{
+		ApproveDate: strfmt.DateTime(time.Now()),
+	}
 	params := officeop.ApprovePPMParams{
-		HTTPRequest:              req,
-		PersonallyProcuredMoveID: strfmt.UUID(ppm.ID.String()),
+		HTTPRequest:                          req,
+		PersonallyProcuredMoveID:             strfmt.UUID(ppm.ID.String()),
+		ApprovePersonallyProcuredMovePayload: &newApprovePersonallyProcuredMovePayload,
 	}
 
 	// And: a ppm is approved

--- a/pkg/handlers/internalapi/personally_procured_move.go
+++ b/pkg/handlers/internalapi/personally_procured_move.go
@@ -34,6 +34,7 @@ func payloadForPPMModel(storer storage.FileStorer, personallyProcuredMove models
 		WeightEstimate:                personallyProcuredMove.WeightEstimate,
 		OriginalMoveDate:              handlers.FmtDatePtr(personallyProcuredMove.OriginalMoveDate),
 		ActualMoveDate:                handlers.FmtDatePtr(personallyProcuredMove.ActualMoveDate),
+		ApproveDate:                   handlers.FmtDateTimePtr(personallyProcuredMove.ApproveDate),
 		NetWeight:                     personallyProcuredMove.NetWeight,
 		PickupPostalCode:              personallyProcuredMove.PickupPostalCode,
 		HasAdditionalPostalCode:       personallyProcuredMove.HasAdditionalPostalCode,

--- a/pkg/handlers/internalapi/personally_procured_move_test.go
+++ b/pkg/handlers/internalapi/personally_procured_move_test.go
@@ -634,7 +634,7 @@ func (suite *HandlerSuite) TestRequestPPMPayment() {
 	if err != nil {
 		t.Fatal("Should transition.")
 	}
-	err = ppm1.Approve()
+	err = ppm1.Approve(time.Now())
 	if err != nil {
 		t.Fatal("Should transition.")
 	}

--- a/pkg/models/personally_procured_move.go
+++ b/pkg/models/personally_procured_move.go
@@ -44,6 +44,7 @@ type PersonallyProcuredMove struct {
 	WeightEstimate                *int64                       `json:"weight_estimate" db:"weight_estimate"`
 	OriginalMoveDate              *time.Time                   `json:"original_move_date" db:"original_move_date"`
 	ActualMoveDate                *time.Time                   `json:"actual_move_date" db:"actual_move_date"`
+	ApproveDate                   *time.Time                   `json:"approve_date" db:"approve_date"`
 	NetWeight                     *int64                       `json:"net_weight" db:"net_weight"`
 	PickupPostalCode              *string                      `json:"pickup_postal_code" db:"pickup_postal_code"`
 	HasAdditionalPostalCode       *bool                        `json:"has_additional_postal_code" db:"has_additional_postal_code"`
@@ -103,12 +104,17 @@ func (p *PersonallyProcuredMove) Submit() error {
 }
 
 // Approve approves the PPM to go forward.
-func (p *PersonallyProcuredMove) Approve() error {
+func (p *PersonallyProcuredMove) Approve(approveDate time.Time) error {
 	if !(p.Status == PPMStatusSUBMITTED || p.Status == PPMStatusDRAFT) {
-		return errors.Wrap(ErrInvalidTransition, "Approve")
+		return errors.Wrap(ErrInvalidTransition, "Approve - status change")
+	}
+
+	if p.ApproveDate != nil {
+		return errors.Wrap(ErrInvalidTransition, "Aprove - approve date change")
 	}
 
 	p.Status = PPMStatusAPPROVED
+	p.ApproveDate = &approveDate
 	return nil
 }
 

--- a/pkg/models/shipment_summary_worksheet_test.go
+++ b/pkg/models/shipment_summary_worksheet_test.go
@@ -84,7 +84,7 @@ func (suite *ModelSuite) TestFetchDataShipmentSummaryWorksheet() {
 	ppm.Move.Approve()
 	// This is the same PPM model as ppm, but this is the one that will be saved by SaveMoveDependencies
 	ppm.Move.PersonallyProcuredMoves[0].Submit()
-	ppm.Move.PersonallyProcuredMoves[0].Approve()
+	ppm.Move.PersonallyProcuredMoves[0].Approve(time.Now())
 	ppm.Move.PersonallyProcuredMoves[0].RequestPayment()
 	models.SaveMoveDependencies(suite.DB(), &ppm.Move)
 	ssd, err := models.FetchDataShipmentSummaryWorksheetFormData(suite.DB(), &session, moveID)

--- a/pkg/testdatagen/scenario/e2ebasic.go
+++ b/pkg/testdatagen/scenario/e2ebasic.go
@@ -362,7 +362,7 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, log
 	ppm2.Move.Approve()
 	// This is the same PPM model as ppm2, but this is the one that will be saved by SaveMoveDependencies
 	ppm2.Move.PersonallyProcuredMoves[0].Submit()
-	ppm2.Move.PersonallyProcuredMoves[0].Approve()
+	ppm2.Move.PersonallyProcuredMoves[0].Approve(time.Now())
 	models.SaveMoveDependencies(db, &ppm2.Move)
 
 	/*
@@ -410,7 +410,7 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, log
 	ppm3.Move.Approve()
 	// This is the same PPM model as ppm3, but this is the one that will be saved by SaveMoveDependencies
 	ppm3.Move.PersonallyProcuredMoves[0].Submit()
-	ppm3.Move.PersonallyProcuredMoves[0].Approve()
+	ppm3.Move.PersonallyProcuredMoves[0].Approve(time.Now())
 	ppm3.Move.PersonallyProcuredMoves[0].RequestPayment()
 	models.SaveMoveDependencies(db, &ppm3.Move)
 
@@ -2276,7 +2276,7 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, log
 	ppm5.Move.Approve()
 	// This is the same PPM model as ppm5, but this is the one that will be saved by SaveMoveDependencies
 	ppm5.Move.PersonallyProcuredMoves[0].Submit()
-	ppm5.Move.PersonallyProcuredMoves[0].Approve()
+	ppm5.Move.PersonallyProcuredMoves[0].Approve(time.Now())
 	models.SaveMoveDependencies(db, &ppm5.Move)
 }
 

--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -77,6 +77,7 @@ import faCheck from '@fortawesome/fontawesome-free-solid/faCheck';
 import faExclamationCircle from '@fortawesome/fontawesome-free-solid/faExclamationCircle';
 import faPlayCircle from '@fortawesome/fontawesome-free-solid/faPlayCircle';
 import faExternalLinkAlt from '@fortawesome/fontawesome-free-solid/faExternalLinkAlt';
+import moment from 'moment';
 
 const BasicsTabContent = props => {
   return (
@@ -215,7 +216,8 @@ class MoveInfo extends Component {
   };
 
   approvePPM = () => {
-    this.props.approvePPM(this.props.ppm.id);
+    const approveDate = moment().format();
+    this.props.approvePPM(this.props.ppm.id, approveDate);
   };
 
   approveShipment = () => {

--- a/src/shared/Entities/modules/ppms.js
+++ b/src/shared/Entities/modules/ppms.js
@@ -8,9 +8,19 @@ const loadPPMsLabel = 'office.loadPPMs';
 const updatePPMLabel = 'office.updatePPM';
 const approveReimbursementLabel = 'office.approveReimbursement';
 
-export function approvePPM(personallyProcuredMoveId, label = approvePpmLabel) {
+export function approvePPM(personallyProcuredMoveId, personallyProcuredMoveApproveDate, label = approvePpmLabel) {
   const swaggerTag = 'office.approvePPM';
-  return swaggerRequest(getClient, swaggerTag, { personallyProcuredMoveId }, { label });
+  return swaggerRequest(
+    getClient,
+    swaggerTag,
+    {
+      personallyProcuredMoveId,
+      approvePersonallyProcuredMovePayload: {
+        approve_date: personallyProcuredMoveApproveDate,
+      },
+    },
+    { label },
+  );
 }
 
 export function loadPPMs(moveId, label = loadPPMsLabel) {

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -396,6 +396,12 @@ definitions:
         format: date
         title: When did you actually move?
         x-nullable: true
+      approve_date:
+        type: string
+        format: date-time
+        title: When was the ppm move approved?
+        example: '2019-03-26T13:19:56-04:00'
+        x-nullable: true
       pickup_postal_code:
         type: string
         format: zip
@@ -556,6 +562,14 @@ definitions:
         type: integer
       GTCC:
         type: integer
+  ApprovePersonallyProcuredMovePayload:
+    type: object
+    properties:
+      approve_date:
+        type: string
+        format: date-time
+        title: When was the ppm move approved?
+        example: '2019-03-26T13:19:56-04:00'
   IndexPersonallyProcuredMovePayload:
     type: array
     items:
@@ -3534,6 +3548,11 @@ paths:
           format: uuid
           required: true
           description: UUID of the PPM being updated
+        - name: approvePersonallyProcuredMovePayload
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/ApprovePersonallyProcuredMovePayload'
       responses:
         200:
           description: updated instance of personally_procured_move


### PR DESCRIPTION
…oved. Updates test to account for new payload param.

## Description

Explain a little about the changes at a high level.

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
echo "Code goes here"
```

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](./docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](./docs/backend.md#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](./docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
  * [ ] Secure migrations have been tested using `bin/run-prod-migrations`
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers](./docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @ntwyman
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](tbd) for this change
* [this article](tbd) explains more about the approach used.

## Screenshots

If this PR makes visible UI changes, an image of the finished UI can help reviewers and casual
observers understand the context of the changes. A before image is optional and
can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow instead of using multiple images. You may want to use GIPHY CAPTURE for this! 📸

_Please frame screenshots to show enough useful context but also highlight the affected regions._
