### PR TITLE
Add exit condition to prevent curl from breaking the build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -451,7 +451,7 @@ jobs:
       - run:
           name: upload code coverage to codecov
           command: |
-            curl -L --retry 5 --retry-connrefused https://codecov.io/bash --output /home/circleci/codecov
+            curl -L --retry 5 --retry-connrefused https://codecov.io/bash --output /home/circleci/codecov || exit 0
             chmod +x /home/circleci/codecov
             /home/circleci/codecov -F go -f coverage.out
 


### PR DESCRIPTION
## Description

Codecov breaks our build during the `server_test_coverage` build step the curl request times out. This PR adds an exit condition to break out of that step if we hit the retry limit.

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/167520564) for this change