### PR TITLE
Progear Changes Slider

### DIFF
--- a/src/scenes/Moves/Ppm/Weight.css
+++ b/src/scenes/Moves/Ppm/Weight.css
@@ -18,6 +18,36 @@ div.slider-container {
   margin: 4em;
 }
 
+div.progear-slider-container {
+  margin-left: 0;
+  margin-right: 0;
+  margin-top: 4em;
+}
+
+.progear-slider-container .rangeslider__fill {
+  background-color: #0071bc;
+}
+
+.rangeslider__handle-tooltip {
+  background-color: white !important;
+  color: black !important;
+  border: 1px solid black;
+  width: 115px !important;
+  height: 25px !important;
+}
+
+.rangeslider__handle-tooltip span {
+  margin-top: 0 !important;
+}
+
+.rangeslider__handle-tooltip span::before {
+  content: "about ";
+}
+
+.rangeslider__handle-tooltip span::after {
+  content: " lbs";
+}
+
 table.numeric-info th {
   border: none;
 }

--- a/src/scenes/Moves/Ppm/Weight.css
+++ b/src/scenes/Moves/Ppm/Weight.css
@@ -28,16 +28,16 @@ div.progear-slider-container {
   background-color: #0071bc;
 }
 
-.rangeslider__handle-tooltip {
-  background-color: white !important;
-  color: black !important;
+.rangeslider .rangeslider__handle-tooltip {
+  background-color: white;
+  color: black;
   border: 1px solid black;
-  width: 115px !important;
-  height: 25px !important;
+  width: 115px;
+  height: 25px;
 }
 
-.rangeslider__handle-tooltip span {
-  margin-top: 0 !important;
+.rangeslider .rangeslider__handle-tooltip span {
+  margin-top: 0;
 }
 
 .rangeslider__handle-tooltip span::before {

--- a/src/scenes/Moves/Ppm/Weight.jsx
+++ b/src/scenes/Moves/Ppm/Weight.jsx
@@ -96,6 +96,10 @@ export class PpmWeight extends Component {
     });
   };
 
+  onWeightSliderSelection = value => {
+    console.log(value);
+  };
+
   onWeightSelected() {
     const { currentPpm, originDutyStationZip } = this.props;
     this.props.getPpmWeightEstimate(
@@ -106,6 +110,7 @@ export class PpmWeight extends Component {
       this.state.pendingPpmWeight,
     );
   }
+
   render() {
     const {
       incentive_estimate_min,
@@ -125,6 +130,20 @@ export class PpmWeight extends Component {
           <div className="grid-container usa-prose site-prose">
             <h3>How much do you think you'll move?</h3>
             <p>Your weight entitlement: {this.props.entitlement.weight.toLocaleString()} lbs</p>
+            <div className="progear-slider-container">
+              <Slider
+                min={0}
+                max={this.props.entitlement.weight}
+                value={this.state.pendingPpmWeight}
+                onChange={this.onWeightSelecting}
+                onChangeComplete={this.onWeightSelected}
+                step={500}
+                labels={{
+                  0: `${0} lbs`,
+                  [this.props.entitlement.weight]: `${this.props.entitlement.weight.toLocaleString()} lbs`,
+                }}
+              />
+            </div>
           </div>
         )}
         {!progearChanges && (


### PR DESCRIPTION
## Description

Creates a slider for the progear redesign. Uses 500 lb steps with a 0 lbs minimum and a maximum at their entitlement amount.

## Reviewer Notes

I wound up using some `!important` tags in the CSS to override some of the library styles for the slider. Is there a better way I could go about this?

## Setup

Make sure you throw the `?flag:progearChanges=true` flag in appended after ppm-incentive in the url.

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/tree/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/tree/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/tree/master/docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
  * [ ] Secure migrations have been tested using `scripts/run-prod-migrations`
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/169151073) for this change


## Screenshots

![progearSlider](https://user-images.githubusercontent.com/4325613/68337458-2eebd500-00a6-11ea-916d-876cd153816d.gif)

