### PR TITLE
Fix script for uploading migrations to actually test running the migrations

### DIFF
--- a/scripts/upload-secure-migration
+++ b/scripts/upload-secure-migration
@@ -58,15 +58,11 @@ ${aws_command} s3 ls "${aws_bucket_prefix}${environments[0]}${aws_bucket_suffix}
 # Test local migration
 #
 
-proceed "Testing local migration. This will involve resetting your local dev database. Proceed?"
-run make db_dev_reset
-run make db_dev_migrate || (
-  echo "error: test migrations failed!"
-  echo "Run 'make db_dev_migrate' to see errors."
-  exit 1
-  )
+echo "Testing migrations ... (This could be several minutes!)"
 
-echo "Test migrations successful!"
+run make run_prod_migrations
+
+echo "Testing migrations was successful!"
 echo
 
 #

--- a/scripts/upload-secure-migration
+++ b/scripts/upload-secure-migration
@@ -17,7 +17,7 @@ readonly usage="usage: $0 <production_migration_file>"
 
 function proceed() {
   proceed_message=${1:-"proceed"}
-  echo -n "${proceed_message} (y/N) "
+  echo -en "\e[31m${proceed_message} (y/N) \e[39m"
   read -r proceed
   if [[ "$proceed" =~ ^[^yY]*$ ]]; then
     echo "exiting"
@@ -68,6 +68,8 @@ echo
 #
 # Upload secure migration
 #
+
+proceed "Are you ready to upload the migrations? This will overwrite files of the same name in S3."
 
 for environment in "${environments[@]}"; do
   echo "Uploading to: $environment"

--- a/scripts/upload-secure-migration
+++ b/scripts/upload-secure-migration
@@ -60,7 +60,7 @@ ${aws_command} s3 ls "${aws_bucket_prefix}${environments[0]}${aws_bucket_suffix}
 
 echo "Testing migrations ... (This could be several minutes!)"
 
-run make run_prod_migrations
+make run_prod_migrations
 
 echo "Testing migrations was successful!"
 echo


### PR DESCRIPTION
## Description

This script was always supposed to check migrations on your behalf. Unfortunately I changed the make targets for prod migrations and this broke, meaning most people making migrations weren't testing before pushing these up.  This fixes the script. It also adds one last manual check before upload to ensure you want to do the upload.

## Setup

If you want to run this locally just download a file and re-upload that same file:

```
download-secure-migration 20190405161919_remove-patrick-s.sql
cp tmp/secure_migrations/prod/20190405161919_remove-patrick-s.sql .
upload-secure-migration 20190405161919_remove-patrick-s.sql
```