### PR TITLE
Update access codes cmd to use cli package for db connection

### DIFF
--- a/cmd/generate_access_codes/logger.go
+++ b/cmd/generate_access_codes/logger.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"go.uber.org/zap"
+)
+
+type logger interface {
+	Debug(msg string, fields ...zap.Field)
+	Info(msg string, fields ...zap.Field)
+	Error(msg string, fields ...zap.Field)
+	Warn(msg string, fields ...zap.Field)
+	Fatal(msg string, fields ...zap.Field)
+}

--- a/cmd/generate_access_codes/main.go
+++ b/cmd/generate_access_codes/main.go
@@ -55,6 +55,10 @@ func checkConfig(v *viper.Viper, logger logger) error {
 	if err != nil {
 		return err
 	}
+	err = cli.CheckVerbose(v)
+	if err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/cmd/generate_access_codes/main.go
+++ b/cmd/generate_access_codes/main.go
@@ -1,14 +1,41 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 	"log"
+	"os"
+	"strings"
+
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+	"go.uber.org/zap"
+
+	"github.com/transcom/mymove/pkg/cli"
+	"github.com/transcom/mymove/pkg/logging"
 
 	"github.com/gobuffalo/pop"
 
 	"github.com/transcom/mymove/pkg/models"
 )
+
+const (
+	hhgFlag string = "hhg"
+	ppmFlag string = "ppm"
+)
+
+func initFlags(flag *pflag.FlagSet) {
+	flag.Int(hhgFlag, 0, "The number of access codes for HHG moves to create")
+	flag.Int(ppmFlag, 0, "The number of access codes for PPM moves to create")
+
+	// DB Config
+	cli.InitDatabaseFlags(flag)
+
+	// Verbose
+	cli.InitVerboseFlags(flag)
+
+	// Don't sort flags
+	flag.SortFlags = false
+}
 
 func mustSave(db *pop.Connection, model interface{}) {
 	verrs, err := db.ValidateAndSave(model)
@@ -20,29 +47,65 @@ func mustSave(db *pop.Connection, model interface{}) {
 	}
 }
 
+func checkConfig(v *viper.Viper, logger logger) error {
+
+	logger.Debug("checking config")
+
+	err := cli.CheckDatabase(v, logger)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func main() {
-	config := flag.String("config-dir", "config", "The location of server config files")
-	env := flag.String("env", "development", "The environment to run in, which configures the database.")
-	hhg := flag.Int("hhg", 0, "The number of access codes for HHG moves to create")
-	ppm := flag.Int("ppm", 0, "The number of access codes for PPM moves to create")
 
-	flag.Parse()
-
-	// DB connection
-	err := pop.AddLookupPaths(*config)
+	flag := pflag.CommandLine
+	initFlags(flag)
+	err := flag.Parse(os.Args[1:])
 	if err != nil {
-		log.Fatal(err)
-	}
-	db, err := pop.Connect(*env)
-	if err != nil {
-		log.Fatal(err)
+		log.Println(err)
+		os.Exit(1)
 	}
 
-	if *hhg == 0 && *ppm == 0 {
+	v := viper.New()
+	err = v.BindPFlags(flag)
+	if err != nil {
+		log.Println(err)
+		os.Exit(1)
+	}
+	v.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
+	v.AutomaticEnv()
+
+	dbEnv := v.GetString(cli.DbEnvFlag)
+	logger, err := logging.Config(dbEnv, v.GetBool(cli.VerboseFlag))
+	if err != nil {
+		log.Fatalf("Failed to initialize Zap logging due to %v", err)
+	}
+	zap.ReplaceGlobals(logger)
+
+	err = checkConfig(v, logger)
+	if err != nil {
+		logger.Fatal("invalid configuration", zap.Error(err))
+	}
+
+	// Create a connection to the DB
+	dbConnection, err := cli.InitDatabase(v, nil, logger)
+	if err != nil {
+		// No connection object means that the configuraton failed to validate and we should not startup
+		// A valid connection object that still has an error indicates that the DB is not up and we should not startup
+		logger.Fatal("Connecting to DB", zap.Error(err))
+	}
+
+	hhg := v.GetInt(hhgFlag)
+	ppm := v.GetInt(ppmFlag)
+
+	if hhg == 0 && ppm == 0 {
 		log.Fatal("Usage: generate_access_codes -ppm 1000 -hhg 4000")
 	}
 	// go run cmd/generate_access_codes/main.go -ppm 2000 -hhg 500
-	for i := 0; i < *hhg; i++ {
+	for i := 0; i < hhg; i++ {
 		selectedMoveType := models.SelectedMoveTypeHHG
 
 		accessCode := models.AccessCode{
@@ -50,10 +113,10 @@ func main() {
 			MoveType: &selectedMoveType,
 		}
 
-		mustSave(db, &accessCode)
+		mustSave(dbConnection, &accessCode)
 	}
 
-	for i := 0; i < *ppm; i++ {
+	for i := 0; i < ppm; i++ {
 		selectedMoveType := models.SelectedMoveTypePPM
 
 		accessCode := models.AccessCode{
@@ -61,7 +124,7 @@ func main() {
 			MoveType: &selectedMoveType,
 		}
 
-		mustSave(db, &accessCode)
+		mustSave(dbConnection, &accessCode)
 	}
 
 	fmt.Println("Completed generate_access_codes")


### PR DESCRIPTION
## Description

The `generate_access_codes` wasn't working because of changes made regarding how to connect to the database from cli tools. This PR updates `generate_access_codes` to use the new approach for connecting to the db.

## Reviewer Notes
1) Reset the db and run the command
```
make db_dev_reset && make db_dev_migrate
go run cmd/generate_access_codes/main.go cmd/generate_access_codes/logger.go --ppm 1000 --hhg 2
```
2) Check that the right number of codes are present in local db:
```
SELECT move_type, count(*) from access_codes
GROUP BY move_type;
```

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/tree/master/docs/backend.md#logging)
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/n/projects/2181745/stories/168544814) for this change