### PR TITLE
Implement "tiebreaker" for TSPs with matching BVS scores

### DIFF
--- a/pkg/models/transportation_service_provider.go
+++ b/pkg/models/transportation_service_provider.go
@@ -29,22 +29,6 @@ type TransportationServiceProvider struct {
 	PocClaimsPhone           *string   `json:"poc_claims_phone" db:"poc_claims_phone"`
 }
 
-// TSPWithBVSAndOfferCount represents a list of TSPs along with their BVS
-// and offered shipment counts.
-type TSPWithBVSAndOfferCount struct {
-	ID                        uuid.UUID `json:"id" db:"id"`
-	TrafficDistributionListID uuid.UUID `json:"traffic_distribution_list_id" db:"traffic_distribution_list_id"`
-	BestValueScore            int       `json:"best_value_score" db:"best_value_score"`
-	OfferCount                int       `json:"offer_count" db:"offer_count"`
-}
-
-// TSPWithBVSCount represents a list of TSPs along with their BVS counts.
-type TSPWithBVSCount struct {
-	ID                        uuid.UUID `json:"id" db:"id"`
-	TrafficDistributionListID uuid.UUID `json:"traffic_distribution_list_id" db:"traffic_distribution_list_id"`
-	BestValueScore            int       `json:"best_value_score" db:"best_value_score"`
-}
-
 // TransportationServiceProviders is not required by pop and may be deleted
 type TransportationServiceProviders []TransportationServiceProvider
 

--- a/pkg/models/transportation_service_provider_performance.go
+++ b/pkg/models/transportation_service_provider_performance.go
@@ -299,7 +299,8 @@ func GetRateCycle(year int, peak bool) (start time.Time, end time.Time) {
 
 // FetchDiscountRates returns the discount linehaul and SIT rates for the TSP with the highest
 // BVS during the specified date, limited to those TSPs in the channel defined by the
-// originZip and destinationZip.
+// originZip and destinationZip.  In case of more than one TSP having the same highest BVS score,
+// we return the one whose TSPP ID comes first alphabetically.
 func FetchDiscountRates(db *pop.Connection, originZip string, destinationZip string, cos string, date time.Time) (linehaulDiscount unit.DiscountRate, sitDiscount unit.DiscountRate, err error) {
 	rateArea, err := FetchRateAreaForZip5(db, originZip)
 	if err != nil {
@@ -317,7 +318,8 @@ func FetchDiscountRates(db *pop.Connection, originZip string, destinationZip str
 		Where("tdl.destination_region = ?", region).
 		Where("tdl.code_of_service = ?", cos).
 		Where("? BETWEEN transportation_service_provider_performances.performance_period_start AND transportation_service_provider_performances.performance_period_end", date).
-		Order("transportation_service_provider_performances.best_value_score DESC").
+		// Additional sort by TSPP ID in case of matching BVS (want to be deterministic with the TSPP record returned)
+		Order("transportation_service_provider_performances.best_value_score DESC, transportation_service_provider_performances.id ASC").
 		First(&tspPerformance)
 
 	if err != nil {

--- a/pkg/models/transportation_service_provider_performance.go
+++ b/pkg/models/transportation_service_provider_performance.go
@@ -123,6 +123,10 @@ func NextTSPPerformanceInQualityBand(tx *pop.Connection, tdlID uuid.UUID,
 			offer_count ASC,
 			best_value_score DESC
 		`
+	// Note: For PPM estimates, we ensure we have a tiebreaker that always returns the same TSPP
+	// record in case multiple records match in the query above.  We may want to adjust the award
+	// queue for consistency if we start doing HHGs again.  For more information, see:
+	// https://docs.google.com/document/d/1T-KYb7BGNWpybkz-LrLGFRfWyKXhAD2w4fwJOBHko5A/edit#
 
 	tspp := TransportationServiceProviderPerformance{}
 	err := tx.RawQuery(sql, tdlID, qualityBand, bookDate, requestedPickupDate).First(&tspp)
@@ -214,6 +218,10 @@ func FetchTSPPerformancesForQualityBandAssignment(tx *pop.Connection, perfGroup 
 		Where("enrolled = true").
 		Order("best_value_score DESC").
 		All(&perfs)
+	// Note: For PPM estimates, we ensure we have a tiebreaker that always returns the same TSPP
+	// record in case multiple records match in the query above.  We may want to adjust the award
+	// queue for consistency if we start doing HHGs again.  For more information, see:
+	// https://docs.google.com/document/d/1T-KYb7BGNWpybkz-LrLGFRfWyKXhAD2w4fwJOBHko5A/edit#
 
 	return perfs, err
 }


### PR DESCRIPTION
## Description

In the `transportation_service_provider_performances` table, we have a few cases where the top BVS in a TDL/period is shared by multiple TSPs.  We use the TSP with the top BVS as part of the formula to determine PPM estimates and reimbursement amounts.  Previously, in a scenario with multiple top-scoring TSPs, we may get any one of them back in our query, but the overall estimate/reimbursement amount could potentially change because they may not all share the same discount rates.

This PR is meant to make the query deterministic by additionally ordering by the UUID when we have matches (note the UUID should be the same for a TSPP record across all of our environments).  This means that we should get the same exact estimate and reimbursement amount no matter how many times it's requested.

## Reviewer Notes

The award queue has a few places where it does some ordering on BVS for placing TSPPs into quality bands or picking the “next” one within a quality band.  I don't think that requires additional ordering like described above for PPM estimates, but would appreciate any thoughts around that.

Marking this as a WIP until I get a few additional clarifications.

## Setup

First, there is a server test included in this PR you should review and ensure works.

Next, to test with a move in dev mode, we'll have to set up a scenario using baseline scrubbed TSPP data.  For reference, here's the SQL to return a performance period and TDL that has two TSPPs with the highest BVS score of 62 (the scenario we're trying to address):

```SQL
select performance_period_start, traffic_distribution_list_id, best_value_score, linehaul_rate, sit_rate from transportation_service_provider_performances
where performance_period_start = '2019-05-15' and traffic_distribution_list_id = '5550ddd2-75e2-4c24-9582-ea67a025755a'
order by best_value_score desc, id asc;
```
![Screen Shot 2019-07-29 at 10 28 40 AM](https://user-images.githubusercontent.com/4960757/62056458-ab3f6400-b1eb-11e9-884e-eab7edf2daf5.png)

The TDL shown above is for source rate area `US79`, destination region `13`, and COS `D`, so we'll set up a PPM move that will fall into that TDL.  Set up a PPM move from zip 85635 and current base Fort Huachuca (zip 85613).  Destination is zip 33602 and destination base MacDill AFB (zip 33621).  When you get to the point of the PPM process where you see the PPM incentive on the screen, check your console and look for `Found Discount for TDL` and ensure that the log message shows the discount rates from the first line of results above.  You can try it multiple times if you'd like -- it should always return the first record because its UUID comes first alphabetically.

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/tree/master/docs/backend.md#logging)
* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/tree/master/docs/backend.md#querying-the-database-safely) have been satisfied.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/164497030) for this change
