### PR TITLE
Disable DB_DEBUG for migrations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -736,6 +736,7 @@ run_prod_migrations: server_deps bin/milmove db_deployed_migrations_reset ## Run
 	DB_HOST=localhost \
 	DB_PORT=$(DB_PORT_DEPLOYED_MIGRATIONS) \
 	DB_NAME=$(DB_NAME_DEPLOYED_MIGRATIONS) \
+	DB_DEBUG=0 \
 	bin/milmove migrate
 
 .PHONY: run_staging_migrations
@@ -745,6 +746,7 @@ run_staging_migrations: server_deps bin/milmove db_deployed_migrations_reset ## 
 	DB_HOST=localhost \
 	DB_PORT=$(DB_PORT_DEPLOYED_MIGRATIONS) \
 	DB_NAME=$(DB_NAME_DEPLOYED_MIGRATIONS) \
+	DB_DEBUG=0 \
 	bin/milmove migrate
 
 .PHONY: run_experimental_migrations
@@ -754,6 +756,7 @@ run_experimental_migrations: server_deps bin/milmove db_deployed_migrations_rese
 	DB_HOST=localhost \
 	DB_PORT=$(DB_PORT_DEPLOYED_MIGRATIONS) \
 	DB_NAME=$(DB_NAME_DEPLOYED_MIGRATIONS) \
+	DB_DEBUG=0 \
 	bin/milmove migrate
 
 #

--- a/Makefile
+++ b/Makefile
@@ -452,7 +452,7 @@ db_dev_reset: db_dev_destroy db_dev_run ## Reset Dev DB (destroy and run)
 .PHONY: db_dev_migrate_standalone ## Migrate Dev DB directly
 db_dev_migrate_standalone: bin/milmove
 	@echo "Migrating the ${DB_NAME_DEV} database..."
-	bin/milmove migrate -p "file://migrations;file://local_migrations" -m migrations_manifest.txt
+	DB_DEBUG=0 bin/milmove migrate -p "file://migrations;file://local_migrations" -m migrations_manifest.txt
 
 .PHONY: db_dev_migrate
 db_dev_migrate: server_deps db_dev_migrate_standalone ## Migrate Dev DB
@@ -507,7 +507,7 @@ db_deployed_migrations_reset: db_deployed_migrations_destroy db_deployed_migrati
 .PHONY: db_deployed_migrations_migrate_standalone
 db_deployed_migrations_migrate_standalone: bin/milmove ## Migrate Deployed Migrations DB with local migrations
 	@echo "Migrating the ${DB_NAME_DEPLOYED_MIGRATIONS} database..."
-	DB_PORT=$(DB_PORT_DEPLOYED_MIGRATIONS) DB_NAME=$(DB_NAME_DEPLOYED_MIGRATIONS) bin/milmove migrate -p "file://migrations;file://local_migrations" -m migrations_manifest.txt
+	DB_DEBUG=0 DB_PORT=$(DB_PORT_DEPLOYED_MIGRATIONS) DB_NAME=$(DB_NAME_DEPLOYED_MIGRATIONS) bin/milmove migrate -p "file://migrations;file://local_migrations" -m migrations_manifest.txt
 
 .PHONY: db_deployed_migrations_migrate
 db_deployed_migrations_migrate: server_deps db_deployed_migrations_migrate_standalone ## Migrate Deployed Migrations DB
@@ -570,10 +570,10 @@ db_test_reset: db_test_destroy db_test_run ## Reset Test DB (destroy and run)
 db_test_migrate_standalone: bin/milmove ## Migrate Test DB directly
 ifndef CIRCLECI
 	@echo "Migrating the ${DB_NAME_TEST} database..."
-	DB_NAME=$(DB_NAME_TEST) DB_PORT=$(DB_PORT_TEST) bin/milmove migrate -p "file://migrations;file://local_migrations" -m migrations_manifest.txt
+	DB_DEBUG=0 DB_NAME=$(DB_NAME_TEST) DB_PORT=$(DB_PORT_TEST) bin/milmove migrate -p "file://migrations;file://local_migrations" -m migrations_manifest.txt
 else
 	@echo "Migrating the ${DB_NAME_TEST} database..."
-	DB_NAME=$(DB_NAME_TEST) DB_PORT=$(DB_PORT_DEV) bin/milmove migrate -p "file://migrations;file://local_migrations" -m migrations_manifest.txt
+	DB_DEBUG=0 DB_NAME=$(DB_NAME_TEST) DB_PORT=$(DB_PORT_DEV) bin/milmove migrate -p "file://migrations;file://local_migrations" -m migrations_manifest.txt
 endif
 
 .PHONY: db_test_migrate


### PR DESCRIPTION
## Description

We turned on SQL logging, see `docs/database.md` for details as to why. However, they were also turned on for migrations, which increased the noise in the output of migrations with little to no value-added. So we are turning it off for those commands specifically.

## Reviewer Notes

If there are other commands where this should be disabled let me know and I'm happy to add them.

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make clean
make db_dev_reset db_dev_migrate
make db_test_reset db_test_migrate
make db_deployed_migrations_reset db_deployed_migrations_migrate 
```

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [#168612835](https://www.pivotaltracker.com/story/show/168612835) for this change
* [Slack thread about this](https://defensedigitalservice.slack.com/archives/G8P7UD05U/p1568936334102400) explains more about the approach used.
