### PR TITLE
Add additional user fields to uploads screen in admin interface

### DIFF
--- a/pkg/gen/adminapi/embedded_spec.go
+++ b/pkg/gen/adminapi/embedded_spec.go
@@ -1278,17 +1278,45 @@ func init() {
           "type": "string",
           "x-nullable": true
         },
+        "office_user_first_name": {
+          "type": "string",
+          "x-nullable": true
+        },
         "office_user_id": {
           "type": "string",
           "format": "uuid",
           "x-nullable": true,
           "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
         },
+        "office_user_last_name": {
+          "type": "string",
+          "x-nullable": true
+        },
+        "office_user_phone": {
+          "type": "string",
+          "x-nullable": true
+        },
+        "service_member_email": {
+          "type": "string",
+          "x-nullable": true
+        },
+        "service_member_first_name": {
+          "type": "string",
+          "x-nullable": true
+        },
         "service_member_id": {
           "type": "string",
           "format": "uuid",
           "x-nullable": true,
           "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+        },
+        "service_member_last_name": {
+          "type": "string",
+          "x-nullable": true
+        },
+        "service_member_phone": {
+          "type": "string",
+          "x-nullable": true
         },
         "upload": {
           "$ref": "#/definitions/Upload"
@@ -2559,17 +2587,45 @@ func init() {
           "type": "string",
           "x-nullable": true
         },
+        "office_user_first_name": {
+          "type": "string",
+          "x-nullable": true
+        },
         "office_user_id": {
           "type": "string",
           "format": "uuid",
           "x-nullable": true,
           "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
         },
+        "office_user_last_name": {
+          "type": "string",
+          "x-nullable": true
+        },
+        "office_user_phone": {
+          "type": "string",
+          "x-nullable": true
+        },
+        "service_member_email": {
+          "type": "string",
+          "x-nullable": true
+        },
+        "service_member_first_name": {
+          "type": "string",
+          "x-nullable": true
+        },
         "service_member_id": {
           "type": "string",
           "format": "uuid",
           "x-nullable": true,
           "example": "c56a4180-65aa-42ec-a945-5fd21dec0538"
+        },
+        "service_member_last_name": {
+          "type": "string",
+          "x-nullable": true
+        },
+        "service_member_phone": {
+          "type": "string",
+          "x-nullable": true
         },
         "upload": {
           "$ref": "#/definitions/Upload"

--- a/pkg/gen/adminmessages/upload_information.go
+++ b/pkg/gen/adminmessages/upload_information.go
@@ -27,13 +27,34 @@ type UploadInformation struct {
 	// office user email
 	OfficeUserEmail *string `json:"office_user_email,omitempty"`
 
+	// office user first name
+	OfficeUserFirstName *string `json:"office_user_first_name,omitempty"`
+
 	// office user id
 	// Format: uuid
 	OfficeUserID *strfmt.UUID `json:"office_user_id,omitempty"`
 
+	// office user last name
+	OfficeUserLastName *string `json:"office_user_last_name,omitempty"`
+
+	// office user phone
+	OfficeUserPhone *string `json:"office_user_phone,omitempty"`
+
+	// service member email
+	ServiceMemberEmail *string `json:"service_member_email,omitempty"`
+
+	// service member first name
+	ServiceMemberFirstName *string `json:"service_member_first_name,omitempty"`
+
 	// service member id
 	// Format: uuid
 	ServiceMemberID *strfmt.UUID `json:"service_member_id,omitempty"`
+
+	// service member last name
+	ServiceMemberLastName *string `json:"service_member_last_name,omitempty"`
+
+	// service member phone
+	ServiceMemberPhone *string `json:"service_member_phone,omitempty"`
 
 	// upload
 	Upload *Upload `json:"upload,omitempty"`

--- a/pkg/handlers/adminapi/upload_information.go
+++ b/pkg/handlers/adminapi/upload_information.go
@@ -25,9 +25,16 @@ func payloadForUpload(u services.UploadInformation) *adminmessages.UploadInforma
 			Filename:    u.Filename,
 			Size:        u.Bytes,
 		},
-		OfficeUserEmail: u.OfficeUserEmail,
-		OfficeUserID:    handlers.FmtUUIDPtr(u.OfficeUserID),
-		ServiceMemberID: handlers.FmtUUIDPtr(u.ServiceMemberID),
+		OfficeUserID:           handlers.FmtUUIDPtr(u.OfficeUserID),
+		OfficeUserEmail:        u.OfficeUserEmail,
+		OfficeUserFirstName:    u.OfficeUserFirstName,
+		OfficeUserLastName:     u.OfficeUserLastName,
+		OfficeUserPhone:        u.OfficeUserPhone,
+		ServiceMemberID:        handlers.FmtUUIDPtr(u.ServiceMemberID),
+		ServiceMemberEmail:     u.ServiceMemberEmail,
+		ServiceMemberFirstName: u.ServiceMemberFirstName,
+		ServiceMemberLastName:  u.ServiceMemberLastName,
+		ServiceMemberPhone:     u.ServiceMemberPhone,
 	}
 }
 

--- a/pkg/services/upload/upload_information_fetcher.go
+++ b/pkg/services/upload/upload_information_fetcher.go
@@ -36,8 +36,15 @@ SELECT uploads.id as upload_id,
        uploads.bytes,
        moves.locator,
        sm.id AS service_member_id,
+       sm.first_name AS service_member_first_name,
+       sm.last_name AS service_member_last_name,
+       sm.personal_email AS service_member_email,
+       sm.telephone AS service_member_telephone,
        ou.id AS office_user_id,
-       ou.email AS office_user_email
+       ou.first_name AS office_user_first_name,
+       ou.last_name AS office_user_last_name,
+       ou.email AS office_user_email,
+       ou.telephone AS office_user_telephone
 FROM uploads
          JOIN users u ON uploads.uploader_id = u.id
          JOIN documents d ON uploads.document_id = d.id

--- a/pkg/services/upload/upload_information_fetcher_test.go
+++ b/pkg/services/upload/upload_information_fetcher_test.go
@@ -18,8 +18,11 @@ func (suite *UploadsServiceSuite) TestFetchUploadInformation() {
 				LoginGovEmail: email,
 			},
 			OfficeUser: models.OfficeUser{
-				ID:    uuid.FromStringOrNil("9c5911a7-5885-4cf4-abec-021a40692403"),
-				Email: email,
+				ID:        uuid.FromStringOrNil("9c5911a7-5885-4cf4-abec-021a40692403"),
+				Email:     email,
+				FirstName: "Office",
+				LastName:  "User",
+				Telephone: "212-312-1234",
 			},
 		})
 
@@ -32,6 +35,9 @@ func (suite *UploadsServiceSuite) TestFetchUploadInformation() {
 		suite.Nil(ui.ServiceMemberID)
 		suite.Equal(ou.ID, *ui.OfficeUserID)
 		suite.Equal(ou.Email, *ui.OfficeUserEmail)
+		suite.Equal(ou.FirstName, *ui.OfficeUserFirstName)
+		suite.Equal(ou.LastName, *ui.OfficeUserLastName)
+		suite.Equal(ou.Telephone, *ui.OfficeUserPhone)
 	})
 
 	suite.T().Run("fetch service member upload", func(t *testing.T) {
@@ -41,7 +47,12 @@ func (suite *UploadsServiceSuite) TestFetchUploadInformation() {
 
 		suite.NoError(err)
 		suite.Nil(ui.OfficeUserID)
-		suite.Equal(u.Document.ServiceMember.ID, *ui.ServiceMemberID)
+		sm := u.Document.ServiceMember
+		suite.Equal(sm.ID, *ui.ServiceMemberID)
+		suite.Equal(*sm.PersonalEmail, *ui.ServiceMemberEmail)
+		suite.Equal(*sm.FirstName, *ui.ServiceMemberFirstName)
+		suite.Equal(*sm.LastName, *ui.ServiceMemberLastName)
+		suite.Equal(*sm.Telephone, *ui.ServiceMemberPhone)
 		suite.Equal(u.ID, ui.UploadID)
 		suite.Equal(u.ContentType, ui.ContentType)
 		suite.Equal(u.Bytes, ui.Bytes)

--- a/pkg/services/upload_information.go
+++ b/pkg/services/upload_information.go
@@ -7,15 +7,22 @@ import (
 )
 
 type UploadInformation struct {
-	UploadID        uuid.UUID `db:"upload_id"`
-	ContentType     string    `db:"content_type"`
-	CreatedAt       time.Time `db:"created_at"`
-	Filename        string
-	Bytes           int64
-	MoveLocator     *string    `db:"locator"`
-	ServiceMemberID *uuid.UUID `db:"service_member_id"`
-	OfficeUserID    *uuid.UUID `db:"office_user_id"`
-	OfficeUserEmail *string    `db:"office_user_email"`
+	UploadID               uuid.UUID `db:"upload_id"`
+	ContentType            string    `db:"content_type"`
+	CreatedAt              time.Time `db:"created_at"`
+	Filename               string
+	Bytes                  int64
+	MoveLocator            *string    `db:"locator"`
+	ServiceMemberID        *uuid.UUID `db:"service_member_id"`
+	ServiceMemberFirstName *string    `db:"service_member_first_name"`
+	ServiceMemberLastName  *string    `db:"service_member_last_name"`
+	ServiceMemberPhone     *string    `db:"service_member_telephone"`
+	ServiceMemberEmail     *string    `db:"service_member_email"`
+	OfficeUserID           *uuid.UUID `db:"office_user_id"`
+	OfficeUserFirstName    *string    `db:"office_user_first_name"`
+	OfficeUserLastName     *string    `db:"office_user_last_name"`
+	OfficeUserPhone        *string    `db:"office_user_telephone"`
+	OfficeUserEmail        *string    `db:"office_user_email"`
 }
 
 // UploadInformationFetcher is the service object interface for FetchUploadInformation

--- a/pkg/testdatagen/make_service_member.go
+++ b/pkg/testdatagen/make_service_member.go
@@ -39,6 +39,7 @@ func MakeServiceMember(db *pop.Connection, assertions Assertions) models.Service
 		FirstName:     models.StringPointer("Leo"),
 		LastName:      models.StringPointer("Spacemen"),
 		PersonalEmail: models.StringPointer(email),
+		Telephone:     models.StringPointer("212-123-4567"),
 	}
 
 	// Overwrite values with those from assertions

--- a/src/scenes/SystemAdmin/Uploads/UploadShow.jsx
+++ b/src/scenes/SystemAdmin/Uploads/UploadShow.jsx
@@ -1,25 +1,35 @@
 import React from 'react';
-import { Component } from 'react';
-import { Show, SimpleShowLayout, TextField, DateField } from 'react-admin';
+import { ShowController, ShowView, SimpleShowLayout, TextField, DateField } from 'react-admin';
 
-class UploadShow extends Component {
-  render(props) {
-    return (
-      <Show {...this.props}>
+const UploadShow = props => (
+  <ShowController {...props}>
+    {controllerProps => (
+      <ShowView {...props} {...controllerProps}>
         <SimpleShowLayout>
-          <TextField source="id" label="Upload ID" />
-          <TextField source="service_member_id" label="Service Member ID" />
-          <TextField source="office_user_id" label="Office User ID" />
-          <TextField source="office_user_email" label="Office User Email" />
+          {controllerProps.record && controllerProps.record.service_member_id
+            ? [
+                <TextField source="service_member_id" label="Service Member ID" />,
+                <TextField source="service_member_first_name" label="Service Member First Name" />,
+                <TextField source="service_member_last_name" label="Service Member Last Name" />,
+                <TextField source="service_member_phone" label="Service Member Phone" />,
+                <TextField source="service_member_email" label="Service Member Email" />,
+              ]
+            : [
+                <TextField source="office_user_id" label="Office User ID" />,
+                <TextField source="office_user_first_name" label="Office User First Name" />,
+                <TextField source="office_user_last_name" label="Office User Last Name" />,
+                <TextField source="office_user_phone" label="Office User Phone" />,
+                <TextField source="office_user_email" label="Office User Email" />,
+              ]}
           <TextField source="move_locator" label="Move Locator" />
           <TextField source="upload.filename" label="Upload Filename" />
           <TextField source="upload.size" label="Upload Size" />
           <TextField source="upload.content_type" label="Upload Content Type" />
           <DateField source="upload.created_at" showTime label="Created At" />
         </SimpleShowLayout>
-      </Show>
-    );
-  }
-}
+      </ShowView>
+    )}
+  </ShowController>
+);
 
 export default UploadShow;

--- a/swagger/admin.yaml
+++ b/swagger/admin.yaml
@@ -517,10 +517,31 @@ definitions:
         format: uuid
         example: c56a4180-65aa-42ec-a945-5fd21dec0538
         x-nullable: true
+      service_member_first_name:
+        type: string
+        x-nullable: true
+      service_member_last_name:
+        type: string
+        x-nullable: true
+      service_member_phone:
+        type: string
+        x-nullable: true
+      service_member_email:
+        type: string
+        x-nullable: true
       office_user_id:
         type: string
         format: uuid
         example: c56a4180-65aa-42ec-a945-5fd21dec0538
+        x-nullable: true
+      office_user_first_name:
+        type: string
+        x-nullable: true
+      office_user_last_name:
+        type: string
+        x-nullable: true
+      office_user_phone:
+        type: string
         x-nullable: true
       office_user_email:
         type: string


### PR DESCRIPTION
## Description

Adds additional fields requested in #2833. For both service member and office user the following should now be displayed if present: `id`, `first_name`, `last_name`, `phone`, `email`. Also, since either a service member or office user will have uploaded a document the elements specific to them will conditionally render based on the type of user that uploaded the document.

## Reviewer Notes

1) Start the server, office client and admin client and seed the db with the e2e data
```
make server_run
make office_client_run
make admin_client_run
make db_dev_e2e_populate
```
2) Chose an upload id from the uploads table
3) In the Admin interface, go to "Search by upload ID" and search for the upload. The uploading service member's id and associated fields should be populated along with the other upload summary information.
4) Now as an office user upload a document. Repeat steps 2 and 3 with the new upload, but now the service member id should be blank while the office user's id and associated fields should be populated.


## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make server_test
```

## Code Review Verification Steps
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/n/projects/2181745/stories/168913993) for this change

![upload-info-2](https://user-images.githubusercontent.com/1036969/67248164-c3a4d080-f420-11e9-9423-3375c42a903a.gif)
