### PR TITLE
Fix missing swagger payloads

### DIFF
--- a/pkg/models/order.go
+++ b/pkg/models/order.go
@@ -158,6 +158,7 @@ func FetchOrderForUser(db *pop.Connection, session *auth.Session, id uuid.UUID) 
 	var order Order
 	err := db.Q().Eager("ServiceMember.User",
 		"NewDutyStation.Address",
+		"NewDutyStation.TransportationOffice",
 		"UploadedOrders.Uploads",
 		"Moves.PersonallyProcuredMoves",
 		"Moves.Shipments.TrafficDistributionList",

--- a/pkg/models/service_member.go
+++ b/pkg/models/service_member.go
@@ -95,7 +95,16 @@ func FetchServiceMemberForUser(ctx context.Context, db *pop.Connection, session 
 	defer span.Send()
 
 	var serviceMember ServiceMember
-	err := db.Q().Eager().Find(&serviceMember, id)
+	err := db.Q().Eager("User",
+		"BackupMailingAddress",
+		"BackupContacts",
+		"DutyStation",
+		"DutyStation.TransportationOffice",
+		"Orders",
+		"Orders.NewDutyStation",
+		"Orders.NewDutyStation.TransportationOffice",
+		"ResidentialAddress",
+		"SocialSecurityNumber").Find(&serviceMember, id)
 	if err != nil {
 		if errors.Cause(err).Error() == recordNotFoundErrorString {
 			return ServiceMember{}, ErrFetchNotFound


### PR DESCRIPTION
## Description

While doing load testing I discovered that the Swagger payloads often refer to other definitions which have required fields. In OpenAPI 2.0 we can't say "for this payload the definition of a sub payload is optional". So if we have a definition that has sub definitions which in turn have required fields then ALL of those need to be returned by the database otherwise swagger clients can throw validation errors.

Also worth noting that using `Eager()` by itself will only return the first layer of DB dependencies and go no further.

## Setup

The tests should all continue to pass.

## Code Review Verification Steps

* [x] Request review from a member of a different team.