### PR TITLE
Fix flaky test by clearing all BaseUrl cookies: 164803621

### DIFF
--- a/cypress/integration/mymove/hhgPPM.js
+++ b/cypress/integration/mymove/hhgPPM.js
@@ -307,7 +307,7 @@ function serviceMemberClicksEditMove() {
 }
 
 function serviceMemberSignsIn(uuid) {
-  cy.signInAsUser(uuid);
+  cy.signIntoMyMoveAsUser(uuid);
 }
 
 function serviceMemberAddsPPMToHHG() {

--- a/cypress/integration/mymove/landingPages.js
+++ b/cypress/integration/mymove/landingPages.js
@@ -84,14 +84,14 @@ describe('testing landing pages', function() {
 });
 
 function draftMove(userId) {
-  cy.signInAsUser(userId);
+  cy.signIntoMyMoveAsUser(userId);
   cy.contains('Move to be scheduled');
   cy.contains('Next Step: Finish setting up your move');
   cy.logout();
 }
 
 function ppmSubmitted(userId) {
-  cy.signInAsUser(userId);
+  cy.signIntoMyMoveAsUser(userId);
   cy.contains('Move your own stuff (PPM)');
   cy.contains('Next Step: Wait for approval');
   cy.should('not.contain', 'Add PPM (DITY) Move');
@@ -99,7 +99,7 @@ function ppmSubmitted(userId) {
 }
 
 function ppmApproved(userId) {
-  cy.signInAsUser(userId);
+  cy.signIntoMyMoveAsUser(userId);
   cy.contains('Move your own stuff (PPM)');
   cy.contains('Next Step: Get ready to move');
   cy.contains('Next Step: Request payment');
@@ -107,7 +107,7 @@ function ppmApproved(userId) {
 }
 
 function ppmPaymentRequested(userId) {
-  cy.signInAsUser(userId);
+  cy.signIntoMyMoveAsUser(userId);
   cy.contains('Move your own stuff (PPM)');
   cy.contains('Your payment is in review');
   cy.contains('You will receive a notification from your destination PPPO office when it has been reviewed.');
@@ -115,7 +115,7 @@ function ppmPaymentRequested(userId) {
 }
 
 function hhgMoveSummary(userId) {
-  cy.signInAsUser(userId);
+  cy.signIntoMyMoveAsUser(userId);
   cy.contains('Government Movers and Packers (HHG)');
   cy.contains('Next Step: Prepare for move');
   cy.contains('Add PPM (DITY) Move');
@@ -123,14 +123,14 @@ function hhgMoveSummary(userId) {
 }
 
 function hhgDeliveredOrCompletedMoveSummary(userId) {
-  cy.signInAsUser(userId);
+  cy.signIntoMyMoveAsUser(userId);
   cy.contains('Government Movers and Packers (HHG)');
   cy.contains('Next Step: Survey');
   cy.logout();
 }
 
 function canceledMove(userId) {
-  cy.signInAsUser(userId);
+  cy.signIntoMyMoveAsUser(userId);
   cy.contains('New move');
   cy.contains('Start here');
   cy.logout();

--- a/cypress/integration/mymove/orders.js
+++ b/cypress/integration/mymove/orders.js
@@ -1,7 +1,7 @@
 /* global cy*/
 describe('orders entry', function() {
   it('will accept orders information', function() {
-    cy.signInAsUser('feac0e92-66ec-4cab-ad29-538129bf918e');
+    cy.signIntoMyMoveAsUser('feac0e92-66ec-4cab-ad29-538129bf918e');
     cy.contains('New move (from Yuma AFB)');
     cy.contains('No details');
     cy.contains('No documents');

--- a/cypress/integration/mymove/ppm.js
+++ b/cypress/integration/mymove/ppm.js
@@ -3,7 +3,7 @@
 describe('completing the ppm flow', function() {
   it('progresses thru forms', function() {
     //profile@comple.te
-    cy.signInAsUser('13f3949d-0d53-4be4-b1b1-ae4314793f34');
+    cy.signIntoMyMoveAsUser('13f3949d-0d53-4be4-b1b1-ae4314793f34');
     cy.contains('Fort Gordon (from Yuma AFB)');
     cy.get('.whole_box > div > :nth-child(3) > span').contains('10,500 lbs');
     cy.contains('Continue Move Setup').click();
@@ -92,7 +92,7 @@ describe('completing the ppm flow', function() {
 
     cy.logout();
     //profile@comple.te
-    cy.signInAsUser('8e0d7e98-134e-4b28-bdd1-7d6b1ff34f9e');
+    cy.signIntoMyMoveAsUser('8e0d7e98-134e-4b28-bdd1-7d6b1ff34f9e');
     cy.setFeatureFlag('ppmPaymentRequest', '/');
     cy.contains('Fort Gordon (from Yuma AFB)');
     cy.contains('Request Payment').click();
@@ -131,7 +131,7 @@ describe('completing the ppm flow', function() {
 
 describe('editing ppm only move', () => {
   it('sees only details relevant to PPM only move', () => {
-    cy.signInAsUser('e10d5964-c070-49cb-9bd1-eaf9f7348eb6');
+    cy.signIntoMyMoveAsUser('e10d5964-c070-49cb-9bd1-eaf9f7348eb6');
     cy
       .get('.sidebar button')
       .contains('Edit Move')
@@ -145,7 +145,7 @@ describe('editing ppm only move', () => {
 });
 
 function serviceMemberVisitsIntroToPPMPaymentRequest() {
-  cy.signInAsUser('8e0d7e98-134e-4b28-bdd1-7d6b1ff34f9e');
+  cy.signIntoMyMoveAsUser('8e0d7e98-134e-4b28-bdd1-7d6b1ff34f9e');
   cy.contains('Fort Gordon (from Yuma AFB)');
   cy.contains('Request Payment').click();
 

--- a/cypress/integration/mymove/shipment.js
+++ b/cypress/integration/mymove/shipment.js
@@ -4,7 +4,7 @@ describe('shipments', function() {
   describe('completing the hhg flow', function() {
     it('selects hhg and progresses thru form', function() {
       // sm_hhg@example.com
-      cy.signInAsUser('4b389406-9258-4695-a091-0bf97b5a132f');
+      cy.signIntoMyMoveAsUser('4b389406-9258-4695-a091-0bf97b5a132f');
       serviceMemberAddsHHG();
       serviceMemberAddsMoveDates();
       serviceMemberAddsLocations();
@@ -24,7 +24,7 @@ describe('shipments', function() {
       const firstIncompletePage = /^\/moves\/[^/]+\/hhg-weight/;
 
       cy.removeFetch();
-      cy.signInAsUser(serviceMemberId);
+      cy.signIntoMyMoveAsUser(serviceMemberId);
       serviceMemberAddsHHG();
       serviceMemberAddsMoveDates();
       serviceMemberAddsLocations();
@@ -46,7 +46,7 @@ function serviceMemberLogsOutThenContinues(serviceMemberId) {
   // placement of server and route are important
   cy.server();
   cy.route({ url: '**/api/v1/shipments/*' }).as('getShipments');
-  cy.signInAsUser(serviceMemberId);
+  cy.signIntoMyMoveAsUser(serviceMemberId);
   cy.wait('@getShipments');
   cy.contains('Continue Move Setup').click();
 }

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -30,7 +30,6 @@ import { milmoveAppName, officeAppName, tspAppName, longPageLoadTimeout } from '
 
 Cypress.Commands.add('signInAsNewUser', () => {
   // make sure we log out first before sign in
-  cy.logout();
 
   cy.visit('/devlocal-auth/login');
   // should have both our csrf cookie tokens now
@@ -55,7 +54,6 @@ Cypress.Commands.add('signIntoTSP', () => {
 });
 Cypress.Commands.add('signInAsUser', userId => {
   // make sure we log out first before sign in
-  cy.logout();
 
   cy.visit('/devlocal-auth/login');
   // should have both our csrf cookie tokens now

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -33,7 +33,7 @@ Cypress.Commands.add('signInAsNewUser', () => {
 
   Cypress.Cookies.debug(true);
   cy.clearCookies();
-  cy.getCookies().should('be.empty');
+  cy.reload();
 
   cy.visit('/devlocal-auth/login');
   // should have both our csrf cookie tokens now
@@ -66,7 +66,7 @@ Cypress.Commands.add('signIntoTSP', () => {
 Cypress.Commands.add('signInAsUser', userId => {
   // make sure we log out first before sign in
   cy.clearCookies();
-  cy.getCookies().should('be.empty');
+  cy.reload();
 
   cy.visit('/devlocal-auth/login');
   // should have both our csrf cookie tokens now

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -31,29 +31,42 @@ import { milmoveAppName, officeAppName, tspAppName, longPageLoadTimeout } from '
 Cypress.Commands.add('signInAsNewUser', () => {
   // make sure we log out first before sign in
 
+  Cypress.Cookies.debug(true);
+  cy.clearCookies();
+  cy.getCookies().should('be.empty');
+
   cy.visit('/devlocal-auth/login');
   // should have both our csrf cookie tokens now
   cy.getCookie('_gorilla_csrf').should('exist');
   cy.getCookie('masked_gorilla_csrf').should('exist');
   cy.get('button[data-hook="new-user-login"]').click();
+  Cypress.Cookies.debug(false);
 });
 
 Cypress.Commands.add('signIntoMyMoveAsUser', userId => {
+  Cypress.Cookies.debug(true);
   cy.setupBaseUrl(milmoveAppName);
   cy.signInAsUser(userId);
+  Cypress.Cookies.debug(false);
 });
 Cypress.Commands.add('signIntoOffice', () => {
+  Cypress.Cookies.debug(true);
   cy.setupBaseUrl(officeAppName);
   cy.signInAsUser('9bfa91d2-7a0c-4de0-ae02-b8cf8b4b858b');
   cy.waitForReactTableLoad();
+  Cypress.Cookies.debug(false);
 });
 Cypress.Commands.add('signIntoTSP', () => {
+  Cypress.Cookies.debug(true);
   cy.setupBaseUrl(tspAppName);
   cy.signInAsUser('6cd03e5b-bee8-4e97-a340-fecb8f3d5465');
   cy.waitForReactTableLoad();
+  Cypress.Cookies.debug(false);
 });
 Cypress.Commands.add('signInAsUser', userId => {
   // make sure we log out first before sign in
+  cy.clearCookies();
+  cy.getCookies().should('be.empty');
 
   cy.visit('/devlocal-auth/login');
   // should have both our csrf cookie tokens now

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -29,7 +29,7 @@ import { milmoveAppName, officeAppName, tspAppName, longPageLoadTimeout } from '
 // Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
 
 Cypress.Commands.add('signInAsNewUser', () => {
-  cy.clearAllCookies(milmoveAppName);
+  cy.setBaseUrlAndClearAllCookies(milmoveAppName);
 
   cy.visit('/devlocal-auth/login');
   // should have both our csrf cookie tokens now
@@ -39,16 +39,16 @@ Cypress.Commands.add('signInAsNewUser', () => {
 });
 
 Cypress.Commands.add('signIntoMyMoveAsUser', userId => {
-  cy.clearAllCookies(milmoveAppName);
+  cy.setBaseUrlAndClearAllCookies(milmoveAppName);
   cy.signInAsUser(userId);
 });
 Cypress.Commands.add('signIntoOffice', () => {
-  cy.clearAllCookies(officeAppName);
+  cy.setBaseUrlAndClearAllCookies(officeAppName);
   cy.signInAsUser('9bfa91d2-7a0c-4de0-ae02-b8cf8b4b858b');
   cy.waitForReactTableLoad();
 });
 Cypress.Commands.add('signIntoTSP', () => {
-  cy.clearAllCookies(tspAppName);
+  cy.setBaseUrlAndClearAllCookies(tspAppName);
   cy.signInAsUser('6cd03e5b-bee8-4e97-a340-fecb8f3d5465');
   cy.waitForReactTableLoad();
 });
@@ -193,7 +193,7 @@ Cypress.Commands.add('logout', () => {
   });
 });
 
-Cypress.Commands.add('clearAllCookies', baseUrl => {
+Cypress.Commands.add('setBaseUrlAndClearAllCookies', baseUrl => {
   cy.setupBaseUrl(baseUrl);
   cy.visit('/');
   Cypress.config('baseUrl', 'http://milmovelocal:4000');

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -30,6 +30,7 @@ import { milmoveAppName, officeAppName, tspAppName, longPageLoadTimeout } from '
 
 Cypress.Commands.add('signInAsNewUser', () => {
   Cypress.Cookies.debug(true);
+  cy.visit('/');
   cy.clearAllCookies();
 
   cy.visit('/devlocal-auth/login');
@@ -42,6 +43,7 @@ Cypress.Commands.add('signInAsNewUser', () => {
 
 Cypress.Commands.add('signIntoMyMoveAsUser', userId => {
   Cypress.Cookies.debug(true);
+  cy.visit('/');
   cy.clearAllCookies();
   cy.setupBaseUrl(milmoveAppName);
   cy.signInAsUser(userId);
@@ -49,6 +51,7 @@ Cypress.Commands.add('signIntoMyMoveAsUser', userId => {
 });
 Cypress.Commands.add('signIntoOffice', () => {
   Cypress.Cookies.debug(true);
+  cy.visit('/');
   cy.clearAllCookies();
   cy.setupBaseUrl(officeAppName);
   cy.signInAsUser('9bfa91d2-7a0c-4de0-ae02-b8cf8b4b858b');
@@ -57,6 +60,7 @@ Cypress.Commands.add('signIntoOffice', () => {
 });
 Cypress.Commands.add('signIntoTSP', () => {
   Cypress.Cookies.debug(true);
+  cy.visit('/');
   cy.clearAllCookies();
   cy.setupBaseUrl(tspAppName);
   cy.signInAsUser('6cd03e5b-bee8-4e97-a340-fecb8f3d5465');

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -45,10 +45,10 @@ Cypress.Commands.add('signInAsNewUser', () => {
 
 Cypress.Commands.add('signIntoMyMoveAsUser', userId => {
   Cypress.Cookies.debug(true);
+  cy.setupBaseUrl(milmoveAppName);
   cy.visit('/');
   cy.clearAllCookies();
   cy.setupBaseUrl(milmoveAppName);
-  cy.visit('/');
   cy.signInAsUser(userId);
   Cypress.Cookies.debug(false);
 });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -30,8 +30,10 @@ import { milmoveAppName, officeAppName, tspAppName, longPageLoadTimeout } from '
 
 Cypress.Commands.add('signInAsNewUser', () => {
   Cypress.Cookies.debug(true);
+  cy.setupBaseUrl(milmoveAppName);
   cy.visit('/');
   cy.clearAllCookies();
+  cy.setupBaseUrl(milmoveAppName);
 
   cy.visit('/devlocal-auth/login');
   // should have both our csrf cookie tokens now
@@ -46,11 +48,13 @@ Cypress.Commands.add('signIntoMyMoveAsUser', userId => {
   cy.visit('/');
   cy.clearAllCookies();
   cy.setupBaseUrl(milmoveAppName);
+  cy.visit('/');
   cy.signInAsUser(userId);
   Cypress.Cookies.debug(false);
 });
 Cypress.Commands.add('signIntoOffice', () => {
   Cypress.Cookies.debug(true);
+  cy.setupBaseUrl(officeAppName);
   cy.visit('/');
   cy.clearAllCookies();
   cy.setupBaseUrl(officeAppName);
@@ -60,6 +64,7 @@ Cypress.Commands.add('signIntoOffice', () => {
 });
 Cypress.Commands.add('signIntoTSP', () => {
   Cypress.Cookies.debug(true);
+  cy.setupBaseUrl(tspAppName);
   cy.visit('/');
   cy.clearAllCookies();
   cy.setupBaseUrl(tspAppName);

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -29,48 +29,28 @@ import { milmoveAppName, officeAppName, tspAppName, longPageLoadTimeout } from '
 // Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
 
 Cypress.Commands.add('signInAsNewUser', () => {
-  Cypress.Cookies.debug(true);
-  cy.setupBaseUrl(milmoveAppName);
-  cy.visit('/');
-  cy.clearAllCookies();
-  cy.setupBaseUrl(milmoveAppName);
+  cy.clearAllCookies(milmoveAppName);
 
   cy.visit('/devlocal-auth/login');
   // should have both our csrf cookie tokens now
   cy.getCookie('_gorilla_csrf').should('exist');
   cy.getCookie('masked_gorilla_csrf').should('exist');
   cy.get('button[data-hook="new-user-login"]').click();
-  Cypress.Cookies.debug(false);
 });
 
 Cypress.Commands.add('signIntoMyMoveAsUser', userId => {
-  Cypress.Cookies.debug(true);
-  cy.setupBaseUrl(milmoveAppName);
-  cy.visit('/');
-  cy.clearAllCookies();
-  cy.setupBaseUrl(milmoveAppName);
+  cy.clearAllCookies(milmoveAppName);
   cy.signInAsUser(userId);
-  Cypress.Cookies.debug(false);
 });
 Cypress.Commands.add('signIntoOffice', () => {
-  Cypress.Cookies.debug(true);
-  cy.setupBaseUrl(officeAppName);
-  cy.visit('/');
-  cy.clearAllCookies();
-  cy.setupBaseUrl(officeAppName);
+  cy.clearAllCookies(officeAppName);
   cy.signInAsUser('9bfa91d2-7a0c-4de0-ae02-b8cf8b4b858b');
   cy.waitForReactTableLoad();
-  Cypress.Cookies.debug(false);
 });
 Cypress.Commands.add('signIntoTSP', () => {
-  Cypress.Cookies.debug(true);
-  cy.setupBaseUrl(tspAppName);
-  cy.visit('/');
-  cy.clearAllCookies();
-  cy.setupBaseUrl(tspAppName);
+  cy.clearAllCookies(tspAppName);
   cy.signInAsUser('6cd03e5b-bee8-4e97-a340-fecb8f3d5465');
   cy.waitForReactTableLoad();
-  Cypress.Cookies.debug(false);
 });
 Cypress.Commands.add('signInAsUser', userId => {
   cy.visit('/devlocal-auth/login');
@@ -213,13 +193,16 @@ Cypress.Commands.add('logout', () => {
   });
 });
 
-Cypress.Commands.add('clearAllCookies', () => {
+Cypress.Commands.add('clearAllCookies', baseUrl => {
+  cy.setupBaseUrl(baseUrl);
+  cy.visit('/');
   Cypress.config('baseUrl', 'http://milmovelocal:4000');
   cy.clearCookies();
   Cypress.config('baseUrl', 'http://officelocal:4000');
   cy.clearCookies();
   Cypress.config('baseUrl', 'http://tsplocal:4000');
   cy.clearCookies();
+  cy.setupBaseUrl(baseUrl);
 });
 
 Cypress.Commands.add('nextPage', () => {

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -29,11 +29,8 @@ import { milmoveAppName, officeAppName, tspAppName, longPageLoadTimeout } from '
 // Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
 
 Cypress.Commands.add('signInAsNewUser', () => {
-  // make sure we log out first before sign in
-
   Cypress.Cookies.debug(true);
-  cy.clearCookies();
-  cy.reload();
+  cy.clearAllCookies();
 
   cy.visit('/devlocal-auth/login');
   // should have both our csrf cookie tokens now
@@ -45,12 +42,14 @@ Cypress.Commands.add('signInAsNewUser', () => {
 
 Cypress.Commands.add('signIntoMyMoveAsUser', userId => {
   Cypress.Cookies.debug(true);
+  cy.clearAllCookies();
   cy.setupBaseUrl(milmoveAppName);
   cy.signInAsUser(userId);
   Cypress.Cookies.debug(false);
 });
 Cypress.Commands.add('signIntoOffice', () => {
   Cypress.Cookies.debug(true);
+  cy.clearAllCookies();
   cy.setupBaseUrl(officeAppName);
   cy.signInAsUser('9bfa91d2-7a0c-4de0-ae02-b8cf8b4b858b');
   cy.waitForReactTableLoad();
@@ -58,16 +57,13 @@ Cypress.Commands.add('signIntoOffice', () => {
 });
 Cypress.Commands.add('signIntoTSP', () => {
   Cypress.Cookies.debug(true);
+  cy.clearAllCookies();
   cy.setupBaseUrl(tspAppName);
   cy.signInAsUser('6cd03e5b-bee8-4e97-a340-fecb8f3d5465');
   cy.waitForReactTableLoad();
   Cypress.Cookies.debug(false);
 });
 Cypress.Commands.add('signInAsUser', userId => {
-  // make sure we log out first before sign in
-  cy.clearCookies();
-  cy.reload();
-
   cy.visit('/devlocal-auth/login');
   // should have both our csrf cookie tokens now
   cy.getCookie('_gorilla_csrf').should('exist');
@@ -206,6 +202,15 @@ Cypress.Commands.add('logout', () => {
     // In case of login redirect we once more go to the homepage
     cy.patientVisit('/');
   });
+});
+
+Cypress.Commands.add('clearAllCookies', () => {
+  Cypress.config('baseUrl', 'http://milmovelocal:4000');
+  cy.clearCookies();
+  Cypress.config('baseUrl', 'http://officelocal:4000');
+  cy.clearCookies();
+  Cypress.config('baseUrl', 'http://tsplocal:4000');
+  cy.clearCookies();
 });
 
 Cypress.Commands.add('nextPage', () => {

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -203,6 +203,7 @@ Cypress.Commands.add('clearAllCookies', baseUrl => {
   Cypress.config('baseUrl', 'http://tsplocal:4000');
   cy.clearCookies();
   cy.setupBaseUrl(baseUrl);
+  cy.visit('/');
 });
 
 Cypress.Commands.add('nextPage', () => {

--- a/pkg/auth/authentication/devlocal.go
+++ b/pkg/auth/authentication/devlocal.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gobuffalo/pop"
 	"github.com/gofrs/uuid"
+	"github.com/gorilla/csrf"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
 
@@ -48,14 +49,8 @@ func (h UserListHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Grab the CSRF token from cookies set by the middleware
-	csrfCookie, err := auth.GetCookie(auth.MaskedGorillaCSRFToken, r)
-	if err != nil {
-		h.logger.Error("CSRF Cookie was not set via middleware")
-		http.Error(w, http.StatusText(500), http.StatusInternalServerError)
-		return
-	}
-	csrfToken := csrfCookie.Value
+	// Generate a CSRF token
+	csrfToken := csrf.Token(r)
 
 	t := template.Must(template.New("users").Parse(`
 		<h1>Select an existing user</h1>


### PR DESCRIPTION
## Description

Fix flaky failing e2e tests:  "expecting to find" button: https://www.pivotaltracker.com/story/show/164803621

## Reviewer Notes

Our e2e tests are very flaky and keep failing. We tracked this down to the app trying to hit the login page, but we're still logged in so the app doesn't find the local user sign in button because we see the queues page.

This is due to cypress not clearing cookies when setting multiple `BaseUrl`. This calls `cy.clearCookies()` for each `BaseUrl` which should clear up any lingering cookies that keep us logged in.

## Setup

Should pass `CircleCI` `e2e` tests...

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/164803621) for this change
* [this article](https://github.com/cypress-io/cypress/issues/781#issuecomment-479519645) explains more about the approach used.
