### PR TITLE
Cg 165869915 fix dependency updater

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -690,9 +690,9 @@ jobs:
           compare_host: gex.move.mil
           health_check_hosts: gex.move.mil,dps.move.mil,orders.move.mil
 
-  # `update_dependencies` periodically updates pre-commit, yarn, and Go dependencies.
+  # `update_dependencies_go` periodically updates Go dependencies.
   # The changes are submitted as a pull request for review.
-  update_dependencies:
+  update_dependencies_go:
     executor: mymove_small
     steps:
       - checkout
@@ -702,9 +702,45 @@ jobs:
       - run:
           name: Add ~/go/bin to path for golint
           command: echo 'export PATH=${PATH}:~/go/bin' >> $BASH_ENV
-      - run: pre-commit autoupdate
       - run: make go_deps_update
+      - run:
+          name: Display changes
+          command: |
+            git --no-pager status
+            git --no-pager diff --ignore-all-space --color
+      - run:
+          name: Push changes
+          command: scripts/circleci-push-dependency-updates
+
+  # `update_dependencies_js` periodically updates yarn dependencies.
+  # The changes are submitted as a pull request for review.
+  update_dependencies_js:
+    executor: mymove_small
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - v1-cache-yarn-v2-{{ checksum "yarn.lock" }}
+      - restore_cache:
+          keys:
+            - v1-mymove-node-modules-{{ checksum "yarn.lock" }}
       - run: make client_deps_update
+      - run:
+          name: Display changes
+          command: |
+            git --no-pager status
+            git --no-pager diff --ignore-all-space --color
+      - run:
+          name: Push changes
+          command: scripts/circleci-push-dependency-updates
+
+  # `update_dependencies_pre_commit` periodically updates pre-commit dependencies.
+  # The changes are submitted as a pull request for review.
+  update_dependencies_pre_commit:
+    executor: mymove_small
+    steps:
+      - checkout
+      - run: pre-commit autoupdate
       - run:
           name: Display changes
           command: |
@@ -903,7 +939,7 @@ workflows:
             branches:
               only: master
 
-  dependency_updater:
+  dependency_updater_go:
     triggers:
       - schedule:
           # Monday at 4am/7am PST/EST
@@ -912,7 +948,29 @@ workflows:
             branches:
               only: master
     jobs:
-      - update_dependencies
+      - update_dependencies_go
+
+  dependency_updater_js:
+    triggers:
+      - schedule:
+          # Monday at 4am/7am PST/EST
+          cron: '0 12 * * 1'
+          filters:
+            branches:
+              only: master
+    jobs:
+      - update_dependencies_js
+
+  dependency_updater_pre_commit:
+    triggers:
+      - schedule:
+          # Monday at 4am/7am PST/EST
+          cron: '0 12 * * 1'
+          filters:
+            branches:
+              only: master
+    jobs:
+      - update_dependencies_pre_commit
 
 experimental:
   notify:

--- a/Dockerfile.dep_updater
+++ b/Dockerfile.dep_updater
@@ -1,0 +1,14 @@
+FROM trussworks/circleci-docker-primary:8734409e869c644343833aa565ef84a792bf6986
+
+ENV GOPATH=/home/circleci/go
+ENV GOBIN=$GOPATH/bin
+ENV PATH=$GOBIN:$PATH
+
+COPY --chown=circleci:circleci . /home/circleci/milmove
+WORKDIR /home/circleci/milmove
+RUN mkdir -p /home/circleci/.cache/
+RUN chown circleci:circleci /home/circleci/.cache/
+
+RUN make go_deps_update
+RUN make client_deps_update
+RUN git --no-pager status && git --no-pager diff --ignore-all-space --color

--- a/Makefile
+++ b/Makefile
@@ -736,6 +736,23 @@ run_experimental_migrations:
 #
 
 #
+# ----- START DEPENDENCY UPDATE TARGETS -----
+#
+
+.PHONY: dependency_update
+dependency_update: go_deps_update client_deps_update
+	git --no-pager status
+	git --no-pager diff --ignore-all-space --color
+
+.PHONY: dependency_update_test
+dependency_update_test:
+	docker build . -f Dockerfile.dep_updater
+
+#
+# ----- END DEPENDENCY UPDATE TARGETS -----
+#
+
+#
 # ----- START RANDOM TARGETS -----
 #
 

--- a/cmd/update_deps/main.go
+++ b/cmd/update_deps/main.go
@@ -12,6 +12,12 @@ import (
 	"github.com/rogpeppe/go-internal/semver"
 )
 
+const (
+	// Some dependencies take longer than 10 seconds to load, this increases the timeout
+	// to deal with network latency
+	cmdTimeout time.Duration = 30 * time.Second
+)
+
 // Use a custom branch for the following dependencies
 var customBranches = map[string]string{
 	"github.com/trussworks/pdfcpu": "afero",
@@ -39,7 +45,7 @@ func main() {
 	for _, req := range file.Require {
 		fmt.Printf("%s", req.Mod.Path)
 
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), cmdTimeout)
 		args := updateArgs(req)
 
 		out, cmdErr := exec.CommandContext(ctx, "go", args...).CombinedOutput()


### PR DESCRIPTION
## Description

Dependency updater has been broken as seen in https://circleci.com/gh/transcom/mymove/104184. It appears that it was a network issue causing a delay in downloading of more than 10 seconds. This PR does:

- Update timeout to 30 seconds
- Split up dependency updates so one won't block the other
- Adds Makefile targets to make testing this stuff easier

## Setup

To test the dependency updater:

```sh
make dependency_update_test
```

You can also update deps with

```
make dependency_update
```

## Code Review Verification Steps

* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/165869915) for this change