### PR TITLE
duplicate copy-paste error with data-cy value fixed

### DIFF
--- a/src/shared/StorageInTransit/StorageInTransit.jsx
+++ b/src/shared/StorageInTransit/StorageInTransit.jsx
@@ -293,7 +293,7 @@ export class StorageInTransit extends Component {
                     {(isReleased || isDelivered) && (
                       <div className="panel-field nested__same-font">
                         <span className="field-title unbold">Date out</span>
-                        <span data-cy="sit-expires" className="field-value">
+                        <span data-cy="sit-date-out" className="field-value">
                           {formatDate4DigitYear(storageInTransit.out_date)}
                         </span>
                       </div>


### PR DESCRIPTION
## Description

Follow-up to PR https://github.com/transcom/mymove/pull/2177 need to fix where there is a duplicate data-cy value being used.

## Reviewer Notes

n/a

## Setup

Nothing to test here.


## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/tree/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/tree/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/tree/master/docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
  * [ ] Secure migrations have been tested using `scripts/run-prod-migrations`
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @ntwyman
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

n/a

## Screenshots

n/a