### PR TITLE
Inverse filters for ecs-service-logs

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -412,6 +412,8 @@ metadata
 Codecov
 `testing.Short`
 uncomment
+ecs-service-logs
+Wildcards
 # Put all custom terms BEFORE this comment, lest 'pre-commit' and 'make spellcheck' yield different errors.
  - /usr/local
  - docs/data/tspp-data-creation.md

--- a/cmd/ecs-service-logs/README.md
+++ b/cmd/ecs-service-logs/README.md
@@ -1,0 +1,55 @@
+# ecs-service-logs
+
+## Description
+
+**ecs-service-logs** is used to filter JSON-formatted log lines in CloudWatch.
+
+## Usage
+
+Easily filter JSON formatted application logs from an ECS Service or Task.  This tool compiles a chain of filters into a filter pattern in the format used by CloudWatch Logs.  You can filter application logs by ECS Cluster (--cluster), ECS Service (--service), and environment (--environment).  When filtering logs for a stopped task, use "--status STOPPED".  Trailing positional arguments are added to the query.  Equality (X=Y) and inverse equality (X!=Y) are supported.  Wildcards are also supported, e.g, "url!=health*".
+
+[https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/FilterAndPatternSyntax.html](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/FilterAndPatternSyntax.html).
+
+```shell
+Usage:
+  ecs-service-logs show [flags] [msg=XYZ] [referer=XYZ]...
+
+Flags:
+      --aws-profile string               The aws-vault profile
+      --aws-region string                The AWS Region (default "us-west-2")
+      --aws-vault-keychain-name string   The aws-vault keychain name
+  -c, --cluster string                   The cluster name
+  -f, --ecs-task-def-family string       The ECS task definition family.
+  -r, --ecs-task-def-revision string     The ECS task definition revision.
+  -e, --environment string               The environment name
+  -b, --git-branch string                The git branch
+      --git-commit string                The git commit
+  -h, --help                             help for show
+  -l, --level string                     The log level: debug, info, warn, error, panic, fatal
+  -n, --limit int                        If 1 or above, the maximum number of log events to print to stdout. (default -1)
+  -p, --page-size int                    The page size or maximum number of log events to return during each API call.  The default is 10,000 log events. (default -1)
+  -s, --service string                   The service name
+      --status string                    The task status: RUNNING, STOPPED
+  -v, --verbose                          Print section lines
+
+```
+
+## Examples
+
+Search for a client IP Address.
+
+```shell
+ecs-service-logs show -c app-staging -s app -e staging --status RUNNING x-forwarded-for=*1.2.3.4
+```
+
+Search for requests in a given environment, but not health checks (url is defined but does not start with /health).
+
+```shell
+ecs-service-logs show -c app-staging -s app -e staging --status STOPPED url=* url!=/health*
+```
+
+Filter by url is defined and git commit.
+
+```shell
+ecs-service-logs show -c app-experimental -s app --status STOPPED -e experimental url=* git_commit=asdfnh98nwuefr9a8jf
+```


### PR DESCRIPTION
## Description

The `ecs-service-logs` tool now supports one or many inverse filters.  For example, the following line returns all log lines that are not hitting the health endpoint.

```
ecs-service-logs show -c app-experimental "url!=/health*"
```

## Reviewer Notes

- The Cloudwatch Filter syntax can be very confusing.  If you only give `!=` and do not include `NOT EXISTS` then the filter does not return lines where the given property was not defined.  That is why the expression syntax includes the or condition.
- The wildcard character `*` can be used at the beginning of end of value to convert `=` or `!=` to starts with or ends with.  The `*` in the middle of a value is treated as a literal and not a wildcard.

## Setup

None

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/tree/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/tree/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/tree/master/docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
  * [ ] Secure migrations have been tested using `scripts/run-prod-migrations`
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

- [AWS Filter Pattern Syntax](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/FilterAndPatternSyntax.html)

## Screenshots

N.A.