### PR TITLE
Use NoError instead of Nil

### DIFF
--- a/pkg/auth/authentication/auth_test.go
+++ b/pkg/auth/authentication/auth_test.go
@@ -148,7 +148,7 @@ func (suite *AuthSuite) TestAuthorizationLogoutHandler() {
 	params := redirectURL.Query()
 
 	postRedirectURI, err := url.Parse(params["post_logout_redirect_uri"][0])
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.Equal(OfficeTestHost, postRedirectURI.Hostname())
 	suite.Equal(strconv.Itoa(callbackPort), postRedirectURI.Port())
 	token := params["id_token_hint"][0]

--- a/pkg/awardqueue/awardqueue_test.go
+++ b/pkg/awardqueue/awardqueue_test.go
@@ -319,7 +319,7 @@ func (suite *AwardQueueSuite) Test_OfferSingleShipment() {
 			QualityBand:                     swag.Int(1),
 		},
 	})
-	suite.Nil(err)
+	suite.NoError(err)
 
 	// Run the Award Queue
 	offer, err := queue.attemptShipmentOffer(context.Background(), shipment)
@@ -389,7 +389,7 @@ func (suite *AwardQueueSuite) Test_FailOfferingSingleShipment() {
 		},
 	})
 
-	suite.Nil(err)
+	suite.NoError(err)
 
 	// Run the Award Queue
 	offer, err := queue.attemptShipmentOffer(context.Background(), shipment)
@@ -790,7 +790,7 @@ func (suite *AwardQueueSuite) Test_validateShipmentForAward() {
 		Shipment: models.Shipment{},
 	})
 	err := validateShipmentForAward(shipment)
-	suite.Nil(err)
+	suite.NoError(err)
 
 	// A shipment with a nil TDL ID
 	shipment = testdatagen.MakeShipment(suite.DB(), testdatagen.Assertions{

--- a/pkg/certs/certs_test.go
+++ b/pkg/certs/certs_test.go
@@ -69,5 +69,5 @@ func (suite *certTestSuite) TestDODCertificates() {
 
 	suite.Setup(cli.InitCertFlags, []string{})
 	_, _, err := InitDoDCertificates(suite.viper, suite.logger)
-	suite.Nil(err)
+	suite.NoError(err)
 }

--- a/pkg/cli/aws_test.go
+++ b/pkg/cli/aws_test.go
@@ -16,7 +16,7 @@ func (suite *cliTestSuite) TestConfigAWS() {
 	}
 	suite.Setup(InitAWSFlags, flagSet)
 	region, err := CheckAWSRegion(suite.viper)
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.Equal(endpoints.UsWest2RegionID, region)
 }
 
@@ -24,16 +24,16 @@ func (suite *cliTestSuite) TestCheckAWSRegionForService() {
 	region := endpoints.UsWest2RegionID
 
 	err := CheckAWSRegionForService(region, cloudwatchevents.ServiceName)
-	suite.Nil(err)
+	suite.NoError(err)
 
 	err = CheckAWSRegionForService(region, ecs.ServiceName)
-	suite.Nil(err)
+	suite.NoError(err)
 
 	// This service is not listed in endpoints.AwsPartition().Services()
 	// Want this to pass anyway
 	err = CheckAWSRegionForService(region, ecr.ServiceName)
-	suite.Nil(err)
+	suite.NoError(err)
 
 	err = CheckAWSRegionForService(region, rds.ServiceName)
-	suite.Nil(err)
+	suite.NoError(err)
 }

--- a/pkg/cli/dbconn_test.go
+++ b/pkg/cli/dbconn_test.go
@@ -18,6 +18,6 @@ func (suite *cliTestSuite) TestInitDatabase() {
 
 	suite.Setup(InitDatabaseFlags, []string{})
 	conn, err := InitDatabase(suite.viper, suite.logger)
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.NotNil(conn)
 }

--- a/pkg/db/dbfmt/dbfmt_test.go
+++ b/pkg/db/dbfmt/dbfmt_test.go
@@ -33,7 +33,7 @@ func (suite *DBFmtSuite) TestTheDBFmt() {
 
 	move = models.Move{}
 	err := suite.DB().Eager("Orders.Moves").Find(&move, moveID.String())
-	suite.Nil(err)
+	suite.NoError(err)
 
 	littlemove := move.Orders.Moves[0]
 	move.Orders.Moves = append(move.Orders.Moves, littlemove)

--- a/pkg/handlers/dpsapi/authentication_test.go
+++ b/pkg/handlers/dpsapi/authentication_test.go
@@ -40,7 +40,7 @@ func (suite *HandlerSuite) TestGetUserHandler() {
 	serviceMember := testdatagen.MakeServiceMember(suite.DB(), assertions)
 	loginGovID := serviceMember.User.LoginGovUUID.String()
 	cookie, err := dpsauth.LoginGovIDToCookie(loginGovID, dpsParams.CookieSecret, dpsParams.CookieExpires)
-	suite.Nil(err)
+	suite.NoError(err)
 
 	request := httptest.NewRequest("GET", "/dps/v0/authentication/user", nil)
 	params := dps.GetUserParams{Token: cookie.Value}

--- a/pkg/handlers/internalapi/move_dates_test.go
+++ b/pkg/handlers/internalapi/move_dates_test.go
@@ -241,7 +241,7 @@ func (suite *HandlerSuite) TestCalculateMoveDatesFromShipment() {
 	for _, testCase := range cases {
 		suite.T().Run(testCase.name, func(t *testing.T) {
 			summary, err := calculateMoveDatesFromShipment(&testCase.shipment)
-			suite.Nil(err)
+			suite.NoError(err)
 			suite.Equal(testCase.summary.PackDays, summary.PackDays, "%v: PackDays did not match, expected %v, got %v", testCase.name, testCase.summary.PackDays, summary.PackDays)
 			suite.Equal(testCase.summary.PickupDays, summary.PickupDays, "%v: PickupDays did not match, expected %v, got %v", testCase.name, testCase.summary.PickupDays, summary.PickupDays)
 			suite.Equal(testCase.summary.TransitDays, summary.TransitDays, "%v: TransitDays did not match, expected %v, got %v", testCase.name, testCase.summary.TransitDays, summary.TransitDays)

--- a/pkg/handlers/internalapi/move_documents_test.go
+++ b/pkg/handlers/internalapi/move_documents_test.go
@@ -158,7 +158,7 @@ func (suite *HandlerSuite) TestIndexWeightTicketSetDocumentsHandlerNoMissingFiel
 		TrailerOwnershipMissing:  false,
 	}
 	verrs, err := suite.DB().ValidateAndCreate(&weightTicketSetDocument)
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.False(verrs.HasAny())
 
 	request := httptest.NewRequest("POST", "/fake/path", nil)
@@ -220,7 +220,7 @@ func (suite *HandlerSuite) TestIndexWeightTicketSetDocumentsHandlerMissingFields
 		TrailerOwnershipMissing:  false,
 	}
 	verrs, err := suite.DB().ValidateAndCreate(&weightTicketSetDocument)
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.False(verrs.HasAny())
 
 	request := httptest.NewRequest("POST", "/fake/path", nil)

--- a/pkg/handlers/internalapi/office_test.go
+++ b/pkg/handlers/internalapi/office_test.go
@@ -31,7 +31,7 @@ func (suite *HandlerSuite) TestApproveMoveHandler() {
 
 	// Move is submitted and saved
 	err := move.Submit(time.Now())
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.Equal(models.MoveStatusSUBMITTED, move.Status, "expected Submitted")
 	suite.MustSave(&move)
 
@@ -63,7 +63,7 @@ func (suite *HandlerSuite) TestApproveMoveHandlerIncompleteOrders() {
 
 	// Move is submitted and saved
 	err := move.Submit(time.Now())
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.Equal(models.MoveStatusSUBMITTED, move.Status, "expected Submitted")
 	suite.MustSave(&move)
 
@@ -115,19 +115,19 @@ func (suite *HandlerSuite) TestCancelMoveHandler() {
 		Show:         swag.Bool(true),
 	}
 	move, verrs, err := orders.CreateNewMove(suite.DB(), moveOptions)
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.False(verrs.HasAny(), "failed to validate move")
 	officeUser := testdatagen.MakeDefaultOfficeUser(suite.DB())
-	suite.Nil(err)
+	suite.NoError(err)
 
 	// Move is submitted
 	err = move.Submit(time.Now())
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.Equal(models.MoveStatusSUBMITTED, move.Status, "expected Submitted")
 
 	// And: Orders are submitted and saved on move
 	err = orders.Submit()
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.Equal(models.OrderStatusSUBMITTED, orders.Status, "expected Submitted")
 	suite.MustSave(&orders)
 	move.Orders = orders

--- a/pkg/handlers/internalapi/weight_ticket_set_documents_test.go
+++ b/pkg/handlers/internalapi/weight_ticket_set_documents_test.go
@@ -69,10 +69,10 @@ func (suite *HandlerSuite) TestCreateWeightTicketSetDocumentHandler() {
 
 	var fetchedMoveDocument models.MoveDocument
 	err := suite.DB().Q().Where("move_id = ?", ppm.MoveID).First(&fetchedMoveDocument)
-	suite.Nil(err)
+	suite.NoError(err)
 	var fetchedWeightTicket models.WeightTicketSetDocument
 	err = suite.DB().Q().Where("move_document_id = ?", fetchedMoveDocument.ID).First(&fetchedWeightTicket)
-	suite.Nil(err)
+	suite.NoError(err)
 
 	// Wrong user
 	wrongUser := testdatagen.MakeDefaultServiceMember(suite.DB())

--- a/pkg/handlers/publicapi/invoices_test.go
+++ b/pkg/handlers/publicapi/invoices_test.go
@@ -60,7 +60,7 @@ func (suite *HandlerSuite) TestGetInvoiceHandler() {
 	response = handler.Handle(params)
 
 	// Then: Invoice is returned
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.Assertions.IsType(&accessorialop.GetInvoiceOK{}, response)
 	okResponse := response.(*accessorialop.GetInvoiceOK)
 	suite.Equal(strfmt.UUID(invoice.ID.String()), okResponse.Payload.ID)
@@ -74,7 +74,7 @@ func (suite *HandlerSuite) TestGetInvoiceHandler() {
 	response = handler.Handle(params)
 
 	// Then: Invoice is returned
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.Assertions.IsType(&accessorialop.GetInvoiceOK{}, response)
 	okResponse = response.(*accessorialop.GetInvoiceOK)
 	suite.Equal(strfmt.UUID(invoice.ID.String()), okResponse.Payload.ID)

--- a/pkg/handlers/publicapi/shipments_test.go
+++ b/pkg/handlers/publicapi/shipments_test.go
@@ -42,7 +42,7 @@ func (suite *HandlerSuite) TestPayloadForShipmentModelWhenTspIDIsPresent() {
 		},
 	})
 	reloadShipment, err := models.FetchShipmentByTSP(suite.DB(), tsp.ID, shipment.ID)
-	suite.Nil(err)
+	suite.NoError(err)
 
 	shipmentPayload := payloadForShipmentModel(*reloadShipment)
 	expectedTspID := *handlers.FmtUUID(tsp.ID)

--- a/pkg/iws/rbs_edi_test.go
+++ b/pkg/iws/rbs_edi_test.go
@@ -4,7 +4,7 @@ import "net/url"
 
 func (suite *iwsSuite) TestBuildEdiURL() {
 	urlString, err := buildEdiURL("example.com", "1234", 1234567890)
-	suite.Nil(err)
+	suite.NoError(err)
 	parsedURL, parseErr := url.Parse(urlString)
 	suite.Nil(parseErr)
 	suite.Equal("https", parsedURL.Scheme)
@@ -52,7 +52,7 @@ func (suite *iwsSuite) TestParseEdiResponse() {
 		</adrRecord>
 	</record>`
 	person, personnel, err := parseEdiResponse([]byte(data))
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.NotNil(person)
 	suite.Equal("xxxx12345", person.ID)
 	suite.NotEmpty(personnel)

--- a/pkg/iws/rbs_pids_test.go
+++ b/pkg/iws/rbs_pids_test.go
@@ -46,7 +46,7 @@ func (suite *iwsSuite) TestParsePidsResponse() {
 	</record>`
 
 	reason, edipi, person, personnel, err := parsePidsResponse([]byte(data))
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.Equal(MatchReasonCodeFull, reason)
 	suite.Equal(uint64(9995006001), edipi)
 	suite.NotNil(person)
@@ -73,7 +73,7 @@ func (suite *iwsSuite) TestParsePidsResponseError() {
 func (suite *iwsSuite) TestBuildPidsUrl() {
 	urlString, err := buildPidsURL("example.com", "1234", "000000000", "Last", "First")
 	suite.NotEmpty(urlString)
-	suite.Nil(err)
+	suite.NoError(err)
 	parsedURL, parseErr := url.Parse(urlString)
 	suite.Nil(parseErr)
 	suite.Equal("https", parsedURL.Scheme)
@@ -84,7 +84,7 @@ func (suite *iwsSuite) TestBuildPidsUrl() {
 func (suite *iwsSuite) TestBuildPidsUrlLongNames() {
 	urlString, err := buildPidsURL("example.com", "1234", "000000000", "abcdefghijklmnopqrstuvwxyzyxwvutsrqponmlkjihgfedcba", "abcdefghijklmnopqrstuvwxyz")
 	suite.NotEmpty(urlString)
-	suite.Nil(err)
+	suite.NoError(err)
 	parsedURL, parseErr := url.Parse(urlString)
 	suite.Nil(parseErr)
 	suite.Equal("https", parsedURL.Scheme)
@@ -95,7 +95,7 @@ func (suite *iwsSuite) TestBuildPidsUrlLongNames() {
 func (suite *iwsSuite) TestBuildPidsUrlNoFirstName() {
 	urlString, err := buildPidsURL("example.com", "1234", "000000000", "Last", "")
 	suite.NotEmpty(urlString)
-	suite.Nil(err)
+	suite.NoError(err)
 	parsedURL, parseErr := url.Parse(urlString)
 	suite.Nil(parseErr)
 	suite.Equal("https", parsedURL.Scheme)

--- a/pkg/iws/rbs_wkema_test.go
+++ b/pkg/iws/rbs_wkema_test.go
@@ -41,7 +41,7 @@ func (suite *iwsSuite) TestParseWkEmaResponse() {
 	  </adrRecord>
 	</record>`
 	edipi, person, personnel, err := parseWkEmaResponse([]byte(data))
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.Equal(uint64(9995006001), edipi)
 	suite.NotNil(person)
 	suite.NotEmpty(personnel)
@@ -67,7 +67,7 @@ func (suite *iwsSuite) TestParseWkEmaResponseError() {
 func (suite *iwsSuite) TestBuildWkEmaURL() {
 	urlString, err := buildWkEmaURL("example.com", "1234", "test@example.com")
 	suite.NotEmpty(urlString)
-	suite.Nil(err)
+	suite.NoError(err)
 	parsedURL, parseErr := url.Parse(urlString)
 	suite.Nil(parseErr)
 	suite.Equal("https", parsedURL.Scheme)
@@ -84,7 +84,7 @@ func (suite *iwsSuite) TestBuildWkEmaURLEmailInvalid() {
 func (suite *iwsSuite) TestBuildWkEmaURLLongEmail() {
 	urlString, err := buildWkEmaURL("example.com", "1234", "pneumonoultramicroscopicsilicovolcanoconiosis_is_a_terrible_way_to_expire@unpronounceablediseases.org")
 	suite.NotEmpty(urlString)
-	suite.Nil(err)
+	suite.NoError(err)
 	parsedURL, parseErr := url.Parse(urlString)
 	suite.Nil(parseErr)
 	suite.Equal("https", parsedURL.Scheme)

--- a/pkg/middleware/limit_body_size_test.go
+++ b/pkg/middleware/limit_body_size_test.go
@@ -13,7 +13,7 @@ func (suite *testSuite) TestLimitBodySizeValid() {
 	suite.do(mw, suite.reflect, rr, httptest.NewRequest("GET", testURL, strings.NewReader("foobar")))
 	suite.Equal(http.StatusOK, rr.Code, errStatusCode) // check status code
 	body, err := ioutil.ReadAll(rr.Body)
-	suite.Nil(err)                               // check that you could read full body
+	suite.NoError(err)                           // check that you could read full body
 	suite.Equal("foobar", string(body), errBody) // check body
 }
 
@@ -23,6 +23,6 @@ func (suite *testSuite) TestLimitBodySizeInvalid() {
 	suite.do(mw, suite.reflect, rr, httptest.NewRequest("GET", testURL, strings.NewReader("foobar")))
 	suite.Equal(http.StatusBadRequest, rr.Code, errStatusCode) // check status code
 	body, err := ioutil.ReadAll(rr.Body)
-	suite.Nil(err)                                                                  // check that you could read full body
+	suite.NoError(err)                                                              // check that you could read full body
 	suite.Equal(http.StatusText(http.StatusBadRequest)+"\n", string(body), errBody) // check body
 }

--- a/pkg/middleware/recovery_test.go
+++ b/pkg/middleware/recovery_test.go
@@ -21,6 +21,6 @@ func (suite *testSuite) TestRecoveryPanic() {
 	suite.do(mw, suite.panic, rr, httptest.NewRequest("GET", testURL, nil))
 	suite.Equal(http.StatusInternalServerError, rr.Code, errStatusCode) // check status code
 	body, err := ioutil.ReadAll(rr.Body)
-	suite.Nil(err)                         // check that you could read full body
+	suite.NoError(err)                     // check that you could read full body
 	suite.Equal("", string(body), errBody) // check body (body was written before panic)
 }

--- a/pkg/middleware/trace_test.go
+++ b/pkg/middleware/trace_test.go
@@ -15,7 +15,7 @@ func (suite *testSuite) TestTrace() {
 	suite.do(mw, suite.trace, rr, httptest.NewRequest("GET", testURL, nil))
 	suite.Equal(http.StatusOK, rr.Code, errStatusCode) // check status code
 	body, err := ioutil.ReadAll(rr.Body)
-	suite.Nil(err)               // check that you could read full body
+	suite.NoError(err)           // check that you could read full body
 	suite.NotEmpty(string(body)) // check that handler returned the trace id
 	id, err := uuid.FromString(string(body))
 	suite.Nil(err, "failed to parse UUID")

--- a/pkg/middleware/valid_methods_static_test.go
+++ b/pkg/middleware/valid_methods_static_test.go
@@ -27,7 +27,7 @@ func (suite *testSuite) TestValidMethodStaticPost() {
 	suite.do(mw, suite.ok, rr, httptest.NewRequest("POST", testURL, nil))
 	suite.Equal(http.StatusMethodNotAllowed, rr.Code, errStatusCode) // check status code
 	body, err := ioutil.ReadAll(rr.Body)
-	suite.Nil(err)                                                                        // check that you could read full body
+	suite.NoError(err)                                                                    // check that you could read full body
 	suite.Equal(http.StatusText(http.StatusMethodNotAllowed)+"\n", string(body), errBody) // check body
 }
 
@@ -37,7 +37,7 @@ func (suite *testSuite) TestValidMethodStaticPut() {
 	suite.do(mw, suite.ok, rr, httptest.NewRequest("PUT", testURL, nil))
 	suite.Equal(http.StatusMethodNotAllowed, rr.Code, errStatusCode) // check status code
 	body, err := ioutil.ReadAll(rr.Body)
-	suite.Nil(err)                                                                        // check that you could read full body
+	suite.NoError(err)                                                                    // check that you could read full body
 	suite.Equal(http.StatusText(http.StatusMethodNotAllowed)+"\n", string(body), errBody) // check body
 }
 
@@ -47,7 +47,7 @@ func (suite *testSuite) TestValidMethodStaticPatch() {
 	suite.do(mw, suite.ok, rr, httptest.NewRequest("PATCH", testURL, nil))
 	suite.Equal(http.StatusMethodNotAllowed, rr.Code, errStatusCode) // check status code
 	body, err := ioutil.ReadAll(rr.Body)
-	suite.Nil(err)                                                                        // check that you could read full body
+	suite.NoError(err)                                                                    // check that you could read full body
 	suite.Equal(http.StatusText(http.StatusMethodNotAllowed)+"\n", string(body), errBody) // check body
 }
 
@@ -57,6 +57,6 @@ func (suite *testSuite) TestValidMethodStaticDelete() {
 	suite.do(mw, suite.ok, rr, httptest.NewRequest("DELETE", testURL, nil))
 	suite.Equal(http.StatusMethodNotAllowed, rr.Code, errStatusCode) // check status code
 	body, err := ioutil.ReadAll(rr.Body)
-	suite.Nil(err)                                                                        // check that you could read full body
+	suite.NoError(err)                                                                    // check that you could read full body
 	suite.Equal(http.StatusText(http.StatusMethodNotAllowed)+"\n", string(body), errBody) // check body
 }

--- a/pkg/models/client_cert_test.go
+++ b/pkg/models/client_cert_test.go
@@ -20,7 +20,7 @@ func (suite *ModelSuite) Test_FetchClientCert() {
 	suite.MustSave(&certNew)
 
 	cert, err := models.FetchClientCert(suite.DB(), digest)
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.Equal(cert.Sha256Digest, digest)
 	suite.Equal(cert.Subject, subject)
 }

--- a/pkg/models/dps_users_test.go
+++ b/pkg/models/dps_users_test.go
@@ -43,7 +43,7 @@ func (suite *ModelSuite) TestFetchDPSUserByEmailCaseSensitivity() {
 
 	suite.MustSave(&dpsUser)
 	user, err := models.FetchDPSUserByEmail(suite.DB(), strings.ToLower(email))
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.NotNil(user)
 	suite.Equal(user.LoginGovEmail, email)
 }

--- a/pkg/models/entitlements_test.go
+++ b/pkg/models/entitlements_test.go
@@ -9,18 +9,18 @@ func (suite *ModelSuite) TestGetEntitlementWithValidValues() {
 
 	// When: E1 has dependents and spouse gear
 	E1FullLoad, err := models.GetEntitlement(E1, true, true)
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.Assertions.Equal(10500, E1FullLoad)
 	// When: E1 doesn't have dependents or spouse gear
 	E1Solo, err := models.GetEntitlement(E1, false, false)
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.Assertions.Equal(7000, E1Solo)
 	// When: E1 doesn't have dependents but has spouse gear - impossible state
 	E1FakeSpouse, err := models.GetEntitlement(E1, false, true)
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.Assertions.Equal(7000, E1FakeSpouse)
 	// When: E1 has dependents but no spouse gear
 	E1DivorcedWithKids, err := models.GetEntitlement(E1, true, false)
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.Assertions.Equal(10000, E1DivorcedWithKids)
 }

--- a/pkg/models/invoice_test.go
+++ b/pkg/models/invoice_test.go
@@ -53,7 +53,7 @@ func (suite *ModelSuite) TestFetchInvoice() {
 
 	// Then: invoice is returned
 	extantInvoice, err := FetchInvoice(suite.DB(), session, invoice.ID)
-	suite.Nil(err)
+	suite.NoError(err)
 	if suite.NoError(err) {
 		suite.Equal(extantInvoice.ID, invoice.ID)
 	}
@@ -75,7 +75,7 @@ func (suite *ModelSuite) TestFetchInvoice() {
 	}
 	// Then: invoice is returned
 	extantInvoice, err = FetchInvoice(suite.DB(), session, invoice.ID)
-	suite.Nil(err)
+	suite.NoError(err)
 	if suite.NoError(err) {
 		suite.Equal(extantInvoice.ID, invoice.ID)
 	}

--- a/pkg/models/move_test.go
+++ b/pkg/models/move_test.go
@@ -34,7 +34,7 @@ func (suite *ModelSuite) TestCreateNewMoveValidLocatorString() {
 	move, verrs, err := orders.CreateNewMove(suite.DB(), moveOptions)
 	//move, verrs, err := orders.CreateNewMove(suite.DB(), &selectedMoveType, true)
 
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.False(verrs.HasAny(), "failed to validate move")
 	// Verify valid items are in locator
 	suite.Regexp("^[346789BCDFGHJKMPQRTVWXY]+$", move.Locator)
@@ -67,7 +67,7 @@ func (suite *ModelSuite) TestFetchMove() {
 		Show:         swag.Bool(true),
 	}
 	move, verrs, err := order1.CreateNewMove(suite.DB(), moveOptions)
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.False(verrs.HasAny(), "failed to validate move")
 	suite.Equal(6, len(move.Locator))
 
@@ -128,19 +128,19 @@ func (suite *ModelSuite) TestMoveCancellationWithReason() {
 		Show:         swag.Bool(true),
 	}
 	move, verrs, err := orders.CreateNewMove(suite.DB(), moveOptions)
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.False(verrs.HasAny(), "failed to validate move")
 	move.Orders = orders
 	reason := "SM's orders revoked"
 
 	// Check to ensure move shows SUBMITTED before Cancel()
 	err = move.Submit(time.Now())
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.Equal(MoveStatusSUBMITTED, move.Status, "expected Submitted")
 
 	// Can cancel move, and status changes as expected
 	err = move.Cancel(reason)
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.Equal(MoveStatusCANCELED, move.Status, "expected Canceled")
 	suite.Equal(&reason, move.CancelReason, "expected 'SM's orders revoked'")
 
@@ -158,7 +158,7 @@ func (suite *ModelSuite) TestMoveStateMachine() {
 		Show:         swag.Bool(true),
 	}
 	move, verrs, err := orders.CreateNewMove(suite.DB(), moveOptions)
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.False(verrs.HasAny(), "failed to validate move")
 	reason := ""
 	move.Orders = orders
@@ -207,13 +207,13 @@ func (suite *ModelSuite) TestMoveStateMachine() {
 	err = move.Submit(currentTime)
 	suite.MustSave(move)
 	suite.DB().Reload(move)
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.Equal(MoveStatusSUBMITTED, move.Status, "expected Submitted")
 	suite.Equal(PPMStatusSUBMITTED, move.PersonallyProcuredMoves[0].Status, "expected Submitted")
 	suite.Equal(ShipmentStatusSUBMITTED, move.Shipments[0].Status, "expected Submitted")
 	// Can cancel move
 	err = move.Cancel(reason)
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.Equal(MoveStatusCANCELED, move.Status, "expected Canceled")
 	suite.Nil(move.CancelReason)
 }
@@ -231,26 +231,26 @@ func (suite *ModelSuite) TestCancelMoveCancelsOrdersPPM() {
 		Show:         swag.Bool(true),
 	}
 	move, verrs, err := orders.CreateNewMove(suite.DB(), moveOptions)
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.False(verrs.HasAny(), "failed to validate move")
 	move.Orders = orders
 
 	advance := BuildDraftReimbursement(1000, MethodOfReceiptMILPAY)
 
 	ppm, verrs, err := move.CreatePPM(suite.DB(), nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, true, &advance)
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.False(verrs.HasAny())
 
 	// Associate PPM with the move it's on.
 	move.PersonallyProcuredMoves = append(move.PersonallyProcuredMoves, *ppm)
 	err = move.Submit(time.Now())
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.Equal(MoveStatusSUBMITTED, move.Status, "expected Submitted")
 
 	// When move is canceled, expect associated PPM and Order to be canceled
 	reason := "Orders changed"
 	err = move.Cancel(reason)
-	suite.Nil(err)
+	suite.NoError(err)
 
 	suite.Equal(MoveStatusCANCELED, move.Status, "expected Canceled")
 	suite.Equal(PPMStatusCANCELED, move.PersonallyProcuredMoves[0].Status, "expected Canceled")
@@ -269,7 +269,7 @@ func (suite *ModelSuite) TestSaveMoveDependenciesFail() {
 		Show:         swag.Bool(true),
 	}
 	move, verrs, err := orders.CreateNewMove(suite.DB(), moveOptions)
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.False(verrs.HasAny(), "failed to validate move")
 	move.Orders = orders
 
@@ -289,13 +289,13 @@ func (suite *ModelSuite) TestSaveMoveDependenciesSuccess() {
 		Show:         swag.Bool(true),
 	}
 	move, verrs, err := orders.CreateNewMove(suite.DB(), moveOptions)
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.False(verrs.HasAny(), "failed to validate move")
 	move.Orders = orders
 
 	verrs, err = SaveMoveDependencies(suite.DB(), move)
 	suite.False(verrs.HasAny(), "failed to save valid statuses")
-	suite.Nil(err)
+	suite.NoError(err)
 }
 
 func (suite *ModelSuite) TestSaveMoveDependenciesSetsGBLOCSuccess() {
@@ -323,7 +323,7 @@ func (suite *ModelSuite) TestSaveMoveDependenciesSetsGBLOCSuccess() {
 		Show:         swag.Bool(true),
 	}
 	move, verrs, err := orders.CreateNewMove(suite.DB(), moveOptions)
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.False(verrs.HasAny(), "failed to validate move")
 
 	shipment := testdatagen.MakeShipment(suite.DB(), testdatagen.Assertions{
@@ -347,7 +347,7 @@ func (suite *ModelSuite) TestSaveMoveDependenciesSetsGBLOCSuccess() {
 	move.Status = MoveStatusSUBMITTED
 	verrs, err = SaveMoveDependencies(suite.DB(), move)
 	suite.False(verrs.HasAny(), "failed to save valid statuses")
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.DB().Reload(&shipment)
 
 	// Then: Shipment GBLOCs will be equal to:

--- a/pkg/models/office_user_test.go
+++ b/pkg/models/office_user_test.go
@@ -65,7 +65,7 @@ func (suite *ModelSuite) TestFetchOfficeUserByEmail() {
 	suite.MustSave(&newUser)
 
 	user, err = FetchOfficeUserByEmail(suite.DB(), email)
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.NotNil(user)
 	suite.Equal(newUser.ID, user.ID)
 }
@@ -93,7 +93,7 @@ func (suite *ModelSuite) TestFetchOfficeUserByEmailCaseSensitivity() {
 	suite.MustSave(&officeUser)
 
 	user, err := FetchOfficeUserByEmail(suite.DB(), strings.ToLower(userEmail))
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.NotNil(user)
 	suite.Equal(user.Email, userEmail)
 }
@@ -115,7 +115,7 @@ func (suite *ModelSuite) TestFetchOfficeUserByID() {
 	suite.MustSave(&newUser)
 
 	user, err = FetchOfficeUserByID(suite.DB(), newUser.ID)
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.NotNil(user)
 	suite.Equal(newUser.ID, user.ID)
 }

--- a/pkg/models/order_test.go
+++ b/pkg/models/order_test.go
@@ -187,12 +187,12 @@ func (suite *ModelSuite) TestOrderStateMachine() {
 
 	// Submit Orders
 	err := order.Submit()
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.Equal(OrderStatusSUBMITTED, order.Status, "expected Submitted")
 
 	// Can cancel orders
 	err = order.Cancel()
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.Equal(OrderStatusCANCELED, order.Status, "expected Canceled")
 }
 
@@ -236,17 +236,17 @@ func (suite *ModelSuite) TestCanceledMoveCancelsOrder() {
 		Show:         swag.Bool(true),
 	}
 	move, verrs, err := orders.CreateNewMove(suite.DB(), moveOptions)
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.False(verrs.HasAny(), "failed to validate move")
 	move.Orders = orders
 	suite.MustSave(move)
 
 	err = move.Submit(time.Now())
-	suite.Nil(err)
+	suite.NoError(err)
 
 	reason := "Mistaken identity"
 	err = move.Cancel(reason)
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.Equal(MoveStatusCANCELED, move.Status, "expected Canceled")
 	suite.Equal(OrderStatusCANCELED, move.Orders.Status, "expected Canceled")
 

--- a/pkg/models/personally_procured_move_test.go
+++ b/pkg/models/personally_procured_move_test.go
@@ -26,7 +26,7 @@ func (suite *ModelSuite) TestPPMAdvance() {
 	advance := BuildDraftReimbursement(1000, MethodOfReceiptMILPAY)
 
 	ppm, verrs, err := move.CreatePPM(suite.DB(), nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, true, &advance)
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.False(verrs.HasAny())
 
 	advance.Request()
@@ -37,7 +37,7 @@ func (suite *ModelSuite) TestPPMAdvance() {
 		ServiceMemberID: serviceMember.ID,
 	}
 	fetchedPPM, err := FetchPersonallyProcuredMove(suite.DB(), &session, ppm.ID)
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.Equal(fetchedPPM.Advance.Status, ReimbursementStatusREQUESTED, "expected Requested")
 }
 
@@ -47,7 +47,7 @@ func (suite *ModelSuite) TestPPMAdvanceNoGTCC() {
 	advance := BuildDraftReimbursement(1000, MethodOfReceiptGTCC)
 
 	_, verrs, err := move.CreatePPM(suite.DB(), nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, true, &advance)
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.True(verrs.HasAny())
 }
 
@@ -63,20 +63,20 @@ func (suite *ModelSuite) TestPPMStateMachine() {
 		Show:         swag.Bool(true),
 	}
 	move, verrs, err := orders.CreateNewMove(suite.DB(), moveOptions)
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.False(verrs.HasAny(), "failed to validate move")
 	move.Orders = orders
 
 	advance := BuildDraftReimbursement(1000, MethodOfReceiptMILPAY)
 
 	ppm, verrs, err := move.CreatePPM(suite.DB(), nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, true, &advance)
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.False(verrs.HasAny())
 
 	ppm.Status = PPMStatusSUBMITTED // NEVER do this outside of a test.
 
 	// Can cancel ppm
 	err = ppm.Cancel()
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.Equal(PPMStatusCANCELED, ppm.Status, "expected Canceled")
 }

--- a/pkg/models/queue_test.go
+++ b/pkg/models/queue_test.go
@@ -20,7 +20,7 @@ func (suite *ModelSuite) TestCreateNewMoveShow() {
 		Show:         swag.Bool(true),
 	}
 	_, verrs, err := orders.CreateNewMove(suite.DB(), moveOptions)
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.False(verrs.HasAny(), "failed to validate move")
 
 	moves, moveErrs := GetMoveQueueItems(suite.DB(), "all")
@@ -38,7 +38,7 @@ func (suite *ModelSuite) TestCreateNewMoveShowFalse() {
 		Show:         swag.Bool(false),
 	}
 	_, verrs, err := orders.CreateNewMove(suite.DB(), moveOptions)
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.False(verrs.HasAny(), "failed to validate move")
 
 	moves, moveErrs := GetMoveQueueItems(suite.DB(), "all")
@@ -69,7 +69,7 @@ func (suite *ModelSuite) TestShowPPMQueue() {
 
 	// Expected 3 moves for PPM queue returned
 	moves, err := GetMoveQueueItems(suite.DB(), "ppm")
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.Len(moves, 3)
 }
 
@@ -96,7 +96,7 @@ func (suite *ModelSuite) TestShowPPMQueueStatusDraftSubmittedCanceled() {
 
 	// Expected 0 moves for PPM queue returned
 	moves, err := GetMoveQueueItems(suite.DB(), "ppm")
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.Len(moves, 0)
 }
 
@@ -134,6 +134,6 @@ func (suite *ModelSuite) TestActivePPMQueue() {
 	})
 
 	moves, err := GetMoveQueueItems(suite.DB(), "hhg_active")
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.Len(moves, 3)
 }

--- a/pkg/models/reimbursement_test.go
+++ b/pkg/models/reimbursement_test.go
@@ -12,15 +12,15 @@ func (suite *ModelSuite) TestReimbursementStateMachine() {
 	reimbursement := BuildDraftReimbursement(1200, MethodOfReceiptOTHERDD)
 
 	err := reimbursement.Request()
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.Equal(ReimbursementStatusREQUESTED, reimbursement.Status, "expected Requested")
 
 	err = reimbursement.Approve()
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.Equal(ReimbursementStatusAPPROVED, reimbursement.Status, "expected Approved")
 
 	err = reimbursement.Pay()
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.Equal(ReimbursementStatusPAID, reimbursement.Status, "expected Paid")
 
 	err = reimbursement.Reject()
@@ -45,7 +45,7 @@ func (suite *ModelSuite) TestBasicReimbursement() {
 	reimbursement.Request()
 
 	verrs, err := suite.DB().ValidateAndCreate(&reimbursement)
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.False(verrs.HasAny())
 
 	suite.NotNil(reimbursement.ID)

--- a/pkg/models/shipment_offer_test.go
+++ b/pkg/models/shipment_offer_test.go
@@ -64,7 +64,7 @@ func (suite *ModelSuite) TestShipmentOfferStateMachine() {
 	suite.Nil(shipmentOffer.RejectionReason)
 
 	err := shipmentOffer.Accept()
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.True(*shipmentOffer.Accepted)
 	suite.Nil(shipmentOffer.RejectionReason)
 
@@ -74,7 +74,7 @@ func (suite *ModelSuite) TestShipmentOfferStateMachine() {
 	suite.Nil(shipmentOffer.RejectionReason)
 
 	err = shipmentOffer.Reject("DO NOT WANT")
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.False(*shipmentOffer.Accepted)
 	suite.Equal("DO NOT WANT", *shipmentOffer.RejectionReason)
 }
@@ -83,14 +83,14 @@ func (suite *ModelSuite) TestAccepted() {
 	// Trying a nil slice of shipment offers.
 	var shipmentOffers ShipmentOffers
 	shipmentOffers, err := shipmentOffers.Accepted()
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.Nil(shipmentOffers)
 
 	// Make a default shipment offer (which shouldn't be accepted).
 	unacceptedOffer := testdatagen.MakeDefaultShipmentOffer(suite.DB())
 	shipmentOffers = ShipmentOffers{unacceptedOffer}
 	shipmentOffers, err = shipmentOffers.Accepted()
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.Nil(shipmentOffers)
 
 	// Add an accepted shipment to our slice.

--- a/pkg/models/shipment_recalculate_test.go
+++ b/pkg/models/shipment_recalculate_test.go
@@ -68,7 +68,7 @@ func (suite *ModelSuite) TestShipmentRecalculateTooManyActiveRecord() {
 		}
 		verrs, err := suite.DB().ValidateAndCreate(&newRecalculateDates)
 		suite.Empty(verrs.Error())
-		suite.Nil(err)
+		suite.NoError(err)
 
 		id = uuid.Must(uuid.NewV4())
 		newRecalculateDates = models.ShipmentRecalculate{
@@ -78,7 +78,7 @@ func (suite *ModelSuite) TestShipmentRecalculateTooManyActiveRecord() {
 		}
 		verrs, err = suite.DB().ValidateAndCreate(&newRecalculateDates)
 		suite.Empty(verrs.Error())
-		suite.Nil(err)
+		suite.NoError(err)
 
 		fetchDates, err := models.FetchShipmentRecalculateDates(suite.DB())
 		suite.EqualError(err, "Too many active re-calculate date records")
@@ -103,7 +103,7 @@ func (suite *ModelSuite) TestShipmentRecalculateFetchActiveRecord() {
 		}
 		verrs, err := suite.DB().ValidateAndCreate(&newRecalculateDatesActive)
 		suite.Empty(verrs.Error())
-		suite.Nil(err)
+		suite.NoError(err)
 
 		id = uuid.Must(uuid.NewV4())
 
@@ -115,10 +115,10 @@ func (suite *ModelSuite) TestShipmentRecalculateFetchActiveRecord() {
 		}
 		verrs, err = suite.DB().ValidateAndCreate(&newRecalculateDatesNotActive)
 		suite.Empty(verrs.Error())
-		suite.Nil(err)
+		suite.NoError(err)
 
 		fetchDates, err := models.FetchShipmentRecalculateDates(suite.DB())
-		suite.Nil(err)
+		suite.NoError(err)
 		suite.Empty(verrs.Error())
 		suite.NotNil(fetchDates)
 

--- a/pkg/models/shipment_summary_worksheet_test.go
+++ b/pkg/models/shipment_summary_worksheet_test.go
@@ -152,7 +152,7 @@ func (suite *ModelSuite) TestFetchMovingExpensesShipmentSummaryWorksheetNoPPM() 
 	movingExpenses, err := models.FetchMovingExpensesShipmentSummaryWorksheet(move, suite.DB(), &session)
 
 	suite.Len(movingExpenses, 0)
-	suite.Nil(err)
+	suite.NoError(err)
 }
 
 func (suite *ModelSuite) TestFormatValuesShipmentSummaryWorksheetFormPage1() {
@@ -403,7 +403,7 @@ func (suite *ModelSuite) TestFormatSSWGetEntitlement() {
 	hasDependants := true
 	allotment := models.GetWeightAllotment(models.ServiceMemberRankE1)
 	totalEntitlement, err := models.GetEntitlement(models.ServiceMemberRankE1, hasDependants, spouseHasProGear)
-	suite.Nil(err)
+	suite.NoError(err)
 	sswEntitlement := models.SSWGetEntitlement(models.ServiceMemberRankE1, hasDependants, spouseHasProGear)
 
 	suite.Equal(unit.Pound(totalEntitlement), sswEntitlement.TotalWeight)
@@ -417,7 +417,7 @@ func (suite *ModelSuite) TestFormatSSWGetEntitlementNoDependants() {
 	hasDependants := false
 	allotment := models.GetWeightAllotment(models.ServiceMemberRankE1)
 	totalEntitlement, err := models.GetEntitlement(models.ServiceMemberRankE1, hasDependants, spouseHasProGear)
-	suite.Nil(err)
+	suite.NoError(err)
 	sswEntitlement := models.SSWGetEntitlement(models.ServiceMemberRankE1, hasDependants, spouseHasProGear)
 
 	suite.Equal(unit.Pound(totalEntitlement), sswEntitlement.TotalWeight)
@@ -563,7 +563,7 @@ func (suite *ModelSuite) TestCalculatePPMEntitlementNoHHGPPMLessThanMaxEntitleme
 	}
 
 	ppmRemainingEntitlement, err := models.CalculateRemainingPPMEntitlement(move, totalEntitlement)
-	suite.Nil(err)
+	suite.NoError(err)
 
 	suite.Equal(unit.Pound(ppmWeight), ppmRemainingEntitlement)
 }
@@ -576,7 +576,7 @@ func (suite *ModelSuite) TestCalculatePPMEntitlementNoHHGPPMGreaterThanMaxEntitl
 	}
 
 	ppmRemainingEntitlement, err := models.CalculateRemainingPPMEntitlement(move, totalEntitlement)
-	suite.Nil(err)
+	suite.NoError(err)
 
 	suite.Equal(totalEntitlement, ppmRemainingEntitlement)
 }
@@ -591,7 +591,7 @@ func (suite *ModelSuite) TestCalculatePPMEntitlementPPMGreaterThanRemainingEntit
 	}
 
 	ppmRemainingEntitlement, err := models.CalculateRemainingPPMEntitlement(move, totalEntitlement)
-	suite.Nil(err)
+	suite.NoError(err)
 
 	suite.Equal(totalEntitlement-hhg, ppmRemainingEntitlement)
 }
@@ -606,7 +606,7 @@ func (suite *ModelSuite) TestCalculatePPMEntitlementPPMLessThanRemainingEntitlem
 	}
 
 	ppmRemainingEntitlement, err := models.CalculateRemainingPPMEntitlement(move, totalEntitlement)
-	suite.Nil(err)
+	suite.NoError(err)
 
 	suite.Equal(unit.Pound(ppmWeight), ppmRemainingEntitlement)
 }

--- a/pkg/models/shipment_test.go
+++ b/pkg/models/shipment_test.go
@@ -68,7 +68,7 @@ func (suite *ModelSuite) Test_ShipmentValidationsSubmittedMove() {
 	}
 
 	verrs, err := shipment.Validate(suite.DB())
-	suite.Nil(err)
+	suite.NoError(err)
 
 	pickupAddressErrors := verrs.Get("pickup_address_id")
 	suite.Equal(1, len(pickupAddressErrors), "expected one error on pickup_address_id, but there were %d: %v", len(pickupAddressErrors), pickupAddressErrors)
@@ -130,35 +130,35 @@ func (suite *ModelSuite) TestShipmentStateMachine() {
 
 	// Can submit shipment
 	err := shipment.Submit(time.Now())
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.Equal(ShipmentStatusSUBMITTED, shipment.Status, "expected Submitted")
 
 	// Can award shipment
 	err = shipment.Award()
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.Equal(ShipmentStatusAWARDED, shipment.Status, "expected Awarded")
 
 	// Can accept shipment
 	err = shipment.Accept()
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.Equal(ShipmentStatusACCEPTED, shipment.Status, "expected Accepted")
 
 	// Can approve shipment (HHG)
 	err = shipment.Approve(time.Now())
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.Equal(ShipmentStatusAPPROVED, shipment.Status, "expected Approved")
 
 	shipDate := time.Now()
 
 	// Can pack shipment
 	err = shipment.Pack(shipDate)
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.Equal(ShipmentStatusAPPROVED, shipment.Status, "expected Approved")
 	suite.Equal(*shipment.ActualPackDate, shipDate, "expected Actual Pack Date to be set")
 
 	// Can transport shipment
 	err = shipment.Transport(shipDate)
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.Equal(ShipmentStatusINTRANSIT, shipment.Status, "expected In Transit")
 	suite.Equal(*shipment.ActualPickupDate, shipDate, "expected Actual Pickup Date to be set")
 
@@ -178,7 +178,7 @@ func (suite *ModelSuite) TestShipmentStateMachine() {
 	shipment.StorageInTransits = StorageInTransits{sit}
 
 	err = shipment.Deliver(shipDate)
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.Equal(ShipmentStatusDELIVERED, shipment.Status, "expected Delivered")
 	suite.Equal(*shipment.ActualDeliveryDate, shipDate, "expected Actual Delivery Date to be set")
 	suite.Equal(StorageInTransitStatusDELIVERED, shipment.StorageInTransits[0].Status)
@@ -195,7 +195,7 @@ func (suite *ModelSuite) TestSetBookDateWhenSubmitted() {
 
 	// Can submit shipment
 	err := shipment.Submit(time.Now())
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.NotNil(shipment.BookDate)
 }
 
@@ -296,7 +296,7 @@ func (suite *ModelSuite) TestCurrentTransportationServiceProviderID() {
 	// Since it doesn't re-fetch the shipment, if the offers have changed
 	// We need to re-fetch the shipment to reload the offers
 	reloadShipment, err := FetchShipmentByTSP(suite.DB(), tsp.ID, shipment.ID)
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.Equal(tsp.ID, reloadShipment.CurrentTransportationServiceProviderID(), "expected ids to be equal")
 }
 
@@ -862,7 +862,7 @@ func (suite *ModelSuite) TestAcceptedShipmentOffer() {
 
 	// Shipment does not have an accepted shipment offer
 	noAcceptedShipmentOffer, err := shipment.AcceptedShipmentOffer()
-	suite.Nil(err) // Shipment.Status does not require an accepted ShipmentOffer
+	suite.NoError(err) // Shipment.Status does not require an accepted ShipmentOffer
 	suite.Nil(noAcceptedShipmentOffer)
 
 	shipmentOffer := testdatagen.MakeDefaultShipmentOffer(suite.DB())
@@ -871,23 +871,23 @@ func (suite *ModelSuite) TestAcceptedShipmentOffer() {
 
 	// Can submit shipment
 	err = shipment.Submit(time.Now())
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.Equal(ShipmentStatusSUBMITTED, shipment.Status, "expected Submitted")
 
 	// Can award shipment
 	err = shipment.Award()
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.Equal(ShipmentStatusAWARDED, shipment.Status, "expected Awarded")
 
 	// ShipmentOffer has not been accepted yet
 	// Shipment does not have an accepted shipment offer
 	noAcceptedShipmentOffer, err = shipment.AcceptedShipmentOffer()
-	suite.Nil(err) // Shipment.Status does not require an accepted ShipmentOffer
+	suite.NoError(err) // Shipment.Status does not require an accepted ShipmentOffer
 	suite.Nil(noAcceptedShipmentOffer)
 
 	// Can accept shipment
 	err = shipment.Accept()
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.Equal(ShipmentStatusACCEPTED, shipment.Status, "expected Accepted")
 
 	// ShipmentOffer has not been accepted yet
@@ -898,22 +898,22 @@ func (suite *ModelSuite) TestAcceptedShipmentOffer() {
 
 	// Accept ShipmentOffer for the TSP
 	err = shipment.ShipmentOffers[0].Accept()
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.True(*shipment.ShipmentOffers[0].Accepted)
 	suite.Nil(shipment.ShipmentOffers[0].RejectionReason)
 
 	// Get accepted shipment offer from shipment
 	acceptedShipmentOffer, err := shipment.AcceptedShipmentOffer()
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.NotNil(acceptedShipmentOffer)
 
 	// Test results of TSP for an accepted shipment offer
 	// accepted shipment offer can't have empty or nil values for certain data
 	scac, err := acceptedShipmentOffer.SCAC()
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.NotEmpty(scac)
 	supplierID, err := acceptedShipmentOffer.SupplierID()
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.NotNil(supplierID)
 	suite.NotEmpty(*supplierID)
 

--- a/pkg/models/signed_certification_test.go
+++ b/pkg/models/signed_certification_test.go
@@ -45,7 +45,7 @@ func (suite *ModelSuite) TestFetchSignedCertificationsPPMPayment() {
 	})
 
 	sc, err := FetchSignedCertificationsPPMPayment(suite.DB(), session, move.ID)
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.Equal(signedCertification.ID, sc.ID)
 }
 
@@ -146,6 +146,6 @@ func (suite *ModelSuite) TestFetchSignedCertifications() {
 	}
 
 	suite.Len(scs, 3)
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.ElementsMatch(ids, []uuid.UUID{hhgSignedCertification.ID, ppmSignedCertification.ID, ppmPaymentsignedCertification.ID})
 }

--- a/pkg/models/storage_in_transit_test.go
+++ b/pkg/models/storage_in_transit_test.go
@@ -96,7 +96,7 @@ func (suite *ModelSuite) TestFetchStorageInTransitsByShipment() {
 
 	storageInTransits, err := models.FetchStorageInTransitsOnShipment(suite.DB(), shipment.ID)
 
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.Equal(10, len(storageInTransits))
 
 }
@@ -116,7 +116,7 @@ func (suite *ModelSuite) TestFetchStorageInTransistByID() {
 
 	fetchedSIT, err := models.FetchStorageInTransitByID(suite.DB(), createdSIT.ID)
 
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.NotEmpty(fetchedSIT)
 	suite.Equal(createdSIT.ID, fetchedSIT.ID)
 	suite.Equal(*createdSIT.WarehouseEmail, *createdSIT.WarehouseEmail)
@@ -180,7 +180,7 @@ func (suite *ModelSuite) TestSaveStorageInTransitAndAddress() {
 	}
 
 	verrs, err := models.SaveStorageInTransitAndAddress(suite.DB(), &storageInTransit)
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.Equal(0, verrs.Count())
 
 	savedStorageInTransit, err := models.FetchStorageInTransitByID(suite.DB(), storageInTransit.ID)
@@ -211,7 +211,7 @@ func (suite *ModelSuite) TestDeliverStorageInTransit() {
 
 	err := storageInTransit.Deliver(deliveryDate)
 
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.Equal(models.StorageInTransitStatusDELIVERED, storageInTransit.Status)
 	suite.Equal(&deliveryDate, storageInTransit.OutDate)
 

--- a/pkg/models/transit_times_test.go
+++ b/pkg/models/transit_times_test.go
@@ -7,11 +7,11 @@ import (
 
 func (suite *ModelSuite) Test_TransitDaysLookup() {
 	days, err := TransitDays(unit.Pound(2500), 1100)
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.Equal(11, days, "wrong number of days")
 
 	days, err = TransitDays(unit.Pound(4300), 6100)
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.Equal(30, days, "wrong number of days")
 }
 

--- a/pkg/models/tsp_users_test.go
+++ b/pkg/models/tsp_users_test.go
@@ -66,7 +66,7 @@ func (suite *ModelSuite) TestFetchTspUserByEmail() {
 	suite.MustSave(&newUser)
 
 	user, err = FetchTspUserByEmail(suite.DB(), email)
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.NotNil(user)
 	suite.Equal(newUser.ID, user.ID)
 }
@@ -84,7 +84,7 @@ func (suite *ModelSuite) TestFetchTspUserByEmailCaseSensitivity() {
 	suite.MustSave(&tspUser)
 
 	user, err := FetchTspUserByEmail(suite.DB(), strings.ToLower(email))
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.NotNil(user)
 	suite.Equal(user.Email, email)
 }

--- a/pkg/models/user_test.go
+++ b/pkg/models/user_test.go
@@ -159,7 +159,7 @@ func (suite *ModelSuite) TestFetchAppUserIdentities() {
 	suite.T().Run("default user no profile", func(t *testing.T) {
 		testdatagen.MakeDefaultUser(suite.DB())
 		identities, err := FetchAppUserIdentities(suite.DB(), auth.MilApp, 5)
-		suite.Nil(err)
+		suite.NoError(err)
 		suite.Empty(identities)
 	})
 
@@ -168,7 +168,7 @@ func (suite *ModelSuite) TestFetchAppUserIdentities() {
 		// Regular service member
 		testdatagen.MakeDefaultServiceMember(suite.DB())
 		identities, err := FetchAppUserIdentities(suite.DB(), auth.MilApp, 5)
-		suite.Nil(err)
+		suite.NoError(err)
 		suite.NotEmpty(identities)
 		suite.Equal(1, len(identities))
 
@@ -186,7 +186,7 @@ func (suite *ModelSuite) TestFetchAppUserIdentities() {
 			},
 		})
 		identities, err = FetchAppUserIdentities(suite.DB(), auth.MilApp, 5)
-		suite.Nil(err)
+		suite.NoError(err)
 		suite.NotEmpty(identities)
 		suite.Equal(2, len(identities))
 
@@ -204,7 +204,7 @@ func (suite *ModelSuite) TestFetchAppUserIdentities() {
 	suite.T().Run("office user", func(t *testing.T) {
 		testdatagen.MakeDefaultOfficeUser(suite.DB())
 		identities, err := FetchAppUserIdentities(suite.DB(), auth.OfficeApp, 5)
-		suite.Nil(err)
+		suite.NoError(err)
 		suite.NotEmpty(identities)
 		suite.Equal(1, len(identities))
 
@@ -219,7 +219,7 @@ func (suite *ModelSuite) TestFetchAppUserIdentities() {
 	suite.T().Run("tsp user", func(t *testing.T) {
 		testdatagen.MakeDefaultTspUser(suite.DB())
 		identities, err := FetchAppUserIdentities(suite.DB(), auth.TspApp, 5)
-		suite.Nil(err)
+		suite.NoError(err)
 		suite.NotEmpty(identities)
 		suite.Equal(1, len(identities))
 

--- a/pkg/paperwork/generator_test.go
+++ b/pkg/paperwork/generator_test.go
@@ -19,13 +19,13 @@ import (
 func (suite *PaperworkSuite) sha256ForPath(path string, fs *afero.Afero) (string, error) {
 	file, err := fs.Open(path)
 	if err != nil {
-		suite.Nil(err)
+		suite.NoError(err)
 	}
 	defer file.Close()
 
 	hash := sha256.New()
 	if _, err := io.Copy(hash, file); err != nil {
-		suite.Nil(err)
+		suite.NoError(err)
 	}
 
 	byteArray := hash.Sum(nil)

--- a/pkg/paperwork/shipment_summary_test.go
+++ b/pkg/paperwork/shipment_summary_test.go
@@ -108,7 +108,7 @@ func (suite *PaperworkSuite) TestTestComputeObligations() {
 		}
 		cost, err := ppmComputer.ComputeObligations(params, planner)
 
-		suite.Nil(err)
+		suite.NoError(err)
 		calledWith := mockComputer.CalledWith()
 		suite.Equal(*ppm.TotalSITCost, cost.ActualObligation.SIT)
 		suite.Equal(expectMaxObligationParams, calledWith[0])
@@ -122,7 +122,7 @@ func (suite *PaperworkSuite) TestTestComputeObligations() {
 		ppmComputer := NewSSWPPMComputer(&mockComputer)
 		obligations, err := ppmComputer.ComputeObligations(params, planner)
 
-		suite.Nil(err)
+		suite.NoError(err)
 		suite.Equal(unit.Cents(500), obligations.ActualObligation.SIT)
 	})
 
@@ -143,7 +143,7 @@ func (suite *PaperworkSuite) TestTestComputeObligations() {
 		ppmComputer := NewSSWPPMComputer(&mockComputer)
 		obligations, err := ppmComputer.ComputeObligations(shipmentSummaryFormParams, planner)
 
-		suite.Nil(err)
+		suite.NoError(err)
 		suite.Equal(unit.Cents(0), obligations.ActualObligation.SIT)
 	})
 

--- a/pkg/rateengine/linehaul_test.go
+++ b/pkg/rateengine/linehaul_test.go
@@ -205,6 +205,6 @@ func (suite *RateEngineSuite) Test_CheckFuelSurchargeComputation() {
 
 	fuelSurcharge, err := engine.fuelSurchargeComputation(unit.Cents(12000), testdatagen.NonPeakRateCycleEnd)
 
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.Equal(unit.Cents(720), fuelSurcharge.Fee)
 }

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -52,7 +52,7 @@ func (suite *serverSuite) TestParseSingleTLSCert() {
 		suite.readFile("localhost.pem"),
 		suite.readFile("localhost.key"))
 
-	suite.Nil(err)
+	suite.NoError(err)
 
 	httpsServer, err := CreateNamedServer(&CreateNamedServerInput{
 		Host:         "127.0.0.1",
@@ -62,7 +62,7 @@ func (suite *serverSuite) TestParseSingleTLSCert() {
 		Logger:       suite.logger,
 		Certificates: []tls.Certificate{keyPair},
 	})
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.Equal(len(httpsServer.TLSConfig.Certificates), 1)
 	suite.Contains(httpsServer.TLSConfig.NameToCertificate, "localhost")
 }
@@ -82,13 +82,13 @@ func (suite *serverSuite) TestParseMultipleTLSCerts() {
 		suite.readFile("localhost.pem"),
 		suite.readFile("localhost.key"))
 
-	suite.Nil(err)
+	suite.NoError(err)
 
 	keyPairOffice, err := tls.X509KeyPair(
 		suite.readFile("officelocal.pem"),
 		suite.readFile("officelocal.key"))
 
-	suite.Nil(err)
+	suite.NoError(err)
 
 	httpsServer, err := CreateNamedServer(&CreateNamedServerInput{
 		Host:        "127.0.0.1",
@@ -101,7 +101,7 @@ func (suite *serverSuite) TestParseMultipleTLSCerts() {
 			keyPairOffice,
 		},
 	})
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.Equal(len(httpsServer.TLSConfig.Certificates), 2)
 	suite.Contains(httpsServer.TLSConfig.NameToCertificate, "localhost")
 	suite.Contains(httpsServer.TLSConfig.NameToCertificate, "officelocal")
@@ -113,7 +113,7 @@ func (suite *serverSuite) TestTLSConfigWithClientAuth() {
 		suite.readFile("localhost.pem"),
 		suite.readFile("localhost.key"))
 
-	suite.Nil(err)
+	suite.NoError(err)
 
 	caFile := suite.readFile("ca.pem")
 	caCertPool := x509.NewCertPool()
@@ -128,7 +128,7 @@ func (suite *serverSuite) TestTLSConfigWithClientAuth() {
 		Logger:       suite.logger,
 		Certificates: []tls.Certificate{keyPair},
 	})
-	suite.Nil(err)
+	suite.NoError(err)
 }
 
 func (suite *serverSuite) TestTLSConfigWithMissingCA() {
@@ -137,7 +137,7 @@ func (suite *serverSuite) TestTLSConfigWithMissingCA() {
 		suite.readFile("localhost.pem"),
 		suite.readFile("localhost.key"))
 
-	suite.Nil(err)
+	suite.NoError(err)
 
 	_, err = CreateNamedServer(&CreateNamedServerInput{
 		Host:         "127.0.0.1",
@@ -156,7 +156,7 @@ func (suite *serverSuite) TestTLSConfigWithMisconfiguredCA() {
 		suite.readFile("localhost.pem"),
 		suite.readFile("localhost.key"))
 
-	suite.Nil(err)
+	suite.NoError(err)
 
 	caFile := suite.readFile("localhost-bad.pem")
 	caCertPool := x509.NewCertPool()
@@ -182,7 +182,7 @@ func (suite *serverSuite) TestHTTPServerConfig() {
 		HTTPHandler: suite.httpHandler,
 		Logger:      suite.logger,
 	})
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.Equal(httpsServer.Addr, "127.0.0.1:8080")
 	suite.Equal(suite.httpHandler, httpsServer.Handler)
 }

--- a/pkg/services/accesscode/claim_access_code_test.go
+++ b/pkg/services/accesscode/claim_access_code_test.go
@@ -40,7 +40,7 @@ func (suite *ClaimAccessCodeTestSuite) TestClaimAccessCode_Success() {
 	claimAccessCode := NewAccessCodeClaimer(suite.DB())
 	ac, _, err := claimAccessCode.ClaimAccessCode(code, serviceMember.ID)
 
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.Equal(ac.Code, accessCode.Code, "expected CODE2")
 	suite.Equal(ac.ServiceMemberID, &serviceMember.ID)
 	suite.NotNil(ac.ClaimedAt)

--- a/pkg/services/invoice/store_invoice_test.go
+++ b/pkg/services/invoice/store_invoice_test.go
@@ -40,7 +40,7 @@ func helperInvoice(suite *InvoiceServiceSuite) (*models.Invoice, *models.OfficeU
 
 	// Then: invoice is returned
 	extantInvoice, err := models.FetchInvoice(suite.DB(), session, invoice.ID)
-	suite.Nil(err)
+	suite.NoError(err)
 	if suite.NoError(err) {
 		suite.Equal(extantInvoice.ID, invoice.ID)
 	}
@@ -67,7 +67,7 @@ func (suite *InvoiceServiceSuite) TestStoreInvoice858C() {
 		Logger: suite.logger,
 		Storer: &fs,
 	}.Call(invoiceString, invoice, *officeUser.UserID)
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.Empty(verrs.Error())
 
 	// When: office user tries to access
@@ -79,7 +79,7 @@ func (suite *InvoiceServiceSuite) TestStoreInvoice858C() {
 
 	// Fetch invoice and verify upload is set
 	invoice, err = models.FetchInvoice(suite.DB(), session, invoice.ID)
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.NotNil(invoice)
 	suite.NotNil(invoice.Upload)
 	suite.NotNil(invoice.UploadID)

--- a/pkg/services/invoice/update_invoice_upload_test.go
+++ b/pkg/services/invoice/update_invoice_upload_test.go
@@ -251,13 +251,13 @@ func (suite *InvoiceServiceSuite) TestUpdateInvoiceUploadCall() {
 
 	// Add upload to invoice
 	verrs, err := UpdateInvoiceUpload{DB: suite.DB(), Uploader: up}.Call(invoice, upload)
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.Empty(verrs.Error())
 	suite.Equal(upload.ID, *invoice.UploadID)
 
 	// Fetch Invoice from database and compare Upload IDs
 	fetchInvoice, err := suite.helperFetchInvoice(invoice.ID)
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.NotNil(fetchInvoice)
 	suite.NotNil(fetchInvoice.UploadID)
 	suite.NotNil(fetchInvoice.Upload)
@@ -267,7 +267,7 @@ func (suite *InvoiceServiceSuite) TestUpdateInvoiceUploadCall() {
 	upload = suite.helperCreateUpload(storer)
 	suite.NotNil(upload)
 	err = UpdateInvoiceUpload{DB: suite.DB(), Uploader: up}.DeleteUpload(invoice)
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.Empty(verrs.Error())
 	suite.Nil(invoice.UploadID)
 	suite.Nil(invoice.Upload)

--- a/pkg/services/paperwork/create_form_test.go
+++ b/pkg/services/paperwork/create_form_test.go
@@ -51,7 +51,7 @@ func (suite *PaperworkServiceSuite) TestCreateFormServiceSuccess() {
 	file, err := formCreator.CreateForm(template)
 
 	suite.NotNil(file)
-	suite.Nil(err)
+	suite.NoError(err)
 	FormFiller.AssertExpectations(suite.T())
 }
 

--- a/pkg/services/shipment/process_recalculate_shipment_test.go
+++ b/pkg/services/shipment/process_recalculate_shipment_test.go
@@ -63,7 +63,7 @@ func (suite *ShipmentServiceSuite) TestProcessRecalculateShipmentCall() {
 	shipmentID := shipment.ID
 
 	shipmentLineItems, err := models.FetchLineItemsByShipmentID(suite.DB(), &shipmentID)
-	suite.Nil(err)
+	suite.NoError(err)
 
 	shipment2, err := invoice.FetchShipmentForInvoice{DB: suite.DB()}.Call(shipmentID)
 	if err != nil {
@@ -83,7 +83,7 @@ func (suite *ShipmentServiceSuite) TestProcessRecalculateShipmentCall() {
 		Logger: suite.logger,
 	}.Call(shipment, shipmentLineItems, *planner)
 	// TEST Validation: No date range records (return false)
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.Equal(false, update)
 
 	id, err := uuid.NewV4()
@@ -97,7 +97,7 @@ func (suite *ShipmentServiceSuite) TestProcessRecalculateShipmentCall() {
 	suite.MustCreate(suite.DB(), &recalculateRange)
 	fetchRecalculateRange, err := models.FetchShipmentRecalculateDates(suite.DB())
 	recalculateRange = *fetchRecalculateRange
-	suite.Nil(err)
+	suite.NoError(err)
 
 	//
 	// TEST: shipment is not in DELIVERED state (return false)
@@ -110,7 +110,7 @@ func (suite *ShipmentServiceSuite) TestProcessRecalculateShipmentCall() {
 		Logger: suite.logger,
 	}.Call(shipment, shipmentLineItems, *planner)
 	// TEST Validation: shipment is not in DELIVERED state (return false)
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.Equal(false, update)
 
 	// Shipment is delivered
@@ -132,7 +132,7 @@ func (suite *ShipmentServiceSuite) TestProcessRecalculateShipmentCall() {
 		Logger: suite.logger,
 	}.Call(shipment, shipmentLineItems, *planner)
 	// TEST Validation: shipment after date range (return false)
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.Equal(false, update)
 
 	//
@@ -152,11 +152,11 @@ func (suite *ShipmentServiceSuite) TestProcessRecalculateShipmentCall() {
 		Logger: suite.logger,
 	}.Call(shipment, shipmentLineItems, *planner)
 	// TEST Validation: Shipment missing base line item or line item was updated in date range (return true)
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.Equal(true, update)
 
 	shipmentLineItems, err = models.FetchLineItemsByShipmentID(suite.DB(), &shipmentID)
-	suite.Nil(err)
+	suite.NoError(err)
 
 	shipment2, err = invoice.FetchShipmentForInvoice{DB: suite.DB()}.Call(shipmentID)
 	if err != nil {
@@ -170,7 +170,7 @@ func (suite *ShipmentServiceSuite) TestProcessRecalculateShipmentCall() {
 	suite.MustSave(&recalculateRange)
 
 	fetchRecalculateRange, err = models.FetchShipmentRecalculateDates(suite.DB())
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.NotNil(fetchRecalculateRange)
 
 	// Move Shipment.CreatedAt to date within range
@@ -183,6 +183,6 @@ func (suite *ShipmentServiceSuite) TestProcessRecalculateShipmentCall() {
 		Logger: suite.logger,
 	}.Call(shipment, shipmentLineItems, *planner)
 	// TEST Validation:  Do not recalculate shipment all line items are up to date (return false)
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.Equal(false, update)
 }

--- a/pkg/uploader/uploader_test.go
+++ b/pkg/uploader/uploader_test.go
@@ -134,7 +134,7 @@ func (suite *UploaderSuite) TestCreateUploadNoDocument() {
 	up := uploader.NewUploader(suite.DB(), suite.logger, suite.storer)
 	file := suite.fixture("test.pdf")
 	fixtureFileInfo, err := file.Stat()
-	suite.Nil(err)
+	suite.NoError(err)
 
 	// Create file and upload
 	upload, verrs, err := up.CreateUpload(userID, &file, uploader.AllowedTypesPDF)
@@ -145,15 +145,15 @@ func (suite *UploaderSuite) TestCreateUploadNoDocument() {
 
 	// Download file and test size
 	download, err := up.Download(upload)
-	suite.Nil(err)
+	suite.NoError(err)
 	defer download.Close()
 
 	outputFile, err := suite.helperNewTempFile()
-	suite.Nil(err)
+	suite.NoError(err)
 	defer outputFile.Close()
 
 	written, err := io.Copy(outputFile, download)
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.NotEqual(0, written)
 
 	info, err := outputFile.Stat()
@@ -161,5 +161,5 @@ func (suite *UploaderSuite) TestCreateUploadNoDocument() {
 
 	// Delete file previously uploaded
 	err = up.Storer.Delete(upload.StorageKey)
-	suite.Nil(err)
+	suite.NoError(err)
 }


### PR DESCRIPTION
## Description

`NoError` will print the error as a formatted string (using `Error() string`) when an error occurs rather just printing the struct.

https://godoc.org/github.com/stretchr/testify/assert#NoError

## Reviewer Notes

None
## Setup

None

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/tree/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/tree/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/tree/master/docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
  * [ ] Secure migrations have been tested using `scripts/run-prod-migrations`
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

None

## Screenshots

None