### PR TITLE
Run integration tests in parallel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -323,8 +323,8 @@ jobs:
             NO_TLS_ENABLED: true
       - announce_failure
 
-  # `integration_tests_parallel` runs integration tests using Cypress.  https://www.cypress.io/
-  integration_tests_parallel:
+  # `integration_tests` runs integration tests using Cypress.  https://www.cypress.io/
+  integration_tests:
     parallelism: 10
     executor: mymove_medium
     steps:
@@ -809,7 +809,7 @@ workflows:
             - pre_deps_golang
             - pre_deps_yarn
 
-      - integration_tests_parallel:
+      - integration_tests:
           requires:
             - pre_deps_golang
             - pre_deps_yarn
@@ -908,7 +908,7 @@ workflows:
             - build_tasks
             - acceptance_tests_local
             - acceptance_tests_staging
-            - integration_tests_parallel
+            - integration_tests
           filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -177,9 +177,6 @@ commands:
             docker tag << parameters.tag >> ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/<< parameters.repo >>:git-${CIRCLE_SHA1}
             docker push ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/<< parameters.repo >>:git-${CIRCLE_SHA1}
   e2e_tests:
-    parameters:
-      spec:
-        type: string
     steps:
       - run:
           name: make e2e_test_docker
@@ -192,7 +189,7 @@ commands:
             echo 'export LOGIN_GOV_HOSTNAME=$E2E_LOGIN_GOV_HOSTNAME' >> $BASH_ENV
             echo 'export HERE_MAPS_APP_ID=$E2E_HERE_MAPS_APP_ID' >> $BASH_ENV
             echo 'export HERE_MAPS_APP_CODE=$E2E_HERE_MAPS_APP_CODE' >> $BASH_ENV
-            echo 'export SPEC=<< parameters.spec>>' >> $BASH_ENV
+            echo "export SPEC=$(find cypress/integration -type f -name '*.js' | circleci tests split | tr '\n' ',' )" >> $BASH_ENV
             source $BASH_ENV
             make e2e_test_docker
           environment:
@@ -326,8 +323,9 @@ jobs:
             NO_TLS_ENABLED: true
       - announce_failure
 
-  # `integration_tests_mymove` runs integration tests using Cypress.  https://www.cypress.io/
-  integration_tests_mymove:
+  # `integration_tests_parallel` runs integration tests using Cypress.  https://www.cypress.io/
+  integration_tests_parallel:
+    parallelism: 10
     executor: mymove_medium
     steps:
       - checkout
@@ -342,92 +340,7 @@ jobs:
       - restore_cache:
           keys:
             - v2-mymove-node-modules-{{ checksum "yarn.lock" }}
-      - e2e_tests:
-          spec: 'cypress/integration/mymove/**/*'
-      - store_artifacts:
-          path: cypress/videos
-          destination: videos
-      - store_artifacts:
-          path: cypress/screenshots
-          destination: screenshots
-      - store_test_results:
-          path: cypress/results
-      - announce_failure
-
-  # `integration_tests_office` runs integration tests using Cypress.  https://www.cypress.io/
-  integration_tests_office:
-    executor: mymove_medium
-    steps:
-      - checkout
-      - setup_remote_docker:
-          docker_layer_caching: true
-      - restore_cache:
-          keys:
-            - go-mod-sources-v2-{{ checksum "go.sum" }}
-      - restore_cache:
-          keys:
-            - v2-cache-yarn-v2-{{ checksum "yarn.lock" }}
-      - restore_cache:
-          keys:
-            - v2-mymove-node-modules-{{ checksum "yarn.lock" }}
-      - e2e_tests:
-          spec: 'cypress/integration/office/**/*'
-      - store_artifacts:
-          path: cypress/videos
-          destination: videos
-      - store_artifacts:
-          path: cypress/screenshots
-          destination: screenshots
-      - store_test_results:
-          path: cypress/results
-      - announce_failure
-
-  # `integration_tests_tsp` runs integration tests using Cypress.  https://www.cypress.io/
-  integration_tests_tsp:
-    executor: mymove_medium
-    steps:
-      - checkout
-      - setup_remote_docker:
-          docker_layer_caching: true
-      - restore_cache:
-          keys:
-            - go-mod-sources-v2-{{ checksum "go.sum" }}
-      - restore_cache:
-          keys:
-            - v2-cache-yarn-v2-{{ checksum "yarn.lock" }}
-      - restore_cache:
-          keys:
-            - v2-mymove-node-modules-{{ checksum "yarn.lock" }}
-      - e2e_tests:
-          spec: 'cypress/integration/tsp/**/*'
-      - store_artifacts:
-          path: cypress/videos
-          destination: videos
-      - store_artifacts:
-          path: cypress/screenshots
-          destination: screenshots
-      - store_test_results:
-          path: cypress/results
-      - announce_failure
-
-  # `integration_tests_api` runs integration tests using Cypress.  https://www.cypress.io/
-  integration_tests_api:
-    executor: mymove_medium
-    steps:
-      - checkout
-      - setup_remote_docker:
-          docker_layer_caching: true
-      - restore_cache:
-          keys:
-            - go-mod-sources-v2-{{ checksum "go.sum" }}
-      - restore_cache:
-          keys:
-            - v2-cache-yarn-v2-{{ checksum "yarn.lock" }}
-      - restore_cache:
-          keys:
-            - v2-mymove-node-modules-{{ checksum "yarn.lock" }}
-      - e2e_tests:
-          spec: 'cypress/integration/api/**/*'
+      - e2e_tests
       - store_artifacts:
           path: cypress/videos
           destination: videos
@@ -896,37 +809,7 @@ workflows:
             - pre_deps_golang
             - pre_deps_yarn
 
-      - integration_tests_mymove:
-          requires:
-            - pre_deps_golang
-            - pre_deps_yarn
-            - acceptance_tests_local
-          # if testing on experimental, you can disable these tests by using the commented block below.
-          # filters:
-          #  branches:
-          #    ignore: placeholder_branch_name
-
-      - integration_tests_office:
-          requires:
-            - pre_deps_golang
-            - pre_deps_yarn
-            - acceptance_tests_local
-          # if testing on experimental, you can disable these tests by using the commented block below.
-          # filters:
-          #   branches:
-          #     ignore: placeholder_branch_name
-
-      - integration_tests_tsp:
-          requires:
-            - pre_deps_golang
-            - pre_deps_yarn
-            - acceptance_tests_local
-          # if testing on experimental, you can disable these tests by using the commented block below.
-          # filters:
-          #   branches:
-          #     ignore: placeholder_branch_name
-
-      - integration_tests_api:
+      - integration_tests_parallel:
           requires:
             - pre_deps_golang
             - pre_deps_yarn
@@ -939,14 +822,26 @@ workflows:
       - client_test:
           requires:
             - pre_deps_yarn
+          # if testing on experimental, you can disable these tests by using the commented block below.
+          # filters:
+          #   branches:
+          #     ignore: placeholder_branch_name
 
       - server_test:
           requires:
             - pre_deps_golang
+          # if testing on experimental, you can disable these tests by using the commented block below.
+          # filters:
+          #   branches:
+          #     ignore: placeholder_branch_name
 
       - server_test_coverage:
           requires:
             - pre_deps_golang
+          # if testing on experimental, you can disable these tests by using the commented block below.
+          # filters:
+          #   branches:
+          #     ignore: placeholder_branch_name
 
       - build_app:
           requires:
@@ -1013,10 +908,7 @@ workflows:
             - build_tasks
             - acceptance_tests_local
             - acceptance_tests_staging
-            - integration_tests_mymove
-            - integration_tests_office
-            - integration_tests_tsp
-            - integration_tests_api
+            - integration_tests_parallel
           filters:
             branches:
               only: master


### PR DESCRIPTION
## Description

Integration tests can take up to 27 minutes when we run them across 4 separate instances. Unfortunately our spitting of the tests is uneven. This PR lets CircleCI split the tests into 10 separate containers so that we get more even coverage and then it runs them in parallel.  Now the average time is closer to 16min.  Here's a breakdown of [a single run](https://circleci.com/gh/transcom/mymove/141165):

<img width="1407" alt="Screen Shot 2019-07-18 at 3 01 23 PM" src="https://user-images.githubusercontent.com/219296/61495152-057b3200-a96d-11e9-8a80-058906b764c4.png">

You can read more about [Running Tests in Parallel](https://circleci.com/docs/2.0/parallelism-faster-jobs/) on the CircleCI website.  This also leverages the Cypress [spec](https://docs.cypress.io/guides/guides/command-line.html#cypress-run-spec-lt-spec-gt) utility like we were using before.

Could we do this faster? Yes! But we'd have to do one e2e test per file and then use CircleCI's built in test timer to figure out how to split them. This is something we could address in the future if we wanted to.

**Note:** If accepted we have to update github's merge criteria first and then folks need to rebase on master to get this change.