### PR TITLE
Bug fix - allow 35A legacy invoices: 165099148

### DIFF
--- a/pkg/services/invoice/fetch_invoice_for_shipment_test.go
+++ b/pkg/services/invoice/fetch_invoice_for_shipment_test.go
@@ -115,13 +115,12 @@ func (suite *InvoiceServiceSuite) TestFetchInvoiceWith35AValid() {
 
 func (suite *InvoiceServiceSuite) TestFetchInvoiceWith35AInvalid() {
 	shipment := makeShipment(suite.DB())
-	lineItem := makeLineItem35A(suite.DB(), shipment, false)
+	_ = makeLineItem35A(suite.DB(), shipment, false)
 
 	f := FetchShipmentForInvoice{suite.DB()}
 	actualShipment, err := f.Call(shipment.ID)
 	suite.NoError(err)
 	suite.Equal(0, len(actualShipment.ShipmentLineItems))
-	suite.Nil(lineItem)
 }
 
 func (suite *InvoiceServiceSuite) TestFetchInvoiceWith35ALegacy() {

--- a/src/shared/Invoice/LineItemTable.jsx
+++ b/src/shared/Invoice/LineItemTable.jsx
@@ -1,5 +1,7 @@
 import React, { PureComponent } from 'react';
+import { get } from 'lodash';
 import PropTypes from 'prop-types';
+import { withContext } from 'shared/AppContext';
 
 import { formatCents } from 'shared/formatters';
 import { displayBaseQuantityUnits } from 'shared/lineItems';
@@ -8,7 +10,7 @@ import './InvoicePanel.css';
 
 class LineItemTable extends PureComponent {
   render() {
-    const showItem35Missing = item => item.tariff400ng_item.code === '35A' && 'actual_amount_cents' in item === false;
+    const showItem35Missing = item => isRobust35A(item, this.props);
     return (
       <div>
         {this.props.title}
@@ -60,4 +62,14 @@ LineItemTable.propTypes = {
   totalAmount: PropTypes.number,
 };
 
-export default LineItemTable;
+function isRobust35A(item, props) {
+  const robustAccessorialFlag = get(props, 'context.flags.robustAccessorial', false);
+  return (
+    robustAccessorialFlag &&
+    item.tariff400ng_item.code === '35A' &&
+    item.estimate_amount_cents &&
+    !item.actual_amount_cents
+  );
+}
+
+export default withContext(LineItemTable);

--- a/src/shared/Invoice/LineItemTable.jsx
+++ b/src/shared/Invoice/LineItemTable.jsx
@@ -10,7 +10,16 @@ import './InvoicePanel.css';
 
 class LineItemTable extends PureComponent {
   render() {
-    const showItem35Missing = item => isRobust35A(item, this.props);
+    const showItem35Missing = item => {
+      const robustAccessorialFlag = get(this.props, 'context.flags.robustAccessorial', false);
+      return (
+        robustAccessorialFlag &&
+        item.tariff400ng_item.code === '35A' &&
+        item.estimate_amount_cents &&
+        !item.actual_amount_cents
+      );
+    };
+
     return (
       <div>
         {this.props.title}
@@ -61,15 +70,5 @@ LineItemTable.propTypes = {
   shipmentLineItems: PropTypes.array,
   totalAmount: PropTypes.number,
 };
-
-function isRobust35A(item, props) {
-  const robustAccessorialFlag = get(props, 'context.flags.robustAccessorial', false);
-  return (
-    robustAccessorialFlag &&
-    item.tariff400ng_item.code === '35A' &&
-    item.estimate_amount_cents &&
-    !item.actual_amount_cents
-  );
-}
 
 export default withContext(LineItemTable);

--- a/src/shared/Invoice/LineItemTable.test.js
+++ b/src/shared/Invoice/LineItemTable.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { mount } from 'enzyme';
 import LineItemTable from './LineItemTable';
 
 describe('LineItemTable tests', () => {
@@ -23,7 +23,7 @@ describe('LineItemTable tests', () => {
 
   describe('When shipmentLineItems exist', () => {
     it('renders without crashing', () => {
-      wrapper = shallow(
+      wrapper = mount(
         <LineItemTable shipmentLineItems={shipmentLineItems} totalAmount={10} shipmentStatus="delivered" />,
       );
       expect(wrapper.find('table').length).toEqual(1);

--- a/src/shared/Invoice/UnbilledTable.test.js
+++ b/src/shared/Invoice/UnbilledTable.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { mount } from 'enzyme';
 import { UnbilledTable } from './UnbilledTable';
 import * as CONSTANTS from 'shared/constants.js';
 import { no_op } from 'shared/utils.js';
@@ -29,7 +29,7 @@ describe('UnbilledTable tests', () => {
 
   describe('When shipmentLineItems exist', () => {
     it('renders without crashing', () => {
-      wrapper = shallow(
+      wrapper = mount(
         <UnbilledTable
           lineItems={shipmentLineItems}
           lineItemsTotal={10}
@@ -45,7 +45,7 @@ describe('UnbilledTable tests', () => {
     });
 
     it('displays payment confirmation', () => {
-      wrapper = shallow(
+      wrapper = mount(
         <UnbilledTable
           lineItems={shipmentLineItems}
           lineItemsTotal={10}


### PR DESCRIPTION
## Description

Update logic to allow legacy 35A items to be invoiced.

This [pr](https://github.com/transcom/mymove/pull/1898) required robust `35A` items must have a value in `actual_amount`, which is what we want for the robust `35A`, but we want to still allow legacy `35A` items to be invoiced. 

## Reviewer Notes

Ensure `35A` robust and `35A` legacy items are invoiced as expected.

## Setup

`make db_dev_e2e_populate`
`make server_run`
`make office_client_run`

Add `?flag:robustAccessorial=false` to the url and reload and add a legacy `35A` item.
Add remove `?flag:robustAccessorial=false` from the url and add a robust `35A` item with `actual amount of service`.
Add another robust `35A` item without a value in `Actual amount of service`

Approve the items...
Click `Approve payment`

Ensure the legacy `35A` item and the robust `35A` item with `actual amount` are invoiced...
Ensure the robust `35A` item w/o the `actual amount` is not invoiced...

## Code Review Verification Steps
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/165099148) for this change

## Screenshots

![35A invoicing](https://user-images.githubusercontent.com/3099491/55653392-f4d6ef80-57b3-11e9-84d8-d10e900819f8.gif)
