### PR TITLE
ecs-service-log fixes and improvements

### DIFF
--- a/scripts/ecs-show-service-logs
+++ b/scripts/ecs-show-service-logs
@@ -7,7 +7,7 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../bin" && pwd )"
 readonly DIR
 
 usage() {
-    echo "$0 <name> <environment> [git-branch [git-commit]] | less"
+    echo "${0##*/} <name> <environment> [git-branch [git-commit]] | less"
     exit 1
 }
 
@@ -16,4 +16,4 @@ set -u
 
 [[ -f "$DIR/ecs-service-logs" ]] || (echo "Missing $DIR/ecs-service-logs. Run make build_tools" && exit 1)
 
-"$DIR/ecs-service-logs" --cluster "app-${2}" --service "${1}" --git-branch "${3:-}" --git-commit "${4:-}" --status "RUNNING" --verbose
+"$DIR/ecs-service-logs" show --cluster "app-${2}" --service "${1}" --git-branch "${3:-}" --git-commit "${4:-}" --status "RUNNING" --verbose

--- a/scripts/ecs-show-service-stopped-logs
+++ b/scripts/ecs-show-service-stopped-logs
@@ -3,17 +3,17 @@
 #   Show logs from the most recently stopped app tasks.
 #
 set -eo pipefail
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../bin" && pwd )"
 readonly DIR
 readonly LIMIT=${LIMIT:-25}
 
 usage() {
-    echo "LIMIT=$LIMIT $0 <name> <environment> [git-branch [git-commit]] | less"
+    echo "LIMIT=$LIMIT ${0##*/} <name> <environment> [git-branch [git-commit]] | less"
     exit 1
 }
 [[ $# -lt 2 || $# -gt 4 ]] && usage
 set -u
 
-[[ -f "$DIR/ecs-service-logs" ]] || (echo "Missing bin/ecs-service-logs. Run make build_tools" && exit 1)
+[[ -f "$DIR/ecs-service-logs" ]] || (echo "Missing $DIR/ecs-service-logs. Run make build_tools" && exit 1)
 
-"$DIR/ecs-service-logs" --cluster "app-${2}" --service "${1}" --environment "${2}" --git-branch "${3:-}" --git-commit "${4:-}" --status "STOPPED" --verbose
+"$DIR/ecs-service-logs" show --cluster "app-${2}" --service "${1}" --environment "${2}" --git-branch "${3:-}" --git-commit "${4:-}" --status "STOPPED" --verbose


### PR DESCRIPTION
## Description

Some fixes and improvements to the `ecs-service-logs` tool, including using [cobra](https://github.com/spf13/cobra), filtering by task definition family or revision, and fixing filtering by git branch and commit.

## Reviewer Notes

Try the new flags.  For example:

```
bin/ecs-service-logs show -c app-staging -s app -e staging -l 8 -r 1803 --status STOPPED | jq .msg
```

## Setup

```
make build_tools
```

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](./docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](./docs/backend.md#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](./docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
  * [ ] Secure migrations have been tested using `scripts/run-prod-migrations`
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers](./docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @ntwyman
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

None

## Screenshots

None