### PR TITLE
Enable Clearable Input and Set Min Search Length to 1 for DutyStationSearchBox [delivers #165750917]

### DIFF
--- a/src/scenes/ServiceMembers/DutyStationSearchBox.jsx
+++ b/src/scenes/ServiceMembers/DutyStationSearchBox.jsx
@@ -103,6 +103,7 @@ export class DutyStationSearchBox extends Component {
           )}
           <p>{this.props.title || defaultTitle}</p>
           <AsyncSelect
+            isClearable
             className={`duty-input-box ${this.props.input.name}`}
             cacheOptions
             getOptionLabel={getOptionName}

--- a/src/scenes/ServiceMembers/DutyStationSearchBox.jsx
+++ b/src/scenes/ServiceMembers/DutyStationSearchBox.jsx
@@ -11,7 +11,7 @@ import { SearchDutyStations } from './api.js';
 import './DutyStation.css';
 
 const inputDebounceTime = 200;
-const minSearchLength = 2;
+const minSearchLength = 1;
 const getOptionName = option => (option ? option.name : '');
 
 export class DutyStationSearchBox extends Component {


### PR DESCRIPTION
## Description

React-Select v2 has new features we want to take advantage of in this PR.

This PR enables the isClearable attribute that lets the react select input clear inputs with the `x` icon shown. The minimum search length is also set to `1` since usability was affected with search minimum length as `2`.

## Setup

1. Login to Office app, local
2. Open a move/shipment
3. Navigate to the basics tab
4. Edit `Orders` panel
5. Click `x` button in the Current duty station search box

## Code Review Verification Steps

* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/165750917) for this change
* [React select](https://react-select.com/home) explains more about the approach used.

## Screenshots

Duty station search box with `x` clearable button
![image](https://user-images.githubusercontent.com/1522549/57330800-eb4ee900-70cb-11e9-86e6-208cdbf126e9.png)

