### PR TITLE
Use new admin users table to authentication and authorization.

### DIFF
--- a/cmd/milmove/serve.go
+++ b/cmd/milmove/serve.go
@@ -769,6 +769,7 @@ func serveFunction(cmd *cobra.Command, args []string) error {
 	adminAPIMux := goji.SubMux()
 	adminMux.Handle(pat.New("/*"), adminAPIMux)
 	adminAPIMux.Use(userAuthMiddleware)
+	adminAPIMux.Use(authentication.AdminAuthMiddleware(logger))
 	adminAPIMux.Use(middleware.NoCache(logger))
 	adminAPIMux.Handle(pat.New("/*"), adminapi.NewAdminAPIHandler(handlerContext))
 

--- a/internal/pkg/dutystationsloader/duty_stations_loader_test.go
+++ b/internal/pkg/dutystationsloader/duty_stations_loader_test.go
@@ -91,7 +91,7 @@ func (suite *DutyStationsLoaderSuite) TestCreateInsertQuery() {
 	query := builder.createInsertQuery(model, &pop.Model{Value: models.User{}})
 
 	suite.Equal(
-		"INSERT into users (id, created_at, updated_at, login_gov_uuid, login_gov_email, disabled, is_superuser) VALUES ('cd40c92e-7c8a-4da4-ad58-4480df84b3f0', now(), now(), 'cd40c92e-7c8a-4da4-ad58-4480df84b3f1', 'email@example.com', false, false);\n",
+		"INSERT into users (id, created_at, updated_at, login_gov_uuid, login_gov_email, disabled) VALUES ('cd40c92e-7c8a-4da4-ad58-4480df84b3f0', now(), now(), 'cd40c92e-7c8a-4da4-ad58-4480df84b3f1', 'email@example.com', false);\n",
 		query)
 }
 

--- a/local_migrations/20190710174257_add_system_admin_users.sql
+++ b/local_migrations/20190710174257_add_system_admin_users.sql
@@ -2,8 +2,8 @@
 -- This will be run on development environments. It should mirror what you
 -- intend to apply on production, but do not include any sensitive data.
 
-INSERT INTO organizations (id, name, created_at, updated_at)
-VALUES ('B0E3EAAE-A1AD-4B01-9415-49139B13265B', 'Truss', now(), now());
+INSERT INTO organizations (id, name, created_at, updated_at, poc_email, poc_phone)
+VALUES ('B0E3EAAE-A1AD-4B01-9415-49139B13265B', 'Truss', now(), now(), 'example@truss.works', '(123) 456-7891');
 
 INSERT INTO admin_users (id, email, role, first_name, last_name, organization_id, created_at, updated_at)
 SELECT '345E751D-4B95-43E6-9043-95043DA3974E', 'example1@truss.works', 'SYSTEM_ADMIN', 'Example', 'Example', id, now(), now()

--- a/local_migrations/20190710174257_add_system_admin_users.sql
+++ b/local_migrations/20190710174257_add_system_admin_users.sql
@@ -1,0 +1,21 @@
+-- Local test migration.
+-- This will be run on development environments. It should mirror what you
+-- intend to apply on production, but do not include any sensitive data.
+
+INSERT INTO organizations (id, name, created_at, updated_at)
+VALUES (uuid_generate_v4(), 'Truss', now(), now());
+
+INSERT INTO admin_users (id, email, role, first_name, last_name, organization_id, created_at, updated_at)
+SELECT uuid_generate_v4(), 'example1@truss.works', 'SYSTEM_ADMIN', 'Example', 'Example', id, now(), now()
+FROM organizations
+WHERE name = 'Truss';
+
+INSERT INTO admin_users (id, email, role, first_name, last_name, organization_id, created_at, updated_at)
+SELECT uuid_generate_v4(), 'example2@truss.works', 'SYSTEM_ADMIN', 'Example', 'Example', id, now(), now()
+FROM organizations
+WHERE name = 'Truss';
+
+INSERT INTO admin_users (id, email, role, first_name, last_name, organization_id, created_at, updated_at)
+SELECT uuid_generate_v4(), 'example3@truss.works', 'SYSTEM_ADMIN', 'Example', 'Example', id, now(), now()
+FROM organizations
+WHERE name = 'Truss';

--- a/local_migrations/20190710174257_add_system_admin_users.sql
+++ b/local_migrations/20190710174257_add_system_admin_users.sql
@@ -3,19 +3,19 @@
 -- intend to apply on production, but do not include any sensitive data.
 
 INSERT INTO organizations (id, name, created_at, updated_at)
-VALUES (uuid_generate_v4(), 'Truss', now(), now());
+VALUES ('B0E3EAAE-A1AD-4B01-9415-49139B13265B', 'Truss', now(), now());
 
 INSERT INTO admin_users (id, email, role, first_name, last_name, organization_id, created_at, updated_at)
-SELECT uuid_generate_v4(), 'example1@truss.works', 'SYSTEM_ADMIN', 'Example', 'Example', id, now(), now()
+SELECT '345E751D-4B95-43E6-9043-95043DA3974E', 'example1@truss.works', 'SYSTEM_ADMIN', 'Example', 'Example', id, now(), now()
 FROM organizations
 WHERE name = 'Truss';
 
 INSERT INTO admin_users (id, email, role, first_name, last_name, organization_id, created_at, updated_at)
-SELECT uuid_generate_v4(), 'example2@truss.works', 'SYSTEM_ADMIN', 'Example', 'Example', id, now(), now()
+SELECT '6FA18AC5-B9A7-4E97-BCF7-4D2DF4243710', 'example2@truss.works', 'SYSTEM_ADMIN', 'Example', 'Example', id, now(), now()
 FROM organizations
 WHERE name = 'Truss';
 
 INSERT INTO admin_users (id, email, role, first_name, last_name, organization_id, created_at, updated_at)
-SELECT uuid_generate_v4(), 'example3@truss.works', 'SYSTEM_ADMIN', 'Example', 'Example', id, now(), now()
+SELECT 'B44A89DE-132A-49C2-A61A-CEB737B28BB9', 'example3@truss.works', 'SYSTEM_ADMIN', 'Example', 'Example', id, now(), now()
 FROM organizations
 WHERE name = 'Truss';

--- a/migrations/20190708201347_make_admin_users_fname_and_lname_required.up.fizz
+++ b/migrations/20190708201347_make_admin_users_fname_and_lname_required.up.fizz
@@ -1,2 +1,2 @@
-change_column("admin_users", "first_name", "string", {})
-change_column("admin_users", "last_name", "string", {})
+change_column("admin_users", "first_name", "string", {"null": false})
+change_column("admin_users", "last_name", "string", {"null": false})

--- a/migrations/20190708201347_make_admin_users_fname_and_lname_required.up.fizz
+++ b/migrations/20190708201347_make_admin_users_fname_and_lname_required.up.fizz
@@ -1,0 +1,2 @@
+change_column("admin_users", "first_name", "string", {})
+change_column("admin_users", "last_name", "string", {})

--- a/migrations/20190708201347_make_admin_users_fname_and_lname_required.up.fizz
+++ b/migrations/20190708201347_make_admin_users_fname_and_lname_required.up.fizz
@@ -1,2 +1,2 @@
-change_column("admin_users", "first_name", "string", {"null": false})
-change_column("admin_users", "last_name", "string", {"null": false})
+sql("ALTER TABLE admin_users ALTER COLUMN first_name SET NOT NULL;")
+sql("ALTER TABLE admin_users ALTER COLUMN last_name SET NOT NULL;")

--- a/migrations/20190709211634_remove_is_superuser.up.fizz
+++ b/migrations/20190709211634_remove_is_superuser.up.fizz
@@ -1,1 +1,0 @@
-drop_column("users", "is_superuser")

--- a/migrations/20190709211634_remove_is_superuser.up.fizz
+++ b/migrations/20190709211634_remove_is_superuser.up.fizz
@@ -1,0 +1,1 @@
+drop_column("users", "is_superuser")

--- a/migrations/20190710151514_make_organizations_poc_nullable.up.fizz
+++ b/migrations/20190710151514_make_organizations_poc_nullable.up.fizz
@@ -1,0 +1,2 @@
+change_column("organizations", "poc_email", "string", {null: true})
+change_column("organizations", "poc_phone", "string", {null: true})

--- a/migrations/20190710174257_add_system_admin_users.up.fizz
+++ b/migrations/20190710174257_add_system_admin_users.up.fizz
@@ -1,0 +1,1 @@
+exec("./apply-secure-migration.sh 20190710174257_add_system_admin_users.sql")

--- a/migrations_manifest.txt
+++ b/migrations_manifest.txt
@@ -322,7 +322,6 @@
 20190705235827_fix_duty_station_zip.up.sql
 20190708201347_make_admin_users_fname_and_lname_required.up.fizz
 20190709204712_add-office-users.up.fizz
-20190709211634_remove_is_superuser.up.fizz
 20190710151514_make_organizations_poc_nullable.up.fizz
 20190710174257_add_system_admin_users.up.fizz
 20190711215901_load_usmc_duty_stations.up.sql

--- a/migrations_manifest.txt
+++ b/migrations_manifest.txt
@@ -320,7 +320,11 @@
 20190702195904_create_organizations.up.fizz
 20190703141326_add-usmc-office-users.up.fizz
 20190705235827_fix_duty_station_zip.up.sql
+20190708201347_make_admin_users_fname_and_lname_required.up.fizz
 20190709204712_add-office-users.up.fizz
+20190709211634_remove_is_superuser.up.fizz
+20190710151514_make_organizations_poc_nullable.up.fizz
+20190710174257_add_system_admin_users.up.fizz
 20190711215901_load_usmc_duty_stations.up.sql
 20190713214312_update-county-code-us.up.sql
 20190715122032_delete-duty-stations-with-no-zip3.up.sql

--- a/pkg/auth/authentication/auth.go
+++ b/pkg/auth/authentication/auth.go
@@ -74,7 +74,7 @@ func UserAuthMiddleware(logger Logger) func(next http.Handler) http.Handler {
 func AdminAuthMiddleware(logger Logger) func(next http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		mw := func(w http.ResponseWriter, r *http.Request) {
-			ctx, span := beeline.StartSpan(r.Context(), "UserAuthMiddleware")
+			ctx, span := beeline.StartSpan(r.Context(), "AdminAuthMiddleware")
 			defer span.Send()
 			session := auth.SessionFromRequestContext(r)
 

--- a/pkg/auth/authentication/auth.go
+++ b/pkg/auth/authentication/auth.go
@@ -59,7 +59,7 @@ func UserAuthMiddleware(logger Logger) func(next http.Handler) http.Handler {
 				return
 			}
 
-			// Include session office ID, service member ID, tsp ID, user ID, and superuser status to the beeline event
+			// Include session office ID, service member ID, tsp ID, user ID, and admin ID to the beeline event
 			span.AddTraceField("auth.office_user_id", session.OfficeUserID)
 			span.AddTraceField("auth.service_member_id", session.ServiceMemberID)
 			span.AddTraceField("auth.tsp_user_id", session.TspUserID)

--- a/pkg/auth/authentication/auth.go
+++ b/pkg/auth/authentication/auth.go
@@ -42,16 +42,15 @@ func UserAuthMiddleware(logger Logger) func(next http.Handler) http.Handler {
 			}
 			// DO NOT CHECK MILMOVE SESSION BECAUSE NEW SERVICE MEMBERS WON'T HAVE AN ID RIGHT AWAY
 			// This must be the right type of user for the application
-			if session.IsOfficeApp() && session.OfficeUserID == uuid.Nil {
+			if session.IsOfficeApp() && !session.IsOfficeUser() {
 				logger.Error("unauthorized user for office.move.mil", zap.String("email", session.Email))
 				http.Error(w, http.StatusText(401), http.StatusUnauthorized)
 				return
-			} else if session.IsTspApp() && session.TspUserID == uuid.Nil {
+			} else if session.IsTspApp() && !session.IsTspUser() {
 				logger.Error("unauthorized user for tsp.move.mil", zap.String("email", session.Email))
 				http.Error(w, http.StatusText(401), http.StatusUnauthorized)
 				return
-			} else if session.IsAdminApp() &&
-				!session.IsAdminUser() {
+			} else if session.IsAdminApp() && !session.IsAdminUser() {
 				logger.Error("unauthorized user for admin.move.mil", zap.String("email", session.Email))
 				http.Error(w, http.StatusText(401), http.StatusUnauthorized)
 				return

--- a/pkg/auth/authentication/auth.go
+++ b/pkg/auth/authentication/auth.go
@@ -79,7 +79,7 @@ func AdminAuthMiddleware(logger Logger) func(next http.Handler) http.Handler {
 			session := auth.SessionFromRequestContext(r)
 
 			if session == nil || !session.IsAdminUser() {
-				http.Error(w, http.StatusText(401), http.StatusUnauthorized)
+				http.Error(w, http.StatusText(403), http.StatusForbidden)
 				return
 			}
 

--- a/pkg/auth/authentication/auth.go
+++ b/pkg/auth/authentication/auth.go
@@ -458,7 +458,7 @@ func authorizeKnownUser(userIdentity *models.UserIdentity, h CallbackHandler, se
 			err := queryBuilder.FetchOne(&adminUser, filters)
 			if err == models.ErrFetchNotFound {
 				h.logger.Error("Non-admin user authenticated at admin site", zap.String("email", session.Email))
-				http.Error(w, http.StatusText(401), http.StatusUnauthorized)
+				http.Error(w, http.StatusText(403), http.StatusForbidden)
 				return
 			} else if err != nil {
 				h.logger.Error("Checking for admin user", zap.String("email", session.Email), zap.Error(err))

--- a/pkg/auth/authentication/auth_test.go
+++ b/pkg/auth/authentication/auth_test.go
@@ -249,7 +249,7 @@ func (suite *AuthSuite) TestRequireAdminAuthMiddlewareUnauthorized() {
 	middleware.ServeHTTP(rr, req)
 
 	// We should receive an unauthorized response
-	if status := rr.Code; status != http.StatusUnauthorized {
+	if status := rr.Code; status != http.StatusForbidden {
 		t.Errorf("handler returned wrong status code: got %v wanted %v", status, http.StatusUnauthorized)
 	}
 }

--- a/pkg/auth/authentication/auth_test.go
+++ b/pkg/auth/authentication/auth_test.go
@@ -204,6 +204,56 @@ func (suite *AuthSuite) TestRequireAuthMiddlewareUnauthorized() {
 	}
 }
 
+func (suite *AuthSuite) TestRequireAdminAuthMiddleware() {
+	// Given: a logged in user
+	loginGovUUID, _ := uuid.FromString("2400c3c5-019d-4031-9c27-8a553e022297")
+	user := models.User{
+		LoginGovUUID:  loginGovUUID,
+		LoginGovEmail: "email@example.com",
+		Disabled:      false,
+	}
+	suite.MustSave(&user)
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/admin/v1/office_users", nil)
+
+	// And: the context contains the auth values
+	session := auth.Session{UserID: user.ID, IDToken: "fake Token", AdminUserID: uuid.Must(uuid.NewV4())}
+	ctx := auth.SetSessionInRequestContext(req, &session)
+	req = req.WithContext(ctx)
+
+	var handlerSession *auth.Session
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handlerSession = auth.SessionFromRequestContext(r)
+	})
+
+	middleware := AdminAuthMiddleware(suite.logger)(handler)
+
+	middleware.ServeHTTP(rr, req)
+
+	// We should be not be redirected since we're logged in
+	suite.Equal(http.StatusOK, rr.Code, "handler returned wrong status code")
+	suite.Equal(handlerSession.UserID, user.ID, "the authenticated user is different from expected")
+}
+
+func (suite *AuthSuite) TestRequireAdminAuthMiddlewareUnauthorized() {
+	t := suite.T()
+
+	// Given: No logged in users
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/admin/v1/office_users", nil)
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+	middleware := AdminAuthMiddleware(suite.logger)(handler)
+
+	middleware.ServeHTTP(rr, req)
+
+	// We should receive an unauthorized response
+	if status := rr.Code; status != http.StatusUnauthorized {
+		t.Errorf("handler returned wrong status code: got %v wanted %v", status, http.StatusUnauthorized)
+	}
+}
+
 func (suite *AuthSuite) TestAuthorizeDisableUser() {
 	userIdentity := models.UserIdentity{
 		Disabled: true,
@@ -421,7 +471,6 @@ func (suite *AuthSuite) TestRedirectLoginGovErrorMsg() {
 		false,
 	}
 	rr := httptest.NewRecorder()
-
 	span := trace.Span{}
 	authorizeKnownUser(&userIdentity, h, &session, rr, &span, req.WithContext(ctx), "")
 
@@ -442,4 +491,83 @@ func (suite *AuthSuite) TestRedirectLoginGovErrorMsg() {
 	}
 
 	suite.Equal("http://office.example.com:1234/?error=SIGNIN_ERROR", rr2.Result().Header.Get("Location"))
+}
+
+func (suite *AuthSuite) TestAuthKnownSingleRoleAdmin() {
+	adminUserID := uuid.Must(uuid.NewV4())
+	officeUserID := uuid.Must(uuid.NewV4())
+	var adminUserRole models.AdminRole = "SYSTEM_ADMIN"
+
+	userIdentity := models.UserIdentity{
+		Disabled:      false,
+		OfficeUserID:  &officeUserID,
+		AdminUserID:   &adminUserID,
+		AdminUserRole: &adminUserRole,
+	}
+
+	req := httptest.NewRequest("GET", fmt.Sprintf("http://%s/auth/authorize", AdminTestHost), nil)
+
+	fakeToken := "some_token"
+	fakeUUID, _ := uuid.FromString("39b28c92-0506-4bef-8b57-e39519f42dc2")
+	session := auth.Session{
+		ApplicationName: auth.AdminApp,
+		UserID:          fakeUUID,
+		IDToken:         fakeToken,
+		Hostname:        AdminTestHost,
+	}
+
+	ctx := auth.SetSessionInRequestContext(req, &session)
+	callbackPort := 1234
+	authContext := NewAuthContext(suite.logger, fakeLoginGovProvider(suite.logger), "http", callbackPort)
+	h := CallbackHandler{
+		authContext,
+		suite.DB(),
+		"fake key",
+		false,
+		false,
+	}
+	rr := httptest.NewRecorder()
+	span := trace.Span{}
+	authorizeKnownUser(&userIdentity, h, &session, rr, &span, req.WithContext(ctx), "")
+
+	// admin app, so should only have admin ID information
+	suite.Equal(adminUserID, session.AdminUserID)
+	suite.Equal(uuid.Nil, session.OfficeUserID)
+	suite.True(session.IsAdminUser())
+	suite.True(session.IsSystemAdmin())
+	suite.False(session.IsProgramAdmin())
+}
+
+func (suite *AuthSuite) TestAuthorizeDisableAdmin() {
+	adminUserDisabled := true
+	userIdentity := models.UserIdentity{
+		AdminUserDisabled: &adminUserDisabled,
+	}
+
+	req := httptest.NewRequest("GET", fmt.Sprintf("http://%s/auth/logout", AdminTestHost), nil)
+
+	fakeToken := "some_token"
+	fakeUUID, _ := uuid.FromString("39b28c92-0506-4bef-8b57-e39519f42dc2")
+	session := auth.Session{
+		ApplicationName: auth.AdminApp,
+		UserID:          fakeUUID,
+		IDToken:         fakeToken,
+		Hostname:        AdminTestHost,
+		Email:           "disabled@example.com",
+	}
+	ctx := auth.SetSessionInRequestContext(req, &session)
+	callbackPort := 1234
+	authContext := NewAuthContext(suite.logger, fakeLoginGovProvider(suite.logger), "http", callbackPort)
+	h := CallbackHandler{
+		authContext,
+		suite.DB(),
+		"fake key",
+		false,
+		false,
+	}
+	rr := httptest.NewRecorder()
+	span := trace.Span{}
+	authorizeKnownUser(&userIdentity, h, &session, rr, &span, req.WithContext(ctx), "")
+
+	suite.Equal(http.StatusForbidden, rr.Code, "authorizer did not recognize disabled office user")
 }

--- a/pkg/auth/authentication/devlocal.go
+++ b/pkg/auth/authentication/devlocal.go
@@ -75,7 +75,6 @@ func (h UserListHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		DpsUserType     string
 		IsAdminApp      bool
 		AdminUserType   string
-		IsAdminUser     bool
 		CsrfToken       string
 		QueryLimit      int
 	}

--- a/pkg/auth/authentication/devlocal.go
+++ b/pkg/auth/authentication/devlocal.go
@@ -75,6 +75,7 @@ func (h UserListHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		DpsUserType     string
 		IsAdminApp      bool
 		AdminUserType   string
+		IsAdminUser     bool
 		CsrfToken       string
 		QueryLimit      int
 	}
@@ -121,7 +122,7 @@ func (h UserListHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					<p id="{{.ID}}">
 						<input type="hidden" name="gorilla.csrf.Token" value="{{$.CsrfToken}}">
 						{{.Email}}
-						{{if .IsSuperuser}}
+						{{if .AdminUserID}}
 						  ({{$.AdminUserType}})
 						  <input type="hidden" name="userType" value="{{$.AdminUserType}}">
 						{{else if .DpsUserID}}
@@ -365,7 +366,6 @@ func createUser(h devlocalAuthHandler, w http.ResponseWriter, r *http.Request) (
 	user := models.User{
 		LoginGovUUID:  id,
 		LoginGovEmail: email,
-		IsSuperuser:   false,
 		Disabled:      false,
 	}
 
@@ -485,8 +485,17 @@ func createUser(h devlocalAuthHandler, w http.ResponseWriter, r *http.Request) (
 			h.logger.Error("validation errors creating dps user", zap.Stringer("errors", verrs))
 		}
 	case AdminUserType:
-		user.IsSuperuser = true
-		verrs, err := h.db.ValidateAndSave(&user)
+		var role models.AdminRole = "SYSTEM_ADMIN"
+
+		adminUser := models.AdminUser{
+			UserID:    &user.ID,
+			Email:     user.LoginGovEmail,
+			FirstName: "Leo",
+			LastName:  "Spaceman",
+			Role:      role,
+		}
+		verrs, err := h.db.ValidateAndSave(&adminUser)
+
 		if err != nil {
 			h.logger.Error("could not create admin user", zap.Error(err))
 		}
@@ -517,7 +526,6 @@ func createSession(h devlocalAuthHandler, user *models.User, userType string, w 
 	session.IDToken = "devlocal"
 	session.UserID = userIdentity.ID
 	session.Email = userIdentity.Email
-	session.IsSuperuser = userIdentity.IsSuperuser
 
 	// Set the app
 	disabled := userIdentity.Disabled
@@ -535,6 +543,8 @@ func createSession(h devlocalAuthHandler, user *models.User, userType string, w 
 	case AdminUserType:
 		session.ApplicationName = auth.AdminApp
 		session.Hostname = h.appnames.AdminServername
+		session.AdminUserID = *userIdentity.AdminUserID
+		session.AdminUserRole = userIdentity.AdminUserRole.String()
 	default:
 		session.ApplicationName = auth.MilApp
 		session.Hostname = h.appnames.MilServername
@@ -593,8 +603,8 @@ func verifySessionWithApp(session *auth.Session) error {
 		return errors.Errorf("Non-TSP user %s authenticated at TSP site", session.Email)
 	}
 
-	if !session.IsSuperuser && session.IsAdminApp() {
-		return errors.Errorf("Non-superuser %s authenticated at admin site", session.Email)
+	if !session.IsAdminUser() && session.IsAdminApp() {
+		return errors.Errorf("Non-admin user %s authenticated at admin site", session.Email)
 	}
 
 	return nil

--- a/pkg/auth/authentication/devlocal_test.go
+++ b/pkg/auth/authentication/devlocal_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/services"
+	"github.com/transcom/mymove/pkg/services/query"
 )
 
 func getCookie(name string, cookies []*http.Cookie) (*http.Cookie, error) {
@@ -229,7 +231,13 @@ func (suite *AuthSuite) TestCreateUserHandlerAdmin() {
 		t.Error("Could not unmarshal json data into User model.", err)
 	}
 
-	if _, err := models.FetchAdminUserByEmail(suite.DB(), user.LoginGovEmail); err != nil {
+	var adminUser models.AdminUser
+	queryBuilder := query.NewQueryBuilder(suite.DB())
+	filters := []services.QueryFilter{
+		query.NewQueryFilter("email", "=", user.LoginGovEmail),
+	}
+
+	if err := queryBuilder.FetchOne(&adminUser, filters); err != nil {
 		t.Error("Couldn't find admin user record")
 	}
 }

--- a/pkg/auth/authentication/devlocal_test.go
+++ b/pkg/auth/authentication/devlocal_test.go
@@ -229,8 +229,9 @@ func (suite *AuthSuite) TestCreateUserHandlerAdmin() {
 		t.Error("Could not unmarshal json data into User model.", err)
 	}
 
-	// Make sure the superuser flag is set to true
-	suite.True(user.IsSuperuser, "superuser flag was not set to true for admin user")
+	if _, err := models.FetchAdminUserByEmail(suite.DB(), user.LoginGovEmail); err != nil {
+		t.Error("Couldn't find admin user record")
+	}
 }
 
 func (suite *AuthSuite) TestCreateAndLoginUserHandlerFromMilMoveToMilMove() {

--- a/pkg/auth/session.go
+++ b/pkg/auth/session.go
@@ -50,7 +50,6 @@ type Session struct {
 	ApplicationName Application
 	Hostname        string
 	IDToken         string
-	IsSuperuser     bool
 	UserID          uuid.UUID
 	Email           string
 	FirstName       string
@@ -59,6 +58,8 @@ type Session struct {
 	ServiceMemberID uuid.UUID
 	OfficeUserID    uuid.UUID
 	TspUserID       uuid.UUID
+	AdminUserID     uuid.UUID
+	AdminUserRole   string
 	DpsUserID       uuid.UUID
 }
 
@@ -102,7 +103,19 @@ func (s *Session) IsTspUser() bool {
 
 // IsAdminUser checks whether the authenticated user is an AdminUser
 func (s *Session) IsAdminUser() bool {
-	return s.IsSuperuser
+	return s.AdminUserID != uuid.Nil
+}
+
+// IsSystemAdmin checks whether the authenticated admin user is a system admin
+func (s *Session) IsSystemAdmin() bool {
+	role := "SYSTEM_ADMIN"
+	return s.IsAdminUser() && s.AdminUserRole == role
+}
+
+// IsProgramAdmin checks whether the authenticated admin user is a program admin
+func (s *Session) IsProgramAdmin() bool {
+	role := "PROGRAM_ADMIN"
+	return s.IsAdminUser() && s.AdminUserRole == role
 }
 
 // IsDpsUser checks whether the authenticated user is a DpsUser

--- a/pkg/models/admin_user_test.go
+++ b/pkg/models/admin_user_test.go
@@ -15,7 +15,7 @@ func (suite *ModelSuite) TestAdminUserCreation() {
 	newAdminUser := AdminUser{
 		FirstName: "Leo",
 		LastName:  "Spaceman",
-		UserID:    user.ID,
+		UserID:    &user.ID,
 		Role:      "SYSTEM_ADMIN",
 		Email:     "leo@gmail.com",
 	}

--- a/pkg/models/admin_user_test.go
+++ b/pkg/models/admin_user_test.go
@@ -36,7 +36,7 @@ func (suite *ModelSuite) TestAdminUserCreationWithoutValues() {
 		"first_name": {"FirstName can not be blank."},
 		"last_name":  {"LastName can not be blank."},
 		"email":      {"Email can not be blank."},
-		"role":       {"Role is not in the list [SYSTEM_ADMIN, PROGRAM_ADMIN]."},
+		"role":       {"Role is not in the list [SYSTEM_ADMIN PROGRAM_ADMIN]."},
 	}
 
 	suite.verifyValidationErrors(newAdminUser, expErrors)

--- a/pkg/models/user_test.go
+++ b/pkg/models/user_test.go
@@ -99,7 +99,6 @@ func (suite *ModelSuite) TestFetchUserIdentity() {
 	suite.Nil(err, "loading alice's identity")
 	suite.NotNil(identity)
 	suite.Equal(alice.ID, identity.ID)
-	suite.False(identity.IsSuperuser)
 	suite.Equal(alice.LoginGovEmail, identity.Email)
 	suite.Nil(identity.ServiceMemberID)
 	suite.Nil(identity.OfficeUserID)
@@ -110,7 +109,6 @@ func (suite *ModelSuite) TestFetchUserIdentity() {
 	suite.Nil(err, "loading bob's identity")
 	suite.NotNil(identity)
 	suite.Equal(bob.UserID, identity.ID)
-	suite.False(identity.IsSuperuser)
 	suite.Equal(bob.User.LoginGovEmail, identity.Email)
 	suite.Equal(bob.ID, *identity.ServiceMemberID)
 	suite.Nil(identity.OfficeUserID)
@@ -121,7 +119,6 @@ func (suite *ModelSuite) TestFetchUserIdentity() {
 	suite.Nil(err, "loading carol's identity")
 	suite.NotNil(identity)
 	suite.Equal(*carol.UserID, identity.ID)
-	suite.False(identity.IsSuperuser)
 	suite.Equal(carol.User.LoginGovEmail, identity.Email)
 	suite.Nil(identity.ServiceMemberID)
 	suite.Equal(carol.ID, *identity.OfficeUserID)
@@ -132,23 +129,17 @@ func (suite *ModelSuite) TestFetchUserIdentity() {
 	suite.Nil(err, "loading danielle's identity")
 	suite.NotNil(identity)
 	suite.Equal(*danielle.UserID, identity.ID)
-	suite.False(identity.IsSuperuser)
 	suite.Equal(danielle.User.LoginGovEmail, identity.Email)
 	suite.Nil(identity.ServiceMemberID)
 	suite.Nil(identity.OfficeUserID)
 	suite.Equal(danielle.ID, *identity.TspUserID)
 
-	superuser := testdatagen.MakeUser(suite.DB(), testdatagen.Assertions{
-		User: User{
-			IsSuperuser: true,
-		},
-	})
-	identity, err = FetchUserIdentity(suite.DB(), superuser.LoginGovUUID.String())
-	suite.Nil(err, "loading superuser's identity")
+	systemAdmin := testdatagen.MakeDefaultAdminUser(suite.DB())
+	identity, err = FetchUserIdentity(suite.DB(), systemAdmin.User.LoginGovUUID.String())
+	suite.Nil(err, "loading systemAdmin's identity")
 	suite.NotNil(identity)
-	suite.Equal(superuser.ID, identity.ID)
-	suite.True(identity.IsSuperuser)
-	suite.Equal(superuser.LoginGovEmail, identity.Email)
+	suite.Equal(*systemAdmin.UserID, identity.ID)
+	suite.Equal(systemAdmin.User.LoginGovEmail, identity.Email)
 	suite.Nil(identity.ServiceMemberID)
 	suite.Nil(identity.OfficeUserID)
 	suite.Nil(identity.TspUserID)
@@ -176,14 +167,11 @@ func (suite *ModelSuite) TestFetchAppUserIdentities() {
 			suite.NotNil(identities[0].ServiceMemberID)
 			suite.Nil(identities[0].OfficeUserID)
 			suite.Nil(identities[0].TspUserID)
-			suite.False(identities[0].IsSuperuser)
 		}
 
 		// Service member is super user
 		testdatagen.MakeServiceMember(suite.DB(), testdatagen.Assertions{
-			User: User{
-				IsSuperuser: true,
-			},
+			User: User{},
 		})
 		identities, err = FetchAppUserIdentities(suite.DB(), auth.MilApp, 5)
 		suite.NoError(err)
@@ -194,7 +182,6 @@ func (suite *ModelSuite) TestFetchAppUserIdentities() {
 			suite.NotNil(identities[1].ServiceMemberID)
 			suite.Nil(identities[1].OfficeUserID)
 			suite.Nil(identities[1].TspUserID)
-			suite.True(identities[1].IsSuperuser)
 		}
 	})
 
@@ -212,7 +199,6 @@ func (suite *ModelSuite) TestFetchAppUserIdentities() {
 			suite.Nil(identities[0].ServiceMemberID)
 			suite.NotNil(identities[0].OfficeUserID)
 			suite.Nil(identities[0].TspUserID)
-			suite.False(identities[0].IsSuperuser)
 		}
 	})
 
@@ -227,7 +213,21 @@ func (suite *ModelSuite) TestFetchAppUserIdentities() {
 			suite.Nil(identities[0].ServiceMemberID)
 			suite.Nil(identities[0].OfficeUserID)
 			suite.NotNil(identities[0].TspUserID)
-			suite.False(identities[0].IsSuperuser)
+		}
+	})
+
+	suite.T().Run("admin user", func(t *testing.T) {
+		testdatagen.MakeDefaultAdminUser(suite.DB())
+		identities, err := FetchAppUserIdentities(suite.DB(), auth.AdminApp, 5)
+		suite.Nil(err)
+		suite.NotEmpty(identities)
+		suite.Equal(1, len(identities))
+
+		if len(identities) > 1 {
+			suite.Nil(identities[0].ServiceMemberID)
+			suite.Nil(identities[0].OfficeUserID)
+			suite.Nil(identities[0].TspUserID)
+			suite.NotNil(identities[0].AdminUserID)
 		}
 	})
 }

--- a/pkg/testdatagen/make_admin_user.go
+++ b/pkg/testdatagen/make_admin_user.go
@@ -1,0 +1,48 @@
+package testdatagen
+
+import (
+	"fmt"
+
+	"github.com/gobuffalo/pop"
+
+	"github.com/transcom/mymove/pkg/models"
+)
+
+// MakeAdminUser creates a single admin user and associated TransportOffice
+func MakeAdminUser(db *pop.Connection, assertions Assertions) models.AdminUser {
+	user := assertions.AdminUser.User
+	// There's a uniqueness constraint on admin user emails so add some randomness
+	email := fmt.Sprintf("admin_%s@example.com", makeRandomString(5))
+
+	if assertions.AdminUser.UserID == nil || isZeroUUID(*assertions.AdminUser.UserID) {
+		if assertions.User.LoginGovEmail == "" {
+			assertions.User.LoginGovEmail = email
+		}
+		user = MakeUser(db, assertions)
+	}
+
+	if assertions.User.LoginGovEmail != "" {
+		email = assertions.User.LoginGovEmail
+	}
+
+	adminUser := models.AdminUser{
+		UserID:    &user.ID,
+		User:      user,
+		FirstName: "Leo",
+		LastName:  "Spaceman",
+		Email:     email,
+		Role:      "SYSTEM_ADMIN",
+		Disabled:  false,
+	}
+
+	mergeModels(&adminUser, assertions.AdminUser)
+
+	mustCreate(db, &adminUser)
+
+	return adminUser
+}
+
+// MakeDefaultAdminUser makes an AdminUser with default values
+func MakeDefaultAdminUser(db *pop.Connection) models.AdminUser {
+	return MakeAdminUser(db, Assertions{})
+}

--- a/pkg/testdatagen/shared.go
+++ b/pkg/testdatagen/shared.go
@@ -23,6 +23,7 @@ import (
 type Assertions struct {
 	AccessCode                               models.AccessCode
 	Address                                  models.Address
+	AdminUser                                models.AdminUser
 	BackupContact                            models.BackupContact
 	BlackoutDate                             models.BlackoutDate
 	DistanceCalculation                      models.DistanceCalculation


### PR DESCRIPTION
## Description

We currently [can't log into](https://docs.google.com/document/d/1Sb6S5bgsqyvfyxJyqLusD5s3n4ZmNDSjdPkEeMrCFYI/edit#) the admin app on dev, experimental, or staging. We're also [not properly authorizing users](https://www.pivotaltracker.com/n/projects/2136866/stories/166656598) for hitting admin app endpoints. The changes in this PR take advantage of the new `admin_users` table to make use of a strategy very similar to what we use to authenticate office users, both unknown (logging in for the first time) and known.

## Reviewer Notes

- How do we feel about the `AdminAuthMiddleware`?
- I've created a secure migration for bootstrapping us with a few system admin users:
  - Risa (the new product person on this feature)
  - Alexi (the original product person on this feature)
  - Me
  - Shall I go ahead and add more? The purpose of this is so we can begin verifying admin stories in staging.

## Setup

- In `local_migrations/20190710174257_add_system_admin_users.sql`, edit one of the insert statements to reflect the email address you use with login.gov.
- `make db_dev_e2e_migrate`
- `make server_run`
- `make client_run`

## Code Review Verification Steps

- Visit `adminlocal:3000`
- Log in via login.gov with the email address you entered in the local migration
- Ensure you don't see an unauthorized page
- Log out
- Login in as an office user, either devlocal or via login.gov
- Attempt to visit `officelocal:3000/admin/v1/office_users` and ensure you hit an `Unauthorized` page


* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/167018198) for this change