### PR TITLE
Do not require document id is present for upload lookup

### DIFF
--- a/pkg/handlers/adminapi/upload_information.go
+++ b/pkg/handlers/adminapi/upload_information.go
@@ -1,6 +1,8 @@
 package adminapi
 
 import (
+	"go.uber.org/zap"
+
 	"github.com/transcom/mymove/pkg/services/upload"
 
 	"github.com/go-openapi/strfmt"
@@ -52,8 +54,10 @@ func (h GetUploadHandler) Handle(params uploadop.GetUploadParams) middleware.Res
 	if err != nil {
 		switch err.(type) {
 		case upload.ErrNotFound:
+			logger.Error("adminapi.GetUploadHandler not found error:", zap.Error(err))
 			return uploadop.NewGetUploadNotFound()
 		default:
+			logger.Error("adminapi.GetUploadHandler error:", zap.Error(err))
 			return handlers.ResponseForError(logger, err)
 		}
 	}

--- a/pkg/services/upload/upload_information_fetcher.go
+++ b/pkg/services/upload/upload_information_fetcher.go
@@ -47,7 +47,7 @@ SELECT uploads.id as upload_id,
        ou.telephone AS office_user_telephone
 FROM uploads
          JOIN users u ON uploads.uploader_id = u.id
-         JOIN documents d ON uploads.document_id = d.id
+         LEFT JOIN documents d ON uploads.document_id = d.id
          LEFT JOIN service_members documents_service_members ON d.service_member_id = documents_service_members.id
          LEFT JOIN orders ON documents_service_members.id = orders.service_member_id
          LEFT JOIN moves ON orders.id = moves.orders_id


### PR DESCRIPTION
## Description

When doing the acceptance for https://www.pivotaltracker.com/n/projects/2181745/stories/168913993, it was noticed that some documents on s3 couldn't be found in the admin lookup. It seems likely these are system generated  temporary documents that don't link back to the rest of the app via `document_id`. This PR relaxes the join condition in order to retrieve these documents as well (see the conversation on the pivotal ticket for more details).

## Setup

```sh
make db_dev_e2e_populate
make office_client_run 
make admin_client_run 
```

1) From the office app, generate a pdf with "Download Orders and Weight Tickets (PDF)". Note the document id. In the generated document url it will be the id right after uploads ( `..../uploads/document_id`).
2) From the uploads lookup in the admin api, lookup the generated document's id. You should find it. Some of the move specific data will be missing, but the information for the user that created the generated document should be populated. 


## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/tree/master/docs/backend.md#logging)
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/n/projects/2181745/stories/168913993) for this change