### PR TITLE
Add April diesel fuel price data

### DIFF
--- a/migrations/20190409155001_add_april_fuel_eia_diesel_prices.up.sql
+++ b/migrations/20190409155001_add_april_fuel_eia_diesel_prices.up.sql
@@ -1,0 +1,5 @@
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
+INSERT INTO public.fuel_eia_diesel_prices (id, pub_date, rate_start_date, rate_end_date,
+										   eia_price_per_gallon_millicents, baseline_rate, created_at, updated_at)
+VALUES (uuid_generate_v4(), '2019-04-01', '2019-04-15', '2019-05-14', 307800, 5, now(), now());


### PR DESCRIPTION
## Description

This PR adds a migration that inserts the EIA diesel fuel price data for April 2019 (posted April 1 for period April 15-May 14) into our `fuel_eia_diesel_prices` table.

## Reviewer Notes

- Since this migration is all SQL, I just made a SQL migration instead of a Fizz-based migration that wraps the SQL as done in previous diesel price migrations.
- I used the `uuid_generate_v4` function to create a UUID.  Previous diesel fuel price migrations used an explicit UUID (presumably generated from elsewhere) -- is there any reason we need to know what the UUID is?  If so, I can generate one instead.

## Setup

* First, check the `fuel_eia_diesel_prices` table to verify that there's no record for April 2019.
* Checkout the branch and do a `make db_dev_migrate`.
* Check the `fuel_eia_diesel_prices` table again and make sure the April 2019 record appears now.  Verify the data in the row against the values in the [second table on this page](https://www.eia.gov/petroleum/gasdiesel/).  You can also see the information (including the $2.50 baseline rate) at [this site](https://etops.sddc.army.mil/pls/ppcig_camp/fsc.output), although your browser may warn you about the certificate.

## Code Review Verification Steps

* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](./docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/164713623) for this change
* EIA's [Gasoline and Diesel Fuel Update](https://www.eia.gov/petroleum/gasdiesel/)
* [Another table](https://etops.sddc.army.mil/pls/ppcig_camp/fsc.output) with the monthly price and the baselines.