### PR TITLE
[WIP] Image rotation spike

### DIFF
--- a/migrations/20190506153904_add_orientation_column_to_uploads.up.fizz
+++ b/migrations/20190506153904_add_orientation_column_to_uploads.up.fizz
@@ -1,1 +1,1 @@
-add_column("uploads", "orientation", "int", {"null": true})
+add_column("uploads", "orientation", "integer", {"default": 0})

--- a/migrations/20190506153904_add_orientation_column_to_uploads.up.fizz
+++ b/migrations/20190506153904_add_orientation_column_to_uploads.up.fizz
@@ -1,0 +1,1 @@
+add_column("uploads", "orientation", "int", {"null": true})

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "ra-data-simple-rest": "^2.8.6",
     "react": "^16.2.0",
     "react-admin": "^2.9.0",
-    "react-app-polyfill": "^0.2.0",
+    "react-app-polyfill": "^1.0.0",
     "react-day-picker": "^7.1.8",
     "react-dom": "^16.2.0",
     "react-filepond": "^2.0.6",

--- a/pkg/handlers/internalapi/api.go
+++ b/pkg/handlers/internalapi/api.go
@@ -73,6 +73,7 @@ func NewInternalAPIHandler(context handlers.HandlerContext) http.Handler {
 	internalAPI.UploadsCreateUploadHandler = CreateUploadHandler{context}
 	internalAPI.UploadsDeleteUploadHandler = DeleteUploadHandler{context}
 	internalAPI.UploadsDeleteUploadsHandler = DeleteUploadsHandler{context}
+	internalAPI.UploadsUpdateUploadHandler = UpdateUploadHandler{context}
 
 	internalAPI.QueuesShowQueueHandler = ShowQueueHandler{context}
 

--- a/pkg/handlers/internalapi/uploads.go
+++ b/pkg/handlers/internalapi/uploads.go
@@ -153,3 +153,13 @@ func (h DeleteUploadsHandler) Handle(params uploadop.DeleteUploadsParams) middle
 
 	return uploadop.NewDeleteUploadsNoContent()
 }
+
+// UpdateUploadsHandler updates an upload
+type UpdateUploadsHandler struct {
+	handlers.HandlerContext
+}
+
+// Handle method
+func (h UpdateUploadsHandler) Handle(params uploadop.UpdateUploadParams) middleware.Responder {
+	return uploadop.NewUpdateUploadOK()
+}

--- a/pkg/models/upload.go
+++ b/pkg/models/upload.go
@@ -28,6 +28,7 @@ type Upload struct {
 	StorageKey  string     `db:"storage_key"`
 	CreatedAt   time.Time  `db:"created_at"`
 	UpdatedAt   time.Time  `db:"updated_at"`
+	Orientation int64      `db:"orientation"`
 }
 
 // Uploads is not required by pop and may be deleted
@@ -85,6 +86,11 @@ func FetchUpload(ctx context.Context, db *pop.Connection, session *auth.Session,
 		return Upload{}, errors.Wrap(ErrFetchNotFound, "user ID doesn't match uploader ID")
 	}
 	return upload, nil
+}
+
+// SaveUpload saves and validates an upload
+func SaveUpload(db *pop.Connection, upload *Upload) (*validate.Errors, error) {
+	return db.ValidateAndSave(upload)
 }
 
 // DeleteUpload deletes an upload from the database

--- a/src/scenes/Office/OrdersInfo.jsx
+++ b/src/scenes/Office/OrdersInfo.jsx
@@ -10,7 +10,12 @@ import DocumentContent from 'shared/DocumentViewer/DocumentContent';
 import OrdersViewerPanel from './OrdersViewerPanel';
 import { getRequestStatus } from 'shared/Swagger/selectors';
 import { loadMove, selectMove } from 'shared/Entities/modules/moves';
-import { loadOrders, loadOrdersLabel, selectUplodsForOrders } from 'shared/Entities/modules/orders';
+import {
+  loadOrders,
+  loadOrdersLabel,
+  selectUplodsForOrders,
+  changeUploadOrientation,
+} from 'shared/Entities/modules/orders';
 import { loadServiceMember, selectServiceMember } from 'shared/Entities/modules/serviceMembers';
 import { stringifyName } from 'shared/utils/serviceMember';
 
@@ -56,6 +61,9 @@ class OrdersInfo extends Component {
                 url={upload.url}
                 filename={upload.filename}
                 contentType={upload.content_type}
+                uploadId={upload.id}
+                orientation={270}
+                rotate={changeUploadOrientation}
               />
             ))}
           </div>

--- a/src/scenes/Office/OrdersInfo.jsx
+++ b/src/scenes/Office/OrdersInfo.jsx
@@ -33,7 +33,7 @@ class OrdersInfo extends Component {
   }
 
   changeUploadOrientation(uploadId, orientation) {
-    updateUpload(uploadId, { uploadId, orientation });
+    this.props.updateUpload(uploadId, { UpdateUpload: { orientation } });
   }
 
   render() {
@@ -55,17 +55,19 @@ class OrdersInfo extends Component {
       <div>
         <div className="usa-grid">
           <div className="usa-width-two-thirds document-contents">
-            {uploads.map(upload => (
-              <DocumentContent
-                key={upload.url}
-                url={upload.url}
-                filename={upload.filename}
-                contentType={upload.content_type}
-                uploadId={upload.id}
-                orientation={270}
-                rotate={this.changeUploadOrientation}
-              />
-            ))}
+            {uploads.map(upload => {
+              return (
+                <DocumentContent
+                  key={upload.url}
+                  url={upload.url}
+                  filename={upload.filename}
+                  contentType={upload.content_type}
+                  uploadId={upload.id}
+                  orientation={upload.orientation}
+                  rotate={this.changeUploadOrientation.bind(this)}
+                />
+              );
+            })}
           </div>
           <div className="usa-width-one-third orders-page-fields">
             <OrdersViewerPanel title={name} className="document-viewer" moveId={this.props.match.params.moveId} />

--- a/src/scenes/Office/OrdersInfo.jsx
+++ b/src/scenes/Office/OrdersInfo.jsx
@@ -10,12 +10,8 @@ import DocumentContent from 'shared/DocumentViewer/DocumentContent';
 import OrdersViewerPanel from './OrdersViewerPanel';
 import { getRequestStatus } from 'shared/Swagger/selectors';
 import { loadMove, selectMove } from 'shared/Entities/modules/moves';
-import {
-  loadOrders,
-  loadOrdersLabel,
-  selectUplodsForOrders,
-  changeUploadOrientation,
-} from 'shared/Entities/modules/orders';
+import { loadOrders, loadOrdersLabel, selectUplodsForOrders } from 'shared/Entities/modules/orders';
+import { updateUpload } from 'shared/Entities/modules/uploads';
 import { loadServiceMember, selectServiceMember } from 'shared/Entities/modules/serviceMembers';
 import { stringifyName } from 'shared/utils/serviceMember';
 
@@ -34,6 +30,10 @@ class OrdersInfo extends Component {
       this.props.loadServiceMember(serviceMemberId);
       this.props.loadOrders(ordersId);
     }
+  }
+
+  changeUploadOrientation(uploadId, orientation) {
+    updateUpload(uploadId, { uploadId, orientation });
   }
 
   render() {
@@ -63,7 +63,7 @@ class OrdersInfo extends Component {
                 contentType={upload.content_type}
                 uploadId={upload.id}
                 orientation={270}
-                rotate={changeUploadOrientation}
+                rotate={this.changeUploadOrientation}
               />
             ))}
           </div>
@@ -102,6 +102,15 @@ const mapStateToProps = (state, ownProps) => {
   };
 };
 
-const mapDispatchToProps = dispatch => bindActionCreators({ loadMove, loadOrders, loadServiceMember }, dispatch);
+const mapDispatchToProps = dispatch =>
+  bindActionCreators(
+    {
+      loadMove,
+      loadOrders,
+      loadServiceMember,
+      updateUpload,
+    },
+    dispatch,
+  );
 
 export default connect(mapStateToProps, mapDispatchToProps)(OrdersInfo);

--- a/src/shared/DocumentViewer/DocumentContent.jsx
+++ b/src/shared/DocumentViewer/DocumentContent.jsx
@@ -3,27 +3,48 @@ import PropTypes from 'prop-types';
 
 import './index.css';
 
-const DocumentContent = ({ contentType, filename, url }) => (
-  <div className="page">
-    {contentType === 'application/pdf' ? (
-      <div className="pdf-placeholder">
-        {filename && <span className="filename">{filename}</span>}
-        This PDF can be{' '}
-        <a target="_blank" href={url}>
-          viewed here
-        </a>
-        .
+const DocumentContent = ({ url, filename, contentType, uploadId, rotate, orientation }) => {
+  const imgHeight = document.querySelector('.page img').getBoundingClientRect().height;
+
+  return (
+    <div
+      className="page"
+      style={{ minHeight: imgHeight + 50, display: 'flex', flexDirection: 'column', justifyContent: 'space-between' }}
+    >
+      {contentType === 'application/pdf' ? (
+        <div className="pdf-placeholder">
+          {filename && <span className="filename">{filename}</span>}
+          This PDF can be{' '}
+          <a target="_blank" href={url}>
+            viewed here
+          </a>
+          .
+        </div>
+      ) : (
+        <div style={{ marginTop: imgHeight / 5, marginBottom: imgHeight / 5 }}>
+          <img src={url} style={{ transform: `rotate(${orientation}deg)` }} alt="document upload" />
+        </div>
+      )}
+
+      <div>
+        <button onClick={rotate.bind(this, uploadId, 'left')} data-direction="left">
+          rotate left
+        </button>
+        <button onClick={rotate.bind(this, uploadId, 'right')} data-direction="right">
+          rotate right
+        </button>
       </div>
-    ) : (
-      <img src={url} width="100%" height="100%" alt="document upload" />
-    )}
-  </div>
-);
+    </div>
+  );
+};
 
 DocumentContent.propTypes = {
   contentType: PropTypes.string.isRequired,
   filename: PropTypes.string.isRequired,
   url: PropTypes.string.isRequired,
+  uploadId: PropTypes.string.isRequired,
+  orientation: PropTypes.string,
+  rotate: PropTypes.func.isRequired,
 };
 
 export default DocumentContent;

--- a/src/shared/DocumentViewer/DocumentContent.jsx
+++ b/src/shared/DocumentViewer/DocumentContent.jsx
@@ -1,42 +1,66 @@
-import React from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
 import './index.css';
 
-const DocumentContent = ({ url, filename, contentType, uploadId, rotate, orientation }) => {
-  const imgHeight = document.querySelector('.page img').getBoundingClientRect().height;
+export class DocumentContent extends Component {
+  imgEl = React.createRef();
 
-  return (
-    <div
-      className="page"
-      style={{ minHeight: imgHeight + 50, display: 'flex', flexDirection: 'column', justifyContent: 'space-between' }}
-    >
-      {contentType === 'application/pdf' ? (
-        <div className="pdf-placeholder">
-          {filename && <span className="filename">{filename}</span>}
-          This PDF can be{' '}
-          <a target="_blank" href={url}>
-            viewed here
-          </a>
-          .
-        </div>
-      ) : (
-        <div style={{ marginTop: imgHeight / 5, marginBottom: imgHeight / 5 }}>
-          <img src={url} style={{ transform: `rotate(${orientation}deg)` }} alt="document upload" />
-        </div>
-      )}
+  state = {
+    imgHeight: 0,
+  };
 
-      <div>
-        <button onClick={rotate.bind(this, uploadId, 'left')} data-direction="left">
-          rotate left
-        </button>
-        <button onClick={rotate.bind(this, uploadId, 'right')} data-direction="right">
-          rotate right
-        </button>
+  adjustContainerHeight() {
+    const imgHeight = this.imgEl.current.getBoundingClientRect().height;
+    this.setState({
+      imgHeight: imgHeight,
+    });
+  }
+
+  render() {
+    return (
+      <div
+        className="page"
+        style={{
+          minHeight: this.state.imgHeight + 50,
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'space-between',
+        }}
+      >
+        {this.props.contentType === 'application/pdf' ? (
+          <div className="pdf-placeholder">
+            {this.props.filename && <span className="filename">{this.props.filename}</span>}
+            This PDF can be{' '}
+            <a target="_blank" href={this.props.url}>
+              viewed here
+            </a>
+            .
+          </div>
+        ) : (
+          <div style={{ marginTop: this.state.imgHeight / 5, marginBottom: this.state.imgHeight / 5 }}>
+            <img
+              src={this.props.url}
+              ref={this.imgEl}
+              style={{ transform: `rotate(${this.props.orientation}deg)` }}
+              onLoad={this.adjustContainerHeight.bind(this)}
+              alt="document upload"
+            />
+          </div>
+        )}
+
+        <div>
+          <button onClick={this.props.rotate.bind(this, this.props.uploadId, 'left')} data-direction="left">
+            rotate left
+          </button>
+          <button onClick={this.props.rotate.bind(this, this.props.uploadId, 'right')} data-direction="right">
+            rotate right
+          </button>
+        </div>
       </div>
-    </div>
-  );
-};
+    );
+  }
+}
 
 DocumentContent.propTypes = {
   contentType: PropTypes.string.isRequired,

--- a/src/shared/DocumentViewer/DocumentContent.jsx
+++ b/src/shared/DocumentViewer/DocumentContent.jsx
@@ -7,6 +7,7 @@ export class DocumentContent extends Component {
   imgEl = React.createRef();
 
   state = {
+    orientation: this.props.orientation,
     imgHeight: 0,
   };
 
@@ -15,6 +16,18 @@ export class DocumentContent extends Component {
     this.setState({
       imgHeight: imgHeight,
     });
+  }
+
+  handleRotate(direction) {
+    if (direction === 'right') {
+      console.log(this.state.orientation, this.state.orientation - 90);
+      this.setState({ orientation: this.state.orientation - 90 });
+      this.props.rotate(this.props.uploadId, this.state.orientation - 90);
+    } else {
+      console.log(this.state.orientation, this.state.orientation + 90);
+      this.setState({ orientation: this.state.orientation + 90 });
+      this.props.rotate(this.props.uploadId, this.state.orientation + 90);
+    }
   }
 
   render() {
@@ -42,7 +55,7 @@ export class DocumentContent extends Component {
             <img
               src={this.props.url}
               ref={this.imgEl}
-              style={{ transform: `rotate(${this.props.orientation}deg)` }}
+              style={{ transform: `rotate(${this.state.orientation}deg)` }}
               onLoad={this.adjustContainerHeight.bind(this)}
               alt="document upload"
             />
@@ -50,18 +63,8 @@ export class DocumentContent extends Component {
         )}
 
         <div>
-          <button
-            onClick={this.props.rotate.bind(this, this.props.uploadId, this.props.orientation + 90)}
-            data-direction="left"
-          >
-            rotate left
-          </button>
-          <button
-            onClick={this.props.rotate.bind(this, this.props.uploadId, this.props.orientation - 90)}
-            data-direction="right"
-          >
-            rotate right
-          </button>
+          <button onClick={this.handleRotate.bind(this, 'left')}>rotate left</button>
+          <button onClick={this.handleRotate.bind(this, 'right')}>rotate right</button>
         </div>
       </div>
     );

--- a/src/shared/DocumentViewer/DocumentContent.jsx
+++ b/src/shared/DocumentViewer/DocumentContent.jsx
@@ -50,10 +50,16 @@ export class DocumentContent extends Component {
         )}
 
         <div>
-          <button onClick={this.props.rotate.bind(this, this.props.uploadId, 'left')} data-direction="left">
+          <button
+            onClick={this.props.rotate.bind(this, this.props.uploadId, this.props.orientation + 90)}
+            data-direction="left"
+          >
             rotate left
           </button>
-          <button onClick={this.props.rotate.bind(this, this.props.uploadId, 'right')} data-direction="right">
+          <button
+            onClick={this.props.rotate.bind(this, this.props.uploadId, this.props.orientation - 90)}
+            data-direction="right"
+          >
             rotate right
           </button>
         </div>
@@ -67,7 +73,7 @@ DocumentContent.propTypes = {
   filename: PropTypes.string.isRequired,
   url: PropTypes.string.isRequired,
   uploadId: PropTypes.string.isRequired,
-  orientation: PropTypes.string,
+  orientation: PropTypes.number,
   rotate: PropTypes.func.isRequired,
 };
 

--- a/src/shared/Entities/modules/orders.js
+++ b/src/shared/Entities/modules/orders.js
@@ -53,8 +53,17 @@ export function selectUplodsForOrders(state, ordersId) {
   const orders = selectOrders(state, ordersId);
   const uploadedOrders = get(state, `entities.documents.${orders.uploaded_orders}`);
   if (uploadedOrders) {
-    return uploadedOrders.uploads.map(uploadId => get(state, `entities.uploads.${uploadId}`));
+    let uploads = uploadedOrders.uploads.map(uploadId => {
+      return { ...get(state, `entities.uploads.${uploadId}`), ...{ orientation: 180 } };
+    });
+
+    return uploads;
   } else {
     return [];
   }
+}
+
+export function changeUploadOrientation(uploadId, direction) {
+  // const upload = selectUpload(uploadId);
+  // return swaggerRequest(getClient, swaggerTag, { ordersId, updateOrders: orders }, { label });
 }

--- a/src/shared/Entities/modules/orders.js
+++ b/src/shared/Entities/modules/orders.js
@@ -54,7 +54,7 @@ export function selectUplodsForOrders(state, ordersId) {
   const uploadedOrders = get(state, `entities.documents.${orders.uploaded_orders}`);
   if (uploadedOrders) {
     let uploads = uploadedOrders.uploads.map(uploadId => {
-      return { ...get(state, `entities.uploads.${uploadId}`), ...{ orientation: 180 } };
+      return { ...get(state, `entities.uploads.${uploadId}`) };
     });
 
     return uploads;

--- a/src/shared/Entities/modules/uploads.js
+++ b/src/shared/Entities/modules/uploads.js
@@ -1,6 +1,6 @@
 import { denormalize } from 'normalizr';
 import { swaggerRequest } from 'shared/Swagger/request';
-import { getPublicClient } from 'shared/Swagger/api';
+import { getPublicClient, getClient } from 'shared/Swagger/api';
 import { uploads } from '../schema';
 import { ADD_ENTITIES } from '../actions';
 
@@ -20,6 +20,7 @@ export default function reducer(state = {}, action) {
 }
 
 export const createShipmentDocumentLabel = 'Uploads.createShipmentDocument';
+export const updateUploadLabel = 'uploads.updateUpload';
 
 export function createShipmentDocument(shipmentId, createGenericMoveDocument, label = createShipmentDocumentLabel) {
   return swaggerRequest(
@@ -33,3 +34,7 @@ export function createShipmentDocument(shipmentId, createGenericMoveDocument, la
 export const selectUpload = (state, id) => {
   return denormalize([id], uploads, state.entities)[0];
 };
+
+export function updateUpload(uploadId, params, label = updateUploadLabel) {
+  return swaggerRequest(getClient, label, { uploadId, params }, { label });
+}

--- a/src/shared/Entities/modules/uploads.js
+++ b/src/shared/Entities/modules/uploads.js
@@ -36,5 +36,5 @@ export const selectUpload = (state, id) => {
 };
 
 export function updateUpload(uploadId, params, label = updateUploadLabel) {
-  return swaggerRequest(getClient, label, { uploadId, params }, { label });
+  return swaggerRequest(getClient, label, { uploadId, ...params }, { label });
 }

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -1467,6 +1467,16 @@ definitions:
       - bytes
       - created_at
       - updated_at
+  UpdateUploadPayload:
+    type: object
+    properties:
+      id:
+        type: string
+        format: uuid
+        example: c56a4180-65aa-42ec-a945-5fd21dec0538
+      orientation:
+        type: integer
+        example: "90, 180, 270"
   DPSAuthCookieURLPayload:
     type: object
     properties:
@@ -3760,6 +3770,40 @@ paths:
         500:
           description: server error
   /uploads/{uploadId}:
+    patch:
+      summary: Updates and upload
+      description: Uploads represent a single digital file, such as a JPEG or PDF.
+      operationId: updateUpload
+      tags:
+        - uploads
+      parameters:
+        - in: path
+          name: uploadId
+          type: string
+          format: uuid
+          required: true
+          description: UUID of the upload to be updated
+        - in: body
+          name: UpdateUploadPayload
+          required: true
+          description: Orientation of the uploaded image, e.g. 90 degrees
+          schema:
+            $ref: '#/definitions/UpdateUploadPayload'
+      responses:
+        200:
+          description: updated
+          schema:
+            $ref: '#/definitions/UploadPayload'
+        400:
+          description: invalid request
+          schema:
+            $ref: '#/definitions/InvalidRequestResponsePayload'
+        403:
+          description: not authorized
+        404:
+          description: not found
+        500:
+          description: server error
     delete:
       summary: Deletes an upload
       description: Uploads represent a single digital file, such as a JPEG or PDF.

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -1453,6 +1453,8 @@ definitions:
         example: application/pdf
       bytes:
         type: integer
+      orientation:
+        type: integer
       created_at:
         type: string
         format: date-time
@@ -1470,10 +1472,6 @@ definitions:
   UpdateUploadPayload:
     type: object
     properties:
-      id:
-        type: string
-        format: uuid
-        example: c56a4180-65aa-42ec-a945-5fd21dec0538
       orientation:
         type: integer
         example: "90, 180, 270"
@@ -3784,9 +3782,8 @@ paths:
           required: true
           description: UUID of the upload to be updated
         - in: body
-          name: UpdateUploadPayload
+          name: UpdateUpload
           required: true
-          description: Orientation of the uploaded image, e.g. 90 degrees
           schema:
             $ref: '#/definitions/UpdateUploadPayload'
       responses:

--- a/yarn.lock
+++ b/yarn.lock
@@ -3284,6 +3284,11 @@ core-js@2.5.7:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.7.tgz#f972608ff0cead68b841a16a932d0b183791814e"
   integrity sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==
 
+core-js@3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.0.1.tgz#1343182634298f7f38622f95e73f54e48ddf4738"
+  integrity sha512-sco40rF+2KlE0ROMvydjkrVMMG1vYilP2ALoRXcYR4obqbYIuV3Bg+51GEDW+HF8n7NRA+iaA4qD0nD9lo9mew==
+
 core-js@^1.0.0:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
@@ -10275,7 +10280,7 @@ raf@3.4.0:
   dependencies:
     performance-now "^2.1.0"
 
-raf@^3.3.0, raf@^3.4.0:
+raf@3.4.1, raf@^3.3.0, raf@^3.4.0:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/raf/-/raf-3.4.1.tgz#0742e99a4a6552f445d73e3ee0328af0ff1ede39"
   integrity sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==
@@ -10372,6 +10377,18 @@ react-app-polyfill@^0.2.0:
     object-assign "4.1.1"
     promise "8.0.2"
     raf "3.4.0"
+    whatwg-fetch "3.0.0"
+
+react-app-polyfill@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/react-app-polyfill/-/react-app-polyfill-1.0.0.tgz#735c725c1d4261b710cb200c498789c8b80e0f74"
+  integrity sha512-fbZxEZdfx+rVENMvGTFjUcDDOZGKHaiavA8Y+FwM2I/o8gJT6pCYZk19XfeOntVzGZH2F1qqH7SLjXMhUM+YJw==
+  dependencies:
+    core-js "3.0.1"
+    object-assign "4.1.1"
+    promise "8.0.2"
+    raf "3.4.1"
+    regenerator-runtime "0.13.2"
     whatwg-fetch "3.0.0"
 
 react-autosuggest@^9.4.2:
@@ -10974,6 +10991,11 @@ regenerate@^1.2.1, regenerate@^1.4.0:
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.0.tgz#4a856ec4b56e4077c557589cae85e7a4c8869a11"
   integrity sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==
 
+regenerator-runtime@0.13.2, regenerator-runtime@^0.13.2:
+  version "0.13.2"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz#32e59c9a6fb9b1a4aff09b4930ca2d4477343447"
+  integrity sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA==
+
 regenerator-runtime@^0.10.5:
   version "0.10.5"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz#336c3efc1220adcedda2c9fab67b5a7955a33658"
@@ -10988,11 +11010,6 @@ regenerator-runtime@^0.12.0:
   version "0.12.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz#fa1a71544764c036f8c49b13a08b2594c9f8a0de"
   integrity sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg==
-
-regenerator-runtime@^0.13.2:
-  version "0.13.2"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz#32e59c9a6fb9b1a4aff09b4930ca2d4477343447"
-  integrity sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA==
 
 regenerator-transform@^0.13.3:
   version "0.13.3"


### PR DESCRIPTION
## Description

Sometimes, uploaded documents show up in the wrong orientation in the document viewer. This is a **rough** draft that demonstrates a potential workaround.

AC: basic ui for rotation
AC: rotation persists when you open the image/document again

## Reviewer Notes

**THIS IS NOT INTENDED TO BE DEPLOYED** 

Does the general architecture make sense? There are some rough spots and there are probably some React idioms/patterns I'm not taking advantage of, so please do let me know where this needs work. 

## Setup

1. Start a move as a new service member
2. On the orders page, upload a photo from your phone
3. Log into the office app
4. Select the move you just submitted and click on the orders link
5. Confirm that the image is rotated and looks incorrect
6. Try clicking "rotate left" or "rotate right"
7. Refresh the page and see that the new orientation was saved based on how you rotated the image

## Code Review Verification Steps

* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/165775065) for this change