### PR TITLE
Prepopulate date field in office sit approval form

### DIFF
--- a/cypress/integration/office/storageInTransitPanel.js
+++ b/cypress/integration/office/storageInTransitPanel.js
@@ -100,6 +100,8 @@ function officeUserStartsAndCancelsSitApproval() {
       expect(text).to.not.include('Edit');
     });
 
+  cy.get('input[name="authorized_start_date"]').should('have.value', '3/22/2019');
+
   cy
     .get('.usa-button-secondary')
     .contains('Cancel')

--- a/src/shared/StorageInTransit/ApproveSitRequest.jsx
+++ b/src/shared/StorageInTransit/ApproveSitRequest.jsx
@@ -12,10 +12,11 @@ export class ApproveSitRequest extends Component {
   };
 
   render() {
+    const { storageInTransit } = this.props;
     return (
       <div className="storage-in-transit-panel-modal">
         <div className="title">Approve SIT Request</div>
-        <StorageInTransitOfficeApprovalForm />
+        <StorageInTransitOfficeApprovalForm initialValues={storageInTransit} />
         <div className="usa-grid-full align-center-vertical">
           <div className="usa-width-one-half">
             <p className="cancel-link">
@@ -40,6 +41,7 @@ export class ApproveSitRequest extends Component {
 
 ApproveSitRequest.propTypes = {
   onClose: PropTypes.func.isRequired,
+  storageInTransit: PropTypes.object.isRequired,
 };
 
 function mapStateToProps(state) {

--- a/src/shared/StorageInTransit/StorageInTransit.jsx
+++ b/src/shared/StorageInTransit/StorageInTransit.jsx
@@ -25,7 +25,17 @@ export class StorageInTransit extends Component {
       showEditForm: false,
       showApproveForm: false,
       showDenyForm: false,
+      storageInTransit: {},
     };
+  }
+
+  componentDidMount() {
+    this.setState({
+      storageInTransit: {
+        ...this.props.storageInTransit,
+        authorized_start_date: this.props.storageInTransit.estimated_start_date,
+      },
+    });
   }
 
   openEditForm = () => {
@@ -75,7 +85,7 @@ export class StorageInTransit extends Component {
           </span>
           <span>SIT {storageInTransit.status.charAt(0) + storageInTransit.status.slice(1).toLowerCase()} </span>
           {showApproveForm ? (
-            <ApproveSitRequest onClose={this.closeApproveForm} />
+            <ApproveSitRequest onClose={this.closeApproveForm} storageInTransit={this.state.storageInTransit} />
           ) : (
             isOfficeSite &&
             !showEditForm &&

--- a/src/shared/StorageInTransit/StorageInTransit.jsx
+++ b/src/shared/StorageInTransit/StorageInTransit.jsx
@@ -30,13 +30,17 @@ export class StorageInTransit extends Component {
   }
 
   componentDidMount() {
+    this.addAuthorizedStartDate();
+  }
+
+  addAuthorizedStartDate = () => {
     this.setState({
       storageInTransit: {
         ...this.props.storageInTransit,
         authorized_start_date: this.props.storageInTransit.estimated_start_date,
       },
     });
-  }
+  };
 
   openEditForm = () => {
     this.setState({ showEditForm: true });

--- a/src/shared/StorageInTransit/StorageInTransit.jsx
+++ b/src/shared/StorageInTransit/StorageInTransit.jsx
@@ -30,10 +30,17 @@ export class StorageInTransit extends Component {
   }
 
   componentDidMount() {
-    this.addAuthorizedStartDate();
+    this.authorizedStartDate();
   }
 
-  addAuthorizedStartDate = () => {
+  authorizedStartDate = () => {
+    const { storageInTransit } = this.props;
+    return storageInTransit.authorized_start_date
+      ? storageInTransit.authorized_start_date
+      : this.assignEstimatedStartDateToAuthorizedStartDate();
+  };
+
+  assignEstimatedStartDateToAuthorizedStartDate = () => {
     this.setState({
       storageInTransit: {
         ...this.props.storageInTransit,

--- a/src/shared/StorageInTransit/StorageInTransitOfficeApprovalForm.test.jsx
+++ b/src/shared/StorageInTransit/StorageInTransitOfficeApprovalForm.test.jsx
@@ -19,13 +19,21 @@ const storageInTransitSchema = {
   },
 };
 
+const storageInTransit = {
+  estimated_start_date: '2018-11-11',
+};
+
 describe('StorageInTransitOfficeApprovalForm tests', () => {
   describe('Empty form', () => {
     let wrapper;
     store = mockStore({});
     wrapper = mount(
       <Provider store={store}>
-        <StorageInTransitOfficeApprovalForm onSubmit={submit} storageInTransitSchema={storageInTransitSchema} />
+        <StorageInTransitOfficeApprovalForm
+          onSubmit={submit}
+          storageInTransitSchema={storageInTransitSchema}
+          initialValues={storageInTransit}
+        />
       </Provider>,
     );
 


### PR DESCRIPTION
## Description

Updates approval form in the Office SIT to pre-populate the date field with the date that was selected when requesting a SIT in the TSP app.

## Reviewer Notes

`StorageInTransit` has two date fields - `estimated_start_date` and `authorized_start_date`. When the date is selected in TSP, it is saved as `estimated_start_date`. We need this date to populate in the Office form, even though the Office approval will save the date as `authorized_start_date`. In order to do this, the state in our React app is updated to set `authorized_start_date` equal to the `estimated_start_date`. You can see this in `src/shared/StorageInTransit/StorageInTransit.jsx`. This allows for the date field in the Office form to be pre-populated. 

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make db_dev_e2e_populate
make server_run
make client_run
```
In the TSP app, select an HHG record and request a SIT. Next, go to the Office app and select the same record for which you added the SIT request. You will see the SIT panel and an `Approve` link. Click the link and you will see that the `Earliest authorized start date` will be pre-populated with the same date that was selected in the TSP app.

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/164250435) for this change

## Screenshots

![Apr-03-2019 10-59-53](https://user-images.githubusercontent.com/3522044/55501615-a7b21c80-55ff-11e9-9be2-014d8093da8c.gif)
