### PR TITLE
Dissallow same destination and pickup zip for PPMs

### DIFF
--- a/cypress/integration/mymove/ppm.js
+++ b/cypress/integration/mymove/ppm.js
@@ -23,7 +23,18 @@ describe('completing the ppm flow', function() {
       .get('input[name="pickup_postal_code"]')
       .clear()
       .type('80913');
-    cy.get('input[name="destination_postal_code"]').type('76127');
+
+    // same destination postal code and pickup postal code is not allowed
+    cy
+      .get('input[name="destination_postal_code"]')
+      .type('80913')
+      .blur();
+    cy.get('#destination_postal_code-error').should('exist');
+
+    cy
+      .get('input[name="destination_postal_code"]')
+      .clear()
+      .type('76127');
 
     cy.nextPage();
 

--- a/src/scenes/Moves/Ppm/DateAndLocation.jsx
+++ b/src/scenes/Moves/Ppm/DateAndLocation.jsx
@@ -27,7 +27,7 @@ const DateAndLocationWizardForm = reduxifyWizardForm(formName);
 
 const validateDifferentZip = (value, formValues) => {
   if (value && value === formValues.pickup_postal_code) {
-    return 'Pickup location zip and destination location zip cannot be the same';
+    return 'You entered the same zip code for your origin and destination. Please change one of them.';
   }
 };
 

--- a/src/scenes/Moves/Ppm/DateAndLocation.jsx
+++ b/src/scenes/Moves/Ppm/DateAndLocation.jsx
@@ -25,6 +25,12 @@ const sitEstimateDebounceTime = 300;
 const formName = 'ppp_date_and_location';
 const DateAndLocationWizardForm = reduxifyWizardForm(formName);
 
+const validateDifferentZip = (value, formValues) => {
+  if (value && value === formValues.pickup_postal_code) {
+    return 'Pickup location zip and destination location zip cannot be the same';
+  }
+};
+
 export class DateAndLocation extends Component {
   state = { showInfo: false };
 
@@ -158,6 +164,7 @@ export class DateAndLocation extends Component {
             fieldName="destination_postal_code"
             swagger={this.props.schema}
             onChange={this.getDebouncedSitEstimate}
+            validate={validateDifferentZip}
             required
           />
           <span className="grey">


### PR DESCRIPTION
## Description

The system doesn't support PPM moves that have the same destination and pickup zip. This PR adds a validation step to check if the destination zip is equal to the pickup zip and displays an error message if so (and does not allow the user to continue).

## Setup

1) Setup a PPM move.
2) When you reach "PPM Dates & Locations" try to enter the same pickup and destination zip. You should see an error message "Pickup location zip and destination location zip cannot be the same".

```sh
make e2e_test
```

## Code Review Verification Steps
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/n/projects/2181745/stories/165550431) for this change

## Screenshots
![Screen Shot 2019-04-29 at 11 13 56 AM](https://user-images.githubusercontent.com/1036969/56913861-ec4e9d80-6a6f-11e9-9525-9f675f87dd7c.png)
