### PR TITLE
Convert computePPM and computePPMIncludingLHDiscount to private funct…

### DIFF
--- a/docs/data/tariff400ng_items-update-data.md
+++ b/docs/data/tariff400ng_items-update-data.md
@@ -39,5 +39,5 @@ This basically is overkill (in this scenario) since there was only 1 column copi
 
 ## Source code
 
-* For an HHG (Household Goods) move, the function that computes and creates shipment line items is [`ComputeShipment`](https://github.com/transcom/mymove/blob/master/pkg/rateengine/rateengine.go#L153)
-* For a PPM (Personally Procured Move) move, the function that computes and creates shipment line items is [`ComputePPM`](https://github.com/transcom/mymove/blob/master/pkg/rateengine/rateengine.go#L73)
+* For an HHG (Household Goods) move, the function that computes and creates shipment line items is [`ComputeShipment`](https://github.com/transcom/mymove/blob/master/pkg/rateengine/rateengine.go#L241)
+* For a PPM (Personally Procured Move) move, the function that computes and creates shipment line items is [`computePPM`](https://github.com/transcom/mymove/blob/master/pkg/rateengine/rateengine.go#L84)

--- a/pkg/rateengine/rateengine.go
+++ b/pkg/rateengine/rateengine.go
@@ -80,8 +80,8 @@ func Zip5ToZip3(zip5 string) string {
 	return zip5[0:3]
 }
 
-// ComputePPM Calculates the cost of a PPM move.
-func (re *RateEngine) ComputePPM(
+// computePPM Calculates the cost of a PPM move.
+func (re *RateEngine) computePPM(
 	weight unit.Pound,
 	originZip5 string,
 	destinationZip5 string,
@@ -164,8 +164,8 @@ func (re *RateEngine) ComputePPM(
 	return cost, nil
 }
 
-//ComputePPMIncludingLHDiscount Calculates the cost of a PPM move using zip + date derived linehaul discount
-func (re *RateEngine) ComputePPMIncludingLHDiscount(weight unit.Pound, originZip5 string, destinationZip5 string, distanceMiles int, date time.Time, daysInSIT int) (cost CostComputation, err error) {
+//computePPMIncludingLHDiscount Calculates the cost of a PPM move using zip + date derived linehaul discount
+func (re *RateEngine) computePPMIncludingLHDiscount(weight unit.Pound, originZip5 string, destinationZip5 string, distanceMiles int, date time.Time, daysInSIT int) (cost CostComputation, err error) {
 
 	lhDiscount, sitDiscount, err := models.PPMDiscountFetch(re.db,
 		re.logger,
@@ -178,7 +178,7 @@ func (re *RateEngine) ComputePPMIncludingLHDiscount(weight unit.Pound, originZip
 		return
 	}
 
-	cost, err = re.ComputePPM(weight,
+	cost, err = re.computePPM(weight,
 		originZip5,
 		destinationZip5,
 		distanceMiles,
@@ -197,7 +197,7 @@ func (re *RateEngine) ComputePPMIncludingLHDiscount(weight unit.Pound, originZip
 
 //ComputeLowestCostPPMove uses zip codes to make two calculations for the price of a PPM move - once with the pickup zip and once with the current duty station zip - and returns the lowest cost move.
 func (re *RateEngine) ComputeLowestCostPPMMove(weight unit.Pound, originPickupZip5 string, originDutyStationZip5 string, destinationZip5 string, distanceMilesFromOriginPickupZip int, distanceMilesFromOriginDutyStationZip int, date time.Time, daysInSit int) (cost CostComputation, err error) {
-	costFromOriginPickupZip, err := re.ComputePPMIncludingLHDiscount(
+	costFromOriginPickupZip, err := re.computePPMIncludingLHDiscount(
 		weight,
 		originPickupZip5,
 		destinationZip5,
@@ -210,7 +210,7 @@ func (re *RateEngine) ComputeLowestCostPPMMove(weight unit.Pound, originPickupZi
 		return
 	}
 
-	costFromOriginDutyStationZip, err := re.ComputePPMIncludingLHDiscount(
+	costFromOriginDutyStationZip, err := re.computePPMIncludingLHDiscount(
 		weight,
 		originDutyStationZip5,
 		destinationZip5,

--- a/pkg/rateengine/rateengine_test.go
+++ b/pkg/rateengine/rateengine_test.go
@@ -187,7 +187,7 @@ func (suite *RateEngineSuite) computePPMIncludingLHRates(originZip string, desti
 	)
 	suite.Require().Nil(err)
 	engine := NewRateEngine(suite.DB(), logger)
-	cost, err := engine.ComputePPM(
+	cost, err := engine.computePPM(
 		weight,
 		originZip,
 		destinationZip,
@@ -213,7 +213,7 @@ func (suite *RateEngineSuite) Test_CheckPPMTotal() {
 	testdatagen.MakeFuelEIADieselPrices(suite.DB(), assertions)
 
 	// 139698 +20000
-	cost, err := engine.ComputePPM(2000, "39574", "33633", 1234, testdatagen.RateEngineDate,
+	cost, err := engine.computePPM(2000, "39574", "33633", 1234, testdatagen.RateEngineDate,
 		1, unit.DiscountRate(.6), unit.DiscountRate(.5))
 
 	if err != nil {
@@ -236,7 +236,7 @@ func (suite *RateEngineSuite) TestComputePPMWithLHDiscount() {
 	cost, err := suite.computePPMIncludingLHRates(originZip, destinationZip, weight, logger, planner)
 
 	engine := NewRateEngine(suite.DB(), logger)
-	ppmCost, err := engine.ComputePPMIncludingLHDiscount(
+	ppmCost, err := engine.computePPMIncludingLHDiscount(
 		weight,
 		originZip,
 		destinationZip,


### PR DESCRIPTION
…ions

## Description

The new `ComputeLowestCostPPMove` function is called by the rate engine callers. `ComputePPM` and `ComputePPMIncludingLHDiscount` are only called within `rateengine.go`, so there is no need to expose them publicly. This PR converts both to private functions.                                  

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make server_test
```
