### PR TITLE
Trust both DOD and commercial certs when connecting to DMDC

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -789,9 +789,9 @@ workflows:
             - pre_deps_yarn
             - acceptance_tests_local
           # if testing on experimental, you can disable these tests by using the commented block below.
-          filters:
-            branches:
-              ignore: iws-commercial-cert
+          # filters:
+          #  branches:
+          #    ignore: placeholder_branch_name
 
       - integration_tests_office:
           requires:
@@ -799,9 +799,9 @@ workflows:
             - pre_deps_yarn
             - acceptance_tests_local
           # if testing on experimental, you can disable these tests by using the commented block below.
-          filters:
-            branches:
-              ignore: iws-commercial-cert
+          # filters:
+          #   branches:
+          #     ignore: placeholder_branch_name
 
       - integration_tests_tsp:
           requires:
@@ -809,9 +809,9 @@ workflows:
             - pre_deps_yarn
             - acceptance_tests_local
           # if testing on experimental, you can disable these tests by using the commented block below.
-          filters:
-            branches:
-              ignore: iws-commercial-cert
+          # filters:
+          #   branches:
+          #     ignore: placeholder_branch_name
 
       - integration_tests_api:
           requires:
@@ -819,9 +819,9 @@ workflows:
             - pre_deps_yarn
             - acceptance_tests_local
           # if testing on experimental, you can disable these tests by using the commented block below.
-          filters:
-            branches:
-              ignore: iws-commercial-cert
+          # filters:
+          #   branches:
+          #     ignore: placeholder_branch_name
 
       - client_test:
           requires:
@@ -861,21 +861,21 @@ workflows:
             - build_migrations
           filters:
             branches:
-              only: iws-commercial-cert
+              only: placeholder_branch_name
 
       - deploy_experimental_app:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: iws-commercial-cert
+              only: placeholder_branch_name
 
       - deploy_experimental_app_client_tls:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: iws-commercial-cert
+              only: placeholder_branch_name
 
       - check_circle_against_staging_sha:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -789,9 +789,9 @@ workflows:
             - pre_deps_yarn
             - acceptance_tests_local
           # if testing on experimental, you can disable these tests by using the commented block below.
-          # filters:
-          #  branches:
-          #    ignore: placeholder_branch_name
+          filters:
+            branches:
+              ignore: iws-commercial-cert
 
       - integration_tests_office:
           requires:
@@ -799,9 +799,9 @@ workflows:
             - pre_deps_yarn
             - acceptance_tests_local
           # if testing on experimental, you can disable these tests by using the commented block below.
-          # filters:
-          #   branches:
-          #     ignore: placeholder_branch_name
+          filters:
+            branches:
+              ignore: iws-commercial-cert
 
       - integration_tests_tsp:
           requires:
@@ -809,9 +809,9 @@ workflows:
             - pre_deps_yarn
             - acceptance_tests_local
           # if testing on experimental, you can disable these tests by using the commented block below.
-          # filters:
-          #   branches:
-          #     ignore: placeholder_branch_name
+          filters:
+            branches:
+              ignore: iws-commercial-cert
 
       - integration_tests_api:
           requires:
@@ -819,9 +819,9 @@ workflows:
             - pre_deps_yarn
             - acceptance_tests_local
           # if testing on experimental, you can disable these tests by using the commented block below.
-          # filters:
-          #   branches:
-          #     ignore: placeholder_branch_name
+          filters:
+            branches:
+              ignore: iws-commercial-cert
 
       - client_test:
           requires:
@@ -861,21 +861,21 @@ workflows:
             - build_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: iws-commercial-cert
 
       - deploy_experimental_app:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: iws-commercial-cert
 
       - deploy_experimental_app_client_tls:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: iws-commercial-cert
 
       - check_circle_against_staging_sha:
           requires:

--- a/pkg/iws/rbs_person_lookup.go
+++ b/pkg/iws/rbs_person_lookup.go
@@ -106,6 +106,9 @@ func NewRBSPersonLookup(host string, dodCACertPackage string, certString string,
 	}
 	// Add the DOD certs to a copy of the system cert pool
 	caCertPool, err := x509.SystemCertPool()
+	if err != nil {
+		return nil, err
+	}
 	for _, cert := range p7.Certificates {
 		caCertPool.AddCert(cert)
 	}

--- a/pkg/iws/rbs_person_lookup.go
+++ b/pkg/iws/rbs_person_lookup.go
@@ -2,6 +2,7 @@ package iws
 
 import (
 	"crypto/tls"
+	"crypto/x509"
 	"encoding/xml"
 	"errors"
 	"fmt"
@@ -11,7 +12,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/transcom/mymove/pkg/server"
+	"go.mozilla.org/pkcs7"
 )
 
 // RBSPersonLookup handles requests to the Real-Time Broker Service
@@ -92,14 +93,21 @@ func NewRBSPersonLookup(host string, dodCACertPackage string, certString string,
 		return nil, err
 	}
 
-	// Load CA certs
-	pkcs7Package, err := ioutil.ReadFile(filepath.Clean(dodCACertPackage)) // to placate GOSEC
+	// DMDC has switched from a DOD-signed cert to a commercially-signed cert.
+	// Seems prudent to trust both DOD and commercial certs when connecting to
+	// them from now on, just in case they change back.
+	pkcs7Package, err := ioutil.ReadFile(filepath.Clean(dodCACertPackage)) // filepath.Clean placates GOSEC
 	if err != nil {
 		return nil, err
 	}
-	caCertPool, err := server.LoadCertPoolFromPkcs7Package(pkcs7Package)
+	p7, err := pkcs7.Parse(pkcs7Package)
 	if err != nil {
 		return nil, err
+	}
+	// Add the DOD certs to a copy of the system cert pool
+	caCertPool, err := x509.SystemCertPool()
+	for _, cert := range p7.Certificates {
+		caCertPool.AddCert(cert)
 	}
 
 	// Setup HTTPS client


### PR DESCRIPTION
DMDC's Identity Web Services recently changed from presenting a certificate signed by DISA to a certificate signed by Entrust. As a result, SSN<->EDIPI conversions required by both the Orders Gateway and by the DPS-to-login.gov bridge stopped working. The error `Get https://pkict.dmdc.osd.mil/appj/rbs/rest/{more URL components}: x509: certificate signed by unknown authority` appears in the logs.

So, instead of trusting only DOD-signed certs when connecting to DMDC, or trusting only commercial certs, trust _both_. That way, if DMDC changes its mind about using a commercial cert, especially when the current cert expires in March of 2020, our code will continue to work.