### PR TITLE
Fix sit estimate

### DIFF
--- a/cypress/integration/mymove/ppm.js
+++ b/cypress/integration/mymove/ppm.js
@@ -88,10 +88,9 @@ describe('completing the ppm flow', function() {
       expect(loc.pathname).to.match(/^\/moves\/[^/]+\/review/);
     });
 
-    // TODO: Fix this
-    // cy.get('[data-cy="sit-display"]')
-    //   .contains('35 days')
-    //   .contains('$2538.68');
+    cy.get('[data-cy="sit-display"]')
+      .contains('35 days')
+      .contains('$2538.68');
 
     cy.nextPage();
 

--- a/src/scenes/Review/EditDateAndLocation.jsx
+++ b/src/scenes/Review/EditDateAndLocation.jsx
@@ -13,6 +13,7 @@ import { bindActionCreators } from 'redux';
 import { createOrUpdatePpm, getPpmSitEstimate } from 'scenes/Moves/Ppm/ducks';
 import { loadEntitlementsFromState } from 'shared/entitlements';
 import { selectPPMForMove } from 'shared/Entities/modules/ppms';
+import { updatePPMEstimate } from 'shared/Entities/modules/ppms';
 import 'scenes/Moves/Ppm/DateAndLocation.css';
 import { editBegin, editSuccessful, entitlementChangeBegin } from './ducks';
 import scrollToTop from 'shared/scrollToTop';
@@ -84,15 +85,30 @@ class EditDateAndLocation extends Component {
       if (!pendingValues.has_sit) {
         pendingValues.days_in_storage = null;
       }
+
       const moveId = this.props.match.params.moveId;
-      return this.props.createOrUpdatePpm(moveId, pendingValues).then(() => {
-        // This promise resolves regardless of error.
-        if (!this.props.hasSubmitError) {
-          this.props.editSuccessful();
-          this.props.history.goBack();
-        } else {
-          scrollToTop();
-        }
+      return this.props.createOrUpdatePpm(moveId, pendingValues).then(({ payload }) => {
+        this.props
+          .updatePPMEstimate(moveId, payload.id)
+          .then(() => {
+            // This promise resolves regardless of error.
+            if (!this.props.hasSubmitError) {
+              this.props.editSuccessful();
+              this.props.history.goBack();
+            } else {
+              scrollToTop();
+            }
+          })
+          .catch(err => {
+            // This promise resolves regardless of error.
+            if (!this.props.hasSubmitError) {
+              this.props.editSuccessful();
+              this.props.history.goBack();
+            } else {
+              scrollToTop();
+            }
+            return err;
+          });
       });
     }
   };
@@ -206,6 +222,7 @@ function mapDispatchToProps(dispatch) {
       editBegin,
       editSuccessful,
       entitlementChangeBegin,
+      updatePPMEstimate,
     },
     dispatch,
   );

--- a/src/scenes/Review/PPMShipmentSummary.jsx
+++ b/src/scenes/Review/PPMShipmentSummary.jsx
@@ -29,12 +29,12 @@ class PPMShipmentSummary extends Component {
     }
   }
   render() {
-    const { advance, movePath, ppm, ppmEstimate } = this.props;
+    const { advance, movePath, ppm, ppmEstimate, estimated_storage_reimbursement } = this.props;
     const editDateAndLocationAddress = movePath + '/edit-date-and-location';
     const editWeightAddress = movePath + '/edit-weight';
 
     const privateStorageString = get(ppm, 'estimated_storage_reimbursement')
-      ? `(spend up to ${ppm.estimated_storage_reimbursement} on private storage)`
+      ? `(spend up to ${estimated_storage_reimbursement} on private storage)`
       : '';
     const sitDisplay = get(ppm, 'has_sit', false)
       ? `${ppm.days_in_storage} days ${privateStorageString}`
@@ -144,7 +144,10 @@ PPMShipmentSummary.propTypes = {
 function mapStateToProps(state, ownProps) {
   const { ppm } = ownProps;
   const advance = selectReimbursement(state, ppm.advance);
-  const { incentive_estimate_min, incentive_estimate_max } = selectPPMForMove(state, ppm.move_id);
+  const { incentive_estimate_min, incentive_estimate_max, estimated_storage_reimbursement } = selectPPMForMove(
+    state,
+    ppm.move_id,
+  );
   return {
     ...ownProps,
     advance,
@@ -156,6 +159,7 @@ function mapStateToProps(state, ownProps) {
       incentive_estimate_min,
       incentive_estimate_max,
     },
+    estimated_storage_reimbursement,
   };
 }
 


### PR DESCRIPTION
## Description

The SIT estimate values weren't getting updated because of things forgotten in the BVS score story. This story fixes it so that the SIT estimate is accurate

## Setup
`make server_run`
`make client_run`
Log in to profile@co.mple.te
Finish flow until the review page and provide a number of SIT days
Edit the Dates & Locations
Change number of days in storage to different number
Save
New value on review panel should reflect value on previous view
