### PR TITLE
Add documentation for Identity Web Services and DoD-signed x509 certs

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -437,6 +437,60 @@ serve.go
 HackerOne
 addons
 addon
+X509v3
+my.move.mil
+api.move.mil
+dps.move.mil
+gex.move.mil
+office.move.mil
+orders.move.mil
+tsp.move.mil
+CA-54
+my.staging.move.mil
+api.staging.move.mil
+dps.staging.move.mil
+gex.staging.move.mil
+office.staging.move.mil
+orders.staging.move.mil
+tsp.staging.move.mil
+my.experimental.move.mil
+api.experimental.move.mil
+dps.experimental.move.mil
+gex.experimental.move.mil
+office.experimental.move.mil
+orders.experimental.move.mil
+tsp.experimental.move.mil
+mymove.sddc.army.mil
+sddc.army.mil
+OpenSSL
+openssl
+FQDNs
+webform
+2048-bit
+Intelink
+CSRs
+2.e
+2.f
+CNs
+2.h
+Mail.app
+x.509
+Base64-encoded
+PKCS#7
+webservice
+CAs
+Tricare
+SSN-to-EDIPI
+MatchReasonCode
+Enum
+MatchReasonCodeMultiple
+PN_ID
+MatchReasonCodeLimited
+PN_ID_TYP_CD
+MatchReasonCodeFull
+MatchReasonCodeNone
+wkEma
+_No_
 # Put all custom terms BEFORE this comment, lest 'pre-commit' and 'make spellcheck' yield different errors.
  - /usr/local
  - docs/data/tspp-data-creation.md
@@ -450,4 +504,3 @@ addon
  - ./docs/data/tariff400ng-yearly-import.md
  - ./scripts/README.md
  - ./docs/how-to/run-storybook.md
-

--- a/docs/backend/dmdc-identity-web-services.md
+++ b/docs/backend/dmdc-identity-web-services.md
@@ -1,0 +1,110 @@
+# DMDC Identity Web Services
+
+DMDC offers a suite of services under the "Identity Web Services" (IWS) program. These services provide clients limited access to DEERS (Defense Enrollment Eligibility Reporting System) for looking up personnel information on anyone affiliated with the DoD, including service members, civilian employees, contractors, and dependents.
+
+MilMove needs to look up personnel information for several reasons:
+
+1. When given the SSN of a member, get the member's EDIPI, to properly associate electronic Orders and avoid saving the SSN in clear-text.
+1. Save time during account creation by pre-populating fields like name, branch of service, and rank.
+1. Using a member's EDIPI, get the member's SSN, to facilitate PPM payments or support other legacy paperwork that has yet to move to EDIPI for unique identifiers.
+1. Look up a member's work e-mail address, to notify a member who has yet to create an account that they have electronic PCS Orders in MilMove and that they can start the move process.
+
+MilMove uses IWS's "Real-time Broker Service" (RBS). This is an allegedly RESTful webservice. It utilizes XML payloads.
+
+## Protocol
+
+DMDC calls RBS RESTful, but it's really not. The client sends a GET request with the parameters encoded in the path of the URL (which is RESTful) but still using the `=` sign (which is not RESTful).
+
+The HTTP status code it returns is meaningless, even in error cases.
+
+Instead, the response body contains one of two completely unrelated types of XML documents - one for normal operation, and another for protocol errors (like malformed data). After determining which of the two document types the body contains, the client must look for the reason and return codes in the document.
+
+The "normal" document type is specified in `2675_DDS_get_cac_data.xsd`. Find it in the Google drive.
+
+## Authentication
+
+We have provided DMDC with our DoD-signed certificates. Our staging and experimental certs are allowed to connect to their CT environment, while our production cert is allowed to connect to their production environment.
+
+As of this writing, IWS presents an ordinary commercial signed cert, although they once presented a DoD-signed cert. Perhaps that means they would trust clients with commercial certs now instead of requiring DoD-signed certs. **As a practical matter, when connecting to RBS, we trust certs signed by both the DoD and the usual commercial CAs.** Who knows, DMDC might switch back.
+
+## Enclaves
+
+IWS has two enclaves - production, where the real data lives, and "Contractor Test", where fake data lives.
+
+It should go without saying that any data retrieved from IWS's Production Environment is PII and needs to be appropriately protected.
+
+As for Contractor Test, it is _shared with other customers,_ some of whom _**have write access**_. These other customers (IIRC this includes Tricare and the VA) won't delete any records, but they frequently change the populations associated with a given test record. (They want to simulate a person separating from the military, for example.)
+
+Therefore, do not write any tests against CT that expect a test record to never change in any details. You can rely on the SSN-to-EDIPI to stay constant.
+
+On the other hand, this resembles production, as records of real people obviously change over time.
+
+Unfortunately, CT is infrequently "refreshed," where the previous data set is obliterated and a new data set is created with all-new fake people. When this happens, reach out to our DMDC Project Officer and request the updated data. In the past, they supplied the data as an Excel spreadsheet in an attachment to an encrypted email.
+
+## Network
+
+We have also provided DMDC with MilMove's outbound static IPs. At the time of this writing, they are not limiting us to our staging and experimental IPs _in CT_, so connecting from developer machines is allowed assuming you have the staging / experimental private DoD keys handy.
+
+## Request Types
+
+We can look up personnel information using one of the following - SSN + name, EDIPI, work e-mail, or CAC token.
+
+### PIDS : SSN + name
+
+Provide SSN, name, and the DOB (if available, which it usually isn't), and get 0, 1, or more person records back, along with a MatchReasonCode that explains why IWS returned what it did. In the interest of brevity, only the reason codes returned for SSN queries (as opposed to sponsor queries) are listed below. They are:
+
+Code | Enum | Description
+-|-|-
+PAB | MatchReasonCodeMultiple | More than one record matched the provided SSN and last name ("more than one PN_ID matched the provided criteria")
+PMB | MatchReasonCodeLimited | SSN matched a record, but the other criteria (like last name) didn't match ("the person matched on PN_ID and PN_ID_TYP_CD only")
+PMC | MatchReasonCodeFull | SSN + last name (and first name, if provided) matched just one record ("the person matched on PN_ID, PN_ID_TYP_CD and at least one additional criterion")
+PNB | MatchReasonCodeNone | Not found ("no person matched the provided PN_ID and PN_ID_TYP_CD combination")
+
+### EDI : DoD ID Number / EDIPI
+
+Provide EDIPI, and get a person record back, or an error.
+
+### wkEma: Work E-mail
+
+Provide work e-mail, and get a person record back, or an error. This query is implemented on our end but not currently used.
+
+### TIDS: CAC Token
+
+Provide certificate information from a CAC and get a person record back, or an error.
+
+This query is unimplemented on our end and untested. This query could potentially be very useful if we start taking CAC logins directly from service members and want to accelerate profile creation and fetch electronic Orders. The URL to use will look like `https://pkict.dmdc.osd.mil/appj/rbs/rest/op=tids03/customer=2675/schemaName=get_cac_data/schemaVersion=1.0/PKIC_AUTH_NM=CN=DOD%20CA-30,%20OU=PKI,%20OU=DoD,%20O=U.S.%20Government,%20C=US/PKIC_SER_ID=000000`
+
+## Populations
+
+MilMove has access to many, but not all, of the "populations" of people in DEERS. It is possible for individuals to be part of multiple populations at the same time. It is also possible to leave or join a population due to events like Separation.
+
+| Category Code | Population | Accessible |
+| ------------- | ---------- | ---------- |
+| A | Active Duty Member | **Yes** |
+| B | Presidential Appointee | **Yes** |
+| C | DoD / Uniformed Service Civil Service Employee | **Yes** |
+| D | Disabled American Veteran | **Yes** |
+| F | Former member | **Yes** |
+| J | Service Academy Student | **Yes** |
+| K | NAF DoD / Uniformed Service employee | **Yes** |
+| N | National Guard Member | **Yes** |
+| Q | Gray Area Retiree | **Yes** |
+| R | Retiree | **Yes** |
+| V | Reserve Member | **Yes** |
+| Y | Civilian Retiree | **Yes** |
+| E | DoD and Uniformed Service contract employee | _No_ |
+| H | Medal of Honor recipient | _No_ |
+| I | Non-DoD civil service employee, except Presidential appointee | _No_ |
+| L | Lighthouse Service (obsolete) | _No_ |
+| M | Non-federal Agency civilian associates | _No_ |
+| O | Non-DoD contract employee | _No_ |
+| T | Foreign Affiliate | _No_ |
+| U | DoD OCONUS Hire | _No_ |
+| W | DoD Beneficiary | _No_ |
+
+## Pitfalls
+
+* RBS is usually fast (&lt;1 seconds), but sometimes takes a long time (&gt;25 seconds) to respond to requests. Keep this in mind when setting timeouts.
+* If you try to look up an individual but do not have access to any of that individual's populations, RBS will simply return no match, as if that individual does not exist.
+* SSNs do not have a 1-to-1 relationship to individuals. Individuals may be issued more than one SSN in their lifetimes for completely legitimate reasons. One SSN can also be associated with multiple people, due to typos or fraud. To account for this, **RBS returns a MatchReasonCode along with possibly multiple matches.** Clients are supposed to send as much information (names and/or DOB) with the PIDS request to increase the odds of returning a single match.
+* RBS will still return a match if it has a person with the provided SSN even if the provided name does not match; it gives the MatchReasonCode "PMB" in this case.

--- a/docs/dod-certs.md
+++ b/docs/dod-certs.md
@@ -1,0 +1,141 @@
+# DoD Certificates
+
+MilMove has two kinds of server certificates. The first is a normal, commercially-signed cert stored in AWS Certificate Manager (ACM). We use these certificates for the user-facing properties like <https://my.move.mil/>. The other kind of certificate is signed by DISA, and we use those for communications (inbound and outbound) with other DoD entities.
+
+As of this writing, our DoD certificates expire in **September of 2021.** These certificates will need to be renewed before then.
+
+## Current Certificates
+
+Here are the current DoD-signed certificates and how they are used:
+
+| Subject | X509v3 Alternative Names | Environment | CA | Expires | Inbound | Outbound |
+| ------- | ------------------------ | ----------- | -- | ------- | ------- | -------- |
+| C=US, O=U.S. Government, OU=DoD, OU=PKI, OU=USTRANSCOM, CN=my.move.mil | `my.move.mil, api.move.mil, dps.move.mil, gex.move.mil, office.move.mil, orders.move.mil, tsp.move.mil` | Production | DOD SW CA-54 | Sep 13 14:14:27 2021 GMT | <https://orders.move.mil> | DMDC Identity Web Services (prod) |
+| C=US, O=U.S. Government, OU=DoD, OU=PKI, OU=USTRANSCOM, CN=my.staging.move.mil | `my.staging.move.mil, api.staging.move.mil, dps.staging.move.mil, gex.staging.move.mil, office.staging.move.mil, orders.staging.move.mil, tsp.staging.move.mil` | Staging | DOD SW CA-54 | Sep 13 14:20:04 2021 GMT | <https://orders.staging.move.mil> | DMDC Identity Web Services (Contractor Test) |
+| C=US, O=U.S. Government, OU=DoD, OU=PKI, OU=USTRANSCOM, CN=my.experimental.move.mil | `my.experimental.move.mil, api.experimental.move.mil, dps.experimental.move.mil, gex.experimental.move.mil, office.experimental.move.mil, orders.experimental.move.mil, tsp.experimental.move.mil` | Experimental | DOD SW CA-54 | Sep 13 14:22:14 2021 GMT | <https://orders.experimental.move.mil> | DMDC Identity Web Services (Contractor Test) |
+| C=US, O=U.S. Government, OU=DoD, OU=PKI, OU=USAF, CN=mymove.sddc.army.mil | `mymove.sddc.army.mil` | Production | DOD SW CA-54 | Sep 11 16:28:48 2021 GMT | <https://mymove.sddc.army.mil> | |
+| C=US, O=U.S. Government, OU=DoD, OU=PKI, OU=USAF, CN=mymove-staging.sddc.army.mil | `mymove-staging.sddc.army.mil` | Staging | DOD SW CA-54 | Sep 11 16:30:10 2021 GMT | <https://mymove-staging.sddc.army.mil> | |
+| C=US, O=U.S. Government, OU=DoD, OU=PKI, OU=USAF, CN=mymove-experimental.sddc.army.mil | `mymove-experimental.sddc.army.mil` | Experimental | DOD SW CA-54 | Sep 11 16:31:02 2021 GMT | <https://mymove-experimental.sddc.army.mil> | |
+
+## Getting a certificate signed by DISA: create a Certificate Signing Request
+
+Generate a Certificate Signing Request (CSR) for each certificate you wish to register or renew.
+
+### CSR Config File
+
+The easiest way to do this with OpenSSL is to create a configuration file with the certificate details and feed that to the openssl command. For example, here is the config file I made for the production my.move.mil CSR:
+
+```ini
+[req]
+default_bits = 2048
+prompt = no
+default_md = sha256
+req_extensions = req_ext
+distinguished_name = dn
+
+[ dn ]
+C=US
+ST=IL
+L=Belleville
+O=USTRANSCOM
+OU=USTRANSCOM
+emailAddress=dp3-integrations@truss.works
+CN = my.move.mil
+
+[ req_ext ]
+subjectAltName = @alt_names
+
+[ alt_names ]
+DNS.1 = my.move.mil
+DNS.2 = api.move.mil
+DNS.3 = dps.move.mil
+DNS.4 = gex.move.mil
+DNS.5 = office.move.mil
+DNS.6 = orders.move.mil
+DNS.7 = tsp.move.mil
+```
+
+Absent other guidance, I used the same C, ST, L, O, and OU values as the cert presented by <https://www.ustranscom.mil/>.
+
+Note the alternate names - this file covers a lot of FQDNs, even ones where we won't present the DoD-signed cert as a server. I did this both to preserve flexibility, and to ensure that when MilMove connects to other DoD entities using this cert, validation has the greatest chance of succeeding. If you don't need alternate names or other extensions, delete the `[ req_ext ]` and `[ alt_names ]` sections, along with the line `req_extensions = req_ext` in the `[req]` section.
+
+### New Certificate
+
+The command to generate the CSR with a new private key (no passphrase) is
+
+`openssl req -nodes -new -config <config file path> -keyout <CommonNameHere>.key -out <CommonNameHere>.csr`
+
+### Renew Certificate
+
+To renew a certificate, you probably want to reuse the existing private key. In that case, the command is
+
+`openssl req -new -config <config file path> -key <CommonNameHere>.key -out <CommonNameHere>.csr`
+
+NOTE: do not trust openssl’s `-x509toreq` option. It strips the alternative names and the e-mail address from the certificate. It’s just a convenience option anyway; use the config file input to be certain you’re getting exactly the certificate you want.
+
+### Checking the CSR
+
+To double-check that the CSR contains the right information, the command is
+
+`openssl req -text -noout -verify -in <csr filename>`
+
+## Submitting the CSR
+
+### Choosing a Certificate Authority
+
+For our purposes, you want the most recent (i.e., highest numbered) DOD SW-CA.
+
+### Get Request Numbers
+
+Using either Google Chrome or Microsoft Edge (NOT Internet Explorer) on a NIPR machine, fill in the webform at the desired CA’s website; for DOD SW CA-54, that’s <https://ee-sw-ca-54.csd.disa.mil/ca/ee/ca>. You will need a NIPR account associated with your CAC. On the "2048-bit SSL Server Enrollment Form," you can paste the contents of the CSR file you generated. You will also need to enter the same certificate details, like the CN and alternate names, into the other fields.
+
+For each CSR you submit, you will get a Request Number. Make a note of that, because the PKI RA will need it to approve your request.
+
+### Getting the PKI RA to approve your CSR(s)
+
+Now that DISA has your CSR, you need to contact the appropriate Registration Authority for your system to approve your request. As of this writing, the appropriate RA for USTRANSCOM is the Air Force PKI RA.
+
+Air Force PKI Help Desk: <https://intelshare.intelink.gov/sites/usaf-pki/> afpki.ra@us.af.mil
+
+### Fill out AF RA 2842-2
+
+Fill out the form AF RA 2842-2 using Adobe Acrobat Reader DC. (Do not use non-Adobe PDF products for this, you will have a bad time.) The form is available from the [AF PKI site on Intelink](https://intelshare.intelink.gov/sites/usaf-pki/).
+
+Some guidance on filling out this form:
+
+1. CERTIFICATE INFORMATION
+   1. The CERTIFICATE TYPE is “Application Server”.
+   1. If you are doing multiple CSRs, the “CERTIFICATE COMMON NAME (CN) / Fully Qualified Domain Name” is “Multiple Device Request”.
+   1. For the REQUEST INFORMATION OR ALT LOGIN TOKEN DETAILS, select the same CA that you submitted the CSR to.
+   1. Enter the DEVICE INFORMATION Type / OS / Application, e.g., “Application Server / Alpine Linux 3.7 / MilMove”.
+1. CERTIFICATE ACCEPTED BY - should be the same person who sent the CSR to DISA. Because you will be digitally signing the form, you can leave 2.e and 2.f blank.
+1. Leave section 3 blank.
+1. On the second page, fill in the CN, CA, and Request number for each CSR. You don’t need to worry about the alternate names, just the CNs.
+
+Once you have filled out all of the other fields, digitally sign the PDF in section 2.h with your CAC.
+
+### Submit the form to the RA
+
+Send a digitally signed e-mail (using Outlook on a NIPR machine, or with Mail.app) to afpki.ra@us.af.mil. Attach the completed and digitally signed 2842-2 form. The AF RA expects applicants to be on AFNET, so you will need to justify why you are using the PDF process instead of the automated Windows-based process. Here’s what worked for me:
+
+>I am reaching out on behalf of MilMove to complete the CSR process. I have attached the signed AF RA 2842-2 form detailing the certificates that we need and acknowledging my responsibilities.
+>
+>MilMove is not able to use the LTMA MMP template for obtaining certificates. MilMove is not internal to AFNET or to USTRANSCOM's network and does not run on Windows.
+
+### Download the signed certificates
+
+Assuming the PKI RA accepts your submission, you will get a notification email including instructions on how to download your signed certificates. In short, in Chrome or Edge go back to the CA’s website on NIPR (e.g., <https://ee-id-sw-ca-54.csd.disa.mil/ca/ee/ca/>), click “Retrieval”, and enter the Request numbers from before.
+
+## Reviewing and Verifying certificates
+
+### Reviewing x.509 certificates
+
+To check a Base64-encoded x.509 certificate:
+
+`openssl x509 -text -noout -in <x509 certificate>.cer`
+
+### Reviewing CA certificate chain in PKCS#7 format
+
+To check a Base64-encoded PKCS#7 format certificate chain:
+
+`openssl pkcs7 -text -print_certs -noout -in <cert chain>.p7b`


### PR DESCRIPTION
Just adding some Markdown documentation to help developers understand MilMove's usage of two things:

1. DMDC's Identity Web Services
1. DoD-signed (as opposed to commercially-signed) server certificates