### PR TITLE
Fixing server_run_debug target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -317,7 +317,7 @@ server_run_default: .check_hosts.stamp .check_go_version.stamp .check_gopath.sta
 
 .PHONY: server_run_debug
 server_run_debug: ## Debug the server
-	$(AWS_VAULT) dlv debug cmd/milmove/main.go cmd/milmove/logger.go -- serve
+	$(AWS_VAULT) dlv debug cmd/milmove/*.go -- serve
 
 .PHONY: build_tools
 build_tools: server_deps \


### PR DESCRIPTION
## Description

This PR fixes the outdated delve command for milmove server.

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

Nope

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
$ make server_run_debug
dlv debug cmd/milmove/*.go -- serve
Type 'help' for list of commands.
(dlv)

```

## Code Review Verification Steps

* [x] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/tree/master/docs/backend.md#logging)
* [x] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/tree/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/tree/master/docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
  * [ ] Secure migrations have been tested using `scripts/run-prod-migrations`
* [x] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

