### PR TITLE
Add warning alert when deleting SIT

### DIFF
--- a/cypress/integration/tsp/storageInTransit.js
+++ b/cypress/integration/tsp/storageInTransit.js
@@ -32,6 +32,9 @@ describe('TSP user interacts with storage in transit panel', function() {
   it('TSP user releases SIT IN-SIT at ORIGIN', function() {
     tspUserSubmitsReleaseSit();
   });
+  it('TSP user cancels delete', function() {
+    tspUserDeletesSitRequest();
+  });
 });
 
 // need to simulate a form submit
@@ -493,4 +496,28 @@ function tspUserSubmitsReleaseSit() {
     expect(text).to.include('Date out');
     expect(text).to.include('26-May-2019');
   });
+}
+
+function tspUserDeletesSitRequest() {
+  // Open accepted shipments queue
+  cy.patientVisit('/queues/accepted');
+  cy.location().should(loc => {
+    expect(loc.pathname).to.match(/^\/queues\/accepted/);
+  });
+
+  // Find shipment and open it
+  cy.selectQueueItemMoveLocator('SITDEL');
+
+  cy.location().should(loc => {
+    expect(loc.pathname).to.match(/^\/shipments\/[^/]+/);
+  });
+
+  // Click on Delete SIT and see SIT Delete warning
+  cy
+    .get('[data-cy=storage-in-transit-panel] [data-cy=sit-delete-link]')
+    .click()
+    .get('[data-cy=sit-delete-warning] [data-cy=sit-delete-cancel]')
+    .click()
+    .get('[data-cy=sit-delete-warning]')
+    .should('not.exist');
 }

--- a/pkg/testdatagen/scenario/e2ebasic.go
+++ b/pkg/testdatagen/scenario/e2ebasic.go
@@ -2556,6 +2556,53 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, log
 	models.SaveMoveDependencies(db, &hhg43.Move)
 
 	/*
+	 * Service member with accepted move for use in testing the deletion of SIT
+	 */
+	email = "hhg@sit.todelete"
+	offer44 := testdatagen.MakeShipmentOffer(db, testdatagen.Assertions{
+		User: models.User{
+			ID:            uuid.Must(uuid.FromString("76616087-713d-4837-8941-f2b73f532a10")),
+			LoginGovEmail: email,
+		},
+		ServiceMember: models.ServiceMember{
+			ID:            uuid.FromStringOrNil("54bae5b4-af77-4693-a3b3-3ff6f5796a92"),
+			FirstName:     models.StringPointer("SIT"),
+			LastName:      models.StringPointer("ToDelete"),
+			Edipi:         models.StringPointer("1357924622"),
+			PersonalEmail: models.StringPointer(email),
+		},
+		Move: models.Move{
+			ID:               uuid.FromStringOrNil("9811bc2c-45e7-40d2-aee0-d863f0d2b7ee"),
+			Locator:          "SITDEL",
+			SelectedMoveType: &selectedMoveTypeHHG,
+		},
+		TrafficDistributionList: models.TrafficDistributionList{
+			ID:                uuid.FromStringOrNil("0c395d75-ec2f-45de-8d3f-74716d69aa67"),
+			SourceRateArea:    "US62",
+			DestinationRegion: "11",
+			CodeOfService:     "D",
+		},
+		Shipment: models.Shipment{
+			Status: models.ShipmentStatusACCEPTED,
+		},
+		ShipmentOffer: models.ShipmentOffer{
+			TransportationServiceProviderID: tspUser.TransportationServiceProviderID,
+			Accepted:                        models.BoolPointer(true),
+		},
+	})
+
+	testdatagen.MakeStorageInTransit(db, testdatagen.Assertions{
+		StorageInTransit: models.StorageInTransit{
+			ShipmentID:         offer44.ShipmentID,
+			Shipment:           offer44.Shipment,
+			EstimatedStartDate: time.Date(2019, time.Month(4), 22, 0, 0, 0, 0, time.UTC),
+		},
+	})
+	hhg44 := offer44.Shipment
+	hhg44.Move.Submit(time.Now())
+	models.SaveMoveDependencies(db, &hhg44.Move)
+
+	/*
 	 * Service member with a ppm ready to request payment
 	 */
 	email = "ppm@requestingpay.ment"

--- a/src/shared/StorageInTransit/DeleteSitRequest.jsx
+++ b/src/shared/StorageInTransit/DeleteSitRequest.jsx
@@ -1,0 +1,29 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+
+class DeleteSitRequest extends Component {
+  render() {
+    return (
+      <div className="usa-alert usa-alert-warning sit-delete-warning">
+        <div className="sit-delete-buttons">
+          <button className="usa-button">Yes, Delete</button>
+          &nbsp;&nbsp;
+          <a className="sit-delete-cancel" onClick={this.props.onClose}>
+            No, do not delete
+          </a>
+        </div>
+        <div className="usa-alert-body">
+          <h3 className="usa-alert-heading">Delete this SIT request?</h3>
+          <p className="usa-alert-text">This action cannot be undone.</p>
+        </div>
+      </div>
+    );
+  }
+}
+
+DeleteSitRequest.propTypes = {
+  storageInTransit: PropTypes.object.isRequired,
+  onClose: PropTypes.func.isRequired,
+};
+
+export default DeleteSitRequest;

--- a/src/shared/StorageInTransit/DeleteSitRequest.jsx
+++ b/src/shared/StorageInTransit/DeleteSitRequest.jsx
@@ -4,11 +4,11 @@ import PropTypes from 'prop-types';
 class DeleteSitRequest extends Component {
   render() {
     return (
-      <div className="usa-alert usa-alert-warning sit-delete-warning">
+      <div className="usa-alert usa-alert-warning sit-delete-warning" data-cy="sit-delete-warning">
         <div className="sit-delete-buttons">
           <button className="usa-button">Yes, Delete</button>
           &nbsp;&nbsp;
-          <a className="sit-delete-cancel" onClick={this.props.onClose}>
+          <a className="sit-delete-cancel" data-cy="sit-delete-cancel" onClick={this.props.onClose}>
             No, do not delete
           </a>
         </div>

--- a/src/shared/StorageInTransit/DeleteSitRequest.test.jsx
+++ b/src/shared/StorageInTransit/DeleteSitRequest.test.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import DeleteSitRequest from './DeleteSitRequest';
+
+let wrapper;
+const requestedStorageInTransit = {
+  status: 'REQUESTED',
+  location: 'DESTINATION',
+  estimated_start_date: '2019-05-15',
+};
+const onCloseHandler = jest.fn();
+
+describe('Delete SIT request', () => {
+  beforeEach(() => {
+    onCloseHandler.mockClear();
+    wrapper = shallow(<DeleteSitRequest storageInTransit={requestedStorageInTransit} onClose={onCloseHandler} />);
+  });
+
+  it('renders without crashing', () => {
+    expect(wrapper.find('.sit-delete-warning').length).toEqual(1);
+  });
+
+  it('clicking calls close handler', () => {
+    wrapper.find('.sit-delete-cancel').simulate('click');
+    expect(onCloseHandler.mock.calls.length).toBe(1);
+  });
+});

--- a/src/shared/StorageInTransit/StorageInTransit.css
+++ b/src/shared/StorageInTransit/StorageInTransit.css
@@ -131,3 +131,7 @@
 .storage-in-transit-panel .sit-delete-warning .usa-alert-text {
   font-weight: normal;
 }
+
+.storage-in-transit-panel .sit-delete-warning h3.usa-alert-heading {
+  font-family: "Source Sans Pro", "Helvetica Neue", "Helvetica", "Roboto", "Arial", sans-serif;
+}

--- a/src/shared/StorageInTransit/StorageInTransit.css
+++ b/src/shared/StorageInTransit/StorageInTransit.css
@@ -107,3 +107,21 @@
   margin-top: 10px;
 }
 
+.storage-in-transit-panel .sit-delete-warning {
+  margin-top: 1em;
+}
+
+.storage-in-transit-panel .sit-delete-warning .sit-delete-buttons {
+  float: right;
+}
+
+.storage-in-transit-panel .sit-delete-warning .sit-delete-cancel {
+  font-size: 1.2em;
+  font-weight: normal;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.storage-in-transit-panel .sit-delete-warning .usa-alert-text {
+  font-weight: normal;
+}

--- a/src/shared/StorageInTransit/StorageInTransit.jsx
+++ b/src/shared/StorageInTransit/StorageInTransit.jsx
@@ -20,6 +20,7 @@ import OfficeEditor from 'shared/StorageInTransit/OfficeEditor';
 import ApproveSitRequest from 'shared/StorageInTransit/ApproveSitRequest';
 import DenySitRequest from 'shared/StorageInTransit/DenySitRequest';
 import PlaceInSit from 'shared/StorageInTransit/PlaceInSit';
+import DeleteSitRequest from 'shared/StorageInTransit/DeleteSitRequest';
 import { updateStorageInTransit } from 'shared/Entities/modules/storageInTransits';
 import { isOfficeSite, isTspSite } from 'shared/constants';
 import SitStatusIcon from './SitStatusIcon';
@@ -192,7 +193,14 @@ export class StorageInTransit extends Component {
 
   render() {
     const { storageInTransit, daysRemaining } = this.props;
-    const { showTspEditForm, showOfficeEditForm, showApproveForm, showDenyForm, showPlaceInSitForm } = this.state;
+    const {
+      showTspEditForm,
+      showOfficeEditForm,
+      showApproveForm,
+      showDenyForm,
+      showPlaceInSitForm,
+      showDeleteWarning,
+    } = this.state;
     const isDenied = storageInTransit.status === 'DENIED';
     const isRequested = storageInTransit.status === 'REQUESTED';
     const isApproved = storageInTransit.status === 'APPROVED';
@@ -244,6 +252,8 @@ export class StorageInTransit extends Component {
               onClose={this.closeOfficeEditForm}
               storageInTransit={storageInTransit}
             />
+          ) : showDeleteWarning ? (
+            <DeleteSitRequest storageInTransit={storageInTransit} onClose={this.closeDeleteWarning} />
           ) : (
             <span className="sit-actions">{this.renderSitActions()}</span>
           )}


### PR DESCRIPTION
## Description

This PR adds a warning alert when deleting SIT.  Note that this PR does not include the actual deletion of the SIT (we have another story for that), so the `Yes, Delete` button doesn't do anything yet.  However, you should be able to see the alert and cancel out of it.

## Reviewer Notes

None.

## Setup

`make server_run`
`make tsp_client_run`

Go to the TSP app, pick an HHG shipment, then request some SIT.  You should then see a `Delete` action for that SIT.  Click `Delete` to get the warning, then click `No, do not delete` to cancel out of it.  The `Yes, Delete` button will become functional in a later story.

The `Delete` button appears in other SIT statuses as well, but they should all function in the same way.

## Code Review Verification Steps

* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/165520730) for this change

## Screenshots

<img width="954" alt="Screen Shot 2019-05-31 at 12 27 11 PM" src="https://user-images.githubusercontent.com/4960757/58738517-18916d00-83d4-11e9-945e-5d3b52512ea3.png">
