### PR TITLE
allow PPMDiscountFetch to use the bookDate as a fallback date

### DIFF
--- a/pkg/handlers/internalapi/personally_procured_move.go
+++ b/pkg/handlers/internalapi/personally_procured_move.go
@@ -396,9 +396,15 @@ func (h PatchPersonallyProcuredMoveHandler) updateEstimates(ppm *models.Personal
 		daysInSIT = int(*ppm.DaysInStorage)
 	}
 
-	// BookDate and SubmitDate are synonymous
-	allowFallbackToSubmitDate := true
-	lhDiscount, sitDiscount, err := models.PPMDiscountFetch(h.DB(), logger, *ppm.PickupPostalCode, *ppm.DestinationPostalCode, *ppm.OriginalMoveDate, *ppm.SubmitDate, allowFallbackToSubmitDate)
+	allowFallbackToBookDate := true
+	bookDate := time.Now()
+	if allowFallbackToBookDate {
+		if ppm.SubmitDate != nil {
+			bookDate = *ppm.SubmitDate
+		}
+	}
+
+	lhDiscount, sitDiscount, err := models.PPMDiscountFetch(h.DB(), logger, *ppm.PickupPostalCode, *ppm.DestinationPostalCode, *ppm.OriginalMoveDate, bookDate, allowFallbackToBookDate)
 	if err != nil {
 		return err
 	}

--- a/pkg/handlers/internalapi/personally_procured_move.go
+++ b/pkg/handlers/internalapi/personally_procured_move.go
@@ -396,7 +396,9 @@ func (h PatchPersonallyProcuredMoveHandler) updateEstimates(ppm *models.Personal
 		daysInSIT = int(*ppm.DaysInStorage)
 	}
 
-	lhDiscount, sitDiscount, err := models.PPMDiscountFetch(h.DB(), logger, *ppm.PickupPostalCode, *ppm.DestinationPostalCode, *ppm.OriginalMoveDate)
+	// BookDate and SubmitDate are synonymous
+	allowFallbackToSubmitDate := true
+	lhDiscount, sitDiscount, err := models.PPMDiscountFetch(h.DB(), logger, *ppm.PickupPostalCode, *ppm.DestinationPostalCode, *ppm.OriginalMoveDate, *ppm.SubmitDate, allowFallbackToSubmitDate)
 	if err != nil {
 		return err
 	}

--- a/pkg/handlers/internalapi/personally_procured_move_estimate.go
+++ b/pkg/handlers/internalapi/personally_procured_move_estimate.go
@@ -31,6 +31,8 @@ func (h ShowPPMEstimateHandler) Handle(params ppmop.ShowPPMEstimateParams) middl
 		params.OriginZip,
 		params.DestinationZip,
 		time.Time(params.OriginalMoveDate),
+		time.Time(params.BookDate),
+		params.AllowBookDate,
 	)
 	if err != nil {
 		return handlers.ResponseForError(logger, err)

--- a/pkg/handlers/internalapi/personally_procured_move_incentive.go
+++ b/pkg/handlers/internalapi/personally_procured_move_incentive.go
@@ -34,6 +34,8 @@ func (h ShowPPMIncentiveHandler) Handle(params ppmop.ShowPPMIncentiveParams) mid
 		params.OriginZip,
 		params.DestinationZip,
 		time.Time(params.OriginalMoveDate),
+		time.Time(params.BookDate),
+		params.AllowBookDate,
 	)
 	if err != nil {
 		return handlers.ResponseForError(logger, err)

--- a/pkg/handlers/internalapi/personally_procured_move_sit_estimate.go
+++ b/pkg/handlers/internalapi/personally_procured_move_sit_estimate.go
@@ -33,6 +33,8 @@ func (h ShowPPMSitEstimateHandler) Handle(params ppmop.ShowPPMSitEstimateParams)
 		params.OriginZip,
 		params.DestinationZip,
 		time.Time(params.OriginalMoveDate),
+		time.Time(params.BookDate),
+		params.AllowBookDate,
 	)
 	if err != nil {
 		return handlers.ResponseForError(logger, err)

--- a/pkg/handlers/internalapi/personally_procured_move_test.go
+++ b/pkg/handlers/internalapi/personally_procured_move_test.go
@@ -187,9 +187,10 @@ func (suite *HandlerSuite) TestPatchPPMHandler() {
 	initialWeight := unit.Pound(4100)
 	newWeight := swag.Int64(4105)
 
-	// Date picked essentialy at random, but needs to be within TestYear
+	// Date picked essentially at random, but needs to be within TestYear
 	newMoveDate := time.Date(testdatagen.TestYear, time.November, 10, 23, 0, 0, 0, time.UTC)
 	initialMoveDate := newMoveDate.Add(-2 * 24 * time.Hour)
+	bookDate := initialMoveDate.Add(-14 * 24 * time.Hour)
 
 	hasAdditionalPostalCode := swag.Bool(true)
 	newHasAdditionalPostalCode := swag.Bool(false)
@@ -223,6 +224,7 @@ func (suite *HandlerSuite) TestPatchPPMHandler() {
 		Status:                     models.PPMStatusDRAFT,
 		AdvanceWorksheet:           newAdvanceWorksheet,
 		AdvanceWorksheetID:         &newAdvanceWorksheet.ID,
+		SubmitDate:                 &bookDate,
 	}
 	suite.MustSave(&ppm1)
 
@@ -272,6 +274,7 @@ func (suite *HandlerSuite) TestPatchPPMHandlerSetWeightLater() {
 
 	// Date picked essentialy at random, but needs to be within TestYear
 	moveDate := time.Date(testdatagen.TestYear, time.November, 10, 23, 0, 0, 0, time.UTC)
+	bookDate := moveDate.Add(-16 * 24 * time.Hour)
 
 	pickupPostalCode := swag.String("32168")
 	destinationPostalCode := swag.String("29401")
@@ -285,6 +288,7 @@ func (suite *HandlerSuite) TestPatchPPMHandlerSetWeightLater() {
 		PickupPostalCode:      pickupPostalCode,
 		DestinationPostalCode: destinationPostalCode,
 		Status:                models.PPMStatusDRAFT,
+		SubmitDate:            &bookDate,
 	}
 	suite.MustSave(&ppm1)
 
@@ -344,6 +348,7 @@ func (suite *HandlerSuite) TestPatchPPMHandlerWrongUser() {
 	// Date picked essentialy at random, but needs to be within TestYear
 	newMoveDate := time.Date(testdatagen.TestYear, time.November, 10, 23, 0, 0, 0, time.UTC)
 	initialMoveDate := newMoveDate.Add(-2 * 24 * time.Hour)
+	bookDate := initialMoveDate.Add(-5 * 24 * time.Hour)
 
 	user2 := testdatagen.MakeDefaultServiceMember(suite.DB())
 	move := testdatagen.MakeDefaultMove(suite.DB())
@@ -355,6 +360,7 @@ func (suite *HandlerSuite) TestPatchPPMHandlerWrongUser() {
 		WeightEstimate:   &initialWeight,
 		OriginalMoveDate: &initialMoveDate,
 		Status:           models.PPMStatusDRAFT,
+		SubmitDate:       &bookDate,
 	}
 	suite.MustSave(&ppm1)
 

--- a/pkg/models/estimate_helper.go
+++ b/pkg/models/estimate_helper.go
@@ -9,46 +9,99 @@ import (
 	"github.com/transcom/mymove/pkg/unit"
 )
 
+type ppmDiscountFetchParams struct {
+	OriginZip string
+	DestZip   string
+	Date      time.Time
+	Cos       string
+	RunFetch  bool
+}
+
+func tryPPMDiscountFetch(db *pop.Connection, logger Logger, fetchParams ppmDiscountFetchParams) (unit.DiscountRate, unit.DiscountRate, error) {
+
+	// Try to fetch
+	lhDiscount, sitDiscount, err := FetchDiscountRates(db,
+		fetchParams.OriginZip,
+		fetchParams.DestZip,
+		fetchParams.Cos,
+		fetchParams.Date)
+
+	if err == nil {
+		logger.Info("Found Discount for TDL with",
+			zap.String("COS", fetchParams.Cos),
+			zap.String("origin_zip", fetchParams.OriginZip),
+			zap.String("destination_zip", fetchParams.DestZip),
+			zap.Time("date", fetchParams.Date),
+			zap.Float64("lh_discount", lhDiscount.Float64()),
+			zap.Float64("sit_discount", sitDiscount.Float64()),
+		)
+		return lhDiscount, sitDiscount, err
+	}
+
+	return 0, 0, err
+}
+
 // PPMDiscountFetch attempts to fetch the discount rates first for COS D, then 2
 // Most PPMs use COS D, but when there is no COS D rate, the calculation is based on Code 2
-func PPMDiscountFetch(db *pop.Connection, logger Logger, originZip string, destZip string, moveDate time.Time) (unit.DiscountRate, unit.DiscountRate, error) {
-	// Try to fetch with COS D.
-	lhDiscount, sitDiscount, err := FetchDiscountRates(db,
-		originZip,
-		destZip,
-		"D",
-		moveDate)
+func PPMDiscountFetch(db *pop.Connection, logger Logger, originZip string, destZip string, moveDate time.Time, bookDate time.Time, allowBookDate bool) (unit.DiscountRate, unit.DiscountRate, error) {
 
-	if err == nil {
-		logger.Info("Found Discount for TDL with COS D.",
-			zap.String("origin_zip", originZip),
-			zap.String("destination_zip", destZip),
-			zap.Time("move_date", moveDate),
-			zap.Float64("lh_discount", lhDiscount.Float64()),
-			zap.Float64("sit_discount", sitDiscount.Float64()),
-		)
-		return lhDiscount, sitDiscount, err
+	datesForFetch := []ppmDiscountFetchParams{
+		{
+			OriginZip: originZip,
+			DestZip:   destZip,
+			Date:      moveDate,
+			Cos:       "D",
+			RunFetch:  true,
+		},
+		{
+			OriginZip: originZip,
+			DestZip:   destZip,
+			Date:      moveDate,
+			Cos:       "2",
+			RunFetch:  true,
+		},
+		{
+			OriginZip: originZip,
+			DestZip:   destZip,
+			Date:      bookDate,
+			Cos:       "D",
+			RunFetch:  allowBookDate,
+		},
+		{
+			OriginZip: originZip,
+			DestZip:   destZip,
+			Date:      bookDate,
+			Cos:       "2",
+			RunFetch:  allowBookDate,
+		},
 	}
 
-	if err != ErrFetchNotFound {
-		return 0, 0, err
+	logger.Info("Fetching PPM Discount for TDL with ", zap.Time("move_date", moveDate))
+	if allowBookDate {
+		logger.Info("PPM Discount for TDL is allowed to use Book Date of move ", zap.Time("book_date", bookDate))
 	}
-	// When COS D not found, COS 2 may have rates.
-	lhDiscount, sitDiscount, err = FetchDiscountRates(db,
-		originZip,
-		destZip,
-		"2",
-		moveDate)
 
-	if err == nil {
-		logger.Info("Found Discount for TDL with COS 2.",
-			zap.String("origin_zip", originZip),
-			zap.String("destination_zip", destZip),
-			zap.Time("move_date", moveDate),
-			zap.Float64("lh_discount", lhDiscount.Float64()),
-			zap.Float64("sit_discount", sitDiscount.Float64()),
-		)
-		return lhDiscount, sitDiscount, err
+	err := ErrFetchNotFound
+	var lhDiscount unit.DiscountRate
+	var sitDiscount unit.DiscountRate
+	for _, params := range datesForFetch {
+		if params.RunFetch {
+			if err == ErrFetchNotFound {
+				lhDiscount, sitDiscount, err = tryPPMDiscountFetch(db, logger, params)
+				if err == nil {
+					logger.Info("Found Discount for TDL with",
+						zap.String("COS", params.Cos),
+						zap.String("origin_zip", originZip),
+						zap.String("destination_zip", destZip),
+						zap.Time("using date for fetch", params.Date),
+						zap.Time("with move_date", moveDate),
+						zap.Float64("lh_discount", lhDiscount.Float64()),
+						zap.Float64("sit_discount", sitDiscount.Float64()),
+					)
+					return lhDiscount, sitDiscount, err
+				}
+			}
+		}
 	}
 
 	logger.Error("Couldn't find Discount for COS D or 2.",

--- a/pkg/models/estimate_helper.go
+++ b/pkg/models/estimate_helper.go
@@ -98,6 +98,9 @@ func PPMDiscountFetch(db *pop.Connection, logger Logger, originZip string, destZ
 						zap.Float64("lh_discount", lhDiscount.Float64()),
 						zap.Float64("sit_discount", sitDiscount.Float64()),
 					)
+					if allowBookDate {
+						logger.Info("Found Discount for TDL allowing use of book date", zap.Time("book_date", bookDate))
+					}
 					return lhDiscount, sitDiscount, err
 				}
 			}
@@ -110,5 +113,8 @@ func PPMDiscountFetch(db *pop.Connection, logger Logger, originZip string, destZ
 		zap.Time("move_date", moveDate),
 		zap.Error(err),
 	)
+	if allowBookDate {
+		logger.Info("Couldn't find Discount with date including", zap.Time("book_date", bookDate))
+	}
 	return 0, 0, err
 }

--- a/pkg/models/estimate_helper_test.go
+++ b/pkg/models/estimate_helper_test.go
@@ -1,0 +1,164 @@
+package models_test
+
+import (
+	"time"
+
+	"github.com/go-openapi/swag"
+	"go.uber.org/zap"
+
+	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/testdatagen"
+	"github.com/transcom/mymove/pkg/unit"
+)
+
+func (suite *ModelSuite) setupPPMDiscountFetchRates() {
+	originZip3 := models.Tariff400ngZip3{
+		Zip3:          "395",
+		BasepointCity: "Saucier",
+		State:         "MS",
+		ServiceArea:   "428",
+		RateArea:      "US48",
+		Region:        "11",
+	}
+	suite.MustSave(&originZip3)
+	originServiceArea := models.Tariff400ngServiceArea{
+		Name:               "Gulfport, MS",
+		ServiceArea:        "428",
+		LinehaulFactor:     57,
+		ServiceChargeCents: 350,
+		ServicesSchedule:   1,
+		EffectiveDateLower: testdatagen.PeakRateCycleStart,
+		EffectiveDateUpper: testdatagen.PeakRateCycleEnd,
+		SIT185ARateCents:   unit.Cents(50),
+		SIT185BRateCents:   unit.Cents(50),
+		SITPDSchedule:      1,
+	}
+	suite.MustSave(&originServiceArea)
+	destinationZip3 := models.Tariff400ngZip3{
+		Zip3:          "336",
+		BasepointCity: "Tampa",
+		State:         "FL",
+		ServiceArea:   "197",
+		RateArea:      "US4964400",
+		Region:        "13",
+	}
+	suite.MustSave(&destinationZip3)
+	destinationServiceArea := models.Tariff400ngServiceArea{
+		Name:               "Tampa, FL",
+		ServiceArea:        "197",
+		LinehaulFactor:     69,
+		ServiceChargeCents: 663,
+		ServicesSchedule:   1,
+		EffectiveDateLower: testdatagen.PeakRateCycleStart,
+		EffectiveDateUpper: testdatagen.PeakRateCycleEnd,
+		SIT185ARateCents:   unit.Cents(5550),
+		SIT185BRateCents:   unit.Cents(222),
+		SITPDSchedule:      1,
+	}
+	suite.MustSave(&destinationServiceArea)
+	newBaseLinehaul := models.Tariff400ngLinehaulRate{
+		DistanceMilesLower: 1,
+		DistanceMilesUpper: 10000,
+		WeightLbsLower:     1000,
+		WeightLbsUpper:     4000,
+		RateCents:          20000,
+		Type:               "ConusLinehaul",
+		EffectiveDateLower: testdatagen.PeakRateCycleStart,
+		EffectiveDateUpper: testdatagen.PeakRateCycleEnd,
+	}
+	suite.MustSave(&newBaseLinehaul)
+}
+
+func (suite *ModelSuite) TestPPMDiscountFetch() {
+	suite.setupPPMDiscountFetchRates()
+	logger, _ := zap.NewDevelopment()
+	tdl := testdatagen.MakeTDL(suite.DB(), testdatagen.Assertions{
+		TrafficDistributionList: models.TrafficDistributionList{
+			SourceRateArea:    "US48",
+			DestinationRegion: "13",
+			CodeOfService:     "2",
+		},
+	})
+	tsp := testdatagen.MakeDefaultTSP(suite.DB())
+	tspPerformance := models.TransportationServiceProviderPerformance{
+		PerformancePeriodStart:          testdatagen.PerformancePeriodStart,
+		PerformancePeriodEnd:            testdatagen.PerformancePeriodEnd,
+		RateCycleStart:                  testdatagen.PeakRateCycleStart,
+		RateCycleEnd:                    testdatagen.PeakRateCycleEnd,
+		TrafficDistributionListID:       tdl.ID,
+		TransportationServiceProviderID: tsp.ID,
+		QualityBand:                     swag.Int(1),
+		BestValueScore:                  90,
+		LinehaulRate:                    unit.NewDiscountRateFromPercent(50.5),
+		SITRate:                         unit.NewDiscountRateFromPercent(50.0),
+	}
+	suite.MustSave(&tspPerformance)
+	originZip := "39574"
+	destinationZip := "33633"
+
+	//
+	// Successful move date
+	//
+	useFallBackDate := false
+	lhDiscount, sitDiscount, err := models.PPMDiscountFetch(suite.DB(),
+		logger,
+		originZip,
+		destinationZip,
+		testdatagen.RateEngineDate,
+		time.Time{},
+		useFallBackDate,
+	)
+	suite.Nil(err)
+	suite.Equal(0.505, lhDiscount.Float64(), "Discount rate is not 0.505")
+	suite.Equal(0.5, sitDiscount.Float64(), "SIT rate is not 0.5")
+
+	//
+	// Successful move date
+	//
+	useFallBackDate = true
+	lhDiscount, sitDiscount, err = models.PPMDiscountFetch(suite.DB(),
+		logger,
+		originZip,
+		destinationZip,
+		testdatagen.RateEngineDate,
+		time.Time{},
+		useFallBackDate,
+	)
+	suite.Nil(err)
+	suite.Equal(0.505, lhDiscount.Float64(), "Discount rate is not 0.505")
+	suite.Equal(0.5, sitDiscount.Float64(), "SIT rate is not 0.5")
+
+	//
+	// Failed move date and not using book date
+	//
+	useFallBackDate = false
+	lhDiscount, sitDiscount, err = models.PPMDiscountFetch(suite.DB(),
+		logger,
+		originZip,
+		destinationZip,
+		testdatagen.RateEngineDate.AddDate(2, 0, 0),
+		time.Time{},
+		useFallBackDate,
+	)
+	// Expect to get FETCH_NOT_FOUND
+	suite.NotNil(err)
+	suite.Equal("FETCH_NOT_FOUND", err.Error(), "Expect FETCH_NOT_FOUND for move date")
+	suite.Equal(0.0, lhDiscount.Float64(), "Discount rate is 0.0")
+	suite.Equal(0.0, sitDiscount.Float64(), "SIT rate is not 0.0")
+
+	//
+	// Failed move date and Successful book date
+	//
+	useFallBackDate = true
+	lhDiscount, sitDiscount, err = models.PPMDiscountFetch(suite.DB(),
+		logger,
+		originZip,
+		destinationZip,
+		testdatagen.RateEngineDate.AddDate(2, 0, 0),
+		testdatagen.RateEngineDate,
+		useFallBackDate,
+	)
+	suite.Nil(err)
+	suite.Equal(0.505, lhDiscount.Float64(), "Discount rate is not 0.505")
+	suite.Equal(0.5, sitDiscount.Float64(), "SIT rate is not 0.5")
+}

--- a/pkg/models/estimate_helper_test.go
+++ b/pkg/models/estimate_helper_test.go
@@ -99,14 +99,14 @@ func (suite *ModelSuite) TestPPMDiscountFetch() {
 	//
 	// Successful move date
 	//
-	useFallBackDate := false
+	allowBookDate := false
 	lhDiscount, sitDiscount, err := models.PPMDiscountFetch(suite.DB(),
 		logger,
 		originZip,
 		destinationZip,
 		testdatagen.RateEngineDate,
 		time.Time{},
-		useFallBackDate,
+		allowBookDate,
 	)
 	suite.Nil(err)
 	suite.Equal(0.505, lhDiscount.Float64(), "Discount rate is not 0.505")
@@ -115,14 +115,14 @@ func (suite *ModelSuite) TestPPMDiscountFetch() {
 	//
 	// Successful move date
 	//
-	useFallBackDate = true
+	allowBookDate = true
 	lhDiscount, sitDiscount, err = models.PPMDiscountFetch(suite.DB(),
 		logger,
 		originZip,
 		destinationZip,
 		testdatagen.RateEngineDate,
 		time.Time{},
-		useFallBackDate,
+		allowBookDate,
 	)
 	suite.Nil(err)
 	suite.Equal(0.505, lhDiscount.Float64(), "Discount rate is not 0.505")
@@ -131,14 +131,14 @@ func (suite *ModelSuite) TestPPMDiscountFetch() {
 	//
 	// Failed move date and not using book date
 	//
-	useFallBackDate = false
+	allowBookDate = false
 	lhDiscount, sitDiscount, err = models.PPMDiscountFetch(suite.DB(),
 		logger,
 		originZip,
 		destinationZip,
 		testdatagen.RateEngineDate.AddDate(2, 0, 0),
 		time.Time{},
-		useFallBackDate,
+		allowBookDate,
 	)
 	// Expect to get FETCH_NOT_FOUND
 	suite.NotNil(err)
@@ -149,14 +149,14 @@ func (suite *ModelSuite) TestPPMDiscountFetch() {
 	//
 	// Failed move date and Successful book date
 	//
-	useFallBackDate = true
+	allowBookDate = true
 	lhDiscount, sitDiscount, err = models.PPMDiscountFetch(suite.DB(),
 		logger,
 		originZip,
 		destinationZip,
 		testdatagen.RateEngineDate.AddDate(2, 0, 0),
 		testdatagen.RateEngineDate,
-		useFallBackDate,
+		allowBookDate,
 	)
 	suite.Nil(err)
 	suite.Equal(0.505, lhDiscount.Float64(), "Discount rate is not 0.505")

--- a/pkg/rateengine/rateengine.go
+++ b/pkg/rateengine/rateengine.go
@@ -167,11 +167,15 @@ func (re *RateEngine) ComputePPM(
 //ComputePPMIncludingLHDiscount Calculates the cost of a PPM move using zip + date derived linehaul discount
 func (re *RateEngine) ComputePPMIncludingLHDiscount(weight unit.Pound, originZip5 string, destinationZip5 string, distanceMiles int, date time.Time, daysInSIT int) (cost CostComputation, err error) {
 
+	var bookDate time.Time
+	allowBookDate := false
 	lhDiscount, sitDiscount, err := models.PPMDiscountFetch(re.db,
 		re.logger,
 		originZip5,
 		destinationZip5,
 		date,
+		bookDate,
+		allowBookDate,
 	)
 	if err != nil {
 		re.logger.Error("Failed to compute linehaul cost", zap.Error(err))

--- a/pkg/rateengine/rateengine_test.go
+++ b/pkg/rateengine/rateengine_test.go
@@ -140,14 +140,14 @@ func (suite *RateEngineSuite) computePPMIncludingLHRates(originZip string, desti
 		SITRate:                         unit.NewDiscountRateFromPercent(50.0),
 	}
 	suite.MustSave(&tspPerformance)
-	useFallBackDate := false
+	allowBookDate := false
 	lhDiscount, sitDiscount, err := models.PPMDiscountFetch(suite.DB(),
 		logger,
 		originZip,
 		destinationZip,
 		testdatagen.RateEngineDate,
 		time.Time{},
-		useFallBackDate,
+		allowBookDate,
 	)
 	suite.Require().Nil(err)
 	engine := NewRateEngine(suite.DB(), logger)

--- a/pkg/rateengine/rateengine_test.go
+++ b/pkg/rateengine/rateengine_test.go
@@ -2,6 +2,7 @@ package rateengine
 
 import (
 	"testing"
+	"time"
 
 	"github.com/go-openapi/swag"
 	"github.com/stretchr/testify/suite"
@@ -139,10 +140,14 @@ func (suite *RateEngineSuite) computePPMIncludingLHRates(originZip string, desti
 		SITRate:                         unit.NewDiscountRateFromPercent(50.0),
 	}
 	suite.MustSave(&tspPerformance)
+	useFallBackDate := false
 	lhDiscount, sitDiscount, err := models.PPMDiscountFetch(suite.DB(),
 		logger,
 		originZip,
-		destinationZip, testdatagen.RateEngineDate,
+		destinationZip,
+		testdatagen.RateEngineDate,
+		time.Time{},
+		useFallBackDate,
 	)
 	suite.Require().Nil(err)
 	engine := NewRateEngine(suite.DB(), logger)

--- a/src/scenes/Moves/Ppm/api.js
+++ b/src/scenes/Moves/Ppm/api.js
@@ -1,5 +1,6 @@
 import { getClient, checkResponse } from 'shared/Swagger/api';
 import { formatPayload, formatDateString } from 'shared/utils';
+import moment from 'moment';
 
 export async function GetPpm(moveId) {
   const client = await getClient();
@@ -38,18 +39,24 @@ export async function UpdatePpm(
 }
 
 export async function GetPpmWeightEstimate(moveDate, originZip, destZip, weightEstimate) {
+  let allowBookDate = true;
+  let bookDate = moment();
   const client = await getClient();
   const response = await client.apis.ppm.showPPMEstimate({
     original_move_date: formatDateString(moveDate),
     origin_zip: originZip,
     destination_zip: destZip,
     weight_estimate: weightEstimate,
+    book_date: formatDateString(bookDate),
+    allow_book_date: allowBookDate,
   });
   checkResponse(response, 'failed to update ppm due to server error');
   return response.body;
 }
 
 export async function GetPpmSitEstimate(moveDate, sitDays, originZip, destZip, weightEstimate) {
+  let allowBookDate = true;
+  let bookDate = moment();
   const client = await getClient();
   const response = await client.apis.ppm.showPPMSitEstimate({
     original_move_date: formatDateString(moveDate),
@@ -57,6 +64,8 @@ export async function GetPpmSitEstimate(moveDate, sitDays, originZip, destZip, w
     origin_zip: originZip,
     destination_zip: destZip,
     weight_estimate: weightEstimate,
+    book_date: formatDateString(bookDate),
+    allow_book_date: allowBookDate,
   });
   checkResponse(response, 'failed to update ppm due to server error');
   return response.body;

--- a/src/scenes/Office/Ppm/api.js
+++ b/src/scenes/Office/Ppm/api.js
@@ -1,13 +1,18 @@
 import { getClient, checkResponse } from 'shared/Swagger/api';
 import { formatDateString } from 'shared/utils';
+import moment from 'moment';
 
 export async function GetPpmIncentive(moveDate, originZip, destZip, weight) {
+  let allowBookDate = true;
+  let bookDate = moment();
   const client = await getClient();
   const response = await client.apis.ppm.showPPMIncentive({
     original_move_date: formatDateString(moveDate),
     origin_zip: originZip,
     destination_zip: destZip,
     weight: weight,
+    book_date: formatDateString(bookDate),
+    allow_book_date: allowBookDate,
   });
   checkResponse(response, 'failed to update ppm due to server error');
   return response.body;

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -2784,6 +2784,11 @@ paths:
         - ppm
       parameters:
         - in: query
+          name: book_date
+          type: string
+          format: date
+          required: true
+        - in: query
           name: original_move_date
           type: string
           format: date
@@ -2803,6 +2808,10 @@ paths:
         - in: query
           name: weight_estimate
           type: integer
+          required: true
+        - in: query
+          name: allow_book_date
+          type: boolean
           required: true
       responses:
         200:
@@ -2830,6 +2839,11 @@ paths:
         - ppm
       parameters:
         - in: query
+          name: book_date
+          type: string
+          format: date
+          required: true
+        - in: query
           name: original_move_date
           type: string
           format: date
@@ -2853,6 +2867,10 @@ paths:
         - in: query
           name: weight_estimate
           type: integer
+          required: true
+        - in: query
+          name: allow_book_date
+          type: boolean
           required: true
       responses:
         200:
@@ -3956,6 +3974,11 @@ paths:
         - ppm
       parameters:
         - in: query
+          name: book_date
+          type: string
+          format: date
+          required: true
+        - in: query
           name: original_move_date
           type: string
           format: date
@@ -3975,6 +3998,10 @@ paths:
         - in: query
           name: weight
           type: integer
+          required: true
+        - in: query
+          name: allow_book_date
+          type: boolean
           required: true
       responses:
         200:


### PR DESCRIPTION
## Description

Allow PPM moves to use `book_date` for **estimates** in function `PPMDiscountFetch` when `move_date` is not available. This is a partial fix until we better understand the rules for booking PPMs. E.g., there is still an outstanding question if the final PPM move submission (for payout) should update to the `move_date` or continue to use the `book_date`, if previously used for estimate.

## Reviewer Notes

n/a

## Setup

Create a new PPM and select a move date 1 year out. The move will still allow you to create it and get an estimate.

```sh
make server_run
make client_run
```

## Code Review Verification Steps
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/tree/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/167358692) for this change

## Screenshots

n/a
