### PR TITLE
Improve submission error handling

### DIFF
--- a/pkg/models/shipment_test.go
+++ b/pkg/models/shipment_test.go
@@ -61,6 +61,20 @@ func (suite *ModelSuite) Test_ShipmentValidations() {
 	suite.verifyValidationErrors(shipment, expErrors)
 }
 
+func (suite *ModelSuite) Test_ShipmentValidationsSubmittedMove() {
+	shipment := &Shipment{
+		Status: ShipmentStatusSUBMITTED,
+	}
+
+	verrs, err := shipment.Validate(suite.DB())
+	suite.Nil(err)
+
+	pickupAddressErrors := verrs.Get("pickup_address_id")
+	suite.Equal(1, len(pickupAddressErrors), "expected one error on pickup_address_id, but there were %d: %v", len(pickupAddressErrors), pickupAddressErrors)
+
+	suite.Equal(pickupAddressErrors[0], "pickup_address_id can not be blank.", "expected pickup_address_id to be required, but it was not")
+}
+
 // Test_FetchUnofferedShipments tests that a shipment is returned when we fetch shipments with offers.
 func (suite *ModelSuite) Test_FetchUnofferedShipments() {
 	t := suite.T()

--- a/src/scenes/Legalese/ducks.js
+++ b/src/scenes/Legalese/ducks.js
@@ -49,7 +49,8 @@ export const signAndSubmitForApproval = (moveId, certificationText, signature, d
       dispatch(addEntities(filtered));
       return dispatch(signAndSubmitForApprovalActions.success());
     } catch (error) {
-      return dispatch(signAndSubmitForApprovalActions.error(error));
+      await dispatch(signAndSubmitForApprovalActions.error(error));
+      throw error;
     }
   };
 };

--- a/src/scenes/Legalese/index.jsx
+++ b/src/scenes/Legalese/index.jsx
@@ -22,6 +22,10 @@ const formName = 'signature-form';
 const SignatureWizardForm = reduxifyWizardForm(formName);
 
 export class SignedCertification extends Component {
+  state = {
+    hasMoveSubmitError: false,
+  };
+
   componentDidMount() {
     const { hasLoggedInUser, certificationText, has_advance, has_sit, selectedMoveType } = this.props;
     if (hasLoggedInUser && !certificationText) {
@@ -44,7 +48,8 @@ export class SignedCertification extends Component {
 
       return this.props
         .signAndSubmitForApproval(moveId, certificationText, pendingValues.signature, pendingValues.date, ppmId)
-        .then(() => this.props.push('/'));
+        .then(() => this.props.push('/'))
+        .catch(() => this.setState({ hasMoveSubmitError: true }));
     }
   };
   print() {
@@ -119,9 +124,9 @@ export class SignedCertification extends Component {
                     </div>
                   </div>
 
-                  {hasSubmitError && (
+                  {(hasSubmitError || this.state.hasMoveSubmitError) && (
                     <Alert type="error" heading="Server Error">
-                      There was a problem saving your signature. Please reload the page.
+                      There was a problem saving your signature.
                     </Alert>
                   )}
                 </div>


### PR DESCRIPTION
## Description

This PR adds some better error handling to the move submission for HHGs so that if a move fails to save, the user is presented with an error.

There is also a new model-level validation to prevent moves from being submitted if they don't have a pickup address.

## Reviewer Notes

It appears that we aren't rejecting promises in a lot of our older code, which makes handling errors at the call site more difficult. I think this is better with the newer style, but since this is part of the SM UI, little of the code there uses `swaggerRequest` and I didn't want to make a big wave with this fix.

## Setup

This should be difficult to actually trigger (is basically shouldn't happen when things are working correctly), but one way to cause it to happen is to clear out a moves `pickup_address_id` before submitting the signed certification form.

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](./docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](./docs/backend.md#querying-the-database-safely)
 have been satisfied.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/164966327) for this change

## Screenshots

_(Note: the error message no longer mentions reloading the page.)_

<img width="1022" alt="Screen Shot 2019-04-03 at 3 17 32 PM" src="https://user-images.githubusercontent.com/3331/55516859-2628b180-5634-11e9-968e-96e3759d0743.png">

