### PR TITLE
Removing defunct apply-secure-migration script

### DIFF
--- a/cmd/milmove/gen.go
+++ b/cmd/milmove/gen.go
@@ -11,9 +11,6 @@ import (
 )
 
 const (
-	// secureMigrationTemplate is the template to apply secure migration
-	secureMigrationTemplate string = `exec("./apply-secure-migration.sh {{.}}")`
-
 	// tempMigrationPath is the temporary path for generated migrations
 	tempMigrationPath string = "./tmp"
 )

--- a/cmd/milmove/gen_disable_user_migration.go
+++ b/cmd/milmove/gen_disable_user_migration.go
@@ -100,7 +100,6 @@ func genDisableUserMigration(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	migrationPath := v.GetString(cli.MigrationPathFlag)
 	migrationManifest := v.GetString(cli.MigrationManifestFlag)
 	migrationName := v.GetString(cli.MigrationNameFlag)
 	migrationVersion := v.GetString(cli.MigrationVersionFlag)
@@ -123,16 +122,10 @@ func genDisableUserMigration(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	migrationFilename := fmt.Sprintf("%s_%s.up.fizz", migrationVersion, migrationName)
-	t2 := template.Must(template.New("migration").Parse(secureMigrationTemplate))
-	err = createMigration(migrationPath, migrationFilename, t2, secureMigrationName)
+	err = addMigrationToManifest(migrationManifest, secureMigrationName)
 	if err != nil {
 		return err
 	}
 
-	err = addMigrationToManifest(migrationManifest, migrationFilename)
-	if err != nil {
-		return err
-	}
 	return nil
 }

--- a/cmd/milmove/gen_office_user_migration.go
+++ b/cmd/milmove/gen_office_user_migration.go
@@ -158,7 +158,6 @@ func genOfficeUserMigration(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	migrationPath := v.GetString(cli.MigrationPathFlag)
 	migrationManifest := v.GetString(cli.MigrationManifestFlag)
 	migrationName := v.GetString(cli.MigrationNameFlag)
 	migrationVersion := v.GetString(cli.MigrationVersionFlag)
@@ -181,14 +180,7 @@ func genOfficeUserMigration(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	migrationFilename := fmt.Sprintf("%s_%s.up.fizz", migrationVersion, migrationName)
-	t2 := template.Must(template.New("migration").Parse(secureMigrationTemplate))
-	err = createMigration(migrationPath, migrationFilename, t2, secureMigrationName)
-	if err != nil {
-		return err
-	}
-
-	err = addMigrationToManifest(migrationManifest, migrationFilename)
+	err = addMigrationToManifest(migrationManifest, secureMigrationName)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Description

This PR removes references to the now defunct `apply-secure-migration.sh`

## Reviewer Notes

NA

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
rm -f bin/milmove && make bin/milmove

# Local Migrations

make db_dev_destroy && make db_dev_start && DB_TIMEOUT=30 make db_dev_create && make db_dev_migrate
```

## Code Review Verification Steps

* [X] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/tree/master/docs/backend.md#logging)
* [X] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/tree/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/tree/master/docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
  * [ ] Secure migrations have been tested using `scripts/run-prod-migrations`
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/n/projects/2136866/stories/168033332) for this change

