### PR TITLE
Add goland debugger build to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,12 +26,17 @@ endif
 
 # Convenience for LDFLAGS
 WEBSERVER_LDFLAGS=-X main.gitBranch=$(shell git branch | grep \* | cut -d ' ' -f2) -X main.gitCommit=$(shell git rev-list -1 HEAD)
+GC_FLAGS=-trimpath=$(GOPATH)
 DB_PORT_DEV=5432
 DB_PORT_PROD_MIGRATIONS=5434
 DB_PORT_DOCKER=5432
 ifdef CIRCLECI
 	DB_PORT_TEST=5432
 	LDFLAGS=-linkmode external -extldflags -static
+endif
+
+ifdef GOLAND
+	GOLAND_GC_FLAGS=all=-N -l
 endif
 
 #
@@ -220,14 +225,14 @@ pkg/assets/assets.go: pkg/paperwork/formtemplates/*
 
 .PHONY: server_build
 server_build: server_deps server_generate
-	go build -gcflags=-trimpath=$(GOPATH) -asmflags=-trimpath=$(GOPATH) -i -ldflags "$(LDFLAGS) $(WEBSERVER_LDFLAGS)" -o bin/milmove ./cmd/milmove
+	go build -gcflags="$(GOLAND_GC_FLAGS) $(GC_FLAGS)" -asmflags=-trimpath=$(GOPATH) -i -ldflags "$(LDFLAGS) $(WEBSERVER_LDFLAGS)" -o bin/milmove ./cmd/milmove
 
 .PHONY: server_build_linux
 server_build_linux: server_deps_linux server_generate_linux
 	# These don't need to go in bin_linux/ because local devs don't use them
 	# Additionally it would not work with the default Dockerfile
 	GOOS=linux GOARCH=amd64 go build -i -ldflags "$(LDFLAGS)" -o bin/chamber github.com/segmentio/chamber
-	GOOS=linux GOARCH=amd64 go build -gcflags=-trimpath=$(GOPATH) -asmflags=-trimpath=$(GOPATH) -i -ldflags "$(LDFLAGS) $(WEBSERVER_LDFLAGS)" -o bin/milmove ./cmd/milmove
+	GOOS=linux GOARCH=amd64 go build -gcflags="$(GOLAND_GC_FLAGS) $(GC_FLAGS)" -asmflags=-trimpath=$(GOPATH) -i -ldflags "$(LDFLAGS) $(WEBSERVER_LDFLAGS)" -o bin/milmove ./cmd/milmove
 
 # This command is for running the server by itself, it will serve the compiled frontend on its own
 server_run_standalone: client_build server_build db_dev_run

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ This prototype was built by a [Defense Digital Service](https://www.dds.mil/) te
   * [Documentation](#documentation)
   * [Spellcheck](#spellcheck)
     * [Tips for staying sane](#tips-for-staying-sane)
+  * [GoLand](#goland)
   * [Troubleshooting](#troubleshooting)
     * [Postgres Issues](#postgres-issues)
     * [Development Machine Timezone Issues](#development-machine-timezone-issues)
@@ -404,6 +405,10 @@ This will let you walk through the caught spelling errors one-by-one and choose 
 #### Tips for staying sane
 
 * If you want to use a bare hyperlink, wrap it in angle braces: `<http://example.com>`
+
+### GoLand
+
+* GoLand supports [attaching the debugger to a running process](https://blog.jetbrains.com/go/2019/02/06/debugging-with-goland-getting-started/#debugging-a-running-application-on-the-local-machine), however this requires that the server has been built with specific flags. If you wish to use this feature in development add the following line `export GOLAND=1` to your `.envrc.local`. Once the server starts follow the steps outlined in the article above and you should now be able to set breakpoints using the GoLand debugger.
 
 ### Troubleshooting
 


### PR DESCRIPTION
## Description

In order to attach the Goland debugger to run a running process the server needs to be built with `gcflags="all=-N -l"`. Update the Makefile to allow for local dev builds with these flags.

## Reviewer Notes

See debugging with Goland: 
https://blog.jetbrains.com/go/2019/02/06/debugging-with-goland-getting-started/#debugging-a-running-application-on-the-local-machine

## Setup

* Add `export GOLAND=1` to `.envrc.local` and you should see the updated `gcflags` when running make build. 

* Remove `export GOLAND=1` from `.envrc.local` and you should not see `"all=-N -l"` in the gcflags.