### PR TITLE
Add Normalizer Function for Edipi (DoD ID) fields [delivers #164807455]

### DIFF
--- a/src/scenes/ServiceMembers/DodInfo.jsx
+++ b/src/scenes/ServiceMembers/DodInfo.jsx
@@ -5,7 +5,7 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { getFormValues } from 'redux-form';
 import { Field } from 'redux-form';
-import validator from 'shared/JsonSchemaForm/validator';
+import { normalizeSSN } from 'shared/JsonSchemaForm/reduxFieldNormalizer';
 
 import { updateServiceMember } from './ducks';
 import { reduxifyWizardForm } from 'shared/WizardPage/Form';
@@ -123,12 +123,7 @@ export class DodInfo extends Component {
         <p>Before we can schedule your move, we need to know a little more about you.</p>
         <SwaggerField fieldName="affiliation" swagger={schema} required />
         <SwaggerField fieldName="edipi" swagger={schema} required />
-        <Field
-          name="social_security_number"
-          component={SSNField}
-          ssnOnServer={ssnOnServer}
-          normalize={validator.normalizeSSN}
-        />
+        <Field name="social_security_number" component={SSNField} ssnOnServer={ssnOnServer} normalize={normalizeSSN} />
         <SwaggerField fieldName="rank" swagger={schema} required />
       </DodWizardForm>
     );

--- a/src/shared/JsonSchemaForm/JsonSchemaField.js
+++ b/src/shared/JsonSchemaForm/JsonSchemaField.js
@@ -142,7 +142,8 @@ const configureTextField = (swaggerField, props) => {
 };
 
 const configureEdipiField = (swaggerField, props) => {
-  props.normalize = validator.normalizeEdipi;
+  const maxLengthDodID = 10;
+  props.normalize = validator.createDigitNormalizer(maxLengthDodID);
   props.validate.push(validator.patternMatches(swaggerField.pattern, 'Must be a valid DoD ID #'));
   props.type = 'text';
 

--- a/src/shared/JsonSchemaForm/JsonSchemaField.js
+++ b/src/shared/JsonSchemaForm/JsonSchemaField.js
@@ -1,10 +1,9 @@
 import React, { Fragment } from 'react';
 
+import * as normalizer from './reduxFieldNormalizer';
 import validator from './validator';
 import { Field } from 'redux-form';
-import moment from 'moment';
 import SingleDatePicker from './SingleDatePicker';
-import { swaggerDateFormat } from 'shared/utils';
 export const ALWAYS_REQUIRED_KEY = 'x-always-required';
 
 // ---- Parsers -----
@@ -87,7 +86,7 @@ const configureCentsField = (swaggerField, props) => {
 // This field allows the form field to accept floats and converts values to
 // decimal units for db storage (value * (10 ^ decimalLength))
 const configureDecimalField = (swaggerField, props, decimalLength, warningMessage) => {
-  props.normalize = validator.createDecimalNormalizer(decimalLength);
+  props.normalize = normalizer.createDecimalNormalizer(decimalLength);
   props.validate.push(validator.patternMatches(swaggerField.pattern, warningMessage));
   props.validate.push(validator.isNumber);
   props.type = 'text';
@@ -95,7 +94,7 @@ const configureDecimalField = (swaggerField, props, decimalLength, warningMessag
 };
 
 const configureTelephoneField = (swaggerField, props) => {
-  props.normalize = validator.normalizePhone;
+  props.normalize = normalizer.normalizePhone;
   props.validate.push(
     validator.patternMatches(swaggerField.pattern, 'Number must have 10 digits and a valid area code.'),
   );
@@ -105,7 +104,7 @@ const configureTelephoneField = (swaggerField, props) => {
 };
 
 const configureZipField = (swaggerField, props, zipPattern) => {
-  props.normalize = validator.normalizeZip;
+  props.normalize = normalizer.normalizeZip;
   if (zipPattern) {
     if (zipPattern === 'USA') {
       const zipRegex = '^[0-9]{5}(?:-[0-9]{4})?$';
@@ -119,14 +118,10 @@ const configureZipField = (swaggerField, props, zipPattern) => {
   return props;
 };
 
-const normalizeDates = value => {
-  return value ? moment(value).format(swaggerDateFormat) : value;
-};
-
 const configureDateField = (swaggerField, props) => {
   props.type = 'date';
   props.customComponent = SingleDatePicker;
-  props.normalize = normalizeDates;
+  props.normalize = normalizer.normalizeDates;
   return props;
 };
 
@@ -143,7 +138,7 @@ const configureTextField = (swaggerField, props) => {
 
 const configureEdipiField = (swaggerField, props) => {
   const maxLengthDodID = 10;
-  props.normalize = validator.createDigitNormalizer(maxLengthDodID);
+  props.normalize = normalizer.createDigitNormalizer(maxLengthDodID);
   props.validate.push(validator.patternMatches(swaggerField.pattern, 'Must be a valid DoD ID # (10 digits long)'));
   props.type = 'text';
 

--- a/src/shared/JsonSchemaForm/JsonSchemaField.js
+++ b/src/shared/JsonSchemaForm/JsonSchemaField.js
@@ -137,8 +137,7 @@ const configureTextField = (swaggerField, props) => {
 };
 
 const configureEdipiField = (swaggerField, props) => {
-  const maxLengthDodID = 10;
-  props.normalize = normalizer.createDigitNormalizer(maxLengthDodID);
+  props.normalize = normalizer.createDigitNormalizer(swaggerField.maxLength);
   props.validate.push(validator.patternMatches(swaggerField.pattern, 'Must be a valid DoD ID # (10 digits long)'));
   props.type = 'text';
 

--- a/src/shared/JsonSchemaForm/JsonSchemaField.js
+++ b/src/shared/JsonSchemaForm/JsonSchemaField.js
@@ -142,6 +142,7 @@ const configureTextField = (swaggerField, props) => {
 };
 
 const configureEdipiField = (swaggerField, props) => {
+  props.normalize = validator.normalizeEdipi;
   props.validate.push(validator.patternMatches(swaggerField.pattern, 'Must be a valid DoD ID #'));
   props.type = 'text';
 

--- a/src/shared/JsonSchemaForm/JsonSchemaField.js
+++ b/src/shared/JsonSchemaForm/JsonSchemaField.js
@@ -144,7 +144,7 @@ const configureTextField = (swaggerField, props) => {
 const configureEdipiField = (swaggerField, props) => {
   const maxLengthDodID = 10;
   props.normalize = validator.createDigitNormalizer(maxLengthDodID);
-  props.validate.push(validator.patternMatches(swaggerField.pattern, 'Must be a valid DoD ID #'));
+  props.validate.push(validator.patternMatches(swaggerField.pattern, 'Must be a valid DoD ID # (10 digits long)'));
   props.type = 'text';
 
   return props;

--- a/src/shared/JsonSchemaForm/reduxFieldNormalizer.js
+++ b/src/shared/JsonSchemaForm/reduxFieldNormalizer.js
@@ -74,6 +74,7 @@ const createDigitNormalizer = maxLength => {
     }
 
     // only digits up to the max length
+    // if undefined, max length is length of string
     return value.replace(/[^\d]/g, '').substr(0, maxLength);
   };
 };

--- a/src/shared/JsonSchemaForm/reduxFieldNormalizer.js
+++ b/src/shared/JsonSchemaForm/reduxFieldNormalizer.js
@@ -1,0 +1,101 @@
+/*
+  When you need to put some control between what the user enters and the value that gets stored in
+  Redux, you can use a "normalizer". A normalizer is just a function that gets run every time a value
+  is changed that can transform the value before storing.
+
+  For more information: https://redux-form.com/7.4.2/examples/normalizing/
+*/
+
+import { swaggerDateFormat } from 'shared/utils';
+import moment from 'moment';
+
+const normalizePhone = value => {
+  if (!value) {
+    return value;
+  }
+  const onlyNums = value.replace(/[^\d]/g, '');
+  let normalizedPhone = '';
+  for (let i = 0; i < 10; i++) {
+    if (i >= onlyNums.length) {
+      break;
+    }
+    if (i === 3 || i === 6) {
+      normalizedPhone += '-';
+    }
+    normalizedPhone += onlyNums[i]; // eslint-disable-line security/detect-object-injection
+  }
+  return normalizedPhone;
+};
+
+const normalizeSSN = value => {
+  if (!value) {
+    return value;
+  }
+  const onlyNums = value.replace(/[^\d]/g, '');
+  let normalizedSSN = '';
+  for (let i = 0; i < 9; i++) {
+    if (i >= onlyNums.length) {
+      break;
+    }
+    if (i === 3 || i === 5) {
+      normalizedSSN += '-';
+    }
+    normalizedSSN += onlyNums[i]; // eslint-disable-line security/detect-object-injection
+  }
+  return normalizedSSN;
+};
+
+const normalizeZip = value => {
+  if (!value) {
+    return value;
+  }
+  const onlyNums = value.replace(/[^\d]/g, '');
+  let normalizedZip = '';
+  for (let i = 0; i < 9; i++) {
+    if (i >= onlyNums.length) {
+      break;
+    }
+    if (i === 5) {
+      normalizedZip += '-';
+    }
+    normalizedZip += onlyNums[i]; // eslint-disable-line security/detect-object-injection
+  }
+  return normalizedZip;
+};
+
+const normalizeDates = value => {
+  return value ? moment(value).format(swaggerDateFormat) : value;
+};
+
+const createDigitNormalizer = maxLength => {
+  return value => {
+    if (!value) {
+      return value;
+    }
+
+    // only digits up to the max length
+    return value.replace(/[^\d]/g, '').substr(0, maxLength);
+  };
+};
+
+const createDecimalNormalizer = decimalDigits => {
+  return value => {
+    if (!value) {
+      return value;
+    }
+    value = value.replace(/[^\d.]/g, '');
+
+    if (value.indexOf('.') >= 0) {
+      value =
+        value.substr(0, value.indexOf('.')) +
+        '.' +
+        value
+          .substr(value.indexOf('.') + 1)
+          .replace(/[^\d]/g, '')
+          .substr(0, decimalDigits);
+    }
+    return value;
+  };
+};
+
+export { normalizePhone, normalizeSSN, normalizeZip, normalizeDates, createDecimalNormalizer, createDigitNormalizer };

--- a/src/shared/JsonSchemaForm/validations.test.js
+++ b/src/shared/JsonSchemaForm/validations.test.js
@@ -310,6 +310,24 @@ describe('SchemaField tests', () => {
 
     testField(dimensionsField, dimensionTests);
   });
+
+  describe('DoD ID # field', () => {
+    const dodIDField = {
+      type: 'string',
+      format: 'edipi',
+      example: '5789345789',
+      pattern: '^[0-9]{10}$',
+    };
+
+    const expectedError = 'Must be a valid DoD ID # (10 digits long)';
+    const dodIDTests = [
+      ['1234567890', '1234567890', null],
+      ['asdf1234', '1234', expectedError],
+      ['123456789', '123456789', expectedError],
+    ];
+
+    testField(dodIDField, dodIDTests);
+  });
 });
 
 describe('fields required tests', () => {

--- a/src/shared/JsonSchemaForm/validator.js
+++ b/src/shared/JsonSchemaForm/validator.js
@@ -114,7 +114,7 @@ const createDigitNormalizer = maxLength => {
       return value;
     }
 
-    // only numbers up to 10 digits
+    // only digits up to the max length
     return value.replace(/[^\d]/g, '').substr(0, maxLength);
   };
 };

--- a/src/shared/JsonSchemaForm/validator.js
+++ b/src/shared/JsonSchemaForm/validator.js
@@ -108,13 +108,15 @@ const normalizeZip = (value, previousValue) => {
   return normalizedZip;
 };
 
-const normalizeEdipi = (value, previousValue) => {
-  if (!value) {
-    return value;
-  }
+const createDigitNormalizer = maxLength => {
+  return value => {
+    if (!value) {
+      return value;
+    }
 
-  // only numbers up to 10 digits
-  return value.replace(/[^\d]/g, '').substr(0, 10);
+    // only numbers up to 10 digits
+    return value.replace(/[^\d]/g, '').substr(0, maxLength);
+  };
 };
 
 const createDecimalNormalizer = decimalDigits => {
@@ -162,5 +164,5 @@ export default {
   normalizeZip,
   patternMatches,
   createDecimalNormalizer,
-  normalizeEdipi,
+  createDigitNormalizer,
 };

--- a/src/shared/JsonSchemaForm/validator.js
+++ b/src/shared/JsonSchemaForm/validator.js
@@ -108,6 +108,15 @@ const normalizeZip = (value, previousValue) => {
   return normalizedZip;
 };
 
+const normalizeEdipi = (value, previousValue) => {
+  if (!value) {
+    return value;
+  }
+
+  // only numbers up to 10 digits
+  return value.replace(/[^\d]/g, '').substr(0, 10);
+};
+
 const createDecimalNormalizer = decimalDigits => {
   return value => {
     if (!value) {
@@ -153,4 +162,5 @@ export default {
   normalizeZip,
   patternMatches,
   createDecimalNormalizer,
+  normalizeEdipi,
 };

--- a/src/shared/JsonSchemaForm/validator.js
+++ b/src/shared/JsonSchemaForm/validator.js
@@ -54,91 +54,6 @@ const isDate = value => {
   }
 };
 
-const normalizePhone = (value, previousValue) => {
-  if (!value) {
-    return value;
-  }
-  const onlyNums = value.replace(/[^\d]/g, '');
-  let normalizedPhone = '';
-  for (let i = 0; i < 10; i++) {
-    if (i >= onlyNums.length) {
-      break;
-    }
-    if (i === 3 || i === 6) {
-      normalizedPhone += '-';
-    }
-    normalizedPhone += onlyNums[i]; // eslint-disable-line security/detect-object-injection
-  }
-  return normalizedPhone;
-};
-
-const normalizeSSN = (value, previousValue) => {
-  if (!value) {
-    return value;
-  }
-  const onlyNums = value.replace(/[^\d]/g, '');
-  let normalizedSSN = '';
-  for (let i = 0; i < 9; i++) {
-    if (i >= onlyNums.length) {
-      break;
-    }
-    if (i === 3 || i === 5) {
-      normalizedSSN += '-';
-    }
-    normalizedSSN += onlyNums[i]; // eslint-disable-line security/detect-object-injection
-  }
-  return normalizedSSN;
-};
-
-const normalizeZip = (value, previousValue) => {
-  if (!value) {
-    return value;
-  }
-  const onlyNums = value.replace(/[^\d]/g, '');
-  let normalizedZip = '';
-  for (let i = 0; i < 9; i++) {
-    if (i >= onlyNums.length) {
-      break;
-    }
-    if (i === 5) {
-      normalizedZip += '-';
-    }
-    normalizedZip += onlyNums[i]; // eslint-disable-line security/detect-object-injection
-  }
-  return normalizedZip;
-};
-
-const createDigitNormalizer = maxLength => {
-  return value => {
-    if (!value) {
-      return value;
-    }
-
-    // only digits up to the max length
-    return value.replace(/[^\d]/g, '').substr(0, maxLength);
-  };
-};
-
-const createDecimalNormalizer = decimalDigits => {
-  return value => {
-    if (!value) {
-      return value;
-    }
-    value = value.replace(/[^\d.]/g, '');
-
-    if (value.indexOf('.') >= 0) {
-      value =
-        value.substr(0, value.indexOf('.')) +
-        '.' +
-        value
-          .substr(value.indexOf('.') + 1)
-          .replace(/[^\d]/g, '')
-          .substr(0, decimalDigits);
-    }
-    return value;
-  };
-};
-
 const patternMatches = memoize((pattern, message) => {
   const regex = RegExp(pattern);
   return value => {
@@ -159,10 +74,5 @@ export default {
   isNumber,
   isInteger,
   isDate,
-  normalizePhone,
-  normalizeSSN,
-  normalizeZip,
   patternMatches,
-  createDecimalNormalizer,
-  createDigitNormalizer,
 };

--- a/swagger/api.yaml
+++ b/swagger/api.yaml
@@ -926,6 +926,8 @@ definitions:
         format: edipi
         example: '5789345789'
         pattern: '^[0-9]{10}$'
+        minLength: 10
+        maxLength: 10
         x-nullable: true
         title: DoD ID number
       affiliation:

--- a/swagger/api.yaml
+++ b/swagger/api.yaml
@@ -925,7 +925,7 @@ definitions:
         type: string
         format: edipi
         example: '5789345789'
-        pattern: '^[0-9]{10}$'
+        pattern: '^\d{10}$'
         minLength: 10
         maxLength: 10
         x-nullable: true

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -864,7 +864,7 @@ definitions:
         type: string
         format: edipi
         example: '5789345789'
-        pattern: '^[0-9]{10}$'
+        pattern: '^\d{10}$'
         minLength: 10
         maxLength: 10
         x-nullable: true
@@ -968,7 +968,7 @@ definitions:
       edipi:
         type: string
         format: edipi
-        pattern: '^[0-9]{10}$'
+        pattern: '^\d{10}$'
         minLength: 10
         maxLength: 10
         example: '5789345789'
@@ -1058,7 +1058,7 @@ definitions:
       edipi:
         type: string
         format: edipi
-        pattern: '^[0-9]{10}$'
+        pattern: '^\d{10}$'
         minLength: 10
         maxLength: 10
         example: '5789345789'
@@ -2305,7 +2305,7 @@ definitions:
       edipi:
         type: string
         format: edipi
-        pattern: '^[0-9]{10}$'
+        pattern: '^\d{10}$'
         minLength: 10
         maxLength: 10
         example: '5789345789'

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -865,6 +865,8 @@ definitions:
         format: edipi
         example: '5789345789'
         pattern: '^[0-9]{10}$'
+        minLength: 10
+        maxLength: 10
         x-nullable: true
         title: DoD ID number
       orders:
@@ -967,6 +969,8 @@ definitions:
         type: string
         format: edipi
         pattern: '^[0-9]{10}$'
+        minLength: 10
+        maxLength: 10
         example: '5789345789'
         x-nullable: true
         title: 'DoD ID number'
@@ -1055,6 +1059,8 @@ definitions:
         type: string
         format: edipi
         pattern: '^[0-9]{10}$'
+        minLength: 10
+        maxLength: 10
         example: '5789345789'
         x-nullable: true
         title: DoD ID number
@@ -2300,6 +2306,8 @@ definitions:
         type: string
         format: edipi
         pattern: '^[0-9]{10}$'
+        minLength: 10
+        maxLength: 10
         example: '5789345789'
         title: 'DoD ID #'
       rank:


### PR DESCRIPTION
## Description

This PR adds a normalizer function for all edipi fields (DoD ID) using SwaggerField component. The current validation didn't stop the user from entering in characters that weren't digits and entering in more than 10 characters. We now prevent this with the normalizer function.

## Setup

```
make server_run
make client_run
```

1. Login as a new service member, local build
2. Try to fill out the DoD ID field with non-digits (ha, you can't)
3. Try to fill out the DoD ID field with more than 10 digits (nope)

## Code Review Verification Steps

* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers](./docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/164807455) for this change

## Screenshots

![image](https://user-images.githubusercontent.com/1522549/56154271-f69b7280-5f6c-11e9-9f3c-54a682b9c53c.png)


