### PR TITLE
Allow "local" as an option before migrations are uploaded to S3

### DIFF
--- a/scripts/run-deployed-migrations
+++ b/scripts/run-deployed-migrations
@@ -10,14 +10,16 @@ function usage() {
   exit 1
 }
 
-if [[ "${SECURE_MIGRATION_SOURCE:-}" != "s3" ]]; then
+if [[ "${SECURE_MIGRATION_SOURCE:-}" != "s3" &&  "${SECURE_MIGRATION_SOURCE:-}" != "local" ]]; then
   echo "environment variable SECURE_MIGRATION_SOURCE is required"
   usage
 fi
 
-if [[ -z "$SECURE_MIGRATION_BUCKET_NAME" ]]; then
-  echo "environment variable SECURE_MIGRATION_BUCKET_NAME is required"
-  usage
+if [ "${SECURE_MIGRATION_SOURCE:-}" == "s3" ]; then
+  if [ -z "$SECURE_MIGRATION_BUCKET_NAME" ]; then
+    echo "environment variable SECURE_MIGRATION_BUCKET_NAME is required"
+    usage
+  fi
 fi
 
 if [[ "$#" -lt 1 ]]; then
@@ -57,14 +59,18 @@ command -v aws 2> /dev/null | grep "ppp-infra/scripts/aws" &> /dev/null || \
   )
 
 # Test AWS command and freshen AWS session token
-aws s3 ls "${SECURE_MIGRATION_BUCKET_NAME}/secure-migrations" > /dev/null
+if [ "${SECURE_MIGRATION_SOURCE:-}" == "s3" ]; then
+  aws s3 ls "${SECURE_MIGRATION_BUCKET_NAME}/secure-migrations" > /dev/null
+fi
 
 #
 # Run migrations
 #
 
 echo
-echo -e "\e[33mUsing ${SECURE_MIGRATION_BUCKET_NAME} to gather secure migrations\e[39m"
+if [ "${SECURE_MIGRATION_SOURCE:-}" == "s3" ]; then
+  echo -e "\e[33mUsing ${SECURE_MIGRATION_BUCKET_NAME} to gather secure migrations\e[39m"
+fi
 echo
 proceed "Running deployed migrations against the local database with name ${DB_NAME}. This will delete everything in that db."
 

--- a/scripts/run-deployed-migrations
+++ b/scripts/run-deployed-migrations
@@ -68,6 +68,8 @@ aws s3 ls > /dev/null
 echo
 if [ "${SECURE_MIGRATION_SOURCE:-}" == "s3" ]; then
   echo -e "\e[33mUsing ${SECURE_MIGRATION_BUCKET_NAME} to gather secure migrations\e[39m"
+else
+    echo -e "\e[33mUsing local_migrations folder to gather secure migrations\e[39m"
 fi
 echo
 proceed "Running deployed migrations against the local database with name ${DB_NAME}. This will delete everything in that db."

--- a/scripts/run-deployed-migrations
+++ b/scripts/run-deployed-migrations
@@ -59,9 +59,7 @@ command -v aws 2> /dev/null | grep "ppp-infra/scripts/aws" &> /dev/null || \
   )
 
 # Test AWS command and freshen AWS session token
-if [ "${SECURE_MIGRATION_SOURCE:-}" == "s3" ]; then
-  aws s3 ls "${SECURE_MIGRATION_BUCKET_NAME}/secure-migrations" > /dev/null
-fi
+aws s3 ls > /dev/null
 
 #
 # Run migrations

--- a/scripts/upload-secure-migration
+++ b/scripts/upload-secure-migration
@@ -61,7 +61,7 @@ ${aws_command} s3 ls "${aws_bucket_prefix}${environments[0]}${aws_bucket_suffix}
 
 echo "Testing migrations ... (This could be several minutes!)"
 
-SECURE_MIGRATION_SOURCE=local make run_prod_migrations
+SECURE_MIGRATION_SOURCE=local ./scripts/run-deployed-migrations deployed_migrations
 
 echo "Testing migrations was successful!"
 echo

--- a/scripts/upload-secure-migration
+++ b/scripts/upload-secure-migration
@@ -61,7 +61,7 @@ ${aws_command} s3 ls "${aws_bucket_prefix}${environments[0]}${aws_bucket_suffix}
 
 echo "Testing migrations ... (This could be several minutes!)"
 
-SECURE_MIGRATION_SOURCE=local ./scripts/run-deployed-migrations deployed_migrations
+SECURE_MIGRATION_SOURCE=local ./scripts/run-deployed-migrations "${DB_NAME_DEPLOYED_MIGRATIONS}"
 
 echo "Testing migrations was successful!"
 echo


### PR DESCRIPTION
[Slack thread](https://defensedigitalservice.slack.com/archives/G8P7UD05U/p1562785580189500) for context. **TLDR;** there is a bug in the `run-deployed-migrations` script that only allows for migrations that are already in S3, effectively blocking you from uploading your migration to S3.
