### PR TITLE
Display the ECS tasks that are RUNNING and PENDING during a deploy

### DIFF
--- a/scripts/ecs-deploy-service-container
+++ b/scripts/ecs-deploy-service-container
@@ -58,8 +58,12 @@ update_service() {
 
     echo "* Waiting for service to be stable before updating"
     time aws ecs wait services-stable --services "$name" --cluster "$cluster"
+    echo "* Currently running ECS tasks:"
+    aws ecs list-tasks --service app --cluster app-experimental --desired-status=RUNNING
     echo "* Updating $name service to use $arn"
     aws ecs update-service --cluster "$cluster" --service "$name" --task-definition "$arn" --query 'service.deployments' --network-configuration "$network_config" || return 1
+    echo "* Newly started ECS tasks:"
+    aws ecs list-tasks --service app --cluster app-experimental --desired-status=PENDING
     echo "* Waiting for service to stabilize (this takes a while)"
     time aws ecs wait services-stable --services "$name" --cluster "$cluster"
     local exit_code=$?


### PR DESCRIPTION
## Description

When a deploy fails we want to know the ECS Task ID so we can go to cloudwatch and look at the logs and find out what happened.