### PR TITLE
PPM weight slider resets if PPM size is changed.

### DIFF
--- a/src/scenes/Moves/Ppm/PPMSizeWizard.jsx
+++ b/src/scenes/Moves/Ppm/PPMSizeWizard.jsx
@@ -12,16 +12,13 @@ import PpmSize from './Size';
 
 export class PpmSizeWizardPage extends Component {
   handleSubmit = () => {
-    const { pendingPpmSize, createOrUpdatePpm, weightInfo, currentPpm } = this.props;
+    const { pendingPpmSize, createOrUpdatePpm, currentPpm } = this.props;
     //todo: we should make sure this move matches the redux state
     const moveId = this.props.match.params.moveId;
     if (pendingPpmSize) {
       let weight = currentPpm.weight_estimate;
-      if (currentPpm.size !== pendingPpmSize || !isFinite(weight)) {
-        // Initialize weight to be mid-range
-        // eslint-disable-next-line security/detect-object-injection
-        let weightRange = weightInfo[pendingPpmSize];
-        weight = weightRange.min + (weightRange.max - weightRange.min) / 2;
+      if (currentPpm.size !== pendingPpmSize || (!isFinite(weight) || weight === 0)) {
+        weight = 0;
       }
 
       return createOrUpdatePpm(moveId, {

--- a/src/scenes/Moves/Ppm/PPMSizeWizard.jsx
+++ b/src/scenes/Moves/Ppm/PPMSizeWizard.jsx
@@ -17,7 +17,7 @@ export class PpmSizeWizardPage extends Component {
     const moveId = this.props.match.params.moveId;
     if (pendingPpmSize) {
       let weight = currentPpm.weight_estimate;
-      if (!isFinite(weight)) {
+      if (currentPpm.size !== pendingPpmSize || !isFinite(weight)) {
         // Initialize weight to be mid-range
         // eslint-disable-next-line security/detect-object-injection
         let weightRange = weightInfo[pendingPpmSize];

--- a/src/scenes/Moves/Ppm/Weight.jsx
+++ b/src/scenes/Moves/Ppm/Weight.jsx
@@ -130,24 +130,41 @@ export class PpmWeight extends Component {
     this.state = {
       pendingPpmWeight: null,
     };
+
+    this.onWeightSelected = this.onWeightSelected.bind(this);
+  }
+
+  getWeightClassMedian() {
+    const { selectedWeightInfo } = this.props;
+    return selectedWeightInfo.min + (selectedWeightInfo.max - selectedWeightInfo.min) / 2;
   }
 
   componentDidMount() {
     const { currentPpm } = this.props;
     if (currentPpm) {
-      this.setState({
-        pendingPpmWeight: currentPpm.weight_estimate,
-      });
-      this.updateIncentive();
+      this.setState(
+        {
+          pendingPpmWeight:
+            currentPpm.weight_estimate && currentPpm.weight_estimate !== 0
+              ? currentPpm.weight_estimate
+              : this.getWeightClassMedian(),
+        },
+        this.updateIncentive,
+      );
     }
   }
   componentDidUpdate(prevProps, prevState) {
     const { currentPpm, hasLoadSuccess } = this.props;
     if (!prevProps.hasLoadSuccess && hasLoadSuccess && currentPpm) {
-      this.setState({
-        pendingPpmWeight: currentPpm.weight_estimate,
-      });
-      this.updateIncentive();
+      this.setState(
+        {
+          pendingPpmWeight:
+            currentPpm.weight_estimate && currentPpm.weight_estimate !== 0
+              ? currentPpm.weight_estimate
+              : this.getWeightClassMedian(),
+        },
+        this.updateIncentive,
+      );
     }
   }
   // this method is used to set the incentive on page load
@@ -156,13 +173,14 @@ export class PpmWeight extends Component {
   updateIncentive() {
     const { currentWeight, currentPpm } = this.props;
     const weight_estimate = get(this.props, 'currentPpm.weight_estimate');
-    if (![this.state.pendingPpmWeight, weight_estimate].includes(currentWeight)) {
-      this.onWeightSelecting(currentWeight);
+    if (![this.state.pendingPpmWeight, weight_estimate].includes(currentWeight) || !currentWeight) {
+      const newWeight = currentWeight && currentWeight !== 0 ? currentWeight : this.state.pendingPpmWeight;
+      this.onWeightSelecting(newWeight);
       this.props.getPpmWeightEstimate(
         currentPpm.original_move_date,
         currentPpm.pickup_postal_code,
         currentPpm.destination_postal_code,
-        currentWeight,
+        newWeight,
       );
     }
   }
@@ -189,7 +207,7 @@ export class PpmWeight extends Component {
       pendingPpmWeight: value,
     });
   };
-  onWeightSelected = value => {
+  onWeightSelected() {
     const { currentPpm } = this.props;
     this.props.getPpmWeightEstimate(
       currentPpm.original_move_date,
@@ -197,7 +215,7 @@ export class PpmWeight extends Component {
       currentPpm.destination_postal_code,
       this.state.pendingPpmWeight,
     );
-  };
+  }
   render() {
     const {
       currentPpm,

--- a/src/scenes/MyMove/getWorkflowRoutes.jsx
+++ b/src/scenes/MyMove/getWorkflowRoutes.jsx
@@ -232,7 +232,7 @@ const pages = {
   '/moves/:moveId/ppm-incentive': {
     isInFlow: hasPPM,
     isComplete: ({ sm, orders, move, ppm }) =>
-      get(ppm, 'weight_estimate', null) && get(ppm, 'weight_estimate', null) !== 0,
+      get(ppm, 'weight_estimate', null) && get(ppm, 'weight_estimate', 0) !== 0,
     render: (key, pages) => ({ match }) => <PpmWeight pages={pages} pageKey={key} match={match} />,
   },
   '/moves/:moveId/review': {

--- a/src/scenes/MyMove/getWorkflowRoutes.jsx
+++ b/src/scenes/MyMove/getWorkflowRoutes.jsx
@@ -214,7 +214,8 @@ const pages = {
   },
   '/moves/:moveId/hhg-ppm-weight': {
     isInFlow: hasHHGPPM,
-    isComplete: ({ sm, orders, move, ppm }) => get(ppm, 'weight_estimate', null),
+    isComplete: ({ sm, orders, move, ppm }) =>
+      get(ppm, 'weight_estimate', null) && get(ppm, 'weight_estimate', 0) !== 0,
     render: (key, pages) => ({ match }) => <PpmWeight pages={hhgPPMPages} pageKey={key} match={match} />,
   },
   '/moves/:moveId/ppm-start': {

--- a/src/scenes/MyMove/getWorkflowRoutes.jsx
+++ b/src/scenes/MyMove/getWorkflowRoutes.jsx
@@ -231,7 +231,8 @@ const pages = {
   },
   '/moves/:moveId/ppm-incentive': {
     isInFlow: hasPPM,
-    isComplete: ({ sm, orders, move, ppm }) => get(ppm, 'weight_estimate', null),
+    isComplete: ({ sm, orders, move, ppm }) =>
+      get(ppm, 'weight_estimate', null) && get(ppm, 'weight_estimate', null) !== 0,
     render: (key, pages) => ({ match }) => <PpmWeight pages={pages} pageKey={key} match={match} />,
   },
   '/moves/:moveId/review': {

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -202,7 +202,7 @@ definitions:
         x-nullable: true
       weight_estimate:
         type: integer
-        minimum: 1
+        minimum: 0
         title: Weight Estimate
         x-nullable: true
       net_weight:
@@ -280,7 +280,7 @@ definitions:
         x-nullable: true
       weight_estimate:
         type: integer
-        minimum: 1
+        minimum: 0
         title: Weight Estimate
         x-nullable: true
       net_weight:
@@ -355,7 +355,7 @@ definitions:
         x-nullable: true
       weight_estimate:
         type: integer
-        minimum: 1
+        minimum: 0
         title: Weight Estimate
         x-nullable: true
       net_weight:
@@ -443,7 +443,7 @@ definitions:
         x-nullable: true
       weight_estimate:
         type: integer
-        minimum: 1
+        minimum: 0
         title: Weight Estimate
         x-nullable: true
         x-formatting: weight


### PR DESCRIPTION
## Description

When the PPM slider is encountered for the first time, the slider is automatically set to the center of the range. If the service member returns to the previous page and chooses a new PPM size, the weight slider should reset to the center of the new range. This delivers that functionality. 

## Setup

Set up a new PPM move
Choose a weight class (S/M/L) and view the weight slider. 
Return to the size page and choose a new size. 
The slider resets to the center of the range.

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/165136769) for this change
