### PR TITLE
Add in scaffolding for progear changes feature flag

### DIFF
--- a/src/scenes/Moves/Ppm/Weight.jsx
+++ b/src/scenes/Moves/Ppm/Weight.jsx
@@ -13,6 +13,7 @@ import { getPpmWeightEstimate, createOrUpdatePpm, getSelectedWeightInfo } from '
 import { updatePPMEstimate } from 'shared/Entities/modules/ppms';
 import 'react-rangeslider/lib/index.css';
 import './Weight.css';
+import { withContext } from 'shared/AppContext';
 
 const WeightWizardForm = reduxifyWizardForm('weight-wizard-form');
 
@@ -116,102 +117,109 @@ export class PpmWeight extends Component {
       hasEstimateError,
       selectedWeightInfo,
     } = this.props;
+    const { context: { flags: { progearChanges } } = { flags: { progearChanges: null } } } = this.props;
+
     return (
-      <div className="grid-container usa-prose site-prose">
-        <WeightWizardForm
-          handleSubmit={this.handleSubmit}
-          pageList={pages}
-          pageKey={pageKey}
-          serverError={error}
-          additionalValues={{
-            hasEstimateInProgress,
-            incentive_estimate_max,
-          }}
-        >
-          {error && (
-            <div className="grid-row">
-              <div className="grid-col-12">
-                <Alert type="error" heading="An error occurred">
-                  {error.message}
-                </Alert>
-              </div>
-            </div>
-          )}
-          <div className="grid-row">
-            <div className="grid-col-12">
-              <h1>Customize Weight</h1>
-              {!hasLoadSuccess && <LoadingPlaceholder />}
-              {hasLoadSuccess && (
-                <Fragment>
-                  <p>Use this slider to customize how much weight you think you’ll carry.</p>
-                  <div className="slider-container">
-                    <Slider
-                      min={selectedWeightInfo.min}
-                      max={selectedWeightInfo.max}
-                      value={this.state.pendingPpmWeight}
-                      onChange={this.onWeightSelecting}
-                      onChangeComplete={this.onWeightSelected}
-                      labels={{
-                        [selectedWeightInfo.min]: `${selectedWeightInfo.min} lbs`,
-                        [selectedWeightInfo.max]: `${selectedWeightInfo.max} lbs`,
-                      }}
-                    />
+      <div>
+        {progearChanges && <h1>Progear placeholder text</h1>}
+        {!progearChanges && (
+          <div className="grid-container usa-prose site-prose">
+            <WeightWizardForm
+              handleSubmit={this.handleSubmit}
+              pageList={pages}
+              pageKey={pageKey}
+              serverError={error}
+              additionalValues={{
+                hasEstimateInProgress,
+                incentive_estimate_max,
+              }}
+            >
+              {error && (
+                <div className="grid-row">
+                  <div className="grid-col-12">
+                    <Alert type="error" heading="An error occurred">
+                      {error.message}
+                    </Alert>
                   </div>
-                  {hasEstimateError && (
+                </div>
+              )}
+              <div className="grid-row">
+                <div className="grid-col-12">
+                  <h1>Customize Weight</h1>
+                  {!hasLoadSuccess && <LoadingPlaceholder />}
+                  {hasLoadSuccess && (
                     <Fragment>
-                      <div className="error-message">
-                        <Alert type="warning" heading="Could not retrieve estimate">
-                          There was an issue retrieving an estimate for your incentive. You still qualify, but need to
-                          talk with your local transportation office which you can look up on{' '}
-                          <a href="move.mil" className="usa-link">
-                            move.mil
-                          </a>
-                        </Alert>
+                      <p>Use this slider to customize how much weight you think you’ll carry.</p>
+                      <div className="slider-container">
+                        <Slider
+                          min={selectedWeightInfo.min}
+                          max={selectedWeightInfo.max}
+                          value={this.state.pendingPpmWeight}
+                          onChange={this.onWeightSelecting}
+                          onChangeComplete={this.onWeightSelected}
+                          labels={{
+                            [selectedWeightInfo.min]: `${selectedWeightInfo.min} lbs`,
+                            [selectedWeightInfo.max]: `${selectedWeightInfo.max} lbs`,
+                          }}
+                        />
+                      </div>
+                      {hasEstimateError && (
+                        <Fragment>
+                          <div className="error-message">
+                            <Alert type="warning" heading="Could not retrieve estimate">
+                              There was an issue retrieving an estimate for your incentive. You still qualify, but need
+                              to talk with your local transportation office which you can look up on{' '}
+                              <a href="move.mil" className="usa-link">
+                                move.mil
+                              </a>
+                            </Alert>
+                          </div>
+                        </Fragment>
+                      )}
+                      <table className="numeric-info">
+                        <tbody>
+                          <tr>
+                            <th>Your PPM Weight Estimate:</th>
+                            <td className="current-weight"> {formatNumber(this.state.pendingPpmWeight)} lbs.</td>
+                          </tr>
+                          <tr>
+                            <th>Your PPM Incentive:</th>
+                            {hasEstimateError ? (
+                              <td className="incentive">
+                                Not ready yet{' '}
+                                <IconWithTooltip toolTipText="We expect to receive rate data covering your move dates by the end of this month. Check back then to see your estimated incentive." />
+                              </td>
+                            ) : (
+                              <td className="incentive">
+                                {formatCentsRange(incentive_estimate_min, incentive_estimate_max)}
+                              </td>
+                            )}
+                          </tr>
+                        </tbody>
+                      </table>
+
+                      <div className="info">
+                        <h3> How is my PPM Incentive calculated?</h3>
+                        <p>
+                          The government gives you 95% of what they would pay a mover when you move your own belongings,
+                          based on weight and distance. You pay taxes on this income. You can reduce the amount taxable
+                          incentive by saving receipts for approved expenses.
+                        </p>
+
+                        <p>
+                          This estimator just presents a range of possible incentives based on your anticipated shipment
+                          weight, anticipated moving date, and the specific route that you will be traveling. During
+                          your move, you will need to weigh the stuff you’re carrying, and submit weight tickets. We’ll
+                          let you know later how to weigh the stuff you carry.
+                        </p>
                       </div>
                     </Fragment>
                   )}
-                  <table className="numeric-info">
-                    <tbody>
-                      <tr>
-                        <th>Your PPM Weight Estimate:</th>
-                        <td className="current-weight"> {formatNumber(this.state.pendingPpmWeight)} lbs.</td>
-                      </tr>
-                      <tr>
-                        <th>Your PPM Incentive:</th>
-                        {hasEstimateError ? (
-                          <td className="incentive">
-                            Not ready yet{' '}
-                            <IconWithTooltip toolTipText="We expect to receive rate data covering your move dates by the end of this month. Check back then to see your estimated incentive." />
-                          </td>
-                        ) : (
-                          <td className="incentive">
-                            {formatCentsRange(incentive_estimate_min, incentive_estimate_max)}
-                          </td>
-                        )}
-                      </tr>
-                    </tbody>
-                  </table>
-
-                  <div className="info">
-                    <h3> How is my PPM Incentive calculated?</h3>
-                    <p>
-                      The government gives you 95% of what they would pay a mover when you move your own belongings,
-                      based on weight and distance. You pay taxes on this income. You can reduce the amount taxable
-                      incentive by saving receipts for approved expenses.
-                    </p>
-
-                    <p>
-                      This estimator just presents a range of possible incentives based on your anticipated shipment
-                      weight, anticipated moving date, and the specific route that you will be traveling. During your
-                      move, you will need to weigh the stuff you’re carrying, and submit weight tickets. We’ll let you
-                      know later how to weigh the stuff you carry.
-                    </p>
-                  </div>
-                </Fragment>
-              )}
-            </div>
+                </div>
+              </div>
+            </WeightWizardForm>
           </div>
-        </WeightWizardForm>
+        )}
       </div>
     );
   }
@@ -253,7 +261,9 @@ function mapDispatchToProps(dispatch) {
   );
 }
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(PpmWeight);
+export default withContext(
+  connect(
+    mapStateToProps,
+    mapDispatchToProps,
+  )(PpmWeight),
+);

--- a/src/shared/featureFlags.js
+++ b/src/shared/featureFlags.js
@@ -15,6 +15,7 @@ const defaultFlags = {
   sitPanel: true,
   ppmPaymentRequest: true,
   too: false,
+  progearChanges: false,
 };
 
 const environmentFlags = {


### PR DESCRIPTION

## Description

Adds in a feature flag that will be usable for future work around progear in the customer facing app. When one appends `?flag:progearChanges=true`  to the `ppm-incentive` page it should show a placeholder `<h1>.`

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/tree/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/tree/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/tree/master/docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
  * [ ] Secure migrations have been tested using `scripts/run-prod-migrations`
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/169155519) for this change
