### PR TITLE
Fix dependency updater issues

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -734,7 +734,7 @@ jobs:
             - go-mod-sources-v2-{{ checksum "go.sum" }}
       - run:
           name: Add ~/go/bin to path for golint
-          command: echo 'export PATH=${PATH}:~/go/bin' >> $BASH_ENV
+          command: echo 'export PATH=${PATH}:~/go/bin:~/transcom/mymove/bin' >> $BASH_ENV
       - run: make go_deps_update
       - run:
           name: Display changes


### PR DESCRIPTION
## Description

The dependency updater job was failing with an error about a missing `mockery` executable.  That turned out to just be a missing path in our CircleCI container.

However, once I made it past that error, I ran into another issue with `gopkg.in/urfave/cli.v1` failing to update:
```
2019/08/07 15:53:37 failed to update gopkg.in/urfave/cli.v1: ran go [get -u=patch gopkg.in/urfave/cli.v1], got go: finding gopkg.in/urfave/cli.v1 v1.21.0
go: gopkg.in/urfave/cli.v1@v1.21.0: go.mod has non-....v1 module path "github.com/urfave/cli" at revision v1.21.0
go get: error loading module requirements
exit status 1
```

It looks like that package recently changed to have a `go.mod` file that notes itself as `github.com/urfave/cli`.  We don't use this package directly, but instead get it indirectly via `github.com/codegangsta/gin`, which uses the (now incompatible) `gopkg.in/urfave/cli.v1` naming.  There is a [pull request](https://github.com/codegangsta/gin/pull/155) for `gin` to address this, but it hasn't landed yet.  In the meantime, we need a way for our dependency updater to otherwise complete.  So, I've added an "excludes" map to our `update_deps` command so that we can conditionally exclude certain libraries in situations like this (and note a reason as well that will appear in the job's output).

## Setup

To test this, you'll probably want to run the CircleCI job locally.  First, I suggest commenting out the section of the job that pushes the dependency updater branch so we don't litter our github with branches (see [lines 744-746](https://github.com/transcom/mymove/blob/5fdd4e6e95b31314a27ab4728e7bbbfbaa9cc497/.circleci/config.yml#L744-L746) of `config.yml`).

Then, run the following:

- `circleci config process .circleci/config.yml > .circleci/config.processed.yml` (to put our CircleCI config into a format that can be run locally)
- `circleci local execute --config .circleci/config.processed.yml --job update_dependencies_go` (to execute the specific job)

It'll take it a while to download everything, but in the end it should succeed.

When this is all done, you can delete the `config.processed.yml` file.

## Code Review Verification Steps

* [ ] Request review from a member of a different team.

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/167574082) for this change
