### PR TITLE
Connect to the correct swagger package.

### DIFF
--- a/pkg/handlers/adminapi/api.go
+++ b/pkg/handlers/adminapi/api.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/go-openapi/loads"
 
+	"github.com/transcom/mymove/pkg/gen/adminapi"
 	adminops "github.com/transcom/mymove/pkg/gen/adminapi/adminoperations"
-	"github.com/transcom/mymove/pkg/gen/restapi"
 	"github.com/transcom/mymove/pkg/handlers"
 )
 
@@ -15,7 +15,7 @@ import (
 func NewAdminAPIHandler(context handlers.HandlerContext) http.Handler {
 
 	// Wire up the handlers to the publicAPIMux
-	adminSpec, err := loads.Analyzed(restapi.SwaggerJSON, "")
+	adminSpec, err := loads.Analyzed(adminapi.SwaggerJSON, "")
 	if err != nil {
 		log.Fatalln(err)
 	}


### PR DESCRIPTION
## Description

This fixes a bug that was delivered as a part of this [ticket](https://www.pivotaltracker.com/story/show/164884893). The code I merged tested the handler but did not provide a way to actually test the endpoint.

## Setup

1. `make server_run`
2. Navigate to adminlocal:3000 and choose local sign in
3. Choose "Create a new admin user"
4. Open up dev tools and find the cookie called "admin_session_token". Copy the value.
5. On the command line, run:
```bash
curl -i -H "Accept: application/json" -H "Content-Type: application/json" --cookie "admin_session_token={YOUR SESSION TOKEN}" -X GET http://adminlocal:3000/admin/v1/office_users
```
6. Confirm that an empty JSON array is returned.

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/164884893) for this change