### PR TITLE
Add session checks and remove pointer address comparison

### DIFF
--- a/pkg/auth/authentication/auth.go
+++ b/pkg/auth/authentication/auth.go
@@ -563,21 +563,20 @@ func authorizeUnknownUser(openIDUser goth.User, h CallbackHandler, session *auth
 	if err == nil { // Successfully created the user
 		session.UserID = user.ID
 		span.AddField("session.user_id", session.UserID)
-		if officeUser != nil {
+		if session.IsOfficeApp() && officeUser != nil {
 			session.OfficeUserID = officeUser.ID
 			span.AddField("session.office_user_id", session.OfficeUserID)
 			officeUser.UserID = &user.ID
 			err = h.db.Save(officeUser)
-		} else if tspUser != nil {
+		} else if session.IsTspApp() && tspUser != nil {
 			session.TspUserID = tspUser.ID
 			span.AddField("session.tsp_user_id", session.TspUserID)
 			tspUser.UserID = &user.ID
 			err = h.db.Save(tspUser)
-		} else if &adminUser.ID != &uuid.Nil {
+		} else if session.IsAdminApp() && adminUser.ID != uuid.Nil {
 			session.AdminUserID = adminUser.ID
 			span.AddField("session.admin_user_id", session.AdminUserID)
 			adminUser.UserID = &user.ID
-
 			err = h.db.Save(&adminUser)
 		}
 	}


### PR DESCRIPTION
[Context](https://defensedigitalservice.slack.com/archives/G8HJSJE67/p1563843265015700)

It looks like there was a subtle incorrect comparison of pointer _addresses_ instead of the values I actually wanted to compare. I had trouble writing a failing test for this, which led me to discover that we don't have any tests for the `AuthorizeUnknownUser` function. I've added a [story](https://www.pivotaltracker.com/story/show/167462990) to the TTV backlog to address this at some point soon.

## Setup

- `make db_dev_e2e_populate`
- `make server_run`
- `make client_run`
- Make sure you have a service member and an admin user record with your email address for login.gov
- Log into the service member app via login.gov
- It should succeed!