### PR TITLE
Disable go module strict mode 

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -63,8 +63,10 @@ fi
 # Project Configuration #
 #########################
 
-# Enable Go modules
-export GO111MODULE=on
+# Enable Go module as 'auto' because we want people working outside the $GOPATH
+# and we also want dependencies in pre-commit to use $GOPATH instead of managing them
+# locally in the ~/.cache/pre-commit/repo*/ directories.
+export GO111MODULE=auto
 
 # Capture the root directory of the project. This works even if someone `cd`s
 # directly into a subdirectory.

--- a/scripts/check-gopath
+++ b/scripts/check-gopath
@@ -1,6 +1,8 @@
 #! /usr/bin/env bash
 
-gpath=$GOPATH
+set -eu -o pipefail
+
+gpath=${GOPATH:-}
 if [ -z "$gpath" ]; then
   gpath=$HOME/go
 fi
@@ -8,8 +10,18 @@ fi
 # Strip a trailing slash off of gpath if it exists (makes binpath below more robust)
 gpath=${gpath%/}
 
+goodpath=$gpath/src/github.com/transcom/mymove
+
+# Ensure project not in GOPATH
+if [ "$PWD" -ef "$goodpath" ]; then
+  echo "In order to build tools the project must NOT be checked out into your gopath"
+  echo "read more at https://github.com/golang/go/wiki/Modules"
+  echo "Found in: $goodpath"
+  exit 1
+fi
+
 # shellcheck disable=SC2154
-if [[ "$gpath" == *"$home" ]]; then
+if [[ "$gpath" == *"$HOME" ]]; then
   if [[ ! ":$PATH:" == *":$gpath/bin:"* ]] && [[ ! ":$PATH:" == *":~${gpath#$HOME}/bin:"* ]]; then
     echo "In order for go dependencies to be runnable, \$GOPATH/bin must be in your \$PATH"
     echo "Please add $gpath/bin to your \$PATH in your .bash_profile"


### PR DESCRIPTION
## Description

Disable go module strict mode while enforcing that the project is built and run outside $GOPATH. This addresses issues with pre-commit golang interactions.  This PR enforces two things:

- `GO111MODULE=auto` is explicit about being automatic (the default)
- `./scripts/check-gopath` enforces that the project is being run outside of `$GOPATH`.

Read about different scenarios about this below.

### Scenario 1: No problems with hook installation

- Run `pre-commit install-hooks` to install hooks. For the `golangci-lint` hook the go dependencies are installed in `$GOPATH`.
- Run `direnv allow` to set `GO111MODULE=on`

### Scenario 2: Problems installing hooks

- Run `direnv allow` to set `GO111MODULE=on`
- Run `pre-commit install-hooks` to install hooks. For the `golangci-lint` hook the go dependencies are installed in `~/.cache/pre-commit/repo<hash>/golangenv-default/pkg`.

The failure in the second case is: 

```
Permission denied: '/Users/username/.cache/pre-commit/repo0i1br295/golangenv-default/pkg/mod/gopkg.in/yaml.v2@v2.2.1/decode_test.go'
```

The `/gopkg.in/yaml.v2@v2.2.1` dependency was installed at `/Users/username/.cache/pre-commit/repo0i1br295/golangenv-default/pkg/mod/` instead of in `$GOPATH`.  It also gets permissions `777` which I haven't figured out but which makes it impossible for the `pre-commit` library to manage.  Personal checks show that many directories or files get permissions which make it impossible for `pre-commit` to manage or for a person to delete or manage without using `sudo`.

## Setup

First move your repo outside of `$GOPATH`.

```sh
rm -rf ~/.cache/pre-commit # Can use sudo if you need to
pre-commit install-hooks
pre-commit run -a
```

## Code Review Verification Steps

* [x] Request review from a member of a different team.

## References

* [Go modules](https://github.com/golang/go/wiki/Modules) is the resource for everything you want to know about `go mod`.