### PR TITLE
Add endpoint to log a TSPP record

### DIFF
--- a/pkg/handlers/publicapi/api.go
+++ b/pkg/handlers/publicapi/api.go
@@ -11,6 +11,8 @@ import (
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/paperwork"
 	"github.com/transcom/mymove/pkg/rateengine"
+	"github.com/transcom/mymove/pkg/services/query"
+	"github.com/transcom/mymove/pkg/services/tsp"
 
 	accesscodeservice "github.com/transcom/mymove/pkg/services/accesscode"
 	paperworkservice "github.com/transcom/mymove/pkg/services/paperwork"
@@ -80,6 +82,14 @@ func NewPublicAPIHandler(context handlers.HandlerContext, logger Logger) http.Ha
 	publicAPI.TransportationServiceProviderGetTransportationServiceProviderHandler = GetTransportationServiceProviderHandler{context}
 	publicAPI.TspsIndexTSPsHandler = TspsIndexTSPsHandler{context}
 	publicAPI.TspsGetTspShipmentsHandler = TspsGetTspShipmentsHandler{context}
+
+	// Transportation Service Provider Performances
+	queryBuilder := query.NewQueryBuilder(context.DB())
+	publicAPI.TransportationServiceProviderPerformanceLogTransportationServiceProviderPerformanceHandler = LogTransportationServiceProviderPerformanceHandler{
+		HandlerContext: context,
+		NewQueryFilter: query.NewQueryFilter,
+		TransportationServiceProviderPerformanceFetcher: tsp.NewTransportationServiceProviderPerformanceFetcher(queryBuilder),
+	}
 
 	// Storage In Transits
 	publicAPI.StorageInTransitsCreateStorageInTransitHandler = CreateStorageInTransitHandler{

--- a/pkg/handlers/publicapi/transportation_service_provider_performances.go
+++ b/pkg/handlers/publicapi/transportation_service_provider_performances.go
@@ -1,0 +1,46 @@
+package publicapi
+
+import (
+	"github.com/go-openapi/runtime/middleware"
+	"github.com/gofrs/uuid"
+	"go.uber.org/zap"
+
+	tsppop "github.com/transcom/mymove/pkg/gen/restapi/apioperations/transportation_service_provider_performance"
+	"github.com/transcom/mymove/pkg/handlers"
+	"github.com/transcom/mymove/pkg/services"
+)
+
+// LogTransportationServiceProviderPerformanceHandler logs a TSPP record (for auditing purposes)
+type LogTransportationServiceProviderPerformanceHandler struct {
+	handlers.HandlerContext
+	services.NewQueryFilter
+	services.TransportationServiceProviderPerformanceFetcher
+}
+
+// Handle logging the TSPP record
+func (h LogTransportationServiceProviderPerformanceHandler) Handle(params tsppop.LogTransportationServiceProviderPerformanceParams) middleware.Responder {
+	session, logger := h.SessionAndLoggerFromRequest(params.HTTPRequest)
+	tsppID, _ := uuid.FromString(params.TransportationServiceProviderPerformanceID.String())
+
+	if !session.IsOfficeUser() {
+		return tsppop.NewLogTransportationServiceProviderPerformanceForbidden()
+	}
+
+	queryFilters := []services.QueryFilter{
+		h.NewQueryFilter("id", "=", tsppID.String()),
+	}
+	tspp, err := h.TransportationServiceProviderPerformanceFetcher.FetchTransportationServiceProviderPerformance(queryFilters)
+
+	if err != nil {
+		if err.Error() == "sql: no rows in result set" {
+			logger.Info("No record found for TSPP ID", zap.String("id", tsppID.String()))
+		} else {
+			logger.Error("DB Query", zap.Error(err))
+			return tsppop.NewLogTransportationServiceProviderPerformanceInternalServerError()
+		}
+	} else {
+		logger.Info("Record found for TSPP ID", zap.Object("TSPP", &tspp))
+	}
+
+	return tsppop.NewLogTransportationServiceProviderPerformanceNoContent()
+}

--- a/pkg/handlers/publicapi/transportation_service_provider_performances_test.go
+++ b/pkg/handlers/publicapi/transportation_service_provider_performances_test.go
@@ -1,0 +1,101 @@
+package publicapi
+
+import (
+	"errors"
+	"fmt"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gofrs/uuid"
+	"github.com/stretchr/testify/mock"
+
+	tsppop "github.com/transcom/mymove/pkg/gen/restapi/apioperations/transportation_service_provider_performance"
+	"github.com/transcom/mymove/pkg/handlers"
+	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/services"
+	"github.com/transcom/mymove/pkg/services/mocks"
+)
+
+func newMockQueryFilterBuilder(filter *mocks.QueryFilter) services.NewQueryFilter {
+	return func(column string, comparator string, value interface{}) services.QueryFilter {
+		return filter
+	}
+}
+
+func (suite *HandlerSuite) TestLogTransportationServiceProviderPerformanceHandler() {
+	tsppID, _ := uuid.NewV4()
+	path := fmt.Sprintf("/transportation_service_provider_performances/%s", tsppID)
+	noAuthReq := httptest.NewRequest("GET", path, nil)
+
+	officeUserID, _ := uuid.NewV4()
+	userID, _ := uuid.NewV4()
+	officeUser := models.OfficeUser{ID: officeUserID, UserID: &userID}
+	officeAuthReq := suite.AuthenticateOfficeRequest(noAuthReq, officeUser)
+
+	officeUserParams := tsppop.LogTransportationServiceProviderPerformanceParams{
+		HTTPRequest: officeAuthReq,
+		TransportationServiceProviderPerformanceID: *handlers.FmtUUID(tsppID),
+	}
+
+	queryFilter := mocks.QueryFilter{}
+	newQueryFilter := newMockQueryFilterBuilder(&queryFilter)
+	tspp := models.TransportationServiceProviderPerformance{ID: tsppID}
+	tsppFetcher := &mocks.TransportationServiceProviderPerformanceFetcher{}
+
+	handler := LogTransportationServiceProviderPerformanceHandler{
+		HandlerContext: handlers.NewHandlerContext(suite.DB(), suite.TestLogger()),
+		NewQueryFilter: newQueryFilter,
+		TransportationServiceProviderPerformanceFetcher: tsppFetcher,
+	}
+
+	suite.T().Run("has TSPP, no content response", func(t *testing.T) {
+		tsppFetcher.On("FetchTransportationServiceProviderPerformance",
+			mock.Anything,
+		).Return(tspp, nil).Once()
+
+		response := handler.Handle(officeUserParams)
+
+		suite.IsType(&tsppop.LogTransportationServiceProviderPerformanceNoContent{}, response)
+		// Note: No payload since it's just being logged.
+	})
+
+	suite.T().Run("does not have TSPP, no content response", func(t *testing.T) {
+		expectedError := errors.New("sql: no rows in result set")
+		tsppFetcher.On("FetchTransportationServiceProviderPerformance",
+			mock.Anything,
+		).Return(models.TransportationServiceProviderPerformance{}, expectedError).Once()
+
+		response := handler.Handle(officeUserParams)
+
+		suite.IsType(&tsppop.LogTransportationServiceProviderPerformanceNoContent{}, response)
+		// Note: No payload since it's just being logged.
+	})
+
+	suite.T().Run("some other error", func(t *testing.T) {
+		expectedError := errors.New("test error")
+		tsppFetcher.On("FetchTransportationServiceProviderPerformance",
+			mock.Anything,
+		).Return(models.TransportationServiceProviderPerformance{}, expectedError).Once()
+
+		response := handler.Handle(officeUserParams)
+
+		suite.IsType(&tsppop.LogTransportationServiceProviderPerformanceInternalServerError{}, response)
+	})
+
+	suite.T().Run("use tsp user, get unauthorized response", func(t *testing.T) {
+		// Create some params where auth'd as TSP to make sure we get an unauthorized response
+		tspUserID, _ := uuid.NewV4()
+		userID, _ = uuid.NewV4()
+		tspUser := models.TspUser{ID: tspUserID, UserID: &userID}
+		tspAuthReq := suite.AuthenticateTspRequest(noAuthReq, tspUser)
+
+		tspUserParams := tsppop.LogTransportationServiceProviderPerformanceParams{
+			HTTPRequest: tspAuthReq,
+			TransportationServiceProviderPerformanceID: *handlers.FmtUUID(tsppID),
+		}
+
+		response := handler.Handle(tspUserParams)
+
+		suite.IsType(&tsppop.LogTransportationServiceProviderPerformanceForbidden{}, response)
+	})
+}

--- a/pkg/models/transportation_service_provider_performance.go
+++ b/pkg/models/transportation_service_provider_performance.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gofrs/uuid"
 	"github.com/honeycombio/beeline-go"
 	"github.com/pkg/errors"
+	"go.uber.org/zap/zapcore"
 
 	"github.com/transcom/mymove/pkg/unit"
 )
@@ -94,6 +95,26 @@ func (t *TransportationServiceProviderPerformance) Validate(tx *pop.Connection) 
 		&DiscountRateIsValid{Field: t.LinehaulRate, Name: "LinehaulRate"},
 		&DiscountRateIsValid{Field: t.SITRate, Name: "SITRate"},
 	), nil
+}
+
+// MarshalLogObject is required to be able to zap.Object log a TSPP
+func (t *TransportationServiceProviderPerformance) MarshalLogObject(encoder zapcore.ObjectEncoder) error {
+	encoder.AddString("ID", t.ID.String())
+	encoder.AddTime("PerformancePeriodStart", t.PerformancePeriodStart)
+	encoder.AddTime("PerformancePeriodEnd", t.PerformancePeriodEnd)
+	encoder.AddTime("RateCycleStart", t.RateCycleStart)
+	encoder.AddTime("RateCycleEnd", t.RateCycleEnd)
+	encoder.AddString("TrafficDistributionListID", t.TrafficDistributionListID.String())
+	encoder.AddString("TransportationServiceProviderID", t.TransportationServiceProviderID.String())
+	if t.QualityBand != nil {
+		encoder.AddInt("QualityBand", *t.QualityBand)
+	}
+	encoder.AddFloat64("BestValueScore", t.BestValueScore)
+	encoder.AddFloat64("LinehaulRate", t.LinehaulRate.Float64())
+	encoder.AddFloat64("SITRate", t.SITRate.Float64())
+	encoder.AddInt("OfferCount", t.OfferCount)
+
+	return nil
 }
 
 // NextTSPPerformanceInQualityBand returns the TSP performance record in a given TDL

--- a/pkg/services/tsp.go
+++ b/pkg/services/tsp.go
@@ -1,0 +1,12 @@
+package services
+
+import (
+	"github.com/transcom/mymove/pkg/models"
+)
+
+// TransportationServiceProviderPerformanceFetcher is the exported interface for fetching
+// a single transportation service provider performance
+//go:generate mockery -name TransportationServiceProviderPerformanceFetcher
+type TransportationServiceProviderPerformanceFetcher interface {
+	FetchTransportationServiceProviderPerformance(filters []QueryFilter) (models.TransportationServiceProviderPerformance, error)
+}

--- a/pkg/services/tsp/logger.go
+++ b/pkg/services/tsp/logger.go
@@ -1,0 +1,15 @@
+package tsp
+
+import (
+	"go.uber.org/zap"
+)
+
+// Logger is an interface that describes the logging requirements of this package.
+type Logger interface {
+	Debug(msg string, fields ...zap.Field)
+	Info(msg string, fields ...zap.Field)
+	Warn(msg string, fields ...zap.Field)
+	Error(msg string, fields ...zap.Field)
+	Fatal(msg string, fields ...zap.Field)
+	WithOptions(opts ...zap.Option) *zap.Logger
+}

--- a/pkg/services/tsp/transportation_service_provider_performance_fetcher.go
+++ b/pkg/services/tsp/transportation_service_provider_performance_fetcher.go
@@ -1,0 +1,26 @@
+package tsp
+
+import (
+	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/services"
+)
+
+type transportationServiceProviderPerformanceQueryBuilder interface {
+	FetchOne(model interface{}, filters []services.QueryFilter) error
+}
+
+type transportationServiceProviderPerformanceFetcher struct {
+	builder transportationServiceProviderPerformanceQueryBuilder
+}
+
+// FetchTransportationServiceProviderPerformance fetches a transportation service provider performance given a slice of filters
+func (o *transportationServiceProviderPerformanceFetcher) FetchTransportationServiceProviderPerformance(filters []services.QueryFilter) (models.TransportationServiceProviderPerformance, error) {
+	var transportationServiceProviderPerformance models.TransportationServiceProviderPerformance
+	error := o.builder.FetchOne(&transportationServiceProviderPerformance, filters)
+	return transportationServiceProviderPerformance, error
+}
+
+// NewTransportationServiceProviderPerformanceFetcher return an implementation of the TransportationServiceProviderPerformanceFetcher interface
+func NewTransportationServiceProviderPerformanceFetcher(builder transportationServiceProviderPerformanceQueryBuilder) services.TransportationServiceProviderPerformanceFetcher {
+	return &transportationServiceProviderPerformanceFetcher{builder}
+}

--- a/pkg/services/tsp/transportation_service_provider_performance_fetcher_test.go
+++ b/pkg/services/tsp/transportation_service_provider_performance_fetcher_test.go
@@ -1,0 +1,60 @@
+package tsp
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/gofrs/uuid"
+
+	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/services"
+	"github.com/transcom/mymove/pkg/services/query"
+)
+
+type testTransportationServiceProviderPerformanceQueryBuilder struct {
+	fakeFetchOne func(model interface{}) error
+}
+
+func (t *testTransportationServiceProviderPerformanceQueryBuilder) FetchOne(model interface{}, filters []services.QueryFilter) error {
+	m := t.fakeFetchOne(model)
+	return m
+}
+
+func (suite *TSPServiceSuite) TestFetchTransportationServiceProviderPerformance() {
+	suite.T().Run("if the TSPP is fetched, it should be returned", func(t *testing.T) {
+		id, err := uuid.NewV4()
+		suite.NoError(err)
+		fakeFetchOne := func(model interface{}) error {
+			reflect.ValueOf(model).Elem().FieldByName("ID").Set(reflect.ValueOf(id))
+			return nil
+		}
+
+		builder := &testTransportationServiceProviderPerformanceQueryBuilder{
+			fakeFetchOne: fakeFetchOne,
+		}
+		fetcher := NewTransportationServiceProviderPerformanceFetcher(builder)
+		filters := []services.QueryFilter{query.NewQueryFilter("id", "=", id.String())}
+
+		tspp, err := fetcher.FetchTransportationServiceProviderPerformance(filters)
+
+		suite.NoError(err)
+		suite.Equal(id, tspp.ID)
+	})
+
+	suite.T().Run("if there is an error, we get it with zero TSPP", func(t *testing.T) {
+		fakeFetchOne := func(model interface{}) error {
+			return errors.New("Fetch error")
+		}
+		builder := &testTransportationServiceProviderPerformanceQueryBuilder{
+			fakeFetchOne: fakeFetchOne,
+		}
+		fetcher := NewTransportationServiceProviderPerformanceFetcher(builder)
+
+		tspp, err := fetcher.FetchTransportationServiceProviderPerformance([]services.QueryFilter{})
+
+		suite.Error(err)
+		suite.Equal(err.Error(), "Fetch error")
+		suite.Equal(models.TransportationServiceProviderPerformance{}, tspp)
+	})
+}

--- a/pkg/services/tsp/tsp_service_test.go
+++ b/pkg/services/tsp/tsp_service_test.go
@@ -1,0 +1,28 @@
+package tsp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"go.uber.org/zap"
+
+	"github.com/transcom/mymove/pkg/testingsuite"
+)
+
+type TSPServiceSuite struct {
+	testingsuite.PopTestSuite
+	logger Logger
+}
+
+func (suite *TSPServiceSuite) SetupTest() {
+	suite.DB().TruncateAll()
+}
+
+func TestUserSuite(t *testing.T) {
+
+	hs := &TSPServiceSuite{
+		PopTestSuite: testingsuite.NewPopTestSuite(testingsuite.CurrentPackage()),
+		logger:       zap.NewNop(), // Use a no-op logger during testing
+	}
+	suite.Run(t, hs)
+}

--- a/pkg/services/user/office_user_fetcher.go
+++ b/pkg/services/user/office_user_fetcher.go
@@ -16,14 +16,14 @@ type officeUserFetcher struct {
 	builder officeUserQueryBuilder
 }
 
-// FetchOfficeUser fetches an office user for the given a slice of filters
+// FetchOfficeUser fetches an office user given a slice of filters
 func (o *officeUserFetcher) FetchOfficeUser(filters []services.QueryFilter) (models.OfficeUser, error) {
 	var officeUser models.OfficeUser
 	error := o.builder.FetchOne(&officeUser, filters)
 	return officeUser, error
 }
 
-// NewOfficeUserFetcher return an implementaion of the OfficeUserFetcher interface
+// NewOfficeUserFetcher return an implementation of the OfficeUserFetcher interface
 func NewOfficeUserFetcher(builder officeUserQueryBuilder) services.OfficeUserFetcher {
 	return &officeUserFetcher{builder}
 }

--- a/swagger/api.yaml
+++ b/swagger/api.yaml
@@ -3658,3 +3658,28 @@ paths:
           description: user is not authorized
         500:
           description: server error
+  /transportation_service_provider_performances/{transportationServiceProviderPerformanceId}:
+    get:
+      summary: Logs a Transportation Service Provider Performance
+      description: Logs a Transportation Service Provider Performance
+      operationId: logTransportationServiceProviderPerformance
+      tags:
+        - transportation_service_provider_performance
+      parameters:
+        - name: transportationServiceProviderPerformanceId
+          in: path
+          type: string
+          format: uuid
+          required: true
+          description: UUID of the Transportation Service Provider Performance
+      responses:
+        204:
+          description: the Transportation Service Provider Performance was logged
+        400:
+          description: invalid request
+        401:
+          description: must be authenticated to use this endpoint
+        403:
+          description: not authorized to log the details of this Transportation Service Provider Performance
+        500:
+          description: server error


### PR DESCRIPTION
## Description

This PR adds an endpoint to log a TSPP record so we can spot-check TSPP data after a big data load.  To keep the data private, this just logs the data and doesn't return any content.  You must be authenticated as an office user to hit this endpoint.

## Reviewer Notes

This new endpoint was originally part of #2407, but that PR was closed an an alternate route taken which didn't involve a large-scale TSPP data modification.

## Setup

Login to the office UI.  You can use the swagger UI to test out the `transportation_service_provider_performances` endpoint in development or hit a URL like this:

http://officelocal:3000/api/v1/transportation_service_provider_performances/0000d239-e4eb-40e3-bcae-7e67c8a25a3b

(change out the UUID above as desired).

Look at your logs and verify that the TSPP data in the log message matches what's in your database for that UUID.

Also try hitting the endpoint as a non-office user (or with no authentication at all) and make sure it does not log data but returns an appropriate status code.

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/tree/master/docs/backend.md#logging)
* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/tree/master/docs/backend.md#querying-the-database-safely) have been satisfied.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/167624649) for this change
