### PR TITLE
Use NoError

### DIFF
--- a/pkg/cli/auth_test.go
+++ b/pkg/cli/auth_test.go
@@ -2,5 +2,5 @@ package cli
 
 func (suite *cliTestSuite) TestConfigAuth() {
 	suite.Setup(InitAuthFlags, []string{})
-	suite.Nil(CheckAuth(suite.viper))
+	suite.NoError(CheckAuth(suite.viper))
 }

--- a/pkg/cli/build_test.go
+++ b/pkg/cli/build_test.go
@@ -2,5 +2,5 @@ package cli
 
 func (suite *cliTestSuite) TestConfigBuild() {
 	suite.Setup(InitBuildFlags, []string{})
-	suite.Nil(CheckBuild(suite.viper))
+	suite.NoError(CheckBuild(suite.viper))
 }

--- a/pkg/cli/certs_test.go
+++ b/pkg/cli/certs_test.go
@@ -12,5 +12,5 @@ func (suite *cliTestSuite) TestDODCertificates() {
 	}
 
 	suite.Setup(InitCertFlags, []string{})
-	suite.Nil(CheckCert(suite.viper))
+	suite.NoError(CheckCert(suite.viper))
 }

--- a/pkg/cli/csrf_test.go
+++ b/pkg/cli/csrf_test.go
@@ -2,5 +2,5 @@ package cli
 
 func (suite *cliTestSuite) TestConfigCSRF() {
 	suite.Setup(InitCSRFFlags, []string{})
-	suite.Nil(CheckCSRF(suite.viper))
+	suite.NoError(CheckCSRF(suite.viper))
 }

--- a/pkg/cli/dbconn_test.go
+++ b/pkg/cli/dbconn_test.go
@@ -6,7 +6,7 @@ import (
 
 func (suite *cliTestSuite) TestConfigDatabase() {
 	suite.Setup(InitDatabaseFlags, []string{})
-	suite.Nil(CheckDatabase(suite.viper, suite.logger))
+	suite.NoError(CheckDatabase(suite.viper, suite.logger))
 }
 
 func (suite *cliTestSuite) TestInitDatabase() {

--- a/pkg/cli/devlocal_test.go
+++ b/pkg/cli/devlocal_test.go
@@ -2,5 +2,5 @@ package cli
 
 func (suite *cliTestSuite) TestConfigDevlocal() {
 	suite.Setup(InitDevlocalFlags, []string{})
-	suite.Nil(CheckDevlocal(suite.viper))
+	suite.NoError(CheckDevlocal(suite.viper))
 }

--- a/pkg/cli/dps_test.go
+++ b/pkg/cli/dps_test.go
@@ -2,5 +2,5 @@ package cli
 
 func (suite *cliTestSuite) TestConfigDPS() {
 	suite.Setup(InitDPSFlags, []string{})
-	suite.Nil(CheckDPS(suite.viper))
+	suite.NoError(CheckDPS(suite.viper))
 }

--- a/pkg/cli/eia_test.go
+++ b/pkg/cli/eia_test.go
@@ -2,5 +2,5 @@ package cli
 
 func (suite *cliTestSuite) TestConfigEIA() {
 	suite.Setup(InitEIAFlags, []string{})
-	suite.Nil(CheckEIA(suite.viper))
+	suite.NoError(CheckEIA(suite.viper))
 }

--- a/pkg/cli/email_test.go
+++ b/pkg/cli/email_test.go
@@ -2,5 +2,5 @@ package cli
 
 func (suite *cliTestSuite) TestConfigEmail() {
 	suite.Setup(InitEmailFlags, []string{})
-	suite.Nil(CheckEmail(suite.viper))
+	suite.NoError(CheckEmail(suite.viper))
 }

--- a/pkg/cli/environment_test.go
+++ b/pkg/cli/environment_test.go
@@ -2,5 +2,5 @@ package cli
 
 func (suite *cliTestSuite) TestConfigEnvironment() {
 	suite.Setup(InitEnvironmentFlags, []string{})
-	suite.Nil(CheckEnvironment(suite.viper))
+	suite.NoError(CheckEnvironment(suite.viper))
 }

--- a/pkg/cli/gex_test.go
+++ b/pkg/cli/gex_test.go
@@ -2,5 +2,5 @@ package cli
 
 func (suite *cliTestSuite) TestConfigGEX() {
 	suite.Setup(InitGEXFlags, []string{})
-	suite.Nil(CheckGEX(suite.viper))
+	suite.NoError(CheckGEX(suite.viper))
 }

--- a/pkg/cli/honeycomb_test.go
+++ b/pkg/cli/honeycomb_test.go
@@ -12,7 +12,7 @@ func (suite *cliTestSuite) TestHoneycomb() {
 	}
 
 	suite.Setup(InitHoneycombFlags, []string{})
-	suite.Nil(CheckHoneycomb(suite.viper))
+	suite.NoError(CheckHoneycomb(suite.viper))
 	enabled := InitHoneycomb(suite.viper, suite.logger)
 	suite.True(enabled)
 }

--- a/pkg/cli/hosts_test.go
+++ b/pkg/cli/hosts_test.go
@@ -2,5 +2,5 @@ package cli
 
 func (suite *cliTestSuite) TestConfigHosts() {
 	suite.Setup(InitHostFlags, []string{})
-	suite.Nil(CheckHosts(suite.viper))
+	suite.NoError(CheckHosts(suite.viper))
 }

--- a/pkg/cli/iws_test.go
+++ b/pkg/cli/iws_test.go
@@ -2,5 +2,5 @@ package cli
 
 func (suite *cliTestSuite) TestConfigIWS() {
 	suite.Setup(InitIWSFlags, []string{})
-	suite.Nil(CheckIWS(suite.viper))
+	suite.NoError(CheckIWS(suite.viper))
 }

--- a/pkg/cli/middleware_test.go
+++ b/pkg/cli/middleware_test.go
@@ -2,5 +2,5 @@ package cli
 
 func (suite *cliTestSuite) TestConfigMiddleware() {
 	suite.Setup(InitMiddlewareFlags, []string{})
-	suite.Nil(CheckMiddleWare(suite.viper))
+	suite.NoError(CheckMiddleWare(suite.viper))
 }

--- a/pkg/cli/migration_test.go
+++ b/pkg/cli/migration_test.go
@@ -2,5 +2,5 @@ package cli
 
 func (suite *cliTestSuite) TestConfigMigration() {
 	suite.Setup(InitMigrationFlags, []string{})
-	suite.Nil(CheckMigration(suite.viper))
+	suite.NoError(CheckMigration(suite.viper))
 }

--- a/pkg/cli/ports_test.go
+++ b/pkg/cli/ports_test.go
@@ -2,5 +2,5 @@ package cli
 
 func (suite *cliTestSuite) TestConfigPorts() {
 	suite.Setup(InitPortFlags, []string{})
-	suite.Nil(CheckPorts(suite.viper))
+	suite.NoError(CheckPorts(suite.viper))
 }

--- a/pkg/cli/route_test.go
+++ b/pkg/cli/route_test.go
@@ -2,5 +2,5 @@ package cli
 
 func (suite *cliTestSuite) TestConfigRoute() {
 	suite.Setup(InitRouteFlags, []string{})
-	suite.Nil(CheckRoute(suite.viper))
+	suite.NoError(CheckRoute(suite.viper))
 }

--- a/pkg/cli/storage_test.go
+++ b/pkg/cli/storage_test.go
@@ -2,5 +2,5 @@ package cli
 
 func (suite *cliTestSuite) TestConfigStorage() {
 	suite.Setup(InitStorageFlags, []string{})
-	suite.Nil(CheckStorage(suite.viper))
+	suite.NoError(CheckStorage(suite.viper))
 }

--- a/pkg/cli/swagger_test.go
+++ b/pkg/cli/swagger_test.go
@@ -2,5 +2,5 @@ package cli
 
 func (suite *cliTestSuite) TestConfigSwagger() {
 	suite.Setup(InitSwaggerFlags, []string{})
-	suite.Nil(CheckSwagger(suite.viper))
+	suite.NoError(CheckSwagger(suite.viper))
 }

--- a/pkg/cli/vault_test.go
+++ b/pkg/cli/vault_test.go
@@ -2,5 +2,5 @@ package cli
 
 func (suite *cliTestSuite) TestConfigVault() {
 	suite.Setup(InitVaultFlags, []string{})
-	suite.Nil(CheckVault(suite.viper))
+	suite.NoError(CheckVault(suite.viper))
 }

--- a/pkg/cli/verbose_test.go
+++ b/pkg/cli/verbose_test.go
@@ -2,5 +2,5 @@ package cli
 
 func (suite *cliTestSuite) TestConfigVerbose() {
 	suite.Setup(InitVerboseFlags, []string{})
-	suite.Nil(CheckVerbose(suite.viper))
+	suite.NoError(CheckVerbose(suite.viper))
 }


### PR DESCRIPTION
## Description

We should use `NoError` instead of `NotNil`, since `NoError` will format the error properly, instead of using default go struct formatting.

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Setup

```
cd pkg/cli EIA_KEY= go test
```

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/tree/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/tree/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/tree/master/docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
  * [ ] Secure migrations have been tested using `scripts/run-prod-migrations`
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

None

## Screenshots

None