### PR TITLE
Accumulate Net Weight of Approved Weight Ticket Set Docs

### DIFF
--- a/cypress/integration/office/officeUserPPM.js
+++ b/cypress/integration/office/officeUserPPM.js
@@ -79,10 +79,6 @@ describe('office user finds the move', function() {
       .should('be.disabled');
   });
 
-  it('office user edits ppm net weight', function() {
-    officeUserEditsNetWeight();
-  });
-
   it('edits pickup and destination zip codes in estimates panel and these values are reflected in the storage and incentive calculators', function() {
     officeUserGoesToPPMPanel('FDXTIU');
     officeUserEditsEstimatesPanel(60606, 72018, 6000);
@@ -98,39 +94,6 @@ describe('office user finds the move', function() {
     userCancelsStorageDetails();
   });
 });
-
-function officeUserEditsNetWeight() {
-  cy.patientVisit('/queues/ppm');
-
-  cy.location().should(loc => {
-    expect(loc.pathname).to.match(/^\/queues\/ppm/);
-  });
-
-  cy.selectQueueItemMoveLocator('FDXTIU');
-
-  cy.location().should(loc => {
-    expect(loc.pathname).to.match(/^\/queues\/new\/moves\/[^/]+\/basics/);
-  });
-
-  cy.get('[data-cy="ppm-tab"]').click();
-
-  cy.get('.net_weight').contains('missing');
-
-  cy
-    .get('.editable-panel-header')
-    .contains('Weights')
-    .siblings()
-    .click();
-
-  cy.get('input[name="net_weight"]').type('6000');
-
-  cy
-    .get('button')
-    .contains('Save')
-    .click();
-
-  cy.get('.net_weight').contains('6,000');
-}
 
 function officeUserViewsMoves() {
   // Open new moves queue

--- a/src/scenes/Office/DocumentViewer/DocumentDetailPanel.jsx
+++ b/src/scenes/Office/DocumentViewer/DocumentDetailPanel.jsx
@@ -12,6 +12,7 @@ import { SwaggerField } from 'shared/JsonSchemaForm/JsonSchemaField';
 import { selectMoveDocument, updateMoveDocument } from 'shared/Entities/modules/moveDocuments';
 import { selectPPMForMove } from 'shared/Entities/modules/ppms';
 import { isMovingExpenseDocument } from 'shared/Entities/modules/movingExpenseDocuments';
+import { MOVE_DOC_TYPE } from 'shared/constants';
 
 import ExpenseDocumentForm from 'scenes/Office/DocumentViewer/ExpenseDocumentForm';
 
@@ -87,7 +88,7 @@ DocumentDetailDisplay.propTypes = {
 };
 
 const DocumentDetailEdit = ({ formValues, moveDocSchema }) => {
-  const isExpenseDocument = formValues.moveDocument.move_document_type === 'EXPENSE';
+  const isExpenseDocument = formValues.moveDocument.move_document_type === MOVE_DOC_TYPE.EXPENSE;
   return (
     <Fragment>
       <div>

--- a/src/scenes/Office/Ppm/NetWeightPanel.jsx
+++ b/src/scenes/Office/Ppm/NetWeightPanel.jsx
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { reduxForm, getFormValues } from 'redux-form';
 import { selectPPMForMove, updatePPM } from 'shared/Entities/modules/ppms';
-import { selectAllDocumentsForMove } from 'shared/Entities/modules/moveDocuments';
+import { selectAllDocumentsForMove, calcWeightTicketNetWeight } from 'shared/Entities/modules/moveDocuments';
 
 import { SwaggerField } from 'shared/JsonSchemaForm/JsonSchemaField';
 import { PanelSwaggerField, editablePanelify } from 'shared/EditablePanel';
@@ -44,12 +44,7 @@ function mapStateToProps(state, ownProps) {
   const formValues = getFormValues(formName)(state);
   const ppm = selectPPMForMove(state, ownProps.moveId);
   const moveDocs = selectAllDocumentsForMove(state, ownProps.moveId);
-  const netWeight = moveDocs.reduce((accum, { move_document_type, status, full_weight, empty_weight }) => {
-    if (move_document_type === 'WEIGHT_TICKET_SET' && status === 'OK') {
-      return accum + (full_weight - empty_weight);
-    }
-    return accum;
-  }, 0);
+  const netWeight = calcWeightTicketNetWeight(moveDocs);
 
   return {
     // reduxForm

--- a/src/scenes/Office/Ppm/NetWeightPanel.jsx
+++ b/src/scenes/Office/Ppm/NetWeightPanel.jsx
@@ -4,24 +4,26 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { reduxForm, getFormValues } from 'redux-form';
 import { selectPPMForMove, updatePPM } from 'shared/Entities/modules/ppms';
+import { selectAllDocumentsForMove } from 'shared/Entities/modules/moveDocuments';
 
 import { SwaggerField } from 'shared/JsonSchemaForm/JsonSchemaField';
 import { PanelSwaggerField, editablePanelify } from 'shared/EditablePanel';
 
-const NetWeightDisplay = props => {
+const NetWeightDisplay = ({ ppmSchema, ppm, netWeight }) => {
   const fieldProps = {
-    schema: props.ppmSchema,
-    values: props.ppm,
+    schema: ppmSchema,
+    values: ppm,
   };
   return (
     <div className="editable-panel-column">
-      <PanelSwaggerField title="Net Weight" fieldName="net_weight" required {...fieldProps} />
+      <PanelSwaggerField title="Net Weight" fieldName="net_weight" required {...fieldProps}>
+        {netWeight}
+      </PanelSwaggerField>
     </div>
   );
 };
 
-const NetWeightEdit = props => {
-  const { ppmSchema } = props;
+const NetWeightEdit = ({ ppmSchema }) => {
   return (
     <div className="editable-panel-column net-weight">
       <SwaggerField className="short-field" title="Net Weight" fieldName="net_weight" swagger={ppmSchema} required />lbs
@@ -31,7 +33,7 @@ const NetWeightEdit = props => {
 
 const formName = 'ppm_net_weight';
 
-let NetWeightPanel = editablePanelify(NetWeightDisplay, NetWeightEdit);
+let NetWeightPanel = editablePanelify(NetWeightDisplay, NetWeightEdit, false);
 NetWeightPanel = reduxForm({
   form: formName,
   enableReinitialize: true,
@@ -41,6 +43,14 @@ NetWeightPanel = reduxForm({
 function mapStateToProps(state, ownProps) {
   const formValues = getFormValues(formName)(state);
   const ppm = selectPPMForMove(state, ownProps.moveId);
+  const moveDocs = selectAllDocumentsForMove(state, ownProps.moveId);
+  const netWeight = moveDocs.reduce((accum, { move_document_type, status, full_weight, empty_weight }) => {
+    if (move_document_type === 'WEIGHT_TICKET_SET' && status === 'OK') {
+      return accum + (full_weight - empty_weight);
+    }
+    return accum;
+  }, 0);
+
   return {
     // reduxForm
     initialValues: pick(ppm, 'net_weight'),
@@ -54,6 +64,7 @@ function mapStateToProps(state, ownProps) {
       const values = getFormValues(formName)(state);
       return [ownProps.moveId, ppm.id, values];
     },
+    netWeight,
   };
 }
 

--- a/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
+++ b/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
@@ -9,7 +9,7 @@ import faPlusCircle from '@fortawesome/fontawesome-free-solid/faPlusCircle';
 import { titleCase } from 'shared/constants.js';
 
 import LoadingPlaceholder from 'shared/LoadingPlaceholder';
-
+import { MOVE_DOC_TYPE } from 'shared/constants';
 import Alert from 'shared/Alert';
 import DocumentList from 'shared/DocumentViewer/DocumentList';
 import { withContext } from 'shared/AppContext';
@@ -484,7 +484,7 @@ const mapStateToProps = (state, props) => {
   const shipmentId = props.match.params.shipmentId;
   const shipment = selectShipment(state, shipmentId);
   const shipmentDocuments = selectShipmentDocuments(state, shipment.id) || {};
-  const gbl = shipmentDocuments.find(element => element.move_document_type === 'GOV_BILL_OF_LADING');
+  const gbl = shipmentDocuments.find(element => element.move_document_type === MOVE_DOC_TYPE.GBL);
   const gblGenerated = !!gbl;
 
   return {

--- a/src/shared/Entities/modules/moveDocuments.js
+++ b/src/shared/Entities/modules/moveDocuments.js
@@ -1,9 +1,9 @@
 import { filter, map } from 'lodash';
+import { denormalize, normalize } from 'normalizr';
+import { getClient, getPublicClient, checkResponse } from 'shared/Swagger/api';
+import { MOVE_DOC_TYPE, MOVE_DOC_STATUS } from 'shared/constants';
 import { moveDocuments } from '../schema';
 import { ADD_ENTITIES, addEntities } from '../actions';
-import { denormalize, normalize } from 'normalizr';
-
-import { getClient, getPublicClient, checkResponse } from 'shared/Swagger/api';
 
 export const STATE_KEY = 'moveDocuments';
 
@@ -20,6 +20,15 @@ export default function reducer(state = {}, action) {
       return state;
   }
 }
+
+// Utilities
+export const calcWeightTicketNetWeight = moveDocs =>
+  moveDocs.reduce((accum, { move_document_type, status, full_weight, empty_weight }) => {
+    if (move_document_type === MOVE_DOC_TYPE.WEIGHT_TICKET_SET && status === MOVE_DOC_STATUS.OK) {
+      return accum + (full_weight - empty_weight);
+    }
+    return accum;
+  }, 0);
 
 // Actions
 export const getMoveDocumentsForMove = moveId => {

--- a/src/shared/Entities/modules/moveDocuments.test.js
+++ b/src/shared/Entities/modules/moveDocuments.test.js
@@ -1,0 +1,44 @@
+import { MOVE_DOC_TYPE, MOVE_DOC_STATUS } from 'shared/constants';
+import { calcWeightTicketNetWeight } from './moveDocuments';
+
+describe('Move Document utility functions', () => {
+  it('calcWeightTicketNetWeight should return 0 if there are no weight ticket sets', () => {
+    const moveDocs = [
+      { status: MOVE_DOC_STATUS.OK, move_document_type: MOVE_DOC_TYPE.GBL },
+      { stauts: MOVE_DOC_STATUS.OK, move_document_type: MOVE_DOC_TYPE.EXPENSE },
+    ];
+    expect(calcWeightTicketNetWeight([])).toBe(0);
+    expect(calcWeightTicketNetWeight(moveDocs)).toBe(0);
+  });
+
+  it('calcWeightTicketNetWeight should return net weight of all OKed weight ticket sets', () => {
+    const moveDocs = [
+      {
+        status: MOVE_DOC_STATUS.OK,
+        move_document_type: MOVE_DOC_TYPE.WEIGHT_TICKET_SET,
+        full_weight: 3000,
+        empty_weight: 1000,
+      },
+      {
+        status: MOVE_DOC_STATUS.HAS_ISSUE,
+        move_document_type: MOVE_DOC_TYPE.WEIGHT_TICKET_SET,
+        full_weight: 9000,
+        empty_weight: 3000,
+      },
+      {
+        status: MOVE_DOC_STATUS.AWAITING_REVIEW,
+        move_document_type: MOVE_DOC_TYPE.WEIGHT_TICKET_SET,
+        full_weight: 4000,
+        empty_weight: 1000,
+      },
+      {
+        status: MOVE_DOC_STATUS.OK,
+        move_document_type: MOVE_DOC_TYPE.WEIGHT_TICKET_SET,
+        full_weight: 4000,
+        empty_weight: 1000,
+      },
+    ];
+
+    expect(calcWeightTicketNetWeight(moveDocs)).toBe(5000);
+  });
+});

--- a/src/shared/constants.js
+++ b/src/shared/constants.js
@@ -20,6 +20,18 @@ export const titleCase = str => {
   return str.charAt(0).toUpperCase() + str.slice(1);
 };
 
+export const MOVE_DOC_TYPE = {
+  WEIGHT_TICKET_SET: 'WEIGHT_TICKET_SET',
+  EXPENSE: 'EXPENSE',
+  GBL: 'GOV_BILL_OF_LADING',
+};
+
+export const MOVE_DOC_STATUS = {
+  OK: 'OK',
+  AWAITING_REVIEW: 'AWAITING_REVIEW',
+  HAS_ISSUE: 'HAS_ISSUE',
+};
+
 // These constants are used to track network requests using component state
 export const isError = 'REQUEST_ERROR';
 export const isLoading = 'REQUEST_LOADING';


### PR DESCRIPTION
## Description

Populate the Net Weight panel based on the OKed weight ticket set documents net weights

## Setup
`make server_run`
`make office_client_run`
1. Have a PPM with a payment requested
2. Change status of a weight ticket set document to OK
Net weight panel on PPM tab should have the net weight of that weight ticket set document

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/166935626) for this change
