### PR TITLE
AddressElementEdit shows state/zip on same row in staging (hopefully)

### DIFF
--- a/src/shared/Address/index.jsx
+++ b/src/shared/Address/index.jsx
@@ -47,16 +47,18 @@ export class AddressElementEdit extends Component {
         <SwaggerField fieldName="street_address_1" swagger={this.props.schema} required />
         <SwaggerField fieldName="street_address_2" swagger={this.props.schema} />
         <SwaggerField fieldName="city" swagger={this.props.schema} required />
-        <div className={style['state-zip']}>
-          <div />
-          <SwaggerField className="usa-width-one-half" fieldName="state" swagger={this.props.schema} required />
-          <SwaggerField
-            className="usa-width-one-half"
-            fieldName="postal_code"
-            swagger={this.props.schema}
-            zipPattern={this.props.zipPattern}
-            required
-          />
+        <div className={style['state-zip-container']}>
+          <div className="usa-width-one-half">
+            <SwaggerField fieldName="state" swagger={this.props.schema} required />
+          </div>
+          <div className="usa-width-one-half">
+            <SwaggerField
+              fieldName="postal_code"
+              swagger={this.props.schema}
+              zipPattern={this.props.zipPattern}
+              required
+            />
+          </div>
         </div>
       </FormSection>
     );

--- a/src/shared/Address/index.module.scss
+++ b/src/shared/Address/index.module.scss
@@ -1,9 +1,8 @@
-.state-zip {
+.state-zip-container {
   max-width: 46rem;
-  margin-right: 1.5rem;
 }
 
-.state-zip:after {
+.state-zip-container:after {
   content: " ";
   display: block;
   clear: both;


### PR DESCRIPTION
## Description

Shows state/zip on same row in Code 125 Pre Approval Requests. 

## Reviewer Notes

This is a bit weird, because the issue can't be duplicated on dev. Here's my argument for why this fixes the problem. 

The difference between dev and staging is that, for some reason, src/App/index.css takes precedence over uswds.css on staging, while uswds.css takes precedence on dev. Specifically, we need the margins of usa-width-one-half in uswds.css to override the margins of usa-input in index.css. To accomplish this, we wrap each input in a node that carries the usa-width-one-half classname, ensuring the two objects stay on the same row. Then we adjust other css to make everything look normal. 

## Code Review Verification Steps

* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/165775158) for this change
