### PR TITLE
Remove only from officeUserHHGPPM test

### DIFF
--- a/cypress/integration/office/officeUserHHGPPM.js
+++ b/cypress/integration/office/officeUserHHGPPM.js
@@ -33,7 +33,7 @@ describe('office user finds the shipment', function() {
     officeUserVisitsHHGTab();
     officeUserApprovesShipment();
   });
-  it.only('office user uploads document', function() {
+  it('office user uploads document', function() {
     officeUserSubmitsDocument();
   });
 });


### PR DESCRIPTION
## Description

Remove `it.only` (introduced in #2022) from officeUserHHGPPM test. 
