### PR TITLE
e2e SM users should be active

### DIFF
--- a/pkg/testdatagen/make_user.go
+++ b/pkg/testdatagen/make_user.go
@@ -12,6 +12,7 @@ func MakeUser(db *pop.Connection, assertions Assertions) models.User {
 	user := models.User{
 		LoginGovUUID:  uuid.Must(uuid.NewV4()),
 		LoginGovEmail: "first.last@login.gov.test",
+		Active:        true,
 	}
 
 	// Overwrite values with those from assertions


### PR DESCRIPTION
## Description

When creating an e2e test SM user, we were making them `active = false` by default. Change this to mark them `active = true`.

## Setup

if you don't see the changes you might need to clean and build...

`make db_dev_reset`
`make db_dev_e2e_populate`

then check `users` table for `active = true`

## Code Review Verification Steps

* [ ] Request review from a member of a different team.

