### PR TITLE
Update prettier to 1.18.2

### DIFF
--- a/cypress/integration/api/static/staticHosting.js
+++ b/cypress/integration/api/static/staticHosting.js
@@ -6,16 +6,14 @@ describe('static file hosting', () => {
   });
 
   it('returns the correct content type', () => {
-    cy
-      .request('/downloads/direct_deposit_form.pdf')
+    cy.request('/downloads/direct_deposit_form.pdf')
       .its('headers')
       .its('content-type')
       .should('include', 'application/pdf');
   });
 
   it('returns the correct status', () => {
-    cy
-      .request('/downloads/direct_deposit_form.pdf')
+    cy.request('/downloads/direct_deposit_form.pdf')
       .its('status')
       .should('equal', 200);
   });

--- a/cypress/integration/mymove/hhgPPM.js
+++ b/cypress/integration/mymove/hhgPPM.js
@@ -37,8 +37,7 @@ describe('service member adds a ppm to an hhg', function() {
 });
 
 function serviceMemberGoesBackToHomepage() {
-  cy
-    .get('.back-to-home')
+  cy.get('.back-to-home')
     .contains('BACK TO HOME')
     .click();
 
@@ -51,8 +50,7 @@ function serviceMemberEditsHHGMoveDates() {
   cy.get('[data-cy="edit-move"]').click();
   // TODO: Currently does not support changing move dates for 2019. Add test to edit dates ewhen fixed
 
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Save')
     .click();
 
@@ -143,8 +141,7 @@ function serviceMemberEditsPPMWeight() {
   cy.get('strong').contains('$3,460.33 - 3,824.57');
   cy.get('.subtext').contains('Originally $3,117.06 - 3,445.18');
 
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Save')
     .click();
 }
@@ -163,8 +160,7 @@ function serviceMemberEditsPPMDatesAndLocations() {
   cy.typeInInput({ name: 'pickup_postal_code', value: '91206' });
   cy.typeInInput({ name: 'destination_postal_code', value: '30813' });
 
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Save')
     .click();
 }
@@ -179,8 +175,7 @@ function serviceMemberVerifiesBackupContactInfoWasEdited() {
 }
 
 function serviceMemberEditsBackupContactInfoSection() {
-  cy
-    .get('.review-content .edit-section-link')
+  cy.get('.review-content .edit-section-link')
     .eq(3)
     .click();
 
@@ -188,8 +183,7 @@ function serviceMemberEditsBackupContactInfoSection() {
   cy.typeInInput({ name: 'email', value: 'backup@example.com' });
   cy.typeInInput({ name: 'telephone', value: '323-111-1111' });
 
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Save')
     .click();
 }
@@ -211,8 +205,7 @@ function serviceMemberVerifiesContactInfoWasEdited() {
 }
 
 function serviceMemberEditsContactInfoSection() {
-  cy
-    .get('.review-content .edit-section-link')
+  cy.get('.review-content .edit-section-link')
     .eq(2)
     .click();
 
@@ -232,8 +225,7 @@ function serviceMemberEditsContactInfoSection() {
   cy.get('select[name="backupAddress.state"]').select('CT');
   cy.typeInInput({ name: 'backupAddress.postal_code', value: '91206' });
 
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Save')
     .click();
 }
@@ -251,8 +243,7 @@ function serviceMemberVerifiesOrderWasEdited() {
 }
 
 function serviceMemberEditsOrdersSection() {
-  cy
-    .get('.review-content .edit-section-link')
+  cy.get('.review-content .edit-section-link')
     .eq(1)
     .click();
 
@@ -261,8 +252,7 @@ function serviceMemberEditsOrdersSection() {
   cy.typeInInput({ name: 'report_by_date', value: '9/1/2018' });
   cy.get('input[type="radio"]').check('no', { force: true }); // checks yes for both radios on form
   cy.selectDutyStation('NAS Fort Worth', 'new_duty_station');
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Save')
     .click();
 }
@@ -279,8 +269,7 @@ function serviceMemberVerifiesProfileWasEdited() {
 }
 
 function serviceMemberEditsProfileSection() {
-  cy
-    .get('.review-content .edit-section-link')
+  cy.get('.review-content .edit-section-link')
     .first()
     .click();
 
@@ -290,20 +279,17 @@ function serviceMemberEditsProfileSection() {
   cy.typeInInput({ name: 'suffix', value: 'Sr' });
   cy.get('select[name="affiliation"]').select('Air Force');
   cy.get('select[name="rank"]').select('E-9');
-  cy
-    .get('input[name="edipi"]')
+  cy.get('input[name="edipi"]')
     .clear()
     .type('9876543210');
   cy.selectDutyStation('NAS Fort Worth', 'current_station');
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Save')
     .click();
 }
 
 function serviceMemberClicksEditMove() {
-  cy
-    .get('.usa-button-secondary')
+  cy.get('.usa-button-secondary')
     .contains('Edit Move')
     .click();
 }
@@ -313,8 +299,7 @@ function serviceMemberSignsIn(uuid) {
 }
 
 function serviceMemberAddsPPMToHHG() {
-  cy
-    .get('.sidebar > div > button')
+  cy.get('.sidebar > div > button')
     .contains('Add PPM (DITY) Move')
     .click();
 
@@ -323,15 +308,13 @@ function serviceMemberAddsPPMToHHG() {
   });
 
   // does not have a back button on first flow page
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Back')
     .should('not.be.visible');
 }
 
 function serviceMemberCancelsAddPPMToHHG() {
-  cy
-    .get('.usa-button-secondary')
+  cy.get('.usa-button-secondary')
     .contains('Cancel')
     .click();
 
@@ -341,8 +324,7 @@ function serviceMemberCancelsAddPPMToHHG() {
 }
 
 function serviceMemberContinuesPPMSetup() {
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Continue Move Setup')
     .click();
 }
@@ -354,13 +336,11 @@ function serviceMemberFillsInDatesAndLocations() {
 
   cy.get('.wizard-header').should('contain', 'Move Setup');
   cy.get('.wizard-header .progress-timeline .current').should('contain', 'Move Setup');
-  cy
-    .get('.wizard-header .progress-timeline .step')
+  cy.get('.wizard-header .progress-timeline .step')
     .last()
     .should('contain', 'Review');
 
-  cy
-    .get('input[name="original_move_date"]')
+  cy.get('input[name="original_move_date"]')
     .should('have.value', '5/20/2018')
     .clear()
     .first()
@@ -381,8 +361,7 @@ function serviceMemberSelectsWeightRange() {
 
   cy.get('.wizard-header').should('contain', 'Move Setup');
   cy.get('.wizard-header .progress-timeline .current').should('contain', 'Move Setup');
-  cy
-    .get('.wizard-header .progress-timeline .step')
+  cy.get('.wizard-header .progress-timeline .step')
     .last()
     .should('contain', 'Review');
 
@@ -403,8 +382,7 @@ function serviceMemberCanCustomizeWeight() {
 
   cy.get('.wizard-header').should('contain', 'Move Setup');
   cy.get('.wizard-header .progress-timeline .current').should('contain', 'Move Setup');
-  cy
-    .get('.wizard-header .progress-timeline .step')
+  cy.get('.wizard-header .progress-timeline .step')
     .last()
     .should('contain', 'Review');
 
@@ -426,8 +404,7 @@ function serviceMemberCanReviewMoveSummary() {
 
   cy.get('.wizard-header .wizard-left').should('not.contain', 'Move Setup');
   cy.get('.wizard-header .wizard-left').should('contain', 'Review');
-  cy
-    .get('.wizard-header .progress-timeline .step')
+  cy.get('.wizard-header .progress-timeline .step')
     .first()
     .should('contain', 'Move Setup');
   cy.get('.wizard-header .progress-timeline .current').should('contain', 'Review');
@@ -454,19 +431,16 @@ function serviceMemberCanSignAgreement() {
   });
 
   cy.get('.wizard-header').should('contain', 'Review');
-  cy
-    .get('.wizard-header .progress-timeline .step')
+  cy.get('.wizard-header .progress-timeline .step')
     .first()
     .should('contain', 'Move Setup');
   cy.get('.wizard-header .progress-timeline .current').should('contain', 'Review');
 
-  cy
-    .get('body')
-    .should($div =>
-      expect($div.text()).to.include(
-        'Before officially booking your move, please carefully read and then sign the following.',
-      ),
-    );
+  cy.get('body').should($div =>
+    expect($div.text()).to.include(
+      'Before officially booking your move, please carefully read and then sign the following.',
+    ),
+  );
 
   cy.get('input[name="signature"]').type('Jane Doe');
   cy.nextPage();
@@ -480,8 +454,7 @@ function serviceMemberViewsUpdatedHomePage() {
   cy.get('.usa-alert-success').within(() => {
     cy.contains('Your PPM shipment is submitted');
     cy.contains('Next, wait for approval. Once approved:');
-    cy
-      .get('a')
+    cy.get('a')
       .contains('PPM info sheet')
       .should('have.attr', 'href')
       .and('include', '/downloads/ppm_info_sheet.pdf');
@@ -496,8 +469,7 @@ function serviceMemberViewsUpdatedHomePage() {
   cy.get('.usa-width-three-fourths').within(() => {
     // PPM information and details
     cy.contains('Next Step: Wait for approval');
-    cy
-      .contains('Go to certified weight scales')
+    cy.contains('Go to certified weight scales')
       .children('a')
       .should('have.attr', 'href', 'https://move.mil/resources/locator-maps');
     cy.contains('Weight (est.): 150');

--- a/cypress/integration/mymove/mymoveCSRFProtect.js
+++ b/cypress/integration/mymove/mymoveCSRFProtect.js
@@ -37,13 +37,11 @@ describe('testing CSRF protection updating user profile', function() {
     cy.visit('/moves/review/edit-profile');
 
     // update info
-    cy
-      .get('select[name=affiliation]')
+    cy.get('select[name=affiliation]')
       .should('exist')
       .should('have.value', 'ARMY');
 
-    cy
-      .get('input[name="middle_name"]')
+    cy.get('input[name="middle_name"]')
       .clear()
       .type('CSRF Test')
       .blur();
@@ -58,8 +56,7 @@ describe('testing CSRF protection updating user profile', function() {
     // reload page
     cy.visit('/moves/review/edit-profile');
 
-    cy
-      .get('input[name="middle_name"]')
+    cy.get('input[name="middle_name"]')
       .should('exist')
       .should('have.value', 'CSRF Test');
   });
@@ -70,8 +67,7 @@ describe('testing CSRF protection updating user profile', function() {
     cy.visit('/moves/review/edit-profile');
 
     // update info
-    cy
-      .get('input[name="middle_name"]')
+    cy.get('input[name="middle_name"]')
       .clear()
       .type('CSRF failed!')
       .blur();
@@ -87,8 +83,7 @@ describe('testing CSRF protection updating user profile', function() {
     // reload page
     cy.visit('/moves/review/edit-profile');
 
-    cy
-      .get('input[name="middle_name"]')
+    cy.get('input[name="middle_name"]')
       .should('exist')
       .should('not.have.value', 'CSRF failed!');
   });

--- a/cypress/integration/mymove/orders.js
+++ b/cypress/integration/mymove/orders.js
@@ -16,28 +16,25 @@ describe('orders entry', function() {
 
     cy.get('select[name="orders_type"]').select('Permanent Change Of Station');
 
-    cy
-      .get('input[name="issue_date"]')
+    cy.get('input[name="issue_date"]')
       .first()
       .click();
 
-    cy
-      .get('input[name="issue_date"]')
+    cy.get('input[name="issue_date"]')
       .first()
       .type('6/2/2018{enter}')
       .blur();
 
-    cy
-      .get('input[name="report_by_date"]')
+    cy.get('input[name="report_by_date"]')
       .last()
       .type('8/9/2018{enter}')
       .blur();
 
     // Choosing same current and destination duty station should block you from progressing and give an error
     cy.selectDutyStation('Yuma AFB', 'new_duty_station');
-    cy
-      .get('.usa-input-error-message')
-      .contains('You entered the same duty station for your origin and destination. Please change one of them.');
+    cy.get('.usa-input-error-message').contains(
+      'You entered the same duty station for your origin and destination. Please change one of them.',
+    );
     cy.get('button.next').should('be.disabled');
 
     cy.selectDutyStation('NAS Fort Worth', 'new_duty_station');

--- a/cypress/integration/mymove/ppm.js
+++ b/cypress/integration/mymove/ppm.js
@@ -14,18 +14,15 @@ describe('completing the ppm flow', function() {
       expect(loc.pathname).to.match(/^\/moves\/[^/]+\/ppm-start/);
     });
     cy.get('.wizard-header').should('not.exist');
-    cy
-      .get('input[name="original_move_date"]')
+    cy.get('input[name="original_move_date"]')
       .first()
       .type('9/2/2018{enter}')
       .blur();
-    cy
-      .get('input[name="pickup_postal_code"]')
+    cy.get('input[name="pickup_postal_code"]')
       .clear()
       .type('80913');
 
-    cy
-      .get('input[name="destination_postal_code"]')
+    cy.get('input[name="destination_postal_code"]')
       .clear()
       .type('76127');
 
@@ -82,8 +79,7 @@ describe('completing the ppm flow', function() {
     cy.get('.usa-alert-success').within(() => {
       cy.contains('Congrats - your move is submitted!');
       cy.contains('Next, wait for approval. Once approved:');
-      cy
-        .get('a')
+      cy.get('a')
         .contains('PPM info sheet')
         .should('have.attr', 'href')
         .and('include', '/downloads/ppm_info_sheet.pdf');
@@ -100,33 +96,28 @@ describe('check invalid ppm inputs', () => {
       expect(loc.pathname).to.match(/^\/moves\/[^/]+\/ppm-start/);
     });
     cy.get('.wizard-header').should('not.exist');
-    cy
-      .get('input[name="original_move_date"]')
+    cy.get('input[name="original_move_date"]')
       .type('6/3/2100')
       .blur();
     // test an invalid pickup zip code
-    cy
-      .get('input[name="pickup_postal_code"]')
+    cy.get('input[name="pickup_postal_code"]')
       .clear()
       .type('00000')
       .blur();
     cy.get('#pickup_postal_code-error').should('exist');
 
-    cy
-      .get('input[name="pickup_postal_code"]')
+    cy.get('input[name="pickup_postal_code"]')
       .clear()
       .type('80913');
 
     // test an invalid destination zip code
-    cy
-      .get('input[name="destination_postal_code"]')
+    cy.get('input[name="destination_postal_code"]')
       .clear()
       .type('00000')
       .blur();
     cy.get('#destination_postal_code-error').should('exist');
 
-    cy
-      .get('input[name="destination_postal_code"]')
+    cy.get('input[name="destination_postal_code"]')
       .clear()
       .type('30813');
     cy.nextPage();
@@ -145,17 +136,14 @@ describe('check invalid ppm inputs', () => {
       expect(loc.pathname).to.match(/^\/moves\/[^/]+\/ppm-start/);
     });
     cy.get('.wizard-header').should('not.exist');
-    cy
-      .get('input[name="original_move_date"]')
+    cy.get('input[name="original_move_date"]')
       .first()
       .type('9/2/2018{enter}')
       .blur();
-    cy
-      .get('input[name="pickup_postal_code"]')
+    cy.get('input[name="pickup_postal_code"]')
       .clear()
       .type('80913');
-    cy
-      .get('input[name="destination_postal_code"]')
+    cy.get('input[name="destination_postal_code"]')
       .type('80913')
       .blur();
 
@@ -166,8 +154,7 @@ describe('check invalid ppm inputs', () => {
 describe('editing ppm only move', () => {
   it('sees only details relevant to PPM only move', () => {
     cy.signInAsUserPostRequest(milmoveAppName, 'e10d5964-c070-49cb-9bd1-eaf9f7348eb6');
-    cy
-      .get('.sidebar button')
+    cy.get('.sidebar button')
       .contains('Edit Move')
       .click();
 
@@ -195,13 +182,11 @@ describe('allows a SM to continue requesting a payment', function() {
     serviceMemberStartsPPMPaymentRequest();
     serviceMemberSubmitsWeightTicket('CAR', true);
 
-    cy
-      .get('button')
+    cy.get('button')
       .contains('Finish Later')
       .click();
 
-    cy
-      .get('button')
+    cy.get('button')
       .contains('OK')
       .click();
 
@@ -209,8 +194,7 @@ describe('allows a SM to continue requesting a payment', function() {
       expect(loc.pathname).to.match(/^\/$/);
     });
 
-    cy
-      .get('.usa-button-secondary')
+    cy.get('.usa-button-secondary')
       .contains('Continue Requesting Payment')
       .click();
     cy.location().should(loc => {
@@ -275,16 +259,14 @@ describe('allows a SM to request a payment', function() {
     cy.upload_file('[data-cy=full-weight-upload] .filepond--root', 'top-secret.png');
     cy.wait('@postUploadDocument');
     cy.get('[data-filepond-item-state="processing-complete"]').should('have.length', 1);
-    cy
-      .get('input[name="weight_ticket_date"]')
+    cy.get('input[name="weight_ticket_date"]')
       .type('6/2/2018{enter}')
       .blur();
 
     cy.get('input[name="additional_weight_ticket"][value="Yes"]').should('not.be.checked');
     cy.get('input[name="additional_weight_ticket"][value="No"]').should('be.checked');
     cy.get('input[name="additional_weight_ticket"][value="Yes"]+label').click();
-    cy
-      .get('button')
+    cy.get('button')
       .contains('Save & Add Another')
       .should('be.enabled');
   });
@@ -307,8 +289,7 @@ describe('allows a SM to request a payment', function() {
     cy.get('input[name="additional_weight_ticket"][value="Yes"]').should('not.be.checked');
     cy.get('input[name="additional_weight_ticket"][value="No"]').should('be.checked');
     cy.get('input[name="additional_weight_ticket"][value="Yes"]+label').click();
-    cy
-      .get('button')
+    cy.get('button')
       .contains('Save & Add Another')
       .should('be.enabled');
   });
@@ -347,14 +328,12 @@ describe('allows a SM to request a payment', function() {
     cy.visit(`/moves/${moveID}/ppm-weight-ticket`);
 
     serviceMemberSubmitsWeightTicket('CAR', true);
-    cy
-      .get('[data-cy=skip]')
+    cy.get('[data-cy=skip]')
       .contains('Skip')
       .click();
     serviceMemberViewsExpensesLandingPage();
     serviceMemberUploadsExpenses();
-    cy
-      .get('[data-cy=skip]')
+    cy.get('[data-cy=skip]')
       .contains('Skip')
       .click();
   });
@@ -364,15 +343,13 @@ function serviceMemberReviewsDocuments() {
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/moves\/[^/]+\/ppm-payment-review/);
   });
-  cy
-    .get('.review-customer-agreement a')
+  cy.get('.review-customer-agreement a')
     .contains('Legal Agreement')
     .click();
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/ppm-customer-agreement/);
   });
-  cy
-    .get('.usa-button-secondary')
+  cy.get('.usa-button-secondary')
     .contains('Back')
     .click();
   cy.location().should(loc => {
@@ -380,8 +357,7 @@ function serviceMemberReviewsDocuments() {
   });
   cy.get('input[id="agree-checkbox"]').check({ force: true });
   cy.contains(`You're requesting a payment of $`);
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Submit Request')
     .should('be.enabled')
     .click();
@@ -390,30 +366,25 @@ function serviceMemberReviewsDocuments() {
   cy.contains("We're reviewing your payment request for $");
 }
 function serviceMemberEditsPaymentRequest() {
-  cy
-    .get('.usa-alert-success')
+  cy.get('.usa-alert-success')
     .contains('Payment request submitted')
     .should('exist');
-  cy
-    .get('.usa-button-secondary')
+  cy.get('.usa-button-secondary')
     .contains('Edit Payment Request')
     .should('exist')
     .click();
-  cy
-    .get('[data-cy=weight-ticket-link]')
+  cy.get('[data-cy=weight-ticket-link]')
     .should('exist')
     .click();
   serviceMemberSubmitsWeightTicket('CAR', false);
   serviceMemberReviewsDocuments();
 }
 function serviceMemberAddsWeightTicketSetWithMissingDocuments() {
-  cy
-    .get('.usa-button-secondary')
+  cy.get('.usa-button-secondary')
     .contains('Edit Payment Request')
     .should('exist')
     .click();
-  cy
-    .get('[data-cy=weight-ticket-link]')
+  cy.get('[data-cy=weight-ticket-link]')
     .should('exist')
     .click();
 
@@ -427,31 +398,26 @@ function serviceMemberAddsWeightTicketSetWithMissingDocuments() {
   cy.get('input[name="full_weight"]').type('5000');
   cy.get('input[name="missingFullWeightTicket"]').check({ force: true });
 
-  cy
-    .get('input[name="weight_ticket_date"]')
+  cy.get('input[name="weight_ticket_date"]')
     .type('6/2/2018{enter}')
     .blur();
   cy.get('input[name="additional_weight_ticket"][value="Yes"]').should('not.be.checked');
   cy.get('input[name="additional_weight_ticket"][value="No"]').should('be.checked');
 
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Save & Continue')
     .click();
-  cy
-    .wait('@postWeightTicket')
+  cy.wait('@postWeightTicket')
     .its('status')
     .should('eq', 200);
 
-  cy
-    .get('.review-customer-agreement a')
+  cy.get('.review-customer-agreement a')
     .contains('Legal Agreement')
     .click();
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/ppm-customer-agreement/);
   });
-  cy
-    .get('.usa-button-secondary')
+  cy.get('.usa-button-secondary')
     .contains('Back')
     .click();
   cy.location().should(loc => {
@@ -461,8 +427,7 @@ function serviceMemberAddsWeightTicketSetWithMissingDocuments() {
 
   cy.get('input[id="agree-checkbox"]').check({ force: true });
 
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Submit Request')
     .should('be.enabled')
     .click();
@@ -470,9 +435,9 @@ function serviceMemberAddsWeightTicketSetWithMissingDocuments() {
   cy.wait('@requestPayment');
 
   cy.get('.usa-alert-warning').contains('Payment request is missing info');
-  cy
-    .get('.usa-alert-warning')
-    .contains('You will need to contact your local PPPO office to resolve your missing weight ticket.');
+  cy.get('.usa-alert-warning').contains(
+    'You will need to contact your local PPPO office to resolve your missing weight ticket.',
+  );
 
   cy.get('.title').contains('Next step: Contact the PPPO office');
   cy.get('.missing-label').contains('Unknown');
@@ -483,22 +448,18 @@ function serviceMemberViewsExpensesLandingPage() {
   });
 
   cy.get('[data-cy=documents-uploaded]').should('exist');
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Continue')
     .should('be.disabled');
 
-  cy
-    .get('[type="radio"]')
+  cy.get('[type="radio"]')
     .first()
     .should('be.not.checked');
-  cy
-    .get('[type="radio"]')
+  cy.get('[type="radio"]')
     .last()
     .should('be.not.checked');
 
-  cy
-    .get('a')
+  cy.get('a')
     .contains('More about expenses')
     .should('have.attr', 'href')
     .and('match', /^\/allowable-expenses/);
@@ -507,8 +468,7 @@ function serviceMemberViewsExpensesLandingPage() {
   cy.get('input[name="hasExpenses"][value="No"]').should('not.be.checked');
   cy.get('input[name="hasExpenses"][value="Yes"]+label').click();
 
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Continue')
     .should('be.enabled')
     .click();
@@ -539,24 +499,20 @@ function serviceMemberUploadsExpenses(hasAnother = true, expenseNumber = null) {
   cy.get('input[name="haveMoreExpenses"][value="No"]').should('be.checked');
   cy.get('input[name="haveMoreExpenses"][value="Yes"]+label').click();
   if (hasAnother) {
-    cy
-      .get('button')
+    cy.get('button')
       .contains('Save & Add Another')
       .click();
-    cy
-      .wait('@postMovingExpense')
+    cy.wait('@postMovingExpense')
       .its('status')
       .should('eq', 200);
     cy.get('[data-cy=documents-uploaded]').should('exist');
   } else {
     cy.get('input[name="haveMoreExpenses"][value="No"]+label').click();
     cy.get('input[name="haveMoreExpenses"][value="No"]').should('be.checked');
-    cy
-      .get('button')
+    cy.get('button')
       .contains('Save & Continue')
       .click();
-    cy
-      .wait('@postMovingExpense')
+    cy.wait('@postMovingExpense')
       .its('status')
       .should('eq', 200);
   }
@@ -567,8 +523,7 @@ function serviceMemberSubmitsCarTrailerWeightTicket() {
 
   cy.get('input[name="vehicle_nickname"]').type('Nickname');
 
-  cy
-    .contains('Do you own this trailer')
+  cy.contains('Do you own this trailer')
     .children('a')
     .should('have.attr', 'href', '/trailer-criteria');
 
@@ -589,8 +544,7 @@ function serviceMemberSubmitsCarTrailerWeightTicket() {
   cy.upload_file('.filepond--root:last', 'top-secret.png');
   cy.wait('@postUploadDocument');
   cy.get('[data-filepond-item-state="processing-complete"]').should('have.length', 2);
-  cy
-    .get('input[name="weight_ticket_date"]')
+  cy.get('input[name="weight_ticket_date"]')
     .type('6/2/2018{enter}')
     .blur();
 
@@ -611,18 +565,15 @@ function serviceMemberCanFinishWeightTicketLater(vehicleType) {
   cy.upload_file('[data-cy=full-weight-upload] .filepond--root', 'top-secret.png');
   cy.wait('@postUploadDocument');
   cy.get('[data-filepond-item-state="processing-complete"]').should('have.length', 2);
-  cy
-    .get('input[name="weight_ticket_date"]')
+  cy.get('input[name="weight_ticket_date"]')
     .type('6/2/2018{enter}')
     .blur();
 
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Finish Later')
     .click();
 
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Cancel')
     .click();
 
@@ -630,13 +581,11 @@ function serviceMemberCanFinishWeightTicketLater(vehicleType) {
     expect(loc.pathname).to.match(/^\/moves\/[^/]+\/ppm-weight-ticket/);
   });
 
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Finish Later')
     .click();
 
-  cy
-    .get('button')
+  cy.get('button')
     .contains('OK')
     .click();
 
@@ -652,32 +601,24 @@ function serviceMemberSubmitsWeightsTicketsWithoutReceipts() {
   cy.get('input[name="full_weight"]').type('2000');
   cy.get('input[name="isValidTrailer"][value="Yes"]+label').click();
   cy.get('input[name="missingDocumentation"]+label').click();
-  cy
-    .get('[data-cy=trailer-warning]')
-    .contains(
-      'If your state does not provide a registration or bill of sale for your trailer, you may write and upload a signed and dated statement certifying that you or your spouse own the trailer and meets the trailer criteria. Upload your statement using the proof of ownership field.',
-    );
+  cy.get('[data-cy=trailer-warning]').contains(
+    'If your state does not provide a registration or bill of sale for your trailer, you may write and upload a signed and dated statement certifying that you or your spouse own the trailer and meets the trailer criteria. Upload your statement using the proof of ownership field.',
+  );
   cy.get('input[name="missingEmptyWeightTicket"]+label').click();
-  cy
-    .get('[data-cy=empty-warning]')
-    .contains(
-      'Contact your local Transportation Office (PPPO) to let them know you’re missing this weight ticket. For now, keep going and enter the info you do have.',
-    );
+  cy.get('[data-cy=empty-warning]').contains(
+    'Contact your local Transportation Office (PPPO) to let them know you’re missing this weight ticket. For now, keep going and enter the info you do have.',
+  );
   cy.get('input[name="missingFullWeightTicket"]+label').click();
-  cy
-    .get('[data-cy=full-warning]')
-    .contains(
-      'Contact your local Transportation Office (PPPO) to let them know you’re missing this weight ticket. For now, keep going and enter the info you do have.',
-    );
-  cy
-    .get('input[name="weight_ticket_date"]')
+  cy.get('[data-cy=full-warning]').contains(
+    'Contact your local Transportation Office (PPPO) to let them know you’re missing this weight ticket. For now, keep going and enter the info you do have.',
+  );
+  cy.get('input[name="weight_ticket_date"]')
     .type('6/2/2018{enter}')
     .blur();
 
   cy.get('input[name="additional_weight_ticket"][value="Yes"]+label').click();
   cy.get('input[name="additional_weight_ticket"][value="Yes"]').should('be.checked');
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Save & Add Another')
     .click();
   cy.wait('@postWeightTicket');
@@ -685,12 +626,10 @@ function serviceMemberSubmitsWeightsTicketsWithoutReceipts() {
 
 function serviceMemberStartsPPMPaymentRequest() {
   cy.contains('Request Payment').click();
-  cy
-    .get('input[name="actual_move_date"]')
+  cy.get('input[name="actual_move_date"]')
     .type('6/20/2018{enter}')
     .blur();
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Get Started')
     .click();
 }
@@ -719,8 +658,7 @@ function serviceMemberSubmitsWeightTicket(vehicleType, hasAnother = true, ordina
   cy.upload_file('[data-cy=full-weight-upload] .filepond--root', 'top-secret.png');
   cy.wait('@postUploadDocument');
   cy.get('[data-filepond-item-state="processing-complete"]').should('have.length', 2);
-  cy
-    .get('input[name="weight_ticket_date"]')
+  cy.get('input[name="weight_ticket_date"]')
     .type('6/2/2018{enter}')
     .blur();
   cy.get('input[name="additional_weight_ticket"][value="Yes"]').should('not.be.checked');
@@ -728,22 +666,18 @@ function serviceMemberSubmitsWeightTicket(vehicleType, hasAnother = true, ordina
   if (hasAnother) {
     cy.get('input[name="additional_weight_ticket"][value="Yes"]+label').click();
     cy.get('input[name="additional_weight_ticket"][value="Yes"]').should('be.checked');
-    cy
-      .get('button')
+    cy.get('button')
       .contains('Save & Add Another')
       .click();
-    cy
-      .wait('@postWeightTicket')
+    cy.wait('@postWeightTicket')
       .its('status')
       .should('eq', 200);
     cy.get('[data-cy=documents-uploaded]').should('exist');
   } else {
-    cy
-      .get('button')
+    cy.get('button')
       .contains('Save & Continue')
       .click();
-    cy
-      .wait('@postWeightTicket')
+    cy.wait('@postWeightTicket')
       .its('status')
       .should('eq', 200);
   }
@@ -751,8 +685,7 @@ function serviceMemberSubmitsWeightTicket(vehicleType, hasAnother = true, ordina
 
 function serviceMemberStartsPPMPaymentRequestWithAssertions() {
   cy.contains('Request Payment').click();
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Get Started')
     .should('be.disabled');
   cy.location().should(loc => {
@@ -769,8 +702,7 @@ function serviceMemberStartsPPMPaymentRequestWithAssertions() {
 
   cy.get('h3').contains('Example weight ticket scenarios');
 
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Back')
     .click();
 
@@ -778,8 +710,7 @@ function serviceMemberStartsPPMPaymentRequestWithAssertions() {
     expect(loc.pathname).to.match(/^\/moves\/[^/]+\/ppm-payment-request-intro/);
   });
 
-  cy
-    .get('a')
+  cy.get('a')
     .contains('More about expenses')
     .click();
 
@@ -789,17 +720,14 @@ function serviceMemberStartsPPMPaymentRequestWithAssertions() {
 
   cy.get('h3').contains('Storage & Moving Expenses');
 
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Back')
     .click();
 
-  cy
-    .get('input[name="actual_move_date"]')
+  cy.get('input[name="actual_move_date"]')
     .type('6/20/2018{enter}')
     .blur();
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Get Started')
     .click();
 }

--- a/cypress/integration/mymove/serviceMemberProfile.js
+++ b/cypress/integration/mymove/serviceMemberProfile.js
@@ -18,8 +18,7 @@ describe('setting up service member profile requiring an access code', function(
 
 function serviceMemberEntersAccessCode() {
   cy.get('input[name="claim_access_code"]').type('PPM-X3FQJK');
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Continue')
     .click();
 }
@@ -27,14 +26,12 @@ function serviceMemberEntersAccessCode() {
 function serviceMemberProfile(reloadAfterEveryPage) {
   //dod info
   // does not have welcome message throughout setup
-  cy
-    .get('span')
+  cy.get('span')
     .contains('Welcome,')
     .should('not.exist');
 
   // does not have a back button on first flow page
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Back')
     .should('not.be.visible');
 
@@ -61,8 +58,7 @@ function serviceMemberProfile(reloadAfterEveryPage) {
   //contact info
   cy.get('button.next').should('be.disabled');
   cy.get('input[name="telephone"]').type('6784567890');
-  cy
-    .get('[type="checkbox"]')
+  cy.get('[type="checkbox"]')
     .not('[disabled]')
     .check({ force: true })
     .should('be.checked');
@@ -87,15 +83,13 @@ function serviceMemberProfile(reloadAfterEveryPage) {
   cy.get('input[name="street_address_1"]').type('123 main');
   cy.get('input[name="city"]').type('Anytown');
   cy.get('select[name="state"]').select('CO');
-  cy
-    .get('input[name="postal_code"]')
+  cy.get('input[name="postal_code"]')
     .clear()
     .type('00001')
     .blur();
   cy.get('#postal_code-error').should('exist');
   cy.get('button.next').should('be.disabled');
-  cy
-    .get('input[name="postal_code"]')
+  cy.get('input[name="postal_code"]')
     .clear()
     .type('80913');
   cy.get('#postal_code-error').should('not.exist');

--- a/cypress/integration/office/cancelAndStartNewMove.js
+++ b/cypress/integration/office/cancelAndStartNewMove.js
@@ -7,19 +7,16 @@ describe('office user finds the move', () => {
     cy.patientVisit('/queues/new/moves/0db80bd6-de75-439e-bf89-deaafa1d0dc9/ppm');
 
     // Find the Cancel Move button
-    cy
-      .get('button')
+    cy.get('button')
       .contains('Cancel Move')
       .click();
 
     // Enter cancel reason
     cy.get('.cancel-panel textarea:first').type('Canceling this move as a test!');
-    cy
-      .get('.cancel-panel button')
+    cy.get('.cancel-panel button')
       .contains('Cancel Move')
       .click();
-    cy
-      .get('.cancel-panel button')
+    cy.get('.cancel-panel button')
       .contains('Yes, Cancel Move')
       .click();
     cy.get('.usa-alert-success').contains('Move #CANCEL for Submitted, PPM has been canceled');
@@ -31,8 +28,7 @@ describe('office user finds the move', () => {
     cy.contains('Your move was canceled');
 
     // User clicks on Start a new move and proceeds to orders page
-    cy
-      .get('button')
+    cy.get('button')
       .contains('Start')
       .click();
 

--- a/cypress/integration/office/datesPanel.js
+++ b/cypress/integration/office/datesPanel.js
@@ -24,8 +24,7 @@ function officeUserGoesToDatesPanel(locator) {
     expect(loc.pathname).to.match(/^\/queues\/new\/moves\/[^/]+\/basics/);
   });
 
-  cy
-    .get('.title')
+  cy.get('.title')
     .contains('HHG')
     .click();
 
@@ -33,8 +32,7 @@ function officeUserGoesToDatesPanel(locator) {
     expect(loc.pathname).to.match(/^\/queues\/new\/moves\/[^/]+\/hhg/);
   });
 
-  cy
-    .get('.editable-panel-header')
+  cy.get('.editable-panel-header')
     .contains('Dates')
     .siblings()
     .click();

--- a/cypress/integration/office/documentViewer.js
+++ b/cypress/integration/office/documentViewer.js
@@ -31,8 +31,7 @@ describe('The document viewer', function() {
     });
     it('can upload a new document', () => {
       cy.patientVisit('/moves/c9df71f2-334f-4f0e-b2e7-050ddb22efa1/documents');
-      cy
-        .get('[data-cy="document-upload-link"]')
+      cy.get('[data-cy="document-upload-link"]')
         .find('a')
         .should('have.attr', 'href')
         .and('contain', '/moves/c9df71f2-334f-4f0e-b2e7-050ddb22efa1/documents/new');
@@ -46,8 +45,7 @@ describe('The document viewer', function() {
       cy.get('button.submit').should('be.disabled');
 
       cy.upload_file('.filepond--root', 'top-secret.png');
-      cy
-        .get('button.submit', { timeout: fileUploadTimeout })
+      cy.get('button.submit', { timeout: fileUploadTimeout })
         .should('not.be.disabled')
         .click();
     });
@@ -61,8 +59,7 @@ describe('The document viewer', function() {
       cy.get('button.submit').should('be.disabled');
 
       cy.upload_file('.filepond--root', 'top-secret.png');
-      cy
-        .get('button.submit', { timeout: fileUploadTimeout })
+      cy.get('button.submit', { timeout: fileUploadTimeout })
         .should('not.be.disabled')
         .click();
 
@@ -78,8 +75,7 @@ describe('The document viewer', function() {
 
       cy.get('select[name="moveDocument.status"]').select('OK');
 
-      cy
-        .get('button')
+      cy.get('button')
         .contains('Save')
         .should('not.be.disabled')
         .click();
@@ -94,8 +90,7 @@ describe('The document viewer', function() {
       cy.patientVisit('/moves/c9df71f2-334f-4f0e-b2e7-050ddb22efa1/documents');
       cy.contains('All Documents (2)');
       cy.contains('super secret info document');
-      cy
-        .get('.panel-field')
+      cy.get('.panel-field')
         .find('a')
         .should('have.attr', 'href')
         .and('match', /^\/moves\/[^/]+\/documents\/[^/]+/);
@@ -113,16 +108,14 @@ describe('The document viewer', function() {
       cy.get('button.submit').should('be.disabled');
 
       cy.upload_file('.filepond--root', 'top-secret.png');
-      cy
-        .get('button.submit', { timeout: fileUploadTimeout })
+      cy.get('button.submit', { timeout: fileUploadTimeout })
         .should('not.be.disabled')
         .click();
     });
     it('can select and update newly-uploaded expense document', () => {
       cy.patientVisit('/moves/c9df71f2-334f-4f0e-b2e7-050ddb22efa1/documents');
       cy.contains('expense document');
-      cy
-        .get('.panel-field')
+      cy.get('.panel-field')
         .find('a')
         .should('have.attr', 'href')
         .and('match', /^\/moves\/[^/]+\/documents\/[^/]+/);
@@ -140,8 +133,7 @@ describe('The document viewer', function() {
       cy.get('select[name="moveDocument.payment_method"]').select('GTCC');
       cy.get('select[name="moveDocument.status"]').select('OK');
 
-      cy
-        .get('button')
+      cy.get('button')
         .contains('Save')
         .should('not.be.disabled')
         .click();
@@ -151,8 +143,7 @@ describe('The document viewer', function() {
     it('can update expense document to other doc type', () => {
       cy.patientVisit('/moves/c9df71f2-334f-4f0e-b2e7-050ddb22efa1/documents');
       cy.contains('expense document');
-      cy
-        .get('.panel-field')
+      cy.get('.panel-field')
         .find('a')
         .should('have.attr', 'href')
         .and('match', /^\/moves\/[^/]+\/documents\/[^/]+/);
@@ -164,24 +155,21 @@ describe('The document viewer', function() {
 
       cy.get('select[name="moveDocument.move_document_type"]').select('Other document type');
 
-      cy
-        .get('button')
+      cy.get('button')
         .contains('Save')
         .should('not.be.disabled')
         .click();
 
       cy.contains('Other document type');
 
-      cy
-        .get('.field-title')
+      cy.get('.field-title')
         .contains('Expense Type')
         .should('not.exist');
     });
     it('can update other document type back to expense type', () => {
       cy.patientVisit('/moves/c9df71f2-334f-4f0e-b2e7-050ddb22efa1/documents');
       cy.contains('expense document');
-      cy
-        .get('.panel-field')
+      cy.get('.panel-field')
         .find('a')
         .should('have.attr', 'href')
         .and('match', /^\/moves\/[^/]+\/documents\/[^/]+/);
@@ -197,8 +185,7 @@ describe('The document viewer', function() {
       cy.get('select[name="moveDocument.payment_method"]').select('GTCC');
       cy.get('select[name="moveDocument.status"]').select('OK');
 
-      cy
-        .get('button')
+      cy.get('button')
         .contains('Save')
         .should('not.be.disabled')
         .click();
@@ -221,8 +208,7 @@ describe('The document viewer', function() {
       cy.get('button.submit').should('be.disabled');
 
       cy.upload_file('.filepond--root', 'top-secret.png');
-      cy
-        .get('button.submit', { timeout: fileUploadTimeout })
+      cy.get('button.submit', { timeout: fileUploadTimeout })
         .should('not.be.disabled')
         .click();
 
@@ -232,8 +218,7 @@ describe('The document viewer', function() {
       cy.get('input[name="title"]').type('Wait ticket');
       cy.get('input[name="notes"]').type('wait for this document');
       cy.upload_file('.filepond--root', 'top-secret.png');
-      cy
-        .get('button.submit', { timeout: fileUploadTimeout })
+      cy.get('button.submit', { timeout: fileUploadTimeout })
         .should('not.be.disabled')
         .click();
 
@@ -250,8 +235,7 @@ describe('The document viewer', function() {
         expect(loc.pathname).to.match(/^\/queues\/new/);
       });
 
-      cy
-        .get('div')
+      cy.get('div')
         .contains('Delivered')
         .click();
 
@@ -263,8 +247,7 @@ describe('The document viewer', function() {
 
       cy.get('[data-cy="hhg-tab"]').click();
 
-      cy
-        .get('[data-cy=invoice-panel]')
+      cy.get('[data-cy=invoice-panel]')
         .get('[data-cy=unbilled-table]')
         .find('tbody tr')
         .should(rows => {

--- a/cypress/integration/office/homepage.js
+++ b/cypress/integration/office/homepage.js
@@ -58,8 +58,7 @@ function officeAllMoves() {
     expect(loc.pathname).to.match(/^\/queues\/all/);
   });
 
-  cy
-    .get('[data-cy=locator]')
+  cy.get('[data-cy=locator]')
     .contains('NOSHOW')
     .should('not.exist');
 }

--- a/cypress/integration/office/invoicing.js
+++ b/cypress/integration/office/invoicing.js
@@ -20,8 +20,7 @@ function checkNoUnbilledLineItems() {
   cy.patientVisit('/queues/new/moves/6eee3663-1973-40c5-b49e-e70e9325b895/hhg');
 
   // The invoice table should be empty.
-  cy
-    .get('[data-cy=invoice-panel] [data-cy=basic-panel-content]')
+  cy.get('[data-cy=invoice-panel] [data-cy=basic-panel-content]')
     .find('span.empty-content')
     .should('have.text', 'No line items');
 }
@@ -31,8 +30,7 @@ function checkExistUnbilledLineItems() {
   cy.patientVisit('/queues/new/moves/fb4105cf-f5a5-43be-845e-d59fdb34f31c/hhg');
 
   // The invoice table should display the unbilled line items.
-  cy
-    .get('[data-cy=invoice-panel] [data-cy=basic-panel-content] tbody')
+  cy.get('[data-cy=invoice-panel] [data-cy=basic-panel-content] tbody')
     .children()
     // For each line item, I should see item code, description, etc.
     .each((row, index, lst) => {
@@ -41,8 +39,7 @@ function checkExistUnbilledLineItems() {
         return;
       }
 
-      cy
-        .wrap(row)
+      cy.wrap(row)
         .children()
         .each(cell => {
           // Each cell should have a value present.
@@ -70,23 +67,19 @@ function checkConfirmationDialogue() {
   cy.patientVisit('/queues/new/moves/fb4105cf-f5a5-43be-845e-d59fdb34f31c/hhg');
 
   cy.get('[data-cy=invoice-panel]').within(() => {
-    cy
-      .get('button')
+    cy.get('button')
       .first()
       .click();
 
-    cy
-      .get('.usa-button-primary')
+    cy.get('.usa-button-primary')
       .first()
       .should('have.text', 'Approve');
 
-    cy
-      .get('.usa-button-secondary')
+    cy.get('.usa-button-secondary')
       .first()
       .should('have.text', 'Cancel');
 
-    cy
-      .get('.usa-button-secondary')
+    cy.get('.usa-button-secondary')
       .first()
       .click();
 
@@ -102,20 +95,17 @@ function checkApproveInvoice() {
   cy.get('[data-cy="unbilled-table"]').within(() => {
     // Count the number of unbilled line items and amount total (we'll use this later)
     cy.get('tr[data-cy="table--item"]').as('unbilledItems');
-    cy
-      .get('tr[data-cy="table--total"] td')
+    cy.get('tr[data-cy="table--total"] td')
       .last()
       .as('unbilledTotal');
 
     // Find/click approve button
-    cy
-      .get('button')
+    cy.get('button')
       .should('have.text', 'Approve Payment')
       .click();
 
     // Find/click second approve button
-    cy
-      .get('.usa-button-primary')
+    cy.get('.usa-button-primary')
       .should('have.text', 'Approve')
       .click();
 
@@ -138,8 +128,7 @@ function checkApproveInvoice() {
 
     // Confirm total of invoiced matches previous unbilled amount
     cy.get('@unbilledTotal').then($unbilledTotal => {
-      cy
-        .get('tr[data-cy="table--total"] td')
+      cy.get('tr[data-cy="table--total"] td')
         .last()
         .should('have.text', $unbilledTotal.text());
     });

--- a/cypress/integration/office/locationsPanel.js
+++ b/cypress/integration/office/locationsPanel.js
@@ -73,18 +73,15 @@ function officeUserViewsLocation({ shipmentId, type, expectation }) {
     expect(loc.pathname).to.match(/^\/queues\/new\/moves\/[^/]+\/basics/);
   });
 
-  cy
-    .get('a')
+  cy.get('a')
     .contains('HHG')
     .click(); // navtab
 
   // Expect Customer Info to be loaded
-  cy
-    .contains('Locations')
+  cy.contains('Locations')
     .parents('.editable-panel')
     .within(() => {
-      cy
-        .contains(type)
+      cy.contains(type)
         .parent('.editable-panel-column')
         .children('.panel-field')
         .children('.field-value')
@@ -140,168 +137,140 @@ function officeUserEntersLocations() {
     expect(loc.pathname).to.match(/^\/queues\/new\/moves\/[^/]+\/basics/);
   });
 
-  cy
-    .get('a')
+  cy.get('a')
     .contains('HHG')
     .click(); // navtab
 
-  cy
-    .get('.editable-panel-header')
+  cy.get('.editable-panel-header')
     .contains('Locations')
     .siblings()
     .click();
 
   // Enter details in form and save locations
-  cy
-    .get('input[name="pickup_address.street_address_1"]')
+  cy.get('input[name="pickup_address.street_address_1"]')
     .first()
     .clear()
     .type(pickupAddress.street_1)
     .blur();
-  cy
-    .get('input[name="pickup_address.city"]')
+  cy.get('input[name="pickup_address.city"]')
     .first()
     .clear()
     .type(pickupAddress.city)
     .blur();
   cy.get('select[name="pickup_address.state"]').select(pickupAddress.state);
 
-  cy
-    .get('input[name="pickup_address.postal_code"]')
+  cy.get('input[name="pickup_address.postal_code"]')
     .first()
     .clear()
     .type('1002')
     .blur();
   // Shouldn't be able to save without 5 digit zip
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Save')
     .should('be.disabled');
-  cy
-    .get('input[name="pickup_address.postal_code"]')
+  cy.get('input[name="pickup_address.postal_code"]')
     .first()
     .clear()
     .type(pickupAddress.postal_code)
     .blur();
 
   // Make sure delivery address is not required
-  cy
-    .get('label[for="has_delivery_address"]')
+  cy.get('label[for="has_delivery_address"]')
     .parent()
     .find('[type="radio"][value="no"]')
     .check({ force: true });
 
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Save')
     .should('be.enabled');
 
   // Set Secondary Pickup Address to required.
-  cy
-    .get('label[for="has_secondary_pickup_address"]')
+  cy.get('label[for="has_secondary_pickup_address"]')
     .parent()
     .find('[type="radio"][value="yes"]')
     .check({ force: true });
-  cy
-    .get('input[name="secondary_pickup_address.street_address_1"]')
+  cy.get('input[name="secondary_pickup_address.street_address_1"]')
     .first()
     .clear()
     .type(secondaryPickupAddress.street_1)
     .blur();
-  cy
-    .get('input[name="secondary_pickup_address.street_address_2"]')
+  cy.get('input[name="secondary_pickup_address.street_address_2"]')
     .first()
     .clear();
-  cy
-    .get('input[name="secondary_pickup_address.city"]')
+  cy.get('input[name="secondary_pickup_address.city"]')
     .first()
     .clear()
     .type(secondaryPickupAddress.city)
     .blur();
   cy.get('select[name="secondary_pickup_address.state"]').select(secondaryPickupAddress.state);
-  cy
-    .get('input[name="secondary_pickup_address.postal_code"]')
+  cy.get('input[name="secondary_pickup_address.postal_code"]')
     .first()
     .clear()
     .type('1002')
     .blur();
   // Shouldn't be able to save without 5 digit zip
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Save')
     .should('be.disabled');
-  cy
-    .get('input[name="secondary_pickup_address.postal_code"]')
+  cy.get('input[name="secondary_pickup_address.postal_code"]')
     .first()
     .clear()
     .type(secondaryPickupAddress.postal_code)
     .blur();
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Save')
     .should('be.enabled');
 
   // Allow secondary delivery address
-  cy
-    .get('label[for="has_delivery_address"]')
+  cy.get('label[for="has_delivery_address"]')
     .parent()
     .find('[type="radio"][value="yes"]')
     .check({ force: true });
 
-  cy
-    .get('input[name="delivery_address.street_address_1"]')
+  cy.get('input[name="delivery_address.street_address_1"]')
     .first()
     .clear()
     .type(deliveryAddress.street_1)
     .blur();
-  cy
-    .get('input[name="delivery_address.city"]')
+  cy.get('input[name="delivery_address.city"]')
     .first()
     .clear()
     .type(deliveryAddress.city)
     .blur();
   cy.get('select[name="delivery_address.state"]').select(deliveryAddress.state);
 
-  cy
-    .get('input[name="delivery_address.postal_code"]')
+  cy.get('input[name="delivery_address.postal_code"]')
     .first()
     .clear()
     .type('1002')
     .blur();
   // Shouldn't be able to save without 5 digit zip
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Save')
     .should('be.disabled');
-  cy
-    .get('input[name="delivery_address.postal_code"]')
+  cy.get('input[name="delivery_address.postal_code"]')
     .first()
     .clear()
     .type(deliveryAddress.postal_code)
     .blur();
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Save')
     .should('be.enabled');
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Save')
     .should('be.enabled');
 
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Save')
     .click();
 
   // Refresh browser and make sure changes persist
   cy.patientReload();
 
-  cy
-    .contains('Locations')
+  cy.contains('Locations')
     .parents('.editable-panel')
     .within(() => {
-      cy
-        .contains('Delivery')
+      cy.contains('Delivery')
         .parent('.editable-panel-column')
         .children('.panel-field')
         .children('.field-value')
@@ -312,12 +281,10 @@ function officeUserEntersLocations() {
         });
     });
 
-  cy
-    .contains('Locations')
+  cy.contains('Locations')
     .parents('.editable-panel')
     .within(() => {
-      cy
-        .contains('Pickup')
+      cy.contains('Pickup')
         .parent('.editable-panel-column')
         .children('.panel-field')
         .children('.field-value')
@@ -328,12 +295,10 @@ function officeUserEntersLocations() {
         });
     });
 
-  cy
-    .contains('Locations')
+  cy.contains('Locations')
     .parents('.editable-panel')
     .within(() => {
-      cy
-        .contains('Pickup')
+      cy.contains('Pickup')
         .parent('.editable-panel-column')
         .children('.panel-field')
         .children('.field-value')
@@ -345,41 +310,34 @@ function officeUserEntersLocations() {
           );
         });
     });
-  cy
-    .get('.editable-panel-header')
+  cy.get('.editable-panel-header')
     .contains('Locations')
     .siblings()
     .click();
 
   // Click every radio button, which means you'll end up with two 'No's selected
-  cy
-    .get('[type="radio"]')
+  cy.get('[type="radio"]')
     .eq(1)
     .check({ force: true });
-  cy
-    .get('[type="radio"]')
+  cy.get('[type="radio"]')
     .eq(3)
     .check({ force: true });
 
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Save')
     .should('be.enabled');
 
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Save')
     .click();
 
   // Refresh browser and make sure changes persist
   cy.patientReload();
 
-  cy
-    .contains('Locations')
+  cy.contains('Locations')
     .parents('.editable-panel')
     .within(() => {
-      cy
-        .contains('Delivery')
+      cy.contains('Delivery')
         .parent('.editable-panel-column')
         .children('.panel-field')
         .children('.field-value')

--- a/cypress/integration/office/officeCSRFProtect.js
+++ b/cypress/integration/office/officeCSRFProtect.js
@@ -32,27 +32,23 @@ describe('testing CSRF protection updating move info', function() {
     cy.signIntoOffice();
 
     // update info
-    cy
-      .get('div[class="rt-tr -odd"]')
+    cy.get('div[class="rt-tr -odd"]')
       .first()
       .dblclick();
 
     // save info
-    cy
-      .get('a[class="editable-panel-edit"]')
+    cy.get('a[class="editable-panel-edit"]')
       .first()
       .click();
 
-    cy
-      .get('input[name="orders.orders_number"]')
+    cy.get('input[name="orders.orders_number"]')
       .clear()
       .type('CSRF Test')
       .blur();
 
     cy.get('select[name="orders.orders_type_detail"]').select('HHG_PERMITTED');
 
-    cy
-      .get('button[class="usa-button editable-panel-save"]')
+    cy.get('button[class="usa-button editable-panel-save"]')
       .should('be.enabled')
       .click();
 
@@ -67,19 +63,16 @@ describe('testing CSRF protection updating move info', function() {
     cy.signIntoOffice();
 
     // update info
-    cy
-      .get('div[class="rt-tr -odd"]')
+    cy.get('div[class="rt-tr -odd"]')
       .first()
       .dblclick();
 
     // save info
-    cy
-      .get('a[class="editable-panel-edit"]')
+    cy.get('a[class="editable-panel-edit"]')
       .first()
       .click();
 
-    cy
-      .get('input[name="orders.orders_number"]')
+    cy.get('input[name="orders.orders_number"]')
       .clear()
       .type('CSRF Protection Failed')
       .blur();
@@ -90,8 +83,7 @@ describe('testing CSRF protection updating move info', function() {
     cy.clearCookie('masked_gorilla_csrf');
     cy.getCookie('masked_gorilla_csrf').should('not.exist');
 
-    cy
-      .get('button[class="usa-button editable-panel-save"]')
+    cy.get('button[class="usa-button editable-panel-save"]')
       .should('be.enabled')
       .click();
 

--- a/cypress/integration/office/officeServiceAgents.js
+++ b/cypress/integration/office/officeServiceAgents.js
@@ -55,8 +55,7 @@ function officeUserOpensHhgPanelForMove(moveLocator) {
   });
 
   // Click on HHG tab
-  cy
-    .get('span')
+  cy.get('span')
     .contains('HHG')
     .click();
   cy.location().should(loc => {
@@ -71,31 +70,26 @@ function officeUserVerifiesServiceAgent() {
 
 function officeUserEditsServiceAgentPanel() {
   // Click on edit Service Agent
-  cy
-    .get('.editable-panel-header')
+  cy.get('.editable-panel-header')
     .contains('TSP & Servicing Agents')
     .siblings()
     .click();
 }
 
 function officeUserSeesBlankTspData() {
-  cy
-    .get('.editable-panel-3-column')
+  cy.get('.editable-panel-3-column')
     .contains('TSP')
     .parent()
     .within(() => {
-      cy
-        .get('.panel-field')
+      cy.get('.panel-field')
         .contains('Name')
         .parent()
         .should('not.contain', 'undefined');
-      cy
-        .get('.panel-field')
+      cy.get('.panel-field')
         .contains('Email')
         .parent()
         .should('not.contain', 'undefined');
-      cy
-        .get('.panel-field')
+      cy.get('.panel-field')
         .contains('Phone number')
         .parent()
         .should('not.contain', 'undefined');

--- a/cypress/integration/office/officeUserHHG.js
+++ b/cypress/integration/office/officeUserHHG.js
@@ -101,8 +101,7 @@ function officeUserApprovesOnlyBasicsHHG() {
   cy.get('.combo-button').click();
 
   // Approve basics
-  cy
-    .get('.combo-button .dropdown')
+  cy.get('.combo-button .dropdown')
     .contains('Approve Basics')
     .click();
 
@@ -121,8 +120,7 @@ function officeUserApprovesOnlyBasicsHHG() {
   cy.get('.combo-button').click();
 
   // Disabled because already approved and not delivered
-  cy
-    .get('.combo-button .dropdown')
+  cy.get('.combo-button .dropdown')
     .contains('Approve HHG')
     .should('have.class', 'disabled');
 
@@ -148,8 +146,7 @@ function officeUserApprovesHHG() {
   cy.get('.combo-button').click();
 
   // Approve basics
-  cy
-    .get('.combo-button .dropdown')
+  cy.get('.combo-button .dropdown')
     .contains('Approve Basics')
     .click();
 
@@ -168,8 +165,7 @@ function officeUserApprovesHHG() {
 
   // Approve HHG
 
-  cy
-    .get('.combo-button .dropdown')
+  cy.get('.combo-button .dropdown')
     .contains('Approve HHG')
     .click();
 

--- a/cypress/integration/office/officeUserHHGPPM.js
+++ b/cypress/integration/office/officeUserHHGPPM.js
@@ -37,13 +37,11 @@ function officeUserApprovesShipment() {
   cy.get('.combo-button').click();
 
   // Approve HHG
-  cy
-    .get('.combo-button .dropdown')
+  cy.get('.combo-button .dropdown')
     .contains('Approve HHG')
     .click();
 
-  cy
-    .get('.combo-button .dropdown')
+  cy.get('.combo-button .dropdown')
     .contains('Approve HHG')
     .should('have.class', 'disabled');
 
@@ -63,8 +61,7 @@ function officeUserVisitsQueue(queue) {
 
 function officeUserVisitsPPMTab() {
   // navtab
-  cy
-    .get('a')
+  cy.get('a')
     .contains('PPM')
     .click();
 
@@ -75,8 +72,7 @@ function officeUserVisitsPPMTab() {
 
 function officeUserVisitsHHGTab() {
   // navtab
-  cy
-    .get('a')
+  cy.get('a')
     .contains('HHG')
     .click();
 
@@ -107,8 +103,7 @@ function officeUserSubmitsDocument() {
   cy.get('button.submit').should('be.disabled');
 
   cy.upload_file('.filepond--root', 'top-secret.png');
-  cy
-    .get('button.submit', { timeout: fileUploadTimeout })
+  cy.get('button.submit', { timeout: fileUploadTimeout })
     .should('not.be.disabled')
     .click();
 

--- a/cypress/integration/office/officeUserPPM.js
+++ b/cypress/integration/office/officeUserPPM.js
@@ -28,8 +28,7 @@ describe('office user finds the move', function() {
     officeUserApprovesMoveAndPPM(moveLocator);
 
     // Make sure the page hasn't exploded
-    cy
-      .get('.combo-button .btn__approve--green')
+    cy.get('.combo-button .btn__approve--green')
       .contains('Approved')
       .should('be.disabled');
   });
@@ -69,12 +68,10 @@ describe('office user finds the move', function() {
 
   it('download all attachments button is disabled when there are no attachments to download', function() {
     officeUserGoesToPPMPanel('FDXTIU');
-    cy
-      .get('a')
+    cy.get('a')
       .contains('Create payment paperwork')
       .click();
-    cy
-      .get('button')
+    cy.get('button')
       .contains('Download All Attachments (PDF)')
       .should('be.disabled');
   });
@@ -125,16 +122,14 @@ function officeUserVerifiesOrders(moveLocator) {
   cy.contains('GBL#').should('not.be.visible');
 
   // Click on Orders document link, check that link matches
-  cy
-    .get('.panel-field')
+  cy.get('.panel-field')
     .contains('Orders (')
     // .find('a')
     .should('have.attr', 'href')
     .and('match', /^\/moves\/[^/]+\/orders/);
 
   // Click on edit orders
-  cy
-    .get('.editable-panel-header')
+  cy.get('.editable-panel-header')
     .contains('Orders')
     .siblings()
     .click();
@@ -146,13 +141,11 @@ function officeUserVerifiesOrders(moveLocator) {
   cy.get('input[name="orders.orders_issuing_agency"]').type('ISSUING AGENCY');
   cy.get('input[name="orders.paragraph_number"]').type('FP-TP');
 
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Save')
     .should('be.enabled');
 
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Save')
     .click();
 
@@ -166,21 +159,18 @@ function officeUserVerifiesOrders(moveLocator) {
   cy.get('.combo-button button').should('be.disabled');
 
   // Click on edit orders
-  cy
-    .get('.editable-panel-header')
+  cy.get('.editable-panel-header')
     .contains('Accounting')
     .siblings()
     .click();
 
   cy.get('input[name="sac"]').type('SAC');
 
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Save')
     .should('be.enabled');
 
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Save')
     .click();
 
@@ -188,8 +178,7 @@ function officeUserVerifiesOrders(moveLocator) {
   cy.patientReload();
 
   cy.get('.combo-button').click();
-  cy
-    .get('.combo-button .dropdown')
+  cy.get('.combo-button .dropdown')
     .contains('Approve PPM')
     .should('have.class', 'disabled');
   cy.get('.combo-button').click();
@@ -215,8 +204,7 @@ function officeUserVerifiesAccounting() {
   });
 
   // Enter details in form and save
-  cy
-    .get('.editable-panel-header')
+  cy.get('.editable-panel-header')
     .contains('Accounting')
     .siblings()
     .click();
@@ -225,13 +213,11 @@ function officeUserVerifiesAccounting() {
   cy.get('select[name="department_indicator"]').select('AIR_FORCE');
   cy.get('input[name="sac"]').type('N002214CSW32Y9');
 
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Save')
     .should('be.enabled');
 
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Save')
     .click();
 
@@ -244,8 +230,7 @@ function officeUserVerifiesAccounting() {
   // Refresh browser and make sure changes persist
   cy.patientReload();
   cy.get('.combo-button').click();
-  cy
-    .get('.combo-button .dropdown')
+  cy.get('.combo-button .dropdown')
     .contains('Approve PPM')
     .should('have.class', 'disabled');
   cy.get('.combo-button').click();
@@ -271,18 +256,15 @@ function officeUserApprovesMoveAndPPM(moveLocator) {
   // Approve the move
   cy.get('.combo-button').click();
 
-  cy
-    .get('.combo-button .dropdown')
+  cy.get('.combo-button .dropdown')
     .contains('Approve PPM')
     .should('have.class', 'disabled');
 
-  cy
-    .get('.combo-button .dropdown')
+  cy.get('.combo-button .dropdown')
     .contains('Approve Basics')
     .click();
 
-  cy
-    .get('.combo-button .dropdown')
+  cy.get('.combo-button .dropdown')
     .contains('Approve PPM')
     .should('not.have.class', 'disabled');
 
@@ -311,8 +293,7 @@ function officeUserApprovesMoveAndPPM(moveLocator) {
   cy.get('.combo-button').click();
 
   // Approve PPM
-  cy
-    .get('.combo-button .dropdown')
+  cy.get('.combo-button .dropdown')
     .contains('Approve PPM')
     .click();
 
@@ -326,20 +307,17 @@ function officeUserVerifiesPPM() {
   // Approve advance
   cy.get('.payment-table').within(() => {
     // Verify the status icon
-    cy
-      .get('td svg:first')
+    cy.get('td svg:first')
       .should('have.attr', 'title')
       .and('eq', 'Awaiting Review');
     // Verify the approve checkmark
-    cy
-      .get('td svg:last')
+    cy.get('td svg:last')
       .should('have.attr', 'title')
       .and('eq', 'Approve');
 
     // Approve advance and verify icon change
     cy.get('td svg:last').click();
-    cy
-      .get('td svg:first')
+    cy.get('td svg:first')
       .should('have.attr', 'title')
       .and('eq', 'Approved');
   });
@@ -368,61 +346,51 @@ function officeUserGoesToPPMPanel(locator) {
 }
 
 function officeUserEditsDatesAndLocationsPanel(date) {
-  cy
-    .get('.editable-panel-header')
+  cy.get('.editable-panel-header')
     .contains('Dates & Locations')
     .siblings()
     .click();
 
-  cy
-    .get('input[name="actual_move_date"]')
+  cy.get('input[name="actual_move_date"]')
     .first()
     .clear()
     .type(date)
     .blur();
 
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Save')
     .should('be.enabled');
 
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Save')
     .click();
 }
 
 function officeUserEditsEstimatesPanel(destinationPostalCode, pickupPostalCode, weightEstimate) {
-  cy
-    .get('.editable-panel-header')
+  cy.get('.editable-panel-header')
     .contains('Estimates')
     .siblings()
     .click();
 
   cy.get('.estimates').within(() => {
-    cy
-      .get('input[name="PPMEstimate.destination_postal_code"]')
+    cy.get('input[name="PPMEstimate.destination_postal_code"]')
       .clear()
       .type(destinationPostalCode);
 
-    cy
-      .get('input[name="PPMEstimate.pickup_postal_code"]')
+    cy.get('input[name="PPMEstimate.pickup_postal_code"]')
       .clear()
       .type(pickupPostalCode);
 
-    cy
-      .get('input[name="PPMEstimate.weight_estimate"]')
+    cy.get('input[name="PPMEstimate.weight_estimate"]')
       .clear()
       .type(weightEstimate);
   });
 
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Save')
     .should('be.enabled');
 
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Save')
     .click();
 }
@@ -448,8 +416,7 @@ function officeUserGoesToStoragePanel(locator) {
     expect(loc.pathname).to.match(/^\/queues\/new\/moves\/[^/]+\/ppm/);
   });
 
-  cy
-    .get('.editable-panel-header')
+  cy.get('.editable-panel-header')
     .contains('Storage')
     .siblings()
     .click();

--- a/cypress/integration/office/ppmMoveDocuments.js
+++ b/cypress/integration/office/ppmMoveDocuments.js
@@ -24,15 +24,13 @@ function officeUserViewsPpmPanel(locatorId) {
     expect(loc.pathname).to.match(/^\/queues\/new/);
   });
 
-  cy
-    .get('.nav-tab')
+  cy.get('.nav-tab')
     .contains('PPM')
     .click();
 }
 
 function officeUserEditsDocumentStatus(documentTitle, oldDocumentStatus, newDocumentStatus) {
-  cy
-    .get('.documents')
+  cy.get('.documents')
     .contains(documentTitle)
     .click();
 
@@ -44,8 +42,7 @@ function officeUserEditsDocumentStatus(documentTitle, oldDocumentStatus, newDocu
 
   cy.get('.editable-panel-edit').click();
 
-  cy
-    .get('label[for="moveDocument.status"]')
+  cy.get('label[for="moveDocument.status"]')
     .siblings()
     .first()
     .children()

--- a/cypress/integration/office/preApprovalRequest.js
+++ b/cypress/integration/office/preApprovalRequest.js
@@ -41,8 +41,7 @@ function officeUserCreatesPreApprovalRequest() {
   });
 
   // Click on HHG tab
-  cy
-    .get('span')
+  cy.get('span')
     .contains('HHG')
     .click();
   cy.location().should(loc => {
@@ -74,8 +73,7 @@ function officeUserEditsPreApprovalRequest() {
   });
 
   // Click on HHG tab
-  cy
-    .get('span')
+  cy.get('span')
     .contains('HHG')
     .click();
   cy.location().should(loc => {
@@ -108,8 +106,7 @@ function officeUserApprovesPreApprovalRequest() {
   });
 
   // Click on HHG tab
-  cy
-    .get('span')
+  cy.get('span')
     .contains('HHG')
     .click();
   cy.location().should(loc => {
@@ -138,8 +135,7 @@ function officeUserDeletesPreApprovalRequest() {
   });
 
   // Click on HHG tab
-  cy
-    .get('span')
+  cy.get('span')
     .contains('HHG')
     .click();
   cy.location().should(loc => {
@@ -150,8 +146,7 @@ function officeUserDeletesPreApprovalRequest() {
   cy.get('span').contains('2,000');
 
   deletePreApprovalRequest();
-  cy
-    .get('.pre-approval-panel td')
+  cy.get('.pre-approval-panel td')
     .first()
     .should('not.contain', 'Bulky Article: Motorcycle/Rec vehicle');
 }
@@ -171,8 +166,7 @@ function officeUserCreates35APreApprovalRequest() {
   });
 
   // Click on HHG tab
-  cy
-    .get('span')
+  cy.get('span')
     .contains('HHG')
     .click();
   cy.location().should(loc => {
@@ -189,86 +183,72 @@ function officeUserCreates35APreApprovalRequest() {
   approvePreApprovalRequest();
 
   // Edit the request
-  cy
-    .get('[data-test=edit-request]')
+  cy.get('[data-test=edit-request]')
     .first()
     .click();
 
   cy.typeInInput({ name: 'actual_amount_cents', value: `235` });
 
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Save')
     .should('be.enabled');
 
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Save')
     .click();
 
-  cy
-    .get('td[details-cy="35A-details"]')
-    .should(
-      'contain',
-      'description description 35A reason reason 35A Est. not to exceed: $250.00 Actual amount: $235.00',
-    );
+  cy.get('td[details-cy="35A-details"]').should(
+    'contain',
+    'description description 35A reason reason 35A Est. not to exceed: $250.00 Actual amount: $235.00',
+  );
 
   // Edit the request again
-  cy
-    .get('[data-test=edit-request]')
+  cy.get('[data-test=edit-request]')
     .first()
     .click();
 
   cy.typeInInput({ name: 'actual_amount_cents', value: `220` });
 
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Save')
     .should('be.enabled');
 
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Save')
     .click();
 
-  cy
-    .get('td[details-cy="35A-details"]')
-    .should(
-      'contain',
-      'description description 35A reason reason 35A Est. not to exceed: $250.00 Actual amount: $220.00',
-    );
+  cy.get('td[details-cy="35A-details"]').should(
+    'contain',
+    'description description 35A reason reason 35A Est. not to exceed: $250.00 Actual amount: $220.00',
+  );
 
   // The edit should propagate to the Invoice panel
-  cy
-    .get('[data-cy=unbilled-table] tbody')
+  cy.get('[data-cy=unbilled-table] tbody')
     .contains('$220.00')
     .should('exist');
 
   // Unset the actual amount
-  cy
-    .get('[data-test=edit-request]')
+  cy.get('[data-test=edit-request]')
     .first()
     .click();
 
   cy.clearInput({ name: 'actual_amount_cents' });
 
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Save')
     .should('be.enabled');
 
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Save')
     .click();
 
-  cy
-    .get('td[details-cy="35A-details"]')
-    .should('contain', 'description description 35A reason reason 35A Est. not to exceed: $250.00 Actual amount: --');
+  cy.get('td[details-cy="35A-details"]').should(
+    'contain',
+    'description description 35A reason reason 35A Est. not to exceed: $250.00 Actual amount: --',
+  );
 
   // The edit should propagate to the Invoice panel
-  cy
-    .get('[data-cy=unbilled-table] tbody')
+  cy.get('[data-cy=unbilled-table] tbody')
     .contains('Missing actual amount')
     .parent();
 }

--- a/cypress/integration/office/storageInTransitPanel.js
+++ b/cypress/integration/office/storageInTransitPanel.js
@@ -48,30 +48,25 @@ function officeUserViewsSITPanel() {
   cy.get('[data-cy=storage-in-transit-panel]').contains('Storage in Transit');
   cy.get('[data-cy=storage-in-transit]').within(() => {
     cy.contains('Destination SIT');
-    cy
-      .get('[data-cy=sit-status-text]')
+    cy.get('[data-cy=sit-status-text]')
       .contains('Status')
       .parent()
       .siblings()
       .contains('SIT Requested');
-    cy
-      .contains('Dates')
+    cy.contains('Dates')
       .siblings()
       .contains('Est. start date')
       .siblings()
       .contains('22-Mar-2019');
-    cy
-      .contains('Note')
+    cy.contains('Note')
       .siblings()
       .contains('Shipper phoned to let us know he is delayed until next week.');
-    cy
-      .contains('Warehouse')
+    cy.contains('Warehouse')
       .siblings()
       .contains('Warehouse ID')
       .siblings()
       .contains('000383');
-    cy
-      .contains('Warehouse')
+    cy.contains('Warehouse')
       .siblings()
       .contains('Contact info')
       .siblings()
@@ -99,8 +94,7 @@ function officeUserStartsAndCancelsSitApproval() {
     expect(loc.pathname).to.match(/^\/queues\/new\/moves\/[^/]+\/hhg/);
   });
 
-  cy
-    .get('a')
+  cy.get('a')
     .contains('Approve')
     .click()
     .get('[data-cy=storage-in-transit]')
@@ -113,8 +107,7 @@ function officeUserStartsAndCancelsSitApproval() {
 
   cy.get('input[name="authorized_start_date"]').should('have.value', '3/22/2019');
 
-  cy
-    .get('.usa-button-secondary')
+  cy.get('.usa-button-secondary')
     .contains('Cancel')
     .click()
     .get('[data-cy=storage-in-transit-panel] [data-cy=add-request]')
@@ -144,8 +137,7 @@ function officeUserStartsAndCancelsSitEdit() {
     expect(loc.pathname).to.match(/^\/queues\/new\/moves\/[^/]+\/hhg/);
   });
 
-  cy
-    .get('[data-cy=storage-in-transit]')
+  cy.get('[data-cy=storage-in-transit]')
     .contains('Edit')
     .click()
     .get('.sit-authorization')
@@ -154,8 +146,7 @@ function officeUserStartsAndCancelsSitEdit() {
       expect(text).to.include('Edit SIT authorization');
     });
 
-  cy
-    .get('.usa-button-secondary')
+  cy.get('.usa-button-secondary')
     .contains('Cancel')
     .click()
     .get('[data-cy=storage-in-transit]')
@@ -186,8 +177,7 @@ function officeUserApprovesSITRequest() {
     expect(loc.pathname).to.match(/^\/queues\/new\/moves\/[^/]+\/hhg/);
   });
 
-  cy
-    .get('a')
+  cy.get('a')
     .contains('Approve')
     .click()
     .get('[data-cy="storage-in-transit"]')
@@ -202,8 +192,7 @@ function officeUserApprovesSITRequest() {
 
   cy.get('textarea[name="authorization_notes"]').type('this is a note', { force: true });
 
-  cy
-    .get('[data-cy="storage-in-transit-approve-button"]')
+  cy.get('[data-cy="storage-in-transit-approve-button"]')
     .contains('Approve')
     .click();
 
@@ -222,8 +211,7 @@ function officeUserApprovesSITRequest() {
 
   cy.get('textarea[name="authorization_notes"]').type('this is also a note', { force: true });
 
-  cy
-    .get('[data-cy="sit-editor-save-button"]')
+  cy.get('[data-cy="sit-editor-save-button"]')
     .contains('Save')
     .click();
 
@@ -253,8 +241,7 @@ function officeUserDeniesSITRequest() {
     expect(loc.pathname).to.match(/^\/queues\/new\/moves\/[^/]+\/hhg/);
   });
 
-  cy
-    .get('a[data-cy="sit-deny-link"]')
+  cy.get('a[data-cy="sit-deny-link"]')
     .contains('Deny')
     .click()
     .get('[data-cy="storage-in-transit"]')
@@ -265,8 +252,7 @@ function officeUserDeniesSITRequest() {
       expect(text).to.not.include('Edit');
     });
   cy.get('textarea[name="authorization_notes"]').type('this is a denial note');
-  cy
-    .get('[data-cy="storage-in-transit-deny-button"]')
+  cy.get('[data-cy="storage-in-transit-deny-button"]')
     .contains('Deny')
     .click();
 
@@ -277,8 +263,7 @@ function officeUserDeniesSITRequest() {
 
   cy.get('textarea[name="authorization_notes"]').type('this is also a note', { force: true });
 
-  cy
-    .get('[data-cy="sit-editor-save-button"]')
+  cy.get('[data-cy="sit-editor-save-button"]')
     .contains('Save')
     .click();
 
@@ -315,8 +300,7 @@ function officeUserEntitlementRemainingDays() {
 
   officeUserGoesToPlacedSIT();
 
-  cy
-    .get('[data-cy=storage-in-transit-panel]')
+  cy.get('[data-cy=storage-in-transit-panel]')
     .should($div => {
       const text = $div.text();
       expect(text).to.include('In SIT');
@@ -335,8 +319,7 @@ function officeUserEntitlementRemainingDaysExpired() {
 
   officeUserGoesToPlacedSIT();
 
-  cy
-    .get('[data-cy=storage-in-transit-panel]')
+  cy.get('[data-cy=storage-in-transit-panel]')
     .should($div => {
       const text = $div.text();
       expect(text).to.include('In SIT - SIT Expired');

--- a/cypress/integration/office/weightsAndItemsPanel.js
+++ b/cypress/integration/office/weightsAndItemsPanel.js
@@ -10,8 +10,7 @@ describe('Office User Interacts With the Weights & Items Panel', function() {
 });
 
 function withinWeightsAndItemsPanel(func) {
-  cy
-    .get('.editable-panel')
+  cy.get('.editable-panel')
     .contains('Weights & Items')
     .get('.editable-panel-content')
     .within(panel => {
@@ -31,8 +30,7 @@ function openMoveHhgPanel() {
     expect(loc.pathname).to.match(/^\/queues\/new\/moves\/[^/]+\/basics/);
   });
 
-  cy
-    .get('.nav-tab')
+  cy.get('.nav-tab')
     .contains('HHG')
     .click();
 }
@@ -44,68 +42,58 @@ function officeUserEntersNetWeight() {
     cy.get('.net_weight').should('not.exist');
   });
 
-  cy
-    .get('.editable-panel-header')
+  cy.get('.editable-panel-header')
     .contains('Weights & Items')
     .siblings()
     .click();
 
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Save')
     .should('not.be.enabled');
 
   // Fill out the net weight and save it
   withinWeightsAndItemsPanel(() => {
     cy.get('label[for="weights.pm_survey_weight_estimate"]').should('have.text', 'TSP estimateOptional');
-    cy
-      .get('input[name="weights.pm_survey_weight_estimate"]')
+    cy.get('input[name="weights.pm_survey_weight_estimate"]')
       .clear()
       .first()
       .type('5000')
       .blur();
     cy.get('label[for="weights.gross_weight"]').should('have.text', 'Gross');
-    cy
-      .get('input[name="weights.gross_weight"]')
+    cy.get('input[name="weights.gross_weight"]')
       .first()
       .type('30000')
       .blur();
     cy.get('label[for="weights.tare_weight"]').should('have.text', 'Tare');
-    cy
-      .get('input[name="weights.tare_weight"]')
+    cy.get('input[name="weights.tare_weight"]')
       .first()
       .type('10000')
       .blur();
     cy.get('label[for="weights.net_weight"]').should('have.text', 'Net (Gross - Tare)');
-    cy
-      .get('input[name="weights.net_weight"]')
+    cy.get('input[name="weights.net_weight"]')
       .first()
       .type('40000')
       .blur();
 
     cy.get('label[for="weights.pm_survey_progear_weight_estimate"]').should('have.text', 'Service memberOptional');
-    cy
-      .get('input[name="weights.pm_survey_progear_weight_estimate"]')
+    cy.get('input[name="weights.pm_survey_progear_weight_estimate"]')
       .clear()
       .first()
       .type('4000')
       .blur();
     cy.get('label[for="weights.pm_survey_spouse_progear_weight_estimate"]').contains('Spouse');
-    cy
-      .get('input[name="weights.pm_survey_spouse_progear_weight_estimate"]')
+    cy.get('input[name="weights.pm_survey_spouse_progear_weight_estimate"]')
       .clear()
       .first()
       .type('800')
       .blur();
   });
 
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Save')
     .should('be.enabled');
 
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Save')
     .click();
 

--- a/cypress/integration/tsp/checkBasics.js
+++ b/cypress/integration/tsp/checkBasics.js
@@ -22,8 +22,7 @@ function tspUserViewsCustomerInfo() {
   });
 
   // Expect Customer Info to be loaded
-  cy
-    .get('.customer-info')
+  cy.get('.customer-info')
     .contains('Customer Info')
     .get('.extras.content')
     .should($div => {

--- a/cypress/integration/tsp/checkHeader.js
+++ b/cypress/integration/tsp/checkHeader.js
@@ -36,8 +36,7 @@ function tspUserViewsHHGHeaderInfo() {
   tspUserVerifiesShipmentStatus('Shipment awarded');
 
   // Check the info bar
-  cy
-    .get('ul')
+  cy.get('ul')
     .contains('li', 'GBL# LKNQ7123456')
     .parentsUntil('div')
     .contains('li', 'Locator# HHGPPM')
@@ -72,8 +71,7 @@ function tspUserViewsHHGPPMHeaderInfo() {
   tspUserVerifiesShipmentStatus('Shipment awarded');
 
   // Check the info bar
-  cy
-    .get('ul')
+  cy.get('ul')
     .contains('li', 'GBL# LKNQ7123456')
     .parentsUntil('div')
     .contains('li', 'Locator# HHGPPM')

--- a/cypress/integration/tsp/customerInfoPanel.js
+++ b/cypress/integration/tsp/customerInfoPanel.js
@@ -43,8 +43,7 @@ function tspUserViewsCustomerContactInfo() {
   cy.get('.customer-info').contains('555-555-5555');
 
   // Check for email
-  cy
-    .get('a')
+  cy.get('a')
     .contains('hhg@award.ed')
     .and('have.attr', 'href')
     .and('match', /mailto:hhg@award.ed/);
@@ -61,8 +60,7 @@ function tspUserViewsBackupContactInfo() {
   cy.get('.customer-info').contains('555-555-5555');
 
   // Check for email
-  cy
-    .get('a')
+  cy.get('a')
     .contains('email@example.com')
     .and('have.attr', 'href')
     .and('match', /mailto:email@example.com/);

--- a/cypress/integration/tsp/datesPanel.js
+++ b/cypress/integration/tsp/datesPanel.js
@@ -24,8 +24,7 @@ function tspUserGoesToDatesPanel(locator) {
     expect(loc.pathname).to.match(/^\/shipments\/[^/]+/);
   });
 
-  cy
-    .get('.editable-panel-header')
+  cy.get('.editable-panel-header')
     .contains('Dates')
     .siblings()
     .click();

--- a/cypress/integration/tsp/documentViewer.js
+++ b/cypress/integration/tsp/documentViewer.js
@@ -13,8 +13,7 @@ describe('The document viewer', function() {
       log: true,
     });
 
-    cy
-      .get('[data-cy="document-upload-link"]')
+    cy.get('[data-cy="document-upload-link"]')
       .find('a')
       .should('have.attr', 'href')
       .and('contain', '/shipments/65e00326-420e-436a-89fc-6aeb3f90b870/documents/new');
@@ -30,8 +29,7 @@ describe('The document viewer', function() {
       expect(loc.pathname).to.match(/^\/shipments\/[^/]+/);
     });
 
-    cy
-      .get('[data-cy="document-upload-link"]')
+    cy.get('[data-cy="document-upload-link"]')
       .find('a')
       .should('have.attr', 'href')
       .and('match', /^\/shipments\/[^/]+\/documents\/[^/]+/);
@@ -41,8 +39,7 @@ describe('The document viewer', function() {
     cy.patientVisit('/shipments/65e00326-420e-436a-89fc-6aeb3f90b870/documents', {
       log: true,
     });
-    cy
-      .get('[data-cy="document-upload-link"]')
+    cy.get('[data-cy="document-upload-link"]')
       .find('a')
       .should('have.attr', 'href')
       .and('contain', '/shipments/65e00326-420e-436a-89fc-6aeb3f90b870/documents/new');
@@ -55,8 +52,7 @@ describe('The document viewer', function() {
     cy.get('input[name="notes"]').type('burn after reading');
     cy.get('button.submit').should('be.disabled');
     cy.upload_file('.filepond--root', 'top-secret.png');
-    cy
-      .get('button.submit', { timeout: fileUploadTimeout })
+    cy.get('button.submit', { timeout: fileUploadTimeout })
       .should('not.be.disabled')
       .click();
     cy.get('input[name="title"]').should('be.empty');
@@ -76,15 +72,13 @@ describe('The document viewer', function() {
       expect(loc.pathname).to.match(/^\/queues\/new/);
     });
 
-    cy
-      .get('div')
+    cy.get('div')
       .contains('Delivered Shipments')
       .click();
 
     cy.selectQueueItemMoveLocator('DOOB');
 
-    cy
-      .get('[data-cy=invoice-panel]')
+    cy.get('[data-cy=invoice-panel]')
       .get('[data-cy=unbilled-table]')
       .find('tbody tr')
       .should(rows => {

--- a/cypress/integration/tsp/generateGBL.js
+++ b/cypress/integration/tsp/generateGBL.js
@@ -34,8 +34,7 @@ function tspUserCannotGenerateGBL() {
     expect(loc.pathname).to.match(/^\/shipments\/[^/]+/);
   });
 
-  cy
-    .get('button')
+  cy.get('button')
     .contains(gblButtonText)
     .should('be.disabled');
 }
@@ -56,20 +55,17 @@ function tspUserGeneratesGBL() {
     expect(loc.pathname).to.match(/^\/shipments\/[^/]+/);
   });
 
-  cy
-    .get('button')
+  cy.get('button')
     .contains(gblButtonText)
     .should('be.enabled');
 
   cy.get('.documents').should('not.contain', 'Government Bill Of Lading');
 
-  cy
-    .get('button')
+  cy.get('button')
     .contains(gblButtonText)
     .click();
 
-  cy
-    .get('button')
+  cy.get('button')
     .contains(gblButtonText)
     .should('be.disabled');
 
@@ -79,13 +75,11 @@ function tspUserGeneratesGBL() {
 
   cy.get('.usa-alert-success').contains('Click the button to view, print, or download the GBL.');
 
-  cy
-    .get('button')
+  cy.get('button')
     .contains('View GBL')
     .should('be.enabled');
 
-  cy
-    .get('button')
+  cy.get('button')
     .contains(gblButtonText)
     .should('not.exist');
 
@@ -117,8 +111,7 @@ function tspUserViewsGBL() {
 
   cy.get('.documents').should($div => expect($div.text()).to.contain('Government Bill Of Lading'));
 
-  cy
-    .get('.documents')
+  cy.get('.documents')
     .get('a')
     .contains('Government Bill Of Lading')
     .click();

--- a/cypress/integration/tsp/homepage.js
+++ b/cypress/integration/tsp/homepage.js
@@ -59,8 +59,7 @@ function tspAllMoves() {
     expect(loc.pathname).to.match(/^\/queues\/all/);
   });
 
-  cy
-    .get('[data-cy=locator]')
+  cy.get('[data-cy=locator]')
     .contains('NOSHOW')
     .should('not.exist');
 }

--- a/cypress/integration/tsp/invoicing.js
+++ b/cypress/integration/tsp/invoicing.js
@@ -14,8 +14,7 @@ function checkNoUnbilledLineItems() {
   cy.patientVisit('/shipments/0851706a-997f-46fb-84e4-2525a444ade0');
 
   // The invoice table should be empty.
-  cy
-    .get('[data-cy=invoice-panel] [data-cy=basic-panel-content]')
+  cy.get('[data-cy=invoice-panel] [data-cy=basic-panel-content]')
     .find('span.empty-content')
     .should('have.text', 'No line items');
 }
@@ -25,8 +24,7 @@ function checkExistUnbilledLineItems() {
   cy.patientVisit('shipments/67a3cbe7-4ae3-4f6a-9f9a-4f312e7458b9');
 
   // The invoice table should display the unbilled line items.
-  cy
-    .get('[data-cy=invoice-panel] [data-cy=basic-panel-content] tbody')
+  cy.get('[data-cy=invoice-panel] [data-cy=basic-panel-content] tbody')
     .children()
     // For each line item, I should see item code, description, etc.
     .each((row, index, lst) => {
@@ -35,8 +33,7 @@ function checkExistUnbilledLineItems() {
         return;
       }
 
-      cy
-        .wrap(row)
+      cy.wrap(row)
         .children()
         .each(cell => {
           // Each cell should have a value present.

--- a/cypress/integration/tsp/locationsPanel.js
+++ b/cypress/integration/tsp/locationsPanel.js
@@ -72,12 +72,10 @@ function tspUserViewsLocation({ shipmentId, type, expectation }) {
   });
 
   // Expect Customer Info to be loaded
-  cy
-    .contains('Locations')
+  cy.contains('Locations')
     .parents('.editable-panel')
     .within(() => {
-      cy
-        .contains(type)
+      cy.contains(type)
         .parent('.editable-panel-column')
         .children('.panel-field')
         .children('.field-value')
@@ -133,147 +131,122 @@ function tspUserEntersLocations() {
     expect(loc.pathname).to.match(/^\/shipments\/[^/]+/);
   });
 
-  cy
-    .get('.editable-panel-header')
+  cy.get('.editable-panel-header')
     .contains('Locations')
     .siblings()
     .click();
 
   // Enter details in form and save locations
-  cy
-    .get('input[name="pickup_address.street_address_1"]')
+  cy.get('input[name="pickup_address.street_address_1"]')
     .first()
     .clear()
     .type(pickupAddress.street_1)
     .blur();
-  cy
-    .get('input[name="pickup_address.city"]')
+  cy.get('input[name="pickup_address.city"]')
     .first()
     .clear()
     .type(pickupAddress.city)
     .blur();
   cy.get('select[name="pickup_address.state"]').select(pickupAddress.state);
-  cy
-    .get('input[name="pickup_address.postal_code"]')
+  cy.get('input[name="pickup_address.postal_code"]')
     .first()
     .clear()
     .type('1002')
     .blur();
   // Shouldn't be able to save without 5 digit zip
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Save')
     .should('be.disabled');
-  cy
-    .get('input[name="pickup_address.postal_code"]')
+  cy.get('input[name="pickup_address.postal_code"]')
     .first()
     .clear()
     .type(pickupAddress.postal_code)
     .blur();
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Save')
     .should('be.enabled');
 
   // Set Secondary Pickup Address to required.
-  cy
-    .get('label[for="has_secondary_pickup_address"]')
+  cy.get('label[for="has_secondary_pickup_address"]')
     .siblings()
     .get('[type="radio"]')
     .first()
     .check({ force: true });
-  cy
-    .get('input[name="secondary_pickup_address.street_address_1"]')
+  cy.get('input[name="secondary_pickup_address.street_address_1"]')
     .first()
     .clear()
     .type(secondaryPickupAddress.street_1)
     .blur();
-  cy
-    .get('input[name="secondary_pickup_address.street_address_2"]')
+  cy.get('input[name="secondary_pickup_address.street_address_2"]')
     .first()
     .clear();
-  cy
-    .get('input[name="secondary_pickup_address.city"]')
+  cy.get('input[name="secondary_pickup_address.city"]')
     .first()
     .clear()
     .type(secondaryPickupAddress.city)
     .blur();
   cy.get('select[name="secondary_pickup_address.state"]').select(secondaryPickupAddress.state);
-  cy
-    .get('input[name="secondary_pickup_address.postal_code"]')
+  cy.get('input[name="secondary_pickup_address.postal_code"]')
     .first()
     .clear()
     .type('1002')
     .blur();
   // Shouldn't be able to save without 5 digit zip
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Save')
     .should('be.disabled');
-  cy
-    .get('input[name="secondary_pickup_address.postal_code"]')
+  cy.get('input[name="secondary_pickup_address.postal_code"]')
     .first()
     .clear()
     .type(secondaryPickupAddress.postal_code)
     .blur();
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Save')
     .should('be.enabled');
 
-  cy
-    .get('input[name="delivery_address.street_address_1"]')
+  cy.get('input[name="delivery_address.street_address_1"]')
     .first()
     .clear()
     .type(deliveryAddress.street_1)
     .blur();
-  cy
-    .get('input[name="delivery_address.city"]')
+  cy.get('input[name="delivery_address.city"]')
     .first()
     .clear()
     .type(deliveryAddress.city)
     .blur();
   cy.get('select[name="delivery_address.state"]').select(deliveryAddress.state);
-  cy
-    .get('input[name="delivery_address.postal_code"]')
+  cy.get('input[name="delivery_address.postal_code"]')
     .first()
     .clear()
     .type('1002')
     .blur();
   // Shouldn't be able to save without 5 digit zip
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Save')
     .should('be.disabled');
-  cy
-    .get('input[name="delivery_address.postal_code"]')
+  cy.get('input[name="delivery_address.postal_code"]')
     .first()
     .clear()
     .type(deliveryAddress.postal_code)
     .blur();
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Save')
     .should('be.enabled');
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Save')
     .should('be.enabled');
 
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Save')
     .click();
 
   // Refresh browser and make sure changes persist
   cy.patientReload();
 
-  cy
-    .contains('Locations')
+  cy.contains('Locations')
     .parents('.editable-panel')
     .within(() => {
-      cy
-        .contains('Delivery')
+      cy.contains('Delivery')
         .parent('.editable-panel-column')
         .children('.panel-field')
         .children('.field-value')
@@ -284,12 +257,10 @@ function tspUserEntersLocations() {
         });
     });
 
-  cy
-    .contains('Locations')
+  cy.contains('Locations')
     .parents('.editable-panel')
     .within(() => {
-      cy
-        .contains('Pickup')
+      cy.contains('Pickup')
         .parent('.editable-panel-column')
         .children('.panel-field')
         .children('.field-value')
@@ -300,12 +271,10 @@ function tspUserEntersLocations() {
         });
     });
 
-  cy
-    .contains('Locations')
+  cy.contains('Locations')
     .parents('.editable-panel')
     .within(() => {
-      cy
-        .contains('Pickup')
+      cy.contains('Pickup')
         .parent('.editable-panel-column')
         .children('.panel-field')
         .children('.field-value')
@@ -317,41 +286,34 @@ function tspUserEntersLocations() {
           );
         });
     });
-  cy
-    .get('.editable-panel-header')
+  cy.get('.editable-panel-header')
     .contains('Locations')
     .siblings()
     .click();
 
   // Click every radio button, which means you'll end up with two 'No's selected
-  cy
-    .get('[type="radio"]')
+  cy.get('[type="radio"]')
     .eq(1)
     .check({ force: true });
-  cy
-    .get('[type="radio"]')
+  cy.get('[type="radio"]')
     .eq(3)
     .check({ force: true });
 
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Save')
     .should('be.enabled');
 
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Save')
     .click();
 
   // Refresh browser and make sure changes persist
   cy.patientReload();
 
-  cy
-    .contains('Locations')
+  cy.contains('Locations')
     .parents('.editable-panel')
     .within(() => {
-      cy
-        .contains('Delivery')
+      cy.contains('Delivery')
         .parent('.editable-panel-column')
         .children('.panel-field')
         .children('.field-value')

--- a/cypress/integration/tsp/preApprovalRequest.js
+++ b/cypress/integration/tsp/preApprovalRequest.js
@@ -107,8 +107,7 @@ function tspUserDeletesPreApprovalRequest() {
   });
 
   deletePreApprovalRequest();
-  cy
-    .get('.pre-approval-panel td')
+  cy.get('.pre-approval-panel td')
     .first()
     .should('not.contain', 'Bulky Article: Motorcycle/Rec vehicle');
 }

--- a/cypress/integration/tsp/premoveSurvey.js
+++ b/cypress/integration/tsp/premoveSurvey.js
@@ -30,100 +30,83 @@ describe('TSP User And the Premove Survey Button', function() {
 });
 
 function tspUserClicksEnterPreMoveSurvey() {
-  cy
-    .contains('Enter pre-move survey')
+  cy.contains('Enter pre-move survey')
     .should('be.enabled')
     .click();
 }
 
 function tspUserFillsInPreMoveSurveyWizard() {
-  cy
-    .get('input[name="pm_survey_planned_pack_date"]')
+  cy.get('input[name="pm_survey_planned_pack_date"]')
     .type('10/24/2018')
     .blur();
 
-  cy
-    .get('a')
+  cy.get('a')
     .contains('Cancel')
     .click();
 
   cy.get('input[name="pm_survey_planned_pack_date"]').should('not.exist');
 
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Enter pre-move survey')
     .should('be.enabled');
 
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Enter pre-move survey')
     .click();
 
-  cy
-    .get('input[name="pm_survey_planned_pack_date"]')
+  cy.get('input[name="pm_survey_planned_pack_date"]')
     .first()
     .type('8/1/2018')
     .blur();
-  cy
-    .get('input[name="pm_survey_planned_pickup_date"]')
+  cy.get('input[name="pm_survey_planned_pickup_date"]')
     .first()
     .type('8/2/2018')
     .blur();
-  cy
-    .get('input[name="pm_survey_planned_delivery_date"]')
+  cy.get('input[name="pm_survey_planned_delivery_date"]')
     .first()
     .type('8/6/2018')
     .blur();
-  cy
-    .get('input[name="pm_survey_conducted_date"]')
+  cy.get('input[name="pm_survey_conducted_date"]')
     .first()
     .type('7/20/2018')
     .blur();
-  cy
-    .get('input[name="pm_survey_weight_estimate"]')
+  cy.get('input[name="pm_survey_weight_estimate"]')
     .clear()
     .first()
     .type('6000')
     .blur();
 
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Done')
     .should('be.disabled');
 
   cy.get('select[name="pm_survey_method"]').select('PHONE');
 
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Done')
     .should('be.enabled');
 
-  cy
-    .get('input[name="pm_survey_progear_weight_estimate"]')
+  cy.get('input[name="pm_survey_progear_weight_estimate"]')
     .clear()
     .first()
     .type('4000')
     .blur();
-  cy
-    .get('input[name="pm_survey_spouse_progear_weight_estimate"]')
+  cy.get('input[name="pm_survey_spouse_progear_weight_estimate"]')
     .clear()
     .first()
     .type('800')
     .blur();
-  cy
-    .get('textarea[name="pm_survey_notes"]')
+  cy.get('textarea[name="pm_survey_notes"]')
     .clear()
     .first()
     .type('Notes notes notes')
     .blur();
 
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Done')
     .should('be.enabled');
 
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Done')
     .click();
 }

--- a/cypress/integration/tsp/queues.js
+++ b/cypress/integration/tsp/queues.js
@@ -29,8 +29,7 @@ function tspUserViewsNewShipments() {
   cy.get('h1').contains('Queue: New Shipments');
 
   // Find shipment and check properties in row
-  cy
-    .get('div')
+  cy.get('div')
     .contains('div', 'BACON1')
     .parentsUntil('div.rt-tr-group')
     .contains('div', 'Awarded')
@@ -105,8 +104,7 @@ function tspUserViewsDeliveredShipments() {
 
 function tspUserViewsAcceptedShipments() {
   // Open accepted shipments queue
-  cy
-    .get('div')
+  cy.get('div')
     .contains('Accepted Shipments')
     .click();
 

--- a/cypress/integration/tsp/serviceAgents.js
+++ b/cypress/integration/tsp/serviceAgents.js
@@ -80,16 +80,13 @@ function tspUserSeesNoServiceAgent(role) {
 
 function tspUserViewsBlankServiceAgent() {
   // Verify data has been saved in the UI
-  cy
-    .get('div.company')
+  cy.get('div.company')
     .get('span')
     .contains('missing');
-  cy
-    .get('div.email')
+  cy.get('div.email')
     .get('span')
     .contains('missing');
-  cy
-    .get('div.phone_number')
+  cy.get('div.phone_number')
     .get('span')
     .contains('missing');
 }
@@ -108,8 +105,7 @@ function tspUserEntersServiceAgent() {
   });
 
   // Click on edit Service Agent
-  cy
-    .get('.editable-panel-header')
+  cy.get('.editable-panel-header')
     .contains('TSP & Servicing Agents')
     .siblings()
     .click();
@@ -133,13 +129,11 @@ function tspUserAcceptsShipment() {
 
   cy.get('a').contains('New Shipments Queue');
 
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Accept Shipment')
     .should('be.enabled');
 
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Accept Shipment')
     .click();
 
@@ -160,13 +154,11 @@ function tspUserClicksAssignServiceAgent(locator) {
   // Status should be Accepted or Approved for "Assign servicing agents" button to exist
   tspUserVerifiesShipmentStatus('Shipment accepted');
 
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Assign servicing agents')
     .should('be.enabled');
 
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Assign servicing agents')
     .click();
 
@@ -178,13 +170,11 @@ function tspUserVerifiesServiceAgentAssigned() {
 }
 
 function userSavesServiceAgentsWizard() {
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Done')
     .should('be.enabled');
 
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Done')
     .click();
 }
@@ -192,39 +182,32 @@ function userSavesServiceAgentsWizard() {
 function userVerifiesServiceAgentInfo(role) {
   const agent = getFixture(role);
   // Verify data has been saved in the UI
-  cy
-    .get('div.company')
+  cy.get('div.company')
     .get('span')
     .contains(agent.Company);
-  cy
-    .get('div.email')
+  cy.get('div.email')
     .get('span')
     .contains(agent.Email);
-  cy
-    .get('div.phone_number')
+  cy.get('div.phone_number')
     .get('span')
     .contains(agent.Phone);
 
   // Refresh browser and make sure changes persist
   cy.patientReload();
 
-  cy
-    .get('div.company')
+  cy.get('div.company')
     .get('span')
     .contains(agent.Company);
-  cy
-    .get('div.email')
+  cy.get('div.email')
     .get('span')
     .contains(agent.Email);
-  cy
-    .get('div.phone_number')
+  cy.get('div.phone_number')
     .get('span')
     .contains(agent.Phone);
 }
 
 function userAllowsDestinationAgentBeSelected() {
-  cy
-    .get('[type="radio"]')
+  cy.get('[type="radio"]')
     .first()
     .check({ force: true });
 }

--- a/cypress/integration/tsp/shipShipment.js
+++ b/cypress/integration/tsp/shipShipment.js
@@ -24,23 +24,19 @@ describe('TSP User Ships a Shipment', function() {
 });
 
 function tspUserCancelsEnteringADeliveryDate() {
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Enter Delivery')
     .should('exist');
 
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Enter Delivery')
     .click();
 
-  cy
-    .get('input[name="actual_delivery_date"]')
+  cy.get('input[name="actual_delivery_date"]')
     .type('10/24/2018')
     .blur();
 
-  cy
-    .get('a')
+  cy.get('a')
     .contains('Cancel')
     .click();
 
@@ -48,20 +44,17 @@ function tspUserCancelsEnteringADeliveryDate() {
 }
 
 function tspUserEntersADeliveryDate() {
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Enter Delivery')
     .click();
 
   cy.get('input[name="actual_delivery_date"]').should('be.empty');
 
-  cy
-    .get('input[name="actual_delivery_date"]')
+  cy.get('input[name="actual_delivery_date"]')
     .type('10/24/2018')
     .blur();
 
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Done')
     .click();
 
@@ -89,8 +82,7 @@ function tspUserEntersPackAndPickUpInfo() {
   cy.patientVisit('/queues/new');
 
   // Open approved shipments queue
-  cy
-    .get('div')
+  cy.get('div')
     .contains('All Shipments')
     .click();
 
@@ -106,90 +98,76 @@ function tspUserEntersPackAndPickUpInfo() {
   });
 
   // Click the Enter Pickup button
-  cy
-    .get('div')
+  cy.get('div')
     .contains('Enter Pickup')
     .click();
 
   // Done button should be disabled.
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Done')
     .should('be.disabled');
 
   // Pick a date!
-  cy
-    .get('div')
+  cy.get('div')
     .contains('Actual pickup')
     .get('input[name="actual_pickup_date"]')
     .type('10/20/2018')
     .blur();
 
   // Cancel
-  cy
-    .get('a')
+  cy.get('a')
     .contains('Cancel')
     .click();
 
   // Wash, Rinse, Repeat
   // Click the Enter Pickup button
-  cy
-    .get('div')
+  cy.get('div')
     .contains('Enter Pickup')
     .click();
 
   // Done button should be disabled.
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Done')
     .should('be.disabled');
 
   // Pick a Pack date!
-  cy
-    .get('div')
+  cy.get('div')
     .contains('Actual packing (first day)')
     .get('input[name="actual_pack_date"]')
     .type('10/18/2018')
     .blur();
 
   // Pick a Pickup date!
-  cy
-    .get('div')
+  cy.get('div')
     .contains('Actual pickup')
     .get('input[name="actual_pickup_date"]')
     .type('10/19/2018')
     .blur();
 
   // Done button should STILL be disabled.
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Done')
     .should('be.disabled');
-  cy
-    .get('input[name="net_weight"]')
+  cy.get('input[name="net_weight"]')
     .first()
     .clear()
     .type('2000')
     .blur();
   // Done button should be enabled.
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Done')
     .should('be.enabled');
-  cy
-    .get('input[name="gross_weight"]')
+  cy.get('input[name="gross_weight"]')
     .first()
     .clear()
     .type('3000')
     .blur();
-  cy
-    .get('input[name="tare_weight"]')
+  cy.get('input[name="tare_weight"]')
     .first()
     .clear()
     .type('1000')
     .blur();
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Done')
     .click();
 
@@ -214,62 +192,52 @@ function tspUserDeliversShipment(availableDays) {
   });
 
   // Click the Transport button
-  cy
-    .get('div')
+  cy.get('div')
     .contains('Enter Delivery')
     .click();
 
   // Done button should be disabled.
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Done')
     .should('be.disabled');
 
   // Pick a date!
-  cy
-    .get('div')
+  cy.get('div')
     .contains('Actual Delivery Date')
     .get('input')
     .click();
 
-  cy
-    .get('.DayPicker-Day')
+  cy.get('.DayPicker-Day')
     .contains(availableDays[0].format('D'))
     .click();
 
   // Cancel
-  cy
-    .get('a')
+  cy.get('a')
     .contains('Cancel')
     .click();
 
   // Wash, Rinse, Repeat
   // Click the Transport button
-  cy
-    .get('div')
+  cy.get('div')
     .contains('Enter Delivery')
     .click();
 
   // Done button should be disabled.
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Done')
     .should('be.disabled');
 
   // Pick a date!
-  cy
-    .get('div')
+  cy.get('div')
     .contains('Actual Delivery Date')
     .get('input')
     .click();
 
-  cy
-    .get('.DayPicker-Day')
+  cy.get('.DayPicker-Day')
     .contains(availableDays[1].format('D'))
     .click();
 
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Done')
     .click();
 

--- a/cypress/integration/tsp/storageInTransit.js
+++ b/cypress/integration/tsp/storageInTransit.js
@@ -166,8 +166,7 @@ function tspUserCreatesSitRequest() {
   });
 
   // Click on Request SIT and see SIT Request form
-  cy
-    .get('[data-cy=storage-in-transit-panel]')
+  cy.get('[data-cy=storage-in-transit-panel]')
     .should($div => {
       const text = $div.text();
       expect(text).to.include('Entitlement: 90 days');
@@ -189,8 +188,7 @@ function tspUserCreatesSitRequest() {
   fillAndSaveStorageInTransit();
 
   // Verify action links
-  cy
-    .get('[data-cy=storage-in-transit-panel] [data-cy=sit-edit-link]')
+  cy.get('[data-cy=storage-in-transit-panel] [data-cy=sit-edit-link]')
     .contains('Edit')
     .get('[data-cy=storage-in-transit-panel] [data-cy=sit-delete-link]')
     .contains('Delete');
@@ -210,13 +208,11 @@ function tspUserStartsAndCancelsSitRequest() {
     expect(loc.pathname).to.match(/^\/shipments\/[^/]+/);
   });
 
-  cy
-    .get('[data-cy=storage-in-transit-panel] [data-cy=add-request]')
+  cy.get('[data-cy=storage-in-transit-panel] [data-cy=add-request]')
     .contains('Request SIT')
     .click();
 
-  cy
-    .get('.usa-button-secondary')
+  cy.get('.usa-button-secondary')
     .contains('Cancel')
     .click()
     .get('[data-cy=storage-in-transit-panel] [data-cy=add-request]')
@@ -240,16 +236,14 @@ function tspUserEditsSitRequest() {
     expect(loc.pathname).to.match(/^\/shipments\/[^/]+/);
   });
 
-  cy
-    .get('[data-cy=storage-in-transit-panel] [data-cy=add-request]')
+  cy.get('[data-cy=storage-in-transit-panel] [data-cy=add-request]')
     .contains('Request SIT')
     .click();
 
   fillAndSaveStorageInTransit();
 
   // click edit
-  cy
-    .get('[data-cy="sit-edit-link"]')
+  cy.get('[data-cy="sit-edit-link"]')
     .first()
     .click();
 
@@ -277,14 +271,12 @@ function tspUserStartsAndCancelsSitPlaceInSit() {
   // Verify action links
   cy.get('[data-cy=storage-in-transit-panel] [data-cy=sit-delete-link]').contains('Delete');
 
-  cy
-    .get('[data-cy=storage-in-transit-panel] [data-cy=sit-place-into-sit-link]')
+  cy.get('[data-cy=storage-in-transit-panel] [data-cy=sit-place-into-sit-link]')
     .contains('Place into SIT')
     .click();
 
   cy.get('input[name=actual_start_date]').should('have.value', '3/26/2019');
-  cy
-    .get('[data-cy=place-into-sit-cancel]')
+  cy.get('[data-cy=place-into-sit-cancel]')
     .contains('Cancel')
     .click()
     .get('[data-cy=storage-in-transit-panel] [data-cy=sit-place-into-sit-link]')
@@ -296,14 +288,12 @@ function tspUserStartsAndCancelsSitPlaceInSit() {
 
 function tspUserEntersInvalidActualStartDate() {
   // User starts from Approved SIT
-  cy
-    .get('[data-cy=storage-in-transit-panel] [data-cy=sit-place-into-sit-link]')
+  cy.get('[data-cy=storage-in-transit-panel] [data-cy=sit-place-into-sit-link]')
     .contains('Place into SIT')
     .click();
 
   // calendar date picker date should be disabled
-  cy
-    .get('input[name=actual_start_date]')
+  cy.get('input[name=actual_start_date]')
     .should('have.value', '3/26/2019')
     // chooses invalid 3/22/2019
     .click()
@@ -312,8 +302,7 @@ function tspUserEntersInvalidActualStartDate() {
     .should('have.class', 'DayPicker-Day--disabled');
 
   // submit should be disabled typed invalid date input
-  cy
-    .get('input[name=actual_start_date]')
+  cy.get('input[name=actual_start_date]')
     .should('have.value', '3/26/2019')
     .click()
     .clear()
@@ -323,21 +312,18 @@ function tspUserEntersInvalidActualStartDate() {
   cy.get('input[name=actual_start_date]').should('have.value', '3/25/2019');
   // expect submit to be disabled
   cy.get('[data-cy=place-in-sit-button]').should('be.disabled');
-  cy
-    .get('[data-cy=place-into-sit-cancel]')
+  cy.get('[data-cy=place-into-sit-cancel]')
     .contains('Cancel')
     .click();
 }
 
 function tspUserSubmitsPlaceInSit() {
   // User starts from Approved SIT
-  cy
-    .get('[data-cy=storage-in-transit-panel] [data-cy=sit-place-into-sit-link]')
+  cy.get('[data-cy=storage-in-transit-panel] [data-cy=sit-place-into-sit-link]')
     .contains('Place into SIT')
     .click();
 
-  cy
-    .get('input[name=actual_start_date')
+  cy.get('input[name=actual_start_date')
     .should('have.value', '3/26/2019')
     // Chooses valid 3/30/2019
     .click()
@@ -345,8 +331,7 @@ function tspUserSubmitsPlaceInSit() {
     .contains('30')
     .click();
   cy.get('input[name=actual_start_date]').should('have.value', '3/30/2019');
-  cy
-    .get('[data-cy=place-in-sit-button]')
+  cy.get('[data-cy=place-in-sit-button]')
     .contains('Place Into SIT')
     .click()
     .get('[data-cy=storage-in-transit-panel]')
@@ -361,8 +346,7 @@ function tspUserSubmitsPlaceInSit() {
     });
 
   // Verify action links
-  cy
-    .get('[data-cy=storage-in-transit-panel] [data-cy=sit-edit-link]')
+  cy.get('[data-cy=storage-in-transit-panel] [data-cy=sit-edit-link]')
     .contains('Edit')
     .get('[data-cy=storage-in-transit-panel] [data-cy=sit-delete-link]')
     .contains('Delete');
@@ -390,8 +374,7 @@ function tspUserEntitlementRemainingDays() {
 
   tspUserGoesToPlacedSit();
 
-  cy
-    .get('[data-cy=storage-in-transit-panel]')
+  cy.get('[data-cy=storage-in-transit-panel]')
     .should($div => {
       const text = $div.text();
       expect(text).to.include('In SIT');
@@ -410,8 +393,7 @@ function tspUserEntitlementRemainingDaysExpired() {
 
   tspUserGoesToPlacedSit();
 
-  cy
-    .get('[data-cy=storage-in-transit-panel]')
+  cy.get('[data-cy=storage-in-transit-panel]')
     .should($div => {
       const text = $div.text();
       expect(text).to.include('In SIT - SIT Expired');
@@ -503,21 +485,18 @@ function tspUserDeliversShipment(tspQueue, moveLocator, deliveryDate) {
   });
 
   // click Enter Delivery button
-  cy
-    .get('[data-cy=tsp-enter-delivery]')
+  cy.get('[data-cy=tsp-enter-delivery]')
     .contains('Enter Delivery')
     .click();
 
   // enter Actual Delivery Date
-  cy
-    .get('input[name=actual_delivery_date]')
+  cy.get('input[name=actual_delivery_date]')
     .type(deliveryDate)
     .blur();
 
   // press button to release shipment and confirm the expected information on the panel
   // after releasing the shipment
-  cy
-    .get('[data-cy=tsp-enter-delivery-submit]')
+  cy.get('[data-cy=tsp-enter-delivery-submit]')
     .contains('Done')
     .click();
 }
@@ -534,14 +513,12 @@ function tspUserSubmitsReleaseSit(tspQueue, moveLocator, releaseOnDate, dateOut)
   });
 
   // click release shipment link
-  cy
-    .get('[data-cy=storage-in-transit-panel] [data-cy=sit-release-from-sit-link]')
+  cy.get('[data-cy=storage-in-transit-panel] [data-cy=sit-release-from-sit-link]')
     .contains('Release from SIT')
     .click();
 
   // Test canceling after clicking release shipment link
-  cy
-    .get('[data-cy=release-from-sit-cancel]')
+  cy.get('[data-cy=release-from-sit-cancel]')
     .contains('Cancel')
     .click();
 
@@ -551,22 +528,19 @@ function tspUserSubmitsReleaseSit(tspQueue, moveLocator, releaseOnDate, dateOut)
   });
 
   // click release shipment link
-  cy
-    .get('[data-cy=storage-in-transit-panel] [data-cy=sit-release-from-sit-link]')
+  cy.get('[data-cy=storage-in-transit-panel] [data-cy=sit-release-from-sit-link]')
     .contains('Release from SIT')
     .click();
 
   // enter in date released on
-  cy
-    .get('input[name=released_on]')
+  cy.get('input[name=released_on]')
     .focus()
     .type(releaseOnDate)
     .blur();
 
   // press button to release shipment and confirm the expected information on the panel
   // after releasing the shipment
-  cy
-    .get('[data-cy=release-from-sit-button]')
+  cy.get('[data-cy=release-from-sit-button]')
     .contains('Done')
     .click();
 
@@ -588,8 +562,7 @@ function tspUserDeletesSitRequest() {
   });
 
   // Click on Delete SIT and see SIT Delete warning, then click cancel and it should go away.
-  cy
-    .get('[data-cy=storage-in-transit-panel] [data-cy=sit-delete-link]')
+  cy.get('[data-cy=storage-in-transit-panel] [data-cy=sit-delete-link]')
     .click()
     .get('[data-cy=sit-delete-warning] [data-cy=sit-delete-cancel]')
     .click()
@@ -597,8 +570,7 @@ function tspUserDeletesSitRequest() {
     .should('not.exist');
 
   // Now click on Delete SIT again, then actually delete it this time.
-  cy
-    .get('[data-cy=storage-in-transit-panel] [data-cy=sit-delete-link]')
+  cy.get('[data-cy=storage-in-transit-panel] [data-cy=sit-delete-link]')
     .click()
     .get('[data-cy=sit-delete-warning] [data-cy=sit-delete-delete]')
     .click()
@@ -620,16 +592,13 @@ function tspUserEditsSitRequestInSit() {
     expect(loc.pathname).to.match(/^\/shipments\/[^/]+/);
   });
 
-  cy
-    .get('[data-cy=storage-in-transit-panel] [data-cy=sit-edit-link]')
+  cy.get('[data-cy=storage-in-transit-panel] [data-cy=sit-edit-link]')
     .contains('Edit')
     .click();
-  cy
-    .get('input[name=actual_start_date]')
+  cy.get('input[name=actual_start_date]')
     .should('have.value', '3/30/2019')
     .click();
-  cy
-    .get('.DayPickerInput-Overlay .DayPicker-Day')
+  cy.get('.DayPickerInput-Overlay .DayPicker-Day')
     .contains('29')
     .click();
   cy.get('input[name=actual_start_date]').should('have.value', '3/29/2019');
@@ -656,16 +625,13 @@ function tspUserEditsReleasedSitRequest() {
     expect(loc.pathname).to.match(/^\/shipments\/[^/]+/);
   });
 
-  cy
-    .get('[data-cy=storage-in-transit-panel] [data-cy=sit-edit-link]')
+  cy.get('[data-cy=storage-in-transit-panel] [data-cy=sit-edit-link]')
     .contains('Edit')
     .click();
-  cy
-    .get('input[name=out_date]')
+  cy.get('input[name=out_date]')
     .should('have.value', '5/26/2019')
     .click();
-  cy
-    .get('.DayPickerInput-Overlay .DayPicker-Day')
+  cy.get('.DayPickerInput-Overlay .DayPicker-Day')
     .contains('29')
     .click();
   cy.get('input[name=out_date]').should('have.value', '5/29/2019');
@@ -689,48 +655,38 @@ function tspUserEditsDeliveredSitRequest() {
     expect(loc.pathname).to.match(/^\/shipments\/[^/]+/);
   });
 
-  cy
-    .get('[data-cy=storage-in-transit-panel] [data-cy=sit-edit-link]')
+  cy.get('[data-cy=storage-in-transit-panel] [data-cy=sit-edit-link]')
     .contains('Edit')
     .click();
-  cy
-    .get('input[name=out_date]')
+  cy.get('input[name=out_date]')
     .should('have.value', '3/27/2019')
     .click();
-  cy
-    .get('.DayPickerInput-Overlay .DayPicker-Day')
+  cy.get('.DayPickerInput-Overlay .DayPicker-Day')
     .contains('22')
     .click();
   // cannot change date_out to a date before the actual start date
-  cy
-    .get('input[name=out_date]')
+  cy.get('input[name=out_date]')
     .should('have.value', '3/27/2019')
     .click();
-  cy
-    .get('.DayPickerInput-Overlay .DayPicker-Day')
+  cy.get('.DayPickerInput-Overlay .DayPicker-Day')
     .contains('29')
     .click();
   cy.get('input[name=out_date]').should('have.value', '3/29/2019');
-  cy
-    .get('input[name=actual_start_date]')
+  cy.get('input[name=actual_start_date]')
     .should('have.value', '3/26/2019')
     .click();
   //if out date is changed, actual start date selector will update to include that new date as it's max date
-  cy
-    .get('.DayPickerInput-Overlay .DayPicker-Day')
+  cy.get('.DayPickerInput-Overlay .DayPicker-Day')
     .contains('30')
     .click();
-  cy
-    .get('input[name=actual_start_date]')
+  cy.get('input[name=actual_start_date]')
     .should('have.value', '3/26/2019')
     .click();
-  cy
-    .get('.DayPickerInput-Overlay .DayPicker-Day')
+  cy.get('.DayPickerInput-Overlay .DayPicker-Day')
     .contains('29')
     .click();
   cy.get('input[name=actual_start_date]').should('have.value', '3/29/2019');
-  cy
-    .get('input[name=actual_start_date]')
+  cy.get('input[name=actual_start_date]')
     .should('have.value', '3/29/2019')
     .click();
   cy.get('.usa-button-primary').click();
@@ -738,8 +694,7 @@ function tspUserEditsDeliveredSitRequest() {
     const text = $div.text();
     expect(text).to.include('29-Mar-2019');
   });
-  cy
-    .get('.editable-panel-header')
+  cy.get('.editable-panel-header')
     .contains('Dates')
     .siblings()
     .click()
@@ -753,8 +708,7 @@ function tspUserEditsDeliveredSitRequest() {
     .get('input[name="dates.actual_delivery_date"]')
     .should('have.value', '3/27/2019');
 
-  cy
-    .get('[data-cy=storage-in-transit-panel] [data-cy=sit-edit-link]')
+  cy.get('[data-cy=storage-in-transit-panel] [data-cy=sit-edit-link]')
     .contains('Edit')
     .click();
   cy

--- a/cypress/integration/tsp/tspCSRFProtect.js
+++ b/cypress/integration/tsp/tspCSRFProtect.js
@@ -32,25 +32,21 @@ describe('testing CSRF protection updating shipment info', function() {
     cy.signIntoTSP();
 
     // update info
-    cy
-      .get('div[class="rt-tr -odd"]')
+    cy.get('div[class="rt-tr -odd"]')
       .first()
       .dblclick();
 
     // save info
-    cy
-      .get('a[class="editable-panel-edit"]')
+    cy.get('a[class="editable-panel-edit"]')
       .first()
       .click();
 
-    cy
-      .get('textarea[name="dates.pm_survey_notes"]')
+    cy.get('textarea[name="dates.pm_survey_notes"]')
       .clear()
       .type('CSRF Test')
       .blur();
 
-    cy
-      .get('button[class="usa-button editable-panel-save"]')
+    cy.get('button[class="usa-button editable-panel-save"]')
       .should('be.enabled')
       .click();
 
@@ -63,19 +59,16 @@ describe('testing CSRF protection updating shipment info', function() {
     cy.signIntoTSP();
 
     // update info
-    cy
-      .get('div[class="rt-tr -odd"]')
+    cy.get('div[class="rt-tr -odd"]')
       .first()
       .dblclick();
 
     // save info
-    cy
-      .get('a[class="editable-panel-edit"]')
+    cy.get('a[class="editable-panel-edit"]')
       .first()
       .click();
 
-    cy
-      .get('textarea[name="dates.pm_survey_notes"]')
+    cy.get('textarea[name="dates.pm_survey_notes"]')
       .clear()
       .type('CSRF failed!')
       .blur();
@@ -84,16 +77,14 @@ describe('testing CSRF protection updating shipment info', function() {
     cy.clearCookie('masked_gorilla_csrf');
     cy.getCookie('masked_gorilla_csrf').should('not.exist');
 
-    cy
-      .get('button[class="usa-button editable-panel-save"]')
+    cy.get('button[class="usa-button editable-panel-save"]')
       .should('be.enabled')
       .click();
 
     cy.patientReload();
 
     // No error pops up so we check the value
-    cy
-      .get('div[class="panel-field pm_survey_notes notes"]')
+    cy.get('div[class="panel-field pm_survey_notes notes"]')
       .should('exist')
       .should('not.contain', 'CSRF failed!');
   });

--- a/cypress/integration/tsp/weightsAndItemsPanel.js
+++ b/cypress/integration/tsp/weightsAndItemsPanel.js
@@ -14,8 +14,7 @@ describe('TSP Interacts With the Weights & Items Panel', function() {
 });
 
 function withinWeightsAndItemsPanel(func) {
-  cy
-    .get('.editable-panel')
+  cy.get('.editable-panel')
     .contains('Weights & Items')
     .get('.editable-panel-content')
     .within(panel => {
@@ -71,8 +70,7 @@ function tspUserSeesEstimatedWeights() {
   // Check that the display view is correct for the estimated weights
   withinWeightsAndItemsPanel(() => testReadOnlyWeights);
 
-  cy
-    .get('.editable-panel-header')
+  cy.get('.editable-panel-header')
     .contains('Weights & Items')
     .siblings()
     .click();
@@ -81,13 +79,11 @@ function tspUserSeesEstimatedWeights() {
   withinWeightsAndItemsPanel(() => testReadOnlyWeights);
 
   // Verify the user can cancel
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Cancel')
     .should('be.enabled');
 
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Cancel')
     .click();
 }
@@ -110,68 +106,58 @@ function tspUserEntersNetWeight() {
     cy.get('.net_weight').should('not.exist');
   });
 
-  cy
-    .get('.editable-panel-header')
+  cy.get('.editable-panel-header')
     .contains('Weights & Items')
     .siblings()
     .click();
 
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Save')
     .should('not.be.enabled');
 
   // Fill out the net weight and save it
   withinWeightsAndItemsPanel(() => {
     cy.get('label[for="weights.pm_survey_weight_estimate"]').should('have.text', 'TSP estimateOptional');
-    cy
-      .get('input[name="weights.pm_survey_weight_estimate"]')
+    cy.get('input[name="weights.pm_survey_weight_estimate"]')
       .clear()
       .first()
       .type('5000')
       .blur();
     cy.get('label[for="weights.gross_weight"]').should('have.text', 'Gross');
-    cy
-      .get('input[name="weights.gross_weight"]')
+    cy.get('input[name="weights.gross_weight"]')
       .first()
       .type('30000')
       .blur();
     cy.get('label[for="weights.tare_weight"]').should('have.text', 'Tare');
-    cy
-      .get('input[name="weights.tare_weight"]')
+    cy.get('input[name="weights.tare_weight"]')
       .first()
       .type('10000')
       .blur();
     cy.get('label[for="weights.net_weight"]').should('have.text', 'Net (Gross - Tare)');
-    cy
-      .get('input[name="weights.net_weight"]')
+    cy.get('input[name="weights.net_weight"]')
       .first()
       .type('40000')
       .blur();
 
     cy.get('label[for="weights.pm_survey_progear_weight_estimate"]').should('have.text', 'Service memberOptional');
-    cy
-      .get('input[name="weights.pm_survey_progear_weight_estimate"]')
+    cy.get('input[name="weights.pm_survey_progear_weight_estimate"]')
       .clear()
       .first()
       .type('4000')
       .blur();
     cy.get('label[for="weights.pm_survey_spouse_progear_weight_estimate"]').contains('Spouse');
-    cy
-      .get('input[name="weights.pm_survey_spouse_progear_weight_estimate"]')
+    cy.get('input[name="weights.pm_survey_spouse_progear_weight_estimate"]')
       .clear()
       .first()
       .type('800')
       .blur();
   });
 
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Save')
     .should('be.enabled');
 
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Save')
     .click();
 

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -125,8 +125,7 @@ Cypress.Commands.add('waitForReactTableLoad', () => {
 Cypress.Commands.add('selectQueueItemMoveLocator', moveLocator => {
   cy.waitForReactTableLoad();
 
-  cy
-    .get('div')
+  cy.get('div')
     .contains(moveLocator)
     .dblclick();
 
@@ -153,48 +152,46 @@ Cypress.Commands.add(
 
     // request use to log in
     let sendRequest = (sendRequestUserType, maskedCSRFToken) => {
-      cy
-        .request({
-          url: '/devlocal-auth/login',
-          method: 'POST',
-          headers: {
-            'X-CSRF-TOKEN': maskedCSRFToken,
-          },
-          body: {
-            id: userId,
-            userType: sendRequestUserType,
-          },
-          form: true,
-          failOnStatusCode: false,
-        })
-        .then(resp => {
-          cy.visit('/');
-          // Default status code to check is 200
-          expect(resp.status).to.eq(expectedStatusCode);
-          // check response body if needed
-          if (expectedRespBody) {
-            expect(resp.body).to.eq(expectedRespBody);
-          }
+      cy.request({
+        url: '/devlocal-auth/login',
+        method: 'POST',
+        headers: {
+          'X-CSRF-TOKEN': maskedCSRFToken,
+        },
+        body: {
+          id: userId,
+          userType: sendRequestUserType,
+        },
+        form: true,
+        failOnStatusCode: false,
+      }).then(resp => {
+        cy.visit('/');
+        // Default status code to check is 200
+        expect(resp.status).to.eq(expectedStatusCode);
+        // check response body if needed
+        if (expectedRespBody) {
+          expect(resp.body).to.eq(expectedRespBody);
+        }
 
-          // Login should provide named session tokens
-          if (checkSessionToken) {
-            // Check that two CSRF cookies and one session cookie exists
-            cy.getCookies().should('have.length', 3);
-            if (sendRequestUserType === milmoveAppName) {
-              cy.getCookie('mil_session_token').should('exist');
-              cy.getCookie('office_session_token').should('not.exist');
-              cy.getCookie('tsp_session_token').should('not.exist');
-            } else if (sendRequestUserType === officeAppName) {
-              cy.getCookie('mil_session_token').should('not.exist');
-              cy.getCookie('office_session_token').should('exist');
-              cy.getCookie('tsp_session_token').should('not.exist');
-            } else if (sendRequestUserType === tspAppName) {
-              cy.getCookie('mil_session_token').should('not.exist');
-              cy.getCookie('office_session_token').should('not.exist');
-              cy.getCookie('tsp_session_token').should('exist');
-            }
+        // Login should provide named session tokens
+        if (checkSessionToken) {
+          // Check that two CSRF cookies and one session cookie exists
+          cy.getCookies().should('have.length', 3);
+          if (sendRequestUserType === milmoveAppName) {
+            cy.getCookie('mil_session_token').should('exist');
+            cy.getCookie('office_session_token').should('not.exist');
+            cy.getCookie('tsp_session_token').should('not.exist');
+          } else if (sendRequestUserType === officeAppName) {
+            cy.getCookie('mil_session_token').should('not.exist');
+            cy.getCookie('office_session_token').should('exist');
+            cy.getCookie('tsp_session_token').should('not.exist');
+          } else if (sendRequestUserType === tspAppName) {
+            cy.getCookie('mil_session_token').should('not.exist');
+            cy.getCookie('office_session_token').should('not.exist');
+            cy.getCookie('tsp_session_token').should('exist');
           }
-        });
+        }
+      });
     };
 
     // make sure we log out first before sign in
@@ -229,15 +226,13 @@ Cypress.Commands.add('logout', () => {
   cy.patientVisit('/');
 
   cy.getCookie('masked_gorilla_csrf').then(cookie => {
-    cy
-      .request({
-        url: '/auth/logout',
-        method: 'POST',
-        headers: { 'x-csrf-token': cookie.value },
-      })
-      .then(resp => {
-        expect(resp.status).to.equal(200);
-      });
+    cy.request({
+      url: '/auth/logout',
+      method: 'POST',
+      headers: { 'x-csrf-token': cookie.value },
+    }).then(resp => {
+      expect(resp.status).to.equal(200);
+    });
 
     // In case of login redirect we once more go to the homepage
     cy.patientVisit('/');
@@ -256,8 +251,7 @@ Cypress.Commands.add('setBaseUrlAndClearAllCookies', userType => {
 });
 
 Cypress.Commands.add('nextPage', () => {
-  cy
-    .get('button.next')
+  cy.get('button.next')
     .should('be.enabled')
     .click();
 });
@@ -304,37 +298,32 @@ function genericSelect(inputData, fieldName, classSelector) {
   if (fieldName) {
     classSelector = `${classSelector}.${fieldName}`;
   }
-  cy
-    .get(`${classSelector} input[type="text"]`)
+  cy.get(`${classSelector} input[type="text"]`)
     .first()
     .type(`{selectall}{backspace}${inputData}`, { force: true, delay: 75 });
 
   // Click on the first presented option
-  cy
-    .get(classSelector)
+  cy.get(classSelector)
     .find('div[class*="option"]')
     .click();
 }
 
 Cypress.Commands.add('typeInInput', ({ name, value }) => {
-  cy
-    .get(`input[name="${name}"]`)
+  cy.get(`input[name="${name}"]`)
     .clear()
     .type(value)
     .blur();
 });
 
 Cypress.Commands.add('clearInput', ({ name }) => {
-  cy
-    .get(`input[name="${name}"]`)
+  cy.get(`input[name="${name}"]`)
     .clear()
     .blur();
 });
 
 // function typeInTextArea({ name, value }) {
 Cypress.Commands.add('typeInTextarea', ({ name, value }) => {
-  cy
-    .get(`textarea[name="${name}"]`)
+  cy.get(`textarea[name="${name}"]`)
     .clear()
     .type(value)
     .blur();

--- a/cypress/support/datesPanel.js
+++ b/cypress/support/datesPanel.js
@@ -1,20 +1,17 @@
 /* global cy */
 
 export function userEntersDates() {
-  cy
-    .get('input[name="dates.pm_survey_conducted_date"]')
+  cy.get('input[name="dates.pm_survey_conducted_date"]')
     .first()
     .type('7/20/2018')
     .blur();
   cy.get('select[name="dates.pm_survey_method"]').select('PHONE');
 
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Save')
     .should('be.enabled');
 
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Save')
     .click();
 
@@ -24,30 +21,25 @@ export function userEntersDates() {
   cy.get('div.pm_survey_method').contains('Phone');
 
   // Pack Dates
-  cy
-    .get('.editable-panel-header')
+  cy.get('.editable-panel-header')
     .contains('Dates')
     .siblings()
     .click();
 
-  cy
-    .get('input[name="dates.pm_survey_planned_pack_date"]')
+  cy.get('input[name="dates.pm_survey_planned_pack_date"]')
     .first()
     .type('8/1/2018')
     .blur();
-  cy
-    .get('input[name="dates.actual_pack_date"]')
+  cy.get('input[name="dates.actual_pack_date"]')
     .first()
     .type('8/2/2018')
     .blur();
 
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Save')
     .should('be.enabled');
 
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Save')
     .click();
 
@@ -58,30 +50,25 @@ export function userEntersDates() {
   cy.get('div.actual_pack_date').contains('02-Aug-18');
 
   // Pickup Dates
-  cy
-    .get('.editable-panel-header')
+  cy.get('.editable-panel-header')
     .contains('Dates')
     .siblings()
     .click();
 
-  cy
-    .get('input[name="dates.pm_survey_planned_pickup_date"]')
+  cy.get('input[name="dates.pm_survey_planned_pickup_date"]')
     .first()
     .type('8/2/2018')
     .blur();
-  cy
-    .get('input[name="dates.actual_pickup_date"]')
+  cy.get('input[name="dates.actual_pickup_date"]')
     .first()
     .type('8/3/2018')
     .blur();
 
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Save')
     .should('be.enabled');
 
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Save')
     .click();
 
@@ -92,29 +79,24 @@ export function userEntersDates() {
   cy.get('div.actual_pickup_date').contains('03-Aug-18');
 
   // Delivery Dates
-  cy
-    .get('.editable-panel-header')
+  cy.get('.editable-panel-header')
     .contains('Dates')
     .siblings()
     .click();
 
-  cy
-    .get('input[name="dates.pm_survey_planned_delivery_date"]')
+  cy.get('input[name="dates.pm_survey_planned_delivery_date"]')
     .first()
     .type('10/9/2018')
     .blur();
-  cy
-    .get('input[name="dates.actual_delivery_date"]')
+  cy.get('input[name="dates.actual_delivery_date"]')
     .first()
     .type('10/10/2018');
 
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Save')
     .should('be.enabled');
 
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Save')
     .click();
 
@@ -126,26 +108,22 @@ export function userEntersDates() {
   cy.get('div.rdd').contains('09-Oct-18');
 
   // Notes
-  cy
-    .get('.editable-panel-header')
+  cy.get('.editable-panel-header')
     .contains('Dates')
     .siblings()
     .click();
 
-  cy
-    .get('textarea[name="dates.pm_survey_notes"]')
+  cy.get('textarea[name="dates.pm_survey_notes"]')
     .first()
     .clear()
     .type('Notes notes notes for dates')
     .blur();
 
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Save')
     .should('be.enabled');
 
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Save')
     .click();
 

--- a/cypress/support/preapprovals/test105be.js
+++ b/cypress/support/preapprovals/test105be.js
@@ -38,18 +38,14 @@ export function test105be() {
   cy.selectQueueItemMoveLocator('DATESP');
 
   add105({ code: '105B', itemSize: 30, crateSize: 25 });
-  cy
-    .get('td[details-cy="105B-details"]')
-    .should(
-      'contain',
-      'description description 105B Crate: 25" x 25" x 25" (9.04 cu ft) Item: 30" x 30" x 30" notes notes',
-    );
+  cy.get('td[details-cy="105B-details"]').should(
+    'contain',
+    'description description 105B Crate: 25" x 25" x 25" (9.04 cu ft) Item: 30" x 30" x 30" notes notes',
+  );
 
   add105({ code: '105E', itemSize: 40, crateSize: 50 });
-  cy
-    .get('td[details-cy="105E-details"]')
-    .should(
-      'contain',
-      'description description 105E Crate: 50" x 50" x 50" (72.33 cu ft) Item: 40" x 40" x 40" notes notes',
-    );
+  cy.get('td[details-cy="105E-details"]').should(
+    'contain',
+    'description description 105E Crate: 50" x 50" x 50" (72.33 cu ft) Item: 40" x 40" x 40" notes notes',
+  );
 }

--- a/cypress/support/preapprovals/test125abcd.js
+++ b/cypress/support/preapprovals/test125abcd.js
@@ -6,8 +6,7 @@ export function add125({ code }) {
   cy.selectTariff400ngItem(code);
   cy.get('select[name="location"]').select('ORIGIN');
   cy.typeInTextarea({ name: 'reason', value: `reason reason ${code}` });
-  cy
-    .get('input[name="date"]')
+  cy.get('input[name="date"]')
     .last()
     .type('4/29/2019{enter}')
     .blur();
@@ -48,34 +47,26 @@ export function test125ABCD() {
   cy.selectQueueItemMoveLocator('DATESP');
 
   add125({ code: '125A' });
-  cy
-    .get('td[data-cy="125A-details"]')
-    .should(
-      'contain',
-      'reason reason 125A Date of service: 29-Apr-19 Time of service: 0400J street address 1 street address 2 city, CA 90210',
-    );
+  cy.get('td[data-cy="125A-details"]').should(
+    'contain',
+    'reason reason 125A Date of service: 29-Apr-19 Time of service: 0400J street address 1 street address 2 city, CA 90210',
+  );
 
   add125({ code: '125B' });
-  cy
-    .get('td[data-cy="125B-details"]')
-    .should(
-      'contain',
-      'reason reason 125B Date of service: 29-Apr-19 Time of service: 0400J street address 1 street address 2 city, CA 90210',
-    );
+  cy.get('td[data-cy="125B-details"]').should(
+    'contain',
+    'reason reason 125B Date of service: 29-Apr-19 Time of service: 0400J street address 1 street address 2 city, CA 90210',
+  );
 
   add125({ code: '125C' });
-  cy
-    .get('td[data-cy="125C-details"]')
-    .should(
-      'contain',
-      'reason reason 125C Date of service: 29-Apr-19 Time of service: 0400J street address 1 street address 2 city, CA 90210',
-    );
+  cy.get('td[data-cy="125C-details"]').should(
+    'contain',
+    'reason reason 125C Date of service: 29-Apr-19 Time of service: 0400J street address 1 street address 2 city, CA 90210',
+  );
 
   add125({ code: '125D' });
-  cy
-    .get('td[data-cy="125D-details"]')
-    .should(
-      'contain',
-      'reason reason 125D Date of service: 29-Apr-19 Time of service: 0400J street address 1 street address 2 city, CA 90210',
-    );
+  cy.get('td[data-cy="125D-details"]').should(
+    'contain',
+    'reason reason 125D Date of service: 29-Apr-19 Time of service: 0400J street address 1 street address 2 city, CA 90210',
+  );
 }

--- a/cypress/support/preapprovals/test35a.js
+++ b/cypress/support/preapprovals/test35a.js
@@ -30,7 +30,8 @@ export function test35A() {
   cy.selectQueueItemMoveLocator('DATESP');
 
   add35A({});
-  cy
-    .get('td[details-cy="35A-details"]')
-    .should('contain', 'description description 35A reason reason 35A Est. not to exceed: $250.00 Actual amount: --');
+  cy.get('td[details-cy="35A-details"]').should(
+    'contain',
+    'description description 35A reason reason 35A Est. not to exceed: $250.00 Actual amount: --',
+  );
 }

--- a/cypress/support/preapprovals/testCreateRequest.js
+++ b/cypress/support/preapprovals/testCreateRequest.js
@@ -1,14 +1,12 @@
 /* global cy */
 export function fillAndSavePreApprovalRequest() {
   // Click on add Pre Approval Request
-  cy
-    .get('.add-request')
+  cy.get('.add-request')
     .contains('Add a request')
     .click();
 
   // Verify tariff items that don't require approval are not loaded into drop down
-  cy
-    .get('.tariff400-select #react-select-2-input')
+  cy.get('.tariff400-select #react-select-2-input')
     .first()
     .type('Linehaul Transportation{downarrow}{enter}', { force: true, delay: 75 });
   cy.get('.tariff400__single-value').should('not.exist');
@@ -17,66 +15,55 @@ export function fillAndSavePreApprovalRequest() {
   cy.selectTariff400ngItem('Article: Motorcycle');
 
   cy.get('select[name="location"]').select('ORIGIN');
-  cy
-    .get('input[name="quantity_1"]')
+  cy.get('input[name="quantity_1"]')
     .clear({ force: true })
     .type('2', { force: true });
   cy.typeInTextarea({ name: 'notes', value: `notes notes` });
 
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Save & Close')
     .should('be.enabled');
 
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Save & Close')
     .click();
 }
 
 export function editPreApprovalRequest() {
-  cy
-    .get('[data-test=edit-request]')
+  cy.get('[data-test=edit-request]')
     .first()
     .click();
 
   cy.typeInTextarea({ name: 'notes', value: `edited` });
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Save')
     .should('be.enabled');
 
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Save')
     .click();
 }
 
 export function approvePreApprovalRequest() {
   cy.get('[data-test=approve-request]').should('exist');
-  cy
-    .get('[data-test=approve-request]')
+  cy.get('[data-test=approve-request]')
     .first()
     .click();
 }
 
 export function deletePreApprovalRequest() {
-  cy
-    .get('[data-test=delete-request]')
+  cy.get('[data-test=delete-request]')
     .first()
     .click();
-  cy
-    .get('button')
+  cy.get('button')
     .contains('No, do not delete')
     .click();
 
-  cy
-    .get('[data-test=delete-request]')
+  cy.get('[data-test=delete-request]')
     .first()
     .click();
 
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Yes, delete')
     .click();
 }

--- a/cypress/support/preapprovals/testRobustAccessorials.js
+++ b/cypress/support/preapprovals/testRobustAccessorials.js
@@ -15,15 +15,13 @@ export function addLegacyRequest({ code, quantity1 }) {
 }
 
 export function clickAddARequest() {
-  cy
-    .get('.add-request')
+  cy.get('.add-request')
     .contains('Add a request')
     .click();
 }
 
 export function clickSaveAndClose() {
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Save & Close')
     .click();
 }

--- a/cypress/support/storagePanel.js
+++ b/cypress/support/storagePanel.js
@@ -1,25 +1,21 @@
 /* global cy */
 
 export function userSavesStorageDetails() {
-  cy
-    .get('.storage')
+  cy.get('.storage')
     .find('input[name="total_sit_cost"]')
     .first()
     .type('600');
 
-  cy
-    .get('.storage')
+  cy.get('.storage')
     .find('input[name="days_in_storage"]')
     .first()
     .type('60');
 
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Save')
     .should('be.enabled');
 
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Save')
     .click();
 
@@ -30,25 +26,21 @@ export function userSavesStorageDetails() {
 }
 
 export function userCancelsStorageDetails() {
-  cy
-    .get('.storage')
+  cy.get('.storage')
     .find('input[name="total_sit_cost"]')
     .first()
     .type('600');
 
-  cy
-    .get('.storage')
+  cy.get('.storage')
     .find('input[name="days_in_storage"]')
     .first()
     .type('60');
 
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Cancel')
     .should('be.enabled');
 
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Cancel')
     .click();
 

--- a/cypress/support/testCreateStorageInTransit.js
+++ b/cypress/support/testCreateStorageInTransit.js
@@ -1,55 +1,45 @@
 /* global cy */
 export function fillAndSaveStorageInTransit() {
   // Enter details in form and create the Storage In Transit request
-  cy
-
-    .get('input[name="estimated_start_date"]')
+  cy.get('input[name="estimated_start_date"]')
 
     .type('10/24/2018')
 
     .blur();
 
-  cy
-    .get('textarea[name="notes"]')
+  cy.get('textarea[name="notes"]')
     .first()
     .type('notes notes', { force: true, delay: 150 });
 
-  cy
-    .get('input[name="warehouse_id"]')
+  cy.get('input[name="warehouse_id"]')
     .first()
     .type('SIT123456SIT', { force: true, delay: 150 });
 
-  cy
-    .get('input[name="warehouse_name"]')
+  cy.get('input[name="warehouse_name"]')
     .first()
     .type('warehouse haus', { force: true, delay: 150 });
 
-  cy
-    .get('input[name="warehouse_address.street_address_1"]')
+  cy.get('input[name="warehouse_address.street_address_1"]')
     .first()
     .type('123 Anystreet St.', { force: true, delay: 150 });
 
-  cy
-    .get('input[name="warehouse_address.city"]')
+  cy.get('input[name="warehouse_address.city"]')
     .first()
     .type('Citycitycity', { force: true, delay: 150 });
 
   cy.get('select[name="warehouse_address.state"]').select('NY');
 
-  cy
-    .get('input[name="warehouse_address.postal_code"]')
+  cy.get('input[name="warehouse_address.postal_code"]')
     .first()
     .type('94703', { force: true, delay: 150 });
 
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Send Request')
     .should('be.enabled'); // assures default location is detected in form
 
   cy.get('input[data-cy="origin-radio"]').check({ force: true }); // checks Origin
 
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Send Request')
     .click();
 
@@ -74,8 +64,7 @@ export function fillAndSaveStorageInTransit() {
 }
 
 export function editAndSaveStorageInTransit() {
-  cy
-    .get('input[name="warehouse_name"]')
+  cy.get('input[name="warehouse_name"]')
     .first()
     .clear()
     .type('the haus', { force: true, delay: 150 });

--- a/cypress/support/testPremoveSurvey.js
+++ b/cypress/support/testPremoveSurvey.js
@@ -2,8 +2,7 @@
 
 export function selectPreMoveSurveyPanel() {
   // Click on edit Premove Survey
-  cy
-    .get('.editable-panel-header')
+  cy.get('.editable-panel-header')
     .contains('Premove')
     .siblings()
     .click();
@@ -11,59 +10,49 @@ export function selectPreMoveSurveyPanel() {
 
 export function fillAndSavePremoveSurvey() {
   // Enter details in form and save orders
-  cy
-    .get('input[name="survey.pm_survey_planned_pack_date"]')
+  cy.get('input[name="survey.pm_survey_planned_pack_date"]')
     .first()
     .type('8/1/2018')
     .blur();
-  cy
-    .get('input[name="survey.pm_survey_planned_pickup_date"]')
+  cy.get('input[name="survey.pm_survey_planned_pickup_date"]')
     .first()
     .type('8/2/2018')
     .blur();
-  cy
-    .get('input[name="survey.pm_survey_planned_delivery_date"]')
+  cy.get('input[name="survey.pm_survey_planned_delivery_date"]')
     .first()
     .type('8/6/2018')
     .blur();
-  cy
-    .get('input[name="survey.pm_survey_conducted_date"]')
+  cy.get('input[name="survey.pm_survey_conducted_date"]')
     .first()
     .type('7/20/2018')
     .blur();
-  cy
-    .get('input[name="survey.pm_survey_weight_estimate"]')
+  cy.get('input[name="survey.pm_survey_weight_estimate"]')
     .clear()
     .first()
     .type('6000')
     .blur();
-  cy
-    .get('input[name="survey.pm_survey_progear_weight_estimate"]')
+  cy.get('input[name="survey.pm_survey_progear_weight_estimate"]')
     .clear()
     .first()
     .type('4000')
     .blur();
-  cy
-    .get('input[name="survey.pm_survey_spouse_progear_weight_estimate"]')
+  cy.get('input[name="survey.pm_survey_spouse_progear_weight_estimate"]')
     .clear()
     .first()
     .type('800')
     .blur();
-  cy
-    .get('textarea[name="survey.pm_survey_notes"]')
+  cy.get('textarea[name="survey.pm_survey_notes"]')
     .clear()
     .first()
     .type('Notes notes notes')
     .blur();
   cy.get('select[name="survey.pm_survey_method"]').select('PHONE');
 
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Save')
     .should('be.enabled');
 
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Save')
     .click();
 }
@@ -78,8 +67,7 @@ export function testPremoveSurvey() {
   // Refresh browser and make sure changes persist
   cy.patientReload();
 
-  cy
-    .get('div.pm_survey_planned_delivery_date')
+  cy.get('div.pm_survey_planned_delivery_date')
     .get('span')
     .contains('4,000 lbs');
   cy.get('div.pm_survey_notes').contains('Notes notes notes');

--- a/cypress/support/testTspServiceAgents.js
+++ b/cypress/support/testTspServiceAgents.js
@@ -32,23 +32,19 @@ export function getFixture(role) {
 }
 
 export function userVerifiesTspAssigned() {
-  cy
-    .get('.editable-panel-3-column')
+  cy.get('.editable-panel-3-column')
     .contains('TSP')
     .parent()
     .within(() => {
-      cy
-        .get('.panel-field')
+      cy.get('.panel-field')
         .contains('Name')
         .parent()
         .should('contain', 'Truss Transport LLC (J12K)');
-      cy
-        .get('.panel-field')
+      cy.get('.panel-field')
         .contains('Email')
         .parent()
         .should('contain', 'joey.j@example.com');
-      cy
-        .get('.panel-field')
+      cy.get('.panel-field')
         .contains('Phone number')
         .parent()
         .should('contain', '(555) 101-0101');
@@ -58,18 +54,15 @@ export function userInputsServiceAgent(role) {
   const fixture = getFixture(role);
 
   // Enter details in form
-  cy
-    .get('input[name="' + fixture.Role + '.company"]')
+  cy.get('input[name="' + fixture.Role + '.company"]')
     .first()
     .type(fixture.Company)
     .blur();
-  cy
-    .get('input[name="' + fixture.Role + '.email"]')
+  cy.get('input[name="' + fixture.Role + '.email"]')
     .first()
     .type(fixture.Email)
     .blur();
-  cy
-    .get('input[name="' + fixture.Role + '.phone_number"]')
+  cy.get('input[name="' + fixture.Role + '.phone_number"]')
     .first()
     .type(fixture.Phone)
     .blur();
@@ -79,28 +72,23 @@ export function userClearsServiceAgent(role) {
   const fixture = getFixture(role);
 
   // Clear details in form
-  cy
-    .get('input[name="' + fixture.Role + '.company"]')
+  cy.get('input[name="' + fixture.Role + '.company"]')
     .clear()
     .blur();
-  cy
-    .get('input[name="' + fixture.Role + '.email"]')
+  cy.get('input[name="' + fixture.Role + '.email"]')
     .clear()
     .blur();
-  cy
-    .get('input[name="' + fixture.Role + '.phone_number"]')
+  cy.get('input[name="' + fixture.Role + '.phone_number"]')
     .clear()
     .blur();
 }
 
 export function userCancelsServiceAgent(role) {
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Cancel')
     .should('be.enabled');
 
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Cancel')
     .click();
 }
@@ -108,43 +96,35 @@ export function userCancelsServiceAgent(role) {
 export function userSavesServiceAgent(role) {
   const fixture = getFixture(role);
 
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Save')
     .should('be.enabled');
 
-  cy
-    .get('button')
+  cy.get('button')
     .contains('Save')
     .click();
 
   // Verify data has been saved in the UI
-  cy
-    .get('div.company')
+  cy.get('div.company')
     .get('span')
     .contains(fixture.Company);
-  cy
-    .get('div.email')
+  cy.get('div.email')
     .get('span')
     .contains(fixture.Email);
-  cy
-    .get('div.phone_number')
+  cy.get('div.phone_number')
     .get('span')
     .contains(fixture.Phone);
 
   // Refresh browser and make sure changes persist
   cy.patientReload();
 
-  cy
-    .get('div.company')
+  cy.get('div.company')
     .get('span')
     .contains(fixture.Company);
-  cy
-    .get('div.email')
+  cy.get('div.email')
     .get('span')
     .contains(fixture.Email);
-  cy
-    .get('div.phone_number')
+  cy.get('div.phone_number')
     .get('span')
     .contains(fixture.Phone);
 }

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -74,6 +74,7 @@ Adhere to Airbnb's [JavaScript Style Guide](https://github.com/airbnb/javascript
   * Prefer trailing commas for cleaner PRs and error reduction (CLI: `--trailing-comma true` API: `trailingComma: true`)
   * A `.prettierrc` file is in the project for the above settings.
   * Make sure to [set up your editor](https://prettier.io/docs/en/editors.html) to format (and possibly autosave) with Prettier with the above configurations. You will need to install Prettier globally for this.
+  * We currently pin the prettier dependency to a specific version to avoid frequent formatting churn.
 
 ### Linting
 

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "mocha-junit-reporter": "^1.18.0",
     "mocha-multi-reporters": "^1.1.7",
     "mockdate": "^2.0.2",
-    "prettier": "=1.12.1",
+    "prettier": "=1.18.2",
     "react-mock-router": "^1.0.15"
   },
   "browserslist": [

--- a/src/scenes/DPSAuthCookie/index.jsx
+++ b/src/scenes/DPSAuthCookie/index.jsx
@@ -67,4 +67,7 @@ function mapDispatchToProps(dispatch) {
   return bindActionCreators({ getCookieURL }, dispatch);
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(reduxForm({ form: 'dpsAuthCookie' })(DPSAuthCookie));
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(reduxForm({ form: 'dpsAuthCookie' })(DPSAuthCookie));

--- a/src/scenes/Landing/MoveSummary.jsx
+++ b/src/scenes/Landing/MoveSummary.jsx
@@ -111,7 +111,8 @@ export const DraftMoveSummary = props => {
 export const PPMAlert = props => {
   return (
     <Alert type="success" heading={props.heading}>
-      Next, wait for approval. Once approved:<br />
+      Next, wait for approval. Once approved:
+      <br />
       <ul>
         <li>
           Get certified <strong>weight tickets</strong>, both empty &amp; full
@@ -727,12 +728,11 @@ export class MoveSummaryComponent extends React.Component {
               <br />
             </div>
           )}
-          {isMissingWeightTicketDocuments &&
-            ppm.status === 'PAYMENT_REQUESTED' && (
-              <Alert type="warning" heading="Payment request is missing info">
-                You will need to contact your local PPPO office to resolve your missing weight ticket.
-              </Alert>
-            )}
+          {isMissingWeightTicketDocuments && ppm.status === 'PAYMENT_REQUESTED' && (
+            <Alert type="warning" heading="Payment request is missing info">
+              You will need to contact your local PPPO office to resolve your missing weight ticket.
+            </Alert>
+          )}
           <div className="usa-width-three-fourths">
             {(showHHG || (!showHHG && !showPPM)) && (
               <HHGComponent
@@ -815,4 +815,7 @@ const mapDispatchToProps = {
   getMoveDocumentsForMove,
   getPpmWeightEstimate,
 };
-export const MoveSummary = connect(mapStateToProps, mapDispatchToProps)(MoveSummaryComponent);
+export const MoveSummary = connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(MoveSummaryComponent);

--- a/src/scenes/Landing/PPMStatusTimeline.js
+++ b/src/scenes/Landing/PPMStatusTimeline.js
@@ -136,4 +136,7 @@ const mapDispatchToProps = {
   getSignedCertification,
 };
 
-export default connect(mapStateToProps, mapDispatchToProps)(PPMStatusTimeline);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(PPMStatusTimeline);

--- a/src/scenes/Landing/StatusTimeline.jsx
+++ b/src/scenes/Landing/StatusTimeline.jsx
@@ -184,8 +184,9 @@ export const StatusBlock = props => {
     <div className={classes.join(' ')}>
       <div className="status_dot" />
       <div className="status_name">{props.name}</div>
-      {props.dates &&
-        props.dates.length > 0 && <div className="status_dates">{displayDateRange(props.dates, 'condensed')}</div>}
+      {props.dates && props.dates.length > 0 && (
+        <div className="status_dates">{displayDateRange(props.dates, 'condensed')}</div>
+      )}
     </div>
   );
 };

--- a/src/scenes/Landing/index.jsx
+++ b/src/scenes/Landing/index.jsx
@@ -118,12 +118,11 @@ export class Landing extends Component {
         {loggedInUserSuccess && (
           <Fragment>
             <div>
-              {moveSubmitSuccess &&
-                !ppm && (
-                  <Alert type="success" heading="Success">
-                    You've submitted your move
-                  </Alert>
-                )}
+              {moveSubmitSuccess && !ppm && (
+                <Alert type="success" heading="Success">
+                  You've submitted your move
+                </Alert>
+              )}
               {isHHGPPMComboMove && hasSubmitSuccess && <PPMAlert heading="Your PPM shipment is submitted" />}
               {ppm && moveSubmitSuccess && <PPMAlert heading="Congrats - your move is submitted!" />}
               {loggedInUserError && (
@@ -138,26 +137,24 @@ export class Landing extends Component {
               )}
             </div>
 
-            {isLoggedIn &&
-              !isEmpty(serviceMember) &&
-              isProfileComplete && (
-                <MoveSummary
-                  context={context}
-                  entitlement={entitlement}
-                  profile={serviceMember}
-                  orders={orders}
-                  move={move}
-                  ppm={ppm}
-                  shipment={currentShipment}
-                  editMove={this.editMove}
-                  resumeMove={this.resumeMove}
-                  reviewProfile={this.reviewProfile}
-                  requestPaymentSuccess={requestPaymentSuccess}
-                  moveSubmitSuccess={moveSubmitSuccess}
-                  updateMove={updateMove}
-                  addPPMShipment={this.addPPMShipment}
-                />
-              )}
+            {isLoggedIn && !isEmpty(serviceMember) && isProfileComplete && (
+              <MoveSummary
+                context={context}
+                entitlement={entitlement}
+                profile={serviceMember}
+                orders={orders}
+                move={move}
+                ppm={ppm}
+                shipment={currentShipment}
+                editMove={this.editMove}
+                resumeMove={this.resumeMove}
+                reviewProfile={this.reviewProfile}
+                requestPaymentSuccess={requestPaymentSuccess}
+                moveSubmitSuccess={moveSubmitSuccess}
+                updateMove={updateMove}
+                addPPMShipment={this.addPPMShipment}
+              />
+            )}
           </Fragment>
         )}
       </div>
@@ -201,4 +198,11 @@ function mapDispatchToProps(dispatch) {
   return bindActionCreators({ push, createServiceMember, updateMove }, dispatch);
 }
 
-export default withContext(withLastLocation(connect(mapStateToProps, mapDispatchToProps)(Landing)));
+export default withContext(
+  withLastLocation(
+    connect(
+      mapStateToProps,
+      mapDispatchToProps,
+    )(Landing),
+  ),
+);

--- a/src/scenes/Legalese/SubmitPpm.jsx
+++ b/src/scenes/Legalese/SubmitPpm.jsx
@@ -35,4 +35,7 @@ function mapDispatchToProps(dispatch) {
   );
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(SignedCertification);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(SignedCertification);

--- a/src/scenes/Legalese/index.jsx
+++ b/src/scenes/Legalese/index.jsx
@@ -180,4 +180,7 @@ function mapDispatchToProps(dispatch) {
   );
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(SignedCertification);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(SignedCertification);

--- a/src/scenes/Moves/Hhg/DatePicker.jsx
+++ b/src/scenes/Moves/Hhg/DatePicker.jsx
@@ -173,4 +173,9 @@ function mapDispatchToProps(dispatch) {
   return bindActionCreators({ getMoveDatesSummary, getAvailableMoveDates }, dispatch);
 }
 
-export default withRouter(connect(mapStateToProps, mapDispatchToProps)(HHGDatePicker));
+export default withRouter(
+  connect(
+    mapStateToProps,
+    mapDispatchToProps,
+  )(HHGDatePicker),
+);

--- a/src/scenes/Moves/Hhg/Locations.jsx
+++ b/src/scenes/Moves/Hhg/Locations.jsx
@@ -116,4 +116,7 @@ function mapStateToProps(state, ownProps) {
   return props;
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(Locations);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(Locations);

--- a/src/scenes/Moves/Hhg/MoveDate.jsx
+++ b/src/scenes/Moves/Hhg/MoveDate.jsx
@@ -126,4 +126,7 @@ function mapStateToProps(state) {
   return props;
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(MoveDate);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(MoveDate);

--- a/src/scenes/Moves/Hhg/Progear.jsx
+++ b/src/scenes/Moves/Hhg/Progear.jsx
@@ -237,4 +237,7 @@ function mapStateToProps(state) {
   return props;
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(Progear);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(Progear);

--- a/src/scenes/Moves/Hhg/WeightCalculator.jsx
+++ b/src/scenes/Moves/Hhg/WeightCalculator.jsx
@@ -85,7 +85,8 @@ class WeightCalculator extends Component {
         <div className="weight-calculator-contents">
           <div className="usa-input">
             <label className="usa-input-label" htmlFor="rooms">
-              How many furnished rooms in your current home?<br />
+              How many furnished rooms in your current home?
+              <br />
               <span className="weight-calculator-help">
                 Include bedrooms, living, dining and family rooms, offices and a garage or offsite storage if you store
                 a lot there.

--- a/src/scenes/Moves/Hhg/WeightEstimate.jsx
+++ b/src/scenes/Moves/Hhg/WeightEstimate.jsx
@@ -195,4 +195,7 @@ function mapStateToProps(state) {
   return props;
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(WeightEstimate);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(WeightEstimate);

--- a/src/scenes/Moves/MoveType.jsx
+++ b/src/scenes/Moves/MoveType.jsx
@@ -59,7 +59,11 @@ class BigButtonGroup extends Component {
                   return (
                     <div key={key.toString()}>
                       <p>{key}</p>
-                      <ul className="smaller-text">{pros.map(item => <li key={item}>{item}</li>)}</ul>
+                      <ul className="smaller-text">
+                        {pros.map(item => (
+                          <li key={item}>{item}</li>
+                        ))}
+                      </ul>
                     </div>
                   );
                 }, this)}
@@ -192,4 +196,7 @@ function mapDispatchToProps(dispatch) {
   return bindActionCreators({ setPendingMoveType }, dispatch);
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(MoveType);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(MoveType);

--- a/src/scenes/Moves/MoveTypeWizard.jsx
+++ b/src/scenes/Moves/MoveTypeWizard.jsx
@@ -50,4 +50,7 @@ function mapDispatchToProps(dispatch) {
 function mapStateToProps(state) {
   return state.moves;
 }
-export default connect(mapStateToProps, mapDispatchToProps)(MoveTypeWizardPage);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(MoveTypeWizardPage);

--- a/src/scenes/Moves/Ppm/AllowableExpenses.jsx
+++ b/src/scenes/Moves/Ppm/AllowableExpenses.jsx
@@ -40,7 +40,8 @@ function AllowableExpenses(props) {
       </p>
       <hr className="divider" />
       <div className="bullet-li-header">
-        <FontAwesomeIcon aria-hidden className="icon" icon={faCheck} />Some commonly claimed moving expenses:
+        <FontAwesomeIcon aria-hidden className="icon" icon={faCheck} />
+        Some commonly claimed moving expenses:
       </div>
       <ul>
         <li>Consumable packing materials</li>
@@ -53,8 +54,8 @@ function AllowableExpenses(props) {
       </ul>
       <div className="divider dashed-divider" />
       <div className="bullet-li-header">
-        <FontAwesomeIcon aria-hidden className="icon" icon={faBan} />Some common expenses that are <em>not</em>{' '}
-        claimable or reimbursable:
+        <FontAwesomeIcon aria-hidden className="icon" icon={faBan} />
+        Some common expenses that are <em>not</em> claimable or reimbursable:
       </div>
       <ul>
         <li>Animal costs (kennels, transportation)</li>

--- a/src/scenes/Moves/Ppm/DateAndLocation.jsx
+++ b/src/scenes/Moves/Ppm/DateAndLocation.jsx
@@ -298,11 +298,11 @@ function mapStateToProps(state) {
   props.initialValues = props.currentPpm
     ? props.currentPpm
     : defaultPickupZip
-      ? {
-          pickup_postal_code: defaultPickupZip,
-          origin_duty_station_zip: originDutyStationZip,
-        }
-      : null;
+    ? {
+        pickup_postal_code: defaultPickupZip,
+        origin_duty_station_zip: originDutyStationZip,
+      }
+    : null;
 
   if (props.isHHGPPMComboMove) {
     props.defaultValues = {
@@ -321,4 +321,7 @@ function mapDispatchToProps(dispatch) {
   return bindActionCreators({ createOrUpdatePpm, getPpmSitEstimate, setInitialFormValues }, dispatch);
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(DateAndLocation);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(DateAndLocation);

--- a/src/scenes/Moves/Ppm/ExpensesUpload.jsx
+++ b/src/scenes/Moves/Ppm/ExpensesUpload.jsx
@@ -252,16 +252,15 @@ class ExpensesUpload extends Component {
                   onChange={this.handleCheckboxChange}
                   normalizeLabel
                 />
-                {isStorageExpense &&
-                  missingReceipt && (
-                    <span data-cy="storage-warning">
-                      <Alert type="warning">
-                        If you can, go online and print a new copy of your receipt, then upload it. <br />Otherwise,
-                        write and sign a statement that explains why this receipt is missing, then upload it. Finance
-                        will approve or reject this expense based on your information.
-                      </Alert>
-                    </span>
-                  )}
+                {isStorageExpense && missingReceipt && (
+                  <span data-cy="storage-warning">
+                    <Alert type="warning">
+                      If you can, go online and print a new copy of your receipt, then upload it. <br />
+                      Otherwise, write and sign a statement that explains why this receipt is missing, then upload it.
+                      Finance will approve or reject this expense based on your information.
+                    </Alert>
+                  </span>
+                )}
                 <div className="payment-method-radio-group-wrapper">
                   <p className="radio-group-header">How did you pay for this?</p>
                   <RadioButton
@@ -353,4 +352,11 @@ const mapDispatchToProps = {
   createMovingExpenseDocument,
 };
 
-export default withContext(withLastLocation(connect(mapStateToProps, mapDispatchToProps)(ExpensesUpload)));
+export default withContext(
+  withLastLocation(
+    connect(
+      mapStateToProps,
+      mapDispatchToProps,
+    )(ExpensesUpload),
+  ),
+);

--- a/src/scenes/Moves/Ppm/PPMPaymentRequestActionBtns.jsx
+++ b/src/scenes/Moves/Ppm/PPMPaymentRequestActionBtns.jsx
@@ -41,18 +41,17 @@ class PPMPaymentRequestActionBtns extends Component {
     } = this.props;
     return (
       <div className="usa-width-one-whole">
-        {hasConfirmation &&
-          this.state.displayConfirmation && (
-            <div className="ppm-payment-request-footer">
-              <AlertWithConfirmation
-                hasConfirmation={hasConfirmation}
-                type="warning"
-                cancelActionHandler={this.cancelConfirmationHandler}
-                okActionHandler={this.confirmFinishLater}
-                message="Go back to the home screen without saving current screen."
-              />
-            </div>
-          )}
+        {hasConfirmation && this.state.displayConfirmation && (
+          <div className="ppm-payment-request-footer">
+            <AlertWithConfirmation
+              hasConfirmation={hasConfirmation}
+              type="warning"
+              cancelActionHandler={this.cancelConfirmationHandler}
+              okActionHandler={this.confirmFinishLater}
+              message="Go back to the home screen without saving current screen."
+            />
+          </div>
+        )}
 
         {!this.state.displayConfirmation && (
           <div className="ppm-payment-request-footer">

--- a/src/scenes/Moves/Ppm/PPMPaymentRequestIntro.jsx
+++ b/src/scenes/Moves/Ppm/PPMPaymentRequestIntro.jsx
@@ -107,4 +107,9 @@ const mapDispatchToProps = {
   createOrUpdatePpm,
 };
 
-export default withContext(connect(mapStateToProps, mapDispatchToProps)(PPMPaymentRequestIntro));
+export default withContext(
+  connect(
+    mapStateToProps,
+    mapDispatchToProps,
+  )(PPMPaymentRequestIntro),
+);

--- a/src/scenes/Moves/Ppm/PPMSizeWizard.jsx
+++ b/src/scenes/Moves/Ppm/PPMSizeWizard.jsx
@@ -77,4 +77,7 @@ function mapStateToProps(state) {
     weightInfo: getRawWeightInfo(state),
   };
 }
-export default connect(mapStateToProps, mapDispatchToProps)(PpmSizeWizardPage);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(PpmSizeWizardPage);

--- a/src/scenes/Moves/Ppm/PaymentRequest.jsx
+++ b/src/scenes/Moves/Ppm/PaymentRequest.jsx
@@ -205,4 +205,7 @@ const mapDispatchToProps = {
   createMovingExpenseDocument,
 };
 
-export default connect(mapStateToProps, mapDispatchToProps)(PaymentRequest);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(PaymentRequest);

--- a/src/scenes/Moves/Ppm/PaymentReview/DocumentsUploaded.js
+++ b/src/scenes/Moves/Ppm/PaymentReview/DocumentsUploaded.js
@@ -125,4 +125,7 @@ const mapDispatchToProps = {
   getMoveDocumentsForMove,
 };
 
-export default connect(mapStateToProps, mapDispatchToProps)(DocumentsUploaded);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(DocumentsUploaded);

--- a/src/scenes/Moves/Ppm/PaymentReview/WeightTicketListItem.jsx
+++ b/src/scenes/Moves/Ppm/PaymentReview/WeightTicketListItem.jsx
@@ -58,13 +58,12 @@ const WeightTicketListItem = ({
       ) : (
         <p>Full weight ticket {full_weight} lbs</p>
       )}
-      {vehicle_options === 'CAR_TRAILER' &&
-        trailer_ownership_missing && (
-          <MissingLabel>
-            Missing ownership documentation{' '}
-            <FontAwesomeIcon style={{ color: 'red' }} className="icon" icon={faExclamationCircle} />
-          </MissingLabel>
-        )}
+      {vehicle_options === 'CAR_TRAILER' && trailer_ownership_missing && (
+        <MissingLabel>
+          Missing ownership documentation{' '}
+          <FontAwesomeIcon style={{ color: 'red' }} className="icon" icon={faExclamationCircle} />
+        </MissingLabel>
+      )}
       {vehicle_options === 'CAR_TRAILER' && !trailer_ownership_missing && <p>Ownership documentation</p>}
     </div>
   </div>

--- a/src/scenes/Moves/Ppm/PaymentReview/index.jsx
+++ b/src/scenes/Moves/Ppm/PaymentReview/index.jsx
@@ -185,4 +185,7 @@ const mapDispatchToProps = {
   getPpmWeightEstimate,
 };
 
-export default connect(mapStateToProps, mapDispatchToProps)(PaymentReview);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(PaymentReview);

--- a/src/scenes/Moves/Ppm/Size.jsx
+++ b/src/scenes/Moves/Ppm/Size.jsx
@@ -180,4 +180,7 @@ function mapDispatchToProps(dispatch) {
   return bindActionCreators({ setPendingPpmSize }, dispatch);
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(PpmSize);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(PpmSize);

--- a/src/scenes/Moves/Ppm/Weight.jsx
+++ b/src/scenes/Moves/Ppm/Weight.jsx
@@ -410,4 +410,7 @@ function mapDispatchToProps(dispatch) {
   );
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(PpmWeight);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(PpmWeight);

--- a/src/scenes/Moves/Ppm/WeightTicket.jsx
+++ b/src/scenes/Moves/Ppm/WeightTicket.jsx
@@ -240,68 +240,67 @@ class WeightTicket extends Component {
               required
             />
             <SwaggerField fieldName="vehicle_nickname" swagger={schema} required />
-            {vehicleType &&
-              this.isCarTrailer && (
-                <>
-                  <div className="radio-group-wrapper normalize-margins">
-                    <p className="radio-group-header">
-                      Do you own this trailer, and does it meet all <Link to="/trailer-criteria">trailer criteria</Link>?
-                    </p>
-                    <RadioButton
-                      inputClassName="inline_radio"
-                      labelClassName="inline_radio"
-                      label="Yes"
-                      value="Yes"
-                      name="isValidTrailer"
-                      checked={isValidTrailer === 'Yes'}
-                      onChange={event => this.handleChange(event, 'isValidTrailer')}
-                    />
+            {vehicleType && this.isCarTrailer && (
+              <>
+                <div className="radio-group-wrapper normalize-margins">
+                  <p className="radio-group-header">
+                    Do you own this trailer, and does it meet all <Link to="/trailer-criteria">trailer criteria</Link>?
+                  </p>
+                  <RadioButton
+                    inputClassName="inline_radio"
+                    labelClassName="inline_radio"
+                    label="Yes"
+                    value="Yes"
+                    name="isValidTrailer"
+                    checked={isValidTrailer === 'Yes'}
+                    onChange={event => this.handleChange(event, 'isValidTrailer')}
+                  />
 
-                    <RadioButton
-                      inputClassName="inline_radio"
-                      labelClassName="inline_radio"
-                      label="No"
-                      value="No"
-                      name="isValidTrailer"
-                      checked={isValidTrailer === 'No'}
-                      onChange={event => this.handleChange(event, 'isValidTrailer')}
-                    />
-                  </div>
-                  {isValidTrailer === 'Yes' && (
-                    <>
-                      <p className="normalize-margins" style={{ marginTop: '1em' }}>
-                        Proof of ownership (ex. registration, bill of sale)
-                      </p>
-                      <p>{documentSizeLimitMsg}</p>
-                      <span data-cy="trailer-upload">
-                        <Uploader
-                          options={{ labelIdle: uploadTrailerProofOfOwnership }}
-                          onRef={ref => (this.uploaders.trailer.uploaderRef = ref)}
-                          onChange={this.onUploadChange('trailer')}
-                          onAddFile={this.onAddFile('trailer')}
-                        />
-                      </span>
-                      <Checkbox
-                        label="I don't have ownership documentation"
-                        name="missingDocumentation"
-                        checked={missingDocumentation}
-                        onChange={this.handleCheckboxChange}
-                        normalizeLabel
+                  <RadioButton
+                    inputClassName="inline_radio"
+                    labelClassName="inline_radio"
+                    label="No"
+                    value="No"
+                    name="isValidTrailer"
+                    checked={isValidTrailer === 'No'}
+                    onChange={event => this.handleChange(event, 'isValidTrailer')}
+                  />
+                </div>
+                {isValidTrailer === 'Yes' && (
+                  <>
+                    <p className="normalize-margins" style={{ marginTop: '1em' }}>
+                      Proof of ownership (ex. registration, bill of sale)
+                    </p>
+                    <p>{documentSizeLimitMsg}</p>
+                    <span data-cy="trailer-upload">
+                      <Uploader
+                        options={{ labelIdle: uploadTrailerProofOfOwnership }}
+                        onRef={ref => (this.uploaders.trailer.uploaderRef = ref)}
+                        onChange={this.onUploadChange('trailer')}
+                        onAddFile={this.onAddFile('trailer')}
                       />
-                      {missingDocumentation && (
-                        <div className="one-half" data-cy="trailer-warning">
-                          <Alert type="warning">
-                            If your state does not provide a registration or bill of sale for your trailer, you may
-                            write and upload a signed and dated statement certifying that you or your spouse own the
-                            trailer and meets the <Link to="/trailer-criteria">trailer criteria</Link>. Upload your
-                            statement using the proof of ownership field.
-                          </Alert>
-                        </div>
-                      )}
-                    </>
-                  )}
-                </>
-              )}
+                    </span>
+                    <Checkbox
+                      label="I don't have ownership documentation"
+                      name="missingDocumentation"
+                      checked={missingDocumentation}
+                      onChange={this.handleCheckboxChange}
+                      normalizeLabel
+                    />
+                    {missingDocumentation && (
+                      <div className="one-half" data-cy="trailer-warning">
+                        <Alert type="warning">
+                          If your state does not provide a registration or bill of sale for your trailer, you may write
+                          and upload a signed and dated statement certifying that you or your spouse own the trailer and
+                          meets the <Link to="/trailer-criteria">trailer criteria</Link>. Upload your statement using
+                          the proof of ownership field.
+                        </Alert>
+                      </div>
+                    )}
+                  </>
+                )}
+              </>
+            )}
             {vehicleType && (
               <>
                 <div className="dashed-divider" />
@@ -490,4 +489,11 @@ const mapDispatchToProps = {
   createWeightTicketSetDocument,
 };
 
-export default withContext(withLastLocation(connect(mapStateToProps, mapDispatchToProps)(WeightTicket)));
+export default withContext(
+  withLastLocation(
+    connect(
+      mapStateToProps,
+      mapDispatchToProps,
+    )(WeightTicket),
+  ),
+);

--- a/src/scenes/MyMove/index.jsx
+++ b/src/scenes/MyMove/index.jsx
@@ -84,64 +84,56 @@ export class AppWrapper extends Component {
                 )}
               </div>
               {this.state.hasError && <SomethingWentWrong />}
-              {!this.state.hasError &&
-                !props.swaggerError && (
-                  <Switch>
-                    <Route exact path="/" component={Landing} />
-                    <Route exact path="/sm_style_guide" component={StyleGuide} />
-                    <Route path="/privacy-and-security-policy" component={PrivacyPolicyStatement} />
-                    <Route path="/accessibility" component={AccessibilityStatement} />
-                    {getWorkflowRoutes(props)}
-                    <ValidatedPrivateRoute exact path="/moves/:moveId/edit" component={Edit} />
-                    <ValidatedPrivateRoute exact path="/moves/review/edit-profile" component={EditProfile} />
-                    <ValidatedPrivateRoute
-                      exact
-                      path="/moves/review/edit-backup-contact"
-                      component={EditBackupContact}
-                    />
-                    <ValidatedPrivateRoute exact path="/moves/review/edit-contact-info" component={EditContactInfo} />
+              {!this.state.hasError && !props.swaggerError && (
+                <Switch>
+                  <Route exact path="/" component={Landing} />
+                  <Route exact path="/sm_style_guide" component={StyleGuide} />
+                  <Route path="/privacy-and-security-policy" component={PrivacyPolicyStatement} />
+                  <Route path="/accessibility" component={AccessibilityStatement} />
+                  {getWorkflowRoutes(props)}
+                  <ValidatedPrivateRoute exact path="/moves/:moveId/edit" component={Edit} />
+                  <ValidatedPrivateRoute exact path="/moves/review/edit-profile" component={EditProfile} />
+                  <ValidatedPrivateRoute exact path="/moves/review/edit-backup-contact" component={EditBackupContact} />
+                  <ValidatedPrivateRoute exact path="/moves/review/edit-contact-info" component={EditContactInfo} />
 
-                    <ValidatedPrivateRoute path="/moves/:moveId/review/edit-orders" component={EditOrders} />
-                    <ValidatedPrivateRoute
-                      path="/moves/:moveId/review/edit-date-and-location"
-                      component={EditDateAndLocation}
-                    />
-                    <ValidatedPrivateRoute path="/moves/:moveId/review/edit-weight" component={EditWeight} />
+                  <ValidatedPrivateRoute path="/moves/:moveId/review/edit-orders" component={EditOrders} />
+                  <ValidatedPrivateRoute
+                    path="/moves/:moveId/review/edit-date-and-location"
+                    component={EditDateAndLocation}
+                  />
+                  <ValidatedPrivateRoute path="/moves/:moveId/review/edit-weight" component={EditWeight} />
 
-                    <ValidatedPrivateRoute
-                      path="/shipments/:shipmentId/review/edit-hhg-dates"
-                      component={EditHHGDates}
-                    />
-                    {/* <ValidatedPrivateRoute path="/moves/:moveId/review/edit-hhg-locations" component={EditHHGLocations} /> */}
-                    {/* <ValidatedPrivateRoute path="/moves/:moveId/review/edit-hhg-weights" component={EditHHGWeights} /> */}
+                  <ValidatedPrivateRoute path="/shipments/:shipmentId/review/edit-hhg-dates" component={EditHHGDates} />
+                  {/* <ValidatedPrivateRoute path="/moves/:moveId/review/edit-hhg-locations" component={EditHHGLocations} /> */}
+                  {/* <ValidatedPrivateRoute path="/moves/:moveId/review/edit-hhg-weights" component={EditHHGWeights} /> */}
 
-                    <ValidatedPrivateRoute path="/moves/:moveId/request-payment" component={PaymentRequest} />
-                    <ValidatedPrivateRoute exact path="/weight-ticket-examples" component={WeightTicketExamples} />
-                    <ValidatedPrivateRoute exact path="/trailer-criteria" component={TrailerCriteria} />
-                    <ValidatedPrivateRoute exact path="/allowable-expenses" component={AllowableExpenses} />
-                    <ValidatedPrivateRoute
-                      path="/moves/:moveId/ppm-payment-request-intro"
-                      component={PPMPaymentRequestIntro}
-                    />
-                    <ValidatedPrivateRoute path="/moves/:moveId/ppm-weight-ticket" component={WeightTicket} />
-                    <ValidatedPrivateRoute path="/moves/:moveId/ppm-expenses-intro" component={ExpensesLanding} />
-                    <ValidatedPrivateRoute path="/moves/:moveId/ppm-expenses" component={ExpensesUpload} />
-                    <ValidatedPrivateRoute path="/moves/:moveId/ppm-payment-review" component={PaymentReview} />
-                    <ValidatedPrivateRoute exact path="/ppm-customer-agreement" component={CustomerAgreementLegalese} />
-                    <ValidatedPrivateRoute path="/dps_cookie" component={DPSAuthCookie} />
-                    <Route exact path="/forbidden">
-                      <div className="usa-grid">
-                        <h2>You are forbidden to use this endpoint</h2>
-                      </div>
-                    </Route>
-                    <Route exact path="/server_error">
-                      <div className="usa-grid">
-                        <h2>We are experiencing an internal server error</h2>
-                      </div>
-                    </Route>
-                    <Route component={this.noMatch} />
-                  </Switch>
-                )}
+                  <ValidatedPrivateRoute path="/moves/:moveId/request-payment" component={PaymentRequest} />
+                  <ValidatedPrivateRoute exact path="/weight-ticket-examples" component={WeightTicketExamples} />
+                  <ValidatedPrivateRoute exact path="/trailer-criteria" component={TrailerCriteria} />
+                  <ValidatedPrivateRoute exact path="/allowable-expenses" component={AllowableExpenses} />
+                  <ValidatedPrivateRoute
+                    path="/moves/:moveId/ppm-payment-request-intro"
+                    component={PPMPaymentRequestIntro}
+                  />
+                  <ValidatedPrivateRoute path="/moves/:moveId/ppm-weight-ticket" component={WeightTicket} />
+                  <ValidatedPrivateRoute path="/moves/:moveId/ppm-expenses-intro" component={ExpensesLanding} />
+                  <ValidatedPrivateRoute path="/moves/:moveId/ppm-expenses" component={ExpensesUpload} />
+                  <ValidatedPrivateRoute path="/moves/:moveId/ppm-payment-review" component={PaymentReview} />
+                  <ValidatedPrivateRoute exact path="/ppm-customer-agreement" component={CustomerAgreementLegalese} />
+                  <ValidatedPrivateRoute path="/dps_cookie" component={DPSAuthCookie} />
+                  <Route exact path="/forbidden">
+                    <div className="usa-grid">
+                      <h2>You are forbidden to use this endpoint</h2>
+                    </div>
+                  </Route>
+                  <Route exact path="/server_error">
+                    <div className="usa-grid">
+                      <h2>We are experiencing an internal server error</h2>
+                    </div>
+                  </Route>
+                  <Route component={this.noMatch} />
+                </Switch>
+              )}
             </Tag>
             <Footer />
           </div>
@@ -168,4 +160,7 @@ const mapStateToProps = state => {
 const mapDispatchToProps = dispatch =>
   bindActionCreators({ goBack, push, loadInternalSchema, getCurrentUserInfo }, dispatch);
 
-export default connect(mapStateToProps, mapDispatchToProps)(AppWrapper);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(AppWrapper);

--- a/src/scenes/Office/AccountingPanel.jsx
+++ b/src/scenes/Office/AccountingPanel.jsx
@@ -84,4 +84,7 @@ function mapDispatchToProps(dispatch) {
   );
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(AccountingPanel);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(AccountingPanel);

--- a/src/scenes/Office/BackupInfoPanel.jsx
+++ b/src/scenes/Office/BackupInfoPanel.jsx
@@ -123,4 +123,7 @@ function mapDispatchToProps(dispatch) {
   return { update };
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(BackupInfoPanel);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(BackupInfoPanel);

--- a/src/scenes/Office/CustomerInfoPanel.jsx
+++ b/src/scenes/Office/CustomerInfoPanel.jsx
@@ -174,4 +174,7 @@ function mapDispatchToProps(dispatch) {
   );
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(CustomerInfoPanel);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(CustomerInfoPanel);

--- a/src/scenes/Office/DocumentViewer/DocumentDetailPanel.jsx
+++ b/src/scenes/Office/DocumentViewer/DocumentDetailPanel.jsx
@@ -38,18 +38,15 @@ const DocumentDetailDisplay = ({
         <PanelSwaggerField title="Document Title" fieldName="title" required {...moveDocFieldProps} />
 
         <PanelSwaggerField title="Document Type" fieldName="move_document_type" required {...moveDocFieldProps} />
-        {isExpenseDocument &&
-          moveDocument.moving_expense_type && (
-            <PanelSwaggerField fieldName="moving_expense_type" {...moveDocFieldProps} />
-          )}
-        {isExpenseDocument &&
-          get(moveDocument, 'requested_amount_cents') && (
-            <PanelSwaggerField fieldName="requested_amount_cents" {...moveDocFieldProps} />
-          )}
-        {isExpenseDocument &&
-          get(moveDocument, 'payment_method') && (
-            <PanelSwaggerField fieldName="payment_method" {...moveDocFieldProps} />
-          )}
+        {isExpenseDocument && moveDocument.moving_expense_type && (
+          <PanelSwaggerField fieldName="moving_expense_type" {...moveDocFieldProps} />
+        )}
+        {isExpenseDocument && get(moveDocument, 'requested_amount_cents') && (
+          <PanelSwaggerField fieldName="requested_amount_cents" {...moveDocFieldProps} />
+        )}
+        {isExpenseDocument && get(moveDocument, 'payment_method') && (
+          <PanelSwaggerField fieldName="payment_method" {...moveDocFieldProps} />
+        )}
         {isWeightTicketDocument && (
           <>
             <PanelSwaggerField title="Vehicle Type" fieldName="vehicle_options" required {...moveDocFieldProps} />
@@ -224,4 +221,7 @@ function mapDispatchToProps(dispatch) {
   );
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(DocumentDetailPanel);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(DocumentDetailPanel);

--- a/src/scenes/Office/DocumentViewer/DocumentUploader.jsx
+++ b/src/scenes/Office/DocumentViewer/DocumentUploader.jsx
@@ -199,4 +199,7 @@ function mapDispatchToProps(dispatch) {
   );
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(DocumentUploader);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(DocumentUploader);

--- a/src/scenes/Office/DocumentViewer/index.jsx
+++ b/src/scenes/Office/DocumentViewer/index.jsx
@@ -174,17 +174,16 @@ class DocumentViewer extends Component {
                 </div>
               </TabPanel>
 
-              {moveDocumentId &&
-                moveDocumentId !== 'new' && (
-                  <TabPanel>
-                    <DocumentDetailPanel
-                      className="document-viewer"
-                      moveDocumentId={moveDocumentId}
-                      moveId={moveId}
-                      title=""
-                    />
-                  </TabPanel>
-                )}
+              {moveDocumentId && moveDocumentId !== 'new' && (
+                <TabPanel>
+                  <DocumentDetailPanel
+                    className="document-viewer"
+                    moveDocumentId={moveDocumentId}
+                    moveId={moveId}
+                    title=""
+                  />
+                </TabPanel>
+              )}
             </Tabs>
           </div>
         </div>
@@ -235,4 +234,7 @@ const mapDispatchToProps = {
   getMoveDocumentsForMove,
 };
 
-export default connect(mapStateToProps, mapDispatchToProps)(DocumentViewer);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(DocumentViewer);

--- a/src/scenes/Office/Hhg/RoutingPanel.jsx
+++ b/src/scenes/Office/Hhg/RoutingPanel.jsx
@@ -80,4 +80,7 @@ function mapDispatchToProps(dispatch) {
   );
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(RoutingPanel);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(RoutingPanel);

--- a/src/scenes/Office/Hhg/ServiceAgentsContainer.js
+++ b/src/scenes/Office/Hhg/ServiceAgentsContainer.js
@@ -60,4 +60,7 @@ function mapDispatchToProps(dispatch) {
   );
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(TspServiceAgents);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(TspServiceAgents);

--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -263,9 +263,7 @@ class MoveInfo extends Component {
 
   cancelMoveAndRedirect = cancelReason => {
     const messageLines = [
-      `Move #${this.props.move.locator} for ${this.props.serviceMember.last_name}, ${
-        this.props.serviceMember.first_name
-      } has been canceled`,
+      `Move #${this.props.move.locator} for ${this.props.serviceMember.last_name}, ${this.props.serviceMember.first_name} has been canceled`,
       'An email confirmation has been sent to the customer.',
     ];
     this.props.cancelMove(this.props.moveId, cancelReason).then(() => {
@@ -633,5 +631,10 @@ const mapDispatchToProps = dispatch =>
     dispatch,
   );
 
-const connectedMoveInfo = withContext(connect(mapStateToProps, mapDispatchToProps)(MoveInfo));
+const connectedMoveInfo = withContext(
+  connect(
+    mapStateToProps,
+    mapDispatchToProps,
+  )(MoveInfo),
+);
 export { connectedMoveInfo as default, ReferrerQueueLink };

--- a/src/scenes/Office/OrdersInfo.jsx
+++ b/src/scenes/Office/OrdersInfo.jsx
@@ -96,4 +96,7 @@ const mapStateToProps = (state, ownProps) => {
 
 const mapDispatchToProps = dispatch => bindActionCreators({ loadMove, loadOrders, loadServiceMember }, dispatch);
 
-export default connect(mapStateToProps, mapDispatchToProps)(OrdersInfo);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(OrdersInfo);

--- a/src/scenes/Office/OrdersPanel.jsx
+++ b/src/scenes/Office/OrdersPanel.jsx
@@ -168,4 +168,7 @@ function mapDispatchToProps(dispatch) {
   return { update };
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(OrdersPanel);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(OrdersPanel);

--- a/src/scenes/Office/OrdersViewerPanel.js
+++ b/src/scenes/Office/OrdersViewerPanel.js
@@ -162,4 +162,7 @@ function mapDispatchToProps(dispatch) {
   return { update };
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(OrdersViewerPanel);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(OrdersViewerPanel);

--- a/src/scenes/Office/Ppm/DatesAndLocationsPanel.jsx
+++ b/src/scenes/Office/Ppm/DatesAndLocationsPanel.jsx
@@ -91,4 +91,7 @@ function mapDispatchToProps(dispatch) {
   );
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(DatesAndLocationPanel);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(DatesAndLocationPanel);

--- a/src/scenes/Office/Ppm/ExpensesPanel.jsx
+++ b/src/scenes/Office/Ppm/ExpensesPanel.jsx
@@ -94,4 +94,7 @@ const mapDispatchToProps = dispatch =>
     dispatch,
   );
 
-export default connect(mapStateToProps, mapDispatchToProps)(ExpensesPanel);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(ExpensesPanel);

--- a/src/scenes/Office/Ppm/NetWeightPanel.jsx
+++ b/src/scenes/Office/Ppm/NetWeightPanel.jsx
@@ -17,12 +17,11 @@ const NetWeightDisplay = ({ ppmSchema, ppm, hasWeightTicketsPending, ppmPaymentR
   };
   return (
     <div className="editable-panel-column">
-      {ppmPaymentRequestedFlag &&
-        hasWeightTicketsPending && (
-          <div className="missing-info-alert">
-            <Alert type="warning">There are more weight tickets awaiting review.</Alert>
-          </div>
-        )}
+      {ppmPaymentRequestedFlag && hasWeightTicketsPending && (
+        <div className="missing-info-alert">
+          <Alert type="warning">There are more weight tickets awaiting review.</Alert>
+        </div>
+      )}
       <PanelSwaggerField title="Net Weight" fieldName="net_weight" required {...fieldProps} />
     </div>
   );
@@ -31,7 +30,8 @@ const NetWeightDisplay = ({ ppmSchema, ppm, hasWeightTicketsPending, ppmPaymentR
 const NetWeightEdit = ({ ppmSchema }) => {
   return (
     <div className="editable-panel-column net-weight">
-      <SwaggerField className="short-field" title="Net Weight" fieldName="net_weight" swagger={ppmSchema} required />lbs
+      <SwaggerField className="short-field" title="Net Weight" fieldName="net_weight" swagger={ppmSchema} required />
+      lbs
     </div>
   );
 };
@@ -77,4 +77,7 @@ function mapDispatchToProps(dispatch) {
   );
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(NetWeightPanel);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(NetWeightPanel);

--- a/src/scenes/Office/Ppm/PPMEstimatesPanel.jsx
+++ b/src/scenes/Office/Ppm/PPMEstimatesPanel.jsx
@@ -132,4 +132,7 @@ function mapDispatchToProps(dispatch) {
   );
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(PPMEstimatesPanel);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(PPMEstimatesPanel);

--- a/src/scenes/Office/Ppm/PaymentsPanel.jsx
+++ b/src/scenes/Office/Ppm/PaymentsPanel.jsx
@@ -319,4 +319,7 @@ const mapDispatchToProps = dispatch =>
     dispatch,
   );
 
-export default connect(mapStateToProps, mapDispatchToProps)(PaymentsTable);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(PaymentsTable);

--- a/src/scenes/Office/Ppm/StoragePanel.js
+++ b/src/scenes/Office/Ppm/StoragePanel.js
@@ -122,4 +122,7 @@ function mapDispatchToProps(dispatch) {
   );
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(StoragePanel);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(StoragePanel);

--- a/src/scenes/Office/Ppm/StorageReimbursementCalculator.jsx
+++ b/src/scenes/Office/Ppm/StorageReimbursementCalculator.jsx
@@ -158,7 +158,10 @@ function mapDispatchToProps(dispatch) {
   return bindActionCreators({ getPpmSitEstimate, clearPpmSitEstimate }, dispatch);
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(
   reduxForm({ form: formName, enableReinitialize: true, keepDirtyOnReinitialize: true })(
     StorageReimbursementCalculator,
   ),

--- a/src/scenes/Office/QueueTable.jsx
+++ b/src/scenes/Office/QueueTable.jsx
@@ -222,4 +222,9 @@ function mapDispatchToProps(dispatch) {
   return bindActionCreators({ setUserIsLoggedIn }, dispatch);
 }
 
-export default withRouter(connect(mapStateToProps, mapDispatchToProps)(QueueTable));
+export default withRouter(
+  connect(
+    mapStateToProps,
+    mapDispatchToProps,
+  )(QueueTable),
+);

--- a/src/scenes/Office/index.jsx
+++ b/src/scenes/Office/index.jsx
@@ -106,4 +106,7 @@ const mapStateToProps = state => ({
 const mapDispatchToProps = dispatch =>
   bindActionCreators({ loadInternalSchema, loadPublicSchema, getCurrentUserInfo }, dispatch);
 
-export default connect(mapStateToProps, mapDispatchToProps)(OfficeWrapper);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(OfficeWrapper);

--- a/src/scenes/Office/queueTableColumns.js
+++ b/src/scenes/Office/queueTableColumns.js
@@ -99,14 +99,16 @@ const sitExpires = CreateReactTableColumn(
     if (row.storage_in_transits && row.storage_in_transits.some(sit => sit.actual_start_date)) {
       return formatDate4DigitYear(
         moment.min(
-          row.storage_in_transits.filter(sit => sit.actual_start_date).map(sit => {
-            return moment(sit.actual_start_date).add(
-              selectEntitlements(row.weight_allotment).storage_in_transit +
-                sitDaysUsed(sit) -
-                sitTotalDaysUsed(row.storage_in_transits),
-              'days',
-            );
-          }),
+          row.storage_in_transits
+            .filter(sit => sit.actual_start_date)
+            .map(sit => {
+              return moment(sit.actual_start_date).add(
+                selectEntitlements(row.weight_allotment).storage_in_transit +
+                  sitDaysUsed(sit) -
+                  sitTotalDaysUsed(row.storage_in_transits),
+                'days',
+              );
+            }),
         ),
       );
     }

--- a/src/scenes/Orders/Orders.jsx
+++ b/src/scenes/Orders/Orders.jsx
@@ -114,4 +114,7 @@ function mapDispatchToProps(dispatch) {
     dispatch,
   );
 }
-export default connect(mapStateToProps, mapDispatchToProps)(Orders);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(Orders);

--- a/src/scenes/Orders/TransitionToMove.jsx
+++ b/src/scenes/Orders/TransitionToMove.jsx
@@ -43,4 +43,7 @@ function mapStateToProps(state) {
 function mapDispatchToProps(dispatch) {
   return bindActionCreators({ updateMove }, dispatch);
 }
-export default connect(mapStateToProps, mapDispatchToProps)(TransitionToMove);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(TransitionToMove);

--- a/src/scenes/Orders/UploadOrders.jsx
+++ b/src/scenes/Orders/UploadOrders.jsx
@@ -121,4 +121,7 @@ function mapStateToProps(state) {
   };
   return props;
 }
-export default connect(mapStateToProps, mapDispatchToProps)(UploadOrders);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(UploadOrders);

--- a/src/scenes/Review/EditBackupContact.jsx
+++ b/src/scenes/Review/EditBackupContact.jsx
@@ -107,4 +107,7 @@ function mapDispatchToProps(dispatch) {
   );
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(EditBackupContact);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(EditBackupContact);

--- a/src/scenes/Review/EditContactInfo.jsx
+++ b/src/scenes/Review/EditContactInfo.jsx
@@ -163,4 +163,7 @@ function mapDispatchToProps(dispatch) {
   );
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(EditContact);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(EditContact);

--- a/src/scenes/Review/EditDateAndLocation.jsx
+++ b/src/scenes/Review/EditDateAndLocation.jsx
@@ -185,10 +185,10 @@ function mapStateToProps(state) {
   props.initialValues = props.currentPpm
     ? props.currentPpm
     : defaultPickupZip
-      ? {
-          pickup_postal_code: defaultPickupZip,
-        }
-      : null;
+    ? {
+        pickup_postal_code: defaultPickupZip,
+      }
+    : null;
   return props;
 }
 function mapDispatchToProps(dispatch) {
@@ -205,4 +205,7 @@ function mapDispatchToProps(dispatch) {
   );
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(EditDateAndLocation);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(EditDateAndLocation);

--- a/src/scenes/Review/EditOrders.jsx
+++ b/src/scenes/Review/EditOrders.jsx
@@ -216,4 +216,7 @@ function mapDispatchToProps(dispatch) {
   );
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(EditOrders);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(EditOrders);

--- a/src/scenes/Review/EditProfile.jsx
+++ b/src/scenes/Review/EditProfile.jsx
@@ -164,4 +164,7 @@ function mapDispatchToProps(dispatch) {
   );
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(EditProfile);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(EditProfile);

--- a/src/scenes/Review/EditShipment.jsx
+++ b/src/scenes/Review/EditShipment.jsx
@@ -129,4 +129,8 @@ function mergeProps(stateProps, dispatchProps, ownProps) {
   });
 }
 
-export default connect(mapStateToProps, mapDispatchToProps, mergeProps)(EditShipment);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+  mergeProps,
+)(EditShipment);

--- a/src/scenes/Review/EditWeight.jsx
+++ b/src/scenes/Review/EditWeight.jsx
@@ -102,16 +102,13 @@ let EditWeightForm = props => {
             <span> lbs</span>
           </div>
           <div>
-            {!advanceError &&
-              initialValues &&
-              initialValues.incentive_estimate_min &&
-              dirty && (
-                <div className="usa-alert usa-alert-warning">
-                  <div className="usa-alert-body">
-                    <p className="usa-alert-text">This update will change your incentive.</p>
-                  </div>
+            {!advanceError && initialValues && initialValues.incentive_estimate_min && dirty && (
+              <div className="usa-alert usa-alert-warning">
+                <div className="usa-alert-body">
+                  <p className="usa-alert-text">This update will change your incentive.</p>
                 </div>
-              )}
+              </div>
+            )}
             {advanceError && (
               <p className="advance-error">Weight is too low and will require paying back the advance.</p>
             )}
@@ -286,4 +283,7 @@ function mapDispatchToProps(dispatch) {
   );
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(EditWeight);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(EditWeight);

--- a/src/scenes/Review/ProfileReview.jsx
+++ b/src/scenes/Review/ProfileReview.jsx
@@ -73,4 +73,7 @@ function mapStateToProps(state) {
 function mapDispatchToProps(dispatch) {
   return bindActionCreators({ push }, dispatch);
 }
-export default connect(mapStateToProps, mapDispatchToProps)(ProfileReview);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(ProfileReview);

--- a/src/scenes/Review/ServiceMemberSummary.jsx
+++ b/src/scenes/Review/ServiceMemberSummary.jsx
@@ -130,13 +130,12 @@ function ServiceMemberSummary(props) {
                     <td> Dependents?: </td>
                     <td> {orders && yesNoMap[get(orders, 'has_dependents').toString()]}</td>
                   </tr>
-                  {orders &&
-                    get(orders, 'spouse_has_pro_gear') && (
-                      <tr>
-                        <td> Spouse Pro Gear?: </td>
-                        <td>{orders && yesNoMap[get(orders, 'spouse_has_pro_gear').toString()]}</td>
-                      </tr>
-                    )}
+                  {orders && get(orders, 'spouse_has_pro_gear') && (
+                    <tr>
+                      <td> Spouse Pro Gear?: </td>
+                      <td>{orders && yesNoMap[get(orders, 'spouse_has_pro_gear').toString()]}</td>
+                    </tr>
+                  )}
                   <tr>
                     <td> Orders Uploaded: </td>
                     <td>{get(orders, 'uploaded_orders.uploads') && get(orders, 'uploaded_orders.uploads').length}</td>

--- a/src/scenes/Review/Summary.jsx
+++ b/src/scenes/Review/Summary.jsx
@@ -107,13 +107,12 @@ export class Summary extends Component {
         {showPPMShipmentSummary && (
           <PPMShipmentSummary ppm={currentPpm} movePath={rootAddressWithMoveId} isHHGPPMComboMove={isHHGPPMComboMove} />
         )}
-        {moveIsApproved &&
-          !isHHGPPMComboMove && (
-            <div className="approved-edit-warning">
-              *To change these fields, contact your local PPPO office at {get(currentStation, 'name')}{' '}
-              {stationPhone ? ` at ${stationPhone}` : ''}.
-            </div>
-          )}
+        {moveIsApproved && !isHHGPPMComboMove && (
+          <div className="approved-edit-warning">
+            *To change these fields, contact your local PPPO office at {get(currentStation, 'name')}{' '}
+            {stationPhone ? ` at ${stationPhone}` : ''}.
+          </div>
+        )}
       </Fragment>
     );
   }
@@ -166,4 +165,9 @@ function mapDispatchToProps(dispatch, ownProps) {
     },
   };
 }
-export default withRouter(connect(mapStateToProps, mapDispatchToProps)(Summary));
+export default withRouter(
+  connect(
+    mapStateToProps,
+    mapDispatchToProps,
+  )(Summary),
+);

--- a/src/scenes/ServiceMembers/BackupContact.jsx
+++ b/src/scenes/ServiceMembers/BackupContact.jsx
@@ -232,4 +232,7 @@ function mapStateToProps(state) {
     values: getFormValues(formName)(state),
   };
 }
-export default connect(mapStateToProps, mapDispatchToProps)(BackupContact);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(BackupContact);

--- a/src/scenes/ServiceMembers/BackupMailingAddress.jsx
+++ b/src/scenes/ServiceMembers/BackupMailingAddress.jsx
@@ -68,4 +68,7 @@ function mapStateToProps(state) {
     ...state.serviceMember,
   };
 }
-export default connect(mapStateToProps, mapDispatchToProps)(BackupMailingAddress);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(BackupMailingAddress);

--- a/src/scenes/ServiceMembers/ContactInfo.jsx
+++ b/src/scenes/ServiceMembers/ContactInfo.jsx
@@ -93,4 +93,7 @@ function mapStateToProps(state) {
     ...state.serviceMember,
   };
 }
-export default connect(mapStateToProps, mapDispatchToProps)(ContactInfo);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(ContactInfo);

--- a/src/scenes/ServiceMembers/DodInfo.jsx
+++ b/src/scenes/ServiceMembers/DodInfo.jsx
@@ -55,12 +55,11 @@ class SSNField extends Component {
           Social security number
         </label>
         <input {...this.props.input} onFocus={this.localOnFocus} onBlur={this.localOnBlur} value={displayedValue} />
-        {touched &&
-          error && (
-            <span className="usa-input-error-message" id={name + '-error'} role="alert">
-              {error}
-            </span>
-          )}
+        {touched && error && (
+          <span className="usa-input-error-message" id={name + '-error'} role="alert">
+            {error}
+          </span>
+        )}
       </div>
     );
   }
@@ -147,4 +146,7 @@ function mapStateToProps(state) {
   };
   return props;
 }
-export default connect(mapStateToProps, mapDispatchToProps)(DodInfo);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(DodInfo);

--- a/src/scenes/ServiceMembers/DutyStation.jsx
+++ b/src/scenes/ServiceMembers/DutyStation.jsx
@@ -103,4 +103,7 @@ function mapStateToProps(state) {
   };
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(DutyStation);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(DutyStation);

--- a/src/scenes/ServiceMembers/Name.jsx
+++ b/src/scenes/ServiceMembers/Name.jsx
@@ -62,4 +62,7 @@ function mapStateToProps(state) {
     ...state.serviceMember,
   };
 }
-export default connect(mapStateToProps, mapDispatchToProps)(Name);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(Name);

--- a/src/scenes/ServiceMembers/ResidentialAddress.jsx
+++ b/src/scenes/ServiceMembers/ResidentialAddress.jsx
@@ -74,4 +74,7 @@ function mapStateToProps(state) {
     ...state.serviceMember,
   };
 }
-export default connect(mapStateToProps, mapDispatchToProps)(ResidentialAddress);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(ResidentialAddress);

--- a/src/scenes/SystemAdmin/LogoutButton.jsx
+++ b/src/scenes/SystemAdmin/LogoutButton.jsx
@@ -21,4 +21,7 @@ const LogoutButton = ({ userLogout, ...rest }) => (
 );
 const redirectTo = '/';
 const customUserLogout = () => userLogout(redirectTo);
-export default connect(undefined, { userLogout: customUserLogout })(LogoutButton);
+export default connect(
+  undefined,
+  { userLogout: customUserLogout },
+)(LogoutButton);

--- a/src/scenes/SystemAdmin/SignIn.jsx
+++ b/src/scenes/SystemAdmin/SignIn.jsx
@@ -14,7 +14,8 @@ const SignIn = ({ context, location }) => {
         {error && (
           <div>
             <Alert type="error" heading="An error occurred">
-              There was an error during your last sign in attempt. Please try again.<br />
+              There was an error during your last sign in attempt. Please try again.
+              <br />
               Error code: {error}
             </Alert>
             <br />

--- a/src/scenes/TransportationServiceProvider/ContactInfo.jsx
+++ b/src/scenes/TransportationServiceProvider/ContactInfo.jsx
@@ -59,4 +59,7 @@ const mapDispatchToProps = dispatch =>
     dispatch,
   );
 
-export default connect(mapStateToProps, mapDispatchToProps)(TransportationServiceProviderContactInfo);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(TransportationServiceProviderContactInfo);

--- a/src/scenes/TransportationServiceProvider/DocumentViewerContainer.jsx
+++ b/src/scenes/TransportationServiceProvider/DocumentViewerContainer.jsx
@@ -45,4 +45,7 @@ const mapDispatchToProps = (dispatch, ownProps) => {
   };
 };
 
-export default connect(mapStateToProps, mapDispatchToProps)(MoveDocumentView);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(MoveDocumentView);

--- a/src/scenes/TransportationServiceProvider/NewDocumentContainer.jsx
+++ b/src/scenes/TransportationServiceProvider/NewDocumentContainer.jsx
@@ -42,4 +42,7 @@ const mapDispatchToProps = (dispatch, ownProps) => {
   };
 };
 
-export default connect(mapStateToProps, mapDispatchToProps)(NewDocumentView);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(NewDocumentView);

--- a/src/scenes/TransportationServiceProvider/QueueTable.jsx
+++ b/src/scenes/TransportationServiceProvider/QueueTable.jsx
@@ -215,4 +215,9 @@ function mapDispatchToProps(dispatch) {
   return bindActionCreators({ setUserIsLoggedIn }, dispatch);
 }
 
-export default withRouter(connect(mapStateToProps, mapDispatchToProps)(QueueTable));
+export default withRouter(
+  connect(
+    mapStateToProps,
+    mapDispatchToProps,
+  )(QueueTable),
+);

--- a/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
+++ b/src/scenes/TransportationServiceProvider/ShipmentInfo.jsx
@@ -374,14 +374,13 @@ class ShipmentInfo extends Component {
                   </span>
                 </Alert>
               )}
-              {pmSurveyComplete &&
-                !gblGenerated && (
-                  <div>
-                    <button onClick={this.generateGBL} disabled={!approved || generateGBLInProgress}>
-                      Generate the GBL
-                    </button>
-                  </div>
-                )}
+              {pmSurveyComplete && !gblGenerated && (
+                <div>
+                  <button onClick={this.generateGBL} disabled={!approved || generateGBLInProgress}>
+                    Generate the GBL
+                  </button>
+                </div>
+              )}
               {canEnterPreMoveSurvey && (
                 <FormButton
                   shipmentId={shipmentId}
@@ -523,6 +522,11 @@ const mapDispatchToProps = dispatch =>
     dispatch,
   );
 
-const connectedShipmentInfo = withContext(connect(mapStateToProps, mapDispatchToProps)(ShipmentInfo));
+const connectedShipmentInfo = withContext(
+  connect(
+    mapStateToProps,
+    mapDispatchToProps,
+  )(ShipmentInfo),
+);
 
 export { DeliveryDateFormView, connectedShipmentInfo as default, ReferrerQueueLink };

--- a/src/scenes/TransportationServiceProvider/index.jsx
+++ b/src/scenes/TransportationServiceProvider/index.jsx
@@ -98,4 +98,7 @@ const mapStateToProps = state => ({
 
 const mapDispatchToProps = dispatch => bindActionCreators({ loadPublicSchema, getCurrentUserInfo }, dispatch);
 
-export default connect(mapStateToProps, mapDispatchToProps)(TspWrapper);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(TspWrapper);

--- a/src/shared/DocumentViewer/DocumentUploader.jsx
+++ b/src/shared/DocumentViewer/DocumentUploader.jsx
@@ -131,4 +131,7 @@ const mapStateToProps = (state, props) => ({
   formValues: getFormValues(props.form)(state),
 });
 
-export default connect(mapStateToProps, { replace })(DocumentUploader);
+export default connect(
+  mapStateToProps,
+  { replace },
+)(DocumentUploader);

--- a/src/shared/EditablePanel/index.jsx
+++ b/src/shared/EditablePanel/index.jsx
@@ -152,12 +152,11 @@ export class EditablePanel extends Component {
       <div className={classes}>
         <div className="editable-panel-header">
           <div className="title">{this.props.title}</div>
-          {!this.props.isEditable &&
-            this.props.editEnabled && (
-              <a className="editable-panel-edit" onClick={this.handleEditClick}>
-                Edit
-              </a>
-            )}
+          {!this.props.isEditable && this.props.editEnabled && (
+            <a className="editable-panel-edit" onClick={this.handleEditClick}>
+              Edit
+            </a>
+          )}
         </div>
         <div className="editable-panel-content">
           {this.props.children}

--- a/src/shared/Entities/modules/invoices.js
+++ b/src/shared/Entities/modules/invoices.js
@@ -27,8 +27,9 @@ const selectInvoices = (state, shipmentId) => {
   });
 };
 
-export const selectSortedInvoices = createSelector([selectInvoices], items =>
-  orderBy(items, ['invoiced_date'], ['desc']),
+export const selectSortedInvoices = createSelector(
+  [selectInvoices],
+  items => orderBy(items, ['invoiced_date'], ['desc']),
 );
 
 export const selectInvoice = (state, id) => denormalize([id], InvoiceModel, state.entities)[0];

--- a/src/shared/Entities/modules/shipmentLineItems.js
+++ b/src/shared/Entities/modules/shipmentLineItems.js
@@ -108,8 +108,9 @@ const selectShipmentLineItems = (state, shipmentId) => {
   return filterByShipmentId(shipmentId, filteredItems);
 };
 
-export const selectSortedShipmentLineItems = createSelector([selectShipmentLineItems], items =>
-  flow([listLinehaulItemsBeforeAccessorials, orderItemsBy])(items),
+export const selectSortedShipmentLineItems = createSelector(
+  [selectShipmentLineItems],
+  items => flow([listLinehaulItemsBeforeAccessorials, orderItemsBy])(items),
 );
 
 export const selectSortedPreApprovalShipmentLineItems = createSelector(
@@ -133,25 +134,33 @@ const selectUnbilledShipmentLineItemsByShipmentId = (state, shipmentId) => {
   ])(getShipmentIds(state));
 };
 
-export const selectUnbilledShipmentLineItems = createSelector([selectUnbilledShipmentLineItemsByShipmentId], items =>
-  flow([listLinehaulItemsBeforeAccessorials, orderItemsBy])(items),
+export const selectUnbilledShipmentLineItems = createSelector(
+  [selectUnbilledShipmentLineItemsByShipmentId],
+  items => flow([listLinehaulItemsBeforeAccessorials, orderItemsBy])(items),
 );
 
-export const selectInvoiceShipmentLineItems = createSelector([selectInvoicesShipmentLineItemsByInvoiceId], items =>
-  flow([listLinehaulItemsBeforeAccessorials, orderItemsBy])(items),
+export const selectInvoiceShipmentLineItems = createSelector(
+  [selectInvoicesShipmentLineItemsByInvoiceId],
+  items => flow([listLinehaulItemsBeforeAccessorials, orderItemsBy])(items),
 );
 
-export const selectTotalFromUnbilledLineItems = createSelector([selectUnbilledShipmentLineItemsByShipmentId], items => {
-  return items.reduce((acm, item) => {
-    return acm + (item.amount_cents ? item.amount_cents : 0);
-  }, 0);
-});
+export const selectTotalFromUnbilledLineItems = createSelector(
+  [selectUnbilledShipmentLineItemsByShipmentId],
+  items => {
+    return items.reduce((acm, item) => {
+      return acm + (item.amount_cents ? item.amount_cents : 0);
+    }, 0);
+  },
+);
 
-export const selectTotalFromInvoicedLineItems = createSelector([selectInvoicesShipmentLineItemsByInvoiceId], items => {
-  return items.reduce((acm, item) => {
-    return acm + item.amount_cents;
-  }, 0);
-});
+export const selectTotalFromInvoicedLineItems = createSelector(
+  [selectInvoicesShipmentLineItemsByInvoiceId],
+  items => {
+    return items.reduce((acm, item) => {
+      return acm + item.amount_cents;
+    }, 0);
+  },
+);
 
 export const selectLocationFromTariff400ngItem = (state, selectedTariff400ngItem) => {
   if (!selectedTariff400ngItem) return [];

--- a/src/shared/Entities/modules/tariff400ngItems.js
+++ b/src/shared/Entities/modules/tariff400ngItems.js
@@ -14,13 +14,16 @@ export function getAllTariff400ngItems(requires_pre_approval, label = getTariff4
 export const selectTariff400ngItems = state =>
   denormalize(keys(state.entities.tariff400ngItems), tariff400ngItems, state.entities);
 
-export const selectSortedTariff400ngItems = createSelector([selectTariff400ngItems], items =>
-  // Sorts by the numeric part of code, e.g. "256A" -> 256
-  sortBy(items, item => parseInt(item.code.match(/[0-9]+/g))),
+export const selectSortedTariff400ngItems = createSelector(
+  [selectTariff400ngItems],
+  items =>
+    // Sorts by the numeric part of code, e.g. "256A" -> 256
+    sortBy(items, item => parseInt(item.code.match(/[0-9]+/g))),
 );
 
-export const selectSortedPreApprovalTariff400ngItems = createSelector([selectSortedTariff400ngItems], items =>
-  filter(items, item => item.requires_pre_approval),
+export const selectSortedPreApprovalTariff400ngItems = createSelector(
+  [selectSortedTariff400ngItems],
+  items => filter(items, item => item.requires_pre_approval),
 );
 
 export const selectTariff400ngItem = (state, id) => denormalize([id], tariff400ngItems, state.entities)[0];

--- a/src/shared/Invoice/InvoicePanel.jsx
+++ b/src/shared/Invoice/InvoicePanel.jsx
@@ -122,4 +122,7 @@ const mapStateToProps = (state, ownProps) => {
 function mapDispatchToProps(dispatch) {
   return bindActionCreators({ createInvoice, getAllShipmentLineItems, getAllInvoices }, dispatch);
 }
-export default connect(mapStateToProps, mapDispatchToProps)(InvoicePanel);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(InvoicePanel);

--- a/src/shared/Invoice/InvoicePaymentAlert.jsx
+++ b/src/shared/Invoice/InvoicePaymentAlert.jsx
@@ -39,7 +39,8 @@ class InvoicePaymentAlert extends PureComponent {
             <Alert type="success" heading="Already submitted">
               <span className={warningHeaderStyle}>
                 A payment request was made by {aproverFirstName} {aproverLastName} at {formatTime(invoiceDate)} on{' '}
-                {formatDate4DigitYear(invoiceDate)} andis already in process.<br />
+                {formatDate4DigitYear(invoiceDate)} andis already in process.
+                <br />
                 Please refresh this screen for updated details.
               </span>
             </Alert>

--- a/src/shared/Invoice/InvoiceTable.jsx
+++ b/src/shared/Invoice/InvoiceTable.jsx
@@ -52,4 +52,7 @@ const mapStateToProps = (state, ownProps) => {
   };
 };
 
-export default connect(mapStateToProps, null)(InvoiceTable);
+export default connect(
+  mapStateToProps,
+  null,
+)(InvoiceTable);

--- a/src/shared/JsonSchemaForm/JsonSchemaField.js
+++ b/src/shared/JsonSchemaForm/JsonSchemaField.js
@@ -210,18 +210,17 @@ const renderInputField = ({
       {hideLabel || (
         <label className={displayError ? 'usa-input-error-label' : 'usa-input-label'} htmlFor={input.name}>
           {title}
-          {!always_required &&
-            type !== 'boolean' &&
-            !customComponent && <span className="label-optional">Optional</span>}
+          {!always_required && type !== 'boolean' && !customComponent && (
+            <span className="label-optional">Optional</span>
+          )}
         </label>
       )}
       <span className={prefixInputClassName}>{FieldComponent}</span>
-      {touched &&
-        error && (
-          <span className="usa-input-error-message" id={input.name + '-error'} role="alert">
-            {error}
-          </span>
-        )}
+      {touched && error && (
+        <span className="usa-input-error-message" id={input.name + '-error'} role="alert">
+          {error}
+        </span>
+      )}
     </div>
   );
 };

--- a/src/shared/PreApprovalRequest/Creator.jsx
+++ b/src/shared/PreApprovalRequest/Creator.jsx
@@ -136,4 +136,7 @@ function mapDispatchToProps(dispatch) {
     dispatch,
   );
 }
-export default connect(mapStateToProps, mapDispatchToProps)(Creator);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(Creator);

--- a/src/shared/PreApprovalRequest/Editor.jsx
+++ b/src/shared/PreApprovalRequest/Editor.jsx
@@ -112,4 +112,7 @@ function mapDispatchToProps(dispatch) {
     dispatch,
   );
 }
-export default connect(mapStateToProps, mapDispatchToProps)(Editor);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(Editor);

--- a/src/shared/PreApprovalRequest/PreApprovalPanel.jsx
+++ b/src/shared/PreApprovalRequest/PreApprovalPanel.jsx
@@ -101,4 +101,7 @@ function mapDispatchToProps(dispatch) {
     dispatch,
   );
 }
-export default connect(mapStateToProps, mapDispatchToProps)(PreApprovalPanel);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(PreApprovalPanel);

--- a/src/shared/PreApprovalRequest/PreApprovalRequest.jsx
+++ b/src/shared/PreApprovalRequest/PreApprovalRequest.jsx
@@ -28,20 +28,18 @@ export function renderActionIcons(status, onEdit, onApproval, onDelete, shipment
     <Fragment>
       <div className="pre-approval-icon-container">
         <div className="pre-approval-icon">
-          {onApproval &&
-            status === 'SUBMITTED' && (
-              <span data-test="approve-request" onClick={() => onApproval(shipmentLineItemId)}>
-                <FontAwesomeIcon className="icon actionable" icon={faCheck} />
-              </span>
-            )}
+          {onApproval && status === 'SUBMITTED' && (
+            <span data-test="approve-request" onClick={() => onApproval(shipmentLineItemId)}>
+              <FontAwesomeIcon className="icon actionable" icon={faCheck} />
+            </span>
+          )}
         </div>
         <div className="pre-approval-icon">
-          {onEdit &&
-            isEditable && (
-              <span data-test="edit-request" onClick={onEdit}>
-                <FontAwesomeIcon className="icon actionable" icon={faPencil} />
-              </span>
-            )}
+          {onEdit && isEditable && (
+            <span data-test="edit-request" onClick={onEdit}>
+              <FontAwesomeIcon className="icon actionable" icon={faPencil} />
+            </span>
+          )}
         </div>
         <div className="pre-approval-icon">
           {onDelete && (

--- a/src/shared/StorageInTransit/ApproveSitRequest.jsx
+++ b/src/shared/StorageInTransit/ApproveSitRequest.jsx
@@ -91,4 +91,7 @@ function mapDispatchToProps(dispatch) {
   );
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(ApproveSitRequest);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(ApproveSitRequest);

--- a/src/shared/StorageInTransit/Creator.jsx
+++ b/src/shared/StorageInTransit/Creator.jsx
@@ -103,4 +103,7 @@ function mapDispatchToProps(dispatch) {
     dispatch,
   );
 }
-export default connect(mapStateToProps, mapDispatchToProps)(Creator);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(Creator);

--- a/src/shared/StorageInTransit/DenySitRequest.jsx
+++ b/src/shared/StorageInTransit/DenySitRequest.jsx
@@ -87,4 +87,7 @@ function mapDispatchToProps(dispatch) {
   );
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(DenySitRequest);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(DenySitRequest);

--- a/src/shared/StorageInTransit/OfficeEditor.jsx
+++ b/src/shared/StorageInTransit/OfficeEditor.jsx
@@ -106,4 +106,7 @@ function mapDispatchToProps(dispatch) {
     dispatch,
   );
 }
-export default connect(mapStateToProps, mapDispatchToProps)(OfficeEditor);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(OfficeEditor);

--- a/src/shared/StorageInTransit/PlaceInSit.jsx
+++ b/src/shared/StorageInTransit/PlaceInSit.jsx
@@ -99,4 +99,7 @@ function mapDispatchToProps(dispatch) {
   return bindActionCreators({ submitForm: () => submit(PlaceInSitFormName), updateSitPlaceIntoSit }, dispatch);
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(PlaceInSit);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(PlaceInSit);

--- a/src/shared/StorageInTransit/ReleaseFromSit.jsx
+++ b/src/shared/StorageInTransit/ReleaseFromSit.jsx
@@ -88,4 +88,7 @@ function mapDispatchToProps(dispatch) {
   return bindActionCreators({ submitForm: () => submit(ReleaseFromSitFormName), updateSitReleaseFromSit }, dispatch);
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(ReleaseFromSit);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(ReleaseFromSit);

--- a/src/shared/StorageInTransit/StorageInTransit.jsx
+++ b/src/shared/StorageInTransit/StorageInTransit.jsx
@@ -420,4 +420,7 @@ function mapDispatchToProps(dispatch) {
   return bindActionCreators({ updateStorageInTransit }, dispatch);
 }
 
-export default connect(null, mapDispatchToProps)(StorageInTransit);
+export default connect(
+  null,
+  mapDispatchToProps,
+)(StorageInTransit);

--- a/src/shared/StorageInTransit/StorageInTransitPanel.jsx
+++ b/src/shared/StorageInTransit/StorageInTransitPanel.jsx
@@ -91,8 +91,9 @@ export class StorageInTransitPanel extends Component {
                 />
               );
             })}
-          {isCreatorActionable &&
-            isTspSite && <Creator onFormActivation={this.onFormActivation} saveStorageInTransit={this.onSubmit} />}
+          {isCreatorActionable && isTspSite && (
+            <Creator onFormActivation={this.onFormActivation} saveStorageInTransit={this.onSubmit} />
+          )}
         </BasicPanel>
       </div>
     );
@@ -135,4 +136,7 @@ function mapDispatchToProps(dispatch) {
   return bindActionCreators({ createStorageInTransit, deleteStorageInTransit }, dispatch);
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(StorageInTransitPanel);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(StorageInTransitPanel);

--- a/src/shared/StorageInTransit/TspEditor.jsx
+++ b/src/shared/StorageInTransit/TspEditor.jsx
@@ -131,4 +131,7 @@ function mapDispatchToProps(dispatch, ownProps) {
     dispatch,
   );
 }
-export default connect(mapStateToProps, mapDispatchToProps)(TspEditor);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(TspEditor);

--- a/src/shared/TransportationOffices/TransportationOfficeContactInfo.jsx
+++ b/src/shared/TransportationOffices/TransportationOfficeContactInfo.jsx
@@ -55,4 +55,7 @@ function mapDispatchToProps(dispatch) {
   return bindActionCreators({ loadDutyStationTransportationOffice }, dispatch);
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(TransportationOfficeContactInfo);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(TransportationOfficeContactInfo);

--- a/src/shared/TspPanel/TspContainer.jsx
+++ b/src/shared/TspPanel/TspContainer.jsx
@@ -60,4 +60,7 @@ function mapDispatchToProps(dispatch) {
   );
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(TspServiceAgents);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(TspServiceAgents);

--- a/src/shared/TspPanel/TspServiceAgents.jsx
+++ b/src/shared/TspPanel/TspServiceAgents.jsx
@@ -60,12 +60,11 @@ export class ServiceAgentEditablePanel extends Component {
       <div className={classes}>
         <div className="editable-panel-header">
           <div className="title">{this.props.title}</div>
-          {!this.props.isEditable &&
-            this.props.editEnabled && (
-              <a className="editable-panel-edit" onClick={this.handleEditClick}>
-                Edit
-              </a>
-            )}
+          {!this.props.isEditable && this.props.editEnabled && (
+            <a className="editable-panel-edit" onClick={this.handleEditClick}>
+              Edit
+            </a>
+          )}
         </div>
         <div className="editable-panel-content">
           {this.props.children}

--- a/src/shared/Uploader/UploadsTable.jsx
+++ b/src/shared/Uploader/UploadsTable.jsx
@@ -57,4 +57,7 @@ function mapDispatchToProps(dispatch) {
   return bindActionCreators({}, dispatch);
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(UploadsTable);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(UploadsTable);

--- a/src/shared/Uploader/index.jsx
+++ b/src/shared/Uploader/index.jsx
@@ -181,4 +181,7 @@ function mapDispatchToProps(dispatch) {
   return bindActionCreators({}, dispatch);
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(Uploader);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(Uploader);

--- a/src/shared/User/AccessCode.jsx
+++ b/src/shared/User/AccessCode.jsx
@@ -109,4 +109,7 @@ function mapDispatchToProps(dispatch) {
   return bindActionCreators({ validateAccessCode, claimAccessCode }, dispatch);
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(withRouter(AccessCode));
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(withRouter(AccessCode));

--- a/src/shared/User/LogoutOnInactivity.jsx
+++ b/src/shared/User/LogoutOnInactivity.jsx
@@ -43,22 +43,21 @@ export class LogoutOnInactivity extends React.Component {
     const props = this.props;
     return (
       <React.Fragment>
-        {isProduction &&
-          props.isLoggedIn && (
-            <IdleTimer
-              ref="idleTimer"
-              element={document}
-              activeAction={this.onActive}
-              idleAction={this.onIdle}
-              timeout={this.props.idleTimeout}
-            >
-              {this.state.isIdle && (
-                <Alert type="warning" heading="Inactive user">
-                  You have been inactive and will be logged out shortly.
-                </Alert>
-              )}
-            </IdleTimer>
-          )}
+        {isProduction && props.isLoggedIn && (
+          <IdleTimer
+            ref="idleTimer"
+            element={document}
+            activeAction={this.onActive}
+            idleAction={this.onIdle}
+            timeout={this.props.idleTimeout}
+          >
+            {this.state.isIdle && (
+              <Alert type="warning" heading="Inactive user">
+                You have been inactive and will be logged out shortly.
+              </Alert>
+            )}
+          </IdleTimer>
+        )}
 
         {this.state.showLoggedOutAlert && (
           <Alert type="error" heading="Logged out">

--- a/src/shared/User/SignIn.jsx
+++ b/src/shared/User/SignIn.jsx
@@ -13,7 +13,8 @@ const SignIn = ({ context, location }) => {
         {error && (
           <div>
             <Alert type="error" heading="An error occurred">
-              There was an error during your last sign in attempt. Please try again.<br />
+              There was an error during your last sign in attempt. Please try again.
+              <br />
               Error code: {error}
             </Alert>
             <br />

--- a/src/shared/User/ValidatedPrivateRoute.jsx
+++ b/src/shared/User/ValidatedPrivateRoute.jsx
@@ -41,6 +41,9 @@ const mapStateToProps = state => {
 
 const mapDispatchToProps = dispatch => bindActionCreators({ fetchAccessCode }, dispatch);
 
-const ValidatedPrivateRoute = connect(mapStateToProps, mapDispatchToProps)(ValidatedPrivateRouteContainer);
+const ValidatedPrivateRoute = connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(ValidatedPrivateRouteContainer);
 
 export default ValidatedPrivateRoute;

--- a/src/shared/WizardPage/Form.jsx
+++ b/src/shared/WizardPage/Form.jsx
@@ -201,5 +201,12 @@ export const reduxifyWizardForm = (name, additionalValidations, asyncValidate, a
     asyncBlurFields,
     enableReinitialize: true,
     keepDirtyOnReinitialize: true,
-  })(withRouter(connect(null, mapDispatchToProps)(wizardFormPageWithSize)));
+  })(
+    withRouter(
+      connect(
+        null,
+        mapDispatchToProps,
+      )(wizardFormPageWithSize),
+    ),
+  );
 };

--- a/src/shared/WizardPage/index.jsx
+++ b/src/shared/WizardPage/index.jsx
@@ -117,4 +117,9 @@ function mapDispatchToProps(dispatch) {
 }
 
 const wizardFormPageWithSize = windowSize(WizardPage);
-export default withRouter(connect(null, mapDispatchToProps)(wizardFormPageWithSize));
+export default withRouter(
+  connect(
+    null,
+    mapDispatchToProps,
+  )(wizardFormPageWithSize),
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -10045,10 +10045,10 @@ prelude-ls@~1.1.2:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
 
-prettier@=1.12.1:
-  version "1.12.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.12.1.tgz#c1ad20e803e7749faf905a409d2367e06bbe7325"
-  integrity sha1-wa0g6APndJ+vkFpAnSNn4Gu+cyU=
+prettier@=1.18.2:
+  version "1.18.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.18.2.tgz#6823e7c5900017b4bd3acf46fe9ac4b4d7bda9ea"
+  integrity sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==
 
 pretty-bytes@^5.1.0:
   version "5.2.0"


### PR DESCRIPTION
## Description

This PR upgrades prettier from our currently pinned 1.12.1 version to 1.18.2 (and re-pins it to avoid frequent reformatting).  One of the reasons to do this now is that the prettier plugin for GoLand now requires prettier 1.13.0+.

## Code Review Verification Steps
* [ ] Request review from a member of a different team.
