### PR TITLE
Ignore mnt directory and increase database timeout

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,6 +12,7 @@ coverage.out
 __snapshots__
 
 # development
+/mnt
 /tmp
 
 # Ignore

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ __snapshots__
 /build
 
 # development
+/mnt
 /tmp
 
 # All compiled binaries

--- a/scripts/wait-for-db
+++ b/scripts/wait-for-db
@@ -11,7 +11,7 @@ db_user="${DB_USER:-postgres}"
 db_name="${DB_NAME:-postgres}"
 db_port="${DB_PORT:-5432}"
 retries=0
-timeout=10
+timeout="${DB_TIMEOUT:-20}"
 db_check_command="psql postgres://${db_user}:${db_password}@${db_host}:${db_port}/${db_name} -c 'select 1;' > /dev/null 2>&1"
 
 echo "> ${db_check_command}"

--- a/scripts/wait-for-db-docker
+++ b/scripts/wait-for-db-docker
@@ -12,7 +12,7 @@ db_user="${DB_USER:-postgres}"
 db_name="${DB_NAME:-postgres}"
 db_port="${DB_PORT:-5432}"
 retries=0
-timeout=10
+timeout="${DB_TIMEOUT:-20}"
 db_check_command="docker exec ${container} psql postgres://${db_user}:${db_password}@${db_host}:${db_port}/${db_name} -c 'select 1;' > /dev/null 2>&1"
 
 echo "> ${db_check_command}"


### PR DESCRIPTION
## Description

PR to ignore the `mnt` directory and add a database timeout.  Want to get this in to decrease the likelihood of accidental commits of `mnt`.

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Setup

None

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/tree/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/tree/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/tree/master/docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
  * [ ] Secure migrations have been tested using `scripts/run-prod-migrations`
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* Any new client dependencies (Google Analytics, hosted libraries, CDNs, etc) have been:
  * [ ] Communicated to @ntwyman
  * [ ] Added to the list of [network dependencies](https://github.com/transcom/mymove#client-network-dependencies)
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

None

## Screenshots

None