### PR TITLE
fix signature alignment when field has error: 168581468

### DIFF
--- a/src/scenes/Legalese/index.css
+++ b/src/scenes/Legalese/index.css
@@ -78,4 +78,6 @@ div.signature-date {
   }
 }
 
-
+.usa-input-error.signature {
+  margin-top: 2rem;
+}


### PR DESCRIPTION
## Description

Fix alignment issue when the SM signature field shows an error message.

## Setup

`make server_run`
`make client_run`

go thru SM flow and when you get to signature page, click into the signature field, then off the field w/o adding a signature... the signature field and date field should still be in allignment.

## Code Review Verification Steps

* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/168581468) for this change

## Screenshots
prior: 
<img width="740" alt="Screen Shot 2019-10-11 at 11 10 02 AM" src="https://user-images.githubusercontent.com/3099491/66667044-9ba7b700-ec41-11e9-83f2-e5ff7d6913d9.png">

after:
<img width="747" alt="Screen Shot 2019-10-11 at 10 13 10 AM" src="https://user-images.githubusercontent.com/3099491/66666668-b2014300-ec40-11e9-9bb0-750f556a7a8e.png">
