### PR TITLE
Disable shipment summary worksheet button when req data is missing

### DIFF
--- a/pkg/handlers/internalapi/api.go
+++ b/pkg/handlers/internalapi/api.go
@@ -26,6 +26,7 @@ func NewInternalAPIHandler(context handlers.HandlerContext) http.Handler {
 	internalAPI.UsersShowLoggedInUserHandler = ShowLoggedInUserHandler{context}
 
 	internalAPI.CertificationCreateSignedCertificationHandler = CreateSignedCertificationHandler{context}
+	internalAPI.CertificationIndexSignedCertificationHandler = IndexSignedCertificationsHandler{context}
 
 	internalAPI.PpmCreatePersonallyProcuredMoveHandler = CreatePersonallyProcuredMoveHandler{context}
 	internalAPI.PpmIndexPersonallyProcuredMovesHandler = IndexPersonallyProcuredMovesHandler{context}

--- a/pkg/handlers/internalapi/signed_certifications_test.go
+++ b/pkg/handlers/internalapi/signed_certifications_test.go
@@ -129,3 +129,108 @@ func (suite *HandlerSuite) TestCreateSignedCertificationHandlerBadMoveID() {
 		t.Errorf("Expected to find no signed certifications but found %v", len(certs))
 	}
 }
+
+func (suite *HandlerSuite) TestIndexSignedCertificationHandlerBadMoveID() {
+	ppm := testdatagen.MakeDefaultPPM(suite.DB())
+	move := ppm.Move
+	sm := ppm.Move.Orders.ServiceMember
+
+	ppmPayment := models.SignedCertificationTypePPMPAYMENT
+	testdatagen.MakeSignedCertification(suite.DB(), testdatagen.Assertions{
+		SignedCertification: models.SignedCertification{
+			MoveID:                   ppm.Move.ID,
+			SubmittingUserID:         sm.User.ID,
+			PersonallyProcuredMoveID: &ppm.ID,
+			CertificationType:        &ppmPayment,
+			CertificationText:        "LEGAL",
+			Signature:                "ACCEPT",
+			Date:                     testdatagen.NextValidMoveDate,
+		},
+	})
+
+	req := httptest.NewRequest("GET", "/move/id/thing", nil)
+	req = suite.AuthenticateRequest(req, move.Orders.ServiceMember)
+	badMoveID := strfmt.UUID("3511d4d6-019d-4031-9c27-8a553e055543")
+	params := certop.IndexSignedCertificationParams{
+		MoveID: badMoveID,
+	}
+
+	params.HTTPRequest = req
+
+	handler := IndexSignedCertificationsHandler{handlers.NewHandlerContext(suite.DB(), suite.TestLogger())}
+	response := handler.Handle(params)
+
+	suite.CheckResponseNotFound(response)
+}
+
+func (suite *HandlerSuite) TestIndexSignedCertificationHandlerMismatchedUser() {
+	ppm := testdatagen.MakeDefaultPPM(suite.DB())
+	move := ppm.Move
+	sm := ppm.Move.Orders.ServiceMember
+	ppmPayment := models.SignedCertificationTypePPMPAYMENT
+	testdatagen.MakeSignedCertification(suite.DB(), testdatagen.Assertions{
+		SignedCertification: models.SignedCertification{
+			MoveID:                   ppm.Move.ID,
+			SubmittingUserID:         sm.User.ID,
+			PersonallyProcuredMoveID: &ppm.ID,
+			CertificationType:        &ppmPayment,
+			CertificationText:        "LEGAL",
+			Signature:                "ACCEPT",
+			Date:                     testdatagen.NextValidMoveDate,
+		},
+	})
+	userUUID2, _ := uuid.FromString("3511d4d6-019d-4031-9c27-8a553e055543")
+	unauthorizedUser := models.User{
+		LoginGovUUID:  userUUID2,
+		LoginGovEmail: "email2@example.com",
+	}
+	params := certop.IndexSignedCertificationParams{
+		MoveID: *handlers.FmtUUID(move.ID),
+	}
+	suite.MustSave(&unauthorizedUser)
+
+	req := httptest.NewRequest("GET", "/move/id/thing", nil)
+	req = suite.AuthenticateUserRequest(req, unauthorizedUser)
+
+	params.HTTPRequest = req
+
+	handler := IndexSignedCertificationsHandler{handlers.NewHandlerContext(suite.DB(), suite.TestLogger())}
+	response := handler.Handle(params)
+
+	suite.CheckResponseForbidden(response)
+}
+
+func (suite *HandlerSuite) TestIndexSignedCertificationHandler() {
+	ppm := testdatagen.MakeDefaultPPM(suite.DB())
+	move := ppm.Move
+	sm := ppm.Move.Orders.ServiceMember
+	ppmPayment := models.SignedCertificationTypePPMPAYMENT
+	testdatagen.MakeSignedCertification(suite.DB(), testdatagen.Assertions{
+		SignedCertification: models.SignedCertification{
+			MoveID:                   ppm.Move.ID,
+			SubmittingUserID:         sm.User.ID,
+			PersonallyProcuredMoveID: &ppm.ID,
+			CertificationType:        &ppmPayment,
+			CertificationText:        "LEGAL",
+			Signature:                "ACCEPT",
+			Date:                     testdatagen.NextValidMoveDate,
+		},
+	})
+	params := certop.IndexSignedCertificationParams{
+		MoveID: *handlers.FmtUUID(move.ID),
+	}
+
+	req := httptest.NewRequest("GET", "/move/id/thing", nil)
+	req = suite.AuthenticateRequest(req, sm)
+
+	params.HTTPRequest = req
+
+	handler := IndexSignedCertificationsHandler{handlers.NewHandlerContext(suite.DB(), suite.TestLogger())}
+	response := handler.Handle(params)
+
+	okResponse, ok := response.(*certop.IndexSignedCertificationOK)
+	suite.True(ok)
+	suite.Equal(1, len(okResponse.Payload))
+	responsePayload := okResponse.Payload[0]
+	suite.Equal(move.ID.String(), responsePayload.MoveID.String())
+}

--- a/src/scenes/Office/Ppm/PaymentsPanel.jsx
+++ b/src/scenes/Office/Ppm/PaymentsPanel.jsx
@@ -35,16 +35,9 @@ const attachmentsErrorMessages = {
 };
 
 export function sswIsDisabled(ppm, signedCertification, shipment) {
-  if (missingSignature(signedCertification)) {
-    return true;
-  }
-  if (missingNetWeightOrActualMoveDate(ppm)) {
-    return true;
-  }
-  if (isComboAndNotDelivered(shipment)) {
-    return true;
-  }
-  return false;
+  return (
+    missingSignature(signedCertification) || missingNetWeightOrActualMoveDate(ppm) || isComboAndNotDelivered(shipment)
+  );
 }
 
 function missingSignature(signedCertification) {

--- a/src/scenes/Office/Ppm/PaymentsPanel.jsx
+++ b/src/scenes/Office/Ppm/PaymentsPanel.jsx
@@ -1,4 +1,4 @@
-import { get, isEmpty } from 'lodash';
+import { get, isEmpty, includes } from 'lodash';
 import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import { push } from 'react-router-redux';
@@ -24,12 +24,39 @@ import faPlusSquare from '@fortawesome/fontawesome-free-solid/faPlusSquare';
 import faMinusSquare from '@fortawesome/fontawesome-free-solid/faMinusSquare';
 
 import './PaymentsPanel.css';
+import { getSignedCertification } from 'shared/Entities/modules/signed_certifications';
+import { selectPaymentRequestCertificationForMove } from 'shared/Entities/modules/signed_certifications';
+import { selectShipmentForMove } from 'shared/Entities/modules/shipments';
 
 const attachmentsErrorMessages = {
   422: 'Encountered an error while trying to create attachments bundle: Document is in the wrong format',
   424: 'Could not find any receipts or documents for this PPM',
   500: 'An unexpected error has occurred',
 };
+
+export function sswIsDisabled(ppm, signedCertification, shipment) {
+  if (missingSignature(signedCertification)) {
+    return true;
+  }
+  if (missingNetWeightOrActualMoveDate(ppm)) {
+    return true;
+  }
+  if (isComboAndNotDelivered(shipment)) {
+    return true;
+  }
+  return false;
+}
+
+function missingSignature(signedCertification) {
+  return isEmpty(signedCertification) || signedCertification.certification_type !== 'PPM_PAYMENT';
+}
+
+function missingNetWeightOrActualMoveDate(ppm) {
+  return isEmpty(ppm) || !ppm.net_weight || !ppm.actual_move_date;
+}
+function isComboAndNotDelivered(shipment) {
+  return !isEmpty(shipment) && !includes(['DELIVERED', 'COMPLETED'], shipment.status);
+}
 
 function getUserDate() {
   return new Date().toISOString().split('T')[0];
@@ -40,6 +67,13 @@ class PaymentsTable extends Component {
     showPaperwork: false,
     disableDownload: false,
   };
+
+  componentDidMount() {
+    const { moveId } = this.props;
+    if (moveId != null) {
+      this.props.getSignedCertification(moveId);
+    }
+  }
 
   approveReimbursement = () => {
     this.props.approveReimbursement(this.props.advance.id);
@@ -135,7 +169,7 @@ class PaymentsTable extends Component {
                   </th>
                 </tr>
                 <tr>
-                  <td className="payment-table-column-content">Advance </td>
+                  <td className="payment-table-column-content">Advance</td>
                   <td className="payment-table-column-content">
                     ${formatCents(get(advance, 'requested_amount')).toLocaleString()}
                   </td>
@@ -190,7 +224,9 @@ class PaymentsTable extends Component {
                     <p>Download Shipment Summary Worksheet</p>
                     <p>Download and complete the worksheet, which is a fill-in PDF form.</p>
                   </div>
-                  <button onClick={this.downloadShipmentSummary}>Download Worksheet (PDF)</button>
+                  <button disabled={this.props.disableSSW} onClick={this.downloadShipmentSummary}>
+                    Download Worksheet (PDF)
+                  </button>
                 </div>
 
                 <hr />
@@ -250,9 +286,13 @@ class PaymentsTable extends Component {
 const mapStateToProps = (state, ownProps) => {
   const { moveId } = ownProps;
   const ppm = selectPPMForMove(state, moveId);
+  const shipment = selectShipmentForMove(state, moveId);
   const advance = selectReimbursement(state, ppm.advance);
+  const signedCertifications = selectPaymentRequestCertificationForMove(state, moveId);
+  const disableSSW = sswIsDisabled(ppm, signedCertifications, shipment);
   return {
     ppm,
+    disableSSW,
     moveId,
     advance,
     attachmentsError: getLastError(state, downloadPPMAttachmentsLabel),
@@ -262,6 +302,7 @@ const mapStateToProps = (state, ownProps) => {
 const mapDispatchToProps = dispatch =>
   bindActionCreators(
     {
+      getSignedCertification,
       approveReimbursement,
       update: no_op,
       downloadPPMAttachments,

--- a/src/scenes/Office/Ppm/PaymentsPanel.test.js
+++ b/src/scenes/Office/Ppm/PaymentsPanel.test.js
@@ -1,0 +1,57 @@
+import { sswIsDisabled } from './PaymentsPanel';
+
+describe('Download Shipment Summary button', () => {
+  describe('PPM only move', () => {
+    it('is disabled when no ppm', () => {
+      const ppm = null;
+      const signedCertification = { certification_type: 'PPM_PAYMENT' };
+
+      expect(sswIsDisabled(ppm, signedCertification)).toEqual(true);
+    });
+
+    it('is disabled when missing net weight', () => {
+      const ppm = { actual_move_date: '2018-11-11' };
+      const signedCertification = { certification_type: 'PPM_PAYMENT' };
+
+      expect(sswIsDisabled(ppm, signedCertification)).toEqual(true);
+    });
+
+    it('is disabled when missing actual move date', () => {
+      const ppm = { net_weight: 8000 };
+      const signedCertification = { certification_type: 'PPM_PAYMENT' };
+
+      expect(sswIsDisabled(ppm, signedCertification)).toEqual(true);
+    });
+
+    it('is disabled when missing signature', () => {
+      const ppm = { net_weight: 8000, actual_move_date: '2018-11-11' };
+      const signedCertification = null;
+
+      expect(sswIsDisabled(ppm, signedCertification)).toEqual(true);
+    });
+
+    it('is enabled when has signature, actual move date, net weight', () => {
+      const ppm = { net_weight: 8000, actual_move_date: '2018-11-11' };
+      const signedCertification = { certification_type: 'PPM_PAYMENT' };
+
+      expect(sswIsDisabled(ppm, signedCertification)).toEqual(false);
+    });
+  });
+
+  describe('Combo move', () => {
+    it('is disabled when hhg not complete', () => {
+      const ppm = { net_weight: 8000, actual_move_date: '2018-11-11' };
+      const signedCertification = { certification_type: 'PPM_PAYMENT' };
+      const shipment = { status: 'AWARDED' };
+
+      expect(sswIsDisabled(ppm, signedCertification, shipment)).toEqual(true);
+    });
+    it('is enabled when hhg is complete, and has signature, actual move date, net weight', () => {
+      const ppm = { net_weight: 8000, actual_move_date: '2018-11-11' };
+      const signedCertification = { certification_type: 'PPM_PAYMENT' };
+      const shipment = { status: 'COMPLETED' };
+
+      expect(sswIsDisabled(ppm, signedCertification, shipment)).toEqual(false);
+    });
+  });
+});

--- a/src/shared/Entities/modules/signed_certifications.js
+++ b/src/shared/Entities/modules/signed_certifications.js
@@ -1,11 +1,14 @@
 import { swaggerRequest } from 'shared/Swagger/request';
 import { getClient } from 'shared/Swagger/api';
+import { filter } from 'lodash';
 
-export const Label = 'SignedCertifications.createSignedCertification';
+export const createSignedCertificationLabel = 'SignedCertifications.createSignedCertification';
+export const getSignedCertificationsLabel = 'SignedCertifications.indexSignedCertifications';
 
 export function createSignedCertification(
   moveId,
   payload /*shape: {personally_procured_move_id, shipment_id, certification_text, signature, date, certification_type}*/,
+  label = createSignedCertificationLabel,
 ) {
   return swaggerRequest(
     getClient,
@@ -16,6 +19,20 @@ export function createSignedCertification(
         ...payload,
       },
     },
-    { Label },
+    { label },
   );
+}
+
+export function getSignedCertification(moveId, label = getSignedCertificationsLabel) {
+  return swaggerRequest(getClient, 'certification.indexSignedCertification', { moveId }, { label });
+}
+
+export function selectPaymentRequestCertificationForMove(state, moveId) {
+  const signedCertifications = filter(state.entities.signedCertifications, cert => {
+    return cert.certification_type === 'PPM_PAYMENT' && cert.move_id === moveId;
+  });
+  if (!Array.isArray(signedCertifications) || !signedCertifications.length) {
+    return {};
+  }
+  return signedCertifications[0];
 }

--- a/src/shared/Entities/modules/signed_certifications.js
+++ b/src/shared/Entities/modules/signed_certifications.js
@@ -31,7 +31,7 @@ export function selectPaymentRequestCertificationForMove(state, moveId) {
   const signedCertifications = filter(state.entities.signedCertifications, cert => {
     return cert.certification_type === 'PPM_PAYMENT' && cert.move_id === moveId;
   });
-  if (!Array.isArray(signedCertifications) || !signedCertifications.length) {
+  if (!signedCertifications.length) {
     return {};
   }
   return signedCertifications[0];

--- a/src/shared/Entities/reducer.js
+++ b/src/shared/Entities/reducer.js
@@ -35,6 +35,7 @@ const initialState = {
   personallyProcuredMoves: {},
   reimbursements: {},
   serviceAgents: {},
+  signedCertifications: {},
   shipmentLineItems: {},
   shipments: {},
   storageInTransits: {},

--- a/src/shared/Entities/schema.js
+++ b/src/shared/Entities/schema.js
@@ -90,7 +90,9 @@ export const invoice = new schema.Entity('invoices');
 export const invoices = new schema.Array(invoice);
 
 // Signed Certificate
-export const signedCertification = new schema.Entity('signedCertification');
+export const signedCertification = new schema.Entity('signedCertifications');
+
+export const signedCertifications = new schema.Array(signedCertification);
 
 // ShipmentLineItem
 export const shipmentLineItem = new schema.Entity('shipmentLineItems', {

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -1316,6 +1316,9 @@ definitions:
         title: Signature
       certification_text:
         type: string
+      move_id:
+        type: string
+        format: uuid
       personally_procured_move_id:
         type: string
         format: uuid
@@ -1329,6 +1332,7 @@ definitions:
         x-nullable: true
     required:
       - id
+      - move_id
       - created_at
       - updated_at
       - date
@@ -1361,6 +1365,10 @@ definitions:
       - date
       - signature
       - certification_text
+  SignedCertifications:
+    type: array
+    items:
+      $ref: '#/definitions/SignedCertificationPayload'
   SignedCertificationType:
     type: string
     enum:
@@ -2725,6 +2733,33 @@ paths:
           description: request requires user authentication
         403:
           description: user is not authorized to sign for this move
+        404:
+          description: move not found
+        500:
+          description: internal server error
+    get:
+      summary: gets the signed certifications for the given move ID
+      description: returns a list of all signed_certifications associated with the move ID
+      operationId: indexSignedCertification
+      tags:
+        - certification
+      parameters:
+        - in: path
+          name: moveId
+          type: string
+          format: uuid
+          required: true
+      responses:
+        200:
+          description: returns a list of signed certifications
+          schema:
+            $ref: '#/definitions/SignedCertifications'
+        400:
+          description: invalid request
+        401:
+          description: request requires user authentication
+        403:
+          description: user is not authorized
         404:
           description: move not found
         500:


### PR DESCRIPTION
## Description

The shipment summary worksheet requires the final move date, final weight, and service member signature before it can be generated. Disable the button until we have the required fields.
 
## Reviewer Notes

Try different variants of the missing fields (i.e. no signature, no weight, etc). The button should remain disabled until the required fields have been added.

In order to check if a service member had agreed to the legalese requesting payment, I had to add an endpoint to query the `signed_certifications` table. This is the first time that I've added a new endpoint to the app, so extra scrutiny around that part would be appreciated. 


## Setup

1) Login to `milmove` as a user ready to request a ppm payment (e.g. ppm@requestingpay.ment ) 
2) Click "Request Payment" and complete the ppm payment request (make note of the move locator)
3) Login to the office app and find the move that submitted a request for payment
4) Go to the move ppm tab and complete any missing information required for the ppm (net weight, departure date, etc)
5) Click "Create payment paperwork" and the "Download Worksheet" button should be enabled

## Code Review Verification Steps
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/n/projects/2181745/stories/165003104) for this change

## Screenshots
![Screen Shot 2019-04-22 at 9 59 14 AM](https://user-images.githubusercontent.com/1036969/56509854-505be980-64e5-11e9-9815-460c84c71d6e.png)

