### PR TITLE
Refactor config for ecs-deploy-task-container

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,6 +79,12 @@ commands:
       - deploy:
           name: Deploy task service
           command: scripts/do-exclusively --job-name ${CIRCLE_JOB} bin/ecs-deploy-task-container --aws-account-id ${AWS_ACCOUNT_ID} --aws-region ${AWS_DEFAULT_REGION} --service app --environment ${APP_ENVIRONMENT} --repository-name app-tasks --image-tag git-${CIRCLE_SHA1} --command save-fuel-price-data
+          environment:
+            DB_PORT: 5432
+            DB_USER: master
+            DB_NAME: app
+            DB_SSL_MODE: verify-full
+            DB_SSL_ROOT_CERT: /bin/rds-combined-ca-bundle.pem
           no_output_timeout: 20m
       - announce_failure
   deploy_app_steps:

--- a/config/app-client-tls.container-definition.json
+++ b/config/app-client-tls.container-definition.json
@@ -167,14 +167,6 @@
     {
       "name": "SERVE_SWAGGER_UI",
       "value": "{{ .SERVE_SWAGGER_UI }}"
-    },
-    {
-      "name": "EIA_KEY",
-      "value": "{{ .EIA_KEY }}"
-    },
-    {
-      "name": "EIA_URL",
-      "value": "https://api.eia.gov/series/"
     }
   ],
   "logConfiguration": {

--- a/config/app.container-definition.json
+++ b/config/app.container-definition.json
@@ -186,14 +186,6 @@
     {
       "name": "SERVE_SWAGGER_UI",
       "value": "{{ .SERVE_SWAGGER_UI }}"
-    },
-    {
-      "name": "EIA_KEY",
-      "value": "{{ .EIA_KEY }}"
-    },
-    {
-      "name": "EIA_URL",
-      "value": "https://api.eia.gov/series/"
     }
   ],
   "logConfiguration": {

--- a/scripts/run-e2e-test-docker
+++ b/scripts/run-e2e-test-docker
@@ -53,8 +53,6 @@ $DOCKER_RUN \
   -e DOD_CA_PACKAGE="/config/tls/Certificates_PKCS7_v5.4_DoD.der.p7b" \
   -e DPS_AUTH_COOKIE_SECRET_KEY \
   -e DPS_COOKIE_EXPIRES_IN_MINUTES \
-  -e EIA_KEY \
-  -e EIA_URL \
   -e ENV="test" \
   -e ENVIRONMENT="test" \
   -e HERE_MAPS_APP_CODE \


### PR DESCRIPTION
## Description

This PR adds support for passing command arguments to underlying ECS tasks through `ecs-deploy-task-container`, which can be used to easily turn flags on and off.  This PR passes through some database config and removes EIA config.

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Setup

None

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/tree/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/tree/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/tree/master/docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
  * [ ] Secure migrations have been tested using `scripts/run-prod-migrations`
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

None

## Screenshots

None