### PR TITLE
Add file size limit to 25MB

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "enzyme-adapter-react-16": "^1.1.1",
     "eslint-plugin-no-only-tests": "^2.3.0",
     "eslint-plugin-security": "^1.4.0",
+    "filepond-plugin-file-validate-size": "^2.2.0",
     "filepond-plugin-file-validate-type": "^1.0.3",
     "filepond-plugin-image-exif-orientation": "^1.0.1",
     "filepond-plugin-image-preview": "https://github.com/transcom/filepond-plugin-image-preview",

--- a/pkg/uploader/uploader.go
+++ b/pkg/uploader/uploader.go
@@ -17,6 +17,11 @@ import (
 // ErrZeroLengthFile represents an error caused by a file with no content
 var ErrZeroLengthFile = errors.New("File has length of 0")
 
+const fileSizeLimit = 25000000
+
+// ErrTooLarge represents an error caused by a file larger than 25MB
+var ErrTooLarge = errors.New("File is too large. We do not accept files larger than 25 MB")
+
 // Uploader encapsulates a few common processes: creating Uploads for a Document,
 // generating pre-signed URLs for file access, and deleting Uploads.
 type Uploader struct {
@@ -54,6 +59,9 @@ func (u *Uploader) CreateUploadForDocument(documentID *uuid.UUID, userID uuid.UU
 
 	if info.Size() == 0 {
 		return nil, responseVErrors, ErrZeroLengthFile
+	}
+	if info.Size() > fileSizeLimit {
+		return nil, responseVErrors, ErrTooLarge
 	}
 
 	contentType, detectContentTypeErr := storage.DetectContentType(file)

--- a/pkg/uploader/uploader_test.go
+++ b/pkg/uploader/uploader_test.go
@@ -119,6 +119,18 @@ func (suite *UploaderSuite) TestUploadFromLocalFileZeroLength() {
 	suite.Nil(upload, "returned an upload when erroring")
 }
 
+func (suite *UploaderSuite) TestTooLargeUploadFromLocalFile() {
+	document := testdatagen.MakeDefaultDocument(suite.DB())
+
+	up := uploader.NewUploader(suite.DB(), suite.logger, suite.storer)
+	file := suite.fixture("largepdf.pdf")
+
+	upload, verrs, err := up.CreateUploadForDocument(&document.ID, document.ServiceMember.UserID, file, uploader.AllowedTypesPDF)
+	suite.Equal(err, uploader.ErrTooLarge)
+	suite.False(verrs.HasAny(), "failed to validate upload")
+	suite.Nil(upload, "returned an upload when erroring")
+}
+
 func (suite *UploaderSuite) helperNewTempFile() (afero.File, error) {
 	outputFile, err := suite.fs.TempFile("/tmp/milmoves/", "TestCreateUploadNoDocument")
 	if err != nil {

--- a/pkg/uploader/uploader_test.go
+++ b/pkg/uploader/uploader_test.go
@@ -123,7 +123,7 @@ func (suite *UploaderSuite) TestTooLargeUploadFromLocalFile() {
 	document := testdatagen.MakeDefaultDocument(suite.DB())
 
 	up := uploader.NewUploader(suite.DB(), suite.logger, suite.storer)
-	file := suite.fixture("largepdf.pdf")
+	file := suite.fixture("largejpeg.jpg")
 
 	upload, verrs, err := up.CreateUploadForDocument(&document.ID, document.ServiceMember.UserID, file, uploader.AllowedTypesPDF)
 	suite.Equal(err, uploader.ErrTooLarge)

--- a/src/scenes/Moves/Ppm/ExpensesUpload.jsx
+++ b/src/scenes/Moves/Ppm/ExpensesUpload.jsx
@@ -235,7 +235,7 @@ class ExpensesUpload extends Component {
                   required
                 />
                 <div className="expenses-uploader">
-                  <p>We do not accept files larger than 25 MB.</p>
+                  <p>Please keep each file under 25MB.</p>
                   <Uploader
                     options={{ labelIdle: uploadReceipt }}
                     isPublic={isPublic}

--- a/src/scenes/Moves/Ppm/ExpensesUpload.jsx
+++ b/src/scenes/Moves/Ppm/ExpensesUpload.jsx
@@ -235,6 +235,7 @@ class ExpensesUpload extends Component {
                   required
                 />
                 <div className="expenses-uploader">
+                  <p>We do not accept files larger than 25 MB.</p>
                   <Uploader
                     options={{ labelIdle: uploadReceipt }}
                     isPublic={isPublic}

--- a/src/scenes/Moves/Ppm/ExpensesUpload.jsx
+++ b/src/scenes/Moves/Ppm/ExpensesUpload.jsx
@@ -26,6 +26,7 @@ import Alert from 'shared/Alert';
 import { getMoveDocumentsForMove } from 'shared/Entities/modules/moveDocuments';
 import { withContext } from 'shared/AppContext';
 import DocumentsUploaded from './PaymentReview/DocumentsUploaded';
+import { documentSizeLimitMsg } from 'shared/constants';
 
 const nextPagePath = '/ppm-payment-review';
 const nextBtnLabels = {
@@ -235,7 +236,7 @@ class ExpensesUpload extends Component {
                   required
                 />
                 <div className="expenses-uploader">
-                  <p>Please keep each file under 25MB.</p>
+                  <p>{documentSizeLimitMsg}</p>
                   <Uploader
                     options={{ labelIdle: uploadReceipt }}
                     isPublic={isPublic}

--- a/src/scenes/Moves/Ppm/WeightTicket.jsx
+++ b/src/scenes/Moves/Ppm/WeightTicket.jsx
@@ -271,6 +271,7 @@ class WeightTicket extends Component {
                       <p className="normalize-margins" style={{ marginTop: '1em' }}>
                         Proof of ownership (ex. registration, bill of sale)
                       </p>
+                      <p>We do not accept files larger than 25 MB.</p>
                       <span data-cy="trailer-upload">
                         <Uploader
                           options={{ labelIdle: uploadTrailerProofOfOwnership }}
@@ -312,6 +313,7 @@ class WeightTicket extends Component {
                   ) : (
                     <div style={{ marginBottom: '1em' }}>
                       The weight of this trailer should be <strong>excluded</strong> from the total weight of this trip.
+                      <p>We do not accept files larger than 25 MB.</p>
                     </div>
                   )}
                   <div className="usa-width-one-third input-group">

--- a/src/scenes/Moves/Ppm/WeightTicket.jsx
+++ b/src/scenes/Moves/Ppm/WeightTicket.jsx
@@ -271,7 +271,7 @@ class WeightTicket extends Component {
                       <p className="normalize-margins" style={{ marginTop: '1em' }}>
                         Proof of ownership (ex. registration, bill of sale)
                       </p>
-                      <p>We do not accept files larger than 25 MB.</p>
+                      <p>Please keep each file under 25MB.</p>
                       <span data-cy="trailer-upload">
                         <Uploader
                           options={{ labelIdle: uploadTrailerProofOfOwnership }}
@@ -313,7 +313,7 @@ class WeightTicket extends Component {
                   ) : (
                     <div style={{ marginBottom: '1em' }}>
                       The weight of this trailer should be <strong>excluded</strong> from the total weight of this trip.
-                      <p>We do not accept files larger than 25 MB.</p>
+                      <p>Please keep each file under 25MB.</p>
                     </div>
                   )}
                   <div className="usa-width-one-third input-group">

--- a/src/scenes/Moves/Ppm/WeightTicket.jsx
+++ b/src/scenes/Moves/Ppm/WeightTicket.jsx
@@ -12,6 +12,7 @@ import RadioButton from 'shared/RadioButton';
 import Checkbox from 'shared/Checkbox';
 import Uploader from 'shared/Uploader';
 import Alert from 'shared/Alert';
+import { documentSizeLimitMsg } from 'shared/constants';
 
 import carTrailerImg from 'shared/images/car-trailer_mobile.png';
 import carImg from 'shared/images/car_mobile.png';
@@ -271,7 +272,7 @@ class WeightTicket extends Component {
                       <p className="normalize-margins" style={{ marginTop: '1em' }}>
                         Proof of ownership (ex. registration, bill of sale)
                       </p>
-                      <p>Please keep each file under 25MB.</p>
+                      <p>{documentSizeLimitMsg}</p>
                       <span data-cy="trailer-upload">
                         <Uploader
                           options={{ labelIdle: uploadTrailerProofOfOwnership }}
@@ -313,7 +314,7 @@ class WeightTicket extends Component {
                   ) : (
                     <div style={{ marginBottom: '1em' }}>
                       The weight of this trailer should be <strong>excluded</strong> from the total weight of this trip.
-                      <p>Please keep each file under 25MB.</p>
+                      <p>{documentSizeLimitMsg}</p>
                     </div>
                   )}
                   <div className="usa-width-one-third input-group">

--- a/src/scenes/Office/DocumentViewer/DocumentUploader.jsx
+++ b/src/scenes/Office/DocumentViewer/DocumentUploader.jsx
@@ -143,6 +143,7 @@ export class DocumentUploader extends Component {
             <div>
               <h4>Attach PDF or image</h4>
               <p>Upload a PDF or take a picture of each page and upload the images.</p>
+              <p>We do not accept files larger than 25 MB.</p>
             </div>
             <Uploader onRef={ref => (this.uploader = ref)} onChange={this.onChange} onAddFile={this.onAddFile} />
             <div className="hint">(Each page must be clear and legible)</div>

--- a/src/scenes/Office/DocumentViewer/DocumentUploader.jsx
+++ b/src/scenes/Office/DocumentViewer/DocumentUploader.jsx
@@ -143,7 +143,7 @@ export class DocumentUploader extends Component {
             <div>
               <h4>Attach PDF or image</h4>
               <p>Upload a PDF or take a picture of each page and upload the images.</p>
-              <p>We do not accept files larger than 25 MB.</p>
+              <p>Please keep each file under 25MB.</p>
             </div>
             <Uploader onRef={ref => (this.uploader = ref)} onChange={this.onChange} onAddFile={this.onAddFile} />
             <div className="hint">(Each page must be clear and legible)</div>

--- a/src/scenes/Office/DocumentViewer/DocumentUploader.jsx
+++ b/src/scenes/Office/DocumentViewer/DocumentUploader.jsx
@@ -14,6 +14,7 @@ import { SwaggerField } from 'shared/JsonSchemaForm/JsonSchemaField';
 import Uploader from 'shared/Uploader';
 import ExpenseDocumentForm from './ExpenseDocumentForm';
 import { convertDollarsToCents } from 'shared/utils';
+import { documentSizeLimitMsg } from 'shared/constants';
 
 import './DocumentUploader.css';
 
@@ -143,7 +144,7 @@ export class DocumentUploader extends Component {
             <div>
               <h4>Attach PDF or image</h4>
               <p>Upload a PDF or take a picture of each page and upload the images.</p>
-              <p>Please keep each file under 25MB.</p>
+              <p>{documentSizeLimitMsg}</p>
             </div>
             <Uploader onRef={ref => (this.uploader = ref)} onChange={this.onChange} onAddFile={this.onAddFile} />
             <div className="hint">(Each page must be clear and legible)</div>

--- a/src/scenes/Orders/UploadOrders.jsx
+++ b/src/scenes/Orders/UploadOrders.jsx
@@ -9,6 +9,7 @@ import { deleteUpload, addUploads } from './ducks';
 import Uploader from 'shared/Uploader';
 import UploadsTable from 'shared/Uploader/UploadsTable';
 import WizardPage from 'shared/WizardPage';
+import { documentSizeLimitMsg } from 'shared/constants';
 
 import './UploadOrders.css';
 
@@ -65,7 +66,7 @@ export class UploadOrders extends Component {
           <h1 className="sm-heading">Upload Your Orders</h1>
           <p>In order to schedule your move, we need to have a complete copy of your orders.</p>
           <p>You can upload a PDF, or you can take a picture of each page and upload the images.</p>
-          <p>Please keep each file under 25MB.</p>
+          <p>{documentSizeLimitMsg}</p>
         </div>
         {Boolean(uploads.length) && (
           <Fragment>

--- a/src/scenes/Orders/UploadOrders.jsx
+++ b/src/scenes/Orders/UploadOrders.jsx
@@ -65,6 +65,7 @@ export class UploadOrders extends Component {
           <h1 className="sm-heading">Upload Your Orders</h1>
           <p>In order to schedule your move, we need to have a complete copy of your orders.</p>
           <p>You can upload a PDF, or you can take a picture of each page and upload the images.</p>
+          <p>We do not accept files larger than 25 MB.</p>
         </div>
         {Boolean(uploads.length) && (
           <Fragment>

--- a/src/scenes/Orders/UploadOrders.jsx
+++ b/src/scenes/Orders/UploadOrders.jsx
@@ -65,7 +65,7 @@ export class UploadOrders extends Component {
           <h1 className="sm-heading">Upload Your Orders</h1>
           <p>In order to schedule your move, we need to have a complete copy of your orders.</p>
           <p>You can upload a PDF, or you can take a picture of each page and upload the images.</p>
-          <p>We do not accept files larger than 25 MB.</p>
+          <p>Please keep each file under 25MB.</p>
         </div>
         {Boolean(uploads.length) && (
           <Fragment>

--- a/src/scenes/Review/EditOrders.jsx
+++ b/src/scenes/Review/EditOrders.jsx
@@ -64,7 +64,7 @@ let EditOrdersForm = props => {
       {Boolean(visibleUploads.length) && <UploadsTable uploads={visibleUploads} onDelete={onDelete} />}
       {Boolean(get(initialValues, 'uploaded_orders')) && (
         <div>
-          <p>We do not accept files larger than 25 MB.</p>
+          <p>Please keep each file under 25MB.</p>
           <Uploader
             document={initialValues.uploaded_orders}
             onChange={onUpload}

--- a/src/scenes/Review/EditOrders.jsx
+++ b/src/scenes/Review/EditOrders.jsx
@@ -63,11 +63,14 @@ let EditOrdersForm = props => {
       <p>Uploads:</p>
       {Boolean(visibleUploads.length) && <UploadsTable uploads={visibleUploads} onDelete={onDelete} />}
       {Boolean(get(initialValues, 'uploaded_orders')) && (
-        <Uploader
-          document={initialValues.uploaded_orders}
-          onChange={onUpload}
-          options={{ labelIdle: uploaderLabelIdle }}
-        />
+        <div>
+          <p>We do not accept files larger than 25 MB.</p>
+          <Uploader
+            document={initialValues.uploaded_orders}
+            onChange={onUpload}
+            options={{ labelIdle: uploaderLabelIdle }}
+          />
+        </div>
       )}
       <SaveCancelButtons valid={valid} submitting={submitting} />
     </form>

--- a/src/scenes/Review/EditOrders.jsx
+++ b/src/scenes/Review/EditOrders.jsx
@@ -17,6 +17,7 @@ import { updateOrders, deleteUploads, addUploads } from 'scenes/Orders/ducks';
 import { moveIsApproved, isPpm } from 'scenes/Moves/ducks';
 import { editBegin, editSuccessful, entitlementChangeBegin, entitlementChanged, checkEntitlement } from './ducks';
 import scrollToTop from 'shared/scrollToTop';
+import { documentSizeLimitMsg } from 'shared/constants';
 
 import './Review.css';
 import profileImage from './images/profile.png';
@@ -64,7 +65,7 @@ let EditOrdersForm = props => {
       {Boolean(visibleUploads.length) && <UploadsTable uploads={visibleUploads} onDelete={onDelete} />}
       {Boolean(get(initialValues, 'uploaded_orders')) && (
         <div>
-          <p>Please keep each file under 25MB.</p>
+          <p>{documentSizeLimitMsg}</p>
           <Uploader
             document={initialValues.uploaded_orders}
             onChange={onUpload}

--- a/src/shared/DocumentViewer/DocumentUploader.jsx
+++ b/src/shared/DocumentViewer/DocumentUploader.jsx
@@ -104,7 +104,7 @@ export class DocumentUploader extends Component {
             <div>
               <h4>Attach PDF or image</h4>
               <p>Upload a PDF or take a picture of each page and upload the images.</p>
-              <p>We do not accept files larger than 25 MB.</p>
+              <p>Please keep each file under 25MB.</p>
             </div>
             <Uploader
               isPublic={isPublic}

--- a/src/shared/DocumentViewer/DocumentUploader.jsx
+++ b/src/shared/DocumentViewer/DocumentUploader.jsx
@@ -104,6 +104,7 @@ export class DocumentUploader extends Component {
             <div>
               <h4>Attach PDF or image</h4>
               <p>Upload a PDF or take a picture of each page and upload the images.</p>
+              <p>We do not accept files larger than 25 MB.</p>
             </div>
             <Uploader
               isPublic={isPublic}

--- a/src/shared/DocumentViewer/DocumentUploader.jsx
+++ b/src/shared/DocumentViewer/DocumentUploader.jsx
@@ -8,6 +8,7 @@ import PropTypes from 'prop-types';
 import Alert from 'shared/Alert';
 import { SwaggerField } from 'shared/JsonSchemaForm/JsonSchemaField';
 import Uploader from 'shared/Uploader';
+import { documentSizeLimitMsg } from 'shared/constants';
 import ExpenseDocumentForm from 'scenes/Office/DocumentViewer/ExpenseDocumentForm';
 
 import './DocumentUploader.css';
@@ -104,7 +105,7 @@ export class DocumentUploader extends Component {
             <div>
               <h4>Attach PDF or image</h4>
               <p>Upload a PDF or take a picture of each page and upload the images.</p>
-              <p>Please keep each file under 25MB.</p>
+              <p>{documentSizeLimitMsg}</p>
             </div>
             <Uploader
               isPublic={isPublic}

--- a/src/shared/Uploader/index.jsx
+++ b/src/shared/Uploader/index.jsx
@@ -14,11 +14,13 @@ import 'filepond/dist/filepond.min.css';
 import './index.css';
 
 import FilepondPluginFileValidateType from 'filepond-plugin-file-validate-type';
+import FilePondPluginFileValidateSize from 'filepond-plugin-file-validate-size';
 import FilepondPluginImageExifOrientation from 'filepond-plugin-image-exif-orientation';
 import FilePondImagePreview from 'filepond-plugin-image-preview';
 import 'filepond-plugin-image-preview/dist/filepond-plugin-image-preview.css';
 
 registerPlugin(FilepondPluginFileValidateType);
+registerPlugin(FilePondPluginFileValidateSize);
 registerPlugin(FilepondPluginImageExifOrientation);
 registerPlugin(FilePondImagePreview);
 
@@ -150,6 +152,7 @@ export class Uploader extends Component {
       labelIdle: 'Drag & drop or <span class="filepond--label-action">click to upload</span>',
       labelTapToUndo: 'tap to delete',
       acceptedFileTypes: ['image/jpeg', 'image/png', 'application/pdf'],
+      maxFileSize: '25MB',
     };
     this.pond._pond.setOptions({ ...defaultOptions, ...options });
   }

--- a/src/shared/constants.js
+++ b/src/shared/constants.js
@@ -37,3 +37,6 @@ export const MOVE_DOC_STATUS = {
 export const isError = 'REQUEST_ERROR';
 export const isLoading = 'REQUEST_LOADING';
 export const isSuccess = 'REQUEST_SUCCESS';
+
+// documentSizeLimitMsg is used in several files around document upload
+export const documentSizeLimitMsg = 'Please keep each file under 25MB.';

--- a/yarn.lock
+++ b/yarn.lock
@@ -5158,6 +5158,11 @@ file-loader@3.0.1:
     loader-utils "^1.0.2"
     schema-utils "^1.0.0"
 
+filepond-plugin-file-validate-size@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/filepond-plugin-file-validate-size/-/filepond-plugin-file-validate-size-2.2.0.tgz#89e393e4c757c38467b8b2f7049760682d036716"
+  integrity sha512-Czlj4JLrxWRXBm50QO4rzvEVZVGfB4Gst0denBAGTKTZtuj566KB7vwDQy/daZoYtXOQdoVvfJgrJGifZ5n9KA==
+
 filepond-plugin-file-validate-type@^1.0.3:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/filepond-plugin-file-validate-type/-/filepond-plugin-file-validate-type-1.2.4.tgz#ce7f5f469dbc7ce0da12fdef7b0f24e4c263c410"


### PR DESCRIPTION
## Description

The copy has been changed to: `Please keep each file under 25MB.`
Too limit in-memory issues, we're adding a limit to the size of file that can be uploaded to 25MB, which is already fairly big. Notably, I thought about adding this directly to the uploader component, but on the SM weight ticket pages, it would appear three times if I did that and the layout looked wonky.

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make db_dev_e2e_populate
make server_run
make office_client_run
```
Try uploading a document greater than 25MB from the document uploader screen.

```sh
make server_run
make client_run
```
As a brand new SM, create your profile and attempt to upload orders greater than 25MB.
Try editing orders upload after that.

Then as `ppm@requestingpay.ment`, go through the flow. At each upload point, try to upload a file greater than 25MB.

## Code Review Verification Steps

* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* https://www.pivotaltracker.com/story/show/167658360

## Screenshots
The copy on the screens should now all be `Please keep each file under 25MB.` instead of `We do not accept files larger than 25 MB.`
Expenses page on PPM Closeout:
<img width="631" alt="Screen Shot 2019-08-05 at 1 59 57 PM" src="https://user-images.githubusercontent.com/5531789/62496767-d6e3c080-b78e-11e9-9bc7-697e7052d071.png">
Weight ticket page on PPM Closeout:
<img width="585" alt="Screen Shot 2019-08-05 at 1 56 02 PM" src="https://user-images.githubusercontent.com/5531789/62496768-d6e3c080-b78e-11e9-9146-1d8818efc301.png">
<img width="1012" alt="Screen Shot 2019-08-05 at 1 55 51 PM" src="https://user-images.githubusercontent.com/5531789/62496769-d6e3c080-b78e-11e9-99ed-c1412add2ff0.png">
Orders upload with a small enough file:
<img width="1054" alt="Screen Shot 2019-08-05 at 1 42 09 PM" src="https://user-images.githubusercontent.com/5531789/62496771-d6e3c080-b78e-11e9-8472-a56844cf05c5.png">
Orders upload with too big of a file:
<img width="948" alt="Screen Shot 2019-08-05 at 1 41 56 PM" src="https://user-images.githubusercontent.com/5531789/62496772-d77c5700-b78e-11e9-9dbd-537f932519ab.png">
Office document uploader:
<img width="580" alt="Screen Shot 2019-08-05 at 1 33 53 PM" src="https://user-images.githubusercontent.com/5531789/62496774-d77c5700-b78e-11e9-8132-ad8fcf704046.png">
