### PR TITLE
Disable download all attachments button when there are no attachments…

### DIFF
--- a/cypress/integration/office/officeUserPPM.js
+++ b/cypress/integration/office/officeUserPPM.js
@@ -67,6 +67,18 @@ describe('office user finds the move', function() {
     });
   });
 
+  it('download all attachments button is disabled when there are no attachments to download', function() {
+    officeUserGoesToPPMPanel('FDXTIU');
+    cy
+      .get('a')
+      .contains('Create payment paperwork')
+      .click();
+    cy
+      .get('button')
+      .contains('Download All Attachments (PDF)')
+      .should('be.disabled');
+  });
+
   it('office user edits ppm net weight', function() {
     officeUserEditsNetWeight();
   });

--- a/src/scenes/Office/Ppm/PaymentsPanel.jsx
+++ b/src/scenes/Office/Ppm/PaymentsPanel.jsx
@@ -10,6 +10,7 @@ import {
   downloadPPMAttachments,
   downloadPPMAttachmentsLabel,
 } from 'shared/Entities/modules/ppms';
+import { selectAllDocumentsForMove } from 'shared/Entities/modules/moveDocuments';
 import { getLastError } from 'shared/Swagger/selectors';
 
 import { no_op } from 'shared/utils';
@@ -74,6 +75,10 @@ class PaymentsTable extends Component {
 
   togglePaperwork = () => {
     this.setState({ showPaperwork: !this.state.showPaperwork });
+  };
+
+  disableDownloadAll = () => {
+    return this.props.moveDocuments.length < 1;
   };
 
   startDownload = docTypes => {
@@ -230,7 +235,7 @@ class PaymentsTable extends Component {
                     <p>Download bundle of PPM receipts and attach it to the completed Shipment Summary Worksheet.</p>
                   </div>
                   <button
-                    disabled={this.state.disableDownload}
+                    disabled={this.state.disableDownload || this.disableDownloadAll()}
                     onClick={() => this.startDownload(['OTHER', 'WEIGHT_TICKET', 'STORAGE_EXPENSE', 'EXPENSE'])}
                   >
                     Download All Attachments (PDF)
@@ -283,12 +288,14 @@ const mapStateToProps = (state, ownProps) => {
   const advance = selectReimbursement(state, ppm.advance);
   const signedCertifications = selectPaymentRequestCertificationForMove(state, moveId);
   const disableSSW = sswIsDisabled(ppm, signedCertifications, shipment);
+  const moveDocuments = selectAllDocumentsForMove(state, moveId);
   return {
     ppm,
     disableSSW,
     moveId,
     advance,
     attachmentsError: getLastError(state, downloadPPMAttachmentsLabel),
+    moveDocuments,
   };
 };
 


### PR DESCRIPTION
… to download

## Description

On the `PPM` tab, the `Download All Attachments` should be disabled when there are no attachments to download.

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

- From the office app select a PPM record. 
- Click into the `PPM` tab.
- Click `Create payment paperwork`
- You will see that the `Download All Attachments` button is disabled
- If you upload a document and return, the `Download All Attachments` button will be enabled

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/166688235) for this change

## Screenshots

![Screen Shot 2019-07-09 at 11 22 22 AM](https://user-images.githubusercontent.com/3522044/60913259-dad9fc80-a23b-11e9-8267-0f2d799fc965.png)
