### PR TITLE
Cg fix apply secure migration

### DIFF
--- a/scripts/apply-secure-migration.sh
+++ b/scripts/apply-secure-migration.sh
@@ -6,10 +6,7 @@
 # If `SECURE_MIGRATION_SOURCE=s3` then we look for a similarly named file in the
 # S3 bucket and pull it down.
 
-if [ -z "${SECURE_MIGRATION_SOURCE:-}" ]; then
-  echo "error: \$SECURE_MIGRATION_SOURCE needs to be set"
-  exit 1
-fi
+SECURE_MIGRATION_SOURCE=${SECURE_MIGRATION_SOURCE:-local}
 
 if [ -z "${DB_USER:-}" ]; then
   echo "error: \$DB_USER needs to be set"


### PR DESCRIPTION
## Description

Sets a sane default for the required variable `SECURE_MIGRATION_SOURCE`.

Catches a problem introduced in #1994 .

## Setup

```
make db_dev_reset db_dev_migrate
make db_test_reset db_test_migrate
```