### PR TITLE
Fix nil error bug for TSP API

### DIFF
--- a/pkg/handlers/errors_test.go
+++ b/pkg/handlers/errors_test.go
@@ -69,3 +69,14 @@ func (suite *ErrorsSuite) TestResponseForErrorWhenASQLErrorIsEncountered() {
 	}
 
 }
+
+func (suite *ErrorsSuite) TestResponseForErrorNil() {
+
+	var err error
+	actual := ResponseForError(suite.logger, err)
+	res, ok := actual.(*ErrResponse)
+	suite.True(ok)
+	suite.Equal(res.Code, 500)
+	suite.Equal(res.Err.Error(), NilErrMessage)
+
+}

--- a/pkg/handlers/publicapi/transportation_service_provider_test.go
+++ b/pkg/handlers/publicapi/transportation_service_provider_test.go
@@ -68,3 +68,58 @@ func (suite *HandlerSuite) TestGetTransportationServiceProviderHandlerWhereSessi
 	suite.NotEqual(session.ServiceMemberID, shipment.ServiceMemberID)
 	suite.Assertions.IsType(&tspop.GetTransportationServiceProviderForbidden{}, response)
 }
+
+func (suite *HandlerSuite) TestGetTransportationServiceProviderHandlerNotFound() {
+	numTspUsers := 1
+	numShipments := 1
+	numShipmentOfferSplit := []int{1}
+	status := []models.ShipmentStatus{models.ShipmentStatusSUBMITTED}
+	tspUsers, shipments, offers, err := testdatagen.CreateShipmentOfferData(suite.DB(), numTspUsers, numShipments, numShipmentOfferSplit, status, models.SelectedMoveTypeHHG)
+	suite.NoError(err)
+
+	tspUser := tspUsers[0]
+	shipment := shipments[0]
+
+	// Remove the offer
+	offer := offers[0]
+	suite.MustDestroy(&offer)
+
+	path := fmt.Sprintf("/shipments/%s/transportation_service_provider", shipment.ID.String())
+
+	// And: the context contains the auth values
+	req := httptest.NewRequest("GET", path, nil)
+	req = suite.AuthenticateTspRequest(req, tspUser)
+
+	params := tspop.GetTransportationServiceProviderParams{
+		HTTPRequest: req,
+		ShipmentID:  strfmt.UUID(shipment.ID.String()),
+	}
+
+	// And: a tsp is returned
+	handler := GetTransportationServiceProviderHandler{handlers.NewHandlerContext(suite.DB(), suite.TestLogger())}
+	response := handler.Handle(params)
+
+	// Then: expect a 404 status code
+	suite.Assertions.IsType(&tspop.GetTransportationServiceProviderNotFound{}, response)
+}
+
+func (suite *HandlerSuite) TestGetTransportationServiceProviderHandlerOfficeUserNotFound() {
+	officeUser := testdatagen.MakeDefaultOfficeUser(suite.DB())
+	shipment := testdatagen.MakeDefaultShipment(suite.DB())
+
+	path := fmt.Sprintf("/shipments/%s/transportation_service_provider", shipment.ID.String())
+	req := httptest.NewRequest("GET", path, nil)
+	req = suite.AuthenticateOfficeRequest(req, officeUser)
+
+	params := tspop.GetTransportationServiceProviderParams{
+		HTTPRequest: req,
+		ShipmentID:  strfmt.UUID(shipment.ID.String()),
+	}
+
+	// And a tsp is returned
+	handler := GetTransportationServiceProviderHandler{handlers.NewHandlerContext(suite.DB(), suite.TestLogger())}
+	response := handler.Handle(params)
+
+	// Then: expect a 404 status code
+	suite.Assertions.IsType(&tspop.GetTransportationServiceProviderNotFound{}, response)
+}

--- a/pkg/testingsuite/pop_suite.go
+++ b/pkg/testingsuite/pop_suite.go
@@ -65,6 +65,17 @@ func (suite *PopTestSuite) MustCreate(db *pop.Connection, model interface{}) {
 	}
 }
 
+// MustDestroy requires deleting without errors
+func (suite *PopTestSuite) MustDestroy(model interface{}) {
+	t := suite.T()
+	t.Helper()
+
+	err := suite.db.Destroy(model)
+	if err != nil {
+		suite.T().Errorf("Errors encountered destroying %v: %v", model, err)
+	}
+}
+
 // NoVerrs prints any errors it receives
 func (suite *PopTestSuite) NoVerrs(verrs *validate.Errors) bool {
 	if !suite.False(verrs.HasAny()) {

--- a/swagger/api.yaml
+++ b/swagger/api.yaml
@@ -2583,12 +2583,12 @@ paths:
           description: returns a Transporation Service Provider
           schema:
             $ref: '#/definitions/TransportationServiceProvider'
-        400:
-          description: invalid request
         401:
           description: must be authenticated to use this endpoint
         403:
           description: not authorized to list these shipments
+        404:
+          description: transportation service provider does not exist for shipment
         422:
           description: cannot process request with given information
         500:


### PR DESCRIPTION
## Description

While load testing in #1597 I ran into a case where the Office user was requesting information on the TSP for a shipment and causing a null pointer dereference. The root of the problem is that the `err` that was being sent to `ResponseForErrors` was uninstantiated and therefore was a `nil` value. This doesn't play nicely with [`zap.Error()`](https://godoc.org/go.uber.org/zap#Error) which wants an instantiated error.  So for the first part of this PR I fixed this so that `ResponseForError` no longer causes issues if a `nil` Error is passed to it.

The second issue is that the TSP handler should return a 404 when the Shipment Offer is not found or for a shipment. You can't get a TSP record for a shipment without a Shipment Offer and it was the case in my load test where a Shipment was created but not yet offered via the award queue. 

Two other things cropped up that were probably related. An old error return path had been disabled and upon closer inspection I noticed that the error was spelled wrong, which probably led to it throwing compilation errors which is why I expect it was disabled. I also noticed two other places where that same spelling mistake occurred so I fixed all three.

Finally, I removed all instances of calling `ResponseForError` because none of them were actually returned. `ResponseForError` doesn't do anything except return an error which should then be sent up the handler. But if we're sending pre-made error objects from Swagger then we don't need them.  This removal is a noop in the code.

## Setup

```sh
make server_test
```

## Code Review Verification Steps

* [x] Request review from a member of a different team.