### PR TITLE
Add PRIMARY_KEY to models that are missing it

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -817,7 +817,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: cg_add_primary_keys
+              ignore: placeholder_branch_name
 
       - client_test:
           requires:
@@ -825,7 +825,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: cg_add_primary_keys
+              ignore: placeholder_branch_name
 
       - server_test:
           requires:
@@ -833,7 +833,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: cg_add_primary_keys
+              ignore: placeholder_branch_name
 
       - build_app:
           requires:
@@ -874,28 +874,28 @@ workflows:
             - build_migrations
           filters:
             branches:
-              only: cg_add_primary_keys
+              only: placeholder_branch_name
 
       - deploy_experimental_tasks:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: cg_add_primary_keys
+              only: placeholder_branch_name
 
       - deploy_experimental_app:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: cg_add_primary_keys
+              only: placeholder_branch_name
 
       - deploy_experimental_app_client_tls:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: cg_add_primary_keys
+              only: placeholder_branch_name
 
       - check_circle_against_staging_sha:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -817,7 +817,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: placeholder_branch_name
+              ignore: cg_add_primary_keys
 
       - client_test:
           requires:
@@ -825,7 +825,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: placeholder_branch_name
+              ignore: cg_add_primary_keys
 
       - server_test:
           requires:
@@ -833,7 +833,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: placeholder_branch_name
+              ignore: cg_add_primary_keys
 
       - build_app:
           requires:
@@ -874,28 +874,28 @@ workflows:
             - build_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: cg_add_primary_keys
 
       - deploy_experimental_tasks:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: cg_add_primary_keys
 
       - deploy_experimental_app:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: cg_add_primary_keys
 
       - deploy_experimental_app_client_tls:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: cg_add_primary_keys
 
       - check_circle_against_staging_sha:
           requires:

--- a/docs/how-to/migrate-the-database.md
+++ b/docs/how-to/migrate-the-database.md
@@ -38,18 +38,7 @@ If you are generating a new model first add a new migration file with the suffix
 that will automatically make these for you. Failure to do so may break tools or lead to inefficiencies in the API
 implementations.
 
-For `fizz` you can use this (NOTE: PLEASE USE SQL INSTEAD OF FIZZ):
-
-```text
-create_table("new_table") {
-  t.Column("id", "uuid", {primary: true})
-  t.Column("column1", "string", {"null": true})
-  t.Column("column2", "string", {})
-  t.Timestamps()
-}
-```
-
-The equivalent SQL is:
+When creating the SQL you may write the migration like this:
 
 ```sql
 create table new_table
@@ -61,6 +50,19 @@ create table new_table
     created_at timestamp not null,
     updated_at timestamp not null
 );
+```
+
+**NOTE**: PLEASE USE SQL INSTEAD OF FIZZ
+
+If instead you must use `fizz`, the equivalent code is this (but **please use sql**):
+
+```text
+create_table("new_table") {
+  t.Column("id", "uuid", {primary: true})
+  t.Column("column1", "string", {"null": true})
+  t.Column("column2", "string", {})
+  t.Timestamps()
+}
 ```
 
 Next run `update-migrations-manifest` to update the `migrations_manifest.txt` file.

--- a/migrations/20191023153000_add_missing_primary_keys.up.sql
+++ b/migrations/20191023153000_add_missing_primary_keys.up.sql
@@ -1,0 +1,8 @@
+ALTER TABLE tariff400ng_full_pack_rates ADD PRIMARY KEY (id);
+ALTER TABLE tariff400ng_full_unpack_rates ADD PRIMARY KEY (id);
+ALTER TABLE tariff400ng_linehaul_rates ADD PRIMARY KEY (id);
+ALTER TABLE tariff400ng_service_areas ADD PRIMARY KEY (id);
+ALTER TABLE tariff400ng_shorthaul_rates ADD PRIMARY KEY (id);
+ALTER TABLE tariff400ng_zip3s ADD PRIMARY KEY (id);
+ALTER TABLE tariff400ng_zip5_rate_areas ADD PRIMARY KEY (id);
+ALTER TABLE fuel_eia_diesel_prices ADD PRIMARY KEY (id);

--- a/migrations_manifest.txt
+++ b/migrations_manifest.txt
@@ -371,3 +371,4 @@
 20191017215845_add_truss_user.up.sql
 20191017230212_deactivate-truss-user.up.sql
 20191018211440_update_combo_moves_to_ppm.up.sql
+20191023153000_add_missing_primary_keys.up.sql


### PR DESCRIPTION
## Description

While doing some auto-code generation from our DB I noticed that there are several tables that have no `PRIMARY_KEY`. This PR attempts to address those tables.

I also went to update the related documentation as part of this.

I will want to deploy this to Experimental.

The warning I got for auto-generated code was:

```sh
milmoveapp.FuelEiaDieselPrices: (models.E004) 'id' can only be used as a field name if the field also sets 'primary_key=True'.
milmoveapp.Tariff400NgFullPackRates: (models.E004) 'id' can only be used as a field name if the field also sets 'primary_key=True'.
milmoveapp.Tariff400NgFullUnpackRates: (models.E004) 'id' can only be used as a field name if the field also sets 'primary_key=True'.
milmoveapp.Tariff400NgLinehaulRates: (models.E004) 'id' can only be used as a field name if the field also sets 'primary_key=True'.
milmoveapp.Tariff400NgServiceAreas: (models.E004) 'id' can only be used as a field name if the field also sets 'primary_key=True'.
milmoveapp.Tariff400NgShorthaulRates: (models.E004) 'id' can only be used as a field name if the field also sets 'primary_key=True'.
milmoveapp.Tariff400NgZip3S: (models.E004) 'id' can only be used as a field name if the field also sets 'primary_key=True'.
milmoveapp.Tariff400NgZip5RateAreas: (models.E004) 'id' can only be used as a field name if the field also sets 'primary_key=True'.
```

## Reviewer Notes

Was there a reason these tables didn't have a `PRIMARY_KEY` defined? Also, `tariff400ng_items` had `PRIMARY_KEY` but the others didn't? It's a bit odd to me.

## Setup

```sh
make db_dev_migrate
```

## Code Review Verification Steps

* Any new migrations/schema changes:
  * [x] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/tree/master/docs/database.md#zero-downtime-migrations))
  * [x] Have been communicated to #dp3-engineering
* [x] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [x] Request review from a member of a different team.