### PR TITLE
Add pagination to admin resources

### DIFF
--- a/pkg/handlers/adminapi/api.go
+++ b/pkg/handlers/adminapi/api.go
@@ -11,6 +11,7 @@ import (
 	"github.com/transcom/mymove/pkg/handlers"
 	electronicorder "github.com/transcom/mymove/pkg/services/electronic_order"
 	"github.com/transcom/mymove/pkg/services/office"
+	"github.com/transcom/mymove/pkg/services/pagination"
 	"github.com/transcom/mymove/pkg/services/query"
 	"github.com/transcom/mymove/pkg/services/user"
 )
@@ -31,6 +32,7 @@ func NewAdminAPIHandler(context handlers.HandlerContext) http.Handler {
 		context,
 		user.NewOfficeUserListFetcher(queryBuilder),
 		query.NewQueryFilter,
+		pagination.NewPagination,
 	}
 
 	adminAPI.OfficeGetOfficeUserHandler = GetOfficeUserHandler{
@@ -49,12 +51,14 @@ func NewAdminAPIHandler(context handlers.HandlerContext) http.Handler {
 		context,
 		office.NewOfficeListFetcher(queryBuilder),
 		query.NewQueryFilter,
+		pagination.NewPagination,
 	}
 
 	adminAPI.ElectronicOrderIndexElectronicOrdersHandler = IndexElectronicOrdersHandler{
 		context,
 		electronicorder.NewElectronicOrderListFetcher(queryBuilder),
 		query.NewQueryFilter,
+		pagination.NewPagination,
 	}
 
 	return adminAPI.Serve(nil)

--- a/pkg/handlers/adminapi/electronic_orders.go
+++ b/pkg/handlers/adminapi/electronic_orders.go
@@ -25,26 +25,37 @@ type IndexElectronicOrdersHandler struct {
 	handlers.HandlerContext
 	services.ElectronicOrderListFetcher
 	services.NewQueryFilter
+	services.NewPagination
 }
 
 func (h IndexElectronicOrdersHandler) Handle(params electronicorderop.IndexElectronicOrdersParams) middleware.Responder {
 	logger := h.LoggerFromRequest(params.HTTPRequest)
-	// queryFilters := []services.QueryFilter{}
+	queryFilters := []services.QueryFilter{}
 
-	// electronicOrders, err := h.ElectronicOrderListFetcher.FetchElectronicOrderList(queryFilters)
-	// TODO: Remove when we ship pagination in the query builder
-	query := `SELECT id, issuer, created_at, updated_at from electronic_orders LIMIT 100`
-	electronicOrders := models.ElectronicOrders{}
-	err := h.DB().RawQuery(query).All(&electronicOrders)
+	var pagination services.Pagination
+	if params.Page == nil {
+		pagination = h.NewPagination(1, 25) // default number of records per page
+	} else {
+		page, perPage := *params.Page, *params.PerPage
+		pagination = h.NewPagination(page, perPage)
+	}
+
+	electronicOrders, err := h.ElectronicOrderListFetcher.FetchElectronicOrderList(queryFilters, pagination)
 	if err != nil {
 		return handlers.ResponseForError(logger, err)
 	}
 
-	electronicOrdersCount := len(electronicOrders)
-	payload := make(adminmessages.ElectronicOrders, electronicOrdersCount)
+	totalElectronicOrdersCount, err := h.DB().Count(&models.ElectronicOrder{})
+	if err != nil {
+		return handlers.ResponseForError(logger, err)
+	}
+
+	queriedOfficeUsersCount := len(electronicOrders)
+
+	payload := make(adminmessages.ElectronicOrders, queriedOfficeUsersCount)
 	for i, s := range electronicOrders {
 		payload[i] = payloadForElectronicOrderModel(s)
 	}
 
-	return electronicorderop.NewIndexElectronicOrdersOK().WithContentRange(fmt.Sprintf("electronic_orders 0-%d/%d", electronicOrdersCount, electronicOrdersCount)).WithPayload(payload)
+	return electronicorderop.NewIndexElectronicOrdersOK().WithContentRange(fmt.Sprintf("electronic_orders %d-%d/%d", pagination.Offset(), pagination.Offset()+queriedOfficeUsersCount, totalElectronicOrdersCount)).WithPayload(payload)
 }

--- a/pkg/handlers/adminapi/electronic_orders.go
+++ b/pkg/handlers/adminapi/electronic_orders.go
@@ -32,13 +32,7 @@ func (h IndexElectronicOrdersHandler) Handle(params electronicorderop.IndexElect
 	logger := h.LoggerFromRequest(params.HTTPRequest)
 	queryFilters := []services.QueryFilter{}
 
-	var pagination services.Pagination
-	if params.Page == nil {
-		pagination = h.NewPagination(1, 25) // default number of records per page
-	} else {
-		page, perPage := *params.Page, *params.PerPage
-		pagination = h.NewPagination(page, perPage)
-	}
+	pagination := h.NewPagination(params.Page, params.PerPage)
 
 	electronicOrders, err := h.ElectronicOrderListFetcher.FetchElectronicOrderList(queryFilters, pagination)
 	if err != nil {

--- a/pkg/handlers/adminapi/office_users.go
+++ b/pkg/handlers/adminapi/office_users.go
@@ -29,6 +29,7 @@ type IndexOfficeUsersHandler struct {
 	handlers.HandlerContext
 	services.OfficeUserListFetcher
 	services.NewQueryFilter
+	services.NewPagination
 }
 
 // Handle retrieves a list of office users
@@ -37,19 +38,32 @@ func (h IndexOfficeUsersHandler) Handle(params officeuserop.IndexOfficeUsersPara
 	// Here is where NewQueryFilter will be used to create Filters from the 'filter' query param
 	queryFilters := []services.QueryFilter{}
 
-	officeUsers, err := h.OfficeUserListFetcher.FetchOfficeUserList(queryFilters)
+	var pagination services.Pagination
+	if params.Page == nil {
+		pagination = h.NewPagination(1, 25) // default number of records per page
+	} else {
+		page, perPage := *params.Page, *params.PerPage
+		pagination = h.NewPagination(page, perPage)
+	}
+
+	officeUsers, err := h.OfficeUserListFetcher.FetchOfficeUserList(queryFilters, pagination)
 	if err != nil {
 		return handlers.ResponseForError(logger, err)
 	}
 
-	officeUsersCount := len(officeUsers)
+	totalOfficeUsersCount, err := h.DB().Count(&models.OfficeUser{})
+	if err != nil {
+		return handlers.ResponseForError(logger, err)
+	}
 
-	payload := make(adminmessages.OfficeUsers, officeUsersCount)
+	queriedOfficeUsersCount := len(officeUsers)
+
+	payload := make(adminmessages.OfficeUsers, queriedOfficeUsersCount)
 	for i, s := range officeUsers {
 		payload[i] = payloadForOfficeUserModel(s)
 	}
 
-	return officeuserop.NewIndexOfficeUsersOK().WithContentRange(fmt.Sprintf("office users 0-%d/%d", officeUsersCount, officeUsersCount)).WithPayload(payload)
+	return officeuserop.NewIndexOfficeUsersOK().WithContentRange(fmt.Sprintf("office users %d-%d/%d", pagination.Offset(), pagination.Offset()+queriedOfficeUsersCount, totalOfficeUsersCount)).WithPayload(payload)
 }
 
 type GetOfficeUserHandler struct {

--- a/pkg/handlers/adminapi/office_users.go
+++ b/pkg/handlers/adminapi/office_users.go
@@ -38,13 +38,7 @@ func (h IndexOfficeUsersHandler) Handle(params officeuserop.IndexOfficeUsersPara
 	// Here is where NewQueryFilter will be used to create Filters from the 'filter' query param
 	queryFilters := []services.QueryFilter{}
 
-	var pagination services.Pagination
-	if params.Page == nil {
-		pagination = h.NewPagination(1, 25) // default number of records per page
-	} else {
-		page, perPage := *params.Page, *params.PerPage
-		pagination = h.NewPagination(page, perPage)
-	}
+	pagination := h.NewPagination(params.Page, params.PerPage)
 
 	officeUsers, err := h.OfficeUserListFetcher.FetchOfficeUserList(queryFilters, pagination)
 	if err != nil {

--- a/pkg/handlers/adminapi/office_users_test.go
+++ b/pkg/handlers/adminapi/office_users_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services/mocks"
+	"github.com/transcom/mymove/pkg/services/pagination"
 	"github.com/transcom/mymove/pkg/services/query"
 	"github.com/transcom/mymove/pkg/services/user"
 	"github.com/transcom/mymove/pkg/testdatagen"
@@ -50,6 +51,7 @@ func (suite *HandlerSuite) TestIndexOfficeUsersHandler() {
 			HandlerContext:        handlers.NewHandlerContext(suite.DB(), suite.TestLogger()),
 			NewQueryFilter:        query.NewQueryFilter,
 			OfficeUserListFetcher: user.NewOfficeUserListFetcher(queryBuilder),
+			NewPagination:         pagination.NewPagination,
 		}
 
 		response := handler.Handle(params)
@@ -71,11 +73,13 @@ func (suite *HandlerSuite) TestIndexOfficeUsersHandler() {
 		officeUserListFetcher := &mocks.OfficeUserListFetcher{}
 		officeUserListFetcher.On("FetchOfficeUserList",
 			mock.Anything,
+			mock.Anything,
 		).Return(models.OfficeUsers{officeUser}, nil).Once()
 		handler := IndexOfficeUsersHandler{
 			HandlerContext:        handlers.NewHandlerContext(suite.DB(), suite.TestLogger()),
 			NewQueryFilter:        newQueryFilter,
 			OfficeUserListFetcher: officeUserListFetcher,
+			NewPagination:         pagination.NewPagination,
 		}
 
 		response := handler.Handle(params)
@@ -94,11 +98,13 @@ func (suite *HandlerSuite) TestIndexOfficeUsersHandler() {
 		officeUserListFetcher := &mocks.OfficeUserListFetcher{}
 		officeUserListFetcher.On("FetchOfficeUserList",
 			mock.Anything,
+			mock.Anything,
 		).Return(nil, expectedError).Once()
 		handler := IndexOfficeUsersHandler{
 			HandlerContext:        handlers.NewHandlerContext(suite.DB(), suite.TestLogger()),
 			NewQueryFilter:        newQueryFilter,
 			OfficeUserListFetcher: officeUserListFetcher,
+			NewPagination:         pagination.NewPagination,
 		}
 
 		response := handler.Handle(params)

--- a/pkg/handlers/adminapi/offices.go
+++ b/pkg/handlers/adminapi/offices.go
@@ -38,13 +38,7 @@ func (h IndexOfficesHandler) Handle(params officeop.IndexOfficesParams) middlewa
 	// Here is where NewQueryFilter will be used to create Filters from the 'filter' query param
 	queryFilters := []services.QueryFilter{}
 
-	var pagination services.Pagination
-	if params.Page == nil {
-		pagination = h.NewPagination(1, 25) // default number of records per page
-	} else {
-		page, perPage := *params.Page, *params.PerPage
-		pagination = h.NewPagination(page, perPage)
-	}
+	pagination := h.NewPagination(params.Page, params.PerPage)
 
 	offices, err := h.OfficeListFetcher.FetchOfficeList(queryFilters, pagination)
 	if err != nil {

--- a/pkg/handlers/adminapi/offices.go
+++ b/pkg/handlers/adminapi/offices.go
@@ -29,6 +29,7 @@ type IndexOfficesHandler struct {
 	handlers.HandlerContext
 	services.OfficeListFetcher
 	services.NewQueryFilter
+	services.NewPagination
 }
 
 // Handle retrieves a list of office users
@@ -37,16 +38,30 @@ func (h IndexOfficesHandler) Handle(params officeop.IndexOfficesParams) middlewa
 	// Here is where NewQueryFilter will be used to create Filters from the 'filter' query param
 	queryFilters := []services.QueryFilter{}
 
-	offices, err := h.OfficeListFetcher.FetchOfficeList(queryFilters)
+	var pagination services.Pagination
+	if params.Page == nil {
+		pagination = h.NewPagination(1, 25) // default number of records per page
+	} else {
+		page, perPage := *params.Page, *params.PerPage
+		pagination = h.NewPagination(page, perPage)
+	}
+
+	offices, err := h.OfficeListFetcher.FetchOfficeList(queryFilters, pagination)
 	if err != nil {
 		return handlers.ResponseForError(logger, err)
 	}
 
-	officesCount := len(offices)
-	payload := make(adminmessages.TransportationOffices, officesCount)
+	totalOfficesCount, err := h.DB().Count(&models.TransportationOffice{})
+	if err != nil {
+		return handlers.ResponseForError(logger, err)
+	}
+
+	queriedOfficesCount := len(offices)
+
+	payload := make(adminmessages.TransportationOffices, queriedOfficesCount)
 	for i, s := range offices {
 		payload[i] = payloadForOfficeModel(s)
 	}
 
-	return officeop.NewIndexOfficesOK().WithContentRange(fmt.Sprintf("offices 0-%d/%d", officesCount, officesCount)).WithPayload(payload)
+	return officeop.NewIndexOfficesOK().WithContentRange(fmt.Sprintf("offices %d-%d/%d", pagination.Offset(), pagination.Offset()+queriedOfficesCount, totalOfficesCount)).WithPayload(payload)
 }

--- a/pkg/handlers/adminapi/offices_test.go
+++ b/pkg/handlers/adminapi/offices_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services/mocks"
 	"github.com/transcom/mymove/pkg/services/office"
+	"github.com/transcom/mymove/pkg/services/pagination"
 	"github.com/transcom/mymove/pkg/services/query"
 	"github.com/transcom/mymove/pkg/testdatagen"
 )
@@ -42,6 +43,7 @@ func (suite *HandlerSuite) TestIndexOfficesHandler() {
 			HandlerContext:    handlers.NewHandlerContext(suite.DB(), suite.TestLogger()),
 			NewQueryFilter:    query.NewQueryFilter,
 			OfficeListFetcher: office.NewOfficeListFetcher(queryBuilder),
+			NewPagination:     pagination.NewPagination,
 		}
 
 		response := handler.Handle(params)
@@ -63,11 +65,13 @@ func (suite *HandlerSuite) TestIndexOfficesHandler() {
 		officeListFetcher := &mocks.OfficeListFetcher{}
 		officeListFetcher.On("FetchOfficeList",
 			mock.Anything,
+			mock.Anything,
 		).Return(models.TransportationOffices{office}, nil).Once()
 		handler := IndexOfficesHandler{
 			HandlerContext:    handlers.NewHandlerContext(suite.DB(), suite.TestLogger()),
 			NewQueryFilter:    newQueryFilter,
 			OfficeListFetcher: officeListFetcher,
+			NewPagination:     pagination.NewPagination,
 		}
 
 		response := handler.Handle(params)
@@ -86,11 +90,13 @@ func (suite *HandlerSuite) TestIndexOfficesHandler() {
 		officeListFetcher := &mocks.OfficeListFetcher{}
 		officeListFetcher.On("FetchOfficeList",
 			mock.Anything,
+			mock.Anything,
 		).Return(nil, expectedError).Once()
 		handler := IndexOfficesHandler{
 			HandlerContext:    handlers.NewHandlerContext(suite.DB(), suite.TestLogger()),
 			NewQueryFilter:    newQueryFilter,
 			OfficeListFetcher: officeListFetcher,
+			NewPagination:     pagination.NewPagination,
 		}
 
 		response := handler.Handle(params)

--- a/pkg/services/electronic_order.go
+++ b/pkg/services/electronic_order.go
@@ -5,5 +5,5 @@ import "github.com/transcom/mymove/pkg/models"
 // ElectronicOrderListFetcher is the exported interface for fetching multiple electronic orders
 //go:generate mockery -name ElectronicOrderListFetcher
 type ElectronicOrderListFetcher interface {
-	FetchElectronicOrderList(filters []QueryFilter) (models.ElectronicOrders, error)
+	FetchElectronicOrderList(filters []QueryFilter, pagination Pagination) (models.ElectronicOrders, error)
 }

--- a/pkg/services/electronic_order/electronic_order_list_fetcher.go
+++ b/pkg/services/electronic_order/electronic_order_list_fetcher.go
@@ -6,7 +6,7 @@ import (
 )
 
 type electronicOrderListQueryBuilder interface {
-	FetchMany(model interface{}, filters []services.QueryFilter) error
+	FetchMany(model interface{}, filters []services.QueryFilter, pagination services.Pagination) error
 }
 
 type electronicOrderListFetcher struct {
@@ -14,9 +14,9 @@ type electronicOrderListFetcher struct {
 }
 
 // FetchElectronicOrderList uses the passed query builder to fetch a list of electronic_orders
-func (o *electronicOrderListFetcher) FetchElectronicOrderList(filters []services.QueryFilter) (models.ElectronicOrders, error) {
+func (o *electronicOrderListFetcher) FetchElectronicOrderList(filters []services.QueryFilter, pagination services.Pagination) (models.ElectronicOrders, error) {
 	var electronicOrders models.ElectronicOrders
-	error := o.builder.FetchMany(&electronicOrders, filters)
+	error := o.builder.FetchMany(&electronicOrders, filters, pagination)
 	return electronicOrders, error
 }
 

--- a/pkg/services/electronic_order/electronic_order_list_fetcher_test.go
+++ b/pkg/services/electronic_order/electronic_order_list_fetcher_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services"
+	"github.com/transcom/mymove/pkg/services/pagination"
 	"github.com/transcom/mymove/pkg/services/query"
 )
 
@@ -16,7 +17,7 @@ type testElectronicOrderListQueryBuilder struct {
 	fakeFetchMany func(model interface{}) error
 }
 
-func (t *testElectronicOrderListQueryBuilder) FetchMany(model interface{}, filters []services.QueryFilter) error {
+func (t *testElectronicOrderListQueryBuilder) FetchMany(model interface{}, filters []services.QueryFilter, pagination services.Pagination) error {
 	m := t.fakeFetchMany(model)
 	return m
 }
@@ -39,7 +40,9 @@ func (suite *ElectronicOrderServiceSuite) TestFetchElectronicOrderList() {
 			query.NewQueryFilter("id", "=", id.String()),
 		}
 
-		electronicOrders, err := fetcher.FetchElectronicOrderList(filters)
+		pagination := pagination.NewPagination(1, 25)
+
+		electronicOrders, err := fetcher.FetchElectronicOrderList(filters, pagination)
 
 		suite.NoError(err)
 		suite.Equal(id, electronicOrders[0].ID)
@@ -55,7 +58,9 @@ func (suite *ElectronicOrderServiceSuite) TestFetchElectronicOrderList() {
 
 		fetcher := NewElectronicOrderListFetcher(builder)
 
-		electronicOrders, err := fetcher.FetchElectronicOrderList([]services.QueryFilter{})
+		pagination := pagination.NewPagination(1, 25)
+
+		electronicOrders, err := fetcher.FetchElectronicOrderList([]services.QueryFilter{}, pagination)
 
 		suite.Error(err)
 		suite.Equal(err.Error(), "Fetch error")

--- a/pkg/services/electronic_order/electronic_order_list_fetcher_test.go
+++ b/pkg/services/electronic_order/electronic_order_list_fetcher_test.go
@@ -22,6 +22,11 @@ func (t *testElectronicOrderListQueryBuilder) FetchMany(model interface{}, filte
 	return m
 }
 
+func defaultPagination() services.Pagination {
+	page, perPage := pagination.DefaultPage(), pagination.DefaultPerPage()
+	return pagination.NewPagination(&page, &perPage)
+}
+
 func (suite *ElectronicOrderServiceSuite) TestFetchElectronicOrderList() {
 	suite.T().Run("if the transportation order is fetched, it should be returned", func(t *testing.T) {
 		id, err := uuid.NewV4()
@@ -40,9 +45,7 @@ func (suite *ElectronicOrderServiceSuite) TestFetchElectronicOrderList() {
 			query.NewQueryFilter("id", "=", id.String()),
 		}
 
-		pagination := pagination.NewPagination(1, 25)
-
-		electronicOrders, err := fetcher.FetchElectronicOrderList(filters, pagination)
+		electronicOrders, err := fetcher.FetchElectronicOrderList(filters, defaultPagination())
 
 		suite.NoError(err)
 		suite.Equal(id, electronicOrders[0].ID)
@@ -58,9 +61,7 @@ func (suite *ElectronicOrderServiceSuite) TestFetchElectronicOrderList() {
 
 		fetcher := NewElectronicOrderListFetcher(builder)
 
-		pagination := pagination.NewPagination(1, 25)
-
-		electronicOrders, err := fetcher.FetchElectronicOrderList([]services.QueryFilter{}, pagination)
+		electronicOrders, err := fetcher.FetchElectronicOrderList([]services.QueryFilter{}, defaultPagination())
 
 		suite.Error(err)
 		suite.Equal(err.Error(), "Fetch error")

--- a/pkg/services/office.go
+++ b/pkg/services/office.go
@@ -12,5 +12,5 @@ type OfficeFetcher interface {
 // OfficeListFetcher is the exported interface for fetching multiple transportation offices
 //go:generate mockery -name OfficeListFetcher
 type OfficeListFetcher interface {
-	FetchOfficeList(filters []QueryFilter) (models.TransportationOffices, error)
+	FetchOfficeList(filters []QueryFilter, pagination Pagination) (models.TransportationOffices, error)
 }

--- a/pkg/services/office/office_list_fetcher.go
+++ b/pkg/services/office/office_list_fetcher.go
@@ -6,7 +6,7 @@ import (
 )
 
 type officeListQueryBuilder interface {
-	FetchMany(model interface{}, filters []services.QueryFilter) error
+	FetchMany(model interface{}, filters []services.QueryFilter, pagination services.Pagination) error
 }
 
 type officeListFetcher struct {
@@ -14,9 +14,9 @@ type officeListFetcher struct {
 }
 
 // FetchOfficeUserList uses the passed query builder to fetch a list of transportation offices
-func (o *officeListFetcher) FetchOfficeList(filters []services.QueryFilter) (models.TransportationOffices, error) {
+func (o *officeListFetcher) FetchOfficeList(filters []services.QueryFilter, pagination services.Pagination) (models.TransportationOffices, error) {
 	var offices models.TransportationOffices
-	error := o.builder.FetchMany(&offices, filters)
+	error := o.builder.FetchMany(&offices, filters, pagination)
 	return offices, error
 }
 

--- a/pkg/services/office/office_list_fetcher_test.go
+++ b/pkg/services/office/office_list_fetcher_test.go
@@ -22,6 +22,11 @@ func (t *testOfficeListQueryBuilder) FetchMany(model interface{}, filters []serv
 	return m
 }
 
+func defaultPagination() services.Pagination {
+	page, perPage := pagination.DefaultPage(), pagination.DefaultPerPage()
+	return pagination.NewPagination(&page, &perPage)
+}
+
 func (suite *OfficeServiceSuite) TestFetchOfficeList() {
 	suite.T().Run("if the transportation office is fetched, it should be returned", func(t *testing.T) {
 		id, err := uuid.NewV4()
@@ -40,9 +45,7 @@ func (suite *OfficeServiceSuite) TestFetchOfficeList() {
 			query.NewQueryFilter("id", "=", id.String()),
 		}
 
-		pagination := pagination.NewPagination(1, 25)
-
-		offices, err := fetcher.FetchOfficeList(filters, pagination)
+		offices, err := fetcher.FetchOfficeList(filters, defaultPagination())
 
 		suite.NoError(err)
 		suite.Equal(id, offices[0].ID)
@@ -57,9 +60,8 @@ func (suite *OfficeServiceSuite) TestFetchOfficeList() {
 		}
 
 		fetcher := NewOfficeListFetcher(builder)
-		pagination := pagination.NewPagination(1, 25)
 
-		offices, err := fetcher.FetchOfficeList([]services.QueryFilter{}, pagination)
+		offices, err := fetcher.FetchOfficeList([]services.QueryFilter{}, defaultPagination())
 
 		suite.Error(err)
 		suite.Equal(err.Error(), "Fetch error")

--- a/pkg/services/office/office_list_fetcher_test.go
+++ b/pkg/services/office/office_list_fetcher_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services"
+	"github.com/transcom/mymove/pkg/services/pagination"
 	"github.com/transcom/mymove/pkg/services/query"
 )
 
@@ -16,7 +17,7 @@ type testOfficeListQueryBuilder struct {
 	fakeFetchMany func(model interface{}) error
 }
 
-func (t *testOfficeListQueryBuilder) FetchMany(model interface{}, filters []services.QueryFilter) error {
+func (t *testOfficeListQueryBuilder) FetchMany(model interface{}, filters []services.QueryFilter, pagination services.Pagination) error {
 	m := t.fakeFetchMany(model)
 	return m
 }
@@ -39,7 +40,9 @@ func (suite *OfficeServiceSuite) TestFetchOfficeList() {
 			query.NewQueryFilter("id", "=", id.String()),
 		}
 
-		offices, err := fetcher.FetchOfficeList(filters)
+		pagination := pagination.NewPagination(1, 25)
+
+		offices, err := fetcher.FetchOfficeList(filters, pagination)
 
 		suite.NoError(err)
 		suite.Equal(id, offices[0].ID)
@@ -54,8 +57,9 @@ func (suite *OfficeServiceSuite) TestFetchOfficeList() {
 		}
 
 		fetcher := NewOfficeListFetcher(builder)
+		pagination := pagination.NewPagination(1, 25)
 
-		offices, err := fetcher.FetchOfficeList([]services.QueryFilter{})
+		offices, err := fetcher.FetchOfficeList([]services.QueryFilter{}, pagination)
 
 		suite.Error(err)
 		suite.Equal(err.Error(), "Fetch error")

--- a/pkg/services/pagination.go
+++ b/pkg/services/pagination.go
@@ -6,4 +6,4 @@ type Pagination interface {
 	Offset() int
 }
 
-type NewPagination func(page int64, perPage int64) Pagination
+type NewPagination func(page *int64, perPage *int64) Pagination

--- a/pkg/services/pagination.go
+++ b/pkg/services/pagination.go
@@ -1,0 +1,9 @@
+package services
+
+type Pagination interface {
+	Page() int
+	PerPage() int
+	Offset() int
+}
+
+type NewPagination func(page int64, perPage int64) Pagination

--- a/pkg/services/pagination/logger.go
+++ b/pkg/services/pagination/logger.go
@@ -1,0 +1,15 @@
+package pagination
+
+import (
+	"go.uber.org/zap"
+)
+
+// Logger is an interface that describes the logging requirements of this package.
+type Logger interface {
+	Debug(msg string, fields ...zap.Field)
+	Info(msg string, fields ...zap.Field)
+	Warn(msg string, fields ...zap.Field)
+	Error(msg string, fields ...zap.Field)
+	Fatal(msg string, fields ...zap.Field)
+	WithOptions(opts ...zap.Option) *zap.Logger
+}

--- a/pkg/services/pagination/pagination.go
+++ b/pkg/services/pagination/pagination.go
@@ -1,0 +1,24 @@
+package pagination
+
+import "github.com/transcom/mymove/pkg/services"
+
+type pagination struct {
+	page    int64
+	perPage int64
+}
+
+func (p pagination) Page() int {
+	return int(p.page)
+}
+
+func (p pagination) PerPage() int {
+	return int(p.perPage)
+}
+
+func (p pagination) Offset() int {
+	return int((p.Page() - 1) * p.PerPage())
+}
+
+func NewPagination(page int64, perPage int64) services.Pagination {
+	return pagination{page, perPage}
+}

--- a/pkg/services/pagination/pagination.go
+++ b/pkg/services/pagination/pagination.go
@@ -3,8 +3,8 @@ package pagination
 import "github.com/transcom/mymove/pkg/services"
 
 type pagination struct {
-	page    int64
-	perPage int64
+	page    int
+	perPage int
 }
 
 func (p pagination) Page() int {
@@ -19,6 +19,20 @@ func (p pagination) Offset() int {
 	return int((p.Page() - 1) * p.PerPage())
 }
 
-func NewPagination(page int64, perPage int64) services.Pagination {
-	return pagination{page, perPage}
+func DefaultPage() int64 {
+	return 1
+}
+
+func DefaultPerPage() int64 {
+	return 25
+}
+
+func NewPagination(page *int64, perPage *int64) services.Pagination {
+	if page == nil {
+		return pagination{int(DefaultPage()), int(DefaultPerPage())}
+	}
+
+	pageValue, perPageValue := int(*page), int(*perPage)
+
+	return pagination{pageValue, perPageValue}
 }

--- a/pkg/services/pagination/pagination_service_test.go
+++ b/pkg/services/pagination/pagination_service_test.go
@@ -1,0 +1,28 @@
+package pagination
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"go.uber.org/zap"
+
+	"github.com/transcom/mymove/pkg/testingsuite"
+)
+
+type PaginationServiceSuite struct {
+	testingsuite.PopTestSuite
+	logger Logger
+}
+
+func (suite *PaginationServiceSuite) SetupTest() {
+	suite.DB().TruncateAll()
+}
+
+func TestPaginationSuite(t *testing.T) {
+	ts := &PaginationServiceSuite{
+		PopTestSuite: testingsuite.NewPopTestSuite(testingsuite.CurrentPackage()),
+		logger:       zap.NewNop(),
+	}
+
+	suite.Run(t, ts)
+}

--- a/pkg/services/pagination/pagination_test.go
+++ b/pkg/services/pagination/pagination_test.go
@@ -1,0 +1,11 @@
+package pagination
+
+import "testing"
+
+func (suite *PaginationServiceSuite) TestOffset() {
+	suite.T().Run("should return the correct offset for a given page", func(t *testing.T) {
+		pagination := NewPagination(4, 25)
+
+		suite.Equal(75, pagination.Offset())
+	})
+}

--- a/pkg/services/pagination/pagination_test.go
+++ b/pkg/services/pagination/pagination_test.go
@@ -4,7 +4,8 @@ import "testing"
 
 func (suite *PaginationServiceSuite) TestOffset() {
 	suite.T().Run("should return the correct offset for a given page", func(t *testing.T) {
-		pagination := NewPagination(4, 25)
+		page, perPage := int64(4), int64(25)
+		pagination := NewPagination(&page, &perPage)
 
 		suite.Equal(75, pagination.Offset())
 	})

--- a/pkg/services/query/query_builder.go
+++ b/pkg/services/query/query_builder.go
@@ -55,6 +55,26 @@ func getComparator(comparator string) (string, bool) {
 	}
 }
 
+func buildQuery(query *pop.Query, filters []services.QueryFilter, pagination services.Pagination, t reflect.Type) (*pop.Query, error) {
+	query, err := filteredQuery(query, filters, t)
+
+	if err != nil {
+		return nil, err
+	}
+
+	query, err = paginatedQuery(query, pagination, t)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return query, nil
+}
+
+func paginatedQuery(query *pop.Query, pagination services.Pagination, t reflect.Type) (*pop.Query, error) {
+	return query.Paginate(pagination.Page(), pagination.PerPage()), nil
+}
+
 func filteredQuery(query *pop.Query, filters []services.QueryFilter, t reflect.Type) (*pop.Query, error) {
 	invalidFields := make([]string, 0)
 	for _, f := range filters {
@@ -105,7 +125,7 @@ func (p *Builder) FetchOne(model interface{}, filters []services.QueryFilter) er
 
 // FetchMany fetches multiple model records using pop's All method
 // Will return error if model is not pointer to slice of structs
-func (p *Builder) FetchMany(model interface{}, filters []services.QueryFilter) error {
+func (p *Builder) FetchMany(model interface{}, filters []services.QueryFilter, pagination services.Pagination) error {
 	t := reflect.TypeOf(model)
 	if t.Kind() != reflect.Ptr {
 		return errors.New(fetchManyReflectionMessage)
@@ -119,7 +139,7 @@ func (p *Builder) FetchMany(model interface{}, filters []services.QueryFilter) e
 		return errors.New(fetchManyReflectionMessage)
 	}
 	query := p.db.Q()
-	query, err := filteredQuery(query, filters, t)
+	query, err := buildQuery(query, filters, pagination, t)
 	if err != nil {
 		return err
 	}

--- a/pkg/services/query/query_builder_test.go
+++ b/pkg/services/query/query_builder_test.go
@@ -32,6 +32,11 @@ func TestUserSuite(t *testing.T) {
 	suite.Run(t, hs)
 }
 
+func defaultPagination() services.Pagination {
+	page, perPage := pagination.DefaultPage(), pagination.DefaultPerPage()
+	return pagination.NewPagination(&page, &perPage)
+}
+
 func (suite *QueryBuilderSuite) TestFetchOne() {
 	user := testdatagen.MakeDefaultOfficeUser(suite.DB())
 	builder := NewQueryBuilder(suite.DB())
@@ -120,9 +125,7 @@ func (suite *QueryBuilderSuite) TestFetchMany() {
 			NewQueryFilter("id", equals, user2.ID.String()),
 		}
 
-		pagination := pagination.NewPagination(1, 25)
-
-		err := builder.FetchMany(&actualUsers, filters, pagination)
+		err := builder.FetchMany(&actualUsers, filters, defaultPagination())
 
 		suite.NoError(err)
 		suite.Len(actualUsers, 1)
@@ -134,7 +137,7 @@ func (suite *QueryBuilderSuite) TestFetchMany() {
 		}
 		var actualUsers models.OfficeUsers
 
-		err = builder.FetchMany(&actualUsers, filters, pagination)
+		err = builder.FetchMany(&actualUsers, filters, defaultPagination())
 
 		suite.NoError(err)
 		suite.Len(actualUsers, 1)
@@ -147,10 +150,8 @@ func (suite *QueryBuilderSuite) TestFetchMany() {
 		}
 		var actualUsers models.OfficeUsers
 
-		pagination := pagination.NewPagination(1, 25)
-
 		pop.Debug = true
-		err := builder.FetchMany(&actualUsers, filters, pagination)
+		err := builder.FetchMany(&actualUsers, filters, defaultPagination())
 		pop.Debug = false
 
 		suite.NoError(err)
@@ -164,9 +165,7 @@ func (suite *QueryBuilderSuite) TestFetchMany() {
 			NewQueryFilter("fake_column", equals, user.ID.String()),
 		}
 
-		pagination := pagination.NewPagination(1, 25)
-
-		err := builder.FetchMany(&actualUsers, filters, pagination)
+		err := builder.FetchMany(&actualUsers, filters, defaultPagination())
 
 		suite.Error(err)
 		suite.Equal("[fake_column =] is not valid input", err.Error())
@@ -179,9 +178,7 @@ func (suite *QueryBuilderSuite) TestFetchMany() {
 			NewQueryFilter("id", "*", user.ID.String()),
 		}
 
-		pagination := pagination.NewPagination(1, 25)
-
-		err := builder.FetchMany(&actualUsers, filters, pagination)
+		err := builder.FetchMany(&actualUsers, filters, defaultPagination())
 
 		suite.Error(err)
 		suite.Equal("[id *] is not valid input", err.Error())
@@ -191,9 +188,7 @@ func (suite *QueryBuilderSuite) TestFetchMany() {
 	suite.T().Run("fails when not pointer", func(t *testing.T) {
 		var actualUsers models.OfficeUsers
 
-		pagination := pagination.NewPagination(1, 25)
-
-		err := builder.FetchMany(actualUsers, []services.QueryFilter{}, pagination)
+		err := builder.FetchMany(actualUsers, []services.QueryFilter{}, defaultPagination())
 
 		suite.Error(err)
 		suite.Equal("Model should be pointer to slice of structs", err.Error())
@@ -203,9 +198,7 @@ func (suite *QueryBuilderSuite) TestFetchMany() {
 	suite.T().Run("fails when not pointer to slice", func(t *testing.T) {
 		var actualUser models.OfficeUser
 
-		pagination := pagination.NewPagination(1, 25)
-
-		err := builder.FetchMany(&actualUser, []services.QueryFilter{}, pagination)
+		err := builder.FetchMany(&actualUser, []services.QueryFilter{}, defaultPagination())
 
 		suite.Error(err)
 		suite.Equal("Model should be pointer to slice of structs", err.Error())
@@ -215,9 +208,7 @@ func (suite *QueryBuilderSuite) TestFetchMany() {
 	suite.T().Run("fails when not pointer to slice of structs", func(t *testing.T) {
 		var intSlice []int
 
-		pagination := pagination.NewPagination(1, 25)
-
-		err := builder.FetchMany(&intSlice, []services.QueryFilter{}, pagination)
+		err := builder.FetchMany(&intSlice, []services.QueryFilter{}, defaultPagination())
 
 		suite.Error(err)
 		suite.Equal("Model should be pointer to slice of structs", err.Error())

--- a/pkg/services/query/query_builder_test.go
+++ b/pkg/services/query/query_builder_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services"
+	"github.com/transcom/mymove/pkg/services/pagination"
 	"github.com/transcom/mymove/pkg/testdatagen"
 	"github.com/transcom/mymove/pkg/testingsuite"
 )
@@ -119,7 +120,9 @@ func (suite *QueryBuilderSuite) TestFetchMany() {
 			NewQueryFilter("id", equals, user2.ID.String()),
 		}
 
-		err := builder.FetchMany(&actualUsers, filters)
+		pagination := pagination.NewPagination(1, 25)
+
+		err := builder.FetchMany(&actualUsers, filters, pagination)
 
 		suite.NoError(err)
 		suite.Len(actualUsers, 1)
@@ -131,7 +134,7 @@ func (suite *QueryBuilderSuite) TestFetchMany() {
 		}
 		var actualUsers models.OfficeUsers
 
-		err = builder.FetchMany(&actualUsers, filters)
+		err = builder.FetchMany(&actualUsers, filters, pagination)
 
 		suite.NoError(err)
 		suite.Len(actualUsers, 1)
@@ -144,8 +147,10 @@ func (suite *QueryBuilderSuite) TestFetchMany() {
 		}
 		var actualUsers models.OfficeUsers
 
+		pagination := pagination.NewPagination(1, 25)
+
 		pop.Debug = true
-		err := builder.FetchMany(&actualUsers, filters)
+		err := builder.FetchMany(&actualUsers, filters, pagination)
 		pop.Debug = false
 
 		suite.NoError(err)
@@ -159,7 +164,9 @@ func (suite *QueryBuilderSuite) TestFetchMany() {
 			NewQueryFilter("fake_column", equals, user.ID.String()),
 		}
 
-		err := builder.FetchMany(&actualUsers, filters)
+		pagination := pagination.NewPagination(1, 25)
+
+		err := builder.FetchMany(&actualUsers, filters, pagination)
 
 		suite.Error(err)
 		suite.Equal("[fake_column =] is not valid input", err.Error())
@@ -172,7 +179,9 @@ func (suite *QueryBuilderSuite) TestFetchMany() {
 			NewQueryFilter("id", "*", user.ID.String()),
 		}
 
-		err := builder.FetchMany(&actualUsers, filters)
+		pagination := pagination.NewPagination(1, 25)
+
+		err := builder.FetchMany(&actualUsers, filters, pagination)
 
 		suite.Error(err)
 		suite.Equal("[id *] is not valid input", err.Error())
@@ -182,7 +191,9 @@ func (suite *QueryBuilderSuite) TestFetchMany() {
 	suite.T().Run("fails when not pointer", func(t *testing.T) {
 		var actualUsers models.OfficeUsers
 
-		err := builder.FetchMany(actualUsers, []services.QueryFilter{})
+		pagination := pagination.NewPagination(1, 25)
+
+		err := builder.FetchMany(actualUsers, []services.QueryFilter{}, pagination)
 
 		suite.Error(err)
 		suite.Equal("Model should be pointer to slice of structs", err.Error())
@@ -192,7 +203,9 @@ func (suite *QueryBuilderSuite) TestFetchMany() {
 	suite.T().Run("fails when not pointer to slice", func(t *testing.T) {
 		var actualUser models.OfficeUser
 
-		err := builder.FetchMany(&actualUser, []services.QueryFilter{})
+		pagination := pagination.NewPagination(1, 25)
+
+		err := builder.FetchMany(&actualUser, []services.QueryFilter{}, pagination)
 
 		suite.Error(err)
 		suite.Equal("Model should be pointer to slice of structs", err.Error())
@@ -202,7 +215,9 @@ func (suite *QueryBuilderSuite) TestFetchMany() {
 	suite.T().Run("fails when not pointer to slice of structs", func(t *testing.T) {
 		var intSlice []int
 
-		err := builder.FetchMany(&intSlice, []services.QueryFilter{})
+		pagination := pagination.NewPagination(1, 25)
+
+		err := builder.FetchMany(&intSlice, []services.QueryFilter{}, pagination)
 
 		suite.Error(err)
 		suite.Equal("Model should be pointer to slice of structs", err.Error())

--- a/pkg/services/user.go
+++ b/pkg/services/user.go
@@ -15,7 +15,7 @@ type OfficeUserFetcher interface {
 // OfficeUserListFetcher is the exported interface for fetching multiple office users
 //go:generate mockery -name OfficeUserListFetcher
 type OfficeUserListFetcher interface {
-	FetchOfficeUserList(filters []QueryFilter) (models.OfficeUsers, error)
+	FetchOfficeUserList(filters []QueryFilter, pagination Pagination) (models.OfficeUsers, error)
 }
 
 // OfficeUserCreator is the exported interface for creating an office user

--- a/pkg/services/user/office_user_list_fetcher.go
+++ b/pkg/services/user/office_user_list_fetcher.go
@@ -6,7 +6,7 @@ import (
 )
 
 type officeUserListQueryBuilder interface {
-	FetchMany(model interface{}, filters []services.QueryFilter) error
+	FetchMany(model interface{}, filters []services.QueryFilter, pagination services.Pagination) error
 }
 
 type officeUserListFetcher struct {
@@ -14,9 +14,9 @@ type officeUserListFetcher struct {
 }
 
 // FetchOfficeUserList uses the passed query builder to fetch a list of office users
-func (o *officeUserListFetcher) FetchOfficeUserList(filters []services.QueryFilter) (models.OfficeUsers, error) {
+func (o *officeUserListFetcher) FetchOfficeUserList(filters []services.QueryFilter, pagination services.Pagination) (models.OfficeUsers, error) {
 	var officeUsers models.OfficeUsers
-	error := o.builder.FetchMany(&officeUsers, filters)
+	error := o.builder.FetchMany(&officeUsers, filters, pagination)
 	return officeUsers, error
 }
 

--- a/pkg/services/user/office_user_list_fetcher_test.go
+++ b/pkg/services/user/office_user_list_fetcher_test.go
@@ -22,6 +22,11 @@ func (t *testOfficeUserListQueryBuilder) FetchMany(model interface{}, filters []
 	return m
 }
 
+func defaultPagination() services.Pagination {
+	page, perPage := pagination.DefaultPage(), pagination.DefaultPerPage()
+	return pagination.NewPagination(&page, &perPage)
+}
+
 func (suite *UserServiceSuite) TestFetchOfficeUserList() {
 	suite.T().Run("if the user is fetched, it should be returned", func(t *testing.T) {
 		id, err := uuid.NewV4()
@@ -40,9 +45,7 @@ func (suite *UserServiceSuite) TestFetchOfficeUserList() {
 			query.NewQueryFilter("id", "=", id.String()),
 		}
 
-		pagination := pagination.NewPagination(1, 25)
-
-		officeUsers, err := fetcher.FetchOfficeUserList(filters, pagination)
+		officeUsers, err := fetcher.FetchOfficeUserList(filters, defaultPagination())
 
 		suite.NoError(err)
 		suite.Equal(id, officeUsers[0].ID)
@@ -57,9 +60,8 @@ func (suite *UserServiceSuite) TestFetchOfficeUserList() {
 		}
 
 		fetcher := NewOfficeUserListFetcher(builder)
-		pagination := pagination.NewPagination(1, 25)
 
-		officeUsers, err := fetcher.FetchOfficeUserList([]services.QueryFilter{}, pagination)
+		officeUsers, err := fetcher.FetchOfficeUserList([]services.QueryFilter{}, defaultPagination())
 
 		suite.Error(err)
 		suite.Equal(err.Error(), "Fetch error")

--- a/pkg/services/user/office_user_list_fetcher_test.go
+++ b/pkg/services/user/office_user_list_fetcher_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/services"
+	"github.com/transcom/mymove/pkg/services/pagination"
 	"github.com/transcom/mymove/pkg/services/query"
 )
 
@@ -16,7 +17,7 @@ type testOfficeUserListQueryBuilder struct {
 	fakeFetchMany func(model interface{}) error
 }
 
-func (t *testOfficeUserListQueryBuilder) FetchMany(model interface{}, filters []services.QueryFilter) error {
+func (t *testOfficeUserListQueryBuilder) FetchMany(model interface{}, filters []services.QueryFilter, pagination services.Pagination) error {
 	m := t.fakeFetchMany(model)
 	return m
 }
@@ -39,7 +40,9 @@ func (suite *UserServiceSuite) TestFetchOfficeUserList() {
 			query.NewQueryFilter("id", "=", id.String()),
 		}
 
-		officeUsers, err := fetcher.FetchOfficeUserList(filters)
+		pagination := pagination.NewPagination(1, 25)
+
+		officeUsers, err := fetcher.FetchOfficeUserList(filters, pagination)
 
 		suite.NoError(err)
 		suite.Equal(id, officeUsers[0].ID)
@@ -54,8 +57,9 @@ func (suite *UserServiceSuite) TestFetchOfficeUserList() {
 		}
 
 		fetcher := NewOfficeUserListFetcher(builder)
+		pagination := pagination.NewPagination(1, 25)
 
-		officeUsers, err := fetcher.FetchOfficeUserList([]services.QueryFilter{})
+		officeUsers, err := fetcher.FetchOfficeUserList([]services.QueryFilter{}, pagination)
 
 		suite.Error(err)
 		suite.Equal(err.Error(), "Fetch error")

--- a/src/scenes/SystemAdmin/ElectronicOrderList.jsx
+++ b/src/scenes/SystemAdmin/ElectronicOrderList.jsx
@@ -4,7 +4,7 @@ import AdminPagination from './AdminPagination';
 import TitleizedField from './TitleizedField';
 
 const ElectronicOrderList = props => (
-  <List {...props} pagination={<AdminPagination />} perPage={500}>
+  <List {...props} pagination={<AdminPagination />} perPage={25}>
     <Datagrid>
       <TextField source="id" />
       <TitleizedField source="issuer" />

--- a/src/scenes/SystemAdmin/Home.jsx
+++ b/src/scenes/SystemAdmin/Home.jsx
@@ -1,4 +1,4 @@
-import restProvider from 'ra-data-simple-rest';
+import restProvider from './rest_provider';
 import { fetchUtils, Admin, Resource, Layout } from 'react-admin';
 import { createBrowserHistory } from 'history';
 import React from 'react';

--- a/src/scenes/SystemAdmin/OfficeList.jsx
+++ b/src/scenes/SystemAdmin/OfficeList.jsx
@@ -3,7 +3,7 @@ import { List, Datagrid, TextField } from 'react-admin';
 import AdminPagination from './AdminPagination';
 
 const OfficeList = props => (
-  <List {...props} pagination={<AdminPagination />} perPage={500}>
+  <List {...props} pagination={<AdminPagination />} perPage={25}>
     <Datagrid>
       <TextField source="id" />
       <TextField source="name" />

--- a/src/scenes/SystemAdmin/UserList.jsx
+++ b/src/scenes/SystemAdmin/UserList.jsx
@@ -3,7 +3,7 @@ import { List, EmailField, Datagrid, TextField } from 'react-admin';
 import AdminPagination from './AdminPagination';
 
 const UserList = props => (
-  <List {...props} pagination={<AdminPagination />} perPage={500}>
+  <List {...props} pagination={<AdminPagination />} perPage={25}>
     <Datagrid rowClick="show">
       <EmailField source="email" />
       <TextField source="first_name" />

--- a/src/scenes/SystemAdmin/rest_provider.js
+++ b/src/scenes/SystemAdmin/rest_provider.js
@@ -1,0 +1,169 @@
+import { stringify } from 'query-string';
+import {
+  fetchUtils,
+  GET_LIST,
+  GET_ONE,
+  GET_MANY,
+  GET_MANY_REFERENCE,
+  CREATE,
+  UPDATE,
+  UPDATE_MANY,
+  DELETE,
+  DELETE_MANY,
+} from 'react-admin';
+
+/**
+ * Maps react-admin queries to a simple REST API
+ *
+ * The REST dialect is similar to the one of FakeRest
+ * @see https://github.com/marmelab/FakeRest
+ * @example
+ * GET_LIST     => GET http://my.api.url/posts?sort=['title','ASC']&range=[0, 24]
+ * GET_ONE      => GET http://my.api.url/posts/123
+ * GET_MANY     => GET http://my.api.url/posts?filter={ids:[123,456,789]}
+ * UPDATE       => PUT http://my.api.url/posts/123
+ * CREATE       => POST http://my.api.url/posts
+ * DELETE       => DELETE http://my.api.url/posts/123
+ */
+export default (apiUrl, httpClient = fetchUtils.fetchJson) => {
+  /**
+   * @param {String} type One of the constants appearing at the top if this file, e.g. 'UPDATE'
+   * @param {String} resource Name of the resource to fetch, e.g. 'posts'
+   * @param {Object} params The data request params, depending on the type
+   * @returns {Object} { url, options } The HTTP request parameters
+   */
+  const convertDataRequestToHTTP = (type, resource, params) => {
+    let url = '';
+    const options = {};
+    switch (type) {
+      case GET_LIST: {
+        const { page, perPage } = params.pagination;
+        const { field, order } = params.sort;
+        const query = {
+          sort: JSON.stringify([field, order]),
+          page: page,
+          perPage: perPage,
+          filter: JSON.stringify(params.filter),
+        };
+        url = `${apiUrl}/${resource}?${stringify(query)}`;
+        break;
+      }
+      case GET_ONE:
+        url = `${apiUrl}/${resource}/${params.id}`;
+        break;
+      case GET_MANY: {
+        const query = {
+          filter: JSON.stringify({ id: params.ids }),
+        };
+        url = `${apiUrl}/${resource}?${stringify(query)}`;
+        break;
+      }
+      case GET_MANY_REFERENCE: {
+        const { page, perPage } = params.pagination;
+        const { field, order } = params.sort;
+        const query = {
+          sort: JSON.stringify([field, order]),
+          page: page,
+          perPage: perPage,
+          filter: JSON.stringify({
+            ...params.filter,
+            [params.target]: params.id,
+          }),
+        };
+        url = `${apiUrl}/${resource}?${stringify(query)}`;
+        break;
+      }
+      case UPDATE:
+        url = `${apiUrl}/${resource}/${params.id}`;
+        options.method = 'PUT';
+        options.body = JSON.stringify(params.data);
+        break;
+      case CREATE:
+        url = `${apiUrl}/${resource}`;
+        options.method = 'POST';
+        options.body = JSON.stringify(params.data);
+        break;
+      case DELETE:
+        url = `${apiUrl}/${resource}/${params.id}`;
+        options.method = 'DELETE';
+        break;
+      default:
+        throw new Error(`Unsupported fetch action type ${type}`);
+    }
+    return { url, options };
+  };
+
+  /**
+   * @param {Object} response HTTP response from fetch()
+   * @param {String} type One of the constants appearing at the top if this file, e.g. 'UPDATE'
+   * @param {String} resource Name of the resource to fetch, e.g. 'posts'
+   * @param {Object} params The data request params, depending on the type
+   * @returns {Object} Data response
+   */
+  const convertHTTPResponse = (response, type, resource, params) => {
+    const { headers, json } = response;
+    switch (type) {
+      case GET_LIST:
+      case GET_MANY_REFERENCE:
+        if (!headers.has('content-range')) {
+          throw new Error(
+            'The Content-Range header is missing in the HTTP Response. The simple REST data provider expects responses for lists of resources to contain this header with the total number of results to build the pagination. If you are using CORS, did you declare Content-Range in the Access-Control-Expose-Headers header?',
+          );
+        }
+        return {
+          data: json,
+          total: parseInt(
+            headers
+              .get('content-range')
+              .split('/')
+              .pop(),
+            10,
+          ),
+        };
+      case CREATE:
+        return { data: { ...params.data, id: json.id } };
+      case DELETE_MANY: {
+        return { data: json || [] };
+      }
+      default:
+        return { data: json };
+    }
+  };
+
+  /**
+   * @param {string} type Request type, e.g GET_LIST
+   * @param {string} resource Resource name, e.g. "posts"
+   * @param {Object} payload Request parameters. Depends on the request type
+   * @returns {Promise} the Promise for a data response
+   */
+  return (type, resource, params) => {
+    // simple-rest doesn't handle filters on UPDATE route, so we fallback to calling UPDATE n times instead
+    if (type === UPDATE_MANY) {
+      return Promise.all(
+        params.ids.map(id =>
+          httpClient(`${apiUrl}/${resource}/${id}`, {
+            method: 'PUT',
+            body: JSON.stringify(params.data),
+          }),
+        ),
+      ).then(responses => ({
+        data: responses.map(response => response.json),
+      }));
+    }
+    // simple-rest doesn't handle filters on DELETE route, so we fallback to calling DELETE n times instead
+    if (type === DELETE_MANY) {
+      return Promise.all(
+        params.ids.map(id =>
+          httpClient(`${apiUrl}/${resource}/${id}`, {
+            method: 'DELETE',
+          }),
+        ),
+      ).then(responses => ({
+        data: responses.map(response => response.json),
+      }));
+    }
+
+    const { url, options } = convertDataRequestToHTTP(type, resource, params);
+    return httpClient(url, options).then(response => convertHTTPResponse(response, type, resource, params));
+  };
+};

--- a/swagger/admin.yaml
+++ b/swagger/admin.yaml
@@ -303,6 +303,12 @@ paths:
           type: array
           items:
             type: string
+        - in: query
+          name: page
+          type: integer
+        - in: query
+          name: perPage
+          type: integer
       responses:
         200:
           description: success
@@ -384,6 +390,12 @@ paths:
           type: array
           items:
             type: string
+        - in: query
+          name: page
+          type: integer
+        - in: query
+          name: perPage
+          type: integer
       responses:
         200:
           description: success
@@ -414,6 +426,12 @@ paths:
           type: array
           items:
             type: string
+        - in: query
+          name: page
+          type: integer
+        - in: query
+          name: perPage
+          type: integer
       responses:
         200:
           description: success


### PR DESCRIPTION
## Description

We want to be able to explore all the records in a table without loading them all at once.

## Reviewer Notes

- Should we move more of the pagination logic from the handler into the `Pagination` service? I wasn't sure exactly where to draw the line.

## Setup

- `make server_run`
- `make client_run`
- Log in to the admin app.
- You should only see 25 records per page and be able to navigate between pages.

## Code Review Verification Steps

* [x] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/167855469) for this change