### PR TITLE
Kim 163338392 office denies sit request

### DIFF
--- a/cypress/integration/office/storageInTransitPanel.js
+++ b/cypress/integration/office/storageInTransitPanel.js
@@ -15,6 +15,9 @@ describe('office user finds the shipment', function() {
   it('office user starts and cancels sit edit', function() {
     officeUserStartsAndCancelsSitEdit();
   });
+  it('office user denies sit request', function() {
+    officeUserDeniesSITRequest();
+  });
 });
 
 function officeUserViewsSITPanel() {
@@ -198,4 +201,43 @@ function officeUserApprovesSITRequest() {
   cy.get('[data-cy="storage-in-transit-status"]').contains('Approved');
   cy.get('[data-cy="sit-authorized-start-date"]').contains('22-Mar-2019');
   cy.get('[data-cy="sit-authorization-notes"]').contains('this is a note');
+}
+
+function officeUserDeniesSITRequest() {
+  cy.patientVisit('/queues/hhg_accepted');
+  cy.location().should(loc => {
+    expect(loc.pathname).to.match(/^\/queues\/hhg_accepted/);
+  });
+
+  cy.selectQueueItemMoveLocator('SITDEN');
+
+  cy.location().should(loc => {
+    expect(loc.pathname).to.match(/^\/queues\/new\/moves\/[^/]+\/basics/);
+  });
+
+  cy.get('[data-cy="hhg-tab"]').click();
+
+  cy.location().should(loc => {
+    expect(loc.pathname).to.match(/^\/queues\/new\/moves\/[^/]+\/hhg/);
+  });
+
+  cy
+    .get('a[data-cy="deny-sit-link"]')
+    .contains('Deny')
+    .click()
+    .get('[data-cy="storage-in-transit"]')
+    .should($div => {
+      const text = $div.text();
+      expect(text).to.include('Deny SIT Request');
+      expect(text).to.not.include('Deny');
+      expect(text).to.not.include('Edit');
+    });
+  cy.get('textarea[name="authorization_notes"]').type('this is a denial note');
+  cy
+    .get('[data-cy="storage-in-transit-approve-button"]')
+    .contains('Deny')
+    .click();
+
+  cy.get('[data-cy="storage-in-transit-status"]').contains('Denied');
+  cy.get('[data-cy="sit-authorization-notes"]').contains('this is a denial note');
 }

--- a/cypress/integration/office/storageInTransitPanel.js
+++ b/cypress/integration/office/storageInTransitPanel.js
@@ -229,15 +229,15 @@ function officeUserDeniesSITRequest() {
     .should($div => {
       const text = $div.text();
       expect(text).to.include('Deny SIT Request');
-      expect(text).to.not.include('Deny');
+      expect(text).to.not.include('Approve');
       expect(text).to.not.include('Edit');
     });
   cy.get('textarea[name="authorization_notes"]').type('this is a denial note');
   cy
-    .get('[data-cy="storage-in-transit-approve-button"]')
+    .get('[data-cy="storage-in-transit-deny-button"]')
     .contains('Deny')
     .click();
 
-  cy.get('[data-cy="storage-in-transit-status"]').contains('Denied');
+  cy.get('[data-cy="storage-in-transit-status-denied"]').contains('Denied');
   cy.get('[data-cy="sit-authorization-notes"]').contains('this is a denial note');
 }

--- a/pkg/handlers/publicapi/storage_in_transits.go
+++ b/pkg/handlers/publicapi/storage_in_transits.go
@@ -144,7 +144,7 @@ type DenyStorageInTransitHandler struct {
 // This is meant to set the status for a storage in transit to denied, save the supporting authorization notes,
 // and return the saved object in a payload.
 func (h DenyStorageInTransitHandler) Handle(params sitop.DenyStorageInTransitParams) middleware.Responder {
-	payload := params.StorageInTransitApprovalPayload
+	payload := params.StorageInTransitDenyPayload
 	shipmentID, err := uuid.FromString(params.ShipmentID.String())
 	storageInTransitID, err := uuid.FromString(params.StorageInTransitID.String())
 

--- a/pkg/handlers/publicapi/storage_in_transits_test.go
+++ b/pkg/handlers/publicapi/storage_in_transits_test.go
@@ -317,10 +317,10 @@ func (suite *HandlerSuite) TestDenyStorageInTransitHandler() {
 	req := httptest.NewRequest("POST", path, nil)
 	req = suite.AuthenticateOfficeRequest(req, user)
 	params := sitop.DenyStorageInTransitParams{
-		HTTPRequest:                     req,
-		ShipmentID:                      strfmt.UUID(shipmentID.String()),
-		StorageInTransitID:              strfmt.UUID(storageInTransitID.String()),
-		StorageInTransitApprovalPayload: &payload,
+		HTTPRequest:                 req,
+		ShipmentID:                  strfmt.UUID(shipmentID.String()),
+		StorageInTransitID:          strfmt.UUID(storageInTransitID.String()),
+		StorageInTransitDenyPayload: &payload,
 	}
 
 	storageInTransitDenier := &mocks.StorageInTransitDenier{}

--- a/pkg/testdatagen/scenario/e2ebasic.go
+++ b/pkg/testdatagen/scenario/e2ebasic.go
@@ -2287,6 +2287,53 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, log
 	models.SaveMoveDependencies(db, &hhg37.Move)
 
 	/*
+	 * Service member with accepted move for use in testing SIT Denial by the office
+	 */
+	email = "hhg@sit.requested.todeny.panel"
+	offer38 := testdatagen.MakeShipmentOffer(db, testdatagen.Assertions{
+		User: models.User{
+			ID:            uuid.Must(uuid.FromString("fc3fe543-589d-4a91-ab03-8bd8bdfc7df3")),
+			LoginGovEmail: email,
+		},
+		ServiceMember: models.ServiceMember{
+			ID:            uuid.FromStringOrNil("db6d867f-4981-4163-b683-7e3210a0a246"),
+			FirstName:     models.StringPointer("SIT"),
+			LastName:      models.StringPointer("RequestedToDeny"),
+			Edipi:         models.StringPointer("1357924680"),
+			PersonalEmail: models.StringPointer(email),
+		},
+		Move: models.Move{
+			ID:               uuid.FromStringOrNil("51971a9d-db4c-4fda-84dc-1099efc3b3a3"),
+			Locator:          "SITDEN",
+			SelectedMoveType: &selectedMoveTypeHHG,
+		},
+		TrafficDistributionList: models.TrafficDistributionList{
+			ID:                uuid.FromStringOrNil("a392b7e2-d15c-4c20-9571-0bed93f8ea5f"),
+			SourceRateArea:    "US62",
+			DestinationRegion: "11",
+			CodeOfService:     "D",
+		},
+		Shipment: models.Shipment{
+			Status: models.ShipmentStatusACCEPTED,
+		},
+		ShipmentOffer: models.ShipmentOffer{
+			TransportationServiceProviderID: tspUser.TransportationServiceProviderID,
+			Accepted:                        models.BoolPointer(true),
+		},
+	})
+
+	testdatagen.MakeStorageInTransit(db, testdatagen.Assertions{
+		StorageInTransit: models.StorageInTransit{
+			ShipmentID:         offer38.ShipmentID,
+			Shipment:           offer38.Shipment,
+			EstimatedStartDate: time.Date(2019, time.Month(3), 22, 0, 0, 0, 0, time.UTC),
+		},
+	})
+	hhg38 := offer38.Shipment
+	hhg38.Move.Submit(time.Now())
+	models.SaveMoveDependencies(db, &hhg38.Move)
+
+	/*
 	 * Service member with a ppm ready to request payment
 	 */
 	email = "ppm@requestingpay.ment"

--- a/src/shared/Entities/modules/storageInTransits.js
+++ b/src/shared/Entities/modules/storageInTransits.js
@@ -81,7 +81,6 @@ export function denyStorageInTransit(
   storageInTransitDenyPayload,
   label = denyStorageInTransitLabel,
 ) {
-  console.log('inside denyStorageInTransit');
   return swaggerRequest(
     getPublicClient,
     'storage_in_transits.denyStorageInTransit',

--- a/src/shared/Entities/modules/storageInTransits.js
+++ b/src/shared/Entities/modules/storageInTransits.js
@@ -5,6 +5,7 @@ const createStorageInTransitLabel = 'StorageInTransits.createStorageInTransit';
 const getStorageInTransitsLabel = 'StorageInTransits.getStorageInTransitsForShipment';
 const updateStorageInTransitLabel = 'StorageInTransits.updateStorageInTransit';
 const approveStorageInTransitLabel = 'StorageInTransits.approveStorageInTransit';
+const denyStorageInTransitLabel = 'StorageInTransits.denyStorageInTransit';
 
 export const selectStorageInTransits = (state, shipmentId) => {
   const storageInTransits = Object.values(state.entities.storageInTransits).filter(
@@ -54,6 +55,25 @@ export function approveStorageInTransit(
       shipmentId,
       storageInTransitId,
       storageInTransitApprovalPayload,
+    },
+    { label },
+  );
+}
+
+export function denyStorageInTransit(
+  shipmentId,
+  storageInTransitId,
+  storageInTransitDenyPayload,
+  label = denyStorageInTransitLabel,
+) {
+  console.log('inside denyStorageInTransit');
+  return swaggerRequest(
+    getPublicClient,
+    'storage_in_transits.denyStorageInTransit',
+    {
+      shipmentId,
+      storageInTransitId,
+      storageInTransitDenyPayload,
     },
     { label },
   );

--- a/src/shared/StorageInTransit/ApproveSitRequest.jsx
+++ b/src/shared/StorageInTransit/ApproveSitRequest.jsx
@@ -11,10 +11,6 @@ import { approveStorageInTransit } from 'shared/Entities/modules/storageInTransi
 import './StorageInTransit.css';
 
 export class ApproveSitRequest extends Component {
-  state = {
-    closeOnSubmit: true,
-  };
-
   componentDidUpdate(prevProps, prevState) {
     if (this.props.hasSubmitSucceeded && !prevProps.hasSubmitSucceeded) {
       this.props.onClose();
@@ -25,10 +21,8 @@ export class ApproveSitRequest extends Component {
     this.props.onClose();
   };
 
-  approveAndClose = () => {
-    this.setState({ closeOnSubmit: true }, () => {
-      this.props.submitForm();
-    });
+  approveSit = () => {
+    this.props.submitForm();
   };
 
   onSubmit = values => {
@@ -60,7 +54,7 @@ export class ApproveSitRequest extends Component {
               data-cy="storage-in-transit-approve-button"
               className="button usa-button-primary storage-in-transit-request-form-send-request-button"
               disabled={!this.props.formEnabled}
-              onClick={this.approveAndClose}
+              onClick={this.approveSit}
             >
               Approve
             </button>

--- a/src/shared/StorageInTransit/DenySitRequest.jsx
+++ b/src/shared/StorageInTransit/DenySitRequest.jsx
@@ -22,7 +22,6 @@ export class DenySitRequest extends Component {
   };
 
   onSubmit = values => {
-    console.log('values', values);
     this.props.denyStorageInTransit(this.props.storageInTransit.shipment_id, this.props.storageInTransit.id, values);
   };
 
@@ -46,7 +45,12 @@ export class DenySitRequest extends Component {
             </p>
           </div>
           <div className="usa-width-one-half align-right">
-            <button className="button usa-button-primary" disabled={!this.props.formEnabled} onClick={this.denySit}>
+            <button
+              className="button usa-button-primary"
+              data-cy="storage-in-transit-deny-button"
+              disabled={!this.props.formEnabled}
+              onClick={this.denySit}
+            >
               Deny
             </button>
           </div>

--- a/src/shared/StorageInTransit/DenySitRequest.jsx
+++ b/src/shared/StorageInTransit/DenySitRequest.jsx
@@ -13,19 +13,12 @@ import StorageInTransitOfficeDenyForm, {
 } from './StorageInTransitOfficeDenyForm.jsx';
 
 export class DenySitRequest extends Component {
-  constructor(props) {
-    super(props);
-    this.state = { closeOnSubmit: true };
-  }
-
   closeForm = () => {
     this.props.onClose();
   };
 
-  denyAndClose = () => {
-    this.setState({ closeOnSubmit: true }, () => {
-      this.props.submitForm();
-    });
+  denySit = () => {
+    this.props.submitForm();
   };
 
   onSubmit = values => {
@@ -53,11 +46,7 @@ export class DenySitRequest extends Component {
             </p>
           </div>
           <div className="usa-width-one-half align-right">
-            <button
-              className="button usa-button-primary"
-              disabled={!this.props.formEnabled}
-              onClick={this.denyAndClose}
-            >
+            <button className="button usa-button-primary" disabled={!this.props.formEnabled} onClick={this.denySit}>
               Deny
             </button>
           </div>

--- a/src/shared/StorageInTransit/DenySitRequest.jsx
+++ b/src/shared/StorageInTransit/DenySitRequest.jsx
@@ -1,20 +1,49 @@
 import React, { Component } from 'react';
-import PropTypes from 'prop-types';
-import './StorageInTransit.css';
-import { connect } from 'react-redux';
+import { isValid, isSubmitting, submit, hasSubmitSucceeded } from 'redux-form';
 import { bindActionCreators } from 'redux';
-import StorageInTransitOfficeDenyForm from './StorageInTransitOfficeDenyForm.jsx';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+
+import { denyStorageInTransit } from 'shared/Entities/modules/storageInTransits';
+
+import './StorageInTransit.css';
+
+import StorageInTransitOfficeDenyForm, {
+  formName as StorageInTransitOfficeDenyFormName,
+} from './StorageInTransitOfficeDenyForm.jsx';
 
 export class DenySitRequest extends Component {
+  constructor(props) {
+    super(props);
+    this.state = { closeOnSubmit: true };
+  }
+
   closeForm = () => {
     this.props.onClose();
   };
+
+  denyAndClose = () => {
+    this.setState({ closeOnSubmit: true }, () => {
+      this.props.submitForm();
+    });
+  };
+
+  onSubmit = values => {
+    console.log('values', values);
+    this.props.denyStorageInTransit(this.props.storageInTransit.shipment_id, this.props.storageInTransit.id, values);
+  };
+
+  componentDidUpdate(prevProps) {
+    if (this.props.hasSubmitSucceeded && !prevProps.hasSubmitSucceeded) {
+      this.props.onClose();
+    }
+  }
 
   render() {
     return (
       <div className="storage-in-transit-panel-modal">
         <div className="title">Deny SIT Request</div>
-        <StorageInTransitOfficeDenyForm />
+        <StorageInTransitOfficeDenyForm onSubmit={this.onSubmit} initialValues={this.props.storageInTransit} />
         <div className="usa-grid-full align-center-vertical">
           <div className="usa-width-one-half">
             <p className="cancel-link">
@@ -24,7 +53,11 @@ export class DenySitRequest extends Component {
             </p>
           </div>
           <div className="usa-width-one-half align-right">
-            <button className="button usa-button-primary" disabled={!this.props.formEnabled}>
+            <button
+              className="button usa-button-primary"
+              disabled={!this.props.formEnabled}
+              onClick={this.denyAndClose}
+            >
               Deny
             </button>
           </div>
@@ -36,14 +69,29 @@ export class DenySitRequest extends Component {
 
 DenySitRequest.propTypes = {
   onClose: PropTypes.func.isRequired,
+  storageInTransit: PropTypes.object.isRequired,
+  submitForm: PropTypes.func.isRequired,
+  formEnabled: PropTypes.bool,
+  hasSubmitSucceeded: PropTypes.bool,
+  denyStorageInTransit: PropTypes.func.isRequired,
 };
 
 function mapStateToProps(state) {
-  return {};
+  return {
+    formEnabled:
+      isValid(StorageInTransitOfficeDenyFormName)(state) && !isSubmitting(StorageInTransitOfficeDenyFormName)(state),
+    hasSubmitSucceeded: hasSubmitSucceeded(StorageInTransitOfficeDenyFormName)(state),
+  };
 }
 function mapDispatchToProps(dispatch) {
   // Bind an action, which submit the form by its name
-  return bindActionCreators({}, dispatch);
+  return bindActionCreators(
+    {
+      submitForm: () => submit(StorageInTransitOfficeDenyFormName),
+      denyStorageInTransit,
+    },
+    dispatch,
+  );
 }
 
 export default connect(mapStateToProps, mapDispatchToProps)(DenySitRequest);

--- a/src/shared/StorageInTransit/PlaceInSit.jsx
+++ b/src/shared/StorageInTransit/PlaceInSit.jsx
@@ -12,9 +12,10 @@ import { formName as PlaceInSitFormName } from 'shared/StorageInTransit/PlaceInS
 import './StorageInTransit.css';
 
 export class PlaceInSit extends Component {
-  state = {
-    storageInTransit: {},
-  };
+  constructor(props) {
+    super(props);
+    this.state = { storageInTransit: {} };
+  }
 
   closeForm = () => {
     this.props.onClose();
@@ -24,7 +25,7 @@ export class PlaceInSit extends Component {
     this.props.updateSitPlaceIntoSit(this.props.sit.shipment_id, this.props.sit.id, values);
   };
 
-  submitPlaceInSitAndClose = () => {
+  submitPlaceInSit = () => {
     this.props.submitForm();
   };
 
@@ -70,7 +71,7 @@ export class PlaceInSit extends Component {
               className="button usa-button-primary"
               data-cy="place-in-sit-button"
               disabled={!this.props.formEnabled}
-              onClick={this.submitPlaceInSitAndClose}
+              onClick={this.submitPlaceInSit}
             >
               Place Into SIT
             </button>

--- a/src/shared/StorageInTransit/StorageInTransit.jsx
+++ b/src/shared/StorageInTransit/StorageInTransit.jsx
@@ -258,7 +258,7 @@ export class StorageInTransit extends Component {
               )}
             </div>
             <div className="usa-width-one-half">
-              {storageInTransit.status !== 'REQUESTED' && (
+              {!isRequested && (
                 <div className="sit-authorization-wrapper">
                   <div className="column-subhead nested__same-font">Authorization</div>
                   <div className="panel-field nested__same-font">

--- a/src/shared/StorageInTransit/StorageInTransit.jsx
+++ b/src/shared/StorageInTransit/StorageInTransit.jsx
@@ -139,7 +139,7 @@ export class StorageInTransit extends Component {
             <span>SIT {capitalize(storageInTransit.status)} </span>
           )}
           {showApproveForm ? (
-            <ApproveSitRequest onClose={this.closeApproveForm} storageInTransit={this.state.storageInTransit} />
+            <ApproveSitRequest onClose={this.closeApproveForm} storageInTransit={storageInTransit} />
           ) : storageInTransit.status === 'APPROVED' || storageInTransit.status === 'DENIED' ? (
             <span>{null}</span>
           ) : (
@@ -155,7 +155,7 @@ export class StorageInTransit extends Component {
             )
           )}
           {showDenyForm ? (
-            <DenySitRequest onClose={this.closeDenyForm} />
+            <DenySitRequest onClose={this.closeDenyForm} storageInTransit={storageInTransit} />
           ) : storageInTransit.status === 'APPROVED' || storageInTransit.status === 'DENIED' ? (
             <span>{null}</span>
           ) : (

--- a/src/shared/StorageInTransit/StorageInTransit.jsx
+++ b/src/shared/StorageInTransit/StorageInTransit.jsx
@@ -132,7 +132,7 @@ export class StorageInTransit extends Component {
               Approved
             </span>
           ) : storageInTransit.status === 'DENIED' ? (
-            <span className="storage-in-transit-status">
+            <span className="storage-in-transit-status" data-cy="storage-in-transit-status-denied">
               <FontAwesomeIcon className="icon approval-problem" icon={faBan} />
               Denied
             </span>
@@ -142,7 +142,7 @@ export class StorageInTransit extends Component {
             <span>SIT {capitalize(storageInTransit.status)}</span>
           )}
           {showApproveForm ? (
-            <ApproveSitRequest onClose={this.closeApproveForm} storageInTransit={storageInTransit} />
+            <ApproveSitRequest onClose={this.closeApproveForm} storageInTransit={this.state.storageInTransit} />
           ) : storageInTransit.status === 'APPROVED' || storageInTransit.status === 'DENIED' ? (
             <span>{null}</span>
           ) : (

--- a/src/shared/StorageInTransit/StorageInTransit.jsx
+++ b/src/shared/StorageInTransit/StorageInTransit.jsx
@@ -116,6 +116,7 @@ export class StorageInTransit extends Component {
     const { showTspEditForm, showOfficeEditForm, showApproveForm, showDenyForm, showPlaceInSitForm } = this.state;
     const isDenied = storageInTransit.status === 'DENIED';
     const isRequested = storageInTransit.status === 'REQUESTED';
+    const isApproved = storageInTransit.status === 'APPROVED';
     return (
       <div data-cy="storage-in-transit" className="storage-in-transit">
         <div className="column-head">
@@ -127,12 +128,12 @@ export class StorageInTransit extends Component {
             </span>{' '}
             {isRequested && <SitStatusIcon isTspSite={isTspSite} />}
           </span>
-          {storageInTransit.status === 'APPROVED' ? (
+          {isApproved ? (
             <span data-cy="storage-in-transit-status">
               <FontAwesomeIcon className="icon approval-ready" icon={faCheck} />
               Approved
             </span>
-          ) : storageInTransit.status === 'DENIED' ? (
+          ) : isDenied ? (
             <span data-cy="storage-in-transit-status-denied">
               <FontAwesomeIcon className="icon approval-problem" icon={faBan} />
               Denied
@@ -144,7 +145,7 @@ export class StorageInTransit extends Component {
           )}
           {showApproveForm ? (
             <ApproveSitRequest onClose={this.closeApproveForm} storageInTransit={this.state.storageInTransit} />
-          ) : storageInTransit.status === 'APPROVED' || storageInTransit.status === 'DENIED' ? (
+          ) : isApproved || isDenied ? (
             <span>{null}</span>
           ) : (
             isOfficeSite &&
@@ -161,7 +162,7 @@ export class StorageInTransit extends Component {
           )}
           {showDenyForm ? (
             <DenySitRequest onClose={this.closeDenyForm} storageInTransit={storageInTransit} />
-          ) : storageInTransit.status === 'APPROVED' || storageInTransit.status === 'DENIED' ? (
+          ) : isApproved || isDenied ? (
             <span>{null}</span>
           ) : (
             isOfficeSite &&
@@ -180,7 +181,7 @@ export class StorageInTransit extends Component {
             <PlaceInSit sit={storageInTransit} onClose={this.closePlaceInSitForm} />
           ) : (
             isTspSite &&
-            storageInTransit.status === 'APPROVED' && (
+            isApproved && (
               <span className="sit-actions">
                 <span className="place-in-sit">
                   <a data-cy="place-in-sit-link" onClick={this.openPlaceInSitForm}>
@@ -199,7 +200,8 @@ export class StorageInTransit extends Component {
             />
           ) : (
             isTspSite &&
-            storageInTransit.status !== 'APPROVED' && (
+            storageInTransit.status !== 'APPROVED' &&
+            !isDenied && (
               <span className="sit-actions">
                 <span className="sit-edit actionable">
                   <a onClick={this.openTspEditForm}>
@@ -217,7 +219,7 @@ export class StorageInTransit extends Component {
               storageInTransit={this.state.storageInTransit}
             />
           ) : (
-            (storageInTransit.status === 'APPROVED' || storageInTransit.status === 'DENIED') &&
+            (isApproved || isDenied) &&
             isOfficeSite &&
             !showApproveForm &&
             !showDenyForm && (

--- a/src/shared/StorageInTransit/StorageInTransit.jsx
+++ b/src/shared/StorageInTransit/StorageInTransit.jsx
@@ -132,7 +132,7 @@ export class StorageInTransit extends Component {
               Approved
             </span>
           ) : storageInTransit.status === 'DENIED' ? (
-            <span className="storage-in-transit-status" data-cy="storage-in-transit-status-denied">
+            <span data-cy="storage-in-transit-status-denied">
               <FontAwesomeIcon className="icon approval-problem" icon={faBan} />
               Denied
             </span>

--- a/src/shared/StorageInTransit/StorageInTransit.jsx
+++ b/src/shared/StorageInTransit/StorageInTransit.jsx
@@ -114,6 +114,7 @@ export class StorageInTransit extends Component {
   render() {
     const { storageInTransit } = this.props;
     const { showTspEditForm, showOfficeEditForm, showApproveForm, showDenyForm, showPlaceInSitForm } = this.state;
+    const isDenied = storageInTransit.status === 'DENIED';
     return (
       <div data-cy="storage-in-transit" className="storage-in-transit">
         <div className="column-head">
@@ -163,7 +164,7 @@ export class StorageInTransit extends Component {
             !showTspEditForm &&
             !showApproveForm && (
               <span className="sit-actions">
-                <a className="deny-sit-link" onClick={this.openDenyForm}>
+                <a className="deny-sit-link" data-cy="deny-sit-link" onClick={this.openDenyForm}>
                   <FontAwesomeIcon className="icon" icon={faBan} />
                   Deny
                 </a>
@@ -242,25 +243,36 @@ export class StorageInTransit extends Component {
               )}
             </div>
             <div className="usa-width-one-half">
-              {storageInTransit.status === 'APPROVED' && (
+              {storageInTransit.status !== 'REQUESTED' && (
                 <div className="sit-authorization-wrapper">
                   <div className="column-subhead nested__same-font">Authorization</div>
                   <div className="panel-field nested__same-font">
                     <span className="field-title unbold">SIT approved</span>
-                    <span className="field-value">Yes</span>
+                    <span className="field-value">{isDenied ? 'No' : 'Yes'}</span>
                   </div>
-                  <div className="panel-field nested__same-font">
-                    <span className="field-title unbold">Earliest start date</span>
-                    <span data-cy="sit-authorized-start-date" className="field-value">
-                      {formatDate4DigitYear(storageInTransit.authorized_start_date)}
-                    </span>
-                  </div>
-                  <div className="panel-field nested__same-font">
-                    <span className="field-title unbold">Note</span>
-                    <span data-cy="sit-authorization-notes" className="field-value">
-                      {storageInTransit.authorization_notes}
-                    </span>
-                  </div>
+                  {!isDenied && (
+                    <div className="panel-field nested__same-font">
+                      <span className="field-title unbold">Earliest start date</span>
+                      <span data-cy="sit-authorized-start-date" className="field-value">
+                        {formatDate4DigitYear(storageInTransit.authorized_start_date)}
+                      </span>
+                    </div>
+                  )}
+
+                  {storageInTransit.authorization_notes && (
+                    <div className="panel-field nested__same-font">
+                      <span className="field-title unbold">Note</span>
+                      <span data-cy="sit-authorization-notes" className="field-value">
+                        {storageInTransit.authorization_notes}
+                      </span>
+                    </div>
+                  )}
+                  {storageInTransit.sit_number && (
+                    <div className="panel-field nested__same-font">
+                      <span className="field-title unbold">SIT Number</span>
+                      <span className="field-value">{storageInTransit.sit_number}</span>
+                    </div>
+                  )}
                 </div>
               )}
 

--- a/src/shared/StorageInTransit/StorageInTransit.jsx
+++ b/src/shared/StorageInTransit/StorageInTransit.jsx
@@ -115,6 +115,7 @@ export class StorageInTransit extends Component {
     const { storageInTransit } = this.props;
     const { showTspEditForm, showOfficeEditForm, showApproveForm, showDenyForm, showPlaceInSitForm } = this.state;
     const isDenied = storageInTransit.status === 'DENIED';
+    const isRequested = storageInTransit.status === 'REQUESTED';
     return (
       <div data-cy="storage-in-transit" className="storage-in-transit">
         <div className="column-head">
@@ -124,7 +125,7 @@ export class StorageInTransit extends Component {
             <span className="sit-status-text" data-cy="sit-status-text">
               Status:
             </span>{' '}
-            {storageInTransit.status === 'REQUESTED' && <SitStatusIcon isTspSite={isTspSite} />}
+            {isRequested && <SitStatusIcon isTspSite={isTspSite} />}
           </span>
           {storageInTransit.status === 'APPROVED' ? (
             <span data-cy="storage-in-transit-status">
@@ -148,7 +149,8 @@ export class StorageInTransit extends Component {
           ) : (
             isOfficeSite &&
             !showOfficeEditForm &&
-            !showDenyForm && (
+            !showDenyForm &&
+            isRequested && (
               <span className="sit-actions">
                 <a className="approve-sit-link" onClick={this.openApproveForm}>
                   <FontAwesomeIcon className="icon" icon={faCheck} />
@@ -164,7 +166,8 @@ export class StorageInTransit extends Component {
           ) : (
             isOfficeSite &&
             !showTspEditForm &&
-            !showApproveForm && (
+            !showApproveForm &&
+            isRequested && (
               <span className="sit-actions">
                 <a className="deny-sit-link" data-cy="deny-sit-link" onClick={this.openDenyForm}>
                   <FontAwesomeIcon className="icon" icon={faBan} />

--- a/src/shared/StorageInTransit/StorageInTransitOfficeDenyForm.jsx
+++ b/src/shared/StorageInTransit/StorageInTransitOfficeDenyForm.jsx
@@ -6,15 +6,10 @@ import { reduxForm } from 'redux-form';
 import { SwaggerField } from 'shared/JsonSchemaForm/JsonSchemaField';
 
 export class StorageInTransitOfficeDenyForm extends Component {
-  //form submission still to be implemented
-  handleSubmit = e => {
-    e.preventDefault();
-  };
-
   render() {
     const { storageInTransitSchema } = this.props;
     return (
-      <form onSubmit={this.handleSubmit} className="storage-in-transit-office-deny-form">
+      <form onSubmit={this.props.handleSubmit(this.props.onSubmit)} className="storage-in-transit-office-deny-form">
         <fieldset key="sit-deny-information">
           <div className="editable-panel-column">
             <SwaggerField
@@ -34,7 +29,7 @@ StorageInTransitOfficeDenyForm.propTypes = {
   storageInTransitSchema: PropTypes.object.isRequired,
 };
 
-const formName = 'storage_in_transit_office_deny_form';
+export const formName = 'storage_in_transit_office_deny_form';
 StorageInTransitOfficeDenyForm = reduxForm({
   form: formName,
   enableReinitialize: true,

--- a/swagger/api.yaml
+++ b/swagger/api.yaml
@@ -3224,7 +3224,7 @@ paths:
           required: true
           description: UUID of storage in transit
         - in: body
-          name: storageInTransitApprovalPayload
+          name: storageInTransitDenyPayload
           required: true
           schema:
             $ref: '#/definitions/StorageInTransitDenialPayload'


### PR DESCRIPTION
## Description

Allows office user to Deny a SIT request from a TSP.
This also does some refactoring of similar forms with unused state.

## Review Notes

Note that I have since changed the "Denied" to black after taking the giphy image
This also removes the 'Approve' and 'Deny' buttons in the Office app when a SIT is not in Requested status (see [thread](https://defensedigitalservice.slack.com/archives/G8HJRJBMZ/p1557441754186400))

## Setup
As office user, go to either SITAPR or SITDEN, go to the storage in transit panel, and click Deny icon and fill out form.

## Code Review Verification Steps

* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/163338392) for this change
* Also delivers [TSP story](https://www.pivotaltracker.com/story/show/164252427) for Denied SIT view
## Screenshots

![SIT Deny](https://user-images.githubusercontent.com/13249580/57484722-9db6b580-725e-11e9-9d3d-206fa61c26b7.gif)


