### PR TITLE
Include 422 errors for endpoints that can return 422

### DIFF
--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -2667,6 +2667,8 @@ paths:
           description: user is not authorized
         404:
           description: ppm discount not found for provided postal codes and original move date
+        422:
+          description: cannot process request with given information
         500:
           description: internal server error
   /estimates/ppm_sit:
@@ -3077,6 +3079,8 @@ paths:
           description: user is not authorized
         404:
           description: ppm is not found or ppm discount not found for provided postal codes and original move date
+        422:
+          description: cannot process request with given information
         500:
           description: internal server error
     get:


### PR DESCRIPTION
## Description

While load testing in #1597 I got a huge number of 422 errors for API endpoints that have no 422 error listed in their swagger definition. Not listing the 422 made it difficult to know where to look for the actual error, which is returned here: https://github.com/transcom/mymove/blob/e328999f0ea8a440b7e9e8e4344b562ea99ce3a6/pkg/handlers/errors.go#L78-L88.  This wasn't caught previously because we use `handlers.ResponseForError()` instead of the actual response struct like `ppmop.ShowPPMEstimateUnprocessableEntity{}`. 

## Reviewer Notes

I'm beginning to think that using `handlers.ResponseForError()` is an anti-pattern because it allows us to diverge from the responses listed in the swagger files. Would love to know if others feel the same way.

## Setup

This ought to be a no-op since its merely documenting the behavior of the API.

## Code Review Verification Steps

* [x] Request review from a member of a different team.