### PR TITLE
corrected api calls for error handlers in moves ducks.

### DIFF
--- a/src/scenes/Moves/ducks.js
+++ b/src/scenes/Moves/ducks.js
@@ -27,7 +27,7 @@ export function updateMove(moveId, moveType) {
     dispatch(action.start());
     return UpdateMove(moveId, { selected_move_type: moveType })
       .then(item => dispatch(action.success(item)))
-      .catch(error => dispatch(action.failure(error)));
+      .catch(error => dispatch(action.error(error)));
   };
 }
 
@@ -37,7 +37,7 @@ export function loadMove(moveId) {
     dispatch(action.start());
     return GetMove(moveId)
       .then(item => dispatch(action.success(item)))
-      .catch(error => dispatch(action.success(error)));
+      .catch(error => dispatch(action.error(error)));
   };
 }
 


### PR DESCRIPTION
## Description

The error handlers for the moves ducks were calling incorrect apis. I realize this will be replaced soon, but it was an easy fix and one of them caused serious unrecoverable errors if there was a server error updating the move.


## Code Review Verification Steps
n/a

