### PR TITLE
Enable combo button in production and update e2e tests

### DIFF
--- a/cypress/integration/office/officeUserHHG.js
+++ b/cypress/integration/office/officeUserHHG.js
@@ -141,17 +141,16 @@ function officeUserApprovesOnlyBasicsHHG() {
     expect(loc.pathname).to.match(/^\/queues\/new\/moves\/[^/]+\/basics/);
   });
 
+  cy.get('.combo-button').click();
+
   // Approve basics
   cy
-    .get('button')
+    .get('.combo-button .dropdown')
     .contains('Approve Basics')
     .click();
 
-  // disabled because not on hhg tab
-  cy
-    .get('button')
-    .contains('Approve HHG')
-    .should('be.disabled');
+  cy.get('.combo-button').click();
+
   cy
     .get('button')
     .contains('Complete Shipments')
@@ -170,16 +169,16 @@ function officeUserApprovesOnlyBasicsHHG() {
   });
 
   // disabled because shipment not yet accepted
-  cy
-    .get('button')
-    .contains('Approve HHG')
-    .should('be.disabled');
+  cy.get('.combo-button').click();
 
   // Disabled because already approved and not delivered
   cy
-    .get('button')
+    .get('.combo-button .dropdown')
     .contains('Approve HHG')
-    .should('be.disabled');
+    .should('have.class', 'disabled');
+
+  cy.get('.combo-button').click();
+
   cy
     .get('button')
     .contains('Complete Shipments')
@@ -202,21 +201,15 @@ function officeUserApprovesHHG() {
     expect(loc.pathname).to.match(/^\/queues\/new\/moves\/[^/]+\/basics/);
   });
 
+  cy.get('.combo-button').click();
+
   // Approve basics
   cy
-    .get('button')
+    .get('.combo-button .dropdown')
     .contains('Approve Basics')
     .click();
 
-  // disabled because not on hhg tab
-  cy
-    .get('button')
-    .contains('Approve HHG')
-    .should('be.disabled');
-  cy
-    .get('button')
-    .contains('Complete Shipments')
-    .should('be.disabled');
+  cy.get('.combo-button').click();
 
   cy.get('.status').contains('Accepted');
 
@@ -230,17 +223,15 @@ function officeUserApprovesHHG() {
     expect(loc.pathname).to.match(/^\/queues\/new\/moves\/[^/]+\/hhg/);
   });
 
+  cy.get('.combo-button').click();
+
   // Approve HHG
+
   cy
-    .get('button')
+    .get('.combo-button .dropdown')
     .contains('Approve HHG')
     .click();
 
-  // Disabled because already approved and not delivered
-  cy
-    .get('button')
-    .contains('Approve HHG')
-    .should('be.disabled');
   cy
     .get('button')
     .contains('Complete Shipments')
@@ -289,11 +280,6 @@ function officeUserCompletesHHG() {
     .get('button')
     .contains('Complete Shipments')
     .click();
-
-  cy
-    .get('button')
-    .contains('Approve HHG')
-    .should('be.disabled');
 
   cy.get('.status').contains('Completed');
 }

--- a/cypress/integration/office/officeUserHHGPPM.js
+++ b/cypress/integration/office/officeUserHHGPPM.js
@@ -34,13 +34,18 @@ describe('office user finds the shipment', function() {
 });
 
 function officeUserApprovesShipment() {
-  const ApproveShipmentButton = cy.get('button').contains('Approve HHG');
+  cy.get('.combo-button').click();
 
-  ApproveShipmentButton.should('be.enabled');
+  // Approve HHG
+  cy
+    .get('.combo-button .dropdown')
+    .contains('Approve HHG')
+    .click();
 
-  ApproveShipmentButton.click();
-
-  ApproveShipmentButton.should('be.disabled');
+  cy
+    .get('.combo-button .dropdown')
+    .contains('Approve HHG')
+    .should('have.class', 'disabled');
 
   cy.get('.status').contains('Approved');
 }

--- a/cypress/integration/office/officeUserPPM.js
+++ b/cypress/integration/office/officeUserPPM.js
@@ -12,9 +12,11 @@ describe('office user finds the move', function() {
   it('office user verifies the orders tab', function() {
     officeUserVerifiesOrders('VGHEIS');
   });
+
   it('office user verifies the accounting tab', function() {
     officeUserVerifiesAccounting();
   });
+
   it('office user approves move, verifies and approves PPM', function() {
     officeUserApprovesMoveAndPPM('VGHEIS');
     officeUserVerifiesPPM();
@@ -27,9 +29,9 @@ describe('office user finds the move', function() {
 
     // Make sure the page hasn't exploded
     cy
-      .get('button')
-      .contains('Approve PPM')
-      .should('have.class', 'btn__approve--green');
+      .get('.combo-button .btn__approve--green')
+      .contains('Approved')
+      .should('be.disabled');
   });
   it('office user views actual move date', function() {
     officeUserGoesToPPMPanel('PAYMNT');
@@ -181,10 +183,13 @@ function officeUserVerifiesOrders(moveLocator) {
 
   // Refresh browser and make sure changes persist
   cy.patientReload();
+
+  cy.get('.combo-button').click();
   cy
-    .get('button')
+    .get('.combo-button .dropdown')
     .contains('Approve PPM')
-    .should('be.disabled');
+    .should('have.class', 'disabled');
+  cy.get('.combo-button').click();
 
   cy.get('span').contains('666666');
   cy.get('span').contains('Delayed Approval 20 Weeks or More');
@@ -235,10 +240,12 @@ function officeUserVerifiesAccounting() {
 
   // Refresh browser and make sure changes persist
   cy.patientReload();
+  cy.get('.combo-button').click();
   cy
-    .get('button')
+    .get('.combo-button .dropdown')
     .contains('Approve PPM')
-    .should('be.disabled');
+    .should('have.class', 'disabled');
+  cy.get('.combo-button').click();
 
   cy.get('span').contains('6789');
   cy.get('span').contains('57 - United States Air Force');
@@ -259,19 +266,24 @@ function officeUserApprovesMoveAndPPM(moveLocator) {
   });
 
   // Approve the move
+  cy.get('.combo-button').click();
+
   cy
-    .get('button')
+    .get('.combo-button .dropdown')
     .contains('Approve PPM')
-    .should('be.disabled');
+    .should('have.class', 'disabled');
+
   cy
-    .get('button')
+    .get('.combo-button .dropdown')
     .contains('Approve Basics')
     .click();
 
   cy
-    .get('button')
+    .get('.combo-button .dropdown')
     .contains('Approve PPM')
-    .should('be.enabled');
+    .should('not.have.class', 'disabled');
+
+  cy.get('.combo-button').click();
 
   // Open new moves queue
   cy.patientVisit('/');
@@ -301,11 +313,15 @@ function officeUserApprovesMoveAndPPM(moveLocator) {
     expect(loc.pathname).to.match(/^\/queues\/new\/moves\/[^/]+\/ppm/);
   });
 
+  cy.get('.combo-button').click();
+
   // Approve PPM
   cy
-    .get('button')
+    .get('.combo-button .dropdown')
     .contains('Approve PPM')
     .click();
+
+  cy.get('.combo-button').click();
 }
 
 function officeUserVerifiesPPM() {

--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -459,42 +459,7 @@ class MoveInfo extends Component {
                   )}
                 </ToolTip>
               </div>
-              <button
-                className={`${moveApproved ? 'btn__approve--green' : ''}`}
-                onClick={this.approveBasics}
-                disabled={moveApproved || !ordersComplete}
-              >
-                Approve Basics
-                {moveApproved && check}
-              </button>
 
-              {(isPPM || isHHGPPM) && (
-                <button
-                  className={`${ppmApproved ? 'btn__approve--green' : ''}`}
-                  onClick={this.approvePPM}
-                  disabled={ppmApproved || !moveApproved || !ordersComplete}
-                >
-                  Approve PPM
-                  {ppmApproved && check}
-                </button>
-              )}
-              {(isHHG || isHHGPPM) && (
-                <button
-                  className={`${hhgApproved ? 'btn__approve--green' : ''}`}
-                  onClick={this.approveShipment}
-                  disabled={
-                    !hhgAccepted ||
-                    hhgApproved ||
-                    hhgCompleted ||
-                    !moveApproved ||
-                    !ordersComplete ||
-                    currentTab !== 'hhg'
-                  }
-                >
-                  Approve HHG
-                  {hhgApproved && check}
-                </button>
-              )}
               {(isHHG || isHHGPPM) && (
                 <button
                   className={`${hhgCompleted ? 'btn__approve--green' : ''}`}

--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -458,6 +458,13 @@ class MoveInfo extends Component {
                     </ComboButton>
                   )}
                 </ToolTip>
+                <ConfirmWithReasonButton
+                  buttonTitle="Cancel Move"
+                  reasonPrompt="Why is the move being canceled?"
+                  warningPrompt="Are you sure you want to cancel the entire move?"
+                  onConfirm={this.cancelMoveAndRedirect}
+                  buttonDisabled={hhgCantBeCanceled}
+                />
               </div>
 
               {(isHHG || isHHGPPM) && (
@@ -470,13 +477,7 @@ class MoveInfo extends Component {
                   {hhgCompleted && check}
                 </button>
               )}
-              <ConfirmWithReasonButton
-                buttonTitle="Cancel Move"
-                reasonPrompt="Why is the move being canceled?"
-                warningPrompt="Are you sure you want to cancel the entire move?"
-                onConfirm={this.cancelMoveAndRedirect}
-                buttonDisabled={hhgCantBeCanceled}
-              />
+
               {/* Disabling until features implemented
               <button>Troubleshoot</button>
               */}

--- a/src/shared/featureFlags.js
+++ b/src/shared/featureFlags.js
@@ -27,12 +27,10 @@ const environmentFlags = {
 
   staging: Object.assign({}, defaultFlags, {
     robustAccessorial: false,
-    moveInfoComboButton: false,
   }),
 
   production: Object.assign({}, defaultFlags, {
     allowHhgInvoicePayment: false,
-    moveInfoComboButton: false,
     robustAccessorial: false,
     sitPanel: false,
   }),


### PR DESCRIPTION
## Description

Update e2e tests to use combo button instead of individual approval buttons

## Reviewer Notes
- Also moved the `Cancel Move` button placement to be next to approval button

## Setup
`make office_client_run`
`make server_run`
Approve PPM and Approve HHG buttons should no longer exist 

## Code Review Verification Steps
* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/164737353) for this change

## Screenshots

![image](https://user-images.githubusercontent.com/13622298/55353058-43645100-5477-11e9-881f-9e175f24f857.png)
