### PR TITLE
Add edit icon and form for approved SIT requests

### DIFF
--- a/cypress/integration/office/storageInTransitPanel.js
+++ b/cypress/integration/office/storageInTransitPanel.js
@@ -36,11 +36,11 @@ function officeUserViewsSITPanel() {
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/queues\/new\/moves\/[^/]+\/hhg/);
   });
-  cy.get('.storage-in-transit-panel').contains('Storage in Transit');
-  cy.get('.storage-in-transit').within(() => {
+  cy.get('[data-cy=storage-in-transit-panel]').contains('Storage in Transit');
+  cy.get('[data-cy=storage-in-transit]').within(() => {
     cy.contains('Destination SIT');
     cy
-      .get('.sit-status-text')
+      .get('[data-cy=sit-status-text]')
       .contains('Status')
       .parent()
       .siblings()
@@ -95,7 +95,7 @@ function officeUserStartsAndCancelsSitApproval() {
     .get('a')
     .contains('Approve')
     .click()
-    .get('.storage-in-transit')
+    .get('[data-cy=storage-in-transit]')
     .should($div => {
       const text = $div.text();
       expect(text).to.include('Approve SIT Request');
@@ -109,7 +109,7 @@ function officeUserStartsAndCancelsSitApproval() {
     .get('.usa-button-secondary')
     .contains('Cancel')
     .click()
-    .get('.storage-in-transit-panel .add-request')
+    .get('[data-cy=storage-in-transit-panel] [data-cy=add-request]')
     .should($div => {
       const text = $div.text();
       expect(text).to.not.include('Approve SIT Request');
@@ -138,7 +138,7 @@ function officeUserStartsAndCancelsSitEdit() {
   });
 
   cy
-    .get('.storage-in-transit')
+    .get('[data-cy=storage-in-transit]')
     .contains('Edit')
     .click()
     .get('.sit-authorization')
@@ -151,7 +151,7 @@ function officeUserStartsAndCancelsSitEdit() {
     .get('.usa-button-secondary')
     .contains('Cancel')
     .click()
-    .get('.storage-in-transit')
+    .get('[data-cy=storage-in-transit]')
     .should($div => {
       const text = $div.text();
       expect(text).to.include('Approved');

--- a/cypress/integration/office/storageInTransitPanel.js
+++ b/cypress/integration/office/storageInTransitPanel.js
@@ -9,6 +9,9 @@ describe('office user finds the shipment', function() {
   it('office user starts and cancels sit approval', function() {
     officeUserStartsAndCancelsSitApproval();
   });
+  it('office user starts and cancels sit edit', function() {
+    officeUserStartsAndCancelsSitEdit();
+  });
 });
 
 function officeUserViewsSITPanel() {
@@ -110,5 +113,48 @@ function officeUserStartsAndCancelsSitApproval() {
     .should($div => {
       const text = $div.text();
       expect(text).to.not.include('Approve SIT Request');
+    });
+}
+
+function officeUserStartsAndCancelsSitEdit() {
+  cy.patientVisit('/queues/new');
+  cy.location().should(loc => {
+    expect(loc.pathname).to.match(/^\/queues\/new/);
+  });
+
+  cy.selectQueueItemMoveLocator('SITAPR');
+
+  cy.location().should(loc => {
+    expect(loc.pathname).to.match(/^\/queues\/new\/moves\/[^/]+\/basics/);
+  });
+
+  cy
+    .get('a')
+    .contains('HHG')
+    .click(); // navtab
+
+  cy.location().should(loc => {
+    expect(loc.pathname).to.match(/^\/queues\/new\/moves\/[^/]+\/hhg/);
+  });
+
+  cy
+    .get('.storage-in-transit')
+    .contains('Edit')
+    .click()
+    .get('.sit-authorization')
+    .should($div => {
+      const text = $div.text();
+      expect(text).to.include('Edit SIT authorization');
+    });
+
+  cy
+    .get('.usa-button-secondary')
+    .contains('Cancel')
+    .click()
+    .get('.storage-in-transit')
+    .should($div => {
+      const text = $div.text();
+      expect(text).to.include('Approved');
+      expect(text).to.not.include('Edit SIT authorization');
     });
 }

--- a/cypress/integration/tsp/storageInTransit.js
+++ b/cypress/integration/tsp/storageInTransit.js
@@ -42,7 +42,7 @@ function tspUserCreatesSitRequest() {
     .get('.storage-in-transit-panel .add-request')
     .contains('Request SIT')
     .click()
-    .get('.storage-in-transit-request-form')
+    .get('.storage-in-transit-form')
     .should($div => {
       const text = $div.text();
       expect(text).to.include('SIT location');

--- a/src/shared/EditablePanel/index.css
+++ b/src/shared/EditablePanel/index.css
@@ -13,13 +13,6 @@
   vertical-align: top;
 }
 
-.editable-panel-2-column {
-  display: inline-block;
-  width: 45%;
-  margin-right: 5%;
-  vertical-align: top;
-}
-
 .editable-panel-3-column {
   display: inline-block;
   width: 28%;

--- a/src/shared/EditablePanel/index.css
+++ b/src/shared/EditablePanel/index.css
@@ -13,6 +13,13 @@
   vertical-align: top;
 }
 
+.editable-panel-2-column {
+  display: inline-block;
+  width: 45%;
+  margin-right: 5%;
+  vertical-align: top;
+}
+
 .editable-panel-3-column {
   display: inline-block;
   width: 28%;
@@ -126,6 +133,7 @@
   width: 40%;
   display: inline-block;
   vertical-align: top;
+  font-weight: normal;
 }
 
 .field-value {

--- a/src/shared/StorageInTransit/ApproveSitRequest.jsx
+++ b/src/shared/StorageInTransit/ApproveSitRequest.jsx
@@ -26,10 +26,7 @@ export class ApproveSitRequest extends Component {
             </p>
           </div>
           <div className="usa-width-one-half align-right">
-            <button
-              className="button usa-button-primary storage-in-transit-request-form-send-request-button"
-              disabled={!this.props.formEnabled}
-            >
+            <button className="button usa-button-primary" disabled={!this.props.formEnabled}>
               Approve
             </button>
           </div>

--- a/src/shared/StorageInTransit/Creator.jsx
+++ b/src/shared/StorageInTransit/Creator.jsx
@@ -69,7 +69,7 @@ export class Creator extends Component {
         </div>
       );
     return (
-      <div className="add-request">
+      <div className="add-request" data-cy="add-request">
         <a onClick={this.openForm}>
           <FontAwesomeIcon className="icon link-blue" icon={faPlusCircle} />
           Request SIT

--- a/src/shared/StorageInTransit/Creator.jsx
+++ b/src/shared/StorageInTransit/Creator.jsx
@@ -58,7 +58,7 @@ export class Creator extends Component {
             </div>
             <div className="usa-width-one-half align-right">
               <button
-                className="button usa-button-primary storage-in-transit-request-form-send-request-button"
+                className="button usa-button-primary"
                 disabled={!this.props.formEnabled}
                 onClick={this.saveAndClose}
               >

--- a/src/shared/StorageInTransit/DenySitRequest.jsx
+++ b/src/shared/StorageInTransit/DenySitRequest.jsx
@@ -24,10 +24,7 @@ export class DenySitRequest extends Component {
             </p>
           </div>
           <div className="usa-width-one-half align-right">
-            <button
-              className="button usa-button-primary storage-in-transit-request-form-send-request-button"
-              disabled={!this.props.formEnabled}
-            >
+            <button className="button usa-button-primary" disabled={!this.props.formEnabled}>
               Deny
             </button>
           </div>

--- a/src/shared/StorageInTransit/OfficeEditor.jsx
+++ b/src/shared/StorageInTransit/OfficeEditor.jsx
@@ -1,0 +1,93 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+
+import './StorageInTransit.css';
+
+import { isValid, isSubmitting, submit, hasSubmitSucceeded } from 'redux-form';
+
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import StorageInTransitOfficeEditForm, {
+  formName as StorageInTransitOfficeEditFormName,
+} from './StorageInTransitOfficeEditForm.jsx';
+
+export class OfficeEditor extends Component {
+  state = {
+    closeOnSubmit: true,
+  };
+
+  componentDidUpdate(prevProps, prevState, snapshot) {
+    if (this.props.hasSubmitSucceeded && !prevProps.hasSubmitSucceeded) {
+      this.props.onClose();
+    }
+  }
+
+  closeForm = () => {
+    this.props.onClose();
+  };
+
+  saveAndClose = () => {
+    this.setState({ closeOnSubmit: true }, () => {
+      this.props.submitForm();
+    });
+  };
+
+  onSubmit = values => {
+    this.props.updateStorageInTransit(values);
+  };
+
+  render() {
+    return (
+      <div className="storage-in-transit-panel-modal">
+        <div className="editable-panel is-editable">
+          <div className="sit-authorization title">Edit SIT authorization</div>
+          <StorageInTransitOfficeEditForm onSubmit={this.onSubmit} initialValues={this.props.storageInTransit} />
+          <div className="usa-grid-full">
+            <div className="usa-width-one-half">
+              <p className="cancel-link">
+                <a className="usa-button-secondary" onClick={this.closeForm}>
+                  Cancel
+                </a>
+              </p>
+            </div>
+            <div className="usa-width-one-half align-right">
+              <button
+                className="button usa-button-primary storage-in-transit-request-form-send-request-button"
+                disabled={!this.props.formEnabled}
+                onClick={this.saveAndClose}
+              >
+                Save
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
+OfficeEditor.propTypes = {
+  updateStorageInTransit: PropTypes.func.isRequired,
+  onClose: PropTypes.func.isRequired,
+  storageInTransit: PropTypes.object.isRequired,
+  submitForm: PropTypes.func.isRequired,
+};
+
+function mapStateToProps(state) {
+  return {
+    formEnabled:
+      isValid(StorageInTransitOfficeEditFormName)(state) && !isSubmitting(StorageInTransitOfficeEditFormName)(state),
+    hasSubmitSucceeded: hasSubmitSucceeded(StorageInTransitOfficeEditFormName)(state),
+  };
+}
+
+function mapDispatchToProps(dispatch) {
+  // Bind an action, which submit the form by its name
+  return bindActionCreators(
+    {
+      submitForm: () => submit(StorageInTransitOfficeEditFormName),
+    },
+    dispatch,
+  );
+}
+export default connect(mapStateToProps, mapDispatchToProps)(OfficeEditor);

--- a/src/shared/StorageInTransit/OfficeEditor.jsx
+++ b/src/shared/StorageInTransit/OfficeEditor.jsx
@@ -52,7 +52,7 @@ export class OfficeEditor extends Component {
             </div>
             <div className="usa-width-one-half align-right">
               <button
-                className="button usa-button-primary storage-in-transit-request-form-send-request-button"
+                className="button usa-button-primary"
                 disabled={!this.props.formEnabled}
                 onClick={this.saveAndClose}
               >

--- a/src/shared/StorageInTransit/OfficeEditor.test.jsx
+++ b/src/shared/StorageInTransit/OfficeEditor.test.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 
-import { Editor } from './Editor';
+import { OfficeEditor } from './OfficeEditor';
 
 const storageInTransit = {
   estimated_start_date: '2019-02-12',
@@ -30,7 +30,7 @@ describe('given an editor', () => {
     beforeEach(() => {
       cancel.mockClear();
       wrapper = shallow(
-        <Editor
+        <OfficeEditor
           updateStorageInTransit={updateStorageInTransit}
           onClose={onClose}
           storageInTransit={storageInTransit}
@@ -54,7 +54,7 @@ describe('given an editor', () => {
     beforeEach(() => {
       cancel.mockClear();
       wrapper = shallow(
-        <Editor
+        <OfficeEditor
           updateStorageInTransit={updateStorageInTransit}
           onClose={onClose}
           storageInTransit={storageInTransit}

--- a/src/shared/StorageInTransit/PlaceInSit.jsx
+++ b/src/shared/StorageInTransit/PlaceInSit.jsx
@@ -45,10 +45,7 @@ export class PlaceInSit extends Component {
             </p>
           </div>
           <div className="usa-width-one-half align-right">
-            <button
-              className="button usa-button-primary storage-in-transit-request-form-send-request-button"
-              disabled={!this.props.formEnabled}
-            >
+            <button className="button usa-button-primary" disabled={!this.props.formEnabled}>
               Approve
             </button>
           </div>

--- a/src/shared/StorageInTransit/StorageInTransit.css
+++ b/src/shared/StorageInTransit/StorageInTransit.css
@@ -118,3 +118,8 @@
   font-weight: normal;
 }
 
+.storage-in-transit-status {
+  color: #0071bc;
+  font-weight: normal;
+}
+

--- a/src/shared/StorageInTransit/StorageInTransit.css
+++ b/src/shared/StorageInTransit/StorageInTransit.css
@@ -1,9 +1,6 @@
 .storage-in-transit-panel-modal {
   border: 3px dashed #00a6d2;
-  padding-left: 1.7rem;
-  padding-right: 1.7rem;
-  padding-top: 16px;
-  padding-bottom: 9px;
+  padding: 16px 1.7rem 9px 1.7rem;
   margin-top: 20px;
 }
 
@@ -43,7 +40,6 @@
 .add-storage-in-transit {
   border-top: 1px solid #f1f1f1;
   padding-top: 0.5em;
-
 }
 
 .storage-in-transit {
@@ -97,7 +93,15 @@
   font-weight: normal;
 }
 
+.storage-in-transit-office-edit-form {
+  font-weight: normal;
+}
+
 .storage-in-transit-office-approval-form textarea {
+  height: 9rem;
+}
+
+.storage-in-transit-office-edit-form textarea {
   height: 9rem;
 }
 
@@ -121,5 +125,9 @@
 .storage-in-transit-status {
   color: #0071bc;
   font-weight: normal;
+}
+
+.warehouse-field-margin {
+  margin-top: 10px;
 }
 

--- a/src/shared/StorageInTransit/StorageInTransit.css
+++ b/src/shared/StorageInTransit/StorageInTransit.css
@@ -20,10 +20,6 @@
   width: calc(60% + 1.9rem);
 }
 
-.storage-in-transit-request-form textarea {
-  height: 9rem;
-}
-
 .storage-in-transit-warehouse-id {
   width: calc(60% + 1.9rem);
 }
@@ -89,37 +85,25 @@
   font-weight: normal;
 }
 
-.storage-in-transit-office-approval-form {
+.storage-in-transit-form {
   font-weight: normal;
 }
 
-.storage-in-transit-office-edit-form {
-  font-weight: normal;
-}
-
-.storage-in-transit-office-approval-form textarea {
+.storage-in-transit-form textarea {
   height: 9rem;
-}
-
-.storage-in-transit-office-edit-form textarea {
-  height: 9rem;
-}
-
-.storage-in-transit-office-deny-form {
-  font-weight: normal;
 }
 
 .place-in-sit-form {
   font-weight: normal;
 }
 
+.storage-in-transit-office-deny-form {
+  font-weight: normal;
+}
+
 .storage-in-transit-office-deny-form textarea {
   width: 45rem;
   height: 6rem;
-}
-
-.storage-in-transit-request-form {
-  font-weight: normal;
 }
 
 .storage-in-transit-status {

--- a/src/shared/StorageInTransit/StorageInTransit.jsx
+++ b/src/shared/StorageInTransit/StorageInTransit.jsx
@@ -196,7 +196,7 @@ export class StorageInTransit extends Component {
             <OfficeEditor
               updateStorageInTransit={this.onSubmit}
               onClose={this.closeOfficeEditForm}
-              storageInTransit={storageInTransit}
+              storageInTransit={this.state.storageInTransit}
             />
           ) : (
             (storageInTransit.status === 'APPROVED' || storageInTransit.status === 'DENIED') &&

--- a/src/shared/StorageInTransit/StorageInTransit.jsx
+++ b/src/shared/StorageInTransit/StorageInTransit.jsx
@@ -42,8 +42,16 @@ export class StorageInTransit extends Component {
   authorizedStartDate = () => {
     const { storageInTransit } = this.props;
     return storageInTransit.authorized_start_date
-      ? storageInTransit.authorized_start_date
+      ? this.storageInTransitAuthorizedStartDate()
       : this.assignEstimatedStartDateToAuthorizedStartDate();
+  };
+
+  storageInTransitAuthorizedStartDate = () => {
+    this.setState({
+      storageInTransit: {
+        ...this.props.storageInTransit,
+      },
+    });
   };
 
   assignEstimatedStartDateToAuthorizedStartDate = () => {

--- a/src/shared/StorageInTransit/StorageInTransit.jsx
+++ b/src/shared/StorageInTransit/StorageInTransit.jsx
@@ -13,7 +13,8 @@ import faSignInAlt from '@fortawesome/fontawesome-free-solid/faSignInAlt';
 
 import './StorageInTransit.css';
 import { formatDate4DigitYear } from 'shared/formatters';
-import Editor from 'shared/StorageInTransit/Editor';
+import TspEditor from 'shared/StorageInTransit/TspEditor';
+import OfficeEditor from 'shared/StorageInTransit/OfficeEditor';
 import ApproveSitRequest from 'shared/StorageInTransit/ApproveSitRequest';
 import DenySitRequest from 'shared/StorageInTransit/DenySitRequest';
 import PlaceInSit from 'shared/StorageInTransit/PlaceInSit';
@@ -25,7 +26,8 @@ export class StorageInTransit extends Component {
   constructor() {
     super();
     this.state = {
-      showEditForm: false,
+      showTspEditForm: false,
+      showOfficeEditForm: false,
       showApproveForm: false,
       showDenyForm: false,
       showPlaceInSitForm: false,
@@ -53,12 +55,20 @@ export class StorageInTransit extends Component {
     });
   };
 
-  openEditForm = () => {
-    this.setState({ showEditForm: true });
+  openTspEditForm = () => {
+    this.setState({ showTspEditForm: true });
   };
 
-  closeEditForm = () => {
-    this.setState({ showEditForm: false });
+  closeTspEditForm = () => {
+    this.setState({ showTspEditForm: false });
+  };
+
+  openOfficeEditForm = () => {
+    this.setState({ showOfficeEditForm: true });
+  };
+
+  closeOfficeEditForm = () => {
+    this.setState({ showOfficeEditForm: false });
   };
 
   openApproveForm = () => {
@@ -95,7 +105,7 @@ export class StorageInTransit extends Component {
 
   render() {
     const { storageInTransit } = this.props;
-    const { showEditForm, showApproveForm, showDenyForm, showPlaceInSitForm } = this.state;
+    const { showTspEditForm, showOfficeEditForm, showApproveForm, showDenyForm, showPlaceInSitForm } = this.state;
     return (
       <div className="storage-in-transit">
         <div className="column-head">
@@ -105,12 +115,26 @@ export class StorageInTransit extends Component {
             <span className="sit-status-text">Status:</span>{' '}
             {storageInTransit.status === 'REQUESTED' && <SitStatusIcon isTspSite={isTspSite} />}
           </span>
-          <span>SIT {capitalize(storageInTransit.status)} </span>
+          {storageInTransit.status === 'APPROVED' ? (
+            <span>
+              <FontAwesomeIcon className="icon approval-ready" icon={faCheck} />
+              Approved
+            </span>
+          ) : storageInTransit.status === 'DENIED' ? (
+            <span className="storage-in-transit-status">
+              <FontAwesomeIcon className="icon approval-problem" icon={faBan} />
+              Denied
+            </span>
+          ) : (
+            <span>SIT {capitalize(storageInTransit.status)} </span>
+          )}
           {showApproveForm ? (
             <ApproveSitRequest onClose={this.closeApproveForm} storageInTransit={this.state.storageInTransit} />
+          ) : storageInTransit.status === 'APPROVED' || storageInTransit.status === 'DENIED' ? (
+            <span>{null}</span>
           ) : (
             isOfficeSite &&
-            !showEditForm &&
+            !showTspEditForm &&
             !showDenyForm && (
               <span className="sit-actions">
                 <a className="approve-sit-link" onClick={this.openApproveForm}>
@@ -122,9 +146,11 @@ export class StorageInTransit extends Component {
           )}
           {showDenyForm ? (
             <DenySitRequest onClose={this.closeDenyForm} />
+          ) : storageInTransit.status === 'APPROVED' || storageInTransit.status === 'DENIED' ? (
+            <span>{null}</span>
           ) : (
             isOfficeSite &&
-            !showEditForm &&
+            !showTspEditForm &&
             !showApproveForm && (
               <span className="sit-actions">
                 <a className="deny-sit-link" onClick={this.openDenyForm}>
@@ -147,30 +173,39 @@ export class StorageInTransit extends Component {
               </span>
             )
           )}
-          {showEditForm ? (
-            <Editor
+          {showTspEditForm ? (
+            <TspEditor
               updateStorageInTransit={this.onSubmit}
-              onClose={this.closeEditForm}
+              onClose={this.closeTspEditForm}
               storageInTransit={storageInTransit}
             />
-          ) : isOfficeSite ? (
-            <span className="sit-actions">
-              <span className="sit-edit actionable">
-                {storageInTransit.status === 'APPROVED' &&
-                  !showApproveForm &&
-                  !showDenyForm && (
-                    <a onClick={this.openEditForm}>
-                      <FontAwesomeIcon className="icon" icon={faPencil} />
-                      Edit
-                    </a>
-                  )}
-              </span>
-            </span>
           ) : (
-            storageInTransit.status !== 'APPROVED' && (
+            isTspSite &&
+            storageInTransit.status === 'APPROVED' && (
               <span className="sit-actions">
                 <span className="sit-edit actionable">
-                  <a onClick={this.openEditForm}>
+                  <a onClick={this.openTspEditForm}>
+                    <FontAwesomeIcon className="icon" icon={faPencil} />
+                    Edit
+                  </a>
+                </span>
+              </span>
+            )
+          )}
+          {showOfficeEditForm ? (
+            <OfficeEditor
+              updateStorageInTransit={this.onSubmit}
+              onClose={this.closeOfficeEditForm}
+              storageInTransit={storageInTransit}
+            />
+          ) : (
+            (storageInTransit.status === 'APPROVED' || storageInTransit.status === 'DENIED') &&
+            isOfficeSite &&
+            !showApproveForm &&
+            !showDenyForm && (
+              <span className="sit-actions">
+                <span className="sit-edit actionable">
+                  <a onClick={this.openOfficeEditForm}>
                     <FontAwesomeIcon className="icon" icon={faPencil} />
                     Edit
                   </a>
@@ -179,7 +214,7 @@ export class StorageInTransit extends Component {
             )
           )}
         </div>
-        {!showEditForm && (
+        {!showTspEditForm && (
           <div className="usa-width-one-whole">
             <div className="usa-width-one-half">
               <div className="column-subhead nested__same-font">Dates</div>

--- a/src/shared/StorageInTransit/StorageInTransit.jsx
+++ b/src/shared/StorageInTransit/StorageInTransit.jsx
@@ -115,12 +115,14 @@ export class StorageInTransit extends Component {
     const { storageInTransit } = this.props;
     const { showTspEditForm, showOfficeEditForm, showApproveForm, showDenyForm, showPlaceInSitForm } = this.state;
     return (
-      <div className="storage-in-transit">
+      <div className="storage-in-transit" data-cy="storage-in-transit">
         <div className="column-head">
           {capitalize(storageInTransit.location)} SIT
           <span className="unbold">
             {' '}
-            <span className="sit-status-text">Status:</span>{' '}
+            <span className="sit-status-text" data-cy="sit-status-text">
+              Status:
+            </span>{' '}
             {storageInTransit.status === 'REQUESTED' && <SitStatusIcon isTspSite={isTspSite} />}
           </span>
           {storageInTransit.status === 'APPROVED' ? (

--- a/src/shared/StorageInTransit/StorageInTransit.jsx
+++ b/src/shared/StorageInTransit/StorageInTransit.jsx
@@ -181,7 +181,7 @@ export class StorageInTransit extends Component {
             />
           ) : (
             isTspSite &&
-            storageInTransit.status === 'APPROVED' && (
+            storageInTransit.status !== 'APPROVED' && (
               <span className="sit-actions">
                 <span className="sit-edit actionable">
                   <a onClick={this.openTspEditForm}>

--- a/src/shared/StorageInTransit/StorageInTransitForm.jsx
+++ b/src/shared/StorageInTransit/StorageInTransitForm.jsx
@@ -13,7 +13,7 @@ export class StorageInTransitForm extends Component {
     const { storageInTransitSchema, addressSchema } = this.props;
     const warehouseAddress = get(this.props, 'formValues.warehouse_address');
     return (
-      <form onSubmit={this.props.handleSubmit(this.props.onSubmit)} className="storage-in-transit-request-form">
+      <form onSubmit={this.props.handleSubmit(this.props.onSubmit)} className="storage-in-transit-form">
         <fieldset key="sit-request-information">
           <div className="editable-panel-column">
             <SwaggerField

--- a/src/shared/StorageInTransit/StorageInTransitForm.test.jsx
+++ b/src/shared/StorageInTransit/StorageInTransitForm.test.jsx
@@ -59,7 +59,7 @@ describe('StorageInTransit tests', () => {
     );
 
     it('renders without crashing', () => {
-      expect(wrapper.find('.storage-in-transit-request-form').length).toEqual(1);
+      expect(wrapper.find('.storage-in-transit-form').length).toEqual(1);
     });
   });
 });

--- a/src/shared/StorageInTransit/StorageInTransitOfficeApprovalForm.jsx
+++ b/src/shared/StorageInTransit/StorageInTransitOfficeApprovalForm.jsx
@@ -14,7 +14,7 @@ export class StorageInTransitOfficeApprovalForm extends Component {
   render() {
     const { storageInTransitSchema } = this.props;
     return (
-      <form onSubmit={this.handleSubmit} className="storage-in-transit-office-approval-form">
+      <form onSubmit={this.handleSubmit} className="storage-in-transit-form">
         <fieldset key="sit-approval-information">
           <div className="editable-panel-column">
             <SwaggerField

--- a/src/shared/StorageInTransit/StorageInTransitOfficeApprovalForm.test.jsx
+++ b/src/shared/StorageInTransit/StorageInTransitOfficeApprovalForm.test.jsx
@@ -38,7 +38,7 @@ describe('StorageInTransitOfficeApprovalForm tests', () => {
     );
 
     it('renders without crashing', () => {
-      expect(wrapper.find('.storage-in-transit-office-approval-form').length).toEqual(1);
+      expect(wrapper.find('.storage-in-transit-form').length).toEqual(1);
     });
   });
 });

--- a/src/shared/StorageInTransit/StorageInTransitOfficeEditForm.jsx
+++ b/src/shared/StorageInTransit/StorageInTransitOfficeEditForm.jsx
@@ -28,7 +28,7 @@ export class StorageInTransitOfficeEditForm extends Component {
 
     return (
       <form onSubmit={this.props.handleSubmit(this.props.onSubmit)} className="storage-in-transit-office-edit-form">
-        <div className="editable-panel-2-column">
+        <div className="editable-panel-column">
           <PanelSwaggerField fieldName="location" required title="SIT location" {...fieldProps} />
           <PanelSwaggerField fieldName="estimated_start_date" required title="Estimated start date" {...fieldProps} />
           <PanelField value="n/a" fieldName="actual_start_date" required title="Actual start date" {...fieldProps} />
@@ -37,26 +37,24 @@ export class StorageInTransitOfficeEditForm extends Component {
           <PanelField value="n/a" fieldName="expires" required title="Expires" {...fieldProps} />
           <PanelSwaggerField fieldName="notes" optional title="Note" {...fieldProps} />
         </div>
-        <div className="editable-panel-2-column">
+        <div className="editable-panel-column">
           <div className="panel-subhead">Authorization</div>
           <PanelField value={sitStatus()} fieldName="status" required title="SIT Approved" {...fieldProps} />
-          <PanelField
-            value="n/a"
+          <SwaggerField
             fieldName="authorized_start_date"
-            required
+            swagger={storageInTransitSchema}
             title="Earliest authorized start"
-            {...fieldProps}
+            required
           />
           <SwaggerField
             className="sit-approval-field"
             fieldName="authorization_notes"
             title="Note from reviewer"
             swagger={storageInTransitSchema}
-            required
           />
           <PanelField value="9999999999" fieldName="sit_number" title="SIT number" {...fieldProps} />
           <div className="panel-field">
-            <span className="field-value">Warehouse</span>
+            <span className="field-value warehouse-field-margin">Warehouse</span>
             <span className="field-title">{storageInTransit.warehouse_name}</span>
             <span className="field-title">{storageInTransit.warehouse_address.street_address_1}</span>
             <span className="field-title">{storageInTransit.warehouse_address.street_address_2}</span>

--- a/src/shared/StorageInTransit/StorageInTransitOfficeEditForm.jsx
+++ b/src/shared/StorageInTransit/StorageInTransitOfficeEditForm.jsx
@@ -20,9 +20,9 @@ export class StorageInTransitOfficeEditForm extends Component {
 
     const sitStatus = () => {
       if (storageInTransit.status === 'APPROVED') {
-        return <span>Yes</span>;
+        return 'Yes';
       } else {
-        return <span>No</span>;
+        return 'No';
       }
     };
 

--- a/src/shared/StorageInTransit/StorageInTransitOfficeEditForm.jsx
+++ b/src/shared/StorageInTransit/StorageInTransitOfficeEditForm.jsx
@@ -27,7 +27,7 @@ export class StorageInTransitOfficeEditForm extends Component {
     };
 
     return (
-      <form onSubmit={this.props.handleSubmit(this.props.onSubmit)} className="storage-in-transit-office-edit-form">
+      <form onSubmit={this.props.handleSubmit(this.props.onSubmit)} className="storage-in-transit-form">
         <div className="editable-panel-column">
           <PanelSwaggerField fieldName="location" required title="SIT location" {...fieldProps} />
           <PanelSwaggerField fieldName="estimated_start_date" required title="Estimated start date" {...fieldProps} />

--- a/src/shared/StorageInTransit/StorageInTransitOfficeEditForm.jsx
+++ b/src/shared/StorageInTransit/StorageInTransitOfficeEditForm.jsx
@@ -1,0 +1,94 @@
+import { get } from 'lodash';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+import { reduxForm } from 'redux-form';
+import { SwaggerField } from 'shared/JsonSchemaForm/JsonSchemaField';
+import { PanelSwaggerField, PanelField } from 'shared/EditablePanel';
+
+import './StorageInTransit.css';
+
+export class StorageInTransitOfficeEditForm extends Component {
+  render() {
+    const { storageInTransitSchema } = this.props;
+    const schema = this.props.storageInTransitSchema;
+    const storageInTransit = this.props.initialValues;
+    const fieldProps = {
+      schema,
+      values: this.props.initialValues,
+    };
+
+    const sitStatus = () => {
+      if (storageInTransit.status === 'APPROVED') {
+        return <span>Yes</span>;
+      } else {
+        return <span>No</span>;
+      }
+    };
+
+    return (
+      <form onSubmit={this.props.handleSubmit(this.props.onSubmit)} className="storage-in-transit-office-edit-form">
+        <div className="editable-panel-2-column">
+          <PanelSwaggerField fieldName="location" required title="SIT location" {...fieldProps} />
+          <PanelSwaggerField fieldName="estimated_start_date" required title="Estimated start date" {...fieldProps} />
+          <PanelField value="n/a" fieldName="actual_start_date" required title="Actual start date" {...fieldProps} />
+          <PanelField value="n/a" fieldName="out_date" required title="Date out" {...fieldProps} />
+          <PanelField value="n/a" fieldName="days_used" required title="Days used" {...fieldProps} />
+          <PanelField value="n/a" fieldName="expires" required title="Expires" {...fieldProps} />
+          <PanelSwaggerField fieldName="notes" optional title="Note" {...fieldProps} />
+        </div>
+        <div className="editable-panel-2-column">
+          <div className="panel-subhead">Authorization</div>
+          <PanelField value={sitStatus()} fieldName="status" required title="SIT Approved" {...fieldProps} />
+          <PanelField
+            value="n/a"
+            fieldName="authorized_start_date"
+            required
+            title="Earliest authorized start"
+            {...fieldProps}
+          />
+          <SwaggerField
+            className="sit-approval-field"
+            fieldName="authorization_notes"
+            title="Note from reviewer"
+            swagger={storageInTransitSchema}
+            required
+          />
+          <PanelField value="9999999999" fieldName="sit_number" title="SIT number" {...fieldProps} />
+          <div className="panel-field">
+            <span className="field-value">Warehouse</span>
+            <span className="field-title">{storageInTransit.warehouse_name}</span>
+            <span className="field-title">{storageInTransit.warehouse_address.street_address_1}</span>
+            <span className="field-title">{storageInTransit.warehouse_address.street_address_2}</span>
+            <span className="field-title">{storageInTransit.warehouse_address.street_address_3}</span>
+            <span className="field-title">
+              {storageInTransit.warehouse_address.city}, {storageInTransit.warehouse_address.state}{' '}
+              {storageInTransit.warehouse_address.postal_code}
+            </span>
+          </div>
+        </div>
+      </form>
+    );
+  }
+}
+
+StorageInTransitOfficeEditForm.propTypes = {
+  storageInTransitSchema: PropTypes.object.isRequired,
+  onSubmit: PropTypes.func.isRequired,
+};
+
+export const formName = 'storage_in_transit_office_edit_form';
+
+StorageInTransitOfficeEditForm = reduxForm({
+  form: formName,
+  enableReinitialize: true,
+  keepDirtyOnReinitialize: true,
+})(StorageInTransitOfficeEditForm);
+
+function mapStateToProps(state) {
+  return {
+    storageInTransitSchema: get(state, 'swaggerPublic.spec.definitions.StorageInTransit', {}),
+  };
+}
+
+export default connect(mapStateToProps)(StorageInTransitOfficeEditForm);

--- a/src/shared/StorageInTransit/StorageInTransitOfficeEditForm.test.jsx
+++ b/src/shared/StorageInTransit/StorageInTransitOfficeEditForm.test.jsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import { StorageInTransitOfficeEditForm } from './StorageInTransitOfficeEditForm';
+
+let store;
+const mockStore = configureStore();
+const submit = jest.fn();
+
+const storageInTransitSchema = {
+  properties: {
+    location: {
+      type: 'string',
+      title: 'SIT Location',
+    },
+    estimated_start_date: {
+      type: 'string',
+      format: 'date',
+      example: '2018-04-26',
+      title: 'Estimated start date',
+    },
+    warehouse_id: {
+      type: 'string',
+      example: '000383',
+      title: 'Warehouse Name',
+    },
+    warehouse_name: {
+      type: 'string',
+      example: 'ABC Warehouse, Inc.',
+      title: 'Warehouse Name',
+    },
+    notes: {
+      type: 'string',
+      example: 'Good to go!',
+      format: 'textarea',
+      title: 'Note',
+    },
+  },
+};
+
+const storageInTransit = {
+  estimated_start_date: '2019-02-12',
+  id: '5cd370a1-ac3d-4fb3-86a3-c4f23e289687',
+  shipment_id: 'dd67cec5-334a-4209-a9d9-a14485414052',
+  status: 'APPROVED',
+  warehouse_address: {
+    city: 'Beverly Hills',
+    postal_code: '90210',
+    state: 'CA',
+    street_address_1: '123 Any Street',
+  },
+  warehouse_id: '76567867',
+  warehouse_name: 'haus',
+};
+
+describe('StorageInTransitOfficeEditForm tests', () => {
+  describe('Empty form', () => {
+    let wrapper;
+    store = mockStore({});
+    wrapper = mount(
+      <Provider store={store}>
+        <StorageInTransitOfficeEditForm
+          onSubmit={submit}
+          storageInTransitSchema={storageInTransitSchema}
+          initialValues={storageInTransit}
+        />
+      </Provider>,
+    );
+
+    it('renders without crashing', () => {
+      expect(wrapper.find('.storage-in-transit-office-edit-form').length).toEqual(1);
+    });
+  });
+});

--- a/src/shared/StorageInTransit/StorageInTransitOfficeEditForm.test.jsx
+++ b/src/shared/StorageInTransit/StorageInTransitOfficeEditForm.test.jsx
@@ -69,7 +69,7 @@ describe('StorageInTransitOfficeEditForm tests', () => {
     );
 
     it('renders without crashing', () => {
-      expect(wrapper.find('.storage-in-transit-office-edit-form').length).toEqual(1);
+      expect(wrapper.find('.storage-in-transit-form').length).toEqual(1);
     });
   });
 });

--- a/src/shared/StorageInTransit/StorageInTransitPanel.test.jsx
+++ b/src/shared/StorageInTransit/StorageInTransitPanel.test.jsx
@@ -23,7 +23,7 @@ describe('StorageInTransit tests', () => {
     );
 
     it('renders without crashing', () => {
-      expect(wrapper.find('.storage-in-transit-panel').length).toEqual(1);
+      expect(wrapper.find('[data-cy="storage-in-transit-panel"]').length).toEqual(1);
     });
   });
   describe('When no items exists and Request SIT appears on TSP app', () => {
@@ -39,8 +39,8 @@ describe('StorageInTransit tests', () => {
     );
 
     it('renders without crashing', () => {
-      expect(wrapper.find('.storage-in-transit-panel').length).toEqual(1);
-      expect(wrapper.find('.add-request').length).toEqual(1);
+      expect(wrapper.find('[data-cy="storage-in-transit-panel"]').length).toEqual(1);
+      expect(wrapper.find('[data-cy="add-request"]').length).toEqual(1);
     });
   });
   describe('When no items exists and Request SIT appears on Office app', () => {
@@ -56,8 +56,8 @@ describe('StorageInTransit tests', () => {
     );
 
     it('renders without crashing', () => {
-      expect(wrapper.find('.storage-in-transit-panel').length).toEqual(1);
-      expect(wrapper.find('.add-request').length).toEqual(0);
+      expect(wrapper.find('[data-cy="storage-in-transit-panel"]').length).toEqual(1);
+      expect(wrapper.find('[data-cy="add-request"]').length).toEqual(0);
     });
   });
 
@@ -108,7 +108,7 @@ describe('StorageInTransit tests', () => {
     );
 
     it('renders without crashing', () => {
-      expect(wrapper.find('.storage-in-transit-panel').length).toEqual(1);
+      expect(wrapper.find('[data-cy="storage-in-transit-panel"]').length).toEqual(1);
     });
 
     it('renders the first mocked Storage In Transit request', () => {

--- a/src/shared/StorageInTransit/TspEditor.jsx
+++ b/src/shared/StorageInTransit/TspEditor.jsx
@@ -49,7 +49,7 @@ export class TspEditor extends Component {
           </div>
           <div className="usa-width-one-half align-right">
             <button
-              className="button usa-button-primary storage-in-transit-request-form-send-request-button"
+              className="button usa-button-primary"
               disabled={!this.props.formEnabled}
               onClick={this.saveAndClose}
             >

--- a/src/shared/StorageInTransit/TspEditor.jsx
+++ b/src/shared/StorageInTransit/TspEditor.jsx
@@ -9,7 +9,7 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import StorageInTransitForm, { formName as StorageInTransitFormName } from './StorageInTransitForm.jsx';
 
-export class Editor extends Component {
+export class TspEditor extends Component {
   state = {
     closeOnSubmit: true,
   };
@@ -62,7 +62,7 @@ export class Editor extends Component {
   }
 }
 
-Editor.propTypes = {
+TspEditor.propTypes = {
   updateStorageInTransit: PropTypes.func.isRequired,
   onClose: PropTypes.func.isRequired,
   storageInTransit: PropTypes.object.isRequired,
@@ -85,4 +85,4 @@ function mapDispatchToProps(dispatch) {
     dispatch,
   );
 }
-export default connect(mapStateToProps, mapDispatchToProps)(Editor);
+export default connect(mapStateToProps, mapDispatchToProps)(TspEditor);

--- a/src/shared/StorageInTransit/TspEditor.test.jsx
+++ b/src/shared/StorageInTransit/TspEditor.test.jsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import { TspEditor } from './TspEditor';
+
+const storageInTransit = {
+  estimated_start_date: '2019-02-12',
+  id: '5cd370a1-ac3d-4fb3-86a3-c4f23e289687',
+  location: 'ORIGIN',
+  shipment_id: 'dd67cec5-334a-4209-a9d9-a14485414052',
+  status: 'REQUESTED',
+  warehouse_address: {
+    city: 'Beverly Hills',
+    postal_code: '90210',
+    state: 'CA',
+    street_address_1: '123 Any Street',
+  },
+  warehouse_id: '76567867',
+  warehouse_name: 'haus',
+};
+
+let wrapper;
+const cancel = jest.fn();
+const updateStorageInTransit = jest.fn();
+const onClose = jest.fn();
+const saveAndClose = jest.fn();
+
+describe('given an editor', () => {
+  describe('when the form is disabled', () => {
+    beforeEach(() => {
+      cancel.mockClear();
+      wrapper = shallow(
+        <TspEditor
+          updateStorageInTransit={updateStorageInTransit}
+          onClose={onClose}
+          storageInTransit={storageInTransit}
+          submitForm={saveAndClose}
+          formEnabled={false}
+          hasSubmitSucceeded={false}
+        />,
+      );
+    });
+
+    it('renders without crashing', () => {
+      expect(wrapper.exists('.storage-in-transit-panel-modal')).toBe(true);
+    });
+
+    it('buttons are disabled', () => {
+      expect(wrapper.find('button.usa-button-primary').prop('disabled')).toBeTruthy();
+    });
+  });
+
+  describe('when the form is enabled', () => {
+    beforeEach(() => {
+      cancel.mockClear();
+      wrapper = shallow(
+        <TspEditor
+          updateStorageInTransit={updateStorageInTransit}
+          onClose={onClose}
+          storageInTransit={storageInTransit}
+          submitForm={saveAndClose}
+          formEnabled={true}
+          hasSubmitSucceeded={false}
+        />,
+      );
+    });
+
+    it('renders without crashing', () => {
+      // eslint-disable-next-line
+      expect(wrapper.exists('.storage-in-transit-panel-modal')).toBe(true);
+    });
+
+    it('buttons are enabled', () => {
+      expect(wrapper.find('button.usa-button-primary').prop('disabled')).toBe(false);
+    });
+
+    it('clicking save calls saveEdit', () => {
+      wrapper.find('button.usa-button-primary').simulate('click');
+      expect(saveAndClose.mock.calls.length).toBe(1);
+    });
+  });
+});


### PR DESCRIPTION
## Description

Adds edit icon and form for approving sit requests. Also adds the logic to handle the various transitions between the icons and forms in the sit panel. 

## Reviewer Notes

Might make sense to break up the logic a bit so it's not all in one file. Conversely, we could end up with a bunch of files that are a pain to navigate.

## Setup

Add any steps or code to run in this section to help others prepare to run your code:


```sh
make db_dev_e2e_populate
make server_run
make client_run
```
In the Office app, select an HHG record with an `APPROVED` SIT. In the SIT panel you will see an 'Edit' link. Clicking on this will open up a form that shoes the various SIT information, with an editable authorized notes field. All other fields are informational and not editable.

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/164251823) for this change

## Screenshots

![Apr-11-2019 14-19-56](https://user-images.githubusercontent.com/3522044/55993872-05c8aa80-5c65-11e9-9ed6-5c195e5c40a4.gif)

