### PR TITLE
Migrate setPendingMoveType to UI Ducks

### DIFF
--- a/src/scenes/Moves/MoveType.jsx
+++ b/src/scenes/Moves/MoveType.jsx
@@ -4,7 +4,6 @@ import windowSize from 'react-window-size';
 import { bindActionCreators } from 'redux';
 import PropTypes from 'prop-types';
 
-import { setPendingMoveType } from './ducks';
 import BigButton from 'shared/BigButton';
 import trailerGray from 'shared/icon/trailer-gray.svg';
 import truckGray from 'shared/icon/truck-gray.svg';
@@ -13,6 +12,7 @@ import './MoveType.css';
 
 import { mobileSize } from 'shared/constants';
 import { withContext } from 'shared/AppContext';
+import { setPendingMoveType } from '../../shared/UI/ducks';
 
 class BigButtonGroup extends Component {
   constructor() {
@@ -185,7 +185,10 @@ MoveType.propTypes = {
 };
 
 function mapStateToProps(state) {
-  return state.moves;
+  return {
+    ...state.moves,
+    pendingMoveType: state.ui.pendingMoveType,
+  };
 }
 
 function mapDispatchToProps(dispatch) {

--- a/src/scenes/Moves/MoveTypeWizard.jsx
+++ b/src/scenes/Moves/MoveTypeWizard.jsx
@@ -48,6 +48,6 @@ function mapDispatchToProps(dispatch) {
   return bindActionCreators({ updateMove, loadMove }, dispatch);
 }
 function mapStateToProps(state) {
-  return state.moves;
+  return { ...state.moves, pendingMoveType: state.ui.pendingMoveType };
 }
 export default connect(mapStateToProps, mapDispatchToProps)(MoveTypeWizardPage);

--- a/src/scenes/Moves/ducks.js
+++ b/src/scenes/Moves/ducks.js
@@ -5,8 +5,6 @@ import { fetchActive } from 'shared/utils';
 
 import * as ReduxHelpers from 'shared/ReduxHelpers';
 // Types
-const SET_PENDING_MOVE_TYPE = 'SET_PENDING_MOVE_TYPE';
-
 export const getMoveType = 'GET_MOVE';
 export const GET_MOVE = ReduxHelpers.generateAsyncActionTypes(getMoveType);
 
@@ -15,11 +13,6 @@ export const CREATE_OR_UPDATE_MOVE = ReduxHelpers.generateAsyncActionTypes(creat
 
 export const submitForApprovalType = 'SUBMIT_FOR_APPROVAL';
 export const SUBMIT_FOR_APPROVAL = ReduxHelpers.generateAsyncActionTypes(submitForApprovalType);
-
-// Action creation
-export function setPendingMoveType(value) {
-  return { type: SET_PENDING_MOVE_TYPE, payload: value };
-}
 
 export function updateMove(moveId, moveType) {
   return function(dispatch) {
@@ -77,10 +70,6 @@ export function moveReducer(state = initialState, action) {
         currentMove: reshapeMove(activeMove),
         hasLoadError: false,
         hasLoadSuccess: true,
-      });
-    case SET_PENDING_MOVE_TYPE:
-      return Object.assign({}, state, {
-        pendingMoveType: action.payload,
       });
     case CREATE_OR_UPDATE_MOVE.success:
       return Object.assign({}, state, {

--- a/src/shared/UI/ducks.js
+++ b/src/shared/UI/ducks.js
@@ -9,6 +9,12 @@ const initialState = {
 };
 
 const SET_CURRENT_SHIPMENT_ID = 'SET_CURRENT_SHIPMENT_ID';
+const SET_PENDING_MOVE_TYPE = 'SET_PENDING_MOVE_TYPE';
+
+// Action Creation
+export function setPendingMoveType(value) {
+  return { type: SET_PENDING_MOVE_TYPE, payload: value };
+}
 
 export default function uiReducer(state = initialState, action) {
   switch (action.type) {
@@ -31,6 +37,10 @@ export default function uiReducer(state = initialState, action) {
         ...state,
         currentShipmentID: action.shipmentID,
       };
+    case SET_PENDING_MOVE_TYPE:
+      return Object.assign({}, state, {
+        pendingMoveType: action.payload,
+      });
     default:
       return state;
   }


### PR DESCRIPTION
## Description

Moves setPendingMoveType from moves ducks to UI ducks. 

## Code Review Verification Steps

* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/165795021) for this change
