### PR TITLE
The entitlement calculator can fail if the weight estimate doesn't exist

### DIFF
--- a/pkg/handlers/internalapi/entitlements.go
+++ b/pkg/handlers/internalapi/entitlements.go
@@ -51,9 +51,20 @@ func (h ValidateEntitlementHandler) Handle(params entitlementop.ValidateEntitlem
 	var weightEstimate int64
 	if len(move.PersonallyProcuredMoves) >= 1 {
 		// PPMs are in descending order - this is the last one created
-		weightEstimate = int64(*move.PersonallyProcuredMoves[0].WeightEstimate)
+		ppm := move.PersonallyProcuredMoves[0]
+		if ppm.WeightEstimate != nil {
+			weightEstimate = int64(*ppm.WeightEstimate)
+		} else {
+			weightEstimate = int64(0)
+		}
+
 	} else if len(move.Shipments) >= 1 {
-		weightEstimate = int64(*move.Shipments[0].WeightEstimate)
+		shipment := move.Shipments[0]
+		if shipment.WeightEstimate != nil {
+			weightEstimate = int64(*shipment.WeightEstimate)
+		} else {
+			weightEstimate = int64(0)
+		}
 	}
 
 	smEntitlement, err := models.GetEntitlement(*serviceMember.Rank, orders.HasDependents, orders.SpouseHasProGear)

--- a/pkg/handlers/internalapi/entitlements_test.go
+++ b/pkg/handlers/internalapi/entitlements_test.go
@@ -226,3 +226,55 @@ func (suite *HandlerSuite) TestValidateEntitlementHandlerReturns404IfNoRank() {
 	// Then: expect a 404 status code
 	suite.Assertions.IsType(&entitlementop.ValidateEntitlementNotFound{}, response)
 }
+
+func (suite *HandlerSuite) TestValidateEntitlementHandlerManagesNilPPMWeightEstimate() {
+	// Given: a set of orders, a move, user, servicemember and a PPM
+	ppm := testdatagen.MakeDefaultPPM(suite.DB())
+	move := ppm.Move
+
+	// This endpoint can be called when the ppm weight estimate has not been set
+	ppm.WeightEstimate = nil
+	suite.MustSave(&ppm)
+
+	// And: the context contains the auth values
+	request := httptest.NewRequest("GET", "/entitlements/move_id", nil)
+	request = suite.AuthenticateRequest(request, move.Orders.ServiceMember)
+
+	params := entitlementop.ValidateEntitlementParams{
+		HTTPRequest: request,
+		MoveID:      strfmt.UUID(move.ID.String()),
+	}
+
+	// And: validate entitlements endpoint is hit
+	handler := ValidateEntitlementHandler{handlers.NewHandlerContext(suite.DB(), suite.TestLogger())}
+	response := handler.Handle(params)
+
+	// Then: expect a 200 status code
+	suite.Assertions.IsType(&entitlementop.ValidateEntitlementOK{}, response)
+}
+
+func (suite *HandlerSuite) TestValidateEntitlementHandlerManagesNilShipmentWeightEstimate() {
+	// Given: a set of orders, a move, user, servicemember and an HHG
+	shipment := testdatagen.MakeDefaultShipment(suite.DB())
+	move := shipment.Move
+
+	// This endpoint can be called when the shipment weight estimate has not been set
+	shipment.WeightEstimate = nil
+	suite.MustSave(&shipment)
+
+	// And: the context contains the auth values
+	request := httptest.NewRequest("GET", "/entitlements/move_id", nil)
+	request = suite.AuthenticateRequest(request, move.Orders.ServiceMember)
+
+	params := entitlementop.ValidateEntitlementParams{
+		HTTPRequest: request,
+		MoveID:      strfmt.UUID(move.ID.String()),
+	}
+
+	// And: validate entitlements endpoint is hit
+	handler := ValidateEntitlementHandler{handlers.NewHandlerContext(suite.DB(), suite.TestLogger())}
+	response := handler.Handle(params)
+
+	// Then: expect a 200 status code
+	suite.Assertions.IsType(&entitlementop.ValidateEntitlementOK{}, response)
+}


### PR DESCRIPTION
## Description

It's possible that the weight estimate doesn't exist on a move or shipment before the estimator is called. This will throw a 500 error if not handled because the value of `WeightEstimate` is `nil`. 

I discovered this when I was load testing in #1597 and called the API endpoint prior to setting the weight estimate (by mistake). 

## Reviewer Notes

In general new moves have a weight estimate of `0` and so I've defaulted to that value here. Alternatively I could throw an error of some sort (which one?) and return it back to the client.

## Setup

I couldn't figure out a good manual test for this yet. I may have to write a new unit test though.

## Code Review Verification Steps

* [ ] Request review from a member of a different team.