### PR TITLE
remove verbose flag from golangci-lint for cleaner output

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,8 +31,7 @@ repos:
     rev: v1.17.1
     hooks:
       - id: golangci-lint
-        entry: golangci-lint run --verbose
-        verbose: true
+        entry: golangci-lint run
 
   - repo: git://github.com/igorshubovych/markdownlint-cli
     rev: v0.17.0


### PR DESCRIPTION
## Description

We enabled `verbose` mode while trying to troubleshoot build problems in CircleCI. Now that we have resolved those issues the verboseness of `golangci-lint` linter can be safely removed.

## Reviewer Notes

`Golangci-lint` should run successfully and its output will be curtailed thanks to verboseness flag in both local and CI environments.

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/166769107) for this change

## Screenshots

![image](https://user-images.githubusercontent.com/5003421/60455160-bd85ac80-9c03-11e9-9145-2cab52161cb8.png)
