### PR TITLE
Add in header and entitlement text

### DIFF
--- a/src/scenes/Moves/Ppm/Weight.jsx
+++ b/src/scenes/Moves/Ppm/Weight.jsx
@@ -10,6 +10,7 @@ import LoadingPlaceholder from 'shared/LoadingPlaceholder';
 import IconWithTooltip from 'shared/ToolTip/IconWithTooltip';
 import { formatCentsRange, formatNumber } from 'shared/formatters';
 import { getPpmWeightEstimate, createOrUpdatePpm, getSelectedWeightInfo } from './ducks';
+import { loadEntitlementsFromState } from 'shared/entitlements';
 import { updatePPMEstimate } from 'shared/Entities/modules/ppms';
 import 'react-rangeslider/lib/index.css';
 import './Weight.css';
@@ -118,10 +119,14 @@ export class PpmWeight extends Component {
       selectedWeightInfo,
     } = this.props;
     const { context: { flags: { progearChanges } } = { flags: { progearChanges: null } } } = this.props;
-
     return (
       <div>
-        {progearChanges && <h1>Progear placeholder text</h1>}
+        {progearChanges && (
+          <div className="grid-container usa-prose site-prose">
+            <h3>How much do you think you'll move?</h3>
+            <p>Your weight entitlement:{this.props.entitlement.weight.toLocaleString()} lbs</p>
+          </div>
+        )}
         {!progearChanges && (
           <div className="grid-container usa-prose site-prose">
             <WeightWizardForm
@@ -243,6 +248,7 @@ function mapStateToProps(state) {
     ...state.ppm,
     selectedWeightInfo: getSelectedWeightInfo(state),
     currentWeight: get(state, 'ppm.currentPpm.weight_estimate'),
+    entitlement: loadEntitlementsFromState(state),
     schema: schema,
     originDutyStationZip,
   };

--- a/src/scenes/Moves/Ppm/Weight.jsx
+++ b/src/scenes/Moves/Ppm/Weight.jsx
@@ -124,7 +124,7 @@ export class PpmWeight extends Component {
         {progearChanges && (
           <div className="grid-container usa-prose site-prose">
             <h3>How much do you think you'll move?</h3>
-            <p>Your weight entitlement:{this.props.entitlement.weight.toLocaleString()} lbs</p>
+            <p>Your weight entitlement: {this.props.entitlement.weight.toLocaleString()} lbs</p>
           </div>
         )}
         {!progearChanges && (


### PR DESCRIPTION
## Description

Adds in a `h3` title and `p` text field describing the weight entitlement as a start to the progear changes. More information on those fields can be found in the [story](https://www.pivotaltracker.com/story/show/169151007).

## Setup
To see this work one needs to append ?flag:progearChanges=true at the end of `ppm-incentive`


## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/tree/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/tree/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/tree/master/docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
  * [ ] Secure migrations have been tested using `scripts/run-prod-migrations`
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/169151007) for this change


## Screenshots
![image](https://user-images.githubusercontent.com/4325613/68243826-034ee900-ffd9-11e9-828d-1c86c465ffbb.png)

