### PR TITLE
DPS Auth requires Mutual TLS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -853,7 +853,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: placeholder_branch_name
+              ignore: cg_dps_mutual_tls
 
       - client_test:
           requires:
@@ -861,7 +861,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: placeholder_branch_name
+              ignore: cg_dps_mutual_tls
 
       - server_test:
           requires:
@@ -869,7 +869,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: placeholder_branch_name
+              ignore: cg_dps_mutual_tls
 
       - build_app:
           requires:
@@ -910,28 +910,28 @@ workflows:
             - build_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: cg_dps_mutual_tls
 
       - deploy_experimental_tasks:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: cg_dps_mutual_tls
 
       - deploy_experimental_app:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: cg_dps_mutual_tls
 
       - deploy_experimental_app_client_tls:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: cg_dps_mutual_tls
 
       - check_circle_against_staging_sha:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -853,7 +853,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: cg_dps_mutual_tls
+              ignore: placeholder_branch_name
 
       - client_test:
           requires:
@@ -861,7 +861,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: cg_dps_mutual_tls
+              ignore: placeholder_branch_name
 
       - server_test:
           requires:
@@ -869,7 +869,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: cg_dps_mutual_tls
+              ignore: placeholder_branch_name
 
       - build_app:
           requires:
@@ -910,28 +910,28 @@ workflows:
             - build_migrations
           filters:
             branches:
-              only: cg_dps_mutual_tls
+              only: placeholder_branch_name
 
       - deploy_experimental_tasks:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: cg_dps_mutual_tls
+              only: placeholder_branch_name
 
       - deploy_experimental_app:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: cg_dps_mutual_tls
+              only: placeholder_branch_name
 
       - deploy_experimental_app_client_tls:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: cg_dps_mutual_tls
+              only: placeholder_branch_name
 
       - check_circle_against_staging_sha:
           requires:

--- a/config/app-client-tls.container-definition.json
+++ b/config/app-client-tls.container-definition.json
@@ -17,8 +17,6 @@
     "production",
     "--debug-logging",
     "--log-task-metadata",
-    "--db-env",
-    "container",
     "--mutual-tls-enabled",
     "--tls-enabled"
   ],
@@ -89,8 +87,20 @@
       "value": "{{ .move_mil_dod_ca_cert }}"
     },
     {
-      "name": "HTTP_MY_SERVER_NAME",
-      "value": "my.{{ .domain }}"
+      "name": "DPS_REDIRECT_URL",
+      "value": "{{ .DPS_REDIRECT_URL }}"
+    },
+    {
+      "name": "DPS_COOKIE_NAME",
+      "value": "{{ .DPS_COOKIE_NAME }}"
+    },
+    {
+      "name": "DPS_COOKIE_DOMAIN",
+      "value": ".sddc.army.mil"
+    },
+    {
+      "name": "HTTP_DPS_SERVER_NAME",
+      "value": "dps.{{ .domain }}"
     },
     {
       "name": "HTTP_ORDERS_SERVER_NAME",
@@ -147,6 +157,10 @@
     {
       "name": "SERVE_SWAGGER_UI",
       "value": "{{ .SERVE_SWAGGER_UI }}"
+    },
+    {
+      "name": "SERVE_DPS",
+      "value": "{{ .SERVE_DPS }}"
     },
     {
       "name": "SERVE_ORDERS",

--- a/config/app.container-definition.json
+++ b/config/app.container-definition.json
@@ -94,14 +94,6 @@
       "value": "admin.{{ .domain }}"
     },
     {
-      "name": "HTTP_ORDERS_SERVER_NAME",
-      "value": "orders.{{ .domain }}"
-    },
-    {
-      "name": "HTTP_DPS_SERVER_NAME",
-      "value": "dps.{{ .domain }}"
-    },
-    {
       "name": "AWS_S3_BUCKET_NAME",
       "value": "transcom-ppp-app-{{ .environment }}-us-west-2"
     },
@@ -162,18 +154,6 @@
       "value": ""
     },
     {
-      "name": "DPS_REDIRECT_URL",
-      "value": "{{ .DPS_REDIRECT_URL }}"
-    },
-    {
-      "name": "DPS_COOKIE_NAME",
-      "value": "{{ .DPS_COOKIE_NAME }}"
-    },
-    {
-      "name": "DPS_COOKIE_DOMAIN",
-      "value": ".sddc.army.mil"
-    },
-    {
       "name": "GEX_URL",
       "value": "https://gexweba.daas.dla.mil/msg_data/submit/"
     },
@@ -200,10 +180,6 @@
     {
       "name": "SERVE_SDDC",
       "value": "{{ .SERVE_SDDC }}"
-    },
-    {
-      "name": "SERVE_DPS",
-      "value": "{{ .SERVE_DPS }}"
     },
     {
       "name": "SERVE_API_INTERNAL",

--- a/pkg/cli/services.go
+++ b/pkg/cli/services.go
@@ -57,17 +57,22 @@ func CheckServices(v *viper.Viper) error {
 		return errors.New("no service was enabled")
 	}
 
+	// if DPS is enabled then the mutualTLSListener is needed too
 	// if Orders is enabled then the mutualTLSListener is needed too
+	// if PRIME is enabled then the mutualTLSListener is needed too
 	mutualTLSEnabled := v.GetBool(MutualTLSListenerFlag)
 	if v.GetString(EnvironmentFlag) != EnvironmentDevelopment {
+		if dpsEnabled && !mutualTLSEnabled {
+			return errors.New(fmt.Sprintf("for dps service to be enabled both %s and the %s flags must be in use", ServeDPSFlag, MutualTLSListenerFlag))
+		}
 		if ordersEnabled && !mutualTLSEnabled {
 			return errors.New(fmt.Sprintf("for orders service to be enabled both %s and the %s flags must be in use", ServeOrdersFlag, MutualTLSListenerFlag))
 		}
 		if primeAPIEnabled && !mutualTLSEnabled {
 			return errors.New(fmt.Sprintf("for prime service to be enabled both %s and the %s flags must be in use", ServePrimeFlag, MutualTLSListenerFlag))
 		}
-		if mutualTLSEnabled && !ordersEnabled && !primeAPIEnabled {
-			return errors.New("either orders service or prime service must be enabled for mutualTSL to be enabled")
+		if mutualTLSEnabled && !(dpsEnabled || ordersEnabled || primeAPIEnabled) {
+			return errors.New("either dps, orders or prime service must be enabled for mutualTSL to be enabled")
 		}
 	}
 


### PR DESCRIPTION
## Description

DPS Auth uses Mutual TLS and I was unaware of this and gave bad guidance when we added CLI flags to split the services and listeners. This appeared in a security review of the architecture where we discovered that the `dps.move.mil` points to the NLB and not the ALB. On review of the code its clear that it expect to get the Mutual TLS cert for authentication before doing anything with DPS in the same way that Orders API does.

The fix is the enable the flags on the app-client-tls container definition and remove it from the app container definition.

## Code Review Verification Steps

* [x] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/169514731) for this change