### PR TITLE
Fix spellcheck slowness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -847,11 +847,11 @@ clean: ## Clean all generated files
 
 .PHONY: spellcheck
 spellcheck: .client_deps.stamp ## Run interactive spellchecker
-	node_modules/.bin/mdspell --ignore-numbers --ignore-acronyms --en-us \
+	node_modules/.bin/mdspell --ignore-numbers --ignore-acronyms --en-us --no-suggestions \
 		`find . -type f -name "*.md" \
 			-not -path "./node_modules/*" \
 			-not -path "./vendor/*" \
-			-not -path "./docs/adr/index.md"`
+			-not -path "./docs/adr/index.md" | sort`
 
 .PHONY: storybook
 storybook: ## Start the storybook server


### PR DESCRIPTION
## Description

`make spellcheck` is slow and annoying. It gets exponentially slower as you use it and the reason appears to be that it can't manage to give suggestions in a timely fashion when you have large numbers of errors. The [docs say you should not allow suggestions](https://www.npmjs.com/package/markdown-spellcheck) if you have a speed problem. I know this is a major problem a lot of folks have with this module and fixing it will save us a lot of pain.