### PR TITLE
Validate SM current address zip

### DIFF
--- a/cypress/integration/mymove/serviceMemberProfile.js
+++ b/cypress/integration/mymove/serviceMemberProfile.js
@@ -74,7 +74,18 @@ function serviceMemberProfile(reloadAfterEveryPage) {
   cy.get('input[name="street_address_1"]').type('123 main');
   cy.get('input[name="city"]').type('Anytown');
   cy.get('select[name="state"]').select('CO');
-  cy.get('input[name="postal_code"]').type('80913');
+  cy
+    .get('input[name="postal_code"]')
+    .clear()
+    .type('00001')
+    .blur();
+  cy.get('#postal_code-error').should('exist');
+  cy.get('button.next').should('be.disabled');
+  cy
+    .get('input[name="postal_code"]')
+    .clear()
+    .type('80913');
+  cy.get('#postal_code-error').should('not.exist');
   cy.nextPage();
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/service-member\/[^/]+\/backup-mailing-address/);

--- a/src/scenes/Moves/Ppm/DateAndLocation.jsx
+++ b/src/scenes/Moves/Ppm/DateAndLocation.jsx
@@ -20,7 +20,8 @@ import WizardHeader from '../WizardHeader';
 import ppmBlack from 'shared/icon/ppm-black.svg';
 import './DateAndLocation.css';
 import { ProgressTimeline, ProgressTimelineStep } from 'shared/ProgressTimeline';
-import { GetPpmWeightEstimate, ValidateZipRateData } from './api';
+import { GetPpmWeightEstimate } from './api';
+import { ValidateZipRateData } from 'shared/api';
 
 const sitEstimateDebounceTime = 300;
 const formName = 'ppp_date_and_location';

--- a/src/scenes/Moves/Ppm/api.js
+++ b/src/scenes/Moves/Ppm/api.js
@@ -1,4 +1,4 @@
-import { getClient, checkResponse, getPublicClient } from 'shared/Swagger/api';
+import { getClient, checkResponse } from 'shared/Swagger/api';
 import { formatPayload, formatDateString } from 'shared/utils';
 
 export async function GetPpm(moveId) {
@@ -59,16 +59,6 @@ export async function GetPpmSitEstimate(moveDate, sitDays, originZip, destZip, w
     weight_estimate: weightEstimate,
   });
   checkResponse(response, 'failed to update ppm due to server error');
-  return response.body;
-}
-
-export async function ValidateZipRateData(zipCode, zipType) {
-  const client = await getPublicClient();
-  const response = await client.apis.postal_codes.validatePostalCode({
-    postal_code: zipCode,
-    postal_code_type: zipType,
-  });
-  checkResponse(response, 'failed to validate ppm data due to server error');
   return response.body;
 }
 

--- a/src/scenes/ServiceMembers/ResidentialAddress.jsx
+++ b/src/scenes/ServiceMembers/ResidentialAddress.jsx
@@ -12,7 +12,7 @@ import { ValidateZipRateData } from 'shared/api';
 const UnsupportedZipCodeErrorMsg =
   'Sorry, we don’t support that zip code yet. Please contact your local PPPO for assistance.';
 
-async function asyncValidate(values, dispatch, props, currentFieldName) {
+async function asyncValidate(values) {
   const { postal_code } = values;
   const responseBody = await ValidateZipRateData(postal_code, 'origin');
   if (!responseBody.valid) {

--- a/src/scenes/ServiceMembers/ResidentialAddress.jsx
+++ b/src/scenes/ServiceMembers/ResidentialAddress.jsx
@@ -7,9 +7,22 @@ import { getFormValues } from 'redux-form';
 import { updateServiceMember } from './ducks';
 import { reduxifyWizardForm } from 'shared/WizardPage/Form';
 import { SwaggerField } from 'shared/JsonSchemaForm/JsonSchemaField';
+import { ValidateZipRateData } from '../Moves/Ppm/api';
+
+const UnsupportedZipCodeErrorMsg =
+  'Sorry, we don’t support that zip code yet. Please contact your local PPPO for assistance.';
+
+async function asyncValidate(values, dispatch, props, currentFieldName) {
+  const { postal_code } = values;
+  const responseBody = await ValidateZipRateData(postal_code, 'origin');
+  if (!responseBody.valid) {
+    // eslint-disable-next-line no-throw-literal
+    throw { postal_code: UnsupportedZipCodeErrorMsg };
+  }
+}
 
 const formName = 'service_member_residential_address';
-const ResidentalWizardForm = reduxifyWizardForm(formName);
+const ResidentalWizardForm = reduxifyWizardForm(formName, null, asyncValidate, ['postal_code']);
 
 export class ResidentialAddress extends Component {
   handleSubmit = () => {

--- a/src/scenes/ServiceMembers/ResidentialAddress.jsx
+++ b/src/scenes/ServiceMembers/ResidentialAddress.jsx
@@ -7,7 +7,7 @@ import { getFormValues } from 'redux-form';
 import { updateServiceMember } from './ducks';
 import { reduxifyWizardForm } from 'shared/WizardPage/Form';
 import { SwaggerField } from 'shared/JsonSchemaForm/JsonSchemaField';
-import { ValidateZipRateData } from '../Moves/Ppm/api';
+import { ValidateZipRateData } from 'shared/api';
 
 const UnsupportedZipCodeErrorMsg =
   'Sorry, we don’t support that zip code yet. Please contact your local PPPO for assistance.';

--- a/src/shared/api.js
+++ b/src/shared/api.js
@@ -41,3 +41,13 @@ export async function CreateDocument(name, serviceMemberId) {
   checkResponse(response, 'failed to create document due to server error');
   return response.body;
 }
+
+export async function ValidateZipRateData(zipCode, zipType) {
+  const client = await getPublicClient();
+  const response = await client.apis.postal_codes.validatePostalCode({
+    postal_code: zipCode,
+    postal_code_type: zipType,
+  });
+  checkResponse(response, 'failed to validate ppm data due to server error');
+  return response.body;
+}


### PR DESCRIPTION
## Description

We were experiencing issues with us default filling the origin zip with the current address. We need to make sure they are moving from a zip code we support. This adds the async validation on the service member profile section on the current address.

## Setup

Create a new SM on milmove and set the zipcode of current address to `00001`, which is an unsupported and invalid zipcode. You should not be able to continue (and you should see an error). If you update the zipcode to a valid one, like `80913`, then you should be able to move forward again.

## Code Review Verification Steps

* [ ] User facing changes have been reviewed by design.
* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* https://www.pivotaltracker.com/story/show/166764543

## Screenshots

<img width="1059" alt="Screen Shot 2019-06-20 at 12 13 07 PM" src="https://user-images.githubusercontent.com/5531789/59875152-da44f900-9354-11e9-9c6e-3385dc5cf58b.png">

