### PR TITLE
Add secure migration for new Suddath users

### DIFF
--- a/migrations/20190613230926_add_suddath_to_tsp_users.up.fizz
+++ b/migrations/20190613230926_add_suddath_to_tsp_users.up.fizz
@@ -1,0 +1,1 @@
+exec("./apply-secure-migration.sh 20190613230926_add_suddath_to_tsp_users.sql")


### PR DESCRIPTION
## Description

Add two new users for Suddath

## Reviewer Notes

The SCAC we appear to be using for other Suddath users is SSOW, so I went ahead and used that same TSP here.

##Testing Locally
 
1. Run `run-prod-migrations` (make sure you enter `y` when prompted to continue).
2. Run `psql-prod-migrations` to open the postgres CLI for the prod migrations db
3. Query the new users to see them! `select * from tsp_users;`

## Code Review Verification Steps

* Any new migrations/schema changes:
  * [x] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/tree/master/docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
  * [x] Secure migrations have been tested using `scripts/run-prod-migrations`
* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/166530713) for this change
