### PR TITLE
Changed env flag for generate-test-data to use double hyphens

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -681,7 +681,7 @@ db_e2e_up: bin/generate-test-data
 	@echo "Truncate the ${DB_NAME_TEST} database..."
 	psql postgres://postgres:$(PGPASSWORD)@localhost:$(DB_PORT_TEST)/$(DB_NAME_TEST)?sslmode=disable -c 'TRUNCATE users CASCADE;'
 	@echo "Populate the ${DB_NAME_TEST} database..."
-	DB_PORT=$(DB_PORT_TEST) bin/generate-test-data --named-scenario="e2e_basic" -env="test"
+	DB_PORT=$(DB_PORT_TEST) bin/generate-test-data --named-scenario="e2e_basic" --env="test"
 
 .PHONY: db_e2e_up_docker
 db_e2e_up_docker:
@@ -716,7 +716,7 @@ db_e2e_init_docker: db_test_reset_docker db_test_migrate_docker db_e2e_up_docker
 .PHONY: db_dev_e2e_populate
 db_dev_e2e_populate: db_dev_reset db_dev_migrate build_tools
 	@echo "Populate the ${DB_NAME_DEV} database with docker command..."
-	bin/generate-test-data --named-scenario="e2e_basic" -env="development"
+	bin/generate-test-data --named-scenario="e2e_basic" --env="development"
 
 .PHONY: db_test_e2e_populate
 db_test_e2e_populate: db_test_reset_docker db_test_migrate_docker build_tools db_e2e_up_docker


### PR DESCRIPTION
## Description

When running a `make db_dev_e2e_populate` on master, this error is occurring:

```
bin/generate-test-data --named-scenario="e2e_basic" -env="development"
unknown shorthand flag: 'e' in -env=development
```

It appears the `env` flag needs double-hyphens now.  This also caused the `db_e2e_up` target to fail as well since it uses the same `generate-test-data` command/flag.

## Setup

Run `make db_dev_e2e_populate` and `make db_e2e_up` and verify that there are no errors and the commands perform as expected.
