### PR TITLE
[WIP] Make e2ebasic file uploads viewable

### DIFF
--- a/cmd/generate-test-data/main.go
+++ b/cmd/generate-test-data/main.go
@@ -156,9 +156,9 @@ func main() {
 
 		// Initialize storage and uploader
 		zap.L().Info("Using memory storage backend")
-		//fsParams := storage.NewMemoryParams("tmp", "testdata", logger)
-		//storer := storage.NewMemory(fsParams)
-		fsParams := storage.NewFilesystemParams("tmp", "storage", logger)
+		localStorageRoot := v.GetString(cli.LocalStorageRootFlag)
+		localStorageWebRoot := v.GetString(cli.LocalStorageWebRootFlag)
+		fsParams := storage.NewFilesystemParams(localStorageRoot, localStorageWebRoot, logger)
 		storer := storage.NewFilesystem(fsParams)
 		loader, uploaderErr := uploader.NewUploader(dbConnection, logger, storer, 25*uploader.MB)
 		if uploaderErr != nil {

--- a/cmd/generate-test-data/main.go
+++ b/cmd/generate-test-data/main.go
@@ -156,8 +156,10 @@ func main() {
 
 		// Initialize storage and uploader
 		zap.L().Info("Using memory storage backend")
-		fsParams := storage.NewMemoryParams("tmp", "testdata", logger)
-		storer := storage.NewMemory(fsParams)
+		//fsParams := storage.NewMemoryParams("tmp", "testdata", logger)
+		//storer := storage.NewMemory(fsParams)
+		fsParams := storage.NewFilesystemParams("tmp", "storage", logger)
+		storer := storage.NewFilesystem(fsParams)
 		loader, uploaderErr := uploader.NewUploader(dbConnection, logger, storer, 25*uploader.MB)
 		if uploaderErr != nil {
 			logger.Fatal("could not instantiate uploader", zap.Error(err))

--- a/cmd/milmove/serve.go
+++ b/cmd/milmove/serve.go
@@ -579,7 +579,17 @@ func serveFunction(cmd *cobra.Command, args []string) error {
 	handlerContext.SetDPSAuthParams(dpsAuthParams)
 
 	// Base routes
-	site := goji.NewMux()
+	bare := goji.NewMux()
+	storageBackend := v.GetString(cli.StorageBackendFlag)
+	if storageBackend == "local" {
+		localStorageRoot := v.GetString(cli.LocalStorageRootFlag)
+		localStorageWebRoot := v.GetString(cli.LocalStorageWebRootFlag)
+		//Add a file handler to provide access to files uploaded in development
+		fs := storage.NewFilesystemHandler(localStorageRoot)
+		bare.Handle(pat.Get(path.Join("/", localStorageWebRoot, "/*")), fs)
+	}
+	site := goji.SubMux()
+	bare.Handle(pat.New("/*"), site)
 	// Add middleware: they are evaluated in the reverse order in which they
 	// are added, but the resulting http.Handlers execute in "normal" order
 	// (i.e., the http.Handler returned by the first Middleware added gets
@@ -825,16 +835,6 @@ func serveFunction(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	storageBackend := v.GetString(cli.StorageBackendFlag)
-	if storageBackend == "local" {
-		localStorageRoot := v.GetString(cli.LocalStorageRootFlag)
-		localStorageWebRoot := v.GetString(cli.LocalStorageWebRootFlag)
-
-		// Add a file handler to provide access to files uploaded in development
-		fs := storage.NewFilesystemHandler(localStorageRoot)
-		root.Handle(pat.Get(path.Join("/", localStorageWebRoot, "/*")), fs)
-	}
-
 	// Serve index.html to all requests that haven't matches a previous route,
 	root.HandleFunc(pat.Get("/*"), indexHandler(build, logger))
 
@@ -848,7 +848,7 @@ func serveFunction(cmd *cobra.Command, args []string) error {
 			Host:        listenInterface,
 			Port:        v.GetInt(cli.NoTLSPortFlag),
 			Logger:      logger,
-			HTTPHandler: site,
+			HTTPHandler: bare,
 		})
 		if err != nil {
 			logger.Fatal("error creating no-tls server", zap.Error(err))
@@ -864,7 +864,7 @@ func serveFunction(cmd *cobra.Command, args []string) error {
 			Host:         listenInterface,
 			Port:         v.GetInt(cli.TLSPortFlag),
 			Logger:       logger,
-			HTTPHandler:  site,
+			HTTPHandler:  bare,
 			ClientAuth:   tls.NoClientCert,
 			Certificates: certificates,
 		})
@@ -882,7 +882,7 @@ func serveFunction(cmd *cobra.Command, args []string) error {
 			Host:         listenInterface,
 			Port:         v.GetInt(cli.MutualTLSPortFlag),
 			Logger:       logger,
-			HTTPHandler:  site,
+			HTTPHandler:  bare,
 			ClientAuth:   tls.RequireAndVerifyClientCert,
 			Certificates: certificates,
 			ClientCAs:    rootCAs,

--- a/pkg/middleware/security_headers.go
+++ b/pkg/middleware/security_headers.go
@@ -10,9 +10,9 @@ var securityHeaders = map[string]string{
 	"strict-transport-security": "max-age=31536000; includeSubdomains; preload",
 	// Sets headers to prevent rendering our page in an iframe, prevents clickjacking
 	// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options
-	"X-Frame-Options": "deny",
+	"X-Frame-Options": "sameorigin",
 	// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/frame-ancestors
-	"Content-Security-Policy": "frame-ancestors 'none'",
+	"Content-Security-Policy": `frame-ancestors 'self'`,
 	// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection
 	"X-XSS-Protection": "1; mode=block",
 }

--- a/pkg/middleware/security_headers.go
+++ b/pkg/middleware/security_headers.go
@@ -10,9 +10,9 @@ var securityHeaders = map[string]string{
 	"strict-transport-security": "max-age=31536000; includeSubdomains; preload",
 	// Sets headers to prevent rendering our page in an iframe, prevents clickjacking
 	// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options
-	"X-Frame-Options": "sameorigin",
+	"X-Frame-Options": "deny",
 	// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/frame-ancestors
-	"Content-Security-Policy": `frame-ancestors 'self'`,
+	"Content-Security-Policy": "frame-ancestors 'none'",
 	// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection
 	"X-XSS-Protection": "1; mode=block",
 }

--- a/pkg/testdatagen/scenario/e2ebasic.go
+++ b/pkg/testdatagen/scenario/e2ebasic.go
@@ -29,7 +29,7 @@ var nextValidMoveDatePlusTen = dates.NextValidMoveDate(nextValidMoveDate.AddDate
 var nextValidMoveDateMinusTen = dates.NextValidMoveDate(nextValidMoveDate.AddDate(0, 0, -10), cal)
 
 // Run does that data load thing
-func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, logger Logger, storer *storage.Memory) {
+func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, logger Logger, storer *storage.Filesystem) {
 	/*
 	 * Basic user with office access
 	 */


### PR DESCRIPTION
## Description

When running `milmove` in local dev, files associated with the test cases in `e2ebasic.go` were not viewable because, for local storage we were using `storage.Memory` instead of `storage.Filesystem` in `e2ebasic.go`. This PR updates `e2ebasic.go` to use `storage.Filesystem`. 

In making this update another issue was discovered that was preventing all locally uploaded / served pdfs from being viewed on local dev. The security headers `X-Frame-Options` and `Content-Security-Policy` in [security_headers.go]( https://github.com/transcom/mymove/blob/master/pkg/middleware/security_headers.go#L7-L18), were blocking locally served files from being embedded within our own site. In order to fix this issue we created a `bare` muxer, which has no middleware attached and is used exclusively for serving local files. The `site` muxer and its accompanying middleware is now attached to `bare`.

## Reviewer Notes

On master run `make db_dev_e2e_populate`. Open the office app and navigate to the document uploader. None of the documents created by `db_dev_e2e_populate` should be viewable. Also, any pdf uploaded from local dev (not just those created by `db_dev_e2e_populate`), should be viewable in the document uploader. Check out this branch and rerun `make db_dev_e2e_populate`. Now the documents should be viewable and pdfs uploaded from local dev should be viewable as well.

## Setup

```sh
make db_dev_e2e_populate
make office_client_run
```

## Code Review Verification Steps
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/n/projects/2181745/stories/167790814) for this change