### PR TITLE
Mk 165498814 fix submit docs combo move

### DIFF
--- a/cypress/integration/office/officeUserHHGPPM.js
+++ b/cypress/integration/office/officeUserHHGPPM.js
@@ -1,5 +1,7 @@
 /* global cy */
 
+import { fileUploadTimeout } from '../../support/constants';
+
 describe('office user finds the shipment', function() {
   beforeEach(() => {
     cy.signIntoOffice();
@@ -30,6 +32,9 @@ describe('office user finds the shipment', function() {
     officeUserVisitsPPMTab();
     officeUserVisitsHHGTab();
     officeUserApprovesShipment();
+  });
+  it.only('office user uploads document', function() {
+    officeUserSubmitsDocuemnt();
   });
 });
 
@@ -91,4 +96,26 @@ function officeUserViewsMove(locator) {
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/queues\/new\/moves\/[^/]+\/basics/);
   });
+}
+
+function officeUserSubmitsDocuemnt() {
+  cy.patientVisit('moves/27266e89-df79-4469-8843-05b45741a818/documents/new');
+
+  cy.contains('Upload a new document');
+  cy.get('button.submit').should('be.disabled');
+  cy.get('select[name="move_document_type"]').select('Expense');
+  cy.get('input[name="title"]').type('expense document for combo');
+  cy.get('select[name="moving_expense_type"]').select('Contracted Expense');
+  cy.get('input[name="requested_amount_cents"]').type('4,000.92');
+  cy.get('select[name="payment_method"]').select('Other account');
+
+  cy.get('button.submit').should('be.disabled');
+
+  cy.upload_file('.filepond--root', 'top-secret.png');
+  cy
+    .get('button.submit', { timeout: fileUploadTimeout })
+    .should('not.be.disabled')
+    .click();
+
+  cy.contains('expense document for combo');
 }

--- a/cypress/integration/office/officeUserHHGPPM.js
+++ b/cypress/integration/office/officeUserHHGPPM.js
@@ -34,7 +34,7 @@ describe('office user finds the shipment', function() {
     officeUserApprovesShipment();
   });
   it.only('office user uploads document', function() {
-    officeUserSubmitsDocuemnt();
+    officeUserSubmitsDocument();
   });
 });
 
@@ -98,7 +98,7 @@ function officeUserViewsMove(locator) {
   });
 }
 
-function officeUserSubmitsDocuemnt() {
+function officeUserSubmitsDocument() {
   cy.patientVisit('moves/27266e89-df79-4469-8843-05b45741a818/documents/new');
 
   cy.contains('Upload a new document');

--- a/pkg/models/move.go
+++ b/pkg/models/move.go
@@ -283,7 +283,7 @@ func (m Move) createMoveDocumentWithoutTransaction(
 	}
 
 	var newMoveDocument *MoveDocument
-	if moveType == SelectedMoveTypeHHG || moveType == SelectedMoveTypeHHGPPM {
+	if moveType == SelectedMoveTypeHHG {
 		newMoveDocument = &MoveDocument{
 			Move:             m,
 			MoveID:           m.ID,


### PR DESCRIPTION
## Description

Fix bug related to submission of documents for combo moves.

## Reviewer Notes

Verify can still submit documents for combo moves along with hhg and ppm only moves.

1) login as an office user
2) select a specific move
3) click the documents tab and upload a document

## Code Review Verification Steps
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/n/projects/2181745/stories/165498814) for this change
