### PR TITLE
Replace cancel and save for later with finish later button

### DIFF
--- a/cypress/integration/mymove/ppm.js
+++ b/cypress/integration/mymove/ppm.js
@@ -206,8 +206,18 @@ describe('allows a SM to continue requesting a payment', function() {
 
     cy
       .get('button')
-      .contains('Cancel')
+      .contains('Finish Later')
       .click();
+
+    cy
+      .get('button')
+      .contains('OK')
+      .click();
+
+    cy.location().should(loc => {
+      expect(loc.pathname).to.match(/^\/$/);
+    });
+
     cy
       .get('.usa-button-secondary')
       .contains('Continue Requesting Payment')
@@ -231,7 +241,7 @@ describe('allows a SM to request a payment', function() {
     cy.signInAsUserPostRequest(milmoveAppName, smId);
   });
 
-  it('service member reads introduction to ppm payment and cancels to go back to homepage', () => {
+  it('service member reads introduction to ppm payment and goes back to homepage', () => {
     serviceMemberStartsPPMPaymentRequestWithAssertions();
   });
 

--- a/cypress/integration/mymove/ppm.js
+++ b/cypress/integration/mymove/ppm.js
@@ -246,7 +246,7 @@ describe('allows a SM to request a payment', function() {
 
   it('service member can save a weight ticket for later', () => {
     cy.visit(`/moves/${moveID}/ppm-weight-ticket`);
-    serviceMemberSavesWeightTicketForLater('BOX_TRUCK');
+    serviceMemberCanFinishWeightTicketLater('BOX_TRUCK');
   });
 
   it('service member submits weight tickets without any documents', () => {
@@ -568,7 +568,7 @@ function serviceMemberSubmitsCarTrailerWeightTicket() {
   cy.get('input[name="additional_weight_ticket"][value="Yes"]').should('not.be.checked');
   cy.get('input[name="additional_weight_ticket"][value="No"]').should('be.checked');
 }
-function serviceMemberSavesWeightTicketForLater(vehicleType) {
+function serviceMemberCanFinishWeightTicketLater(vehicleType) {
   cy.get('select[name="vehicle_options"]').select(vehicleType);
 
   cy.get('input[name="vehicle_nickname"]').type('Nickname');
@@ -589,12 +589,28 @@ function serviceMemberSavesWeightTicketForLater(vehicleType) {
 
   cy
     .get('button')
-    .contains('Save For Later')
+    .contains('Finish Later')
     .click();
+
   cy
-    .wait('@postWeightTicket')
-    .its('status')
-    .should('eq', 200);
+    .get('button')
+    .contains('Cancel')
+    .click();
+
+  cy.location().should(loc => {
+    expect(loc.pathname).to.match(/^\/moves\/[^/]+\/ppm-weight-ticket/);
+  });
+
+  cy
+    .get('button')
+    .contains('Finish Later')
+    .click();
+
+  cy
+    .get('button')
+    .contains('OK')
+    .click();
+
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/$/);
   });

--- a/src/scenes/Moves/Ppm/ExpensesLanding.jsx
+++ b/src/scenes/Moves/Ppm/ExpensesLanding.jsx
@@ -87,10 +87,9 @@ class ExpensesLanding extends Component {
           </div>
           <PPMPaymentRequestActionBtns
             cancelHandler={() => {}}
-            displaySaveForLater={true}
             nextBtnLabel="Continue"
             saveAndAddHandler={this.saveAndAddHandler}
-            saveForLaterHandler={() => history.push('/')}
+            finishLaterHandler={() => history.push('/')}
             submitButtonsAreDisabled={!hasExpenses}
           />
         </div>

--- a/src/scenes/Moves/Ppm/ExpensesUpload.jsx
+++ b/src/scenes/Moves/Ppm/ExpensesUpload.jsx
@@ -71,13 +71,25 @@ class ExpensesUpload extends Component {
     history.push(`/moves/${moveId}${nextPagePath}`);
   };
 
-  saveForLaterHandler = formValues => {
+  finishLaterHandler = formValues => {
     const { history } = this.props;
-    return this.saveAndAddHandler(formValues).then(() => {
-      if (this.state.moveDocumentCreateError === false) {
-        history.push('/');
-      }
-    });
+    const {
+      storage_start_date,
+      storage_end_date,
+      moving_expense_type: movingExpenseType,
+      requested_amount_cents: requestedAmountCents,
+    } = formValues;
+    if (!(storage_start_date && storage_end_date && movingExpenseType && requestedAmountCents)) {
+      this.cleanup();
+      history.push('/');
+      return;
+    } else {
+      return this.saveAndAddHandler(formValues).then(() => {
+        if (this.state.moveDocumentCreateError === false) {
+          history.push('/');
+        }
+      });
+    }
   };
 
   isStorageExpense = formValues => {
@@ -325,10 +337,9 @@ class ExpensesUpload extends Component {
               submitButtonsAreDisabled={this.isInvalidUploaderState() || invalid}
               submitting={submitting}
               skipHandler={this.skipHandler}
-              saveForLaterHandler={handleSubmit(this.saveForLaterHandler)}
-              saveAndAddHandler={handleSubmit(this.saveAndAddHandler)}
               displaySkip={expenses.length >= 1}
-              displaySaveForLater={true}
+              finishLaterHandler={handleSubmit(this.finishLaterHandler)}
+              saveAndAddHandler={handleSubmit(this.saveAndAddHandler)}
             />
           </form>
         </div>

--- a/src/scenes/Moves/Ppm/ExpensesUpload.jsx
+++ b/src/scenes/Moves/Ppm/ExpensesUpload.jsx
@@ -71,27 +71,6 @@ class ExpensesUpload extends Component {
     history.push(`/moves/${moveId}${nextPagePath}`);
   };
 
-  finishLaterHandler = formValues => {
-    const { history } = this.props;
-    const {
-      storage_start_date,
-      storage_end_date,
-      moving_expense_type: movingExpenseType,
-      requested_amount_cents: requestedAmountCents,
-    } = formValues;
-    if (!(storage_start_date && storage_end_date && movingExpenseType && requestedAmountCents)) {
-      this.cleanup();
-      history.push('/');
-      return;
-    } else {
-      return this.saveAndAddHandler(formValues).then(() => {
-        if (this.state.moveDocumentCreateError === false) {
-          history.push('/');
-        }
-      });
-    }
-  };
-
   isStorageExpense = formValues => {
     return !isEmpty(formValues) && formValues.moving_expense_type === 'STORAGE';
   };
@@ -334,11 +313,11 @@ class ExpensesUpload extends Component {
             )}
             <PPMPaymentRequestActionBtns
               nextBtnLabel={nextBtnLabel}
+              hasConfirmation={true}
               submitButtonsAreDisabled={this.isInvalidUploaderState() || invalid}
               submitting={submitting}
               skipHandler={this.skipHandler}
               displaySkip={expenses.length >= 1}
-              finishLaterHandler={handleSubmit(this.finishLaterHandler)}
               saveAndAddHandler={handleSubmit(this.saveAndAddHandler)}
             />
           </form>

--- a/src/scenes/Moves/Ppm/PPMPaymentRequest.css
+++ b/src/scenes/Moves/Ppm/PPMPaymentRequest.css
@@ -51,9 +51,19 @@
   border-top: 1px solid black;
   display: flex;
   justify-content: space-between;
+  flex-direction: row;
   border-top: 1px solid black;
   margin-top: 2.3rem;
   padding-top: 1.5rem;
+  width: 100%;
+}
+
+.usa-button-secondary {
+  margin-left: 1.5rem;
+}
+
+.usa-button {
+  margin-right: 1.5rem;
 }
 
 @media only screen and (max-width: 481px) {

--- a/src/scenes/Moves/Ppm/PPMPaymentRequestActionBtns.jsx
+++ b/src/scenes/Moves/Ppm/PPMPaymentRequestActionBtns.jsx
@@ -6,33 +6,28 @@ import './PPMPaymentRequest.css';
 import AlertWithConfirmation from 'shared/AlertWithConfirmation';
 
 class PPMPaymentRequestActionBtns extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      hasConfirmation: props.hasConfirmation,
-      displayConfirmation: false,
-    };
+  state = {
+    hasConfirmation: this.props.hasConfirmation,
+    displayConfirmation: false,
+  };
 
-    this.showConfirmationOrFinishLater = formValues => {
-      const { history, hasConfirmation } = this.props;
+  showConfirmationOrFinishLater = formValues => {
+    const { history, hasConfirmation } = this.props;
 
-      if (!hasConfirmation) {
-        return history.push('/');
-      }
+    if (!hasConfirmation) {
+      return history.push('/');
+    }
 
-      this.setState({ displayConfirmation: true });
-      return;
-    };
+    this.setState({ displayConfirmation: true });
+  };
 
-    this.cancelConfirmationHandler = () => {
-      this.setState({ displayConfirmation: false });
-      return;
-    };
+  cancelConfirmationHandler = () => {
+    this.setState({ displayConfirmation: false });
+  };
 
-    this.confirmFinishLater = () => {
-      return this.props.history.push('/');
-    };
-  }
+  confirmFinishLater = () => {
+    this.props.history.push('/');
+  };
 
   render() {
     const {

--- a/src/scenes/Moves/Ppm/PPMPaymentRequestActionBtns.jsx
+++ b/src/scenes/Moves/Ppm/PPMPaymentRequestActionBtns.jsx
@@ -1,46 +1,65 @@
 import React from 'react';
 import { withRouter } from 'react-router-dom';
 import './PPMPaymentRequest.css';
+import Alert from 'shared/Alert';
+
+const ConfirmationAlert = props => {
+  const { confirmationAlertMsg, history } = props;
+  return (
+    <Alert type="warning" heading="">
+      <div className="usa-width-two-thirds">{confirmationAlertMsg}</div>
+      <div className="usa-width-one-thirds">
+        <button type="button" className="usa-button-secondary" onClick={() => console.log('cancelled')}>
+          Cancel
+        </button>
+        <button type="button" className="usa-button" onClick={() => history.push('/')}>
+          OK
+        </button>
+      </div>
+    </Alert>
+  );
+};
 
 const PPMPaymentRequestActionBtns = props => {
   const {
     nextBtnLabel,
+    displaySkip,
     skipHandler,
     saveAndAddHandler,
-    saveForLaterHandler,
+    finishLaterHandler,
+    displayConfirmation,
     submitButtonsAreDisabled,
-    displaySaveForLater,
-    displaySkip,
     submitting,
-    history,
   } = props;
   return (
     <div className="ppm-payment-request-footer">
-      <div className="usa-width-two-thirds">
-        <button type="button" className="usa-button-secondary" onClick={() => history.push('/')}>
-          Cancel
-        </button>
-        {displaySaveForLater && (
-          <button
-            type="button"
-            className="usa-button-secondary"
-            onClick={saveForLaterHandler}
-            disabled={submitButtonsAreDisabled || submitting}
-          >
-            Save For Later
-          </button>
-        )}
+      <div className="usa-width-one-whole">
+        <ConfirmationAlert confirmationAlertMsg="Partially completed entries will not be saved. Click OK to continue. Click cancel to return and edit." />
       </div>
-      <div className="usa-width-one-third">
-        {displaySkip && (
-          <button data-cy="skip" type="button" className="usa-button-secondary" onClick={skipHandler}>
-            Skip
-          </button>
-        )}
-        <button type="button" onClick={saveAndAddHandler} disabled={submitButtonsAreDisabled || submitting}>
-          {nextBtnLabel}
-        </button>
-      </div>
+      {displayConfirmation && (
+        <div>
+          <div className="usa-width-two-thirds">
+            <button
+              type="button"
+              className="usa-button-secondary"
+              onClick={finishLaterHandler}
+              disabled={submitButtonsAreDisabled || submitting}
+            >
+              Finish Later
+            </button>
+          </div>
+          <div className="usa-width-one-thirds">
+            {displaySkip && (
+              <button data-cy="skip" type="button" className="usa-button-secondary" onClick={skipHandler}>
+                Skip
+              </button>
+            )}
+            <button type="button" onClick={saveAndAddHandler} disabled={submitButtonsAreDisabled || submitting}>
+              {nextBtnLabel}
+            </button>
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/scenes/Moves/Ppm/PPMPaymentRequestActionBtns.jsx
+++ b/src/scenes/Moves/Ppm/PPMPaymentRequestActionBtns.jsx
@@ -41,10 +41,9 @@ class PPMPaymentRequestActionBtns extends Component {
       skipHandler,
       saveAndAddHandler,
       hasConfirmation,
-      displayConfirmation,
       submitButtonsAreDisabled,
       submitting,
-    } = props;
+    } = this.props;
     return (
       <div className="usa-width-one-whole">
         {hasConfirmation &&
@@ -63,14 +62,6 @@ class PPMPaymentRequestActionBtns extends Component {
         {!this.state.displayConfirmation && (
           <div className="ppm-payment-request-footer">
             <button type="button" className="usa-button-secondary" onClick={this.showConfirmationOrFinishLater}>
-              Finish Later
-            </button>
-            <button
-              type="button"
-              className="usa-button"
-              onClick={saveAndAddHandler}
-              disabled={submitButtonsAreDisabled || submitting}
-            >
               Finish Later
             </button>
             <div className="usa-width-one-thirds">

--- a/src/scenes/Moves/Ppm/PPMPaymentRequestActionBtns.jsx
+++ b/src/scenes/Moves/Ppm/PPMPaymentRequestActionBtns.jsx
@@ -1,67 +1,93 @@
-import React from 'react';
+import React, { Component } from 'react';
 import { withRouter } from 'react-router-dom';
+// import { get} from 'lodash';
+
 import './PPMPaymentRequest.css';
-import Alert from 'shared/Alert';
+import AlertWithConfirmation from 'shared/AlertWithConfirmation';
 
-const ConfirmationAlert = props => {
-  const { confirmationAlertMsg, history } = props;
-  return (
-    <Alert type="warning" heading="">
-      <div className="usa-width-two-thirds">{confirmationAlertMsg}</div>
-      <div className="usa-width-one-thirds">
-        <button type="button" className="usa-button-secondary" onClick={() => console.log('cancelled')}>
-          Cancel
-        </button>
-        <button type="button" className="usa-button" onClick={() => history.push('/')}>
-          OK
-        </button>
-      </div>
-    </Alert>
-  );
-};
+class PPMPaymentRequestActionBtns extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      hasConfirmation: props.hasConfirmation,
+      displayConfirmation: false,
+    };
 
-const PPMPaymentRequestActionBtns = props => {
-  const {
-    nextBtnLabel,
-    displaySkip,
-    skipHandler,
-    saveAndAddHandler,
-    finishLaterHandler,
-    displayConfirmation,
-    submitButtonsAreDisabled,
-    submitting,
-  } = props;
-  return (
-    <div className="ppm-payment-request-footer">
+    this.showConfirmationOrFinishLater = formValues => {
+      const { history, hasConfirmation } = this.props;
+
+      if (!hasConfirmation) {
+        return history.push('/');
+      }
+
+      this.setState({ displayConfirmation: true });
+      return;
+    };
+
+    this.cancelConfirmationHandler = () => {
+      this.setState({ displayConfirmation: false });
+      return;
+    };
+
+    this.confirmFinishLater = () => {
+      return this.props.history.push('/');
+    };
+  }
+
+  render() {
+    const {
+      nextBtnLabel,
+      displaySkip,
+      skipHandler,
+      saveAndAddHandler,
+      hasConfirmation,
+      displayConfirmation,
+      submitButtonsAreDisabled,
+      submitting,
+    } = props;
+    return (
       <div className="usa-width-one-whole">
-        <ConfirmationAlert confirmationAlertMsg="Partially completed entries will not be saved. Click OK to continue. Click cancel to return and edit." />
-      </div>
-      {displayConfirmation && (
-        <div>
-          <div className="usa-width-two-thirds">
+        {hasConfirmation &&
+          this.state.displayConfirmation && (
+            <div className="ppm-payment-request-footer">
+              <AlertWithConfirmation
+                hasConfirmation={hasConfirmation}
+                type="warning"
+                cancelActionHandler={this.cancelConfirmationHandler}
+                okActionHandler={this.confirmFinishLater}
+                message="Go back to the home screen without saving current screen."
+              />
+            </div>
+          )}
+
+        {!this.state.displayConfirmation && (
+          <div className="ppm-payment-request-footer">
+            <button type="button" className="usa-button-secondary" onClick={this.showConfirmationOrFinishLater}>
+              Finish Later
+            </button>
             <button
               type="button"
-              className="usa-button-secondary"
-              onClick={finishLaterHandler}
+              className="usa-button"
+              onClick={saveAndAddHandler}
               disabled={submitButtonsAreDisabled || submitting}
             >
               Finish Later
             </button>
-          </div>
-          <div className="usa-width-one-thirds">
-            {displaySkip && (
-              <button data-cy="skip" type="button" className="usa-button-secondary" onClick={skipHandler}>
-                Skip
+            <div className="usa-width-one-thirds">
+              {displaySkip && (
+                <button data-cy="skip" type="button" className="usa-button-secondary" onClick={skipHandler}>
+                  Skip
+                </button>
+              )}
+              <button type="button" onClick={saveAndAddHandler} disabled={submitButtonsAreDisabled || submitting}>
+                {nextBtnLabel}
               </button>
-            )}
-            <button type="button" onClick={saveAndAddHandler} disabled={submitButtonsAreDisabled || submitting}>
-              {nextBtnLabel}
-            </button>
+            </div>
           </div>
-        </div>
-      )}
-    </div>
-  );
-};
+        )}
+      </div>
+    );
+  }
+}
 
 export default withRouter(PPMPaymentRequestActionBtns);

--- a/src/scenes/Moves/Ppm/PPMPaymentRequestIntro.jsx
+++ b/src/scenes/Moves/Ppm/PPMPaymentRequestIntro.jsx
@@ -32,7 +32,7 @@ const PPMPaymentRequestIntro = props => {
       </p>
       {/* TODO: change onclick handler to go to next page in flow */}
       <PPMPaymentRequestActionBtns
-        cancelHandler={() => history.push('/')}
+        finishLaterHandler={() => history.push('/')}
         saveAndAddHandler={() => {
           history.push(`/moves/${match.params.moveId}/ppm-weight-ticket`);
         }}

--- a/src/scenes/Moves/Ppm/PPMPaymentRequestIntro.jsx
+++ b/src/scenes/Moves/Ppm/PPMPaymentRequestIntro.jsx
@@ -32,7 +32,6 @@ const PPMPaymentRequestIntro = props => {
       </p>
       {/* TODO: change onclick handler to go to next page in flow */}
       <PPMPaymentRequestActionBtns
-        finishLaterHandler={() => history.push('/')}
         saveAndAddHandler={() => {
           history.push(`/moves/${match.params.moveId}/ppm-weight-ticket`);
         }}

--- a/src/scenes/Moves/Ppm/PaymentReview/index.jsx
+++ b/src/scenes/Moves/Ppm/PaymentReview/index.jsx
@@ -60,7 +60,7 @@ class PaymentReview extends Component {
   };
 
   render() {
-    const { moveId, moveDocuments, submitting } = this.props;
+    const { moveId, moveDocuments, submitting, history } = this.props;
     const weightTickets = moveDocuments.weightTickets;
     const missingSomeWeightTicket = weightTickets.some(
       ({ empty_weight_ticket_missing, full_weight_ticket_missing }) =>
@@ -125,10 +125,10 @@ class PaymentReview extends Component {
           </div>
           <PPMPaymentRequestActionBtns
             nextBtnLabel={nextBtnLabel}
+            finishLaterHandler={() => history.push('/')}
             submitButtonsAreDisabled={!this.state.acceptTerms}
             saveAndAddHandler={this.applyClickHandlers}
             submitting={submitting}
-            displaySaveForLater
           />
         </div>
       </>

--- a/src/scenes/Moves/Ppm/WeightTicket.jsx
+++ b/src/scenes/Moves/Ppm/WeightTicket.jsx
@@ -123,7 +123,7 @@ class WeightTicket extends Component {
     history.push(`/moves/${moveId}${nextPagePath}`);
   };
 
-  saveForLaterHandler = formValues => {
+  finishLaterHandler = formValues => {
     const { history } = this.props;
     return this.saveAndAddHandler(formValues).then(() => {
       if (this.state.weightTicketSubmissionError === false) {
@@ -456,7 +456,7 @@ class WeightTicket extends Component {
               submitButtonsAreDisabled={this.uploaderWithInvalidState() || invalid}
               submitting={submitting}
               skipHandler={this.skipHandler}
-              saveForLaterHandler={handleSubmit(this.saveForLaterHandler)}
+              finishLaterHandler={handleSubmit(this.finishLaterHandler)}
               saveAndAddHandler={handleSubmit(this.saveAndAddHandler)}
               displaySaveForLater={true}
               displaySkip={weightTicketSets.length >= 1}

--- a/src/scenes/Moves/Ppm/WeightTicket.jsx
+++ b/src/scenes/Moves/Ppm/WeightTicket.jsx
@@ -118,6 +118,7 @@ class WeightTicket extends Component {
     });
   };
 
+<<<<<<< HEAD
   skipHandler = () => {
     const { moveId, history } = this.props;
     history.push(`/moves/${moveId}${nextPagePath}`);
@@ -132,6 +133,8 @@ class WeightTicket extends Component {
     });
   };
 
+=======
+>>>>>>> Buttons work appropriately
   nonEmptyUploaderKeys() {
     const uploadersKeys = Object.keys(this.uploaders);
     return uploadersKeys.filter(
@@ -453,10 +456,10 @@ class WeightTicket extends Component {
             )}
             <PPMPaymentRequestActionBtns
               nextBtnLabel={nextBtnLabel}
+              hasConfirmation={true}
               submitButtonsAreDisabled={this.uploaderWithInvalidState() || invalid}
               submitting={submitting}
               skipHandler={this.skipHandler}
-              finishLaterHandler={handleSubmit(this.finishLaterHandler)}
               saveAndAddHandler={handleSubmit(this.saveAndAddHandler)}
               displaySaveForLater={true}
               displaySkip={weightTicketSets.length >= 1}

--- a/src/scenes/Moves/Ppm/WeightTicket.jsx
+++ b/src/scenes/Moves/Ppm/WeightTicket.jsx
@@ -118,23 +118,11 @@ class WeightTicket extends Component {
     });
   };
 
-<<<<<<< HEAD
   skipHandler = () => {
     const { moveId, history } = this.props;
     history.push(`/moves/${moveId}${nextPagePath}`);
   };
 
-  finishLaterHandler = formValues => {
-    const { history } = this.props;
-    return this.saveAndAddHandler(formValues).then(() => {
-      if (this.state.weightTicketSubmissionError === false) {
-        history.push('/');
-      }
-    });
-  };
-
-=======
->>>>>>> Buttons work appropriately
   nonEmptyUploaderKeys() {
     const uploadersKeys = Object.keys(this.uploaders);
     return uploadersKeys.filter(
@@ -461,7 +449,6 @@ class WeightTicket extends Component {
               submitting={submitting}
               skipHandler={this.skipHandler}
               saveAndAddHandler={handleSubmit(this.saveAndAddHandler)}
-              displaySaveForLater={true}
               displaySkip={weightTicketSets.length >= 1}
             />
           </div>

--- a/src/scenes/Moves/Ppm/WeightTicket.test.js
+++ b/src/scenes/Moves/Ppm/WeightTicket.test.js
@@ -37,28 +37,24 @@ describe('Weight tickets page', () => {
     it('renders both the Save buttons are disabled', () => {
       const weightTicket = mountComponents('No', true, true);
       const buttonGroup = weightTicket.find(PPMPaymentRequestActionBtns);
-      const cancel = weightTicket.find('button').at(0);
-      const saveForLater = weightTicket.find('button').at(1);
-      const saveAndAdd = weightTicket.find('button').at(2);
+      const finishLater = weightTicket.find('button').at(0);
+      const saveAndAdd = weightTicket.find('button').at(1);
 
       expect(buttonGroup.length).toEqual(1);
-      expect(cancel.props().disabled).not.toEqual(true);
       expect(saveAndAdd.props().disabled).toEqual(true);
-      expect(saveForLater.props().disabled).toEqual(true);
+      expect(finishLater.props().disabled).not.toEqual(true);
     });
   });
   describe('Service member has uploaded both a weight tickets', () => {
     it('renders both the Save buttons are enabled', () => {
       const weightTicket = mountComponents('No', false, false);
       const buttonGroup = weightTicket.find(PPMPaymentRequestActionBtns);
-      const cancel = weightTicket.find('button').at(0);
-      const saveForLater = weightTicket.find('button').at(1);
-      const saveAndAdd = weightTicket.find('button').at(2);
+      const finishLater = weightTicket.find('button').at(0);
+      const saveAndAdd = weightTicket.find('button').at(1);
 
       expect(buttonGroup.length).toEqual(1);
-      expect(cancel.props().disabled).not.toEqual(true);
       expect(saveAndAdd.props().disabled).toEqual(false);
-      expect(saveForLater.props().disabled).toEqual(false);
+      expect(finishLater.props().disabled).not.toEqual(true);
     });
   });
   describe('Service member answers "Yes" that they have more weight tickets', () => {

--- a/src/shared/AlertWithConfirmation/index.css
+++ b/src/shared/AlertWithConfirmation/index.css
@@ -23,17 +23,14 @@
   display: inline;
 }
 
-.usa-alert-loading {
-  background-color: #e1f3f8;
-}
-
 .heading--icon {
   margin-right: 2em;
 }
 
-.remove-icon {
-  position: absolute;
-  right: 2em;
+.cancel-or-ok-buttons {
+	flex-grow: 1;
+	display: flex;
+	justify-content: flex-end;
 }
 
 .usa-alert-loading::before {

--- a/src/shared/AlertWithConfirmation/index.css
+++ b/src/shared/AlertWithConfirmation/index.css
@@ -1,0 +1,45 @@
+.usa-alert {
+	white-space: pre-wrap;
+}
+
+.usa-alert.usa-alert-success p {
+	margin-bottom: 1rem;
+}
+
+.usa-alert .usa-alert-no-padding {
+  padding: 0em;
+}
+
+.usa-alert .usa-alert-right {
+  float: right;
+}
+
+.body--heading {
+  display: flex;
+  align-items: center;
+}
+
+.usa-alert-heading {
+  display: inline;
+}
+
+.usa-alert-loading {
+  background-color: #e1f3f8;
+}
+
+.heading--icon {
+  margin-right: 2em;
+}
+
+.remove-icon {
+  position: absolute;
+  right: 2em;
+}
+
+.usa-alert-loading::before {
+  background-color: #02bfe7;
+}
+
+.actionable.actionable-secondary {
+  color: #999999;
+}

--- a/src/shared/AlertWithConfirmation/index.jsx
+++ b/src/shared/AlertWithConfirmation/index.jsx
@@ -1,0 +1,65 @@
+// eslint-disable-next-line no-unused-vars
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import './index.css';
+import FontAwesomeIcon from '@fortawesome/react-fontawesome';
+import faTimes from '@fortawesome/fontawesome-free-solid/faTimes';
+import { withRouter } from 'react-router-dom';
+
+//this is taken from https://designsystem.digital.gov/components/alerts/
+class AlertWithConfirmation extends Component {
+  cancelActionHandler = () => {
+    return this.props.cancelActionHandler;
+  };
+
+  confirmActionHandler = () => {
+    return this.props.okActionHandler;
+  };
+
+  render() {
+    return (
+      <div className="usa-width-one-whole">
+        <div className={`usa-alert usa-alert-${this.props.type}`}>
+          <div className="usa-alert-body">
+            <div className="body--heading">
+              <div>
+                <div>
+                  {this.props.heading && <h3 className="usa-alert-heading">{this.props.heading}</h3>}
+                  {this.props.onRemove && (
+                    <FontAwesomeIcon
+                      className="icon remove-icon actionable actionable-secondary"
+                      onClick={this.props.onRemove}
+                      icon={faTimes}
+                    />
+                  )}
+                </div>
+                <div className="usa-alert-text">{this.props.message}</div>
+                <div className="cancel-or-ok-buttons">
+                  <button type="button" className="usa-button-secondary" onClick={this.cancelActionHandler()}>
+                    Cancel
+                  </button>
+                  <button type="button" className="usa-button" onClick={this.confirmActionHandler()}>
+                    OK
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
+const requiredPropsCheck = (props, propName, componentName) => {
+  if (!props.message) {
+    return new Error(`Message is required by '${componentName}' component.`);
+  }
+};
+
+AlertWithConfirmation.propTypes = {
+  message: requiredPropsCheck,
+  onRemove: PropTypes.func,
+  type: PropTypes.oneOf(['error', 'warning', 'info', 'success', 'loading']),
+};
+export default withRouter(AlertWithConfirmation);

--- a/src/shared/AlertWithConfirmation/index.jsx
+++ b/src/shared/AlertWithConfirmation/index.jsx
@@ -2,9 +2,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import './index.css';
-import FontAwesomeIcon from '@fortawesome/react-fontawesome';
-import faTimes from '@fortawesome/fontawesome-free-solid/faTimes';
-import { withRouter } from 'react-router-dom';
 
 //this is taken from https://designsystem.digital.gov/components/alerts/
 class AlertWithConfirmation extends Component {
@@ -23,16 +20,7 @@ class AlertWithConfirmation extends Component {
           <div className="usa-alert-body">
             <div className="body--heading">
               <div>
-                <div>
-                  {this.props.heading && <h3 className="usa-alert-heading">{this.props.heading}</h3>}
-                  {this.props.onRemove && (
-                    <FontAwesomeIcon
-                      className="icon remove-icon actionable actionable-secondary"
-                      onClick={this.props.onRemove}
-                      icon={faTimes}
-                    />
-                  )}
-                </div>
+                <div>{this.props.heading && <h3 className="usa-alert-heading">{this.props.heading}</h3>}</div>
                 <div className="usa-alert-text">{this.props.message}</div>
                 <div className="cancel-or-ok-buttons">
                   <button type="button" className="usa-button-secondary" onClick={this.cancelActionHandler()}>
@@ -52,14 +40,14 @@ class AlertWithConfirmation extends Component {
 }
 
 const requiredPropsCheck = (props, propName, componentName) => {
-  if (!props.message) {
-    return new Error(`Message is required by '${componentName}' component.`);
+  if (!props.heading || !props.message) {
+    return new Error(`A heading or message is required by '${componentName}' component.`);
   }
 };
 
 AlertWithConfirmation.propTypes = {
+  heading: requiredPropsCheck,
   message: requiredPropsCheck,
-  onRemove: PropTypes.func,
-  type: PropTypes.oneOf(['error', 'warning', 'info', 'success', 'loading']),
+  type: PropTypes.oneOf(['error', 'warning', 'info', 'success']),
 };
-export default withRouter(AlertWithConfirmation);
+export default AlertWithConfirmation;

--- a/src/shared/AlertWithConfirmation/index.jsx
+++ b/src/shared/AlertWithConfirmation/index.jsx
@@ -3,36 +3,25 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import './index.css';
 
-//this is taken from https://designsystem.digital.gov/components/alerts/
-class AlertWithConfirmation extends Component {
-  cancelActionHandler = () => {
-    return this.props.cancelActionHandler;
-  };
-
-  confirmActionHandler = () => {
-    return this.props.okActionHandler;
-  };
-
-  render() {
-    return (
-      <div className={`usa-alert usa-alert-${this.props.type} usa-width-one-whole`}>
-        <div className="usa-alert-body usa-width-one-whole">
-          <div className="body--heading">
-            <div>{this.props.heading && <h3 className="usa-alert-heading">{this.props.heading}</h3>}</div>
-            <div className="usa-alert-text">{this.props.message}</div>
-            <div className="cancel-or-ok-buttons">
-              <button type="button" className="usa-button-secondary" onClick={this.cancelActionHandler()}>
-                Cancel
-              </button>
-              <button type="button" className="usa-button" onClick={this.confirmActionHandler()}>
-                OK
-              </button>
-            </div>
+export function AlertWithConfirmation(props) {
+  return (
+    <div className={`usa-alert usa-alert-${props.type} usa-width-one-whole`}>
+      <div className="usa-alert-body usa-width-one-whole">
+        <div className="body--heading">
+          <div>{props.heading && <h3 className="usa-alert-heading">{props.heading}</h3>}</div>
+          <div className="usa-alert-text">{props.message}</div>
+          <div className="cancel-or-ok-buttons">
+            <button type="button" className="usa-button-secondary" onClick={props.cancelActionHandler}>
+              Cancel
+            </button>
+            <button type="button" className="usa-button" onClick={props.okActionHandler}>
+              OK
+            </button>
           </div>
         </div>
       </div>
-    );
-  }
+    </div>
+  );
 }
 
 const requiredPropsCheck = (props, propName, componentName) => {

--- a/src/shared/AlertWithConfirmation/index.jsx
+++ b/src/shared/AlertWithConfirmation/index.jsx
@@ -15,22 +15,18 @@ class AlertWithConfirmation extends Component {
 
   render() {
     return (
-      <div className="usa-width-one-whole">
-        <div className={`usa-alert usa-alert-${this.props.type}`}>
-          <div className="usa-alert-body">
-            <div className="body--heading">
-              <div>
-                <div>{this.props.heading && <h3 className="usa-alert-heading">{this.props.heading}</h3>}</div>
-                <div className="usa-alert-text">{this.props.message}</div>
-                <div className="cancel-or-ok-buttons">
-                  <button type="button" className="usa-button-secondary" onClick={this.cancelActionHandler()}>
-                    Cancel
-                  </button>
-                  <button type="button" className="usa-button" onClick={this.confirmActionHandler()}>
-                    OK
-                  </button>
-                </div>
-              </div>
+      <div className={`usa-alert usa-alert-${this.props.type} usa-width-one-whole`}>
+        <div className="usa-alert-body usa-width-one-whole">
+          <div className="body--heading">
+            <div>{this.props.heading && <h3 className="usa-alert-heading">{this.props.heading}</h3>}</div>
+            <div className="usa-alert-text">{this.props.message}</div>
+            <div className="cancel-or-ok-buttons">
+              <button type="button" className="usa-button-secondary" onClick={this.cancelActionHandler()}>
+                Cancel
+              </button>
+              <button type="button" className="usa-button" onClick={this.confirmActionHandler()}>
+                OK
+              </button>
             </div>
           </div>
         </div>

--- a/src/shared/AlertWithConfirmation/index.test.jsx
+++ b/src/shared/AlertWithConfirmation/index.test.jsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import Alert from '.';
+
+describe('basic alert component', () => {
+  const text = 'some text';
+  const heading = 'a heading';
+  const wrapper = shallow(<Alert heading={heading}>{text}</Alert>);
+  it('should render children and heading', () => {
+    expect(wrapper.find('.usa-alert-heading').text()).toBe(heading);
+    expect(wrapper.find('.usa-alert-text').text()).toBe(text);
+  });
+  it('should not have a close button', () => {
+    expect(wrapper.find('.icon.remove-icon')).toHaveLength(0);
+  });
+  it('should not display a spinner', () => {
+    expect(wrapper.find('.heading--icon')).toHaveLength(0);
+  });
+  describe('loading alert', () => {
+    const wrapper = shallow(
+      <Alert heading={heading} type="loading">
+        {text}
+      </Alert>,
+    );
+    it('should display a spinner', () => {
+      expect(wrapper.find('.heading--icon')).toHaveLength(1);
+    });
+  });
+  describe('close button', () => {
+    const mockOnRemove = jest.fn();
+    const wrapper = shallow(
+      <Alert heading={heading} onRemove={mockOnRemove}>
+        {text}
+      </Alert>,
+    );
+    it('should render a close button', () => {
+      expect(wrapper.find('.icon.remove-icon')).toHaveLength(1);
+      wrapper.find('.icon.remove-icon').simulate('click');
+      expect(mockOnRemove).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/shared/AlertWithConfirmation/index.test.jsx
+++ b/src/shared/AlertWithConfirmation/index.test.jsx
@@ -1,11 +1,18 @@
 import React from 'react';
-import { shallow } from 'enzyme';
-import Alert from '.';
+// import { shallow } from 'enzyme';
+import { Provider } from 'react-redux';
+import store from 'shared/store';
+import { mount } from 'enzyme';
+import AlertWithConfirmation from '.';
 
-describe('basic alert component', () => {
+describe('basic alert with confirmation component', () => {
   const text = 'some text';
   const heading = 'a heading';
-  const wrapper = shallow(<Alert heading={heading}>{text}</Alert>);
+  const wrapper = mount(
+    <Provider store={store}>
+      <AlertWithConfirmation heading={heading} message={text} />
+    </Provider>,
+  );
   it('should render children and heading', () => {
     expect(wrapper.find('.usa-alert-heading').text()).toBe(heading);
     expect(wrapper.find('.usa-alert-text').text()).toBe(text);
@@ -16,27 +23,30 @@ describe('basic alert component', () => {
   it('should not display a spinner', () => {
     expect(wrapper.find('.heading--icon')).toHaveLength(0);
   });
-  describe('loading alert', () => {
-    const wrapper = shallow(
-      <Alert heading={heading} type="loading">
-        {text}
-      </Alert>,
+  describe('cancel confirmation', () => {
+    const mockCancelActionHandler = jest.fn();
+    const wrapper = mount(
+      <Provider store={store}>
+        <AlertWithConfirmation heading={heading} message={text} cancelActionHandler={mockCancelActionHandler} />
+      </Provider>,
     );
-    it('should display a spinner', () => {
-      expect(wrapper.find('.heading--icon')).toHaveLength(1);
+    it('should render cancel button', () => {
+      expect(wrapper.find('.usa-button-secondary')).toHaveLength(1);
+      wrapper.find('.usa-button-secondary').simulate('click');
+      expect(mockCancelActionHandler).toHaveBeenCalled();
     });
   });
-  describe('close button', () => {
-    const mockOnRemove = jest.fn();
-    const wrapper = shallow(
-      <Alert heading={heading} onRemove={mockOnRemove}>
-        {text}
-      </Alert>,
+  describe('ok confirmation', () => {
+    const mockOkActionHandler = jest.fn();
+    const wrapper = mount(
+      <Provider store={store}>
+        <AlertWithConfirmation heading={heading} message={text} okActionHandler={mockOkActionHandler} />
+      </Provider>,
     );
-    it('should render a close button', () => {
-      expect(wrapper.find('.icon.remove-icon')).toHaveLength(1);
-      wrapper.find('.icon.remove-icon').simulate('click');
-      expect(mockOnRemove).toHaveBeenCalled();
+    it('should render cancel and ok buttons', () => {
+      expect(wrapper.find('.usa-button')).toHaveLength(1);
+      wrapper.find('.usa-button').simulate('click');
+      expect(mockOkActionHandler).toHaveBeenCalled();
     });
   });
 });

--- a/src/shared/AlertWithConfirmation/index.test.jsx
+++ b/src/shared/AlertWithConfirmation/index.test.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-// import { shallow } from 'enzyme';
 import { Provider } from 'react-redux';
 import store from 'shared/store';
 import { mount } from 'enzyme';


### PR DESCRIPTION
## Description

This work replaces cancel and save for later and now gives a warning to those that plan on finishing later.

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make db_dev_e2e_populate && make server_run
make client_run
```
visit `milmovelocal:3000?flag:ppmPaymentRequest=true`
sign in as `ppm@requestingpay.ment`.
Start requesting payment, at each step, try out the `finish later` button. It should only warn on the weight tickets page and the expenses page. 

## Code Review Verification Steps

* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* https://www.pivotaltracker.com/story/show/166932269

## Screenshots

<img width="1117" alt="Screen Shot 2019-07-15 at 4 33 28 PM" src="https://user-images.githubusercontent.com/5531789/61256300-24858400-a721-11e9-8538-f5c94fdeed70.png">
<img width="1023" alt="Screen Shot 2019-07-15 at 4 53 01 PM" src="https://user-images.githubusercontent.com/5531789/61256308-251e1a80-a721-11e9-82a3-52a9fdbb7307.png">
<img width="1055" alt="Screen Shot 2019-07-15 at 4 53 20 PM" src="https://user-images.githubusercontent.com/5531789/61256305-24858400-a721-11e9-9117-cd2f4bc713fa.png">
<img width="1126" alt="Screen Shot 2019-07-15 at 4 53 32 PM" src="https://user-images.githubusercontent.com/5531789/61256303-24858400-a721-11e9-9343-8f0f98652ae6.png">
<img width="1035" alt="Screen Shot 2019-07-15 at 4 53 37 PM" src="https://user-images.githubusercontent.com/5531789/61256301-24858400-a721-11e9-87cd-f3a2d60f1267.png">
<img width="1131" alt="Screen Shot 2019-07-15 at 4 53 08 PM" src="https://user-images.githubusercontent.com/5531789/61256307-251e1a80-a721-11e9-8100-28d363b73b28.png">
<img width="1137" alt="Screen Shot 2019-07-15 at 4 58 05 PM" src="https://user-images.githubusercontent.com/5531789/61256467-bf7e5e00-a721-11e9-8c61-cafd81dd2621.png">