### PR TITLE
Fix problem with ecs-deploy-task-container having a shadow err var

### DIFF
--- a/cmd/ecs-deploy-task-container/main.go
+++ b/cmd/ecs-deploy-task-container/main.go
@@ -327,9 +327,9 @@ func main() {
 	keychainProfile := v.GetString(awsProfileFlag)
 
 	if len(keychainName) > 0 && len(keychainProfile) > 0 {
-		creds, err := getAWSCredentials(keychainName, keychainProfile)
-		if err != nil {
-			quit(logger, nil, errors.Wrap(err, fmt.Sprintf("Unable to get AWS credentials from the keychain %s and profile %s", keychainName, keychainProfile)))
+		creds, getAWSCredsErr := getAWSCredentials(keychainName, keychainProfile)
+		if getAWSCredsErr != nil {
+			quit(logger, nil, errors.Wrap(getAWSCredsErr, fmt.Sprintf("Unable to get AWS credentials from the keychain %s and profile %s", keychainName, keychainProfile)))
 		}
 		awsConfig.CredentialsChainVerboseErrors = aws.Bool(verbose)
 		awsConfig.Credentials = creds


### PR DESCRIPTION
## Description

In #2042 I must have missed one of these shadow vars. This is the fix for master.

Run `pre-commit run -a go-vet` to check.