### PR TITLE
Update the Memory reservations for app containers by doubling them

### DIFF
--- a/scripts/ecs-deploy-service-container
+++ b/scripts/ecs-deploy-service-container
@@ -25,7 +25,7 @@ readonly environment=$4
 readonly launch_type="${5:-EC2}"
 
 readonly RESERVATION_CPU=512
-readonly RESERVATION_MEM=1024
+readonly RESERVATION_MEM=2048
 
 if [[ $launch_type != EC2 && $launch_type != FARGATE ]]; then
     echo "Error: launch_type must be EC2 or FARGATE"


### PR DESCRIPTION
## Description

Memory utilization spikes during PDF generation which can then cause 502 Bad Gateway errors or 504 Gateway Timeout errors from our application. Double memory allocated to accommodate larger pdfs.

## References

* [Pivotal story](https://www.pivotaltracker.com/n/projects/2181745/stories/167949815) for this change