### PR TITLE
Add E2E tests for office user seeing SIT entitlement days remaining

### DIFF
--- a/cypress/integration/tsp/storageInTransit.js
+++ b/cypress/integration/tsp/storageInTransit.js
@@ -33,8 +33,6 @@ describe('TSP user interacts with storage in transit panel', function() {
 function tspUserCreatesSitRequest() {
   // Open accepted shipments queue
   cy.patientVisit('/queues/accepted');
-
-  // Open new shipments queue
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/queues\/accepted/);
   });
@@ -73,8 +71,6 @@ function tspUserCreatesSitRequest() {
 function tspUserStartsAndCancelsSitRequest() {
   // Open accepted shipments queue
   cy.patientVisit('/queues/accepted');
-
-  // Open new shipments queue
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/queues\/accepted/);
   });
@@ -105,8 +101,6 @@ function tspUserStartsAndCancelsSitRequest() {
 function tspUserEditsSitRequest() {
   // Open accepted shipments queue
   cy.patientVisit('/queues/accepted');
-
-  // Open new shipments queue
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/queues\/accepted/);
   });
@@ -135,10 +129,8 @@ function tspUserEditsSitRequest() {
 }
 
 function tspUserGoesToAcceptedSIT() {
-  // Open accepted shipments queue
+  // Open in_transit shipments queue
   cy.patientVisit('/queues/in_transit');
-
-  // Open new shipments queue
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/queues\/in_transit/);
   });
@@ -237,12 +229,27 @@ function tspUserSubmitsPlaceInSit() {
     });
 }
 
+function tspUserGoesToPlacedSIT() {
+  // Open in_transit shipments queue
+  cy.patientVisit('/queues/in_transit');
+  cy.location().should(loc => {
+    expect(loc.pathname).to.match(/^\/queues\/in_transit/);
+  });
+
+  // Find shipment and open it
+  cy.selectQueueItemMoveLocator('SITIN1');
+
+  cy.location().should(loc => {
+    expect(loc.pathname).to.match(/^\/shipments\/[^/]+/);
+  });
+}
+
 function tspUserEntitlementRemainingDays() {
   // Freeze the clock so we can test a specific remaining days.
   let now = new Date(Date.UTC(2019, 3, 10)).getTime(); // 4/10/2019
   cy.clock(now);
 
-  tspUserGoesToAcceptedSIT();
+  tspUserGoesToPlacedSIT();
 
   cy
     .get('[data-cy=storage-in-transit-panel]')
@@ -262,7 +269,7 @@ function tspUserEntitlementRemainingDaysExpired() {
   let now = new Date(Date.UTC(2019, 6, 10)).getTime(); // 7/10/2019
   cy.clock(now);
 
-  tspUserGoesToAcceptedSIT();
+  tspUserGoesToPlacedSIT();
 
   cy
     .get('[data-cy=storage-in-transit-panel]')

--- a/src/shared/StorageInTransit/StorageInTransit.jsx
+++ b/src/shared/StorageInTransit/StorageInTransit.jsx
@@ -268,7 +268,7 @@ export class StorageInTransit extends Component {
                           ? formatDate4DigitYear(
                               moment(storageInTransit.actual_start_date).add(daysRemaining + daysUsed, 'days'),
                             )
-                          : 'na'}
+                          : 'n/a'}
                       </span>
                     </div>
                   </div>


### PR DESCRIPTION
## Description

This PR adds E2E tests for the office user to make sure the SIT entitlement days remaining appear as expected.  The office app shares the same code/UI for this feature as the TSP app (see PR #2139 for that code).

## Reviewer Notes

I had to add mock clocks for the E2E tests since the values for the remaining and used days are dependent upon the current time.

## Setup

`make db_dev_e2e_populate`
`make server_run`
`make office_client_run` (when needing office app)
`make tsp_client_run` (when needing TSP app)

Using the TSP app, add one or more SIT requests to an existing shipment such as `BACON1`. For at least one of the SIT requests, use the office app to approve it. Then, use the TSP app to place it into SIT. Once you have a shipment placed in SIT, you should see (on both the office app and the TSP app) the `Entitlement` header show a remaining days, as well as `Days used` and `Expires` fields for the SIT request that's been placed into SIT.

If you place an item into SIT with an actual start date that's way in the past, you can also see that a negative number of days shows up as remaining, and the SIT's status changes to `In SIT - SIT Expired`.

## Code Review Verification Steps

* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/163340897) for this change

## Screenshots

<img width="1162" alt="Screen Shot 2019-05-20 at 4 56 50 PM" src="https://user-images.githubusercontent.com/4960757/58051561-827e5c80-7b20-11e9-8a55-c4048a844547.png">

<img width="1160" alt="Screen Shot 2019-05-20 at 4 58 18 PM" src="https://user-images.githubusercontent.com/4960757/58051564-86aa7a00-7b20-11e9-89c3-ffb1bc6ce955.png">
