### PR TITLE
Remove tempfiles after using them

### DIFF
--- a/cmd/update_deps/main.go
+++ b/cmd/update_deps/main.go
@@ -50,7 +50,7 @@ func main() {
 		if cmdErr != nil {
 			fmt.Println(" ×")
 			if ctx.Err() == context.DeadlineExceeded {
-				log.Fatalf("timed out trying trying to run %s %s", "go", args)
+				log.Fatalf("timed out trying tryig to run %s %s", "go", args)
 			} else {
 				log.Fatalf("failed to update %s: ran %s %v, got %s", req.Mod.Path, "go", args, string(out))
 			}

--- a/cmd/update_deps/main.go
+++ b/cmd/update_deps/main.go
@@ -50,7 +50,7 @@ func main() {
 		if cmdErr != nil {
 			fmt.Println(" ×")
 			if ctx.Err() == context.DeadlineExceeded {
-				log.Fatalf("timed out trying tryig to run %s %s", "go", args)
+				log.Fatalf("timed out trying trying to run %s %s", "go", args)
 			} else {
 				log.Fatalf("failed to update %s: ran %s %v, got %s", req.Mod.Path, "go", args, string(out))
 			}

--- a/pkg/handlers/internalapi/personally_procured_move_attachments.go
+++ b/pkg/handlers/internalapi/personally_procured_move_attachments.go
@@ -46,6 +46,7 @@ func (h CreatePersonallyProcuredMoveAttachmentsHandler) Handle(params ppmop.Crea
 		logger.Error("failed to initialize generator", zap.Error(err))
 		return ppmop.NewCreatePPMAttachmentsInternalServerError()
 	}
+	defer generator.Cleanup()
 
 	// Start with uploaded orders info
 	uploads := ppm.Move.Orders.UploadedOrders.Uploads

--- a/pkg/handlers/internalapi/personally_procured_move_attachments.go
+++ b/pkg/handlers/internalapi/personally_procured_move_attachments.go
@@ -46,7 +46,11 @@ func (h CreatePersonallyProcuredMoveAttachmentsHandler) Handle(params ppmop.Crea
 		logger.Error("failed to initialize generator", zap.Error(err))
 		return ppmop.NewCreatePPMAttachmentsInternalServerError()
 	}
-	defer generator.Cleanup()
+	defer func() {
+		if cleanupErr := generator.Cleanup(); cleanupErr != nil {
+			logger.Error("failed to cleanup", zap.Error(cleanupErr))
+		}
+	}()
 
 	// Start with uploaded orders info
 	uploads := ppm.Move.Orders.UploadedOrders.Uploads

--- a/pkg/paperwork/generator.go
+++ b/pkg/paperwork/generator.go
@@ -132,6 +132,10 @@ func (g *Generator) newTempFile() (afero.File, error) {
 	return outputFile, nil
 }
 
+func (g *Generator) Cleanup() error {
+	return g.fs.RemoveAll(g.workDir)
+}
+
 // CreateMergedPDFUpload converts Uploads to PDF and merges them into a single PDF
 func (g *Generator) CreateMergedPDFUpload(uploads models.Uploads) (afero.File, error) {
 	pdfs, err := g.ConvertUploadsToPDF(uploads)

--- a/pkg/paperwork/generator_test.go
+++ b/pkg/paperwork/generator_test.go
@@ -181,3 +181,31 @@ func (suite *PaperworkSuite) TestCreateMergedPDF() {
 
 	suite.Equal(3, ctx.PageCount)
 }
+
+func (suite *PaperworkSuite) TestCleanup() {
+	generator, order := suite.setupOrdersDocument()
+
+	uploads := order.UploadedOrders.Uploads
+	_, err := generator.CreateMergedPDFUpload(uploads)
+	suite.FatalNil(err)
+
+	generator.Cleanup()
+
+	fs := suite.uploader.Storer.FileSystem()
+	exists, existsErr := fs.DirExists(generator.workDir)
+	suite.Nil(existsErr)
+
+	if exists {
+		suite.Failf("expected %s to not be a directory, but it was", generator.workDir)
+
+		var paths []string
+		walkErr := fs.Walk(generator.workDir, func(path string, info os.FileInfo, err error) error {
+			if path != generator.workDir { // Walk starts off with the directory passed to it
+				paths = append(paths, path)
+			}
+			return nil
+		})
+		suite.Nil(walkErr)
+		suite.Failf("did not clean up", "expected %s to be empty, but it contained %v", generator.workDir, paths)
+	}
+}

--- a/pkg/paperwork/generator_test.go
+++ b/pkg/paperwork/generator_test.go
@@ -206,6 +206,8 @@ func (suite *PaperworkSuite) TestCleanup() {
 			return nil
 		})
 		suite.Nil(walkErr)
-		suite.Failf("did not clean up", "expected %s to be empty, but it contained %v", generator.workDir, paths)
+		if len(paths) > 0 {
+			suite.Failf("did not clean up", "expected %s to be empty, but it contained %v", generator.workDir, paths)
+		}
 	}
 }


### PR DESCRIPTION
## Description

This should help with the memory leak we're seeing when generating PDFs. We weren't cleaning up the temp files, and since they were in memory, the memory usage of the app was growing with each request.