### PR TITLE
Add storage dates to moving_expense_documents endpoint

### DIFF
--- a/migrations/20190617184232_add_storage_start_end_date_to_moving_expenses.up.sql
+++ b/migrations/20190617184232_add_storage_start_end_date_to_moving_expenses.up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE moving_expense_documents
+	ADD COLUMN storage_start_date date,
+	ADD COLUMN storage_end_date date;

--- a/pkg/handlers/internalapi/move_documents.go
+++ b/pkg/handlers/internalapi/move_documents.go
@@ -99,6 +99,14 @@ func payloadForMoveDocumentExtractor(storer storage.FileStorer, docExtractor mod
 	if docExtractor.ReceiptMissing != nil {
 		receiptMissing = docExtractor.ReceiptMissing
 	}
+	var storageStartDate *strfmt.Date
+	if docExtractor.StorageStartDate != nil {
+		storageStartDate = handlers.FmtDate(*docExtractor.StorageStartDate)
+	}
+	var storageEndDate *strfmt.Date
+	if docExtractor.StorageEndDate != nil {
+		storageEndDate = handlers.FmtDate(*docExtractor.StorageEndDate)
+	}
 
 	payload := internalmessages.MoveDocumentPayload{
 		ID:                       handlers.FmtUUID(docExtractor.ID),
@@ -121,6 +129,8 @@ func payloadForMoveDocumentExtractor(storer storage.FileStorer, docExtractor mod
 		FullWeightTicketMissing:  fullWeightTicketMissing,
 		WeightTicketDate:         weightTicketDate,
 		TrailerOwnershipMissing:  trailerOwnershipMissing,
+		StorageStartDate:         storageStartDate,
+		StorageEndDate:           storageEndDate,
 	}
 
 	return &payload, nil

--- a/pkg/handlers/internalapi/moving_expense_documents.go
+++ b/pkg/handlers/internalapi/moving_expense_documents.go
@@ -101,7 +101,7 @@ func (h CreateMovingExpenseDocumentHandler) Handle(params movedocop.CreateMoving
 		storageStartDate = (*time.Time)(payload.StorageStartDate)
 	}
 	var storageEndDate *time.Time
-	if payload.StorageStartDate != nil {
+	if payload.StorageEndDate != nil {
 		storageEndDate = (*time.Time)(payload.StorageEndDate)
 	}
 	movingExpenseDocument := models.MovingExpenseDocument{

--- a/pkg/handlers/internalapi/moving_expense_documents.go
+++ b/pkg/handlers/internalapi/moving_expense_documents.go
@@ -2,6 +2,7 @@ package internalapi
 
 import (
 	"reflect"
+	"time"
 
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/gofrs/uuid"
@@ -22,7 +23,6 @@ func payloadForMovingExpenseDocumentModel(storer storage.FileStorer, movingExpen
 	if err != nil {
 		return nil, err
 	}
-
 	movingExpenseDocumentPayload := internalmessages.MoveDocumentPayload{
 		ID:                   handlers.FmtUUID(movingExpenseDocument.MoveDocument.ID),
 		MoveID:               handlers.FmtUUID(movingExpenseDocument.MoveDocument.MoveID),
@@ -96,11 +96,21 @@ func (h CreateMovingExpenseDocumentHandler) Handle(params movedocop.CreateMoving
 		ppmID = &id
 	}
 
+	var storageStartDate *time.Time
+	if payload.StorageStartDate != nil {
+		storageStartDate = (*time.Time)(payload.StorageStartDate)
+	}
+	var storageEndDate *time.Time
+	if payload.StorageStartDate != nil {
+		storageEndDate = (*time.Time)(payload.StorageEndDate)
+	}
 	movingExpenseDocument := models.MovingExpenseDocument{
 		MovingExpenseType:    models.MovingExpenseType(payload.MovingExpenseType),
 		RequestedAmountCents: unit.Cents(*payload.RequestedAmountCents),
 		PaymentMethod:        *payload.PaymentMethod,
 		ReceiptMissing:       payload.ReceiptMissing,
+		StorageEndDate:       storageEndDate,
+		StorageStartDate:     storageStartDate,
 	}
 	newMovingExpenseDocument, verrs, err := move.CreateMovingExpenseDocument(
 		h.DB(),

--- a/pkg/handlers/internalapi/moving_expense_documents_test.go
+++ b/pkg/handlers/internalapi/moving_expense_documents_test.go
@@ -2,6 +2,7 @@ package internalapi
 
 import (
 	"net/http/httptest"
+	"time"
 
 	"github.com/go-openapi/strfmt"
 	"github.com/gofrs/uuid"
@@ -143,4 +144,41 @@ func (suite *HandlerSuite) TestCreateMovingExpenseDocumentHandlerNoUploadsAndNot
 
 	// Submitting no uploads w/o selecting ReceiptMissing is an error
 	suite.Assertions.IsType(&movedocop.CreateMovingExpenseDocumentBadRequest{}, response)
+}
+
+func (suite *HandlerSuite) TestCreateMovingExpenseDocumentHandlerStorageExpense() {
+	move := testdatagen.MakeDefaultMove(suite.DB())
+	sm := move.Orders.ServiceMember
+	request := httptest.NewRequest("POST", "/fake/path", nil)
+	request = suite.AuthenticateRequest(request, sm)
+	newMovingExpenseDocPayload := internalmessages.CreateMovingExpenseDocumentPayload{
+		MoveDocumentType:     internalmessages.MoveDocumentTypeOTHER,
+		Title:                handlers.FmtString("awesome_document.pdf"),
+		Notes:                handlers.FmtString("Some notes here"),
+		MovingExpenseType:    internalmessages.MovingExpenseTypeSTORAGE,
+		PaymentMethod:        handlers.FmtString("GTCC"),
+		ReceiptMissing:       true,
+		RequestedAmountCents: handlers.FmtInt64(200),
+		StorageStartDate:     handlers.FmtDate(time.Date(2016, 01, 01, 0, 0, 0, 0, time.UTC)),
+		StorageEndDate:       handlers.FmtDate(time.Date(2016, 01, 16, 0, 0, 0, 0, time.UTC)),
+	}
+	newMovingExpenseDocParams := movedocop.CreateMovingExpenseDocumentParams{
+		HTTPRequest:                        request,
+		CreateMovingExpenseDocumentPayload: &newMovingExpenseDocPayload,
+		MoveID:                             strfmt.UUID(move.ID.String()),
+	}
+	context := handlers.NewHandlerContext(suite.DB(), suite.TestLogger())
+	fakeS3 := storageTest.NewFakeS3Storage(true)
+	context.SetFileStorer(fakeS3)
+	handler := CreateMovingExpenseDocumentHandler{context}
+
+	response := handler.Handle(newMovingExpenseDocParams)
+
+	suite.Assertions.IsType(&movedocop.CreateMovingExpenseDocumentOK{}, response)
+	createdResponse := response.(*movedocop.CreateMovingExpenseDocumentOK)
+	movingExpense := models.MovingExpenseDocument{}
+	err := suite.DB().Where("move_document_id = ?", createdResponse.Payload.ID).First(&movingExpense)
+	suite.NoError(err)
+	suite.Equal(movingExpense.StorageEndDate.UTC(), (time.Time)(*newMovingExpenseDocPayload.StorageEndDate))
+	suite.Equal(movingExpense.StorageStartDate.UTC(), (time.Time)(*newMovingExpenseDocPayload.StorageStartDate))
 }

--- a/pkg/models/move.go
+++ b/pkg/models/move.go
@@ -397,6 +397,8 @@ func (m Move) CreateMovingExpenseDocument(
 			RequestedAmountCents: expenseDocument.RequestedAmountCents,
 			PaymentMethod:        expenseDocument.PaymentMethod,
 			ReceiptMissing:       expenseDocument.ReceiptMissing,
+			StorageStartDate:     expenseDocument.StorageStartDate,
+			StorageEndDate:       expenseDocument.StorageEndDate,
 		}
 		verrs, err := db.ValidateAndCreate(newMovingExpenseDocument)
 		if err != nil || verrs.HasAny() {

--- a/pkg/models/move_documents_extractor.go
+++ b/pkg/models/move_documents_extractor.go
@@ -36,6 +36,8 @@ type MoveDocumentExtractor struct {
 	Notes                    *string            `json:"notes" db:"notes"`
 	CreatedAt                time.Time          `json:"created_at" db:"created_at"`
 	UpdatedAt                time.Time          `json:"updated_at" db:"updated_at"`
+	StorageStartDate         *time.Time         `json:"storage_start_date" db:"storage_start_date"`
+	StorageEndDate           *time.Time         `json:"storage_end_date" db:"storage_end_date"`
 }
 
 // MoveDocumentExtractors is not required by pop and may be deleted
@@ -54,6 +56,8 @@ func (m *Move) FetchAllMoveDocumentsForMove(db *pop.Connection) (MoveDocumentExt
 	  ed.requested_amount_cents,
 	  ed.payment_method,
       ed.receipt_missing,
+      ed.storage_start_date,
+      ed.storage_end_date,
 	  wt.empty_weight,
 	  wt.empty_weight_ticket_missing,
 	  wt.full_weight_ticket_missing,

--- a/pkg/models/moving_expense_document.go
+++ b/pkg/models/moving_expense_document.go
@@ -29,6 +29,8 @@ const (
 	MovingExpenseTypeTOLLS MovingExpenseType = "TOLLS"
 	// MovingExpenseTypeOIL captures enum value "OIL"
 	MovingExpenseTypeOIL MovingExpenseType = "OIL"
+	// MovingExpenseTypeSTORAGE captures enum value "STORAGE"
+	MovingExpenseTypeSTORAGE MovingExpenseType = "STORAGE"
 	// MovingExpenseTypeOTHER captures enum value "OTHER"
 	MovingExpenseTypeOTHER MovingExpenseType = "OTHER"
 )
@@ -57,6 +59,8 @@ type MovingExpenseDocument struct {
 	RequestedAmountCents unit.Cents        `json:"requested_amount_cents" db:"requested_amount_cents"`
 	PaymentMethod        string            `json:"payment_method" db:"payment_method"`
 	ReceiptMissing       bool              `json:"receipt_missing" db:"receipt_missing"`
+	StorageStartDate     *time.Time        `json:"storage_start_date" db:"storage_start_date"`
+	StorageEndDate       *time.Time        `json:"storage_end_date" db:"storage_end_date"`
 	CreatedAt            time.Time         `json:"created_at" db:"created_at"`
 	UpdatedAt            time.Time         `json:"updated_at" db:"updated_at"`
 }

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -804,6 +804,18 @@ definitions:
         title: missing trailer ownership documentation
         type: boolean
         x-nullable: true
+      storage_start_date:
+        type: string
+        format: date
+        title: Start date of storage for storage expenses
+        example: '2018-04-26'
+        x-nullable: true
+      storage_end_date:
+        type: string
+        format: date
+        title: End date of storage for storage expenses
+        example: '2018-04-26'
+        x-nullable: true
     required:
       - id
       - move_id
@@ -901,6 +913,18 @@ definitions:
         example: This document is good to go!
         x-nullable: true
         title: Notes
+      storage_start_date:
+        type: string
+        format: date
+        title: Start date of storage for storage expenses
+        example: '2018-04-26'
+        x-nullable: true
+      storage_end_date:
+        type: string
+        format: date
+        title: End date of storage for storage expenses
+        example: '2018-04-26'
+        x-nullable: true
     required:
       - title
       - move_document_type
@@ -917,17 +941,19 @@ definitions:
       - OTHER
       - PACKING_MATERIALS
       - RENTAL_EQUIPMENT
+      - STORAGE
       - TOLLS
       - WEIGHING_FEES
     x-display-value:
       CONTRACTED_EXPENSE: Contracted Expense
-      RENTAL_EQUIPMENT: Rental Equipment
-      PACKING_MATERIALS: Packing Materials
-      WEIGHING_FEES: Weighing Fees
       GAS: Gas
-      TOLLS: Tolls
       OIL: Oil
       OTHER: Other
+      PACKING_MATERIALS: Packing Materials
+      STORAGE: Storage
+      RENTAL_EQUIPMENT: Rental Equipment
+      TOLLS: Tolls
+      WEIGHING_FEES: Weighing Fees
   MoveDocumentStatus:
     type: string
     title: Document Status


### PR DESCRIPTION
## Description

Update `moving_expense_documents` to save storage start and end dates for storage expenses. Currently, storage expenses are stored as a generic move document. This PR updates the `moving_expense_documents` endpoint to accept storage expenses along with their associated storage dates. Also, now calls to `move_documents` for storage expenses, will return the associated storage dates .


## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make server_test
```

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/tree/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/tree/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/tree/master/docs/database.md#zero-downtime-migrations))
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/n/projects/2181745/stories/166479775) for this change
