### PR TITLE
Change OTHER label to Not GTCC

### DIFF
--- a/src/scenes/Moves/Ppm/PaymentReview/ExpenseTicketListItem.jsx
+++ b/src/scenes/Moves/Ppm/PaymentReview/ExpenseTicketListItem.jsx
@@ -9,7 +9,7 @@ const ExpenseTicketListItem = ({ amount, type, paymentMethod, showDelete }) => (
       </h4>
     </div>
     <div>
-      {type} ({paymentMethod})
+      {type} ({paymentMethod === 'OTHER' ? 'Not GTCC' : paymentMethod})
     </div>
   </div>
 );


### PR DESCRIPTION
## Description

Change `OTHER` label to `Not GTCC` on expense tickets in the payment review screen

## Setup
`make client_run`
`make server_run`
Upload expense ticket with an `OTHER` payment method
View payment review screen in ppm closeout flow

## Code Review Verification Steps
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/167880917) for this change

## Screenshots

![image](https://user-images.githubusercontent.com/13622298/62971598-1598fc80-bdc7-11e9-837d-c5ce267204d2.png)
