### PR TITLE
Redirect to login page upon queues 401 error  [delivers #166389725]

### DIFF
--- a/src/scenes/Office/QueueTable.jsx
+++ b/src/scenes/Office/QueueTable.jsx
@@ -95,9 +95,8 @@ class QueueTable extends Component {
         refreshing: false,
         lastLoadedAt: new Date(),
       });
-      // hard redirect to home page if unauthorized
+      // redirect to home page if unauthorized
       if (e.status === 401) {
-        //window.location.assign('/');
         this.props.setUserIsLoggedIn(false);
       }
     }
@@ -238,12 +237,7 @@ const mapStateToProps = state => {
 };
 
 function mapDispatchToProps(dispatch) {
-  return bindActionCreators(
-    {
-      setUserIsLoggedIn,
-    },
-    dispatch,
-  );
+  return bindActionCreators({ setUserIsLoggedIn }, dispatch);
 }
 
 export default withRouter(connect(mapStateToProps, mapDispatchToProps)(QueueTable));

--- a/src/scenes/Office/QueueTable.jsx
+++ b/src/scenes/Office/QueueTable.jsx
@@ -89,6 +89,10 @@ class QueueTable extends Component {
         refreshing: false,
         lastLoadedAt: new Date(),
       });
+      // hard redirect to home page if unauthorized
+      if (e.status === 401) {
+        window.location.assign('/');
+      }
     }
   }
 

--- a/src/scenes/Office/QueueTable.jsx
+++ b/src/scenes/Office/QueueTable.jsx
@@ -2,11 +2,13 @@ import React, { Component } from 'react';
 import { withRouter } from 'react-router';
 import ReactTable from 'react-table';
 import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
 import { get } from 'lodash';
 import 'react-table/react-table.css';
 import Alert from 'shared/Alert';
 import { formatTimeAgo } from 'shared/formatters';
 import { newColumns, ppmColumns, hhgActiveColumns, defaultColumns } from './queueTableColumns';
+import { setUserIsLoggedIn } from 'shared/Data/users';
 
 import FontAwesomeIcon from '@fortawesome/react-fontawesome';
 import faSyncAlt from '@fortawesome/fontawesome-free-solid/faSyncAlt';
@@ -91,7 +93,8 @@ class QueueTable extends Component {
       });
       // hard redirect to home page if unauthorized
       if (e.status === 401) {
-        window.location.assign('/');
+        //window.location.assign('/');
+        this.props.setUserIsLoggedIn(false);
       }
     }
   }
@@ -230,4 +233,13 @@ const mapStateToProps = state => {
   };
 };
 
-export default withRouter(connect(mapStateToProps)(QueueTable));
+function mapDispatchToProps(dispatch) {
+  return bindActionCreators(
+    {
+      setUserIsLoggedIn,
+    },
+    dispatch,
+  );
+}
+
+export default withRouter(connect(mapStateToProps, mapDispatchToProps)(QueueTable));

--- a/src/scenes/Office/QueueTable.jsx
+++ b/src/scenes/Office/QueueTable.jsx
@@ -46,6 +46,10 @@ class QueueTable extends Component {
     }
   }
 
+  componentWillUnmount() {
+    clearInterval(this.state.interval);
+  }
+
   openMove(rowInfo) {
     this.props.history.push(`new/moves/${rowInfo.original.id}`, {
       referrerPathname: this.props.history.location.pathname,

--- a/src/scenes/Office/QueueTable.test.js
+++ b/src/scenes/Office/QueueTable.test.js
@@ -100,6 +100,29 @@ describe('Refreshing', () => {
   });
 });
 
+describe('window.location.assign() is called', () => {
+  it('upon 401 unauthorized error', done => {
+    const fetchDataSpy = jest.spyOn(QueueTable.WrappedComponent.prototype, 'fetchData');
+    const windowLocationAssignSpy = jest.spyOn(window.location, 'assign');
+
+    let error = new Error('Unauthorized');
+    error.status = 401;
+
+    const wrapper = mountComponents(retrieveMovesStub(null, error));
+    wrapper
+      .find('[data-cy="refreshQueue"]')
+      .at(0)
+      .simulate('click');
+
+    setTimeout(() => {
+      expect(fetchDataSpy).toHaveBeenCalled();
+      expect(windowLocationAssignSpy).toBeCalledWith('/');
+
+      done();
+    });
+  });
+});
+
 function retrieveMovesStub(params, throwError) {
   // This is meant as a stub that will act in place of
   // `RetrieveMovesForOffice` from Office/api.js
@@ -107,6 +130,8 @@ function retrieveMovesStub(params, throwError) {
     return await new Promise(resolve => {
       if (throwError) {
         throw throwError;
+      }
+
       resolve([
         {
           id: 'c56a4180-65aa-42ec-a945-5fd21dec0538',

--- a/src/scenes/Office/QueueTable.test.js
+++ b/src/scenes/Office/QueueTable.test.js
@@ -100,11 +100,13 @@ describe('Refreshing', () => {
   });
 });
 
-function retrieveMovesStub(params) {
+function retrieveMovesStub(params, throwError) {
   // This is meant as a stub that will act in place of
   // `RetrieveMovesForOffice` from Office/api.js
   return async () => {
     return await new Promise(resolve => {
+      if (throwError) {
+        throw throwError;
       resolve([
         {
           id: 'c56a4180-65aa-42ec-a945-5fd21dec0538',

--- a/src/shared/Data/users.js
+++ b/src/shared/Data/users.js
@@ -6,6 +6,7 @@ import { ordersArray } from 'shared/Entities/schema';
 import { addEntities } from 'shared/Entities/actions';
 import { getShipment } from 'shared/Entities/modules/shipments';
 
+const SET_IS_LOGGED_IN = 'SET_IS_LOGGED_IN';
 const getLoggedInUserType = 'GET_LOGGED_IN_USER';
 
 export const GET_LOGGED_IN_USER = helpers.generateAsyncActionTypes(getLoggedInUserType);
@@ -31,6 +32,12 @@ export function getCurrentUserInfo() {
         return dispatch(getLoggedInActions.success(response));
       })
       .catch(error => dispatch(getLoggedInActions.error(error)));
+  };
+}
+
+export function setUserIsLoggedIn(isLoggedIn) {
+  return function(dispatch) {
+    return dispatch({ type: SET_IS_LOGGED_IN, isLoggedIn });
   };
 }
 
@@ -90,6 +97,13 @@ const currentUserReducer = (state = currentUserReducerDefault(), action) => {
         hasSucceeded: false,
         error: action.error,
         userInfo: userInfoDefault(),
+      };
+    case SET_IS_LOGGED_IN:
+      return {
+        ...state,
+        userInfo: {
+          isLoggedIn: action.isLoggedIn,
+        },
       };
     default:
       return state;

--- a/src/shared/Data/users.js
+++ b/src/shared/Data/users.js
@@ -6,7 +6,7 @@ import { ordersArray } from 'shared/Entities/schema';
 import { addEntities } from 'shared/Entities/actions';
 import { getShipment } from 'shared/Entities/modules/shipments';
 
-const SET_IS_LOGGED_IN = 'SET_IS_LOGGED_IN';
+const setIsLoggedInType = 'SET_IS_LOGGED_IN';
 const getLoggedInUserType = 'GET_LOGGED_IN_USER';
 
 export const GET_LOGGED_IN_USER = helpers.generateAsyncActionTypes(getLoggedInUserType);
@@ -37,7 +37,7 @@ export function getCurrentUserInfo() {
 
 export function setUserIsLoggedIn(isLoggedIn) {
   return function(dispatch) {
-    return dispatch({ type: SET_IS_LOGGED_IN, isLoggedIn });
+    return dispatch({ type: setIsLoggedInType, isLoggedIn });
   };
 }
 
@@ -98,10 +98,11 @@ const currentUserReducer = (state = currentUserReducerDefault(), action) => {
         error: action.error,
         userInfo: userInfoDefault(),
       };
-    case SET_IS_LOGGED_IN:
+    case setIsLoggedInType:
       return {
         ...state,
         userInfo: {
+          ...userInfoDefault(),
           isLoggedIn: action.isLoggedIn,
         },
       };

--- a/src/shared/Data/users.js
+++ b/src/shared/Data/users.js
@@ -6,7 +6,7 @@ import { ordersArray } from 'shared/Entities/schema';
 import { addEntities } from 'shared/Entities/actions';
 import { getShipment } from 'shared/Entities/modules/shipments';
 
-const setIsLoggedInType = 'SET_IS_LOGGED_IN';
+export const setIsLoggedInType = 'SET_IS_LOGGED_IN';
 const getLoggedInUserType = 'GET_LOGGED_IN_USER';
 
 export const GET_LOGGED_IN_USER = helpers.generateAsyncActionTypes(getLoggedInUserType);

--- a/src/shared/Swagger/api.js
+++ b/src/shared/Swagger/api.js
@@ -49,6 +49,8 @@ export async function getPublicSpec() {
 // Used by pre-swaggerRequest code to verify responses
 export function checkResponse(response, errorMessage) {
   if (!response.ok) {
-    throw new Error(`${errorMessage}: ${response.url}: ${response.statusText}`);
+    let err = new Error(`${errorMessage}: ${response.url}: ${response.statusText}`);
+    err.status = response.status;
+    throw err;
   }
 }


### PR DESCRIPTION
## Description

We want to redirect the user to the login page upon 401 (unauthorized) errors. @tinyels noticed that the queues data didn't load when app returns 401s but no error propagated to the user. This work will redirect the user ONLY on the office queues page if somehow their session expires before the timeout triggers.

## Reviewer Notes

- Decided to go with `window.location.assign()` instead of the `history` store
- `history` didn't do a "hard" redirect to the login page so the app kept hitting 401s
- Redirection only applies to the Office queues page
- Should a cypress test be added?

## Setup

1. Login to office app, locally
2. Open up dev console and delete office session cookie `office_session_token`
3. Click on any queue tab to try to load data
4. Should be redirected to the login page `/`

## Code Review Verification Steps

* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/166389725) for this change