### PR TITLE
Remove scrollable queue table div to get rid of gray bar.

### DIFF
--- a/src/scenes/Office/index.jsx
+++ b/src/scenes/Office/index.jsx
@@ -29,9 +29,7 @@ class Queues extends Component {
           <QueueList />
         </div>
         <div className="queue-list-column">
-          <div className="queue-table-scrollable">
-            <QueueTable queueType={this.props.match.params.queueType} />
-          </div>
+          <QueueTable queueType={this.props.match.params.queueType} />
         </div>
       </div>
     );

--- a/src/scenes/Office/office.css
+++ b/src/scenes/Office/office.css
@@ -4,10 +4,6 @@
   margin-bottom: 4em;
 }
 
-.queue-table-scrollable {
-  overflow-x: scroll;
-}
-
 .fake-link {
   text-decoration: underline;
   color: blue;

--- a/src/scenes/TransportationServiceProvider/index.jsx
+++ b/src/scenes/TransportationServiceProvider/index.jsx
@@ -29,9 +29,7 @@ class Queues extends Component {
           <QueueList />
         </div>
         <div className="queue-list-column">
-          <div className="queue-table-scrollable">
-            <QueueTable queueType={this.props.match.params.queueType} />
-          </div>
+          <QueueTable queueType={this.props.match.params.queueType} />
         </div>
       </div>
     );


### PR DESCRIPTION
## Description

Removes the gray bar that was leftover from the old pagination controls.

## Setup

- Visit the office or tsp queue.

## Code Review Verification Steps

* [x] User facing changes have been reviewed by design.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/165157738) for this change

## Screenshots

<img width="1458" alt="Screen Shot 2019-04-09 at 09 59 46" src="https://user-images.githubusercontent.com/3522323/55811105-3adecc80-5aae-11e9-95a5-03789db7248f.png">
