### PR TITLE
Hide expenses panel in SSW PPM tab

### DIFF
--- a/cypress/integration/office/officeUserPPM.js
+++ b/cypress/integration/office/officeUserPPM.js
@@ -38,6 +38,7 @@ describe('office user finds the move', function() {
     cy.get('.weights').should('not.exist');
     cy.get('.dates').should('not.exist');
     cy.get('.storage').should('not.exist');
+    cy.get('.expense-panel').should('not.exist');
   });
   it('office user views actual move date', function() {
     officeUserGoesToPPMPanel('PAYMNT');

--- a/cypress/integration/office/officeUserPPM.js
+++ b/cypress/integration/office/officeUserPPM.js
@@ -33,7 +33,7 @@ describe('office user finds the move', function() {
       .contains('Approved')
       .should('be.disabled');
   });
-  it('office user can not see storage, weight, and locations panels if payment has not been requested', function() {
+  it('office user can not see storage, weight, expenses, and locations panels if payment has not been requested', function() {
     officeUserGoesToPPMPanel('APPROV');
     cy.get('.weights').should('not.exist');
     cy.get('.dates').should('not.exist');

--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -92,9 +92,9 @@ const PPMTabContent = props => {
   return (
     <div className="office-tab">
       <PaymentsPanel title="Payments" moveId={props.moveId} />
-      <ExpensesPanel title="Expenses" moveId={props.moveId} />
       {props.ppmPaymentRequested && (
         <>
+          <ExpensesPanel title="Expenses" moveId={props.moveId} />
           <StoragePanel title="Storage" moveId={props.moveId} />
           <DatesAndLocationPanel title="Dates & Locations" moveId={props.moveId} />
           <NetWeightPanel title="Weights" moveId={props.moveId} />


### PR DESCRIPTION
## Description

Currently only hiding Storage, Dates & Locations, and Weights panels if PPM hasn't had payment requested yet. Expenses needs to also be hidden.

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make server_run
make office_client_run
make e2e_test
```

## Code Review Verification Steps
* [x] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/165574911) for this change

## Screenshots
<img width="1680" alt="Screen Shot 2019-04-29 at 10 49 35 AM" src="https://user-images.githubusercontent.com/6464062/56904567-87457880-6a6c-11e9-8c2d-91016aa9a7cb.png">