### PR TITLE
PPM Closeout: Make weight ticket fields optional when users are missing weight ticket

### DIFF
--- a/cypress/integration/mymove/ppm.js
+++ b/cypress/integration/mymove/ppm.js
@@ -204,6 +204,56 @@ describe('allows a SM to request a payment', function() {
     serviceMemberCanCancel();
   });
 
+  it('makes missing weight ticket fields optional when missing is checked', () => {
+    // Always required fields
+    cy.visit(`/moves/${moveID}/ppm-weight-ticket`);
+    cy.get('select[name="vehicle_options"]').select('CAR');
+    cy.get('input[name="vehicle_nickname"]').type('Nickname');
+
+    // only required when missing not checked
+    cy.get('input[name="missingEmptyWeightTicket"]+label').click();
+
+    // only required when missing is not checked
+    cy.get('input[name="full_weight"]').type('5000');
+    cy.upload_file('[data-cy=full-weight-upload] .filepond--root', 'top-secret.png');
+    cy.wait('@postUploadDocument');
+    cy.get('[data-filepond-item-state="processing-complete"]').should('have.length', 1);
+    cy
+      .get('input[name="weight_ticket_date"]')
+      .type('6/2/2018{enter}')
+      .blur();
+
+    cy.get('input[name="additional_weight_ticket"][value="Yes"]').should('be.checked');
+    cy.get('input[name="additional_weight_ticket"][value="No"]').should('not.be.checked');
+    cy
+      .get('button')
+      .contains('Save & Add Another')
+      .should('be.enabled');
+  });
+
+  it('makes full weight ticket fields optional when missing is checked', () => {
+    // Always required fields
+    cy.visit(`/moves/${moveID}/ppm-weight-ticket`);
+    cy.get('select[name="vehicle_options"]').select('CAR');
+    cy.get('input[name="vehicle_nickname"]').type('Nickname');
+
+    // only required when missing not checked
+    cy.get('input[name="empty_weight"]').type('1000');
+    cy.upload_file('[data-cy=empty-weight-upload] .filepond--root', 'top-secret.png');
+    cy.wait('@postUploadDocument');
+    cy.get('[data-filepond-item-state="processing-complete"]').should('have.length', 1);
+
+    // only required when missing is not checked
+    cy.get('input[name="missingFullWeightTicket"]+label').click();
+
+    cy.get('input[name="additional_weight_ticket"][value="Yes"]').should('be.checked');
+    cy.get('input[name="additional_weight_ticket"][value="No"]').should('not.be.checked');
+    cy
+      .get('button')
+      .contains('Save & Add Another')
+      .should('be.enabled');
+  });
+
   it('service member goes through entire request payment flow', () => {
     serviceMemberStartsPPMPaymentRequest();
     serviceMemberSubmitsWeightTicket('CAR', false, '1st');

--- a/pkg/handlers/internalapi/move_documents_test.go
+++ b/pkg/handlers/internalapi/move_documents_test.go
@@ -143,16 +143,18 @@ func (suite *HandlerSuite) TestIndexWeightTicketSetDocumentsHandler() {
 				MoveDocumentType:         models.MoveDocumentTypeWEIGHTTICKETSET,
 			},
 		})
+	emptyWeight := unit.Pound(1000)
+	fullWeight := unit.Pound(2500)
 	weightTicketSetDocument := models.WeightTicketSetDocument{
 		MoveDocumentID:           moveDoc.ID,
 		MoveDocument:             moveDoc,
-		EmptyWeight:              unit.Pound(1000),
+		EmptyWeight:              &emptyWeight,
 		EmptyWeightTicketMissing: true,
-		FullWeight:               unit.Pound(2500),
+		FullWeight:               &fullWeight,
 		FullWeightTicketMissing:  true,
 		VehicleNickname:          "My Car",
 		VehicleOptions:           "CAR",
-		WeightTicketDate:         testdatagen.NextValidMoveDate,
+		WeightTicketDate:         &testdatagen.NextValidMoveDate,
 		TrailerOwnershipMissing:  true,
 	}
 	verrs, err := suite.DB().ValidateAndCreate(&weightTicketSetDocument)
@@ -180,11 +182,11 @@ func (suite *HandlerSuite) TestIndexWeightTicketSetDocumentsHandler() {
 	for _, moveDoc := range indexPayload {
 		suite.Require().Equal(*moveDoc.ID, strfmt.UUID(weightTicketSetDocument.MoveDocument.ID.String()), "expected move ids to match")
 		suite.Require().Equal(*moveDoc.PersonallyProcuredMoveID, strfmt.UUID(ppm.ID.String()), "expected ppm ids to match")
-		suite.Require().Equal(*moveDoc.EmptyWeight, int64(weightTicketSetDocument.EmptyWeight), "expected empty weight to match")
+		suite.Require().Equal(*moveDoc.EmptyWeight, int64(*weightTicketSetDocument.EmptyWeight), "expected empty weight to match")
 		suite.Require().Equal(*moveDoc.EmptyWeightTicketMissing, weightTicketSetDocument.EmptyWeightTicketMissing, "expected empty weight ticket missing to match")
-		suite.Require().Equal(*moveDoc.FullWeight, int64(weightTicketSetDocument.FullWeight), "expected empty weight to match")
+		suite.Require().Equal(*moveDoc.FullWeight, int64(*weightTicketSetDocument.FullWeight), "expected empty weight to match")
 		suite.Require().Equal(*moveDoc.FullWeightTicketMissing, weightTicketSetDocument.FullWeightTicketMissing, "expected full weight ticket missing to match")
-		suite.Require().Equal(moveDoc.WeightTicketDate.String(), strfmt.Date(weightTicketSetDocument.WeightTicketDate).String(), "expected weight ticket date to match")
+		suite.Require().Equal(moveDoc.WeightTicketDate.String(), strfmt.Date(*weightTicketSetDocument.WeightTicketDate).String(), "expected weight ticket date to match")
 		suite.Require().Equal(*moveDoc.TrailerOwnershipMissing, weightTicketSetDocument.TrailerOwnershipMissing, "expected trailer ownership missing to match")
 		suite.Require().Equal(moveDoc.VehicleOptions, weightTicketSetDocument.VehicleOptions, "expected vehicle options to match")
 		suite.Require().Equal(moveDoc.VehicleNickname, weightTicketSetDocument.VehicleNickname, "expected vehicle nickname to match")

--- a/pkg/handlers/internalapi/move_documents_test.go
+++ b/pkg/handlers/internalapi/move_documents_test.go
@@ -129,7 +129,7 @@ func (suite *HandlerSuite) TestIndexMoveDocumentsHandler() {
 	suite.CheckResponseNotFound(badMoveResponse)
 }
 
-func (suite *HandlerSuite) TestIndexWeightTicketSetDocumentsHandler() {
+func (suite *HandlerSuite) TestIndexWeightTicketSetDocumentsHandlerNoMissingFields() {
 	ppm := testdatagen.MakeDefaultPPM(suite.DB())
 	move := ppm.Move
 	sm := move.Orders.ServiceMember
@@ -149,13 +149,13 @@ func (suite *HandlerSuite) TestIndexWeightTicketSetDocumentsHandler() {
 		MoveDocumentID:           moveDoc.ID,
 		MoveDocument:             moveDoc,
 		EmptyWeight:              &emptyWeight,
-		EmptyWeightTicketMissing: true,
+		EmptyWeightTicketMissing: false,
 		FullWeight:               &fullWeight,
-		FullWeightTicketMissing:  true,
+		FullWeightTicketMissing:  false,
 		VehicleNickname:          "My Car",
 		VehicleOptions:           "CAR",
 		WeightTicketDate:         &testdatagen.NextValidMoveDate,
-		TrailerOwnershipMissing:  true,
+		TrailerOwnershipMissing:  false,
 	}
 	verrs, err := suite.DB().ValidateAndCreate(&weightTicketSetDocument)
 	suite.Nil(err)
@@ -187,6 +187,68 @@ func (suite *HandlerSuite) TestIndexWeightTicketSetDocumentsHandler() {
 		suite.Require().Equal(*moveDoc.FullWeight, int64(*weightTicketSetDocument.FullWeight), "expected empty weight to match")
 		suite.Require().Equal(*moveDoc.FullWeightTicketMissing, weightTicketSetDocument.FullWeightTicketMissing, "expected full weight ticket missing to match")
 		suite.Require().Equal(moveDoc.WeightTicketDate.String(), strfmt.Date(*weightTicketSetDocument.WeightTicketDate).String(), "expected weight ticket date to match")
+		suite.Require().Equal(*moveDoc.TrailerOwnershipMissing, weightTicketSetDocument.TrailerOwnershipMissing, "expected trailer ownership missing to match")
+		suite.Require().Equal(moveDoc.VehicleOptions, weightTicketSetDocument.VehicleOptions, "expected vehicle options to match")
+		suite.Require().Equal(moveDoc.VehicleNickname, weightTicketSetDocument.VehicleNickname, "expected vehicle nickname to match")
+	}
+}
+
+func (suite *HandlerSuite) TestIndexWeightTicketSetDocumentsHandlerMissingFields() {
+	ppm := testdatagen.MakeDefaultPPM(suite.DB())
+	move := ppm.Move
+	sm := move.Orders.ServiceMember
+
+	moveDoc := testdatagen.MakeMoveDocument(suite.DB(),
+		testdatagen.Assertions{
+			MoveDocument: models.MoveDocument{
+				MoveID:                   move.ID,
+				Move:                     move,
+				PersonallyProcuredMoveID: &ppm.ID,
+				MoveDocumentType:         models.MoveDocumentTypeWEIGHTTICKETSET,
+			},
+		})
+	weightTicketSetDocument := models.WeightTicketSetDocument{
+		MoveDocumentID:           moveDoc.ID,
+		MoveDocument:             moveDoc,
+		EmptyWeight:              nil,
+		EmptyWeightTicketMissing: true,
+		FullWeight:               nil,
+		FullWeightTicketMissing:  true,
+		VehicleNickname:          "My Car",
+		VehicleOptions:           "CAR",
+		WeightTicketDate:         nil,
+		TrailerOwnershipMissing:  false,
+	}
+	verrs, err := suite.DB().ValidateAndCreate(&weightTicketSetDocument)
+	suite.Nil(err)
+	suite.False(verrs.HasAny())
+
+	request := httptest.NewRequest("POST", "/fake/path", nil)
+	request = suite.AuthenticateRequest(request, sm)
+
+	indexMoveDocParams := movedocop.IndexMoveDocumentsParams{
+		HTTPRequest: request,
+		MoveID:      strfmt.UUID(move.ID.String()),
+	}
+
+	context := handlers.NewHandlerContext(suite.DB(), suite.TestLogger())
+	fakeS3 := storageTest.NewFakeS3Storage(true)
+	context.SetFileStorer(fakeS3)
+	handler := IndexMoveDocumentsHandler{context}
+	response := handler.Handle(indexMoveDocParams)
+
+	// assert we got back the 201 response
+	indexResponse := response.(*movedocop.IndexMoveDocumentsOK)
+	indexPayload := indexResponse.Payload
+	suite.NotNil(indexPayload)
+	for _, moveDoc := range indexPayload {
+		suite.Require().Equal(*moveDoc.ID, strfmt.UUID(weightTicketSetDocument.MoveDocument.ID.String()), "expected move ids to match")
+		suite.Require().Equal(*moveDoc.PersonallyProcuredMoveID, strfmt.UUID(ppm.ID.String()), "expected ppm ids to match")
+		suite.Require().Nil(moveDoc.EmptyWeight)
+		suite.Require().Equal(*moveDoc.EmptyWeightTicketMissing, weightTicketSetDocument.EmptyWeightTicketMissing, "expected empty weight ticket missing to match")
+		suite.Require().Nil(moveDoc.FullWeight)
+		suite.Require().Equal(*moveDoc.FullWeightTicketMissing, weightTicketSetDocument.FullWeightTicketMissing, "expected full weight ticket missing to match")
+		suite.Require().Nil(moveDoc.WeightTicketDate)
 		suite.Require().Equal(*moveDoc.TrailerOwnershipMissing, weightTicketSetDocument.TrailerOwnershipMissing, "expected trailer ownership missing to match")
 		suite.Require().Equal(moveDoc.VehicleOptions, weightTicketSetDocument.VehicleOptions, "expected vehicle options to match")
 		suite.Require().Equal(moveDoc.VehicleNickname, weightTicketSetDocument.VehicleNickname, "expected vehicle nickname to match")

--- a/pkg/models/move.go
+++ b/pkg/models/move.go
@@ -420,7 +420,7 @@ func (m Move) CreateWeightTicketSetDocument(
 	db *pop.Connection,
 	uploads Uploads,
 	personallyProcuredMoveID *uuid.UUID,
-	weightTicketSetdocument *WeightTicketSetDocument,
+	weightTicketSetDocument *WeightTicketSetDocument,
 	moveType SelectedMoveType) (*WeightTicketSetDocument, *validate.Errors, error) {
 
 	var responseError error
@@ -436,20 +436,20 @@ func (m Move) CreateWeightTicketSetDocument(
 			personallyProcuredMoveID,
 			MoveDocumentTypeWEIGHTTICKETSET,
 			"weight_ticket_set",
-			&weightTicketSetdocument.VehicleNickname,
+			&weightTicketSetDocument.VehicleNickname,
 			moveType)
 		if responseVErrors.HasAny() || responseError != nil {
 			return transactionError
 		}
 
-		weightTicketSetdocument.MoveDocument = *newMoveDocument
-		weightTicketSetdocument.MoveDocumentID = newMoveDocument.ID
+		weightTicketSetDocument.MoveDocument = *newMoveDocument
+		weightTicketSetDocument.MoveDocumentID = newMoveDocument.ID
 
-		verrs, err := db.ValidateAndCreate(weightTicketSetdocument)
+		verrs, err := db.ValidateAndCreate(weightTicketSetDocument)
 		if err != nil || verrs.HasAny() {
 			responseVErrors.Append(verrs)
 			responseError = errors.Wrap(err, "Error creating moving expense document")
-			weightTicketSetdocument = nil
+			weightTicketSetDocument = nil
 			return transactionError
 		}
 
@@ -457,7 +457,7 @@ func (m Move) CreateWeightTicketSetDocument(
 
 	})
 
-	return weightTicketSetdocument, responseVErrors, responseError
+	return weightTicketSetDocument, responseVErrors, responseError
 }
 
 // CreatePPM creates a new PPM associated with this move

--- a/pkg/models/move.go
+++ b/pkg/models/move.go
@@ -420,10 +420,9 @@ func (m Move) CreateWeightTicketSetDocument(
 	db *pop.Connection,
 	uploads Uploads,
 	personallyProcuredMoveID *uuid.UUID,
-	weightTicketSetdocument WeightTicketSetDocument,
+	weightTicketSetdocument *WeightTicketSetDocument,
 	moveType SelectedMoveType) (*WeightTicketSetDocument, *validate.Errors, error) {
 
-	var newWeightTicketSetDocument *WeightTicketSetDocument
 	var responseError error
 	responseVErrors := validate.NewErrors()
 
@@ -443,23 +442,14 @@ func (m Move) CreateWeightTicketSetDocument(
 			return transactionError
 		}
 
-		newWeightTicketSetDocument = &WeightTicketSetDocument{
-			MoveDocumentID:           newMoveDocument.ID,
-			MoveDocument:             *newMoveDocument,
-			EmptyWeight:              unit.Pound(weightTicketSetdocument.EmptyWeight),
-			EmptyWeightTicketMissing: weightTicketSetdocument.EmptyWeightTicketMissing,
-			FullWeight:               unit.Pound(weightTicketSetdocument.FullWeight),
-			FullWeightTicketMissing:  weightTicketSetdocument.FullWeightTicketMissing,
-			VehicleNickname:          weightTicketSetdocument.VehicleNickname,
-			VehicleOptions:           weightTicketSetdocument.VehicleOptions,
-			WeightTicketDate:         weightTicketSetdocument.WeightTicketDate,
-			TrailerOwnershipMissing:  weightTicketSetdocument.TrailerOwnershipMissing,
-		}
-		verrs, err := db.ValidateAndCreate(newWeightTicketSetDocument)
+		weightTicketSetdocument.MoveDocument = *newMoveDocument
+		weightTicketSetdocument.MoveDocumentID = newMoveDocument.ID
+
+		verrs, err := db.ValidateAndCreate(weightTicketSetdocument)
 		if err != nil || verrs.HasAny() {
 			responseVErrors.Append(verrs)
 			responseError = errors.Wrap(err, "Error creating moving expense document")
-			newWeightTicketSetDocument = nil
+			weightTicketSetdocument = nil
 			return transactionError
 		}
 
@@ -467,7 +457,7 @@ func (m Move) CreateWeightTicketSetDocument(
 
 	})
 
-	return newWeightTicketSetDocument, responseVErrors, responseError
+	return weightTicketSetdocument, responseVErrors, responseError
 }
 
 // CreatePPM creates a new PPM associated with this move

--- a/pkg/models/weight_ticket_set_document.go
+++ b/pkg/models/weight_ticket_set_document.go
@@ -16,13 +16,13 @@ type WeightTicketSetDocument struct {
 	ID                       uuid.UUID    `json:"id" db:"id"`
 	MoveDocumentID           uuid.UUID    `json:"move_document_id" db:"move_document_id"`
 	MoveDocument             MoveDocument `belongs_to:"move_documents"`
-	EmptyWeight              unit.Pound   `json:"empty_weight,omitempty" db:"empty_weight"`
+	EmptyWeight              *unit.Pound  `json:"empty_weight,omitempty" db:"empty_weight"`
 	EmptyWeightTicketMissing bool         `json:"empty_weight_ticket_missing,omitempty" db:"empty_weight_ticket_missing"`
-	FullWeight               unit.Pound   `json:"full_weight,omitempty" db:"full_weight"`
+	FullWeight               *unit.Pound  `json:"full_weight,omitempty" db:"full_weight"`
 	FullWeightTicketMissing  bool         `json:"full_weight_ticket_missing,omitempty" db:"full_weight_ticket_missing"`
 	VehicleNickname          string       `json:"vehicle_nickname,omitempty" db:"vehicle_nickname"`
 	VehicleOptions           string       `json:"vehicle_options,omitempty" db:"vehicle_options"`
-	WeightTicketDate         time.Time    `json:"weight_ticket_date,omitempty" db:"weight_ticket_date"`
+	WeightTicketDate         *time.Time   `json:"weight_ticket_date,omitempty" db:"weight_ticket_date"`
 	TrailerOwnershipMissing  bool         `json:"trailer_ownership_missing,omitempty" db:"trailer_ownership_missing"`
 	CreatedAt                time.Time    `json:"created_at" db:"created_at"`
 	UpdatedAt                time.Time    `json:"updated_at" db:"updated_at"`
@@ -38,9 +38,6 @@ func (m *WeightTicketSetDocument) Validate(tx *pop.Connection) (*validate.Errors
 		&validators.UUIDIsPresent{Field: m.MoveDocumentID, Name: "MoveDocumentID"},
 		&validators.StringIsPresent{Field: string(m.VehicleNickname), Name: "VehicleNickname"},
 		&validators.StringIsPresent{Field: string(m.VehicleOptions), Name: "VehicleOptions"},
-		&validators.IntIsGreaterThan{Field: int(m.FullWeight), Name: "FullWeight", Compared: 0},
-		&validators.IntIsGreaterThan{Field: int(m.EmptyWeight), Name: "EmptyWeight", Compared: 0},
-		&validators.TimeIsPresent{Field: m.WeightTicketDate, Name: "WeightTicketDate"},
 	), nil
 }
 

--- a/pkg/models/weight_ticket_set_document_test.go
+++ b/pkg/models/weight_ticket_set_document_test.go
@@ -8,12 +8,9 @@ func (suite *ModelSuite) TestBasicWeightTicketSetDocumentInstantiation() {
 	expenseDoc := &models.WeightTicketSetDocument{}
 
 	expErrors := map[string][]string{
-		"move_document_id":   {"MoveDocumentID can not be blank."},
-		"vehicle_nickname":   {"VehicleNickname can not be blank."},
-		"vehicle_options":    {"VehicleOptions can not be blank."},
-		"empty_weight":       {"0 is not greater than 0."},
-		"full_weight":        {"0 is not greater than 0."},
-		"weight_ticket_date": {"WeightTicketDate can not be blank."},
+		"move_document_id": {"MoveDocumentID can not be blank."},
+		"vehicle_nickname": {"VehicleNickname can not be blank."},
+		"vehicle_options":  {"VehicleOptions can not be blank."},
 	}
 
 	suite.verifyValidationErrors(expenseDoc, expErrors)

--- a/pkg/testdatagen/make_weight_ticket_set_document.go
+++ b/pkg/testdatagen/make_weight_ticket_set_document.go
@@ -15,14 +15,16 @@ func MakeWeightTicketSetDocument(db *pop.Connection, assertions Assertions) mode
 		moveDoc = MakeMoveDocument(db, assertions)
 	}
 
+	emptyWeight := unit.Pound(1000)
+	fullWeight := unit.Pound(2500)
 	weightTicketSetDocument := models.WeightTicketSetDocument{
 		MoveDocumentID:   moveDoc.ID,
 		MoveDocument:     moveDoc,
-		EmptyWeight:      unit.Pound(1000),
-		FullWeight:       unit.Pound(2500),
+		EmptyWeight:      &emptyWeight,
+		FullWeight:       &fullWeight,
 		VehicleNickname:  "My Car",
 		VehicleOptions:   "CAR",
-		WeightTicketDate: NextValidMoveDate,
+		WeightTicketDate: &NextValidMoveDate,
 	}
 
 	// Overwrite values with those from assertions

--- a/src/scenes/Moves/Ppm/WeightTicket.jsx
+++ b/src/scenes/Moves/Ppm/WeightTicket.jsx
@@ -198,6 +198,8 @@ class WeightTicket extends Component {
     const nextBtnLabel =
       additionalWeightTickets === 'Yes' ? nextBtnLabels.SaveAndAddAnother : nextBtnLabels.SaveAndContinue;
     const weightTicketSetOrdinal = intToOrdinal(weightTicketSets.length + 1);
+    const fullWeightTicketFieldsRequired = missingFullWeightTicket ? null : true;
+    const emptyWeightTicketFieldsRequired = missingEmptyWeightTicket ? null : true;
     return (
       <Fragment>
         <WizardHeader
@@ -331,7 +333,7 @@ class WeightTicket extends Component {
                       fieldName="empty_weight"
                       swagger={schema}
                       hideLabel
-                      required
+                      required={emptyWeightTicketFieldsRequired}
                     />{' '}
                     lbs
                   </div>
@@ -377,7 +379,7 @@ class WeightTicket extends Component {
                       fieldName="full_weight"
                       swagger={schema}
                       hideLabel
-                      required
+                      required={fullWeightTicketFieldsRequired}
                     />{' '}
                     lbs
                   </div>
@@ -409,7 +411,11 @@ class WeightTicket extends Component {
                   </div>
                 </div>
 
-                <SwaggerField fieldName="weight_ticket_date" swagger={schema} required />
+                <SwaggerField
+                  fieldName="weight_ticket_date"
+                  swagger={schema}
+                  required={fullWeightTicketFieldsRequired}
+                />
                 <div className="dashed-divider" />
 
                 <div className="radio-group-wrapper">

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -1008,6 +1008,7 @@ definitions:
         type: string
         example: '2018-04-26'
         format: date
+        x-nullable: true
       trailer_ownership_missing:
         title: missing trailer ownership documentation
         type: boolean
@@ -1015,11 +1016,8 @@ definitions:
       - personally_procured_move_id
       - vehicle_options
       - vehicle_nickname
-      - full_weight
       - full_weight_ticket_missing
-      - empty_weight
       - empty_weight_ticket_missing
-      - weight_ticket_date
       - trailer_ownership_missing
   ServiceMemberPayload:
     type: object


### PR DESCRIPTION
## Description

Allow for weight ticket fields to be empty when service members select "I'm missing this weight ticket".

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make e2e_test
```

## Code Review Verification Steps
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/n/projects/2181745/stories/166820888) for this change

## Screenshots
![Screen Shot 2019-06-26 at 4 06 36 PM](https://user-images.githubusercontent.com/1036969/60218425-90648300-982c-11e9-85eb-afaae36287a8.png)
![Screen Shot 2019-06-26 at 4 06 57 PM](https://user-images.githubusercontent.com/1036969/60218434-9b1f1800-982c-11e9-98c9-1965c185ec8e.png)
