### PR TITLE
Add New Admin Users

### DIFF
--- a/local_migrations/20191011162818_add-admin-users.up.sql
+++ b/local_migrations/20191011162818_add-admin-users.up.sql
@@ -1,0 +1,4 @@
+-- Local test migration.
+-- This will be run on development environments.
+-- It should mirror what you intend to apply on prod/staging/experimental
+-- DO NOT include any sensitive data.

--- a/migrations_manifest.txt
+++ b/migrations_manifest.txt
@@ -361,3 +361,4 @@
 20190927150748_insert_duty_station_names.up.sql
 20190930152918_import_bvs_performance_period_4.up.sql
 20191008151614_re_create_reference_tables.up.sql
+20191011162818_add-admin-users.up.sql


### PR DESCRIPTION
## Description

Migration to add new admin users. This adds the new admin users in prod, staging and experimental. You should see 3 new admin users in total (see the linked pivotal ticket below for the expected user information).

## Reviewer Notes

Double check that you see the expected records after running the various commands in setup.

## Setup

`make run_prod_migrations` to check that the users are in prod db
`make run_staging_migrations` to check that the users are in the staging db.
`make run_experimental_migrations` to check that the users are in the experimental db.

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/n/projects/2181745/stories/169078794) for this change