### PR TITLE
Adjust the SIT related text on the move review screen

### DIFF
--- a/src/scenes/Review/PPMShipmentSummary.jsx
+++ b/src/scenes/Review/PPMShipmentSummary.jsx
@@ -34,10 +34,12 @@ class PPMShipmentSummary extends Component {
     const editWeightAddress = movePath + '/edit-weight';
 
     const privateStorageString = get(ppm, 'estimated_storage_reimbursement')
-      ? `(spend up to ${estimated_storage_reimbursement} on private storage)`
+      ? `= ${estimated_storage_reimbursement} estimated reimbursement`
       : '';
     const sitDisplay = get(ppm, 'has_sit', false)
-      ? `${ppm.days_in_storage} days ${privateStorageString}`
+      ? `${ppm.weight_estimate && ppm.weight_estimate.toLocaleString()} lbs for ${
+          ppm.days_in_storage
+        } days ${privateStorageString}`
       : 'Not requested';
 
     return (


### PR DESCRIPTION
## Description

This PR makes an adjustment to the text that's generated in the customer move review screen when storage time is indicated by them. It now should match this formatting: ```
[9,250] lbs for [15] days = [$2584.12] estimated reimbursement```

## Setup

No special steps, other than going through the wizard to set up a move, indicating along the way that storage is needed.

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/tree/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/tree/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/tree/master/docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
  * [ ] Secure migrations have been tested using `scripts/run-prod-migrations`
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](tbd) for this change
* [this article](tbd) explains more about the approach used.

## Screenshots

![image](https://user-images.githubusercontent.com/4325613/65919304-8610d280-e3a1-11e9-8d2d-6f99b32e766e.png)

