### PR TITLE
Update MoveSummaryComponent to always fetch estimate

### DIFF
--- a/src/scenes/Landing/MoveSummary.jsx
+++ b/src/scenes/Landing/MoveSummary.jsx
@@ -495,7 +495,7 @@ const getPPMStatus = (moveStatus, ppm, selectedMoveType) => {
 };
 
 export class MoveSummaryComponent extends React.Component {
-  componentDidUpdate() {
+  componentDidMount() {
     this.props.getMoveDocumentsForMove(this.props.move.id).then(({ obj: documents }) => {
       const weightTicketNetWeight = calcNetWeight(documents);
       const netWeight =

--- a/src/scenes/Landing/MoveSummary.jsx
+++ b/src/scenes/Landing/MoveSummary.jsx
@@ -495,21 +495,19 @@ const getPPMStatus = (moveStatus, ppm, selectedMoveType) => {
 };
 
 export class MoveSummaryComponent extends React.Component {
-  componentDidUpdate(prevProps) {
-    if (this.props.move.id !== prevProps.move.id) {
-      this.props.getMoveDocumentsForMove(this.props.move.id).then(({ obj: documents }) => {
-        const weightTicketNetWeight = calcNetWeight(documents);
-        const netWeight =
-          weightTicketNetWeight > this.props.entitlement.sum ? this.props.entitlement.sum : weightTicketNetWeight;
-        this.props.getPpmWeightEstimate(
-          this.props.ppm.actual_move_date || this.props.ppm.original_move_date,
-          this.props.ppm.pickup_postal_code,
-          this.props.originDutyStationZip,
-          this.props.ppm.destination_postal_code,
-          netWeight,
-        );
-      });
-    }
+  componentDidUpdate() {
+    this.props.getMoveDocumentsForMove(this.props.move.id).then(({ obj: documents }) => {
+      const weightTicketNetWeight = calcNetWeight(documents);
+      const netWeight =
+        weightTicketNetWeight > this.props.entitlement.sum ? this.props.entitlement.sum : weightTicketNetWeight;
+      this.props.getPpmWeightEstimate(
+        this.props.ppm.actual_move_date || this.props.ppm.original_move_date,
+        this.props.ppm.pickup_postal_code,
+        this.props.originDutyStationZip,
+        this.props.ppm.destination_postal_code,
+        netWeight,
+      );
+    });
   }
   render() {
     const {


### PR DESCRIPTION
## Description

For service member's that have requested payment, the estimated payment was still using the payment estimate based on the initial weight estimate rather than weight ticket derived weight. Update so that we always fetch a new estimated payment.

* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?