### PR TITLE
Shipments column in the new moves/shipments queue

### DIFF
--- a/pkg/models/queue.go
+++ b/pkg/models/queue.go
@@ -45,6 +45,7 @@ func GetMoveQueueItems(db *pop.Connection, lifecycleState string) ([]MoveQueueIt
 				moves.updated_at as last_modified_date,
 				moves.status as status,
 				ppm.status as ppm_status,
+				shipment.status as hhg_status,
 				shipment.gbl_number as gbl_number
 			FROM moves
 			JOIN orders as ord ON moves.orders_id = ord.id

--- a/src/scenes/Office/QueueTable.jsx
+++ b/src/scenes/Office/QueueTable.jsx
@@ -21,12 +21,12 @@ class QueueTable extends Component {
   }
 
   componentDidMount() {
-    this.fetchData(this.props.retrieveMoves);
+    this.fetchData();
   }
 
   componentDidUpdate(prevProps) {
     if (this.props.queueType !== prevProps.queueType) {
-      this.fetchData(this.props.retrieveMoves);
+      this.fetchData();
     }
   }
 
@@ -36,7 +36,7 @@ class QueueTable extends Component {
     lastName: '',
   };
 
-  async fetchData(retrieveMoves) {
+  async fetchData() {
     const loadingQueueType = this.props.queueType;
 
     this.setState({
@@ -48,7 +48,7 @@ class QueueTable extends Component {
 
     // Catch any errors here and render an empty queue
     try {
-      const body = await retrieveMoves(this.props.queueType);
+      const body = await this.props.retrieveMoves(this.props.queueType);
 
       // Only update the queue list if the request that is returning
       // is for the same queue as the most recent request.
@@ -80,7 +80,7 @@ class QueueTable extends Component {
     };
 
     this.state.data.forEach(row => {
-      if (row.ppm_status && row.hhg_status) {
+      if (this.props.queueType === 'new' && row.ppm_status && row.hhg_status) {
         row.shipments = 'HHG, PPM';
       } else if (row.ppm_status && !row.hhg_status) {
         row.shipments = 'PPM';
@@ -147,6 +147,7 @@ class QueueTable extends Component {
               {
                 Header: 'Shipments',
                 accessor: 'shipments',
+                show: this.props.queueType === 'new',
               },
               {
                 Header: 'Locator #',

--- a/src/scenes/Office/QueueTable.test.js
+++ b/src/scenes/Office/QueueTable.test.js
@@ -12,62 +12,67 @@ const push = jest.fn();
 describe('Shipments column', () => {
   let wrapper;
 
-  it('renders "PPM" when it is a PPM move', async () => {
+  it('renders "PPM" when it is a PPM move', done => {
     wrapper = mountComponents(
-      retrieveMoves({
+      retrieveMovesStub({
         ppm_status: 'PAYMENT_REQUESTED',
         hhg_status: undefined,
       }),
     );
 
-    await resolveAllPromises();
+    setTimeout(() => {
+      const move = getMove(wrapper);
+      expect(move.shipments).toEqual('PPM');
 
-    const move = getMove(wrapper);
-
-    expect(move.shipments).toEqual('PPM');
+      done();
+    });
   });
 
-  it('renders "HHG" when it is a HHG move', async () => {
+  it('renders "HHG" when it is a HHG move', done => {
     wrapper = mountComponents(
-      retrieveMoves({
+      retrieveMovesStub({
         ppm_status: undefined,
         hhg_status: 'APPROVED',
       }),
     );
 
-    await resolveAllPromises();
+    setTimeout(() => {
+      const move = getMove(wrapper);
+      expect(move.shipments).toEqual('HHG');
 
-    const move = getMove(wrapper);
-
-    expect(move.shipments).toEqual('HHG');
+      done();
+    });
   });
 
-  it('renders "HHG, PPM" when it is a combo move', async () => {
+  it('renders "HHG, PPM" when it is a combo move', done => {
     wrapper = mountComponents(
-      retrieveMoves({
+      retrieveMovesStub({
         ppm_status: 'PAYMENT_REQUESTED',
         hhg_status: 'APPROVED',
       }),
     );
 
-    await resolveAllPromises();
+    setTimeout(() => {
+      const move = getMove(wrapper);
+      expect(move.shipments).toEqual('HHG, PPM');
 
-    const move = getMove(wrapper);
-
-    expect(move.shipments).toEqual('HHG, PPM');
+      done();
+    });
   });
 });
 
-function retrieveMoves(params) {
+function retrieveMovesStub(params) {
   // This is meant as a stub that will act in place of
   // `RetrieveMovesForOffice` from Office/api.js
   return async () => {
-    return [
-      {
-        id: 'c56a4180-65aa-42ec-a945-5fd21dec0538',
-        ...params,
-      },
-    ];
+    return await new Promise(resolve => {
+      resolve([
+        {
+          id: 'c56a4180-65aa-42ec-a945-5fd21dec0538',
+          ...params,
+        },
+      ]);
+    });
   };
 }
 
@@ -83,15 +88,4 @@ function mountComponents(getMoves) {
 
 function getMove(wrapper) {
   return wrapper.find(ReactTable).state().data[0];
-}
-
-function resolveAllPromises() {
-  // Forces all promises that are returned inside the
-  // component to resolve before the one returned here,
-  // effectively giving us the end state of the component
-  // as it would be rendered on the page.
-
-  return new Promise(resolve => {
-    setTimeout(resolve, 0);
-  });
 }

--- a/src/scenes/Office/QueueTable.test.js
+++ b/src/scenes/Office/QueueTable.test.js
@@ -59,6 +59,23 @@ describe('Shipments column', () => {
       done();
     });
   });
+
+  it('does not display when the queue type is anything other than "new"', done => {
+    wrapper = mountComponents(
+      retrieveMovesStub({
+        ppm_status: undefined,
+        hhg_status: undefined,
+      }),
+      'ppm',
+    );
+
+    setTimeout(() => {
+      const move = getMove(wrapper);
+      expect(move.shipments);
+
+      done();
+    });
+  });
 });
 
 function retrieveMovesStub(params) {
@@ -76,11 +93,11 @@ function retrieveMovesStub(params) {
   };
 }
 
-function mountComponents(getMoves) {
+function mountComponents(getMoves, queueType = 'new') {
   return mount(
     <Provider store={store}>
       <MockRouter push={push}>
-        <QueueTable queueType="new" retrieveMoves={getMoves} />
+        <QueueTable queueType={queueType} retrieveMoves={getMoves} />
       </MockRouter>
     </Provider>,
   );

--- a/src/scenes/Office/QueueTable.test.js
+++ b/src/scenes/Office/QueueTable.test.js
@@ -1,0 +1,90 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import MockRouter from 'react-mock-router';
+
+import QueueTable from './QueueTable';
+import ReactTable from 'react-table';
+import store from 'shared/store';
+import { mount } from 'enzyme/build';
+
+const push = jest.fn();
+
+describe('Shipments column', () => {
+  let wrapper;
+
+  it('renders "PPM" when it is a PPM move', async () => {
+    wrapper = mountComponents(
+      retrieveMoves({
+        ppm_status: 'PAYMENT_REQUESTED',
+        hhg_status: undefined,
+      }),
+    );
+
+    await resolveAllPromises();
+
+    const move = getMove(wrapper);
+
+    expect(move.shipments).toEqual('PPM');
+  });
+
+  it('renders "HHG" when it is a HHG move', async () => {
+    wrapper = mountComponents(
+      retrieveMoves({
+        ppm_status: undefined,
+        hhg_status: 'APPROVED',
+      }),
+    );
+
+    await resolveAllPromises();
+
+    const move = getMove(wrapper);
+
+    expect(move.shipments).toEqual('HHG');
+  });
+
+  it('renders "HHG, PPM" when it is a combo move', async () => {
+    wrapper = mountComponents(
+      retrieveMoves({
+        ppm_status: 'PAYMENT_REQUESTED',
+        hhg_status: 'APPROVED',
+      }),
+    );
+
+    await resolveAllPromises();
+
+    const move = getMove(wrapper);
+
+    expect(move.shipments).toEqual('HHG, PPM');
+  });
+});
+
+function retrieveMoves(params) {
+  return async () => {
+    return [
+      {
+        id: 'c56a4180-65aa-42ec-a945-5fd21dec0538',
+        ...params,
+      },
+    ];
+  };
+}
+
+function mountComponents(getMoves) {
+  return mount(
+    <Provider store={store}>
+      <MockRouter push={push}>
+        <QueueTable queueType="new" retrieveMoves={getMoves} />
+      </MockRouter>
+    </Provider>,
+  );
+}
+
+function getMove(wrapper) {
+  return wrapper.find(ReactTable).state().data[0];
+}
+
+function resolveAllPromises() {
+  return new Promise(resolve => {
+    setTimeout(resolve, 0);
+  });
+}

--- a/src/scenes/Office/QueueTable.test.js
+++ b/src/scenes/Office/QueueTable.test.js
@@ -59,6 +59,8 @@ describe('Shipments column', () => {
 });
 
 function retrieveMoves(params) {
+  // This is meant as a stub that will act in place of
+  // `RetrieveMovesForOffice` from Office/api.js
   return async () => {
     return [
       {
@@ -84,6 +86,11 @@ function getMove(wrapper) {
 }
 
 function resolveAllPromises() {
+  // Forces all promises that are returned inside the
+  // component to resolve before the one returned here,
+  // effectively giving us the end state of the component
+  // as it would be rendered on the page.
+
   return new Promise(resolve => {
     setTimeout(resolve, 0);
   });

--- a/src/scenes/Office/index.jsx
+++ b/src/scenes/Office/index.jsx
@@ -18,6 +18,7 @@ import LogoutOnInactivity from 'shared/User/LogoutOnInactivity';
 import PrivateRoute from 'shared/User/PrivateRoute';
 import ScratchPad from 'shared/ScratchPad';
 import { isProduction } from 'shared/constants';
+import { RetrieveMovesForOffice } from './api.js';
 
 import './office.css';
 
@@ -29,7 +30,7 @@ class Queues extends Component {
           <QueueList />
         </div>
         <div className="queue-list-column">
-          <QueueTable queueType={this.props.match.params.queueType} />
+          <QueueTable queueType={this.props.match.params.queueType} retrieveMoves={RetrieveMovesForOffice} />
         </div>
       </div>
     );

--- a/src/scenes/Office/index.jsx
+++ b/src/scenes/Office/index.jsx
@@ -18,7 +18,7 @@ import LogoutOnInactivity from 'shared/User/LogoutOnInactivity';
 import PrivateRoute from 'shared/User/PrivateRoute';
 import ScratchPad from 'shared/ScratchPad';
 import { isProduction } from 'shared/constants';
-import { RetrieveMovesForOffice } from './api.js';
+import { RetrieveMovesForOffice } from './api';
 
 import './office.css';
 


### PR DESCRIPTION
## Description

As an office user
I want to see the types of shipments in a move
So that I can evaluate urgency

## Reviewer Notes

This is a small change, but I used this ticket as a way to practice making our React code more modular and testable. You'll notice that the `QueueTable` component no longer directly references `RetrieveMovesForOffice`, but takes that function as a prop. The component became easier to unit test once I could pass in the function that would be in charge of fetching the data. Overall, I believe this is our intention in trying to write components in the container vs. presentational component design. Presentational components should be easy to unit test.

One issue I faced in writing the test came when I realized that `QueueTable` fetches its data asynchronously. This caused the tests to evaluate their expectations before the data had been fetched. Jest has some [docs](https://jestjs.io/docs/en/asynchronous.html) on how to effectively test async code, but seems to only account for the case where the only code under test is an async function. The async code in this case is nested inside the entire component under test, so it wasn't super clear where to go from there. My workaround is the `resolveAllPromises` function in `QueueTable.test.js`. I'd love to hear some opinions on whether or not this is an antipattern and if there is a better way to handle this case.

## Setup

1. `make server_run`
2. `make client_run`
3. Navigate to the office app and the `New` queue
4. Confirm that there is a `Shipments` column that has the proper values for each shipment

## Code Review Verification Steps

* [x] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] User facing changes have been reviewed by design.
* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/165769347) for this change

## Screenshots

<img width="1450" alt="Screen Shot 2019-05-09 at 09 51 26" src="https://user-images.githubusercontent.com/3522323/57463781-16a71480-7241-11e9-81c8-beab4bb036d8.png">

