### PR TITLE
dependabot automerge PRs

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -7,6 +7,10 @@ update_configs:
   - package_manager: "javascript"
     directory: "/"
     update_schedule: "live"
+    automerged_updates:
+      - match:
+          dependency_type: "all"
+          update_type: "semver:minor"
     default_labels:
       - dependencies
       - automerge
@@ -21,6 +25,10 @@ update_configs:
   - package_manager: "go:modules"
     directory: "/"
     update_schedule: "daily"
+    automerged_updates:
+      - match:
+          dependency_type: "all"
+          update_type: "semver:minor"
     default_labels:
       - dependencies
       - automerge
@@ -35,6 +43,10 @@ update_configs:
   - package_manager: "docker"
     directory: "/"
     update_schedule: "daily"
+    automerged_updates:
+      - match:
+          dependency_type: "all"
+          update_type: "semver:minor"
     default_labels:
       - dependencies
       - automerge

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -1,0 +1,12 @@
+name: Auto approve
+on: pull_request
+
+jobs:
+  approve:
+    name: Auto-approve dependabot PRs
+    if: github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: hmarr/auto-approve-action@v2.0.0
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
## Description

Auto merge minor version upgrades initiated by dependabot. Dependabot can automerge updates, but our branch protection will block it, so also add an auto approve GH action to approve dependabot PRs.

