### PR TITLE
Pre-move survey is prepopulated with dates from Dates panel

### DIFF
--- a/src/scenes/TransportationServiceProvider/FormButton.jsx
+++ b/src/scenes/TransportationServiceProvider/FormButton.jsx
@@ -20,12 +20,11 @@ export default class FormButton extends Component {
   };
 
   enterFormView = () => {
-    const { schema, onSubmit, FormComponent } = this.props;
+    const { FormComponent } = this.props;
 
     const formProps = {
       onCancel: this.setButtonState,
-      schema: schema,
-      onSubmit: onSubmit,
+      ...this.props,
     };
     return <FormComponent {...formProps} />;
   };

--- a/src/scenes/TransportationServiceProvider/PremoveSurveyForm.jsx
+++ b/src/scenes/TransportationServiceProvider/PremoveSurveyForm.jsx
@@ -58,6 +58,7 @@ PremoveSurveyForm.propTypes = {
   handleSubmit: PropTypes.func,
   submitting: PropTypes.bool,
   valid: PropTypes.bool,
+  shipmentId: PropTypes.string,
 };
 
 const mapStateToProps = (state, ownProps) => {


### PR DESCRIPTION
## Description

When the Pre-move survey form is opened, it is prepopulated with dates from the Dates panel, if they exist. 

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/166091601) for this change
