### PR TITLE
Add migration to add two Truss users to tsp and office staging

### DIFF
--- a/local_migrations/20190624204138_add-missing-users.sql
+++ b/local_migrations/20190624204138_add-missing-users.sql
@@ -1,0 +1,3 @@
+-- Local test migration.
+-- This will be run on development environments. It should mirror what you
+-- intend to apply on production, but do not include any sensitive data.

--- a/migrations/20190624204138_add-missing-users.up.fizz
+++ b/migrations/20190624204138_add-missing-users.up.fizz
@@ -1,0 +1,1 @@
+exec("./apply-secure-migration.sh 20190624204138_add-missing-users.sql")


### PR DESCRIPTION
## Description

When Accepting the story, it was discovered that two of the 3 users were not actually in the staging db.  This adds them as office users and as the 3 tsp users.

## Setup

`make run_staging_migrations` to see the migrations in your prod db.
`make run_prod_migrations` to check that the users are NOT in the prod db.
`make run_experimental_migrations` to check that the users are NOT in the experimental db.

## Code Review Verification Steps

* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/tree/master/docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
  * [ ] Secure migrations have been tested using `scripts/run-prod-migrations`
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/165255637) for this change



