### PR TITLE
Add ability to edit disabled field on office users

### DIFF
--- a/cmd/milmove/gen_disable_user_migration.go
+++ b/cmd/milmove/gen_disable_user_migration.go
@@ -25,10 +25,6 @@ WHERE login_gov_email='{{.EmailPrefix}}@{{.EmailDomain}}';
 UPDATE admin_users
 SET disabled=true
 WHERE email='{{.EmailPrefix}}@{{.EmailDomain}}';
-
-UPDATE office_users
-SET disabled=true
-WHERE email='{{.EmailPrefix}}@{{.EmailDomain}}';
 `
 )
 

--- a/docs/how-to/create-or-disable-users.md
+++ b/docs/how-to/create-or-disable-users.md
@@ -207,11 +207,12 @@ This is the only way to disable Service Members.
 
 ### Disabling Office Users
 
-An example of disabling an Office user by email:
+This can now be done in the admin user application:
 
-```sql
-UPDATE office_users SET disabled = true WHERE email = 'username@example.com';
-```
+1. Navigate to the admin app and log in
+2. Click on "Office Users" in the sidebar
+3. Select the user you would like to disable and click "Edit" in the top right
+   corner. Here, you'll be able to choose whether or not that user is disabled.
 
 ### Disabling TSP Users
 

--- a/pkg/gen/adminapi/embedded_spec.go
+++ b/pkg/gen/adminapi/embedded_spec.go
@@ -926,6 +926,9 @@ func init() {
     "OfficeUserUpdatePayload": {
       "type": "object",
       "properties": {
+        "disabled": {
+          "type": "boolean"
+        },
         "first_name": {
           "type": "string",
           "title": "First Name"
@@ -1970,6 +1973,9 @@ func init() {
     "OfficeUserUpdatePayload": {
       "type": "object",
       "properties": {
+        "disabled": {
+          "type": "boolean"
+        },
         "first_name": {
           "type": "string",
           "title": "First Name"

--- a/pkg/gen/adminmessages/office_user_update_payload.go
+++ b/pkg/gen/adminmessages/office_user_update_payload.go
@@ -17,6 +17,9 @@ import (
 // swagger:model OfficeUserUpdatePayload
 type OfficeUserUpdatePayload struct {
 
+	// disabled
+	Disabled bool `json:"disabled,omitempty"`
+
 	// First Name
 	FirstName string `json:"first_name,omitempty"`
 

--- a/pkg/handlers/adminapi/office_users.go
+++ b/pkg/handlers/adminapi/office_users.go
@@ -149,9 +149,11 @@ func (h UpdateOfficeUserHandler) Handle(params officeuserop.UpdateOfficeUserPara
 		LastName:       payload.LastName,
 		FirstName:      payload.FirstName,
 		Telephone:      payload.Telephone,
+		Disabled:       payload.Disabled,
 	}
 
 	updatedOfficeUser, verrs, err := h.OfficeUserUpdater.UpdateOfficeUser(&officeUser)
+
 	if err != nil || verrs != nil {
 		fmt.Printf("%#v", verrs)
 		logger.Error("Error saving user", zap.Error(err))

--- a/pkg/services/office_user/office_user_updater.go
+++ b/pkg/services/office_user/office_user_updater.go
@@ -25,6 +25,7 @@ func (o *officeUserUpdater) UpdateOfficeUser(user *models.OfficeUser) (*models.O
 	foundUser.MiddleInitials = user.MiddleInitials
 	foundUser.LastName = user.LastName
 	foundUser.Telephone = user.Telephone
+	foundUser.Disabled = user.Disabled
 
 	verrs, err := o.builder.UpdateOne(&foundUser)
 	if verrs != nil || err != nil {

--- a/src/scenes/SystemAdmin/Home.module.scss
+++ b/src/scenes/SystemAdmin/Home.module.scss
@@ -39,3 +39,8 @@
     margin: 1.5em 0 0 0;
   }
 }
+
+div[class^="MuiSelect-root-"] {
+  padding: 4rem 0 1rem 0;
+  font-size: 1.5rem;
+}

--- a/src/scenes/SystemAdmin/OfficeUsers/OfficeUserEdit.jsx
+++ b/src/scenes/SystemAdmin/OfficeUsers/OfficeUserEdit.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { phoneValidators } from 'scenes/SystemAdmin/shared/form_validators';
-import { Edit, SimpleForm, TextInput, DisabledInput, required, Toolbar, SaveButton } from 'react-admin';
+import { Edit, SimpleForm, TextInput, DisabledInput, SelectInput, required, Toolbar, SaveButton } from 'react-admin';
 
 const OfficeUserEditToolbar = props => (
   <Toolbar {...props}>
@@ -17,7 +17,11 @@ const OfficeUserEdit = props => (
       <TextInput source="middle_initials" />
       <TextInput source="last_name" validate={required()} />
       <TextInput source="telephone" validate={phoneValidators} />
-      <DisabledInput source="disabled" label="Deactivated" />
+      <SelectInput
+        source="disabled"
+        label="Deactivated"
+        choices={[{ id: true, name: 'Yes' }, { id: false, name: 'No' }]}
+      />
       <DisabledInput source="created_at" />
       <DisabledInput source="updated_at" />
     </SimpleForm>

--- a/swagger/admin.yaml
+++ b/swagger/admin.yaml
@@ -361,6 +361,8 @@ definitions:
         format: telephone
         pattern: '^[2-9]\d{2}-\d{3}-\d{4}$'
         example: 212-555-5555
+      disabled:
+        type: boolean
   ElectronicOrder:
     type: object
     required:


### PR DESCRIPTION
## Description

We can now disable office users through the admin app!

## Reviewer Notes

- Are there any security implications that I haven't considered in allowing us to do this via the admin console?
- We have a [log line](https://github.com/transcom/mymove/blob/5df3cdf41b691d3cfa39492eaa887a0fc35a345f/pkg/handlers/adminapi/office_users.go#L163) in place so we can audit who changes the office user record.

## Setup

- `make server_run`
- `make client_run`
- Navigate to the edit office user page - you can now changed the user's disabled column.

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/167384040) for this change