### PR TITLE
Add migration to remove TextMessageIsPreferred column

### DIFF
--- a/migrations/20190812184046_remove_column_text_message_is_preferred.up.fizz
+++ b/migrations/20190812184046_remove_column_text_message_is_preferred.up.fizz
@@ -1,0 +1,1 @@
+drop_column("service_members", "text_message_is_preferred")

--- a/migrations/20190812184046_remove_column_text_message_is_preferred.up.sql
+++ b/migrations/20190812184046_remove_column_text_message_is_preferred.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE service_members DROP COLUMN text_message_is_preferred;

--- a/migrations/20190812184046_remove_column_text_message_is_preferred.up.sql
+++ b/migrations/20190812184046_remove_column_text_message_is_preferred.up.sql
@@ -1,1 +1,0 @@
-ALTER TABLE service_members DROP COLUMN text_message_is_preferred;

--- a/migrations_manifest.txt
+++ b/migrations_manifest.txt
@@ -340,4 +340,4 @@
 20190805161006_disable_truss_user.up.fizz
 20190807134704_admin_user_fname_lname_required.up.fizz
 20190812151703_add_product_admin_users.up.fizz
-20190812184046_remove_column_text_message_is_preferred.up.sql
+20190812184046_remove_column_text_message_is_preferred.up.fizz

--- a/migrations_manifest.txt
+++ b/migrations_manifest.txt
@@ -340,3 +340,4 @@
 20190805161006_disable_truss_user.up.fizz
 20190807134704_admin_user_fname_lname_required.up.fizz
 20190812151703_add_product_admin_users.up.fizz
+20190812184046_remove_column_text_message_is_preferred.up.sql


### PR DESCRIPTION
## Description

This is the follow-up PR to [removal of references](https://github.com/transcom/mymove/tree/kim-167580601-remove-textpreferred-column) to `text_message_is_preferred` in the code.  This is the migration that removes the `text_message_is_preferred` column in the service member table.

## Reviewer Notes

Since we never actively used the text message option, I am not concerned about lost data.  I am following the zero-downtime migrations in our documentation.  I am not creating a `deprecated_text_message_is_preferred` column, as I'm deeming it unnecessary ([see this convo](https://defensedigitalservice.slack.com/archives/G8HJRJBMZ/p1565627271025000))
NOTE: this cannot get merged until the related PR is deployed.

## Setup

`make db_dev_migrate`

## Code Review Verification Steps

* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/tree/master/docs/database.md#zero-downtime-migrations))
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/167580601) for this change (PART 2)
* [this documentation](https://github.com/transcom/mymove/blob/master/docs/how-to/migrate-the-database.md#zero-downtime-migrations) explains more about the approach used.
