### PR TITLE
Fixed race condition with IAM Postgres Driver

### DIFF
--- a/pkg/iampostgres/iampostgres_test.go
+++ b/pkg/iampostgres/iampostgres_test.go
@@ -33,8 +33,11 @@ func TestEnableIamNilCreds(t *testing.T) {
 		time.NewTicker(1*time.Second),
 		logger)
 	time.Sleep(2 * time.Second)
+
+	iamConfig.currentPassMutex.Lock()
 	t.Logf("Current password: %s", iamConfig.currentIamPass)
 	assert.Equal(iamConfig.currentIamPass, "")
+	iamConfig.currentPassMutex.Unlock()
 
 }
 
@@ -76,20 +79,28 @@ func TestEnableIAMNormal(t *testing.T) {
 		logger)
 
 	time.Sleep(time.Second)
+	iamConfig.currentPassMutex.Lock()
 	assert.Equal(iamConfig.currentIamPass, "abc")
 	t.Logf("Current password: %s", iamConfig.currentIamPass)
+	iamConfig.currentPassMutex.Unlock()
 
 	time.Sleep(2 * time.Second)
+	iamConfig.currentPassMutex.Lock()
 	t.Logf("Current password: %s", iamConfig.currentIamPass)
 	assert.Equal(iamConfig.currentIamPass, "123")
+	iamConfig.currentPassMutex.Unlock()
 
 	time.Sleep(2 * time.Second)
+	iamConfig.currentPassMutex.Lock()
 	t.Logf("Current password: %s", iamConfig.currentIamPass)
 	assert.Equal(iamConfig.currentIamPass, "xyz")
+	iamConfig.currentPassMutex.Unlock()
 
 	time.Sleep(2 * time.Second)
+	iamConfig.currentPassMutex.Lock()
 	t.Logf("Current password: %s", iamConfig.currentIamPass)
 	assert.Equal(iamConfig.currentIamPass, "999")
+	iamConfig.currentPassMutex.Unlock()
 
 }
 


### PR DESCRIPTION
## Description

This PR addresses the issue of having a shared state. This was detected by running `go test` with the `-race` option. More info [here](https://defensedigitalservice.slack.com/archives/G8HJSJE67/p1570203999140700)

The use of a mutex fixed the opportunity to read and write at the same time. Since the context of the mutex is kept extremely small there is no expected impact or deadlocks.

## Reviewer Notes

None

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
cd pkg/iampostgres/
go test -race -v .
```

## Code Review Verification Steps

* [x] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References
* [Pivotal Story](https://github.com/transcom/mymove/pull/2776)

