### PR TITLE
Removed unused go modules and fixed migration path

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -83,7 +83,7 @@ export CHAMBER_RETRIES=20
 export ENVIRONMENT=development
 
 # Migration Path
-export MIGRATION_PATH="${MYMOVE_DIR}/local_migrations;${MYMOVE_DIR}/migrations"
+export MIGRATION_PATH="file://${MYMOVE_DIR}/local_migrations;file://${MYMOVE_DIR}/migrations"
 export MIGRATION_MANIFEST="${MYMOVE_DIR}/migrations_manifest.txt"
 
 # Default DB configuration

--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,6 @@ require (
 	github.com/golang/protobuf v1.3.2 // indirect
 	github.com/gopherjs/gopherjs v0.0.0-20190430165422-3e4dfb77656c // indirect
 	github.com/gorilla/csrf v1.6.0
-	github.com/hashicorp/go-multierror v1.0.0
 	github.com/imdario/mergo v0.3.7
 	github.com/jackc/fake v0.0.0-20150926172116-812a484cc733 // indirect
 	github.com/jackc/pgx v3.5.0+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -272,10 +272,6 @@ github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t
 github.com/grpc-ecosystem/grpc-gateway v1.9.3/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c h1:6rhixN/i8ZofjG1Y75iExal34USq5p+wiN1tpie8IrU=
 github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c/go.mod h1:NMPJylDgVpX0MLRlPy15sqSwOFv/U1GZ2m21JhFfek0=
-github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
-github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
-github.com/hashicorp/go-multierror v1.0.0 h1:iVjPR7a6H0tWELX5NxNe7bYopibicUzc7uPribsnS6o=
-github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=


### PR DESCRIPTION
## Description

After merging master into one of my branches that's adding a new go dependency, I noticed a few issues:

- I was getting some diffs after a `go mod tidy`.  Looks like we have a module (and its dependencies) that was used in the past but is no longer needed after the HHG mothballing.
- The `TestConfigMigration` test kept failing in dev (but works in circleci) with an `invalid migration path` error.  I believe @chrisgilmerproj  has fixed this as part of PR #2375, but it hasn't landed quite yet.

## Setup

- To test our go modules, do a `make clean server_build mocks_generate`, then run `go mod tidy` and ensure that no additional changes were made to `go.mod` or `go.sum`.
- To test the migration path fix, do a `make server_test` in dev and ensure all server tests complete successfully.

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
