### PR TITLE
Only use entrypoint

### DIFF
--- a/config/app-client-tls.container-definition.json
+++ b/config/app-client-tls.container-definition.json
@@ -17,9 +17,7 @@
     "app-{{ .environment }}",
     "--",
     "/bin/milmove",
-    "serve"
-  ],
-  "command": [
+    "serve",
     "--env",
     "container",
     "--debug-logging",
@@ -27,6 +25,7 @@
     "--tls-enabled",
     "--mutual-tls-enabled"
   ],
+  "command": [],
   "environment": [
     {
       "name": "SERVICE_NAME",

--- a/config/app-migrations.container-definition.json
+++ b/config/app-migrations.container-definition.json
@@ -10,15 +10,14 @@
     "exec",
     "app-{{ .environment }}",
     "--",
-    "/bin/milmove"
-  ],
-  "command": [
+    "/bin/milmove",
     "migrate",
     "--env",
     "container",
     "-p",
     "/migrate/migrations"
   ],
+  "command": [],
   "environment": [
     {
       "name": "ENVIRONMENT",

--- a/config/app.container-definition.json
+++ b/config/app.container-definition.json
@@ -17,15 +17,14 @@
     "app-{{ .environment }}",
     "--",
     "/bin/milmove",
-    "serve"
-  ],
-  "command": [
+    "serve",
     "--env",
     "container",
     "--debug-logging",
     "--log-task-metadata",
     "--tls-enabled"
   ],
+  "command": [],
   "environment": [
     {
       "name": "SERVICE_NAME",


### PR DESCRIPTION
## Description

Only use entrypoint for deployed containers.

## Reviewer Notes

None

## Setup

None

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/tree/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/tree/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/tree/master/docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
  * [ ] Secure migrations have been tested using `scripts/run-prod-migrations`
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

None

## Screenshots

None