### PR TITLE
Remove links to DDS GDrive from .envrc file 

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -104,7 +104,7 @@ export LOGIN_GOV_TSP_CLIENT_ID="urn:gov:gsa:openidconnect.profiles:sp:sso:dod:ts
 export LOGIN_GOV_ADMIN_CLIENT_ID="urn:gov:gsa:openidconnect.profiles:sp:sso:dod:adminmovemillocal"
 export LOGIN_GOV_HOSTNAME="idp.int.identitysandbox.gov"
 
-require LOGIN_GOV_SECRET_KEY "See 'chamber read app-devlocal login_gov_secret_key' or https://docs.google.com/document/d/148RzqgaQbhOxXd4z_xuj5Jz8JNETThrn7RVFmMqXFvk"
+require LOGIN_GOV_SECRET_KEY "See 'chamber read app-devlocal login_gov_secret_key'"
 
 # JSON Web Token (JWT) config
 CLIENT_AUTH_SECRET_KEY=$(cat config/tls/devlocal-client_auth_secret.key)
@@ -124,8 +124,8 @@ export DOD_CA_PACKAGE="${MYMOVE_DIR}/config/tls/Certificates_PKCS7_v5.4_DoD.der.
 # MyMove client certificate
 # All of our DoD-signed certs are currently signed by DOD SW CA-54
 MOVE_MIL_DOD_CA_CERT=$(cat ${MYMOVE_DIR}/config/tls/dod-sw-ca-54.pem)
-require MOVE_MIL_DOD_TLS_CERT "See 'chamber read app-devlocal move_mil_dod_tls_cert' or https://docs.google.com/document/d/1nvLXLQYz5ax3Ds4n2Y5OeANJhs0AbHtjkrKzI0gN3_o"
-require MOVE_MIL_DOD_TLS_KEY "See 'chamber read app-devlocal move_mil_dod_tls_key' or https://docs.google.com/document/d/1nvLXLQYz5ax3Ds4n2Y5OeANJhs0AbHtjkrKzI0gN3_o"
+require MOVE_MIL_DOD_TLS_CERT "See 'chamber read app-devlocal move_mil_dod_tls_cert'"
+require MOVE_MIL_DOD_TLS_KEY "See 'chamber read app-devlocal move_mil_dod_tls_key'"
 export MOVE_MIL_DOD_CA_CERT
 
 # Prevent user sessions from timing out
@@ -160,21 +160,21 @@ export AWS_SES_REGION="us-west-2"
 # HERE MAPS API
 export HERE_MAPS_GEOCODE_ENDPOINT="https://geocoder.cit.api.here.com/6.2/geocode.json"
 export HERE_MAPS_ROUTING_ENDPOINT="https://route.cit.api.here.com/routing/7.2/calculateroute.json"
-require HERE_MAPS_APP_ID "See 'chamber read app-devlocal here_maps_app_id' or https://docs.google.com/document/d/16ZomLuR6BPEIK4enfMcqu31oiJYZWNDe9Znyf9e88dg"
-require HERE_MAPS_APP_CODE "See 'chamber read app-devlocal here_maps_app_code' or https://docs.google.com/document/d/16ZomLuR6BPEIK4enfMcqu31oiJYZWNDe9Znyf9e88dg"
+require HERE_MAPS_APP_ID "See 'chamber read app-devlocal here_maps_app_id'"
+require HERE_MAPS_APP_CODE "See 'chamber read app-devlocal here_maps_app_code'"
 
 # Transcom ppp-infra repo path
 require PPP_INFRA_PATH "Set to your local checkout of https://github.com/transcom/ppp-infra (e.g., ~/your-personal-repo-directory/ppp-infra)."
 
 # GEX integration config
 export GEX_BASIC_AUTH_USERNAME="mymovet"
-require GEX_BASIC_AUTH_PASSWORD "See 'chamber read app-devlocal gex_basic_auth_password' or https://docs.google.com/document/d/1nvLXLQYz5ax3Ds4n2Y5OeANJhs0AbHtjkrKzI0gN3_o"
+require GEX_BASIC_AUTH_PASSWORD "See 'chamber read app-devlocal gex_basic_auth_password'"
 export GEX_URL=""
 # To actually send the GEX request, replace url in envrc.local with the line below
 # export GEX_URL=https://gexweba.daas.dla.mil/msg_data/submit/
 
-require DPS_AUTH_SECRET_KEY "See 'chamber read app-devlocal dps_auth_secret_key' or https://docs.google.com/document/d/1HAD9tu9WahzVEam5FFWrgywdMm4aTfVW-Mp3rL7idAo"
-require DPS_AUTH_COOKIE_SECRET_KEY "See 'chamber read app-devlocal dps_auth_cookie_secret_key' or https://docs.google.com/document/d/1HAD9tu9WahzVEam5FFWrgywdMm4aTfVW-Mp3rL7idAo"
+require DPS_AUTH_SECRET_KEY "See 'chamber read app-devlocal dps_auth_secret_key'"
+require DPS_AUTH_COOKIE_SECRET_KEY "See 'chamber read app-devlocal dps_auth_cookie_secret_key'"
 export DPS_COOKIE_EXPIRES_IN_MINUTES="240"
 export HTTP_SDDC_PROTOCOL="http"
 export HTTP_SDDC_PORT="8080"
@@ -185,13 +185,13 @@ export DPS_COOKIE_NAME="DPSIVV"
 export IWS_RBS_HOST="pkict.dmdc.osd.mil"
 
 # Unsecured CSRF Auth Key, for local dev only
-require CSRF_AUTH_KEY "See 'chamber read app-devlocal csrf_auth_key' or https://docs.google.com/document/d/1DuWXZLFaW7FXvqh-PStqjZI40niEavXWS5PPtWPlK3w"
+require CSRF_AUTH_KEY "See 'chamber read app-devlocal csrf_auth_key'"
 
 # Always show Swagger UI in development
 export SERVE_SWAGGER_UI=true
 
 # EIA API Key (for fuel price data)
-require EIA_KEY "See 'chamber read app-devlocal eia_key' or https://docs.google.com/document/d/1K1-xlYcZaS518PQiaB39gSvqz2tTo0W8eM0wImB7TcI"
+require EIA_KEY "See 'chamber read app-devlocal eia_key'"
 export EIA_URL="https://api.eia.gov/series/"
 
 # Enable No TLS Listener


### PR DESCRIPTION
## Description

Truss migrated all the docs from DDS GDrive to a Truss owned shared GDrive.  Also, since we started using `chamber` the docs are no longer the source of truth for these secrets. In addition, we shouldn't share secrets via google docs.

All of these documents are now `View Only` on the DDS GDrive and they have been deleted from the Truss shared GDrive.

## Setup

```sh
direnv allow
```

## Code Review Verification Steps

* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/166477704) for this change