### PR TITLE
Remove custom usa-button override

### DIFF
--- a/src/scenes/Moves/Ppm/PPMPaymentRequest.css
+++ b/src/scenes/Moves/Ppm/PPMPaymentRequest.css
@@ -56,10 +56,6 @@
   width: 100%;
 }
 
-.usa-button {
-  margin-right: 1.5rem;
-}
-
 @media only screen and (max-width: 481px) {
   .ppm-payment-request-footer {
     flex-direction: column;


### PR DESCRIPTION
## Setup

- `make server_run`
- `make client_run`
- Create a new service member using the mobile view available in your dev tools. The prev/next buttons should be aligned correctly now.

## Code Review Verification Steps

* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/169458150) for this change