### PR TITLE
Add endpoint for create and fetch weight ticket document

### DIFF
--- a/migrations/20190604171035_create_weight_ticket_documents.up.sql
+++ b/migrations/20190604171035_create_weight_ticket_documents.up.sql
@@ -1,0 +1,12 @@
+CREATE TABLE weight_ticket_set_documents
+(
+	id                 uuid PRIMARY KEY,
+	vehicle_options    text,
+	vehicle_nickname   text,
+	move_document_id   uuid REFERENCES move_documents (id),
+	empty_weight       int,
+	full_weight        int,
+	weight_ticket_date date,
+	created_at         timestamp NOT NULL,
+	updated_at         timestamp NOT NULL
+);

--- a/migrations/20190604171035_create_weight_ticket_documents.up.sql
+++ b/migrations/20190604171035_create_weight_ticket_documents.up.sql
@@ -1,12 +1,14 @@
 CREATE TABLE weight_ticket_set_documents
 (
-	id                 uuid PRIMARY KEY,
-	vehicle_options    text,
-	vehicle_nickname   text,
-	move_document_id   uuid REFERENCES move_documents (id),
-	empty_weight       int,
-	full_weight        int,
-	weight_ticket_date date,
-	created_at         timestamp NOT NULL,
-	updated_at         timestamp NOT NULL
+	id                          uuid PRIMARY KEY,
+	vehicle_options             text,
+	vehicle_nickname            text,
+	move_document_id            uuid REFERENCES move_documents (id),
+	empty_weight                int,
+	empty_weight_ticket_missing bool,
+	full_weight                 int,
+	full_weight_ticket_missing  bool,
+	weight_ticket_date          date,
+	created_at                  timestamp NOT NULL,
+	updated_at                  timestamp NOT NULL
 );

--- a/pkg/handlers/internalapi/move_documents.go
+++ b/pkg/handlers/internalapi/move_documents.go
@@ -67,9 +67,17 @@ func payloadForMoveDocumentExtractor(storer storage.FileStorer, docExtractor mod
 	if docExtractor.EmptyWeight != nil {
 		emptyWeight = handlers.FmtInt64(int64(*docExtractor.EmptyWeight))
 	}
+	var emptyWeightTicketMissing *bool
+	if docExtractor.EmptyWeight != nil {
+		emptyWeightTicketMissing = docExtractor.EmptyWeightTicketMissing
+	}
 	var fullWeight *int64
 	if docExtractor.FullWeight != nil {
 		fullWeight = handlers.FmtInt64(int64(*docExtractor.FullWeight))
+	}
+	var fullWeightTicketMissing *bool
+	if docExtractor.EmptyWeight != nil {
+		fullWeightTicketMissing = docExtractor.FullWeightTicketMissing
 	}
 	var vehicleNickname string
 	if docExtractor.VehicleNickname != nil {
@@ -99,7 +107,9 @@ func payloadForMoveDocumentExtractor(storer storage.FileStorer, docExtractor mod
 		VehicleOptions:           vehicleOptions,
 		VehicleNickname:          vehicleNickname,
 		EmptyWeight:              emptyWeight,
+		EmptyWeightTicketMissing: emptyWeightTicketMissing,
 		FullWeight:               fullWeight,
+		FullWeightTicketMissing:  fullWeightTicketMissing,
 		WeightTicketDate:         weightTicketDate,
 	}
 

--- a/pkg/handlers/internalapi/move_documents.go
+++ b/pkg/handlers/internalapi/move_documents.go
@@ -1,6 +1,8 @@
 package internalapi
 
 import (
+	"github.com/go-openapi/strfmt"
+
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/gofrs/uuid"
 
@@ -61,6 +63,26 @@ func payloadForMoveDocumentExtractor(storer storage.FileStorer, docExtractor mod
 	if docExtractor.RequestedAmountCents != nil {
 		requestedAmt = *docExtractor.RequestedAmountCents
 	}
+	var emptyWeight *int64
+	if docExtractor.EmptyWeight != nil {
+		emptyWeight = handlers.FmtInt64(int64(*docExtractor.EmptyWeight))
+	}
+	var fullWeight *int64
+	if docExtractor.FullWeight != nil {
+		fullWeight = handlers.FmtInt64(int64(*docExtractor.FullWeight))
+	}
+	var vehicleNickname string
+	if docExtractor.VehicleNickname != nil {
+		vehicleNickname = *docExtractor.VehicleNickname
+	}
+	var vehicleOptions string
+	if docExtractor.VehicleOptions != nil {
+		vehicleOptions = *docExtractor.VehicleOptions
+	}
+	var weightTicketDate *strfmt.Date
+	if docExtractor.WeightTicketDate != nil {
+		weightTicketDate = handlers.FmtDate(*docExtractor.WeightTicketDate)
+	}
 
 	payload := internalmessages.MoveDocumentPayload{
 		ID:                       handlers.FmtUUID(docExtractor.ID),
@@ -74,6 +96,11 @@ func payloadForMoveDocumentExtractor(storer storage.FileStorer, docExtractor mod
 		MovingExpenseType:        expenseType,
 		RequestedAmountCents:     int64(requestedAmt),
 		PaymentMethod:            paymentMethod,
+		VehicleOptions:           vehicleOptions,
+		VehicleNickname:          vehicleNickname,
+		EmptyWeight:              emptyWeight,
+		FullWeight:               fullWeight,
+		WeightTicketDate:         weightTicketDate,
 	}
 
 	return &payload, nil

--- a/pkg/handlers/internalapi/move_documents_test.go
+++ b/pkg/handlers/internalapi/move_documents_test.go
@@ -3,6 +3,8 @@ package internalapi
 import (
 	"net/http/httptest"
 
+	"github.com/transcom/mymove/pkg/unit"
+
 	"github.com/go-openapi/strfmt"
 	"github.com/gofrs/uuid"
 
@@ -132,7 +134,7 @@ func (suite *HandlerSuite) TestIndexWeightTicketSetDocumentsHandler() {
 	move := ppm.Move
 	sm := move.Orders.ServiceMember
 
-	weightTicketSetDocument := testdatagen.MakeWeightTicketSetDocument(suite.DB(),
+	moveDoc := testdatagen.MakeMoveDocument(suite.DB(),
 		testdatagen.Assertions{
 			MoveDocument: models.MoveDocument{
 				MoveID:                   move.ID,
@@ -141,6 +143,20 @@ func (suite *HandlerSuite) TestIndexWeightTicketSetDocumentsHandler() {
 				MoveDocumentType:         models.MoveDocumentTypeWEIGHTTICKETSET,
 			},
 		})
+	emptyWeight := unit.Pound(1000)
+	fullWeight := unit.Pound(2500)
+	weightTicketSetDocument := models.WeightTicketSetDocument{
+		MoveDocumentID:   moveDoc.ID,
+		MoveDocument:     moveDoc,
+		EmptyWeight:      &emptyWeight,
+		FullWeight:       &fullWeight,
+		VehicleNickname:  "My Car",
+		VehicleOptions:   "CAR",
+		WeightTicketDate: testdatagen.NextValidMoveDate,
+	}
+	verrs, err := suite.DB().ValidateAndCreate(&weightTicketSetDocument)
+	suite.Nil(err)
+	suite.False(verrs.HasAny())
 
 	request := httptest.NewRequest("POST", "/fake/path", nil)
 	request = suite.AuthenticateRequest(request, sm)

--- a/pkg/handlers/internalapi/move_documents_test.go
+++ b/pkg/handlers/internalapi/move_documents_test.go
@@ -143,16 +143,16 @@ func (suite *HandlerSuite) TestIndexWeightTicketSetDocumentsHandler() {
 				MoveDocumentType:         models.MoveDocumentTypeWEIGHTTICKETSET,
 			},
 		})
-	emptyWeight := unit.Pound(1000)
-	fullWeight := unit.Pound(2500)
 	weightTicketSetDocument := models.WeightTicketSetDocument{
-		MoveDocumentID:   moveDoc.ID,
-		MoveDocument:     moveDoc,
-		EmptyWeight:      &emptyWeight,
-		FullWeight:       &fullWeight,
-		VehicleNickname:  "My Car",
-		VehicleOptions:   "CAR",
-		WeightTicketDate: testdatagen.NextValidMoveDate,
+		MoveDocumentID:           moveDoc.ID,
+		MoveDocument:             moveDoc,
+		EmptyWeight:              unit.Pound(1000),
+		EmptyWeightTicketMissing: true,
+		FullWeight:               unit.Pound(2500),
+		FullWeightTicketMissing:  false,
+		VehicleNickname:          "My Car",
+		VehicleOptions:           "CAR",
+		WeightTicketDate:         testdatagen.NextValidMoveDate,
 	}
 	verrs, err := suite.DB().ValidateAndCreate(&weightTicketSetDocument)
 	suite.Nil(err)
@@ -179,8 +179,10 @@ func (suite *HandlerSuite) TestIndexWeightTicketSetDocumentsHandler() {
 	for _, moveDoc := range indexPayload {
 		suite.Require().Equal(*moveDoc.ID, strfmt.UUID(weightTicketSetDocument.MoveDocument.ID.String()), "expected move ids to match")
 		suite.Require().Equal(*moveDoc.PersonallyProcuredMoveID, strfmt.UUID(ppm.ID.String()), "expected ppm ids to match")
-		suite.Require().Equal(*moveDoc.EmptyWeight, int64(*weightTicketSetDocument.EmptyWeight), "expected empty weight to match")
-		suite.Require().Equal(*moveDoc.FullWeight, int64(*weightTicketSetDocument.FullWeight), "expected empty weight to match")
+		suite.Require().Equal(*moveDoc.EmptyWeight, int64(weightTicketSetDocument.EmptyWeight), "expected empty weight to match")
+		suite.Require().Equal(*moveDoc.EmptyWeightTicketMissing, weightTicketSetDocument.EmptyWeightTicketMissing, "expected empty weight ticket missing to match")
+		suite.Require().Equal(*moveDoc.FullWeight, int64(weightTicketSetDocument.FullWeight), "expected empty weight to match")
+		suite.Require().Equal(*moveDoc.FullWeightTicketMissing, weightTicketSetDocument.FullWeightTicketMissing, "expected full weight ticket missing to match")
 		suite.Require().Equal(moveDoc.WeightTicketDate.String(), strfmt.Date(weightTicketSetDocument.WeightTicketDate).String(), "expected weight ticket date to match")
 		suite.Require().Equal(moveDoc.VehicleOptions, weightTicketSetDocument.VehicleOptions, "expected vehicle options to match")
 		suite.Require().Equal(moveDoc.VehicleNickname, weightTicketSetDocument.VehicleNickname, "expected vehicle nickname to match")

--- a/pkg/handlers/internalapi/move_documents_test.go
+++ b/pkg/handlers/internalapi/move_documents_test.go
@@ -163,8 +163,8 @@ func (suite *HandlerSuite) TestIndexWeightTicketSetDocumentsHandler() {
 	for _, moveDoc := range indexPayload {
 		suite.Require().Equal(*moveDoc.ID, strfmt.UUID(weightTicketSetDocument.MoveDocument.ID.String()), "expected move ids to match")
 		suite.Require().Equal(*moveDoc.PersonallyProcuredMoveID, strfmt.UUID(ppm.ID.String()), "expected ppm ids to match")
-		suite.Require().Equal(*moveDoc.EmptyWeight, int64(weightTicketSetDocument.EmptyWeight), "expected empty weight to match")
-		suite.Require().Equal(*moveDoc.FullWeight, int64(weightTicketSetDocument.FullWeight), "expected empty weight to match")
+		suite.Require().Equal(*moveDoc.EmptyWeight, int64(*weightTicketSetDocument.EmptyWeight), "expected empty weight to match")
+		suite.Require().Equal(*moveDoc.FullWeight, int64(*weightTicketSetDocument.FullWeight), "expected empty weight to match")
 		suite.Require().Equal(moveDoc.WeightTicketDate.String(), strfmt.Date(weightTicketSetDocument.WeightTicketDate).String(), "expected weight ticket date to match")
 		suite.Require().Equal(moveDoc.VehicleOptions, weightTicketSetDocument.VehicleOptions, "expected vehicle options to match")
 		suite.Require().Equal(moveDoc.VehicleNickname, weightTicketSetDocument.VehicleNickname, "expected vehicle nickname to match")

--- a/pkg/handlers/internalapi/weight_ticket_set_documents.go
+++ b/pkg/handlers/internalapi/weight_ticket_set_documents.go
@@ -93,8 +93,8 @@ func (h CreateWeightTicketSetDocumentHandler) Handle(params movedocop.CreateWeig
 		&ppmID,
 		*payload.VehicleNickname,
 		*payload.VehicleOptions,
-		int(*payload.FullWeight),
-		int(*payload.EmptyWeight),
+		payload.FullWeight,
+		payload.EmptyWeight,
 		(*time.Time)(payload.WeightTicketDate),
 		*move.SelectedMoveType,
 	)

--- a/pkg/handlers/internalapi/weight_ticket_set_documents.go
+++ b/pkg/handlers/internalapi/weight_ticket_set_documents.go
@@ -24,7 +24,6 @@ func payloadForWeightTicketSetMoveDocumentModel(storer storage.FileStorer, weigh
 		return nil, err
 	}
 
-	//
 	genericMoveDocumentPayload := internalmessages.MoveDocumentPayload{
 		ID:               handlers.FmtUUID(weightTicketSet.ID),
 		MoveID:           handlers.FmtUUID(weightTicketSet.MoveDocument.MoveID),
@@ -38,12 +37,12 @@ func payloadForWeightTicketSetMoveDocumentModel(storer storage.FileStorer, weigh
 	return &genericMoveDocumentPayload, nil
 }
 
-// CreateMovingExpenseDocumentHandler creates a MovingExpenseDocument
+// CreateWeightTicketSetDocumentHandler creates a WeightTicketSetDocument
 type CreateWeightTicketSetDocumentHandler struct {
 	handlers.HandlerContext
 }
 
-// Handle is the handler
+// Handle is the handler for CreateWeightTicketSetDocumentHandler
 func (h CreateWeightTicketSetDocumentHandler) Handle(params movedocop.CreateWeightTicketDocumentParams) middleware.Responder {
 	ctx, span := beeline.StartSpan(params.HTTPRequest.Context(), reflect.TypeOf(h).Name())
 	defer span.Send()
@@ -95,7 +94,7 @@ func (h CreateWeightTicketSetDocumentHandler) Handle(params movedocop.CreateWeig
 		*payload.VehicleOptions,
 		payload.FullWeight,
 		payload.EmptyWeight,
-		(*time.Time)(payload.WeightTicketDate),
+		(time.Time)(*payload.WeightTicketDate),
 		*move.SelectedMoveType,
 	)
 

--- a/pkg/handlers/internalapi/weight_ticket_set_documents.go
+++ b/pkg/handlers/internalapi/weight_ticket_set_documents.go
@@ -83,7 +83,7 @@ func (h CreateWeightTicketSetDocumentHandler) Handle(params movedocop.CreateWeig
 		return handlers.ResponseForError(h.Logger(), fetchPPMErr)
 	}
 	if ppm.MoveID != moveID {
-		return movedocop.NewCreateMovingExpenseDocumentBadRequest()
+		return movedocop.NewCreateWeightTicketDocumentBadRequest()
 	}
 
 	newWeightTicketSetDocument, verrs, err := move.CreateWeightTicketSetDocument(
@@ -106,5 +106,5 @@ func (h CreateWeightTicketSetDocumentHandler) Handle(params movedocop.CreateWeig
 	if err != nil {
 		return handlers.ResponseForError(h.Logger(), err)
 	}
-	return movedocop.NewCreateMovingExpenseDocumentOK().WithPayload(newPayload)
+	return movedocop.NewCreateWeightTicketDocumentOK().WithPayload(newPayload)
 }

--- a/pkg/handlers/internalapi/weight_ticket_set_documents.go
+++ b/pkg/handlers/internalapi/weight_ticket_set_documents.go
@@ -4,6 +4,8 @@ import (
 	"reflect"
 	"time"
 
+	"github.com/transcom/mymove/pkg/unit"
+
 	"github.com/transcom/mymove/pkg/gen/internalmessages"
 	"github.com/transcom/mymove/pkg/storage"
 
@@ -86,15 +88,20 @@ func (h CreateWeightTicketSetDocumentHandler) Handle(params movedocop.CreateWeig
 		return movedocop.NewCreateWeightTicketDocumentBadRequest()
 	}
 
+	wtsd := models.WeightTicketSetDocument{
+		EmptyWeight:              unit.Pound(*payload.EmptyWeight),
+		EmptyWeightTicketMissing: *payload.EmptyWeightTicketMissing,
+		FullWeight:               unit.Pound(*payload.FullWeight),
+		FullWeightTicketMissing:  *payload.FullWeightTicketMissing,
+		VehicleNickname:          *payload.VehicleNickname,
+		VehicleOptions:           *payload.VehicleOptions,
+		WeightTicketDate:         (time.Time)(*payload.WeightTicketDate),
+	}
 	newWeightTicketSetDocument, verrs, err := move.CreateWeightTicketSetDocument(
 		h.DB(),
 		uploads,
 		&ppmID,
-		*payload.VehicleNickname,
-		*payload.VehicleOptions,
-		payload.FullWeight,
-		payload.EmptyWeight,
-		(time.Time)(*payload.WeightTicketDate),
+		wtsd,
 		*move.SelectedMoveType,
 	)
 

--- a/pkg/handlers/internalapi/weight_ticket_set_documents.go
+++ b/pkg/handlers/internalapi/weight_ticket_set_documents.go
@@ -1,0 +1,111 @@
+package internalapi
+
+import (
+	"reflect"
+	"time"
+
+	"github.com/transcom/mymove/pkg/gen/internalmessages"
+	"github.com/transcom/mymove/pkg/storage"
+
+	"github.com/go-openapi/runtime/middleware"
+	"github.com/gofrs/uuid"
+	"github.com/honeycombio/beeline-go"
+
+	"github.com/transcom/mymove/pkg/auth"
+	movedocop "github.com/transcom/mymove/pkg/gen/internalapi/internaloperations/move_docs"
+	"github.com/transcom/mymove/pkg/handlers"
+	"github.com/transcom/mymove/pkg/models"
+)
+
+func payloadForWeightTicketSetMoveDocumentModel(storer storage.FileStorer, weightTicketSet models.WeightTicketSetDocument) (*internalmessages.MoveDocumentPayload, error) {
+
+	documentPayload, err := payloadForDocumentModel(storer, weightTicketSet.MoveDocument.Document)
+	if err != nil {
+		return nil, err
+	}
+
+	//
+	genericMoveDocumentPayload := internalmessages.MoveDocumentPayload{
+		ID:               handlers.FmtUUID(weightTicketSet.ID),
+		MoveID:           handlers.FmtUUID(weightTicketSet.MoveDocument.MoveID),
+		Document:         documentPayload,
+		Title:            &weightTicketSet.MoveDocument.Title,
+		MoveDocumentType: internalmessages.MoveDocumentType(weightTicketSet.MoveDocument.MoveDocumentType),
+		Status:           internalmessages.MoveDocumentStatus(weightTicketSet.MoveDocument.Status),
+		Notes:            weightTicketSet.MoveDocument.Notes,
+	}
+
+	return &genericMoveDocumentPayload, nil
+}
+
+// CreateMovingExpenseDocumentHandler creates a MovingExpenseDocument
+type CreateWeightTicketSetDocumentHandler struct {
+	handlers.HandlerContext
+}
+
+// Handle is the handler
+func (h CreateWeightTicketSetDocumentHandler) Handle(params movedocop.CreateWeightTicketDocumentParams) middleware.Responder {
+	ctx, span := beeline.StartSpan(params.HTTPRequest.Context(), reflect.TypeOf(h).Name())
+	defer span.Send()
+
+	session := auth.SessionFromRequestContext(params.HTTPRequest)
+	// #nosec UUID is pattern matched by swagger and will be ok
+	moveID, _ := uuid.FromString(params.MoveID.String())
+
+	// Validate that this move belongs to the current user
+	move, err := models.FetchMove(h.DB(), session, moveID)
+	if err != nil {
+		return handlers.ResponseForError(h.Logger(), err)
+	}
+
+	payload := params.CreateWeightTicketDocument
+
+	// Fetch uploads to confirm ownership
+	uploadIds := payload.UploadIds
+	if len(uploadIds) == 0 {
+		return movedocop.NewCreateWeightTicketDocumentBadRequest()
+	}
+
+	uploads := models.Uploads{}
+	for _, id := range uploadIds {
+		converted := uuid.Must(uuid.FromString(id.String()))
+		upload, fetchUploadErr := models.FetchUpload(ctx, h.DB(), session, converted)
+		if fetchUploadErr != nil {
+			return handlers.ResponseForError(h.Logger(), fetchUploadErr)
+		}
+		uploads = append(uploads, upload)
+	}
+
+	ppmID := uuid.Must(uuid.FromString(payload.PersonallyProcuredMoveID.String()))
+
+	// Enforce that the ppm's move_id matches our move
+	ppm, fetchPPMErr := models.FetchPersonallyProcuredMove(h.DB(), session, ppmID)
+	if fetchPPMErr != nil {
+		return handlers.ResponseForError(h.Logger(), fetchPPMErr)
+	}
+	if ppm.MoveID != moveID {
+		return movedocop.NewCreateMovingExpenseDocumentBadRequest()
+	}
+
+	newWeightTicketSetDocument, verrs, err := move.CreateWeightTicketSetDocument(
+		h.DB(),
+		uploads,
+		&ppmID,
+		*payload.VehicleNickname,
+		*payload.VehicleOptions,
+		int(*payload.FullWeight),
+		int(*payload.EmptyWeight),
+		(*time.Time)(payload.WeightTicketDate),
+		*move.SelectedMoveType,
+	)
+
+	if err != nil || verrs.HasAny() {
+		return handlers.ResponseForVErrors(h.Logger(), verrs, err)
+	}
+
+	newPayload, err := payloadForWeightTicketSetMoveDocumentModel(h.FileStorer(), *newWeightTicketSetDocument)
+	if err != nil {
+		return handlers.ResponseForError(h.Logger(), err)
+	}
+	return movedocop.NewCreateMovingExpenseDocumentOK().WithPayload(newPayload)
+}

--- a/pkg/handlers/internalapi/weight_ticket_set_documents_test.go
+++ b/pkg/handlers/internalapi/weight_ticket_set_documents_test.go
@@ -54,7 +54,7 @@ func (suite *HandlerSuite) TestCreateWeightTicketSetDocumentHandler() {
 	handler := CreateWeightTicketSetDocumentHandler{context}
 	response := handler.Handle(newWeightTicketSetDocParams)
 	suite.IsNotErrResponse(response)
-	createdResponse := response.(*movedocop.CreateMovingExpenseDocumentOK)
+	createdResponse := response.(*movedocop.CreateWeightTicketDocumentOK)
 	createdPayload := createdResponse.Payload
 	suite.NotNil(createdPayload.ID)
 
@@ -118,7 +118,7 @@ func (suite *HandlerSuite) TestCreateWeightTicketSetDocumentHandlerNoWeights() {
 	response := handler.Handle(newWeightTicketSetDocParams)
 	// assert we got back the 201 response
 	suite.IsNotErrResponse(response)
-	createdResponse := response.(*movedocop.CreateMovingExpenseDocumentOK)
+	createdResponse := response.(*movedocop.CreateWeightTicketDocumentOK)
 	createdPayload := createdResponse.Payload
 	suite.NotNil(createdPayload.ID)
 

--- a/pkg/handlers/internalapi/weight_ticket_set_documents_test.go
+++ b/pkg/handlers/internalapi/weight_ticket_set_documents_test.go
@@ -1,7 +1,6 @@
 package internalapi
 
 import (
-	"log"
 	"net/http/httptest"
 
 	"github.com/go-openapi/strfmt"
@@ -36,6 +35,8 @@ func (suite *HandlerSuite) TestCreateWeightTicketSetDocumentHandler() {
 		UploadIds:                uploadIds,
 		EmptyWeight:              handlers.FmtInt64(1000),
 		FullWeight:               handlers.FmtInt64(2000),
+		EmptyWeightTicketMissing: handlers.FmtBool(false),
+		FullWeightTicketMissing:  handlers.FmtBool(false),
 		PersonallyProcuredMoveID: handlers.FmtUUID(ppm.ID),
 		VehicleNickname:          handlers.FmtString("My car"),
 		VehicleOptions:           handlers.FmtString("CAR"),
@@ -65,6 +66,13 @@ func (suite *HandlerSuite) TestCreateWeightTicketSetDocumentHandler() {
 	suite.Equal(createdDocumentID.String(), fetchedUpload.DocumentID.String())
 	suite.Equal(createdPayload.Status, internalmessages.MoveDocumentStatusAWAITINGREVIEW)
 
+	var fetchedMoveDocument models.MoveDocument
+	err := suite.DB().Q().Where("move_id = ?", ppm.MoveID).First(&fetchedMoveDocument)
+	suite.Nil(err)
+	var fetchedWeightTicket models.WeightTicketSetDocument
+	err = suite.DB().Q().Where("move_document_id = ?", fetchedMoveDocument.ID).First(&fetchedWeightTicket)
+	suite.Nil(err)
+
 	// Wrong user
 	wrongUser := testdatagen.MakeDefaultServiceMember(suite.DB())
 	request = suite.AuthenticateRequest(request, wrongUser)
@@ -78,58 +86,4 @@ func (suite *HandlerSuite) TestCreateWeightTicketSetDocumentHandler() {
 	badMoveResponse := handler.Handle(newWeightTicketSetDocParams)
 	suite.CheckResponseNotFound(badMoveResponse)
 
-}
-
-func (suite *HandlerSuite) TestCreateWeightTicketSetDocumentHandlerNoWeights() {
-
-	ppm := testdatagen.MakeDefaultPPM(suite.DB())
-	sm := ppm.Move.Orders.ServiceMember
-
-	upload := testdatagen.MakeUpload(suite.DB(), testdatagen.Assertions{
-		Upload: models.Upload{
-			UploaderID: sm.UserID,
-		},
-	})
-	upload.DocumentID = nil
-	suite.MustSave(&upload)
-	uploadIds := []strfmt.UUID{*handlers.FmtUUID(upload.ID)}
-
-	request := httptest.NewRequest("POST", "/fake/path", nil)
-	request = suite.AuthenticateRequest(request, sm)
-
-	newWeightTicketSetDocumentPayload := internalmessages.CreateWeightTicketDocumentsPayload{
-		UploadIds:                uploadIds,
-		PersonallyProcuredMoveID: handlers.FmtUUID(ppm.ID),
-		VehicleNickname:          handlers.FmtString("My car 1"),
-		VehicleOptions:           handlers.FmtString("CAR"),
-		WeightTicketDate:         handlers.FmtDate(testdatagen.NextValidMoveDate),
-	}
-
-	newWeightTicketSetDocParams := movedocop.CreateWeightTicketDocumentParams{
-		HTTPRequest:                request,
-		CreateWeightTicketDocument: &newWeightTicketSetDocumentPayload,
-		MoveID:                     strfmt.UUID(ppm.MoveID.String()),
-	}
-
-	context := handlers.NewHandlerContext(suite.DB(), suite.TestLogger())
-	fakeS3 := storageTest.NewFakeS3Storage(true)
-	context.SetFileStorer(fakeS3)
-	handler := CreateWeightTicketSetDocumentHandler{context}
-	response := handler.Handle(newWeightTicketSetDocParams)
-	// assert we got back the 201 response
-	suite.IsNotErrResponse(response)
-	createdResponse := response.(*movedocop.CreateWeightTicketDocumentOK)
-	createdPayload := createdResponse.Payload
-	suite.NotNil(createdPayload.ID)
-
-	// confirm empty, full weights are nil
-	var fetchedMoveDocument models.MoveDocument
-	err := suite.DB().Q().Where("move_id = ?", ppm.MoveID).First(&fetchedMoveDocument)
-	suite.Nil(err)
-	var fetchedWeightTicket models.WeightTicketSetDocument
-	log.Println(fetchedMoveDocument.DocumentID)
-	err = suite.DB().Q().Where("move_document_id = ?", fetchedMoveDocument.ID).First(&fetchedWeightTicket)
-	suite.Nil(err)
-	suite.Nil(fetchedWeightTicket.EmptyWeight)
-	suite.Nil(fetchedWeightTicket.FullWeight)
 }

--- a/pkg/handlers/internalapi/weight_ticket_set_documents_test.go
+++ b/pkg/handlers/internalapi/weight_ticket_set_documents_test.go
@@ -1,8 +1,6 @@
 package internalapi
 
 import (
-	"encoding/json"
-	"log"
 	"net/http/httptest"
 
 	"github.com/go-openapi/strfmt"
@@ -54,16 +52,73 @@ func (suite *HandlerSuite) TestCreateWeightTicketSetDocumentHandler() {
 	context.SetFileStorer(fakeS3)
 	handler := CreateWeightTicketSetDocumentHandler{context}
 	response := handler.Handle(newWeightTicketSetDocParams)
+	suite.IsNotErrResponse(response)
+	createdResponse := response.(*movedocop.CreateMovingExpenseDocumentOK)
+	createdPayload := createdResponse.Payload
+	suite.NotNil(createdPayload.ID)
+
+	// confirm Upload is associated to the new document
+	createdDocumentID := createdPayload.Document.ID
+	var fetchedUpload models.Upload
+	suite.DB().Find(&fetchedUpload, upload.ID)
+	suite.Equal(createdDocumentID.String(), fetchedUpload.DocumentID.String())
+	suite.Equal(createdPayload.Status, internalmessages.MoveDocumentStatusAWAITINGREVIEW)
+
+	// Wrong user
+	wrongUser := testdatagen.MakeDefaultServiceMember(suite.DB())
+	request = suite.AuthenticateRequest(request, wrongUser)
+	newWeightTicketSetDocParams.HTTPRequest = request
+
+	badUserResponse := handler.Handle(newWeightTicketSetDocParams)
+	suite.CheckResponseForbidden(badUserResponse)
+
+	// Bad move
+	newWeightTicketSetDocParams.MoveID = strfmt.UUID(uuid.Must(uuid.NewV4()).String())
+	badMoveResponse := handler.Handle(newWeightTicketSetDocParams)
+	suite.CheckResponseNotFound(badMoveResponse)
+
+}
+
+func (suite *HandlerSuite) TestCreateWeightTicketSetDocumentHandlerNoWeights() {
+
+	ppm := testdatagen.MakeDefaultPPM(suite.DB())
+	sm := ppm.Move.Orders.ServiceMember
+
+	upload := testdatagen.MakeUpload(suite.DB(), testdatagen.Assertions{
+		Upload: models.Upload{
+			UploaderID: sm.UserID,
+		},
+	})
+	upload.DocumentID = nil
+	suite.MustSave(&upload)
+	uploadIds := []strfmt.UUID{*handlers.FmtUUID(upload.ID)}
+
+	request := httptest.NewRequest("POST", "/fake/path", nil)
+	request = suite.AuthenticateRequest(request, sm)
+
+	newWeightTicketSetDocumentPayload := internalmessages.CreateWeightTicketDocumentsPayload{
+		UploadIds:                uploadIds,
+		PersonallyProcuredMoveID: handlers.FmtUUID(ppm.ID),
+		VehicleNickname:          handlers.FmtString("My car"),
+		VehicleOptions:           handlers.FmtString("CAR"),
+		WeightTicketDate:         handlers.FmtDate(testdatagen.NextValidMoveDate),
+	}
+
+	newWeightTicketSetDocParams := movedocop.CreateWeightTicketDocumentParams{
+		HTTPRequest:                request,
+		CreateWeightTicketDocument: &newWeightTicketSetDocumentPayload,
+		MoveID:                     strfmt.UUID(ppm.MoveID.String()),
+	}
+
+	context := handlers.NewHandlerContext(suite.DB(), suite.TestLogger())
+	fakeS3 := storageTest.NewFakeS3Storage(true)
+	context.SetFileStorer(fakeS3)
+	handler := CreateWeightTicketSetDocumentHandler{context}
+	response := handler.Handle(newWeightTicketSetDocParams)
 	// assert we got back the 201 response
 	suite.IsNotErrResponse(response)
 	createdResponse := response.(*movedocop.CreateMovingExpenseDocumentOK)
 	createdPayload := createdResponse.Payload
-	b, err := json.Marshal(createdPayload)
-	if err != nil {
-		log.Println(err)
-		return
-	}
-	log.Println(string(b))
 	suite.NotNil(createdPayload.ID)
 
 	// Make sure the Upload was associated to the new document
@@ -72,20 +127,5 @@ func (suite *HandlerSuite) TestCreateWeightTicketSetDocumentHandler() {
 	suite.DB().Find(&fetchedUpload, upload.ID)
 	suite.Equal(createdDocumentID.String(), fetchedUpload.DocumentID.String())
 
-	// Check that the status is correct
 	suite.Equal(createdPayload.Status, internalmessages.MoveDocumentStatusAWAITINGREVIEW)
-
-	// Next try the wrong user
-	wrongUser := testdatagen.MakeDefaultServiceMember(suite.DB())
-	request = suite.AuthenticateRequest(request, wrongUser)
-	newWeightTicketSetDocParams.HTTPRequest = request
-
-	badUserResponse := handler.Handle(newWeightTicketSetDocParams)
-	suite.CheckResponseForbidden(badUserResponse)
-
-	// Now try a bad move
-	newWeightTicketSetDocParams.MoveID = strfmt.UUID(uuid.Must(uuid.NewV4()).String())
-	badMoveResponse := handler.Handle(newWeightTicketSetDocParams)
-	suite.CheckResponseNotFound(badMoveResponse)
-
 }

--- a/pkg/handlers/internalapi/weight_ticket_set_documents_test.go
+++ b/pkg/handlers/internalapi/weight_ticket_set_documents_test.go
@@ -1,0 +1,91 @@
+package internalapi
+
+import (
+	"encoding/json"
+	"log"
+	"net/http/httptest"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/gofrs/uuid"
+
+	movedocop "github.com/transcom/mymove/pkg/gen/internalapi/internaloperations/move_docs"
+	"github.com/transcom/mymove/pkg/gen/internalmessages"
+	"github.com/transcom/mymove/pkg/handlers"
+	"github.com/transcom/mymove/pkg/models"
+	storageTest "github.com/transcom/mymove/pkg/storage/test"
+	"github.com/transcom/mymove/pkg/testdatagen"
+)
+
+func (suite *HandlerSuite) TestCreateWeightTicketSetDocumentHandler() {
+
+	ppm := testdatagen.MakeDefaultPPM(suite.DB())
+	sm := ppm.Move.Orders.ServiceMember
+
+	upload := testdatagen.MakeUpload(suite.DB(), testdatagen.Assertions{
+		Upload: models.Upload{
+			UploaderID: sm.UserID,
+		},
+	})
+	upload.DocumentID = nil
+	suite.MustSave(&upload)
+	uploadIds := []strfmt.UUID{*handlers.FmtUUID(upload.ID)}
+
+	request := httptest.NewRequest("POST", "/fake/path", nil)
+	request = suite.AuthenticateRequest(request, sm)
+
+	newWeightTicketSetDocumentPayload := internalmessages.CreateWeightTicketDocumentsPayload{
+		UploadIds:                uploadIds,
+		EmptyWeight:              handlers.FmtInt64(1000),
+		FullWeight:               handlers.FmtInt64(2000),
+		PersonallyProcuredMoveID: handlers.FmtUUID(ppm.ID),
+		VehicleNickname:          handlers.FmtString("My car"),
+		VehicleOptions:           handlers.FmtString("CAR"),
+		WeightTicketDate:         handlers.FmtDate(testdatagen.NextValidMoveDate),
+	}
+
+	newWeightTicketSetDocParams := movedocop.CreateWeightTicketDocumentParams{
+		HTTPRequest:                request,
+		CreateWeightTicketDocument: &newWeightTicketSetDocumentPayload,
+		MoveID:                     strfmt.UUID(ppm.MoveID.String()),
+	}
+
+	context := handlers.NewHandlerContext(suite.DB(), suite.TestLogger())
+	fakeS3 := storageTest.NewFakeS3Storage(true)
+	context.SetFileStorer(fakeS3)
+	handler := CreateWeightTicketSetDocumentHandler{context}
+	response := handler.Handle(newWeightTicketSetDocParams)
+	// assert we got back the 201 response
+	suite.IsNotErrResponse(response)
+	createdResponse := response.(*movedocop.CreateMovingExpenseDocumentOK)
+	createdPayload := createdResponse.Payload
+	b, err := json.Marshal(createdPayload)
+	if err != nil {
+		log.Println(err)
+		return
+	}
+	log.Println(string(b))
+	suite.NotNil(createdPayload.ID)
+
+	// Make sure the Upload was associated to the new document
+	createdDocumentID := createdPayload.Document.ID
+	var fetchedUpload models.Upload
+	suite.DB().Find(&fetchedUpload, upload.ID)
+	suite.Equal(createdDocumentID.String(), fetchedUpload.DocumentID.String())
+
+	// Check that the status is correct
+	suite.Equal(createdPayload.Status, internalmessages.MoveDocumentStatusAWAITINGREVIEW)
+
+	// Next try the wrong user
+	wrongUser := testdatagen.MakeDefaultServiceMember(suite.DB())
+	request = suite.AuthenticateRequest(request, wrongUser)
+	newWeightTicketSetDocParams.HTTPRequest = request
+
+	badUserResponse := handler.Handle(newWeightTicketSetDocParams)
+	suite.CheckResponseForbidden(badUserResponse)
+
+	// Now try a bad move
+	newWeightTicketSetDocParams.MoveID = strfmt.UUID(uuid.Must(uuid.NewV4()).String())
+	badMoveResponse := handler.Handle(newWeightTicketSetDocParams)
+	suite.CheckResponseNotFound(badMoveResponse)
+
+}

--- a/pkg/models/move.go
+++ b/pkg/models/move.go
@@ -418,11 +418,7 @@ func (m Move) CreateWeightTicketSetDocument(
 	db *pop.Connection,
 	uploads Uploads,
 	personallyProcuredMoveID *uuid.UUID,
-	vehicleNickName string,
-	vehicleOptions string,
-	fullWeight *int64,
-	emptyWeight *int64,
-	weightTicketDate time.Time,
+	weightTicketSetdocument WeightTicketSetDocument,
 	moveType SelectedMoveType) (*WeightTicketSetDocument, *validate.Errors, error) {
 
 	var newWeightTicketSetDocument *WeightTicketSetDocument
@@ -439,30 +435,22 @@ func (m Move) CreateWeightTicketSetDocument(
 			personallyProcuredMoveID,
 			MoveDocumentTypeWEIGHTTICKETSET,
 			"weight_ticket_set",
-			&vehicleNickName,
+			&weightTicketSetdocument.VehicleNickname,
 			moveType)
 		if responseVErrors.HasAny() || responseError != nil {
 			return transactionError
 		}
 
-		var ew *unit.Pound
-		if emptyWeight != nil {
-			p := unit.Pound(*emptyWeight)
-			ew = &p
-		}
-		var fw *unit.Pound
-		if fullWeight != nil {
-			p := unit.Pound(*fullWeight)
-			fw = &p
-		}
 		newWeightTicketSetDocument = &WeightTicketSetDocument{
-			MoveDocumentID:   newMoveDocument.ID,
-			MoveDocument:     *newMoveDocument,
-			EmptyWeight:      ew,
-			FullWeight:       fw,
-			VehicleNickname:  vehicleNickName,
-			VehicleOptions:   vehicleOptions,
-			WeightTicketDate: weightTicketDate,
+			MoveDocumentID:           newMoveDocument.ID,
+			MoveDocument:             *newMoveDocument,
+			EmptyWeight:              unit.Pound(weightTicketSetdocument.EmptyWeight),
+			EmptyWeightTicketMissing: weightTicketSetdocument.EmptyWeightTicketMissing,
+			FullWeight:               unit.Pound(weightTicketSetdocument.FullWeight),
+			FullWeightTicketMissing:  weightTicketSetdocument.FullWeightTicketMissing,
+			VehicleNickname:          weightTicketSetdocument.VehicleNickname,
+			VehicleOptions:           weightTicketSetdocument.VehicleOptions,
+			WeightTicketDate:         weightTicketSetdocument.WeightTicketDate,
 		}
 		verrs, err := db.ValidateAndCreate(newWeightTicketSetDocument)
 		if err != nil || verrs.HasAny() {

--- a/pkg/models/move.go
+++ b/pkg/models/move.go
@@ -420,8 +420,8 @@ func (m Move) CreateWeightTicketSetDocument(
 	personallyProcuredMoveID *uuid.UUID,
 	vehicleNickName string,
 	vehicleOptions string,
-	fullWeight int,
-	emptyWeight int,
+	fullWeight *int64,
+	emptyWeight *int64,
 	weightTicketDate *time.Time,
 	moveType SelectedMoveType) (*WeightTicketSetDocument, *validate.Errors, error) {
 
@@ -445,12 +445,20 @@ func (m Move) CreateWeightTicketSetDocument(
 			return transactionError
 		}
 
+		var ew unit.Pound
+		if emptyWeight != nil {
+			ew = unit.Pound(*emptyWeight)
+		}
+		var fw unit.Pound
+		if fullWeight != nil {
+			fw = unit.Pound(*fullWeight)
+		}
 		// Finally, create the MovingExpenseDocument
 		newWeightTicketSetDocument = &WeightTicketSetDocument{
 			MoveDocumentID:   newMoveDocument.ID,
 			MoveDocument:     *newMoveDocument,
-			EmptyWeight:      unit.Pound(emptyWeight),
-			FullWeight:       unit.Pound(fullWeight),
+			EmptyWeight:      &ew,
+			FullWeight:       &fw,
 			VehicleNickname:  vehicleNickName,
 			VehicleOptions:   vehicleOptions,
 			WeightTicketDate: *weightTicketDate,

--- a/pkg/models/move.go
+++ b/pkg/models/move.go
@@ -413,7 +413,7 @@ func (m Move) CreateMovingExpenseDocument(
 	return newMovingExpenseDocument, responseVErrors, responseError
 }
 
-// CreateMovingExpenseDocument creates a moving expense document associated to a move and move document
+// CreateWeightTicketSetDocument creates a moving weight ticket document associated to a move and move document
 func (m Move) CreateWeightTicketSetDocument(
 	db *pop.Connection,
 	uploads Uploads,
@@ -422,7 +422,7 @@ func (m Move) CreateWeightTicketSetDocument(
 	vehicleOptions string,
 	fullWeight *int64,
 	emptyWeight *int64,
-	weightTicketDate *time.Time,
+	weightTicketDate time.Time,
 	moveType SelectedMoveType) (*WeightTicketSetDocument, *validate.Errors, error) {
 
 	var newWeightTicketSetDocument *WeightTicketSetDocument
@@ -437,7 +437,7 @@ func (m Move) CreateWeightTicketSetDocument(
 			db,
 			uploads,
 			personallyProcuredMoveID,
-			MoveDocumentTypeWEIGHTTICKET,
+			MoveDocumentTypeWEIGHTTICKETSET,
 			"weight_ticket_set",
 			&vehicleNickName,
 			moveType)
@@ -445,23 +445,24 @@ func (m Move) CreateWeightTicketSetDocument(
 			return transactionError
 		}
 
-		var ew unit.Pound
+		var ew *unit.Pound
 		if emptyWeight != nil {
-			ew = unit.Pound(*emptyWeight)
+			p := unit.Pound(*emptyWeight)
+			ew = &p
 		}
-		var fw unit.Pound
+		var fw *unit.Pound
 		if fullWeight != nil {
-			fw = unit.Pound(*fullWeight)
+			p := unit.Pound(*fullWeight)
+			fw = &p
 		}
-		// Finally, create the MovingExpenseDocument
 		newWeightTicketSetDocument = &WeightTicketSetDocument{
 			MoveDocumentID:   newMoveDocument.ID,
 			MoveDocument:     *newMoveDocument,
-			EmptyWeight:      &ew,
-			FullWeight:       &fw,
+			EmptyWeight:      ew,
+			FullWeight:       fw,
 			VehicleNickname:  vehicleNickName,
 			VehicleOptions:   vehicleOptions,
-			WeightTicketDate: *weightTicketDate,
+			WeightTicketDate: weightTicketDate,
 		}
 		verrs, err := db.ValidateAndCreate(newWeightTicketSetDocument)
 		if err != nil || verrs.HasAny() {

--- a/pkg/models/move_document.go
+++ b/pkg/models/move_document.go
@@ -46,6 +46,8 @@ const (
 	MoveDocumentTypeSHIPMENTSUMMARY MoveDocumentType = "SHIPMENT_SUMMARY"
 	// MoveDocumentTypeEXPENSE captures enum value "EXPENSE"
 	MoveDocumentTypeEXPENSE MoveDocumentType = "EXPENSE"
+	// MoveDocumentTypeWEIGHTTICKETSET captures enum value "WEIGHT_TICKET_SET"
+	MoveDocumentTypeWEIGHTTICKETSET MoveDocumentType = "WEIGHT_TICKET_SET"
 
 	// HHG Doc Types
 

--- a/pkg/models/move_documents_extractor.go
+++ b/pkg/models/move_documents_extractor.go
@@ -24,7 +24,9 @@ type MoveDocumentExtractor struct {
 	MovingExpenseType        *MovingExpenseType `json:"moving_expense_type" db:"moving_expense_type"`
 	RequestedAmountCents     *unit.Cents        `json:"requested_amount_cents" db:"requested_amount_cents"`
 	EmptyWeight              *unit.Pound        `json:"empty_weight,omitempty" db:"empty_weight"`
+	EmptyWeightTicketMissing *bool              `json:"empty_weight_ticket_missing,omitempty" db:"empty_weight_ticket_missing"`
 	FullWeight               *unit.Pound        `json:"full_weight,omitempty" db:"full_weight"`
+	FullWeightTicketMissing  *bool              `json:"full_weight_ticket_missing,omitempty" db:"full_weight_ticket_missing"`
 	VehicleNickname          *string            `json:"vehicle_nickname,omitempty" db:"vehicle_nickname"`
 	VehicleOptions           *string            `json:"vehicle_options,omitempty" db:"vehicle_options"`
 	WeightTicketDate         *time.Time         `json:"weight_ticket_date,omitempty" db:"weight_ticket_date"`
@@ -47,7 +49,7 @@ func (m *Move) FetchAllMoveDocumentsForMove(db *pop.Connection) (MoveDocumentExt
 	sql, args := query.ToSQL(&pop.Model{Value: MoveDocument{}},
 		`move_documents.*,
 					  ed.moving_expense_type, ed.requested_amount_cents, ed.payment_method,
-                      wt.empty_weight, wt.full_weight, wt.vehicle_nickname, wt.vehicle_options, wt.weight_ticket_date`)
+                      wt.empty_weight, wt.empty_weight_ticket_missing, wt.full_weight_ticket_missing, wt.full_weight, wt.vehicle_nickname, wt.vehicle_options, wt.weight_ticket_date`)
 
 	err := db.RawQuery(sql, args...).Eager("Document.Uploads").All(&moveDocs)
 	if err != nil {

--- a/pkg/models/move_documents_extractor_test.go
+++ b/pkg/models/move_documents_extractor_test.go
@@ -23,9 +23,10 @@ func (suite *ModelSuite) TestFetchAllMoveDocumentsForMove() {
 
 	testdatagen.MakeMoveDocument(suite.DB(), assertions)
 	testdatagen.MakeMovingExpenseDocument(suite.DB(), assertions)
+	testdatagen.MakeWeightTicketSetDocument(suite.DB(), assertions)
 
 	docs, err := move.FetchAllMoveDocumentsForMove(suite.DB())
 	if suite.NoError(err) {
-		suite.Len(docs, 2)
+		suite.Len(docs, 3)
 	}
 }

--- a/pkg/models/weight_ticket_set_document.go
+++ b/pkg/models/weight_ticket_set_document.go
@@ -1,0 +1,54 @@
+package models
+
+import (
+	"time"
+
+	"github.com/transcom/mymove/pkg/unit"
+
+	"github.com/gobuffalo/pop"
+	"github.com/gobuffalo/validate"
+	"github.com/gobuffalo/validate/validators"
+	"github.com/gofrs/uuid"
+)
+
+// WeightTicketDocumentsPayload weight ticket documents payload
+type WeightTicketSetDocument struct {
+	ID               uuid.UUID    `json:"id" db:"id"`
+	MoveDocumentID   uuid.UUID    `json:"move_document_id" db:"move_document_id"`
+	MoveDocument     MoveDocument `belongs_to:"move_documents"`
+	EmptyWeight      unit.Pound   `json:"empty_weight,omitempty" db:"empty_weight"`
+	FullWeight       unit.Pound   `json:"full_weight,omitempty" db:"full_weight"`
+	VehicleNickname  string       `json:"vehicle_nickname,omitempty" db:"vehicle_nickname"`
+	VehicleOptions   string       `json:"vehicle_options,omitempty" db:"vehicle_options"`
+	WeightTicketDate time.Time    `json:"weight_ticket_date,omitempty" db:"weight_ticket_date"`
+	CreatedAt        time.Time    `json:"created_at" db:"created_at"`
+	UpdatedAt        time.Time    `json:"updated_at" db:"updated_at"`
+}
+
+// MovingExpenseDocuments is not required by pop and may be deleted
+type WeightTicketSetDocuments []WeightTicketSetDocument
+
+// Validate gets run every time you call a "pop.Validate*" (pop.ValidateAndSave, pop.ValidateAndCreate, pop.ValidateAndUpdate) method.
+// This method is not required and may be deleted.
+func (m *WeightTicketSetDocument) Validate(tx *pop.Connection) (*validate.Errors, error) {
+	return validate.Validate(
+		&validators.UUIDIsPresent{Field: m.MoveDocumentID, Name: "MoveDocumentID"},
+		&validators.StringIsPresent{Field: string(m.VehicleNickname), Name: "VehicleNickname"},
+		&validators.StringIsPresent{Field: string(m.VehicleOptions), Name: "VehicleOptions"},
+		&validators.IntIsGreaterThan{Field: int(m.FullWeight), Name: "FullWeight", Compared: 0},
+		&validators.IntIsGreaterThan{Field: int(m.EmptyWeight), Name: "EmptyWeight", Compared: 0},
+		&validators.TimeIsPresent{Field: m.WeightTicketDate, Name: "WeightTicketDate"},
+	), nil
+}
+
+// ValidateCreate gets run every time you call "pop.ValidateAndCreate" method.
+// This method is not required and may be deleted.
+func (m *WeightTicketSetDocument) ValidateCreate(tx *pop.Connection) (*validate.Errors, error) {
+	return validate.NewErrors(), nil
+}
+
+// ValidateUpdate gets run every time you call "pop.ValidateAndUpdate" method.
+// This method is not required and may be deleted.
+func (m *WeightTicketSetDocument) ValidateUpdate(tx *pop.Connection) (*validate.Errors, error) {
+	return validate.NewErrors(), nil
+}

--- a/pkg/models/weight_ticket_set_document.go
+++ b/pkg/models/weight_ticket_set_document.go
@@ -13,16 +13,18 @@ import (
 
 // WeightTicketDocumentsPayload weight ticket documents payload
 type WeightTicketSetDocument struct {
-	ID               uuid.UUID    `json:"id" db:"id"`
-	MoveDocumentID   uuid.UUID    `json:"move_document_id" db:"move_document_id"`
-	MoveDocument     MoveDocument `belongs_to:"move_documents"`
-	EmptyWeight      *unit.Pound  `json:"empty_weight,omitempty" db:"empty_weight"`
-	FullWeight       *unit.Pound  `json:"full_weight,omitempty" db:"full_weight"`
-	VehicleNickname  string       `json:"vehicle_nickname,omitempty" db:"vehicle_nickname"`
-	VehicleOptions   string       `json:"vehicle_options,omitempty" db:"vehicle_options"`
-	WeightTicketDate time.Time    `json:"weight_ticket_date,omitempty" db:"weight_ticket_date"`
-	CreatedAt        time.Time    `json:"created_at" db:"created_at"`
-	UpdatedAt        time.Time    `json:"updated_at" db:"updated_at"`
+	ID                       uuid.UUID    `json:"id" db:"id"`
+	MoveDocumentID           uuid.UUID    `json:"move_document_id" db:"move_document_id"`
+	MoveDocument             MoveDocument `belongs_to:"move_documents"`
+	EmptyWeight              unit.Pound   `json:"empty_weight,omitempty" db:"empty_weight"`
+	EmptyWeightTicketMissing bool         `json:"empty_weight_ticket_missing,omitempty" db:"empty_weight_ticket_missing"`
+	FullWeight               unit.Pound   `json:"full_weight,omitempty" db:"full_weight"`
+	FullWeightTicketMissing  bool         `json:"full_weight_ticket_missing,omitempty" db:"full_weight_ticket_missing"`
+	VehicleNickname          string       `json:"vehicle_nickname,omitempty" db:"vehicle_nickname"`
+	VehicleOptions           string       `json:"vehicle_options,omitempty" db:"vehicle_options"`
+	WeightTicketDate         time.Time    `json:"weight_ticket_date,omitempty" db:"weight_ticket_date"`
+	CreatedAt                time.Time    `json:"created_at" db:"created_at"`
+	UpdatedAt                time.Time    `json:"updated_at" db:"updated_at"`
 }
 
 // WeightTicketSetDocuments slice of WeightTicketSetDocuments
@@ -35,6 +37,8 @@ func (m *WeightTicketSetDocument) Validate(tx *pop.Connection) (*validate.Errors
 		&validators.UUIDIsPresent{Field: m.MoveDocumentID, Name: "MoveDocumentID"},
 		&validators.StringIsPresent{Field: string(m.VehicleNickname), Name: "VehicleNickname"},
 		&validators.StringIsPresent{Field: string(m.VehicleOptions), Name: "VehicleOptions"},
+		&validators.IntIsGreaterThan{Field: int(m.FullWeight), Name: "FullWeight", Compared: 0},
+		&validators.IntIsGreaterThan{Field: int(m.EmptyWeight), Name: "EmptyWeight", Compared: 0},
 		&validators.TimeIsPresent{Field: m.WeightTicketDate, Name: "WeightTicketDate"},
 	), nil
 }

--- a/pkg/models/weight_ticket_set_document.go
+++ b/pkg/models/weight_ticket_set_document.go
@@ -16,8 +16,8 @@ type WeightTicketSetDocument struct {
 	ID               uuid.UUID    `json:"id" db:"id"`
 	MoveDocumentID   uuid.UUID    `json:"move_document_id" db:"move_document_id"`
 	MoveDocument     MoveDocument `belongs_to:"move_documents"`
-	EmptyWeight      unit.Pound   `json:"empty_weight,omitempty" db:"empty_weight"`
-	FullWeight       unit.Pound   `json:"full_weight,omitempty" db:"full_weight"`
+	EmptyWeight      *unit.Pound  `json:"empty_weight,omitempty" db:"empty_weight"`
+	FullWeight       *unit.Pound  `json:"full_weight,omitempty" db:"full_weight"`
 	VehicleNickname  string       `json:"vehicle_nickname,omitempty" db:"vehicle_nickname"`
 	VehicleOptions   string       `json:"vehicle_options,omitempty" db:"vehicle_options"`
 	WeightTicketDate time.Time    `json:"weight_ticket_date,omitempty" db:"weight_ticket_date"`
@@ -35,8 +35,6 @@ func (m *WeightTicketSetDocument) Validate(tx *pop.Connection) (*validate.Errors
 		&validators.UUIDIsPresent{Field: m.MoveDocumentID, Name: "MoveDocumentID"},
 		&validators.StringIsPresent{Field: string(m.VehicleNickname), Name: "VehicleNickname"},
 		&validators.StringIsPresent{Field: string(m.VehicleOptions), Name: "VehicleOptions"},
-		&validators.IntIsGreaterThan{Field: int(m.FullWeight), Name: "FullWeight", Compared: 0},
-		&validators.IntIsGreaterThan{Field: int(m.EmptyWeight), Name: "EmptyWeight", Compared: 0},
 		&validators.TimeIsPresent{Field: m.WeightTicketDate, Name: "WeightTicketDate"},
 	), nil
 }

--- a/pkg/models/weight_ticket_set_document.go
+++ b/pkg/models/weight_ticket_set_document.go
@@ -25,8 +25,8 @@ type WeightTicketSetDocument struct {
 	UpdatedAt        time.Time    `json:"updated_at" db:"updated_at"`
 }
 
-// MovingExpenseDocuments is not required by pop and may be deleted
-type WeightTicketSetDocuments []WeightTicketSetDocument
+// WeightTicketSetDocuments slice of WeightTicketSetDocuments
+type WeightTicketSetDocuments []WeightTicketSetDocuments
 
 // Validate gets run every time you call a "pop.Validate*" (pop.ValidateAndSave, pop.ValidateAndCreate, pop.ValidateAndUpdate) method.
 // This method is not required and may be deleted.

--- a/pkg/models/weight_ticket_set_document_test.go
+++ b/pkg/models/weight_ticket_set_document_test.go
@@ -11,6 +11,8 @@ func (suite *ModelSuite) TestBasicWeightTicketSetDocumentInstantiation() {
 		"move_document_id":   {"MoveDocumentID can not be blank."},
 		"vehicle_nickname":   {"VehicleNickname can not be blank."},
 		"vehicle_options":    {"VehicleOptions can not be blank."},
+		"empty_weight":       {"0 is not greater than 0."},
+		"full_weight":        {"0 is not greater than 0."},
 		"weight_ticket_date": {"WeightTicketDate can not be blank."},
 	}
 

--- a/pkg/models/weight_ticket_set_document_test.go
+++ b/pkg/models/weight_ticket_set_document_test.go
@@ -11,8 +11,6 @@ func (suite *ModelSuite) TestBasicWeightTicketSetDocumentInstantiation() {
 		"move_document_id":   {"MoveDocumentID can not be blank."},
 		"vehicle_nickname":   {"VehicleNickname can not be blank."},
 		"vehicle_options":    {"VehicleOptions can not be blank."},
-		"empty_weight":       {"0 is not greater than 0."},
-		"full_weight":        {"0 is not greater than 0."},
 		"weight_ticket_date": {"WeightTicketDate can not be blank."},
 	}
 

--- a/pkg/models/weight_ticket_set_document_test.go
+++ b/pkg/models/weight_ticket_set_document_test.go
@@ -1,0 +1,20 @@
+package models_test
+
+import (
+	"github.com/transcom/mymove/pkg/models"
+)
+
+func (suite *ModelSuite) TestBasicWeightTicketSetDocumentInstantiation() {
+	expenseDoc := &models.WeightTicketSetDocument{}
+
+	expErrors := map[string][]string{
+		"move_document_id":   {"MoveDocumentID can not be blank."},
+		"vehicle_nickname":   {"VehicleNickname can not be blank."},
+		"vehicle_options":    {"VehicleOptions can not be blank."},
+		"empty_weight":       {"0 is not greater than 0."},
+		"full_weight":        {"0 is not greater than 0."},
+		"weight_ticket_date": {"WeightTicketDate can not be blank."},
+	}
+
+	suite.verifyValidationErrors(expenseDoc, expErrors)
+}

--- a/pkg/testdatagen/make_weight_ticket_set_document.go
+++ b/pkg/testdatagen/make_weight_ticket_set_document.go
@@ -11,7 +11,7 @@ import (
 func MakeWeightTicketSetDocument(db *pop.Connection, assertions Assertions) models.WeightTicketSetDocument {
 	moveDoc := assertions.WeightTicketSetDocument.MoveDocument
 	// ID is required because it must be populated for Eager saving to work.
-	if isZeroUUID(assertions.MovingExpenseDocument.MoveDocumentID) {
+	if isZeroUUID(moveDoc.MoveID) {
 		moveDoc = MakeMoveDocument(db, assertions)
 	}
 

--- a/pkg/testdatagen/make_weight_ticket_set_document.go
+++ b/pkg/testdatagen/make_weight_ticket_set_document.go
@@ -15,13 +15,11 @@ func MakeWeightTicketSetDocument(db *pop.Connection, assertions Assertions) mode
 		moveDoc = MakeMoveDocument(db, assertions)
 	}
 
-	emptyWeight := unit.Pound(1000)
-	fullWeight := unit.Pound(2500)
 	weightTicketSetDocument := models.WeightTicketSetDocument{
 		MoveDocumentID:   moveDoc.ID,
 		MoveDocument:     moveDoc,
-		EmptyWeight:      &emptyWeight,
-		FullWeight:       &fullWeight,
+		EmptyWeight:      unit.Pound(1000),
+		FullWeight:       unit.Pound(2500),
 		VehicleNickname:  "My Car",
 		VehicleOptions:   "CAR",
 		WeightTicketDate: NextValidMoveDate,

--- a/pkg/testdatagen/make_weight_ticket_set_document.go
+++ b/pkg/testdatagen/make_weight_ticket_set_document.go
@@ -1,0 +1,38 @@
+package testdatagen
+
+import (
+	"github.com/gobuffalo/pop"
+
+	"github.com/transcom/mymove/pkg/models"
+)
+
+// MakeWeightTicketSetDocument creates a single Moving Expense Document.
+func MakeWeightTicketSetDocument(db *pop.Connection, assertions Assertions) models.WeightTicketSetDocument {
+	moveDoc := assertions.WeightTicketSetDocument.MoveDocument
+	// ID is required because it must be populated for Eager saving to work.
+	if isZeroUUID(assertions.MovingExpenseDocument.MoveDocumentID) {
+		moveDoc = MakeMoveDocument(db, assertions)
+	}
+
+	weightTicketSetDocument := models.WeightTicketSetDocument{
+		MoveDocumentID:   moveDoc.ID,
+		MoveDocument:     moveDoc,
+		EmptyWeight:      1000,
+		FullWeight:       2500,
+		VehicleNickname:  "My Car",
+		VehicleOptions:   "CAR",
+		WeightTicketDate: NextValidMoveDate,
+	}
+
+	// Overwrite values with those from assertions
+	mergeModels(&weightTicketSetDocument, assertions.WeightTicketSetDocument)
+
+	mustCreate(db, &weightTicketSetDocument)
+
+	return weightTicketSetDocument
+}
+
+// MakeDefaultWeightTicketSetDocument returns a MoveDocument with default values
+func MakeDefaultWeightTicketSetDocument(db *pop.Connection) models.WeightTicketSetDocument {
+	return MakeWeightTicketSetDocument(db, Assertions{})
+}

--- a/pkg/testdatagen/make_weight_ticket_set_document.go
+++ b/pkg/testdatagen/make_weight_ticket_set_document.go
@@ -4,6 +4,7 @@ import (
 	"github.com/gobuffalo/pop"
 
 	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/unit"
 )
 
 // MakeWeightTicketSetDocument creates a single Moving Expense Document.
@@ -14,11 +15,13 @@ func MakeWeightTicketSetDocument(db *pop.Connection, assertions Assertions) mode
 		moveDoc = MakeMoveDocument(db, assertions)
 	}
 
+	emptyWeight := unit.Pound(1000)
+	fullWeight := unit.Pound(2500)
 	weightTicketSetDocument := models.WeightTicketSetDocument{
 		MoveDocumentID:   moveDoc.ID,
 		MoveDocument:     moveDoc,
-		EmptyWeight:      1000,
-		FullWeight:       2500,
+		EmptyWeight:      &emptyWeight,
+		FullWeight:       &fullWeight,
 		VehicleNickname:  "My Car",
 		VehicleOptions:   "CAR",
 		WeightTicketDate: NextValidMoveDate,

--- a/pkg/testdatagen/shared.go
+++ b/pkg/testdatagen/shared.go
@@ -34,6 +34,7 @@ type Assertions struct {
 	Move                                     models.Move
 	MoveDocument                             models.MoveDocument
 	MovingExpenseDocument                    models.MovingExpenseDocument
+	WeightTicketSetDocument                  models.WeightTicketSetDocument
 	OfficeUser                               models.OfficeUser
 	Order                                    models.Order
 	PersonallyProcuredMove                   models.PersonallyProcuredMove

--- a/src/scenes/Moves/Ppm/WeightTicket.jsx
+++ b/src/scenes/Moves/Ppm/WeightTicket.jsx
@@ -410,7 +410,7 @@ function mapStateToProps(state, ownProps) {
     formValues: getFormValues(formName)(state),
     genericMoveDocSchema: get(state, 'swaggerInternal.spec.definitions.CreateGenericMoveDocumentPayload', {}),
     moveDocSchema: get(state, 'swaggerInternal.spec.definitions.MoveDocumentPayload', {}),
-    schema: get(state, 'swaggerInternal.spec.definitions.WeightTicketPayload', {}),
+    schema: get(state, 'swaggerInternal.spec.definitions.CreateWeightTicketDocumentsPayload', {}),
     currentPpm: get(state, 'ppm.currentPpm'),
   };
 }

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -776,12 +776,12 @@ definitions:
         title: empty weight ticket recorded weight
         type: integer
         minimum: 0
-        example: 10000
+        x-nullable: true
       full_weight:
         title: full weight ticket recorded weight
         type: integer
         minimum: 0
-        example: 10000
+        x-nullable: true
       weight_ticket_date:
         title: Weight ticket date
         type: string
@@ -949,12 +949,12 @@ definitions:
         title: empty weight ticket recorded weight
         type: integer
         minimum: 0
-        example: 10000
+        x-nullable: true
       full_weight:
         title: full weight ticket recorded weight
         type: integer
         minimum: 0
-        example: 10000
+        x-nullable: true
       weight_ticket_date:
         title: Weight ticket date
         type: string

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -777,10 +777,18 @@ definitions:
         type: integer
         minimum: 0
         x-nullable: true
+      empty_weight_ticket_missing:
+        title: missing empty weight ticket
+        type: boolean
+        x-nullable: true
       full_weight:
         title: full weight ticket recorded weight
         type: integer
         minimum: 0
+        x-nullable: true
+      full_weight_ticket_missing:
+        title: missing full weight ticket
+        type: boolean
         x-nullable: true
       weight_ticket_date:
         title: Weight ticket date
@@ -945,16 +953,20 @@ definitions:
       vehicle_nickname:
         type: string
         title: Vehicle nickname (ex. "My car")
+      empty_weight_ticket_missing:
+        title: missing empty weight ticket
+        type: boolean
       empty_weight:
         title: empty weight ticket recorded weight
         type: integer
         minimum: 0
-        x-nullable: true
+      full_weight_ticket_missing:
+        title: missing full weight ticket
+        type: boolean
       full_weight:
         title: full weight ticket recorded weight
         type: integer
         minimum: 0
-        x-nullable: true
       weight_ticket_date:
         title: Weight ticket date
         type: string
@@ -964,6 +976,10 @@ definitions:
       - personally_procured_move_id
       - vehicle_options
       - vehicle_nickname
+      - full_weight
+      - full_weight_ticket_missing
+      - empty_weight
+      - empty_weight_ticket_missing
       - weight_ticket_date
   ServiceMemberPayload:
     type: object

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -705,6 +705,18 @@ definitions:
         type: integer
         title: Distance
         description: unit is miles
+  VehicleOptions:
+    type: string
+    x-nullable: true
+    title: What type of vehicle are these weight tickets for?
+    enum: &VehicleOptions
+      - CAR
+      - CAR_TRAILER
+      - BOX_TRUCK
+    x-display-value:
+      CAR: Car
+      CAR_TRAILER: Car + Trailer
+      BOX_TRUCK: Box truck
   MoveDocumentPayload:
     type: object
     properties:
@@ -753,6 +765,29 @@ definitions:
         x-display-value:
           OTHER: Other account
           GTCC: GTCC
+      vehicle_options:
+        title: What type of vehicle are these weight tickets for?
+        type: string
+        enum: *VehicleOptions
+      vehicle_nickname:
+        type: string
+        title: Vehicle nickname (ex. "My car")
+      empty_weight:
+        title: empty weight ticket recorded weight
+        type: integer
+        minimum: 0
+        example: 10000
+      full_weight:
+        title: full weight ticket recorded weight
+        type: integer
+        minimum: 0
+        example: 10000
+      weight_ticket_date:
+        title: Weight ticket date
+        type: string
+        example: '2018-04-26'
+        format: date
+        x-nullable: true
     required:
       - id
       - move_id
@@ -798,12 +833,14 @@ definitions:
       - STORAGE_EXPENSE
       - SHIPMENT_SUMMARY
       - EXPENSE
+      - WEIGHT_TICKET_SET
     x-display-value:
       OTHER: Other document type
       WEIGHT_TICKET: Weight ticket
       STORAGE_EXPENSE: Storage expense receipt
       SHIPMENT_SUMMARY: Shipment summary
       EXPENSE: Expense
+      WEIGHT_TICKET_SET: Weight ticket set
   CreateMovingExpenseDocumentPayload:
     type: object
     properties:
@@ -884,6 +921,52 @@ definitions:
       AWAITING_REVIEW: Awaiting review
       OK: OK
       HAS_ISSUE: Has issue
+  CreateWeightTicketDocumentsPayload:
+    type: object
+    properties:
+      personally_procured_move_id:
+        type: string
+        format: uuid
+        example: c56a4180-65aa-42ec-a945-5fd21dec0538
+      upload_ids:
+        type: array
+        items:
+          type: string
+          format: uuid
+          example: c56a4180-65aa-42ec-a945-5fd21dec0538
+      vehicle_options:
+        title: What type of vehicle are these weight tickets for?
+        type: string
+        enum: *VehicleOptions
+        x-display-value:
+          CAR: Car
+          CAR_TRAILER: Car + Trailer
+          BOX_TRUCK: Box truck
+      vehicle_nickname:
+        type: string
+        title: Vehicle nickname (ex. "My car")
+      empty_weight:
+        title: empty weight ticket recorded weight
+        type: integer
+        minimum: 0
+        example: 10000
+      full_weight:
+        title: full weight ticket recorded weight
+        type: integer
+        minimum: 0
+        example: 10000
+      weight_ticket_date:
+        title: Weight ticket date
+        type: string
+        example: '2018-04-26'
+        format: date
+    required:
+      - personally_procured_move_id
+      - vehicle_options
+      - vehicle_nickname
+      - empty_weight
+      - full_weight
+      - weight_ticket_date
   ServiceMemberPayload:
     type: object
     properties:
@@ -2463,41 +2546,6 @@ definitions:
     required:
       - start_date
       - available
-  VehicleOptions:
-    type: string
-    x-nullable: true
-    title: What type of vehicle are these weight tickets for?
-    enum: &VehicleOptions
-      - CAR
-      - CAR_TRAILER
-      - BOX_TRUCK
-    x-display-value:
-      CAR: Car
-      CAR_TRAILER: Car + Trailer
-      BOX_TRUCK: Box truck
-  WeightTicketPayload:
-    type: object
-    properties:
-      vehicle_options:
-        $ref: '#/definitions/VehicleOptions'
-      vehicle_nickname:
-        $ref: '#/definitions/VehicleNickname'
-      empty_weight:
-        type: number
-        x-nullable: true
-      full_weight:
-        type: number
-        x-nullable: true
-      weight_ticket_date:
-        type: string
-        example: '2018-04-26'
-        format: date
-        title: Weight ticket date
-        x-nullable: true
-  VehicleNickname:
-    type: string
-    x-nullable: true
-    title: Vehicle nickname (ex. "My car")
 paths:
   /estimates/ppm:
     get:
@@ -4230,7 +4278,6 @@ paths:
           description: user is not authorized
         500:
           description: internal server error
-
   /dps_auth/cookie_url:
     post:
       summary: Returns the URL to redirect to that begins DPS auth
@@ -4260,3 +4307,35 @@ paths:
           description: user is not authorized
         500:
           description: internal server error
+  /moves/{moveId}/weight_ticket:
+    post:
+      summary: Creates a weight ticket document
+      description: Created a weight ticket document with the given information
+      operationId: createWeightTicketDocument
+      tags:
+        - move_docs
+      parameters:
+        - name: moveId
+          in: path
+          type: string
+          format: uuid
+          required: true
+          description: UUID of the move
+        - in: body
+          name: createWeightTicketDocument
+          required: true
+          schema:
+            $ref: '#/definitions/CreateWeightTicketDocumentsPayload'
+      responses:
+        200:
+          description: returns new weight ticket document object
+          schema:
+            $ref: '#/definitions/MoveDocumentPayload'
+        400:
+          description: invalid request
+        401:
+          description: must be authenticated to use this endpoint
+        403:
+          description: not authorized to modify this move
+        500:
+          description: server error

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -964,8 +964,6 @@ definitions:
       - personally_procured_move_id
       - vehicle_options
       - vehicle_nickname
-      - empty_weight
-      - full_weight
       - weight_ticket_date
   ServiceMemberPayload:
     type: object


### PR DESCRIPTION
## Description

Currently, weight tickets are stored as generic move documents in the `move_documents` table. The new PPM closeout flow requires that we store each set of weight tickets (full, empty) with additional details similar to expenses. This PR creates a `weight_ticket_set_documents` table and the associated GET / POST endpoints.

## Reviewer Notes

The POST endpoint follows the pattern of expenses in creating a move document that links to the detail table. The GET endpoint also follows the pattern of expenses, with a weight ticket set being retrieved along with the other move documents. 

## Setup

```sh
make server_test
```

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/tree/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/tree/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/tree/master/docs/database.md#zero-downtime-migrations))
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/n/projects/2181745) for this change