### PR TITLE
add queue to show approved hhg moves

### DIFF
--- a/cypress/integration/office/officeUserHHG.js
+++ b/cypress/integration/office/officeUserHHG.js
@@ -6,7 +6,7 @@ describe('office user finds the shipment', function() {
   it('office user views hhg moves in queue new moves', function() {
     officeUserViewsMoves();
   });
-  it('office user views accepted hhg moves in queue Accepted HHGs', function() {
+  it('office user views approved hhg moves in queue Approved HHGs', function() {
     officeUserViewsApprovedShipment();
   });
   it('office user views delivered hhg moves in queue Delivered HHGs', function() {
@@ -85,7 +85,7 @@ function officeUserViewsApprovedShipment() {
 }
 
 function officeUserApprovesOnlyBasicsHHG() {
-  // Open accepted hhg queue
+  // Open approved hhg queue
   cy.patientVisit('/queues/new');
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/queues\/new/);
@@ -132,10 +132,10 @@ function officeUserApprovesOnlyBasicsHHG() {
 }
 
 function officeUserApprovesHHG() {
-  // Open accepted hhg queue
-  cy.patientVisit('/queues/hhg_accepted');
+  // Open approved hhg queue
+  cy.patientVisit('/queues/new');
   cy.location().should(loc => {
-    expect(loc.pathname).to.match(/^\/queues\/hhg_accepted/);
+    expect(loc.pathname).to.match(/^\/queues\/new/);
   });
 
   // Find move and open it
@@ -155,7 +155,7 @@ function officeUserApprovesHHG() {
 
   cy.get('.combo-button').click();
 
-  cy.get('.status').contains('Accepted');
+  cy.get('.status').contains('Approved');
 
   // Click on HHG tab
   cy.get('[data-cy="hhg-tab"]').click();

--- a/cypress/integration/office/officeUserHHG.js
+++ b/cypress/integration/office/officeUserHHG.js
@@ -7,7 +7,7 @@ describe('office user finds the shipment', function() {
     officeUserViewsMoves();
   });
   it('office user views accepted hhg moves in queue Accepted HHGs', function() {
-    officeUserViewsAcceptedShipment();
+    officeUserViewsApprovedShipment();
   });
   it('office user views delivered hhg moves in queue Delivered HHGs', function() {
     officeUserViewsDeliveredShipment();
@@ -63,15 +63,15 @@ function officeUserViewsDeliveredShipment() {
   });
 }
 
-function officeUserViewsAcceptedShipment() {
+function officeUserViewsApprovedShipment() {
   // Open new moves queue
-  cy.patientVisit('/queues/hhg_accepted');
+  cy.patientVisit('/queues/hhg_approved');
   cy.location().should(loc => {
-    expect(loc.pathname).to.match(/^\/queues\/hhg_accepted/);
+    expect(loc.pathname).to.match(/^\/queues\/hhg_approved/);
   });
 
   // Find move (generated in e2ebasic.go) and open it
-  cy.selectQueueItemMoveLocator('BACON3');
+  cy.selectQueueItemMoveLocator('GBLGBL');
 
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/queues\/new\/moves\/[^/]+\/basics/);
@@ -82,12 +82,6 @@ function officeUserViewsAcceptedShipment() {
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/queues\/new\/moves\/[^/]+\/hhg/);
   });
-
-  // Since the shipment hasn't been picked up yet, it can be cancelled
-  cy
-    .get('button')
-    .contains('Cancel Move')
-    .should('not.be.disabled');
 }
 
 function officeUserApprovesOnlyBasicsHHG() {
@@ -153,7 +147,7 @@ function officeUserApprovesHHG() {
 
   cy.get('.combo-button').click();
 
-  // Approve basics
+  // Approve basic
   cy
     .get('.combo-button .dropdown')
     .contains('Approve Basics')

--- a/cypress/integration/office/officeUserHHG.js
+++ b/cypress/integration/office/officeUserHHG.js
@@ -147,7 +147,7 @@ function officeUserApprovesHHG() {
 
   cy.get('.combo-button').click();
 
-  // Approve basic
+  // Approve basics
   cy
     .get('.combo-button .dropdown')
     .contains('Approve Basics')

--- a/cypress/integration/office/officeUserHHGPPM.js
+++ b/cypress/integration/office/officeUserHHGPPM.js
@@ -13,8 +13,8 @@ describe('office user finds the shipment', function() {
     deliveredHHG: 'hhg_delivered',
     all: 'all',
   };
-  it('office user sees approved HHG in Approved HHGs queue', function() {
-    officeUserVisitsQueue(queues.approvedHHG);
+  it('office user sees accepted HHG in New queue', function() {
+    officeUserVisitsQueue(queues.new);
     officeUserViewsMove('COMBO2');
   });
   it('office user sees delivered HHG in Delivered HHG queue', function() {

--- a/cypress/integration/office/officeUserHHGPPM.js
+++ b/cypress/integration/office/officeUserHHGPPM.js
@@ -9,12 +9,12 @@ describe('office user finds the shipment', function() {
   const queues = {
     new: 'new',
     ppm: 'ppm',
-    acceptedHHG: 'hhg_accepted',
+    approvedHHG: 'hhg_approved',
     deliveredHHG: 'hhg_delivered',
     all: 'all',
   };
-  it('office user sees accepted HHG in Accepted HHGs queue', function() {
-    officeUserVisitsQueue(queues.acceptedHHG);
+  it('office user sees approved HHG in Approved HHGs queue', function() {
+    officeUserVisitsQueue(queues.approvedHHG);
     officeUserViewsMove('COMBO2');
   });
   it('office user sees delivered HHG in Delivered HHG queue', function() {

--- a/cypress/integration/office/storageInTransitPanel.js
+++ b/cypress/integration/office/storageInTransitPanel.js
@@ -27,10 +27,10 @@ describe('office user finds the shipment', function() {
 });
 
 function officeUserViewsSITPanel() {
-  // Open hhg_accepted moves queue
-  cy.patientVisit('/queues/hhg_accepted');
+  // Open new moves queue
+  cy.patientVisit('/queues/new');
   cy.location().should(loc => {
-    expect(loc.pathname).to.match(/^\/queues\/hhg_accepted/);
+    expect(loc.pathname).to.match(/^\/queues\/new/);
   });
 
   // Find move (generated in e2ebasic.go) and open it
@@ -80,10 +80,10 @@ function officeUserViewsSITPanel() {
 }
 
 function officeUserStartsAndCancelsSitApproval() {
-  // Open hhg_accepted moves queue
-  cy.patientVisit('/queues/hhg_accepted');
+  // Open new moves queue
+  cy.patientVisit('/queues/new');
   cy.location().should(loc => {
-    expect(loc.pathname).to.match(/^\/queues\/hhg_accepted/);
+    expect(loc.pathname).to.match(/^\/queues\/new/);
   });
 
   // Find move (generated in e2ebasic.go) and open it
@@ -167,10 +167,10 @@ function officeUserStartsAndCancelsSitEdit() {
 }
 
 function officeUserApprovesSITRequest() {
-  // Open hhg_accepted moves queue
-  cy.patientVisit('/queues/hhg_accepted');
+  // Open new moves queue
+  cy.patientVisit('/queues/new');
   cy.location().should(loc => {
-    expect(loc.pathname).to.match(/^\/queues\/hhg_accepted/);
+    expect(loc.pathname).to.match(/^\/queues\/new/);
   });
 
   // Find move (generated in e2ebasic.go) and open it
@@ -200,7 +200,7 @@ function officeUserApprovesSITRequest() {
 
   cy.get('input[name="authorized_start_date"]').should('have.value', '3/22/2019');
 
-  cy.get('textarea[name="authorization_notes"]').type('this is a note', { force: true, delay: 150 });
+  cy.get('textarea[name="authorization_notes"]').type('this is a note', { force: true });
 
   cy
     .get('[data-cy="storage-in-transit-approve-button"]')
@@ -217,10 +217,10 @@ function officeUserApprovesSITRequest() {
   cy.get('[data-cy="sit-edit-link"]').click();
 
   cy.get('input[name="authorized_start_date"]').clear();
-  cy.get('input[name="authorized_start_date"]').type('3/23/2019', { force: true, delay: 150 });
+  cy.get('input[name="authorized_start_date"]').type('3/23/2019', { force: true });
   cy.get('input[name="authorized_start_date"]').should('have.value', '3/23/2019');
 
-  cy.get('textarea[name="authorization_notes"]').type('this is also a note', { force: true, delay: 150 });
+  cy.get('textarea[name="authorization_notes"]').type('this is also a note', { force: true });
 
   cy
     .get('[data-cy="sit-editor-save-button"]')
@@ -234,10 +234,10 @@ function officeUserApprovesSITRequest() {
 }
 
 function officeUserDeniesSITRequest() {
-  // Open hhg_accepted moves queue
-  cy.patientVisit('/queues/hhg_accepted');
+  // Open new moves queue
+  cy.patientVisit('/queues/new');
   cy.location().should(loc => {
-    expect(loc.pathname).to.match(/^\/queues\/hhg_accepted/);
+    expect(loc.pathname).to.match(/^\/queues\/new/);
   });
 
   // Find move (generated in e2ebasic.go) and open it
@@ -275,7 +275,7 @@ function officeUserDeniesSITRequest() {
 
   cy.get('[data-cy="sit-edit-link"]').click();
 
-  cy.get('textarea[name="authorization_notes"]').type('this is also a note', { force: true, delay: 150 });
+  cy.get('textarea[name="authorization_notes"]').type('this is also a note', { force: true });
 
   cy
     .get('[data-cy="sit-editor-save-button"]')

--- a/pkg/models/queue.go
+++ b/pkg/models/queue.go
@@ -89,7 +89,8 @@ func GetMoveQueueItems(db *pop.Connection, lifecycleState string) ([]MoveQueueIt
 			WHERE moves.status = 'APPROVED'
 			and moves.show is true
 		`
-	} else if lifecycleState == "hhg_accepted" {
+	} else if lifecycleState == "hhg_approved" {
+
 		// Move date is the Requested Pickup Date because accepted shipments haven't yet gone through the
 		// premove survey to set the actual Pickup Date.
 		query = `
@@ -109,7 +110,7 @@ func GetMoveQueueItems(db *pop.Connection, lifecycleState string) ([]MoveQueueIt
 			JOIN orders as ord ON moves.orders_id = ord.id
 			JOIN service_members AS sm ON ord.service_member_id = sm.id
 			LEFT JOIN shipments as shipment ON moves.id = shipment.move_id
-			WHERE shipment.status = 'ACCEPTED'
+			WHERE shipment.status = 'APPROVED'
 			and moves.show is true
 		`
 	} else if lifecycleState == "hhg_in_transit" {

--- a/pkg/testdatagen/scenario/e2ebasic.go
+++ b/pkg/testdatagen/scenario/e2ebasic.go
@@ -2988,7 +2988,6 @@ func MakeHhgWithPpm(db *pop.Connection, tspUser models.TspUser, loader *uploader
 			PmSurveyWeightEstimate:      &weightEstimate,
 			SourceGBLOC:                 &sourceOffice.Gbloc,
 			DestinationGBLOC:            &destOffice.Gbloc,
-			GBLNumber:                   &GBLNumber,
 		},
 		ShipmentOffer: models.ShipmentOffer{
 			TransportationServiceProviderID: tspUser.TransportationServiceProviderID,
@@ -3073,6 +3072,7 @@ func MakeHhgFromAwardedToAcceptedGBLReady(db *pop.Connection, tspUser models.Tsp
 			PmSurveyWeightEstimate:      &weightEstimate,
 			SourceGBLOC:                 &sourceOffice.Gbloc,
 			DestinationGBLOC:            &destOffice.Gbloc,
+			GBLNumber:                   &GBLNumber,
 		},
 		ShipmentOffer: models.ShipmentOffer{
 			TransportationServiceProviderID: tspUser.TransportationServiceProviderID,

--- a/pkg/testdatagen/scenario/e2ebasic.go
+++ b/pkg/testdatagen/scenario/e2ebasic.go
@@ -2755,7 +2755,7 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, log
 			Edipi:         models.StringPointer("7617044099"),
 			PersonalEmail: models.StringPointer(email),
 		},
-		// These values should be populaten for an approved move
+		// These values should be populated for an approved move
 		Order: models.Order{
 			OrdersNumber:        models.StringPointer("12345"),
 			OrdersTypeDetail:    &typeDetails,

--- a/pkg/testdatagen/scenario/e2ebasic.go
+++ b/pkg/testdatagen/scenario/e2ebasic.go
@@ -2988,6 +2988,7 @@ func MakeHhgWithPpm(db *pop.Connection, tspUser models.TspUser, loader *uploader
 			PmSurveyWeightEstimate:      &weightEstimate,
 			SourceGBLOC:                 &sourceOffice.Gbloc,
 			DestinationGBLOC:            &destOffice.Gbloc,
+			GBLNumber:                   &GBLNumber,
 		},
 		ShipmentOffer: models.ShipmentOffer{
 			TransportationServiceProviderID: tspUser.TransportationServiceProviderID,
@@ -3017,7 +3018,6 @@ func MakeHhgFromAwardedToAcceptedGBLReady(db *pop.Connection, tspUser models.Tsp
 	 * Service member with uploaded orders and an approved shipment to be accepted, able to generate GBL
 	 */
 	email := "hhg@govbilloflading.ready"
-
 	ordersTypeDetail := internalmessages.OrdersTypeDetailHHGPERMITTED
 	weightEstimate := unit.Pound(5000)
 	sourceOffice := testdatagen.MakeTransportationOffice(db, testdatagen.Assertions{
@@ -3030,6 +3030,7 @@ func MakeHhgFromAwardedToAcceptedGBLReady(db *pop.Connection, tspUser models.Tsp
 			Gbloc: "QRED",
 		},
 	})
+	GBLNumber := destOffice.Gbloc + "001234"
 	offer9 := testdatagen.MakeShipmentOffer(db, testdatagen.Assertions{
 		User: models.User{
 			ID:            uuid.Must(uuid.FromString("658f3a78-b3a9-47f4-a820-af673103d62d")),

--- a/pkg/testdatagen/scenario/e2ebasic.go
+++ b/pkg/testdatagen/scenario/e2ebasic.go
@@ -948,6 +948,13 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, log
 			ID:               uuid.FromStringOrNil("616560f2-7e35-4504-b7e6-69038fb0c015"),
 			Locator:          "APPRVD",
 			SelectedMoveType: &selectedMoveTypeHHG,
+			Status:           models.MoveStatusAPPROVED,
+		},
+		Order: models.Order{
+			OrdersNumber:        models.StringPointer("54321"),
+			OrdersTypeDetail:    &typeDetail,
+			DepartmentIndicator: models.StringPointer("AIR_FORCE"),
+			TAC:                 models.StringPointer("99"),
 		},
 		TrafficDistributionList: models.TrafficDistributionList{
 			ID:                uuid.FromStringOrNil("5fe59be4-45d0-47c7-b426-cf4db9882af7"),
@@ -1496,10 +1503,18 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, log
 			Edipi:         models.StringPointer("2232332334"),
 			PersonalEmail: models.StringPointer(email),
 		},
+		// These values should be populated for an approved move
+		Order: models.Order{
+			OrdersNumber:        models.StringPointer("12345"),
+			OrdersTypeDetail:    &typeDetail,
+			DepartmentIndicator: models.StringPointer("AIR_FORCE"),
+			TAC:                 models.StringPointer("99"),
+		},
 		Move: models.Move{
 			ID:               uuid.FromStringOrNil("60098ff1-8dc9-4318-a2e8-47bc8aac11a4"),
 			Locator:          "GOTDOC",
 			SelectedMoveType: &selectedMoveTypeHHG,
+			Status:           models.MoveStatusAPPROVED,
 		},
 		TrafficDistributionList: models.TrafficDistributionList{
 			ID:                uuid.FromStringOrNil("7ad595da-9b34-4914-aeaa-9a540d13872f"),
@@ -1554,10 +1569,18 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, log
 			Edipi:         models.StringPointer("4424567890"),
 			PersonalEmail: models.StringPointer(email),
 		},
+		// These values should be populated for an approved move
+		Order: models.Order{
+			OrdersNumber:        models.StringPointer("12345"),
+			OrdersTypeDetail:    &typeDetail,
+			DepartmentIndicator: models.StringPointer("AIR_FORCE"),
+			TAC:                 models.StringPointer("99"),
+		},
 		Move: models.Move{
 			ID:               uuid.FromStringOrNil("42d85649-18c2-44ad-854d-da8884579f42"),
 			Locator:          "ENTPMS",
 			SelectedMoveType: &selectedMoveTypeHHG,
+			Status:           models.MoveStatusAPPROVED,
 		},
 		TrafficDistributionList: models.TrafficDistributionList{
 			ID:                uuid.FromStringOrNil("f426c4fc-a2fb-45b6-a3a6-7c35357ab79a"),
@@ -1929,10 +1952,18 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, log
 			Edipi:         models.StringPointer("4124337809"),
 			PersonalEmail: models.StringPointer(email),
 		},
+		// These values should be populated for an approved move
+		Order: models.Order{
+			OrdersNumber:        models.StringPointer("12345"),
+			OrdersTypeDetail:    &typeDetail,
+			DepartmentIndicator: models.StringPointer("AIR_FORCE"),
+			TAC:                 models.StringPointer("99"),
+		},
 		Move: models.Move{
 			ID:               uuid.FromStringOrNil("8c03b5a5-2ca5-49c1-a5a0-12f56c5f15c7"),
 			Locator:          "APPPMS",
 			SelectedMoveType: &selectedMoveTypeHHG,
+			Status:           models.MoveStatusAPPROVED,
 		},
 		TrafficDistributionList: models.TrafficDistributionList{
 			ID:                uuid.FromStringOrNil("e2351f50-9b07-4e6a-85eb-7c622486e859"),
@@ -2724,7 +2755,7 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, log
 			Edipi:         models.StringPointer("7617044099"),
 			PersonalEmail: models.StringPointer(email),
 		},
-		// These values should be populated for an approved move
+		// These values should be populaten for an approved move
 		Order: models.Order{
 			OrdersNumber:        models.StringPointer("12345"),
 			OrdersTypeDetail:    &typeDetails,
@@ -2987,6 +3018,7 @@ func MakeHhgFromAwardedToAcceptedGBLReady(db *pop.Connection, tspUser models.Tsp
 	 */
 	email := "hhg@govbilloflading.ready"
 
+	ordersTypeDetail := internalmessages.OrdersTypeDetailHHGPERMITTED
 	weightEstimate := unit.Pound(5000)
 	sourceOffice := testdatagen.MakeTransportationOffice(db, testdatagen.Assertions{
 		TransportationOffice: models.TransportationOffice{
@@ -3014,11 +3046,13 @@ func MakeHhgFromAwardedToAcceptedGBLReady(db *pop.Connection, tspUser models.Tsp
 			DepartmentIndicator: models.StringPointer("AIR_FORCE"),
 			TAC:                 models.StringPointer("NTA4"),
 			SAC:                 models.StringPointer("1234567890 9876543210"),
+			OrdersTypeDetail:    &ordersTypeDetail,
 		},
 		Move: models.Move{
 			ID:               uuid.FromStringOrNil("05a58b2e-07da-4b41-b4f8-d18ab68dddd5"),
 			Locator:          "GBLGBL",
 			SelectedMoveType: &selectedMoveTypeHHG,
+			Status:           models.MoveStatusAPPROVED,
 		},
 		TrafficDistributionList: models.TrafficDistributionList{
 			ID:                uuid.FromStringOrNil("b15fdc2b-52cd-4b3e-91ba-a36d6ab94a16"),
@@ -3065,6 +3099,7 @@ func MakeHhgWithGBL(db *pop.Connection, tspUser models.TspUser, logger Logger, s
 	 * Service member with uploaded orders and an approved shipment to be accepted, able to generate GBL
 	 */
 	email := "hhg@gov_bill_of_lading.created"
+	ordersTypeDetail := internalmessages.OrdersTypeDetailHHGPERMITTED
 
 	weightEstimate := unit.Pound(5000)
 	sourceOffice := testdatagen.MakeTransportationOffice(db, testdatagen.Assertions{
@@ -3093,11 +3128,13 @@ func MakeHhgWithGBL(db *pop.Connection, tspUser models.TspUser, logger Logger, s
 			DepartmentIndicator: models.StringPointer("17"),
 			TAC:                 models.StringPointer("NTA4"),
 			SAC:                 models.StringPointer("1234567890 9876543210"),
+			OrdersTypeDetail:    &ordersTypeDetail,
 		},
 		Move: models.Move{
 			ID:               uuid.FromStringOrNil("6eee3663-1973-40c5-b49e-e70e9325b895"),
 			Locator:          "CONGBL",
 			SelectedMoveType: &selectedMoveTypeHHG,
+			Status:           models.MoveStatusAPPROVED,
 		},
 		TrafficDistributionList: models.TrafficDistributionList{
 			ID:                uuid.FromStringOrNil("87fcebf6-63b8-40cb-bc40-b553f5b91b9c"),

--- a/scripts/find-invoices
+++ b/scripts/find-invoices
@@ -9,7 +9,7 @@
 # XYZ is the name of your app: mil, office, or tsp. It's a very long string.
 #
 # Valid environments: staging, prod, experimental
-# Valid queue names:  all, hhg_delivered, hhg_accepted
+# Valid queue names:  new, ppm, hhg_approved, hhg_in_transit, hhg_delivered, all
 #
 
 function usage() {

--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -142,10 +142,10 @@ const ReferrerQueueLink = props => {
           <span>PPM Queue</span>
         </NavLink>
       );
-    case '/queues/hhg_accepted':
+    case '/queues/hhg_approved':
       return (
-        <NavLink to="/queues/hhg_accepted" activeClassName="usa-current">
-          <span>Accepted HHG Queue</span>
+        <NavLink to="/queues/hhg_approved" activeClassName="usa-current">
+          <span>Approved HHG Queue</span>
         </NavLink>
       );
     case '/queues/hhg_delivered':

--- a/src/scenes/Office/MoveInfo.test.js
+++ b/src/scenes/Office/MoveInfo.test.js
@@ -49,11 +49,11 @@ describe('ShipmentInfo tests', () => {
       wrapper = mount(
         <Provider store={store}>
           <MockRouter push={jest.fn()}>
-            <ReferrerQueueLink history={{ location: { state: { referrerPathname: '/queues/hhg_accepted' } } }} />
+            <ReferrerQueueLink history={{ location: { state: { referrerPathname: '/queues/hhg_approved' } } }} />
           </MockRouter>
         </Provider>,
       );
-      expect(wrapper.text()).toEqual('Accepted HHG Queue');
+      expect(wrapper.text()).toEqual('Approved HHG Queue');
     });
     it('when no referrer is set', () => {
       wrapper = mount(

--- a/src/scenes/Office/QueueList.jsx
+++ b/src/scenes/Office/QueueList.jsx
@@ -27,7 +27,7 @@ export default class QueueList extends Component {
             <NavLink
               to="#hhgshipments"
               activeClassName="usa-current"
-              isActive={isActive('hhg_accepted', 'hhg_delivered')}
+              isActive={isActive('hhg_approved', 'hhg_delivered')}
             >
               <span>HHG shipments:</span>
             </NavLink>

--- a/src/scenes/Office/QueueList.jsx
+++ b/src/scenes/Office/QueueList.jsx
@@ -33,8 +33,8 @@ export default class QueueList extends Component {
             </NavLink>
             <ul className="usa-sidenav-sub_list">
               <li>
-                <NavLink to="/queues/hhg_accepted" activeClassName="usa-current">
-                  <span>Accepted</span>
+                <NavLink to="/queues/hhg_approved" activeClassName="usa-current">
+                  <span>Approved</span>
                 </NavLink>
               </li>
               <li>

--- a/src/scenes/Office/QueueTable.jsx
+++ b/src/scenes/Office/QueueTable.jsx
@@ -109,7 +109,7 @@ class QueueTable extends Component {
       new: 'New Moves/Shipments',
       troubleshooting: 'Troubleshooting',
       ppm: 'PPMs',
-      hhg_accepted: 'Accepted HHGs',
+      hhg_approved: 'Approved HHGs',
       hhg_delivered: 'Delivered HHGs',
       all: 'All Moves',
     };

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -4235,6 +4235,7 @@ paths:
             - troubleshooting
             - ppm
             - hhg_accepted
+            - hhg_approved
             - hhg_delivered
             - all
           required: true

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -4234,7 +4234,6 @@ paths:
             - new
             - troubleshooting
             - ppm
-            - hhg_accepted
             - hhg_approved
             - hhg_delivered
             - all


### PR DESCRIPTION
## Description

Remove the `Accepted` queue (these moves are shown in the `New Moves` queue).
Add `Approved` queue to show hhg moves that have been approved by the office.

## Reviewer Notes

Ensure approved moves show in the `Approved` queue.

## Setup

`make db_dev_e2e_populate`
`make server_run`
`make office_client_run`

## Code Review Verification Steps

* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/166091600) for this change

## Screenshots
<img width="1680" alt="Screen Shot 2019-06-10 at 10 56 41 AM" src="https://user-images.githubusercontent.com/3099491/59208328-7bba9680-8b6e-11e9-86cf-2dab7464f275.png">
