### PR TITLE
Show "Actual item dimensions (inches)" label if editing robust item 105 [delivers #165747893]

### DIFF
--- a/src/shared/PreApprovalRequest/Code105Form.jsx
+++ b/src/shared/PreApprovalRequest/Code105Form.jsx
@@ -3,14 +3,15 @@ import { SwaggerField } from 'shared/JsonSchemaForm/JsonSchemaField';
 import { DimensionsField } from '../JsonSchemaForm/DimensionsField';
 
 export const Code105Form = props => {
-  const { ship_line_item_schema } = props;
+  const { ship_line_item_schema, initialValues } = props;
+  const labelItem = initialValues ? 'Actual item' : 'Item';
   return (
     <Fragment>
       <SwaggerField className="textarea-half" fieldName="description" swagger={ship_line_item_schema} required />
       <DimensionsField
         fieldName="item_dimensions"
         swagger={ship_line_item_schema}
-        labelText="Item dimensions (inches)"
+        labelText={`${labelItem} dimensions (inches)`}
         isRequired={true}
       />
       <DimensionsField


### PR DESCRIPTION
## Description

This PR changes the label for robust accessorial item 105 dimension item to show label "Actual item dimensions (inches)" in edit mode. Create mode will stay the same, "Item dimensions (inches)".

## Code Review Verification Steps

* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](./docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/165747893) for this change

## Screenshots

![image](https://user-images.githubusercontent.com/1522549/57031667-26997580-6bfd-11e9-9a42-e6f9162cf8b2.png)

![image](https://user-images.githubusercontent.com/1522549/57031688-344efb00-6bfd-11e9-8162-16091c18f5d7.png)
