### PR TITLE
Add back code that was lost during merge and only show edit when sit …

### DIFF
--- a/src/shared/StorageInTransit/StorageInTransit.jsx
+++ b/src/shared/StorageInTransit/StorageInTransit.jsx
@@ -5,7 +5,6 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 
 import FontAwesomeIcon from '@fortawesome/react-fontawesome';
-import faClock from '@fortawesome/fontawesome-free-solid/faClock';
 import faPencil from '@fortawesome/fontawesome-free-solid/faPencilAlt';
 
 import './StorageInTransit.css';
@@ -14,6 +13,7 @@ import Editor from 'shared/StorageInTransit/Editor';
 import ApproveSitRequest from 'shared/StorageInTransit/ApproveSitRequest';
 import { updateStorageInTransit } from 'shared/Entities/modules/storageInTransits';
 import { isTspSite } from 'shared/constants.js';
+import SitStatusIcon from './SitStatusIcon';
 
 export class StorageInTransit extends Component {
   constructor() {
@@ -50,7 +50,7 @@ export class StorageInTransit extends Component {
           <span className="unbold">
             {' '}
             <span className="sit-status-text">Status:</span>{' '}
-            <FontAwesomeIcon className="icon icon-grey" icon={faClock} />
+            {storageInTransit.status === 'REQUESTED' && <SitStatusIcon isTspSite={isTspSite} />}
           </span>
           <span>SIT {storageInTransit.status.charAt(0) + storageInTransit.status.slice(1).toLowerCase()} </span>
           {!isTspSite && <ApproveSitRequest />}
@@ -63,7 +63,7 @@ export class StorageInTransit extends Component {
           ) : (
             <span className="sit-actions">
               <span className="sit-edit actionable">
-                {storageInTransit.status !== 'APPROVED' && (
+                {storageInTransit.status === 'APPROVED' && (
                   <a onClick={this.openEditForm}>
                     <FontAwesomeIcon className="icon" icon={faPencil} />
                     Edit


### PR DESCRIPTION
…has been approved

## Description
A call to the `SitStatusIcon` component was lost during a merge. Added it back so the clock in the SIT panel is orange in office and gray in TSP. Also, only shows the `edit` link when SIT has been approved.

FYI - that the `Deny` link is added in another PR (https://github.com/transcom/mymove/pull/1924)

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make db_dev_e2e_populate
make server_run
make client_run
```
In the TSP app, select an HHG record and request a SIT. Next, go to the Office app and select the same record for which you added the SIT request. You will see the SIT panel, and an `Approve` link that opens up the form. Will not see the `Edit` link.