### PR TITLE
Fix link in DB Migrations README to GDoc

### DIFF
--- a/docs/how-to/migrate-the-database.md
+++ b/docs/how-to/migrate-the-database.md
@@ -111,7 +111,7 @@ If you are generating a new migration, use: `milmove gen migration -n <migration
 
 ## Zero-Downtime Migrations
 
-As a good practice, all of our migrations should create a database state that works both with the current version of the application code _and_ the new version of the application code. This allows us to run migrations before the new app code is live without creating downtime for our users. More in-depth list of migrations that might cause issues are outlined in our [google drive](https://docs.google.com/document/d/1ht57qz1ut--fqTQdLKbCqbZO_f_S0UoVSIyO6Bg-wJw).
+As a good practice, all of our migrations should create a database state that works both with the current version of the application code _and_ the new version of the application code. This allows us to run migrations before the new app code is live without creating downtime for our users. More in-depth list of migrations that might cause issues are outlined in our [google drive](https://docs.google.com/document/d/1q-Ho5NINRPpsHQI-DjmLrDlzHsBh-hUc).
 
 Eg: If we need to rename a column, doing a traditional rename would cause the app to fail if the database changes went live before the new application code (pointing to the new column name) went live. Instead, this should be done in a two-stage process.
 


### PR DESCRIPTION
## Description

Fix link to "PostgreSQL Locking Migrations" in this readme. 


## Reviewer Notes

n/a

## Setup

n/a

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/168438048) for this change

## Screenshots

n/a
