### PR TITLE
Office queue PPM changes

### DIFF
--- a/cypress/integration/office/ppmQueue.js
+++ b/cypress/integration/office/ppmQueue.js
@@ -1,0 +1,28 @@
+/* global cy */
+describe('Office ppm queue', () => {
+  beforeEach(() => {
+    cy.signIntoOffice();
+    cy.get('[data-cy=ppm-queue]').click();
+  });
+
+  it('does not have a GBL column', checkForGBLColumn);
+  it('shows a clock icon for records with PAYMENT_REQUESTED or SUBMITTED status', checkIcons);
+});
+
+function checkForGBLColumn() {
+  cy.contains('GBL').should('not.exist');
+}
+
+function checkIcons() {
+  cy.wait(1000);
+  cy.get('[data-cy=ppm-queue-icon]').each((el, index, list) => {
+    cy
+      .wrap(el)
+      .closest('.rt-td')
+      .next('.rt-td')
+      .find('[data-cy=status]')
+      .should(status => {
+        expect(status.text()).to.match(/Payment requested|Submitted/);
+      });
+  });
+}

--- a/pkg/models/queue.go
+++ b/pkg/models/queue.go
@@ -64,7 +64,7 @@ func GetMoveQueueItems(db *pop.Connection, lifecycleState string) ([]MoveQueueIt
 				ord.orders_type as orders_type,
 				ppm.original_move_date as move_date,
 				moves.created_at as created_at,
-				moves.updated_at as last_modified_date,
+				ppm.updated_at as last_modified_date,
 				moves.status as status,
 				ppm.status as ppm_status,
 				shipment.gbl_number as gbl_number

--- a/pkg/models/queue.go
+++ b/pkg/models/queue.go
@@ -62,7 +62,7 @@ func GetMoveQueueItems(db *pop.Connection, lifecycleState string) ([]MoveQueueIt
 				CONCAT(COALESCE(sm.last_name, '*missing*'), ', ', COALESCE(sm.first_name, '*missing*')) AS customer_name,
 				moves.locator as locator,
 				ord.orders_type as orders_type,
-				ppm.original_move_date as move_date,
+				COALESCE(ppm.actual_move_date, ppm.original_move_date) as move_date,
 				moves.created_at as created_at,
 				ppm.updated_at as last_modified_date,
 				moves.status as status,

--- a/src/scenes/Office/QueueList.jsx
+++ b/src/scenes/Office/QueueList.jsx
@@ -13,7 +13,7 @@ export default class QueueList extends Component {
             </NavLink>
           </li>
           <li>
-            <NavLink to="/queues/ppm" activeClassName="usa-current">
+            <NavLink to="/queues/ppm" activeClassName="usa-current" data-cy="ppm-queue">
               <span>PPMs</span>
             </NavLink>
           </li>

--- a/src/scenes/Office/QueueTable.jsx
+++ b/src/scenes/Office/QueueTable.jsx
@@ -102,7 +102,8 @@ class QueueTable extends Component {
             columns={[
               {
                 Header: <FontAwesomeIcon icon={faClock} />,
-                accessor: 'synthetic_status',
+                id: 'clockIcon',
+                accessor: row => row.synthetic_status,
                 Cell: row =>
                   row.value === 'PAYMENT_REQUESTED' || row.value === 'SUBMITTED' ? (
                     <span data-cy="ppm-queue-icon">

--- a/src/scenes/Office/QueueTable.jsx
+++ b/src/scenes/Office/QueueTable.jsx
@@ -110,6 +110,7 @@ class QueueTable extends Component {
                     ''
                   ),
                 width: 50,
+                show: this.props.queueType === 'ppm',
               },
               {
                 Header: 'Status',

--- a/src/scenes/Office/QueueTable.jsx
+++ b/src/scenes/Office/QueueTable.jsx
@@ -79,7 +79,7 @@ class QueueTable extends Component {
     };
 
     this.state.data.forEach(row => {
-      if (row.ppm_status === 'PAYMENT_REQUESTED') {
+      if (this.props.queueType === 'ppm' && row.ppm_status !== null) {
         row.synthetic_status = row.ppm_status;
       } else {
         row.synthetic_status = row.status;

--- a/src/scenes/Office/QueueTable.jsx
+++ b/src/scenes/Office/QueueTable.jsx
@@ -101,22 +101,20 @@ class QueueTable extends Component {
           <ReactTable
             columns={[
               {
+                Header: <FontAwesomeIcon icon={faClock} />,
+                accessor: 'synthetic_status',
+                Cell: row =>
+                  row.value === 'PAYMENT_REQUESTED' || row.value === 'SUBMITTED' ? (
+                    <FontAwesomeIcon icon={faClock} style={{ color: 'orange' }} />
+                  ) : (
+                    ''
+                  ),
+                width: 50,
+              },
+              {
                 Header: 'Status',
                 accessor: 'synthetic_status',
-                Cell: row => {
-                  const actionIcon =
-                    row.value === 'PAYMENT_REQUESTED' || row.value === 'SUBMITTED' ? (
-                      <FontAwesomeIcon icon={faClock} />
-                    ) : (
-                      ''
-                    );
-                  return (
-                    <span className="status">
-                      {capitalize(row.value.replace('_', ' '))}
-                      {actionIcon}
-                    </span>
-                  );
-                },
+                Cell: row => <span className="status">{capitalize(row.value.replace('_', ' '))}</span>,
               },
               {
                 Header: 'Customer name',

--- a/src/scenes/Office/QueueTable.jsx
+++ b/src/scenes/Office/QueueTable.jsx
@@ -123,6 +123,7 @@ class QueueTable extends Component {
               {
                 Header: 'GBL',
                 accessor: 'gbl_number',
+                show: this.props.queueType !== 'ppm',
               },
               {
                 Header: 'Move date',

--- a/src/scenes/Office/QueueTable.jsx
+++ b/src/scenes/Office/QueueTable.jsx
@@ -103,21 +103,20 @@ class QueueTable extends Component {
               {
                 Header: 'Status',
                 accessor: 'synthetic_status',
-                Cell: row => <span className="status">{capitalize(row.value.replace('_', ' '))}</span>,
-              },
-              {
-                Header: '',
-                accessor: 'synthetic_status',
-                show: this.props.queueType === 'ppm',
-                Cell: row => (
-                  <span className="">
-                    {row.value === 'PAYMENT_REQUESTED' || row.value === 'SUBMITTED' ? (
+                Cell: row => {
+                  const actionIcon =
+                    row.value === 'PAYMENT_REQUESTED' || row.value === 'SUBMITTED' ? (
                       <FontAwesomeIcon icon={faClock} />
                     ) : (
                       ''
-                    )}
-                  </span>
-                ),
+                    );
+                  return (
+                    <span className="status">
+                      {capitalize(row.value.replace('_', ' '))}
+                      {actionIcon}
+                    </span>
+                  );
+                },
               },
               {
                 Header: 'Customer name',

--- a/src/scenes/Office/QueueTable.jsx
+++ b/src/scenes/Office/QueueTable.jsx
@@ -7,6 +7,8 @@ import 'react-table/react-table.css';
 import { RetrieveMovesForOffice } from './api.js';
 import Alert from 'shared/Alert';
 import { formatDate, formatDateTimeWithTZ } from 'shared/formatters';
+import FontAwesomeIcon from '@fortawesome/react-fontawesome';
+import faClock from '@fortawesome/fontawesome-free-solid/faClock';
 
 class QueueTable extends Component {
   constructor() {
@@ -102,6 +104,20 @@ class QueueTable extends Component {
                 Header: 'Status',
                 accessor: 'synthetic_status',
                 Cell: row => <span className="status">{capitalize(row.value.replace('_', ' '))}</span>,
+              },
+              {
+                Header: '',
+                accessor: 'synthetic_status',
+                show: this.props.queueType === 'ppm',
+                Cell: row => (
+                  <span className="">
+                    {row.value === 'PAYMENT_REQUESTED' || row.value === 'SUBMITTED' ? (
+                      <FontAwesomeIcon icon={faClock} />
+                    ) : (
+                      ''
+                    )}
+                  </span>
+                ),
               },
               {
                 Header: 'Customer name',

--- a/src/scenes/Office/QueueTable.jsx
+++ b/src/scenes/Office/QueueTable.jsx
@@ -105,7 +105,9 @@ class QueueTable extends Component {
                 accessor: 'synthetic_status',
                 Cell: row =>
                   row.value === 'PAYMENT_REQUESTED' || row.value === 'SUBMITTED' ? (
-                    <FontAwesomeIcon icon={faClock} style={{ color: 'orange' }} />
+                    <span data-cy="ppm-queue-icon">
+                      <FontAwesomeIcon icon={faClock} style={{ color: 'orange' }} />
+                    </span>
                   ) : (
                     ''
                   ),
@@ -115,7 +117,11 @@ class QueueTable extends Component {
               {
                 Header: 'Status',
                 accessor: 'synthetic_status',
-                Cell: row => <span className="status">{capitalize(row.value.replace('_', ' '))}</span>,
+                Cell: row => (
+                  <span className="status" data-cy="status">
+                    {capitalize(row.value.replace('_', ' '))}
+                  </span>
+                ),
               },
               {
                 Header: 'Customer name',

--- a/src/scenes/Office/office.css
+++ b/src/scenes/Office/office.css
@@ -42,11 +42,6 @@
   text-align: left;
 }
 
-.queue-table .status {
-  display: flex;
-  justify-content: space-between;
-}
-
 /* Use with .usa-grid for a liquid and nearly full-width grid layout. */
 .grid-wide {
   max-width: 2000px;

--- a/src/scenes/Office/office.css
+++ b/src/scenes/Office/office.css
@@ -42,6 +42,11 @@
   text-align: left;
 }
 
+.queue-table .status {
+  display: flex;
+  justify-content: space-between;
+}
+
 /* Use with .usa-grid for a liquid and nearly full-width grid layout. */
 .grid-wide {
   max-width: 2000px;


### PR DESCRIPTION
## Description

### Why

**As an office user**
**I want see all the ppms in a single queue**
**So that I can process them**

### Acceptance Criteria

```gherkin
Scenario: 1.0
Given there are ppms that are submitted but basics are not approved
When I view the ppm queue
Then these should appear in the queue
and the GBL column should removed
```

**Notes:**
validate move date is the SM departure date
investigate using the ppm last_modified instead of the move last modified
investigate using the ppm status instead of the move status
investigate adding a icon for items that are actionable (submitted and payment requested)

## Setup

1. `make server_run`
2. `make client_run`
3. Visit the office PPM queue

## Code Review Verification Steps

* [ ] User facing changes have been reviewed by design.
* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/165500767) for this change

## Screenshots

<img width="1453" alt="Screen Shot 2019-04-26 at 11 23 25" src="https://user-images.githubusercontent.com/3522323/56830916-4f042700-682d-11e9-80f0-0a4697581f3c.png">

