### PR TITLE
Office user can edit weight ticket set weights (updated branch name)

### DIFF
--- a/cypress/integration/office/documentViewer.js
+++ b/cypress/integration/office/documentViewer.js
@@ -92,7 +92,7 @@ describe('The document viewer', function() {
 
     it('shows the newly uploaded document in the document list tab', () => {
       cy.patientVisit('/moves/c9df71f2-334f-4f0e-b2e7-050ddb22efa1/documents');
-      cy.contains('All Documents (1)');
+      cy.contains('All Documents (2)');
       cy.contains('super secret info document');
       cy
         .get('.panel-field')
@@ -206,35 +206,6 @@ describe('The document viewer', function() {
       cy.contains('Expense');
       cy.contains('4,999.92');
       cy.contains('GTCC');
-    });
-    it('can upload and view a weight ticket set document', () => {
-      cy.patientVisit('/moves/c9df71f2-334f-4f0e-b2e7-050ddb22efa1/documents/new');
-      cy.contains('Upload a new document');
-      cy.get('button.submit').should('be.disabled');
-      cy.get('select[name="move_document_type"]').select('Weight ticket set');
-      cy.get('input[name="title"]').type('weight ticket document');
-
-      cy.get('button.submit').should('be.disabled');
-
-      cy.upload_file('.filepond--root', 'top-secret.png');
-      cy
-        .get('button.submit', { timeout: fileUploadTimeout })
-        .should('not.be.disabled')
-        .click();
-
-      cy.patientVisit('/moves/c9df71f2-334f-4f0e-b2e7-050ddb22efa1/documents');
-      cy.contains('weight ticket document');
-      cy
-        .get('.panel-field')
-        .find('a')
-        .should('have.attr', 'href')
-        .and('match', /^\/moves\/[^/]+\/documents\/[^/]+/);
-
-      cy.contains('weight ticket').click();
-      cy.contains('Details').click();
-
-      cy.contains('Empty Weight Ticket');
-      cy.contains('Full Weight Ticket');
     });
     it('can upload documents to an HHG move', () => {
       cy.patientVisit('moves/533d176f-0bab-4c51-88cd-c899f6855b9d/documents/new');

--- a/cypress/integration/office/documentViewer.js
+++ b/cypress/integration/office/documentViewer.js
@@ -51,6 +51,45 @@ describe('The document viewer', function() {
         .should('not.be.disabled')
         .click();
     });
+    it('can upload a weight ticket set and edit it', () => {
+      cy.patientVisit('/moves/c9df71f2-334f-4f0e-b2e7-050ddb22efa1/documents/new');
+      cy.contains('Upload a new document');
+      cy.get('button.submit').should('be.disabled');
+      cy.get('input[name="title"]').type('Weight ticket document');
+      cy.get('select[name="move_document_type"]').select('Weight ticket set');
+      cy.get('input[name="notes"]').type('burn after reading');
+      cy.get('button.submit').should('be.disabled');
+
+      cy.upload_file('.filepond--root', 'top-secret.png');
+      cy
+        .get('button.submit', { timeout: fileUploadTimeout })
+        .should('not.be.disabled')
+        .click();
+
+      cy.contains('Weight ticket document').click();
+      cy.contains('Details').click();
+
+      cy.contains('Edit').click();
+
+      cy.get('select[name="moveDocument.vehicle_options"]').select('CAR');
+      cy.get('input[name="moveDocument.vehicle_nickname"]').type('Herbie');
+      cy.get('input[name="moveDocument.empty_weight"]').type('1000');
+      cy.get('input[name="moveDocument.full_weight"]').type('2000');
+
+      cy.get('select[name="moveDocument.status"]').select('OK');
+
+      cy
+        .get('button')
+        .contains('Save')
+        .should('not.be.disabled')
+        .click();
+
+      cy.contains('Car');
+      cy.contains('Herbie');
+      cy.contains('1,000');
+      cy.contains('2,000');
+    });
+
     it('shows the newly uploaded document in the document list tab', () => {
       cy.patientVisit('/moves/c9df71f2-334f-4f0e-b2e7-050ddb22efa1/documents');
       cy.contains('All Documents (1)');

--- a/pkg/handlers/internalapi/move_documents.go
+++ b/pkg/handlers/internalapi/move_documents.go
@@ -49,6 +49,8 @@ func payloadForMoveDocument(storer storage.FileStorer, moveDoc models.MoveDocume
 		if moveDoc.WeightTicketSetDocument.FullWeight != nil {
 			payload.FullWeight = handlers.FmtInt64(int64(*moveDoc.WeightTicketSetDocument.FullWeight))
 		}
+		payload.VehicleNickname = moveDoc.WeightTicketSetDocument.VehicleNickname
+		payload.VehicleOptions = moveDoc.WeightTicketSetDocument.VehicleOptions
 	}
 
 	return &payload, nil
@@ -309,6 +311,7 @@ func (h UpdateMoveDocumentHandler) Handle(params movedocop.UpdateMoveDocumentPar
 			fw := unit.Pound(*payload.FullWeight)
 			fullWeight = &fw
 		}
+
 		var weightTicketDate *time.Time
 		if payload.WeightTicketDate != nil {
 			weightTicketDate = (*time.Time)(payload.WeightTicketDate)
@@ -334,7 +337,8 @@ func (h UpdateMoveDocumentHandler) Handle(params movedocop.UpdateMoveDocumentPar
 			// update existing weight ticket set
 			moveDoc.WeightTicketSetDocument.EmptyWeight = emptyWeight
 			moveDoc.WeightTicketSetDocument.FullWeight = fullWeight
-
+			moveDoc.WeightTicketSetDocument.VehicleOptions = payload.VehicleOptions
+			moveDoc.WeightTicketSetDocument.VehicleNickname = payload.VehicleNickname
 		}
 		saveWeightTicketSetAction = models.MoveDocumentSaveActionSAVEWEIGHTTICKETSETMODEL
 

--- a/pkg/handlers/internalapi/move_documents_test.go
+++ b/pkg/handlers/internalapi/move_documents_test.go
@@ -307,6 +307,8 @@ func (suite *HandlerSuite) TestUpdateMoveDocumentHandler() {
 		MoveDocumentType: internalmessages.MoveDocumentTypeWEIGHTTICKETSET,
 		EmptyWeight:      &emptyWeight,
 		FullWeight:       &fullWeight,
+		VehicleNickname:  "My Car",
+		VehicleOptions:   "Car",
 	}
 
 	updateMoveDocParams := movedocop.UpdateMoveDocumentParams{

--- a/src/scenes/Office/DocumentViewer/DocumentDetailPanel.jsx
+++ b/src/scenes/Office/DocumentViewer/DocumentDetailPanel.jsx
@@ -46,8 +46,11 @@ const DocumentDetailDisplay = ({ isExpenseDocument, isWeightTicketDocument, move
           )}
         {isWeightTicketDocument && (
           <>
-            <PanelSwaggerField title="Empty Weight Ticket" fieldName="empty_weight" required {...moveDocFieldProps} />
-            <PanelSwaggerField title="Full Weight Ticket" fieldName="full_weight" required {...moveDocFieldProps} />
+            <PanelSwaggerField title="Vehicle Type" fieldName="vehicle_options" required {...moveDocFieldProps} />
+            <PanelSwaggerField title="Vehicle Nickname" fieldName="vehicle_nickname" required {...moveDocFieldProps} />
+
+            <PanelSwaggerField title="Empty Weight" fieldName="empty_weight" required {...moveDocFieldProps} />
+            <PanelSwaggerField title="Full Weight" fieldName="full_weight" required {...moveDocFieldProps} />
           </>
         )}
         <PanelSwaggerField title="Document Status" fieldName="status" required {...moveDocFieldProps} />
@@ -105,6 +108,13 @@ const DocumentDetailEdit = ({ formValues, moveDocSchema }) => {
           {isExpenseDocument && <ExpenseDocumentForm moveDocSchema={moveDocSchema} />}
           {isWeightTicketDocument && (
             <>
+              <div className="field-with-units">
+                <SwaggerField className="short-field" fieldName="vehicle_options" swagger={moveDocSchema} required />
+              </div>
+              <div className="field-with-units">
+                <SwaggerField className="short-field" fieldName="vehicle_nickname" swagger={moveDocSchema} required />
+              </div>
+
               <div className="field-with-units">
                 <SwaggerField className="short-field" fieldName="empty_weight" swagger={moveDocSchema} required /> lbs
               </div>

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -773,6 +773,10 @@ definitions:
         title: What type of vehicle are these weight tickets for?
         type: string
         enum: *VehicleOptions
+        x-display-value:
+          CAR: Car
+          CAR_TRAILER: Car + Trailer
+          BOX_TRUCK: Box truck
       vehicle_nickname:
         type: string
         title: Vehicle nickname (ex. "My car")
@@ -2561,9 +2565,9 @@ definitions:
       - warehouse_name
       - estimated_start_date
   StorageInTransits:
-      type: array
-      items:
-        $ref: '#/definitions/StorageInTransit'
+    type: array
+    items:
+      $ref: '#/definitions/StorageInTransit'
   MoveQueueItem:
     type: object
     properties:


### PR DESCRIPTION
## Description

**_This is the same pr as @Ronolibert's pr #2461. The only difference is the `#` in the branch name was causing ci to fail, so this PR only updates the branch name_**

Office user can now edit the full and empty weight of a weight ticket set that they uploaded

## Setup
`make server_run`
`make office_client_run`

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/167476108) for this change
## Description
