### PR TITLE
Init aws-vault flags

### DIFF
--- a/cmd/milmove/migrate.go
+++ b/cmd/milmove/migrate.go
@@ -18,28 +18,36 @@ import (
 
 // initMigrateFlags - Order matters!
 func initMigrateFlags(flag *pflag.FlagSet) {
-	// Migration Config
-	cli.InitMigrationFlags(flag)
 
 	// DB Config
 	cli.InitDatabaseFlags(flag)
 
+	// Migration Config
+	cli.InitMigrationFlags(flag)
+
+	// aws-vault Config
+	cli.InitVaultFlags(flag)
+
 	// Verbose
 	cli.InitVerboseFlags(flag)
 
-	// Don't sort flags
-	flag.SortFlags = false
+	// Sort flags
+	flag.SortFlags = true
 }
 
 func checkMigrateConfig(v *viper.Viper, logger logger) error {
 
 	logger.Info("checking migration config")
 
+	if err := cli.CheckDatabase(v, logger); err != nil {
+		return err
+	}
+
 	if err := cli.CheckMigration(v); err != nil {
 		return err
 	}
 
-	if err := cli.CheckDatabase(v, logger); err != nil {
+	if err := cli.CheckVault(v); err != nil {
 		return err
 	}
 

--- a/cmd/milmove/serve.go
+++ b/cmd/milmove/serve.go
@@ -113,6 +113,9 @@ func initServeFlags(flag *pflag.FlagSet) {
 	// Middleware
 	cli.InitMiddlewareFlags(flag)
 
+	// aws-vault
+	cli.InitVaultFlags(flag)
+
 	// Verbose
 	cli.InitVerboseFlags(flag)
 
@@ -200,6 +203,10 @@ func checkServeConfig(v *viper.Viper, logger logger) error {
 		return err
 	}
 
+	if err := cli.CheckVault(v); err != nil {
+		return err
+	}
+
 	if err := cli.CheckVerbose(v); err != nil {
 		return err
 	}
@@ -256,7 +263,7 @@ func indexHandler(buildDir string, logger logger) http.HandlerFunc {
 
 func serveFunction(cmd *cobra.Command, args []string) error {
 
-	err := cmd.ParseFlags(os.Args[1:])
+	err := cmd.ParseFlags(args)
 	if err != nil {
 		return errors.Wrap(err, "Could not parse flags")
 	}

--- a/pkg/cli/vault.go
+++ b/pkg/cli/vault.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/99designs/aws-vault/prompt"
 	"github.com/99designs/aws-vault/vault"
@@ -22,6 +23,10 @@ const (
 	VaultAWSVaultFlag string = "aws-vault"
 	// VaultAWSSessionTokenFlag is the AWS session token flag
 	VaultAWSSessionTokenFlag string = "aws-session-token"
+	// VaultAWSSessionDurationFlag is the AWS session duration flag
+	VaultAWSSessionDurationFlag string = "aws-session-duration"
+	// VaultAWSAssumeRoleDurationFlag is the AWS assume role duration flag
+	VaultAWSAssumeRoleDurationFlag string = "aws-assume-role-duration"
 
 	// VaultAWSKeychainNameDefault is the aws-vault default keychain name
 	VaultAWSKeychainNameDefault string = "login"
@@ -59,6 +64,8 @@ func InitVaultFlags(flag *pflag.FlagSet) {
 	// Flags default to empty string to facilitate deploys from CircleCI
 	flag.String(VaultAWSKeychainNameFlag, "", "The aws-vault keychain name")
 	flag.String(VaultAWSProfileFlag, "", "The aws-vault profile")
+	flag.Duration(VaultAWSSessionDurationFlag, time.Hour*4, "the aws-vault sesion duration")
+	flag.Duration(VaultAWSAssumeRoleDurationFlag, time.Minute*15, "the aws-vault assume role duration")
 }
 
 // CheckVault validates Vault command line flags
@@ -97,7 +104,7 @@ func CheckVault(v *viper.Viper) error {
 }
 
 // GetAWSCredentialsFromKeyring uses aws-vault to return AWS credential from a system keyring.
-func GetAWSCredentialsFromKeyring(keychainName string, awsProfile string) (*credentials.Credentials, error) {
+func GetAWSCredentialsFromKeyring(keychainName string, awsProfile string, sessionDuration time.Duration, assumeRoleDuration time.Duration) (*credentials.Credentials, error) {
 
 	// Open the keyring which holds the credentials
 	ring, err := keyring.Open(keyring.Config{
@@ -116,8 +123,10 @@ func GetAWSCredentialsFromKeyring(keychainName string, awsProfile string) (*cred
 		return nil, errors.Wrap(err, "Unable to load AWS config from environment")
 	}
 	vOptions := vault.VaultOptions{
-		Config:    vConfig,
-		MfaPrompt: prompt.Method("terminal"),
+		Config:             vConfig,
+		MfaPrompt:          prompt.Method("terminal"),
+		SessionDuration:    sessionDuration,
+		AssumeRoleDuration: assumeRoleDuration,
 	}
 	vOptions = vOptions.ApplyDefaults()
 	err = vOptions.Validate()
@@ -151,7 +160,12 @@ func GetAWSConfig(v *viper.Viper, verbose bool) (*aws.Config, error) {
 		keychainName := v.GetString(VaultAWSKeychainNameFlag)
 		awsProfile := v.GetString(VaultAWSProfileFlag)
 		if len(keychainName) > 0 && len(awsProfile) > 0 {
-			creds, getAWSCredsErr := GetAWSCredentialsFromKeyring(keychainName, awsProfile)
+			creds, getAWSCredsErr := GetAWSCredentialsFromKeyring(
+				keychainName,
+				awsProfile,
+				v.GetDuration(VaultAWSSessionDurationFlag),
+				v.GetDuration(VaultAWSAssumeRoleDurationFlag),
+			)
 			if getAWSCredsErr != nil {
 				return nil, errors.Wrap(getAWSCredsErr,
 					fmt.Sprintf("Unable to get AWS credentials from the keychain %s and profile %s", keychainName, awsProfile))


### PR DESCRIPTION
## Description

This PR initializes the aws-vault flags for `milmove serve` and `milmove migrate`.  It also adds the `aws-session-duration` and `aws-assume-role-duration` flags, which can be used to customize the aws-vault session duration during local testing.  By default, an `aws-vault` "session" would "logout" after 15 minutes.

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make clean
make server_build
```

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/tree/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/tree/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/tree/master/docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
  * [ ] Secure migrations have been tested using `scripts/run-prod-migrations`
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @ntwyman
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

None

## Screenshots

None