### PR TITLE
Fixed a few lingering go 1.12 references

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,7 @@ There are a number of things you'll need at a minimum to be able to check out, d
 * Install [Homebrew](https://brew.sh)
   * Use the following command `/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"`
 * We normally use the latest version of Go unless there's a known conflict (which will be announced by the team) or if we're in the time period just after a new version has been released.
-  * We are still using go 1.12 for now; we will be migrating to go 1.13 soon (the trigger is when we update Go in our baseline CircleCI Docker container).
-  * Install it with Homebrew: `brew install go@1.12 && brew link --force go@1.12`
+  * Install it with Homebrew: `brew install go`
   * **Note**: If you have previously modified your PATH to point to a specific version of go, make sure to remove that. This would be either in your `.bash_profile` or `.bashrc`, and might look something like `PATH=$PATH:/usr/local/opt/go@1.12/bin`.
 * Ensure you are using the latest version of bash for this project:
   * Install it with Homebrew: `brew install bash`

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/transcom/mymove
 
-go 1.12
+go 1.13
 
 require (
 	github.com/0xAX/notificator v0.0.0-20181105090803-d81462e38c21 // indirect

--- a/scripts/prereqs
+++ b/scripts/prereqs
@@ -15,7 +15,7 @@ function has() {
     fi
 }
 
-has go "brew install go@1.12 && brew link --force go@1.12"
+has go "brew install go"
 has bash "brew install bash"
 has yarn "brew install yarn"
 has pre-commit "brew install pre-commit"


### PR DESCRIPTION
## Description

I noticed a few lingering `go 1.12` references in docs as well as `go.mod` (where we set the [expected go version](https://golang.org/cmd/go/#hdr-The_go_mod_file)).

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
