### PR TITLE
Fix organization model to reflect nullable columns

### DIFF
--- a/pkg/models/organization.go
+++ b/pkg/models/organization.go
@@ -15,8 +15,8 @@ type Organization struct {
 	CreatedAt time.Time `json:"created_at" db:"created_at"`
 	UpdatedAt time.Time `json:"updated_at" db:"updated_at"`
 	Name      string    `json:"name" db:"name"`
-	PocEmail  string    `json:"poc_email" db:"poc_email"`
-	PocPhone  string    `json:"poc_phone" db:"poc_phone"`
+	PocEmail  *string   `json:"poc_email" db:"poc_email"`
+	PocPhone  *string   `json:"poc_phone" db:"poc_phone"`
 }
 
 // String is not required by pop and may be deleted
@@ -39,8 +39,6 @@ func (o Organizations) String() string {
 func (o *Organization) Validate(tx *pop.Connection) (*validate.Errors, error) {
 	return validate.Validate(
 		&validators.StringIsPresent{Field: o.Name, Name: "Name"},
-		&validators.StringIsPresent{Field: o.PocEmail, Name: "PocEmail"},
-		&validators.StringIsPresent{Field: o.PocPhone, Name: "PocPhone"},
 	), nil
 }
 

--- a/pkg/models/organization_test.go
+++ b/pkg/models/organization_test.go
@@ -9,10 +9,13 @@ import (
 func (suite *ModelSuite) TestOrganizationCreation() {
 	t := suite.T()
 
+	email := "test@truss.works"
+	phone := "9144825484"
+
 	newOrganization := Organization{
 		Name:     "Truss",
-		PocEmail: "test@truss.works",
-		PocPhone: "9144825484",
+		PocEmail: &email,
+		PocPhone: &phone,
 	}
 
 	if verrs, err := suite.DB().ValidateAndCreate(&newOrganization); err != nil || verrs.HasAny() {
@@ -28,9 +31,7 @@ func (suite *ModelSuite) TestOrganizationCreationWithoutValues() {
 	newOrganization := &Organization{}
 
 	expErrors := map[string][]string{
-		"name":      {"Name can not be blank."},
-		"poc_email": {"PocEmail can not be blank."},
-		"poc_phone": {"PocPhone can not be blank."},
+		"name": {"Name can not be blank."},
 	}
 
 	suite.verifyValidationErrors(newOrganization, expErrors)


### PR DESCRIPTION
@chrisgilmerproj this came from your [slack message](https://defensedigitalservice.slack.com/archives/G8P7UD05U/p1570480573337900).

I introduced nullable columns for `poc_email` and `poc_phone` in `migrations/20190710151514_make_organizations_poc_nullable.up.fizz`, but never updated the app code the reflect that.