### PR TITLE
Add copy to Payment Requested Step: 168153437

### DIFF
--- a/src/scenes/Landing/MoveSummary.jsx
+++ b/src/scenes/Landing/MoveSummary.jsx
@@ -226,6 +226,14 @@ const NewApprovedMoveSummaryComponent = ({
                     </div>
                   ) : (
                     <div className="step">
+                      <div className="title">What's next?</div>
+                      <div>
+                        We'll email you a link so you can see and download your final payment paperwork.
+                        <br />
+                        <br />
+                        We've also sent your paperwork to Finance. They'll review it, determine a final amount, then
+                        send your payment.
+                      </div>
                       <Link
                         data-cy="edit-payment-request"
                         to={ppmPaymentRequestReviewRoute}


### PR DESCRIPTION
## Description

Add `What's next` Copy to the home screen for moves in thet Payment Requested state. 

## Setup

`make server_run`
`make client_run`
login to the service member app a user that has a payment requested: 
`ppm@paymentrequest.ed` and/or `ppmpayment@request.ed`

Ensure copy is correct

## Code Review Verification Steps
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/168153437) for this change

## Screenshots

<img width="1057" alt="Screen Shot 2019-09-12 at 2 11 26 PM" src="https://user-images.githubusercontent.com/3099491/64814831-d72f6280-d569-11e9-8d20-873d1353c7fd.png">
