### PR TITLE
fix the broken path to soda binary so secure migrations script works

### DIFF
--- a/scripts/generate-secure-migration
+++ b/scripts/generate-secure-migration
@@ -7,7 +7,7 @@
 set -eu -o pipefail
 
 readonly dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-readonly soda="${dir}/soda"
+readonly soda="${dir}/../bin/soda"
 
 readonly local_migrations_dir="${dir}/../local_migrations"
 readonly prod_migrations_temp_dir="${dir}/../tmp"


### PR DESCRIPTION
## Description

The secure migrations script used to live in bin directory and soda binary was locally available. A recent refactor broke the link and this pr fixes it.

## Reviewer Notes

`generate-secure-migration` does not error out because it cannot find soda binary. See screenshot for more.

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/165092068) for this change
* [this article](tbd) explains more about the approach used.

## Screenshots
![image](https://user-images.githubusercontent.com/5003421/55491079-dbdb0c80-5602-11e9-9fb7-dd6d96d93e2b.png)

