### PR TITLE
Add save button behavior to weight ticket page for new PPM closeout flow

### DIFF
--- a/cypress/integration/mymove/ppm.js
+++ b/cypress/integration/mymove/ppm.js
@@ -216,6 +216,7 @@ it('allows a SM to request ppm payment', function() {
   cy.removeFetch();
   cy.server();
   cy.route('POST', '**/internal/uploads').as('postUploadDocument');
+  cy.route('POST', '**/moves/**/move_documents').as('postMoveDocument');
 
   cy.signInAsUserPostRequest(milmoveAppName, '8e0d7e98-134e-4b28-bdd1-7d6b1ff34f9e');
   cy.contains('Fort Gordon (from Yuma AFB)');
@@ -224,13 +225,12 @@ it('allows a SM to request ppm payment', function() {
   cy.get('.in_progress .status_dates').should('exist');
   serviceMemberCanCancel();
   serviceMemberVisitsIntroToPPMPaymentRequest();
-  serviceMemberFillsOutWeightTicket('Car');
-  // TODO: remove when we are doing something with the data
-  cy.reload();
-  serviceMemberFillsOutWeightTicket('Box truck');
+  serviceMemberSubmitsWeightTicket('CAR');
+  serviceMemberSubmitsWeightTicket('BOX_TRUCK');
+  serviceMemberSaveWeightTicketForLater('CAR');
 });
 
-function serviceMemberFillsOutWeightTicket(vehicleType) {
+function serviceMemberSaveWeightTicketForLater(vehicleType) {
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/moves\/[^/]+\/ppm-weight-ticket/);
   });
@@ -242,10 +242,12 @@ function serviceMemberFillsOutWeightTicket(vehicleType) {
   cy.get('input[name="empty_weight"]').type('1000');
   cy.upload_file('.filepond--root:first', 'top-secret.png');
   cy.wait('@postUploadDocument');
+  cy.get('[data-filepond-item-state="processing-complete"]').should('have.length', 1);
 
   cy.get('input[name="full_weight"]').type('5000');
   cy.upload_file('.filepond--root:last', 'top-secret.png');
   cy.wait('@postUploadDocument');
+  cy.get('[data-filepond-item-state="processing-complete"]').should('have.length', 2);
   cy
     .get('input[name="weight_ticket_date"]')
     .type('6/2/2018{enter}')
@@ -255,6 +257,50 @@ function serviceMemberFillsOutWeightTicket(vehicleType) {
     .get('[type="radio"]')
     .first()
     .should('be.checked');
+
+  cy
+    .get('button')
+    .contains('Save For Later')
+    .click();
+  cy.wait('@postMoveDocument');
+  cy.location().should(loc => {
+    expect(loc.pathname).to.match(/^\/$/);
+  });
+}
+
+function serviceMemberSubmitsWeightTicket(vehicleType) {
+  cy.location().should(loc => {
+    expect(loc.pathname).to.match(/^\/moves\/[^/]+\/ppm-weight-ticket/);
+  });
+
+  cy.get('select[name="vehicle_options"]').select(vehicleType);
+
+  cy.get('input[name="vehicle_nickname"]').type('Nickname');
+
+  cy.get('input[name="empty_weight"]').type('1000');
+  cy.upload_file('.filepond--root:first', 'top-secret.png');
+  cy.wait('@postUploadDocument');
+  cy.get('[data-filepond-item-state="processing-complete"]').should('have.length', 1);
+
+  cy.get('input[name="full_weight"]').type('5000');
+  cy.upload_file('.filepond--root:last', 'top-secret.png');
+  cy.wait('@postUploadDocument');
+  cy.get('[data-filepond-item-state="processing-complete"]').should('have.length', 2);
+  cy
+    .get('input[name="weight_ticket_date"]')
+    .type('6/2/2018{enter}')
+    .blur();
+
+  cy
+    .get('[type="radio"]')
+    .first()
+    .should('be.checked');
+
+  cy
+    .get('button')
+    .contains('Save & Add Another')
+    .click();
+  cy.wait('@postMoveDocument');
 }
 
 function serviceMemberCanCancel() {

--- a/cypress/integration/mymove/ppm.js
+++ b/cypress/integration/mymove/ppm.js
@@ -227,10 +227,10 @@ it('allows a SM to request ppm payment', function() {
   serviceMemberVisitsIntroToPPMPaymentRequest();
   serviceMemberSubmitsWeightTicket('CAR');
   serviceMemberSubmitsWeightTicket('BOX_TRUCK');
-  serviceMemberSaveWeightTicketForLater('CAR');
+  serviceMemberSavesWeightTicketForLater('CAR');
 });
 
-function serviceMemberSaveWeightTicketForLater(vehicleType) {
+function serviceMemberSavesWeightTicketForLater(vehicleType) {
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/moves\/[^/]+\/ppm-weight-ticket/);
   });

--- a/src/scenes/Moves/Ppm/PPMPaymentRequestActionBtns.jsx
+++ b/src/scenes/Moves/Ppm/PPMPaymentRequestActionBtns.jsx
@@ -1,68 +1,39 @@
 import React from 'react';
 import { withRouter } from 'react-router-dom';
-import { connect } from 'react-redux';
 import './PPMPaymentRequest.css';
 
 const PPMPaymentRequestActionBtns = props => {
-  const { nextBtnLabel, onClick, history, disabled, missingWeightTicket, displaySaveForLater, submitting } = props;
+  const {
+    nextBtnLabel,
+    cancelHandler,
+    saveAndHandler,
+    saveForLaterHandler,
+    isDisabled,
+    displaySaveForLater,
+    submitting,
+  } = props;
   return (
     <div className="ppm-payment-request-footer">
       <div className="usa-width-two-thirds">
-        <button
-          type="button"
-          className="usa-button-secondary"
-          onClick={() => {
-            history.push('/');
-          }}
-        >
+        <button type="button" className="usa-button-secondary" onClick={cancelHandler}>
           Cancel
         </button>
         {displaySaveForLater && (
           <button
             type="button"
             className="usa-button-secondary"
-            onClick={() => {
-              let result = Promise.resolve(onClick());
-              result.then(value => {
-                if (value === undefined) {
-                  history.push('/');
-                }
-              });
-            }}
-            disabled={disabled || submitting || missingWeightTicket}
+            onClick={saveForLaterHandler}
+            disabled={isDisabled || submitting}
           >
             Save For Later
           </button>
         )}
       </div>
-      <button
-        type="button"
-        onClick={() => {
-          onClick();
-        }}
-        disabled={disabled || submitting || missingWeightTicket}
-      >
+      <button type="button" onClick={saveAndHandler} disabled={isDisabled || submitting}>
         {nextBtnLabel}
       </button>
     </div>
   );
 };
-function mapStateToProps(state) {
-  const { form } = state;
-  let isDisabled = false;
-  if (form.weight_ticket_wizard) {
-    isDisabled = !(
-      form.weight_ticket_wizard.values &&
-      form.weight_ticket_wizard.values.vehicle_nickname &&
-      form.weight_ticket_wizard.values.vehicle_options &&
-      form.weight_ticket_wizard.values.empty_weight &&
-      form.weight_ticket_wizard.values.full_weight &&
-      form.weight_ticket_wizard.values.weight_ticket_date
-    );
-  }
-  return {
-    disabled: isDisabled,
-  };
-}
 
-export default connect(mapStateToProps)(withRouter(PPMPaymentRequestActionBtns));
+export default withRouter(PPMPaymentRequestActionBtns);

--- a/src/scenes/Moves/Ppm/PPMPaymentRequestActionBtns.jsx
+++ b/src/scenes/Moves/Ppm/PPMPaymentRequestActionBtns.jsx
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 import './PPMPaymentRequest.css';
 
 const PPMPaymentRequestActionBtns = props => {
-  const { nextBtnLabel, onClick, history, disabled, displaySaveForLater } = props;
+  const { nextBtnLabel, onClick, history, disabled, missingWeightTicket, displaySaveForLater, submitting } = props;
   return (
     <div className="ppm-payment-request-footer">
       <div className="usa-width-two-thirds">
@@ -29,7 +29,7 @@ const PPMPaymentRequestActionBtns = props => {
                 }
               });
             }}
-            disabled={disabled}
+            disabled={disabled || submitting || missingWeightTicket}
           >
             Save For Later
           </button>
@@ -40,7 +40,7 @@ const PPMPaymentRequestActionBtns = props => {
         onClick={() => {
           onClick();
         }}
-        disabled={disabled}
+        disabled={disabled || submitting || missingWeightTicket}
       >
         {nextBtnLabel}
       </button>

--- a/src/scenes/Moves/Ppm/PPMPaymentRequestActionBtns.jsx
+++ b/src/scenes/Moves/Ppm/PPMPaymentRequestActionBtns.jsx
@@ -4,18 +4,44 @@ import { connect } from 'react-redux';
 import './PPMPaymentRequest.css';
 
 const PPMPaymentRequestActionBtns = props => {
-  const { nextBtnLabel, onClick, history, disabled } = props;
+  const { nextBtnLabel, onClick, history, disabled, displaySaveForLater } = props;
   return (
     <div className="ppm-payment-request-footer">
+      <div className="usa-width-two-thirds">
+        <button
+          type="button"
+          className="usa-button-secondary"
+          onClick={() => {
+            history.push('/');
+          }}
+        >
+          Cancel
+        </button>
+        {displaySaveForLater && (
+          <button
+            type="button"
+            className="usa-button-secondary"
+            onClick={() => {
+              let result = Promise.resolve(onClick());
+              result.then(value => {
+                if (value === undefined) {
+                  history.push('/');
+                }
+              });
+            }}
+            disabled={disabled}
+          >
+            Save For Later
+          </button>
+        )}
+      </div>
       <button
-        className="usa-button-secondary"
+        type="button"
         onClick={() => {
-          history.push('/');
+          onClick();
         }}
+        disabled={disabled}
       >
-        Cancel
-      </button>
-      <button onClick={onClick} disabled={disabled}>
         {nextBtnLabel}
       </button>
     </div>
@@ -28,7 +54,10 @@ function mapStateToProps(state) {
     isDisabled = !(
       form.weight_ticket_wizard.values &&
       form.weight_ticket_wizard.values.vehicle_nickname &&
-      form.weight_ticket_wizard.values.vehicle_options
+      form.weight_ticket_wizard.values.vehicle_options &&
+      form.weight_ticket_wizard.values.empty_weight &&
+      form.weight_ticket_wizard.values.full_weight &&
+      form.weight_ticket_wizard.values.weight_ticket_date
     );
   }
   return {

--- a/src/scenes/Moves/Ppm/PPMPaymentRequestActionBtns.jsx
+++ b/src/scenes/Moves/Ppm/PPMPaymentRequestActionBtns.jsx
@@ -6,9 +6,9 @@ const PPMPaymentRequestActionBtns = props => {
   const {
     nextBtnLabel,
     cancelHandler,
-    saveAndHandler,
+    saveAndAddHandler,
     saveForLaterHandler,
-    isDisabled,
+    submitButtonsAreDisabled,
     displaySaveForLater,
     submitting,
   } = props;
@@ -23,13 +23,13 @@ const PPMPaymentRequestActionBtns = props => {
             type="button"
             className="usa-button-secondary"
             onClick={saveForLaterHandler}
-            disabled={isDisabled || submitting}
+            disabled={submitButtonsAreDisabled || submitting}
           >
             Save For Later
           </button>
         )}
       </div>
-      <button type="button" onClick={saveAndHandler} disabled={isDisabled || submitting}>
+      <button type="button" onClick={saveAndAddHandler} disabled={submitButtonsAreDisabled || submitting}>
         {nextBtnLabel}
       </button>
     </div>

--- a/src/scenes/Moves/Ppm/PPMPaymentRequestIntro.jsx
+++ b/src/scenes/Moves/Ppm/PPMPaymentRequestIntro.jsx
@@ -33,7 +33,7 @@ const PPMPaymentRequestIntro = props => {
       {/* TODO: change onclick handler to go to next page in flow */}
       <PPMPaymentRequestActionBtns
         cancelHandler={() => history.push('/')}
-        saveAndHandler={() => {
+        saveAndAddHandler={() => {
           history.push(`/moves/${match.params.moveId}/ppm-weight-ticket`);
         }}
         nextBtnLabel="Get Started"

--- a/src/scenes/Moves/Ppm/PPMPaymentRequestIntro.jsx
+++ b/src/scenes/Moves/Ppm/PPMPaymentRequestIntro.jsx
@@ -32,7 +32,8 @@ const PPMPaymentRequestIntro = props => {
       </p>
       {/* TODO: change onclick handler to go to next page in flow */}
       <PPMPaymentRequestActionBtns
-        onClick={() => {
+        cancelHandler={() => history.push('/')}
+        saveAndHandler={() => {
           history.push(`/moves/${match.params.moveId}/ppm-weight-ticket`);
         }}
         nextBtnLabel="Get Started"

--- a/src/scenes/Moves/Ppm/WeightTicket.jsx
+++ b/src/scenes/Moves/Ppm/WeightTicket.jsx
@@ -72,12 +72,12 @@ class WeightTicket extends Component {
 
   saveForLaterHandler = formValues => {
     const { history } = this.props;
-    return this.saveAndHandler(formValues)
+    return this.saveAndAddHandler(formValues)
       .then(history.push('/'))
       .catch(() => this.setState({ weightTicketSubmissionError: true }));
   };
 
-  saveAndHandler = formValues => {
+  saveAndAddHandler = formValues => {
     const { moveId, currentPpm } = this.props;
 
     const moveDocumentSubmissions = [];
@@ -123,12 +123,11 @@ class WeightTicket extends Component {
     reset();
   };
 
-  get submitButtonIsDisabled() {
+  get submitButtonsAreDisabled() {
     return !this.formIsComplete() || this.isMissingWeightTickets();
   }
 
   render() {
-    const isDisabled = this.submitButtonIsDisabled;
     const { additionalWeightTickets, vehicleType } = this.state;
     const { handleSubmit, submitting, schema } = this.props;
     const nextBtnLabel = additionalWeightTickets === 'Yes' ? 'Save & Add Another' : 'Save & Continue';
@@ -244,11 +243,11 @@ class WeightTicket extends Component {
             {/* TODO: change onclick handler to go to next page in flow */}
             <PPMPaymentRequestActionBtns
               nextBtnLabel={nextBtnLabel}
-              isDisabled={isDisabled}
+              submitButtonsAreDisabled={this.submitButtonsAreDisabled}
               submitting={submitting}
               cancelHandler={this.cancelHandler}
               saveForLaterHandler={handleSubmit(this.saveForLaterHandler)}
-              saveAndHandler={handleSubmit(this.saveAndHandler)}
+              saveAndAddHandler={handleSubmit(this.saveAndAddHandler)}
               displaySaveForLater={true}
             />
           </div>

--- a/src/scenes/Moves/Ppm/WeightTicket.jsx
+++ b/src/scenes/Moves/Ppm/WeightTicket.jsx
@@ -36,9 +36,9 @@ class WeightTicket extends Component {
     return false;
   };
 
-  formIsComplete = () => {
+  formIsIncomplete = () => {
     const { formValues } = this.props;
-    return !!(
+    const isMissingFormInput = !(
       formValues &&
       formValues.vehicle_nickname &&
       formValues.vehicle_options &&
@@ -46,6 +46,7 @@ class WeightTicket extends Component {
       formValues.full_weight &&
       formValues.weight_ticket_date
     );
+    return isMissingFormInput && this.isMissingWeightTickets();
   };
 
   //  handleChange for vehicleType and additionalWeightTickets
@@ -124,10 +125,6 @@ class WeightTicket extends Component {
     }
     reset();
   };
-
-  get submitButtonsAreDisabled() {
-    return !this.formIsComplete() || this.isMissingWeightTickets();
-  }
 
   render() {
     const { additionalWeightTickets, vehicleType } = this.state;
@@ -245,7 +242,7 @@ class WeightTicket extends Component {
             {/* TODO: change onclick handler to go to next page in flow */}
             <PPMPaymentRequestActionBtns
               nextBtnLabel={nextBtnLabel}
-              submitButtonsAreDisabled={this.submitButtonsAreDisabled}
+              submitButtonsAreDisabled={this.formIsIncomplete()}
               submitting={submitting}
               cancelHandler={this.cancelHandler}
               saveForLaterHandler={handleSubmit(this.saveForLaterHandler)}

--- a/src/scenes/Moves/Ppm/WeightTicket.jsx
+++ b/src/scenes/Moves/Ppm/WeightTicket.jsx
@@ -15,20 +15,6 @@ import Uploader from 'shared/Uploader';
 import { createMoveDocument } from 'shared/Entities/modules/moveDocuments';
 import Alert from 'shared/Alert';
 
-export const missingWeightTickets = uploaders => {
-  if (isEmpty(uploaders)) {
-    return true;
-  }
-  const uploadersKeys = Object.keys(uploaders);
-  for (const key of uploadersKeys) {
-    // eslint-disable-next-line security/detect-object-injection
-    if (uploaders[key].isEmpty()) {
-      return true;
-    }
-  }
-  return false;
-};
-
 class WeightTicket extends Component {
   state = {
     uploaderIsIdle: {},
@@ -36,6 +22,20 @@ class WeightTicket extends Component {
     additionalWeightTickets: 'Yes',
   };
   uploaders = {};
+
+  missingWeightTickets = uploaders => {
+    if (isEmpty(uploaders)) {
+      return true;
+    }
+    const uploadersKeys = Object.keys(uploaders);
+    for (const key of uploadersKeys) {
+      // eslint-disable-next-line security/detect-object-injection
+      if (uploaders[key].isEmpty()) {
+        return true;
+      }
+    }
+    return false;
+  };
 
   //  handleChange for vehicleType and additionalWeightTickets
   handleChange = (event, type) => {
@@ -100,7 +100,7 @@ class WeightTicket extends Component {
   };
 
   render() {
-    const missingWeightTicket = missingWeightTickets(this.uploaders);
+    const missingWeightTicket = this.missingWeightTickets(this.uploaders);
     const { additionalWeightTickets, vehicleType } = this.state;
     const { error, handleSubmit, submitting, schema } = this.props;
     const nextBtnLabel = additionalWeightTickets === 'Yes' ? 'Save & Add Another' : 'Save & Continue';

--- a/src/scenes/Moves/Ppm/WeightTicket.jsx
+++ b/src/scenes/Moves/Ppm/WeightTicket.jsx
@@ -1,31 +1,118 @@
 import React, { Component, Fragment } from 'react';
-import { reduxForm } from 'redux-form';
+import { reduxForm, getFormValues, SubmissionError } from 'redux-form';
 import { connect } from 'react-redux';
-import { get } from 'lodash';
+import { get, map } from 'lodash';
 import PropTypes from 'prop-types';
 
 import PPMPaymentRequestActionBtns from './PPMPaymentRequestActionBtns';
 import WizardHeader from '../WizardHeader';
 import { ProgressTimeline, ProgressTimelineStep } from 'shared/ProgressTimeline';
+import { replace } from 'react-router-redux';
 import { SwaggerField } from 'shared/JsonSchemaForm/JsonSchemaField';
 import RadioButton from 'shared/RadioButton';
 import './PPMPaymentRequest.css';
 import Uploader from 'shared/Uploader';
+import { createMoveDocument } from '../../../shared/Entities/modules/moveDocuments';
+import Alert from '../../../shared/Alert';
 
 class WeightTicket extends Component {
   state = {
+    newUploads: {},
+    uploaderIsIdle: {},
     vehicleType: '',
     additionalWeightTickets: 'Yes',
   };
+  uploaders = {};
 
   //  handleChange for vehicleType and additionalWeightTickets
   handleChange = (event, type) => {
     this.setState({ [type]: event.target.value });
   };
 
+  onAddFile = uploaderName => () => {
+    this.setState({
+      uploaderIsIdle: { ...this.state.uploaderIsIdle, [uploaderName]: false },
+    });
+  };
+
+  onChange = uploaderName => (newUploads, uploaderIsIdle) => {
+    this.setState({
+      newUploads: { ...this.state.newUploads, [uploaderName]: newUploads },
+      uploaderIsIdle: { ...this.state.uploaderIsIdle, [uploaderName]: uploaderIsIdle },
+    });
+  };
+
+  validateWeightTickets = () => {
+    const uploaders = Object.keys(this.uploaders);
+    const newUploads = this.state.newUploads;
+    for (let i = 0; i < uploaders.length; i++) {
+      // eslint-disable-next-line security/detect-object-injection
+      let key = uploaders[i];
+      if (newUploads.hasOwnProperty(key)) {
+        // eslint-disable-next-line security/detect-object-injection
+        const uploadIds = map(newUploads[key], 'id');
+        if (uploadIds.length === 0) {
+          throw new SubmissionError({ [key]: 'Missing required weight ticket upload' });
+        }
+      } else {
+        throw new SubmissionError({ [key]: 'Missing required weight ticket upload' });
+      }
+    }
+  };
+
+  submitWeightTickets = formValues => {
+    this.validateWeightTickets();
+    const { moveId, currentPpm } = this.props;
+    const uploadersKeys = Object.keys(this.uploaders);
+    const newUploads = this.state.newUploads;
+
+    const moveDocumentSubmissions = [];
+    for (let i = 0; i < uploadersKeys.length; i++) {
+      // eslint-disable-next-line security/detect-object-injection
+      let key = uploadersKeys[i];
+      if (newUploads.hasOwnProperty(key)) {
+        // eslint-disable-next-line security/detect-object-injection
+        const uploadIds = map(newUploads[key], 'id');
+        const weightTicket = {
+          moveId: moveId,
+          personallyProcuredMoveId: currentPpm.id,
+          uploadIds: uploadIds,
+          title: key,
+          moveDocumentType: 'WEIGHT_TICKET',
+          notes: formValues.notes,
+        };
+        moveDocumentSubmissions.push(
+          this.props.createMoveDocument(weightTicket).catch(err => {
+            throw new SubmissionError({ _error: 'Error creating move document' });
+          }),
+        );
+      }
+    }
+    return Promise.all(moveDocumentSubmissions)
+      .then(() => {
+        this.cleanup();
+      })
+      .catch(e => {
+        throw new SubmissionError({ _error: e.message });
+      });
+  };
+
+  cleanup = () => {
+    const { reset } = this.props;
+    const uploadersKeys = Object.keys(this.uploaders);
+    const uploaders = this.uploaders;
+    for (let i = 0; i < uploadersKeys.length; i++) {
+      // eslint-disable-next-line security/detect-object-injection
+      let key = uploadersKeys[i];
+      // eslint-disable-next-line security/detect-object-injection
+      uploaders[key].clearFiles();
+    }
+    reset();
+  };
+
   render() {
     const { additionalWeightTickets, vehicleType } = this.state;
-    const { schema } = this.props;
+    const { error, handleSubmit, schema } = this.props;
     const nextBtnLabel = additionalWeightTickets === 'Yes' ? 'Save & Add Another' : 'Save & Continue';
     const uploadEmptyTicketLabel =
       '<span class="uploader-label">Drag & drop or <span class="filepond--label-action">click to upload upload empty weight ticket</span></span>';
@@ -43,86 +130,107 @@ class WeightTicket extends Component {
             </ProgressTimeline>
           }
         />
-        <div className="usa-grid">
-          <SwaggerField
-            fieldName="vehicle_options"
-            swagger={schema}
-            onChange={event => this.handleChange(event, 'vehicleType')}
-            value={vehicleType}
-            required
-          />
-          <SwaggerField fieldName="vehicle_nickname" swagger={schema} required />
-          {(vehicleType === 'CAR' || vehicleType === 'BOX_TRUCK') && (
-            <>
-              <div className="dashed-divider" />
-
-              <div className="usa-grid-full" style={{ marginTop: '1em' }}>
-                <div className="usa-width-one-third">
-                  <strong className="input-header">Empty Weight</strong>
-                  <SwaggerField
-                    className="short-field"
-                    fieldName="empty_weight"
-                    swagger={schema}
-                    hideLabel
-                    required
-                  />{' '}
-                  lbs
-                </div>
-                <div className="usa-width-two-third uploader-wrapper">
-                  <Uploader options={{ labelIdle: uploadEmptyTicketLabel }} />
-                </div>
+        <form>
+          {error && (
+            <div className="usa-grid">
+              <div className="usa-width-one-whole error-message">
+                <Alert type="error" heading="An error occurred">
+                  Something went wrong contacting the server.
+                </Alert>
               </div>
-
-              <div className="usa-grid-full" style={{ marginTop: '1em' }}>
-                <div className="usa-width-one-third">
-                  <strong className="input-header">Full Weight</strong>
-                  <label className="full-weight-label">Full weight at destination</label>
-                  <SwaggerField
-                    className="short-field"
-                    fieldName="full_weight"
-                    swagger={schema}
-                    hideLabel
-                    required
-                  />{' '}
-                  lbs
-                </div>
-
-                <div className="usa-width-two-third uploader-wrapper">
-                  <Uploader options={{ labelIdle: uploadFullTicketLabel }} />
-                </div>
-              </div>
-
-              <SwaggerField fieldName="weight_ticket_date" swagger={schema} required />
-              <div className="dashed-divider" />
-
-              <div className="radio-group-wrapper">
-                <p className="radio-group-header">Do you have more weight tickets for another vehicle or trip?</p>
-                <RadioButton
-                  inputClassName="inline_radio"
-                  labelClassName="inline_radio"
-                  label="Yes"
-                  value="Yes"
-                  name="additional_weight_ticket"
-                  checked={additionalWeightTickets === 'Yes'}
-                  onChange={event => this.handleChange(event, 'additionalWeightTickets')}
-                />
-
-                <RadioButton
-                  inputClassName="inline_radio"
-                  labelClassName="inline_radio"
-                  label="No"
-                  value="No"
-                  name="additional_weight_ticket"
-                  checked={additionalWeightTickets === 'No'}
-                  onChange={event => this.handleChange(event, 'additionalWeightTickets')}
-                />
-              </div>
-            </>
+            </div>
           )}
+          <div className="usa-grid">
+            <SwaggerField
+              fieldName="vehicle_options"
+              swagger={schema}
+              onChange={event => this.handleChange(event, 'vehicleType')}
+              value={vehicleType}
+              required
+            />
+            <SwaggerField fieldName="vehicle_nickname" swagger={schema} required />
+            {(vehicleType === 'CAR' || vehicleType === 'BOX_TRUCK') && (
+              <>
+                <div className="dashed-divider" />
 
-          {/* TODO: change onclick handler to go to next page in flow */}
-          <PPMPaymentRequestActionBtns nextBtnLabel={nextBtnLabel} />
-        </div>
+                <div className="usa-grid-full" style={{ marginTop: '1em' }}>
+                  <div className="usa-width-one-third">
+                    <strong className="input-header">Empty Weight</strong>
+                    <SwaggerField
+                      className="short-field"
+                      fieldName="empty_weight"
+                      swagger={schema}
+                      hideLabel
+                      required
+                    />{' '}
+                    lbs
+                  </div>
+                  <Uploader
+                    options={{ labelIdle: uploadEmptyTicketLabel }}
+                    onRef={ref => (this.uploaders['empty_weight'] = ref)}
+                    onChange={this.onChange('empty_weight')}
+                    onAddFile={this.onAddFile('empty_weight')}
+                  />
+                </div>
+
+                <div className="usa-grid-full" style={{ marginTop: '1em' }}>
+                  <div className="usa-width-one-third">
+                    <strong className="input-header">Full Weight</strong>
+                    <label className="full-weight-label">Full weight at destination</label>
+                    <SwaggerField
+                      className="short-field"
+                      fieldName="full_weight"
+                      swagger={schema}
+                      hideLabel
+                      required
+                    />{' '}
+                    lbs
+                  </div>
+                  <Uploader
+                    options={{ labelIdle: uploadFullTicketLabel }}
+                    onRef={ref => (this.uploaders['full_weight'] = ref)}
+                    onChange={this.onChange('full_weight')}
+                    onAddFile={this.onAddFile('full_weight')}
+                  />
+                </div>
+
+                <SwaggerField fieldName="weight_ticket_date" swagger={schema} required />
+                <div className="dashed-divider" />
+
+                <div className="radio-group-wrapper">
+                  <p className="radio-group-header">Do you have more weight tickets for another vehicle or trip?</p>
+                  <RadioButton
+                    inputClassName="inline_radio"
+                    labelClassName="inline_radio"
+                    label="Yes"
+                    value="Yes"
+                    name="additional_weight_ticket"
+                    checked={additionalWeightTickets === 'Yes'}
+                    onChange={event => this.handleChange(event, 'additionalWeightTickets')}
+                  />
+
+                  <RadioButton
+                    inputClassName="inline_radio"
+                    labelClassName="inline_radio"
+                    label="No"
+                    value="No"
+                    name="additional_weight_ticket"
+                    shipment_line_items
+                    checked={additionalWeightTickets === 'No'}
+                    onChange={event => this.handleChange(event, 'additionalWeightTickets')}
+                  />
+                </div>
+              </>
+            )}
+
+            {/* TODO: change onclick handler to go to next page in flow */}
+            <PPMPaymentRequestActionBtns
+              nextBtnLabel={nextBtnLabel}
+              onClick={handleSubmit(this.submitWeightTickets)}
+              displaySaveForLater={true}
+            />
+          </div>
+        </form>
       </Fragment>
     );
   }
@@ -139,10 +247,20 @@ WeightTicket.propTypes = {
   schema: PropTypes.object.isRequired,
 };
 
-function mapStateToProps(state) {
-  const props = {
+function mapStateToProps(state, ownProps) {
+  const moveId = ownProps.match.params.moveId;
+  return {
+    moveId: moveId,
+    formValues: getFormValues(formName)(state),
+    genericMoveDocSchema: get(state, 'swaggerInternal.spec.definitions.CreateGenericMoveDocumentPayload', {}),
+    moveDocSchema: get(state, 'swaggerInternal.spec.definitions.MoveDocumentPayload', {}),
     schema: get(state, 'swaggerInternal.spec.definitions.WeightTicketPayload', {}),
+    currentPpm: get(state, 'ppm.currentPpm'),
   };
-  return props;
 }
-export default connect(mapStateToProps)(WeightTicket);
+const mapDispatchToProps = {
+  createMoveDocument,
+  replace,
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(WeightTicket);

--- a/src/scenes/Moves/Ppm/WeightTicket.jsx
+++ b/src/scenes/Moves/Ppm/WeightTicket.jsx
@@ -72,9 +72,11 @@ class WeightTicket extends Component {
 
   saveForLaterHandler = formValues => {
     const { history } = this.props;
-    return this.saveAndAddHandler(formValues)
-      .then(history.push('/'))
-      .catch(() => this.setState({ weightTicketSubmissionError: true }));
+    return this.saveAndAddHandler(formValues).then(() => {
+      if (this.state.weightTicketSubmissionError === false) {
+        history.push('/');
+      }
+    });
   };
 
   saveAndAddHandler = formValues => {

--- a/src/scenes/Moves/Ppm/WeightTicket.test.js
+++ b/src/scenes/Moves/Ppm/WeightTicket.test.js
@@ -39,11 +39,11 @@ describe('Weight tickets page', () => {
       const buttonGroup = weightTicket.find(PPMPaymentRequestActionBtns);
       const cancel = weightTicket.find('button').at(0);
       const saveForLater = weightTicket.find('button').at(1);
-      const saveAnd = weightTicket.find('button').at(2);
+      const saveAndAdd = weightTicket.find('button').at(2);
 
       expect(buttonGroup.length).toEqual(1);
       expect(cancel.props().disabled).not.toEqual(true);
-      expect(saveAnd.props().disabled).toEqual(true);
+      expect(saveAndAdd.props().disabled).toEqual(true);
       expect(saveForLater.props().disabled).toEqual(true);
     });
   });
@@ -53,11 +53,11 @@ describe('Weight tickets page', () => {
       const buttonGroup = weightTicket.find(PPMPaymentRequestActionBtns);
       const cancel = weightTicket.find('button').at(0);
       const saveForLater = weightTicket.find('button').at(1);
-      const saveAnd = weightTicket.find('button').at(2);
+      const saveAndAdd = weightTicket.find('button').at(2);
 
       expect(buttonGroup.length).toEqual(1);
       expect(cancel.props().disabled).not.toEqual(true);
-      expect(saveAnd.props().disabled).toEqual(false);
+      expect(saveAndAdd.props().disabled).toEqual(false);
       expect(saveForLater.props().disabled).toEqual(false);
     });
   });
@@ -68,11 +68,11 @@ describe('Weight tickets page', () => {
       const buttonGroup = weightTicket.find(PPMPaymentRequestActionBtns);
       const cancel = weightTicket.find('button').at(0);
       const saveForLater = weightTicket.find('button').at(1);
-      const saveAnd = weightTicket.find('button').at(2);
+      const saveAndAdd = weightTicket.find('button').at(2);
 
       expect(buttonGroup.length).toEqual(1);
       expect(cancel.props().disabled).not.toEqual(true);
-      expect(saveAnd.props().disabled).toEqual(true);
+      expect(saveAndAdd.props().disabled).toEqual(true);
       expect(saveForLater.props().disabled).toEqual(true);
     });
   });

--- a/src/scenes/Moves/Ppm/WeightTicket.test.js
+++ b/src/scenes/Moves/Ppm/WeightTicket.test.js
@@ -5,9 +5,8 @@ import { Provider } from 'react-redux';
 import store from 'shared/store';
 import MockRouter from 'react-mock-router';
 import PPMPaymentRequestActionBtns from './PPMPaymentRequestActionBtns';
-import { missingWeightTickets } from './WeightTicket';
 
-function mountComponents(moreWeightTickets = 'Yes', missingWeightTickets = true) {
+function mountComponents(moreWeightTickets = 'Yes', missingWeightTickets) {
   const initialValues = {
     empty_weight: 1100,
     full_weight: 2000,
@@ -24,7 +23,9 @@ function mountComponents(moreWeightTickets = 'Yes', missingWeightTickets = true)
     </Provider>,
   );
   const wt = wrapper.find('WeightTicket');
-  wt.instance().missingWeightTickets = jest.fn(uploaders => missingWeightTickets);
+  if (missingWeightTickets !== undefined) {
+    wt.instance().missingWeightTickets = jest.fn(uploaders => missingWeightTickets);
+  }
   wt.setState({ additionalWeightTickets: moreWeightTickets, initialValues: initialValues });
   wt.update();
   return wrapper.find('WeightTicket');
@@ -95,18 +96,24 @@ describe('Weight tickets page', () => {
 
 describe('missingWeightTickets', () => {
   it('returns true when there are no uploaders', () => {
-    expect(missingWeightTickets({})).toEqual(true);
+    const weightTicket = mountComponents('No');
+
+    expect(weightTicket.instance().missingWeightTickets({})).toEqual(true);
   });
   it('returns false when both uploaders have at least one file', () => {
+    const weightTicket = mountComponents('No');
     const uploaders = { one: {}, two: {} };
     uploaders['one'].isEmpty = jest.fn(() => false);
     uploaders['two'].isEmpty = jest.fn(() => false);
-    expect(missingWeightTickets(uploaders)).toEqual(false);
+
+    expect(weightTicket.instance().missingWeightTickets(uploaders)).toEqual(false);
   });
   it('returns true when one uploaders do not have at least one file', () => {
+    const weightTicket = mountComponents('No');
     const uploaders = { one: {}, two: {} };
     uploaders['one'].isEmpty = jest.fn(() => false);
     uploaders['two'].isEmpty = jest.fn(() => true);
-    expect(missingWeightTickets(uploaders)).toEqual(true);
+
+    expect(weightTicket.instance().missingWeightTickets(uploaders)).toEqual(true);
   });
 });

--- a/src/scenes/Moves/Ppm/WeightTicket.test.js
+++ b/src/scenes/Moves/Ppm/WeightTicket.test.js
@@ -24,7 +24,8 @@ function mountComponents(moreWeightTickets = 'Yes', missingWeightTickets) {
   );
   const wt = wrapper.find('WeightTicket');
   if (missingWeightTickets !== undefined) {
-    wt.instance().missingWeightTickets = jest.fn(uploaders => missingWeightTickets);
+    wt.instance().isMissingWeightTickets = jest.fn().mockReturnValue(missingWeightTickets);
+    wt.instance().formIsComplete = jest.fn().mockReturnValue(true);
   }
   wt.setState({ additionalWeightTickets: moreWeightTickets, initialValues: initialValues });
   wt.update();
@@ -70,7 +71,6 @@ describe('Weight tickets page', () => {
       const saveAnd = weightTicket.find('button').at(2);
 
       expect(buttonGroup.length).toEqual(1);
-      console.log(cancel.debug());
       expect(cancel.props().disabled).not.toEqual(true);
       expect(saveAnd.props().disabled).toEqual(true);
       expect(saveForLater.props().disabled).toEqual(true);
@@ -97,23 +97,26 @@ describe('Weight tickets page', () => {
 describe('missingWeightTickets', () => {
   it('returns true when there are no uploaders', () => {
     const weightTicket = mountComponents('No');
+    weightTicket.instance().uploaders = {};
 
-    expect(weightTicket.instance().missingWeightTickets({})).toEqual(true);
+    expect(weightTicket.instance().isMissingWeightTickets()).toEqual(true);
   });
   it('returns false when both uploaders have at least one file', () => {
     const weightTicket = mountComponents('No');
     const uploaders = { one: {}, two: {} };
     uploaders['one'].isEmpty = jest.fn(() => false);
     uploaders['two'].isEmpty = jest.fn(() => false);
+    weightTicket.instance().uploaders = uploaders;
 
-    expect(weightTicket.instance().missingWeightTickets(uploaders)).toEqual(false);
+    expect(weightTicket.instance().isMissingWeightTickets()).toEqual(false);
   });
   it('returns true when one uploaders do not have at least one file', () => {
     const weightTicket = mountComponents('No');
     const uploaders = { one: {}, two: {} };
     uploaders['one'].isEmpty = jest.fn(() => false);
     uploaders['two'].isEmpty = jest.fn(() => true);
+    weightTicket.instance().uploaders = uploaders;
 
-    expect(weightTicket.instance().missingWeightTickets(uploaders)).toEqual(true);
+    expect(weightTicket.instance().isMissingWeightTickets()).toEqual(true);
   });
 });

--- a/src/scenes/Moves/Ppm/WeightTicket.test.js
+++ b/src/scenes/Moves/Ppm/WeightTicket.test.js
@@ -5,36 +5,108 @@ import { Provider } from 'react-redux';
 import store from 'shared/store';
 import MockRouter from 'react-mock-router';
 import PPMPaymentRequestActionBtns from './PPMPaymentRequestActionBtns';
+import { missingWeightTickets } from './WeightTicket';
 
-function mountComponents(moreWeightTickets = 'Yes') {
+function mountComponents(moreWeightTickets = 'Yes', missingWeightTickets = true) {
+  const initialValues = {
+    empty_weight: 1100,
+    full_weight: 2000,
+    vehicle_nickname: 'HALE',
+    vehicle_options: 'CAR',
+    weight_ticket_date: '2019-05-22',
+  };
+  const match = { params: { moveId: 'someID' } };
   const wrapper = mount(
     <Provider store={store}>
       <MockRouter push={jest.fn()}>
-        <WeightTicket />
+        <WeightTicket match={match} />
       </MockRouter>
     </Provider>,
   );
   const wt = wrapper.find('WeightTicket');
-  wt.setState({ additionalWeightTickets: moreWeightTickets });
+  wt.instance().missingWeightTickets = jest.fn(uploaders => missingWeightTickets);
+  wt.setState({ additionalWeightTickets: moreWeightTickets, initialValues: initialValues });
   wt.update();
   return wrapper.find('WeightTicket');
 }
 
 describe('Weight tickets page', () => {
+  describe('Service member is missing a weight ticket', () => {
+    it('renders both the Save buttons are disabled', () => {
+      const weightTicket = mountComponents('No', true);
+      const buttonGroup = weightTicket.find(PPMPaymentRequestActionBtns);
+      const cancel = weightTicket.find('button').at(0);
+      const saveForLater = weightTicket.find('button').at(1);
+      const saveAnd = weightTicket.find('button').at(2);
+
+      expect(buttonGroup.length).toEqual(1);
+      expect(cancel.props().disabled).not.toEqual(true);
+      expect(saveAnd.props().disabled).toEqual(true);
+      expect(saveForLater.props().disabled).toEqual(true);
+    });
+  });
+  describe('Service member has uploaded both a weight tickets', () => {
+    it('renders both the Save buttons are enabled', () => {
+      const weightTicket = mountComponents('No', false);
+      const buttonGroup = weightTicket.find(PPMPaymentRequestActionBtns);
+      const cancel = weightTicket.find('button').at(0);
+      const saveForLater = weightTicket.find('button').at(1);
+      const saveAnd = weightTicket.find('button').at(2);
+
+      expect(buttonGroup.length).toEqual(1);
+      expect(cancel.props().disabled).not.toEqual(true);
+      expect(saveAnd.props().disabled).toEqual(false);
+      expect(saveForLater.props().disabled).toEqual(false);
+    });
+  });
+
+  describe('Service member hasnt provided an Empty Weight weight ticket', () => {
+    it('renders both the Save buttons are disabled', () => {
+      const weightTicket = mountComponents('No');
+      const buttonGroup = weightTicket.find(PPMPaymentRequestActionBtns);
+      const cancel = weightTicket.find('button').at(0);
+      const saveForLater = weightTicket.find('button').at(1);
+      const saveAnd = weightTicket.find('button').at(2);
+
+      expect(buttonGroup.length).toEqual(1);
+      console.log(cancel.debug());
+      expect(cancel.props().disabled).not.toEqual(true);
+      expect(saveAnd.props().disabled).toEqual(true);
+      expect(saveForLater.props().disabled).toEqual(true);
+    });
+  });
   describe('Service member answers "Yes" that they have more weight tickets', () => {
     it('renders Save and Add Another Button', () => {
       const weightTicket = mountComponents('Yes');
-      const button = weightTicket.find(PPMPaymentRequestActionBtns);
-      expect(button.length).toEqual(1);
-      expect(button.props().nextBtnLabel).toEqual('Save & Add Another');
+      const buttonGroup = weightTicket.find(PPMPaymentRequestActionBtns);
+      expect(buttonGroup.length).toEqual(1);
+      expect(buttonGroup.props().nextBtnLabel).toEqual('Save & Add Another');
     });
   });
   describe('Service member answers "No" that they have more weight tickets', () => {
     it('renders Save and Add Continue Button', () => {
       const weightTicket = mountComponents('No');
-      const button = weightTicket.find(PPMPaymentRequestActionBtns);
-      expect(button.length).toEqual(1);
-      expect(button.props().nextBtnLabel).toEqual('Save & Continue');
+      const buttonGroup = weightTicket.find(PPMPaymentRequestActionBtns);
+      expect(buttonGroup.length).toEqual(1);
+      expect(buttonGroup.props().nextBtnLabel).toEqual('Save & Continue');
     });
+  });
+});
+
+describe('missingWeightTickets', () => {
+  it('returns true when there are no uploaders', () => {
+    expect(missingWeightTickets({})).toEqual(true);
+  });
+  it('returns false when both uploaders have at least one file', () => {
+    const uploaders = { one: {}, two: {} };
+    uploaders['one'].isEmpty = jest.fn(() => false);
+    uploaders['two'].isEmpty = jest.fn(() => false);
+    expect(missingWeightTickets(uploaders)).toEqual(false);
+  });
+  it('returns true when one uploaders do not have at least one file', () => {
+    const uploaders = { one: {}, two: {} };
+    uploaders['one'].isEmpty = jest.fn(() => false);
+    uploaders['two'].isEmpty = jest.fn(() => true);
+    expect(missingWeightTickets(uploaders)).toEqual(true);
   });
 });

--- a/src/scenes/Moves/Ppm/WeightTicket.test.js
+++ b/src/scenes/Moves/Ppm/WeightTicket.test.js
@@ -6,7 +6,7 @@ import store from 'shared/store';
 import MockRouter from 'react-mock-router';
 import PPMPaymentRequestActionBtns from './PPMPaymentRequestActionBtns';
 
-function mountComponents(moreWeightTickets = 'Yes', missingWeightTickets) {
+function mountComponents(moreWeightTickets = 'Yes', formIsIncomplete) {
   const initialValues = {
     empty_weight: 1100,
     full_weight: 2000,
@@ -23,9 +23,8 @@ function mountComponents(moreWeightTickets = 'Yes', missingWeightTickets) {
     </Provider>,
   );
   const wt = wrapper.find('WeightTicket');
-  if (missingWeightTickets !== undefined) {
-    wt.instance().isMissingWeightTickets = jest.fn().mockReturnValue(missingWeightTickets);
-    wt.instance().formIsComplete = jest.fn().mockReturnValue(true);
+  if (formIsIncomplete !== undefined) {
+    wt.instance().formIsIncomplete = jest.fn().mockReturnValue(formIsIncomplete);
   }
   wt.setState({ additionalWeightTickets: moreWeightTickets, initialValues: initialValues });
   wt.update();

--- a/src/shared/JsonSchemaForm/SingleDatePicker.jsx
+++ b/src/shared/JsonSchemaForm/SingleDatePicker.jsx
@@ -35,7 +35,7 @@ const getDayPickerProps = disabledDays => {
 };
 
 export default function SingleDatePicker(props) {
-  const { value = null, onChange, disabled, name, disabledDays } = props;
+  const { value = null, onChange, onBlur, disabled, name, disabledDays } = props;
   const formatted = parseDate(value);
   return (
     <DayPickerInput
@@ -45,7 +45,7 @@ export default function SingleDatePicker(props) {
       formatDate={formatDate}
       value={formatted}
       dayPickerProps={getDayPickerProps(disabledDays)}
-      inputProps={{ disabled, name }}
+      inputProps={{ disabled, name, onChange, onBlur }}
     />
   );
 }

--- a/src/shared/JsonSchemaForm/SingleDatePicker.jsx
+++ b/src/shared/JsonSchemaForm/SingleDatePicker.jsx
@@ -35,7 +35,7 @@ const getDayPickerProps = disabledDays => {
 };
 
 export default function SingleDatePicker(props) {
-  const { value = null, onChange, onBlur, disabled, name, disabledDays } = props;
+  const { value = null, onChange, disabled, name, disabledDays } = props;
   const formatted = parseDate(value);
   return (
     <DayPickerInput
@@ -45,7 +45,7 @@ export default function SingleDatePicker(props) {
       formatDate={formatDate}
       value={formatted}
       dayPickerProps={getDayPickerProps(disabledDays)}
-      inputProps={{ disabled, name, onChange, onBlur }}
+      inputProps={{ disabled, name, onChange }}
     />
   );
 }

--- a/src/shared/Uploader/index.jsx
+++ b/src/shared/Uploader/index.jsx
@@ -57,6 +57,14 @@ export class Uploader extends Component {
     }
   }
 
+  isEmpty() {
+    return this.state.files.length === 0;
+  }
+
+  getFiles() {
+    return this.state.files;
+  }
+
   isIdle() {
     // Returns a boolean: is FilePond done with all uploading?
     const existingFiles = this.pond._pond.getFiles();


### PR DESCRIPTION
## Description

Adds the button behavior for the "Save for later" and "Save and add another" buttons. 

## Setup
1) Login as a user that is ready to request payment (e.g. `ppm@requestingpay.ment`)
2) Navigate to the weight tickets screen and attempt to submit a few weight tickets

```sh
make e2e_test
```

## Code Review Verification Steps
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/n/projects/2181745/stories/164718673) for this change

## Screenshots

![164718673-add-save-button-behavior](https://user-images.githubusercontent.com/1036969/58519395-9f461000-8170-11e9-807f-3b5901f089eb.gif)

