### PR TITLE
TSP can see remaining/used days in SIT

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "mocha": "^5.2.0",
     "mocha-junit-reporter": "^1.18.0",
     "mocha-multi-reporters": "^1.1.7",
+    "mockdate": "^2.0.2",
     "prettier": "=1.12.1",
     "react-mock-router": "^1.0.15"
   },

--- a/src/shared/StorageInTransit/StorageInTransit.jsx
+++ b/src/shared/StorageInTransit/StorageInTransit.jsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { capitalize } from 'lodash';
+import moment from 'moment';
 
 import FontAwesomeIcon from '@fortawesome/react-fontawesome';
 import faPencil from '@fortawesome/fontawesome-free-solid/faPencilAlt';
@@ -21,6 +22,7 @@ import PlaceInSit from 'shared/StorageInTransit/PlaceInSit';
 import { updateStorageInTransit } from 'shared/Entities/modules/storageInTransits';
 import { isOfficeSite, isTspSite } from 'shared/constants';
 import SitStatusIcon from './SitStatusIcon';
+import { sitDaysUsed } from 'shared/StorageInTransit/calculator';
 
 export class StorageInTransit extends Component {
   constructor() {
@@ -112,11 +114,15 @@ export class StorageInTransit extends Component {
   };
 
   render() {
-    const { storageInTransit } = this.props;
+    const { storageInTransit, daysRemaining } = this.props;
     const { showTspEditForm, showOfficeEditForm, showApproveForm, showDenyForm, showPlaceInSitForm } = this.state;
     const isDenied = storageInTransit.status === 'DENIED';
     const isRequested = storageInTransit.status === 'REQUESTED';
     const isApproved = storageInTransit.status === 'APPROVED';
+    const isInSit = storageInTransit.status === 'IN_SIT';
+
+    const daysUsed = sitDaysUsed(storageInTransit);
+
     return (
       <div data-cy="storage-in-transit" className="storage-in-transit">
         <div className="column-head">
@@ -138,8 +144,8 @@ export class StorageInTransit extends Component {
               <FontAwesomeIcon className="icon approval-problem" icon={faBan} />
               Denied
             </span>
-          ) : storageInTransit.status === 'IN_SIT' ? (
-            <span>In SIT</span>
+          ) : isInSit ? (
+            <span>In SIT{daysRemaining < 0 ? ' - SIT Expired' : ''}</span>
           ) : (
             <span>SIT {capitalize(storageInTransit.status)}</span>
           )}
@@ -200,7 +206,7 @@ export class StorageInTransit extends Component {
             />
           ) : (
             isTspSite &&
-            storageInTransit.status !== 'APPROVED' &&
+            !isApproved &&
             !isDenied && (
               <span className="sit-actions">
                 <span className="sit-edit actionable">
@@ -244,9 +250,25 @@ export class StorageInTransit extends Component {
                   <span className="field-value">{formatDate4DigitYear(storageInTransit.estimated_start_date)}</span>
                 </div>
                 {storageInTransit.actual_start_date && (
-                  <div className="panel-field nested__same-font">
-                    <span className="field-title unbold">Actual start date</span>
-                    <span className="field-value">{formatDate4DigitYear(storageInTransit.actual_start_date)}</span>
+                  <div>
+                    <div className="panel-field nested__same-font">
+                      <span className="field-title unbold">Actual start date</span>
+                      <span className="field-value">{formatDate4DigitYear(storageInTransit.actual_start_date)}</span>
+                    </div>
+                    <div className="panel-field nested__same-font">
+                      <span className="field-title unbold">Days used</span>
+                      <span className="field-value">{daysUsed} days</span>
+                    </div>
+                    <div className="panel-field nested__same-font">
+                      <span className="field-title unbold">Expires</span>
+                      <span className="field-value">
+                        {isInSit
+                          ? formatDate4DigitYear(
+                              moment(storageInTransit.actual_start_date).add(daysRemaining + daysUsed, 'days'),
+                            )
+                          : 'na'}
+                      </span>
+                    </div>
                   </div>
                 )}
               </div>
@@ -337,6 +359,7 @@ export class StorageInTransit extends Component {
 
 StorageInTransit.propTypes = {
   storageInTransit: PropTypes.object.isRequired,
+  daysRemaining: PropTypes.number,
 };
 
 function mapDispatchToProps(dispatch) {

--- a/src/shared/StorageInTransit/StorageInTransit.jsx
+++ b/src/shared/StorageInTransit/StorageInTransit.jsx
@@ -257,11 +257,13 @@ export class StorageInTransit extends Component {
                     </div>
                     <div className="panel-field nested__same-font">
                       <span className="field-title unbold">Days used</span>
-                      <span className="field-value">{daysUsed} days</span>
+                      <span data-cy="sit-days-used" className="field-value">
+                        {daysUsed} days
+                      </span>
                     </div>
                     <div className="panel-field nested__same-font">
                       <span className="field-title unbold">Expires</span>
-                      <span className="field-value">
+                      <span data-cy="sit-expires" className="field-value">
                         {isInSit
                           ? formatDate4DigitYear(
                               moment(storageInTransit.actual_start_date).add(daysRemaining + daysUsed, 'days'),

--- a/src/shared/StorageInTransit/StorageInTransitPanel.jsx
+++ b/src/shared/StorageInTransit/StorageInTransitPanel.jsx
@@ -16,6 +16,7 @@ import { calculateEntitlementsForMove } from 'shared/Entities/modules/moves';
 
 import { isTspSite } from 'shared/constants.js';
 import SitStatusIcon from './SitStatusIcon';
+import { sitTotalDaysUsed } from 'shared/StorageInTransit/calculator';
 
 export class StorageInTransitPanel extends Component {
   constructor() {
@@ -42,9 +43,9 @@ export class StorageInTransitPanel extends Component {
   render() {
     const { storageInTransitEntitlement, storageInTransits } = this.props;
     const { error, isCreatorActionable } = this.state;
-    const daysUsed = 0; // placeholder
-    const daysRemaining = storageInTransitEntitlement - daysUsed;
     const hasRequestedSIT = some(storageInTransits, sit => sit.status === 'REQUESTED');
+    const hasInSIT = some(storageInTransits, sit => sit.status === 'IN_SIT');
+    const daysRemaining = storageInTransitEntitlement - sitTotalDaysUsed(storageInTransits);
 
     return (
       <div className="storage-in-transit-panel" data-cy="storage-in-transit-panel">
@@ -58,11 +59,18 @@ export class StorageInTransitPanel extends Component {
             </Alert>
           )}
           <div className="column-head">
-            Entitlement: {storageInTransitEntitlement} days <span className="unbold">({daysRemaining} remaining)</span>
+            Entitlement: {storageInTransitEntitlement} days
+            {hasInSIT && <span className="unbold"> ({daysRemaining} remaining)</span>}
           </div>
           {storageInTransits !== undefined &&
             storageInTransits.map(storageInTransit => {
-              return <StorageInTransit key={storageInTransit.id} storageInTransit={storageInTransit} />;
+              return (
+                <StorageInTransit
+                  key={storageInTransit.id}
+                  storageInTransit={storageInTransit}
+                  daysRemaining={daysRemaining}
+                />
+              );
             })}
           {isCreatorActionable &&
             isTspSite && <Creator onFormActivation={this.onFormActivation} saveStorageInTransit={this.onSubmit} />}

--- a/src/shared/StorageInTransit/calculator.js
+++ b/src/shared/StorageInTransit/calculator.js
@@ -1,0 +1,41 @@
+import moment from 'moment';
+
+// Calculate the total days used by an array of SITs.
+export function sitTotalDaysUsed(storageInTransits) {
+  if (!storageInTransits) {
+    return 0;
+  }
+
+  return storageInTransits.reduce((totalDays, storageInTransit) => {
+    return totalDays + sitDaysUsed(storageInTransit);
+  }, 0);
+}
+
+// Calculate the days used by a single SIT.
+export function sitDaysUsed(storageInTransit) {
+  if (!storageInTransit || !storageInTransit.actual_start_date) {
+    return 0;
+  }
+
+  const today = moment(); // TODO: What about the time zone? These moments are all local time.
+
+  const startDate = moment(storageInTransit.actual_start_date);
+
+  let sitDays = 0;
+  switch (storageInTransit.status) {
+    case 'IN_SIT':
+      sitDays = today.diff(startDate, 'days') + 1;
+      break;
+    case 'RELEASED':
+    case 'DELIVERED':
+      if (storageInTransit.out_date) {
+        const outDate = moment(storageInTransit.out_date);
+        sitDays = outDate.diff(startDate, 'days') + 1;
+      }
+      break;
+    default:
+      sitDays = 0;
+  }
+
+  return sitDays > 0 ? sitDays : 0;
+}

--- a/src/shared/StorageInTransit/calculator.test.js
+++ b/src/shared/StorageInTransit/calculator.test.js
@@ -1,0 +1,88 @@
+import { sitTotalDaysUsed, sitDaysUsed } from './calculator';
+import MockDate from 'mockdate';
+
+const requestedStorageInTransit = {
+  status: 'REQUESTED',
+  location: 'DESTINATION',
+  estimated_start_date: '2019-05-15',
+};
+
+const inSitStorageInTransit = {
+  status: 'IN_SIT',
+  location: 'DESTINATION',
+  estimated_start_date: '2019-05-10',
+  authorized_start_date: '2019-05-10',
+  actual_start_date: '2019-05-10',
+};
+
+const releasedStorageInTransit = {
+  status: 'RELEASED',
+  location: 'ORIGIN',
+  estimated_start_date: '2019-05-07',
+  authorized_start_date: '2019-05-07',
+  actual_start_date: '2019-05-07',
+  out_date: '2019-05-11',
+};
+
+const deliveredStorageInTransit = {
+  status: 'DELIVERED',
+  location: 'ORIGIN',
+  estimated_start_date: '2019-05-02',
+  authorized_start_date: '2019-05-03',
+  actual_start_date: '2019-05-03',
+  out_date: '2019-05-14',
+};
+
+const inSitFutureDateStorageInTransit = {
+  status: 'IN_SIT',
+  location: 'DESTINATION',
+  estimated_start_date: '2019-05-10',
+  authorized_start_date: '2019-05-10',
+  actual_start_date: '2019-05-20',
+};
+
+describe('SIT calculator', () => {
+  beforeAll(() => {
+    MockDate.set('2019-05-12');
+  });
+
+  afterAll(() => MockDate.reset());
+
+  describe('calculate SIT days used', () => {
+    it('requested SIT', () => {
+      expect(sitDaysUsed(requestedStorageInTransit)).toEqual(0);
+    });
+
+    it('in SIT', () => {
+      expect(sitDaysUsed(inSitStorageInTransit)).toEqual(3);
+    });
+
+    it('released SIT', () => {
+      expect(sitDaysUsed(releasedStorageInTransit)).toEqual(5);
+    });
+
+    it('delivered SIT', () => {
+      expect(sitDaysUsed(deliveredStorageInTransit)).toEqual(12);
+    });
+
+    it('start date after today', () => {
+      expect(sitDaysUsed(inSitFutureDateStorageInTransit)).toEqual(0);
+    });
+  });
+
+  describe('calculate total SIT days used', () => {
+    it('all SIT records', () => {
+      const all = [
+        requestedStorageInTransit,
+        inSitStorageInTransit,
+        releasedStorageInTransit,
+        deliveredStorageInTransit,
+      ];
+      expect(sitTotalDaysUsed(all)).toEqual(20);
+    });
+
+    it('empty array', () => {
+      expect(sitTotalDaysUsed([])).toEqual(0);
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -8301,6 +8301,11 @@ mocha@^5.2.0:
     mkdirp "0.5.1"
     supports-color "5.4.0"
 
+mockdate@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/mockdate/-/mockdate-2.0.2.tgz#5ae0c0eaf8fe23e009cd01f9889b42c4f634af12"
+  integrity sha1-WuDA6vj+I+AJzQH5iJtCxPY0rxI=
+
 module-deps@^4.0.8:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/module-deps/-/module-deps-4.1.1.tgz#23215833f1da13fd606ccb8087b44852dcb821fd"


### PR DESCRIPTION
## Description

This PR calculates the remaining days in SIT for all the SIT requests for a shipment.  It also notes the days used and the expiration date for each individual SIT request.

## Reviewer Notes

I had to add mock clocks for both the client tests and the E2E tests since the values for the remaining and used days are dependent upon the current time.

## Setup

`make db_dev_e2e_populate`
`make server_run`
`make tsp_client_run`

Add one or more SIT requests to an existing shipment such as `BACON1`.  For at least one of the SIT requests, use the office app (`make office_client_run`) to approve it.  Then, use the TSP app to place it into SIT.  Once you have a shipment placed in SIT, you should see the `Entitlement` header show a remaining days, as well as `Days used` and `Expires` fields for the SIT request that's been placed into SIT.

If you place an item into SIT with an actual start date that's way in the past, you can also see that a negative number of days shows up as remaining, and the SIT's status changes to `In SIT - SIT Expired`.

## Code Review Verification Steps

* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/163340895) for this change

## Screenshots

![Screen Shot 2019-05-15 at 2 00 31 PM](https://user-images.githubusercontent.com/4960757/57814804-e1b82780-7742-11e9-98bb-4d7cea89ebc7.png)

![Screen Shot 2019-05-15 at 2 00 50 PM](https://user-images.githubusercontent.com/4960757/57814810-e977cc00-7742-11e9-899b-7316762da529.png)
