### PR TITLE
Update SwaggerRequest to be compatible with swagger-client 3.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "regenerator-runtime": "^0.13.2",
     "reselect": "^4.0.0",
     "selenium-webdriver": "^3.6.0",
-    "swagger-client": "=3.8.25",
+    "swagger-client": "^3.9.0",
     "swagger-ui-dist": "^3.9.2",
     "uswds": "^1.4.4"
   },

--- a/src/shared/Swagger/request.js
+++ b/src/shared/Swagger/request.js
@@ -33,7 +33,7 @@ const toCamelCase = str => str[0].toLowerCase() + str.slice(1);
 function successfulReturnType(routeDefinition, status) {
   // eslint-disable-next-line security/detect-object-injection
   const response = routeDefinition.responses[status];
-  const [, , schemaKey] = response.schema['$$ref'].split('/');
+  const schemaKey = response.schema['$$ref'].split('/').pop();
   if (!response) {
     console.error(`No response found for operation ${routeDefinition.operationId} with status ${status}`);
     return;

--- a/yarn.lock
+++ b/yarn.lock
@@ -12407,10 +12407,10 @@ svgo@^1.0.0, svgo@^1.2.2:
     unquote "~1.1.1"
     util.promisify "~1.0.0"
 
-swagger-client@=3.8.25:
-  version "3.8.25"
-  resolved "https://registry.yarnpkg.com/swagger-client/-/swagger-client-3.8.25.tgz#89cb58b000c103ee5e23accc13a9db1e686035e6"
-  integrity sha512-7ZtSSPnempsUbCAOJCQ6PyGaNkRoCm6ghOpJlI62ChfMGbLWtlOm8dLlgYiTkP9OAWuNHoRoTzOW14+QmZY1HA==
+swagger-client@=3.9.0:
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/swagger-client/-/swagger-client-3.9.0.tgz#b94ea65baa0194f4cb3fad2f8bd552c531d57e03"
+  integrity sha512-uyCq2xoaAtmE0oIQ0fCfnsDoy/v97ANnAZywtyk4yumBP74xXp4NFlpZaqZJHN9K9dbPzgs3MH98VocZeM0ExQ==
   dependencies:
     "@kyleshockey/js-yaml" "^1.0.1"
     "@kyleshockey/object-assign-deep" "^0.4.0"
@@ -12426,6 +12426,7 @@ swagger-client@=3.8.25:
     lodash "^4.16.2"
     qs "^6.3.0"
     querystring-browser "^1.0.4"
+    traverse "^0.6.6"
     url "^0.11.0"
     utf8-bytes "0.0.1"
     utfstring "^2.0.0"
@@ -12738,6 +12739,11 @@ tr46@^1.0.1:
   integrity sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=
   dependencies:
     punycode "^2.1.0"
+
+traverse@^0.6.6:
+  version "0.6.6"
+  resolved "https://registry.yarnpkg.com/traverse/-/traverse-0.6.6.tgz#cbdf560fd7b9af632502fed40f918c157ea97137"
+  integrity sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=
 
 trim-newlines@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
## Description

In the most recent version of swagger-client the `$$ref` is now an absolute path (see https://github.com/swagger-api/swagger-js/pull/1435). So previously the path would look like `#/definitions/AvailableMoveDates`, however in the new version of swagger-client this has become `/internal/swagger.yaml#/definitions/AvailableMoveDates`. This was causing the `routeDefinition` to not be found in `successfulReturnType`. This PR updates `routeDefinition` to use last part of the path, rather than assuming there would only be three elements.

## Reviewer Notes

Did a search for `$$ref` and only saw it used in one other place, which was also popping the last item in the path. But let me know if there is anywhere else that needs a 2nd look.

## Setup

```sh
make e2e_test
```

## Code Review Verification Steps
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/n/projects/2226219/stories/167075564) for this change