### PR TITLE
Make serve tests wait for server to be ready

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/pkg/errors"
@@ -51,7 +52,8 @@ type CreateNamedServerInput struct {
 type NamedServer struct {
 	*http.Server
 	Name    string
-	IsReady bool
+	IsServerReady bool
+	IsServerReadyMutex sync.Mutex
 }
 
 // Port returns the port the server binds to.  Returns -1 if any error.
@@ -72,9 +74,26 @@ func (s *NamedServer) ListenAndServeTLS() error {
 	if err != nil {
 		return err
 	}
-	s.IsReady = true
+	s.IsServerReadyMutex.Lock()
+	s.IsServerReady = true
+	s.IsServerReadyMutex.Unlock()
 	defer listener.Close()
 	return s.Serve(listener)
+}
+
+func (s *NamedServer) IsReady() bool {
+	s.IsServerReadyMutex.Lock()
+	defer s.IsServerReadyMutex.Unlock()
+	return s.IsServerReady
+}
+
+func (s *NamedServer) WaitUntilReady() {
+	times := 0
+	// Wait for server to be ready
+	for s.IsReady() != true && times < 4 {
+		times++
+		time.Sleep(500 * time.Millisecond)
+	}
 }
 
 // CreateNamedServer returns a no-tls, tls, or mutual-tls Server based on the input given and an error, if any.

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -51,8 +51,8 @@ type CreateNamedServerInput struct {
 // NamedServer wraps *http.Server to override the definition of ListenAndServeTLS, but bypasses some restrictions.
 type NamedServer struct {
 	*http.Server
-	Name    string
-	IsServerReady bool
+	Name               string
+	IsServerReady      bool
 	IsServerReadyMutex sync.Mutex
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -50,7 +50,8 @@ type CreateNamedServerInput struct {
 // NamedServer wraps *http.Server to override the definition of ListenAndServeTLS, but bypasses some restrictions.
 type NamedServer struct {
 	*http.Server
-	Name string
+	Name    string
+	IsReady bool
 }
 
 // Port returns the port the server binds to.  Returns -1 if any error.
@@ -71,6 +72,7 @@ func (s *NamedServer) ListenAndServeTLS() error {
 	if err != nil {
 		return err
 	}
+	s.IsReady = true
 	defer listener.Close()
 	return s.Serve(listener)
 }

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/zap"
@@ -236,10 +235,7 @@ func (suite *serverSuite) testTLSConfigWithRequest(tlsVersion uint16) {
 	// Start the Server
 	go srv.ListenAndServeTLS()
 
-	// Wait for server to be ready
-	for srv.IsReady != true {
-		time.Sleep(500 * time.Millisecond)
-	}
+	srv.WaitUntilReady()
 
 	// Send a request
 	clientTLSConfig := tls.Config{
@@ -313,10 +309,7 @@ func (suite *serverSuite) TestTLSConfigWithRequestNoClientAuth() {
 	// Start the Server
 	go srv.ListenAndServeTLS()
 
-	// Wait for server to be ready
-	for srv.IsReady != true {
-		time.Sleep(500 * time.Millisecond)
-	}
+	srv.WaitUntilReady()
 
 	// Send a request without TLS client side cert configuration, should return error
 	client := &http.Client{
@@ -368,10 +361,7 @@ func (suite *serverSuite) TestTLSConfigWithInvalidAuth() {
 	// Start the Server
 	go srv.ListenAndServeTLS()
 
-	// Wait for server to be ready
-	for srv.IsReady != true {
-		time.Sleep(500 * time.Millisecond)
-	}
+	srv.WaitUntilReady()
 
 	// Send a request with self signed cert and CA, but doesn't match server used CA
 	invalidKeyPair, err := tls.X509KeyPair(

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/zap"
@@ -235,6 +236,11 @@ func (suite *serverSuite) testTLSConfigWithRequest(tlsVersion uint16) {
 	// Start the Server
 	go srv.ListenAndServeTLS()
 
+	// Wait for server to be ready
+	for srv.IsReady != true {
+		time.Sleep(500 * time.Millisecond)
+	}
+
 	// Send a request
 	clientTLSConfig := tls.Config{
 		RootCAs:      caCertPool,
@@ -307,6 +313,11 @@ func (suite *serverSuite) TestTLSConfigWithRequestNoClientAuth() {
 	// Start the Server
 	go srv.ListenAndServeTLS()
 
+	// Wait for server to be ready
+	for srv.IsReady != true {
+		time.Sleep(500 * time.Millisecond)
+	}
+
 	// Send a request without TLS client side cert configuration, should return error
 	client := &http.Client{
 		Transport: &http.Transport{},
@@ -356,6 +367,11 @@ func (suite *serverSuite) TestTLSConfigWithInvalidAuth() {
 
 	// Start the Server
 	go srv.ListenAndServeTLS()
+
+	// Wait for server to be ready
+	for srv.IsReady != true {
+		time.Sleep(500 * time.Millisecond)
+	}
 
 	// Send a request with self signed cert and CA, but doesn't match server used CA
 	invalidKeyPair, err := tls.X509KeyPair(


### PR DESCRIPTION
## Description

As part of the investigation into intermittent failing server tests we found that these tests would fail if the server took too long to start. The solution was to add a flag to indicate the server was ready and have the tests wait until it was true.

## Reviewer Notes

If you add the following line at line 71 of pkg/server/server.go you can replicate the failure on CircleCI

```
time.Sleep(1 * time.Second)
```

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make clean
make server_test
```

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/tree/master/docs/backend.md#logging)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [#168881057](https://www.pivotaltracker.com/story/show/168881057) for this change
* [this slack thread](https://trussworks.slack.com/archives/CG1N07XR6/p1571066887029600) explains more about the approach used.