### PR TITLE
Update storybook deploy to use sync not cp

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1015,12 +1015,12 @@ workflows:
       - deploy_prod_storybook:
           requires:
             - build_storybook_app
-            - approve_prod_deploy
+            # - approve_prod_deploy
           filters:
             branches:
-              only: master
+              # only: master
               # Uncomment below if pushing a test branch. Also comment out approve_prod_deploy few lines above.
-              #only: placeholder_branch_name
+              only: cg_storybook_sync_no_cp
 
   dependency_updater_go:
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1015,12 +1015,12 @@ workflows:
       - deploy_prod_storybook:
           requires:
             - build_storybook_app
-            # - approve_prod_deploy
+            - approve_prod_deploy
           filters:
             branches:
-              # only: master
+              only: master
               # Uncomment below if pushing a test branch. Also comment out approve_prod_deploy few lines above.
-              only: cg_storybook_sync_no_cp
+              #only: placeholder_branch_name
 
   dependency_updater_go:
     triggers:

--- a/scripts/push-storybook-assets
+++ b/scripts/push-storybook-assets
@@ -13,4 +13,7 @@ fi
 
 readonly bucket=${1:-}
 
-aws s3 cp --recursive --sse AES256 /tmp/storybook/storybook-static/ s3://"${bucket}"/
+# Sync files from source to destination
+# encrypt files on upload
+# delete files at destination that are not on source (bucket versioning is enabled so it only adds a delete marker)
+aws s3 sync --delete --sse AES256 /tmp/storybook/storybook-static/ s3://"${bucket}"/


### PR DESCRIPTION
## Description

We want only the latest artifacts up in S3 and we don't want any old object to accumulate. This ought to make sure that only the generated files are accessible in S3 and the remaining ones disappear.

## Setup

Will test this via a CircleCI branch

## Code Review Verification Steps

* [x] Request review from a member of a different team.
* [x] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/169346959) for this change