### PR TITLE
Fix issue with console error about missing address in LocationsPanel

### DIFF
--- a/src/shared/Address/index.jsx
+++ b/src/shared/Address/index.jsx
@@ -35,7 +35,7 @@ AddressElementDisplay.propTypes = {
     city: PropTypes.string.isRequired,
     state: PropTypes.string.isRequired,
     postal_code: PropTypes.string.isRequired,
-  }),
+  }).isRequired,
   title: PropTypes.string.isRequired,
 };
 

--- a/src/shared/LocationsPanel/LocationsPanel.jsx
+++ b/src/shared/LocationsPanel/LocationsPanel.jsx
@@ -25,7 +25,7 @@ const LocationsDisplay = props => {
     <Fragment>
       <div className="editable-panel-column">
         <span className="column-subhead">Pickup</span>
-        <AddressElementDisplay address={pickupAddress} title="Primary" />
+        {pickupAddress && <AddressElementDisplay address={pickupAddress} title="Primary" />}
         {hasSecondaryPickupAddress && <AddressElementDisplay address={secondaryPickupAddress} title="Additional" />}
       </div>
       <div className="editable-panel-column">


### PR DESCRIPTION
## Description

This fixes a console error where the address prop was required but missing in LocationsPanel. This occurred due to the address being loaded just after the page initially renders. 

## Code Review Verification Steps

* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](./docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/164939280) for this change