### PR TITLE
Remove jen2000 from codeowners file, replace with ARBOC

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,6 +6,5 @@
 # owners will be requested for a review.
 # Add language specific code owners if it becomes relevant
 
-# ADRs are architectural decisions that, at least for now, should all be run by Nick
-# with Jen Leech as a backup.
-/docs/adr/* @ntwyman @jen2000
+# ADRs are architectural decisions records that should all be approved by ARBOC
+/docs/adr/* @ntwyman @chrisrcoles @jim @lynzt @mikena-truss @sarboc


### PR DESCRIPTION
## Description

@jen2000 has left the Transcom org in https://github.com/transcom/ppp-infra/pull/508. Instead of having only @ntwyman in codeowners I've replaced her with the team leads. Happy to make other changes too but figure we should have more than one person on the ADR review.

## Code Review Verification Steps

* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/165892140) for this change