### PR TITLE
Alert if no receipt for storage exepsne

### DIFF
--- a/cypress/integration/mymove/ppm.js
+++ b/cypress/integration/mymove/ppm.js
@@ -502,6 +502,9 @@ function serviceMemberUploadsStorageExpenses(hasAnother = true, expenseNumber = 
 
   cy.get('input[name="missingReceipt"]').should('not.be.checked');
   cy.get('input[name="missingReceipt"]+label').click();
+  cy
+    .get('[data-cy=storage-warning]')
+    .contains('If you can, go online and print a new copy of your receipt, then upload it.');
   cy.get('input[name="missingReceipt"]').should('be.checked');
   cy.get('input[name="haveMoreExpenses"][value="Yes"]+label').click();
 

--- a/src/scenes/Moves/Ppm/ExpensesUpload.jsx
+++ b/src/scenes/Moves/Ppm/ExpensesUpload.jsx
@@ -254,13 +254,11 @@ class ExpensesUpload extends Component {
                 />
                 {isStorageExpense &&
                   missingReceipt && (
-                    <span data-cy="storage-warning">
-                      <Alert type="warning">
-                        If you can, go online and print a new copy of your receipt, then upload it. <br />Otherwise,
-                        write and sign a statement that explains why this receipt is missing, then upload it. Finance
-                        will approve or reject this expense based on your information.
-                      </Alert>
-                    </span>
+                    <Alert type="warning" data-cy="storage-warning">
+                      If you can, go online and print a new copy of your receipt, then upload it. <br />Otherwise, write
+                      and sign a statement that explains why this receipt is missing, then upload it. Finance will
+                      approve or reject this expense based on your information.
+                    </Alert>
                   )}
                 <div className="payment-method-radio-group-wrapper">
                   <p className="radio-group-header">How did you pay for this?</p>

--- a/src/scenes/Moves/Ppm/ExpensesUpload.jsx
+++ b/src/scenes/Moves/Ppm/ExpensesUpload.jsx
@@ -252,6 +252,16 @@ class ExpensesUpload extends Component {
                   onChange={this.handleCheckboxChange}
                   normalizeLabel
                 />
+                {isStorageExpense &&
+                  missingReceipt && (
+                    <span data-cy="full-warning">
+                      <Alert type="warning">
+                        If you can, go online and print a new copy of your receipt, then upload it. <br />Otherwise,
+                        write and sign a statement that explains why this receipt is missing, then upload it. Finance
+                        will approve or reject this expense based on your information.
+                      </Alert>
+                    </span>
+                  )}
                 <div className="payment-method-radio-group-wrapper">
                   <p className="radio-group-header">How did you pay for this?</p>
                   <RadioButton

--- a/src/scenes/Moves/Ppm/ExpensesUpload.jsx
+++ b/src/scenes/Moves/Ppm/ExpensesUpload.jsx
@@ -254,11 +254,13 @@ class ExpensesUpload extends Component {
                 />
                 {isStorageExpense &&
                   missingReceipt && (
-                    <Alert type="warning" data-cy="storage-warning">
-                      If you can, go online and print a new copy of your receipt, then upload it. <br />Otherwise, write
-                      and sign a statement that explains why this receipt is missing, then upload it. Finance will
-                      approve or reject this expense based on your information.
-                    </Alert>
+                    <span data-cy="storage-warning">
+                      <Alert type="warning">
+                        If you can, go online and print a new copy of your receipt, then upload it. <br />Otherwise,
+                        write and sign a statement that explains why this receipt is missing, then upload it. Finance
+                        will approve or reject this expense based on your information.
+                      </Alert>
+                    </span>
                   )}
                 <div className="payment-method-radio-group-wrapper">
                   <p className="radio-group-header">How did you pay for this?</p>

--- a/src/scenes/Moves/Ppm/ExpensesUpload.jsx
+++ b/src/scenes/Moves/Ppm/ExpensesUpload.jsx
@@ -254,7 +254,7 @@ class ExpensesUpload extends Component {
                 />
                 {isStorageExpense &&
                   missingReceipt && (
-                    <span data-cy="full-warning">
+                    <span data-cy="storage-warning">
                       <Alert type="warning">
                         If you can, go online and print a new copy of your receipt, then upload it. <br />Otherwise,
                         write and sign a statement that explains why this receipt is missing, then upload it. Finance


### PR DESCRIPTION
## Description

If the user checks the "Missing Receipt" checkbox for a Storage expense, an alert will show up with instructions.

## Setup

Login with `ppm@requestingpay.ment`.
```sh
make server_run
make client_run
```

## Code Review Verification Steps
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/166856017) for this change

## Screenshots
![Screen Shot 2019-07-02 at 8 51 09 AM](https://user-images.githubusercontent.com/6464062/60515185-19eed780-9ca9-11e9-9f16-f8beab6d1108.png)

