### PR TITLE
Remove usa-width css and utilize media css

### DIFF
--- a/cypress/integration/mymove/hhgPPM.js
+++ b/cypress/integration/mymove/hhgPPM.js
@@ -424,8 +424,8 @@ function serviceMemberCanReviewMoveSummary() {
     expect(loc.pathname).to.match(/^\/moves\/[^/]+\/review/);
   });
 
-  cy.get('.wizard-header .usa-width-one-third').should('not.contain', 'Move Setup');
-  cy.get('.wizard-header .usa-width-one-third').should('contain', 'Review');
+  cy.get('.wizard-header .wizard-left').should('not.contain', 'Move Setup');
+  cy.get('.wizard-header .wizard-left').should('contain', 'Review');
   cy
     .get('.wizard-header .progress-timeline .step')
     .first()

--- a/src/scenes/Moves/WizardHeader.css
+++ b/src/scenes/Moves/WizardHeader.css
@@ -14,14 +14,23 @@
   width: auto;
 }
 
+.wizard-header .wizard-left {
+  float: left;
+}
+
+.wizard-header .wizard-right {
+  float: right;
+  margin-right: -17px;
+}
+
 @media only screen and (max-width: 375px) {
-  .wizard-right {
+  .wizard-header .wizard-right {
     margin-top: -30px;
   }
 }
 
 @media only screen and (min-width: 380px) {
-  .wizard-right {
+  .wizard-header .wizard-right {
     margin-top: 30px;
   }
 }

--- a/src/scenes/Moves/WizardHeader.css
+++ b/src/scenes/Moves/WizardHeader.css
@@ -5,10 +5,23 @@
 }
 
 .wizard-header h3 {
-  display: inline;
+  font-size: 1.7rem;
+  font-weight: normal;
 }
 
 .icon {
   height: 75;
   width: auto;
+}
+
+@media only screen and (max-width: 375px) {
+  .wizard-right {
+    margin-top: -30px;
+  }
+}
+
+@media only screen and (min-width: 380px) {
+  .wizard-right {
+    margin-top: 30px;
+  }
 }

--- a/src/scenes/Moves/WizardHeader.jsx
+++ b/src/scenes/Moves/WizardHeader.jsx
@@ -5,12 +5,12 @@ import './WizardHeader.css';
 const WizardHeader = ({ icon, right, title }) => (
   <div className="wizard-header">
     <div className="usa-grid">
-      <div className="usa-width-one-third">
+      <div style={{ float: 'left' }}>
         <img className="icon" src={icon} alt="" />
         <h3>{title}</h3>
       </div>
-      <div className="usa-width-two-thirds">
-        <div style={{ float: 'right', marginRight: '-17px' }}>{right}</div>
+      <div className="wizard-right" style={{ float: 'right', marginRight: '-17px' }}>
+        {right}
       </div>
     </div>
     <div className="usa-grid">

--- a/src/scenes/Moves/WizardHeader.jsx
+++ b/src/scenes/Moves/WizardHeader.jsx
@@ -5,7 +5,7 @@ import './WizardHeader.css';
 const WizardHeader = ({ icon, right, title }) => (
   <div className="wizard-header">
     <div className="usa-grid">
-      <div style={{ float: 'left' }}>
+      <div className="wizard-left" style={{ float: 'left' }}>
         <img className="icon" src={icon} alt="" />
         <h3>{title}</h3>
       </div>

--- a/src/scenes/Moves/WizardHeader.jsx
+++ b/src/scenes/Moves/WizardHeader.jsx
@@ -5,13 +5,11 @@ import './WizardHeader.css';
 const WizardHeader = ({ icon, right, title }) => (
   <div className="wizard-header">
     <div className="usa-grid">
-      <div className="wizard-left" style={{ float: 'left' }}>
+      <div className="wizard-left">
         <img className="icon" src={icon} alt="" />
         <h3>{title}</h3>
       </div>
-      <div className="wizard-right" style={{ float: 'right', marginRight: '-17px' }}>
-        {right}
-      </div>
+      <div className="wizard-right">{right}</div>
     </div>
     <div className="usa-grid">
       <div className="usa-width-one-whole">


### PR DESCRIPTION
## Description

The header of the PPM closeout with the timeline and the title was not aligning correctly in mobile. This PR seeks to fix that.

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make server_run
make client_run
```

Use the developer tools to change the size of the screen.

## Code Review Verification Steps
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/166516744) for this change

## Screenshots
![Screen Shot 2019-06-25 at 9 48 29 AM](https://user-images.githubusercontent.com/6464062/60104170-ea7f1e80-972e-11e9-9d9d-cce2c4d3a203.png)
![Screen Shot 2019-06-25 at 9 48 38 AM](https://user-images.githubusercontent.com/6464062/60104171-ea7f1e80-972e-11e9-855f-c050c55dad01.png)
![Screen Shot 2019-06-25 at 9 48 33 AM (2)](https://user-images.githubusercontent.com/6464062/60104172-ea7f1e80-972e-11e9-85ca-7b0c5bb01b11.png)
![Screen Shot 2019-06-25 at 9 48 51 AM](https://user-images.githubusercontent.com/6464062/60104173-ea7f1e80-972e-11e9-9185-349fb136d303.png)
