### PR TITLE
Improve error handling around CalculateRemainingPPMEntitlement.

### DIFF
--- a/pkg/handlers/internalapi/moves.go
+++ b/pkg/handlers/internalapi/moves.go
@@ -244,10 +244,16 @@ func (h ShowShipmentSummaryWorksheetHandler) Handle(params moveop.ShowShipmentSu
 	ppmComputer := paperwork.NewSSWPPMComputer(rateengine.NewRateEngine(h.DB(), h.Logger()))
 
 	ssfd, err := models.FetchDataShipmentSummaryWorksheetFormData(h.DB(), session, moveID)
+	if err != nil {
+		h.Logger().Error("Error fetching data for SSW", zap.Error(err))
+		return handlers.ResponseForError(h.Logger(), err)
+	}
+
 	ssfd.PreparationDate = time.Time(params.PreparationDate)
 	ssfd.Obligations, err = ppmComputer.ComputeObligations(ssfd, h.Planner())
 	if err != nil {
 		h.Logger().Error("Error calculating obligations ", zap.Error(err))
+		return handlers.ResponseForError(h.Logger(), err)
 	}
 
 	page1Data, page2Data, err := models.FormatValuesShipmentSummaryWorksheet(ssfd)

--- a/pkg/handlers/internalapi/moves_test.go
+++ b/pkg/handlers/internalapi/moves_test.go
@@ -394,9 +394,76 @@ func (suite *HandlerSuite) TestShowMoveDatesSummaryForbiddenUser() {
 }
 
 func (suite *HandlerSuite) TestShowShipmentSummaryWorksheet() {
+	testdatagen.MakeTariff400ngItemRate(suite.DB(), testdatagen.Assertions{
+		Tariff400ngItemRate: models.Tariff400ngItemRate{
+			Code:     "210A",
+			Schedule: models.IntPointer(1),
+		},
+	})
+	testdatagen.MakeTariff400ngItemRate(suite.DB(), testdatagen.Assertions{
+		Tariff400ngItemRate: models.Tariff400ngItemRate{
+			Code:     "225A",
+			Schedule: models.IntPointer(1),
+		},
+	})
+	testdatagen.MakeDefaultTariff400ngItem(suite.DB())
+	testdatagen.MakeTariff400ngServiceArea(suite.DB(), testdatagen.Assertions{
+		Tariff400ngServiceArea: models.Tariff400ngServiceArea{
+			ServiceArea: "296",
+		},
+	})
+	testdatagen.MakeTariff400ngServiceArea(suite.DB(), testdatagen.Assertions{
+		Tariff400ngServiceArea: models.Tariff400ngServiceArea{
+			ServiceArea: "208",
+		},
+	})
+	lhr := models.Tariff400ngLinehaulRate{
+		DistanceMilesLower: 1,
+		DistanceMilesUpper: 10000,
+		WeightLbsLower:     1,
+		WeightLbsUpper:     10000,
+		RateCents:          20000,
+		Type:               "ConusLinehaul",
+		EffectiveDateLower: testdatagen.PeakRateCycleStart,
+		EffectiveDateUpper: testdatagen.PeakRateCycleEnd,
+	}
+	suite.MustSave(&lhr)
+	fpr := models.Tariff400ngFullPackRate{
+		Schedule:           1,
+		WeightLbsLower:     1,
+		WeightLbsUpper:     10000,
+		EffectiveDateLower: testdatagen.PeakRateCycleStart,
+		EffectiveDateUpper: testdatagen.PeakRateCycleEnd,
+	}
+	suite.MustSave(&fpr)
+	fupr := models.Tariff400ngFullUnpackRate{
+		Schedule:           1,
+		EffectiveDateLower: testdatagen.PeakRateCycleStart,
+		EffectiveDateUpper: testdatagen.PeakRateCycleEnd,
+	}
+	suite.MustSave(&fupr)
+	tdl := testdatagen.MakeTDL(suite.DB(), testdatagen.Assertions{
+		TrafficDistributionList: models.TrafficDistributionList{
+			SourceRateArea:    "US53",
+			DestinationRegion: "12",
+		},
+	})
+	testdatagen.MakeTSPPerformance(suite.DB(),
+		testdatagen.Assertions{
+			TransportationServiceProviderPerformance: models.TransportationServiceProviderPerformance{
+				TrafficDistributionListID: tdl.ID,
+			},
+		})
+
 	move := testdatagen.MakeDefaultMove(suite.DB())
 	testdatagen.MakePPM(suite.DB(), testdatagen.Assertions{
-		PersonallyProcuredMove: models.PersonallyProcuredMove{},
+		PersonallyProcuredMove: models.PersonallyProcuredMove{
+			MoveID:                move.ID,
+			ActualMoveDate:        &testdatagen.DateInsidePerformancePeriod,
+			NetWeight:             models.Int64Pointer(1000),
+			PickupPostalCode:      models.StringPointer("50303"),
+			DestinationPostalCode: models.StringPointer("30814"),
+		},
 	})
 
 	req := httptest.NewRequest("GET", "/moves/some_id/shipment_summary_worksheet", nil)

--- a/pkg/models/shipment_summary_worksheet.go
+++ b/pkg/models/shipment_summary_worksheet.go
@@ -209,7 +209,10 @@ func FetchDataShipmentSummaryWorksheetFormData(db *pop.Connection, session *auth
 		return ShipmentSummaryFormData{}, err
 	}
 
-	ppmRemainingEntitlement := CalculateRemainingPPMEntitlement(move, totalEntitlement)
+	ppmRemainingEntitlement, err := CalculateRemainingPPMEntitlement(move, totalEntitlement)
+	if err != nil {
+		return ShipmentSummaryFormData{}, err
+	}
 
 	ssd := ShipmentSummaryFormData{
 		ServiceMember:           serviceMember,
@@ -228,22 +231,30 @@ func FetchDataShipmentSummaryWorksheetFormData(db *pop.Connection, session *auth
 
 // CalculateRemainingPPMEntitlement calculates the remaining PPM entitlement for PPM moves
 // a PPMs remaining entitlement weight is equal to total entitlement - hhg weight
-func CalculateRemainingPPMEntitlement(move Move, totalEntitlement unit.Pound) unit.Pound {
+func CalculateRemainingPPMEntitlement(move Move, totalEntitlement unit.Pound) (unit.Pound, error) {
 	var hhgActualWeight unit.Pound
-	if len(move.Shipments) > 0 && move.Shipments[0].NetWeight != nil {
+	if len(move.Shipments) > 0 {
+		if move.Shipments[0].NetWeight == nil {
+			return hhgActualWeight, errors.Errorf("Shipment %s does not have NetWeight", move.Shipments[0].ID)
+		}
 		hhgActualWeight = *move.Shipments[0].NetWeight
 	}
+
 	var ppmActualWeight unit.Pound
 	if len(move.PersonallyProcuredMoves) > 0 {
+		if move.PersonallyProcuredMoves[0].NetWeight == nil {
+			return ppmActualWeight, errors.Errorf("PPM %s does not have NetWeight", move.PersonallyProcuredMoves[0].ID)
+		}
 		ppmActualWeight = unit.Pound(*move.PersonallyProcuredMoves[0].NetWeight)
 	}
+
 	switch ppmRemainingEntitlement := totalEntitlement - hhgActualWeight; {
 	case ppmActualWeight < ppmRemainingEntitlement:
-		return ppmActualWeight
+		return ppmActualWeight, nil
 	case ppmRemainingEntitlement < 0:
-		return 0
+		return 0, nil
 	default:
-		return ppmRemainingEntitlement
+		return ppmRemainingEntitlement, nil
 	}
 }
 

--- a/pkg/models/shipment_summary_worksheet_test.go
+++ b/pkg/models/shipment_summary_worksheet_test.go
@@ -535,7 +535,8 @@ func (suite *ModelSuite) TestCalculatePPMEntitlementNoHHGPPMLessThanMaxEntitleme
 		PersonallyProcuredMoves: models.PersonallyProcuredMoves{models.PersonallyProcuredMove{NetWeight: &ppmWeight}},
 	}
 
-	ppmRemainingEntitlement := models.CalculateRemainingPPMEntitlement(move, totalEntitlement)
+	ppmRemainingEntitlement, err := models.CalculateRemainingPPMEntitlement(move, totalEntitlement)
+	suite.Nil(err)
 
 	suite.Equal(unit.Pound(ppmWeight), ppmRemainingEntitlement)
 }
@@ -547,7 +548,8 @@ func (suite *ModelSuite) TestCalculatePPMEntitlementNoHHGPPMGreaterThanMaxEntitl
 		PersonallyProcuredMoves: models.PersonallyProcuredMoves{models.PersonallyProcuredMove{NetWeight: &ppmWeight}},
 	}
 
-	ppmRemainingEntitlement := models.CalculateRemainingPPMEntitlement(move, totalEntitlement)
+	ppmRemainingEntitlement, err := models.CalculateRemainingPPMEntitlement(move, totalEntitlement)
+	suite.Nil(err)
 
 	suite.Equal(totalEntitlement, ppmRemainingEntitlement)
 }
@@ -561,7 +563,8 @@ func (suite *ModelSuite) TestCalculatePPMEntitlementPPMGreaterThanRemainingEntit
 		Shipments:               models.Shipments{models.Shipment{NetWeight: &hhg}},
 	}
 
-	ppmRemainingEntitlement := models.CalculateRemainingPPMEntitlement(move, totalEntitlement)
+	ppmRemainingEntitlement, err := models.CalculateRemainingPPMEntitlement(move, totalEntitlement)
+	suite.Nil(err)
 
 	suite.Equal(totalEntitlement-hhg, ppmRemainingEntitlement)
 }
@@ -575,7 +578,8 @@ func (suite *ModelSuite) TestCalculatePPMEntitlementPPMLessThanRemainingEntitlem
 		Shipments:               models.Shipments{models.Shipment{NetWeight: &hhg}},
 	}
 
-	ppmRemainingEntitlement := models.CalculateRemainingPPMEntitlement(move, totalEntitlement)
+	ppmRemainingEntitlement, err := models.CalculateRemainingPPMEntitlement(move, totalEntitlement)
+	suite.Nil(err)
 
 	suite.Equal(unit.Pound(ppmWeight), ppmRemainingEntitlement)
 }

--- a/pkg/models/shipment_summary_worksheet_test.go
+++ b/pkg/models/shipment_summary_worksheet_test.go
@@ -69,10 +69,12 @@ func (suite *ModelSuite) TestFetchDataShipmentSummaryWorksheet() {
 	}
 	testdatagen.MakeMovingExpenseDocument(suite.DB(), movedocuments)
 	testdatagen.MakeMovingExpenseDocument(suite.DB(), movedocuments)
+	shipmentWeight := unit.Pound(1000)
 	shipment := testdatagen.MakeShipment(suite.DB(), testdatagen.Assertions{
 		Shipment: models.Shipment{
 			ServiceMemberID: serviceMemberID,
 			MoveID:          move.ID,
+			NetWeight:       &shipmentWeight,
 		},
 	})
 	session := auth.Session{


### PR DESCRIPTION
## Description

@mkrump and I looked into the 502s we're seeing, which stem from missing some data on the PPM models. This PR adds better error handling to that code to prevent `panic`s.

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/164910942) for this change