### PR TITLE
Set the max timeout for migration step to 60 minutes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,6 +74,7 @@ commands:
       - run:
           name: Run migrations
           command: scripts/do-exclusively --job-name ${CIRCLE_JOB} scripts/ecs-run-app-migrations-container config/app-migrations.container-definition.json ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/app-migrations:git-${CIRCLE_SHA1} $APP_ENVIRONMENT
+          no_output_timeout: 60m
           environment:
             CHAMBER_RETRIES: 20
       - announce_failure


### PR DESCRIPTION
## Description

The default timeout for CircleCI when they have no output is to close after 10 minutes. This is a problem for long migrations since we then can't monitor from CircleCI and have to move to CloudWatch logs. According to [this article](https://support.circleci.com/hc/en-us/articles/360007188574-Build-has-hit-timeout-limit) the fix is pretty simple.