### PR TITLE
Fix environment variable quoting which disrupts the way the array is formed in the script

### DIFF
--- a/scripts/download-secure-migration
+++ b/scripts/download-secure-migration
@@ -8,7 +8,8 @@ set -eu -o pipefail
 
 readonly aws_command="aws"
 # Environments to download production migrations from
-readonly environments=("${ENVIRONMENTS:-experimental staging prod}")
+# shellcheck disable=SC2206
+readonly environments=(${ENVIRONMENTS:-experimental staging prod})
 readonly aws_bucket_prefix="transcom-ppp-app-"
 readonly aws_bucket_suffix="-us-west-2"
 readonly aws_path_prefix="secure-migrations"

--- a/scripts/upload-secure-migration
+++ b/scripts/upload-secure-migration
@@ -8,7 +8,8 @@ set -eu -o pipefail
 
 readonly aws_command="aws"
 # Environments to upload production migrations to
-readonly environments=("${ENVIRONMENTS:-experimental staging prod}")
+# shellcheck disable=SC2206
+readonly environments=(${ENVIRONMENTS:-experimental staging prod})
 readonly aws_bucket_prefix="transcom-ppp-app-"
 readonly aws_bucket_suffix="-us-west-2"
 readonly aws_path_prefix="secure-migrations"


### PR DESCRIPTION
## Description

`shellcheck` asked that the variable be quoted. However, doing so means that it doesn't turn into an array, which is what's needed to run the script.