### PR TITLE
Add paperwork tests back in with SSW instead of GBL

### DIFF
--- a/pkg/services/paperwork/create_form_test.go
+++ b/pkg/services/paperwork/create_form_test.go
@@ -1,5 +1,223 @@
 package paperwork
 
+import (
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/transcom/mymove/pkg/services"
+	"github.com/transcom/mymove/pkg/services/paperwork/mocks"
+
+	"github.com/gofrs/uuid"
+
+	"github.com/transcom/mymove/pkg/auth"
+	"github.com/transcom/mymove/pkg/gen/internalmessages"
+	"github.com/transcom/mymove/pkg/models"
+	paperworkforms "github.com/transcom/mymove/pkg/paperwork"
+	"github.com/transcom/mymove/pkg/testdatagen"
+	"github.com/transcom/mymove/pkg/unit"
+)
+
+func (suite *PaperworkServiceSuite) GenerateSSWFormPage1Values() models.ShipmentSummaryWorksheetPage1Values {
+	moveID, _ := uuid.NewV4()
+	serviceMemberID, _ := uuid.NewV4()
+	//advanceID, _ := uuid.NewV4()
+	ordersType := internalmessages.OrdersTypePERMANENTCHANGEOFSTATION
+	yuma := testdatagen.FetchOrMakeDefaultCurrentDutyStation(suite.DB())
+	fortGordon := testdatagen.FetchOrMakeDefaultNewOrdersDutyStation(suite.DB())
+	rank := models.ServiceMemberRankE9
+	moveType := models.SelectedMoveTypeHHGPPM
+
+	move := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{
+		Move: models.Move{
+			ID:               moveID,
+			SelectedMoveType: &moveType,
+		},
+		Order: models.Order{
+			OrdersType:       ordersType,
+			NewDutyStationID: fortGordon.ID,
+		},
+		ServiceMember: models.ServiceMember{
+			ID:            serviceMemberID,
+			DutyStationID: &yuma.ID,
+			Rank:          &rank,
+		},
+	})
+
+	netWeight := unit.Pound(10000)
+	ppm := testdatagen.MakePPM(suite.DB(), testdatagen.Assertions{
+		PersonallyProcuredMove: models.PersonallyProcuredMove{
+			MoveID:              move.ID,
+			NetWeight:           &netWeight,
+			HasRequestedAdvance: true,
+		},
+	})
+
+	movedocuments := testdatagen.Assertions{
+		MoveDocument: models.MoveDocument{
+			MoveID:                   ppm.Move.ID,
+			Move:                     ppm.Move,
+			PersonallyProcuredMoveID: &ppm.ID,
+			Status:                   models.MoveDocumentStatusOK,
+			MoveDocumentType:         "EXPENSE",
+		},
+		Document: models.Document{
+			ServiceMemberID: serviceMemberID,
+			ServiceMember:   move.Orders.ServiceMember,
+		},
+	}
+	testdatagen.MakeMovingExpenseDocument(suite.DB(), movedocuments)
+	testdatagen.MakeMovingExpenseDocument(suite.DB(), movedocuments)
+
+	session := auth.Session{
+		UserID:          move.Orders.ServiceMember.UserID,
+		ServiceMemberID: serviceMemberID,
+		ApplicationName: auth.MilApp,
+	}
+	ppm.Move.Submit(time.Now())
+	ppm.Move.Approve()
+	// This is the same PPM model as ppm, but this is the one that will be saved by SaveMoveDependencies
+	ppm.Move.PersonallyProcuredMoves[0].Submit(time.Now())
+	ppm.Move.PersonallyProcuredMoves[0].Approve(time.Now())
+	ppm.Move.PersonallyProcuredMoves[0].RequestPayment()
+	models.SaveMoveDependencies(suite.DB(), &ppm.Move)
+	certificationType := models.SignedCertificationTypePPMPAYMENT
+	testdatagen.MakeSignedCertification(suite.DB(), testdatagen.Assertions{
+		SignedCertification: models.SignedCertification{
+			MoveID:                   moveID,
+			PersonallyProcuredMoveID: &ppm.ID,
+			CertificationType:        &certificationType,
+			CertificationText:        "LEGAL",
+			Signature:                "ACCEPT",
+			Date:                     testdatagen.NextValidMoveDate,
+		},
+	})
+	ssd, _ := models.FetchDataShipmentSummaryWorksheetFormData(suite.DB(), &session, moveID)
+	page1Data, _, _, _ := models.FormatValuesShipmentSummaryWorksheet(ssd)
+	return page1Data
+}
+
+func (suite *PaperworkServiceSuite) TestCreateFormServiceSuccess() {
+	FileStorer := &mocks.FileStorer{}
+	FormFiller := &mocks.FormFiller{}
+
+	ssd := suite.GenerateSSWFormPage1Values()
+	fs := afero.NewMemMapFs()
+	afs := &afero.Afero{Fs: fs}
+	f, _ := afs.TempFile("", "ioutil-test")
+
+	FormFiller.On("AppendPage",
+		mock.AnythingOfType("*bytes.Reader"),
+		mock.AnythingOfType("map[string]paperwork.FieldPos"),
+		mock.AnythingOfType("models.ShipmentSummaryWorksheetPage1Values"),
+	).Return(nil).Times(1)
+
+	FileStorer.On("Create",
+		mock.AnythingOfType("string"),
+	).Return(f, nil)
+
+	FormFiller.On("Output",
+		f,
+	).Return(nil)
+
+	formCreator := NewFormCreator(FileStorer, FormFiller)
+	template, _ := MakeFormTemplate(ssd, "some-file-name", paperworkforms.ShipmentSummaryPage1Layout, services.SSW)
+	file, err := formCreator.CreateForm(template)
+
+	suite.NotNil(file)
+	suite.NoError(err)
+	FormFiller.AssertExpectations(suite.T())
+}
+
+func (suite *PaperworkServiceSuite) TestCreateFormServiceFormFillerAppendPageFailure() {
+	FileStorer := &mocks.FileStorer{}
+	FormFiller := &mocks.FormFiller{}
+
+	ssd := suite.GenerateSSWFormPage1Values()
+
+	FormFiller.On("AppendPage",
+		mock.AnythingOfType("*bytes.Reader"),
+		mock.AnythingOfType("map[string]paperwork.FieldPos"),
+		mock.AnythingOfType("models.ShipmentSummaryWorksheetPage1Values"),
+	).Return(errors.New("Error for FormFiller.AppendPage()")).Times(1)
+
+	formCreator := NewFormCreator(FileStorer, FormFiller)
+	template, _ := MakeFormTemplate(ssd, "some-file-name", paperworkforms.ShipmentSummaryPage1Layout, services.SSW)
+	file, err := formCreator.CreateForm(template)
+
+	suite.NotNil(err)
+	suite.Nil(file)
+	serviceErrMsg := errors.Cause(err)
+	suite.Equal("Error for FormFiller.AppendPage()", serviceErrMsg.Error())
+	suite.Equal("Failure writing SSW data to form.: Error for FormFiller.AppendPage()", err.Error())
+	FormFiller.AssertExpectations(suite.T())
+}
+
+func (suite *PaperworkServiceSuite) TestCreateFormServiceFileStorerCreateFailure() {
+	FileStorer := &mocks.FileStorer{}
+	FormFiller := &mocks.FormFiller{}
+
+	ssd := suite.GenerateSSWFormPage1Values()
+
+	FormFiller.On("AppendPage",
+		mock.AnythingOfType("*bytes.Reader"),
+		mock.AnythingOfType("map[string]paperwork.FieldPos"),
+		mock.AnythingOfType("models.ShipmentSummaryWorksheetPage1Values"),
+	).Return(nil).Times(1)
+
+	FileStorer.On("Create",
+		mock.AnythingOfType("string"),
+	).Return(nil, errors.New("Error for FileStorer.Create()"))
+
+	formCreator := NewFormCreator(FileStorer, FormFiller)
+	template, _ := MakeFormTemplate(ssd, "some-file-name", paperworkforms.ShipmentSummaryPage1Layout, services.SSW)
+	file, err := formCreator.CreateForm(template)
+
+	suite.Nil(file)
+	suite.NotNil(err)
+	serviceErrMsg := errors.Cause(err)
+	suite.Equal("Error for FileStorer.Create()", serviceErrMsg.Error())
+	suite.Equal("Error creating a new afero file for SSW form.: Error for FileStorer.Create()", err.Error())
+	FormFiller.AssertExpectations(suite.T())
+}
+
+func (suite *PaperworkServiceSuite) TestCreateFormServiceFormFillerOutputFailure() {
+	FileStorer := &mocks.FileStorer{}
+	FormFiller := &mocks.FormFiller{}
+
+	ssd := suite.GenerateSSWFormPage1Values()
+	fs := afero.NewMemMapFs()
+	afs := &afero.Afero{Fs: fs}
+	f, _ := afs.TempFile("", "ioutil-test")
+
+	FormFiller.On("AppendPage",
+		mock.AnythingOfType("*bytes.Reader"),
+		mock.AnythingOfType("map[string]paperwork.FieldPos"),
+		mock.AnythingOfType("models.ShipmentSummaryWorksheetPage1Values"),
+	).Return(nil).Times(1)
+
+	FileStorer.On("Create",
+		mock.AnythingOfType("string"),
+	).Return(f, nil)
+
+	FormFiller.On("Output",
+		f,
+	).Return(errors.New("Error for FormFiller.Output()"))
+
+	formCreator := NewFormCreator(FileStorer, FormFiller)
+	template, _ := MakeFormTemplate(ssd, "some-file-name", paperworkforms.ShipmentSummaryPage1Layout, services.SSW)
+	file, err := formCreator.CreateForm(template)
+
+	suite.Nil(file)
+	suite.NotNil(err)
+	serviceErrMsg := errors.Cause(err)
+	suite.Equal("Error for FormFiller.Output()", serviceErrMsg.Error())
+	suite.Equal("Failure exporting SSW form to file.: Error for FormFiller.Output()", err.Error())
+	FormFiller.AssertExpectations(suite.T())
+}
+
 func (suite *PaperworkServiceSuite) TestCreateFormServiceCreateAssetByteReaderFailure() {
 	badAssetPath := "pkg/paperwork/formtemplates/someUndefinedTemplatePath.png"
 	templateBuffer, err := createAssetByteReader(badAssetPath)


### PR DESCRIPTION
## Description

Tests for the paperwork module were removed in #2616. Since they are still used for payment request flows, I've readded this back in with the ssw in mind.

## Reviewer Notes

As I was writing this, I realized that there is a ton that's mocked here. I'm unsure if this tests this thoroughly enough because of it. Can you please give me feedback on this? I'm worried there's no use in testing a completely mocked test.

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make db_test_migrate
go test ./pkg/services/paperwork
```

## Code Review Verification Steps

* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* https://www.pivotaltracker.com/story/show/168274732
