### PR TITLE
Add migration to manifest file (bad zip codes)

### DIFF
--- a/migrations/20190705235827_fix_duty_station_zip.up.sql
+++ b/migrations/20190705235827_fix_duty_station_zip.up.sql
@@ -1,1 +1,1 @@
-UPDATE addresses SET postal_code = '98134' WHERE postal_code = '98734'
+UPDATE addresses SET postal_code = '98134' WHERE postal_code = '98734';

--- a/migrations_manifest.txt
+++ b/migrations_manifest.txt
@@ -318,5 +318,6 @@
 20190702170631_add_new_office_user.up.fizz
 20190702195904_create_organizations.up.fizz
 20190703141326_add-usmc-office-users.up.fizz
+20190705235827_fix_duty_station_zip.up.sql
 20190709204712_add-office-users.up.fizz
 20190711215901_load_usmc_duty_stations.up.sql


### PR DESCRIPTION
## Description

Missed adding this file to the manifest. Probably would have been caught by a pre-commit hook if we updated to master before committing.
This should fix master

the orig pr: https://github.com/transcom/mymove/pull/2390

## Setup

`make db_dev_migrate` 
