### PR TITLE
Revert "Remove Liz from experimental, staging, and prod"

### DIFF
--- a/local_migrations/20190925190920_disable_liz.up.sql
+++ b/local_migrations/20190925190920_disable_liz.up.sql
@@ -1,4 +1,0 @@
--- Local test migration.
--- This will be run on development environments.
--- It should mirror what you intend to apply on prod/staging/experimental
--- DO NOT include any sensitive data.

--- a/migrations_manifest.txt
+++ b/migrations_manifest.txt
@@ -354,4 +354,3 @@
 20190912202709_update-duty-station-names.up.sql
 20190913205819_delete_dup_duty_stations.up.sql
 20190917162117_update_duty_station_names.up.sql
-20190925190920_disable_liz.up.sql


### PR DESCRIPTION
Reverts transcom/mymove#2734

This migration assumed the tsp_users table still existed. It does not, as of [this commit](https://github.com/transcom/mymove/commit/746fd86e8441967b8626c30d8b0bab1df4319560).