### PR TITLE
db-debug flag

### DIFF
--- a/cmd/milmove/migrate.go
+++ b/cmd/milmove/migrate.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"log"
-	"os"
 	"strings"
 
 	"github.com/gobuffalo/pop"
@@ -53,7 +52,7 @@ func checkMigrateConfig(v *viper.Viper, logger logger) error {
 
 func migrateFunction(cmd *cobra.Command, args []string) error {
 
-	err := cmd.ParseFlags(os.Args[1:])
+	err := cmd.ParseFlags(args)
 	if err != nil {
 		return errors.Wrap(err, "Could not parse flags")
 	}
@@ -90,6 +89,10 @@ func migrateFunction(cmd *cobra.Command, args []string) error {
 	err = checkMigrateConfig(v, logger)
 	if err != nil {
 		logger.Fatal("invalid configuration", zap.Error(err))
+	}
+
+	if v.GetBool(cli.DbDebugFlag) {
+		pop.Debug = true
 	}
 
 	// Create a connection to the DB

--- a/cmd/milmove/serve.go
+++ b/cmd/milmove/serve.go
@@ -19,6 +19,7 @@ import (
 	"syscall"
 
 	"github.com/dgrijalva/jwt-go"
+	"github.com/gobuffalo/pop"
 	"github.com/gorilla/csrf"
 	"github.com/honeycombio/beeline-go"
 	"github.com/honeycombio/beeline-go/wrappers/hnynethttp"
@@ -345,6 +346,10 @@ func serveFunction(cmd *cobra.Command, args []string) error {
 	}
 	if len(loginGovHostname) == 0 {
 		logger.Fatal("Must provide the Login.gov hostname parameter, exiting")
+	}
+
+	if v.GetBool(cli.DbDebugFlag) {
+		pop.Debug = true
 	}
 
 	// Create a connection to the DB

--- a/pkg/cli/dbconn.go
+++ b/pkg/cli/dbconn.go
@@ -15,6 +15,8 @@ import (
 )
 
 const (
+	// DbDebugFlag is the DB Debug flag
+	DbDebugFlag string = "db-debug"
 	// DbEnvFlag is the DB environment flag
 	DbEnvFlag string = "env"
 	// DbNameFlag is the DB name flag
@@ -105,6 +107,7 @@ func InitDatabaseFlags(flag *pflag.FlagSet) {
 	flag.String(DbPasswordFlag, "", "Database Password")
 	flag.String(DbSSLModeFlag, SSLModeDisable, "Database SSL Mode: "+strings.Join(allSSLModes, ", "))
 	flag.String(DbSSLRootCertFlag, "", "Path to the database root certificate file used for database connections")
+	flag.Bool(DbDebugFlag, false, "Set Pop to debug mode")
 }
 
 // CheckDatabase validates DB command line flags


### PR DESCRIPTION
## Description

Adds a `db-debug` flag that turns on Pop's debug mode, which logs every SQL statement to stdout.

## Reviewer Notes

None

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make db_dev_reset
DB_DEBUG=1 make db_dev_migrate
```

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/tree/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/tree/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/tree/master/docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
  * [ ] Secure migrations have been tested using `scripts/run-prod-migrations`
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @ntwyman
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

None

## Screenshots

N.A.