### PR TITLE
Fix tariff400ng_item_rates lower weight and rate_cents

### DIFF
--- a/migrations/20190429161555_fix-item-rates-cents-weight-lower.up.sql
+++ b/migrations/20190429161555_fix-item-rates-cents-weight-lower.up.sql
@@ -1,0 +1,20 @@
+-- These charges are subject to a min of 1,000lbs, so that rate should apply to weights < 1,000 also
+UPDATE tariff400ng_item_rates
+SET weight_lbs_lower = 0
+WHERE weight_lbs_lower = 1000
+    AND code IN ('125A', '125C', '210A', '210D', '225A', '225B')
+    AND effective_date_lower = '2019-05-15';
+
+
+-- These rates were assumed to be listed in cents but they were in dollars, though they were already scaled by 10
+-- because they contained decimal values
+UPDATE tariff400ng_item_rates
+SET rate_cents = rate_cents * 10
+WHERE code IN ('125C', '210D', '225B')
+	AND effective_date_lower = '2019-05-15';
+
+-- These rates were assumed to be listed in cents but they were in dollars
+UPDATE tariff400ng_item_rates
+SET rate_cents = rate_cents * 100
+WHERE code IN ('125A', '210A', '225A')
+	AND effective_date_lower = '2019-05-15';


### PR DESCRIPTION
## Description

Additional work needs to be done when loading yearly `400ng` rate codes.
* Certain codes need `weight_lbs_lower` to be 0 vs what is set in the `xlsx ` rates file.
* Certain codes `rate_cents` are passed in dollars, but had partial cents - multiply these by 10.
* Certain codes `rate_cents` are passed in dollars - multiply these by 100.

migration copied (and modified) from https://github.com/transcom/mymove/pull/1313

## Reviewer Notes

Spot check: '125A', '125C', '210A', '210D', '225A', '225B'

I did this via this query and replacing the `code` / `schedule` to see if the new data makes sense...
```
select * 
from tariff400ng_item_rates
WHERE code IN ('210D') and schedule = 3
order by code, schedule, weight_lbs_lower, effective_date_lower
```

## Setup

`make db_dev_migrate`

## Code Review Verification Steps

* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](./docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/165550248) for this change
