### PR TITLE
Fix running prod migrations locally first before upload

### DIFF
--- a/scripts/run-prod-migrations
+++ b/scripts/run-prod-migrations
@@ -6,7 +6,7 @@
 set -eu -o pipefail
 
 # Required env vars for apply-secure-migration.sh
-export SECURE_MIGRATION_SOURCE=s3
+export SECURE_MIGRATION_SOURCE=${SECURE_MIGRATION_SOURCE:-s3}
 export SECURE_MIGRATION_BUCKET_NAME="${SECURE_MIGRATION_BUCKET_NAME:-transcom-ppp-app-prod-us-west-2}"
 export PSQL_SSL_MODE=disable
 export DB_NAME="${DB_NAME_PROD_MIGRATIONS:-prod_migrations}"

--- a/scripts/upload-secure-migration
+++ b/scripts/upload-secure-migration
@@ -61,7 +61,7 @@ ${aws_command} s3 ls "${aws_bucket_prefix}${environments[0]}${aws_bucket_suffix}
 echo "Testing migrations ... (This could be several minutes!)"
 
 SECURE_MIGRATION_SOURCE=local make run_prod_migrations
-exit 1
+
 echo "Testing migrations was successful!"
 echo
 

--- a/scripts/upload-secure-migration
+++ b/scripts/upload-secure-migration
@@ -60,8 +60,8 @@ ${aws_command} s3 ls "${aws_bucket_prefix}${environments[0]}${aws_bucket_suffix}
 
 echo "Testing migrations ... (This could be several minutes!)"
 
-make run_prod_migrations
-
+SECURE_MIGRATION_SOURCE=local make run_prod_migrations
+exit 1
 echo "Testing migrations was successful!"
 echo
 


### PR DESCRIPTION
## Description

Fixes a mistake I made when updating this script. This should test locally running the migration first before uploading to s3 as opposed the the chicken-and-egg problem I'd created with testing s3 before uploading to s3.