### PR TITLE
Show all expenses regardless of status shipment summary worksheet

### DIFF
--- a/pkg/handlers/internalapi/personally_procured_move.go
+++ b/pkg/handlers/internalapi/personally_procured_move.go
@@ -540,7 +540,8 @@ func (h RequestPPMExpenseSummaryHandler) Handle(params ppmop.RequestPPMExpenseSu
 	ppmID, _ := uuid.FromString(params.PersonallyProcuredMoveID.String())
 
 	// Fetch all approved expense documents for a PPM
-	moveDocsExpense, err := models.FetchApprovedMovingExpenseDocuments(h.DB(), session, ppmID)
+	status := models.MoveDocumentStatusOK
+	moveDocsExpense, err := models.FetchMovingExpenseDocuments(h.DB(), session, ppmID, &status)
 	if err != nil {
 		return handlers.ResponseForError(h.Logger(), err)
 	}

--- a/pkg/models/shipment_summary_worksheet.go
+++ b/pkg/models/shipment_summary_worksheet.go
@@ -274,7 +274,7 @@ func FetchMovingExpensesShipmentSummaryWorksheet(move Move, db *pop.Connection, 
 	var movingExpenses []MovingExpenseDocument
 	if len(move.PersonallyProcuredMoves) > 0 {
 		ppm := move.PersonallyProcuredMoves[0]
-		moveDocuments, err := FetchApprovedMovingExpenseDocuments(db, session, ppm.ID)
+		moveDocuments, err := FetchMovingExpenseDocuments(db, session, ppm.ID, nil)
 		if err != nil {
 			return movingExpenses, err
 		}

--- a/pkg/models/shipment_summary_worksheet_test.go
+++ b/pkg/models/shipment_summary_worksheet_test.go
@@ -59,7 +59,7 @@ func (suite *ModelSuite) TestFetchDataShipmentSummaryWorksheet() {
 			MoveID:                   ppm.Move.ID,
 			Move:                     ppm.Move,
 			PersonallyProcuredMoveID: &ppm.ID,
-			Status:                   "OK",
+			Status:                   models.MoveDocumentStatusAWAITINGREVIEW,
 			MoveDocumentType:         "EXPENSE",
 		},
 		Document: models.Document{


### PR DESCRIPTION
## Description

Update the shipment summary worksheet to display all submitted expenses regardless of expense status.

## Reviewer Notes

The expense fetch method `FetchApprovedMovingExpenseDocuments` in `models/move_document.go` only retrieved approved expenses. Updated this method with a general method that takes an optional `status` parameter. Also, updated existing calls of `FetchApprovedMovingExpenseDocuments` to use `FetchMovingExpenseDocuments` with `status` = `MoveDocumentStatusOK`.

## Setup

1) As a service member complete a PPM
2) As an office user approve PPM
3) As a service member agree to the terms and submit some expenses (if doing in dev make sure to use the `moves/${move.id}/request-payment` endpoint).
4) As an office user add the required info (weight, move date) and generate the shipment summary worksheet.

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/n/projects/2181745/stories/165133573) 
