### PR TITLE
Disable user records for former user

### DIFF
--- a/local_migrations/20190805161006_disable_truss_user.sql
+++ b/local_migrations/20190805161006_disable_truss_user.sql
@@ -1,0 +1,3 @@
+-- Local test migration.
+-- This will be run on development environments. It should mirror what you
+-- intend to apply on production, but do not include any sensitive data.

--- a/migrations/20190805161006_disable_truss_user.up.fizz
+++ b/migrations/20190805161006_disable_truss_user.up.fizz
@@ -1,0 +1,1 @@
+exec("./apply-secure-migration.sh 20190805161006_disable_truss_user.sql")

--- a/migrations_manifest.txt
+++ b/migrations_manifest.txt
@@ -337,3 +337,4 @@
 20190726151515_grant_all_ecs_user.up.fizz
 20190730194820_pp3_2019_tspp_data.up.fizz
 20190731163048_remove_is_superuser.up.fizz
+20190805161006_disable_truss_user.up.fizz


### PR DESCRIPTION
## Description

This PR disables a former project member's user records from all environments.

## Setup

`make run_prod_migrations` and/or `make run_staging_migrations` and verify that user is disabled in all *users tables in which they appear.

Also, [review the secure migration](https://github.com/transcom/mymove/blob/master/docs/how-to/migrate-the-database.md#downloading-secure-migrations) (which should be the same across all environments) to make sure it's handling the disabling appropriately.

## Code Review Verification Steps

* [ ] Secure migrations have been tested using `scripts/run-prod-migrations`
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/167685219) for this change
