### PR TITLE
Fix TSPP show page can't display 20 decimal points in IE11

### DIFF
--- a/src/scenes/SystemAdmin/TSPPs/TSPPShow.jsx
+++ b/src/scenes/SystemAdmin/TSPPs/TSPPShow.jsx
@@ -25,12 +25,12 @@ const TSPPShow = props => {
         <NumberField
           source="linehaul_rate"
           reference="transportation_service_provider_performances"
-          options={{ style: 'percent', maximumFractionDigits: 20 }}
+          options={{ style: 'percent', maximumFractionDigits: 2 }}
         />
         <NumberField
           source="sit_rate"
           reference="transportation_service_provider_performances"
-          options={{ style: 'percent', maximumFractionDigits: 20 }}
+          options={{ style: 'percent', maximumFractionDigits: 2 }}
         />
       </SimpleShowLayout>
     </Show>


### PR DESCRIPTION
## Description

Messed up. IE11 can't display 20 decimal points for a number. Opting to show only 2 decimal points (ex: 2.11%).

1. Log in to admin app
2. Click on the TSPPs side menu bar
3. Click on a single TSPP in the list

**Expected**: The show page shows details of the TSPP in IE11
**Actual**: The show page shows a client side error page in IE11 (see screenshot)

## Setup

```sh
make server_run
make admin_client_run
```

## Code Review Verification Steps

* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/169211909) for this change

## Screenshots

Bug
![image](https://user-images.githubusercontent.com/1522549/67033283-3f71e680-f0ca-11e9-8c69-27581941157e.png)

Fix
![image](https://user-images.githubusercontent.com/1522549/67033406-8b249000-f0ca-11e9-83c6-15cc113c0d9c.png)
