### PR TITLE
Remove console log from EditablePanel index file

### DIFF
--- a/src/shared/EditablePanel/index.jsx
+++ b/src/shared/EditablePanel/index.jsx
@@ -177,7 +177,6 @@ export class EditablePanel extends Component {
     );
 
     const { title, isEditable, editEnabled, HeaderComponent } = this.props;
-    console.log(HeaderComponent);
 
     return (
       <div className={classes}>


### PR DESCRIPTION
## Description

Found a console log in the EditablePanel index.jsx file. It was only meant to be for debugging. The PR will remove the console log.

## Code Review Verification Steps

* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/169439659) for this change