### PR TITLE
Add and organize new moves/shipments queue columns [delivers #165769221]

### DIFF
--- a/src/scenes/Office/QueueTable.jsx
+++ b/src/scenes/Office/QueueTable.jsx
@@ -2,12 +2,13 @@ import React, { Component } from 'react';
 import { withRouter } from 'react-router';
 import ReactTable from 'react-table';
 import { connect } from 'react-redux';
-import { get, capitalize } from 'lodash';
+import { get } from 'lodash';
 import 'react-table/react-table.css';
 import Alert from 'shared/Alert';
-import { formatDate, formatDateTimeWithTZ, formatTimeAgo } from 'shared/formatters';
+import { formatTimeAgo } from 'shared/formatters';
+import { newColumns, ppmColumns, defaultColumns } from './queueTableColumns';
+
 import FontAwesomeIcon from '@fortawesome/react-fontawesome';
-import faClock from '@fortawesome/fontawesome-free-solid/faClock';
 import './office.scss';
 import faSyncAlt from '@fortawesome/fontawesome-free-solid/faSyncAlt';
 
@@ -114,6 +115,17 @@ class QueueTable extends Component {
       all: 'All Moves',
     };
 
+    const showColumns = queueType => {
+      switch (queueType) {
+        case 'new':
+          return newColumns;
+        case 'ppm':
+          return ppmColumns;
+        default:
+          return defaultColumns;
+      }
+    };
+
     this.state.data.forEach(row => {
       if (this.props.queueType === 'new' && row.ppm_status && row.hhg_status) {
         row.shipments = 'HHG, PPM';
@@ -155,77 +167,7 @@ class QueueTable extends Component {
             />
           </span>
           <ReactTable
-            columns={[
-              {
-                Header: <FontAwesomeIcon icon={faClock} />,
-                id: 'clockIcon',
-                accessor: row => row.synthetic_status,
-                Cell: row =>
-                  row.value === 'PAYMENT_REQUESTED' || row.value === 'SUBMITTED' ? (
-                    <span data-cy="ppm-queue-icon">
-                      <FontAwesomeIcon icon={faClock} style={{ color: 'orange' }} />
-                    </span>
-                  ) : (
-                    ''
-                  ),
-                width: 50,
-                show: this.props.queueType === 'ppm',
-              },
-              {
-                Header: 'Status',
-                accessor: 'synthetic_status',
-                Cell: row => (
-                  <span className="status" data-cy="status">
-                    {capitalize(row.value && row.value.replace('_', ' '))}
-                  </span>
-                ),
-              },
-              {
-                Header: 'Customer name',
-                accessor: 'customer_name',
-              },
-              {
-                Header: 'DoD ID',
-                accessor: 'edipi',
-              },
-              {
-                Header: 'Rank',
-                accessor: 'rank',
-                Cell: row => <span className="rank">{row.value && row.value.replace('_', '-')}</span>,
-              },
-              {
-                Header: 'Shipments',
-                accessor: 'shipments',
-                show: this.props.queueType === 'new',
-              },
-              {
-                Header: 'Locator #',
-                accessor: 'locator',
-                Cell: row => <span data-cy="locator">{row.value}</span>,
-              },
-              {
-                Header: 'GBL',
-                accessor: 'gbl_number',
-                show: this.props.queueType !== 'ppm',
-              },
-              {
-                Header: 'Move date',
-                accessor: 'move_date',
-                Cell: row => <span className="move_date">{formatDate(row.value)}</span>,
-              },
-              {
-                Header: 'Last modified',
-                accessor: 'last_modified_date',
-                Cell: row => <span className="updated_at">{formatDateTimeWithTZ(row.value)}</span>,
-                show: this.props.queueType !== 'new',
-              },
-              {
-                Header: 'Submitted',
-                accessor: 'submitted_date',
-                Cell: row => <span className="submitted_date">{formatDateTimeWithTZ(row.value)}</span>,
-                show: this.props.queueType === 'new',
-              },
-            ]}
+            columns={showColumns(this.props.queueType)}
             data={this.state.data}
             loading={this.state.loading} // Display the loading overlay when we need it
             defaultSorted={[{ id: 'move_date', asc: true }]}

--- a/src/scenes/Office/queueTableColumns.js
+++ b/src/scenes/Office/queueTableColumns.js
@@ -1,0 +1,69 @@
+import React from 'react';
+import { capitalize } from 'lodash';
+import { formatDate, formatDateTimeWithTZ } from 'shared/formatters';
+import FontAwesomeIcon from '@fortawesome/react-fontawesome';
+import faClock from '@fortawesome/fontawesome-free-solid/faClock';
+
+// Abstracting react table column creation
+const CreateReactTableColumn = (header, accessor, options = {}) => ({
+  Header: header,
+  accessor: accessor,
+  ...options,
+});
+
+const clockIcon = CreateReactTableColumn(<FontAwesomeIcon icon={faClock} />, 'synthetic_status', {
+  id: 'clockIcon',
+  Cell: row =>
+    row.value === 'PAYMENT_REQUESTED' || row.value === 'SUBMITTED' ? (
+      <span data-cy="ppm-queue-icon">
+        <FontAwesomeIcon icon={faClock} style={{ color: 'orange' }} />
+      </span>
+    ) : (
+      ''
+    ),
+  width: 50,
+});
+
+const status = CreateReactTableColumn('Status', 'synthetic_status', {
+  Cell: row => (
+    <span className="status" data-cy="status">
+      {capitalize(row.value && row.value.replace('_', ' '))}
+    </span>
+  ),
+});
+
+const customerName = CreateReactTableColumn('Customer name', 'customer_name');
+
+const dodId = CreateReactTableColumn('DoD ID', 'edipi');
+
+const rank = CreateReactTableColumn('Rank', 'rank', {
+  Cell: row => <span className="rank">{row.value && row.value.replace('_', '-')}</span>,
+});
+
+const shipments = CreateReactTableColumn('Shipments', 'shipments');
+
+const locator = CreateReactTableColumn('Locator #', 'locator', {
+  Cell: row => <span data-cy="locator">{row.value}</span>,
+});
+
+const gbl = CreateReactTableColumn('GBL', 'gbl_number');
+
+const moveDate = CreateReactTableColumn('Move date', 'move_date', {
+  Cell: row => <span className="move_date">{formatDate(row.value)}</span>,
+});
+
+const lastModifiedDate = CreateReactTableColumn('Last modified', 'last_modified_date', {
+  Cell: row => <span className="updated_at">{formatDateTimeWithTZ(row.value)}</span>,
+});
+
+const submittedDate = CreateReactTableColumn('Submitted', 'submitted_date', {
+  Cell: row => <span className="submitted_date">{formatDateTimeWithTZ(row.value)}</span>,
+});
+
+// Columns used to display in react table
+
+export const newColumns = [clockIcon, customerName, locator, dodId, rank, shipments, moveDate, submittedDate];
+
+export const ppmColumns = [clockIcon, status, customerName, dodId, rank, locator, moveDate, lastModifiedDate];
+
+export const defaultColumns = [status, customerName, dodId, rank, locator, gbl, moveDate, lastModifiedDate];


### PR DESCRIPTION
## Description

We want to add new and re-organize the new move/shipments queue columns. This will convey information the office user needs and wants. More info in pivotal story.

## Reviewer Notes

- Columns are now separated out into its own js file so we can import
- Each column is turned into an object so we can reuse in different queues
- Let me know if this was a good idea or not

## Setup

1. Login to office app, locally
2. Check out the `New Moves` queues

## Code Review Verification Steps

* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/165769221) for this change

## Screenshots
![image](https://user-images.githubusercontent.com/1522549/58596777-3cb14a80-822a-11e9-964f-8e2d7241bd92.png)
