### PR TITLE
Expose entitlements via API request

### DIFF
--- a/pkg/handlers/internalapi/api.go
+++ b/pkg/handlers/internalapi/api.go
@@ -89,6 +89,7 @@ func NewInternalAPIHandler(context handlers.HandlerContext) http.Handler {
 	internalAPI.OfficeApproveReimbursementHandler = ApproveReimbursementHandler{context}
 	internalAPI.OfficeCancelMoveHandler = CancelMoveHandler{context}
 
+	internalAPI.EntitlementsIndexEntitlementsHandler = IndexEntitlementsHandler{context}
 	internalAPI.EntitlementsValidateEntitlementHandler = ValidateEntitlementHandler{context}
 
 	internalAPI.CalendarShowAvailableMoveDatesHandler = ShowAvailableMoveDatesHandler{context}

--- a/pkg/handlers/internalapi/entitlements.go
+++ b/pkg/handlers/internalapi/entitlements.go
@@ -12,9 +12,42 @@ import (
 
 	"github.com/transcom/mymove/pkg/auth"
 	entitlementop "github.com/transcom/mymove/pkg/gen/internalapi/internaloperations/entitlements"
+	"github.com/transcom/mymove/pkg/gen/internalmessages"
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/models"
 )
+
+func payloadForEntitlementModel(e models.WeightAllotment) internalmessages.WeightAllotment {
+	// Type Conversion
+	TotalWeightSelf := int64(e.TotalWeightSelf)
+	TotalWeightSelfPlusDependents := int64(e.TotalWeightSelfPlusDependents)
+	ProGearWeight := int64(e.ProGearWeight)
+	ProGearWeightSpouse := int64(e.ProGearWeightSpouse)
+
+	return internalmessages.WeightAllotment{
+		TotalWeightSelf:               &TotalWeightSelf,
+		TotalWeightSelfPlusDependents: &TotalWeightSelfPlusDependents,
+		ProGearWeight:                 &ProGearWeight,
+		ProGearWeightSpouse:           &ProGearWeightSpouse,
+	}
+}
+
+// IndexEntitlementsHandler indexes entitlements
+type IndexEntitlementsHandler struct {
+	handlers.HandlerContext
+}
+
+// Handle is the handler
+func (h IndexEntitlementsHandler) Handle(params entitlementop.IndexEntitlementsParams) middleware.Responder {
+	entitlements := models.IndexWeightAllotment()
+	payload := make(map[string]internalmessages.WeightAllotment)
+	for k, v := range entitlements {
+		rank := string(k)
+		allotment := payloadForEntitlementModel(v)
+		payload[rank] = allotment
+	}
+	return entitlementop.NewIndexEntitlementsOK().WithPayload(payload)
+}
 
 // ValidateEntitlementHandler validates a weight estimate based on entitlement for a PPM move
 type ValidateEntitlementHandler struct {

--- a/pkg/handlers/internalapi/entitlements.go
+++ b/pkg/handlers/internalapi/entitlements.go
@@ -39,7 +39,7 @@ type IndexEntitlementsHandler struct {
 
 // Handle is the handler
 func (h IndexEntitlementsHandler) Handle(params entitlementop.IndexEntitlementsParams) middleware.Responder {
-	entitlements := models.IndexWeightAllotment()
+	entitlements := models.AllWeightAllotments()
 	payload := make(map[string]internalmessages.WeightAllotment)
 	for k, v := range entitlements {
 		rank := string(k)

--- a/pkg/handlers/internalapi/entitlements_test.go
+++ b/pkg/handlers/internalapi/entitlements_test.go
@@ -14,6 +14,27 @@ import (
 	"github.com/transcom/mymove/pkg/unit"
 )
 
+func (suite *HandlerSuite) TestIndexEntitlementsHandlerReturns200() {
+	// Given: a set of orders, a move, user, servicemember and a PPM
+	ppm := testdatagen.MakeDefaultPPM(suite.DB())
+	move := ppm.Move
+
+	// And: the context contains the auth values
+	request := httptest.NewRequest("GET", "/entitlements", nil)
+	request = suite.AuthenticateRequest(request, move.Orders.ServiceMember)
+
+	params := entitlementop.IndexEntitlementsParams{
+		HTTPRequest: request,
+	}
+
+	// And: index entitlements endpoint is hit
+	handler := IndexEntitlementsHandler{handlers.NewHandlerContext(suite.DB(), suite.TestLogger())}
+	response := handler.Handle(params)
+
+	// Then: expect a 200 status code
+	suite.Assertions.IsType(&entitlementop.IndexEntitlementsOK{}, response)
+}
+
 func (suite *HandlerSuite) TestValidateEntitlementHandlerReturns200() {
 	// Given: a set of orders, a move, user, servicemember and a PPM
 	ppm := testdatagen.MakeDefaultPPM(suite.DB())

--- a/pkg/models/entitlements.go
+++ b/pkg/models/entitlements.go
@@ -202,8 +202,8 @@ func makeEntitlements() map[ServiceMemberRank]WeightAllotment {
 	return entitlements
 }
 
-// IndexWeightAllotment returns all the weight allotments for each rank.
-func IndexWeightAllotment() map[ServiceMemberRank]WeightAllotment {
+// AllWeightAllotments returns all the weight allotments for each rank.
+func AllWeightAllotments() map[ServiceMemberRank]WeightAllotment {
 	return makeEntitlements()
 }
 

--- a/pkg/models/entitlements.go
+++ b/pkg/models/entitlements.go
@@ -202,6 +202,11 @@ func makeEntitlements() map[ServiceMemberRank]WeightAllotment {
 	return entitlements
 }
 
+// IndexWeightAllotment returns all the weight allotments for each rank.
+func IndexWeightAllotment() map[ServiceMemberRank]WeightAllotment {
+	return makeEntitlements()
+}
+
 // GetWeightAllotment returns the weight allotments for a given rank.
 func GetWeightAllotment(rank ServiceMemberRank) WeightAllotment {
 	entitlements := makeEntitlements()

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -2574,6 +2574,30 @@ definitions:
     required:
       - start_date
       - available
+  WeightAllotment:
+    type: object
+    properties:
+      total_weight_self:
+        type: integer
+        example: 18000
+      total_weight_self_plus_dependents:
+        type: integer
+        example: 18000
+      pro_gear_weight:
+        type: integer
+        example: 2000
+      pro_gear_weight_spouse:
+        type: integer
+        example: 500
+    required:
+      - total_weight_self
+      - total_weight_self_plus_dependents
+      - pro_gear_weight
+      - pro_gear_weight_spouse
+  IndexEntitlements:
+    type: object
+    additionalProperties:
+      $ref: '#/definitions/WeightAllotment'
 paths:
   /estimates/ppm:
     get:
@@ -4260,6 +4284,18 @@ paths:
           description: request requires user authentication
         403:
           description: user is not authorized to access this queue
+  /entitlements:
+    get:
+      summary: List weight weights allotted by entitlement
+      description:  List weight weights allotted by entitlement
+      operationId: indexEntitlements
+      tags:
+        - entitlements
+      responses:
+        200:
+          description: List of weights allotted entitlement
+          schema:
+            $ref: '#/definitions/IndexEntitlements'
   /entitlements/{moveId}:
     get:
       summary: Validates that the stored weight estimate is below the allotted entitlement range for a service member


### PR DESCRIPTION
## Description

Adding a new API endpoint to the internal API that exposes the entitlements that map service member rank to entitled weight allotment. This change DOES NOT AFFECT any client code.  It may support future use cases but not at this time.

This supports automating load testing in #1597 .

## Reviewer Notes

I attempted to make the naming consistent between the model and the swagger definition file. I'm not happy with `IndexEntitlements` as its not a list but a map that is returned.  Happy to change it.

In this process I noticed that the entitlements between the Golang and Javascript files are inconsistent:

- [Golang]( https://github.com/transcom/mymove/blob/59dc3984ac26704e96b5784d169a77ad7361a78a/pkg/models/entitlements.go#L18)
- [Javascript](https://github.com/transcom/mymove/blob/59dc3984ac26704e96b5784d169a77ad7361a78a/src/shared/entitlements.js#L38)

I also noticed that the Javascript code doesn't call out the [O1-5 and W1-5 entitlements separately by rank](https://github.com/transcom/mymove/blob/59dc3984ac26704e96b5784d169a77ad7361a78a/src/shared/entitlements.js#L102-L131), which makes me question how these are being looked up.

## Setup

Log in as a service member locally. Then browse to http://milmovelocal:3000/internal/docs#/entitlements/indexEntitlements and execute the api call. You should see the returned data in a map.

## Code Review Verification Steps

* [ ] Request review from a member of a different team.