### PR TITLE
Add missing 400ng item rate for `130J`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -731,9 +731,9 @@ workflows:
             - pre_deps_yarn
             - acceptance_tests_local
           # if testing on experimental, you can disable these tests by using the commented block below.
-          filters:
-           branches:
-             ignore: lt-add-missing-item-rate-130j
+          # filters:
+          #  branches:
+          #    ignore: placeholder_branch_name
 
       - integration_tests_office:
           requires:
@@ -741,9 +741,9 @@ workflows:
             - pre_deps_yarn
             - acceptance_tests_local
           # if testing on experimental, you can disable these tests by using the commented block below.
-          filters:
-            branches:
-              ignore: lt-add-missing-item-rate-130j
+          # filters:
+          #   branches:
+          #     ignore: placeholder_branch_name
 
       - integration_tests_tsp:
           requires:
@@ -751,9 +751,9 @@ workflows:
             - pre_deps_yarn
             - acceptance_tests_local
           # if testing on experimental, you can disable these tests by using the commented block below.
-          filters:
-            branches:
-              ignore: lt-add-missing-item-rate-130j
+          # filters:
+          #   branches:
+          #     ignore: placeholder_branch_name
 
       - integration_tests_api:
           requires:
@@ -761,9 +761,9 @@ workflows:
             - pre_deps_yarn
             - acceptance_tests_local
           # if testing on experimental, you can disable these tests by using the commented block below.
-          filters:
-            branches:
-              ignore: lt-add-missing-item-rate-130j
+          # filters:
+          #   branches:
+          #     ignore: placeholder_branch_name
 
       - client_test:
           requires:
@@ -803,21 +803,21 @@ workflows:
             - build_migrations
           filters:
             branches:
-              only: lt-add-missing-item-rate-130j
+              only: placeholder_branch_name
 
       - deploy_experimental_app:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: lt-add-missing-item-rate-130j
+              only: placeholder_branch_name
 
       - deploy_experimental_app_client_tls:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: lt-add-missing-item-rate-130j
+              only: placeholder_branch_name
 
       - check_circle_against_staging_sha:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -731,9 +731,9 @@ workflows:
             - pre_deps_yarn
             - acceptance_tests_local
           # if testing on experimental, you can disable these tests by using the commented block below.
-          # filters:
-          #  branches:
-          #    ignore: placeholder_branch_name
+          filters:
+           branches:
+             ignore: lt-add-missing-item-rate-130j
 
       - integration_tests_office:
           requires:
@@ -741,9 +741,9 @@ workflows:
             - pre_deps_yarn
             - acceptance_tests_local
           # if testing on experimental, you can disable these tests by using the commented block below.
-          # filters:
-          #   branches:
-          #     ignore: placeholder_branch_name
+          filters:
+            branches:
+              ignore: lt-add-missing-item-rate-130j
 
       - integration_tests_tsp:
           requires:
@@ -751,9 +751,9 @@ workflows:
             - pre_deps_yarn
             - acceptance_tests_local
           # if testing on experimental, you can disable these tests by using the commented block below.
-          # filters:
-          #   branches:
-          #     ignore: placeholder_branch_name
+          filters:
+            branches:
+              ignore: lt-add-missing-item-rate-130j
 
       - integration_tests_api:
           requires:
@@ -761,9 +761,9 @@ workflows:
             - pre_deps_yarn
             - acceptance_tests_local
           # if testing on experimental, you can disable these tests by using the commented block below.
-          # filters:
-          #   branches:
-          #     ignore: placeholder_branch_name
+          filters:
+            branches:
+              ignore: lt-add-missing-item-rate-130j
 
       - client_test:
           requires:
@@ -803,21 +803,21 @@ workflows:
             - build_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: lt-add-missing-item-rate-130j
 
       - deploy_experimental_app:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: lt-add-missing-item-rate-130j
 
       - deploy_experimental_app_client_tls:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: lt-add-missing-item-rate-130j
 
       - check_circle_against_staging_sha:
           requires:

--- a/migrations/20190426134841_insert_missing_400ng_item_rate_130J.up.sql
+++ b/migrations/20190426134841_insert_missing_400ng_item_rate_130J.up.sql
@@ -1,0 +1,1 @@
+INSERT INTO tariff400ng_item_rates (id, created_at, updated_at, code, rate_cents, effective_date_lower, effective_date_upper) VALUES (uuid_generate_v4(), now(), now(), '130J', 22814, '2019-05-15', '2020-05-15');


### PR DESCRIPTION
## Description

We missed a single row when importing the `400ng items`.
Add `130J` to the `tariff400ng_item_rates` table.

## Setup

`make db_dev_migrate`

## Code Review Verification Steps

* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](./docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
* [ ] Request review from a member of a different team.

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/165550248) for this change