### PR TITLE
Remove bold font from tsp edit forms

### DIFF
--- a/src/shared/StorageInTransit/StorageInTransitTspEditForm.jsx
+++ b/src/shared/StorageInTransit/StorageInTransitTspEditForm.jsx
@@ -49,6 +49,7 @@ export class StorageInTransitTspEditForm extends Component {
           <PanelSwaggerField fieldName="estimated_start_date" required title="Estimated start date" {...fieldProps} />
           {inSit || isReleased || isDelivered ? (
             <SwaggerField
+              className="storage-in-transit-form"
               fieldName="actual_start_date"
               swagger={storageInTransitSchema}
               title="Actual start date"
@@ -67,6 +68,7 @@ export class StorageInTransitTspEditForm extends Component {
           )}
           {isReleased || isDelivered ? (
             <SwaggerField
+              className="storage-in-transit-form"
               fieldName="out_date"
               disabledDays={disabledDaysForOutDayPicker}
               minDate={minDate}


### PR DESCRIPTION
## Description

In the TSP SIT edit forms the date fields should be normal font. This small fix replaces bold font with normal font.

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/165900387) for this change

## Screenshots
<img width="1008" alt="Screen Shot 2019-06-13 at 2 42 33 PM" src="https://user-images.githubusercontent.com/3522044/59472676-2099d580-8df4-11e9-8d54-aa809c04da34.png">
