### PR TITLE
PPM payment request: Non-storage Expense page: Save behavior

### DIFF
--- a/cypress/integration/mymove/ppm.js
+++ b/cypress/integration/mymove/ppm.js
@@ -202,7 +202,7 @@ describe('allows a SM to request a payment', function() {
     serviceMemberCanCancel();
   });
 
-  it('service member request payment entire flow', () => {
+  it('service member goes through entire request payment flow', () => {
     serviceMemberSubmitsWeightTicket('CAR', false);
     serviceMemberViewsExpensesLandingPage();
     serviceMemberUploadsExpenses();

--- a/cypress/integration/mymove/ppm.js
+++ b/cypress/integration/mymove/ppm.js
@@ -193,6 +193,7 @@ describe('allows a SM to request a payment', function() {
     cy.server();
     cy.route('POST', '**/internal/uploads').as('postUploadDocument');
     cy.route('POST', '**/moves/**/weight_ticket').as('postWeightTicket');
+    cy.route('POST', '**/moves/**/moving_expense_documents').as('postMovingExpense');
     cy.signInAsUserPostRequest(milmoveAppName, '8e0d7e98-134e-4b28-bdd1-7d6b1ff34f9e');
   });
 
@@ -201,10 +202,10 @@ describe('allows a SM to request a payment', function() {
     serviceMemberCanCancel();
   });
 
-  it('service member requests car weight ticket payment and views expenses landing page', () => {
+  it('service member request payment entire flow', () => {
     serviceMemberSubmitsWeightTicket('CAR', false);
     serviceMemberViewsExpensesLandingPage();
-    serviceMemberViewsExpensesUploadPage();
+    serviceMemberUploadsExpenses();
   });
 
   it('service member requests a box truck weight ticket payment', () => {
@@ -303,7 +304,7 @@ function serviceMemberViewsExpensesLandingPage() {
     .click();
 }
 
-function serviceMemberViewsExpensesUploadPage() {
+function serviceMemberUploadsExpenses() {
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/moves\/[^/]+\/ppm-expenses/);
   });
@@ -321,9 +322,33 @@ function serviceMemberViewsExpensesUploadPage() {
   cy.get('input[name="missingReceipt"]').should('not.be.checked');
   cy.get('input[name="paymentMethod"][value="GTCC"]').should('not.be.checked');
   cy.get('input[name="paymentMethod"][value="OTHER"]').should('be.checked');
-
   cy.get('input[name="haveMoreExpenses"][value="Yes"]').should('not.be.checked');
   cy.get('input[name="haveMoreExpenses"][value="No"]').should('be.checked');
+  cy.get('input[name="haveMoreExpenses"][value="Yes"]+label').click();
+
+  cy.contains('Save & Add Another').click();
+  cy
+    .wait('@postMovingExpense')
+    .its('status')
+    .should('eq', 200);
+
+  // Add an expense that's missing a receipt
+  cy.contains('Expense 2');
+
+  cy.get('select[name="moving_expense_type"]').select('GAS');
+  cy.get('input[name="title"]').type('title 2');
+  cy.get('input[name="requested_amount_cents"]').type('2000');
+
+  cy.get('input[name="missingReceipt"]').should('not.be.checked');
+  cy.get('input[name="missingReceipt"]+label').click();
+  cy.get('input[name="missingReceipt"]').should('be.checked');
+  cy.get('input[name="haveMoreExpenses"][value="Yes"]+label').click();
+
+  cy.contains('Save & Add Another').click();
+  cy
+    .wait('@postMovingExpense')
+    .its('status')
+    .should('eq', 200);
 }
 
 function serviceMemberSubmitsCarTrailerWeightTicket() {
@@ -424,7 +449,10 @@ function serviceMemberSavesWeightTicketForLater(vehicleType) {
     .get('button')
     .contains('Save For Later')
     .click();
-  cy.wait('@postWeightTicket');
+  cy
+    .wait('@postWeightTicket')
+    .its('status')
+    .should('eq', 200);
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/$/);
   });

--- a/migrations/20190612185213_add_receipt_missing_moving_expense_documents.up.sql
+++ b/migrations/20190612185213_add_receipt_missing_moving_expense_documents.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE moving_expense_documents
+	ADD COLUMN receipt_missing bool DEFAULT FALSE;

--- a/pkg/handlers/internalapi/move_documents.go
+++ b/pkg/handlers/internalapi/move_documents.go
@@ -97,7 +97,7 @@ func payloadForMoveDocumentExtractor(storer storage.FileStorer, docExtractor mod
 	}
 	var receiptMissing *bool
 	if docExtractor.ReceiptMissing != nil {
-		trailerOwnershipMissing = docExtractor.ReceiptMissing
+		receiptMissing = docExtractor.ReceiptMissing
 	}
 
 	payload := internalmessages.MoveDocumentPayload{

--- a/pkg/handlers/internalapi/move_documents.go
+++ b/pkg/handlers/internalapi/move_documents.go
@@ -95,6 +95,10 @@ func payloadForMoveDocumentExtractor(storer storage.FileStorer, docExtractor mod
 	if docExtractor.TrailerOwnershipMissing != nil {
 		trailerOwnershipMissing = docExtractor.TrailerOwnershipMissing
 	}
+	var receiptMissing *bool
+	if docExtractor.ReceiptMissing != nil {
+		trailerOwnershipMissing = docExtractor.ReceiptMissing
+	}
 
 	payload := internalmessages.MoveDocumentPayload{
 		ID:                       handlers.FmtUUID(docExtractor.ID),
@@ -108,6 +112,7 @@ func payloadForMoveDocumentExtractor(storer storage.FileStorer, docExtractor mod
 		MovingExpenseType:        expenseType,
 		RequestedAmountCents:     int64(requestedAmt),
 		PaymentMethod:            paymentMethod,
+		ReceiptMissing:           receiptMissing,
 		VehicleOptions:           vehicleOptions,
 		VehicleNickname:          vehicleNickname,
 		EmptyWeight:              emptyWeight,

--- a/pkg/handlers/internalapi/moving_expense_documents.go
+++ b/pkg/handlers/internalapi/moving_expense_documents.go
@@ -96,7 +96,7 @@ func (h CreateMovingExpenseDocumentHandler) Handle(params movedocop.CreateMoving
 		ppmID = &id
 	}
 
-	moveingExpenseDocument := models.MovingExpenseDocument{
+	movingExpenseDocument := models.MovingExpenseDocument{
 		MovingExpenseType:    models.MovingExpenseType(payload.MovingExpenseType),
 		RequestedAmountCents: unit.Cents(*payload.RequestedAmountCents),
 		PaymentMethod:        *payload.PaymentMethod,
@@ -109,7 +109,7 @@ func (h CreateMovingExpenseDocumentHandler) Handle(params movedocop.CreateMoving
 		models.MoveDocumentType(payload.MoveDocumentType),
 		*payload.Title,
 		payload.Notes,
-		moveingExpenseDocument,
+		movingExpenseDocument,
 		*move.SelectedMoveType,
 	)
 

--- a/pkg/models/move.go
+++ b/pkg/models/move.go
@@ -365,10 +365,9 @@ func (m Move) CreateMovingExpenseDocument(
 	moveDocumentType MoveDocumentType,
 	title string,
 	notes *string,
-	requestedAmountCents unit.Cents,
-	paymentMethod string,
-	movingExpenseType MovingExpenseType,
-	moveType SelectedMoveType) (*MovingExpenseDocument, *validate.Errors, error) {
+	expenseDocument MovingExpenseDocument,
+	moveType SelectedMoveType,
+) (*MovingExpenseDocument, *validate.Errors, error) {
 
 	var newMovingExpenseDocument *MovingExpenseDocument
 	var responseError error
@@ -394,9 +393,10 @@ func (m Move) CreateMovingExpenseDocument(
 		newMovingExpenseDocument = &MovingExpenseDocument{
 			MoveDocumentID:       newMoveDocument.ID,
 			MoveDocument:         *newMoveDocument,
-			MovingExpenseType:    movingExpenseType,
-			RequestedAmountCents: requestedAmountCents,
-			PaymentMethod:        paymentMethod,
+			MovingExpenseType:    expenseDocument.MovingExpenseType,
+			RequestedAmountCents: expenseDocument.RequestedAmountCents,
+			PaymentMethod:        expenseDocument.PaymentMethod,
+			ReceiptMissing:       expenseDocument.ReceiptMissing,
 		}
 		verrs, err := db.ValidateAndCreate(newMovingExpenseDocument)
 		if err != nil || verrs.HasAny() {

--- a/pkg/models/move_documents_extractor.go
+++ b/pkg/models/move_documents_extractor.go
@@ -23,6 +23,7 @@ type MoveDocumentExtractor struct {
 	MoveDocumentType         MoveDocumentType   `json:"move_document_type" db:"move_document_type"`
 	MovingExpenseType        *MovingExpenseType `json:"moving_expense_type" db:"moving_expense_type"`
 	RequestedAmountCents     *unit.Cents        `json:"requested_amount_cents" db:"requested_amount_cents"`
+	ReceiptMissing           *bool              `json:"receipt_missing" db:"receipt_missing"`
 	EmptyWeight              *unit.Pound        `json:"empty_weight,omitempty" db:"empty_weight"`
 	EmptyWeightTicketMissing *bool              `json:"empty_weight_ticket_missing,omitempty" db:"empty_weight_ticket_missing"`
 	FullWeight               *unit.Pound        `json:"full_weight,omitempty" db:"full_weight"`
@@ -52,6 +53,7 @@ func (m *Move) FetchAllMoveDocumentsForMove(db *pop.Connection) (MoveDocumentExt
 	  ed.moving_expense_type,
 	  ed.requested_amount_cents,
 	  ed.payment_method,
+      ed.receipt_missing,
 	  wt.empty_weight,
 	  wt.empty_weight_ticket_missing,
 	  wt.full_weight_ticket_missing,

--- a/pkg/models/moving_expense_document.go
+++ b/pkg/models/moving_expense_document.go
@@ -56,6 +56,7 @@ type MovingExpenseDocument struct {
 	MovingExpenseType    MovingExpenseType `json:"moving_expense_type" db:"moving_expense_type"`
 	RequestedAmountCents unit.Cents        `json:"requested_amount_cents" db:"requested_amount_cents"`
 	PaymentMethod        string            `json:"payment_method" db:"payment_method"`
+	ReceiptMissing       bool              `json:"receipt_missing" db:"receipt_missing"`
 	CreatedAt            time.Time         `json:"created_at" db:"created_at"`
 	UpdatedAt            time.Time         `json:"updated_at" db:"updated_at"`
 }

--- a/src/scenes/Moves/Ppm/ExpensesUpload.jsx
+++ b/src/scenes/Moves/Ppm/ExpensesUpload.jsx
@@ -6,7 +6,8 @@ import PPMPaymentRequestActionBtns from './PPMPaymentRequestActionBtns';
 import WizardHeader from '../WizardHeader';
 
 import 'shared/DocumentViewer/DocumentUploader.jsx';
-import { get, isEmpty } from 'lodash';
+import { get, isEmpty, map } from 'lodash';
+import { convertDollarsToCents } from 'shared/utils';
 import RadioButton from 'shared/RadioButton';
 import { Link } from 'react-router-dom';
 import FontAwesomeIcon from '@fortawesome/react-fontawesome';
@@ -16,6 +17,7 @@ import Uploader from 'shared/Uploader';
 import Checkbox from 'shared/Checkbox';
 import { getFormValues, reduxForm } from 'redux-form';
 import { connect } from 'react-redux';
+import { createMovingExpenseDocument } from 'shared/Entities/modules/movingExpenseDocuments';
 import Alert from 'shared/Alert';
 
 class ExpensesUpload extends Component {
@@ -50,6 +52,54 @@ class ExpensesUpload extends Component {
     });
   };
 
+  saveForLaterHandler = formValues => {
+    const { history } = this.props;
+    return this.saveAndAddHandler(formValues).then(() => {
+      if (this.state.moveDocumentCreateError === false) {
+        history.push('/');
+      }
+    });
+  };
+
+  saveAndAddHandler = formValues => {
+    const { moveId, currentPpm } = this.props;
+    const { paymentMethod, missingReceipt } = this.state;
+    const { title, moving_expense_type: movingExpenseType, requested_amount_cents: requestedAmountCents } = formValues;
+
+    // eslint-disable-next-line security/detect-object-injection
+    let files = this.uploader.getFiles();
+    const uploadIds = map(files, 'id');
+    const personallyProcuredMoveId = currentPpm ? currentPpm.id : null;
+    return this.props
+      .createMovingExpenseDocument({
+        moveId,
+        personallyProcuredMoveId,
+        uploadIds,
+        title,
+        movingExpenseType,
+        moveDocumentType: 'EXPENSE',
+        requestedAmountCents: convertDollarsToCents(requestedAmountCents),
+        paymentMethod,
+        notes: '',
+        missingReceipt,
+      })
+      .then(() => {
+        this.setState({ expenseNumber: this.state.expenseNumber + 1 });
+        this.cleanup();
+      })
+      .catch(e => {
+        this.setState({ moveDocumentCreateError: true });
+      });
+  };
+
+  cleanup = () => {
+    const { reset } = this.props;
+    // eslint-disable-next-line security/detect-object-injection
+    this.uploader.clearFiles();
+    reset();
+    this.setState({ ...this.initialState });
+  };
+
   onAddFile = () => {
     this.setState({
       uploaderIsIdle: false,
@@ -72,9 +122,22 @@ class ExpensesUpload extends Component {
     alert('Cash, personal credit card, check — any payment method that’s not your GTCC.');
   };
 
+  formIsIncomplete = () => {
+    const { formValues } = this.props;
+    const { missingReceipt } = this.state;
+    const receiptUploaded = this.uploader && !this.uploader.isEmpty();
+    return !(
+      formValues &&
+      formValues.moving_expense_type &&
+      formValues.title &&
+      formValues.requested_amount_cents &&
+      (missingReceipt || receiptUploaded)
+    );
+  };
+
   render() {
     const { missingReceipt, paymentMethod, haveMoreExpenses, expenseNumber, moveDocumentCreateError } = this.state;
-    const { moveDocSchema, formValues, isPublic } = this.props;
+    const { moveDocSchema, formValues, isPublic, handleSubmit, submitting } = this.props;
     const nextBtnLabel =
       haveMoreExpenses === 'Yes'
         ? ExpensesUpload.nextBtnLabels.SaveAndAddAnother
@@ -162,7 +225,7 @@ class ExpensesUpload extends Component {
                     aria-hidden
                     className="color_blue_link"
                     icon={faQuestionCircle}
-                    onClick={this.handleRadioChange}
+                    onClick={this.handleHowDidYouPayForThis}
                   />
                 </div>
                 <div className="dashed-divider" />
@@ -191,9 +254,12 @@ class ExpensesUpload extends Component {
             )}
             <PPMPaymentRequestActionBtns
               nextBtnLabel={nextBtnLabel}
-              submitButtonsAreDisabled={true}
-              saveForLaterHandler={() => {}}
-              saveAndAddHandler={() => {}}
+              submitButtonsAreDisabled={
+                this.formIsIncomplete() || nextBtnLabel === ExpensesUpload.nextBtnLabels.SaveAndContinue
+              }
+              submitting={submitting}
+              saveForLaterHandler={handleSubmit(this.saveForLaterHandler)}
+              saveAndAddHandler={handleSubmit(this.saveAndAddHandler)}
               displaySaveForLater={true}
             />
           </form>
@@ -216,4 +282,9 @@ function mapStateToProps(state, props) {
     currentPpm: get(state, 'ppm.currentPpm'),
   };
 }
-export default connect(mapStateToProps)(ExpensesUpload);
+
+const mapDispatchToProps = {
+  createMovingExpenseDocument,
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(ExpensesUpload);

--- a/src/scenes/Moves/Ppm/PaymentRequest.jsx
+++ b/src/scenes/Moves/Ppm/PaymentRequest.jsx
@@ -61,6 +61,7 @@ export class PaymentRequest extends Component {
         requestedAmountCents: convertDollarsToCents(requestedAmountCents),
         paymentMethod,
         notes,
+        missingReceipt: false,
       });
     }
     return this.props.createMoveDocument({

--- a/src/scenes/Office/DocumentViewer/DocumentUploader.jsx
+++ b/src/scenes/Office/DocumentViewer/DocumentUploader.jsx
@@ -50,6 +50,7 @@ export class DocumentUploader extends Component {
     });
     if (get(formValues, 'move_document_type', false) === 'EXPENSE') {
       formValues.requested_amount_cents = convertDollarsToCents(formValues.requested_amount_cents);
+      const missingReceipt = false;
       this.props
         .createMovingExpenseDocument(
           moveId,
@@ -61,7 +62,7 @@ export class DocumentUploader extends Component {
           formValues.requested_amount_cents,
           formValues.payment_method,
           formValues.notes,
-          false,
+          missingReceipt,
         )
         .then(() => {
           reset();
@@ -195,4 +196,5 @@ function mapDispatchToProps(dispatch) {
     dispatch,
   );
 }
+
 export default connect(mapStateToProps, mapDispatchToProps)(DocumentUploader);

--- a/src/scenes/Office/DocumentViewer/DocumentUploader.jsx
+++ b/src/scenes/Office/DocumentViewer/DocumentUploader.jsx
@@ -61,6 +61,7 @@ export class DocumentUploader extends Component {
           formValues.requested_amount_cents,
           formValues.payment_method,
           formValues.notes,
+          false,
         )
         .then(() => {
           reset();

--- a/src/scenes/Office/DocumentViewer/DocumentUploader.jsx
+++ b/src/scenes/Office/DocumentViewer/DocumentUploader.jsx
@@ -50,7 +50,7 @@ export class DocumentUploader extends Component {
     });
     if (get(formValues, 'move_document_type', false) === 'EXPENSE') {
       formValues.requested_amount_cents = convertDollarsToCents(formValues.requested_amount_cents);
-      const missingReceipt = false;
+      const receiptMissing = false;
       this.props
         .createMovingExpenseDocument(
           moveId,
@@ -62,7 +62,7 @@ export class DocumentUploader extends Component {
           formValues.requested_amount_cents,
           formValues.payment_method,
           formValues.notes,
-          missingReceipt,
+          receiptMissing,
         )
         .then(() => {
           reset();

--- a/src/scenes/Office/DocumentViewer/index.jsx
+++ b/src/scenes/Office/DocumentViewer/index.jsx
@@ -97,6 +97,7 @@ class DocumentViewer extends Component {
         requestedAmountCents: convertDollarsToCents(requestedAmountCents),
         paymentMethod,
         notes,
+        missingReceipt: false,
       });
     }
     return this.props.createMoveDocument({

--- a/src/shared/Entities/modules/movingExpenseDocuments.js
+++ b/src/shared/Entities/modules/movingExpenseDocuments.js
@@ -22,6 +22,7 @@ export function createMovingExpenseDocument({
   requestedAmountCents,
   paymentMethod,
   notes,
+  missingReceipt,
 }) {
   return async function(dispatch, getState, { schema }) {
     const client = await getClient();
@@ -36,6 +37,7 @@ export function createMovingExpenseDocument({
         requested_amount_cents: requestedAmountCents,
         payment_method: paymentMethod,
         notes: notes,
+        receipt_missing: missingReceipt,
       },
     });
     checkResponse(response, 'failed to create moving expense document due to server error');

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -765,6 +765,10 @@ definitions:
         x-display-value:
           OTHER: Other account
           GTCC: GTCC
+      receipt_missing:
+        title: missing expense receipt
+        type: boolean
+        x-nullable: true
       vehicle_options:
         title: What type of vehicle are these weight tickets for?
         type: string
@@ -889,13 +893,15 @@ definitions:
         x-display-value:
           OTHER: Other payment method
           GTCC: GTCC
+      receipt_missing:
+        title: missing expense receipt
+        type: boolean
       notes:
         type: string
         example: This document is good to go!
         x-nullable: true
         title: Notes
     required:
-      - upload_ids
       - title
       - move_document_type
       - moving_expense_type


### PR DESCRIPTION
## Description

Allows service members to save expense information

## Reviewer Notes

The `moving_expense_documents` endpoint by default would reject any expense documents without associated upload ids. The new PPM closeout flow allows users to explicitly say that they are missing a receipt and proceed to save the expense (whereas before this wasn't allowed). I updated the endpoint to accept a receipt missing parameter, but kept the behavior (receipt required) the same for existing endpoint calls. Also, I made the default in db for existing moves false, since the previous endpoint design enforced that behavior. But extra scrutiny on the various expense upload screens to verify that they are behaving as expect is appreciated. 

## Setup

```sh
make e2e_test
make server_test

```
1) Login as a user that is ready to request payment (e.g. ppm@requestingpay.ment)
2) Navigate through the closeout flow until the expense screen (`/ppm-expenses`)
3) Attempt to upload several expense documents (both with / without receipts)


## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/tree/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/tree/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/n/projects/2181745/stories/166132117) for this change