### PR TITLE
Fixed test for pricing template parser

### DIFF
--- a/pkg/parser/pricing/parse_service_areas_test.go
+++ b/pkg/parser/pricing/parse_service_areas_test.go
@@ -27,14 +27,14 @@ func (suite *PricingParserSuite) Test_verifyServiceAreas() {
 }
 
 func (suite *PricingParserSuite) Test_verifyServiceAreasWrongSheet() {
-	const sheetIndex = 4
+	const sheetIndex = 5
 	InitDataSheetInfo()
 
 	params := ParamConfig{
 		ProcessAll:   false,
 		ShowOutput:   false,
 		XlsxFilename: suite.xlsxFilename,
-		XlsxSheets:   []string{strconv.Itoa(sheetIndex)},
+		XlsxSheets:   []string{"4"},
 		SaveToFile:   true,
 		RunTime:      time.Now(),
 		XlsxFile:     suite.xlsxFile,
@@ -42,7 +42,9 @@ func (suite *PricingParserSuite) Test_verifyServiceAreasWrongSheet() {
 	}
 
 	err := verifyServiceAreas(params, sheetIndex)
-	suite.NoError(err, "verifyServiceAreas function failed")
+	if suite.Error(err) {
+		suite.Equal("verifyServiceAreas expected to process sheet 4, but received sheetIndex 5", err.Error())
+	}
 }
 
 // Test_parseDomesticServiceAreas


### PR DESCRIPTION
## Description

In PR #2941, I had introduced a typo that caused a test to behave differently.  This PR fixes that.  But it also fixes the test itself -- even prior to the PR, it wasn't testing what it was apparently intending to.

## Setup

To run tests:
`go test ./pkg/parser/pricing/`

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
