### PR TITLE
Remove pagination from TSP queues index

### DIFF
--- a/pkg/handlers/publicapi/shipments.go
+++ b/pkg/handlers/publicapi/shipments.go
@@ -130,7 +130,7 @@ func (h IndexShipmentsHandler) Handle(params shipmentop.IndexShipmentsParams) mi
 	}
 
 	shipments, err := models.FetchShipmentsByTSP(h.DB(), tspUser.TransportationServiceProviderID,
-		params.Status, params.OrderBy, params.Limit, params.Offset)
+		params.Status, params.OrderBy)
 	if err != nil {
 		h.Logger().Error("DB Query", zap.Error(err))
 		return shipmentop.NewIndexShipmentsBadRequest()

--- a/pkg/handlers/publicapi/shipments_test.go
+++ b/pkg/handlers/publicapi/shipments_test.go
@@ -431,10 +431,6 @@ func (suite *HandlerSuite) TestIndexShipmentsHandlerPaginated() {
 	tspUser1 := tspUsers[0]
 	tspUser2 := tspUsers[1]
 
-	// Constants
-	limit := int64(25)
-	offset := int64(1)
-
 	// Handler to Test
 	handler := IndexShipmentsHandler{handlers.NewHandlerContext(suite.DB(), suite.TestLogger())}
 
@@ -443,8 +439,6 @@ func (suite *HandlerSuite) TestIndexShipmentsHandlerPaginated() {
 	req1 = suite.AuthenticateTspRequest(req1, tspUser1)
 	params1 := shipmentop.IndexShipmentsParams{
 		HTTPRequest: req1,
-		Limit:       &limit,
-		Offset:      &offset,
 	}
 
 	response1 := handler.Handle(params1)
@@ -457,8 +451,6 @@ func (suite *HandlerSuite) TestIndexShipmentsHandlerPaginated() {
 	req2 = suite.AuthenticateTspRequest(req2, tspUser2)
 	params2 := shipmentop.IndexShipmentsParams{
 		HTTPRequest: req2,
-		Limit:       &limit,
-		Offset:      &offset,
 	}
 
 	response2 := handler.Handle(params2)
@@ -482,13 +474,9 @@ func (suite *HandlerSuite) TestIndexShipmentsHandlerSortShipmentsPickupAsc() {
 	req := httptest.NewRequest("GET", "/shipments", nil)
 	req = suite.AuthenticateTspRequest(req, tspUser)
 
-	limit := int64(25)
-	offset := int64(1)
 	orderBy := "PICKUP_DATE_ASC"
 	params := shipmentop.IndexShipmentsParams{
 		HTTPRequest: req,
-		Limit:       &limit,
-		Offset:      &offset,
 		OrderBy:     &orderBy,
 	}
 
@@ -531,13 +519,9 @@ func (suite *HandlerSuite) TestIndexShipmentsHandlerSortShipmentsPickupDesc() {
 	req := httptest.NewRequest("GET", "/shipments", nil)
 	req = suite.AuthenticateTspRequest(req, tspUser)
 
-	limit := int64(25)
-	offset := int64(1)
 	orderBy := "PICKUP_DATE_DESC"
 	params := shipmentop.IndexShipmentsParams{
 		HTTPRequest: req,
-		Limit:       &limit,
-		Offset:      &offset,
 		OrderBy:     &orderBy,
 	}
 
@@ -580,13 +564,9 @@ func (suite *HandlerSuite) TestIndexShipmentsHandlerSortShipmentsDeliveryAsc() {
 	req := httptest.NewRequest("GET", "/shipments", nil)
 	req = suite.AuthenticateTspRequest(req, tspUser)
 
-	limit := int64(25)
-	offset := int64(1)
 	orderBy := "DELIVERY_DATE_ASC"
 	params := shipmentop.IndexShipmentsParams{
 		HTTPRequest: req,
-		Limit:       &limit,
-		Offset:      &offset,
 		OrderBy:     &orderBy,
 	}
 
@@ -629,13 +609,9 @@ func (suite *HandlerSuite) TestIndexShipmentsHandlerSortShipmentsDeliveryDesc() 
 	req := httptest.NewRequest("GET", "/shipments", nil)
 	req = suite.AuthenticateTspRequest(req, tspUser)
 
-	limit := int64(25)
-	offset := int64(1)
 	orderBy := "DELIVERY_DATE_DESC"
 	params := shipmentop.IndexShipmentsParams{
 		HTTPRequest: req,
-		Limit:       &limit,
-		Offset:      &offset,
 		OrderBy:     &orderBy,
 	}
 

--- a/pkg/models/shipment.go
+++ b/pkg/models/shipment.go
@@ -589,7 +589,7 @@ func FetchUnofferedShipments(db *pop.Connection) (Shipments, error) {
 }
 
 // FetchShipmentsByTSP looks up all shipments belonging to a TSP ID
-func FetchShipmentsByTSP(tx *pop.Connection, tspID uuid.UUID, status []string, orderBy *string, limit *int64, offset *int64) ([]Shipment, error) {
+func FetchShipmentsByTSP(tx *pop.Connection, tspID uuid.UUID, status []string, orderBy *string) ([]Shipment, error) {
 
 	shipments := []Shipment{}
 
@@ -624,25 +624,6 @@ func FetchShipmentsByTSP(tx *pop.Connection, tspID uuid.UUID, status []string, o
 			query.Order(*orderBy)
 		}
 	}
-
-	// Manage limit and offset values
-	var limitVar = 25
-	if limit != nil && *limit > 0 {
-		limitVar = int(*limit)
-	}
-
-	var offsetVar = 1
-	if offset != nil && *offset > 1 {
-		offsetVar = int(*offset)
-	}
-
-	// Pop doesn't have a direct Offset() function and instead paginates. This means the offset isn't actually
-	// the DB offset.  It's first multiplied by the limit and then applied.  Examples:
-	//   - Paginate(0, 25) = LIMIT 25 OFFSET 0  (this is an odd case and is coded into Pop)
-	//   - Paginate(1, 25) = LIMIT 25 OFFSET 0
-	//   - Paginate(2, 25) = LIMIT 25 OFFSET 25
-	//   - Paginate(3, 25) = LIMIT 25 OFFSET 50
-	query.Paginate(offsetVar, limitVar)
 
 	err := query.All(&shipments)
 

--- a/src/scenes/TransportationServiceProvider/QueueTable.jsx
+++ b/src/scenes/TransportationServiceProvider/QueueTable.jsx
@@ -128,6 +128,7 @@ class QueueTable extends Component {
             loading={this.state.loading} // Display the loading overlay when we need it
             pageSize={this.state.data.length}
             className="-striped -highlight"
+            showPagination={false}
             getTrProps={(state, rowInfo) => ({
               onDoubleClick: e => this.props.history.push(`/shipments/${rowInfo.original.id}`),
             })}

--- a/src/scenes/TransportationServiceProvider/api.js
+++ b/src/scenes/TransportationServiceProvider/api.js
@@ -18,8 +18,6 @@ export async function RetrieveShipmentsForTSP(queueType) {
   const client = await getPublicClient();
   const response = await client.apis.shipments.indexShipments({
     status,
-    limit: 100,
-    offset: 1,
   });
   checkResponse(response, 'failed to retrieve moves due to server error');
   return response.body;

--- a/src/scenes/TransportationServiceProvider/tsp.css
+++ b/src/scenes/TransportationServiceProvider/tsp.css
@@ -1,6 +1,7 @@
 .queue-table {
   font-size: 0.75em;
   min-width: 1000px;
+  margin-bottom: 4em;
 }
 
 .queue-table-scrollable {

--- a/swagger/api.yaml
+++ b/swagger/api.yaml
@@ -2132,18 +2132,6 @@ paths:
             - PICKUP_DATE_DESC
             - DELIVERY_DATE_ASC
             - DELIVERY_DATE_DESC
-        - name: limit
-          in: query
-          type: integer
-          description: maximum number of records to return
-          minimum: 1
-          default: 25
-        - name: offset
-          in: query
-          type: integer
-          description: offset into records to select from. Actual offset is this value multiplied by limit.
-          minimum: 1
-          default: 1
       responses:
         200:
           description: returns an array of Shipments


### PR DESCRIPTION
## Description
The current pagination for TSP queues doesn't add much value and we now want to see all shipments for a given queue.

## Reviewer notes
- This removes the limit and offset parameters from one of our public API endpoints

## Setup
- Log in as a TSP user
- Look through each queue and note the lack of pagination 

## Code Review Verification Steps
* [x] User facing changes have been reviewed by design.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/164789535) for this change

## Screenshots
Here's the final product:
![Screen Recording 2019-03-29 at 14 51 44](https://user-images.githubusercontent.com/3522323/55259080-aa44f880-5232-11e9-9b56-ace5d3a3c857.gif)



