### PR TITLE
Fix e2e env

### DIFF
--- a/scripts/run-e2e-test
+++ b/scripts/run-e2e-test
@@ -9,7 +9,7 @@ trap "kill %1" SIGINT
 make db_test_e2e_backup
 
 CYPRESS_PORT=4000
-ENV=test DB_PORT="$DB_PORT_TEST" LOGIN_GOV_CALLBACK_PORT="$CYPRESS_PORT" NO_TLS_ENABLED=1 NO_TLS_PORT="$CYPRESS_PORT" \
+DB_ENV=test DB_PORT="$DB_PORT_TEST" LOGIN_GOV_CALLBACK_PORT="$CYPRESS_PORT" NO_TLS_ENABLED=1 NO_TLS_PORT="$CYPRESS_PORT" \
     ./bin/gin \
     --build cmd/milmove \
 		--bin /bin/webserver_e2e \

--- a/scripts/run-e2e-test-docker
+++ b/scripts/run-e2e-test-docker
@@ -43,6 +43,7 @@ docker build --tag e2e:latest .
 $DOCKER_RUN \
   -e CLIENT_AUTH_SECRET_KEY \
   -e CSRF_AUTH_KEY \
+  -e DB_ENV="test" \
   -e DB_HOST="database" \
   -e DB_NAME \
   -e DB_PASSWORD \
@@ -53,7 +54,6 @@ $DOCKER_RUN \
   -e DOD_CA_PACKAGE="/config/tls/Certificates_PKCS7_v5.4_DoD.der.p7b" \
   -e DPS_AUTH_COOKIE_SECRET_KEY \
   -e DPS_COOKIE_EXPIRES_IN_MINUTES \
-  -e ENV="test" \
   -e ENVIRONMENT="test" \
   -e HERE_MAPS_APP_CODE \
   -e HERE_MAPS_APP_ID \


### PR DESCRIPTION
## Description

Fix to `e2e` database environment variable.

## Reviewer Notes

```
make e2e_test
```

```
make e2e_test_docker
```

## Setup

None

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/tree/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/tree/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/tree/master/docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
  * [ ] Secure migrations have been tested using `scripts/run-prod-migrations`
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

None

## Screenshots

None