### PR TITLE
remove dup duty stations - take 2: 168408874

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -829,33 +829,33 @@ workflows:
             - build_migrations
             - acceptance_tests_local
           # if testing on experimental, you can disable these tests by using the commented block below.
-          filters:
-            branches:
-              ignore: lt-remove-dup-duty-stations-168408874
+          # filters:
+          #   branches:
+          #     ignore: placeholder_branch_name
 
       - client_test:
           requires:
             - pre_deps_yarn
           # if testing on experimental, you can disable these tests by using the commented block below.
-          filters:
-            branches:
-              ignore: lt-remove-dup-duty-stations-168408874
+          # filters:
+          #   branches:
+          #     ignore: placeholder_branch_name
 
       - server_test:
           requires:
             - pre_deps_golang
           # if testing on experimental, you can disable these tests by using the commented block below.
-          filters:
-            branches:
-              ignore: lt-remove-dup-duty-stations-168408874
+          # filters:
+          #   branches:
+          #     ignore: placeholder_branch_name
 
       - server_test_coverage:
           requires:
             - pre_deps_golang
           # if testing on experimental, you can disable these tests by using the commented block below.
-          filters:
-            branches:
-              ignore: lt-remove-dup-duty-stations-168408874
+          # filters:
+          #   branches:
+          #     ignore: placeholder_branch_name
 
       - build_app:
           requires:
@@ -891,28 +891,28 @@ workflows:
             - build_migrations
           filters:
             branches:
-              only: lt-remove-dup-duty-stations-168408874
+              only: placeholder_branch_name
 
       - deploy_experimental_tasks:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: lt-remove-dup-duty-stations-168408874
+              only: placeholder_branch_name
 
       - deploy_experimental_app:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: lt-remove-dup-duty-stations-168408874
+              only: placeholder_branch_name
 
       - deploy_experimental_app_client_tls:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: lt-remove-dup-duty-stations-168408874
+              only: placeholder_branch_name
 
       - check_circle_against_staging_sha:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -829,33 +829,33 @@ workflows:
             - build_migrations
             - acceptance_tests_local
           # if testing on experimental, you can disable these tests by using the commented block below.
-          # filters:
-          #   branches:
-          #     ignore: placeholder_branch_name
+          filters:
+            branches:
+              ignore: lt-remove-dup-duty-stations-168408874
 
       - client_test:
           requires:
             - pre_deps_yarn
           # if testing on experimental, you can disable these tests by using the commented block below.
-          # filters:
-          #   branches:
-          #     ignore: placeholder_branch_name
+          filters:
+            branches:
+              ignore: lt-remove-dup-duty-stations-168408874
 
       - server_test:
           requires:
             - pre_deps_golang
           # if testing on experimental, you can disable these tests by using the commented block below.
-          # filters:
-          #   branches:
-          #     ignore: placeholder_branch_name
+          filters:
+            branches:
+              ignore: lt-remove-dup-duty-stations-168408874
 
       - server_test_coverage:
           requires:
             - pre_deps_golang
           # if testing on experimental, you can disable these tests by using the commented block below.
-          # filters:
-          #   branches:
-          #     ignore: placeholder_branch_name
+          filters:
+            branches:
+              ignore: lt-remove-dup-duty-stations-168408874
 
       - build_app:
           requires:
@@ -891,28 +891,28 @@ workflows:
             - build_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: lt-remove-dup-duty-stations-168408874
 
       - deploy_experimental_tasks:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: lt-remove-dup-duty-stations-168408874
 
       - deploy_experimental_app:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: lt-remove-dup-duty-stations-168408874
 
       - deploy_experimental_app_client_tls:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: lt-remove-dup-duty-stations-168408874
 
       - check_circle_against_staging_sha:
           requires:

--- a/migrations/20190913205819_delete_dup_duty_stations.up.sql
+++ b/migrations/20190913205819_delete_dup_duty_stations.up.sql
@@ -1,0 +1,38 @@
+-- Minot Air Force Base
+UPDATE service_members
+	SET duty_station_id = (select id from duty_stations where name = 'Minot AFB')
+	WHERE duty_station_id = (select id from duty_stations where name = 'Minot Air Force Base');
+UPDATE orders
+	SET new_duty_station_id = (select id from duty_stations where name = 'Minot AFB')
+	WHERE new_duty_station_id = (select id from duty_stations where name = 'Minot Air Force Base');
+DELETE FROM duty_stations WHERE name = 'Minot Air Force Base'
+	AND NOT EXISTS (SELECT id FROM orders WHERE new_duty_station_id = (select id from duty_stations where name = 'Minot Air Force Base'))
+	AND NOT EXISTS (SELECT id FROM service_members WHERE duty_station_id = (select id from duty_stations where name = 'Minot Air Force Base'));
+DELETE FROM addresses WHERE id = '43e3ab4a-a307-47da-b2dc-93a1bc8ace44'
+	AND NOT EXISTS (SELECT id FROM duty_stations WHERE name = 'Minot Air Force Base');
+
+-- Warren
+UPDATE service_members
+	SET duty_station_id = (select id from duty_stations where name = 'F.E. Warren AFB')
+	WHERE duty_station_id = (select id from duty_stations where name = 'Warren');
+UPDATE orders
+	SET new_duty_station_id = (select id from duty_stations where name = 'F.E. Warren AFB')
+	WHERE new_duty_station_id = (select id from duty_stations where name = 'Warren');
+DELETE FROM duty_stations WHERE name = 'Warren'
+	AND NOT EXISTS (SELECT id FROM orders WHERE new_duty_station_id = (select id from duty_stations where name = 'Warren'))
+	AND NOT EXISTS (SELECT id FROM service_members WHERE duty_station_id = (select id from duty_stations where name = 'Warren'));
+DELETE FROM addresses WHERE id = '3ff01b01-a1ce-4442-b588-a434858bf8c5'
+	AND NOT EXISTS (SELECT id FROM duty_stations WHERE name = 'Warren');
+
+-- Warren Air Force Base
+UPDATE service_members
+	SET duty_station_id = (select id from duty_stations where name = 'F.E. Warren AFB')
+	WHERE duty_station_id = (select id from duty_stations where name = 'Warren Air Force Base');
+UPDATE orders
+	SET new_duty_station_id = (select id from duty_stations where name = 'F.E. Warren AFB')
+	WHERE new_duty_station_id = (select id from duty_stations where name = 'Warren Air Force Base');
+DELETE FROM duty_stations WHERE name = 'Warren Air Force Base'
+	AND NOT EXISTS (SELECT id FROM orders WHERE new_duty_station_id = (select id from duty_stations where name = 'Warren Air Force Base'))
+	AND NOT EXISTS (SELECT id FROM service_members WHERE duty_station_id = (select id from duty_stations where name = 'Warren Air Force Base'));
+DELETE FROM addresses WHERE id = '44c1df72-c433-4d09-a8c0-89672fc2f3ee'
+	AND NOT EXISTS (SELECT id FROM duty_stations WHERE name = 'Warren Air Force Base');

--- a/migrations/20190913205819_delete_dup_duty_stations.up.sql
+++ b/migrations/20190913205819_delete_dup_duty_stations.up.sql
@@ -1,4 +1,4 @@
--- Minot Air Force Base
+-- Minot Air Force Base -> Minot AFB
 UPDATE service_members
 	SET duty_station_id = (select id from duty_stations where name = 'Minot AFB')
 	WHERE duty_station_id = (select id from duty_stations where name = 'Minot Air Force Base');
@@ -11,7 +11,7 @@ DELETE FROM duty_stations WHERE name = 'Minot Air Force Base'
 DELETE FROM addresses WHERE id = '43e3ab4a-a307-47da-b2dc-93a1bc8ace44'
 	AND NOT EXISTS (SELECT id FROM duty_stations WHERE name = 'Minot Air Force Base');
 
--- Warren
+-- Warren -> F.E. Warren AFB
 UPDATE service_members
 	SET duty_station_id = (select id from duty_stations where name = 'F.E. Warren AFB')
 	WHERE duty_station_id = (select id from duty_stations where name = 'Warren');
@@ -24,7 +24,7 @@ DELETE FROM duty_stations WHERE name = 'Warren'
 DELETE FROM addresses WHERE id = '3ff01b01-a1ce-4442-b588-a434858bf8c5'
 	AND NOT EXISTS (SELECT id FROM duty_stations WHERE name = 'Warren');
 
--- Warren Air Force Base
+-- Warren Air Force Base -> F.E. Warren AFB
 UPDATE service_members
 	SET duty_station_id = (select id from duty_stations where name = 'F.E. Warren AFB')
 	WHERE duty_station_id = (select id from duty_stations where name = 'Warren Air Force Base');
@@ -36,3 +36,29 @@ DELETE FROM duty_stations WHERE name = 'Warren Air Force Base'
 	AND NOT EXISTS (SELECT id FROM service_members WHERE duty_station_id = (select id from duty_stations where name = 'Warren Air Force Base'));
 DELETE FROM addresses WHERE id = '44c1df72-c433-4d09-a8c0-89672fc2f3ee'
 	AND NOT EXISTS (SELECT id FROM duty_stations WHERE name = 'Warren Air Force Base');
+
+-- USCG Mobile -> Sector Mobile
+UPDATE service_members
+	SET duty_station_id = (select id from duty_stations where name = 'Sector Mobile')
+	WHERE duty_station_id = (select id from duty_stations where name = 'USCG Mobile');
+UPDATE orders
+	SET new_duty_station_id = (select id from duty_stations where name = 'Sector Mobile')
+	WHERE new_duty_station_id = (select id from duty_stations where name = 'USCG Mobile');
+DELETE FROM duty_stations WHERE name = 'USCG Mobile'
+	AND NOT EXISTS (SELECT id FROM orders WHERE new_duty_station_id = (select id from duty_stations where name = 'USCG Mobile'))
+	AND NOT EXISTS (SELECT id FROM service_members WHERE duty_station_id = (select id from duty_stations where name = 'USCG Mobile'));
+DELETE FROM addresses WHERE id = '042222cd-2f6a-47b7-bd0c-3de55c6f3f17'
+	AND NOT EXISTS (SELECT id FROM duty_stations WHERE name = 'USCG Mobile');
+
+-- Fort Eustis -> Joint Base Langley-Eustis
+UPDATE service_members
+	SET duty_station_id = (select id from duty_stations where name = 'Joint Base Langley-Eustis')
+	WHERE duty_station_id = (select id from duty_stations where name = 'Fort Eustis');
+UPDATE orders
+	SET new_duty_station_id = (select id from duty_stations where name = 'Joint Base Langley-Eustis')
+	WHERE new_duty_station_id = (select id from duty_stations where name = 'Fort Eustis');
+DELETE FROM duty_stations WHERE name = 'Fort Eustis'
+	AND NOT EXISTS (SELECT id FROM orders WHERE new_duty_station_id = (select id from duty_stations where name = 'Fort Eustis'))
+	AND NOT EXISTS (SELECT id FROM service_members WHERE duty_station_id = (select id from duty_stations where name = 'Fort Eustis'));
+DELETE FROM addresses WHERE id = '4c1605b8-ac15-41ef-bf1e-b26d45c0005e'
+	AND NOT EXISTS (SELECT id FROM duty_stations WHERE name = 'Fort Eustis');

--- a/migrations/20190913205819_delete_dup_duty_stations.up.sql
+++ b/migrations/20190913205819_delete_dup_duty_stations.up.sql
@@ -47,7 +47,7 @@ UPDATE orders
 DELETE FROM duty_stations WHERE name = 'USCG Mobile'
 	AND NOT EXISTS (SELECT id FROM orders WHERE new_duty_station_id = (select id from duty_stations where name = 'USCG Mobile'))
 	AND NOT EXISTS (SELECT id FROM service_members WHERE duty_station_id = (select id from duty_stations where name = 'USCG Mobile'));
-DELETE FROM addresses WHERE id = '042222cd-2f6a-47b7-bd0c-3de55c6f3f17'
+DELETE FROM addresses WHERE id = 'be84b14a-f836-4821-af13-fdbe8530386d'
 	AND NOT EXISTS (SELECT id FROM duty_stations WHERE name = 'USCG Mobile');
 
 -- Fort Eustis -> Joint Base Langley-Eustis

--- a/migrations/20190913205819_delete_dup_duty_stations.up.sql
+++ b/migrations/20190913205819_delete_dup_duty_stations.up.sql
@@ -50,12 +50,12 @@ DELETE FROM duty_stations WHERE name = 'USCG Mobile'
 DELETE FROM addresses WHERE id = 'be84b14a-f836-4821-af13-fdbe8530386d'
 	AND NOT EXISTS (SELECT id FROM duty_stations WHERE name = 'USCG Mobile');
 
--- Fort Eustis -> Joint Base Langley-Eustis
+-- Fort Eustis -> JB Langley-Eustis
 UPDATE service_members
-	SET duty_station_id = (select id from duty_stations where name = 'Joint Base Langley-Eustis')
+	SET duty_station_id = (select id from duty_stations where name = 'JB Langley-Eustis')
 	WHERE duty_station_id = (select id from duty_stations where name = 'Fort Eustis');
 UPDATE orders
-	SET new_duty_station_id = (select id from duty_stations where name = 'Joint Base Langley-Eustis')
+	SET new_duty_station_id = (select id from duty_stations where name = 'JB Langley-Eustis')
 	WHERE new_duty_station_id = (select id from duty_stations where name = 'Fort Eustis');
 DELETE FROM duty_stations WHERE name = 'Fort Eustis'
 	AND NOT EXISTS (SELECT id FROM orders WHERE new_duty_station_id = (select id from duty_stations where name = 'Fort Eustis'))

--- a/migrations/20190917162117_update_duty_station_names.up.sql
+++ b/migrations/20190917162117_update_duty_station_names.up.sql
@@ -1,0 +1,5 @@
+
+UPDATE duty_stations set name = 'Station New York' WHERE name = 'Sector New York';
+UPDATE duty_stations set name = 'Fort Sam Houston' WHERE name = 'Fort Sam Houston';
+UPDATE duty_stations set name = 'JBSA Randolph' WHERE name = 'Randolph AFB';
+UPDATE duty_stations set name = 'JBSA Lackland' WHERE name = 'Lackland AFB';

--- a/migrations/20190917162117_update_duty_station_names.up.sql
+++ b/migrations/20190917162117_update_duty_station_names.up.sql
@@ -1,5 +1,5 @@
 
 UPDATE duty_stations set name = 'Station New York' WHERE name = 'Sector New York';
-UPDATE duty_stations set name = 'Fort Sam Houston' WHERE name = 'Fort Sam Houston';
+UPDATE duty_stations set name = 'JBSA Fort Sam Houston' WHERE name = 'Fort Sam Houston';
 UPDATE duty_stations set name = 'JBSA Randolph' WHERE name = 'Randolph AFB';
 UPDATE duty_stations set name = 'JBSA Lackland' WHERE name = 'Lackland AFB';

--- a/migrations_manifest.txt
+++ b/migrations_manifest.txt
@@ -353,3 +353,4 @@
 20190906223934_remove_oia_pn.up.fizz
 20190912202709_update-duty-station-names.up.sql
 20190913205819_delete_dup_duty_stations.up.sql
+20190917162117_update_duty_station_names.up.sql

--- a/migrations_manifest.txt
+++ b/migrations_manifest.txt
@@ -352,3 +352,4 @@
 20190905183034_disable_truss_tsp_user.up.sql
 20190906223934_remove_oia_pn.up.fizz
 20190912202709_update-duty-station-names.up.sql
+20190913205819_delete_dup_duty_stations.up.sql


### PR DESCRIPTION
## Description

The original pr: https://github.com/transcom/mymove/pull/2696

A fix for a failed migration in `Prod`: https://defensedigitalservice.slack.com/archives/GEDH7P70E/p1568916819028400

The migration passed on `Staging` and `Experimental` because those DBS didn't have a move with `JB Langley-Eustis` as an origin or destination duty station.

A prior migration(https://github.com/transcom/mymove/pull/2687) changed the name from `Joint Base Langley-Eustis` to `JB Langley-Eustis` and when I rebased my branch, I didn't catch/remember when creating this migration.

The diff between this and ( https://github.com/transcom/mymove/pull/2696) is changing `Joint Base Langley-Eustis` to `JB Langley-Eustis`...