### PR TITLE
Sum net weight of multiple weight tickets

### DIFF
--- a/pkg/services/move_documents/storage_expense_updater.go
+++ b/pkg/services/move_documents/storage_expense_updater.go
@@ -74,7 +74,7 @@ func (seu StorageExpenseUpdater) updatePPMSIT(moveDoc *models.MoveDocument, sess
 		return &models.MoveDocument{}, returnVerrs, errors.New("storageexpenseupdater.updateppmsit: no PPM loaded for move doc")
 	}
 	okStatus := models.MoveDocumentStatusOK
-	mergedMoveDocuments, err := mergeMoveDocuments(seu.db, session, ppm.ID, moveDoc, okStatus)
+	mergedMoveDocuments, err := mergeMoveDocuments(seu.db, session, ppm.ID, moveDoc, models.MoveDocumentTypeEXPENSE, okStatus)
 	if err != nil {
 		return &models.MoveDocument{}, returnVerrs, errors.New("storageexpenseupdater.updateppmsit: unable to merge move documents")
 	}

--- a/pkg/services/move_documents/update_move_document.go
+++ b/pkg/services/move_documents/update_move_document.go
@@ -90,9 +90,9 @@ func (mds moveDocumentStatusUpdater) UpdateMoveDocumentStatus(moveDocumentPayloa
 	return moveDoc, returnVerrs, nil
 }
 
-func mergeMoveDocuments(db *pop.Connection, session *auth.Session, ppmID uuid.UUID, moveDoc *models.MoveDocument, status models.MoveDocumentStatus) (models.MoveDocuments, error) {
+func mergeMoveDocuments(db *pop.Connection, session *auth.Session, ppmID uuid.UUID, moveDoc *models.MoveDocument, moveDocumentType models.MoveDocumentType, status models.MoveDocumentStatus) (models.MoveDocuments, error) {
 	// get all documents excluding new document merge in new updated document if status is correct
-	moveDocuments, err := models.FetchMoveDocuments(db, session, ppmID, &status, models.MoveDocumentTypeEXPENSE)
+	moveDocuments, err := models.FetchMoveDocuments(db, session, ppmID, &status, moveDocumentType)
 	if err != nil {
 		return models.MoveDocuments{}, errors.New("mergeDocuments: unable to fetch move documents")
 	}

--- a/pkg/services/move_documents/weight_ticket_updater.go
+++ b/pkg/services/move_documents/weight_ticket_updater.go
@@ -93,7 +93,7 @@ func (wtu WeightTicketUpdater) updatePPMNetWeight(moveDoc *models.MoveDocument, 
 		return &models.MoveDocument{}, returnVerrs, errors.New("weightticketupdater.updateppmnetweight: no PPM loaded for move doc")
 	}
 	okStatus := models.MoveDocumentStatusOK
-	mergedMoveDocuments, err := mergeMoveDocuments(wtu.db, session, ppm.ID, moveDoc, okStatus)
+	mergedMoveDocuments, err := mergeMoveDocuments(wtu.db, session, ppm.ID, moveDoc, models.MoveDocumentTypeWEIGHTTICKETSET, okStatus)
 	if err != nil {
 		return &models.MoveDocument{}, returnVerrs, errors.New("weightticketupdater.updateppmnetweight: unable to merge move documents")
 	}

--- a/pkg/services/move_documents/weight_ticket_updater_test.go
+++ b/pkg/services/move_documents/weight_ticket_updater_test.go
@@ -101,6 +101,130 @@ func (suite *MoveDocumentServiceSuite) TestNetWeightUpdate() {
 
 }
 
+func (suite *MoveDocumentServiceSuite) TestNetWeightWhenMultipleWeightTickets() {
+	wtu := WeightTicketUpdater{suite.DB(), moveDocumentStatusUpdater{}}
+	officeUser := testdatagen.MakeDefaultOfficeUser(suite.DB())
+	session := &auth.Session{
+		ApplicationName: auth.OfficeApp,
+		UserID:          *officeUser.UserID,
+		OfficeUserID:    officeUser.ID,
+	}
+
+	emptyWeight1 := unit.Pound(1000)
+	fullWeight1 := unit.Pound(2500)
+	netWeight1 := fullWeight1 - emptyWeight1
+	ppm := testdatagen.MakePPM(suite.DB(), testdatagen.Assertions{PersonallyProcuredMove: models.PersonallyProcuredMove{NetWeight: &netWeight1}})
+	move := ppm.Move
+	sm := ppm.Move.Orders.ServiceMember
+	moveDocumentOne := testdatagen.MakeMoveDocument(suite.DB(),
+		testdatagen.Assertions{
+			MoveDocument: models.MoveDocument{
+				MoveID:                   move.ID,
+				Move:                     move,
+				PersonallyProcuredMoveID: &ppm.ID,
+				MoveDocumentType:         models.MoveDocumentTypeWEIGHTTICKETSET,
+				Status:                   models.MoveDocumentStatusOK,
+			},
+			Document: models.Document{
+				ServiceMemberID: sm.ID,
+				ServiceMember:   sm,
+			},
+		})
+	weightTicketSetDocumentOne := models.WeightTicketSetDocument{
+		MoveDocumentID:           moveDocumentOne.ID,
+		MoveDocument:             moveDocumentOne,
+		EmptyWeight:              &emptyWeight1,
+		EmptyWeightTicketMissing: false,
+		FullWeight:               &fullWeight1,
+		FullWeightTicketMissing:  false,
+		VehicleNickname:          "My Car",
+		VehicleOptions:           "CAR",
+		WeightTicketDate:         &testdatagen.NextValidMoveDate,
+		TrailerOwnershipMissing:  false,
+	}
+	verrs, err := suite.DB().ValidateAndCreate(&weightTicketSetDocumentOne)
+	suite.NoVerrs(verrs)
+	suite.NoError(err)
+
+	emptyWeight2 := unit.Pound(1000)
+	fullWeight2 := unit.Pound(5000)
+	netWeight2 := fullWeight2 - emptyWeight2
+	wtDateTwo := time.Date(2019, 05, 11, 0, 0, 0, 0, time.UTC)
+	moveDocumentTwo := testdatagen.MakeMoveDocument(suite.DB(),
+		testdatagen.Assertions{
+			MoveDocument: models.MoveDocument{
+				MoveID:                   move.ID,
+				Move:                     move,
+				PersonallyProcuredMoveID: &ppm.ID,
+				MoveDocumentType:         models.MoveDocumentTypeWEIGHTTICKETSET,
+				Status:                   models.MoveDocumentStatusOK,
+			},
+			Document: models.Document{
+				ServiceMemberID: sm.ID,
+				ServiceMember:   sm,
+			},
+		})
+	weightTicketSetDocumentTwo := models.WeightTicketSetDocument{
+		MoveDocumentID:           moveDocumentTwo.ID,
+		MoveDocument:             moveDocumentTwo,
+		EmptyWeight:              &emptyWeight2,
+		EmptyWeightTicketMissing: false,
+		FullWeight:               &fullWeight2,
+		FullWeightTicketMissing:  false,
+		VehicleNickname:          "My Car",
+		VehicleOptions:           "CAR",
+		WeightTicketDate:         &testdatagen.NextValidMoveDate,
+		TrailerOwnershipMissing:  false,
+	}
+	verrs, err = suite.DB().ValidateAndCreate(&weightTicketSetDocumentTwo)
+	suite.NoVerrs(verrs)
+	suite.NoError(err)
+
+	updateMoveDocOnePayload := &internalmessages.MoveDocumentPayload{
+		ID:               handlers.FmtUUID(moveDocumentOne.ID),
+		Status:           internalmessages.MoveDocumentStatusOK,
+		Title:            handlers.FmtString("super_awesome.pdf"),
+		Notes:            handlers.FmtString("This document is super awesome."),
+		VehicleNickname:  "My Car",
+		VehicleOptions:   "CAR",
+		MoveDocumentType: internalmessages.MoveDocumentTypeWEIGHTTICKETSET,
+		EmptyWeight:      handlers.FmtInt64((int64)(emptyWeight1)),
+		FullWeight:       handlers.FmtInt64((int64)(fullWeight1)),
+		WeightTicketDate: handlers.FmtDate(wtDateTwo),
+	}
+	updateMoveDocTwoPayload := &internalmessages.MoveDocumentPayload{
+		ID:               handlers.FmtUUID(moveDocumentOne.ID),
+		Status:           internalmessages.MoveDocumentStatusOK,
+		Title:            handlers.FmtString("super_awesome.pdf"),
+		Notes:            handlers.FmtString("This document is super awesome."),
+		VehicleNickname:  "My Car",
+		VehicleOptions:   "CAR",
+		MoveDocumentType: internalmessages.MoveDocumentTypeWEIGHTTICKETSET,
+		EmptyWeight:      handlers.FmtInt64((int64)(emptyWeight2)),
+		FullWeight:       handlers.FmtInt64((int64)(fullWeight2)),
+		WeightTicketDate: handlers.FmtDate(wtDateTwo),
+	}
+	originalMoveDocumentOne, err := models.FetchMoveDocument(suite.DB(), session, moveDocumentOne.ID)
+	suite.Nil(err)
+	umd, verrs, err := wtu.Update(updateMoveDocOnePayload, originalMoveDocumentOne, session)
+	suite.NotNil(umd)
+	suite.NoVerrs(verrs)
+	suite.Nil(err)
+
+	originalMoveDocumentTwo, err := models.FetchMoveDocument(suite.DB(), session, moveDocumentTwo.ID)
+	suite.Nil(err)
+	umd, verrs, err = wtu.Update(updateMoveDocTwoPayload, originalMoveDocumentTwo, session)
+	suite.NotNil(umd)
+	suite.NoVerrs(verrs)
+	suite.Nil(err)
+
+	updatedPpm := models.PersonallyProcuredMove{}
+	err = suite.DB().Where(`id = $1`, ppm.ID).First(&updatedPpm)
+	suite.Require().Nil(err)
+	suite.Require().Equal(netWeight1+netWeight2, *updatedPpm.NetWeight)
+
+}
+
 func (suite *MoveDocumentServiceSuite) TestNetWeightRemovedWhenStatusNotOK() {
 	wtu := WeightTicketUpdater{suite.DB(), moveDocumentStatusUpdater{}}
 	officeUser := testdatagen.MakeDefaultOfficeUser(suite.DB())


### PR DESCRIPTION
## Description

Fix bug that was occurring for ppm's with multiple weight tickets (likely introduced in #2467). 

The net weight for a PPM didn't correctly reflect the sum of weight tickets, when there were multiple weight tickets. This PR fixes this issue and adds tests to confirm that the net weight field on the ppm is updated and correctly reflects the the sum of the weight ticket weights (when there are multiple weight tickets). It also adds a similar test for storage expenses, as the logic is similar and changes made relate to storage expenses too (even though this was working correctly).

## Reviewer Notes

1) Request payment for a move (i.e. `ppm@paymentrequest.ed`). 
2) Then try adding several weight ticket sets to a move on the office side. The weight ticket sets with a status of 'OK' should be included in the net weight found on the PPM tab *and* in the actual obligations section on the SSW. 
3) Add multiple storage expenses. The total of the days in storage and the total cost should show up on the PPM tab. Also, the total cost should be reflected in the SSW 

## Setup

```sh
make server_test
```

## Code Review Verification Steps
* [ ] Request review from a member of a different team.