### PR TITLE
Office PPM payment requests queue [delivers #167575622]

### DIFF
--- a/pkg/models/queue_test.go
+++ b/pkg/models/queue_test.go
@@ -73,6 +73,33 @@ func (suite *ModelSuite) TestShowPPMQueue() {
 	suite.Len(moves, 3)
 }
 
+func (suite *ModelSuite) TestShowPPMPaymentRequestsQueue() {
+	// PPMs should only show statuses in the queue:
+	// payment requested
+
+	// Make PPMs with different statuses
+	testdatagen.MakePPM(suite.DB(), testdatagen.Assertions{
+		PersonallyProcuredMove: models.PersonallyProcuredMove{
+			Status: models.PPMStatusAPPROVED,
+		},
+	})
+	testdatagen.MakePPM(suite.DB(), testdatagen.Assertions{
+		PersonallyProcuredMove: models.PersonallyProcuredMove{
+			Status: models.PPMStatusPAYMENTREQUESTED,
+		},
+	})
+	testdatagen.MakePPM(suite.DB(), testdatagen.Assertions{
+		PersonallyProcuredMove: models.PersonallyProcuredMove{
+			Status: models.PPMStatusCOMPLETED,
+		},
+	})
+
+	// Expected 1 move for PPM payment requests queue returned
+	moves, err := GetMoveQueueItems(suite.DB(), "ppm_payment_requested")
+	suite.NoError(err)
+	suite.Len(moves, 1)
+}
+
 func (suite *ModelSuite) TestShowPPMQueueStatusDraftSubmittedCanceled() {
 	// PPMs should only show statuses in the queue:
 	// approved, payment requested and completed

--- a/pkg/models/queue_test.go
+++ b/pkg/models/queue_test.go
@@ -98,6 +98,7 @@ func (suite *ModelSuite) TestShowPPMPaymentRequestsQueue() {
 	moves, err := GetMoveQueueItems(suite.DB(), "ppm_payment_requested")
 	suite.NoError(err)
 	suite.Len(moves, 1)
+	suite.EqualValues(models.PPMStatusPAYMENTREQUESTED, *moves[0].PpmStatus)
 }
 
 func (suite *ModelSuite) TestShowPPMQueueStatusDraftSubmittedCanceled() {

--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -147,6 +147,12 @@ const ReferrerQueueLink = props => {
           <span>PPM Queue</span>
         </NavLink>
       );
+    case '/queues/ppm_payment_requested':
+      return (
+        <NavLink to="/queues/ppm_payment_requested" activeClassName="usa-current">
+          <span>PPM Payment Requests Queue</span>
+        </NavLink>
+      );
     case '/queues/hhg_active':
       return (
         <NavLink to="/queues/hhg_active" activeClassName="usa-current">

--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -144,13 +144,13 @@ const ReferrerQueueLink = props => {
     case '/queues/ppm':
       return (
         <NavLink to="/queues/ppm" activeClassName="usa-current">
-          <span>PPM Queue</span>
+          <span>All PPMs Queue</span>
         </NavLink>
       );
     case '/queues/ppm_payment_requested':
       return (
         <NavLink to="/queues/ppm_payment_requested" activeClassName="usa-current">
-          <span>PPM Payment Requests Queue</span>
+          <span>Payment Requests PPMs Queue</span>
         </NavLink>
       );
     case '/queues/hhg_active':

--- a/src/scenes/Office/QueueList.jsx
+++ b/src/scenes/Office/QueueList.jsx
@@ -19,9 +19,29 @@ export default class QueueList extends Component {
             </NavLink>
           </li>
           <li>
-            <NavLink to="/queues/ppm" activeClassName="usa-current" data-cy="ppm-queue">
-              <span>PPM Shipments</span>
+            <NavLink
+              to="#ppmshipments"
+              activeClassName="usa-current"
+              isActive={isActive('ppm', 'ppm_payment_requested')}
+            >
+              <span>PPM shipments:</span>
             </NavLink>
+            <ul className="usa-sidenav-sub_list">
+              <li>
+                <NavLink to="/queues/ppm" activeClassName="usa-current" data-cy="ppm-queue">
+                  <span>All</span>
+                </NavLink>
+              </li>
+              <li>
+                <NavLink
+                  to="/queues/ppm_payment_requested"
+                  activeClassName="usa-current"
+                  data-cy="ppm-payment-requests-queue"
+                >
+                  <span>Payment requests</span>
+                </NavLink>
+              </li>
+            </ul>
           </li>
           <li>
             <NavLink

--- a/src/scenes/Office/QueueTable.jsx
+++ b/src/scenes/Office/QueueTable.jsx
@@ -118,8 +118,8 @@ class QueueTable extends Component {
     const titles = {
       new: 'New Moves/Shipments',
       troubleshooting: 'Troubleshooting',
-      ppm: 'PPM All',
-      ppm_payment_requested: 'PPM Payment Requests',
+      ppm: 'All PPMs',
+      ppm_payment_requested: 'Payment Requests PPMs',
       hhg_active: 'Active HHGs',
       hhg_delivered: 'Delivered HHGs',
       all: 'All Moves',

--- a/src/scenes/Office/QueueTable.jsx
+++ b/src/scenes/Office/QueueTable.jsx
@@ -118,7 +118,8 @@ class QueueTable extends Component {
     const titles = {
       new: 'New Moves/Shipments',
       troubleshooting: 'Troubleshooting',
-      ppm: 'PPM Shipments',
+      ppm: 'PPM All',
+      ppm_payment_requested: 'PPM Payment Requests',
       hhg_active: 'Active HHGs',
       hhg_delivered: 'Delivered HHGs',
       all: 'All Moves',

--- a/src/scenes/Office/QueueTable.jsx
+++ b/src/scenes/Office/QueueTable.jsx
@@ -130,6 +130,7 @@ class QueueTable extends Component {
         case 'new':
           return newColumns;
         case 'ppm':
+        case 'ppm_payment_requested':
           return ppmColumns;
         case 'hhg_active':
           return hhgActiveColumns;

--- a/src/scenes/Office/QueueTable.jsx
+++ b/src/scenes/Office/QueueTable.jsx
@@ -157,7 +157,10 @@ class QueueTable extends Component {
         row.shipments = 'HHG';
       }
 
-      if (this.props.queueType === 'ppm' && row.ppm_status !== null) {
+      if (
+        (this.props.queueType === 'ppm' || this.props.queueType === 'ppm_payment_requested') &&
+        row.ppm_status !== null
+      ) {
         row.synthetic_status = row.ppm_status;
       } else {
         row.synthetic_status = row.status;

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -4459,6 +4459,7 @@ paths:
           enum:
             - new
             - ppm
+            - ppm_payment_requested
             - hhg_active
             - hhg_delivered
             - all


### PR DESCRIPTION
## Description

Given that I am an office user
And I am logged in
When I visit the queues page
Then I should see a queue for "Payment Requests"
And it should be listed in the left-hand nav below PPM Shipments

## Reviewer Notes

- `All` tab is the PPM queue that shows all active PPMs
- `Payment Requests` tab only shows PPMs with statuses `Payment requested`
- Changes were made to the referral link to add the ppm payment requests queue

## Setup

```sh
make server_run
make office_client_run
```

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/tree/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/tree/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/167575622) for this change

## Screenshots

![Aug-14-2019 16-04-52](https://user-images.githubusercontent.com/1522549/63062326-510df680-bead-11e9-9336-e15ea1bbe08b.gif)

