### PR TITLE
Update office new moves queue heading: 165749867

### DIFF
--- a/cypress/integration/office/officeCSRFProtect.js
+++ b/cypress/integration/office/officeCSRFProtect.js
@@ -11,7 +11,7 @@ describe('testing CSRF protection', function() {
 
   it('tests dev login with both unmasked and masked token', function() {
     cy.signInAsUserPostRequest(officeAppName, userId);
-    cy.contains('Queue: New Moves');
+    cy.contains('New Moves/Shipments');
   });
 
   it('tests dev login with masked token only', function() {

--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -136,12 +136,6 @@ const HHGTabContent = props => {
 const ReferrerQueueLink = props => {
   const pathname = props.history.location.state ? props.history.location.state.referrerPathname : '';
   switch (pathname) {
-    case '/queues/new':
-      return (
-        <NavLink to="/queues/new" activeClassName="usa-current">
-          <span>New Moves Queue</span>
-        </NavLink>
-      );
     case '/queues/ppm':
       return (
         <NavLink to="/queues/ppm" activeClassName="usa-current">
@@ -169,7 +163,7 @@ const ReferrerQueueLink = props => {
     default:
       return (
         <NavLink to="/queues/new" activeClassName="usa-current">
-          <span>New Moves Queue</span>
+          <span>New Moves/Shipments Queue</span>
         </NavLink>
       );
   }

--- a/src/scenes/Office/MoveInfo.test.js
+++ b/src/scenes/Office/MoveInfo.test.js
@@ -63,7 +63,7 @@ describe('ShipmentInfo tests', () => {
           </MockRouter>
         </Provider>,
       );
-      expect(wrapper.text()).toEqual('New Moves Queue');
+      expect(wrapper.text()).toEqual('New Moves/Shipments Queue');
     });
   });
 });

--- a/src/scenes/Office/QueueList.jsx
+++ b/src/scenes/Office/QueueList.jsx
@@ -15,7 +15,7 @@ export default class QueueList extends Component {
         <ul className="usa-sidenav-list">
           <li>
             <NavLink to="/queues/new" activeClassName="usa-current">
-              <span>New Moves</span>
+              <span>New Moves/Shipments</span>
             </NavLink>
           </li>
           <li>

--- a/src/scenes/Office/QueueTable.jsx
+++ b/src/scenes/Office/QueueTable.jsx
@@ -106,7 +106,7 @@ class QueueTable extends Component {
 
   render() {
     const titles = {
-      new: 'New Moves',
+      new: 'New Moves/Shipments',
       troubleshooting: 'Troubleshooting',
       ppm: 'PPMs',
       hhg_accepted: 'Accepted HHGs',
@@ -149,7 +149,7 @@ class QueueTable extends Component {
             <br />
           </Alert>
         ) : null}
-        <h1 className="queue-heading">Queue: {titles[this.props.queueType]}</h1>
+        <h1 className="queue-heading">{titles[this.props.queueType]}</h1>
         <div className="queue-table">
           <span className="staleness-indicator" data-cy="staleness-indicator">
             Last updated {formatTimeAgo(this.state.lastLoadedAt)}


### PR DESCRIPTION
## Description

Update office `New Moves` heading to `New Moves/Shipments` and update related tests.
Update the link on a moves page from `New Moves Queue` to `New Moves/Shipments Queue`.

## Setup

`make server_run`
`make office_client_run`

## Code Review Verification Steps

* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/165749867) for this change

## Screenshots

<img width="1759" alt="Screen Shot 2019-05-24 at 7 51 26 AM" src="https://user-images.githubusercontent.com/3099491/58328868-cdd28c80-7df8-11e9-8856-e8ca573a27d2.png">

<img width="1299" alt="Screen Shot 2019-05-29 at 8 18 30 AM" src="https://user-images.githubusercontent.com/3099491/58560459-cb05dc00-81ea-11e9-9641-d10e6b8f559b.png">
