### PR TITLE
Fix office "Approve" button click issues in IE11

### DIFF
--- a/src/shared/ComboButton/index.css
+++ b/src/shared/ComboButton/index.css
@@ -1,5 +1,6 @@
 .combo-button {
-  position: relative;
+  /* NOTE: Commenting this out to fix IE11 issue where combo button did not handle clicks */
+  /* position: relative; */
 }
 
 .combo-button-icon {


### PR DESCRIPTION
## Description

The "Approve" button in the office UI for approving a PPM initiates a drop-down menu when clicked.  In IE11, the click did not seem to be registering at all, but was acting as expected in other browsers.  After researching and experimenting, we found that having the `combo-box` style that sets `position: relative` was triggering the problem.  We were able to comment that out and get the clicks to register on all browsers.  We did not notice any change in the display on various browsers by removing this style.

## Reviewer Notes

Please double-check multiple supported browsers and ensure the "Approve" button still renders and functions as expected.

## Setup

- `make db_dev_e2e_populate`
- Login to the office app and pull up any of these three moves: `CANCEL`, `ORDER3`, `VGHEIS`
- The "Approve" button will be disabled until you put in the data noted as missing.
- Once missing data has been added, verify that the "Approve" drop down looks OK and that you can approve basics/PPM as expected.

## Code Review Verification Steps

* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Request review from a member of a different team.
