### PR TITLE
Fixing dollar sign prefix for dollar amount inputs.

### DIFF
--- a/src/shared/JsonSchemaForm/index.css
+++ b/src/shared/JsonSchemaForm/index.css
@@ -16,20 +16,11 @@ h2.sm-heading-2 {
   line-height: 1.25rem;
 }
 
-.usa-input span.dollar-sign:before,
-.usa-input-error span.dollar-sign:before {
+.usa-form-group span.dollar-sign:before {
   content: '$';
   position: absolute;
-  color: #212121;
-  font-size: 1.7rem;
-  line-height: 1.3;
   margin: 0 0;
-  padding: 1.1rem 0.7em;
-}
-
-.usa-input-error span.dollar-sign:before {
-  margin: 0.1em 0;
-  padding: 1.2rem 0.7em;
+  padding: 1rem 0.7em;
 }
 
 .dollar-input input {


### PR DESCRIPTION
## Description

Update the css for dollar sign prefix to work with new USWDS input styles

## Code Review Verification Steps
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/169343985) for this change

## Screenshots
Broken:
<img width="234" alt="Screen Shot 2019-10-24 at 8 25 55 AM" src="https://user-images.githubusercontent.com/4434681/67500865-2f14bb00-f638-11e9-8897-8f7c8e1c1feb.png">

Fixed:
<img width="243" alt="Screen Shot 2019-10-24 at 8 25 43 AM" src="https://user-images.githubusercontent.com/4434681/67500881-3340d880-f638-11e9-9363-0cf2e3a943de.png">
