### PR TITLE
Remove 'format: string' from spec since it does nothing and throws warnings

### DIFF
--- a/swagger/api.yaml
+++ b/swagger/api.yaml
@@ -116,7 +116,6 @@ definitions:
         example: https://uploads.domain.test/dir/c56a4180-65aa-42ec-a945-5fd21dec0538
       filename:
         type: string
-        format: string
         example: filename.pdf
       content_type:
         type: string
@@ -990,7 +989,6 @@ definitions:
         example: c56a4180-65aa-42ec-a945-5fd21dec0538
       name:
         type: string
-        format: string
         example: Fort Bragg North Station
       address:
         $ref: '#/definitions/Address'

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -80,7 +80,6 @@ definitions:
         example: c56a4180-65aa-42ec-a945-5fd21dec0538
       name:
         type: string
-        format: string
         example: Fort Bragg North Station
       address:
         $ref: '#/definitions/Address'
@@ -110,7 +109,6 @@ definitions:
         example: c56a4180-65aa-42ec-a945-5fd21dec0538
       name:
         type: string
-        format: string
         example: Fort Bragg North Station
       address:
         $ref: '#/definitions/Address'
@@ -123,7 +121,6 @@ definitions:
           example: 212-555-5555
       gbloc:
         type: string
-        format: string
         pattern: '^[A-Z]{4}$'
         example: JENQ
       latitude:
@@ -1449,7 +1446,6 @@ definitions:
         example: https://uploads.domain.test/dir/c56a4180-65aa-42ec-a945-5fd21dec0538
       filename:
         type: string
-        format: string
         example: filename.pdf
       content_type:
         type: string
@@ -4113,7 +4109,6 @@ paths:
         - in: query
           name: search
           type: string
-          format: string
           required: true
           description: Search string for duty stations
       responses:


### PR DESCRIPTION
## Description

`string` is not a format as defined by https://swagger.io/docs/specification/data-models/data-types/. In fact its redundant and doesn't add value to the places where it is used. In #1597 the load testing framework throws warnings for these and so I am removing them.

## Setup

Run the app, it should have no issues.

## Code Review Verification Steps

* [x] Request review from a member of a different team.