### PR TITLE
Upgrade React-Select to Latest Version [delivers #165750917]

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -317,7 +317,7 @@ function genericSelect(inputData, fieldName, classSelector) {
   // Click on the first presented option
   cy
     .get(classSelector)
-    .find('div[id="react-select-2-option-0"]')
+    .find('mark')
     .first()
     .click();
 }

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -317,8 +317,7 @@ function genericSelect(inputData, fieldName, classSelector) {
   // Click on the first presented option
   cy
     .get(classSelector)
-    .find('mark')
-    .first()
+    .find('div[class*="option"]')
     .click();
 }
 

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -317,7 +317,7 @@ function genericSelect(inputData, fieldName, classSelector) {
   // Click on the first presented option
   cy
     .get(classSelector)
-    .find('div[role="option"]')
+    .find('div[id="react-select-2-option-0"]')
     .first()
     .click();
 }

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "react-router-redux": "^5.0.0-alpha.8",
     "react-router-tabs": "^1.1.1",
     "react-scripts": "2.1.3",
-    "react-select": "^2.0.0-beta.1",
+    "react-select": "^2.4.3",
     "react-table": "^6.8.2",
     "react-tabs": "^2.2.2",
     "react-window-size": "^1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8014,10 +8014,10 @@ mem@^4.0.0:
     mimic-fn "^1.0.0"
     p-is-promise "^2.0.0"
 
-memoize-one@^4.0.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-4.1.0.tgz#a2387c58c03fff27ca390c31b764a79addf3f906"
-  integrity sha512-2GApq0yI/b22J2j9rhbrAlsHb0Qcz+7yWxeLG8h+95sl1XPUgeLimQSOdur4Vw7cUhrBHwaUZxWFZueojqNRzA==
+memoize-one@^5.0.0:
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-5.0.4.tgz#005928aced5c43d890a4dfab18ca908b0ec92cbc"
+  integrity sha512-P0z5IeAH6qHHGkJIXWw0xC2HNEgkx/9uWWBQw64FJj3/ol14VYdfVGWWr0fXfjhhv3TKVIqUq65os6O4GUNksA==
 
 memory-fs@^0.4.0, memory-fs@~0.4.1:
   version "0.4.1"
@@ -10679,14 +10679,14 @@ react-scripts@2.1.3:
   optionalDependencies:
     fsevents "1.2.4"
 
-react-select@^2.0.0-beta.1:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/react-select/-/react-select-2.3.0.tgz#990429622445eb2b4a6e985b8069fe7d498cae91"
-  integrity sha512-CD3jyZs5lwy/CHW3SdYU1d1FtmJxgvVPdKMwEE8dD6MyNANFtvW95P/V20StPsPppFY7oePv/i2Mun2C2+WgTA==
+react-select@^2.4.3:
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/react-select/-/react-select-2.4.3.tgz#62efdf76d7e33e9bde22d907a0cc8abd0aeab656"
+  integrity sha512-cmxNaiHpviRYkojeW9rGEUJ4jpX7QTmPe2wcscwA4d1lStzw/cJtr4ft5H2O/YhfpkrcwaLghu3XmEYdXhBo8Q==
   dependencies:
     classnames "^2.2.5"
     emotion "^9.1.2"
-    memoize-one "^4.0.0"
+    memoize-one "^5.0.0"
     prop-types "^15.6.0"
     raf "^3.4.0"
     react-input-autosize "^2.2.1"


### PR DESCRIPTION
## Description

Upgrades to the latest react-select 2.4.3.

## Code Review Verification Steps

* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/165750917) for this change