### PR TITLE
Update description of shipment language on GBL form [delivers #165924373]

### DIFF
--- a/pkg/models/gov_bill_of_lading.go
+++ b/pkg/models/gov_bill_of_lading.go
@@ -76,7 +76,7 @@ type GovBillOfLadingFormValues struct {
 	// TGBL shipment case - see description ("LOT").
 	PackagesNumber int64
 	PackagesKind   string
-	// Hardcoded for now - “Household Goods. Containers: 0 Shipment is released at full replacement protection of $4.00 times the net weight in pounds of the shipment or $5,000, whichever is greater.”
+	// Hardcoded for now - “Household Goods. Containers: 0 Shipment is released at full replacement protection of $6.00 times the net weight in pounds of the HHG shipment or the gross weight of the UB shipment or $5,000, whichever is greater.”
 	DescriptionOfShipment string
 	// TSP enters weight values
 	WeightGrossPounds *int64
@@ -199,7 +199,7 @@ func FetchGovBillOfLadingFormValues(db *pop.Connection, shipmentID uuid.UUID) (G
 		"Minneapolis, MN\n" +
 		"800-417-1844\n" +
 		"PowerTrack@usbank.com"
-	gbl.DescriptionOfShipment = "Household Goods. Containers: 0 Shipment is released at full replacement protection of $4.00 times the net weight in pounds of the shipment or $5,000, whichever is greater."
+	gbl.DescriptionOfShipment = "Household Goods. Containers: 0 Shipment is released at full replacement protection of $6.00 times the net weight in pounds of the HHG shipment or the gross weight of the UB shipment or $5,000, whichever is greater."
 	gbl.Remarks = "Direct Delivery Requested"
 	if gbl.LineHaulTransportationRate != nil {
 		// Field has the following format:


### PR DESCRIPTION
## Description

This changes the language of the `description of shipment` box on the GBL form. 

Current text: 

> Household Goods. Containers: 0 Shipment is released at full replacement protection of $4.00 times the net weight in pounds of of the shipment or $5,000, whichever is greater.

On May 15 the DTR Claims and Liability Business rules; 1.1. Liability, 1.1.3.1 and 1.1.3.2 states this should say:

> Household Goods. Containers: 0 Shipment is released at full replacement protection of $6.00 times the net weight in pounds of the HHG shipment or the gross weight of the UB shipment or $5,000, whichever is greater

## Setup

1. Log in to TSP app, locally
2. Locate move with locator `GBLGBL`
3. Open move
4. Click `Generate GBL`
5. View the GBL with the updated language

## Code Review Verification Steps

* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/165924373) for this change

## Screenshots

![image](https://user-images.githubusercontent.com/1522549/58671191-86fffd80-82f6-11e9-9c46-08bec002e096.png)
