### PR TITLE
Don't show the login page until we know the user is not logged in.

### DIFF
--- a/src/shared/User/PrivateRoute.jsx
+++ b/src/shared/User/PrivateRoute.jsx
@@ -2,24 +2,25 @@ import React from 'react';
 import { Route } from 'react-router-dom';
 import { connect } from 'react-redux';
 
-import { selectCurrentUser } from 'shared/Data/users';
+import { selectGetCurrentUserIsSuccess, selectGetCurrentUserIsError } from 'shared/Data/users';
 import SignIn from './SignIn';
+import LoadingPlaceholder from 'shared/LoadingPlaceholder';
 
 // this was adapted from https://github.com/ReactTraining/react-router/blob/master/packages/react-router-redux/examples/AuthExample.js
 // note that it does not work if the route is not inside a Switch
 class PrivateRouteContainer extends React.Component {
   render() {
-    const { isLoggedIn, path, ...props } = this.props;
-    if (isLoggedIn) return <Route {...props} />;
-    else return <Route path={path} component={SignIn} />;
+    const { loginHasSucceeded, loginHasErrored, path, ...props } = this.props;
+    if (loginHasSucceeded) return <Route {...props} />;
+    else if (loginHasErrored) return <Route path={path} component={SignIn} />;
+    else return <LoadingPlaceholder />;
   }
 }
-const mapStateToProps = state => {
-  const user = selectCurrentUser(state);
-  return {
-    isLoggedIn: user.isLoggedIn,
-  };
-};
+const mapStateToProps = state => ({
+  loginHasErrored: selectGetCurrentUserIsError(state),
+  loginHasSucceeded: selectGetCurrentUserIsSuccess(state),
+});
+
 const PrivateRoute = connect(mapStateToProps)(PrivateRouteContainer);
 
 export default PrivateRoute;


### PR DESCRIPTION
## Description

When we made our cookies secure, we removed the ability to check for cookie presence/absence to determine whether or not a user is logged in. This means it takes a bit to determined logged in status, and thus the log in page would flash briefly before that API call was complete. This change waits until we know the log in check has failed before we show the log in screen.

## Reviewer Notes

Originally, we were going to try and implement a new loading indicator as part of the bug fix. Turns out that's a bit more involved than we thought (US Web Design doesn't have a ready-made one for us to use), so we're splitting that part of the story to a separate task to be completed later.

## Code Review Verification Steps

* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/166531436) for this change
