### PR TITLE
Create a dedicated DB for testing prod-migrations

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -69,8 +69,12 @@ export DB_PASSWORD=mysecretpassword
 export DB_USER=postgres
 export DB_HOST=localhost
 export DB_PORT=5432
+export DB_PORT_PROD_MIGRATIONS=5434
 export DB_PORT_TEST=5433
 export DB_NAME=dev_db
+export DB_NAME_DEV=dev_db
+export DB_NAME_PROD_MIGRATIONS=prod_migrations
+export DB_NAME_TEST=test_db
 export DB_SSL_MODE=disable
 
 # Login.gov configuration

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 NAME = ppp
 DB_NAME_DEV = dev_db
+DB_NAME_PROD_MIGRATIONS = prod_migrations
 DB_NAME_TEST = test_db
 DB_DOCKER_CONTAINER_DEV = milmove-db-dev
 DB_DOCKER_CONTAINER_TEST = milmove-db-test
@@ -25,6 +26,7 @@ endif
 # Convenience for LDFLAGS
 WEBSERVER_LDFLAGS=-X main.gitBranch=$(shell git branch | grep \* | cut -d ' ' -f2) -X main.gitCommit=$(shell git rev-list -1 HEAD)
 DB_PORT_DEV=5432
+DB_PORT_PROD_MIGRATIONS=5434
 DB_PORT_DOCKER=5432
 ifdef CIRCLECI
 	DB_PORT_TEST=5432
@@ -376,6 +378,61 @@ db_dev_migrate: server_deps db_dev_migrate_standalone
 
 #
 # ----- END DB_DEV TARGETS -----
+#
+
+#
+# ----- START DB_PROD_MIGRATIONS TARGETS -----
+#
+
+.PHONY: db_prod_migrations_destroy
+db_prod_migrations_destroy:
+ifndef CIRCLECI
+	@echo "Destroying the ${DB_DOCKER_CONTAINER_DEV} docker database container..."
+	docker rm -f $(DB_DOCKER_CONTAINER_DEV) || \
+		echo "No database container"
+else
+	@echo "Relying on CircleCI's database setup to destroy the DB."
+endif
+
+.PHONY: db_prod_migrations_start
+db_prod_migrations_start:
+ifndef CIRCLECI
+	brew services stop postgresql 2> /dev/null || true
+endif
+	@echo "Starting the ${DB_DOCKER_CONTAINER_DEV} docker database container..."
+	# If running do nothing, if not running try to start, if can't start then run
+	docker start $(DB_DOCKER_CONTAINER_DEV) || \
+		docker run --name $(DB_DOCKER_CONTAINER_DEV) \
+			-e \
+			POSTGRES_PASSWORD=$(PGPASSWORD) \
+			-d \
+			-p $(DB_PORT_PROD_MIGRATIONS):$(DB_PORT_DOCKER)\
+			$(DB_DOCKER_CONTAINER_IMAGE)
+
+.PHONY: db_prod_migrations_create
+db_prod_migrations_create:
+	@echo "Create the ${DB_NAME_PROD_MIGRATIONS} database..."
+	DB_NAME=postgres DB_PORT=$(DB_PORT_PROD_MIGRATIONS) scripts/wait-for-db && \
+		createdb -p $(DB_PORT_PROD_MIGRATIONS) -h localhost -U postgres $(DB_NAME_PROD_MIGRATIONS) || true
+
+.PHONY: db_prod_migrations_run
+db_prod_migrations_run: db_prod_migrations_start db_prod_migrations_create
+
+.PHONY: db_prod_migrations_reset
+db_prod_migrations_reset: db_prod_migrations_destroy db_prod_migrations_run
+
+.PHONY: db_prod_migrations_migrate_standalone
+db_prod_migrations_migrate_standalone:
+	@echo "Migrating the ${DB_NAME_PROD_MIGRATIONS} database..."
+	# We need to move to the scripts/ directory so that the cwd contains `apply-secure-migration.sh`
+	cd scripts && \
+		../bin/soda -c ../config/database.yml -p ../migrations migrate up
+
+.PHONY: db_prod_migrations_migrate
+db_prod_migrations_migrate: server_deps db_prod_migrations_migrate_standalone
+
+#
+# ----- END DB_PROD_MIGRATIONS TARGETS -----
 #
 
 #

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ DB_NAME_DEV = dev_db
 DB_NAME_PROD_MIGRATIONS = prod_migrations
 DB_NAME_TEST = test_db
 DB_DOCKER_CONTAINER_DEV = milmove-db-dev
+DB_DOCKER_CONTAINER_PROD_MIGRATIONS = milmove-db-prod-migrations
 DB_DOCKER_CONTAINER_TEST = milmove-db-test
 # The version of the postgres container should match production as closely
 # as possible.
@@ -387,8 +388,8 @@ db_dev_migrate: server_deps db_dev_migrate_standalone
 .PHONY: db_prod_migrations_destroy
 db_prod_migrations_destroy:
 ifndef CIRCLECI
-	@echo "Destroying the ${DB_DOCKER_CONTAINER_DEV} docker database container..."
-	docker rm -f $(DB_DOCKER_CONTAINER_DEV) || \
+	@echo "Destroying the ${DB_DOCKER_CONTAINER_PROD_MIGRATIONS} docker database container..."
+	docker rm -f $(DB_DOCKER_CONTAINER_PROD_MIGRATIONS) || \
 		echo "No database container"
 else
 	@echo "Relying on CircleCI's database setup to destroy the DB."
@@ -399,10 +400,10 @@ db_prod_migrations_start:
 ifndef CIRCLECI
 	brew services stop postgresql 2> /dev/null || true
 endif
-	@echo "Starting the ${DB_DOCKER_CONTAINER_DEV} docker database container..."
+	@echo "Starting the ${DB_DOCKER_CONTAINER_PROD_MIGRATIONS} docker database container..."
 	# If running do nothing, if not running try to start, if can't start then run
-	docker start $(DB_DOCKER_CONTAINER_DEV) || \
-		docker run --name $(DB_DOCKER_CONTAINER_DEV) \
+	docker start $(DB_DOCKER_CONTAINER_PROD_MIGRATIONS) || \
+		docker run --name $(DB_DOCKER_CONTAINER_PROD_MIGRATIONS) \
 			-e \
 			POSTGRES_PASSWORD=$(PGPASSWORD) \
 			-d \

--- a/docs/how-to/migrate-the-database.md
+++ b/docs/how-to/migrate-the-database.md
@@ -44,7 +44,7 @@ We are piggy-backing on the migration system for importing static datasets. This
 3. Copy the production migration into the local test migration.
 4. Scrub the test migration of sensitive data, but use it to test the gist of the production migration operation.
 5. Test the local migration by running `make db_dev_migrate`. You should see it run your local migration.
-6. Test the secure migration by running `scripts/run-prod-migrations` to setup a local  prod_migrations` database. Then run `env DB_NAME=prod_migrations scripts/psql-wrapper < tmp/$NAME_OF_YOUR_SECURE_MIGRATION`. Verify that the updated values are in the database.
+6. Test the secure migration by running `scripts/run-prod-migrations` to setup a local  prod_migrations` database. Then run `psql-prod-migrations< tmp/$NAME_OF_YOUR_SECURE_MIGRATION`. Verify that the updated values are in the database.
 7. If you are wanting to run a secure migration for a specific non-production environment, then **skip to the next section**.
 8. Upload the migration to S3 with: `scripts/upload-secure-migration <production_migration_file>`.
 9. Run `scripts/run-prod-migrations` to verify that the upload worked and that the migration can be applied successfully. If not, you can make changes and run `scripts/upload-secure-migration` again and it will overwrite the old files.
@@ -72,7 +72,7 @@ When secure migrations are run, `soda` will shell out to our script, `apply-secu
 * Look at `$SECURE_MIGRATION_SOURCE` to determine if the migrations should be found locally (`local`, for dev & testing,) or on S3 (`s3`).
 * If the file is to be found on S3, it is downloaded from `${AWS_S3_BUCKET_NAME}/secure-migrations/${FILENAME}`.
 * If it is to be found locally, the script looks for it in `$SECURE_MIGRATION_DIR`.
-* Regardless of where the migration comes from, it is then applied to the database by essentially doing: `scritps/psql-wrapper < ${FILENAME}`.
+* Regardless of where the migration comes from, it is then applied to the database by essentially doing: `psql-prod-migrations < ${FILENAME}`.
 
 There is an example of a secure migration [in the repo](https://github.com/transcom/mymove/blob/master/migrations/20180424010930_test_secure_migrations.up.fizz).
 

--- a/scripts/apply-secure-migration.sh
+++ b/scripts/apply-secure-migration.sh
@@ -2,7 +2,9 @@
 # Executes an SQL file from S3 against the environment's database.
 #
 # If `SECURE_MIGRATION_SOURCE=local` then we look for a similarly named file in the
-# local repository, instead of pulling from S3.
+# local repository.
+# If `SECURE_MIGRATION_SOURCE=s3` then we look for a similarly named file in the
+# S3 bucket and pull it down.
 
 if [ -z "${SECURE_MIGRATION_SOURCE:-}" ]; then
   echo "error: \$SECURE_MIGRATION_SOURCE needs to be set"

--- a/scripts/psql-prod-migrations
+++ b/scripts/psql-prod-migrations
@@ -1,5 +1,6 @@
 #! /usr/bin/env bash
 
 export DB_NAME=prod_migrations
+export DB_PORT=$DB_PORT_PROD_MIGRATIONS
 # shellcheck disable=SC1091,SC1090
 . "$(dirname "$0")"/psql-wrapper

--- a/scripts/run-prod-migrations
+++ b/scripts/run-prod-migrations
@@ -10,8 +10,8 @@ set -eu -o pipefail
 export SECURE_MIGRATION_SOURCE=s3
 export AWS_S3_BUCKET_NAME=transcom-ppp-app-prod-us-west-2
 export PSQL_SSL_MODE=disable
-export DB_NAME="${PROD_MIGRATION_DB_NAME:-prod_migrations}"
-export DB_PORT="${PROD_MIGRATION_DB_PORT:-5434}"
+export DB_NAME="${DB_NAME_PROD_MIGRATIONS:-prod_migrations}"
+export DB_PORT="${DB_PORT_PROD_MIGRATIONS:-5434}"
 
 function proceed() {
   proceed_message=${1:-"proceed"}

--- a/scripts/run-prod-migrations
+++ b/scripts/run-prod-migrations
@@ -1,12 +1,11 @@
 #! /usr/bin/env bash
 #
 # A script to apply all migrations, including secure migrations, to a local database.
-# https://github.com/transcom/mymove#secure-migrations
-#
-# You can override the database to use by setting DB_NAME outside the script.
+# https://github.com/transcom/mymove/blob/master/docs/how-to/migrate-the-database.md#secure-migrations
 
 set -eu -o pipefail
 
+# Required env vars for apply-secure-migration.sh
 export SECURE_MIGRATION_SOURCE=s3
 export AWS_S3_BUCKET_NAME=transcom-ppp-app-prod-us-west-2
 export PSQL_SSL_MODE=disable
@@ -50,7 +49,7 @@ aws s3 ls "${AWS_S3_BUCKET_NAME}/secure-migrations" > /dev/null
 proceed "Running production migrations against the ${DB_NAME} database. This will delete everything in that db."
 
 export PGPASSWORD=${DB_PASSWORD}
-DB_NAME=postgres DB_PORT="${DB_PORT}" ./scripts/wait-for-db || make db_prod_migrations_reset
+make db_prod_migrations_reset
 run make db_prod_migrations_migrate || (
   echo "error: migrations failed!"
   exit 1

--- a/scripts/run-prod-migrations
+++ b/scripts/run-prod-migrations
@@ -11,6 +11,7 @@ export SECURE_MIGRATION_SOURCE=s3
 export AWS_S3_BUCKET_NAME=transcom-ppp-app-prod-us-west-2
 export PSQL_SSL_MODE=disable
 export DB_NAME="${PROD_MIGRATION_DB_NAME:-prod_migrations}"
+export DB_PORT="${PROD_MIGRATION_DB_PORT:-5434}"
 
 function proceed() {
   proceed_message=${1:-"proceed"}
@@ -49,10 +50,8 @@ aws s3 ls "${AWS_S3_BUCKET_NAME}/secure-migrations" > /dev/null
 proceed "Running production migrations against the ${DB_NAME} database. This will delete everything in that db."
 
 export PGPASSWORD=${DB_PASSWORD}
-DB_NAME=postgres ./scripts/wait-for-db || make db_dev_run
-dropdb -h localhost -U postgres -w --if-exists "${DB_NAME}"
-createdb -h localhost -U postgres -w "${DB_NAME}"
-run make db_dev_migrate || (
+DB_NAME=postgres DB_PORT="${DB_PORT}" ./scripts/wait-for-db || make db_prod_migrations_reset
+run make db_prod_migrations_migrate || (
   echo "error: migrations failed!"
   exit 1
   )


### PR DESCRIPTION
## Description

Adding the role `ecs_user` to the DB via a migration broke the ability to run multiple migrations against the same postgres container. This change creates a dedicated container for testing prod-migrations. This should give us even more confidence that the migrations are not being affected by the dev-db migrations.

The new DB runs in a container on port 5434.  Everyone will need to update their SQL Editor to use that port if they want to connect.

With this abstraction we should be able to make `run-prod-migrations` a step in the CircleCI workflow, meaning we wouldn't have to rely on manual testing to ensure things pass.

## Setup

```sh
direnv allow
run-prod-migrations
```

## Code Review Verification Steps

* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/164936406) for this change