### PR TITLE
Add 404 for ppm estimator and update 404 description for ppm patch. 

### DIFF
--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -2609,6 +2609,8 @@ paths:
           description: request requires user authentication
         403:
           description: user is not authorized
+        404:
+          description: ppm discount not found for provided postal codes and original move date
         500:
           description: internal server error
   /estimates/ppm_sit:
@@ -3018,7 +3020,7 @@ paths:
         403:
           description: user is not authorized
         404:
-          description: ppm is not found
+          description: ppm is not found or ppm discount not found for provided postal codes and original move date
         500:
           description: internal server error
     get:


### PR DESCRIPTION
## Description

Both endpoints can fail due to missing discount information and return a 404 from the Fetch being done.

I discovered this while doing load testing in #1597. My swagger client couldn't parse the error into anything useful and threw an error because of it.

## Setup

```sh
make server_generate
```

## Code Review Verification Steps

* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?