### PR TITLE
Fix broken call to stat command

### DIFF
--- a/scripts/prereqs
+++ b/scripts/prereqs
@@ -24,8 +24,8 @@ has docker "Get Docker CE for Mac from https://download.docker.com/mac/stable/Do
 has psql "brew install postgresql"
 has go-bindata "brew install go-bindata"
 has node "brew install node"
-has pkcs11-tool "brew install opensc; chmod go+w /usr/local/lib/pkcs11-tool; brew link opensc"
-has pkcs15-tool "brew install opensc; chmod go+w /usr/local/lib/pkcs15-tool; brew link opensc"
+has pkcs11-tool "brew install opensc; chmod go+w /usr/local/bin/pkcs11-tool; brew link opensc"
+has pkcs15-tool "brew install opensc; chmod go+w /usr/local/bin/pkcs15-tool; brew link opensc"
 
 # macOS only
 if [[ $(uname -s) = Darwin ]]; then

--- a/scripts/upload-secure-migration
+++ b/scripts/upload-secure-migration
@@ -48,7 +48,7 @@ readonly production_migration_file="$1"
 # Ensure the file is below the limit for upload of 250MB for anti-virus
 # Files larger than this size will not scan and thus will not be available for streaming download
 # to the migration container.
-FILESIZE=$(stat -f%z "${1}")
+FILESIZE=$(/usr/bin/stat -f%z "${1}")
 # 250MB in bytes
 BYTES_IN_MB=1048576
 MAX_FILESIZE=$((250 * "${BYTES_IN_MB}" ))


### PR DESCRIPTION
## Description

Running the `upload-secure-migration` caused the following error. This pr fixes it.

> stat: invalid option -- ‘%’
> Try ‘stat --help’ for more information.

## Reviewer Notes

I'm not sure if there is another environment where the original stat call works but the new one will fail. If so let me know so I can add a check and select between the two.

## Setup

Upload a secure migration

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
