### PR TITLE
Add script for opening up cloudwatch logs page

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -111,3 +111,11 @@ These scripts are primarily used for working with the database
 | `psql-wrapper` | A wrapper around `psql` that sets correct values |
 | `wait-for-db` |  waits for an available database connection, or until a timeout is reached |
 | `wait-for-db-docker` |  waits for an available database connection, or until a timeout is reached using docker |
+
+### Amazon Console Scripts
+
+These scripts are used for quickly opening up tools in the AWS Console
+
+| Script Name | Description |
+| --- | --- |
+| `cloudwatch-logs` | Open up the CloudWatch logs group page |

--- a/scripts/cloudwatch-logs
+++ b/scripts/cloudwatch-logs
@@ -1,0 +1,15 @@
+#! /usr/bin/env bash
+
+#
+# Open CloudWatch log groups console page directly
+#
+
+readonly environment="$1"
+
+# Validate the environments
+if [[ "${environment}" != "experimental" ]] && [[ "${environment}" != "staging" ]] && [[ "${environment}" != "prod" ]] ; then
+  echo "<environment> must be one of experimental, staging, or prod"
+  exit 1
+fi
+
+open "https://us-west-2.console.aws.amazon.com/cloudwatch/home?region=us-west-2#logStream:group=ecs-tasks-app-${environment}"


### PR DESCRIPTION
## Description

It takes me too long to open up this page and I wanted a faster way. Only works on OSX :)

```
cloudwatch-logs experimental
```