### PR TITLE
TSP shipment page has link to shipment queue user came from.

### DIFF
--- a/cypress/integration/tsp/serviceAgents.js
+++ b/cypress/integration/tsp/serviceAgents.js
@@ -145,8 +145,6 @@ function tspUserAcceptsShipment() {
 
   // Status should be Accepted
   tspUserVerifiesShipmentStatus('Shipment accepted');
-
-  cy.get('a').contains('Accepted Shipments Queue');
 }
 
 function tspUserClicksAssignServiceAgent(locator) {

--- a/src/scenes/Office/QueueTable.jsx
+++ b/src/scenes/Office/QueueTable.jsx
@@ -142,7 +142,10 @@ class QueueTable extends Component {
             className="-striped -highlight"
             showPagination={false}
             getTrProps={(state, rowInfo) => ({
-              onDoubleClick: e => this.props.history.push(`new/moves/${rowInfo.original.id}`),
+              onDoubleClick: e =>
+                this.props.history.push(`new/moves/${rowInfo.original.id}`, {
+                  referrerPathname: this.props.history.location.pathname,
+                }),
             })}
           />
         </div>

--- a/src/scenes/TransportationServiceProvider/QueueTable.jsx
+++ b/src/scenes/TransportationServiceProvider/QueueTable.jsx
@@ -137,7 +137,10 @@ class QueueTable extends Component {
             className="-striped -highlight"
             showPagination={false}
             getTrProps={(state, rowInfo) => ({
-              onDoubleClick: e => this.props.history.push(`/shipments/${rowInfo.original.id}`),
+              onDoubleClick: e =>
+                this.props.history.push(`/shipments/${rowInfo.original.id}`, {
+                  referrerPathname: this.props.history.location.pathname,
+                }),
             })}
           />
         </div>

--- a/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
+++ b/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
@@ -229,6 +229,64 @@ class ShipmentInfo extends Component {
     if (!loadTspDependenciesHasSuccess) {
       return <LoadingPlaceholder />;
     }
+
+    let referrerQueueLink;
+    if (this.props.history.location.state) {
+      switch (this.props.history.location.state.referrerPathname) {
+        case '/queues/new':
+          referrerQueueLink = (
+            <NavLink to="/queues/new" activeClassName="usa-current">
+              <span>New Shipments Queue</span>
+            </NavLink>
+          );
+          break;
+        case '/queues/accepted':
+          referrerQueueLink = (
+            <NavLink to="/queues/accepted" activeClassName="usa-current">
+              <span>Accepted Shipments Queue</span>
+            </NavLink>
+          );
+          break;
+        case '/queues/approved':
+          referrerQueueLink = (
+            <NavLink to="/queues/approved" activeClassName="usa-current">
+              <span>Approved Shipments Queue</span>
+            </NavLink>
+          );
+          break;
+        case '/queues/in_transit':
+          referrerQueueLink = (
+            <NavLink to="/queues/in_transit" activeClassName="usa-current">
+              <span>In Transit Shipments Queue</span>
+            </NavLink>
+          );
+          break;
+        case '/queues/delivered':
+          referrerQueueLink = (
+            <NavLink to="/queues/delivered" activeClassName="usa-current">
+              <span>Delivered Shipments Queue</span>
+            </NavLink>
+          );
+          break;
+        case '/queues/completed':
+          referrerQueueLink = (
+            <NavLink to="/queues/completed" activeClassName="usa-current">
+              <span>Completed Shipments Queue</span>
+            </NavLink>
+          );
+          break;
+        default:
+          break;
+      }
+    }
+    if (!referrerQueueLink) {
+      referrerQueueLink = (
+        <NavLink to="/queues/new" activeClassName="usa-current">
+          <span>New Shipments Queue</span>
+        </NavLink>
+      );
+    }
+
     return (
       <div>
         <div className="usa-grid grid-wide">
@@ -243,48 +301,7 @@ class ShipmentInfo extends Component {
             </div>
             <div className="shipment-status">Status: {statusText}</div>
           </div>
-          <div className="usa-width-one-third nav-controls">
-            {awarded && (
-              <NavLink to="/queues/new" activeClassName="usa-current">
-                <span>New Shipments Queue</span>
-              </NavLink>
-            )}
-            {accepted && (
-              <NavLink to="/queues/accepted" activeClassName="usa-current">
-                <span>Accepted Shipments Queue</span>
-              </NavLink>
-            )}
-            {approved && (
-              <NavLink to="/queues/approved" activeClassName="usa-current">
-                <span>Approved Shipments Queue</span>
-              </NavLink>
-            )}
-            {inTransit && (
-              <NavLink to="/queues/in_transit" activeClassName="usa-current">
-                <span>In Transit Shipments Queue</span>
-              </NavLink>
-            )}
-            {delivered && (
-              <NavLink to="/queues/delivered" activeClassName="usa-current">
-                <span>Delivered Shipments Queue</span>
-              </NavLink>
-            )}
-            {completed && (
-              <NavLink to="/queues/completed" activeClassName="usa-current">
-                <span>Completed Shipments Queue</span>
-              </NavLink>
-            )}
-            {!awarded &&
-              !accepted &&
-              !approved &&
-              !inTransit &&
-              !delivered &&
-              !completed && (
-                <NavLink to="/queues/all" activeClassName="usa-current">
-                  <span>All Shipments Queue</span>
-                </NavLink>
-              )}
-          </div>
+          <div className="usa-width-one-third nav-controls">{referrerQueueLink}</div>
         </div>
         <div className="usa-grid grid-wide">
           <div className="usa-width-one-whole">

--- a/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
+++ b/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
@@ -103,59 +103,57 @@ const DeliveryDateFormView = props => {
 };
 
 const ReferrerQueueLink = props => {
-  if (props.history.location.state) {
-    switch (props.history.location.state.referrerPathname) {
-      case '/queues/new':
-        return (
-          <NavLink to="/queues/new" activeClassName="usa-current">
-            <span>New Shipments Queue</span>
-          </NavLink>
-        );
-      case '/queues/accepted':
-        return (
-          <NavLink to="/queues/accepted" activeClassName="usa-current">
-            <span>Accepted Shipments Queue</span>
-          </NavLink>
-        );
-      case '/queues/approved':
-        return (
-          <NavLink to="/queues/approved" activeClassName="usa-current">
-            <span>Approved Shipments Queue</span>
-          </NavLink>
-        );
-      case '/queues/in_transit':
-        return (
-          <NavLink to="/queues/in_transit" activeClassName="usa-current">
-            <span>In Transit Shipments Queue</span>
-          </NavLink>
-        );
-      case '/queues/delivered':
-        return (
-          <NavLink to="/queues/delivered" activeClassName="usa-current">
-            <span>Delivered Shipments Queue</span>
-          </NavLink>
-        );
-      case '/queues/completed':
-        return (
-          <NavLink to="/queues/completed" activeClassName="usa-current">
-            <span>Completed Shipments Queue</span>
-          </NavLink>
-        );
-      case '/queues/all':
-        return (
-          <NavLink to="/queues/all" activeClassName="usa-current">
-            <span>All Shipments Queue</span>
-          </NavLink>
-        );
-      default:
-        break;
-    }
+  const pathname = props.history.location.state ? props.history.location.state.referrerPathname : '';
+  switch (pathname) {
+    case '/queues/new':
+      return (
+        <NavLink to="/queues/new" activeClassName="usa-current">
+          <span>New Shipments Queue</span>
+        </NavLink>
+      );
+    case '/queues/accepted':
+      return (
+        <NavLink to="/queues/accepted" activeClassName="usa-current">
+          <span>Accepted Shipments Queue</span>
+        </NavLink>
+      );
+    case '/queues/approved':
+      return (
+        <NavLink to="/queues/approved" activeClassName="usa-current">
+          <span>Approved Shipments Queue</span>
+        </NavLink>
+      );
+    case '/queues/in_transit':
+      return (
+        <NavLink to="/queues/in_transit" activeClassName="usa-current">
+          <span>In Transit Shipments Queue</span>
+        </NavLink>
+      );
+    case '/queues/delivered':
+      return (
+        <NavLink to="/queues/delivered" activeClassName="usa-current">
+          <span>Delivered Shipments Queue</span>
+        </NavLink>
+      );
+    case '/queues/completed':
+      return (
+        <NavLink to="/queues/completed" activeClassName="usa-current">
+          <span>Completed Shipments Queue</span>
+        </NavLink>
+      );
+    case '/queues/all':
+      return (
+        <NavLink to="/queues/all" activeClassName="usa-current">
+          <span>All Shipments Queue</span>
+        </NavLink>
+      );
+    default:
+      return (
+        <NavLink to="/queues/new" activeClassName="usa-current">
+          <span>New Shipments Queue</span>
+        </NavLink>
+      );
   }
-  return (
-    <NavLink to="/queues/new" activeClassName="usa-current">
-      <span>New Shipments Queue</span>
-    </NavLink>
-  );
 };
 
 const DeliveryDateForm = reduxForm({ form: 'deliver_shipment' })(DeliveryDateFormView);

--- a/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
+++ b/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
@@ -102,6 +102,62 @@ const DeliveryDateFormView = props => {
   );
 };
 
+const ReferrerQueueLink = props => {
+  if (props.history.location.state) {
+    switch (props.history.location.state.referrerPathname) {
+      case '/queues/new':
+        return (
+          <NavLink to="/queues/new" activeClassName="usa-current">
+            <span>New Shipments Queue</span>
+          </NavLink>
+        );
+      case '/queues/accepted':
+        return (
+          <NavLink to="/queues/accepted" activeClassName="usa-current">
+            <span>Accepted Shipments Queue</span>
+          </NavLink>
+        );
+      case '/queues/approved':
+        return (
+          <NavLink to="/queues/approved" activeClassName="usa-current">
+            <span>Approved Shipments Queue</span>
+          </NavLink>
+        );
+      case '/queues/in_transit':
+        return (
+          <NavLink to="/queues/in_transit" activeClassName="usa-current">
+            <span>In Transit Shipments Queue</span>
+          </NavLink>
+        );
+      case '/queues/delivered':
+        return (
+          <NavLink to="/queues/delivered" activeClassName="usa-current">
+            <span>Delivered Shipments Queue</span>
+          </NavLink>
+        );
+      case '/queues/completed':
+        return (
+          <NavLink to="/queues/completed" activeClassName="usa-current">
+            <span>Completed Shipments Queue</span>
+          </NavLink>
+        );
+      case '/queues/all':
+        return (
+          <NavLink to="/queues/all" activeClassName="usa-current">
+            <span>All Shipments Queue</span>
+          </NavLink>
+        );
+      default:
+        break;
+    }
+  }
+  return (
+    <NavLink to="/queues/new" activeClassName="usa-current">
+      <span>New Shipments Queue</span>
+    </NavLink>
+  );
+};
+
 const DeliveryDateForm = reduxForm({ form: 'deliver_shipment' })(DeliveryDateFormView);
 
 // Action Buttons Conditions
@@ -230,63 +286,6 @@ class ShipmentInfo extends Component {
       return <LoadingPlaceholder />;
     }
 
-    let referrerQueueLink;
-    if (this.props.history.location.state) {
-      switch (this.props.history.location.state.referrerPathname) {
-        case '/queues/new':
-          referrerQueueLink = (
-            <NavLink to="/queues/new" activeClassName="usa-current">
-              <span>New Shipments Queue</span>
-            </NavLink>
-          );
-          break;
-        case '/queues/accepted':
-          referrerQueueLink = (
-            <NavLink to="/queues/accepted" activeClassName="usa-current">
-              <span>Accepted Shipments Queue</span>
-            </NavLink>
-          );
-          break;
-        case '/queues/approved':
-          referrerQueueLink = (
-            <NavLink to="/queues/approved" activeClassName="usa-current">
-              <span>Approved Shipments Queue</span>
-            </NavLink>
-          );
-          break;
-        case '/queues/in_transit':
-          referrerQueueLink = (
-            <NavLink to="/queues/in_transit" activeClassName="usa-current">
-              <span>In Transit Shipments Queue</span>
-            </NavLink>
-          );
-          break;
-        case '/queues/delivered':
-          referrerQueueLink = (
-            <NavLink to="/queues/delivered" activeClassName="usa-current">
-              <span>Delivered Shipments Queue</span>
-            </NavLink>
-          );
-          break;
-        case '/queues/completed':
-          referrerQueueLink = (
-            <NavLink to="/queues/completed" activeClassName="usa-current">
-              <span>Completed Shipments Queue</span>
-            </NavLink>
-          );
-          break;
-        default:
-          break;
-      }
-    }
-    if (!referrerQueueLink) {
-      referrerQueueLink = (
-        <NavLink to="/queues/new" activeClassName="usa-current">
-          <span>New Shipments Queue</span>
-        </NavLink>
-      );
-    }
-
     return (
       <div>
         <div className="usa-grid grid-wide">
@@ -301,7 +300,9 @@ class ShipmentInfo extends Component {
             </div>
             <div className="shipment-status">Status: {statusText}</div>
           </div>
-          <div className="usa-width-one-third nav-controls">{referrerQueueLink}</div>
+          <div className="usa-width-one-third nav-controls">
+            <ReferrerQueueLink history={this.props.history} />
+          </div>
         </div>
         <div className="usa-grid grid-wide">
           <div className="usa-width-one-whole">
@@ -518,4 +519,4 @@ const mapDispatchToProps = dispatch =>
 
 const connectedShipmentInfo = withContext(connect(mapStateToProps, mapDispatchToProps)(ShipmentInfo));
 
-export { DeliveryDateFormView, connectedShipmentInfo as default };
+export { DeliveryDateFormView, connectedShipmentInfo as default, ReferrerQueueLink };

--- a/src/scenes/TransportationServiceProvider/ShipmentInfo.test.js
+++ b/src/scenes/TransportationServiceProvider/ShipmentInfo.test.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import { ReferrerQueueLink } from './ShipmentInfo';
+import MockRouter from 'react-mock-router';
+
+const mockstore = configureStore();
+let wrapper;
+let store;
+describe('ShipmentInfo tests', () => {
+  describe('Shows correct queue to return to', () => {
+    beforeEach(() => {
+      store = mockstore({});
+    });
+    it('when a referrer is set in history', () => {
+      wrapper = mount(
+        <Provider store={store}>
+          <MockRouter push={jest.fn()}>
+            <ReferrerQueueLink history={{ location: { state: { referrerPathname: '/queues/accepted' } } }} />
+          </MockRouter>
+        </Provider>,
+      );
+      expect(wrapper.text()).toEqual('Accepted Shipments Queue');
+    });
+    it('when no referrer is set', () => {
+      wrapper = mount(
+        <Provider store={store}>
+          <MockRouter push={jest.fn()}>
+            <ReferrerQueueLink history={{ location: {} }} />
+          </MockRouter>
+        </Provider>,
+      );
+      expect(wrapper.text()).toEqual('New Shipments Queue');
+    });
+  });
+});


### PR DESCRIPTION
## Description

If a TSP clicks on a shipment from a shipment queue, the new page should have a link back to the queue. If the TSP navigates to a shipment directly (e.g. pasting a link in the address bar), it should have a link to the new moves queue. 

## Notes

Previously, there was a link to the queue that this shipment belonged to, e.g. if the shipment was in "delivered" state, the link would return to the delivered shipments queue. This new implementation will probably work almost identically, except that shipments that are accessed directly will now point to the new moves queue rather than the queue matching that shipment's state. 

## Code Review Verification Steps

* [ ] This works in [Supported Browsers and their phone views](./docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/165498464) for this change