### PR TITLE
Removed unused variables in scripts to address shellcheck warning

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -816,33 +816,33 @@ workflows:
             - pre_deps_yarn
             - acceptance_tests_local
           # if testing on experimental, you can disable these tests by using the commented block below.
-          filters:
-            branches:
-              ignore: rr-fix-shellcheck-issues
+          # filters:
+          #   branches:
+          #     ignore: placeholder_branch_name
 
       - client_test:
           requires:
             - pre_deps_yarn
           # if testing on experimental, you can disable these tests by using the commented block below.
-          filters:
-            branches:
-              ignore: rr-fix-shellcheck-issues
+          # filters:
+          #   branches:
+          #     ignore: placeholder_branch_name
 
       - server_test:
           requires:
             - pre_deps_golang
           # if testing on experimental, you can disable these tests by using the commented block below.
-          filters:
-            branches:
-              ignore: rr-fix-shellcheck-issues
+          # filters:
+          #   branches:
+          #     ignore: placeholder_branch_name
 
       - server_test_coverage:
           requires:
             - pre_deps_golang
           # if testing on experimental, you can disable these tests by using the commented block below.
-          filters:
-            branches:
-              ignore: rr-fix-shellcheck-issues
+          # filters:
+          #   branches:
+          #     ignore: placeholder_branch_name
 
       - build_app:
           requires:
@@ -875,28 +875,28 @@ workflows:
             - build_migrations
           filters:
             branches:
-              only: rr-fix-shellcheck-issues
+              only: placeholder_branch_name
 
       - deploy_experimental_tasks:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: rr-fix-shellcheck-issues
+              only: placeholder_branch_name
 
       - deploy_experimental_app:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: rr-fix-shellcheck-issues
+              only: placeholder_branch_name
 
       - deploy_experimental_app_client_tls:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: rr-fix-shellcheck-issues
+              only: placeholder_branch_name
 
       - check_circle_against_staging_sha:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -816,33 +816,33 @@ workflows:
             - pre_deps_yarn
             - acceptance_tests_local
           # if testing on experimental, you can disable these tests by using the commented block below.
-          # filters:
-          #   branches:
-          #     ignore: placeholder_branch_name
+          filters:
+            branches:
+              ignore: rr-fix-shellcheck-issues
 
       - client_test:
           requires:
             - pre_deps_yarn
           # if testing on experimental, you can disable these tests by using the commented block below.
-          # filters:
-          #   branches:
-          #     ignore: placeholder_branch_name
+          filters:
+            branches:
+              ignore: rr-fix-shellcheck-issues
 
       - server_test:
           requires:
             - pre_deps_golang
           # if testing on experimental, you can disable these tests by using the commented block below.
-          # filters:
-          #   branches:
-          #     ignore: placeholder_branch_name
+          filters:
+            branches:
+              ignore: rr-fix-shellcheck-issues
 
       - server_test_coverage:
           requires:
             - pre_deps_golang
           # if testing on experimental, you can disable these tests by using the commented block below.
-          # filters:
-          #   branches:
-          #     ignore: placeholder_branch_name
+          filters:
+            branches:
+              ignore: rr-fix-shellcheck-issues
 
       - build_app:
           requires:
@@ -875,28 +875,28 @@ workflows:
             - build_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: rr-fix-shellcheck-issues
 
       - deploy_experimental_tasks:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: rr-fix-shellcheck-issues
 
       - deploy_experimental_app:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: rr-fix-shellcheck-issues
 
       - deploy_experimental_app_client_tls:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: rr-fix-shellcheck-issues
 
       - check_circle_against_staging_sha:
           requires:

--- a/scripts/dump-function-calls
+++ b/scripts/dump-function-calls
@@ -14,7 +14,6 @@ usage() {
 set -u
 
 readonly entrypoint=github.com/transcom/mymove/cmd/milmove
-readonly header="Package | Line | Column | Caller | Callee"
 readonly format='{"path":"{{.Caller.Pkg.Pkg.Path}}","line":"{{.Line}}","column":"{{.Column}}","caller":{"package":{"name":"{{.Caller.Pkg.Pkg.Name}}","path":"{{.Caller.Pkg.Pkg.Path}}"},"name":"{{.Caller.Name}}"},"callee":{"package":{"name":"{{.Caller.Pkg.Pkg.Name}}","path":"{{.Caller.Pkg.Pkg.Path}}"},"name":"{{.Callee.Name}}"}}'
 
 # Use the deployed architecture, since we don't really care what is used just for darwin/macOS.

--- a/scripts/ecs-deploy-service-container
+++ b/scripts/ecs-deploy-service-container
@@ -36,7 +36,6 @@ readonly cluster=app-${environment}
 readonly rds=app-${environment}
 
 readonly task_family=${name}-${environment}
-readonly container_name=${name}-${environment}
 
 readonly zone_name="move.mil"
 

--- a/scripts/ecs-restart-services
+++ b/scripts/ecs-restart-services
@@ -3,8 +3,6 @@
 #   Restarted the ECS services associated with the given environment.
 #
 set -eo pipefail
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-readonly DIR
 
 usage() {
     echo "${0##*/} <environment>"

--- a/scripts/ecs-restart-services
+++ b/scripts/ecs-restart-services
@@ -2,7 +2,7 @@
 #
 #   Restarted the ECS services associated with the given environment.
 #
-set -eo pipefail
+set -euo pipefail
 
 usage() {
     echo "${0##*/} <environment>"
@@ -13,16 +13,19 @@ usage() {
 # Display command being run
 echo "$0 $*"
 
-set -u
+readonly environment="$1"
+readonly cluster="app-${environment}"
 
+# Validate the environments
+if [[ "${environment}" != "experimental" ]] && [[ "${environment}" != "staging" ]] && [[ "${environment}" != "prod" ]] ; then
+  echo "<environment> must be one of experimental, staging, or prod"
+  exit 1
+fi
 
-readonly environment=$1
-readonly cluster=app-${environment}
-
-echo "* Restarting service \"app\""
+echo "* Restarting service \"app\" for cluster \"${cluster}\""
 aws ecs update-service --cluster "$cluster" --service app --force-new-deployment > /dev/null
 
-echo "* Restarting service \"app-client-tls\""
+echo "* Restarting service \"app-client-tls\" for cluster \"${cluster}\""
 aws ecs update-service --cluster "$cluster" --service app-client-tls --force-new-deployment > /dev/null
 
 echo "* Waiting for service \"app\" and \"app-client-tls\" to stabilize (this takes a while)"

--- a/scripts/go-find-pattern
+++ b/scripts/go-find-pattern
@@ -4,11 +4,8 @@
 #   For example: scripts/go-find-pattern '[.]Info[(]"[^"]+\s+"'
 #
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-readonly DIR
-
 usage() {
-    echo "$0 <pattern"
+    echo "$0 <pattern>"
     exit 1
 }
 [[ -z $1  ]] && usage


### PR DESCRIPTION
## Description

When running `pre-commit run -a`, I started getting some errors when processing four different bash scripts.  It's likely this just started with `shellcheck` 0.7.0 that came out a few days ago.  The errors are about unused variables and look legit.  This PR removes the unused variables.

## Reviewer Notes

I was able to test `dump-function-calls` and `go-find-pattern` locally.  I need some infra help verifying that `ecs-deploy-service-container` and `ecs-restart-services` still work.

## Setup

- `shellcheck --version` to see if you are on version 0.7.0
-  If on earlier version, then do a `brew update` then `brew upgrade shellcheck`
- `make clean server_build client_build`
- `pre-commit run -a` to make sure there are no `shellcheck` errors.
- Run the scripts (except the ECS ones unless you know what you're doing with them).

## Code Review Verification Steps

* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] Request review from a member of a different team.

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/167629917) for this change
