### PR TITLE
Add missing admin and orders hosts to e2e docker test

### DIFF
--- a/scripts/run-e2e-test-docker
+++ b/scripts/run-e2e-test-docker
@@ -13,6 +13,8 @@ CONTAINER_CYPRESS=cypress
 MILMOVEHOST=milmovelocal
 OFFICEHOST=officelocal
 TSPHOST=tsplocal
+ADMINHOST=adminlocal
+ORDERSHOST=orderslocal
 
 # Change the port for tests
 HTTP_PORT=4000
@@ -58,6 +60,10 @@ $DOCKER_RUN \
   -e HERE_MAPS_GEOCODE_ENDPOINT \
   -e HERE_MAPS_ROUTING_ENDPOINT \
   -e HTTP_MY_SERVER_NAME="${MILMOVEHOST}" \
+  -e HTTP_OFFICE_SERVER_NAME="${OFFICEHOST}" \
+  -e HTTP_TSP_SERVER_NAME="${TSPHOST}" \
+  -e HTTP_ADMIN_SERVER_NAME="${ADMINHOST}" \
+  -e HTTP_ORDERS_SERVER_NAME="${ORDERSHOST}" \
   -e IWS_RBS_HOST \
   -e LOGIN_GOV_CALLBACK_PORT="${HTTP_PORT}" \
   -e LOGIN_GOV_CALLBACK_PROTOCOL \
@@ -106,6 +112,7 @@ $DOCKER_RUN \
   --add-host ${MILMOVEHOST}:"${E2E_IP}" \
   --add-host ${OFFICEHOST}:"${E2E_IP}" \
   --add-host ${TSPHOST}:"${E2E_IP}" \
+  --add-host ${ADMINHOST}:"${E2E_IP}" \
   --name="${CONTAINER_CYPRESS}" \
   --link="${CONTAINER}" \
   --ipc=host \


### PR DESCRIPTION
## Description

I need to add some extra vars to the e2e tests in support of #2081.  While I was at it I added the Admin and Orders hosts to the tests to support future tests.

## Setup

```sh
make e2e_test_docker
```

## Code Review Verification Steps

* [x] Request review from a member of a different team.