### PR TITLE
Make build/index.html  more resilient

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,7 @@ client_deps: .check_hosts.stamp .client_deps.stamp ## Install client dependencie
 client_build: .client_deps.stamp .client_build.stamp ## Build the client
 
 build/index.html: ## milmove serve requires this file to boot, but it isn't used during local development
-	mkdir build
+	mkdir -p build
 	touch build/index.html
 
 .PHONY: client_run


### PR DESCRIPTION
## Description

`make build/index.html` was failing if the build folder was present but the index.html was not. This PR uses `-p` parameter so the command is successful on a no-op.