### PR TITLE
Save HHG submit date/time (with timezone) in DB

### DIFF
--- a/docs/how-to/migrate-the-database.md
+++ b/docs/how-to/migrate-the-database.md
@@ -16,7 +16,7 @@ If you are generating a new model, use: `./scripts/gen-model model-name column-n
 
 ### Modifying an Existing Model
 
-If you are modifying an existing model, use `./bin/soda generate migration migration-name` and add the [Fizz commands](https://github.com/gobuffalo/fizz) yourself to the created `{migration_name}.up.fizz` file. Delete the `down.fizz` file, as we aren't using those (see note below.)
+If you are modifying an existing model, use `./bin/soda generate migration migration_name` and add the [Fizz commands](https://github.com/gobuffalo/fizz) yourself to the created `{migration_name}.up.fizz` file. Delete the `down.fizz` file, as we aren't using those (see note below.)
 
 ## Zero-Downtime Migrations
 

--- a/migrations/20190503223719_add_submit_date_to_hhg.up.fizz
+++ b/migrations/20190503223719_add_submit_date_to_hhg.up.fizz
@@ -1,0 +1,1 @@
+add_column("shipments", "submit_date", "timestamptz", {"null": true})

--- a/pkg/models/move.go
+++ b/pkg/models/move.go
@@ -122,7 +122,7 @@ func (m *Move) Submit(ppmSubmitDate time.Time) error {
 
 	// Update HHG (Shipment) status too
 	for i := range m.Shipments {
-		err := m.Shipments[i].Submit()
+		err := m.Shipments[i].Submit(ppmSubmitDate)
 		if err != nil {
 			return err
 		}

--- a/pkg/models/move.go
+++ b/pkg/models/move.go
@@ -104,7 +104,7 @@ func (m *Move) ValidateUpdate(tx *pop.Connection) (*validate.Errors, error) {
 // Avoid calling Move.Status = ... ever. Use these methods to change the state.
 
 // Submit submits the Move
-func (m *Move) Submit(ppmSubmitDate time.Time) error {
+func (m *Move) Submit(submitDate time.Time) error {
 	if m.Status != MoveStatusDRAFT {
 		return errors.Wrap(ErrInvalidTransition, "Submit")
 	}
@@ -114,7 +114,7 @@ func (m *Move) Submit(ppmSubmitDate time.Time) error {
 	// Update PPM status too
 	for i := range m.PersonallyProcuredMoves {
 		ppm := &m.PersonallyProcuredMoves[i]
-		err := ppm.Submit(ppmSubmitDate)
+		err := ppm.Submit(submitDate)
 		if err != nil {
 			return err
 		}
@@ -122,7 +122,7 @@ func (m *Move) Submit(ppmSubmitDate time.Time) error {
 
 	// Update HHG (Shipment) status too
 	for i := range m.Shipments {
-		err := m.Shipments[i].Submit(ppmSubmitDate)
+		err := m.Shipments[i].Submit(submitDate)
 		if err != nil {
 			return err
 		}

--- a/pkg/models/shipment.go
+++ b/pkg/models/shipment.go
@@ -95,6 +95,7 @@ type Shipment struct {
 	RequestedPickupDate  *time.Time `json:"requested_pickup_date" db:"requested_pickup_date"`   // when shipment was originally scheduled to be picked up
 	OriginalDeliveryDate *time.Time `json:"original_delivery_date" db:"original_delivery_date"` // when shipment is to be delivered
 	OriginalPackDate     *time.Time `json:"original_pack_date" db:"original_pack_date"`         // when packing is to begin
+	SubmitDate           *time.Time `json:"submit_date" db:"submit_date"`                       // when shipment was submitted by SM
 
 	// calculated durations
 	EstimatedPackDays    *int64 `json:"estimated_pack_days" db:"estimated_pack_days"`       // how many days it will take to pack
@@ -254,12 +255,13 @@ func (s *Shipment) CurrentTransportationServiceProviderID() uuid.UUID {
 // Avoid calling Shipment.Status = ... ever. Use these methods to change the state.
 
 // Submit marks the Shipment request for review
-func (s *Shipment) Submit() error {
+func (s *Shipment) Submit(hhgSubmitDate time.Time) error {
 	if s.Status != ShipmentStatusDRAFT {
 		return errors.Wrap(ErrInvalidTransition, "Submit")
 	}
 	now := time.Now()
 	s.BookDate = &now
+	s.SubmitDate = &hhgSubmitDate
 	s.Status = ShipmentStatusSUBMITTED
 	return nil
 }

--- a/pkg/models/shipment_test.go
+++ b/pkg/models/shipment_test.go
@@ -128,7 +128,7 @@ func (suite *ModelSuite) TestShipmentStateMachine() {
 	suite.Equal(ShipmentStatusDRAFT, shipment.Status, "expected Draft")
 
 	// Can submit shipment
-	err := shipment.Submit()
+	err := shipment.Submit(time.Now())
 	suite.Nil(err)
 	suite.Equal(ShipmentStatusSUBMITTED, shipment.Status, "expected Submitted")
 
@@ -182,7 +182,7 @@ func (suite *ModelSuite) TestSetBookDateWhenSubmitted() {
 	suite.Nil(shipment.BookDate)
 
 	// Can submit shipment
-	err := shipment.Submit()
+	err := shipment.Submit(time.Now())
 	suite.Nil(err)
 	suite.NotNil(shipment.BookDate)
 }
@@ -858,7 +858,7 @@ func (suite *ModelSuite) TestAcceptedShipmentOffer() {
 	suite.Len(shipment.ShipmentOffers, 1)
 
 	// Can submit shipment
-	err = shipment.Submit()
+	err = shipment.Submit(time.Now())
 	suite.Nil(err)
 	suite.Equal(ShipmentStatusSUBMITTED, shipment.Status, "expected Submitted")
 

--- a/src/scenes/Legalese/ducks.js
+++ b/src/scenes/Legalese/ducks.js
@@ -34,7 +34,7 @@ export function dateToTimestamp(dt) {
   return moment(dt).format();
 }
 
-export const signAndSubmitForApproval = (moveId, certificationText, signature, dateSigned, _ppmId, ppmSubmitDate) => {
+export const signAndSubmitForApproval = (moveId, certificationText, signature, dateSigned, _ppmId, submitDate) => {
   return async function(dispatch, getState) {
     const dateTimeSigned = dateToTimestamp(dateSigned);
     dispatch(signAndSubmitForApprovalActions.start());
@@ -52,7 +52,7 @@ export const signAndSubmitForApproval = (moveId, certificationText, signature, d
 
       const response = await dispatch(
         SubmitForApproval(moveId, {
-          ppm_submit_date: ppmSubmitDate,
+          ppm_submit_date: submitDate,
         }),
       );
 

--- a/src/scenes/Legalese/index.jsx
+++ b/src/scenes/Legalese/index.jsx
@@ -38,7 +38,7 @@ export class SignedCertification extends Component {
   handleSubmit = () => {
     const pendingValues = this.props.values;
     const { latestSignedCertification, ppmId } = this.props;
-    const SubmitDate = moment().format();
+    const submitDate = moment().format();
     if (latestSignedCertification) {
       return this.props.push('/');
     }
@@ -54,7 +54,7 @@ export class SignedCertification extends Component {
           pendingValues.signature,
           pendingValues.date,
           ppmId,
-          SubmitDate,
+          submitDate,
         )
         .then(() => this.props.push('/'))
         .catch(() => this.setState({ hasMoveSubmitError: true }));

--- a/src/scenes/Legalese/index.jsx
+++ b/src/scenes/Legalese/index.jsx
@@ -38,7 +38,7 @@ export class SignedCertification extends Component {
   handleSubmit = () => {
     const pendingValues = this.props.values;
     const { latestSignedCertification, ppmId } = this.props;
-    const ppmSubmitDate = moment().format();
+    const SubmitDate = moment().format();
     if (latestSignedCertification) {
       return this.props.push('/');
     }
@@ -54,7 +54,7 @@ export class SignedCertification extends Component {
           pendingValues.signature,
           pendingValues.date,
           ppmId,
-          ppmSubmitDate,
+          SubmitDate,
         )
         .then(() => this.props.push('/'))
         .catch(() => this.setState({ hasMoveSubmitError: true }));


### PR DESCRIPTION
## Description

The system records the time (local to the SM) that an HHG shipment is submitted. 

## Reviewer Notes

There is an existing field in the shipments table called book date. It's currently stored in the DB as a date. It behaves the same as the new submit date (i.e. it is set when the SM signs the legalese and is never edited). I'm not sure what the book date is used for, but I wonder if these could be consolidated into a single field. Does TimestampTZ encapsulate all the info that date does?

## Setup

Create an HHG Move (USE sm_hhg@example.com LOCAL SIGN-IN TO SAVE TIME) 
Sign the move (this "submits" the shipment)
See the shipment time reflected in the shipments table in the DB

## Code Review Verification Steps

* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/tree/master/docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
  * [ ] Secure migrations have been tested using `scripts/run-prod-migrations`
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/165752534) for this change