### PR TITLE
fix warning emitting for minDate usage in client test

### DIFF
--- a/src/shared/StorageInTransit/ReleaseFromSitForm.test.jsx
+++ b/src/shared/StorageInTransit/ReleaseFromSitForm.test.jsx
@@ -22,10 +22,11 @@ const storageInTransitSchema = {
 describe('ReleaseFromSitForm tests', () => {
   describe('Pre-filled form', () => {
     let wrapper;
+    let minDate = new Date('2019-03-08');
     store = mockStore({});
     wrapper = mount(
       <Provider store={store}>
-        <ReleaseFromSitForm onSubmit={submit} storageInTransitSchema={storageInTransitSchema} />
+        <ReleaseFromSitForm minDate={minDate} onSubmit={submit} storageInTransitSchema={storageInTransitSchema} />
       </Provider>,
     );
 


### PR DESCRIPTION
## Description

Client test emitting warning for not using `minDate` field. Initialize field in test to resolve issue.

## Reviewer Notes

n/a

## Setup


```sh
make client_test
```
filter on ReleaseFromSitForm

## Code Review Verification Steps

* [X] Request review from a member of a different team.
* [X] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/166590881) for this change


## Screenshots

n/a