### PR TITLE
Add migration to fix admin user data and require first and last name

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -818,9 +818,9 @@ workflows:
             - pre_deps_yarn
             - acceptance_tests_local
           # if testing on experimental, you can disable these tests by using the commented block below.
-          filters:
-            branches:
-              ignore: gm-fix-admin-table
+          # filters:
+          #   branches:
+          #     ignore: placeholder_branch_name
 
       - client_test:
           requires:
@@ -828,7 +828,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           # filters:
           #   branches:
-          #     ignore: gm-fix-admin-table
+          #     ignore: placeholder_branch_name
 
       - server_test:
           requires:
@@ -836,7 +836,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           # filters:
           #   branches:
-          #     ignore: gm-fix-admin-table
+          #     ignore: placeholder_branch_name
 
       - server_test_coverage:
           requires:
@@ -844,7 +844,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           # filters:
           #   branches:
-          #     ignore: gm-fix-admin-table
+          #     ignore: placeholder_branch_name
 
       - build_app:
           requires:
@@ -877,28 +877,28 @@ workflows:
             - build_migrations
           filters:
             branches:
-              only: gm-fix-admin-table
+              only: placeholder_branch_name
 
       - deploy_experimental_tasks:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: gm-fix-admin-table
+              only: placeholder_branch_name
 
       - deploy_experimental_app:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: gm-fix-admin-table
+              only: placeholder_branch_name
 
       - deploy_experimental_app_client_tls:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: gm-fix-admin-table
+              only: placeholder_branch_name
 
       - check_circle_against_staging_sha:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -818,9 +818,9 @@ workflows:
             - pre_deps_yarn
             - acceptance_tests_local
           # if testing on experimental, you can disable these tests by using the commented block below.
-          # filters:
-          #   branches:
-          #     ignore: placeholder_branch_name
+          filters:
+            branches:
+              ignore: gm-fix-admin-table
 
       - client_test:
           requires:
@@ -828,7 +828,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           # filters:
           #   branches:
-          #     ignore: placeholder_branch_name
+          #     ignore: gm-fix-admin-table
 
       - server_test:
           requires:
@@ -836,7 +836,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           # filters:
           #   branches:
-          #     ignore: placeholder_branch_name
+          #     ignore: gm-fix-admin-table
 
       - server_test_coverage:
           requires:
@@ -844,7 +844,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           # filters:
           #   branches:
-          #     ignore: placeholder_branch_name
+          #     ignore: gm-fix-admin-table
 
       - build_app:
           requires:
@@ -877,28 +877,28 @@ workflows:
             - build_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: gm-fix-admin-table
 
       - deploy_experimental_tasks:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: gm-fix-admin-table
 
       - deploy_experimental_app:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: gm-fix-admin-table
 
       - deploy_experimental_app_client_tls:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: gm-fix-admin-table
 
       - check_circle_against_staging_sha:
           requires:

--- a/migrations/20190807134704_admin_user_fname_lname_required.up.fizz
+++ b/migrations/20190807134704_admin_user_fname_lname_required.up.fizz
@@ -6,4 +6,5 @@ ALTER TABLE admin_users
 	ALTER COLUMN last_name SET NOT NULL
 ")
 
+add_foreign_key("admin_users", "user_id", {"users": ["id"]}, {})
 add_index("admin_users", "email", {"unique": true, "name": "admin_users_email_uniq_idx"})

--- a/migrations/20190807134704_admin_user_fname_lname_required.up.fizz
+++ b/migrations/20190807134704_admin_user_fname_lname_required.up.fizz
@@ -7,4 +7,5 @@ ALTER TABLE admin_users
 ")
 
 add_foreign_key("admin_users", "user_id", {"users": ["id"]}, {})
+add_foreign_key("admin_users", "organization_id", {"organizations": ["id"]}, {})
 add_index("admin_users", "email", {"unique": true, "name": "admin_users_email_uniq_idx"})

--- a/migrations/20190807134704_admin_user_fname_lname_required.up.fizz
+++ b/migrations/20190807134704_admin_user_fname_lname_required.up.fizz
@@ -1,0 +1,9 @@
+sql("DELETE FROM admin_users WHERE first_name is null OR last_name is null")
+
+sql("
+ALTER TABLE admin_users
+	ALTER COLUMN first_name SET NOT NULL,
+	ALTER COLUMN last_name SET NOT NULL
+")
+
+add_index("admin_users", "email", {"unique": true, "name": "admin_users_email_uniq_idx"})

--- a/migrations_manifest.txt
+++ b/migrations_manifest.txt
@@ -338,3 +338,4 @@
 20190730194820_pp3_2019_tspp_data.up.fizz
 20190731163048_remove_is_superuser.up.fizz
 20190805161006_disable_truss_user.up.fizz
+20190807134704_admin_user_fname_lname_required.up.fizz


### PR DESCRIPTION
## Description

We have a [data issue](https://us-west-2.console.aws.amazon.com/cloudwatch/home?region=us-west-2#logEventViewer:group=ecs-tasks-app-staging;stream=app/app-staging/4fbbb314-311c-4faf-a30a-eb11735bf748;refid=34903426859243328996492337799874179240241030956971327491;reftime=1565123790641) where there are admin user records without a first name and last name. This by itself is not a problem, but the `admin_user` model struct is written in a way that doesn't expect those fields to be nullable. This PR introduces a migration to remove the admin user records that don't have a first name or last name (removing them since they have duplicate email addresses), adds a `NOT NULL` constraint to the table, and also adds a unique constraint on the `email` column.

## Reviewer Notes

I spoke with @reggieriser about potential risks for this migration being:
- Locking the table by adding constraints is generally not a good idea. Since nobody is really accessing this table yet, we thought this wouldn't be a problem. Also, the table is quite small.
- The risk of not removing all of the duplicates. We're fairly confident that we will, but since we can't see the data, we're not positive.

Is there anything else we're not considering?

## Setup

`make db_dev_migration`

