### PR TITLE
Add /office_users endpoint for admin API

### DIFF
--- a/pkg/handlers/adminapi/api.go
+++ b/pkg/handlers/adminapi/api.go
@@ -22,7 +22,7 @@ func NewAdminAPIHandler(context handlers.HandlerContext) http.Handler {
 
 	adminAPI := adminops.NewMymoveAPI(adminSpec)
 
-	// TODO: Wire up admin endpoints here.
+	adminAPI.OfficeIndexOfficeUsersHandler = IndexOfficeUsersHandler{context}
 
 	return adminAPI.Serve(nil)
 }

--- a/pkg/handlers/adminapi/api_test.go
+++ b/pkg/handlers/adminapi/api_test.go
@@ -1,0 +1,43 @@
+package adminapi
+
+import (
+	"log"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"go.uber.org/zap"
+
+	"github.com/transcom/mymove/pkg/handlers"
+	"github.com/transcom/mymove/pkg/notifications"
+)
+
+// HandlerSuite is an abstraction of our original suite
+type HandlerSuite struct {
+	handlers.BaseHandlerTestSuite
+}
+
+// SetupTest sets up the test suite by preparing the DB
+func (suite *HandlerSuite) SetupTest() {
+	suite.DB().TruncateAll()
+}
+
+// AfterTest completes tests by trying to close open files
+func (suite *HandlerSuite) AfterTest() {
+	for _, file := range suite.TestFilesToClose() {
+		file.Data.Close()
+	}
+}
+
+// TestHandlerSuite creates our test suite
+func TestHandlerSuite(t *testing.T) {
+	logger, err := zap.NewDevelopment()
+	if err != nil {
+		log.Panic(err)
+	}
+
+	hs := &HandlerSuite{
+		BaseHandlerTestSuite: handlers.NewBaseHandlerTestSuite(logger, notifications.NewStubNotificationSender("adminlocal", logger)),
+	}
+
+	suite.Run(t, hs)
+}

--- a/pkg/handlers/adminapi/office_users.go
+++ b/pkg/handlers/adminapi/office_users.go
@@ -1,0 +1,18 @@
+package adminapi
+
+import (
+	"github.com/go-openapi/runtime/middleware"
+
+	officeuserop "github.com/transcom/mymove/pkg/gen/adminapi/adminoperations/office"
+	"github.com/transcom/mymove/pkg/handlers"
+)
+
+// IndexOfficeUsersHandler returns a list of office users via GET /office_users
+type IndexOfficeUsersHandler struct {
+	handlers.HandlerContext
+}
+
+// Handle retrieves a list of office users
+func (h IndexOfficeUsersHandler) Handle(params officeuserop.IndexOfficeUsersParams) middleware.Responder {
+	return officeuserop.NewIndexOfficeUsersOK()
+}

--- a/pkg/handlers/adminapi/office_users_test.go
+++ b/pkg/handlers/adminapi/office_users_test.go
@@ -1,0 +1,21 @@
+package adminapi
+
+import (
+	"net/http/httptest"
+
+	officeuserop "github.com/transcom/mymove/pkg/gen/adminapi/adminoperations/office"
+	"github.com/transcom/mymove/pkg/handlers"
+)
+
+func (suite *HandlerSuite) TestIndexOfficeUsersHandler() {
+	req := httptest.NewRequest("GET", "/office_users", nil)
+
+	params := officeuserop.IndexOfficeUsersParams{
+		HTTPRequest: req,
+	}
+
+	handler := IndexOfficeUsersHandler{handlers.NewHandlerContext(suite.DB(), suite.TestLogger())}
+	response := handler.Handle(params)
+
+	suite.Assertions.IsType(&officeuserop.IndexOfficeUsersOK{}, response)
+}

--- a/pkg/handlers/adminapi/office_users_test.go
+++ b/pkg/handlers/adminapi/office_users_test.go
@@ -9,9 +9,9 @@ import (
 )
 
 func (suite *HandlerSuite) TestIndexOfficeUsersHandler() {
-	officeUser := testdatagen.MakeDefaultOfficeUser(suite.DB())
+	user := testdatagen.MakeDefaultUser(suite.DB())
 	req := httptest.NewRequest("GET", "/office_users", nil)
-	req = suite.AuthenticateOfficeRequest(req, officeUser)
+	req = suite.AuthenticateUserRequest(req, user)
 
 	params := officeuserop.IndexOfficeUsersParams{
 		HTTPRequest: req,

--- a/pkg/handlers/adminapi/office_users_test.go
+++ b/pkg/handlers/adminapi/office_users_test.go
@@ -5,10 +5,13 @@ import (
 
 	officeuserop "github.com/transcom/mymove/pkg/gen/adminapi/adminoperations/office"
 	"github.com/transcom/mymove/pkg/handlers"
+	"github.com/transcom/mymove/pkg/testdatagen"
 )
 
 func (suite *HandlerSuite) TestIndexOfficeUsersHandler() {
+	officeUser := testdatagen.MakeDefaultOfficeUser(suite.DB())
 	req := httptest.NewRequest("GET", "/office_users", nil)
+	req = suite.AuthenticateOfficeRequest(req, officeUser)
 
 	params := officeuserop.IndexOfficeUsersParams{
 		HTTPRequest: req,

--- a/swagger/admin.yaml
+++ b/swagger/admin.yaml
@@ -228,8 +228,8 @@ definitions:
 paths:
   /office_users:
     get:
-      summary: List the office users for a specific office
-      description: Returns a list of office users given an office ID
+      summary: List office users
+      description: Returns a list of office users
       operationId: indexOfficeUsers
       tags:
         - office

--- a/swagger/admin.yaml
+++ b/swagger/admin.yaml
@@ -235,9 +235,10 @@ paths:
         - office
       parameters:
         - in: query
-          name: transportationOfficeId
-          type: string
-          format: uuid
+          name: filter
+          type: array
+          items:
+            type: string
       responses:
         200:
           description: success

--- a/swagger/admin.yaml
+++ b/swagger/admin.yaml
@@ -11,14 +11,241 @@ consumes:
   - application/json
 produces:
   - application/json
+definitions:
+  OfficeUser:
+    type: object
+    properties:
+      id:
+        type: string
+        format: uuid
+        example: c56a4180-65aa-42ec-a945-5fd21dec0538
+      first_name:
+        type: string
+      last_name:
+        type: string
+      email:
+        type: string
+        format: x-email
+        pattern: '^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$'
+      telephone:
+        type: string
+        format: telephone
+        pattern: '^[2-9]\d{2}-\d{3}-\d{4}$'
+      transportation_office:
+        $ref: '#/definitions/TransportationOffice'
+  OfficeUsers:
+    type: array
+    items:
+      $ref: '#/definitions/OfficeUser'
+  TransportationOffice:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          example: c56a4180-65aa-42ec-a945-5fd21dec0538
+        name:
+          type: string
+          example: Fort Bragg North Station
+        address:
+          $ref: '#/definitions/Address'
+        phone_lines:
+          type: array
+          items:
+            type: string
+            format: telephone
+            pattern: '^[2-9]\d{2}-\d{3}-\d{4}$'
+            example: 212-555-5555
+        gbloc:
+          type: string
+          pattern: '^[A-Z]{4}$'
+          example: JENQ
+        latitude:
+          type: number
+          format: float
+          example: 29.382973
+        longitude:
+          type: number
+          format: float
+          example: -98.62759
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+      required:
+        - id
+        - name
+        - address
+        - created_at
+        - updated_at
+  Address:
+    type: object
+    properties:
+      street_address_1:
+        type: string
+        example: 123 Main Ave
+        title: Address line 1
+      street_address_2:
+        type: string
+        example: Apartment 9000
+        x-nullable: true
+        title: Address line 2
+      street_address_3:
+        type: string
+        example: Montmârtre
+        x-nullable: true
+        title: Address line 3
+      city:
+        type: string
+        example: Anytown
+        title: City
+      state:
+        title: State
+        type: string
+        x-display-value:
+          AL: AL
+          AK: AK
+          AR: AR
+          AZ: AZ
+          CA: CA
+          CO: CO
+          CT: CT
+          DC: DC
+          DE: DE
+          FL: FL
+          GA: GA
+          HI: HI
+          IA: IA
+          ID: ID
+          IL: IL
+          IN: IN
+          KS: KS
+          KY: KY
+          LA: LA
+          MA: MA
+          MD: MD
+          ME: ME
+          MI: MI
+          MN: MN
+          MO: MO
+          MS: MS
+          MT: MT
+          NC: NC
+          ND: ND
+          NE: NE
+          NH: NH
+          NJ: NJ
+          NM: NM
+          NV: NV
+          NY: NY
+          OH: OH
+          OK: OK
+          OR: OR
+          PA: PA
+          RI: RI
+          SC: SC
+          SD: SD
+          TN: TN
+          TX: TX
+          UT: UT
+          VA: VA
+          VT: VT
+          WA: WA
+          WI: WI
+          WV: WV
+          WY: WY
+        enum:
+          - AL
+          - AK
+          - AR
+          - AZ
+          - CA
+          - CO
+          - CT
+          - DC
+          - DE
+          - FL
+          - GA
+          - HI
+          - IA
+          - ID
+          - IL
+          - IN
+          - KS
+          - KY
+          - LA
+          - MA
+          - MD
+          - ME
+          - MI
+          - MN
+          - MO
+          - MS
+          - MT
+          - NC
+          - ND
+          - NE
+          - NH
+          - NJ
+          - NM
+          - NV
+          - NY
+          - OH
+          - OK
+          - OR
+          - PA
+          - RI
+          - SC
+          - SD
+          - TN
+          - TX
+          - UT
+          - VA
+          - VT
+          - WA
+          - WI
+          - WV
+          - WY
+      postal_code:
+        type: string
+        description: zip code, international allowed
+        format: zip
+        title: ZIP
+        example: "'90210' or 'N15 3NL'"
+      country:
+        type: string
+        title: Country
+        x-nullable: true
+        example: 'USA'
+        default: USA
+    required:
+      - street_address_1
+      - state
+      - city
+      - postal_code
 paths:
-  /placeholder:
+  /office_users:
     get:
-      summary: Placeholder until we get real endpoints
-      description: Just a placeholder
-      operationId: placeholder
+      summary: List the office users for a specific office
+      description: Returns a list of office users given an office ID
+      operationId: indexOfficeUsers
       tags:
-        - placeholder
+        - office
+      parameters:
+        - in: query
+          name: transportationOfficeId
+          type: string
+          format: uuid
       responses:
-        501:
-          description: nothing to see here
+        200:
+          description: success
+          schema:
+            $ref: '#/definitions/OfficeUsers'
+        400:
+          description: invalid request
+        401:
+          description: request requires user authentication
+        404:
+          description: office not found


### PR DESCRIPTION
## Description

As an System Admin
I want to query the office user list admin endpoint
So I can verify who has office permissions

## Reviewer Notes

- Is there anything else I need to do to make sure the endpoint is unreachable to people that aren't logged in?

## Setup

1. `make server_run`
2. `make server_test`

## Code Review Verification Steps

* [x] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/164884893) for this change
