### PR TITLE
Add validation pre-check for codecov file

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -130,7 +130,6 @@ repos:
         files: \.md$
         pass_filenames: false
 
-
   - repo: local
     hooks:
     - id: circleci-validate
@@ -138,4 +137,13 @@ repos:
       entry: scripts/pre-commit-circleci-validate
       language: script
       files: '[.]circleci/config.yml$'
+      pass_filenames: false
+
+  - repo: local
+    hooks:
+    - id: codecov-validate
+      name: codecov validate
+      entry: scripts/pre-commit-codecov-validate
+      language: script
+      files: .codecov.yml
       pass_filenames: false

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -26,6 +26,7 @@ committing.
 | gen-docs-index | generate index for documents |
 | generate-md-toc |  Wrapper script to generate table of contents on Markdown files. |
 | pre-commit-circleci-validate | validate circleci `config.yml` file |
+| pre-commit-codecov-validate | validate codecov `.codecov.yml` file |
 | pre-commit-go-imports | modify imports in go files |
 | pre-commit-go-lint | modify go files with linting rules |
 | pre-commit-go-mod | modify `go.mod` and `go.sum` to match whats in the project |

--- a/scripts/pre-commit-codecov-validate
+++ b/scripts/pre-commit-codecov-validate
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+/usr/bin/curl -s --data-binary @.codecov.yml https://codecov.io/validate | grep "Valid!"


### PR DESCRIPTION
## Description

We don't validate the codecov config file. This is a quick way to do it per the docs.


## Setup

```sh
pre-commit run -a codecov-validate
```

## Code Review Verification Steps

* [x] Request review from a member of a different team.