### PR TITLE
failed merge, fix conflicts for e2ebasic.go from PR 2298

### DIFF
--- a/pkg/testdatagen/scenario/e2ebasic.go
+++ b/pkg/testdatagen/scenario/e2ebasic.go
@@ -2599,6 +2599,53 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, log
 	models.SaveMoveDependencies(db, &hhg43.Move)
 
 	/*
+	 * Service member with accepted move for use in testing the deletion of SIT
+	 */
+	email = "hhg@sit.todelete"
+	offer44 := testdatagen.MakeShipmentOffer(db, testdatagen.Assertions{
+		User: models.User{
+			ID:            uuid.Must(uuid.FromString("76616087-713d-4837-8941-f2b73f532a10")),
+			LoginGovEmail: email,
+		},
+		ServiceMember: models.ServiceMember{
+			ID:            uuid.FromStringOrNil("54bae5b4-af77-4693-a3b3-3ff6f5796a92"),
+			FirstName:     models.StringPointer("SIT"),
+			LastName:      models.StringPointer("ToDelete"),
+			Edipi:         models.StringPointer("1357924622"),
+			PersonalEmail: models.StringPointer(email),
+		},
+		Move: models.Move{
+			ID:               uuid.FromStringOrNil("9811bc2c-45e7-40d2-aee0-d863f0d2b7ee"),
+			Locator:          "SITDEL",
+			SelectedMoveType: &selectedMoveTypeHHG,
+		},
+		TrafficDistributionList: models.TrafficDistributionList{
+			ID:                uuid.FromStringOrNil("0c395d75-ec2f-45de-8d3f-74716d69aa67"),
+			SourceRateArea:    "US62",
+			DestinationRegion: "11",
+			CodeOfService:     "D",
+		},
+		Shipment: models.Shipment{
+			Status: models.ShipmentStatusACCEPTED,
+		},
+		ShipmentOffer: models.ShipmentOffer{
+			TransportationServiceProviderID: tspUser.TransportationServiceProviderID,
+			Accepted:                        models.BoolPointer(true),
+		},
+	})
+
+	testdatagen.MakeStorageInTransit(db, testdatagen.Assertions{
+		StorageInTransit: models.StorageInTransit{
+			ShipmentID:         offer44.ShipmentID,
+			Shipment:           offer44.Shipment,
+			EstimatedStartDate: time.Date(2019, time.Month(4), 22, 0, 0, 0, 0, time.UTC),
+		},
+	})
+	hhg44 := offer44.Shipment
+	hhg44.Move.Submit(time.Now())
+	models.SaveMoveDependencies(db, &hhg44.Move)
+
+	/*
 	 * HHG45
 	 * Service member with in-transit shipment and Origin DELIVERED SIT
 	 */
@@ -2655,111 +2702,6 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, log
 	hhg45 := offer45.Shipment
 	hhg45.Move.Submit(time.Now())
 	models.SaveMoveDependencies(db, &hhg45.Move)
-
-	/*
-	 * HHG46
-	 * Service member with in-transit shipment and Destination DELIVERED SIT
-	 */
-	email = "hhg@sit.delivered.destination"
-	offer46 := testdatagen.MakeShipmentOffer(db, testdatagen.Assertions{
-		User: models.User{
-			ID:            uuid.Must(uuid.NewV4()),
-			LoginGovEmail: email,
-		},
-		ServiceMember: models.ServiceMember{
-			ID:            uuid.Must(uuid.NewV4()),
-			FirstName:     models.StringPointer("DESTINATION-SIT"),
-			LastName:      models.StringPointer("DELIVERED"),
-			Edipi:         models.StringPointer("1857924699"),
-			PersonalEmail: models.StringPointer(email),
-		},
-		Move: models.Move{
-			ID:               uuid.Must(uuid.NewV4()),
-			Locator:          "SITDST", // SIT Destination DELIVERED
-			SelectedMoveType: &selectedMoveTypeHHG,
-		},
-		TrafficDistributionList: models.TrafficDistributionList{
-			ID:                uuid.Must(uuid.NewV4()),
-			SourceRateArea:    "US62",
-			DestinationRegion: "11",
-			CodeOfService:     "D",
-		},
-		Shipment: models.Shipment{
-			Status: models.ShipmentStatusDELIVERED,
-		},
-		ShipmentOffer: models.ShipmentOffer{
-			TransportationServiceProviderID: tspUser.TransportationServiceProviderID,
-			Accepted:                        models.BoolPointer(true),
-		},
-	})
-
-	authorizedStartDateOffer46 := time.Date(2019, time.Month(3), 26, 0, 0, 0, 0, time.UTC)
-	outDate46 := time.Date(2019, time.Month(3), 27, 0, 0, 0, 0, time.UTC)
-	sit46 := models.StorageInTransit{
-		ID:                  uuid.Must(uuid.NewV4()),
-		ShipmentID:          offer46.ShipmentID,
-		Shipment:            offer46.Shipment,
-		Location:            models.StorageInTransitLocationDESTINATION,
-		Status:              models.StorageInTransitStatusDELIVERED,
-		EstimatedStartDate:  time.Date(2019, time.Month(3), 22, 0, 0, 0, 0, time.UTC),
-		ActualStartDate:     &authorizedStartDateOffer46,
-		AuthorizedStartDate: &authorizedStartDateOffer46,
-		OutDate:             &outDate46,
-		SITNumber:           models.StringPointer("400000001"),
-	}
-	testdatagen.MakeStorageInTransit(db, testdatagen.Assertions{
-		StorageInTransit: sit46,
-	})
-	hhg46 := offer46.Shipment
-	hhg46.Move.Submit(time.Now())
-	models.SaveMoveDependencies(db, &hhg46.Move)
-
-	/*
-	 * Service member with accepted move for use in testing the deletion of SIT
-	 */
-	email = "hhg@sit.todelete"
-	offer44 := testdatagen.MakeShipmentOffer(db, testdatagen.Assertions{
-		User: models.User{
-			ID:            uuid.Must(uuid.FromString("76616087-713d-4837-8941-f2b73f532a10")),
-			LoginGovEmail: email,
-		},
-		ServiceMember: models.ServiceMember{
-			ID:            uuid.FromStringOrNil("54bae5b4-af77-4693-a3b3-3ff6f5796a92"),
-			FirstName:     models.StringPointer("SIT"),
-			LastName:      models.StringPointer("ToDelete"),
-			Edipi:         models.StringPointer("1357924622"),
-			PersonalEmail: models.StringPointer(email),
-		},
-		Move: models.Move{
-			ID:               uuid.FromStringOrNil("9811bc2c-45e7-40d2-aee0-d863f0d2b7ee"),
-			Locator:          "SITDEL",
-			SelectedMoveType: &selectedMoveTypeHHG,
-		},
-		TrafficDistributionList: models.TrafficDistributionList{
-			ID:                uuid.FromStringOrNil("0c395d75-ec2f-45de-8d3f-74716d69aa67"),
-			SourceRateArea:    "US62",
-			DestinationRegion: "11",
-			CodeOfService:     "D",
-		},
-		Shipment: models.Shipment{
-			Status: models.ShipmentStatusACCEPTED,
-		},
-		ShipmentOffer: models.ShipmentOffer{
-			TransportationServiceProviderID: tspUser.TransportationServiceProviderID,
-			Accepted:                        models.BoolPointer(true),
-		},
-	})
-
-	testdatagen.MakeStorageInTransit(db, testdatagen.Assertions{
-		StorageInTransit: models.StorageInTransit{
-			ShipmentID:         offer44.ShipmentID,
-			Shipment:           offer44.Shipment,
-			EstimatedStartDate: time.Date(2019, time.Month(4), 22, 0, 0, 0, 0, time.UTC),
-		},
-	})
-	hhg44 := offer44.Shipment
-	hhg44.Move.Submit(time.Now())
-	models.SaveMoveDependencies(db, &hhg44.Move)
 
 	/* HHG46
 	 * Service member with in transit shipment and SIT less than 30 mi
@@ -3161,6 +3103,64 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, log
 
 	hhg48.Move.Submit(time.Now())
 	models.SaveMoveDependencies(db, &hhg48.Move)
+
+	/*
+	 * HHG49
+	 * Service member with in-transit shipment and Destination DELIVERED SIT
+	 */
+	email = "hhg@sit.delivered.destination"
+	offer49 := testdatagen.MakeShipmentOffer(db, testdatagen.Assertions{
+		User: models.User{
+			ID:            uuid.Must(uuid.NewV4()),
+			LoginGovEmail: email,
+		},
+		ServiceMember: models.ServiceMember{
+			ID:            uuid.Must(uuid.NewV4()),
+			FirstName:     models.StringPointer("DESTINATION-SIT"),
+			LastName:      models.StringPointer("DELIVERED"),
+			Edipi:         models.StringPointer("1857924699"),
+			PersonalEmail: models.StringPointer(email),
+		},
+		Move: models.Move{
+			ID:               uuid.Must(uuid.NewV4()),
+			Locator:          "SITDST", // SIT Destination DELIVERED
+			SelectedMoveType: &selectedMoveTypeHHG,
+		},
+		TrafficDistributionList: models.TrafficDistributionList{
+			ID:                uuid.Must(uuid.NewV4()),
+			SourceRateArea:    "US62",
+			DestinationRegion: "11",
+			CodeOfService:     "D",
+		},
+		Shipment: models.Shipment{
+			Status: models.ShipmentStatusDELIVERED,
+		},
+		ShipmentOffer: models.ShipmentOffer{
+			TransportationServiceProviderID: tspUser.TransportationServiceProviderID,
+			Accepted:                        models.BoolPointer(true),
+		},
+	})
+
+	authorizedStartDateOffer49 := time.Date(2019, time.Month(3), 26, 0, 0, 0, 0, time.UTC)
+	outDate49 := time.Date(2019, time.Month(3), 27, 0, 0, 0, 0, time.UTC)
+	sit49 := models.StorageInTransit{
+		ID:                  uuid.Must(uuid.NewV4()),
+		ShipmentID:          offer49.ShipmentID,
+		Shipment:            offer49.Shipment,
+		Location:            models.StorageInTransitLocationDESTINATION,
+		Status:              models.StorageInTransitStatusDELIVERED,
+		EstimatedStartDate:  time.Date(2019, time.Month(3), 22, 0, 0, 0, 0, time.UTC),
+		ActualStartDate:     &authorizedStartDateOffer49,
+		AuthorizedStartDate: &authorizedStartDateOffer49,
+		OutDate:             &outDate49,
+		SITNumber:           models.StringPointer("400000001"),
+	}
+	testdatagen.MakeStorageInTransit(db, testdatagen.Assertions{
+		StorageInTransit: sit49,
+	})
+	hhg49 := offer49.Shipment
+	hhg49.Move.Submit(time.Now())
+	models.SaveMoveDependencies(db, &hhg49.Move)
 
 	/*
 	 * Service member with a ppm ready to request payment


### PR DESCRIPTION
## Description

Fix for PR merge #2298, failed merge of e2ebasic.go file.

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
echo "Code goes here"
```

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/tree/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/tree/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/tree/master/docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
  * [ ] Secure migrations have been tested using `scripts/run-prod-migrations`
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](tbd) for this change
* [this article](tbd) explains more about the approach used.

## Screenshots

If this PR makes visible UI changes, an image of the finished UI can help reviewers and casual
observers understand the context of the changes. A before image is optional and
can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow instead of using multiple images. You may want to use GIPHY CAPTURE for this! 📸

_Please frame screenshots to show enough useful context but also highlight the affected regions._
