### PR TITLE
TTV remove unused db tables part 3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -891,28 +891,28 @@ workflows:
             - build_migrations
           filters:
             branches:
-              only: ttv-167977685-remove-unused-db-tables-3
+              only: placeholder_branch_name
 
       - deploy_experimental_tasks:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: ttv-167977685-remove-unused-db-tables-3
+              only: placeholder_branch_name
 
       - deploy_experimental_app:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: ttv-167977685-remove-unused-db-tables-3
+              only: placeholder_branch_name
 
       - deploy_experimental_app_client_tls:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: ttv-167977685-remove-unused-db-tables-3
+              only: placeholder_branch_name
 
       - check_circle_against_staging_sha:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -891,28 +891,28 @@ workflows:
             - build_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: tv-167977685-remove-unused-db-tables-3
 
       - deploy_experimental_tasks:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: tv-167977685-remove-unused-db-tables-3
 
       - deploy_experimental_app:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: tv-167977685-remove-unused-db-tables-3
 
       - deploy_experimental_app_client_tls:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: tv-167977685-remove-unused-db-tables-3
 
       - check_circle_against_staging_sha:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -891,28 +891,28 @@ workflows:
             - build_migrations
           filters:
             branches:
-              only: tv-167977685-remove-unused-db-tables-3
+              only: ttv-167977685-remove-unused-db-tables-3
 
       - deploy_experimental_tasks:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: tv-167977685-remove-unused-db-tables-3
+              only: ttv-167977685-remove-unused-db-tables-3
 
       - deploy_experimental_app:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: tv-167977685-remove-unused-db-tables-3
+              only: ttv-167977685-remove-unused-db-tables-3
 
       - deploy_experimental_app_client_tls:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: tv-167977685-remove-unused-db-tables-3
+              only: ttv-167977685-remove-unused-db-tables-3
 
       - check_circle_against_staging_sha:
           requires:

--- a/migrations/20190919173143_delete_hhg_tables_data.up.sql
+++ b/migrations/20190919173143_delete_hhg_tables_data.up.sql
@@ -1,0 +1,81 @@
+select * into temp tempsit from storage_in_transits;
+select * into temp tempshipment from shipments;
+select * into temp tempsli from shipment_line_items;
+select m.id as move_id, o.id as order_id, o.uploaded_orders_id, sm.id as service_member_id, sm.residential_address_id, sm.backup_mailing_address_id into temp tempsom
+	from service_members sm
+		inner join orders o on sm.id = o.service_member_id
+		inner join moves m on m.orders_id = o.id
+		WHERE m.selected_move_type = 'HHG'
+		and m.id NOT IN (SELECT move_id FROM personally_procured_moves);
+select * into temp tempdc from distance_calculations where id IN (select shipping_distance_id from tempshipment);
+
+DROP TABLE IF EXISTS shipment_line_items;
+DROP TABLE IF EXISTS shipment_line_item_dimensions;
+DROP TABLE IF EXISTS shipment_offers;
+DROP TABLE IF EXISTS service_agents;
+DROP TABLE IF EXISTS shipment_recalculates;
+DROP TABLE IF EXISTS shipment_recalculate_logs;
+DROP TABLE IF EXISTS storage_in_transits;
+DROP TABLE IF EXISTS storage_in_transit_number_trackers;
+DROP TABLE IF EXISTS gbl_number_trackers;
+DROP TABLE IF EXISTS blackout_dates;
+
+ALTER TABLE move_documents DROP COLUMN IF EXISTS shipment_id;
+ALTER TABLE invoices DROP COLUMN IF EXISTS shipment_id;
+ALTER TABLE signed_certifications DROP COLUMN IF EXISTS shipment_id;
+
+-- remove tsp_users table and disable associated tsp_users in users table
+-- make sure that users that are also office users are not disabled
+UPDATE USERS SET disabled = TRUE
+	WHERE id IN (select user_id from tsp_users where user_id is not null)
+		and id NOT IN (select user_id from office_users where user_id is not null)
+		and id NOT IN (select user_id from admin_users where user_id is not null);
+DROP TABLE tsp_users;
+
+-- removing hhg moves
+-- documents
+DELETE FROM weight_ticket_set_documents WHERE move_document_id IN (SELECT md.id FROM move_documents md INNER JOIN moves m ON m.id = md.move_id AND m.selected_move_type = 'HHG');
+DELETE FROM moving_expense_documents WHERE move_document_id IN (SELECT md.id FROM move_documents md INNER JOIN moves m ON m.id = md.move_id AND m.selected_move_type = 'HHG');
+
+DELETE FROM move_documents WHERE move_id IN (SELECT id FROM moves where selected_move_type = 'HHG');
+DELETE FROM signed_certifications WHERE move_id IN (SELECT id FROM moves where selected_move_type = 'HHG');
+
+-- finally dropping the shipments
+DROP TABLE IF EXISTS shipments;
+
+-- Dropping moves that are select HHG
+-- make sure that the moves don't have PPMs previously
+DELETE FROM moves WHERE orders_id in (select id from orders WHERE service_member_id IN (select service_member_id from tempsom));
+
+
+-- service members
+DELETE FROM access_codes WHERE service_member_id IN (select service_member_id from tempsom);
+DELETE FROM backup_contacts WHERE service_member_id IN (select service_member_id from tempsom);
+DELETE FROM orders WHERE service_member_id IN (select service_member_id from tempsom);
+
+-- delete service member order document
+-- might be some data left from the service member so delete based on service member id
+DELETE FROM uploads WHERE document_id IN (select id from documents where service_member_id in (select service_member_id from tempsom));
+DELETE FROM documents WHERE service_member_id IN (select service_member_id from tempsom);
+
+-- delete notifications before service member
+DELETE FROM notifications WHERE service_member_id IN (select service_member_id from tempsom);
+-- finally delete service members
+DELETE FROM service_members WHERE id IN (select service_member_id from tempsom);
+
+-- delete distance calcs
+DELETE FROM distance_calculations where id IN (select storage_in_transit_distance_id from tempsit);
+DELETE FROM distance_calculations where id IN (select shipping_distance_id from tempshipment);
+
+-- delete addresses
+DELETE FROM addresses where id IN (select warehouse_address_id from tempsit);
+DELETE FROM addresses where id IN (select pickup_address_id from tempshipment);
+DELETE FROM addresses where id IN (select secondary_pickup_address_id from tempshipment);
+DELETE FROM addresses where id IN (select delivery_address_id from tempshipment);
+DELETE FROM addresses where id IN (select partial_sit_delivery_address_id from tempshipment);
+DELETE FROM addresses where id IN (select destination_address_on_acceptance_id from tempshipment);
+DELETE FROM addresses where id IN (select address_id from tempsli);
+DELETE FROM addresses where id IN (select residential_address_id from tempsom);
+DELETE FROM addresses where id IN (select backup_mailing_address_id from tempsom);
+DELETE FROM addresses where id IN (select dc.origin_address_id from tempdc dc right join duty_stations ds on dc.origin_address_id = ds.address_id where ds.address_id is null);
+DELETE FROM addresses where id IN (select dc.destination_address_id from tempdc dc right join duty_stations ds on dc.destination_address_id = ds.address_id where ds.address_id is null);

--- a/migrations_manifest.txt
+++ b/migrations_manifest.txt
@@ -352,5 +352,6 @@
 20190905183034_disable_truss_tsp_user.up.sql
 20190906223934_remove_oia_pn.up.fizz
 20190912202709_update-duty-station-names.up.sql
+20190919173143_delete_hhg_tables_data.up.sql
 20190913205819_delete_dup_duty_stations.up.sql
 20190917162117_update_duty_station_names.up.sql

--- a/pkg/migrate/SplitStatements_test.go
+++ b/pkg/migrate/SplitStatements_test.go
@@ -79,6 +79,8 @@ func TestSplitStatementsLoop(t *testing.T) {
 	go SplitStatements(lines, statements, wait)
 
 	expectedStmt := []string{
+		"CREATE TABLE IF NOT EXISTS shipments (id serial PRIMARY KEY);",
+		"ALTER TABLE invoices ADD COLUMN IF NOT EXISTS shipment_id uuid NULL;",
 		"LOCK TABLE invoice_number_trackers, invoices IN SHARE MODE;",
 		"DELETE\nFROM invoice_number_trackers;",
 		`DO $do$
@@ -144,6 +146,8 @@ invoice_count := invoice_count + 1;
 END LOOP;
 END LOOP;
 END $do$;`,
+		"ALTER TABLE invoices DROP COLUMN IF EXISTS shipment_id;",
+		"DROP TABLE IF EXISTS shipments;",
 	}
 
 	i := 0
@@ -151,5 +155,5 @@ END $do$;`,
 		require.Equal(t, expectedStmt[i], stmt)
 		i++
 	}
-	require.Equal(t, i, 3)
+	require.Equal(t, i, 7)
 }

--- a/pkg/migrate/fixtures/deleteUsers.sql
+++ b/pkg/migrate/fixtures/deleteUsers.sql
@@ -1,4 +1,3 @@
 -- Removes hackerone users from tsp and office users tables.
 
-DELETE FROM public.tsp_users where email like '%(@hackerone.com|@wearehackerone.com|@managed.hackerone.com)';
 DELETE FROM public.office_users where email like '%(@hackerone.com|@wearehackerone.com|@managed.hackerone.com)';

--- a/pkg/migrate/fixtures/loop.sql
+++ b/pkg/migrate/fixtures/loop.sql
@@ -1,3 +1,9 @@
+-- Shipment table no longer exists
+-- Creating the table here as a workaround for now
+-- Will re-visit to squash migrations
+CREATE TABLE IF NOT EXISTS shipments (id serial PRIMARY KEY);
+ALTER TABLE invoices ADD COLUMN IF NOT EXISTS shipment_id uuid NULL;
+
 -- Lock both the invoice_number_trackers and invoices tables to prevent concurrent updates.  Just
 -- trying to prevent another invoice number from landing in the middle of this transaction.
 LOCK TABLE invoice_number_trackers, invoices IN SHARE MODE;
@@ -86,3 +92,10 @@ DO $do$
           END LOOP;
       END LOOP;
   END $do$;
+
+-- Shipment table no longer exists
+-- Creating the table at the top as a workaround for now
+-- Removing the table and column after we're done
+-- Will re-visit to squash migrations
+ALTER TABLE invoices DROP COLUMN IF EXISTS shipment_id;
+DROP TABLE IF EXISTS shipments;


### PR DESCRIPTION
## Description

Try number 3. Building off of https://github.com/transcom/mymove/pull/2704.

Drops unused database tables and deletes records for the HHG mothball work.

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Code Review Verification Steps

* Any new migrations/schema changes:
  * [x] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/tree/master/docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
  * [x] Secure migrations have been tested using `scripts/run-prod-migrations`
* [x] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/167977685) for this change