### PR TITLE
Remove troubleshooting queue item. 

### DIFF
--- a/pkg/handlers/internalapi/move_queue_items_test.go
+++ b/pkg/handlers/internalapi/move_queue_items_test.go
@@ -94,6 +94,29 @@ func (suite *HandlerSuite) TestShowQueueHandlerForbidden() {
 	}
 }
 
+func (suite *HandlerSuite) TestShowQueueHandlerNotFound() {
+
+	// Given: An office user
+	officeUser := testdatagen.MakeDefaultOfficeUser(suite.DB())
+
+	// And: the context contains the auth values
+	queueType := "queue_not_found"
+	path := "/queues/" + queueType
+	req := httptest.NewRequest("GET", path, nil)
+	req = suite.AuthenticateOfficeRequest(req, officeUser)
+
+	params := queueop.ShowQueueParams{
+		HTTPRequest: req,
+		QueueType:   queueType,
+	}
+	// And: show Queue is queried
+	showHandler := ShowQueueHandler{handlers.NewHandlerContext(suite.DB(), suite.TestLogger())}
+	showResponse := showHandler.Handle(params)
+
+	// Then: Expect a 404 status code
+	suite.CheckResponseNotFound(showResponse)
+}
+
 func (suite *HandlerSuite) TestGetMoveQueueItemsComboMoveDate() {
 	suite.SetupTest()
 

--- a/pkg/models/queue.go
+++ b/pkg/models/queue.go
@@ -184,6 +184,8 @@ func GetMoveQueueItems(db *pop.Connection, lifecycleState string) ([]MoveQueueIt
 			LEFT JOIN personally_procured_moves AS ppm ON moves.id = ppm.move_id
 			WHERE moves.show is true
 		`
+	} else {
+		return moveQueueItems, ErrFetchNotFound
 	}
 
 	err := db.RawQuery(query).All(&moveQueueItems)

--- a/pkg/models/queue_test.go
+++ b/pkg/models/queue_test.go
@@ -97,3 +97,9 @@ func (suite *ModelSuite) TestShowPPMQueueStatusDraftSubmittedCanceled() {
 	suite.Nil(err)
 	suite.Len(moves, 0)
 }
+
+func (suite *ModelSuite) TestQueueNotFound() {
+	moves, moveErrs := GetMoveQueueItems(suite.DB(), "queue_not_found")
+	suite.Equal(ErrFetchNotFound, moveErrs, "Expected not to find move queue items")
+	suite.Empty(moves)
+}

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -4290,7 +4290,6 @@ paths:
           type: string
           enum:
             - new
-            - troubleshooting
             - ppm
             - hhg_approved
             - hhg_delivered
@@ -4310,6 +4309,8 @@ paths:
           description: request requires user authentication
         403:
           description: user is not authorized to access this queue
+        404:
+          description: move queue item is not found
   /entitlements:
     get:
       summary: List weight weights allotted by entitlement


### PR DESCRIPTION
## Description

While doing load testing in #1597 I discovered that the `troubleshooting` move queue item has no corresponding SQL query to populate it. Yet being an available option in Swagger means I could call it and throw a 500 error on the server because there was no error handling. 

This PR removes the bad move queue item and also ensures that the queue item api returns 404 for bad queue types.

## Setup

```sh
make server_test
```

## Code Review Verification Steps

* [x] Request review from a member of a different team.