### PR TITLE
Update PPM model to use unit.Pound for weights

### DIFF
--- a/pkg/handlers/internalapi/entitlements_test.go
+++ b/pkg/handlers/internalapi/entitlements_test.go
@@ -5,7 +5,6 @@ import (
 	"net/http/httptest"
 
 	"github.com/go-openapi/strfmt"
-	"github.com/go-openapi/swag"
 	"github.com/gofrs/uuid"
 
 	entitlementop "github.com/transcom/mymove/pkg/gen/internalapi/internaloperations/entitlements"
@@ -22,7 +21,8 @@ func (suite *HandlerSuite) TestValidateEntitlementHandlerReturns200() {
 
 	// When: rank is E1, the orders have dependents and spouse gear, and
 	// the weight estimate stored is under entitlement of 10500
-	ppm.WeightEstimate = swag.Int64(10000)
+	wtgEst := unit.Pound(10000)
+	ppm.WeightEstimate = &wtgEst
 	suite.MustSave(&ppm)
 
 	// And: the context contains the auth values
@@ -49,7 +49,8 @@ func (suite *HandlerSuite) TestValidateEntitlementHandlerReturns409IfPPM() {
 
 	// When: rank is E1, the orders have dependents and spouse gear, and
 	// the weight estimate stored is over entitlement of 10500
-	ppm.WeightEstimate = swag.Int64(14000)
+	wtgEst := unit.Pound(14000)
+	ppm.WeightEstimate = &wtgEst
 	suite.MustSave(&ppm)
 
 	// And: the context contains the auth values
@@ -116,7 +117,7 @@ func (suite *HandlerSuite) TestValidateEntitlementHandlerReturns409IfComboMove()
 	shipment.WeightEstimate = &weight
 	suite.MustSave(&shipment)
 
-	ppmWeight := int64(weight)
+	ppmWeight := unit.Pound(weight)
 	testdatagen.MakePPM(suite.DB(), testdatagen.Assertions{
 		PersonallyProcuredMove: models.PersonallyProcuredMove{
 			Move:           move,
@@ -202,7 +203,8 @@ func (suite *HandlerSuite) TestValidateEntitlementHandlerReturns404IfNoRank() {
 
 	// When: rank is E1, the orders have dependents and spouse gear, and
 	// the weight estimate stored is under entitlement of 10500
-	ppm.WeightEstimate = swag.Int64(10000)
+	wtgEst := unit.Pound(10000)
+	ppm.WeightEstimate = &wtgEst
 	suite.MustSave(&ppm)
 
 	move.Orders.ServiceMember.Rank = nil

--- a/pkg/handlers/internalapi/moves_test.go
+++ b/pkg/handlers/internalapi/moves_test.go
@@ -6,6 +6,8 @@ import (
 	"net/http/httptest"
 	"time"
 
+	"github.com/transcom/mymove/pkg/unit"
+
 	"github.com/go-openapi/swag"
 
 	"github.com/transcom/mymove/pkg/models"
@@ -456,11 +458,12 @@ func (suite *HandlerSuite) TestShowShipmentSummaryWorksheet() {
 		})
 
 	move := testdatagen.MakeDefaultMove(suite.DB())
+	netWeight := unit.Pound(1000)
 	ppm := testdatagen.MakePPM(suite.DB(), testdatagen.Assertions{
 		PersonallyProcuredMove: models.PersonallyProcuredMove{
 			MoveID:                move.ID,
 			ActualMoveDate:        &testdatagen.DateInsidePerformancePeriod,
-			NetWeight:             models.Int64Pointer(1000),
+			NetWeight:             &netWeight,
 			PickupPostalCode:      models.StringPointer("50303"),
 			DestinationPostalCode: models.StringPointer("30814"),
 		},

--- a/pkg/models/move.go
+++ b/pkg/models/move.go
@@ -415,7 +415,7 @@ func (m Move) CreateMovingExpenseDocument(
 // CreatePPM creates a new PPM associated with this move
 func (m Move) CreatePPM(db *pop.Connection,
 	size *internalmessages.TShirtSize,
-	weightEstimate *int64,
+	weightEstimate *unit.Pound,
 	originalMoveDate *time.Time,
 	pickupPostalCode *string,
 	hasAdditionalPostalCode *bool,

--- a/pkg/models/personally_procured_move.go
+++ b/pkg/models/personally_procured_move.go
@@ -41,11 +41,11 @@ type PersonallyProcuredMove struct {
 	CreatedAt                     time.Time                    `json:"created_at" db:"created_at"`
 	UpdatedAt                     time.Time                    `json:"updated_at" db:"updated_at"`
 	Size                          *internalmessages.TShirtSize `json:"size" db:"size"`
-	WeightEstimate                *int64                       `json:"weight_estimate" db:"weight_estimate"`
+	WeightEstimate                *unit.Pound                  `json:"weight_estimate" db:"weight_estimate"`
 	OriginalMoveDate              *time.Time                   `json:"original_move_date" db:"original_move_date"`
 	ActualMoveDate                *time.Time                   `json:"actual_move_date" db:"actual_move_date"`
 	ApproveDate                   *time.Time                   `json:"approve_date" db:"approve_date"`
-	NetWeight                     *int64                       `json:"net_weight" db:"net_weight"`
+	NetWeight                     *unit.Pound                  `json:"net_weight" db:"net_weight"`
 	PickupPostalCode              *string                      `json:"pickup_postal_code" db:"pickup_postal_code"`
 	HasAdditionalPostalCode       *bool                        `json:"has_additional_postal_code" db:"has_additional_postal_code"`
 	AdditionalPickupPostalCode    *string                      `json:"additional_pickup_postal_code" db:"additional_pickup_postal_code"`

--- a/pkg/models/shipment_summary_worksheet_test.go
+++ b/pkg/models/shipment_summary_worksheet_test.go
@@ -40,10 +40,11 @@ func (suite *ModelSuite) TestFetchDataShipmentSummaryWorksheet() {
 	})
 
 	advance := models.BuildDraftReimbursement(1000, models.MethodOfReceiptMILPAY)
+	netWeight := unit.Pound(10000)
 	ppm := testdatagen.MakePPM(suite.DB(), testdatagen.Assertions{
 		PersonallyProcuredMove: models.PersonallyProcuredMove{
 			MoveID:              move.ID,
-			NetWeight:           models.Int64Pointer(10000),
+			NetWeight:           &netWeight,
 			HasRequestedAdvance: true,
 			AdvanceID:           &advance.ID,
 			Advance:             &advance,
@@ -200,11 +201,12 @@ func (suite *ModelSuite) TestFormatValuesShipmentSummaryWorksheetFormPage1() {
 		},
 	}
 	advance := models.BuildDraftReimbursement(1000, models.MethodOfReceiptMILPAY)
+	netWeight := unit.Pound(4000)
 	personallyProcuredMoves := []models.PersonallyProcuredMove{
 		{
 			OriginalMoveDate: &pickupDate,
 			Status:           models.PPMStatusPAYMENTREQUESTED,
-			NetWeight:        models.Int64Pointer(4000),
+			NetWeight:        &netWeight,
 			Advance:          &advance,
 		},
 	}
@@ -534,7 +536,7 @@ func (suite *ModelSuite) TestFormatServiceMemberAffiliation() {
 }
 
 func (suite *ModelSuite) TestFormatPPMWeight() {
-	var pounds int64 = 1000
+	pounds := unit.Pound(1000)
 	ppm := models.PersonallyProcuredMove{NetWeight: &pounds}
 	noWtg := models.PersonallyProcuredMove{NetWeight: nil}
 
@@ -543,7 +545,7 @@ func (suite *ModelSuite) TestFormatPPMWeight() {
 }
 
 func (suite *ModelSuite) TestCalculatePPMEntitlementNoHHGPPMLessThanMaxEntitlement() {
-	ppmWeight := int64(900)
+	ppmWeight := unit.Pound(900)
 	totalEntitlement := unit.Pound(1000)
 	move := models.Move{
 		PersonallyProcuredMoves: models.PersonallyProcuredMoves{models.PersonallyProcuredMove{NetWeight: &ppmWeight}},
@@ -556,7 +558,7 @@ func (suite *ModelSuite) TestCalculatePPMEntitlementNoHHGPPMLessThanMaxEntitleme
 }
 
 func (suite *ModelSuite) TestCalculatePPMEntitlementNoHHGPPMGreaterThanMaxEntitlement() {
-	ppmWeight := int64(1100)
+	ppmWeight := unit.Pound(1100)
 	totalEntitlement := unit.Pound(1000)
 	move := models.Move{
 		PersonallyProcuredMoves: models.PersonallyProcuredMoves{models.PersonallyProcuredMove{NetWeight: &ppmWeight}},
@@ -569,7 +571,7 @@ func (suite *ModelSuite) TestCalculatePPMEntitlementNoHHGPPMGreaterThanMaxEntitl
 }
 
 func (suite *ModelSuite) TestCalculatePPMEntitlementPPMGreaterThanRemainingEntitlement() {
-	ppmWeight := int64(1100)
+	ppmWeight := unit.Pound(1100)
 	totalEntitlement := unit.Pound(1000)
 	hhg := unit.Pound(100)
 	move := models.Move{
@@ -584,7 +586,7 @@ func (suite *ModelSuite) TestCalculatePPMEntitlementPPMGreaterThanRemainingEntit
 }
 
 func (suite *ModelSuite) TestCalculatePPMEntitlementPPMLessThanRemainingEntitlement() {
-	ppmWeight := int64(500)
+	ppmWeight := unit.Pound(500)
 	totalEntitlement := unit.Pound(1000)
 	hhg := unit.Pound(100)
 	move := models.Move{

--- a/pkg/testdatagen/make_ppm.go
+++ b/pkg/testdatagen/make_ppm.go
@@ -22,7 +22,7 @@ func MakePPM(db *pop.Connection, assertions Assertions) models.PersonallyProcure
 		Move:                          move,
 		MoveID:                        move.ID,
 		Size:                          &shirt,
-		WeightEstimate:                models.Int64Pointer(8000),
+		WeightEstimate:                poundPointer(8000),
 		OriginalMoveDate:              models.TimePointer(DateInsidePeakRateCycle),
 		PickupPostalCode:              models.StringPointer("72017"),
 		HasAdditionalPostalCode:       models.BoolPointer(false),


### PR DESCRIPTION
## Description

The `Shipment` and `PersonallyProcuredMove` models were using inconsistent types to represent weights. This PR updates the ppm model to use the custom `unit.Pound` to represent weights (instead of `int64`)

## Reviewer Notes

PR consists of mostly just updating the types, but there was one section in the [handler](https://github.com/transcom/mymove/compare/mk-164337616-use-consistent-types-ppm-shipments-models?expand=1#diff-bcab993ef3ba662f85d2325bb55548e3R286), and accompanying [test](https://github.com/transcom/mymove/compare/mk-164337616-use-consistent-types-ppm-shipments-models?expand=1#diff-bcab993ef3ba662f85d2325bb55548e3R286) that could probably use a 2nd set of eyes to confirm that I correctly mimicked the original intent.

## Setup

```sh
make server_test
```

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/n/projects/2181745/stories/164337616) for this change
