### PR TITLE
Fix missing rendering variable file for migrations

### DIFF
--- a/scripts/ecs-run-app-migrations-container
+++ b/scripts/ecs-run-app-migrations-container
@@ -52,7 +52,7 @@ readonly db_host
 
 # renderer builds its template context from (1) environment variables, (2) file at -v FILE, and (3) positional command line args.
 echo "Get the container definition from template ${template} for environment ${environment} with image ${image} and db host ${db_host}"
-container_definition_json=$("$DIR"/../bin/renderer -t "$template" environment="$environment" image="$image" db_host="$db_host")
+container_definition_json=$("$DIR"/../bin/renderer -t "$template" -v "$DIR"/../config/env/"${environment}".env environment="$environment" image="$image" db_host="$db_host")
 readonly container_definition_json
 
 # create new task definition with the given image


### PR DESCRIPTION
## Description

A merge conflict in #2128 meant that I removed the variables file from the script for rendering the migrations task definition. This ought to fix that up.