### PR TITLE
Fix issues with paths in some "milmove gen" commands

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -492,6 +492,7 @@ MatchReasonCodeFull
 MatchReasonCodeNone
 wkEma
 _No_
+subcommands
 # Put all custom terms BEFORE this comment, lest 'pre-commit' and 'make spellcheck' yield different errors.
  - /usr/local
  - docs/data/tspp-data-creation.md

--- a/cmd/milmove/gen_duty_stations_migration.go
+++ b/cmd/milmove/gen_duty_stations_migration.go
@@ -53,6 +53,10 @@ func CheckAddDutyStations(v *viper.Viper, logger logger) error {
 		return err
 	}
 
+	if err := cli.CheckMigrationGenPath(v); err != nil {
+		return err
+	}
+
 	DutyStationsFilename := v.GetString(DutyStationsFilenameFlag)
 	if DutyStationsFilename == "" {
 		return fmt.Errorf("--duty-stations-filename is required")
@@ -69,6 +73,9 @@ func initGenDutyStationsMigrationFlags(flag *pflag.FlagSet) {
 
 	// Migration File Config
 	cli.InitMigrationFileFlags(flag)
+
+	// Migration Gen Path Config
+	cli.InitMigrationGenPathFlags(flag)
 
 	// Add Duty Stations
 	InitAddDutyStationsFlags(flag)
@@ -129,6 +136,7 @@ func genDutyStationsMigration(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	migrationPath := v.GetString(cli.MigrationGenPathFlag)
 	migrationManifest := v.GetString(cli.MigrationManifestFlag)
 	migrationName := v.GetString(cli.MigrationNameFlag)
 	migrationVersion := v.GetString(cli.MigrationVersionFlag)
@@ -154,7 +162,7 @@ func genDutyStationsMigration(cmd *cobra.Command, args []string) error {
 	}
 
 	migrationFilename := fmt.Sprintf("%s_%s.up.sql", migrationVersion, migrationName)
-	err = createDutyStationMigration("./migrations", migrationFilename, insertions)
+	err = createDutyStationMigration(migrationPath, migrationFilename, insertions)
 	if err != nil {
 		return err
 	}

--- a/cmd/milmove/gen_duty_stations_migration.go
+++ b/cmd/milmove/gen_duty_stations_migration.go
@@ -129,7 +129,6 @@ func genDutyStationsMigration(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	migrationPath := v.GetString(cli.MigrationPathFlag)
 	migrationManifest := v.GetString(cli.MigrationManifestFlag)
 	migrationName := v.GetString(cli.MigrationNameFlag)
 	migrationVersion := v.GetString(cli.MigrationVersionFlag)
@@ -155,7 +154,7 @@ func genDutyStationsMigration(cmd *cobra.Command, args []string) error {
 	}
 
 	migrationFilename := fmt.Sprintf("%s_%s.up.sql", migrationVersion, migrationName)
-	err = createDutyStationMigration(migrationPath, migrationFilename, insertions)
+	err = createDutyStationMigration("./migrations", migrationFilename, insertions)
 	if err != nil {
 		return err
 	}

--- a/cmd/milmove/gen_migration.go
+++ b/cmd/milmove/gen_migration.go
@@ -22,6 +22,9 @@ func initGenMigrationFlags(flag *pflag.FlagSet) {
 	// Migration File Config
 	cli.InitMigrationFileFlags(flag)
 
+	// Migration Gen Path Config
+	cli.InitMigrationGenPathFlags(flag)
+
 	// Sort command line flags
 	flag.SortFlags = true
 }
@@ -33,6 +36,10 @@ func checkGenMigrationConfig(v *viper.Viper) error {
 	}
 
 	if err := cli.CheckMigrationFile(v); err != nil {
+		return err
+	}
+
+	if err := cli.CheckMigrationGenPath(v); err != nil {
 		return err
 	}
 
@@ -65,13 +72,14 @@ func genMigrationFunction(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	migrationPath := v.GetString(cli.MigrationGenPathFlag)
 	migrationManifest := v.GetString(cli.MigrationManifestFlag)
 	migrationVersion := v.GetString(cli.MigrationVersionFlag)
 	migrationName := v.GetString(cli.MigrationNameFlag)
 	migrationType := v.GetString(cli.MigrationTypeFlag)
 
 	filename := fmt.Sprintf("%s_%s.up.%s", migrationVersion, migrationName, migrationType)
-	err = writeEmptyFile("./migrations", filename)
+	err = writeEmptyFile(migrationPath, filename)
 	if err != nil {
 		return err
 	}

--- a/cmd/milmove/gen_migration.go
+++ b/cmd/milmove/gen_migration.go
@@ -65,14 +65,13 @@ func genMigrationFunction(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	migrationPath := v.GetString(cli.MigrationPathFlag)
 	migrationManifest := v.GetString(cli.MigrationManifestFlag)
 	migrationVersion := v.GetString(cli.MigrationVersionFlag)
 	migrationName := v.GetString(cli.MigrationNameFlag)
 	migrationType := v.GetString(cli.MigrationTypeFlag)
 
 	filename := fmt.Sprintf("%s_%s.up.%s", migrationVersion, migrationName, migrationType)
-	err = writeEmptyFile(migrationPath, filename)
+	err = writeEmptyFile("./migrations", filename)
 	if err != nil {
 		return err
 	}

--- a/cmd/milmove/migrate.go
+++ b/cmd/milmove/migrate.go
@@ -40,6 +40,9 @@ func initMigrateFlags(flag *pflag.FlagSet) {
 	// Migration Config
 	cli.InitMigrationFlags(flag)
 
+	// Migration Path Config
+	cli.InitMigrationPathFlags(flag)
+
 	// aws-vault Config
 	cli.InitVaultFlags(flag)
 
@@ -66,6 +69,10 @@ func checkMigrateConfig(v *viper.Viper, logger logger) error {
 	}
 
 	if err := cli.CheckMigration(v); err != nil {
+		return err
+	}
+
+	if err := cli.CheckMigrationPath(v); err != nil {
 		return err
 	}
 

--- a/docs/how-to/migrate-the-database.md
+++ b/docs/how-to/migrate-the-database.md
@@ -19,7 +19,8 @@ database with environment variables.
 
 ## Creating a migration
 
-Use the `milmove gen <subcommand>` commands to generate models and migrations.
+Use the `milmove gen <subcommand>` commands to generate models and migrations.  To see a list of available subcommands,
+use `milmove gen`.
 
 > **We don't use down-migrations to revert changes to the schema; any problems are to be fixed by a follow-up migration.**
 
@@ -29,7 +30,7 @@ If you are generating a new model, use: `gen-model model-name column-name:type c
 
 ### Generating a New Migration
 
-If you are generating a new migration, use: `milmove gen migration`, which will create a placeholder migration and add it to the manifest.
+If you are generating a new migration, use: `milmove gen migration -n <migration_name>`, which will create a placeholder migration and add it to the manifest.
 
 ## Zero-Downtime Migrations
 

--- a/docs/how-to/migrate-the-database.md
+++ b/docs/how-to/migrate-the-database.md
@@ -20,7 +20,13 @@ database with environment variables.
 ## Creating a migration
 
 Use the `milmove gen <subcommand>` commands to generate models and migrations.  To see a list of available subcommands,
-use `milmove gen`.
+use `milmove gen`.  Those subcommands include:
+
+* `migration`: creates a generic migration for you to populate
+* `disable-user-migration`: creates a migration for disabling a user given their e-mail address
+* `duty-stations-migration`: creates a migration to update duty stations given a CSV of duty station data
+* `office-user-migration`: creates a migration to add office users given a CSV of new office user data
+* `orders-migration`: creates a migration to add a certificate for access to electronic orders
 
 > **We don't use down-migrations to revert changes to the schema; any problems are to be fixed by a follow-up migration.**
 

--- a/pkg/cli/migration.go
+++ b/pkg/cli/migration.go
@@ -1,9 +1,6 @@
 package cli
 
 import (
-	"fmt"
-	"os"
-	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -12,8 +9,6 @@ import (
 )
 
 const (
-	// MigrationPathFlag is the migration path flag
-	MigrationPathFlag string = "migration-path"
 	// MigrationManifestFlag is the migration manifest flag
 	MigrationManifestFlag string = "migration-manifest"
 	// MigrationWaitFlag is the migration wait flag
@@ -21,47 +16,17 @@ const (
 )
 
 var (
-	errMissingMigrationPath     = errors.New("missing migration path, expected to be set")
 	errMissingMigrationManifest = errors.New("missing migration manifest, expected to be set")
 )
 
-type errInvalidMigrationPath struct {
-	Path string
-}
-
-func (e *errInvalidMigrationPath) Error() string {
-	return fmt.Sprintf("invalid migration path %q", e.Path)
-}
-
 // InitMigrationFlags initializes the Migration command line flags
 func InitMigrationFlags(flag *pflag.FlagSet) {
-	flag.StringP(MigrationPathFlag, "p", "file:///migrations", "Path to the migrations folder")
 	flag.StringP(MigrationManifestFlag, "m", "migrations_manifest.txt", "Path to the manifest")
 	flag.DurationP(MigrationWaitFlag, "w", time.Millisecond*10, "duration to wait when polling for new data from migration file")
 }
 
 // CheckMigration validates migration command line flags
 func CheckMigration(v *viper.Viper) error {
-	migrationPath := v.GetString(MigrationPathFlag)
-	if len(migrationPath) == 0 {
-		return errMissingMigrationPath
-	}
-	for _, p := range strings.Split(migrationPath, ";") {
-		if len(p) == 0 {
-			continue
-		}
-		if strings.HasPrefix(p, "file://") {
-			filesystemPath := p[len("file://"):]
-			if _, err := os.Stat(filesystemPath); os.IsNotExist(err) {
-				return errors.Wrapf(&errInvalidMigrationPath{Path: filesystemPath}, "Expected %s to be a path in the filesystem", filesystemPath)
-			}
-		} else if !strings.HasPrefix(p, "s3://") {
-			return errors.Wrapf(&errInvalidMigrationPath{Path: p}, "Expected %s to have prefix file:// or s3://", p)
-		}
-		if strings.HasSuffix(p, "/") {
-			return errors.Wrapf(&errInvalidMigrationPath{Path: p}, "Path %s Cannot end in slash", p)
-		}
-	}
 	migrationManifest := v.GetString(MigrationManifestFlag)
 	if len(migrationManifest) == 0 {
 		return errMissingMigrationManifest

--- a/pkg/cli/migration_file.go
+++ b/pkg/cli/migration_file.go
@@ -14,7 +14,7 @@ import (
 const (
 	// MigrationVersionFlag is the migration version flag
 	MigrationVersionFlag string = "version"
-	// MigrationNameFlag is the migration path flag
+	// MigrationNameFlag is the migration name flag
 	MigrationNameFlag string = "name"
 	// MigrationTypeFlag is the migration manifest flag
 	MigrationTypeFlag string = "type"

--- a/pkg/cli/migration_file_test.go
+++ b/pkg/cli/migration_file_test.go
@@ -1,0 +1,14 @@
+package cli
+
+import (
+	"fmt"
+)
+
+func (suite *cliTestSuite) TestConfigMigrationFile() {
+	flagSet := []string{
+		fmt.Sprintf("--%s=%s", MigrationNameFlag, "test_migration"),
+	}
+
+	suite.Setup(InitMigrationFileFlags, flagSet)
+	suite.NoError(CheckMigrationFile(suite.viper))
+}

--- a/pkg/cli/migration_gen_path.go
+++ b/pkg/cli/migration_gen_path.go
@@ -1,0 +1,44 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+)
+
+const (
+	// MigrationGenPathFlag is the migration path (for generated migrations) flag
+	MigrationGenPathFlag string = "migration-gen-path"
+)
+
+var (
+	errMissingMigrationGenPath = errors.New("missing migration path, expected to be set")
+)
+
+type errInvalidMigrationGenPath struct {
+	Path string
+}
+
+func (e *errInvalidMigrationGenPath) Error() string {
+	return fmt.Sprintf("invalid migration file path %q", e.Path)
+}
+
+// InitMigrationFlags initializes the Migration command line flags
+func InitMigrationGenPathFlags(flag *pflag.FlagSet) {
+	flag.StringP(MigrationGenPathFlag, "p", "./migrations", "Path to the migrations folder")
+}
+
+// CheckMigration validates migration command line flags
+func CheckMigrationGenPath(v *viper.Viper) error {
+	migrationGenPath := v.GetString(MigrationGenPathFlag)
+	if len(migrationGenPath) == 0 {
+		return errMissingMigrationGenPath
+	}
+	if _, err := os.Stat(migrationGenPath); os.IsNotExist(err) {
+		return errors.Wrapf(&errInvalidMigrationGenPath{Path: migrationGenPath}, "Expected %s to be a path in the filesystem", migrationGenPath)
+	}
+	return nil
+}

--- a/pkg/cli/migration_gen_path.go
+++ b/pkg/cli/migration_gen_path.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	// MigrationGenPathFlag is the migration path (for generated migrations) flag
+	// MigrationGenPathFlag is the migration path flag used for generating new migrations
 	MigrationGenPathFlag string = "migration-gen-path"
 )
 

--- a/pkg/cli/migration_gen_path_test.go
+++ b/pkg/cli/migration_gen_path_test.go
@@ -1,0 +1,14 @@
+package cli
+
+import (
+	"fmt"
+)
+
+func (suite *cliTestSuite) TestConfigMigrationGenPath() {
+	flagSet := []string{
+		fmt.Sprintf("--%s=%s", MigrationGenPathFlag, "../../migrations"),
+	}
+
+	suite.Setup(InitMigrationGenPathFlags, flagSet)
+	suite.NoError(CheckMigrationGenPath(suite.viper))
+}

--- a/pkg/cli/migration_path.go
+++ b/pkg/cli/migration_path.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	// MigrationPathFlag is the migration path flag
+	// MigrationPathFlag is the migration path flag used for finding files to migrate the DB
 	MigrationPathFlag string = "migration-path"
 )
 

--- a/pkg/cli/migration_path.go
+++ b/pkg/cli/migration_path.go
@@ -1,0 +1,58 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+)
+
+const (
+	// MigrationPathFlag is the migration path flag
+	MigrationPathFlag string = "migration-path"
+)
+
+var (
+	errMissingMigrationPath = errors.New("missing migration path, expected to be set")
+)
+
+type errInvalidMigrationPath struct {
+	Path string
+}
+
+func (e *errInvalidMigrationPath) Error() string {
+	return fmt.Sprintf("invalid migration path %q", e.Path)
+}
+
+// InitMigrationFlags initializes the Migration command line flags
+func InitMigrationPathFlags(flag *pflag.FlagSet) {
+	flag.StringP(MigrationPathFlag, "p", "file:///migrations", "Path to the migrations folder")
+}
+
+// CheckMigration validates migration command line flags
+func CheckMigrationPath(v *viper.Viper) error {
+	migrationPath := v.GetString(MigrationPathFlag)
+	if len(migrationPath) == 0 {
+		return errMissingMigrationPath
+	}
+	for _, p := range strings.Split(migrationPath, ";") {
+		if len(p) == 0 {
+			continue
+		}
+		if strings.HasPrefix(p, "file://") {
+			filesystemPath := p[len("file://"):]
+			if _, err := os.Stat(filesystemPath); os.IsNotExist(err) {
+				return errors.Wrapf(&errInvalidMigrationPath{Path: filesystemPath}, "Expected %s to be a path in the filesystem", filesystemPath)
+			}
+		} else if !strings.HasPrefix(p, "s3://") {
+			return errors.Wrapf(&errInvalidMigrationPath{Path: p}, "Expected %s to have prefix file:// or s3://", p)
+		}
+		if strings.HasSuffix(p, "/") {
+			return errors.Wrapf(&errInvalidMigrationPath{Path: p}, "Path %s Cannot end in slash", p)
+		}
+	}
+	return nil
+}

--- a/pkg/cli/migration_path_test.go
+++ b/pkg/cli/migration_path_test.go
@@ -1,0 +1,6 @@
+package cli
+
+func (suite *cliTestSuite) TestConfigMigrationPath() {
+	suite.Setup(InitMigrationPathFlags, []string{})
+	suite.NoError(CheckMigrationPath(suite.viper))
+}


### PR DESCRIPTION
## Description

This PR attempts to fix some issues with paths in some `milmove gen` commands such as `milmove gen migration`.  The command was failing because of a bad path that was being read in from the `.envrc` file via a flag.  So, per @chrisgilmerproj's suggestion, I have broken out the path-related flags to a separate file and init them only on the appropriate commands.  I have also made some small updates to the docs to clarify how the command should be used.

For more background on the issue, see this [slack thread](https://defensedigitalservice.slack.com/archives/G8P7UD05U/p1568228803145400).

## Setup

Any of the following commands should now work as expected (each should prompt you for any required parameters).
- `milmove migrate`
- `milmove gen disable-user-migration`
- `milmove gen duty-stations-migration`
- `milmove gen migration`
- `milmove gen office-user-migration`
- `milmove gen orders-migration`

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/tree/master/docs/backend.md#logging)
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/168456543) for this change
* [Slack thread](https://defensedigitalservice.slack.com/archives/G8P7UD05U/p1568228803145400) about the problem being experienced.
