### PR TITLE
Update e2e test selector

### DIFF
--- a/cypress/integration/tsp/shipShipment.js
+++ b/cypress/integration/tsp/shipShipment.js
@@ -233,8 +233,8 @@ function tspUserDeliversShipment(availableDays) {
     .click();
 
   cy
-    .get('div')
-    .contains(availableDays[0].format('DD'))
+    .get('.DayPicker-Day')
+    .contains(availableDays[0].format('D'))
     .click();
 
   // Cancel
@@ -264,8 +264,8 @@ function tspUserDeliversShipment(availableDays) {
     .click();
 
   cy
-    .get('div')
-    .contains(availableDays[1].format('DD'))
+    .get('.DayPicker-Day')
+    .contains(availableDays[1].format('D'))
     .click();
 
   cy


### PR DESCRIPTION
## Description

Update cypress selector for date picker test.

## Reviewer Notes

This test was giving us problems last month #2341. This fix seems to resolve the immediate issue, but maybe we should consider a follow on PR to update it such that it doesn't interact with the date picker at all like the accompanying test `tspUserEntersPackAndPickUpInfo` 

https://github.com/transcom/mymove/blob/master/cypress/integration/tsp/shipShipment.js#L88-L205


