### PR TITLE
use parent directory for links

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,16 +16,16 @@ echo "Code goes here"
 
 ## Code Review Verification Steps
 
-* [ ] Code follows the guidelines for [Logging](./docs/backend.md#logging)
+* [ ] Code follows the guidelines for [Logging](../docs/backend.md#logging)
 * [ ] The requirements listed in
- [Querying the Database Safely](./docs/backend.md#querying-the-database-safely)
+ [Querying the Database Safely](../docs/backend.md#querying-the-database-safely)
  have been satisfied.
 * Any new migrations/schema changes:
-  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](./docs/database.md#zero-downtime-migrations))
+  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](../docs/database.md#zero-downtime-migrations))
   * [ ] Have been communicated to #dp3-engineering
   * [ ] Secure migrations have been tested using `scripts/run-prod-migrations`
 * [ ] There are no aXe warnings for UI.
-* [ ] This works in [Supported Browsers and their phone views](./docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
+* [ ] This works in [Supported Browsers and their phone views](../docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
 * Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
   * [ ] Communicated to @ntwyman
   * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,16 +16,16 @@ echo "Code goes here"
 
 ## Code Review Verification Steps
 
-* [ ] Code follows the guidelines for [Logging](../tree/master/docs/backend.md#logging)
+* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/tree/master/docs/backend.md#logging)
 * [ ] The requirements listed in
- [Querying the Database Safely](../tree/master/docs/backend.md#querying-the-database-safely)
+ [Querying the Database Safely](https://github.com/transcom/mymove/tree/master/docs/backend.md#querying-the-database-safely)
  have been satisfied.
 * Any new migrations/schema changes:
-  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](../tree/master/docs/database.md#zero-downtime-migrations))
+  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/tree/master/docs/database.md#zero-downtime-migrations))
   * [ ] Have been communicated to #dp3-engineering
   * [ ] Secure migrations have been tested using `scripts/run-prod-migrations`
 * [ ] There are no aXe warnings for UI.
-* [ ] This works in [Supported Browsers and their phone views](../tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
+* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
 * Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
   * [ ] Communicated to @ntwyman
   * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,16 +16,16 @@ echo "Code goes here"
 
 ## Code Review Verification Steps
 
-* [ ] Code follows the guidelines for [Logging](../docs/backend.md#logging)
+* [ ] Code follows the guidelines for [Logging](../tree/master/docs/backend.md#logging)
 * [ ] The requirements listed in
- [Querying the Database Safely](../docs/backend.md#querying-the-database-safely)
+ [Querying the Database Safely](../tree/master/docs/backend.md#querying-the-database-safely)
  have been satisfied.
 * Any new migrations/schema changes:
-  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](../docs/database.md#zero-downtime-migrations))
+  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](../tree/master/docs/database.md#zero-downtime-migrations))
   * [ ] Have been communicated to #dp3-engineering
   * [ ] Secure migrations have been tested using `scripts/run-prod-migrations`
 * [ ] There are no aXe warnings for UI.
-* [ ] This works in [Supported Browsers and their phone views](../docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
+* [ ] This works in [Supported Browsers and their phone views](../tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
 * Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
   * [ ] Communicated to @ntwyman
   * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)


### PR DESCRIPTION
## Description

Right now the links in the PR template are linking to `/pull` instead of the correct docs. I changed this PR to demonstrate the new link structure works.

## Reviewer Notes

Do you see docs or an example that shows a more correct way to do this? The alternative is use the full url, not relative paths.


## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](../tree/master/docs/backend.md#logging)