### PR TITLE
Pin swagger client to version 3.8.25 [delivers #167112999]

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "regenerator-runtime": "^0.13.2",
     "reselect": "^4.0.0",
     "selenium-webdriver": "^3.6.0",
-    "swagger-client": "^3.4.6",
+    "swagger-client": "=3.8.25",
     "swagger-ui-dist": "^3.9.2",
     "uswds": "^1.4.4"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -12368,7 +12368,7 @@ svgo@^1.0.0, svgo@^1.2.2:
     unquote "~1.1.1"
     util.promisify "~1.0.0"
 
-swagger-client@^3.4.6:
+swagger-client@=3.8.25:
   version "3.8.25"
   resolved "https://registry.yarnpkg.com/swagger-client/-/swagger-client-3.8.25.tgz#89cb58b000c103ee5e23accc13a9db1e686035e6"
   integrity sha512-7ZtSSPnempsUbCAOJCQ6PyGaNkRoCm6ghOpJlI62ChfMGbLWtlOm8dLlgYiTkP9OAWuNHoRoTzOW14+QmZY1HA==


### PR DESCRIPTION
## Description

Pinning swagger client to version 3.8.25 for now so we can investigate why later versions break the application.

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/167112999) for this change