### PR TITLE
Update updateServiceMember dispatch call so service member current du…

### DIFF
--- a/src/scenes/Office/OrdersPanel.jsx
+++ b/src/scenes/Office/OrdersPanel.jsx
@@ -155,7 +155,7 @@ function mapStateToProps(state, ownProps) {
 function mapDispatchToProps(dispatch) {
   const update = (ordersId, orders, serviceMemberId, serviceMember) => {
     serviceMember.current_station_id = serviceMember.current_station.id;
-    dispatch(updateServiceMember(serviceMemberId, { serviceMember }));
+    dispatch(updateServiceMember(serviceMemberId, serviceMember));
 
     if (!orders.has_dependents) {
       orders.spouse_has_pro_gear = false;

--- a/src/scenes/Office/OrdersViewerPanel.js
+++ b/src/scenes/Office/OrdersViewerPanel.js
@@ -149,7 +149,7 @@ function mapStateToProps(state, ownProps) {
 function mapDispatchToProps(dispatch) {
   const update = (ordersId, orders, serviceMemberId, serviceMember) => {
     serviceMember.current_station_id = serviceMember.current_station.id;
-    dispatch(updateServiceMember(serviceMemberId, { serviceMember }));
+    dispatch(updateServiceMember(serviceMemberId, serviceMember));
 
     if (!orders.has_dependents) {
       orders.spouse_has_pro_gear = false;


### PR DESCRIPTION
…ty station saves on edit

## Description

In the office app orders panel, current duty station does not update when changed. `ServiceMember` was being passed in incorrectly to the `updateServiceMember` dispatch call. This PR fixes that, so when current duty station is changed, the update is saved.

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make server_run
make client_run
```

See steps in the description of the [Pivotal story](https://www.pivotaltracker.com/story/show/167584611) for this change

