### PR TITLE
Hover styling for tsp queues

### DIFF
--- a/src/scenes/Office/QueueTable.jsx
+++ b/src/scenes/Office/QueueTable.jsx
@@ -9,7 +9,6 @@ import { formatTimeAgo } from 'shared/formatters';
 import { newColumns, ppmColumns, defaultColumns } from './queueTableColumns';
 
 import FontAwesomeIcon from '@fortawesome/react-fontawesome';
-import './office.scss';
 import faSyncAlt from '@fortawesome/fontawesome-free-solid/faSyncAlt';
 
 class QueueTable extends Component {

--- a/src/scenes/Office/office.scss
+++ b/src/scenes/Office/office.scss
@@ -447,7 +447,7 @@ head .panel-subhead {
 
 .ReactTable.-highlight .rt-tbody .rt-tr:not(.-padRow):hover {
   background-color: #E2F1FB;
-  color: #0071bb
+  color: #0071bb;
 }
 
 .staleness-indicator {

--- a/src/scenes/TransportationServiceProvider/index.jsx
+++ b/src/scenes/TransportationServiceProvider/index.jsx
@@ -6,6 +6,8 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 
 import TspHeader from 'shared/Header/Tsp';
+import QueueList from './QueueList';
+import QueueTable from './QueueTable';
 import { getCurrentUserInfo } from 'shared/Data/users';
 import { loadPublicSchema } from 'shared/Swagger/ducks';
 import { detectIE11, no_op } from 'shared/utils';
@@ -16,8 +18,6 @@ import { isProduction } from 'shared/constants';
 import DocumentViewer from './DocumentViewerContainer';
 import NewDocument from './NewDocumentContainer';
 import ShipmentInfo from './ShipmentInfo';
-import QueueList from './QueueList';
-import QueueTable from './QueueTable';
 
 import './tsp.scss';
 

--- a/src/scenes/TransportationServiceProvider/tsp.scss
+++ b/src/scenes/TransportationServiceProvider/tsp.scss
@@ -297,6 +297,11 @@ label.inline_radio {
   color: gray;
 }
 
+.ReactTable.-highlight .rt-tbody .rt-tr:not(.-padRow):hover {
+  background-color: #E2F1FB;
+  color: #0071bb;
+}
+
 .refresh {
   display: inline-block;
   cursor: pointer;


### PR DESCRIPTION
## Description

The highlighted row of a queue's styling should match the office app for background color, text color and cursor.

## Reviewer notes

I did a little re-arranging of the imports to get the cascade working properly.

## Setup

1. `make server_run`
2. `make client_run`
3. Visit the tsp queues

## Code Review Verification Steps

* [x] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/166130119) for this change