### PR TITLE
Remove duplicate success messages for completion of PPM setup

### DIFF
--- a/cypress/integration/mymove/ppm.js
+++ b/cypress/integration/mymove/ppm.js
@@ -75,7 +75,7 @@ describe('completing the ppm flow', function() {
       expect(loc.pathname).to.match(/^\/$/);
     });
 
-    cy.contains('Success');
+    cy.contains('Congrats - your move is submitted!');
     cy.contains('Next Step: Wait for approval');
     cy.contains('Advance Requested: $1,333.91');
   });

--- a/src/scenes/Landing/index.jsx
+++ b/src/scenes/Landing/index.jsx
@@ -119,11 +119,12 @@ export class Landing extends Component {
         {loggedInUserSuccess && (
           <Fragment>
             <div>
-              {moveSubmitSuccess && (
-                <Alert type="success" heading="Success">
-                  You've submitted your move
-                </Alert>
-              )}
+              {moveSubmitSuccess &&
+                !ppm && (
+                  <Alert type="success" heading="Success">
+                    You've submitted your move
+                  </Alert>
+                )}
               {isHHGPPMComboMove &&
                 hasSubmitSuccess && (
                   <Alert type="success" heading="You've added a PPM shipment">


### PR DESCRIPTION
## Description

Only have one success message for completion of PPM setup

## Setup
`make server_run`
`make client_run`
Set up a PPM

## Code Review Verification Steps
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/165095730) for this change

## Screenshots

![image](https://user-images.githubusercontent.com/13622298/55821354-d42cd380-5aec-11e9-8cbb-8e0982bd65c4.png)
