### PR TITLE
Strip hash character from branch name for docker images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,8 +176,8 @@ commands:
             bash -c "$(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION)"
             docker tag << parameters.tag >> ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/<< parameters.repo >>:git-${CIRCLE_SHA1}
             docker push ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/<< parameters.repo >>:git-${CIRCLE_SHA1}
-            docker tag << parameters.tag >> ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/<< parameters.repo >>:git-branch-${CIRCLE_BRANCH}
-            docker push ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/<< parameters.repo >>:git-branch-${CIRCLE_BRANCH}
+            docker tag << parameters.tag >> ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/<< parameters.repo >>:git-branch-${CIRCLE_BRANCH//#}
+            docker push ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/<< parameters.repo >>:git-branch-${CIRCLE_BRANCH//#}
   e2e_tests:
     steps:
       - run:

--- a/scripts/update-docker-compose
+++ b/scripts/update-docker-compose
@@ -3,5 +3,5 @@
 set -eu -o pipefail
 
 BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
-perl -pi.bak -e "s/(.*git-branch).*/\$1-${BRANCH_NAME}/g" docker-compose.yml
+perl -pi.bak -e "s/(.*git-branch).*/\$1-${BRANCH_NAME//\#}/g" docker-compose.yml
 rm docker-compose.yml.bak


### PR DESCRIPTION
## Description

Having a `#` character in the branch name breaks docker-compose. This is an attempt to strip out that character using Bash native character manipulation.

This fixes issues as seen in https://github.com/transcom/mymove/pull/2535

You can see that the tagging and pushing of docker images worked with this branch: https://circleci.com/workflow-run/9a2aa4c5-6452-41aa-aafc-88ce7f6283de

You can also use docker-compose:

```
make docker_compose_up
make docker_compose_down
```