### PR TITLE
Script to generate migrations for disabling users

### DIFF
--- a/cmd/milmove/gen_disable_user_migration.go
+++ b/cmd/milmove/gen_disable_user_migration.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"text/template"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	"github.com/spf13/viper"
+
+	"github.com/transcom/mymove/pkg/cli"
+)
+
+const (
+	// DisableUserMigrationFilenameFlag sql file containing the migration
+	DisableUserMigrationFilenameFlag string = "migration-filename"
+)
+
+const (
+	// template for adding office users
+	disableUser string = `UPDATE admin_users
+SET disabled=true
+WHERE email='{{.EmailPrefix}}@truss.works';
+
+UPDATE office_users
+SET disabled=true
+WHERE email='{{.EmailPrefix}}@truss.works';
+
+UPDATE tsp_users
+SET disabled=true
+WHERE email='{{.EmailPrefix}}+pyvl@truss.works'
+	OR email='{{.EmailPrefix}}+dlxm@truss.works'
+	OR email='{{.EmailPrefix}}+ssow@truss.works';
+`
+)
+
+// UserTemplate is a struct that stores the EmailPrefix from which to generate the migration
+type UserTemplate struct {
+	EmailPrefix string
+}
+
+func genDisableUserMigration(cmd *cobra.Command, args []string) error {
+	err := cmd.ParseFlags(args)
+	flag := cmd.Flags()
+	err = flag.Parse(os.Args[1:])
+	if err != nil {
+		return errors.Wrap(err, "could not parse flags")
+	}
+	v := viper.New()
+	err = v.BindPFlags(flag)
+	if err != nil {
+		return errors.Wrap(err, "could not bind flags")
+	}
+
+	migrationsPath := v.GetString(cli.MigrationPathFlag)
+	migrationManifest := v.GetString(cli.MigrationManifestFlag)
+	migrationFileName := v.GetString(DisableUserMigrationFilenameFlag)
+
+	user := UserTemplate{EmailPrefix: "NAME"}
+
+	secureMigrationName := fmt.Sprintf("%s_%s.up.sql", time.Now().Format(VersionTimeFormat), migrationFileName)
+	t1 := template.Must(template.New("disable_user").Parse(disableUser))
+	err = createMigration("./tmp", secureMigrationName, t1, user)
+	if err != nil {
+		return err
+	}
+	localMigrationPath := filepath.Join("local_migrations", secureMigrationName)
+	localMigrationFile, err := os.Create(localMigrationPath)
+	defer closeFile(localMigrationFile)
+	if err != nil {
+		return errors.Wrapf(err, "error creating %s", localMigrationPath)
+	}
+	log.Printf("new migration file created at:  %q\n", localMigrationPath)
+
+	migrationName := fmt.Sprintf("%s_%s.up.fizz", time.Now().Format(VersionTimeFormat), migrationFileName)
+	t2 := template.Must(template.New("migration").Parse(migration))
+	err = createMigration(migrationsPath, migrationName, t2, secureMigrationName)
+	if err != nil {
+		return err
+	}
+
+	err = addMigrationToManifest(migrationManifest, migrationName)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/cmd/milmove/gen_disable_user_migration.go
+++ b/cmd/milmove/gen_disable_user_migration.go
@@ -26,7 +26,11 @@ const (
 
 const (
 	// template for adding office users
-	disableUser string = `UPDATE admin_users
+	disableUser string = `UPDATE users
+SET disabled=true
+WHERE login_gov_email='{{.EmailPrefix}}@{{.EmailDomain}}';
+
+UPDATE admin_users
 SET disabled=true
 WHERE email='{{.EmailPrefix}}@{{.EmailDomain}}';
 

--- a/cmd/milmove/gen_disable_user_migration.go
+++ b/cmd/milmove/gen_disable_user_migration.go
@@ -19,9 +19,7 @@ import (
 )
 
 const (
-	// DisableUserMigrationFilenameFlag sql file containing the migration
-	DisableUserMigrationFilenameFlag string = "migration-filename"
-	DisableUserEmailFlag             string = "migration-email"
+	DisableUserEmailFlag string = "migration-email"
 )
 
 const (
@@ -48,7 +46,6 @@ WHERE email='{{.EmailPrefix}}+pyvl@{{.EmailDomain}}'
 
 func InitDisableUserFlags(flag *pflag.FlagSet) {
 	flag.StringP(DisableUserEmailFlag, "e", "", "Email address")
-	flag.StringP(DisableUserMigrationFilenameFlag, "n", "", "File name of the migration files for the new office users")
 }
 
 func initDisableUserMigrationFlags(flag *pflag.FlagSet) {
@@ -68,6 +65,15 @@ type UserTemplate struct {
 	EmailDomain string
 }
 
+func CheckDisableUserFlags(v *viper.Viper) error {
+	email := v.GetString(DisableUserEmailFlag)
+	if len(email) == 0 {
+		return fmt.Errorf("-e is required")
+	}
+
+	return nil
+}
+
 func genDisableUserMigration(cmd *cobra.Command, args []string) error {
 	err := cmd.ParseFlags(args)
 	flag := cmd.Flags()
@@ -83,11 +89,12 @@ func genDisableUserMigration(cmd *cobra.Command, args []string) error {
 
 	migrationsPath := v.GetString(cli.MigrationPathFlag)
 	migrationManifest := v.GetString(cli.MigrationManifestFlag)
-	migrationFileName := v.GetString(DisableUserMigrationFilenameFlag)
+	migrationFileName := "disable_user"
 	migrationEmail := strings.Split(v.GetString(DisableUserEmailFlag), "@")
 
-	if len(migrationEmail) < 2 {
-		return fmt.Errorf("-e is required")
+	err = CheckDisableUserFlags(v)
+	if err != nil {
+		return err
 	}
 
 	emailPrefix := migrationEmail[0]

--- a/cmd/milmove/main.go
+++ b/cmd/milmove/main.go
@@ -85,6 +85,16 @@ func main() {
 	initGenOfficeUserMigrationFlags(genOfficeUserMigrationCommand.Flags())
 	genCommand.AddCommand(genOfficeUserMigrationCommand)
 
+	genDisableUserMigrationCommand := &cobra.Command{
+		Use:                   "disable-user-migration -n MIGRATION_NAME",
+		Short:                 "Generate migrations required for disabling a user",
+		Long:                  "Generate migrations required for disabling a user",
+		RunE:                  genDisableUserMigration,
+		DisableFlagsInUseLine: true,
+	}
+	initGenOfficeUserMigrationFlags(genDisableUserMigrationCommand.Flags())
+	genCommand.AddCommand(genDisableUserMigrationCommand)
+
 	completionCommand := &cobra.Command{
 		Use:   "completion",
 		Short: "Generates bash completion scripts",

--- a/cmd/milmove/main.go
+++ b/cmd/milmove/main.go
@@ -86,13 +86,13 @@ func main() {
 	genCommand.AddCommand(genOfficeUserMigrationCommand)
 
 	genDisableUserMigrationCommand := &cobra.Command{
-		Use:                   "disable-user-migration -n MIGRATION_NAME",
+		Use:                   "disable-user-migration -e EMAIL -n MIGRATION_NAME",
 		Short:                 "Generate migrations required for disabling a user",
 		Long:                  "Generate migrations required for disabling a user",
 		RunE:                  genDisableUserMigration,
 		DisableFlagsInUseLine: true,
 	}
-	initGenOfficeUserMigrationFlags(genDisableUserMigrationCommand.Flags())
+	initDisableUserMigrationFlags(genDisableUserMigrationCommand.Flags())
 	genCommand.AddCommand(genDisableUserMigrationCommand)
 
 	completionCommand := &cobra.Command{

--- a/cmd/milmove/main.go
+++ b/cmd/milmove/main.go
@@ -86,7 +86,7 @@ func main() {
 	genCommand.AddCommand(genOfficeUserMigrationCommand)
 
 	genDisableUserMigrationCommand := &cobra.Command{
-		Use:                   "disable-user-migration -e EMAIL -n MIGRATION_NAME",
+		Use:                   "disable-user-migration -e EMAIL",
 		Short:                 "Generate migrations required for disabling a user",
 		Long:                  "Generate migrations required for disabling a user",
 		RunE:                  genDisableUserMigration,

--- a/docs/how-to/create-or-disable-users.md
+++ b/docs/how-to/create-or-disable-users.md
@@ -228,3 +228,9 @@ An example of disabling a DPS user by email:
 ```sql
 UPDATE dps_users SET disabled = true WHERE email = 'username@example.com';
 ```
+
+### Generating a migration to disable a specific user
+
+You can use the following `milmove` sub-command:
+
+`milmove gen disable-user-migration -n MIGRATION_NAME -e EMAIL`

--- a/docs/how-to/create-or-disable-users.md
+++ b/docs/how-to/create-or-disable-users.md
@@ -233,4 +233,4 @@ UPDATE dps_users SET disabled = true WHERE email = 'username@example.com';
 
 You can use the following `milmove` sub-command:
 
-`milmove gen disable-user-migration -n MIGRATION_NAME -e EMAIL`
+`milmove gen disable-user-migration -e EMAIL`


### PR DESCRIPTION
## Description

We can use this script to easily generate migrations to disable people when they roll off of the project.

## Setup

- `rm -f bin/milmove && make bin/milmove`
- `milmove gen disable-user-migration -e example@truss.works`
- Check `/tmp` for the generating production migration