### PR TITLE
Add single click handler for queue rows

### DIFF
--- a/cypress/integration/office/homepage.js
+++ b/cypress/integration/office/homepage.js
@@ -19,6 +19,12 @@ describe('Office Home Page', function() {
     cy.signIntoOffice();
     officeAllMoves();
   });
+  it('office user can use a single click to view move info', function() {
+    cy.waitForReactTableLoad();
+
+    cy.get('[data-cy=queueTableRow]:first').click();
+    cy.url().should('include', '/moves/');
+  });
 });
 
 function officeUserIsOnSignInPage() {

--- a/src/scenes/Office/QueueTable.jsx
+++ b/src/scenes/Office/QueueTable.jsx
@@ -182,6 +182,7 @@ class QueueTable extends Component {
             className="-striped -highlight"
             showPagination={false}
             getTrProps={(state, rowInfo) => ({
+              'data-cy': 'queueTableRow',
               onDoubleClick: _ => this.openMove(rowInfo),
               onClick: _ => this.openMove(rowInfo),
             })}

--- a/src/scenes/Office/QueueTable.jsx
+++ b/src/scenes/Office/QueueTable.jsx
@@ -30,6 +30,12 @@ class QueueTable extends Component {
     }
   }
 
+  openMove(rowInfo) {
+    this.props.history.push(`new/moves/${rowInfo.original.id}`, {
+      referrerPathname: this.props.history.location.pathname,
+    });
+  }
+
   static defaultProps = {
     moveLocator: '',
     firstName: '',
@@ -176,10 +182,8 @@ class QueueTable extends Component {
             className="-striped -highlight"
             showPagination={false}
             getTrProps={(state, rowInfo) => ({
-              onDoubleClick: e =>
-                this.props.history.push(`new/moves/${rowInfo.original.id}`, {
-                  referrerPathname: this.props.history.location.pathname,
-                }),
+              onDoubleClick: _ => this.openMove(rowInfo),
+              onClick: _ => this.openMove(rowInfo),
             })}
           />
         </div>

--- a/src/scenes/Office/office.scss
+++ b/src/scenes/Office/office.scss
@@ -60,6 +60,10 @@ h5 {
   text-align: left;
 }
 
+.rt-tr-group {
+  cursor: pointer;
+}
+
 /* Use with .usa-grid for a liquid and nearly full-width grid layout. */
 .grid-wide {
   max-width: 2000px;


### PR DESCRIPTION
## Description

As office user
I want to open moves on single clicks
So that I don't have to figure out double click

## Reviewer Notes

The ticket says to keep the double click behavior for now, but a user will never get the chance to double click now that we have the single click handler in place. Still worth leaving in?

## Setup

1. `make server_run`
2. `make client_run`
3. Navigate to the office app and click on a move

## Code Review Verification Steps

* [x] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/n/projects/2136867#) for this change