### PR TITLE
Add "Delivered on" column to TSP queue.

### DIFF
--- a/cypress/integration/tsp/queues.js
+++ b/cypress/integration/tsp/queues.js
@@ -69,6 +69,9 @@ function tspUserViewsInTransitShipments() {
   // Find title
   cy.get('h1').contains('Queue: In Transit Shipments');
 
+  // Not delivered yet
+  cy.get('.delivered_on').should('be.empty');
+
   // Find in transit (generated in e2ebasic.go) and open it
   cy.selectQueueItemMoveLocator('NINOPK');
 
@@ -91,6 +94,7 @@ function tspUserViewsDeliveredShipments() {
 
   // Find title
   cy.get('h1').contains('Queue: Delivered Shipments');
+  cy.get('.delivered_on').contains(/\d{2}-\w{3}-\d{2}/);
 
   // Find delivered shipment (generated in e2ebasic.go) and open it
   cy.selectQueueItemMoveLocator('SCHNOO');

--- a/src/scenes/TransportationServiceProvider/QueueTable.jsx
+++ b/src/scenes/TransportationServiceProvider/QueueTable.jsx
@@ -119,6 +119,22 @@ class QueueTable extends Component {
                 Cell: row => <span className="pickup_date">{formatDate(row.value)}</span>,
               },
               {
+                Header: 'Pickup Date',
+                id: 'pickup_date',
+                accessor: d =>
+                  d.actual_pickup_date ||
+                  d.pm_survey_planned_pickup_date ||
+                  d.requested_pickup_date ||
+                  d.original_pickup_date,
+                Cell: row => <span className="pickup_date">{formatDate(row.value)}</span>,
+              },
+              {
+                Header: 'Delivered on',
+                id: 'delivered_on',
+                accessor: 'actual_delivery_date',
+                Cell: row => <span className="delivered_on">{formatDate(row.value)}</span>,
+              },
+              {
                 Header: 'Last modified',
                 accessor: 'updated_at',
                 Cell: row => <span className="updated_at">{formatDateTime(row.value)}</span>,

--- a/src/scenes/TransportationServiceProvider/QueueTable.jsx
+++ b/src/scenes/TransportationServiceProvider/QueueTable.jsx
@@ -119,16 +119,6 @@ class QueueTable extends Component {
                 Cell: row => <span className="pickup_date">{formatDate(row.value)}</span>,
               },
               {
-                Header: 'Pickup Date',
-                id: 'pickup_date',
-                accessor: d =>
-                  d.actual_pickup_date ||
-                  d.pm_survey_planned_pickup_date ||
-                  d.requested_pickup_date ||
-                  d.original_pickup_date,
-                Cell: row => <span className="pickup_date">{formatDate(row.value)}</span>,
-              },
-              {
                 Header: 'Delivered on',
                 id: 'delivered_on',
                 accessor: 'actual_delivery_date',


### PR DESCRIPTION
## Description

As a TSP user
I want to see the delivered on date
So that I can identify which shipments have been recently delivered and may need to be invoiced.

## Setup

- Log in as a TSP user
- Take a look at the "Delivered on" column that is now in the queue table


## Code Review Verification Steps

* [x] User facing changes have been reviewed by design.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/164788590) for this change

## Screenshots
![Screen Recording 2019-04-01 at 11 29 47](https://user-images.githubusercontent.com/3522323/55421745-93a6e600-553f-11e9-8a36-e53c8c58f699.gif)


