### PR TITLE
Update file size comparison in upload-secure-migration to use integer comparison operator

### DIFF
--- a/scripts/upload-secure-migration
+++ b/scripts/upload-secure-migration
@@ -58,7 +58,7 @@ FILESIZE=$(/usr/bin/stat -f%z "${1}")
 # 250MB in bytes
 BYTES_IN_MB=1048576
 MAX_FILESIZE=$((250 * "${BYTES_IN_MB}" ))
-if [[ ${FILESIZE} > ${MAX_FILESIZE} ]]; then
+if [[ ${FILESIZE} -gt ${MAX_FILESIZE} ]]; then
   FILESIZE_MB=$(( "${FILESIZE}" / "${BYTES_IN_MB}" ))
   echo "error: Max file size for upload is 250 MB, this file is too large for anti-virus to work."
   echo "Your file is ${FILESIZE_MB} MB, please reduce or split before uploading."


### PR DESCRIPTION
## Description

when trying to run ` upload-secure-migration` I was getting the following error: 

```
 echo "error: Max file size for upload is 250 MB, this file is too large for anti-virus to work."
```

even though the file was ~700KB. 

Updated the file size check to use the integer [comparison operator](http://tldp.org/LDP/abs/html/comparison-ops.html) `-gt` in place of `>` .