### PR TITLE
Office queue default sort

### DIFF
--- a/pkg/testdatagen/scenario/e2ebasic.go
+++ b/pkg/testdatagen/scenario/e2ebasic.go
@@ -1075,7 +1075,8 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, log
 			CodeOfService:     "D",
 		},
 		Shipment: models.Shipment{
-			Status: models.ShipmentStatusDELIVERED,
+			Status:           models.ShipmentStatusDELIVERED,
+			ActualPickupDate: &nextValidMoveDateMinusFive,
 		},
 		ShipmentOffer: models.ShipmentOffer{
 			TransportationServiceProviderID: tspUser.TransportationServiceProviderID,
@@ -1116,7 +1117,8 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, log
 			CodeOfService:     "D",
 		},
 		Shipment: models.Shipment{
-			Status: models.ShipmentStatusCOMPLETED,
+			Status:           models.ShipmentStatusCOMPLETED,
+			ActualPickupDate: &nextValidMoveDateMinusFive,
 		},
 		ShipmentOffer: models.ShipmentOffer{
 			TransportationServiceProviderID: tspUser.TransportationServiceProviderID,
@@ -1164,7 +1166,8 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, log
 			CodeOfService:     "D",
 		},
 		Shipment: models.Shipment{
-			Status: models.ShipmentStatusDELIVERED,
+			Status:           models.ShipmentStatusDELIVERED,
+			ActualPickupDate: &nextValidMoveDateMinusFive,
 		},
 		ShipmentOffer: models.ShipmentOffer{
 			TransportationServiceProviderID: tspUser.TransportationServiceProviderID,

--- a/src/scenes/Office/QueueTable.jsx
+++ b/src/scenes/Office/QueueTable.jsx
@@ -136,6 +136,7 @@ class QueueTable extends Component {
             ]}
             data={this.state.data}
             loading={this.state.loading} // Display the loading overlay when we need it
+            defaultSorted={[{ id: 'move_date', asc: true }]}
             pageSize={this.state.data.length}
             className="-striped -highlight"
             showPagination={false}


### PR DESCRIPTION
## Description

As an Office User
I want to easily see pertinent information about moves
So that it is easy to select the move I want to focus on

## Reviewer Notes

I added some references to `ActualPickupDate` in `e2e_basic.go` in order for moves that I would expect to have a `move_date` in the queue table to actually have one. Let me know if what I added doesn't make sense.

## Setup

1. Run `make db_dev_e2e_populate`
2. Check the office queue for default sort by Move Date ascending

## Code Review Verification Steps

* [x] User facing changes have been reviewed by design.
* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/n/projects/2136867) for this change
