### PR TITLE
Skip button for PPM Closeout

### DIFF
--- a/cypress/integration/mymove/ppm.js
+++ b/cypress/integration/mymove/ppm.js
@@ -252,8 +252,9 @@ describe('allows a SM to request a payment', function() {
       .type('6/2/2018{enter}')
       .blur();
 
-    cy.get('input[name="additional_weight_ticket"][value="Yes"]').should('be.checked');
-    cy.get('input[name="additional_weight_ticket"][value="No"]').should('not.be.checked');
+    cy.get('input[name="additional_weight_ticket"][value="Yes"]').should('not.be.checked');
+    cy.get('input[name="additional_weight_ticket"][value="No"]').should('be.checked');
+    cy.get('input[name="additional_weight_ticket"][value="Yes"]+label').click();
     cy
       .get('button')
       .contains('Save & Add Another')
@@ -275,8 +276,9 @@ describe('allows a SM to request a payment', function() {
     // only required when missing is not checked
     cy.get('input[name="missingFullWeightTicket"]+label').click();
 
-    cy.get('input[name="additional_weight_ticket"][value="Yes"]').should('be.checked');
-    cy.get('input[name="additional_weight_ticket"][value="No"]').should('not.be.checked');
+    cy.get('input[name="additional_weight_ticket"][value="Yes"]').should('not.be.checked');
+    cy.get('input[name="additional_weight_ticket"][value="No"]').should('be.checked');
+    cy.get('input[name="additional_weight_ticket"][value="Yes"]+label').click();
     cy
       .get('button')
       .contains('Save & Add Another')
@@ -311,6 +313,21 @@ describe('allows a SM to request a payment', function() {
     cy.location().should(loc => {
       expect(loc.pathname).to.match(/^\/moves\/[^/]+\/ppm-payment-review/);
     });
+  });
+
+  it('service member can skip weight tickets and expenses if already have one', () => {
+    serviceMemberStartsPPMPaymentRequest();
+    serviceMemberSubmitsWeightTicket('CAR', true);
+    cy
+      .get('[data-cy=skip]')
+      .contains('Skip')
+      .click();
+    serviceMemberViewsExpensesLandingPage();
+    serviceMemberUploadsExpenses();
+    cy
+      .get('[data-cy=skip]')
+      .contains('Skip')
+      .click();
   });
 
   it('service member goes through entire request payment flow', () => {
@@ -576,10 +593,8 @@ function serviceMemberSubmitsCarTrailerWeightTicket() {
     .type('6/2/2018{enter}')
     .blur();
 
-  cy
-    .get('[type="radio"]')
-    .eq(2)
-    .should('be.checked');
+  cy.get('input[name="additional_weight_ticket"][value="Yes"]').should('not.be.checked');
+  cy.get('input[name="additional_weight_ticket"][value="No"]').should('be.checked');
 }
 function serviceMemberSavesWeightTicketForLater(vehicleType) {
   cy.get('select[name="vehicle_options"]').select(vehicleType);
@@ -641,6 +656,9 @@ function serviceMemberSubmitsWeightsTicketsWithoutReceipts() {
     .get('input[name="weight_ticket_date"]')
     .type('6/2/2018{enter}')
     .blur();
+
+  cy.get('input[name="additional_weight_ticket"][value="Yes"]+label').click();
+  cy.get('input[name="additional_weight_ticket"][value="Yes"]').should('be.checked');
   cy
     .get('button')
     .contains('Save & Add Another')
@@ -684,9 +702,11 @@ function serviceMemberSubmitsWeightTicket(vehicleType, hasAnother = true, ordina
     .get('input[name="weight_ticket_date"]')
     .type('6/2/2018{enter}')
     .blur();
-  cy.get('input[name="additional_weight_ticket"][value="Yes"]').should('be.checked');
-  cy.get('input[name="additional_weight_ticket"][value="No"]').should('not.be.checked');
+  cy.get('input[name="additional_weight_ticket"][value="Yes"]').should('not.be.checked');
+  cy.get('input[name="additional_weight_ticket"][value="No"]').should('be.checked');
   if (hasAnother) {
+    cy.get('input[name="additional_weight_ticket"][value="Yes"]+label').click();
+    cy.get('input[name="additional_weight_ticket"][value="Yes"]').should('be.checked');
     cy
       .get('button')
       .contains('Save & Add Another')
@@ -697,8 +717,6 @@ function serviceMemberSubmitsWeightTicket(vehicleType, hasAnother = true, ordina
       .should('eq', 200);
     cy.get('[data-cy=documents-uploaded]').should('exist');
   } else {
-    cy.get('input[name="additional_weight_ticket"][value="No"]+label').click();
-    cy.get('input[name="additional_weight_ticket"][value="No"]').should('be.checked');
     cy
       .get('button')
       .contains('Save & Continue')

--- a/src/scenes/Moves/Ppm/ExpensesUpload.jsx
+++ b/src/scenes/Moves/Ppm/ExpensesUpload.jsx
@@ -66,6 +66,11 @@ class ExpensesUpload extends Component {
     });
   };
 
+  skipHandler = () => {
+    const { moveId, history } = this.props;
+    history.push(`/moves/${moveId}${nextPagePath}`);
+  };
+
   saveForLaterHandler = formValues => {
     const { history } = this.props;
     return this.saveAndAddHandler(formValues).then(() => {
@@ -319,8 +324,10 @@ class ExpensesUpload extends Component {
               nextBtnLabel={nextBtnLabel}
               submitButtonsAreDisabled={this.isInvalidUploaderState() || invalid}
               submitting={submitting}
+              skipHandler={this.skipHandler}
               saveForLaterHandler={handleSubmit(this.saveForLaterHandler)}
               saveAndAddHandler={handleSubmit(this.saveAndAddHandler)}
+              displaySkip={expenses.length >= 1}
               displaySaveForLater={true}
             />
           </form>

--- a/src/scenes/Moves/Ppm/PPMPaymentRequestActionBtns.jsx
+++ b/src/scenes/Moves/Ppm/PPMPaymentRequestActionBtns.jsx
@@ -31,14 +31,16 @@ const PPMPaymentRequestActionBtns = props => {
           </button>
         )}
       </div>
-      {displaySkip && (
-        <button type="button" className="usa-button-secondary" onClick={skipHandler}>
-          Skip
+      <div className="usa-width-one-third">
+        {displaySkip && (
+          <button type="button" className="usa-button-secondary" onClick={skipHandler}>
+            Skip
+          </button>
+        )}
+        <button type="button" onClick={saveAndAddHandler} disabled={submitButtonsAreDisabled || submitting}>
+          {nextBtnLabel}
         </button>
-      )}
-      <button type="button" onClick={saveAndAddHandler} disabled={submitButtonsAreDisabled || submitting}>
-        {nextBtnLabel}
-      </button>
+      </div>
     </div>
   );
 };

--- a/src/scenes/Moves/Ppm/PPMPaymentRequestActionBtns.jsx
+++ b/src/scenes/Moves/Ppm/PPMPaymentRequestActionBtns.jsx
@@ -33,7 +33,7 @@ const PPMPaymentRequestActionBtns = props => {
       </div>
       <div className="usa-width-one-third">
         {displaySkip && (
-          <button type="button" className="usa-button-secondary" onClick={skipHandler}>
+          <button data-cy="skip" type="button" className="usa-button-secondary" onClick={skipHandler}>
             Skip
           </button>
         )}

--- a/src/scenes/Moves/Ppm/PPMPaymentRequestActionBtns.jsx
+++ b/src/scenes/Moves/Ppm/PPMPaymentRequestActionBtns.jsx
@@ -9,6 +9,7 @@ const PPMPaymentRequestActionBtns = props => {
     saveForLaterHandler,
     submitButtonsAreDisabled,
     displaySaveForLater,
+    displaySkip,
     submitting,
     history,
   } = props;
@@ -29,6 +30,11 @@ const PPMPaymentRequestActionBtns = props => {
           </button>
         )}
       </div>
+      {displaySkip && (
+        <button type="button" className="usa-button-secondary">
+          Skip
+        </button>
+      )}
       <button type="button" onClick={saveAndAddHandler} disabled={submitButtonsAreDisabled || submitting}>
         {nextBtnLabel}
       </button>

--- a/src/scenes/Moves/Ppm/PPMPaymentRequestActionBtns.jsx
+++ b/src/scenes/Moves/Ppm/PPMPaymentRequestActionBtns.jsx
@@ -5,6 +5,7 @@ import './PPMPaymentRequest.css';
 const PPMPaymentRequestActionBtns = props => {
   const {
     nextBtnLabel,
+    skipHandler,
     saveAndAddHandler,
     saveForLaterHandler,
     submitButtonsAreDisabled,
@@ -31,7 +32,7 @@ const PPMPaymentRequestActionBtns = props => {
         )}
       </div>
       {displaySkip && (
-        <button type="button" className="usa-button-secondary">
+        <button type="button" className="usa-button-secondary" onClick={skipHandler}>
           Skip
         </button>
       )}

--- a/src/scenes/Moves/Ppm/WeightTicket.jsx
+++ b/src/scenes/Moves/Ppm/WeightTicket.jsx
@@ -62,7 +62,7 @@ class WeightTicket extends Component {
   get initialState() {
     return {
       vehicleType: '',
-      additionalWeightTickets: 'Yes',
+      additionalWeightTickets: 'No',
       isValidTrailer: 'No',
       weightTicketSubmissionError: false,
       missingDocumentation: false,

--- a/src/scenes/Moves/Ppm/WeightTicket.jsx
+++ b/src/scenes/Moves/Ppm/WeightTicket.jsx
@@ -118,6 +118,14 @@ class WeightTicket extends Component {
     });
   };
 
+  skipHandler = () => {
+    const { moveId, history } = this.props;
+
+    const nextPage = getNextPage(`/moves/${moveId}${nextPagePath}`, this.props.lastLocation, reviewPagePath);
+    console.log(nextPage);
+    history.push(nextPage);
+  };
+
   saveForLaterHandler = formValues => {
     const { history } = this.props;
     return this.saveAndAddHandler(formValues).then(() => {
@@ -451,6 +459,7 @@ class WeightTicket extends Component {
               nextBtnLabel={nextBtnLabel}
               submitButtonsAreDisabled={this.uploaderWithInvalidState() || invalid}
               submitting={submitting}
+              skipHandler={this.skipHandler}
               saveForLaterHandler={handleSubmit(this.saveForLaterHandler)}
               saveAndAddHandler={handleSubmit(this.saveAndAddHandler)}
               displaySaveForLater={true}

--- a/src/scenes/Moves/Ppm/WeightTicket.jsx
+++ b/src/scenes/Moves/Ppm/WeightTicket.jsx
@@ -202,6 +202,7 @@ class WeightTicket extends Component {
     const weightTicketSetOrdinal = formatToOrdinal(weightTicketSets.length + 1);
     const fullWeightTicketFieldsRequired = missingFullWeightTicket ? null : true;
     const emptyWeightTicketFieldsRequired = missingEmptyWeightTicket ? null : true;
+
     return (
       <Fragment>
         <WizardHeader
@@ -453,6 +454,7 @@ class WeightTicket extends Component {
               saveForLaterHandler={handleSubmit(this.saveForLaterHandler)}
               saveAndAddHandler={handleSubmit(this.saveAndAddHandler)}
               displaySaveForLater={true}
+              displaySkip={weightTicketSets.length >= 1}
             />
           </div>
         </form>

--- a/src/scenes/Moves/Ppm/WeightTicket.jsx
+++ b/src/scenes/Moves/Ppm/WeightTicket.jsx
@@ -120,10 +120,7 @@ class WeightTicket extends Component {
 
   skipHandler = () => {
     const { moveId, history } = this.props;
-
-    const nextPage = getNextPage(`/moves/${moveId}${nextPagePath}`, this.props.lastLocation, reviewPagePath);
-    console.log(nextPage);
-    history.push(nextPage);
+    history.push(`/moves/${moveId}${nextPagePath}`);
   };
 
   saveForLaterHandler = formValues => {


### PR DESCRIPTION
## Description

Add a button to both the weight ticket and expense pages to skip either if there is already an existing ticket/expense.

## Setup

Log in as `ppm@requestingpay.ment`.

```sh
make server_run
make client_run
```

## Code Review Verification Steps
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/167107104) for this change

## Screenshots
![Screen Shot 2019-07-10 at 4 17 30 PM](https://user-images.githubusercontent.com/6464062/61001952-97ac8600-a32e-11e9-935e-882c160b4276.png)

