### PR TITLE
adrs are owned by engineering leads

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,5 +6,6 @@
 # owners will be requested for a review.
 # Add language specific code owners if it becomes relevant
 
-# ADRs are architectural decisions records that should all be approved by ARBOC
-/docs/adr/* @ntwyman @chrisrcoles @jim @lynzt @mikena-truss @sarboc
+# ADRs are architectural decisions records that should all be approved by all teams
+/docs/adr/* @tinyels @chrisrcoles @sarboc @chrisgilmerproj @jacquelineIO
+


### PR DESCRIPTION
The codeowners for ADRs was out of date. Updating to include "official" engineering leads for project.