### PR TITLE
Remove duplicate cancel move and approval buttons on office app

### DIFF
--- a/cypress/integration/office/officeUserHHG.js
+++ b/cypress/integration/office/officeUserHHG.js
@@ -219,11 +219,5 @@ function officeUserApprovesHHG() {
     .contains('Approve HHG')
     .click();
 
-  // Disabled because already approved and not delivered
-  cy
-    .get('button')
-    .contains('Approve HHG')
-    .should('be.disabled');
-
   cy.get('.status').contains('Approved');
 }

--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -280,12 +280,9 @@ class MoveInfo extends Component {
     const isPPM = move.selected_move_type === 'PPM';
     const isHHG = move.selected_move_type === 'HHG';
     const isHHGPPM = move.selected_move_type === 'HHG_PPM';
-    const pathnames = this.props.location.pathname.split('/');
-    const currentTab = pathnames[pathnames.length - 1];
     const showDocumentViewer = this.props.context.flags.documentViewer;
     const moveInfoComboButton = this.props.context.flags.moveInfoComboButton;
     const allowHhgInvoicePayment = this.props.context.flags.allowHhgInvoicePayment;
-    const check = <FontAwesomeIcon className="icon" icon={faCheck} />;
     const ordersComplete = Boolean(
       orders.orders_number && orders.orders_type_detail && orders.department_indicator && orders.tac,
     );
@@ -463,45 +460,6 @@ class MoveInfo extends Component {
                   buttonDisabled={hhgCantBeCanceled}
                 />
               </div>
-
-              {(isPPM || isHHGPPM) && (
-                <button
-                  className={`${ppmApproved ? 'btn__approve--green' : ''}`}
-                  onClick={this.approvePPM}
-                  disabled={ppmApproved || !moveApproved || !ordersComplete}
-                >
-                  Approve PPM
-                  {ppmApproved && check}
-                </button>
-              )}
-
-              {(isHHG || isHHGPPM) && (
-                <button
-                  className={`${hhgApproved ? 'btn__approve--green' : ''}`}
-                  onClick={this.approveShipment}
-                  disabled={
-                    !hhgAccepted ||
-                    hhgApproved ||
-                    hhgCompleted ||
-                    !moveApproved ||
-                    !ordersComplete ||
-                    currentTab !== 'hhg'
-                  }
-                >
-                  Approve HHG
-                  {hhgApproved && check}
-                </button>
-              )}
-              <ConfirmWithReasonButton
-                buttonTitle="Cancel Move"
-                reasonPrompt="Why is the move being canceled?"
-                warningPrompt="Are you sure you want to cancel the entire move?"
-                onConfirm={this.cancelMoveAndRedirect}
-                buttonDisabled={hhgCantBeCanceled}
-              />
-              {/* Disabling until features implemented
-              <button>Troubleshoot</button>
-              */}
             </div>
             <div className="documents">
               <h2 className="extras usa-heading">


### PR DESCRIPTION
## Description

Remove duplicate cancel move and approval buttons on office app

## Reviewer Notes
- a merge conflict at some point added them back in

## Setup
`make office_client_run`
`make server_run`

## Code Review Verification Steps
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/165219559) for this change

## Screenshots

![image](https://user-images.githubusercontent.com/13622298/55819768-04727300-5ae9-11e9-8f83-2a1dc97b5e19.png)
