### PR TITLE
Add .queue-heading class to decrease queue top margin

### DIFF
--- a/src/scenes/Office/QueueList.jsx
+++ b/src/scenes/Office/QueueList.jsx
@@ -11,7 +11,7 @@ export default class QueueList extends Component {
 
     return (
       <div>
-        <h2>Queues</h2>
+        <h2 className="queue-list-heading">Queues</h2>
         <ul className="usa-sidenav-list">
           <li>
             <NavLink to="/queues/new" activeClassName="usa-current">

--- a/src/scenes/Office/QueueTable.jsx
+++ b/src/scenes/Office/QueueTable.jsx
@@ -96,7 +96,7 @@ class QueueTable extends Component {
             <br />
           </Alert>
         ) : null}
-        <h1>Queue: {titles[this.props.queueType]}</h1>
+        <h1 className="queue-heading">Queue: {titles[this.props.queueType]}</h1>
         <div className="queue-table">
           <ReactTable
             columns={[

--- a/src/scenes/Office/office.scss
+++ b/src/scenes/Office/office.scss
@@ -8,6 +8,14 @@ h5 {
   font-family: $font-stack-primary;
 }
 
+.queue-heading {
+  margin-top: 0;
+}
+
+.queue-list-heading {
+  margin-top: 0.4em;
+}
+
 .queue-table {
   font-size: 0.75em;
   min-width: 1000px;

--- a/src/scenes/TransportationServiceProvider/QueueList.jsx
+++ b/src/scenes/TransportationServiceProvider/QueueList.jsx
@@ -5,7 +5,7 @@ export default class QueueList extends Component {
   render() {
     return (
       <div>
-        <h2>Queues</h2>
+        <h2 class="queue-list-heading">Queues</h2>
         <ul className="usa-sidenav-list">
           <li>
             <NavLink to="/queues/new" activeClassName="usa-current">

--- a/src/scenes/TransportationServiceProvider/QueueTable.jsx
+++ b/src/scenes/TransportationServiceProvider/QueueTable.jsx
@@ -73,7 +73,7 @@ class QueueTable extends Component {
 
     return (
       <div>
-        <h1>Queue: {titles[this.props.queueType]}</h1>
+        <h1 className="queue-heading">Queue: {titles[this.props.queueType]}</h1>
         <div className="queue-table">
           <ReactTable
             columns={[

--- a/src/scenes/TransportationServiceProvider/tsp.css
+++ b/src/scenes/TransportationServiceProvider/tsp.css
@@ -1,3 +1,11 @@
+.queue-heading {
+  margin-top: 0;
+}
+
+.queue-list-heading {
+  margin-top: 0.4em;
+}
+
 .queue-table {
   font-size: 0.75em;
   min-width: 1000px;


### PR DESCRIPTION
## Description

We have too much whitespace at the top of the queues. Let's clean that up a bit!

## Setup

1. `make server_run`
2. `make client_run`
3. Navigate to either the TSP or office queue page

## Code Review Verification Steps

* [ ] User facing changes have been reviewed by design.
* [x] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/165940020) for this change