### PR TITLE
Update e2e test to not choose weekend

### DIFF
--- a/cypress/integration/tsp/shipShipment.js
+++ b/cypress/integration/tsp/shipShipment.js
@@ -262,7 +262,7 @@ function tspUserDeliversShipment() {
 
   cy
     .get('div')
-    .contains('14')
+    .contains('15')
     .click();
 
   cy


### PR DESCRIPTION
## Description

Cypress is choosing a weekend day (non-valid move date), which is causing the e2e test to fail. Update the test date to be a non-weekend date. This is just a temporary fix, but hopefully will resolve fails related to new month.

## Setup
```sh
make e2e_test
```