### PR TITLE
SPIKE: golden ticket

### DIFF
--- a/migrations/20190409225540_create-golden-ticket-table.up.sql
+++ b/migrations/20190409225540_create-golden-ticket-table.up.sql
@@ -1,0 +1,14 @@
+CREATE TABLE IF NOT EXISTS golden_tickets
+(
+	id         uuid
+		CONSTRAINT golden_tickets_pk PRIMARY KEY,
+	move_id    uuid
+		CONSTRAINT move_id__fk REFERENCES moves,
+	code       text,
+	move_type  text,
+	created_at timestamp NOT NULL,
+	updated_at timestamp NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS golden_tickets_code_uindex
+	ON golden_tickets (code);

--- a/pkg/handlers/internalapi/office_test.go
+++ b/pkg/handlers/internalapi/office_test.go
@@ -108,7 +108,7 @@ func (suite *HandlerSuite) TestCancelMoveHandler() {
 	orders := testdatagen.MakeDefaultOrder(suite.DB())
 
 	selectedMoveType := models.SelectedMoveTypePPM
-	move, verrs, err := orders.CreateNewMove(suite.DB(), &selectedMoveType)
+	move, verrs, err := orders.CreateNewMove(suite.DB(), &selectedMoveType, nil)
 	suite.Nil(err)
 	suite.False(verrs.HasAny(), "failed to validate move")
 	officeUser := testdatagen.MakeDefaultOfficeUser(suite.DB())

--- a/pkg/handlers/internalapi/orders.go
+++ b/pkg/handlers/internalapi/orders.go
@@ -114,7 +114,7 @@ func (h CreateOrdersHandler) Handle(params ordersop.CreateOrdersParams) middlewa
 		return handlers.ResponseForVErrors(h.Logger(), verrs, err)
 	}
 
-	newMove, verrs, err := newOrder.CreateNewMove(h.DB(), nil)
+	newMove, verrs, err := newOrder.CreateNewMove(h.DB(), nil, nil)
 	if err != nil || verrs.HasAny() {
 		return handlers.ResponseForVErrors(h.Logger(), verrs, err)
 	}

--- a/pkg/handlers/internalapi/personally_procured_move_test.go
+++ b/pkg/handlers/internalapi/personally_procured_move_test.go
@@ -22,7 +22,7 @@ func (suite *HandlerSuite) TestCreatePPMHandler() {
 	orders := testdatagen.MakeDefaultOrder(suite.DB())
 	selectedMoveType := models.SelectedMoveTypeHHGPPM
 
-	move, verrs, locErr := orders.CreateNewMove(suite.DB(), &selectedMoveType)
+	move, verrs, locErr := orders.CreateNewMove(suite.DB(), &selectedMoveType, nil)
 	suite.False(verrs.HasAny(), "failed to create new move")
 	suite.Nil(locErr)
 
@@ -381,12 +381,12 @@ func (suite *HandlerSuite) TestPatchPPMHandlerWrongMoveID() {
 
 	selectedMoveType := models.SelectedMoveTypeHHGPPM
 
-	move, verrs, err := orders.CreateNewMove(suite.DB(), &selectedMoveType)
+	move, verrs, err := orders.CreateNewMove(suite.DB(), &selectedMoveType, nil)
 	suite.Nil(err, "Failed to save move")
 	suite.False(verrs.HasAny(), "failed to validate move")
 	move.Orders = orders
 
-	move2, verrs, err := orders1.CreateNewMove(suite.DB(), &selectedMoveType)
+	move2, verrs, err := orders1.CreateNewMove(suite.DB(), &selectedMoveType, nil)
 	suite.Nil(err, "Failed to save move")
 	suite.False(verrs.HasAny(), "failed to validate move")
 	move2.Orders = orders1

--- a/pkg/models/golden_ticket.go
+++ b/pkg/models/golden_ticket.go
@@ -1,0 +1,146 @@
+package models
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/pkg/errors"
+
+	"github.com/gobuffalo/validate/validators"
+
+	"github.com/gobuffalo/pop"
+	"github.com/gobuffalo/validate"
+	"github.com/gofrs/uuid"
+)
+
+type GoldenTicket struct {
+	ID        uuid.UUID  `json:"id" db:"id"`
+	MoveID    *uuid.UUID `json:"move_id" db:"move_id"`
+	Code      string     `json:"code" db:"code"`
+	MoveType  string     `json:"move_type" db:"move_type"`
+	CreatedAt time.Time  `json:"created_at" db:"created_at"`
+	UpdatedAt time.Time  `json:"updated_at" db:"updated_at"`
+}
+
+// String is not required by pop and may be deleted
+func (g GoldenTicket) String() string {
+	jg, _ := json.Marshal(g)
+	return string(jg)
+}
+
+// GoldenTickets is not required by pop and may be deleted
+type GoldenTickets []GoldenTicket
+
+// String is not required by pop and may be deleted
+func (g GoldenTickets) String() string {
+	jg, _ := json.Marshal(g)
+	return string(jg)
+}
+
+// Validate gets run every time you call a "pop.Validate*" (pop.ValidateAndSave, pop.ValidateAndCreate, pop.ValidateAndUpdate) method.
+// This method is not required and may be deleted.
+func (g *GoldenTicket) Validate(tx *pop.Connection) (*validate.Errors, error) {
+	return validate.Validate(
+		&validators.StringIsPresent{Field: g.Code, Name: "Code"},
+	), nil
+}
+
+// ValidateCreate gets run every time you call "pop.ValidateAndCreate" method.
+// This method is not required and may be deleted.
+func (g *GoldenTicket) ValidateCreate(tx *pop.Connection) (*validate.Errors, error) {
+	return validate.NewErrors(), nil
+}
+
+// ValidateUpdate gets run every time you call "pop.ValidateAndUpdate" method.
+// This method is not required and may be deleted.
+func (g *GoldenTicket) ValidateUpdate(tx *pop.Connection) (*validate.Errors, error) {
+	return validate.Validate(
+		&validators.StringIsPresent{Field: g.Code, Name: "Code"},
+	), nil
+}
+
+func MakeGoldenTicket(db *pop.Connection, moveType SelectedMoveType) (*GoldenTicket, *validate.Errors, error) {
+	var err error
+	var responseError error
+	responseVErrors := validate.NewErrors()
+	gt := GoldenTicket{MoveType: string(moveType)}
+	gt.Code, err = GenerateGoldenTicketCode()
+	if err != nil {
+		responseError = errors.Wrap(err, "Error creating golden ticket")
+		return &GoldenTicket{}, responseVErrors, err
+	}
+	verrs, err := db.ValidateAndCreate(&gt)
+	if err != nil || verrs.HasAny() {
+		responseVErrors.Append(verrs)
+		responseError = errors.Wrap(err, "Error creating golden ticket")
+		return &GoldenTicket{}, responseVErrors, responseError
+	}
+	if err != nil {
+		responseError = errors.Wrap(err, "Error creating golden ticket")
+		return &GoldenTicket{}, responseVErrors, err
+	}
+	return &gt, responseVErrors, err
+}
+
+func GenerateGoldenTicketCode() (string, error) {
+	// Not committing to uuid, yet, but just use a placeholder for now
+	id, err := uuid.NewV4()
+	if err == nil {
+		return string(id.String()), nil
+	}
+	return "", err
+}
+
+func ValidateGoldenTicket(db *pop.Connection, code string, move Move) (*GoldenTicket, bool) {
+	gt := GoldenTicket{}
+	err := db.
+		Where("code = ?", code).
+		Where("move_id IS NULL").
+		//TODO where / when does move type get assigned. Assuming that has already been set
+		//TODO when sm enters golden ticket code
+		Where("move_type = ?", move.SelectedMoveType).
+		First(&gt)
+	if err != nil {
+		return &gt, false
+	}
+	return &gt, true
+}
+
+func UseGoldenTicket(db *pop.Connection, code string, move Move) (*GoldenTicket, *validate.Errors, error) {
+	var err error
+	var responseError error
+	responseVErrors := validate.NewErrors()
+
+	gt, isValid := ValidateGoldenTicket(db, code, move)
+	if !isValid {
+		err := errors.New("invalid code")
+		responseError = errors.Wrap(err, "Error using golden ticket")
+		return &GoldenTicket{}, responseVErrors, responseError
+	}
+
+	gt.MoveID = &move.ID
+	verrs, err := db.ValidateAndUpdate(gt)
+	if err != nil || verrs.HasAny() {
+		responseVErrors.Append(verrs)
+		responseError = errors.Wrap(err, "Error using golden ticket")
+		return &GoldenTicket{}, responseVErrors, responseError
+	}
+	return gt, responseVErrors, responseError
+}
+
+type GoldenTicketCounts map[SelectedMoveType]int
+
+func MakeGoldenTickets(db *pop.Connection, moveTypes GoldenTicketCounts) (GoldenTickets, *validate.Errors, error) {
+	verrs := validate.NewErrors()
+	var goldenTickets []GoldenTicket
+	for k, v := range moveTypes {
+		for i := 0; i < v; i++ {
+			gt, verrs, err := MakeGoldenTicket(db, k)
+			if err != nil || verrs.HasAny() {
+				return goldenTickets, verrs, err
+			}
+			goldenTickets = append(goldenTickets, *gt)
+		}
+	}
+	return goldenTickets, verrs, nil
+}

--- a/pkg/models/golden_ticket.go
+++ b/pkg/models/golden_ticket.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gofrs/uuid"
 )
 
+//GoldenTicket used to represent app access codes
 type GoldenTicket struct {
 	ID        uuid.UUID  `json:"id" db:"id"`
 	MoveID    *uuid.UUID `json:"move_id" db:"move_id"`
@@ -59,6 +60,7 @@ func (g *GoldenTicket) ValidateUpdate(tx *pop.Connection) (*validate.Errors, err
 	), nil
 }
 
+//MakeGoldenTicket generates a single GoldenTicket for a move type
 func MakeGoldenTicket(db *pop.Connection, moveType SelectedMoveType) (*GoldenTicket, *validate.Errors, error) {
 	var err error
 	var responseError error
@@ -75,15 +77,12 @@ func MakeGoldenTicket(db *pop.Connection, moveType SelectedMoveType) (*GoldenTic
 		responseError = errors.Wrap(err, "Error creating golden ticket")
 		return &GoldenTicket{}, responseVErrors, responseError
 	}
-	if err != nil {
-		responseError = errors.Wrap(err, "Error creating golden ticket")
-		return &GoldenTicket{}, responseVErrors, err
-	}
 	return &gt, responseVErrors, err
 }
 
+//GenerateGoldenTicketCode generates the codes associated with GoldenTickets
 func GenerateGoldenTicketCode() (string, error) {
-	// Not committing to uuid, yet, but just use a placeholder for now
+	// TODO Not committing to uuid, yet, but just use a placeholder for now
 	id, err := uuid.NewV4()
 	if err == nil {
 		return string(id.String()), nil
@@ -91,6 +90,7 @@ func GenerateGoldenTicketCode() (string, error) {
 	return "", err
 }
 
+//ValidateGoldenTicket checks whether a golden ticket code is valid and unused
 func ValidateGoldenTicket(db *pop.Connection, code string, move Move) (*GoldenTicket, bool) {
 	gt := GoldenTicket{}
 	err := db.
@@ -106,6 +106,7 @@ func ValidateGoldenTicket(db *pop.Connection, code string, move Move) (*GoldenTi
 	return &gt, true
 }
 
+//UseGoldenTicket associates a GoldenTicket w/ a move, effectively uses that code
 func UseGoldenTicket(db *pop.Connection, code string, move Move) (*GoldenTicket, *validate.Errors, error) {
 	var err error
 	var responseError error
@@ -128,8 +129,10 @@ func UseGoldenTicket(db *pop.Connection, code string, move Move) (*GoldenTicket,
 	return gt, responseVErrors, responseError
 }
 
+//GoldenTicketCounts map of move types and counts used to generate golden tickets
 type GoldenTicketCounts map[SelectedMoveType]int
 
+//MakeGoldenTickets generates a series of golden tickets as specified by GoldenTicketCounts
 func MakeGoldenTickets(db *pop.Connection, moveTypes GoldenTicketCounts) (GoldenTickets, *validate.Errors, error) {
 	verrs := validate.NewErrors()
 	var goldenTickets []GoldenTicket

--- a/pkg/models/golden_ticket_test.go
+++ b/pkg/models/golden_ticket_test.go
@@ -15,41 +15,13 @@ type GoldenTicketSuite struct {
 	testingsuite.PopTestSuite
 }
 
+func (suite *GoldenTicketSuite) SetupTest() {
+	suite.DB().TruncateAll()
+}
+
 func TestGoldenTicketSuite(t *testing.T) {
 	hs := &GoldenTicketSuite{PopTestSuite: testingsuite.NewPopTestSuite()}
 	suite.Run(t, hs)
-}
-
-func (suite *GoldenTicketSuite) SetupTest() {
-	goldenTicketDDL := suite.DB().RawQuery(`
-CREATE TABLE IF NOT EXISTS golden_tickets
-(
-  id         uuid CONSTRAINT golden_tickets_pk PRIMARY KEY,
-  move_id    uuid CONSTRAINT move_id__fk REFERENCES moves,
-  code       text,
-  move_type text,
-  created_at timestamp NOT NULL,
-  updated_at timestamp NOT NULL
-);
-
-CREATE UNIQUE INDEX IF NOT EXISTS golden_tickets_code_uindex
-  ON golden_tickets (code);`)
-
-	err := goldenTicketDDL.Exec()
-	suite.Nil(err)
-
-}
-func (suite *GoldenTicketSuite) TearDownTest() {
-	removeGoldenTicket := suite.DB().RawQuery(`drop table if exists golden_tickets;`)
-	err := removeGoldenTicket.Exec()
-	suite.Nil(err)
-}
-
-func (suite *GoldenTicketSuite) TestGoldenTicket() {
-	exists := suite.DB().RawQuery(`select 1 from golden_tickets;`)
-	err := exists.Exec()
-
-	suite.Nil(err)
 }
 
 func (suite *GoldenTicketSuite) TestMakeGoldenTicket() {

--- a/pkg/models/golden_ticket_test.go
+++ b/pkg/models/golden_ticket_test.go
@@ -1,0 +1,139 @@
+package models_test
+
+import (
+	"testing"
+
+	"github.com/transcom/mymove/pkg/testdatagen"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/testingsuite"
+)
+
+type GoldenTicketSuite struct {
+	testingsuite.PopTestSuite
+}
+
+func TestGoldenTicketSuite(t *testing.T) {
+	hs := &GoldenTicketSuite{PopTestSuite: testingsuite.NewPopTestSuite()}
+	suite.Run(t, hs)
+}
+
+func (suite *GoldenTicketSuite) SetupTest() {
+	goldenTicketDDL := suite.DB().RawQuery(`
+CREATE TABLE IF NOT EXISTS golden_tickets
+(
+  id         uuid CONSTRAINT golden_tickets_pk PRIMARY KEY,
+  move_id    uuid CONSTRAINT move_id__fk REFERENCES moves,
+  code       text,
+  move_type text,
+  created_at timestamp NOT NULL,
+  updated_at timestamp NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS golden_tickets_code_uindex
+  ON golden_tickets (code);`)
+
+	err := goldenTicketDDL.Exec()
+	suite.Nil(err)
+
+}
+func (suite *GoldenTicketSuite) TearDownTest() {
+	removeGoldenTicket := suite.DB().RawQuery(`drop table if exists golden_tickets;`)
+	err := removeGoldenTicket.Exec()
+	suite.Nil(err)
+}
+
+func (suite *GoldenTicketSuite) TestGoldenTicket() {
+	exists := suite.DB().RawQuery(`select 1 from golden_tickets;`)
+	err := exists.Exec()
+
+	suite.Nil(err)
+}
+
+func (suite *GoldenTicketSuite) TestMakeGoldenTicket() {
+	_, verrs, err := models.MakeGoldenTicket(suite.DB(), models.SelectedMoveTypeHHG)
+
+	suite.Nil(err)
+	suite.False(verrs.HasAny())
+	gt := models.GoldenTicket{}
+	err = suite.DB().First(&gt)
+	suite.Nil(err)
+}
+
+func (suite *GoldenTicketSuite) TestValidGoldenTicket() {
+	moveType := models.SelectedMoveTypeHHG
+	move := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{
+		Move: models.Move{SelectedMoveType: &moveType},
+	})
+	gt := &models.GoldenTicket{}
+	gt, verrs, err := models.MakeGoldenTicket(suite.DB(), moveType)
+	suite.Nil(err)
+	suite.False(verrs.HasAny())
+	suite.NotNil(gt)
+
+	_, isValid := models.ValidateGoldenTicket(suite.DB(), gt.Code, move)
+	suite.True(isValid)
+}
+
+func (suite *GoldenTicketSuite) TestGoldenTicketInvalidMoveType() {
+	moveType := models.SelectedMoveTypeHHG
+	gt := &models.GoldenTicket{}
+	gt, verrs, err := models.MakeGoldenTicket(suite.DB(), moveType)
+	suite.Nil(err)
+	suite.False(verrs.HasAny())
+	suite.NotNil(gt)
+
+	invalidMoveType := models.SelectedMoveTypePPM
+	moveWithInvalidMoveType := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{
+		Move: models.Move{SelectedMoveType: &invalidMoveType},
+	})
+
+	_, isValid := models.ValidateGoldenTicket(suite.DB(), gt.Code, moveWithInvalidMoveType)
+	suite.False(isValid)
+}
+
+func (suite *GoldenTicketSuite) TestGoldenTicketInvalidCode() {
+	moveType := models.SelectedMoveTypeHHG
+	move := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{
+		Move: models.Move{SelectedMoveType: &moveType},
+	})
+	gt := &models.GoldenTicket{}
+	gt, verrs, err := models.MakeGoldenTicket(suite.DB(), moveType)
+	suite.Nil(err)
+	suite.False(verrs.HasAny())
+	suite.NotNil(gt)
+
+	_, isValid := models.ValidateGoldenTicket(suite.DB(), "INVALID CODE", move)
+	suite.False(isValid)
+}
+
+func (suite *GoldenTicketSuite) TestUseGoldenTicket() {
+	move := testdatagen.MakeDefaultMove(suite.DB())
+	gt, verrs, err := models.MakeGoldenTicket(suite.DB(), *move.SelectedMoveType)
+	suite.Nil(err)
+	suite.False(verrs.HasAny())
+	suite.NotNil(gt)
+
+	gt, verrs, err = models.UseGoldenTicket(suite.DB(), gt.Code, move)
+	suite.Nil(err)
+	suite.False(verrs.HasAny())
+	updatedGT := &models.GoldenTicket{}
+	err = suite.DB().Find(updatedGT, gt.ID)
+	suite.Nil(err)
+	suite.Equal(move.ID, *updatedGT.MoveID)
+}
+
+func (suite *GoldenTicketSuite) TestMultipleTickets() {
+	gtc := models.GoldenTicketCounts{models.SelectedMoveTypePPM: 66, models.SelectedMoveTypeHHG: 33}
+	_, verrs, err := models.MakeGoldenTickets(suite.DB(), gtc)
+	suite.Nil(err)
+	suite.False(verrs.HasAny())
+
+	hhgs, err := suite.DB().Where("move_type = ?", "HHG").Count(&models.GoldenTicket{})
+	ppms, err := suite.DB().Where("move_type = ?", "PPM").Count(&models.GoldenTicket{})
+
+	suite.Equal(33, hhgs)
+	suite.Equal(66, ppms)
+}

--- a/pkg/models/move_test.go
+++ b/pkg/models/move_test.go
@@ -26,7 +26,7 @@ func (suite *ModelSuite) TestCreateNewMoveValidLocatorString() {
 	orders := testdatagen.MakeDefaultOrder(suite.DB())
 	selectedMoveType := SelectedMoveTypeHHG
 
-	move, verrs, err := orders.CreateNewMove(suite.DB(), &selectedMoveType)
+	move, verrs, err := orders.CreateNewMove(suite.DB(), &selectedMoveType, nil)
 
 	suite.Nil(err)
 	suite.False(verrs.HasAny(), "failed to validate move")
@@ -34,6 +34,33 @@ func (suite *ModelSuite) TestCreateNewMoveValidLocatorString() {
 	suite.Regexp("^[346789BCDFGHJKMPQRTVWXY]+$", move.Locator)
 	// Verify invalid items are not in locator - this should produce "non-word" locators
 	suite.NotRegexp("[0125AEIOULNSZ]", move.Locator)
+}
+
+func (suite *ModelSuite) TestCreateNewGoldenTicketMove() {
+	orders := testdatagen.MakeDefaultOrder(suite.DB())
+	selectedMoveType := SelectedMoveTypeHHG
+	gt, verrs, err := MakeGoldenTicket(suite.DB(), SelectedMoveTypeHHG)
+	suite.Nil(err)
+	suite.False(verrs.HasAny())
+
+	_, verrs, err = orders.CreateNewMove(suite.DB(), &selectedMoveType, &gt.Code)
+
+	suite.Nil(err)
+	suite.NoVerrs(verrs)
+}
+
+func (suite *ModelSuite) TestCreateInvalidGoldenTicketMove() {
+	orders := testdatagen.MakeDefaultOrder(suite.DB())
+	selectedMoveType := SelectedMoveTypeHHG
+	_, verrs, err := MakeGoldenTicket(suite.DB(), SelectedMoveTypeHHG)
+	suite.Nil(err)
+	suite.False(verrs.HasAny())
+
+	gtCode := "INVALID_CODE"
+	_, verrs, err = orders.CreateNewMove(suite.DB(), &selectedMoveType, &gtCode)
+
+	suite.NotNil(err)
+	suite.NoVerrs(verrs)
 }
 
 func (suite *ModelSuite) TestFetchMove() {
@@ -56,7 +83,7 @@ func (suite *ModelSuite) TestFetchMove() {
 	}
 	selectedMoveType := SelectedMoveTypeHHG
 
-	move, verrs, err := order1.CreateNewMove(suite.DB(), &selectedMoveType)
+	move, verrs, err := order1.CreateNewMove(suite.DB(), &selectedMoveType, nil)
 	suite.Nil(err)
 	suite.False(verrs.HasAny(), "failed to validate move")
 	suite.Equal(6, len(move.Locator))
@@ -99,7 +126,7 @@ func (suite *ModelSuite) TestMoveCancellationWithReason() {
 
 	selectedMoveType := SelectedMoveTypeHHGPPM
 
-	move, verrs, err := orders.CreateNewMove(suite.DB(), &selectedMoveType)
+	move, verrs, err := orders.CreateNewMove(suite.DB(), &selectedMoveType, nil)
 	suite.Nil(err)
 	suite.False(verrs.HasAny(), "failed to validate move")
 	move.Orders = orders
@@ -125,7 +152,7 @@ func (suite *ModelSuite) TestMoveStateMachine() {
 
 	selectedMoveType := SelectedMoveTypeHHGPPM
 
-	move, verrs, err := orders.CreateNewMove(suite.DB(), &selectedMoveType)
+	move, verrs, err := orders.CreateNewMove(suite.DB(), &selectedMoveType, nil)
 	suite.Nil(err)
 	suite.False(verrs.HasAny(), "failed to validate move")
 	reason := ""
@@ -193,7 +220,7 @@ func (suite *ModelSuite) TestCancelMoveCancelsOrdersPPM() {
 
 	selectedMoveType := SelectedMoveTypeHHGPPM
 
-	move, verrs, err := orders.CreateNewMove(suite.DB(), &selectedMoveType)
+	move, verrs, err := orders.CreateNewMove(suite.DB(), &selectedMoveType, nil)
 	suite.Nil(err)
 	suite.False(verrs.HasAny(), "failed to validate move")
 	move.Orders = orders
@@ -227,7 +254,7 @@ func (suite *ModelSuite) TestSaveMoveDependenciesFail() {
 
 	selectedMoveType := SelectedMoveTypeHHGPPM
 
-	move, verrs, err := orders.CreateNewMove(suite.DB(), &selectedMoveType)
+	move, verrs, err := orders.CreateNewMove(suite.DB(), &selectedMoveType, nil)
 	suite.Nil(err)
 	suite.False(verrs.HasAny(), "failed to validate move")
 	move.Orders = orders
@@ -243,7 +270,7 @@ func (suite *ModelSuite) TestSaveMoveDependenciesSuccess() {
 
 	selectedMoveType := SelectedMoveTypeHHGPPM
 
-	move, verrs, err := orders.CreateNewMove(suite.DB(), &selectedMoveType)
+	move, verrs, err := orders.CreateNewMove(suite.DB(), &selectedMoveType, nil)
 	suite.Nil(err)
 	suite.False(verrs.HasAny(), "failed to validate move")
 	move.Orders = orders
@@ -273,7 +300,7 @@ func (suite *ModelSuite) TestSaveMoveDependenciesSetsGBLOCSuccess() {
 	orders.Status = OrderStatusSUBMITTED
 
 	selectedMoveType := SelectedMoveTypeHHGPPM
-	move, verrs, err := orders.CreateNewMove(suite.DB(), &selectedMoveType)
+	move, verrs, err := orders.CreateNewMove(suite.DB(), &selectedMoveType, nil)
 	suite.Nil(err)
 	suite.False(verrs.HasAny(), "failed to validate move")
 

--- a/pkg/models/move_test.go
+++ b/pkg/models/move_test.go
@@ -39,28 +39,32 @@ func (suite *ModelSuite) TestCreateNewMoveValidLocatorString() {
 func (suite *ModelSuite) TestCreateNewGoldenTicketMove() {
 	orders := testdatagen.MakeDefaultOrder(suite.DB())
 	selectedMoveType := SelectedMoveTypeHHG
-	gt, verrs, err := MakeGoldenTicket(suite.DB(), SelectedMoveTypeHHG)
-	suite.Nil(err)
+	gt, verrs, gtErr := MakeGoldenTicket(suite.DB(), SelectedMoveTypeHHG)
+	suite.Nil(gtErr)
 	suite.False(verrs.HasAny())
 
-	_, verrs, err = orders.CreateNewMove(suite.DB(), &selectedMoveType, &gt.Code)
+	_, verrs, gtErr = orders.CreateNewMove(suite.DB(), &selectedMoveType, &gt.Code)
+	count, countErr := suite.DB().Count(&Move{})
 
-	suite.Nil(err)
+	suite.Nil(gtErr)
 	suite.NoVerrs(verrs)
+	suite.Nil(countErr)
+	suite.Equal(1, count)
 }
 
 func (suite *ModelSuite) TestCreateInvalidGoldenTicketMove() {
 	orders := testdatagen.MakeDefaultOrder(suite.DB())
 	selectedMoveType := SelectedMoveTypeHHG
-	_, verrs, err := MakeGoldenTicket(suite.DB(), SelectedMoveTypeHHG)
-	suite.Nil(err)
-	suite.False(verrs.HasAny())
+	_, verrs, gtErr := MakeGoldenTicket(suite.DB(), SelectedMoveTypeHHG)
 
 	gtCode := "INVALID_CODE"
-	_, verrs, err = orders.CreateNewMove(suite.DB(), &selectedMoveType, &gtCode)
+	_, verrs, gtErr = orders.CreateNewMove(suite.DB(), &selectedMoveType, &gtCode)
+	count, countErr := suite.DB().Count(&Move{})
 
-	suite.NotNil(err)
+	suite.NotNil(gtErr)
 	suite.NoVerrs(verrs)
+	suite.Nil(countErr)
+	suite.Equal(0, count)
 }
 
 func (suite *ModelSuite) TestFetchMove() {

--- a/pkg/models/order.go
+++ b/pkg/models/order.go
@@ -207,7 +207,10 @@ func FetchOrderForPDFConversion(db *pop.Connection, id uuid.UUID) (Order, error)
 }
 
 // CreateNewMove creates a move associated with these Orders
-func (o *Order) CreateNewMove(db *pop.Connection, moveType *SelectedMoveType) (*Move, *validate.Errors, error) {
+func (o *Order) CreateNewMove(db *pop.Connection, moveType *SelectedMoveType, goldenTicketCode *string) (*Move, *validate.Errors, error) {
+	if goldenTicketCode != nil {
+		return createGoldenTicketMove(db, *o, moveType, *goldenTicketCode)
+	}
 	return createNewMove(db, *o, moveType)
 }
 

--- a/pkg/models/order_test.go
+++ b/pkg/models/order_test.go
@@ -230,7 +230,7 @@ func (suite *ModelSuite) TestCanceledMoveCancelsOrder() {
 	suite.MustSave(&orders)
 
 	selectedMoveType := SelectedMoveTypeHHGPPM
-	move, verrs, err := orders.CreateNewMove(suite.DB(), &selectedMoveType)
+	move, verrs, err := orders.CreateNewMove(suite.DB(), &selectedMoveType, nil)
 	suite.Nil(err)
 	suite.False(verrs.HasAny(), "failed to validate move")
 	move.Orders = orders

--- a/pkg/models/personally_procured_move_test.go
+++ b/pkg/models/personally_procured_move_test.go
@@ -56,7 +56,7 @@ func (suite *ModelSuite) TestPPMStateMachine() {
 
 	selectedMoveType := SelectedMoveTypeHHGPPM
 
-	move, verrs, err := orders.CreateNewMove(suite.DB(), &selectedMoveType)
+	move, verrs, err := orders.CreateNewMove(suite.DB(), &selectedMoveType, nil)
 	suite.Nil(err)
 	suite.False(verrs.HasAny(), "failed to validate move")
 	move.Orders = orders


### PR DESCRIPTION
## Description

Spike generating access codes for [Pivotal story](https://www.pivotaltracker.com/n/projects/2181745/stories/164937475). 

## Reviewer Notes
1) Attempt to use the existing move locator generator to create 100 access codes

     I think that it might be difficult to use the current move locator as the access codes for the app (at least w/o some refactoring to the current move creation code). I left this part open and assumed whatever we decide can be implemented in `GenerateGoldenTicketCode`. My Reasoning regarding why it might be difficult to use the existing move locator is outlined below: 
	* The move locator is created in `GenerateLocator()`  in `pkg/models/move.go`. Right now, when we attempt to create a new move there is a unique constraint on the move locator, so a locator is generated and if it's not unique the db will reject it and the creation process is tried again with a new move locator. This process is repeated until it succeeds or goes over the allotted attempts. 
	* It seems like there are a couple approaches for using the current move locator, but I think both have issues:
		* Just create 100 empty / placeholder moves associated with each access code. Moves require an associated set of orders, so (I think) we can’t create a move until we have orders, which means that creating placeholder moves seems like it might not be possible. We could maybe create placeholder orders that get updated with actual orders, but that seems like it would probably have its own issues.
		* Just check the move locators for the golden ticket ids against the `moves` table (add a constraint to `golden_tickets`). This would work for the golden ticket moves, but then the actual move locator id would potentially miss collisions, since its unique constraint only checks the `moves` table. We could add another constraint to moves table (against the `golden_ticket` table), but I was little unsure of how we'd create the move when it comes time to actually create it, since its locator will already be in `golden_ticket` table and therefore would fail the constraint. I think we could probably get around this, by maybe asking the user for the move locator / access code if they have one and falling back on the existing process when they don't.

2) Identify where these code will be stored (which database table, etc.)

    Seems like these should just go in their own table. For the spike this is called `golden_tickets`. The associated DDL is in the tests.

3) Prototype the SQL lookup to check if a code is valid

   See [code](https://github.com/transcom/mymove/blob/b4f2fea76372e159eeff14982c98e8b408073841/pkg/models/golden_ticket.go#L94-L107)

4) Prototype the SQL lookup to check if a code has already been used

   See [code](https://github.com/transcom/mymove/blob/b4f2fea76372e159eeff14982c98e8b408073841/pkg/models/golden_ticket.go#L94-L107). Thought we could link to `move_id` in `moves` table when an access code has been used (null if unused).

5) Prototype the SQL lookup to determine the move type for a code

   See [code](https://github.com/transcom/mymove/blob/b4f2fea76372e159eeff14982c98e8b408073841/pkg/models/golden_ticket.go#L94-L107)
