### PR TITLE
Remove gosec

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -118,16 +118,6 @@ repos:
 
   - repo: local
     hooks:
-      - id: gosec
-        name: gosec scanner
-        entry: bin/gosec -exclude=G104 -fmt text ./...
-        language: script
-        description: Inspects source code for security problems by scanning the Go AST.
-        files: \.go$
-        pass_filenames: false
-
-  - repo: local
-    hooks:
       - id: gomod
         name: gomod
         entry: scripts/pre-commit-go-mod


### PR DESCRIPTION
## Description

`gosec` doesn't work with go modules yet.  See https://github.com/securego/gosec/issues/234

## Reviewer Notes

If you run `bin/gosec -exclude=G104 -fmt text github.com/transcom/mymove/pkg/auth` directly you get a stream of `could not import` errors.

## Setup

N.A.

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](./docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](./docs/backend.md#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](./docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
  * [ ] Secure migrations have been tested using `scripts/run-prod-migrations`
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers](./docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @ntwyman
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* https://github.com/securego/gosec/issues/234

## Screenshots

N.A.