### PR TITLE
Notify users when their PPP_INFRA_PATH repo is behind

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -227,7 +227,7 @@ fi
 if [ -e "$PPP_INFRA_PATH"/transcom-ppp/.envrc ]
 then
     source_env "$PPP_INFRA_PATH"/transcom-ppp/.envrc
-    behind=$(git --git-dir="$PPP_INFRA_PATH/.git" rev-list --count origin/master...master)
+    behind=$(git --git-dir="$PPP_INFRA_PATH/.git" rev-list --count origin/master...HEAD)
     if [[ "$behind" != "0" ]]; then
       log_error "Your repository checkout of transcom/ppp-infra is $behind commits behind master. Please update."
     fi

--- a/.envrc
+++ b/.envrc
@@ -227,6 +227,10 @@ fi
 if [ -e "$PPP_INFRA_PATH"/transcom-ppp/.envrc ]
 then
     source_env "$PPP_INFRA_PATH"/transcom-ppp/.envrc
+    behind=$(git --git-dir="$PPP_INFRA_PATH/.git" rev-list --count origin/master...master)
+    if [[ "$behind" != "0" ]]; then
+      log_error "Your repository checkout of transcom/ppp-infra is $behind commits behind master. Please update."
+    fi
 else
     log_error "Unable to find the transcom-ppp/.envrc file. Please check PPP_INFRA_PATH if aws commands don't work."
 fi


### PR DESCRIPTION
## Description

I've noticed that lots of engineers only check out the `transcom/ppp` infra repo once and then never update it. This can leave them 10s to 100s of commits behind master. The consequence is that updates to scripts, tools, and docs fall out of date. This adds a tiny warning in red text if you aren't up to date.

## Reviewer Notes

Does this work in `fish` shell?

## Setup

```sh
direnv allow
```