### PR TITLE
Show office user's associated transportation office

### DIFF
--- a/pkg/gen/adminapi/adminoperations/office/index_offices_parameters.go
+++ b/pkg/gen/adminapi/adminoperations/office/index_offices_parameters.go
@@ -35,7 +35,7 @@ type IndexOfficesParams struct {
 	/*
 	  In: query
 	*/
-	Filter []string
+	Filter *string
 	/*
 	  In: query
 	*/
@@ -78,30 +78,20 @@ func (o *IndexOfficesParams) BindRequest(r *http.Request, route *middleware.Matc
 	return nil
 }
 
-// bindFilter binds and validates array parameter Filter from query.
-//
-// Arrays are parsed according to CollectionFormat: "" (defaults to "csv" when empty).
+// bindFilter binds and validates parameter Filter from query.
 func (o *IndexOfficesParams) bindFilter(rawData []string, hasKey bool, formats strfmt.Registry) error {
-
-	var qvFilter string
+	var raw string
 	if len(rawData) > 0 {
-		qvFilter = rawData[len(rawData)-1]
+		raw = rawData[len(rawData)-1]
 	}
 
-	// CollectionFormat:
-	filterIC := swag.SplitByFormat(qvFilter, "")
-	if len(filterIC) == 0 {
+	// Required: false
+	// AllowEmptyValue: false
+	if raw == "" { // empty values pass all other validations
 		return nil
 	}
 
-	var filterIR []string
-	for _, filterIV := range filterIC {
-		filterI := filterIV
-
-		filterIR = append(filterIR, filterI)
-	}
-
-	o.Filter = filterIR
+	o.Filter = &raw
 
 	return nil
 }

--- a/pkg/gen/adminapi/adminoperations/office/index_offices_urlbuilder.go
+++ b/pkg/gen/adminapi/adminoperations/office/index_offices_urlbuilder.go
@@ -15,7 +15,7 @@ import (
 
 // IndexOfficesURL generates an URL for the index offices operation
 type IndexOfficesURL struct {
-	Filter  []string
+	Filter  *string
 	Page    *int64
 	PerPage *int64
 
@@ -53,21 +53,12 @@ func (o *IndexOfficesURL) Build() (*url.URL, error) {
 
 	qs := make(url.Values)
 
-	var filterIR []string
-	for _, filterI := range o.Filter {
-		filterIS := filterI
-		if filterIS != "" {
-			filterIR = append(filterIR, filterIS)
-		}
+	var filterQ string
+	if o.Filter != nil {
+		filterQ = *o.Filter
 	}
-
-	filter := swag.JoinByFormat(filterIR, "")
-
-	if len(filter) > 0 {
-		qsv := filter[0]
-		if qsv != "" {
-			qs.Set("filter", qsv)
-		}
+	if filterQ != "" {
+		qs.Set("filter", filterQ)
 	}
 
 	var pageQ string

--- a/pkg/gen/adminapi/embedded_spec.go
+++ b/pkg/gen/adminapi/embedded_spec.go
@@ -476,10 +476,7 @@ func init() {
         "operationId": "indexOffices",
         "parameters": [
           {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
+            "type": "string",
             "name": "filter",
             "in": "query"
           },
@@ -974,6 +971,7 @@ func init() {
         "last_name",
         "email",
         "telephone",
+        "transportation_office_id",
         "deactivated",
         "created_at",
         "updated_at"
@@ -1010,8 +1008,9 @@ func init() {
           "format": "telephone",
           "pattern": "^[2-9]\\d{2}-\\d{3}-\\d{4}$"
         },
-        "transportation_office": {
-          "$ref": "#/definitions/TransportationOffice"
+        "transportation_office_id": {
+          "type": "string",
+          "format": "uuid"
         },
         "updated_at": {
           "type": "string",
@@ -1739,10 +1738,7 @@ func init() {
         "operationId": "indexOffices",
         "parameters": [
           {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
+            "type": "string",
             "name": "filter",
             "in": "query"
           },
@@ -2238,6 +2234,7 @@ func init() {
         "last_name",
         "email",
         "telephone",
+        "transportation_office_id",
         "deactivated",
         "created_at",
         "updated_at"
@@ -2274,8 +2271,9 @@ func init() {
           "format": "telephone",
           "pattern": "^[2-9]\\d{2}-\\d{3}-\\d{4}$"
         },
-        "transportation_office": {
-          "$ref": "#/definitions/TransportationOffice"
+        "transportation_office_id": {
+          "type": "string",
+          "format": "uuid"
         },
         "updated_at": {
           "type": "string",

--- a/pkg/gen/adminmessages/office_user.go
+++ b/pkg/gen/adminmessages/office_user.go
@@ -53,8 +53,10 @@ type OfficeUser struct {
 	// Pattern: ^[2-9]\d{2}-\d{3}-\d{4}$
 	Telephone *string `json:"telephone"`
 
-	// transportation office
-	TransportationOffice *TransportationOffice `json:"transportation_office,omitempty"`
+	// transportation office id
+	// Required: true
+	// Format: uuid
+	TransportationOfficeID *strfmt.UUID `json:"transportation_office_id"`
 
 	// updated at
 	// Required: true
@@ -98,7 +100,7 @@ func (m *OfficeUser) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
-	if err := m.validateTransportationOffice(formats); err != nil {
+	if err := m.validateTransportationOfficeID(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -200,19 +202,14 @@ func (m *OfficeUser) validateTelephone(formats strfmt.Registry) error {
 	return nil
 }
 
-func (m *OfficeUser) validateTransportationOffice(formats strfmt.Registry) error {
+func (m *OfficeUser) validateTransportationOfficeID(formats strfmt.Registry) error {
 
-	if swag.IsZero(m.TransportationOffice) { // not required
-		return nil
+	if err := validate.Required("transportation_office_id", "body", m.TransportationOfficeID); err != nil {
+		return err
 	}
 
-	if m.TransportationOffice != nil {
-		if err := m.TransportationOffice.Validate(formats); err != nil {
-			if ve, ok := err.(*errors.Validation); ok {
-				return ve.ValidateName("transportation_office")
-			}
-			return err
-		}
+	if err := validate.FormatOf("transportation_office_id", "body", "uuid", m.TransportationOfficeID.String(), formats); err != nil {
+		return err
 	}
 
 	return nil

--- a/pkg/handlers/adminapi/office_users.go
+++ b/pkg/handlers/adminapi/office_users.go
@@ -17,15 +17,16 @@ import (
 
 func payloadForOfficeUserModel(o models.OfficeUser) *adminmessages.OfficeUser {
 	return &adminmessages.OfficeUser{
-		ID:             handlers.FmtUUID(o.ID),
-		FirstName:      handlers.FmtString(o.FirstName),
-		MiddleInitials: handlers.FmtStringPtr(o.MiddleInitials),
-		LastName:       handlers.FmtString(o.LastName),
-		Telephone:      handlers.FmtString(o.Telephone),
-		Email:          handlers.FmtString(o.Email),
-		Deactivated:    handlers.FmtBool(o.Deactivated),
-		CreatedAt:      handlers.FmtDateTime(o.CreatedAt),
-		UpdatedAt:      handlers.FmtDateTime(o.UpdatedAt),
+		ID:                     handlers.FmtUUID(o.ID),
+		FirstName:              handlers.FmtString(o.FirstName),
+		MiddleInitials:         handlers.FmtStringPtr(o.MiddleInitials),
+		LastName:               handlers.FmtString(o.LastName),
+		Telephone:              handlers.FmtString(o.Telephone),
+		Email:                  handlers.FmtString(o.Email),
+		TransportationOfficeID: handlers.FmtUUID(o.TransportationOfficeID),
+		Deactivated:            handlers.FmtBool(o.Deactivated),
+		CreatedAt:              handlers.FmtDateTime(o.CreatedAt),
+		UpdatedAt:              handlers.FmtDateTime(o.UpdatedAt),
 	}
 }
 

--- a/pkg/handlers/adminapi/offices.go
+++ b/pkg/handlers/adminapi/offices.go
@@ -1,7 +1,10 @@
 package adminapi
 
 import (
+	"encoding/json"
 	"fmt"
+
+	"go.uber.org/zap"
 
 	"github.com/transcom/mymove/pkg/services/query"
 
@@ -38,7 +41,7 @@ type IndexOfficesHandler struct {
 func (h IndexOfficesHandler) Handle(params officeop.IndexOfficesParams) middleware.Responder {
 	logger := h.LoggerFromRequest(params.HTTPRequest)
 	// Here is where NewQueryFilter will be used to create Filters from the 'filter' query param
-	queryFilters := []services.QueryFilter{}
+	queryFilters := h.generateQueryFilters(params.Filter, logger)
 
 	pagination := h.NewPagination(params.Page, params.PerPage)
 	associations := query.NewQueryAssociations([]services.QueryAssociation{})
@@ -61,4 +64,29 @@ func (h IndexOfficesHandler) Handle(params officeop.IndexOfficesParams) middlewa
 	}
 
 	return officeop.NewIndexOfficesOK().WithContentRange(fmt.Sprintf("offices %d-%d/%d", pagination.Offset(), pagination.Offset()+queriedOfficesCount, totalOfficesCount)).WithPayload(payload)
+}
+
+func (h IndexOfficesHandler) generateQueryFilters(filters *string, logger handlers.Logger) []services.QueryFilter {
+	type Filter struct {
+		ID string `json:"id"`
+	}
+
+	f := Filter{}
+	var queryFilters []services.QueryFilter
+	if filters == nil {
+		return queryFilters
+	}
+	b := []byte(*filters)
+	err := json.Unmarshal(b, &f)
+	if err != nil {
+		fs := fmt.Sprintf("%v", filters)
+		logger.Warn("unable to decode param", zap.Error(err),
+			zap.String("filters", fs))
+	}
+
+	if f.ID != "" {
+		queryFilters = append(queryFilters, query.NewQueryFilter("id", "=", f.ID))
+	}
+
+	return queryFilters
 }

--- a/src/scenes/SystemAdmin/OfficeUsers/OfficeUserShow.jsx
+++ b/src/scenes/SystemAdmin/OfficeUsers/OfficeUserShow.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Show, SimpleShowLayout, TextField, BooleanField, DateField } from 'react-admin';
+import { Show, SimpleShowLayout, TextField, BooleanField, DateField, ReferenceField } from 'react-admin';
 
 const OfficeUserShowTitle = ({ record }) => {
   return <span>{`${record.first_name} ${record.last_name}`}</span>;
@@ -16,6 +16,9 @@ const OfficeUserShow = props => {
         <TextField source="last_name" />
         <TextField source="telephone" />
         <BooleanField source="deactivated" />
+        <ReferenceField label="Transportation Office" source="transportation_office_id" reference="offices">
+          <TextField source="name" />
+        </ReferenceField>
         <DateField source="created_at" showTime />
         <DateField source="updated_at" showTime />
       </SimpleShowLayout>

--- a/src/scenes/SystemAdmin/shared/rest_provider.js
+++ b/src/scenes/SystemAdmin/shared/rest_provider.js
@@ -52,8 +52,11 @@ export default (apiUrl, httpClient = fetchUtils.fetchJson) => {
         url = `${apiUrl}/${resource}/${params.id}`;
         break;
       case GET_MANY: {
+        if (params.ids !== undefined) {
+          params.id = params.ids[0];
+        }
         const query = {
-          filter: JSON.stringify({ id: params.ids }),
+          filter: JSON.stringify({ id: params.id }),
         };
         url = `${apiUrl}/${resource}?${stringify(query)}`;
         break;

--- a/swagger/admin.yaml
+++ b/swagger/admin.yaml
@@ -56,8 +56,9 @@ definitions:
         type: string
         format: telephone
         pattern: '^[2-9]\d{2}-\d{3}-\d{4}$'
-      transportation_office:
-        $ref: '#/definitions/TransportationOffice'
+      transportation_office_id:
+        type: string
+        format: uuid
       deactivated:
         type: boolean
       created_at:
@@ -73,6 +74,7 @@ definitions:
       - last_name
       - email
       - telephone
+      - transportation_office_id
       - deactivated
       - created_at
       - updated_at
@@ -795,9 +797,7 @@ paths:
       parameters:
         - in: query
           name: filter
-          type: array
-          items:
-            type: string
+          type: string
         - in: query
           name: page
           type: integer


### PR DESCRIPTION
## Description

This PR adds a `ReferenceField` to `OfficeUserShow` which makes an extra API call to the `/offices` endpoint with a filter like `/offices?filter={id: 'abc123'}`, retrieves just the `transportation_office_id`, and then displays it in the officer user’s profile.

## Setup

```
make server_run
make admin_client_run
```
then navigate into an office user's profile to see their associated transportation office.

## Code Review Verification Steps

* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/169091929) for this change
* [Slack conversation](https://defensedigitalservice.slack.com/archives/G8NHL0QGN/p1570796010018900?thread_ts=1570741124.014300&cid=G8NHL0QGN) that resulted in this story

## Screenshot
![Screen Shot 2019-10-21 at 1 37 19 PM](https://user-images.githubusercontent.com/16230705/67241259-f55d6d80-f407-11e9-832f-1df5dec8dbd4.png)