### PR TITLE
Add missing semicolons to sql

### DIFF
--- a/migrations/20190205001721_remove-hackerone-users.sql
+++ b/migrations/20190205001721_remove-hackerone-users.sql
@@ -1,4 +1,4 @@
 -- Removes hackerone users from tsp and office users tables.
 
-DELETE FROM public.tsp_users where email like '%(@hackerone.com|@wearehackerone.com|@managed.hackerone.com)'
-DELETE FROM public.office_users where email like '%(@hackerone.com|@wearehackerone.com|@managed.hackerone.com)'
+DELETE FROM public.tsp_users where email like '%(@hackerone.com|@wearehackerone.com|@managed.hackerone.com)';
+DELETE FROM public.office_users where email like '%(@hackerone.com|@wearehackerone.com|@managed.hackerone.com)';


### PR DESCRIPTION
## Description

I'm pulling this out of #2349 so that it can go in with #2506. Fixing SQL migration files is important so that they run correctly locally.