### PR TITLE
Removes Feature Flag for Robust Item 125A/B/C/D [delivers #164869508]

### DIFF
--- a/cypress/fixtures/preApprovals/requests/createRobustAccessorial.js
+++ b/cypress/fixtures/preApprovals/requests/createRobustAccessorial.js
@@ -4,6 +4,22 @@ export function createItemRequest({ shipmentId, csrfToken, code, quantity1 }) {
     '105E': { item: 'UnPack Reg Crate', id: '6df4f1aa-a232-4eef-bbe8-f06bfb0b6d40', location: 'DESTINATION' },
     '35A': { item: 'Third Party Service', id: 'c6a865dd-324a-48a5-9b03-5db8dcd044d1', location: 'EITHER' },
     '226A': { item: 'Miscellaneous Charge', id: 'c5a6b126-de1a-4ab7-a5f4-c6e42cdf443b', location: 'EITHER' },
+    '125A': {
+      item: 'Shuttle Service 25 or less miles',
+      id: 'e27968f9-44a7-4582-af85-f4a5891120fd',
+      location: 'EITHER',
+    },
+    '125B': { item: 'Shuttle Service Over 25 Miles', id: 'd8044214-7fab-4588-8a6d-96d39d42e11d', location: 'EITHER' },
+    '125C': {
+      item: 'Shuttle Service 25 or less miles-OT',
+      id: 'c85179e9-3986-463c-b970-d470133be993',
+      location: 'EITHER',
+    },
+    '125D': {
+      item: 'Shuttle Service Over 25 Miles-OT',
+      id: '703c3e58-3835-439a-9ed1-6755eb91b62f',
+      location: 'EITHER',
+    },
   };
   let itemDetails;
   if (code in tariff400ng) {

--- a/cypress/integration/tsp/preApprovalRequest.js
+++ b/cypress/integration/tsp/preApprovalRequest.js
@@ -6,6 +6,7 @@ import {
 import { test35A, test35ALegacy } from '../../support/preapprovals/test35a';
 import { test105be, test105beLegacy } from '../../support/preapprovals/test105be';
 import { test226A, test226ALegacy } from '../../support/preapprovals/test226a';
+import { test125ABCD, test125ABCDLegacy } from '../../support/preapprovals/test125abcd';
 
 /* global cy */
 describe('TSP user interacts with pre approval request panel', function() {
@@ -38,6 +39,12 @@ describe('TSP user interacts with pre approval request panel', function() {
   });
   it('TSP user creates 226A request', function() {
     test226A();
+  });
+  it('Add legacy 125A/B/C/D to verify they display correctly', function() {
+    test125ABCDLegacy();
+  });
+  it('TSP user creates 125A/B/C/D request', function() {
+    test125ABCD();
   });
 });
 

--- a/cypress/support/preapprovals/test125abcd.js
+++ b/cypress/support/preapprovals/test125abcd.js
@@ -1,0 +1,81 @@
+import { addLegacyRequest, clickSaveAndClose, clickAddARequest } from './testRobustAccessorials';
+
+/* global cy */
+export function add125({ code }) {
+  clickAddARequest();
+  cy.selectTariff400ngItem(code);
+  cy.get('select[name="location"]').select('ORIGIN');
+  cy.typeInTextarea({ name: 'reason', value: `reason reason ${code}` });
+  cy
+    .get('input[name="date"]')
+    .last()
+    .type('4/29/2019{enter}')
+    .blur();
+  cy.typeInInput({ name: 'time', value: '0400J' });
+  cy.typeInTextarea({ name: 'notes', value: `notes notes ${code}` });
+  cy.typeInInput({ name: 'address.street_address_1', value: 'street address 1' });
+  cy.typeInInput({ name: 'address.street_address_2', value: 'street address 2' });
+  cy.typeInInput({ name: 'address.city', value: 'city' });
+  cy.get('select[name="address.state"]').select('CA');
+  cy.typeInInput({ name: 'address.postal_code', value: '90210' });
+  clickSaveAndClose();
+}
+
+export function test125ABCDLegacy() {
+  cy.selectQueueItemMoveLocator('DATESP');
+  addLegacyRequest({ code: '125A', quantity1: 12 }).then(res => {
+    expect(res.status).to.equal(201);
+  });
+  addLegacyRequest({ code: '125B', quantity1: 12 }).then(res => {
+    expect(res.status).to.equal(201);
+  });
+  addLegacyRequest({ code: '125C', quantity1: 12 }).then(res => {
+    expect(res.status).to.equal(201);
+  });
+  addLegacyRequest({ code: '125D', quantity1: 12 }).then(res => {
+    expect(res.status).to.equal(201);
+  });
+
+  // must reload page because original 125 are added by cy.request()
+  cy.reload();
+  cy.get('td[details-cy="125A-default-details"]').should('contain', '12.0000 notes notes 125A');
+  cy.get('td[details-cy="125B-default-details"]').should('contain', '12.0000 notes notes 125B');
+  cy.get('td[details-cy="125C-default-details"]').should('contain', '12.0000 notes notes 125C');
+  cy.get('td[details-cy="125D-default-details"]').should('contain', '12.0000 notes notes 125D');
+}
+
+export function test125ABCD() {
+  cy.selectQueueItemMoveLocator('DATESP');
+
+  add125({ code: '125A' });
+  cy
+    .get('td[data-cy="125A-details"]')
+    .should(
+      'contain',
+      'reason reason 125A Date of service: 29-Apr-19 Time of service: 0400J street address 1 street address 2 city, CA 90210',
+    );
+
+  add125({ code: '125B' });
+  cy
+    .get('td[data-cy="125B-details"]')
+    .should(
+      'contain',
+      'reason reason 125B Date of service: 29-Apr-19 Time of service: 0400J street address 1 street address 2 city, CA 90210',
+    );
+
+  add125({ code: '125C' });
+  cy
+    .get('td[data-cy="125C-details"]')
+    .should(
+      'contain',
+      'reason reason 125C Date of service: 29-Apr-19 Time of service: 0400J street address 1 street address 2 city, CA 90210',
+    );
+
+  add125({ code: '125D' });
+  cy
+    .get('td[data-cy="125D-details"]')
+    .should(
+      'contain',
+      'reason reason 125D Date of service: 29-Apr-19 Time of service: 0400J street address 1 street address 2 city, CA 90210',
+    );
+}

--- a/src/shared/PreApprovalRequest/Code125Form.jsx
+++ b/src/shared/PreApprovalRequest/Code125Form.jsx
@@ -15,7 +15,12 @@ export const Code125Form = props => {
         required
       />
       <SwaggerField title="Date of service" fieldName="date" swagger={ship_line_item_schema} required />
-      <SwaggerField title="Time of service" fieldName="time" swagger={ship_line_item_schema} />
+      <SwaggerField
+        className="par-time-input"
+        title="Time of service"
+        fieldName="time"
+        swagger={ship_line_item_schema}
+      />
       <AddressElementEdit
         fieldName="address"
         schema={get(ship_line_item_schema, 'properties.address')}

--- a/src/shared/PreApprovalRequest/Code125Form.jsx
+++ b/src/shared/PreApprovalRequest/Code125Form.jsx
@@ -22,9 +22,6 @@ export const Code125Form = props => {
         title="Truck-to-truck transfer location"
         zipPattern="USA"
       />
-      <div className="bq-explanation">
-        <p>Enter amount after service is completed</p>
-      </div>
     </Fragment>
   );
 };

--- a/src/shared/PreApprovalRequest/Code125Form.jsx
+++ b/src/shared/PreApprovalRequest/Code125Form.jsx
@@ -22,6 +22,9 @@ export const Code125Form = props => {
         title="Truck-to-truck transfer location"
         zipPattern="USA"
       />
+      <div className="bq-explanation">
+        <p>If this address changes last minute, notify your PPPO.</p>
+      </div>
     </Fragment>
   );
 };

--- a/src/shared/PreApprovalRequest/DetailsHelper.js
+++ b/src/shared/PreApprovalRequest/DetailsHelper.js
@@ -10,7 +10,7 @@ import { Code226Details } from './Code226Details';
 import { Code125Form } from './Code125Form';
 import { Code125Details } from './Code125Details';
 
-export function getFormComponent(code, robustAccessorialFlag, initialValues) {
+export function getFormComponent(code, initialValues) {
   code = code ? code.toLowerCase() : '';
   const isNew = !initialValues;
   if (code.startsWith('105b') || code.startsWith('105e')) {
@@ -25,7 +25,7 @@ export function getFormComponent(code, robustAccessorialFlag, initialValues) {
   return DefaultForm;
 }
 
-export function getDetailsComponent(code, robustAccessorialFlag, isRobustAccessorial) {
+export function getDetailsComponent(code, isRobustAccessorial) {
   if (!isRobustAccessorial) return DefaultDetails;
   if (code === '105B' || code === '105E') return Code105Details;
   if (code === '35A') return Code35Details;

--- a/src/shared/PreApprovalRequest/DetailsHelper.js
+++ b/src/shared/PreApprovalRequest/DetailsHelper.js
@@ -19,7 +19,7 @@ export function getFormComponent(code, robustAccessorialFlag, initialValues) {
     if (isNew || get(initialValues, 'estimate_amount_cents')) return Code35Form;
   } else if (code.startsWith('226')) {
     if (isNew || get(initialValues, 'actual_amount_cents')) return Code226Form;
-  } else if (robustAccessorialFlag && code.startsWith('125')) {
+  } else if (code.startsWith('125')) {
     if (isNew || get(initialValues, 'address')) return Code125Form;
   }
   return DefaultForm;
@@ -30,7 +30,7 @@ export function getDetailsComponent(code, robustAccessorialFlag, isRobustAccesso
   if (code === '105B' || code === '105E') return Code105Details;
   if (code === '35A') return Code35Details;
   if (code === '226A') return Code226Details;
-  if (code.startsWith('125') && robustAccessorialFlag) return Code125Details;
+  if (code.startsWith('125')) return Code125Details;
   return DefaultDetails;
 }
 

--- a/src/shared/PreApprovalRequest/DetailsHelper.test.js
+++ b/src/shared/PreApprovalRequest/DetailsHelper.test.js
@@ -4,7 +4,6 @@ import { Code105Form } from './Code105Form';
 import { Code35Form } from './Code35Form';
 import { Code226Form } from './Code226Form';
 
-let featureFlag = false;
 let initialValuesWithoutCrateDimensions = {};
 let initialValuesWithCrateDimensions = { crate_dimensions: true };
 describe('testing getFormComponent()', () => {
@@ -16,87 +15,54 @@ describe('testing getFormComponent()', () => {
     });
   });
 
-  describe('returns default form component with feature flag off', () => {
-    //pass in known code item with feature flag off
-    featureFlag = false;
-
-    let FormComponent;
-    it('for code 105', () => {
-      FormComponent = getFormComponent('105', featureFlag, initialValuesWithCrateDimensions);
-      expect(FormComponent).toBe(DefaultForm);
-    });
-
-    //testing for non-existing code
-    it('for code 4A', () => {
-      FormComponent = getFormComponent('4A', featureFlag, initialValuesWithCrateDimensions);
-      expect(FormComponent).toBe(DefaultForm);
-    });
-
-    it('for code 105D', () => {
-      FormComponent = getFormComponent('105D', featureFlag, initialValuesWithCrateDimensions);
-      expect(FormComponent).toBe(DefaultForm);
-    });
-
-    it('for code 105D', () => {
-      FormComponent = getFormComponent('105D', featureFlag, null);
-      expect(FormComponent).toBe(DefaultForm);
-    });
-  });
-
-  describe('returns 105B/E form component with feature flag on', () => {
-    featureFlag = true;
+  describe('returns 105B/E form component', () => {
     let FormComponent;
 
     it('for code 105B', () => {
-      FormComponent = getFormComponent('105B', featureFlag, initialValuesWithCrateDimensions);
+      FormComponent = getFormComponent('105B', initialValuesWithCrateDimensions);
       expect(FormComponent).toBe(Code105Form);
     });
 
     it('for code 105E', () => {
-      FormComponent = getFormComponent('105E', featureFlag, initialValuesWithCrateDimensions);
+      FormComponent = getFormComponent('105E', initialValuesWithCrateDimensions);
       expect(FormComponent).toBe(Code105Form);
     });
   });
 
-  describe('returns 35A form component with feature flag on', () => {
-    featureFlag = true;
-
+  describe('returns 35A form component', () => {
     it('for code 35A', () => {
-      let FormComponent = getFormComponent('35A', featureFlag, { estimate_amount_cents: true });
+      let FormComponent = getFormComponent('35A', { estimate_amount_cents: true });
       expect(FormComponent).toBe(Code35Form);
     });
   });
 
-  describe('returns 226A form component with feature flag on', () => {
-    featureFlag = true;
-
+  describe('returns 226A form component', () => {
     it('for code 226A', () => {
-      let FormComponent = getFormComponent('226A', featureFlag, { actual_amount_cents: true });
+      let FormComponent = getFormComponent('226A', { actual_amount_cents: true });
       expect(FormComponent).toBe(Code226Form);
     });
   });
 
-  describe('returns default form component with feature flag on', () => {
-    featureFlag = true;
+  describe('returns default form component without robust fields', () => {
     let FormComponent;
 
     it('for code 105D', () => {
-      FormComponent = getFormComponent('105D', featureFlag);
+      FormComponent = getFormComponent('105D');
       expect(FormComponent).toBe(DefaultForm);
     });
 
     it('for code 105B without crate dimensions', () => {
-      FormComponent = getFormComponent('105B', featureFlag, initialValuesWithoutCrateDimensions);
+      FormComponent = getFormComponent('105B', initialValuesWithoutCrateDimensions);
       expect(FormComponent).toBe(DefaultForm);
     });
 
     it('for code 105E without crate dimensions', () => {
-      FormComponent = getFormComponent('105E', featureFlag, initialValuesWithoutCrateDimensions);
+      FormComponent = getFormComponent('105E', initialValuesWithoutCrateDimensions);
       expect(FormComponent).toBe(DefaultForm);
     });
 
     it('for code 226A without crate dimensions', () => {
-      FormComponent = getFormComponent('226A', featureFlag, initialValuesWithoutCrateDimensions);
+      FormComponent = getFormComponent('226A', initialValuesWithoutCrateDimensions);
       expect(FormComponent).toBe(DefaultForm);
     });
   });

--- a/src/shared/PreApprovalRequest/PreApprovalForm.jsx
+++ b/src/shared/PreApprovalRequest/PreApprovalForm.jsx
@@ -2,7 +2,6 @@ import { get, includes, reject } from 'lodash';
 import React, { Component, Fragment } from 'react';
 import Select, { createFilter } from 'react-select';
 import { connect } from 'react-redux';
-import { withContext } from 'shared/AppContext';
 import PropTypes from 'prop-types';
 import { reduxForm, Form, Field, formValueSelector } from 'redux-form';
 import { validateAdditionalFields } from 'shared/JsonSchemaForm';
@@ -190,12 +189,7 @@ export class PreApprovalForm extends Component {
   }
 
   render() {
-    const robustAccessorial = get(this.props, 'context.flags.robustAccessorial', false);
-    const FormComponent = getFormComponent(
-      this.props.tariff400ng_item_code,
-      robustAccessorial,
-      this.props.initialValues,
-    );
+    const FormComponent = getFormComponent(this.props.tariff400ng_item_code, this.props.initialValues);
     const isStatic = this.props.status === 'CONDITIONALLY_APPROVED' || this.props.status === 'APPROVED';
     return isStatic ? this.makeStaticForm(FormComponent) : this.makeEditableForm(FormComponent);
   }
@@ -244,4 +238,4 @@ function getActualAmount(state) {
   return convertDollarsToCents(selector(state, 'actual_amount_cents'));
 }
 
-export default withContext(connect(mapStateToProps)(PreApprovalForm));
+export default connect(mapStateToProps)(PreApprovalForm);

--- a/src/shared/PreApprovalRequest/PreApprovalRequest.css
+++ b/src/shared/PreApprovalRequest/PreApprovalRequest.css
@@ -3,6 +3,10 @@
   margin-top: 3rem;
 }
 
+.pre-approval-form .par-time-input {
+  display: inline-block;
+}
+
 /*PreApproval Table styles*/
 .pre-approval-panel {
   border-width: 3px;

--- a/src/shared/PreApprovalRequest/PreApprovalRequest.css
+++ b/src/shared/PreApprovalRequest/PreApprovalRequest.css
@@ -137,6 +137,7 @@
 
 .bq-explanation {
   font-size: 0.9em;
+  color: grey;
 }
 
 .bq-explanation p {

--- a/src/shared/PreApprovalRequest/PreApprovalRequest.css
+++ b/src/shared/PreApprovalRequest/PreApprovalRequest.css
@@ -1,3 +1,8 @@
+.pre-approval-form .usa-width-one-half > :first-child,
+.pre-approval-form .panel-subhead {
+  margin-top: 3rem;
+}
+
 /*PreApproval Table styles*/
 .pre-approval-panel {
   border-width: 3px;

--- a/src/shared/PreApprovalRequest/PreApprovalRequest.jsx
+++ b/src/shared/PreApprovalRequest/PreApprovalRequest.jsx
@@ -1,8 +1,6 @@
-import { get } from 'lodash';
 import React, { Component, Fragment } from 'react';
 import FontAwesomeIcon from '@fortawesome/react-fontawesome';
 import PropTypes from 'prop-types';
-import { withContext } from 'shared/AppContext';
 import { renderStatusIcon } from 'shared/utils';
 import { isOfficeSite } from 'shared/constants.js';
 import { formatDate } from 'shared/formatters';
@@ -99,11 +97,7 @@ export class PreApprovalRequest extends Component {
     const hasInvoice = Boolean(row.invoice_id);
     const isShowingForm = Boolean(this.state.showDeleteForm || this.state.showEditForm);
     const showButtons = this.props.isActionable && !isShowingForm && !hasInvoice;
-    const DetailsComponent = getDetailsComponent(
-      row.tariff400ng_item.code,
-      get(this.props, 'context.flags.robustAccessorial', false),
-      isRobustAccessorial(row),
-    );
+    const DetailsComponent = getDetailsComponent(row.tariff400ng_item.code, isRobustAccessorial(row));
     if (this.state.showEditForm) {
       return (
         <tr>
@@ -186,5 +180,5 @@ PreApprovalRequest.propTypes = {
   tariff400ngItems: PropTypes.array,
 };
 
-export default withContext(PreApprovalRequest);
+export default PreApprovalRequest;
 export { PreApprovalRequest as BasicPreApprovalRequest };

--- a/src/shared/featureFlags.js
+++ b/src/shared/featureFlags.js
@@ -13,7 +13,6 @@ const defaultFlags = {
   hhg: true,
   documentViewer: true,
   moveInfoComboButton: true,
-  robustAccessorial: true,
   sitPanel: true,
   ppmPaymentRequest: true,
 };
@@ -26,12 +25,10 @@ const environmentFlags = {
   experimental: Object.assign({}, defaultFlags),
 
   staging: Object.assign({}, defaultFlags, {
-    robustAccessorial: false,
     ppmPaymentRequest: false,
   }),
 
   production: Object.assign({}, defaultFlags, {
-    robustAccessorial: false,
     sitPanel: false,
     ppmPaymentRequest: false,
   }),


### PR DESCRIPTION
## Description

This PR removes the feature flag for robust item 125 and from the app as well. This also adds e2e tests for robust 125 and legacy 125.

## Code Review Verification Steps

* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](./docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/164869508) for this change

## Screenshots

![image](https://user-images.githubusercontent.com/1522549/57035980-028f6180-6c08-11e9-9dc7-17c2fbfc777d.png)

![image](https://user-images.githubusercontent.com/1522549/57036030-0cb16000-6c08-11e9-9cfe-c8af63904bf9.png)


