### PR TITLE
added verbose flag when executing go get -u=patch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -146,7 +146,7 @@ admin_client_run: client_deps
 
 .PHONY: go_deps_update
 go_deps_update:
-	go get -u=patch
+	go get -u=patch -v
 	go mod tidy
 
 .PHONY: check_gopath


### PR DESCRIPTION
## Description

`go_deps_update` will now execute `get get -u=patch` with `-v` aka verbose flag so we can debug and fix dependency updating issues faster.

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make go_deps_update
```

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/165189583) for this change
