### PR TITLE
Update PPM success alerts

### DIFF
--- a/cypress/integration/mymove/hhgPPM.js
+++ b/cypress/integration/mymove/hhgPPM.js
@@ -477,7 +477,15 @@ function serviceMemberViewsUpdatedHomePage() {
     expect(loc.pathname).to.eq('/');
   });
 
-  cy.get('.usa-alert-success').contains('Your PPM shipment is submitted');
+  cy.get('.usa-alert-success').within(() => {
+    cy.contains('Your PPM shipment is submitted');
+    cy.contains('Next, wait for approval. Once approved:');
+    cy
+      .get('a')
+      .contains('PPM info sheet')
+      .should('have.attr', 'href')
+      .and('include', '/downloads/ppm_info_sheet.pdf');
+  });
 
   cy.get('body').should($div => {
     expect($div.text()).to.include('Government Movers and Packers');
@@ -485,11 +493,14 @@ function serviceMemberViewsUpdatedHomePage() {
     expect($div.text()).to.not.include('Add PPM (DITY) Move');
   });
 
-  cy.get('.usa-width-three-fourths').should($div => {
-    const text = $div.text();
+  cy.get('.usa-width-three-fourths').within(() => {
     // PPM information and details
-    expect(text).to.include('Next Step: Wait for approval');
-    expect(text).to.include('Weight (est.): 150');
-    expect(text).to.include('Incentive (est.): $2,677.52 - 2,959.36');
+    cy.contains('Next Step: Wait for approval');
+    cy
+      .contains('Go to weight scales')
+      .children('a')
+      .should('have.attr', 'href', 'https://move.mil/resources/locator-maps');
+    cy.contains('Weight (est.): 150');
+    cy.contains('Incentive (est.): $2,677.52 - 2,959.36');
   });
 }

--- a/cypress/integration/mymove/hhgPPM.js
+++ b/cypress/integration/mymove/hhgPPM.js
@@ -477,10 +477,7 @@ function serviceMemberViewsUpdatedHomePage() {
     expect(loc.pathname).to.eq('/');
   });
 
-  cy.get('.usa-alert-success').contains("You've added a PPM shipment");
-  cy
-    .get('.usa-alert-success')
-    .contains('Next, your shipment is awaiting approval and this can take up to 3 business days');
+  cy.get('.usa-alert-success').contains('Your PPM shipment is submitted');
 
   cy.get('body').should($div => {
     expect($div.text()).to.include('Government Movers and Packers');

--- a/cypress/integration/mymove/ppm.js
+++ b/cypress/integration/mymove/ppm.js
@@ -79,7 +79,7 @@ describe('completing the ppm flow', function() {
       expect(loc.pathname).to.match(/^\/$/);
     });
 
-    cy.get('.usa-alert-success').contains('Your PPM shipment is submitted');
+    cy.get('.usa-alert-success').contains('Congrats - your move is submitted!');
     cy.contains('Next Step: Wait for approval');
     cy
       .get('.next-step')

--- a/cypress/integration/mymove/ppm.js
+++ b/cypress/integration/mymove/ppm.js
@@ -79,7 +79,7 @@ describe('completing the ppm flow', function() {
       expect(loc.pathname).to.match(/^\/$/);
     });
 
-    cy.contains('Congrats - your move is submitted!');
+    cy.get('.usa-alert-success').contains('Your PPM shipment is submitted');
     cy.contains('Next Step: Wait for approval');
     cy
       .get('.next-step')

--- a/cypress/integration/mymove/ppm.js
+++ b/cypress/integration/mymove/ppm.js
@@ -79,20 +79,24 @@ describe('completing the ppm flow', function() {
       expect(loc.pathname).to.match(/^\/$/);
     });
 
-    cy.get('.usa-alert-success').contains('Congrats - your move is submitted!');
-    cy.contains('Next Step: Wait for approval');
-    cy
-      .get('.next-step')
-      .contains('Go to weight scales')
-      .children('a')
-      .should('have.attr', 'href', 'https://move.mil/resources/locator-maps');
-    cy
-      .get('a')
-      .contains('PPM info sheet')
-      .should('have.attr', 'href')
-      .and('include', '/downloads/ppm_info_sheet.pdf');
+    cy.get('.usa-alert-success').within(() => {
+      cy.contains('Congrats - your move is submitted!');
+      cy.contains('Next, wait for approval. Once approved:');
+      cy
+        .get('a')
+        .contains('PPM info sheet')
+        .should('have.attr', 'href')
+        .and('include', '/downloads/ppm_info_sheet.pdf');
+    });
 
-    cy.contains('Advance Requested: $1,333.91');
+    cy.get('.usa-width-three-fourths').within(() => {
+      cy.contains('Next Step: Wait for approval');
+      cy
+        .contains('Go to weight scales')
+        .children('a')
+        .should('have.attr', 'href', 'https://move.mil/resources/locator-maps');
+      cy.contains('Advance Requested: $1,333.91');
+    });
   });
 
   //TODO: remove when done with the new flow to request payment

--- a/src/scenes/Landing/MoveSummary.jsx
+++ b/src/scenes/Landing/MoveSummary.jsx
@@ -137,7 +137,6 @@ export const SubmittedPpmMoveSummary = props => {
           <img className="move_sm" src={ppmCar} alt="ppm-car" />
           Move your own stuff (PPM)
         </div>
-
         <div className="shipment_box_contents">
           <PPMStatusTimeline ppm={ppm} />
           <div className="step-contents">

--- a/src/scenes/Landing/MoveSummary.jsx
+++ b/src/scenes/Landing/MoveSummary.jsx
@@ -103,34 +103,37 @@ export const DraftMoveSummary = props => {
   );
 };
 
+export const PPMAlert = props => {
+  return (
+    <Alert type="success" heading={props.heading}>
+      Next, wait for approval. Once approved:<br />
+      <ul>
+        <li>
+          Get certified <strong>weight tickets</strong>, both empty &amp; full
+        </li>
+        <li>
+          Save <strong>expense receipts</strong>, including for storgage
+        </li>
+        <li>
+          Read the{' '}
+          <strong>
+            <a href={ppmInfoPacket} target="_blank" rel="noopener noreferrer">
+              PPM info sheet
+            </a>
+          </strong>{' '}
+          for more info
+        </li>
+      </ul>
+    </Alert>
+  );
+};
+
 export const SubmittedPpmMoveSummary = props => {
-  const { ppm, moveSubmitSuccess } = props;
+  const { ppm } = props;
   return (
     <Fragment>
       <div>
-        {moveSubmitSuccess && (
-          <Alert type="success" heading="Congrats - your move is submitted!">
-            Next, wait for approval. Once approved:<br />
-            <ul>
-              <li>
-                Get certified <strong>weight tickets</strong>, both empty &amp; full
-              </li>
-              <li>
-                Save <strong>expense receipts</strong>, including for storgage
-              </li>
-              <li>
-                Read the{' '}
-                <strong>
-                  <a href={ppmInfoPacket} target="_blank" rel="noopener noreferrer">
-                    PPM info sheet
-                  </a>
-                </strong>{' '}
-                for more info
-              </li>
-            </ul>
-          </Alert>
-        )}
-
+        <PPMAlert heading="Congrats - your move is submitted!" />
         <div className="shipment_box">
           <div className="shipment_type">
             <img className="move_sm" src={ppmCar} alt="ppm-car" />
@@ -503,7 +506,6 @@ export const MoveSummary = props => {
     resumeMove,
     reviewProfile,
     requestPaymentSuccess,
-    moveSubmitSuccess,
     addPPMShipment,
   } = props;
   const moveStatus = get(move, 'status', 'DRAFT');
@@ -563,7 +565,6 @@ export const MoveSummary = props => {
               entitlement={entitlement}
               resumeMove={resumeMove}
               reviewProfile={reviewProfile}
-              moveSubmitSuccess={moveSubmitSuccess}
               requestPaymentSuccess={requestPaymentSuccess}
             />
           )}

--- a/src/scenes/Landing/MoveSummary.jsx
+++ b/src/scenes/Landing/MoveSummary.jsx
@@ -132,55 +132,47 @@ export const SubmittedPpmMoveSummary = props => {
   const { ppm } = props;
   return (
     <Fragment>
-      <div>
-        <PPMAlert heading="Congrats - your move is submitted!" />
-        <div className="shipment_box">
-          <div className="shipment_type">
-            <img className="move_sm" src={ppmCar} alt="ppm-car" />
-            Move your own stuff (PPM)
-          </div>
+      <div className="shipment_box">
+        <div className="shipment_type">
+          <img className="move_sm" src={ppmCar} alt="ppm-car" />
+          Move your own stuff (PPM)
+        </div>
 
-          <div className="shipment_box_contents">
-            <PPMStatusTimeline ppm={ppm} />
-            <div className="step-contents">
-              <div className="status_box usa-width-two-thirds">
-                <div className="step">
-                  <div className="title">Next Step: Wait for approval &amp; get ready</div>
-                  <div className="next-step">
-                    You'll be notified when your move is approved (up to 3 days). To get ready to move:
-                    <ul>
-                      <li>
-                        Go to <a href="https://move.mil/resources/locator-maps">weight scales</a> to get empty &amp;
-                        full weight tickets.
-                      </li>
-                      <li>Save expense receipts, including for storage.</li>
-                    </ul>
-                  </div>
-                </div>
-              </div>
-              <div className="usa-width-one-third">
-                <PPMMoveDetails ppm={ppm} />
-                <div className="titled_block">
-                  <div className="title">Documents</div>
-                  <div className="details-links">
-                    <a href={ppmInfoPacket} target="_blank" rel="noopener noreferrer">
-                      PPM Info Packet
-                    </a>
-                  </div>
+        <div className="shipment_box_contents">
+          <PPMStatusTimeline ppm={ppm} />
+          <div className="step-contents">
+            <div className="status_box usa-width-two-thirds">
+              <div className="step">
+                <div className="title">Next Step: Wait for approval &amp; get ready</div>
+                <div className="next-step">
+                  You'll be notified when your move is approved (up to 3 days). To get ready to move:
+                  <ul>
+                    <li>
+                      Go to <a href="https://move.mil/resources/locator-maps">weight scales</a> to get empty &amp; full
+                      weight tickets.
+                    </li>
+                    <li>Save expense receipts, including for storage.</li>
+                  </ul>
                 </div>
               </div>
             </div>
-            <a
-              className="usa-button usa-button-secondary"
-              href={ppmInfoPacket}
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              Read PPM Info Sheet
-            </a>
-            <div className="step-links">
-              <FindWeightScales />
+            <div className="usa-width-one-third">
+              <PPMMoveDetails ppm={ppm} />
+              <div className="titled_block">
+                <div className="title">Documents</div>
+                <div className="details-links">
+                  <a href={ppmInfoPacket} target="_blank" rel="noopener noreferrer">
+                    PPM Info Packet
+                  </a>
+                </div>
+              </div>
             </div>
+          </div>
+          <a className="usa-button usa-button-secondary" href={ppmInfoPacket} target="_blank" rel="noopener noreferrer">
+            Read PPM Info Sheet
+          </a>
+          <div className="step-links">
+            <FindWeightScales />
           </div>
         </div>
       </div>

--- a/src/scenes/Landing/MoveSummary.test.jsx
+++ b/src/scenes/Landing/MoveSummary.test.jsx
@@ -8,7 +8,6 @@ import {
   SubmittedHhgMoveSummary,
 } from './MoveSummary';
 import moment from 'moment';
-import Alert from 'shared/Alert';
 
 describe('MoveSummary', () => {
   const editMoveFn = jest.fn();
@@ -76,41 +75,8 @@ describe('MoveSummary', () => {
       ).toEqual('<h2>New move</h2>');
     });
   });
-  describe('when a move with a ppm has successfully been submitted', () => {
-    it('renders submitted content and alert with summary information', () => {
-      const moveObj = { selected_move_type: 'PPM', status: 'SUBMITTED', moveSubmitSuccess: true };
-      const futureFortNight = moment().add(14, 'day');
-      const ppmObj = {
-        original_move_date: futureFortNight,
-        weight_estimate: '10000',
-        estimated_incentive: '$24665.59 - 27261.97',
-      };
-      const hhgObj = {};
-      const subComponent = getShallowRender(
-        entitlementObj,
-        serviceMember,
-        ordersObj,
-        moveObj,
-        ppmObj,
-        hhgObj,
-        editMoveFn,
-        resumeMoveFn,
-      ).find(SubmittedPpmMoveSummary);
-      expect(subComponent.find(SubmittedPpmMoveSummary).length).toBe(1);
-      expect(subComponent.dive().find(Alert).length).toBe(1);
-      expect(
-        subComponent
-          .find(SubmittedPpmMoveSummary)
-          .dive()
-          .find('.step')
-          .find('div.title')
-          .first()
-          .html(),
-      ).toEqual('<div class="title">Next Step: Wait for approval &amp; get ready</div>');
-    });
-  });
-  describe('when a move with a ppm is in submitted state after initial submission', () => {
-    it('renders submitted content (but no alert)', () => {
+  describe('when a move with a ppm is in submitted state', () => {
+    it('renders submitted content', () => {
       const moveObj = { selected_move_type: 'PPM', status: 'SUBMITTED' };
       const futureFortNight = moment().add(14, 'day');
       const ppmObj = {
@@ -130,7 +96,6 @@ describe('MoveSummary', () => {
         resumeMoveFn,
       ).find(SubmittedPpmMoveSummary);
       expect(subComponent.find(SubmittedPpmMoveSummary).length).toBe(1);
-      expect(subComponent.dive().find(Alert).length).toBe(0);
       expect(
         subComponent
           .find(SubmittedPpmMoveSummary)

--- a/src/scenes/Landing/index.jsx
+++ b/src/scenes/Landing/index.jsx
@@ -6,7 +6,7 @@ import { bindActionCreators } from 'redux';
 import { withLastLocation } from 'react-router-last-location';
 import { withContext } from 'shared/AppContext';
 
-import { MoveSummary } from './MoveSummary';
+import { MoveSummary, PPMAlert } from './MoveSummary';
 import { isHHGPPMComboMove } from 'scenes/Moves/Ppm/ducks';
 import { selectedMoveType, lastMoveIsCanceled } from 'scenes/Moves/ducks';
 import { getCurrentShipment } from 'shared/UI/ducks';
@@ -98,11 +98,10 @@ export class Landing extends Component {
       loggedInUserIsLoading,
       loggedInUserSuccess,
       loggedInUserError,
-      hasSubmitSuccess,
       isProfileComplete,
-      isHHGPPMComboMove,
       createdServiceMemberError,
       moveSubmitSuccess,
+      isHHGPPMComboMove,
       entitlement,
       serviceMember,
       orders,
@@ -112,6 +111,7 @@ export class Landing extends Component {
       requestPaymentSuccess,
       updateMove,
     } = this.props;
+    console.log('isHHGPPMComboMove ', isHHGPPMComboMove);
     return (
       <div className="usa-grid">
         {loggedInUserIsLoading && <LoadingPlaceholder />}
@@ -125,12 +125,7 @@ export class Landing extends Component {
                     You've submitted your move
                   </Alert>
                 )}
-              {isHHGPPMComboMove &&
-                hasSubmitSuccess && (
-                  <Alert type="success" heading="You've added a PPM shipment">
-                    Next, your shipment is awaiting approval and this can take up to 3 business days
-                  </Alert>
-                )}
+              {isHHGPPMComboMove && moveSubmitSuccess && <PPMAlert heading="Your PPM shipment is submitted" />}
               {loggedInUserError && (
                 <Alert type="error" heading="An error occurred">
                   There was an error loading your user information.

--- a/src/scenes/Landing/index.jsx
+++ b/src/scenes/Landing/index.jsx
@@ -101,6 +101,7 @@ export class Landing extends Component {
       isProfileComplete,
       createdServiceMemberError,
       moveSubmitSuccess,
+      hasSubmitSuccess,
       isHHGPPMComboMove,
       entitlement,
       serviceMember,
@@ -111,7 +112,6 @@ export class Landing extends Component {
       requestPaymentSuccess,
       updateMove,
     } = this.props;
-    console.log('isHHGPPMComboMove ', isHHGPPMComboMove);
     return (
       <div className="usa-grid">
         {loggedInUserIsLoading && <LoadingPlaceholder />}
@@ -125,7 +125,8 @@ export class Landing extends Component {
                     You've submitted your move
                   </Alert>
                 )}
-              {isHHGPPMComboMove && moveSubmitSuccess && <PPMAlert heading="Your PPM shipment is submitted" />}
+              {isHHGPPMComboMove && hasSubmitSuccess && <PPMAlert heading="Your PPM shipment is submitted" />}
+              {ppm && moveSubmitSuccess && <PPMAlert heading="Congrats - your move is submitted!" />}
               {loggedInUserError && (
                 <Alert type="error" heading="An error occurred">
                   There was an error loading your user information.

--- a/src/scenes/Landing/index.test.js
+++ b/src/scenes/Landing/index.test.js
@@ -7,7 +7,7 @@ import configureStore from 'redux-mock-store';
 import { shallow, mount } from 'enzyme';
 
 import { Landing } from '.';
-import { MoveSummary } from './MoveSummary';
+import { MoveSummary, PPMAlert } from './MoveSummary';
 
 describe('HomePage tests', () => {
   let wrapper;
@@ -139,6 +139,48 @@ describe('HomePage tests', () => {
             .first()
             .html(),
         ).toEqual('<div class="title">Next Step: Finish setting up your move</div>');
+      });
+      describe('When a ppm move is submitted', () => {
+        it('Renders the PPM specific alert', () => {
+          const moveObj = { selected_move_type: 'PPM', status: 'SUBMITTED', moveSubmitSuccess: true };
+          wrapper = shallow(
+            <Landing
+              move={moveObj}
+              moveSubmitSuccess={moveObj.moveSubmitSuccess}
+              serviceMember={service_member}
+              ppm={ppmObj}
+              orders={orders}
+              isLoggedIn={true}
+              loggedInUserSuccess={true}
+              isProfileComplete={true}
+            />,
+          );
+          const ppmAlert = wrapper.find(PPMAlert).shallow();
+
+          expect(ppmAlert.length).toBe(1);
+          expect(ppmAlert.props().heading).toEqual('Congrats - your move is submitted!');
+        });
+        it('Renders the PPM combo move alert', () => {
+          const moveObj = { selected_move_type: 'HHG_PPM', status: 'SUBMITTED', hasSubmitSuccess: true };
+          wrapper = shallow(
+            <Landing
+              move={moveObj}
+              moveSubmitSuccess={moveObj.moveSubmitSuccess}
+              serviceMember={service_member}
+              ppm={ppmObj}
+              orders={orders}
+              isLoggedIn={true}
+              loggedInUserSuccess={true}
+              isProfileComplete={true}
+              hasSubmitSuccess={true}
+              isHHGPPMComboMove={true}
+            />,
+          );
+          const ppmAlert = wrapper.find(PPMAlert).shallow();
+
+          expect(ppmAlert.length).toBe(1);
+          expect(ppmAlert.props().heading).toEqual('Your PPM shipment is submitted');
+        });
       });
     });
   });

--- a/src/scenes/Landing/index.test.js
+++ b/src/scenes/Landing/index.test.js
@@ -140,8 +140,8 @@ describe('HomePage tests', () => {
             .html(),
         ).toEqual('<div class="title">Next Step: Finish setting up your move</div>');
       });
-      describe('When a ppm move is submitted', () => {
-        it('Renders the PPM specific alert', () => {
+      describe('When a ppm only move is submitted', () => {
+        it('renders the ppm only alert', () => {
           const moveObj = { selected_move_type: 'PPM', status: 'SUBMITTED', moveSubmitSuccess: true };
           wrapper = shallow(
             <Landing
@@ -157,29 +157,31 @@ describe('HomePage tests', () => {
           );
           const ppmAlert = wrapper.find(PPMAlert).shallow();
 
-          expect(ppmAlert.length).toBe(1);
+          expect(ppmAlert.length).toEqual(1);
           expect(ppmAlert.props().heading).toEqual('Congrats - your move is submitted!');
         });
-        it('Renders the PPM combo move alert', () => {
-          const moveObj = { selected_move_type: 'HHG_PPM', status: 'SUBMITTED', hasSubmitSuccess: true };
-          wrapper = shallow(
-            <Landing
-              move={moveObj}
-              moveSubmitSuccess={moveObj.moveSubmitSuccess}
-              serviceMember={service_member}
-              ppm={ppmObj}
-              orders={orders}
-              isLoggedIn={true}
-              loggedInUserSuccess={true}
-              isProfileComplete={true}
-              hasSubmitSuccess={true}
-              isHHGPPMComboMove={true}
-            />,
-          );
-          const ppmAlert = wrapper.find(PPMAlert).shallow();
+        describe('When a ppm is added to a combo move', () => {
+          it('renders the ppm added to combo move alert', () => {
+            const moveObj = { selected_move_type: 'HHG_PPM', status: 'SUBMITTED', hasSubmitSuccess: true };
+            wrapper = shallow(
+              <Landing
+                move={moveObj}
+                moveSubmitSuccess={moveObj.moveSubmitSuccess}
+                serviceMember={service_member}
+                ppm={ppmObj}
+                orders={orders}
+                isLoggedIn={true}
+                loggedInUserSuccess={true}
+                isProfileComplete={true}
+                hasSubmitSuccess={true}
+                isHHGPPMComboMove={true}
+              />,
+            );
+            const ppmAlert = wrapper.find(PPMAlert).shallow();
 
-          expect(ppmAlert.length).toBe(1);
-          expect(ppmAlert.props().heading).toEqual('Your PPM shipment is submitted');
+            expect(ppmAlert.length).toEqual(1);
+            expect(ppmAlert.props().heading).toEqual('Your PPM shipment is submitted');
+          });
         });
       });
     });

--- a/src/shared/WizardPage/Form.jsx
+++ b/src/shared/WizardPage/Form.jsx
@@ -156,8 +156,8 @@ export class WizardFormPage extends Component {
 }
 
 WizardFormPage.propTypes = {
-  handleSubmit: PropTypes.func.isRequired,
-  reduxFormSubmit: PropTypes.func.isRequired, // function supplied to use w/ redux-form's submit validation
+  handleSubmit: PropTypes.func,
+  reduxFormSubmit: PropTypes.func, // function supplied to use w/ redux-form's submit validation
   serverError: PropTypes.object,
   pageList: PropTypes.arrayOf(PropTypes.string).isRequired,
   pageKey: PropTypes.string.isRequired,


### PR DESCRIPTION
## Description

Update PPM submission success message text and only display a single success message when a PPM is added to a combo move.

## Notes for reviewers 

Pivotal story title is 
> Three success messages shown at the same time - there should only be one (after adding a PPM to an HHG move)

See discussion on the pivotal story for additional context regarding expected messaging / behavior. 

## Setup

```sh
make e2e_test
make client_test
```

## Code Review Verification Steps
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/n/projects/2181745/stories/165728042) for this change

## Screenshots
### Combo Move
![Screen Shot 2019-05-20 at 9 45 10 AM](https://user-images.githubusercontent.com/1036969/58034592-2564b580-7ae4-11e9-97e1-cb269132e37f.png)

### PPM Only Move
![Screen Shot 2019-05-20 at 9 46 14 AM](https://user-images.githubusercontent.com/1036969/58034605-2b5a9680-7ae4-11e9-9f01-2e979a90f69a.png)
