### PR TITLE
Allow specifying environments for uploading and downloading secure migrations

### DIFF
--- a/docs/how-to/migrate-the-database.md
+++ b/docs/how-to/migrate-the-database.md
@@ -12,7 +12,7 @@ Use soda (a part of [pop](https://github.com/gobuffalo/pop/)) to generate migrat
 
 ### Generating a New Model
 
-If you are generating a new model, use: `./scripts/gen-model model-name column-name:type column-name:type ...`. The fields `id`, `created_at`, and `updated_at` are all created automatically.
+If you are generating a new model, use: `gen-model model-name column-name:type column-name:type ...`. The fields `id`, `created_at`, and `updated_at` are all created automatically.
 
 ### Modifying an Existing Model
 
@@ -37,7 +37,7 @@ We are piggy-backing on the migration system for importing static datasets. This
 
 ### Creating Secure Migrations
 
-1. Generate new migration files: `scripts/generate-secure-migration <migration_name>`. This creates two migration files:
+1. Generate new migration files: `generate-secure-migration <migration_name>`. This creates two migration files:
     * a local test file with no secret data
     * a production file to be uploaded to S3 and contain sensitive data
 2. Edit the production migration first, and put whatever sensitive data in it that you need to.
@@ -46,24 +46,21 @@ We are piggy-backing on the migration system for importing static datasets. This
 5. Test the local migration by running `make db_dev_migrate`. You should see it run your local migration.
 6. Test the secure migration by running `make run_prod_migrations` to setup a local  prod_migrations` database. Then run `psql-prod-migrations< tmp/$NAME_OF_YOUR_SECURE_MIGRATION`. Verify that the updated values are in the database.
 7. If you are wanting to run a secure migration for a specific non-production environment, then **skip to the next section**.
-8. Upload the migration to S3 with: `scripts/upload-secure-migration <production_migration_file>`.
-9. Run `make run_prod_migrations` to verify that the upload worked and that the migration can be applied successfully. If not, you can make changes and run `scripts/upload-secure-migration` again and it will overwrite the old files.
+8. Upload the migration to S3 with: `upload-secure-migration <production_migration_file>`. **NOTE:** For a single environment see the next section.
+9. Run `make run_prod_migrations` to verify that the upload worked and that the migration can be applied successfully. If not, you can make changes and run `upload-secure-migration` again and it will overwrite the old files.
 10. Once the migration is working properly, **delete the secure migration from your `tmp` directory** if you didn't delete it in step 8.
 11. Open a pull request!
 12. When the pull request lands, the production migrations will be run on Staging and Prod.
-
-### Running a Secure Migration on Specific Environments
 
 ### Secure Migrations for One Environment
 
 To run a secure migration on ONLY staging (or other chosen environment), upload the migration only to the S3 environment and blank files to the others:
 
-1. Instead of the "Upload the migration" step above, run `aws s3 cp --sse AES256 $YOUR_TMP_MIGRATION_FILE s3://transcom-ppp-app-staging-us-west-2/secure-migrations/`
+1. Similar to the "Upload the migration" step above, run `ENVIRONMENTS="staging" upload-secure-migration <production_migration_file>` where `ENVIRONMENTS` is a quoted list of all the environments you wish to upload to.  The default is `"experimental staging prod"` but you can just do staging and production with `ENVIRONMENTS="staging prod"`
 2. Check that it is listed in the S3 staging secure-migrations folder: `aws s3 ls s3://transcom-ppp-app-staging-us-west-2/secure-migrations/`
 3. Check that it is NOT listed in the S3 production folder: `aws s3 ls s3://transcom-ppp-app-prod-us-west-2/secure-migrations/`
-4. Now upload empty files of the same name to the prod environment: `aws s3 cp --sse AES256 $YOUR_EMPTY_TMP_MIGRATION_FILE s3://transcom-ppp-app-prod-us-west-2/secure-migrations/`
-5. Now upload empty files of the same name to the experimental environment: `aws s3 cp --sse AES256 $YOUR_EMPTY_TMP_MIGRATION_FILE s3://transcom-ppp-app-experimental-us-west-2/secure-migrations/`
-6. To verify upload and that the migration can be applied use the make target corresponding to your environment:
+4. Now upload empty files of the same name to the prod and experimental environments: `ENVIRONMENTS="experimental prod" upload-secure-migration <empty_migration_file_with_same_name>`
+5. To verify upload and that the migration can be applied use the make target corresponding to your environment:
 
 * `make run_prod_migrations`
 * `make run_staging_migrations`
@@ -87,7 +84,7 @@ you are done with these secure migrations please delete them from your computer.
 
 You may need to download and inspect secure migrations. Or perhaps you need to correct a file you uploaded by mistake. Here is how you download the secure migrations:
 
-* Download the migration to S3 with: `scripts/download-secure-migration <production_migration_file>`
+* Download the migration to S3 with: `download-secure-migration <production_migration_file>`. You can also use the `ENVIRONMENTS` environment variable to specify one or more than one environment.
 * This will put files in `./tmp/secure_migrations/${environment}`.
 
 You can now inspect or modify and re-upload those files as needed.

--- a/scripts/download-secure-migration
+++ b/scripts/download-secure-migration
@@ -28,7 +28,7 @@ function proceed() {
 function run() {
   command=( "$@" )
   echo "...executing: ${command[*]}"
-  ${command[*]} &> /dev/null
+  ${command[*]} &> /dev/null || (echo "Failed!!" && exit 1)
 }
 
 #

--- a/scripts/download-secure-migration
+++ b/scripts/download-secure-migration
@@ -8,7 +8,7 @@ set -eu -o pipefail
 
 readonly aws_command="aws"
 # Environments to download production migrations from
-readonly environments=(experimental staging prod)
+readonly environments=("${ENVIRONMENTS:-experimental staging prod}")
 readonly aws_bucket_prefix="transcom-ppp-app-"
 readonly aws_bucket_suffix="-us-west-2"
 readonly aws_path_prefix="secure-migrations"

--- a/scripts/upload-secure-migration
+++ b/scripts/upload-secure-migration
@@ -28,7 +28,7 @@ function proceed() {
 function run() {
   command=( "$@" )
   echo "...executing: ${command[*]}"
-  ${command[*]} &> /dev/null
+  ${command[*]} &> /dev/null || (echo "Failed!!" && exit 1)
 }
 
 #

--- a/scripts/upload-secure-migration
+++ b/scripts/upload-secure-migration
@@ -8,7 +8,7 @@ set -eu -o pipefail
 
 readonly aws_command="aws"
 # Environments to upload production migrations to
-readonly environments=(experimental staging prod)
+readonly environments=("${ENVIRONMENTS:-experimental staging prod}")
 readonly aws_bucket_prefix="transcom-ppp-app-"
 readonly aws_bucket_suffix="-us-west-2"
 readonly aws_path_prefix="secure-migrations"


### PR DESCRIPTION
## Description

Instead of working around the scripts to upload or download migrations for a single environment I've simply modified the scripts we already have to check environment variables.

## Setup

Instead of running

```sh
download-secure-migration 20190515160313_add-sba-office-user-051509.sql
```

Try running

```sh
ENVIRONMENTS="staging" download-secure-migration 20190515160313_add-sba-office-user-051509.sql
```

or 

```sh
ENVIRONMENTS="staging prod" download-secure-migration 20190515160313_add-sba-office-user-051509.sql
```

Should work the same for uploading migrations too.

## Code Review Verification Steps

* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?