### PR TITLE
Renaming references from prod migrations to deployed migrations

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -89,11 +89,11 @@ export DB_PASSWORD=mysecretpassword
 export DB_USER=postgres
 export DB_HOST=localhost
 export DB_PORT=5432
-export DB_PORT_PROD_MIGRATIONS=5434
+export DB_PORT_DEPLOYED_MIGRATIONS=5434
 export DB_PORT_TEST=5433
 export DB_NAME=dev_db
 export DB_NAME_DEV=dev_db
-export DB_NAME_PROD_MIGRATIONS=prod_migrations
+export DB_NAME_DEPLOYED_MIGRATIONS=deployed_migrations
 export DB_NAME_TEST=test_db
 export DB_SSL_MODE=disable
 

--- a/Makefile
+++ b/Makefile
@@ -535,7 +535,7 @@ db_deployed_migrations_migrate_standalone: bin/milmove ## Migrate Deployed Migra
 db_deployed_migrations_migrate: server_deps db_deployed_migrations_migrate_standalone ## Migrate Deployed Migrations DB
 
 #
-# ----- END DB_PROD_MIGRATIONS TARGETS -----
+# ----- END DB_DEPLOYED_MIGRATIONS TARGETS -----
 #
 
 #

--- a/docs/data/tspp-data-creation.md
+++ b/docs/data/tspp-data-creation.md
@@ -208,7 +208,7 @@ We'll now create a new migration with that data (replace your migration filename
 ./bin/soda generate sql add_new_tdls
 rm migrations/20190410152949_add_new_tdls.down.sql
 echo -e "INSERT INTO traffic_distribution_lists (id, source_rate_area, destination_region, code_of_service, created_at, updated_at) \nVALUES\n$(
-./scripts/psql-prod-migrations "\copy (SELECT id, source_rate_area, destination_region, code_of_service FROM temp_tdls WHERE import = true) TO stdout WITH (FORMAT CSV, FORCE_QUOTE *, QUOTE '''');" \
+./scripts/psql-deployed-migrations "\copy (SELECT id, source_rate_area, destination_region, code_of_service FROM temp_tdls WHERE import = true) TO stdout WITH (FORMAT CSV, FORCE_QUOTE *, QUOTE '''');" \
   | awk '{print "  ("$0", now(), now()),"}' \
   | sed '$ s/.$//');" \
   > migrations/20190410152949_add_new_tdls.up.sql
@@ -271,7 +271,7 @@ Generate the migration (replacing your migration filename):
 rm migrations/20190409010258_add_new_scacs.down.sql
 
 echo -e "INSERT INTO transportation_service_providers (id, standard_carrier_alpha_code, created_at, updated_at, name) \nVALUES\n$(
-./scripts/psql-prod-migrations "\copy (SELECT id, standard_carrier_alpha_code from temp_tsps) TO stdout WITH (FORMAT CSV, FORCE_QUOTE *, QUOTE '''');" \
+./scripts/psql-deployed-migrations "\copy (SELECT id, standard_carrier_alpha_code from temp_tsps) TO stdout WITH (FORMAT CSV, FORCE_QUOTE *, QUOTE '''');" \
   | awk '{print "  ("$0", now(), now(), '\''),"}' \
   | sed '$ s/.$//');" \
   > migrations/20190409010258_add_new_scacs.up.sql

--- a/docs/how-to/migrate-the-database.md
+++ b/docs/how-to/migrate-the-database.md
@@ -13,7 +13,7 @@ the same code.  To migrate you should use a command based on your DB:
 
 * `make db_dev_migrate`
 * `make db_test_migrate`
-* `make db_prod_migrations_migrate`
+* `make db_deployed_migrations_migrate`
 
 The reason to use a `make` target is because it will put you into the `scripts/` directory from which it is required
 you run the migration so that `scripts/apply-secure-migrations.sh` is called with the correct paths for the different
@@ -59,7 +59,7 @@ We are piggy-backing on the migration system for importing static datasets. This
 3. Copy the production migration into the local test migration.
 4. Scrub the test migration of sensitive data, but use it to test the gist of the production migration operation.
 5. Test the local migration by running `make db_dev_migrate`. You should see it run your local migration.
-6. Test the secure migration by running `make run_prod_migrations` to setup a local `prod_migrations` database. Then run `psql-prod-migrations< tmp/$NAME_OF_YOUR_SECURE_MIGRATION`. Verify that the updated values are in the database.
+6. Test the secure migration by running `make run_prod_migrations` to setup a local `deployed_migrations` database. Then run `psql-deployed-migrations< tmp/$NAME_OF_YOUR_SECURE_MIGRATION`. Verify that the updated values are in the database.
 7. If you are wanting to run a secure migration for a specific non-production environment, then **skip to the next section**.
 8. Upload the migration to S3 with: `upload-secure-migration <production_migration_file>`. **NOTE:** For a single environment see the next section.
 9. Run `make run_prod_migrations` to verify that the upload worked and that the migration can be applied successfully. If not, you can make changes and run `upload-secure-migration` again and it will overwrite the old files.
@@ -88,7 +88,7 @@ When secure migrations are run, `soda` will shell out to our script, `apply-secu
 * Look at `$SECURE_MIGRATION_SOURCE` to determine if the migrations should be found locally (`local`, for dev & testing,) or on S3 (`s3`).
 * If the file is to be found on S3, it is downloaded from `${AWS_S3_BUCKET_NAME}/secure-migrations/${FILENAME}`.
 * If it is to be found locally, the script looks for it in `$SECURE_MIGRATION_DIR`.
-* Regardless of where the migration comes from, it is then applied to the database by essentially doing: `psql-prod-migrations < ${FILENAME}`.
+* Regardless of where the migration comes from, it is then applied to the database by essentially doing: `psql-deployed-migrations < ${FILENAME}`.
 
 There is an example of a secure migration [in the repo](https://github.com/transcom/mymove/blob/master/migrations/20180424010930_test_secure_migrations.up.fizz).
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -118,7 +118,7 @@ These scripts are primarily used for working with the database
 | `db-cleanup` | Remove the database backup. |
 | `db-restore` |  Restore the contents of the development database from an earlier backup. |
 | `psql-dev` | Convenience script to drop into development postgres DB |
-| `psql-prod-migrations` | Convenience script to drop into production migrations postgres DB |
+| `psql-deployed-migrations` | Convenience script to drop into deployed migrations postgres DB |
 | `psql-test` | Convenience script to drop into testing postgres DB |
 | `psql-wrapper` | A wrapper around `psql` that sets correct values |
 | `wait-for-db` |  waits for an available database connection, or until a timeout is reached |

--- a/scripts/psql-deployed-migrations
+++ b/scripts/psql-deployed-migrations
@@ -1,6 +1,6 @@
 #! /usr/bin/env bash
 
-export DB_NAME=prod_migrations
-export DB_PORT=$DB_PORT_PROD_MIGRATIONS
+export DB_NAME=deployed_migrations
+export DB_PORT=$DB_PORT_DEPLOYED_MIGRATIONS
 # shellcheck disable=SC1091,SC1090
 . "$(dirname "$0")"/psql-wrapper


### PR DESCRIPTION
## Description

I was doing some migrations work and noticed that the `psql-prod-migrations` script wasn't working as expected.  It looks like we still have some scripts/references to "prod" migrations even though the new "deployed" migrations terminology landed recently in #2312.  This PR fixes those references and renames the `psql-prod-migrations` script to `psql-deployed-migrations`.

## Reviewer Notes

I tried to find all the remaining references that needed to be changed, but you may want to double-check that I didn't miss one (or changed one that shouldn't actually change).

## Setup

1. `make run_prod_migrations` to create a `deployed_migrations` database
2. `psql-deployed-migrations` to start `psql` for that database

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
