### PR TITLE
PPM Payment Request: Weight Ticket Set Indicator Behavior

### DIFF
--- a/cypress/integration/mymove/ppm.js
+++ b/cypress/integration/mymove/ppm.js
@@ -203,7 +203,7 @@ describe('allows a SM to request a payment', function() {
   });
 
   it('service member goes through entire request payment flow', () => {
-    serviceMemberSubmitsWeightTicket('CAR', false, '1st');
+    serviceMemberSubmitsWeightTicket('CAR', false);
     serviceMemberViewsExpensesLandingPage();
     serviceMemberUploadsExpenses();
   });

--- a/cypress/integration/mymove/ppm.js
+++ b/cypress/integration/mymove/ppm.js
@@ -203,7 +203,7 @@ describe('allows a SM to request a payment', function() {
   });
 
   it('service member goes through entire request payment flow', () => {
-    serviceMemberSubmitsWeightTicket('CAR', false);
+    serviceMemberSubmitsWeightTicket('CAR', false, '1st');
     serviceMemberViewsExpensesLandingPage();
     serviceMemberUploadsExpenses();
   });
@@ -217,7 +217,7 @@ describe('allows a SM to request a payment', function() {
   });
 
   it('service member can save a weight ticket for later', () => {
-    serviceMemberSavesWeightTicketForLater('CAR');
+    serviceMemberSavesWeightTicketForLater('BOX_TRUCK');
   });
 
   //TODO: remove when done with the new flow to request payment
@@ -474,12 +474,14 @@ function serviceMemberSubmitsWeightsTicketsWithoutReceipts() {
   cy.wait('@postWeightTicket');
 }
 
-function serviceMemberSubmitsWeightTicket(vehicleType, hasAnother = true) {
+function serviceMemberSubmitsWeightTicket(vehicleType, hasAnother = true, ordinal = '1st') {
   cy.contains('Request Payment').click();
   cy
     .get('button')
     .contains('Get Started')
     .click();
+
+  cy.contains(`Weight Tickets - ${ordinal} set`);
 
   cy.get('select[name="vehicle_options"]').select(vehicleType);
 

--- a/pkg/handlers/internalapi/weight_ticket_set_documents.go
+++ b/pkg/handlers/internalapi/weight_ticket_set_documents.go
@@ -4,6 +4,8 @@ import (
 	"reflect"
 	"time"
 
+	"github.com/go-openapi/strfmt"
+
 	"github.com/transcom/mymove/pkg/unit"
 
 	"github.com/transcom/mymove/pkg/gen/internalmessages"
@@ -26,14 +28,27 @@ func payloadForWeightTicketSetMoveDocumentModel(storer storage.FileStorer, weigh
 		return nil, err
 	}
 
+	var ppmID *strfmt.UUID
+	if weightTicketSet.MoveDocument.PersonallyProcuredMoveID != nil {
+		ppmID = handlers.FmtUUID(*weightTicketSet.MoveDocument.PersonallyProcuredMoveID)
+	}
 	genericMoveDocumentPayload := internalmessages.MoveDocumentPayload{
-		ID:               handlers.FmtUUID(weightTicketSet.ID),
-		MoveID:           handlers.FmtUUID(weightTicketSet.MoveDocument.MoveID),
-		Document:         documentPayload,
-		Title:            &weightTicketSet.MoveDocument.Title,
-		MoveDocumentType: internalmessages.MoveDocumentType(weightTicketSet.MoveDocument.MoveDocumentType),
-		Status:           internalmessages.MoveDocumentStatus(weightTicketSet.MoveDocument.Status),
-		Notes:            weightTicketSet.MoveDocument.Notes,
+		ID:                       handlers.FmtUUID(weightTicketSet.MoveDocument.ID),
+		MoveID:                   handlers.FmtUUID(weightTicketSet.MoveDocument.MoveID),
+		Document:                 documentPayload,
+		Title:                    &weightTicketSet.MoveDocument.Title,
+		MoveDocumentType:         internalmessages.MoveDocumentType(weightTicketSet.MoveDocument.MoveDocumentType),
+		VehicleNickname:          weightTicketSet.VehicleNickname,
+		VehicleOptions:           weightTicketSet.VehicleOptions,
+		PersonallyProcuredMoveID: ppmID,
+		EmptyWeight:              handlers.FmtInt64(int64(weightTicketSet.EmptyWeight)),
+		EmptyWeightTicketMissing: handlers.FmtBool(weightTicketSet.EmptyWeightTicketMissing),
+		FullWeight:               handlers.FmtInt64(int64(weightTicketSet.FullWeight)),
+		FullWeightTicketMissing:  handlers.FmtBool(weightTicketSet.FullWeightTicketMissing),
+		TrailerOwnershipMissing:  handlers.FmtBool(weightTicketSet.TrailerOwnershipMissing),
+		WeightTicketDate:         handlers.FmtDate(weightTicketSet.WeightTicketDate),
+		Status:                   internalmessages.MoveDocumentStatus(weightTicketSet.MoveDocument.Status),
+		Notes:                    weightTicketSet.MoveDocument.Notes,
 	}
 
 	return &genericMoveDocumentPayload, nil

--- a/src/scenes/Moves/Ppm/ExpensesUpload.jsx
+++ b/src/scenes/Moves/Ppm/ExpensesUpload.jsx
@@ -103,7 +103,6 @@ class ExpensesUpload extends Component {
         storage_end_date,
       })
       .then(() => {
-        this.setState({ expenseNumber: this.state.expenseNumber + 1 });
         this.cleanup();
       })
       .catch(e => {

--- a/src/scenes/Moves/Ppm/utility.js
+++ b/src/scenes/Moves/Ppm/utility.js
@@ -1,0 +1,7 @@
+// maps int to int with ordinal 1 -> 1st, 2 -> 2nd, 3rd ...
+export const intToOrdinal = n => {
+  const s = ['th', 'st', 'nd', 'rd'];
+  const v = n % 100;
+  // eslint-disable-next-line security/detect-object-injection
+  return n + (s[(v - 20) % 10] || s[v] || s[0]);
+};

--- a/src/shared/Entities/modules/movingExpenseDocuments.js
+++ b/src/shared/Entities/modules/movingExpenseDocuments.js
@@ -47,9 +47,16 @@ export function createMovingExpenseDocument({
   };
 }
 
-export const selectAllMovingExpenseDocumentsForMove = (state, id) => {
+export const selectPPMCloseoutDocumentsForMove = (
+  state,
+  id,
+  selectedDocumentTypes = ['EXPENSE', 'WEIGHT_TICKET_SET'],
+) => {
+  if (!id) {
+    return [];
+  }
   const movingExpenseDocs = filter(state.entities.moveDocuments, doc => {
-    return doc.move_id === id && doc.move_document_type === 'EXPENSE';
+    return doc.move_id === id && selectedDocumentTypes.includes(doc.move_document_type);
   });
   return denormalize(map(movingExpenseDocs, 'id'), moveDocuments, state.entities);
 };


### PR DESCRIPTION
## Description

Show the number of weight tickets and expenses in the header of each respective page for the new PPM closeout flow.

## Setup

```sh
make e2e_test
```

1) Login as a user that is ready to request payment (e.g. ppm@requestingpay.ment)
2) Navigate through the closeout flow upload some weight tickets. The weight ticket set count should be incremented.
3) Cancel and return to the home page. Click "Request Payment". When you return to the weight ticket page, the weight ticket set count should match the count from the previous step.

*This behavior should also apply for expenses, however the flow for revisiting of pages is still being worked out, so you can directly revisit the expense page by going to `/ppm-expenses` for that move.*

## Code Review Verification Steps
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/n/projects/2181745/stories/166503538) for this change

## Screenshots
![Screen Shot 2019-06-19 at 1 08 10 PM](https://user-images.githubusercontent.com/1036969/59793299-6b539b80-9293-11e9-8aea-47a99866c031.png)
