### PR TITLE
System admin office lists api

### DIFF
--- a/pkg/handlers/adminapi/addresses.go
+++ b/pkg/handlers/adminapi/addresses.go
@@ -1,0 +1,23 @@
+package adminapi
+
+import (
+	"github.com/go-openapi/swag"
+
+	"github.com/transcom/mymove/pkg/gen/adminmessages"
+	"github.com/transcom/mymove/pkg/models"
+)
+
+func payloadForAddressModel(a *models.Address) *adminmessages.Address {
+	if a == nil {
+		return nil
+	}
+	return &adminmessages.Address{
+		StreetAddress1: swag.String(a.StreetAddress1),
+		StreetAddress2: a.StreetAddress2,
+		StreetAddress3: a.StreetAddress3,
+		City:           swag.String(a.City),
+		State:          swag.String(a.State),
+		PostalCode:     swag.String(a.PostalCode),
+		Country:        a.Country,
+	}
+}

--- a/pkg/handlers/adminapi/api.go
+++ b/pkg/handlers/adminapi/api.go
@@ -9,6 +9,7 @@ import (
 	"github.com/transcom/mymove/pkg/gen/adminapi"
 	adminops "github.com/transcom/mymove/pkg/gen/adminapi/adminoperations"
 	"github.com/transcom/mymove/pkg/handlers"
+	"github.com/transcom/mymove/pkg/services/office"
 	"github.com/transcom/mymove/pkg/services/query"
 	"github.com/transcom/mymove/pkg/services/user"
 )
@@ -36,14 +37,16 @@ func NewAdminAPIHandler(context handlers.HandlerContext) http.Handler {
 		user.NewOfficeUserFetcher(queryBuilder),
 		query.NewQueryFilter,
 	}
-	adminAPI.OfficeIndexOfficesHandler = IndexOfficesHandler{
-		HandlerContext: context,
-		NewQueryFilter: query.NewQueryFilter,
-	}
 
 	adminAPI.OfficeCreateOfficeUserHandler = CreateOfficeUserHandler{
 		context,
 		user.NewOfficeUserCreator(queryBuilder),
+		query.NewQueryFilter,
+	}
+
+	adminAPI.OfficeIndexOfficesHandler = IndexOfficesHandler{
+		context,
+		office.NewOfficeListFetcher(queryBuilder),
 		query.NewQueryFilter,
 	}
 

--- a/pkg/handlers/adminapi/offices.go
+++ b/pkg/handlers/adminapi/offices.go
@@ -6,8 +6,21 @@ import (
 	officeop "github.com/transcom/mymove/pkg/gen/adminapi/adminoperations/office"
 	"github.com/transcom/mymove/pkg/gen/adminmessages"
 	"github.com/transcom/mymove/pkg/handlers"
+	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services"
 )
+
+func payloadForOfficeModel(o models.TransportationOffice) *adminmessages.TransportationOffice {
+	return &adminmessages.TransportationOffice{
+		ID:         handlers.FmtUUID(o.ID),
+		Name:       handlers.FmtString(o.Name),
+		Address:    payloadForAddressModel(&o.Address),
+		Gbloc:      o.Gbloc,
+		PhoneLines: payloadForPhoneLines(o.PhoneLines),
+		Latitude:   o.Latitude,
+		Longitude:  o.Longitude,
+	}
+}
 
 // IndexOfficesHandler returns a list of office users via GET /office_users
 type IndexOfficesHandler struct {

--- a/pkg/handlers/adminapi/offices.go
+++ b/pkg/handlers/adminapi/offices.go
@@ -12,6 +12,7 @@ import (
 // IndexOfficesHandler returns a list of office users via GET /office_users
 type IndexOfficesHandler struct {
 	handlers.HandlerContext
+	services.OfficeListFetcher
 	services.NewQueryFilter
 }
 

--- a/pkg/handlers/adminapi/offices.go
+++ b/pkg/handlers/adminapi/offices.go
@@ -17,5 +17,19 @@ type IndexOfficesHandler struct {
 
 // Handle retrieves a list of office users
 func (h IndexOfficesHandler) Handle(params officeop.IndexOfficesParams) middleware.Responder {
-	return officeop.NewIndexOfficesOK().WithPayload(adminmessages.TransportationOffices{})
+	logger := h.LoggerFromRequest(params.HTTPRequest)
+	// Here is where NewQueryFilter will be used to create Filters from the 'filter' query param
+	queryFilters := []services.QueryFilter{}
+
+	offices, err := h.OfficeListFetcher.FetchOfficeList(queryFilters)
+	if err != nil {
+		return handlers.ResponseForError(logger, err)
+	}
+
+	payload := make(adminmessages.TransportationOffices, len(offices))
+	for i, s := range offices {
+		payload[i] = payloadForOfficeModel(s)
+	}
+
+	return officeop.NewIndexOfficesOK().WithPayload(payload)
 }

--- a/pkg/handlers/adminapi/offices_test.go
+++ b/pkg/handlers/adminapi/offices_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services/mocks"
+	"github.com/transcom/mymove/pkg/services/office"
 	"github.com/transcom/mymove/pkg/services/query"
 	"github.com/transcom/mymove/pkg/testdatagen"
 )
@@ -36,10 +37,11 @@ func (suite *HandlerSuite) TestIndexOfficesHandler() {
 		params := officeop.IndexOfficesParams{
 			HTTPRequest: req,
 		}
-
+		queryBuilder := query.NewQueryBuilder(suite.DB())
 		handler := IndexOfficesHandler{
-			HandlerContext: handlers.NewHandlerContext(suite.DB(), suite.TestLogger()),
-			NewQueryFilter: query.NewQueryFilter,
+			HandlerContext:    handlers.NewHandlerContext(suite.DB(), suite.TestLogger()),
+			NewQueryFilter:    query.NewQueryFilter,
+			OfficeListFetcher: office.NewOfficeListFetcher(queryBuilder),
 		}
 
 		response := handler.Handle(params)
@@ -86,8 +88,9 @@ func (suite *HandlerSuite) TestIndexOfficesHandler() {
 			mock.Anything,
 		).Return(nil, expectedError).Once()
 		handler := IndexOfficesHandler{
-			HandlerContext: handlers.NewHandlerContext(suite.DB(), suite.TestLogger()),
-			NewQueryFilter: newQueryFilter,
+			HandlerContext:    handlers.NewHandlerContext(suite.DB(), suite.TestLogger()),
+			NewQueryFilter:    newQueryFilter,
+			OfficeListFetcher: officeListFetcher,
 		}
 
 		response := handler.Handle(params)

--- a/pkg/handlers/adminapi/offices_test.go
+++ b/pkg/handlers/adminapi/offices_test.go
@@ -1,14 +1,17 @@
 package adminapi
 
 import (
+	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/gofrs/uuid"
+	"github.com/stretchr/testify/mock"
 
 	officeop "github.com/transcom/mymove/pkg/gen/adminapi/adminoperations/office"
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/services/mocks"
 	"github.com/transcom/mymove/pkg/services/query"
 	"github.com/transcom/mymove/pkg/testdatagen"
 )
@@ -43,6 +46,56 @@ func (suite *HandlerSuite) TestIndexOfficesHandler() {
 
 		suite.IsType(&officeop.IndexOfficesOK{}, response)
 		okResponse := response.(*officeop.IndexOfficesOK)
-		suite.Len(okResponse.Payload, 0)
+		suite.Len(okResponse.Payload, 1)
+		suite.Equal(uuidString, okResponse.Payload[0].ID.String())
+	})
+
+	queryFilter := mocks.QueryFilter{}
+	newQueryFilter := newMockQueryFilterBuilder(&queryFilter)
+
+	suite.T().Run("successful response", func(t *testing.T) {
+		office := models.TransportationOffice{ID: id}
+		params := officeop.IndexOfficesParams{
+			HTTPRequest: req,
+		}
+		officeListFetcher := &mocks.OfficeListFetcher{}
+		officeListFetcher.On("FetchOfficeList",
+			mock.Anything,
+		).Return(models.TransportationOffices{office}, nil).Once()
+		handler := IndexOfficesHandler{
+			HandlerContext:    handlers.NewHandlerContext(suite.DB(), suite.TestLogger()),
+			NewQueryFilter:    newQueryFilter,
+			OfficeListFetcher: officeListFetcher,
+		}
+
+		response := handler.Handle(params)
+
+		suite.IsType(&officeop.IndexOfficesOK{}, response)
+		okResponse := response.(*officeop.IndexOfficesOK)
+		suite.Len(okResponse.Payload, 1)
+		suite.Equal(uuidString, okResponse.Payload[0].ID.String())
+	})
+
+	suite.T().Run("unsuccesful response when fetch fails", func(t *testing.T) {
+		params := officeop.IndexOfficesParams{
+			HTTPRequest: req,
+		}
+		expectedError := models.ErrFetchNotFound
+		officeListFetcher := &mocks.OfficeListFetcher{}
+		officeListFetcher.On("FetchOfficeList",
+			mock.Anything,
+		).Return(nil, expectedError).Once()
+		handler := IndexOfficesHandler{
+			HandlerContext: handlers.NewHandlerContext(suite.DB(), suite.TestLogger()),
+			NewQueryFilter: newQueryFilter,
+		}
+
+		response := handler.Handle(params)
+
+		expectedResponse := &handlers.ErrResponse{
+			Code: http.StatusNotFound,
+			Err:  expectedError,
+		}
+		suite.Equal(expectedResponse, response)
 	})
 }

--- a/pkg/handlers/adminapi/phone_lines.go
+++ b/pkg/handlers/adminapi/phone_lines.go
@@ -1,0 +1,16 @@
+package adminapi
+
+import (
+	"github.com/transcom/mymove/pkg/models"
+)
+
+func payloadForPhoneLines(officePhoneLines models.OfficePhoneLines) []string {
+	var phoneLines []string
+	for _, phoneLine := range officePhoneLines {
+		if phoneLine.Type == "voice" {
+			phoneLines = append(phoneLines, phoneLine.Number)
+		}
+	}
+
+	return phoneLines
+}

--- a/pkg/services/office/office_fetcher.go
+++ b/pkg/services/office/office_fetcher.go
@@ -1,0 +1,26 @@
+package office
+
+import (
+	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/services"
+)
+
+type officeQueryBuilder interface {
+	FetchOne(model interface{}, filters []services.QueryFilter) error
+}
+
+type officeFetcher struct {
+	builder officeQueryBuilder
+}
+
+// FetchOffice fetches an office user for the given a slice of filters
+func (o *officeFetcher) FetchOffice(filters []services.QueryFilter) (models.TransportationOffice, error) {
+	var office models.TransportationOffice
+	error := o.builder.FetchOne(&office, filters)
+	return office, error
+}
+
+// NewOfficeFetcher return an implementaion of the OfficeFetcher interface
+func NewOfficeFetcher(builder officeQueryBuilder) services.OfficeFetcher {
+	return &officeFetcher{builder}
+}

--- a/pkg/services/office/office_fetcher_test.go
+++ b/pkg/services/office/office_fetcher_test.go
@@ -1,0 +1,60 @@
+package office
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/gofrs/uuid"
+
+	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/services"
+	"github.com/transcom/mymove/pkg/services/query"
+)
+
+type testOfficeQueryBuilder struct {
+	fakeFetchOne func(model interface{}) error
+}
+
+func (t *testOfficeQueryBuilder) FetchOne(model interface{}, filters []services.QueryFilter) error {
+	m := t.fakeFetchOne(model)
+	return m
+}
+
+func (suite *OfficeServiceSuite) TestFetchOffice() {
+	suite.T().Run("if the transportation office is fetched, it should be returned", func(t *testing.T) {
+		id, err := uuid.NewV4()
+		suite.NoError(err)
+		fakeFetchOne := func(model interface{}) error {
+			reflect.ValueOf(model).Elem().FieldByName("ID").Set(reflect.ValueOf(id))
+			return nil
+		}
+
+		builder := &testOfficeQueryBuilder{
+			fakeFetchOne: fakeFetchOne,
+		}
+		fetcher := NewOfficeFetcher(builder)
+		filters := []services.QueryFilter{query.NewQueryFilter("id", "=", id.String())}
+
+		office, err := fetcher.FetchOffice(filters)
+
+		suite.NoError(err)
+		suite.Equal(id, office.ID)
+	})
+
+	suite.T().Run("if there is an error, we get it with zero office", func(t *testing.T) {
+		fakeFetchOne := func(model interface{}) error {
+			return errors.New("Fetch error")
+		}
+		builder := &testOfficeQueryBuilder{
+			fakeFetchOne: fakeFetchOne,
+		}
+		fetcher := NewOfficeFetcher(builder)
+
+		office, err := fetcher.FetchOffice([]services.QueryFilter{})
+
+		suite.Error(err)
+		suite.Equal(err.Error(), "Fetch error")
+		suite.Equal(models.TransportationOffice{}, office)
+	})
+}

--- a/pkg/services/office/office_list_fetcher.go
+++ b/pkg/services/office/office_list_fetcher.go
@@ -1,0 +1,26 @@
+package office
+
+import (
+	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/services"
+)
+
+type officeListQueryBuilder interface {
+	FetchMany(model interface{}, filters []services.QueryFilter) error
+}
+
+type officeListFetcher struct {
+	builder officeListQueryBuilder
+}
+
+// FetchOfficeUserList uses the passed query builder to fetch a list of transportation offices
+func (o *officeListFetcher) FetchOfficeList(filters []services.QueryFilter) (models.TransportationOffices, error) {
+	var offices models.TransportationOffices
+	error := o.builder.FetchMany(&offices, filters)
+	return offices, error
+}
+
+// NewOfficeListFetcher returns an implementation of OfficeListFetcher
+func NewOfficeListFetcher(builder officeListQueryBuilder) services.OfficeListFetcher {
+	return &officeListFetcher{builder}
+}

--- a/pkg/services/office/office_list_fetcher_test.go
+++ b/pkg/services/office/office_list_fetcher_test.go
@@ -1,0 +1,64 @@
+package office
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/gofrs/uuid"
+
+	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/services"
+	"github.com/transcom/mymove/pkg/services/query"
+)
+
+type testOfficeListQueryBuilder struct {
+	fakeFetchMany func(model interface{}) error
+}
+
+func (t *testOfficeListQueryBuilder) FetchMany(model interface{}, filters []services.QueryFilter) error {
+	m := t.fakeFetchMany(model)
+	return m
+}
+
+func (suite *OfficeServiceSuite) TestFetchOfficeList() {
+	suite.T().Run("if the transportation office is fetched, it should be returned", func(t *testing.T) {
+		id, err := uuid.NewV4()
+		suite.NoError(err)
+		fakeFetchMany := func(model interface{}) error {
+			value := reflect.ValueOf(model).Elem()
+			value.Set(reflect.Append(value, reflect.ValueOf(models.TransportationOffice{ID: id})))
+			return nil
+		}
+		builder := &testOfficeListQueryBuilder{
+			fakeFetchMany: fakeFetchMany,
+		}
+
+		fetcher := NewOfficeListFetcher(builder)
+		filters := []services.QueryFilter{
+			query.NewQueryFilter("id", "=", id.String()),
+		}
+
+		offices, err := fetcher.FetchOfficeList(filters)
+
+		suite.NoError(err)
+		suite.Equal(id, offices[0].ID)
+	})
+
+	suite.T().Run("if there is an error, we get it with no offices", func(t *testing.T) {
+		fakeFetchMany := func(model interface{}) error {
+			return errors.New("Fetch error")
+		}
+		builder := &testOfficeListQueryBuilder{
+			fakeFetchMany: fakeFetchMany,
+		}
+
+		fetcher := NewOfficeListFetcher(builder)
+
+		offices, err := fetcher.FetchOfficeList([]services.QueryFilter{})
+
+		suite.Error(err)
+		suite.Equal(err.Error(), "Fetch error")
+		suite.Equal(models.TransportationOffices(nil), offices)
+	})
+}


### PR DESCRIPTION
## Description

As an System Admin
I want to query the office list admin endpoint and receive all offices
So I can verify who has office permissions

## Setup

1. `make server_run`
2. `make client_run`
3. Log in as admin user via devlocal auth
4. Navigate to http://adminlocal:3000/admin/v1/offices
5. You should see a 200 response with a list of transportation offices
8. If you log out or log in as a different user type and repeat step4, you will get a 403 Forbidden.

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/166121391) for this change
