### PR TITLE
Replace completePmSurvey

### DIFF
--- a/cypress/integration/tsp/premoveSurvey.js
+++ b/cypress/integration/tsp/premoveSurvey.js
@@ -30,15 +30,10 @@ describe('TSP User And the Premove Survey Button', function() {
 });
 
 function tspUserClicksEnterPreMoveSurvey() {
-  cy
-    .get('button')
-    .contains('Enter pre-move survey')
-    .should('be.enabled');
+  const button = cy.contains('Enter pre-move survey');
 
-  cy
-    .get('button')
-    .contains('Enter pre-move survey')
-    .click();
+  button.should('be.enabled');
+  button.click();
 }
 
 function tspUserFillsInPreMoveSurveyWizard() {

--- a/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
+++ b/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
@@ -125,10 +125,11 @@ class ShipmentInfo extends Component {
   };
 
   componentDidMount() {
+    const shipmentId = this.props.shipmentId;
+
     this.props
-      .getPublicShipment(this.props.shipmentId)
+      .getPublicShipment(shipmentId)
       .then(() => {
-        const shipmentId = this.props.shipment.id;
         this.props.getServiceAgentsForShipment(shipmentId);
         this.props.getTspForShipment(shipmentId);
         this.props.getAllShipmentDocuments(shipmentId);

--- a/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
+++ b/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
@@ -31,6 +31,7 @@ import {
   selectShipment,
   getPublicShipmentLabel,
   acceptShipment,
+  completePmSurvey,
 } from 'shared/Entities/modules/shipments';
 import {
   getServiceAgentsForShipment,
@@ -49,7 +50,7 @@ import Dates from 'shared/ShipmentDates';
 import LocationsContainer from 'shared/LocationsPanel/LocationsContainer';
 import { getLastRequestIsSuccess, getLastRequestIsLoading, getLastError } from 'shared/Swagger/selectors';
 import { resetRequests } from 'shared/Swagger/request';
-import { completePmSurvey, transportShipment, deliverShipment } from './ducks';
+import { transportShipment, deliverShipment } from './ducks';
 import FormButton from './FormButton';
 import CustomerInfo from './CustomerInfo';
 import PreApprovalPanel from 'shared/PreApprovalRequest/PreApprovalPanel.jsx';

--- a/src/scenes/TransportationServiceProvider/api.js
+++ b/src/scenes/TransportationServiceProvider/api.js
@@ -55,15 +55,6 @@ export async function DeliverShipment(shipmentId, payload) {
   return response.body;
 }
 
-export async function CompletePmSurvey(shipmentId) {
-  const client = await getPublicClient();
-  const response = await client.apis.shipments.completePmSurvey({
-    shipmentId,
-  });
-  checkResponse(response, 'failed to complete pre-move survey due to server error');
-  return response.body;
-}
-
 // ServiceAgents
 export async function IndexServiceAgents(shipmentId) {
   const client = await getPublicClient();

--- a/src/scenes/TransportationServiceProvider/ducks.js
+++ b/src/scenes/TransportationServiceProvider/ducks.js
@@ -1,11 +1,5 @@
 import { isNull } from 'lodash';
-import {
-  TransportShipment,
-  DeliverShipment,
-  CompletePmSurvey,
-  IndexServiceAgents,
-  GetAllShipmentDocuments,
-} from './api.js';
+import { TransportShipment, DeliverShipment, IndexServiceAgents, GetAllShipmentDocuments } from './api.js';
 
 import * as ReduxHelpers from 'shared/ReduxHelpers';
 import { getEntitlements } from 'shared/entitlements.js';
@@ -15,7 +9,6 @@ import { selectShipment } from 'shared/Entities/modules/shipments';
 const transportShipmentType = 'TRANSPORT_SHIPMENT';
 const deliverShipmentType = 'DELIVER_SHIPMENT';
 const loadShipmentDocumentsType = 'LOAD_SHIPMENT_DOCUMENTS';
-const completePmSurveyType = 'COMPLETE_PM_SURVEY';
 
 const indexServiceAgentsType = 'INDEX_SERVICE_AGENTS';
 
@@ -25,7 +18,6 @@ const loadTspDependenciesType = 'LOAD_TSP_DEPENDENCIES';
 // SINGLE RESOURCE ACTION TYPES
 const TRANSPORT_SHIPMENT = ReduxHelpers.generateAsyncActionTypes(transportShipmentType);
 const DELIVER_SHIPMENT = ReduxHelpers.generateAsyncActionTypes(deliverShipmentType);
-const COMPLETE_PM_SURVEY = ReduxHelpers.generateAsyncActionTypes(completePmSurveyType);
 const LOAD_SHIPMENT_DOCUMENTS = ReduxHelpers.generateAsyncActionTypes(loadShipmentDocumentsType);
 
 const INDEX_SERVICE_AGENTS = ReduxHelpers.generateAsyncActionTypes(indexServiceAgentsType);
@@ -39,8 +31,6 @@ const LOAD_TSP_DEPENDENCIES = ReduxHelpers.generateAsyncActionTypes(loadTspDepen
 export const transportShipment = ReduxHelpers.generateAsyncActionCreator(transportShipmentType, TransportShipment);
 
 export const deliverShipment = ReduxHelpers.generateAsyncActionCreator(deliverShipmentType, DeliverShipment);
-
-export const completePmSurvey = ReduxHelpers.generateAsyncActionCreator(completePmSurveyType, CompletePmSurvey);
 
 export const getAllShipmentDocuments = ReduxHelpers.generateAsyncActionCreator(
   loadShipmentDocumentsType,
@@ -131,27 +121,6 @@ export function tspReducer(state = initialState, action) {
         shipmentIsDelivering: false,
         shipmentHasDeliverSuccess: false,
         shipmentHasDeliverError: null,
-        error: action.error.message,
-      });
-
-    // PM SURVEY ACTION
-    case COMPLETE_PM_SURVEY.start:
-      return Object.assign({}, state, {
-        pmSurveyIsCompleting: true,
-        pmSurveyHasCompletionSuccess: false,
-      });
-    case COMPLETE_PM_SURVEY.success:
-      return Object.assign({}, state, {
-        pmSurveyIsCompleting: false,
-        pmSurveyHasCompletionSuccess: true,
-        pmSurveyHasCompletionError: false,
-        shipment: action.payload,
-      });
-    case COMPLETE_PM_SURVEY.failure:
-      return Object.assign({}, state, {
-        pmSurveyIsCompleting: false,
-        pmSurveyHasCompletionSuccess: false,
-        pmSurveyHasCompletionError: null,
         error: action.error.message,
       });
 

--- a/src/shared/Entities/modules/shipments.js
+++ b/src/shared/Entities/modules/shipments.js
@@ -63,7 +63,8 @@ export function acceptShipment(shipmentId, label = acceptPublicShipmentLabel) {
 }
 
 export function completePmSurvey(shipmentId, label = completePmSurveyLabel) {
-  return swaggerRequest(getPublicClient, label, { shipmentId }, label);
+  const swaggerTag = 'shipments.completePmSurvey';
+  return swaggerRequest(getPublicClient, swaggerTag, { shipmentId }, label);
 }
 
 export function selectShipment(state, id) {

--- a/src/shared/Entities/modules/shipments.js
+++ b/src/shared/Entities/modules/shipments.js
@@ -11,6 +11,7 @@ const createShipmentLabel = 'Shipments.createShipment';
 const updateShipmentLabel = 'shipments.updateShipment';
 const updatePublicShipmentLabel = 'shipments.updatePublicShipment';
 const acceptPublicShipmentLabel = 'shipments.acceptShipment';
+const completePmSurveyLabel = 'shipments.completePmSurvey';
 
 export function createOrUpdateShipment(moveId, shipment, id, label) {
   if (id) {
@@ -59,6 +60,10 @@ export function approveShipment(shipmentId, label = approveShipmentLabel) {
 
 export function acceptShipment(shipmentId, label = acceptPublicShipmentLabel) {
   return swaggerRequest(getPublicClient, label, { shipmentId }, { label });
+}
+
+export function completePmSurvey(shipmentId, label = completePmSurveyLabel) {
+  return swaggerRequest(getPublicClient, label, { shipmentId }, label);
 }
 
 export function selectShipment(state, id) {


### PR DESCRIPTION
## Description

Refactor the tsp components to use the entities action to complete the pre-move survey. Delete the code needed to support completePmSurvey from the tsp ducks file.

## Setup

1. `make server_run`
2. `make client_run`
3. Navigate to the tsp queues page
4. Click on a shipment in the approved queue
5. Go through the pre-move survey

## Code Review Verification Steps

* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/165150212) for this change