### PR TITLE
Convereted anchor tag to react-router link

### DIFF
--- a/src/scenes/Legalese/CustomerAgreement.jsx
+++ b/src/scenes/Legalese/CustomerAgreement.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
 
 const CustomerAgreement = ({ onChange, link, checked, agreementText, className }) => {
   const handleOnChange = e => {
@@ -20,10 +21,11 @@ const CustomerAgreement = ({ onChange, link, checked, agreementText, className }
       <input id="agree-checkbox" type="checkbox" checked={checked} onChange={handleOnChange} />
       <label htmlFor="agree-checkbox">
         I agree to the{' '}
-        <a href={link} onClick={link ? null : handleClick}>
-          {' '}
-          Legal Agreement / Privacy Act
-        </a>
+        {link ? (
+          <Link to={link}> Legal Agreement / Privacy Act</Link>
+        ) : (
+          <a onClick={handleClick}> Legal Agreement / Privacy Act</a>
+        )}
       </label>
     </div>
   );


### PR DESCRIPTION
## Description

The sign in view was flashing on the page when viewing the clicking the link to the legalese page. This was because it was using an anchor tag which was visiting the link as a new page effectively refreshing the page and having to verify that the user is logged in. Using the react-router Link tag stays within react-router's routing system so it just switches views and does not have to do the auth check constantly.

## Setup
`make server_run`
`make client_run`
Click on Legal Agreement / Privacy Act on payment review screen
Should not flash the sign in page

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/167659228) for this change

