### PR TITLE
PPM payment request: Number of documents loaded shows (alert) on pages in flow

### DIFF
--- a/cypress/integration/mymove/ppm.js
+++ b/cypress/integration/mymove/ppm.js
@@ -272,6 +272,7 @@ function serviceMemberViewsExpensesLandingPage() {
     expect(loc.pathname).to.match(/^\/moves\/[^/]+\/ppm-expenses-intro/);
   });
 
+  cy.get('[data-cy=documents-uploaded]').should('exist');
   cy
     .get('button')
     .contains('Continue')
@@ -310,6 +311,7 @@ function serviceMemberUploadsExpenses() {
   });
 
   cy.contains('Expense 1');
+  cy.get('[data-cy=documents-uploaded]').should('exist');
 
   cy.get('select[name="moving_expense_type"]').select('GAS');
   cy.get('input[name="title"]').type('title');
@@ -489,6 +491,7 @@ function serviceMemberSubmitsWeightTicket(vehicleType, hasAnother = true, ordina
     .click();
 
   cy.contains(`Weight Tickets - ${ordinal} set`);
+  cy.get('[data-cy=documents-uploaded]').should('not.exist');
 
   cy.get('select[name="vehicle_options"]').select(vehicleType);
 
@@ -530,6 +533,7 @@ function serviceMemberSubmitsWeightTicket(vehicleType, hasAnother = true, ordina
       .click();
   }
   cy.wait('@postWeightTicket');
+  cy.get('[data-cy=documents-uploaded]').should('exist');
 }
 
 function serviceMemberCanCancel() {

--- a/src/scenes/Moves/Ppm/DocumentsUploaded.js
+++ b/src/scenes/Moves/Ppm/DocumentsUploaded.js
@@ -12,7 +12,7 @@ export class DocumentsUploaded extends Component {
 
   createHeaderMessage = documentLength => {
     return (
-      <div>
+      <div style={{ marginBottom: 5, paddingTop: 5 }}>
         {documentLength} document{documentLength > 1 ? 's' : ''} added <a style={{ paddingLeft: '1em' }}>Show</a>
       </div>
     );

--- a/src/scenes/Moves/Ppm/DocumentsUploaded.js
+++ b/src/scenes/Moves/Ppm/DocumentsUploaded.js
@@ -1,0 +1,54 @@
+import React, { Component } from 'react';
+import Alert from 'shared/Alert';
+import { selectPPMCloseoutDocumentsForMove } from 'shared/Entities/modules/movingExpenseDocuments';
+import { getMoveDocumentsForMove } from 'shared/Entities/modules/moveDocuments';
+import { connect } from 'react-redux';
+
+export class DocumentsUploaded extends Component {
+  componentDidMount() {
+    const { moveId } = this.props;
+    this.props.getMoveDocumentsForMove(moveId);
+  }
+
+  createHeaderMessage = documentLength => {
+    return (
+      <p>
+        {documentLength} document{documentLength > 1 ? 's' : ''} added <a style={{ paddingLeft: '1em' }}>Show</a>
+      </p>
+    );
+  };
+
+  render() {
+    const { allDocuments } = this.props;
+    const documentLength = allDocuments.length;
+    if (documentLength === 0) {
+      return null;
+    }
+    return (
+      <>
+        {
+          <div className="usa-grid" data-cy="documents-uploaded">
+            <div className="usa-width-one-whole">
+              <Alert type="success" heading={this.createHeaderMessage(documentLength)} />
+            </div>
+          </div>
+        }
+      </>
+    );
+  }
+}
+
+function mapStateToProps(state, ownProps) {
+  const moveId = ownProps.moveId;
+  return {
+    moveId: moveId,
+    allDocuments: selectPPMCloseoutDocumentsForMove(state, moveId),
+  };
+}
+
+const mapDispatchToProps = {
+  selectPPMCloseoutDocumentsForMove,
+  getMoveDocumentsForMove,
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(DocumentsUploaded);

--- a/src/scenes/Moves/Ppm/DocumentsUploaded.js
+++ b/src/scenes/Moves/Ppm/DocumentsUploaded.js
@@ -12,9 +12,9 @@ export class DocumentsUploaded extends Component {
 
   createHeaderMessage = documentLength => {
     return (
-      <p>
+      <div>
         {documentLength} document{documentLength > 1 ? 's' : ''} added <a style={{ paddingLeft: '1em' }}>Show</a>
-      </p>
+      </div>
     );
   };
 

--- a/src/scenes/Moves/Ppm/DocumentsUploaded.test.js
+++ b/src/scenes/Moves/Ppm/DocumentsUploaded.test.js
@@ -3,33 +3,34 @@ import { DocumentsUploaded } from './DocumentsUploaded';
 import { mount } from 'enzyme';
 import Alert from 'shared/Alert';
 
-describe('Documents Uploaded Alert', () => {
+function generateWrapper(allDocuments, mockGetMoveDocumentsForMove) {
+  return mount(<DocumentsUploaded allDocuments={allDocuments} getMoveDocumentsForMove={mockGetMoveDocumentsForMove} />);
+}
+
+describe('DocumentsUploaded Alert', () => {
   describe('No documents uploaded', () => {
-    it('does not render DocumentUploaded', () => {
-      const wrapper = mount(<DocumentsUploaded allDocuments={[]} getMoveDocumentsForMove={jest.fn()} />);
+    it('component does not render', () => {
+      const mockGetMoveDocumentsForMove = jest.fn();
+      const wrapper = generateWrapper([], mockGetMoveDocumentsForMove);
+
       expect(wrapper.find(Alert).length).toEqual(0);
     });
   });
   describe('One document uploaded', () => {
-    it('renders DocumentUploaded', () => {
+    it('component renders', () => {
       const mockGetMoveDocumentsForMove = jest.fn();
-      const wrapper = mount(
-        <DocumentsUploaded allDocuments={['document']} getMoveDocumentsForMove={mockGetMoveDocumentsForMove} />,
-      );
+      const wrapper = generateWrapper(['document'], mockGetMoveDocumentsForMove);
+
       expect(mockGetMoveDocumentsForMove).toHaveBeenCalled();
       expect(wrapper.find(Alert).length).toEqual(1);
       expect(wrapper.find(Alert).text()).toContain('1 document added');
     });
   });
   describe('More than one document uploaded', () => {
-    it('renders DocumentUploaded with "documents" in message', () => {
+    it('component renders and text uses "documents" instead of "document"', () => {
       const mockGetMoveDocumentsForMove = jest.fn();
-      const wrapper = mount(
-        <DocumentsUploaded
-          allDocuments={['document 1', 'document 2']}
-          getMoveDocumentsForMove={mockGetMoveDocumentsForMove}
-        />,
-      );
+      const wrapper = generateWrapper(['document 1', 'document 2'], mockGetMoveDocumentsForMove);
+
       expect(mockGetMoveDocumentsForMove).toHaveBeenCalled();
       expect(wrapper.find(Alert).length).toEqual(1);
       expect(wrapper.find(Alert).text()).toContain('2 documents added');

--- a/src/scenes/Moves/Ppm/DocumentsUploaded.test.js
+++ b/src/scenes/Moves/Ppm/DocumentsUploaded.test.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import { DocumentsUploaded } from './DocumentsUploaded';
+import { mount } from 'enzyme';
+import Alert from 'shared/Alert';
+
+describe('Documents Uploaded Alert', () => {
+  describe('No documents uploaded', () => {
+    it('does not render DocumentUploaded', () => {
+      const wrapper = mount(<DocumentsUploaded allDocuments={[]} getMoveDocumentsForMove={jest.fn()} />);
+      expect(wrapper.find(Alert).length).toEqual(0);
+    });
+  });
+  describe('One document uploaded', () => {
+    it('renders DocumentUploaded', () => {
+      const mockGetMoveDocumentsForMove = jest.fn();
+      const wrapper = mount(
+        <DocumentsUploaded allDocuments={['document']} getMoveDocumentsForMove={mockGetMoveDocumentsForMove} />,
+      );
+      expect(mockGetMoveDocumentsForMove).toHaveBeenCalled();
+      expect(wrapper.find(Alert).length).toEqual(1);
+      expect(wrapper.find(Alert).text()).toContain('1 document added');
+    });
+  });
+  describe('More than one document uploaded', () => {
+    it('renders DocumentUploaded with "documents" in message', () => {
+      const mockGetMoveDocumentsForMove = jest.fn();
+      const wrapper = mount(
+        <DocumentsUploaded
+          allDocuments={['document 1', 'document 2']}
+          getMoveDocumentsForMove={mockGetMoveDocumentsForMove}
+        />,
+      );
+      expect(mockGetMoveDocumentsForMove).toHaveBeenCalled();
+      expect(wrapper.find(Alert).length).toEqual(1);
+      expect(wrapper.find(Alert).text()).toContain('2 documents added');
+    });
+  });
+});

--- a/src/scenes/Moves/Ppm/ExpensesLanding.jsx
+++ b/src/scenes/Moves/Ppm/ExpensesLanding.jsx
@@ -9,6 +9,7 @@ import WizardHeader from '../WizardHeader';
 
 import './Expenses.css';
 import { connect } from 'react-redux';
+import DocumentsUploaded from './DocumentsUploaded';
 
 class ExpensesLanding extends Component {
   state = {
@@ -28,7 +29,7 @@ class ExpensesLanding extends Component {
 
   render() {
     const { hasExpenses } = this.state;
-    const { history } = this.props;
+    const { history, moveId } = this.props;
     return (
       <>
         <WizardHeader
@@ -41,6 +42,7 @@ class ExpensesLanding extends Component {
             </ProgressTimeline>
           }
         />
+        <DocumentsUploaded moveId={moveId} />
 
         <div className="usa-grid expenses-container">
           <h3 className="expenses-header">Do you have any storage or moving expenses?</h3>

--- a/src/scenes/Moves/Ppm/ExpensesUpload.jsx
+++ b/src/scenes/Moves/Ppm/ExpensesUpload.jsx
@@ -325,7 +325,6 @@ function mapStateToProps(state, props) {
     expenseSchema: get(state, 'swaggerInternal.spec.definitions.CreateMovingExpenseDocumentPayload', {}),
     currentPpm: get(state, 'ppm.currentPpm'),
     expenses: selectPPMCloseoutDocumentsForMove(state, moveId, ['EXPENSE']),
-    allDocuments: selectPPMCloseoutDocumentsForMove(state, moveId),
   };
 }
 

--- a/src/scenes/Moves/Ppm/ExpensesUpload.jsx
+++ b/src/scenes/Moves/Ppm/ExpensesUpload.jsx
@@ -21,6 +21,7 @@ import { createMovingExpenseDocument } from 'shared/Entities/modules/movingExpen
 import Alert from 'shared/Alert';
 import { selectPPMCloseoutDocumentsForMove } from 'shared/Entities/modules/movingExpenseDocuments';
 import { getMoveDocumentsForMove } from 'shared/Entities/modules/moveDocuments';
+import DocumentsUploaded from './DocumentsUploaded';
 
 class ExpensesUpload extends Component {
   state = { ...this.initialState };
@@ -148,7 +149,16 @@ class ExpensesUpload extends Component {
 
   render() {
     const { missingReceipt, paymentMethod, haveMoreExpenses, moveDocumentCreateError } = this.state;
-    const { moveDocSchema, formValues, isPublic, handleSubmit, submitting, expenses, expenseSchema } = this.props;
+    const {
+      moveDocSchema,
+      formValues,
+      isPublic,
+      handleSubmit,
+      submitting,
+      expenses,
+      expenseSchema,
+      moveId,
+    } = this.props;
     const nextBtnLabel =
       haveMoreExpenses === 'Yes'
         ? ExpensesUpload.nextBtnLabels.SaveAndAddAnother
@@ -168,6 +178,7 @@ class ExpensesUpload extends Component {
             </ProgressTimeline>
           }
         />
+        <DocumentsUploaded moveId={moveId} />
 
         <div className="usa-grid expenses-container">
           <h3 className="expenses-header">Expense {expenseNumber}</h3>
@@ -314,6 +325,7 @@ function mapStateToProps(state, props) {
     expenseSchema: get(state, 'swaggerInternal.spec.definitions.CreateMovingExpenseDocumentPayload', {}),
     currentPpm: get(state, 'ppm.currentPpm'),
     expenses: selectPPMCloseoutDocumentsForMove(state, moveId, ['EXPENSE']),
+    allDocuments: selectPPMCloseoutDocumentsForMove(state, moveId),
   };
 }
 

--- a/src/scenes/Moves/Ppm/WeightTicket.jsx
+++ b/src/scenes/Moves/Ppm/WeightTicket.jsx
@@ -1,5 +1,5 @@
 import React, { Component, Fragment } from 'react';
-import { reduxForm, getFormValues } from 'redux-form';
+import { getFormValues, reduxForm } from 'redux-form';
 import { connect } from 'react-redux';
 import { get, map } from 'lodash';
 import PropTypes from 'prop-types';
@@ -24,6 +24,7 @@ import faQuestionCircle from '@fortawesome/fontawesome-free-solid/faQuestionCirc
 import { selectPPMCloseoutDocumentsForMove } from 'shared/Entities/modules/movingExpenseDocuments';
 import { getMoveDocumentsForMove } from 'shared/Entities/modules/moveDocuments';
 import { intToOrdinal } from './utility';
+import DocumentsUploaded from './DocumentsUploaded';
 
 const vehicleTypes = {
   CarAndTrailer: 'CAR_TRAILER',
@@ -203,11 +204,10 @@ class WeightTicket extends Component {
       missingDocumentation,
       isValidTrailer,
     } = this.state;
-    const { handleSubmit, submitting, schema, weightTicketSets } = this.props;
+    const { handleSubmit, submitting, schema, weightTicketSets, moveId } = this.props;
     const nextBtnLabel =
       additionalWeightTickets === 'Yes' ? nextBtnLabels.SaveAndAddAnother : nextBtnLabels.SaveAndContinue;
     const weightTicketSetOrdinal = intToOrdinal(weightTicketSets.length + 1);
-
     return (
       <Fragment>
         <WizardHeader
@@ -220,6 +220,7 @@ class WeightTicket extends Component {
             </ProgressTimeline>
           }
         />
+        <DocumentsUploaded moveId={moveId} />
         <form>
           {this.state.weightTicketSubmissionError && (
             <div className="usa-grid">
@@ -482,6 +483,7 @@ function mapStateToProps(state, ownProps) {
     schema: get(state, 'swaggerInternal.spec.definitions.CreateWeightTicketDocumentsPayload', {}),
     currentPpm: get(state, 'ppm.currentPpm'),
     weightTicketSets: selectPPMCloseoutDocumentsForMove(state, moveId, ['WEIGHT_TICKET_SET']),
+    allDocuments: selectPPMCloseoutDocumentsForMove(state, moveId),
   };
 }
 

--- a/src/scenes/Moves/Ppm/WeightTicket.jsx
+++ b/src/scenes/Moves/Ppm/WeightTicket.jsx
@@ -483,7 +483,6 @@ function mapStateToProps(state, ownProps) {
     schema: get(state, 'swaggerInternal.spec.definitions.CreateWeightTicketDocumentsPayload', {}),
     currentPpm: get(state, 'ppm.currentPpm'),
     weightTicketSets: selectPPMCloseoutDocumentsForMove(state, moveId, ['WEIGHT_TICKET_SET']),
-    allDocuments: selectPPMCloseoutDocumentsForMove(state, moveId),
   };
 }
 


### PR DESCRIPTION
## Description

In the new ppm closeout flow, users should see an indicator at the top showing the total number of documents uploaded for the weight tickets, expense landing, and expense uploads pages.

## Setup

```sh
make client_test
make e2e_test
```

## Code Review Verification Steps
* [x] User facing changes have been reviewed by design.
* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/n/projects/2181745/stories/164718754) for this change

## Screenshots
![Screen Shot 2019-06-20 at 3 53 47 PM](https://user-images.githubusercontent.com/1036969/59883841-a4633d00-9373-11e9-9342-deb6e561698f.png)
![Screen Shot 2019-06-20 at 3 53 36 PM](https://user-images.githubusercontent.com/1036969/59883842-a4fbd380-9373-11e9-886f-4444206f2567.png)
![Screen Shot 2019-06-20 at 3 52 07 PM](https://user-images.githubusercontent.com/1036969/59883843-a4fbd380-9373-11e9-9462-fb5861007b0d.png)
