### PR TITLE
Adjust queues for ppm table so they match what's described in the story.

### DIFF
--- a/cypress/integration/office/ppmQueue.js
+++ b/cypress/integration/office/ppmQueue.js
@@ -6,23 +6,8 @@ describe('Office ppm queue', () => {
   });
 
   it('does not have a GBL column', checkForGBLColumn);
-  it('shows a clock icon for records with PAYMENT_REQUESTED or SUBMITTED status', checkIcons);
 });
 
 function checkForGBLColumn() {
   cy.contains('GBL').should('not.exist');
-}
-
-function checkIcons() {
-  cy.wait(1000);
-  cy.get('[data-cy=ppm-queue-icon]').each((el, index, list) => {
-    cy
-      .wrap(el)
-      .closest('.rt-td')
-      .next('.rt-td')
-      .find('[data-cy=status]')
-      .should(status => {
-        expect(status.text()).to.match(/Payment requested|Submitted/);
-      });
-  });
 }

--- a/pkg/models/queue.go
+++ b/pkg/models/queue.go
@@ -92,11 +92,15 @@ func GetMoveQueueItems(db *pop.Connection, lifecycleState string) ([]MoveQueueIt
 				ppm.updated_at as last_modified_date,
 				moves.status as status,
 				ppm.status as ppm_status,
-				shipment.gbl_number as gbl_number
+				shipment.gbl_number as gbl_number,
+				origin_duty_station.name as origin_duty_station_name,
+				destination_duty_station.name as destination_duty_station_name
 			FROM moves
 			JOIN orders as ord ON moves.orders_id = ord.id
 			JOIN service_members AS sm ON ord.service_member_id = sm.id
 			JOIN personally_procured_moves AS ppm ON moves.id = ppm.move_id
+			JOIN duty_stations as origin_duty_station ON sm.duty_station_id = origin_duty_station.id
+			JOIN duty_stations as destination_duty_station ON ord.new_duty_station_id = destination_duty_station.id
 			LEFT JOIN shipments AS shipment ON moves.id = shipment.move_id
 			WHERE moves.show is true
 			and ppm.status in ('APPROVED', 'PAYMENT_REQUESTED', 'COMPLETED')

--- a/src/scenes/Office/QueueList.jsx
+++ b/src/scenes/Office/QueueList.jsx
@@ -20,7 +20,7 @@ export default class QueueList extends Component {
           </li>
           <li>
             <NavLink to="/queues/ppm" activeClassName="usa-current" data-cy="ppm-queue">
-              <span>PPMs</span>
+              <span>PPM Shipments</span>
             </NavLink>
           </li>
           <li>

--- a/src/scenes/Office/QueueTable.jsx
+++ b/src/scenes/Office/QueueTable.jsx
@@ -118,7 +118,7 @@ class QueueTable extends Component {
     const titles = {
       new: 'New Moves/Shipments',
       troubleshooting: 'Troubleshooting',
-      ppm: 'PPMs',
+      ppm: 'PPM Shipments',
       hhg_active: 'Active HHGs',
       hhg_delivered: 'Delivered HHGs',
       all: 'All Moves',

--- a/src/scenes/Office/queueTableColumns.js
+++ b/src/scenes/Office/queueTableColumns.js
@@ -16,25 +16,6 @@ const CreateReactTableColumn = (header, accessor, options = {}) => ({
   ...options,
 });
 
-const clockIcon = CreateReactTableColumn(
-  <FontAwesomeIcon icon={faClock} />,
-  row => {
-    return row.synthetic_status === 'SUBMITTED' || row.synthetic_status === 'PAYMENT_REQUESTED' ? 'CLOCK' : 'NONE';
-  },
-  {
-    id: 'clockIcon',
-    Cell: row =>
-      row.value === 'CLOCK' ? (
-        <span data-cy="ppm-queue-icon">
-          <FontAwesomeIcon icon={faClock} className="clock-icon" />
-        </span>
-      ) : (
-        ''
-      ),
-    width: 50,
-  },
-);
-
 const status = CreateReactTableColumn('Status', 'synthetic_status', {
   Cell: row => (
     <span className="status" data-cy="status">
@@ -72,7 +53,7 @@ const locator = CreateReactTableColumn('Locator #', 'locator', {
 
 const gbl = CreateReactTableColumn('GBL #', 'gbl_number');
 
-const moveDate = CreateReactTableColumn('Move date', 'move_date', {
+const moveDate = CreateReactTableColumn('PPM start', 'move_date', {
   Cell: row => <span className="move_date">{formatDate(row.value)}</span>,
 });
 
@@ -207,7 +188,7 @@ export const newColumns = [
   submittedDate,
 ];
 
-export const ppmColumns = [clockIcon, status, customerName, dodId, rank, locator, moveDate, lastModifiedDate];
+export const ppmColumns = [status, customerName, origin, destination, dodId, locator, moveDate, lastModifiedDate];
 
 export const hhgActiveColumns = [
   needsAttentionClockIcon,


### PR DESCRIPTION
## Description

Arranges the columns in the PPM part of the office queue site so that they match the story. Columns include:
```
 - PPM status
 - Customer name
 - Origin
 - Destination
 - DOD ID
 - Locator #
 - PPM start
 - Last modified
```

## Setup

```sh
make db_dev_e2e_populate
```

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/tree/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/tree/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/tree/master/docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
  * [ ] Secure migrations have been tested using `scripts/run-prod-migrations`
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/166648594) for this change

## Screenshots

<img width="1678" alt="image" src="https://user-images.githubusercontent.com/4325613/61139373-d35e6180-a48e-11e9-8298-e174e2b7e93b.png">
