### PR TITLE
Prepopulate SIT approval form with the estimated start date

### DIFF
--- a/src/shared/StorageInTransit/ApproveSitRequest.jsx
+++ b/src/shared/StorageInTransit/ApproveSitRequest.jsx
@@ -12,10 +12,11 @@ export class ApproveSitRequest extends Component {
   };
 
   render() {
+    const { storageInTransit } = this.props;
     return (
       <div className="storage-in-transit-panel-modal">
         <div className="title">Approve SIT Request</div>
-        <StorageInTransitOfficeApprovalForm />
+        <StorageInTransitOfficeApprovalForm initialValues={storageInTransit} />
         <div className="usa-grid-full align-center-vertical">
           <div className="usa-width-one-half">
             <p className="cancel-link">
@@ -40,6 +41,7 @@ export class ApproveSitRequest extends Component {
 
 ApproveSitRequest.propTypes = {
   onClose: PropTypes.func.isRequired,
+  storageInTransit: PropTypes.object.isRequired,
 };
 
 function mapStateToProps(state) {

--- a/src/shared/StorageInTransit/StorageInTransit.jsx
+++ b/src/shared/StorageInTransit/StorageInTransit.jsx
@@ -75,7 +75,7 @@ export class StorageInTransit extends Component {
           </span>
           <span>SIT {storageInTransit.status.charAt(0) + storageInTransit.status.slice(1).toLowerCase()} </span>
           {showApproveForm ? (
-            <ApproveSitRequest onClose={this.closeApproveForm} />
+            <ApproveSitRequest onClose={this.closeApproveForm} storageInTransit={storageInTransit} />
           ) : (
             isOfficeSite &&
             !showEditForm &&

--- a/src/shared/StorageInTransit/StorageInTransitOfficeApprovalForm.jsx
+++ b/src/shared/StorageInTransit/StorageInTransitOfficeApprovalForm.jsx
@@ -12,7 +12,8 @@ export class StorageInTransitOfficeApprovalForm extends Component {
   };
 
   render() {
-    const { storageInTransitSchema } = this.props;
+    const { storageInTransitSchema, initialValues } = this.props;
+    initialValues.authorized_start_date = initialValues.estimated_start_date;
     return (
       <form onSubmit={this.handleSubmit} className="storage-in-transit-office-approval-form">
         <fieldset key="sit-approval-information">

--- a/src/shared/StorageInTransit/StorageInTransitOfficeApprovalForm.test.jsx
+++ b/src/shared/StorageInTransit/StorageInTransitOfficeApprovalForm.test.jsx
@@ -19,13 +19,21 @@ const storageInTransitSchema = {
   },
 };
 
+const storageInTransit = {
+  estimated_start_date: '2018-11-11',
+};
+
 describe('StorageInTransitOfficeApprovalForm tests', () => {
   describe('Empty form', () => {
     let wrapper;
     store = mockStore({});
     wrapper = mount(
       <Provider store={store}>
-        <StorageInTransitOfficeApprovalForm onSubmit={submit} storageInTransitSchema={storageInTransitSchema} />
+        <StorageInTransitOfficeApprovalForm
+          onSubmit={submit}
+          storageInTransitSchema={storageInTransitSchema}
+          initialValues={storageInTransit}
+        />
       </Provider>,
     );
 


### PR DESCRIPTION
## Description

Updates approval form in the Office SIT to be pre-populated with the `estimated_start_date` that the TSP entered.

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make db_dev_e2e_populate
make server_run
make client_run
```
In the TSP app, select an HHG record and request a SIT. Next, go to the Office app and select the same record for which you added the SIT request. You will see the SIT panel and an `Approve` link. Click the link and you will see that the `Earliest authorized start date` will be pre-populated with the same date that was selected in the TSP app.

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/164250435) for this change

## Screenshots

![Apr-03-2019 10-59-53](https://user-images.githubusercontent.com/3522044/55501615-a7b21c80-55ff-11e9-9be2-014d8093da8c.gif)


