### PR TITLE
Display GBL# on the move info page

### DIFF
--- a/cypress/integration/office/officeUserHHG.js
+++ b/cypress/integration/office/officeUserHHG.js
@@ -33,6 +33,8 @@ function officeUserViewsMoves() {
     expect(loc.pathname).to.match(/^\/queues\/new\/moves\/[^/]+\/basics/);
   });
 
+  cy.contains('GBL#').should('be.visible');
+
   cy.get('[data-cy="hhg-tab"]').click();
 
   cy.location().should(loc => {

--- a/cypress/integration/office/officeUserPPM.js
+++ b/cypress/integration/office/officeUserPPM.js
@@ -147,6 +147,8 @@ function officeUserVerifiesOrders(moveLocator) {
     expect(loc.pathname).to.match(/^\/queues\/new\/moves\/[^/]+\/basics/);
   });
 
+  cy.contains('GBL#').should('not.be.visible');
+
   // Click on Orders document link, check that link matches
   cy
     .get('.panel-field')

--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -373,6 +373,7 @@ class MoveInfo extends Component {
                 &nbsp;
               </li>
               <li>Locator# {move.locator}&nbsp;</li>
+              {shipment.gbl_number && <li>GBL# {shipment.gbl_number}&nbsp;</li>}
               <li>Move date {formatDate(moveDate)}&nbsp;</li>
             </ul>
           </div>


### PR DESCRIPTION
## Description

Office users need to see the GBL # for HHG moves in a prominent location.

## Setup

1. `make server_run`
2. `make client_run`
3. Click on an HHG move and note that there is now a visible GBL# at the top of the page.

## Code Review Verification Steps

* [x] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [x] User facing changes have been reviewed by design.
* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/166091606) for this change

## Screenshots
<img width="1243" alt="Screen Shot 2019-05-30 at 10 03 45" src="https://user-images.githubusercontent.com/3522323/58642117-41c1d880-82c2-11e9-98d8-fc2451515206.png">

