### PR TITLE
PPM Closeout: Revisiting weight tickets and expense page behavior.

### DIFF
--- a/cypress/integration/mymove/ppm.js
+++ b/cypress/integration/mymove/ppm.js
@@ -188,36 +188,74 @@ describe('editing ppm only move', () => {
 });
 
 describe('allows a SM to request a payment', function() {
+  const smId = '8e0d7e98-134e-4b28-bdd1-7d6b1ff34f9e';
+  const moveID = '946a5d40-0636-418f-b457-474915fb0149';
   beforeEach(() => {
     cy.removeFetch();
     cy.server();
     cy.route('POST', '**/internal/uploads').as('postUploadDocument');
     cy.route('POST', '**/moves/**/weight_ticket').as('postWeightTicket');
     cy.route('POST', '**/moves/**/moving_expense_documents').as('postMovingExpense');
-    cy.signInAsUserPostRequest(milmoveAppName, '8e0d7e98-134e-4b28-bdd1-7d6b1ff34f9e');
+    cy.signInAsUserPostRequest(milmoveAppName, smId);
   });
 
   it('service member reads introduction to ppm payment and cancels to go back to homepage', () => {
-    serviceMemberVisitsIntroToPPMPaymentRequest();
+    serviceMemberStartsPPMPaymentRequestWithAssertions();
     serviceMemberCanCancel();
   });
 
   it('service member goes through entire request payment flow', () => {
-    serviceMemberSubmitsWeightTicket('CAR', false);
+    serviceMemberStartsPPMPaymentRequest();
+    serviceMemberSubmitsWeightTicket('CAR', false, '1st');
     serviceMemberViewsExpensesLandingPage();
-    serviceMemberUploadsExpenses();
+    serviceMemberUploadsExpenses(true, 1);
+    serviceMemberUploadsStorageExpenses(false, 2);
+    serviceMemberReviewsDocuments();
   });
 
   it('service member submits weight tickets without any documents', () => {
+    serviceMemberStartsPPMPaymentRequest();
     serviceMemberSubmitsWeightsTicketsWithoutReceipts();
   });
 
   it('service member requests a car + trailer weight ticket payment', () => {
+    serviceMemberStartsPPMPaymentRequest();
     serviceMemberSubmitsCarTrailerWeightTicket();
   });
 
   it('service member can save a weight ticket for later', () => {
+    serviceMemberStartsPPMPaymentRequest();
     serviceMemberSavesWeightTicketForLater('BOX_TRUCK');
+  });
+
+  it('service member starting at review page returns to review page after adding a weight ticket', () => {
+    cy.visit(`/moves/${moveID}/ppm-review`);
+    cy.location().should(loc => {
+      expect(loc.pathname).to.match(/^\/moves\/[^/]+\/ppm-review/);
+    });
+    cy.get('[data-cy="weight-ticket-link"]').click();
+    cy.location().should(loc => {
+      expect(loc.pathname).to.match(/^\/moves\/[^/]+\/ppm-weight-ticket/);
+    });
+    serviceMemberSubmitsWeightTicket('CAR', false);
+    cy.location().should(loc => {
+      expect(loc.pathname).to.match(/^\/moves\/[^/]+\/ppm-review/);
+    });
+  });
+
+  it('service member starting at review page returns to review page after adding an expense', () => {
+    cy.visit(`/moves/${moveID}/ppm-review`);
+    cy.location().should(loc => {
+      expect(loc.pathname).to.match(/^\/moves\/[^/]+\/ppm-review/);
+    });
+    cy.get('[data-cy="expense-link"]').click();
+    cy.location().should(loc => {
+      expect(loc.pathname).to.match(/^\/moves\/[^/]+\/ppm-expenses/);
+    });
+    serviceMemberUploadsExpenses(false);
+    cy.location().should(loc => {
+      expect(loc.pathname).to.match(/^\/moves\/[^/]+\/ppm-review/);
+    });
   });
 
   //TODO: remove when done with the new flow to request payment
@@ -267,6 +305,12 @@ describe('allows a SM to request a payment', function() {
   });
 });
 
+function serviceMemberReviewsDocuments() {
+  cy.location().should(loc => {
+    expect(loc.pathname).to.match(/^\/moves\/[^/]+\/ppm-review/);
+  });
+}
+
 function serviceMemberViewsExpensesLandingPage() {
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/moves\/[^/]+\/ppm-expenses-intro/);
@@ -293,10 +337,9 @@ function serviceMemberViewsExpensesLandingPage() {
     .should('have.attr', 'href')
     .and('match', /^\/allowable-expenses/);
 
-  cy
-    .get('[type="radio"]')
-    .first()
-    .check({ force: true });
+  cy.get('input[name="hasExpenses"][value="Yes"]').should('not.be.checked');
+  cy.get('input[name="hasExpenses"][value="No"]').should('not.be.checked');
+  cy.get('input[name="hasExpenses"][value="Yes"]+label').click();
 
   cy
     .get('button')
@@ -305,12 +348,14 @@ function serviceMemberViewsExpensesLandingPage() {
     .click();
 }
 
-function serviceMemberUploadsExpenses() {
+function serviceMemberUploadsExpenses(hasAnother = true, expenseNumber = null) {
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/moves\/[^/]+\/ppm-expenses/);
   });
 
-  cy.contains('Expense 1');
+  if (expenseNumber) {
+    cy.contains(`Expense ${expenseNumber}`);
+  }
   cy.get('[data-cy=documents-uploaded]').should('exist');
 
   cy.get('select[name="moving_expense_type"]').select('GAS');
@@ -327,15 +372,32 @@ function serviceMemberUploadsExpenses() {
   cy.get('input[name="haveMoreExpenses"][value="Yes"]').should('not.be.checked');
   cy.get('input[name="haveMoreExpenses"][value="No"]').should('be.checked');
   cy.get('input[name="haveMoreExpenses"][value="Yes"]+label').click();
-
-  cy.contains('Save & Add Another').click();
+  if (hasAnother) {
+    cy
+      .get('button')
+      .contains('Save & Add Another')
+      .click();
+  } else {
+    cy.get('input[name="haveMoreExpenses"][value="No"]+label').click();
+    cy.get('input[name="haveMoreExpenses"][value="No"]').should('be.checked');
+    cy
+      .get('button')
+      .contains('Save & Continue')
+      .click();
+  }
   cy
     .wait('@postMovingExpense')
     .its('status')
     .should('eq', 200);
+}
 
-  // Add an expense that's missing a receipt
-  cy.contains('Expense 2');
+function serviceMemberUploadsStorageExpenses(hasAnother = true, expenseNumber = null) {
+  cy.location().should(loc => {
+    expect(loc.pathname).to.match(/^\/moves\/[^/]+\/ppm-expenses/);
+  });
+  if (expenseNumber) {
+    cy.contains(`Expense ${expenseNumber}`);
+  }
 
   cy.get('select[name="moving_expense_type"]').select('STORAGE');
   cy
@@ -353,7 +415,19 @@ function serviceMemberUploadsExpenses() {
   cy.get('input[name="missingReceipt"]').should('be.checked');
   cy.get('input[name="haveMoreExpenses"][value="Yes"]+label').click();
 
-  cy.contains('Save & Add Another').click();
+  if (hasAnother) {
+    cy
+      .get('button')
+      .contains('Save & Add Another')
+      .click();
+  } else {
+    cy.get('input[name="haveMoreExpenses"][value="No"]+label').click();
+    cy.get('input[name="haveMoreExpenses"][value="No"]').should('be.checked');
+    cy
+      .get('button')
+      .contains('Save & Continue')
+      .click();
+  }
   cy
     .wait('@postMovingExpense')
     .its('status')
@@ -361,12 +435,6 @@ function serviceMemberUploadsExpenses() {
 }
 
 function serviceMemberSubmitsCarTrailerWeightTicket() {
-  cy.contains('Request Payment').click();
-  cy
-    .get('button')
-    .contains('Get Started')
-    .click();
-
   cy.get('select[name="vehicle_options"]').select('CAR_TRAILER');
 
   cy.get('input[name="vehicle_nickname"]').type('Nickname');
@@ -376,10 +444,9 @@ function serviceMemberSubmitsCarTrailerWeightTicket() {
     .children('a')
     .should('have.attr', 'href', '/trailer-criteria');
 
-  cy
-    .get('[type="radio"]')
-    .first()
-    .check({ force: true });
+  cy.get('input[name="isValidTrailer"][value="Yes"]').should('not.be.checked');
+  cy.get('input[name="isValidTrailer"][value="No"]').should('be.checked');
+  cy.get('input[name="isValidTrailer"][value="Yes"]+label').click();
 
   cy.upload_file('[data-cy=trailer-upload] .filepond--root', 'top-secret.png');
   cy.wait('@postUploadDocument');
@@ -405,12 +472,6 @@ function serviceMemberSubmitsCarTrailerWeightTicket() {
     .should('be.checked');
 }
 function serviceMemberSavesWeightTicketForLater(vehicleType) {
-  cy.contains('Request Payment').click();
-  cy
-    .get('button')
-    .contains('Get Started')
-    .click();
-
   cy.get('select[name="vehicle_options"]').select(vehicleType);
 
   cy.get('input[name="vehicle_nickname"]').type('Nickname');
@@ -443,12 +504,6 @@ function serviceMemberSavesWeightTicketForLater(vehicleType) {
 }
 
 function serviceMemberSubmitsWeightsTicketsWithoutReceipts() {
-  cy.contains('Request Payment').click();
-  cy
-    .get('button')
-    .contains('Get Started')
-    .click();
-
   cy.get('select[name="vehicle_options"]').select('CAR_TRAILER');
   cy.get('input[name="vehicle_nickname"]').type('Nickname');
   cy.get('input[name="empty_weight"]').type('1000');
@@ -483,15 +538,23 @@ function serviceMemberSubmitsWeightsTicketsWithoutReceipts() {
   cy.wait('@postWeightTicket');
 }
 
-function serviceMemberSubmitsWeightTicket(vehicleType, hasAnother = true, ordinal = '1st') {
+function serviceMemberStartsPPMPaymentRequest() {
   cy.contains('Request Payment').click();
   cy
     .get('button')
     .contains('Get Started')
     .click();
+}
 
-  cy.contains(`Weight Tickets - ${ordinal} set`);
-  cy.get('[data-cy=documents-uploaded]').should('not.exist');
+function serviceMemberSubmitsWeightTicket(vehicleType, hasAnother = true, ordinal = null) {
+  if (ordinal) {
+    cy.contains(`Weight Tickets - ${ordinal} set`);
+    if (ordinal === '1st') {
+      cy.get('[data-cy=documents-uploaded]').should('not.exist');
+    } else {
+      cy.get('[data-cy=documents-uploaded]').should('exist');
+    }
+  }
 
   cy.get('select[name="vehicle_options"]').select(vehicleType);
 
@@ -511,29 +574,24 @@ function serviceMemberSubmitsWeightTicket(vehicleType, hasAnother = true, ordina
     .get('input[name="weight_ticket_date"]')
     .type('6/2/2018{enter}')
     .blur();
+  cy.get('input[name="additional_weight_ticket"][value="Yes"]').should('be.checked');
+  cy.get('input[name="additional_weight_ticket"][value="No"]').should('not.be.checked');
   if (hasAnother) {
-    cy
-      .get('[type="radio"]')
-      .first()
-      .should('be.checked');
-
     cy
       .get('button')
       .contains('Save & Add Another')
       .click();
+    cy.wait('@postWeightTicket');
+    cy.get('[data-cy=documents-uploaded]').should('exist');
   } else {
-    cy
-      .get('[type="radio"]')
-      .last()
-      .check({ force: true });
-
+    cy.get('input[name="additional_weight_ticket"][value="No"]+label').click();
+    cy.get('input[name="additional_weight_ticket"][value="No"]').should('be.checked');
     cy
       .get('button')
       .contains('Save & Continue')
       .click();
+    cy.wait('@postWeightTicket');
   }
-  cy.wait('@postWeightTicket');
-  cy.get('[data-cy=documents-uploaded]').should('exist');
 }
 
 function serviceMemberCanCancel() {
@@ -547,7 +605,7 @@ function serviceMemberCanCancel() {
   });
 }
 
-function serviceMemberVisitsIntroToPPMPaymentRequest() {
+function serviceMemberStartsPPMPaymentRequestWithAssertions() {
   cy.contains('Request Payment').click();
 
   cy.location().should(loc => {

--- a/cypress/integration/mymove/ppm.js
+++ b/cypress/integration/mymove/ppm.js
@@ -377,6 +377,11 @@ function serviceMemberUploadsExpenses(hasAnother = true, expenseNumber = null) {
       .get('button')
       .contains('Save & Add Another')
       .click();
+    cy
+      .wait('@postMovingExpense')
+      .its('status')
+      .should('eq', 200);
+    cy.get('[data-cy=documents-uploaded]').should('exist');
   } else {
     cy.get('input[name="haveMoreExpenses"][value="No"]+label').click();
     cy.get('input[name="haveMoreExpenses"][value="No"]').should('be.checked');
@@ -384,11 +389,11 @@ function serviceMemberUploadsExpenses(hasAnother = true, expenseNumber = null) {
       .get('button')
       .contains('Save & Continue')
       .click();
+    cy
+      .wait('@postMovingExpense')
+      .its('status')
+      .should('eq', 200);
   }
-  cy
-    .wait('@postMovingExpense')
-    .its('status')
-    .should('eq', 200);
 }
 
 function serviceMemberUploadsStorageExpenses(hasAnother = true, expenseNumber = null) {
@@ -581,7 +586,10 @@ function serviceMemberSubmitsWeightTicket(vehicleType, hasAnother = true, ordina
       .get('button')
       .contains('Save & Add Another')
       .click();
-    cy.wait('@postWeightTicket');
+    cy
+      .wait('@postWeightTicket')
+      .its('status')
+      .should('eq', 200);
     cy.get('[data-cy=documents-uploaded]').should('exist');
   } else {
     cy.get('input[name="additional_weight_ticket"][value="No"]+label').click();
@@ -590,7 +598,10 @@ function serviceMemberSubmitsWeightTicket(vehicleType, hasAnother = true, ordina
       .get('button')
       .contains('Save & Continue')
       .click();
-    cy.wait('@postWeightTicket');
+    cy
+      .wait('@postWeightTicket')
+      .its('status')
+      .should('eq', 200);
   }
 }
 

--- a/cypress/integration/mymove/ppm.js
+++ b/cypress/integration/mymove/ppm.js
@@ -229,9 +229,9 @@ describe('allows a SM to request a payment', function() {
   });
 
   it('service member starting at review page returns to review page after adding a weight ticket', () => {
-    cy.visit(`/moves/${moveID}/ppm-review`);
+    cy.visit(`/moves/${moveID}/ppm-payment-review`);
     cy.location().should(loc => {
-      expect(loc.pathname).to.match(/^\/moves\/[^/]+\/ppm-review/);
+      expect(loc.pathname).to.match(/^\/moves\/[^/]+\/ppm-payment-review/);
     });
     cy.get('[data-cy="weight-ticket-link"]').click();
     cy.location().should(loc => {
@@ -239,14 +239,14 @@ describe('allows a SM to request a payment', function() {
     });
     serviceMemberSubmitsWeightTicket('CAR', false);
     cy.location().should(loc => {
-      expect(loc.pathname).to.match(/^\/moves\/[^/]+\/ppm-review/);
+      expect(loc.pathname).to.match(/^\/moves\/[^/]+\/ppm-payment-review/);
     });
   });
 
   it('service member starting at review page returns to review page after adding an expense', () => {
-    cy.visit(`/moves/${moveID}/ppm-review`);
+    cy.visit(`/moves/${moveID}/ppm-payment-review`);
     cy.location().should(loc => {
-      expect(loc.pathname).to.match(/^\/moves\/[^/]+\/ppm-review/);
+      expect(loc.pathname).to.match(/^\/moves\/[^/]+\/ppm-payment-review/);
     });
     cy.get('[data-cy="expense-link"]').click();
     cy.location().should(loc => {
@@ -254,7 +254,7 @@ describe('allows a SM to request a payment', function() {
     });
     serviceMemberUploadsExpenses(false);
     cy.location().should(loc => {
-      expect(loc.pathname).to.match(/^\/moves\/[^/]+\/ppm-review/);
+      expect(loc.pathname).to.match(/^\/moves\/[^/]+\/ppm-payment-review/);
     });
   });
 
@@ -307,7 +307,7 @@ describe('allows a SM to request a payment', function() {
 
 function serviceMemberReviewsDocuments() {
   cy.location().should(loc => {
-    expect(loc.pathname).to.match(/^\/moves\/[^/]+\/ppm-review/);
+    expect(loc.pathname).to.match(/^\/moves\/[^/]+\/ppm-payment-review/);
   });
 }
 

--- a/pkg/handlers/internalapi/move_documents.go
+++ b/pkg/handlers/internalapi/move_documents.go
@@ -68,7 +68,7 @@ func payloadForMoveDocumentExtractor(storer storage.FileStorer, docExtractor mod
 		emptyWeight = handlers.FmtInt64(int64(*docExtractor.EmptyWeight))
 	}
 	var emptyWeightTicketMissing *bool
-	if docExtractor.EmptyWeight != nil {
+	if docExtractor.EmptyWeightTicketMissing != nil {
 		emptyWeightTicketMissing = docExtractor.EmptyWeightTicketMissing
 	}
 	var fullWeight *int64
@@ -76,7 +76,7 @@ func payloadForMoveDocumentExtractor(storer storage.FileStorer, docExtractor mod
 		fullWeight = handlers.FmtInt64(int64(*docExtractor.FullWeight))
 	}
 	var fullWeightTicketMissing *bool
-	if docExtractor.EmptyWeight != nil {
+	if docExtractor.FullWeightTicketMissing != nil {
 		fullWeightTicketMissing = docExtractor.FullWeightTicketMissing
 	}
 	var vehicleNickname string

--- a/src/scenes/Moves/Ppm/ExpensesLanding.jsx
+++ b/src/scenes/Moves/Ppm/ExpensesLanding.jsx
@@ -21,7 +21,7 @@ class ExpensesLanding extends Component {
 
   handleRadioChange = event => {
     this.setState({
-      hasExpenses: event.target.value,
+      [event.target.name]: event.target.value,
     });
   };
 

--- a/src/scenes/Moves/Ppm/ExpensesLanding.jsx
+++ b/src/scenes/Moves/Ppm/ExpensesLanding.jsx
@@ -11,7 +11,7 @@ import './Expenses.css';
 import { connect } from 'react-redux';
 import DocumentsUploaded from './DocumentsUploaded';
 
-const reviewPagePath = '/ppm-review';
+const reviewPagePath = '/ppm-payment-review';
 const nextPagePath = '/ppm-expenses';
 
 class ExpensesLanding extends Component {

--- a/src/scenes/Moves/Ppm/ExpensesLanding.jsx
+++ b/src/scenes/Moves/Ppm/ExpensesLanding.jsx
@@ -28,7 +28,6 @@ class ExpensesLanding extends Component {
   saveAndAddHandler = () => {
     const { history, moveId } = this.props;
     const { hasExpenses } = this.state;
-    console.log(hasExpenses);
     if (hasExpenses === 'No') {
       return history.push(`/moves/${moveId}${reviewPagePath}`);
     }

--- a/src/scenes/Moves/Ppm/ExpensesLanding.jsx
+++ b/src/scenes/Moves/Ppm/ExpensesLanding.jsx
@@ -11,6 +11,9 @@ import './Expenses.css';
 import { connect } from 'react-redux';
 import DocumentsUploaded from './DocumentsUploaded';
 
+const reviewPagePath = '/ppm-review';
+const nextPagePath = '/ppm-expenses';
+
 class ExpensesLanding extends Component {
   state = {
     hasExpenses: '',
@@ -24,7 +27,12 @@ class ExpensesLanding extends Component {
 
   saveAndAddHandler = () => {
     const { history, moveId } = this.props;
-    history.push(`/moves/${moveId}/ppm-expenses`);
+    const { hasExpenses } = this.state;
+    console.log(hasExpenses);
+    if (hasExpenses === 'No') {
+      return history.push(`/moves/${moveId}${reviewPagePath}`);
+    }
+    return history.push(`/moves/${moveId}${nextPagePath}`);
   };
 
   render() {
@@ -62,7 +70,7 @@ class ExpensesLanding extends Component {
               labelClassName="inline_radio"
               label="Yes"
               value="Yes"
-              name="has_expenses"
+              name="hasExpenses"
               checked={hasExpenses === 'Yes'}
               onChange={this.handleRadioChange}
             />
@@ -71,15 +79,14 @@ class ExpensesLanding extends Component {
               labelClassName="inline_radio"
               label="No"
               value="No"
-              name="has_no_expenses"
+              name="hasExpenses"
               checked={hasExpenses === 'No'}
               onChange={this.handleRadioChange}
             />
           </div>
           <PPMPaymentRequestActionBtns
             cancelHandler={() => {}}
-            //TODO remove once have review page in place
-            displaySaveForLater={hasExpenses === 'No'}
+            displaySaveForLater={true}
             nextBtnLabel="Continue"
             saveAndAddHandler={this.saveAndAddHandler}
             saveForLaterHandler={() => history.push('/')}

--- a/src/scenes/Moves/Ppm/ExpensesUpload.jsx
+++ b/src/scenes/Moves/Ppm/ExpensesUpload.jsx
@@ -27,7 +27,7 @@ import { getMoveDocumentsForMove } from 'shared/Entities/modules/moveDocuments';
 import { withContext } from 'shared/AppContext';
 import DocumentsUploaded from './DocumentsUploaded';
 
-const nextPagePath = '/ppm-review';
+const nextPagePath = '/ppm-payment-review';
 const nextBtnLabels = {
   SaveAndAddAnother: 'Save & Add Another',
   SaveAndContinue: 'Save & Continue',

--- a/src/scenes/Moves/Ppm/ExpensesUpload.jsx
+++ b/src/scenes/Moves/Ppm/ExpensesUpload.jsx
@@ -8,6 +8,7 @@ import WizardHeader from '../WizardHeader';
 import 'shared/DocumentViewer/DocumentUploader.jsx';
 import { get, isEmpty, map } from 'lodash';
 import { convertDollarsToCents } from 'shared/utils';
+import { withLastLocation } from 'react-router-last-location';
 import RadioButton from 'shared/RadioButton';
 import { Link } from 'react-router-dom';
 import FontAwesomeIcon from '@fortawesome/react-fontawesome';
@@ -17,30 +18,35 @@ import Uploader from 'shared/Uploader';
 import Checkbox from 'shared/Checkbox';
 import { getFormValues, reduxForm } from 'redux-form';
 import { connect } from 'react-redux';
-import { createMovingExpenseDocument } from 'shared/Entities/modules/movingExpenseDocuments';
+import {
+  createMovingExpenseDocument,
+  selectPPMCloseoutDocumentsForMove,
+} from 'shared/Entities/modules/movingExpenseDocuments';
 import Alert from 'shared/Alert';
-import { selectPPMCloseoutDocumentsForMove } from 'shared/Entities/modules/movingExpenseDocuments';
 import { getMoveDocumentsForMove } from 'shared/Entities/modules/moveDocuments';
+import { withContext } from 'shared/AppContext';
 import DocumentsUploaded from './DocumentsUploaded';
+
+const nextPagePath = '/ppm-review';
+const nextBtnLabels = {
+  SaveAndAddAnother: 'Save & Add Another',
+  SaveAndContinue: 'Save & Continue',
+};
+
+const paymentMethods = {
+  Other: 'OTHER',
+  GTCC: 'GTCC',
+};
+
+const uploadReceipt =
+  '<span class="uploader-label">Drag & drop or <span class="filepond--label-action">click to upload receipt</span></span>';
 
 class ExpensesUpload extends Component {
   state = { ...this.initialState };
 
-  static nextBtnLabels = {
-    SaveAndAddAnother: 'Save & Add Another',
-    SaveAndContinue: 'Save & Continue',
-  };
-
-  static paymentMethods = {
-    Other: 'OTHER',
-    GTCC: 'GTCC',
-  };
-
-  static uploadReceipt = '<span class="uploader-label">Drag & drop or <span class="filepond--label-action">click to upload receipt</span></span>';
-
   get initialState() {
     return {
-      paymentMethod: ExpensesUpload.paymentMethods.GTCC,
+      paymentMethod: paymentMethods.GTCC,
       uploaderIsIdle: true,
       missingReceipt: false,
       expenseType: '',
@@ -74,8 +80,8 @@ class ExpensesUpload extends Component {
   };
 
   saveAndAddHandler = formValues => {
-    const { moveId, currentPpm } = this.props;
-    const { paymentMethod, missingReceipt } = this.state;
+    const { moveId, currentPpm, history } = this.props;
+    const { paymentMethod, missingReceipt, haveMoreExpenses } = this.state;
     const {
       storage_start_date,
       storage_end_date,
@@ -105,6 +111,9 @@ class ExpensesUpload extends Component {
       })
       .then(() => {
         this.cleanup();
+        if (haveMoreExpenses === 'No') {
+          history.push(`/moves/${moveId}${nextPagePath}`);
+        }
       })
       .catch(e => {
         this.setState({ moveDocumentCreateError: true });
@@ -157,12 +166,10 @@ class ExpensesUpload extends Component {
       submitting,
       expenses,
       expenseSchema,
+      invalid,
       moveId,
     } = this.props;
-    const nextBtnLabel =
-      haveMoreExpenses === 'Yes'
-        ? ExpensesUpload.nextBtnLabels.SaveAndAddAnother
-        : ExpensesUpload.nextBtnLabels.SaveAndContinue;
+    const nextBtnLabel = haveMoreExpenses === 'Yes' ? nextBtnLabels.SaveAndAddAnother : nextBtnLabels.SaveAndContinue;
     const hasMovingExpenseType = !isEmpty(formValues) && formValues.moving_expense_type !== '';
     const isStorageExpense = this.isStorageExpense(formValues);
     const expenseNumber = expenses.length + 1;
@@ -231,7 +238,7 @@ class ExpensesUpload extends Component {
                 />
                 <div className="expenses-uploader">
                   <Uploader
-                    options={{ labelIdle: ExpensesUpload.uploadReceipt }}
+                    options={{ labelIdle: uploadReceipt }}
                     isPublic={isPublic}
                     onRef={ref => (this.uploader = ref)}
                     onChange={this.onChange}
@@ -251,18 +258,18 @@ class ExpensesUpload extends Component {
                     inputClassName="inline_radio"
                     labelClassName="inline_radio"
                     label="Government travel charge card (GTCC)"
-                    value={ExpensesUpload.paymentMethods.GTCC}
+                    value={paymentMethods.GTCC}
                     name="paymentMethod"
-                    checked={paymentMethod === ExpensesUpload.paymentMethods.GTCC}
+                    checked={paymentMethod === paymentMethods.GTCC}
                     onChange={this.handleRadioChange}
                   />
                   <RadioButton
                     inputClassName="inline_radio"
                     labelClassName="inline_radio"
                     label="Other"
-                    value={ExpensesUpload.paymentMethods.Other}
+                    value={paymentMethods.Other}
                     name="paymentMethod"
-                    checked={paymentMethod === ExpensesUpload.paymentMethods.Other}
+                    checked={paymentMethod === paymentMethods.Other}
                     onChange={this.handleRadioChange}
                   />
                   <FontAwesomeIcon
@@ -298,9 +305,7 @@ class ExpensesUpload extends Component {
             )}
             <PPMPaymentRequestActionBtns
               nextBtnLabel={nextBtnLabel}
-              submitButtonsAreDisabled={
-                this.isInvalidUploaderState() || nextBtnLabel === ExpensesUpload.nextBtnLabels.SaveAndContinue
-              }
+              submitButtonsAreDisabled={this.isInvalidUploaderState() || invalid}
               submitting={submitting}
               saveForLaterHandler={handleSubmit(this.saveForLaterHandler)}
               saveAndAddHandler={handleSubmit(this.saveAndAddHandler)}
@@ -337,4 +342,4 @@ const mapDispatchToProps = {
   createMovingExpenseDocument,
 };
 
-export default connect(mapStateToProps, mapDispatchToProps)(ExpensesUpload);
+export default withContext(withLastLocation(connect(mapStateToProps, mapDispatchToProps)(ExpensesUpload)));

--- a/src/scenes/Moves/Ppm/PaymentReview/index.jsx
+++ b/src/scenes/Moves/Ppm/PaymentReview/index.jsx
@@ -2,10 +2,10 @@ import React, { Component } from 'react';
 
 import { ProgressTimeline, ProgressTimelineStep } from 'shared/ProgressTimeline';
 
-import WizardHeader from '../WizardHeader';
+import WizardHeader from 'scenes/Moves/WizardHeader';
 import { Link } from 'react-router-dom';
 
-class Review extends Component {
+class PaymentReview extends Component {
   render() {
     const moveId = this.props.match.params.moveId;
     const weightTicketsPage = `/moves/${moveId}/ppm-weight-ticket`;
@@ -41,4 +41,4 @@ class Review extends Component {
   }
 }
 
-export default Review;
+export default PaymentReview;

--- a/src/scenes/Moves/Ppm/Review.jsx
+++ b/src/scenes/Moves/Ppm/Review.jsx
@@ -3,7 +3,7 @@ import React, { Component } from 'react';
 import { ProgressTimeline, ProgressTimelineStep } from 'shared/ProgressTimeline';
 
 import WizardHeader from '../WizardHeader';
-import Link from 'react-router-dom/es/Link';
+import { Link } from 'react-router-dom';
 
 class Review extends Component {
   render() {

--- a/src/scenes/Moves/Ppm/Review.jsx
+++ b/src/scenes/Moves/Ppm/Review.jsx
@@ -1,0 +1,44 @@
+import React, { Component } from 'react';
+
+import { ProgressTimeline, ProgressTimelineStep } from 'shared/ProgressTimeline';
+
+import WizardHeader from '../WizardHeader';
+import Link from 'react-router-dom/es/Link';
+
+class Review extends Component {
+  render() {
+    const moveId = this.props.match.params.moveId;
+    const weightTicketsPage = `/moves/${moveId}/ppm-weight-ticket`;
+    const expensePage = `/moves/${moveId}/ppm-expenses`;
+    return (
+      <>
+        <WizardHeader
+          title="Review"
+          right={
+            <ProgressTimeline>
+              <ProgressTimelineStep name="Weight" completed />
+              <ProgressTimelineStep name="Expenses" completed />
+              <ProgressTimelineStep name="Review" current />
+            </ProgressTimeline>
+          }
+        />
+        <div className="usa-grid ">
+          <ul>
+            <li>
+              <Link to={weightTicketsPage} data-cy="weight-ticket-link">
+                Weight Ticket
+              </Link>
+            </li>
+            <li>
+              <Link to={expensePage} data-cy="expense-link">
+                Expenses
+              </Link>
+            </li>
+          </ul>
+        </div>
+      </>
+    );
+  }
+}
+
+export default Review;

--- a/src/scenes/Moves/Ppm/WeightTicket.jsx
+++ b/src/scenes/Moves/Ppm/WeightTicket.jsx
@@ -24,7 +24,7 @@ import FontAwesomeIcon from '@fortawesome/react-fontawesome';
 import faQuestionCircle from '@fortawesome/fontawesome-free-solid/faQuestionCircle';
 import { selectPPMCloseoutDocumentsForMove } from 'shared/Entities/modules/movingExpenseDocuments';
 import { getMoveDocumentsForMove } from 'shared/Entities/modules/moveDocuments';
-import { intToOrdinal, getNextPage } from './utility';
+import { getNextPage, intToOrdinal } from './utility';
 import { withContext } from 'shared/AppContext';
 import DocumentsUploaded from './DocumentsUploaded';
 
@@ -129,7 +129,7 @@ class WeightTicket extends Component {
     const uploadersKeys = Object.keys(this.uploaders);
     return uploadersKeys.filter(
       // eslint-disable-next-line security/detect-object-injection
-      key => this.uploaders[key].uploaderRef && this.uploaders[key].uploaderRef.getFiles() > 0,
+      key => this.uploaders[key].uploaderRef && !this.uploaders[key].uploaderRef.isEmpty(),
     );
   }
 

--- a/src/scenes/Moves/Ppm/WeightTicket.jsx
+++ b/src/scenes/Moves/Ppm/WeightTicket.jsx
@@ -39,7 +39,7 @@ const nextBtnLabels = {
   SaveAndContinue: 'Save & Continue',
 };
 
-const reviewPagePath = '/ppm-review';
+const reviewPagePath = '/ppm-payment-review';
 const nextPagePath = '/ppm-expenses-intro';
 
 const uploadEmptyTicketLabel =

--- a/src/scenes/Moves/Ppm/WeightTicket.test.js
+++ b/src/scenes/Moves/Ppm/WeightTicket.test.js
@@ -6,7 +6,7 @@ import store from 'shared/store';
 import MockRouter from 'react-mock-router';
 import PPMPaymentRequestActionBtns from './PPMPaymentRequestActionBtns';
 
-function mountComponents(moreWeightTickets = 'Yes', disableSubmit) {
+function mountComponents(moreWeightTickets = 'Yes', formInvalid, uploderWithInvalidState) {
   const initialValues = {
     empty_weight: 1100,
     full_weight: 2000,
@@ -23,8 +23,9 @@ function mountComponents(moreWeightTickets = 'Yes', disableSubmit) {
     </Provider>,
   );
   const wt = wrapper.find('WeightTicket');
-  if (disableSubmit !== undefined) {
-    wt.instance().submitButtonsAreDisabled = jest.fn().mockReturnValue(disableSubmit);
+  if (formInvalid !== undefined) {
+    wt.instance().invalid = jest.fn().mockReturnValue(formInvalid);
+    wt.instance().uploaderWithInvalidState = jest.fn().mockReturnValue(uploderWithInvalidState);
   }
   wt.setState({ additionalWeightTickets: moreWeightTickets, initialValues: initialValues });
   wt.update();
@@ -34,7 +35,7 @@ function mountComponents(moreWeightTickets = 'Yes', disableSubmit) {
 describe('Weight tickets page', () => {
   describe('Service member is missing a weight ticket', () => {
     it('renders both the Save buttons are disabled', () => {
-      const weightTicket = mountComponents('No', true);
+      const weightTicket = mountComponents('No', true, true);
       const buttonGroup = weightTicket.find(PPMPaymentRequestActionBtns);
       const cancel = weightTicket.find('button').at(0);
       const saveForLater = weightTicket.find('button').at(1);
@@ -48,7 +49,7 @@ describe('Weight tickets page', () => {
   });
   describe('Service member has uploaded both a weight tickets', () => {
     it('renders both the Save buttons are enabled', () => {
-      const weightTicket = mountComponents('No', false);
+      const weightTicket = mountComponents('No', false, false);
       const buttonGroup = weightTicket.find(PPMPaymentRequestActionBtns);
       const cancel = weightTicket.find('button').at(0);
       const saveForLater = weightTicket.find('button').at(1);
@@ -58,21 +59,6 @@ describe('Weight tickets page', () => {
       expect(cancel.props().disabled).not.toEqual(true);
       expect(saveAndAdd.props().disabled).toEqual(false);
       expect(saveForLater.props().disabled).toEqual(false);
-    });
-  });
-
-  describe('Service member hasnt provided an Empty Weight weight ticket', () => {
-    it('renders both the Save buttons are disabled', () => {
-      const weightTicket = mountComponents('No');
-      const buttonGroup = weightTicket.find(PPMPaymentRequestActionBtns);
-      const cancel = weightTicket.find('button').at(0);
-      const saveForLater = weightTicket.find('button').at(1);
-      const saveAndAdd = weightTicket.find('button').at(2);
-
-      expect(buttonGroup.length).toEqual(1);
-      expect(cancel.props().disabled).not.toEqual(true);
-      expect(saveAndAdd.props().disabled).toEqual(true);
-      expect(saveForLater.props().disabled).toEqual(true);
     });
   });
   describe('Service member answers "Yes" that they have more weight tickets', () => {

--- a/src/scenes/Moves/Ppm/utility.js
+++ b/src/scenes/Moves/Ppm/utility.js
@@ -5,3 +5,10 @@ export const intToOrdinal = n => {
   // eslint-disable-next-line security/detect-object-injection
   return n + (s[(v - 20) % 10] || s[v] || s[0]);
 };
+
+export const getNextPage = (nextPage, lastPage, pageToRevisit) => {
+  if (lastPage && lastPage.pathname.includes(pageToRevisit)) {
+    return lastPage.pathname;
+  }
+  return nextPage;
+};

--- a/src/scenes/Moves/Ppm/utility.test.js
+++ b/src/scenes/Moves/Ppm/utility.test.js
@@ -11,14 +11,14 @@ describe('intToOrdinal', () => {
 describe('nextPage', () => {
   it('returns to the lastPage when user is visiting from pageToRevisit', () => {
     const lastPage = {
-      pathname: 'moves/:moveid/ppm-review',
+      pathname: 'moves/:moveid/ppm-payment-review',
       search: '',
       hash: '',
       state: undefined,
     };
-    const nextPage = getNextPage('moves/:moveid/next-page', lastPage, '/ppm-review');
+    const nextPage = getNextPage('moves/:moveid/next-page', lastPage, '/ppm-payment-review');
 
-    expect(nextPage).toEqual('moves/:moveid/ppm-review');
+    expect(nextPage).toEqual('moves/:moveid/ppm-payment-review');
   });
   it('returns to the nextPage when user is not visiting from pageToRevisit', () => {
     const lastPage = {
@@ -27,12 +27,12 @@ describe('nextPage', () => {
       hash: '',
       state: undefined,
     };
-    const nextPage = getNextPage('moves/:moveid/next-page', lastPage, '/ppm-review');
+    const nextPage = getNextPage('moves/:moveid/next-page', lastPage, '/ppm-payment-review');
 
     expect(nextPage).toEqual('moves/:moveid/next-page');
   });
   it('returns to the nextPage when no lastpage', () => {
-    const nextPage = getNextPage('moves/:moveid/next-page', null, '/ppm-review');
+    const nextPage = getNextPage('moves/:moveid/next-page', null, '/ppm-payment-review');
 
     expect(nextPage).toEqual('moves/:moveid/next-page');
   });

--- a/src/scenes/Moves/Ppm/utility.test.js
+++ b/src/scenes/Moves/Ppm/utility.test.js
@@ -1,0 +1,39 @@
+import { intToOrdinal, getNextPage } from './utility';
+
+describe('intToOrdinal', () => {
+  it('returns the ordinal corresponding to an int', () => {
+    expect(intToOrdinal(1)).toEqual('1st');
+    expect(intToOrdinal(2)).toEqual('2nd');
+    expect(intToOrdinal(3)).toEqual('3rd');
+    expect(intToOrdinal(4)).toEqual('4th');
+  });
+});
+describe('nextPage', () => {
+  it('returns to the lastPage when user is visiting from pageToRevisit', () => {
+    const lastPage = {
+      pathname: 'moves/:moveid/ppm-review',
+      search: '',
+      hash: '',
+      state: undefined,
+    };
+    const nextPage = getNextPage('moves/:moveid/next-page', lastPage, '/ppm-review');
+
+    expect(nextPage).toEqual('moves/:moveid/ppm-review');
+  });
+  it('returns to the nextPage when user is not visiting from pageToRevisit', () => {
+    const lastPage = {
+      pathname: 'moves/:moveid/some-other-page',
+      search: '',
+      hash: '',
+      state: undefined,
+    };
+    const nextPage = getNextPage('moves/:moveid/next-page', lastPage, '/ppm-review');
+
+    expect(nextPage).toEqual('moves/:moveid/next-page');
+  });
+  it('returns to the nextPage when no lastpage', () => {
+    const nextPage = getNextPage('moves/:moveid/next-page', null, '/ppm-review');
+
+    expect(nextPage).toEqual('moves/:moveid/next-page');
+  });
+});

--- a/src/scenes/MyMove/index.jsx
+++ b/src/scenes/MyMove/index.jsx
@@ -40,6 +40,7 @@ import FailWhale from 'shared/FailWhale';
 import { detectIE11, no_op } from 'shared/utils';
 import DPSAuthCookie from 'scenes/DPSAuthCookie';
 import TrailerCriteria from 'scenes/Moves/Ppm/TrailerCriteria';
+import Review from '../Moves/Ppm/Review';
 
 export class AppWrapper extends Component {
   state = { hasError: false };
@@ -111,6 +112,7 @@ export class AppWrapper extends Component {
                     <PrivateRoute path="/moves/:moveId/ppm-weight-ticket" component={WeightTicket} />
                     <PrivateRoute path="/moves/:moveId/ppm-expenses-intro" component={ExpensesLanding} />
                     <PrivateRoute path="/moves/:moveId/ppm-expenses" component={ExpensesUpload} />
+                    <PrivateRoute path="/moves/:moveId/ppm-review" component={Review} />
                     <PrivateRoute path="/dps_cookie" component={DPSAuthCookie} />
                     <Route exact path="/forbidden">
                       <div className="usa-grid">

--- a/src/scenes/MyMove/index.jsx
+++ b/src/scenes/MyMove/index.jsx
@@ -40,7 +40,7 @@ import FailWhale from 'shared/FailWhale';
 import { detectIE11, no_op } from 'shared/utils';
 import DPSAuthCookie from 'scenes/DPSAuthCookie';
 import TrailerCriteria from 'scenes/Moves/Ppm/TrailerCriteria';
-import Review from '../Moves/Ppm/Review';
+import PaymentReview from '../Moves/Ppm/PaymentReview';
 
 export class AppWrapper extends Component {
   state = { hasError: false };
@@ -112,7 +112,7 @@ export class AppWrapper extends Component {
                     <PrivateRoute path="/moves/:moveId/ppm-weight-ticket" component={WeightTicket} />
                     <PrivateRoute path="/moves/:moveId/ppm-expenses-intro" component={ExpensesLanding} />
                     <PrivateRoute path="/moves/:moveId/ppm-expenses" component={ExpensesUpload} />
-                    <PrivateRoute path="/moves/:moveId/ppm-review" component={Review} />
+                    <PrivateRoute path="/moves/:moveId/ppm-payment-review" component={PaymentReview} />
                     <PrivateRoute path="/dps_cookie" component={DPSAuthCookie} />
                     <Route exact path="/forbidden">
                       <div className="usa-grid">


### PR DESCRIPTION
## Description

Once a service member has reached the review page, they have the option to add additional weight tickets and expenses. If they choose to do either after adding the item they will be rerouted back to the review page.  

## Reviewer Notes
There were four scenarios outlined in the story. Each scenario as I understood them are listed below:

* S1: **Normal flow:** … -> Expense -> Review
* S2: **Add Weight Ticket:** Review -> Weight Tickets -> Review
* S3: **Add Expense Ticket:** Review -> Expenses -> Review
* S4:  Same as above except adding storage expense.

Experiment with different combinations. You can simulate being at the review page if you don't want to repeat the flow by visiting `/moves/:moveid/ppm-payment-review`.

_The story styling the review page is still being worked on, so for now I've just added a placeholder with the relevant links, but you can otherwise ignore the review page_

## Setup

```sh
make client_test
make e2e_test
```

## Code Review Verification Steps
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/n/projects/2181745/stories/166185120) for this change