### PR TITLE
Fix issues on PPM shipment summary (bad merge)

### DIFF
--- a/src/scenes/Moves/Ppm/DateAndLocation.jsx
+++ b/src/scenes/Moves/Ppm/DateAndLocation.jsx
@@ -189,7 +189,6 @@ function mapStateToProps(state) {
     currentOrders: state.orders.currentOrders,
     formValues: getFormValues(formName)(state),
     entitlement: loadEntitlementsFromState(state),
-    hasEstimateError: state.ppm.hasEstimateError,
     originDutyStationZip: state.serviceMember.currentServiceMember.current_station.address.postal_code,
   };
   const defaultPickupZip = get(state.serviceMember, 'currentServiceMember.residential_address.postal_code');

--- a/src/scenes/Review/PPMShipmentSummary.jsx
+++ b/src/scenes/Review/PPMShipmentSummary.jsx
@@ -63,10 +63,6 @@ function PPMShipmentSummary(props) {
               <td> Storage: </td>
               <td data-cy="sit-display">{sitDisplay}</td>
             </tr>
-            <tr>
-              <td> Storage: </td>
-              <td data-cy="sit-display">{sitDisplay}</td>
-            </tr>
           </tbody>
         </table>
       </div>


### PR DESCRIPTION
## Description

It looks like the Mothball HHG client story (#2562) had a bad merge that caused the storage field of the PPM shipment summary to appear twice (this was noticed during acceptance of #2553).  This PR fixes that issue and another component that also had a bad merge (but inconsequential in that case).

## Setup

Set up a new PPM with some storage and make sure the shipment summary just shows one storage line.

## Code Review Verification Steps

* [ ] Request review from a member of a different team.

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/167932683) for this change -- this links to the original story that was rejected because of the bad merge that came after the story landed.  It contains a screenshot showing the duplicate fields.
