### PR TITLE
Enable test result collection for go tests in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -407,9 +407,9 @@ jobs:
           command: |
             echo 'export LOGIN_GOV_SECRET_KEY=$(echo $E2E_LOGIN_GOV_SECRET_KEY | base64 --decode)' >> $BASH_ENV
             source $BASH_ENV
-            mkdir -p test-results
-            make server_test_standalone | tee test-results/go-test.out
-            go-junit-report < test-results/go-test.out > test-results/go-test-report.xml
+            mkdir -p test-results/gotest
+            make server_test_standalone | tee test-results/gotest/go-test.out
+            go-junit-report < test-results/gotest/go-test.out > test-results/gotest/go-test-report.xml
           environment:
             DB_PASSWORD: mysecretpassword
             DB_USER: postgres

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -408,8 +408,9 @@ jobs:
             echo 'export LOGIN_GOV_SECRET_KEY=$(echo $E2E_LOGIN_GOV_SECRET_KEY | base64 --decode)' >> $BASH_ENV
             source $BASH_ENV
             mkdir -p tmp/test-results/gotest
+            # setup a trap incase the tests fail, we still want to generate the report
+            trap "go-junit-report < tmp/test-results/gotest/go-test.out >  tmp/test-results/gotest/go-test-report.xml" EXIT
             make server_test_standalone | tee tmp/test-results/gotest/go-test.out
-            go-junit-report < tmp/test-results/gotest/go-test.out > tmp/test-results/gotest/go-test-report.xml
           environment:
             DB_PASSWORD: mysecretpassword
             DB_USER: postgres

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -407,9 +407,9 @@ jobs:
           command: |
             echo 'export LOGIN_GOV_SECRET_KEY=$(echo $E2E_LOGIN_GOV_SECRET_KEY | base64 --decode)' >> $BASH_ENV
             source $BASH_ENV
-            mkdir -p test-results/gotest
-            make server_test_standalone | tee test-results/gotest/go-test.out
-            go-junit-report < test-results/gotest/go-test.out > test-results/gotest/go-test-report.xml
+            mkdir -p tmp/test-results/gotest
+            make server_test_standalone | tee tmp/test-results/gotest/go-test.out
+            go-junit-report < tmp/test-results/gotest/go-test.out > tmp/test-results/gotest/go-test-report.xml
           environment:
             DB_PASSWORD: mysecretpassword
             DB_USER: postgres
@@ -424,7 +424,7 @@ jobs:
             MIGRATION_MANIFEST: "/home/circleci/transcom/mymove/migrations_manifest.txt"
             SERVE_API_INTERNAL: true
       - store_artifacts:
-          path: ~/transcom/mymove/test-results
+          path: ~/transcom/mymove/tmp/test-results
           destination: test-results
       - store_test_results:
           path: test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -387,6 +387,10 @@ jobs:
           keys:
             - go-mod-sources-v2-{{ checksum "go.sum" }}
       - run:
+          # This will eventually need to move to the base circleci image, but for now it is here for testing
+          name: Install go-junit-report
+          command: go get -u github.com/jstemmer/go-junit-report
+      - run:
           # This is needed to use `psql` to clone the DB for parallel server tests
           name: Install postgres client
           command: |
@@ -403,7 +407,9 @@ jobs:
           command: |
             echo 'export LOGIN_GOV_SECRET_KEY=$(echo $E2E_LOGIN_GOV_SECRET_KEY | base64 --decode)' >> $BASH_ENV
             source $BASH_ENV
-            make server_test_standalone
+            mkdir -p test-results
+            make server_test_standalone | tee test-results/go-test.out
+            go-junit-report < test-results/go-test.out > test-results/go-test-report.xml
           environment:
             DB_PASSWORD: mysecretpassword
             DB_USER: postgres
@@ -417,6 +423,11 @@ jobs:
             MIGRATION_PATH: "file:///home/circleci/transcom/mymove/local_migrations;file:///home/circleci/transcom/mymove/migrations"
             MIGRATION_MANIFEST: "/home/circleci/transcom/mymove/migrations_manifest.txt"
             SERVE_API_INTERNAL: true
+      - store_artifacts:
+          path: ~/transcom/mymove/test-results
+          destination: test-results
+      - store_test_results:
+          path: test-results
       - announce_failure
 
   # `server_test_coverage` runs code coverage and submits it to CodeClimate

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -427,7 +427,7 @@ jobs:
           path: ~/transcom/mymove/tmp/test-results
           destination: test-results
       - store_test_results:
-          path: test-results
+          path: ~/transcom/mymove/tmp/test-results
       - announce_failure
 
   # `server_test_coverage` runs code coverage and submits it to CodeClimate

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -387,9 +387,8 @@ jobs:
           keys:
             - go-mod-sources-v2-{{ checksum "go.sum" }}
       - run:
-          # This will eventually need to move to the base circleci image, but for now it is here for testing
-          name: Install go-junit-report
-          command: go get -u github.com/jstemmer/go-junit-report
+          name: Build Go Junit Report
+          command: make bin/go-junit-report
       - run:
           # This is needed to use `psql` to clone the DB for parallel server tests
           name: Install postgres client
@@ -409,7 +408,7 @@ jobs:
             source $BASH_ENV
             mkdir -p tmp/test-results/gotest
             # setup a trap incase the tests fail, we still want to generate the report
-            trap "go-junit-report < tmp/test-results/gotest/go-test.out >  tmp/test-results/gotest/go-test-report.xml" EXIT
+            trap "bin/go-junit-report < tmp/test-results/gotest/go-test.out >  tmp/test-results/gotest/go-test-report.xml" EXIT
             make server_test_standalone | tee tmp/test-results/gotest/go-test.out
           environment:
             DB_PASSWORD: mysecretpassword

--- a/Makefile
+++ b/Makefile
@@ -193,6 +193,7 @@ bin/soda: .check_go_version.stamp .check_gopath.stamp
 bin/swagger: .check_go_version.stamp .check_gopath.stamp
 	go build -ldflags "$(LDFLAGS)" -o bin/swagger github.com/go-swagger/go-swagger/cmd/swagger
 
+# No static linking / $(LDFLAGS) because go-junit-report is only used for building the CirlceCi test report
 bin/go-junit-report: .check_go_version.stamp .check_gopath.stamp
 	go build -o bin/go-junit-report github.com/jstemmer/go-junit-report
 

--- a/Makefile
+++ b/Makefile
@@ -389,6 +389,7 @@ server_test_standalone: ## Run server unit tests with no deps
 	# Don't run tests in /cmd or /pkg/gen/ & pass `-short` to exclude long running tests
 	# Disable test caching with `-count 1` - caching was masking local test failures
 	# Limit the maximum number of tests to run in parallel to 8.
+	# Add verbose (-v) so go-junit-report can parse it for CircleCI results
 	DB_PORT=$(DB_PORT_TEST) go test -parallel 8 -v -count 1 -short $$(go list ./... | grep -v \\/pkg\\/gen\\/ | grep -v \\/cmd\\/)
 
 server_test_build:

--- a/Makefile
+++ b/Makefile
@@ -193,6 +193,9 @@ bin/soda: .check_go_version.stamp .check_gopath.stamp
 bin/swagger: .check_go_version.stamp .check_gopath.stamp
 	go build -ldflags "$(LDFLAGS)" -o bin/swagger github.com/go-swagger/go-swagger/cmd/swagger
 
+bin/go-junit-report: .check_go_version.stamp .check_gopath.stamp
+	go build -o bin/go-junit-report github.com/jstemmer/go-junit-report
+
 # No static linking / $(LDFLAGS) because mockery is only used for testing
 bin/mockery: .check_go_version.stamp .check_gopath.stamp
 	go build -o bin/mockery github.com/vektra/mockery/cmd/mockery

--- a/go.mod
+++ b/go.mod
@@ -48,6 +48,7 @@ require (
 	github.com/jackc/pgx v3.6.0+incompatible // indirect
 	github.com/jessevdk/go-flags v1.4.0
 	github.com/jmoiron/sqlx v1.2.0
+	github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024
 	github.com/jung-kurt/gofpdf v1.12.1
 	github.com/leodido/go-urn v1.1.0
 	github.com/lib/pq v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -303,6 +303,8 @@ github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht
 github.com/joho/godotenv v1.3.0 h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=
 github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
+github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024 h1:rBMNdlhTLzJjJSDIjNEXX1Pz3Hmwmz91v+zycvx9PJc=
+github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=

--- a/pkg/tools/tools.go
+++ b/pkg/tools/tools.go
@@ -33,4 +33,7 @@ import (
 	_ "github.com/stretchr/objx"
 	_ "github.com/tealeg/xlsx"
 	_ "gopkg.in/go-playground/validator.v9"
+
+	// Install go-junit-report for CirclCI test result report generation
+	_ "github.com/jstemmer/go-junit-report"
 )


### PR DESCRIPTION
## Description

The server_test job seems to fail irregularly with various test failures. In an effort to identify what's going on this PR changes server_test to output the test results so that CircleCI can read and collect the results. Once we start collecting these results we can see if the failures are common to specific tests or not

## Reviewer Notes

This change makes `make server_test` run `go test -v` instead of just `go test` which means the output is different and more verbose. If you feel this is confusing to other engineers on the project we can do something else, like add another make command for running and outputting the results.

Second, this is to start collecting data, not resolve the problem.

## Setup

This is primarily a change to CircleCI

Run `make server_test` and see the output is different
See build collect results as artifacts, example: https://circleci.com/gh/transcom/mymove/171523#artifacts/containers/0 

## Code Review Verification Steps

* [ ] Request review from a member of a different team.

## References

* [#168881057](https://www.pivotaltracker.com/story/show/168881057) for this change
* [Slack Conversation for Context 1](https://defensedigitalservice.slack.com/archives/G8HJRJBMZ/p1569890174218500)
* [Slack Conversation for Context 2](https://defensedigitalservice.slack.com/archives/G8P7UD05U/p1569882968251200)