### PR TITLE
Remove OIA and PN columns from orders table

### DIFF
--- a/migrations/20190906223934_remove_oia_pn.up.fizz
+++ b/migrations/20190906223934_remove_oia_pn.up.fizz
@@ -1,0 +1,2 @@
+drop_column("orders", "orders_issuing_agency")
+drop_column("orders", "paragraph_number")

--- a/migrations_manifest.txt
+++ b/migrations_manifest.txt
@@ -349,3 +349,4 @@
 20190822210248_add-payment-reviewed-date-to-personally-procured-moves.up.sql
 20190829150706_create_notifications_table.up.sql
 20190829152347_create-deleted-at-indices-for-document-tables.up.sql
+20190906223934_remove_oia_pn.up.fizz


### PR DESCRIPTION
## Description

Adds a migration that removes the Orders Issuing Agency and Paragraph Number columns from the orders table. 


## Code Review Verification Steps

* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/tree/master/docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
  * [ ] Secure migrations have been tested using `scripts/run-prod-migrations`
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/167951861) for this change
