### PR TITLE
CSS changes to prevent error message crashing into text below

### DIFF
--- a/src/shared/JsonSchemaForm/index.css
+++ b/src/shared/JsonSchemaForm/index.css
@@ -55,12 +55,11 @@ h2.sm-heading-2 {
 }
 
 .usa-input-error-message {
-  position: absolute;
   max-width: 460px;
 }
 
 .usa-input-error-long-message {
-  padding-bottom: 4rem;
+  padding-bottom: 1.8rem;
 }
 
 @media only screen and (max-width: 419px) {


### PR DESCRIPTION
## Description

Prevent error messages from overlapping/being too close to the text below. Check screenshots for more details.

## Setup

```sh
make server_run
make client_run
```

## Code Review Verification Steps

* [x] There are no aXe warnings for UI.
* [x] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] User facing changes have been reviewed by design.
* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/168043640) for this change

## Screenshots

Before:
![image](https://user-images.githubusercontent.com/1522549/66014255-00655380-e483-11e9-87e0-17c4fe9e0efa.png)

After:
![image](https://user-images.githubusercontent.com/1522549/66014268-08bd8e80-e483-11e9-9261-c7a577654da9.png)
