### PR TITLE
Manually add styles to react-admin

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,15 +4,11 @@ import 'core-js/stable';
 import 'regenerator-runtime/runtime';
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { isSystemAdminSite } from 'shared/constants.js';
 import 'uswds';
+import '../node_modules/uswds/dist/css/uswds.css';
 
 import App from './App';
 import registerServiceWorker from './registerServiceWorker';
 import './index.css';
-
-if (!isSystemAdminSite) {
-  require('../node_modules/uswds/dist/css/uswds.css');
-}
 ReactDOM.render(<App />, document.getElementById('root'));
 registerServiceWorker();

--- a/src/scenes/SystemAdmin/Home.jsx
+++ b/src/scenes/SystemAdmin/Home.jsx
@@ -4,6 +4,7 @@ import { Route } from 'react-router-dom';
 import { createBrowserHistory } from 'history';
 import React from 'react';
 import Menu from './Menu';
+import styles from './Home.module.scss';
 
 const httpClient = (url, options = {}) => {
   if (!options.headers) {
@@ -48,7 +49,7 @@ const routes = [
 const history = createBrowserHistory({ basename: '/system' });
 
 const Home = () => (
-  <div className="admin-system-wrapper">
+  <div className={styles['admin-system-wrapper']}>
     <Admin customRoutes={routes} dataProvider={dataProvider} history={history} appLayout={AdminLayout}>
       <Resource name="office_users" list={UserList} />
       <Resource name="offices" list={OfficeList} />

--- a/src/scenes/SystemAdmin/Home.module.scss
+++ b/src/scenes/SystemAdmin/Home.module.scss
@@ -1,0 +1,23 @@
+.admin-system-wrapper {
+  a, p, span {
+    font-size: 1.5rem !important;
+  }
+
+  table {
+    margin: 0;
+  }
+
+  th, td {
+    border: 1px solid #efefef;
+  }
+
+  a {
+    &:visited {
+      color: #0071bc;
+    }
+  }
+
+  .headroom-wrapper {
+    font-size: 2rem !important;
+  }
+}

--- a/src/scenes/SystemAdmin/SignIn.module.scss
+++ b/src/scenes/SystemAdmin/SignIn.module.scss
@@ -20,4 +20,8 @@
   padding: 1rem 2rem;
   text-align: center;
   text-decoration: none;
+
+  &:visited {
+    color: #ffffff;
+  }
 }


### PR DESCRIPTION
## Description

[USWDS](https://v1.designsystem.digital.gov/) interferes with react-admin's styles. I thought I had successfully conditionally loaded it before, but that seems to only work in development, not in staging. This PR manually targets the affected elements with css to fix the look and feel.

## Setup

1. `make server_run`
2. `make client_run`
3. Log into the admin app

## Code Review Verification Steps

* [x] Request review from a member of a different team.

## Screenshots
These screenshots will illustrate the issue.

Dev:
<img width="1668" alt="Screen Shot 2019-08-07 at 16 44 08" src="https://user-images.githubusercontent.com/3522323/62706197-a9785c00-b9b4-11e9-9091-0f7d4f8f1068.png">

Staging:
<img width="1671" alt="Screen Shot 2019-08-07 at 16 43 53" src="https://user-images.githubusercontent.com/3522323/62706209-b006d380-b9b4-11e9-81ce-b8480c2a8703.png">

