### PR TITLE
Fix the swagger pre-commit check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,42 +57,11 @@ repos:
   - repo: local
     hooks:
       - id: swagger
-        name: API Swagger
+        name: Swagger
         entry: bin/swagger validate
         language: script
-        files: swagger/api.yaml
-
-  - repo: local
-    hooks:
-      - id: swagger
-        name: Internal Swagger
-        entry: bin/swagger validate
-        language: script
-        files: swagger/internal.yaml
-
-  - repo: local
-    hooks:
-      - id: swagger
-        name: Orders Swagger
-        entry: bin/swagger validate
-        language: script
-        files: swagger/orders.yaml
-
-  - repo: local
-    hooks:
-    - id: swagger
-      name: DPS Swagger
-      entry: bin/swagger validate
-      language: script
-      files: swagger/dps.yaml
-
-  - repo: local
-    hooks:
-      - id: swagger
-        name: Admin Swagger
-        entry: bin/swagger validate
-        language: script
-        files: swagger/admin.yaml
+        files: swagger/*
+        types: [yaml]
 
   # Ensure markdown files have updated table of contents
   - repo: local


### PR DESCRIPTION
## Description

This combines the swagger checks into one check entry. It's a response to a long list of PRs that have just copied and pasted:

- #1980
- #1844
- #789
- #170
- #114 

## Setup

Try modifying one or more of the swagger files and run the check.

```sh
pre-commit run -a swagger
```

## Code Review Verification Steps

* [ ] Request review from a member of a different team.