### PR TITLE
Use dollars to calculate dollar amounts for other expenses

### DIFF
--- a/pkg/models/shipment_summary_worksheet.go
+++ b/pkg/models/shipment_summary_worksheet.go
@@ -477,7 +477,7 @@ func FormatOtherExpenses(docs MovingExpenseDocuments) FormattedOtherExpenses {
 	for _, doc := range docs {
 		if doc.MovingExpenseType == MovingExpenseTypeOTHER {
 			expenseDescriptions = append(expenseDescriptions, doc.MoveDocument.Title)
-			expenseAmounts = append(expenseAmounts, FormatDollars(float64(doc.RequestedAmountCents)))
+			expenseAmounts = append(expenseAmounts, FormatDollars(float64(doc.RequestedAmountCents.ToDollarFloat())))
 		}
 	}
 	return FormattedOtherExpenses{

--- a/pkg/models/shipment_summary_worksheet_test.go
+++ b/pkg/models/shipment_summary_worksheet_test.go
@@ -459,17 +459,36 @@ func (suite *ModelSuite) TestFormatValuesShipmentSummaryWorksheetFormPage3() {
 		FirstName: models.StringPointer("John"),
 		LastName:  models.StringPointer("Smith"),
 	}
+	movingExpenses := models.MovingExpenseDocuments{
+		{
+			MovingExpenseType:    models.MovingExpenseTypeOTHER,
+			RequestedAmountCents: unit.Cents(100000),
+			PaymentMethod:        "GTCC",
+		},
+		{
+			MovingExpenseType:    models.MovingExpenseTypeOTHER,
+			RequestedAmountCents: unit.Cents(20000),
+			PaymentMethod:        "GTCC",
+		},
+		{
+			MovingExpenseType:    models.MovingExpenseTypeOTHER,
+			RequestedAmountCents: unit.Cents(10000),
+			PaymentMethod:        "OTHER",
+		},
+	}
 	signature := models.SignedCertification{
 		Date: signatureDate,
 	}
 
 	ssd := models.ShipmentSummaryFormData{
-		ServiceMember:       sm,
-		SignedCertification: signature,
+		ServiceMember:          sm,
+		SignedCertification:    signature,
+		MovingExpenseDocuments: movingExpenses,
 	}
 
 	sswPage3 := models.FormatValuesShipmentSummaryWorksheetFormPage3(ssd)
 
+	suite.Equal("$1,000.00\n\n$200.00\n\n$100.00", sswPage3.AmountsPaid)
 	suite.Equal("John Smith electronically signed", sswPage3.ServiceMemberSignature)
 	suite.Equal("26 Jan 2019 at 2:40pm", sswPage3.SignatureDate)
 }

--- a/pkg/models/shipment_summary_worksheet_test.go
+++ b/pkg/models/shipment_summary_worksheet_test.go
@@ -835,7 +835,7 @@ func (suite *ModelSuite) TestFormatOtherExpenses() {
 	formattedOtherExpenses := models.FormatOtherExpenses(otherExpenseDocs)
 
 	suite.Equal("The Bard\n\nThe Beedle", formattedOtherExpenses.Descriptions)
-	suite.Equal("$2,589.00\n\n$1,439.00", formattedOtherExpenses.AmountsPaid)
+	suite.Equal("$25.89\n\n$14.39", formattedOtherExpenses.AmountsPaid)
 }
 
 func (suite *ModelSuite) TestFormatSignature() {


### PR DESCRIPTION
## Description

I introduced a bug in #2650, so this fixes it. I was using the cents amount instead of the dollar amount in the dollar formatting. 

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make db_dev_e2e_populate
make server_run
make client_run
make office_client_run
```
Add a few other expenses as the SM. I recommend using `ppm@requestingpayment.newflow`. Make sure to take note of the amounts. Using either the office client or running `go run ./cmd/generate-shipment-summary --move f9f10492-587e-43b3-af2a-9f67d2ac8757 && open shipment-summary-w*` (this is the move id for the user I recommended above). Make sure on the third page that the amounts are the same as the amounts you entered for other expenses.

## Code Review Verification Steps

* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* https://www.pivotaltracker.com/story/show/167907725

## Screenshots

n/a
