### PR TITLE
Changed path of pdfcpu package (was causing dependency updater to fail)

### DIFF
--- a/docs/adr/0027-pdf-generation.md
+++ b/docs/adr/0027-pdf-generation.md
@@ -38,7 +38,7 @@ specialized tools might be required), we divided the problem into two parts:
 * [gotenberg](https://github.com/thecodingmachine/gotenberg)
 * [Unidoc](https://github.com/unidoc/unidoc)
 * [poppler](https://poppler.freedesktop.org/)
-* [pdfcpu](https://github.com/hhrutter/pdfcpu)
+* [pdfcpu](https://github.com/pdfcpu/pdfcpu)
 
 ## Decision Outcome
 
@@ -58,7 +58,7 @@ Chosen alternative: Draw the PDF form manually using [gofpdf](https://github.com
 
 ### Merging PDFs and Images
 
-Chosen alternative: [pdfcpu](https://github.com/hhrutter/pdfcpu)
+Chosen alternative: [pdfcpu](https://github.com/pdfcpu/pdfcpu)
 
 * `+` Written in Go and requires only other Go libraries as dependencies
 * `+` Was able to wrap images in PDFs using our test files

--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,6 @@ require (
 	github.com/gopherjs/gopherjs v0.0.0-20190430165422-3e4dfb77656c // indirect
 	github.com/gorilla/csrf v1.6.0
 	github.com/hashicorp/go-multierror v1.0.0
-	github.com/hhrutter/pdfcpu v0.2.1
 	github.com/honeycombio/beeline-go v0.4.4
 	github.com/honeycombio/libhoney-go v1.11.1 // indirect
 	github.com/imdario/mergo v0.3.7
@@ -59,6 +58,7 @@ require (
 	github.com/mattn/go-shellwords v1.0.5 // indirect
 	github.com/mitchellh/mapstructure v1.1.2
 	github.com/namsral/flag v1.7.4-pre.0.20170814194028-67f268f20922
+	github.com/pdfcpu/pdfcpu v0.2.3
 	github.com/pkg/errors v0.8.1
 	github.com/rickar/cal v1.0.1
 	github.com/rogpeppe/go-internal v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -288,8 +288,6 @@ github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
-github.com/hhrutter/pdfcpu v0.2.1 h1:Z/BAEmGr92QELpsLW/7hW72oasyoBXi6rfxOev1tiVU=
-github.com/hhrutter/pdfcpu v0.2.1/go.mod h1:vRp7lzKvxF4+7VgBPjNxSuArQafA247dnd1LepVM+DE=
 github.com/honeycombio/beeline-go v0.4.4 h1:fafAE/05lfxctzKBNejs/cUPemKJvNdifjVwLXO0Wm8=
 github.com/honeycombio/beeline-go v0.4.4/go.mod h1:xZNfHCpYQFjVS4Xuc8eMKhBclLnW/PvBz5L1Dwcp81Y=
 github.com/honeycombio/libhoney-go v1.11.1 h1:RVC6OTagbWKdX04V2N/NHhQVTwG2Nzb7DE7xYizqWQ0=
@@ -398,6 +396,8 @@ github.com/onsi/ginkgo v1.8.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+W
 github.com/onsi/gomega v1.5.0 h1:izbySO9zDPmjJ8rDjLvkA2zJHIo+HkYXHnf7eN7SSyo=
 github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
+github.com/pdfcpu/pdfcpu v0.2.3 h1:vVgbDtFTGIHiyArGFIUl3O+SYcvQPFmvQOpnT4ByWS0=
+github.com/pdfcpu/pdfcpu v0.2.3/go.mod h1:Bp9OfH2H74BCs4GOYqIg1IS4GUq3gnuE05R53lckbzM=
 github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181zc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.4.0 h1:u3Z1r+oOXJIkxqw34zVhyPgjBsm6X2wn21NWs/HfSeg=

--- a/pkg/handlers/internalapi/personally_procured_move_attachments_test.go
+++ b/pkg/handlers/internalapi/personally_procured_move_attachments_test.go
@@ -5,10 +5,9 @@ import (
 	"os"
 	"regexp"
 
-	"github.com/hhrutter/pdfcpu/pkg/pdfcpu/validate"
-
-	"github.com/hhrutter/pdfcpu/pkg/api"
-	"github.com/hhrutter/pdfcpu/pkg/pdfcpu"
+	"github.com/pdfcpu/pdfcpu/pkg/api"
+	"github.com/pdfcpu/pdfcpu/pkg/pdfcpu"
+	"github.com/pdfcpu/pdfcpu/pkg/pdfcpu/validate"
 	"github.com/spf13/afero"
 
 	ppmop "github.com/transcom/mymove/pkg/gen/internalapi/internaloperations/ppm"

--- a/pkg/paperwork/generator_test.go
+++ b/pkg/paperwork/generator_test.go
@@ -8,15 +8,13 @@ import (
 	"os"
 	"path"
 
-	"github.com/hhrutter/pdfcpu/pkg/pdfcpu/validate"
-
-	"github.com/transcom/mymove/pkg/uploader"
-
-	"github.com/hhrutter/pdfcpu/pkg/api"
+	"github.com/pdfcpu/pdfcpu/pkg/api"
+	"github.com/pdfcpu/pdfcpu/pkg/pdfcpu/validate"
 	"github.com/spf13/afero"
 
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"
+	"github.com/transcom/mymove/pkg/uploader"
 )
 
 func (suite *PaperworkSuite) sha256ForPath(path string, fs *afero.Afero) (string, error) {


### PR DESCRIPTION
## Description

In version 0.2.3 of `pdfcpu`, the path changed from `github.com/hhrutter/pdfcpu` to `github.com/pdfcpu/pdfcpu`.  This caused our dependency updater to fail because the `go.mod` in the `pdfcpu` project pointed to the new path, but we were trying to fetch v0.2.3 using the old path.

```
2019/08/12 12:09:09 failed to update github.com/hhrutter/pdfcpu: ran go [get -u=patch github.com/hhrutter/pdfcpu], got go: finding github.com/hhrutter/pdfcpu v0.2.3
go: github.com/hhrutter/pdfcpu@v0.2.3: parsing go.mod: unexpected module path "github.com/pdfcpu/pdfcpu"
```

There also was a change to the `Merge` function in `pdfcpu` 0.2.3 to accept a `ReadSeeker` instead of `ReadSeekerCloser` as a parameter.

This PR updates us to v0.2.3 and fixes the incompatibilities.

## Reviewer Notes

My exposure to the PDF code has been limited, so I would appreciate some help testing the PDF functionality in the app to make sure nothing has broken with the new version or my changes.

If we find that upgrading is a problem for now, we do have the ability now with #2501 to exclude a library from being upgraded by the dependency updater.

## Setup

See the setup notes on #2408, then test the PDF merging functionality in the office app.

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/tree/master/docs/backend.md#logging)
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/167574082) for this change
