### PR TITLE
Assigns session data based on app name [delivers #163469960]

### DIFF
--- a/pkg/auth/authentication/auth.go
+++ b/pkg/auth/authentication/auth.go
@@ -271,53 +271,57 @@ func authorizeKnownUser(userIdentity *models.UserIdentity, h CallbackHandler, se
 		session.DpsUserID = *(userIdentity.DpsUserID)
 	}
 
-	if userIdentity.OfficeUserID != nil {
-		session.OfficeUserID = *(userIdentity.OfficeUserID)
-	} else if session.IsOfficeApp() {
-		// In case they managed to login before the office_user record was created
-		officeUser, err := models.FetchOfficeUserByEmail(h.db, session.Email)
-		if err == models.ErrFetchNotFound {
-			h.logger.Error("Non-office user authenticated at office site", zap.String("email", session.Email))
-			http.Error(w, http.StatusText(401), http.StatusUnauthorized)
-			return
-		} else if err != nil {
-			h.logger.Error("Checking for office user", zap.String("email", session.Email), zap.Error(err))
-			http.Error(w, http.StatusText(500), http.StatusInternalServerError)
-			return
-		}
-		session.OfficeUserID = officeUser.ID
-		span.AddField("session.office_user_id", session.OfficeUserID)
-		officeUser.UserID = &userIdentity.ID
-		err = h.db.Save(officeUser)
-		if err != nil {
-			h.logger.Error("Updating office user", zap.String("email", session.Email), zap.Error(err))
-			http.Error(w, http.StatusText(500), http.StatusInternalServerError)
-			return
+	if session.IsOfficeApp() {
+		if userIdentity.OfficeUserID != nil {
+			session.OfficeUserID = *(userIdentity.OfficeUserID)
+		} else {
+			// In case they managed to login before the office_user record was created
+			officeUser, err := models.FetchOfficeUserByEmail(h.db, session.Email)
+			if err == models.ErrFetchNotFound {
+				h.logger.Error("Non-office user authenticated at office site", zap.String("email", session.Email))
+				http.Error(w, http.StatusText(401), http.StatusUnauthorized)
+				return
+			} else if err != nil {
+				h.logger.Error("Checking for office user", zap.String("email", session.Email), zap.Error(err))
+				http.Error(w, http.StatusText(500), http.StatusInternalServerError)
+				return
+			}
+			session.OfficeUserID = officeUser.ID
+			span.AddField("session.office_user_id", session.OfficeUserID)
+			officeUser.UserID = &userIdentity.ID
+			err = h.db.Save(officeUser)
+			if err != nil {
+				h.logger.Error("Updating office user", zap.String("email", session.Email), zap.Error(err))
+				http.Error(w, http.StatusText(500), http.StatusInternalServerError)
+				return
+			}
 		}
 	}
 
-	if userIdentity.TspUserID != nil {
-		session.TspUserID = *(userIdentity.TspUserID)
-	} else if session.IsTspApp() {
-		// In case they managed to login before the tsp_user record was created
-		tspUser, err := models.FetchTspUserByEmail(h.db, session.Email)
-		if err == models.ErrFetchNotFound {
-			h.logger.Error("Non-TSP user authenticated at tsp site", zap.String("email", session.Email))
-			http.Error(w, http.StatusText(401), http.StatusUnauthorized)
-			return
-		} else if err != nil {
-			h.logger.Error("Checking for TSP user", zap.String("email", session.Email), zap.Error(err))
-			http.Error(w, http.StatusText(500), http.StatusInternalServerError)
-			return
-		}
-		session.TspUserID = tspUser.ID
-		span.AddField("session.tsp_user_id", session.TspUserID)
-		tspUser.UserID = &userIdentity.ID
-		err = h.db.Save(tspUser)
-		if err != nil {
-			h.logger.Error("Updating TSP user", zap.String("email", session.Email), zap.Error(err))
-			http.Error(w, http.StatusText(500), http.StatusInternalServerError)
-			return
+	if session.IsTspApp() {
+		if userIdentity.TspUserID != nil {
+			session.TspUserID = *(userIdentity.TspUserID)
+		} else {
+			// In case they managed to login before the tsp_user record was created
+			tspUser, err := models.FetchTspUserByEmail(h.db, session.Email)
+			if err == models.ErrFetchNotFound {
+				h.logger.Error("Non-TSP user authenticated at tsp site", zap.String("email", session.Email))
+				http.Error(w, http.StatusText(401), http.StatusUnauthorized)
+				return
+			} else if err != nil {
+				h.logger.Error("Checking for TSP user", zap.String("email", session.Email), zap.Error(err))
+				http.Error(w, http.StatusText(500), http.StatusInternalServerError)
+				return
+			}
+			session.TspUserID = tspUser.ID
+			span.AddField("session.tsp_user_id", session.TspUserID)
+			tspUser.UserID = &userIdentity.ID
+			err = h.db.Save(tspUser)
+			if err != nil {
+				h.logger.Error("Updating TSP user", zap.String("email", session.Email), zap.Error(err))
+				http.Error(w, http.StatusText(500), http.StatusInternalServerError)
+				return
+			}
 		}
 	}
 	session.FirstName = userIdentity.FirstName()

--- a/pkg/auth/authentication/auth_test.go
+++ b/pkg/auth/authentication/auth_test.go
@@ -157,7 +157,7 @@ func (suite *AuthSuite) TestAuthorizeDisableUser() {
 		Disabled: true,
 	}
 
-	req := httptest.NewRequest("GET", fmt.Sprintf("http://%s/auth/logout", "office.example.com"), nil)
+	req := httptest.NewRequest("GET", fmt.Sprintf("http://%s/auth/logout", OfficeTestHost), nil)
 
 	fakeToken := "some_token"
 	fakeUUID, _ := uuid.FromString("39b28c92-0506-4bef-8b57-e39519f42dc2")
@@ -193,7 +193,7 @@ func (suite *AuthSuite) TestAuthKnownSingleRoleOffice() {
 		TspUserID:    &tspUserID,
 	}
 
-	req := httptest.NewRequest("GET", fmt.Sprintf("http://%s/auth/authorize", "office.example.com"), nil)
+	req := httptest.NewRequest("GET", fmt.Sprintf("http://%s/auth/authorize", OfficeTestHost), nil)
 
 	fakeToken := "some_token"
 	fakeUUID, _ := uuid.FromString("39b28c92-0506-4bef-8b57-e39519f42dc2")
@@ -231,7 +231,7 @@ func (suite *AuthSuite) TestAuthKnownSingleRoleTSP() {
 		TspUserID:    &tspUserID,
 	}
 
-	req := httptest.NewRequest("GET", fmt.Sprintf("http://%s/auth/authorize", "tsp.example.com"), nil)
+	req := httptest.NewRequest("GET", fmt.Sprintf("http://%s/auth/authorize", TspTestHost), nil)
 
 	fakeToken := "some_token"
 	fakeUUID, _ := uuid.FromString("39b28c92-0506-4bef-8b57-e39519f42dc2")

--- a/pkg/auth/authentication/devlocal.go
+++ b/pkg/auth/authentication/devlocal.go
@@ -243,11 +243,11 @@ func createSession(h devlocalAuthHandler, user *models.User, w http.ResponseWrit
 		session.ServiceMemberID = *(userIdentity.ServiceMemberID)
 	}
 
-	if userIdentity.OfficeUserID != nil {
+	if userIdentity.OfficeUserID != nil && session.IsOfficeApp() {
 		session.OfficeUserID = *(userIdentity.OfficeUserID)
 	}
 
-	if userIdentity.TspUserID != nil {
+	if userIdentity.TspUserID != nil && session.IsTspApp() {
 		session.TspUserID = *(userIdentity.TspUserID)
 	}
 


### PR DESCRIPTION
## Description

Currently we populate the session with `OfficeUserID` and `TSPUserID` regardless of which app they are accessing. Because our model authorization checks are mutually exclusive (if isTSPUser do something, else if isOfficeUser do something else), users were potentially being restricted with TSP auth checks when on the office app or vice versa.

This PR modifies that code so that `OfficeUserID` is only populated when accessing the office app, and similarly for the TSP data and app.

## References

* [Pivotal story](tbd) for this change