### PR TITLE
Don't health check tsp route

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -628,7 +628,7 @@ jobs:
     steps:
       - deploy_app_steps:
           compare_host: "" # leave blank since we want experimental to be able to roll back
-          health_check_hosts: my.experimental.move.mil,office.experimental.move.mil
+          health_check_hosts: my.experimental.move.mil,office.experimental.move.mil,admin.experimental.move.mil
 
   # `deploy_experimental_app_client_tls` updates the mutual-TLS service in the experimental environment
   deploy_experimental_app_client_tls:
@@ -696,7 +696,7 @@ jobs:
     steps:
       - deploy_app_steps:
           compare_host: my.staging.move.mil
-          health_check_hosts: my.staging.move.mil,office.staging.move.mil
+          health_check_hosts: my.staging.move.mil,office.staging.move.mil,admin.staging.move.mil
 
   # `deploy_staging_app_client_tls` updates the mutual-TLS service in the staging environment
   deploy_staging_app_client_tls:
@@ -732,7 +732,7 @@ jobs:
     steps:
       - deploy_app_steps:
           compare_host: my.move.mil
-          health_check_hosts: my.move.mil,office.move.mil
+          health_check_hosts: my.move.mil,office.move.mil,admin.move.mil
 
   # `deploy_prod_app_client_tls` updates the mutual-TLS service in the prod environment
   deploy_prod_app_client_tls:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -696,7 +696,7 @@ jobs:
     steps:
       - deploy_app_steps:
           compare_host: my.staging.move.mil
-          health_check_hosts: my.staging.move.mil,office.staging.move.mil,tsp.staging.move.mil
+          health_check_hosts: my.staging.move.mil,office.staging.move.mil
 
   # `deploy_staging_app_client_tls` updates the mutual-TLS service in the staging environment
   deploy_staging_app_client_tls:
@@ -732,7 +732,7 @@ jobs:
     steps:
       - deploy_app_steps:
           compare_host: my.move.mil
-          health_check_hosts: my.move.mil,office.move.mil,tsp.move.mil
+          health_check_hosts: my.move.mil,office.move.mil
 
   # `deploy_prod_app_client_tls` updates the mutual-TLS service in the prod environment
   deploy_prod_app_client_tls:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -628,7 +628,7 @@ jobs:
     steps:
       - deploy_app_steps:
           compare_host: "" # leave blank since we want experimental to be able to roll back
-          health_check_hosts: my.experimental.move.mil,office.experimental.move.mil,tsp.experimental.move.mil
+          health_check_hosts: my.experimental.move.mil,office.experimental.move.mil
 
   # `deploy_experimental_app_client_tls` updates the mutual-TLS service in the experimental environment
   deploy_experimental_app_client_tls:


### PR DESCRIPTION
Builds are failing due to the removal of tsp routes during the health check when deploying.
Remove tsp health check as they're not needed anymore.

Also, add health check for admin routes