### PR TITLE
revert addition of ppm queue that shows suppressed: 169015597

### DIFF
--- a/pkg/gen/internalapi/embedded_spec.go
+++ b/pkg/gen/internalapi/embedded_spec.go
@@ -2206,8 +2206,7 @@ func init() {
               "ppm_payment_requested",
               "all",
               "ppm_approved",
-              "ppm_completed",
-              "MBxFJqtAoWfTYJd"
+              "ppm_completed"
             ],
             "type": "string",
             "description": "Queue type to show",
@@ -7953,8 +7952,7 @@ func init() {
               "ppm_payment_requested",
               "all",
               "ppm_approved",
-              "ppm_completed",
-              "MBxFJqtAoWfTYJd"
+              "ppm_completed"
             ],
             "type": "string",
             "description": "Queue type to show",

--- a/pkg/gen/internalapi/internaloperations/queues/show_queue_parameters.go
+++ b/pkg/gen/internalapi/internaloperations/queues/show_queue_parameters.go
@@ -80,7 +80,7 @@ func (o *ShowQueueParams) bindQueueType(rawData []string, hasKey bool, formats s
 // validateQueueType carries on validations for parameter QueueType
 func (o *ShowQueueParams) validateQueueType(formats strfmt.Registry) error {
 
-	if err := validate.Enum("queueType", "path", o.QueueType, []interface{}{"new", "ppm_payment_requested", "all", "ppm_approved", "ppm_completed", "MBxFJqtAoWfTYJd"}); err != nil {
+	if err := validate.Enum("queueType", "path", o.QueueType, []interface{}{"new", "ppm_payment_requested", "all", "ppm_approved", "ppm_completed"}); err != nil {
 		return err
 	}
 

--- a/pkg/models/queue.go
+++ b/pkg/models/queue.go
@@ -164,33 +164,7 @@ func GetMoveQueueItems(db *pop.Connection, lifecycleState string) ([]MoveQueueIt
 			JOIN duty_stations as destination_duty_station ON ord.new_duty_station_id = destination_duty_station.id
 			WHERE moves.show is true
 		`
-	} else if lifecycleState == "MBxFJqtAoWfTYJd" {
-		query = `
-			SELECT moves.ID,
-				COALESCE(sm.edipi, '*missing*') as edipi,
-				COALESCE(sm.rank, '*missing*') as rank,
-				CONCAT(COALESCE(sm.last_name, '*missing*'), ', ', COALESCE(sm.first_name, '*missing*')) AS customer_name,
-				moves.locator as locator,
-				ord.orders_type as orders_type,
-				COALESCE(
-					ppm.actual_move_date,
-					ppm.original_move_date
-				) as move_date,
-				moves.created_at as created_at,
-				moves.updated_at as last_modified_date,
-				moves.status as status,
-				ppm.status as ppm_status,
-				origin_duty_station.name as origin_duty_station_name,
-				destination_duty_station.name as destination_duty_station_name
-			FROM moves
-			JOIN orders as ord ON moves.orders_id = ord.id
-			JOIN service_members AS sm ON ord.service_member_id = sm.id
-			LEFT JOIN personally_procured_moves AS ppm ON moves.id = ppm.move_id
-			JOIN duty_stations as origin_duty_station ON sm.duty_station_id = origin_duty_station.id
-			JOIN duty_stations as destination_duty_station ON ord.new_duty_station_id = destination_duty_station.id
-		`
 	} else {
-
 		return moveQueueItems, ErrFetchNotFound
 	}
 

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -3984,7 +3984,6 @@ paths:
             - all
             - ppm_approved
             - ppm_completed
-            - MBxFJqtAoWfTYJd
           required: true
           description: Queue type to show
       responses:


### PR DESCRIPTION
## Description

leaving this in draft till we we get the data need...

Revert pr(https://github.com/transcom/mymove/pull/2784) that added a way to see all moves including moves that are suppressed.

## Setup

`make server_run`
`make client_run`

open network tab and hit: http://officelocal:3000/queues/MBxFJqtAoWfTYJd
the response should return a `606`

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/169015597) for this change
