### PR TITLE
Add retry and error printing to codecov validation.

### DIFF
--- a/scripts/pre-commit-codecov-validate
+++ b/scripts/pre-commit-codecov-validate
@@ -2,9 +2,4 @@
 
 set -eu -o pipefail
 
-output=$(/usr/bin/curl -s -S --retry 5 --retry-connrefused --data-binary @.codecov.yml https://codecov.io/validate)
-
-if [[ ! $output =~ (Valid) ]]; then
-    echo "$output"
-    exit 1
-fi
+/usr/bin/curl -s -S --retry 5 --retry-connrefused --data-binary @.codecov.yml https://codecov.io/validate | tee /dev/stderr | grep "Valid!"

--- a/scripts/pre-commit-codecov-validate
+++ b/scripts/pre-commit-codecov-validate
@@ -2,4 +2,9 @@
 
 set -eu -o pipefail
 
-/usr/bin/curl -s --data-binary @.codecov.yml https://codecov.io/validate | grep "Valid!"
+output=$(/usr/bin/curl -s -S --retry 5 --retry-connrefused --data-binary @.codecov.yml https://codecov.io/validate)
+
+if [[ ! $output =~ (Valid) ]]; then
+    echo "$output"
+    exit 1
+fi


### PR DESCRIPTION
## Description

We added a pre-commit check to validate our `codecov` config file in [an earlier PR](https://github.com/transcom/mymove/pull/2209/files). It's been mostly working, but we have started to see [intermittent failures in CI from this check](https://circleci.com/gh/transcom/mymove/123286). Since the check passes locally and usually on CI with a retry, I am operating under the assumption that the underlying `curl` statement is failing for one reason or another.

This PR does three things:
* It modifies the `curl` command to retry up to 5 times and also consider connection refused errors as retriable.
* It configures `curl` to still print out errors, despite running in silent `-S` mode (which itself is required by how pre-commit works).
* If the validation fails, the output of the `curl` command will be printed to the console to aid in debugging.

## Reviewer Notes

I don't write a lot of bash, so while `shellcheck` is OK with everything, I'd like some human eyes on these changes.

## Setup

You can test this out locally by running `scripts/pre-commit-codecov-validate` after mangling your `.codecov` file.