### PR TITLE
Kim 167580601 remove texting option

### DIFF
--- a/cypress/fixtures/serviceMember.json
+++ b/cypress/fixtures/serviceMember.json
@@ -12,7 +12,6 @@
   "secondary_telephone": "212-555-5555",
   "personal_email": "john_bob@example.com",
   "phone_is_preferred": true,
-  "text_message_is_preferred": true,
   "email_is_preferred": true,
   "current_station_id": "C6885D29-0CF5-4D91-8534-7C729CBE5A7D",
   "residential_address": {

--- a/cypress/integration/mymove/hhgPPM.js
+++ b/cypress/integration/mymove/hhgPPM.js
@@ -200,7 +200,7 @@ function serviceMemberVerifiesContactInfoWasEdited() {
     expect(text).to.include('Best Contact Phone: 213-111-1111');
     expect(text).to.include('Alt. Phone: 222-222-2222');
     expect(text).to.include('Personal Email: hhgforppm@awarded.com');
-    expect(text).to.include('Preferred Contact Method: Phone, Text, Email');
+    expect(text).to.include('Preferred Contact Method: Phone, Email');
     expect(text).to.include('Current Mailing Address: 321 Any Street');
     expect(text).to.include('Los Angeles, CO 91206');
 

--- a/pkg/handlers/internalapi/service_members.go
+++ b/pkg/handlers/internalapi/service_members.go
@@ -57,7 +57,6 @@ func payloadForServiceMemberModel(storer storage.FileStorer, serviceMember model
 		SecondaryTelephone:      serviceMember.SecondaryTelephone,
 		PhoneIsPreferred:        serviceMember.PhoneIsPreferred,
 		PersonalEmail:           serviceMember.PersonalEmail,
-		TextMessageIsPreferred:  serviceMember.TextMessageIsPreferred,
 		EmailIsPreferred:        serviceMember.EmailIsPreferred,
 		ResidentialAddress:      payloadForAddressModel(serviceMember.ResidentialAddress),
 		BackupMailingAddress:    payloadForAddressModel(serviceMember.BackupMailingAddress),
@@ -119,26 +118,25 @@ func (h CreateServiceMemberHandler) Handle(params servicememberop.CreateServiceM
 
 	// Create a new serviceMember for an authenticated user
 	newServiceMember := models.ServiceMember{
-		UserID:                 session.UserID,
-		Edipi:                  params.CreateServiceMemberPayload.Edipi,
-		Affiliation:            (*models.ServiceMemberAffiliation)(params.CreateServiceMemberPayload.Affiliation),
-		Rank:                   (*models.ServiceMemberRank)(params.CreateServiceMemberPayload.Rank),
-		FirstName:              params.CreateServiceMemberPayload.FirstName,
-		MiddleName:             params.CreateServiceMemberPayload.MiddleName,
-		LastName:               params.CreateServiceMemberPayload.LastName,
-		Suffix:                 params.CreateServiceMemberPayload.Suffix,
-		Telephone:              params.CreateServiceMemberPayload.Telephone,
-		SecondaryTelephone:     params.CreateServiceMemberPayload.SecondaryTelephone,
-		PersonalEmail:          params.CreateServiceMemberPayload.PersonalEmail,
-		PhoneIsPreferred:       params.CreateServiceMemberPayload.PhoneIsPreferred,
-		TextMessageIsPreferred: params.CreateServiceMemberPayload.TextMessageIsPreferred,
-		EmailIsPreferred:       params.CreateServiceMemberPayload.EmailIsPreferred,
-		ResidentialAddress:     residentialAddress,
-		BackupMailingAddress:   backupMailingAddress,
-		SocialSecurityNumber:   ssn,
-		DutyStation:            station,
-		RequiresAccessCode:     h.HandlerContext.GetFeatureFlag(cli.FeatureFlagAccessCode),
-		DutyStationID:          stationID,
+		UserID:               session.UserID,
+		Edipi:                params.CreateServiceMemberPayload.Edipi,
+		Affiliation:          (*models.ServiceMemberAffiliation)(params.CreateServiceMemberPayload.Affiliation),
+		Rank:                 (*models.ServiceMemberRank)(params.CreateServiceMemberPayload.Rank),
+		FirstName:            params.CreateServiceMemberPayload.FirstName,
+		MiddleName:           params.CreateServiceMemberPayload.MiddleName,
+		LastName:             params.CreateServiceMemberPayload.LastName,
+		Suffix:               params.CreateServiceMemberPayload.Suffix,
+		Telephone:            params.CreateServiceMemberPayload.Telephone,
+		SecondaryTelephone:   params.CreateServiceMemberPayload.SecondaryTelephone,
+		PersonalEmail:        params.CreateServiceMemberPayload.PersonalEmail,
+		PhoneIsPreferred:     params.CreateServiceMemberPayload.PhoneIsPreferred,
+		EmailIsPreferred:     params.CreateServiceMemberPayload.EmailIsPreferred,
+		ResidentialAddress:   residentialAddress,
+		BackupMailingAddress: backupMailingAddress,
+		SocialSecurityNumber: ssn,
+		DutyStation:          station,
+		RequiresAccessCode:   h.HandlerContext.GetFeatureFlag(cli.FeatureFlagAccessCode),
+		DutyStationID:        stationID,
 	}
 	smVerrs, err := models.SaveServiceMember(ctx, h.DB(), &newServiceMember)
 	verrs.Append(smVerrs)
@@ -266,9 +264,6 @@ func (h PatchServiceMemberHandler) patchServiceMemberWithPayload(ctx context.Con
 	}
 	if payload.PhoneIsPreferred != nil {
 		serviceMember.PhoneIsPreferred = payload.PhoneIsPreferred
-	}
-	if payload.TextMessageIsPreferred != nil {
-		serviceMember.TextMessageIsPreferred = payload.TextMessageIsPreferred
 	}
 	if payload.EmailIsPreferred != nil {
 		serviceMember.EmailIsPreferred = payload.EmailIsPreferred

--- a/pkg/handlers/internalapi/service_members_test.go
+++ b/pkg/handlers/internalapi/service_members_test.go
@@ -127,21 +127,20 @@ func (suite *HandlerSuite) TestSubmitServiceMemberHandlerAllValues() {
 
 	// When: a new ServiceMember is posted
 	newServiceMemberPayload := internalmessages.CreateServiceMemberPayload{
-		UserID:                 strfmt.UUID(user.ID.String()),
-		Edipi:                  swag.String("random string bla"),
-		FirstName:              swag.String("random string bla"),
-		MiddleName:             swag.String("random string bla"),
-		LastName:               swag.String("random string bla"),
-		Suffix:                 swag.String("random string bla"),
-		Telephone:              swag.String("random string bla"),
-		SecondaryTelephone:     swag.String("random string bla"),
-		PersonalEmail:          swag.String("wml@example.com"),
-		PhoneIsPreferred:       swag.Bool(false),
-		TextMessageIsPreferred: swag.Bool(false),
-		EmailIsPreferred:       swag.Bool(true),
-		ResidentialAddress:     fakeAddressPayload(),
-		BackupMailingAddress:   fakeAddressPayload(),
-		SocialSecurityNumber:   (*strfmt.SSN)(swag.String("123-45-6789")),
+		UserID:               strfmt.UUID(user.ID.String()),
+		Edipi:                swag.String("random string bla"),
+		FirstName:            swag.String("random string bla"),
+		MiddleName:           swag.String("random string bla"),
+		LastName:             swag.String("random string bla"),
+		Suffix:               swag.String("random string bla"),
+		Telephone:            swag.String("random string bla"),
+		SecondaryTelephone:   swag.String("random string bla"),
+		PersonalEmail:        swag.String("wml@example.com"),
+		PhoneIsPreferred:     swag.Bool(false),
+		EmailIsPreferred:     swag.Bool(true),
+		ResidentialAddress:   fakeAddressPayload(),
+		BackupMailingAddress: fakeAddressPayload(),
+		SocialSecurityNumber: (*strfmt.SSN)(swag.String("123-45-6789")),
 	}
 
 	req := httptest.NewRequest("GET", "/service_members/some_id", nil)
@@ -236,22 +235,21 @@ func (suite *HandlerSuite) TestPatchServiceMemberHandler() {
 	resAddress := fakeAddressPayload()
 	backupAddress := fakeAddressPayload()
 	patchPayload := internalmessages.PatchServiceMemberPayload{
-		Edipi:                  &newEdipi,
-		BackupMailingAddress:   backupAddress,
-		ResidentialAddress:     resAddress,
-		Affiliation:            &affiliation,
-		EmailIsPreferred:       swag.Bool(true),
-		FirstName:              swag.String("Firstname"),
-		LastName:               swag.String("Lastname"),
-		MiddleName:             swag.String("Middlename"),
-		PersonalEmail:          swag.String("name@domain.com"),
-		PhoneIsPreferred:       swag.Bool(true),
-		Rank:                   &rank,
-		TextMessageIsPreferred: swag.Bool(true),
-		SecondaryTelephone:     swag.String("555555555"),
-		SocialSecurityNumber:   ssn,
-		Suffix:                 swag.String("Sr."),
-		Telephone:              swag.String("555555555"),
+		Edipi:                &newEdipi,
+		BackupMailingAddress: backupAddress,
+		ResidentialAddress:   resAddress,
+		Affiliation:          &affiliation,
+		EmailIsPreferred:     swag.Bool(true),
+		FirstName:            swag.String("Firstname"),
+		LastName:             swag.String("Lastname"),
+		MiddleName:           swag.String("Middlename"),
+		PersonalEmail:        swag.String("name@domain.com"),
+		PhoneIsPreferred:     swag.Bool(true),
+		Rank:                 &rank,
+		SecondaryTelephone:   swag.String("555555555"),
+		SocialSecurityNumber: ssn,
+		Suffix:               swag.String("Sr."),
+		Telephone:            swag.String("555555555"),
 	}
 
 	req := httptest.NewRequest("PATCH", "/service_members/some_id", nil)
@@ -274,7 +272,6 @@ func (suite *HandlerSuite) TestPatchServiceMemberHandler() {
 	suite.Assertions.Equal(*serviceMemberPayload.Edipi, newEdipi)
 	suite.Assertions.Equal(*serviceMemberPayload.Affiliation, affiliation)
 	suite.Assertions.Equal(*serviceMemberPayload.HasSocialSecurityNumber, true)
-	suite.Assertions.Equal(*serviceMemberPayload.TextMessageIsPreferred, true)
 	suite.Assertions.Equal(*serviceMemberPayload.ResidentialAddress.StreetAddress1, *resAddress.StreetAddress1)
 	suite.Assertions.Equal(*serviceMemberPayload.BackupMailingAddress.StreetAddress1, *backupAddress.StreetAddress1)
 

--- a/pkg/handlers/publicapi/service_members.go
+++ b/pkg/handlers/publicapi/service_members.go
@@ -18,21 +18,20 @@ func payloadForServiceMemberModel(serviceMember *models.ServiceMember) *apimessa
 	}
 
 	serviceMemberPayload := apimessages.ServiceMember{
-		FirstName:              serviceMember.FirstName,
-		MiddleName:             serviceMember.MiddleName,
-		LastName:               serviceMember.LastName,
-		Suffix:                 serviceMember.Suffix,
-		Edipi:                  serviceMember.Edipi,
-		Affiliation:            (*apimessages.Affiliation)(serviceMember.Affiliation),
-		Rank:                   (*apimessages.ServiceMemberRank)(serviceMember.Rank),
-		Telephone:              serviceMember.Telephone,
-		SecondaryTelephone:     serviceMember.SecondaryTelephone,
-		PersonalEmail:          serviceMember.PersonalEmail,
-		PhoneIsPreferred:       serviceMember.PhoneIsPreferred,
-		TextMessageIsPreferred: serviceMember.TextMessageIsPreferred,
-		EmailIsPreferred:       serviceMember.EmailIsPreferred,
-		BackupContacts:         contactPayloads,
-		WeightAllotment:        weightAllotment,
+		FirstName:          serviceMember.FirstName,
+		MiddleName:         serviceMember.MiddleName,
+		LastName:           serviceMember.LastName,
+		Suffix:             serviceMember.Suffix,
+		Edipi:              serviceMember.Edipi,
+		Affiliation:        (*apimessages.Affiliation)(serviceMember.Affiliation),
+		Rank:               (*apimessages.ServiceMemberRank)(serviceMember.Rank),
+		Telephone:          serviceMember.Telephone,
+		SecondaryTelephone: serviceMember.SecondaryTelephone,
+		PersonalEmail:      serviceMember.PersonalEmail,
+		PhoneIsPreferred:   serviceMember.PhoneIsPreferred,
+		EmailIsPreferred:   serviceMember.EmailIsPreferred,
+		BackupContacts:     contactPayloads,
+		WeightAllotment:    weightAllotment,
 	}
 
 	return &serviceMemberPayload

--- a/pkg/models/service_member.go
+++ b/pkg/models/service_member.go
@@ -50,7 +50,6 @@ type ServiceMember struct {
 	SecondaryTelephone     *string                   `json:"secondary_telephone" db:"secondary_telephone"`
 	PersonalEmail          *string                   `json:"personal_email" db:"personal_email"`
 	PhoneIsPreferred       *bool                     `json:"phone_is_preferred" db:"phone_is_preferred"`
-	TextMessageIsPreferred *bool                     `json:"text_message_is_preferred" db:"text_message_is_preferred"`
 	EmailIsPreferred       *bool                     `json:"email_is_preferred" db:"email_is_preferred"`
 	ResidentialAddressID   *uuid.UUID                `json:"residential_address_id" db:"residential_address_id"`
 	ResidentialAddress     *Address                  `belongs_to:"address"`
@@ -328,7 +327,7 @@ func (s *ServiceMember) IsProfileComplete() bool {
 	if s.PersonalEmail == nil {
 		return false
 	}
-	if s.PhoneIsPreferred == nil && s.TextMessageIsPreferred == nil && s.EmailIsPreferred == nil {
+	if s.PhoneIsPreferred == nil && s.EmailIsPreferred == nil {
 		return false
 	}
 	if s.ResidentialAddressID == nil {

--- a/src/scenes/MyMove/getWorkflowRoutes.jsx
+++ b/src/scenes/MyMove/getWorkflowRoutes.jsx
@@ -93,8 +93,7 @@ const pages = {
     isInFlow: myFirstRodeo,
     isComplete: ({ sm }) =>
       sm.is_profile_complete ||
-      (every([sm.telephone, sm.personal_email]) &&
-        some([sm.phone_is_preferred, sm.email_is_preferred, sm.text_message_is_preferred])),
+      (every([sm.telephone, sm.personal_email]) && some([sm.phone_is_preferred, sm.email_is_preferred])),
     render: (key, pages) => ({ match }) => <ContactInfo pages={pages} pageKey={key} match={match} />,
   },
   '/service-member/:serviceMemberId/duty-station': {

--- a/src/scenes/Office/CustomerInfoPanel.jsx
+++ b/src/scenes/Office/CustomerInfoPanel.jsx
@@ -19,7 +19,6 @@ import { getRequestStatus } from 'shared/Swagger/selectors';
 
 import FontAwesomeIcon from '@fortawesome/react-fontawesome';
 import faPhone from '@fortawesome/fontawesome-free-solid/faPhone';
-import faComments from '@fortawesome/fontawesome-free-solid/faComments';
 import faEmail from '@fortawesome/fontawesome-free-solid/faEnvelope';
 
 const CustomerInfoDisplay = props => {
@@ -49,12 +48,6 @@ const CustomerInfoDisplay = props => {
             <span>
               <FontAwesomeIcon icon={faPhone} flip="horizontal" />
               phone
-            </span>
-          )}
-          {values.text_message_is_preferred && (
-            <span>
-              <FontAwesomeIcon icon={faComments} />
-              text
             </span>
           )}
           {values.email_is_preferred && (

--- a/src/scenes/Office/CustomerInfoPanel.jsx
+++ b/src/scenes/Office/CustomerInfoPanel.jsx
@@ -105,7 +105,6 @@ const CustomerInfoEdit = props => {
                 <p>Preferred contact method</p>
               </legend>
               <SwaggerField fieldName="phone_is_preferred" swagger={schema} />
-              <SwaggerField fieldName="text_message_is_preferred" swagger={schema} />
               <SwaggerField fieldName="email_is_preferred" swagger={schema} />
             </fieldset>
           </FormSection>

--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -71,7 +71,6 @@ import SitStatusIcon from 'shared/StorageInTransit/SitStatusIcon';
 
 import FontAwesomeIcon from '@fortawesome/react-fontawesome';
 import faPhone from '@fortawesome/fontawesome-free-solid/faPhone';
-import faComments from '@fortawesome/fontawesome-free-solid/faComments';
 import faEmail from '@fortawesome/fontawesome-free-solid/faEnvelope';
 import faClock from '@fortawesome/fontawesome-free-solid/faClock';
 import faCheck from '@fortawesome/fontawesome-free-solid/faCheck';
@@ -368,9 +367,6 @@ class MoveInfo extends Component {
                 {serviceMember.telephone}
                 {serviceMember.phone_is_preferred && (
                   <FontAwesomeIcon className="icon icon-grey" icon={faPhone} flip="horizontal" />
-                )}
-                {serviceMember.text_message_is_preferred && (
-                  <FontAwesomeIcon className="icon icon-grey" icon={faComments} />
                 )}
                 {serviceMember.email_is_preferred && <FontAwesomeIcon className="icon icon-grey" icon={faEmail} />}
                 &nbsp;

--- a/src/scenes/Review/EditContactInfo.jsx
+++ b/src/scenes/Review/EditContactInfo.jsx
@@ -85,11 +85,7 @@ const validateEditContactFormBools = fields => {
 
 EditContactForm = reduxForm({
   form: editContactFormName,
-  validate: validateEditContactFormBools([
-    'serviceMember.phone_is_preferred',
-    'serviceMember.text_message_is_preferred',
-    'serviceMember.email_is_preferred',
-  ]),
+  validate: validateEditContactFormBools(['serviceMember.phone_is_preferred', 'serviceMember.email_is_preferred']),
 })(EditContactForm);
 
 class EditContact extends Component {

--- a/src/scenes/Review/EditContactInfo.jsx
+++ b/src/scenes/Review/EditContactInfo.jsx
@@ -30,7 +30,6 @@ let EditContactForm = props => {
         <fieldset key="contact_preferences">
           <legend htmlFor="contact_preferences">Preferred contact method(s) during your move:</legend>
           <SwaggerField fieldName="phone_is_preferred" swagger={serviceMemberSchema} />
-          <SwaggerField fieldName="text_message_is_preferred" swagger={serviceMemberSchema} disabled={true} />
           <SwaggerField fieldName="email_is_preferred" swagger={serviceMemberSchema} />
         </fieldset>
       </FormSection>

--- a/src/scenes/Review/ServiceMemberSummary.jsx
+++ b/src/scenes/Review/ServiceMemberSummary.jsx
@@ -19,7 +19,6 @@ function getFullContactPreferences(serviceMember) {
   if (!serviceMember) return;
   const prefs = {
     phone_is_preferred: 'Phone',
-    text_message_is_preferred: 'Text',
     email_is_preferred: 'Email',
   };
   const preferredMethods = [];

--- a/src/scenes/ServiceMembers/ContactInfo.jsx
+++ b/src/scenes/ServiceMembers/ContactInfo.jsx
@@ -70,7 +70,6 @@ export class ContactInfo extends Component {
         <fieldset key="contact_preferences">
           <legend htmlFor="contact_preferences">Preferred contact method(s) during your move:</legend>
           <SwaggerField fieldName="phone_is_preferred" swagger={schema} />
-          <SwaggerField fieldName="text_message_is_preferred" swagger={schema} disabled={true} />
           <SwaggerField fieldName="email_is_preferred" swagger={schema} />
         </fieldset>
       </ContactWizardForm>

--- a/src/scenes/ServiceMembers/ContactInfo.jsx
+++ b/src/scenes/ServiceMembers/ContactInfo.jsx
@@ -17,16 +17,13 @@ const subsetOfFields = [
   'secondary_telephone',
   'personal_email',
   'phone_is_preferred',
-  'text_message_is_preferred',
   'email_is_preferred',
 ];
 
 const validateContactForm = values => {
   let errors = {};
 
-  let prefSelected = Boolean(
-    values.phone_is_preferred || values.text_message_is_preferred || values.email_is_preferred,
-  );
+  let prefSelected = Boolean(values.phone_is_preferred || values.email_is_preferred);
   if (!prefSelected) {
     const newError = {
       phone_is_preferred: 'Please select a preferred method of contact.',

--- a/src/scenes/ServiceMembers/ducks.test.js
+++ b/src/scenes/ServiceMembers/ducks.test.js
@@ -52,7 +52,6 @@ const expectedSM = {
     street_address_1: '123 Main',
   },
   telephone: '555-555-5556',
-  text_message_is_preferred: true,
   updated_at: '2018-05-25T21:39:10.484Z',
   user_id: 'b46e651e-9d1c-4be5-bb88-bba58e817696',
 };

--- a/src/scenes/TransportationServiceProvider/CustomerInfo.jsx
+++ b/src/scenes/TransportationServiceProvider/CustomerInfo.jsx
@@ -8,7 +8,6 @@ import { formatWeight } from 'shared/formatters';
 
 import FontAwesomeIcon from '@fortawesome/react-fontawesome';
 import faPhone from '@fortawesome/fontawesome-free-solid/faPhone';
-import faComments from '@fortawesome/fontawesome-free-solid/faComments';
 import faEmail from '@fortawesome/fontawesome-free-solid/faEnvelope';
 
 function renderEntitlements(entitlements) {
@@ -47,11 +46,6 @@ export const CustomerInfo = ({ serviceMember, backupContact, entitlements }) => 
             {serviceMember.phone_is_preferred && (
               <span>
                 <FontAwesomeIcon className="icon icon-grey" icon={faPhone} flip="horizontal" /> <span>Phone</span>
-              </span>
-            )}
-            {serviceMember.text_message_is_preferred && (
-              <span>
-                <FontAwesomeIcon className="icon icon-grey" icon={faComments} /> <span>Text</span>
               </span>
             )}
             {serviceMember.email_is_preferred && (
@@ -119,7 +113,6 @@ CustomerInfo.propTypes = {
     first_name: string.isRequired,
     personal_email: string.isRequired,
     phone_is_preferred: bool,
-    text_message_is_preferred: bool,
     email_is_preferred: bool,
   }).isRequired,
 };

--- a/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
+++ b/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
@@ -47,7 +47,6 @@ import {
 
 import FontAwesomeIcon from '@fortawesome/react-fontawesome';
 import faPhone from '@fortawesome/fontawesome-free-solid/faPhone';
-import faComments from '@fortawesome/fontawesome-free-solid/faComments';
 import faEmail from '@fortawesome/fontawesome-free-solid/faEnvelope';
 import TspContainer from 'shared/TspPanel/TspContainer';
 import Weights from 'shared/ShipmentWeights';
@@ -337,9 +336,6 @@ class ShipmentInfo extends Component {
                 {serviceMember.telephone}
                 {serviceMember.phone_is_preferred && (
                   <FontAwesomeIcon className="icon icon-grey" icon={faPhone} flip="horizontal" />
-                )}
-                {serviceMember.text_message_is_preferred && (
-                  <FontAwesomeIcon className="icon icon-grey" icon={faComments} />
                 )}
                 {serviceMember.email_is_preferred && <FontAwesomeIcon className="icon icon-grey" icon={faEmail} />}
                 &nbsp;

--- a/src/shared/User/sampleLoggedInUserPayload.js
+++ b/src/shared/User/sampleLoggedInUserPayload.js
@@ -220,7 +220,6 @@ export default {
         street_address_1: '123 Main',
       },
       telephone: '555-555-5556',
-      text_message_is_preferred: true,
       updated_at: '2018-05-25T21:39:10.484Z',
       user_id: 'b46e651e-9d1c-4be5-bb88-bba58e817696',
     },

--- a/swagger/api.yaml
+++ b/swagger/api.yaml
@@ -1065,10 +1065,6 @@ definitions:
         type: boolean
         x-nullable: true
         title: Telephone
-      text_message_is_preferred:
-        type: boolean
-        x-nullable: true
-        title: Text Message - Coming Soon!
       email_is_preferred:
         type: boolean
         x-nullable: true

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -1102,10 +1102,6 @@ definitions:
         type: boolean
         x-nullable: true
         title: Telephone
-      text_message_is_preferred:
-        type: boolean
-        x-nullable: true
-        title: Text Message - Coming Soon!
       email_is_preferred:
         type: boolean
         x-nullable: true
@@ -1212,10 +1208,6 @@ definitions:
         type: boolean
         x-nullable: true
         title: Phone
-      text_message_is_preferred:
-        type: boolean
-        x-nullable: true
-        title: Text Message - Coming Soon!
       email_is_preferred:
         type: boolean
         x-nullable: true
@@ -1302,10 +1294,6 @@ definitions:
         type: boolean
         x-nullable: true
         title: Phone
-      text_message_is_preferred:
-        type: boolean
-        x-nullable: true
-        title: Text Message - Coming Soon!
       email_is_preferred:
         type: boolean
         x-nullable: true


### PR DESCRIPTION
## Description

Removes the text -- Coming soon!  from the SM UI, preferred contact info.  Also removes all instances of it in the app.  To support zero-downtime migration, the PR to remove the field from the SM table will come after this one gets deployed.

## Setup

Go to the service member app.
As user ppm@incomple.te, go to Edit Move and Contact Info, Edit.  See that text is removed.
Create a new milmove service member user and and move through the wizard until you get to the preferred contact method section.

## Code Review Verification Steps

* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/167580601) for this change

## Screenshots
![image](https://user-images.githubusercontent.com/13249580/62879191-72b98300-bcdf-11e9-9971-2011ab5e9108.png)

