### PR TITLE
Removed references to GOPROXY; now using default with Go 1.13.x

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -224,8 +224,6 @@ jobs:
       - run:
           name: Install dependencies
           command: for i in $(seq 1 5); do go get ./... && s=0 && break || s=$? && sleep 5; done; (exit $s)
-          environment:
-            GOPROXY: https://gocenter.io
       - save_cache:
           key: go-mod-sources-v2-{{ checksum "go.sum" }}-{{ checksum "scripts/check-go-version" }}
           paths:

--- a/.envrc
+++ b/.envrc
@@ -72,9 +72,6 @@ fi
 # locally in the ~/.cache/pre-commit/repo*/ directories.
 export GO111MODULE=auto
 
-# Enable a proxy service for getting dependencies
-export GOPROXY=https://gocenter.io
-
 # Capture the root directory of the project. This works even if someone `cd`s
 # directly into a subdirectory.
 export MYMOVE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"


### PR DESCRIPTION
## Description

Our dependency updater started to get 404s back when trying to run commands such as `go get github.com/0xAX/notificator@master`.  This seems to be coming from our current GOPROXY of `https://gocenter.io`.  Using the official proxy of `https://proxy.golang.org`, the problem goes away.

Now that we've officially moved to Go 1.13.x, we don't even necessarily need to [set GOPROXY](https://golang.org/doc/go1.13#modules):

> The GOPROXY environment variable may now be set to a comma-separated list of proxy URLs or the special token direct, and its default value is now https://proxy.golang.org,direct. When resolving a package path to its containing module, the go command will try all candidate module paths on each proxy in the list in succession. An unreachable proxy or HTTP status code other than 404 or 410 terminates the search without consulting the remaining proxies.

So, this PR removes any GOPROXY setting/exporting and relies on the Go 1.13.x default instead.

## Setup

`make go_deps_update` to ensure that you don't get the 404 errors we were getting before.

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
