### PR TITLE
Tweak top margin on wizard buttons

### DIFF
--- a/src/shared/WizardPage/Form.jsx
+++ b/src/shared/WizardPage/Form.jsx
@@ -115,7 +115,7 @@ export class WizardFormPage extends Component {
         )}
         <form className={className}>{children}</form>
         <div className="grid-row" style={{ marginTop: '0.5rem' }}>
-          <div className="grid-col-12 text-right">
+          <div className="grid-col-12 text-right margin-top-6 tablet:margin-top-3">
             {!isMobile && (
               <button className="usa-button usa-button--outline cancel" onClick={this.cancelFlow}>
                 Cancel


### PR DESCRIPTION
## Description

[Context](https://ustcdp3.slack.com/archives/CNTDW9Q1Z/p1573059017454000?thread_ts=1573054753.453300&cid=CNTDW9Q1Z) from Slack.

## Setup

- `make server_run`
- `make client_run`

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## Screenshots

**Before**
<img width="355" alt="Screen Shot 2019-11-06 at 11 39 37" src="https://user-images.githubusercontent.com/3522323/68323028-2be2eb80-008a-11ea-8608-3a9f69664a4c.png">

**After**
<img width="339" alt="Screen Shot 2019-11-06 at 11 39 23" src="https://user-images.githubusercontent.com/3522323/68323037-31403600-008a-11ea-9f43-f1f2e8db0f07.png">
