### PR TITLE
Add failwhale to office app

### DIFF
--- a/src/scenes/MyMove/index.jsx
+++ b/src/scenes/MyMove/index.jsx
@@ -45,6 +45,7 @@ import CustomerAgreementLegalese from 'scenes/Moves/Ppm/CustomerAgreementLegales
 
 export class AppWrapper extends Component {
   state = { hasError: false };
+
   componentDidMount() {
     this.props.loadInternalSchema();
     this.props.getCurrentUserInfo();

--- a/src/scenes/MyMove/index.jsx
+++ b/src/scenes/MyMove/index.jsx
@@ -36,7 +36,7 @@ import { selectedMoveType, lastMoveIsCanceled } from 'scenes/Moves/ducks';
 import { getWorkflowRoutes } from './getWorkflowRoutes';
 import { getCurrentUserInfo } from 'shared/Data/users';
 import { loadInternalSchema } from 'shared/Swagger/ducks';
-import FailWhale from 'shared/FailWhale';
+import SomethingWentWrong from 'shared/SomethingWentWrong';
 import { detectIE11, no_op } from 'shared/utils';
 import DPSAuthCookie from 'scenes/DPSAuthCookie';
 import TrailerCriteria from 'scenes/Moves/Ppm/TrailerCriteria';
@@ -83,7 +83,7 @@ export class AppWrapper extends Component {
                   </Alert>
                 )}
               </div>
-              {this.state.hasError && <FailWhale />}
+              {this.state.hasError && <SomethingWentWrong />}
               {!this.state.hasError &&
                 !props.swaggerError && (
                   <Switch>

--- a/src/scenes/MyMove/index.test.js
+++ b/src/scenes/MyMove/index.test.js
@@ -3,6 +3,7 @@ import { shallow } from 'enzyme';
 import { AppWrapper } from '.';
 import Header from 'shared/Header/MyMove';
 import Footer from 'shared/Footer';
+import FailWhale from 'shared/FailWhale';
 
 describe('AppWrapper tests', () => {
   let _wrapper;
@@ -11,9 +12,10 @@ describe('AppWrapper tests', () => {
     _wrapper = shallow(<AppWrapper />);
   });
 
-  it('renders without crashing', () => {
+  it('renders without crashing or erroring', () => {
     const appWrapper = _wrapper.find('div');
     expect(appWrapper).toBeDefined();
+    expect(_wrapper.find(FailWhale)).toHaveLength(0);
   });
 
   it('renders Header component', () => {
@@ -22,5 +24,10 @@ describe('AppWrapper tests', () => {
 
   it('renders Footer component', () => {
     expect(_wrapper.find(Footer)).toHaveLength(1);
+  });
+
+  it('renders the fail whale', () => {
+    _wrapper.setState({ hasError: true });
+    expect(_wrapper.find(FailWhale)).toHaveLength(1);
   });
 });

--- a/src/scenes/MyMove/index.test.js
+++ b/src/scenes/MyMove/index.test.js
@@ -3,7 +3,7 @@ import { shallow } from 'enzyme';
 import { AppWrapper } from '.';
 import Header from 'shared/Header/MyMove';
 import Footer from 'shared/Footer';
-import FailWhale from 'shared/FailWhale';
+import SomethingWentWrong from 'shared/SomethingWentWrong';
 
 describe('AppWrapper tests', () => {
   let _wrapper;
@@ -15,7 +15,7 @@ describe('AppWrapper tests', () => {
   it('renders without crashing or erroring', () => {
     const appWrapper = _wrapper.find('div');
     expect(appWrapper).toBeDefined();
-    expect(_wrapper.find(FailWhale)).toHaveLength(0);
+    expect(_wrapper.find(SomethingWentWrong)).toHaveLength(0);
   });
 
   it('renders Header component', () => {
@@ -28,6 +28,6 @@ describe('AppWrapper tests', () => {
 
   it('renders the fail whale', () => {
     _wrapper.setState({ hasError: true });
-    expect(_wrapper.find(FailWhale)).toHaveLength(1);
+    expect(_wrapper.find(SomethingWentWrong)).toHaveLength(1);
   });
 });

--- a/src/scenes/Office/index.jsx
+++ b/src/scenes/Office/index.jsx
@@ -18,7 +18,7 @@ import LogoutOnInactivity from 'shared/User/LogoutOnInactivity';
 import PrivateRoute from 'shared/User/PrivateRoute';
 import ScratchPad from 'shared/ScratchPad';
 import { isProduction } from 'shared/constants';
-import FailWhale from 'shared/FailWhale';
+import SomethingWentWrong from 'shared/SomethingWentWrong';
 import { RetrieveMovesForOffice } from './api';
 
 import './office.scss';
@@ -63,7 +63,7 @@ export class OfficeWrapper extends Component {
           <Tag role="main" className="site__content">
             <div>
               <LogoutOnInactivity />
-              {this.state.hasError && <FailWhale />}
+              {this.state.hasError && <SomethingWentWrong />}
               {!this.state.hasError && (
                 <Switch>
                   <Route

--- a/src/scenes/Office/index.jsx
+++ b/src/scenes/Office/index.jsx
@@ -18,6 +18,7 @@ import LogoutOnInactivity from 'shared/User/LogoutOnInactivity';
 import PrivateRoute from 'shared/User/PrivateRoute';
 import ScratchPad from 'shared/ScratchPad';
 import { isProduction } from 'shared/constants';
+import FailWhale from 'shared/FailWhale';
 import { RetrieveMovesForOffice } from './api';
 
 import './office.scss';
@@ -38,11 +39,19 @@ class Queues extends Component {
 }
 
 class OfficeWrapper extends Component {
+  state = { hasError: false };
+
   componentDidMount() {
     document.title = 'Transcom PPP: Office';
     this.props.loadInternalSchema();
     this.props.loadPublicSchema();
     this.props.getCurrentUserInfo();
+  }
+
+  componentDidCatch(error, info) {
+    this.setState({
+      hasError: true,
+    });
   }
 
   render() {
@@ -54,26 +63,29 @@ class OfficeWrapper extends Component {
           <Tag role="main" className="site__content">
             <div>
               <LogoutOnInactivity />
-              <Switch>
-                <Route
-                  exact
-                  path="/"
-                  component={({ location }) => (
-                    <Redirect
-                      from="/"
-                      to={{
-                        ...location,
-                        pathname: '/queues/new',
-                      }}
-                    />
-                  )}
-                />
-                <PrivateRoute path="/queues/:queueType/moves/:moveId" component={MoveInfo} />
-                <PrivateRoute path="/queues/:queueType" component={Queues} />
-                <PrivateRoute path="/moves/:moveId/orders" component={OrdersInfo} />
-                <PrivateRoute path="/moves/:moveId/documents/:moveDocumentId?" component={DocumentViewer} />
-                {!isProduction && <PrivateRoute path="/playground" component={ScratchPad} />}
-              </Switch>
+              {this.state.hasError && <FailWhale />}
+              {!this.state.hasError && (
+                <Switch>
+                  <Route
+                    exact
+                    path="/"
+                    component={({ location }) => (
+                      <Redirect
+                        from="/"
+                        to={{
+                          ...location,
+                          pathname: '/queues/new',
+                        }}
+                      />
+                    )}
+                  />
+                  <PrivateRoute path="/queues/:queueType/moves/:moveId" component={MoveInfo} />
+                  <PrivateRoute path="/queues/:queueType" component={Queues} />
+                  <PrivateRoute path="/moves/:moveId/orders" component={OrdersInfo} />
+                  <PrivateRoute path="/moves/:moveId/documents/:moveDocumentId?" component={DocumentViewer} />
+                  {!isProduction && <PrivateRoute path="/playground" component={ScratchPad} />}
+                </Switch>
+              )}
             </div>
           </Tag>
         </div>

--- a/src/scenes/Office/index.jsx
+++ b/src/scenes/Office/index.jsx
@@ -38,7 +38,7 @@ class Queues extends Component {
   }
 }
 
-class OfficeWrapper extends Component {
+export class OfficeWrapper extends Component {
   state = { hasError: false };
 
   componentDidMount() {

--- a/src/scenes/Office/index.test.js
+++ b/src/scenes/Office/index.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import { OfficeWrapper } from '.';
 import QueueHeader from 'shared/Header/Office';
-import FailWhale from 'shared/FailWhale';
+import SomethingWentWrong from 'shared/SomethingWentWrong';
 
 describe('OfficeWrapper tests', () => {
   let _wrapper;
@@ -14,7 +14,7 @@ describe('OfficeWrapper tests', () => {
   it('renders without crashing or erroring', () => {
     const officeWrapper = _wrapper.find('div');
     expect(officeWrapper).toBeDefined();
-    expect(_wrapper.find(FailWhale)).toHaveLength(0);
+    expect(_wrapper.find(SomethingWentWrong)).toHaveLength(0);
   });
 
   it('renders Queue Header component', () => {
@@ -23,6 +23,6 @@ describe('OfficeWrapper tests', () => {
 
   it('renders the fail whale', () => {
     _wrapper.setState({ hasError: true });
-    expect(_wrapper.find(FailWhale)).toHaveLength(1);
+    expect(_wrapper.find(SomethingWentWrong)).toHaveLength(1);
   });
 });

--- a/src/scenes/Office/index.test.js
+++ b/src/scenes/Office/index.test.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { OfficeWrapper } from '.';
+import QueueHeader from 'shared/Header/Office';
+import FailWhale from 'shared/FailWhale';
+
+describe('OfficeWrapper tests', () => {
+  let _wrapper;
+
+  beforeEach(() => {
+    _wrapper = shallow(<OfficeWrapper getCurrentUserInfo={() => {}} />);
+  });
+
+  it('renders without crashing or erroring', () => {
+    const officeWrapper = _wrapper.find('div');
+    expect(officeWrapper).toBeDefined();
+    expect(_wrapper.find(FailWhale)).toHaveLength(0);
+  });
+
+  it('renders Queue Header component', () => {
+    expect(_wrapper.find(QueueHeader)).toHaveLength(1);
+  });
+
+  it('renders the fail whale', () => {
+    _wrapper.setState({ hasError: true });
+    expect(_wrapper.find(FailWhale)).toHaveLength(1);
+  });
+});

--- a/src/shared/SomethingWentWrong/index.jsx
+++ b/src/shared/SomethingWentWrong/index.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import sadComputer from 'shared/images/sad-computer.png';
-const FailWhale = () => (
+const SomethingWentWrong = () => (
   <div className="usa-grid">
     <div className="usa-width-one-whole align-center">
       <p>
@@ -23,4 +23,4 @@ const FailWhale = () => (
   </div>
 );
 
-export default FailWhale;
+export default SomethingWentWrong;

--- a/src/shared/SomethingWentWrong/index.test.js
+++ b/src/shared/SomethingWentWrong/index.test.js
@@ -1,12 +1,12 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import FailWhale from '.';
+import SomethingWentWrong from '.';
 
-describe('FailWhale tests', () => {
+describe('SomethingWentWrong tests', () => {
   let wrapper;
   it('renders without crashing', () => {
     const div = document.createElement('div');
-    wrapper = shallow(<FailWhale />, div);
+    wrapper = shallow(<SomethingWentWrong />, div);
     expect(wrapper.find('.usa-grid').length).toEqual(1);
   });
 });


### PR DESCRIPTION
## Description

Right now our office app will just crash quietly, so this is a small thing to put this in the same level of standard as our service member app

## Setup

I couldn't figure out how to throw a JS error without breaking linting/build errors, but if you run this locally and reverse the clauses for state.hasError, you should be able to see the right behavior.

## Code Review Verification Steps

* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* https://www.pivotaltracker.com/story/show/167470296

## Screenshots

<img width="1022" alt="Screen Shot 2019-07-23 at 2 25 36 PM" src="https://user-images.githubusercontent.com/5531789/61749020-8d3eb300-ad56-11e9-9879-03ae6c368a72.png">

