### PR TITLE
Add refresh button to office queue

### DIFF
--- a/src/scenes/Office/QueueTable.jsx
+++ b/src/scenes/Office/QueueTable.jsx
@@ -112,12 +112,6 @@ class QueueTable extends Component {
       }
     });
 
-    let refreshIconClassList = ['refresh'];
-
-    if (this.state.refreshing) {
-      refreshIconClassList.push('focused');
-    }
-
     return (
       <div>
         {this.props.showFlashMessage ? (
@@ -128,7 +122,7 @@ class QueueTable extends Component {
         ) : null}
         <h1 className="queue-heading">Queue: {titles[this.props.queueType]}</h1>
         <div className="queue-table">
-          <span className={refreshIconClassList.join(' ')} title="Refresh" aria-label="Refresh">
+          <span className={'refresh' + (this.state.refreshing ? ' focused' : '')} title="Refresh" aria-label="Refresh">
             <FontAwesomeIcon
               data-cy="refreshQueue"
               className="link-blue"

--- a/src/scenes/Office/QueueTable.jsx
+++ b/src/scenes/Office/QueueTable.jsx
@@ -8,6 +8,7 @@ import Alert from 'shared/Alert';
 import { formatDate, formatDateTimeWithTZ } from 'shared/formatters';
 import FontAwesomeIcon from '@fortawesome/react-fontawesome';
 import faClock from '@fortawesome/fontawesome-free-solid/faClock';
+import faSyncAlt from '@fortawesome/fontawesome-free-solid/faSyncAlt';
 
 class QueueTable extends Component {
   constructor() {
@@ -16,6 +17,7 @@ class QueueTable extends Component {
       data: [],
       pages: null,
       loading: true,
+      refreshing: false, // only true when the user clicks the refresh button
     };
     this.fetchData = this.fetchData.bind(this);
   }
@@ -63,6 +65,7 @@ class QueueTable extends Component {
           data: body,
           pages: 1,
           loading: false,
+          refreshing: false,
         });
       }
     } catch (e) {
@@ -70,8 +73,17 @@ class QueueTable extends Component {
         data: [],
         pages: 1,
         loading: false,
+        refreshing: false,
       });
     }
+  }
+
+  refresh() {
+    this.setState({
+      refreshing: true,
+    });
+
+    this.fetchData();
   }
 
   render() {
@@ -100,6 +112,12 @@ class QueueTable extends Component {
       }
     });
 
+    let refreshIconClassList = ['refresh'];
+
+    if (this.state.refreshing) {
+      refreshIconClassList.push('focused');
+    }
+
     return (
       <div>
         {this.props.showFlashMessage ? (
@@ -110,6 +128,17 @@ class QueueTable extends Component {
         ) : null}
         <h1 className="queue-heading">Queue: {titles[this.props.queueType]}</h1>
         <div className="queue-table">
+          <span className={refreshIconClassList.join(' ')} title="Refresh" aria-label="Refresh">
+            <FontAwesomeIcon
+              data-cy="refreshQueue"
+              className="link-blue"
+              icon={faSyncAlt}
+              onClick={this.refresh.bind(this)}
+              color="blue"
+              size="lg"
+              spin={!this.state.refreshing && this.state.loading}
+            />
+          </span>
           <ReactTable
             columns={[
               {

--- a/src/scenes/Office/QueueTable.test.js
+++ b/src/scenes/Office/QueueTable.test.js
@@ -78,6 +78,28 @@ describe('Shipments column', () => {
   });
 });
 
+describe('Refreshing', () => {
+  let wrapper;
+  it('loads the data again', done => {
+    const refreshSpy = jest.spyOn(QueueTable.WrappedComponent.prototype, 'refresh');
+    const fetchDataSpy = jest.spyOn(QueueTable.WrappedComponent.prototype, 'fetchData');
+
+    wrapper = mountComponents(retrieveMovesStub());
+
+    wrapper
+      .find('[data-cy="refreshQueue"]')
+      .at(0)
+      .simulate('click');
+
+    setTimeout(() => {
+      expect(refreshSpy).toHaveBeenCalled();
+      expect(fetchDataSpy).toHaveBeenCalled();
+
+      done();
+    });
+  });
+});
+
 function retrieveMovesStub(params) {
   // This is meant as a stub that will act in place of
   // `RetrieveMovesForOffice` from Office/api.js

--- a/src/scenes/Office/office.scss
+++ b/src/scenes/Office/office.scss
@@ -444,3 +444,15 @@ head .panel-subhead {
   white-space: normal;
   word-wrap: break-word;
 }
+
+.refresh {
+  display: inline-block;
+  cursor: pointer;
+  margin-bottom: 0.3em;
+  padding: 0.3em 0;
+  border: 1px solid white;
+
+  &.focused {
+    border: 1px dashed gray;
+  }
+}


### PR DESCRIPTION
## Description

As office user
I want to be able to refresh my queue
So that I see latest information without reloading whole application

## Setup

1. `make server_run`
2. `make client_run`

## Code Review Verification Steps

* [x] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [x] User facing changes have been reviewed by design.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/165770552) for this change

## Screenshots

![refresh_queue](https://user-images.githubusercontent.com/3522323/57729834-bfe47500-765c-11e9-890a-bd0454fb6b9a.gif)

