### PR TITLE
delete duty stations w/ no corresponding zip3 row - skip conflicts

### DIFF
--- a/migrations/20190715122032_delete-duty-stations-with-no-zip3.up.sql
+++ b/migrations/20190715122032_delete-duty-stations-with-no-zip3.up.sql
@@ -1,25 +1,33 @@
+-- SKIP THIS MIGRATION due to failing db constraints...
+-- fixed in migration: 20190715144534_delete-duty-stations-with-no-zip3-conflict.up.sql
+
+
+
+
+
+
 -- delete duty stations with zip5 that have no zip3 row
 
--- Joint Base Pearl Harbor Hickam
-DELETE FROM duty_stations WHERE id = '7f397238-ca68-4417-b17f-61709e019e3b';
-DELETE FROM addresses WHERE id = '7b844695-eb40-4028-8ddd-8c2f5d6e142e';
+-- -- Joint Base Pearl Harbor Hickam
+-- DELETE FROM duty_stations WHERE id = '7f397238-ca68-4417-b17f-61709e019e3b';
+-- DELETE FROM addresses WHERE id = '7b844695-eb40-4028-8ddd-8c2f5d6e142e';
 
--- Kaneohe Marine Air Station
-DELETE FROM duty_stations WHERE id = 'ba15d369-e284-4edb-a2e2-5cf91022dd4f';
-DELETE FROM addresses WHERE id = '2887f384-b895-4507-a808-084c2b4e8e28';
+-- -- Kaneohe Marine Air Station
+-- DELETE FROM duty_stations WHERE id = 'ba15d369-e284-4edb-a2e2-5cf91022dd4f';
+-- DELETE FROM addresses WHERE id = '2887f384-b895-4507-a808-084c2b4e8e28';
 
--- US Coast Guard Honolulu
-DELETE FROM duty_stations WHERE id = '2b0f8faf-1385-4be1-89dd-478a4837abe9';
-DELETE FROM addresses WHERE id = 'ea9b6e35-1d4e-4744-89c0-371b977b3f0e';
+-- -- US Coast Guard Honolulu
+-- DELETE FROM duty_stations WHERE id = '2b0f8faf-1385-4be1-89dd-478a4837abe9';
+-- DELETE FROM addresses WHERE id = 'ea9b6e35-1d4e-4744-89c0-371b977b3f0e';
 
--- Camp H M Smith
-DELETE FROM duty_stations WHERE id = 'a665fabc-6637-4acf-878c-d0fb3f0b8cd4';
-DELETE FROM addresses WHERE id = '5911bb14-f027-43c3-8b93-b21e4a90dfeb';
+-- -- Camp H M Smith
+-- DELETE FROM duty_stations WHERE id = 'a665fabc-6637-4acf-878c-d0fb3f0b8cd4';
+-- DELETE FROM addresses WHERE id = '5911bb14-f027-43c3-8b93-b21e4a90dfeb';
 
--- Fort Shafter
-DELETE FROM duty_stations WHERE id = 'e18a829e-d1ec-405e-9ac3-77b28965ea2d';
-DELETE FROM addresses WHERE id = '307bb34e-0690-495b-acc6-2ef45fbc229c';
+-- -- Fort Shafter
+-- DELETE FROM duty_stations WHERE id = 'e18a829e-d1ec-405e-9ac3-77b28965ea2d';
+-- DELETE FROM addresses WHERE id = '307bb34e-0690-495b-acc6-2ef45fbc229c';
 
--- Pacific Missle Range Facility
-DELETE FROM duty_stations WHERE id = '2bc08117-6533-4aa6-8a46-3447d91c5513';
-DELETE FROM addresses WHERE id = 'db7e96bf-f127-4d12-bf2e-51b3ef6889e5';
+-- -- Pacific Missle Range Facility
+-- DELETE FROM duty_stations WHERE id = '2bc08117-6533-4aa6-8a46-3447d91c5513';
+-- DELETE FROM addresses WHERE id = 'db7e96bf-f127-4d12-bf2e-51b3ef6889e5';

--- a/migrations/20190715144534_delete-duty-stations-with-no-zip3-conflict.up.sql
+++ b/migrations/20190715144534_delete-duty-stations-with-no-zip3-conflict.up.sql
@@ -1,0 +1,50 @@
+-- delete duty stations with zip5 that have no zip3 row
+-- this will skip duty stations that are exist in the `orders` or `service_members` tables
+
+-- Joint Base Pearl Harbor Hickam
+DELETE FROM duty_stations WHERE id = '7f397238-ca68-4417-b17f-61709e019e3b'
+AND NOT EXISTS (SELECT id FROM orders WHERE new_duty_station_id = '7f397238-ca68-4417-b17f-61709e019e3b')
+AND NOT EXISTS (SELECT id FROM service_members WHERE duty_station_id = '7f397238-ca68-4417-b17f-61709e019e3b');
+
+DELETE FROM addresses WHERE id = '7b844695-eb40-4028-8ddd-8c2f5d6e142e'
+AND NOT EXISTS (SELECT id FROM duty_stations WHERE id = '7f397238-ca68-4417-b17f-61709e019e3b');
+
+-- -- Kaneohe Marine Air Station
+DELETE FROM duty_stations WHERE id = 'ba15d369-e284-4edb-a2e2-5cf91022dd4f'
+AND NOT EXISTS (SELECT id FROM orders WHERE new_duty_station_id = 'ba15d369-e284-4edb-a2e2-5cf91022dd4f')
+AND NOT EXISTS (SELECT id FROM service_members WHERE duty_station_id = 'ba15d369-e284-4edb-a2e2-5cf91022dd4f');
+
+DELETE FROM addresses WHERE id = '2887f384-b895-4507-a808-084c2b4e8e28'
+AND NOT EXISTS (SELECT id FROM duty_stations WHERE id = 'ba15d369-e284-4edb-a2e2-5cf91022dd4f');
+
+-- -- US Coast Guard Honolulu
+DELETE FROM duty_stations WHERE id = '2b0f8faf-1385-4be1-89dd-478a4837abe9'
+AND NOT EXISTS (SELECT id FROM orders WHERE new_duty_station_id = '2b0f8faf-1385-4be1-89dd-478a4837abe9')
+AND NOT EXISTS (SELECT id FROM service_members WHERE duty_station_id = '2b0f8faf-1385-4be1-89dd-478a4837abe9');
+
+DELETE FROM addresses WHERE id = 'ea9b6e35-1d4e-4744-89c0-371b977b3f0e'
+AND NOT EXISTS (SELECT id FROM duty_stations WHERE id = '2b0f8faf-1385-4be1-89dd-478a4837abe9');
+
+-- -- Camp H M Smith
+DELETE FROM duty_stations WHERE id = 'a665fabc-6637-4acf-878c-d0fb3f0b8cd4'
+AND NOT EXISTS (SELECT id FROM orders WHERE new_duty_station_id = 'a665fabc-6637-4acf-878c-d0fb3f0b8cd4')
+AND NOT EXISTS (SELECT id FROM service_members WHERE duty_station_id = 'a665fabc-6637-4acf-878c-d0fb3f0b8cd4');
+
+DELETE FROM addresses WHERE id = '5911bb14-f027-43c3-8b93-b21e4a90dfeb'
+AND NOT EXISTS (SELECT id FROM duty_stations WHERE id = 'a665fabc-6637-4acf-878c-d0fb3f0b8cd4');
+
+-- -- Fort Shafter
+DELETE FROM duty_stations WHERE id = 'e18a829e-d1ec-405e-9ac3-77b28965ea2d'
+AND NOT EXISTS (SELECT id FROM orders WHERE new_duty_station_id = 'e18a829e-d1ec-405e-9ac3-77b28965ea2d')
+AND NOT EXISTS (SELECT id FROM service_members WHERE duty_station_id = 'e18a829e-d1ec-405e-9ac3-77b28965ea2d');
+
+DELETE FROM addresses WHERE id = '307bb34e-0690-495b-acc6-2ef45fbc229c'
+AND NOT EXISTS (SELECT id FROM duty_stations WHERE id = 'e18a829e-d1ec-405e-9ac3-77b28965ea2d');
+
+-- -- Pacific Missle Range Facility
+DELETE FROM duty_stations WHERE id = '2bc08117-6533-4aa6-8a46-3447d91c5513'
+AND NOT EXISTS (SELECT id FROM orders WHERE new_duty_station_id = '2bc08117-6533-4aa6-8a46-3447d91c5513')
+AND NOT EXISTS (SELECT id FROM service_members WHERE duty_station_id = '2bc08117-6533-4aa6-8a46-3447d91c5513');
+
+DELETE FROM addresses WHERE id = 'db7e96bf-f127-4d12-bf2e-51b3ef6889e5'
+AND NOT EXISTS (SELECT id FROM duty_stations WHERE id = '2bc08117-6533-4aa6-8a46-3447d91c5513');

--- a/migrations_manifest.txt
+++ b/migrations_manifest.txt
@@ -323,3 +323,4 @@
 20190711215901_load_usmc_duty_stations.up.sql
 20190713214312_update-county-code-us.up.sql
 20190715122032_delete-duty-stations-with-no-zip3.up.sql
+20190715144534_delete-duty-stations-with-no-zip3-conflict.up.sql

--- a/pkg/models/queue.go
+++ b/pkg/models/queue.go
@@ -218,12 +218,16 @@ func GetMoveQueueItems(db *pop.Connection, lifecycleState string) ([]MoveQueueIt
 				moves.updated_at as last_modified_date,
 				moves.status as status,
 				ppm.status as ppm_status,
-				shipment.gbl_number as gbl_number
+				shipment.gbl_number as gbl_number,
+				origin_duty_station.name as origin_duty_station_name,
+				destination_duty_station.name as destination_duty_station_name
 			FROM moves
 			JOIN orders as ord ON moves.orders_id = ord.id
 			JOIN service_members AS sm ON ord.service_member_id = sm.id
 			LEFT JOIN shipments AS shipment ON moves.id = shipment.move_id
 			LEFT JOIN personally_procured_moves AS ppm ON moves.id = ppm.move_id
+			JOIN duty_stations as origin_duty_station ON sm.duty_station_id = origin_duty_station.id
+			JOIN duty_stations as destination_duty_station ON ord.new_duty_station_id = destination_duty_station.id
 			WHERE moves.show is true
 		`
 	} else {


### PR DESCRIPTION
## Description

Delete duty stations and addresses that are not referenced in `orders` or `service_members` tables. 
If one o the duty station is referenced, do nothing. (a workaround due to a constraint: https://github.com/transcom/mymove/pull/2393)

Also, update `all` in `queues.go` - this will return origin and destination duty stations so we can determine moves that are using an "invalid" duty station.

## Reviewer Notes

1. Verify duty stations are deleted.
2. End point for `all` shows `origin` and `dest` duty stations

## Setup

`make db_dev_migrate`

`make server_run`
`make office_client_run`
