### PR TITLE
Remove Code 226A Robust Accessorial feature flag

### DIFF
--- a/src/shared/PreApprovalRequest/DetailsHelper.js
+++ b/src/shared/PreApprovalRequest/DetailsHelper.js
@@ -15,7 +15,7 @@ export function getFormComponent(code, robustAccessorialFlag, initialValues) {
     if (isNew || get(initialValues, 'crate_dimensions', false)) return Code105Form;
   } else if (code.startsWith('35')) {
     if (isNew || get(initialValues, 'estimate_amount_cents')) return Code35Form;
-  } else if (robustAccessorialFlag && code.startsWith('226')) {
+  } else if (code.startsWith('226')) {
     if (isNew || get(initialValues, 'actual_amount_cents')) return Code226Form;
   }
   return DefaultForm;
@@ -25,7 +25,7 @@ export function getDetailsComponent(code, robustAccessorialFlag, isRobustAccesso
   if (!isRobustAccessorial) return DefaultDetails;
   if (code === '105B' || code === '105E') return Code105Details;
   if (code === '35A') return Code35Details;
-  if (code === '226A' && robustAccessorialFlag) return Code226Details;
+  if (code === '226A') return Code226Details;
   return DefaultDetails;
 }
 

--- a/src/shared/PreApprovalRequest/DetailsHelper.test.js
+++ b/src/shared/PreApprovalRequest/DetailsHelper.test.js
@@ -20,63 +20,40 @@ describe('testing getFormComponent()', () => {
     //pass in known code item with feature flag off
     featureFlag = false;
 
-    let FormComponent = getFormComponent('105', featureFlag, initialValuesWithCrateDimensions);
+    let FormComponent;
     it('for code 105', () => {
-      expect(FormComponent).toBe(DefaultForm);
-    });
-
-    FormComponent = getFormComponent('105B', featureFlag, initialValuesWithCrateDimensions);
-    it('for code 105B', () => {
-      expect(FormComponent).toBe(DefaultForm);
-    });
-
-    FormComponent = getFormComponent('105E', featureFlag, initialValuesWithCrateDimensions);
-    it('for code 105E', () => {
+      FormComponent = getFormComponent('105', featureFlag, initialValuesWithCrateDimensions);
       expect(FormComponent).toBe(DefaultForm);
     });
 
     //testing for non-existing code
-    FormComponent = getFormComponent('4A', featureFlag, initialValuesWithCrateDimensions);
     it('for code 4A', () => {
+      FormComponent = getFormComponent('4A', featureFlag, initialValuesWithCrateDimensions);
       expect(FormComponent).toBe(DefaultForm);
     });
 
-    FormComponent = getFormComponent('105D', featureFlag, initialValuesWithCrateDimensions);
     it('for code 105D', () => {
+      FormComponent = getFormComponent('105D', featureFlag, initialValuesWithCrateDimensions);
       expect(FormComponent).toBe(DefaultForm);
     });
 
-    FormComponent = getFormComponent('105D', featureFlag, null);
     it('for code 105D', () => {
-      expect(FormComponent).toBe(DefaultForm);
-    });
-
-    FormComponent = getFormComponent('35A', featureFlag);
-    it('for code 35A', () => {
-      expect(FormComponent).toBe(DefaultForm);
-    });
-
-    FormComponent = getFormComponent('226A', featureFlag);
-    it('for code 226A', () => {
+      FormComponent = getFormComponent('105D', featureFlag, null);
       expect(FormComponent).toBe(DefaultForm);
     });
   });
 
   describe('returns 105B/E form component with feature flag on', () => {
     featureFlag = true;
+    let FormComponent;
 
-    let FormComponent = getFormComponent('105', featureFlag, initialValuesWithCrateDimensions);
-    it('for code 105', () => {
-      expect(FormComponent).toBe(Code105Form);
-    });
-
-    FormComponent = getFormComponent('105B', featureFlag, initialValuesWithCrateDimensions);
     it('for code 105B', () => {
+      FormComponent = getFormComponent('105B', featureFlag, initialValuesWithCrateDimensions);
       expect(FormComponent).toBe(Code105Form);
     });
 
-    FormComponent = getFormComponent('105E', featureFlag, initialValuesWithCrateDimensions);
     it('for code 105E', () => {
+      FormComponent = getFormComponent('105E', featureFlag, initialValuesWithCrateDimensions);
       expect(FormComponent).toBe(Code105Form);
     });
   });
@@ -84,8 +61,8 @@ describe('testing getFormComponent()', () => {
   describe('returns 35A form component with feature flag on', () => {
     featureFlag = true;
 
-    let FormComponent = getFormComponent('35A', featureFlag, { estimate_amount_cents: true });
     it('for code 35A', () => {
+      let FormComponent = getFormComponent('35A', featureFlag, { estimate_amount_cents: true });
       expect(FormComponent).toBe(Code35Form);
     });
   });
@@ -93,32 +70,33 @@ describe('testing getFormComponent()', () => {
   describe('returns 226A form component with feature flag on', () => {
     featureFlag = true;
 
-    let FormComponent = getFormComponent('226A', featureFlag, { actual_amount_cents: true });
     it('for code 226A', () => {
+      let FormComponent = getFormComponent('226A', featureFlag, { actual_amount_cents: true });
       expect(FormComponent).toBe(Code226Form);
     });
   });
 
   describe('returns default form component with feature flag on', () => {
     featureFlag = true;
+    let FormComponent;
 
-    let FormComponent = getFormComponent('105D', featureFlag);
     it('for code 105D', () => {
+      FormComponent = getFormComponent('105D', featureFlag);
       expect(FormComponent).toBe(DefaultForm);
     });
 
-    FormComponent = getFormComponent('105B', featureFlag, initialValuesWithoutCrateDimensions);
     it('for code 105B without crate dimensions', () => {
+      FormComponent = getFormComponent('105B', featureFlag, initialValuesWithoutCrateDimensions);
       expect(FormComponent).toBe(DefaultForm);
     });
 
-    FormComponent = getFormComponent('105E', featureFlag, initialValuesWithoutCrateDimensions);
     it('for code 105E without crate dimensions', () => {
+      FormComponent = getFormComponent('105E', featureFlag, initialValuesWithoutCrateDimensions);
       expect(FormComponent).toBe(DefaultForm);
     });
 
-    FormComponent = getFormComponent('226A', featureFlag, initialValuesWithoutCrateDimensions);
     it('for code 226A without crate dimensions', () => {
+      FormComponent = getFormComponent('226A', featureFlag, initialValuesWithoutCrateDimensions);
       expect(FormComponent).toBe(DefaultForm);
     });
   });

--- a/src/shared/PreApprovalRequest/DetailsHelper.test.js
+++ b/src/shared/PreApprovalRequest/DetailsHelper.test.js
@@ -153,4 +153,16 @@ describe('preApprovals', () => {
       expect(isRobustAccessorial(itemNull)).toEqual(false);
     });
   });
+
+  describe('isNewAccessorial 226A', () => {
+    it('should return true if new accessorial, false if old accessorial', () => {
+      const item226AOld = { tariff400ng_item: { code: '226A' } };
+      const item226ANew = { tariff400ng_item: { code: '226A' }, actual_amount_cents: 1 };
+      const itemNull = null;
+
+      expect(isRobustAccessorial(item226AOld)).toEqual(false);
+      expect(isRobustAccessorial(item226ANew)).toEqual(true);
+      expect(isRobustAccessorial(itemNull)).toEqual(false);
+    });
+  });
 });


### PR DESCRIPTION
## Description

Removes Feature Flag check for code 226A, releasing the new form into production. 

## Code Review Verification Steps

* [ ] This works in [Supported Browsers](./docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/163829406) for this change
