### PR TITLE
Show submitted, approved, and in progress dates in PPM timeline.

### DIFF
--- a/cypress/integration/mymove/ppm.js
+++ b/cypress/integration/mymove/ppm.js
@@ -151,6 +151,7 @@ function serviceMemberVisitsIntroToPPMPaymentRequest() {
   cy.contains('Fort Gordon (from Yuma AFB)');
   cy.get('.submitted .status_dates').should('exist');
   cy.get('.ppm_approved .status_dates').should('exist');
+  cy.get('.in_progress .status_dates').should('exist');
   cy.contains('Request Payment').click();
 
   cy.location().should(loc => {

--- a/cypress/integration/mymove/ppm.js
+++ b/cypress/integration/mymove/ppm.js
@@ -149,6 +149,8 @@ describe('editing ppm only move', () => {
 function serviceMemberVisitsIntroToPPMPaymentRequest() {
   cy.signInAsUserPostRequest(milmoveAppName, '8e0d7e98-134e-4b28-bdd1-7d6b1ff34f9e');
   cy.contains('Fort Gordon (from Yuma AFB)');
+  cy.get('.submitted .status_dates').should('exist');
+  cy.get('.ppm_approved .status_dates').should('exist');
   cy.contains('Request Payment').click();
 
   cy.location().should(loc => {

--- a/src/scenes/Landing/StatusTimeline.jsx
+++ b/src/scenes/Landing/StatusTimeline.jsx
@@ -88,7 +88,7 @@ export class PPMStatusTimeline extends React.Component {
 
   render() {
     const statuses = this.addDates(this.addCompleted(this.getStatuses()));
-    return <StatusTimeline statuses={statuses} />;
+    return <StatusTimeline statuses={statuses} showEstimated={false} />;
   }
 }
 
@@ -174,7 +174,7 @@ export class ShipmentStatusTimeline extends React.Component {
 
   render() {
     const statuses = this.addDates(this.addCompleted(this.getStatuses()));
-    return <StatusTimeline statuses={statuses} />;
+    return <StatusTimeline statuses={statuses} showEstimated={true} />;
   }
 }
 
@@ -194,7 +194,7 @@ export class ProfileStatusTimeline extends React.Component {
   }
 
   render() {
-    return <StatusTimeline statuses={this.getStatuses()} />;
+    return <StatusTimeline statuses={this.getStatuses()} showEstimated={false} />;
   }
 }
 
@@ -225,7 +225,7 @@ class StatusTimeline extends PureComponent {
     return (
       <div className="status_timeline">
         {statusBlocks}
-        <div className="legend">* Estimated</div>
+        {this.props.showEstimated && <div className="legend">* Estimated</div>}
       </div>
     );
   }

--- a/src/scenes/Landing/StatusTimeline.test.jsx
+++ b/src/scenes/Landing/StatusTimeline.test.jsx
@@ -8,7 +8,7 @@ describe('StatusTimeline', () => {
       const ppm = {};
       const wrapper = mount(<PPMStatusTimeline ppm={ppm} />);
 
-      expect(wrapper.find(StatusBlock)).toHaveLength(5);
+      expect(wrapper.find(StatusBlock)).toHaveLength(4);
     });
 
     test('renders timeline for submitted ppm', () => {


### PR DESCRIPTION
## Description

Now that the submitted and approved dates are now captured for PPM moves, we can now display them and a date for the "in progress" status in the PPM timeline!

## Reviewer Notes
Any extra tests I should throw in somewhere?

## Setup

```sh
make server_run
make client_run
```

## Code Review Verification Steps
* [x] User facing changes have been reviewed by design.
* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/164717633) for this change
## Screenshots
<img width="1680" alt="Screen Shot 2019-04-26 at 4 37 40 PM" src="https://user-images.githubusercontent.com/6464062/56835974-b9c05d00-6843-11e9-9883-3d565be46d29.png">

