### PR TITLE
New unexpired certs the Marine Corps wants to use for the Orders API

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -882,9 +882,9 @@ workflows:
             - pre_deps_yarn
             - acceptance_tests_local
           # if testing on experimental, you can disable these tests by using the commented block below.
-          filters:
-            branches:
-              ignore: update-marine-corps-certs-for-orders
+          # filters:
+          #  branches:
+          #    ignore: placeholder_branch_name
 
       - integration_tests_office:
           requires:
@@ -892,9 +892,9 @@ workflows:
             - pre_deps_yarn
             - acceptance_tests_local
           # if testing on experimental, you can disable these tests by using the commented block below.
-          filters:
-            branches:
-              ignore: update-marine-corps-certs-for-orders
+          # filters:
+          #   branches:
+          #     ignore: placeholder_branch_name
 
       - integration_tests_tsp:
           requires:
@@ -902,9 +902,9 @@ workflows:
             - pre_deps_yarn
             - acceptance_tests_local
           # if testing on experimental, you can disable these tests by using the commented block below.
-          filters:
-            branches:
-              ignore: update-marine-corps-certs-for-orders
+          # filters:
+          #   branches:
+          #     ignore: placeholder_branch_name
 
       - integration_tests_api:
           requires:
@@ -912,9 +912,9 @@ workflows:
             - pre_deps_yarn
             - acceptance_tests_local
           # if testing on experimental, you can disable these tests by using the commented block below.
-          filters:
-            branches:
-              ignore: update-marine-corps-certs-for-orders
+          # filters:
+          #   branches:
+          #     ignore: placeholder_branch_name
 
       - client_test:
           requires:
@@ -959,28 +959,28 @@ workflows:
             - build_migrations
           filters:
             branches:
-              only: update-marine-corps-certs-for-orders
+              only: placeholder_branch_name
 
       - deploy_experimental_tasks:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: update-marine-corps-certs-for-orders
+              only: placeholder_branch_name
 
       - deploy_experimental_app:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: update-marine-corps-certs-for-orders
+              only: placeholder_branch_name
 
       - deploy_experimental_app_client_tls:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: update-marine-corps-certs-for-orders
+              only: placeholder_branch_name
 
       - check_circle_against_staging_sha:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -882,9 +882,9 @@ workflows:
             - pre_deps_yarn
             - acceptance_tests_local
           # if testing on experimental, you can disable these tests by using the commented block below.
-          # filters:
-          #  branches:
-          #    ignore: placeholder_branch_name
+          filters:
+            branches:
+              ignore: update-marine-corps-certs-for-orders
 
       - integration_tests_office:
           requires:
@@ -892,9 +892,9 @@ workflows:
             - pre_deps_yarn
             - acceptance_tests_local
           # if testing on experimental, you can disable these tests by using the commented block below.
-          # filters:
-          #   branches:
-          #     ignore: placeholder_branch_name
+          filters:
+            branches:
+              ignore: update-marine-corps-certs-for-orders
 
       - integration_tests_tsp:
           requires:
@@ -902,9 +902,9 @@ workflows:
             - pre_deps_yarn
             - acceptance_tests_local
           # if testing on experimental, you can disable these tests by using the commented block below.
-          # filters:
-          #   branches:
-          #     ignore: placeholder_branch_name
+          filters:
+            branches:
+              ignore: update-marine-corps-certs-for-orders
 
       - integration_tests_api:
           requires:
@@ -912,9 +912,9 @@ workflows:
             - pre_deps_yarn
             - acceptance_tests_local
           # if testing on experimental, you can disable these tests by using the commented block below.
-          # filters:
-          #   branches:
-          #     ignore: placeholder_branch_name
+          filters:
+            branches:
+              ignore: update-marine-corps-certs-for-orders
 
       - client_test:
           requires:
@@ -959,28 +959,28 @@ workflows:
             - build_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: update-marine-corps-certs-for-orders
 
       - deploy_experimental_tasks:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: update-marine-corps-certs-for-orders
 
       - deploy_experimental_app:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: update-marine-corps-certs-for-orders
 
       - deploy_experimental_app_client_tls:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: update-marine-corps-certs-for-orders
 
       - check_circle_against_staging_sha:
           requires:

--- a/local_migrations/20190620184142_update-marine-corps-certs.sql
+++ b/local_migrations/20190620184142_update-marine-corps-certs.sql
@@ -1,0 +1,3 @@
+-- Local test migration.
+-- This will be run on development environments. It should mirror what you
+-- intend to apply on production, but do not include any sensitive data.

--- a/migrations/20190620184142_update-marine-corps-certs.up.fizz
+++ b/migrations/20190620184142_update-marine-corps-certs.up.fizz
@@ -1,0 +1,1 @@
+exec("./apply-secure-migration.sh 20190620184142_update-marine-corps-certs.sql")


### PR DESCRIPTION
## Description

The Marine Corps has provided fresh, unexpired certificates for use with the Orders API. This PR is a secure migration to add one certificate with permission to read and write Marine Corps Orders to `prod` and add five different certificates with the same permissions to `staging` and `experimental`.

## Code Review Verification Steps

* Any new migrations/schema changes:
  * [x] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/tree/master/docs/database.md#zero-downtime-migrations))
  * [x] Have been communicated to #dp3-engineering
  * [x] Secure migrations have been tested using `scripts/run-prod-migrations`
* [x] Request review from a member of a different team.
