### PR TITLE
[SPIKE] Split swagger file into multiple files

### DIFF
--- a/swagger-all-refs/definitions/errors.yaml
+++ b/swagger-all-refs/definitions/errors.yaml
@@ -1,0 +1,7 @@
+Error:
+  properties:
+    message:
+      type: string
+  required:
+    - message
+  type: object

--- a/swagger-all-refs/definitions/move-task-orders.yaml
+++ b/swagger-all-refs/definitions/move-task-orders.yaml
@@ -1,0 +1,292 @@
+Customer:
+  type: object
+Entitlements:
+  properties:
+    dependentsAuthorized:
+      example: true
+      type: boolean
+    nonTemporaryStorage:
+      example: false
+      type: boolean
+    privatelyOwnedVehicle:
+      example: false
+      type: boolean
+    proGearWeight:
+      example: 2000
+      type: integer
+      x-formatting: weight
+    proGearWeightSpouse:
+      example: 500
+      type: integer
+      x-formatting: weight
+    storageInTransit:
+      example: 90
+      type: integer
+    totalDependents:
+      example: 2
+      type: integer
+    totalWeightSelf:
+      example: 18000
+      type: integer
+      x-formatting: weight
+  type: object
+MoveTaskOrder:
+  properties:
+    code:
+      example: USMC-0001
+      type: string
+    createdAt:
+      format: date
+      type: string
+    customer:
+      $ref: '#/Customer'
+    deletedAt:
+      format: date
+      type: string
+    destinationDutyStation:
+      example: 1f2270c7-7166-40ae-981e-b200ebdf3054
+      format: uuid
+      type: string
+    destinationPPSO:
+      example: 1f2270c7-7166-40ae-981e-b200ebdf3054
+      format: uuid
+      type: string
+    entitlements:
+      $ref: '#/Entitlements'
+    id:
+      example: 1f2270c7-7166-40ae-981e-b200ebdf3054
+      format: uuid
+      type: string
+    moveDate:
+      format: date
+      type: string
+    moveID:
+      example: c56a4180-65aa-42ec-a945-5fd21dec0538
+      format: uuid
+      type: string
+    moveTaskOrdersType:
+      enum:
+        - NON_TEMPORARY_STORAGE
+        - PRIME
+      type: string
+    originDutyStation:
+      example: 1f2270c7-7166-40ae-981e-b200ebdf3054
+      format: uuid
+      type: string
+    originPPSO:
+      example: 1f2270c7-7166-40ae-981e-b200ebdf3054
+      format: uuid
+      type: string
+    remarks:
+      example: Requires more gentle care
+      type: string
+    requestedPickupDate:
+      format: date
+      type: string
+    serviceItems:
+      items:
+        $ref: '#/ServiceItem'
+      type: array
+    status:
+      enum:
+        - APPROVED
+        - REJECTED
+        - SUBMITTED
+      type: string
+    updatedAt:
+      format: date
+      type: string
+  type: object
+MoveTaskOrderStatus:
+  properties:
+    status:
+      enum:
+        - APPROVED
+        - SUBMITTED
+        - REJECTED
+      type: string
+  type: object
+MoveTaskOrders:
+  items:
+    $ref: '#/MoveTaskOrder'
+  type: array
+ServiceItem:
+  properties:
+    MoveTaskOrderID:
+      example: 1f2270c7-7166-40ae-981e-b200ebdf3054
+      format: uuid
+      type: string
+    approvedAt:
+      format: date
+      type: string
+    createdAt:
+      format: date
+      type: string
+    deletedAt:
+      format: date
+      type: string
+    description:
+      type: string
+    feeType:
+      enum:
+        - COUNSELING
+        - CRATING
+        - TRUCKING
+        - SHUTTLE
+      type: string
+    id:
+      example: 1f2270c7-7166-40ae-981e-b200ebdf3054
+      format: uuid
+      type: string
+    quantity:
+      type: integer
+    rate:
+      type: integer
+    rejectedAt:
+      format: date
+      type: string
+    status:
+      enum:
+        - APPROVED
+        - SUBMITTED
+        - REJECTED
+      type: string
+    submittedAt:
+      format: date
+      type: string
+    total:
+      format: cents
+      type: integer
+    updatedAt:
+      format: date
+      type: string
+  type: object
+ServiceItemStatus:
+  properties:
+    status:
+      enum:
+        - APPROVED
+        - SUBMITTED
+        - REJECTED
+      type: string
+  type: object
+CreatePaymentRequestPayload:
+  properties:
+    isFinal:
+      default: false
+      type: boolean
+    moveOrderID:
+      example: c56a4180-65aa-42ec-a945-5fd21dec0538
+      format: uuid
+      type: string
+    proofOfServicePackage:
+      $ref: '#/ProofOfServicePackage'
+    serviceItemIDs:
+      items:
+        example: c56a4180-65aa-42ec-a945-5fd21dec0538
+        format: uuid
+        type: string
+      type: array
+  type: object
+PaymentRequest:
+  properties:
+    documentPackage:
+      $ref: '#/ProofOfServicePackage'
+    id:
+      example: c56a4180-65aa-42ec-a945-5fd21dec0538
+      format: uuid
+      readOnly: true
+      type: string
+    isFinal:
+      default: false
+      type: boolean
+    moveOrderID:
+      example: c56a4180-65aa-42ec-a945-5fd21dec0538
+      format: uuid
+      type: string
+    rejectionReason:
+      example: documentation was incomplete
+      type: string
+      x-nullable: true
+    serviceItemIDs:
+      items:
+        example: c56a4180-65aa-42ec-a945-5fd21dec0538
+        format: uuid
+        type: string
+      type: array
+    status:
+      $ref: '#/PaymentRequestStatus'
+  type: object
+PaymentRequestStatus:
+  enum:
+    - PAYMENT_SUBMITTED
+    - APPROVED
+    - REJECTED
+  title: Payment Request Status
+  type: string
+ProofOfServicePackage:
+  properties:
+    id:
+      example: c56a4180-65aa-42ec-a945-5fd21dec0538
+      format: uuid
+      type: string
+    uploads:
+      items:
+        $ref: '#/Upload'
+      type: array
+  type: object
+UpdatePaymentRequestPayload:
+  properties:
+    proofOfServicePackage:
+      $ref: '#/ProofOfServicePackage'
+    serviceItemIDs:
+      items:
+        example: c56a4180-65aa-42ec-a945-5fd21dec0538
+        format: uuid
+        type: string
+      type: array
+  type: object
+UpdatePaymentRequestStatusPayload:
+  properties:
+    rejectionReason:
+      example: documentation was incomplete
+      type: string
+      x-nullable: true
+    status:
+      $ref: '#/PaymentRequestStatus'
+  type: object
+Upload:
+  properties:
+    bytes:
+      type: integer
+    contentType:
+      example: application/pdf
+      format: mime-type
+      type: string
+    createdAt:
+      format: date-time
+      type: string
+    filename:
+      example: filename.pdf
+      format: binary
+      type: string
+    id:
+      example: c56a4180-65aa-42ec-a945-5fd21dec0538
+      format: uuid
+      type: string
+    updatedAt:
+      format: date-time
+      type: string
+    url:
+      example: 'https://uploads.domain.test/dir/c56a4180-65aa-42ec-a945-5fd21dec0538'
+      format: uri
+      type: string
+  required:
+    - id
+    - url
+    - filename
+    - contentType
+    - bytes
+    - createdAt
+    - updatedAt
+  type: object

--- a/swagger-all-refs/definitions/payment-requests.yaml
+++ b/swagger-all-refs/definitions/payment-requests.yaml
@@ -1,0 +1,120 @@
+CreatePaymentRequestPayload:
+  properties:
+    isFinal:
+      default: false
+      type: boolean
+    moveOrderID:
+      example: c56a4180-65aa-42ec-a945-5fd21dec0538
+      format: uuid
+      type: string
+    proofOfServicePackage:
+      $ref: '#/ProofOfServicePackage'
+    serviceItemIDs:
+      items:
+        example: c56a4180-65aa-42ec-a945-5fd21dec0538
+        format: uuid
+        type: string
+      type: array
+  type: object
+PaymentRequest:
+  properties:
+    documentPackage:
+      $ref: '#/ProofOfServicePackage'
+    id:
+      example: c56a4180-65aa-42ec-a945-5fd21dec0538
+      format: uuid
+      readOnly: true
+      type: string
+    isFinal:
+      default: false
+      type: boolean
+    moveOrderID:
+      example: c56a4180-65aa-42ec-a945-5fd21dec0538
+      format: uuid
+      type: string
+    rejectionReason:
+      example: documentation was incomplete
+      type: string
+      x-nullable: true
+    serviceItemIDs:
+      items:
+        example: c56a4180-65aa-42ec-a945-5fd21dec0538
+        format: uuid
+        type: string
+      type: array
+    status:
+      $ref: '#/PaymentRequestStatus'
+  type: object
+PaymentRequestStatus:
+  enum:
+    - PAYMENT_SUBMITTED
+    - APPROVED
+    - REJECTED
+  title: Payment Request Status
+  type: string
+ProofOfServicePackage:
+  properties:
+    id:
+      example: c56a4180-65aa-42ec-a945-5fd21dec0538
+      format: uuid
+      type: string
+    uploads:
+      items:
+        $ref: '#/Upload'
+      type: array
+  type: object
+UpdatePaymentRequestPayload:
+  properties:
+    proofOfServicePackage:
+      $ref: '#/ProofOfServicePackage'
+    serviceItemIDs:
+      items:
+        example: c56a4180-65aa-42ec-a945-5fd21dec0538
+        format: uuid
+        type: string
+      type: array
+  type: object
+UpdatePaymentRequestStatusPayload:
+  properties:
+    rejectionReason:
+      example: documentation was incomplete
+      type: string
+      x-nullable: true
+    status:
+      $ref: '#/PaymentRequestStatus'
+  type: object
+Upload:
+  properties:
+    bytes:
+      type: integer
+    contentType:
+      example: application/pdf
+      format: mime-type
+      type: string
+    createdAt:
+      format: date-time
+      type: string
+    filename:
+      example: filename.pdf
+      format: binary
+      type: string
+    id:
+      example: c56a4180-65aa-42ec-a945-5fd21dec0538
+      format: uuid
+      type: string
+    updatedAt:
+      format: date-time
+      type: string
+    url:
+      example: 'https://uploads.domain.test/dir/c56a4180-65aa-42ec-a945-5fd21dec0538'
+      format: uri
+      type: string
+  required:
+    - id
+    - url
+    - filename
+    - contentType
+    - bytes
+    - createdAt
+    - updatedAt
+  type: object

--- a/swagger-all-refs/ghc.yaml
+++ b/swagger-all-refs/ghc.yaml
@@ -1,0 +1,32 @@
+swagger: '2.0'
+info:
+  contact:
+    email: dp3@truss.works
+  description: The API for move.mil
+  license:
+    name: MIT
+    url: 'https://opensource.org/licenses/MIT'
+  title: move.mil API
+  version: 0.0.1
+basePath: /ghc/v1
+schemes:
+  - http
+paths:
+  /move-task-orders:
+    $ref: './paths/move-task-orders.yaml#/MoveTaskOrders'
+  /move-task-orders/{moveTaskOrderID}:
+    $ref: './paths/move-task-orders.yaml#/MoveTaskOrder'
+  /move-task-orders/{moveTaskOrderID}/service-items:
+    $ref: './paths/move-task-orders.yaml#/MoveTaskOrderStatus'
+  /move-task-orders/{moveTaskOrderID}/service-items/{serviceItemID}:
+    $ref: './paths/move-task-orders.yaml#/ServiceItems'
+  /move-task-orders/{moveTaskOrderID}/service-items/{serviceItemID}/status:
+    $ref: './paths/move-task-orders.yaml#/ServiceItem'
+  /move-task-orders/{moveTaskOrderID}/status:
+    $ref: './paths/move-task-orders.yaml#/ServiceItemStatus'
+  /payment-requests:
+    $ref: './paths/payment-requests.yaml#/PaymentRequests'
+  /payment-requests/{paymentRequestID}:
+    $ref: './paths/payment-requests.yaml#/PaymentRequest'
+  /payment-requests/{paymentRequestID}/status:
+    $ref: './paths/payment-requests.yaml#/PaymentRequestStatus'

--- a/swagger-all-refs/paths/move-task-orders.yaml
+++ b/swagger-all-refs/paths/move-task-orders.yaml
@@ -1,0 +1,346 @@
+MoveTaskOrders:
+  get:
+    produces:
+      - application/json
+    parameters: []
+    responses:
+      '200':
+        description: Successfully retrieved all move task orders
+        schema:
+          $ref: '../definitions/move-task-orders.yaml#/MoveTaskOrders'
+      '400':
+        $ref: '../responses/errors.yaml#/InvalidRequest'
+      '401':
+        $ref: '../responses/errors.yaml#/PermissionDenied'
+      '403':
+        $ref: '../responses/errors.yaml#/PermissionDenied'
+      '404':
+        $ref: '../responses/errors.yaml#/NotFound'
+      '500':
+        $ref: '../responses/errors.yaml#/ServerError'
+    tags:
+      - moveTaskOrder
+    description: Gets all move orders
+    operationId: listMoveTaskOrders
+    summary: Gets all move orders
+MoveTaskOrder:
+  parameters:
+    - description: ID of move order to use
+      in: path
+      name: moveTaskOrderID
+      required: true
+      type: string
+  delete:
+    produces:
+      - application/json
+    parameters: []
+    responses:
+      '200':
+        description: Successfully deleted move task order
+        schema:
+          $ref: '../definitions/move-task-orders.yaml#/MoveTaskOrder'
+      '400':
+        $ref: '../responses/errors.yaml#/InvalidRequest'
+      '401':
+        $ref: '../responses/errors.yaml#/PermissionDenied'
+      '403':
+        $ref: '../responses/errors.yaml#/PermissionDenied'
+      '404':
+        $ref: '../responses/errors.yaml#/NotFound'
+      '500':
+        $ref: '../responses/errors.yaml#/ServerError'
+    tags:
+      - moveTaskOrder
+    description: Deletes a move order by ID
+    operationId: deleteMoveTaskOrder
+    summary: Deletes a move order by ID
+  get:
+    produces:
+      - application/json
+    parameters: []
+    responses:
+      '200':
+        description: Successfully retrieved move task order
+        schema:
+          $ref: '../definitions/move-task-orders.yaml#/MoveTaskOrder'
+      '400':
+        $ref: '../responses/errors.yaml#/InvalidRequest'
+      '401':
+        $ref: '../responses/errors.yaml#/PermissionDenied'
+      '403':
+        $ref: '../responses/errors.yaml#/PermissionDenied'
+      '404':
+        $ref: '../responses/errors.yaml#/NotFound'
+      '500':
+        $ref: '../responses/errors.yaml#/ServerError'
+    tags:
+      - moveTaskOrder
+    description: Gets a move order
+    operationId: getMoveTaskOrder
+    summary: Gets a move order by ID
+  patch:
+    consumes:
+      - application/json
+    produces:
+      - application/json
+    parameters:
+      - in: body
+        name: body
+        required: true
+        schema:
+          $ref: '../definitions/move-task-orders.yaml#/MoveTaskOrder'
+    responses:
+      '200':
+        description: Successfully retrieved move task order
+        schema:
+          $ref: '../definitions/move-task-orders.yaml#/MoveTaskOrder'
+      '400':
+        $ref: '../responses/errors.yaml#/InvalidRequest'
+      '401':
+        $ref: '../responses/errors.yaml#/PermissionDenied'
+      '403':
+        $ref: '../responses/errors.yaml#/PermissionDenied'
+      '404':
+        $ref: '../responses/errors.yaml#/NotFound'
+      '500':
+        $ref: '../responses/errors.yaml#/ServerError'
+    tags:
+      - moveTaskOrder
+    description: Updates a move order by ID
+    operationId: updateMoveTaskOrder
+    summary: Updates a move order by ID
+MoveTaskOrderStatus:
+  parameters:
+    - description: ID of move order for service item to use
+      in: path
+      name: moveTaskOrderID
+      required: true
+      type: string
+  get:
+    produces:
+      - application/json
+    parameters: []
+    responses:
+      '200':
+        description: Successfully retrieved all line items for a move task order
+        schema:
+          $ref: '../definitions/move-task-orders.yaml#/ServiceItem'
+      '400':
+        $ref: '../responses/errors.yaml#/InvalidRequest'
+      '401':
+        $ref: '../responses/errors.yaml#/PermissionDenied'
+      '403':
+        $ref: '../responses/errors.yaml#/PermissionDenied'
+      '404':
+        $ref: '../responses/errors.yaml#/NotFound'
+      '500':
+        $ref: '../responses/errors.yaml#/ServerError'
+    tags:
+      - serviceItem
+    description: Gets all line items for a move orders
+    operationId: listServiceItems
+    summary: Gets all line items for a move order
+  post:
+    consumes:
+      - application/json
+    produces:
+      - application/json
+    parameters:
+      - in: body
+        name: body
+        required: true
+        schema:
+          $ref: '../definitions/move-task-orders.yaml#/ServiceItem'
+    responses:
+      '201':
+        description: Successfully created line item for move task order
+        schema:
+          $ref: '../definitions/move-task-orders.yaml#/ServiceItem'
+      '400':
+        $ref: '../responses/errors.yaml#/InvalidRequest'
+      '401':
+        $ref: '../responses/errors.yaml#/PermissionDenied'
+      '403':
+        $ref: '../responses/errors.yaml#/PermissionDenied'
+      '404':
+        $ref: '../responses/errors.yaml#/NotFound'
+      '500':
+        $ref: '../responses/errors.yaml#/ServerError'
+    tags:
+      - serviceItem
+    description: Creates a service item for a move order by id
+    operationId: createServiceItem
+    summary: Creates a service item for a move order by id
+ServiceItems:
+  parameters:
+    - description: ID of move order to use
+      in: path
+      name: moveTaskOrderID
+      required: true
+      type: string
+    - description: ID of line item to use
+      in: path
+      name: serviceItemID
+      required: true
+      type: string
+  delete:
+    produces:
+      - application/json
+    parameters: []
+    responses:
+      '200':
+        description: Successfully deleted move task order
+        schema:
+          $ref: '../definitions/move-task-orders.yaml#/MoveTaskOrder'
+      '400':
+        $ref: '../responses/errors.yaml#/InvalidRequest'
+      '401':
+        $ref: '../responses/errors.yaml#/PermissionDenied'
+      '403':
+        $ref: '../responses/errors.yaml#/PermissionDenied'
+      '404':
+        $ref: '../responses/errors.yaml#/NotFound'
+      '500':
+        $ref: '../responses/errors.yaml#/ServerError'
+    tags:
+      - serviceItem
+    description: Deletes a line item by ID for a move order by ID
+    operationId: deleteServiceItem
+    summary: Deletes a line item by ID for a move order by ID
+  get:
+    produces:
+      - application/json
+    parameters: []
+    responses:
+      '200':
+        description: Successfully retrieved a line item for a move task order by ID
+        schema:
+          $ref: '../definitions/move-task-orders.yaml#/ServiceItem'
+      '400':
+        $ref: '../responses/errors.yaml#/InvalidRequest'
+      '401':
+        $ref: '../responses/errors.yaml#/PermissionDenied'
+      '403':
+        $ref: '../responses/errors.yaml#/PermissionDenied'
+      '404':
+        $ref: '../responses/errors.yaml#/NotFound'
+      '500':
+        $ref: '../responses/errors.yaml#/ServerError'
+    tags:
+      - serviceItem
+    description: Gets a line item by ID for a move order by ID
+    operationId: getServiceItem
+    summary: Gets a line item by ID for a move order by ID
+  patch:
+    consumes:
+      - application/json
+    produces:
+      - application/json
+    parameters:
+      - in: body
+        name: body
+        required: true
+        schema:
+          $ref: '../definitions/move-task-orders.yaml#/ServiceItem'
+    responses:
+      '200':
+        description: Successfully updated move task order status
+        schema:
+          $ref: '../definitions/move-task-orders.yaml#/MoveTaskOrder'
+      '400':
+        $ref: '../responses/errors.yaml#/InvalidRequest'
+      '401':
+        $ref: '../responses/errors.yaml#/PermissionDenied'
+      '403':
+        $ref: '../responses/errors.yaml#/PermissionDenied'
+      '404':
+        $ref: '../responses/errors.yaml#/NotFound'
+      '500':
+        $ref: '../responses/errors.yaml#/ServerError'
+    tags:
+      - serviceItem
+    description: Updates a service item by ID for a move order by ID
+    operationId: updateServiceItem
+    summary: Updates a service item by ID for a move order by ID
+ServiceItem:
+  parameters:
+    - description: ID of move order to use
+      in: path
+      name: moveTaskOrderID
+      required: true
+      type: string
+    - description: ID of line item to use
+      in: path
+      name: serviceItemID
+      required: true
+      type: string
+  patch:
+    consumes:
+      - application/json
+    produces:
+      - application/json
+    parameters:
+      - in: body
+        name: body
+        required: true
+        schema:
+          $ref: '../definitions/move-task-orders.yaml#/ServiceItemStatus'
+    responses:
+      '200':
+        description: >-
+          Successfully updated status for a line item for a move task order by
+          ID
+        schema:
+          $ref: '../definitions/move-task-orders.yaml#/ServiceItem'
+      '400':
+        $ref: '../responses/errors.yaml#/InvalidRequest'
+      '401':
+        $ref: '../responses/errors.yaml#/PermissionDenied'
+      '403':
+        $ref: '../responses/errors.yaml#/PermissionDenied'
+      '404':
+        $ref: '../responses/errors.yaml#/NotFound'
+      '500':
+        $ref: '../responses/errors.yaml#/ServerError'
+    tags:
+      - serviceItem
+    description: Changes the status of a line item for a move order by ID
+    operationId: updateServiceItemStatus
+    summary: Change the status of a line item for a move order by ID
+ServiceItemStatus:
+  patch:
+    consumes:
+      - application/json
+    produces:
+      - application/json
+    parameters:
+      - description: ID of move order to use
+        in: path
+        name: moveTaskOrderID
+        required: true
+        type: string
+      - in: body
+        name: body
+        required: true
+        schema:
+          $ref: '../definitions/move-task-orders.yaml#/MoveTaskOrderStatus'
+    responses:
+      '200':
+        description: Successfully updated move task order status
+        schema:
+          $ref: '../definitions/move-task-orders.yaml#/MoveTaskOrder'
+      '400':
+        $ref: '../responses/errors.yaml#/InvalidRequest'
+      '401':
+        $ref: '../responses/errors.yaml#/PermissionDenied'
+      '403':
+        $ref: '../responses/errors.yaml#/PermissionDenied'
+      '404':
+        $ref: '../responses/errors.yaml#/NotFound'
+      '500':
+        $ref: '../responses/errors.yaml#/ServerError'
+    tags:
+      - moveTaskOrder
+    description: Changes move order status
+    operationId: updateMoveTaskOrderStatus
+    summary: Change the status of a move order

--- a/swagger-all-refs/paths/payment-requests.yaml
+++ b/swagger-all-refs/paths/payment-requests.yaml
@@ -1,0 +1,163 @@
+PaymentRequests:
+  get:
+    produces:
+      - application/json
+    parameters: []
+    responses:
+      '200':
+        description: fetched list of payment requests
+        schema:
+          type: object
+      '400':
+        $ref: '../responses/errors.yaml#/InvalidRequest'
+      '401':
+        $ref: '../responses/errors.yaml#/PermissionDenied'
+      '403':
+        $ref: '../responses/errors.yaml#/PermissionDenied'
+      '404':
+        $ref: '../responses/errors.yaml#/NotFound'
+      '500':
+        $ref: '../responses/errors.yaml#/ServerError'
+    tags:
+      - paymentRequests
+      - prime
+      - gov
+    description: Gets a list of payment requests
+    operationId: listPaymentRequests
+    summary: Gets payment requests
+  post:
+    consumes:
+      - application/json
+    produces:
+      - application/json
+    parameters:
+      - in: body
+        name: body
+        schema:
+          $ref: '../definitions/payment-requests.yaml#/CreatePaymentRequestPayload'
+    responses:
+      '201':
+        description: created instance of payment request
+        schema:
+          $ref: '../definitions/payment-requests.yaml#/PaymentRequest'
+      '400':
+        $ref: '../responses/errors.yaml#/InvalidRequest'
+      '401':
+        $ref: '../responses/errors.yaml#/PermissionDenied'
+      '403':
+        $ref: '../responses/errors.yaml#/PermissionDenied'
+      '404':
+        $ref: '../responses/errors.yaml#/NotFound'
+      '500':
+        $ref: '../responses/errors.yaml#/ServerError'
+    tags:
+      - paymentRequests
+      - prime
+    description: Creates a payment request
+    operationId: createPaymentRequest
+    summary: Creates a payment request
+PaymentRequest:
+  parameters:
+    - description: UUID of payment request
+      format: uuid
+      in: path
+      name: paymentRequestID
+      required: true
+      type: string
+  get:
+    produces:
+      - application/json
+    parameters: []
+    responses:
+      '200':
+        description: fetched instance of payment request
+        schema:
+          $ref: '../definitions/payment-requests.yaml#/PaymentRequest'
+      '400':
+        $ref: '../responses/errors.yaml#/InvalidRequest'
+      '401':
+        $ref: '../responses/errors.yaml#/PermissionDenied'
+      '403':
+        $ref: '../responses/errors.yaml#/PermissionDenied'
+      '404':
+        $ref: '../responses/errors.yaml#/NotFound'
+      '500':
+        $ref: '../responses/errors.yaml#/ServerError'
+    tags:
+      - paymentRequests
+      - prime
+      - gov
+    description: Fetches an instance of a payment request by id
+    operationId: getPaymentRequest
+    summary: Fetches a payment request by id
+  patch:
+    consumes:
+      - application/json
+    produces:
+      - application/json
+    parameters:
+      - in: body
+        name: body
+        required: true
+        schema:
+          $ref: '../definitions/payment-requests.yaml#/UpdatePaymentRequestPayload'
+    responses:
+      '200':
+        description: updated payment request
+        schema:
+          $ref: '../definitions/payment-requests.yaml#/PaymentRequest'
+      '400':
+        $ref: '../responses/errors.yaml#/InvalidRequest'
+      '401':
+        $ref: '../responses/errors.yaml#/PermissionDenied'
+      '403':
+        $ref: '../responses/errors.yaml#/PermissionDenied'
+      '404':
+        $ref: '../responses/errors.yaml#/NotFound'
+      '500':
+        $ref: '../responses/errors.yaml#/ServerError'
+    tags:
+      - paymentRequests
+      - prime
+    description: Updates a payment request by id
+    operationId: updatePaymentRequest
+    summary: Updates a payment request by id
+PaymentRequestStatus:
+  patch:
+    consumes:
+      - application/json
+    produces:
+      - application/json
+    parameters:
+      - description: UUID of payment request
+        format: uuid
+        in: path
+        name: paymentRequestID
+        required: true
+        type: string
+      - in: body
+        name: body
+        required: true
+        schema:
+          $ref: '../definitions/payment-requests.yaml#/UpdatePaymentRequestStatusPayload'
+    responses:
+      '200':
+        description: updated payment request
+        schema:
+          $ref: '../definitions/payment-requests.yaml#/PaymentRequest'
+      '400':
+        $ref: '../responses/errors.yaml#/InvalidRequest'
+      '401':
+        $ref: '../responses/errors.yaml#/PermissionDenied'
+      '403':
+        $ref: '../responses/errors.yaml#/PermissionDenied'
+      '404':
+        $ref: '../responses/errors.yaml#/NotFound'
+      '500':
+        $ref: '../responses/errors.yaml#/ServerError'
+    tags:
+      - paymentRequests
+      - gov
+    description: Updates status of a payment request by id
+    operationId: updatePaymentRequestStatus
+    summary: Updates status of a payment request by id

--- a/swagger-all-refs/responses/errors.yaml
+++ b/swagger-all-refs/responses/errors.yaml
@@ -1,0 +1,16 @@
+InvalidRequest:
+  description: The request payload is invalid
+  schema:
+    $ref: '../definitions/errors.yaml#/Error'
+NotFound:
+  description: The requested resource wasn't found
+  schema:
+    $ref: '../definitions/errors.yaml#/Error'
+PermissionDenied:
+  description: The request was denied
+  schema:
+    $ref: '../definitions/errors.yaml#/Error'
+ServerError:
+  description: A server error occurred
+  schema:
+    $ref: '../definitions/errors.yaml#/Error'

--- a/swagger-defs-only/ghc-flattned.yaml
+++ b/swagger-defs-only/ghc-flattned.yaml
@@ -1,0 +1,976 @@
+schemes:
+- http
+swagger: "2.0"
+info:
+  description: The API for move.mil
+  title: move.mil API
+  contact:
+    email: dp3@truss.works
+  license:
+    name: MIT
+    url: https://opensource.org/licenses/MIT
+  version: 0.0.1
+basePath: /ghc/v1
+paths:
+  /move-task-orders:
+    get:
+      description: Gets all move orders
+      produces:
+      - application/json
+      tags:
+      - moveTaskOrder
+      summary: Gets all move orders
+      operationId: listMoveTaskOrders
+      responses:
+        "200":
+          description: Successfully retrieved all move task orders
+          schema:
+            $ref: '#/definitions/moveTaskOrders'
+        "400":
+          description: The request payload is invalid
+          schema:
+            $ref: '#/definitions/error'
+        "401":
+          description: The request was denied
+          schema:
+            $ref: '#/definitions/error'
+        "403":
+          description: The request was denied
+          schema:
+            $ref: '#/definitions/error'
+        "404":
+          description: The requested resource wasn't found
+          schema:
+            $ref: '#/definitions/error'
+        "500":
+          description: A server error occurred
+          schema:
+            $ref: '#/definitions/error'
+  /move-task-orders/{moveTaskOrderID}:
+    get:
+      description: Gets a move order
+      produces:
+      - application/json
+      tags:
+      - moveTaskOrder
+      summary: Gets a move order by ID
+      operationId: getMoveTaskOrder
+      responses:
+        "200":
+          description: Successfully retrieved move task order
+          schema:
+            $ref: '#/definitions/moveTaskOrder'
+        "400":
+          description: The request payload is invalid
+          schema:
+            $ref: '#/definitions/error'
+        "401":
+          description: The request was denied
+          schema:
+            $ref: '#/definitions/error'
+        "403":
+          description: The request was denied
+          schema:
+            $ref: '#/definitions/error'
+        "404":
+          description: The requested resource wasn't found
+          schema:
+            $ref: '#/definitions/error'
+        "500":
+          description: A server error occurred
+          schema:
+            $ref: '#/definitions/error'
+    delete:
+      description: Deletes a move order by ID
+      produces:
+      - application/json
+      tags:
+      - moveTaskOrder
+      summary: Deletes a move order by ID
+      operationId: deleteMoveTaskOrder
+      responses:
+        "200":
+          description: Successfully deleted move task order
+          schema:
+            $ref: '#/definitions/moveTaskOrder'
+        "400":
+          description: The request payload is invalid
+          schema:
+            $ref: '#/definitions/error'
+        "401":
+          description: The request was denied
+          schema:
+            $ref: '#/definitions/error'
+        "403":
+          description: The request was denied
+          schema:
+            $ref: '#/definitions/error'
+        "404":
+          description: The requested resource wasn't found
+          schema:
+            $ref: '#/definitions/error'
+        "500":
+          description: A server error occurred
+          schema:
+            $ref: '#/definitions/error'
+    patch:
+      description: Updates a move order by ID
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      tags:
+      - moveTaskOrder
+      summary: Updates a move order by ID
+      operationId: updateMoveTaskOrder
+      parameters:
+      - name: body
+        in: body
+        required: true
+        schema:
+          $ref: '#/definitions/moveTaskOrder'
+      responses:
+        "200":
+          description: Successfully retrieved move task order
+          schema:
+            $ref: '#/definitions/moveTaskOrder'
+        "400":
+          description: The request payload is invalid
+          schema:
+            $ref: '#/definitions/error'
+        "401":
+          description: The request was denied
+          schema:
+            $ref: '#/definitions/error'
+        "403":
+          description: The request was denied
+          schema:
+            $ref: '#/definitions/error'
+        "404":
+          description: The requested resource wasn't found
+          schema:
+            $ref: '#/definitions/error'
+        "500":
+          description: A server error occurred
+          schema:
+            $ref: '#/definitions/error'
+    parameters:
+    - type: string
+      description: ID of move order to use
+      name: moveTaskOrderID
+      in: path
+      required: true
+  /move-task-orders/{moveTaskOrderID}/service-items:
+    get:
+      description: Gets all line items for a move orders
+      produces:
+      - application/json
+      tags:
+      - serviceItem
+      summary: Gets all line items for a move order
+      operationId: listServiceItems
+      responses:
+        "200":
+          description: Successfully retrieved all line items for a move task order
+          schema:
+            $ref: '#/definitions/serviceItem'
+        "400":
+          description: The request payload is invalid
+          schema:
+            $ref: '#/definitions/error'
+        "401":
+          description: The request was denied
+          schema:
+            $ref: '#/definitions/error'
+        "403":
+          description: The request was denied
+          schema:
+            $ref: '#/definitions/error'
+        "404":
+          description: The requested resource wasn't found
+          schema:
+            $ref: '#/definitions/error'
+        "500":
+          description: A server error occurred
+          schema:
+            $ref: '#/definitions/error'
+    post:
+      description: Creates a service item for a move order by id
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      tags:
+      - serviceItem
+      summary: Creates a service item for a move order by id
+      operationId: createServiceItem
+      parameters:
+      - name: body
+        in: body
+        required: true
+        schema:
+          $ref: '#/definitions/serviceItem'
+      responses:
+        "201":
+          description: Successfully created line item for move task order
+          schema:
+            $ref: '#/definitions/serviceItem'
+        "400":
+          description: The request payload is invalid
+          schema:
+            $ref: '#/definitions/error'
+        "401":
+          description: The request was denied
+          schema:
+            $ref: '#/definitions/error'
+        "403":
+          description: The request was denied
+          schema:
+            $ref: '#/definitions/error'
+        "404":
+          description: The requested resource wasn't found
+          schema:
+            $ref: '#/definitions/error'
+        "500":
+          description: A server error occurred
+          schema:
+            $ref: '#/definitions/error'
+    parameters:
+    - type: string
+      description: ID of move order for service item to use
+      name: moveTaskOrderID
+      in: path
+      required: true
+  /move-task-orders/{moveTaskOrderID}/service-items/{serviceItemID}:
+    get:
+      description: Gets a line item by ID for a move order by ID
+      produces:
+      - application/json
+      tags:
+      - serviceItem
+      summary: Gets a line item by ID for a move order by ID
+      operationId: getServiceItem
+      responses:
+        "200":
+          description: Successfully retrieved a line item for a move task order by
+            ID
+          schema:
+            $ref: '#/definitions/serviceItem'
+        "400":
+          description: The request payload is invalid
+          schema:
+            $ref: '#/definitions/error'
+        "401":
+          description: The request was denied
+          schema:
+            $ref: '#/definitions/error'
+        "403":
+          description: The request was denied
+          schema:
+            $ref: '#/definitions/error'
+        "404":
+          description: The requested resource wasn't found
+          schema:
+            $ref: '#/definitions/error'
+        "500":
+          description: A server error occurred
+          schema:
+            $ref: '#/definitions/error'
+    delete:
+      description: Deletes a line item by ID for a move order by ID
+      produces:
+      - application/json
+      tags:
+      - serviceItem
+      summary: Deletes a line item by ID for a move order by ID
+      operationId: deleteServiceItem
+      responses:
+        "200":
+          description: Successfully deleted move task order
+          schema:
+            $ref: '#/definitions/moveTaskOrder'
+        "400":
+          description: The request payload is invalid
+          schema:
+            $ref: '#/definitions/error'
+        "401":
+          description: The request was denied
+          schema:
+            $ref: '#/definitions/error'
+        "403":
+          description: The request was denied
+          schema:
+            $ref: '#/definitions/error'
+        "404":
+          description: The requested resource wasn't found
+          schema:
+            $ref: '#/definitions/error'
+        "500":
+          description: A server error occurred
+          schema:
+            $ref: '#/definitions/error'
+    patch:
+      description: Updates a service item by ID for a move order by ID
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      tags:
+      - serviceItem
+      summary: Updates a service item by ID for a move order by ID
+      operationId: updateServiceItem
+      parameters:
+      - name: body
+        in: body
+        required: true
+        schema:
+          $ref: '#/definitions/serviceItem'
+      responses:
+        "200":
+          description: Successfully updated move task order status
+          schema:
+            $ref: '#/definitions/moveTaskOrder'
+        "400":
+          description: The request payload is invalid
+          schema:
+            $ref: '#/definitions/error'
+        "401":
+          description: The request was denied
+          schema:
+            $ref: '#/definitions/error'
+        "403":
+          description: The request was denied
+          schema:
+            $ref: '#/definitions/error'
+        "404":
+          description: The requested resource wasn't found
+          schema:
+            $ref: '#/definitions/error'
+        "500":
+          description: A server error occurred
+          schema:
+            $ref: '#/definitions/error'
+    parameters:
+    - type: string
+      description: ID of move order to use
+      name: moveTaskOrderID
+      in: path
+      required: true
+    - type: string
+      description: ID of line item to use
+      name: serviceItemID
+      in: path
+      required: true
+  /move-task-orders/{moveTaskOrderID}/service-items/{serviceItemID}/status:
+    patch:
+      description: Changes the status of a line item for a move order by ID
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      tags:
+      - serviceItem
+      summary: Change the status of a line item for a move order by ID
+      operationId: updateServiceItemStatus
+      parameters:
+      - name: body
+        in: body
+        required: true
+        schema:
+          $ref: '#/definitions/serviceItemStatus'
+      responses:
+        "200":
+          description: Successfully updated status for a line item for a move task
+            order by ID
+          schema:
+            $ref: '#/definitions/serviceItem'
+        "400":
+          description: The request payload is invalid
+          schema:
+            $ref: '#/definitions/error'
+        "401":
+          description: The request was denied
+          schema:
+            $ref: '#/definitions/error'
+        "403":
+          description: The request was denied
+          schema:
+            $ref: '#/definitions/error'
+        "404":
+          description: The requested resource wasn't found
+          schema:
+            $ref: '#/definitions/error'
+        "500":
+          description: A server error occurred
+          schema:
+            $ref: '#/definitions/error'
+    parameters:
+    - type: string
+      description: ID of move order to use
+      name: moveTaskOrderID
+      in: path
+      required: true
+    - type: string
+      description: ID of line item to use
+      name: serviceItemID
+      in: path
+      required: true
+  /move-task-orders/{moveTaskOrderID}/status:
+    patch:
+      description: Changes move order status
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      tags:
+      - moveTaskOrder
+      summary: Change the status of a move order
+      operationId: updateMoveTaskOrderStatus
+      parameters:
+      - type: string
+        description: ID of move order to use
+        name: moveTaskOrderID
+        in: path
+        required: true
+      - name: body
+        in: body
+        required: true
+        schema:
+          $ref: '#/definitions/moveTaskOrderStatus'
+      responses:
+        "200":
+          description: Successfully updated move task order status
+          schema:
+            $ref: '#/definitions/moveTaskOrder'
+        "400":
+          description: The request payload is invalid
+          schema:
+            $ref: '#/definitions/error'
+        "401":
+          description: The request was denied
+          schema:
+            $ref: '#/definitions/error'
+        "403":
+          description: The request was denied
+          schema:
+            $ref: '#/definitions/error'
+        "404":
+          description: The requested resource wasn't found
+          schema:
+            $ref: '#/definitions/error'
+        "500":
+          description: A server error occurred
+          schema:
+            $ref: '#/definitions/error'
+  /payment-requests:
+    get:
+      description: Gets a list of payment requests
+      produces:
+      - application/json
+      tags:
+      - paymentRequests
+      - prime
+      - gov
+      summary: Gets payment requests
+      operationId: listPaymentRequests
+      responses:
+        "200":
+          description: fetched list of payment requests
+          schema:
+            type: object
+        "400":
+          description: The request payload is invalid
+          schema:
+            $ref: '#/definitions/error'
+        "401":
+          description: The request was denied
+          schema:
+            $ref: '#/definitions/error'
+        "403":
+          description: The request was denied
+          schema:
+            $ref: '#/definitions/error'
+        "404":
+          description: The requested resource wasn't found
+          schema:
+            $ref: '#/definitions/error'
+        "500":
+          description: A server error occurred
+          schema:
+            $ref: '#/definitions/error'
+    post:
+      description: Creates a payment request
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      tags:
+      - paymentRequests
+      - prime
+      summary: Creates a payment request
+      operationId: createPaymentRequest
+      parameters:
+      - name: body
+        in: body
+        schema:
+          $ref: '#/definitions/createPaymentRequestPayload'
+      responses:
+        "201":
+          description: created instance of payment request
+          schema:
+            $ref: '#/definitions/paymentRequest'
+        "400":
+          description: The request payload is invalid
+          schema:
+            $ref: '#/definitions/error'
+        "401":
+          description: The request was denied
+          schema:
+            $ref: '#/definitions/error'
+        "403":
+          description: The request was denied
+          schema:
+            $ref: '#/definitions/error'
+        "404":
+          description: The requested resource wasn't found
+          schema:
+            $ref: '#/definitions/error'
+        "500":
+          description: A server error occurred
+          schema:
+            $ref: '#/definitions/error'
+  /payment-requests/{paymentRequestID}:
+    get:
+      description: Fetches an instance of a payment request by id
+      produces:
+      - application/json
+      tags:
+      - paymentRequests
+      - prime
+      - gov
+      summary: Fetches a payment request by id
+      operationId: getPaymentRequest
+      responses:
+        "200":
+          description: fetched instance of payment request
+          schema:
+            $ref: '#/definitions/paymentRequest'
+        "400":
+          description: The request payload is invalid
+          schema:
+            $ref: '#/definitions/error'
+        "401":
+          description: The request was denied
+          schema:
+            $ref: '#/definitions/error'
+        "403":
+          description: The request was denied
+          schema:
+            $ref: '#/definitions/error'
+        "404":
+          description: The requested resource wasn't found
+          schema:
+            $ref: '#/definitions/error'
+        "500":
+          description: A server error occurred
+          schema:
+            $ref: '#/definitions/error'
+    patch:
+      description: Updates a payment request by id
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      tags:
+      - paymentRequests
+      - prime
+      summary: Updates a payment request by id
+      operationId: updatePaymentRequest
+      parameters:
+      - name: body
+        in: body
+        required: true
+        schema:
+          $ref: '#/definitions/updatePaymentRequestPayload'
+      responses:
+        "200":
+          description: updated payment request
+          schema:
+            $ref: '#/definitions/paymentRequest'
+        "400":
+          description: The request payload is invalid
+          schema:
+            $ref: '#/definitions/error'
+        "401":
+          description: The request was denied
+          schema:
+            $ref: '#/definitions/error'
+        "403":
+          description: The request was denied
+          schema:
+            $ref: '#/definitions/error'
+        "404":
+          description: The requested resource wasn't found
+          schema:
+            $ref: '#/definitions/error'
+        "500":
+          description: A server error occurred
+          schema:
+            $ref: '#/definitions/error'
+    parameters:
+    - type: string
+      format: uuid
+      description: UUID of payment request
+      name: paymentRequestID
+      in: path
+      required: true
+  /payment-requests/{paymentRequestID}/status:
+    patch:
+      description: Updates status of a payment request by id
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      tags:
+      - paymentRequests
+      - gov
+      summary: Updates status of a payment request by id
+      operationId: updatePaymentRequestStatus
+      parameters:
+      - type: string
+        format: uuid
+        description: UUID of payment request
+        name: paymentRequestID
+        in: path
+        required: true
+      - name: body
+        in: body
+        required: true
+        schema:
+          $ref: '#/definitions/updatePaymentRequestStatusPayload'
+      responses:
+        "200":
+          description: updated payment request
+          schema:
+            $ref: '#/definitions/paymentRequest'
+        "400":
+          description: The request payload is invalid
+          schema:
+            $ref: '#/definitions/error'
+        "401":
+          description: The request was denied
+          schema:
+            $ref: '#/definitions/error'
+        "403":
+          description: The request was denied
+          schema:
+            $ref: '#/definitions/error'
+        "404":
+          description: The requested resource wasn't found
+          schema:
+            $ref: '#/definitions/error'
+        "500":
+          description: A server error occurred
+          schema:
+            $ref: '#/definitions/error'
+definitions:
+  createPaymentRequestPayload:
+    type: object
+    properties:
+      isFinal:
+        type: boolean
+        default: false
+      moveOrderID:
+        type: string
+        format: uuid
+        example: c56a4180-65aa-42ec-a945-5fd21dec0538
+      proofOfServicePackage:
+        $ref: '#/definitions/proofOfServicePackage'
+      serviceItemIDs:
+        type: array
+        items:
+          type: string
+          format: uuid
+          example: c56a4180-65aa-42ec-a945-5fd21dec0538
+  customer:
+    type: object
+  entitlements:
+    type: object
+    properties:
+      dependentsAuthorized:
+        type: boolean
+        example: true
+      nonTemporaryStorage:
+        type: boolean
+        example: false
+      privatelyOwnedVehicle:
+        type: boolean
+        example: false
+      proGearWeight:
+        type: integer
+        x-formatting: weight
+        example: 2000
+      proGearWeightSpouse:
+        type: integer
+        x-formatting: weight
+        example: 500
+      storageInTransit:
+        type: integer
+        example: 90
+      totalDependents:
+        type: integer
+        example: 2
+      totalWeightSelf:
+        type: integer
+        x-formatting: weight
+        example: 18000
+  error:
+    type: object
+    required:
+    - message
+    properties:
+      message:
+        type: string
+  moveTaskOrder:
+    type: object
+    properties:
+      code:
+        type: string
+        example: USMC-0001
+      createdAt:
+        type: string
+        format: date
+      customer:
+        $ref: '#/definitions/customer'
+      deletedAt:
+        type: string
+        format: date
+      destinationDutyStation:
+        type: string
+        format: uuid
+        example: 1f2270c7-7166-40ae-981e-b200ebdf3054
+      destinationPPSO:
+        type: string
+        format: uuid
+        example: 1f2270c7-7166-40ae-981e-b200ebdf3054
+      entitlements:
+        $ref: '#/definitions/entitlements'
+      id:
+        type: string
+        format: uuid
+        example: 1f2270c7-7166-40ae-981e-b200ebdf3054
+      moveDate:
+        type: string
+        format: date
+      moveID:
+        type: string
+        format: uuid
+        example: c56a4180-65aa-42ec-a945-5fd21dec0538
+      moveTaskOrdersType:
+        type: string
+        enum:
+        - NON_TEMPORARY_STORAGE
+        - PRIME
+      originDutyStation:
+        type: string
+        format: uuid
+        example: 1f2270c7-7166-40ae-981e-b200ebdf3054
+      originPPSO:
+        type: string
+        format: uuid
+        example: 1f2270c7-7166-40ae-981e-b200ebdf3054
+      remarks:
+        type: string
+        example: Requires more gentle care
+      requestedPickupDate:
+        type: string
+        format: date
+      serviceItems:
+        type: array
+        items:
+          $ref: '#/definitions/serviceItem'
+      status:
+        type: string
+        enum:
+        - APPROVED
+        - REJECTED
+        - SUBMITTED
+      updatedAt:
+        type: string
+        format: date
+  moveTaskOrderStatus:
+    type: object
+    properties:
+      status:
+        type: string
+        enum:
+        - APPROVED
+        - SUBMITTED
+        - REJECTED
+  moveTaskOrders:
+    type: array
+    items:
+      $ref: '#/definitions/moveTaskOrder'
+  paymentRequest:
+    type: object
+    properties:
+      documentPackage:
+        $ref: '#/definitions/proofOfServicePackage'
+      id:
+        type: string
+        format: uuid
+        readOnly: true
+        example: c56a4180-65aa-42ec-a945-5fd21dec0538
+      isFinal:
+        type: boolean
+        default: false
+      moveOrderID:
+        type: string
+        format: uuid
+        example: c56a4180-65aa-42ec-a945-5fd21dec0538
+      rejectionReason:
+        type: string
+        x-nullable: true
+        example: documentation was incomplete
+      serviceItemIDs:
+        type: array
+        items:
+          type: string
+          format: uuid
+          example: c56a4180-65aa-42ec-a945-5fd21dec0538
+      status:
+        $ref: '#/definitions/paymentRequestStatus'
+  paymentRequestStatus:
+    type: string
+    title: Payment Request Status
+    enum:
+    - PAYMENT_SUBMITTED
+    - APPROVED
+    - REJECTED
+  proofOfServicePackage:
+    type: object
+    properties:
+      id:
+        type: string
+        format: uuid
+        example: c56a4180-65aa-42ec-a945-5fd21dec0538
+      uploads:
+        type: array
+        items:
+          $ref: '#/definitions/upload'
+  serviceItem:
+    type: object
+    properties:
+      MoveTaskOrderID:
+        type: string
+        format: uuid
+        example: 1f2270c7-7166-40ae-981e-b200ebdf3054
+      approvedAt:
+        type: string
+        format: date
+      createdAt:
+        type: string
+        format: date
+      deletedAt:
+        type: string
+        format: date
+      description:
+        type: string
+      feeType:
+        type: string
+        enum:
+        - COUNSELING
+        - CRATING
+        - TRUCKING
+        - SHUTTLE
+      id:
+        type: string
+        format: uuid
+        example: 1f2270c7-7166-40ae-981e-b200ebdf3054
+      quantity:
+        type: integer
+      rate:
+        type: integer
+      rejectedAt:
+        type: string
+        format: date
+      status:
+        type: string
+        enum:
+        - APPROVED
+        - SUBMITTED
+        - REJECTED
+      submittedAt:
+        type: string
+        format: date
+      total:
+        type: integer
+        format: cents
+      updatedAt:
+        type: string
+        format: date
+  serviceItemStatus:
+    type: object
+    properties:
+      status:
+        type: string
+        enum:
+        - APPROVED
+        - SUBMITTED
+        - REJECTED
+  updatePaymentRequestPayload:
+    type: object
+    properties:
+      proofOfServicePackage:
+        $ref: '#/definitions/proofOfServicePackage'
+      serviceItemIDs:
+        type: array
+        items:
+          type: string
+          format: uuid
+          example: c56a4180-65aa-42ec-a945-5fd21dec0538
+  updatePaymentRequestStatusPayload:
+    type: object
+    properties:
+      rejectionReason:
+        type: string
+        x-nullable: true
+        example: documentation was incomplete
+      status:
+        $ref: '#/definitions/paymentRequestStatus'
+  upload:
+    type: object
+    required:
+    - id
+    - url
+    - filename
+    - contentType
+    - bytes
+    - createdAt
+    - updatedAt
+    properties:
+      bytes:
+        type: integer
+      contentType:
+        type: string
+        format: mime-type
+        example: application/pdf
+      createdAt:
+        type: string
+        format: date-time
+      filename:
+        type: string
+        format: binary
+        example: filename.pdf
+      id:
+        type: string
+        format: uuid
+        example: c56a4180-65aa-42ec-a945-5fd21dec0538
+      updatedAt:
+        type: string
+        format: date-time
+      url:
+        type: string
+        format: uri
+        example: https://uploads.domain.test/dir/c56a4180-65aa-42ec-a945-5fd21dec0538
+

--- a/swagger-defs-only/ghc.yaml
+++ b/swagger-defs-only/ghc.yaml
@@ -1,0 +1,523 @@
+swagger: '2.0'
+info:
+  contact:
+    email: dp3@truss.works
+  description: The API for move.mil
+  license:
+    name: MIT
+    url: 'https://opensource.org/licenses/MIT'
+  title: move.mil API
+  version: 0.0.1
+basePath: /ghc/v1
+schemes:
+  - http
+paths:
+  /move-task-orders:
+    get:
+      produces:
+        - application/json
+      parameters: []
+      responses:
+        '200':
+          description: Successfully retrieved all move task orders
+          schema:
+            $ref: './schemas/move-task-orders.yaml#/definitions/MoveTaskOrders'
+        '400':
+            $ref: './shared/responses.yaml#/responses/InvalidRequest'
+        '401':
+            $ref: './shared/responses.yaml#/responses/PermissionDenied'
+        '403':
+            $ref: './shared/responses.yaml#/responses/PermissionDenied'
+        '404':
+            $ref: './shared/responses.yaml#/responses/NotFound'
+        '500':
+            $ref: './shared/responses.yaml#/responses/ServerError'
+      tags:
+        - moveTaskOrder
+      description: Gets all move orders
+      operationId: listMoveTaskOrders
+      summary: Gets all move orders
+  '/move-task-orders/{moveTaskOrderID}':
+    parameters:
+      - description: ID of move order to use
+        in: path
+        name: moveTaskOrderID
+        required: true
+        type: string
+    delete:
+      produces:
+        - application/json
+      parameters: []
+      responses:
+        '200':
+          description: Successfully deleted move task order
+          schema:
+            $ref: './schemas/move-task-orders.yaml#/definitions/MoveTaskOrder'
+        '400':
+          $ref: './shared/responses.yaml#/responses/InvalidRequest'
+        '401':
+          $ref: './shared/responses.yaml#/responses/PermissionDenied'
+        '403':
+          $ref: './shared/responses.yaml#/responses/PermissionDenied'
+        '404':
+          $ref: './shared/responses.yaml#/responses/NotFound'
+        '500':
+          $ref: './shared/responses.yaml#/responses/ServerError'
+      tags:
+        - moveTaskOrder
+      description: Deletes a move order by ID
+      operationId: deleteMoveTaskOrder
+      summary: Deletes a move order by ID
+    get:
+      produces:
+        - application/json
+      parameters: []
+      responses:
+        '200':
+          description: Successfully retrieved move task order
+          schema:
+            $ref: './schemas/move-task-orders.yaml#/definitions/MoveTaskOrder'
+        '400':
+          $ref: './shared/responses.yaml#/responses/InvalidRequest'
+        '401':
+          $ref: './shared/responses.yaml#/responses/PermissionDenied'
+        '403':
+          $ref: './shared/responses.yaml#/responses/PermissionDenied'
+        '404':
+          $ref: './shared/responses.yaml#/responses/NotFound'
+        '500':
+          $ref: './shared/responses.yaml#/responses/ServerError'
+      tags:
+        - moveTaskOrder
+      description: Gets a move order
+      operationId: getMoveTaskOrder
+      summary: Gets a move order by ID
+    patch:
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - in: body
+          name: body
+          required: true
+          schema:
+            $ref: './schemas/move-task-orders.yaml#/definitions/MoveTaskOrder'
+      responses:
+        '200':
+          description: Successfully retrieved move task order
+          schema:
+            $ref: './schemas/move-task-orders.yaml#/definitions/MoveTaskOrder'
+        '400':
+          $ref: './shared/responses.yaml#/responses/InvalidRequest'
+        '401':
+          $ref: './shared/responses.yaml#/responses/PermissionDenied'
+        '403':
+          $ref: './shared/responses.yaml#/responses/PermissionDenied'
+        '404':
+          $ref: './shared/responses.yaml#/responses/NotFound'
+        '500':
+          $ref: './shared/responses.yaml#/responses/ServerError'
+      tags:
+        - moveTaskOrder
+      description: Updates a move order by ID
+      operationId: updateMoveTaskOrder
+      summary: Updates a move order by ID
+  '/move-task-orders/{moveTaskOrderID}/service-items':
+    parameters:
+      - description: ID of move order for service item to use
+        in: path
+        name: moveTaskOrderID
+        required: true
+        type: string
+    get:
+      produces:
+        - application/json
+      parameters: []
+      responses:
+        '200':
+          description: Successfully retrieved all line items for a move task order
+          schema:
+            $ref: './schemas/move-task-orders.yaml#/definitions/ServiceItem'
+        '400':
+          $ref: './shared/responses.yaml#/responses/InvalidRequest'
+        '401':
+          $ref: './shared/responses.yaml#/responses/PermissionDenied'
+        '403':
+          $ref: './shared/responses.yaml#/responses/PermissionDenied'
+        '404':
+          $ref: './shared/responses.yaml#/responses/NotFound'
+        '500':
+          $ref: './shared/responses.yaml#/responses/ServerError'
+      tags:
+        - serviceItem
+      description: Gets all line items for a move orders
+      operationId: listServiceItems
+      summary: Gets all line items for a move order
+    post:
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - in: body
+          name: body
+          required: true
+          schema:
+            $ref: './schemas/move-task-orders.yaml#/definitions/ServiceItem'
+      responses:
+        '201':
+          description: Successfully created line item for move task order
+          schema:
+            $ref: './schemas/move-task-orders.yaml#/definitions/ServiceItem'
+        '400':
+          $ref: './shared/responses.yaml#/responses/InvalidRequest'
+        '401':
+          $ref: './shared/responses.yaml#/responses/PermissionDenied'
+        '403':
+          $ref: './shared/responses.yaml#/responses/PermissionDenied'
+        '404':
+          $ref: './shared/responses.yaml#/responses/NotFound'
+        '500':
+          $ref: './shared/responses.yaml#/responses/ServerError'
+      tags:
+        - serviceItem
+      description: Creates a service item for a move order by id
+      operationId: createServiceItem
+      summary: Creates a service item for a move order by id
+  '/move-task-orders/{moveTaskOrderID}/service-items/{serviceItemID}':
+    parameters:
+      - description: ID of move order to use
+        in: path
+        name: moveTaskOrderID
+        required: true
+        type: string
+      - description: ID of line item to use
+        in: path
+        name: serviceItemID
+        required: true
+        type: string
+    delete:
+      produces:
+        - application/json
+      parameters: []
+      responses:
+        '200':
+          description: Successfully deleted move task order
+          schema:
+            $ref: './schemas/move-task-orders.yaml#/definitions/MoveTaskOrder'
+        '400':
+          $ref: './shared/responses.yaml#/responses/InvalidRequest'
+        '401':
+          $ref: './shared/responses.yaml#/responses/PermissionDenied'
+        '403':
+          $ref: './shared/responses.yaml#/responses/PermissionDenied'
+        '404':
+          $ref: './shared/responses.yaml#/responses/NotFound'
+        '500':
+          $ref: './shared/responses.yaml#/responses/ServerError'
+      tags:
+        - serviceItem
+      description: Deletes a line item by ID for a move order by ID
+      operationId: deleteServiceItem
+      summary: Deletes a line item by ID for a move order by ID
+    get:
+      produces:
+        - application/json
+      parameters: []
+      responses:
+        '200':
+          description: Successfully retrieved a line item for a move task order by ID
+          schema:
+            $ref: './schemas/move-task-orders.yaml#/definitions/ServiceItem'
+        '400':
+          $ref: './shared/responses.yaml#/responses/InvalidRequest'
+        '401':
+          $ref: './shared/responses.yaml#/responses/PermissionDenied'
+        '403':
+          $ref: './shared/responses.yaml#/responses/PermissionDenied'
+        '404':
+          $ref: './shared/responses.yaml#/responses/NotFound'
+        '500':
+          $ref: './shared/responses.yaml#/responses/ServerError'
+      tags:
+        - serviceItem
+      description: Gets a line item by ID for a move order by ID
+      operationId: getServiceItem
+      summary: Gets a line item by ID for a move order by ID
+    patch:
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - in: body
+          name: body
+          required: true
+          schema:
+            $ref: './schemas/move-task-orders.yaml#/definitions/ServiceItem'
+      responses:
+        '200':
+          description: Successfully updated move task order status
+          schema:
+            $ref: './schemas/move-task-orders.yaml#/definitions/MoveTaskOrder'
+        '400':
+          $ref: './shared/responses.yaml#/responses/InvalidRequest'
+        '401':
+          $ref: './shared/responses.yaml#/responses/PermissionDenied'
+        '403':
+          $ref: './shared/responses.yaml#/responses/PermissionDenied'
+        '404':
+          $ref: './shared/responses.yaml#/responses/NotFound'
+        '500':
+          $ref: './shared/responses.yaml#/responses/ServerError'
+      tags:
+        - serviceItem
+      description: Updates a service item by ID for a move order by ID
+      operationId: updateServiceItem
+      summary: Updates a service item by ID for a move order by ID
+  '/move-task-orders/{moveTaskOrderID}/service-items/{serviceItemID}/status':
+    parameters:
+      - description: ID of move order to use
+        in: path
+        name: moveTaskOrderID
+        required: true
+        type: string
+      - description: ID of line item to use
+        in: path
+        name: serviceItemID
+        required: true
+        type: string
+    patch:
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - in: body
+          name: body
+          required: true
+          schema:
+            $ref: './schemas/move-task-orders.yaml#/definitions/ServiceItemStatus'
+      responses:
+        '200':
+          description: >-
+            Successfully updated status for a line item for a move task order by
+            ID
+          schema:
+            $ref: './schemas/move-task-orders.yaml#/definitions/ServiceItem'
+        '400':
+          $ref: './shared/responses.yaml#/responses/InvalidRequest'
+        '401':
+          $ref: './shared/responses.yaml#/responses/PermissionDenied'
+        '403':
+          $ref: './shared/responses.yaml#/responses/PermissionDenied'
+        '404':
+          $ref: './shared/responses.yaml#/responses/NotFound'
+        '500':
+          $ref: './shared/responses.yaml#/responses/ServerError'
+      tags:
+        - serviceItem
+      description: Changes the status of a line item for a move order by ID
+      operationId: updateServiceItemStatus
+      summary: Change the status of a line item for a move order by ID
+  '/move-task-orders/{moveTaskOrderID}/status':
+    patch:
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - description: ID of move order to use
+          in: path
+          name: moveTaskOrderID
+          required: true
+          type: string
+        - in: body
+          name: body
+          required: true
+          schema:
+            $ref: './schemas/move-task-orders.yaml#/definitions/MoveTaskOrderStatus'
+      responses:
+        '200':
+          description: Successfully updated move task order status
+          schema:
+            $ref: './schemas/move-task-orders.yaml#/definitions/MoveTaskOrder'
+        '400':
+          $ref: './shared/responses.yaml#/responses/InvalidRequest'
+        '401':
+          $ref: './shared/responses.yaml#/responses/PermissionDenied'
+        '403':
+          $ref: './shared/responses.yaml#/responses/PermissionDenied'
+        '404':
+          $ref: './shared/responses.yaml#/responses/NotFound'
+        '500':
+          $ref: './shared/responses.yaml#/responses/ServerError'
+      tags:
+        - moveTaskOrder
+      description: Changes move order status
+      operationId: updateMoveTaskOrderStatus
+      summary: Change the status of a move order
+  /payment-requests:
+    get:
+      produces:
+        - application/json
+      parameters: []
+      responses:
+        '200':
+          description: fetched list of payment requests
+          schema:
+            type: object
+        '400':
+          $ref: './shared/responses.yaml#/responses/InvalidRequest'
+        '401':
+          $ref: './shared/responses.yaml#/responses/PermissionDenied'
+        '403':
+          $ref: './shared/responses.yaml#/responses/PermissionDenied'
+        '404':
+          $ref: './shared/responses.yaml#/responses/NotFound'
+        '500':
+          $ref: './shared/responses.yaml#/responses/ServerError'
+      tags:
+        - paymentRequests
+        - prime
+        - gov
+      description: Gets a list of payment requests
+      operationId: listPaymentRequests
+      summary: Gets payment requests
+    post:
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - in: body
+          name: body
+          schema:
+            $ref: './schemas/payment-requests.yaml#/definitions/CreatePaymentRequestPayload'
+      responses:
+        '201':
+          description: created instance of payment request
+          schema:
+            $ref: './schemas/payment-requests.yaml#/definitions/PaymentRequest'
+        '400':
+          $ref: './shared/responses.yaml#/responses/InvalidRequest'
+        '401':
+          $ref: './shared/responses.yaml#/responses/PermissionDenied'
+        '403':
+          $ref: './shared/responses.yaml#/responses/PermissionDenied'
+        '404':
+          $ref: './shared/responses.yaml#/responses/NotFound'
+        '500':
+          $ref: './shared/responses.yaml#/responses/ServerError'
+      tags:
+        - paymentRequests
+        - prime
+      description: Creates a payment request
+      operationId: createPaymentRequest
+      summary: Creates a payment request
+  '/payment-requests/{paymentRequestID}':
+    parameters:
+      - description: UUID of payment request
+        format: uuid
+        in: path
+        name: paymentRequestID
+        required: true
+        type: string
+    get:
+      produces:
+        - application/json
+      parameters: []
+      responses:
+        '200':
+          description: fetched instance of payment request
+          schema:
+            $ref: './schemas/payment-requests.yaml#/definitions/PaymentRequest'
+        '400':
+          $ref: './shared/responses.yaml#/responses/InvalidRequest'
+        '401':
+          $ref: './shared/responses.yaml#/responses/PermissionDenied'
+        '403':
+          $ref: './shared/responses.yaml#/responses/PermissionDenied'
+        '404':
+          $ref: './shared/responses.yaml#/responses/NotFound'
+        '500':
+          $ref: './shared/responses.yaml#/responses/ServerError'
+      tags:
+        - paymentRequests
+        - prime
+        - gov
+      description: Fetches an instance of a payment request by id
+      operationId: getPaymentRequest
+      summary: Fetches a payment request by id
+    patch:
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - in: body
+          name: body
+          required: true
+          schema:
+            $ref: './schemas/payment-requests.yaml#/definitions/UpdatePaymentRequestPayload'
+      responses:
+        '200':
+          description: updated payment request
+          schema:
+            $ref: './schemas/payment-requests.yaml#/definitions/PaymentRequest'
+        '400':
+          $ref: './shared/responses.yaml#/responses/InvalidRequest'
+        '401':
+          $ref: './shared/responses.yaml#/responses/PermissionDenied'
+        '403':
+          $ref: './shared/responses.yaml#/responses/PermissionDenied'
+        '404':
+          $ref: './shared/responses.yaml#/responses/NotFound'
+        '500':
+          $ref: './shared/responses.yaml#/responses/ServerError'
+      tags:
+        - paymentRequests
+        - prime
+      description: Updates a payment request by id
+      operationId: updatePaymentRequest
+      summary: Updates a payment request by id
+  '/payment-requests/{paymentRequestID}/status':
+    patch:
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - description: UUID of payment request
+          format: uuid
+          in: path
+          name: paymentRequestID
+          required: true
+          type: string
+        - in: body
+          name: body
+          required: true
+          schema:
+            $ref: './schemas/payment-requests.yaml#/definitions/UpdatePaymentRequestStatusPayload'
+      responses:
+        '200':
+          description: updated payment request
+          schema:
+            $ref: './schemas/payment-requests.yaml#/definitions/PaymentRequest'
+        '400':
+          $ref: './shared/responses.yaml#/responses/InvalidRequest'
+        '401':
+          $ref: './shared/responses.yaml#/responses/PermissionDenied'
+        '403':
+          $ref: './shared/responses.yaml#/responses/PermissionDenied'
+        '404':
+          $ref: './shared/responses.yaml#/responses/NotFound'
+        '500':
+          $ref: './shared/responses.yaml#/responses/ServerError'
+      tags:
+        - paymentRequests
+        - gov
+      description: Updates status of a payment request by id
+      operationId: updatePaymentRequestStatus
+      summary: Updates status of a payment request by id

--- a/swagger-defs-only/schemas/move-task-orders.yaml
+++ b/swagger-defs-only/schemas/move-task-orders.yaml
@@ -1,0 +1,173 @@
+definitions:
+  Customer:
+    type: object
+  Entitlements:
+    properties:
+      dependentsAuthorized:
+        example: true
+        type: boolean
+      nonTemporaryStorage:
+        example: false
+        type: boolean
+      privatelyOwnedVehicle:
+        example: false
+        type: boolean
+      proGearWeight:
+        example: 2000
+        type: integer
+        x-formatting: weight
+      proGearWeightSpouse:
+        example: 500
+        type: integer
+        x-formatting: weight
+      storageInTransit:
+        example: 90
+        type: integer
+      totalDependents:
+        example: 2
+        type: integer
+      totalWeightSelf:
+        example: 18000
+        type: integer
+        x-formatting: weight
+    type: object
+  MoveTaskOrder:
+    properties:
+      code:
+        example: USMC-0001
+        type: string
+      createdAt:
+        format: date
+        type: string
+      customer:
+        $ref: '#/definitions/Customer'
+      deletedAt:
+        format: date
+        type: string
+      destinationDutyStation:
+        example: 1f2270c7-7166-40ae-981e-b200ebdf3054
+        format: uuid
+        type: string
+      destinationPPSO:
+        example: 1f2270c7-7166-40ae-981e-b200ebdf3054
+        format: uuid
+        type: string
+      entitlements:
+        $ref: '#/definitions/Entitlements'
+      id:
+        example: 1f2270c7-7166-40ae-981e-b200ebdf3054
+        format: uuid
+        type: string
+      moveDate:
+        format: date
+        type: string
+      moveID:
+        example: c56a4180-65aa-42ec-a945-5fd21dec0538
+        format: uuid
+        type: string
+      moveTaskOrdersType:
+        enum:
+          - NON_TEMPORARY_STORAGE
+          - PRIME
+        type: string
+      originDutyStation:
+        example: 1f2270c7-7166-40ae-981e-b200ebdf3054
+        format: uuid
+        type: string
+      originPPSO:
+        example: 1f2270c7-7166-40ae-981e-b200ebdf3054
+        format: uuid
+        type: string
+      remarks:
+        example: Requires more gentle care
+        type: string
+      requestedPickupDate:
+        format: date
+        type: string
+      serviceItems:
+        items:
+          $ref: '#/definitions/ServiceItem'
+        type: array
+      status:
+        enum:
+          - APPROVED
+          - REJECTED
+          - SUBMITTED
+        type: string
+      updatedAt:
+        format: date
+        type: string
+    type: object
+  MoveTaskOrderStatus:
+    properties:
+      status:
+        enum:
+          - APPROVED
+          - SUBMITTED
+          - REJECTED
+        type: string
+    type: object
+  MoveTaskOrders:
+    items:
+      $ref: '#/definitions/MoveTaskOrder'
+    type: array
+  ServiceItem:
+    properties:
+      MoveTaskOrderID:
+        example: 1f2270c7-7166-40ae-981e-b200ebdf3054
+        format: uuid
+        type: string
+      approvedAt:
+        format: date
+        type: string
+      createdAt:
+        format: date
+        type: string
+      deletedAt:
+        format: date
+        type: string
+      description:
+        type: string
+      feeType:
+        enum:
+          - COUNSELING
+          - CRATING
+          - TRUCKING
+          - SHUTTLE
+        type: string
+      id:
+        example: 1f2270c7-7166-40ae-981e-b200ebdf3054
+        format: uuid
+        type: string
+      quantity:
+        type: integer
+      rate:
+        type: integer
+      rejectedAt:
+        format: date
+        type: string
+      status:
+        enum:
+          - APPROVED
+          - SUBMITTED
+          - REJECTED
+        type: string
+      submittedAt:
+        format: date
+        type: string
+      total:
+        format: cents
+        type: integer
+      updatedAt:
+        format: date
+        type: string
+    type: object
+  ServiceItemStatus:
+    properties:
+      status:
+        enum:
+          - APPROVED
+          - SUBMITTED
+          - REJECTED
+        type: string
+    type: object

--- a/swagger-defs-only/schemas/payment-requests.yaml
+++ b/swagger-defs-only/schemas/payment-requests.yaml
@@ -1,0 +1,121 @@
+definitions:
+  CreatePaymentRequestPayload:
+    properties:
+      isFinal:
+        default: false
+        type: boolean
+      moveOrderID:
+        example: c56a4180-65aa-42ec-a945-5fd21dec0538
+        format: uuid
+        type: string
+      proofOfServicePackage:
+        $ref: '#/definitions/ProofOfServicePackage'
+      serviceItemIDs:
+        items:
+          example: c56a4180-65aa-42ec-a945-5fd21dec0538
+          format: uuid
+          type: string
+        type: array
+    type: object
+  PaymentRequest:
+    properties:
+      documentPackage:
+        $ref: '#/definitions/ProofOfServicePackage'
+      id:
+        example: c56a4180-65aa-42ec-a945-5fd21dec0538
+        format: uuid
+        readOnly: true
+        type: string
+      isFinal:
+        default: false
+        type: boolean
+      moveOrderID:
+        example: c56a4180-65aa-42ec-a945-5fd21dec0538
+        format: uuid
+        type: string
+      rejectionReason:
+        example: documentation was incomplete
+        type: string
+        x-nullable: true
+      serviceItemIDs:
+        items:
+          example: c56a4180-65aa-42ec-a945-5fd21dec0538
+          format: uuid
+          type: string
+        type: array
+      status:
+        $ref: '#/definitions/PaymentRequestStatus'
+    type: object
+  PaymentRequestStatus:
+    enum:
+      - PAYMENT_SUBMITTED
+      - APPROVED
+      - REJECTED
+    title: Payment Request Status
+    type: string
+  ProofOfServicePackage:
+    properties:
+      id:
+        example: c56a4180-65aa-42ec-a945-5fd21dec0538
+        format: uuid
+        type: string
+      uploads:
+        items:
+          $ref: '#/definitions/Upload'
+        type: array
+    type: object
+  UpdatePaymentRequestPayload:
+    properties:
+      proofOfServicePackage:
+        $ref: '#/definitions/ProofOfServicePackage'
+      serviceItemIDs:
+        items:
+          example: c56a4180-65aa-42ec-a945-5fd21dec0538
+          format: uuid
+          type: string
+        type: array
+    type: object
+  UpdatePaymentRequestStatusPayload:
+    properties:
+      rejectionReason:
+        example: documentation was incomplete
+        type: string
+        x-nullable: true
+      status:
+        $ref: '#/definitions/PaymentRequestStatus'
+    type: object
+  Upload:
+    properties:
+      bytes:
+        type: integer
+      contentType:
+        example: application/pdf
+        format: mime-type
+        type: string
+      createdAt:
+        format: date-time
+        type: string
+      filename:
+        example: filename.pdf
+        format: binary
+        type: string
+      id:
+        example: c56a4180-65aa-42ec-a945-5fd21dec0538
+        format: uuid
+        type: string
+      updatedAt:
+        format: date-time
+        type: string
+      url:
+        example: 'https://uploads.domain.test/dir/c56a4180-65aa-42ec-a945-5fd21dec0538'
+        format: uri
+        type: string
+    required:
+      - id
+      - url
+      - filename
+      - contentType
+      - bytes
+      - createdAt
+      - updatedAt
+    type: object

--- a/swagger-defs-only/shared/responses.yaml
+++ b/swagger-defs-only/shared/responses.yaml
@@ -1,0 +1,26 @@
+definitions:
+  Error:
+    type: object
+    properties:
+      message:
+        type: string
+    required:
+      - message
+responses:
+  InvalidRequest:
+    description: The request payload is invalid
+    schema:
+      $ref: '#/definitions/Error'
+  NotFound:
+    description: The requested resource wasn't found
+    content:
+    schema:
+      $ref: '#/definitions/Error'
+  PermissionDenied:
+    description: The request was denied
+    schema:
+      $ref: '#/definitions/Error'
+  ServerError:
+    description: A server error occurred
+    schema:
+      $ref: '#/definitions/Error'


### PR DESCRIPTION
## Description

Attempt at splitting swagger file into multiple files. Tried two approaches:

1) split out the `definitions` and `responses` (in `swagger-defs-only` dir) since that seemed like it should work with `go-swagger` without requiring any additional tools. 

2) split out everything including the `paths` (in `swagger-all-refs` dir). I couldn't make `go-swagger` work with this approach, but post-processing the swagger file with `json-refs` seemed like it could potentially work. 

FWIW, both approaches seemed to work without any post-processing within Goland allowing navigation between files and viewing the api within the swagger-client. However, I'm not sure either approach could be adopted without making changes to the build. As it stands, both would likely require generating a second file to be forwarded along for code generation. At the same time, the formatting of the yaml files is pretty finicky and the `go-swagger` error messaging pretty sparse when something goes wrong, so it's possible that I'm not formatting something correctly in the specs, or don't have the right combination of flags for `./bin/swagger generate server` so point that out if you see it. A high level summary of what was tried below.

### swagger-defs-only

`swagger-defs-only/ghc.yaml` has factored out all definition and response objects into separate files. This approach seems like it should be supported by `go-swagger`, but when I tried to run the generate commands: 

```
gendir=./pkg/gen
rm -rf $gendir/ghc*
./bin/swagger generate server -q -f swagger-defs-only/ghc.yaml -t $gendir --model-package ghcmessages --server-package ghcapi --api-package ghcoperations --exclude-main -A mymove
```

I see the following error: 
```
The swagger spec at "{MYPATH}/swagger-defs-only/ghc.yaml" is invalid against swagger specification 2.0. see errors :
- some references could not be resolved in spec. First found: open {MYPATH}/swagger-defs-only/shared/shared/responses.yaml: no such file or directory
```

However, the file can be flattened and validated
```
./bin/swagger flatten swagger-defs-only/ghc.yaml --format=yaml --with-flatten=full -o ./swagger-defs-only/ghc-flattned.yaml
./bin/swagger validate ./swagger-defs-only/ghc-flattned.yaml
```

The generation command takes a`--with-flatten` flag, so it seems like if a file can be flattened into a valid spec then the generation should work too, but 
```
./bin/swagger generate server -q -f swagger-defs-only/ghc.yaml -t $gendir --model-package ghcmessages --server-package ghcapi --api-package ghcoperations --exclude-main -A mymove --with-flatten=full
The swagger spec at "{MYPATH}/swagger-defs-only/ghc.yaml" is invalid against swagger specification 2.0. see errors :
- some references could not be resolved in spec. First found: open /Users/matthewkrump/Projects/mymove/swagger-defs-only/shared/shared/responses.yaml: no such file or directory
```

### swagger-all-refs
`swagger-defs-only/ghc.yaml` has factored out all definition and response objects into separate files and additionally factored out the paths. This was how the initial open api 3.0 file was structured. I couldn't make `go-swagger` work with this approach. Attempting to flatten the file failed with the error below.

```
./bin/swagger flatten swagger-all-refs/ghc.yaml --format=yaml --with-flatten=full -o ./swagger-defs-only/ghc-flattned.yaml
{MYPATH}/responses/errors.yaml: no such file or directory
``` 

Even though `go-swagger` didn't work post processing the file with a general yaml tool like [json-refs](https://github.com/whitlockjc/json-refs/blob/master/docs/README.md), generates a valid schema. 

```
 json-refs resolve swagger-all-refs/ghc.yaml >! swagger-all-refs/ghc-combined.yaml
./bin/swagger validate swagger-all-refs/ghc-combined.yaml
```



