### PR TITLE
Update dependency failure script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,6 +63,16 @@ commands:
             [[ $CIRCLE_BRANCH = master ]] || exit 0
             scripts/circleci-announce-broken-branch
           when: on_fail
+  dependency_update_failure:
+    parameters:
+      dependency_name:
+        type: string
+    steps:
+      - run:
+          name: Depdendency update failure
+          command: |
+            [[ -z "<< parameters.dependency_name >>" ]] || scripts/circleci-dependency-update-failure "<< parameters.dependency_name >>"
+          when: on_fail
   deploy_migrations_steps:
     steps:
       - checkout
@@ -726,7 +736,8 @@ jobs:
       - run:
           name: Push changes
           command: scripts/circleci-push-dependency-updates golang
-      - announce_failure
+      - dependency_update_failure:
+          dependency_name: go
 
   # `update_dependencies_js` periodically updates yarn dependencies.
   # The changes are submitted as a pull request for review.
@@ -749,7 +760,8 @@ jobs:
       - run:
           name: Push changes
           command: scripts/circleci-push-dependency-updates js
-      - announce_failure
+      - dependency_update_failure:
+          dependency_name: js
 
   # `update_dependencies_pre_commit` periodically updates pre-commit dependencies.
   # The changes are submitted as a pull request for review.
@@ -766,7 +778,8 @@ jobs:
       - run:
           name: Push changes
           command: scripts/circleci-push-dependency-updates pre-commit
-      - announce_failure
+      - dependency_update_failure:
+          dependency_name: pre_commit
 
 workflows:
   version: 2

--- a/scripts/circleci-dependency-update-failure
+++ b/scripts/circleci-dependency-update-failure
@@ -1,0 +1,42 @@
+#! /usr/bin/env bash
+set -euo pipefail
+
+NOW=$(date '+%s')
+dependency_update=${1:-}
+
+pretext="Dependency update failure for ${dependency_update} update"
+title="CircleCI build #$CIRCLE_BUILD_NUM failed on job $CIRCLE_JOB"
+message="If the failure isn't intermittent (and can't be fixed by a rerun), make story to investigate its cause"
+
+#####
+## Announce in Slack channel
+#####
+# 'color' can be any hex code or the key words 'good', 'warning', or 'danger'
+color="warning"
+
+slack_payload=$(
+cat <<EOM
+{
+    "channel": "#dp3-bat-team",
+    "attachments": [
+        {
+            "fallback": "$message $CIRCLE_BUILD_URL",
+            "color": "$color",
+            "pretext": "$pretext",
+            "author_name": "$CIRCLE_USERNAME",
+            "title": "$title",
+            "title_link": "$CIRCLE_BUILD_URL",
+            "text": "$message",
+            "ts": $NOW
+        }
+    ]
+}
+EOM
+)
+
+echo
+echo "Slack Payload:"
+echo "$slack_payload"
+echo
+
+curl -X POST --data-urlencode payload="$slack_payload" "$SLACK_WEBHOOK_URL"

--- a/scripts/circleci-push-dependency-updates
+++ b/scripts/circleci-push-dependency-updates
@@ -62,7 +62,7 @@ else
 fi
 git commit -am "Automated dependency updates ${deps_name} | $(date -R)"
 git push -v --set-upstream origin "${branch}"
-pr_url=$(hub pull-request -l dependencies,automerge -m "Automated ${deps_name} dependency update | $(date -R)")
+pr_url=$(hub pull-request -l dependencies,automerge -r tinyels,chrisgilmerproj -m "Automated ${deps_name} dependency update | $(date -R)")
 
 # Announce changes
 text="<${pr_url}|Pull request> created in ${github_repo} for $(date +'%m-%d-%Y') ${deps_name} dependency update"

--- a/scripts/circleci-push-dependency-updates
+++ b/scripts/circleci-push-dependency-updates
@@ -62,7 +62,7 @@ else
 fi
 git commit -am "Automated dependency updates ${deps_name} | $(date -R)"
 git push -v --set-upstream origin "${branch}"
-pr_url=$(hub pull-request -l dependencies,automerge -r tinyels,chrisgilmerproj -m "Automated ${deps_name} dependency update | $(date -R)")
+pr_url=$(hub pull-request -l dependencies,automerge -r tinyels,chrisgilmerproj,jacquelineIO,sarboc,chrisrcoles -m "Automated ${deps_name} dependency update | $(date -R)")
 
 # Announce changes
 text="<${pr_url}|Pull request> created in ${github_repo} for $(date +'%m-%d-%Y') ${deps_name} dependency update"


### PR DESCRIPTION
## Description

Create failure script for dependency updates. When this job fails a message will be created in the bat-team channel and advise them to take action. 

Also, @chrisgilmerproj and @tinyels since this is kinda a new process I was going to 
~tag both of you~ tag both of you and all of the team leads as reviewers on the PR, just to make sure these PRs aren't getting ignored.

## Reviewer Notes

Tested by changing branch filtering on one of the updates to include my branch and then added an `exit 1` to the top of the dependency update script. You can see an example message at https://defensedigitalservice.slack.com/archives/GEDH7P70E/p1571766321033500. 

```
  dependency_updater_pre_commit:
    triggers:
      - schedule:
          # Monday at 12:00 UTC
          cron: '0 12 * * 1'
          filters:
            branches:
              only: master
    jobs:
      - update_dependencies_pre_commit
```
