### PR TITLE
Add missing space around UI elements.

### DIFF
--- a/src/scenes/Review/Edit.jsx
+++ b/src/scenes/Review/Edit.jsx
@@ -17,7 +17,7 @@ export class Edit extends React.Component {
       <div className="usa-grid">
         <div className="usa-width-one-whole">
           <a className="back-to-home" onClick={this.goHome}>
-            &lt;BACK TO HOME
+            &lt; BACK TO HOME
           </a>
           <h1 className="edit-title">Edit Move</h1>
           <p>Changes to your orders or shipments could impact your move, including the estimated PPM incentive.</p>

--- a/src/scenes/Review/Review.css
+++ b/src/scenes/Review/Review.css
@@ -2,6 +2,10 @@
   margin-top: 1.5rem;
 }
 
+.service-member-summary {
+  margin-top: 2rem;
+}
+
 .review-title > h2 {
   margin-top: 1.5em;
 }
@@ -12,8 +16,7 @@
 }
 
 .review-section {
-  padding-left: 1.5rem;
-  padding-bottom: 1rem;
+  padding: 2rem 0 1rem 1.5rem;
 }
 
 .review-section .notice {

--- a/src/scenes/Review/ServiceMemberSummary.jsx
+++ b/src/scenes/Review/ServiceMemberSummary.jsx
@@ -64,7 +64,7 @@ function ServiceMemberSummary(props) {
   const yesNoMap = { true: 'Yes', false: 'No' };
 
   return (
-    <div>
+    <div class="service-member-summary">
       <h3>Profile and Orders</h3>
       <div className="usa-grid-full review-content">
         <div className="usa-width-one-half review-section">


### PR DESCRIPTION
## Description

I noticed during Linda's training demo that there were some pretty serious spacing issues on the review and edit screens at the end of the service member flow. This PR addresses some of these.

## Setup

Go through the SM flow until the Review screen OR go to "Edit move" for a submitted move.

## Code Review Verification Steps

* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.

## Screenshots

Before:

<img width="975" alt="Screen Shot 2019-06-27 at 3 49 24 PM" src="https://user-images.githubusercontent.com/3331/60300299-4d6de280-98f4-11e9-846d-cda5d848bf0d.png">

After:

<img width="974" alt="Screen Shot 2019-06-27 at 3 47 19 PM" src="https://user-images.githubusercontent.com/3331/60300302-4fd03c80-98f4-11e9-8a73-8be5ab47b514.png">

I found [this wireframe](http://www.slicedbreadclient.com/dds/dp3/sketches/edit-move/1%20edit%20move.png), but it's pretty old and potentially out of date.