### PR TITLE
Remove backend uploader filesize limit

### DIFF
--- a/pkg/uploader/uploader.go
+++ b/pkg/uploader/uploader.go
@@ -17,11 +17,6 @@ import (
 // ErrZeroLengthFile represents an error caused by a file with no content
 var ErrZeroLengthFile = errors.New("File has length of 0")
 
-const fileSizeLimit = 25000000
-
-// ErrTooLarge represents an error caused by a file larger than 25MB
-var ErrTooLarge = errors.New("File is too large. We do not accept files larger than 25 MB")
-
 // Uploader encapsulates a few common processes: creating Uploads for a Document,
 // generating pre-signed URLs for file access, and deleting Uploads.
 type Uploader struct {
@@ -59,9 +54,6 @@ func (u *Uploader) CreateUploadForDocument(documentID *uuid.UUID, userID uuid.UU
 
 	if info.Size() == 0 {
 		return nil, responseVErrors, ErrZeroLengthFile
-	}
-	if info.Size() > fileSizeLimit {
-		return nil, responseVErrors, ErrTooLarge
 	}
 
 	contentType, detectContentTypeErr := storage.DetectContentType(file)

--- a/pkg/uploader/uploader_test.go
+++ b/pkg/uploader/uploader_test.go
@@ -119,6 +119,18 @@ func (suite *UploaderSuite) TestUploadFromLocalFileZeroLength() {
 	suite.Nil(upload, "returned an upload when erroring")
 }
 
+func (suite *UploaderSuite) TestTooLargeUploadFromLocalFile() {
+	document := testdatagen.MakeDefaultDocument(suite.DB())
+
+	up := uploader.NewUploader(suite.DB(), suite.logger, suite.storer)
+	file := suite.fixture("largejpeg.jpg")
+
+	upload, verrs, err := up.CreateUploadForDocument(&document.ID, document.ServiceMember.UserID, file, uploader.AllowedTypesServiceMember)
+	suite.Nil(err)
+	suite.False(verrs.HasAny(), "failed to validate upload")
+	suite.NotNil(upload)
+}
+
 func (suite *UploaderSuite) helperNewTempFile() (afero.File, error) {
 	outputFile, err := suite.fs.TempFile("/tmp/milmoves/", "TestCreateUploadNoDocument")
 	if err != nil {

--- a/pkg/uploader/uploader_test.go
+++ b/pkg/uploader/uploader_test.go
@@ -119,18 +119,6 @@ func (suite *UploaderSuite) TestUploadFromLocalFileZeroLength() {
 	suite.Nil(upload, "returned an upload when erroring")
 }
 
-func (suite *UploaderSuite) TestTooLargeUploadFromLocalFile() {
-	document := testdatagen.MakeDefaultDocument(suite.DB())
-
-	up := uploader.NewUploader(suite.DB(), suite.logger, suite.storer)
-	file := suite.fixture("largejpeg.jpg")
-
-	upload, verrs, err := up.CreateUploadForDocument(&document.ID, document.ServiceMember.UserID, file, uploader.AllowedTypesPDF)
-	suite.Equal(err, uploader.ErrTooLarge)
-	suite.False(verrs.HasAny(), "failed to validate upload")
-	suite.Nil(upload, "returned an upload when erroring")
-}
-
 func (suite *UploaderSuite) helperNewTempFile() (afero.File, error) {
 	outputFile, err := suite.fs.TempFile("/tmp/milmoves/", "TestCreateUploadNoDocument")
 	if err != nil {


### PR DESCRIPTION
## Description

The uploader was causing generated pdfs exceeding 25MB to fail. The filesize check is mainly intended to prevent service members and office users from uploading very large files #2486 . It wasn't intended to block generated files. 

## Reviewer Notes

This is somewhat hard to verify, since you'd have to submit an upload without using the uploader on the front end. So I just changed our previous backend test to check for a successful upload of a file larger than 25mb.

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make server_test
```

## Code Review Verification Steps
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/n/projects/2181745/stories/167945995) for this change