### PR TITLE
Ttv 168758755 fix storybook build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -895,9 +895,7 @@ workflows:
       - build_storybook_app:
           requires:
             - anti_virus
-            - pre_deps_golang
             - pre_deps_yarn
-            - acceptance_tests_local # don't bother building and pushing the application if it won't even start properly
 
       - build_tools:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -534,7 +534,7 @@ jobs:
           repo: app
       - announce_failure
 
-  # `build_app` builds the application container and pushes to the container repository
+  # `build_storybook_app` builds the storybook application container and pushes to the container repository
   build_storybook_app:
     executor: mymove_medium
     steps:
@@ -896,6 +896,13 @@ workflows:
           #     ignore: placeholder_branch_name
 
       - build_app:
+          requires:
+            - anti_virus
+            - pre_deps_golang
+            - pre_deps_yarn
+            - acceptance_tests_local # don't bother building and pushing the application if it won't even start properly
+
+      - build_storybook_app:
           requires:
             - anti_virus
             - pre_deps_golang

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -556,8 +556,8 @@ jobs:
       - run: make storybook_build
       - build_tag_push:
           dockerfile: Dockerfile
-          tag: ppp:web-dev
-          repo: app
+          tag: ppp:web-dev-storybook
+          repo: app-storybook
       - announce_failure
 
   # `build_migrations` builds the migrations container and pushes to the container repository

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -543,21 +543,11 @@ jobs:
           docker_layer_caching: true
       - restore_cache:
           keys:
-            - go-mod-sources-v2-{{ checksum "go.sum" }}
-      - restore_cache:
-          keys:
             - v2-cache-yarn-v2-{{ checksum "yarn.lock" }}
       - restore_cache:
           keys:
             - v2-mymove-node-modules-{{ checksum "yarn.lock" }}
-      - run: make bin/chamber
-      - run: make bin/rds-combined-ca-bundle.pem
-      - run: make client_build
       - run: make storybook_build
-      - build_tag_push:
-          dockerfile: Dockerfile
-          tag: ppp:web-dev-storybook
-          repo: app-storybook
       - announce_failure
 
   # `build_migrations` builds the migrations container and pushes to the container repository

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -534,6 +534,32 @@ jobs:
           repo: app
       - announce_failure
 
+  # `build_app` builds the application container and pushes to the container repository
+  build_storybook_app:
+    executor: mymove_medium
+    steps:
+      - checkout
+      - setup_remote_docker:
+          docker_layer_caching: true
+      - restore_cache:
+          keys:
+            - go-mod-sources-v2-{{ checksum "go.sum" }}
+      - restore_cache:
+          keys:
+            - v2-cache-yarn-v2-{{ checksum "yarn.lock" }}
+      - restore_cache:
+          keys:
+            - v2-mymove-node-modules-{{ checksum "yarn.lock" }}
+      - run: make bin/chamber
+      - run: make bin/rds-combined-ca-bundle.pem
+      - run: make client_build
+      - run: make storybook_build
+      - build_tag_push:
+          dockerfile: Dockerfile
+          tag: ppp:web-dev
+          repo: app
+      - announce_failure
+
   # `build_migrations` builds the migrations container and pushes to the container repository
   build_migrations:
     executor: mymove_small

--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -1,0 +1,19 @@
+// remove eslint from the webpack configuration to use the create-react-app eslint config
+const removeEsLint = exports => {
+  return (
+    exports.module.rules
+      .filter(e => e.use && e.use.some(e => e.options && void 0 !== e.options.useEslintrc))
+      .forEach(s => {
+        exports.module.rules = exports.module.rules.filter(e => e !== s);
+      }),
+    exports
+  );
+};
+
+module.exports = async ({ config, mode }) => {
+  // remove eslint from config
+  config = removeEsLint(config);
+
+  // return the new config
+  return config;
+};

--- a/Makefile
+++ b/Makefile
@@ -848,8 +848,8 @@ spellcheck: .client_deps.stamp ## Run interactive spellchecker
 storybook: ## Start the storybook server
 	yarn run storybook
 
-.PHONY: build_storybook
-build_storybook: ## Build static storybook site
+.PHONY: storybook_build
+storybook_build: ## Build static storybook site
 	yarn run build-storybook
 
 #


### PR DESCRIPTION
## Description

Fixes the `storybook` build and adds a new step in CircleCi to make sure the storybook build passes.

## Reviewer Notes

- I renamed the Makefile cmd `build_storybook` to `storybook_build` to stay consistent with our pattern

## Setup

```sh
make client_build
make storybook_build
```

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/168758755) for this change
* [this article](https://stackoverflow.com/questions/58186680/how-disable-eslint-loader-of-storybooks-webpack) explains more about the approach used.