### PR TITLE
Update DB_PORT to use DB_PORT_TEST in pop_suite.go

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -469,6 +469,7 @@ jobs:
             DB_PASSWORD: mysecretpassword
             DB_USER: postgres
             DB_HOST: localhost
+            DB_PORT_TEST: 5433
             DB_PORT: 5432
             DB_NAME: test_db
             EIA_KEY: db2522a43820268a41a802a16ae9fd26 # dummy key generated with openssl rand -hex 16
@@ -520,6 +521,7 @@ jobs:
             DB_PASSWORD: mysecretpassword
             DB_USER: postgres
             DB_HOST: localhost
+            DB_PORT_TEST: 5433
             DB_PORT: 5432
             DB_NAME: test_db
             EIA_KEY: db2522a43820268a41a802a16ae9fd26 # dummy key generated with openssl rand -hex 16

--- a/docs/how-to/run-go-tests.md
+++ b/docs/how-to/run-go-tests.md
@@ -33,7 +33,7 @@ $ TEST_ACC_ENV=staging TEST_ACC_DOD_CERTIFICATES=1 make webserver_test
 ### Run All Tests in a Single Package
 
 ```console
-$ scripts/go-test ./pkg/handlers/internalapi/
+$ go-test ./pkg/handlers/internalapi/
 ```
 
 ### Run Tests with Names Matching a String
@@ -41,7 +41,7 @@ $ scripts/go-test ./pkg/handlers/internalapi/
 The following will run any Testify tests that have a name matching `Test_Name` in the `handlers/internalapi` package:
 
 ```console
-$ scripts/go-test ./pkg/handlers/internalapi/ -testify.m Test_Name
+$ go-test ./pkg/handlers/internalapi/ -testify.m Test_Name
 ```
 
 ## Run Tests when a File Changes

--- a/docs/how-to/run-go-tests.md
+++ b/docs/how-to/run-go-tests.md
@@ -33,7 +33,7 @@ $ TEST_ACC_ENV=staging TEST_ACC_DOD_CERTIFICATES=1 make webserver_test
 ### Run All Tests in a Single Package
 
 ```console
-$ go-test ./pkg/handlers/internalapi/
+$ go test ./pkg/handlers/internalapi/
 ```
 
 ### Run Tests with Names Matching a String
@@ -41,7 +41,7 @@ $ go-test ./pkg/handlers/internalapi/
 The following will run any Testify tests that have a name matching `Test_Name` in the `handlers/internalapi` package:
 
 ```console
-$ go-test ./pkg/handlers/internalapi/ -testify.m Test_Name
+$ go test ./pkg/handlers/internalapi/ -testify.m Test_Name
 ```
 
 ## Run Tests when a File Changes

--- a/pkg/testingsuite/pop_suite.go
+++ b/pkg/testingsuite/pop_suite.go
@@ -22,7 +22,7 @@ type PopTestSuite struct {
 }
 
 func commandWithDefaults(command string, args ...string) *exec.Cmd {
-	port := envy.MustGet("DB_PORT")
+	port := envy.MustGet("DB_PORT_TEST")
 	defaults := []string{"-U", "postgres", "-h", "localhost", "-p", port}
 
 	arguments := append(defaults, args...)
@@ -109,7 +109,7 @@ func NewPopTestSuite(packageName PackageName) PopTestSuite {
 		Dialect:  "postgres",
 		Database: dbName,
 		Host:     envy.MustGet("DB_HOST"),
-		Port:     envy.MustGet("DB_PORT"),
+		Port:     envy.MustGet("DB_PORT_TEST"),
 		User:     envy.MustGet("DB_USER"),
 		Password: envy.MustGet("DB_PASSWORD"),
 	})

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -91,7 +91,6 @@ This subset of development scripts is used for testing
 | Script Name | Description |
 | --- | --- |
 | `gen-e2e-migration` | generate migrations for cypress |
-| `go-test` | runs go test but with the correct DB port |
 | `run-e2e-test` | Runs cypress tests with interactive GUI |
 | `run-e2e-test-docker` | Runs cypress tests entirely inside docker containers like in CircleCI |
 

--- a/scripts/go-test
+++ b/scripts/go-test
@@ -1,7 +1,0 @@
-#! /usr/bin/env bash
-#
-#   go-test runs go test but with the correct DB port
-#   For example: scripts/go-test ./pkg/models
-#
-
-go test "$@"

--- a/scripts/go-test
+++ b/scripts/go-test
@@ -4,4 +4,4 @@
 #   For example: scripts/go-test ./pkg/models
 #
 
-DB_PORT=$DB_PORT_TEST go test "$@"
+go test "$@"


### PR DESCRIPTION
## Description

Running individual tests in Goland was failing to pickup the correct DB_PORT for the test db since it was being set in `scripts/go-test`. I think was can just set in the setup commands for the test db and not have to rely on it being set in the script.

## Reviewer Notes

Wasn't sure if should change scripts/go-test, seemed redundant if change in `pop_suite.go`, but maybe should just leave it be.

## Setup

```sh
make server_test
```
Also try running individual tests in Goland

## Code Review Verification Steps
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?