### PR TITLE
Add USMC office users

### DIFF
--- a/local_migrations/20190703141326_add-usmc-office-users.sql
+++ b/local_migrations/20190703141326_add-usmc-office-users.sql
@@ -1,0 +1,4 @@
+-- Local test migration.
+-- This will be run on development environments. It should mirror what you
+-- intend to apply on production, but do not include any sensitive data.
+

--- a/migrations/20190703141326_add-usmc-office-users.up.fizz
+++ b/migrations/20190703141326_add-usmc-office-users.up.fizz
@@ -1,0 +1,1 @@
+exec("./apply-secure-migration.sh 20190703141326_add-usmc-office-users.sql")


### PR DESCRIPTION
## Description

Migration to add new office users. This adds the new office user in prod but not staging and experimental. All the users were added to `DMO MCAS Beaufort`, so you should see 13 new office users for that transportation office.

## Setup
`make run_prod_migrations` to check that the users are in prod db
`make run_staging_migrations` to check that the users are NOT in the staging db.
`make run_experimental_migrations` to check that the users are NOT in the experimental db.

## Code Review Verification Steps

* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/tree/master/docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
  * [ ] Secure migrations have been tested using `scripts/run-prod-migrations`
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/n/projects/2226219/stories/167055619) for this change