### PR TITLE
Add tags to generated files

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -829,33 +829,33 @@ workflows:
             - build_migrations
             - acceptance_tests_local
           # if testing on experimental, you can disable these tests by using the commented block below.
-          # filters:
-          #   branches:
-          #     ignore: placeholder_branch_name
+          filters:
+            branches:
+              ignore: mk-168515072-add-clean-tags-metdata
 
       - client_test:
           requires:
             - pre_deps_yarn
           # if testing on experimental, you can disable these tests by using the commented block below.
-          # filters:
-          #   branches:
-          #     ignore: placeholder_branch_name
+          filters:
+            branches:
+              ignore: mk-168515072-add-clean-tags-metdata
 
       - server_test:
           requires:
             - pre_deps_golang
           # if testing on experimental, you can disable these tests by using the commented block below.
-          # filters:
-          #   branches:
-          #     ignore: placeholder_branch_name
+          filters:
+            branches:
+              ignore: mk-168515072-add-clean-tags-metdata
 
       - server_test_coverage:
           requires:
             - pre_deps_golang
           # if testing on experimental, you can disable these tests by using the commented block below.
-          # filters:
-          #   branches:
-          #     ignore: placeholder_branch_name
+          filters:
+            branches:
+              ignore: mk-168515072-add-clean-tags-metdata
 
       - build_app:
           requires:
@@ -891,28 +891,28 @@ workflows:
             - build_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: mk-168515072-add-clean-tags-metdata
 
       - deploy_experimental_tasks:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: mk-168515072-add-clean-tags-metdata
 
       - deploy_experimental_app:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: mk-168515072-add-clean-tags-metdata
 
       - deploy_experimental_app_client_tls:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: mk-168515072-add-clean-tags-metdata
 
       - check_circle_against_staging_sha:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -829,33 +829,33 @@ workflows:
             - build_migrations
             - acceptance_tests_local
           # if testing on experimental, you can disable these tests by using the commented block below.
-          filters:
-            branches:
-              ignore: mk-168515072-add-clean-tags-metdata
+          # filters:
+          #   branches:
+          #     ignore: placeholder_branch_name
 
       - client_test:
           requires:
             - pre_deps_yarn
           # if testing on experimental, you can disable these tests by using the commented block below.
-          filters:
-            branches:
-              ignore: mk-168515072-add-clean-tags-metdata
+          # filters:
+          #   branches:
+          #     ignore: placeholder_branch_name
 
       - server_test:
           requires:
             - pre_deps_golang
           # if testing on experimental, you can disable these tests by using the commented block below.
-          filters:
-            branches:
-              ignore: mk-168515072-add-clean-tags-metdata
+          # filters:
+          #   branches:
+          #     ignore: placeholder_branch_name
 
       - server_test_coverage:
           requires:
             - pre_deps_golang
           # if testing on experimental, you can disable these tests by using the commented block below.
-          filters:
-            branches:
-              ignore: mk-168515072-add-clean-tags-metdata
+          # filters:
+          #   branches:
+          #     ignore: placeholder_branch_name
 
       - build_app:
           requires:
@@ -891,28 +891,28 @@ workflows:
             - build_migrations
           filters:
             branches:
-              only: mk-168515072-add-clean-tags-metdata
+              only: placeholder_branch_name
 
       - deploy_experimental_tasks:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: mk-168515072-add-clean-tags-metdata
+              only: placeholder_branch_name
 
       - deploy_experimental_app:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: mk-168515072-add-clean-tags-metdata
+              only: placeholder_branch_name
 
       - deploy_experimental_app_client_tls:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: mk-168515072-add-clean-tags-metdata
+              only: placeholder_branch_name
 
       - check_circle_against_staging_sha:
           requires:

--- a/go.mod
+++ b/go.mod
@@ -80,7 +80,7 @@ require (
 	golang.org/x/net v0.0.0-20190724013045-ca1201d0de80
 	golang.org/x/sys v0.0.0-20190804053845-51ab0e2deafa // indirect
 	golang.org/x/text v0.3.2
-	golang.org/x/tools v0.0.0-20190807223507-b346f7fd45de
+	golang.org/x/tools v0.0.0-20190807223507-b346f7fd45de // indirect
 	gopkg.in/alexcesaro/quotedprintable.v3 v3.0.0-20150716171945-2caba252f4dc // indirect
 	gopkg.in/go-playground/assert.v1 v1.2.1 // indirect
 	gopkg.in/go-playground/validator.v9 v9.29.1

--- a/pkg/handlers/internalapi/personally_procured_move_attachments.go
+++ b/pkg/handlers/internalapi/personally_procured_move_attachments.go
@@ -17,10 +17,7 @@ type CreatePersonallyProcuredMoveAttachmentsHandler struct {
 	handlers.HandlerContext
 }
 
-var generatedObjectMetaData = map[string]*string{
-	"av-status": handlers.FmtString("CLEANED"),
-	"av-notes":  handlers.FmtString("GENERATED"),
-}
+var generatedObjectTags = handlers.FmtString("av-status=CLEANED&av-notes=GENERATED")
 
 // Handle is the handler
 func (h CreatePersonallyProcuredMoveAttachmentsHandler) Handle(params ppmop.CreatePPMAttachmentsParams) middleware.Responder {
@@ -81,7 +78,7 @@ func (h CreatePersonallyProcuredMoveAttachmentsHandler) Handle(params ppmop.Crea
 	}
 
 	// Upload merged PDF to S3 and return Upload object
-	file := uploader.File{File: mergedPdf, MetaData: generatedObjectMetaData}
+	file := uploader.File{File: mergedPdf, Tags: generatedObjectTags}
 	pdfUpload, verrs, err := loader.CreateUpload(session.UserID, file, uploader.AllowedTypesPDF)
 	if verrs.HasAny() || err != nil {
 		switch err.(type) {

--- a/pkg/handlers/internalapi/personally_procured_move_attachments.go
+++ b/pkg/handlers/internalapi/personally_procured_move_attachments.go
@@ -17,8 +17,6 @@ type CreatePersonallyProcuredMoveAttachmentsHandler struct {
 	handlers.HandlerContext
 }
 
-var generatedObjectTags = handlers.FmtString("av-status=CLEAN&av-notes=GENERATED")
-
 // Handle is the handler
 func (h CreatePersonallyProcuredMoveAttachmentsHandler) Handle(params ppmop.CreatePPMAttachmentsParams) middleware.Responder {
 	session, logger := h.SessionAndLoggerFromRequest(params.HTTPRequest)
@@ -78,6 +76,7 @@ func (h CreatePersonallyProcuredMoveAttachmentsHandler) Handle(params ppmop.Crea
 	}
 
 	// Upload merged PDF to S3 and return Upload object
+	generatedObjectTags := handlers.FmtString("av-status=CLEAN&av-notes=GENERATED")
 	file := uploader.File{File: mergedPdf, Tags: generatedObjectTags}
 	pdfUpload, verrs, err := loader.CreateUpload(session.UserID, file, uploader.AllowedTypesPDF)
 	if verrs.HasAny() || err != nil {

--- a/pkg/handlers/internalapi/personally_procured_move_attachments.go
+++ b/pkg/handlers/internalapi/personally_procured_move_attachments.go
@@ -85,8 +85,8 @@ func (h CreatePersonallyProcuredMoveAttachmentsHandler) Handle(params ppmop.Crea
 	}
 
 	// Upload merged PDF to S3 and return Upload object
-	metaData := newGeneratedObjectMetaData()
-	pdfUpload, verrs, err := loader.CreateUpload(session.UserID, &mergedPdf, uploader.AllowedTypesPDF, metaData)
+	file := uploader.File{File: mergedPdf, MetaData: newGeneratedObjectMetaData()}
+	pdfUpload, verrs, err := loader.CreateUpload(session.UserID, file, uploader.AllowedTypesPDF)
 	if verrs.HasAny() || err != nil {
 		switch err.(type) {
 		case uploader.ErrTooLarge:

--- a/pkg/handlers/internalapi/personally_procured_move_attachments.go
+++ b/pkg/handlers/internalapi/personally_procured_move_attachments.go
@@ -17,13 +17,9 @@ type CreatePersonallyProcuredMoveAttachmentsHandler struct {
 	handlers.HandlerContext
 }
 
-func newGeneratedObjectMetaData() map[string]*string {
-	metaData := make(map[string]*string)
-	avStatus := "CLEANED"
-	metaData["av-status"] = &avStatus
-	avNotes := "GENERATED"
-	metaData["av-notes"] = &avNotes
-	return metaData
+var generatedObjectMetaData = map[string]*string{
+	"av-status": handlers.FmtString("CLEANED"),
+	"av-notes":  handlers.FmtString("GENERATED"),
 }
 
 // Handle is the handler
@@ -85,7 +81,7 @@ func (h CreatePersonallyProcuredMoveAttachmentsHandler) Handle(params ppmop.Crea
 	}
 
 	// Upload merged PDF to S3 and return Upload object
-	file := uploader.File{File: mergedPdf, MetaData: newGeneratedObjectMetaData()}
+	file := uploader.File{File: mergedPdf, MetaData: generatedObjectMetaData}
 	pdfUpload, verrs, err := loader.CreateUpload(session.UserID, file, uploader.AllowedTypesPDF)
 	if verrs.HasAny() || err != nil {
 		switch err.(type) {

--- a/pkg/handlers/internalapi/personally_procured_move_attachments.go
+++ b/pkg/handlers/internalapi/personally_procured_move_attachments.go
@@ -17,6 +17,15 @@ type CreatePersonallyProcuredMoveAttachmentsHandler struct {
 	handlers.HandlerContext
 }
 
+func newGeneratedObjectMetaData() map[string]*string {
+	metaData := make(map[string]*string)
+	avStatus := "CLEANED"
+	metaData["av-status"] = &avStatus
+	avNotes := "GENERATED"
+	metaData["av-notes"] = &avNotes
+	return metaData
+}
+
 // Handle is the handler
 func (h CreatePersonallyProcuredMoveAttachmentsHandler) Handle(params ppmop.CreatePPMAttachmentsParams) middleware.Responder {
 	session, logger := h.SessionAndLoggerFromRequest(params.HTTPRequest)
@@ -76,7 +85,8 @@ func (h CreatePersonallyProcuredMoveAttachmentsHandler) Handle(params ppmop.Crea
 	}
 
 	// Upload merged PDF to S3 and return Upload object
-	pdfUpload, verrs, err := loader.CreateUpload(session.UserID, &mergedPdf, uploader.AllowedTypesPDF)
+	metaData := newGeneratedObjectMetaData()
+	pdfUpload, verrs, err := loader.CreateUpload(session.UserID, &mergedPdf, uploader.AllowedTypesPDF, metaData)
 	if verrs.HasAny() || err != nil {
 		switch err.(type) {
 		case uploader.ErrTooLarge:

--- a/pkg/handlers/internalapi/personally_procured_move_attachments.go
+++ b/pkg/handlers/internalapi/personally_procured_move_attachments.go
@@ -75,9 +75,10 @@ func (h CreatePersonallyProcuredMoveAttachmentsHandler) Handle(params ppmop.Crea
 		return ppmop.NewCreatePPMAttachmentsUnprocessableEntity()
 	}
 
-	// Upload merged PDF to S3 and return Upload object
+	// Add relevant av-.* tags for generated objects (for s3)
 	generatedObjectTags := handlers.FmtString("av-status=CLEAN&av-notes=GENERATED")
 	file := uploader.File{File: mergedPdf, Tags: generatedObjectTags}
+	// Upload merged PDF to S3 and return Upload object
 	pdfUpload, verrs, err := loader.CreateUpload(session.UserID, file, uploader.AllowedTypesPDF)
 	if verrs.HasAny() || err != nil {
 		switch err.(type) {

--- a/pkg/handlers/internalapi/personally_procured_move_attachments.go
+++ b/pkg/handlers/internalapi/personally_procured_move_attachments.go
@@ -17,7 +17,7 @@ type CreatePersonallyProcuredMoveAttachmentsHandler struct {
 	handlers.HandlerContext
 }
 
-var generatedObjectTags = handlers.FmtString("av-status=CLEANED&av-notes=GENERATED")
+var generatedObjectTags = handlers.FmtString("av-status=CLEAN&av-notes=GENERATED")
 
 // Handle is the handler
 func (h CreatePersonallyProcuredMoveAttachmentsHandler) Handle(params ppmop.CreatePPMAttachmentsParams) middleware.Responder {

--- a/pkg/handlers/internalapi/personally_procured_move_attachments_test.go
+++ b/pkg/handlers/internalapi/personally_procured_move_attachments_test.go
@@ -78,13 +78,13 @@ func (suite *HandlerSuite) TestCreatePPMAttachmentsHandlerTests() {
 			suite.NoError(err)
 			// Backfill the uploaded orders file in filesystem
 			uploadedOrdersUpload := ppm.Move.Orders.UploadedOrders.Uploads[0]
-			_, err = context.FileStorer().Store(uploadedOrdersUpload.StorageKey, f, uploadedOrdersUpload.Checksum)
+			_, err = context.FileStorer().Store(uploadedOrdersUpload.StorageKey, f, uploadedOrdersUpload.Checksum, nil)
 			suite.NoError(err)
 
 			// Create upload for expense document model
 			loader, err := uploader.NewUploader(suite.DB(), suite.TestLogger(), context.FileStorer(), 100*uploader.MB)
 			suite.NoError(err)
-			loader.CreateUploadForDocument(&expDoc.MoveDocument.DocumentID, *officeUser.UserID, f, uploader.AllowedTypesServiceMember)
+			loader.CreateUploadForDocument(&expDoc.MoveDocument.DocumentID, *officeUser.UserID, f, uploader.AllowedTypesServiceMember, nil)
 
 			request := httptest.NewRequest("POST", "/fake/path", nil)
 			request = suite.AuthenticateOfficeRequest(request, officeUser)

--- a/pkg/handlers/internalapi/personally_procured_move_attachments_test.go
+++ b/pkg/handlers/internalapi/personally_procured_move_attachments_test.go
@@ -84,7 +84,7 @@ func (suite *HandlerSuite) TestCreatePPMAttachmentsHandlerTests() {
 			// Create upload for expense document model
 			loader, err := uploader.NewUploader(suite.DB(), suite.TestLogger(), context.FileStorer(), 100*uploader.MB)
 			suite.NoError(err)
-			loader.CreateUploadForDocument(&expDoc.MoveDocument.DocumentID, *officeUser.UserID, f, uploader.AllowedTypesServiceMember, nil)
+			loader.CreateUploadForDocument(&expDoc.MoveDocument.DocumentID, *officeUser.UserID, uploader.File{File: f}, uploader.AllowedTypesServiceMember)
 
 			request := httptest.NewRequest("POST", "/fake/path", nil)
 			request = suite.AuthenticateOfficeRequest(request, officeUser)

--- a/pkg/handlers/internalapi/uploads.go
+++ b/pkg/handlers/internalapi/uploads.go
@@ -85,7 +85,7 @@ func (h CreateUploadHandler) Handle(params uploadop.CreateUploadParams) middlewa
 	if err != nil {
 		logger.Fatal("could not instantiate uploader", zap.Error(err))
 	}
-	newUpload, verrs, err := uploader.CreateUploadForDocument(docID, session.UserID, aFile, uploaderpkg.AllowedTypesServiceMember)
+	newUpload, verrs, err := uploader.CreateUploadForDocument(docID, session.UserID, aFile, uploaderpkg.AllowedTypesServiceMember, nil)
 	if verrs.HasAny() || err != nil {
 		switch err.(type) {
 		case uploaderpkg.ErrTooLarge:

--- a/pkg/handlers/internalapi/uploads.go
+++ b/pkg/handlers/internalapi/uploads.go
@@ -85,7 +85,7 @@ func (h CreateUploadHandler) Handle(params uploadop.CreateUploadParams) middlewa
 	if err != nil {
 		logger.Fatal("could not instantiate uploader", zap.Error(err))
 	}
-	newUpload, verrs, err := uploader.CreateUploadForDocument(docID, session.UserID, aFile, uploaderpkg.AllowedTypesServiceMember, nil)
+	newUpload, verrs, err := uploader.CreateUploadForDocument(docID, session.UserID, uploaderpkg.File{File: aFile}, uploaderpkg.AllowedTypesServiceMember)
 	if verrs.HasAny() || err != nil {
 		switch err.(type) {
 		case uploaderpkg.ErrTooLarge:

--- a/pkg/handlers/internalapi/uploads_test.go
+++ b/pkg/handlers/internalapi/uploads_test.go
@@ -161,7 +161,7 @@ func (suite *HandlerSuite) TestDeleteUploadHandlerSuccess() {
 	suite.Nil(upload.DeletedAt)
 
 	file := suite.Fixture("test.pdf")
-	fakeS3.Store(upload.StorageKey, file.Data, "somehash", nil, nil)
+	fakeS3.Store(upload.StorageKey, file.Data, "somehash", nil)
 
 	params := uploadop.NewDeleteUploadParams()
 	params.UploadID = strfmt.UUID(upload.ID.String())
@@ -199,8 +199,8 @@ func (suite *HandlerSuite) TestDeleteUploadsHandlerSuccess() {
 	upload2 := testdatagen.MakeUpload(suite.DB(), upload2Assertions)
 
 	file := suite.Fixture("test.pdf")
-	fakeS3.Store(upload1.StorageKey, file.Data, "somehash", nil, nil)
-	fakeS3.Store(upload2.StorageKey, file.Data, "somehash", nil, nil)
+	fakeS3.Store(upload1.StorageKey, file.Data, "somehash", nil)
+	fakeS3.Store(upload2.StorageKey, file.Data, "somehash", nil)
 
 	params := uploadop.NewDeleteUploadsParams()
 	params.UploadIds = []strfmt.UUID{

--- a/pkg/handlers/internalapi/uploads_test.go
+++ b/pkg/handlers/internalapi/uploads_test.go
@@ -161,7 +161,7 @@ func (suite *HandlerSuite) TestDeleteUploadHandlerSuccess() {
 	suite.Nil(upload.DeletedAt)
 
 	file := suite.Fixture("test.pdf")
-	fakeS3.Store(upload.StorageKey, file.Data, "somehash", nil)
+	fakeS3.Store(upload.StorageKey, file.Data, "somehash", nil, nil)
 
 	params := uploadop.NewDeleteUploadParams()
 	params.UploadID = strfmt.UUID(upload.ID.String())
@@ -199,8 +199,8 @@ func (suite *HandlerSuite) TestDeleteUploadsHandlerSuccess() {
 	upload2 := testdatagen.MakeUpload(suite.DB(), upload2Assertions)
 
 	file := suite.Fixture("test.pdf")
-	fakeS3.Store(upload1.StorageKey, file.Data, "somehash", nil)
-	fakeS3.Store(upload2.StorageKey, file.Data, "somehash", nil)
+	fakeS3.Store(upload1.StorageKey, file.Data, "somehash", nil, nil)
+	fakeS3.Store(upload2.StorageKey, file.Data, "somehash", nil, nil)
 
 	params := uploadop.NewDeleteUploadsParams()
 	params.UploadIds = []strfmt.UUID{

--- a/pkg/handlers/internalapi/uploads_test.go
+++ b/pkg/handlers/internalapi/uploads_test.go
@@ -161,7 +161,7 @@ func (suite *HandlerSuite) TestDeleteUploadHandlerSuccess() {
 	suite.Nil(upload.DeletedAt)
 
 	file := suite.Fixture("test.pdf")
-	fakeS3.Store(upload.StorageKey, file.Data, "somehash")
+	fakeS3.Store(upload.StorageKey, file.Data, "somehash", nil)
 
 	params := uploadop.NewDeleteUploadParams()
 	params.UploadID = strfmt.UUID(upload.ID.String())
@@ -199,8 +199,8 @@ func (suite *HandlerSuite) TestDeleteUploadsHandlerSuccess() {
 	upload2 := testdatagen.MakeUpload(suite.DB(), upload2Assertions)
 
 	file := suite.Fixture("test.pdf")
-	fakeS3.Store(upload1.StorageKey, file.Data, "somehash")
-	fakeS3.Store(upload2.StorageKey, file.Data, "somehash")
+	fakeS3.Store(upload1.StorageKey, file.Data, "somehash", nil)
+	fakeS3.Store(upload2.StorageKey, file.Data, "somehash", nil)
 
 	params := uploadop.NewDeleteUploadsParams()
 	params.UploadIds = []strfmt.UUID{

--- a/pkg/paperwork/generator_test.go
+++ b/pkg/paperwork/generator_test.go
@@ -50,19 +50,19 @@ func (suite *PaperworkSuite) setupOrdersDocument() (*Generator, models.Order) {
 	file, err := suite.openLocalFile("testdata/orders1.jpg", generator.fs)
 	suite.FatalNil(err)
 
-	_, _, err = suite.uploader.CreateUploadForDocument(&document.ID, document.ServiceMember.UserID, file, uploader.AllowedTypesAny)
+	_, _, err = suite.uploader.CreateUploadForDocument(&document.ID, document.ServiceMember.UserID, file, uploader.AllowedTypesAny, nil)
 	suite.FatalNil(err)
 
 	file, err = suite.openLocalFile("testdata/orders1.pdf", generator.fs)
 	suite.FatalNil(err)
 
-	_, _, err = suite.uploader.CreateUploadForDocument(&document.ID, document.ServiceMember.UserID, file, uploader.AllowedTypesAny)
+	_, _, err = suite.uploader.CreateUploadForDocument(&document.ID, document.ServiceMember.UserID, file, uploader.AllowedTypesAny, nil)
 	suite.FatalNil(err)
 
 	file, err = suite.openLocalFile("testdata/orders2.jpg", generator.fs)
 	suite.FatalNil(err)
 
-	_, _, err = suite.uploader.CreateUploadForDocument(&document.ID, document.ServiceMember.UserID, file, uploader.AllowedTypesAny)
+	_, _, err = suite.uploader.CreateUploadForDocument(&document.ID, document.ServiceMember.UserID, file, uploader.AllowedTypesAny, nil)
 	suite.FatalNil(err)
 
 	err = suite.DB().Load(&document, "Uploads")

--- a/pkg/paperwork/generator_test.go
+++ b/pkg/paperwork/generator_test.go
@@ -50,19 +50,19 @@ func (suite *PaperworkSuite) setupOrdersDocument() (*Generator, models.Order) {
 	file, err := suite.openLocalFile("testdata/orders1.jpg", generator.fs)
 	suite.FatalNil(err)
 
-	_, _, err = suite.uploader.CreateUploadForDocument(&document.ID, document.ServiceMember.UserID, file, uploader.AllowedTypesAny, nil)
+	_, _, err = suite.uploader.CreateUploadForDocument(&document.ID, document.ServiceMember.UserID, uploader.File{File: file}, uploader.AllowedTypesAny)
 	suite.FatalNil(err)
 
 	file, err = suite.openLocalFile("testdata/orders1.pdf", generator.fs)
 	suite.FatalNil(err)
 
-	_, _, err = suite.uploader.CreateUploadForDocument(&document.ID, document.ServiceMember.UserID, file, uploader.AllowedTypesAny, nil)
+	_, _, err = suite.uploader.CreateUploadForDocument(&document.ID, document.ServiceMember.UserID, uploader.File{File: file}, uploader.AllowedTypesAny)
 	suite.FatalNil(err)
 
 	file, err = suite.openLocalFile("testdata/orders2.jpg", generator.fs)
 	suite.FatalNil(err)
 
-	_, _, err = suite.uploader.CreateUploadForDocument(&document.ID, document.ServiceMember.UserID, file, uploader.AllowedTypesAny, nil)
+	_, _, err = suite.uploader.CreateUploadForDocument(&document.ID, document.ServiceMember.UserID, uploader.File{File: file}, uploader.AllowedTypesAny)
 	suite.FatalNil(err)
 
 	err = suite.DB().Load(&document, "Uploads")

--- a/pkg/services/invoice/store_invoice.go
+++ b/pkg/services/invoice/store_invoice.go
@@ -75,7 +75,7 @@ func (s StoreInvoice858C) Call(edi string, invoice *models.Invoice, userID uuid.
 	}
 
 	// Create and save Upload to s3
-	upload, verrs2, err := loader.CreateUpload(userID, &f, uploader.AllowedTypesText, nil)
+	upload, verrs2, err := loader.CreateUpload(userID, uploader.File{File: f}, uploader.AllowedTypesText)
 	verrs.Append(verrs2)
 	if err != nil {
 		return verrs, errors.Wrapf(err, "Failed to Create Upload for StoreInvoice858C(), invoice ID: %s", invoiceID)

--- a/pkg/services/invoice/store_invoice.go
+++ b/pkg/services/invoice/store_invoice.go
@@ -75,7 +75,7 @@ func (s StoreInvoice858C) Call(edi string, invoice *models.Invoice, userID uuid.
 	}
 
 	// Create and save Upload to s3
-	upload, verrs2, err := loader.CreateUpload(userID, &f, uploader.AllowedTypesText)
+	upload, verrs2, err := loader.CreateUpload(userID, &f, uploader.AllowedTypesText, nil)
 	verrs.Append(verrs2)
 	if err != nil {
 		return verrs, errors.Wrapf(err, "Failed to Create Upload for StoreInvoice858C(), invoice ID: %s", invoiceID)

--- a/pkg/services/invoice/update_invoice_upload_test.go
+++ b/pkg/services/invoice/update_invoice_upload_test.go
@@ -78,7 +78,7 @@ func (suite *InvoiceServiceSuite) helperCreateUpload(storer *storage.FileStorer)
 	}
 
 	// Create Upload and save it
-	upload, verrs, err := up.CreateUpload(userID, &file, uploader.AllowedTypesPDF, nil)
+	upload, verrs, err := up.CreateUpload(userID, uploader.File{File: file}, uploader.AllowedTypesPDF)
 	suite.Nil(err, "CreateUpload() failed to create upload")
 	suite.Empty(verrs.Error(), "CreateUpload() verrs returned error")
 	suite.NotNil(upload, "CreateUpload() failed to create upload structure")

--- a/pkg/services/invoice/update_invoice_upload_test.go
+++ b/pkg/services/invoice/update_invoice_upload_test.go
@@ -78,7 +78,7 @@ func (suite *InvoiceServiceSuite) helperCreateUpload(storer *storage.FileStorer)
 	}
 
 	// Create Upload and save it
-	upload, verrs, err := up.CreateUpload(userID, &file, uploader.AllowedTypesPDF)
+	upload, verrs, err := up.CreateUpload(userID, &file, uploader.AllowedTypesPDF, nil)
 	suite.Nil(err, "CreateUpload() failed to create upload")
 	suite.Empty(verrs.Error(), "CreateUpload() verrs returned error")
 	suite.NotNil(upload, "CreateUpload() failed to create upload structure")

--- a/pkg/storage/filesystem.go
+++ b/pkg/storage/filesystem.go
@@ -61,7 +61,7 @@ func NewFilesystem(params FilesystemParams) *Filesystem {
 }
 
 // Store stores the content from an io.ReadSeeker at the specified key.
-func (fs *Filesystem) Store(key string, data io.ReadSeeker, checksum string) (*StoreResult, error) {
+func (fs *Filesystem) Store(key string, data io.ReadSeeker, checksum string, strings map[string]*string) (*StoreResult, error) {
 	if key == "" {
 		return nil, errors.New("A valid StorageKey must be set before data can be uploaded")
 	}

--- a/pkg/storage/filesystem.go
+++ b/pkg/storage/filesystem.go
@@ -61,7 +61,7 @@ func NewFilesystem(params FilesystemParams) *Filesystem {
 }
 
 // Store stores the content from an io.ReadSeeker at the specified key.
-func (fs *Filesystem) Store(key string, data io.ReadSeeker, checksum string, strings map[string]*string) (*StoreResult, error) {
+func (fs *Filesystem) Store(key string, data io.ReadSeeker, checksum string, strings *string) (*StoreResult, error) {
 	if key == "" {
 		return nil, errors.New("A valid StorageKey must be set before data can be uploaded")
 	}

--- a/pkg/storage/filesystem.go
+++ b/pkg/storage/filesystem.go
@@ -61,7 +61,7 @@ func NewFilesystem(params FilesystemParams) *Filesystem {
 }
 
 // Store stores the content from an io.ReadSeeker at the specified key.
-func (fs *Filesystem) Store(key string, data io.ReadSeeker, checksum string, strings *string) (*StoreResult, error) {
+func (fs *Filesystem) Store(key string, data io.ReadSeeker, checksum string, tags *string) (*StoreResult, error) {
 	if key == "" {
 		return nil, errors.New("A valid StorageKey must be set before data can be uploaded")
 	}

--- a/pkg/storage/memory.go
+++ b/pkg/storage/memory.go
@@ -61,7 +61,7 @@ func NewMemory(params MemoryParams) *Memory {
 }
 
 // Store stores the content from an io.ReadSeeker at the specified key.
-func (fs *Memory) Store(key string, data io.ReadSeeker, checksum string, strings *string) (*StoreResult, error) {
+func (fs *Memory) Store(key string, data io.ReadSeeker, checksum string, tags *string) (*StoreResult, error) {
 	if key == "" {
 		return nil, errors.New("A valid StorageKey must be set before data can be uploaded")
 	}

--- a/pkg/storage/memory.go
+++ b/pkg/storage/memory.go
@@ -61,7 +61,7 @@ func NewMemory(params MemoryParams) *Memory {
 }
 
 // Store stores the content from an io.ReadSeeker at the specified key.
-func (fs *Memory) Store(key string, data io.ReadSeeker, checksum string, strings map[string]*string) (*StoreResult, error) {
+func (fs *Memory) Store(key string, data io.ReadSeeker, checksum string, strings *string) (*StoreResult, error) {
 	if key == "" {
 		return nil, errors.New("A valid StorageKey must be set before data can be uploaded")
 	}

--- a/pkg/storage/memory.go
+++ b/pkg/storage/memory.go
@@ -61,7 +61,7 @@ func NewMemory(params MemoryParams) *Memory {
 }
 
 // Store stores the content from an io.ReadSeeker at the specified key.
-func (fs *Memory) Store(key string, data io.ReadSeeker, checksum string) (*StoreResult, error) {
+func (fs *Memory) Store(key string, data io.ReadSeeker, checksum string, strings map[string]*string) (*StoreResult, error) {
 	if key == "" {
 		return nil, errors.New("A valid StorageKey must be set before data can be uploaded")
 	}

--- a/pkg/storage/s3.go
+++ b/pkg/storage/s3.go
@@ -37,7 +37,7 @@ func NewS3(bucket string, keyNamespace string, logger Logger, session *session.S
 }
 
 // Store stores the content from an io.ReadSeeker at the specified key.
-func (s *S3) Store(key string, data io.ReadSeeker, checksum string, metaData map[string]*string) (*StoreResult, error) {
+func (s *S3) Store(key string, data io.ReadSeeker, checksum string, tags *string) (*StoreResult, error) {
 	if key == "" {
 		return nil, errors.New("A valid StorageKey must be set before data can be uploaded")
 	}
@@ -50,8 +50,8 @@ func (s *S3) Store(key string, data io.ReadSeeker, checksum string, metaData map
 		Body:       data,
 		ContentMD5: &checksum,
 	}
-	if metaData != nil {
-		input.Metadata = metaData
+	if tags != nil {
+		input.Tagging = tags
 	}
 
 	if _, err := s.client.PutObject(input); err != nil {

--- a/pkg/storage/s3.go
+++ b/pkg/storage/s3.go
@@ -37,7 +37,7 @@ func NewS3(bucket string, keyNamespace string, logger Logger, session *session.S
 }
 
 // Store stores the content from an io.ReadSeeker at the specified key.
-func (s *S3) Store(key string, data io.ReadSeeker, checksum string) (*StoreResult, error) {
+func (s *S3) Store(key string, data io.ReadSeeker, checksum string, metaData map[string]*string) (*StoreResult, error) {
 	if key == "" {
 		return nil, errors.New("A valid StorageKey must be set before data can be uploaded")
 	}
@@ -49,6 +49,9 @@ func (s *S3) Store(key string, data io.ReadSeeker, checksum string) (*StoreResul
 		Key:        &namespacedKey,
 		Body:       data,
 		ContentMD5: &checksum,
+	}
+	if metaData != nil {
+		input.Metadata = metaData
 	}
 
 	if _, err := s.client.PutObject(input); err != nil {

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -27,7 +27,7 @@ type StoreResult struct{}
 // FileStorer is the set of methods needed to store and retrieve objects.
 //go:generate mockery -name FileStorer
 type FileStorer interface {
-	Store(string, io.ReadSeeker, string) (*StoreResult, error)
+	Store(string, io.ReadSeeker, string, map[string]*string) (*StoreResult, error)
 	Fetch(string) (io.ReadCloser, error)
 	Delete(string) error
 	PresignedURL(string, string) (string, error)

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -27,7 +27,7 @@ type StoreResult struct{}
 // FileStorer is the set of methods needed to store and retrieve objects.
 //go:generate mockery -name FileStorer
 type FileStorer interface {
-	Store(string, io.ReadSeeker, string, map[string]*string) (*StoreResult, error)
+	Store(string, io.ReadSeeker, string, *string) (*StoreResult, error)
 	Fetch(string) (io.ReadCloser, error)
 	Delete(string) error
 	PresignedURL(string, string) (string, error)

--- a/pkg/storage/test/s3.go
+++ b/pkg/storage/test/s3.go
@@ -28,7 +28,7 @@ func (fake *FakeS3Storage) Delete(key string) error {
 }
 
 // Store stores a file.
-func (fake *FakeS3Storage) Store(key string, data io.ReadSeeker, md5 string, strings *string) (*storage.StoreResult, error) {
+func (fake *FakeS3Storage) Store(key string, data io.ReadSeeker, md5 string, tags *string) (*storage.StoreResult, error) {
 	f, err := fake.fs.Create(key)
 	if err != nil {
 		return nil, err

--- a/pkg/storage/test/s3.go
+++ b/pkg/storage/test/s3.go
@@ -38,7 +38,6 @@ func (fake *FakeS3Storage) Store(key string, data io.ReadSeeker, md5 string, str
 	if err != nil {
 		return nil, err
 	}
-
 	if fake.willSucceed {
 		return &storage.StoreResult{}, nil
 	}

--- a/pkg/storage/test/s3.go
+++ b/pkg/storage/test/s3.go
@@ -28,7 +28,7 @@ func (fake *FakeS3Storage) Delete(key string) error {
 }
 
 // Store stores a file.
-func (fake *FakeS3Storage) Store(key string, data io.ReadSeeker, md5 string) (*storage.StoreResult, error) {
+func (fake *FakeS3Storage) Store(key string, data io.ReadSeeker, md5 string, strings map[string]*string) (*storage.StoreResult, error) {
 	f, err := fake.fs.Create(key)
 	if err != nil {
 		return nil, err

--- a/pkg/storage/test/s3.go
+++ b/pkg/storage/test/s3.go
@@ -28,7 +28,7 @@ func (fake *FakeS3Storage) Delete(key string) error {
 }
 
 // Store stores a file.
-func (fake *FakeS3Storage) Store(key string, data io.ReadSeeker, md5 string, strings map[string]*string) (*storage.StoreResult, error) {
+func (fake *FakeS3Storage) Store(key string, data io.ReadSeeker, md5 string, strings *string) (*storage.StoreResult, error) {
 	f, err := fake.fs.Create(key)
 	if err != nil {
 		return nil, err

--- a/pkg/testdatagen/make_upload.go
+++ b/pkg/testdatagen/make_upload.go
@@ -31,7 +31,7 @@ func MakeUpload(db *pop.Connection, assertions Assertions) models.Upload {
 		var verrs *validate.Errors
 		var err error
 		file := fixture("test.pdf")
-		upload, verrs, err = assertions.Uploader.CreateUploadForDocument(&document.ID, uploaderID, file, uploader.AllowedTypesServiceMember)
+		upload, verrs, err = assertions.Uploader.CreateUploadForDocument(&document.ID, uploaderID, file, uploader.AllowedTypesServiceMember, nil)
 		if verrs.HasAny() || err != nil {
 			log.Panic(fmt.Errorf("Errors encountered saving upload %v, %v", verrs, err))
 		}

--- a/pkg/testdatagen/make_upload.go
+++ b/pkg/testdatagen/make_upload.go
@@ -31,7 +31,7 @@ func MakeUpload(db *pop.Connection, assertions Assertions) models.Upload {
 		var verrs *validate.Errors
 		var err error
 		file := fixture("test.pdf")
-		upload, verrs, err = assertions.Uploader.CreateUploadForDocument(&document.ID, uploaderID, file, uploader.AllowedTypesServiceMember, nil)
+		upload, verrs, err = assertions.Uploader.CreateUploadForDocument(&document.ID, uploaderID, uploader.File{File: file}, uploader.AllowedTypesServiceMember)
 		if verrs.HasAny() || err != nil {
 			log.Panic(fmt.Errorf("Errors encountered saving upload %v, %v", verrs, err))
 		}

--- a/pkg/uploader/uploader.go
+++ b/pkg/uploader/uploader.go
@@ -149,7 +149,7 @@ func (u *Uploader) CreateUploadForDocument(documentID *uuid.UUID, userID uuid.UU
 		}
 
 		// Push file to S3
-		if _, err := u.Storer.Store(newUpload.StorageKey, file, checksum, nil); err != nil {
+		if _, err := u.Storer.Store(newUpload.StorageKey, file.File, checksum, file.MetaData); err != nil {
 			u.logger.Error("failed to store object", zap.Error(err))
 			responseVErrors.Append(verrs)
 			uploadError = errors.Wrap(err, "failed to store object")

--- a/pkg/uploader/uploader.go
+++ b/pkg/uploader/uploader.go
@@ -43,6 +43,8 @@ func (b ByteSize) Int64() int64 {
 	return int64(b)
 }
 
+// File type to be used by Uploader. A wrapper around afero.File that allows attaching
+// some additional metadata
 type File struct {
 	afero.File
 	Tags *string

--- a/pkg/uploader/uploader.go
+++ b/pkg/uploader/uploader.go
@@ -75,7 +75,7 @@ func (u *Uploader) SetUploadStorageKey(key string) {
 // CreateUploadForDocument creates a new Upload by performing validations, storing the specified
 // file using the supplied storer, and saving an Upload object to the database containing
 // the file's metadata.
-func (u *Uploader) CreateUploadForDocument(documentID *uuid.UUID, userID uuid.UUID, file afero.File, allowedTypes AllowedFileTypes) (*models.Upload, *validate.Errors, error) {
+func (u *Uploader) CreateUploadForDocument(documentID *uuid.UUID, userID uuid.UUID, file afero.File, allowedTypes AllowedFileTypes, metaData map[string]*string) (*models.Upload, *validate.Errors, error) {
 	responseVErrors := validate.NewErrors()
 
 	info, fileStatErr := file.Stat()
@@ -144,7 +144,7 @@ func (u *Uploader) CreateUploadForDocument(documentID *uuid.UUID, userID uuid.UU
 		}
 
 		// Push file to S3
-		if _, err := u.Storer.Store(newUpload.StorageKey, file, checksum); err != nil {
+		if _, err := u.Storer.Store(newUpload.StorageKey, file, checksum, metaData); err != nil {
 			u.logger.Error("failed to store object", zap.Error(err))
 			responseVErrors.Append(verrs)
 			uploadError = errors.Wrap(err, "failed to store object")
@@ -162,8 +162,8 @@ func (u *Uploader) CreateUploadForDocument(documentID *uuid.UUID, userID uuid.UU
 }
 
 // CreateUpload stores Upload but does not assign a Document
-func (u *Uploader) CreateUpload(userID uuid.UUID, aFile *afero.File, allowedFileTypes AllowedFileTypes) (*models.Upload, *validate.Errors, error) {
-	return u.CreateUploadForDocument(nil, userID, *aFile, allowedFileTypes)
+func (u *Uploader) CreateUpload(userID uuid.UUID, aFile *afero.File, allowedFileTypes AllowedFileTypes, fileMetaData map[string]*string) (*models.Upload, *validate.Errors, error) {
+	return u.CreateUploadForDocument(nil, userID, *aFile, allowedFileTypes, fileMetaData)
 }
 
 // PresignedURL returns a URL that can be used to access an Upload's file.

--- a/pkg/uploader/uploader.go
+++ b/pkg/uploader/uploader.go
@@ -45,7 +45,7 @@ func (b ByteSize) Int64() int64 {
 
 type File struct {
 	afero.File
-	MetaData map[string]*string
+	Tags *string
 }
 
 // Uploader encapsulates a few common processes: creating Uploads for a Document,
@@ -149,7 +149,7 @@ func (u *Uploader) CreateUploadForDocument(documentID *uuid.UUID, userID uuid.UU
 		}
 
 		// Push file to S3
-		if _, err := u.Storer.Store(newUpload.StorageKey, file.File, checksum, file.MetaData); err != nil {
+		if _, err := u.Storer.Store(newUpload.StorageKey, file.File, checksum, file.Tags); err != nil {
 			u.logger.Error("failed to store object", zap.Error(err))
 			responseVErrors.Append(verrs)
 			uploadError = errors.Wrap(err, "failed to store object")

--- a/pkg/uploader/uploader_test.go
+++ b/pkg/uploader/uploader_test.go
@@ -108,7 +108,7 @@ func (suite *UploaderSuite) TestUploadFromLocalFile() {
 	suite.NoError(err)
 	file := suite.fixture("test.pdf")
 
-	upload, verrs, err := up.CreateUploadForDocument(&document.ID, document.ServiceMember.UserID, file, uploader.AllowedTypesPDF, nil)
+	upload, verrs, err := up.CreateUploadForDocument(&document.ID, document.ServiceMember.UserID, uploader.File{File: file}, uploader.AllowedTypesPDF)
 	suite.Nil(err, "failed to create upload")
 	suite.False(verrs.HasAny(), "failed to validate upload", verrs)
 	suite.Equal(upload.ContentType, "application/pdf")
@@ -124,7 +124,7 @@ func (suite *UploaderSuite) TestUploadFromLocalFileZeroLength() {
 	suite.Nil(err, "failed to create upload")
 	defer cleanup()
 
-	upload, verrs, err := up.CreateUploadForDocument(&document.ID, document.ServiceMember.UserID, file, uploader.AllowedTypesAny, nil)
+	upload, verrs, err := up.CreateUploadForDocument(&document.ID, document.ServiceMember.UserID, uploader.File{File: file}, uploader.AllowedTypesAny)
 	suite.Equal(uploader.ErrZeroLengthFile, err)
 	suite.False(verrs.HasAny(), "failed to validate upload")
 	suite.Nil(upload, "returned an upload when erroring")
@@ -139,7 +139,7 @@ func (suite *UploaderSuite) TestUploadFromLocalFileWrongContentType() {
 	suite.Nil(err, "failed to create upload")
 	defer cleanup()
 
-	upload, verrs, err := up.CreateUploadForDocument(&document.ID, document.ServiceMember.UserID, file, uploader.AllowedTypesPDF, nil)
+	upload, verrs, err := up.CreateUploadForDocument(&document.ID, document.ServiceMember.UserID, uploader.File{File: file}, uploader.AllowedTypesPDF)
 	suite.NoError(err)
 	suite.True(verrs.HasAny(), "invalid content type for upload")
 	suite.Nil(upload, "returned an upload when erroring")
@@ -154,7 +154,7 @@ func (suite *UploaderSuite) TestTooLargeUploadFromLocalFile() {
 	suite.NoError(err)
 	defer cleanup()
 
-	_, verrs, err := up.CreateUploadForDocument(&document.ID, document.ServiceMember.UserID, f, uploader.AllowedTypesAny, nil)
+	_, verrs, err := up.CreateUploadForDocument(&document.ID, document.ServiceMember.UserID, uploader.File{File: f}, uploader.AllowedTypesAny)
 	suite.Error(err)
 	suite.IsType(uploader.ErrTooLarge{}, err)
 	suite.False(verrs.HasAny(), "failed to validate upload")
@@ -201,7 +201,7 @@ func (suite *UploaderSuite) TestCreateUploadNoDocument() {
 	suite.NoError(err)
 
 	// Create file and upload
-	upload, verrs, err := up.CreateUpload(userID, &file, uploader.AllowedTypesPDF, nil)
+	upload, verrs, err := up.CreateUpload(userID, uploader.File{File: file}, uploader.AllowedTypesPDF)
 	suite.Nil(err, "failed to create upload")
 	suite.Empty(verrs.Error(), "verrs returned error")
 	suite.NotNil(upload, "failed to create upload structure")

--- a/pkg/uploader/uploader_test.go
+++ b/pkg/uploader/uploader_test.go
@@ -108,7 +108,7 @@ func (suite *UploaderSuite) TestUploadFromLocalFile() {
 	suite.NoError(err)
 	file := suite.fixture("test.pdf")
 
-	upload, verrs, err := up.CreateUploadForDocument(&document.ID, document.ServiceMember.UserID, file, uploader.AllowedTypesPDF)
+	upload, verrs, err := up.CreateUploadForDocument(&document.ID, document.ServiceMember.UserID, file, uploader.AllowedTypesPDF, nil)
 	suite.Nil(err, "failed to create upload")
 	suite.False(verrs.HasAny(), "failed to validate upload", verrs)
 	suite.Equal(upload.ContentType, "application/pdf")
@@ -124,7 +124,7 @@ func (suite *UploaderSuite) TestUploadFromLocalFileZeroLength() {
 	suite.Nil(err, "failed to create upload")
 	defer cleanup()
 
-	upload, verrs, err := up.CreateUploadForDocument(&document.ID, document.ServiceMember.UserID, file, uploader.AllowedTypesAny)
+	upload, verrs, err := up.CreateUploadForDocument(&document.ID, document.ServiceMember.UserID, file, uploader.AllowedTypesAny, nil)
 	suite.Equal(uploader.ErrZeroLengthFile, err)
 	suite.False(verrs.HasAny(), "failed to validate upload")
 	suite.Nil(upload, "returned an upload when erroring")
@@ -139,7 +139,7 @@ func (suite *UploaderSuite) TestUploadFromLocalFileWrongContentType() {
 	suite.Nil(err, "failed to create upload")
 	defer cleanup()
 
-	upload, verrs, err := up.CreateUploadForDocument(&document.ID, document.ServiceMember.UserID, file, uploader.AllowedTypesPDF)
+	upload, verrs, err := up.CreateUploadForDocument(&document.ID, document.ServiceMember.UserID, file, uploader.AllowedTypesPDF, nil)
 	suite.NoError(err)
 	suite.True(verrs.HasAny(), "invalid content type for upload")
 	suite.Nil(upload, "returned an upload when erroring")
@@ -154,7 +154,7 @@ func (suite *UploaderSuite) TestTooLargeUploadFromLocalFile() {
 	suite.NoError(err)
 	defer cleanup()
 
-	_, verrs, err := up.CreateUploadForDocument(&document.ID, document.ServiceMember.UserID, f, uploader.AllowedTypesAny)
+	_, verrs, err := up.CreateUploadForDocument(&document.ID, document.ServiceMember.UserID, f, uploader.AllowedTypesAny, nil)
 	suite.Error(err)
 	suite.IsType(uploader.ErrTooLarge{}, err)
 	suite.False(verrs.HasAny(), "failed to validate upload")
@@ -201,7 +201,7 @@ func (suite *UploaderSuite) TestCreateUploadNoDocument() {
 	suite.NoError(err)
 
 	// Create file and upload
-	upload, verrs, err := up.CreateUpload(userID, &file, uploader.AllowedTypesPDF)
+	upload, verrs, err := up.CreateUpload(userID, &file, uploader.AllowedTypesPDF, nil)
 	suite.Nil(err, "failed to create upload")
 	suite.Empty(verrs.Error(), "verrs returned error")
 	suite.NotNil(upload, "failed to create upload structure")

--- a/pkg/uploader/uploader_test.go
+++ b/pkg/uploader/uploader_test.go
@@ -164,7 +164,7 @@ func (suite *UploaderSuite) TestTooLargeUploadFromLocalFile() {
 	suite.False(verrs.HasAny(), "failed to validate upload")
 }
 
-func (suite *UploaderSuite) TestStorerCalledWithMetaData() {
+func (suite *UploaderSuite) TestStorerCalledWithTags() {
 	document := testdatagen.MakeDefaultDocument(suite.DB())
 
 	fakeS3 := &mocks.FileStorer{}

--- a/pkg/uploader/uploader_test.go
+++ b/pkg/uploader/uploader_test.go
@@ -174,15 +174,14 @@ func (suite *UploaderSuite) TestStorerCalledWithMetaData() {
 	suite.NoError(err)
 	defer cleanup()
 
-	value := "value"
-	metaData := map[string]*string{"metaDataTag": &value}
+	tags := "metaDataTag=value"
 	fakeS3.On("Store",
 		mock.Anything,
 		mock.Anything,
 		mock.Anything,
-		metaData).Return(&storage.StoreResult{}, nil)
-	// assert metadata is passed along to storer
-	_, verrs, err := up.CreateUploadForDocument(&document.ID, document.ServiceMember.UserID, uploader.File{File: f, MetaData: metaData}, uploader.AllowedTypesAny)
+		&tags).Return(&storage.StoreResult{}, nil)
+	// assert tags are passed along to storer
+	_, verrs, err := up.CreateUploadForDocument(&document.ID, document.ServiceMember.UserID, uploader.File{File: f, Tags: &tags}, uploader.AllowedTypesAny)
 
 	suite.NoError(err)
 	suite.False(verrs.HasAny(), "failed to validate upload")


### PR DESCRIPTION
## Description

In the office app when a document is generated via "Download All Attachments (PDF)" or "Download Orders and Weight Tickets (PDF)", a new browser tab opened with a link to the new document.

When the the new virus scanning policy is applied to S3, this approach will no longer work (because while the document is scanning the s3 bucket is inaccessible). However, documents generated by the application are not required to be scanned. For these documents on upload the s3 tags will be set for/to: `av-status: CLEAN` and `av-notes: GENERATED`, which will allow for immediate access to the newly generated document.

## Reviewer Notes
1) Open the S3 console. After each upload below, take note of the associated tags. 
![Screen Shot 2019-09-17 at 9 05 15 AM](https://user-images.githubusercontent.com/1036969/65054131-53d78d80-d92a-11e9-9607-b0856adceb0e.png)

2) Create a new move from scratch using a [s3 backend](https://github.com/transcom/mymove/blob/master/docs/how-to/run-against-s3-locally.md) (like in Setup below). Upload some documents as the service member. Look at the upload in S3. No tags should be present.
3) Open the office app click both "Download All Attachments (PDF)" and "Download Orders and Weight Tickets". Look at the upload in S3. The following s3 tags should be populated `av-status`: `CLEAN` and `av-notes`: `GENERATED`.



## Setup
```sh
rm ./bin/milmove
make db_dev_reset && make db_dev_migrate
env STORAGE_BACKEND=s3 make server_run_standalone
```

## Code Review Verification Steps
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/n/projects/2181745/stories/168515072) for this change