### PR TITLE
make prune

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -859,6 +859,24 @@ pre_commit_tests: .server_generate.stamp .client_deps.stamp ## Run pre-commit te
 pretty: gofmt ## Run code through JS and Golang formatters
 	npx prettier --write --loglevel warn "src/**/*.{js,jsx}"
 
+.PHONY: prune_images
+prune_images:  ## Prune docker images
+	@echo '****************'
+	docker image prune -a
+
+.PHONY: prune_containers
+prune_containers:  ## Prune docker containers
+	@echo '****************'
+	docker container prune
+
+.PHONY: prune_volumes
+prune_volumes:  ## Prune docker volumes
+	@echo '****************'
+	docker volume prune
+
+.PHONY: prune
+prune: prune_images prune_containers prune_volumes ## Prune docker containers, images, and volumes
+
 .PHONY: clean
 clean: # Clean all generated files
 	rm -f .*.stamp


### PR DESCRIPTION
## Description

This PR adds make targets for stepping through pruning of your docker system.  You can use the `make prune` target or call an underlying target.  The force flag is not set, so the developer will be able to cancel any operation.

## Reviewer Notes

```
make prune
```

## Setup

None

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/tree/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/tree/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/tree/master/docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
  * [ ] Secure migrations have been tested using `scripts/run-prod-migrations`
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

None

## Screenshots

None