### PR TITLE
Speed up checking the generated code

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -291,7 +291,7 @@ jobs:
 
   # `check_generated_code` is used to ensure generated code doesn't change
   check_generated_code:
-    executor: mymove_small
+    executor: mymove_medium
     steps:
       - checkout
       - restore_cache:


### PR DESCRIPTION
## Description

Originally we chose a small instance because this was a fast check. But now it takes 4+ minutes to run! The standard CircleCI size is medium so I'm changing it.