### PR TITLE
Ensure db is reset before running migrations

### DIFF
--- a/scripts/upload-secure-migration
+++ b/scripts/upload-secure-migration
@@ -81,10 +81,13 @@ ${aws_command} s3 ls "${aws_bucket_prefix}${environments[0]}${aws_bucket_suffix}
 
 echo "Testing migrations ... (This could be several minutes!)"
 
+make db_deployed_migrations_reset
+
 MIGRATION_PATH="file://local_migrations;file://migrations" \
   DB_HOST=localhost \
   DB_PORT="${DB_PORT_DEPLOYED_MIGRATIONS}" \
   DB_NAME="${DB_NAME_DEPLOYED_MIGRATIONS}" \
+	DB_DEBUG=0 \
   bin/milmove migrate
 
 echo "Testing migrations was successful!"


### PR DESCRIPTION
## Description

@Igarfinkle had some trouble with this script the other day and I believe its because the script doesn't reset the DB anymore. This is a quick fix. It also turns off the debug DB logging while its running.