### PR TITLE
Modify condensed to not precede single digit dates with 0

### DIFF
--- a/src/shared/formatters.js
+++ b/src/shared/formatters.js
@@ -142,7 +142,7 @@ const formatDateForDateRange = (date, formatType) => {
       format = 'ddd, MMM DD';
       break;
     case 'condensed':
-      format = 'MMM DD';
+      format = 'MMM D';
       break;
     default:
       format = 'ddd, MMM DD';


### PR DESCRIPTION
## Description

In the timelines, when the day of the month is a single digit for a status' date, allow it to remain displayed as a single digit. Do not let it precede with a 0.

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make server_run
make client_run
```

## Code Review Verification Steps

* [x] User facing changes have been reviewed by design.
* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/165860726) for this change

## Screenshots
<img width="1680" alt="Screen Shot 2019-05-07 at 11 20 59 AM" src="https://user-images.githubusercontent.com/6464062/57316030-817a1380-70ba-11e9-8a37-3175c5267703.png">

