### PR TITLE
WIP: testing

### DIFF
--- a/pkg/models/shipment.go
+++ b/pkg/models/shipment.go
@@ -56,6 +56,15 @@ var (
 	}
 )
 
+var (
+	// ShipmentsAssociationsDefault declares the default eager associations for shipments
+	ShipmentsAssociationsDefault = EagerAssociations{
+		"TrafficDistributionList",
+		"ServiceMember",
+		"Move",
+	}
+)
+
 // Shipment represents a single shipment within a Service Member's move.
 type Shipment struct {
 	ID               uuid.UUID      `json:"id" db:"id"`
@@ -586,7 +595,7 @@ func FetchShipmentsByTSP(tx *pop.Connection, tspID uuid.UUID, status []string, o
 
 	shipments := []Shipment{}
 
-	query := tx.Q().Eager(ShipmentAssociationsDEFAULT...).
+	query := tx.Q().Eager(ShipmentsAssociationsDefault...).
 		Where("shipment_offers.transportation_service_provider_id = $1", tspID).
 		LeftJoin("shipment_offers", "shipments.id=shipment_offers.shipment_id")
 

--- a/pkg/models/shipment.go
+++ b/pkg/models/shipment.go
@@ -57,8 +57,8 @@ var (
 )
 
 var (
-	// ShipmentsAssociationsDefault declares the default eager associations for shipments
-	ShipmentsAssociationsDefault = EagerAssociations{
+	// ShipmentsAssociationsDEFAULT declares the default eager associations for shipments
+	ShipmentsAssociationsDEFAULT = EagerAssociations{
 		"TrafficDistributionList",
 		"ServiceMember",
 		"Move",
@@ -595,7 +595,7 @@ func FetchShipmentsByTSP(tx *pop.Connection, tspID uuid.UUID, status []string, o
 
 	shipments := []Shipment{}
 
-	query := tx.Q().Eager(ShipmentsAssociationsDefault...).
+	query := tx.Q().Eager(ShipmentsAssociationsDEFAULT...).
 		Where("shipment_offers.transportation_service_provider_id = $1", tspID).
 		LeftJoin("shipment_offers", "shipments.id=shipment_offers.shipment_id")
 

--- a/pkg/models/shipment.go
+++ b/pkg/models/shipment.go
@@ -40,8 +40,8 @@ const (
 )
 
 var (
-	// ShipmentAssociationsDEFAULT declares the default eager associations for a shipment
-	ShipmentAssociationsDEFAULT = EagerAssociations{
+	// ShipmentAssociationsDefault declares the default eager associations for a shipment
+	ShipmentAssociationsDefault = EagerAssociations{
 		"TrafficDistributionList",
 		"ServiceMember.BackupContacts",
 		"Move.Orders.NewDutyStation.Address",
@@ -57,8 +57,8 @@ var (
 )
 
 var (
-	// ShipmentsAssociationsDEFAULT declares the default eager associations for shipments
-	ShipmentsAssociationsDEFAULT = EagerAssociations{
+	// ShipmentListAssociationsDefault declares the default eager associations for shipments
+	ShipmentListAssociationsDefault = EagerAssociations{
 		"TrafficDistributionList",
 		"ServiceMember",
 		"Move",
@@ -595,7 +595,7 @@ func FetchShipmentsByTSP(tx *pop.Connection, tspID uuid.UUID, status []string, o
 
 	shipments := []Shipment{}
 
-	query := tx.Q().Eager(ShipmentsAssociationsDEFAULT...).
+	query := tx.Q().Eager(ShipmentListAssociationsDefault...).
 		Where("shipment_offers.transportation_service_provider_id = $1", tspID).
 		LeftJoin("shipment_offers", "shipments.id=shipment_offers.shipment_id")
 
@@ -635,7 +635,7 @@ func FetchShipmentsByTSP(tx *pop.Connection, tspID uuid.UUID, status []string, o
 // FetchShipment Fetches and Validates a Shipment model
 func FetchShipment(db *pop.Connection, session *auth.Session, id uuid.UUID) (*Shipment, error) {
 	var shipment Shipment
-	err := db.Eager(ShipmentAssociationsDEFAULT...).Find(&shipment, id)
+	err := db.Eager(ShipmentAssociationsDefault...).Find(&shipment, id)
 
 	if err != nil {
 		if errors.Cause(err).Error() == recordNotFoundErrorString {
@@ -661,7 +661,7 @@ func FetchShipmentByTSP(tx *pop.Connection, tspID uuid.UUID, shipmentID uuid.UUI
 
 	shipments := []Shipment{}
 
-	err := tx.Eager(ShipmentAssociationsDEFAULT...).
+	err := tx.Eager(ShipmentAssociationsDefault...).
 		Where("shipment_offers.transportation_service_provider_id = $1 and shipments.id = $2", tspID, shipmentID).
 		LeftJoin("shipment_offers", "shipments.id=shipment_offers.shipment_id").
 		All(&shipments)


### PR DESCRIPTION
TESTING: DO NOT MERGE


## Description

Explain a little about the changes at a high level.

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
echo "Code goes here"
```

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](./docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](./docs/backend.md#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](./docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
  * [ ] Secure migrations have been tested using `scripts/run-prod-migrations`
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers](./docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @ntwyman
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](tbd) for this change
* [this article](tbd) explains more about the approach used.

## Screenshots

If this PR makes visible UI changes, an image of the finished UI can help reviewers and casual
observers understand the context of the changes. A before image is optional and
can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow instead of using multiple images. You may want to use GIPHY CAPTURE for this! 📸

_Please frame screenshots to show enough useful context but also highlight the affected regions._
