### PR TITLE
Calculate and Display PPM Storage Costs

### DIFF
--- a/pkg/handlers/internalapi/move_documents.go
+++ b/pkg/handlers/internalapi/move_documents.go
@@ -207,14 +207,13 @@ func (h UpdateMoveDocumentHandler) Handle(params movedocop.UpdateMoveDocumentPar
 			return handlers.ResponseForError(logger, err)
 		}
 
-		if moveDoc.PersonallyProcuredMoveID == nil {
-			return handlers.ResponseForError(logger, errors.New("No PPM loaded for Approved Move Doc"))
-		}
-
-		ppm := &moveDoc.PersonallyProcuredMove
-
 		// If this is a shipment summary and it has been approved, we process the ppm.
 		if newStatus == models.MoveDocumentStatusOK && moveDoc.MoveDocumentType == models.MoveDocumentTypeSHIPMENTSUMMARY {
+			if moveDoc.PersonallyProcuredMoveID == nil {
+				return handlers.ResponseForError(logger, errors.New("No PPM loaded for Approved Move Doc"))
+			}
+
+			ppm := &moveDoc.PersonallyProcuredMove
 			// If the status has already been completed
 			// (because the document has been toggled between OK and HAS_ISSUE and back)
 			// then don't complete it again.
@@ -228,10 +227,15 @@ func (h UpdateMoveDocumentHandler) Handle(params movedocop.UpdateMoveDocumentPar
 
 		// If this is a storage expense, we need to make changes to the total sit amount for the ppm.
 		if moveDoc.MoveDocumentType == models.MoveDocumentTypeEXPENSE && moveDoc.MovingExpenseDocument.MovingExpenseType == models.MovingExpenseTypeSTORAGE {
+			if moveDoc.PersonallyProcuredMoveID == nil {
+				return handlers.ResponseForError(logger, errors.New("No PPM loaded for Approved Move Doc"))
+			}
+
+			ppm := &moveDoc.PersonallyProcuredMove
 			storageRequestedAmt := unit.Cents(payload.RequestedAmountCents)
 			var newCost unit.Cents
 
-			// add to SIT total amont if OK
+			// add to SIT total amount if OK
 			if newStatus == models.MoveDocumentStatusOK {
 				if ppm.TotalSITCost == nil {
 					newCost = storageRequestedAmt

--- a/pkg/handlers/internalapi/move_documents.go
+++ b/pkg/handlers/internalapi/move_documents.go
@@ -199,20 +199,22 @@ func (h UpdateMoveDocumentHandler) Handle(params movedocop.UpdateMoveDocumentPar
 	moveDoc.MoveDocumentType = newType
 
 	newStatus := models.MoveDocumentStatus(payload.Status)
+	oldStatus := moveDoc.Status
 
-	// If this is a shipment summary and it has been approved, we process the ppm.
-	if newStatus != moveDoc.Status {
+	if newStatus != oldStatus {
 		err = moveDoc.AttemptTransition(newStatus)
 		if err != nil {
 			return handlers.ResponseForError(logger, err)
 		}
 
-		if newStatus == models.MoveDocumentStatusOK && moveDoc.MoveDocumentType == models.MoveDocumentTypeSHIPMENTSUMMARY {
-			if moveDoc.PersonallyProcuredMoveID == nil {
-				return handlers.ResponseForError(logger, errors.New("No PPM loaded for Approved Move Doc"))
-			}
+		if moveDoc.PersonallyProcuredMoveID == nil {
+			return handlers.ResponseForError(logger, errors.New("No PPM loaded for Approved Move Doc"))
+		}
 
-			ppm := &moveDoc.PersonallyProcuredMove
+		ppm := &moveDoc.PersonallyProcuredMove
+
+		// If this is a shipment summary and it has been approved, we process the ppm.
+		if newStatus == models.MoveDocumentStatusOK && moveDoc.MoveDocumentType == models.MoveDocumentTypeSHIPMENTSUMMARY {
 			// If the status has already been completed
 			// (because the document has been toggled between OK and HAS_ISSUE and back)
 			// then don't complete it again.
@@ -222,6 +224,28 @@ func (h UpdateMoveDocumentHandler) Handle(params movedocop.UpdateMoveDocumentPar
 					return handlers.ResponseForError(logger, completeErr)
 				}
 			}
+		}
+
+		// If this is a storage expense, we need to make changes to the total sit amount for the ppm.
+		if moveDoc.MoveDocumentType == models.MoveDocumentTypeEXPENSE && moveDoc.MovingExpenseDocument.MovingExpenseType == models.MovingExpenseTypeSTORAGE {
+			storageRequestedAmt := unit.Cents(payload.RequestedAmountCents)
+			var newCost unit.Cents
+
+			// add to SIT total amont if OK
+			if newStatus == models.MoveDocumentStatusOK {
+				if ppm.TotalSITCost == nil {
+					newCost = storageRequestedAmt
+				} else {
+					newCost = *ppm.TotalSITCost + storageRequestedAmt
+				}
+			}
+
+			// subtract from SIT total amount if changed from OK
+			if oldStatus == models.MoveDocumentStatusOK && newStatus != models.MoveDocumentStatusOK {
+				newCost = *ppm.TotalSITCost - storageRequestedAmt
+			}
+
+			ppm.TotalSITCost = &newCost
 		}
 	}
 

--- a/src/scenes/Office/Ppm/StoragePanel.js
+++ b/src/scenes/Office/Ppm/StoragePanel.js
@@ -13,7 +13,7 @@ import { convertDollarsToCents } from '../../../shared/utils';
 const StorageDisplay = props => {
   let cost = props.ppm && props.ppm.total_sit_cost ? formatCents(props.ppm.total_sit_cost) : 0;
   let days = props.ppm && props.ppm.days_in_storage ? props.ppm.days_in_storage : 0;
-
+  console.log(cost);
   const fieldProps = {
     schema: {
       properties: {

--- a/src/scenes/Office/Ppm/StoragePanel.js
+++ b/src/scenes/Office/Ppm/StoragePanel.js
@@ -13,7 +13,7 @@ import { convertDollarsToCents } from '../../../shared/utils';
 const StorageDisplay = props => {
   let cost = props.ppm && props.ppm.total_sit_cost ? formatCents(props.ppm.total_sit_cost) : 0;
   let days = props.ppm && props.ppm.days_in_storage ? props.ppm.days_in_storage : 0;
-  console.log(cost);
+
   const fieldProps = {
     schema: {
       properties: {


### PR DESCRIPTION
## Description

When a storage expense has been OK'd, the requested amount is added to the PPM's total SIT cost. IF a storage expense has been previously OK'd but has been changed to another status then the requested amount is subtracted from the PPM total SIT cost.

## Setup

As `ppm@requestingpay.ment`, go through the PPM closeout process and make several storage expense requests.

Then, as an office user, find the move for the previous account, head to the document viewer, and OK the storage expenses. The sum of those expenses should be reflected in the Storage panel of the PPM.

```sh
make server_run
make client_run
make office_client_run.
```

## Code Review Verification Steps
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/166935994) for this change