### PR TITLE
166648697 office queue apis should have a sort

### DIFF
--- a/pkg/handlers/internalapi/move_queue_items.go
+++ b/pkg/handlers/internalapi/move_queue_items.go
@@ -2,6 +2,7 @@ package internalapi
 
 import (
 	"encoding/json"
+	"sort"
 	"strings"
 	"time"
 
@@ -83,6 +84,10 @@ func (h ShowQueueHandler) Handle(params queueop.ShowQueueParams) middleware.Resp
 		h.Logger().Error("Loading Queue", zap.String("State", lifecycleState), zap.Error(err))
 		return handlers.ResponseForError(h.Logger(), err)
 	}
+	// Sorting the slice by LastModifiedDate so that the API results follow suit.
+	sort.Slice(MoveQueueItems, func(i, j int) bool {
+		return MoveQueueItems[i].LastModifiedDate.Before(MoveQueueItems[j].LastModifiedDate)
+	})
 
 	MoveQueueItemPayloads := make([]*internalmessages.MoveQueueItem, len(MoveQueueItems))
 	for i, MoveQueueItem := range MoveQueueItems {

--- a/pkg/handlers/internalapi/move_queue_items.go
+++ b/pkg/handlers/internalapi/move_queue_items.go
@@ -69,6 +69,22 @@ type QueueSitData struct {
 	OutDate         JSONDate  `json:"out_date"`
 }
 
+// Implementation of a type and methods in order to use sort.Interface directly.
+// This allows us to call sortQueueItemsByLastModifiedDate in the ShowQueueHandler which will
+// sort the slice by the LastModfiedDate. Doing it this way allows us to avoid having reflect called
+// which should act to speed the sort up.
+type MoveQueueItems []models.MoveQueueItem
+
+func (mqi MoveQueueItems) Less(i, j int) bool {
+	return mqi[i].LastModifiedDate.Before(mqi[j].LastModifiedDate)
+}
+func (mqi MoveQueueItems) Len() int      { return len(mqi) }
+func (mqi MoveQueueItems) Swap(i, j int) { mqi[i], mqi[j] = mqi[j], mqi[i] }
+
+func sortQueueItemsByLastModifiedDate(moveQueueItems []models.MoveQueueItem) {
+	sort.Sort(MoveQueueItems(moveQueueItems))
+}
+
 // Handle retrieves a list of all MoveQueueItems in the system in the moves queue
 func (h ShowQueueHandler) Handle(params queueop.ShowQueueParams) middleware.Responder {
 	session := auth.SessionFromRequestContext(params.HTTPRequest)
@@ -84,10 +100,9 @@ func (h ShowQueueHandler) Handle(params queueop.ShowQueueParams) middleware.Resp
 		h.Logger().Error("Loading Queue", zap.String("State", lifecycleState), zap.Error(err))
 		return handlers.ResponseForError(h.Logger(), err)
 	}
+
 	// Sorting the slice by LastModifiedDate so that the API results follow suit.
-	sort.Slice(MoveQueueItems, func(i, j int) bool {
-		return MoveQueueItems[i].LastModifiedDate.Before(MoveQueueItems[j].LastModifiedDate)
-	})
+	sortQueueItemsByLastModifiedDate(MoveQueueItems)
 
 	MoveQueueItemPayloads := make([]*internalmessages.MoveQueueItem, len(MoveQueueItems))
 	for i, MoveQueueItem := range MoveQueueItems {


### PR DESCRIPTION
…he MoveQueueItems slice by last_modified_date before its then processed into the payload.

## Description

Implementation that uses `sort.Interface` to sort the slice of `MoveQueueItems` within the `ShowQueueHandler` before they are processed into the handler's payload. This is being done to enforce an ordering on `LastModifiedDate`.

## Reviewer Notes

This method for sorting is a bit more verbose than using the catch all `sort.Slice()` that's available. My thought was that we might wind up with enough moves in these queues at a given moment that it would be worth the trade off for performance. The reason why there is a performance gain is that doing the implementing ourselves gives the process access to the type of what we're doing this on. As a result, we don't have to make use of `reflect` like `sort.Slice()`. Does that choice make sense?

## Setup

You'll want test data in your dev_db.
```sh
make db_dev_e2e_populate
```

After that, load into the office app check out a queue and look at your HTTP traffic to make sure that the result you're getting in the response is sorted by the last modified date.

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/tree/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/tree/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/tree/master/docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
  * [ ] Secure migrations have been tested using `scripts/run-prod-migrations`
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/166648697) for this change
* [Sort package doc](https://golang.org/pkg/sort/)
