### PR TITLE
Add more admin users

### DIFF
--- a/local_migrations/20190724193344_add_more_system_admin_users.sql
+++ b/local_migrations/20190724193344_add_more_system_admin_users.sql
@@ -1,0 +1,3 @@
+-- Local test migration.
+-- This will be run on development environments. It should mirror what you
+-- intend to apply on production, but do not include any sensitive data.

--- a/migrations/20190724193344_add_more_system_admin_users.up.fizz
+++ b/migrations/20190724193344_add_more_system_admin_users.up.fizz
@@ -1,0 +1,1 @@
+exec("./apply-secure-migration.sh 20190724193344_add_more_system_admin_users.sql")

--- a/migrations_manifest.txt
+++ b/migrations_manifest.txt
@@ -332,3 +332,4 @@
 20190722225748_add_office_users.up.fizz
 20190723165935_add-duty-station-uslb-albany-ga.up.sql
 20190723214108_add_office_users.up.fizz
+20190724193344_add_more_system_admin_users.up.fizz


### PR DESCRIPTION
## Description

My original secure migration, `migrations/20190702150158_create_admin_users.up.fizz`, didn't seem to create the admin user records that I wanted, so only Risa is able to log into the admin app via login.gov. This secure migration adds a bunch more folks.

## Reviewer Notes
Am I missing anyone?

## Setup

`make run_prod_migrations`

## Code Review Verification Steps

 * [x] Secure migrations have been tested using `scripts/run-prod-migrations`