### PR TITLE
Els duty station lookup #166968918

### DIFF
--- a/cypress/support/constants.js
+++ b/cypress/support/constants.js
@@ -2,9 +2,10 @@ export const longPageLoadTimeout = 10000;
 export const fileUploadTimeout = 10000;
 
 // Base URLs
-export const milmoveBaseURL = 'http://milmovelocal:4000';
-export const officeBaseURL = 'http://officelocal:4000';
-export const tspBaseURL = 'http://tsplocal:4000';
+const cypressClientPort = 4000; //change this to 3000 to run cypress against dev instance
+export const milmoveBaseURL = `http://milmovelocal:${cypressClientPort}`;
+export const officeBaseURL = `http://officelocal:${cypressClientPort}`;
+export const tspBaseURL = `http://tsplocal:${cypressClientPort}`;
 
 // App Types
 export const milmoveAppName = 'milmove';

--- a/migrations/20190701205931_add_duty_station_index.up.fizz
+++ b/migrations/20190701205931_add_duty_station_index.up.fizz
@@ -1,0 +1,1 @@
+add_index("duty_stations", "name", {});

--- a/migrations_manifest.txt
+++ b/migrations_manifest.txt
@@ -313,6 +313,7 @@
 20190624204138_add-missing-users.up.fizz
 20190625175052_add_office_users.up.fizz
 20190627162208_add-one-new-truss-user.up.fizz
+20190701205931_add_duty_station_index.up.fizz
 20190702150158_create_admin_users.up.fizz
 20190702170631_add_new_office_user.up.fizz
 20190702195904_create_organizations.up.fizz

--- a/pkg/models/duty_station.go
+++ b/pkg/models/duty_station.go
@@ -98,19 +98,7 @@ func FetchDutyStationByName(tx *pop.Connection, name string) (DutyStation, error
 // FindDutyStations returns all duty stations matching a search query and military affiliation
 func FindDutyStations(tx *pop.Connection, search string) (DutyStations, error) {
 	var stations DutyStations
-
-	// ILIKE does case-insensitive pattern matching, "%" matches any string
-	// We build a query by inserting '%' between each letter in the search string.
-	// This allows matching substrings as well as abbreviations.
-	// It would probably be worth ordering the results by similarity to the search string, one day.
-	searchQuery := []rune("%")
-
-	for _, runeChar := range search {
-		searchQuery = append(searchQuery, runeChar)
-		searchQuery = append(searchQuery, '%')
-	}
-	queryString := string(searchQuery)
-
+	queryString := "%" + search + "%"
 	query := tx.Q().Eager().Where("name ILIKE $1", queryString)
 
 	if err := query.All(&stations); err != nil {

--- a/src/scenes/ServiceMembers/DutyStationSearchBox.jsx
+++ b/src/scenes/ServiceMembers/DutyStationSearchBox.jsx
@@ -12,7 +12,7 @@ import { SearchDutyStations } from './api.js';
 import './DutyStation.css';
 
 const inputDebounceTime = 200;
-const minSearchLength = 1;
+const minSearchLength = 2;
 const getOptionName = option => (option ? option.name : '');
 
 export class DutyStationSearchBox extends Component {

--- a/src/scenes/ServiceMembers/DutyStationSearchBox.jsx
+++ b/src/scenes/ServiceMembers/DutyStationSearchBox.jsx
@@ -12,7 +12,7 @@ import { SearchDutyStations } from './api.js';
 import './DutyStation.css';
 
 const inputDebounceTime = 200;
-const minSearchLength = 3;
+const minSearchLength = 1;
 const getOptionName = option => (option ? option.name : '');
 
 export class DutyStationSearchBox extends Component {
@@ -77,10 +77,8 @@ export class DutyStationSearchBox extends Component {
     return inputValue;
   }
   noOptionsMessage(props) {
-    if (this.state.inputValue === '') {
-      return <span>Start typing</span>;
-    } else if (this.state.inputValue.length < minSearchLength) {
-      return <span>Keep typing</span>;
+    if (this.state.inputValue.length < minSearchLength) {
+      return <span />;
     }
     return <span>No Options</span>;
   }

--- a/src/scenes/ServiceMembers/DutyStationSearchBox.jsx
+++ b/src/scenes/ServiceMembers/DutyStationSearchBox.jsx
@@ -12,7 +12,7 @@ import { SearchDutyStations } from './api.js';
 import './DutyStation.css';
 
 const inputDebounceTime = 200;
-const minSearchLength = 1;
+const minSearchLength = 3;
 const getOptionName = option => (option ? option.name : '');
 
 export class DutyStationSearchBox extends Component {
@@ -29,6 +29,7 @@ export class DutyStationSearchBox extends Component {
     this.localOnChange = this.localOnChange.bind(this);
     this.onInputChange = this.onInputChange.bind(this);
     this.renderOption = this.renderOption.bind(this);
+    this.noOptionsMessage = this.noOptionsMessage.bind(this);
   }
 
   loadOptions(inputValue, callback) {
@@ -75,7 +76,14 @@ export class DutyStationSearchBox extends Component {
     this.setState({ inputValue });
     return inputValue;
   }
-
+  noOptionsMessage(props) {
+    if (this.state.inputValue === '') {
+      return <span>Start typing</span>;
+    } else if (this.state.inputValue.length < minSearchLength) {
+      return <span>Keep typing</span>;
+    }
+    return <span>No Options</span>;
+  }
   renderOption(props) {
     // React throws an error complaining about use of this property, so we delete it
     delete props.innerProps.innerRef;
@@ -125,6 +133,7 @@ export class DutyStationSearchBox extends Component {
               onInputChange={this.onInputChange}
               components={{ Option: this.renderOption }}
               value={isEmptyStation ? null : this.props.input.value}
+              noOptionsMessage={this.noOptionsMessage}
               placeholder="Start typing a duty station..."
             />
             {!isEmptyStation && (


### PR DESCRIPTION
## Description

This pull request addresses performance issues with the duty station lookup by 

- adding an index on name to the `duty_stations` table
- making the lookup less fuzzy because the current algorithm of add '%' between every typed character performs poorly and was not what design asked for originally: 
![image](https://user-images.githubusercontent.com/3142631/60935939-7fd6f280-a299-11e9-97a5-b5b1222a4469.png)
- changes the duty station lookup so that it won't display "No Options" until after it has requested matching options from the server to prevent a regression of the work to resolve [User Feedback](https://docs.google.com/document/d/1wnJb9FCqTo6NY3iR1yF17t80-U-2ggmN/edit#heading=h.1t3h5sf)


## Reviewer Notes

Given that the current endpoint could kill the server, this is meant to be potentially temporary change until we can get more feedback from design about how this lookup should really work.

## Code Review Verification Steps

* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/tree/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/tree/master/docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
* [x] There are no aXe warnings for UI.
* [x] User facing changes have been reviewed by design.
* [x] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/166968918) for this change

## Screenshots
On edit, the dropdown shows an empty message
![image](https://user-images.githubusercontent.com/3142631/60936476-338cb200-a29b-11e9-92fe-0bb620084a21.png)

Instead of showing a "no options" message :
![image](https://user-images.githubusercontent.com/3142631/60936435-1526b680-a29b-11e9-9c1a-95bc1131b7d0.png)

Typing "do" now returns this:
![image](https://user-images.githubusercontent.com/3142631/60936315-a8abb780-a29a-11e9-97c4-5fde2abacd90.png)

instead of this:
![image](https://user-images.githubusercontent.com/3142631/60936365-d690fc00-a29a-11e9-9877-b026412cdc9a.png)
