### PR TITLE
Update country to `United States` vs `US`

### DIFF
--- a/migrations/20190713214312_update-county-code-us.up.sql
+++ b/migrations/20190713214312_update-county-code-us.up.sql
@@ -1,0 +1,2 @@
+
+UPDATE addresses SET country = 'United States' where country = 'US';

--- a/migrations/20190713214312_update-county-code-us.up.sql
+++ b/migrations/20190713214312_update-county-code-us.up.sql
@@ -1,2 +1,2 @@
 
-UPDATE addresses SET country = 'United States' where country = 'US';
+UPDATE addresses SET country = 'United States' WHERE country = 'US';

--- a/migrations_manifest.txt
+++ b/migrations_manifest.txt
@@ -321,4 +321,5 @@
 20190705235827_fix_duty_station_zip.up.sql
 20190709204712_add-office-users.up.fizz
 20190711215901_load_usmc_duty_stations.up.sql
+20190713214312_update-county-code-us.up.sql
 20190715122032_delete-duty-stations-with-no-zip3.up.sql


### PR DESCRIPTION
## Description

Update `addresses` `country` column to be `United States` where it is currently `US`.

When loading missing marine duty stations (https://github.com/transcom/mymove/pull/2388), we inserted country as `US`, but existing rows in the table use `United States`. 

## Reviewer Notes

Ensure `address` rows have `United States` in country column.

## Setup

`make db_dev_migrate`

## Code Review Verification Steps

* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/tree/master/docs/database.md#zero-downtime-migrations))
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

