### PR TITLE
Change usa-alert-body to display block

### DIFF
--- a/src/scenes/Moves/Ppm/WeightTicket.jsx
+++ b/src/scenes/Moves/Ppm/WeightTicket.jsx
@@ -387,14 +387,14 @@ class WeightTicket extends Component {
                   </div>
 
                   <div className="usa-width-two-thirds uploader-wrapper">
-                    <span data-cy="full-weight-upload">
+                    <div data-cy="full-weight-upload">
                       <Uploader
                         options={{ labelIdle: uploadFullTicketLabel }}
                         onRef={ref => (this.uploaders.fullWeight.uploaderRef = ref)}
                         onChange={this.onUploadChange('fullWeight')}
                         onAddFile={this.onAddFile('fullWeight')}
                       />
-                    </span>
+                    </div>
                     <Checkbox
                       label="I'm missing this weight ticket"
                       name="missingFullWeightTicket"
@@ -403,12 +403,12 @@ class WeightTicket extends Component {
                       normalizeLabel
                     />
                     {missingFullWeightTicket && (
-                      <span data-cy="full-warning">
+                      <div data-cy="full-warning">
                         <Alert type="warning">
                           Contact your local Transportation Office (PPPO) to let them know you’re missing this weight
                           ticket. For now, keep going and enter the info you do have.
                         </Alert>
-                      </span>
+                      </div>
                     )}
                   </div>
                 </div>

--- a/src/shared/Alert/index.css
+++ b/src/shared/Alert/index.css
@@ -14,6 +14,10 @@
   float: right;
 }
 
+.usa-alert-body {
+	display: block;
+}
+
 .body--heading {
   display: flex;
   align-items: center;

--- a/src/shared/Alert/index.jsx
+++ b/src/shared/Alert/index.jsx
@@ -17,16 +17,14 @@ const Alert = props => (
           </div>
         ) : null}
         <div>
-          <div>
-            {props.heading && <h3 className="usa-alert-heading">{props.heading}</h3>}
-            {props.onRemove && (
-              <FontAwesomeIcon
-                className="icon remove-icon actionable actionable-secondary"
-                onClick={props.onRemove}
-                icon={faTimes}
-              />
-            )}
-          </div>
+          {props.heading && <h3 className="usa-alert-heading">{props.heading}</h3>}
+          {props.onRemove && (
+            <FontAwesomeIcon
+              className="icon remove-icon actionable actionable-secondary"
+              onClick={props.onRemove}
+              icon={faTimes}
+            />
+          )}
           <div className="usa-alert-text">{props.children}</div>
         </div>
       </div>

--- a/src/shared/AlertWithConfirmation/index.css
+++ b/src/shared/AlertWithConfirmation/index.css
@@ -14,6 +14,10 @@
   float: right;
 }
 
+.usa-alert-body {
+	display: block;
+}
+
 .body--heading {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Description

It appears that we've been using a franken-version of uswds. This led to the alert text overflowing because the `usa-alert-body` computes as a table-cell display instead of as a block.

## Reviewer Notes

Is there a better way for us to override CSS from USWDS? I did the easiest thing that fixed it, but would love to know if there's a better way.

## Setup

You'll need to pull down this work and check it on a VM to verify this works. You'll also need to run this on IE11 to see the original issue as there are no problems in Edge.

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make server_run
make client_run
```
Sign in as `ppm@requestingpayment.newflow` and request payment. On the weight ticket page, click missing weight ticket checkbox. The text should not overflow the yellow background for the alert.

## Code Review Verification Steps

* [x] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* https://www.pivotaltracker.com/story/show/168002753

## Screenshots

Before in IE11:
<img width="829" alt="Screen Shot 2019-09-11 at 4 12 58 PM" src="https://user-images.githubusercontent.com/5531789/64741905-19479e00-d4af-11e9-9692-0276a7326306.png">


After in IE11:
<img width="266" alt="Screen Shot 2019-09-11 at 4 06 47 PM" src="https://user-images.githubusercontent.com/5531789/64741845-e3a2b500-d4ae-11e9-836c-0ddfd457e1bf.png">
