### PR TITLE
Make curl commands in CI scripts more resilient to intermittent connection issues.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -482,7 +482,7 @@ jobs:
           name: Setup Code Climate test-reporter
           command: |
             # download test reporter as a static binary
-            curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > /home/circleci/cc-test-reporter
+            curl -L -S --retry 5 --retry-connrefused https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 --output /home/circleci/cc-test-reporter
             chmod +x /home/circleci/cc-test-reporter
             /home/circleci/cc-test-reporter before-build -d
       - run:
@@ -506,7 +506,7 @@ jobs:
       - run:
           name: upload code coverage to codecov
           command: |
-            curl -s https://codecov.io/bash > /home/circleci/codecov
+            curl -s -S --retry 5 --retry-connrefused https://codecov.io/bash --output /home/circleci/codecov
             chmod +x /home/circleci/codecov
             /home/circleci/codecov -F go -f coverage.out
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -482,7 +482,7 @@ jobs:
           name: Setup Code Climate test-reporter
           command: |
             # download test reporter as a static binary
-            curl -L -S --retry 5 --retry-connrefused https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 --output /home/circleci/cc-test-reporter
+            curl -L --retry 5 --retry-connrefused https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 --output /home/circleci/cc-test-reporter
             chmod +x /home/circleci/cc-test-reporter
             /home/circleci/cc-test-reporter before-build -d
       - run:
@@ -506,7 +506,7 @@ jobs:
       - run:
           name: upload code coverage to codecov
           command: |
-            curl -s -S --retry 5 --retry-connrefused https://codecov.io/bash --output /home/circleci/codecov
+            curl -L --retry 5 --retry-connrefused https://codecov.io/bash --output /home/circleci/codecov
             chmod +x /home/circleci/codecov
             /home/circleci/codecov -F go -f coverage.out
 


### PR DESCRIPTION
[A build recently failed](https://circleci.com/gh/transcom/mymove/123714) because `curl`'s connection was refused when we attempted to download the `codecov` result uploader. [Curl's exit code docs](https://ec.haxx.se/usingcurl-returns.html) explain that an exit code of `7` is the result of such a connection refusal.

## Description

This PR adds some retrying to every `curl` command in our CircleCI script, hopefully making our builds slightly more resilient in the face of intermittent connection issues.

I also changed the scripts from using output redirection to using the `--output` `curl` flag so that we don't have to think about how curl printing out messages might affect the downloaded files. Nothing in this PR requires this change, but it feels slightly safer to me in light of unknown future changes to the code.

## Reviewer Notes

Just the usual 👀.