### PR TITLE
increase timeout on golangci-lint to 8 minutes

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -38,10 +38,7 @@ issues:
         - govet
   fix: true
 run:
-  # timeout for analysis, e.g. 30s, 5m, default is 1m
-  deadline: 8m
-
-#  # which dirs to skip: they won't be analyzed;
+  # which dirs to skip: they won't be analyzed;
   skip-dirs:
     - pkg/gen
     - mocks

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -38,7 +38,11 @@ issues:
         - govet
   fix: true
 run:
-  # which dirs to skip: they won't be analyzed;
+  # timeout for analysis, e.g. 30s, 5m, default is 1m
+  deadline: 8m
+  concurrency: 1
+
+# which dirs to skip: they won't be analyzed;
   skip-dirs:
     - pkg/gen
     - mocks

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -39,7 +39,7 @@ issues:
   fix: true
 run:
   # timeout for analysis, e.g. 30s, 5m, default is 1m
-  deadline: 10m
+  deadline: 8m
 
 #  # which dirs to skip: they won't be analyzed;
   skip-dirs:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -37,3 +37,10 @@ issues:
       linters:
         - govet
   fix: true
+run:
+  # timeout for analysis, e.g. 30s, 5m, default is 1m
+  deadline: 10m
+
+#  # which dirs to skip: they won't be analyzed;
+  skip-dirs:
+    - pkg/gen

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -44,3 +44,4 @@ run:
 #  # which dirs to skip: they won't be analyzed;
   skip-dirs:
     - pkg/gen
+    - mocks

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
     rev: v1.16.0
     hooks:
       - id: golangci-lint
-        entry: golangci-lint run --fix --verbose --deadline=5m
+        entry: golangci-lint run --verbose
         verbose: true
 
   - repo: git://github.com/igorshubovych/markdownlint-cli

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
     rev: v1.16.0
     hooks:
       - id: golangci-lint
-        entry: golangci-lint run --fix --verbose
+        entry: golangci-lint run --fix --verbose --deadline=5m
         verbose: true
 
   - repo: git://github.com/igorshubovych/markdownlint-cli

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,6 +31,8 @@ repos:
     rev: v1.16.0
     hooks:
       - id: golangci-lint
+        entry: golangci-lint run --fix --verbose
+        verbose: true
 
   - repo: git://github.com/igorshubovych/markdownlint-cli
     rev: v0.16.0


### PR DESCRIPTION
## Description

Golangci-lint is taking 4x to run on circle ci. This PR will bump the timeout to 8 minutes and skip running linters on code from generated files.
 
## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/166653999) for this change

![image](https://user-images.githubusercontent.com/5003421/59384995-722d5c00-8d31-11e9-9fb9-9da1d146f108.png)

