### PR TITLE
[System admin] Show disabled/deactivated column, and other cleanup

### DIFF
--- a/pkg/handlers/adminapi/office_users.go
+++ b/pkg/handlers/adminapi/office_users.go
@@ -17,10 +17,12 @@ import (
 
 func payloadForOfficeUserModel(o models.OfficeUser) *adminmessages.OfficeUser {
 	return &adminmessages.OfficeUser{
-		ID:        *handlers.FmtUUID(o.ID),
-		FirstName: o.FirstName,
-		LastName:  o.LastName,
-		Email:     o.Email,
+		ID:        handlers.FmtUUID(o.ID),
+		FirstName: handlers.FmtString(o.FirstName),
+		LastName:  handlers.FmtString(o.LastName),
+		Telephone: handlers.FmtString(o.Telephone),
+		Email:     handlers.FmtString(o.Email),
+		Disabled:  handlers.FmtBool(o.Disabled),
 	}
 }
 
@@ -53,6 +55,7 @@ func (h IndexOfficeUsersHandler) Handle(params officeuserop.IndexOfficeUsersPara
 	queriedOfficeUsersCount := len(officeUsers)
 
 	payload := make(adminmessages.OfficeUsers, queriedOfficeUsersCount)
+
 	for i, s := range officeUsers {
 		payload[i] = payloadForOfficeUserModel(s)
 	}

--- a/src/scenes/SystemAdmin/UserList.jsx
+++ b/src/scenes/SystemAdmin/UserList.jsx
@@ -1,13 +1,13 @@
 import React from 'react';
-import { List, EmailField, Datagrid, TextField, BooleanField } from 'react-admin';
+import { List, Datagrid, TextField, BooleanField } from 'react-admin';
 import AdminPagination from './AdminPagination';
 
 const UserList = props => (
   <List {...props} pagination={<AdminPagination />} perPage={25}>
     <Datagrid rowClick="show">
-      <EmailField source="email" />
-      <TextField source="first_name" />
       <TextField source="id" />
+      <TextField source="email" />
+      <TextField source="first_name" />
       <TextField source="last_name" />
       <BooleanField source="disabled" label="Deactivated" />
     </Datagrid>

--- a/src/scenes/SystemAdmin/UserList.jsx
+++ b/src/scenes/SystemAdmin/UserList.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { List, EmailField, Datagrid, TextField } from 'react-admin';
+import { List, EmailField, Datagrid, TextField, BooleanField } from 'react-admin';
 import AdminPagination from './AdminPagination';
 
 const UserList = props => (
@@ -9,6 +9,7 @@ const UserList = props => (
       <TextField source="first_name" />
       <TextField source="id" />
       <TextField source="last_name" />
+      <BooleanField source="disabled" label="Deactivated" />
     </Datagrid>
   </List>
 );

--- a/src/scenes/SystemAdmin/UserShow.jsx
+++ b/src/scenes/SystemAdmin/UserShow.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Show, SimpleShowLayout, TextField } from 'react-admin';
+import { Show, SimpleShowLayout, TextField, BooleanField } from 'react-admin';
 
 const UserShowTitle = ({ record }) => {
   return <span>{`${record.first_name} ${record.last_name}`}</span>;
@@ -13,6 +13,7 @@ const UserShow = props => {
         <TextField source="email" />
         <TextField source="first_name" />
         <TextField source="last_name" />
+        <BooleanField source="disabled" label="Deactivated" />
       </SimpleShowLayout>
     </Show>
   );

--- a/swagger/admin.yaml
+++ b/swagger/admin.yaml
@@ -33,6 +33,15 @@ definitions:
         pattern: '^[2-9]\d{2}-\d{3}-\d{4}$'
       transportation_office:
         $ref: '#/definitions/TransportationOffice'
+      disabled:
+        type: boolean
+    required:
+      - id
+      - first_name
+      - last_name
+      - email
+      - telephone
+      - disabled
   OfficeUsers:
     type: array
     items:


### PR DESCRIPTION
## Setup

- `make server_run`
- `make client_run`
- Log into the admin app and navigate to the office users resource

## Code Review Verification Steps

* [x] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## Pivotal tickets

* [Admin UI office users list should include disabled column](https://www.pivotaltracker.com/story/show/167872706)
* [Admin UI office users details should include disabled column](https://www.pivotaltracker.com/story/show/167872723)
* [Remove mailto: link for office user email addresses in admin UI](https://www.pivotaltracker.com/story/show/167872293)
* [Clean up columns on office users page in admin UI](https://www.pivotaltracker.com/story/show/167855095)
