### PR TITLE
Remove pagination controls from office queue index

### DIFF
--- a/src/scenes/Office/QueueTable.jsx
+++ b/src/scenes/Office/QueueTable.jsx
@@ -138,6 +138,7 @@ class QueueTable extends Component {
             loading={this.state.loading} // Display the loading overlay when we need it
             pageSize={this.state.data.length}
             className="-striped -highlight"
+            showPagination={false}
             getTrProps={(state, rowInfo) => ({
               onDoubleClick: e => this.props.history.push(`new/moves/${rowInfo.original.id}`),
             })}

--- a/src/scenes/Office/office.css
+++ b/src/scenes/Office/office.css
@@ -1,6 +1,7 @@
 .queue-table {
   font-size: 0.75em;
   min-width: 1000px;
+  margin-bottom: 4em;
 }
 
 .queue-table-scrollable {


### PR DESCRIPTION
## Description
The current pagination for office queues doesn't add much value and we now want to see all moves for a given queue.

## Setup
- Log in as an office user
- Look through each queue and note the lack of pagination 😎 

## Code Review Verification Steps
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/164789531) for this change

## Screenshots
Here's the final product:
![Screen Recording 2019-03-29 at 11 53 31 mov](https://user-images.githubusercontent.com/3522323/55249731-c5a40980-521a-11e9-9d70-4521b307d613.gif)


