### PR TITLE
User can now complete HHG move setup when residential and pickup address are the same value

### DIFF
--- a/cypress/integration/mymove/shipment.js
+++ b/cypress/integration/mymove/shipment.js
@@ -111,15 +111,11 @@ function serviceMemberAddsLocations() {
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/moves\/[^/]+\/hhg-locations/);
   });
-  // Note that we are not checking for a disabled save button because we
-  // expect the pickup address to prefill with the SM residential address
 
-  // Pickup address
-  cy.get('input[name="pickup_address.street_address_1"]').should('have.value', '123 Any Street');
-  cy.get('input[name="pickup_address.street_address_2"]').should('have.value', 'P.O. Box 12345');
-  cy.get('input[name="pickup_address.city"]').should('have.value', 'Beverly Hills');
-  cy.get('select[name="pickup_address.state"]').should('have.value', 'CA');
-  cy.get('input[name="pickup_address.postal_code"]').should('have.value', '90210');
+  cy
+    .get('button')
+    .contains('Next')
+    .should('be.disabled');
 
   // Pickup address
   cy

--- a/src/scenes/Moves/Hhg/Locations.jsx
+++ b/src/scenes/Moves/Hhg/Locations.jsx
@@ -11,7 +11,12 @@ import Alert from 'shared/Alert';
 import { reduxifyWizardForm } from 'shared/WizardPage/Form';
 import Address from 'scenes/Moves/Hhg/Address';
 
-import { createOrUpdateShipment, getShipment, getShipmentLabel } from 'shared/Entities/modules/shipments';
+import {
+  createOrUpdateShipment,
+  getShipment,
+  getShipmentLabel,
+  selectShipmentForMove,
+} from 'shared/Entities/modules/shipments';
 
 import './ShipmentWizard.css';
 
@@ -97,15 +102,15 @@ Locations.propTypes = {
 function mapDispatchToProps(dispatch) {
   return bindActionCreators({ createOrUpdateShipment, setCurrentShipmentID, getShipment }, dispatch);
 }
-function mapStateToProps(state) {
+function mapStateToProps(state, ownProps) {
   const shipment = getCurrentShipment(state);
-  const smAddress = get(state, 'serviceMember.currentServiceMember.residential_address', {});
+  const { pickup_address } = selectShipmentForMove(state, ownProps.match.params.moveId);
   const props = {
     schema: getInternalSwaggerDefinition(state, 'Shipment'),
     move: get(state, 'moves.currentMove', {}),
     formValues: getFormValues(formName)(state),
     currentShipment: shipment,
-    initialValues: { pickup_address: smAddress },
+    initialValues: { pickup_address },
     error: getLastError(state, getShipmentLabel),
   };
   return props;


### PR DESCRIPTION
## Description

Initially, if the residential address and pickup address were the same then the pickup address would not be saved making the user unable to complete the HHG move setup. This issue fixes that behavior.

## Reviewer Notes
- I tried to see if we are able to keep the behavior of having the pickup address prepopulated based on what the user put for the residential address earlier on in the flow. But it would be more work than needed at this time or highly specific logic just for this scenario (it would start with the `beforeTransition` function in `src/shared/WizardPage/utils.js`)

## Setup
`make server_run`
`make client_run`
Go through hhg move setup regularly with values of current residential address and pickup address being the same

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/164966327) for this change
