### PR TITLE
PPM payment request: Weight ticket page: Allow Saving empty weight tickets

### DIFF
--- a/cypress/integration/mymove/ppm.js
+++ b/cypress/integration/mymove/ppm.js
@@ -208,8 +208,8 @@ describe('allows a SM to request a payment', function() {
     serviceMemberUploadsExpenses();
   });
 
-  it('service member requests a box truck weight ticket payment', () => {
-    serviceMemberSubmitsWeightTicket('BOX_TRUCK');
+  it('service member submits weight tickets without any documents', () => {
+    serviceMemberSubmitsWeightsTicketsWithoutReceipts();
   });
 
   it('service member requests a car + trailer weight ticket payment', () => {
@@ -372,7 +372,7 @@ function serviceMemberSubmitsCarTrailerWeightTicket() {
     .first()
     .check({ force: true });
 
-  cy.upload_file('.filepond--root:first', 'top-secret.png');
+  cy.upload_file('[data-cy=trailer-upload] .filepond--root', 'top-secret.png');
   cy.wait('@postUploadDocument');
   cy.get('[data-filepond-item-state="processing-complete"]').should('have.length', 1);
 
@@ -419,31 +419,18 @@ function serviceMemberSavesWeightTicketForLater(vehicleType) {
   cy.get('input[name="vehicle_nickname"]').type('Nickname');
 
   cy.get('input[name="empty_weight"]').type('1000');
-  cy.upload_file('.filepond--root:first', 'top-secret.png');
+  cy.upload_file('[data-cy=empty-weight-upload] .filepond--root', 'top-secret.png');
   cy.wait('@postUploadDocument');
   cy.get('[data-filepond-item-state="processing-complete"]').should('have.length', 1);
 
   cy.get('input[name="full_weight"]').type('5000');
-  cy.upload_file('.filepond--root:last', 'top-secret.png');
+  cy.upload_file('[data-cy=full-weight-upload] .filepond--root', 'top-secret.png');
   cy.wait('@postUploadDocument');
   cy.get('[data-filepond-item-state="processing-complete"]').should('have.length', 2);
   cy
     .get('input[name="weight_ticket_date"]')
     .type('6/2/2018{enter}')
     .blur();
-
-  cy.get('input[name="missingEmptyWeightTicket"]').check({ force: true });
-
-  cy
-    .get('.usa-alert-warning')
-    .contains(
-      'Contact your local Transportation Office (PPPO) to let them know you’re missing this weight ticket. For now, keep going and enter the info you do have.',
-    );
-
-  cy
-    .get('[type="radio"]')
-    .first()
-    .should('be.checked');
 
   cy
     .get('button')
@@ -458,6 +445,32 @@ function serviceMemberSavesWeightTicketForLater(vehicleType) {
   });
 }
 
+function serviceMemberSubmitsWeightsTicketsWithoutReceipts() {
+  cy.contains('Request Payment').click();
+  cy
+    .get('button')
+    .contains('Get Started')
+    .click();
+
+  cy.get('select[name="vehicle_options"]').select('CAR_TRAILER');
+  cy.get('input[name="vehicle_nickname"]').type('Nickname');
+  cy.get('input[name="empty_weight"]').type('1000');
+  cy.get('input[name="full_weight"]').type('2000');
+  cy.get('input[name="valid_trailer"][value="Yes"]+label').click();
+  cy.get('input[name="missingDocumentation"]+label').click();
+  cy.get('input[name="missingEmptyWeightTicket"]+label').click();
+  cy.get('input[name="missingFullWeightTicket"]+label').click();
+  cy
+    .get('input[name="weight_ticket_date"]')
+    .type('6/2/2018{enter}')
+    .blur();
+  cy
+    .get('button')
+    .contains('Save & Add Another')
+    .click();
+  cy.wait('@postWeightTicket');
+}
+
 function serviceMemberSubmitsWeightTicket(vehicleType, hasAnother = true) {
   cy.contains('Request Payment').click();
   cy
@@ -470,12 +483,13 @@ function serviceMemberSubmitsWeightTicket(vehicleType, hasAnother = true) {
   cy.get('input[name="vehicle_nickname"]').type('Nickname');
 
   cy.get('input[name="empty_weight"]').type('1000');
-  cy.upload_file('.filepond--root:first', 'top-secret.png');
+
+  cy.upload_file('[data-cy=empty-weight-upload] .filepond--root', 'top-secret.png');
   cy.wait('@postUploadDocument');
   cy.get('[data-filepond-item-state="processing-complete"]').should('have.length', 1);
 
   cy.get('input[name="full_weight"]').type('5000');
-  cy.upload_file('.filepond--root:last', 'top-secret.png');
+  cy.upload_file('[data-cy=full-weight-upload] .filepond--root', 'top-secret.png');
   cy.wait('@postUploadDocument');
   cy.get('[data-filepond-item-state="processing-complete"]').should('have.length', 2);
   cy

--- a/cypress/integration/mymove/ppm.js
+++ b/cypress/integration/mymove/ppm.js
@@ -378,12 +378,6 @@ function serviceMemberSubmitsCarTrailerWeightTicket() {
 
   cy.get('input[name="missingDocumentation"]').check({ force: true });
 
-  cy
-    .get('.usa-alert-warning')
-    .contains(
-      'If your state does not provide a registration or bill of sale for your trailer, you may write and upload a signed and dated statement certifying that you or your spouse own the trailer and meets the trailer criteria. Upload your statement using the proof of ownership field.',
-    );
-
   cy.get('input[name="empty_weight"]').type('1000');
   cy.get('input[name="missingEmptyWeightTicket"]').check({ force: true });
 
@@ -395,12 +389,6 @@ function serviceMemberSubmitsCarTrailerWeightTicket() {
     .get('input[name="weight_ticket_date"]')
     .type('6/2/2018{enter}')
     .blur();
-
-  cy
-    .get('.usa-alert-warning')
-    .contains(
-      'Contact your local Transportation Office (PPPO) to let them know you’re missing this weight ticket. For now, keep going and enter the info you do have.',
-    );
 
   cy
     .get('[type="radio"]')
@@ -456,10 +444,25 @@ function serviceMemberSubmitsWeightsTicketsWithoutReceipts() {
   cy.get('input[name="vehicle_nickname"]').type('Nickname');
   cy.get('input[name="empty_weight"]').type('1000');
   cy.get('input[name="full_weight"]').type('2000');
-  cy.get('input[name="valid_trailer"][value="Yes"]+label').click();
+  cy.get('input[name="isValidTrailer"][value="Yes"]+label').click();
   cy.get('input[name="missingDocumentation"]+label').click();
+  cy
+    .get('[data-cy=trailer-warning]')
+    .contains(
+      'If your state does not provide a registration or bill of sale for your trailer, you may write and upload a signed and dated statement certifying that you or your spouse own the trailer and meets the trailer criteria. Upload your statement using the proof of ownership field.',
+    );
   cy.get('input[name="missingEmptyWeightTicket"]+label').click();
+  cy
+    .get('[data-cy=empty-warning]')
+    .contains(
+      'Contact your local Transportation Office (PPPO) to let them know you’re missing this weight ticket. For now, keep going and enter the info you do have.',
+    );
   cy.get('input[name="missingFullWeightTicket"]+label').click();
+  cy
+    .get('[data-cy=full-warning]')
+    .contains(
+      'Contact your local Transportation Office (PPPO) to let them know you’re missing this weight ticket. For now, keep going and enter the info you do have.',
+    );
   cy
     .get('input[name="weight_ticket_date"]')
     .type('6/2/2018{enter}')

--- a/pkg/handlers/internalapi/weight_ticket_set_documents.go
+++ b/pkg/handlers/internalapi/weight_ticket_set_documents.go
@@ -60,13 +60,7 @@ func (h CreateWeightTicketSetDocumentHandler) Handle(params movedocop.CreateWeig
 	}
 
 	payload := params.CreateWeightTicketDocument
-
-	// Fetch uploads to confirm ownership
 	uploadIds := payload.UploadIds
-	if len(uploadIds) == 0 {
-		return movedocop.NewCreateWeightTicketDocumentBadRequest()
-	}
-
 	uploads := models.Uploads{}
 	for _, id := range uploadIds {
 		converted := uuid.Must(uuid.FromString(id.String()))

--- a/src/scenes/Moves/Ppm/WeightTicket.test.js
+++ b/src/scenes/Moves/Ppm/WeightTicket.test.js
@@ -6,11 +6,11 @@ import store from 'shared/store';
 import MockRouter from 'react-mock-router';
 import PPMPaymentRequestActionBtns from './PPMPaymentRequestActionBtns';
 
-function mountComponents(moreWeightTickets = 'Yes', formIsIncomplete) {
+function mountComponents(moreWeightTickets = 'Yes', disableSubmit) {
   const initialValues = {
     empty_weight: 1100,
     full_weight: 2000,
-    vehicle_nickname: 'HALE',
+    vehicle_nickname: 'KIRBY',
     vehicle_options: 'CAR',
     weight_ticket_date: '2019-05-22',
   };
@@ -23,8 +23,8 @@ function mountComponents(moreWeightTickets = 'Yes', formIsIncomplete) {
     </Provider>,
   );
   const wt = wrapper.find('WeightTicket');
-  if (formIsIncomplete !== undefined) {
-    wt.instance().formIsIncomplete = jest.fn().mockReturnValue(formIsIncomplete);
+  if (disableSubmit !== undefined) {
+    wt.instance().submitButtonsAreDisabled = jest.fn().mockReturnValue(disableSubmit);
   }
   wt.setState({ additionalWeightTickets: moreWeightTickets, initialValues: initialValues });
   wt.update();
@@ -93,29 +93,50 @@ describe('Weight tickets page', () => {
   });
 });
 
-describe('missingWeightTickets', () => {
+describe('uploaderWithInvalidState', () => {
   it('returns true when there are no uploaders', () => {
     const weightTicket = mountComponents('No');
-    weightTicket.instance().uploaders = {};
+    const uploaders = {
+      emptyWeight: { uploaderRef: {} },
+      fullWeight: { uploaderRef: {} },
+      trailer: { uploaderRef: {} },
+    };
+    weightTicket.instance().uploaders = uploaders;
+    uploaders.emptyWeight.uploaderRef.isEmpty = jest.fn(() => false);
+    uploaders.emptyWeight.isMissingChecked = jest.fn(() => false);
+    uploaders.fullWeight.uploaderRef.isEmpty = jest.fn(() => false);
+    uploaders.fullWeight.isMissingChecked = jest.fn(() => false);
 
-    expect(weightTicket.instance().isMissingWeightTickets()).toEqual(true);
+    expect(weightTicket.instance().uploaderWithInvalidState()).toEqual(false);
   });
-  it('returns false when both uploaders have at least one file', () => {
+  it('returns false when uploaders have at least one file and isMissing is not checked', () => {
     const weightTicket = mountComponents('No');
-    const uploaders = { one: {}, two: {} };
-    uploaders['one'].isEmpty = jest.fn(() => false);
-    uploaders['two'].isEmpty = jest.fn(() => false);
+    const uploaders = {
+      emptyWeight: { uploaderRef: {} },
+      fullWeight: { uploaderRef: {} },
+      trailer: { uploaderRef: {} },
+    };
+    uploaders.emptyWeight.uploaderRef.isEmpty = jest.fn(() => false);
+    uploaders.emptyWeight.isMissingChecked = jest.fn(() => false);
+    uploaders.fullWeight.uploaderRef.isEmpty = jest.fn(() => false);
+    uploaders.fullWeight.isMissingChecked = jest.fn(() => false);
     weightTicket.instance().uploaders = uploaders;
 
-    expect(weightTicket.instance().isMissingWeightTickets()).toEqual(false);
+    expect(weightTicket.instance().uploaderWithInvalidState()).toEqual(false);
   });
-  it('returns true when one uploaders do not have at least one file', () => {
+  it('returns true when uploaders have at least one file and isMissing is checked', () => {
     const weightTicket = mountComponents('No');
-    const uploaders = { one: {}, two: {} };
-    uploaders['one'].isEmpty = jest.fn(() => false);
-    uploaders['two'].isEmpty = jest.fn(() => true);
+    const uploaders = {
+      emptyWeight: { uploaderRef: {} },
+      fullWeight: { uploaderRef: {} },
+      trailer: { uploaderRef: {} },
+    };
+    uploaders.emptyWeight.uploaderRef.isEmpty = jest.fn(() => false);
+    uploaders.emptyWeight.isMissingChecked = jest.fn(() => false);
+    uploaders.fullWeight.uploaderRef.isEmpty = jest.fn(() => false);
+    uploaders.fullWeight.isMissingChecked = jest.fn(() => true);
     weightTicket.instance().uploaders = uploaders;
 
-    expect(weightTicket.instance().isMissingWeightTickets()).toEqual(true);
+    expect(weightTicket.instance().uploaderWithInvalidState()).toEqual(true);
   });
 });


### PR DESCRIPTION
## Description

Allows for the submitting of weight tickets that are missing the accompanying receipt. 

## Setup

1) Login as a user that is ready to request payment (e.g. ppm@requestingpay.ment)
2) Navigate through the closeout flow until the weight ticket uploads screen (/ppm-weight-ticket)
3) Attempt to upload several weight ticket documents. Experiment with different combinations of the vehicles selected and the checkboxes both checked and unchecked.

```sh
make e2e_test
make client_test
```

## Code Review Verification Steps
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/n/projects/2181745/stories/165887786) for this change