### PR TITLE
Add full to weight ticket date in ppm closeout

### DIFF
--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -1010,7 +1010,7 @@ definitions:
         type: integer
         minimum: 0
       weight_ticket_date:
-        title: Weight ticket date
+        title: Full Weight Ticket Date
         type: string
         example: '2018-04-26'
         format: date


### PR DESCRIPTION
## Description

Weight ticket date is unclear when there are two weight tickets that may have occurred on different dates. This disambiguates it. Note that I only changed the title so the swagger field would change appropriately, rather than changing the payload property in the schema.

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make db_dev_e2e_populate
make server_run
make client_run
```
Login as `ppm@requestingpay.ment` and go through the payment request flow. On the weight ticket page, you should see `Full Weight Ticket Date` instead of `Weight ticket date`.

## Code Review Verification Steps

* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* https://www.pivotaltracker.com/story/show/167627219

## Screenshots
OLD:
<img width="590" alt="Screen Shot 2019-08-05 at 4 06 25 PM" src="https://user-images.githubusercontent.com/5531789/62500402-07315c00-b79b-11e9-93f2-919a9aa2c206.png">

NEW:
<img width="591" alt="Screen Shot 2019-08-05 at 4 04 20 PM" src="https://user-images.githubusercontent.com/5531789/62500355-d81aea80-b79a-11e9-8d54-fb0db55ff32a.png">

