### PR TITLE
More improvements to ecs-service-logs

### DIFF
--- a/cmd/ecs-service-logs/main.go
+++ b/cmd/ecs-service-logs/main.go
@@ -386,7 +386,7 @@ func showFunction(cmd *cobra.Command, args []string) error {
 
 	clusterName := v.GetString("cluster")
 	serviceName := v.GetString("service")
-	status := v.GetString("status")
+	status := strings.ToUpper(v.GetString("status"))
 	pageSize := v.GetInt(flagPageSize)
 	environment := v.GetString("environment")
 


### PR DESCRIPTION
## Description

Can now filter by log level, such as `error`.  Also will now paginate through logs until no more results.

## Reviewer Notes

Try

```shell
ecs-service-logs show --cluster app-staging --service app -e staging -r 1809 --status stopped --level error | jq .
```

## Setup

```shell
make build_tools
```

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](./docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](./docs/backend.md#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](./docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
  * [ ] Secure migrations have been tested using `scripts/run-prod-migrations`
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](./docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @ntwyman
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

None

## Screenshots

None