### PR TITLE
Prevent direnv from complaining while entering MFA token

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -54,6 +54,10 @@ check_required_variables() {
 # Loads secrets from chamber instead of requiring them to be listed in .envrc.local
 
 if [ -e .envrc.chamber ]; then
+  # Loading secrets from Chamber can take a while. Prevent direnv from
+  # complaining.
+  export DIRENV_WARN_TIMEOUT="20s"
+
   source_env .envrc.chamber
 else
   log_status "Want to load secrets from chamber? 'cp .envrc.chamber.template .envrc.chamber'"


### PR DESCRIPTION
## Description

Direnv doesn't typically expect users to be required to interact with the `.envrc` script. As such, if the execution time of `.envrc` is below some $SMALL_THRESHOLD, it complains. This is annoying when you're trying to enter your AWS MFA token:

```
$ direnv allow
direnv: loading .envrc
direnv: loading .envrc.chamber
Enter token for arn:aws:iam::923914045601:mfa/alexi: direnv: ([/usr/local/bin/direnv export bash]) is taking a while to execute. Use CTRL-C to give up.
```
> I'M DOING MY BEST, OK!?!

This PR takes advantage of a direnv configuration environment variable to make the timeout 20s, which hopefully is long enough for even the pokiest of us to enter 6 digits.

## Testing

I was concerned that because this is an environment variable managed by direnv itself, it might not be available for direnv. This doesn't seem to be a problem (though it might not apply until after people `direnv allow` this commit.

To test:
* Checkout this branch
* `direnv allow`
* Clear your aws-vault session by deleting `aws-vault session for transcom-ppp` from your login keychain
* Manually `direnv allow` again, and notice that there is a blissful 20 seconds to enter the MFA.