### PR TITLE
Weight ticket page layout

### DIFF
--- a/cypress/integration/mymove/ppm.js
+++ b/cypress/integration/mymove/ppm.js
@@ -215,8 +215,36 @@ it('allows a SM to request ppm payment', function() {
   cy.get('.in_progress .status_dates').should('exist');
   serviceMemberCanCancel();
   serviceMemberVisitsIntroToPPMPaymentRequest();
-  serviceMemberUploadsWeightTicket();
+  serviceMemberFillsOutWeightTicket('Car');
+  // TODO: remove when we are doing something with the data
+  cy.reload();
+  serviceMemberFillsOutWeightTicket('Box truck');
 });
+
+function serviceMemberFillsOutWeightTicket(vehicleType) {
+  cy.location().should(loc => {
+    expect(loc.pathname).to.match(/^\/moves\/[^/]+\/ppm-weight-ticket/);
+  });
+
+  cy.get('select[name="vehicle_options"]').select(vehicleType);
+
+  cy.get('input[name="empty_weight"]').type('1000');
+  cy.upload_file('.filepond--root:first', 'top-secret.png');
+  cy.wait('@postUploadDocument');
+
+  cy.get('input[name="full_weight"]').type('5000');
+  cy.upload_file('.filepond--root:last', 'top-secret.png');
+  cy.wait('@postUploadDocument');
+  cy
+    .get('input[name="weight_ticket_date"]')
+    .type('6/2/2018{enter}')
+    .blur();
+
+  cy
+    .get('[type="radio"]')
+    .first()
+    .should('be.checked');
+}
 
 function serviceMemberCanCancel() {
   cy.contains('Request Payment').click();
@@ -280,13 +308,4 @@ function serviceMemberVisitsIntroToPPMPaymentRequest() {
     .get('button')
     .contains('Get Started')
     .click();
-}
-
-function serviceMemberUploadsWeightTicket() {
-  cy.location().should(loc => {
-    expect(loc.pathname).to.match(/^\/moves\/[^/]+\/ppm-weight-ticket/);
-  });
-  cy.get('select[name="vehicle_options"]').select('CAR');
-  cy.upload_file('.filepond--root', 'top-secret.png');
-  cy.wait('@postUploadDocument');
 }

--- a/src/scenes/Moves/Ppm/PPMPaymentRequest.css
+++ b/src/scenes/Moves/Ppm/PPMPaymentRequest.css
@@ -96,6 +96,10 @@
   padding-top: 2em;
 }
 
+.uploader-label {
+  font-size: 1.5em;
+}
+
 .full-weight-label {
   margin-top: 0px;
 }

--- a/src/scenes/Moves/Ppm/PPMPaymentRequest.css
+++ b/src/scenes/Moves/Ppm/PPMPaymentRequest.css
@@ -67,3 +67,8 @@
 .secondary-label {
   font-size: 1.5rem;
 }
+
+.dashed-divider {
+  border-bottom: 1px dashed #e9e8e8;
+  padding: 1rem;
+}

--- a/src/scenes/Moves/Ppm/PPMPaymentRequest.css
+++ b/src/scenes/Moves/Ppm/PPMPaymentRequest.css
@@ -77,3 +77,13 @@
   margin-top: 1em;
   margin-bottom: 0.5em;
 }
+
+.short-field {
+  max-width: 46rem;
+  display: inline-block;
+  margin-right: 0px;
+}
+
+.uploader-container {
+  padding-top: 1.5em;
+}

--- a/src/scenes/Moves/Ppm/PPMPaymentRequest.css
+++ b/src/scenes/Moves/Ppm/PPMPaymentRequest.css
@@ -72,3 +72,8 @@
   border-bottom: 1px dashed #e9e8e8;
   padding: 1rem;
 }
+
+.radio-group-header {
+  margin-top: 1em;
+  margin-bottom: 0.5em;
+}

--- a/src/scenes/Moves/Ppm/PPMPaymentRequest.css
+++ b/src/scenes/Moves/Ppm/PPMPaymentRequest.css
@@ -78,12 +78,28 @@
   margin-bottom: 0.5em;
 }
 
+.radio-group-wrapper {
+  margin-bottom: 2em;
+}
+
 .short-field {
   max-width: 46rem;
   display: inline-block;
   margin-right: 0px;
 }
 
-.uploader-container {
-  padding-top: 1.5em;
+.uploader-wrapper {
+  padding-top: 1em;
+}
+
+.uploader-wrapper:nth-child(2) {
+  padding-top: 2em;
+}
+
+.full-weight-label {
+  margin-top: 0px;
+}
+
+.input-header {
+  display: block;
 }

--- a/src/scenes/Moves/Ppm/WeightTicket.jsx
+++ b/src/scenes/Moves/Ppm/WeightTicket.jsx
@@ -3,30 +3,32 @@ import { reduxForm } from 'redux-form';
 import { connect } from 'react-redux';
 import { get } from 'lodash';
 import PropTypes from 'prop-types';
-import { uniqueId } from 'lodash';
 
 import PPMPaymentRequestActionBtns from './PPMPaymentRequestActionBtns';
 import WizardHeader from '../WizardHeader';
 import { ProgressTimeline, ProgressTimelineStep } from 'shared/ProgressTimeline';
 import { SwaggerField } from 'shared/JsonSchemaForm/JsonSchemaField';
-
+import RadioButton from 'shared/RadioButton';
 import './PPMPaymentRequest.css';
 import Uploader from 'shared/Uploader';
 
 class WeightTicket extends Component {
   state = {
-    value: 'Yes',
+    vehicleType: '',
+    additionalWeightTickets: 'Yes',
   };
 
-  labelIdle = 'Drag & drop or <span class="filepond--label-action">click to upload upload empty weight ticket</span>';
-
-  handleRadioChange = event => {
-    this.setState({ value: event.target.value });
+  //  handleChange for vehicleType and additionalWeightTickets
+  handleChange = (event, type) => {
+    this.setState({ [type]: event.target.value });
   };
 
   render() {
-    const { value } = this.state;
+    const { additionalWeightTickets, vehicleType } = this.state;
     const { schema } = this.props;
+    const labelIdle =
+      'Drag & drop or <span class="filepond--label-action">click to upload upload empty weight ticket</span>';
+
     return (
       <Fragment>
         <WizardHeader
@@ -43,62 +45,78 @@ class WeightTicket extends Component {
           <SwaggerField
             fieldName="vehicle_options"
             swagger={schema}
-            onChange={this.handleChange}
-            value={this.state.value}
+            onChange={event => this.handleChange(event, 'vehicleType')}
+            value={vehicleType}
             required
           />
           <SwaggerField fieldName="vehicle_nickname" swagger={schema} required />
-          <div className="dashed-divider" />
+          {(vehicleType === 'CAR' || vehicleType === 'BOX_TRUCK') && (
+            <>
+              <div className="dashed-divider" />
 
-          <div className="usa-grid-full">
-            <div className="usa-width-one-third">
-              <SwaggerField className="short-field" fieldName="empty_weight" swagger={schema} title=" " required /> lbs
-            </div>
-            <div className="usa-width-two-third">
-              <Uploader options={{ labelIdle: this.labelIdle }} />
-            </div>
-          </div>
+              <div className="usa-grid-full" style={{ marginTop: '1em' }}>
+                <div className="usa-width-one-third">
+                  <strong className="input-header">Empty Weight</strong>
+                  <SwaggerField
+                    className="short-field"
+                    fieldName="empty_weight"
+                    swagger={schema}
+                    hideLabel
+                    required
+                  />{' '}
+                  lbs
+                </div>
+                <div className="usa-width-two-third uploader-wrapper">
+                  <Uploader options={{ labelIdle }} />
+                </div>
+              </div>
 
-          <div className="usa-grid-full">
-            <div className="usa-width-one-third">
-              <SwaggerField
-                className="short-field"
-                fieldName="full_weight"
-                swagger={schema}
-                title="Full weight at destination"
-                required
-              />{' '}
-              lbs
-            </div>
+              <div className="usa-grid-full" style={{ marginTop: '1em' }}>
+                <div className="usa-width-one-third">
+                  <strong className="input-header">Full Weight</strong>
+                  <label className="full-weight-label">Full weight at destination</label>
+                  <SwaggerField
+                    className="short-field"
+                    fieldName="full_weight"
+                    swagger={schema}
+                    hideLabel
+                    required
+                  />{' '}
+                  lbs
+                </div>
 
-            <div className="usa-width-two-third uploader-container">
-              <Uploader options={{ labelIdle: this.labelIdle }} />
-            </div>
-          </div>
+                <div className="usa-width-two-third uploader-wrapper">
+                  <Uploader options={{ labelIdle }} />
+                </div>
+              </div>
 
-          <SwaggerField fieldName="weight_ticket_date" swagger={schema} required />
-          <div className="dashed-divider" />
+              <SwaggerField fieldName="weight_ticket_date" swagger={schema} required />
+              <div className="dashed-divider" />
 
-          <p className="radio-group-header">Do you have more weight tickets for another vehicle or trip?</p>
-          <RadioBtn
-            inputClassName="inline_radio"
-            labelClassName="inline_radio"
-            label="Yes"
-            value="Yes"
-            name="additional_weight_ticket"
-            checked={value === 'Yes'}
-            onChange={this.handleRadioChange}
-          />
+              <div className="radio-group-wrapper">
+                <p className="radio-group-header">Do you have more weight tickets for another vehicle or trip?</p>
+                <RadioButton
+                  inputClassName="inline_radio"
+                  labelClassName="inline_radio"
+                  label="Yes"
+                  value="Yes"
+                  name="additional_weight_ticket"
+                  checked={additionalWeightTickets === 'Yes'}
+                  onChange={event => this.handleChange(event, 'additionalWeightTickets')}
+                />
 
-          <RadioBtn
-            inputClassName="inline_radio"
-            labelClassName="inline_radio"
-            label="No"
-            value="No"
-            name="additional_weight_ticket"
-            checked={value === 'No'}
-            onChange={this.handleRadioChange}
-          />
+                <RadioButton
+                  inputClassName="inline_radio"
+                  labelClassName="inline_radio"
+                  label="No"
+                  value="No"
+                  name="additional_weight_ticket"
+                  checked={additionalWeightTickets === 'No'}
+                  onChange={event => this.handleChange(event, 'additionalWeightTickets')}
+                />
+              </div>
+            </>
+          )}
 
           {/* TODO: change onclick handler to go to next page in flow */}
           <PPMPaymentRequestActionBtns onClick={() => {}} nextBtnLabel="Save & Add Another" />
@@ -107,25 +125,6 @@ class WeightTicket extends Component {
     );
   }
 }
-const RadioBtn = ({ name, label, onChange, value, checked, inputClassName, labelClassName }) => {
-  const radioId = uniqueId(label);
-  return (
-    <>
-      <input
-        className={inputClassName}
-        id={radioId}
-        type="radio"
-        name={name}
-        value={value}
-        checked={checked}
-        onChange={onChange}
-      />
-      <label className={labelClassName} htmlFor={radioId}>
-        {label}
-      </label>
-    </>
-  );
-};
 
 const formName = 'weight_ticket_wizard';
 WeightTicket = reduxForm({

--- a/src/scenes/Moves/Ppm/WeightTicket.jsx
+++ b/src/scenes/Moves/Ppm/WeightTicket.jsx
@@ -3,6 +3,8 @@ import { reduxForm } from 'redux-form';
 import { connect } from 'react-redux';
 import { get } from 'lodash';
 import PropTypes from 'prop-types';
+import { uniqueId } from 'lodash';
+
 import PPMPaymentRequestActionBtns from './PPMPaymentRequestActionBtns';
 import WizardHeader from '../WizardHeader';
 import { ProgressTimeline, ProgressTimelineStep } from 'shared/ProgressTimeline';
@@ -13,11 +15,17 @@ import Uploader from 'shared/Uploader';
 
 class WeightTicket extends Component {
   state = {
-    value: '',
+    value: 'Yes',
   };
+
   labelIdle = 'Drag & drop or <span class="filepond--label-action">click to upload upload empty weight ticket</span>';
 
+  handleRadioChange = event => {
+    this.setState({ value: event.target.value });
+  };
+
   render() {
+    const { value } = this.state;
     const { schema } = this.props;
     return (
       <Fragment>
@@ -39,12 +47,35 @@ class WeightTicket extends Component {
             value={this.state.value}
             required
           />
-          {this.state.value !== '' && (
-            <div className="uploader-box">
-              <Uploader options={{ allowMultiple: true, labelIdle: this.labelIdle }} />
-            </div>
-          )}
           <SwaggerField fieldName="vehicle_nickname" swagger={schema} required />
+          <div className="dashed-divider" />
+          <SwaggerField fieldName="empty_weight" swagger={schema} title="Empty Weight" required />
+          <Uploader options={{ labelIdle: this.labelIdle }} />
+          <SwaggerField fieldName="full_weight" swagger={schema} title="Full Weight" required />
+          <Uploader options={{ labelIdle: this.labelIdle }} />
+          <SwaggerField fieldName="weight_ticket_date" swagger={schema} required />
+          <div className="dashed-divider" />
+
+          <p className="radio-group-header">Do you have more weight tickets for another vehicle or trip?</p>
+          <RadioBtn
+            inputClassName="inline_radio"
+            labelClassName="inline_radio"
+            label="Yes"
+            value="Yes"
+            name="additional_weight_ticket"
+            checked={value === 'Yes'}
+            onChange={this.handleRadioChange}
+          />
+
+          <RadioBtn
+            inputClassName="inline_radio"
+            labelClassName="inline_radio"
+            label="No"
+            value="No"
+            name="additional_weight_ticket"
+            checked={value === 'No'}
+            onChange={this.handleRadioChange}
+          />
 
           {/* TODO: change onclick handler to go to next page in flow */}
           <PPMPaymentRequestActionBtns onClick={() => {}} nextBtnLabel="Save & Add Another" />
@@ -53,6 +84,25 @@ class WeightTicket extends Component {
     );
   }
 }
+const RadioBtn = ({ name, label, onChange, value, checked, inputClassName, labelClassName }) => {
+  const radioId = uniqueId(label);
+  return (
+    <>
+      <input
+        className={inputClassName}
+        id={radioId}
+        type="radio"
+        name={name}
+        value={value}
+        checked={checked}
+        onChange={onChange}
+      />
+      <label className={labelClassName} htmlFor={radioId}>
+        {label}
+      </label>
+    </>
+  );
+};
 
 const formName = 'weight_ticket_wizard';
 WeightTicket = reduxForm({

--- a/src/scenes/Moves/Ppm/WeightTicket.jsx
+++ b/src/scenes/Moves/Ppm/WeightTicket.jsx
@@ -7,6 +7,7 @@ import PPMPaymentRequestActionBtns from './PPMPaymentRequestActionBtns';
 import WizardHeader from '../WizardHeader';
 import { ProgressTimeline, ProgressTimelineStep } from 'shared/ProgressTimeline';
 import { SwaggerField } from 'shared/JsonSchemaForm/JsonSchemaField';
+
 import './PPMPaymentRequest.css';
 import Uploader from 'shared/Uploader';
 
@@ -15,10 +16,6 @@ class WeightTicket extends Component {
     value: '',
   };
   labelIdle = 'Drag & drop or <span class="filepond--label-action">click to upload upload empty weight ticket</span>';
-
-  handleChange = event => {
-    this.setState({ value: event.target.value });
-  };
 
   render() {
     const { schema } = this.props;

--- a/src/scenes/Moves/Ppm/WeightTicket.jsx
+++ b/src/scenes/Moves/Ppm/WeightTicket.jsx
@@ -26,9 +26,10 @@ class WeightTicket extends Component {
   render() {
     const { additionalWeightTickets, vehicleType } = this.state;
     const { schema } = this.props;
-    const labelIdle =
-      'Drag & drop or <span class="filepond--label-action">click to upload upload empty weight ticket</span>';
-
+    const uploadEmptyTicketLabel =
+      '<span class="uploader-label">Drag & drop or <span class="filepond--label-action">click to upload upload empty weight ticket</span></span>';
+    const uploadFullTicketLabel =
+      '<span class="uploader-label">Drag & drop or <span class="filepond--label-action">click to upload upload full weight ticket</span></span>';
     return (
       <Fragment>
         <WizardHeader
@@ -67,7 +68,7 @@ class WeightTicket extends Component {
                   lbs
                 </div>
                 <div className="usa-width-two-third uploader-wrapper">
-                  <Uploader options={{ labelIdle }} />
+                  <Uploader options={{ labelIdle: uploadEmptyTicketLabel }} />
                 </div>
               </div>
 
@@ -86,7 +87,7 @@ class WeightTicket extends Component {
                 </div>
 
                 <div className="usa-width-two-third uploader-wrapper">
-                  <Uploader options={{ labelIdle }} />
+                  <Uploader options={{ labelIdle: uploadFullTicketLabel }} />
                 </div>
               </div>
 

--- a/src/scenes/Moves/Ppm/WeightTicket.jsx
+++ b/src/scenes/Moves/Ppm/WeightTicket.jsx
@@ -49,10 +49,33 @@ class WeightTicket extends Component {
           />
           <SwaggerField fieldName="vehicle_nickname" swagger={schema} required />
           <div className="dashed-divider" />
-          <SwaggerField fieldName="empty_weight" swagger={schema} title="Empty Weight" required />
-          <Uploader options={{ labelIdle: this.labelIdle }} />
-          <SwaggerField fieldName="full_weight" swagger={schema} title="Full Weight" required />
-          <Uploader options={{ labelIdle: this.labelIdle }} />
+
+          <div className="usa-grid-full">
+            <div className="usa-width-one-third">
+              <SwaggerField className="short-field" fieldName="empty_weight" swagger={schema} title=" " required /> lbs
+            </div>
+            <div className="usa-width-two-third">
+              <Uploader options={{ labelIdle: this.labelIdle }} />
+            </div>
+          </div>
+
+          <div className="usa-grid-full">
+            <div className="usa-width-one-third">
+              <SwaggerField
+                className="short-field"
+                fieldName="full_weight"
+                swagger={schema}
+                title="Full weight at destination"
+                required
+              />{' '}
+              lbs
+            </div>
+
+            <div className="usa-width-two-third uploader-container">
+              <Uploader options={{ labelIdle: this.labelIdle }} />
+            </div>
+          </div>
+
           <SwaggerField fieldName="weight_ticket_date" swagger={schema} required />
           <div className="dashed-divider" />
 

--- a/src/shared/RadioButton/index.js
+++ b/src/shared/RadioButton/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { string, func, bool } from 'prop-types';
 import { uniqueId } from 'lodash';
 
 const RadioButton = ({ name, label, onChange, value, checked, inputClassName, labelClassName }) => {
@@ -19,6 +20,16 @@ const RadioButton = ({ name, label, onChange, value, checked, inputClassName, la
       </label>
     </>
   );
+};
+
+RadioButton.propTypes = {
+  name: string.isRequired,
+  label: string.isRequired,
+  onChange: func.isRequired,
+  value: string.isRequired,
+  checked: bool.isRequired,
+  inputClassName: string,
+  labelClassName: string,
 };
 
 export default RadioButton;

--- a/src/shared/RadioButton/index.js
+++ b/src/shared/RadioButton/index.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import { uniqueId } from 'lodash';
+
+const RadioButton = ({ name, label, onChange, value, checked, inputClassName, labelClassName }) => {
+  const radioId = uniqueId(label);
+  return (
+    <>
+      <input
+        className={inputClassName}
+        id={radioId}
+        type="radio"
+        name={name}
+        value={value}
+        checked={checked}
+        onChange={onChange}
+      />
+      <label className={labelClassName} htmlFor={radioId}>
+        {label}
+      </label>
+    </>
+  );
+};
+
+export default RadioButton;

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -2481,6 +2481,18 @@ definitions:
         $ref: '#/definitions/VehicleOptions'
       vehicle_nickname:
         $ref: '#/definitions/VehicleNickname'
+      empty_weight:
+        type: number
+        x-nullable: true
+      full_weight:
+        type: number
+        x-nullable: true
+      weight_ticket_date:
+        type: string
+        example: '2018-04-26'
+        format: date
+        title: Weight ticket date
+        x-nullable: true
   VehicleNickname:
     type: string
     x-nullable: true


### PR DESCRIPTION
## Description

Add initial layout and input fields for weight ticket page

## Reviewer Notes
- `Weight ticket - 1st set` header in the wireframe will be added when `Save & Add Another` functionality is added
- `I'm missing this weight ticket` checkboxes in the wireframe are also in a different card
## Setup
`make server_run`
`make client_run`


## Code Review Verification Steps
* [x] User facing changes have been reviewed by design.
* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/164718824) for this change

## Screenshots
![image](https://user-images.githubusercontent.com/13622298/58110332-2f4ded80-7ba4-11e9-9111-c1a99b6176cb.png)
