### PR TITLE
Retry 'go get' command 5 times to handle 502 errors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -211,7 +211,7 @@ jobs:
             - go-mod-souces-v1-{{ checksum "go.sum" }}
       - run:
           name: Install dependencies
-          command: go get
+          command: for i in $(seq 1 5); do go get && s=0 && break || s=$? && sleep 5; done; (exit $s)
       - save_cache:
           key: go-mod-souces-v1-{{ checksum "go.sum" }}
           paths:


### PR DESCRIPTION
## Description

Lately we've seen [a lot of failures](https://circleci.com/gh/transcom/mymove/112697?utm_campaign=workflow-failed&utm_medium=email&utm_source=notification) getting our golang deps installed. This adds a retry mechanism so that if the error is transient the testing will continue.

## Reviewer Notes

Is there a nicer way to do this? I couldn't find a built-in mechanism to `go get`.

## Setup

Try it yourself!

```sh
for i in $(seq 1 5); do go get && s=0 && break || s=$? && sleep 5; done; (exit $s)
```

## Code Review Verification Steps

* [x] Request review from a member of a different team.