### PR TITLE
increase concurrency for running golangci-lint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -274,6 +274,7 @@ jobs:
           keys:
             - pre-commit-dot-cache-{{ checksum ".pre-commit-config.yaml" }}
       - run: echo 'export PATH=${PATH}:~/go/bin:~/transcom/mymove/bin' >> $BASH_ENV
+      - run: echo 'export GOLANGCI_LINT_CONCURRENCY=1' >> $BASH_ENV
       - run: make bin/callgraph
       - run: make server_generate mocks_generate
       # this is so we can avoid go mod downloading and resulting in an error on a false positive

--- a/.envrc
+++ b/.envrc
@@ -210,6 +210,9 @@ export HTTP_ORDERS_SERVER_NAME=orderslocal
 # Set feature flags
 export FEATURE_FLAG_ACCESS_CODE=false
 
+# Set golangci-lint concurrency to 1
+export GOLANGCI_LINT_CONCURRENCY=1
+
 ##############################################
 # Load Local Overrides and Check Environment #
 ##############################################

--- a/.envrc
+++ b/.envrc
@@ -210,6 +210,9 @@ export HTTP_ORDERS_SERVER_NAME=orderslocal
 # Set feature flags
 export FEATURE_FLAG_ACCESS_CODE=false
 
+# Set override of golangci-lint concurrency env variable
+export GOLANGCI_LINT_CONCURRENCY=6
+
 ##############################################
 # Load Local Overrides and Check Environment #
 ##############################################

--- a/.envrc
+++ b/.envrc
@@ -210,9 +210,6 @@ export HTTP_ORDERS_SERVER_NAME=orderslocal
 # Set feature flags
 export FEATURE_FLAG_ACCESS_CODE=false
 
-# Set golangci-lint concurrency to 1
-export GOLANGCI_LINT_CONCURRENCY=1
-
 ##############################################
 # Load Local Overrides and Check Environment #
 ##############################################

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,8 @@ repos:
     rev: v1.17.1
     hooks:
       - id: golangci-lint
-        entry: golangci-lint run
+        entry: bash -c 'exec golangci-lint run -v -j=${GOLANGCI_LINT_CONCURRENCY:-3}' # custom bash so we can override concurrency for faster dev runs
+
 
   - repo: git://github.com/igorshubovych/markdownlint-cli
     rev: v0.17.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
     rev: v1.17.1
     hooks:
       - id: golangci-lint
-        entry: bash -c 'exec golangci-lint run -j=${GOLANGCI_LINT_CONCURRENCY}' # custom bash so we can override concurrency for faster dev runs
+        entry: bash -c 'exec golangci-lint run -j=${GOLANGCI_LINT_CONCURRENCY:-1}' # custom bash so we can override concurrency for faster dev runs
 
 
   - repo: git://github.com/igorshubovych/markdownlint-cli

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
     rev: v1.17.1
     hooks:
       - id: golangci-lint
-        entry: bash -c 'exec golangci-lint run -v -j=${GOLANGCI_LINT_CONCURRENCY:-3}' # custom bash so we can override concurrency for faster dev runs
+        entry: bash -c 'exec golangci-lint run -j=${GOLANGCI_LINT_CONCURRENCY}' # custom bash so we can override concurrency for faster dev runs
 
 
   - repo: git://github.com/igorshubovych/markdownlint-cli

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
     rev: v1.17.1
     hooks:
       - id: golangci-lint
-        entry: bash -c 'exec golangci-lint run -j=${GOLANGCI_LINT_CONCURRENCY:-1}' # custom bash so we can override concurrency for faster dev runs
+        entry: bash -c 'exec golangci-lint run -j=${GOLANGCI_LINT_CONCURRENCY}' # custom bash so we can override concurrency for faster dev runs
 
 
   - repo: git://github.com/igorshubovych/markdownlint-cli

--- a/.spelling
+++ b/.spelling
@@ -415,6 +415,8 @@ uncomment
 ecs-service-logs
 Wildcards
 envrc.local
+golangci-lint
+goland
 # Put all custom terms BEFORE this comment, lest 'pre-commit' and 'make spellcheck' yield different errors.
  - /usr/local
  - docs/data/tspp-data-creation.md

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ This prototype was built by a [Defense Digital Service](https://www.dds.mil/) te
   * [Setup: Quick Initial Setup](#setup-quick-initial-setup)
   * [Setup: Prerequisites](#setup-prerequisites)
   * [Setup: Direnv](#setup-direnv)
+    * [Helpful variables for `.envrc.local`](#helpful-variables-for-envrclocal)
   * [Setup: Pre-Commit](#setup-pre-commit)
   * [Setup: Hosts](#setup-hosts)
   * [Setup: Dependencies](#setup-dependencies)
@@ -213,6 +214,11 @@ Run `direnv allow` to load up the `.envrc` file. It should complain that you hav
 You can add a `.envrc.local` file. One way to do this is using chamber.  You must have the infra-com repo already cloned and must add the path to it in your .envrc.local (`PPP_INFRA_PATH='~/yourlocalpath/ppp-infra'`) Then run `chamber env app-devlocal >> .envrc.local`. If you don't have access to chamber you can also `touch .envrc.local` and add any values that the output from direnv asks you to define. Instructions are in the error messages.
 
 If you wish to not maintain a `.envrc.local` you can alternatively run `cp .envrc.chamber.template .envrc.chamber` to enable getting secret values from `chamber`. **Note** that this method does not work for users of the `fish` shell unless you replace `direnv allow` with `direnv export fish | source`.
+
+#### Helpful variables for `.envrc.local`
+
+* `export GOLANGCI_LINT_CONCURRENCY=12` - variable to increase concurrency of golangci-lint for an up to 3X performance gain.
+* `export GOLAND=1` - variable to enable go code debugging in goland
 
 ### Setup: Pre-Commit
 

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ If you wish to not maintain a `.envrc.local` you can alternatively run `cp .envr
 
 #### Helpful variables for `.envrc.local`
 
-* `export GOLANGCI_LINT_CONCURRENCY=6` - variable to increase concurrency of golangci-lint for an up to 3X performance gain.
+* `export GOLANGCI_LINT_CONCURRENCY=8` - variable to increase concurrency of golangci-lint; defaults to 6 on dev machines and to 1 in CircleCI.
 * `export GOLAND=1` - variable to enable go code debugging in goland
 
 ### Setup: Pre-Commit

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ If you wish to not maintain a `.envrc.local` you can alternatively run `cp .envr
 
 #### Helpful variables for `.envrc.local`
 
-* `export GOLANGCI_LINT_CONCURRENCY=12` - variable to increase concurrency of golangci-lint for an up to 3X performance gain.
+* `export GOLANGCI_LINT_CONCURRENCY=6` - variable to increase concurrency of golangci-lint for an up to 3X performance gain.
 * `export GOLAND=1` - variable to enable go code debugging in goland
 
 ### Setup: Pre-Commit


### PR DESCRIPTION
## Description

Defaults golangci-lint concurrency to 1 that doesn't crash CI server but decreases run time for dev machines by setting a local env variable. 

![image](https://user-images.githubusercontent.com/5003421/61932418-5ed8f780-af51-11e9-9dd5-75d44465d409.png)
![image](https://user-images.githubusercontent.com/5003421/61932505-92b41d00-af51-11e9-9aab-f2a2fe7fd2ea.png)
