### PR TITLE
Limit the number of tests to run in parallel to 8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -376,7 +376,8 @@ mocks_generate: bin/mockery ## Generate mockery mocks for tests
 server_test: server_deps db_test_reset db_test_migrate ## Run server unit tests
 	# Don't run tests in /cmd or /pkg/gen/ & pass `-short` to exclude long running tests
 	# Disable test caching with `-count 1` - caching was masking local test failures
-	DB_PORT=$(DB_PORT_TEST) go test -count 1 -short $$(go list ./... | grep -v \\/pkg\\/gen\\/ | grep -v \\/cmd\\/)
+	# Limit the maximum number of tests to run in parallel to 8.
+	DB_PORT=$(DB_PORT_TEST) go test -parallel 8 -count 1 -short $$(go list ./... | grep -v \\/pkg\\/gen\\/ | grep -v \\/cmd\\/)
 
 server_test_build:
 	# Try to compile tests, but don't run them.

--- a/migrations_manifest.txt
+++ b/migrations_manifest.txt
@@ -352,6 +352,6 @@
 20190905183034_disable_truss_tsp_user.up.sql
 20190906223934_remove_oia_pn.up.fizz
 20190912202709_update-duty-station-names.up.sql
-20190919173143_delete_hhg_tables_data.up.sql
 20190913205819_delete_dup_duty_stations.up.sql
 20190917162117_update_duty_station_names.up.sql
+20190919173143_delete_hhg_tables_data.up.sql


### PR DESCRIPTION
## Description

We're seeing out-of-memory issues with CircleCI in the `server_test` job. This ought to free up memory for us.

https://golang.org/pkg/cmd/go/internal/test/