### PR TITLE
Fix move queue last modified date and name

### DIFF
--- a/pkg/handlers/internalapi/move_queue_items.go
+++ b/pkg/handlers/internalapi/move_queue_items.go
@@ -28,7 +28,6 @@ func payloadForMoveQueueItem(MoveQueueItem models.MoveQueueItem) *internalmessag
 		MoveDate:         handlers.FmtDatePtr(MoveQueueItem.MoveDate),
 		SubmittedDate:    handlers.FmtDatePtr(MoveQueueItem.SubmittedDate),
 		LastModifiedDate: handlers.FmtDateTime(MoveQueueItem.LastModifiedDate),
-		LastModifiedName: swag.String(MoveQueueItem.LastModifiedName),
 	}
 	return &MoveQueueItemPayload
 }

--- a/pkg/models/queue.go
+++ b/pkg/models/queue.go
@@ -25,7 +25,6 @@ type MoveQueueItem struct {
 	MoveDate         *time.Time                          `json:"move_date" db:"move_date"`
 	SubmittedDate    *time.Time                          `json:"submitted_date" db:"submitted_date"`
 	LastModifiedDate time.Time                           `json:"last_modified_date" db:"last_modified_date"`
-	LastModifiedName string                              `json:"last_modified_name" db:"last_modified_name"`
 }
 
 // GetMoveQueueItems gets all moveQueueItems for a specific lifecycleState

--- a/pkg/models/queue.go
+++ b/pkg/models/queue.go
@@ -52,6 +52,7 @@ func GetMoveQueueItems(db *pop.Connection, lifecycleState string) ([]MoveQueueIt
 					ppm.submit_date
 				) as submitted_date,
 				moves.created_at as created_at,
+				moves.updated_at as last_modified_date,
 				moves.status as status,
 				ppm.status as ppm_status,
 				shipment.status as hhg_status,

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -2381,9 +2381,6 @@ definitions:
         type: string
         format: date-time
         example: 2017-07-21T17:32:28Z
-      last_modified_name:
-        type: string
-        example: Bollinger, Sam
       created_at:
         type: string
         format: date-time
@@ -2396,7 +2393,6 @@ definitions:
       - rank
       - orders_type
       - last_modified_date
-      - last_modified_name
       - created_at
   MoveDatesSummary:
     type: object


### PR DESCRIPTION
## Description

Two problems are being fixed here. 

1. `last_modified_date` needs to be returned in every queue call because it's required. Strict swagger clients complain if it is missing. Since it is derived from `updated_at` in the DB it ought to always be there to send back in the API call.

2. `last_modified_name` was added but never actually used. It may have been added in preparation for doing auditing on moves but if its not being filled in then strict swagger clients complain.

These changes facilitate load-testing in #1597.

## Setup

Nothing to test here other than to ensure all tests pass.

## Code Review Verification Steps

* [x] Request review from a member of a different team.