### PR TITLE
sql error handling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -46,8 +46,8 @@ require (
 	github.com/jackc/pgx v3.4.0+incompatible // indirect
 	github.com/jessevdk/go-flags v1.4.0
 	github.com/jmoiron/sqlx v1.2.0
-	github.com/jung-kurt/gofpdf v1.1.1
-	github.com/karrick/godirwalk v1.8.2 // indirect
+	github.com/jung-kurt/gofpdf v1.3.3
+	github.com/karrick/godirwalk v1.9.1 // indirect
 	github.com/lib/pq v1.0.0
 	github.com/markbates/going v1.0.3 // indirect
 	github.com/markbates/goth v1.50.0

--- a/go.mod
+++ b/go.mod
@@ -46,8 +46,9 @@ require (
 	github.com/jackc/pgx v3.4.0+incompatible // indirect
 	github.com/jessevdk/go-flags v1.4.0
 	github.com/jmoiron/sqlx v1.2.0
-	github.com/jung-kurt/gofpdf v1.3.3
-	github.com/karrick/godirwalk v1.9.1 // indirect
+	github.com/jung-kurt/gofpdf v1.1.1
+	github.com/karrick/godirwalk v1.8.2 // indirect
+	github.com/lib/pq v1.0.0
 	github.com/markbates/going v1.0.3 // indirect
 	github.com/markbates/goth v1.50.0
 	github.com/mattn/go-shellwords v1.0.5 // indirect

--- a/pkg/handlers/errors.go
+++ b/pkg/handlers/errors.go
@@ -3,7 +3,10 @@ package handlers
 import (
 	"encoding/json"
 	"net/http"
+	"os"
 	"strings"
+
+	"github.com/transcom/mymove/pkg/cli"
 
 	"github.com/lib/pq"
 
@@ -60,6 +63,10 @@ func ResponseForError(logger Logger, err error) middleware.Responder {
 	// AddCallerSkip(1) prevents log statements from listing this file and func as the caller
 	skipLogger := logger.WithOptions(zap.AddCallerSkip(1))
 
+	// get development flag value for more verbose data
+	dbEnv := os.Getenv(cli.DbEnvFlag)
+	isDev := dbEnv == "development" || dbEnv == "test"
+
 	cause := errors.Cause(err)
 	switch e := cause.(type) {
 	case route.Error:
@@ -75,10 +82,9 @@ func ResponseForError(logger Logger, err error) middleware.Responder {
 		}
 	case *pq.Error:
 		skipLogger.Info("SQL error encountered", zap.Error(e))
-		// if in development environment then return sql err for easy debugging
-		//if isDev {
-		//	return  newErrResponse(http.StatusInternalServerError, err)
-		//}
+		if isDev {
+			return newErrResponse(http.StatusInternalServerError, err)
+		}
 		return newErrResponse(http.StatusInternalServerError, errors.New("unexpected error from db"))
 	default:
 		return responseForBaseError(skipLogger, err)

--- a/pkg/handlers/errors.go
+++ b/pkg/handlers/errors.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/lib/pq"
+
 	"github.com/transcom/mymove/pkg/route"
 
 	"github.com/go-openapi/runtime"
@@ -71,6 +73,13 @@ func ResponseForError(logger Logger, err error) middleware.Responder {
 		default:
 			return newErrResponse(http.StatusInternalServerError, err)
 		}
+	case *pq.Error:
+		skipLogger.Info("SQL error encountered", zap.Error(e))
+		// if in development environment then return sql err for easy debugging
+		//if isDev {
+		//	return  newErrResponse(http.StatusInternalServerError, err)
+		//}
+		return newErrResponse(http.StatusInternalServerError, errors.New("unexpected error from db"))
 	default:
 		return responseForBaseError(skipLogger, err)
 	}

--- a/pkg/handlers/errors.go
+++ b/pkg/handlers/errors.go
@@ -3,10 +3,7 @@ package handlers
 import (
 	"encoding/json"
 	"net/http"
-	"os"
 	"strings"
-
-	"github.com/transcom/mymove/pkg/cli"
 
 	"github.com/lib/pq"
 
@@ -63,10 +60,6 @@ func ResponseForError(logger Logger, err error) middleware.Responder {
 	// AddCallerSkip(1) prevents log statements from listing this file and func as the caller
 	skipLogger := logger.WithOptions(zap.AddCallerSkip(1))
 
-	// get development flag value for more verbose data
-	dbEnv := os.Getenv(cli.DbEnvFlag)
-	isDev := dbEnv == "development"
-
 	cause := errors.Cause(err)
 	switch e := cause.(type) {
 	case route.Error:
@@ -82,10 +75,6 @@ func ResponseForError(logger Logger, err error) middleware.Responder {
 		}
 	case *pq.Error:
 		skipLogger.Info("SQL error encountered", zap.Error(e))
-		//if dev environment then return sql error
-		if isDev {
-			return newErrResponse(http.StatusInternalServerError, err)
-		}
 		return newErrResponse(http.StatusInternalServerError, errors.New("unexpected error from db"))
 	default:
 		return responseForBaseError(skipLogger, err)

--- a/pkg/handlers/errors.go
+++ b/pkg/handlers/errors.go
@@ -65,7 +65,7 @@ func ResponseForError(logger Logger, err error) middleware.Responder {
 
 	// get development flag value for more verbose data
 	dbEnv := os.Getenv(cli.DbEnvFlag)
-	isDev := dbEnv == "development" || dbEnv == "test"
+	isDev := dbEnv == "development"
 
 	cause := errors.Cause(err)
 	switch e := cause.(type) {
@@ -82,6 +82,7 @@ func ResponseForError(logger Logger, err error) middleware.Responder {
 		}
 	case *pq.Error:
 		skipLogger.Info("SQL error encountered", zap.Error(e))
+		//if dev environment then return sql error
 		if isDev {
 			return newErrResponse(http.StatusInternalServerError, err)
 		}

--- a/pkg/handlers/errors.go
+++ b/pkg/handlers/errors.go
@@ -19,6 +19,9 @@ import (
 	uploaderpkg "github.com/transcom/mymove/pkg/uploader"
 )
 
+// SQLErrMessage represents string value to represent generic sql error to avoid leaking implementation details
+const SQLErrMessage string = "Unhandled SQL error encountered"
+
 // ValidationErrorsResponse is a middleware.Responder for a set of validation errors
 type ValidationErrorsResponse struct {
 	Errors map[string]string `json:"errors,omitempty"`
@@ -74,8 +77,8 @@ func ResponseForError(logger Logger, err error) middleware.Responder {
 			return newErrResponse(http.StatusInternalServerError, err)
 		}
 	case *pq.Error:
-		skipLogger.Info("SQL error encountered", zap.Error(e))
-		return newErrResponse(http.StatusInternalServerError, errors.New("unexpected error from db"))
+		skipLogger.Info(SQLErrMessage, zap.Error(e))
+		return newErrResponse(http.StatusInternalServerError, errors.New(SQLErrMessage))
 	default:
 		return responseForBaseError(skipLogger, err)
 	}

--- a/pkg/handlers/errors_test.go
+++ b/pkg/handlers/errors_test.go
@@ -1,17 +1,16 @@
 package handlers
 
 import (
-	"log"
 	"testing"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
 
 	"github.com/go-openapi/runtime/middleware"
 
-	"github.com/stretchr/testify/suite"
-	"go.uber.org/zap"
-
 	"github.com/gofrs/uuid"
+	"github.com/stretchr/testify/suite"
 
-	"github.com/transcom/mymove/pkg/logging/hnyzap"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testingsuite"
 )
@@ -23,7 +22,7 @@ type fakeModel struct {
 
 type ErrorsSuite struct {
 	testingsuite.PopTestSuite
-	logger *hnyzap.Logger
+	logger Logger
 }
 
 func (suite *ErrorsSuite) SetupTest() {
@@ -31,14 +30,12 @@ func (suite *ErrorsSuite) SetupTest() {
 }
 
 func TestErrorsSuite(t *testing.T) {
-	logger, err := zap.NewDevelopment()
-	if err != nil {
-		log.Panic(err)
-	}
+	logger := zaptest.NewLogger(t)
+	zap.ReplaceGlobals(logger)
 
 	hs := &ErrorsSuite{
 		PopTestSuite: testingsuite.NewPopTestSuite(),
-		logger:       &hnyzap.Logger{Logger: logger},
+		logger:       logger,
 	}
 	suite.Run(t, hs)
 }

--- a/pkg/handlers/errors_test.go
+++ b/pkg/handlers/errors_test.go
@@ -6,13 +6,20 @@ import (
 
 	"github.com/go-openapi/runtime/middleware"
 
-	"github.com/lib/pq"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/zap"
 
+	"github.com/gofrs/uuid"
+
 	"github.com/transcom/mymove/pkg/logging/hnyzap"
+	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testingsuite"
 )
+
+type fakeModel struct {
+	ID   uuid.UUID
+	Name string
+}
 
 type ErrorsSuite struct {
 	testingsuite.PopTestSuite
@@ -37,27 +44,28 @@ func TestErrorsSuite(t *testing.T) {
 }
 
 func (suite *ErrorsSuite) TestResponseForErrorWhenASQLErrorIsEncountered() {
-	err := &pq.Error{}
 	var actual middleware.Responder
-	errTypes := []string{
-		"connection_exception",
-		"invalid_escape_character",
-		"integrity_constraint_violation",
-		"invalid_schema_name",
-		"foreign_key_violation",
-		"undefined_table",
-		"disk_full",
-		"too_many_columns",
-		"index_corrupted",
-		"invalid_transaction_state",
-	}
+	var signedCertification []*models.SignedCertification
+	var noTableModel []*fakeModel
 
-	for _, errT := range errTypes {
-		err.Message = errT
+	// invalid column
+	errInvalidColumn := suite.DB().Where("move_iid = $1", "123").All(&signedCertification)
+
+	// invalid arguments
+	errInvalidArguments := suite.DB().Where("id in (?) and foo = ?", 1, 2, 3, "bar").All(&signedCertification)
+
+	// invalid table
+	errNoTable := suite.DB().Where("1=1").First(noTableModel)
+
+	//slice to hold all errors and assert against
+	errs := []error{errInvalidColumn, errNoTable, errInvalidArguments}
+
+	for _, err := range errs {
 		actual = ResponseForError(suite.logger, err)
 		res, ok := actual.(*ErrResponse)
 		suite.True(ok)
 		suite.Equal(res.Code, 500)
 		suite.Equal(res.Err.Error(), SQLErrMessage)
 	}
+
 }

--- a/pkg/handlers/errors_test.go
+++ b/pkg/handlers/errors_test.go
@@ -1,0 +1,51 @@
+package handlers
+
+import (
+	"log"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/lib/pq"
+	"github.com/stretchr/testify/suite"
+	"go.uber.org/zap"
+
+	"github.com/transcom/mymove/pkg/cli"
+	"github.com/transcom/mymove/pkg/logging/hnyzap"
+	"github.com/transcom/mymove/pkg/testingsuite"
+)
+
+type ErrorsSuite struct {
+	testingsuite.PopTestSuite
+	logger *hnyzap.Logger
+}
+
+func (suite *ErrorsSuite) SetupTest() {
+	suite.DB().TruncateAll()
+}
+
+func TestErrorsSuite(t *testing.T) {
+	logger, err := zap.NewDevelopment()
+	if err != nil {
+		log.Panic(err)
+	}
+
+	hs := &ErrorsSuite{
+		PopTestSuite: testingsuite.NewPopTestSuite(),
+		logger:       &hnyzap.Logger{Logger: logger},
+	}
+	suite.Run(t, hs)
+}
+
+func (suite *ErrorsSuite) TestResponseForErrorWhenASQLErrorIsEncounteredInDevEnv() {
+	// get development flag value for more verbose data
+	os.Setenv(cli.DbEnvFlag, "development")
+	err := &pq.Error{}
+
+	sut := ResponseForError(suite.logger, err)
+	expectedResponse := &ErrResponse{
+		Code: http.StatusInternalServerError,
+		Err:  err,
+	}
+	suite.Equal(expectedResponse, sut)
+}

--- a/pkg/handlers/errors_test.go
+++ b/pkg/handlers/errors_test.go
@@ -3,14 +3,12 @@ package handlers
 import (
 	"log"
 	"net/http"
-	"os"
 	"testing"
 
 	"github.com/lib/pq"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/zap"
 
-	"github.com/transcom/mymove/pkg/cli"
 	"github.com/transcom/mymove/pkg/logging/hnyzap"
 	"github.com/transcom/mymove/pkg/testingsuite"
 )
@@ -38,14 +36,12 @@ func TestErrorsSuite(t *testing.T) {
 }
 
 func (suite *ErrorsSuite) TestResponseForErrorWhenASQLErrorIsEncounteredInDevEnv() {
-	// get development flag value for more verbose data
-	os.Setenv(cli.DbEnvFlag, "development")
 	err := &pq.Error{}
+	actual := ResponseForError(suite.logger, err)
 
-	sut := ResponseForError(suite.logger, err)
 	expectedResponse := &ErrResponse{
 		Code: http.StatusInternalServerError,
 		Err:  err,
 	}
-	suite.Equal(expectedResponse, sut)
+	suite.Equal(expectedResponse, actual)
 }


### PR DESCRIPTION
## Description

This PR filters out sql error messages so we do not leak implementation details to front end in test or production environments.

## Setup
Simulate a sql error:
1. Make sure server and tsp client are running:
2. Cause a sql error, for example you can change the following [line](https://github.com/transcom/mymove/blob/c5d75f4fa0c42a0ba3fdaa2c130c523d50f4b543/pkg/models/signed_certification.go#L108) and then try [invoking](http://tsplocal:3000/internal/moves/0db80bd6-de75-439e-bf89-deaafa1d0dc8/signed_certifications) 
3. If your `.enrc.local` contains `export env="development"` you should be able to see the sql error otherwise you should get a 500 error and a generic `unexpected error from db`

## Code Review Verification Steps
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/164936998) for this change