### PR TITLE
Permit a specific CAC cert to read/write Navy Orders

### DIFF
--- a/local_migrations/20190404150123_allow_certain_cac_navy_orders.sql
+++ b/local_migrations/20190404150123_allow_certain_cac_navy_orders.sql
@@ -1,0 +1,15 @@
+-- The US Navy is not going to connect to the Orders Gateway directly in the
+-- near-term. Instead, they are providing us flat-file exports from their
+-- orders database, and we run those flat-file exports through the Navy Orders
+-- Muncher (nom) which handles converting the flat file into the appropriate
+-- JSON structures and uploading them to the Orders API.
+-- The Orders API uses client certificate authentication. Only certificates
+-- signed by a trusted CA (such as DISA) are allowed. As nom is a command-line
+-- tool run by a person, using that person's CAC as the certificate is a
+-- convenient way to permit a single trusted individual to upload Orders.
+-- Once the Navy completes their integration between NSIPS and the Orders API,
+-- this CAC certificate should be removed.
+-- Alternatively, if nom is integrated into MilMove and nom or the Orders API
+-- gains the ability to authenticate using login.gov, then we should use that
+-- instead for this particular Navy use-case and remove this CAC certificate.
+-- In development, load no new certs. This is just for the real environments.

--- a/migrations/20190404150123_allow_certain_cac_navy_orders.up.fizz
+++ b/migrations/20190404150123_allow_certain_cac_navy_orders.up.fizz
@@ -1,0 +1,1 @@
+exec("./apply-secure-migration.sh 20190404150123_allow_certain_cac_navy_orders.sql")


### PR DESCRIPTION
## Description

This PR is a secure migration to permit a specific CAC certificate to read and write Navy Orders in the Orders API.

## Reviewer Notes

The US Navy is not going to connect to the Orders Gateway directly in the near-term. Instead, they are providing us flat-file exports from their orders database, and we run those flat-file exports through the Navy Orders Muncher (nom) which handles converting the flat file into the appropriate JSON structures and uploading them to the Orders API.

The Orders API uses client certificate authentication. Only certificates signed by a trusted CA (such as DISA) are allowed. As nom is a command-line tool run by a person, using that person's CAC as the certificate is a  convenient way to permit a single trusted individual to upload Orders.

Once the Navy completes their integration between NSIPS and the Orders API, this CAC certificate should be removed.

Alternatively, if nom is integrated into MilMove and nom or the Orders API gains the ability to authenticate using login.gov, then we should use that instead for this particular Navy use-case and remove this CAC certificate.

## Code Review Verification Steps

* Any new migrations/schema changes:
  * [x] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](./docs/database.md#zero-downtime-migrations))
  * [x] Have been communicated to #dp3-engineering
  * [x] Secure migrations have been tested using `scripts/run-prod-migrations`
* [x] Request review from a member of a different team.