### PR TITLE
Add the dependency update type to the script and include it in branch name and message

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -747,7 +747,7 @@ jobs:
             git --no-pager diff --ignore-all-space --color
       - run:
           name: Push changes
-          command: scripts/circleci-push-dependency-updates
+          command: scripts/circleci-push-dependency-updates golang
 
   # `update_dependencies_js` periodically updates yarn dependencies.
   # The changes are submitted as a pull request for review.
@@ -769,7 +769,7 @@ jobs:
             git --no-pager diff --ignore-all-space --color
       - run:
           name: Push changes
-          command: scripts/circleci-push-dependency-updates
+          command: scripts/circleci-push-dependency-updates js
 
   # `update_dependencies_pre_commit` periodically updates pre-commit dependencies.
   # The changes are submitted as a pull request for review.
@@ -785,7 +785,7 @@ jobs:
             git --no-pager diff --ignore-all-space --color
       - run:
           name: Push changes
-          command: scripts/circleci-push-dependency-updates
+          command: scripts/circleci-push-dependency-updates pre-commit
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -336,7 +336,7 @@ jobs:
   # `integration_tests` runs integration tests using Cypress.  https://www.cypress.io/
   integration_tests:
     parallelism: 10
-    executor: mymove_medium
+    executor: mymove_medium_plus
     steps:
       - checkout
       - setup_remote_docker:

--- a/scripts/circleci-push-dependency-updates
+++ b/scripts/circleci-push-dependency-updates
@@ -1,10 +1,18 @@
 #! /usr/bin/env bash
+
+#
+# Push dependency update branch to Github and message Slack with the branch and CircleCI information
+#
+
 set -euxo pipefail
 
 readonly github_repo="transcom/mymove"
-readonly github_repo_url=https://github.com/$github_repo
-readonly github_compare_url=$github_repo_url/compare/
-readonly circleci_tree_url=https://circleci.com/gh/$github_repo/tree
+readonly github_repo_url="https://github.com/${github_repo}"
+readonly github_compare_url="${github_repo_url}/compare/"
+readonly circleci_tree_url="https://circleci.com/gh/${github_repo}/tree"
+
+# Capture the dependency name that is being updated
+deps_name="$1"
 
 if [[ -z "$(git status --short)" ]]; then
     echo No updates to push.
@@ -14,18 +22,18 @@ fi
 # Setup deploy key with write access.
 ssh_key=$(mktemp -p /dev/shm)
 readonly ssh_key
-shred_key() { shred -v "$ssh_key"; }
+shred_key() { shred -v "${ssh_key}"; }
 trap shred_key EXIT
 aws ssm get-parameters \
     --names ssh-key-mymove-dependency-updater \
     --with-decryption \
     --query 'Parameters[0].Value' \
     --output text \
-    > "$ssh_key"
+    > "${ssh_key}"
 cat >>~/.ssh/config <<EOF
 Host github.com
   IdentitiesOnly yes
-  IdentityFile $ssh_key
+  IdentityFile ${ssh_key}
 EOF
 
 # Configure git
@@ -36,10 +44,10 @@ git config user.name "Dependency Updater"
 # Push changes to a branch
 branch=dependency-updates-$(date +%s)
 readonly branch
-git checkout -b "$branch"
-git commit -am "Automated dependency updates | $(date -R)"
-git push -v --set-upstream origin "$branch"
+git checkout -b "${branch}"
+git commit -am "Automated dependency updates ${deps_name} | $(date -R)"
+git push -v --set-upstream origin "${branch}"
 
 # Announce changes
-text="Pushed updated dependencies for $github_repo: <$github_compare_url/$branch#new_pull_request|$branch> (<$circleci_tree_url/$branch|view tests>)."
-curl -X POST --data-urlencode 'payload={"text":"'"$text"'"}' "$SLACK_WEBHOOK_URL"
+text="Pushed updated dependencies for ${deps_name} in ${github_repo}: <${github_compare_url}/${branch}#new_pull_request|${branch}> (<${circleci_tree_url}/${branch}|view tests>)."
+curl -X POST --data-urlencode 'payload={"text":"'"${text}"'"}' "${SLACK_WEBHOOK_URL}"


### PR DESCRIPTION
## Description

Dependency updates don't indicate what type of dependency is being updated. This modifies the script to include the name.  It also fixes some bash syntax.

## Reviewer Notes

We can include more information in the slack message like Team Name or we can specifically call out a github user. Would we want to do that?