### PR TITLE
Update circle-ci-primary docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,28 +15,28 @@ executors:
     resource_class: small
     working_directory: ~/transcom/mymove
     docker:
-      - image: trussworks/circleci-docker-primary:e5c10bf19185aa55354901106bad3ffd4c016265
+      - image: trussworks/circleci-docker-primary:782c370a89564e10e7ee00f6a6ad5c32309c11d5
   mymove_medium:
     resource_class: medium
     working_directory: ~/transcom/mymove
     docker:
-      - image: trussworks/circleci-docker-primary:e5c10bf19185aa55354901106bad3ffd4c016265
+      - image: trussworks/circleci-docker-primary:782c370a89564e10e7ee00f6a6ad5c32309c11d5
   mymove_medium_plus:
     resource_class: medium+
     working_directory: ~/transcom/mymove
     docker:
-      - image: trussworks/circleci-docker-primary:e5c10bf19185aa55354901106bad3ffd4c016265
+      - image: trussworks/circleci-docker-primary:782c370a89564e10e7ee00f6a6ad5c32309c11d5
   mymove_large:
     resource_class: large
     working_directory: ~/transcom/mymove
     docker:
-      - image: trussworks/circleci-docker-primary:e5c10bf19185aa55354901106bad3ffd4c016265
+      - image: trussworks/circleci-docker-primary:782c370a89564e10e7ee00f6a6ad5c32309c11d5
   # `mymove_and_postgres_medium` adds a secondary postgres container to be used during testing.
   mymove_and_postgres_medium:
     resource_class: medium
     working_directory: ~/transcom/mymove
     docker:
-      - image: trussworks/circleci-docker-primary:e5c10bf19185aa55354901106bad3ffd4c016265
+      - image: trussworks/circleci-docker-primary:782c370a89564e10e7ee00f6a6ad5c32309c11d5
       - image: postgres:10.9
         environment:
           - POSTGRES_PASSWORD: mysecretpassword
@@ -46,7 +46,7 @@ executors:
     resource_class: large
     working_directory: ~/transcom/mymove
     docker:
-      - image: trussworks/circleci-docker-primary:e5c10bf19185aa55354901106bad3ffd4c016265
+      - image: trussworks/circleci-docker-primary:782c370a89564e10e7ee00f6a6ad5c32309c11d5
       - image: postgres:10.9
         environment:
           - POSTGRES_PASSWORD: mysecretpassword

--- a/Dockerfile.dep_updater
+++ b/Dockerfile.dep_updater
@@ -1,4 +1,4 @@
-FROM trussworks/circleci-docker-primary:9b7bfbf6bfae544566ade0c896f8aacbd16281e5
+FROM trussworks/circleci-docker-primary:782c370a89564e10e7ee00f6a6ad5c32309c11d5
 
 ENV GOPATH=/home/circleci/go
 ENV GOBIN=$GOPATH/bin


### PR DESCRIPTION
## Description
In https://github.com/transcom/mymove/pull/2794 was asked to add `hub` to `circle-ci-primary` instead of fetching the binary at runtime. This PR updates `trussworks/circleci-docker-primary` from ~[e5c10bf19185aa55354901106bad3ffd4c016265](https://hub.docker.com/layers/trussworks/circleci-docker-primary/e5c10bf19185aa55354901106bad3ffd4c016265/images/sha256-7dea90b809b30a45e2d0ea4113184796005acbe5fca1f5baa696895b2dfa09f4)~ [0a7bcc19642337bcfb16d5d1a1f05da646b7ec27](https://hub.docker.com/layers/trussworks/circleci-docker-primary/0a7bcc19642337bcfb16d5d1a1f05da646b7ec27/images/sha256-00d382ad0b13d50f6d0fc7e5146944899f1e6b01fda4736422a1921e886c1530) to [782c370a89564e10e7ee00f6a6ad5c32309c11d5](https://hub.docker.com/layers/trussworks/circleci-docker-primary/782c370a89564e10e7ee00f6a6ad5c32309c11d5/images/sha256-8f68a395b0a30e1b2755a72b48f950ce4044a5b0d245d0cd1f411409f3fb939c) which includes `hub` 

## Setup

```sh
make server_test
```

## Code Review Verification Steps
* [ ] Request review from a member of a different team.