### PR TITLE
Patient visit for login

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -57,7 +57,7 @@ Cypress.Commands.add('signInAsUser', userId => {
   // make sure we log out first before sign in
   cy.logout();
 
-  cy.visit('/devlocal-auth/login');
+  cy.patientVisit('/devlocal-auth/login');
   // should have both our csrf cookie tokens now
   cy.getCookie('_gorilla_csrf').should('exist');
   cy.getCookie('masked_gorilla_csrf').should('exist');


### PR DESCRIPTION
## Description

We've been having some flakiness in the before hook on TSP and office e2e tests, namely with finding the button to local login in as the tsp or office user. My suspicion is that since we were just using `visit` instead of `patientVisit`, parts of the site hadn't loaded yet (but cookies were set fairly instantaneously), which caused us to be unable to find the button for the appropriate user.

## Setup

I was unable to reproduce locally on my computer, which is why I think the best way to test this is in the pr process. It shouldn't hurt, at a minimum.

## Code Review Verification Steps

* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* https://www.pivotaltracker.com/story/show/164803621

