### PR TITLE
Ensure mocks are built for pre-commit tests run by makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -871,7 +871,7 @@ gofmt:  ## Run go fmt over all Go files
 	go fmt $$(go list ./...) >> /dev/null
 
 .PHONY: pre_commit_tests
-pre_commit_tests: .server_generate.stamp .client_deps.stamp ## Run pre-commit tests
+pre_commit_tests: .server_generate.stamp .mocks_generate.stamp .client_deps.stamp ## Run pre-commit tests
 	pre-commit run --all-files
 
 .PHONY: pretty


### PR DESCRIPTION
## Description

This was missing so when you ran `make clean pre_commit_tests` it would fail because mocks were not built.