### PR TITLE
Fix 'make help' in places where it wasn't working

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,14 +99,7 @@ endif
 	touch .check_bash_version.stamp
 
 .PHONY: deps
-deps: prereqs \
-	check_hosts \
-	check_go_version \
-	check_gopath \
-	check_bash_version \
-	ensure_pre_commit \
-	client_deps \
-	server_deps ## Run all checks and install all depdendencies
+deps: prereqs check_hosts check_go_version check_gopath check_bash_version ensure_pre_commit client_deps server_deps ## Run all checks and install all depdendencies
 
 .PHONY: test
 test: client_test server_test e2e_test ## Run all tests
@@ -291,14 +284,7 @@ go_deps_update: server_deps server_generate mocks_generate ## Update golang depe
 	go run cmd/update_deps/main.go
 
 .PHONY: server_deps
-server_deps: .check_gopath.stamp \
-	bin/callgraph \
-	bin/chamber \
-	bin/gin \
-	bin/soda \
-	bin/swagger \
-	bin/mockery \
-	bin/rds-combined-ca-bundle.pem ## Install or Build server dependencies
+server_deps: .check_gopath.stamp bin/callgraph bin/chamber bin/gin bin/soda bin/swagger bin/mockery bin/rds-combined-ca-bundle.pem ## Install or Build server dependencies
 
 .PHONY: server_generate
 server_generate: .check_go_version.stamp .check_gopath.stamp .server_generate.stamp ## Generate golang server code from Swagger files
@@ -897,7 +883,7 @@ prune_volumes:  ## Prune docker volumes
 prune: prune_images prune_containers prune_volumes ## Prune docker containers, images, and volumes
 
 .PHONY: clean
-clean: # Clean all generated files
+clean: ## Clean all generated files
 	rm -f .*.stamp
 	rm -f coverage.out
 	rm -rf ./bin
@@ -912,7 +898,7 @@ clean: # Clean all generated files
 	find ./pkg -type d -name "mocks" -exec rm -rf {} +
 
 .PHONY: spellcheck
-spellcheck: .client_deps.stamp # Run interactive spellchecker
+spellcheck: .client_deps.stamp ## Run interactive spellchecker
 	node_modules/.bin/mdspell --ignore-numbers --ignore-acronyms --en-us \
 		`find . -type f -name "*.md" \
 			-not -path "./node_modules/*" \


### PR DESCRIPTION
## Description

A couple of these targets didn't show up when you used `make help`. Turns out some were missing an extra `#` and some had multiple lines. I didn't fix `build_tools` because it became unreadable but I'm open to folks wanting me to fix that too.