### PR TITLE
Modify circleci to remove the repo from the gopath

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -478,7 +478,7 @@ jobs:
             curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
             chmod +x ./cc-test-reporter
             ./cc-test-reporter before-build -d
-          working_directory: /home/circleci/go/src
+          working_directory: /home/circleci/
       - run:
           name: make server_test_coverage_generate
           command: |
@@ -508,11 +508,11 @@ jobs:
       - run:
           name: upload code coverage to code climate
           command: |
-            export GIT_COMMITTED_AT=`git -C "github.com/transcom/mymove" log -1 --pretty=format:%ct`
+            export GIT_COMMITTED_AT=`git -C "transcom/mymove" log -1 --pretty=format:%ct`
             ./cc-test-reporter format-coverage github.com/transcom/mymove/coverage.out -t gocov -d
             ./cc-test-reporter upload-coverage -d
           # needs to run from this directory so that it can find the source code.
-          working_directory: /home/circleci/go/src
+          working_directory: /home/circleci/
 
   # `client_test` runs the client side Javascript tests
   client_test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -502,12 +502,6 @@ jobs:
             curl -s https://codecov.io/bash > /home/circleci/codecov
             chmod +x /home/circleci/codecov
             /home/circleci/codecov -F go -f coverage.out
-      - run:
-          name: upload code coverage to code climate
-          command: |
-            export GIT_COMMITTED_AT=`git log -1 --pretty=format:%ct`
-            /home/circleci/cc-test-reporter format-coverage coverage.out -t gocov -d
-            /home/circleci/cc-test-reporter upload-coverage -d
 
   # `client_test` runs the client side Javascript tests
   client_test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -862,9 +862,9 @@ workflows:
             - pre_deps_yarn
             - acceptance_tests_local
           # if testing on experimental, you can disable these tests by using the commented block below.
-          filters:
-           branches:
-             ignore: cg_repo_not_in_gopath
+          # filters:
+          #  branches:
+          #    ignore: placeholder_branch_name
 
       - integration_tests_office:
           requires:
@@ -872,9 +872,9 @@ workflows:
             - pre_deps_yarn
             - acceptance_tests_local
           # if testing on experimental, you can disable these tests by using the commented block below.
-          filters:
-            branches:
-              ignore: cg_repo_not_in_gopath
+          # filters:
+          #   branches:
+          #     ignore: placeholder_branch_name
 
       - integration_tests_tsp:
           requires:
@@ -882,9 +882,9 @@ workflows:
             - pre_deps_yarn
             - acceptance_tests_local
           # if testing on experimental, you can disable these tests by using the commented block below.
-          filters:
-            branches:
-              ignore: cg_repo_not_in_gopath
+          # filters:
+          #   branches:
+          #     ignore: placeholder_branch_name
 
       - integration_tests_api:
           requires:
@@ -892,9 +892,9 @@ workflows:
             - pre_deps_yarn
             - acceptance_tests_local
           # if testing on experimental, you can disable these tests by using the commented block below.
-          filters:
-            branches:
-              ignore: cg_repo_not_in_gopath
+          # filters:
+          #   branches:
+          #     ignore: placeholder_branch_name
 
       - client_test:
           requires:
@@ -939,28 +939,28 @@ workflows:
             - build_migrations
           filters:
             branches:
-              only: cg_repo_not_in_gopath
+              only: placeholder_branch_name
 
       - deploy_experimental_tasks:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: cg_repo_not_in_gopath
+              only: placeholder_branch_name
 
       - deploy_experimental_app:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: cg_repo_not_in_gopath
+              only: placeholder_branch_name
 
       - deploy_experimental_app_client_tls:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: cg_repo_not_in_gopath
+              only: placeholder_branch_name
 
       - check_circle_against_staging_sha:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -475,10 +475,9 @@ jobs:
           name: Setup Code Climate test-reporter
           command: |
             # download test reporter as a static binary
-            curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
-            chmod +x ./cc-test-reporter
-            ./cc-test-reporter before-build -d
-          working_directory: /home/circleci/
+            curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > /home/circleci/cc-test-reporter
+            chmod +x /home/circleci/cc-test-reporter
+            /home/circleci/cc-test-reporter before-build -d
       - run:
           name: make server_test_coverage_generate
           command: |
@@ -497,22 +496,18 @@ jobs:
             MIGRATION_PATH: /home/circleci/transcom/mymove/migrations
             SECURE_MIGRATION_DIR: /home/circleci/transcom/mymove/local_migrations
             SECURE_MIGRATION_SOURCE: local
-          working_directory: /home/circleci/transcom/mymove
       - run:
           name: upload code coverage to codecov
           command: |
-            curl -s https://codecov.io/bash > codecov
-            chmod +x codecov
-            ./codecov -F go -f coverage.out
-          working_directory: /home/circleci/transcom/mymove
+            curl -s https://codecov.io/bash > /home/circleci/codecov
+            chmod +x /home/circleci/codecov
+            /home/circleci/codecov -F go -f coverage.out
       - run:
           name: upload code coverage to code climate
           command: |
-            export GIT_COMMITTED_AT=`git -C "transcom/mymove" log -1 --pretty=format:%ct`
-            ./cc-test-reporter format-coverage transcom/mymove/coverage.out -t gocov -d
-            ./cc-test-reporter upload-coverage -d
-          # needs to run from this directory so that it can find the source code.
-          working_directory: /home/circleci/
+            export GIT_COMMITTED_AT=`git log -1 --pretty=format:%ct`
+            /home/circleci/cc-test-reporter format-coverage coverage.out -t gocov -d
+            /home/circleci/cc-test-reporter upload-coverage -d
 
   # `client_test` runs the client side Javascript tests
   client_test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -509,7 +509,7 @@ jobs:
           name: upload code coverage to code climate
           command: |
             export GIT_COMMITTED_AT=`git -C "transcom/mymove" log -1 --pretty=format:%ct`
-            ./cc-test-reporter format-coverage github.com/transcom/mymove/coverage.out -t gocov -d
+            ./cc-test-reporter format-coverage transcom/mymove/coverage.out -t gocov -d
             ./cc-test-reporter upload-coverage -d
           # needs to run from this directory so that it can find the source code.
           working_directory: /home/circleci/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -862,9 +862,9 @@ workflows:
             - pre_deps_yarn
             - acceptance_tests_local
           # if testing on experimental, you can disable these tests by using the commented block below.
-          # filters:
-          #  branches:
-          #    ignore: placeholder_branch_name
+          filters:
+           branches:
+             ignore: cg_repo_not_in_gopath
 
       - integration_tests_office:
           requires:
@@ -872,9 +872,9 @@ workflows:
             - pre_deps_yarn
             - acceptance_tests_local
           # if testing on experimental, you can disable these tests by using the commented block below.
-          # filters:
-          #   branches:
-          #     ignore: placeholder_branch_name
+          filters:
+            branches:
+              ignore: cg_repo_not_in_gopath
 
       - integration_tests_tsp:
           requires:
@@ -882,9 +882,9 @@ workflows:
             - pre_deps_yarn
             - acceptance_tests_local
           # if testing on experimental, you can disable these tests by using the commented block below.
-          # filters:
-          #   branches:
-          #     ignore: placeholder_branch_name
+          filters:
+            branches:
+              ignore: cg_repo_not_in_gopath
 
       - integration_tests_api:
           requires:
@@ -892,9 +892,9 @@ workflows:
             - pre_deps_yarn
             - acceptance_tests_local
           # if testing on experimental, you can disable these tests by using the commented block below.
-          # filters:
-          #   branches:
-          #     ignore: placeholder_branch_name
+          filters:
+            branches:
+              ignore: cg_repo_not_in_gopath
 
       - client_test:
           requires:
@@ -939,28 +939,28 @@ workflows:
             - build_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: cg_repo_not_in_gopath
 
       - deploy_experimental_tasks:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: cg_repo_not_in_gopath
 
       - deploy_experimental_app:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: cg_repo_not_in_gopath
 
       - deploy_experimental_app_client_tls:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: cg_repo_not_in_gopath
 
       - check_circle_against_staging_sha:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,33 +13,25 @@ executors:
   # `mymove_small` and `mymove_medium` use the `trussworks/circleci-docker-primary` docker image with a checkout of the mymove code
   mymove_small:
     resource_class: small
-    working_directory: ~/go/src/github.com/transcom/mymove
+    working_directory: ~/transcom/mymove
     docker:
       - image: trussworks/circleci-docker-primary:9ad70927655a601580c036d53456c70061c76cba
-        environment:
-            GO111MODULE: "on"
   mymove_medium:
     resource_class: medium
-    working_directory: ~/go/src/github.com/transcom/mymove
+    working_directory: ~/transcom/mymove
     docker:
       - image: trussworks/circleci-docker-primary:9ad70927655a601580c036d53456c70061c76cba
-        environment:
-          GO111MODULE: "on"
   mymove_large:
     resource_class: large
-    working_directory: ~/go/src/github.com/transcom/mymove
+    working_directory: ~/transcom/mymove
     docker:
       - image: trussworks/circleci-docker-primary:9ad70927655a601580c036d53456c70061c76cba
-        environment:
-          GO111MODULE: "on"
   # `mymove_and_postgres_medium` adds a secondary postgres container to be used during testing.
   mymove_and_postgres_medium:
     resource_class: medium
-    working_directory: ~/go/src/github.com/transcom/mymove
+    working_directory: ~/transcom/mymove
     docker:
       - image: trussworks/circleci-docker-primary:9ad70927655a601580c036d53456c70061c76cba
-        environment:
-          GO111MODULE: "on"
       - image: postgres:10.6
         environment:
           - POSTGRES_PASSWORD: mysecretpassword
@@ -76,7 +68,7 @@ commands:
           docker_layer_caching: true
       - restore_cache:
           keys:
-            - go-mod-souces-v1-{{ checksum "go.sum" }}
+            - go-mod-sources-v2-{{ checksum "go.sum" }}
       - attach_workspace:
           at: bin
       - deploy:
@@ -98,7 +90,7 @@ commands:
             [[ -z "<< parameters.compare_host >>" ]] || scripts/compare-deployed-commit "<< parameters.compare_host >>" $CIRCLE_SHA1
       - restore_cache:
           keys:
-            - go-mod-souces-v1-{{ checksum "go.sum" }}
+            - go-mod-sources-v2-{{ checksum "go.sum" }}
       - attach_workspace:
           at: bin
       - setup_remote_docker:
@@ -128,7 +120,7 @@ commands:
             [[ -z "<< parameters.compare_host >>" ]] || scripts/compare-deployed-commit "<< parameters.compare_host >>" $CIRCLE_SHA1 ${EXPERIMENTAL_MOVE_MIL_DOD_TLS_KEY} ${EXPERIMENTAL_MOVE_MIL_DOD_TLS_CERT} ${EXPERIMENTAL_MOVE_MIL_DOD_TLS_CA}
       - restore_cache:
           keys:
-            - go-mod-souces-v1-{{ checksum "go.sum" }}
+            - go-mod-sources-v2-{{ checksum "go.sum" }}
       - setup_remote_docker:
           docker_layer_caching: true
       - attach_workspace:
@@ -169,10 +161,10 @@ commands:
       - run:
           name: make e2e_test_docker
           command: |
-            echo 'export MOVE_MIL_DOD_CA_CERT=$(cat /home/circleci/go/src/github.com/transcom/mymove/config/tls/devlocal-ca.pem)' >> $BASH_ENV
-            echo 'export MOVE_MIL_DOD_TLS_CERT=$(cat /home/circleci/go/src/github.com/transcom/mymove/config/tls/devlocal-https.pem)' >> $BASH_ENV
-            echo 'export MOVE_MIL_DOD_TLS_KEY=$(cat /home/circleci/go/src/github.com/transcom/mymove/config/tls/devlocal-https.key)' >> $BASH_ENV
-            echo 'export CLIENT_AUTH_SECRET_KEY=$(cat /home/circleci/go/src/github.com/transcom/mymove/config/tls/devlocal-client_auth_secret.key)' >> $BASH_ENV
+            echo 'export MOVE_MIL_DOD_CA_CERT=$(cat /home/circleci/transcom/mymove/config/tls/devlocal-ca.pem)' >> $BASH_ENV
+            echo 'export MOVE_MIL_DOD_TLS_CERT=$(cat /home/circleci/transcom/mymove/config/tls/devlocal-https.pem)' >> $BASH_ENV
+            echo 'export MOVE_MIL_DOD_TLS_KEY=$(cat /home/circleci/transcom/mymove/config/tls/devlocal-https.key)' >> $BASH_ENV
+            echo 'export CLIENT_AUTH_SECRET_KEY=$(cat /home/circleci/transcom/mymove/config/tls/devlocal-client_auth_secret.key)' >> $BASH_ENV
             echo 'export LOGIN_GOV_SECRET_KEY=$(echo $E2E_LOGIN_GOV_SECRET_KEY | base64 --decode)' >> $BASH_ENV
             echo 'export LOGIN_GOV_HOSTNAME=$E2E_LOGIN_GOV_HOSTNAME' >> $BASH_ENV
             echo 'export HERE_MAPS_APP_ID=$E2E_HERE_MAPS_APP_ID' >> $BASH_ENV
@@ -188,7 +180,7 @@ commands:
             DB_PORT: 5432
             DB_NAME: test_db
             # Env vars needed for the webserver to run inside docker
-            SECURE_MIGRATION_DIR: /home/circleci/go/src/github.com/transcom/mymove/local_migrations
+            SECURE_MIGRATION_DIR: /home/circleci/transcom/mymove/local_migrations
             SECURE_MIGRATION_SOURCE: local
             LOGIN_GOV_CALLBACK_PROTOCOL: http
             LOGIN_GOV_MY_CLIENT_ID: urn:gov:gsa:openidconnect.profiles:sp:sso:dod:mymovemillocal
@@ -198,7 +190,7 @@ commands:
             LOGIN_GOV_HOSTNAME: idp.int.identitysandbox.gov
             HERE_MAPS_GEOCODE_ENDPOINT: https://geocoder.cit.api.here.com/6.2/geocode.json
             HERE_MAPS_ROUTING_ENDPOINT: https://route.cit.api.here.com/routing/7.2/calculateroute.json
-            DOD_CA_PACKAGE: /home/circleci/go/src/github.com/transcom/mymove/config/tls/Certificates_PKCS7_v5.4_DoD.der.p7b
+            DOD_CA_PACKAGE: /home/circleci/transcom/mymove/config/tls/Certificates_PKCS7_v5.4_DoD.der.p7b
 
 jobs:
   # `pre_deps_golang` is used for caching Go module sources
@@ -208,12 +200,12 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - go-mod-souces-v1-{{ checksum "go.sum" }}
+            - go-mod-sources-v2-{{ checksum "go.sum" }}
       - run:
           name: Install dependencies
           command: for i in $(seq 1 5); do go get && s=0 && break || s=$? && sleep 5; done; (exit $s)
       - save_cache:
-          key: go-mod-souces-v1-{{ checksum "go.sum" }}
+          key: go-mod-sources-v2-{{ checksum "go.sum" }}
           paths:
             - "/go/pkg/mod"
       - announce_failure
@@ -225,23 +217,23 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - v1-cache-yarn-v2-{{ checksum "yarn.lock" }}
+            - v2-cache-yarn-v2-{{ checksum "yarn.lock" }}
       - restore_cache:
           keys:
-            - v1-mymove-node-modules-{{ checksum "yarn.lock" }}
+            - v2-mymove-node-modules-{{ checksum "yarn.lock" }}
       - run:
           name: Install YARN dependencies
           command: yarn install
-      # `v1-cache-yarn-v2-{{ checksum "yarn.lock" }}` is used to cache yarn sources
+      # `v2-cache-yarn-v2-{{ checksum "yarn.lock" }}` is used to cache yarn sources
       - save_cache:
-          key: v1-cache-yarn-v2-{{ checksum "yarn.lock" }}
+          key: v2-cache-yarn-v2-{{ checksum "yarn.lock" }}
           paths:
             - ~/.cache/yarn/v2
-      # `v1-mymove-node-modules-{{ checksum "yarn.lock" }}` is used to cache installed node modules
+      # `v2-mymove-node-modules-{{ checksum "yarn.lock" }}` is used to cache installed node modules
       - save_cache:
-          key: v1-mymove-node-modules-{{ checksum "yarn.lock" }}
+          key: v2-mymove-node-modules-{{ checksum "yarn.lock" }}
           paths:
-            - ~/go/src/github.com/transcom/mymove/node_modules
+            - ~/transcom/mymove/node_modules
       - announce_failure
 
   # `pre_test` runs pre-commit against all files.
@@ -251,13 +243,13 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - go-mod-souces-v1-{{ checksum "go.sum" }}
+            - go-mod-sources-v2-{{ checksum "go.sum" }}
       - restore_cache:
           keys:
-            - v1-cache-yarn-v2-{{ checksum "yarn.lock" }}
+            - v2-cache-yarn-v2-{{ checksum "yarn.lock" }}
       - restore_cache:
           keys:
-            - v1-mymove-node-modules-{{ checksum "yarn.lock" }}
+            - v2-mymove-node-modules-{{ checksum "yarn.lock" }}
       - restore_cache:
           keys:
             - pre-commit-dot-cache-{{ checksum ".pre-commit-config.yaml" }}
@@ -282,17 +274,17 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - go-mod-souces-v1-{{ checksum "go.sum" }}
+            - go-mod-sources-v2-{{ checksum "go.sum" }}
       - run:
           name: Run make server_generate
           command: make server_generate
       - run:
           name: Run acceptance tests
           command: |
-            echo 'export MOVE_MIL_DOD_CA_CERT=$(cat /home/circleci/go/src/github.com/transcom/mymove/config/tls/devlocal-ca.pem)' >> $BASH_ENV
-            echo 'export MOVE_MIL_DOD_TLS_CERT=$(cat /home/circleci/go/src/github.com/transcom/mymove/config/tls/devlocal-https.pem)' >> $BASH_ENV
-            echo 'export MOVE_MIL_DOD_TLS_KEY=$(cat /home/circleci/go/src/github.com/transcom/mymove/config/tls/devlocal-https.key)' >> $BASH_ENV
-            echo 'export CLIENT_AUTH_SECRET_KEY=$(cat /home/circleci/go/src/github.com/transcom/mymove/config/tls/devlocal-client_auth_secret.key)' >> $BASH_ENV
+            echo 'export MOVE_MIL_DOD_CA_CERT=$(cat /home/circleci/transcom/mymove/config/tls/devlocal-ca.pem)' >> $BASH_ENV
+            echo 'export MOVE_MIL_DOD_TLS_CERT=$(cat /home/circleci/transcom/mymove/config/tls/devlocal-https.pem)' >> $BASH_ENV
+            echo 'export MOVE_MIL_DOD_TLS_KEY=$(cat /home/circleci/transcom/mymove/config/tls/devlocal-https.key)' >> $BASH_ENV
+            echo 'export CLIENT_AUTH_SECRET_KEY=$(cat /home/circleci/transcom/mymove/config/tls/devlocal-client_auth_secret.key)' >> $BASH_ENV
             echo 'export LOGIN_GOV_SECRET_KEY=$(echo $E2E_LOGIN_GOV_SECRET_KEY | base64 --decode)' >> $BASH_ENV
             echo 'export LOGIN_GOV_HOSTNAME=$E2E_LOGIN_GOV_HOSTNAME' >> $BASH_ENV
             echo 'export HERE_MAPS_APP_ID=$E2E_HERE_MAPS_APP_ID' >> $BASH_ENV
@@ -302,10 +294,10 @@ jobs:
           environment:
             ENV: test
             ENVIRONMENT: test
-            PWD: /home/circleci/go/src/github.com/transcom/mymove
+            PWD: /home/circleci/transcom/mymove
             LOGIN_GOV_HOSTNAME: idp.int.identitysandbox.gov
-            DOD_CA_PACKAGE: /home/circleci/go/src/github.com/transcom/mymove/config/tls/Certificates_PKCS7_v5.4_DoD.der.p7b
-            DEVLOCAL_CA: /home/circleci/go/src/github.com/transcom/mymove/config/tls/devlocal-ca.pem
+            DOD_CA_PACKAGE: /home/circleci/transcom/mymove/config/tls/Certificates_PKCS7_v5.4_DoD.der.p7b
+            DEVLOCAL_CA: /home/circleci/transcom/mymove/config/tls/devlocal-ca.pem
             NO_TLS_ENABLED: true
       - announce_failure
 
@@ -318,13 +310,13 @@ jobs:
           docker_layer_caching: true
       - restore_cache:
           keys:
-            - go-mod-souces-v1-{{ checksum "go.sum" }}
+            - go-mod-sources-v2-{{ checksum "go.sum" }}
       - restore_cache:
           keys:
-            - v1-cache-yarn-v2-{{ checksum "yarn.lock" }}
+            - v2-cache-yarn-v2-{{ checksum "yarn.lock" }}
       - restore_cache:
           keys:
-            - v1-mymove-node-modules-{{ checksum "yarn.lock" }}
+            - v2-mymove-node-modules-{{ checksum "yarn.lock" }}
       - e2e_tests:
           spec: 'cypress/integration/mymove/**/*'
       - store_artifacts:
@@ -346,13 +338,13 @@ jobs:
           docker_layer_caching: true
       - restore_cache:
           keys:
-            - go-mod-souces-v1-{{ checksum "go.sum" }}
+            - go-mod-sources-v2-{{ checksum "go.sum" }}
       - restore_cache:
           keys:
-            - v1-cache-yarn-v2-{{ checksum "yarn.lock" }}
+            - v2-cache-yarn-v2-{{ checksum "yarn.lock" }}
       - restore_cache:
           keys:
-            - v1-mymove-node-modules-{{ checksum "yarn.lock" }}
+            - v2-mymove-node-modules-{{ checksum "yarn.lock" }}
       - e2e_tests:
           spec: 'cypress/integration/office/**/*'
       - store_artifacts:
@@ -374,13 +366,13 @@ jobs:
           docker_layer_caching: true
       - restore_cache:
           keys:
-            - go-mod-souces-v1-{{ checksum "go.sum" }}
+            - go-mod-sources-v2-{{ checksum "go.sum" }}
       - restore_cache:
           keys:
-            - v1-cache-yarn-v2-{{ checksum "yarn.lock" }}
+            - v2-cache-yarn-v2-{{ checksum "yarn.lock" }}
       - restore_cache:
           keys:
-            - v1-mymove-node-modules-{{ checksum "yarn.lock" }}
+            - v2-mymove-node-modules-{{ checksum "yarn.lock" }}
       - e2e_tests:
           spec: 'cypress/integration/tsp/**/*'
       - store_artifacts:
@@ -402,13 +394,13 @@ jobs:
           docker_layer_caching: true
       - restore_cache:
           keys:
-            - go-mod-souces-v1-{{ checksum "go.sum" }}
+            - go-mod-sources-v2-{{ checksum "go.sum" }}
       - restore_cache:
           keys:
-            - v1-cache-yarn-v2-{{ checksum "yarn.lock" }}
+            - v2-cache-yarn-v2-{{ checksum "yarn.lock" }}
       - restore_cache:
           keys:
-            - v1-mymove-node-modules-{{ checksum "yarn.lock" }}
+            - v2-mymove-node-modules-{{ checksum "yarn.lock" }}
       - e2e_tests:
           spec: 'cypress/integration/api/**/*'
       - store_artifacts:
@@ -430,7 +422,7 @@ jobs:
           docker_layer_caching: true
       - restore_cache:
           keys:
-            - go-mod-souces-v1-{{ checksum "go.sum" }}
+            - go-mod-sources-v2-{{ checksum "go.sum" }}
       - run:
           # This is needed to use `psql` to test DB connectivity, until the app
           # itself starts making database connections.
@@ -455,8 +447,8 @@ jobs:
             DB_NAME: test_db
             ENV: test
             ENVIRONMENT: test
-            MIGRATION_PATH: /home/circleci/go/src/github.com/transcom/mymove/migrations
-            SECURE_MIGRATION_DIR: /home/circleci/go/src/github.com/transcom/mymove/local_migrations
+            MIGRATION_PATH: /home/circleci/transcom/mymove/migrations
+            SECURE_MIGRATION_DIR: /home/circleci/transcom/mymove/local_migrations
             SECURE_MIGRATION_SOURCE: local
       - announce_failure
 
@@ -469,7 +461,7 @@ jobs:
           docker_layer_caching: true
       - restore_cache:
           keys:
-            - go-mod-souces-v1-{{ checksum "go.sum" }}
+            - go-mod-sources-v2-{{ checksum "go.sum" }}
       - run:
           # This is needed to use `psql` to test DB connectivity, until the app
           # itself starts making database connections.
@@ -502,17 +494,17 @@ jobs:
             DB_NAME: test_db
             ENV: test
             ENVIRONMENT: test
-            MIGRATION_PATH: /home/circleci/go/src/github.com/transcom/mymove/migrations
-            SECURE_MIGRATION_DIR: /home/circleci/go/src/github.com/transcom/mymove/local_migrations
+            MIGRATION_PATH: /home/circleci/transcom/mymove/migrations
+            SECURE_MIGRATION_DIR: /home/circleci/transcom/mymove/local_migrations
             SECURE_MIGRATION_SOURCE: local
-          working_directory: /home/circleci/go/src/github.com/transcom/mymove
+          working_directory: /home/circleci/transcom/mymove
       - run:
           name: upload code coverage to codecov
           command: |
             curl -s https://codecov.io/bash > codecov
             chmod +x codecov
             ./codecov -F go -f coverage.out
-          working_directory: /home/circleci/go/src/github.com/transcom/mymove
+          working_directory: /home/circleci/transcom/mymove
       - run:
           name: upload code coverage to code climate
           command: |
@@ -531,10 +523,10 @@ jobs:
           docker_layer_caching: true
       - restore_cache:
           keys:
-            - v1-cache-yarn-v2-{{ checksum "yarn.lock" }}
+            - v2-cache-yarn-v2-{{ checksum "yarn.lock" }}
       - restore_cache:
           keys:
-            - v1-mymove-node-modules-{{ checksum "yarn.lock" }}
+            - v2-mymove-node-modules-{{ checksum "yarn.lock" }}
       - run: make client_test
       - announce_failure
 
@@ -545,7 +537,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - go-mod-souces-v1-{{ checksum "go.sum" }}
+            - go-mod-sources-v2-{{ checksum "go.sum" }}
       - run: make build_tools
       - persist_to_workspace:
           root: bin
@@ -565,13 +557,13 @@ jobs:
           docker_layer_caching: true
       - restore_cache:
           keys:
-            - go-mod-souces-v1-{{ checksum "go.sum" }}
+            - go-mod-sources-v2-{{ checksum "go.sum" }}
       - restore_cache:
           keys:
-            - v1-cache-yarn-v2-{{ checksum "yarn.lock" }}
+            - v2-cache-yarn-v2-{{ checksum "yarn.lock" }}
       - restore_cache:
           keys:
-            - v1-mymove-node-modules-{{ checksum "yarn.lock" }}
+            - v2-mymove-node-modules-{{ checksum "yarn.lock" }}
       - run: make bin/chamber
       - run: make bin/rds-combined-ca-bundle.pem
       - run: make build
@@ -606,7 +598,7 @@ jobs:
           docker_layer_caching: true
       - restore_cache:
           keys:
-            - go-mod-souces-v1-{{ checksum "go.sum" }}
+            - go-mod-sources-v2-{{ checksum "go.sum" }}
       - run: make bin/chamber
       - run: make bin/rds-combined-ca-bundle.pem
       - run: make tasks_build
@@ -623,7 +615,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - go-mod-souces-v1-{{ checksum "go.sum" }}
+            - go-mod-sources-v2-{{ checksum "go.sum" }}
       - run:
           name: Run make server_generate
           command: make server_generate
@@ -637,8 +629,8 @@ jobs:
             ENV: test
             ENVIRONMENT: experimental
             CHAMBER_RETRIES: 20
-            PWD: /home/circleci/go/src/github.com/transcom/mymove
-            DOD_CA_PACKAGE: /home/circleci/go/src/github.com/transcom/mymove/config/tls/Certificates_PKCS7_v5.4_DoD.der.p7b
+            PWD: /home/circleci/transcom/mymove
+            DOD_CA_PACKAGE: /home/circleci/transcom/mymove/config/tls/Certificates_PKCS7_v5.4_DoD.der.p7b
             TEST_ACC_ENV: experimental
             NO_TLS_ENABLED: true
       - announce_failure
@@ -694,7 +686,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - go-mod-souces-v1-{{ checksum "go.sum" }}
+            - go-mod-sources-v2-{{ checksum "go.sum" }}
       - run:
           name: Run make server_generate
           command: make server_generate
@@ -708,8 +700,8 @@ jobs:
             ENV: test
             ENVIRONMENT: staging
             CHAMBER_RETRIES: 20
-            PWD: /home/circleci/go/src/github.com/transcom/mymove
-            DOD_CA_PACKAGE: /home/circleci/go/src/github.com/transcom/mymove/config/tls/Certificates_PKCS7_v5.4_DoD.der.p7b
+            PWD: /home/circleci/transcom/mymove
+            DOD_CA_PACKAGE: /home/circleci/transcom/mymove/config/tls/Certificates_PKCS7_v5.4_DoD.der.p7b
             TEST_ACC_ENV: staging
             NO_TLS_ENABLED: true
       - announce_failure
@@ -794,7 +786,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - go-mod-souces-v1-{{ checksum "go.sum" }}
+            - go-mod-sources-v2-{{ checksum "go.sum" }}
       - run:
           name: Add ~/go/bin to path for golint
           command: echo 'export PATH=${PATH}:~/go/bin' >> $BASH_ENV
@@ -816,10 +808,10 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - v1-cache-yarn-v2-{{ checksum "yarn.lock" }}
+            - v2-cache-yarn-v2-{{ checksum "yarn.lock" }}
       - restore_cache:
           keys:
-            - v1-mymove-node-modules-{{ checksum "yarn.lock" }}
+            - v2-mymove-node-modules-{{ checksum "yarn.lock" }}
       - run: make client_deps_update
       - run:
           name: Display changes


### PR DESCRIPTION
## Description

Go modules were enabled in go 1.12. Instead of changing the path of the repo outside of the `$GOPATH` we instead forced go modules to be turned on with `GO111MODULE=on`.  Unfortunately not all our tools work with go modules yet and forcing `on` vs `auto` makes it so they won't work. This became apparent as we worked with `golangci-lint` repo that has a dependency not yet ready for go modules.  

In this PR I move the repo outside the gopath and remove `GO111MODULE=on` for testing.  This implies the default of `GO111MODULE=auto` and fixes issues with tool dependencies.

## Setup

Run in CircleCI

## Code Review Verification Steps

* [x] Request review from a member of a different team.
* [x] Deploy to Experimental

## References

See work in https://github.com/transcom/mymove/pull/2156
