### PR TITLE
Fix service member inputting access code flow

### DIFF
--- a/src/shared/User/ValidatedPrivateRoute.jsx
+++ b/src/shared/User/ValidatedPrivateRoute.jsx
@@ -14,9 +14,7 @@ import { fetchAccessCode } from 'shared/Entities/modules/accessCodes';
 // note that it does not work if the route is not inside a Switch
 class ValidatedPrivateRouteContainer extends React.Component {
   componentDidMount() {
-    if (this.props.requiresAccessCode) {
-      this.props.fetchAccessCode();
-    }
+    this.props.fetchAccessCode();
   }
 
   render() {


### PR DESCRIPTION
## Description

Service members were unable to proceed in setting up a move even with a correct access code. This change reverts a change we have made previously and always fetches an access code in order to unblock production users.

## Reviewer Notes
- conditional was added originally because of https://defensedigitalservice.slack.com/archives/G8NHL0QGN/p1565824145093400
- longer term solution card will be added to roci backlog

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/168181238) for this change