### PR TITLE
Fix broken test: should find div with data-cy

### DIFF
--- a/cypress/integration/office/storageInTransitPanel.js
+++ b/cypress/integration/office/storageInTransitPanel.js
@@ -165,10 +165,7 @@ function officeUserApprovesSITRequest() {
     expect(loc.pathname).to.match(/^\/queues\/new\/moves\/[^/]+\/basics/);
   });
 
-  cy
-    .get('a')
-    .contains('HHG')
-    .click(); // navtab
+  cy.get('[data-cy="hhg-tab"]').click();
 
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/queues\/new\/moves\/[^/]+\/hhg/);


### PR DESCRIPTION
## Description

My changes in another PR required the HHG tab in a move to be located in cypress using data-cy. Some tests were changed in that PR. A new test was created during this time and merged to master, which was not edited by my PR, hence master broke. 

## Code Review Verification Steps

* [ ] Request review from a member of a different team.

