### PR TITLE
Add linter rule for it.only tests

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,8 @@
 {
-  "plugins": ["security"],
+  "plugins": ["security", "no-only-tests"],
   "extends": ["react-app", "plugin:security/recommended"],
   "rules": {
+    "no-only-tests/no-only-tests": "error",
     "no-debugger": "warn",
     "jsx-a11y/anchor-is-valid": "off",
     "react/jsx-no-target-blank": "off",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "classnames": "^2.2.5",
     "enzyme": "^3.2.0",
     "enzyme-adapter-react-16": "^1.1.1",
+    "eslint-plugin-no-only-tests": "^2.3.0",
     "eslint-plugin-security": "^1.4.0",
     "filepond-plugin-file-validate-type": "^1.0.3",
     "filepond-plugin-image-exif-orientation": "^1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4443,6 +4443,11 @@ eslint-plugin-jsx-a11y@6.1.2:
     has "^1.0.3"
     jsx-ast-utils "^2.0.1"
 
+eslint-plugin-no-only-tests@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-2.3.0.tgz#1b0007c3b2600c74ad5f144d24bfef620e824c9d"
+  integrity sha512-5YZvazTJLWrGU8WUq3xp0Eot02zK/yUT9GoVjrFdXP8flVqH6YBdC6PsAKBRIpcs48WvSfSYrmdwAj3a4d/Iyg==
+
 eslint-plugin-react@7.11.1:
   version "7.11.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.11.1.tgz#c01a7af6f17519457d6116aa94fc6d2ccad5443c"


### PR DESCRIPTION
## Description

Cypress allows limiting the scope of the [test suite for tests](https://docs.cypress.io/guides/core-concepts/writing-and-organizing-tests.html#Excluding-and-Including-Tests) by adding `.only` to the function. This is good for development, but we don't want these tests to be committed.

## Reviewer Notes

1) Update an `it` or `describe` block to use `it.only` or `describe.only`. 
2) Try running the pre-commit script. You should see and error `error  it.only not permitted  no-only-tests/no-only-tests`. 
3) Try committed the file. The pre-commit check should reject the commit with the same error.

## Setup

```sh
yarn install
pre-commit run --all-files eslint
```

## Code Review Verification Steps
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?