### PR TITLE
Default ppm to empty object if it is an HHG move to prevent app crashing

### DIFF
--- a/src/scenes/Moves/Ppm/ducks.js
+++ b/src/scenes/Moves/Ppm/ducks.js
@@ -225,7 +225,7 @@ export function getPPM(state) {
   const move = state.moves.currentMove || state.moves.latestMove || {};
   const moveId = move.id;
   const ppmFromEntities = Object.values(state.entities.personallyProcuredMoves).find(ppm => ppm.move_id === moveId);
-  return ppmFromEntities || state.ppm.currentPpm;
+  return ppmFromEntities || state.ppm.currentPpm || {};
 }
 
 // Reducer

--- a/src/scenes/Review/PPMShipmentSummary.jsx
+++ b/src/scenes/Review/PPMShipmentSummary.jsx
@@ -83,7 +83,7 @@ function PPMShipmentSummary(props) {
           <tbody>
             <tr>
               <td> Estimated Weight: </td>
-              <td> {ppm && ppm.weight_estimate.toLocaleString()} lbs</td>
+              <td> {ppm.weight_estimate && ppm.weight_estimate.toLocaleString()} lbs</td>
             </tr>
             <tr>
               <td> Estimated PPM Incentive: </td>


### PR DESCRIPTION
## Description

The app would crash if it is a service member with an HHG move due to the PPM being defaulted to null. This PR defaults a PPM to an empty object

## Setup
`make client_run`
`make server_run`

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/167820682) for this change
