### PR TITLE
Be more explicit in naming

### DIFF
--- a/pkg/handlers/publicapi/api.go
+++ b/pkg/handlers/publicapi/api.go
@@ -124,7 +124,7 @@ func NewPublicAPIHandler(context handlers.HandlerContext) http.Handler {
 	publicAPI.AccesscodeClaimAccessCodeHandler = ClaimAccessCodeHandler{context, accesscodeservice.NewAccessCodeClaimer(context.DB())}
 
 	// Postal Codes
-	publicAPI.PostalCodesValidatePostalCodeHandler = ValidatePostalCodeHandler{
+	publicAPI.PostalCodesValidatePostalCodeWithRateDataHandler = ValidatePostalCodeWithRateDataHandler{
 		context,
 		postalcodeservice.NewPostalCodeValidator(context.DB()),
 	}

--- a/pkg/handlers/publicapi/postal_codes.go
+++ b/pkg/handlers/publicapi/postal_codes.go
@@ -13,14 +13,14 @@ import (
 	"github.com/transcom/mymove/pkg/services"
 )
 
-// ValidatePostalCodeHandler has the service validator
-type ValidatePostalCodeHandler struct {
+// ValidatePostalCodeWithRateDataHandler has the service validator
+type ValidatePostalCodeWithRateDataHandler struct {
 	handlers.HandlerContext
 	validatePostalCode services.PostalCodeValidator
 }
 
 // Handle should call the service validator and rescue expected errors and return false to valid
-func (h ValidatePostalCodeHandler) Handle(params postalcodesops.ValidatePostalCodeParams) middleware.Responder {
+func (h ValidatePostalCodeWithRateDataHandler) Handle(params postalcodesops.ValidatePostalCodeWithRateDataParams) middleware.Responder {
 	postalCode := params.PostalCode
 	postalCodeType := params.PostalCodeType
 
@@ -40,14 +40,14 @@ func (h ValidatePostalCodeHandler) Handle(params postalcodesops.ValidatePostalCo
 			h.Logger().Error("We do not have region rate data for destination postal code", zap.Error(err))
 		default:
 			h.Logger().Error("Validate postal code", zap.Error(err))
-			return postalcodesops.NewValidatePostalCodeBadRequest()
+			return postalcodesops.NewValidatePostalCodeWithRateDataBadRequest()
 		}
 	}
 
-	payload := apimessages.ValidatePostalCodePayload{
+	payload := apimessages.RateEnginePostalCodePayload{
 		Valid:          &valid,
 		PostalCode:     &postalCode,
 		PostalCodeType: &postalCodeType,
 	}
-	return postalcodesops.NewValidatePostalCodeOK().WithPayload(&payload)
+	return postalcodesops.NewValidatePostalCodeWithRateDataOK().WithPayload(&payload)
 }

--- a/pkg/handlers/publicapi/postal_codes_test.go
+++ b/pkg/handlers/publicapi/postal_codes_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/transcom/mymove/pkg/testdatagen"
 )
 
-func (suite *HandlerSuite) TestValidatePostalCodeHandler_Valid() {
+func (suite *HandlerSuite) TestValidatePostalCodeWithRateDataHandler_Valid() {
 	// create user
 	user := testdatagen.MakeDefaultUser(suite.DB())
 
@@ -37,7 +37,7 @@ func (suite *HandlerSuite) TestValidatePostalCodeHandler_Valid() {
 		postalCodeType,
 	).Return(true, nil)
 
-	handler := ValidatePostalCodeHandler{context, postalCodeValidator}
+	handler := ValidatePostalCodeWithRateDataHandler{context, postalCodeValidator}
 	response := handler.Handle(params)
 
 	suite.IsNotErrResponse(response)
@@ -50,7 +50,7 @@ func (suite *HandlerSuite) TestValidatePostalCodeHandler_Valid() {
 	suite.Assertions.IsType(&postalcodesops.ValidatePostalCodeOK{}, response)
 }
 
-func (suite *HandlerSuite) TestValidatePostalCodeHandler_Invalid() {
+func (suite *HandlerSuite) TestValidatePostalCodeWithRateDataHandler_Invalid() {
 	// create user
 	user := testdatagen.MakeDefaultUser(suite.DB())
 
@@ -75,7 +75,7 @@ func (suite *HandlerSuite) TestValidatePostalCodeHandler_Invalid() {
 		postalCodeType,
 	).Return(false, nil)
 
-	handler := ValidatePostalCodeHandler{context, postalCodeValidator}
+	handler := ValidatePostalCodeWithRateDataHandler{context, postalCodeValidator}
 	response := handler.Handle(params)
 
 	suite.IsNotErrResponse(response)

--- a/pkg/handlers/publicapi/postal_codes_test.go
+++ b/pkg/handlers/publicapi/postal_codes_test.go
@@ -24,7 +24,7 @@ func (suite *HandlerSuite) TestValidatePostalCodeWithRateDataHandler_Valid() {
 	request := httptest.NewRequest("GET", fmt.Sprintf("/postal_codes/%s", postalCode), strings.NewReader("postal_code_type=origin"))
 	request = suite.AuthenticateUserRequest(request, user)
 
-	params := postalcodesops.ValidatePostalCodeParams{
+	params := postalcodesops.ValidatePostalCodeWithRateDataParams{
 		HTTPRequest:    request,
 		PostalCode:     postalCode,
 		PostalCodeType: postalCodeTypeString,
@@ -41,13 +41,13 @@ func (suite *HandlerSuite) TestValidatePostalCodeWithRateDataHandler_Valid() {
 	response := handler.Handle(params)
 
 	suite.IsNotErrResponse(response)
-	validatePostalCodeResponse := response.(*postalcodesops.ValidatePostalCodeOK)
+	validatePostalCodeResponse := response.(*postalcodesops.ValidatePostalCodeWithRateDataOK)
 	validatePostalCodePayload := validatePostalCodeResponse.Payload
 
 	suite.NotNil(validatePostalCodePayload.PostalCode)
 	suite.NotNil(validatePostalCodePayload.PostalCodeType)
 	suite.True(*validatePostalCodePayload.Valid)
-	suite.Assertions.IsType(&postalcodesops.ValidatePostalCodeOK{}, response)
+	suite.Assertions.IsType(&postalcodesops.ValidatePostalCodeWithRateDataOK{}, response)
 }
 
 func (suite *HandlerSuite) TestValidatePostalCodeWithRateDataHandler_Invalid() {
@@ -62,7 +62,7 @@ func (suite *HandlerSuite) TestValidatePostalCodeWithRateDataHandler_Invalid() {
 	request := httptest.NewRequest("GET", fmt.Sprintf("/postal_codes/%s", postalCode), strings.NewReader("postal_code_type=origin"))
 	request = suite.AuthenticateUserRequest(request, user)
 
-	params := postalcodesops.ValidatePostalCodeParams{
+	params := postalcodesops.ValidatePostalCodeWithRateDataParams{
 		HTTPRequest:    request,
 		PostalCode:     postalCode,
 		PostalCodeType: postalCodeTypeString,
@@ -79,11 +79,11 @@ func (suite *HandlerSuite) TestValidatePostalCodeWithRateDataHandler_Invalid() {
 	response := handler.Handle(params)
 
 	suite.IsNotErrResponse(response)
-	validatePostalCodeResponse := response.(*postalcodesops.ValidatePostalCodeOK)
+	validatePostalCodeResponse := response.(*postalcodesops.ValidatePostalCodeWithRateDataOK)
 	validatePostalCodePayload := validatePostalCodeResponse.Payload
 
 	suite.NotNil(validatePostalCodePayload.PostalCode)
 	suite.NotNil(validatePostalCodePayload.PostalCodeType)
 	suite.False(*validatePostalCodePayload.Valid)
-	suite.Assertions.IsType(&postalcodesops.ValidatePostalCodeOK{}, response)
+	suite.Assertions.IsType(&postalcodesops.ValidatePostalCodeWithRateDataOK{}, response)
 }

--- a/src/shared/api.js
+++ b/src/shared/api.js
@@ -44,7 +44,7 @@ export async function CreateDocument(name, serviceMemberId) {
 
 export async function ValidateZipRateData(zipCode, zipType) {
   const client = await getPublicClient();
-  const response = await client.apis.postal_codes.validatePostalCode({
+  const response = await client.apis.postal_codes.validatePostalCodeWithRateData({
     postal_code: zipCode,
     postal_code_type: zipType,
   });

--- a/swagger/api.yaml
+++ b/swagger/api.yaml
@@ -1942,7 +1942,7 @@ definitions:
       - code
       - move_type
       - created_at
-  ValidatePostalCodePayload:
+  RateEnginePostalCodePayload:
     type: object
     properties:
       valid:
@@ -3591,11 +3591,11 @@ paths:
           description: access code not found in system
         500:
           description: server error
-  /postal_codes/{postal_code}:
+  /rate_postal_codes/{postal_code}:
     get:
       summary: Validate if a zipcode is valid for origin or destination location for a move.
       description: Verifies if a zipcode is valid for origin or destination location for a move.
-      operationId: validatePostalCode
+      operationId: validatePostalCodeWithRateData
       tags:
         - postal_codes
       parameters:
@@ -3616,7 +3616,7 @@ paths:
         200:
           description: postal_code is valid or invalid
           schema:
-            $ref: '#/definitions/ValidatePostalCodePayload'
+            $ref: '#/definitions/RateEnginePostalCodePayload'
         400:
           description: invalid request
         401:

--- a/swagger/api.yaml
+++ b/swagger/api.yaml
@@ -3591,7 +3591,7 @@ paths:
           description: access code not found in system
         500:
           description: server error
-  /rate_postal_codes/{postal_code}:
+  /rate_engine_postal_codes/{postal_code}:
     get:
       summary: Validate if a zipcode is valid for origin or destination location for a move.
       description: Verifies if a zipcode is valid for origin or destination location for a move.


### PR DESCRIPTION
## Description

It was discussed at ARBOC that the naming on the public facing side could be more explicit that this is not validating all postal codes, just validating postal codes against the ones that we support with our rate engine, so our public api should reflect that.

## Reviewer Notes

Should I go even further than just the public facing stuff?

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make db_dev_e2e_migrate
```
Sign in as `profile@comple.te`. Then start setting up a PPM. On the date, enter in a date in the year of `2100`. Edit the delivery postal code as `00000` a known bad zip. Try matching the pickup and delivery postal code. Play around with any wrong data and see if the errors show up and prevent you from moving to the next screen with invalid or obviously wrong data.

## Code Review Verification Steps

* [x] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [x] Request review from a member of a different team.

## References

n/a

## Screenshots

n/a
