### PR TITLE
reduce run time of golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -40,7 +40,7 @@ issues:
 run:
   # timeout for analysis, e.g. 30s, 5m, default is 1m
   deadline: 8m
-  concurrency: 1
+  concurrency: 3
 
 # which dirs to skip: they won't be analyzed;
   skip-dirs:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -40,7 +40,7 @@ issues:
 run:
   # timeout for analysis, e.g. 30s, 5m, default is 1m
   deadline: 8m
-  concurrency: 3
+  concurrency: 8
 
 # which dirs to skip: they won't be analyzed;
   skip-dirs:


### PR DESCRIPTION
## Description

At the moment golangci-lint takes anywhere between ~40-50 seconds to run. We can decrease its runtime by bumping up concurrency.
## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/167225819) for this change

## Screenshots
Concurrency = 1
![image](https://user-images.githubusercontent.com/5003421/61060820-266de100-a3c9-11e9-842a-83a52070f322.png)

Concurrency = 3
![image](https://user-images.githubusercontent.com/5003421/61060892-469da000-a3c9-11e9-8d25-7b6375487214.png)
