### PR TITLE
Save golang coverage as an artifact

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -454,6 +454,8 @@ jobs:
             curl -L --retry 5 --retry-connrefused https://codecov.io/bash --output /home/circleci/codecov || exit 0
             chmod +x /home/circleci/codecov
             /home/circleci/codecov -F go -f coverage.out
+      - store_artifacts:
+          path: ~/transcom/mymove/coverage.out
 
   # `client_test` runs the client side Javascript tests
   client_test:


### PR DESCRIPTION
## Description

It would be nice to store the coverage file in case codecov fails. Then a person can download the file and run `go tool cover -html=coverage.out` to see the output. This is in response to https://github.com/transcom/mymove/pull/2527.