### PR TITLE
Sb 166421075 tsp logout on 401 queue

### DIFF
--- a/src/scenes/TransportationServiceProvider/QueueTable.jsx
+++ b/src/scenes/TransportationServiceProvider/QueueTable.jsx
@@ -2,11 +2,13 @@ import React, { Component } from 'react';
 import { withRouter } from 'react-router';
 import ReactTable from 'react-table';
 import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
 import { capitalize } from 'lodash';
 import 'react-table/react-table.css';
 import { formatDate, formatDateTimeWithTZ, formatTimeAgo } from 'shared/formatters';
 import FontAwesomeIcon from '@fortawesome/react-fontawesome';
 import faSyncAlt from '@fortawesome/fontawesome-free-solid/faSyncAlt';
+import { setUserIsLoggedIn } from 'shared/Data/users';
 
 class QueueTable extends Component {
   constructor() {
@@ -76,6 +78,10 @@ class QueueTable extends Component {
         refreshing: false,
         lastLoadedAt: new Date(),
       });
+      // redirect to home page if unauthorized
+      if (e.status === 401) {
+        this.props.setUserIsLoggedIn(false);
+      }
     }
   }
 
@@ -201,4 +207,8 @@ const mapStateToProps = (state, ownProps) => ({
   retrieveShipments: ownProps.retrieveShipments,
 });
 
-export default withRouter(connect(mapStateToProps)(QueueTable));
+function mapDispatchToProps(dispatch) {
+  return bindActionCreators({ setUserIsLoggedIn }, dispatch);
+}
+
+export default withRouter(connect(mapStateToProps, mapDispatchToProps)(QueueTable));

--- a/src/scenes/TransportationServiceProvider/QueueTable.jsx
+++ b/src/scenes/TransportationServiceProvider/QueueTable.jsx
@@ -39,6 +39,10 @@ class QueueTable extends Component {
     }
   }
 
+  componentWillUnmount() {
+    clearInterval(this.state.interval);
+  }
+
   openShipment(rowInfo) {
     this.props.history.push(`/shipments/${rowInfo.original.id}`, {
       referrerPathname: this.props.history.location.pathname,

--- a/src/scenes/TransportationServiceProvider/QueueTable.jsx
+++ b/src/scenes/TransportationServiceProvider/QueueTable.jsx
@@ -4,7 +4,6 @@ import ReactTable from 'react-table';
 import { connect } from 'react-redux';
 import { capitalize } from 'lodash';
 import 'react-table/react-table.css';
-import { RetrieveShipmentsForTSP } from './api.js';
 import { formatDate, formatDateTimeWithTZ, formatTimeAgo } from 'shared/formatters';
 import FontAwesomeIcon from '@fortawesome/react-fontawesome';
 import faSyncAlt from '@fortawesome/fontawesome-free-solid/faSyncAlt';
@@ -56,7 +55,7 @@ class QueueTable extends Component {
 
     // Catch any errors here and render an empty queue
     try {
-      const body = await RetrieveShipmentsForTSP(this.props.queueType);
+      const body = await this.props.retrieveShipments(this.props.queueType);
 
       // Only update the queue list if the request that is returning
       // is for the same queue as the most recent request.
@@ -198,6 +197,8 @@ class QueueTable extends Component {
   }
 }
 
-const mapStateToProps = state => ({});
+const mapStateToProps = (state, ownProps) => ({
+  retrieveShipments: ownProps.retrieveShipments,
+});
 
 export default withRouter(connect(mapStateToProps)(QueueTable));

--- a/src/scenes/TransportationServiceProvider/QueueTable.test.js
+++ b/src/scenes/TransportationServiceProvider/QueueTable.test.js
@@ -37,8 +37,6 @@ describe('on 401 unauthorized error', () => {
   const mockStore = configureMockStore(middlewares);
 
   it('force user log out', done => {
-    const fetchDataSpy = jest.spyOn(QueueTable.WrappedComponent.prototype, 'fetchData');
-
     let error = new Error('Unauthorized');
     error.status = 401;
 
@@ -50,8 +48,6 @@ describe('on 401 unauthorized error', () => {
       .simulate('click');
 
     setTimeout(() => {
-      expect(fetchDataSpy).toHaveBeenCalled();
-
       const userLoggedOutAction = { type: setIsLoggedInType, isLoggedIn: false };
       expect(store.getActions()).toContainEqual(userLoggedOutAction);
 
@@ -72,6 +68,9 @@ function retrieveShipmentsStub(params, throwError) {
       resolve([
         {
           id: 'c56a4180-65aa-42ec-a945-5fd21dec0538',
+          status: '',
+          service_member: {},
+          traffic_distribution_list: {},
           ...params,
         },
       ]);
@@ -79,11 +78,11 @@ function retrieveShipmentsStub(params, throwError) {
   };
 }
 
-function mountComponents(getMoves, queueType = 'new', mockStore = store) {
+function mountComponents(getShipments, queueType = 'new', mockStore = store) {
   return mount(
     <Provider store={mockStore}>
       <MockRouter push={push}>
-        <QueueTable queueType={queueType} retrieveMoves={getMoves} />
+        <QueueTable queueType={queueType} retrieveShipments={getShipments} />
       </MockRouter>
     </Provider>,
   );

--- a/src/scenes/TransportationServiceProvider/index.jsx
+++ b/src/scenes/TransportationServiceProvider/index.jsx
@@ -18,6 +18,7 @@ import { isProduction } from 'shared/constants';
 import DocumentViewer from './DocumentViewerContainer';
 import NewDocument from './NewDocumentContainer';
 import ShipmentInfo from './ShipmentInfo';
+import { RetrieveShipmentsForTSP } from './api.js';
 
 import './tsp.scss';
 
@@ -29,7 +30,7 @@ class Queues extends Component {
           <QueueList />
         </div>
         <div className="queue-list-column">
-          <QueueTable queueType={this.props.match.params.queueType} />
+          <QueueTable queueType={this.props.match.params.queueType} retrieveShipments={RetrieveShipmentsForTSP} />
         </div>
       </div>
     );

--- a/src/shared/Data/users.js
+++ b/src/shared/Data/users.js
@@ -65,7 +65,7 @@ const userInfoDefault = () => ({
 const currentUserReducerDefault = () => ({
   hasSucceeded: false,
   hasErrored: false,
-  isLoading: false,
+  isLoading: true,
   userInfo: userInfoDefault(),
 });
 

--- a/src/shared/User/PrivateRoute.jsx
+++ b/src/shared/User/PrivateRoute.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Route } from 'react-router-dom';
 import { connect } from 'react-redux';
 
-import { selectGetCurrentUserIsSuccess, selectGetCurrentUserIsError } from 'shared/Data/users';
+import { selectCurrentUser, selectGetCurrentUserIsLoading } from 'shared/Data/users';
 import SignIn from './SignIn';
 import LoadingPlaceholder from 'shared/LoadingPlaceholder';
 
@@ -10,15 +10,15 @@ import LoadingPlaceholder from 'shared/LoadingPlaceholder';
 // note that it does not work if the route is not inside a Switch
 class PrivateRouteContainer extends React.Component {
   render() {
-    const { loginHasSucceeded, loginHasErrored, path, ...props } = this.props;
-    if (loginHasSucceeded) return <Route {...props} />;
-    else if (loginHasErrored) return <Route path={path} component={SignIn} />;
-    else return <LoadingPlaceholder />;
+    const { loginIsLoading, userIsLoggedIn, path, ...props } = this.props;
+    if (userIsLoggedIn) return <Route {...props} />;
+    else if (loginIsLoading) return <LoadingPlaceholder />;
+    else return <Route path={path} component={SignIn} />;
   }
 }
 const mapStateToProps = state => ({
-  loginHasErrored: selectGetCurrentUserIsError(state),
-  loginHasSucceeded: selectGetCurrentUserIsSuccess(state),
+  loginIsLoading: selectGetCurrentUserIsLoading(state),
+  userIsLoggedIn: selectCurrentUser(state).isLoggedIn,
 });
 
 const PrivateRoute = connect(mapStateToProps)(PrivateRouteContainer);


### PR DESCRIPTION
## Description

If a TSP user's session has expired, show the log in page instead of an empty queue.

## Reviewer Notes

The logout user action conflicted with some other code that I wrote to show the loading indicator rather than flash the login screen, so I had to update that logic to be better.

## Code Review Verification Steps

* [x] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] User facing changes have been reviewed by design.
* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/166421075) for this change