### PR TITLE
Move the `Init*` functions to their respective packages 

### DIFF
--- a/cmd/milmove/serve.go
+++ b/cmd/milmove/serve.go
@@ -46,6 +46,7 @@ import (
 	"github.com/transcom/mymove/pkg/handlers/internalapi"
 	"github.com/transcom/mymove/pkg/handlers/ordersapi"
 	"github.com/transcom/mymove/pkg/handlers/publicapi"
+	"github.com/transcom/mymove/pkg/iws"
 	"github.com/transcom/mymove/pkg/logging"
 	"github.com/transcom/mymove/pkg/middleware"
 	"github.com/transcom/mymove/pkg/notifications"
@@ -485,7 +486,7 @@ func serveFunction(cmd *cobra.Command, args []string) error {
 	}
 	handlerContext.SetICNSequencer(icnSequencer)
 
-	rbs, err := cli.InitRBSPersonLookup(v, logger)
+	rbs, err := iws.InitRBSPersonLookup(v, logger)
 	if err != nil {
 		logger.Fatal("Could not instantiate IWS RBS", zap.Error(err))
 	}

--- a/cmd/milmove/serve.go
+++ b/cmd/milmove/serve.go
@@ -34,6 +34,7 @@ import (
 
 	"github.com/transcom/mymove/pkg/auth"
 	"github.com/transcom/mymove/pkg/auth/authentication"
+	"github.com/transcom/mymove/pkg/certs"
 	"github.com/transcom/mymove/pkg/cli"
 	"github.com/transcom/mymove/pkg/db/sequence"
 	"github.com/transcom/mymove/pkg/dpsauth"
@@ -434,7 +435,7 @@ func serveFunction(cmd *cobra.Command, args []string) error {
 	storer := cli.InitStorage(v, session, logger)
 	handlerContext.SetFileStorer(storer)
 
-	certificates, rootCAs, err := cli.InitDoDCertificates(v, logger)
+	certificates, rootCAs, err := certs.InitDoDCertificates(v, logger)
 	if certificates == nil || rootCAs == nil || err != nil {
 		logger.Fatal("Failed to initialize DOD certificates", zap.Error(err))
 	}

--- a/cmd/milmove/serve.go
+++ b/cmd/milmove/serve.go
@@ -47,6 +47,7 @@ import (
 	"github.com/transcom/mymove/pkg/handlers/publicapi"
 	"github.com/transcom/mymove/pkg/logging"
 	"github.com/transcom/mymove/pkg/middleware"
+	"github.com/transcom/mymove/pkg/notifications"
 	"github.com/transcom/mymove/pkg/server"
 	"github.com/transcom/mymove/pkg/services"
 	"github.com/transcom/mymove/pkg/services/invoice"
@@ -412,7 +413,7 @@ func serveFunction(cmd *cobra.Command, args []string) error {
 	}
 
 	// Email
-	notificationSender := cli.InitEmail(v, session, logger)
+	notificationSender := notifications.InitEmail(v, session, logger)
 	handlerContext.SetNotificationSender(notificationSender)
 
 	build := v.GetString(cli.BuildFlag)

--- a/cmd/milmove/serve.go
+++ b/cmd/milmove/serve.go
@@ -48,6 +48,7 @@ import (
 	"github.com/transcom/mymove/pkg/logging"
 	"github.com/transcom/mymove/pkg/middleware"
 	"github.com/transcom/mymove/pkg/notifications"
+	"github.com/transcom/mymove/pkg/route"
 	"github.com/transcom/mymove/pkg/server"
 	"github.com/transcom/mymove/pkg/services"
 	"github.com/transcom/mymove/pkg/services/invoice"
@@ -423,7 +424,7 @@ func serveFunction(cmd *cobra.Command, args []string) error {
 
 	// Get route planner for handlers to calculate transit distances
 	// routePlanner := route.NewBingPlanner(logger, bingMapsEndpoint, bingMapsKey)
-	routePlanner := cli.InitRoutePlanner(v, logger)
+	routePlanner := route.InitRoutePlanner(v, logger)
 	handlerContext.SetPlanner(routePlanner)
 
 	// Set SendProductionInvoice for ediinvoice

--- a/cmd/milmove/serve.go
+++ b/cmd/milmove/serve.go
@@ -496,7 +496,7 @@ func serveFunction(cmd *cobra.Command, args []string) error {
 	dpsCookieSecret := []byte(v.GetString(cli.DPSAuthCookieSecretKeyFlag))
 	dpsCookieExpires := v.GetInt(cli.DPSCookieExpiresInMinutesFlag)
 
-	dpsAuthParams := cli.InitDPSAuthParams(v, appnames)
+	dpsAuthParams := dpsauth.InitDPSAuthParams(v, appnames)
 	handlerContext.SetDPSAuthParams(dpsAuthParams)
 
 	// Base routes

--- a/cmd/milmove/serve.go
+++ b/cmd/milmove/serve.go
@@ -432,7 +432,7 @@ func serveFunction(cmd *cobra.Command, args []string) error {
 	handlerContext.SetSendProductionInvoice(v.GetBool(cli.GEXSendProdInvoiceFlag))
 
 	// Storage
-	storer := cli.InitStorage(v, session, logger)
+	storer := storage.InitStorage(v, session, logger)
 	handlerContext.SetFileStorer(storer)
 
 	certificates, rootCAs, err := certs.InitDoDCertificates(v, logger)

--- a/cmd/milmove/serve.go
+++ b/cmd/milmove/serve.go
@@ -393,7 +393,7 @@ func serveFunction(cmd *cobra.Command, args []string) error {
 	}
 
 	// Register Login.gov authentication provider for My.(move.mil)
-	loginGovProvider, err := cli.InitAuth(v, logger, appnames)
+	loginGovProvider, err := authentication.InitAuth(v, logger, appnames)
 	if err != nil {
 		logger.Fatal("Registering login provider", zap.Error(err))
 	}

--- a/pkg/auth/authentication/auth.go
+++ b/pkg/auth/authentication/auth.go
@@ -16,9 +16,11 @@ import (
 	"github.com/markbates/goth"
 	"github.com/markbates/goth/providers/openidConnect"
 	"github.com/pkg/errors"
+	"github.com/spf13/viper"
 	"go.uber.org/zap"
 
 	"github.com/transcom/mymove/pkg/auth"
+	"github.com/transcom/mymove/pkg/cli"
 	"github.com/transcom/mymove/pkg/models"
 )
 
@@ -447,4 +449,26 @@ func fetchToken(logger Logger, code string, clientID string, loginGovProvider Lo
 		IDToken:     parsedResponse.IDToken,
 	}
 	return &session, err
+}
+
+// InitAuth initializes the Login.gov provider
+func InitAuth(v *viper.Viper, logger Logger, appnames auth.ApplicationServername) (LoginGovProvider, error) {
+	loginGovCallbackProtocol := v.GetString(cli.LoginGovCallbackProtocolFlag)
+	loginGovCallbackPort := v.GetInt(cli.LoginGovCallbackPortFlag)
+	loginGovSecretKey := v.GetString(cli.LoginGovSecretKeyFlag)
+	loginGovHostname := v.GetString(cli.LoginGovHostnameFlag)
+
+	loginGovProvider := NewLoginGovProvider(loginGovHostname, loginGovSecretKey, logger)
+	err := loginGovProvider.RegisterProvider(
+		appnames.MilServername,
+		v.GetString(cli.LoginGovMyClientIDFlag),
+		appnames.OfficeServername,
+		v.GetString(cli.LoginGovOfficeClientIDFlag),
+		appnames.TspServername,
+		v.GetString(cli.LoginGovTSPClientIDFlag),
+		appnames.AdminServername,
+		v.GetString(cli.LoginGovAdminClientIDFlag),
+		loginGovCallbackProtocol,
+		loginGovCallbackPort)
+	return loginGovProvider, err
 }

--- a/pkg/certs/certs.go
+++ b/pkg/certs/certs.go
@@ -1,0 +1,68 @@
+package certs
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"io/ioutil"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/viper"
+	"go.uber.org/zap"
+
+	"github.com/transcom/mymove/pkg/cli"
+	"github.com/transcom/mymove/pkg/server"
+)
+
+// InitDoDCertificates initializes the DoD Certificates
+func InitDoDCertificates(v *viper.Viper, logger Logger) ([]tls.Certificate, *x509.CertPool, error) {
+
+	tlsCertString := v.GetString(cli.MoveMilDoDTLSCertFlag)
+	tlsCerts := cli.ParseCertificates(tlsCertString)
+	if len(tlsCerts) == 0 {
+		return make([]tls.Certificate, 0), nil, errors.Errorf("%s is missing certificate PEM block", cli.MoveMilDoDTLSCertFlag)
+	}
+	if len(tlsCerts) > 1 {
+		return make([]tls.Certificate, 0), nil, errors.Errorf("%s has too many certificate PEM blocks", cli.MoveMilDoDTLSCertFlag)
+	}
+
+	logger.Info(fmt.Sprintf("certitficate chain from %s parsed", cli.MoveMilDoDTLSCertFlag), zap.Any("count", len(tlsCerts)))
+
+	caCertString := v.GetString(cli.MoveMilDoDCACertFlag)
+	caCerts := cli.ParseCertificates(caCertString)
+	if len(caCerts) == 0 {
+		return make([]tls.Certificate, 0), nil, errors.Errorf("%s is missing certificate PEM block", cli.MoveMilDoDTLSCertFlag)
+	}
+
+	logger.Info(fmt.Sprintf("certitficate chain from %s parsed", cli.MoveMilDoDCACertFlag), zap.Any("count", len(caCerts)))
+
+	//Append move.mil cert with intermediate CA to create a validate certificate chain
+	cert := strings.Join(append(append(make([]string, 0), tlsCerts...), caCerts...), "\n")
+
+	key := v.GetString(cli.MoveMilDoDTLSKeyFlag)
+	keyPair, err := tls.X509KeyPair([]byte(cert), []byte(key))
+	if err != nil {
+		return make([]tls.Certificate, 0), nil, errors.Wrap(err, "failed to parse DOD x509 keypair for server")
+	}
+
+	logger.Info("DOD keypair", zap.Any("certificates", len(keyPair.Certificate)))
+
+	pathToPackage := v.GetString(cli.DoDCAPackageFlag)
+	pkcs7Package, err := ioutil.ReadFile(pathToPackage) // #nosec
+	if err != nil {
+		return make([]tls.Certificate, 0), nil, errors.Wrap(err, fmt.Sprintf("%s is invalid", cli.DoDCAPackageFlag))
+	}
+
+	if len(pkcs7Package) == 0 {
+		return make([]tls.Certificate, 0), nil, errors.Wrap(&cli.ErrInvalidPKCS7{Path: pathToPackage}, fmt.Sprintf("%s is an empty file", cli.DoDCAPackageFlag))
+	}
+
+	dodCACertPool, err := server.LoadCertPoolFromPkcs7Package(pkcs7Package)
+	if err != nil {
+		return make([]tls.Certificate, 0), dodCACertPool, errors.Wrap(err, "Failed to parse DoD CA certificate package")
+	}
+
+	return []tls.Certificate{keyPair}, dodCACertPool, nil
+
+}

--- a/pkg/certs/certs_test.go
+++ b/pkg/certs/certs_test.go
@@ -1,0 +1,73 @@
+package certs
+
+import (
+	"log"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/suite"
+	"go.uber.org/zap"
+
+	"github.com/transcom/mymove/pkg/cli"
+	"github.com/transcom/mymove/pkg/logging"
+)
+
+type certTestSuite struct {
+	suite.Suite
+	viper  *viper.Viper
+	logger Logger
+}
+
+type initFlags func(f *pflag.FlagSet)
+
+func (suite *certTestSuite) Setup(fn initFlags, flagSet []string) {
+	suite.viper = nil
+
+	flag := pflag.NewFlagSet(os.Args[0], pflag.ExitOnError)
+	fn(flag)
+	flag.Parse(flagSet)
+
+	v := viper.New()
+	err := v.BindPFlags(flag)
+	if err != nil {
+		suite.logger.Fatal("could not bind flags", zap.Error(err))
+	}
+	v.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
+	v.AutomaticEnv()
+
+	suite.SetViper(v)
+}
+
+func (suite *certTestSuite) SetViper(v *viper.Viper) {
+	suite.viper = v
+}
+
+func TestCertSuite(t *testing.T) {
+
+	logger, err := logging.Config("development", true)
+	if err != nil {
+		log.Fatalf("Failed to initialize Zap logging due to %v", err)
+	}
+	zap.ReplaceGlobals(logger)
+
+	ss := &certTestSuite{
+		logger: logger,
+	}
+
+	suite.Run(t, ss)
+}
+
+func (suite *certTestSuite) TestDODCertificates() {
+
+	if os.Getenv("TEST_ACC_DOD_CERTIFICATES") != "1" {
+		suite.logger.Info("skipping TestDODCertificates")
+		return
+	}
+
+	suite.Setup(cli.InitCertFlags, []string{})
+	_, _, err := InitDoDCertificates(suite.viper, suite.logger)
+	suite.Nil(err)
+}

--- a/pkg/certs/logger.go
+++ b/pkg/certs/logger.go
@@ -1,0 +1,14 @@
+package certs
+
+import (
+	"go.uber.org/zap"
+)
+
+// Logger is an interface that describes the logging requirements of this package.
+type Logger interface {
+	Debug(msg string, fields ...zap.Field)
+	Info(msg string, fields ...zap.Field)
+	Error(msg string, fields ...zap.Field)
+	Warn(msg string, fields ...zap.Field)
+	Fatal(msg string, fields ...zap.Field)
+}

--- a/pkg/cli/auth.go
+++ b/pkg/cli/auth.go
@@ -8,9 +8,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
-
-	"github.com/transcom/mymove/pkg/auth"
-	"github.com/transcom/mymove/pkg/auth/authentication"
 )
 
 const (
@@ -60,28 +57,6 @@ func InitAuthFlags(flag *pflag.FlagSet) {
 	flag.String(LoginGovTSPClientIDFlag, "", "Client ID registered with login gov.")
 	flag.String(LoginGovAdminClientIDFlag, "", "Client ID registered with login gov.")
 	flag.String(LoginGovHostnameFlag, "secure.login.gov", "Hostname for communicating with login gov.")
-}
-
-// InitAuth initializes the Login.gov provider
-func InitAuth(v *viper.Viper, logger Logger, appnames auth.ApplicationServername) (authentication.LoginGovProvider, error) {
-	loginGovCallbackProtocol := v.GetString(LoginGovCallbackProtocolFlag)
-	loginGovCallbackPort := v.GetInt(LoginGovCallbackPortFlag)
-	loginGovSecretKey := v.GetString(LoginGovSecretKeyFlag)
-	loginGovHostname := v.GetString(LoginGovHostnameFlag)
-
-	loginGovProvider := authentication.NewLoginGovProvider(loginGovHostname, loginGovSecretKey, logger)
-	err := loginGovProvider.RegisterProvider(
-		appnames.MilServername,
-		v.GetString(LoginGovMyClientIDFlag),
-		appnames.OfficeServername,
-		v.GetString(LoginGovOfficeClientIDFlag),
-		appnames.TspServername,
-		v.GetString(LoginGovTSPClientIDFlag),
-		appnames.AdminServername,
-		v.GetString(LoginGovAdminClientIDFlag),
-		loginGovCallbackProtocol,
-		loginGovCallbackPort)
-	return loginGovProvider, err
 }
 
 // CheckAuth validates Auth command line flags

--- a/pkg/cli/certs_test.go
+++ b/pkg/cli/certs_test.go
@@ -12,6 +12,5 @@ func (suite *cliTestSuite) TestDODCertificates() {
 	}
 
 	suite.Setup(InitCertFlags, []string{})
-	_, _, err := InitDoDCertificates(suite.viper, suite.logger)
-	suite.Nil(err)
+	suite.Nil(CheckCert(suite.viper))
 }

--- a/pkg/cli/dps.go
+++ b/pkg/cli/dps.go
@@ -4,9 +4,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
-
-	"github.com/transcom/mymove/pkg/auth"
-	"github.com/transcom/mymove/pkg/dpsauth"
 )
 
 const (
@@ -45,21 +42,6 @@ func InitDPSFlags(flag *pflag.FlagSet) {
 	flag.String(DPSCookieDomainFlag, "sddclocal", "Domain of the DPS cookie")
 	flag.String(DPSAuthCookieSecretKeyFlag, "", "DPS auth cookie secret key, 32 byte long")
 	flag.Int(DPSCookieExpiresInMinutesFlag, 240, "DPS cookie expiration in minutes")
-}
-
-// InitDPSAuthParams initializes the DPS Auth Params
-func InitDPSAuthParams(v *viper.Viper, appnames auth.ApplicationServername) dpsauth.Params {
-	return dpsauth.Params{
-		SDDCProtocol:   v.GetString(HTTPSDDCProtocolFlag),
-		SDDCHostname:   appnames.SddcServername,
-		SDDCPort:       v.GetInt(HTTPSDDCPortFlag),
-		SecretKey:      v.GetString(DPSAuthSecretKeyFlag),
-		DPSRedirectURL: v.GetString(DPSRedirectURLFlag),
-		CookieName:     v.GetString(DPSCookieNameFlag),
-		CookieDomain:   v.GetString(DPSCookieDomainFlag),
-		CookieSecret:   []byte(v.GetString(DPSAuthCookieSecretKeyFlag)),
-		CookieExpires:  v.GetInt(DPSCookieExpiresInMinutesFlag),
-	}
 }
 
 // CheckDPS validates DPS command line flags

--- a/pkg/cli/email.go
+++ b/pkg/cli/email.go
@@ -3,14 +3,10 @@ package cli
 import (
 	"fmt"
 
-	awssession "github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ses"
 	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
-	"go.uber.org/zap"
-
-	"github.com/transcom/mymove/pkg/notifications"
 )
 
 const (
@@ -47,24 +43,4 @@ func CheckEmail(v *viper.Viper) error {
 	}
 
 	return nil
-}
-
-// InitEmail initializes the email backend
-func InitEmail(v *viper.Viper, sess *awssession.Session, logger Logger) notifications.NotificationSender {
-	if v.GetString(EmailBackendFlag) == "ses" {
-		// Setup Amazon SES (email) service
-		// TODO: This might be able to be combined with the AWS Session that we're using for S3 down
-		// below.
-		awsSESRegion := v.GetString(AWSSESRegionFlag)
-		awsSESDomain := v.GetString(AWSSESDomainFlag)
-		logger.Info("Using ses email backend",
-			zap.String("region", awsSESRegion),
-			zap.String("domain", awsSESDomain))
-		sesService := ses.New(sess)
-		return notifications.NewNotificationSender(sesService, awsSESDomain, logger)
-	}
-
-	domain := "milmovelocal"
-	logger.Info("Using local email backend", zap.String("domain", domain))
-	return notifications.NewStubNotificationSender(domain, logger)
 }

--- a/pkg/cli/iws.go
+++ b/pkg/cli/iws.go
@@ -3,8 +3,6 @@ package cli
 import (
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
-
-	"github.com/transcom/mymove/pkg/iws"
 )
 
 const (
@@ -15,15 +13,6 @@ const (
 // InitIWSFlags initializes CSRF command line flags
 func InitIWSFlags(flag *pflag.FlagSet) {
 	flag.String(IWSRBSHostFlag, "", "Hostname for the IWS RBS")
-}
-
-// InitRBSPersonLookup is the RBS Person Lookup service
-func InitRBSPersonLookup(v *viper.Viper, logger Logger) (*iws.RBSPersonLookup, error) {
-	return iws.NewRBSPersonLookup(
-		v.GetString(IWSRBSHostFlag),
-		v.GetString(DoDCAPackageFlag),
-		v.GetString(MoveMilDoDTLSCertFlag),
-		v.GetString(MoveMilDoDTLSKeyFlag))
 }
 
 // CheckIWS validates IWS command line flags

--- a/pkg/cli/route.go
+++ b/pkg/cli/route.go
@@ -1,13 +1,8 @@
 package cli
 
 import (
-	"net/http"
-	"time"
-
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
-
-	"github.com/transcom/mymove/pkg/route"
 )
 
 const (
@@ -19,9 +14,6 @@ const (
 	HEREMapsAppIDFlag string = "here-maps-app-id"
 	// HEREMapsAppCodeFlag is the HERE Maps App Code Flag
 	HEREMapsAppCodeFlag string = "here-maps-app-code"
-
-	// hereRequestTimeout is how long to wait on HERE request before timing out (15 seconds).
-	hereRequestTimeout = time.Duration(15) * time.Second
 )
 
 // InitRouteFlags initializes Route command line flags
@@ -30,18 +22,6 @@ func InitRouteFlags(flag *pflag.FlagSet) {
 	flag.String(HEREMapsRoutingEndpointFlag, "", "URL for the HERE maps routing endpoint")
 	flag.String(HEREMapsAppIDFlag, "", "HERE maps App ID for this application")
 	flag.String(HEREMapsAppCodeFlag, "", "HERE maps App API code")
-}
-
-// InitRoutePlanner validates Route Planner command line flags
-func InitRoutePlanner(v *viper.Viper, logger Logger) route.Planner {
-	hereClient := &http.Client{Timeout: hereRequestTimeout}
-	return route.NewHEREPlanner(
-		logger,
-		hereClient,
-		v.GetString(HEREMapsGeocodeEndpointFlag),
-		v.GetString(HEREMapsRoutingEndpointFlag),
-		v.GetString(HEREMapsAppIDFlag),
-		v.GetString(HEREMapsAppCodeFlag))
 }
 
 // CheckRoute validates Route command line flags

--- a/pkg/dpsauth/auth.go
+++ b/pkg/dpsauth/auth.go
@@ -4,7 +4,11 @@ import (
 	"net/http"
 
 	jwt "github.com/dgrijalva/jwt-go"
+	"github.com/spf13/viper"
 	"go.uber.org/zap"
+
+	"github.com/transcom/mymove/pkg/auth"
+	"github.com/transcom/mymove/pkg/cli"
 )
 
 // SetCookiePath is the path for this resource
@@ -66,4 +70,19 @@ func (h SetCookieHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	http.SetCookie(w, &roleCookie)
 
 	http.Redirect(w, r, claims.DPSRedirectURL, http.StatusSeeOther)
+}
+
+// InitDPSAuthParams initializes the DPS Auth Params
+func InitDPSAuthParams(v *viper.Viper, appnames auth.ApplicationServername) Params {
+	return Params{
+		SDDCProtocol:   v.GetString(cli.HTTPSDDCProtocolFlag),
+		SDDCHostname:   appnames.SddcServername,
+		SDDCPort:       v.GetInt(cli.HTTPSDDCPortFlag),
+		SecretKey:      v.GetString(cli.DPSAuthSecretKeyFlag),
+		DPSRedirectURL: v.GetString(cli.DPSRedirectURLFlag),
+		CookieName:     v.GetString(cli.DPSCookieNameFlag),
+		CookieDomain:   v.GetString(cli.DPSCookieDomainFlag),
+		CookieSecret:   []byte(v.GetString(cli.DPSAuthCookieSecretKeyFlag)),
+		CookieExpires:  v.GetInt(cli.DPSCookieExpiresInMinutesFlag),
+	}
 }

--- a/pkg/iws/logger.go
+++ b/pkg/iws/logger.go
@@ -1,0 +1,14 @@
+package iws
+
+import (
+	"go.uber.org/zap"
+)
+
+// Logger is an interface that describes the logging requirements of this package.
+type Logger interface {
+	Debug(msg string, fields ...zap.Field)
+	Info(msg string, fields ...zap.Field)
+	Error(msg string, fields ...zap.Field)
+	Warn(msg string, fields ...zap.Field)
+	Fatal(msg string, fields ...zap.Field)
+}

--- a/pkg/iws/rbs_person_lookup.go
+++ b/pkg/iws/rbs_person_lookup.go
@@ -12,7 +12,10 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/spf13/viper"
 	"go.mozilla.org/pkcs7"
+
+	"github.com/transcom/mymove/pkg/cli"
 )
 
 // RBSPersonLookup handles requests to the Real-Time Broker Service
@@ -247,4 +250,13 @@ func recordFromResponse(data []byte) (Record, error) {
 		return rec, unmarshalErr
 	}
 	return rec, nil
+}
+
+// InitRBSPersonLookup is the RBS Person Lookup service
+func InitRBSPersonLookup(v *viper.Viper, logger Logger) (*RBSPersonLookup, error) {
+	return NewRBSPersonLookup(
+		v.GetString(cli.IWSRBSHostFlag),
+		v.GetString(cli.DoDCAPackageFlag),
+		v.GetString(cli.MoveMilDoDTLSCertFlag),
+		v.GetString(cli.MoveMilDoDTLSKeyFlag))
 }

--- a/pkg/notifications/notification_sender.go
+++ b/pkg/notifications/notification_sender.go
@@ -5,11 +5,15 @@ import (
 	"context"
 
 	"github.com/aws/aws-sdk-go/aws"
+	awssession "github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ses"
 	"github.com/aws/aws-sdk-go/service/ses/sesiface"
 	"github.com/go-gomail/gomail"
 	"github.com/pkg/errors"
+	"github.com/spf13/viper"
 	"go.uber.org/zap"
+
+	"github.com/transcom/mymove/pkg/cli"
 )
 
 type notification interface {
@@ -53,6 +57,26 @@ func (n NotificationSendingContext) SendNotification(ctx context.Context, notifi
 	}
 
 	return sendEmails(emails, n.svc, n.domain, n.logger)
+}
+
+// InitEmail initializes the email backend
+func InitEmail(v *viper.Viper, sess *awssession.Session, logger Logger) NotificationSender {
+	if v.GetString(cli.EmailBackendFlag) == "ses" {
+		// Setup Amazon SES (email) service
+		// TODO: This might be able to be combined with the AWS Session that we're using for S3 down
+		// below.
+		awsSESRegion := v.GetString(cli.AWSSESRegionFlag)
+		awsSESDomain := v.GetString(cli.AWSSESDomainFlag)
+		logger.Info("Using ses email backend",
+			zap.String("region", awsSESRegion),
+			zap.String("domain", awsSESDomain))
+		sesService := ses.New(sess)
+		return NewNotificationSender(sesService, awsSESDomain, logger)
+	}
+
+	domain := "milmovelocal"
+	logger.Info("Using local email backend", zap.String("domain", domain))
+	return NewStubNotificationSender(domain, logger)
 }
 
 func sendEmails(emails []emailContent, svc sesiface.SESAPI, domain string, logger Logger) error {

--- a/pkg/route/planner.go
+++ b/pkg/route/planner.go
@@ -1,12 +1,21 @@
 package route
 
 import (
+	"fmt"
+	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
-	"fmt"
+	"github.com/spf13/viper"
 
+	"github.com/transcom/mymove/pkg/cli"
 	"github.com/transcom/mymove/pkg/models"
+)
+
+const (
+	// hereRequestTimeout is how long to wait on HERE request before timing out (15 seconds).
+	hereRequestTimeout = time.Duration(15) * time.Second
 )
 
 // LatLong is used to hold latitude and longitude as floats
@@ -53,4 +62,16 @@ type Planner interface {
 	TransitDistance(source *models.Address, destination *models.Address) (int, error)
 	LatLongTransitDistance(source LatLong, destination LatLong) (int, error)
 	Zip5TransitDistance(source string, destination string) (int, error)
+}
+
+// InitRoutePlanner validates Route Planner command line flags
+func InitRoutePlanner(v *viper.Viper, logger Logger) Planner {
+	hereClient := &http.Client{Timeout: hereRequestTimeout}
+	return NewHEREPlanner(
+		logger,
+		hereClient,
+		v.GetString(cli.HEREMapsGeocodeEndpointFlag),
+		v.GetString(cli.HEREMapsRoutingEndpointFlag),
+		v.GetString(cli.HEREMapsAppIDFlag),
+		v.GetString(cli.HEREMapsAppCodeFlag))
 }

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -10,9 +10,15 @@ import (
 	"encoding/base64"
 	"io"
 	"net/http"
+	"path"
 
+	awssession "github.com/aws/aws-sdk-go/aws/session"
 	"github.com/pkg/errors"
 	"github.com/spf13/afero"
+	"github.com/spf13/viper"
+	"go.uber.org/zap"
+
+	"github.com/transcom/mymove/pkg/cli"
 )
 
 // StoreResult represents the result of a call to Store().
@@ -66,4 +72,45 @@ func DetectContentType(data io.ReadSeeker) (string, error) {
 		return "", errors.Wrap(err, "could not seek to beginning of file")
 	}
 	return contentType, nil
+}
+
+// InitStorage initializes the storage backend
+func InitStorage(v *viper.Viper, sess *awssession.Session, logger Logger) FileStorer {
+	storageBackend := v.GetString(cli.StorageBackendFlag)
+	localStorageRoot := v.GetString(cli.LocalStorageRootFlag)
+	localStorageWebRoot := v.GetString(cli.LocalStorageWebRootFlag)
+
+	var storer FileStorer
+	if storageBackend == "s3" {
+		awsS3Bucket := v.GetString(cli.AWSS3BucketNameFlag)
+		awsS3Region := v.GetString(cli.AWSS3RegionFlag)
+		awsS3KeyNamespace := v.GetString(cli.AWSS3KeyNamespaceFlag)
+		logger.Info("Using s3 storage backend",
+			zap.String("bucket", awsS3Bucket),
+			zap.String("region", awsS3Region),
+			zap.String("key", awsS3KeyNamespace))
+		if len(awsS3Bucket) == 0 {
+			logger.Fatal("must provide aws-s3-bucket-name parameter, exiting")
+		}
+		if len(awsS3Region) == 0 {
+			logger.Fatal("Must provide aws-s3-region parameter, exiting")
+		}
+		if len(awsS3KeyNamespace) == 0 {
+			logger.Fatal("Must provide aws_s3_key_namespace parameter, exiting")
+		}
+		storer = NewS3(awsS3Bucket, awsS3KeyNamespace, logger, sess)
+	} else if storageBackend == "memory" {
+		logger.Info("Using memory storage backend",
+			zap.String(cli.LocalStorageRootFlag, path.Join(localStorageRoot, localStorageWebRoot)),
+			zap.String(cli.LocalStorageWebRootFlag, localStorageWebRoot))
+		fsParams := NewMemoryParams(localStorageRoot, localStorageWebRoot, logger)
+		storer = NewMemory(fsParams)
+	} else {
+		logger.Info("Using local storage backend",
+			zap.String(cli.LocalStorageRootFlag, path.Join(localStorageRoot, localStorageWebRoot)),
+			zap.String(cli.LocalStorageWebRootFlag, localStorageWebRoot))
+		fsParams := NewFilesystemParams(localStorageRoot, localStorageWebRoot, logger)
+		storer = NewFilesystem(fsParams)
+	}
+	return storer
 }


### PR DESCRIPTION
## Description

Infra wants to use `github.com/transcom/mymove/pkg/cli` in the `ppp-infra` repo. However many of the `Init*` functions imported from `github.com/transcom/mymove/models` indirectly which meant a dependency on `github.com/transcom/mymove/pkg/gen/internalmessages` which is generated code from swagger. You can verify this by looking at the imports:

```
go list -f '{{ join .Imports "\n"}}'  github.com/transcom/mymove/pkg/auth/authentication
go: finding github.com/transcom/mymove/pkg/gen/internalmessages latest
go: finding github.com/transcom/mymove/pkg/gen latest
go: finding github.com/transcom/mymove/pkg latest
go: finding github.com/transcom/mymove latest
context
crypto/sha256
encoding/base64
encoding/hex
encoding/json
fmt
github.com/dgrijalva/jwt-go
github.com/gobuffalo/pop
github.com/gofrs/uuid
github.com/gorilla/csrf
github.com/honeycombio/beeline-go
github.com/honeycombio/beeline-go/trace
github.com/markbates/goth
github.com/markbates/goth/providers/openidConnect
github.com/pkg/errors
github.com/transcom/mymove/pkg/auth
github.com/transcom/mymove/pkg/models
go.uber.org/zap
html/template
io/ioutil
math/rand
net/http
net/url
reflect
strings
time
```

So in this PR the `Init*` functions are moved to their respective packages.

## Reviewer Notes

This doesn't move `InitHoneycomb` and `InitDatabase` since these don't have analog packages inside milmove. I could move them out but at least the `InitDatabase` would affect several other binaries.

## Setup

This ought to be a no-op so let's verify the tests pass.

## Code Review Verification Steps

* [x] Request review from a member of a different team.