### PR TITLE
Add USMC office users

### DIFF
--- a/local_migrations/20190709204712_add-office-users.sql
+++ b/local_migrations/20190709204712_add-office-users.sql
@@ -1,0 +1,3 @@
+-- Local test migration.
+-- This will be run on development environments. It should mirror what you
+-- intend to apply on production, but do not include any sensitive data.

--- a/migrations/20190709204712_add-office-users.up.fizz
+++ b/migrations/20190709204712_add-office-users.up.fizz
@@ -1,0 +1,1 @@
+exec("./apply-secure-migration.sh 20190709204712_add-office-users.sql")


### PR DESCRIPTION
## Description

Migration to add new office users. This adds the new office users in prod but not staging and experimental. You should see 10 new office users in total.

## Setup
`make run_prod_migrations` to check that the users are in prod db
`make run_staging_migrations` to check that the users are NOT in the staging db.
`make run_experimental_migrations` to check that the users are NOT in the experimental db.

## Code Review Verification Steps

* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/tree/master/docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
  * [ ] Secure migrations have been tested using `scripts/run-prod-migrations`
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/n/projects/2226219/stories/167181218) for this change