### PR TITLE
In invoice table, show 226A and 35A base quantity in USD

### DIFF
--- a/cypress/integration/office/preApprovalRequest.js
+++ b/cypress/integration/office/preApprovalRequest.js
@@ -241,7 +241,7 @@ function officeUserCreates35APreApprovalRequest() {
   // The edit should propagate to the Invoice panel
   cy
     .get('.invoice-panel-table-cont tbody')
-    .contains('220.0000')
+    .contains('$220.00')
     .should('exist');
 
   // Unset the actual amount

--- a/src/shared/formatters.js
+++ b/src/shared/formatters.js
@@ -22,7 +22,7 @@ export function formatCents(cents) {
 }
 
 // Format base quantity as cents
-export function formatBaseQuantityAsCents(baseQuantity) {
+export function formatBaseQuantityAsDollars(baseQuantity) {
   return formatCents(baseQuantity / 100);
 }
 

--- a/src/shared/formatters.js
+++ b/src/shared/formatters.js
@@ -21,6 +21,11 @@ export function formatCents(cents) {
   });
 }
 
+// Format base quantity as cents
+export function formatBaseQuantityAsCents(baseQuantity) {
+  return formatCents(baseQuantity / 100);
+}
+
 // Format a base quantity into a user-friendly number string, e.g. 167000 -> "16.7000"
 export function formatFromBaseQuantity(baseQuantity) {
   if (!isFinite(baseQuantity)) {

--- a/src/shared/lineItems.js
+++ b/src/shared/lineItems.js
@@ -3,6 +3,7 @@ import {
   addCommasToNumberString,
   formatFromBaseQuantity,
   convertFromBaseQuantity,
+  formatBaseQuantityAsCents,
 } from 'shared/formatters';
 import { isRobustAccessorial } from 'shared/PreApprovalRequest/DetailsHelper';
 
@@ -26,7 +27,11 @@ export const displayBaseQuantityUnits = (item, scale) => {
     const decimalPlaces = 2;
     const volume = convertTruncateAddCommas(itemQuantity1, decimalPlaces);
     return `${volume} cu ft`;
+  } else if (isPrice(itemCode) && isRobustAccessorial(item)) {
+    const price = formatBaseQuantityAsCents(itemQuantity1);
+    return `$${price}`;
   }
+
   return formatFromBaseQuantity(itemQuantity1);
 };
 
@@ -43,6 +48,11 @@ function isVolume(itemCode) {
 function isWeightDistance(itemCode) {
   const lbsMiItems = ['LHS', '16A'];
   return lbsMiItems.includes(itemCode);
+}
+
+function isPrice(itemCode) {
+  const priceItems = ['226A', '35A'];
+  return priceItems.includes(itemCode);
 }
 
 function convertTruncateAddCommas(value, decimalPlaces) {

--- a/src/shared/lineItems.js
+++ b/src/shared/lineItems.js
@@ -3,7 +3,7 @@ import {
   addCommasToNumberString,
   formatFromBaseQuantity,
   convertFromBaseQuantity,
-  formatBaseQuantityAsCents,
+  formatBaseQuantityAsDollars,
 } from 'shared/formatters';
 import { isRobustAccessorial } from 'shared/PreApprovalRequest/DetailsHelper';
 
@@ -28,7 +28,7 @@ export const displayBaseQuantityUnits = (item, scale) => {
     const volume = convertTruncateAddCommas(itemQuantity1, decimalPlaces);
     return `${volume} cu ft`;
   } else if (isPrice(itemCode) && isRobustAccessorial(item)) {
-    const price = formatBaseQuantityAsCents(itemQuantity1);
+    const price = formatBaseQuantityAsDollars(itemQuantity1);
     return `$${price}`;
   }
 


### PR DESCRIPTION
## Description

In the invoice panel, the base quantity for 226A and 35A items should be shown in USD, i.e. $1,234.00 rather than 1234.0000.

## Code Review Verification Steps

* [ ] There are no aXe warnings for UI.
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/163829420) for this change