### PR TITLE
Move email content into templates

### DIFF
--- a/pkg/notifications/move_approved.go
+++ b/pkg/notifications/move_approved.go
@@ -1,24 +1,38 @@
 package notifications
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	html "html/template"
 	"net/url"
+	text "text/template"
 
 	"github.com/gobuffalo/pop"
 	"github.com/gofrs/uuid"
+	"go.uber.org/zap"
 
+	"github.com/transcom/mymove/pkg/assets"
 	"github.com/transcom/mymove/pkg/auth"
 	"github.com/transcom/mymove/pkg/models"
 )
 
+var (
+	moveApprovedRawTextTemplate = string(assets.MustAsset("pkg/notifications/templates/move_approved_template.txt"))
+	moveApprovedTextTemplate    = text.Must(text.New("text_template").Parse(moveApprovedRawTextTemplate))
+	moveApprovedRawHTMLTemplate = string(assets.MustAsset("pkg/notifications/templates/move_approved_template.html"))
+	moveApprovedHTMLTemplate    = html.Must(html.New("text_template").Parse(moveApprovedRawHTMLTemplate))
+)
+
 // MoveApproved has notification content for approved moves
 type MoveApproved struct {
-	db      *pop.Connection
-	logger  Logger
-	host    string
-	moveID  uuid.UUID
-	session *auth.Session // TODO - remove this when we move permissions up to handlers and out of models
+	db           *pop.Connection
+	logger       Logger
+	host         string
+	moveID       uuid.UUID
+	session      *auth.Session // TODO - remove this when we move permissions up to handlers and out of models
+	htmlTemplate *html.Template
+	textTemplate *text.Template
 }
 
 // NewMoveApproved returns a new move approval notification
@@ -29,11 +43,13 @@ func NewMoveApproved(db *pop.Connection,
 	moveID uuid.UUID) *MoveApproved {
 
 	return &MoveApproved{
-		db:      db,
-		logger:  logger,
-		host:    host,
-		moveID:  moveID,
-		session: session,
+		db:           db,
+		logger:       logger,
+		host:         host,
+		moveID:       moveID,
+		session:      session,
+		htmlTemplate: moveApprovedHTMLTemplate,
+		textTemplate: moveApprovedTextTemplate,
 	}
 }
 
@@ -73,45 +89,62 @@ func (m MoveApproved) emails(ctx context.Context) ([]emailContent, error) {
 		Path:   "downloads/ppm_info_sheet.pdf",
 	}
 
-	introTextHTML := "You're all set to move!"
-	introText := "You're all set to move!"
+	htmlBody, textBody, err := m.renderTemplates(moveApprovedEmailData{
+		Link:                       ppmInfoSheetURL.String(),
+		OriginDutyStation:          dsTransportInfo.Name,
+		DestinationDutyStation:     orders.NewDutyStation.Name,
+		OriginDutyStationPhoneLine: dsTransportInfo.PhoneLine,
+	})
 
-	dutyStationTextHTML := fmt.Sprintf("The local transportation office <strong>approved your move</strong> from <strong>%s</strong> to <strong>%s</strong>.", dsTransportInfo.Name, orders.NewDutyStation.Name)
-	dutyStationText := fmt.Sprintf("The local transportation office approved your move from %s to %s.", dsTransportInfo.Name, orders.NewDutyStation.Name)
-
-	ppmInfoSheetInstructionsHTML := fmt.Sprintf("Please <a href=\"%s\">review the Personally Procured Move (PPM) info sheet</a> for detailed instructions.", ppmInfoSheetURL.String())
-	ppmInfoSheetInstructions := fmt.Sprintf("Please review the Personally Procured Move (PPM) info sheet for detailed instructions at %s.", ppmInfoSheetURL.String())
-
-	if move.PersonallyProcuredMoves != nil {
-		introTextHTML = fmt.Sprintf("<strong>%s</strong><br /><br /> %s <br /><br />%s<br />",
-			introTextHTML,
-			dutyStationTextHTML,
-			ppmInfoSheetInstructionsHTML,
-		)
-		introText = fmt.Sprintf("%s\n\n%s\n\n%s", introText, dutyStationText, ppmInfoSheetInstructions)
+	if err != nil {
+		m.logger.Error("error rendering template", zap.Error(err))
 	}
-
-	nextStepsTextHTML := `<strong>Next steps</strong>`
-	nextStepsText := "Next steps"
-
-	ppmTextHTML := ""
-	ppmText := ""
-	if move.PersonallyProcuredMoves != nil {
-		ppmTextHTML = `Because you’ve chosen a do-it-yourself move, you can start whenever you are ready.<br /><br >
-		Be sure to <strong>save your weight tickets and any receipts</strong> associated with your move. You’ll need them to request payment later in the process.`
-		ppmText = "Because you’ve chosen a do-it-yourself move, you can start whenever you are ready.\n\nBe sure to save your weight tickets and any receipts associated with your move. You’ll need them to request payment later in the process."
-	}
-
-	closingTextHTML := fmt.Sprintf("If you have any questions, call the <strong>%s</strong> PPPO at %s.<br /><br />You can <a href=\"%s\">check the status of your move</a> anytime at https://my.move.mil", dsTransportInfo.Name, dsTransportInfo.PhoneLine, "https://my.move.mil")
-	closingText := fmt.Sprintf("If you have any questions, call the %s PPPO at %s.\n\nYou can check the status of your move anytime at https://my.move.mil", dsTransportInfo.Name, dsTransportInfo.PhoneLine)
 
 	smEmail := emailContent{
 		recipientEmail: *serviceMember.PersonalEmail,
 		subject:        "[MilMove] Your move is approved",
-		htmlBody:       fmt.Sprintf("%s<br/>%s<br/>%s<br/><br />%s", introTextHTML, nextStepsTextHTML, ppmTextHTML, closingTextHTML),
-		textBody:       fmt.Sprintf("%s\n%s\n%s\n%s", introText, nextStepsText, ppmText, closingText),
+		htmlBody:       htmlBody,
+		textBody:       textBody,
 	}
 
 	// TODO: Send email to trusted contacts when that's supported
 	return append(emails, smEmail), nil
+}
+
+func (m MoveApproved) renderTemplates(data moveApprovedEmailData) (string, string, error) {
+	htmlBody, err := m.RenderHTML(data)
+	if err != nil {
+		return "", "", fmt.Errorf("error rendering html template using %#v", data)
+	}
+	textBody, err := m.RenderText(data)
+	if err != nil {
+		return "", "", fmt.Errorf("error rendering text template using %#v", data)
+	}
+	return htmlBody, textBody, nil
+}
+
+type moveApprovedEmailData struct {
+	Link                       string
+	OriginDutyStation          string
+	DestinationDutyStation     string
+	OriginDutyStationPhoneLine string
+}
+
+// RenderHTML renders the html for the email
+func (m MoveApproved) RenderHTML(data moveApprovedEmailData) (string, error) {
+	var htmlBuffer bytes.Buffer
+	if err := m.htmlTemplate.Execute(&htmlBuffer, data); err != nil {
+		m.logger.Error("cant render html template ", zap.Error(err))
+	}
+	return htmlBuffer.String(), nil
+}
+
+// RenderText renders the text for the email
+func (m MoveApproved) RenderText(data moveApprovedEmailData) (string, error) {
+	var textBuffer bytes.Buffer
+	if err := m.textTemplate.Execute(&textBuffer, data); err != nil {
+		m.logger.Error("cant render text template ", zap.Error(err))
+		return "", err
+	}
+	return textBuffer.String(), nil
 }

--- a/pkg/notifications/move_canceled.go
+++ b/pkg/notifications/move_canceled.go
@@ -1,32 +1,48 @@
 package notifications
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	html "html/template"
+	text "text/template"
 
 	"github.com/gobuffalo/pop"
 	"github.com/gofrs/uuid"
+	"go.uber.org/zap"
 
+	"github.com/transcom/mymove/pkg/assets"
 	"github.com/transcom/mymove/pkg/auth"
 	"github.com/transcom/mymove/pkg/models"
 )
 
+var (
+	moveCanceledRawTextTemplate = string(assets.MustAsset("pkg/notifications/templates/move_canceled_template.txt"))
+	moveCanceledTextTemplate    = text.Must(text.New("text_template").Parse(moveCanceledRawTextTemplate))
+	moveCanceledRawHTMLTemplate = string(assets.MustAsset("pkg/notifications/templates/move_canceled_template.html"))
+	moveCanceledHTMLTemplate    = html.Must(html.New("text_template").Parse(moveCanceledRawHTMLTemplate))
+)
+
 // MoveCanceled has notification content for approved moves
 type MoveCanceled struct {
-	db      *pop.Connection
-	logger  Logger
-	moveID  uuid.UUID
-	session *auth.Session // TODO - remove this when we move permissions up to handlers and out of models
+	db           *pop.Connection
+	logger       Logger
+	moveID       uuid.UUID
+	session      *auth.Session // TODO - remove this when we move permissions up to handlers and out of models
+	htmlTemplate *html.Template
+	textTemplate *text.Template
 }
 
 // NewMoveCanceled returns a new move approval notification
 func NewMoveCanceled(db *pop.Connection, logger Logger, session *auth.Session, moveID uuid.UUID) *MoveCanceled {
 
 	return &MoveCanceled{
-		db:      db,
-		logger:  logger,
-		moveID:  moveID,
-		session: session,
+		db:           db,
+		logger:       logger,
+		moveID:       moveID,
+		session:      session,
+		htmlTemplate: moveCanceledHTMLTemplate,
+		textTemplate: moveCanceledTextTemplate,
 	}
 }
 
@@ -65,19 +81,60 @@ func (m MoveCanceled) emails(ctx context.Context) ([]emailContent, error) {
 	// https://docs.google.com/document/d/1gIQZprWzJJE_sAAyg5NViPwy9ckL5RK37gFq1fEfipU
 	// TODO: we will want some sort of templating system
 
-	introText := `Update on your move`
-	nextSteps := fmt.Sprintf("Upon review, the office has determined that MilMove can’t handle your move from %s to %s, and canceled it in the system. You’re still moving, but we’ll need to manage your move with a different system.",
-		dsTransportInfo.Name, orders.NewDutyStation.Name)
-	closingText := fmt.Sprintf("Please call the PPPO at %s at %s and they’ll help you figure out what to do next.",
-		dsTransportInfo.Name, dsTransportInfo.PhoneLine)
+	htmlBody, textBody, err := m.renderTemplates(moveCanceledEmailData{
+		OriginDutyStation:          dsTransportInfo.Name,
+		DestinationDutyStation:     orders.NewDutyStation.Name,
+		OriginDutyStationPhoneLine: dsTransportInfo.PhoneLine,
+	})
+
+	if err != nil {
+		m.logger.Error("error rendering template", zap.Error(err))
+	}
 
 	smEmail := emailContent{
 		recipientEmail: *serviceMember.PersonalEmail,
-		subject:        fmt.Sprintf("[MilMove] %s", introText),
-		htmlBody:       fmt.Sprintf("%s<br/><br/><br/>%s", nextSteps, closingText),
-		textBody:       fmt.Sprintf("%s\n\n\n%s", nextSteps, closingText),
+		subject:        "[MilMove] Update on your move",
+		htmlBody:       htmlBody,
+		textBody:       textBody,
 	}
 
 	// TODO: Send email to trusted contacts when that's supported
 	return append(emails, smEmail), nil
+}
+
+func (m MoveCanceled) renderTemplates(data moveCanceledEmailData) (string, string, error) {
+	htmlBody, err := m.RenderHTML(data)
+	if err != nil {
+		return "", "", fmt.Errorf("error rendering html template using %#v", data)
+	}
+	textBody, err := m.RenderText(data)
+	if err != nil {
+		return "", "", fmt.Errorf("error rendering text template using %#v", data)
+	}
+	return htmlBody, textBody, nil
+}
+
+type moveCanceledEmailData struct {
+	OriginDutyStation          string
+	DestinationDutyStation     string
+	OriginDutyStationPhoneLine string
+}
+
+// RenderHTML renders the html for the email
+func (m MoveCanceled) RenderHTML(data moveCanceledEmailData) (string, error) {
+	var htmlBuffer bytes.Buffer
+	if err := m.htmlTemplate.Execute(&htmlBuffer, data); err != nil {
+		m.logger.Error("cant render html template ", zap.Error(err))
+	}
+	return htmlBuffer.String(), nil
+}
+
+// RenderText renders the text for the email
+func (m MoveCanceled) RenderText(data moveCanceledEmailData) (string, error) {
+	var textBuffer bytes.Buffer
+	if err := m.textTemplate.Execute(&textBuffer, data); err != nil {
+		m.logger.Error("cant render text template ", zap.Error(err))
+		return "", err
+	}
+	return textBuffer.String(), nil
 }

--- a/pkg/notifications/notification_test.go
+++ b/pkg/notifications/notification_test.go
@@ -36,16 +36,10 @@ func (suite *NotificationSuite) TestMoveApproved() {
 
 	approver := testdatagen.MakeDefaultUser(suite.DB())
 	move := testdatagen.MakeDefaultMove(suite.DB())
-	notification := MoveApproved{
-		db:     suite.DB(),
-		logger: suite.logger,
-		host:   "milmovelocal",
-		moveID: move.ID,
-		session: &auth.Session{
-			UserID:          approver.ID,
-			ApplicationName: auth.OfficeApp,
-		},
-	}
+	notification := NewMoveApproved(suite.DB(), suite.logger, &auth.Session{
+		UserID:          approver.ID,
+		ApplicationName: auth.OfficeApp,
+	}, "milmovelocal", move.ID)
 
 	emails, err := notification.emails(ctx)
 	if err != nil {
@@ -68,15 +62,10 @@ func (suite *NotificationSuite) TestMoveSubmitted() {
 	t := suite.T()
 
 	move := testdatagen.MakeDefaultMove(suite.DB())
-	notification := MoveSubmitted{
-		db:     suite.DB(),
-		logger: suite.logger,
-		moveID: move.ID,
-		session: &auth.Session{
-			ServiceMemberID: move.Orders.ServiceMember.ID,
-			ApplicationName: auth.MilApp,
-		},
-	}
+	notification := NewMoveSubmitted(suite.DB(), suite.logger, &auth.Session{
+		ServiceMemberID: move.Orders.ServiceMember.ID,
+		ApplicationName: auth.MilApp,
+	}, move.ID)
 
 	emails, err := notification.emails(ctx)
 	if err != nil {

--- a/pkg/notifications/templates/move_approved_template.html
+++ b/pkg/notifications/templates/move_approved_template.html
@@ -1,0 +1,22 @@
+<p>You're all set to move!</p>
+
+<p>
+  The local transportation office <strong>approved your move</strong> from <strong>{{.OriginDutyStation}}</strong> to
+  <strong>{{.DestinationDutyStation}}</strong
+  >.
+</p>
+
+<p>Please <a href="{{.Link}}">review the Personally Procured Move (PPM) info sheet</a> for detailed instructions.</p>
+
+<p>
+  <strong>Next steps</strong> <br />Because you’ve chosen a do-it-yourself move, you can start whenever you are ready.
+</p>
+
+<p>
+  Be sure to <strong>save your weight tickets and any receipts</strong> associated with your move. You’ll need them to
+  request payment later in the process.
+</p>
+
+<p>If you have any questions, call the {{.OriginDutyStation}} PPPO at {{.OriginDutyStationPhoneLine}}.</p>
+
+<p>You can <a href="https://my.move.mil">check the status of your move</a> anytime at https://my.move.mil"</p>

--- a/pkg/notifications/templates/move_approved_template.html
+++ b/pkg/notifications/templates/move_approved_template.html
@@ -7,7 +7,7 @@
 </p>
 
 <p>Please <a href="{{.Link}}">review the Personally Procured Move (PPM) info sheet</a> for detailed instructions.</p>
-
+<br />
 <p>
   <strong>Next steps</strong> <br />Because you’ve chosen a do-it-yourself move, you can start whenever you are ready.
 </p>

--- a/pkg/notifications/templates/move_approved_template.txt
+++ b/pkg/notifications/templates/move_approved_template.txt
@@ -4,6 +4,7 @@ The local transportation office approved your move from {{.OriginDutyStation}} t
 
 Please review the Personally Procured Move (PPM) info sheet for detailed instructions at {{.Link}}.
 
+
 Next steps
 Because you’ve chosen a do-it-yourself move, you can start whenever you are ready.
 

--- a/pkg/notifications/templates/move_approved_template.txt
+++ b/pkg/notifications/templates/move_approved_template.txt
@@ -1,0 +1,14 @@
+You're all set to move!
+
+The local transportation office approved your move from {{.OriginDutyStation}} to {{.DestinationDutyStation}}.
+
+Please review the Personally Procured Move (PPM) info sheet for detailed instructions at {{.Link}}.
+
+Next steps
+Because you’ve chosen a do-it-yourself move, you can start whenever you are ready.
+
+Be sure to save your weight tickets and any receipts associated with your move. You’ll need them to request payment later in the process.
+
+If you have any questions, call the {{.OriginDutyStation}} PPPO at {{.OriginDutyStationPhoneLine}}.
+
+You can check the status of your move anytime at https://my.move.mil"

--- a/pkg/notifications/templates/move_canceled_template.html
+++ b/pkg/notifications/templates/move_canceled_template.html
@@ -1,0 +1,10 @@
+<p>
+  Upon review, the office has determined that MilMove can’t handle your move from {{.OriginDutyStation}} to
+  {{.DestinationDutyStation}}, and canceled it in the system. You’re still moving, but we’ll need to manage your move
+  with a different system.
+</p>
+
+<p>
+  Please call the PPPO at {{.OriginDutyStation}} at {{.OriginDutyStationPhoneLine}} and they’ll help you figure out what
+  to do next.
+</p>

--- a/pkg/notifications/templates/move_canceled_template.txt
+++ b/pkg/notifications/templates/move_canceled_template.txt
@@ -1,0 +1,3 @@
+Upon review, the office has determined that MilMove can’t handle your move from {{.OriginDutyStation}} to {{.DestinationDutyStation}}, and canceled it in the system. You’re still moving, but we’ll need to manage your move with a different system.
+
+Please call the PPPO at {{.OriginDutyStation}} at {{.OriginDutyStationPhoneLine}} and they’ll help you figure out what to do next.

--- a/pkg/notifications/templates/move_submitted_template.html
+++ b/pkg/notifications/templates/move_submitted_template.html
@@ -1,0 +1,18 @@
+<p>
+  Your move from {{.OriginDutyStation}} to {{.DestinationDutyStation}} has been submitted to your local transportation
+  office for review.
+</p>
+
+<p>This can take up to 3 business days. The office will email you once your move has been approved.</p>
+
+<p>
+  In the meantime, if you have questions or need expedited processing, call the {{.OriginDutyStation}} PPPO at
+  {{.OriginDutyStationPhoneLine}}.
+</p>
+
+<p>You can check the status of your move at any time at https://my.move.mil/</p>
+
+<p>
+  <strong>Let us know how we’re doing.</strong> <a href="{{.Link}}">Please take a brief survey</a> and share how well
+  we’re handling your move so far at {{.Link}}.
+</p>

--- a/pkg/notifications/templates/move_submitted_template.txt
+++ b/pkg/notifications/templates/move_submitted_template.txt
@@ -1,0 +1,9 @@
+Your move from {{.OriginDutyStation}} to {{.DestinationDutyStation}} has been submitted to your local transportation office for review.
+
+This can take up to 3 business days. The office will email you once your move has been approved.
+
+In the meantime, if you have questions or need expedited processing, call the {{.OriginDutyStation}} PPPO at {{.OriginDutyStationPhoneLine}}.
+
+You can check the status of your move at any time at https://my.move.mil/
+
+Let us know how we’re doing. Please take a brief survey and share how well we’re handling your move so far at {{.Link}}.


### PR DESCRIPTION
## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Setup

```sh
make clean
make server_run
make client_run
make office_client_run
```

Please keep eye on server logs in your command line for the email content.

**Scenario 1** 
Go through the process of making a move and verify "move submitted" email is formatted correctly. 
https://docs.google.com/document/d/1QOCFZ4w003ouJxPYXdnCtTWqBR3MGTDqCBtqjtpXpkE

**Scenario 2**
As an office user, find the move you submitted and approve it. Verify the "move approved" email is formatted correctly. 
https://docs.google.com/document/d/1gIQZprWzJJE_sAAyg5NViPwy9ckL5RK37gFq1fEfipU

**Scenario 3**
As an office user, find another move that has been submitted and cancel it. Verify the "move canceled" email is formatted correctly.
https://docs.google.com/document/d/1gIQZprWzJJE_sAAyg5NViPwy9ckL5RK37gF

## Code Review Verification Steps
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/168174558) for this change