### PR TITLE
Add moving expenses landing page

### DIFF
--- a/cypress/integration/mymove/ppm.js
+++ b/cypress/integration/mymove/ppm.js
@@ -319,11 +319,11 @@ function serviceMemberViewsExpensesUploadPage() {
   cy.get('[data-filepond-item-state="processing-complete"]').should('have.length', 1);
 
   cy.get('input[name="missingReceipt"]').should('not.be.checked');
-  cy.get('input[name="payment_method"][value="GTCC"]').should('not.be.checked');
-  cy.get('input[name="payment_method"][value="OTHER"]').should('be.checked');
+  cy.get('input[name="paymentMethod"][value="GTCC"]').should('not.be.checked');
+  cy.get('input[name="paymentMethod"][value="OTHER"]').should('be.checked');
 
-  cy.get('input[name="has_more_expenses"][value="Yes"]').should('not.be.checked');
-  cy.get('input[name="has_more_expenses"][value="No"]').should('be.checked');
+  cy.get('input[name="haveMoreExpenses"][value="Yes"]').should('not.be.checked');
+  cy.get('input[name="haveMoreExpenses"][value="No"]').should('be.checked');
 }
 
 function serviceMemberSubmitsCarTrailerWeightTicket() {

--- a/cypress/integration/mymove/ppm.js
+++ b/cypress/integration/mymove/ppm.js
@@ -193,6 +193,7 @@ describe('allows a SM to request a payment', function() {
     cy.server();
     cy.route('POST', '**/internal/uploads').as('postUploadDocument');
     cy.route('POST', '**/moves/**/weight_ticket').as('postWeightTicket');
+    cy.route('POST', '**/moves/**/moving_expense_documents').as('postMovingExpense');
     cy.signInAsUserPostRequest(milmoveAppName, '8e0d7e98-134e-4b28-bdd1-7d6b1ff34f9e');
   });
 
@@ -204,6 +205,7 @@ describe('allows a SM to request a payment', function() {
   it('service member requests car weight ticket payment and views expenses landing page', () => {
     serviceMemberSubmitsWeightTicket('CAR', false);
     serviceMemberViewsExpensesLandingPage();
+    serviceMemberViewsExpensesUploadPage();
   });
 
   it('service member requests a box truck weight ticket payment', () => {
@@ -298,7 +300,31 @@ function serviceMemberViewsExpensesLandingPage() {
   cy
     .get('button')
     .contains('Continue')
-    .should('be.enabled');
+    .should('be.enabled')
+    .click();
+}
+
+function serviceMemberViewsExpensesUploadPage() {
+  cy.location().should(loc => {
+    expect(loc.pathname).to.match(/^\/moves\/[^/]+\/ppm-expenses/);
+  });
+
+  cy.contains('Expense 1');
+
+  cy.get('select[name="moving_expense_type"]').select('GAS');
+  cy.get('input[name="title"]').type('title');
+  cy.get('input[name="requested_amount_cents"]').type('1000');
+
+  cy.upload_file('.filepond--root:first', 'top-secret.png');
+  cy.wait('@postUploadDocument');
+  cy.get('[data-filepond-item-state="processing-complete"]').should('have.length', 1);
+
+  cy.get('input[name="missingReceipt"]').should('not.be.checked');
+  cy.get('input[name="payment_method"][value="GTCC"]').should('not.be.checked');
+  cy.get('input[name="payment_method"][value="OTHER"]').should('be.checked');
+
+  cy.get('input[name="has_more_expenses"][value="Yes"]').should('not.be.checked');
+  cy.get('input[name="has_more_expenses"][value="No"]').should('be.checked');
 }
 
 function serviceMemberSubmitsCarTrailerWeightTicket() {

--- a/cypress/integration/mymove/ppm.js
+++ b/cypress/integration/mymove/ppm.js
@@ -193,7 +193,6 @@ describe('allows a SM to request a payment', function() {
     cy.server();
     cy.route('POST', '**/internal/uploads').as('postUploadDocument');
     cy.route('POST', '**/moves/**/weight_ticket').as('postWeightTicket');
-    cy.route('POST', '**/moves/**/moving_expense_documents').as('postMovingExpense');
     cy.signInAsUserPostRequest(milmoveAppName, '8e0d7e98-134e-4b28-bdd1-7d6b1ff34f9e');
   });
 

--- a/src/scenes/Moves/Ppm/Expenses.css
+++ b/src/scenes/Moves/Ppm/Expenses.css
@@ -19,10 +19,6 @@
   padding-top: 2em;
 }
 
-.short-input {
-  max-width: 200px;
-}
-
 .expenses-container a:visited {
   color: #0071bc;
 }

--- a/src/scenes/Moves/Ppm/Expenses.css
+++ b/src/scenes/Moves/Ppm/Expenses.css
@@ -2,6 +2,27 @@
   padding-top: 2em;
 }
 
+.expenses-header {
+  margin-bottom: 0;
+}
+
+.expenses-container > p {
+  margin-bottom: 0;
+  margin-top: 0;
+}
+
+.expenses-container .dashed-divider {
+  margin-top: 0;
+}
+
+.expenses-container .expenses-uploader {
+  padding-top: 2em;
+}
+
+.short-input {
+  max-width: 200px;
+}
+
 .expenses-container a:visited {
   color: #0071bc;
 }
@@ -13,4 +34,10 @@
 .has-expenses-radio-group {
   margin-top: 1em;
   margin-bottom: 3.5em;
+}
+
+.payment-method-radio-group-wrapper {
+  margin-bottom: 0;
+  line-height: 1.8em;
+  margin-top: 1.8em;
 }

--- a/src/scenes/Moves/Ppm/ExpensesLanding.jsx
+++ b/src/scenes/Moves/Ppm/ExpensesLanding.jsx
@@ -8,6 +8,7 @@ import PPMPaymentRequestActionBtns from './PPMPaymentRequestActionBtns';
 import WizardHeader from '../WizardHeader';
 
 import './Expenses.css';
+import { connect } from 'react-redux';
 
 class ExpensesLanding extends Component {
   state = {
@@ -18,6 +19,11 @@ class ExpensesLanding extends Component {
     this.setState({
       hasExpenses: event.target.value,
     });
+  };
+
+  saveAndAddHandler = () => {
+    const { history, moveId } = this.props;
+    history.push(`/moves/${moveId}/ppm-expenses`);
   };
 
   render() {
@@ -58,7 +64,6 @@ class ExpensesLanding extends Component {
               checked={hasExpenses === 'Yes'}
               onChange={this.handleRadioChange}
             />
-
             <RadioButton
               inputClassName="inline_radio"
               labelClassName="inline_radio"
@@ -73,7 +78,7 @@ class ExpensesLanding extends Component {
             cancelHandler={() => {}}
             displaySaveForLater
             nextBtnLabel="Continue"
-            saveAndAddHandler={() => {}}
+            saveAndAddHandler={this.saveAndAddHandler}
             saveForLaterHandler={() => history.push('/')}
             submitButtonsAreDisabled={!hasExpenses}
           />
@@ -83,4 +88,11 @@ class ExpensesLanding extends Component {
   }
 }
 
-export default ExpensesLanding;
+function mapStateToProps(state, ownProps) {
+  const moveId = ownProps.match.params.moveId;
+  return {
+    moveId: moveId,
+  };
+}
+
+export default connect(mapStateToProps)(ExpensesLanding);

--- a/src/scenes/Moves/Ppm/ExpensesLanding.jsx
+++ b/src/scenes/Moves/Ppm/ExpensesLanding.jsx
@@ -76,7 +76,8 @@ class ExpensesLanding extends Component {
           </div>
           <PPMPaymentRequestActionBtns
             cancelHandler={() => {}}
-            displaySaveForLater
+            //TODO remove once have review page in place
+            displaySaveForLater={hasExpenses === 'No'}
             nextBtnLabel="Continue"
             saveAndAddHandler={this.saveAndAddHandler}
             saveForLaterHandler={() => history.push('/')}

--- a/src/scenes/Moves/Ppm/ExpensesUpload.jsx
+++ b/src/scenes/Moves/Ppm/ExpensesUpload.jsx
@@ -119,8 +119,14 @@ class ExpensesUpload extends Component {
             {hasMovingExpenseType && (
               <>
                 <SwaggerField title="Document title" fieldName="title" swagger={moveDocSchema} required />
-                <SwaggerField title="Amount" fieldName="requested_amount_cents" swagger={moveDocSchema} required />
-                <div className="usa-width-two-thirds uploader-wrapper">
+                <SwaggerField
+                  className="short-input"
+                  title="Amount"
+                  fieldName="requested_amount_cents"
+                  swagger={moveDocSchema}
+                  required
+                />
+                <div className="expenses-uploader">
                   <Uploader
                     isPublic={isPublic}
                     onRef={ref => (this.uploader = ref)}
@@ -135,7 +141,7 @@ class ExpensesUpload extends Component {
                   onChange={this.handleCheckboxChange}
                   normalizeLabel
                 />
-                <div className="radio-group-wrapper" style={{ marginBottom: '0px' }}>
+                <div className="payment-method-radio-group-wrapper">
                   <p className="radio-group-header">How did you pay for this?</p>
                   <RadioButton
                     inputClassName="inline_radio"
@@ -162,7 +168,7 @@ class ExpensesUpload extends Component {
                     onClick={this.handleHowDidYouPayForThis}
                   />
                 </div>
-                <div className="dashed-divider" style={{ marginTop: '0px' }} />
+                <div className="dashed-divider" />
                 <div className="radio-group-wrapper">
                   <p className="radio-group-header">Do you have more expenses to upload?</p>
                   <RadioButton

--- a/src/scenes/Moves/Ppm/ExpensesUpload.jsx
+++ b/src/scenes/Moves/Ppm/ExpensesUpload.jsx
@@ -42,15 +42,9 @@ class ExpensesUpload extends Component {
     };
   }
 
-  handleHasMoreExpensesChange = event => {
+  handleRadioChange = event => {
     this.setState({
-      haveMoreExpenses: event.target.value,
-    });
-  };
-
-  handlePaymentMethodChange = event => {
-    this.setState({
-      paymentMethod: event.target.value,
+      [event.target.name]: event.target.value,
     });
   };
 
@@ -148,24 +142,24 @@ class ExpensesUpload extends Component {
                     labelClassName="inline_radio"
                     label="Government travel charge card (GTCC)"
                     value={ExpensesUpload.paymentMethods.GTCC}
-                    name="payment_method"
+                    name="paymentMethod"
                     checked={paymentMethod === ExpensesUpload.paymentMethods.GTCC}
-                    onChange={this.handlePaymentMethodChange}
+                    onChange={this.handleRadioChange}
                   />
                   <RadioButton
                     inputClassName="inline_radio"
                     labelClassName="inline_radio"
                     label="Other"
                     value={ExpensesUpload.paymentMethods.Other}
-                    name="payment_method"
+                    name="paymentMethod"
                     checked={paymentMethod === ExpensesUpload.paymentMethods.Other}
-                    onChange={this.handlePaymentMethodChange}
+                    onChange={this.handleRadioChange}
                   />
                   <FontAwesomeIcon
                     aria-hidden
                     className="color_blue_link"
                     icon={faQuestionCircle}
-                    onClick={this.handleHowDidYouPayForThis}
+                    onClick={this.handleRadioChange}
                   />
                 </div>
                 <div className="dashed-divider" />
@@ -176,18 +170,18 @@ class ExpensesUpload extends Component {
                     labelClassName="inline_radio"
                     label="Yes"
                     value="Yes"
-                    name="has_more_expenses"
+                    name="haveMoreExpenses"
                     checked={haveMoreExpenses === 'Yes'}
-                    onChange={this.handleHasMoreExpensesChange}
+                    onChange={this.handleRadioChange}
                   />
                   <RadioButton
                     inputClassName="inline_radio"
                     labelClassName="inline_radio"
                     label="No"
                     value="No"
-                    name="has_more_expenses"
+                    name="haveMoreExpenses"
                     checked={haveMoreExpenses === 'No'}
-                    onChange={this.handleHasMoreExpensesChange}
+                    onChange={this.handleRadioChange}
                   />
                 </div>
               </>

--- a/src/scenes/Moves/Ppm/ExpensesUpload.jsx
+++ b/src/scenes/Moves/Ppm/ExpensesUpload.jsx
@@ -31,6 +31,8 @@ class ExpensesUpload extends Component {
     GTCC: 'GTCC',
   };
 
+  static uploadReceipt = '<span class="uploader-label">Drag & drop or <span class="filepond--label-action">click to upload receipt</span></span>';
+
   get initialState() {
     return {
       paymentMethod: ExpensesUpload.paymentMethods.Other,
@@ -114,7 +116,7 @@ class ExpensesUpload extends Component {
               <>
                 <SwaggerField title="Document title" fieldName="title" swagger={moveDocSchema} required />
                 <SwaggerField
-                  className="short-input"
+                  className="short-field"
                   title="Amount"
                   fieldName="requested_amount_cents"
                   swagger={moveDocSchema}
@@ -122,6 +124,7 @@ class ExpensesUpload extends Component {
                 />
                 <div className="expenses-uploader">
                   <Uploader
+                    options={{ labelIdle: ExpensesUpload.uploadReceipt }}
                     isPublic={isPublic}
                     onRef={ref => (this.uploader = ref)}
                     onChange={this.onChange}

--- a/src/scenes/Moves/Ppm/ExpensesUpload.jsx
+++ b/src/scenes/Moves/Ppm/ExpensesUpload.jsx
@@ -1,0 +1,216 @@
+import React, { Component } from 'react';
+
+import { ProgressTimeline, ProgressTimelineStep } from 'shared/ProgressTimeline';
+
+import PPMPaymentRequestActionBtns from './PPMPaymentRequestActionBtns';
+import WizardHeader from '../WizardHeader';
+
+import 'shared/DocumentViewer/DocumentUploader.jsx';
+import { get, isEmpty } from 'lodash';
+import RadioButton from 'shared/RadioButton';
+import { Link } from 'react-router-dom';
+import FontAwesomeIcon from '@fortawesome/react-fontawesome';
+import faQuestionCircle from '@fortawesome/fontawesome-free-solid/faQuestionCircle';
+import { SwaggerField } from 'shared/JsonSchemaForm/JsonSchemaField';
+import Uploader from 'shared/Uploader';
+import Checkbox from 'shared/Checkbox';
+import { getFormValues, reduxForm } from 'redux-form';
+import { connect } from 'react-redux';
+import Alert from 'shared/Alert';
+
+class ExpensesUpload extends Component {
+  state = { ...this.initialState, expenseNumber: 1 };
+
+  static nextBtnLabels = {
+    SaveAndAddAnother: 'Save & Add Another',
+    SaveAndContinue: 'Save & Continue',
+  };
+
+  static paymentMethods = {
+    Other: 'OTHER',
+    GTCC: 'GTCC',
+  };
+
+  get initialState() {
+    return {
+      paymentMethod: ExpensesUpload.paymentMethods.Other,
+      uploaderIsIdle: true,
+      missingReceipt: false,
+      expenseType: '',
+      haveMoreExpenses: 'No',
+      moveDocumentCreateError: false,
+    };
+  }
+
+  handleHasMoreExpensesChange = event => {
+    this.setState({
+      haveMoreExpenses: event.target.value,
+    });
+  };
+
+  handlePaymentMethodChange = event => {
+    this.setState({
+      paymentMethod: event.target.value,
+    });
+  };
+
+  onAddFile = () => {
+    this.setState({
+      uploaderIsIdle: false,
+    });
+  };
+
+  onChange = (newUploads, uploaderIsIdle) => {
+    this.setState({
+      uploaderIsIdle,
+    });
+  };
+
+  handleCheckboxChange = event => {
+    this.setState({
+      [event.target.name]: event.target.checked,
+    });
+  };
+
+  handleHowDidYouPayForThis = () => {
+    alert('Cash, personal credit card, check — any payment method that’s not your GTCC.');
+  };
+
+  render() {
+    const { missingReceipt, paymentMethod, haveMoreExpenses, expenseNumber, moveDocumentCreateError } = this.state;
+    const { moveDocSchema, formValues, isPublic } = this.props;
+    const nextBtnLabel =
+      haveMoreExpenses === 'Yes'
+        ? ExpensesUpload.nextBtnLabels.SaveAndAddAnother
+        : ExpensesUpload.nextBtnLabels.SaveAndContinue;
+    const hasMovingExpenseType = !isEmpty(formValues) && formValues.moving_expense_type !== '';
+    return (
+      <>
+        <WizardHeader
+          title="Expenses"
+          right={
+            <ProgressTimeline>
+              <ProgressTimelineStep name="Weight" completed />
+              <ProgressTimelineStep name="Expenses" current />
+              <ProgressTimelineStep name="Review" />
+            </ProgressTimeline>
+          }
+        />
+
+        <div className="usa-grid expenses-container">
+          <h3 className="expenses-header">Expense {expenseNumber}</h3>
+          <p>
+            Upload expenses one at a time.{' '}
+            <Link to="/allowable-expenses">
+              <FontAwesomeIcon aria-hidden className="color_blue_link" icon={faQuestionCircle} />
+            </Link>
+          </p>
+          <form>
+            {moveDocumentCreateError && (
+              <div className="usa-grid">
+                <div className="usa-width-one-whole error-message">
+                  <Alert type="error" heading="An error occurred">
+                    Something went wrong contacting the server.
+                  </Alert>
+                </div>
+              </div>
+            )}
+            <SwaggerField title="Expense type" fieldName="moving_expense_type" swagger={moveDocSchema} required />
+            {hasMovingExpenseType && (
+              <>
+                <SwaggerField title="Document title" fieldName="title" swagger={moveDocSchema} required />
+                <SwaggerField title="Amount" fieldName="requested_amount_cents" swagger={moveDocSchema} required />
+                <div className="usa-width-two-thirds uploader-wrapper">
+                  <Uploader
+                    isPublic={isPublic}
+                    onRef={ref => (this.uploader = ref)}
+                    onChange={this.onChange}
+                    onAddFile={this.onAddFile}
+                  />
+                </div>
+                <Checkbox
+                  label="I'm missing this receipt"
+                  name="missingReceipt"
+                  checked={missingReceipt}
+                  onChange={this.handleCheckboxChange}
+                  normalizeLabel
+                />
+                <div className="radio-group-wrapper" style={{ marginBottom: '0px' }}>
+                  <p className="radio-group-header">How did you pay for this?</p>
+                  <RadioButton
+                    inputClassName="inline_radio"
+                    labelClassName="inline_radio"
+                    label="Government travel charge card (GTCC)"
+                    value={ExpensesUpload.paymentMethods.GTCC}
+                    name="payment_method"
+                    checked={paymentMethod === ExpensesUpload.paymentMethods.GTCC}
+                    onChange={this.handlePaymentMethodChange}
+                  />
+                  <RadioButton
+                    inputClassName="inline_radio"
+                    labelClassName="inline_radio"
+                    label="Other"
+                    value={ExpensesUpload.paymentMethods.Other}
+                    name="payment_method"
+                    checked={paymentMethod === ExpensesUpload.paymentMethods.Other}
+                    onChange={this.handlePaymentMethodChange}
+                  />
+                  <FontAwesomeIcon
+                    aria-hidden
+                    className="color_blue_link"
+                    icon={faQuestionCircle}
+                    onClick={this.handleHowDidYouPayForThis}
+                  />
+                </div>
+                <div className="dashed-divider" style={{ marginTop: '0px' }} />
+                <div className="radio-group-wrapper">
+                  <p className="radio-group-header">Do you have more expenses to upload?</p>
+                  <RadioButton
+                    inputClassName="inline_radio"
+                    labelClassName="inline_radio"
+                    label="Yes"
+                    value="Yes"
+                    name="has_more_expenses"
+                    checked={haveMoreExpenses === 'Yes'}
+                    onChange={this.handleHasMoreExpensesChange}
+                  />
+                  <RadioButton
+                    inputClassName="inline_radio"
+                    labelClassName="inline_radio"
+                    label="No"
+                    value="No"
+                    name="has_more_expenses"
+                    checked={haveMoreExpenses === 'No'}
+                    onChange={this.handleHasMoreExpensesChange}
+                  />
+                </div>
+              </>
+            )}
+            <PPMPaymentRequestActionBtns
+              nextBtnLabel={nextBtnLabel}
+              submitButtonsAreDisabled={true}
+              saveForLaterHandler={() => {}}
+              saveAndAddHandler={() => {}}
+              displaySaveForLater={true}
+            />
+          </form>
+        </div>
+      </>
+    );
+  }
+}
+
+const formName = 'expense_document_upload';
+ExpensesUpload = reduxForm({ form: formName })(ExpensesUpload);
+
+function mapStateToProps(state, props) {
+  const moveId = props.match.params.moveId;
+  return {
+    moveId: moveId,
+    formValues: getFormValues(formName)(state),
+    moveDocSchema: get(state, 'swaggerInternal.spec.definitions.MoveDocumentPayload', {}),
+    initialValues: {},
+    currentPpm: get(state, 'ppm.currentPpm'),
+  };
+}
+export default connect(mapStateToProps)(ExpensesUpload);

--- a/src/scenes/Moves/Ppm/PPMPaymentRequest.css
+++ b/src/scenes/Moves/Ppm/PPMPaymentRequest.css
@@ -53,7 +53,7 @@
   justify-content: space-between;
   border-top: 1px solid black;
   margin-top: 2.3rem;
-  padding-top: 0.5rem;
+  padding-top: 1.5rem;
 }
 
 @media only screen and (max-width: 481px) {

--- a/src/scenes/MyMove/index.jsx
+++ b/src/scenes/MyMove/index.jsx
@@ -23,6 +23,7 @@ import Header from 'shared/Header/MyMove';
 import PPMPaymentRequestIntro from 'scenes/Moves/Ppm/PPMPaymentRequestIntro';
 import WeightTicket from 'scenes/Moves/Ppm/WeightTicket';
 import ExpensesLanding from 'scenes/Moves/Ppm/ExpensesLanding';
+import ExpensesUpload from 'scenes/Moves/Ppm/ExpensesUpload';
 import AllowableExpenses from 'scenes/Moves/Ppm/AllowableExpenses';
 import WeightTicketExamples from 'scenes/Moves/Ppm/WeightTicketExamples';
 import PaymentRequest from 'scenes/Moves/Ppm/PaymentRequest';
@@ -109,6 +110,7 @@ export class AppWrapper extends Component {
                     <PrivateRoute path="/moves/:moveId/ppm-payment-request-intro" component={PPMPaymentRequestIntro} />
                     <PrivateRoute path="/moves/:moveId/ppm-weight-ticket" component={WeightTicket} />
                     <PrivateRoute path="/moves/:moveId/ppm-expenses-intro" component={ExpensesLanding} />
+                    <PrivateRoute path="/moves/:moveId/ppm-expenses" component={ExpensesUpload} />
                     <PrivateRoute path="/dps_cookie" component={DPSAuthCookie} />
                     <Route exact path="/forbidden">
                       <div className="usa-grid">

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -906,13 +906,13 @@ definitions:
     title: Moving Expense Type
     enum:
       - CONTRACTED_EXPENSE
-      - RENTAL_EQUIPMENT
-      - PACKING_MATERIALS
-      - WEIGHING_FEES
       - GAS
-      - TOLLS
       - OIL
       - OTHER
+      - PACKING_MATERIALS
+      - RENTAL_EQUIPMENT
+      - TOLLS
+      - WEIGHING_FEES
     x-display-value:
       CONTRACTED_EXPENSE: Contracted Expense
       RENTAL_EQUIPMENT: Rental Equipment


### PR DESCRIPTION
## Description

Add the expense upload page for PPM closeout.

## Reviewer Notes

I got a little confused on this story as didn't immediately see a story to complete the rest of the page layout, so this pr adds all the fields for the expense upload page, which was broken out into two separate stories in pivotal.

## Setup

```sh
make e2e_test
```

## Code Review Verification Steps
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/n/projects/2181745/stories/165888684)
* [Pivotal story](https://www.pivotaltracker.com/n/projects/2181745/stories/166019945) 

## Screenshots
![image](https://user-images.githubusercontent.com/1036969/59296826-1a64f700-8c44-11e9-83dd-8ae394184dc2.png)