### PR TITLE
Add deploy to experimental instructions

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -411,6 +411,7 @@ toolset
 metadata
 Codecov
 `testing.Short`
+uncomment
 # Put all custom terms BEFORE this comment, lest 'pre-commit' and 'make spellcheck' yield different errors.
  - /usr/local
  - docs/data/tspp-data-creation.md

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,6 +22,7 @@ If you are looking to understand choices made in this project, see the list of [
 * [Call Swagger Endpoints from React](how-to/access-swagger-endpoints-from-react.md#how-to-call-swagger-endpoints-from-react)
 * [Add Application Logging](how-to/add-application-logging.md#how-to-add-application-logging)
 * [Backup and Restore the Development Database](how-to/backup-and-restore-dev-database.md#how-to-backup-and-restore-the-development-database)
+* [Deploy to Experimental](how-to/deploy-to-experimental.md#how-to-deploy-to-experimental)
 * [display dates and times](how-to/display-dates-and-times.md#how-to-display-dates-and-times)
 * [Generate Mocks with Mockery](how-to/generate-mocks-with-mockery.md#how-to-generate-mocks-with-mockery)
 * [Instrument Data in Honeycomb](how-to/instrument-data-in-honeycomb.md#how-to-instrument-data-in-honeycomb)

--- a/docs/how-to/deploy-to-experimental.md
+++ b/docs/how-to/deploy-to-experimental.md
@@ -1,6 +1,6 @@
 # How to Deploy to Experimental
 
-Experimental is the MilMove environment that can be used to test out a branch out. This is especially good if you'd like Product, Design, or the client to test out a change before you merge the code in. It's also a good decision to use experimental to test out particularly risky changes.
+Experimental is the MilMove environment that can be used to test out a code change in a branch in a safe way. This is especially good if you'd like Product, Design, or the client to test out the change before you merge the code in. It's also a good decision to use experimental to test out particularly risky changes like changes to containers, app startup, connection to data stores, secure migrations and data loads.
 
 ## How to do it
 
@@ -14,12 +14,12 @@ Edit [the config file](https://github.com/transcom/mymove/blob/master/.circleci/
       ignore: your_branch_name_goes_here
 ```
 
-When you push up to Github, it'll trigger the CircleCI workflow to start. You can view it's progress on [CircleCI's UI](https://circleci.com/gh/transcom/workflows/mymove) and clicking on your branch. If it's succeeded, then it should be up on [SM experimental](https://my.experimental.move.mil/), [Office experimental](https://office.experimental.move.mil/), and [TSP experimental](https://tsp.experimental.move.mil/). Best practices mean you should announce deploys to experimental in the `#dp3-engineering` slack channel, so only one person is trying to use it at the same time.
+Best practices mean you should announce deploys to experimental in the `#dp3-experinental-env` slack channel at least 20 minutes before you intend to deploy. Try to get a 👍 from someone who is commonly using experimental. If no one comments in that time-frame feel free to deploy. Only one person can use experimental at the same time. Any deploys will overwrite what is currently on experimental. When you push up to Github, it'll trigger the CircleCI workflow to start immediately. You can view its progress on [CircleCI's UI](https://circleci.com/gh/transcom/workflows/mymove) and clicking on your branch. If it has succeeded, then it should be available immediately on [SM experimental](https://my.experimental.move.mil/), [Office experimental](https://office.experimental.move.mil/), and [TSP experimental](https://tsp.experimental.move.mil/).
 
 ## I've got a server-side feature flag
 
-You'll need to add it to [the container definition](https://github.com/transcom/mymove/blob/master/config/app.container-definition.json) in the `environment` array with the name of the server-side flag and the value you'd like it to be on experimental.
+You'll need to add it to [experimental config file](https://github.com/transcom/mymove/blob/master/config/env/experimental.env).
 
 ## Don't forget to clean up your branch for your pr review
 
-All of the [how to do it instructions](#How-to-do-it) need to be reverted so all future branches don't get deployed to experimental. Also, be sure to announce in `#dp3-engineering` that experimental is available for someone else to use!
+All of the [how to do it instructions](#How-to-do-it) need to be reverted so all future branches don't get deployed to experimental. Also, be sure to announce in `#dp3-experimental-env` that experimental is available for someone else to use!

--- a/docs/how-to/deploy-to-experimental.md
+++ b/docs/how-to/deploy-to-experimental.md
@@ -1,0 +1,25 @@
+# How to Deploy to Experimental
+
+Experimental is the MilMove environment that can be used to test out a branch out. This is especially good if you'd like Product, Design, or the client to test out a change before you merge the code in. It's also a good decision to use experimental to test out particularly risky changes.
+
+## How to do it
+
+To deploy to experimental, you'll need to trigger the CircleCI workflow to include the deploy to experimental steps.
+Edit [the config file](https://github.com/transcom/mymove/blob/master/.circleci/config.yml) by replacing all instances of `placeholder_branch_name` with your branch name. You'll also want to uncomment any of these lines (and related ones), like this:
+
+```sh
+# if testing on experimental, you can disable these tests by using the commented block below.
+  filters:
+    branches:
+      ignore: your_branch_name_goes_here
+```
+
+When you push up to Github, it'll trigger the CircleCI workflow to start. You can view it's progress on [CircleCI's UI](https://circleci.com/gh/transcom/workflows/mymove) and clicking on your branch. If it's succeeded, then it should be up on [SM experimental](https://my.experimental.move.mil/), [Office experimental](https://office.experimental.move.mil/), and [TSP experimental](https://tsp.experimental.move.mil/). Best practices mean you should announce deploys to experimental in the `#dp3-engineering` slack channel, so only one person is trying to use it at the same time.
+
+## I've got a server-side feature flag
+
+You'll need to add it to [the container definition](https://github.com/transcom/mymove/blob/master/config/app.container-definition.json) in the `environment` array with the name of the server-side flag and the value you'd like it to be on experimental.
+
+## Don't forget to clean up your branch for your pr review
+
+All of the [how to do it instructions](#How-to-do-it) need to be reverted so all future branches don't get deployed to experimental. Also, be sure to announce in `#dp3-engineering` that experimental is available for someone else to use!

--- a/docs/how-to/deploy-to-experimental.md
+++ b/docs/how-to/deploy-to-experimental.md
@@ -18,7 +18,7 @@ Best practices mean you should announce deploys to experimental in the `#dp3-exp
 
 ## I've got a server-side feature flag
 
-You'll need to add it to [experimental config file](https://github.com/transcom/mymove/blob/master/config/env/experimental.env).
+You'll need to add it to [experimental config file](https://github.com/transcom/mymove/blob/master/config/env/experimental.env). In [the container config file](https://github.com/transcom/mymove/blob/master/config/app.container-definition.json) you'll need to add it by using mustache syntax.
 
 ## Don't forget to clean up your branch for your pr review
 


### PR DESCRIPTION
## Description

Adds documentation about how to deploy to experimental as well as how to clean up after yourself.

## Setup

n/a

## Code Review Verification Steps

* [x] Request review from a member of a different team.
