### PR TITLE
Add office user show component

### DIFF
--- a/src/scenes/SystemAdmin/AdminPagination.jsx
+++ b/src/scenes/SystemAdmin/AdminPagination.jsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import { Pagination } from 'react-admin';
+
+const AdminPagination = props => <Pagination rowsPerPageOptions={[]} {...props} />;
+
+export default AdminPagination;

--- a/src/scenes/SystemAdmin/Home.jsx
+++ b/src/scenes/SystemAdmin/Home.jsx
@@ -1,9 +1,11 @@
 import restProvider from 'ra-data-simple-rest';
-import { fetchUtils, Admin, Resource, Layout, List, Pagination, Datagrid, TextField } from 'react-admin';
-import { Route } from 'react-router-dom';
+import { fetchUtils, Admin, Resource, Layout } from 'react-admin';
 import { createBrowserHistory } from 'history';
 import React from 'react';
 import Menu from './Menu';
+import UserList from './UserList';
+import OfficeList from './OfficeList';
+import UserShow from './UserShow';
 
 const httpClient = (url, options = {}) => {
   if (!options.headers) {
@@ -14,43 +16,15 @@ const httpClient = (url, options = {}) => {
   options.credentials = 'same-origin';
   return fetchUtils.fetchJson(url, options);
 };
+
 const dataProvider = restProvider('/admin/v1', httpClient);
-
 const AdminLayout = props => <Layout {...props} menu={Menu} />;
-const AdminPagination = props => <Pagination rowsPerPageOptions={[]} {...props} />;
-const UserList = props => (
-  <List {...props} pagination={<AdminPagination />} perPage={500}>
-    <Datagrid>
-      <TextField source="id" />
-      <TextField source="email" />
-      <TextField source="first_name" />
-      <TextField source="last_name" />
-    </Datagrid>
-  </List>
-);
-const OfficeList = props => (
-  <List {...props} pagination={<AdminPagination />} perPage={500}>
-    <Datagrid>
-      <TextField source="id" />
-      <TextField source="name" />
-      <TextField source="latitude" />
-      <TextField source="longitude" />
-      <TextField source="gbloc" />
-    </Datagrid>
-  </List>
-);
-
-const routes = [
-  <Route exact path="/system/office_users" component={UserList} />,
-  <Route exact path="/system/offices" component={OfficeList} />,
-];
-
 const history = createBrowserHistory({ basename: '/system' });
 
 const Home = () => (
   <div className="admin-system-wrapper">
-    <Admin customRoutes={routes} dataProvider={dataProvider} history={history} appLayout={AdminLayout}>
-      <Resource name="office_users" list={UserList} />
+    <Admin dataProvider={dataProvider} history={history} appLayout={AdminLayout}>
+      <Resource name="office_users" list={UserList} show={UserShow} />
       <Resource name="offices" list={OfficeList} />
     </Admin>
   </div>

--- a/src/scenes/SystemAdmin/Home.jsx
+++ b/src/scenes/SystemAdmin/Home.jsx
@@ -11,7 +11,6 @@ const httpClient = (url, options = {}) => {
   if (!options.headers) {
     options.headers = new Headers({ Accept: 'application/json' });
   }
-
   // send cookies in the request
   options.credentials = 'same-origin';
   return fetchUtils.fetchJson(url, options);

--- a/src/scenes/SystemAdmin/OfficeList.jsx
+++ b/src/scenes/SystemAdmin/OfficeList.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { List, Datagrid, TextField } from 'react-admin';
+import AdminPagination from './AdminPagination'
+
+const OfficeList = props => (
+  <List {...props} pagination={<AdminPagination />} perPage={500}>
+    <Datagrid>
+      <TextField source="id" />
+      <TextField source="name" />
+      <TextField source="latitude" />
+      <TextField source="longitude" />
+      <TextField source="gbloc" />
+    </Datagrid>
+  </List>
+);
+
+export default OfficeList;

--- a/src/scenes/SystemAdmin/OfficeList.jsx
+++ b/src/scenes/SystemAdmin/OfficeList.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { List, Datagrid, TextField } from 'react-admin';
-import AdminPagination from './AdminPagination'
+import AdminPagination from './AdminPagination';
 
 const OfficeList = props => (
   <List {...props} pagination={<AdminPagination />} perPage={500}>

--- a/src/scenes/SystemAdmin/UserList.jsx
+++ b/src/scenes/SystemAdmin/UserList.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { List, EmailField, Datagrid, TextField } from 'react-admin';
+import AdminPagination from './AdminPagination'
+
+const UserList = props => (
+  <List {...props} pagination={<AdminPagination />} perPage={500}>
+    <Datagrid rowClick="show">
+      <EmailField source="email" />
+      <TextField source="first_name" />
+      <TextField source="id" />
+      <TextField source="last_name" />
+    </Datagrid>
+  </List>
+);
+
+export default UserList;

--- a/src/scenes/SystemAdmin/UserList.jsx
+++ b/src/scenes/SystemAdmin/UserList.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { List, EmailField, Datagrid, TextField } from 'react-admin';
-import AdminPagination from './AdminPagination'
+import AdminPagination from './AdminPagination';
 
 const UserList = props => (
   <List {...props} pagination={<AdminPagination />} perPage={500}>

--- a/src/scenes/SystemAdmin/UserShow.jsx
+++ b/src/scenes/SystemAdmin/UserShow.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { Show, SimpleShowLayout, TextField } from 'react-admin';
+
+const UserShowTitle = ({ record }) => {
+  return <span>{`${record.first_name} ${record.last_name}`}</span>;
+};
+
+const UserShow = props => {
+  return (
+    <Show {...props} title={<UserShowTitle />}>
+      <SimpleShowLayout>
+        <TextField source="id" />
+        <TextField source="email" />
+        <TextField source="first_name" />
+        <TextField source="last_name" />
+      </SimpleShowLayout>
+    </Show>
+  );
+};
+
+export default UserShow;


### PR DESCRIPTION
## Description

We'd like to be able to click on an admin user to drill down further. This PR takes care of that and also does a bit of cleanup/organization of our system admin react components.

## Setup

1. `make server_run`
2. `make client_run`
3. Log into the admin app
4. Click on an office user record. You should be taken to a screen that shows you information about the office user you clicked on.

## Code Review Verification Steps

* [x] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/167490088) for this change