### PR TITLE
Unique Devlocal Users

### DIFF
--- a/pkg/auth/authentication/devlocal.go
+++ b/pkg/auth/authentication/devlocal.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"html/template"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/gobuffalo/pop"
@@ -310,8 +311,12 @@ func createUser(h devlocalAuthHandler, w http.ResponseWriter, r *http.Request) (
 	}
 	email := r.Form.Get("email")
 	if email == "" {
+		// Time alone doesn't guarantee uniqueness if a system is being automated
+		// To add some more uniqueness without making the email unreadable a UUID adds a nonce
 		now := time.Now()
-		email = fmt.Sprintf("%s@example.com", now.Format("20060102150405"))
+		guid, _ := uuid.NewV4()
+		nonce := strings.Split(guid.String(), "-")[4]
+		email = fmt.Sprintf("%s-%s@example.com", now.Format("20060102150405"), nonce)
 	}
 
 	// Create the User (which is the basis of all Service Members)


### PR DESCRIPTION
## Description

Email collision happens when automated testing run because time is not unique enough by itself to disambiguate. For example, when letting load-testing in #1597 create users it can do it at a rate faster than the time stamp will change, which means you get weird session authentication errors for users with the same email.

## Reviewer Notes

Is there a better way to get uniqueness? Or should I just be using the full uuid as the email address instead of the time?

## Setup

You can use the demo script in #1597 to see the problem happen in real time. 