### PR TITLE
Show the proper move date in the "new" and "all" queues

### DIFF
--- a/pkg/handlers/internalapi/move_queue_items_test.go
+++ b/pkg/handlers/internalapi/move_queue_items_test.go
@@ -91,3 +91,57 @@ func (suite *HandlerSuite) TestShowQueueHandlerForbidden() {
 		suite.Assertions.IsType(&queueop.ShowQueueForbidden{}, showResponse)
 	}
 }
+
+func (suite *HandlerSuite) TestGetMoveQueueItemsComboMoveDate() {
+	suite.SetupTest()
+
+	// Given: An office user
+	officeUser := testdatagen.MakeDefaultOfficeUser(suite.DB())
+
+	// Make a PPM
+	ppm := testdatagen.MakePPM(suite.DB(), testdatagen.Assertions{
+		PersonallyProcuredMove: models.PersonallyProcuredMove{},
+	})
+
+	move := &ppm.Move
+	move.Status = "SUBMITTED"
+	suite.DB().Save(move)
+
+	pickupDate := testdatagen.NextValidMoveDate
+
+	// Make a shipment
+	shipment := testdatagen.MakeShipment(suite.DB(), testdatagen.Assertions{
+		Shipment: models.Shipment{
+			RequestedPickupDate: &pickupDate,
+			ActualPickupDate:    &pickupDate,
+			Status:              models.ShipmentStatusSUBMITTED,
+			Move:                ppm.Move,
+			MoveID:              ppm.Move.ID,
+		},
+	})
+
+	// And: the context contains the auth values
+	path := "/queues/new"
+	req := httptest.NewRequest("GET", path, nil)
+	req = suite.AuthenticateOfficeRequest(req, officeUser)
+	params := queueop.ShowQueueParams{
+		HTTPRequest: req,
+		QueueType:   "new",
+	}
+
+	// And: show Queue is queried
+	showHandler := ShowQueueHandler{handlers.NewHandlerContext(suite.DB(), suite.TestLogger())}
+	showResponse := showHandler.Handle(params)
+
+	// Then: Expect a 200 status code
+	okResponse := showResponse.(*queueop.ShowQueueOK)
+
+	suite.NotEmpty(okResponse.Payload)
+
+	moveQueueItem := okResponse.Payload[0]
+
+	// And: expect the moveQueueItem's move date to be the actual pickup date
+	expectedMoveDate := fmt.Sprintf("%v", handlers.FmtDate(*shipment.ActualPickupDate))
+	actualMoveDate := fmt.Sprintf("%v", *moveQueueItem.MoveDate)
+	suite.Equal(expectedMoveDate, actualMoveDate)
+}

--- a/pkg/models/queue.go
+++ b/pkg/models/queue.go
@@ -40,7 +40,13 @@ func GetMoveQueueItems(db *pop.Connection, lifecycleState string) ([]MoveQueueIt
 				CONCAT(COALESCE(sm.last_name, '*missing*'), ', ', COALESCE(sm.first_name, '*missing*')) AS customer_name,
 				moves.locator as locator,
 				ord.orders_type as orders_type,
-				ppm.original_move_date as move_date,
+				COALESCE(
+					shipment.actual_pickup_date,
+					shipment.pm_survey_planned_pickup_date,
+					shipment.requested_pickup_date,
+					ppm.actual_move_date,
+					ppm.original_move_date
+				) as move_date,
 				moves.created_at as created_at,
 				moves.updated_at as last_modified_date,
 				moves.status as status,
@@ -152,7 +158,13 @@ func GetMoveQueueItems(db *pop.Connection, lifecycleState string) ([]MoveQueueIt
 				CONCAT(COALESCE(sm.last_name, '*missing*'), ', ', COALESCE(sm.first_name, '*missing*')) AS customer_name,
 				moves.locator as locator,
 				ord.orders_type as orders_type,
-				ppm.original_move_date as move_date,
+				COALESCE(
+					shipment.actual_pickup_date,
+					shipment.pm_survey_planned_pickup_date,
+					shipment.requested_pickup_date,
+					ppm.actual_move_date,
+					ppm.original_move_date
+				) as move_date,
 				moves.created_at as created_at,
 				moves.updated_at as last_modified_date,
 				moves.status as status,


### PR DESCRIPTION
## Description

**NOTE** this PR was previously submitted but broke the build. It was then reverted so we could get `master` to pass again. This PR includes a more reliable test.

We're not handling move dates very well in the office queue. Right now, it's only looking at the ppm move date, but it should be smart enough to handle HHGs as well.

## Setup

1. `make server_run`
2. `make client_run`
3. Visit the office `new` and `all` queues, and note that the HHG date is used for HHGs as well as combo moves. See the pivotal ticket for specific acceptance criteria.

## Code Review Verification Steps

* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/165323225) for this change