### PR TITLE
Add custom cloudwatch metrics for deploys and migrations

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -820,33 +820,33 @@ workflows:
             - pre_deps_yarn
             - acceptance_tests_local
           # if testing on experimental, you can disable these tests by using the commented block below.
-          # filters:
-          #   branches:
-          #     ignore: placeholder_branch_name
+          filters:
+            branches:
+              ignore: cg_custom_metric_for_deploys_and_migrations
 
       - client_test:
           requires:
             - pre_deps_yarn
           # if testing on experimental, you can disable these tests by using the commented block below.
-          # filters:
-          #   branches:
-          #     ignore: placeholder_branch_name
+          filters:
+            branches:
+              ignore: cg_custom_metric_for_deploys_and_migrations
 
       - server_test:
           requires:
             - pre_deps_golang
           # if testing on experimental, you can disable these tests by using the commented block below.
-          # filters:
-          #   branches:
-          #     ignore: placeholder_branch_name
+          filters:
+            branches:
+              ignore: cg_custom_metric_for_deploys_and_migrations
 
       - server_test_coverage:
           requires:
             - pre_deps_golang
           # if testing on experimental, you can disable these tests by using the commented block below.
-          # filters:
-          #   branches:
-          #     ignore: placeholder_branch_name
+          filters:
+            branches:
+              ignore: cg_custom_metric_for_deploys_and_migrations
 
       - build_app:
           requires:
@@ -879,28 +879,28 @@ workflows:
             - build_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: cg_custom_metric_for_deploys_and_migrations
 
       - deploy_experimental_tasks:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: cg_custom_metric_for_deploys_and_migrations
 
       - deploy_experimental_app:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: cg_custom_metric_for_deploys_and_migrations
 
       - deploy_experimental_app_client_tls:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: cg_custom_metric_for_deploys_and_migrations
 
       - check_circle_against_staging_sha:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -820,33 +820,33 @@ workflows:
             - pre_deps_yarn
             - acceptance_tests_local
           # if testing on experimental, you can disable these tests by using the commented block below.
-          filters:
-            branches:
-              ignore: cg_custom_metric_for_deploys_and_migrations
+          # filters:
+          #   branches:
+          #     ignore: placeholder_branch_name
 
       - client_test:
           requires:
             - pre_deps_yarn
           # if testing on experimental, you can disable these tests by using the commented block below.
-          filters:
-            branches:
-              ignore: cg_custom_metric_for_deploys_and_migrations
+          # filters:
+          #   branches:
+          #     ignore: placeholder_branch_name
 
       - server_test:
           requires:
             - pre_deps_golang
           # if testing on experimental, you can disable these tests by using the commented block below.
-          filters:
-            branches:
-              ignore: cg_custom_metric_for_deploys_and_migrations
+          # filters:
+          #   branches:
+          #     ignore: placeholder_branch_name
 
       - server_test_coverage:
           requires:
             - pre_deps_golang
           # if testing on experimental, you can disable these tests by using the commented block below.
-          filters:
-            branches:
-              ignore: cg_custom_metric_for_deploys_and_migrations
+          # filters:
+          #   branches:
+          #     ignore: placeholder_branch_name
 
       - build_app:
           requires:
@@ -879,28 +879,28 @@ workflows:
             - build_migrations
           filters:
             branches:
-              only: cg_custom_metric_for_deploys_and_migrations
+              only: placeholder_branch_name
 
       - deploy_experimental_tasks:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: cg_custom_metric_for_deploys_and_migrations
+              only: placeholder_branch_name
 
       - deploy_experimental_app:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: cg_custom_metric_for_deploys_and_migrations
+              only: placeholder_branch_name
 
       - deploy_experimental_app_client_tls:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: cg_custom_metric_for_deploys_and_migrations
+              only: placeholder_branch_name
 
       - check_circle_against_staging_sha:
           requires:

--- a/scripts/ecs-deploy-service-container
+++ b/scripts/ecs-deploy-service-container
@@ -107,6 +107,7 @@ if update_service "$green_task_def_arn"; then
     aws cloudwatch put-metric-data --metric-name DeployCount --namespace "${environment}" --value 1 --timestamp "$(date +\"%Y-%m-%dT%H:%M:%SZ\")"
     exit 0
 fi
+aws cloudwatch put-metric-data --metric-name DeployFail --namespace "${environment}" --value 1 --timestamp "$(date +\"%Y-%m-%dT%H:%M:%SZ\")"
 echo "Service failed to stabilize!"
 
 echo
@@ -118,8 +119,9 @@ echo "* Rolling back to $blue_task_def_arn"
 if update_service "$blue_task_def_arn"; then
     echo "Rollback complete."
     # Mark as rollback
-    aws cloudwatch put-metric-data --metric-name DeployRollback --namespace "${environment}" --value 1 --timestamp "$(date +\"%Y-%m-%dT%H:%M:%SZ\")"
+    aws cloudwatch put-metric-data --metric-name RollbackCount --namespace "${environment}" --value 1 --timestamp "$(date +\"%Y-%m-%dT%H:%M:%SZ\")"
     exit 1
 fi
+aws cloudwatch put-metric-data --metric-name RollbackFail --namespace "${environment}" --value 1 --timestamp "$(date +\"%Y-%m-%dT%H:%M:%SZ\")"
 echo "Rollback failed!"
 exit 1

--- a/scripts/ecs-deploy-service-container
+++ b/scripts/ecs-deploy-service-container
@@ -103,6 +103,8 @@ check_arn "$green_task_def_arn"
 
 if update_service "$green_task_def_arn"; then
     echo "Success."
+    # Mark as success
+    aws cloudwatch put-metric-data --metric-name DeployCount --namespace "${environment}" --value 1 --timestamp "$(date +\"%Y-%m-%dT%H:%M:%SZ\")"
     exit 0
 fi
 echo "Service failed to stabilize!"
@@ -115,6 +117,8 @@ echo
 echo "* Rolling back to $blue_task_def_arn"
 if update_service "$blue_task_def_arn"; then
     echo "Rollback complete."
+    # Mark as rollback
+    aws cloudwatch put-metric-data --metric-name DeployRollback --namespace "${environment}" --value 1 --timestamp "$(date +\"%Y-%m-%dT%H:%M:%SZ\")"
     exit 1
 fi
 echo "Rollback failed!"

--- a/scripts/ecs-deploy-service-container
+++ b/scripts/ecs-deploy-service-container
@@ -73,6 +73,15 @@ update_service() {
     return $exit_code
 }
 
+# Put a dimensionless metric into cloudwatch
+put_metric() {
+    local metric_name="$1"
+    local namespace="$2"
+    local timestamp
+    timestamp=$(date +"%Y-%m-%dT%H:%M:%SZ")
+    aws cloudwatch put-metric-data --metric-name "${metric_name}" --namespace "${namespace}" --value 1 --timestamp "${timestamp}"
+}
+
 # get current task definiton (for rollback)
 blue_task_def_arn=$(aws ecs describe-services --services "$name" --cluster "$cluster" --query 'services[0].taskDefinition' | jq -r .)
 
@@ -103,12 +112,11 @@ check_arn "$green_task_def_arn"
 
 if update_service "$green_task_def_arn"; then
     echo "Success."
-    # Mark as success
-    aws cloudwatch put-metric-data --metric-name DeployCount --namespace "${environment}" --value 1 --timestamp "$(date +\"%Y-%m-%dT%H:%M:%SZ\")"
+    put_metric DeployCount "${name}-${environment}"
     exit 0
 fi
-aws cloudwatch put-metric-data --metric-name DeployFail --namespace "${environment}" --value 1 --timestamp "$(date +\"%Y-%m-%dT%H:%M:%SZ\")"
 echo "Service failed to stabilize!"
+put_metric DeployFail "${name}-${environment}"
 
 echo
 echo "Showing logs from recently stopped tasks:"
@@ -118,10 +126,9 @@ echo
 echo "* Rolling back to $blue_task_def_arn"
 if update_service "$blue_task_def_arn"; then
     echo "Rollback complete."
-    # Mark as rollback
-    aws cloudwatch put-metric-data --metric-name RollbackCount --namespace "${environment}" --value 1 --timestamp "$(date +\"%Y-%m-%dT%H:%M:%SZ\")"
+    put_metric RollbackCount "${name}-${environment}"
     exit 1
 fi
-aws cloudwatch put-metric-data --metric-name RollbackFail --namespace "${environment}" --value 1 --timestamp "$(date +\"%Y-%m-%dT%H:%M:%SZ\")"
 echo "Rollback failed!"
+put_metric RollbackFail "${name}-${environment}"
 exit 1

--- a/scripts/ecs-restart-services
+++ b/scripts/ecs-restart-services
@@ -14,6 +14,7 @@ usage() {
 echo "$0 $*"
 
 readonly environment="$1"
+# Cluster is always named `app-*` even for app-client-tls
 readonly cluster="app-${environment}"
 
 # Validate the environments
@@ -21,6 +22,15 @@ if [[ "${environment}" != "experimental" ]] && [[ "${environment}" != "staging" 
   echo "<environment> must be one of experimental, staging, or prod"
   exit 1
 fi
+
+# Put a dimensionless metric into cloudwatch
+put_metric() {
+    local metric_name="$1"
+    local namespace="$2"
+    local timestamp
+    timestamp=$(date +"%Y-%m-%dT%H:%M:%SZ")
+    aws cloudwatch put-metric-data --metric-name "${metric_name}" --namespace "${namespace}" --value 1 --timestamp "${timestamp}"
+}
 
 echo "* Restarting service \"app\" for cluster \"${cluster}\""
 aws ecs update-service --cluster "$cluster" --service app --force-new-deployment > /dev/null
@@ -33,7 +43,8 @@ time aws ecs wait services-stable --cluster "$cluster" --services app app-client
 readonly exit_code=$?
 
 echo "* Marking successful deploy in cloudwatch"
-aws cloudwatch put-metric-data --metric-name DeployCount --namespace "${environment}" --value 1 --timestamp "$(date +\"%Y-%m-%dT%H:%M:%SZ\")"
+put_metric DeployCount "app-${environment}"
+put_metric DeployCount "app-client-tls-${environment}"
 
 echo
 echo "****************************"

--- a/scripts/ecs-restart-services
+++ b/scripts/ecs-restart-services
@@ -32,6 +32,9 @@ echo "* Waiting for service \"app\" and \"app-client-tls\" to stabilize (this ta
 time aws ecs wait services-stable --cluster "$cluster" --services app app-client-tls
 readonly exit_code=$?
 
+echo "* Marking successful deploy in cloudwatch"
+aws cloudwatch put-metric-data --metric-name DeployCount --namespace "${environment}" --value 1 --timestamp "$(date +\"%Y-%m-%dT%H:%M:%SZ\")"
+
 echo
 echo "****************************"
 echo "Last 5 events for service \"app\":"

--- a/scripts/ecs-run-app-migrations-container
+++ b/scripts/ecs-run-app-migrations-container
@@ -82,10 +82,12 @@ exit_code=$(aws ecs describe-tasks --tasks "$task_arn" --cluster "$cluster" --qu
 
 if [[ $exit_code = "0" ]]; then
     echo "Task $task_arn finished."
+    aws cloudwatch put-metric-data --metric-name MigrationCount --namespace "${environment}" --value 1 --timestamp "$(date +\"%Y-%m-%dT%H:%M:%SZ\")"
     exit 0
 fi
 
 # announce task run failure
+aws cloudwatch put-metric-data --metric-name MigrationFail --namespace "${environment}" --value 1 --timestamp "$(date +\"%Y-%m-%dT%H:%M:%SZ\")"
 echo "Task $task_arn failed!"
 echo
 echo "If the log stream does not exist check the task description above for 'tasks[].stoppedReason'"

--- a/scripts/ecs-run-app-migrations-container
+++ b/scripts/ecs-run-app-migrations-container
@@ -40,6 +40,15 @@ show_logs() {
     echo
 }
 
+# Put a dimensionless metric into cloudwatch
+put_metric() {
+    local metric_name="$1"
+    local namespace="$2"
+    local timestamp
+    timestamp=$(date +"%Y-%m-%dT%H:%M:%SZ")
+    aws cloudwatch put-metric-data --metric-name "${metric_name}" --namespace "${namespace}" --value 1 --timestamp "${timestamp}"
+}
+
 # get network configuration from the cluster we'll run on
 echo "Get the network configuration for ${cluster}"
 network_configuration=$(aws ecs describe-services --services app --cluster "$cluster" --query 'services[0].networkConfiguration')
@@ -82,12 +91,12 @@ exit_code=$(aws ecs describe-tasks --tasks "$task_arn" --cluster "$cluster" --qu
 
 if [[ $exit_code = "0" ]]; then
     echo "Task $task_arn finished."
-    aws cloudwatch put-metric-data --metric-name MigrationCount --namespace "${environment}" --value 1 --timestamp "$(date +\"%Y-%m-%dT%H:%M:%SZ\")"
+    put_metric MigrationCount "${container_name}"
     exit 0
 fi
 
 # announce task run failure
-aws cloudwatch put-metric-data --metric-name MigrationFail --namespace "${environment}" --value 1 --timestamp "$(date +\"%Y-%m-%dT%H:%M:%SZ\")"
+put_metric MigrationFail "${container_name}"
 echo "Task $task_arn failed!"
 echo
 echo "If the log stream does not exist check the task description above for 'tasks[].stoppedReason'"


### PR DESCRIPTION
## Description

Requires https://github.com/transcom/ppp-infra/pull/595

There's no good way to see deploys and migrations with ECS. This adds custom metrics that simply count via a dimensionless metric.

You can see it here: https://us-west-2.console.aws.amazon.com/cloudwatch/home?region=us-west-2#metricsV2:graph=~(view~'timeSeries~stacked~false~region~'us-west-2~metrics~(~(~'Experimental~'DeployCount)));query=~'*7bExperimental*7d

## Code Review Verification Steps

* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/167954561) for this change