### PR TITLE
Add payment reviewed status to PPM timeline

### DIFF
--- a/src/scenes/Landing/MoveSummary.jsx
+++ b/src/scenes/Landing/MoveSummary.jsx
@@ -310,9 +310,12 @@ export const SubmittedHhgMoveSummary = props => {
 //TODO remove redundant ApprovedMoveSummary component w/ ppmPaymentRequest flag
 const NewApprovedMoveSummaryComponent = ({ ppm, move, weightTicketSets }) => {
   const paymentRequested = ppm.status === 'PAYMENT_REQUESTED';
+  const paymentReviewed = ppm.status === 'COMPLETED';
   const moveInProgress = moment(ppm.original_move_date, 'YYYY-MM-DD').isSameOrBefore();
   const ppmPaymentRequestIntroRoute = `moves/${move.id}/ppm-payment-request-intro`;
   const ppmPaymentRequestReviewRoute = `moves/${move.id}/ppm-payment-review`;
+  console.log(ppm);
+  console.log(paymentReviewed);
   return (
     <Fragment>
       <div>
@@ -338,7 +341,10 @@ const NewApprovedMoveSummaryComponent = ({ ppm, move, weightTicketSets }) => {
                     </a>
                   </div>
                 )}
-                {paymentRequested ? (
+                {paymentReviewed ? (
+                  // Copy will be added later.
+                  <></>
+                ) : paymentRequested ? (
                   <div className="step">
                     <div className="title">Next step: Wait for your payment paperwork</div>
                     <div>

--- a/src/scenes/Landing/PPMStatusTimeline.js
+++ b/src/scenes/Landing/PPMStatusTimeline.js
@@ -21,6 +21,7 @@ const PpmStatusTimelineCodes = {
   PpmApproved: 'PPM_APPROVED',
   InProgress: 'IN_PROGRESS',
   PaymentRequested: 'PAYMENT_REQUESTED',
+  PaymentReviewed: 'PAYMENT_REVIEWED',
 };
 
 export class PPMStatusTimeline extends React.Component {
@@ -66,6 +67,8 @@ export class PPMStatusTimeline extends React.Component {
         return (moveInProgress && ppm.status === PpmStatuses.Approved) || moveIsComplete;
       case PpmStatusTimelineCodes.PaymentRequested:
         return moveIsComplete;
+      case PpmStatusTimelineCodes.PaymentReviewed:
+        return ppm.status === PpmStatuses.Completed;
       default:
         console.log('Unknown status');
     }
@@ -101,6 +104,11 @@ export class PPMStatusTimeline extends React.Component {
         code: PpmStatusTimelineCodes.PaymentRequested,
         dates: [paymentRequestedDate],
         completed: this.isCompleted(PpmStatusTimelineCodes.PaymentRequested),
+      },
+      {
+        name: 'Payment reviewed',
+        code: PpmStatusTimelineCodes.PaymentReviewed,
+        completed: this.isCompleted(PpmStatusTimelineCodes.PaymentReviewed),
       },
     ];
   }

--- a/src/scenes/Landing/StatusTimeline.test.jsx
+++ b/src/scenes/Landing/StatusTimeline.test.jsx
@@ -9,7 +9,7 @@ describe('StatusTimeline', () => {
       const ppm = {};
       const wrapper = mount(<PPMStatusTimeline ppm={ppm} getSignedCertification={jest.fn()} />);
 
-      expect(wrapper.find(StatusBlock)).toHaveLength(4);
+      expect(wrapper.find(StatusBlock)).toHaveLength(5);
     });
 
     test('renders timeline for submitted ppm', () => {

--- a/src/scenes/Moves/Ppm/ducks.js
+++ b/src/scenes/Moves/Ppm/ducks.js
@@ -2,7 +2,7 @@ import { get, every, isNull, isNumber, isEmpty } from 'lodash';
 import { CreatePpm, UpdatePpm, GetPpm, GetPpmWeightEstimate, GetPpmSitEstimate, RequestPayment } from './api.js';
 import * as ReduxHelpers from 'shared/ReduxHelpers';
 import { GET_LOGGED_IN_USER } from 'shared/Data/users';
-import { fetchActive } from 'shared/utils';
+import { fetchActive, fetchActivePPM } from 'shared/utils';
 import { loadEntitlementsFromState } from 'shared/entitlements';
 import { formatCents } from 'shared/formatters';
 import { selectShipment } from 'shared/Entities/modules/shipments';
@@ -249,7 +249,7 @@ export function ppmReducer(state = initialState, action) {
       // Initialize state when we get the logged in user
       const activeOrders = fetchActive(get(action.payload, 'service_member.orders'));
       const activeMove = fetchActive(get(activeOrders, 'moves'));
-      const activePpm = fetchActive(get(activeMove, 'personally_procured_moves'));
+      const activePpm = fetchActivePPM(get(activeMove, 'personally_procured_moves'));
       return Object.assign({}, state, {
         currentPpm: activePpm,
         pendingPpmSize: get(activePpm, 'size', null),

--- a/src/shared/utils.js
+++ b/src/shared/utils.js
@@ -40,6 +40,13 @@ export function fetchActive(foos) {
   return find(foos, i => includes(['DRAFT', 'SUBMITTED', 'APPROVED', 'PAYMENT_REQUESTED'], get(i, 'status'))) || null;
 }
 
+export function fetchActivePPM(foos) {
+  return (
+    find(foos, i => includes(['DRAFT', 'SUBMITTED', 'APPROVED', 'PAYMENT_REQUESTED', 'COMPLETED'], get(i, 'status'))) ||
+    null
+  );
+}
+
 export function fetchActiveShipment(shipments) {
   return (
     find(shipments, i =>


### PR DESCRIPTION
## Description
Fix bug when transitioning a PPM from Payment Reviewed to Completed which causes the PPM to not be fetch on the SM side. 

Added a new status to indicate a PPM has had Payment Reviewed.

## Setup

```sh
make sever_run
make client_run
make office_client_run
```

1. Log in as `ppm@requestingpay.ment`
2. Make a payment request.
3. Log in as an office user.
4. Approve the documents.
5. Upload a document that is type Shipment Summary to trigger transition.
6. Go back to SM user and confirm status has moved from Payment Requested to Payment Reviewed. 

## Code Review Verification Steps
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/167635153) for this change

## Screenshots

Will add screenshots LATER