### PR TITLE
Add weight ticket uploader to PPM payment request Weight ticket page

### DIFF
--- a/src/scenes/Moves/Ppm/WeightTicket.jsx
+++ b/src/scenes/Moves/Ppm/WeightTicket.jsx
@@ -44,7 +44,7 @@ class WeightTicket extends Component {
           />
           {this.state.value !== '' && (
             <div className="uploader-box">
-              <Uploader options={{ allowMultiple: false, labelIdle: this.labelIdle }} />
+              <Uploader options={{ allowMultiple: false, labelIdle: this.labelIdle, allowReplace: false }} />
             </div>
           )}
           <SwaggerField fieldName="vehicle_nickname" swagger={schema} required />

--- a/src/scenes/Moves/Ppm/WeightTicket.jsx
+++ b/src/scenes/Moves/Ppm/WeightTicket.jsx
@@ -44,7 +44,7 @@ class WeightTicket extends Component {
           />
           {this.state.value !== '' && (
             <div className="uploader-box">
-              <Uploader options={{ allowMultiple: false, labelIdle: this.labelIdle, allowReplace: false }} />
+              <Uploader options={{ allowMultiple: true, labelIdle: this.labelIdle }} />
             </div>
           )}
           <SwaggerField fieldName="vehicle_nickname" swagger={schema} required />

--- a/src/scenes/Moves/Ppm/WeightTicket.jsx
+++ b/src/scenes/Moves/Ppm/WeightTicket.jsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React, { Component, Fragment } from 'react';
 import { reduxForm } from 'redux-form';
 import { connect } from 'react-redux';
 import { get } from 'lodash';
@@ -8,31 +8,54 @@ import WizardHeader from '../WizardHeader';
 import { ProgressTimeline, ProgressTimelineStep } from 'shared/ProgressTimeline';
 import { SwaggerField } from 'shared/JsonSchemaForm/JsonSchemaField';
 import './PPMPaymentRequest.css';
+import Uploader from 'shared/Uploader';
 
-let WeightTicket = props => {
-  const { schema } = props;
-  return (
-    <Fragment>
-      <WizardHeader
-        title="Weight tickets"
-        right={
-          <ProgressTimeline>
-            <ProgressTimelineStep name="Weight" current />
-            <ProgressTimelineStep name="Expenses" />
-            <ProgressTimelineStep name="Review" />
-          </ProgressTimeline>
-        }
-      />
-      <div className="usa-grid">
-        <SwaggerField fieldName="vehicle_options" swagger={schema} required />
-        <SwaggerField fieldName="vehicle_nickname" swagger={schema} required />
+class WeightTicket extends Component {
+  state = {
+    value: '',
+  };
+  labelIdle = 'Drag & drop or <span class="filepond--label-action">click to upload upload empty weight ticket</span>';
 
-        {/* TODO: change onclick handler to go to next page in flow */}
-        <PPMPaymentRequestActionBtns onClick={() => {}} nextBtnLabel="Save & Add Another" />
-      </div>
-    </Fragment>
-  );
-};
+  handleChange = event => {
+    this.setState({ value: event.target.value });
+  };
+
+  render() {
+    const { schema } = this.props;
+    return (
+      <Fragment>
+        <WizardHeader
+          title="Weight tickets"
+          right={
+            <ProgressTimeline>
+              <ProgressTimelineStep name="Weight" current />
+              <ProgressTimelineStep name="Expenses" />
+              <ProgressTimelineStep name="Review" />
+            </ProgressTimeline>
+          }
+        />
+        <div className="usa-grid">
+          <SwaggerField
+            fieldName="vehicle_options"
+            swagger={schema}
+            onChange={this.handleChange}
+            value={this.state.value}
+            required
+          />
+          {this.state.value !== '' && (
+            <div className="uploader-box">
+              <Uploader options={{ allowMultiple: false, labelIdle: this.labelIdle }} />
+            </div>
+          )}
+          <SwaggerField fieldName="vehicle_nickname" swagger={schema} required />
+
+          {/* TODO: change onclick handler to go to next page in flow */}
+          <PPMPaymentRequestActionBtns onClick={() => {}} nextBtnLabel="Save & Add Another" />
+        </div>
+      </Fragment>
+    );
+  }
+}
 
 const formName = 'weight_ticket_wizard';
 WeightTicket = reduxForm({

--- a/src/scenes/Orders/UploadOrders.jsx
+++ b/src/scenes/Orders/UploadOrders.jsx
@@ -74,7 +74,11 @@ export class UploadOrders extends Component {
         )}
         {currentOrders && (
           <div className="uploader-box">
-            <Uploader document={currentOrders.uploaded_orders} onChange={this.onChange} labelIdle={uploaderLabelIdle} />
+            <Uploader
+              document={currentOrders.uploaded_orders}
+              onChange={this.onChange}
+              options={{ labelIdle: uploaderLabelIdle }}
+            />
             <div className="hint">(Each page must be clear and legible)</div>
           </div>
         )}

--- a/src/scenes/Review/EditOrders.jsx
+++ b/src/scenes/Review/EditOrders.jsx
@@ -63,7 +63,11 @@ let EditOrdersForm = props => {
       <p>Uploads:</p>
       {Boolean(visibleUploads.length) && <UploadsTable uploads={visibleUploads} onDelete={onDelete} />}
       {Boolean(get(initialValues, 'uploaded_orders')) && (
-        <Uploader document={initialValues.uploaded_orders} onChange={onUpload} labelIdle={uploaderLabelIdle} />
+        <Uploader
+          document={initialValues.uploaded_orders}
+          onChange={onUpload}
+          options={{ labelIdle: uploaderLabelIdle }}
+        />
       )}
       <SaveCancelButtons valid={valid} submitting={submitting} />
     </form>

--- a/src/shared/Uploader/index.jsx
+++ b/src/shared/Uploader/index.jsx
@@ -67,48 +67,6 @@ export class Uploader extends Component {
     return isIdle;
   }
 
-  handlePondInit() {
-    // If this component is unloaded quickly, this function can be called after the ref is deleted,
-    // so check that the ref still exists before continuing
-    if (!this.pond) {
-      return;
-    }
-
-    const { labelIdle } = this.props;
-    this.pond._pond.setOptions({
-      allowMultiple: true,
-      server: {
-        url: '/',
-        process: this.processFile,
-        revert: this.revertFile,
-      },
-      iconUndo: this.pond._pond.iconRemove,
-      imagePreviewMaxHeight: 100,
-      labelIdle: labelIdle || 'Drag & drop or <span class="filepond--label-action">click to upload</span>',
-      labelTapToUndo: 'tap to delete',
-      acceptedFileTypes: ['image/jpeg', 'image/png', 'application/pdf'],
-    });
-
-    this.pond._pond.on('processfile', e => {
-      if (this.props.onChange) {
-        this.props.onChange(this.state.files, this.isIdle());
-      }
-    });
-
-    this.pond._pond.on('addfilestart', e => {
-      if (this.props.onAddFile) {
-        this.props.onAddFile();
-      }
-    });
-
-    // Don't mention drag and drop if on mobile device
-    if (isMobile()) {
-      this.pond._pond.setOptions({
-        labelIdle: '<span class="filepond--label-action">Upload</span>',
-      });
-    }
-  }
-
   processFile = (fieldName, file, metadata, load, error, progress, abort) => {
     const { document, isPublic } = this.props;
     const self = this;
@@ -141,6 +99,52 @@ export class Uploader extends Component {
       })
       .catch(error);
   };
+
+  handlePondInit() {
+    // If this component is unloaded quickly, this function can be called after the ref is deleted,
+    // so check that the ref still exists before continuing
+    if (!this.pond) {
+      return;
+    }
+    this.setPondOptions();
+
+    this.pond._pond.on('processfile', e => {
+      if (this.props.onChange) {
+        this.props.onChange(this.state.files, this.isIdle());
+      }
+    });
+
+    this.pond._pond.on('addfilestart', e => {
+      if (this.props.onAddFile) {
+        this.props.onAddFile();
+      }
+    });
+
+    // Don't mention drag and drop if on mobile device
+    if (isMobile()) {
+      this.pond._pond.setOptions({
+        labelIdle: '<span class="filepond--label-action">Upload</span>',
+      });
+    }
+  }
+
+  setPondOptions() {
+    const { options } = this.props;
+    const defaultOptions = {
+      allowMultiple: true,
+      server: {
+        url: '/',
+        process: this.processFile,
+        revert: this.revertFile,
+      },
+      iconUndo: this.pond._pond.iconRemove,
+      imagePreviewMaxHeight: 100,
+      labelIdle: 'Drag & drop or <span class="filepond--label-action">click to upload</span>',
+      labelTapToUndo: 'tap to delete',
+      acceptedFileTypes: ['image/jpeg', 'image/png', 'application/pdf'],
+    };
+    this.pond._pond.setOptions({ ...defaultOptions, ...options });
+  }
 
   render() {
     return (

--- a/src/shared/Uploader/index.jsx
+++ b/src/shared/Uploader/index.jsx
@@ -67,6 +67,34 @@ export class Uploader extends Component {
     return isIdle;
   }
 
+  handlePondInit() {
+    // If this component is unloaded quickly, this function can be called after the ref is deleted,
+    // so check that the ref still exists before continuing
+    if (!this.pond) {
+      return;
+    }
+    this.setPondOptions();
+
+    this.pond._pond.on('processfile', e => {
+      if (this.props.onChange) {
+        this.props.onChange(this.state.files, this.isIdle());
+      }
+    });
+
+    this.pond._pond.on('addfilestart', e => {
+      if (this.props.onAddFile) {
+        this.props.onAddFile();
+      }
+    });
+
+    // Don't mention drag and drop if on mobile device
+    if (isMobile()) {
+      this.pond._pond.setOptions({
+        labelIdle: '<span class="filepond--label-action">Upload</span>',
+      });
+    }
+  }
+
   processFile = (fieldName, file, metadata, load, error, progress, abort) => {
     const { document, isPublic } = this.props;
     const self = this;
@@ -99,34 +127,6 @@ export class Uploader extends Component {
       })
       .catch(error);
   };
-
-  handlePondInit() {
-    // If this component is unloaded quickly, this function can be called after the ref is deleted,
-    // so check that the ref still exists before continuing
-    if (!this.pond) {
-      return;
-    }
-    this.setPondOptions();
-
-    this.pond._pond.on('processfile', e => {
-      if (this.props.onChange) {
-        this.props.onChange(this.state.files, this.isIdle());
-      }
-    });
-
-    this.pond._pond.on('addfilestart', e => {
-      if (this.props.onAddFile) {
-        this.props.onAddFile();
-      }
-    });
-
-    // Don't mention drag and drop if on mobile device
-    if (isMobile()) {
-      this.pond._pond.setOptions({
-        labelIdle: '<span class="filepond--label-action">Upload</span>',
-      });
-    }
-  }
 
   setPondOptions() {
     const { options } = this.props;


### PR DESCRIPTION
## Description

For the new PPM closeout, allow service members to upload weight tickets. 

_Note this PR only adds the uploader to the component. [Pivotal story](https://www.pivotaltracker.com/n/projects/2181745/stories/164718824) is updating the layout and will include the uploader in the appropriate place on the page._

## Reviewer Notes

One of the requirements of the story was to disallow multiple uploads. This option was hardcoded in `handlePondInit()` within `Uploader/index.jsx`. So updated `Uploader` to allow for options to be passed  when we want to override the defaults.

## \*\*\*\*\*\*\*Edit\*\*\*\*\*\*\*

**_In the design review it was decided that we do want to be able to handle multiple uploads for weight tickets afterall. I still think that it makes sense to leave the modifications to the Uploader in, since it will allow us more flexibility to toggle its various options in the future._**

## Setup

1) Login to `milmove` as a user ready to request a ppm payment
2) Click "Request Payment" and complete the ppm payment request (make note of the move locator)
3) Proceed to the Weight Tickets page
4) Choose a vehicle type and then upload a weight ticket

```sh
make e2e_test
```

## Code Review Verification Steps
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/n/projects/2181745/stories/164719011) for this change

