### PR TITLE
Only fire blur event when the calendar closes.

### DIFF
--- a/src/shared/JsonSchemaForm/SingleDatePicker.jsx
+++ b/src/shared/JsonSchemaForm/SingleDatePicker.jsx
@@ -40,12 +40,13 @@ export default function SingleDatePicker(props) {
   return (
     <DayPickerInput
       onDayChange={onChange}
+      onDayPickerHide={onBlur}
       placeholder=""
       parseDate={parseDate}
       formatDate={formatDate}
       value={formatted}
       dayPickerProps={getDayPickerProps(disabledDays)}
-      inputProps={{ disabled, name, onChange, onBlur }}
+      inputProps={{ disabled, name, onChange, autoComplete: 'off' }}
     />
   );
 }


### PR DESCRIPTION
## Description

This change prevents the `blur` event from being fired until the calendar widget is closed. This prevents the issue we were seeing where multiple clicks were required to select a date.

## Reviewer Notes

This PR also disables the autocomplete menu for date fields, as it overlaps and hides the calendar in many cases.

## Setup

Run the app and proceed in the service member flow until the first orders page. There are two date fields on this page.

## Code Review Verification Steps

* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/166764456) for this change