### PR TITLE
Upgrades go to 1.12.9.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,28 +15,28 @@ executors:
     resource_class: small
     working_directory: ~/transcom/mymove
     docker:
-      - image: trussworks/circleci-docker-primary:9b7bfbf6bfae544566ade0c896f8aacbd16281e5
+      - image: trussworks/circleci-docker-primary:e5c10bf19185aa55354901106bad3ffd4c016265
   mymove_medium:
     resource_class: medium
     working_directory: ~/transcom/mymove
     docker:
-      - image: trussworks/circleci-docker-primary:9b7bfbf6bfae544566ade0c896f8aacbd16281e5
+      - image: trussworks/circleci-docker-primary:e5c10bf19185aa55354901106bad3ffd4c016265
   mymove_medium_plus:
     resource_class: medium+
     working_directory: ~/transcom/mymove
     docker:
-      - image: trussworks/circleci-docker-primary:9b7bfbf6bfae544566ade0c896f8aacbd16281e5
+      - image: trussworks/circleci-docker-primary:e5c10bf19185aa55354901106bad3ffd4c016265
   mymove_large:
     resource_class: large
     working_directory: ~/transcom/mymove
     docker:
-      - image: trussworks/circleci-docker-primary:9b7bfbf6bfae544566ade0c896f8aacbd16281e5
+      - image: trussworks/circleci-docker-primary:e5c10bf19185aa55354901106bad3ffd4c016265
   # `mymove_and_postgres_medium` adds a secondary postgres container to be used during testing.
   mymove_and_postgres_medium:
     resource_class: medium
     working_directory: ~/transcom/mymove
     docker:
-      - image: trussworks/circleci-docker-primary:9b7bfbf6bfae544566ade0c896f8aacbd16281e5
+      - image: trussworks/circleci-docker-primary:e5c10bf19185aa55354901106bad3ffd4c016265
       - image: postgres:10.9
         environment:
           - POSTGRES_PASSWORD: mysecretpassword
@@ -46,7 +46,7 @@ executors:
     resource_class: large
     working_directory: ~/transcom/mymove
     docker:
-      - image: trussworks/circleci-docker-primary:9b7bfbf6bfae544566ade0c896f8aacbd16281e5
+      - image: trussworks/circleci-docker-primary:e5c10bf19185aa55354901106bad3ffd4c016265
       - image: postgres:10.9
         environment:
           - POSTGRES_PASSWORD: mysecretpassword


### PR DESCRIPTION
## Description

Updates go from 1.12.x to 1.12.9 for minor release that includes two main security concerns:

1. go1.12.8 (released 2019/08/13) includes security fixes to the net/http and net/url packages. See the Go 1.12.8 milestone on our issue tracker for details.
1. go1.12.9 (released 2019/08/15) includes fixes to the linker, and the os and math/big packages. See the Go 1.12.9 milestone on our issue tracker for details.

See the directions to [upgrade go here](https://github.com/transcom/mymove/blob/master/docs/how-to/upgrade-go-version.md).

See the landed [PR](https://github.com/trussworks/circleci-docker-primary/pull/39) that updates our docker image.

See the [minor version notes](https://golang.org/doc/devel/release.html#go1.12.minor) for more release notes.

Verify the docker image hash [here](https://hub.docker.com/r/trussworks/circleci-docker-primary/tags) - `e5c10bf19185aa55354901106bad3ffd4c016265 `

## Setup

```sh
brew update go
```

## Code Review Verification Steps

* [x] Have been communicated to #dp3-engineering
* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/167895881)
