### PR TITLE
Add queue staleness indicator

### DIFF
--- a/cypress/integration/office/homepage.js
+++ b/cypress/integration/office/homepage.js
@@ -27,6 +27,21 @@ describe('Office Home Page', function() {
   });
 });
 
+describe('Queue staleness indicator', () => {
+  it('displays the correct time ago text', () => {
+    cy.clock();
+    cy.setupBaseUrl(officeAppName);
+    cy.signIntoOffice();
+    cy.patientVisit('/queues/all');
+
+    cy.get('[data-cy=staleness-indicator]').should('have.text', 'Last updated a few seconds ago');
+
+    cy.tick(120000);
+
+    cy.get('[data-cy=staleness-indicator]').should('have.text', 'Last updated 2 mins ago');
+  });
+});
+
 function officeUserIsOnSignInPage() {
   cy.contains('office.move.mil');
   cy.contains('Sign In');

--- a/src/scenes/Office/QueueTable.jsx
+++ b/src/scenes/Office/QueueTable.jsx
@@ -5,7 +5,7 @@ import { connect } from 'react-redux';
 import { get, capitalize } from 'lodash';
 import 'react-table/react-table.css';
 import Alert from 'shared/Alert';
-import { formatDate, formatDateTimeWithTZ } from 'shared/formatters';
+import { formatDate, formatDateTimeWithTZ, formatTimeAgo } from 'shared/formatters';
 import FontAwesomeIcon from '@fortawesome/react-fontawesome';
 import faClock from '@fortawesome/fontawesome-free-solid/faClock';
 import './office.scss';
@@ -19,6 +19,13 @@ class QueueTable extends Component {
       pages: null,
       loading: true,
       refreshing: false, // only true when the user clicks the refresh button
+      lastLoadedAt: new Date(),
+      lastLoadedAtText: formatTimeAgo(new Date()),
+      interval: setInterval(() => {
+        this.setState({
+          lastLoadedAtText: formatTimeAgo(this.state.lastLoadedAt),
+        });
+      }, 5000),
     };
     this.fetchData = this.fetchData.bind(this);
   }
@@ -67,6 +74,7 @@ class QueueTable extends Component {
           pages: 1,
           loading: false,
           refreshing: false,
+          lastLoadedAt: new Date(),
         });
       }
     } catch (e) {
@@ -75,13 +83,22 @@ class QueueTable extends Component {
         pages: 1,
         loading: false,
         refreshing: false,
+        lastLoadedAt: new Date(),
       });
     }
   }
 
   refresh() {
+    clearInterval(this.state.interval);
+
     this.setState({
       refreshing: true,
+      lastLoadedAt: new Date(),
+      interval: setInterval(() => {
+        this.setState({
+          lastLoadedAtText: formatTimeAgo(this.state.lastLoadedAt),
+        });
+      }, 5000),
     });
 
     this.fetchData();
@@ -123,6 +140,9 @@ class QueueTable extends Component {
         ) : null}
         <h1 className="queue-heading">Queue: {titles[this.props.queueType]}</h1>
         <div className="queue-table">
+          <span className="staleness-indicator" data-cy="staleness-indicator">
+            Last updated {formatTimeAgo(this.state.lastLoadedAt)}
+          </span>
           <span className={'refresh' + (this.state.refreshing ? ' focused' : '')} title="Refresh" aria-label="Refresh">
             <FontAwesomeIcon
               data-cy="refreshQueue"

--- a/src/scenes/Office/office.scss
+++ b/src/scenes/Office/office.scss
@@ -450,9 +450,14 @@ head .panel-subhead {
   color: #0071bb
 }
 
+.staleness-indicator {
+  color: gray;
+}
+
 .refresh {
   display: inline-block;
   cursor: pointer;
+  margin-left: 0.3em;
   margin-bottom: 0.3em;
   padding: 0.3em 0;
   border: 1px solid white;

--- a/src/shared/formatters.js
+++ b/src/shared/formatters.js
@@ -215,6 +215,15 @@ export function formatDateTimeWithTZ(date) {
   return moment(date, moment.ISO_8601, true).format('DD-MMM-YY HH:mm') + ` ${shortZone}`;
 }
 
+export function formatTimeAgo(date) {
+  if (!date) return undefined;
+
+  return moment(date)
+    .fromNow()
+    .replace('minute', 'min')
+    .replace(/a min\s/, '1 min ');
+}
+
 // truncate a number and return appropiate decimal places... (watch out for negitive numbers: floor(-5.1) === -6)
 // see test for examples of how this works
 export const truncateNumber = (num, decimalPlaces = 0) => {

--- a/src/shared/formatters.test.js
+++ b/src/shared/formatters.test.js
@@ -1,4 +1,5 @@
 import * as formatters from './formatters';
+import moment from 'moment';
 
 describe('formatters', () => {
   describe('formatWeight', () => {
@@ -51,6 +52,20 @@ describe('formatters', () => {
     it('should include the timezone shortcode', () => {
       const formattedDate = formatters.formatDateTimeWithTZ(new Date());
       expect(formattedDate).toMatch(/\d{2}-\w{3}-\d{2} \d{2}:\d{2} \w{2,3}/);
+    });
+  });
+
+  describe('formatTimeAgo', () => {
+    it('should account for 1 minute correctly', () => {
+      let time = new Date();
+      let formattedTime = formatters.formatTimeAgo(time);
+
+      expect(formattedTime).toEqual('a few seconds ago');
+
+      time = moment().subtract(1, 'minute')._d;
+      formattedTime = formatters.formatTimeAgo(time);
+
+      expect(formattedTime).toEqual('1 min ago');
     });
   });
 });


### PR DESCRIPTION
## Description

As office user
I want to know how up to date my queue data is
So that I can decide if it needs to be refreshed 

## Setup

1. `make server_run`
2. `make client_run`

## Code Review Verification Steps

* [x] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [x] User facing changes have been reviewed by design.
* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/165771168) for this change

## Screenshots


![Screen Recording 2019-05-16 at 15 45 53](https://user-images.githubusercontent.com/3522323/57886789-aa558380-77f3-11e9-9924-c19a8f549425.gif)
