### PR TITLE
Add an alert if any of the storage expenses have not been OK'd

### DIFF
--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -98,7 +98,7 @@ const PPMTabContent = props => {
       {props.ppmPaymentRequested && (
         <>
           <ExpensesPanel title="Expenses" moveId={props.moveId} />
-          <StoragePanel title="Storage" moveId={props.moveId} />
+          <StoragePanel title="Storage" moveId={props.moveId} moveDocuments={props.moveDocuments} />
           <DatesAndLocationPanel title="Dates & Locations" moveId={props.moveId} />
           <NetWeightPanel title="Weights" moveId={props.moveId} />
         </>
@@ -429,7 +429,11 @@ class MoveInfo extends Component {
                   <BasicsTabContent moveId={this.props.moveId} serviceMember={this.props.serviceMember} />
                 </PrivateRoute>
                 <PrivateRoute path={`${this.props.match.path}/ppm`}>
-                  <PPMTabContent moveId={this.props.moveId} ppmPaymentRequested={ppmPaymentRequested} />
+                  <PPMTabContent
+                    moveId={this.props.moveId}
+                    ppmPaymentRequested={ppmPaymentRequested}
+                    moveDocuments={moveDocuments}
+                  />
                 </PrivateRoute>
                 <PrivateRoute path={`${this.props.match.path}/hhg`}>
                   {this.props.shipment && (

--- a/src/scenes/Office/Ppm/StoragePanel.js
+++ b/src/scenes/Office/Ppm/StoragePanel.js
@@ -13,9 +13,9 @@ import { formatCents } from '../../../shared/formatters';
 import { convertDollarsToCents } from '../../../shared/utils';
 
 const StorageDisplay = props => {
-  let cost = props.ppm && props.ppm.total_sit_cost ? formatCents(props.ppm.total_sit_cost) : 0;
-  let days = props.ppm && props.ppm.days_in_storage ? props.ppm.days_in_storage : 0;
-  let awaitingStorageExpenses = filter(props.storageExpenses, function(expense) {
+  const cost = props.ppm && props.ppm.total_sit_cost ? formatCents(props.ppm.total_sit_cost) : 0;
+  const days = props.ppm && props.ppm.days_in_storage ? props.ppm.days_in_storage : 0;
+  const awaitingStorageExpenses = filter(props.storageExpenses, function(expense) {
     return expense.status !== 'OK';
   });
 

--- a/src/scenes/Office/Ppm/StoragePanel.js
+++ b/src/scenes/Office/Ppm/StoragePanel.js
@@ -85,7 +85,6 @@ StoragePanel = reduxForm({
 function mapStateToProps(state, props) {
   const formValues = getFormValues(formName)(state);
   const ppm = selectPPMForMove(state, props.moveId);
-  const moveDocuments = props.moveDocuments;
 
   return {
     // reduxForm
@@ -94,7 +93,7 @@ function mapStateToProps(state, props) {
       total_sit_cost: formatCents(ppm.total_sit_cost),
       days_in_storage: ppm.days_in_storage,
     },
-    storageExpenses: filter(moveDocuments, ['moving_expense_type', 'STORAGE']),
+    storageExpenses: filter(props.moveDocuments, ['moving_expense_type', 'STORAGE']),
     ppmSchema: get(state, 'swaggerInternal.spec.definitions.PersonallyProcuredMovePayload'),
     ppm,
 

--- a/src/scenes/Office/Ppm/StoragePanel.test.js
+++ b/src/scenes/Office/Ppm/StoragePanel.test.js
@@ -1,0 +1,43 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import store from 'shared/store';
+import { mount } from 'enzyme';
+
+import StoragePanel from './StoragePanel';
+import Alert from 'shared/Alert';
+import { PanelSwaggerField } from 'shared/EditablePanel';
+
+describe('StoragePanel', () => {
+  describe('Receipts Awaiting Review Alert', () => {
+    it('is non-existent when all receipts have OK status', () => {
+      const moveDocuments = [
+        { moving_expense_type: 'STORAGE', status: 'OK' },
+        { moving_expense_type: 'STORAGE', status: 'OK' },
+      ];
+      const moveId = 'some ID';
+
+      const wrapper = mount(
+        <Provider store={store}>
+          <StoragePanel title="Storage" moveId={moveId} moveDocuments={moveDocuments} />
+        </Provider>,
+      );
+      expect(wrapper.find(PanelSwaggerField)).toHaveLength(2);
+      expect(wrapper.find(Alert)).toHaveLength(0);
+    });
+    it('is existent when any receipt does not have an have OK status', () => {
+      const moveDocuments = [
+        { moving_expense_type: 'STORAGE', status: 'OK' },
+        { moving_expense_type: 'STORAGE', status: 'HAS_ISSUE' },
+      ];
+      const moveId = 'some ID';
+
+      const wrapper = mount(
+        <Provider store={store}>
+          <StoragePanel title="Storage" moveId={moveId} moveDocuments={moveDocuments} />
+        </Provider>,
+      );
+      expect(wrapper.find(PanelSwaggerField)).toHaveLength(2);
+      expect(wrapper.find(Alert)).toHaveLength(1);
+    });
+  });
+});

--- a/src/scenes/Office/office.scss
+++ b/src/scenes/Office/office.scss
@@ -248,6 +248,10 @@ head .panel-subhead {
   margin-top: 0;
 }
 
+.editable-panel-column .awaiting-storage-expenses-warning {
+  margin-bottom: 20px;
+}
+
 .usa-input.duty-station p {
   margin-bottom: 0;
 }


### PR DESCRIPTION
## Setup

Request payment as `ppm@requestingpay.ment` with several storage expenses. Find that move as an office user. Verify there's an alert in the storage panel. Verify it goes away when all storage expenses have been OK'd

```sh
make server_run
make client_run
make office_client_run
```

## Code Review Verification Steps
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/167107960) for this change

## Screenshots
![Screen Shot 2019-07-11 at 11 44 19 AM](https://user-images.githubusercontent.com/6464062/61065395-88cadf80-a3d1-11e9-949b-0cdeabd0083e.png)

