### PR TITLE
Change alert for missing full weight ticket

### DIFF
--- a/cypress/integration/mymove/ppmCloseout.js
+++ b/cypress/integration/mymove/ppmCloseout.js
@@ -395,9 +395,7 @@ function serviceMemberSubmitsWeightsTicketsWithoutReceipts() {
     'Contact your local Transportation Office (PPPO) to let them know you’re missing this weight ticket. For now, keep going and enter the info you do have.',
   );
   cy.get('input[name="missingFullWeightTicket"]+label').click();
-  cy.get('[data-cy=full-warning]').contains(
-    'Contact your local Transportation Office (PPPO) to let them know you’re missing this weight ticket. For now, keep going and enter the info you do have.',
-  );
+  cy.get('[data-cy=full-warning]').contains('You can’t get paid without a full weight ticket.');
   cy.get('input[name="weight_ticket_date"]')
     .type('6/2/2018{enter}')
     .blur();

--- a/src/scenes/Moves/Ppm/WeightTicket.jsx
+++ b/src/scenes/Moves/Ppm/WeightTicket.jsx
@@ -22,6 +22,7 @@ import faQuestionCircle from '@fortawesome/fontawesome-free-solid/faQuestionCirc
 import { selectPPMCloseoutDocumentsForMove } from 'shared/Entities/modules/movingExpenseDocuments';
 import { getMoveDocumentsForMove } from 'shared/Entities/modules/moveDocuments';
 import { withContext } from 'shared/AppContext';
+import { loadDutyStationTransportationOffice } from 'shared/TransportationOffices/ducks';
 
 import { getNextPage } from './utility';
 import DocumentsUploaded from './PaymentReview/DocumentsUploaded';
@@ -75,6 +76,7 @@ class WeightTicket extends Component {
   componentDidMount() {
     const { moveId } = this.props;
     this.props.getMoveDocumentsForMove(moveId);
+    this.props.loadDutyStationTransportationOffice(this.props.dutyStationId);
   }
 
   get isCarTrailer() {
@@ -195,7 +197,7 @@ class WeightTicket extends Component {
       missingDocumentation,
       isValidTrailer,
     } = this.state;
-    const { handleSubmit, submitting, schema, weightTicketSets, invalid, moveId } = this.props;
+    const { handleSubmit, submitting, schema, weightTicketSets, invalid, moveId, transportationOffice } = this.props;
     const nextBtnLabel =
       additionalWeightTickets === 'Yes' ? nextBtnLabels.SaveAndAddAnother : nextBtnLabels.SaveAndContinue;
     const weightTicketSetOrdinal = formatToOrdinal(weightTicketSets.length + 1);
@@ -407,8 +409,10 @@ class WeightTicket extends Component {
                     {missingFullWeightTicket && (
                       <div data-cy="full-warning">
                         <Alert type="warning">
-                          Contact your local Transportation Office (PPPO) to let them know you’re missing this weight
-                          ticket. For now, keep going and enter the info you do have.
+                          <b>You can’t get paid without a full weight ticket.</b> See what you can do to find it,
+                          because without certified documentation of the weight of your belongings, we can’t pay you
+                          your incentive. Call the {transportationOffice.name} Transportation Office at{' '}
+                          {transportationOffice.phone_lines[0]} if you have any questions.
                         </Alert>
                       </div>
                     )}
@@ -475,6 +479,9 @@ WeightTicket.propTypes = {
 
 function mapStateToProps(state, ownProps) {
   const moveId = ownProps.match.params.moveId;
+  const dutyStationId = get(state, 'serviceMember.currentServiceMember.current_station.id');
+  const officeId = get(state, `transportationOffices.byDutyStationId[${dutyStationId}]`);
+
   return {
     moveId: moveId,
     formValues: getFormValues(formName)(state),
@@ -483,12 +490,15 @@ function mapStateToProps(state, ownProps) {
     schema: get(state, 'swaggerInternal.spec.definitions.CreateWeightTicketDocumentsPayload', {}),
     currentPpm: get(state, 'ppm.currentPpm'),
     weightTicketSets: selectPPMCloseoutDocumentsForMove(state, moveId, ['WEIGHT_TICKET_SET']),
+    transportationOffice: get(state, `transportationOffices.byId.${officeId}`),
+    dutyStationId: dutyStationId,
   };
 }
 
 const mapDispatchToProps = {
   getMoveDocumentsForMove,
   createWeightTicketSetDocument,
+  loadDutyStationTransportationOffice,
 };
 
 export default withContext(


### PR DESCRIPTION
## Description

Adjusts the text one the warning alert being used when someone checks that they don't have a full weight ticket in that portion of the customer facing app. Screenshot included below. 

## Setup

No special setup needed. Just need to login as a customer and initiate making a payment request. Instead of uploading a full weight ticket, check the box indicating you don't have that documentation.

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/tree/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/tree/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/tree/master/docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
  * [ ] Secure migrations have been tested using `scripts/run-prod-migrations`
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/168700566) for this change

## Screenshots

![image](https://user-images.githubusercontent.com/4325613/65774437-dbc84f00-e103-11e9-929b-be3822c6fc01.png)

