### PR TITLE
Lower case email of all office users

### DIFF
--- a/migrations/20190404181226_lowercase_office_users.up.sql
+++ b/migrations/20190404181226_lowercase_office_users.up.sql
@@ -1,0 +1,2 @@
+-- We have a few office_users with e-mail accounts that are mixed case.
+UPDATE office_users SET email = lower(email);


### PR DESCRIPTION
## Description

We had some office users that had mixed-case e-mail addresses in the `office_users` table (set via secure migrations).  Right now, we lower-case the user's input, [but compare against the mixed-case address](https://github.com/transcom/mymove/blob/1c6824bb19a070dfea34749f441a7f0b8e692ba2/pkg/models/office_user.go#L60) in the database.  This migration makes all office user e-mail addresses lower-case for now until we have a longer-term fix.

## Setup

Set a couple of e-mail addresses in your local database to have mixed case, then run `make db_dev_migrate` and verify that they are updated to lower case.
