### PR TITLE
Add links to pairing videos

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,10 @@ If you are looking to understand choices made in this project, see the list of [
   * [Service Objects / Go](service-objects.md) guide
 * [Database / Postgres](database.md) guide
 
+## Pairing Sessions
+
+* [Pairing](pairing.md). A list of past pairing recordings.
+
 <!--index-->
 
 ## HOWTOs

--- a/docs/pairing.md
+++ b/docs/pairing.md
@@ -19,6 +19,9 @@ Please update this document with a brief description of the pairing session.
 
 ## Sessions
 
+* [2015-05-29 Query Builder Pairing](https://drive.google.com/file/d/1r1hAs0bdyFmrvSa8T9B3fq8u4Lq0iQLh/view)
+  Code overview of the [Query Builder implementation](https://github.com/transcom/mymove/pull/2120/files)
+  for the Admin APIs
 * [2015-05-15 Query Builder Discussion](https://drive.google.com/file/d/1G7UYQbI41beY2yngvUlrGjuFMCXeq3qS/view)
   A discussion about a [proof of concept](https://github.com/transcom/mymove/pull/2120/files)
   for implementing a Query Builder to support the Admin APIs

--- a/docs/pairing.md
+++ b/docs/pairing.md
@@ -1,0 +1,28 @@
+# Pairing Sessions
+
+On MilMove, we encourage folks to pair program.
+It can increase code quality,
+knowledge sharing,
+and team cohesion.
+Teams may have different practices around when they pair program,
+but when tackling a complex problem,
+it's helpful to get multiple people's perspectives.
+
+Recording pairing sessions can be helpful for documenting code decisions,
+sharing knowledge with those not free to pair,
+and keeping other teams aware of the work you're doing.
+
+Pairing sessions can be recorded with Zoom
+and added to the [MilMove Team Drive](https://drive.google.com/drive/u/0/folders/1WMZ5FzzWMU-HzEr36QFfVRr8TRyuK8I-)
+
+Please update this document with a brief description of the pairing session.
+
+## Sessions
+
+* [2015-05-15 Query Builder Discussion](https://drive.google.com/file/d/1G7UYQbI41beY2yngvUlrGjuFMCXeq3qS/view)
+  A discussion about a [proof of concept](https://github.com/transcom/mymove/pull/2120/files)
+  for implementing a Query Builder to support the Admin APIs
+* [2015-04-15 A-Team Pairing on Storage in Transit Service Object](https://drive.google.com/file/d/19cCDLt1hDJSbZDhHdwQ8u63lBhupTK_s/view)
+  A-team had a discussion about why/how to implement service objects
+  and used [the Storage in Transit handlers](https://github.com/transcom/mymove/pull/2017)
+  as an example.


### PR DESCRIPTION
## Description

We've been pairing more often and recording those pairing sessions. Let's make sure we're not losing these videos into various people's Zoom accounts and downloads folders. I've added the pairing doc to the doc index and made a list for video links.