### PR TITLE
Change submitted date to date-time type to show time in new moves/shipments queue [delivers #165754927]

### DIFF
--- a/pkg/handlers/converters_strfmt.go
+++ b/pkg/handlers/converters_strfmt.go
@@ -21,6 +21,16 @@ func FmtDatePtrToPopPtr(date *strfmt.Date) *time.Time {
 	return &fmtDate
 }
 
+// FmtDateTimePtrToPopPtr converts go-swagger type to pop type
+func FmtDateTimePtrToPopPtr(date *strfmt.DateTime) *time.Time {
+	if date == nil {
+		return nil
+	}
+
+	fmtDate := time.Time(*date)
+	return &fmtDate
+}
+
 // FmtInt64PtrToPopPtr converts go-swagger type to pop type
 func FmtInt64PtrToPopPtr(c *int64) *unit.Cents {
 	if c == nil {

--- a/pkg/handlers/internalapi/move_queue_items.go
+++ b/pkg/handlers/internalapi/move_queue_items.go
@@ -26,7 +26,7 @@ func payloadForMoveQueueItem(MoveQueueItem models.MoveQueueItem) *internalmessag
 		HhgStatus:        handlers.FmtStringPtr(MoveQueueItem.HhgStatus),
 		OrdersType:       swag.String(MoveQueueItem.OrdersType),
 		MoveDate:         handlers.FmtDatePtr(MoveQueueItem.MoveDate),
-		SubmittedDate:    handlers.FmtDatePtr(MoveQueueItem.SubmittedDate),
+		SubmittedDate:    handlers.FmtDateTimePtr(MoveQueueItem.SubmittedDate),
 		LastModifiedDate: handlers.FmtDateTime(MoveQueueItem.LastModifiedDate),
 		LastModifiedName: swag.String(MoveQueueItem.LastModifiedName),
 	}

--- a/pkg/handlers/internalapi/move_queue_items_test.go
+++ b/pkg/handlers/internalapi/move_queue_items_test.go
@@ -210,8 +210,8 @@ func (suite *HandlerSuite) TestGetMoveQueueItemsComboSubmittedDate() {
 	moveQueueItem1 := okResponse.Payload[0]
 	moveQueueItem2 := okResponse.Payload[1]
 
-	resultPPMDate := *handlers.FmtDatePtrToPopPtr(moveQueueItem1.SubmittedDate)
-	resultHHGDate := *handlers.FmtDatePtrToPopPtr(moveQueueItem2.SubmittedDate)
+	resultPPMDate := *handlers.FmtDateTimePtrToPopPtr(moveQueueItem1.SubmittedDate)
+	resultHHGDate := *handlers.FmtDateTimePtrToPopPtr(moveQueueItem2.SubmittedDate)
 
 	suite.Equal(hhgSubmitDate.Format(time.UnixDate), resultHHGDate.Format(time.UnixDate))
 	suite.Equal(ppmSubmitDate.Format(time.UnixDate), resultPPMDate.Format(time.UnixDate))

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -2374,7 +2374,7 @@ definitions:
         x-nullable: true
       submitted_date:
         type: string
-        format: date
+        format: date-time
         example: 2018-04-25
         x-nullable: true
       last_modified_date:


### PR DESCRIPTION
## Description

This fixes the return type `submitted_date` for the moves queue. The type is now `date-time` instead of just `date` to display the proper time information.

## Setup

1. Log in to Office app, locally
2. Check out the new moves/shipments queue
3. Submitted column should display date and time data

## Code Review Verification Steps

* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/165754927) for this change

## Screenshots

![image](https://user-images.githubusercontent.com/1522549/58662676-a0e21600-82df-11e9-91b9-465a9ff252cf.png)
