### PR TITLE
Normalize the migration generation commands

### DIFF
--- a/cmd/milmove/gen.go
+++ b/cmd/milmove/gen.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+	"text/template"
+
+	"github.com/pkg/errors"
+)
+
+const (
+	// secureMigrationTemplate is the template to apply secure migration
+	secureMigrationTemplate string = `exec("./apply-secure-migration.sh {{.}}")`
+
+	// tempMigrationPath is the temporary path for generated migrations
+	tempMigrationPath string = "./tmp"
+)
+
+// Close an open file or exit
+func closeFile(outfile *os.File) {
+	err := outfile.Close()
+	if err != nil {
+		log.Printf("error closing %s: %v\n", outfile.Name(), err)
+		os.Exit(1)
+	}
+}
+
+func createMigration(path string, filename string, t *template.Template, templateData interface{}) error {
+	migrationPath := filepath.Join(path, filename)
+	migrationFile, err := os.Create(migrationPath)
+	defer closeFile(migrationFile)
+	if err != nil {
+		return errors.Wrapf(err, "error creating %s", migrationPath)
+	}
+	err = t.Execute(migrationFile, templateData)
+	if err != nil {
+		log.Println("error executing template: ", err)
+	}
+	log.Printf("new migration file created at: %q\n", migrationPath)
+	return nil
+}
+
+func addMigrationToManifest(migrationManifest string, filename string) error {
+	mmf, err := os.OpenFile(migrationManifest, os.O_APPEND|os.O_WRONLY, 0600)
+	if err != nil {
+		return errors.Wrap(err, "could not open migration manifest")
+	}
+	defer mmf.Close()
+
+	_, err = mmf.WriteString(filename + "\n")
+	if err != nil {
+		return errors.Wrap(err, "could not append to the migration manifest")
+	}
+
+	log.Printf("new migration appended to manifest at: %q\n", migrationManifest)
+	return nil
+}
+
+func writeEmptyFile(migrationPath, filename string) error {
+	path := filepath.Join(migrationPath, filename)
+
+	err := ioutil.WriteFile(path, []byte{}, 0644)
+	if err != nil {
+		return errors.Wrap(err, "could not write new migration file")
+	}
+
+	log.Printf("new migration file created at: %q\n", path)
+	return nil
+}

--- a/cmd/milmove/gen_disable_user_migration.go
+++ b/cmd/milmove/gen_disable_user_migration.go
@@ -82,7 +82,7 @@ func CheckDisableUserFlags(v *viper.Viper) error {
 func genDisableUserMigration(cmd *cobra.Command, args []string) error {
 	err := cmd.ParseFlags(args)
 	if err != nil {
-		errors.Wrap(err, "Could not parse flags")
+		return errors.Wrap(err, "Could not parse flags")
 	}
 
 	flag := cmd.Flags()
@@ -123,14 +123,14 @@ func genDisableUserMigration(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	migrationFileName := fmt.Sprintf("%s_%s.up.fizz", migrationVersion, migrationName)
+	migrationFilename := fmt.Sprintf("%s_%s.up.fizz", migrationVersion, migrationName)
 	t2 := template.Must(template.New("migration").Parse(secureMigrationTemplate))
-	err = createMigration(migrationPath, migrationFileName, t2, secureMigrationName)
+	err = createMigration(migrationPath, migrationFilename, t2, secureMigrationName)
 	if err != nil {
 		return err
 	}
 
-	err = addMigrationToManifest(migrationManifest, migrationFileName)
+	err = addMigrationToManifest(migrationManifest, migrationFilename)
 	if err != nil {
 		return err
 	}

--- a/cmd/milmove/gen_migration.go
+++ b/cmd/milmove/gen_migration.go
@@ -2,10 +2,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
-	"log"
-	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -42,22 +38,6 @@ func checkGenMigrationConfig(v *viper.Viper) error {
 	return nil
 }
 
-func addMigrationToManifest(migrationManifest string, filename string) error {
-	mmf, err := os.OpenFile(migrationManifest, os.O_APPEND|os.O_WRONLY, 0600)
-	if err != nil {
-		return errors.Wrap(err, "could not open migration manifest")
-	}
-	defer mmf.Close()
-
-	_, err = mmf.WriteString(filename + "\n")
-	if err != nil {
-		return errors.Wrap(err, "could not append to the migration manifest")
-	}
-
-	log.Println(fmt.Sprintf("new migration appended to manifest at %q", migrationManifest))
-	return nil
-}
-
 func genMigrationFunction(cmd *cobra.Command, args []string) error {
 
 	err := cmd.ParseFlags(args)
@@ -87,14 +67,10 @@ func genMigrationFunction(cmd *cobra.Command, args []string) error {
 	migrationType := v.GetString(cli.MigrationTypeFlag)
 
 	filename := fmt.Sprintf("%s_%s.up.%s", migrationVersion, migrationName, migrationType)
-	p := filepath.Join(migrationPath, filename)
-
-	err = ioutil.WriteFile(p, []byte{}, 0644)
+	err = writeEmptyFile(migrationPath, filename)
 	if err != nil {
-		return errors.Wrap(err, "could not write new migration file")
+		return err
 	}
-
-	fmt.Println(fmt.Sprintf("new migration file created at %q", p))
 
 	err = addMigrationToManifest(migrationManifest, filename)
 	if err != nil {

--- a/cmd/milmove/gen_office_user_migration.go
+++ b/cmd/milmove/gen_office_user_migration.go
@@ -64,8 +64,8 @@ func CheckAddOfficeUsersFlags(v *viper.Viper) error {
 		return err
 	}
 
-	officeUsersFileName := v.GetString(OfficeUsersFilenameFlag)
-	if officeUsersFileName == "" {
+	officeUsersFilename := v.GetString(OfficeUsersFilenameFlag)
+	if officeUsersFilename == "" {
 		return errors.Errorf("%s is missing", OfficeUsersFilenameFlag)
 	}
 	return nil
@@ -137,7 +137,7 @@ func readOfficeUsersCSV(fileName string) ([]models.OfficeUser, error) {
 func genOfficeUserMigration(cmd *cobra.Command, args []string) error {
 	err := cmd.ParseFlags(args)
 	if err != nil {
-		errors.Wrap(err, "Could not parse flags")
+		return errors.Wrap(err, "Could not parse flags")
 	}
 
 	flag := cmd.Flags()
@@ -159,9 +159,9 @@ func genOfficeUserMigration(cmd *cobra.Command, args []string) error {
 	migrationManifest := v.GetString(cli.MigrationManifestFlag)
 	migrationName := v.GetString(cli.MigrationNameFlag)
 	migrationVersion := v.GetString(cli.MigrationVersionFlag)
-	officeUsersFileName := v.GetString(OfficeUsersFilenameFlag)
+	officeUsersFilename := v.GetString(OfficeUsersFilenameFlag)
 
-	officeUsers, err := readOfficeUsersCSV(officeUsersFileName)
+	officeUsers, err := readOfficeUsersCSV(officeUsersFilename)
 	if err != nil {
 		return errors.Wrap(err, "error reading csv file")
 	}
@@ -178,14 +178,14 @@ func genOfficeUserMigration(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	migrationFileName := fmt.Sprintf("%s_%s.up.fizz", migrationVersion, migrationName)
+	migrationFilename := fmt.Sprintf("%s_%s.up.fizz", migrationVersion, migrationName)
 	t2 := template.Must(template.New("migration").Parse(secureMigrationTemplate))
-	err = createMigration(migrationPath, migrationFileName, t2, secureMigrationName)
+	err = createMigration(migrationPath, migrationFilename, t2, secureMigrationName)
 	if err != nil {
 		return err
 	}
 
-	err = addMigrationToManifest(migrationManifest, migrationFileName)
+	err = addMigrationToManifest(migrationManifest, migrationFilename)
 	if err != nil {
 		return err
 	}

--- a/cmd/milmove/gen_office_user_migration.go
+++ b/cmd/milmove/gen_office_user_migration.go
@@ -5,20 +5,15 @@ import (
 	"encoding/csv"
 	"fmt"
 	"io"
-	"log"
 	"os"
-	"path/filepath"
 	"strings"
 	"text/template"
-	"time"
-
-	"github.com/pkg/errors"
-	"github.com/spf13/cobra"
 
 	"github.com/gobuffalo/validate"
 	"github.com/gobuffalo/validate/validators"
-
 	"github.com/gofrs/uuid"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 
@@ -29,13 +24,7 @@ import (
 const (
 	// OfficeUsersFilenameFlag filename containing the details for new office users
 	OfficeUsersFilenameFlag string = "office-users-filename"
-	// OfficeUsersMigrationFile sql file containing the migration to add the new office users
-	OfficeUsersMigrationFilenameFlag string = "migration-filename"
-	// VersionTimeFormat is the Go time format for creating a version number.
-	VersionTimeFormat string = "20060102150405"
-)
 
-const (
 	// template for adding office users
 	createOfficeUser string = `INSERT INTO public.office_users
 (id, user_id, first_name, last_name, middle_initials, email, telephone, transportation_office_id, created_at, updated_at)
@@ -44,39 +33,42 @@ VALUES
 {{ if $i}},{{end}}('{{$e.ID}}', NULL, '{{$e.FirstName}}', '{{$e.LastName}}', {{if .MiddleInitials}}'{{.MiddleInitials}}'{{else}}NULL{{end}}, '{{$e.Email}}', '{{$e.Telephone}}', '{{$e.TransportationOfficeID}}', now(), now())
 {{- end}};
 `
-
-	// template to apply secure migration
-	migration string = `exec("./apply-secure-migration.sh {{.}}")`
 )
 
-// OfficeUsersFilenameFlag initializes add_office_users command line flags
+// InitAddOfficeUsersFlags initializes command line flags
 func InitAddOfficeUsersFlags(flag *pflag.FlagSet) {
 	flag.StringP(OfficeUsersFilenameFlag, "f", "", "File name of csv file containing the new office users")
-	flag.StringP(OfficeUsersMigrationFilenameFlag, "n", "", "File name of the migration files for the new office users")
-}
-
-// CheckAddOfficeUsers validates add_office_users command line flags
-func CheckAddOfficeUsers(v *viper.Viper) error {
-	officeUsersFileName := v.GetString(OfficeUsersFilenameFlag)
-	if officeUsersFileName == "" {
-		return fmt.Errorf("--office-users-filename is required")
-	}
-	officeUsersMigrationFilenameFlag := v.GetString(OfficeUsersMigrationFilenameFlag)
-	if officeUsersMigrationFilenameFlag == "" {
-		return fmt.Errorf("--migration-filename is required")
-	}
-	return nil
 }
 
 func initGenOfficeUserMigrationFlags(flag *pflag.FlagSet) {
 	// Migration Config
 	cli.InitMigrationFlags(flag)
 
+	// Migration File Config
+	cli.InitMigrationFileFlags(flag)
+
 	// Add Office Users
 	InitAddOfficeUsersFlags(flag)
 
-	// Sort command line flags
-	flag.SortFlags = true
+	// Don't sort command line flags
+	flag.SortFlags = false
+}
+
+// CheckAddOfficeUsersFlags validates add_office_users command line flags
+func CheckAddOfficeUsersFlags(v *viper.Viper) error {
+	if err := cli.CheckMigration(v); err != nil {
+		return err
+	}
+
+	if err := cli.CheckMigrationFile(v); err != nil {
+		return err
+	}
+
+	officeUsersFileName := v.GetString(OfficeUsersFilenameFlag)
+	if officeUsersFileName == "" {
+		return errors.Errorf("%s is missing", OfficeUsersFilenameFlag)
+	}
+	return nil
 }
 
 func ValidateOfficeUser(o *models.OfficeUser) (*validate.Errors, error) {
@@ -142,77 +134,58 @@ func readOfficeUsersCSV(fileName string) ([]models.OfficeUser, error) {
 	return officeUsers, nil
 }
 
-func closeFile(outfile *os.File) {
-	err := outfile.Close()
-	if err != nil {
-		log.Printf("error closing %s: %v\n", outfile.Name(), err)
-		os.Exit(1)
-	}
-}
-
-func createMigration(path string, filename string, t *template.Template, templateData interface{}) error {
-	migrationPath := filepath.Join(path, filename)
-	migrationFile, err := os.Create(migrationPath)
-	defer closeFile(migrationFile)
-	if err != nil {
-		return errors.Wrapf(err, "error creating %s", migrationPath)
-	}
-	err = t.Execute(migrationFile, templateData)
-	if err != nil {
-		log.Println("error executing template: ", err)
-	}
-	log.Printf("new migration file created at:  %q\n", migrationPath)
-	return nil
-}
-
 func genOfficeUserMigration(cmd *cobra.Command, args []string) error {
 	err := cmd.ParseFlags(args)
-	flag := cmd.Flags()
-	err = flag.Parse(os.Args[1:])
 	if err != nil {
-		return errors.Wrap(err, "could not parse flags")
+		errors.Wrap(err, "Could not parse flags")
 	}
+
+	flag := cmd.Flags()
+
 	v := viper.New()
 	err = v.BindPFlags(flag)
 	if err != nil {
 		return errors.Wrap(err, "could not bind flags")
 	}
-	err = CheckAddOfficeUsers(v)
+	v.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
+	v.AutomaticEnv()
+
+	err = CheckAddOfficeUsersFlags(v)
 	if err != nil {
 		return err
 	}
-	migrationsPath := v.GetString(cli.MigrationPathFlag)
+
+	migrationPath := v.GetString(cli.MigrationPathFlag)
 	migrationManifest := v.GetString(cli.MigrationManifestFlag)
+	migrationName := v.GetString(cli.MigrationNameFlag)
+	migrationVersion := v.GetString(cli.MigrationVersionFlag)
 	officeUsersFileName := v.GetString(OfficeUsersFilenameFlag)
-	migrationFileName := v.GetString(OfficeUsersMigrationFilenameFlag)
 
 	officeUsers, err := readOfficeUsersCSV(officeUsersFileName)
 	if err != nil {
 		return errors.Wrap(err, "error reading csv file")
 	}
 
-	secureMigrationName := fmt.Sprintf("%s_%s.up.sql", time.Now().Format(VersionTimeFormat), migrationFileName)
+	secureMigrationName := fmt.Sprintf("%s_%s.up.sql", migrationVersion, migrationName)
 	t1 := template.Must(template.New("add_office_user").Parse(createOfficeUser))
-	err = createMigration("./tmp", secureMigrationName, t1, officeUsers)
-	if err != nil {
-		return err
-	}
-	localMigrationPath := filepath.Join("local_migrations", secureMigrationName)
-	localMigrationFile, err := os.Create(localMigrationPath)
-	defer closeFile(localMigrationFile)
-	if err != nil {
-		return errors.Wrapf(err, "error creating %s", localMigrationPath)
-	}
-	log.Printf("new migration file created at:  %q\n", localMigrationPath)
-
-	migrationName := fmt.Sprintf("%s_%s.up.fizz", time.Now().Format(VersionTimeFormat), migrationFileName)
-	t2 := template.Must(template.New("migration").Parse(migration))
-	err = createMigration(migrationsPath, migrationName, t2, secureMigrationName)
+	err = createMigration(tempMigrationPath, secureMigrationName, t1, officeUsers)
 	if err != nil {
 		return err
 	}
 
-	err = addMigrationToManifest(migrationManifest, migrationName)
+	err = writeEmptyFile("local_migrations", secureMigrationName)
+	if err != nil {
+		return err
+	}
+
+	migrationFileName := fmt.Sprintf("%s_%s.up.fizz", migrationVersion, migrationName)
+	t2 := template.Must(template.New("migration").Parse(secureMigrationTemplate))
+	err = createMigration(migrationPath, migrationFileName, t2, secureMigrationName)
+	if err != nil {
+		return err
+	}
+
+	err = addMigrationToManifest(migrationManifest, migrationFileName)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Description

I am planning to build another generation command in https://github.com/transcom/mymove/pull/2375 and found I needed to normalize the migration generation code so I could reuse it. I decided to break this out of that PR so it could be merged sooner and so it could also support https://github.com/transcom/mymove/pull/2386 being worked on right now.

Notice that the common code is in `gen.go` now. I'm also using the default CLI commands from `pkg/cli/migrate.go` and `pkg/cli/migrate_file.go`.  I'm also using `log` instead of `fmt`. And errors use the default constants instead of strings.

## Reviewer Notes

Does your command still work as expected? I did my best to test them.

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
rm -f bin/milmove && make bin/milmove
milmove gen disable-user-migration -n disable_user -e chris@truss.works
```

## Code Review Verification Steps

* [x] Request review from a member of a different team.