### PR TITLE
Add "deactivated" column and replace "disabled" in the codebase

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -32,7 +32,7 @@ If you are looking to understand choices made in this project, see the list of [
 * [Add Application Logging](how-to/add-application-logging.md#how-to-add-application-logging)
 * [Backup and Restore the Development Database](how-to/backup-and-restore-dev-database.md#how-to-backup-and-restore-the-development-database)
 * [Create An ECS Scheduled Task](how-to/create-an-ecs-scheduled-task.md#how-to-create-an-ecs-scheduled-task)
-* [Create or Disable Users](how-to/create-or-disable-users.md#how-to-create-or-disable-users)
+* [Create or Deactivate Users](how-to/create-or-deactivate-users.md#how-to-create-or-deactivate-users)
 * [Deploy to Experimental](how-to/deploy-to-experimental.md#how-to-deploy-to-experimental)
 * [display dates and times](how-to/display-dates-and-times.md#how-to-display-dates-and-times)
 * [Generate Mocks with Mockery](how-to/generate-mocks-with-mockery.md#how-to-generate-mocks-with-mockery)

--- a/docs/how-to/create-or-deactivate-users.md
+++ b/docs/how-to/create-or-deactivate-users.md
@@ -184,10 +184,10 @@ INSERT INTO public.dps_users
     );
 ```
 
-## Disabling Users
+## Deactivating Users
 
 MilMove doesn't delete users because of both auditing concerns and CASCADE DELETE failures. Instead each
-user table has a `deactivated` boolean column that can be used to deactivate a user. Disabling a user means the
+user table has a `deactivated` boolean column that can be used to deactivate a user. Deactivating a user means the
 person with valid credentials to Login.gov may not be permitted to get a session in MilMove.
 
 There are several places you can deactivate a user, at the global level and at each application level. It's important
@@ -195,9 +195,9 @@ to deactivate users at the application level if you are concerned that a user en
 table but they have not yet claimed the user entry by logging in.  This is an issue to be aware of for both Office
 and TSP users.
 
-### Disabling Users Globally
+### Deactivating Users Globally
 
-An example of disabling a user by email:
+An example of deactivating a user by email:
 
 ```sql
 UPDATE users SET deactivated = true WHERE email = 'username@example.com';
@@ -205,7 +205,7 @@ UPDATE users SET deactivated = true WHERE email = 'username@example.com';
 
 This is the only way to deactivate Service Members.
 
-### Disabling Office Users
+### Deactivating Office Users
 
 This can now be done in the admin user application:
 
@@ -214,17 +214,21 @@ This can now be done in the admin user application:
 3. Select the user you would like to deactivate and click "Edit" in the top right
    corner. Here, you'll be able to choose whether or not that user is deactivated.
 
-### Disabling TSP Users
+### Deactivating TSP Users
 
-An example of disabling a TSP user by email:
+**Note**: if we revive this table after the HHG mothball work, we will need to
+change the `disabled` column to `deactivated`, as well as replace references to
+`disabled` throughout the TSP app.
+
+An example of deactivating a TSP user by email:
 
 ```sql
 UPDATE tsp_users SET deactivated = true WHERE email = 'username@example.com';
 ```
 
-### Disabling DPS Users
+### Deactivating DPS Users
 
-An example of disabling a DPS user by email:
+An example of deactivating a DPS user by email:
 
 ```sql
 UPDATE dps_users SET deactivated = true WHERE email = 'username@example.com';

--- a/docs/how-to/create-or-deactivate-users.md
+++ b/docs/how-to/create-or-deactivate-users.md
@@ -1,7 +1,7 @@
-# How To Create or Disable Users
+# How To Create or Deactivate Users
 
 For all users you will [create a secure migration](./migrate-the-database.md#secure-migrations). Please
-only create a migration corresponding to the environment where you intend to add or disable users. For instance,
+only create a migration corresponding to the environment where you intend to add or deactivate users. For instance,
 please only add a `staging` secure migration if you intend to add staging users and leave the `prod`
 and `experimental` migrations empty.
 
@@ -38,7 +38,7 @@ INSERT INTO public.office_users
      last_name, first_name, middle_initials,
      email, telephone,
      transportation_office_id,
-     created_at, updated_at, disabled)
+     created_at, updated_at, deactivated)
     VALUES (
            GENERATED_UUID4_VAL, NULL,
            'Jones', 'Alice', NULL,
@@ -114,7 +114,7 @@ INSERT INTO public.tsp_users
      last_name, first_name, middle_initials,
      email, telephone,
      transportation_service_provider_id,
-     created_at, updated_at, disabled)
+     created_at, updated_at, deactivated)
     VALUES (
         GENERATED_UUID4_VAL, NULL,
         'Jones', 'Alice', NULL,
@@ -132,7 +132,7 @@ INSERT INTO public.tsp_users
      last_name, first_name, middle_initials,
      email, telephone,
      transportation_service_provider_id,
-     created_at, updated_at, disabled)
+     created_at, updated_at, deactivated)
     VALUES (
         GENERATED_UUID4_VAL, NULL,
         'Jones', 'Alice', NULL,
@@ -145,7 +145,7 @@ INSERT INTO public.tsp_users
      last_name, first_name, middle_initials,
      email, telephone,
      transportation_service_provider_id,
-     created_at, updated_at, disabled)
+     created_at, updated_at, deactivated)
     VALUES (
         GENERATED_UUID4_VAL, NULL,
         'Jones', 'Alice', NULL,
@@ -158,7 +158,7 @@ INSERT INTO public.tsp_users
      last_name, first_name, middle_initials,
      email, telephone,
      transportation_service_provider_id,
-     created_at, updated_at, disabled)
+     created_at, updated_at, deactivated)
     VALUES (
         GENERATED_UUID4_VAL, NULL,
         'Jones', 'Alice', NULL,
@@ -177,7 +177,7 @@ Here is an example migration to create a DPS user (please edit as needed):
 ```sql
 INSERT INTO public.dps_users
     (id, login_gov_email,
-     created_at, updated_at, disabled)
+     created_at, updated_at, deactivated)
     VALUES (
         GENERATED_UUID4_VAL, 'username@example.com',
         now(), now(), false
@@ -187,11 +187,11 @@ INSERT INTO public.dps_users
 ## Disabling Users
 
 MilMove doesn't delete users because of both auditing concerns and CASCADE DELETE failures. Instead each
-user table has a `disabled` boolean column that can be used to disable a user. Disabling a user means the
+user table has a `deactivated` boolean column that can be used to deactivate a user. Disabling a user means the
 person with valid credentials to Login.gov may not be permitted to get a session in MilMove.
 
-There are several places you can disable a user, at the global level and at each application level. It's important
-to disable users at the application level if you are concerned that a user entry was made for the user in that
+There are several places you can deactivate a user, at the global level and at each application level. It's important
+to deactivate users at the application level if you are concerned that a user entry was made for the user in that
 table but they have not yet claimed the user entry by logging in.  This is an issue to be aware of for both Office
 and TSP users.
 
@@ -200,10 +200,10 @@ and TSP users.
 An example of disabling a user by email:
 
 ```sql
-UPDATE users SET disabled = true WHERE email = 'username@example.com';
+UPDATE users SET deactivated = true WHERE email = 'username@example.com';
 ```
 
-This is the only way to disable Service Members.
+This is the only way to deactivate Service Members.
 
 ### Disabling Office Users
 
@@ -211,15 +211,15 @@ This can now be done in the admin user application:
 
 1. Navigate to the admin app and log in
 2. Click on "Office Users" in the sidebar
-3. Select the user you would like to disable and click "Edit" in the top right
-   corner. Here, you'll be able to choose whether or not that user is disabled.
+3. Select the user you would like to deactivate and click "Edit" in the top right
+   corner. Here, you'll be able to choose whether or not that user is deactivated.
 
 ### Disabling TSP Users
 
 An example of disabling a TSP user by email:
 
 ```sql
-UPDATE tsp_users SET disabled = true WHERE email = 'username@example.com';
+UPDATE tsp_users SET deactivated = true WHERE email = 'username@example.com';
 ```
 
 ### Disabling DPS Users
@@ -227,11 +227,11 @@ UPDATE tsp_users SET disabled = true WHERE email = 'username@example.com';
 An example of disabling a DPS user by email:
 
 ```sql
-UPDATE dps_users SET disabled = true WHERE email = 'username@example.com';
+UPDATE dps_users SET deactivated = true WHERE email = 'username@example.com';
 ```
 
-### Generating a migration to disable a specific user
+### Generating a migration to deactivate a specific user
 
 You can use the following `milmove` sub-command:
 
-`milmove gen disable-user-migration -e EMAIL`
+`milmove gen deactivate-user-migration -e EMAIL`

--- a/internal/pkg/dutystationsloader/duty_stations_loader_test.go
+++ b/internal/pkg/dutystationsloader/duty_stations_loader_test.go
@@ -92,7 +92,7 @@ func (suite *DutyStationsLoaderSuite) TestCreateInsertQuery() {
 	query := builder.createInsertQuery(model, &pop.Model{Value: models.User{}})
 
 	suite.Equal(
-		"INSERT into users (id, created_at, updated_at, login_gov_uuid, login_gov_email, disabled) VALUES ('cd40c92e-7c8a-4da4-ad58-4480df84b3f0', now(), now(), 'cd40c92e-7c8a-4da4-ad58-4480df84b3f1', 'email@example.com', false);\n",
+		"INSERT into users (id, created_at, updated_at, login_gov_uuid, login_gov_email, deactivated) VALUES ('cd40c92e-7c8a-4da4-ad58-4480df84b3f0', now(), now(), 'cd40c92e-7c8a-4da4-ad58-4480df84b3f1', 'email@example.com', false);\n",
 		query)
 }
 

--- a/migrations/20191016153532_replace_disabled.up.sql
+++ b/migrations/20191016153532_replace_disabled.up.sql
@@ -1,0 +1,23 @@
+ALTER TABLE users
+ADD COLUMN deactivated BOOLEAN NOT NULL DEFAULT FALSE;
+
+ALTER TABLE office_users
+ADD COLUMN deactivated BOOLEAN NOT NULL DEFAULT FALSE;
+
+ALTER TABLE admin_users
+ADD COLUMN deactivated BOOLEAN NOT NULL DEFAULT FALSE;
+
+ALTER TABLE dps_users
+ADD COLUMN deactivated BOOLEAN NOT NULL DEFAULT FALSE;
+
+UPDATE users
+SET deactivated = disabled;
+
+UPDATE office_users
+SET deactivated = disabled;
+
+UPDATE admin_users
+SET deactivated = disabled;
+
+UPDATE dps_users
+SET deactivated = disabled;

--- a/migrations/20191016214136_remove_disabled_column.up.sql
+++ b/migrations/20191016214136_remove_disabled_column.up.sql
@@ -1,0 +1,11 @@
+ALTER TABLE users
+DROP COLUMN disabled;
+
+ALTER TABLE office_users
+DROP COLUMN disabled;
+
+ALTER TABLE admin_users
+DROP COLUMN disabled;
+
+ALTER TABLE dps_users
+DROP COLUMN disabled;

--- a/migrations_manifest.txt
+++ b/migrations_manifest.txt
@@ -365,3 +365,4 @@
 20191011183006_alter_column_type_to_string_.up.sql
 20191011191842_re_create_domestic_tables.up.sql
 20191016153532_replace_disabled.up.sql
+20191016214136_remove_disabled_column.up.sql

--- a/migrations_manifest.txt
+++ b/migrations_manifest.txt
@@ -364,3 +364,4 @@
 20191011162818_add-admin-users.up.sql
 20191011183006_alter_column_type_to_string_.up.sql
 20191011191842_re_create_domestic_tables.up.sql
+20191016153532_replace_disabled.up.sql

--- a/pkg/auth/authentication/auth.go
+++ b/pkg/auth/authentication/auth.go
@@ -349,8 +349,8 @@ func (h CallbackHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 func authorizeKnownUser(userIdentity *models.UserIdentity, h CallbackHandler, session *auth.Session, w http.ResponseWriter, r *http.Request, lURL string) {
 
-	if userIdentity.Disabled {
-		h.logger.Error("Disabled user requesting authentication",
+	if userIdentity.Deactivated {
+		h.logger.Error("Deactivated user requesting authentication",
 			zap.String("application_name", string(session.ApplicationName)),
 			zap.String("hostname", session.Hostname),
 			zap.String("user_id", session.UserID.String()),
@@ -365,13 +365,13 @@ func authorizeKnownUser(userIdentity *models.UserIdentity, h CallbackHandler, se
 		session.ServiceMemberID = *(userIdentity.ServiceMemberID)
 	}
 
-	if userIdentity.DpsUserID != nil && (userIdentity.DpsDisabled != nil && !*userIdentity.DpsDisabled) {
+	if userIdentity.DpsUserID != nil && (userIdentity.DpsDeactivated != nil && !*userIdentity.DpsDeactivated) {
 		session.DpsUserID = *(userIdentity.DpsUserID)
 	}
 
 	if session.IsOfficeApp() {
-		if userIdentity.OfficeDisabled != nil && *userIdentity.OfficeDisabled {
-			h.logger.Error("Office user is disabled", zap.String("email", session.Email))
+		if userIdentity.OfficeDeactivated != nil && *userIdentity.OfficeDeactivated {
+			h.logger.Error("Office user is deactivated", zap.String("email", session.Email))
 			http.Error(w, http.StatusText(403), http.StatusForbidden)
 			return
 		}
@@ -401,8 +401,8 @@ func authorizeKnownUser(userIdentity *models.UserIdentity, h CallbackHandler, se
 	}
 
 	if session.IsAdminApp() {
-		if userIdentity.AdminUserDisabled != nil && *userIdentity.AdminUserDisabled {
-			h.logger.Error("Admin user is disabled", zap.String("email", session.Email))
+		if userIdentity.AdminUserDeactivated != nil && *userIdentity.AdminUserDeactivated {
+			h.logger.Error("Admin user is deactivated", zap.String("email", session.Email))
 			http.Error(w, http.StatusText(403), http.StatusForbidden)
 			return
 		}
@@ -468,8 +468,8 @@ func authorizeUnknownUser(openIDUser goth.User, h CallbackHandler, session *auth
 			http.Error(w, http.StatusText(500), http.StatusInternalServerError)
 			return
 		}
-		if officeUser.Disabled {
-			h.logger.Error("Office user is disabled", zap.String("email", session.Email))
+		if officeUser.Deactivated {
+			h.logger.Error("Office user is deactivated", zap.String("email", session.Email))
 			http.Error(w, http.StatusText(403), http.StatusForbidden)
 			return
 		}
@@ -492,8 +492,8 @@ func authorizeUnknownUser(openIDUser goth.User, h CallbackHandler, session *auth
 			http.Error(w, http.StatusText(500), http.StatusInternalServerError)
 			return
 		}
-		if adminUser.Disabled {
-			h.logger.Error("Admin user is disabled", zap.String("email", session.Email))
+		if adminUser.Deactivated {
+			h.logger.Error("Admin user is deactivated", zap.String("email", session.Email))
 			http.Error(w, http.StatusText(403), http.StatusForbidden)
 			return
 		}

--- a/pkg/auth/authentication/auth_test.go
+++ b/pkg/auth/authentication/auth_test.go
@@ -161,7 +161,7 @@ func (suite *AuthSuite) TestRequireAuthMiddleware() {
 	user := models.User{
 		LoginGovUUID:  loginGovUUID,
 		LoginGovEmail: "email@example.com",
-		Disabled:      false,
+		Deactivated:   false,
 	}
 	suite.MustSave(&user)
 
@@ -207,7 +207,7 @@ func (suite *AuthSuite) TestIsLoggedInWhenUserLoggedIn() {
 	user := models.User{
 		LoginGovUUID:  loginGovUUID,
 		LoginGovEmail: "email@example.com",
-		Disabled:      false,
+		Deactivated:   false,
 	}
 	suite.MustSave(&user)
 
@@ -255,7 +255,7 @@ func (suite *AuthSuite) TestRequireAdminAuthMiddleware() {
 	user := models.User{
 		LoginGovUUID:  loginGovUUID,
 		LoginGovEmail: "email@example.com",
-		Disabled:      false,
+		Deactivated:   false,
 	}
 	suite.MustSave(&user)
 
@@ -299,9 +299,9 @@ func (suite *AuthSuite) TestRequireAdminAuthMiddlewareUnauthorized() {
 	}
 }
 
-func (suite *AuthSuite) TestAuthorizeDisableUser() {
+func (suite *AuthSuite) TestAuthorizeDeactivateUser() {
 	userIdentity := models.UserIdentity{
-		Disabled: true,
+		Deactivated: true,
 	}
 
 	req := httptest.NewRequest("GET", fmt.Sprintf("http://%s/auth/logout", OfficeTestHost), nil)
@@ -313,7 +313,7 @@ func (suite *AuthSuite) TestAuthorizeDisableUser() {
 		UserID:          fakeUUID,
 		IDToken:         fakeToken,
 		Hostname:        OfficeTestHost,
-		Email:           "disabled@example.com",
+		Email:           "deactivated@example.com",
 	}
 	ctx := auth.SetSessionInRequestContext(req, &session)
 	callbackPort := 1234
@@ -328,13 +328,13 @@ func (suite *AuthSuite) TestAuthorizeDisableUser() {
 	rr := httptest.NewRecorder()
 	authorizeKnownUser(&userIdentity, h, &session, rr, req.WithContext(ctx), "")
 
-	suite.Equal(http.StatusForbidden, rr.Code, "authorizer did not recognize disabled user")
+	suite.Equal(http.StatusForbidden, rr.Code, "authorizer did not recognize deactivated user")
 }
 
 func (suite *AuthSuite) TestAuthKnownSingleRoleOffice() {
 	officeUserID := uuid.Must(uuid.NewV4())
 	userIdentity := models.UserIdentity{
-		Disabled:     false,
+		Deactivated:  false,
 		OfficeUserID: &officeUserID,
 	}
 
@@ -365,10 +365,10 @@ func (suite *AuthSuite) TestAuthKnownSingleRoleOffice() {
 	suite.Equal(officeUserID, session.OfficeUserID)
 }
 
-func (suite *AuthSuite) TestAuthorizeDisableOfficeUser() {
-	officeDisabled := true
+func (suite *AuthSuite) TestAuthorizeDeactivateOfficeUser() {
+	officeDeactivated := true
 	userIdentity := models.UserIdentity{
-		OfficeDisabled: &officeDisabled,
+		OfficeDeactivated: &officeDeactivated,
 	}
 
 	req := httptest.NewRequest("GET", fmt.Sprintf("http://%s/auth/logout", OfficeTestHost), nil)
@@ -380,7 +380,7 @@ func (suite *AuthSuite) TestAuthorizeDisableOfficeUser() {
 		UserID:          fakeUUID,
 		IDToken:         fakeToken,
 		Hostname:        OfficeTestHost,
-		Email:           "disabled@example.com",
+		Email:           "deactivated@example.com",
 	}
 	ctx := auth.SetSessionInRequestContext(req, &session)
 	callbackPort := 1234
@@ -395,13 +395,13 @@ func (suite *AuthSuite) TestAuthorizeDisableOfficeUser() {
 	rr := httptest.NewRecorder()
 	authorizeKnownUser(&userIdentity, h, &session, rr, req.WithContext(ctx), "")
 
-	suite.Equal(http.StatusForbidden, rr.Code, "authorizer did not recognize disabled office user")
+	suite.Equal(http.StatusForbidden, rr.Code, "authorizer did not recognize deactivated office user")
 }
 
 func (suite *AuthSuite) TestRedirectLoginGovErrorMsg() {
 	officeUserID := uuid.Must(uuid.NewV4())
 	userIdentity := models.UserIdentity{
-		Disabled:     false,
+		Deactivated:  false,
 		OfficeUserID: &officeUserID,
 	}
 
@@ -462,7 +462,7 @@ func (suite *AuthSuite) TestAuthKnownSingleRoleAdmin() {
 	var adminUserRole models.AdminRole = "SYSTEM_ADMIN"
 
 	userIdentity := models.UserIdentity{
-		Disabled:      false,
+		Deactivated:   false,
 		OfficeUserID:  &officeUserID,
 		AdminUserID:   &adminUserID,
 		AdminUserRole: &adminUserRole,
@@ -500,10 +500,10 @@ func (suite *AuthSuite) TestAuthKnownSingleRoleAdmin() {
 	suite.False(session.IsProgramAdmin())
 }
 
-func (suite *AuthSuite) TestAuthorizeDisableAdmin() {
-	adminUserDisabled := true
+func (suite *AuthSuite) TestAuthorizeDeactivateAdmin() {
+	adminUserDeactivated := true
 	userIdentity := models.UserIdentity{
-		AdminUserDisabled: &adminUserDisabled,
+		AdminUserDeactivated: &adminUserDeactivated,
 	}
 
 	req := httptest.NewRequest("GET", fmt.Sprintf("http://%s/auth/logout", AdminTestHost), nil)
@@ -515,7 +515,7 @@ func (suite *AuthSuite) TestAuthorizeDisableAdmin() {
 		UserID:          fakeUUID,
 		IDToken:         fakeToken,
 		Hostname:        AdminTestHost,
-		Email:           "disabled@example.com",
+		Email:           "deactivated@example.com",
 	}
 	ctx := auth.SetSessionInRequestContext(req, &session)
 	callbackPort := 1234
@@ -530,13 +530,13 @@ func (suite *AuthSuite) TestAuthorizeDisableAdmin() {
 	rr := httptest.NewRecorder()
 	authorizeKnownUser(&userIdentity, h, &session, rr, req.WithContext(ctx), "")
 
-	suite.Equal(http.StatusForbidden, rr.Code, "authorizer did not recognize disabled admin user")
+	suite.Equal(http.StatusForbidden, rr.Code, "authorizer did not recognize deactivated admin user")
 }
 
-func (suite *AuthSuite) TestAuthorizeUnknownUserOfficeDisabled() {
+func (suite *AuthSuite) TestAuthorizeUnknownUserOfficeDeactivated() {
 	officeUser := testdatagen.MakeOfficeUser(suite.DB(), testdatagen.Assertions{
 		OfficeUser: models.OfficeUser{
-			Disabled: true,
+			Deactivated: true,
 		},
 	})
 
@@ -570,7 +570,7 @@ func (suite *AuthSuite) TestAuthorizeUnknownUserOfficeDisabled() {
 
 	authorizeUnknownUser(user, h, &session, rr, req.WithContext(ctx), "")
 
-	suite.Equal(http.StatusForbidden, rr.Code, "Office user is disabled")
+	suite.Equal(http.StatusForbidden, rr.Code, "Office user is deactivated")
 }
 
 func (suite *AuthSuite) TestAuthorizeUnknownUserOfficeNotFound() {
@@ -646,10 +646,10 @@ func (suite *AuthSuite) TestAuthorizeUnknownUserOfficeLogsIn() {
 	suite.Equal(uuid.Nil, session.AdminUserID)
 }
 
-func (suite *AuthSuite) TestAuthorizeUnknownUserAdminDisabled() {
+func (suite *AuthSuite) TestAuthorizeUnknownUserAdminDeactivated() {
 	adminUser := testdatagen.MakeAdminUser(suite.DB(), testdatagen.Assertions{
 		AdminUser: models.AdminUser{
-			Disabled: true,
+			Deactivated: true,
 		},
 	})
 
@@ -683,7 +683,7 @@ func (suite *AuthSuite) TestAuthorizeUnknownUserAdminDisabled() {
 
 	authorizeUnknownUser(user, h, &session, rr, req.WithContext(ctx), "")
 
-	suite.Equal(http.StatusForbidden, rr.Code, "Admin user is disabled")
+	suite.Equal(http.StatusForbidden, rr.Code, "Admin user is deactivated")
 }
 
 func (suite *AuthSuite) TestAuthorizeUnknownUserAdminNotFound() {

--- a/pkg/gen/adminapi/embedded_spec.go
+++ b/pkg/gen/adminapi/embedded_spec.go
@@ -814,7 +814,7 @@ func init() {
         "email",
         "user_id",
         "organization_id",
-        "disabled",
+        "deactivated",
         "created_at",
         "updated_at"
       ],
@@ -823,7 +823,7 @@ func init() {
           "type": "string",
           "format": "datetime"
         },
-        "disabled": {
+        "deactivated": {
           "type": "boolean"
         },
         "email": {
@@ -935,7 +935,7 @@ func init() {
         "last_name",
         "email",
         "telephone",
-        "disabled",
+        "deactivated",
         "created_at",
         "updated_at"
       ],
@@ -944,7 +944,7 @@ func init() {
           "type": "string",
           "format": "datetime"
         },
-        "disabled": {
+        "deactivated": {
           "type": "boolean"
         },
         "email": {
@@ -1018,7 +1018,7 @@ func init() {
     "OfficeUserUpdatePayload": {
       "type": "object",
       "properties": {
-        "disabled": {
+        "deactivated": {
           "type": "boolean"
         },
         "first_name": {
@@ -2038,7 +2038,7 @@ func init() {
         "email",
         "user_id",
         "organization_id",
-        "disabled",
+        "deactivated",
         "created_at",
         "updated_at"
       ],
@@ -2047,7 +2047,7 @@ func init() {
           "type": "string",
           "format": "datetime"
         },
-        "disabled": {
+        "deactivated": {
           "type": "boolean"
         },
         "email": {
@@ -2160,7 +2160,7 @@ func init() {
         "last_name",
         "email",
         "telephone",
-        "disabled",
+        "deactivated",
         "created_at",
         "updated_at"
       ],
@@ -2169,7 +2169,7 @@ func init() {
           "type": "string",
           "format": "datetime"
         },
-        "disabled": {
+        "deactivated": {
           "type": "boolean"
         },
         "email": {
@@ -2243,7 +2243,7 @@ func init() {
     "OfficeUserUpdatePayload": {
       "type": "object",
       "properties": {
-        "disabled": {
+        "deactivated": {
           "type": "boolean"
         },
         "first_name": {

--- a/pkg/gen/adminmessages/admin_user.go
+++ b/pkg/gen/adminmessages/admin_user.go
@@ -22,9 +22,9 @@ type AdminUser struct {
 	// Format: datetime
 	CreatedAt *strfmt.DateTime `json:"created_at"`
 
-	// disabled
+	// deactivated
 	// Required: true
-	Disabled *bool `json:"disabled"`
+	Deactivated *bool `json:"deactivated"`
 
 	// email
 	// Required: true
@@ -68,7 +68,7 @@ func (m *AdminUser) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
-	if err := m.validateDisabled(formats); err != nil {
+	if err := m.validateDeactivated(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -119,9 +119,9 @@ func (m *AdminUser) validateCreatedAt(formats strfmt.Registry) error {
 	return nil
 }
 
-func (m *AdminUser) validateDisabled(formats strfmt.Registry) error {
+func (m *AdminUser) validateDeactivated(formats strfmt.Registry) error {
 
-	if err := validate.Required("disabled", "body", m.Disabled); err != nil {
+	if err := validate.Required("deactivated", "body", m.Deactivated); err != nil {
 		return err
 	}
 

--- a/pkg/gen/adminmessages/office_user.go
+++ b/pkg/gen/adminmessages/office_user.go
@@ -22,9 +22,9 @@ type OfficeUser struct {
 	// Format: datetime
 	CreatedAt *strfmt.DateTime `json:"created_at"`
 
-	// disabled
+	// deactivated
 	// Required: true
-	Disabled *bool `json:"disabled"`
+	Deactivated *bool `json:"deactivated"`
 
 	// email
 	// Required: true
@@ -70,7 +70,7 @@ func (m *OfficeUser) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
-	if err := m.validateDisabled(formats); err != nil {
+	if err := m.validateDeactivated(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -125,9 +125,9 @@ func (m *OfficeUser) validateCreatedAt(formats strfmt.Registry) error {
 	return nil
 }
 
-func (m *OfficeUser) validateDisabled(formats strfmt.Registry) error {
+func (m *OfficeUser) validateDeactivated(formats strfmt.Registry) error {
 
-	if err := validate.Required("disabled", "body", m.Disabled); err != nil {
+	if err := validate.Required("deactivated", "body", m.Deactivated); err != nil {
 		return err
 	}
 

--- a/pkg/gen/adminmessages/office_user_update_payload.go
+++ b/pkg/gen/adminmessages/office_user_update_payload.go
@@ -17,8 +17,8 @@ import (
 // swagger:model OfficeUserUpdatePayload
 type OfficeUserUpdatePayload struct {
 
-	// disabled
-	Disabled bool `json:"disabled,omitempty"`
+	// deactivated
+	Deactivated bool `json:"deactivated,omitempty"`
 
 	// First Name
 	FirstName string `json:"first_name,omitempty"`

--- a/pkg/handlers/adminapi/admin_users.go
+++ b/pkg/handlers/adminapi/admin_users.go
@@ -22,7 +22,7 @@ func payloadForAdminUser(o models.AdminUser) *adminmessages.AdminUser {
 		Email:          handlers.FmtString(o.Email),
 		UserID:         handlers.FmtUUIDPtr(o.UserID),
 		OrganizationID: handlers.FmtUUIDPtr(o.OrganizationID),
-		Disabled:       handlers.FmtBool(o.Disabled),
+		Deactivated:    handlers.FmtBool(o.Deactivated),
 		CreatedAt:      handlers.FmtDateTime(o.CreatedAt),
 		UpdatedAt:      handlers.FmtDateTime(o.UpdatedAt),
 	}

--- a/pkg/handlers/adminapi/office_users.go
+++ b/pkg/handlers/adminapi/office_users.go
@@ -23,7 +23,7 @@ func payloadForOfficeUserModel(o models.OfficeUser) *adminmessages.OfficeUser {
 		LastName:       handlers.FmtString(o.LastName),
 		Telephone:      handlers.FmtString(o.Telephone),
 		Email:          handlers.FmtString(o.Email),
-		Disabled:       handlers.FmtBool(o.Disabled),
+		Deactivated:    handlers.FmtBool(o.Deactivated),
 		CreatedAt:      handlers.FmtDateTime(o.CreatedAt),
 		UpdatedAt:      handlers.FmtDateTime(o.UpdatedAt),
 	}
@@ -149,7 +149,7 @@ func (h UpdateOfficeUserHandler) Handle(params officeuserop.UpdateOfficeUserPara
 		LastName:       payload.LastName,
 		FirstName:      payload.FirstName,
 		Telephone:      payload.Telephone,
-		Disabled:       payload.Disabled,
+		Deactivated:    payload.Deactivated,
 	}
 
 	updatedOfficeUser, verrs, err := h.OfficeUserUpdater.UpdateOfficeUser(&officeUser)

--- a/pkg/models/admin_user.go
+++ b/pkg/models/admin_user.go
@@ -41,7 +41,7 @@ type AdminUser struct {
 	LastName       string       `json:"last_name" db:"last_name"`
 	OrganizationID *uuid.UUID   `json:"organization_id" db:"organization_id"`
 	Organization   Organization `belongs_to:"organization"`
-	Disabled       bool         `json:"disabled" db:"disabled"`
+	Deactivated    bool         `json:"deactivated" db:"deactivated"`
 }
 
 // String is not required by pop and may be deleted

--- a/pkg/models/dps_users.go
+++ b/pkg/models/dps_users.go
@@ -17,7 +17,7 @@ type DpsUser struct {
 	CreatedAt     time.Time `json:"created_at" db:"created_at"`
 	UpdatedAt     time.Time `json:"updated_at" db:"updated_at"`
 	LoginGovEmail string    `json:"login_gov_email" db:"login_gov_email"`
-	Disabled      bool      `json:"disabled" db:"disabled"`
+	Deactivated   bool      `json:"deactivated" db:"deactivated"`
 }
 
 // String is not required by pop and may be deleted

--- a/pkg/models/office_user.go
+++ b/pkg/models/office_user.go
@@ -24,7 +24,7 @@ type OfficeUser struct {
 	TransportationOffice   TransportationOffice `belongs_to:"transportation_office"`
 	CreatedAt              time.Time            `json:"created_at" db:"created_at"`
 	UpdatedAt              time.Time            `json:"updated_at" db:"updated_at"`
-	Disabled               bool                 `json:"disabled" db:"disabled"`
+	Deactivated            bool                 `json:"deactivated" db:"deactivated"`
 }
 
 // OfficeUsers is not required by pop and may be deleted

--- a/pkg/models/user.go
+++ b/pkg/models/user.go
@@ -21,7 +21,7 @@ type User struct {
 	UpdatedAt     time.Time `json:"updated_at" db:"updated_at"`
 	LoginGovUUID  uuid.UUID `json:"login_gov_uuid" db:"login_gov_uuid"`
 	LoginGovEmail string    `json:"login_gov_email" db:"login_gov_email"`
-	Disabled      bool      `json:"disabled" db:"disabled"`
+	Deactivated   bool      `json:"deactivated" db:"deactivated"`
 }
 
 // Users is not required by pop and may be deleted
@@ -77,7 +77,7 @@ func CreateUser(db *pop.Connection, loginGovID string, email string) (*User, err
 	newUser := User{
 		LoginGovUUID:  lgu,
 		LoginGovEmail: strings.ToLower(email),
-		Disabled:      false,
+		Deactivated:   false,
 	}
 	verrs, err := db.ValidateAndCreate(&newUser)
 	if verrs.HasAny() {
@@ -92,7 +92,7 @@ func CreateUser(db *pop.Connection, loginGovID string, email string) (*User, err
 // UserIdentity is summary of the information about a user from the database
 type UserIdentity struct {
 	ID                     uuid.UUID  `db:"id"`
-	Disabled               bool       `db:"disabled"`
+	Deactivated            bool       `db:"deactivated"`
 	Email                  string     `db:"email"`
 	ServiceMemberID        *uuid.UUID `db:"sm_id"`
 	ServiceMemberFirstName *string    `db:"sm_fname"`
@@ -102,14 +102,14 @@ type UserIdentity struct {
 	OfficeUserFirstName    *string    `db:"ou_fname"`
 	OfficeUserLastName     *string    `db:"ou_lname"`
 	OfficeUserMiddle       *string    `db:"ou_middle"`
-	OfficeDisabled         *bool      `db:"ou_disabled"`
+	OfficeDeactivated      *bool      `db:"ou_deactivated"`
 	AdminUserID            *uuid.UUID `db:"au_id"`
 	AdminUserRole          *AdminRole `db:"au_role"`
 	AdminUserFirstName     *string    `db:"au_fname"`
 	AdminUserLastName      *string    `db:"au_lname"`
-	AdminUserDisabled      *bool      `db:"au_disabled"`
+	AdminUserDeactivated   *bool      `db:"au_deactivated"`
 	DpsUserID              *uuid.UUID `db:"du_id"`
-	DpsDisabled            *bool      `db:"du_disabled"`
+	DpsDeactivated         *bool      `db:"du_deactivated"`
 }
 
 // FetchUserIdentity queries the database for information about the logged in user
@@ -117,7 +117,7 @@ func FetchUserIdentity(db *pop.Connection, loginGovID string) (*UserIdentity, er
 	var identities []UserIdentity
 	query := `SELECT users.id,
 				users.login_gov_email AS email,
-				users.disabled AS disabled,
+				users.deactivated AS deactivated,
 				sm.id AS sm_id,
 				sm.first_name AS sm_fname,
 				sm.last_name AS sm_lname,
@@ -126,14 +126,14 @@ func FetchUserIdentity(db *pop.Connection, loginGovID string) (*UserIdentity, er
 				ou.first_name AS ou_fname,
 				ou.last_name AS ou_lname,
 				ou.middle_initials AS ou_middle,
-				ou.disabled AS ou_disabled,
+				ou.deactivated AS ou_deactivated,
 				au.id AS au_id,
 				au.role AS au_role,
 				au.first_name AS au_fname,
 				au.last_name AS au_lname,
-				au.disabled AS au_disabled,
+				au.deactivated AS au_deactivated,
 				du.id AS du_id,
-				du.disabled AS du_disabled
+				du.deactivated AS du_deactivated
 			FROM users
 			LEFT OUTER JOIN service_members AS sm on sm.user_id = users.id
 			LEFT OUTER JOIN office_users AS ou on ou.user_id = users.id
@@ -159,7 +159,7 @@ func FetchAppUserIdentities(db *pop.Connection, appname auth.Application, limit 
 		query = `SELECT
 		        users.id,
 				users.login_gov_email AS email,
-				users.disabled AS disabled,
+				users.deactivated AS deactivated,
 				ou.id AS ou_id,
 				ou.first_name AS ou_fname,
 				ou.last_name AS ou_lname,
@@ -170,7 +170,7 @@ func FetchAppUserIdentities(db *pop.Connection, appname auth.Application, limit 
 	case auth.AdminApp:
 		query = `SELECT users.id,
 				users.login_gov_email AS email,
-				users.disabled AS disabled,
+				users.deactivated AS deactivated,
 				au.id AS au_id,
 				au.role AS au_role,
 				au.first_name AS au_fname,
@@ -181,7 +181,7 @@ func FetchAppUserIdentities(db *pop.Connection, appname auth.Application, limit 
 	default:
 		query = `SELECT users.id,
 				users.login_gov_email AS email,
-				users.disabled AS disabled,
+				users.deactivated AS deactivated,
 				sm.id AS sm_id,
 				sm.first_name AS sm_fname,
 				sm.last_name AS sm_lname,

--- a/pkg/services/office_user/office_user_updater.go
+++ b/pkg/services/office_user/office_user_updater.go
@@ -25,7 +25,7 @@ func (o *officeUserUpdater) UpdateOfficeUser(user *models.OfficeUser) (*models.O
 	foundUser.MiddleInitials = user.MiddleInitials
 	foundUser.LastName = user.LastName
 	foundUser.Telephone = user.Telephone
-	foundUser.Disabled = user.Disabled
+	foundUser.Deactivated = user.Deactivated
 
 	verrs, err := o.builder.UpdateOne(&foundUser)
 	if verrs != nil || err != nil {

--- a/pkg/testdatagen/make_admin_user.go
+++ b/pkg/testdatagen/make_admin_user.go
@@ -26,13 +26,13 @@ func MakeAdminUser(db *pop.Connection, assertions Assertions) models.AdminUser {
 	}
 
 	adminUser := models.AdminUser{
-		UserID:    &user.ID,
-		User:      user,
-		FirstName: "Leo",
-		LastName:  "Spaceman",
-		Email:     email,
-		Role:      "SYSTEM_ADMIN",
-		Disabled:  false,
+		UserID:      &user.ID,
+		User:        user,
+		FirstName:   "Leo",
+		LastName:    "Spaceman",
+		Email:       email,
+		Role:        "SYSTEM_ADMIN",
+		Deactivated: false,
 	}
 
 	mergeModels(&adminUser, assertions.AdminUser)

--- a/pkg/testdatagen/make_dps_user.go
+++ b/pkg/testdatagen/make_dps_user.go
@@ -17,7 +17,7 @@ func MakeDpsUser(db *pop.Connection, assertions Assertions) models.DpsUser {
 
 	user := models.DpsUser{
 		LoginGovEmail: email,
-		Disabled:      false,
+		Deactivated:   false,
 	}
 
 	mustCreate(db, &user)

--- a/pkg/testdatagen/make_office_user.go
+++ b/pkg/testdatagen/make_office_user.go
@@ -39,7 +39,7 @@ func MakeOfficeUser(db *pop.Connection, assertions Assertions) models.OfficeUser
 		LastName:               "Spaceman",
 		Email:                  email,
 		Telephone:              "415-555-1212",
-		Disabled:               false,
+		Deactivated:            false,
 	}
 
 	mergeModels(&officeUser, assertions.OfficeUser)

--- a/pkg/testdatagen/make_user.go
+++ b/pkg/testdatagen/make_user.go
@@ -12,7 +12,7 @@ func MakeUser(db *pop.Connection, assertions Assertions) models.User {
 	user := models.User{
 		LoginGovUUID:  uuid.Must(uuid.NewV4()),
 		LoginGovEmail: "first.last@login.gov.test",
-		Disabled:      false,
+		Deactivated:   false,
 	}
 
 	// Overwrite values with those from assertions

--- a/src/scenes/SystemAdmin/AdminUsers/AdminUserList.jsx
+++ b/src/scenes/SystemAdmin/AdminUsers/AdminUserList.jsx
@@ -9,7 +9,7 @@ const AdminUserList = props => (
       <TextField source="email" />
       <TextField source="first_name" />
       <TextField source="last_name" />
-      <BooleanField source="disabled" label="Deactivated" />
+      <BooleanField source="deactivated" />
     </Datagrid>
   </List>
 );

--- a/src/scenes/SystemAdmin/AdminUsers/AdminUserShow.jsx
+++ b/src/scenes/SystemAdmin/AdminUsers/AdminUserShow.jsx
@@ -14,7 +14,7 @@ const OfficeUserShow = props => {
         <TextField source="first_name" />
         <TextField source="last_name" />
         <TextField source="organization_id" />
-        <BooleanField source="disabled" label="Deactivated" />
+        <BooleanField source="deactivated" />
         <DateField source="created_at" showTime />
         <DateField source="updated_at" showTime />
       </SimpleShowLayout>

--- a/src/scenes/SystemAdmin/OfficeUsers/OfficeUserEdit.jsx
+++ b/src/scenes/SystemAdmin/OfficeUsers/OfficeUserEdit.jsx
@@ -17,11 +17,7 @@ const OfficeUserEdit = props => (
       <TextInput source="middle_initials" />
       <TextInput source="last_name" validate={required()} />
       <TextInput source="telephone" validate={phoneValidators} />
-      <SelectInput
-        source="disabled"
-        label="Deactivated"
-        choices={[{ id: true, name: 'Yes' }, { id: false, name: 'No' }]}
-      />
+      <SelectInput source="deactivated" choices={[{ id: true, name: 'Yes' }, { id: false, name: 'No' }]} />
       <DisabledInput source="created_at" />
       <DisabledInput source="updated_at" />
     </SimpleForm>

--- a/src/scenes/SystemAdmin/OfficeUsers/OfficeUserList.jsx
+++ b/src/scenes/SystemAdmin/OfficeUsers/OfficeUserList.jsx
@@ -9,7 +9,7 @@ const OfficeUserList = props => (
       <TextField source="email" />
       <TextField source="first_name" />
       <TextField source="last_name" />
-      <BooleanField source="disabled" label="Deactivated" />
+      <BooleanField source="deactivated" />
     </Datagrid>
   </List>
 );

--- a/src/scenes/SystemAdmin/OfficeUsers/OfficeUserShow.jsx
+++ b/src/scenes/SystemAdmin/OfficeUsers/OfficeUserShow.jsx
@@ -15,7 +15,7 @@ const OfficeUserShow = props => {
         <TextField source="middle_initials" />
         <TextField source="last_name" />
         <TextField source="telephone" />
-        <BooleanField source="disabled" label="Deactivated" />
+        <BooleanField source="deactivated" />
         <DateField source="created_at" showTime />
         <DateField source="updated_at" showTime />
       </SimpleShowLayout>

--- a/swagger/admin.yaml
+++ b/swagger/admin.yaml
@@ -58,7 +58,7 @@ definitions:
         pattern: '^[2-9]\d{2}-\d{3}-\d{4}$'
       transportation_office:
         $ref: '#/definitions/TransportationOffice'
-      disabled:
+      deactivated:
         type: boolean
       created_at:
         type: string
@@ -73,7 +73,7 @@ definitions:
       - last_name
       - email
       - telephone
-      - disabled
+      - deactivated
       - created_at
       - updated_at
   OfficeUsers:
@@ -101,7 +101,7 @@ definitions:
       organization_id:
         type: string
         format: uuid
-      disabled:
+      deactivated:
         type: boolean
       created_at:
         type: string
@@ -116,7 +116,7 @@ definitions:
       - email
       - user_id
       - organization_id
-      - disabled
+      - deactivated
       - created_at
       - updated_at
   AdminUsers:
@@ -428,7 +428,7 @@ definitions:
         format: telephone
         pattern: '^[2-9]\d{2}-\d{3}-\d{4}$'
         example: 212-555-5555
-      disabled:
+      deactivated:
         type: boolean
   ElectronicOrder:
     type: object


### PR DESCRIPTION
## Description

"Disabled" probably isn't the right word for describing users and their ability to access the Milmove system. This PR proposes replacing "disabled" with "deactivated".

## Reviewer Notes

This is the first half of a [zero-downtime migration](https://github.com/transcom/mymove/blob/a7b7d7f734cb73141d2ce8b969355bd3b96eab8d/docs/how-to/migrate-the-database.md#zero-downtime-migrations), the second half of which will remove the old `disabled` column. There will be a forthcoming PR for that when this lands in master

## Setup

- `make db_dev_migrate`

## Code Review Verification Steps

* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/tree/master/docs/database.md#zero-downtime-migrations))
/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/169100930) for this change
