### PR TITLE
golangci-lint enable auto fix

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -36,3 +36,4 @@ issues:
     - path: internal/pkg/dutystationsloader/duty_stations_loader.go
       linters:
         - govet
+  fix: true

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ This prototype was built by a [Defense Digital Service](https://www.dds.mil/) te
   * [Troubleshooting](#troubleshooting)
     * [Postgres Issues](#postgres-issues)
     * [Development Machine Timezone Issues](#development-machine-timezone-issues)
+    * [Linters & Pre-commit Hooks](#linters--pre-commit-hooks)
 
 Regenerate with "scripts/generate-md-toc"
 
@@ -542,3 +543,7 @@ export TZ="UTC"
 ```
 
 Doing so will set the timezone environment variable to UTC utilizing the same localized context as your other `.envrc.local` settings.
+
+#### Linters & Pre-commit Hooks
+
+We use a number of linters for formatting, security and error checking. Please see this [how-to document](./docs/how-to/run-pre-commit-hooks.md) for a list of linters and troubleshooting tips.

--- a/docs/how-to/run-pre-commit-hooks.md
+++ b/docs/how-to/run-pre-commit-hooks.md
@@ -46,4 +46,4 @@ If you would like to run an individual hook, for example if you want to only run
 ### Troubleshooting Tips
 
 1. If you encounter `cannot find module providing package github.com/transcom/mymove/pkg/gen/*` try running `make server_generate` which should generate files for `gen` folder automatically
-2. If you encounter `cannot find module providing package github.com/transcom/mymove/pkg/services/mocks` try running `make mocks_generate` which should auto generate mocks
+2. If you encounter `cannot find module providing package github.com/transcom/mymove/pkg/.../mocks` try running `make mocks_generate` which should auto generate mocks

--- a/docs/how-to/run-pre-commit-hooks.md
+++ b/docs/how-to/run-pre-commit-hooks.md
@@ -11,6 +11,10 @@ Pre-commit can be run by simply running the following command in terminal:
 
 If you would like to run an individual hook, for example if you want to only run *prettier*: `pre-commit run prettier -a`
 
+## Editor Integration
+
+1. `golangci-lint` supports various [editors](https://github.com/golangci/golangci-lint/#editor-integration)
+
 ## Current pre-commit hooks
 
 | Hook  | Description |
@@ -38,3 +42,8 @@ If you would like to run an individual hook, for example if you want to only run
 | `typecheck` | Part of `golangci-lint` linter and works like the front-end of a Go compiler, parses and type-checks Go code
 | `structcheck` | Part of `golangci-lint` linter and finds an unused struct fields
 | `deadcode` | Part of `golangci-lint` linter and used to find unused code
+
+### Troubleshooting Tips
+
+1. If you encounter `cannot find module providing package github.com/transcom/mymove/pkg/gen/*` try running `make server_generate` which should generate files for `gen` folder automatically
+2. If you encounter `cannot find module providing package github.com/transcom/mymove/pkg/services/mocks` try running `make mocks_generate` which should auto generate mocks


### PR DESCRIPTION
## Description

Add `--fix` flag to golangci-lint config file so linters like `gofmt` that support auto fixing can patch lint errors 
## Reviewer Notes

Add a `gofmt` lint error and try running `pre-commit run` or creating a new git commit.

## Code Review Verification Steps

* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/166618743) for this change