### PR TITLE
Log the STS caller identity when using RDS IAM

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -813,33 +813,33 @@ workflows:
             - pre_deps_yarn
             - acceptance_tests_local
           # if testing on experimental, you can disable these tests by using the commented block below.
-          filters:
-            branches:
-              ignore: cg_log_sts_caller_identity
+          # filters:
+          #   branches:
+          #     ignore: placeholder_branch_name
 
       - client_test:
           requires:
             - pre_deps_yarn
           # if testing on experimental, you can disable these tests by using the commented block below.
-          filters:
-            branches:
-              ignore: cg_log_sts_caller_identity
+          # filters:
+          #   branches:
+          #     ignore: placeholder_branch_name
 
       - server_test:
           requires:
             - pre_deps_golang
           # if testing on experimental, you can disable these tests by using the commented block below.
-          filters:
-            branches:
-              ignore: cg_log_sts_caller_identity
+          # filters:
+          #   branches:
+          #     ignore: placeholder_branch_name
 
       - server_test_coverage:
           requires:
             - pre_deps_golang
           # if testing on experimental, you can disable these tests by using the commented block below.
-          filters:
-            branches:
-              ignore: cg_log_sts_caller_identity
+          # filters:
+          #   branches:
+          #     ignore: placeholder_branch_name
 
       - build_app:
           requires:
@@ -872,28 +872,28 @@ workflows:
             - build_migrations
           filters:
             branches:
-              only: cg_log_sts_caller_identity
+              only: placeholder_branch_name
 
       - deploy_experimental_tasks:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: cg_log_sts_caller_identity
+              only: placeholder_branch_name
 
       - deploy_experimental_app:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: cg_log_sts_caller_identity
+              only: placeholder_branch_name
 
       - deploy_experimental_app_client_tls:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: cg_log_sts_caller_identity
+              only: placeholder_branch_name
 
       - check_circle_against_staging_sha:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -813,33 +813,33 @@ workflows:
             - pre_deps_yarn
             - acceptance_tests_local
           # if testing on experimental, you can disable these tests by using the commented block below.
-          # filters:
-          #   branches:
-          #     ignore: placeholder_branch_name
+          filters:
+            branches:
+              ignore: cg_log_sts_caller_identity
 
       - client_test:
           requires:
             - pre_deps_yarn
           # if testing on experimental, you can disable these tests by using the commented block below.
-          # filters:
-          #   branches:
-          #     ignore: placeholder_branch_name
+          filters:
+            branches:
+              ignore: cg_log_sts_caller_identity
 
       - server_test:
           requires:
             - pre_deps_golang
           # if testing on experimental, you can disable these tests by using the commented block below.
-          # filters:
-          #   branches:
-          #     ignore: placeholder_branch_name
+          filters:
+            branches:
+              ignore: cg_log_sts_caller_identity
 
       - server_test_coverage:
           requires:
             - pre_deps_golang
           # if testing on experimental, you can disable these tests by using the commented block below.
-          # filters:
-          #   branches:
-          #     ignore: placeholder_branch_name
+          filters:
+            branches:
+              ignore: cg_log_sts_caller_identity
 
       - build_app:
           requires:
@@ -872,28 +872,28 @@ workflows:
             - build_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: cg_log_sts_caller_identity
 
       - deploy_experimental_tasks:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: cg_log_sts_caller_identity
 
       - deploy_experimental_app:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: cg_log_sts_caller_identity
 
       - deploy_experimental_app_client_tls:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: cg_log_sts_caller_identity
 
       - check_circle_against_staging_sha:
           requires:

--- a/cmd/milmove/migrate.go
+++ b/cmd/milmove/migrate.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	awssession "github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/gobuffalo/pop"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -209,6 +210,13 @@ func migrateFunction(cmd *cobra.Command, args []string) error {
 			dbIamRole := v.GetString(cli.DbIamRoleFlag)
 			logger.Info(fmt.Sprintf("assuming AWS role %q for db connection", dbIamRole))
 			dbCreds = stscreds.NewCredentials(session, dbIamRole)
+			stsService := sts.New(session)
+			callerIdentity, callerIdentityErr := stsService.GetCallerIdentity(&sts.GetCallerIdentityInput{})
+			if callerIdentityErr != nil {
+				logger.Error(errors.Wrap(callerIdentityErr, "error getting aws sts caller identity").Error())
+			} else {
+				logger.Info(fmt.Sprintf("STS Caller Identity - Account: %s, ARN: %s, UserId: %s", *callerIdentity.Account, *callerIdentity.Arn, *callerIdentity.UserId))
+			}
 		}
 	}
 

--- a/cmd/milmove/serve.go
+++ b/cmd/milmove/serve.go
@@ -426,7 +426,7 @@ func serveFunction(cmd *cobra.Command, args []string) error {
 			if callerIdentityErr != nil {
 				logger.Error(errors.Wrap(callerIdentityErr, "error getting aws sts caller identity").Error())
 			} else {
-				logger.Info(fmt.Sprintf("Account: %s, ARN: %s, UserId: %s", *callerIdentity.Account, *callerIdentity.Arn, *callerIdentity.UserId))
+				logger.Info(fmt.Sprintf("STS Caller Identity - Account: %s, ARN: %s, UserId: %s", *callerIdentity.Account, *callerIdentity.Arn, *callerIdentity.UserId))
 			}
 		}
 	}

--- a/cmd/milmove/serve.go
+++ b/cmd/milmove/serve.go
@@ -21,6 +21,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	awssession "github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/dgrijalva/jwt-go"
 	"github.com/gobuffalo/pop"
 	"github.com/gorilla/csrf"
@@ -420,6 +421,13 @@ func serveFunction(cmd *cobra.Command, args []string) error {
 			dbIamRole := v.GetString(cli.DbIamRoleFlag)
 			logger.Info(fmt.Sprintf("assuming AWS role %q for db connection", dbIamRole))
 			dbCreds = stscreds.NewCredentials(session, dbIamRole)
+			stsService := sts.New(session)
+			callerIdentity, callerIdentityErr := stsService.GetCallerIdentity(&sts.GetCallerIdentityInput{})
+			if callerIdentityErr != nil {
+				logger.Error(errors.Wrap(callerIdentityErr, "error getting aws sts caller identity").Error())
+			} else {
+				logger.Info(fmt.Sprintf("Account: %s, ARN: %s, UserId: %s", *callerIdentity.Account, *callerIdentity.Arn, *callerIdentity.UserId))
+			}
 		}
 	}
 


### PR DESCRIPTION
## Description

Per AWS support, this is a useful way to debug if there is an issue with the STS call being made. Since we use STS for RDS IAM connections we might as well have this in the logs every time.

Need to deploy to Experimental to test this.

## Setup

Should compile:

```sh
make server_run
```

To test this you need to actually have access to an RDS instance and the ability to assume the roll. So manual testing on local development is super involved, easier to push this out to experimental.

## Code Review Verification Steps

* [x] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/tree/master/docs/backend.md#logging)
* [x] Request review from a member of a different team.