### PR TITLE
Disable RDS IAM except in Experimental using env vars instead of flags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -813,33 +813,33 @@ workflows:
             - pre_deps_yarn
             - acceptance_tests_local
           # if testing on experimental, you can disable these tests by using the commented block below.
-          # filters:
-          #   branches:
-          #     ignore: placeholder_branch_name
+          filters:
+            branches:
+              ignore: cg_disable_rds_iam_except_experimental
 
       - client_test:
           requires:
             - pre_deps_yarn
           # if testing on experimental, you can disable these tests by using the commented block below.
-          # filters:
-          #   branches:
-          #     ignore: placeholder_branch_name
+          filters:
+            branches:
+              ignore: cg_disable_rds_iam_except_experimental
 
       - server_test:
           requires:
             - pre_deps_golang
           # if testing on experimental, you can disable these tests by using the commented block below.
-          # filters:
-          #   branches:
-          #     ignore: placeholder_branch_name
+          filters:
+            branches:
+              ignore: cg_disable_rds_iam_except_experimental
 
       - server_test_coverage:
           requires:
             - pre_deps_golang
           # if testing on experimental, you can disable these tests by using the commented block below.
-          # filters:
-          #   branches:
-          #     ignore: placeholder_branch_name
+          filters:
+            branches:
+              ignore: cg_disable_rds_iam_except_experimental
 
       - build_app:
           requires:
@@ -872,28 +872,28 @@ workflows:
             - build_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: cg_disable_rds_iam_except_experimental
 
       - deploy_experimental_tasks:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: cg_disable_rds_iam_except_experimental
 
       - deploy_experimental_app:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: cg_disable_rds_iam_except_experimental
 
       - deploy_experimental_app_client_tls:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: cg_disable_rds_iam_except_experimental
 
       - check_circle_against_staging_sha:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -813,33 +813,33 @@ workflows:
             - pre_deps_yarn
             - acceptance_tests_local
           # if testing on experimental, you can disable these tests by using the commented block below.
-          filters:
-            branches:
-              ignore: cg_disable_rds_iam_except_experimental
+          # filters:
+          #   branches:
+          #     ignore: placeholder_branch_name
 
       - client_test:
           requires:
             - pre_deps_yarn
           # if testing on experimental, you can disable these tests by using the commented block below.
-          filters:
-            branches:
-              ignore: cg_disable_rds_iam_except_experimental
+          # filters:
+          #   branches:
+          #     ignore: placeholder_branch_name
 
       - server_test:
           requires:
             - pre_deps_golang
           # if testing on experimental, you can disable these tests by using the commented block below.
-          filters:
-            branches:
-              ignore: cg_disable_rds_iam_except_experimental
+          # filters:
+          #   branches:
+          #     ignore: placeholder_branch_name
 
       - server_test_coverage:
           requires:
             - pre_deps_golang
           # if testing on experimental, you can disable these tests by using the commented block below.
-          filters:
-            branches:
-              ignore: cg_disable_rds_iam_except_experimental
+          # filters:
+          #   branches:
+          #     ignore: placeholder_branch_name
 
       - build_app:
           requires:
@@ -872,28 +872,28 @@ workflows:
             - build_migrations
           filters:
             branches:
-              only: cg_disable_rds_iam_except_experimental
+              only: placeholder_branch_name
 
       - deploy_experimental_tasks:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: cg_disable_rds_iam_except_experimental
+              only: placeholder_branch_name
 
       - deploy_experimental_app:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: cg_disable_rds_iam_except_experimental
+              only: placeholder_branch_name
 
       - deploy_experimental_app_client_tls:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: cg_disable_rds_iam_except_experimental
+              only: placeholder_branch_name
 
       - check_circle_against_staging_sha:
           requires:

--- a/config/app-client-tls.container-definition.json
+++ b/config/app-client-tls.container-definition.json
@@ -11,19 +11,14 @@
     "--",
     "/bin/milmove",
     "serve",
+    "--db-env",
+    "container",
     "--logging-env",
     "production",
     "--debug-logging",
     "--log-task-metadata",
-    "--db-env",
-    "container",
     "--tls-enabled",
-    "--mutual-tls-enabled",
-    "--db-iam",
-    "--db-iam-role",
-    "arn:aws:iam::923914045601:role/ecs-rds-role-app-{{ .environment }}",
-    "--db-region",
-    "us-west-2"
+    "--mutual-tls-enabled"
   ],
   "command": [],
   "portMappings": [
@@ -36,8 +31,16 @@
   "command": [],
   "environment": [
     {
-      "name": "HONEYCOMB_SERVICE_NAME",
-      "value": "app-client-tls"
+      "name": "DB_IAM",
+      "value": "{{ .DB_IAM }}"
+    },
+    {
+      "name": "DB_IAM_ROLE",
+      "value": "{{ .DB_IAM_ROLE }}"
+    },
+    {
+      "name": "DB_REGION",
+      "value": "us-west-2"
     },
     {
       "name": "ENVIRONMENT",
@@ -146,14 +149,6 @@
     {
       "name": "LOGIN_GOV_HOSTNAME",
       "value": "{{ .LOGIN_GOV_HOSTNAME }}"
-    },
-    {
-      "name": "HONEYCOMB_ENABLED",
-      "value": "{{ .HONEYCOMB_ENABLED }}"
-    },
-    {
-      "name": "HONEYCOMB_DATASET",
-      "value": "{{ .HONEYCOMB_DATASET }}"
     },
     {
       "name": "DOD_CA_PACKAGE",

--- a/config/app-migrations.container-definition.json
+++ b/config/app-migrations.container-definition.json
@@ -12,18 +12,25 @@
     "--",
     "/bin/milmove",
     "migrate",
-    "--logging-env",
-    "production",
     "--db-env",
     "container",
-    "--db-iam",
-    "--db-iam-role",
-    "arn:aws:iam::923914045601:role/ecs-rds-role-app-{{ .environment }}",
-    "--db-region",
-    "us-west-2"
+    "--logging-env",
+    "production"
   ],
   "command": [],
   "environment": [
+    {
+      "name": "DB_IAM",
+      "value": "{{ .DB_IAM }}"
+    },
+    {
+      "name": "DB_IAM_ROLE",
+      "value": "{{ .DB_IAM_ROLE }}"
+    },
+    {
+      "name": "DB_REGION",
+      "value": "us-west-2"
+    },
     {
       "name": "ENVIRONMENT",
       "value": "{{ .environment }}"

--- a/config/app.container-definition.json
+++ b/config/app.container-definition.json
@@ -17,12 +17,7 @@
     "production",
     "--debug-logging",
     "--log-task-metadata",
-    "--tls-enabled",
-    "--db-iam",
-    "--db-iam-role",
-    "arn:aws:iam::923914045601:role/ecs-rds-role-app-{{ .environment }}",
-    "--db-region",
-    "us-west-2"
+    "--tls-enabled"
   ],
   "command": [],
   "portMappings": [
@@ -35,8 +30,16 @@
   "command": [],
   "environment": [
     {
-      "name": "HONEYCOMB_SERVICE_NAME",
-      "value": "app"
+      "name": "DB_IAM",
+      "value": "{{ .DB_IAM }}"
+    },
+    {
+      "name": "DB_IAM_ROLE",
+      "value": "{{ .DB_IAM_ROLE }}"
+    },
+    {
+      "name": "DB_REGION",
+      "value": "us-west-2"
     },
     {
       "name": "ENVIRONMENT",
@@ -141,14 +144,6 @@
     {
       "name": "LOGIN_GOV_HOSTNAME",
       "value": "{{ .LOGIN_GOV_HOSTNAME }}"
-    },
-    {
-      "name": "HONEYCOMB_ENABLED",
-      "value": "{{ .HONEYCOMB_ENABLED }}"
-    },
-    {
-      "name": "HONEYCOMB_DATASET",
-      "value": "{{ .HONEYCOMB_DATASET }}"
     },
     {
       "name": "DOD_CA_PACKAGE",

--- a/config/env/experimental.env
+++ b/config/env/experimental.env
@@ -1,6 +1,4 @@
 LOGIN_GOV_HOSTNAME=idp.int.identitysandbox.gov
-HONEYCOMB_ENABLED=true
-HONEYCOMB_DATASET=app-experimental
 IWS_RBS_HOST=pkict.dmdc.osd.mil
 HTTP_SDDC_SERVER_NAME=mymove-experimental.sddc.army.mil
 DPS_REDIRECT_URL=https://dpstest.sddc.army.mil/cust
@@ -14,3 +12,5 @@ DB_SSL_ROOT_CERT=/bin/rds-combined-ca-bundle.pem
 DEVLOCAL_CA=/config/tls/devlocal-ca.pem
 DEVLOCAL_AUTH=false
 FEATURE_FLAG_ACCESS_CODE=false
+DB_IAM=true
+DB_IAM_ROLE=arn:aws:iam::923914045601:role/ecs-rds-role-app-experimental

--- a/config/env/prod.env
+++ b/config/env/prod.env
@@ -1,6 +1,4 @@
 LOGIN_GOV_HOSTNAME=secure.login.gov
-HONEYCOMB_ENABLED=false
-HONEYCOMB_DATASET=
 IWS_RBS_HOST=sadr.dmdc.osd.mil
 HTTP_SDDC_SERVER_NAME=mymove.sddc.army.mil
 DPS_REDIRECT_URL=https://dps.sddc.army.mil/cust
@@ -14,3 +12,5 @@ DB_SSL_ROOT_CERT=/bin/rds-combined-ca-bundle.pem
 DEVLOCAL_CA=/config/tls/devlocal-ca.pem
 DEVLOCAL_AUTH=false
 FEATURE_FLAG_ACCESS_CODE=true
+DB_IAM=false
+DB_IAM_ROLE=arn:aws:iam::923914045601:role/ecs-rds-role-app-experimental

--- a/config/env/prod.env
+++ b/config/env/prod.env
@@ -13,4 +13,4 @@ DEVLOCAL_CA=/config/tls/devlocal-ca.pem
 DEVLOCAL_AUTH=false
 FEATURE_FLAG_ACCESS_CODE=true
 DB_IAM=false
-DB_IAM_ROLE=arn:aws:iam::923914045601:role/ecs-rds-role-app-experimental
+DB_IAM_ROLE=arn:aws:iam::923914045601:role/ecs-rds-role-app-prod

--- a/config/env/staging.env
+++ b/config/env/staging.env
@@ -13,4 +13,4 @@ DEVLOCAL_CA=/config/tls/devlocal-ca.pem
 DEVLOCAL_AUTH=false
 FEATURE_FLAG_ACCESS_CODE=false
 DB_IAM=false
-DB_IAM_ROLE=arn:aws:iam::923914045601:role/ecs-rds-role-app-experimental
+DB_IAM_ROLE=arn:aws:iam::923914045601:role/ecs-rds-role-app-staging

--- a/config/env/staging.env
+++ b/config/env/staging.env
@@ -1,6 +1,4 @@
 LOGIN_GOV_HOSTNAME=idp.int.identitysandbox.gov
-HONEYCOMB_ENABLED=true
-HONEYCOMB_DATASET=app-staging
 IWS_RBS_HOST=pkict.dmdc.osd.mil
 HTTP_SDDC_SERVER_NAME=mymove-staging.sddc.army.mil
 DPS_REDIRECT_URL=https://dpstest.sddc.army.mil/cust
@@ -14,3 +12,5 @@ DB_SSL_ROOT_CERT=/bin/rds-combined-ca-bundle.pem
 DEVLOCAL_CA=/config/tls/devlocal-ca.pem
 DEVLOCAL_AUTH=false
 FEATURE_FLAG_ACCESS_CODE=false
+DB_IAM=false
+DB_IAM_ROLE=arn:aws:iam::923914045601:role/ecs-rds-role-app-experimental


### PR DESCRIPTION
## Description

Previously we used flags in the endpoint to set the DB connection to use RDS IAM auth. Now we're using env vars so that we can turn this off for Prod/Staging while we debug the auth session timeout issue on Experimental.

Also - removed old env vars we aren't using any more (ie honeycomb)

## Reviewer Notes

Can you folks take a close look at the config files? I'll also want to deploy to experimental.

## Code Review Verification Steps

* [x] Request review from a member of a different team.