### PR TITLE
Speed Up server_test with DB magic

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -418,6 +418,7 @@ jobs:
             DB_PORT_TEST: 5433
             DB_PORT: 5432
             DB_NAME: test_db
+            DB_NAME_TEST: test_db
             EIA_KEY: db2522a43820268a41a802a16ae9fd26 # dummy key generated with openssl rand -hex 16
             ENV: test
             ENVIRONMENT: test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -389,15 +389,6 @@ jobs:
       - run:
           name: Build Go Junit Report
           command: make bin/go-junit-report
-      - run:
-          # This is needed to use `psql` to clone the DB for parallel server tests
-          name: Install postgres client
-          command: |
-            # Debian stretch only supports 9.6 client, so add the Postgresql apt repository for 10.x
-            echo "deb http://apt.postgresql.org/pub/repos/apt/ stretch-pgdg main" | sudo tee -a /etc/apt/sources.list.d/pgdg.list
-            wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
-            sudo apt-get -qq update
-            sudo apt-get -qq -y install postgresql-client-10
       - run: echo 'export PATH=${PATH}:~/go/bin:~/transcom/mymove/bin' >> $BASH_ENV
       - run: make bin/milmove
       - run: make db_test_reset
@@ -442,16 +433,6 @@ jobs:
       - restore_cache:
           keys:
             - go-mod-sources-v2-{{ checksum "go.sum" }}
-      - run:
-          # This is needed to use `psql` to test DB connectivity, until the app
-          # itself starts making database connections.
-          name: Install postgres client
-          command: |
-            # Debian stretch only supports 9.6 client, so add the Postgresql apt repository for 10.x
-            echo "deb http://apt.postgresql.org/pub/repos/apt/ stretch-pgdg main" | sudo tee -a /etc/apt/sources.list.d/pgdg.list
-            wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
-            sudo apt-get -qq update
-            sudo apt-get -qq -y install postgresql-client-10
       - run: echo 'export PATH=${PATH}:~/go/bin:~/transcom/mymove/bin' >> $BASH_ENV
       - run:
           name: Setup Code Climate test-reporter

--- a/Makefile
+++ b/Makefile
@@ -394,7 +394,7 @@ server_test_standalone: ## Run server unit tests with no deps
 	# Pass `-short` to exclude long running tests
 	# Disable test caching with `-count 1` - caching was masking local test failures
 ifndef CIRCLECI
-	DB_PORT=$(DB_PORT_TEST) go test -v -count 1 -short $$(go list ./... | grep -v \\/pkg\\/gen\\/ | grep -v \\/cmd\\/ | grep -v mocks)
+	DB_PORT=$(DB_PORT_TEST) go test -count 1 -short $$(go list ./... | grep -v \\/pkg\\/gen\\/ | grep -v \\/cmd\\/ | grep -v mocks)
 else
 	# Limit the maximum number of tests to run in parallel to 8 for CircleCI due to memory constraints.
 	# Add verbose (-v) so go-junit-report can parse it for CircleCI results

--- a/Makefile
+++ b/Makefile
@@ -394,11 +394,11 @@ server_test_standalone: ## Run server unit tests with no deps
 	# Pass `-short` to exclude long running tests
 	# Disable test caching with `-count 1` - caching was masking local test failures
 ifndef CIRCLECI
-	DB_PORT=$(DB_PORT_TEST) go test -count 1 -short $$(go list ./... | grep -v \\/pkg\\/gen\\/ | grep -v \\/cmd\\/ | grep -v mocks)
+	DB_NAME=$(DB_NAME_TEST) DB_PORT=$(DB_PORT_TEST) go test -count 1 -short $$(go list ./... | grep -v \\/pkg\\/gen\\/ | grep -v \\/cmd\\/ | grep -v mocks)
 else
 	# Limit the maximum number of tests to run in parallel to 8 for CircleCI due to memory constraints.
 	# Add verbose (-v) so go-junit-report can parse it for CircleCI results
-	DB_PORT=$(DB_PORT_TEST) go test -v -parallel 8 -count 1 -short $$(go list ./... | grep -v \\/pkg\\/gen\\/ | grep -v \\/cmd\\/ | grep -v mocks)
+	DB_NAME=$(DB_NAME_TEST) DB_PORT=$(DB_PORT_TEST) go test -v -parallel 8 -count 1 -short $$(go list ./... | grep -v \\/pkg\\/gen\\/ | grep -v \\/cmd\\/ | grep -v mocks)
 endif
 
 server_test_build:

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/aws/aws-sdk-go v1.23.21
 	github.com/cockroachdb/apd v1.1.0 // indirect
 	github.com/cockroachdb/cockroach-go v0.0.0-20181001143604-e0a95dfd547c // indirect
-	github.com/codegangsta/envy v0.0.0-20141216192214-4b78388c8ce4
+	github.com/codegangsta/envy v0.0.0-20141216192214-4b78388c8ce4 // indirect
 	github.com/codegangsta/gin v0.0.0-20171026143024-cafe2ce98974
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/disintegration/imaging v1.6.1
@@ -30,7 +30,7 @@ require (
 	github.com/go-playground/locales v0.12.1
 	github.com/go-playground/universal-translator v0.16.0
 	github.com/go-swagger/go-swagger v0.20.2-0.20190910212040-c49ea4ca2112
-	github.com/gobuffalo/envy v1.7.1 // indirect
+	github.com/gobuffalo/envy v1.7.1
 	github.com/gobuffalo/fizz v1.9.5
 	github.com/gobuffalo/flect v0.1.6 // indirect
 	github.com/gobuffalo/logger v1.0.1 // indirect

--- a/pkg/awardqueue/awardqueue_test.go
+++ b/pkg/awardqueue/awardqueue_test.go
@@ -148,10 +148,6 @@ type AwardQueueSuite struct {
 	logger Logger
 }
 
-func (suite *AwardQueueSuite) SetupTest() {
-	suite.DB().TruncateAll()
-}
-
 func TestAwardQueueSuite(t *testing.T) {
 	logger, err := zap.NewDevelopment()
 	if err != nil {

--- a/pkg/dates/calculators_test.go
+++ b/pkg/dates/calculators_test.go
@@ -125,10 +125,6 @@ type DatesSuite struct {
 	testingsuite.PopTestSuite
 }
 
-func (suite *DatesSuite) SetupTest() {
-	suite.DB().TruncateAll()
-}
-
 func TestDatesSuite(t *testing.T) {
 
 	hs := &DatesSuite{

--- a/pkg/db/dbfmt/dbfmt_test.go
+++ b/pkg/db/dbfmt/dbfmt_test.go
@@ -14,10 +14,6 @@ type DBFmtSuite struct {
 	testingsuite.PopTestSuite
 }
 
-func (suite *DBFmtSuite) SetupTest() {
-	suite.DB().TruncateAll()
-}
-
 func TestDBFmtSuite(t *testing.T) {
 	hs := &DBFmtSuite{
 		PopTestSuite: testingsuite.NewPopTestSuite(testingsuite.CurrentPackage()),

--- a/pkg/db/sequence/sequencer_test.go
+++ b/pkg/db/sequence/sequencer_test.go
@@ -13,7 +13,6 @@ type SequenceSuite struct {
 }
 
 func (suite *SequenceSuite) SetupTest() {
-	suite.DB().TruncateAll()
 	err := suite.DB().RawQuery("CREATE SEQUENCE IF NOT EXISTS test_sequence;").Exec()
 	suite.NoError(err, "Error creating test sequence")
 	err = suite.DB().RawQuery("SELECT setval($1, 1);", testSequence).Exec()

--- a/pkg/db/utilities/utilities_test.go
+++ b/pkg/db/utilities/utilities_test.go
@@ -17,10 +17,6 @@ type UtilitiesSuite struct {
 	testingsuite.PopTestSuite
 }
 
-func (suite *UtilitiesSuite) SetupTest() {
-	suite.DB().TruncateAll()
-}
-
 func TestUtilitiesSuite(t *testing.T) {
 	hs := &UtilitiesSuite{
 		PopTestSuite: testingsuite.NewPopTestSuite(testingsuite.CurrentPackage()),

--- a/pkg/edi/invoice/generator_test.go
+++ b/pkg/edi/invoice/generator_test.go
@@ -21,10 +21,6 @@ type InvoiceSuite struct {
 	icnSequencer sequence.Sequencer
 }
 
-func (suite *InvoiceSuite) SetupTest() {
-	suite.DB().TruncateAll()
-}
-
 func TestInvoiceSuite(t *testing.T) {
 	// Use a no-op logger during testing
 	logger := zap.NewNop()

--- a/pkg/handlers/errors_test.go
+++ b/pkg/handlers/errors_test.go
@@ -25,10 +25,6 @@ type ErrorsSuite struct {
 	logger Logger
 }
 
-func (suite *ErrorsSuite) SetupTest() {
-	suite.DB().TruncateAll()
-}
-
 func TestErrorsSuite(t *testing.T) {
 	logger := zaptest.NewLogger(t)
 	zap.ReplaceGlobals(logger)

--- a/pkg/migrate/migrate_test.go
+++ b/pkg/migrate/migrate_test.go
@@ -18,10 +18,6 @@ type MigrateSuite struct {
 	logger Logger
 }
 
-func (suite *MigrateSuite) SetupTest() {
-	suite.DB().TruncateAll()
-}
-
 func TestMigrateSuite(t *testing.T) {
 	logger, err := zap.NewDevelopment()
 	if err != nil {

--- a/pkg/paperwork/paperwork_test.go
+++ b/pkg/paperwork/paperwork_test.go
@@ -23,10 +23,6 @@ type PaperworkSuite struct {
 	filesToClose []afero.File
 }
 
-func (suite *PaperworkSuite) SetupTest() {
-	suite.DB().TruncateAll()
-}
-
 func (suite *PaperworkSuite) AfterTest() {
 	for _, file := range suite.filesToClose {
 		file.Close()

--- a/pkg/route/here_planner_test.go
+++ b/pkg/route/here_planner_test.go
@@ -83,10 +83,6 @@ func (t *testClient) Get(getURL string) (*http.Response, error) {
 	return recorder.Result(), err
 }
 
-func (suite *HereTestSuite) SetupTest() {
-	suite.DB().TruncateAll()
-}
-
 func (suite *HereTestSuite) checkErrorCode(err error, c ErrorCode) bool {
 	if suite.Error(err) && suite.Implements((*Error)(nil), err) {
 		r := err.(Error)

--- a/pkg/services/admin_user/admin_user_service_test.go
+++ b/pkg/services/admin_user/admin_user_service_test.go
@@ -14,10 +14,6 @@ type AdminUserServiceSuite struct {
 	logger Logger
 }
 
-func (suite *AdminUserServiceSuite) SetupTest() {
-	suite.DB().TruncateAll()
-}
-
 func TestUserSuite(t *testing.T) {
 
 	ts := &AdminUserServiceSuite{

--- a/pkg/services/electronic_order/electronic_order_service_test.go
+++ b/pkg/services/electronic_order/electronic_order_service_test.go
@@ -14,10 +14,6 @@ type ElectronicOrderServiceSuite struct {
 	logger Logger
 }
 
-func (suite *ElectronicOrderServiceSuite) SetupTest() {
-	suite.DB().TruncateAll()
-}
-
 func TestUserSuite(t *testing.T) {
 
 	ts := &ElectronicOrderServiceSuite{

--- a/pkg/services/invoice/invoice_service_test.go
+++ b/pkg/services/invoice/invoice_service_test.go
@@ -17,10 +17,6 @@ type InvoiceServiceSuite struct {
 	storer storage.FileStorer
 }
 
-func (suite *InvoiceServiceSuite) SetupTest() {
-	suite.DB().TruncateAll()
-}
-
 func TestInvoiceSuite(t *testing.T) {
 
 	ts := &InvoiceServiceSuite{

--- a/pkg/services/invoice/send_to_gex_http_test.go
+++ b/pkg/services/invoice/send_to_gex_http_test.go
@@ -16,10 +16,6 @@ type GexSuite struct {
 	logger Logger
 }
 
-func (suite *GexSuite) SetupTest() {
-	suite.DB().TruncateAll()
-}
-
 func TestGexSuite(t *testing.T) {
 
 	ts := &GexSuite{

--- a/pkg/services/move_documents/move_document_test.go
+++ b/pkg/services/move_documents/move_document_test.go
@@ -15,10 +15,6 @@ type MoveDocumentServiceSuite struct {
 	logger Logger
 }
 
-func (suite *MoveDocumentServiceSuite) SetupTest() {
-	suite.DB().TruncateAll()
-}
-
 func TestMoveDocumentUpdaterServiceSuite(t *testing.T) {
 	ts := &MoveDocumentServiceSuite{
 		PopTestSuite: testingsuite.NewPopTestSuite(testingsuite.CurrentPackage().Suffix("move_document_service")),

--- a/pkg/services/office/office_service_test.go
+++ b/pkg/services/office/office_service_test.go
@@ -14,10 +14,6 @@ type OfficeServiceSuite struct {
 	logger Logger
 }
 
-func (suite *OfficeServiceSuite) SetupTest() {
-	suite.DB().TruncateAll()
-}
-
 func TestUserSuite(t *testing.T) {
 
 	ts := &OfficeServiceSuite{

--- a/pkg/services/office_user/office_user_service_test.go
+++ b/pkg/services/office_user/office_user_service_test.go
@@ -14,10 +14,6 @@ type OfficeUserServiceSuite struct {
 	logger Logger
 }
 
-func (suite *OfficeUserServiceSuite) SetupTest() {
-	suite.DB().TruncateAll()
-}
-
 func TestUserSuite(t *testing.T) {
 
 	hs := &OfficeUserServiceSuite{

--- a/pkg/services/pagination/pagination_service_test.go
+++ b/pkg/services/pagination/pagination_service_test.go
@@ -14,10 +14,6 @@ type PaginationServiceSuite struct {
 	logger Logger
 }
 
-func (suite *PaginationServiceSuite) SetupTest() {
-	suite.DB().TruncateAll()
-}
-
 func TestPaginationSuite(t *testing.T) {
 	ts := &PaginationServiceSuite{
 		PopTestSuite: testingsuite.NewPopTestSuite(testingsuite.CurrentPackage()),

--- a/pkg/services/paperwork/paperwork_service_test.go
+++ b/pkg/services/paperwork/paperwork_service_test.go
@@ -12,10 +12,6 @@ type PaperworkServiceSuite struct {
 	testingsuite.PopTestSuite
 }
 
-func (suite *PaperworkServiceSuite) SetupTest() {
-	suite.DB().TruncateAll()
-}
-
 func TestPaperworkServiceSuite(t *testing.T) {
 
 	ts := &PaperworkServiceSuite{

--- a/pkg/services/postal_codes/validate_postal_code_test.go
+++ b/pkg/services/postal_codes/validate_postal_code_test.go
@@ -13,10 +13,6 @@ type ValidatePostalCodeTestSuite struct {
 	testingsuite.PopTestSuite
 }
 
-func (suite *ValidatePostalCodeTestSuite) SetupTest() {
-	suite.DB().TruncateAll()
-}
-
 func TestValidatePostalCodeTestSuite(t *testing.T) {
 	ts := &ValidatePostalCodeTestSuite{
 		testingsuite.NewPopTestSuite(testingsuite.CurrentPackage()),

--- a/pkg/services/query/query_builder_test.go
+++ b/pkg/services/query/query_builder_test.go
@@ -20,10 +20,6 @@ type QueryBuilderSuite struct {
 	logger Logger
 }
 
-func (suite *QueryBuilderSuite) SetupTest() {
-	suite.DB().TruncateAll()
-}
-
 func TestUserSuite(t *testing.T) {
 
 	ts := &QueryBuilderSuite{

--- a/pkg/services/tsp/tsp_service_test.go
+++ b/pkg/services/tsp/tsp_service_test.go
@@ -14,10 +14,6 @@ type TSPServiceSuite struct {
 	logger Logger
 }
 
-func (suite *TSPServiceSuite) SetupTest() {
-	suite.DB().TruncateAll()
-}
-
 func TestTSPServiceSuite(t *testing.T) {
 
 	ts := &TSPServiceSuite{

--- a/pkg/services/upload/uploads_test.go
+++ b/pkg/services/upload/uploads_test.go
@@ -14,10 +14,6 @@ type UploadsServiceSuite struct {
 	logger Logger
 }
 
-func (suite *UploadsServiceSuite) SetupTest() {
-	suite.DB().TruncateAll()
-}
-
 func TestUploadsServiceSuite(t *testing.T) {
 
 	hs := &UploadsServiceSuite{

--- a/pkg/testingsuite/pop_suite.go
+++ b/pkg/testingsuite/pop_suite.go
@@ -105,7 +105,7 @@ func NewPopTestSuite(packageName PackageName) PopTestSuite {
 	}
 
 	dbDialect := "postgres"
-	dbNameTest := envy.MustGet("DB_NAME_TEST")
+	dbNameTest := envy.MustGet("DB_NAME")
 	dbHost := envy.MustGet("DB_HOST")
 	dbPort := envy.MustGet("DB_PORT_TEST")
 	dbUser := envy.MustGet("DB_USER")

--- a/pkg/testingsuite/pop_suite.go
+++ b/pkg/testingsuite/pop_suite.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"time"
 
-	envy "github.com/codegangsta/envy/lib"
+	"github.com/gobuffalo/envy"
 	"github.com/gobuffalo/pop"
 	"github.com/gobuffalo/validate"
 	"github.com/gofrs/flock"
@@ -105,18 +105,35 @@ func NewPopTestSuite(packageName PackageName) PopTestSuite {
 	}
 
 	dbDialect := "postgres"
-	dbNameTest := envy.MustGet("DB_NAME")
-	dbHost := envy.MustGet("DB_HOST")
-	dbPort := envy.MustGet("DB_PORT_TEST")
-	dbUser := envy.MustGet("DB_USER")
-	dbPassword := envy.MustGet("DB_PASSWORD")
+	dbName, dbNameErr := envy.MustGet("DB_NAME")
+	if dbNameErr != nil {
+		log.Panic(dbNameErr)
+	}
+	dbNameTest := envy.Get("DB_NAME_TEST", dbName)
+	dbHost, dbHostErr := envy.MustGet("DB_HOST")
+	if dbHostErr != nil {
+		log.Panic(dbHostErr)
+	}
+	dbPort, dbPortErr := envy.MustGet("DB_PORT")
+	if dbPortErr != nil {
+		log.Panic(dbPortErr)
+	}
+	dbPortTest := envy.Get("DB_PORT_TEST", dbPort)
+	dbUser, dbUserErr := envy.MustGet("DB_USER")
+	if dbUserErr != nil {
+		log.Panic(dbUserErr)
+	}
+	dbPassword, dbPasswordErr := envy.MustGet("DB_PASSWORD")
+	if dbPasswordErr != nil {
+		log.Panic(dbPasswordErr)
+	}
 
 	log.Printf("package %s is attempting to connect to database %s", packageName.String(), dbNameTest)
 	primaryConnDetails := pop.ConnectionDetails{
 		Dialect:  dbDialect,
 		Database: dbNameTest,
 		Host:     dbHost,
-		Port:     dbPort,
+		Port:     dbPortTest,
 		User:     dbUser,
 		Password: dbPassword,
 	}
@@ -156,7 +173,7 @@ func NewPopTestSuite(packageName PackageName) PopTestSuite {
 		Dialect:  dbDialect,
 		Database: dbNamePackage,
 		Host:     dbHost,
-		Port:     dbPort,
+		Port:     dbPortTest,
 		User:     dbUser,
 		Password: dbPassword,
 	}

--- a/pkg/uploader/uploader_test.go
+++ b/pkg/uploader/uploader_test.go
@@ -35,7 +35,6 @@ type UploaderSuite struct {
 func (suite *UploaderSuite) SetupTest() {
 	var fs = afero.NewMemMapFs()
 	suite.fs = &afero.Afero{Fs: fs}
-	suite.DB().TruncateAll()
 }
 
 func (suite *UploaderSuite) openLocalFile(path string) (afero.File, error) {


### PR DESCRIPTION
## Description

- Truncate the DB early to make things speedier when cloning
- Remove DB Truncate when not needed from some test suites
- Use `RawQuery` to drop the DB or create the DB instead of shelling out

## Setup

```sh
make server_test
```

## Code Review Verification Steps

* [x] Request review from a member of a different team.