### PR TITLE
Office PPM queue: only show ppms in approved, payment requested and completed status [delivers #165859430]

### DIFF
--- a/cypress/integration/office/officeUserPPM.js
+++ b/cypress/integration/office/officeUserPPM.js
@@ -297,12 +297,6 @@ function officeUserApprovesMoveAndPPM(moveLocator) {
     expect(loc.pathname).to.match(/^\/queues\/new/);
   });
 
-  // Open PPMs Queue
-  cy
-    .get('span')
-    .contains('PPMs')
-    .click();
-
   // Find move and open it
   cy.selectQueueItemMoveLocator(moveLocator);
 

--- a/pkg/handlers/internalapi/move_queue_items_test.go
+++ b/pkg/handlers/internalapi/move_queue_items_test.go
@@ -40,6 +40,7 @@ func (suite *HandlerSuite) TestShowQueueHandler() {
 			PersonallyProcuredMove: models.PersonallyProcuredMove{
 				Move:   newMove,
 				MoveID: newMove.ID,
+				Status: models.PPMStatusAPPROVED,
 			},
 		})
 

--- a/pkg/models/queue.go
+++ b/pkg/models/queue.go
@@ -86,8 +86,8 @@ func GetMoveQueueItems(db *pop.Connection, lifecycleState string) ([]MoveQueueIt
 			JOIN service_members AS sm ON ord.service_member_id = sm.id
 			JOIN personally_procured_moves AS ppm ON moves.id = ppm.move_id
 			LEFT JOIN shipments AS shipment ON moves.id = shipment.move_id
-			WHERE moves.status in ('DRAFT', 'SUBMITTED', 'APPROVED')
-			and moves.show is true
+			WHERE moves.show is true
+			and ppm.status in ('APPROVED', 'PAYMENT_REQUESTED', 'COMPLETED')
 		`
 	} else if lifecycleState == "hhg_approved" {
 

--- a/pkg/models/queue_test.go
+++ b/pkg/models/queue_test.go
@@ -44,28 +44,24 @@ func (suite *ModelSuite) TestCreateNewMoveShowFalse() {
 	suite.Empty(moves)
 }
 
-func (suite *ModelSuite) TestShowMovesDraftSubmittedApprovedPPMQueue() {
-	// Make three PPMs with different move statuses
-	testdatagen.MakePPM(suite.DB(), testdatagen.Assertions{
-		Move: models.Move{
-			Status: models.MoveStatusDRAFT,
-		},
-	})
-	testdatagen.MakePPM(suite.DB(), testdatagen.Assertions{
-		Move: models.Move{
-			Status: models.MoveStatusSUBMITTED,
-		},
-	})
-	testdatagen.MakePPM(suite.DB(), testdatagen.Assertions{
-		Move: models.Move{
-			Status: models.MoveStatusAPPROVED,
-		},
-	})
+func (suite *ModelSuite) TestShowPPMQueue() {
+	// PPMs should only show statuses in the queue:
+	// approved, payment requested and completed
 
-	// Move canceled should not return, for testing
+	// Make PPMs with different statuses
 	testdatagen.MakePPM(suite.DB(), testdatagen.Assertions{
-		Move: models.Move{
-			Status: models.MoveStatusCANCELED,
+		PersonallyProcuredMove: models.PersonallyProcuredMove{
+			Status: models.PPMStatusAPPROVED,
+		},
+	})
+	testdatagen.MakePPM(suite.DB(), testdatagen.Assertions{
+		PersonallyProcuredMove: models.PersonallyProcuredMove{
+			Status: models.PPMStatusPAYMENTREQUESTED,
+		},
+	})
+	testdatagen.MakePPM(suite.DB(), testdatagen.Assertions{
+		PersonallyProcuredMove: models.PersonallyProcuredMove{
+			Status: models.PPMStatusCOMPLETED,
 		},
 	})
 
@@ -73,4 +69,31 @@ func (suite *ModelSuite) TestShowMovesDraftSubmittedApprovedPPMQueue() {
 	moves, err := GetMoveQueueItems(suite.DB(), "ppm")
 	suite.Nil(err)
 	suite.Len(moves, 3)
+}
+
+func (suite *ModelSuite) TestShowPPMQueueStatusDraftSubmittedCanceled() {
+	// PPMs should only show statuses in the queue:
+	// approved, payment requested and completed
+
+	// PPMs not in approved, payment requested or completed states are not returned
+	testdatagen.MakePPM(suite.DB(), testdatagen.Assertions{
+		PersonallyProcuredMove: models.PersonallyProcuredMove{
+			Status: models.PPMStatusDRAFT,
+		},
+	})
+	testdatagen.MakePPM(suite.DB(), testdatagen.Assertions{
+		PersonallyProcuredMove: models.PersonallyProcuredMove{
+			Status: models.PPMStatusSUBMITTED,
+		},
+	})
+	testdatagen.MakePPM(suite.DB(), testdatagen.Assertions{
+		PersonallyProcuredMove: models.PersonallyProcuredMove{
+			Status: models.PPMStatusCANCELED,
+		},
+	})
+
+	// Expected 0 moves for PPM queue returned
+	moves, err := GetMoveQueueItems(suite.DB(), "ppm")
+	suite.Nil(err)
+	suite.Len(moves, 0)
 }


### PR DESCRIPTION
## Description

REWORK

This refactors the office PPM queue query to only include moves with ppms `APPROVED`, `PAYMENT_REQUESTED`, and `COMPLETED` statuses.

## Reviewer Notes

- Please check pivotal story for more info about this bug

## Setup

1. Login to office app, locally
2. Navigate to the `PPMs` queue
3. Make sure that the queue only shows PPMs in `APPROVED`, `PAYMENT_REQUESTED`, and `COMPLETED` statuses.

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/tree/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/tree/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/165859430) for this change