### PR TITLE
upgrade postgres from 10.6 to 10.9 which brings security patches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ executors:
     working_directory: ~/transcom/mymove
     docker:
       - image: trussworks/circleci-docker-primary:9b7bfbf6bfae544566ade0c896f8aacbd16281e5
-      - image: postgres:10.6
+      - image: postgres:10.9
         environment:
           - POSTGRES_PASSWORD: mysecretpassword
           - POSTGRES_DB: test_db

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ DB_DOCKER_CONTAINER_TEST = milmove-db-test
 # The version of the postgres container should match production as closely
 # as possible.
 # https://github.com/transcom/ppp-infra/blob/7ba2e1086ab1b2a0d4f917b407890817327ffb3d/modules/aws-app-environment/database/variables.tf#L48
-DB_DOCKER_CONTAINER_IMAGE = postgres:10.6
+DB_DOCKER_CONTAINER_IMAGE = postgres:10.9
 TASKS_DOCKER_CONTAINER = tasks
 export PGPASSWORD=mysecretpassword
 


### PR DESCRIPTION
## Description

Upgrade postgres to 10.9 in local and circleci containers so we have the latest security patches on our db instance
## Reviewer Notes

Local db and circle ci containers should be running postgres 10.9

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/167169650) for this change

## Screenshots

Screenshot of local postgres on 10.9: 
![image](https://user-images.githubusercontent.com/5003421/60914024-a4f64180-a256-11e9-82e7-ec7d3e11c63f.png)
