### PR TITLE
Allow TSP user to use a single click to open shipment

### DIFF
--- a/cypress/integration/tsp/homepage.js
+++ b/cypress/integration/tsp/homepage.js
@@ -19,6 +19,13 @@ describe('TSP Home Page', function() {
     cy.signIntoTSP();
     tspAllMoves();
   });
+  it('office user can use a single click to view shipment info', function() {
+    cy.signIntoTSP();
+    cy.waitForReactTableLoad();
+
+    cy.get('[data-cy=queueTableRow]:first').click();
+    cy.url().should('include', '/shipments/');
+  });
 });
 
 function tspUserIsOnSignInPage() {

--- a/src/scenes/TransportationServiceProvider/QueueTable.jsx
+++ b/src/scenes/TransportationServiceProvider/QueueTable.jsx
@@ -28,6 +28,12 @@ class QueueTable extends Component {
     }
   }
 
+  openShipment(rowInfo) {
+    this.props.history.push(`/shipments/${rowInfo.original.id}`, {
+      referrerPathname: this.props.history.location.pathname,
+    });
+  }
+
   async fetchData() {
     const loadingQueueType = this.props.queueType;
 
@@ -138,10 +144,9 @@ class QueueTable extends Component {
             className="-striped -highlight"
             showPagination={false}
             getTrProps={(state, rowInfo) => ({
-              onDoubleClick: e =>
-                this.props.history.push(`/shipments/${rowInfo.original.id}`, {
-                  referrerPathname: this.props.history.location.pathname,
-                }),
+              'data-cy': 'queueTableRow',
+              onDoubleClick: () => this.openShipment(rowInfo),
+              onClick: () => this.openShipment(rowInfo),
             })}
           />
         </div>

--- a/src/scenes/TransportationServiceProvider/tsp.css
+++ b/src/scenes/TransportationServiceProvider/tsp.css
@@ -288,3 +288,7 @@ label.inline_radio {
 	margin-top: 1px;
 	margin-bottom: 1px;
 }
+
+.rt-tr-group {
+  cursor: pointer;
+}


### PR DESCRIPTION
## Description

As tsp user
I want to open moves on single clicks
So that I don't have to figure out double click

## Setup

1. `make server_run`
2. `make client_run`

## Code Review Verification Steps

* [x] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/165770052) for this change
