### PR TITLE
Remove feature flag check for 35a

### DIFF
--- a/src/shared/Invoice/LineItemTable.jsx
+++ b/src/shared/Invoice/LineItemTable.jsx
@@ -1,5 +1,4 @@
 import React, { PureComponent } from 'react';
-import { get } from 'lodash';
 import PropTypes from 'prop-types';
 import { withContext } from 'shared/AppContext';
 
@@ -11,13 +10,7 @@ import './InvoicePanel.css';
 class LineItemTable extends PureComponent {
   render() {
     const showItem35Missing = item => {
-      const robustAccessorialFlag = get(this.props, 'context.flags.robustAccessorial', false);
-      return (
-        robustAccessorialFlag &&
-        item.tariff400ng_item.code === '35A' &&
-        item.estimate_amount_cents &&
-        !item.actual_amount_cents
-      );
+      return item.tariff400ng_item.code === '35A' && item.estimate_amount_cents && !item.actual_amount_cents;
     };
 
     return (

--- a/src/shared/PreApprovalRequest/DetailsHelper.js
+++ b/src/shared/PreApprovalRequest/DetailsHelper.js
@@ -8,14 +8,14 @@ import { Code105Details } from './Code105Details';
 import { DefaultDetails } from './DefaultDetails';
 import { Code226Details } from './Code226Details';
 
-export function getFormComponent(code, robustAccessorial, initialValues) {
+export function getFormComponent(code, robustAccessorialFlag, initialValues) {
   code = code ? code.toLowerCase() : '';
   const isNew = !initialValues;
   if (code.startsWith('105b') || code.startsWith('105e')) {
     if (isNew || get(initialValues, 'crate_dimensions', false)) return Code105Form;
   } else if (code.startsWith('35')) {
     if (isNew || get(initialValues, 'estimate_amount_cents')) return Code35Form;
-  } else if (robustAccessorial && code.startsWith('226')) {
+  } else if (robustAccessorialFlag && code.startsWith('226')) {
     if (isNew || get(initialValues, 'actual_amount_cents')) return Code226Form;
   }
   return DefaultForm;

--- a/src/shared/PreApprovalRequest/DetailsHelper.js
+++ b/src/shared/PreApprovalRequest/DetailsHelper.js
@@ -13,7 +13,7 @@ export function getFormComponent(code, robustAccessorial, initialValues) {
   const isNew = !initialValues;
   if (code.startsWith('105b') || code.startsWith('105e')) {
     if (isNew || get(initialValues, 'crate_dimensions', false)) return Code105Form;
-  } else if (robustAccessorial && code.startsWith('35')) {
+  } else if (code.startsWith('35')) {
     if (isNew || get(initialValues, 'estimate_amount_cents')) return Code35Form;
   } else if (robustAccessorial && code.startsWith('226')) {
     if (isNew || get(initialValues, 'actual_amount_cents')) return Code226Form;
@@ -24,7 +24,7 @@ export function getFormComponent(code, robustAccessorial, initialValues) {
 export function getDetailsComponent(code, robustAccessorialFlag, isRobustAccessorial) {
   if (!isRobustAccessorial) return DefaultDetails;
   if (code === '105B' || code === '105E') return Code105Details;
-  if (code === '35A' && robustAccessorialFlag) return Code35Details;
+  if (code === '35A') return Code35Details;
   if (code === '226A' && robustAccessorialFlag) return Code226Details;
   return DefaultDetails;
 }

--- a/src/shared/PreApprovalRequest/DetailsHelper.test.js
+++ b/src/shared/PreApprovalRequest/DetailsHelper.test.js
@@ -141,4 +141,16 @@ describe('preApprovals', () => {
       expect(isRobustAccessorial(itemNull)).toEqual(false);
     });
   });
+
+  describe('isNewAccessorial 35A', () => {
+    it('should return true if new accessorial, false if old accessorial', () => {
+      const item35AOld = { tariff400ng_item: { code: '35A' } };
+      const item35ANew = { tariff400ng_item: { code: '35A' }, estimate_amount_cents: 1 };
+      const itemNull = null;
+
+      expect(isRobustAccessorial(item35AOld)).toEqual(false);
+      expect(isRobustAccessorial(item35ANew)).toEqual(true);
+      expect(isRobustAccessorial(itemNull)).toEqual(false);
+    });
+  });
 });


### PR DESCRIPTION
## Description

Release the robust accessorial for 35a, even without the feature flag

## Questions for reviewer
There are a lot of tests in `src/shared/PreApprovalRequest/DetailsHelper.test.js` that are passing that I wouldn't expect to be passing based on the way the code is written. I'd like to dig into that, but it might be outside the purview of this PR. Happy to pick it apart here, or I'll add a chore for us to tackle it later.

## Code Review Verification Steps

* [x] User facing changes have been reviewed by design.
* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/163403046) for this change
