### PR TITLE
Remove Sprintf Where queries

### DIFF
--- a/pkg/handlers/internalapi/service_members_test.go
+++ b/pkg/handlers/internalapi/service_members_test.go
@@ -95,7 +95,7 @@ func (suite *HandlerSuite) TestSubmitServiceMemberHandlerNoValues() {
 	suite.Assertions.IsType(&servicememberop.CreateServiceMemberCreated{}, unwrappedResponse)
 
 	// Then: we expect a servicemember to have been created for the user
-	query := suite.DB().Where(fmt.Sprintf("user_id='%v'", user.ID))
+	query := suite.DB().Where("user_id = ?", user.ID)
 	var serviceMembers models.ServiceMembers
 	query.All(&serviceMembers)
 
@@ -160,7 +160,7 @@ func (suite *HandlerSuite) TestSubmitServiceMemberHandlerAllValues() {
 	suite.Assertions.IsType(&servicememberop.CreateServiceMemberCreated{}, unwrappedResponse)
 
 	// Then: we expect a servicemember to have been created for the user
-	query := suite.DB().Where(fmt.Sprintf("user_id='%v'", user.ID))
+	query := suite.DB().Where("user_id = ?", user.ID)
 	var serviceMembers models.ServiceMembers
 	query.All(&serviceMembers)
 
@@ -202,7 +202,7 @@ func (suite *HandlerSuite) TestSubmitServiceMemberSSN() {
 	suite.Assertions.True(*okResponse.Payload.HasSocialSecurityNumber)
 
 	// Then: we expect a ServiceMember to have been created for the user
-	query := suite.DB().Where(fmt.Sprintf("user_id='%v'", user.ID))
+	query := suite.DB().Where("user_id = ?", user.ID)
 	var serviceMembers models.ServiceMembers
 	query.All(&serviceMembers)
 

--- a/pkg/handlers/internalapi/signed_certifications_test.go
+++ b/pkg/handlers/internalapi/signed_certifications_test.go
@@ -1,7 +1,6 @@
 package internalapi
 
 import (
-	"fmt"
 	"net/http/httptest"
 	"time"
 
@@ -44,7 +43,8 @@ func (suite *HandlerSuite) TestCreateSignedCertificationHandler() {
 		t.Fatalf("Request failed: %#v", response)
 	}
 
-	query := suite.DB().Where(fmt.Sprintf("submitting_user_id='%v'", move.Orders.ServiceMember.User.ID)).Where(fmt.Sprintf("move_id='%v'", move.ID))
+	query := suite.DB().Where("submitting_user_id = ?", move.Orders.ServiceMember.User.ID).
+		Where("move_id = ?", move.ID)
 	certs := []models.SignedCertification{}
 	query.All(&certs)
 

--- a/pkg/testdatagen/make_tdl_records.go
+++ b/pkg/testdatagen/make_tdl_records.go
@@ -26,7 +26,9 @@ func MakeTDL(db *pop.Connection, assertions Assertions) models.TrafficDistributi
 	}
 
 	tdls := []models.TrafficDistributionList{}
-	query := db.Where(fmt.Sprintf("source_rate_area = '%s' AND destination_region = '%s' AND code_of_service = '%s'", source, dest, cos))
+	query := db.Where("source_rate_area = ?", source).
+		Where("destination_region = ?", dest).
+		Where("code_of_service = ?", cos)
 	err := query.All(&tdls)
 	if err != nil {
 		log.Panic(err)


### PR DESCRIPTION
## Description

In some places we're using `Sprintf` to interpolate `Where` queries. This pattern can lead to sql injection. Docs are here: https://github.com/transcom/mymove/blob/master/docs/backend.md#querying-the-database-safely

## Setup

All the changes are in tests, so `make server_test`

## Code Review Verification Steps

* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/tree/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/165891824) for this change
