### PR TITLE
Admin users and organizations

### DIFF
--- a/migrations/20190702150158_create_admin_users.up.fizz
+++ b/migrations/20190702150158_create_admin_users.up.fizz
@@ -1,0 +1,21 @@
+sql("CREATE TYPE admin_role AS ENUM ('SYSTEM_ADMIN', 'PROGRAM_ADMIN');")
+
+create_table("admin_users") {
+	t.Column("id", "uuid", {primary: true})
+	t.Column("user_id", "uuid", {})
+	t.Column("first_name", "string", {null: true})
+	t.Column("last_name", "string", {null: true})
+	t.Column("organization_id", "uuid", {null: true})
+	t.Column("role", "admin_role", {})
+	t.Timestamps()
+}
+
+add_index("admin_users", "user_id", {})
+add_index("admin_users", "organization_id", {})
+
+sql("
+	INSERT INTO admin_users(id, user_id, role, created_at, updated_at)
+	SELECT uuid_generate_v4(), id, 'SYSTEM_ADMIN', now(), now()
+	FROM users
+	WHERE is_superuser = true
+")

--- a/migrations/20190702150158_create_admin_users.up.fizz
+++ b/migrations/20190702150158_create_admin_users.up.fizz
@@ -2,11 +2,13 @@ sql("CREATE TYPE admin_role AS ENUM ('SYSTEM_ADMIN', 'PROGRAM_ADMIN');")
 
 create_table("admin_users") {
 	t.Column("id", "uuid", {primary: true})
-	t.Column("user_id", "uuid", {})
+	t.Column("user_id", "uuid", {null: true})
 	t.Column("first_name", "string", {null: true})
 	t.Column("last_name", "string", {null: true})
 	t.Column("organization_id", "uuid", {null: true})
 	t.Column("role", "admin_role", {})
+	t.Column("disabled", "bool", {default: false})
+	t.Column("email", "string", {})
 	t.Timestamps()
 }
 

--- a/migrations/20190702195904_create_organizations.up.fizz
+++ b/migrations/20190702195904_create_organizations.up.fizz
@@ -1,0 +1,7 @@
+create_table("organizations") {
+	t.Column("id", "uuid", {primary: true})
+	t.Column("name", "string", {})
+	t.Column("poc_email", "string", {})
+	t.Column("poc_phone", "string", {})
+	t.Timestamps()
+}

--- a/pkg/models/admin_user.go
+++ b/pkg/models/admin_user.go
@@ -10,15 +10,26 @@ import (
 	"github.com/gofrs/uuid"
 )
 
+type AdminRole string
+
+func (ar *AdminRole) ValidRoles() []string {
+	return []string{
+		"SYSTEM_ADMIN",
+		"PROGRAM_ADMIN",
+	}
+}
+
 type AdminUser struct {
 	ID             uuid.UUID `json:"id" db:"id"`
 	CreatedAt      time.Time `json:"created_at" db:"created_at"`
 	UpdatedAt      time.Time `json:"updated_at" db:"updated_at"`
 	UserID         uuid.UUID `json:"user_id" db:"user_id"`
-	Role           string    `json:"role" db:"role"`
+	Role           AdminRole `json:"role" db:"role"`
+	Email          string    `json:"email" db:"email"`
 	FirstName      string    `json:"first_name" db:"first_name"`
 	LastName       string    `json:"last_name" db:"last_name"`
 	OrganizationID uuid.UUID `json:"organization_id" db:"organization_id"`
+	Disabled       bool      `json:"disabled" db:"disabled"`
 }
 
 // String is not required by pop and may be deleted
@@ -39,12 +50,11 @@ func (a AdminUsers) String() string {
 // Validate gets run every time you call a "pop.Validate*" (pop.ValidateAndSave, pop.ValidateAndCreate, pop.ValidateAndUpdate) method.
 // This method is not required and may be deleted.
 func (a *AdminUser) Validate(tx *pop.Connection) (*validate.Errors, error) {
-	validAdminRoles := []string{"SYSTEM_ADMIN", "PROGRAM_ADMIN"}
 	return validate.Validate(
 		&validators.StringIsPresent{Field: a.FirstName, Name: "FirstName"},
 		&validators.StringIsPresent{Field: a.LastName, Name: "LastName"},
-		&validators.UUIDIsPresent{Field: a.UserID, Name: "UserID"},
-		&validators.StringInclusion{Field: a.Role, Name: "Role", List: validAdminRoles},
+		&validators.StringIsPresent{Field: a.Email, Name: "Email"},
+		&validators.StringInclusion{Field: string(a.Role), Name: "Role", List: new(AdminRole).ValidRoles()},
 	), nil
 }
 

--- a/pkg/models/admin_user.go
+++ b/pkg/models/admin_user.go
@@ -1,0 +1,57 @@
+package models
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/gobuffalo/pop"
+	"github.com/gobuffalo/validate"
+	"github.com/gobuffalo/validate/validators"
+	"github.com/gofrs/uuid"
+)
+
+type AdminUser struct {
+	ID             uuid.UUID `json:"id" db:"id"`
+	CreatedAt      time.Time `json:"created_at" db:"created_at"`
+	UpdatedAt      time.Time `json:"updated_at" db:"updated_at"`
+	UserID         uuid.UUID `json:"user_id" db:"user_id"`
+	FirstName      string    `json:"first_name" db:"first_name"`
+	LastName       string    `json:"last_name" db:"last_name"`
+	OrganizationID uuid.UUID `json:"organization_id" db:"organization_id"`
+}
+
+// String is not required by pop and may be deleted
+func (a AdminUser) String() string {
+	ja, _ := json.Marshal(a)
+	return string(ja)
+}
+
+// AdminUsers is not required by pop and may be deleted
+type AdminUsers []AdminUser
+
+// String is not required by pop and may be deleted
+func (a AdminUsers) String() string {
+	ja, _ := json.Marshal(a)
+	return string(ja)
+}
+
+// Validate gets run every time you call a "pop.Validate*" (pop.ValidateAndSave, pop.ValidateAndCreate, pop.ValidateAndUpdate) method.
+// This method is not required and may be deleted.
+func (a *AdminUser) Validate(tx *pop.Connection) (*validate.Errors, error) {
+	return validate.Validate(
+		&validators.StringIsPresent{Field: a.FirstName, Name: "FirstName"},
+		&validators.StringIsPresent{Field: a.LastName, Name: "LastName"},
+	), nil
+}
+
+// ValidateCreate gets run every time you call "pop.ValidateAndCreate" method.
+// This method is not required and may be deleted.
+func (a *AdminUser) ValidateCreate(tx *pop.Connection) (*validate.Errors, error) {
+	return validate.NewErrors(), nil
+}
+
+// ValidateUpdate gets run every time you call "pop.ValidateAndUpdate" method.
+// This method is not required and may be deleted.
+func (a *AdminUser) ValidateUpdate(tx *pop.Connection) (*validate.Errors, error) {
+	return validate.NewErrors(), nil
+}

--- a/pkg/models/admin_user.go
+++ b/pkg/models/admin_user.go
@@ -15,6 +15,7 @@ type AdminUser struct {
 	CreatedAt      time.Time `json:"created_at" db:"created_at"`
 	UpdatedAt      time.Time `json:"updated_at" db:"updated_at"`
 	UserID         uuid.UUID `json:"user_id" db:"user_id"`
+	Role           string    `json:"role" db:"role"`
 	FirstName      string    `json:"first_name" db:"first_name"`
 	LastName       string    `json:"last_name" db:"last_name"`
 	OrganizationID uuid.UUID `json:"organization_id" db:"organization_id"`
@@ -38,9 +39,12 @@ func (a AdminUsers) String() string {
 // Validate gets run every time you call a "pop.Validate*" (pop.ValidateAndSave, pop.ValidateAndCreate, pop.ValidateAndUpdate) method.
 // This method is not required and may be deleted.
 func (a *AdminUser) Validate(tx *pop.Connection) (*validate.Errors, error) {
+	validAdminRoles := []string{"SYSTEM_ADMIN", "PROGRAM_ADMIN"}
 	return validate.Validate(
 		&validators.StringIsPresent{Field: a.FirstName, Name: "FirstName"},
 		&validators.StringIsPresent{Field: a.LastName, Name: "LastName"},
+		&validators.UUIDIsPresent{Field: a.UserID, Name: "UserID"},
+		&validators.StringInclusion{Field: a.Role, Name: "Role", List: validAdminRoles},
 	), nil
 }
 

--- a/pkg/models/admin_user_test.go
+++ b/pkg/models/admin_user_test.go
@@ -17,6 +17,7 @@ func (suite *ModelSuite) TestAdminUserCreation() {
 		LastName:  "Spaceman",
 		UserID:    user.ID,
 		Role:      "SYSTEM_ADMIN",
+		Email:     "leo@gmail.com",
 	}
 
 	if verrs, err := suite.DB().ValidateAndCreate(&newAdminUser); err != nil || verrs.HasAny() {
@@ -34,7 +35,7 @@ func (suite *ModelSuite) TestAdminUserCreationWithoutValues() {
 	expErrors := map[string][]string{
 		"first_name": {"FirstName can not be blank."},
 		"last_name":  {"LastName can not be blank."},
-		"user_id":    {"UserID can not be blank."},
+		"email":      {"Email can not be blank."},
 		"role":       {"Role is not in the list [SYSTEM_ADMIN, PROGRAM_ADMIN]."},
 	}
 

--- a/pkg/models/admin_user_test.go
+++ b/pkg/models/admin_user_test.go
@@ -1,0 +1,7 @@
+package models
+
+import "testing"
+
+func Test_AdminUser(t *testing.T) {
+	t.Fatal("This test needs to be implemented!")
+}

--- a/pkg/models/admin_user_test.go
+++ b/pkg/models/admin_user_test.go
@@ -1,7 +1,42 @@
-package models
+package models_test
 
-import "testing"
+import (
+	"github.com/gofrs/uuid"
 
-func Test_AdminUser(t *testing.T) {
-	t.Fatal("This test needs to be implemented!")
+	. "github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/testdatagen"
+)
+
+func (suite *ModelSuite) TestAdminUserCreation() {
+	t := suite.T()
+
+	user := testdatagen.MakeDefaultUser(suite.DB())
+
+	newAdminUser := AdminUser{
+		FirstName: "Leo",
+		LastName:  "Spaceman",
+		UserID:    user.ID,
+		Role:      "SYSTEM_ADMIN",
+	}
+
+	if verrs, err := suite.DB().ValidateAndCreate(&newAdminUser); err != nil || verrs.HasAny() {
+		t.Fatal("Didn't create admin user in db.")
+	}
+
+	if newAdminUser.ID == uuid.Nil {
+		t.Error("Didn't get an id back for admin user.")
+	}
+}
+
+func (suite *ModelSuite) TestAdminUserCreationWithoutValues() {
+	newAdminUser := &AdminUser{}
+
+	expErrors := map[string][]string{
+		"first_name": {"FirstName can not be blank."},
+		"last_name":  {"LastName can not be blank."},
+		"user_id":    {"UserID can not be blank."},
+		"role":       {"Role is not in the list [SYSTEM_ADMIN, PROGRAM_ADMIN]."},
+	}
+
+	suite.verifyValidationErrors(newAdminUser, expErrors)
 }

--- a/pkg/models/organization.go
+++ b/pkg/models/organization.go
@@ -1,0 +1,57 @@
+package models
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/gobuffalo/pop"
+	"github.com/gobuffalo/validate"
+	"github.com/gobuffalo/validate/validators"
+	"github.com/gofrs/uuid"
+)
+
+type Organization struct {
+	ID        uuid.UUID `json:"id" db:"id"`
+	CreatedAt time.Time `json:"created_at" db:"created_at"`
+	UpdatedAt time.Time `json:"updated_at" db:"updated_at"`
+	Name      string    `json:"name" db:"name"`
+	PocEmail  string    `json:"poc_email" db:"poc_email"`
+	PocPhone  string    `json:"poc_phone" db:"poc_phone"`
+}
+
+// String is not required by pop and may be deleted
+func (o Organization) String() string {
+	jo, _ := json.Marshal(o)
+	return string(jo)
+}
+
+// Organizations is not required by pop and may be deleted
+type Organizations []Organization
+
+// String is not required by pop and may be deleted
+func (o Organizations) String() string {
+	jo, _ := json.Marshal(o)
+	return string(jo)
+}
+
+// Validate gets run every time you call a "pop.Validate*" (pop.ValidateAndSave, pop.ValidateAndCreate, pop.ValidateAndUpdate) method.
+// This method is not required and may be deleted.
+func (o *Organization) Validate(tx *pop.Connection) (*validate.Errors, error) {
+	return validate.Validate(
+		&validators.StringIsPresent{Field: o.Name, Name: "Name"},
+		&validators.StringIsPresent{Field: o.PocEmail, Name: "PocEmail"},
+		&validators.StringIsPresent{Field: o.PocPhone, Name: "PocPhone"},
+	), nil
+}
+
+// ValidateCreate gets run every time you call "pop.ValidateAndCreate" method.
+// This method is not required and may be deleted.
+func (o *Organization) ValidateCreate(tx *pop.Connection) (*validate.Errors, error) {
+	return validate.NewErrors(), nil
+}
+
+// ValidateUpdate gets run every time you call "pop.ValidateAndUpdate" method.
+// This method is not required and may be deleted.
+func (o *Organization) ValidateUpdate(tx *pop.Connection) (*validate.Errors, error) {
+	return validate.NewErrors(), nil
+}

--- a/pkg/models/organization_test.go
+++ b/pkg/models/organization_test.go
@@ -1,0 +1,37 @@
+package models_test
+
+import (
+	"github.com/gofrs/uuid"
+
+	. "github.com/transcom/mymove/pkg/models"
+)
+
+func (suite *ModelSuite) TestOrganizationCreation() {
+	t := suite.T()
+
+	newOrganization := Organization{
+		Name:     "Truss",
+		PocEmail: "test@truss.works",
+		PocPhone: "9144825484",
+	}
+
+	if verrs, err := suite.DB().ValidateAndCreate(&newOrganization); err != nil || verrs.HasAny() {
+		t.Fatal("Didn't create admin user in db.")
+	}
+
+	if newOrganization.ID == uuid.Nil {
+		t.Error("Didn't get an id back for admin user.")
+	}
+}
+
+func (suite *ModelSuite) TestOrganizationCreationWithoutValues() {
+	newOrganization := &Organization{}
+
+	expErrors := map[string][]string{
+		"name":      {"Name can not be blank."},
+		"poc_email": {"PocEmail can not be blank."},
+		"poc_phone": {"PocPhone can not be blank."},
+	}
+
+	suite.verifyValidationErrors(newOrganization, expErrors)
+}


### PR DESCRIPTION
## Description

We are adding an `admin_users` table in order to mirror the way we have `office_users` and `tsp_users` set up. This will allow us to use login.gov more easily in staging, experimental, and dev. It will also allow us to separate admin authorization from the main `users` table.

## Setup

1. Update one of the existing users in your dev database to have `is_superuser` toggled to `true`. 
2. `make db_dev_migrate`
3.  You should now have an admin user record that matches the user record that you made into a superuser.
4. Ensure you also have an organizations table.

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/167018034) for this change
