### PR TITLE
Remove Submit Date from Shipment, use Book Date instead

### DIFF
--- a/migrations/20190510210938_remove_submit_date_shipments.up.fizz
+++ b/migrations/20190510210938_remove_submit_date_shipments.up.fizz
@@ -1,0 +1,3 @@
+drop_column("shipments", "submit_date")
+
+sql("ALTER TABLE shipments ALTER COLUMN book_date TYPE timestamptz USING book_date AT TIME ZONE 'UTC';")

--- a/pkg/models/shipment.go
+++ b/pkg/models/shipment.go
@@ -96,7 +96,6 @@ type Shipment struct {
 	OriginalDeliveryDate *time.Time `json:"original_delivery_date" db:"original_delivery_date"` // when shipment is to be delivered
 	OriginalPackDate     *time.Time `json:"original_pack_date" db:"original_pack_date"`         // when packing is to begin
 	ApproveDate          *time.Time `json:"approve_date" db:"approve_date"`                     // when shipment is approved by office user
-	SubmitDate           *time.Time `json:"submit_date" db:"submit_date"`                       // when shipment was submitted by SM
 
 	// calculated durations
 	EstimatedPackDays    *int64 `json:"estimated_pack_days" db:"estimated_pack_days"`       // how many days it will take to pack
@@ -260,9 +259,7 @@ func (s *Shipment) Submit(hhgSubmitDate time.Time) error {
 	if s.Status != ShipmentStatusDRAFT {
 		return errors.Wrap(ErrInvalidTransition, "Submit")
 	}
-	now := time.Now()
-	s.BookDate = &now
-	s.SubmitDate = &hhgSubmitDate
+	s.BookDate = &hhgSubmitDate
 	s.Status = ShipmentStatusSUBMITTED
 	return nil
 }

--- a/pkg/models/transportation_service_provider_performance.go
+++ b/pkg/models/transportation_service_provider_performance.go
@@ -125,7 +125,7 @@ func NextTSPPerformanceInQualityBand(tx *pop.Connection, tdlID uuid.UUID,
 		`
 
 	tspp := TransportationServiceProviderPerformance{}
-	err := tx.RawQuery(sql, tdlID, qualityBand, bookDate, requestedPickupDate).First(&tspp)
+	err := tx.RawQuery(sql, tdlID, qualityBand, bookDate.UTC(), requestedPickupDate).First(&tspp)
 
 	return tspp, err
 }

--- a/pkg/rateengine/linehaul.go
+++ b/pkg/rateengine/linehaul.go
@@ -121,7 +121,7 @@ func (re *RateEngine) fuelSurchargeComputation(totalLinehaulCost unit.Cents, boo
 	fuelEIADieselPriceSlice := []models.FuelEIADieselPrice{}
 
 	// Changing the format of the date to remove the time portion so it plays nicely with db
-	bookDateString := bookDate.Format("2006-01-02")
+	bookDateString := bookDate.UTC().Format("2006-01-02")
 
 	query := re.db.Where("rate_start_date <= ?", bookDateString).Where("rate_end_date >= ?", bookDateString)
 	err1 := query.All(&fuelEIADieselPriceSlice)


### PR DESCRIPTION
## Description

A previous PR added a Submit Date field (with timezone) to shipments table to be used in queues. This removes that in favor of the existing Book Date field, which is modified to include info about timezones. 

## Code Review Verification Steps

* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/tree/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/tree/master/docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
  * [ ] Secure migrations have been tested using `scripts/run-prod-migrations`
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] Request review from a member of a different team.