### PR TITLE
Fix pagination count for TSPPs on Admin App

### DIFF
--- a/pkg/handlers/adminapi/access_code.go
+++ b/pkg/handlers/adminapi/access_code.go
@@ -58,7 +58,7 @@ func (h IndexAccessCodesHandler) Handle(params accesscodeop.IndexAccessCodesPara
 	}
 	accessCodesCount := len(accessCodes)
 
-	totalAccessCodeCount, err := h.DB().Count(&models.AccessCode{})
+	totalAccessCodeCount, err := h.AccessCodeListFetcher.FetchAccessCodeCount(queryFilters)
 	if err != nil {
 		return handlers.ResponseForError(logger, err)
 	}

--- a/pkg/handlers/adminapi/admin_users.go
+++ b/pkg/handlers/adminapi/admin_users.go
@@ -54,7 +54,7 @@ func (h IndexAdminUsersHandler) Handle(params adminuserop.IndexAdminUsersParams)
 		return handlers.ResponseForError(logger, err)
 	}
 
-	totalAdminUsersCount, err := h.DB().Count(&models.AdminUser{})
+	totalAdminUsersCount, err := h.AdminUserListFetcher.FetchAdminUserCount(queryFilters)
 	if err != nil {
 		return handlers.ResponseForError(logger, err)
 	}

--- a/pkg/handlers/adminapi/admin_users_test.go
+++ b/pkg/handlers/adminapi/admin_users_test.go
@@ -77,6 +77,9 @@ func (suite *HandlerSuite) TestIndexAdminUsersHandler() {
 			mock.Anything,
 			mock.Anything,
 		).Return(models.AdminUsers{adminUser}, nil).Once()
+		adminUserListFetcher.On("FetchAdminUserCount",
+			mock.Anything,
+		).Return(1, nil).Once()
 		handler := IndexAdminUsersHandler{
 			HandlerContext:       handlers.NewHandlerContext(suite.DB(), suite.TestLogger()),
 			NewQueryFilter:       newQueryFilter,
@@ -104,6 +107,9 @@ func (suite *HandlerSuite) TestIndexAdminUsersHandler() {
 			mock.Anything,
 			mock.Anything,
 		).Return(nil, expectedError).Once()
+		adminUserListFetcher.On("FetchAdminUserCount",
+			mock.Anything,
+		).Return(0, expectedError).Once()
 		handler := IndexAdminUsersHandler{
 			HandlerContext:       handlers.NewHandlerContext(suite.DB(), suite.TestLogger()),
 			NewQueryFilter:       newQueryFilter,

--- a/pkg/handlers/adminapi/electronic_orders.go
+++ b/pkg/handlers/adminapi/electronic_orders.go
@@ -45,7 +45,7 @@ func (h IndexElectronicOrdersHandler) Handle(params electronicorderop.IndexElect
 		return handlers.ResponseForError(logger, err)
 	}
 
-	totalElectronicOrdersCount, err := h.DB().Count(&models.ElectronicOrder{})
+	totalElectronicOrdersCount, err := h.ElectronicOrderListFetcher.FetchElectronicOrderCount(queryFilters)
 	if err != nil {
 		return handlers.ResponseForError(logger, err)
 	}

--- a/pkg/handlers/adminapi/office_users.go
+++ b/pkg/handlers/adminapi/office_users.go
@@ -53,7 +53,7 @@ func (h IndexOfficeUsersHandler) Handle(params officeuserop.IndexOfficeUsersPara
 		return handlers.ResponseForError(logger, err)
 	}
 
-	totalOfficeUsersCount, err := h.DB().Count(&models.OfficeUser{})
+	totalOfficeUsersCount, err := h.OfficeUserListFetcher.FetchOfficeUserCount(queryFilters)
 	if err != nil {
 		return handlers.ResponseForError(logger, err)
 	}

--- a/pkg/handlers/adminapi/office_users_test.go
+++ b/pkg/handlers/adminapi/office_users_test.go
@@ -77,6 +77,9 @@ func (suite *HandlerSuite) TestIndexOfficeUsersHandler() {
 			mock.Anything,
 			mock.Anything,
 		).Return(models.OfficeUsers{officeUser}, nil).Once()
+		officeUserListFetcher.On("FetchOfficeUserCount",
+			mock.Anything,
+		).Return(1, nil).Once()
 		handler := IndexOfficeUsersHandler{
 			HandlerContext:        handlers.NewHandlerContext(suite.DB(), suite.TestLogger()),
 			NewQueryFilter:        newQueryFilter,
@@ -104,6 +107,9 @@ func (suite *HandlerSuite) TestIndexOfficeUsersHandler() {
 			mock.Anything,
 			mock.Anything,
 		).Return(nil, expectedError).Once()
+		officeUserListFetcher.On("FetchOfficeUserCount",
+			mock.Anything,
+		).Return(0, expectedError).Once()
 		handler := IndexOfficeUsersHandler{
 			HandlerContext:        handlers.NewHandlerContext(suite.DB(), suite.TestLogger()),
 			NewQueryFilter:        newQueryFilter,

--- a/pkg/handlers/adminapi/offices.go
+++ b/pkg/handlers/adminapi/offices.go
@@ -52,7 +52,7 @@ func (h IndexOfficesHandler) Handle(params officeop.IndexOfficesParams) middlewa
 		return handlers.ResponseForError(logger, err)
 	}
 
-	totalOfficesCount, err := h.DB().Count(&models.TransportationOffice{})
+	totalOfficesCount, err := h.OfficeListFetcher.FetchOfficeCount(queryFilters)
 	if err != nil {
 		return handlers.ResponseForError(logger, err)
 	}

--- a/pkg/handlers/adminapi/offices_test.go
+++ b/pkg/handlers/adminapi/offices_test.go
@@ -69,6 +69,9 @@ func (suite *HandlerSuite) TestIndexOfficesHandler() {
 			mock.Anything,
 			mock.Anything,
 		).Return(models.TransportationOffices{office}, nil).Once()
+		officeListFetcher.On("FetchOfficeCount",
+			mock.Anything,
+		).Return(1, nil).Once()
 		handler := IndexOfficesHandler{
 			HandlerContext:    handlers.NewHandlerContext(suite.DB(), suite.TestLogger()),
 			NewQueryFilter:    newQueryFilter,
@@ -96,6 +99,9 @@ func (suite *HandlerSuite) TestIndexOfficesHandler() {
 			mock.Anything,
 			mock.Anything,
 		).Return(nil, expectedError).Once()
+		officeListFetcher.On("FetchOfficeCount",
+			mock.Anything,
+		).Return(0, expectedError).Once()
 		handler := IndexOfficesHandler{
 			HandlerContext:    handlers.NewHandlerContext(suite.DB(), suite.TestLogger()),
 			NewQueryFilter:    newQueryFilter,

--- a/pkg/handlers/adminapi/organizations.go
+++ b/pkg/handlers/adminapi/organizations.go
@@ -47,7 +47,7 @@ func (h IndexOrganizationsHandler) Handle(params organization.IndexOrganizations
 		return handlers.ResponseForError(logger, err)
 	}
 
-	totalOrganizationsCount, err := h.DB().Count(&models.Organization{})
+	totalOrganizationsCount, err := h.OrganizationListFetcher.FetchOrganizationCount(queryFilters)
 	if err != nil {
 		return handlers.ResponseForError(logger, err)
 	}

--- a/pkg/handlers/adminapi/organizations_test.go
+++ b/pkg/handlers/adminapi/organizations_test.go
@@ -70,6 +70,9 @@ func (suite *HandlerSuite) TestIndexOrganizationsHandler() {
 			mock.Anything,
 			mock.Anything,
 		).Return(models.Organizations{org}, nil).Once()
+		organizationListFetcher.On("FetchOrganizationCount",
+			mock.Anything,
+		).Return(1, nil).Once()
 		handler := IndexOrganizationsHandler{
 			HandlerContext:          handlers.NewHandlerContext(suite.DB(), suite.TestLogger()),
 			NewQueryFilter:          newQueryFilter,
@@ -97,6 +100,9 @@ func (suite *HandlerSuite) TestIndexOrganizationsHandler() {
 			mock.Anything,
 			mock.Anything,
 		).Return(nil, expectedError).Once()
+		organizationListFetcher.On("FetchOrganizationCount",
+			mock.Anything,
+		).Return(0, expectedError).Once()
 		handler := IndexOrganizationsHandler{
 			HandlerContext:          handlers.NewHandlerContext(suite.DB(), suite.TestLogger()),
 			NewQueryFilter:          newQueryFilter,

--- a/pkg/handlers/adminapi/transportation_service_provider_performances.go
+++ b/pkg/handlers/adminapi/transportation_service_provider_performances.go
@@ -60,7 +60,7 @@ func (h IndexTSPPsHandler) Handle(params tsppop.IndexTSPPsParams) middleware.Res
 		return handlers.ResponseForError(logger, err)
 	}
 
-	totalTSPPsCount, err := h.DB().Count(&models.TransportationServiceProviderPerformance{})
+	totalTSPPsCount, err := h.TransportationServiceProviderPerformanceListFetcher.FetchTransportationServiceProviderPerformanceCount(queryFilters)
 	if err != nil {
 		return handlers.ResponseForError(logger, err)
 	}
@@ -72,7 +72,7 @@ func (h IndexTSPPsHandler) Handle(params tsppop.IndexTSPPsParams) middleware.Res
 		payload[i] = payloadForTSPPModel(s)
 	}
 
-	return tsppop.NewIndexTSPPsOK().WithContentRange(fmt.Sprintf("tspps %d-%d/%d", pagination.Offset(), pagination.Offset()+queriedTSPPsCount, totalTSPPsCount)).WithPayload(payload)
+	return tsppop.NewIndexTSPPsOK().WithContentRange(fmt.Sprintf("tspps %d-%d/%d", pagination.Offset(), pagination.Offset()+queriedTSPPsCount, *totalTSPPsCount)).WithPayload(payload)
 }
 
 // GetTSPPHandler returns a transportation service provider performance via GET /transportation_service_provider_performances/{tspId}

--- a/pkg/handlers/adminapi/transportation_service_provider_performances.go
+++ b/pkg/handlers/adminapi/transportation_service_provider_performances.go
@@ -72,7 +72,7 @@ func (h IndexTSPPsHandler) Handle(params tsppop.IndexTSPPsParams) middleware.Res
 		payload[i] = payloadForTSPPModel(s)
 	}
 
-	return tsppop.NewIndexTSPPsOK().WithContentRange(fmt.Sprintf("tspps %d-%d/%d", pagination.Offset(), pagination.Offset()+queriedTSPPsCount, *totalTSPPsCount)).WithPayload(payload)
+	return tsppop.NewIndexTSPPsOK().WithContentRange(fmt.Sprintf("tspps %d-%d/%d", pagination.Offset(), pagination.Offset()+queriedTSPPsCount, totalTSPPsCount)).WithPayload(payload)
 }
 
 // GetTSPPHandler returns a transportation service provider performance via GET /transportation_service_provider_performances/{tspId}

--- a/pkg/handlers/adminapi/transportation_service_provider_performances_test.go
+++ b/pkg/handlers/adminapi/transportation_service_provider_performances_test.go
@@ -70,6 +70,9 @@ func (suite *HandlerSuite) TestIndexTSPPsHandler() {
 			mock.Anything,
 			mock.Anything,
 		).Return(models.TransportationServiceProviderPerformances{tspp}, nil).Once()
+		ListFetcher.On("FetchTransportationServiceProviderPerformanceCount",
+			mock.Anything,
+		).Return(1, nil).Once()
 		handler := IndexTSPPsHandler{
 			HandlerContext: handlers.NewHandlerContext(suite.DB(), suite.TestLogger()),
 			NewQueryFilter: newQueryFilter,

--- a/pkg/services/accesscode.go
+++ b/pkg/services/accesscode.go
@@ -33,4 +33,5 @@ type OfficeAccessCodes []adminmessages.AccessCode
 //go:generate mockery -name AccessCodeListFetcher
 type AccessCodeListFetcher interface {
 	FetchAccessCodeList(filters []QueryFilter, associations QueryAssociations, pagination Pagination, ordering QueryOrder) (models.AccessCodes, error)
+	FetchAccessCodeCount(filters []QueryFilter) (int, error)
 }

--- a/pkg/services/accesscode/fetch_access_code_list.go
+++ b/pkg/services/accesscode/fetch_access_code_list.go
@@ -7,6 +7,7 @@ import (
 
 type accessCodeListQueryBuilder interface {
 	FetchMany(model interface{}, filters []services.QueryFilter, associations services.QueryAssociations, pagination services.Pagination, ordering services.QueryOrder) error
+	Count(model interface{}, filters []services.QueryFilter) (int, error)
 }
 
 type accessCodeListFetcher struct {
@@ -23,6 +24,13 @@ func (o *accessCodeListFetcher) FetchAccessCodeList(filters []services.QueryFilt
 	}
 
 	return accessCodes, nil
+}
+
+// FetchAccessCodeCount uses the passed query builder to count access codes
+func (o *accessCodeListFetcher) FetchAccessCodeCount(filters []services.QueryFilter) (int, error) {
+	var accessCodes models.AccessCodes
+	count, err := o.builder.Count(&accessCodes, filters)
+	return count, err
 }
 
 // NewAccessCodeListFetcher returns an implementation of AccessCodeListFetcher

--- a/pkg/services/admin_user.go
+++ b/pkg/services/admin_user.go
@@ -10,6 +10,7 @@ import (
 //go:generate mockery -name AdminUserListFetcher
 type AdminUserListFetcher interface {
 	FetchAdminUserList(filters []QueryFilter, associations QueryAssociations, pagination Pagination, ordering QueryOrder) (models.AdminUsers, error)
+	FetchAdminUserCount(filters []QueryFilter) (int, error)
 }
 
 // AdminUserFetcher is the exported interface for fetching a single admin user

--- a/pkg/services/admin_user/admin_user_list_fetcher.go
+++ b/pkg/services/admin_user/admin_user_list_fetcher.go
@@ -7,6 +7,7 @@ import (
 
 type adminUserListQueryBuilder interface {
 	FetchMany(model interface{}, filters []services.QueryFilter, associations services.QueryAssociations, pagination services.Pagination, ordering services.QueryOrder) error
+	Count(model interface{}, filters []services.QueryFilter) (int, error)
 }
 
 type adminUserListFetcher struct {
@@ -18,6 +19,13 @@ func (o *adminUserListFetcher) FetchAdminUserList(filters []services.QueryFilter
 	var adminUsers models.AdminUsers
 	error := o.builder.FetchMany(&adminUsers, filters, associations, pagination, ordering)
 	return adminUsers, error
+}
+
+// FetchAdminUserList uses the passed query builder to fetch a list of office users
+func (o *adminUserListFetcher) FetchAdminUserCount(filters []services.QueryFilter) (int, error) {
+	var adminUsers models.AdminUsers
+	count, error := o.builder.Count(&adminUsers, filters)
+	return count, error
 }
 
 // NewAdminUserListFetcher returns an implementation of AdminUserListFetcher

--- a/pkg/services/admin_user/admin_user_list_fetcher_test.go
+++ b/pkg/services/admin_user/admin_user_list_fetcher_test.go
@@ -15,11 +15,17 @@ import (
 
 type testAdminUserListQueryBuilder struct {
 	fakeFetchMany func(model interface{}) error
+	fakeCount     func(model interface{}) (int, error)
 }
 
 func (t *testAdminUserListQueryBuilder) FetchMany(model interface{}, filters []services.QueryFilter, associations services.QueryAssociations, pagination services.Pagination, ordering services.QueryOrder) error {
 	m := t.fakeFetchMany(model)
 	return m
+}
+
+func (t *testAdminUserListQueryBuilder) Count(model interface{}, filters []services.QueryFilter) (int, error) {
+	count, m := t.fakeCount(model)
+	return count, m
 }
 
 func defaultPagination() services.Pagination {

--- a/pkg/services/electronic_order.go
+++ b/pkg/services/electronic_order.go
@@ -6,6 +6,7 @@ import "github.com/transcom/mymove/pkg/models"
 //go:generate mockery -name ElectronicOrderListFetcher
 type ElectronicOrderListFetcher interface {
 	FetchElectronicOrderList(filters []QueryFilter, associations QueryAssociations, pagination Pagination, ordering QueryOrder) (models.ElectronicOrders, error)
+	FetchElectronicOrderCount(filters []QueryFilter) (int, error)
 }
 
 // ElectronicOrderCategoryCountFetcher is the exported interface for fetching counts of Electronic orders based on provided category QueryFilters.

--- a/pkg/services/electronic_order/electronic_order_list_fetcher.go
+++ b/pkg/services/electronic_order/electronic_order_list_fetcher.go
@@ -7,6 +7,7 @@ import (
 
 type electronicOrderListQueryBuilder interface {
 	FetchMany(model interface{}, filters []services.QueryFilter, associations services.QueryAssociations, pagination services.Pagination, ordering services.QueryOrder) error
+	Count(model interface{}, filters []services.QueryFilter) (int, error)
 }
 
 type electronicOrderListFetcher struct {
@@ -18,6 +19,13 @@ func (o *electronicOrderListFetcher) FetchElectronicOrderList(filters []services
 	var electronicOrders models.ElectronicOrders
 	error := o.builder.FetchMany(&electronicOrders, filters, associations, pagination, ordering)
 	return electronicOrders, error
+}
+
+// FetchElectronicOrderCount uses the passed query builder to count electronic_orders
+func (o *electronicOrderListFetcher) FetchElectronicOrderCount(filters []services.QueryFilter) (int, error) {
+	var electronicOrders models.ElectronicOrders
+	count, error := o.builder.Count(&electronicOrders, filters)
+	return count, error
 }
 
 // NewElectronicOrderListFetcher returns an implementation of OrdersListFetcher

--- a/pkg/services/electronic_order/electronic_order_list_fetcher_test.go
+++ b/pkg/services/electronic_order/electronic_order_list_fetcher_test.go
@@ -15,11 +15,17 @@ import (
 
 type testElectronicOrderListQueryBuilder struct {
 	fakeFetchMany func(model interface{}) error
+	fakeCount     func(model interface{}) (int, error)
 }
 
 func (t *testElectronicOrderListQueryBuilder) FetchMany(model interface{}, filters []services.QueryFilter, associations services.QueryAssociations, pagination services.Pagination, ordering services.QueryOrder) error {
 	m := t.fakeFetchMany(model)
 	return m
+}
+
+func (t *testElectronicOrderListQueryBuilder) Count(model interface{}, filters []services.QueryFilter) (int, error) {
+	count, m := t.fakeCount(model)
+	return count, m
 }
 
 func defaultPagination() services.Pagination {

--- a/pkg/services/mocks/AccessCodeListFetcher.go
+++ b/pkg/services/mocks/AccessCodeListFetcher.go
@@ -14,6 +14,27 @@ type AccessCodeListFetcher struct {
 	mock.Mock
 }
 
+// FetchAccessCodeCount provides a mock function with given fields: filters
+func (_m *AccessCodeListFetcher) FetchAccessCodeCount(filters []services.QueryFilter) (int, error) {
+	ret := _m.Called(filters)
+
+	var r0 int
+	if rf, ok := ret.Get(0).(func([]services.QueryFilter) int); ok {
+		r0 = rf(filters)
+	} else {
+		r0 = ret.Get(0).(int)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func([]services.QueryFilter) error); ok {
+		r1 = rf(filters)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // FetchAccessCodeList provides a mock function with given fields: filters, associations, pagination, ordering
 func (_m *AccessCodeListFetcher) FetchAccessCodeList(filters []services.QueryFilter, associations services.QueryAssociations, pagination services.Pagination, ordering services.QueryOrder) (models.AccessCodes, error) {
 	ret := _m.Called(filters, associations, pagination, ordering)

--- a/pkg/services/mocks/AdminUserListFetcher.go
+++ b/pkg/services/mocks/AdminUserListFetcher.go
@@ -14,6 +14,27 @@ type AdminUserListFetcher struct {
 	mock.Mock
 }
 
+// FetchAdminUserCount provides a mock function with given fields: filters
+func (_m *AdminUserListFetcher) FetchAdminUserCount(filters []services.QueryFilter) (int, error) {
+	ret := _m.Called(filters)
+
+	var r0 int
+	if rf, ok := ret.Get(0).(func([]services.QueryFilter) int); ok {
+		r0 = rf(filters)
+	} else {
+		r0 = ret.Get(0).(int)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func([]services.QueryFilter) error); ok {
+		r1 = rf(filters)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // FetchAdminUserList provides a mock function with given fields: filters, associations, pagination, ordering
 func (_m *AdminUserListFetcher) FetchAdminUserList(filters []services.QueryFilter, associations services.QueryAssociations, pagination services.Pagination, ordering services.QueryOrder) (models.AdminUsers, error) {
 	ret := _m.Called(filters, associations, pagination, ordering)

--- a/pkg/services/mocks/ElectronicOrderListFetcher.go
+++ b/pkg/services/mocks/ElectronicOrderListFetcher.go
@@ -14,6 +14,27 @@ type ElectronicOrderListFetcher struct {
 	mock.Mock
 }
 
+// FetchElectronicOrderCount provides a mock function with given fields: filters
+func (_m *ElectronicOrderListFetcher) FetchElectronicOrderCount(filters []services.QueryFilter) (int, error) {
+	ret := _m.Called(filters)
+
+	var r0 int
+	if rf, ok := ret.Get(0).(func([]services.QueryFilter) int); ok {
+		r0 = rf(filters)
+	} else {
+		r0 = ret.Get(0).(int)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func([]services.QueryFilter) error); ok {
+		r1 = rf(filters)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // FetchElectronicOrderList provides a mock function with given fields: filters, associations, pagination, ordering
 func (_m *ElectronicOrderListFetcher) FetchElectronicOrderList(filters []services.QueryFilter, associations services.QueryAssociations, pagination services.Pagination, ordering services.QueryOrder) (models.ElectronicOrders, error) {
 	ret := _m.Called(filters, associations, pagination, ordering)

--- a/pkg/services/mocks/OfficeListFetcher.go
+++ b/pkg/services/mocks/OfficeListFetcher.go
@@ -14,6 +14,27 @@ type OfficeListFetcher struct {
 	mock.Mock
 }
 
+// FetchOfficeCount provides a mock function with given fields: filters
+func (_m *OfficeListFetcher) FetchOfficeCount(filters []services.QueryFilter) (int, error) {
+	ret := _m.Called(filters)
+
+	var r0 int
+	if rf, ok := ret.Get(0).(func([]services.QueryFilter) int); ok {
+		r0 = rf(filters)
+	} else {
+		r0 = ret.Get(0).(int)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func([]services.QueryFilter) error); ok {
+		r1 = rf(filters)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // FetchOfficeList provides a mock function with given fields: filters, associations, pagination, ordering
 func (_m *OfficeListFetcher) FetchOfficeList(filters []services.QueryFilter, associations services.QueryAssociations, pagination services.Pagination, ordering services.QueryOrder) (models.TransportationOffices, error) {
 	ret := _m.Called(filters, associations, pagination, ordering)

--- a/pkg/services/mocks/OfficeUserListFetcher.go
+++ b/pkg/services/mocks/OfficeUserListFetcher.go
@@ -14,6 +14,27 @@ type OfficeUserListFetcher struct {
 	mock.Mock
 }
 
+// FetchOfficeUserCount provides a mock function with given fields: filters
+func (_m *OfficeUserListFetcher) FetchOfficeUserCount(filters []services.QueryFilter) (int, error) {
+	ret := _m.Called(filters)
+
+	var r0 int
+	if rf, ok := ret.Get(0).(func([]services.QueryFilter) int); ok {
+		r0 = rf(filters)
+	} else {
+		r0 = ret.Get(0).(int)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func([]services.QueryFilter) error); ok {
+		r1 = rf(filters)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // FetchOfficeUserList provides a mock function with given fields: filters, associations, pagination, ordering
 func (_m *OfficeUserListFetcher) FetchOfficeUserList(filters []services.QueryFilter, associations services.QueryAssociations, pagination services.Pagination, ordering services.QueryOrder) (models.OfficeUsers, error) {
 	ret := _m.Called(filters, associations, pagination, ordering)

--- a/pkg/services/mocks/OrganizationListFetcher.go
+++ b/pkg/services/mocks/OrganizationListFetcher.go
@@ -14,6 +14,27 @@ type OrganizationListFetcher struct {
 	mock.Mock
 }
 
+// FetchOrganizationCount provides a mock function with given fields: filters
+func (_m *OrganizationListFetcher) FetchOrganizationCount(filters []services.QueryFilter) (int, error) {
+	ret := _m.Called(filters)
+
+	var r0 int
+	if rf, ok := ret.Get(0).(func([]services.QueryFilter) int); ok {
+		r0 = rf(filters)
+	} else {
+		r0 = ret.Get(0).(int)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func([]services.QueryFilter) error); ok {
+		r1 = rf(filters)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // FetchOrganizationList provides a mock function with given fields: filters, associations, pagination, ordering
 func (_m *OrganizationListFetcher) FetchOrganizationList(filters []services.QueryFilter, associations services.QueryAssociations, pagination services.Pagination, ordering services.QueryOrder) (models.Organizations, error) {
 	ret := _m.Called(filters, associations, pagination, ordering)

--- a/pkg/services/mocks/TransportationServiceProviderPerformanceListFetcher.go
+++ b/pkg/services/mocks/TransportationServiceProviderPerformanceListFetcher.go
@@ -14,6 +14,27 @@ type TransportationServiceProviderPerformanceListFetcher struct {
 	mock.Mock
 }
 
+// FetchTransportationServiceProviderPerformanceCount provides a mock function with given fields: filters
+func (_m *TransportationServiceProviderPerformanceListFetcher) FetchTransportationServiceProviderPerformanceCount(filters []services.QueryFilter) (int, error) {
+	ret := _m.Called(filters)
+
+	var r0 int
+	if rf, ok := ret.Get(0).(func([]services.QueryFilter) int); ok {
+		r0 = rf(filters)
+	} else {
+		r0 = ret.Get(0).(int)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func([]services.QueryFilter) error); ok {
+		r1 = rf(filters)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // FetchTransportationServiceProviderPerformanceList provides a mock function with given fields: filters, associations, pagination, ordering
 func (_m *TransportationServiceProviderPerformanceListFetcher) FetchTransportationServiceProviderPerformanceList(filters []services.QueryFilter, associations services.QueryAssociations, pagination services.Pagination, ordering services.QueryOrder) (models.TransportationServiceProviderPerformances, error) {
 	ret := _m.Called(filters, associations, pagination, ordering)

--- a/pkg/services/office.go
+++ b/pkg/services/office.go
@@ -13,4 +13,5 @@ type OfficeFetcher interface {
 //go:generate mockery -name OfficeListFetcher
 type OfficeListFetcher interface {
 	FetchOfficeList(filters []QueryFilter, associations QueryAssociations, pagination Pagination, ordering QueryOrder) (models.TransportationOffices, error)
+	FetchOfficeCount(filters []QueryFilter) (int, error)
 }

--- a/pkg/services/office/office_list_fetcher.go
+++ b/pkg/services/office/office_list_fetcher.go
@@ -7,6 +7,7 @@ import (
 
 type officeListQueryBuilder interface {
 	FetchMany(model interface{}, filters []services.QueryFilter, associations services.QueryAssociations, pagination services.Pagination, ordering services.QueryOrder) error
+	Count(model interface{}, filters []services.QueryFilter) (int, error)
 }
 
 type officeListFetcher struct {
@@ -18,6 +19,13 @@ func (o *officeListFetcher) FetchOfficeList(filters []services.QueryFilter, asso
 	var offices models.TransportationOffices
 	error := o.builder.FetchMany(&offices, filters, associations, pagination, ordering)
 	return offices, error
+}
+
+// FetchOfficeUserCount uses the passed query builder to count the number of transportation offices
+func (o *officeListFetcher) FetchOfficeCount(filters []services.QueryFilter) (int, error) {
+	var offices models.TransportationOffices
+	count, error := o.builder.Count(&offices, filters)
+	return count, error
 }
 
 // NewOfficeListFetcher returns an implementation of OfficeListFetcher

--- a/pkg/services/office/office_list_fetcher_test.go
+++ b/pkg/services/office/office_list_fetcher_test.go
@@ -15,11 +15,17 @@ import (
 
 type testOfficeListQueryBuilder struct {
 	fakeFetchMany func(model interface{}) error
+	fakeCount     func(model interface{}) (int, error)
 }
 
 func (t *testOfficeListQueryBuilder) FetchMany(model interface{}, filters []services.QueryFilter, associations services.QueryAssociations, pagination services.Pagination, ordering services.QueryOrder) error {
 	m := t.fakeFetchMany(model)
 	return m
+}
+
+func (t *testOfficeListQueryBuilder) Count(model interface{}, filters []services.QueryFilter) (int, error) {
+	count, m := t.fakeCount(model)
+	return count, m
 }
 
 func defaultPagination() services.Pagination {

--- a/pkg/services/office_user.go
+++ b/pkg/services/office_user.go
@@ -16,6 +16,7 @@ type OfficeUserFetcher interface {
 //go:generate mockery -name OfficeUserListFetcher
 type OfficeUserListFetcher interface {
 	FetchOfficeUserList(filters []QueryFilter, associations QueryAssociations, pagination Pagination, ordering QueryOrder) (models.OfficeUsers, error)
+	FetchOfficeUserCount(filters []QueryFilter) (int, error)
 }
 
 // OfficeUserCreator is the exported interface for creating an office user

--- a/pkg/services/office_user/office_user_list_fetcher.go
+++ b/pkg/services/office_user/office_user_list_fetcher.go
@@ -7,6 +7,7 @@ import (
 
 type officeUserListQueryBuilder interface {
 	FetchMany(model interface{}, filters []services.QueryFilter, associations services.QueryAssociations, pagination services.Pagination, ordering services.QueryOrder) error
+	Count(model interface{}, filters []services.QueryFilter) (int, error)
 }
 
 type officeUserListFetcher struct {
@@ -18,6 +19,13 @@ func (o *officeUserListFetcher) FetchOfficeUserList(filters []services.QueryFilt
 	var officeUsers models.OfficeUsers
 	error := o.builder.FetchMany(&officeUsers, filters, associations, pagination, ordering)
 	return officeUsers, error
+}
+
+// FetchOfficeUserCount uses the passed query builder to count office users
+func (o *officeUserListFetcher) FetchOfficeUserCount(filters []services.QueryFilter) (int, error) {
+	var officeUsers models.OfficeUsers
+	count, error := o.builder.Count(&officeUsers, filters)
+	return count, error
 }
 
 // NewOfficeUserListFetcher returns an implementation of OfficeUserListFetcher

--- a/pkg/services/office_user/office_user_list_fetcher_test.go
+++ b/pkg/services/office_user/office_user_list_fetcher_test.go
@@ -15,11 +15,17 @@ import (
 
 type testOfficeUserListQueryBuilder struct {
 	fakeFetchMany func(model interface{}) error
+	fakeCount     func(model interface{}) (int, error)
 }
 
 func (t *testOfficeUserListQueryBuilder) FetchMany(model interface{}, filters []services.QueryFilter, associations services.QueryAssociations, pagination services.Pagination, ordering services.QueryOrder) error {
 	m := t.fakeFetchMany(model)
 	return m
+}
+
+func (t *testOfficeUserListQueryBuilder) Count(model interface{}, filters []services.QueryFilter) (int, error) {
+	count, m := t.fakeCount(model)
+	return count, m
 }
 
 func defaultPagination() services.Pagination {

--- a/pkg/services/organization.go
+++ b/pkg/services/organization.go
@@ -13,4 +13,5 @@ type OrganizationFetcher interface {
 //go:generate mockery -name OrganizationListFetcher
 type OrganizationListFetcher interface {
 	FetchOrganizationList(filters []QueryFilter, associations QueryAssociations, pagination Pagination, ordering QueryOrder) (models.Organizations, error)
+	FetchOrganizationCount(filters []QueryFilter) (int, error)
 }

--- a/pkg/services/organization/organization_list_fetcher.go
+++ b/pkg/services/organization/organization_list_fetcher.go
@@ -7,6 +7,7 @@ import (
 
 type organizationListQueryBuilder interface {
 	FetchMany(model interface{}, filters []services.QueryFilter, associations services.QueryAssociations, pagination services.Pagination, ordering services.QueryOrder) error
+	Count(model interface{}, filters []services.QueryFilter) (int, error)
 }
 
 type organizationListFetcher struct {
@@ -18,6 +19,13 @@ func (o *organizationListFetcher) FetchOrganizationList(filters []services.Query
 	var organizations models.Organizations
 	error := o.builder.FetchMany(&organizations, filters, associations, pagination, ordering)
 	return organizations, error
+}
+
+// FetchOrganizationUserList uses the passed query builder to fetch a list of transportation offices
+func (o *organizationListFetcher) FetchOrganizationCount(filters []services.QueryFilter) (int, error) {
+	var organizations models.Organizations
+	count, error := o.builder.Count(&organizations, filters)
+	return count, error
 }
 
 // NewOrganizationListFetcher returns an implementation of OrganizationListFetcher

--- a/pkg/services/query/query_builder.go
+++ b/pkg/services/query/query_builder.go
@@ -246,30 +246,30 @@ func (p *Builder) FetchMany(model interface{}, filters []services.QueryFilter, a
 	return nil
 }
 
-func (p *Builder) Count(model interface{}, filters []services.QueryFilter) (*int, error) {
+func (p *Builder) Count(model interface{}, filters []services.QueryFilter) (int, error) {
 	t := reflect.TypeOf(model)
 	if t.Kind() != reflect.Ptr {
-		return nil, errors.New(fetchManyReflectionMessage)
+		return 0, errors.New(fetchManyReflectionMessage)
 	}
 	t = t.Elem()
 	if t.Kind() != reflect.Slice {
-		return nil, errors.New(fetchManyReflectionMessage)
+		return 0, errors.New(fetchManyReflectionMessage)
 	}
 	t = t.Elem()
 	if t.Kind() != reflect.Struct {
-		return nil, errors.New(fetchManyReflectionMessage)
+		return 0, errors.New(fetchManyReflectionMessage)
 	}
 	query := p.db.Q()
 	query, err := filteredQuery(query, filters, t)
 	if err != nil {
-		return nil, err
+		return 0, err
 	}
 
 	count, err := query.Count(model)
 	if err != nil {
-		return nil, err
+		return 0, err
 	}
-	return &count, nil
+	return count, nil
 }
 
 func (p *Builder) CreateOne(model interface{}) (*validate.Errors, error) {

--- a/pkg/services/query/query_builder.go
+++ b/pkg/services/query/query_builder.go
@@ -246,6 +246,32 @@ func (p *Builder) FetchMany(model interface{}, filters []services.QueryFilter, a
 	return nil
 }
 
+func (p *Builder) Count(model interface{}, filters []services.QueryFilter) (*int, error) {
+	t := reflect.TypeOf(model)
+	if t.Kind() != reflect.Ptr {
+		return nil, errors.New(fetchManyReflectionMessage)
+	}
+	t = t.Elem()
+	if t.Kind() != reflect.Slice {
+		return nil, errors.New(fetchManyReflectionMessage)
+	}
+	t = t.Elem()
+	if t.Kind() != reflect.Struct {
+		return nil, errors.New(fetchManyReflectionMessage)
+	}
+	query := p.db.Q()
+	query, err := filteredQuery(query, filters, t)
+	if err != nil {
+		return nil, err
+	}
+
+	count, err := query.Count(model)
+	if err != nil {
+		return nil, err
+	}
+	return &count, nil
+}
+
 func (p *Builder) CreateOne(model interface{}) (*validate.Errors, error) {
 	t := reflect.TypeOf(model)
 	if t.Kind() != reflect.Ptr {

--- a/pkg/services/query/query_builder_test.go
+++ b/pkg/services/query/query_builder_test.go
@@ -261,6 +261,99 @@ func (suite *QueryBuilderSuite) TestFetchMany() {
 	})
 }
 
+func (suite *QueryBuilderSuite) TestCount() {
+	// this should be stubbed out with a model that is agnostic to our code
+	// similar to how the pop repo tests might work
+	user := testdatagen.MakeDefaultOfficeUser(suite.DB())
+	user2 := testdatagen.MakeDefaultOfficeUser(suite.DB())
+	builder := NewQueryBuilder(suite.DB())
+
+	suite.T().Run("counts with uuid filter", func(t *testing.T) {
+		filters := []services.QueryFilter{
+			NewQueryFilter("id", equals, user2.ID.String()),
+		}
+
+		count, err := builder.Count(&models.OfficeUsers{}, filters)
+
+		suite.NoError(err)
+		suite.Equal(1, *count)
+
+		// do the reverse to make sure we don't get the same record every time
+		filters = []services.QueryFilter{
+			NewQueryFilter("id", equals, user.ID.String()),
+		}
+
+		count, err = builder.Count(&models.OfficeUsers{}, filters)
+
+		suite.NoError(err)
+		suite.Equal(1, *count)
+	})
+
+	suite.T().Run("counts with time filter", func(t *testing.T) {
+		filters := []services.QueryFilter{
+			NewQueryFilter("created_at", greaterThan, user.CreatedAt),
+		}
+
+		pop.Debug = true
+		count, err := builder.Count(&models.OfficeUsers{}, filters)
+		pop.Debug = false
+		suite.NoError(err)
+		suite.Equal(1, *count)
+	})
+
+	suite.T().Run("fails with invalid column", func(t *testing.T) {
+		filters := []services.QueryFilter{
+			NewQueryFilter("fake_column", equals, user.ID.String()),
+		}
+
+		count, err := builder.Count(&models.OfficeUsers{}, filters)
+
+		suite.Error(err)
+		suite.Equal("[fake_column =] is not valid input", err.Error())
+		suite.Nil(count)
+	})
+
+	suite.T().Run("fails with invalid comparator", func(t *testing.T) {
+		filters := []services.QueryFilter{
+			NewQueryFilter("id", "*", user.ID.String()),
+		}
+
+		count, err := builder.Count(&models.OfficeUsers{}, filters)
+
+		suite.Error(err)
+		suite.Equal("[id *] is not valid input", err.Error())
+		suite.Nil(count)
+	})
+
+	suite.T().Run("fails when not pointer", func(t *testing.T) {
+
+		count, err := builder.Count(models.OfficeUsers{}, []services.QueryFilter{})
+
+		suite.Error(err)
+		suite.Equal("Model should be pointer to slice of structs", err.Error())
+		suite.Nil(count)
+	})
+
+	suite.T().Run("fails when not pointer to slice", func(t *testing.T) {
+
+		count, err := builder.Count(&models.OfficeUser{}, []services.QueryFilter{})
+
+		suite.Error(err)
+		suite.Equal("Model should be pointer to slice of structs", err.Error())
+		suite.Nil(count)
+	})
+
+	suite.T().Run("fails when not pointer to slice of structs", func(t *testing.T) {
+		var intSlice []int
+
+		count, err := builder.Count(&intSlice, []services.QueryFilter{})
+
+		suite.Error(err)
+		suite.Equal("Model should be pointer to slice of structs", err.Error())
+		suite.Nil(count)
+	})
+}
+
 func (suite *QueryBuilderSuite) TestCreateOne() {
 	builder := NewQueryBuilder(suite.DB())
 

--- a/pkg/services/query/query_builder_test.go
+++ b/pkg/services/query/query_builder_test.go
@@ -276,7 +276,7 @@ func (suite *QueryBuilderSuite) TestCount() {
 		count, err := builder.Count(&models.OfficeUsers{}, filters)
 
 		suite.NoError(err)
-		suite.Equal(1, *count)
+		suite.Equal(1, count)
 
 		// do the reverse to make sure we don't get the same record every time
 		filters = []services.QueryFilter{
@@ -286,7 +286,7 @@ func (suite *QueryBuilderSuite) TestCount() {
 		count, err = builder.Count(&models.OfficeUsers{}, filters)
 
 		suite.NoError(err)
-		suite.Equal(1, *count)
+		suite.Equal(1, count)
 	})
 
 	suite.T().Run("counts with time filter", func(t *testing.T) {
@@ -298,7 +298,7 @@ func (suite *QueryBuilderSuite) TestCount() {
 		count, err := builder.Count(&models.OfficeUsers{}, filters)
 		pop.Debug = false
 		suite.NoError(err)
-		suite.Equal(1, *count)
+		suite.Equal(1, count)
 	})
 
 	suite.T().Run("fails with invalid column", func(t *testing.T) {

--- a/pkg/services/query/query_builder_test.go
+++ b/pkg/services/query/query_builder_test.go
@@ -310,7 +310,7 @@ func (suite *QueryBuilderSuite) TestCount() {
 
 		suite.Error(err)
 		suite.Equal("[fake_column =] is not valid input", err.Error())
-		suite.Nil(count)
+		suite.Zero(count)
 	})
 
 	suite.T().Run("fails with invalid comparator", func(t *testing.T) {
@@ -322,7 +322,7 @@ func (suite *QueryBuilderSuite) TestCount() {
 
 		suite.Error(err)
 		suite.Equal("[id *] is not valid input", err.Error())
-		suite.Nil(count)
+		suite.Zero(count)
 	})
 
 	suite.T().Run("fails when not pointer", func(t *testing.T) {
@@ -331,7 +331,7 @@ func (suite *QueryBuilderSuite) TestCount() {
 
 		suite.Error(err)
 		suite.Equal("Model should be pointer to slice of structs", err.Error())
-		suite.Nil(count)
+		suite.Zero(count)
 	})
 
 	suite.T().Run("fails when not pointer to slice", func(t *testing.T) {
@@ -340,7 +340,7 @@ func (suite *QueryBuilderSuite) TestCount() {
 
 		suite.Error(err)
 		suite.Equal("Model should be pointer to slice of structs", err.Error())
-		suite.Nil(count)
+		suite.Zero(count)
 	})
 
 	suite.T().Run("fails when not pointer to slice of structs", func(t *testing.T) {
@@ -350,7 +350,7 @@ func (suite *QueryBuilderSuite) TestCount() {
 
 		suite.Error(err)
 		suite.Equal("Model should be pointer to slice of structs", err.Error())
-		suite.Nil(count)
+		suite.Zero(count)
 	})
 }
 

--- a/pkg/services/tsp.go
+++ b/pkg/services/tsp.go
@@ -16,4 +16,5 @@ type TransportationServiceProviderPerformanceFetcher interface {
 //go:generate mockery -name TransportationServiceProviderPerformanceListFetcher
 type TransportationServiceProviderPerformanceListFetcher interface {
 	FetchTransportationServiceProviderPerformanceList(filters []QueryFilter, associations QueryAssociations, pagination Pagination, ordering QueryOrder) (models.TransportationServiceProviderPerformances, error)
+	FetchTransportationServiceProviderPerformanceCount(filters []QueryFilter) (*int, error)
 }

--- a/pkg/services/tsp.go
+++ b/pkg/services/tsp.go
@@ -16,5 +16,5 @@ type TransportationServiceProviderPerformanceFetcher interface {
 //go:generate mockery -name TransportationServiceProviderPerformanceListFetcher
 type TransportationServiceProviderPerformanceListFetcher interface {
 	FetchTransportationServiceProviderPerformanceList(filters []QueryFilter, associations QueryAssociations, pagination Pagination, ordering QueryOrder) (models.TransportationServiceProviderPerformances, error)
-	FetchTransportationServiceProviderPerformanceCount(filters []QueryFilter) (*int, error)
+	FetchTransportationServiceProviderPerformanceCount(filters []QueryFilter) (int, error)
 }

--- a/pkg/services/tsp/transportation_service_provider_performance_list_fetcher.go
+++ b/pkg/services/tsp/transportation_service_provider_performance_list_fetcher.go
@@ -7,7 +7,7 @@ import (
 
 type transportationServiceProviderPerformanceListQueryBuilder interface {
 	FetchMany(model interface{}, filters []services.QueryFilter, associations services.QueryAssociations, pagination services.Pagination, ordering services.QueryOrder) error
-	Count(model interface{}, filters []services.QueryFilter) (*int, error)
+	Count(model interface{}, filters []services.QueryFilter) (int, error)
 }
 
 type transportationServiceProviderPerformanceListFetcher struct {
@@ -22,7 +22,7 @@ func (o *transportationServiceProviderPerformanceListFetcher) FetchTransportatio
 }
 
 // FetchTransportationServiceProviderPerformanceCount counts the transportation service provider performance given a slice of filters
-func (o *transportationServiceProviderPerformanceListFetcher) FetchTransportationServiceProviderPerformanceCount(filters []services.QueryFilter) (*int, error) {
+func (o *transportationServiceProviderPerformanceListFetcher) FetchTransportationServiceProviderPerformanceCount(filters []services.QueryFilter) (int, error) {
 	var tspps models.TransportationServiceProviderPerformances
 	count, error := o.builder.Count(&tspps, filters)
 	return count, error

--- a/pkg/services/tsp/transportation_service_provider_performance_list_fetcher.go
+++ b/pkg/services/tsp/transportation_service_provider_performance_list_fetcher.go
@@ -7,6 +7,7 @@ import (
 
 type transportationServiceProviderPerformanceListQueryBuilder interface {
 	FetchMany(model interface{}, filters []services.QueryFilter, associations services.QueryAssociations, pagination services.Pagination, ordering services.QueryOrder) error
+	Count(model interface{}, filters []services.QueryFilter) (*int, error)
 }
 
 type transportationServiceProviderPerformanceListFetcher struct {
@@ -18,6 +19,13 @@ func (o *transportationServiceProviderPerformanceListFetcher) FetchTransportatio
 	var tspps models.TransportationServiceProviderPerformances
 	error := o.builder.FetchMany(&tspps, filters, associations, pagination, ordering)
 	return tspps, error
+}
+
+// FetchTransportationServiceProviderPerformanceCount counts the transportation service provider performance given a slice of filters
+func (o *transportationServiceProviderPerformanceListFetcher) FetchTransportationServiceProviderPerformanceCount(filters []services.QueryFilter) (*int, error) {
+	var tspps models.TransportationServiceProviderPerformances
+	count, error := o.builder.Count(&tspps, filters)
+	return count, error
 }
 
 // NewTransportationServiceProviderPerformanceListFetcher return an implementation of the TransportationServiceProviderPerformanceFetcher interface

--- a/pkg/services/tsp/transportation_service_provider_performance_list_fetcher_test.go
+++ b/pkg/services/tsp/transportation_service_provider_performance_list_fetcher_test.go
@@ -15,7 +15,7 @@ import (
 
 type testTransportationServiceProviderPerformanceListQueryBuilder struct {
 	fakeFetchMany func(model interface{}) error
-	fakeCount     func(model interface{}) (*int, error)
+	fakeCount     func(model interface{}) (int, error)
 }
 
 func (t *testTransportationServiceProviderPerformanceListQueryBuilder) FetchMany(model interface{}, filters []services.QueryFilter, associations services.QueryAssociations, pagination services.Pagination, ordering services.QueryOrder) error {
@@ -23,7 +23,7 @@ func (t *testTransportationServiceProviderPerformanceListQueryBuilder) FetchMany
 	return m
 }
 
-func (t *testTransportationServiceProviderPerformanceListQueryBuilder) Count(model interface{}, filters []services.QueryFilter) (*int, error) {
+func (t *testTransportationServiceProviderPerformanceListQueryBuilder) Count(model interface{}, filters []services.QueryFilter) (int, error) {
 	count, m := t.fakeCount(model)
 	return count, m
 }
@@ -116,9 +116,9 @@ func (suite *TSPServiceSuite) TestCountTSPPs() {
 		id, err := uuid.NewV4()
 
 		suite.NoError(err)
-		fakeCount := func(model interface{}) (*int, error) {
+		fakeCount := func(model interface{}) (int, error) {
 			count := 2
-			return &count, nil
+			return count, nil
 		}
 		builder := &testTransportationServiceProviderPerformanceListQueryBuilder{
 			fakeCount: fakeCount,
@@ -132,12 +132,12 @@ func (suite *TSPServiceSuite) TestCountTSPPs() {
 		count, err := fetcher.FetchTransportationServiceProviderPerformanceCount(filters)
 
 		suite.NoError(err)
-		suite.Equal(2, *count)
+		suite.Equal(2, count)
 	})
 
 	suite.T().Run("if there is an error, we get it with no count", func(t *testing.T) {
-		fakeCount := func(model interface{}) (*int, error) {
-			return nil, errors.New("Fetch error")
+		fakeCount := func(model interface{}) (int, error) {
+			return 0, errors.New("Fetch error")
 		}
 		builder := &testTransportationServiceProviderPerformanceListQueryBuilder{
 			fakeCount: fakeCount,
@@ -149,6 +149,6 @@ func (suite *TSPServiceSuite) TestCountTSPPs() {
 
 		suite.Error(err)
 		suite.Equal(err.Error(), "Fetch error")
-		suite.Nil(count)
+		suite.Equal(0, count)
 	})
 }


### PR DESCRIPTION
## Description

On admin app, fixes pagination total when TSPPs are filtered. 

## Setup

On admin app
go to TSPP Page
filter by Traffic Distribuition List id = f761a999-03c6-4b36-95a7-c035a8e7453c
Total count (as seen in pagination bar) should match number of records shown. 

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/169137533) for this change
