### PR TITLE
Align request logger

### DIFF
--- a/cmd/milmove/main.go
+++ b/cmd/milmove/main.go
@@ -1209,7 +1209,7 @@ func serveFunction(cmd *cobra.Command, args []string) error {
 
 	root := goji.NewMux()
 	root.Use(sessionCookieMiddleware)
-	root.Use(logging.LogRequestMiddleware(gitBranch, gitCommit))
+	root.Use(logging.LogRequestMiddleware(logger))
 
 	// CSRF path is set specifically at the root to avoid duplicate tokens from different paths
 	csrfAuthKey, err := hex.DecodeString(v.GetString("csrf-auth-key"))

--- a/pkg/logging/log.go
+++ b/pkg/logging/log.go
@@ -2,6 +2,7 @@ package logging
 
 import (
 	"net/http"
+	"strings"
 
 	"github.com/felixge/httpsnoop"
 	"github.com/gofrs/uuid"
@@ -34,7 +35,7 @@ func Config(env string, debugLogging bool) (*zap.Logger, error) {
 }
 
 // LogRequestMiddleware generates an HTTP/HTTPS request logs using Zap
-func LogRequestMiddleware(gitBranch string, gitCommit string) func(inner http.Handler) http.Handler {
+func LogRequestMiddleware(logger Logger) func(inner http.Handler) http.Handler {
 	return func(inner http.Handler) http.Handler {
 		mw := func(w http.ResponseWriter, r *http.Request) {
 			var protocol, tspUserID, officeUserID, serviceMemberID, userID string
@@ -62,9 +63,8 @@ func LogRequestMiddleware(gitBranch string, gitCommit string) func(inner http.Ha
 			}
 
 			metrics := httpsnoop.CaptureMetrics(inner, w, r)
-			zap.L().Info("Request",
-				zap.String("git-branch", gitBranch),
-				zap.String("git-commit", gitCommit),
+
+			fields := []zap.Field{
 				zap.String("accepted-language", r.Header.Get("accepted-language")),
 				zap.Int64("content-length", r.ContentLength),
 				zap.Duration("duration", metrics.Duration),
@@ -82,11 +82,18 @@ func LogRequestMiddleware(gitBranch string, gitCommit string) func(inner http.Ha
 				zap.String("url", r.URL.String()),
 				zap.String("user-agent", r.UserAgent()),
 				zap.String("user-id", userID),
-				zap.String("x-amzn-trace-id", r.Header.Get("x-amzn-trace-id")),
-				zap.String("x-forwarded-for", r.Header.Get("x-forwarded-for")),
-				zap.String("x-forwarded-host", r.Header.Get("x-forwarded-host")),
-				zap.String("x-forwarded-proto", r.Header.Get("x-forwarded-proto")),
-			)
+			}
+
+			// Append x- headers, e.g., x-forwarded-for.
+			for name, values := range r.Header {
+				if strings.HasPrefix(name, "x-") {
+					if len(values) > 0 {
+						fields = append(fields, zap.String(name, values[0]))
+					}
+				}
+			}
+
+			logger.Info("Request", fields...)
 
 		}
 		return http.HandlerFunc(mw)

--- a/pkg/logging/logger.go
+++ b/pkg/logging/logger.go
@@ -1,0 +1,10 @@
+package logging
+
+import (
+	"go.uber.org/zap"
+)
+
+// Logger is an interface that describes the logging requirements of this package.
+type Logger interface {
+	Info(msg string, fields ...zap.Field)
+}


### PR DESCRIPTION
## Description

The request logger was duplicating the `git_commit` and `git_branch` fields as `git-commit` and `git-branch`.

## Reviewer Notes

None

## Setup

None

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](./docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](./docs/backend.md#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](./docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
  * [ ] Secure migrations have been tested using `scripts/run-prod-migrations`
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers](./docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @ntwyman
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

None

## Screenshots

N.A.