### PR TITLE
Date field is not editable when sit is denied

### DIFF
--- a/src/shared/StorageInTransit/StorageInTransitOfficeEditForm.jsx
+++ b/src/shared/StorageInTransit/StorageInTransitOfficeEditForm.jsx
@@ -40,12 +40,22 @@ export class StorageInTransitOfficeEditForm extends Component {
         <div className="editable-panel-column">
           <div className="panel-subhead">Authorization</div>
           <PanelField value={sitStatus()} fieldName="status" required title="SIT Approved" {...fieldProps} />
-          <SwaggerField
-            fieldName="authorized_start_date"
-            swagger={storageInTransitSchema}
-            title="Earliest authorized start"
-            required
-          />
+          {storageInTransit.status === 'APPROVED' ? (
+            <SwaggerField
+              fieldName="authorized_start_date"
+              swagger={storageInTransitSchema}
+              title="Earliest authorized start"
+              required
+            />
+          ) : (
+            <PanelField
+              value="n/a"
+              fieldName="authorized_start_date"
+              required
+              title="Earliest authorized start"
+              {...fieldProps}
+            />
+          )}
           <SwaggerField
             className="sit-approval-field"
             fieldName="authorization_notes"


### PR DESCRIPTION
## Description

When a SIT request has been denied, the date field in the edit form should not be editable.


## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make db_dev_e2e_populate
make server_run
make client_run
```
In the Office app, select an HHG record with an `DENIED` SIT. In the SIT panel you will see an 'Edit' link. Clicking on this will open up a form that shoes the various SIT information. The date will not be editable.

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/164252289) for this change

## Screenshots

<img width="1121" alt="Screen Shot 2019-05-02 at 2 25 39 PM" src="https://user-images.githubusercontent.com/3522044/57107929-317c0500-6ce6-11e9-8ee7-c0b15e1fa1c0.png">

