### PR TITLE
Ensure login case insensitivity 

### DIFF
--- a/pkg/models/dps_users.go
+++ b/pkg/models/dps_users.go
@@ -66,7 +66,7 @@ func IsDPSUser(db *pop.Connection, email string) (bool, error) {
 // FetchDPSUserByEmail looks for an DPS user with a specific email
 func FetchDPSUserByEmail(tx *pop.Connection, email string) (*DpsUser, error) {
 	var users DpsUsers
-	err := tx.Where("login_gov_email = $1", strings.ToLower(email)).All(&users)
+	err := tx.Where("LOWER(login_gov_email) = $1", strings.ToLower(email)).All(&users)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/models/dps_users_test.go
+++ b/pkg/models/dps_users_test.go
@@ -1,6 +1,8 @@
 package models_test
 
 import (
+	"strings"
+
 	"github.com/transcom/mymove/pkg/models"
 )
 
@@ -30,4 +32,18 @@ func (suite *ModelSuite) Test_DpsUserValidations() {
 	}
 
 	suite.verifyValidationErrors(document, expErrors)
+}
+
+func (suite *ModelSuite) TestFetchDPSUserByEmailCaseSensitivity() {
+	email := "Test@example.com"
+
+	dpsUser := models.DpsUser{
+		LoginGovEmail: email,
+	}
+
+	suite.MustSave(&dpsUser)
+	user, err := models.FetchDPSUserByEmail(suite.DB(), strings.ToLower(email))
+	suite.Nil(err)
+	suite.NotNil(user)
+	suite.Equal(user.LoginGovEmail, email)
 }

--- a/pkg/models/office_user.go
+++ b/pkg/models/office_user.go
@@ -57,7 +57,7 @@ func (o *OfficeUser) ValidateUpdate(tx *pop.Connection) (*validate.Errors, error
 // FetchOfficeUserByEmail looks for an office user with a specific email
 func FetchOfficeUserByEmail(tx *pop.Connection, email string) (*OfficeUser, error) {
 	var users OfficeUsers
-	err := tx.Where("email = $1", strings.ToLower(email)).All(&users)
+	err := tx.Where("LOWER(email) = $1", strings.ToLower(email)).All(&users)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/models/office_user_test.go
+++ b/pkg/models/office_user_test.go
@@ -1,6 +1,8 @@
 package models_test
 
 import (
+	"strings"
+
 	"github.com/gofrs/uuid"
 
 	. "github.com/transcom/mymove/pkg/models"
@@ -66,6 +68,34 @@ func (suite *ModelSuite) TestFetchOfficeUserByEmail() {
 	suite.Nil(err)
 	suite.NotNil(user)
 	suite.Equal(newUser.ID, user.ID)
+}
+
+func (suite *ModelSuite) TestFetchOfficeUserByEmailCaseSensitivity() {
+	fakeUUID, _ := uuid.FromString("f390a584-3974-47b9-9ab2-05383304d696")
+	userEmail := "Chris@government.gov"
+
+	chris := User{
+		LoginGovUUID:  fakeUUID,
+		LoginGovEmail: userEmail,
+	}
+	suite.MustSave(&chris)
+	office := CreateTestShippingOffice(suite)
+
+	officeUser := OfficeUser{
+		LastName:               "Tester",
+		FirstName:              "Chris",
+		Email:                  userEmail,
+		Telephone:              "(908) 555-1313",
+		UserID:                 &chris.ID,
+		User:                   chris,
+		TransportationOfficeID: office.ID,
+	}
+	suite.MustSave(&officeUser)
+
+	user, err := FetchOfficeUserByEmail(suite.DB(), strings.ToLower(userEmail))
+	suite.Nil(err)
+	suite.NotNil(user)
+	suite.Equal(user.Email, userEmail)
 }
 
 func (suite *ModelSuite) TestFetchOfficeUserByID() {

--- a/pkg/models/tsp_users.go
+++ b/pkg/models/tsp_users.go
@@ -67,7 +67,7 @@ func FetchTspUserByID(tx *pop.Connection, id uuid.UUID) (*TspUser, error) {
 // FetchTspUserByEmail looks for an tsp user with a specific email
 func FetchTspUserByEmail(tx *pop.Connection, email string) (*TspUser, error) {
 	var users TspUsers
-	err := tx.Where("email = $1", strings.ToLower(email)).All(&users)
+	err := tx.Where("LOWER(email) = $1", strings.ToLower(email)).All(&users)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/models/tsp_users_test.go
+++ b/pkg/models/tsp_users_test.go
@@ -1,6 +1,8 @@
 package models_test
 
 import (
+	"strings"
+
 	"github.com/gofrs/uuid"
 
 	. "github.com/transcom/mymove/pkg/models"
@@ -67,4 +69,22 @@ func (suite *ModelSuite) TestFetchTspUserByEmail() {
 	suite.Nil(err)
 	suite.NotNil(user)
 	suite.Equal(newUser.ID, user.ID)
+}
+
+func (suite *ModelSuite) TestFetchTspUserByEmailCaseSensitivity() {
+	email := "Jimbo.work@government.gov"
+	tsp := CreateTestTsp(suite)
+	tspUser := TspUser{
+		LastName:                        "Tester",
+		FirstName:                       "JimBo",
+		Email:                           email,
+		Telephone:                       "(807) 553-1122",
+		TransportationServiceProviderID: tsp.ID,
+	}
+	suite.MustSave(&tspUser)
+
+	user, err := FetchTspUserByEmail(suite.DB(), strings.ToLower(email))
+	suite.Nil(err)
+	suite.NotNil(user)
+	suite.Equal(user.Email, email)
 }

--- a/scripts/apply-secure-migration.sh
+++ b/scripts/apply-secure-migration.sh
@@ -6,10 +6,7 @@
 # If `SECURE_MIGRATION_SOURCE=s3` then we look for a similarly named file in the
 # S3 bucket and pull it down.
 
-if [ -z "${SECURE_MIGRATION_SOURCE:-}" ]; then
-  echo "error: \$SECURE_MIGRATION_SOURCE needs to be set"
-  exit 1
-fi
+SECURE_MIGRATION_SOURCE=${SECURE_MIGRATION_SOURCE:-local}
 
 if [ -z "${DB_USER:-}" ]; then
   echo "error: \$DB_USER needs to be set"


### PR DESCRIPTION
## Description

This PR ensures that login does a case insensitive comparison for the email column for `dps_user`, `tsp_user`, and `office_user` tables. 

## Setup

1. `./bin/make-office-user --email Email`
- Email must start with a capital letter
- You must have access to Email
1. `make office_client_run`
1. `make server_run`
1. Go to the office client in the [browser](http://officelocal:3000).
1. Click `Sign In`
1. Sign in or Create an Account with the same Email as above, but lower case. 
1. Complete the 2MFA Verification Step
1. Click Next
1. Before you would have seen a white screen that says `Unauthorized`. Now, it continues.

## Code Review Verification Steps

* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/165218937) for this change