### PR TITLE
Remove approved and completed queues in TSP app

### DIFF
--- a/cypress/integration/tsp/queues.js
+++ b/cypress/integration/tsp/queues.js
@@ -11,9 +11,6 @@ describe('TSP User Views Shipment', function() {
   it('tsp user views shipments in accepted shipments queue', function() {
     tspUserViewsAcceptedShipments();
   });
-  it('tsp user views shipments in approved shipments queue', function() {
-    tspUserViewsApprovedShipments();
-  });
   it('tsp user views shipments in in_transit shipments queue', function() {
     tspUserViewsInTransitShipments();
   });
@@ -127,31 +124,4 @@ function tspUserViewsAcceptedShipments() {
   tspUserVerifiesShipmentStatus('Shipment accepted');
 
   cy.get('a').contains('Accepted Shipments Queue');
-}
-
-function tspUserViewsApprovedShipments() {
-  // Open approved shipments queue
-  cy
-    .get('div')
-    .contains('Approved Shipments')
-    .click();
-
-  cy.location().should(loc => {
-    expect(loc.pathname).to.match(/^\/queues\/approved/);
-  });
-
-  // Find title
-  cy.get('h1').contains('Queue: Approved Shipments');
-
-  // Find shipment
-  cy
-    .get('div')
-    .contains('BACON1')
-    .should('not.exist');
-  cy.selectQueueItemMoveLocator('APPRVD');
-
-  // Status
-  tspUserVerifiesShipmentStatus('Awaiting pre-move survey');
-
-  cy.get('a').contains('Approved Shipments Queue');
 }

--- a/cypress/integration/tsp/shipShipment.js
+++ b/cypress/integration/tsp/shipShipment.js
@@ -80,11 +80,11 @@ function tspUserEntersPackAndPickUpInfo() {
   // Open approved shipments queue
   cy
     .get('div')
-    .contains('Approved Shipments')
+    .contains('All Shipments')
     .click();
 
   cy.location().should(loc => {
-    expect(loc.pathname).to.match(/^\/queues\/approved/);
+    expect(loc.pathname).to.match(/^\/queues\/all/);
   });
 
   // Find shipment and open it

--- a/src/scenes/TransportationServiceProvider/QueueList.jsx
+++ b/src/scenes/TransportationServiceProvider/QueueList.jsx
@@ -18,11 +18,6 @@ export default class QueueList extends Component {
             </NavLink>
           </li>
           <li>
-            <NavLink to="/queues/approved" activeClassName="usa-current">
-              <span>Approved Shipments</span>
-            </NavLink>
-          </li>
-          <li>
             <NavLink to="/queues/in_transit" activeClassName="usa-current">
               <span>In Transit Shipments</span>
             </NavLink>
@@ -30,11 +25,6 @@ export default class QueueList extends Component {
           <li>
             <NavLink to="/queues/delivered" activeClassName="usa-current">
               <span>Delivered Shipments</span>
-            </NavLink>
-          </li>
-          <li>
-            <NavLink to="/queues/completed" activeClassName="usa-current">
-              <span>Completed Shipments</span>
             </NavLink>
           </li>
           <li>

--- a/src/scenes/TransportationServiceProvider/QueueTable.jsx
+++ b/src/scenes/TransportationServiceProvider/QueueTable.jsx
@@ -100,8 +100,6 @@ class QueueTable extends Component {
     const titles = {
       new: 'New Shipments',
       accepted: 'Accepted Shipments',
-      completed: 'Completed Shipments',
-      approved: 'Approved Shipments',
       in_transit: 'In Transit Shipments',
       delivered: 'Delivered Shipments',
       all: 'All Shipments',


### PR DESCRIPTION
## Description

As a TSP User
I want only queues of actionable shipments
So that it is easy to select the queue I want to focus on

## Reviewer Notes

As far as I can tell, we don't need any other back-end changes for this, but I could be wrong.

## Setup

1. `make server_run`
2. `make client_run`
3. Visit the TSP queues and verify that you can no longer navigate to the `completed` or `approved` queues.

## Code Review Verification Steps

* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/164788647) for this change

## Screenshots

<img width="1671" alt="Screen Shot 2019-05-31 at 11 09 02" src="https://user-images.githubusercontent.com/3522323/58719109-85851280-8394-11e9-9e55-ad0693c124dc.png">

