### PR TITLE
Cg goproxy for circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -224,6 +224,8 @@ jobs:
       - run:
           name: Install dependencies
           command: for i in $(seq 1 5); do go get ./... && s=0 && break || s=$? && sleep 5; done; (exit $s)
+          environment:
+            GOPROXY: https://gocenter.io
       - save_cache:
           key: go-mod-sources-v2-{{ checksum "go.sum" }}
           paths:

--- a/.envrc
+++ b/.envrc
@@ -72,6 +72,9 @@ fi
 # locally in the ~/.cache/pre-commit/repo*/ directories.
 export GO111MODULE=auto
 
+# Enable a proxy service for getting dependencies
+export GOPROXY=https://gocenter.io
+
 # Capture the root directory of the project. This works even if someone `cd`s
 # directly into a subdirectory.
 export MYMOVE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"


### PR DESCRIPTION
## Description

I've been using `GOPROXY` for two months and have had a better experience locally getting dependencies. I think this is a good solution to fix problems for other developers and to fix problems getting deps in CircleCI. 