### PR TITLE
Replace patchShipment and loadShipmentDependencies

### DIFF
--- a/src/scenes/TransportationServiceProvider/CustomerInfo.jsx
+++ b/src/scenes/TransportationServiceProvider/CustomerInfo.jsx
@@ -125,7 +125,6 @@ CustomerInfo.propTypes = {
 };
 
 const mapStateToProps = (state, ownProps) => {
-  const shipment = ownProps.shipment;
   const defaultServiceMember = {
     backupContacts: [],
     id: '',
@@ -153,8 +152,8 @@ const mapStateToProps = (state, ownProps) => {
     email: '',
     phone: '',
   };
-  const serviceMember = shipment.service_member || defaultServiceMember;
-  const backupContact = shipment.service_member.backup_contacts[0] || defaultBackupContact;
+  const serviceMember = ownProps.serviceMember || defaultServiceMember;
+  const backupContact = ownProps.serviceMember.backup_contacts[0] || defaultBackupContact;
 
   return {
     serviceMember,

--- a/src/scenes/TransportationServiceProvider/CustomerInfo.jsx
+++ b/src/scenes/TransportationServiceProvider/CustomerInfo.jsx
@@ -124,7 +124,8 @@ CustomerInfo.propTypes = {
   }).isRequired,
 };
 
-const mapStateToProps = state => {
+const mapStateToProps = (state, ownProps) => {
+  const shipment = ownProps.shipment;
   const defaultServiceMember = {
     backupContacts: [],
     id: '',
@@ -152,8 +153,8 @@ const mapStateToProps = state => {
     email: '',
     phone: '',
   };
-  const serviceMember = get(state, 'tsp.shipment.service_member', defaultServiceMember);
-  const backupContact = get(state, 'tsp.shipment.service_member.backup_contacts[0]', defaultBackupContact);
+  const serviceMember = shipment.service_member || defaultServiceMember;
+  const backupContact = shipment.service_member.backup_contacts[0] || defaultBackupContact;
 
   return {
     serviceMember,

--- a/src/scenes/TransportationServiceProvider/CustomerInfo.jsx
+++ b/src/scenes/TransportationServiceProvider/CustomerInfo.jsx
@@ -152,13 +152,13 @@ const mapStateToProps = (state, ownProps) => {
     email: '',
     phone: '',
   };
-  const serviceMember = ownProps.serviceMember || defaultServiceMember;
-  const backupContact = ownProps.serviceMember.backup_contacts[0] || defaultBackupContact;
+  const serviceMember = ownProps.shipment.service_member || defaultServiceMember;
+  const backupContact = ownProps.shipment.service_member.backup_contacts[0] || defaultBackupContact;
 
   return {
     serviceMember,
     backupContact,
-    entitlements: loadEntitlements(state),
+    entitlements: loadEntitlements(state, ownProps.shipment.id),
   };
 };
 

--- a/src/scenes/TransportationServiceProvider/DocumentViewerContainer.jsx
+++ b/src/scenes/TransportationServiceProvider/DocumentViewerContainer.jsx
@@ -1,5 +1,5 @@
 import { connect } from 'react-redux';
-import { loadShipmentDependencies } from './ducks';
+import { getPublicShipment } from 'shared/Entities/modules/shipments';
 import MoveDocumentView from 'shared/DocumentViewer/MoveDocumentView';
 import {
   getAllShipmentDocuments,
@@ -40,7 +40,7 @@ const mapDispatchToProps = (dispatch, ownProps) => {
   const { shipmentId } = ownProps.match.params;
   return {
     onDidMount: () => {
-      dispatch(loadShipmentDependencies(shipmentId));
+      dispatch(getPublicShipment(shipmentId));
       dispatch(getAllShipmentDocuments(shipmentId));
     },
   };

--- a/src/scenes/TransportationServiceProvider/NewDocumentContainer.jsx
+++ b/src/scenes/TransportationServiceProvider/NewDocumentContainer.jsx
@@ -1,23 +1,23 @@
 import { connect } from 'react-redux';
-import { loadShipmentDependencies } from './ducks';
 import NewDocumentView from 'shared/DocumentViewer/NewDocumentView';
 import {
   getAllShipmentDocuments,
   createShipmentDocument,
   selectShipmentDocuments,
 } from 'shared/Entities/modules/shipmentDocuments';
+import { selectShipment, getPublicShipment } from 'shared/Entities/modules/shipments';
 import { stringifyName } from 'shared/utils/serviceMember';
 import { get } from 'lodash';
 
 const mapStateToProps = (state, ownProps) => {
   const { shipmentId } = ownProps.match.params;
   const {
-    tsp,
     entities: { uploads = {} },
   } = state;
-  const serviceMember = get(tsp, 'serviceMember', {});
-  const { locator: moveLocator } = get(tsp, 'shipment.move', {});
-  const { edipi = '' } = get(tsp, 'serviceMember', {});
+  const shipment = selectShipment(state, shipmentId);
+  const serviceMember = shipment.service_member || {};
+  const { locator: moveLocator } = shipment.move || {};
+  const { edipi = '' } = serviceMember;
   const name = stringifyName(serviceMember);
 
   return {
@@ -35,7 +35,7 @@ const mapDispatchToProps = (dispatch, ownProps) => {
   const { shipmentId } = ownProps.match.params;
   return {
     onDidMount: () => {
-      dispatch(loadShipmentDependencies(shipmentId));
+      dispatch(getPublicShipment(shipmentId));
       dispatch(getAllShipmentDocuments(shipmentId));
     },
     createShipmentDocument: (shipmentId, body) => dispatch(createShipmentDocument(shipmentId, body)),

--- a/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
+++ b/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
@@ -30,6 +30,7 @@ import {
   getPublicShipment,
   selectShipment,
   getPublicShipmentLabel,
+  acceptShipment,
 } from 'shared/Entities/modules/shipments';
 import { getServiceAgentsForShipment, selectServiceAgentsForShipment } from 'shared/Entities/modules/serviceAgents';
 
@@ -44,7 +45,7 @@ import Dates from 'shared/ShipmentDates';
 import LocationsContainer from 'shared/LocationsPanel/LocationsContainer';
 import { getLastRequestIsSuccess, getLastRequestIsLoading, getLastError } from 'shared/Swagger/selectors';
 import { resetRequests } from 'shared/Swagger/request';
-import { completePmSurvey, acceptShipment, transportShipment, deliverShipment, handleServiceAgents } from './ducks';
+import { completePmSurvey, transportShipment, deliverShipment, handleServiceAgents } from './ducks';
 import FormButton from './FormButton';
 import CustomerInfo from './CustomerInfo';
 import PreApprovalPanel from 'shared/PreApprovalRequest/PreApprovalPanel.jsx';

--- a/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
+++ b/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
@@ -132,7 +132,6 @@ class ShipmentInfo extends Component {
         this.props.getStorageInTransitsForShipment(shipmentId);
       })
       .catch(err => {
-        console.log(err);
         this.props.history.replace('/');
       });
   }

--- a/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
+++ b/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
@@ -419,7 +419,7 @@ class ShipmentInfo extends Component {
             <div className="usa-width-one-third">
               <div className="customer-info">
                 <h2 className="extras usa-heading">Customer Info</h2>
-                <CustomerInfo shipment={this.props.shipment} />
+                <CustomerInfo serviceMember={this.props.shipment.service_member} />
               </div>
               <div className="documents">
                 <h2 className="extras usa-heading">

--- a/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
+++ b/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
@@ -418,7 +418,7 @@ class ShipmentInfo extends Component {
             <div className="usa-width-one-third">
               <div className="customer-info">
                 <h2 className="extras usa-heading">Customer Info</h2>
-                <CustomerInfo serviceMember={this.props.shipment.service_member} />
+                <CustomerInfo shipment={this.props.shipment} />
               </div>
               <div className="documents">
                 <h2 className="extras usa-heading">

--- a/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
+++ b/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
@@ -25,6 +25,13 @@ import { getAllShipmentLineItems, selectSortedShipmentLineItems } from 'shared/E
 import { getAllInvoices } from 'shared/Entities/modules/invoices';
 import { getTspForShipment } from 'shared/Entities/modules/transportationServiceProviders';
 import { getStorageInTransitsForShipment } from 'shared/Entities/modules/storageInTransits';
+import {
+  updatePublicShipment,
+  getPublicShipment,
+  selectShipment,
+  getPublicShipmentLabel,
+} from 'shared/Entities/modules/shipments';
+import { getServiceAgentsForShipment, selectServiceAgentsForShipment } from 'shared/Entities/modules/serviceAgents';
 
 import FontAwesomeIcon from '@fortawesome/react-fontawesome';
 import faPhone from '@fortawesome/fontawesome-free-solid/faPhone';
@@ -35,17 +42,9 @@ import TspContainer from 'shared/TspPanel/TspContainer';
 import Weights from 'shared/ShipmentWeights';
 import Dates from 'shared/ShipmentDates';
 import LocationsContainer from 'shared/LocationsPanel/LocationsContainer';
-import { getLastRequestIsSuccess, getLastRequestIsLoading } from 'shared/Swagger/selectors';
+import { getLastRequestIsSuccess, getLastRequestIsLoading, getLastError } from 'shared/Swagger/selectors';
 import { resetRequests } from 'shared/Swagger/request';
-import {
-  loadShipmentDependencies,
-  completePmSurvey,
-  patchShipment,
-  acceptShipment,
-  transportShipment,
-  deliverShipment,
-  handleServiceAgents,
-} from './ducks';
+import { completePmSurvey, acceptShipment, transportShipment, deliverShipment, handleServiceAgents } from './ducks';
 import FormButton from './FormButton';
 import CustomerInfo from './CustomerInfo';
 import PreApprovalPanel from 'shared/PreApprovalRequest/PreApprovalPanel.jsx';
@@ -121,9 +120,10 @@ class ShipmentInfo extends Component {
 
   componentDidMount() {
     this.props
-      .loadShipmentDependencies(this.props.match.params.shipmentId)
+      .getPublicShipment(this.props.shipmentId)
       .then(() => {
         const shipmentId = this.props.shipment.id;
+        this.props.getServiceAgentsForShipment(shipmentId);
         this.props.getTspForShipment(shipmentId);
         this.props.getAllShipmentDocuments(shipmentId);
         this.props.getAllTariff400ngItems(true);
@@ -132,6 +132,7 @@ class ShipmentInfo extends Component {
         this.props.getStorageInTransitsForShipment(shipmentId);
       })
       .catch(err => {
+        console.log(err);
         this.props.history.replace('/');
       });
   }
@@ -149,7 +150,7 @@ class ShipmentInfo extends Component {
   };
 
   enterPreMoveSurvey = values => {
-    this.props.patchShipment(this.props.shipment.id, values).then(() => {
+    this.props.updatePublicShipment(this.props.shipment.id, values).then(() => {
       if (this.props.shipment.pm_survey_completed_at === undefined) {
         this.props.completePmSurvey(this.props.shipment.id);
       }
@@ -394,9 +395,13 @@ class ShipmentInfo extends Component {
               )}
               {this.props.loadTspDependenciesHasSuccess && (
                 <div className="office-tab">
-                  <Dates title="Dates" shipment={this.props.shipment} update={this.props.patchShipment} />
-                  <Weights title="Weights & Items" shipment={this.props.shipment} update={this.props.patchShipment} />
-                  <LocationsContainer update={this.props.patchShipment} />
+                  <Dates title="Dates" shipment={this.props.shipment} update={this.props.updatePublicShipment} />
+                  <Weights
+                    title="Weights & Items"
+                    shipment={this.props.shipment}
+                    update={this.props.updatePublicShipment}
+                  />
+                  <LocationsContainer shipment={this.props.shipment} update={this.props.updatePublicShipment} />
                   <PreApprovalPanel shipmentId={this.props.match.params.shipmentId} />
                   {showSitPanel && <StorageInTransitPanel shipmentId={this.props.shipmentId} />}
 
@@ -414,7 +419,7 @@ class ShipmentInfo extends Component {
             <div className="usa-width-one-third">
               <div className="customer-info">
                 <h2 className="extras usa-heading">Customer Info</h2>
-                <CustomerInfo />
+                <CustomerInfo shipment={this.props.shipment} />
               </div>
               <div className="documents">
                 <h2 className="extras usa-heading">
@@ -447,7 +452,7 @@ class ShipmentInfo extends Component {
 
 const mapStateToProps = (state, props) => {
   const shipmentId = props.match.params.shipmentId;
-  const shipment = get(state, 'tsp.shipment', {});
+  const shipment = selectShipment(state, shipmentId);
   const shipmentDocuments = selectShipmentDocuments(state, shipment.id) || {};
   const gbl = shipmentDocuments.find(element => element.move_document_type === 'GOV_BILL_OF_LADING');
   const gblGenerated = !!gbl;
@@ -459,10 +464,10 @@ const mapStateToProps = (state, props) => {
     gblGenerated,
     tariff400ngItems: selectTariff400ngItems(state),
     shipmentLineItems: selectSortedShipmentLineItems(state),
-    serviceAgents: get(state, 'tsp.serviceAgents', []),
+    serviceAgents: selectServiceAgentsForShipment(state, shipmentId),
     tsp: get(state, 'tsp'),
-    loadTspDependenciesHasSuccess: get(state, 'tsp.loadTspDependenciesHasSuccess'),
-    loadTspDependenciesHasError: get(state, 'tsp.loadTspDependenciesHasError'),
+    loadTspDependenciesHasSuccess: getLastRequestIsSuccess(state, getPublicShipmentLabel),
+    loadTspDependenciesHasError: getLastError(state, getPublicShipmentLabel),
     acceptError: get(state, 'tsp.shipmentHasAcceptError'),
     generateGBLError: get(state, 'tsp.generateGBLError'),
     generateGBLInProgress: getLastRequestIsLoading(state, generateGBLLabel),
@@ -480,9 +485,10 @@ const mapStateToProps = (state, props) => {
 const mapDispatchToProps = dispatch =>
   bindActionCreators(
     {
-      loadShipmentDependencies,
+      getPublicShipment,
+      getServiceAgentsForShipment,
       completePmSurvey,
-      patchShipment,
+      updatePublicShipment,
       acceptShipment,
       generateGBL,
       handleServiceAgents,

--- a/src/scenes/TransportationServiceProvider/api.js
+++ b/src/scenes/TransportationServiceProvider/api.js
@@ -23,16 +23,6 @@ export async function RetrieveShipmentsForTSP(queueType) {
   return response.body;
 }
 
-// SHIPMENT
-export async function LoadShipment(shipmentId) {
-  const client = await getPublicClient();
-  const response = await client.apis.shipments.getShipment({
-    shipmentId,
-  });
-  checkResponse(response, 'failed to load shipment due to server error');
-  return response.body;
-}
-
 // SHIPMENT ACCEPT
 export async function AcceptShipment(shipmentId) {
   const client = await getPublicClient();
@@ -62,16 +52,6 @@ export async function DeliverShipment(shipmentId, payload) {
     payload: formatPayload(payload, payloadDef),
   });
   checkResponse(response, 'failed to deliver shipment due to server error');
-  return response.body;
-}
-
-export async function PatchShipment(shipmentId, shipment) {
-  const client = await getPublicClient();
-  const response = await client.apis.shipments.patchShipment({
-    shipmentId,
-    update: shipment,
-  });
-  checkResponse(response, 'failed to load shipment due to server error');
   return response.body;
 }
 

--- a/src/scenes/TransportationServiceProvider/ducks.js
+++ b/src/scenes/TransportationServiceProvider/ducks.js
@@ -96,12 +96,13 @@ export function createOrUpdateServiceAgent(shipmentId, serviceAgent) {
 }
 
 // Selectors
-export function loadEntitlements(state) {
-  const shipmentId = Object.keys(state.entities.shipments)[0];
+export function loadEntitlements(state, shipmentId) {
   const shipment = selectShipment(state, shipmentId);
-  const hasDependents = shipment.move.has_dependents;
-  const spouseHasProGear = shipment.move.spouse_has_progear;
-  const rank = shipment.service_member.rank;
+  const move = shipment.move || {};
+  const serviceMember = shipment.service_member || {};
+  const hasDependents = move.has_dependents;
+  const spouseHasProGear = move.spouse_has_progear;
+  const rank = serviceMember.rank;
 
   if (isNull(hasDependents) || isNull(spouseHasProGear) || isNull(rank)) {
     return null;

--- a/src/shared/Entities/modules/shipments.js
+++ b/src/shared/Entities/modules/shipments.js
@@ -10,6 +10,7 @@ export const getPublicShipmentLabel = 'Shipments.getPublicShipment';
 const createShipmentLabel = 'Shipments.createShipment';
 const updateShipmentLabel = 'shipments.updateShipment';
 const updatePublicShipmentLabel = 'shipments.updatePublicShipment';
+const acceptPublicShipmentLabel = 'shipments.acceptShipment';
 
 export function createOrUpdateShipment(moveId, shipment, id, label) {
   if (id) {
@@ -54,6 +55,10 @@ export function updatePublicShipment(
 export function approveShipment(shipmentId, label = approveShipmentLabel) {
   const swaggerTag = 'shipments.approveHHG';
   return swaggerRequest(getClient, swaggerTag, { shipmentId }, { label });
+}
+
+export function acceptShipment(shipmentId, label = acceptPublicShipmentLabel) {
+  return swaggerRequest(getPublicClient, label, { shipmentId }, { label });
 }
 
 export function selectShipment(state, id) {

--- a/src/shared/Entities/modules/shipments.js
+++ b/src/shared/Entities/modules/shipments.js
@@ -6,7 +6,7 @@ import { getClient, getPublicClient } from 'shared/Swagger/api';
 
 const approveShipmentLabel = 'Shipments.approveShipment';
 export const getShipmentLabel = 'Shipments.getShipment';
-const getPublicShipmentLabel = 'Shipments.getPublicShipment';
+export const getPublicShipmentLabel = 'Shipments.getPublicShipment';
 const createShipmentLabel = 'Shipments.createShipment';
 const updateShipmentLabel = 'shipments.updateShipment';
 const updatePublicShipmentLabel = 'shipments.updatePublicShipment';

--- a/src/shared/LocationsPanel/LocationsContainer.js
+++ b/src/shared/LocationsPanel/LocationsContainer.js
@@ -5,8 +5,8 @@ import { getFormValues } from 'redux-form';
 import { getPublicSwaggerDefinition } from 'shared/Swagger/selectors';
 import LocationsPanel from './LocationsPanel';
 
-const mapStateToProps = state => {
-  const shipment = get(state, 'tsp.shipment', {});
+const mapStateToProps = (state, ownProps) => {
+  const shipment = ownProps.shipment;
   const formName = 'shipment_locations';
   const newDutyStation = get(shipment, 'move.new_duty_station.address', {});
   const schema = getPublicSwaggerDefinition(state, 'Shipment');

--- a/src/shared/StorageInTransit/StorageInTransitPanel.jsx
+++ b/src/shared/StorageInTransit/StorageInTransitPanel.jsx
@@ -84,21 +84,22 @@ StorageInTransitPanel.propTypes = {
 // moveId is needed to find the entitlement on the Office side. It is
 // not needed to pull entitlement from the TSP side.
 // calculateEntitlementsForMove is a more up-to-date way of storing data
-function getStorageInTransitEntitlement(state, moveId) {
+function getStorageInTransitEntitlement(state, resourceId) {
   let storageInTransitEntitlement = 0;
   if (isTspSite) {
-    storageInTransitEntitlement = loadEntitlements(state).storage_in_transit;
+    storageInTransitEntitlement = loadEntitlements(state, resourceId).storage_in_transit;
   } else {
-    storageInTransitEntitlement = calculateEntitlementsForMove(state, moveId).storage_in_transit;
+    storageInTransitEntitlement = calculateEntitlementsForMove(state, resourceId).storage_in_transit;
   }
   return storageInTransitEntitlement;
 }
 
 function mapStateToProps(state, ownProps) {
-  const moveId = ownProps.moveId;
+  const resourceId = isTspSite ? ownProps.shipmentId : ownProps.moveId;
+
   return {
     storageInTransits: selectStorageInTransits(state, ownProps.shipmentId),
-    storageInTransitEntitlement: getStorageInTransitEntitlement(state, moveId),
+    storageInTransitEntitlement: getStorageInTransitEntitlement(state, resourceId),
     shipmentId: ownProps.shipmentId,
   };
 }


### PR DESCRIPTION
## Description

- Refactor the tsp components to use the entities action to patch a shipment. Delete the code needed to support patchShipment from the tsp ducks file.
- Refactor the tsp components to use the entities actions to load shipment and service agents. Delete the code needed to support loadShipmentDependencies from the tsp ducks file.

## Setup

1. Log in to the TSP app
2. Click on a specific shipment
3. Try editing any field in the shipment forms, save, and make sure you see the updated values.

## Code Review Verification Steps

* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

I combined two stories for this PR since they had overlapping logic.

* [Pivotal story #1](https://www.pivotaltracker.com/story/show/165150098)
* [Pivotal story #2](https://www.pivotaltracker.com/story/show/165150067)
