### PR TITLE
Upgrade to Go 1.13.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,7 @@ commands:
       - checkout
       - restore_cache:
           keys:
-            - go-mod-sources-v2-{{ checksum "go.sum" }}
+            - go-mod-sources-v2-{{ checksum "go.sum" }}-{{ checksum "scripts/check-go-version" }}}
       - attach_workspace:
           at: bin
       - deploy:
@@ -122,7 +122,7 @@ commands:
             [[ -z "<< parameters.compare_host >>" ]] || scripts/compare-deployed-commit "<< parameters.compare_host >>" $CIRCLE_SHA1
       - restore_cache:
           keys:
-            - go-mod-sources-v2-{{ checksum "go.sum" }}
+            - go-mod-sources-v2-{{ checksum "go.sum" }}-{{ checksum "scripts/check-go-version" }}
       - attach_workspace:
           at: bin
       - deploy:
@@ -150,7 +150,7 @@ commands:
             [[ -z "<< parameters.compare_host >>" ]] || scripts/compare-deployed-commit "<< parameters.compare_host >>" $CIRCLE_SHA1 ${EXPERIMENTAL_MOVE_MIL_DOD_TLS_KEY} ${EXPERIMENTAL_MOVE_MIL_DOD_TLS_CERT} ${EXPERIMENTAL_MOVE_MIL_DOD_TLS_CA}
       - restore_cache:
           keys:
-            - go-mod-sources-v2-{{ checksum "go.sum" }}
+            - go-mod-sources-v2-{{ checksum "go.sum" }}-{{ checksum "scripts/check-go-version" }}
       - attach_workspace:
           at: bin
       - deploy:
@@ -220,14 +220,14 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - go-mod-sources-v2-{{ checksum "go.sum" }}
+            - go-mod-sources-v2-{{ checksum "go.sum" }}-{{ checksum "scripts/check-go-version" }}
       - run:
           name: Install dependencies
           command: for i in $(seq 1 5); do go get ./... && s=0 && break || s=$? && sleep 5; done; (exit $s)
           environment:
             GOPROXY: https://gocenter.io
       - save_cache:
-          key: go-mod-sources-v2-{{ checksum "go.sum" }}
+          key: go-mod-sources-v2-{{ checksum "go.sum" }}-{{ checksum "scripts/check-go-version" }}
           paths:
             - "/go/pkg/mod"
       - announce_failure
@@ -265,12 +265,12 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - go-mod-sources-v2-{{ checksum "go.sum" }}
+            - go-mod-sources-v2-{{ checksum "go.sum" }}-{{ checksum "scripts/check-go-version" }}
       - run: echo 'export PATH=${PATH}:~/go/bin:~/transcom/mymove/bin' >> $BASH_ENV
       - run: make server_generate mocks_generate
       - run: scripts/check-generated-code
       - save_cache:
-          key: go-mod-sources-v2-{{ checksum "go.sum" }}
+          key: go-mod-sources-v2-{{ checksum "go.sum" }}-{{ checksum "scripts/check-go-version" }}
           paths:
             - "/go/pkg/mod"
       - announce_failure
@@ -292,7 +292,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - go-mod-sources-v2-{{ checksum "go.sum" }}
+            - go-mod-sources-v2-{{ checksum "go.sum" }}-{{ checksum "scripts/check-go-version" }}}
       - restore_cache:
           keys:
             - v2-cache-yarn-v2-{{ checksum "yarn.lock" }}
@@ -324,7 +324,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - go-mod-sources-v2-{{ checksum "go.sum" }}
+            - go-mod-sources-v2-{{ checksum "go.sum" }}-{{ checksum "scripts/check-go-version" }}
       - run:
           name: Run acceptance tests
           command: |
@@ -358,7 +358,7 @@ jobs:
           docker_layer_caching: true
       - restore_cache:
           keys:
-            - go-mod-sources-v2-{{ checksum "go.sum" }}
+            - go-mod-sources-v2-{{ checksum "go.sum" }}-{{ checksum "scripts/check-go-version" }}
       - restore_cache:
           keys:
             - v2-cache-yarn-v2-{{ checksum "yarn.lock" }}
@@ -385,7 +385,7 @@ jobs:
           docker_layer_caching: true
       - restore_cache:
           keys:
-            - go-mod-sources-v2-{{ checksum "go.sum" }}
+            - go-mod-sources-v2-{{ checksum "go.sum" }}-{{ checksum "scripts/check-go-version" }}
       - run: echo 'export PATH=${PATH}:~/go/bin:~/transcom/mymove/bin' >> $BASH_ENV
       - run:
           name: Build Go Junit Report
@@ -431,7 +431,7 @@ jobs:
           docker_layer_caching: true
       - restore_cache:
           keys:
-            - go-mod-sources-v2-{{ checksum "go.sum" }}
+            - go-mod-sources-v2-{{ checksum "go.sum" }}-{{ checksum "scripts/check-go-version" }}}
       - run: echo 'export PATH=${PATH}:~/go/bin:~/transcom/mymove/bin' >> $BASH_ENV
       - run:
           name: Setup Code Climate test-reporter
@@ -492,7 +492,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - go-mod-sources-v2-{{ checksum "go.sum" }}
+            - go-mod-sources-v2-{{ checksum "go.sum" }}-{{ checksum "scripts/check-go-version" }}
       - run: make build_tools
       - persist_to_workspace:
           root: bin
@@ -513,7 +513,7 @@ jobs:
           docker_layer_caching: true
       - restore_cache:
           keys:
-            - go-mod-sources-v2-{{ checksum "go.sum" }}
+            - go-mod-sources-v2-{{ checksum "go.sum" }}-{{ checksum "scripts/check-go-version" }}
       - restore_cache:
           keys:
             - v2-cache-yarn-v2-{{ checksum "yarn.lock" }}
@@ -571,7 +571,7 @@ jobs:
           docker_layer_caching: true
       - restore_cache:
           keys:
-            - go-mod-sources-v2-{{ checksum "go.sum" }}
+            - go-mod-sources-v2-{{ checksum "go.sum" }}-{{ checksum "scripts/check-go-version" }}}
       - run: make bin/chamber
       - run: make bin/rds-combined-ca-bundle.pem
       - run: make tasks_build
@@ -588,7 +588,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - go-mod-sources-v2-{{ checksum "go.sum" }}
+            - go-mod-sources-v2-{{ checksum "go.sum" }}-{{ checksum "scripts/check-go-version" }}
       - run:
           name: Build Chamber
           command: make bin/chamber
@@ -657,7 +657,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - go-mod-sources-v2-{{ checksum "go.sum" }}
+            - go-mod-sources-v2-{{ checksum "go.sum" }}-{{ checksum "scripts/check-go-version" }}
       - run:
           name: Build Chamber
           command: make bin/chamber
@@ -754,7 +754,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - go-mod-sources-v2-{{ checksum "go.sum" }}
+            - go-mod-sources-v2-{{ checksum "go.sum" }}-{{ checksum "scripts/check-go-version" }}
       - run:
           name: Add ~/go/bin to path for golint
           command: echo 'export PATH=${PATH}:~/go/bin:~/transcom/mymove/bin' >> $BASH_ENV

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,28 +15,28 @@ executors:
     resource_class: small
     working_directory: ~/transcom/mymove
     docker:
-      - image: trussworks/circleci-docker-primary:e5c10bf19185aa55354901106bad3ffd4c016265
+      - image: trussworks/circleci-docker-primary:0a7bcc19642337bcfb16d5d1a1f05da646b7ec27
   mymove_medium:
     resource_class: medium
     working_directory: ~/transcom/mymove
     docker:
-      - image: trussworks/circleci-docker-primary:e5c10bf19185aa55354901106bad3ffd4c016265
+      - image: trussworks/circleci-docker-primary:0a7bcc19642337bcfb16d5d1a1f05da646b7ec27
   mymove_medium_plus:
     resource_class: medium+
     working_directory: ~/transcom/mymove
     docker:
-      - image: trussworks/circleci-docker-primary:e5c10bf19185aa55354901106bad3ffd4c016265
+      - image: trussworks/circleci-docker-primary:0a7bcc19642337bcfb16d5d1a1f05da646b7ec27
   mymove_large:
     resource_class: large
     working_directory: ~/transcom/mymove
     docker:
-      - image: trussworks/circleci-docker-primary:e5c10bf19185aa55354901106bad3ffd4c016265
+      - image: trussworks/circleci-docker-primary:0a7bcc19642337bcfb16d5d1a1f05da646b7ec27
   # `mymove_and_postgres_medium` adds a secondary postgres container to be used during testing.
   mymove_and_postgres_medium:
     resource_class: medium
     working_directory: ~/transcom/mymove
     docker:
-      - image: trussworks/circleci-docker-primary:e5c10bf19185aa55354901106bad3ffd4c016265
+      - image: trussworks/circleci-docker-primary:0a7bcc19642337bcfb16d5d1a1f05da646b7ec27
       - image: postgres:10.9
         environment:
           - POSTGRES_PASSWORD: mysecretpassword
@@ -46,7 +46,7 @@ executors:
     resource_class: large
     working_directory: ~/transcom/mymove
     docker:
-      - image: trussworks/circleci-docker-primary:e5c10bf19185aa55354901106bad3ffd4c016265
+      - image: trussworks/circleci-docker-primary:0a7bcc19642337bcfb16d5d1a1f05da646b7ec27
       - image: postgres:10.9
         environment:
           - POSTGRES_PASSWORD: mysecretpassword

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
         exclude: public/swagger-ui/*
 
   - repo: git://github.com/golangci/golangci-lint
-    rev: v1.19.1
+    rev: v1.20.0
     hooks:
       - id: golangci-lint
         entry: bash -c 'exec golangci-lint run -j=${GOLANGCI_LINT_CONCURRENCY:-1}' # custom bash so we can override concurrency for faster dev runs

--- a/Dockerfile.dep_updater
+++ b/Dockerfile.dep_updater
@@ -1,4 +1,4 @@
-FROM trussworks/circleci-docker-primary:9b7bfbf6bfae544566ade0c896f8aacbd16281e5
+FROM trussworks/circleci-docker-primary:0a7bcc19642337bcfb16d5d1a1f05da646b7ec27
 
 ENV GOPATH=/home/circleci/go
 ENV GOBIN=$GOPATH/bin

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -188,7 +188,7 @@ func (suite *serverSuite) TestHTTPServerConfig() {
 	suite.Equal(suite.httpHandler, httpsServer.Handler)
 }
 
-func (suite *serverSuite) TestTLSConfigWithRequest() {
+func (suite *serverSuite) testTLSConfigWithRequest(tlsVersion uint16) {
 
 	keyPair, err := tls.X509KeyPair(
 		suite.readFile("localhost.pem"),
@@ -205,7 +205,7 @@ func (suite *serverSuite) TestTLSConfigWithRequest() {
 	httpHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Check the TLS connection from inside the request
 		connState := r.TLS
-		suite.Equal(tls.VersionTLS12, int(connState.Version))
+		suite.Equal(tlsVersion, connState.Version)
 		suite.True(connState.HandshakeComplete)
 		suite.False(connState.DidResume)
 		suite.Equal("", connState.NegotiatedProtocol)
@@ -236,13 +236,15 @@ func (suite *serverSuite) TestTLSConfigWithRequest() {
 	go srv.ListenAndServeTLS()
 
 	// Send a request
-	config := tls.Config{
+	clientTLSConfig := tls.Config{
 		RootCAs:      caCertPool,
 		Certificates: certificates,
+		MinVersion:   tlsVersion,
+		MaxVersion:   tlsVersion,
 	}
 	client := &http.Client{
 		Transport: &http.Transport{
-			TLSClientConfig: &config,
+			TLSClientConfig: &clientTLSConfig,
 		},
 	}
 	res, err := client.Get(fmt.Sprintf("https://%s:%d", host, port))
@@ -257,9 +259,18 @@ func (suite *serverSuite) TestTLSConfigWithRequest() {
 	}
 
 	// Check the TLS connection directly
-	conn, err := tls.Dial("tcp", fmt.Sprintf("%s:%d", host, port), &config)
+	conn, err := tls.Dial("tcp", fmt.Sprintf("%s:%d", host, port), &clientTLSConfig)
 	defer conn.Close()
 	suite.NoError(err)
+}
+
+func (suite *serverSuite) TestTLSConfigWithRequest() {
+	var versions = map[string]uint16{"1.2": tls.VersionTLS12, "1.3": tls.VersionTLS13}
+	for name, version := range versions {
+		suite.T().Run(fmt.Sprintf("TLS version %s", name), func(t *testing.T) {
+			suite.testTLSConfigWithRequest(version)
+		})
+	}
 }
 
 func (suite *serverSuite) TestTLSConfigWithRequestNoClientAuth() {

--- a/scripts/check-go-version
+++ b/scripts/check-go-version
@@ -2,14 +2,14 @@
 
 set -eu -o pipefail
 
-VERSION="go1.12"
+VERSION="go1.13"
 
 GOLANG_VERSION=$(go version)
 if [[ $GOLANG_VERSION = *$VERSION* ]]; then
   echo "Golang $GOLANG_VERSION installed"
 else
   echo "Golang $VERSION is required to run this project! Found $GOLANG_VERSION"
-  echo "Run 'brew install go@1.12 && brew link --force go@1.12' to install"
+  echo "Run 'brew install go && brew link --force go' to install"
   exit 1
 fi
 

--- a/scripts/check-go-version
+++ b/scripts/check-go-version
@@ -9,7 +9,9 @@ if [[ $GOLANG_VERSION = *$VERSION* ]]; then
   echo "Golang $GOLANG_VERSION installed"
 else
   echo "Golang $VERSION is required to run this project! Found $GOLANG_VERSION"
-  echo "Run 'brew install go && brew link --force go' to install"
+  echo "Install go with 'brew install go'"
+  echo "or if that version is ahead of ${GOLANG_VERSION} then run:"
+  echo "Run 'brew install go@1.13 && brew link --force go@1.13' to install"
   exit 1
 fi
 


### PR DESCRIPTION
## Description

This PR:
* Updates our app to run on Go 1.13.1.
* Adds a test to ensure that TLS 1.2 clients can still connect to the app as Go 1.13 supports TLS1.3 and uses it by default.
* Tweaks the go caches on CircleCI to be invalidated when the go version changes
* Updates our CircleCI config to use a container that includes Go 1.13.1.

## Code Review Verification Steps

* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/168845215) for this change