### PR TITLE
Update data type for zip3 and service area in new rate engine

### DIFF
--- a/migrations/20191011183006_alter_column_type_to_string_.up.sql
+++ b/migrations/20191011183006_alter_column_type_to_string_.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE re_domestic_service_areas ALTER COLUMN service_area TYPE varchar(80);
+ALTER TABLE re_zip3s ALTER COLUMN zip3 TYPE varchar(80);

--- a/migrations/20191011183006_alter_column_type_to_string_.up.sql
+++ b/migrations/20191011183006_alter_column_type_to_string_.up.sql
@@ -1,2 +1,2 @@
 ALTER TABLE re_domestic_service_areas ALTER COLUMN service_area TYPE varchar(80);
-ALTER TABLE re_zip3s ALTER COLUMN zip3 TYPE varchar(80);
+ALTER TABLE re_zip3s ALTER COLUMN zip3 TYPE varchar(3);

--- a/migrations_manifest.txt
+++ b/migrations_manifest.txt
@@ -361,3 +361,4 @@
 20190927150748_insert_duty_station_names.up.sql
 20190930152918_import_bvs_performance_period_4.up.sql
 20191008151614_re_create_reference_tables.up.sql
+20191011183006_alter_column_type_to_string_.up.sql

--- a/pkg/models/re_contract_test.go
+++ b/pkg/models/re_contract_test.go
@@ -20,11 +20,11 @@ func (suite *ModelSuite) TestReContractValidations() {
 	})
 
 	suite.T().Run("test empty ReContract", func(t *testing.T) {
-		emptyReContract := &models.ReContract{}
+		emptyReContract := models.ReContract{}
 		expErrors := map[string][]string{
 			"code": {"Code can not be blank."},
 			"name": {"Name can not be blank."},
 		}
-		suite.verifyValidationErrors(emptyReContract, expErrors)
+		suite.verifyValidationErrors(&emptyReContract, expErrors)
 	})
 }

--- a/pkg/models/re_contract_year_test.go
+++ b/pkg/models/re_contract_year_test.go
@@ -26,7 +26,7 @@ func (suite *ModelSuite) TestReContractYearValidations() {
 	})
 
 	suite.T().Run("test empty ReContractYear", func(t *testing.T) {
-		emptyReContractYear := &models.ReContractYear{}
+		emptyReContractYear := models.ReContractYear{}
 		expErrors := map[string][]string{
 			"contract_id":           {"ContractID can not be blank."},
 			"name":                  {"Name can not be blank."},
@@ -35,7 +35,7 @@ func (suite *ModelSuite) TestReContractYearValidations() {
 			"escalation":            {"Escalation can not be blank.", "0.000000 is not greater than 0.000000."},
 			"escalation_compounded": {"EscalationCompounded can not be blank.", "0.000000 is not greater than 0.000000."},
 		}
-		suite.verifyValidationErrors(emptyReContractYear, expErrors)
+		suite.verifyValidationErrors(&emptyReContractYear, expErrors)
 	})
 
 	suite.T().Run("test end date after start date, negative escalation, negative escalation compounded for ReContractYear", func(t *testing.T) {

--- a/pkg/models/re_domestic_service_area.go
+++ b/pkg/models/re_domestic_service_area.go
@@ -14,7 +14,7 @@ type ReDomesticServiceArea struct {
 	ID              uuid.UUID `json:"id" db:"id"`
 	BasePointCity   string    `json:"base_point_city" db:"base_point_city"`
 	State           string    `json:"state" db:"state"`
-	ServiceArea     int       `json:"service_area" db:"service_area"`
+	ServiceArea     string    `json:"service_area" db:"service_area"`
 	ServiceSchedule int       `json:"service_schedule" db:"service_schedule"`
 	SITPDSchedule   int       `json:"sit_pd_schedule" db:"sit_pd_schedule"`
 	CreatedAt       time.Time `json:"created_at" db:"created_at"`
@@ -30,7 +30,7 @@ func (r *ReDomesticServiceArea) Validate(tx *pop.Connection) (*validate.Errors, 
 	return validate.Validate(
 		&validators.StringIsPresent{Field: r.BasePointCity, Name: "BasePointCity"},
 		&validators.StringIsPresent{Field: r.State, Name: "State"},
-		&validators.IntIsPresent{Field: r.ServiceArea, Name: "ServiceArea"},
+		&validators.StringIsPresent{Field: r.ServiceArea, Name: "ServiceArea"},
 		&validators.IntIsGreaterThan{Field: r.ServiceSchedule, Name: "ServiceSchedule", Compared: 0},
 		&validators.IntIsLessThan{Field: r.ServiceSchedule, Name: "ServiceSchedule", Compared: 4},
 		&validators.IntIsGreaterThan{Field: r.SITPDSchedule, Name: "SITPDSchedule", Compared: 0},

--- a/pkg/models/re_domestic_service_area_test.go
+++ b/pkg/models/re_domestic_service_area_test.go
@@ -11,7 +11,7 @@ func (suite *ModelSuite) TestReDomesticServiceAreaValidation() {
 		validReDomesticServiceArea := models.ReDomesticServiceArea{
 			BasePointCity:   "New York",
 			State:           "NY",
-			ServiceArea:     9,
+			ServiceArea:     "009",
 			ServiceSchedule: 2,
 			SITPDSchedule:   2,
 		}
@@ -35,7 +35,7 @@ func (suite *ModelSuite) TestReDomesticServiceAreaValidation() {
 		invalidReDomesticServiceArea := models.ReDomesticServiceArea{
 			BasePointCity:   "New York",
 			State:           "NY",
-			ServiceArea:     9,
+			ServiceArea:     "009",
 			ServiceSchedule: 4,
 			SITPDSchedule:   5,
 		}
@@ -50,7 +50,7 @@ func (suite *ModelSuite) TestReDomesticServiceAreaValidation() {
 		invalidReDomesticServiceArea := models.ReDomesticServiceArea{
 			BasePointCity:   "New York",
 			State:           "NY",
-			ServiceArea:     9,
+			ServiceArea:     "009",
 			ServiceSchedule: -3,
 			SITPDSchedule:   -1,
 		}

--- a/pkg/models/re_domestic_service_area_test.go
+++ b/pkg/models/re_domestic_service_area_test.go
@@ -20,7 +20,7 @@ func (suite *ModelSuite) TestReDomesticServiceAreaValidation() {
 	})
 
 	suite.T().Run("test invalid ReDomesticServiceArea", func(t *testing.T) {
-		invalidReDomesticServiceArea := models.ReDomesticServiceArea{}
+		emptyReDomesticServiceArea := models.ReDomesticServiceArea{}
 		expErrors := map[string][]string{
 			"base_point_city":    {"BasePointCity can not be blank."},
 			"state":              {"State can not be blank."},
@@ -28,7 +28,7 @@ func (suite *ModelSuite) TestReDomesticServiceAreaValidation() {
 			"service_schedule":   {"0 is not greater than 0."},
 			"s_i_t_p_d_schedule": {"0 is not greater than 0."},
 		}
-		suite.verifyValidationErrors(&invalidReDomesticServiceArea, expErrors)
+		suite.verifyValidationErrors(&emptyReDomesticServiceArea, expErrors)
 	})
 
 	suite.T().Run("test schedules over 3 for ReDomesticServiceArea", func(t *testing.T) {

--- a/pkg/models/re_rate_area_test.go
+++ b/pkg/models/re_rate_area_test.go
@@ -18,11 +18,11 @@ func (suite *ModelSuite) TestReRateAreaValidation() {
 	})
 
 	suite.T().Run("test empty ReRateArea", func(t *testing.T) {
-		invalidReRateArea := models.ReRateArea{}
+		emptyReRateArea := models.ReRateArea{}
 		expErrors := map[string][]string{
 			"code": {"Code can not be blank."},
 			"name": {"Name can not be blank."},
 		}
-		suite.verifyValidationErrors(&invalidReRateArea, expErrors)
+		suite.verifyValidationErrors(&emptyReRateArea, expErrors)
 	})
 }

--- a/pkg/models/re_service_test.go
+++ b/pkg/models/re_service_test.go
@@ -17,11 +17,11 @@ func (suite *ModelSuite) TestReServiceValidation() {
 	})
 
 	suite.T().Run("test empty ReService", func(t *testing.T) {
-		invalidReService := models.ReService{}
+		emptyReService := models.ReService{}
 		expErrors := map[string][]string{
 			"code": {"Code can not be blank."},
 			"name": {"Name can not be blank."},
 		}
-		suite.verifyValidationErrors(&invalidReService, expErrors)
+		suite.verifyValidationErrors(&emptyReService, expErrors)
 	})
 }

--- a/pkg/models/re_shipment_type_test.go
+++ b/pkg/models/re_shipment_type_test.go
@@ -17,11 +17,11 @@ func (suite *ModelSuite) TestReShipmentTypeValidation() {
 	})
 
 	suite.T().Run("test empty ReShipmentType", func(t *testing.T) {
-		invalidReShipmentType := models.ReShipmentType{}
+		emptyReShipmentType := models.ReShipmentType{}
 		expErrors := map[string][]string{
 			"code": {"Code can not be blank."},
 			"name": {"Name can not be blank."},
 		}
-		suite.verifyValidationErrors(&invalidReShipmentType, expErrors)
+		suite.verifyValidationErrors(&emptyReShipmentType, expErrors)
 	})
 }

--- a/pkg/models/re_zip3s_test.go
+++ b/pkg/models/re_zip3s_test.go
@@ -19,22 +19,22 @@ func (suite *ModelSuite) TestReZip3Validations() {
 	})
 
 	suite.T().Run("test invalid ReZip3", func(t *testing.T) {
-		invalidReZip3 := &models.ReZip3{}
+		emptyReZip3 := models.ReZip3{}
 		expErrors := map[string][]string{
 			"domestic_service_area_id": {"DomesticServiceAreaID can not be blank."},
 			"zip3":                     {"Zip3 not in range(3, 3)"},
 		}
-		suite.verifyValidationErrors(invalidReZip3, expErrors)
+		suite.verifyValidationErrors(&emptyReZip3, expErrors)
 	})
 
 	suite.T().Run("test when zip3 is not a length of 3", func(t *testing.T) {
-		invalidReZip3 := &models.ReZip3{
+		invalidReZip3 := models.ReZip3{
 			DomesticServiceAreaID: uuid.Must(uuid.NewV4()),
 			Zip3:                  "60",
 		}
 		expErrors := map[string][]string{
 			"zip3": {"Zip3 not in range(3, 3)"},
 		}
-		suite.verifyValidationErrors(invalidReZip3, expErrors)
+		suite.verifyValidationErrors(&invalidReZip3, expErrors)
 	})
 }


### PR DESCRIPTION
## Description

This PR updates the following data types (and the associated models/tests) in the new rate engine reference tables:

* `re_domestic_service_areas`: change `service_area` from `integer` to `varchar(80)`
* `re_zip3s`: change `zip3` from `integer` to `varchar(3)`

In addition, a few minor style inconsistencies were fixed in the tests.

## Reviewer Notes

Note that the Pop model for `re_zip3s` already had `zip3` as a `string`, so no changes were needed there.

## Setup

- `make db_dev_reset db_dev_migrate` --> verify that the migrations applied successfully and the two fields noted above are the desired data types
- `make server_test` --> verify that all tests pass

## Code Review Verification Steps

* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/tree/master/docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
  * [ ] Secure migrations have been tested using `scripts/run-prod-migrations`
* [ ] Request review from a member of a different team.

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/168357735) for this change (note that we added the reference tables as part of implementing domestic pricing since it depended on them)
* The [data model design doc](https://docs.google.com/document/d/1yLU-QBxuRTmZSzhZAm4LqAqxAnESVIxMGGeR9xHRZlM/edit#heading=h.ozduj2uk73t) explains more about the overall data model for the new rate engine.
