### PR TITLE
fix to bad video link in Service Object design doc

### DIFF
--- a/docs/backend/service-objects.md
+++ b/docs/backend/service-objects.md
@@ -320,5 +320,6 @@ to minimize side affects and allows us as developers to focus on what we are tru
 ## Resources
 
 * Pairing session on creating the storage in transit GET handler with a service layer:
-  [video](https://drive.google.com/open?id=1gqjlL8rmOEqkHVPjuJrhVH5_Ybazzoso)
+  [video](https://drive.google.com/drive/folders/1WMZ5FzzWMU-HzEr36QFfVRr8TRyuK8I-)
+  from the [folder](https://drive.google.com/drive/folders/1WMZ5FzzWMU-HzEr36QFfVRr8TRyuK8I-)
   and [pull request](https://github.com/transcom/mymove/pull/2017)

--- a/docs/backend/service-objects.md
+++ b/docs/backend/service-objects.md
@@ -320,6 +320,6 @@ to minimize side affects and allows us as developers to focus on what we are tru
 ## Resources
 
 * Pairing session on creating the storage in transit GET handler with a service layer:
-  [video](https://drive.google.com/drive/folders/1WMZ5FzzWMU-HzEr36QFfVRr8TRyuK8I-)
+  [video](https://drive.google.com/file/d/19cCDLt1hDJSbZDhHdwQ8u63lBhupTK_s/view)
   from the [folder](https://drive.google.com/drive/folders/1WMZ5FzzWMU-HzEr36QFfVRr8TRyuK8I-)
   and [pull request](https://github.com/transcom/mymove/pull/2017)


### PR DESCRIPTION
## Description

Fix the video linked at the bottom of the page to point to file in USTC instead of the old DDS drive.

## Reviewer Notes

n/a

## Setup

n/a

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/169506399) for this change

## Screenshots

n/a
