### PR TITLE
Fix move date for moves in the 'new' and 'all' queues

### DIFF
--- a/pkg/handlers/internalapi/move_queue_items_test.go
+++ b/pkg/handlers/internalapi/move_queue_items_test.go
@@ -89,3 +89,69 @@ func (suite *HandlerSuite) TestShowQueueHandlerForbidden() {
 		suite.Assertions.IsType(&queueop.ShowQueueForbidden{}, showResponse)
 	}
 }
+
+func (suite *HandlerSuite) TestGetMoveQueueItemsComboMoveDate() {
+	suite.SetupTest()
+
+	// Given: An office user
+	officeUser := testdatagen.MakeDefaultOfficeUser(suite.DB())
+
+	//  A set of orders and a move belonging to those orders
+	sm := testdatagen.MakeDefaultServiceMember(suite.DB())
+	order := testdatagen.MakeOrder(suite.DB(), testdatagen.Assertions{
+		Order: models.Order{
+			ServiceMemberID: sm.ID,
+		},
+	})
+
+	newMove := models.Move{
+		OrdersID: order.ID,
+		Status:   models.MoveStatus("SUBMITTED"),
+	}
+	suite.MustSave(&newMove)
+
+	// Make a PPM
+	testdatagen.MakePPM(suite.DB(), testdatagen.Assertions{
+		PersonallyProcuredMove: models.PersonallyProcuredMove{
+			Move:   newMove,
+			MoveID: newMove.ID,
+		},
+	})
+
+	pickupDate := testdatagen.NextValidMoveDate
+
+	// Make a shipment
+	shipment := testdatagen.MakeShipment(suite.DB(), testdatagen.Assertions{
+		Shipment: models.Shipment{
+			RequestedPickupDate: &pickupDate,
+			ActualPickupDate:    &pickupDate,
+			Status:              models.ShipmentStatusSUBMITTED,
+			Move:                newMove,
+			MoveID:              newMove.ID,
+			ServiceMemberID:     sm.ID,
+			ServiceMember:       sm,
+		},
+	})
+
+	// And: the context contains the auth values
+	path := "/queues/new"
+	req := httptest.NewRequest("GET", path, nil)
+	req = suite.AuthenticateOfficeRequest(req, officeUser)
+	params := queueop.ShowQueueParams{
+		HTTPRequest: req,
+		QueueType:   "new",
+	}
+
+	// And: show Queue is queried
+	showHandler := ShowQueueHandler{handlers.NewHandlerContext(suite.DB(), suite.TestLogger())}
+	showResponse := showHandler.Handle(params)
+
+	// Then: Expect a 200 status code
+	okResponse := showResponse.(*queueop.ShowQueueOK)
+	moveQueueItem := okResponse.Payload[0]
+
+	// And: expect the moveQueueItem's move date to be the actual pickup date
+	expectedMoveDate := fmt.Sprintf("%v", handlers.FmtDate(*shipment.ActualPickupDate))
+	actualMoveDate := fmt.Sprintf("%v", *moveQueueItem.MoveDate)
+	suite.Equal(expectedMoveDate, actualMoveDate)
+}

--- a/pkg/models/queue.go
+++ b/pkg/models/queue.go
@@ -41,7 +41,13 @@ func GetMoveQueueItems(db *pop.Connection, lifecycleState string) ([]MoveQueueIt
 				CONCAT(COALESCE(sm.last_name, '*missing*'), ', ', COALESCE(sm.first_name, '*missing*')) AS customer_name,
 				moves.locator as locator,
 				ord.orders_type as orders_type,
-				ppm.original_move_date as move_date,
+				COALESCE(
+					shipment.actual_pickup_date,
+					shipment.pm_survey_planned_pickup_date,
+					shipment.requested_pickup_date,
+					ppm.actual_move_date,
+					ppm.original_move_date
+				) as move_date,
 				moves.created_at as created_at,
 				moves.updated_at as last_modified_date,
 				moves.status as status,
@@ -168,7 +174,13 @@ func GetMoveQueueItems(db *pop.Connection, lifecycleState string) ([]MoveQueueIt
 				CONCAT(COALESCE(sm.last_name, '*missing*'), ', ', COALESCE(sm.first_name, '*missing*')) AS customer_name,
 				moves.locator as locator,
 				ord.orders_type as orders_type,
-				ppm.original_move_date as move_date,
+				COALESCE(
+					shipment.actual_pickup_date,
+					shipment.pm_survey_planned_pickup_date,
+					shipment.requested_pickup_date,
+					ppm.actual_move_date,
+					ppm.original_move_date
+				) as move_date,
 				moves.created_at as created_at,
 				moves.updated_at as last_modified_date,
 				moves.status as status,


### PR DESCRIPTION
## Description

We're not handling move dates very well in the office queue. Right now, it's only looking at the ppm move date, but it should be smart enough to handle HHGs as well.

## Setup

1. `make server_run`
2. `make client_run`
3. Visit the office `new` and `all` queues, and note that the HHG date is used for HHGs as well as combo moves. See the pivotal ticket for specific acceptance criteria.

## Code Review Verification Steps

* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/165323225) for this change