### PR TITLE
Include Moves in Draft and Submitted Status Office PPM Queue [delivers #165859430]

### DIFF
--- a/pkg/models/queue.go
+++ b/pkg/models/queue.go
@@ -86,7 +86,7 @@ func GetMoveQueueItems(db *pop.Connection, lifecycleState string) ([]MoveQueueIt
 			JOIN service_members AS sm ON ord.service_member_id = sm.id
 			JOIN personally_procured_moves AS ppm ON moves.id = ppm.move_id
 			LEFT JOIN shipments AS shipment ON moves.id = shipment.move_id
-			WHERE moves.status = 'APPROVED'
+			WHERE moves.status in ('DRAFT', 'SUBMITTED', 'APPROVED')
 			and moves.show is true
 		`
 	} else if lifecycleState == "hhg_approved" {

--- a/pkg/models/queue_test.go
+++ b/pkg/models/queue_test.go
@@ -3,6 +3,7 @@ package models_test
 import (
 	"github.com/go-openapi/swag"
 
+	"github.com/transcom/mymove/pkg/models"
 	. "github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"
 )
@@ -41,4 +42,35 @@ func (suite *ModelSuite) TestCreateNewMoveShowFalse() {
 	moves, moveErrs := GetMoveQueueItems(suite.DB(), "all")
 	suite.Nil(moveErrs)
 	suite.Empty(moves)
+}
+
+func (suite *ModelSuite) TestShowMovesDraftSubmittedApprovedPPMQueue() {
+	// Make three PPMs with different move statuses
+	testdatagen.MakePPM(suite.DB(), testdatagen.Assertions{
+		Move: models.Move{
+			Status: models.MoveStatusDRAFT,
+		},
+	})
+	testdatagen.MakePPM(suite.DB(), testdatagen.Assertions{
+		Move: models.Move{
+			Status: models.MoveStatusSUBMITTED,
+		},
+	})
+	testdatagen.MakePPM(suite.DB(), testdatagen.Assertions{
+		Move: models.Move{
+			Status: models.MoveStatusAPPROVED,
+		},
+	})
+
+	// Move canceled should not return, for testing
+	testdatagen.MakePPM(suite.DB(), testdatagen.Assertions{
+		Move: models.Move{
+			Status: models.MoveStatusCANCELED,
+		},
+	})
+
+	// Expected 3 moves for PPM queue returned
+	moves, err := GetMoveQueueItems(suite.DB(), "ppm")
+	suite.Nil(err)
+	suite.Len(moves, 3)
 }


### PR DESCRIPTION
## Description

This fixes a bug that only included moves that have been `APPROVED`. We're now including moves statuses in `DRAFT`,  `SUBMITTED`, `APPROVED` for the office ppm queue.

The ppms status should include approved, payment requested or completed states.

## Setup

1. Login office app, locally
2. Find moves in statuses `DRAFT`,  `SUBMITTED`, `APPROVED`
3. Keep note of those moves
3. Navigate to PPM queue
4. Check if those moves are in the PPM queue

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/tree/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/tree/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/165859430) for this change
