### PR TITLE
Remove is_superuser column from users table

### DIFF
--- a/migrations/20190731163048_remove_is_superuser.up.fizz
+++ b/migrations/20190731163048_remove_is_superuser.up.fizz
@@ -1,0 +1,1 @@
+drop_column("users", "is_superuser")

--- a/migrations_manifest.txt
+++ b/migrations_manifest.txt
@@ -335,3 +335,4 @@
 20190723214108_add_office_users.up.fizz
 20190724193344_add_more_system_admin_users.up.fizz
 20190730194820_pp3_2019_tspp_data.up.fizz
+20190731163048_remove_is_superuser.up.fizz


### PR DESCRIPTION
## Description

We no longer need `is_superuser` in the users table.

## Setup

1. `make db_dev_migrate`

## Code Review Verification Steps

* [x] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/167437806) for this change