### PR TITLE
PPM Payment Request: Add storage expense form 

### DIFF
--- a/cypress/integration/mymove/ppm.js
+++ b/cypress/integration/mymove/ppm.js
@@ -335,8 +335,15 @@ function serviceMemberUploadsExpenses() {
   // Add an expense that's missing a receipt
   cy.contains('Expense 2');
 
-  cy.get('select[name="moving_expense_type"]').select('GAS');
-  cy.get('input[name="title"]').type('title 2');
+  cy.get('select[name="moving_expense_type"]').select('STORAGE');
+  cy
+    .get('input[name="storage_start_date"]')
+    .type('6/2/2018{enter}')
+    .blur();
+  cy
+    .get('input[name="storage_end_date"]')
+    .type('6/12/2018{enter}')
+    .blur();
   cy.get('input[name="requested_amount_cents"]').type('2000');
 
   cy.get('input[name="missingReceipt"]').should('not.be.checked');

--- a/cypress/integration/mymove/ppm.js
+++ b/cypress/integration/mymove/ppm.js
@@ -320,8 +320,8 @@ function serviceMemberUploadsExpenses() {
   cy.get('[data-filepond-item-state="processing-complete"]').should('have.length', 1);
 
   cy.get('input[name="missingReceipt"]').should('not.be.checked');
-  cy.get('input[name="paymentMethod"][value="GTCC"]').should('not.be.checked');
-  cy.get('input[name="paymentMethod"][value="OTHER"]').should('be.checked');
+  cy.get('input[name="paymentMethod"][value="GTCC"]').should('be.checked');
+  cy.get('input[name="paymentMethod"][value="OTHER"]').should('not.be.checked');
   cy.get('input[name="haveMoreExpenses"][value="Yes"]').should('not.be.checked');
   cy.get('input[name="haveMoreExpenses"][value="No"]').should('be.checked');
   cy.get('input[name="haveMoreExpenses"][value="Yes"]+label').click();

--- a/cypress/integration/office/documentViewer.js
+++ b/cypress/integration/office/documentViewer.js
@@ -60,7 +60,7 @@ describe('The document viewer', function() {
       cy.get('button.submit').should('be.disabled');
       cy.get('select[name="move_document_type"]').select('Expense');
       cy.get('input[name="title"]').type('expense document');
-      cy.get('select[name="moving_expense_type"]').select('Contracted Expense');
+      cy.get('select[name="moving_expense_type"]').select('Contracted expense');
       cy.get('input[name="requested_amount_cents"]').type('4,000.92');
       cy.get('select[name="payment_method"]').select('Other account');
 
@@ -86,7 +86,7 @@ describe('The document viewer', function() {
 
       // Verify values have been stored correctly
       cy.contains('4,000.92');
-      cy.contains('Contracted Expense');
+      cy.contains('Contracted expense');
       cy.contains('Other account');
 
       // Edit payment method
@@ -146,7 +146,7 @@ describe('The document viewer', function() {
       cy.contains('Edit').click();
 
       cy.get('select[name="moveDocument.move_document_type"]').select('Expense');
-      cy.get('select[name="moveDocument.moving_expense_type"]').select('Contracted Expense');
+      cy.get('select[name="moveDocument.moving_expense_type"]').select('Contracted expense');
       cy.get('input[name="moveDocument.requested_amount_cents"]').type('4,999.92');
       cy.get('select[name="moveDocument.payment_method"]').select('GTCC');
       cy.get('select[name="moveDocument.status"]').select('OK');
@@ -168,7 +168,7 @@ describe('The document viewer', function() {
       cy.get('button.submit').should('be.disabled');
       cy.get('select[name="move_document_type"]').select('Expense');
       cy.get('input[name="title"]').type('expense document');
-      cy.get('select[name="moving_expense_type"]').select('Contracted Expense');
+      cy.get('select[name="moving_expense_type"]').select('Contracted expense');
       cy.get('input[name="requested_amount_cents"]').type('4,000.92');
       cy.get('select[name="payment_method"]').select('Other account');
 

--- a/cypress/integration/office/officeUserHHGPPM.js
+++ b/cypress/integration/office/officeUserHHGPPM.js
@@ -100,7 +100,7 @@ function officeUserSubmitsDocument() {
   cy.get('button.submit').should('be.disabled');
   cy.get('select[name="move_document_type"]').select('Expense');
   cy.get('input[name="title"]').type('expense document for combo');
-  cy.get('select[name="moving_expense_type"]').select('Contracted Expense');
+  cy.get('select[name="moving_expense_type"]').select('Contracted expense');
   cy.get('input[name="requested_amount_cents"]').type('4,000.92');
   cy.get('select[name="payment_method"]').select('Other account');
 

--- a/src/scenes/Moves/Ppm/Expenses.css
+++ b/src/scenes/Moves/Ppm/Expenses.css
@@ -3,7 +3,7 @@
 }
 
 .expenses-header {
-  margin-bottom: 0;
+  margin-bottom: 0.5em;
 }
 
 .expenses-container > p {
@@ -39,9 +39,10 @@
 }
 
 .expenses-form-group {
-  margin: 0 2em 0 0;
+  margin: 0 2em 1em 0;
 }
 
 .expenses-form-group > label {
   margin: 0;
 }
+

--- a/src/scenes/Moves/Ppm/Expenses.css
+++ b/src/scenes/Moves/Ppm/Expenses.css
@@ -37,3 +37,11 @@
   line-height: 1.8em;
   margin-top: 1.8em;
 }
+
+.expenses-form-group {
+  margin: 0 2em 0 0;
+}
+
+.expenses-form-group > label {
+  margin: 0;
+}

--- a/src/scenes/Moves/Ppm/Expenses.css
+++ b/src/scenes/Moves/Ppm/Expenses.css
@@ -38,11 +38,20 @@
   margin-top: 1.8em;
 }
 
+.expenses-group-header {
+  margin: 1.8em 0 -0.5em 0;
+}
+
+.expense-form-element > label {
+  margin: 1.5em 0 0 0;
+}
+
 .expenses-form-group {
-  margin: 0 2em 1em 0;
+  /*border: red solid;*/
+  margin: 0 2em 0 0;
 }
 
 .expenses-form-group > label {
-  margin: 0;
+  margin: 1em 0 0 0;
 }
 

--- a/src/scenes/Moves/Ppm/ExpensesUpload.jsx
+++ b/src/scenes/Moves/Ppm/ExpensesUpload.jsx
@@ -64,12 +64,19 @@ class ExpensesUpload extends Component {
   saveAndAddHandler = formValues => {
     const { moveId, currentPpm } = this.props;
     const { paymentMethod, missingReceipt } = this.state;
-    const { title, moving_expense_type: movingExpenseType, requested_amount_cents: requestedAmountCents } = formValues;
+    const {
+      storage_start_date,
+      storage_end_date,
+      moving_expense_type: movingExpenseType,
+      requested_amount_cents: requestedAmountCents,
+    } = formValues;
 
     // eslint-disable-next-line security/detect-object-injection
     let files = this.uploader.getFiles();
     const uploadIds = map(files, 'id');
     const personallyProcuredMoveId = currentPpm ? currentPpm.id : null;
+    const isStorageExpense = !isEmpty(formValues) && formValues.moving_expense_type === 'STORAGE';
+    const title = isStorageExpense ? 'Storage Expense' : formValues.title;
     return this.props
       .createMovingExpenseDocument({
         moveId,
@@ -82,6 +89,8 @@ class ExpensesUpload extends Component {
         paymentMethod,
         notes: '',
         missingReceipt,
+        storage_start_date,
+        storage_end_date,
       })
       .then(() => {
         this.setState({ expenseNumber: this.state.expenseNumber + 1 });
@@ -122,27 +131,21 @@ class ExpensesUpload extends Component {
     alert('Cash, personal credit card, check — any payment method that’s not your GTCC.');
   };
 
-  formIsIncomplete = () => {
-    const { formValues } = this.props;
+  isInvalidUploaderState = () => {
     const { missingReceipt } = this.state;
     const receiptUploaded = this.uploader && !this.uploader.isEmpty();
-    return !(
-      formValues &&
-      formValues.moving_expense_type &&
-      formValues.title &&
-      formValues.requested_amount_cents &&
-      (missingReceipt || receiptUploaded)
-    );
+    return missingReceipt === receiptUploaded;
   };
 
   render() {
     const { missingReceipt, paymentMethod, haveMoreExpenses, expenseNumber, moveDocumentCreateError } = this.state;
-    const { moveDocSchema, formValues, isPublic, handleSubmit, submitting } = this.props;
+    const { moveDocSchema, formValues, isPublic, handleSubmit, submitting, expenseSchema } = this.props;
     const nextBtnLabel =
       haveMoreExpenses === 'Yes'
         ? ExpensesUpload.nextBtnLabels.SaveAndAddAnother
         : ExpensesUpload.nextBtnLabels.SaveAndContinue;
     const hasMovingExpenseType = !isEmpty(formValues) && formValues.moving_expense_type !== '';
+    const isStorageExpense = !isEmpty(formValues) && formValues.moving_expense_type === 'STORAGE';
     return (
       <>
         <WizardHeader
@@ -177,7 +180,27 @@ class ExpensesUpload extends Component {
             <SwaggerField title="Expense type" fieldName="moving_expense_type" swagger={moveDocSchema} required />
             {hasMovingExpenseType && (
               <>
-                <SwaggerField title="Document title" fieldName="title" swagger={moveDocSchema} required />
+                {isStorageExpense ? (
+                  <div>
+                    <h4 className="expenses-header">Dates</h4>
+                    <SwaggerField
+                      className="short-field expenses-form-group"
+                      fieldName="storage_start_date"
+                      title="Start date"
+                      swagger={expenseSchema}
+                      required
+                    />
+                    <SwaggerField
+                      className="short-field expenses-form-group"
+                      fieldName="storage_end_date"
+                      title="End date"
+                      swagger={expenseSchema}
+                      required
+                    />
+                  </div>
+                ) : (
+                  <SwaggerField title="Document title" fieldName="title" swagger={moveDocSchema} required />
+                )}
                 <SwaggerField
                   className="short-field"
                   title="Amount"
@@ -255,7 +278,7 @@ class ExpensesUpload extends Component {
             <PPMPaymentRequestActionBtns
               nextBtnLabel={nextBtnLabel}
               submitButtonsAreDisabled={
-                this.formIsIncomplete() || nextBtnLabel === ExpensesUpload.nextBtnLabels.SaveAndContinue
+                this.isInvalidUploaderState() || nextBtnLabel === ExpensesUpload.nextBtnLabels.SaveAndContinue
               }
               submitting={submitting}
               saveForLaterHandler={handleSubmit(this.saveForLaterHandler)}
@@ -278,7 +301,7 @@ function mapStateToProps(state, props) {
     moveId: moveId,
     formValues: getFormValues(formName)(state),
     moveDocSchema: get(state, 'swaggerInternal.spec.definitions.MoveDocumentPayload', {}),
-    initialValues: {},
+    expenseSchema: get(state, 'swaggerInternal.spec.definitions.CreateMovingExpenseDocumentPayload', {}),
     currentPpm: get(state, 'ppm.currentPpm'),
   };
 }

--- a/src/scenes/Moves/Ppm/ExpensesUpload.jsx
+++ b/src/scenes/Moves/Ppm/ExpensesUpload.jsx
@@ -185,7 +185,7 @@ class ExpensesUpload extends Component {
               <>
                 {isStorageExpense ? (
                   <div>
-                    <h4 className="expenses-header">Dates</h4>
+                    <h4 className="expenses-group-header">Dates</h4>
                     <SwaggerField
                       className="short-field expenses-form-group"
                       fieldName="storage_start_date"
@@ -205,7 +205,7 @@ class ExpensesUpload extends Component {
                   <SwaggerField title="Document title" fieldName="title" swagger={moveDocSchema} required />
                 )}
                 <SwaggerField
-                  className="short-field"
+                  className="short-field expense-form-element"
                   title="Amount"
                   fieldName="requested_amount_cents"
                   swagger={moveDocSchema}

--- a/src/scenes/Moves/Ppm/ExpensesUpload.jsx
+++ b/src/scenes/Moves/Ppm/ExpensesUpload.jsx
@@ -37,7 +37,7 @@ class ExpensesUpload extends Component {
 
   get initialState() {
     return {
-      paymentMethod: ExpensesUpload.paymentMethods.Other,
+      paymentMethod: ExpensesUpload.paymentMethods.GTCC,
       uploaderIsIdle: true,
       missingReceipt: false,
       expenseType: '',

--- a/src/scenes/Moves/Ppm/ExpensesUpload.jsx
+++ b/src/scenes/Moves/Ppm/ExpensesUpload.jsx
@@ -61,6 +61,10 @@ class ExpensesUpload extends Component {
     });
   };
 
+  isStorageExpense = formValues => {
+    return !isEmpty(formValues) && formValues.moving_expense_type === 'STORAGE';
+  };
+
   saveAndAddHandler = formValues => {
     const { moveId, currentPpm } = this.props;
     const { paymentMethod, missingReceipt } = this.state;
@@ -75,8 +79,7 @@ class ExpensesUpload extends Component {
     let files = this.uploader.getFiles();
     const uploadIds = map(files, 'id');
     const personallyProcuredMoveId = currentPpm ? currentPpm.id : null;
-    const isStorageExpense = !isEmpty(formValues) && formValues.moving_expense_type === 'STORAGE';
-    const title = isStorageExpense ? 'Storage Expense' : formValues.title;
+    const title = this.isStorageExpense(formValues) ? 'Storage Expense' : formValues.title;
     return this.props
       .createMovingExpenseDocument({
         moveId,
@@ -145,7 +148,7 @@ class ExpensesUpload extends Component {
         ? ExpensesUpload.nextBtnLabels.SaveAndAddAnother
         : ExpensesUpload.nextBtnLabels.SaveAndContinue;
     const hasMovingExpenseType = !isEmpty(formValues) && formValues.moving_expense_type !== '';
-    const isStorageExpense = !isEmpty(formValues) && formValues.moving_expense_type === 'STORAGE';
+    const isStorageExpense = this.isStorageExpense(formValues);
     return (
       <>
         <WizardHeader

--- a/src/shared/Entities/modules/movingExpenseDocuments.js
+++ b/src/shared/Entities/modules/movingExpenseDocuments.js
@@ -23,6 +23,8 @@ export function createMovingExpenseDocument({
   paymentMethod,
   notes,
   missingReceipt,
+  storage_start_date,
+  storage_end_date,
 }) {
   return async function(dispatch, getState, { schema }) {
     const client = await getClient();
@@ -38,6 +40,8 @@ export function createMovingExpenseDocument({
         payment_method: paymentMethod,
         notes: notes,
         receipt_missing: missingReceipt,
+        storage_start_date,
+        storage_end_date,
       },
     });
     checkResponse(response, 'failed to create moving expense document due to server error');

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -945,15 +945,15 @@ definitions:
       - TOLLS
       - WEIGHING_FEES
     x-display-value:
-      CONTRACTED_EXPENSE: Contracted Expense
+      CONTRACTED_EXPENSE: Contracted expense
       GAS: Gas
       OIL: Oil
       OTHER: Other
-      PACKING_MATERIALS: Packing Materials
+      PACKING_MATERIALS: Packing materials
       STORAGE: Storage
-      RENTAL_EQUIPMENT: Rental Equipment
+      RENTAL_EQUIPMENT: Rental equipment
       TOLLS: Tolls
-      WEIGHING_FEES: Weighing Fees
+      WEIGHING_FEES: Weighing fees
   MoveDocumentStatus:
     type: string
     title: Document Status


### PR DESCRIPTION
## Description

For the new PPM closeout flow, it's required that we store the start and end dates for storage expenses. This PR updates the storage expenses form to capture these dates. Also, it updates the call to `createMovingExpenseDocument` to submit the storage expense start, end dates when an expense is uploaded.

## Setup

```sh
make e2e_test
```

1) Login as a user that is ready to request payment (e.g. ppm@requestingpay.ment)
2) Navigate through the closeout flow until the expense screen (`/ppm-expenses`)
3) Attempt to upload a storage expense document. The storage dates should be recorded in the database.


## Code Review Verification Steps
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/n/projects/2181745/stories/166290578) for this change

## Screenshots
![Screen Shot 2019-06-18 at 1 39 08 PM](https://user-images.githubusercontent.com/1036969/59714283-8c9e8400-91ce-11e9-9a8b-b2315fcaf356.png)

