### PR TITLE
Devlocal login using email

### DIFF
--- a/pkg/auth/authentication/devlocal.go
+++ b/pkg/auth/authentication/devlocal.go
@@ -66,8 +66,11 @@ func (h UserListHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	type TemplateData struct {
 		Identities      []models.UserIdentity
+		IsMilApp        bool
 		MilMoveUserType string
+		IsOfficeApp     bool
 		OfficeUserType  string
+		IsTspApp        bool
 		TspUserType     string
 		DpsUserType     string
 		AdminUserType   string
@@ -77,8 +80,11 @@ func (h UserListHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	templateData := TemplateData{
 		Identities:      identities,
+		IsMilApp:        auth.MilApp == session.ApplicationName,
 		MilMoveUserType: MilMoveUserType,
+		IsOfficeApp:     auth.OfficeApp == session.ApplicationName,
 		OfficeUserType:  OfficeUserType,
+		IsTspApp:        auth.TspApp == session.ApplicationName,
 		TspUserType:     TspUserType,
 		DpsUserType:     DpsUserType,
 		AdminUserType:   AdminUserType,
@@ -130,26 +136,12 @@ func (h UserListHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 			<div class="col-md-4">
 			  <h2 class="mt-4">Create a New User</h1>
-			  <p>Creating new users for different sites will mean you need to redirect and log in yourself.</p>
+			  {{ if $.IsMilApp }}
 			  <form method="post" action="/devlocal-auth/new">
 				<p>
 				  <input type="hidden" name="gorilla.csrf.Token" value="{{.CsrfToken}}">
 				  <input type="hidden" name="userType" value="{{.MilMoveUserType}}">
 				  <button type="submit" data-hook="new-user-login-{{.MilMoveUserType}}">Create a New {{.MilMoveUserType}} User</button>
-				</p>
-			  </form>
-			  <form method="post" action="/devlocal-auth/new">
-				<p>
-				  <input type="hidden" name="gorilla.csrf.Token" value="{{.CsrfToken}}">
-				  <input type="hidden" name="userType" value="{{.OfficeUserType}}">
-				  <button type="submit" data-hook="new-user-login-{{.OfficeUserType}}">Create a New {{.OfficeUserType}} User</button>
-				</p>
-			  </form>
-			  <form method="post" action="/devlocal-auth/new">
-				<p>
-				  <input type="hidden" name="gorilla.csrf.Token" value="{{.CsrfToken}}">
-				  <input type="hidden" name="userType" value="{{.TspUserType}}">
-				  <button type="submit" data-hook="new-user-login-{{.TspUserType}}">Create a New {{.TspUserType}} User</button>
 				</p>
 			  </form>
 			  <form method="post" action="/devlocal-auth/new">
@@ -166,6 +158,23 @@ func (h UserListHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				  <button type="submit" data-hook="new-user-login-{{.AdminUserType}}">Create a New {{.AdminUserType}} User</button>
 				</p>
 			  </form>
+			  {{else if $.IsOfficeApp }}
+			  <form method="post" action="/devlocal-auth/new">
+				<p>
+				  <input type="hidden" name="gorilla.csrf.Token" value="{{.CsrfToken}}">
+				  <input type="hidden" name="userType" value="{{.OfficeUserType}}">
+				  <button type="submit" data-hook="new-user-login-{{.OfficeUserType}}">Create a New {{.OfficeUserType}} User</button>
+				</p>
+			  </form>
+			  {{else if $.IsTspApp }}
+			  <form method="post" action="/devlocal-auth/new">
+				<p>
+				  <input type="hidden" name="gorilla.csrf.Token" value="{{.CsrfToken}}">
+				  <input type="hidden" name="userType" value="{{.TspUserType}}">
+				  <button type="submit" data-hook="new-user-login-{{.TspUserType}}">Create a New {{.TspUserType}} User</button>
+				</p>
+			  </form>
+			  {{end}}
 			</div>
 		  </div>
 		</div> <!-- container -->

--- a/pkg/models/user.go
+++ b/pkg/models/user.go
@@ -10,6 +10,8 @@ import (
 	"github.com/gobuffalo/validate/validators"
 	"github.com/gofrs/uuid"
 	"github.com/pkg/errors"
+
+	"github.com/transcom/mymove/pkg/auth"
 )
 
 // User is an entity with a registered uuid and email at login.gov
@@ -131,10 +133,39 @@ func FetchUserIdentity(db *pop.Connection, loginGovID string) (*UserIdentity, er
 	return &identities[0], nil
 }
 
-// FetchAllUserIdentities returns information for all users in the db
-func FetchAllUserIdentities(db *pop.Connection) ([]UserIdentity, error) {
+// FetchAppUserIdentities returns a limited set of user records based on application
+func FetchAppUserIdentities(db *pop.Connection, appname auth.Application, limit int) ([]UserIdentity, error) {
 	var identities []UserIdentity
-	query := `SELECT users.id,
+
+	var query string
+	switch appname {
+	case auth.OfficeApp:
+		query = `SELECT
+		        users.id,
+				users.login_gov_email AS email,
+				users.disabled AS disabled,
+				users.is_superuser AS is_superuser,
+				ou.id AS ou_id,
+				ou.first_name AS ou_fname,
+				ou.last_name AS ou_lname,
+				ou.middle_initials AS ou_middle
+			FROM office_users as ou
+			JOIN users on ou.user_id = users.id
+			ORDER BY users.created_at LIMIT $1`
+	case auth.TspApp:
+		query = `SELECT users.id,
+				users.login_gov_email AS email,
+				users.disabled AS disabled,
+				users.is_superuser AS is_superuser,
+				tu.id AS tu_id,
+				tu.first_name AS tu_fname,
+				tu.last_name AS tu_lname,
+				tu.middle_initials AS tu_middle
+			FROM tsp_users as tu
+			JOIN users on tu.user_id = users.id
+			ORDER BY users.created_at LIMIT $1`
+	default:
+		query = `SELECT users.id,
 				users.login_gov_email AS email,
 				users.disabled AS disabled,
 				users.is_superuser AS is_superuser,
@@ -142,23 +173,14 @@ func FetchAllUserIdentities(db *pop.Connection) ([]UserIdentity, error) {
 				sm.first_name AS sm_fname,
 				sm.last_name AS sm_lname,
 				sm.middle_name AS sm_middle,
-				ou.id AS ou_id,
-				ou.first_name AS ou_fname,
-				ou.last_name AS ou_lname,
-				ou.middle_initials AS ou_middle,
-				tu.id AS tu_id,
-				tu.first_name AS tu_fname,
-				tu.last_name AS tu_lname,
-				tu.middle_initials AS tu_middle,
 				du.id AS du_id
-			FROM users
-			LEFT OUTER JOIN service_members AS sm on sm.user_id = users.id
-			LEFT OUTER JOIN office_users AS ou on ou.user_id = users.id
-			LEFT OUTER JOIN tsp_users AS tu on tu.user_id = users.id
+			FROM service_members as sm
+			JOIN users on sm.user_id = users.id
 			LEFT OUTER JOIN dps_users AS du on du.login_gov_email = users.login_gov_email
-			ORDER BY users.created_at`
+			ORDER BY users.created_at LIMIT $1`
+	}
 
-	err := db.RawQuery(query).All(&identities)
+	err := db.RawQuery(query, limit).All(&identities)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/models/user.go
+++ b/pkg/models/user.go
@@ -49,11 +49,24 @@ func (u *User) ValidateUpdate(tx *pop.Connection) (*validate.Errors, error) {
 	return validate.NewErrors(), nil
 }
 
-// GetUser loads the associated User from the DB
+// GetUser loads the associated User from the DB using the user ID
 func GetUser(db *pop.Connection, userID uuid.UUID) (*User, error) {
 	var user User
-	err := db.Find(&user, userID)
-	return &user, err
+	err := db.Find(&user, userID.String())
+	if err != nil {
+		return nil, errors.Wrapf(err, "Unable to find user by id %s", userID.String())
+	}
+	return &user, nil
+}
+
+// GetUserFromEmail loads the associated User from the DB using the user email
+func GetUserFromEmail(db *pop.Connection, email string) (*User, error) {
+	users := []User{}
+	err := db.Where("login_gov_email = $1", email).All(&users)
+	if len(users) == 0 {
+		return nil, errors.Wrapf(err, "Unable to find user by email %s", email)
+	}
+	return &users[0], err
 }
 
 // CreateUser is called upon successful login.gov verification of a new user

--- a/pkg/models/user_test.go
+++ b/pkg/models/user_test.go
@@ -1,8 +1,11 @@
 package models_test
 
 import (
+	"testing"
+
 	"github.com/gofrs/uuid"
 
+	"github.com/transcom/mymove/pkg/auth"
 	. "github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"
 )
@@ -151,44 +154,80 @@ func (suite *ModelSuite) TestFetchUserIdentity() {
 	suite.Nil(identity.TspUserID)
 }
 
-func (suite *ModelSuite) TestFetchAllUserIdentities() {
-	testdatagen.MakeDefaultUser(suite.DB())
-	testdatagen.MakeDefaultServiceMember(suite.DB())
-	testdatagen.MakeDefaultOfficeUser(suite.DB())
-	testdatagen.MakeDefaultTspUser(suite.DB())
-	testdatagen.MakeUser(suite.DB(), testdatagen.Assertions{
-		User: User{
-			IsSuperuser: true,
-		},
+func (suite *ModelSuite) TestFetchAppUserIdentities() {
+
+	suite.T().Run("default user no profile", func(t *testing.T) {
+		testdatagen.MakeDefaultUser(suite.DB())
+		identities, err := FetchAppUserIdentities(suite.DB(), auth.MilApp, 5)
+		suite.Nil(err)
+		suite.Empty(identities)
 	})
 
-	identities, err := FetchAllUserIdentities(suite.DB())
-	suite.Nil(err)
-	suite.NotEmpty(identities)
-	suite.Equal(len(identities), 5)
+	suite.T().Run("service member", func(t *testing.T) {
 
-	suite.Nil(identities[0].ServiceMemberID)
-	suite.Nil(identities[0].OfficeUserID)
-	suite.Nil(identities[0].TspUserID)
-	suite.False(identities[0].IsSuperuser)
+		// Regular service member
+		testdatagen.MakeDefaultServiceMember(suite.DB())
+		identities, err := FetchAppUserIdentities(suite.DB(), auth.MilApp, 5)
+		suite.Nil(err)
+		suite.NotEmpty(identities)
+		suite.Equal(1, len(identities))
 
-	suite.NotNil(identities[1].ServiceMemberID)
-	suite.Nil(identities[1].OfficeUserID)
-	suite.Nil(identities[1].TspUserID)
-	suite.False(identities[1].IsSuperuser)
+		if len(identities) > 1 {
+			suite.NotNil(identities[0].ServiceMemberID)
+			suite.Nil(identities[0].OfficeUserID)
+			suite.Nil(identities[0].TspUserID)
+			suite.False(identities[0].IsSuperuser)
+		}
 
-	suite.Nil(identities[2].ServiceMemberID)
-	suite.NotNil(identities[2].OfficeUserID)
-	suite.Nil(identities[2].TspUserID)
-	suite.False(identities[2].IsSuperuser)
+		// Service member is super user
+		testdatagen.MakeServiceMember(suite.DB(), testdatagen.Assertions{
+			User: User{
+				IsSuperuser: true,
+			},
+		})
+		identities, err = FetchAppUserIdentities(suite.DB(), auth.MilApp, 5)
+		suite.Nil(err)
+		suite.NotEmpty(identities)
+		suite.Equal(2, len(identities))
 
-	suite.Nil(identities[3].ServiceMemberID)
-	suite.Nil(identities[3].OfficeUserID)
-	suite.NotNil(identities[3].TspUserID)
-	suite.False(identities[3].IsSuperuser)
+		if len(identities) == 2 {
+			suite.NotNil(identities[1].ServiceMemberID)
+			suite.Nil(identities[1].OfficeUserID)
+			suite.Nil(identities[1].TspUserID)
+			suite.True(identities[1].IsSuperuser)
+		}
+	})
 
-	suite.Nil(identities[0].ServiceMemberID)
-	suite.Nil(identities[0].OfficeUserID)
-	suite.Nil(identities[0].TspUserID)
-	suite.True(identities[4].IsSuperuser)
+	// In the following tests you won't see extra users returned. Eeach query is
+	// limited by the app it expects to be run in.
+
+	suite.T().Run("office user", func(t *testing.T) {
+		testdatagen.MakeDefaultOfficeUser(suite.DB())
+		identities, err := FetchAppUserIdentities(suite.DB(), auth.OfficeApp, 5)
+		suite.Nil(err)
+		suite.NotEmpty(identities)
+		suite.Equal(1, len(identities))
+
+		if len(identities) > 1 {
+			suite.Nil(identities[0].ServiceMemberID)
+			suite.NotNil(identities[0].OfficeUserID)
+			suite.Nil(identities[0].TspUserID)
+			suite.False(identities[0].IsSuperuser)
+		}
+	})
+
+	suite.T().Run("tsp user", func(t *testing.T) {
+		testdatagen.MakeDefaultTspUser(suite.DB())
+		identities, err := FetchAppUserIdentities(suite.DB(), auth.TspApp, 5)
+		suite.Nil(err)
+		suite.NotEmpty(identities)
+		suite.Equal(1, len(identities))
+
+		if len(identities) > 1 {
+			suite.Nil(identities[0].ServiceMemberID)
+			suite.Nil(identities[0].OfficeUserID)
+			suite.NotNil(identities[0].TspUserID)
+			suite.False(identities[0].IsSuperuser)
+		}
+	})
 }

--- a/pkg/models/user_test.go
+++ b/pkg/models/user_test.go
@@ -231,3 +231,23 @@ func (suite *ModelSuite) TestFetchAppUserIdentities() {
 		}
 	})
 }
+
+func (suite *ModelSuite) TestGetUser() {
+
+	alice := testdatagen.MakeDefaultUser(suite.DB())
+
+	user1, err := GetUserFromEmail(suite.DB(), alice.LoginGovEmail)
+	suite.Nil(err, "loading alice's user")
+	suite.NotNil(user1)
+	if err == nil && user1 != nil {
+		suite.Equal(alice.ID, user1.ID)
+		suite.Equal(alice.LoginGovEmail, user1.LoginGovEmail)
+	}
+
+	user2, err := GetUser(suite.DB(), alice.ID)
+	suite.Nil(err, "loading alice's user")
+	suite.NotNil(user2)
+	if err == nil && user2 != nil {
+		suite.Equal(alice.ID, user2.ID)
+	}
+}


### PR DESCRIPTION
## Description

Several changes here:

- Can log in as a user given an email address in a text box
- Only users for the app that is being used are shown (ie no office users shown in service member site)
- Only creation buttons exist for app that is being used (ie can't create TSP user from service member site)

This came up because I need to keep track of where I am in creating load testing personas by hand and logging back into them. However load testing can create 100s-1000s of users so I can never find them in the list to log in.

## Setup

Go to each app and try out local sign in.

## Code Review Verification Steps

* [x] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/tree/master/docs/backend.md#logging)
* [x] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/tree/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## Screenshot

<img width="1549" alt="Screen Shot 2019-06-06 at 11 19 39 AM" src="https://user-images.githubusercontent.com/219296/59056424-b0d19b00-8887-11e9-8593-32626b0f26a5.png">

