### PR TITLE
Delete duty stations w/ no corresponding zip3: 165924370

### DIFF
--- a/migrations/20190715122032_delete-duty-stations-with-no-zip3.up.sql
+++ b/migrations/20190715122032_delete-duty-stations-with-no-zip3.up.sql
@@ -1,0 +1,25 @@
+-- delete duty stations with zip5 that have no zip3 row
+
+-- Joint Base Pearl Harbor Hickam
+DELETE FROM duty_stations WHERE id = '7f397238-ca68-4417-b17f-61709e019e3b';
+DELETE FROM addresses WHERE id = '7b844695-eb40-4028-8ddd-8c2f5d6e142e';
+
+-- Kaneohe Marine Air Station
+DELETE FROM duty_stations WHERE id = 'ba15d369-e284-4edb-a2e2-5cf91022dd4f';
+DELETE FROM addresses WHERE id = '2887f384-b895-4507-a808-084c2b4e8e28';
+
+-- US Coast Guard Honolulu
+DELETE FROM duty_stations WHERE id = '2b0f8faf-1385-4be1-89dd-478a4837abe9';
+DELETE FROM addresses WHERE id = 'ea9b6e35-1d4e-4744-89c0-371b977b3f0e';
+
+-- Camp H M Smith
+DELETE FROM duty_stations WHERE id = 'a665fabc-6637-4acf-878c-d0fb3f0b8cd4';
+DELETE FROM addresses WHERE id = '5911bb14-f027-43c3-8b93-b21e4a90dfeb';
+
+-- Fort Shafter
+DELETE FROM duty_stations WHERE id = 'e18a829e-d1ec-405e-9ac3-77b28965ea2d';
+DELETE FROM addresses WHERE id = '307bb34e-0690-495b-acc6-2ef45fbc229c';
+
+-- Pacific Missle Range Facility
+DELETE FROM duty_stations WHERE id = '2bc08117-6533-4aa6-8a46-3447d91c5513';
+DELETE FROM addresses WHERE id = 'db7e96bf-f127-4d12-bf2e-51b3ef6889e5';

--- a/migrations_manifest.txt
+++ b/migrations_manifest.txt
@@ -321,3 +321,4 @@
 20190705235827_fix_duty_station_zip.up.sql
 20190709204712_add-office-users.up.fizz
 20190711215901_load_usmc_duty_stations.up.sql
+20190715122032_delete-duty-stations-with-no-zip3.up.sql


### PR DESCRIPTION
## Description

Delete duty stations that have no valid zip3 row (all these duty stations are in `HI`).

## Reviewer Notes

Ensure rows are deleted from`duty_stations` and `addresses` tables.

## Setup

`make db_dev_migrate`

## Code Review Verification Steps

* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/tree/master/docs/database.md#zero-downtime-migrations))
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/165924370) for this change
