### PR TITLE
Parse ghc international price data for tabs 3a, 3b, 3c

### DIFF
--- a/pkg/models/stage_pricing.go
+++ b/pkg/models/stage_pricing.go
@@ -36,3 +36,33 @@ type StageDomesticServiceAreaPrice struct {
 	OriginDestinationSITFirstDayWarehouse string `db:"origin_destination_sit_first_day_warehouse" csv:"origin_destination_sit_first_day_warehouse"`
 	OriginDestinationSITAddlDays          string `db:"origin_destination_sit_addl_days" csv:"origin_destination_sit_addl_days"`
 }
+
+type StageOconusToOconusPrice struct {
+	OriginIntlPriceAreaID      string `db:"origin_intl_price_area_id" csv:"origin_intl_price_area_id"`
+	OriginIntlPriceArea        string `db:"origin_intl_price_area" csv:"origin_intl_price_area"`
+	DestinationIntlPriceAreaID string `db:"destination_intl_price_area_id" csv:"destination_intl_price_area_id"`
+	DestinationIntlPriceArea   string `db:"destination_intl_price_area" csv:"destination_intl_price_area"`
+	Season                     string `db:"season" csv:"season"`
+	HHGShippingLinehaulPrice   string `db:"hhg_shipping_linehaul_price" csv:"hhg_shipping_linehaul_price"`
+	UBPrice                    string `db:"ub_price" csv:"ub_price"`
+}
+
+type StageConusToOconusPrice struct {
+	OriginDomesticPriceAreaCode string `db:"origin_domestic_price_area_code" csv:"origin_domestic_price_area_code"`
+	OriginDomesticPriceArea     string `db:"origin_domestic_price_area" csv:"origin_domestic_price_area"`
+	DestinationIntlPriceAreaID  string `db:"destination_intl_price_area_id" csv:"destination_intl_price_area_id"`
+	DestinationIntlPriceArea    string `db:"destination_intl_price_area" csv:"destination_intl_price_area"`
+	Season                      string `db:"season" csv:"season"`
+	HHGShippingLinehaulPrice    string `db:"hhg_shipping_linehaul_price" csv:"hhg_shipping_linehaul_price"`
+	UBPrice                     string `db:"ub_price" csv:"ub_price"`
+}
+
+type StageOconusToConusPrice struct {
+	OriginIntlPriceAreaID            string `db:"origin_intl_price_area_id" csv:"origin_intl_price_area_id"`
+	OriginIntlPriceArea              string `db:"origin_intl_price_area" csv:"origin_intl_price_area"`
+	DestinationDomesticPriceAreaCode string `db:"destination_domestic_price_area_area" csv:"destination_domestic_price_area_area"`
+	DestinationDomesticPriceArea     string `db:"destination_domestic_price_area" csv:"destination_domestic_price_area"`
+	Season                           string `db:"season" csv:"season"`
+	HHGShippingLinehaulPrice         string `db:"hhg_shipping_linehaul_price" csv:"hhg_shipping_linehaul_price"`
+	UBPrice                          string `db:"ub_price" csv:"ub_price"`
+}

--- a/pkg/parser/pricing/fixtures/10_3a_oconus_to_oconus_prices_golden.csv
+++ b/pkg/parser/pricing/fixtures/10_3a_oconus_to_oconus_prices_golden.csv
@@ -1,0 +1,5409 @@
+origin_intl_price_area_id,origin_intl_price_area,destination_intl_price_area_id,destination_intl_price_area,season,hhg_shipping_linehaul_price,ub_price
+AR,Argentina,AR,Argentina,NonPeak,$10.35,$16.89
+AR,Argentina,AR,Argentina,Peak,$12.21,$19.93
+AR,Argentina,AS11,New South Wales/Australian Capital Territory,NonPeak,$10.83,$11.66
+AR,Argentina,AS11,New South Wales/Australian Capital Territory,Peak,$12.78,$13.76
+AR,Argentina,AS21,Northern Territory,NonPeak,$11.35,$10.16
+AR,Argentina,AS21,Northern Territory,Peak,$13.39,$11.99
+AR,Argentina,BA,Bahrain,NonPeak,$11.82,$16.98
+AR,Argentina,BA,Bahrain,Peak,$13.95,$20.04
+AR,Argentina,BE,Belgium,NonPeak,$8.88,$11.75
+AR,Argentina,BE,Belgium,Peak,$10.48,$13.86
+AR,Argentina,BL,Bolivia,NonPeak,$9.31,$10.25
+AR,Argentina,BL,Bolivia,Peak,$10.99,$12.09
+AR,Argentina,BR,Brazil - Brazilia,NonPeak,$9.77,$17.11
+AR,Argentina,BR,Brazil - Brazilia,Peak,$11.53,$20.19
+AR,Argentina,CA10,Ontario,NonPeak,$10.21,$11.86
+AR,Argentina,CA10,Ontario,Peak,$12.05,$13.99
+AR,Argentina,CA20,Quebec,NonPeak,$10.65,$10.37
+AR,Argentina,CA20,Quebec,Peak,$12.57,$12.24
+AR,Argentina,CA30,Manitoba,NonPeak,$10.35,$17.17
+AR,Argentina,CA30,Manitoba,Peak,$12.21,$20.26
+AR,Argentina,CI,Chile,NonPeak,$10.83,$10.50
+AR,Argentina,CI,Chile,Peak,$12.78,$12.39
+AR,Argentina,CO,Colombia,NonPeak,$11.35,$17.59
+AR,Argentina,CO,Colombia,Peak,$13.39,$20.76
+AR,Argentina,CS,Costa Rica,NonPeak,$11.82,$12.03
+AR,Argentina,CS,Costa Rica,Peak,$13.95,$14.20
+AR,Argentina,EC,Ecuador,NonPeak,$8.88,$12.66
+AR,Argentina,EC,Ecuador,Peak,$10.48,$14.94
+AR,Argentina,ES,El Salvador,NonPeak,$9.31,$17.97
+AR,Argentina,ES,El Salvador,Peak,$10.99,$21.20
+AR,Argentina,GE,Germany,NonPeak,$9.77,$12.36
+AR,Argentina,GE,Germany,Peak,$11.53,$14.58
+AR,Argentina,GQ,Guam,NonPeak,$10.21,$10.91
+AR,Argentina,GQ,Guam,Peak,$12.05,$12.87
+AR,Argentina,GR,Greece,NonPeak,$10.65,$18.51
+AR,Argentina,GR,Greece,Peak,$12.57,$21.84
+AR,Argentina,GR29,Crete,NonPeak,$10.35,$12.70
+AR,Argentina,GR29,Crete,Peak,$12.21,$14.99
+AR,Argentina,GT,Guatemala,NonPeak,$10.83,$11.24
+AR,Argentina,GT,Guatemala,Peak,$12.78,$13.26
+AR,Argentina,HO,Honduras,NonPeak,$11.35,$19.00
+AR,Argentina,HO,Honduras,Peak,$13.39,$22.42
+AR,Argentina,HU,Hungary,NonPeak,$11.82,$12.99
+AR,Argentina,HU,Hungary,Peak,$13.95,$15.33
+AR,Argentina,IT,Italy,NonPeak,$8.88,$11.54
+AR,Argentina,IT,Italy,Peak,$10.48,$13.62
+AR,Argentina,IT10,Sicily,NonPeak,$9.31,$16.89
+AR,Argentina,IT10,Sicily,Peak,$10.99,$19.93
+AR,Argentina,JA01,Japan-Central,NonPeak,$9.77,$11.66
+AR,Argentina,JA01,Japan-Central,Peak,$11.53,$13.76
+AR,Argentina,JA02,Japan-South (Excludes Hokkaido),NonPeak,$10.21,$10.16
+AR,Argentina,JA02,Japan-South (Excludes Hokkaido),Peak,$12.05,$11.99
+AR,Argentina,JA03,Japan-North,NonPeak,$10.65,$16.98
+AR,Argentina,JA03,Japan-North,Peak,$12.57,$20.04
+AR,Argentina,JA96,Okinawa,NonPeak,$10.35,$11.75
+AR,Argentina,JA96,Okinawa,Peak,$12.21,$13.86
+AR,Argentina,KS,"Korea, Republic Of",NonPeak,$10.83,$10.25
+AR,Argentina,KS,"Korea, Republic Of",Peak,$12.78,$12.09
+AR,Argentina,KU,Kuwait,NonPeak,$11.35,$17.11
+AR,Argentina,KU,Kuwait,Peak,$13.39,$20.19
+AR,Argentina,NL,Netherlands,NonPeak,$11.82,$11.86
+AR,Argentina,NL,Netherlands,Peak,$13.95,$13.99
+AR,Argentina,NO,Norway,NonPeak,$8.88,$10.37
+AR,Argentina,NO,Norway,Peak,$10.48,$12.24
+AR,Argentina,PA,Paraguay,NonPeak,$9.31,$17.17
+AR,Argentina,PA,Paraguay,Peak,$10.99,$20.26
+AR,Argentina,PE,Peru,NonPeak,$9.77,$10.50
+AR,Argentina,PE,Peru,Peak,$11.53,$12.39
+AR,Argentina,PL,Poland,NonPeak,$10.21,$17.59
+AR,Argentina,PL,Poland,Peak,$12.05,$20.76
+AR,Argentina,PO,Portugal,NonPeak,$10.65,$12.03
+AR,Argentina,PO,Portugal,Peak,$12.57,$14.20
+AR,Argentina,PO01,Azores,NonPeak,$10.35,$12.66
+AR,Argentina,PO01,Azores,Peak,$12.21,$14.94
+AR,Argentina,QA,Qatar,NonPeak,$10.83,$17.97
+AR,Argentina,QA,Qatar,Peak,$12.78,$21.20
+AR,Argentina,RO,Romania,NonPeak,$11.35,$12.36
+AR,Argentina,RO,Romania,Peak,$13.39,$14.58
+AR,Argentina,RQ,Puerto Rico,NonPeak,$11.82,$10.91
+AR,Argentina,RQ,Puerto Rico,Peak,$13.95,$12.87
+AR,Argentina,SA,Saudi Arabia,NonPeak,$8.88,$18.51
+AR,Argentina,SA,Saudi Arabia,Peak,$10.48,$21.84
+AR,Argentina,SN,Singapore,NonPeak,$9.31,$12.70
+AR,Argentina,SN,Singapore,Peak,$10.99,$14.99
+AR,Argentina,SP,Spain,NonPeak,$9.77,$11.24
+AR,Argentina,SP,Spain,Peak,$11.53,$13.26
+AR,Argentina,TU,Turkey,NonPeak,$10.21,$19.00
+AR,Argentina,TU,Turkey,Peak,$12.05,$22.42
+AR,Argentina,UK,United Kingdom,NonPeak,$10.65,$12.99
+AR,Argentina,UK,United Kingdom,Peak,$12.57,$15.33
+AR,Argentina,US8030400,Alaska (Zone) IV,NonPeak,$10.35,$11.54
+AR,Argentina,US8030400,Alaska (Zone) IV,Peak,$12.21,$13.62
+AR,Argentina,US8050500,Alaska (Zone) III,NonPeak,$10.83,$16.89
+AR,Argentina,US8050500,Alaska (Zone) III,Peak,$12.78,$19.93
+AR,Argentina,US8101000,Alaska (Zone) I,NonPeak,$11.35,$11.66
+AR,Argentina,US8101000,Alaska (Zone) I,Peak,$13.39,$13.76
+AR,Argentina,US8190100,Alaska (Zone) II,NonPeak,$11.82,$10.16
+AR,Argentina,US8190100,Alaska (Zone) II,Peak,$13.95,$11.99
+AR,Argentina,US89,Hawaii,NonPeak,$8.88,$16.98
+AR,Argentina,US89,Hawaii,Peak,$10.48,$20.04
+AR,Argentina,UY,Uruguay,NonPeak,$9.31,$11.75
+AR,Argentina,UY,Uruguay,Peak,$10.99,$13.86
+AR,Argentina,VE,Venezuela,NonPeak,$9.77,$10.25
+AR,Argentina,VE,Venezuela,Peak,$11.53,$12.09
+AS11,New South Wales/Australian Capital Territory,AR,Argentina,NonPeak,$10.21,$17.11
+AS11,New South Wales/Australian Capital Territory,AR,Argentina,Peak,$12.05,$20.19
+AS11,New South Wales/Australian Capital Territory,AS11,New South Wales/Australian Capital Territory,NonPeak,$10.65,$11.86
+AS11,New South Wales/Australian Capital Territory,AS11,New South Wales/Australian Capital Territory,Peak,$12.57,$13.99
+AS11,New South Wales/Australian Capital Territory,AS21,Northern Territory,NonPeak,$10.35,$10.37
+AS11,New South Wales/Australian Capital Territory,AS21,Northern Territory,Peak,$12.21,$12.24
+AS11,New South Wales/Australian Capital Territory,BA,Bahrain,NonPeak,$10.83,$17.17
+AS11,New South Wales/Australian Capital Territory,BA,Bahrain,Peak,$12.78,$20.26
+AS11,New South Wales/Australian Capital Territory,BE,Belgium,NonPeak,$11.35,$10.50
+AS11,New South Wales/Australian Capital Territory,BE,Belgium,Peak,$13.39,$12.39
+AS11,New South Wales/Australian Capital Territory,BL,Bolivia,NonPeak,$11.82,$17.59
+AS11,New South Wales/Australian Capital Territory,BL,Bolivia,Peak,$13.95,$20.76
+AS11,New South Wales/Australian Capital Territory,BR,Brazil - Brazilia,NonPeak,$8.88,$12.03
+AS11,New South Wales/Australian Capital Territory,BR,Brazil - Brazilia,Peak,$10.48,$14.20
+AS11,New South Wales/Australian Capital Territory,CA10,Ontario,NonPeak,$9.31,$12.66
+AS11,New South Wales/Australian Capital Territory,CA10,Ontario,Peak,$10.99,$14.94
+AS11,New South Wales/Australian Capital Territory,CA20,Quebec,NonPeak,$9.77,$17.97
+AS11,New South Wales/Australian Capital Territory,CA20,Quebec,Peak,$11.53,$21.20
+AS11,New South Wales/Australian Capital Territory,CA30,Manitoba,NonPeak,$10.21,$12.36
+AS11,New South Wales/Australian Capital Territory,CA30,Manitoba,Peak,$12.05,$14.58
+AS11,New South Wales/Australian Capital Territory,CI,Chile,NonPeak,$10.65,$10.91
+AS11,New South Wales/Australian Capital Territory,CI,Chile,Peak,$12.57,$12.87
+AS11,New South Wales/Australian Capital Territory,CO,Colombia,NonPeak,$10.35,$18.51
+AS11,New South Wales/Australian Capital Territory,CO,Colombia,Peak,$12.21,$21.84
+AS11,New South Wales/Australian Capital Territory,CS,Costa Rica,NonPeak,$10.83,$12.70
+AS11,New South Wales/Australian Capital Territory,CS,Costa Rica,Peak,$12.78,$14.99
+AS11,New South Wales/Australian Capital Territory,EC,Ecuador,NonPeak,$11.35,$11.24
+AS11,New South Wales/Australian Capital Territory,EC,Ecuador,Peak,$13.39,$13.26
+AS11,New South Wales/Australian Capital Territory,ES,El Salvador,NonPeak,$11.82,$19.00
+AS11,New South Wales/Australian Capital Territory,ES,El Salvador,Peak,$13.95,$22.42
+AS11,New South Wales/Australian Capital Territory,GE,Germany,NonPeak,$8.88,$12.99
+AS11,New South Wales/Australian Capital Territory,GE,Germany,Peak,$10.48,$15.33
+AS11,New South Wales/Australian Capital Territory,GQ,Guam,NonPeak,$9.31,$11.54
+AS11,New South Wales/Australian Capital Territory,GQ,Guam,Peak,$10.99,$13.62
+AS11,New South Wales/Australian Capital Territory,GR,Greece,NonPeak,$9.77,$16.89
+AS11,New South Wales/Australian Capital Territory,GR,Greece,Peak,$11.53,$19.93
+AS11,New South Wales/Australian Capital Territory,GR29,Crete,NonPeak,$10.21,$11.66
+AS11,New South Wales/Australian Capital Territory,GR29,Crete,Peak,$12.05,$13.76
+AS11,New South Wales/Australian Capital Territory,GT,Guatemala,NonPeak,$10.65,$10.16
+AS11,New South Wales/Australian Capital Territory,GT,Guatemala,Peak,$12.57,$11.99
+AS11,New South Wales/Australian Capital Territory,HO,Honduras,NonPeak,$10.35,$16.98
+AS11,New South Wales/Australian Capital Territory,HO,Honduras,Peak,$12.21,$20.04
+AS11,New South Wales/Australian Capital Territory,HU,Hungary,NonPeak,$10.83,$11.75
+AS11,New South Wales/Australian Capital Territory,HU,Hungary,Peak,$12.78,$13.86
+AS11,New South Wales/Australian Capital Territory,IT,Italy,NonPeak,$11.35,$10.25
+AS11,New South Wales/Australian Capital Territory,IT,Italy,Peak,$13.39,$12.09
+AS11,New South Wales/Australian Capital Territory,IT10,Sicily,NonPeak,$11.82,$17.11
+AS11,New South Wales/Australian Capital Territory,IT10,Sicily,Peak,$13.95,$20.19
+AS11,New South Wales/Australian Capital Territory,JA01,Japan-Central,NonPeak,$8.88,$11.86
+AS11,New South Wales/Australian Capital Territory,JA01,Japan-Central,Peak,$10.48,$13.99
+AS11,New South Wales/Australian Capital Territory,JA02,Japan-South (Excludes Hokkaido),NonPeak,$9.31,$10.37
+AS11,New South Wales/Australian Capital Territory,JA02,Japan-South (Excludes Hokkaido),Peak,$10.99,$12.24
+AS11,New South Wales/Australian Capital Territory,JA03,Japan-North,NonPeak,$9.77,$17.17
+AS11,New South Wales/Australian Capital Territory,JA03,Japan-North,Peak,$11.53,$20.26
+AS11,New South Wales/Australian Capital Territory,JA96,Okinawa,NonPeak,$10.21,$10.50
+AS11,New South Wales/Australian Capital Territory,JA96,Okinawa,Peak,$12.05,$12.39
+AS11,New South Wales/Australian Capital Territory,KS,"Korea, Republic Of",NonPeak,$10.65,$17.59
+AS11,New South Wales/Australian Capital Territory,KS,"Korea, Republic Of",Peak,$12.57,$20.76
+AS11,New South Wales/Australian Capital Territory,KU,Kuwait,NonPeak,$10.35,$12.03
+AS11,New South Wales/Australian Capital Territory,KU,Kuwait,Peak,$12.21,$14.20
+AS11,New South Wales/Australian Capital Territory,NL,Netherlands,NonPeak,$10.83,$12.66
+AS11,New South Wales/Australian Capital Territory,NL,Netherlands,Peak,$12.78,$14.94
+AS11,New South Wales/Australian Capital Territory,NO,Norway,NonPeak,$11.35,$17.97
+AS11,New South Wales/Australian Capital Territory,NO,Norway,Peak,$13.39,$21.20
+AS11,New South Wales/Australian Capital Territory,PA,Paraguay,NonPeak,$11.82,$12.36
+AS11,New South Wales/Australian Capital Territory,PA,Paraguay,Peak,$13.95,$14.58
+AS11,New South Wales/Australian Capital Territory,PE,Peru,NonPeak,$8.88,$10.91
+AS11,New South Wales/Australian Capital Territory,PE,Peru,Peak,$10.48,$12.87
+AS11,New South Wales/Australian Capital Territory,PL,Poland,NonPeak,$9.31,$18.51
+AS11,New South Wales/Australian Capital Territory,PL,Poland,Peak,$10.99,$21.84
+AS11,New South Wales/Australian Capital Territory,PO,Portugal,NonPeak,$9.77,$12.70
+AS11,New South Wales/Australian Capital Territory,PO,Portugal,Peak,$11.53,$14.99
+AS11,New South Wales/Australian Capital Territory,PO01,Azores,NonPeak,$10.21,$11.24
+AS11,New South Wales/Australian Capital Territory,PO01,Azores,Peak,$12.05,$13.26
+AS11,New South Wales/Australian Capital Territory,QA,Qatar,NonPeak,$10.65,$19.00
+AS11,New South Wales/Australian Capital Territory,QA,Qatar,Peak,$12.57,$22.42
+AS11,New South Wales/Australian Capital Territory,RO,Romania,NonPeak,$10.35,$12.99
+AS11,New South Wales/Australian Capital Territory,RO,Romania,Peak,$12.21,$15.33
+AS11,New South Wales/Australian Capital Territory,RQ,Puerto Rico,NonPeak,$10.83,$11.54
+AS11,New South Wales/Australian Capital Territory,RQ,Puerto Rico,Peak,$12.78,$13.62
+AS11,New South Wales/Australian Capital Territory,SA,Saudi Arabia,NonPeak,$11.35,$16.89
+AS11,New South Wales/Australian Capital Territory,SA,Saudi Arabia,Peak,$13.39,$19.93
+AS11,New South Wales/Australian Capital Territory,SN,Singapore,NonPeak,$11.82,$11.66
+AS11,New South Wales/Australian Capital Territory,SN,Singapore,Peak,$13.95,$13.76
+AS11,New South Wales/Australian Capital Territory,SP,Spain,NonPeak,$8.88,$10.16
+AS11,New South Wales/Australian Capital Territory,SP,Spain,Peak,$10.48,$11.99
+AS11,New South Wales/Australian Capital Territory,TU,Turkey,NonPeak,$9.31,$16.98
+AS11,New South Wales/Australian Capital Territory,TU,Turkey,Peak,$10.99,$20.04
+AS11,New South Wales/Australian Capital Territory,UK,United Kingdom,NonPeak,$9.77,$11.75
+AS11,New South Wales/Australian Capital Territory,UK,United Kingdom,Peak,$11.53,$13.86
+AS11,New South Wales/Australian Capital Territory,US8030400,Alaska (Zone) IV,NonPeak,$10.21,$10.25
+AS11,New South Wales/Australian Capital Territory,US8030400,Alaska (Zone) IV,Peak,$12.05,$12.09
+AS11,New South Wales/Australian Capital Territory,US8050500,Alaska (Zone) III,NonPeak,$10.65,$17.11
+AS11,New South Wales/Australian Capital Territory,US8050500,Alaska (Zone) III,Peak,$12.57,$20.19
+AS11,New South Wales/Australian Capital Territory,US8101000,Alaska (Zone) I,NonPeak,$10.35,$11.86
+AS11,New South Wales/Australian Capital Territory,US8101000,Alaska (Zone) I,Peak,$12.21,$13.99
+AS11,New South Wales/Australian Capital Territory,US8190100,Alaska (Zone) II,NonPeak,$10.83,$10.37
+AS11,New South Wales/Australian Capital Territory,US8190100,Alaska (Zone) II,Peak,$12.78,$12.24
+AS11,New South Wales/Australian Capital Territory,US89,Hawaii,NonPeak,$11.35,$17.17
+AS11,New South Wales/Australian Capital Territory,US89,Hawaii,Peak,$13.39,$20.26
+AS11,New South Wales/Australian Capital Territory,UY,Uruguay,NonPeak,$11.82,$10.50
+AS11,New South Wales/Australian Capital Territory,UY,Uruguay,Peak,$13.95,$12.39
+AS11,New South Wales/Australian Capital Territory,VE,Venezuela,NonPeak,$8.88,$17.59
+AS11,New South Wales/Australian Capital Territory,VE,Venezuela,Peak,$10.48,$20.76
+AS21,Northern Territory,AR,Argentina,NonPeak,$9.31,$12.03
+AS21,Northern Territory,AR,Argentina,Peak,$10.99,$14.20
+AS21,Northern Territory,AS11,New South Wales/Australian Capital Territory,NonPeak,$9.77,$12.66
+AS21,Northern Territory,AS11,New South Wales/Australian Capital Territory,Peak,$11.53,$14.94
+AS21,Northern Territory,AS21,Northern Territory,NonPeak,$10.21,$17.97
+AS21,Northern Territory,AS21,Northern Territory,Peak,$12.05,$21.20
+AS21,Northern Territory,BA,Bahrain,NonPeak,$10.65,$12.36
+AS21,Northern Territory,BA,Bahrain,Peak,$12.57,$14.58
+AS21,Northern Territory,BE,BELGIUM,NonPeak,$10.35,$10.91
+AS21,Northern Territory,BE,BELGIUM,Peak,$12.21,$12.87
+AS21,Northern Territory,BL,Bolivia,NonPeak,$10.83,$18.51
+AS21,Northern Territory,BL,Bolivia,Peak,$12.78,$21.84
+AS21,Northern Territory,BR,Brazil - Brazilia,NonPeak,$11.35,$12.70
+AS21,Northern Territory,BR,Brazil - Brazilia,Peak,$13.39,$14.99
+AS21,Northern Territory,CA10,Ontario,NonPeak,$11.82,$11.24
+AS21,Northern Territory,CA10,Ontario,Peak,$13.95,$13.26
+AS21,Northern Territory,CA20,Quebec,NonPeak,$8.88,$19.00
+AS21,Northern Territory,CA20,Quebec,Peak,$10.48,$22.42
+AS21,Northern Territory,CA30,Manitoba,NonPeak,$9.31,$12.99
+AS21,Northern Territory,CA30,Manitoba,Peak,$10.99,$15.33
+AS21,Northern Territory,CI,Chile,NonPeak,$9.77,$11.54
+AS21,Northern Territory,CI,Chile,Peak,$11.53,$13.62
+AS21,Northern Territory,CO,Colombia,NonPeak,$10.21,$16.89
+AS21,Northern Territory,CO,Colombia,Peak,$12.05,$19.93
+AS21,Northern Territory,CS,Costa Rica,NonPeak,$10.65,$11.66
+AS21,Northern Territory,CS,Costa Rica,Peak,$12.57,$13.76
+AS21,Northern Territory,EC,Ecuador,NonPeak,$10.35,$10.16
+AS21,Northern Territory,EC,Ecuador,Peak,$12.21,$11.99
+AS21,Northern Territory,ES,El Salvador,NonPeak,$10.83,$16.98
+AS21,Northern Territory,ES,El Salvador,Peak,$12.78,$20.04
+AS21,Northern Territory,GE,GERMANY,NonPeak,$11.35,$11.75
+AS21,Northern Territory,GE,GERMANY,Peak,$13.39,$13.86
+AS21,Northern Territory,GQ,GUAM,NonPeak,$11.82,$10.25
+AS21,Northern Territory,GQ,GUAM,Peak,$13.95,$12.09
+AS21,Northern Territory,GR,Greece,NonPeak,$8.88,$17.11
+AS21,Northern Territory,GR,Greece,Peak,$10.48,$20.19
+AS21,Northern Territory,GR29,Crete,NonPeak,$9.31,$11.86
+AS21,Northern Territory,GR29,Crete,Peak,$10.99,$13.99
+AS21,Northern Territory,GT,Guatemala,NonPeak,$9.77,$10.37
+AS21,Northern Territory,GT,Guatemala,Peak,$11.53,$12.24
+AS21,Northern Territory,HO,Honduras,NonPeak,$10.21,$17.17
+AS21,Northern Territory,HO,Honduras,Peak,$12.05,$20.26
+AS21,Northern Territory,HU,Hungary,NonPeak,$10.65,$10.50
+AS21,Northern Territory,HU,Hungary,Peak,$12.57,$12.39
+AS21,Northern Territory,IT,Italy,NonPeak,$10.35,$17.59
+AS21,Northern Territory,IT,Italy,Peak,$12.21,$20.76
+AS21,Northern Territory,IT10,Sicily,NonPeak,$10.83,$12.03
+AS21,Northern Territory,IT10,Sicily,Peak,$12.78,$14.20
+AS21,Northern Territory,JA01,JAPAN-CENTRAL,NonPeak,$11.35,$12.66
+AS21,Northern Territory,JA01,JAPAN-CENTRAL,Peak,$13.39,$14.94
+AS21,Northern Territory,JA02,JAPAN-SOUTH (EXCLUDES HOKKAIDO),NonPeak,$11.82,$17.97
+AS21,Northern Territory,JA02,JAPAN-SOUTH (EXCLUDES HOKKAIDO),Peak,$13.95,$21.20
+AS21,Northern Territory,JA03,JAPAN-NORTH,NonPeak,$8.88,$12.36
+AS21,Northern Territory,JA03,JAPAN-NORTH,Peak,$10.48,$14.58
+AS21,Northern Territory,JA96,OKINAWA,NonPeak,$9.31,$10.91
+AS21,Northern Territory,JA96,OKINAWA,Peak,$10.99,$12.87
+AS21,Northern Territory,KS,"KOREA, REPUBLIC OF",NonPeak,$9.77,$18.51
+AS21,Northern Territory,KS,"KOREA, REPUBLIC OF",Peak,$11.53,$21.84
+AS21,Northern Territory,KU,Kuwait,NonPeak,$10.21,$12.70
+AS21,Northern Territory,KU,Kuwait,Peak,$12.05,$14.99
+AS21,Northern Territory,NL,Netherlands,NonPeak,$10.65,$11.24
+AS21,Northern Territory,NL,Netherlands,Peak,$12.57,$13.26
+AS21,Northern Territory,NO,Norway,NonPeak,$10.35,$19.00
+AS21,Northern Territory,NO,Norway,Peak,$12.21,$22.42
+AS21,Northern Territory,PA,Paraguay,NonPeak,$10.83,$12.99
+AS21,Northern Territory,PA,Paraguay,Peak,$12.78,$15.33
+AS21,Northern Territory,PE,Peru,NonPeak,$11.35,$11.54
+AS21,Northern Territory,PE,Peru,Peak,$13.39,$13.62
+AS21,Northern Territory,PL,Poland,NonPeak,$11.82,$16.89
+AS21,Northern Territory,PL,Poland,Peak,$13.95,$19.93
+AS21,Northern Territory,PO,Portugal,NonPeak,$8.88,$11.66
+AS21,Northern Territory,PO,Portugal,Peak,$10.48,$13.76
+AS21,Northern Territory,PO01,Azores,NonPeak,$9.31,$10.16
+AS21,Northern Territory,PO01,Azores,Peak,$10.99,$11.99
+AS21,Northern Territory,QA,Qatar,NonPeak,$9.77,$16.98
+AS21,Northern Territory,QA,Qatar,Peak,$11.53,$20.04
+AS21,Northern Territory,RO,Romania,NonPeak,$10.21,$11.75
+AS21,Northern Territory,RO,Romania,Peak,$12.05,$13.86
+AS21,Northern Territory,RQ,Puerto Rico,NonPeak,$10.65,$10.25
+AS21,Northern Territory,RQ,Puerto Rico,Peak,$12.57,$12.09
+AS21,Northern Territory,SA,Saudi Arabia,NonPeak,$10.35,$17.11
+AS21,Northern Territory,SA,Saudi Arabia,Peak,$12.21,$20.19
+AS21,Northern Territory,SN,Singapore,NonPeak,$10.83,$11.86
+AS21,Northern Territory,SN,Singapore,Peak,$12.78,$13.99
+AS21,Northern Territory,SP,SPAIN,NonPeak,$11.35,$10.37
+AS21,Northern Territory,SP,SPAIN,Peak,$13.39,$12.24
+AS21,Northern Territory,TU,TURKEY,NonPeak,$11.82,$17.17
+AS21,Northern Territory,TU,TURKEY,Peak,$13.95,$20.26
+AS21,Northern Territory,UK,UNITED KINGDOM,NonPeak,$8.88,$10.50
+AS21,Northern Territory,UK,UNITED KINGDOM,Peak,$10.48,$12.39
+AS21,Northern Territory,US8030400,Alaska (Zone) IV,NonPeak,$9.31,$17.59
+AS21,Northern Territory,US8030400,Alaska (Zone) IV,Peak,$10.99,$20.76
+AS21,Northern Territory,US8050500,Alaska (Zone) III,NonPeak,$9.77,$12.03
+AS21,Northern Territory,US8050500,Alaska (Zone) III,Peak,$11.53,$14.20
+AS21,Northern Territory,US8101000,Alaska (Zone) I,NonPeak,$10.21,$12.66
+AS21,Northern Territory,US8101000,Alaska (Zone) I,Peak,$12.05,$14.94
+AS21,Northern Territory,US8190100,Alaska (Zone) II,NonPeak,$10.65,$17.97
+AS21,Northern Territory,US8190100,Alaska (Zone) II,Peak,$12.57,$21.20
+AS21,Northern Territory,US89,Hawaii,NonPeak,$10.35,$12.36
+AS21,Northern Territory,US89,Hawaii,Peak,$12.21,$14.58
+AS21,Northern Territory,UY,Uruguay,NonPeak,$10.83,$10.91
+AS21,Northern Territory,UY,Uruguay,Peak,$12.78,$12.87
+AS21,Northern Territory,VE,Venezuela,NonPeak,$11.35,$18.51
+AS21,Northern Territory,VE,Venezuela,Peak,$13.39,$21.84
+BA,Bahrain,AR,Argentina,NonPeak,$11.82,$12.70
+BA,Bahrain,AR,Argentina,Peak,$13.95,$14.99
+BA,Bahrain,AS11,New South Wales/Australian Capital Territory,NonPeak,$8.88,$11.24
+BA,Bahrain,AS11,New South Wales/Australian Capital Territory,Peak,$10.48,$13.26
+BA,Bahrain,AS21,Northern Territory,NonPeak,$9.31,$19.00
+BA,Bahrain,AS21,Northern Territory,Peak,$10.99,$22.42
+BA,Bahrain,BA,Bahrain,NonPeak,$9.77,$12.99
+BA,Bahrain,BA,Bahrain,Peak,$11.53,$15.33
+BA,Bahrain,BE,Belgium,NonPeak,$10.21,$11.54
+BA,Bahrain,BE,Belgium,Peak,$12.05,$13.62
+BA,Bahrain,BL,Bolivia,NonPeak,$10.65,$16.89
+BA,Bahrain,BL,Bolivia,Peak,$12.57,$19.93
+BA,Bahrain,BR,Brazil - Brazilia,NonPeak,$10.35,$11.66
+BA,Bahrain,BR,Brazil - Brazilia,Peak,$12.21,$13.76
+BA,Bahrain,CA10,Ontario,NonPeak,$10.83,$10.16
+BA,Bahrain,CA10,Ontario,Peak,$12.78,$11.99
+BA,Bahrain,CA20,Quebec,NonPeak,$11.35,$16.98
+BA,Bahrain,CA20,Quebec,Peak,$13.39,$20.04
+BA,Bahrain,CA30,Manitoba,NonPeak,$11.82,$11.75
+BA,Bahrain,CA30,Manitoba,Peak,$13.95,$13.86
+BA,Bahrain,CI,Chile,NonPeak,$8.88,$10.25
+BA,Bahrain,CI,Chile,Peak,$10.48,$12.09
+BA,Bahrain,CO,Colombia,NonPeak,$9.31,$17.11
+BA,Bahrain,CO,Colombia,Peak,$10.99,$20.19
+BA,Bahrain,CS,Costa Rica,NonPeak,$9.77,$11.86
+BA,Bahrain,CS,Costa Rica,Peak,$11.53,$13.99
+BA,Bahrain,EC,Ecuador,NonPeak,$10.21,$10.37
+BA,Bahrain,EC,Ecuador,Peak,$12.05,$12.24
+BA,Bahrain,ES,El Salvador,NonPeak,$10.65,$17.17
+BA,Bahrain,ES,El Salvador,Peak,$12.57,$20.26
+BA,Bahrain,GE,Germany,NonPeak,$10.35,$10.50
+BA,Bahrain,GE,Germany,Peak,$12.21,$12.39
+BA,Bahrain,GQ,GUAM,NonPeak,$10.83,$17.59
+BA,Bahrain,GQ,GUAM,Peak,$12.78,$20.76
+BA,Bahrain,GR,Greece,NonPeak,$11.35,$12.03
+BA,Bahrain,GR,Greece,Peak,$13.39,$14.20
+BA,Bahrain,GR29,Crete,NonPeak,$11.82,$12.66
+BA,Bahrain,GR29,Crete,Peak,$13.95,$14.94
+BA,Bahrain,GT,Guatemala,NonPeak,$8.88,$17.97
+BA,Bahrain,GT,Guatemala,Peak,$10.48,$21.20
+BA,Bahrain,HO,Honduras,NonPeak,$9.31,$12.36
+BA,Bahrain,HO,Honduras,Peak,$10.99,$14.58
+BA,Bahrain,HU,Hungary,NonPeak,$9.77,$10.91
+BA,Bahrain,HU,Hungary,Peak,$11.53,$12.87
+BA,Bahrain,IT,ITALY,NonPeak,$10.21,$18.51
+BA,Bahrain,IT,ITALY,Peak,$12.05,$21.84
+BA,Bahrain,IT10,Sicily,NonPeak,$10.65,$12.70
+BA,Bahrain,IT10,Sicily,Peak,$12.57,$14.99
+BA,Bahrain,JA01,JAPAN-CENTRAL,NonPeak,$10.35,$11.24
+BA,Bahrain,JA01,JAPAN-CENTRAL,Peak,$12.21,$13.26
+BA,Bahrain,JA02,JAPAN-SOUTH (EXCLUDES HOKKAIDO),NonPeak,$10.83,$19.00
+BA,Bahrain,JA02,JAPAN-SOUTH (EXCLUDES HOKKAIDO),Peak,$12.78,$22.42
+BA,Bahrain,JA03,Japan-North,NonPeak,$11.35,$12.99
+BA,Bahrain,JA03,Japan-North,Peak,$13.39,$15.33
+BA,Bahrain,JA96,OKINAWA,NonPeak,$11.82,$11.54
+BA,Bahrain,JA96,OKINAWA,Peak,$13.95,$13.62
+BA,Bahrain,KS,"Korea, Republic Of",NonPeak,$8.88,$16.89
+BA,Bahrain,KS,"Korea, Republic Of",Peak,$10.48,$19.93
+BA,Bahrain,KU,Kuwait,NonPeak,$9.31,$11.66
+BA,Bahrain,KU,Kuwait,Peak,$10.99,$13.76
+BA,Bahrain,NL,Netherlands,NonPeak,$9.77,$10.16
+BA,Bahrain,NL,Netherlands,Peak,$11.53,$11.99
+BA,Bahrain,NO,Norway,NonPeak,$10.21,$16.98
+BA,Bahrain,NO,Norway,Peak,$12.05,$20.04
+BA,Bahrain,PA,Paraguay,NonPeak,$10.65,$11.75
+BA,Bahrain,PA,Paraguay,Peak,$12.57,$13.86
+BA,Bahrain,PE,Peru,NonPeak,$10.35,$10.25
+BA,Bahrain,PE,Peru,Peak,$12.21,$12.09
+BA,Bahrain,PL,Poland,NonPeak,$10.83,$17.11
+BA,Bahrain,PL,Poland,Peak,$12.78,$20.19
+BA,Bahrain,PO,Portugal,NonPeak,$11.35,$11.86
+BA,Bahrain,PO,Portugal,Peak,$13.39,$13.99
+BA,Bahrain,PO01,Azores,NonPeak,$11.82,$10.37
+BA,Bahrain,PO01,Azores,Peak,$13.95,$12.24
+BA,Bahrain,QA,Qatar,NonPeak,$8.88,$17.17
+BA,Bahrain,QA,Qatar,Peak,$10.48,$20.26
+BA,Bahrain,RO,Romania,NonPeak,$9.31,$10.50
+BA,Bahrain,RO,Romania,Peak,$10.99,$12.39
+BA,Bahrain,RQ,Puerto Rico,NonPeak,$9.77,$17.59
+BA,Bahrain,RQ,Puerto Rico,Peak,$11.53,$20.76
+BA,Bahrain,SA,Saudi Arabia,NonPeak,$10.21,$12.03
+BA,Bahrain,SA,Saudi Arabia,Peak,$12.05,$14.20
+BA,Bahrain,SN,Singapore,NonPeak,$10.65,$12.66
+BA,Bahrain,SN,Singapore,Peak,$12.57,$14.94
+BA,Bahrain,SP,Spain,NonPeak,$10.35,$17.97
+BA,Bahrain,SP,Spain,Peak,$12.21,$21.20
+BA,Bahrain,TU,Turkey,NonPeak,$10.83,$12.36
+BA,Bahrain,TU,Turkey,Peak,$12.78,$14.58
+BA,Bahrain,UK,United Kingdom,NonPeak,$11.35,$10.91
+BA,Bahrain,UK,United Kingdom,Peak,$13.39,$12.87
+BA,Bahrain,US8030400,Alaska (Zone) IV,NonPeak,$11.82,$18.51
+BA,Bahrain,US8030400,Alaska (Zone) IV,Peak,$13.95,$21.84
+BA,Bahrain,US8050500,Alaska (Zone) III,NonPeak,$8.88,$12.70
+BA,Bahrain,US8050500,Alaska (Zone) III,Peak,$10.48,$14.99
+BA,Bahrain,US8101000,Alaska (Zone) I,NonPeak,$9.31,$11.24
+BA,Bahrain,US8101000,Alaska (Zone) I,Peak,$10.99,$13.26
+BA,Bahrain,US8190100,Alaska (Zone) II,NonPeak,$9.77,$19.00
+BA,Bahrain,US8190100,Alaska (Zone) II,Peak,$11.53,$22.42
+BA,Bahrain,US89,Hawaii,NonPeak,$10.21,$12.99
+BA,Bahrain,US89,Hawaii,Peak,$12.05,$15.33
+BA,Bahrain,UY,Uruguay,NonPeak,$10.65,$11.54
+BA,Bahrain,UY,Uruguay,Peak,$12.57,$13.62
+BA,Bahrain,VE,Venezuela,NonPeak,$10.35,$16.89
+BA,Bahrain,VE,Venezuela,Peak,$12.21,$19.93
+BE,Belgium,AR,Argentina,NonPeak,$10.83,$11.66
+BE,Belgium,AR,Argentina,Peak,$12.78,$13.76
+BE,Belgium,AS11,NEW SOUTH WALES/AUSTRALIAN CAPITAL TERRITORY,NonPeak,$11.35,$10.16
+BE,Belgium,AS11,NEW SOUTH WALES/AUSTRALIAN CAPITAL TERRITORY,Peak,$13.39,$11.99
+BE,Belgium,AS21,NORTHERN TERRITORY,NonPeak,$11.82,$16.98
+BE,Belgium,AS21,NORTHERN TERRITORY,Peak,$13.95,$20.04
+BE,Belgium,BA,Bahrain,NonPeak,$8.88,$11.75
+BE,Belgium,BA,Bahrain,Peak,$10.48,$13.86
+BE,Belgium,BE,BELGIUM,NonPeak,$9.31,$10.25
+BE,Belgium,BE,BELGIUM,Peak,$10.99,$12.09
+BE,Belgium,BL,Bolivia,NonPeak,$9.77,$17.11
+BE,Belgium,BL,Bolivia,Peak,$11.53,$20.19
+BE,Belgium,BR,Brazil - Brazilia,NonPeak,$10.21,$11.86
+BE,Belgium,BR,Brazil - Brazilia,Peak,$12.05,$13.99
+BE,Belgium,CA10,Ontario,NonPeak,$10.65,$10.37
+BE,Belgium,CA10,Ontario,Peak,$12.57,$12.24
+BE,Belgium,CA20,Quebec,NonPeak,$10.35,$17.17
+BE,Belgium,CA20,Quebec,Peak,$12.21,$20.26
+BE,Belgium,CA30,Manitoba,NonPeak,$10.83,$10.50
+BE,Belgium,CA30,Manitoba,Peak,$12.78,$12.39
+BE,Belgium,CI,Chile,NonPeak,$11.35,$17.59
+BE,Belgium,CI,Chile,Peak,$13.39,$20.76
+BE,Belgium,CO,Colombia,NonPeak,$11.82,$12.03
+BE,Belgium,CO,Colombia,Peak,$13.95,$14.20
+BE,Belgium,CS,Costa Rica,NonPeak,$8.88,$12.66
+BE,Belgium,CS,Costa Rica,Peak,$10.48,$14.94
+BE,Belgium,EC,Ecuador,NonPeak,$9.31,$17.97
+BE,Belgium,EC,Ecuador,Peak,$10.99,$21.20
+BE,Belgium,ES,El Salvador,NonPeak,$9.77,$12.36
+BE,Belgium,ES,El Salvador,Peak,$11.53,$14.58
+BE,Belgium,GE,GERMANY,NonPeak,$10.21,$10.91
+BE,Belgium,GE,GERMANY,Peak,$12.05,$12.87
+BE,Belgium,GQ,GUAM,NonPeak,$10.65,$18.51
+BE,Belgium,GQ,GUAM,Peak,$12.57,$21.84
+BE,Belgium,GR,GREECE,NonPeak,$10.35,$12.70
+BE,Belgium,GR,GREECE,Peak,$12.21,$14.99
+BE,Belgium,GR29,CRETE,NonPeak,$10.83,$11.24
+BE,Belgium,GR29,CRETE,Peak,$12.78,$13.26
+BE,Belgium,GT,Guatemala,NonPeak,$11.35,$19.00
+BE,Belgium,GT,Guatemala,Peak,$13.39,$22.42
+BE,Belgium,HO,Honduras,NonPeak,$11.82,$12.99
+BE,Belgium,HO,Honduras,Peak,$13.95,$15.33
+BE,Belgium,HU,Hungary,NonPeak,$8.88,$11.54
+BE,Belgium,HU,Hungary,Peak,$10.48,$13.62
+BE,Belgium,IT,ITALY,NonPeak,$9.31,$16.89
+BE,Belgium,IT,ITALY,Peak,$10.99,$19.93
+BE,Belgium,IT10,SICILY,NonPeak,$9.77,$11.66
+BE,Belgium,IT10,SICILY,Peak,$11.53,$13.76
+BE,Belgium,JA01,JAPAN-CENTRAL,NonPeak,$10.21,$10.16
+BE,Belgium,JA01,JAPAN-CENTRAL,Peak,$12.05,$11.99
+BE,Belgium,JA02,JAPAN-SOUTH (EXCLUDES HOKKAIDO),NonPeak,$10.65,$16.98
+BE,Belgium,JA02,JAPAN-SOUTH (EXCLUDES HOKKAIDO),Peak,$12.57,$20.04
+BE,Belgium,JA03,JAPAN-NORTH,NonPeak,$10.35,$11.75
+BE,Belgium,JA03,JAPAN-NORTH,Peak,$12.21,$13.86
+BE,Belgium,JA96,OKINAWA,NonPeak,$10.83,$10.25
+BE,Belgium,JA96,OKINAWA,Peak,$12.78,$12.09
+BE,Belgium,KS,"KOREA, REPUBLIC OF",NonPeak,$11.35,$17.11
+BE,Belgium,KS,"KOREA, REPUBLIC OF",Peak,$13.39,$20.19
+BE,Belgium,KU,Kuwait,NonPeak,$11.82,$11.86
+BE,Belgium,KU,Kuwait,Peak,$13.95,$13.99
+BE,Belgium,NL,NETHERLANDS,NonPeak,$8.88,$10.37
+BE,Belgium,NL,NETHERLANDS,Peak,$10.48,$12.24
+BE,Belgium,NO,Norway,NonPeak,$9.31,$17.17
+BE,Belgium,NO,Norway,Peak,$10.99,$20.26
+BE,Belgium,PA,Paraguay,NonPeak,$9.77,$10.50
+BE,Belgium,PA,Paraguay,Peak,$11.53,$12.39
+BE,Belgium,PE,Peru,NonPeak,$10.21,$17.59
+BE,Belgium,PE,Peru,Peak,$12.05,$20.76
+BE,Belgium,PL,Poland,NonPeak,$10.65,$12.03
+BE,Belgium,PL,Poland,Peak,$12.57,$14.20
+BE,Belgium,PO,PORTUGAL,NonPeak,$10.35,$12.66
+BE,Belgium,PO,PORTUGAL,Peak,$12.21,$14.94
+BE,Belgium,PO01,Azores,NonPeak,$10.83,$17.97
+BE,Belgium,PO01,Azores,Peak,$12.78,$21.20
+BE,Belgium,QA,Qatar,NonPeak,$11.35,$12.36
+BE,Belgium,QA,Qatar,Peak,$13.39,$14.58
+BE,Belgium,RO,Romania,NonPeak,$11.82,$10.91
+BE,Belgium,RO,Romania,Peak,$13.95,$12.87
+BE,Belgium,RQ,PUERTO RICO,NonPeak,$8.88,$18.51
+BE,Belgium,RQ,PUERTO RICO,Peak,$10.48,$21.84
+BE,Belgium,SA,Saudi Arabia,NonPeak,$9.31,$12.70
+BE,Belgium,SA,Saudi Arabia,Peak,$10.99,$14.99
+BE,Belgium,SN,Singapore,NonPeak,$9.77,$11.24
+BE,Belgium,SN,Singapore,Peak,$11.53,$13.26
+BE,Belgium,SP,SPAIN,NonPeak,$10.21,$19.00
+BE,Belgium,SP,SPAIN,Peak,$12.05,$22.42
+BE,Belgium,TU,TURKEY,NonPeak,$10.65,$12.99
+BE,Belgium,TU,TURKEY,Peak,$12.57,$15.33
+BE,Belgium,UK,UNITED KINGDOM,NonPeak,$10.35,$11.54
+BE,Belgium,UK,UNITED KINGDOM,Peak,$12.21,$13.62
+BE,Belgium,US8030400,Alaska (Zone) IV,NonPeak,$10.83,$16.89
+BE,Belgium,US8030400,Alaska (Zone) IV,Peak,$12.78,$19.93
+BE,Belgium,US8050500,Alaska (Zone) III,NonPeak,$11.35,$11.66
+BE,Belgium,US8050500,Alaska (Zone) III,Peak,$13.39,$13.76
+BE,Belgium,US8101000,Alaska (Zone) I,NonPeak,$11.82,$10.16
+BE,Belgium,US8101000,Alaska (Zone) I,Peak,$13.95,$11.99
+BE,Belgium,US8190100,Alaska (Zone) II,NonPeak,$8.88,$16.98
+BE,Belgium,US8190100,Alaska (Zone) II,Peak,$10.48,$20.04
+BE,Belgium,US89,Hawaii,NonPeak,$9.31,$11.75
+BE,Belgium,US89,Hawaii,Peak,$10.99,$13.86
+BE,Belgium,UY,Uruguay,NonPeak,$9.77,$10.25
+BE,Belgium,UY,Uruguay,Peak,$11.53,$12.09
+BE,Belgium,VE,Venezuela,NonPeak,$10.21,$17.11
+BE,Belgium,VE,Venezuela,Peak,$12.05,$20.19
+BL,Bolivia,AR,Argentina,NonPeak,$10.65,$11.86
+BL,Bolivia,AR,Argentina,Peak,$12.57,$13.99
+BL,Bolivia,AS11,New South Wales/Australian Capital Territory,NonPeak,$10.35,$10.37
+BL,Bolivia,AS11,New South Wales/Australian Capital Territory,Peak,$12.21,$12.24
+BL,Bolivia,AS21,Northern Territory,NonPeak,$10.83,$17.17
+BL,Bolivia,AS21,Northern Territory,Peak,$12.78,$20.26
+BL,Bolivia,BA,Bahrain,NonPeak,$11.35,$10.50
+BL,Bolivia,BA,Bahrain,Peak,$13.39,$12.39
+BL,Bolivia,BE,Belgium,NonPeak,$11.82,$17.59
+BL,Bolivia,BE,Belgium,Peak,$13.95,$20.76
+BL,Bolivia,BL,Bolivia,NonPeak,$8.88,$12.03
+BL,Bolivia,BL,Bolivia,Peak,$10.48,$14.20
+BL,Bolivia,BR,Brazil - Brazilia,NonPeak,$9.31,$12.66
+BL,Bolivia,BR,Brazil - Brazilia,Peak,$10.99,$14.94
+BL,Bolivia,CA10,Ontario,NonPeak,$9.77,$17.97
+BL,Bolivia,CA10,Ontario,Peak,$11.53,$21.20
+BL,Bolivia,CA20,Quebec,NonPeak,$10.21,$12.36
+BL,Bolivia,CA20,Quebec,Peak,$12.05,$14.58
+BL,Bolivia,CA30,Manitoba,NonPeak,$10.65,$10.91
+BL,Bolivia,CA30,Manitoba,Peak,$12.57,$12.87
+BL,Bolivia,CI,Chile,NonPeak,$10.35,$18.51
+BL,Bolivia,CI,Chile,Peak,$12.21,$21.84
+BL,Bolivia,CO,Colombia,NonPeak,$10.83,$12.70
+BL,Bolivia,CO,Colombia,Peak,$12.78,$14.99
+BL,Bolivia,CS,Costa Rica,NonPeak,$11.35,$11.24
+BL,Bolivia,CS,Costa Rica,Peak,$13.39,$13.26
+BL,Bolivia,EC,Ecuador,NonPeak,$11.82,$19.00
+BL,Bolivia,EC,Ecuador,Peak,$13.95,$22.42
+BL,Bolivia,ES,El Salvador,NonPeak,$8.88,$12.99
+BL,Bolivia,ES,El Salvador,Peak,$10.48,$15.33
+BL,Bolivia,GE,Germany,NonPeak,$9.31,$11.54
+BL,Bolivia,GE,Germany,Peak,$10.99,$13.62
+BL,Bolivia,GQ,Guam,NonPeak,$9.77,$16.89
+BL,Bolivia,GQ,Guam,Peak,$11.53,$19.93
+BL,Bolivia,GR,Greece,NonPeak,$10.21,$11.66
+BL,Bolivia,GR,Greece,Peak,$12.05,$13.76
+BL,Bolivia,GR29,Crete,NonPeak,$10.65,$10.16
+BL,Bolivia,GR29,Crete,Peak,$12.57,$11.99
+BL,Bolivia,GT,Guatemala,NonPeak,$10.35,$16.98
+BL,Bolivia,GT,Guatemala,Peak,$12.21,$20.04
+BL,Bolivia,HO,Honduras,NonPeak,$10.83,$11.75
+BL,Bolivia,HO,Honduras,Peak,$12.78,$13.86
+BL,Bolivia,HU,Hungary,NonPeak,$11.35,$10.25
+BL,Bolivia,HU,Hungary,Peak,$13.39,$12.09
+BL,Bolivia,IT,Italy,NonPeak,$11.82,$17.11
+BL,Bolivia,IT,Italy,Peak,$13.95,$20.19
+BL,Bolivia,IT10,Sicily,NonPeak,$8.88,$11.86
+BL,Bolivia,IT10,Sicily,Peak,$10.48,$13.99
+BL,Bolivia,JA01,Japan-Central,NonPeak,$9.31,$10.37
+BL,Bolivia,JA01,Japan-Central,Peak,$10.99,$12.24
+BL,Bolivia,JA02,Japan-South (Excludes Hokkaido),NonPeak,$9.77,$17.17
+BL,Bolivia,JA02,Japan-South (Excludes Hokkaido),Peak,$11.53,$20.26
+BL,Bolivia,JA03,Japan-North,NonPeak,$10.21,$10.50
+BL,Bolivia,JA03,Japan-North,Peak,$12.05,$12.39
+BL,Bolivia,JA96,Okinawa,NonPeak,$10.65,$17.59
+BL,Bolivia,JA96,Okinawa,Peak,$12.57,$20.76
+BL,Bolivia,KS,"Korea, Republic Of",NonPeak,$10.35,$12.03
+BL,Bolivia,KS,"Korea, Republic Of",Peak,$12.21,$14.20
+BL,Bolivia,KU,Kuwait,NonPeak,$10.83,$12.66
+BL,Bolivia,KU,Kuwait,Peak,$12.78,$14.94
+BL,Bolivia,NL,Netherlands,NonPeak,$11.35,$17.97
+BL,Bolivia,NL,Netherlands,Peak,$13.39,$21.20
+BL,Bolivia,NO,Norway,NonPeak,$11.82,$12.36
+BL,Bolivia,NO,Norway,Peak,$13.95,$14.58
+BL,Bolivia,PA,Paraguay,NonPeak,$8.88,$10.91
+BL,Bolivia,PA,Paraguay,Peak,$10.48,$12.87
+BL,Bolivia,PE,Peru,NonPeak,$9.31,$18.51
+BL,Bolivia,PE,Peru,Peak,$10.99,$21.84
+BL,Bolivia,PL,Poland,NonPeak,$9.77,$12.70
+BL,Bolivia,PL,Poland,Peak,$11.53,$14.99
+BL,Bolivia,PO,Portugal,NonPeak,$10.21,$11.24
+BL,Bolivia,PO,Portugal,Peak,$12.05,$13.26
+BL,Bolivia,PO01,Azores,NonPeak,$10.65,$19.00
+BL,Bolivia,PO01,Azores,Peak,$12.57,$22.42
+BL,Bolivia,QA,Qatar,NonPeak,$10.35,$12.99
+BL,Bolivia,QA,Qatar,Peak,$12.21,$15.33
+BL,Bolivia,RO,Romania,NonPeak,$10.83,$11.54
+BL,Bolivia,RO,Romania,Peak,$12.78,$13.62
+BL,Bolivia,RQ,Puerto Rico,NonPeak,$11.35,$16.89
+BL,Bolivia,RQ,Puerto Rico,Peak,$13.39,$19.93
+BL,Bolivia,SA,Saudi Arabia,NonPeak,$11.82,$11.66
+BL,Bolivia,SA,Saudi Arabia,Peak,$13.95,$13.76
+BL,Bolivia,SN,Singapore,NonPeak,$8.88,$10.16
+BL,Bolivia,SN,Singapore,Peak,$10.48,$11.99
+BL,Bolivia,SP,Spain,NonPeak,$9.31,$16.98
+BL,Bolivia,SP,Spain,Peak,$10.99,$20.04
+BL,Bolivia,TU,Turkey,NonPeak,$9.77,$11.75
+BL,Bolivia,TU,Turkey,Peak,$11.53,$13.86
+BL,Bolivia,UK,United Kingdom,NonPeak,$10.21,$10.25
+BL,Bolivia,UK,United Kingdom,Peak,$12.05,$12.09
+BL,Bolivia,US8030400,Alaska (Zone) IV,NonPeak,$10.65,$17.11
+BL,Bolivia,US8030400,Alaska (Zone) IV,Peak,$12.57,$20.19
+BL,Bolivia,US8050500,Alaska (Zone) III,NonPeak,$10.35,$11.86
+BL,Bolivia,US8050500,Alaska (Zone) III,Peak,$12.21,$13.99
+BL,Bolivia,US8101000,Alaska (Zone) I,NonPeak,$10.83,$10.37
+BL,Bolivia,US8101000,Alaska (Zone) I,Peak,$12.78,$12.24
+BL,Bolivia,US8190100,Alaska (Zone) II,NonPeak,$11.35,$17.17
+BL,Bolivia,US8190100,Alaska (Zone) II,Peak,$13.39,$20.26
+BL,Bolivia,US89,Hawaii,NonPeak,$11.82,$10.50
+BL,Bolivia,US89,Hawaii,Peak,$13.95,$12.39
+BL,Bolivia,UY,Uruguay,NonPeak,$8.88,$17.59
+BL,Bolivia,UY,Uruguay,Peak,$10.48,$20.76
+BL,Bolivia,VE,Venezuela,NonPeak,$9.31,$12.03
+BL,Bolivia,VE,Venezuela,Peak,$10.99,$14.20
+BR,Brazil - Brazilia,AR,Argentina,NonPeak,$9.77,$12.66
+BR,Brazil - Brazilia,AR,Argentina,Peak,$11.53,$14.94
+BR,Brazil - Brazilia,AS11,New South Wales/Australian Capital Territory,NonPeak,$10.21,$17.97
+BR,Brazil - Brazilia,AS11,New South Wales/Australian Capital Territory,Peak,$12.05,$21.20
+BR,Brazil - Brazilia,AS21,Northern Territory,NonPeak,$10.65,$12.36
+BR,Brazil - Brazilia,AS21,Northern Territory,Peak,$12.57,$14.58
+BR,Brazil - Brazilia,BA,Bahrain,NonPeak,$10.35,$10.91
+BR,Brazil - Brazilia,BA,Bahrain,Peak,$12.21,$12.87
+BR,Brazil - Brazilia,BE,Belgium,NonPeak,$10.83,$18.51
+BR,Brazil - Brazilia,BE,Belgium,Peak,$12.78,$21.84
+BR,Brazil - Brazilia,BL,Bolivia,NonPeak,$11.35,$12.70
+BR,Brazil - Brazilia,BL,Bolivia,Peak,$13.39,$14.99
+BR,Brazil - Brazilia,BR,Brazil - Brazilia,NonPeak,$11.82,$11.24
+BR,Brazil - Brazilia,BR,Brazil - Brazilia,Peak,$13.95,$13.26
+BR,Brazil - Brazilia,CA10,Ontario,NonPeak,$8.88,$19.00
+BR,Brazil - Brazilia,CA10,Ontario,Peak,$10.48,$22.42
+BR,Brazil - Brazilia,CA20,Quebec,NonPeak,$9.31,$12.99
+BR,Brazil - Brazilia,CA20,Quebec,Peak,$10.99,$15.33
+BR,Brazil - Brazilia,CA30,Manitoba,NonPeak,$9.77,$11.54
+BR,Brazil - Brazilia,CA30,Manitoba,Peak,$11.53,$13.62
+BR,Brazil - Brazilia,CI,Chile,NonPeak,$10.21,$16.89
+BR,Brazil - Brazilia,CI,Chile,Peak,$12.05,$19.93
+BR,Brazil - Brazilia,CO,Colombia,NonPeak,$10.65,$11.66
+BR,Brazil - Brazilia,CO,Colombia,Peak,$12.57,$13.76
+BR,Brazil - Brazilia,CS,Costa Rica,NonPeak,$10.35,$10.16
+BR,Brazil - Brazilia,CS,Costa Rica,Peak,$12.21,$11.99
+BR,Brazil - Brazilia,EC,Ecuador,NonPeak,$10.83,$16.98
+BR,Brazil - Brazilia,EC,Ecuador,Peak,$12.78,$20.04
+BR,Brazil - Brazilia,ES,El Salvador,NonPeak,$11.35,$11.75
+BR,Brazil - Brazilia,ES,El Salvador,Peak,$13.39,$13.86
+BR,Brazil - Brazilia,GE,Germany,NonPeak,$11.82,$10.25
+BR,Brazil - Brazilia,GE,Germany,Peak,$13.95,$12.09
+BR,Brazil - Brazilia,GQ,Guam,NonPeak,$8.88,$17.11
+BR,Brazil - Brazilia,GQ,Guam,Peak,$10.48,$20.19
+BR,Brazil - Brazilia,GR,Greece,NonPeak,$9.31,$11.86
+BR,Brazil - Brazilia,GR,Greece,Peak,$10.99,$13.99
+BR,Brazil - Brazilia,GR29,Crete,NonPeak,$9.77,$10.37
+BR,Brazil - Brazilia,GR29,Crete,Peak,$11.53,$12.24
+BR,Brazil - Brazilia,GT,Guatemala,NonPeak,$10.21,$17.17
+BR,Brazil - Brazilia,GT,Guatemala,Peak,$12.05,$20.26
+BR,Brazil - Brazilia,HO,Honduras,NonPeak,$10.65,$10.50
+BR,Brazil - Brazilia,HO,Honduras,Peak,$12.57,$12.39
+BR,Brazil - Brazilia,HU,Hungary,NonPeak,$10.35,$17.59
+BR,Brazil - Brazilia,HU,Hungary,Peak,$12.21,$20.76
+BR,Brazil - Brazilia,IT,Italy,NonPeak,$10.83,$12.03
+BR,Brazil - Brazilia,IT,Italy,Peak,$12.78,$14.20
+BR,Brazil - Brazilia,IT10,Sicily,NonPeak,$11.35,$12.66
+BR,Brazil - Brazilia,IT10,Sicily,Peak,$13.39,$14.94
+BR,Brazil - Brazilia,JA01,Japan-Central,NonPeak,$11.82,$17.97
+BR,Brazil - Brazilia,JA01,Japan-Central,Peak,$13.95,$21.20
+BR,Brazil - Brazilia,JA02,Japan-South (Excludes Hokkaido),NonPeak,$8.88,$12.36
+BR,Brazil - Brazilia,JA02,Japan-South (Excludes Hokkaido),Peak,$10.48,$14.58
+BR,Brazil - Brazilia,JA03,Japan-North,NonPeak,$9.31,$10.91
+BR,Brazil - Brazilia,JA03,Japan-North,Peak,$10.99,$12.87
+BR,Brazil - Brazilia,JA96,Okinawa,NonPeak,$9.77,$18.51
+BR,Brazil - Brazilia,JA96,Okinawa,Peak,$11.53,$21.84
+BR,Brazil - Brazilia,KS,"Korea, Republic Of",NonPeak,$10.21,$12.70
+BR,Brazil - Brazilia,KS,"Korea, Republic Of",Peak,$12.05,$14.99
+BR,Brazil - Brazilia,KU,Kuwait,NonPeak,$10.65,$11.24
+BR,Brazil - Brazilia,KU,Kuwait,Peak,$12.57,$13.26
+BR,Brazil - Brazilia,NL,Netherlands,NonPeak,$10.35,$19.00
+BR,Brazil - Brazilia,NL,Netherlands,Peak,$12.21,$22.42
+BR,Brazil - Brazilia,NO,Norway,NonPeak,$10.83,$12.99
+BR,Brazil - Brazilia,NO,Norway,Peak,$12.78,$15.33
+BR,Brazil - Brazilia,PA,Paraguay,NonPeak,$11.35,$11.54
+BR,Brazil - Brazilia,PA,Paraguay,Peak,$13.39,$13.62
+BR,Brazil - Brazilia,PE,Peru,NonPeak,$11.82,$16.89
+BR,Brazil - Brazilia,PE,Peru,Peak,$13.95,$19.93
+BR,Brazil - Brazilia,PL,Poland,NonPeak,$8.88,$11.66
+BR,Brazil - Brazilia,PL,Poland,Peak,$10.48,$13.76
+BR,Brazil - Brazilia,PO,Portugal,NonPeak,$9.31,$10.16
+BR,Brazil - Brazilia,PO,Portugal,Peak,$10.99,$11.99
+BR,Brazil - Brazilia,PO01,Azores,NonPeak,$9.77,$16.98
+BR,Brazil - Brazilia,PO01,Azores,Peak,$11.53,$20.04
+BR,Brazil - Brazilia,QA,Qatar,NonPeak,$10.21,$11.75
+BR,Brazil - Brazilia,QA,Qatar,Peak,$12.05,$13.86
+BR,Brazil - Brazilia,RO,Romania,NonPeak,$10.65,$10.25
+BR,Brazil - Brazilia,RO,Romania,Peak,$12.57,$12.09
+BR,Brazil - Brazilia,RQ,Puerto Rico,NonPeak,$10.35,$17.11
+BR,Brazil - Brazilia,RQ,Puerto Rico,Peak,$12.21,$20.19
+BR,Brazil - Brazilia,SA,Saudi Arabia,NonPeak,$10.83,$11.86
+BR,Brazil - Brazilia,SA,Saudi Arabia,Peak,$12.78,$13.99
+BR,Brazil - Brazilia,SN,Singapore,NonPeak,$11.35,$10.37
+BR,Brazil - Brazilia,SN,Singapore,Peak,$13.39,$12.24
+BR,Brazil - Brazilia,SP,Spain,NonPeak,$11.82,$17.17
+BR,Brazil - Brazilia,SP,Spain,Peak,$13.95,$20.26
+BR,Brazil - Brazilia,TU,Turkey,NonPeak,$8.88,$10.50
+BR,Brazil - Brazilia,TU,Turkey,Peak,$10.48,$12.39
+BR,Brazil - Brazilia,UK,United Kingdom,NonPeak,$9.31,$17.59
+BR,Brazil - Brazilia,UK,United Kingdom,Peak,$10.99,$20.76
+BR,Brazil - Brazilia,US8030400,Alaska (Zone) IV,NonPeak,$9.77,$12.03
+BR,Brazil - Brazilia,US8030400,Alaska (Zone) IV,Peak,$11.53,$14.20
+BR,Brazil - Brazilia,US8050500,Alaska (Zone) III,NonPeak,$10.21,$12.66
+BR,Brazil - Brazilia,US8050500,Alaska (Zone) III,Peak,$12.05,$14.94
+BR,Brazil - Brazilia,US8101000,Alaska (Zone) I,NonPeak,$10.65,$17.97
+BR,Brazil - Brazilia,US8101000,Alaska (Zone) I,Peak,$12.57,$21.20
+BR,Brazil - Brazilia,US8190100,Alaska (Zone) II,NonPeak,$10.35,$12.36
+BR,Brazil - Brazilia,US8190100,Alaska (Zone) II,Peak,$12.21,$14.58
+BR,Brazil - Brazilia,US89,Hawaii,NonPeak,$10.83,$10.91
+BR,Brazil - Brazilia,US89,Hawaii,Peak,$12.78,$12.87
+BR,Brazil - Brazilia,UY,Uruguay,NonPeak,$11.35,$18.51
+BR,Brazil - Brazilia,UY,Uruguay,Peak,$13.39,$21.84
+BR,Brazil - Brazilia,VE,Venezuela,NonPeak,$11.82,$12.70
+BR,Brazil - Brazilia,VE,Venezuela,Peak,$13.95,$14.99
+CA10,Ontario,AR,Argentina,NonPeak,$8.88,$11.24
+CA10,Ontario,AR,Argentina,Peak,$10.48,$13.26
+CA10,Ontario,AS11,New South Wales/Australian Capital Territory,NonPeak,$9.31,$19.00
+CA10,Ontario,AS11,New South Wales/Australian Capital Territory,Peak,$10.99,$22.42
+CA10,Ontario,AS21,Northern Territory,NonPeak,$9.77,$12.99
+CA10,Ontario,AS21,Northern Territory,Peak,$11.53,$15.33
+CA10,Ontario,BA,Bahrain,NonPeak,$10.21,$11.54
+CA10,Ontario,BA,Bahrain,Peak,$12.05,$13.62
+CA10,Ontario,BE,Belgium,NonPeak,$10.65,$16.89
+CA10,Ontario,BE,Belgium,Peak,$12.57,$19.93
+CA10,Ontario,BL,Bolivia,NonPeak,$10.35,$11.66
+CA10,Ontario,BL,Bolivia,Peak,$12.21,$13.76
+CA10,Ontario,BR,Brazil - Brazilia,NonPeak,$10.83,$10.16
+CA10,Ontario,BR,Brazil - Brazilia,Peak,$12.78,$11.99
+CA10,Ontario,CA10,Ontario,NonPeak,$11.35,$16.98
+CA10,Ontario,CA10,Ontario,Peak,$13.39,$20.04
+CA10,Ontario,CA20,Quebec,NonPeak,$11.82,$11.75
+CA10,Ontario,CA20,Quebec,Peak,$13.95,$13.86
+CA10,Ontario,CA30,Manitoba,NonPeak,$8.88,$10.25
+CA10,Ontario,CA30,Manitoba,Peak,$10.48,$12.09
+CA10,Ontario,CI,Chile,NonPeak,$9.31,$17.11
+CA10,Ontario,CI,Chile,Peak,$10.99,$20.19
+CA10,Ontario,CO,Colombia,NonPeak,$9.77,$11.86
+CA10,Ontario,CO,Colombia,Peak,$11.53,$13.99
+CA10,Ontario,CS,Costa Rica,NonPeak,$10.21,$10.37
+CA10,Ontario,CS,Costa Rica,Peak,$12.05,$12.24
+CA10,Ontario,EC,Ecuador,NonPeak,$10.65,$17.17
+CA10,Ontario,EC,Ecuador,Peak,$12.57,$20.26
+CA10,Ontario,ES,El Salvador,NonPeak,$10.35,$10.50
+CA10,Ontario,ES,El Salvador,Peak,$12.21,$12.39
+CA10,Ontario,GE,Germany,NonPeak,$10.83,$17.59
+CA10,Ontario,GE,Germany,Peak,$12.78,$20.76
+CA10,Ontario,GQ,Guam,NonPeak,$11.35,$12.03
+CA10,Ontario,GQ,Guam,Peak,$13.39,$14.20
+CA10,Ontario,GR,Greece,NonPeak,$11.82,$12.66
+CA10,Ontario,GR,Greece,Peak,$13.95,$14.94
+CA10,Ontario,GR29,Crete,NonPeak,$8.88,$17.97
+CA10,Ontario,GR29,Crete,Peak,$10.48,$21.20
+CA10,Ontario,GT,Guatemala,NonPeak,$9.31,$12.36
+CA10,Ontario,GT,Guatemala,Peak,$10.99,$14.58
+CA10,Ontario,HO,Honduras,NonPeak,$9.77,$10.91
+CA10,Ontario,HO,Honduras,Peak,$11.53,$12.87
+CA10,Ontario,HU,Hungary,NonPeak,$10.21,$18.51
+CA10,Ontario,HU,Hungary,Peak,$12.05,$21.84
+CA10,Ontario,IT,Italy,NonPeak,$10.65,$12.70
+CA10,Ontario,IT,Italy,Peak,$12.57,$14.99
+CA10,Ontario,IT10,Sicily,NonPeak,$10.35,$11.24
+CA10,Ontario,IT10,Sicily,Peak,$12.21,$13.26
+CA10,Ontario,JA01,Japan-Central,NonPeak,$10.83,$19.00
+CA10,Ontario,JA01,Japan-Central,Peak,$12.78,$22.42
+CA10,Ontario,JA02,Japan-South (Excludes Hokkaido),NonPeak,$11.35,$12.99
+CA10,Ontario,JA02,Japan-South (Excludes Hokkaido),Peak,$13.39,$15.33
+CA10,Ontario,JA03,Japan-North,NonPeak,$11.82,$11.54
+CA10,Ontario,JA03,Japan-North,Peak,$13.95,$13.62
+CA10,Ontario,JA96,Okinawa,NonPeak,$8.88,$16.89
+CA10,Ontario,JA96,Okinawa,Peak,$10.48,$19.93
+CA10,Ontario,KS,"Korea, Republic Of",NonPeak,$9.31,$11.66
+CA10,Ontario,KS,"Korea, Republic Of",Peak,$10.99,$13.76
+CA10,Ontario,KU,Kuwait,NonPeak,$9.77,$10.16
+CA10,Ontario,KU,Kuwait,Peak,$11.53,$11.99
+CA10,Ontario,NL,Netherlands,NonPeak,$10.21,$16.98
+CA10,Ontario,NL,Netherlands,Peak,$12.05,$20.04
+CA10,Ontario,NO,Norway,NonPeak,$10.65,$11.75
+CA10,Ontario,NO,Norway,Peak,$12.57,$13.86
+CA10,Ontario,PA,Paraguay,NonPeak,$10.35,$10.25
+CA10,Ontario,PA,Paraguay,Peak,$12.21,$12.09
+CA10,Ontario,PE,Peru,NonPeak,$10.83,$17.11
+CA10,Ontario,PE,Peru,Peak,$12.78,$20.19
+CA10,Ontario,PL,Poland,NonPeak,$11.35,$11.86
+CA10,Ontario,PL,Poland,Peak,$13.39,$13.99
+CA10,Ontario,PO,Portugal,NonPeak,$11.82,$10.37
+CA10,Ontario,PO,Portugal,Peak,$13.95,$12.24
+CA10,Ontario,PO01,Azores,NonPeak,$8.88,$17.17
+CA10,Ontario,PO01,Azores,Peak,$10.48,$20.26
+CA10,Ontario,QA,Qatar,NonPeak,$9.31,$10.50
+CA10,Ontario,QA,Qatar,Peak,$10.99,$12.39
+CA10,Ontario,RO,Romania,NonPeak,$9.77,$17.59
+CA10,Ontario,RO,Romania,Peak,$11.53,$20.76
+CA10,Ontario,RQ,Puerto Rico,NonPeak,$10.21,$12.03
+CA10,Ontario,RQ,Puerto Rico,Peak,$12.05,$14.20
+CA10,Ontario,SA,Saudi Arabia,NonPeak,$10.65,$12.66
+CA10,Ontario,SA,Saudi Arabia,Peak,$12.57,$14.94
+CA10,Ontario,SN,Singapore,NonPeak,$10.35,$17.97
+CA10,Ontario,SN,Singapore,Peak,$12.21,$21.20
+CA10,Ontario,SP,Spain,NonPeak,$10.83,$12.36
+CA10,Ontario,SP,Spain,Peak,$12.78,$14.58
+CA10,Ontario,TU,Turkey,NonPeak,$11.35,$10.91
+CA10,Ontario,TU,Turkey,Peak,$13.39,$12.87
+CA10,Ontario,UK,United Kingdom,NonPeak,$11.82,$18.51
+CA10,Ontario,UK,United Kingdom,Peak,$13.95,$21.84
+CA10,Ontario,US8030400,Alaska (Zone) IV,NonPeak,$8.88,$12.70
+CA10,Ontario,US8030400,Alaska (Zone) IV,Peak,$10.48,$14.99
+CA10,Ontario,US8050500,Alaska (Zone) III,NonPeak,$9.31,$11.24
+CA10,Ontario,US8050500,Alaska (Zone) III,Peak,$10.99,$13.26
+CA10,Ontario,US8101000,Alaska (Zone) I,NonPeak,$9.77,$19.00
+CA10,Ontario,US8101000,Alaska (Zone) I,Peak,$11.53,$22.42
+CA10,Ontario,US8190100,Alaska (Zone) II,NonPeak,$10.21,$12.99
+CA10,Ontario,US8190100,Alaska (Zone) II,Peak,$12.05,$15.33
+CA10,Ontario,US89,Hawaii,NonPeak,$10.65,$11.54
+CA10,Ontario,US89,Hawaii,Peak,$12.57,$13.62
+CA10,Ontario,UY,Uruguay,NonPeak,$10.35,$16.89
+CA10,Ontario,UY,Uruguay,Peak,$12.21,$19.93
+CA10,Ontario,VE,Venezuela,NonPeak,$10.83,$11.66
+CA10,Ontario,VE,Venezuela,Peak,$12.78,$13.76
+CA20,Quebec,AR,Argentina,NonPeak,$11.35,$10.16
+CA20,Quebec,AR,Argentina,Peak,$13.39,$11.99
+CA20,Quebec,AS11,New South Wales/Australian Capital Territory,NonPeak,$11.82,$16.98
+CA20,Quebec,AS11,New South Wales/Australian Capital Territory,Peak,$13.95,$20.04
+CA20,Quebec,AS21,Northern Territory,NonPeak,$8.88,$11.75
+CA20,Quebec,AS21,Northern Territory,Peak,$10.48,$13.86
+CA20,Quebec,BA,Bahrain,NonPeak,$9.31,$10.25
+CA20,Quebec,BA,Bahrain,Peak,$10.99,$12.09
+CA20,Quebec,BE,Belgium,NonPeak,$9.77,$17.11
+CA20,Quebec,BE,Belgium,Peak,$11.53,$20.19
+CA20,Quebec,BL,Bolivia,NonPeak,$10.21,$11.86
+CA20,Quebec,BL,Bolivia,Peak,$12.05,$13.99
+CA20,Quebec,BR,Brazil - Brazilia,NonPeak,$10.65,$10.37
+CA20,Quebec,BR,Brazil - Brazilia,Peak,$12.57,$12.24
+CA20,Quebec,CA10,Ontario,NonPeak,$10.35,$17.17
+CA20,Quebec,CA10,Ontario,Peak,$12.21,$20.26
+CA20,Quebec,CA20,Quebec,NonPeak,$10.83,$10.50
+CA20,Quebec,CA20,Quebec,Peak,$12.78,$12.39
+CA20,Quebec,CA30,Manitoba,NonPeak,$11.35,$17.59
+CA20,Quebec,CA30,Manitoba,Peak,$13.39,$20.76
+CA20,Quebec,CI,Chile,NonPeak,$11.82,$12.03
+CA20,Quebec,CI,Chile,Peak,$13.95,$14.20
+CA20,Quebec,CO,Colombia,NonPeak,$8.88,$12.66
+CA20,Quebec,CO,Colombia,Peak,$10.48,$14.94
+CA20,Quebec,CS,Costa Rica,NonPeak,$9.31,$17.97
+CA20,Quebec,CS,Costa Rica,Peak,$10.99,$21.20
+CA20,Quebec,EC,Ecuador,NonPeak,$9.77,$12.36
+CA20,Quebec,EC,Ecuador,Peak,$11.53,$14.58
+CA20,Quebec,ES,El Salvador,NonPeak,$10.21,$10.91
+CA20,Quebec,ES,El Salvador,Peak,$12.05,$12.87
+CA20,Quebec,GE,Germany,NonPeak,$10.65,$18.51
+CA20,Quebec,GE,Germany,Peak,$12.57,$21.84
+CA20,Quebec,GQ,Guam,NonPeak,$10.35,$12.70
+CA20,Quebec,GQ,Guam,Peak,$12.21,$14.99
+CA20,Quebec,GR,Greece,NonPeak,$10.83,$11.24
+CA20,Quebec,GR,Greece,Peak,$12.78,$13.26
+CA20,Quebec,GR29,Crete,NonPeak,$11.35,$19.00
+CA20,Quebec,GR29,Crete,Peak,$13.39,$22.42
+CA20,Quebec,GT,Guatemala,NonPeak,$11.82,$12.99
+CA20,Quebec,GT,Guatemala,Peak,$13.95,$15.33
+CA20,Quebec,HO,Honduras,NonPeak,$8.88,$11.54
+CA20,Quebec,HO,Honduras,Peak,$10.48,$13.62
+CA20,Quebec,HU,Hungary,NonPeak,$9.31,$16.89
+CA20,Quebec,HU,Hungary,Peak,$10.99,$19.93
+CA20,Quebec,IT,Italy,NonPeak,$9.77,$11.66
+CA20,Quebec,IT,Italy,Peak,$11.53,$13.76
+CA20,Quebec,IT10,Sicily,NonPeak,$10.21,$10.16
+CA20,Quebec,IT10,Sicily,Peak,$12.05,$11.99
+CA20,Quebec,JA01,Japan-Central,NonPeak,$10.65,$16.98
+CA20,Quebec,JA01,Japan-Central,Peak,$12.57,$20.04
+CA20,Quebec,JA02,Japan-South (Excludes Hokkaido),NonPeak,$10.35,$11.75
+CA20,Quebec,JA02,Japan-South (Excludes Hokkaido),Peak,$12.21,$13.86
+CA20,Quebec,JA03,Japan-North,NonPeak,$10.83,$10.25
+CA20,Quebec,JA03,Japan-North,Peak,$12.78,$12.09
+CA20,Quebec,JA96,Okinawa,NonPeak,$11.35,$17.11
+CA20,Quebec,JA96,Okinawa,Peak,$13.39,$20.19
+CA20,Quebec,KS,"Korea, Republic Of",NonPeak,$11.82,$11.86
+CA20,Quebec,KS,"Korea, Republic Of",Peak,$13.95,$13.99
+CA20,Quebec,KU,Kuwait,NonPeak,$8.88,$10.37
+CA20,Quebec,KU,Kuwait,Peak,$10.48,$12.24
+CA20,Quebec,NL,Netherlands,NonPeak,$9.31,$17.17
+CA20,Quebec,NL,Netherlands,Peak,$10.99,$20.26
+CA20,Quebec,NO,Norway,NonPeak,$9.77,$10.50
+CA20,Quebec,NO,Norway,Peak,$11.53,$12.39
+CA20,Quebec,PA,Paraguay,NonPeak,$10.21,$17.59
+CA20,Quebec,PA,Paraguay,Peak,$12.05,$20.76
+CA20,Quebec,PE,Peru,NonPeak,$10.65,$12.03
+CA20,Quebec,PE,Peru,Peak,$12.57,$14.20
+CA20,Quebec,PL,Poland,NonPeak,$10.35,$12.66
+CA20,Quebec,PL,Poland,Peak,$12.21,$14.94
+CA20,Quebec,PO,Portugal,NonPeak,$10.83,$17.97
+CA20,Quebec,PO,Portugal,Peak,$12.78,$21.20
+CA20,Quebec,PO01,Azores,NonPeak,$11.35,$12.36
+CA20,Quebec,PO01,Azores,Peak,$13.39,$14.58
+CA20,Quebec,QA,Qatar,NonPeak,$11.82,$10.91
+CA20,Quebec,QA,Qatar,Peak,$13.95,$12.87
+CA20,Quebec,RO,Romania,NonPeak,$8.88,$18.51
+CA20,Quebec,RO,Romania,Peak,$10.48,$21.84
+CA20,Quebec,RQ,Puerto Rico,NonPeak,$9.31,$12.70
+CA20,Quebec,RQ,Puerto Rico,Peak,$10.99,$14.99
+CA20,Quebec,SA,Saudi Arabia,NonPeak,$9.77,$11.24
+CA20,Quebec,SA,Saudi Arabia,Peak,$11.53,$13.26
+CA20,Quebec,SN,Singapore,NonPeak,$10.21,$19.00
+CA20,Quebec,SN,Singapore,Peak,$12.05,$22.42
+CA20,Quebec,SP,Spain,NonPeak,$10.65,$12.99
+CA20,Quebec,SP,Spain,Peak,$12.57,$15.33
+CA20,Quebec,TU,Turkey,NonPeak,$10.35,$11.54
+CA20,Quebec,TU,Turkey,Peak,$12.21,$13.62
+CA20,Quebec,UK,United Kingdom,NonPeak,$10.83,$16.89
+CA20,Quebec,UK,United Kingdom,Peak,$12.78,$19.93
+CA20,Quebec,US8030400,Alaska (Zone) IV,NonPeak,$11.35,$11.66
+CA20,Quebec,US8030400,Alaska (Zone) IV,Peak,$13.39,$13.76
+CA20,Quebec,US8050500,Alaska (Zone) III,NonPeak,$11.82,$10.16
+CA20,Quebec,US8050500,Alaska (Zone) III,Peak,$13.95,$11.99
+CA20,Quebec,US8101000,Alaska (Zone) I,NonPeak,$8.88,$16.98
+CA20,Quebec,US8101000,Alaska (Zone) I,Peak,$10.48,$20.04
+CA20,Quebec,US8190100,Alaska (Zone) II,NonPeak,$9.31,$11.75
+CA20,Quebec,US8190100,Alaska (Zone) II,Peak,$10.99,$13.86
+CA20,Quebec,US89,Hawaii,NonPeak,$9.77,$10.25
+CA20,Quebec,US89,Hawaii,Peak,$11.53,$12.09
+CA20,Quebec,UY,Uruguay,NonPeak,$10.21,$17.11
+CA20,Quebec,UY,Uruguay,Peak,$12.05,$20.19
+CA20,Quebec,VE,Venezuela,NonPeak,$10.65,$11.86
+CA20,Quebec,VE,Venezuela,Peak,$12.57,$13.99
+CA30,Manitoba,AR,Argentina,NonPeak,$10.35,$10.37
+CA30,Manitoba,AR,Argentina,Peak,$12.21,$12.24
+CA30,Manitoba,AS11,New South Wales/Australian Capital Territory,NonPeak,$10.83,$17.17
+CA30,Manitoba,AS11,New South Wales/Australian Capital Territory,Peak,$12.78,$20.26
+CA30,Manitoba,AS21,Northern Territory,NonPeak,$11.35,$10.50
+CA30,Manitoba,AS21,Northern Territory,Peak,$13.39,$12.39
+CA30,Manitoba,BA,Bahrain,NonPeak,$11.82,$17.59
+CA30,Manitoba,BA,Bahrain,Peak,$13.95,$20.76
+CA30,Manitoba,BE,Belgium,NonPeak,$8.88,$12.03
+CA30,Manitoba,BE,Belgium,Peak,$10.48,$14.20
+CA30,Manitoba,BL,Bolivia,NonPeak,$9.31,$12.66
+CA30,Manitoba,BL,Bolivia,Peak,$10.99,$14.94
+CA30,Manitoba,BR,Brazil - Brazilia,NonPeak,$9.77,$17.97
+CA30,Manitoba,BR,Brazil - Brazilia,Peak,$11.53,$21.20
+CA30,Manitoba,CA10,Ontario,NonPeak,$10.21,$12.36
+CA30,Manitoba,CA10,Ontario,Peak,$12.05,$14.58
+CA30,Manitoba,CA20,Quebec,NonPeak,$10.65,$10.91
+CA30,Manitoba,CA20,Quebec,Peak,$12.57,$12.87
+CA30,Manitoba,CA30,Manitoba,NonPeak,$10.35,$18.51
+CA30,Manitoba,CA30,Manitoba,Peak,$12.21,$21.84
+CA30,Manitoba,CI,Chile,NonPeak,$10.83,$12.70
+CA30,Manitoba,CI,Chile,Peak,$12.78,$14.99
+CA30,Manitoba,CO,Colombia,NonPeak,$11.35,$11.24
+CA30,Manitoba,CO,Colombia,Peak,$13.39,$13.26
+CA30,Manitoba,CS,Costa Rica,NonPeak,$11.82,$19.00
+CA30,Manitoba,CS,Costa Rica,Peak,$13.95,$22.42
+CA30,Manitoba,EC,Ecuador,NonPeak,$8.88,$12.99
+CA30,Manitoba,EC,Ecuador,Peak,$10.48,$15.33
+CA30,Manitoba,ES,El Salvador,NonPeak,$9.31,$11.54
+CA30,Manitoba,ES,El Salvador,Peak,$10.99,$13.62
+CA30,Manitoba,GE,Germany,NonPeak,$9.77,$16.89
+CA30,Manitoba,GE,Germany,Peak,$11.53,$19.93
+CA30,Manitoba,GQ,Guam,NonPeak,$10.21,$11.66
+CA30,Manitoba,GQ,Guam,Peak,$12.05,$13.76
+CA30,Manitoba,GR,Greece,NonPeak,$10.65,$10.16
+CA30,Manitoba,GR,Greece,Peak,$12.57,$11.99
+CA30,Manitoba,GR29,Crete,NonPeak,$10.35,$16.98
+CA30,Manitoba,GR29,Crete,Peak,$12.21,$20.04
+CA30,Manitoba,GT,Guatemala,NonPeak,$10.83,$11.75
+CA30,Manitoba,GT,Guatemala,Peak,$12.78,$13.86
+CA30,Manitoba,HO,Honduras,NonPeak,$11.35,$10.25
+CA30,Manitoba,HO,Honduras,Peak,$13.39,$12.09
+CA30,Manitoba,HU,Hungary,NonPeak,$11.82,$17.11
+CA30,Manitoba,HU,Hungary,Peak,$13.95,$20.19
+CA30,Manitoba,IT,Italy,NonPeak,$8.88,$11.86
+CA30,Manitoba,IT,Italy,Peak,$10.48,$13.99
+CA30,Manitoba,IT10,Sicily,NonPeak,$9.31,$10.37
+CA30,Manitoba,IT10,Sicily,Peak,$10.99,$12.24
+CA30,Manitoba,JA01,Japan-Central,NonPeak,$9.77,$17.17
+CA30,Manitoba,JA01,Japan-Central,Peak,$11.53,$20.26
+CA30,Manitoba,JA02,Japan-South (Excludes Hokkaido),NonPeak,$10.21,$10.50
+CA30,Manitoba,JA02,Japan-South (Excludes Hokkaido),Peak,$12.05,$12.39
+CA30,Manitoba,JA03,Japan-North,NonPeak,$10.65,$17.59
+CA30,Manitoba,JA03,Japan-North,Peak,$12.57,$20.76
+CA30,Manitoba,JA96,Okinawa,NonPeak,$10.35,$12.03
+CA30,Manitoba,JA96,Okinawa,Peak,$12.21,$14.20
+CA30,Manitoba,KS,"Korea, Republic Of",NonPeak,$10.35,$16.89
+CA30,Manitoba,KS,"Korea, Republic Of",Peak,$12.21,$19.93
+CA30,Manitoba,KU,Kuwait,NonPeak,$10.83,$11.66
+CA30,Manitoba,KU,Kuwait,Peak,$12.78,$13.76
+CA30,Manitoba,NL,Netherlands,NonPeak,$11.35,$10.16
+CA30,Manitoba,NL,Netherlands,Peak,$13.39,$11.99
+CA30,Manitoba,NO,Norway,NonPeak,$11.82,$16.98
+CA30,Manitoba,NO,Norway,Peak,$13.95,$20.04
+CA30,Manitoba,PA,Paraguay,NonPeak,$8.88,$11.75
+CA30,Manitoba,PA,Paraguay,Peak,$10.48,$13.86
+CA30,Manitoba,PE,Peru,NonPeak,$9.31,$10.25
+CA30,Manitoba,PE,Peru,Peak,$10.99,$12.09
+CA30,Manitoba,PL,Poland,NonPeak,$9.77,$17.11
+CA30,Manitoba,PL,Poland,Peak,$11.53,$20.19
+CA30,Manitoba,PO,Portugal,NonPeak,$10.21,$11.86
+CA30,Manitoba,PO,Portugal,Peak,$12.05,$13.99
+CA30,Manitoba,PO01,Azores,NonPeak,$10.65,$10.37
+CA30,Manitoba,PO01,Azores,Peak,$12.57,$12.24
+CA30,Manitoba,QA,Qatar,NonPeak,$10.35,$17.17
+CA30,Manitoba,QA,Qatar,Peak,$12.21,$20.26
+CA30,Manitoba,RO,Romania,NonPeak,$10.83,$10.50
+CA30,Manitoba,RO,Romania,Peak,$12.78,$12.39
+CA30,Manitoba,RQ,Puerto Rico,NonPeak,$11.35,$17.59
+CA30,Manitoba,RQ,Puerto Rico,Peak,$13.39,$20.76
+CA30,Manitoba,SA,Saudi Arabia,NonPeak,$11.82,$12.03
+CA30,Manitoba,SA,Saudi Arabia,Peak,$13.95,$14.20
+CA30,Manitoba,SN,Singapore,NonPeak,$8.88,$12.66
+CA30,Manitoba,SN,Singapore,Peak,$10.48,$14.94
+CA30,Manitoba,SP,Spain,NonPeak,$9.31,$17.97
+CA30,Manitoba,SP,Spain,Peak,$10.99,$21.20
+CA30,Manitoba,TU,Turkey,NonPeak,$9.77,$12.36
+CA30,Manitoba,TU,Turkey,Peak,$11.53,$14.58
+CA30,Manitoba,UK,United Kingdom,NonPeak,$10.21,$10.91
+CA30,Manitoba,UK,United Kingdom,Peak,$12.05,$12.87
+CA30,Manitoba,US8030400,Alaska (Zone) IV,NonPeak,$10.65,$18.51
+CA30,Manitoba,US8030400,Alaska (Zone) IV,Peak,$12.57,$21.84
+CA30,Manitoba,US8050500,Alaska (Zone) III,NonPeak,$10.35,$12.70
+CA30,Manitoba,US8050500,Alaska (Zone) III,Peak,$12.21,$14.99
+CA30,Manitoba,US8101000,Alaska (Zone) I,NonPeak,$10.83,$11.24
+CA30,Manitoba,US8101000,Alaska (Zone) I,Peak,$12.78,$13.26
+CA30,Manitoba,US8190100,Alaska (Zone) II,NonPeak,$11.35,$19.00
+CA30,Manitoba,US8190100,Alaska (Zone) II,Peak,$13.39,$22.42
+CA30,Manitoba,US89,Hawaii,NonPeak,$11.82,$12.99
+CA30,Manitoba,US89,Hawaii,Peak,$13.95,$15.33
+CA30,Manitoba,UY,Uruguay,NonPeak,$8.88,$11.54
+CA30,Manitoba,UY,Uruguay,Peak,$10.48,$13.62
+CA30,Manitoba,VE,Venezuela,NonPeak,$9.31,$16.89
+CA30,Manitoba,VE,Venezuela,Peak,$10.99,$19.93
+CI,Chile,AR,Argentina,NonPeak,$9.77,$11.66
+CI,Chile,AR,Argentina,Peak,$11.53,$13.76
+CI,Chile,AS11,New South Wales/Australian Capital Territory,NonPeak,$10.21,$10.16
+CI,Chile,AS11,New South Wales/Australian Capital Territory,Peak,$12.05,$11.99
+CI,Chile,AS21,Northern Territory,NonPeak,$10.65,$16.98
+CI,Chile,AS21,Northern Territory,Peak,$12.57,$20.04
+CI,Chile,BA,Bahrain,NonPeak,$10.35,$11.75
+CI,Chile,BA,Bahrain,Peak,$12.21,$13.86
+CI,Chile,BE,Belgium,NonPeak,$10.83,$10.25
+CI,Chile,BE,Belgium,Peak,$12.78,$12.09
+CI,Chile,BL,Bolivia,NonPeak,$11.35,$17.11
+CI,Chile,BL,Bolivia,Peak,$13.39,$20.19
+CI,Chile,BR,Brazil - Brazilia,NonPeak,$11.82,$11.86
+CI,Chile,BR,Brazil - Brazilia,Peak,$13.95,$13.99
+CI,Chile,CA10,Ontario,NonPeak,$8.88,$10.37
+CI,Chile,CA10,Ontario,Peak,$10.48,$12.24
+CI,Chile,CA20,Quebec,NonPeak,$9.31,$17.17
+CI,Chile,CA20,Quebec,Peak,$10.99,$20.26
+CI,Chile,CA30,Manitoba,NonPeak,$9.77,$10.50
+CI,Chile,CA30,Manitoba,Peak,$11.53,$12.39
+CI,Chile,CI,Chile,NonPeak,$10.21,$17.59
+CI,Chile,CI,Chile,Peak,$12.05,$20.76
+CI,Chile,CO,Colombia,NonPeak,$10.65,$12.03
+CI,Chile,CO,Colombia,Peak,$12.57,$14.20
+CI,Chile,CS,Costa Rica,NonPeak,$10.35,$12.66
+CI,Chile,CS,Costa Rica,Peak,$12.21,$14.94
+CI,Chile,EC,Ecuador,NonPeak,$10.83,$17.97
+CI,Chile,EC,Ecuador,Peak,$12.78,$21.20
+CI,Chile,ES,El Salvador,NonPeak,$11.35,$12.36
+CI,Chile,ES,El Salvador,Peak,$13.39,$14.58
+CI,Chile,GE,Germany,NonPeak,$11.82,$10.91
+CI,Chile,GE,Germany,Peak,$13.95,$12.87
+CI,Chile,GQ,Guam,NonPeak,$8.88,$18.51
+CI,Chile,GQ,Guam,Peak,$10.48,$21.84
+CI,Chile,GR,Greece,NonPeak,$9.31,$12.70
+CI,Chile,GR,Greece,Peak,$10.99,$14.99
+CI,Chile,GR29,Crete,NonPeak,$9.77,$11.24
+CI,Chile,GR29,Crete,Peak,$11.53,$13.26
+CI,Chile,GT,Guatemala,NonPeak,$10.21,$19.00
+CI,Chile,GT,Guatemala,Peak,$12.05,$22.42
+CI,Chile,HO,Honduras,NonPeak,$10.65,$12.99
+CI,Chile,HO,Honduras,Peak,$12.57,$15.33
+CI,Chile,HU,Hungary,NonPeak,$10.35,$11.54
+CI,Chile,HU,Hungary,Peak,$12.21,$13.62
+CI,Chile,IT,Italy,NonPeak,$10.83,$16.89
+CI,Chile,IT,Italy,Peak,$12.78,$19.93
+CI,Chile,IT10,Sicily,NonPeak,$11.35,$11.66
+CI,Chile,IT10,Sicily,Peak,$13.39,$13.76
+CI,Chile,JA01,Japan-Central,NonPeak,$11.82,$10.16
+CI,Chile,JA01,Japan-Central,Peak,$13.95,$11.99
+CI,Chile,JA02,Japan-South (Excludes Hokkaido),NonPeak,$8.88,$16.98
+CI,Chile,JA02,Japan-South (Excludes Hokkaido),Peak,$10.48,$20.04
+CI,Chile,JA03,Japan-North,NonPeak,$9.31,$11.75
+CI,Chile,JA03,Japan-North,Peak,$10.99,$13.86
+CI,Chile,JA96,Okinawa,NonPeak,$9.77,$10.25
+CI,Chile,JA96,Okinawa,Peak,$11.53,$12.09
+CI,Chile,KS,"Korea, Republic Of",NonPeak,$10.21,$17.11
+CI,Chile,KS,"Korea, Republic Of",Peak,$12.05,$20.19
+CI,Chile,KU,Kuwait,NonPeak,$10.65,$11.86
+CI,Chile,KU,Kuwait,Peak,$12.57,$13.99
+CI,Chile,NL,Netherlands,NonPeak,$10.35,$10.37
+CI,Chile,NL,Netherlands,Peak,$12.21,$12.24
+CI,Chile,NO,Norway,NonPeak,$10.83,$17.17
+CI,Chile,NO,Norway,Peak,$12.78,$20.26
+CI,Chile,PA,Paraguay,NonPeak,$11.35,$10.50
+CI,Chile,PA,Paraguay,Peak,$13.39,$12.39
+CI,Chile,PE,Peru,NonPeak,$11.82,$17.59
+CI,Chile,PE,Peru,Peak,$13.95,$20.76
+CI,Chile,PL,Poland,NonPeak,$8.88,$12.03
+CI,Chile,PL,Poland,Peak,$10.48,$14.20
+CI,Chile,PO,Portugal,NonPeak,$9.31,$12.66
+CI,Chile,PO,Portugal,Peak,$10.99,$14.94
+CI,Chile,PO01,Azores,NonPeak,$9.77,$17.97
+CI,Chile,PO01,Azores,Peak,$11.53,$21.20
+CI,Chile,QA,Qatar,NonPeak,$10.21,$12.36
+CI,Chile,QA,Qatar,Peak,$12.05,$14.58
+CI,Chile,RO,Romania,NonPeak,$10.65,$10.91
+CI,Chile,RO,Romania,Peak,$12.57,$12.87
+CI,Chile,RQ,Puerto Rico,NonPeak,$10.35,$18.51
+CI,Chile,RQ,Puerto Rico,Peak,$12.21,$21.84
+CI,Chile,SA,Saudi Arabia,NonPeak,$10.83,$12.70
+CI,Chile,SA,Saudi Arabia,Peak,$12.78,$14.99
+CI,Chile,SN,Singapore,NonPeak,$11.35,$11.24
+CI,Chile,SN,Singapore,Peak,$13.39,$13.26
+CI,Chile,SP,Spain,NonPeak,$11.82,$19.00
+CI,Chile,SP,Spain,Peak,$13.95,$22.42
+CI,Chile,TU,Turkey,NonPeak,$8.88,$12.99
+CI,Chile,TU,Turkey,Peak,$10.48,$15.33
+CI,Chile,UK,United Kingdom,NonPeak,$9.31,$11.54
+CI,Chile,UK,United Kingdom,Peak,$10.99,$13.62
+CI,Chile,US8030400,Alaska (Zone) IV,NonPeak,$9.77,$16.89
+CI,Chile,US8030400,Alaska (Zone) IV,Peak,$11.53,$19.93
+CI,Chile,US8050500,Alaska (Zone) III,NonPeak,$10.21,$11.66
+CI,Chile,US8050500,Alaska (Zone) III,Peak,$12.05,$13.76
+CI,Chile,US8101000,Alaska (Zone) I,NonPeak,$10.65,$10.16
+CI,Chile,US8101000,Alaska (Zone) I,Peak,$12.57,$11.99
+CI,Chile,US8190100,Alaska (Zone) II,NonPeak,$10.35,$16.98
+CI,Chile,US8190100,Alaska (Zone) II,Peak,$12.21,$20.04
+CI,Chile,US89,Hawaii,NonPeak,$10.83,$11.75
+CI,Chile,US89,Hawaii,Peak,$12.78,$13.86
+CI,Chile,UY,Uruguay,NonPeak,$11.35,$10.25
+CI,Chile,UY,Uruguay,Peak,$13.39,$12.09
+CI,Chile,VE,Venezuela,NonPeak,$11.82,$17.11
+CI,Chile,VE,Venezuela,Peak,$13.95,$20.19
+CO,Colombia,AR,Argentina,NonPeak,$8.88,$11.86
+CO,Colombia,AR,Argentina,Peak,$10.48,$13.99
+CO,Colombia,AS11,New South Wales/Australian Capital Territory,NonPeak,$9.31,$10.37
+CO,Colombia,AS11,New South Wales/Australian Capital Territory,Peak,$10.99,$12.24
+CO,Colombia,AS21,Northern Territory,NonPeak,$9.77,$17.17
+CO,Colombia,AS21,Northern Territory,Peak,$11.53,$20.26
+CO,Colombia,BA,Bahrain,NonPeak,$10.21,$10.50
+CO,Colombia,BA,Bahrain,Peak,$12.05,$12.39
+CO,Colombia,BE,Belgium,NonPeak,$10.65,$17.59
+CO,Colombia,BE,Belgium,Peak,$12.57,$20.76
+CO,Colombia,BL,Bolivia,NonPeak,$10.35,$12.03
+CO,Colombia,BL,Bolivia,Peak,$12.21,$14.20
+CO,Colombia,BR,Brazil - Brazilia,NonPeak,$10.83,$12.66
+CO,Colombia,BR,Brazil - Brazilia,Peak,$12.78,$14.94
+CO,Colombia,CA10,Ontario,NonPeak,$11.35,$17.97
+CO,Colombia,CA10,Ontario,Peak,$13.39,$21.20
+CO,Colombia,CA20,Quebec,NonPeak,$11.82,$12.36
+CO,Colombia,CA20,Quebec,Peak,$13.95,$14.58
+CO,Colombia,CA30,Manitoba,NonPeak,$8.88,$10.91
+CO,Colombia,CA30,Manitoba,Peak,$10.48,$12.87
+CO,Colombia,CI,Chile,NonPeak,$9.31,$18.51
+CO,Colombia,CI,Chile,Peak,$10.99,$21.84
+CO,Colombia,CO,Colombia,NonPeak,$9.77,$12.70
+CO,Colombia,CO,Colombia,Peak,$11.53,$14.99
+CO,Colombia,CS,Costa Rica,NonPeak,$10.21,$11.24
+CO,Colombia,CS,Costa Rica,Peak,$12.05,$13.26
+CO,Colombia,EC,Ecuador,NonPeak,$10.65,$19.00
+CO,Colombia,EC,Ecuador,Peak,$12.57,$22.42
+CO,Colombia,ES,El Salvador,NonPeak,$10.35,$12.99
+CO,Colombia,ES,El Salvador,Peak,$12.21,$15.33
+CO,Colombia,GE,Germany,NonPeak,$10.83,$11.54
+CO,Colombia,GE,Germany,Peak,$12.78,$13.62
+CO,Colombia,GQ,Guam,NonPeak,$11.35,$16.89
+CO,Colombia,GQ,Guam,Peak,$13.39,$19.93
+CO,Colombia,GR,Greece,NonPeak,$11.82,$11.66
+CO,Colombia,GR,Greece,Peak,$13.95,$13.76
+CO,Colombia,GR29,Crete,NonPeak,$8.88,$10.16
+CO,Colombia,GR29,Crete,Peak,$10.48,$11.99
+CO,Colombia,GT,Guatemala,NonPeak,$9.31,$16.98
+CO,Colombia,GT,Guatemala,Peak,$10.99,$20.04
+CO,Colombia,HO,Honduras,NonPeak,$9.77,$11.75
+CO,Colombia,HO,Honduras,Peak,$11.53,$13.86
+CO,Colombia,HU,Hungary,NonPeak,$10.21,$10.25
+CO,Colombia,HU,Hungary,Peak,$12.05,$12.09
+CO,Colombia,IT,Italy,NonPeak,$10.65,$17.11
+CO,Colombia,IT,Italy,Peak,$12.57,$20.19
+CO,Colombia,IT10,Sicily,NonPeak,$10.35,$11.86
+CO,Colombia,IT10,Sicily,Peak,$12.21,$13.99
+CO,Colombia,JA01,Japan-Central,NonPeak,$10.83,$10.37
+CO,Colombia,JA01,Japan-Central,Peak,$12.78,$12.24
+CO,Colombia,JA02,Japan-South (Excludes Hokkaido),NonPeak,$11.35,$17.17
+CO,Colombia,JA02,Japan-South (Excludes Hokkaido),Peak,$13.39,$20.26
+CO,Colombia,JA03,Japan-North,NonPeak,$11.82,$10.50
+CO,Colombia,JA03,Japan-North,Peak,$13.95,$12.39
+CO,Colombia,JA96,Okinawa,NonPeak,$8.88,$17.59
+CO,Colombia,JA96,Okinawa,Peak,$10.48,$20.76
+CO,Colombia,KS,"Korea, Republic Of",NonPeak,$9.31,$12.03
+CO,Colombia,KS,"Korea, Republic Of",Peak,$10.99,$14.20
+CO,Colombia,KU,Kuwait,NonPeak,$9.77,$12.66
+CO,Colombia,KU,Kuwait,Peak,$11.53,$14.94
+CO,Colombia,NL,Netherlands,NonPeak,$10.21,$17.97
+CO,Colombia,NL,Netherlands,Peak,$12.05,$21.20
+CO,Colombia,NO,Norway,NonPeak,$10.65,$12.36
+CO,Colombia,NO,Norway,Peak,$12.57,$14.58
+CO,Colombia,PA,Paraguay,NonPeak,$10.35,$10.91
+CO,Colombia,PA,Paraguay,Peak,$12.21,$12.87
+CO,Colombia,PE,Peru,NonPeak,$10.83,$18.51
+CO,Colombia,PE,Peru,Peak,$12.78,$21.84
+CO,Colombia,PL,Poland,NonPeak,$11.35,$12.70
+CO,Colombia,PL,Poland,Peak,$13.39,$14.99
+CO,Colombia,PO,Portugal,NonPeak,$11.82,$11.24
+CO,Colombia,PO,Portugal,Peak,$13.95,$13.26
+CO,Colombia,PO01,Azores,NonPeak,$8.88,$19.00
+CO,Colombia,PO01,Azores,Peak,$10.48,$22.42
+CO,Colombia,QA,Qatar,NonPeak,$9.31,$12.99
+CO,Colombia,QA,Qatar,Peak,$10.99,$15.33
+CO,Colombia,RO,Romania,NonPeak,$9.77,$11.54
+CO,Colombia,RO,Romania,Peak,$11.53,$13.62
+CO,Colombia,RQ,Puerto Rico,NonPeak,$10.21,$16.89
+CO,Colombia,RQ,Puerto Rico,Peak,$12.05,$19.93
+CO,Colombia,SA,Saudi Arabia,NonPeak,$10.65,$11.66
+CO,Colombia,SA,Saudi Arabia,Peak,$12.57,$13.76
+CO,Colombia,SN,Singapore,NonPeak,$10.35,$10.16
+CO,Colombia,SN,Singapore,Peak,$12.21,$11.99
+CO,Colombia,SP,Spain,NonPeak,$10.83,$16.98
+CO,Colombia,SP,Spain,Peak,$12.78,$20.04
+CO,Colombia,TU,Turkey,NonPeak,$11.35,$11.75
+CO,Colombia,TU,Turkey,Peak,$13.39,$13.86
+CO,Colombia,UK,United Kingdom,NonPeak,$11.82,$10.25
+CO,Colombia,UK,United Kingdom,Peak,$13.95,$12.09
+CO,Colombia,US8030400,Alaska (Zone) IV,NonPeak,$8.88,$17.11
+CO,Colombia,US8030400,Alaska (Zone) IV,Peak,$10.48,$20.19
+CO,Colombia,US8050500,Alaska (Zone) III,NonPeak,$9.31,$11.86
+CO,Colombia,US8050500,Alaska (Zone) III,Peak,$10.99,$13.99
+CO,Colombia,US8101000,Alaska (Zone) I,NonPeak,$9.77,$10.37
+CO,Colombia,US8101000,Alaska (Zone) I,Peak,$11.53,$12.24
+CO,Colombia,US8190100,Alaska (Zone) II,NonPeak,$10.21,$17.17
+CO,Colombia,US8190100,Alaska (Zone) II,Peak,$12.05,$20.26
+CO,Colombia,US89,Hawaii,NonPeak,$10.65,$10.50
+CO,Colombia,US89,Hawaii,Peak,$12.57,$12.39
+CO,Colombia,UY,Uruguay,NonPeak,$10.35,$17.59
+CO,Colombia,UY,Uruguay,Peak,$12.21,$20.76
+CO,Colombia,VE,Venezuela,NonPeak,$10.83,$12.03
+CO,Colombia,VE,Venezuela,Peak,$12.78,$14.20
+CS,Costa Rica,AR,Argentina,NonPeak,$11.35,$12.66
+CS,Costa Rica,AR,Argentina,Peak,$13.39,$14.94
+CS,Costa Rica,AS11,New South Wales/Australian Capital Territory,NonPeak,$11.82,$17.97
+CS,Costa Rica,AS11,New South Wales/Australian Capital Territory,Peak,$13.95,$21.20
+CS,Costa Rica,AS21,Northern Territory,NonPeak,$8.88,$12.36
+CS,Costa Rica,AS21,Northern Territory,Peak,$10.48,$14.58
+CS,Costa Rica,BA,Bahrain,NonPeak,$9.31,$10.91
+CS,Costa Rica,BA,Bahrain,Peak,$10.99,$12.87
+CS,Costa Rica,BE,Belgium,NonPeak,$9.77,$18.51
+CS,Costa Rica,BE,Belgium,Peak,$11.53,$21.84
+CS,Costa Rica,BL,Bolivia,NonPeak,$10.21,$12.70
+CS,Costa Rica,BL,Bolivia,Peak,$12.05,$14.99
+CS,Costa Rica,BR,Brazil - Brazilia,NonPeak,$10.65,$11.24
+CS,Costa Rica,BR,Brazil - Brazilia,Peak,$12.57,$13.26
+CS,Costa Rica,CA10,Ontario,NonPeak,$10.35,$19.00
+CS,Costa Rica,CA10,Ontario,Peak,$12.21,$22.42
+CS,Costa Rica,CA20,Quebec,NonPeak,$10.83,$12.99
+CS,Costa Rica,CA20,Quebec,Peak,$12.78,$15.33
+CS,Costa Rica,CA30,Manitoba,NonPeak,$11.35,$11.54
+CS,Costa Rica,CA30,Manitoba,Peak,$13.39,$13.62
+CS,Costa Rica,CI,Chile,NonPeak,$11.82,$16.89
+CS,Costa Rica,CI,Chile,Peak,$13.95,$19.93
+CS,Costa Rica,CO,Colombia,NonPeak,$8.88,$11.66
+CS,Costa Rica,CO,Colombia,Peak,$10.48,$13.76
+CS,Costa Rica,CS,Costa Rica,NonPeak,$9.31,$10.16
+CS,Costa Rica,CS,Costa Rica,Peak,$10.99,$11.99
+CS,Costa Rica,EC,Ecuador,NonPeak,$9.77,$16.98
+CS,Costa Rica,EC,Ecuador,Peak,$11.53,$20.04
+CS,Costa Rica,ES,El Salvador,NonPeak,$10.21,$11.75
+CS,Costa Rica,ES,El Salvador,Peak,$12.05,$13.86
+CS,Costa Rica,GE,Germany,NonPeak,$10.65,$10.25
+CS,Costa Rica,GE,Germany,Peak,$12.57,$12.09
+CS,Costa Rica,GQ,Guam,NonPeak,$10.35,$17.11
+CS,Costa Rica,GQ,Guam,Peak,$12.21,$20.19
+CS,Costa Rica,GR,Greece,NonPeak,$10.83,$11.86
+CS,Costa Rica,GR,Greece,Peak,$12.78,$13.99
+CS,Costa Rica,GR29,Crete,NonPeak,$11.35,$10.37
+CS,Costa Rica,GR29,Crete,Peak,$13.39,$12.24
+CS,Costa Rica,GT,Guatemala,NonPeak,$11.82,$17.17
+CS,Costa Rica,GT,Guatemala,Peak,$13.95,$20.26
+CS,Costa Rica,HO,Honduras,NonPeak,$8.88,$10.50
+CS,Costa Rica,HO,Honduras,Peak,$10.48,$12.39
+CS,Costa Rica,HU,Hungary,NonPeak,$9.31,$17.59
+CS,Costa Rica,HU,Hungary,Peak,$10.99,$20.76
+CS,Costa Rica,IT,Italy,NonPeak,$9.77,$12.03
+CS,Costa Rica,IT,Italy,Peak,$11.53,$14.20
+CS,Costa Rica,IT10,Sicily,NonPeak,$10.21,$12.66
+CS,Costa Rica,IT10,Sicily,Peak,$12.05,$14.94
+CS,Costa Rica,JA01,Japan-Central,NonPeak,$10.65,$17.97
+CS,Costa Rica,JA01,Japan-Central,Peak,$12.57,$21.20
+CS,Costa Rica,JA02,Japan-South (Excludes Hokkaido),NonPeak,$10.35,$12.36
+CS,Costa Rica,JA02,Japan-South (Excludes Hokkaido),Peak,$12.21,$14.58
+CS,Costa Rica,JA03,Japan-North,NonPeak,$10.83,$10.91
+CS,Costa Rica,JA03,Japan-North,Peak,$12.78,$12.87
+CS,Costa Rica,JA96,Okinawa,NonPeak,$11.35,$18.51
+CS,Costa Rica,JA96,Okinawa,Peak,$13.39,$21.84
+CS,Costa Rica,KS,"Korea, Republic Of",NonPeak,$11.82,$12.70
+CS,Costa Rica,KS,"Korea, Republic Of",Peak,$13.95,$14.99
+CS,Costa Rica,KU,Kuwait,NonPeak,$8.88,$11.24
+CS,Costa Rica,KU,Kuwait,Peak,$10.48,$13.26
+CS,Costa Rica,NL,Netherlands,NonPeak,$9.31,$19.00
+CS,Costa Rica,NL,Netherlands,Peak,$10.99,$22.42
+CS,Costa Rica,NO,Norway,NonPeak,$9.77,$12.99
+CS,Costa Rica,NO,Norway,Peak,$11.53,$15.33
+CS,Costa Rica,PA,Paraguay,NonPeak,$10.21,$11.54
+CS,Costa Rica,PA,Paraguay,Peak,$12.05,$13.62
+CS,Costa Rica,PE,Peru,NonPeak,$10.65,$16.89
+CS,Costa Rica,PE,Peru,Peak,$12.57,$19.93
+CS,Costa Rica,PL,Poland,NonPeak,$10.35,$11.66
+CS,Costa Rica,PL,Poland,Peak,$12.21,$13.76
+CS,Costa Rica,PO,Portugal,NonPeak,$10.83,$10.16
+CS,Costa Rica,PO,Portugal,Peak,$12.78,$11.99
+CS,Costa Rica,PO01,Azores,NonPeak,$11.35,$16.98
+CS,Costa Rica,PO01,Azores,Peak,$13.39,$20.04
+CS,Costa Rica,QA,Qatar,NonPeak,$11.82,$11.75
+CS,Costa Rica,QA,Qatar,Peak,$13.95,$13.86
+CS,Costa Rica,RO,Romania,NonPeak,$8.88,$10.25
+CS,Costa Rica,RO,Romania,Peak,$10.48,$12.09
+CS,Costa Rica,RQ,Puerto Rico,NonPeak,$9.31,$17.11
+CS,Costa Rica,RQ,Puerto Rico,Peak,$10.99,$20.19
+CS,Costa Rica,SA,Saudi Arabia,NonPeak,$9.77,$11.86
+CS,Costa Rica,SA,Saudi Arabia,Peak,$11.53,$13.99
+CS,Costa Rica,SN,Singapore,NonPeak,$10.21,$10.37
+CS,Costa Rica,SN,Singapore,Peak,$12.05,$12.24
+CS,Costa Rica,SP,Spain,NonPeak,$10.65,$17.17
+CS,Costa Rica,SP,Spain,Peak,$12.57,$20.26
+CS,Costa Rica,TU,Turkey,NonPeak,$10.35,$10.50
+CS,Costa Rica,TU,Turkey,Peak,$12.21,$12.39
+CS,Costa Rica,UK,United Kingdom,NonPeak,$10.83,$17.59
+CS,Costa Rica,UK,United Kingdom,Peak,$12.78,$20.76
+CS,Costa Rica,US8030400,Alaska (Zone) IV,NonPeak,$11.35,$12.03
+CS,Costa Rica,US8030400,Alaska (Zone) IV,Peak,$13.39,$14.20
+CS,Costa Rica,US8050500,Alaska (Zone) III,NonPeak,$11.82,$12.66
+CS,Costa Rica,US8050500,Alaska (Zone) III,Peak,$13.95,$14.94
+CS,Costa Rica,US8101000,Alaska (Zone) I,NonPeak,$8.88,$17.97
+CS,Costa Rica,US8101000,Alaska (Zone) I,Peak,$10.48,$21.20
+CS,Costa Rica,US8190100,Alaska (Zone) II,NonPeak,$9.31,$12.36
+CS,Costa Rica,US8190100,Alaska (Zone) II,Peak,$10.99,$14.58
+CS,Costa Rica,US89,Hawaii,NonPeak,$9.77,$10.91
+CS,Costa Rica,US89,Hawaii,Peak,$11.53,$12.87
+CS,Costa Rica,UY,Uruguay,NonPeak,$10.21,$18.51
+CS,Costa Rica,UY,Uruguay,Peak,$12.05,$21.84
+CS,Costa Rica,VE,Venezuela,NonPeak,$10.65,$12.70
+CS,Costa Rica,VE,Venezuela,Peak,$12.57,$14.99
+EC,Ecuador,AR,Argentina,NonPeak,$10.35,$11.24
+EC,Ecuador,AR,Argentina,Peak,$12.21,$13.26
+EC,Ecuador,AS11,New South Wales/Australian Capital Territory,NonPeak,$10.83,$19.00
+EC,Ecuador,AS11,New South Wales/Australian Capital Territory,Peak,$12.78,$22.42
+EC,Ecuador,AS21,Northern Territory,NonPeak,$11.35,$12.99
+EC,Ecuador,AS21,Northern Territory,Peak,$13.39,$15.33
+EC,Ecuador,BA,Bahrain,NonPeak,$11.82,$11.54
+EC,Ecuador,BA,Bahrain,Peak,$13.95,$13.62
+EC,Ecuador,BE,Belgium,NonPeak,$8.88,$16.89
+EC,Ecuador,BE,Belgium,Peak,$10.48,$19.93
+EC,Ecuador,BL,Bolivia,NonPeak,$9.31,$11.66
+EC,Ecuador,BL,Bolivia,Peak,$10.99,$13.76
+EC,Ecuador,BR,Brazil - Brazilia,NonPeak,$9.77,$10.16
+EC,Ecuador,BR,Brazil - Brazilia,Peak,$11.53,$11.99
+EC,Ecuador,CA10,Ontario,NonPeak,$10.21,$16.98
+EC,Ecuador,CA10,Ontario,Peak,$12.05,$20.04
+EC,Ecuador,CA20,Quebec,NonPeak,$10.65,$11.75
+EC,Ecuador,CA20,Quebec,Peak,$12.57,$13.86
+EC,Ecuador,CA30,Manitoba,NonPeak,$10.35,$10.25
+EC,Ecuador,CA30,Manitoba,Peak,$12.21,$12.09
+EC,Ecuador,CI,Chile,NonPeak,$10.83,$17.11
+EC,Ecuador,CI,Chile,Peak,$12.78,$20.19
+EC,Ecuador,CO,Colombia,NonPeak,$11.35,$11.86
+EC,Ecuador,CO,Colombia,Peak,$13.39,$13.99
+EC,Ecuador,CS,Costa Rica,NonPeak,$11.82,$10.37
+EC,Ecuador,CS,Costa Rica,Peak,$13.95,$12.24
+EC,Ecuador,EC,Ecuador,NonPeak,$8.88,$17.17
+EC,Ecuador,EC,Ecuador,Peak,$10.48,$20.26
+EC,Ecuador,ES,El Salvador,NonPeak,$9.31,$10.50
+EC,Ecuador,ES,El Salvador,Peak,$10.99,$12.39
+EC,Ecuador,GE,Germany,NonPeak,$9.77,$17.59
+EC,Ecuador,GE,Germany,Peak,$11.53,$20.76
+EC,Ecuador,GQ,Guam,NonPeak,$10.21,$12.03
+EC,Ecuador,GQ,Guam,Peak,$12.05,$14.20
+EC,Ecuador,GR,Greece,NonPeak,$10.65,$12.66
+EC,Ecuador,GR,Greece,Peak,$12.57,$14.94
+EC,Ecuador,GR29,Crete,NonPeak,$10.35,$17.97
+EC,Ecuador,GR29,Crete,Peak,$12.21,$21.20
+EC,Ecuador,GT,Guatemala,NonPeak,$10.83,$12.36
+EC,Ecuador,GT,Guatemala,Peak,$12.78,$14.58
+EC,Ecuador,HO,Honduras,NonPeak,$11.35,$10.91
+EC,Ecuador,HO,Honduras,Peak,$13.39,$12.87
+EC,Ecuador,HU,Hungary,NonPeak,$11.82,$18.51
+EC,Ecuador,HU,Hungary,Peak,$13.95,$21.84
+EC,Ecuador,IT,Italy,NonPeak,$8.88,$12.70
+EC,Ecuador,IT,Italy,Peak,$10.48,$14.99
+EC,Ecuador,IT10,Sicily,NonPeak,$9.31,$11.24
+EC,Ecuador,IT10,Sicily,Peak,$10.99,$13.26
+EC,Ecuador,JA01,Japan-Central,NonPeak,$9.77,$19.00
+EC,Ecuador,JA01,Japan-Central,Peak,$11.53,$22.42
+EC,Ecuador,JA02,Japan-South (Excludes Hokkaido),NonPeak,$10.21,$12.99
+EC,Ecuador,JA02,Japan-South (Excludes Hokkaido),Peak,$12.05,$15.33
+EC,Ecuador,JA03,Japan-North,NonPeak,$10.65,$11.54
+EC,Ecuador,JA03,Japan-North,Peak,$12.57,$13.62
+EC,Ecuador,JA96,Okinawa,NonPeak,$10.35,$16.89
+EC,Ecuador,JA96,Okinawa,Peak,$12.21,$19.93
+EC,Ecuador,KS,"Korea, Republic Of",NonPeak,$10.83,$11.66
+EC,Ecuador,KS,"Korea, Republic Of",Peak,$12.78,$13.76
+EC,Ecuador,KU,Kuwait,NonPeak,$11.35,$10.16
+EC,Ecuador,KU,Kuwait,Peak,$13.39,$11.99
+EC,Ecuador,NL,Netherlands,NonPeak,$11.82,$16.98
+EC,Ecuador,NL,Netherlands,Peak,$13.95,$20.04
+EC,Ecuador,NO,Norway,NonPeak,$8.88,$11.75
+EC,Ecuador,NO,Norway,Peak,$10.48,$13.86
+EC,Ecuador,PA,Paraguay,NonPeak,$9.31,$10.25
+EC,Ecuador,PA,Paraguay,Peak,$10.99,$12.09
+EC,Ecuador,PE,Peru,NonPeak,$9.77,$17.11
+EC,Ecuador,PE,Peru,Peak,$11.53,$20.19
+EC,Ecuador,PL,Poland,NonPeak,$10.21,$11.86
+EC,Ecuador,PL,Poland,Peak,$12.05,$13.99
+EC,Ecuador,PO,Portugal,NonPeak,$10.65,$10.37
+EC,Ecuador,PO,Portugal,Peak,$12.57,$12.24
+EC,Ecuador,PO01,Azores,NonPeak,$10.35,$17.17
+EC,Ecuador,PO01,Azores,Peak,$12.21,$20.26
+EC,Ecuador,QA,Qatar,NonPeak,$10.83,$10.50
+EC,Ecuador,QA,Qatar,Peak,$12.78,$12.39
+EC,Ecuador,RO,Romania,NonPeak,$11.35,$17.59
+EC,Ecuador,RO,Romania,Peak,$13.39,$20.76
+EC,Ecuador,RQ,Puerto Rico,NonPeak,$11.82,$12.03
+EC,Ecuador,RQ,Puerto Rico,Peak,$13.95,$14.20
+EC,Ecuador,SA,Saudi Arabia,NonPeak,$8.88,$12.66
+EC,Ecuador,SA,Saudi Arabia,Peak,$10.48,$14.94
+EC,Ecuador,SN,Singapore,NonPeak,$9.31,$17.97
+EC,Ecuador,SN,Singapore,Peak,$10.99,$21.20
+EC,Ecuador,SP,Spain,NonPeak,$9.77,$12.36
+EC,Ecuador,SP,Spain,Peak,$11.53,$14.58
+EC,Ecuador,TU,Turkey,NonPeak,$10.21,$10.91
+EC,Ecuador,TU,Turkey,Peak,$12.05,$12.87
+EC,Ecuador,UK,United Kingdom,NonPeak,$10.65,$18.51
+EC,Ecuador,UK,United Kingdom,Peak,$12.57,$21.84
+EC,Ecuador,US8030400,Alaska (Zone) IV,NonPeak,$10.35,$12.70
+EC,Ecuador,US8030400,Alaska (Zone) IV,Peak,$12.21,$14.99
+EC,Ecuador,US8050500,Alaska (Zone) III,NonPeak,$10.83,$11.24
+EC,Ecuador,US8050500,Alaska (Zone) III,Peak,$12.78,$13.26
+EC,Ecuador,US8101000,Alaska (Zone) I,NonPeak,$11.35,$19.00
+EC,Ecuador,US8101000,Alaska (Zone) I,Peak,$13.39,$22.42
+EC,Ecuador,US8190100,Alaska (Zone) II,NonPeak,$11.82,$12.99
+EC,Ecuador,US8190100,Alaska (Zone) II,Peak,$13.95,$15.33
+EC,Ecuador,US89,Hawaii,NonPeak,$8.88,$11.54
+EC,Ecuador,US89,Hawaii,Peak,$10.48,$13.62
+EC,Ecuador,UY,Uruguay,NonPeak,$9.31,$16.89
+EC,Ecuador,UY,Uruguay,Peak,$10.99,$19.93
+EC,Ecuador,VE,Venezuela,NonPeak,$9.77,$11.66
+EC,Ecuador,VE,Venezuela,Peak,$11.53,$13.76
+ES,El Salvador,AR,Argentina,NonPeak,$10.21,$10.16
+ES,El Salvador,AR,Argentina,Peak,$12.05,$11.99
+ES,El Salvador,AS11,New South Wales/Australian Capital Territory,NonPeak,$10.65,$16.98
+ES,El Salvador,AS11,New South Wales/Australian Capital Territory,Peak,$12.57,$20.04
+ES,El Salvador,AS21,Northern Territory,NonPeak,$10.35,$11.75
+ES,El Salvador,AS21,Northern Territory,Peak,$12.21,$13.86
+ES,El Salvador,BA,Bahrain,NonPeak,$10.83,$10.25
+ES,El Salvador,BA,Bahrain,Peak,$12.78,$12.09
+ES,El Salvador,BE,Belgium,NonPeak,$11.35,$17.11
+ES,El Salvador,BE,Belgium,Peak,$13.39,$20.19
+ES,El Salvador,BL,Bolivia,NonPeak,$11.82,$11.86
+ES,El Salvador,BL,Bolivia,Peak,$13.95,$13.99
+ES,El Salvador,BR,Brazil - Brazilia,NonPeak,$8.88,$10.37
+ES,El Salvador,BR,Brazil - Brazilia,Peak,$10.48,$12.24
+ES,El Salvador,CA10,Ontario,NonPeak,$9.31,$17.17
+ES,El Salvador,CA10,Ontario,Peak,$10.99,$20.26
+ES,El Salvador,CA20,Quebec,NonPeak,$9.77,$10.50
+ES,El Salvador,CA20,Quebec,Peak,$11.53,$12.39
+ES,El Salvador,CA30,Manitoba,NonPeak,$10.21,$17.59
+ES,El Salvador,CA30,Manitoba,Peak,$12.05,$20.76
+ES,El Salvador,CI,Chile,NonPeak,$10.65,$12.03
+ES,El Salvador,CI,Chile,Peak,$12.57,$14.20
+ES,El Salvador,CO,Colombia,NonPeak,$10.35,$12.66
+ES,El Salvador,CO,Colombia,Peak,$12.21,$14.94
+ES,El Salvador,CS,Costa Rica,NonPeak,$10.83,$17.97
+ES,El Salvador,CS,Costa Rica,Peak,$12.78,$21.20
+ES,El Salvador,EC,Ecuador,NonPeak,$11.35,$12.36
+ES,El Salvador,EC,Ecuador,Peak,$13.39,$14.58
+ES,El Salvador,ES,El Salvador,NonPeak,$11.82,$10.91
+ES,El Salvador,ES,El Salvador,Peak,$13.95,$12.87
+ES,El Salvador,GE,Germany,NonPeak,$8.88,$18.51
+ES,El Salvador,GE,Germany,Peak,$10.48,$21.84
+ES,El Salvador,GQ,Guam,NonPeak,$9.31,$12.70
+ES,El Salvador,GQ,Guam,Peak,$10.99,$14.99
+ES,El Salvador,GR,Greece,NonPeak,$9.77,$11.24
+ES,El Salvador,GR,Greece,Peak,$11.53,$13.26
+ES,El Salvador,GR29,Crete,NonPeak,$10.21,$19.00
+ES,El Salvador,GR29,Crete,Peak,$12.05,$22.42
+ES,El Salvador,GT,Guatemala,NonPeak,$10.65,$12.99
+ES,El Salvador,GT,Guatemala,Peak,$12.57,$15.33
+ES,El Salvador,HO,Honduras,NonPeak,$10.35,$11.54
+ES,El Salvador,HO,Honduras,Peak,$12.21,$13.62
+ES,El Salvador,HU,Hungary,NonPeak,$10.83,$16.89
+ES,El Salvador,HU,Hungary,Peak,$12.78,$19.93
+ES,El Salvador,IT,Italy,NonPeak,$11.35,$11.66
+ES,El Salvador,IT,Italy,Peak,$13.39,$13.76
+ES,El Salvador,IT10,Sicily,NonPeak,$11.82,$10.16
+ES,El Salvador,IT10,Sicily,Peak,$13.95,$11.99
+ES,El Salvador,JA01,Japan-Central,NonPeak,$8.88,$16.98
+ES,El Salvador,JA01,Japan-Central,Peak,$10.48,$20.04
+ES,El Salvador,JA02,Japan-South (Excludes Hokkaido),NonPeak,$9.31,$11.75
+ES,El Salvador,JA02,Japan-South (Excludes Hokkaido),Peak,$10.99,$13.86
+ES,El Salvador,JA03,Japan-North,NonPeak,$9.77,$10.25
+ES,El Salvador,JA03,Japan-North,Peak,$11.53,$12.09
+ES,El Salvador,JA96,Okinawa,NonPeak,$10.21,$17.11
+ES,El Salvador,JA96,Okinawa,Peak,$12.05,$20.19
+ES,El Salvador,KS,"Korea, Republic Of",NonPeak,$10.65,$11.86
+ES,El Salvador,KS,"Korea, Republic Of",Peak,$12.57,$13.99
+ES,El Salvador,KU,Kuwait,NonPeak,$10.35,$10.37
+ES,El Salvador,KU,Kuwait,Peak,$12.21,$12.24
+ES,El Salvador,NL,Netherlands,NonPeak,$10.83,$17.17
+ES,El Salvador,NL,Netherlands,Peak,$12.78,$20.26
+ES,El Salvador,NO,Norway,NonPeak,$11.35,$10.50
+ES,El Salvador,NO,Norway,Peak,$13.39,$12.39
+ES,El Salvador,PA,Paraguay,NonPeak,$11.82,$17.59
+ES,El Salvador,PA,Paraguay,Peak,$13.95,$20.76
+ES,El Salvador,PE,Peru,NonPeak,$8.88,$12.03
+ES,El Salvador,PE,Peru,Peak,$10.48,$14.20
+ES,El Salvador,PL,Poland,NonPeak,$9.31,$12.66
+ES,El Salvador,PL,Poland,Peak,$10.99,$14.94
+ES,El Salvador,PO,Portugal,NonPeak,$9.77,$17.97
+ES,El Salvador,PO,Portugal,Peak,$11.53,$21.20
+ES,El Salvador,PO01,Azores,NonPeak,$10.21,$12.36
+ES,El Salvador,PO01,Azores,Peak,$12.05,$14.58
+ES,El Salvador,QA,Qatar,NonPeak,$10.65,$10.91
+ES,El Salvador,QA,Qatar,Peak,$12.57,$12.87
+ES,El Salvador,RO,Romania,NonPeak,$10.35,$18.51
+ES,El Salvador,RO,Romania,Peak,$12.21,$21.84
+ES,El Salvador,RQ,Puerto Rico,NonPeak,$10.83,$12.70
+ES,El Salvador,RQ,Puerto Rico,Peak,$12.78,$14.99
+ES,El Salvador,SA,Saudi Arabia,NonPeak,$11.35,$11.24
+ES,El Salvador,SA,Saudi Arabia,Peak,$13.39,$13.26
+ES,El Salvador,SN,Singapore,NonPeak,$11.82,$19.00
+ES,El Salvador,SN,Singapore,Peak,$13.95,$22.42
+ES,El Salvador,SP,Spain,NonPeak,$8.88,$12.99
+ES,El Salvador,SP,Spain,Peak,$10.48,$15.33
+ES,El Salvador,TU,Turkey,NonPeak,$9.31,$11.54
+ES,El Salvador,TU,Turkey,Peak,$10.99,$13.62
+ES,El Salvador,UK,United Kingdom,NonPeak,$9.77,$16.89
+ES,El Salvador,UK,United Kingdom,Peak,$11.53,$19.93
+ES,El Salvador,US8030400,Alaska (Zone) IV,NonPeak,$10.21,$11.66
+ES,El Salvador,US8030400,Alaska (Zone) IV,Peak,$12.05,$13.76
+ES,El Salvador,US8050500,Alaska (Zone) III,NonPeak,$10.65,$10.16
+ES,El Salvador,US8050500,Alaska (Zone) III,Peak,$12.57,$11.99
+ES,El Salvador,US8101000,Alaska (Zone) I,NonPeak,$10.35,$16.98
+ES,El Salvador,US8101000,Alaska (Zone) I,Peak,$12.21,$20.04
+ES,El Salvador,US8190100,Alaska (Zone) II,NonPeak,$10.83,$11.75
+ES,El Salvador,US8190100,Alaska (Zone) II,Peak,$12.78,$13.86
+ES,El Salvador,US89,Hawaii,NonPeak,$11.35,$10.25
+ES,El Salvador,US89,Hawaii,Peak,$13.39,$12.09
+ES,El Salvador,UY,Uruguay,NonPeak,$11.82,$17.11
+ES,El Salvador,UY,Uruguay,Peak,$13.95,$20.19
+ES,El Salvador,VE,Venezuela,NonPeak,$8.88,$11.86
+ES,El Salvador,VE,Venezuela,Peak,$10.48,$13.99
+GE,Germany,AR,Argentina,NonPeak,$9.31,$10.37
+GE,Germany,AR,Argentina,Peak,$10.99,$12.24
+GE,Germany,AS11,New South Wales/Australian Capital Territory,NonPeak,$9.77,$17.17
+GE,Germany,AS11,New South Wales/Australian Capital Territory,Peak,$11.53,$20.26
+GE,Germany,AS21,Northern Territory,NonPeak,$10.21,$10.50
+GE,Germany,AS21,Northern Territory,Peak,$12.05,$12.39
+GE,Germany,BA,Bahrain,NonPeak,$10.65,$17.59
+GE,Germany,BA,Bahrain,Peak,$12.57,$20.76
+GE,Germany,BE,Belgium,NonPeak,$10.35,$12.03
+GE,Germany,BE,Belgium,Peak,$12.21,$14.20
+GE,Germany,BL,Bolivia,NonPeak,$10.83,$12.66
+GE,Germany,BL,Bolivia,Peak,$12.78,$14.94
+GE,Germany,BR,Brazil - Brazilia,NonPeak,$11.35,$17.97
+GE,Germany,BR,Brazil - Brazilia,Peak,$13.39,$21.20
+GE,Germany,CA10,Ontario,NonPeak,$11.82,$12.36
+GE,Germany,CA10,Ontario,Peak,$13.95,$14.58
+GE,Germany,CA20,Quebec,NonPeak,$8.88,$10.91
+GE,Germany,CA20,Quebec,Peak,$10.48,$12.87
+GE,Germany,CA30,Manitoba,NonPeak,$9.31,$18.51
+GE,Germany,CA30,Manitoba,Peak,$10.99,$21.84
+GE,Germany,CI,Chile,NonPeak,$9.77,$12.70
+GE,Germany,CI,Chile,Peak,$11.53,$14.99
+GE,Germany,CO,Colombia,NonPeak,$10.21,$11.24
+GE,Germany,CO,Colombia,Peak,$12.05,$13.26
+GE,Germany,CS,Costa Rica,NonPeak,$10.65,$19.00
+GE,Germany,CS,Costa Rica,Peak,$12.57,$22.42
+GE,Germany,EC,Ecuador,NonPeak,$10.35,$12.99
+GE,Germany,EC,Ecuador,Peak,$12.21,$15.33
+GE,Germany,ES,El Salvador,NonPeak,$10.83,$11.54
+GE,Germany,ES,El Salvador,Peak,$12.78,$13.62
+GE,Germany,GE,Germany,NonPeak,$11.35,$16.89
+GE,Germany,GE,Germany,Peak,$13.39,$19.93
+GE,Germany,GQ,Guam,NonPeak,$11.82,$11.66
+GE,Germany,GQ,Guam,Peak,$13.95,$13.76
+GE,Germany,GR,Greece,NonPeak,$8.88,$10.16
+GE,Germany,GR,Greece,Peak,$10.48,$11.99
+GE,Germany,GR29,Crete,NonPeak,$9.31,$16.98
+GE,Germany,GR29,Crete,Peak,$10.99,$20.04
+GE,Germany,GT,Guatemala,NonPeak,$9.77,$11.75
+GE,Germany,GT,Guatemala,Peak,$11.53,$13.86
+GE,Germany,HO,Honduras,NonPeak,$10.21,$10.25
+GE,Germany,HO,Honduras,Peak,$12.05,$12.09
+GE,Germany,HU,Hungary,NonPeak,$10.65,$17.11
+GE,Germany,HU,Hungary,Peak,$12.57,$20.19
+GE,Germany,IT,Italy,NonPeak,$10.35,$11.86
+GE,Germany,IT,Italy,Peak,$12.21,$13.99
+GE,Germany,IT10,Sicily,NonPeak,$10.83,$10.37
+GE,Germany,IT10,Sicily,Peak,$12.78,$12.24
+GE,Germany,JA01,Japan-Central,NonPeak,$11.35,$17.17
+GE,Germany,JA01,Japan-Central,Peak,$13.39,$20.26
+GE,Germany,JA02,Japan-South (Excludes Hokkaido),NonPeak,$11.82,$10.50
+GE,Germany,JA02,Japan-South (Excludes Hokkaido),Peak,$13.95,$12.39
+GE,Germany,JA03,Japan-North,NonPeak,$8.88,$17.59
+GE,Germany,JA03,Japan-North,Peak,$10.48,$20.76
+GE,Germany,JA96,Okinawa,NonPeak,$9.31,$12.03
+GE,Germany,JA96,Okinawa,Peak,$10.99,$14.20
+GE,Germany,KS,"Korea, Republic Of",NonPeak,$9.77,$12.66
+GE,Germany,KS,"Korea, Republic Of",Peak,$11.53,$14.94
+GE,Germany,KU,Kuwait,NonPeak,$10.21,$17.97
+GE,Germany,KU,Kuwait,Peak,$12.05,$21.20
+GE,Germany,NL,Netherlands,NonPeak,$10.65,$12.36
+GE,Germany,NL,Netherlands,Peak,$12.57,$14.58
+GE,Germany,NO,Norway,NonPeak,$10.35,$10.91
+GE,Germany,NO,Norway,Peak,$12.21,$12.87
+GE,Germany,PA,Paraguay,NonPeak,$10.83,$18.51
+GE,Germany,PA,Paraguay,Peak,$12.78,$21.84
+GE,Germany,PE,Peru,NonPeak,$11.35,$12.70
+GE,Germany,PE,Peru,Peak,$13.39,$14.99
+GE,Germany,PL,Poland,NonPeak,$11.82,$11.24
+GE,Germany,PL,Poland,Peak,$13.95,$13.26
+GE,Germany,PO,Portugal,NonPeak,$8.88,$19.00
+GE,Germany,PO,Portugal,Peak,$10.48,$22.42
+GE,Germany,PO01,Azores,NonPeak,$9.31,$12.99
+GE,Germany,PO01,Azores,Peak,$10.99,$15.33
+GE,Germany,QA,Qatar,NonPeak,$9.77,$11.54
+GE,Germany,QA,Qatar,Peak,$11.53,$13.62
+GE,Germany,RO,Romania,NonPeak,$10.21,$16.89
+GE,Germany,RO,Romania,Peak,$12.05,$19.93
+GE,Germany,RQ,Puerto Rico,NonPeak,$10.65,$11.66
+GE,Germany,RQ,Puerto Rico,Peak,$12.57,$13.76
+GE,Germany,SA,Saudi Arabia,NonPeak,$10.35,$10.16
+GE,Germany,SA,Saudi Arabia,Peak,$12.21,$11.99
+GE,Germany,SN,Singapore,NonPeak,$10.83,$16.98
+GE,Germany,SN,Singapore,Peak,$12.78,$20.04
+GE,Germany,SP,Spain,NonPeak,$11.35,$11.75
+GE,Germany,SP,Spain,Peak,$13.39,$13.86
+GE,Germany,TU,Turkey,NonPeak,$11.82,$10.25
+GE,Germany,TU,Turkey,Peak,$13.95,$12.09
+GE,Germany,UK,United Kingdom,NonPeak,$8.88,$17.11
+GE,Germany,UK,United Kingdom,Peak,$10.48,$20.19
+GE,Germany,US8030400,Alaska (Zone) IV,NonPeak,$9.31,$11.86
+GE,Germany,US8030400,Alaska (Zone) IV,Peak,$10.99,$13.99
+GE,Germany,US8050500,Alaska (Zone) III,NonPeak,$9.77,$10.37
+GE,Germany,US8050500,Alaska (Zone) III,Peak,$11.53,$12.24
+GE,Germany,US8101000,Alaska (Zone) I,NonPeak,$10.21,$17.17
+GE,Germany,US8101000,Alaska (Zone) I,Peak,$12.05,$20.26
+GE,Germany,US8190100,Alaska (Zone) II,NonPeak,$10.65,$10.50
+GE,Germany,US8190100,Alaska (Zone) II,Peak,$12.57,$12.39
+GE,Germany,US89,Hawaii,NonPeak,$10.35,$17.59
+GE,Germany,US89,Hawaii,Peak,$12.21,$20.76
+GE,Germany,UY,Uruguay,NonPeak,$10.83,$12.03
+GE,Germany,UY,Uruguay,Peak,$12.78,$14.20
+GE,Germany,VE,Venezuela,NonPeak,$11.35,$12.66
+GE,Germany,VE,Venezuela,Peak,$13.39,$14.94
+GQ,Guam,AR,Argentina,NonPeak,$11.82,$17.97
+GQ,Guam,AR,Argentina,Peak,$13.95,$21.20
+GQ,Guam,AS11,New South Wales/Australian Capital Territory,NonPeak,$8.88,$12.36
+GQ,Guam,AS11,New South Wales/Australian Capital Territory,Peak,$10.48,$14.58
+GQ,Guam,AS21,Northern Territory,NonPeak,$9.31,$10.91
+GQ,Guam,AS21,Northern Territory,Peak,$10.99,$12.87
+GQ,Guam,BA,Bahrain,NonPeak,$9.77,$18.51
+GQ,Guam,BA,Bahrain,Peak,$11.53,$21.84
+GQ,Guam,BE,Belgium,NonPeak,$10.21,$12.70
+GQ,Guam,BE,Belgium,Peak,$12.05,$14.99
+GQ,Guam,BL,Bolivia,NonPeak,$10.65,$11.24
+GQ,Guam,BL,Bolivia,Peak,$12.57,$13.26
+GQ,Guam,BR,Brazil - Brazilia,NonPeak,$10.35,$19.00
+GQ,Guam,BR,Brazil - Brazilia,Peak,$12.21,$22.42
+GQ,Guam,CA10,Ontario,NonPeak,$10.83,$12.99
+GQ,Guam,CA10,Ontario,Peak,$12.78,$15.33
+GQ,Guam,CA20,Quebec,NonPeak,$11.35,$11.54
+GQ,Guam,CA20,Quebec,Peak,$13.39,$13.62
+GQ,Guam,CA30,Manitoba,NonPeak,$11.82,$16.89
+GQ,Guam,CA30,Manitoba,Peak,$13.95,$19.93
+GQ,Guam,CI,Chile,NonPeak,$8.88,$11.66
+GQ,Guam,CI,Chile,Peak,$10.48,$13.76
+GQ,Guam,CO,Colombia,NonPeak,$9.31,$10.16
+GQ,Guam,CO,Colombia,Peak,$10.99,$11.99
+GQ,Guam,CS,Costa Rica,NonPeak,$9.77,$16.98
+GQ,Guam,CS,Costa Rica,Peak,$11.53,$20.04
+GQ,Guam,EC,Ecuador,NonPeak,$10.21,$11.75
+GQ,Guam,EC,Ecuador,Peak,$12.05,$13.86
+GQ,Guam,ES,El Salvador,NonPeak,$10.65,$10.25
+GQ,Guam,ES,El Salvador,Peak,$12.57,$12.09
+GQ,Guam,GE,Germany,NonPeak,$10.35,$17.11
+GQ,Guam,GE,Germany,Peak,$12.21,$20.19
+GQ,Guam,GQ,Guam,NonPeak,$10.83,$11.86
+GQ,Guam,GQ,Guam,Peak,$12.78,$13.99
+GQ,Guam,GR,Greece,NonPeak,$11.35,$10.37
+GQ,Guam,GR,Greece,Peak,$13.39,$12.24
+GQ,Guam,GR29,Crete,NonPeak,$11.82,$17.17
+GQ,Guam,GR29,Crete,Peak,$13.95,$20.26
+GQ,Guam,GT,Guatemala,NonPeak,$8.88,$10.50
+GQ,Guam,GT,Guatemala,Peak,$10.48,$12.39
+GQ,Guam,HO,Honduras,NonPeak,$9.31,$17.59
+GQ,Guam,HO,Honduras,Peak,$10.99,$20.76
+GQ,Guam,HU,Hungary,NonPeak,$9.77,$12.03
+GQ,Guam,HU,Hungary,Peak,$11.53,$14.20
+GQ,Guam,IT,Italy,NonPeak,$10.21,$12.66
+GQ,Guam,IT,Italy,Peak,$12.05,$14.94
+GQ,Guam,IT10,Sicily,NonPeak,$10.65,$17.97
+GQ,Guam,IT10,Sicily,Peak,$12.57,$21.20
+GQ,Guam,JA01,Japan-Central,NonPeak,$10.35,$12.36
+GQ,Guam,JA01,Japan-Central,Peak,$12.21,$14.58
+GQ,Guam,JA02,Japan-South (Excludes Hokkaido),NonPeak,$10.83,$10.91
+GQ,Guam,JA02,Japan-South (Excludes Hokkaido),Peak,$12.78,$12.87
+GQ,Guam,JA03,Japan-North,NonPeak,$11.35,$18.51
+GQ,Guam,JA03,Japan-North,Peak,$13.39,$21.84
+GQ,Guam,JA96,Okinawa,NonPeak,$11.82,$12.70
+GQ,Guam,JA96,Okinawa,Peak,$13.95,$14.99
+GQ,Guam,KS,"Korea, Republic Of",NonPeak,$8.88,$11.24
+GQ,Guam,KS,"Korea, Republic Of",Peak,$10.48,$13.26
+GQ,Guam,KU,Kuwait,NonPeak,$9.31,$19.00
+GQ,Guam,KU,Kuwait,Peak,$10.99,$22.42
+GQ,Guam,NL,Netherlands,NonPeak,$9.77,$12.99
+GQ,Guam,NL,Netherlands,Peak,$11.53,$15.33
+GQ,Guam,NO,Norway,NonPeak,$10.21,$11.54
+GQ,Guam,NO,Norway,Peak,$12.05,$13.62
+GQ,Guam,PA,Paraguay,NonPeak,$10.65,$16.89
+GQ,Guam,PA,Paraguay,Peak,$12.57,$19.93
+GQ,Guam,PE,Peru,NonPeak,$10.35,$11.66
+GQ,Guam,PE,Peru,Peak,$12.21,$13.76
+GQ,Guam,PL,Poland,NonPeak,$10.83,$10.16
+GQ,Guam,PL,Poland,Peak,$12.78,$11.99
+GQ,Guam,PO,Portugal,NonPeak,$11.35,$16.98
+GQ,Guam,PO,Portugal,Peak,$13.39,$20.04
+GQ,Guam,PO01,Azores,NonPeak,$11.82,$11.75
+GQ,Guam,PO01,Azores,Peak,$13.95,$13.86
+GQ,Guam,QA,Qatar,NonPeak,$8.88,$10.25
+GQ,Guam,QA,Qatar,Peak,$10.48,$12.09
+GQ,Guam,RO,Romania,NonPeak,$9.31,$17.11
+GQ,Guam,RO,Romania,Peak,$10.99,$20.19
+GQ,Guam,RQ,Puerto Rico,NonPeak,$9.77,$11.86
+GQ,Guam,RQ,Puerto Rico,Peak,$11.53,$13.99
+GQ,Guam,SA,Saudi Arabia,NonPeak,$10.21,$10.37
+GQ,Guam,SA,Saudi Arabia,Peak,$12.05,$12.24
+GQ,Guam,SN,Singapore,NonPeak,$10.65,$17.17
+GQ,Guam,SN,Singapore,Peak,$12.57,$20.26
+GQ,Guam,SP,Spain,NonPeak,$10.35,$10.50
+GQ,Guam,SP,Spain,Peak,$12.21,$12.39
+GQ,Guam,TU,Turkey,NonPeak,$10.83,$17.59
+GQ,Guam,TU,Turkey,Peak,$12.78,$20.76
+GQ,Guam,UK,United Kingdom,NonPeak,$11.35,$12.03
+GQ,Guam,UK,United Kingdom,Peak,$13.39,$14.20
+GQ,Guam,US8030400,Alaska (Zone) IV,NonPeak,$11.82,$12.66
+GQ,Guam,US8030400,Alaska (Zone) IV,Peak,$13.95,$14.94
+GQ,Guam,US8050500,Alaska (Zone) III,NonPeak,$8.88,$17.97
+GQ,Guam,US8050500,Alaska (Zone) III,Peak,$10.48,$21.20
+GQ,Guam,US8101000,Alaska (Zone) I,NonPeak,$9.31,$12.36
+GQ,Guam,US8101000,Alaska (Zone) I,Peak,$10.99,$14.58
+GQ,Guam,US8190100,Alaska (Zone) II,NonPeak,$9.77,$10.91
+GQ,Guam,US8190100,Alaska (Zone) II,Peak,$11.53,$12.87
+GQ,Guam,US89,Hawaii,NonPeak,$10.21,$18.51
+GQ,Guam,US89,Hawaii,Peak,$12.05,$21.84
+GQ,Guam,UY,Uruguay,NonPeak,$10.65,$12.70
+GQ,Guam,UY,Uruguay,Peak,$12.57,$14.99
+GQ,Guam,VE,Venezuela,NonPeak,$10.35,$11.24
+GQ,Guam,VE,Venezuela,Peak,$12.21,$13.26
+GR,Greece,AR,Argentina,NonPeak,$10.83,$19.00
+GR,Greece,AR,Argentina,Peak,$12.78,$22.42
+GR,Greece,AS11,New South Wales/Australian Capital Territory,NonPeak,$11.35,$12.99
+GR,Greece,AS11,New South Wales/Australian Capital Territory,Peak,$13.39,$15.33
+GR,Greece,AS21,Northern Territory,NonPeak,$11.82,$11.54
+GR,Greece,AS21,Northern Territory,Peak,$13.95,$13.62
+GR,Greece,BA,Bahrain,NonPeak,$8.88,$16.89
+GR,Greece,BA,Bahrain,Peak,$10.48,$19.93
+GR,Greece,BE,Belgium,NonPeak,$9.31,$11.66
+GR,Greece,BE,Belgium,Peak,$10.99,$13.76
+GR,Greece,BL,Bolivia,NonPeak,$9.77,$10.16
+GR,Greece,BL,Bolivia,Peak,$11.53,$11.99
+GR,Greece,BR,Brazil - Brazilia,NonPeak,$10.21,$16.98
+GR,Greece,BR,Brazil - Brazilia,Peak,$12.05,$20.04
+GR,Greece,CA10,Ontario,NonPeak,$10.65,$11.75
+GR,Greece,CA10,Ontario,Peak,$12.57,$13.86
+GR,Greece,CA20,Quebec,NonPeak,$10.35,$10.25
+GR,Greece,CA20,Quebec,Peak,$12.21,$12.09
+GR,Greece,CA30,Manitoba,NonPeak,$10.83,$17.11
+GR,Greece,CA30,Manitoba,Peak,$12.78,$20.19
+GR,Greece,CI,Chile,NonPeak,$11.35,$11.86
+GR,Greece,CI,Chile,Peak,$13.39,$13.99
+GR,Greece,CO,Colombia,NonPeak,$11.82,$10.37
+GR,Greece,CO,Colombia,Peak,$13.95,$12.24
+GR,Greece,CS,Costa Rica,NonPeak,$8.88,$17.17
+GR,Greece,CS,Costa Rica,Peak,$10.48,$20.26
+GR,Greece,EC,Ecuador,NonPeak,$9.31,$10.50
+GR,Greece,EC,Ecuador,Peak,$10.99,$12.39
+GR,Greece,ES,El Salvador,NonPeak,$9.77,$17.59
+GR,Greece,ES,El Salvador,Peak,$11.53,$20.76
+GR,Greece,GE,Germany,NonPeak,$10.21,$12.03
+GR,Greece,GE,Germany,Peak,$12.05,$14.20
+GR,Greece,GQ,Guam,NonPeak,$10.65,$12.66
+GR,Greece,GQ,Guam,Peak,$12.57,$14.94
+GR,Greece,GR,Greece,NonPeak,$10.35,$17.97
+GR,Greece,GR,Greece,Peak,$12.21,$21.20
+GR,Greece,GR29,Crete,NonPeak,$10.83,$12.36
+GR,Greece,GR29,Crete,Peak,$12.78,$14.58
+GR,Greece,GT,Guatemala,NonPeak,$11.35,$10.91
+GR,Greece,GT,Guatemala,Peak,$13.39,$12.87
+GR,Greece,HO,Honduras,NonPeak,$11.82,$18.51
+GR,Greece,HO,Honduras,Peak,$13.95,$21.84
+GR,Greece,HU,Hungary,NonPeak,$8.88,$12.70
+GR,Greece,HU,Hungary,Peak,$10.48,$14.99
+GR,Greece,IT,Italy,NonPeak,$9.31,$11.24
+GR,Greece,IT,Italy,Peak,$10.99,$13.26
+GR,Greece,IT10,Sicily,NonPeak,$9.77,$19.00
+GR,Greece,IT10,Sicily,Peak,$11.53,$22.42
+GR,Greece,JA01,Japan-Central,NonPeak,$10.21,$12.99
+GR,Greece,JA01,Japan-Central,Peak,$12.05,$15.33
+GR,Greece,JA02,Japan-South (Excludes Hokkaido),NonPeak,$10.65,$11.54
+GR,Greece,JA02,Japan-South (Excludes Hokkaido),Peak,$12.57,$13.62
+GR,Greece,JA03,Japan-North,NonPeak,$10.35,$16.89
+GR,Greece,JA03,Japan-North,Peak,$12.21,$19.93
+GR,Greece,JA96,Okinawa,NonPeak,$10.83,$11.66
+GR,Greece,JA96,Okinawa,Peak,$12.78,$13.76
+GR,Greece,KS,"Korea, Republic Of",NonPeak,$11.35,$10.16
+GR,Greece,KS,"Korea, Republic Of",Peak,$13.39,$11.99
+GR,Greece,KU,Kuwait,NonPeak,$11.82,$16.98
+GR,Greece,KU,Kuwait,Peak,$13.95,$20.04
+GR,Greece,NL,Netherlands,NonPeak,$8.88,$11.75
+GR,Greece,NL,Netherlands,Peak,$10.48,$13.86
+GR,Greece,NO,Norway,NonPeak,$9.31,$10.25
+GR,Greece,NO,Norway,Peak,$10.99,$12.09
+GR,Greece,PA,Paraguay,NonPeak,$9.77,$17.11
+GR,Greece,PA,Paraguay,Peak,$11.53,$20.19
+GR,Greece,PE,Peru,NonPeak,$10.21,$11.86
+GR,Greece,PE,Peru,Peak,$12.05,$13.99
+GR,Greece,PL,Poland,NonPeak,$10.65,$10.37
+GR,Greece,PL,Poland,Peak,$12.57,$12.24
+GR,Greece,PO,Portugal,NonPeak,$10.35,$17.17
+GR,Greece,PO,Portugal,Peak,$12.21,$20.26
+GR,Greece,PO01,Azores,NonPeak,$10.83,$10.50
+GR,Greece,PO01,Azores,Peak,$12.78,$12.39
+GR,Greece,QA,Qatar,NonPeak,$11.35,$17.59
+GR,Greece,QA,Qatar,Peak,$13.39,$20.76
+GR,Greece,RO,Romania,NonPeak,$11.82,$12.03
+GR,Greece,RO,Romania,Peak,$13.95,$14.20
+GR,Greece,RQ,Puerto Rico,NonPeak,$8.88,$12.66
+GR,Greece,RQ,Puerto Rico,Peak,$10.48,$14.94
+GR,Greece,SA,Saudi Arabia,NonPeak,$9.31,$17.97
+GR,Greece,SA,Saudi Arabia,Peak,$10.99,$21.20
+GR,Greece,SN,Singapore,NonPeak,$9.77,$12.36
+GR,Greece,SN,Singapore,Peak,$11.53,$14.58
+GR,Greece,SP,Spain,NonPeak,$10.21,$10.91
+GR,Greece,SP,Spain,Peak,$12.05,$12.87
+GR,Greece,TU,Turkey,NonPeak,$10.65,$18.51
+GR,Greece,TU,Turkey,Peak,$12.57,$21.84
+GR,Greece,UK,United Kingdom,NonPeak,$10.35,$12.70
+GR,Greece,UK,United Kingdom,Peak,$12.21,$14.99
+GR,Greece,US8030400,Alaska (Zone) IV,NonPeak,$10.83,$11.24
+GR,Greece,US8030400,Alaska (Zone) IV,Peak,$12.78,$13.26
+GR,Greece,US8050500,Alaska (Zone) III,NonPeak,$11.35,$19.00
+GR,Greece,US8050500,Alaska (Zone) III,Peak,$13.39,$22.42
+GR,Greece,US8101000,Alaska (Zone) I,NonPeak,$11.82,$12.99
+GR,Greece,US8101000,Alaska (Zone) I,Peak,$13.95,$15.33
+GR,Greece,US8190100,Alaska (Zone) II,NonPeak,$8.88,$11.54
+GR,Greece,US8190100,Alaska (Zone) II,Peak,$10.48,$13.62
+GR,Greece,US89,Hawaii,NonPeak,$9.31,$16.89
+GR,Greece,US89,Hawaii,Peak,$10.99,$19.93
+GR,Greece,UY,Uruguay,NonPeak,$9.77,$11.66
+GR,Greece,UY,Uruguay,Peak,$11.53,$13.76
+GR,Greece,VE,Venezuela,NonPeak,$10.21,$10.16
+GR,Greece,VE,Venezuela,Peak,$12.05,$11.99
+GR29,Crete,AR,Argentina,NonPeak,$10.65,$16.98
+GR29,Crete,AR,Argentina,Peak,$12.57,$20.04
+GR29,Crete,AS11,New South Wales/Australian Capital Territory,NonPeak,$10.35,$11.75
+GR29,Crete,AS11,New South Wales/Australian Capital Territory,Peak,$12.21,$13.86
+GR29,Crete,AS21,Northern Territory,NonPeak,$10.83,$10.25
+GR29,Crete,AS21,Northern Territory,Peak,$12.78,$12.09
+GR29,Crete,BA,Bahrain,NonPeak,$11.35,$17.11
+GR29,Crete,BA,Bahrain,Peak,$13.39,$20.19
+GR29,Crete,BE,Belgium,NonPeak,$11.82,$11.86
+GR29,Crete,BE,Belgium,Peak,$13.95,$13.99
+GR29,Crete,BL,Bolivia,NonPeak,$8.88,$10.37
+GR29,Crete,BL,Bolivia,Peak,$10.48,$12.24
+GR29,Crete,BR,Brazil - Brazilia,NonPeak,$9.31,$17.17
+GR29,Crete,BR,Brazil - Brazilia,Peak,$10.99,$20.26
+GR29,Crete,CA10,Ontario,NonPeak,$9.77,$10.50
+GR29,Crete,CA10,Ontario,Peak,$11.53,$12.39
+GR29,Crete,CA20,Quebec,NonPeak,$10.21,$17.59
+GR29,Crete,CA20,Quebec,Peak,$12.05,$20.76
+GR29,Crete,CA30,Manitoba,NonPeak,$10.65,$12.03
+GR29,Crete,CA30,Manitoba,Peak,$12.57,$14.20
+GR29,Crete,CI,Chile,NonPeak,$10.35,$12.66
+GR29,Crete,CI,Chile,Peak,$12.21,$14.94
+GR29,Crete,CO,Colombia,NonPeak,$10.83,$17.97
+GR29,Crete,CO,Colombia,Peak,$12.78,$21.20
+GR29,Crete,CS,Costa Rica,NonPeak,$11.35,$12.36
+GR29,Crete,CS,Costa Rica,Peak,$13.39,$14.58
+GR29,Crete,EC,Ecuador,NonPeak,$11.82,$10.91
+GR29,Crete,EC,Ecuador,Peak,$13.95,$12.87
+GR29,Crete,ES,El Salvador,NonPeak,$8.88,$18.51
+GR29,Crete,ES,El Salvador,Peak,$10.48,$21.84
+GR29,Crete,GE,Germany,NonPeak,$9.31,$12.70
+GR29,Crete,GE,Germany,Peak,$10.99,$14.99
+GR29,Crete,GQ,Guam,NonPeak,$9.77,$11.24
+GR29,Crete,GQ,Guam,Peak,$11.53,$13.26
+GR29,Crete,GR,Greece,NonPeak,$10.21,$19.00
+GR29,Crete,GR,Greece,Peak,$12.05,$22.42
+GR29,Crete,GR29,Crete,NonPeak,$10.65,$12.99
+GR29,Crete,GR29,Crete,Peak,$12.57,$15.33
+GR29,Crete,GT,Guatemala,NonPeak,$10.35,$11.54
+GR29,Crete,GT,Guatemala,Peak,$12.21,$13.62
+GR29,Crete,HO,Honduras,NonPeak,$10.83,$16.89
+GR29,Crete,HO,Honduras,Peak,$12.78,$19.93
+GR29,Crete,HU,Hungary,NonPeak,$11.35,$11.66
+GR29,Crete,HU,Hungary,Peak,$13.39,$13.76
+GR29,Crete,IT,Italy,NonPeak,$11.82,$10.16
+GR29,Crete,IT,Italy,Peak,$13.95,$11.99
+GR29,Crete,IT10,Sicily,NonPeak,$8.88,$16.98
+GR29,Crete,IT10,Sicily,Peak,$10.48,$20.04
+GR29,Crete,JA01,Japan-Central,NonPeak,$9.31,$11.75
+GR29,Crete,JA01,Japan-Central,Peak,$10.99,$13.86
+GR29,Crete,JA02,Japan-South (Excludes Hokkaido),NonPeak,$9.77,$10.25
+GR29,Crete,JA02,Japan-South (Excludes Hokkaido),Peak,$11.53,$12.09
+GR29,Crete,JA03,Japan-North,NonPeak,$10.21,$17.11
+GR29,Crete,JA03,Japan-North,Peak,$12.05,$20.19
+GR29,Crete,JA96,Okinawa,NonPeak,$10.65,$11.86
+GR29,Crete,JA96,Okinawa,Peak,$12.57,$13.99
+GR29,Crete,KS,"Korea, Republic Of",NonPeak,$10.35,$10.37
+GR29,Crete,KS,"Korea, Republic Of",Peak,$12.21,$12.24
+GR29,Crete,KU,Kuwait,NonPeak,$10.83,$17.17
+GR29,Crete,KU,Kuwait,Peak,$12.78,$20.26
+GR29,Crete,NL,Netherlands,NonPeak,$11.35,$10.50
+GR29,Crete,NL,Netherlands,Peak,$13.39,$12.39
+GR29,Crete,NO,Norway,NonPeak,$11.82,$17.59
+GR29,Crete,NO,Norway,Peak,$13.95,$20.76
+GR29,Crete,PA,Paraguay,NonPeak,$8.88,$12.03
+GR29,Crete,PA,Paraguay,Peak,$10.48,$14.20
+GR29,Crete,PE,Peru,NonPeak,$9.31,$12.66
+GR29,Crete,PE,Peru,Peak,$10.99,$14.94
+GR29,Crete,PL,Poland,NonPeak,$9.77,$17.97
+GR29,Crete,PL,Poland,Peak,$11.53,$21.20
+GR29,Crete,PO,Portugal,NonPeak,$10.21,$12.36
+GR29,Crete,PO,Portugal,Peak,$12.05,$14.58
+GR29,Crete,PO01,Azores,NonPeak,$10.65,$10.91
+GR29,Crete,PO01,Azores,Peak,$12.57,$12.87
+GR29,Crete,QA,Qatar,NonPeak,$10.35,$18.51
+GR29,Crete,QA,Qatar,Peak,$12.21,$21.84
+GR29,Crete,RO,Romania,NonPeak,$10.83,$12.70
+GR29,Crete,RO,Romania,Peak,$12.78,$14.99
+GR29,Crete,RQ,Puerto Rico,NonPeak,$11.35,$11.24
+GR29,Crete,RQ,Puerto Rico,Peak,$13.39,$13.26
+GR29,Crete,SA,Saudi Arabia,NonPeak,$11.82,$19.00
+GR29,Crete,SA,Saudi Arabia,Peak,$13.95,$22.42
+GR29,Crete,SN,Singapore,NonPeak,$8.88,$12.99
+GR29,Crete,SN,Singapore,Peak,$10.48,$15.33
+GR29,Crete,SP,Spain,NonPeak,$9.31,$11.54
+GR29,Crete,SP,Spain,Peak,$10.99,$13.62
+GR29,Crete,TU,Turkey,NonPeak,$9.77,$16.89
+GR29,Crete,TU,Turkey,Peak,$11.53,$19.93
+GR29,Crete,UK,United Kingdom,NonPeak,$10.21,$11.66
+GR29,Crete,UK,United Kingdom,Peak,$12.05,$13.76
+GR29,Crete,US8030400,Alaska (Zone) IV,NonPeak,$10.65,$10.16
+GR29,Crete,US8030400,Alaska (Zone) IV,Peak,$12.57,$11.99
+GR29,Crete,US8050500,Alaska (Zone) III,NonPeak,$10.35,$16.98
+GR29,Crete,US8050500,Alaska (Zone) III,Peak,$12.21,$20.04
+GR29,Crete,US8101000,Alaska (Zone) I,NonPeak,$10.83,$11.75
+GR29,Crete,US8101000,Alaska (Zone) I,Peak,$12.78,$13.86
+GR29,Crete,US8190100,Alaska (Zone) II,NonPeak,$11.35,$10.25
+GR29,Crete,US8190100,Alaska (Zone) II,Peak,$13.39,$12.09
+GR29,Crete,US89,Hawaii,NonPeak,$11.82,$17.11
+GR29,Crete,US89,Hawaii,Peak,$13.95,$20.19
+GR29,Crete,UY,Uruguay,NonPeak,$8.88,$11.86
+GR29,Crete,UY,Uruguay,Peak,$10.48,$13.99
+GR29,Crete,VE,Venezuela,NonPeak,$9.31,$10.37
+GR29,Crete,VE,Venezuela,Peak,$10.99,$12.24
+GT,Guatemala,AR,Argentina,NonPeak,$9.77,$17.17
+GT,Guatemala,AR,Argentina,Peak,$11.53,$20.26
+GT,Guatemala,AS11,New South Wales/Australian Capital Territory,NonPeak,$10.21,$10.50
+GT,Guatemala,AS11,New South Wales/Australian Capital Territory,Peak,$12.05,$12.39
+GT,Guatemala,AS21,Northern Territory,NonPeak,$10.65,$17.59
+GT,Guatemala,AS21,Northern Territory,Peak,$12.57,$20.76
+GT,Guatemala,BA,Bahrain,NonPeak,$10.35,$12.03
+GT,Guatemala,BA,Bahrain,Peak,$12.21,$14.20
+GT,Guatemala,BE,Belgium,NonPeak,$10.35,$16.89
+GT,Guatemala,BE,Belgium,Peak,$12.21,$19.93
+GT,Guatemala,BL,Bolivia,NonPeak,$10.83,$11.66
+GT,Guatemala,BL,Bolivia,Peak,$12.78,$13.76
+GT,Guatemala,BR,Brazil - Brazilia,NonPeak,$11.35,$10.16
+GT,Guatemala,BR,Brazil - Brazilia,Peak,$13.39,$11.99
+GT,Guatemala,CA10,Ontario,NonPeak,$11.82,$16.98
+GT,Guatemala,CA10,Ontario,Peak,$13.95,$20.04
+GT,Guatemala,CA20,Quebec,NonPeak,$8.88,$11.75
+GT,Guatemala,CA20,Quebec,Peak,$10.48,$13.86
+GT,Guatemala,CA30,Manitoba,NonPeak,$9.31,$10.25
+GT,Guatemala,CA30,Manitoba,Peak,$10.99,$12.09
+GT,Guatemala,CI,Chile,NonPeak,$9.77,$17.11
+GT,Guatemala,CI,Chile,Peak,$11.53,$20.19
+GT,Guatemala,CO,Colombia,NonPeak,$10.21,$11.86
+GT,Guatemala,CO,Colombia,Peak,$12.05,$13.99
+GT,Guatemala,CS,Costa Rica,NonPeak,$10.65,$10.37
+GT,Guatemala,CS,Costa Rica,Peak,$12.57,$12.24
+GT,Guatemala,EC,Ecuador,NonPeak,$10.35,$17.17
+GT,Guatemala,EC,Ecuador,Peak,$12.21,$20.26
+GT,Guatemala,ES,El Salvador,NonPeak,$10.83,$10.50
+GT,Guatemala,ES,El Salvador,Peak,$12.78,$12.39
+GT,Guatemala,GE,Germany,NonPeak,$11.35,$17.59
+GT,Guatemala,GE,Germany,Peak,$13.39,$20.76
+GT,Guatemala,GQ,Guam,NonPeak,$11.82,$12.03
+GT,Guatemala,GQ,Guam,Peak,$13.95,$14.20
+GT,Guatemala,GR,Greece,NonPeak,$8.88,$12.66
+GT,Guatemala,GR,Greece,Peak,$10.48,$14.94
+GT,Guatemala,GR29,Crete,NonPeak,$9.31,$17.97
+GT,Guatemala,GR29,Crete,Peak,$10.99,$21.20
+GT,Guatemala,GT,Guatemala,NonPeak,$9.77,$12.36
+GT,Guatemala,GT,Guatemala,Peak,$11.53,$14.58
+GT,Guatemala,HO,Honduras,NonPeak,$10.21,$10.91
+GT,Guatemala,HO,Honduras,Peak,$12.05,$12.87
+GT,Guatemala,HU,Hungary,NonPeak,$10.65,$18.51
+GT,Guatemala,HU,Hungary,Peak,$12.57,$21.84
+GT,Guatemala,IT,Italy,NonPeak,$10.35,$12.70
+GT,Guatemala,IT,Italy,Peak,$12.21,$14.99
+GT,Guatemala,IT10,Sicily,NonPeak,$10.83,$11.24
+GT,Guatemala,IT10,Sicily,Peak,$12.78,$13.26
+GT,Guatemala,JA01,Japan-Central,NonPeak,$11.35,$19.00
+GT,Guatemala,JA01,Japan-Central,Peak,$13.39,$22.42
+GT,Guatemala,JA02,Japan-South (Excludes Hokkaido),NonPeak,$11.82,$12.99
+GT,Guatemala,JA02,Japan-South (Excludes Hokkaido),Peak,$13.95,$15.33
+GT,Guatemala,JA03,Japan-North,NonPeak,$8.88,$11.54
+GT,Guatemala,JA03,Japan-North,Peak,$10.48,$13.62
+GT,Guatemala,JA96,Okinawa,NonPeak,$9.31,$16.89
+GT,Guatemala,JA96,Okinawa,Peak,$10.99,$19.93
+GT,Guatemala,KS,"Korea, Republic Of",NonPeak,$9.77,$11.66
+GT,Guatemala,KS,"Korea, Republic Of",Peak,$11.53,$13.76
+GT,Guatemala,KU,Kuwait,NonPeak,$10.21,$10.16
+GT,Guatemala,KU,Kuwait,Peak,$12.05,$11.99
+GT,Guatemala,NL,Netherlands,NonPeak,$10.65,$16.98
+GT,Guatemala,NL,Netherlands,Peak,$12.57,$20.04
+GT,Guatemala,NO,Norway,NonPeak,$10.35,$11.75
+GT,Guatemala,NO,Norway,Peak,$12.21,$13.86
+GT,Guatemala,PA,Paraguay,NonPeak,$10.83,$10.25
+GT,Guatemala,PA,Paraguay,Peak,$12.78,$12.09
+GT,Guatemala,PE,Peru,NonPeak,$11.35,$17.11
+GT,Guatemala,PE,Peru,Peak,$13.39,$20.19
+GT,Guatemala,PL,Poland,NonPeak,$11.82,$11.86
+GT,Guatemala,PL,Poland,Peak,$13.95,$13.99
+GT,Guatemala,PO,Portugal,NonPeak,$8.88,$10.37
+GT,Guatemala,PO,Portugal,Peak,$10.48,$12.24
+GT,Guatemala,PO01,Azores,NonPeak,$9.31,$17.17
+GT,Guatemala,PO01,Azores,Peak,$10.99,$20.26
+GT,Guatemala,QA,Qatar,NonPeak,$9.77,$10.50
+GT,Guatemala,QA,Qatar,Peak,$11.53,$12.39
+GT,Guatemala,RO,Romania,NonPeak,$10.21,$17.59
+GT,Guatemala,RO,Romania,Peak,$12.05,$20.76
+GT,Guatemala,RQ,Puerto Rico,NonPeak,$10.65,$12.03
+GT,Guatemala,RQ,Puerto Rico,Peak,$12.57,$14.20
+GT,Guatemala,SA,Saudi Arabia,NonPeak,$10.35,$12.66
+GT,Guatemala,SA,Saudi Arabia,Peak,$12.21,$14.94
+GT,Guatemala,SN,Singapore,NonPeak,$10.83,$17.97
+GT,Guatemala,SN,Singapore,Peak,$12.78,$21.20
+GT,Guatemala,SP,Spain,NonPeak,$11.35,$12.36
+GT,Guatemala,SP,Spain,Peak,$13.39,$14.58
+GT,Guatemala,TU,Turkey,NonPeak,$11.82,$10.91
+GT,Guatemala,TU,Turkey,Peak,$13.95,$12.87
+GT,Guatemala,UK,United Kingdom,NonPeak,$8.88,$18.51
+GT,Guatemala,UK,United Kingdom,Peak,$10.48,$21.84
+GT,Guatemala,US8030400,Alaska (Zone) IV,NonPeak,$9.31,$12.70
+GT,Guatemala,US8030400,Alaska (Zone) IV,Peak,$10.99,$14.99
+GT,Guatemala,US8050500,Alaska (Zone) III,NonPeak,$9.77,$11.24
+GT,Guatemala,US8050500,Alaska (Zone) III,Peak,$11.53,$13.26
+GT,Guatemala,US8101000,Alaska (Zone) I,NonPeak,$10.21,$19.00
+GT,Guatemala,US8101000,Alaska (Zone) I,Peak,$12.05,$22.42
+GT,Guatemala,US8190100,Alaska (Zone) II,NonPeak,$10.65,$12.99
+GT,Guatemala,US8190100,Alaska (Zone) II,Peak,$12.57,$15.33
+GT,Guatemala,US89,Hawaii,NonPeak,$10.35,$11.54
+GT,Guatemala,US89,Hawaii,Peak,$12.21,$13.62
+GT,Guatemala,UY,Uruguay,NonPeak,$10.83,$16.89
+GT,Guatemala,UY,Uruguay,Peak,$12.78,$19.93
+GT,Guatemala,VE,Venezuela,NonPeak,$11.35,$11.66
+GT,Guatemala,VE,Venezuela,Peak,$13.39,$13.76
+HO,Honduras,AR,Argentina,NonPeak,$11.82,$10.16
+HO,Honduras,AR,Argentina,Peak,$13.95,$11.99
+HO,Honduras,AS11,New South Wales/Australian Capital Territory,NonPeak,$8.88,$16.98
+HO,Honduras,AS11,New South Wales/Australian Capital Territory,Peak,$10.48,$20.04
+HO,Honduras,AS21,Northern Territory,NonPeak,$9.31,$11.75
+HO,Honduras,AS21,Northern Territory,Peak,$10.99,$13.86
+HO,Honduras,BA,Bahrain,NonPeak,$9.77,$10.25
+HO,Honduras,BA,Bahrain,Peak,$11.53,$12.09
+HO,Honduras,BE,Belgium,NonPeak,$10.21,$17.11
+HO,Honduras,BE,Belgium,Peak,$12.05,$20.19
+HO,Honduras,BL,Bolivia,NonPeak,$10.65,$11.86
+HO,Honduras,BL,Bolivia,Peak,$12.57,$13.99
+HO,Honduras,BR,Brazil - Brazilia,NonPeak,$10.35,$10.37
+HO,Honduras,BR,Brazil - Brazilia,Peak,$12.21,$12.24
+HO,Honduras,CA10,Ontario,NonPeak,$10.83,$17.17
+HO,Honduras,CA10,Ontario,Peak,$12.78,$20.26
+HO,Honduras,CA20,Quebec,NonPeak,$11.35,$10.50
+HO,Honduras,CA20,Quebec,Peak,$13.39,$12.39
+HO,Honduras,CA30,Manitoba,NonPeak,$11.82,$17.59
+HO,Honduras,CA30,Manitoba,Peak,$13.95,$20.76
+HO,Honduras,CI,Chile,NonPeak,$8.88,$12.03
+HO,Honduras,CI,Chile,Peak,$10.48,$14.20
+HO,Honduras,CO,Colombia,NonPeak,$9.31,$12.66
+HO,Honduras,CO,Colombia,Peak,$10.99,$14.94
+HO,Honduras,CS,Costa Rica,NonPeak,$9.77,$17.97
+HO,Honduras,CS,Costa Rica,Peak,$11.53,$21.20
+HO,Honduras,EC,Ecuador,NonPeak,$10.21,$12.36
+HO,Honduras,EC,Ecuador,Peak,$12.05,$14.58
+HO,Honduras,ES,El Salvador,NonPeak,$10.65,$10.91
+HO,Honduras,ES,El Salvador,Peak,$12.57,$12.87
+HO,Honduras,GE,Germany,NonPeak,$10.35,$18.51
+HO,Honduras,GE,Germany,Peak,$12.21,$21.84
+HO,Honduras,GQ,Guam,NonPeak,$10.83,$12.70
+HO,Honduras,GQ,Guam,Peak,$12.78,$14.99
+HO,Honduras,GR,Greece,NonPeak,$11.35,$11.24
+HO,Honduras,GR,Greece,Peak,$13.39,$13.26
+HO,Honduras,GR29,Crete,NonPeak,$11.82,$19.00
+HO,Honduras,GR29,Crete,Peak,$13.95,$22.42
+HO,Honduras,GT,Guatemala,NonPeak,$8.88,$12.99
+HO,Honduras,GT,Guatemala,Peak,$10.48,$15.33
+HO,Honduras,HO,Honduras,NonPeak,$9.31,$11.54
+HO,Honduras,HO,Honduras,Peak,$10.99,$13.62
+HO,Honduras,HU,Hungary,NonPeak,$9.77,$16.89
+HO,Honduras,HU,Hungary,Peak,$11.53,$19.93
+HO,Honduras,IT,Italy,NonPeak,$10.21,$11.66
+HO,Honduras,IT,Italy,Peak,$12.05,$13.76
+HO,Honduras,IT10,Sicily,NonPeak,$10.65,$10.16
+HO,Honduras,IT10,Sicily,Peak,$12.57,$11.99
+HO,Honduras,JA01,Japan-Central,NonPeak,$10.35,$16.98
+HO,Honduras,JA01,Japan-Central,Peak,$12.21,$20.04
+HO,Honduras,JA02,Japan-South (Excludes Hokkaido),NonPeak,$10.83,$11.75
+HO,Honduras,JA02,Japan-South (Excludes Hokkaido),Peak,$12.78,$13.86
+HO,Honduras,JA03,Japan-North,NonPeak,$11.35,$10.25
+HO,Honduras,JA03,Japan-North,Peak,$13.39,$12.09
+HO,Honduras,JA96,Okinawa,NonPeak,$11.82,$17.11
+HO,Honduras,JA96,Okinawa,Peak,$13.95,$20.19
+HO,Honduras,KS,"Korea, Republic Of",NonPeak,$8.88,$11.86
+HO,Honduras,KS,"Korea, Republic Of",Peak,$10.48,$13.99
+HO,Honduras,KU,Kuwait,NonPeak,$9.31,$10.37
+HO,Honduras,KU,Kuwait,Peak,$10.99,$12.24
+HO,Honduras,NL,Netherlands,NonPeak,$9.77,$17.17
+HO,Honduras,NL,Netherlands,Peak,$11.53,$20.26
+HO,Honduras,NO,Norway,NonPeak,$10.21,$10.50
+HO,Honduras,NO,Norway,Peak,$12.05,$12.39
+HO,Honduras,PA,Paraguay,NonPeak,$10.65,$17.59
+HO,Honduras,PA,Paraguay,Peak,$12.57,$20.76
+HO,Honduras,PE,Peru,NonPeak,$10.35,$12.03
+HO,Honduras,PE,Peru,Peak,$12.21,$14.20
+HO,Honduras,PL,Poland,NonPeak,$10.83,$12.66
+HO,Honduras,PL,Poland,Peak,$12.78,$14.94
+HO,Honduras,PO,Portugal,NonPeak,$11.35,$17.97
+HO,Honduras,PO,Portugal,Peak,$13.39,$21.20
+HO,Honduras,PO01,Azores,NonPeak,$11.82,$12.36
+HO,Honduras,PO01,Azores,Peak,$13.95,$14.58
+HO,Honduras,QA,Qatar,NonPeak,$8.88,$10.91
+HO,Honduras,QA,Qatar,Peak,$10.48,$12.87
+HO,Honduras,RO,Romania,NonPeak,$9.31,$18.51
+HO,Honduras,RO,Romania,Peak,$10.99,$21.84
+HO,Honduras,RQ,Puerto Rico,NonPeak,$9.77,$12.70
+HO,Honduras,RQ,Puerto Rico,Peak,$11.53,$14.99
+HO,Honduras,SA,Saudi Arabia,NonPeak,$10.21,$11.24
+HO,Honduras,SA,Saudi Arabia,Peak,$12.05,$13.26
+HO,Honduras,SN,Singapore,NonPeak,$10.65,$19.00
+HO,Honduras,SN,Singapore,Peak,$12.57,$22.42
+HO,Honduras,SP,Spain,NonPeak,$10.35,$12.99
+HO,Honduras,SP,Spain,Peak,$12.21,$15.33
+HO,Honduras,TU,Turkey,NonPeak,$10.83,$11.54
+HO,Honduras,TU,Turkey,Peak,$12.78,$13.62
+HO,Honduras,UK,United Kingdom,NonPeak,$11.35,$16.89
+HO,Honduras,UK,United Kingdom,Peak,$13.39,$19.93
+HO,Honduras,US8030400,Alaska (Zone) IV,NonPeak,$11.82,$11.66
+HO,Honduras,US8030400,Alaska (Zone) IV,Peak,$13.95,$13.76
+HO,Honduras,US8050500,Alaska (Zone) III,NonPeak,$8.88,$10.16
+HO,Honduras,US8050500,Alaska (Zone) III,Peak,$10.48,$11.99
+HO,Honduras,US8101000,Alaska (Zone) I,NonPeak,$9.31,$16.98
+HO,Honduras,US8101000,Alaska (Zone) I,Peak,$10.99,$20.04
+HO,Honduras,US8190100,Alaska (Zone) II,NonPeak,$9.77,$11.75
+HO,Honduras,US8190100,Alaska (Zone) II,Peak,$11.53,$13.86
+HO,Honduras,US89,Hawaii,NonPeak,$10.21,$10.25
+HO,Honduras,US89,Hawaii,Peak,$12.05,$12.09
+HO,Honduras,UY,Uruguay,NonPeak,$10.65,$17.11
+HO,Honduras,UY,Uruguay,Peak,$12.57,$20.19
+HO,Honduras,VE,Venezuela,NonPeak,$10.35,$11.86
+HO,Honduras,VE,Venezuela,Peak,$12.21,$13.99
+HU,Hungary,AR,Argentina,NonPeak,$10.83,$10.37
+HU,Hungary,AR,Argentina,Peak,$12.78,$12.24
+HU,Hungary,AS11,New South Wales/Australian Capital Territory,NonPeak,$11.35,$17.17
+HU,Hungary,AS11,New South Wales/Australian Capital Territory,Peak,$13.39,$20.26
+HU,Hungary,AS21,Northern Territory,NonPeak,$11.82,$10.50
+HU,Hungary,AS21,Northern Territory,Peak,$13.95,$12.39
+HU,Hungary,BA,Bahrain,NonPeak,$8.88,$17.59
+HU,Hungary,BA,Bahrain,Peak,$10.48,$20.76
+HU,Hungary,BE,Belgium,NonPeak,$9.31,$12.03
+HU,Hungary,BE,Belgium,Peak,$10.99,$14.20
+HU,Hungary,BL,Bolivia,NonPeak,$9.77,$12.66
+HU,Hungary,BL,Bolivia,Peak,$11.53,$14.94
+HU,Hungary,BR,Brazil - Brazilia,NonPeak,$10.21,$17.97
+HU,Hungary,BR,Brazil - Brazilia,Peak,$12.05,$21.20
+HU,Hungary,CA10,Ontario,NonPeak,$10.65,$12.36
+HU,Hungary,CA10,Ontario,Peak,$12.57,$14.58
+HU,Hungary,CA20,Quebec,NonPeak,$10.35,$10.91
+HU,Hungary,CA20,Quebec,Peak,$12.21,$12.87
+HU,Hungary,CA30,Manitoba,NonPeak,$10.83,$18.51
+HU,Hungary,CA30,Manitoba,Peak,$12.78,$21.84
+HU,Hungary,CI,Chile,NonPeak,$11.35,$12.70
+HU,Hungary,CI,Chile,Peak,$13.39,$14.99
+HU,Hungary,CO,Colombia,NonPeak,$11.82,$11.24
+HU,Hungary,CO,Colombia,Peak,$13.95,$13.26
+HU,Hungary,CS,Costa Rica,NonPeak,$8.88,$19.00
+HU,Hungary,CS,Costa Rica,Peak,$10.48,$22.42
+HU,Hungary,EC,Ecuador,NonPeak,$9.31,$12.99
+HU,Hungary,EC,Ecuador,Peak,$10.99,$15.33
+HU,Hungary,ES,El Salvador,NonPeak,$9.77,$11.54
+HU,Hungary,ES,El Salvador,Peak,$11.53,$13.62
+HU,Hungary,GE,Germany,NonPeak,$10.21,$16.89
+HU,Hungary,GE,Germany,Peak,$12.05,$19.93
+HU,Hungary,GQ,Guam,NonPeak,$10.65,$11.66
+HU,Hungary,GQ,Guam,Peak,$12.57,$13.76
+HU,Hungary,GR,Greece,NonPeak,$10.35,$10.16
+HU,Hungary,GR,Greece,Peak,$12.21,$11.99
+HU,Hungary,GR29,Crete,NonPeak,$10.83,$16.98
+HU,Hungary,GR29,Crete,Peak,$12.78,$20.04
+HU,Hungary,GT,Guatemala,NonPeak,$11.35,$11.75
+HU,Hungary,GT,Guatemala,Peak,$13.39,$13.86
+HU,Hungary,HO,Honduras,NonPeak,$11.82,$10.25
+HU,Hungary,HO,Honduras,Peak,$13.95,$12.09
+HU,Hungary,HU,Hungary,NonPeak,$8.88,$17.11
+HU,Hungary,HU,Hungary,Peak,$10.48,$20.19
+HU,Hungary,IT,Italy,NonPeak,$9.31,$11.86
+HU,Hungary,IT,Italy,Peak,$10.99,$13.99
+HU,Hungary,IT10,Sicily,NonPeak,$9.77,$10.37
+HU,Hungary,IT10,Sicily,Peak,$11.53,$12.24
+HU,Hungary,JA01,Japan-Central,NonPeak,$10.21,$17.17
+HU,Hungary,JA01,Japan-Central,Peak,$12.05,$20.26
+HU,Hungary,JA02,Japan-South (Excludes Hokkaido),NonPeak,$10.65,$10.50
+HU,Hungary,JA02,Japan-South (Excludes Hokkaido),Peak,$12.57,$12.39
+HU,Hungary,JA03,Japan-North,NonPeak,$10.35,$17.59
+HU,Hungary,JA03,Japan-North,Peak,$12.21,$20.76
+HU,Hungary,JA96,Okinawa,NonPeak,$10.83,$12.03
+HU,Hungary,JA96,Okinawa,Peak,$12.78,$14.20
+HU,Hungary,KS,"Korea, Republic Of",NonPeak,$11.35,$12.66
+HU,Hungary,KS,"Korea, Republic Of",Peak,$13.39,$14.94
+HU,Hungary,KU,Kuwait,NonPeak,$11.82,$17.97
+HU,Hungary,KU,Kuwait,Peak,$13.95,$21.20
+HU,Hungary,NL,Netherlands,NonPeak,$8.88,$12.36
+HU,Hungary,NL,Netherlands,Peak,$10.48,$14.58
+HU,Hungary,NO,Norway,NonPeak,$9.31,$10.91
+HU,Hungary,NO,Norway,Peak,$10.99,$12.87
+HU,Hungary,PA,Paraguay,NonPeak,$9.77,$18.51
+HU,Hungary,PA,Paraguay,Peak,$11.53,$21.84
+HU,Hungary,PE,Peru,NonPeak,$10.21,$12.70
+HU,Hungary,PE,Peru,Peak,$12.05,$14.99
+HU,Hungary,PL,Poland,NonPeak,$10.65,$11.24
+HU,Hungary,PL,Poland,Peak,$12.57,$13.26
+HU,Hungary,PO,Portugal,NonPeak,$10.35,$19.00
+HU,Hungary,PO,Portugal,Peak,$12.21,$22.42
+HU,Hungary,PO01,Azores,NonPeak,$10.83,$12.99
+HU,Hungary,PO01,Azores,Peak,$12.78,$15.33
+HU,Hungary,QA,Qatar,NonPeak,$11.35,$11.54
+HU,Hungary,QA,Qatar,Peak,$13.39,$13.62
+HU,Hungary,RO,Romania,NonPeak,$11.82,$16.89
+HU,Hungary,RO,Romania,Peak,$13.95,$19.93
+HU,Hungary,RQ,Puerto Rico,NonPeak,$8.88,$11.66
+HU,Hungary,RQ,Puerto Rico,Peak,$10.48,$13.76
+HU,Hungary,SA,Saudi Arabia,NonPeak,$9.31,$10.16
+HU,Hungary,SA,Saudi Arabia,Peak,$10.99,$11.99
+HU,Hungary,SN,Singapore,NonPeak,$9.77,$16.98
+HU,Hungary,SN,Singapore,Peak,$11.53,$20.04
+HU,Hungary,SP,Spain,NonPeak,$10.21,$11.75
+HU,Hungary,SP,Spain,Peak,$12.05,$13.86
+HU,Hungary,TU,Turkey,NonPeak,$10.65,$10.25
+HU,Hungary,TU,Turkey,Peak,$12.57,$12.09
+HU,Hungary,UK,United Kingdom,NonPeak,$10.35,$17.11
+HU,Hungary,UK,United Kingdom,Peak,$12.21,$20.19
+HU,Hungary,US8030400,Alaska (Zone) IV,NonPeak,$10.83,$11.86
+HU,Hungary,US8030400,Alaska (Zone) IV,Peak,$12.78,$13.99
+HU,Hungary,US8050500,Alaska (Zone) III,NonPeak,$11.35,$10.37
+HU,Hungary,US8050500,Alaska (Zone) III,Peak,$13.39,$12.24
+HU,Hungary,US8101000,Alaska (Zone) I,NonPeak,$11.82,$17.17
+HU,Hungary,US8101000,Alaska (Zone) I,Peak,$13.95,$20.26
+HU,Hungary,US8190100,Alaska (Zone) II,NonPeak,$8.88,$10.50
+HU,Hungary,US8190100,Alaska (Zone) II,Peak,$10.48,$12.39
+HU,Hungary,US89,Hawaii,NonPeak,$9.31,$17.59
+HU,Hungary,US89,Hawaii,Peak,$10.99,$20.76
+HU,Hungary,UY,Uruguay,NonPeak,$9.77,$12.03
+HU,Hungary,UY,Uruguay,Peak,$11.53,$14.20
+HU,Hungary,VE,Venezuela,NonPeak,$10.21,$12.66
+HU,Hungary,VE,Venezuela,Peak,$12.05,$14.94
+IT,Italy,AR,Argentina,NonPeak,$10.65,$17.97
+IT,Italy,AR,Argentina,Peak,$12.57,$21.20
+IT,Italy,AS11,New South Wales/Australian Capital Territory,NonPeak,$10.35,$12.36
+IT,Italy,AS11,New South Wales/Australian Capital Territory,Peak,$12.21,$14.58
+IT,Italy,AS21,Northern Territory,NonPeak,$10.83,$10.91
+IT,Italy,AS21,Northern Territory,Peak,$12.78,$12.87
+IT,Italy,BA,Bahrain,NonPeak,$11.35,$18.51
+IT,Italy,BA,Bahrain,Peak,$13.39,$21.84
+IT,Italy,BE,Belgium,NonPeak,$11.82,$12.70
+IT,Italy,BE,Belgium,Peak,$13.95,$14.99
+IT,Italy,BL,Bolivia,NonPeak,$8.88,$11.24
+IT,Italy,BL,Bolivia,Peak,$10.48,$13.26
+IT,Italy,BR,Brazil - Brazilia,NonPeak,$9.31,$19.00
+IT,Italy,BR,Brazil - Brazilia,Peak,$10.99,$22.42
+IT,Italy,CA10,Ontario,NonPeak,$9.77,$12.99
+IT,Italy,CA10,Ontario,Peak,$11.53,$15.33
+IT,Italy,CA20,Quebec,NonPeak,$10.21,$11.54
+IT,Italy,CA20,Quebec,Peak,$12.05,$13.62
+IT,Italy,CA30,Manitoba,NonPeak,$10.65,$16.89
+IT,Italy,CA30,Manitoba,Peak,$12.57,$19.93
+IT,Italy,CI,Chile,NonPeak,$10.35,$11.66
+IT,Italy,CI,Chile,Peak,$12.21,$13.76
+IT,Italy,CO,Colombia,NonPeak,$10.83,$10.16
+IT,Italy,CO,Colombia,Peak,$12.78,$11.99
+IT,Italy,CS,Costa Rica,NonPeak,$11.35,$16.98
+IT,Italy,CS,Costa Rica,Peak,$13.39,$20.04
+IT,Italy,EC,Ecuador,NonPeak,$11.82,$11.75
+IT,Italy,EC,Ecuador,Peak,$13.95,$13.86
+IT,Italy,ES,El Salvador,NonPeak,$8.88,$10.25
+IT,Italy,ES,El Salvador,Peak,$10.48,$12.09
+IT,Italy,GE,Germany,NonPeak,$9.31,$17.11
+IT,Italy,GE,Germany,Peak,$10.99,$20.19
+IT,Italy,GQ,Guam,NonPeak,$9.77,$11.86
+IT,Italy,GQ,Guam,Peak,$11.53,$13.99
+IT,Italy,GR,Greece,NonPeak,$10.21,$10.37
+IT,Italy,GR,Greece,Peak,$12.05,$12.24
+IT,Italy,GR29,Crete,NonPeak,$10.65,$17.17
+IT,Italy,GR29,Crete,Peak,$12.57,$20.26
+IT,Italy,GT,Guatemala,NonPeak,$10.35,$10.50
+IT,Italy,GT,Guatemala,Peak,$12.21,$12.39
+IT,Italy,HO,Honduras,NonPeak,$10.83,$17.59
+IT,Italy,HO,Honduras,Peak,$12.78,$20.76
+IT,Italy,HU,Hungary,NonPeak,$11.35,$12.03
+IT,Italy,HU,Hungary,Peak,$13.39,$14.20
+IT,Italy,IT,Italy,NonPeak,$11.82,$12.66
+IT,Italy,IT,Italy,Peak,$13.95,$14.94
+IT,Italy,IT10,Sicily,NonPeak,$8.88,$17.97
+IT,Italy,IT10,Sicily,Peak,$10.48,$21.20
+IT,Italy,JA01,Japan-Central,NonPeak,$9.31,$12.36
+IT,Italy,JA01,Japan-Central,Peak,$10.99,$14.58
+IT,Italy,JA02,Japan-South (Excludes Hokkaido),NonPeak,$9.77,$10.91
+IT,Italy,JA02,Japan-South (Excludes Hokkaido),Peak,$11.53,$12.87
+IT,Italy,JA03,Japan-North,NonPeak,$10.21,$18.51
+IT,Italy,JA03,Japan-North,Peak,$12.05,$21.84
+IT,Italy,JA96,Okinawa,NonPeak,$10.65,$12.70
+IT,Italy,JA96,Okinawa,Peak,$12.57,$14.99
+IT,Italy,KS,"Korea, Republic Of",NonPeak,$10.35,$11.24
+IT,Italy,KS,"Korea, Republic Of",Peak,$12.21,$13.26
+IT,Italy,KU,Kuwait,NonPeak,$10.83,$19.00
+IT,Italy,KU,Kuwait,Peak,$12.78,$22.42
+IT,Italy,NL,Netherlands,NonPeak,$11.35,$12.99
+IT,Italy,NL,Netherlands,Peak,$13.39,$15.33
+IT,Italy,NO,Norway,NonPeak,$11.82,$11.54
+IT,Italy,NO,Norway,Peak,$13.95,$13.62
+IT,Italy,PA,Paraguay,NonPeak,$8.88,$16.89
+IT,Italy,PA,Paraguay,Peak,$10.48,$19.93
+IT,Italy,PE,Peru,NonPeak,$9.31,$11.66
+IT,Italy,PE,Peru,Peak,$10.99,$13.76
+IT,Italy,PL,Poland,NonPeak,$9.77,$10.16
+IT,Italy,PL,Poland,Peak,$11.53,$11.99
+IT,Italy,PO,Portugal,NonPeak,$10.21,$16.98
+IT,Italy,PO,Portugal,Peak,$12.05,$20.04
+IT,Italy,PO01,Azores,NonPeak,$10.65,$11.75
+IT,Italy,PO01,Azores,Peak,$12.57,$13.86
+IT,Italy,QA,Qatar,NonPeak,$10.35,$10.25
+IT,Italy,QA,Qatar,Peak,$12.21,$12.09
+IT,Italy,RO,Romania,NonPeak,$10.83,$17.11
+IT,Italy,RO,Romania,Peak,$12.78,$20.19
+IT,Italy,RQ,Puerto Rico,NonPeak,$11.35,$11.86
+IT,Italy,RQ,Puerto Rico,Peak,$13.39,$13.99
+IT,Italy,SA,Saudi Arabia,NonPeak,$11.82,$10.37
+IT,Italy,SA,Saudi Arabia,Peak,$13.95,$12.24
+IT,Italy,SN,Singapore,NonPeak,$8.88,$17.17
+IT,Italy,SN,Singapore,Peak,$10.48,$20.26
+IT,Italy,SP,Spain,NonPeak,$9.31,$10.50
+IT,Italy,SP,Spain,Peak,$10.99,$12.39
+IT,Italy,TU,Turkey,NonPeak,$9.77,$17.59
+IT,Italy,TU,Turkey,Peak,$11.53,$20.76
+IT,Italy,UK,United Kingdom,NonPeak,$10.21,$12.03
+IT,Italy,UK,United Kingdom,Peak,$12.05,$14.20
+IT,Italy,US8030400,Alaska (Zone) IV,NonPeak,$10.65,$12.66
+IT,Italy,US8030400,Alaska (Zone) IV,Peak,$12.57,$14.94
+IT,Italy,US8050500,Alaska (Zone) III,NonPeak,$10.35,$17.97
+IT,Italy,US8050500,Alaska (Zone) III,Peak,$12.21,$21.20
+IT,Italy,US8101000,Alaska (Zone) I,NonPeak,$10.83,$12.36
+IT,Italy,US8101000,Alaska (Zone) I,Peak,$12.78,$14.58
+IT,Italy,US8190100,Alaska (Zone) II,NonPeak,$11.35,$10.91
+IT,Italy,US8190100,Alaska (Zone) II,Peak,$13.39,$12.87
+IT,Italy,US89,Hawaii,NonPeak,$11.82,$18.51
+IT,Italy,US89,Hawaii,Peak,$13.95,$21.84
+IT,Italy,UY,Uruguay,NonPeak,$8.88,$12.70
+IT,Italy,UY,Uruguay,Peak,$10.48,$14.99
+IT,Italy,VE,Venezuela,NonPeak,$9.31,$11.24
+IT,Italy,VE,Venezuela,Peak,$10.99,$13.26
+IT10,Sicily,AR,Argentina,NonPeak,$9.77,$19.00
+IT10,Sicily,AR,Argentina,Peak,$11.53,$22.42
+IT10,Sicily,AS11,New South Wales/Australian Capital Territory,NonPeak,$10.21,$12.99
+IT10,Sicily,AS11,New South Wales/Australian Capital Territory,Peak,$12.05,$15.33
+IT10,Sicily,AS21,Northern Territory,NonPeak,$10.65,$11.54
+IT10,Sicily,AS21,Northern Territory,Peak,$12.57,$13.62
+IT10,Sicily,BA,Bahrain,NonPeak,$10.35,$16.89
+IT10,Sicily,BA,Bahrain,Peak,$12.21,$19.93
+IT10,Sicily,BE,Belgium,NonPeak,$10.83,$11.66
+IT10,Sicily,BE,Belgium,Peak,$12.78,$13.76
+IT10,Sicily,BL,Bolivia,NonPeak,$11.35,$10.16
+IT10,Sicily,BL,Bolivia,Peak,$13.39,$11.99
+IT10,Sicily,BR,Brazil - Brazilia,NonPeak,$11.82,$16.98
+IT10,Sicily,BR,Brazil - Brazilia,Peak,$13.95,$20.04
+IT10,Sicily,CA10,Ontario,NonPeak,$8.88,$11.75
+IT10,Sicily,CA10,Ontario,Peak,$10.48,$13.86
+IT10,Sicily,CA20,Quebec,NonPeak,$9.31,$10.25
+IT10,Sicily,CA20,Quebec,Peak,$10.99,$12.09
+IT10,Sicily,CA30,Manitoba,NonPeak,$9.77,$17.11
+IT10,Sicily,CA30,Manitoba,Peak,$11.53,$20.19
+IT10,Sicily,CI,Chile,NonPeak,$10.21,$11.86
+IT10,Sicily,CI,Chile,Peak,$12.05,$13.99
+IT10,Sicily,CO,Colombia,NonPeak,$10.65,$10.37
+IT10,Sicily,CO,Colombia,Peak,$12.57,$12.24
+IT10,Sicily,CS,Costa Rica,NonPeak,$10.35,$17.17
+IT10,Sicily,CS,Costa Rica,Peak,$12.21,$20.26
+IT10,Sicily,EC,Ecuador,NonPeak,$10.83,$10.50
+IT10,Sicily,EC,Ecuador,Peak,$12.78,$12.39
+IT10,Sicily,ES,El Salvador,NonPeak,$11.35,$17.59
+IT10,Sicily,ES,El Salvador,Peak,$13.39,$20.76
+IT10,Sicily,GE,Germany,NonPeak,$11.82,$12.03
+IT10,Sicily,GE,Germany,Peak,$13.95,$14.20
+IT10,Sicily,GQ,Guam,NonPeak,$8.88,$12.66
+IT10,Sicily,GQ,Guam,Peak,$10.48,$14.94
+IT10,Sicily,GR,Greece,NonPeak,$9.31,$17.97
+IT10,Sicily,GR,Greece,Peak,$10.99,$21.20
+IT10,Sicily,GR29,Crete,NonPeak,$9.77,$12.36
+IT10,Sicily,GR29,Crete,Peak,$11.53,$14.58
+IT10,Sicily,GT,Guatemala,NonPeak,$10.21,$10.91
+IT10,Sicily,GT,Guatemala,Peak,$12.05,$12.87
+IT10,Sicily,HO,Honduras,NonPeak,$10.65,$18.51
+IT10,Sicily,HO,Honduras,Peak,$12.57,$21.84
+IT10,Sicily,HU,Hungary,NonPeak,$10.35,$12.70
+IT10,Sicily,HU,Hungary,Peak,$12.21,$14.99
+IT10,Sicily,IT,Italy,NonPeak,$10.83,$11.24
+IT10,Sicily,IT,Italy,Peak,$12.78,$13.26
+IT10,Sicily,IT10,Sicily,NonPeak,$11.35,$19.00
+IT10,Sicily,IT10,Sicily,Peak,$13.39,$22.42
+IT10,Sicily,JA01,Japan-Central,NonPeak,$11.82,$12.99
+IT10,Sicily,JA01,Japan-Central,Peak,$13.95,$15.33
+IT10,Sicily,JA02,Japan-South (Excludes Hokkaido),NonPeak,$8.88,$11.54
+IT10,Sicily,JA02,Japan-South (Excludes Hokkaido),Peak,$10.48,$13.62
+IT10,Sicily,JA03,Japan-North,NonPeak,$9.31,$16.89
+IT10,Sicily,JA03,Japan-North,Peak,$10.99,$19.93
+IT10,Sicily,JA96,Okinawa,NonPeak,$9.77,$11.66
+IT10,Sicily,JA96,Okinawa,Peak,$11.53,$13.76
+IT10,Sicily,KS,"Korea, Republic Of",NonPeak,$10.21,$10.16
+IT10,Sicily,KS,"Korea, Republic Of",Peak,$12.05,$11.99
+IT10,Sicily,KU,Kuwait,NonPeak,$10.65,$16.98
+IT10,Sicily,KU,Kuwait,Peak,$12.57,$20.04
+IT10,Sicily,NL,Netherlands,NonPeak,$10.35,$11.75
+IT10,Sicily,NL,Netherlands,Peak,$12.21,$13.86
+IT10,Sicily,NO,Norway,NonPeak,$10.83,$10.25
+IT10,Sicily,NO,Norway,Peak,$12.78,$12.09
+IT10,Sicily,PA,Paraguay,NonPeak,$11.35,$17.11
+IT10,Sicily,PA,Paraguay,Peak,$13.39,$20.19
+IT10,Sicily,PE,Peru,NonPeak,$11.82,$11.86
+IT10,Sicily,PE,Peru,Peak,$13.95,$13.99
+IT10,Sicily,PL,Poland,NonPeak,$8.88,$10.37
+IT10,Sicily,PL,Poland,Peak,$10.48,$12.24
+IT10,Sicily,PO,Portugal,NonPeak,$9.31,$17.17
+IT10,Sicily,PO,Portugal,Peak,$10.99,$20.26
+IT10,Sicily,PO01,Azores,NonPeak,$9.77,$10.50
+IT10,Sicily,PO01,Azores,Peak,$11.53,$12.39
+IT10,Sicily,QA,Qatar,NonPeak,$10.21,$17.59
+IT10,Sicily,QA,Qatar,Peak,$12.05,$20.76
+IT10,Sicily,RO,Romania,NonPeak,$10.65,$12.03
+IT10,Sicily,RO,Romania,Peak,$12.57,$14.20
+IT10,Sicily,RQ,Puerto Rico,NonPeak,$10.35,$12.66
+IT10,Sicily,RQ,Puerto Rico,Peak,$12.21,$14.94
+IT10,Sicily,SA,Saudi Arabia,NonPeak,$10.83,$17.97
+IT10,Sicily,SA,Saudi Arabia,Peak,$12.78,$21.20
+IT10,Sicily,SN,Singapore,NonPeak,$11.35,$12.36
+IT10,Sicily,SN,Singapore,Peak,$13.39,$14.58
+IT10,Sicily,SP,Spain,NonPeak,$11.82,$10.91
+IT10,Sicily,SP,Spain,Peak,$13.95,$12.87
+IT10,Sicily,TU,Turkey,NonPeak,$8.88,$18.51
+IT10,Sicily,TU,Turkey,Peak,$10.48,$21.84
+IT10,Sicily,UK,United Kingdom,NonPeak,$9.31,$12.70
+IT10,Sicily,UK,United Kingdom,Peak,$10.99,$14.99
+IT10,Sicily,US8030400,Alaska (Zone) IV,NonPeak,$9.77,$11.24
+IT10,Sicily,US8030400,Alaska (Zone) IV,Peak,$11.53,$13.26
+IT10,Sicily,US8050500,Alaska (Zone) III,NonPeak,$10.21,$19.00
+IT10,Sicily,US8050500,Alaska (Zone) III,Peak,$12.05,$22.42
+IT10,Sicily,US8101000,Alaska (Zone) I,NonPeak,$10.65,$12.99
+IT10,Sicily,US8101000,Alaska (Zone) I,Peak,$12.57,$15.33
+IT10,Sicily,US8190100,Alaska (Zone) II,NonPeak,$10.35,$11.54
+IT10,Sicily,US8190100,Alaska (Zone) II,Peak,$12.21,$13.62
+IT10,Sicily,US89,Hawaii,NonPeak,$10.83,$16.89
+IT10,Sicily,US89,Hawaii,Peak,$12.78,$19.93
+IT10,Sicily,UY,Uruguay,NonPeak,$11.35,$11.66
+IT10,Sicily,UY,Uruguay,Peak,$13.39,$13.76
+IT10,Sicily,VE,Venezuela,NonPeak,$11.82,$10.16
+IT10,Sicily,VE,Venezuela,Peak,$13.95,$11.99
+JA01,Japan-Central,AR,Argentina,NonPeak,$8.88,$16.98
+JA01,Japan-Central,AR,Argentina,Peak,$10.48,$20.04
+JA01,Japan-Central,AS11,New South Wales/Australian Capital Territory,NonPeak,$9.31,$11.75
+JA01,Japan-Central,AS11,New South Wales/Australian Capital Territory,Peak,$10.99,$13.86
+JA01,Japan-Central,AS21,Northern Territory,NonPeak,$9.77,$10.25
+JA01,Japan-Central,AS21,Northern Territory,Peak,$11.53,$12.09
+JA01,Japan-Central,BA,Bahrain,NonPeak,$10.21,$17.11
+JA01,Japan-Central,BA,Bahrain,Peak,$12.05,$20.19
+JA01,Japan-Central,BE,Belgium,NonPeak,$10.65,$11.86
+JA01,Japan-Central,BE,Belgium,Peak,$12.57,$13.99
+JA01,Japan-Central,BL,Bolivia,NonPeak,$10.35,$10.37
+JA01,Japan-Central,BL,Bolivia,Peak,$12.21,$12.24
+JA01,Japan-Central,BR,Brazil - Brazilia,NonPeak,$10.83,$17.17
+JA01,Japan-Central,BR,Brazil - Brazilia,Peak,$12.78,$20.26
+JA01,Japan-Central,CA10,Ontario,NonPeak,$11.35,$10.50
+JA01,Japan-Central,CA10,Ontario,Peak,$13.39,$12.39
+JA01,Japan-Central,CA20,Quebec,NonPeak,$11.82,$17.59
+JA01,Japan-Central,CA20,Quebec,Peak,$13.95,$20.76
+JA01,Japan-Central,CA30,Manitoba,NonPeak,$8.88,$12.03
+JA01,Japan-Central,CA30,Manitoba,Peak,$10.48,$14.20
+JA01,Japan-Central,CI,Chile,NonPeak,$9.31,$12.66
+JA01,Japan-Central,CI,Chile,Peak,$10.99,$14.94
+JA01,Japan-Central,CO,Colombia,NonPeak,$9.77,$17.97
+JA01,Japan-Central,CO,Colombia,Peak,$11.53,$21.20
+JA01,Japan-Central,CS,Costa Rica,NonPeak,$10.21,$12.36
+JA01,Japan-Central,CS,Costa Rica,Peak,$12.05,$14.58
+JA01,Japan-Central,EC,Ecuador,NonPeak,$10.65,$10.91
+JA01,Japan-Central,EC,Ecuador,Peak,$12.57,$12.87
+JA01,Japan-Central,ES,El Salvador,NonPeak,$10.35,$18.51
+JA01,Japan-Central,ES,El Salvador,Peak,$12.21,$21.84
+JA01,Japan-Central,GE,Germany,NonPeak,$10.83,$12.70
+JA01,Japan-Central,GE,Germany,Peak,$12.78,$14.99
+JA01,Japan-Central,GQ,Guam,NonPeak,$11.35,$11.24
+JA01,Japan-Central,GQ,Guam,Peak,$13.39,$13.26
+JA01,Japan-Central,GR,Greece,NonPeak,$11.82,$19.00
+JA01,Japan-Central,GR,Greece,Peak,$13.95,$22.42
+JA01,Japan-Central,GR29,Crete,NonPeak,$8.88,$12.99
+JA01,Japan-Central,GR29,Crete,Peak,$10.48,$15.33
+JA01,Japan-Central,GT,Guatemala,NonPeak,$9.31,$11.54
+JA01,Japan-Central,GT,Guatemala,Peak,$10.99,$13.62
+JA01,Japan-Central,HO,Honduras,NonPeak,$9.77,$16.89
+JA01,Japan-Central,HO,Honduras,Peak,$11.53,$19.93
+JA01,Japan-Central,HU,Hungary,NonPeak,$10.21,$11.66
+JA01,Japan-Central,HU,Hungary,Peak,$12.05,$13.76
+JA01,Japan-Central,IT,Italy,NonPeak,$10.65,$10.16
+JA01,Japan-Central,IT,Italy,Peak,$12.57,$11.99
+JA01,Japan-Central,IT10,Sicily,NonPeak,$10.35,$16.98
+JA01,Japan-Central,IT10,Sicily,Peak,$12.21,$20.04
+JA01,Japan-Central,JA01,Japan-Central,NonPeak,$10.83,$11.75
+JA01,Japan-Central,JA01,Japan-Central,Peak,$12.78,$13.86
+JA01,Japan-Central,JA02,Japan-South (Excludes Hokkaido),NonPeak,$11.35,$10.25
+JA01,Japan-Central,JA02,Japan-South (Excludes Hokkaido),Peak,$13.39,$12.09
+JA01,Japan-Central,JA03,Japan-North,NonPeak,$11.82,$17.11
+JA01,Japan-Central,JA03,Japan-North,Peak,$13.95,$20.19
+JA01,Japan-Central,JA96,Okinawa,NonPeak,$8.88,$11.86
+JA01,Japan-Central,JA96,Okinawa,Peak,$10.48,$13.99
+JA01,Japan-Central,KS,"Korea, Republic Of",NonPeak,$9.31,$10.37
+JA01,Japan-Central,KS,"Korea, Republic Of",Peak,$10.99,$12.24
+JA01,Japan-Central,KU,Kuwait,NonPeak,$9.77,$17.17
+JA01,Japan-Central,KU,Kuwait,Peak,$11.53,$20.26
+JA01,Japan-Central,NL,Netherlands,NonPeak,$10.21,$10.50
+JA01,Japan-Central,NL,Netherlands,Peak,$12.05,$12.39
+JA01,Japan-Central,NO,Norway,NonPeak,$10.65,$17.59
+JA01,Japan-Central,NO,Norway,Peak,$12.57,$20.76
+JA01,Japan-Central,PA,Paraguay,NonPeak,$10.35,$12.03
+JA01,Japan-Central,PA,Paraguay,Peak,$12.21,$14.20
+JA01,Japan-Central,PE,Peru,NonPeak,$10.83,$12.66
+JA01,Japan-Central,PE,Peru,Peak,$12.78,$14.94
+JA01,Japan-Central,PL,Poland,NonPeak,$11.35,$17.97
+JA01,Japan-Central,PL,Poland,Peak,$13.39,$21.20
+JA01,Japan-Central,PO,Portugal,NonPeak,$11.82,$12.36
+JA01,Japan-Central,PO,Portugal,Peak,$13.95,$14.58
+JA01,Japan-Central,PO01,Azores,NonPeak,$8.88,$10.91
+JA01,Japan-Central,PO01,Azores,Peak,$10.48,$12.87
+JA01,Japan-Central,QA,Qatar,NonPeak,$9.31,$18.51
+JA01,Japan-Central,QA,Qatar,Peak,$10.99,$21.84
+JA01,Japan-Central,RO,Romania,NonPeak,$9.77,$12.70
+JA01,Japan-Central,RO,Romania,Peak,$11.53,$14.99
+JA01,Japan-Central,RQ,Puerto Rico,NonPeak,$10.21,$11.24
+JA01,Japan-Central,RQ,Puerto Rico,Peak,$12.05,$13.26
+JA01,Japan-Central,SA,Saudi Arabia,NonPeak,$10.65,$19.00
+JA01,Japan-Central,SA,Saudi Arabia,Peak,$12.57,$22.42
+JA01,Japan-Central,SN,Singapore,NonPeak,$10.35,$12.99
+JA01,Japan-Central,SN,Singapore,Peak,$12.21,$15.33
+JA01,Japan-Central,SP,Spain,NonPeak,$10.83,$11.54
+JA01,Japan-Central,SP,Spain,Peak,$12.78,$13.62
+JA01,Japan-Central,TU,Turkey,NonPeak,$11.35,$16.89
+JA01,Japan-Central,TU,Turkey,Peak,$13.39,$19.93
+JA01,Japan-Central,UK,United Kingdom,NonPeak,$11.82,$11.66
+JA01,Japan-Central,UK,United Kingdom,Peak,$13.95,$13.76
+JA01,Japan-Central,US8030400,Alaska (Zone) IV,NonPeak,$8.88,$10.16
+JA01,Japan-Central,US8030400,Alaska (Zone) IV,Peak,$10.48,$11.99
+JA01,Japan-Central,US8050500,Alaska (Zone) III,NonPeak,$9.31,$16.98
+JA01,Japan-Central,US8050500,Alaska (Zone) III,Peak,$10.99,$20.04
+JA01,Japan-Central,US8101000,Alaska (Zone) I,NonPeak,$9.77,$11.75
+JA01,Japan-Central,US8101000,Alaska (Zone) I,Peak,$11.53,$13.86
+JA01,Japan-Central,US8190100,Alaska (Zone) II,NonPeak,$10.21,$10.25
+JA01,Japan-Central,US8190100,Alaska (Zone) II,Peak,$12.05,$12.09
+JA01,Japan-Central,US89,Hawaii,NonPeak,$10.65,$17.11
+JA01,Japan-Central,US89,Hawaii,Peak,$12.57,$20.19
+JA01,Japan-Central,UY,Uruguay,NonPeak,$10.35,$11.86
+JA01,Japan-Central,UY,Uruguay,Peak,$12.21,$13.99
+JA01,Japan-Central,VE,Venezuela,NonPeak,$10.83,$10.37
+JA01,Japan-Central,VE,Venezuela,Peak,$12.78,$12.24
+JA02,Japan-South (Excludes Hokkaido),AR,Argentina,NonPeak,$11.35,$17.17
+JA02,Japan-South (Excludes Hokkaido),AR,Argentina,Peak,$13.39,$20.26
+JA02,Japan-South (Excludes Hokkaido),AS11,New South Wales/Australian Capital Territory,NonPeak,$11.82,$10.50
+JA02,Japan-South (Excludes Hokkaido),AS11,New South Wales/Australian Capital Territory,Peak,$13.95,$12.39
+JA02,Japan-South (Excludes Hokkaido),AS21,Northern Territory,NonPeak,$8.88,$17.59
+JA02,Japan-South (Excludes Hokkaido),AS21,Northern Territory,Peak,$10.48,$20.76
+JA02,Japan-South (Excludes Hokkaido),BA,Bahrain,NonPeak,$9.31,$12.03
+JA02,Japan-South (Excludes Hokkaido),BA,Bahrain,Peak,$10.99,$14.20
+JA02,Japan-South (Excludes Hokkaido),BE,Belgium,NonPeak,$9.77,$12.66
+JA02,Japan-South (Excludes Hokkaido),BE,Belgium,Peak,$11.53,$14.94
+JA02,Japan-South (Excludes Hokkaido),BL,Bolivia,NonPeak,$10.21,$17.97
+JA02,Japan-South (Excludes Hokkaido),BL,Bolivia,Peak,$12.05,$21.20
+JA02,Japan-South (Excludes Hokkaido),BR,Brazil - Brazilia,NonPeak,$10.65,$12.36
+JA02,Japan-South (Excludes Hokkaido),BR,Brazil - Brazilia,Peak,$12.57,$14.58
+JA02,Japan-South (Excludes Hokkaido),CA10,Ontario,NonPeak,$10.35,$10.91
+JA02,Japan-South (Excludes Hokkaido),CA10,Ontario,Peak,$12.21,$12.87
+JA02,Japan-South (Excludes Hokkaido),CA20,Quebec,NonPeak,$10.83,$18.51
+JA02,Japan-South (Excludes Hokkaido),CA20,Quebec,Peak,$12.78,$21.84
+JA02,Japan-South (Excludes Hokkaido),CA30,Manitoba,NonPeak,$11.35,$12.70
+JA02,Japan-South (Excludes Hokkaido),CA30,Manitoba,Peak,$13.39,$14.99
+JA02,Japan-South (Excludes Hokkaido),CI,Chile,NonPeak,$11.82,$11.24
+JA02,Japan-South (Excludes Hokkaido),CI,Chile,Peak,$13.95,$13.26
+JA02,Japan-South (Excludes Hokkaido),CO,Colombia,NonPeak,$8.88,$19.00
+JA02,Japan-South (Excludes Hokkaido),CO,Colombia,Peak,$10.48,$22.42
+JA02,Japan-South (Excludes Hokkaido),CS,Costa Rica,NonPeak,$9.31,$12.99
+JA02,Japan-South (Excludes Hokkaido),CS,Costa Rica,Peak,$10.99,$15.33
+JA02,Japan-South (Excludes Hokkaido),EC,Ecuador,NonPeak,$9.77,$11.54
+JA02,Japan-South (Excludes Hokkaido),EC,Ecuador,Peak,$11.53,$13.62
+JA02,Japan-South (Excludes Hokkaido),ES,El Salvador,NonPeak,$10.21,$16.89
+JA02,Japan-South (Excludes Hokkaido),ES,El Salvador,Peak,$12.05,$19.93
+JA02,Japan-South (Excludes Hokkaido),GE,Germany,NonPeak,$10.65,$11.66
+JA02,Japan-South (Excludes Hokkaido),GE,Germany,Peak,$12.57,$13.76
+JA02,Japan-South (Excludes Hokkaido),GQ,Guam,NonPeak,$10.35,$10.16
+JA02,Japan-South (Excludes Hokkaido),GQ,Guam,Peak,$12.21,$11.99
+JA02,Japan-South (Excludes Hokkaido),GR,Greece,NonPeak,$10.83,$16.98
+JA02,Japan-South (Excludes Hokkaido),GR,Greece,Peak,$12.78,$20.04
+JA02,Japan-South (Excludes Hokkaido),GR29,Crete,NonPeak,$11.35,$11.75
+JA02,Japan-South (Excludes Hokkaido),GR29,Crete,Peak,$13.39,$13.86
+JA02,Japan-South (Excludes Hokkaido),GT,Guatemala,NonPeak,$11.82,$10.25
+JA02,Japan-South (Excludes Hokkaido),GT,Guatemala,Peak,$13.95,$12.09
+JA02,Japan-South (Excludes Hokkaido),HO,Honduras,NonPeak,$8.88,$17.11
+JA02,Japan-South (Excludes Hokkaido),HO,Honduras,Peak,$10.48,$20.19
+JA02,Japan-South (Excludes Hokkaido),HU,Hungary,NonPeak,$9.31,$11.86
+JA02,Japan-South (Excludes Hokkaido),HU,Hungary,Peak,$10.99,$13.99
+JA02,Japan-South (Excludes Hokkaido),IT,Italy,NonPeak,$9.77,$10.37
+JA02,Japan-South (Excludes Hokkaido),IT,Italy,Peak,$11.53,$12.24
+JA02,Japan-South (Excludes Hokkaido),IT10,Sicily,NonPeak,$10.21,$17.17
+JA02,Japan-South (Excludes Hokkaido),IT10,Sicily,Peak,$12.05,$20.26
+JA02,Japan-South (Excludes Hokkaido),JA01,Japan-Central,NonPeak,$10.65,$10.50
+JA02,Japan-South (Excludes Hokkaido),JA01,Japan-Central,Peak,$12.57,$12.39
+JA02,Japan-South (Excludes Hokkaido),JA02,Japan-South (Excludes Hokkaido),NonPeak,$10.35,$17.59
+JA02,Japan-South (Excludes Hokkaido),JA02,Japan-South (Excludes Hokkaido),Peak,$12.21,$20.76
+JA02,Japan-South (Excludes Hokkaido),JA03,Japan-North,NonPeak,$10.83,$12.03
+JA02,Japan-South (Excludes Hokkaido),JA03,Japan-North,Peak,$12.78,$14.20
+JA02,Japan-South (Excludes Hokkaido),JA96,Okinawa,NonPeak,$11.35,$12.66
+JA02,Japan-South (Excludes Hokkaido),JA96,Okinawa,Peak,$13.39,$14.94
+JA02,Japan-South (Excludes Hokkaido),KS,"Korea, Republic Of",NonPeak,$11.82,$17.97
+JA02,Japan-South (Excludes Hokkaido),KS,"Korea, Republic Of",Peak,$13.95,$21.20
+JA02,Japan-South (Excludes Hokkaido),KU,Kuwait,NonPeak,$8.88,$12.36
+JA02,Japan-South (Excludes Hokkaido),KU,Kuwait,Peak,$10.48,$14.58
+JA02,Japan-South (Excludes Hokkaido),NL,Netherlands,NonPeak,$9.31,$10.91
+JA02,Japan-South (Excludes Hokkaido),NL,Netherlands,Peak,$10.99,$12.87
+JA02,Japan-South (Excludes Hokkaido),NO,Norway,NonPeak,$9.77,$18.51
+JA02,Japan-South (Excludes Hokkaido),NO,Norway,Peak,$11.53,$21.84
+JA02,Japan-South (Excludes Hokkaido),PA,Paraguay,NonPeak,$10.21,$12.70
+JA02,Japan-South (Excludes Hokkaido),PA,Paraguay,Peak,$12.05,$14.99
+JA02,Japan-South (Excludes Hokkaido),PE,Peru,NonPeak,$10.65,$11.24
+JA02,Japan-South (Excludes Hokkaido),PE,Peru,Peak,$12.57,$13.26
+JA02,Japan-South (Excludes Hokkaido),PL,Poland,NonPeak,$10.35,$19.00
+JA02,Japan-South (Excludes Hokkaido),PL,Poland,Peak,$12.21,$22.42
+JA02,Japan-South (Excludes Hokkaido),PO,Portugal,NonPeak,$10.83,$12.99
+JA02,Japan-South (Excludes Hokkaido),PO,Portugal,Peak,$12.78,$15.33
+JA02,Japan-South (Excludes Hokkaido),PO01,Azores,NonPeak,$11.35,$11.54
+JA02,Japan-South (Excludes Hokkaido),PO01,Azores,Peak,$13.39,$13.62
+JA02,Japan-South (Excludes Hokkaido),QA,Qatar,NonPeak,$11.82,$16.89
+JA02,Japan-South (Excludes Hokkaido),QA,Qatar,Peak,$13.95,$19.93
+JA02,Japan-South (Excludes Hokkaido),RO,Romania,NonPeak,$8.88,$11.66
+JA02,Japan-South (Excludes Hokkaido),RO,Romania,Peak,$10.48,$13.76
+JA02,Japan-South (Excludes Hokkaido),RQ,Puerto Rico,NonPeak,$9.31,$10.16
+JA02,Japan-South (Excludes Hokkaido),RQ,Puerto Rico,Peak,$10.99,$11.99
+JA02,Japan-South (Excludes Hokkaido),SA,Saudi Arabia,NonPeak,$9.77,$16.98
+JA02,Japan-South (Excludes Hokkaido),SA,Saudi Arabia,Peak,$11.53,$20.04
+JA02,Japan-South (Excludes Hokkaido),SN,Singapore,NonPeak,$10.21,$11.75
+JA02,Japan-South (Excludes Hokkaido),SN,Singapore,Peak,$12.05,$13.86
+JA02,Japan-South (Excludes Hokkaido),SP,Spain,NonPeak,$10.65,$10.25
+JA02,Japan-South (Excludes Hokkaido),SP,Spain,Peak,$12.57,$12.09
+JA02,Japan-South (Excludes Hokkaido),TU,Turkey,NonPeak,$10.35,$17.11
+JA02,Japan-South (Excludes Hokkaido),TU,Turkey,Peak,$12.21,$20.19
+JA02,Japan-South (Excludes Hokkaido),UK,United Kingdom,NonPeak,$10.83,$11.86
+JA02,Japan-South (Excludes Hokkaido),UK,United Kingdom,Peak,$12.78,$13.99
+JA02,Japan-South (Excludes Hokkaido),US8030400,Alaska (Zone) IV,NonPeak,$11.35,$10.37
+JA02,Japan-South (Excludes Hokkaido),US8030400,Alaska (Zone) IV,Peak,$13.39,$12.24
+JA02,Japan-South (Excludes Hokkaido),US8050500,Alaska (Zone) III,NonPeak,$11.82,$17.17
+JA02,Japan-South (Excludes Hokkaido),US8050500,Alaska (Zone) III,Peak,$13.95,$20.26
+JA02,Japan-South (Excludes Hokkaido),US8101000,Alaska (Zone) I,NonPeak,$8.88,$10.50
+JA02,Japan-South (Excludes Hokkaido),US8101000,Alaska (Zone) I,Peak,$10.48,$12.39
+JA02,Japan-South (Excludes Hokkaido),US8190100,Alaska (Zone) II,NonPeak,$9.31,$17.59
+JA02,Japan-South (Excludes Hokkaido),US8190100,Alaska (Zone) II,Peak,$10.99,$20.76
+JA02,Japan-South (Excludes Hokkaido),US89,Hawaii,NonPeak,$9.77,$12.03
+JA02,Japan-South (Excludes Hokkaido),US89,Hawaii,Peak,$11.53,$14.20
+JA02,Japan-South (Excludes Hokkaido),UY,Uruguay,NonPeak,$10.21,$12.66
+JA02,Japan-South (Excludes Hokkaido),UY,Uruguay,Peak,$12.05,$14.94
+JA02,Japan-South (Excludes Hokkaido),VE,Venezuela,NonPeak,$10.65,$17.97
+JA02,Japan-South (Excludes Hokkaido),VE,Venezuela,Peak,$12.57,$21.20
+JA03,Japan-North,AR,Argentina,NonPeak,$10.35,$12.36
+JA03,Japan-North,AR,Argentina,Peak,$12.21,$14.58
+JA03,Japan-North,AS11,New South Wales/Australian Capital Territory,NonPeak,$10.83,$10.91
+JA03,Japan-North,AS11,New South Wales/Australian Capital Territory,Peak,$12.78,$12.87
+JA03,Japan-North,AS21,Northern Territory,NonPeak,$11.35,$18.51
+JA03,Japan-North,AS21,Northern Territory,Peak,$13.39,$21.84
+JA03,Japan-North,BA,Bahrain,NonPeak,$11.82,$12.70
+JA03,Japan-North,BA,Bahrain,Peak,$13.95,$14.99
+JA03,Japan-North,BE,Belgium,NonPeak,$8.88,$11.24
+JA03,Japan-North,BE,Belgium,Peak,$10.48,$13.26
+JA03,Japan-North,BL,Bolivia,NonPeak,$9.31,$19.00
+JA03,Japan-North,BL,Bolivia,Peak,$10.99,$22.42
+JA03,Japan-North,BR,Brazil - Brazilia,NonPeak,$9.77,$12.99
+JA03,Japan-North,BR,Brazil - Brazilia,Peak,$11.53,$15.33
+JA03,Japan-North,CA10,Ontario,NonPeak,$10.21,$11.54
+JA03,Japan-North,CA10,Ontario,Peak,$12.05,$13.62
+JA03,Japan-North,CA20,Quebec,NonPeak,$10.65,$16.89
+JA03,Japan-North,CA20,Quebec,Peak,$12.57,$19.93
+JA03,Japan-North,CA30,Manitoba,NonPeak,$10.35,$11.66
+JA03,Japan-North,CA30,Manitoba,Peak,$12.21,$13.76
+JA03,Japan-North,CI,Chile,NonPeak,$10.83,$10.16
+JA03,Japan-North,CI,Chile,Peak,$12.78,$11.99
+JA03,Japan-North,CO,Colombia,NonPeak,$11.35,$16.98
+JA03,Japan-North,CO,Colombia,Peak,$13.39,$20.04
+JA03,Japan-North,CS,Costa Rica,NonPeak,$11.82,$11.75
+JA03,Japan-North,CS,Costa Rica,Peak,$13.95,$13.86
+JA03,Japan-North,EC,Ecuador,NonPeak,$8.88,$10.25
+JA03,Japan-North,EC,Ecuador,Peak,$10.48,$12.09
+JA03,Japan-North,ES,El Salvador,NonPeak,$9.31,$17.11
+JA03,Japan-North,ES,El Salvador,Peak,$10.99,$20.19
+JA03,Japan-North,GE,Germany,NonPeak,$9.77,$11.86
+JA03,Japan-North,GE,Germany,Peak,$11.53,$13.99
+JA03,Japan-North,GQ,Guam,NonPeak,$10.21,$10.37
+JA03,Japan-North,GQ,Guam,Peak,$12.05,$12.24
+JA03,Japan-North,GR,Greece,NonPeak,$10.65,$17.17
+JA03,Japan-North,GR,Greece,Peak,$12.57,$20.26
+JA03,Japan-North,GR29,Crete,NonPeak,$10.35,$10.50
+JA03,Japan-North,GR29,Crete,Peak,$12.21,$12.39
+JA03,Japan-North,GT,Guatemala,NonPeak,$10.83,$17.59
+JA03,Japan-North,GT,Guatemala,Peak,$12.78,$20.76
+JA03,Japan-North,HO,Honduras,NonPeak,$11.35,$12.03
+JA03,Japan-North,HO,Honduras,Peak,$13.39,$14.20
+JA03,Japan-North,HU,Hungary,NonPeak,$11.82,$12.66
+JA03,Japan-North,HU,Hungary,Peak,$13.95,$14.94
+JA03,Japan-North,IT,Italy,NonPeak,$8.88,$17.97
+JA03,Japan-North,IT,Italy,Peak,$10.48,$21.20
+JA03,Japan-North,IT10,Sicily,NonPeak,$9.31,$12.36
+JA03,Japan-North,IT10,Sicily,Peak,$10.99,$14.58
+JA03,Japan-North,JA01,Japan-Central,NonPeak,$9.77,$10.91
+JA03,Japan-North,JA01,Japan-Central,Peak,$11.53,$12.87
+JA03,Japan-North,JA02,Japan-South (Excludes Hokkaido),NonPeak,$10.21,$18.51
+JA03,Japan-North,JA02,Japan-South (Excludes Hokkaido),Peak,$12.05,$21.84
+JA03,Japan-North,JA03,Japan-North,NonPeak,$10.65,$12.70
+JA03,Japan-North,JA03,Japan-North,Peak,$12.57,$14.99
+JA03,Japan-North,JA96,Okinawa,NonPeak,$10.35,$11.24
+JA03,Japan-North,JA96,Okinawa,Peak,$12.21,$13.26
+JA03,Japan-North,KS,"Korea, Republic Of",NonPeak,$10.83,$19.00
+JA03,Japan-North,KS,"Korea, Republic Of",Peak,$12.78,$22.42
+JA03,Japan-North,KU,Kuwait,NonPeak,$11.35,$12.99
+JA03,Japan-North,KU,Kuwait,Peak,$13.39,$15.33
+JA03,Japan-North,NL,Netherlands,NonPeak,$11.82,$11.54
+JA03,Japan-North,NL,Netherlands,Peak,$13.95,$13.62
+JA03,Japan-North,NO,Norway,NonPeak,$8.88,$16.89
+JA03,Japan-North,NO,Norway,Peak,$10.48,$19.93
+JA03,Japan-North,PA,Paraguay,NonPeak,$9.31,$11.66
+JA03,Japan-North,PA,Paraguay,Peak,$10.99,$13.76
+JA03,Japan-North,PE,Peru,NonPeak,$9.77,$10.16
+JA03,Japan-North,PE,Peru,Peak,$11.53,$11.99
+JA03,Japan-North,PL,Poland,NonPeak,$10.21,$16.98
+JA03,Japan-North,PL,Poland,Peak,$12.05,$20.04
+JA03,Japan-North,PO,Portugal,NonPeak,$10.65,$11.75
+JA03,Japan-North,PO,Portugal,Peak,$12.57,$13.86
+JA03,Japan-North,PO01,Azores,NonPeak,$10.35,$10.25
+JA03,Japan-North,PO01,Azores,Peak,$12.21,$12.09
+JA03,Japan-North,QA,Qatar,NonPeak,$10.83,$17.11
+JA03,Japan-North,QA,Qatar,Peak,$12.78,$20.19
+JA03,Japan-North,RO,Romania,NonPeak,$11.35,$11.86
+JA03,Japan-North,RO,Romania,Peak,$13.39,$13.99
+JA03,Japan-North,RQ,Puerto Rico,NonPeak,$11.82,$10.37
+JA03,Japan-North,RQ,Puerto Rico,Peak,$13.95,$12.24
+JA03,Japan-North,SA,Saudi Arabia,NonPeak,$8.88,$17.17
+JA03,Japan-North,SA,Saudi Arabia,Peak,$10.48,$20.26
+JA03,Japan-North,SN,Singapore,NonPeak,$9.31,$10.50
+JA03,Japan-North,SN,Singapore,Peak,$10.99,$12.39
+JA03,Japan-North,SP,Spain,NonPeak,$9.77,$17.59
+JA03,Japan-North,SP,Spain,Peak,$11.53,$20.76
+JA03,Japan-North,TU,Turkey,NonPeak,$10.21,$12.03
+JA03,Japan-North,TU,Turkey,Peak,$12.05,$14.20
+JA03,Japan-North,UK,United Kingdom,NonPeak,$10.65,$12.66
+JA03,Japan-North,UK,United Kingdom,Peak,$12.57,$14.94
+JA03,Japan-North,US8030400,Alaska (Zone) IV,NonPeak,$10.35,$17.97
+JA03,Japan-North,US8030400,Alaska (Zone) IV,Peak,$12.21,$21.20
+JA03,Japan-North,US8050500,Alaska (Zone) III,NonPeak,$10.83,$12.36
+JA03,Japan-North,US8050500,Alaska (Zone) III,Peak,$12.78,$14.58
+JA03,Japan-North,US8101000,Alaska (Zone) I,NonPeak,$11.35,$10.91
+JA03,Japan-North,US8101000,Alaska (Zone) I,Peak,$13.39,$12.87
+JA03,Japan-North,US8190100,Alaska (Zone) II,NonPeak,$11.82,$18.51
+JA03,Japan-North,US8190100,Alaska (Zone) II,Peak,$13.95,$21.84
+JA03,Japan-North,US89,Hawaii,NonPeak,$8.88,$12.70
+JA03,Japan-North,US89,Hawaii,Peak,$10.48,$14.99
+JA03,Japan-North,UY,Uruguay,NonPeak,$9.31,$11.24
+JA03,Japan-North,UY,Uruguay,Peak,$10.99,$13.26
+JA03,Japan-North,VE,Venezuela,NonPeak,$9.77,$19.00
+JA03,Japan-North,VE,Venezuela,Peak,$11.53,$22.42
+JA96,Okinawa,AR,Argentina,NonPeak,$10.21,$12.99
+JA96,Okinawa,AR,Argentina,Peak,$12.05,$15.33
+JA96,Okinawa,AS11,New South Wales/Australian Capital Territory,NonPeak,$10.65,$11.54
+JA96,Okinawa,AS11,New South Wales/Australian Capital Territory,Peak,$12.57,$13.62
+JA96,Okinawa,AS21,Northern Territory,NonPeak,$10.35,$16.89
+JA96,Okinawa,AS21,Northern Territory,Peak,$12.21,$19.93
+JA96,Okinawa,BA,Bahrain,NonPeak,$10.83,$11.66
+JA96,Okinawa,BA,Bahrain,Peak,$12.78,$13.76
+JA96,Okinawa,BE,Belgium,NonPeak,$11.35,$10.16
+JA96,Okinawa,BE,Belgium,Peak,$13.39,$11.99
+JA96,Okinawa,BL,Bolivia,NonPeak,$11.82,$16.98
+JA96,Okinawa,BL,Bolivia,Peak,$13.95,$20.04
+JA96,Okinawa,BR,Brazil - Brazilia,NonPeak,$8.88,$11.75
+JA96,Okinawa,BR,Brazil - Brazilia,Peak,$10.48,$13.86
+JA96,Okinawa,CA10,Ontario,NonPeak,$9.31,$10.25
+JA96,Okinawa,CA10,Ontario,Peak,$10.99,$12.09
+JA96,Okinawa,CA20,Quebec,NonPeak,$9.77,$17.11
+JA96,Okinawa,CA20,Quebec,Peak,$11.53,$20.19
+JA96,Okinawa,CA30,Manitoba,NonPeak,$10.21,$11.86
+JA96,Okinawa,CA30,Manitoba,Peak,$12.05,$13.99
+JA96,Okinawa,CI,Chile,NonPeak,$10.65,$10.37
+JA96,Okinawa,CI,Chile,Peak,$12.57,$12.24
+JA96,Okinawa,CO,Colombia,NonPeak,$10.35,$17.17
+JA96,Okinawa,CO,Colombia,Peak,$12.21,$20.26
+JA96,Okinawa,CS,Costa Rica,NonPeak,$10.83,$10.50
+JA96,Okinawa,CS,Costa Rica,Peak,$12.78,$12.39
+JA96,Okinawa,EC,Ecuador,NonPeak,$11.35,$17.59
+JA96,Okinawa,EC,Ecuador,Peak,$13.39,$20.76
+JA96,Okinawa,ES,El Salvador,NonPeak,$11.82,$12.03
+JA96,Okinawa,ES,El Salvador,Peak,$13.95,$14.20
+JA96,Okinawa,GE,Germany,NonPeak,$8.88,$12.66
+JA96,Okinawa,GE,Germany,Peak,$10.48,$14.94
+JA96,Okinawa,GQ,Guam,NonPeak,$9.31,$17.97
+JA96,Okinawa,GQ,Guam,Peak,$10.99,$21.20
+JA96,Okinawa,GR,Greece,NonPeak,$9.77,$12.36
+JA96,Okinawa,GR,Greece,Peak,$11.53,$14.58
+JA96,Okinawa,GR29,Crete,NonPeak,$10.21,$10.91
+JA96,Okinawa,GR29,Crete,Peak,$12.05,$12.87
+JA96,Okinawa,GT,Guatemala,NonPeak,$10.65,$18.51
+JA96,Okinawa,GT,Guatemala,Peak,$12.57,$21.84
+JA96,Okinawa,HO,Honduras,NonPeak,$10.35,$12.70
+JA96,Okinawa,HO,Honduras,Peak,$12.21,$14.99
+JA96,Okinawa,HU,Hungary,NonPeak,$10.83,$11.24
+JA96,Okinawa,HU,Hungary,Peak,$12.78,$13.26
+JA96,Okinawa,IT,Italy,NonPeak,$11.35,$19.00
+JA96,Okinawa,IT,Italy,Peak,$13.39,$22.42
+JA96,Okinawa,IT10,Sicily,NonPeak,$11.82,$12.99
+JA96,Okinawa,IT10,Sicily,Peak,$13.95,$15.33
+JA96,Okinawa,JA01,Japan-Central,NonPeak,$8.88,$11.54
+JA96,Okinawa,JA01,Japan-Central,Peak,$10.48,$13.62
+JA96,Okinawa,JA02,Japan-South (Excludes Hokkaido),NonPeak,$9.31,$16.89
+JA96,Okinawa,JA02,Japan-South (Excludes Hokkaido),Peak,$10.99,$19.93
+JA96,Okinawa,JA03,Japan-North,NonPeak,$9.77,$11.66
+JA96,Okinawa,JA03,Japan-North,Peak,$11.53,$13.76
+JA96,Okinawa,JA96,Okinawa,NonPeak,$10.21,$10.16
+JA96,Okinawa,JA96,Okinawa,Peak,$12.05,$11.99
+JA96,Okinawa,KS,"Korea, Republic Of",NonPeak,$10.65,$16.98
+JA96,Okinawa,KS,"Korea, Republic Of",Peak,$12.57,$20.04
+JA96,Okinawa,KU,Kuwait,NonPeak,$10.35,$11.75
+JA96,Okinawa,KU,Kuwait,Peak,$12.21,$13.86
+JA96,Okinawa,NL,Netherlands,NonPeak,$10.83,$10.25
+JA96,Okinawa,NL,Netherlands,Peak,$12.78,$12.09
+JA96,Okinawa,NO,Norway,NonPeak,$11.35,$17.11
+JA96,Okinawa,NO,Norway,Peak,$13.39,$20.19
+JA96,Okinawa,PA,Paraguay,NonPeak,$11.82,$11.86
+JA96,Okinawa,PA,Paraguay,Peak,$13.95,$13.99
+JA96,Okinawa,PE,Peru,NonPeak,$8.88,$10.37
+JA96,Okinawa,PE,Peru,Peak,$10.48,$12.24
+JA96,Okinawa,PL,Poland,NonPeak,$9.31,$17.17
+JA96,Okinawa,PL,Poland,Peak,$10.99,$20.26
+JA96,Okinawa,PO,Portugal,NonPeak,$9.77,$10.50
+JA96,Okinawa,PO,Portugal,Peak,$11.53,$12.39
+JA96,Okinawa,PO01,Azores,NonPeak,$10.21,$17.59
+JA96,Okinawa,PO01,Azores,Peak,$12.05,$20.76
+JA96,Okinawa,QA,Qatar,NonPeak,$10.65,$12.03
+JA96,Okinawa,QA,Qatar,Peak,$12.57,$14.20
+JA96,Okinawa,RO,Romania,NonPeak,$10.35,$12.66
+JA96,Okinawa,RO,Romania,Peak,$12.21,$14.94
+JA96,Okinawa,RQ,Puerto Rico,NonPeak,$10.83,$17.97
+JA96,Okinawa,RQ,Puerto Rico,Peak,$12.78,$21.20
+JA96,Okinawa,SA,Saudi Arabia,NonPeak,$11.35,$12.36
+JA96,Okinawa,SA,Saudi Arabia,Peak,$13.39,$14.58
+JA96,Okinawa,SN,Singapore,NonPeak,$11.82,$10.91
+JA96,Okinawa,SN,Singapore,Peak,$13.95,$12.87
+JA96,Okinawa,SP,Spain,NonPeak,$8.88,$18.51
+JA96,Okinawa,SP,Spain,Peak,$10.48,$21.84
+JA96,Okinawa,TU,Turkey,NonPeak,$9.31,$12.70
+JA96,Okinawa,TU,Turkey,Peak,$10.99,$14.99
+JA96,Okinawa,UK,United Kingdom,NonPeak,$9.77,$11.24
+JA96,Okinawa,UK,United Kingdom,Peak,$11.53,$13.26
+JA96,Okinawa,US8030400,Alaska (Zone) IV,NonPeak,$10.21,$19.00
+JA96,Okinawa,US8030400,Alaska (Zone) IV,Peak,$12.05,$22.42
+JA96,Okinawa,US8050500,Alaska (Zone) III,NonPeak,$10.65,$12.99
+JA96,Okinawa,US8050500,Alaska (Zone) III,Peak,$12.57,$15.33
+JA96,Okinawa,US8101000,Alaska (Zone) I,NonPeak,$10.35,$11.54
+JA96,Okinawa,US8101000,Alaska (Zone) I,Peak,$12.21,$13.62
+JA96,Okinawa,US8190100,Alaska (Zone) II,NonPeak,$10.83,$16.89
+JA96,Okinawa,US8190100,Alaska (Zone) II,Peak,$12.78,$19.93
+JA96,Okinawa,US89,Hawaii,NonPeak,$11.35,$11.66
+JA96,Okinawa,US89,Hawaii,Peak,$13.39,$13.76
+JA96,Okinawa,UY,Uruguay,NonPeak,$11.82,$10.16
+JA96,Okinawa,UY,Uruguay,Peak,$13.95,$11.99
+JA96,Okinawa,VE,Venezuela,NonPeak,$8.88,$16.98
+JA96,Okinawa,VE,Venezuela,Peak,$10.48,$20.04
+KS,"Korea, Republic Of",AR,Argentina,NonPeak,$9.31,$11.75
+KS,"Korea, Republic Of",AR,Argentina,Peak,$10.99,$13.86
+KS,"Korea, Republic Of",AS11,New South Wales/Australian Capital Territory,NonPeak,$9.77,$10.25
+KS,"Korea, Republic Of",AS11,New South Wales/Australian Capital Territory,Peak,$11.53,$12.09
+KS,"Korea, Republic Of",AS21,Northern Territory,NonPeak,$10.21,$17.11
+KS,"Korea, Republic Of",AS21,Northern Territory,Peak,$12.05,$20.19
+KS,"Korea, Republic Of",BA,Bahrain,NonPeak,$10.65,$11.86
+KS,"Korea, Republic Of",BA,Bahrain,Peak,$12.57,$13.99
+KS,"Korea, Republic Of",BE,Belgium,NonPeak,$10.35,$10.37
+KS,"Korea, Republic Of",BE,Belgium,Peak,$12.21,$12.24
+KS,"Korea, Republic Of",BL,Bolivia,NonPeak,$10.83,$17.17
+KS,"Korea, Republic Of",BL,Bolivia,Peak,$12.78,$20.26
+KS,"Korea, Republic Of",BR,Brazil - Brazilia,NonPeak,$11.35,$10.50
+KS,"Korea, Republic Of",BR,Brazil - Brazilia,Peak,$13.39,$12.39
+KS,"Korea, Republic Of",CA10,Ontario,NonPeak,$11.82,$17.59
+KS,"Korea, Republic Of",CA10,Ontario,Peak,$13.95,$20.76
+KS,"Korea, Republic Of",CA20,Quebec,NonPeak,$8.88,$12.03
+KS,"Korea, Republic Of",CA20,Quebec,Peak,$10.48,$14.20
+KS,"Korea, Republic Of",CA30,Manitoba,NonPeak,$9.31,$12.66
+KS,"Korea, Republic Of",CA30,Manitoba,Peak,$10.99,$14.94
+KS,"Korea, Republic Of",CI,Chile,NonPeak,$9.77,$17.97
+KS,"Korea, Republic Of",CI,Chile,Peak,$11.53,$21.20
+KS,"Korea, Republic Of",CO,Colombia,NonPeak,$10.21,$12.36
+KS,"Korea, Republic Of",CO,Colombia,Peak,$12.05,$14.58
+KS,"Korea, Republic Of",CS,Costa Rica,NonPeak,$10.65,$10.91
+KS,"Korea, Republic Of",CS,Costa Rica,Peak,$12.57,$12.87
+KS,"Korea, Republic Of",EC,Ecuador,NonPeak,$10.35,$18.51
+KS,"Korea, Republic Of",EC,Ecuador,Peak,$12.21,$21.84
+KS,"Korea, Republic Of",ES,El Salvador,NonPeak,$10.83,$12.70
+KS,"Korea, Republic Of",ES,El Salvador,Peak,$12.78,$14.99
+KS,"Korea, Republic Of",GE,Germany,NonPeak,$11.35,$11.24
+KS,"Korea, Republic Of",GE,Germany,Peak,$13.39,$13.26
+KS,"Korea, Republic Of",GQ,Guam,NonPeak,$11.82,$19.00
+KS,"Korea, Republic Of",GQ,Guam,Peak,$13.95,$22.42
+KS,"Korea, Republic Of",GR,Greece,NonPeak,$8.88,$12.99
+KS,"Korea, Republic Of",GR,Greece,Peak,$10.48,$15.33
+KS,"Korea, Republic Of",GR29,Crete,NonPeak,$9.31,$11.54
+KS,"Korea, Republic Of",GR29,Crete,Peak,$10.99,$13.62
+KS,"Korea, Republic Of",GT,Guatemala,NonPeak,$9.77,$16.89
+KS,"Korea, Republic Of",GT,Guatemala,Peak,$11.53,$19.93
+KS,"Korea, Republic Of",HO,Honduras,NonPeak,$10.21,$11.66
+KS,"Korea, Republic Of",HO,Honduras,Peak,$12.05,$13.76
+KS,"Korea, Republic Of",HU,Hungary,NonPeak,$10.65,$10.16
+KS,"Korea, Republic Of",HU,Hungary,Peak,$12.57,$11.99
+KS,"Korea, Republic Of",IT,Italy,NonPeak,$10.35,$16.98
+KS,"Korea, Republic Of",IT,Italy,Peak,$12.21,$20.04
+KS,"Korea, Republic Of",IT10,Sicily,NonPeak,$10.83,$11.75
+KS,"Korea, Republic Of",IT10,Sicily,Peak,$12.78,$13.86
+KS,"Korea, Republic Of",JA01,Japan-Central,NonPeak,$11.35,$10.25
+KS,"Korea, Republic Of",JA01,Japan-Central,Peak,$13.39,$12.09
+KS,"Korea, Republic Of",JA02,Japan-South (Excludes Hokkaido),NonPeak,$11.82,$17.11
+KS,"Korea, Republic Of",JA02,Japan-South (Excludes Hokkaido),Peak,$13.95,$20.19
+KS,"Korea, Republic Of",JA03,Japan-North,NonPeak,$8.88,$11.86
+KS,"Korea, Republic Of",JA03,Japan-North,Peak,$10.48,$13.99
+KS,"Korea, Republic Of",JA96,Okinawa,NonPeak,$9.31,$10.37
+KS,"Korea, Republic Of",JA96,Okinawa,Peak,$10.99,$12.24
+KS,"Korea, Republic Of",KS,"Korea, Republic Of",NonPeak,$9.77,$17.17
+KS,"Korea, Republic Of",KS,"Korea, Republic Of",Peak,$11.53,$20.26
+KS,"Korea, Republic Of",KU,Kuwait,NonPeak,$10.21,$10.50
+KS,"Korea, Republic Of",KU,Kuwait,Peak,$12.05,$12.39
+KS,"Korea, Republic Of",NL,Netherlands,NonPeak,$10.65,$17.59
+KS,"Korea, Republic Of",NL,Netherlands,Peak,$12.57,$20.76
+KS,"Korea, Republic Of",NO,Norway,NonPeak,$10.35,$12.03
+KS,"Korea, Republic Of",NO,Norway,Peak,$12.21,$14.20
+KS,"Korea, Republic Of",PA,Paraguay,NonPeak,$10.35,$16.89
+KS,"Korea, Republic Of",PA,Paraguay,Peak,$12.21,$19.93
+KS,"Korea, Republic Of",PE,Peru,NonPeak,$10.83,$11.66
+KS,"Korea, Republic Of",PE,Peru,Peak,$12.78,$13.76
+KS,"Korea, Republic Of",PL,Poland,NonPeak,$11.35,$10.16
+KS,"Korea, Republic Of",PL,Poland,Peak,$13.39,$11.99
+KS,"Korea, Republic Of",PO,Portugal,NonPeak,$11.82,$16.98
+KS,"Korea, Republic Of",PO,Portugal,Peak,$13.95,$20.04
+KS,"Korea, Republic Of",PO01,Azores,NonPeak,$8.88,$11.75
+KS,"Korea, Republic Of",PO01,Azores,Peak,$10.48,$13.86
+KS,"Korea, Republic Of",QA,Qatar,NonPeak,$9.31,$10.25
+KS,"Korea, Republic Of",QA,Qatar,Peak,$10.99,$12.09
+KS,"Korea, Republic Of",RO,Romania,NonPeak,$9.77,$17.11
+KS,"Korea, Republic Of",RO,Romania,Peak,$11.53,$20.19
+KS,"Korea, Republic Of",RQ,Puerto Rico,NonPeak,$10.21,$11.86
+KS,"Korea, Republic Of",RQ,Puerto Rico,Peak,$12.05,$13.99
+KS,"Korea, Republic Of",SA,Saudi Arabia,NonPeak,$10.65,$10.37
+KS,"Korea, Republic Of",SA,Saudi Arabia,Peak,$12.57,$12.24
+KS,"Korea, Republic Of",SN,Singapore,NonPeak,$10.35,$17.17
+KS,"Korea, Republic Of",SN,Singapore,Peak,$12.21,$20.26
+KS,"Korea, Republic Of",SP,Spain,NonPeak,$10.83,$10.50
+KS,"Korea, Republic Of",SP,Spain,Peak,$12.78,$12.39
+KS,"Korea, Republic Of",TU,Turkey,NonPeak,$11.35,$17.59
+KS,"Korea, Republic Of",TU,Turkey,Peak,$13.39,$20.76
+KS,"Korea, Republic Of",UK,United Kingdom,NonPeak,$11.82,$12.03
+KS,"Korea, Republic Of",UK,United Kingdom,Peak,$13.95,$14.20
+KS,"Korea, Republic Of",US8030400,Alaska (Zone) IV,NonPeak,$8.88,$12.66
+KS,"Korea, Republic Of",US8030400,Alaska (Zone) IV,Peak,$10.48,$14.94
+KS,"Korea, Republic Of",US8050500,Alaska (Zone) III,NonPeak,$9.31,$17.97
+KS,"Korea, Republic Of",US8050500,Alaska (Zone) III,Peak,$10.99,$21.20
+KS,"Korea, Republic Of",US8101000,Alaska (Zone) I,NonPeak,$9.77,$12.36
+KS,"Korea, Republic Of",US8101000,Alaska (Zone) I,Peak,$11.53,$14.58
+KS,"Korea, Republic Of",US8190100,Alaska (Zone) II,NonPeak,$10.21,$10.91
+KS,"Korea, Republic Of",US8190100,Alaska (Zone) II,Peak,$12.05,$12.87
+KS,"Korea, Republic Of",US89,Hawaii,NonPeak,$10.65,$18.51
+KS,"Korea, Republic Of",US89,Hawaii,Peak,$12.57,$21.84
+KS,"Korea, Republic Of",UY,Uruguay,NonPeak,$10.35,$12.70
+KS,"Korea, Republic Of",UY,Uruguay,Peak,$12.21,$14.99
+KS,"Korea, Republic Of",VE,Venezuela,NonPeak,$10.83,$11.24
+KS,"Korea, Republic Of",VE,Venezuela,Peak,$12.78,$13.26
+KU,Kuwait,AR,Argentina,NonPeak,$11.35,$19.00
+KU,Kuwait,AR,Argentina,Peak,$13.39,$22.42
+KU,Kuwait,AS11,New South Wales/Australian Capital Territory,NonPeak,$11.82,$12.99
+KU,Kuwait,AS11,New South Wales/Australian Capital Territory,Peak,$13.95,$15.33
+KU,Kuwait,AS21,Northern Territory,NonPeak,$8.88,$11.54
+KU,Kuwait,AS21,Northern Territory,Peak,$10.48,$13.62
+KU,Kuwait,BA,Bahrain,NonPeak,$9.31,$16.89
+KU,Kuwait,BA,Bahrain,Peak,$10.99,$19.93
+KU,Kuwait,BE,Belgium,NonPeak,$9.77,$11.66
+KU,Kuwait,BE,Belgium,Peak,$11.53,$13.76
+KU,Kuwait,BL,Bolivia,NonPeak,$10.21,$10.16
+KU,Kuwait,BL,Bolivia,Peak,$12.05,$11.99
+KU,Kuwait,BR,Brazil - Brazilia,NonPeak,$10.65,$16.98
+KU,Kuwait,BR,Brazil - Brazilia,Peak,$12.57,$20.04
+KU,Kuwait,CA10,Ontario,NonPeak,$10.35,$11.75
+KU,Kuwait,CA10,Ontario,Peak,$12.21,$13.86
+KU,Kuwait,CA20,Quebec,NonPeak,$10.83,$10.25
+KU,Kuwait,CA20,Quebec,Peak,$12.78,$12.09
+KU,Kuwait,CA30,Manitoba,NonPeak,$11.35,$17.11
+KU,Kuwait,CA30,Manitoba,Peak,$13.39,$20.19
+KU,Kuwait,CI,Chile,NonPeak,$11.82,$11.86
+KU,Kuwait,CI,Chile,Peak,$13.95,$13.99
+KU,Kuwait,CO,Colombia,NonPeak,$8.88,$10.37
+KU,Kuwait,CO,Colombia,Peak,$10.48,$12.24
+KU,Kuwait,CS,Costa Rica,NonPeak,$9.31,$17.17
+KU,Kuwait,CS,Costa Rica,Peak,$10.99,$20.26
+KU,Kuwait,EC,Ecuador,NonPeak,$9.77,$10.50
+KU,Kuwait,EC,Ecuador,Peak,$11.53,$12.39
+KU,Kuwait,ES,El Salvador,NonPeak,$10.21,$17.59
+KU,Kuwait,ES,El Salvador,Peak,$12.05,$20.76
+KU,Kuwait,GE,Germany,NonPeak,$10.65,$12.03
+KU,Kuwait,GE,Germany,Peak,$12.57,$14.20
+KU,Kuwait,GQ,Guam,NonPeak,$10.35,$12.66
+KU,Kuwait,GQ,Guam,Peak,$12.21,$14.94
+KU,Kuwait,GR,Greece,NonPeak,$10.83,$17.97
+KU,Kuwait,GR,Greece,Peak,$12.78,$21.20
+KU,Kuwait,GR29,Crete,NonPeak,$11.35,$12.36
+KU,Kuwait,GR29,Crete,Peak,$13.39,$14.58
+KU,Kuwait,GT,Guatemala,NonPeak,$11.82,$10.91
+KU,Kuwait,GT,Guatemala,Peak,$13.95,$12.87
+KU,Kuwait,HO,Honduras,NonPeak,$8.88,$18.51
+KU,Kuwait,HO,Honduras,Peak,$10.48,$21.84
+KU,Kuwait,HU,Hungary,NonPeak,$9.31,$12.70
+KU,Kuwait,HU,Hungary,Peak,$10.99,$14.99
+KU,Kuwait,IT,Italy,NonPeak,$9.77,$11.24
+KU,Kuwait,IT,Italy,Peak,$11.53,$13.26
+KU,Kuwait,IT10,Sicily,NonPeak,$10.21,$19.00
+KU,Kuwait,IT10,Sicily,Peak,$12.05,$22.42
+KU,Kuwait,JA01,Japan-Central,NonPeak,$10.65,$12.99
+KU,Kuwait,JA01,Japan-Central,Peak,$12.57,$15.33
+KU,Kuwait,JA02,Japan-South (Excludes Hokkaido),NonPeak,$10.35,$11.54
+KU,Kuwait,JA02,Japan-South (Excludes Hokkaido),Peak,$12.21,$13.62
+KU,Kuwait,JA03,Japan-North,NonPeak,$10.83,$16.89
+KU,Kuwait,JA03,Japan-North,Peak,$12.78,$19.93
+KU,Kuwait,JA96,Okinawa,NonPeak,$11.35,$11.66
+KU,Kuwait,JA96,Okinawa,Peak,$13.39,$13.76
+KU,Kuwait,KS,"Korea, Republic Of",NonPeak,$11.82,$10.16
+KU,Kuwait,KS,"Korea, Republic Of",Peak,$13.95,$11.99
+KU,Kuwait,KU,Kuwait,NonPeak,$8.88,$16.98
+KU,Kuwait,KU,Kuwait,Peak,$10.48,$20.04
+KU,Kuwait,NL,Netherlands,NonPeak,$9.31,$11.75
+KU,Kuwait,NL,Netherlands,Peak,$10.99,$13.86
+KU,Kuwait,NO,Norway,NonPeak,$9.77,$10.25
+KU,Kuwait,NO,Norway,Peak,$11.53,$12.09
+KU,Kuwait,PA,Paraguay,NonPeak,$10.21,$17.11
+KU,Kuwait,PA,Paraguay,Peak,$12.05,$20.19
+KU,Kuwait,PE,Peru,NonPeak,$10.65,$11.86
+KU,Kuwait,PE,Peru,Peak,$12.57,$13.99
+KU,Kuwait,PL,Poland,NonPeak,$10.35,$10.37
+KU,Kuwait,PL,Poland,Peak,$12.21,$12.24
+KU,Kuwait,PO,Portugal,NonPeak,$10.83,$17.17
+KU,Kuwait,PO,Portugal,Peak,$12.78,$20.26
+KU,Kuwait,PO01,Azores,NonPeak,$11.35,$10.50
+KU,Kuwait,PO01,Azores,Peak,$13.39,$12.39
+KU,Kuwait,QA,Qatar,NonPeak,$11.82,$17.59
+KU,Kuwait,QA,Qatar,Peak,$13.95,$20.76
+KU,Kuwait,RO,Romania,NonPeak,$8.88,$12.03
+KU,Kuwait,RO,Romania,Peak,$10.48,$14.20
+KU,Kuwait,RQ,Puerto Rico,NonPeak,$9.31,$12.66
+KU,Kuwait,RQ,Puerto Rico,Peak,$10.99,$14.94
+KU,Kuwait,SA,Saudi Arabia,NonPeak,$9.77,$17.97
+KU,Kuwait,SA,Saudi Arabia,Peak,$11.53,$21.20
+KU,Kuwait,SN,Singapore,NonPeak,$10.21,$12.36
+KU,Kuwait,SN,Singapore,Peak,$12.05,$14.58
+KU,Kuwait,SP,Spain,NonPeak,$10.65,$10.91
+KU,Kuwait,SP,Spain,Peak,$12.57,$12.87
+KU,Kuwait,TU,Turkey,NonPeak,$10.35,$18.51
+KU,Kuwait,TU,Turkey,Peak,$12.21,$21.84
+KU,Kuwait,UK,United Kingdom,NonPeak,$10.83,$12.70
+KU,Kuwait,UK,United Kingdom,Peak,$12.78,$14.99
+KU,Kuwait,US8030400,Alaska (Zone) IV,NonPeak,$11.35,$11.24
+KU,Kuwait,US8030400,Alaska (Zone) IV,Peak,$13.39,$13.26
+KU,Kuwait,US8050500,Alaska (Zone) III,NonPeak,$11.82,$19.00
+KU,Kuwait,US8050500,Alaska (Zone) III,Peak,$13.95,$22.42
+KU,Kuwait,US8101000,Alaska (Zone) I,NonPeak,$8.88,$12.99
+KU,Kuwait,US8101000,Alaska (Zone) I,Peak,$10.48,$15.33
+KU,Kuwait,US8190100,Alaska (Zone) II,NonPeak,$9.31,$11.54
+KU,Kuwait,US8190100,Alaska (Zone) II,Peak,$10.99,$13.62
+KU,Kuwait,US89,Hawaii,NonPeak,$9.77,$16.89
+KU,Kuwait,US89,Hawaii,Peak,$11.53,$19.93
+KU,Kuwait,UY,Uruguay,NonPeak,$10.21,$11.66
+KU,Kuwait,UY,Uruguay,Peak,$12.05,$13.76
+KU,Kuwait,VE,Venezuela,NonPeak,$10.65,$10.16
+KU,Kuwait,VE,Venezuela,Peak,$12.57,$11.99
+NL,Netherlands,AR,Argentina,NonPeak,$10.35,$16.98
+NL,Netherlands,AR,Argentina,Peak,$12.21,$20.04
+NL,Netherlands,AS11,New South Wales/Australian Capital Territory,NonPeak,$10.83,$11.75
+NL,Netherlands,AS11,New South Wales/Australian Capital Territory,Peak,$12.78,$13.86
+NL,Netherlands,AS21,Northern Territory,NonPeak,$11.35,$10.25
+NL,Netherlands,AS21,Northern Territory,Peak,$13.39,$12.09
+NL,Netherlands,BA,Bahrain,NonPeak,$11.82,$17.11
+NL,Netherlands,BA,Bahrain,Peak,$13.95,$20.19
+NL,Netherlands,BE,Belgium,NonPeak,$8.88,$11.86
+NL,Netherlands,BE,Belgium,Peak,$10.48,$13.99
+NL,Netherlands,BL,Bolivia,NonPeak,$9.31,$10.37
+NL,Netherlands,BL,Bolivia,Peak,$10.99,$12.24
+NL,Netherlands,BR,Brazil - Brazilia,NonPeak,$9.77,$17.17
+NL,Netherlands,BR,Brazil - Brazilia,Peak,$11.53,$20.26
+NL,Netherlands,CA10,Ontario,NonPeak,$10.21,$10.50
+NL,Netherlands,CA10,Ontario,Peak,$12.05,$12.39
+NL,Netherlands,CA20,Quebec,NonPeak,$10.65,$17.59
+NL,Netherlands,CA20,Quebec,Peak,$12.57,$20.76
+NL,Netherlands,CA30,Manitoba,NonPeak,$10.35,$12.03
+NL,Netherlands,CA30,Manitoba,Peak,$12.21,$14.20
+NL,Netherlands,CI,Chile,NonPeak,$10.83,$12.66
+NL,Netherlands,CI,Chile,Peak,$12.78,$14.94
+NL,Netherlands,CO,Colombia,NonPeak,$11.35,$17.97
+NL,Netherlands,CO,Colombia,Peak,$13.39,$21.20
+NL,Netherlands,CS,Costa Rica,NonPeak,$11.82,$12.36
+NL,Netherlands,CS,Costa Rica,Peak,$13.95,$14.58
+NL,Netherlands,EC,Ecuador,NonPeak,$8.88,$10.91
+NL,Netherlands,EC,Ecuador,Peak,$10.48,$12.87
+NL,Netherlands,ES,El Salvador,NonPeak,$9.31,$18.51
+NL,Netherlands,ES,El Salvador,Peak,$10.99,$21.84
+NL,Netherlands,GE,Germany,NonPeak,$9.77,$12.70
+NL,Netherlands,GE,Germany,Peak,$11.53,$14.99
+NL,Netherlands,GQ,Guam,NonPeak,$10.21,$11.24
+NL,Netherlands,GQ,Guam,Peak,$12.05,$13.26
+NL,Netherlands,GR,Greece,NonPeak,$10.65,$19.00
+NL,Netherlands,GR,Greece,Peak,$12.57,$22.42
+NL,Netherlands,GR29,Crete,NonPeak,$10.35,$12.99
+NL,Netherlands,GR29,Crete,Peak,$12.21,$15.33
+NL,Netherlands,GT,Guatemala,NonPeak,$10.83,$11.54
+NL,Netherlands,GT,Guatemala,Peak,$12.78,$13.62
+NL,Netherlands,HO,Honduras,NonPeak,$11.35,$16.89
+NL,Netherlands,HO,Honduras,Peak,$13.39,$19.93
+NL,Netherlands,HU,Hungary,NonPeak,$11.82,$11.66
+NL,Netherlands,HU,Hungary,Peak,$13.95,$13.76
+NL,Netherlands,IT,Italy,NonPeak,$8.88,$10.16
+NL,Netherlands,IT,Italy,Peak,$10.48,$11.99
+NL,Netherlands,IT10,Sicily,NonPeak,$9.31,$16.98
+NL,Netherlands,IT10,Sicily,Peak,$10.99,$20.04
+NL,Netherlands,JA01,Japan-Central,NonPeak,$9.77,$11.75
+NL,Netherlands,JA01,Japan-Central,Peak,$11.53,$13.86
+NL,Netherlands,JA02,Japan-South (Excludes Hokkaido),NonPeak,$10.21,$10.25
+NL,Netherlands,JA02,Japan-South (Excludes Hokkaido),Peak,$12.05,$12.09
+NL,Netherlands,JA03,Japan-North,NonPeak,$10.65,$17.11
+NL,Netherlands,JA03,Japan-North,Peak,$12.57,$20.19
+NL,Netherlands,JA96,Okinawa,NonPeak,$10.35,$11.86
+NL,Netherlands,JA96,Okinawa,Peak,$12.21,$13.99
+NL,Netherlands,KS,"Korea, Republic Of",NonPeak,$10.83,$10.37
+NL,Netherlands,KS,"Korea, Republic Of",Peak,$12.78,$12.24
+NL,Netherlands,KU,Kuwait,NonPeak,$11.35,$17.17
+NL,Netherlands,KU,Kuwait,Peak,$13.39,$20.26
+NL,Netherlands,NL,Netherlands,NonPeak,$11.82,$10.50
+NL,Netherlands,NL,Netherlands,Peak,$13.95,$12.39
+NL,Netherlands,NO,Norway,NonPeak,$8.88,$17.59
+NL,Netherlands,NO,Norway,Peak,$10.48,$20.76
+NL,Netherlands,PA,Paraguay,NonPeak,$9.31,$12.03
+NL,Netherlands,PA,Paraguay,Peak,$10.99,$14.20
+NL,Netherlands,PE,Peru,NonPeak,$9.77,$12.66
+NL,Netherlands,PE,Peru,Peak,$11.53,$14.94
+NL,Netherlands,PL,Poland,NonPeak,$10.21,$17.97
+NL,Netherlands,PL,Poland,Peak,$12.05,$21.20
+NL,Netherlands,PO,Portugal,NonPeak,$10.65,$12.36
+NL,Netherlands,PO,Portugal,Peak,$12.57,$14.58
+NL,Netherlands,PO01,Azores,NonPeak,$10.35,$10.91
+NL,Netherlands,PO01,Azores,Peak,$12.21,$12.87
+NL,Netherlands,QA,Qatar,NonPeak,$10.83,$18.51
+NL,Netherlands,QA,Qatar,Peak,$12.78,$21.84
+NL,Netherlands,RO,Romania,NonPeak,$11.35,$12.70
+NL,Netherlands,RO,Romania,Peak,$13.39,$14.99
+NL,Netherlands,RQ,Puerto Rico,NonPeak,$11.82,$11.24
+NL,Netherlands,RQ,Puerto Rico,Peak,$13.95,$13.26
+NL,Netherlands,SA,Saudi Arabia,NonPeak,$8.88,$19.00
+NL,Netherlands,SA,Saudi Arabia,Peak,$10.48,$22.42
+NL,Netherlands,SN,Singapore,NonPeak,$9.31,$12.99
+NL,Netherlands,SN,Singapore,Peak,$10.99,$15.33
+NL,Netherlands,SP,Spain,NonPeak,$9.77,$11.54
+NL,Netherlands,SP,Spain,Peak,$11.53,$13.62
+NL,Netherlands,TU,Turkey,NonPeak,$10.21,$16.89
+NL,Netherlands,TU,Turkey,Peak,$12.05,$19.93
+NL,Netherlands,UK,United Kingdom,NonPeak,$10.65,$11.66
+NL,Netherlands,UK,United Kingdom,Peak,$12.57,$13.76
+NL,Netherlands,US8030400,Alaska (Zone) IV,NonPeak,$10.35,$10.16
+NL,Netherlands,US8030400,Alaska (Zone) IV,Peak,$12.21,$11.99
+NL,Netherlands,US8050500,Alaska (Zone) III,NonPeak,$10.83,$16.98
+NL,Netherlands,US8050500,Alaska (Zone) III,Peak,$12.78,$20.04
+NL,Netherlands,US8101000,Alaska (Zone) I,NonPeak,$11.35,$11.75
+NL,Netherlands,US8101000,Alaska (Zone) I,Peak,$13.39,$13.86
+NL,Netherlands,US8190100,Alaska (Zone) II,NonPeak,$11.82,$10.25
+NL,Netherlands,US8190100,Alaska (Zone) II,Peak,$13.95,$12.09
+NL,Netherlands,US89,Hawaii,NonPeak,$8.88,$17.11
+NL,Netherlands,US89,Hawaii,Peak,$10.48,$20.19
+NL,Netherlands,UY,Uruguay,NonPeak,$9.31,$11.86
+NL,Netherlands,UY,Uruguay,Peak,$10.99,$13.99
+NL,Netherlands,VE,Venezuela,NonPeak,$9.77,$10.37
+NL,Netherlands,VE,Venezuela,Peak,$11.53,$12.24
+NO,Norway,AR,Argentina,NonPeak,$10.21,$17.17
+NO,Norway,AR,Argentina,Peak,$12.05,$20.26
+NO,Norway,AS11,New South Wales/Australian Capital Territory,NonPeak,$10.65,$10.50
+NO,Norway,AS11,New South Wales/Australian Capital Territory,Peak,$12.57,$12.39
+NO,Norway,AS21,Northern Territory,NonPeak,$10.35,$17.59
+NO,Norway,AS21,Northern Territory,Peak,$12.21,$20.76
+NO,Norway,BA,Bahrain,NonPeak,$10.83,$12.03
+NO,Norway,BA,Bahrain,Peak,$12.78,$14.20
+NO,Norway,BE,Belgium,NonPeak,$11.35,$12.66
+NO,Norway,BE,Belgium,Peak,$13.39,$14.94
+NO,Norway,BL,Bolivia,NonPeak,$11.82,$17.97
+NO,Norway,BL,Bolivia,Peak,$13.95,$21.20
+NO,Norway,BR,Brazil - Brazilia,NonPeak,$8.88,$12.36
+NO,Norway,BR,Brazil - Brazilia,Peak,$10.48,$14.58
+NO,Norway,CA10,Ontario,NonPeak,$9.31,$10.91
+NO,Norway,CA10,Ontario,Peak,$10.99,$12.87
+NO,Norway,CA20,Quebec,NonPeak,$9.77,$18.51
+NO,Norway,CA20,Quebec,Peak,$11.53,$21.84
+NO,Norway,CA30,Manitoba,NonPeak,$10.21,$12.70
+NO,Norway,CA30,Manitoba,Peak,$12.05,$14.99
+NO,Norway,CI,Chile,NonPeak,$10.65,$11.24
+NO,Norway,CI,Chile,Peak,$12.57,$13.26
+NO,Norway,CO,Colombia,NonPeak,$10.35,$19.00
+NO,Norway,CO,Colombia,Peak,$12.21,$22.42
+NO,Norway,CS,Costa Rica,NonPeak,$10.83,$12.99
+NO,Norway,CS,Costa Rica,Peak,$12.78,$15.33
+NO,Norway,EC,Ecuador,NonPeak,$11.35,$11.54
+NO,Norway,EC,Ecuador,Peak,$13.39,$13.62
+NO,Norway,ES,El Salvador,NonPeak,$11.82,$16.89
+NO,Norway,ES,El Salvador,Peak,$13.95,$19.93
+NO,Norway,GE,Germany,NonPeak,$8.88,$11.66
+NO,Norway,GE,Germany,Peak,$10.48,$13.76
+NO,Norway,GQ,Guam,NonPeak,$9.31,$10.16
+NO,Norway,GQ,Guam,Peak,$10.99,$11.99
+NO,Norway,GR,Greece,NonPeak,$9.77,$16.98
+NO,Norway,GR,Greece,Peak,$11.53,$20.04
+NO,Norway,GR29,Crete,NonPeak,$10.21,$11.75
+NO,Norway,GR29,Crete,Peak,$12.05,$13.86
+NO,Norway,GT,Guatemala,NonPeak,$10.65,$10.25
+NO,Norway,GT,Guatemala,Peak,$12.57,$12.09
+NO,Norway,HO,Honduras,NonPeak,$10.35,$17.11
+NO,Norway,HO,Honduras,Peak,$12.21,$20.19
+NO,Norway,HU,Hungary,NonPeak,$10.83,$11.86
+NO,Norway,HU,Hungary,Peak,$12.78,$13.99
+NO,Norway,IT,Italy,NonPeak,$11.35,$10.37
+NO,Norway,IT,Italy,Peak,$13.39,$12.24
+NO,Norway,IT10,Sicily,NonPeak,$11.82,$17.17
+NO,Norway,IT10,Sicily,Peak,$13.95,$20.26
+NO,Norway,JA01,Japan-Central,NonPeak,$8.88,$10.50
+NO,Norway,JA01,Japan-Central,Peak,$10.48,$12.39
+NO,Norway,JA02,Japan-South (Excludes Hokkaido),NonPeak,$9.31,$17.59
+NO,Norway,JA02,Japan-South (Excludes Hokkaido),Peak,$10.99,$20.76
+NO,Norway,JA03,Japan-North,NonPeak,$9.77,$12.03
+NO,Norway,JA03,Japan-North,Peak,$11.53,$14.20
+NO,Norway,JA96,Okinawa,NonPeak,$10.21,$12.66
+NO,Norway,JA96,Okinawa,Peak,$12.05,$14.94
+NO,Norway,KS,"Korea, Republic Of",NonPeak,$10.65,$17.97
+NO,Norway,KS,"Korea, Republic Of",Peak,$12.57,$21.20
+NO,Norway,KU,Kuwait,NonPeak,$10.35,$12.36
+NO,Norway,KU,Kuwait,Peak,$12.21,$14.58
+NO,Norway,NL,Netherlands,NonPeak,$10.83,$10.91
+NO,Norway,NL,Netherlands,Peak,$12.78,$12.87
+NO,Norway,NO,Norway,NonPeak,$11.35,$18.51
+NO,Norway,NO,Norway,Peak,$13.39,$21.84
+NO,Norway,PA,Paraguay,NonPeak,$11.82,$12.70
+NO,Norway,PA,Paraguay,Peak,$13.95,$14.99
+NO,Norway,PE,Peru,NonPeak,$8.88,$11.24
+NO,Norway,PE,Peru,Peak,$10.48,$13.26
+NO,Norway,PL,Poland,NonPeak,$9.31,$19.00
+NO,Norway,PL,Poland,Peak,$10.99,$22.42
+NO,Norway,PO,Portugal,NonPeak,$9.77,$12.99
+NO,Norway,PO,Portugal,Peak,$11.53,$15.33
+NO,Norway,PO01,Azores,NonPeak,$10.21,$11.54
+NO,Norway,PO01,Azores,Peak,$12.05,$13.62
+NO,Norway,QA,Qatar,NonPeak,$10.65,$16.89
+NO,Norway,QA,Qatar,Peak,$12.57,$19.93
+NO,Norway,RO,Romania,NonPeak,$10.35,$11.66
+NO,Norway,RO,Romania,Peak,$12.21,$13.76
+NO,Norway,RQ,Puerto Rico,NonPeak,$10.83,$10.16
+NO,Norway,RQ,Puerto Rico,Peak,$12.78,$11.99
+NO,Norway,SA,Saudi Arabia,NonPeak,$11.35,$16.98
+NO,Norway,SA,Saudi Arabia,Peak,$13.39,$20.04
+NO,Norway,SN,Singapore,NonPeak,$11.82,$11.75
+NO,Norway,SN,Singapore,Peak,$13.95,$13.86
+NO,Norway,SP,Spain,NonPeak,$8.88,$10.25
+NO,Norway,SP,Spain,Peak,$10.48,$12.09
+NO,Norway,TU,Turkey,NonPeak,$9.31,$17.11
+NO,Norway,TU,Turkey,Peak,$10.99,$20.19
+NO,Norway,UK,United Kingdom,NonPeak,$9.77,$11.86
+NO,Norway,UK,United Kingdom,Peak,$11.53,$13.99
+NO,Norway,US8030400,Alaska (Zone) IV,NonPeak,$10.21,$10.37
+NO,Norway,US8030400,Alaska (Zone) IV,Peak,$12.05,$12.24
+NO,Norway,US8050500,Alaska (Zone) III,NonPeak,$10.65,$17.17
+NO,Norway,US8050500,Alaska (Zone) III,Peak,$12.57,$20.26
+NO,Norway,US8101000,Alaska (Zone) I,NonPeak,$10.35,$10.50
+NO,Norway,US8101000,Alaska (Zone) I,Peak,$12.21,$12.39
+NO,Norway,US8190100,Alaska (Zone) II,NonPeak,$10.83,$17.59
+NO,Norway,US8190100,Alaska (Zone) II,Peak,$12.78,$20.76
+NO,Norway,US89,Hawaii,NonPeak,$11.35,$12.03
+NO,Norway,US89,Hawaii,Peak,$13.39,$14.20
+NO,Norway,UY,Uruguay,NonPeak,$11.82,$12.66
+NO,Norway,UY,Uruguay,Peak,$13.95,$14.94
+NO,Norway,VE,Venezuela,NonPeak,$8.88,$17.97
+NO,Norway,VE,Venezuela,Peak,$10.48,$21.20
+PA,Paraguay,AR,Argentina,NonPeak,$9.31,$12.36
+PA,Paraguay,AR,Argentina,Peak,$10.99,$14.58
+PA,Paraguay,AS11,New South Wales/Australian Capital Territory,NonPeak,$9.77,$10.91
+PA,Paraguay,AS11,New South Wales/Australian Capital Territory,Peak,$11.53,$12.87
+PA,Paraguay,AS21,Northern Territory,NonPeak,$10.21,$18.51
+PA,Paraguay,AS21,Northern Territory,Peak,$12.05,$21.84
+PA,Paraguay,BA,Bahrain,NonPeak,$10.65,$12.70
+PA,Paraguay,BA,Bahrain,Peak,$12.57,$14.99
+PA,Paraguay,BE,Belgium,NonPeak,$10.35,$11.24
+PA,Paraguay,BE,Belgium,Peak,$12.21,$13.26
+PA,Paraguay,BL,Bolivia,NonPeak,$10.83,$19.00
+PA,Paraguay,BL,Bolivia,Peak,$12.78,$22.42
+PA,Paraguay,BR,Brazil - Brazilia,NonPeak,$11.35,$12.99
+PA,Paraguay,BR,Brazil - Brazilia,Peak,$13.39,$15.33
+PA,Paraguay,CA10,Ontario,NonPeak,$11.82,$11.54
+PA,Paraguay,CA10,Ontario,Peak,$13.95,$13.62
+PA,Paraguay,CA20,Quebec,NonPeak,$8.88,$16.89
+PA,Paraguay,CA20,Quebec,Peak,$10.48,$19.93
+PA,Paraguay,CA30,Manitoba,NonPeak,$9.31,$11.66
+PA,Paraguay,CA30,Manitoba,Peak,$10.99,$13.76
+PA,Paraguay,CI,Chile,NonPeak,$9.77,$10.16
+PA,Paraguay,CI,Chile,Peak,$11.53,$11.99
+PA,Paraguay,CO,Colombia,NonPeak,$10.21,$16.98
+PA,Paraguay,CO,Colombia,Peak,$12.05,$20.04
+PA,Paraguay,CS,Costa Rica,NonPeak,$10.65,$11.75
+PA,Paraguay,CS,Costa Rica,Peak,$12.57,$13.86
+PA,Paraguay,EC,Ecuador,NonPeak,$10.35,$10.25
+PA,Paraguay,EC,Ecuador,Peak,$12.21,$12.09
+PA,Paraguay,ES,El Salvador,NonPeak,$10.83,$17.11
+PA,Paraguay,ES,El Salvador,Peak,$12.78,$20.19
+PA,Paraguay,GE,Germany,NonPeak,$11.35,$11.86
+PA,Paraguay,GE,Germany,Peak,$13.39,$13.99
+PA,Paraguay,GQ,Guam,NonPeak,$11.82,$10.37
+PA,Paraguay,GQ,Guam,Peak,$13.95,$12.24
+PA,Paraguay,GR,Greece,NonPeak,$8.88,$17.17
+PA,Paraguay,GR,Greece,Peak,$10.48,$20.26
+PA,Paraguay,GR29,Crete,NonPeak,$9.31,$10.50
+PA,Paraguay,GR29,Crete,Peak,$10.99,$12.39
+PA,Paraguay,GT,Guatemala,NonPeak,$9.77,$17.59
+PA,Paraguay,GT,Guatemala,Peak,$11.53,$20.76
+PA,Paraguay,HO,Honduras,NonPeak,$10.21,$12.03
+PA,Paraguay,HO,Honduras,Peak,$12.05,$14.20
+PA,Paraguay,HU,Hungary,NonPeak,$10.65,$12.66
+PA,Paraguay,HU,Hungary,Peak,$12.57,$14.94
+PA,Paraguay,IT,Italy,NonPeak,$10.35,$17.97
+PA,Paraguay,IT,Italy,Peak,$12.21,$21.20
+PA,Paraguay,IT10,Sicily,NonPeak,$10.83,$12.36
+PA,Paraguay,IT10,Sicily,Peak,$12.78,$14.58
+PA,Paraguay,JA01,Japan-Central,NonPeak,$11.35,$10.91
+PA,Paraguay,JA01,Japan-Central,Peak,$13.39,$12.87
+PA,Paraguay,JA02,Japan-South (Excludes Hokkaido),NonPeak,$11.82,$18.51
+PA,Paraguay,JA02,Japan-South (Excludes Hokkaido),Peak,$13.95,$21.84
+PA,Paraguay,JA03,Japan-North,NonPeak,$8.88,$12.70
+PA,Paraguay,JA03,Japan-North,Peak,$10.48,$14.99
+PA,Paraguay,JA96,Okinawa,NonPeak,$9.31,$11.24
+PA,Paraguay,JA96,Okinawa,Peak,$10.99,$13.26
+PA,Paraguay,KS,"Korea, Republic Of",NonPeak,$9.77,$19.00
+PA,Paraguay,KS,"Korea, Republic Of",Peak,$11.53,$22.42
+PA,Paraguay,KU,Kuwait,NonPeak,$10.21,$12.99
+PA,Paraguay,KU,Kuwait,Peak,$12.05,$15.33
+PA,Paraguay,NL,Netherlands,NonPeak,$10.65,$11.54
+PA,Paraguay,NL,Netherlands,Peak,$12.57,$13.62
+PA,Paraguay,NO,Norway,NonPeak,$10.35,$16.89
+PA,Paraguay,NO,Norway,Peak,$12.21,$19.93
+PA,Paraguay,PA,Paraguay,NonPeak,$10.83,$11.66
+PA,Paraguay,PA,Paraguay,Peak,$12.78,$13.76
+PA,Paraguay,PE,Peru,NonPeak,$11.35,$10.16
+PA,Paraguay,PE,Peru,Peak,$13.39,$11.99
+PA,Paraguay,PL,Poland,NonPeak,$11.82,$16.98
+PA,Paraguay,PL,Poland,Peak,$13.95,$20.04
+PA,Paraguay,PO,Portugal,NonPeak,$8.88,$11.75
+PA,Paraguay,PO,Portugal,Peak,$10.48,$13.86
+PA,Paraguay,PO01,Azores,NonPeak,$9.31,$10.25
+PA,Paraguay,PO01,Azores,Peak,$10.99,$12.09
+PA,Paraguay,QA,Qatar,NonPeak,$9.77,$17.11
+PA,Paraguay,QA,Qatar,Peak,$11.53,$20.19
+PA,Paraguay,RO,Romania,NonPeak,$10.21,$11.86
+PA,Paraguay,RO,Romania,Peak,$12.05,$13.99
+PA,Paraguay,RQ,Puerto Rico,NonPeak,$10.65,$10.37
+PA,Paraguay,RQ,Puerto Rico,Peak,$12.57,$12.24
+PA,Paraguay,SA,Saudi Arabia,NonPeak,$10.35,$17.17
+PA,Paraguay,SA,Saudi Arabia,Peak,$12.21,$20.26
+PA,Paraguay,SN,Singapore,NonPeak,$10.83,$10.50
+PA,Paraguay,SN,Singapore,Peak,$12.78,$12.39
+PA,Paraguay,SP,Spain,NonPeak,$11.35,$17.59
+PA,Paraguay,SP,Spain,Peak,$13.39,$20.76
+PA,Paraguay,TU,Turkey,NonPeak,$11.82,$12.03
+PA,Paraguay,TU,Turkey,Peak,$13.95,$14.20
+PA,Paraguay,UK,United Kingdom,NonPeak,$8.88,$12.66
+PA,Paraguay,UK,United Kingdom,Peak,$10.48,$14.94
+PA,Paraguay,US8030400,Alaska (Zone) IV,NonPeak,$9.31,$17.97
+PA,Paraguay,US8030400,Alaska (Zone) IV,Peak,$10.99,$21.20
+PA,Paraguay,US8050500,Alaska (Zone) III,NonPeak,$9.77,$12.36
+PA,Paraguay,US8050500,Alaska (Zone) III,Peak,$11.53,$14.58
+PA,Paraguay,US8101000,Alaska (Zone) I,NonPeak,$10.21,$10.91
+PA,Paraguay,US8101000,Alaska (Zone) I,Peak,$12.05,$12.87
+PA,Paraguay,US8190100,Alaska (Zone) II,NonPeak,$10.65,$18.51
+PA,Paraguay,US8190100,Alaska (Zone) II,Peak,$12.57,$21.84
+PA,Paraguay,US89,Hawaii,NonPeak,$10.35,$12.70
+PA,Paraguay,US89,Hawaii,Peak,$12.21,$14.99
+PA,Paraguay,UY,Uruguay,NonPeak,$10.83,$11.24
+PA,Paraguay,UY,Uruguay,Peak,$12.78,$13.26
+PA,Paraguay,VE,Venezuela,NonPeak,$11.35,$19.00
+PA,Paraguay,VE,Venezuela,Peak,$13.39,$22.42
+PE,Peru,AR,Argentina,NonPeak,$11.82,$12.99
+PE,Peru,AR,Argentina,Peak,$13.95,$15.33
+PE,Peru,AS11,New South Wales/Australian Capital Territory,NonPeak,$8.88,$11.54
+PE,Peru,AS11,New South Wales/Australian Capital Territory,Peak,$10.48,$13.62
+PE,Peru,AS21,Northern Territory,NonPeak,$9.31,$16.89
+PE,Peru,AS21,Northern Territory,Peak,$10.99,$19.93
+PE,Peru,BA,Bahrain,NonPeak,$9.77,$11.66
+PE,Peru,BA,Bahrain,Peak,$11.53,$13.76
+PE,Peru,BE,Belgium,NonPeak,$10.21,$10.16
+PE,Peru,BE,Belgium,Peak,$12.05,$11.99
+PE,Peru,BL,Bolivia,NonPeak,$10.65,$16.98
+PE,Peru,BL,Bolivia,Peak,$12.57,$20.04
+PE,Peru,BR,Brazil - Brazilia,NonPeak,$10.35,$11.75
+PE,Peru,BR,Brazil - Brazilia,Peak,$12.21,$13.86
+PE,Peru,CA10,Ontario,NonPeak,$10.83,$10.25
+PE,Peru,CA10,Ontario,Peak,$12.78,$12.09
+PE,Peru,CA20,Quebec,NonPeak,$11.35,$17.11
+PE,Peru,CA20,Quebec,Peak,$13.39,$20.19
+PE,Peru,CA30,Manitoba,NonPeak,$11.82,$11.86
+PE,Peru,CA30,Manitoba,Peak,$13.95,$13.99
+PE,Peru,CI,Chile,NonPeak,$8.88,$10.37
+PE,Peru,CI,Chile,Peak,$10.48,$12.24
+PE,Peru,CO,Colombia,NonPeak,$9.31,$17.17
+PE,Peru,CO,Colombia,Peak,$10.99,$20.26
+PE,Peru,CS,Costa Rica,NonPeak,$9.77,$10.50
+PE,Peru,CS,Costa Rica,Peak,$11.53,$12.39
+PE,Peru,EC,Ecuador,NonPeak,$10.21,$17.59
+PE,Peru,EC,Ecuador,Peak,$12.05,$20.76
+PE,Peru,ES,El Salvador,NonPeak,$10.65,$12.03
+PE,Peru,ES,El Salvador,Peak,$12.57,$14.20
+PE,Peru,GE,Germany,NonPeak,$10.35,$12.66
+PE,Peru,GE,Germany,Peak,$12.21,$14.94
+PE,Peru,GQ,Guam,NonPeak,$10.83,$17.97
+PE,Peru,GQ,Guam,Peak,$12.78,$21.20
+PE,Peru,GR,Greece,NonPeak,$11.35,$12.36
+PE,Peru,GR,Greece,Peak,$13.39,$14.58
+PE,Peru,GR29,Crete,NonPeak,$11.82,$10.91
+PE,Peru,GR29,Crete,Peak,$13.95,$12.87
+PE,Peru,GT,Guatemala,NonPeak,$8.88,$18.51
+PE,Peru,GT,Guatemala,Peak,$10.48,$21.84
+PE,Peru,HO,Honduras,NonPeak,$9.31,$12.70
+PE,Peru,HO,Honduras,Peak,$10.99,$14.99
+PE,Peru,HU,Hungary,NonPeak,$9.77,$11.24
+PE,Peru,HU,Hungary,Peak,$11.53,$13.26
+PE,Peru,IT,Italy,NonPeak,$10.21,$19.00
+PE,Peru,IT,Italy,Peak,$12.05,$22.42
+PE,Peru,IT10,Sicily,NonPeak,$10.65,$12.99
+PE,Peru,IT10,Sicily,Peak,$12.57,$15.33
+PE,Peru,JA01,Japan-Central,NonPeak,$10.35,$11.54
+PE,Peru,JA01,Japan-Central,Peak,$12.21,$13.62
+PE,Peru,JA02,Japan-South (Excludes Hokkaido),NonPeak,$10.83,$16.89
+PE,Peru,JA02,Japan-South (Excludes Hokkaido),Peak,$12.78,$19.93
+PE,Peru,JA03,Japan-North,NonPeak,$11.35,$11.66
+PE,Peru,JA03,Japan-North,Peak,$13.39,$13.76
+PE,Peru,JA96,Okinawa,NonPeak,$11.82,$10.16
+PE,Peru,JA96,Okinawa,Peak,$13.95,$11.99
+PE,Peru,KS,"Korea, Republic Of",NonPeak,$8.88,$16.98
+PE,Peru,KS,"Korea, Republic Of",Peak,$10.48,$20.04
+PE,Peru,KU,Kuwait,NonPeak,$9.31,$11.75
+PE,Peru,KU,Kuwait,Peak,$10.99,$13.86
+PE,Peru,NL,Netherlands,NonPeak,$9.77,$10.25
+PE,Peru,NL,Netherlands,Peak,$11.53,$12.09
+PE,Peru,NO,Norway,NonPeak,$10.21,$17.11
+PE,Peru,NO,Norway,Peak,$12.05,$20.19
+PE,Peru,PA,Paraguay,NonPeak,$10.65,$11.86
+PE,Peru,PA,Paraguay,Peak,$12.57,$13.99
+PE,Peru,PE,Peru,NonPeak,$10.35,$10.37
+PE,Peru,PE,Peru,Peak,$12.21,$12.24
+PE,Peru,PL,Poland,NonPeak,$10.83,$17.17
+PE,Peru,PL,Poland,Peak,$12.78,$20.26
+PE,Peru,PO,Portugal,NonPeak,$11.35,$10.50
+PE,Peru,PO,Portugal,Peak,$13.39,$12.39
+PE,Peru,PO01,Azores,NonPeak,$11.82,$17.59
+PE,Peru,PO01,Azores,Peak,$13.95,$20.76
+PE,Peru,QA,Qatar,NonPeak,$8.88,$12.03
+PE,Peru,QA,Qatar,Peak,$10.48,$14.20
+PE,Peru,RO,Romania,NonPeak,$9.31,$12.66
+PE,Peru,RO,Romania,Peak,$10.99,$14.94
+PE,Peru,RQ,Puerto Rico,NonPeak,$9.77,$17.97
+PE,Peru,RQ,Puerto Rico,Peak,$11.53,$21.20
+PE,Peru,SA,Saudi Arabia,NonPeak,$10.21,$12.36
+PE,Peru,SA,Saudi Arabia,Peak,$12.05,$14.58
+PE,Peru,SN,Singapore,NonPeak,$10.65,$10.91
+PE,Peru,SN,Singapore,Peak,$12.57,$12.87
+PE,Peru,SP,Spain,NonPeak,$10.35,$18.51
+PE,Peru,SP,Spain,Peak,$12.21,$21.84
+PE,Peru,TU,Turkey,NonPeak,$10.83,$12.70
+PE,Peru,TU,Turkey,Peak,$12.78,$14.99
+PE,Peru,UK,United Kingdom,NonPeak,$11.35,$11.24
+PE,Peru,UK,United Kingdom,Peak,$13.39,$13.26
+PE,Peru,US8030400,Alaska (Zone) IV,NonPeak,$11.82,$19.00
+PE,Peru,US8030400,Alaska (Zone) IV,Peak,$13.95,$22.42
+PE,Peru,US8050500,Alaska (Zone) III,NonPeak,$8.88,$12.99
+PE,Peru,US8050500,Alaska (Zone) III,Peak,$10.48,$15.33
+PE,Peru,US8101000,Alaska (Zone) I,NonPeak,$9.31,$11.54
+PE,Peru,US8101000,Alaska (Zone) I,Peak,$10.99,$13.62
+PE,Peru,US8190100,Alaska (Zone) II,NonPeak,$9.77,$16.89
+PE,Peru,US8190100,Alaska (Zone) II,Peak,$11.53,$19.93
+PE,Peru,US89,Hawaii,NonPeak,$10.21,$11.66
+PE,Peru,US89,Hawaii,Peak,$12.05,$13.76
+PE,Peru,UY,Uruguay,NonPeak,$10.65,$10.16
+PE,Peru,UY,Uruguay,Peak,$12.57,$11.99
+PE,Peru,VE,Venezuela,NonPeak,$10.35,$16.98
+PE,Peru,VE,Venezuela,Peak,$12.21,$20.04
+PL,Poland,AR,Argentina,NonPeak,$10.83,$11.75
+PL,Poland,AR,Argentina,Peak,$12.78,$13.86
+PL,Poland,AS11,New South Wales/Australian Capital Territory,NonPeak,$11.35,$10.25
+PL,Poland,AS11,New South Wales/Australian Capital Territory,Peak,$13.39,$12.09
+PL,Poland,AS21,Northern Territory,NonPeak,$11.82,$17.11
+PL,Poland,AS21,Northern Territory,Peak,$13.95,$20.19
+PL,Poland,BA,Bahrain,NonPeak,$8.88,$11.86
+PL,Poland,BA,Bahrain,Peak,$10.48,$13.99
+PL,Poland,BE,Belgium,NonPeak,$9.31,$10.37
+PL,Poland,BE,Belgium,Peak,$10.99,$12.24
+PL,Poland,BL,Bolivia,NonPeak,$9.77,$17.17
+PL,Poland,BL,Bolivia,Peak,$11.53,$20.26
+PL,Poland,BR,Brazil - Brazilia,NonPeak,$10.21,$10.50
+PL,Poland,BR,Brazil - Brazilia,Peak,$12.05,$12.39
+PL,Poland,CA10,Ontario,NonPeak,$10.65,$17.59
+PL,Poland,CA10,Ontario,Peak,$12.57,$20.76
+PL,Poland,CA20,Quebec,NonPeak,$10.35,$12.03
+PL,Poland,CA20,Quebec,Peak,$12.21,$14.20
+PL,Poland,CA30,Manitoba,NonPeak,$10.83,$12.66
+PL,Poland,CA30,Manitoba,Peak,$12.78,$14.94
+PL,Poland,CI,Chile,NonPeak,$11.35,$17.97
+PL,Poland,CI,Chile,Peak,$13.39,$21.20
+PL,Poland,CO,Colombia,NonPeak,$11.82,$12.36
+PL,Poland,CO,Colombia,Peak,$13.95,$14.58
+PL,Poland,CS,Costa Rica,NonPeak,$8.88,$10.91
+PL,Poland,CS,Costa Rica,Peak,$10.48,$12.87
+PL,Poland,EC,Ecuador,NonPeak,$9.31,$18.51
+PL,Poland,EC,Ecuador,Peak,$10.99,$21.84
+PL,Poland,ES,El Salvador,NonPeak,$9.77,$12.70
+PL,Poland,ES,El Salvador,Peak,$11.53,$14.99
+PL,Poland,GE,Germany,NonPeak,$10.21,$11.24
+PL,Poland,GE,Germany,Peak,$12.05,$13.26
+PL,Poland,GQ,Guam,NonPeak,$10.65,$19.00
+PL,Poland,GQ,Guam,Peak,$12.57,$22.42
+PL,Poland,GR,Greece,NonPeak,$10.35,$12.99
+PL,Poland,GR,Greece,Peak,$12.21,$15.33
+PL,Poland,GR29,Crete,NonPeak,$10.83,$11.54
+PL,Poland,GR29,Crete,Peak,$12.78,$13.62
+PL,Poland,GT,Guatemala,NonPeak,$11.35,$16.89
+PL,Poland,GT,Guatemala,Peak,$13.39,$19.93
+PL,Poland,HO,Honduras,NonPeak,$11.82,$11.66
+PL,Poland,HO,Honduras,Peak,$13.95,$13.76
+PL,Poland,HU,Hungary,NonPeak,$8.88,$10.16
+PL,Poland,HU,Hungary,Peak,$10.48,$11.99
+PL,Poland,IT,Italy,NonPeak,$9.31,$16.98
+PL,Poland,IT,Italy,Peak,$10.99,$20.04
+PL,Poland,IT10,Sicily,NonPeak,$9.77,$11.75
+PL,Poland,IT10,Sicily,Peak,$11.53,$13.86
+PL,Poland,JA01,Japan-Central,NonPeak,$10.21,$10.25
+PL,Poland,JA01,Japan-Central,Peak,$12.05,$12.09
+PL,Poland,JA02,Japan-South (Excludes Hokkaido),NonPeak,$10.65,$17.11
+PL,Poland,JA02,Japan-South (Excludes Hokkaido),Peak,$12.57,$20.19
+PL,Poland,JA03,Japan-North,NonPeak,$10.35,$11.86
+PL,Poland,JA03,Japan-North,Peak,$12.21,$13.99
+PL,Poland,JA96,Okinawa,NonPeak,$10.83,$10.37
+PL,Poland,JA96,Okinawa,Peak,$12.78,$12.24
+PL,Poland,KS,"Korea, Republic Of",NonPeak,$11.35,$17.17
+PL,Poland,KS,"Korea, Republic Of",Peak,$13.39,$20.26
+PL,Poland,KU,Kuwait,NonPeak,$11.82,$10.50
+PL,Poland,KU,Kuwait,Peak,$13.95,$12.39
+PL,Poland,NL,Netherlands,NonPeak,$8.88,$17.59
+PL,Poland,NL,Netherlands,Peak,$10.48,$20.76
+PL,Poland,NO,Norway,NonPeak,$9.31,$12.03
+PL,Poland,NO,Norway,Peak,$10.99,$14.20
+PL,Poland,PA,Paraguay,NonPeak,$9.77,$12.66
+PL,Poland,PA,Paraguay,Peak,$11.53,$14.94
+PL,Poland,PE,Peru,NonPeak,$10.21,$17.97
+PL,Poland,PE,Peru,Peak,$12.05,$21.20
+PL,Poland,PL,Poland,NonPeak,$10.65,$12.36
+PL,Poland,PL,Poland,Peak,$12.57,$14.58
+PL,Poland,PO,Portugal,NonPeak,$10.35,$10.91
+PL,Poland,PO,Portugal,Peak,$12.21,$12.87
+PL,Poland,PO01,Azores,NonPeak,$10.83,$18.51
+PL,Poland,PO01,Azores,Peak,$12.78,$21.84
+PL,Poland,QA,Qatar,NonPeak,$11.35,$12.70
+PL,Poland,QA,Qatar,Peak,$13.39,$14.99
+PL,Poland,RO,Romania,NonPeak,$11.82,$11.24
+PL,Poland,RO,Romania,Peak,$13.95,$13.26
+PL,Poland,RQ,Puerto Rico,NonPeak,$8.88,$19.00
+PL,Poland,RQ,Puerto Rico,Peak,$10.48,$22.42
+PL,Poland,SA,Saudi Arabia,NonPeak,$9.31,$12.99
+PL,Poland,SA,Saudi Arabia,Peak,$10.99,$15.33
+PL,Poland,SN,Singapore,NonPeak,$9.77,$11.54
+PL,Poland,SN,Singapore,Peak,$11.53,$13.62
+PL,Poland,SP,Spain,NonPeak,$10.21,$16.89
+PL,Poland,SP,Spain,Peak,$12.05,$19.93
+PL,Poland,TU,Turkey,NonPeak,$10.65,$11.66
+PL,Poland,TU,Turkey,Peak,$12.57,$13.76
+PL,Poland,UK,United Kingdom,NonPeak,$10.35,$10.16
+PL,Poland,UK,United Kingdom,Peak,$12.21,$11.99
+PL,Poland,US8030400,Alaska (Zone) IV,NonPeak,$10.83,$16.98
+PL,Poland,US8030400,Alaska (Zone) IV,Peak,$12.78,$20.04
+PL,Poland,US8050500,Alaska (Zone) III,NonPeak,$11.35,$11.75
+PL,Poland,US8050500,Alaska (Zone) III,Peak,$13.39,$13.86
+PL,Poland,US8101000,Alaska (Zone) I,NonPeak,$11.82,$10.25
+PL,Poland,US8101000,Alaska (Zone) I,Peak,$13.95,$12.09
+PL,Poland,US8190100,Alaska (Zone) II,NonPeak,$8.88,$17.11
+PL,Poland,US8190100,Alaska (Zone) II,Peak,$10.48,$20.19
+PL,Poland,US89,Hawaii,NonPeak,$9.31,$11.86
+PL,Poland,US89,Hawaii,Peak,$10.99,$13.99
+PL,Poland,UY,Uruguay,NonPeak,$9.77,$10.37
+PL,Poland,UY,Uruguay,Peak,$11.53,$12.24
+PL,Poland,VE,Venezuela,NonPeak,$10.21,$17.17
+PL,Poland,VE,Venezuela,Peak,$12.05,$20.26
+PO,Portugal,AR,Argentina,NonPeak,$10.65,$10.50
+PO,Portugal,AR,Argentina,Peak,$12.57,$12.39
+PO,Portugal,AS11,New South Wales/Australian Capital Territory,NonPeak,$10.35,$17.59
+PO,Portugal,AS11,New South Wales/Australian Capital Territory,Peak,$12.21,$20.76
+PO,Portugal,AS21,Northern Territory,NonPeak,$10.83,$12.03
+PO,Portugal,AS21,Northern Territory,Peak,$12.78,$14.20
+PO,Portugal,BA,Bahrain,NonPeak,$11.35,$12.66
+PO,Portugal,BA,Bahrain,Peak,$13.39,$14.94
+PO,Portugal,BE,Belgium,NonPeak,$11.82,$17.97
+PO,Portugal,BE,Belgium,Peak,$13.95,$21.20
+PO,Portugal,BL,Bolivia,NonPeak,$8.88,$12.36
+PO,Portugal,BL,Bolivia,Peak,$10.48,$14.58
+PO,Portugal,BR,Brazil - Brazilia,NonPeak,$9.31,$10.91
+PO,Portugal,BR,Brazil - Brazilia,Peak,$10.99,$12.87
+PO,Portugal,CA10,Ontario,NonPeak,$9.77,$18.51
+PO,Portugal,CA10,Ontario,Peak,$11.53,$21.84
+PO,Portugal,CA20,Quebec,NonPeak,$10.21,$12.70
+PO,Portugal,CA20,Quebec,Peak,$12.05,$14.99
+PO,Portugal,CA30,Manitoba,NonPeak,$10.65,$11.24
+PO,Portugal,CA30,Manitoba,Peak,$12.57,$13.26
+PO,Portugal,CI,Chile,NonPeak,$10.35,$19.00
+PO,Portugal,CI,Chile,Peak,$12.21,$22.42
+PO,Portugal,CO,Colombia,NonPeak,$10.83,$12.99
+PO,Portugal,CO,Colombia,Peak,$12.78,$15.33
+PO,Portugal,CS,Costa Rica,NonPeak,$11.35,$11.54
+PO,Portugal,CS,Costa Rica,Peak,$13.39,$13.62
+PO,Portugal,EC,Ecuador,NonPeak,$11.82,$16.89
+PO,Portugal,EC,Ecuador,Peak,$13.95,$19.93
+PO,Portugal,ES,El Salvador,NonPeak,$8.88,$11.66
+PO,Portugal,ES,El Salvador,Peak,$10.48,$13.76
+PO,Portugal,GE,Germany,NonPeak,$9.31,$10.16
+PO,Portugal,GE,Germany,Peak,$10.99,$11.99
+PO,Portugal,GQ,Guam,NonPeak,$9.77,$16.98
+PO,Portugal,GQ,Guam,Peak,$11.53,$20.04
+PO,Portugal,GR,Greece,NonPeak,$10.21,$11.75
+PO,Portugal,GR,Greece,Peak,$12.05,$13.86
+PO,Portugal,GR29,Crete,NonPeak,$10.65,$10.25
+PO,Portugal,GR29,Crete,Peak,$12.57,$12.09
+PO,Portugal,GT,Guatemala,NonPeak,$10.35,$17.11
+PO,Portugal,GT,Guatemala,Peak,$12.21,$20.19
+PO,Portugal,HO,Honduras,NonPeak,$10.83,$11.86
+PO,Portugal,HO,Honduras,Peak,$12.78,$13.99
+PO,Portugal,HU,Hungary,NonPeak,$11.35,$10.37
+PO,Portugal,HU,Hungary,Peak,$13.39,$12.24
+PO,Portugal,IT,Italy,NonPeak,$11.82,$17.17
+PO,Portugal,IT,Italy,Peak,$13.95,$20.26
+PO,Portugal,IT10,Sicily,NonPeak,$8.88,$10.50
+PO,Portugal,IT10,Sicily,Peak,$10.48,$12.39
+PO,Portugal,JA01,Japan-Central,NonPeak,$9.31,$17.59
+PO,Portugal,JA01,Japan-Central,Peak,$10.99,$20.76
+PO,Portugal,JA02,Japan-South (Excludes Hokkaido),NonPeak,$9.77,$12.03
+PO,Portugal,JA02,Japan-South (Excludes Hokkaido),Peak,$11.53,$14.20
+PO,Portugal,JA03,Japan-North,NonPeak,$10.21,$12.66
+PO,Portugal,JA03,Japan-North,Peak,$12.05,$14.94
+PO,Portugal,JA96,Okinawa,NonPeak,$10.65,$17.97
+PO,Portugal,JA96,Okinawa,Peak,$12.57,$21.20
+PO,Portugal,KS,"Korea, Republic Of",NonPeak,$10.35,$12.36
+PO,Portugal,KS,"Korea, Republic Of",Peak,$12.21,$14.58
+PO,Portugal,KU,Kuwait,NonPeak,$10.83,$10.91
+PO,Portugal,KU,Kuwait,Peak,$12.78,$12.87
+PO,Portugal,NL,Netherlands,NonPeak,$11.35,$18.51
+PO,Portugal,NL,Netherlands,Peak,$13.39,$21.84
+PO,Portugal,NO,Norway,NonPeak,$11.82,$12.70
+PO,Portugal,NO,Norway,Peak,$13.95,$14.99
+PO,Portugal,PA,Paraguay,NonPeak,$8.88,$11.24
+PO,Portugal,PA,Paraguay,Peak,$10.48,$13.26
+PO,Portugal,PE,Peru,NonPeak,$9.31,$19.00
+PO,Portugal,PE,Peru,Peak,$10.99,$22.42
+PO,Portugal,PL,Poland,NonPeak,$9.77,$12.99
+PO,Portugal,PL,Poland,Peak,$11.53,$15.33
+PO,Portugal,PO,Portugal,NonPeak,$10.21,$11.54
+PO,Portugal,PO,Portugal,Peak,$12.05,$13.62
+PO,Portugal,PO01,Azores,NonPeak,$10.65,$16.89
+PO,Portugal,PO01,Azores,Peak,$12.57,$19.93
+PO,Portugal,QA,Qatar,NonPeak,$10.35,$11.66
+PO,Portugal,QA,Qatar,Peak,$12.21,$13.76
+PO,Portugal,RO,Romania,NonPeak,$10.83,$10.16
+PO,Portugal,RO,Romania,Peak,$12.78,$11.99
+PO,Portugal,RQ,Puerto Rico,NonPeak,$11.35,$16.98
+PO,Portugal,RQ,Puerto Rico,Peak,$13.39,$20.04
+PO,Portugal,SA,Saudi Arabia,NonPeak,$11.82,$11.75
+PO,Portugal,SA,Saudi Arabia,Peak,$13.95,$13.86
+PO,Portugal,SN,Singapore,NonPeak,$8.88,$10.25
+PO,Portugal,SN,Singapore,Peak,$10.48,$12.09
+PO,Portugal,SP,Spain,NonPeak,$9.31,$17.11
+PO,Portugal,SP,Spain,Peak,$10.99,$20.19
+PO,Portugal,TU,Turkey,NonPeak,$9.77,$11.86
+PO,Portugal,TU,Turkey,Peak,$11.53,$13.99
+PO,Portugal,UK,United Kingdom,NonPeak,$10.21,$10.37
+PO,Portugal,UK,United Kingdom,Peak,$12.05,$12.24
+PO,Portugal,US8030400,Alaska (Zone) IV,NonPeak,$10.65,$17.17
+PO,Portugal,US8030400,Alaska (Zone) IV,Peak,$12.57,$20.26
+PO,Portugal,US8050500,Alaska (Zone) III,NonPeak,$10.35,$10.50
+PO,Portugal,US8050500,Alaska (Zone) III,Peak,$12.21,$12.39
+PO,Portugal,US8101000,Alaska (Zone) I,NonPeak,$10.83,$17.59
+PO,Portugal,US8101000,Alaska (Zone) I,Peak,$12.78,$20.76
+PO,Portugal,US8190100,Alaska (Zone) II,NonPeak,$11.35,$12.03
+PO,Portugal,US8190100,Alaska (Zone) II,Peak,$13.39,$14.20
+PO,Portugal,US89,Hawaii,NonPeak,$11.82,$12.66
+PO,Portugal,US89,Hawaii,Peak,$13.95,$14.94
+PO,Portugal,UY,Uruguay,NonPeak,$8.88,$17.97
+PO,Portugal,UY,Uruguay,Peak,$10.48,$21.20
+PO,Portugal,VE,Venezuela,NonPeak,$9.31,$12.36
+PO,Portugal,VE,Venezuela,Peak,$10.99,$14.58
+PO01,Azores,AR,Argentina,NonPeak,$9.77,$10.91
+PO01,Azores,AR,Argentina,Peak,$11.53,$12.87
+PO01,Azores,AS11,New South Wales/Australian Capital Territory,NonPeak,$10.21,$18.51
+PO01,Azores,AS11,New South Wales/Australian Capital Territory,Peak,$12.05,$21.84
+PO01,Azores,AS21,Northern Territory,NonPeak,$10.65,$12.70
+PO01,Azores,AS21,Northern Territory,Peak,$12.57,$14.99
+PO01,Azores,BA,Bahrain,NonPeak,$10.35,$11.24
+PO01,Azores,BA,Bahrain,Peak,$12.21,$13.26
+PO01,Azores,BE,Belgium,NonPeak,$10.83,$19.00
+PO01,Azores,BE,Belgium,Peak,$12.78,$22.42
+PO01,Azores,BL,Bolivia,NonPeak,$11.35,$12.99
+PO01,Azores,BL,Bolivia,Peak,$13.39,$15.33
+PO01,Azores,BR,Brazil - Brazilia,NonPeak,$11.82,$11.54
+PO01,Azores,BR,Brazil - Brazilia,Peak,$13.95,$13.62
+PO01,Azores,CA10,Ontario,NonPeak,$8.88,$16.89
+PO01,Azores,CA10,Ontario,Peak,$10.48,$19.93
+PO01,Azores,CA20,Quebec,NonPeak,$9.31,$11.66
+PO01,Azores,CA20,Quebec,Peak,$10.99,$13.76
+PO01,Azores,CA30,Manitoba,NonPeak,$9.77,$10.16
+PO01,Azores,CA30,Manitoba,Peak,$11.53,$11.99
+PO01,Azores,CI,Chile,NonPeak,$10.21,$16.98
+PO01,Azores,CI,Chile,Peak,$12.05,$20.04
+PO01,Azores,CO,Colombia,NonPeak,$10.65,$11.75
+PO01,Azores,CO,Colombia,Peak,$12.57,$13.86
+PO01,Azores,CS,Costa Rica,NonPeak,$10.35,$10.25
+PO01,Azores,CS,Costa Rica,Peak,$12.21,$12.09
+PO01,Azores,EC,Ecuador,NonPeak,$10.83,$17.11
+PO01,Azores,EC,Ecuador,Peak,$12.78,$20.19
+PO01,Azores,ES,El Salvador,NonPeak,$11.35,$11.86
+PO01,Azores,ES,El Salvador,Peak,$13.39,$13.99
+PO01,Azores,GE,Germany,NonPeak,$11.82,$10.37
+PO01,Azores,GE,Germany,Peak,$13.95,$12.24
+PO01,Azores,GQ,Guam,NonPeak,$8.88,$17.17
+PO01,Azores,GQ,Guam,Peak,$10.48,$20.26
+PO01,Azores,GR,Greece,NonPeak,$9.31,$10.50
+PO01,Azores,GR,Greece,Peak,$10.99,$12.39
+PO01,Azores,GR29,Crete,NonPeak,$9.77,$17.59
+PO01,Azores,GR29,Crete,Peak,$11.53,$20.76
+PO01,Azores,GT,Guatemala,NonPeak,$10.21,$12.03
+PO01,Azores,GT,Guatemala,Peak,$12.05,$14.20
+PO01,Azores,HO,Honduras,NonPeak,$10.65,$12.66
+PO01,Azores,HO,Honduras,Peak,$12.57,$14.94
+PO01,Azores,HU,Hungary,NonPeak,$10.35,$17.97
+PO01,Azores,HU,Hungary,Peak,$12.21,$21.20
+PO01,Azores,IT,Italy,NonPeak,$10.83,$12.36
+PO01,Azores,IT,Italy,Peak,$12.78,$14.58
+PO01,Azores,IT10,Sicily,NonPeak,$11.35,$10.91
+PO01,Azores,IT10,Sicily,Peak,$13.39,$12.87
+PO01,Azores,JA01,Japan-Central,NonPeak,$11.82,$18.51
+PO01,Azores,JA01,Japan-Central,Peak,$13.95,$21.84
+PO01,Azores,JA02,Japan-South (Excludes Hokkaido),NonPeak,$8.88,$12.70
+PO01,Azores,JA02,Japan-South (Excludes Hokkaido),Peak,$10.48,$14.99
+PO01,Azores,JA03,Japan-North,NonPeak,$9.31,$11.24
+PO01,Azores,JA03,Japan-North,Peak,$10.99,$13.26
+PO01,Azores,JA96,Okinawa,NonPeak,$9.77,$19.00
+PO01,Azores,JA96,Okinawa,Peak,$11.53,$22.42
+PO01,Azores,KS,"Korea, Republic Of",NonPeak,$10.21,$12.99
+PO01,Azores,KS,"Korea, Republic Of",Peak,$12.05,$15.33
+PO01,Azores,KU,Kuwait,NonPeak,$10.65,$11.54
+PO01,Azores,KU,Kuwait,Peak,$12.57,$13.62
+PO01,Azores,NL,Netherlands,NonPeak,$10.35,$16.89
+PO01,Azores,NL,Netherlands,Peak,$12.21,$19.93
+PO01,Azores,NO,Norway,NonPeak,$10.83,$11.66
+PO01,Azores,NO,Norway,Peak,$12.78,$13.76
+PO01,Azores,PA,Paraguay,NonPeak,$11.35,$10.16
+PO01,Azores,PA,Paraguay,Peak,$13.39,$11.99
+PO01,Azores,PE,Peru,NonPeak,$11.82,$16.98
+PO01,Azores,PE,Peru,Peak,$13.95,$20.04
+PO01,Azores,PL,Poland,NonPeak,$8.88,$11.75
+PO01,Azores,PL,Poland,Peak,$10.48,$13.86
+PO01,Azores,PO,Portugal,NonPeak,$9.31,$10.25
+PO01,Azores,PO,Portugal,Peak,$10.99,$12.09
+PO01,Azores,PO01,Azores,NonPeak,$9.77,$17.11
+PO01,Azores,PO01,Azores,Peak,$11.53,$20.19
+PO01,Azores,QA,Qatar,NonPeak,$10.21,$11.86
+PO01,Azores,QA,Qatar,Peak,$12.05,$13.99
+PO01,Azores,RO,Romania,NonPeak,$10.65,$10.37
+PO01,Azores,RO,Romania,Peak,$12.57,$12.24
+PO01,Azores,RQ,Puerto Rico,NonPeak,$10.35,$17.17
+PO01,Azores,RQ,Puerto Rico,Peak,$12.21,$20.26
+PO01,Azores,SA,Saudi Arabia,NonPeak,$10.83,$10.50
+PO01,Azores,SA,Saudi Arabia,Peak,$12.78,$12.39
+PO01,Azores,SN,Singapore,NonPeak,$11.35,$17.59
+PO01,Azores,SN,Singapore,Peak,$13.39,$20.76
+PO01,Azores,SP,Spain,NonPeak,$11.82,$12.03
+PO01,Azores,SP,Spain,Peak,$13.95,$14.20
+PO01,Azores,TU,Turkey,NonPeak,$8.88,$12.66
+PO01,Azores,TU,Turkey,Peak,$10.48,$14.94
+PO01,Azores,UK,United Kingdom,NonPeak,$9.31,$17.97
+PO01,Azores,UK,United Kingdom,Peak,$10.99,$21.20
+PO01,Azores,US8030400,Alaska (Zone) IV,NonPeak,$9.77,$12.36
+PO01,Azores,US8030400,Alaska (Zone) IV,Peak,$11.53,$14.58
+PO01,Azores,US8050500,Alaska (Zone) III,NonPeak,$10.21,$10.91
+PO01,Azores,US8050500,Alaska (Zone) III,Peak,$12.05,$12.87
+PO01,Azores,US8101000,Alaska (Zone) I,NonPeak,$10.65,$18.51
+PO01,Azores,US8101000,Alaska (Zone) I,Peak,$12.57,$21.84
+PO01,Azores,US8190100,Alaska (Zone) II,NonPeak,$10.35,$12.70
+PO01,Azores,US8190100,Alaska (Zone) II,Peak,$12.21,$14.99
+PO01,Azores,US89,Hawaii,NonPeak,$10.83,$11.24
+PO01,Azores,US89,Hawaii,Peak,$12.78,$13.26
+PO01,Azores,UY,Uruguay,NonPeak,$11.35,$19.00
+PO01,Azores,UY,Uruguay,Peak,$13.39,$22.42
+PO01,Azores,VE,Venezuela,NonPeak,$11.82,$12.99
+PO01,Azores,VE,Venezuela,Peak,$13.95,$15.33
+QA,Qatar,AR,Argentina,NonPeak,$8.88,$11.54
+QA,Qatar,AR,Argentina,Peak,$10.48,$13.62
+QA,Qatar,AS11,New South Wales/Australian Capital Territory,NonPeak,$9.31,$16.89
+QA,Qatar,AS11,New South Wales/Australian Capital Territory,Peak,$10.99,$19.93
+QA,Qatar,AS21,Northern Territory,NonPeak,$9.77,$11.66
+QA,Qatar,AS21,Northern Territory,Peak,$11.53,$13.76
+QA,Qatar,BA,Bahrain,NonPeak,$10.21,$10.16
+QA,Qatar,BA,Bahrain,Peak,$12.05,$11.99
+QA,Qatar,BE,Belgium,NonPeak,$10.65,$16.98
+QA,Qatar,BE,Belgium,Peak,$12.57,$20.04
+QA,Qatar,BL,Bolivia,NonPeak,$10.35,$11.75
+QA,Qatar,BL,Bolivia,Peak,$12.21,$13.86
+QA,Qatar,BR,Brazil - Brazilia,NonPeak,$10.83,$10.25
+QA,Qatar,BR,Brazil - Brazilia,Peak,$12.78,$12.09
+QA,Qatar,CA10,Ontario,NonPeak,$11.35,$17.11
+QA,Qatar,CA10,Ontario,Peak,$13.39,$20.19
+QA,Qatar,CA20,Quebec,NonPeak,$11.82,$11.86
+QA,Qatar,CA20,Quebec,Peak,$13.95,$13.99
+QA,Qatar,CA30,Manitoba,NonPeak,$8.88,$10.37
+QA,Qatar,CA30,Manitoba,Peak,$10.48,$12.24
+QA,Qatar,CI,Chile,NonPeak,$9.31,$17.17
+QA,Qatar,CI,Chile,Peak,$10.99,$20.26
+QA,Qatar,CO,Colombia,NonPeak,$9.77,$10.50
+QA,Qatar,CO,Colombia,Peak,$11.53,$12.39
+QA,Qatar,CS,Costa Rica,NonPeak,$10.21,$17.59
+QA,Qatar,CS,Costa Rica,Peak,$12.05,$20.76
+QA,Qatar,EC,Ecuador,NonPeak,$10.65,$12.03
+QA,Qatar,EC,Ecuador,Peak,$12.57,$14.20
+QA,Qatar,ES,El Salvador,NonPeak,$10.35,$12.66
+QA,Qatar,ES,El Salvador,Peak,$12.21,$14.94
+QA,Qatar,GE,Germany,NonPeak,$10.83,$17.97
+QA,Qatar,GE,Germany,Peak,$12.78,$21.20
+QA,Qatar,GQ,Guam,NonPeak,$11.35,$12.36
+QA,Qatar,GQ,Guam,Peak,$13.39,$14.58
+QA,Qatar,GR,Greece,NonPeak,$11.82,$10.91
+QA,Qatar,GR,Greece,Peak,$13.95,$12.87
+QA,Qatar,GR29,Crete,NonPeak,$8.88,$18.51
+QA,Qatar,GR29,Crete,Peak,$10.48,$21.84
+QA,Qatar,GT,Guatemala,NonPeak,$9.31,$12.70
+QA,Qatar,GT,Guatemala,Peak,$10.99,$14.99
+QA,Qatar,HO,Honduras,NonPeak,$9.77,$11.24
+QA,Qatar,HO,Honduras,Peak,$11.53,$13.26
+QA,Qatar,HU,Hungary,NonPeak,$10.21,$19.00
+QA,Qatar,HU,Hungary,Peak,$12.05,$22.42
+QA,Qatar,IT,Italy,NonPeak,$10.65,$12.99
+QA,Qatar,IT,Italy,Peak,$12.57,$15.33
+QA,Qatar,IT10,Sicily,NonPeak,$10.35,$11.54
+QA,Qatar,IT10,Sicily,Peak,$12.21,$13.62
+QA,Qatar,JA01,Japan-Central,NonPeak,$10.83,$16.89
+QA,Qatar,JA01,Japan-Central,Peak,$12.78,$19.93
+QA,Qatar,JA02,Japan-South (Excludes Hokkaido),NonPeak,$11.35,$11.66
+QA,Qatar,JA02,Japan-South (Excludes Hokkaido),Peak,$13.39,$13.76
+QA,Qatar,JA03,Japan-North,NonPeak,$11.82,$10.16
+QA,Qatar,JA03,Japan-North,Peak,$13.95,$11.99
+QA,Qatar,JA96,Okinawa,NonPeak,$8.88,$16.98
+QA,Qatar,JA96,Okinawa,Peak,$10.48,$20.04
+QA,Qatar,KS,"Korea, Republic Of",NonPeak,$9.31,$11.75
+QA,Qatar,KS,"Korea, Republic Of",Peak,$10.99,$13.86
+QA,Qatar,KU,Kuwait,NonPeak,$9.77,$10.25
+QA,Qatar,KU,Kuwait,Peak,$11.53,$12.09
+QA,Qatar,NL,Netherlands,NonPeak,$10.21,$17.11
+QA,Qatar,NL,Netherlands,Peak,$12.05,$20.19
+QA,Qatar,NO,Norway,NonPeak,$10.65,$11.86
+QA,Qatar,NO,Norway,Peak,$12.57,$13.99
+QA,Qatar,PA,Paraguay,NonPeak,$10.35,$10.37
+QA,Qatar,PA,Paraguay,Peak,$12.21,$12.24
+QA,Qatar,PE,Peru,NonPeak,$10.83,$17.17
+QA,Qatar,PE,Peru,Peak,$12.78,$20.26
+QA,Qatar,PL,Poland,NonPeak,$11.35,$10.50
+QA,Qatar,PL,Poland,Peak,$13.39,$12.39
+QA,Qatar,PO,Portugal,NonPeak,$11.82,$17.59
+QA,Qatar,PO,Portugal,Peak,$13.95,$20.76
+QA,Qatar,PO01,Azores,NonPeak,$8.88,$12.03
+QA,Qatar,PO01,Azores,Peak,$10.48,$14.20
+QA,Qatar,QA,Qatar,NonPeak,$9.31,$12.66
+QA,Qatar,QA,Qatar,Peak,$10.99,$14.94
+QA,Qatar,RO,Romania,NonPeak,$9.77,$17.97
+QA,Qatar,RO,Romania,Peak,$11.53,$21.20
+QA,Qatar,RQ,Puerto Rico,NonPeak,$10.21,$12.36
+QA,Qatar,RQ,Puerto Rico,Peak,$12.05,$14.58
+QA,Qatar,SA,Saudi Arabia,NonPeak,$10.65,$10.91
+QA,Qatar,SA,Saudi Arabia,Peak,$12.57,$12.87
+QA,Qatar,SN,Singapore,NonPeak,$10.35,$18.51
+QA,Qatar,SN,Singapore,Peak,$12.21,$21.84
+QA,Qatar,SP,Spain,NonPeak,$10.83,$12.70
+QA,Qatar,SP,Spain,Peak,$12.78,$14.99
+QA,Qatar,TU,Turkey,NonPeak,$11.35,$11.24
+QA,Qatar,TU,Turkey,Peak,$13.39,$13.26
+QA,Qatar,UK,United Kingdom,NonPeak,$11.82,$19.00
+QA,Qatar,UK,United Kingdom,Peak,$13.95,$22.42
+QA,Qatar,US8030400,Alaska (Zone) IV,NonPeak,$8.88,$12.99
+QA,Qatar,US8030400,Alaska (Zone) IV,Peak,$10.48,$15.33
+QA,Qatar,US8050500,Alaska (Zone) III,NonPeak,$9.31,$11.54
+QA,Qatar,US8050500,Alaska (Zone) III,Peak,$10.99,$13.62
+QA,Qatar,US8101000,Alaska (Zone) I,NonPeak,$9.77,$16.89
+QA,Qatar,US8101000,Alaska (Zone) I,Peak,$11.53,$19.93
+QA,Qatar,US8190100,Alaska (Zone) II,NonPeak,$10.21,$11.66
+QA,Qatar,US8190100,Alaska (Zone) II,Peak,$12.05,$13.76
+QA,Qatar,US89,Hawaii,NonPeak,$10.65,$10.16
+QA,Qatar,US89,Hawaii,Peak,$12.57,$11.99
+QA,Qatar,UY,Uruguay,NonPeak,$10.35,$16.98
+QA,Qatar,UY,Uruguay,Peak,$12.21,$20.04
+QA,Qatar,VE,Venezuela,NonPeak,$10.83,$11.75
+QA,Qatar,VE,Venezuela,Peak,$12.78,$13.86
+RO,Romania,AR,Argentina,NonPeak,$11.35,$10.25
+RO,Romania,AR,Argentina,Peak,$13.39,$12.09
+RO,Romania,AS11,New South Wales/Australian Capital Territory,NonPeak,$11.82,$17.11
+RO,Romania,AS11,New South Wales/Australian Capital Territory,Peak,$13.95,$20.19
+RO,Romania,AS21,Northern Territory,NonPeak,$8.88,$11.86
+RO,Romania,AS21,Northern Territory,Peak,$10.48,$13.99
+RO,Romania,BA,Bahrain,NonPeak,$9.31,$10.37
+RO,Romania,BA,Bahrain,Peak,$10.99,$12.24
+RO,Romania,BE,Belgium,NonPeak,$9.77,$17.17
+RO,Romania,BE,Belgium,Peak,$11.53,$20.26
+RO,Romania,BL,Bolivia,NonPeak,$10.21,$10.50
+RO,Romania,BL,Bolivia,Peak,$12.05,$12.39
+RO,Romania,BR,Brazil - Brazilia,NonPeak,$10.65,$17.59
+RO,Romania,BR,Brazil - Brazilia,Peak,$12.57,$20.76
+RO,Romania,CA10,Ontario,NonPeak,$10.35,$12.03
+RO,Romania,CA10,Ontario,Peak,$12.21,$14.20
+RO,Romania,CA20,Quebec,NonPeak,$10.35,$16.89
+RO,Romania,CA20,Quebec,Peak,$12.21,$19.93
+RO,Romania,CA30,Manitoba,NonPeak,$10.83,$11.66
+RO,Romania,CA30,Manitoba,Peak,$12.78,$13.76
+RO,Romania,CI,Chile,NonPeak,$11.35,$10.16
+RO,Romania,CI,Chile,Peak,$13.39,$11.99
+RO,Romania,CO,Colombia,NonPeak,$11.82,$16.98
+RO,Romania,CO,Colombia,Peak,$13.95,$20.04
+RO,Romania,CS,Costa Rica,NonPeak,$8.88,$11.75
+RO,Romania,CS,Costa Rica,Peak,$10.48,$13.86
+RO,Romania,EC,Ecuador,NonPeak,$9.31,$10.25
+RO,Romania,EC,Ecuador,Peak,$10.99,$12.09
+RO,Romania,ES,El Salvador,NonPeak,$9.77,$17.11
+RO,Romania,ES,El Salvador,Peak,$11.53,$20.19
+RO,Romania,GE,Germany,NonPeak,$10.21,$11.86
+RO,Romania,GE,Germany,Peak,$12.05,$13.99
+RO,Romania,GQ,Guam,NonPeak,$10.65,$10.37
+RO,Romania,GQ,Guam,Peak,$12.57,$12.24
+RO,Romania,GR,Greece,NonPeak,$10.35,$17.17
+RO,Romania,GR,Greece,Peak,$12.21,$20.26
+RO,Romania,GR29,Crete,NonPeak,$10.83,$10.50
+RO,Romania,GR29,Crete,Peak,$12.78,$12.39
+RO,Romania,GT,Guatemala,NonPeak,$11.35,$17.59
+RO,Romania,GT,Guatemala,Peak,$13.39,$20.76
+RO,Romania,HO,Honduras,NonPeak,$11.82,$12.03
+RO,Romania,HO,Honduras,Peak,$13.95,$14.20
+RO,Romania,HU,Hungary,NonPeak,$8.88,$12.66
+RO,Romania,HU,Hungary,Peak,$10.48,$14.94
+RO,Romania,IT,Italy,NonPeak,$9.31,$17.97
+RO,Romania,IT,Italy,Peak,$10.99,$21.20
+RO,Romania,IT10,Sicily,NonPeak,$9.77,$12.36
+RO,Romania,IT10,Sicily,Peak,$11.53,$14.58
+RO,Romania,JA01,Japan-Central,NonPeak,$10.21,$10.91
+RO,Romania,JA01,Japan-Central,Peak,$12.05,$12.87
+RO,Romania,JA02,Japan-South (Excludes Hokkaido),NonPeak,$10.65,$18.51
+RO,Romania,JA02,Japan-South (Excludes Hokkaido),Peak,$12.57,$21.84
+RO,Romania,JA03,Japan-North,NonPeak,$10.35,$12.70
+RO,Romania,JA03,Japan-North,Peak,$12.21,$14.99
+RO,Romania,JA96,Okinawa,NonPeak,$10.83,$11.24
+RO,Romania,JA96,Okinawa,Peak,$12.78,$13.26
+RO,Romania,KS,"Korea, Republic Of",NonPeak,$11.35,$19.00
+RO,Romania,KS,"Korea, Republic Of",Peak,$13.39,$22.42
+RO,Romania,KU,Kuwait,NonPeak,$11.82,$12.99
+RO,Romania,KU,Kuwait,Peak,$13.95,$15.33
+RO,Romania,NL,Netherlands,NonPeak,$8.88,$11.54
+RO,Romania,NL,Netherlands,Peak,$10.48,$13.62
+RO,Romania,NO,Norway,NonPeak,$9.31,$16.89
+RO,Romania,NO,Norway,Peak,$10.99,$19.93
+RO,Romania,PA,Paraguay,NonPeak,$9.77,$11.66
+RO,Romania,PA,Paraguay,Peak,$11.53,$13.76
+RO,Romania,PE,Peru,NonPeak,$10.21,$10.16
+RO,Romania,PE,Peru,Peak,$12.05,$11.99
+RO,Romania,PL,Poland,NonPeak,$10.65,$16.98
+RO,Romania,PL,Poland,Peak,$12.57,$20.04
+RO,Romania,PO,Portugal,NonPeak,$10.35,$11.75
+RO,Romania,PO,Portugal,Peak,$12.21,$13.86
+RO,Romania,PO01,Azores,NonPeak,$10.83,$10.25
+RO,Romania,PO01,Azores,Peak,$12.78,$12.09
+RO,Romania,QA,Qatar,NonPeak,$11.35,$17.11
+RO,Romania,QA,Qatar,Peak,$13.39,$20.19
+RO,Romania,RO,Romania,NonPeak,$11.82,$11.86
+RO,Romania,RO,Romania,Peak,$13.95,$13.99
+RO,Romania,RQ,Puerto Rico,NonPeak,$8.88,$10.37
+RO,Romania,RQ,Puerto Rico,Peak,$10.48,$12.24
+RO,Romania,SA,Saudi Arabia,NonPeak,$9.31,$17.17
+RO,Romania,SA,Saudi Arabia,Peak,$10.99,$20.26
+RO,Romania,SN,Singapore,NonPeak,$9.77,$10.50
+RO,Romania,SN,Singapore,Peak,$11.53,$12.39
+RO,Romania,SP,Spain,NonPeak,$10.21,$17.59
+RO,Romania,SP,Spain,Peak,$12.05,$20.76
+RO,Romania,TU,Turkey,NonPeak,$10.65,$12.03
+RO,Romania,TU,Turkey,Peak,$12.57,$14.20
+RO,Romania,UK,United Kingdom,NonPeak,$10.35,$12.66
+RO,Romania,UK,United Kingdom,Peak,$12.21,$14.94
+RO,Romania,US8030400,Alaska (Zone) IV,NonPeak,$10.83,$17.97
+RO,Romania,US8030400,Alaska (Zone) IV,Peak,$12.78,$21.20
+RO,Romania,US8050500,Alaska (Zone) III,NonPeak,$11.35,$12.36
+RO,Romania,US8050500,Alaska (Zone) III,Peak,$13.39,$14.58
+RO,Romania,US8101000,Alaska (Zone) I,NonPeak,$11.82,$10.91
+RO,Romania,US8101000,Alaska (Zone) I,Peak,$13.95,$12.87
+RO,Romania,US8190100,Alaska (Zone) II,NonPeak,$8.88,$18.51
+RO,Romania,US8190100,Alaska (Zone) II,Peak,$10.48,$21.84
+RO,Romania,US89,Hawaii,NonPeak,$9.31,$12.70
+RO,Romania,US89,Hawaii,Peak,$10.99,$14.99
+RO,Romania,UY,Uruguay,NonPeak,$9.77,$11.24
+RO,Romania,UY,Uruguay,Peak,$11.53,$13.26
+RO,Romania,VE,Venezuela,NonPeak,$10.21,$19.00
+RO,Romania,VE,Venezuela,Peak,$12.05,$22.42
+RQ,Puerto Rico,AR,Argentina,NonPeak,$10.65,$12.99
+RQ,Puerto Rico,AR,Argentina,Peak,$12.57,$15.33
+RQ,Puerto Rico,AS11,New South Wales/Australian Capital Territory,NonPeak,$10.35,$11.54
+RQ,Puerto Rico,AS11,New South Wales/Australian Capital Territory,Peak,$12.21,$13.62
+RQ,Puerto Rico,AS21,Northern Territory,NonPeak,$10.83,$16.89
+RQ,Puerto Rico,AS21,Northern Territory,Peak,$12.78,$19.93
+RQ,Puerto Rico,BA,Bahrain,NonPeak,$11.35,$11.66
+RQ,Puerto Rico,BA,Bahrain,Peak,$13.39,$13.76
+RQ,Puerto Rico,BE,Belgium,NonPeak,$11.82,$10.16
+RQ,Puerto Rico,BE,Belgium,Peak,$13.95,$11.99
+RQ,Puerto Rico,BL,Bolivia,NonPeak,$8.88,$16.98
+RQ,Puerto Rico,BL,Bolivia,Peak,$10.48,$20.04
+RQ,Puerto Rico,BR,Brazil - Brazilia,NonPeak,$9.31,$11.75
+RQ,Puerto Rico,BR,Brazil - Brazilia,Peak,$10.99,$13.86
+RQ,Puerto Rico,CA10,Ontario,NonPeak,$9.77,$10.25
+RQ,Puerto Rico,CA10,Ontario,Peak,$11.53,$12.09
+RQ,Puerto Rico,CA20,Quebec,NonPeak,$10.21,$17.11
+RQ,Puerto Rico,CA20,Quebec,Peak,$12.05,$20.19
+RQ,Puerto Rico,CA30,Manitoba,NonPeak,$10.65,$11.86
+RQ,Puerto Rico,CA30,Manitoba,Peak,$12.57,$13.99
+RQ,Puerto Rico,CI,Chile,NonPeak,$10.35,$10.37
+RQ,Puerto Rico,CI,Chile,Peak,$12.21,$12.24
+RQ,Puerto Rico,CO,Colombia,NonPeak,$10.83,$17.17
+RQ,Puerto Rico,CO,Colombia,Peak,$12.78,$20.26
+RQ,Puerto Rico,CS,Costa Rica,NonPeak,$11.35,$10.50
+RQ,Puerto Rico,CS,Costa Rica,Peak,$13.39,$12.39
+RQ,Puerto Rico,EC,Ecuador,NonPeak,$11.82,$17.59
+RQ,Puerto Rico,EC,Ecuador,Peak,$13.95,$20.76
+RQ,Puerto Rico,ES,El Salvador,NonPeak,$8.88,$12.03
+RQ,Puerto Rico,ES,El Salvador,Peak,$10.48,$14.20
+RQ,Puerto Rico,GE,Germany,NonPeak,$9.31,$12.66
+RQ,Puerto Rico,GE,Germany,Peak,$10.99,$14.94
+RQ,Puerto Rico,GQ,Guam,NonPeak,$9.77,$17.97
+RQ,Puerto Rico,GQ,Guam,Peak,$11.53,$21.20
+RQ,Puerto Rico,GR,Greece,NonPeak,$10.21,$12.36
+RQ,Puerto Rico,GR,Greece,Peak,$12.05,$14.58
+RQ,Puerto Rico,GR29,Crete,NonPeak,$10.65,$10.91
+RQ,Puerto Rico,GR29,Crete,Peak,$12.57,$12.87
+RQ,Puerto Rico,GT,Guatemala,NonPeak,$10.35,$18.51
+RQ,Puerto Rico,GT,Guatemala,Peak,$12.21,$21.84
+RQ,Puerto Rico,HO,Honduras,NonPeak,$10.83,$12.70
+RQ,Puerto Rico,HO,Honduras,Peak,$12.78,$14.99
+RQ,Puerto Rico,HU,Hungary,NonPeak,$11.35,$11.24
+RQ,Puerto Rico,HU,Hungary,Peak,$13.39,$13.26
+RQ,Puerto Rico,IT,Italy,NonPeak,$11.82,$19.00
+RQ,Puerto Rico,IT,Italy,Peak,$13.95,$22.42
+RQ,Puerto Rico,IT10,Sicily,NonPeak,$8.88,$12.99
+RQ,Puerto Rico,IT10,Sicily,Peak,$10.48,$15.33
+RQ,Puerto Rico,JA01,Japan-Central,NonPeak,$9.31,$11.54
+RQ,Puerto Rico,JA01,Japan-Central,Peak,$10.99,$13.62
+RQ,Puerto Rico,JA02,Japan-South (Excludes Hokkaido),NonPeak,$9.77,$16.89
+RQ,Puerto Rico,JA02,Japan-South (Excludes Hokkaido),Peak,$11.53,$19.93
+RQ,Puerto Rico,JA03,Japan-North,NonPeak,$10.21,$11.66
+RQ,Puerto Rico,JA03,Japan-North,Peak,$12.05,$13.76
+RQ,Puerto Rico,JA96,Okinawa,NonPeak,$10.65,$10.16
+RQ,Puerto Rico,JA96,Okinawa,Peak,$12.57,$11.99
+RQ,Puerto Rico,KS,"Korea, Republic Of",NonPeak,$10.35,$16.98
+RQ,Puerto Rico,KS,"Korea, Republic Of",Peak,$12.21,$20.04
+RQ,Puerto Rico,KU,Kuwait,NonPeak,$10.83,$11.75
+RQ,Puerto Rico,KU,Kuwait,Peak,$12.78,$13.86
+RQ,Puerto Rico,NL,Netherlands,NonPeak,$11.35,$10.25
+RQ,Puerto Rico,NL,Netherlands,Peak,$13.39,$12.09
+RQ,Puerto Rico,NO,Norway,NonPeak,$11.82,$17.11
+RQ,Puerto Rico,NO,Norway,Peak,$13.95,$20.19
+RQ,Puerto Rico,PA,Paraguay,NonPeak,$8.88,$11.86
+RQ,Puerto Rico,PA,Paraguay,Peak,$10.48,$13.99
+RQ,Puerto Rico,PE,Peru,NonPeak,$9.31,$10.37
+RQ,Puerto Rico,PE,Peru,Peak,$10.99,$12.24
+RQ,Puerto Rico,PL,Poland,NonPeak,$9.77,$17.17
+RQ,Puerto Rico,PL,Poland,Peak,$11.53,$20.26
+RQ,Puerto Rico,PO,Portugal,NonPeak,$10.21,$10.50
+RQ,Puerto Rico,PO,Portugal,Peak,$12.05,$12.39
+RQ,Puerto Rico,PO01,Azores,NonPeak,$10.65,$17.59
+RQ,Puerto Rico,PO01,Azores,Peak,$12.57,$20.76
+RQ,Puerto Rico,QA,Qatar,NonPeak,$10.35,$12.03
+RQ,Puerto Rico,QA,Qatar,Peak,$12.21,$14.20
+RQ,Puerto Rico,RO,Romania,NonPeak,$10.83,$12.66
+RQ,Puerto Rico,RO,Romania,Peak,$12.78,$14.94
+RQ,Puerto Rico,RQ,Puerto Rico,NonPeak,$11.35,$17.97
+RQ,Puerto Rico,RQ,Puerto Rico,Peak,$13.39,$21.20
+RQ,Puerto Rico,SA,Saudi Arabia,NonPeak,$11.82,$12.36
+RQ,Puerto Rico,SA,Saudi Arabia,Peak,$13.95,$14.58
+RQ,Puerto Rico,SN,Singapore,NonPeak,$8.88,$10.91
+RQ,Puerto Rico,SN,Singapore,Peak,$10.48,$12.87
+RQ,Puerto Rico,SP,Spain,NonPeak,$9.31,$18.51
+RQ,Puerto Rico,SP,Spain,Peak,$10.99,$21.84
+RQ,Puerto Rico,TU,Turkey,NonPeak,$9.77,$12.70
+RQ,Puerto Rico,TU,Turkey,Peak,$11.53,$14.99
+RQ,Puerto Rico,UK,United Kingdom,NonPeak,$10.21,$11.24
+RQ,Puerto Rico,UK,United Kingdom,Peak,$12.05,$13.26
+RQ,Puerto Rico,US8030400,Alaska (Zone) IV,NonPeak,$10.65,$19.00
+RQ,Puerto Rico,US8030400,Alaska (Zone) IV,Peak,$12.57,$22.42
+RQ,Puerto Rico,US8050500,Alaska (Zone) III,NonPeak,$10.35,$12.99
+RQ,Puerto Rico,US8050500,Alaska (Zone) III,Peak,$12.21,$15.33
+RQ,Puerto Rico,US8101000,Alaska (Zone) I,NonPeak,$10.83,$11.54
+RQ,Puerto Rico,US8101000,Alaska (Zone) I,Peak,$12.78,$13.62
+RQ,Puerto Rico,US8190100,Alaska (Zone) II,NonPeak,$11.35,$16.89
+RQ,Puerto Rico,US8190100,Alaska (Zone) II,Peak,$13.39,$19.93
+RQ,Puerto Rico,US89,Hawaii,NonPeak,$11.82,$11.66
+RQ,Puerto Rico,US89,Hawaii,Peak,$13.95,$13.76
+RQ,Puerto Rico,UY,Uruguay,NonPeak,$8.88,$10.16
+RQ,Puerto Rico,UY,Uruguay,Peak,$10.48,$11.99
+RQ,Puerto Rico,VE,Venezuela,NonPeak,$9.31,$16.98
+RQ,Puerto Rico,VE,Venezuela,Peak,$10.99,$20.04
+SA,Saudi Arabia,AR,Argentina,NonPeak,$9.77,$11.75
+SA,Saudi Arabia,AR,Argentina,Peak,$11.53,$13.86
+SA,Saudi Arabia,AS11,New South Wales/Australian Capital Territory,NonPeak,$10.21,$10.25
+SA,Saudi Arabia,AS11,New South Wales/Australian Capital Territory,Peak,$12.05,$12.09
+SA,Saudi Arabia,AS21,Northern Territory,NonPeak,$10.65,$17.11
+SA,Saudi Arabia,AS21,Northern Territory,Peak,$12.57,$20.19
+SA,Saudi Arabia,BA,Bahrain,NonPeak,$10.35,$11.86
+SA,Saudi Arabia,BA,Bahrain,Peak,$12.21,$13.99
+SA,Saudi Arabia,BE,Belgium,NonPeak,$10.83,$10.37
+SA,Saudi Arabia,BE,Belgium,Peak,$12.78,$12.24
+SA,Saudi Arabia,BL,Bolivia,NonPeak,$11.35,$17.17
+SA,Saudi Arabia,BL,Bolivia,Peak,$13.39,$20.26
+SA,Saudi Arabia,BR,Brazil - Brazilia,NonPeak,$11.82,$10.50
+SA,Saudi Arabia,BR,Brazil - Brazilia,Peak,$13.95,$12.39
+SA,Saudi Arabia,CA10,Ontario,NonPeak,$8.88,$17.59
+SA,Saudi Arabia,CA10,Ontario,Peak,$10.48,$20.76
+SA,Saudi Arabia,CA20,Quebec,NonPeak,$9.31,$12.03
+SA,Saudi Arabia,CA20,Quebec,Peak,$10.99,$14.20
+SA,Saudi Arabia,CA30,Manitoba,NonPeak,$9.77,$12.66
+SA,Saudi Arabia,CA30,Manitoba,Peak,$11.53,$14.94
+SA,Saudi Arabia,CI,Chile,NonPeak,$10.21,$17.97
+SA,Saudi Arabia,CI,Chile,Peak,$12.05,$21.20
+SA,Saudi Arabia,CO,Colombia,NonPeak,$10.65,$12.36
+SA,Saudi Arabia,CO,Colombia,Peak,$12.57,$14.58
+SA,Saudi Arabia,CS,Costa Rica,NonPeak,$10.35,$10.91
+SA,Saudi Arabia,CS,Costa Rica,Peak,$12.21,$12.87
+SA,Saudi Arabia,EC,Ecuador,NonPeak,$10.83,$18.51
+SA,Saudi Arabia,EC,Ecuador,Peak,$12.78,$21.84
+SA,Saudi Arabia,ES,El Salvador,NonPeak,$11.35,$12.70
+SA,Saudi Arabia,ES,El Salvador,Peak,$13.39,$14.99
+SA,Saudi Arabia,GE,Germany,NonPeak,$11.82,$11.24
+SA,Saudi Arabia,GE,Germany,Peak,$13.95,$13.26
+SA,Saudi Arabia,GQ,Guam,NonPeak,$8.88,$19.00
+SA,Saudi Arabia,GQ,Guam,Peak,$10.48,$22.42
+SA,Saudi Arabia,GR,Greece,NonPeak,$9.31,$12.99
+SA,Saudi Arabia,GR,Greece,Peak,$10.99,$15.33
+SA,Saudi Arabia,GR29,Crete,NonPeak,$9.77,$11.54
+SA,Saudi Arabia,GR29,Crete,Peak,$11.53,$13.62
+SA,Saudi Arabia,GT,Guatemala,NonPeak,$10.21,$16.89
+SA,Saudi Arabia,GT,Guatemala,Peak,$12.05,$19.93
+SA,Saudi Arabia,HO,Honduras,NonPeak,$10.65,$11.66
+SA,Saudi Arabia,HO,Honduras,Peak,$12.57,$13.76
+SA,Saudi Arabia,HU,Hungary,NonPeak,$10.35,$10.16
+SA,Saudi Arabia,HU,Hungary,Peak,$12.21,$11.99
+SA,Saudi Arabia,IT,Italy,NonPeak,$10.83,$16.98
+SA,Saudi Arabia,IT,Italy,Peak,$12.78,$20.04
+SA,Saudi Arabia,IT10,Sicily,NonPeak,$11.35,$11.75
+SA,Saudi Arabia,IT10,Sicily,Peak,$13.39,$13.86
+SA,Saudi Arabia,JA01,Japan-Central,NonPeak,$11.82,$10.25
+SA,Saudi Arabia,JA01,Japan-Central,Peak,$13.95,$12.09
+SA,Saudi Arabia,JA02,Japan-South (Excludes Hokkaido),NonPeak,$8.88,$17.11
+SA,Saudi Arabia,JA02,Japan-South (Excludes Hokkaido),Peak,$10.48,$20.19
+SA,Saudi Arabia,JA03,Japan-North,NonPeak,$9.31,$11.86
+SA,Saudi Arabia,JA03,Japan-North,Peak,$10.99,$13.99
+SA,Saudi Arabia,JA96,Okinawa,NonPeak,$9.77,$10.37
+SA,Saudi Arabia,JA96,Okinawa,Peak,$11.53,$12.24
+SA,Saudi Arabia,KS,"Korea, Republic Of",NonPeak,$10.21,$17.17
+SA,Saudi Arabia,KS,"Korea, Republic Of",Peak,$12.05,$20.26
+SA,Saudi Arabia,KU,Kuwait,NonPeak,$10.65,$10.50
+SA,Saudi Arabia,KU,Kuwait,Peak,$12.57,$12.39
+SA,Saudi Arabia,NL,Netherlands,NonPeak,$10.35,$17.59
+SA,Saudi Arabia,NL,Netherlands,Peak,$12.21,$20.76
+SA,Saudi Arabia,NO,Norway,NonPeak,$10.83,$12.03
+SA,Saudi Arabia,NO,Norway,Peak,$12.78,$14.20
+SA,Saudi Arabia,PA,Paraguay,NonPeak,$11.35,$12.66
+SA,Saudi Arabia,PA,Paraguay,Peak,$13.39,$14.94
+SA,Saudi Arabia,PE,Peru,NonPeak,$11.82,$17.97
+SA,Saudi Arabia,PE,Peru,Peak,$13.95,$21.20
+SA,Saudi Arabia,PL,Poland,NonPeak,$8.88,$12.36
+SA,Saudi Arabia,PL,Poland,Peak,$10.48,$14.58
+SA,Saudi Arabia,PO,Portugal,NonPeak,$9.31,$10.91
+SA,Saudi Arabia,PO,Portugal,Peak,$10.99,$12.87
+SA,Saudi Arabia,PO01,Azores,NonPeak,$9.77,$18.51
+SA,Saudi Arabia,PO01,Azores,Peak,$11.53,$21.84
+SA,Saudi Arabia,QA,Qatar,NonPeak,$10.21,$12.70
+SA,Saudi Arabia,QA,Qatar,Peak,$12.05,$14.99
+SA,Saudi Arabia,RO,Romania,NonPeak,$10.65,$11.24
+SA,Saudi Arabia,RO,Romania,Peak,$12.57,$13.26
+SA,Saudi Arabia,RQ,Puerto Rico,NonPeak,$10.35,$19.00
+SA,Saudi Arabia,RQ,Puerto Rico,Peak,$12.21,$22.42
+SA,Saudi Arabia,SA,Saudi Arabia,NonPeak,$10.83,$12.99
+SA,Saudi Arabia,SA,Saudi Arabia,Peak,$12.78,$15.33
+SA,Saudi Arabia,SN,Singapore,NonPeak,$11.35,$11.54
+SA,Saudi Arabia,SN,Singapore,Peak,$13.39,$13.62
+SA,Saudi Arabia,SP,Spain,NonPeak,$11.82,$16.89
+SA,Saudi Arabia,SP,Spain,Peak,$13.95,$19.93
+SA,Saudi Arabia,TU,Turkey,NonPeak,$8.88,$11.66
+SA,Saudi Arabia,TU,Turkey,Peak,$10.48,$13.76
+SA,Saudi Arabia,UK,United Kingdom,NonPeak,$9.31,$10.16
+SA,Saudi Arabia,UK,United Kingdom,Peak,$10.99,$11.99
+SA,Saudi Arabia,US8030400,Alaska (Zone) IV,NonPeak,$9.77,$16.98
+SA,Saudi Arabia,US8030400,Alaska (Zone) IV,Peak,$11.53,$20.04
+SA,Saudi Arabia,US8050500,Alaska (Zone) III,NonPeak,$10.21,$11.75
+SA,Saudi Arabia,US8050500,Alaska (Zone) III,Peak,$12.05,$13.86
+SA,Saudi Arabia,US8101000,Alaska (Zone) I,NonPeak,$10.65,$10.25
+SA,Saudi Arabia,US8101000,Alaska (Zone) I,Peak,$12.57,$12.09
+SA,Saudi Arabia,US8190100,Alaska (Zone) II,NonPeak,$10.35,$17.11
+SA,Saudi Arabia,US8190100,Alaska (Zone) II,Peak,$12.21,$20.19
+SA,Saudi Arabia,US89,Hawaii,NonPeak,$10.83,$11.86
+SA,Saudi Arabia,US89,Hawaii,Peak,$12.78,$13.99
+SA,Saudi Arabia,UY,Uruguay,NonPeak,$11.35,$10.37
+SA,Saudi Arabia,UY,Uruguay,Peak,$13.39,$12.24
+SA,Saudi Arabia,VE,Venezuela,NonPeak,$11.82,$17.17
+SA,Saudi Arabia,VE,Venezuela,Peak,$13.95,$20.26
+SN,Singapore,AR,Argentina,NonPeak,$8.88,$10.50
+SN,Singapore,AR,Argentina,Peak,$10.48,$12.39
+SN,Singapore,AS11,New South Wales/Australian Capital Territory,NonPeak,$9.31,$17.59
+SN,Singapore,AS11,New South Wales/Australian Capital Territory,Peak,$10.99,$20.76
+SN,Singapore,AS21,Northern Territory,NonPeak,$9.77,$12.03
+SN,Singapore,AS21,Northern Territory,Peak,$11.53,$14.20
+SN,Singapore,BA,Bahrain,NonPeak,$10.21,$12.66
+SN,Singapore,BA,Bahrain,Peak,$12.05,$14.94
+SN,Singapore,BE,Belgium,NonPeak,$10.65,$17.97
+SN,Singapore,BE,Belgium,Peak,$12.57,$21.20
+SN,Singapore,BL,Bolivia,NonPeak,$10.35,$12.36
+SN,Singapore,BL,Bolivia,Peak,$12.21,$14.58
+SN,Singapore,BR,Brazil - Brazilia,NonPeak,$10.83,$10.91
+SN,Singapore,BR,Brazil - Brazilia,Peak,$12.78,$12.87
+SN,Singapore,CA10,Ontario,NonPeak,$11.35,$18.51
+SN,Singapore,CA10,Ontario,Peak,$13.39,$21.84
+SN,Singapore,CA20,Quebec,NonPeak,$11.82,$12.70
+SN,Singapore,CA20,Quebec,Peak,$13.95,$14.99
+SN,Singapore,CA30,Manitoba,NonPeak,$8.88,$11.24
+SN,Singapore,CA30,Manitoba,Peak,$10.48,$13.26
+SN,Singapore,CI,Chile,NonPeak,$9.31,$19.00
+SN,Singapore,CI,Chile,Peak,$10.99,$22.42
+SN,Singapore,CO,Colombia,NonPeak,$9.77,$12.99
+SN,Singapore,CO,Colombia,Peak,$11.53,$15.33
+SN,Singapore,CS,Costa Rica,NonPeak,$10.21,$11.54
+SN,Singapore,CS,Costa Rica,Peak,$12.05,$13.62
+SN,Singapore,EC,Ecuador,NonPeak,$10.65,$16.89
+SN,Singapore,EC,Ecuador,Peak,$12.57,$19.93
+SN,Singapore,ES,El Salvador,NonPeak,$10.35,$11.66
+SN,Singapore,ES,El Salvador,Peak,$12.21,$13.76
+SN,Singapore,GE,Germany,NonPeak,$10.83,$10.16
+SN,Singapore,GE,Germany,Peak,$12.78,$11.99
+SN,Singapore,GQ,Guam,NonPeak,$11.35,$16.98
+SN,Singapore,GQ,Guam,Peak,$13.39,$20.04
+SN,Singapore,GR,Greece,NonPeak,$11.82,$11.75
+SN,Singapore,GR,Greece,Peak,$13.95,$13.86
+SN,Singapore,GR29,Crete,NonPeak,$8.88,$10.25
+SN,Singapore,GR29,Crete,Peak,$10.48,$12.09
+SN,Singapore,GT,Guatemala,NonPeak,$9.31,$17.11
+SN,Singapore,GT,Guatemala,Peak,$10.99,$20.19
+SN,Singapore,HO,Honduras,NonPeak,$9.77,$11.86
+SN,Singapore,HO,Honduras,Peak,$11.53,$13.99
+SN,Singapore,HU,Hungary,NonPeak,$10.21,$10.37
+SN,Singapore,HU,Hungary,Peak,$12.05,$12.24
+SN,Singapore,IT,Italy,NonPeak,$10.65,$17.17
+SN,Singapore,IT,Italy,Peak,$12.57,$20.26
+SN,Singapore,IT10,Sicily,NonPeak,$10.35,$10.50
+SN,Singapore,IT10,Sicily,Peak,$12.21,$12.39
+SN,Singapore,JA01,Japan-Central,NonPeak,$10.83,$17.59
+SN,Singapore,JA01,Japan-Central,Peak,$12.78,$20.76
+SN,Singapore,JA02,Japan-South (Excludes Hokkaido),NonPeak,$11.35,$12.03
+SN,Singapore,JA02,Japan-South (Excludes Hokkaido),Peak,$13.39,$14.20
+SN,Singapore,JA03,Japan-North,NonPeak,$11.82,$12.66
+SN,Singapore,JA03,Japan-North,Peak,$13.95,$14.94
+SN,Singapore,JA96,Okinawa,NonPeak,$8.88,$17.97
+SN,Singapore,JA96,Okinawa,Peak,$10.48,$21.20
+SN,Singapore,KS,"Korea, Republic Of",NonPeak,$9.31,$12.36
+SN,Singapore,KS,"Korea, Republic Of",Peak,$10.99,$14.58
+SN,Singapore,KU,Kuwait,NonPeak,$9.77,$10.91
+SN,Singapore,KU,Kuwait,Peak,$11.53,$12.87
+SN,Singapore,NL,Netherlands,NonPeak,$10.21,$18.51
+SN,Singapore,NL,Netherlands,Peak,$12.05,$21.84
+SN,Singapore,NO,Norway,NonPeak,$10.65,$12.70
+SN,Singapore,NO,Norway,Peak,$12.57,$14.99
+SN,Singapore,PA,Paraguay,NonPeak,$10.35,$11.24
+SN,Singapore,PA,Paraguay,Peak,$12.21,$13.26
+SN,Singapore,PE,Peru,NonPeak,$10.83,$19.00
+SN,Singapore,PE,Peru,Peak,$12.78,$22.42
+SN,Singapore,PL,Poland,NonPeak,$11.35,$12.99
+SN,Singapore,PL,Poland,Peak,$13.39,$15.33
+SN,Singapore,PO,Portugal,NonPeak,$11.82,$11.54
+SN,Singapore,PO,Portugal,Peak,$13.95,$13.62
+SN,Singapore,PO01,Azores,NonPeak,$8.88,$16.89
+SN,Singapore,PO01,Azores,Peak,$10.48,$19.93
+SN,Singapore,QA,Qatar,NonPeak,$9.31,$11.66
+SN,Singapore,QA,Qatar,Peak,$10.99,$13.76
+SN,Singapore,RO,Romania,NonPeak,$9.77,$10.16
+SN,Singapore,RO,Romania,Peak,$11.53,$11.99
+SN,Singapore,RQ,Puerto Rico,NonPeak,$10.21,$16.98
+SN,Singapore,RQ,Puerto Rico,Peak,$12.05,$20.04
+SN,Singapore,SA,Saudi Arabia,NonPeak,$10.65,$11.75
+SN,Singapore,SA,Saudi Arabia,Peak,$12.57,$13.86
+SN,Singapore,SN,Singapore,NonPeak,$10.35,$10.25
+SN,Singapore,SN,Singapore,Peak,$12.21,$12.09
+SN,Singapore,SP,Spain,NonPeak,$10.83,$17.11
+SN,Singapore,SP,Spain,Peak,$12.78,$20.19
+SN,Singapore,TU,Turkey,NonPeak,$11.35,$11.86
+SN,Singapore,TU,Turkey,Peak,$13.39,$13.99
+SN,Singapore,UK,United Kingdom,NonPeak,$11.82,$10.37
+SN,Singapore,UK,United Kingdom,Peak,$13.95,$12.24
+SN,Singapore,US8030400,Alaska (Zone) IV,NonPeak,$8.88,$17.17
+SN,Singapore,US8030400,Alaska (Zone) IV,Peak,$10.48,$20.26
+SN,Singapore,US8050500,Alaska (Zone) III,NonPeak,$9.31,$10.50
+SN,Singapore,US8050500,Alaska (Zone) III,Peak,$10.99,$12.39
+SN,Singapore,US8101000,Alaska (Zone) I,NonPeak,$9.77,$17.59
+SN,Singapore,US8101000,Alaska (Zone) I,Peak,$11.53,$20.76
+SN,Singapore,US8190100,Alaska (Zone) II,NonPeak,$10.21,$12.03
+SN,Singapore,US8190100,Alaska (Zone) II,Peak,$12.05,$14.20
+SN,Singapore,US89,Hawaii,NonPeak,$10.65,$12.66
+SN,Singapore,US89,Hawaii,Peak,$12.57,$14.94
+SN,Singapore,UY,Uruguay,NonPeak,$10.35,$17.97
+SN,Singapore,UY,Uruguay,Peak,$12.21,$21.20
+SN,Singapore,VE,Venezuela,NonPeak,$10.83,$12.36
+SN,Singapore,VE,Venezuela,Peak,$12.78,$14.58
+SP,Spain,AR,Argentina,NonPeak,$11.35,$10.91
+SP,Spain,AR,Argentina,Peak,$13.39,$12.87
+SP,Spain,AS11,New South Wales/Australian Capital Territory,NonPeak,$11.82,$18.51
+SP,Spain,AS11,New South Wales/Australian Capital Territory,Peak,$13.95,$21.84
+SP,Spain,AS21,Northern Territory,NonPeak,$8.88,$12.70
+SP,Spain,AS21,Northern Territory,Peak,$10.48,$14.99
+SP,Spain,BA,Bahrain,NonPeak,$9.31,$11.24
+SP,Spain,BA,Bahrain,Peak,$10.99,$13.26
+SP,Spain,BE,Belgium,NonPeak,$9.77,$19.00
+SP,Spain,BE,Belgium,Peak,$11.53,$22.42
+SP,Spain,BL,Bolivia,NonPeak,$10.21,$12.99
+SP,Spain,BL,Bolivia,Peak,$12.05,$15.33
+SP,Spain,BR,Brazil - Brazilia,NonPeak,$10.65,$11.54
+SP,Spain,BR,Brazil - Brazilia,Peak,$12.57,$13.62
+SP,Spain,CA10,Ontario,NonPeak,$10.35,$16.89
+SP,Spain,CA10,Ontario,Peak,$12.21,$19.93
+SP,Spain,CA20,Quebec,NonPeak,$10.83,$11.66
+SP,Spain,CA20,Quebec,Peak,$12.78,$13.76
+SP,Spain,CA30,Manitoba,NonPeak,$11.35,$10.16
+SP,Spain,CA30,Manitoba,Peak,$13.39,$11.99
+SP,Spain,CI,Chile,NonPeak,$11.82,$16.98
+SP,Spain,CI,Chile,Peak,$13.95,$20.04
+SP,Spain,CO,Colombia,NonPeak,$8.88,$11.75
+SP,Spain,CO,Colombia,Peak,$10.48,$13.86
+SP,Spain,CS,Costa Rica,NonPeak,$9.31,$10.25
+SP,Spain,CS,Costa Rica,Peak,$10.99,$12.09
+SP,Spain,EC,Ecuador,NonPeak,$9.77,$17.11
+SP,Spain,EC,Ecuador,Peak,$11.53,$20.19
+SP,Spain,ES,El Salvador,NonPeak,$10.21,$11.86
+SP,Spain,ES,El Salvador,Peak,$12.05,$13.99
+SP,Spain,GE,Germany,NonPeak,$10.65,$10.37
+SP,Spain,GE,Germany,Peak,$12.57,$12.24
+SP,Spain,GQ,Guam,NonPeak,$10.35,$17.17
+SP,Spain,GQ,Guam,Peak,$12.21,$20.26
+SP,Spain,GR,Greece,NonPeak,$10.83,$10.50
+SP,Spain,GR,Greece,Peak,$12.78,$12.39
+SP,Spain,GR29,Crete,NonPeak,$11.35,$17.59
+SP,Spain,GR29,Crete,Peak,$13.39,$20.76
+SP,Spain,GT,Guatemala,NonPeak,$11.82,$12.03
+SP,Spain,GT,Guatemala,Peak,$13.95,$14.20
+SP,Spain,HO,Honduras,NonPeak,$8.88,$12.66
+SP,Spain,HO,Honduras,Peak,$10.48,$14.94
+SP,Spain,HU,Hungary,NonPeak,$9.31,$17.97
+SP,Spain,HU,Hungary,Peak,$10.99,$21.20
+SP,Spain,IT,Italy,NonPeak,$9.77,$12.36
+SP,Spain,IT,Italy,Peak,$11.53,$14.58
+SP,Spain,IT10,Sicily,NonPeak,$10.21,$10.91
+SP,Spain,IT10,Sicily,Peak,$12.05,$12.87
+SP,Spain,JA01,Japan-Central,NonPeak,$10.65,$18.51
+SP,Spain,JA01,Japan-Central,Peak,$12.57,$21.84
+SP,Spain,JA02,Japan-South (Excludes Hokkaido),NonPeak,$10.35,$12.70
+SP,Spain,JA02,Japan-South (Excludes Hokkaido),Peak,$12.21,$14.99
+SP,Spain,JA03,Japan-North,NonPeak,$10.83,$11.24
+SP,Spain,JA03,Japan-North,Peak,$12.78,$13.26
+SP,Spain,JA96,Okinawa,NonPeak,$11.35,$19.00
+SP,Spain,JA96,Okinawa,Peak,$13.39,$22.42
+SP,Spain,KS,"Korea, Republic Of",NonPeak,$11.82,$12.99
+SP,Spain,KS,"Korea, Republic Of",Peak,$13.95,$15.33
+SP,Spain,KU,Kuwait,NonPeak,$8.88,$11.54
+SP,Spain,KU,Kuwait,Peak,$10.48,$13.62
+SP,Spain,NL,Netherlands,NonPeak,$9.31,$16.89
+SP,Spain,NL,Netherlands,Peak,$10.99,$19.93
+SP,Spain,NO,Norway,NonPeak,$9.77,$11.66
+SP,Spain,NO,Norway,Peak,$11.53,$13.76
+SP,Spain,PA,Paraguay,NonPeak,$10.21,$10.16
+SP,Spain,PA,Paraguay,Peak,$12.05,$11.99
+SP,Spain,PE,Peru,NonPeak,$10.65,$16.98
+SP,Spain,PE,Peru,Peak,$12.57,$20.04
+SP,Spain,PL,Poland,NonPeak,$10.35,$11.75
+SP,Spain,PL,Poland,Peak,$12.21,$13.86
+SP,Spain,PO,Portugal,NonPeak,$10.83,$10.25
+SP,Spain,PO,Portugal,Peak,$12.78,$12.09
+SP,Spain,PO01,Azores,NonPeak,$11.35,$17.11
+SP,Spain,PO01,Azores,Peak,$13.39,$20.19
+SP,Spain,QA,Qatar,NonPeak,$11.82,$11.86
+SP,Spain,QA,Qatar,Peak,$13.95,$13.99
+SP,Spain,RO,Romania,NonPeak,$8.88,$10.37
+SP,Spain,RO,Romania,Peak,$10.48,$12.24
+SP,Spain,RQ,Puerto Rico,NonPeak,$9.31,$17.17
+SP,Spain,RQ,Puerto Rico,Peak,$10.99,$20.26
+SP,Spain,SA,Saudi Arabia,NonPeak,$9.77,$10.50
+SP,Spain,SA,Saudi Arabia,Peak,$11.53,$12.39
+SP,Spain,SN,Singapore,NonPeak,$10.21,$17.59
+SP,Spain,SN,Singapore,Peak,$12.05,$20.76
+SP,Spain,SP,Spain,NonPeak,$10.65,$12.03
+SP,Spain,SP,Spain,Peak,$12.57,$14.20
+SP,Spain,TU,Turkey,NonPeak,$10.35,$12.66
+SP,Spain,TU,Turkey,Peak,$12.21,$14.94
+SP,Spain,UK,United Kingdom,NonPeak,$10.83,$17.97
+SP,Spain,UK,United Kingdom,Peak,$12.78,$21.20
+SP,Spain,US8030400,Alaska (Zone) IV,NonPeak,$11.35,$12.36
+SP,Spain,US8030400,Alaska (Zone) IV,Peak,$13.39,$14.58
+SP,Spain,US8050500,Alaska (Zone) III,NonPeak,$11.82,$10.91
+SP,Spain,US8050500,Alaska (Zone) III,Peak,$13.95,$12.87
+SP,Spain,US8101000,Alaska (Zone) I,NonPeak,$8.88,$18.51
+SP,Spain,US8101000,Alaska (Zone) I,Peak,$10.48,$21.84
+SP,Spain,US8190100,Alaska (Zone) II,NonPeak,$9.31,$12.70
+SP,Spain,US8190100,Alaska (Zone) II,Peak,$10.99,$14.99
+SP,Spain,US89,Hawaii,NonPeak,$9.77,$11.24
+SP,Spain,US89,Hawaii,Peak,$11.53,$13.26
+SP,Spain,UY,Uruguay,NonPeak,$10.21,$19.00
+SP,Spain,UY,Uruguay,Peak,$12.05,$22.42
+SP,Spain,VE,Venezuela,NonPeak,$10.65,$12.99
+SP,Spain,VE,Venezuela,Peak,$12.57,$15.33
+TU,Turkey,AR,Argentina,NonPeak,$10.35,$11.54
+TU,Turkey,AR,Argentina,Peak,$12.21,$13.62
+TU,Turkey,AS11,New South Wales/Australian Capital Territory,NonPeak,$10.83,$16.89
+TU,Turkey,AS11,New South Wales/Australian Capital Territory,Peak,$12.78,$19.93
+TU,Turkey,AS21,Northern Territory,NonPeak,$11.35,$11.66
+TU,Turkey,AS21,Northern Territory,Peak,$13.39,$13.76
+TU,Turkey,BA,Bahrain,NonPeak,$11.82,$10.16
+TU,Turkey,BA,Bahrain,Peak,$13.95,$11.99
+TU,Turkey,BE,Belgium,NonPeak,$8.88,$16.98
+TU,Turkey,BE,Belgium,Peak,$10.48,$20.04
+TU,Turkey,BL,Bolivia,NonPeak,$9.31,$11.75
+TU,Turkey,BL,Bolivia,Peak,$10.99,$13.86
+TU,Turkey,BR,Brazil - Brazilia,NonPeak,$9.77,$10.25
+TU,Turkey,BR,Brazil - Brazilia,Peak,$11.53,$12.09
+TU,Turkey,CA10,Ontario,NonPeak,$10.21,$17.11
+TU,Turkey,CA10,Ontario,Peak,$12.05,$20.19
+TU,Turkey,CA20,Quebec,NonPeak,$10.65,$11.86
+TU,Turkey,CA20,Quebec,Peak,$12.57,$13.99
+TU,Turkey,CA30,Manitoba,NonPeak,$10.35,$10.37
+TU,Turkey,CA30,Manitoba,Peak,$12.21,$12.24
+TU,Turkey,CI,Chile,NonPeak,$10.83,$17.17
+TU,Turkey,CI,Chile,Peak,$12.78,$20.26
+TU,Turkey,CO,Colombia,NonPeak,$11.35,$10.50
+TU,Turkey,CO,Colombia,Peak,$13.39,$12.39
+TU,Turkey,CS,Costa Rica,NonPeak,$11.82,$17.59
+TU,Turkey,CS,Costa Rica,Peak,$13.95,$20.76
+TU,Turkey,EC,Ecuador,NonPeak,$8.88,$12.03
+TU,Turkey,EC,Ecuador,Peak,$10.48,$14.20
+TU,Turkey,ES,El Salvador,NonPeak,$9.31,$12.66
+TU,Turkey,ES,El Salvador,Peak,$10.99,$14.94
+TU,Turkey,GE,Germany,NonPeak,$9.77,$17.97
+TU,Turkey,GE,Germany,Peak,$11.53,$21.20
+TU,Turkey,GQ,Guam,NonPeak,$10.21,$12.36
+TU,Turkey,GQ,Guam,Peak,$12.05,$14.58
+TU,Turkey,GR,Greece,NonPeak,$10.65,$10.91
+TU,Turkey,GR,Greece,Peak,$12.57,$12.87
+TU,Turkey,GR29,Crete,NonPeak,$10.35,$18.51
+TU,Turkey,GR29,Crete,Peak,$12.21,$21.84
+TU,Turkey,GT,Guatemala,NonPeak,$10.83,$12.70
+TU,Turkey,GT,Guatemala,Peak,$12.78,$14.99
+TU,Turkey,HO,Honduras,NonPeak,$11.35,$11.24
+TU,Turkey,HO,Honduras,Peak,$13.39,$13.26
+TU,Turkey,HU,Hungary,NonPeak,$11.82,$19.00
+TU,Turkey,HU,Hungary,Peak,$13.95,$22.42
+TU,Turkey,IT,Italy,NonPeak,$8.88,$12.99
+TU,Turkey,IT,Italy,Peak,$10.48,$15.33
+TU,Turkey,IT10,Sicily,NonPeak,$9.31,$11.54
+TU,Turkey,IT10,Sicily,Peak,$10.99,$13.62
+TU,Turkey,JA01,Japan-Central,NonPeak,$9.77,$16.89
+TU,Turkey,JA01,Japan-Central,Peak,$11.53,$19.93
+TU,Turkey,JA02,Japan-South (Excludes Hokkaido),NonPeak,$10.21,$11.66
+TU,Turkey,JA02,Japan-South (Excludes Hokkaido),Peak,$12.05,$13.76
+TU,Turkey,JA03,Japan-North,NonPeak,$10.65,$10.16
+TU,Turkey,JA03,Japan-North,Peak,$12.57,$11.99
+TU,Turkey,JA96,Okinawa,NonPeak,$10.35,$16.98
+TU,Turkey,JA96,Okinawa,Peak,$12.21,$20.04
+TU,Turkey,KS,"Korea, Republic Of",NonPeak,$10.83,$11.75
+TU,Turkey,KS,"Korea, Republic Of",Peak,$12.78,$13.86
+TU,Turkey,KU,Kuwait,NonPeak,$11.35,$10.25
+TU,Turkey,KU,Kuwait,Peak,$13.39,$12.09
+TU,Turkey,NL,Netherlands,NonPeak,$11.82,$17.11
+TU,Turkey,NL,Netherlands,Peak,$13.95,$20.19
+TU,Turkey,NO,Norway,NonPeak,$8.88,$11.86
+TU,Turkey,NO,Norway,Peak,$10.48,$13.99
+TU,Turkey,PA,Paraguay,NonPeak,$9.31,$10.37
+TU,Turkey,PA,Paraguay,Peak,$10.99,$12.24
+TU,Turkey,PE,Peru,NonPeak,$9.77,$17.17
+TU,Turkey,PE,Peru,Peak,$11.53,$20.26
+TU,Turkey,PL,Poland,NonPeak,$10.21,$10.50
+TU,Turkey,PL,Poland,Peak,$12.05,$12.39
+TU,Turkey,PO,Portugal,NonPeak,$10.65,$17.59
+TU,Turkey,PO,Portugal,Peak,$12.57,$20.76
+TU,Turkey,PO01,Azores,NonPeak,$10.35,$12.03
+TU,Turkey,PO01,Azores,Peak,$12.21,$14.20
+TU,Turkey,QA,Qatar,NonPeak,$10.83,$12.66
+TU,Turkey,QA,Qatar,Peak,$12.78,$14.94
+TU,Turkey,RO,Romania,NonPeak,$11.35,$17.97
+TU,Turkey,RO,Romania,Peak,$13.39,$21.20
+TU,Turkey,RQ,Puerto Rico,NonPeak,$11.82,$12.36
+TU,Turkey,RQ,Puerto Rico,Peak,$13.95,$14.58
+TU,Turkey,SA,Saudi Arabia,NonPeak,$8.88,$10.91
+TU,Turkey,SA,Saudi Arabia,Peak,$10.48,$12.87
+TU,Turkey,SN,Singapore,NonPeak,$9.31,$18.51
+TU,Turkey,SN,Singapore,Peak,$10.99,$21.84
+TU,Turkey,SP,Spain,NonPeak,$9.77,$12.70
+TU,Turkey,SP,Spain,Peak,$11.53,$14.99
+TU,Turkey,TU,Turkey,NonPeak,$10.21,$11.24
+TU,Turkey,TU,Turkey,Peak,$12.05,$13.26
+TU,Turkey,UK,United Kingdom,NonPeak,$10.65,$19.00
+TU,Turkey,UK,United Kingdom,Peak,$12.57,$22.42
+TU,Turkey,US8030400,Alaska (Zone) IV,NonPeak,$10.35,$12.99
+TU,Turkey,US8030400,Alaska (Zone) IV,Peak,$12.21,$15.33
+TU,Turkey,US8050500,Alaska (Zone) III,NonPeak,$10.83,$11.54
+TU,Turkey,US8050500,Alaska (Zone) III,Peak,$12.78,$13.62
+TU,Turkey,US8101000,Alaska (Zone) I,NonPeak,$11.35,$16.89
+TU,Turkey,US8101000,Alaska (Zone) I,Peak,$13.39,$19.93
+TU,Turkey,US8190100,Alaska (Zone) II,NonPeak,$11.82,$11.66
+TU,Turkey,US8190100,Alaska (Zone) II,Peak,$13.95,$13.76
+TU,Turkey,US89,Hawaii,NonPeak,$8.88,$10.16
+TU,Turkey,US89,Hawaii,Peak,$10.48,$11.99
+TU,Turkey,UY,Uruguay,NonPeak,$9.31,$16.98
+TU,Turkey,UY,Uruguay,Peak,$10.99,$20.04
+TU,Turkey,VE,Venezuela,NonPeak,$9.77,$11.75
+TU,Turkey,VE,Venezuela,Peak,$11.53,$13.86
+UK,United Kingdom,AR,Argentina,NonPeak,$10.21,$10.25
+UK,United Kingdom,AR,Argentina,Peak,$12.05,$12.09
+UK,United Kingdom,AS11,New South Wales/Australian Capital Territory,NonPeak,$10.65,$17.11
+UK,United Kingdom,AS11,New South Wales/Australian Capital Territory,Peak,$12.57,$20.19
+UK,United Kingdom,AS21,Northern Territory,NonPeak,$10.35,$11.86
+UK,United Kingdom,AS21,Northern Territory,Peak,$12.21,$13.99
+UK,United Kingdom,BA,Bahrain,NonPeak,$10.83,$10.37
+UK,United Kingdom,BA,Bahrain,Peak,$12.78,$12.24
+UK,United Kingdom,BE,Belgium,NonPeak,$11.35,$17.17
+UK,United Kingdom,BE,Belgium,Peak,$13.39,$20.26
+UK,United Kingdom,BL,Bolivia,NonPeak,$11.82,$10.50
+UK,United Kingdom,BL,Bolivia,Peak,$13.95,$12.39
+UK,United Kingdom,BR,Brazil - Brazilia,NonPeak,$8.88,$17.59
+UK,United Kingdom,BR,Brazil - Brazilia,Peak,$10.48,$20.76
+UK,United Kingdom,CA10,Ontario,NonPeak,$9.31,$12.03
+UK,United Kingdom,CA10,Ontario,Peak,$10.99,$14.20
+UK,United Kingdom,CA20,Quebec,NonPeak,$9.77,$12.66
+UK,United Kingdom,CA20,Quebec,Peak,$11.53,$14.94
+UK,United Kingdom,CA30,Manitoba,NonPeak,$10.21,$17.97
+UK,United Kingdom,CA30,Manitoba,Peak,$12.05,$21.20
+UK,United Kingdom,CI,Chile,NonPeak,$10.65,$12.36
+UK,United Kingdom,CI,Chile,Peak,$12.57,$14.58
+UK,United Kingdom,CO,Colombia,NonPeak,$10.35,$10.91
+UK,United Kingdom,CO,Colombia,Peak,$12.21,$12.87
+UK,United Kingdom,CS,Costa Rica,NonPeak,$10.83,$18.51
+UK,United Kingdom,CS,Costa Rica,Peak,$12.78,$21.84
+UK,United Kingdom,EC,Ecuador,NonPeak,$11.35,$12.70
+UK,United Kingdom,EC,Ecuador,Peak,$13.39,$14.99
+UK,United Kingdom,ES,El Salvador,NonPeak,$11.82,$11.24
+UK,United Kingdom,ES,El Salvador,Peak,$13.95,$13.26
+UK,United Kingdom,GE,Germany,NonPeak,$8.88,$19.00
+UK,United Kingdom,GE,Germany,Peak,$10.48,$22.42
+UK,United Kingdom,GQ,Guam,NonPeak,$9.31,$12.99
+UK,United Kingdom,GQ,Guam,Peak,$10.99,$15.33
+UK,United Kingdom,GR,Greece,NonPeak,$9.77,$11.54
+UK,United Kingdom,GR,Greece,Peak,$11.53,$13.62
+UK,United Kingdom,GR29,Crete,NonPeak,$10.21,$16.89
+UK,United Kingdom,GR29,Crete,Peak,$12.05,$19.93
+UK,United Kingdom,GT,Guatemala,NonPeak,$10.65,$11.66
+UK,United Kingdom,GT,Guatemala,Peak,$12.57,$13.76
+UK,United Kingdom,HO,Honduras,NonPeak,$10.35,$10.16
+UK,United Kingdom,HO,Honduras,Peak,$12.21,$11.99
+UK,United Kingdom,HU,Hungary,NonPeak,$10.83,$16.98
+UK,United Kingdom,HU,Hungary,Peak,$12.78,$20.04
+UK,United Kingdom,IT,Italy,NonPeak,$11.35,$11.75
+UK,United Kingdom,IT,Italy,Peak,$13.39,$13.86
+UK,United Kingdom,IT10,Sicily,NonPeak,$11.82,$10.25
+UK,United Kingdom,IT10,Sicily,Peak,$13.95,$12.09
+UK,United Kingdom,JA01,Japan-Central,NonPeak,$8.88,$17.11
+UK,United Kingdom,JA01,Japan-Central,Peak,$10.48,$20.19
+UK,United Kingdom,JA02,Japan-South (Excludes Hokkaido),NonPeak,$9.31,$11.86
+UK,United Kingdom,JA02,Japan-South (Excludes Hokkaido),Peak,$10.99,$13.99
+UK,United Kingdom,JA03,Japan-North,NonPeak,$9.77,$10.37
+UK,United Kingdom,JA03,Japan-North,Peak,$11.53,$12.24
+UK,United Kingdom,JA96,Okinawa,NonPeak,$10.21,$17.17
+UK,United Kingdom,JA96,Okinawa,Peak,$12.05,$20.26
+UK,United Kingdom,KS,"Korea, Republic Of",NonPeak,$10.65,$10.50
+UK,United Kingdom,KS,"Korea, Republic Of",Peak,$12.57,$12.39
+UK,United Kingdom,KU,Kuwait,NonPeak,$10.35,$17.59
+UK,United Kingdom,KU,Kuwait,Peak,$12.21,$20.76
+UK,United Kingdom,NL,Netherlands,NonPeak,$10.83,$12.03
+UK,United Kingdom,NL,Netherlands,Peak,$12.78,$14.20
+UK,United Kingdom,NO,Norway,NonPeak,$11.35,$12.66
+UK,United Kingdom,NO,Norway,Peak,$13.39,$14.94
+UK,United Kingdom,PA,Paraguay,NonPeak,$11.82,$17.97
+UK,United Kingdom,PA,Paraguay,Peak,$13.95,$21.20
+UK,United Kingdom,PE,Peru,NonPeak,$8.88,$12.36
+UK,United Kingdom,PE,Peru,Peak,$10.48,$14.58
+UK,United Kingdom,PL,Poland,NonPeak,$9.31,$10.91
+UK,United Kingdom,PL,Poland,Peak,$10.99,$12.87
+UK,United Kingdom,PO,Portugal,NonPeak,$9.77,$18.51
+UK,United Kingdom,PO,Portugal,Peak,$11.53,$21.84
+UK,United Kingdom,PO01,Azores,NonPeak,$10.21,$12.70
+UK,United Kingdom,PO01,Azores,Peak,$12.05,$14.99
+UK,United Kingdom,QA,Qatar,NonPeak,$10.65,$11.24
+UK,United Kingdom,QA,Qatar,Peak,$12.57,$13.26
+UK,United Kingdom,RO,Romania,NonPeak,$10.35,$19.00
+UK,United Kingdom,RO,Romania,Peak,$12.21,$22.42
+UK,United Kingdom,RQ,Puerto Rico,NonPeak,$10.83,$12.99
+UK,United Kingdom,RQ,Puerto Rico,Peak,$12.78,$15.33
+UK,United Kingdom,SA,Saudi Arabia,NonPeak,$11.35,$11.54
+UK,United Kingdom,SA,Saudi Arabia,Peak,$13.39,$13.62
+UK,United Kingdom,SN,Singapore,NonPeak,$11.82,$16.89
+UK,United Kingdom,SN,Singapore,Peak,$13.95,$19.93
+UK,United Kingdom,SP,Spain,NonPeak,$8.88,$11.66
+UK,United Kingdom,SP,Spain,Peak,$10.48,$13.76
+UK,United Kingdom,TU,Turkey,NonPeak,$9.31,$10.16
+UK,United Kingdom,TU,Turkey,Peak,$10.99,$11.99
+UK,United Kingdom,UK,United Kingdom,NonPeak,$9.77,$16.98
+UK,United Kingdom,UK,United Kingdom,Peak,$11.53,$20.04
+UK,United Kingdom,US8030400,Alaska (Zone) IV,NonPeak,$10.21,$11.75
+UK,United Kingdom,US8030400,Alaska (Zone) IV,Peak,$12.05,$13.86
+UK,United Kingdom,US8050500,Alaska (Zone) III,NonPeak,$10.65,$10.25
+UK,United Kingdom,US8050500,Alaska (Zone) III,Peak,$12.57,$12.09
+UK,United Kingdom,US8101000,Alaska (Zone) I,NonPeak,$10.35,$17.11
+UK,United Kingdom,US8101000,Alaska (Zone) I,Peak,$12.21,$20.19
+UK,United Kingdom,US8190100,Alaska (Zone) II,NonPeak,$10.83,$11.86
+UK,United Kingdom,US8190100,Alaska (Zone) II,Peak,$12.78,$13.99
+UK,United Kingdom,US89,Hawaii,NonPeak,$11.35,$10.37
+UK,United Kingdom,US89,Hawaii,Peak,$13.39,$12.24
+UK,United Kingdom,UY,Uruguay,NonPeak,$11.82,$17.17
+UK,United Kingdom,UY,Uruguay,Peak,$13.95,$20.26
+UK,United Kingdom,VE,Venezuela,NonPeak,$8.88,$10.50
+UK,United Kingdom,VE,Venezuela,Peak,$10.48,$12.39
+US8030400,Alaska (Zone) IV,AR,Argentina,NonPeak,$9.31,$17.59
+US8030400,Alaska (Zone) IV,AR,Argentina,Peak,$10.99,$20.76
+US8030400,Alaska (Zone) IV,AS11,New South Wales/Australian Capital Territory,NonPeak,$9.77,$12.03
+US8030400,Alaska (Zone) IV,AS11,New South Wales/Australian Capital Territory,Peak,$11.53,$14.20
+US8030400,Alaska (Zone) IV,AS21,Northern Territory,NonPeak,$10.21,$12.66
+US8030400,Alaska (Zone) IV,AS21,Northern Territory,Peak,$12.05,$14.94
+US8030400,Alaska (Zone) IV,BA,Bahrain,NonPeak,$10.65,$17.97
+US8030400,Alaska (Zone) IV,BA,Bahrain,Peak,$12.57,$21.20
+US8030400,Alaska (Zone) IV,BE,Belgium,NonPeak,$10.35,$12.36
+US8030400,Alaska (Zone) IV,BE,Belgium,Peak,$12.21,$14.58
+US8030400,Alaska (Zone) IV,BL,Bolivia,NonPeak,$10.83,$10.91
+US8030400,Alaska (Zone) IV,BL,Bolivia,Peak,$12.78,$12.87
+US8030400,Alaska (Zone) IV,BR,Brazil - Brazilia,NonPeak,$11.35,$18.51
+US8030400,Alaska (Zone) IV,BR,Brazil - Brazilia,Peak,$13.39,$21.84
+US8030400,Alaska (Zone) IV,CA10,Ontario,NonPeak,$11.82,$12.70
+US8030400,Alaska (Zone) IV,CA10,Ontario,Peak,$13.95,$14.99
+US8030400,Alaska (Zone) IV,CA20,Quebec,NonPeak,$8.88,$11.24
+US8030400,Alaska (Zone) IV,CA20,Quebec,Peak,$10.48,$13.26
+US8030400,Alaska (Zone) IV,CA30,Manitoba,NonPeak,$9.31,$19.00
+US8030400,Alaska (Zone) IV,CA30,Manitoba,Peak,$10.99,$22.42
+US8030400,Alaska (Zone) IV,CI,Chile,NonPeak,$9.77,$12.99
+US8030400,Alaska (Zone) IV,CI,Chile,Peak,$11.53,$15.33
+US8030400,Alaska (Zone) IV,CO,Colombia,NonPeak,$10.21,$11.54
+US8030400,Alaska (Zone) IV,CO,Colombia,Peak,$12.05,$13.62
+US8030400,Alaska (Zone) IV,CS,Costa Rica,NonPeak,$10.65,$16.89
+US8030400,Alaska (Zone) IV,CS,Costa Rica,Peak,$12.57,$19.93
+US8030400,Alaska (Zone) IV,EC,Ecuador,NonPeak,$10.35,$11.66
+US8030400,Alaska (Zone) IV,EC,Ecuador,Peak,$12.21,$13.76
+US8030400,Alaska (Zone) IV,ES,El Salvador,NonPeak,$10.83,$10.16
+US8030400,Alaska (Zone) IV,ES,El Salvador,Peak,$12.78,$11.99
+US8030400,Alaska (Zone) IV,GE,Germany,NonPeak,$11.35,$16.98
+US8030400,Alaska (Zone) IV,GE,Germany,Peak,$13.39,$20.04
+US8030400,Alaska (Zone) IV,GQ,Guam,NonPeak,$11.82,$11.75
+US8030400,Alaska (Zone) IV,GQ,Guam,Peak,$13.95,$13.86
+US8030400,Alaska (Zone) IV,GR,Greece,NonPeak,$8.88,$10.25
+US8030400,Alaska (Zone) IV,GR,Greece,Peak,$10.48,$12.09
+US8030400,Alaska (Zone) IV,GR29,Crete,NonPeak,$9.31,$17.11
+US8030400,Alaska (Zone) IV,GR29,Crete,Peak,$10.99,$20.19
+US8030400,Alaska (Zone) IV,GT,Guatemala,NonPeak,$9.77,$11.86
+US8030400,Alaska (Zone) IV,GT,Guatemala,Peak,$11.53,$13.99
+US8030400,Alaska (Zone) IV,HO,Honduras,NonPeak,$10.21,$10.37
+US8030400,Alaska (Zone) IV,HO,Honduras,Peak,$12.05,$12.24
+US8030400,Alaska (Zone) IV,HU,Hungary,NonPeak,$10.65,$17.17
+US8030400,Alaska (Zone) IV,HU,Hungary,Peak,$12.57,$20.26
+US8030400,Alaska (Zone) IV,IT,Italy,NonPeak,$10.35,$10.50
+US8030400,Alaska (Zone) IV,IT,Italy,Peak,$12.21,$12.39
+US8030400,Alaska (Zone) IV,IT10,Sicily,NonPeak,$10.83,$17.59
+US8030400,Alaska (Zone) IV,IT10,Sicily,Peak,$12.78,$20.76
+US8030400,Alaska (Zone) IV,JA01,Japan-Central,NonPeak,$11.35,$12.03
+US8030400,Alaska (Zone) IV,JA01,Japan-Central,Peak,$13.39,$14.20
+US8030400,Alaska (Zone) IV,JA02,Japan-South (Excludes Hokkaido),NonPeak,$11.82,$12.66
+US8030400,Alaska (Zone) IV,JA02,Japan-South (Excludes Hokkaido),Peak,$13.95,$14.94
+US8030400,Alaska (Zone) IV,JA03,Japan-North,NonPeak,$8.88,$17.97
+US8030400,Alaska (Zone) IV,JA03,Japan-North,Peak,$10.48,$21.20
+US8030400,Alaska (Zone) IV,JA96,Okinawa,NonPeak,$9.31,$12.36
+US8030400,Alaska (Zone) IV,JA96,Okinawa,Peak,$10.99,$14.58
+US8030400,Alaska (Zone) IV,KS,"Korea, Republic Of",NonPeak,$9.77,$10.91
+US8030400,Alaska (Zone) IV,KS,"Korea, Republic Of",Peak,$11.53,$12.87
+US8030400,Alaska (Zone) IV,KU,Kuwait,NonPeak,$10.21,$18.51
+US8030400,Alaska (Zone) IV,KU,Kuwait,Peak,$12.05,$21.84
+US8030400,Alaska (Zone) IV,NL,Netherlands,NonPeak,$10.65,$12.70
+US8030400,Alaska (Zone) IV,NL,Netherlands,Peak,$12.57,$14.99
+US8030400,Alaska (Zone) IV,NO,Norway,NonPeak,$10.35,$11.24
+US8030400,Alaska (Zone) IV,NO,Norway,Peak,$12.21,$13.26
+US8030400,Alaska (Zone) IV,PA,Paraguay,NonPeak,$10.83,$19.00
+US8030400,Alaska (Zone) IV,PA,Paraguay,Peak,$12.78,$22.42
+US8030400,Alaska (Zone) IV,PE,Peru,NonPeak,$11.35,$12.99
+US8030400,Alaska (Zone) IV,PE,Peru,Peak,$13.39,$15.33
+US8030400,Alaska (Zone) IV,PL,Poland,NonPeak,$11.82,$11.54
+US8030400,Alaska (Zone) IV,PL,Poland,Peak,$13.95,$13.62
+US8030400,Alaska (Zone) IV,PO,Portugal,NonPeak,$8.88,$16.89
+US8030400,Alaska (Zone) IV,PO,Portugal,Peak,$10.48,$19.93
+US8030400,Alaska (Zone) IV,PO01,Azores,NonPeak,$9.31,$11.66
+US8030400,Alaska (Zone) IV,PO01,Azores,Peak,$10.99,$13.76
+US8030400,Alaska (Zone) IV,QA,Qatar,NonPeak,$9.77,$10.16
+US8030400,Alaska (Zone) IV,QA,Qatar,Peak,$11.53,$11.99
+US8030400,Alaska (Zone) IV,RO,Romania,NonPeak,$10.21,$16.98
+US8030400,Alaska (Zone) IV,RO,Romania,Peak,$12.05,$20.04
+US8030400,Alaska (Zone) IV,RQ,Puerto Rico,NonPeak,$10.65,$11.75
+US8030400,Alaska (Zone) IV,RQ,Puerto Rico,Peak,$12.57,$13.86
+US8030400,Alaska (Zone) IV,SA,Saudi Arabia,NonPeak,$10.35,$10.25
+US8030400,Alaska (Zone) IV,SA,Saudi Arabia,Peak,$12.21,$12.09
+US8030400,Alaska (Zone) IV,SN,Singapore,NonPeak,$10.83,$17.11
+US8030400,Alaska (Zone) IV,SN,Singapore,Peak,$12.78,$20.19
+US8030400,Alaska (Zone) IV,SP,Spain,NonPeak,$11.35,$11.86
+US8030400,Alaska (Zone) IV,SP,Spain,Peak,$13.39,$13.99
+US8030400,Alaska (Zone) IV,TU,Turkey,NonPeak,$11.82,$10.37
+US8030400,Alaska (Zone) IV,TU,Turkey,Peak,$13.95,$12.24
+US8030400,Alaska (Zone) IV,UK,United Kingdom,NonPeak,$8.88,$17.17
+US8030400,Alaska (Zone) IV,UK,United Kingdom,Peak,$10.48,$20.26
+US8030400,Alaska (Zone) IV,US8030400,Alaska (Zone) IV,NonPeak,$9.31,$10.50
+US8030400,Alaska (Zone) IV,US8030400,Alaska (Zone) IV,Peak,$10.99,$12.39
+US8030400,Alaska (Zone) IV,US8050500,Alaska (Zone) III,NonPeak,$9.77,$17.59
+US8030400,Alaska (Zone) IV,US8050500,Alaska (Zone) III,Peak,$11.53,$20.76
+US8030400,Alaska (Zone) IV,US8101000,Alaska (Zone) I,NonPeak,$10.21,$12.03
+US8030400,Alaska (Zone) IV,US8101000,Alaska (Zone) I,Peak,$12.05,$14.20
+US8030400,Alaska (Zone) IV,US8190100,Alaska (Zone) II,NonPeak,$10.65,$12.66
+US8030400,Alaska (Zone) IV,US8190100,Alaska (Zone) II,Peak,$12.57,$14.94
+US8030400,Alaska (Zone) IV,US89,Hawaii,NonPeak,$10.35,$17.97
+US8030400,Alaska (Zone) IV,US89,Hawaii,Peak,$12.21,$21.20
+US8030400,Alaska (Zone) IV,UY,Uruguay,NonPeak,$10.83,$12.36
+US8030400,Alaska (Zone) IV,UY,Uruguay,Peak,$12.78,$14.58
+US8030400,Alaska (Zone) IV,VE,Venezuela,NonPeak,$11.35,$10.91
+US8030400,Alaska (Zone) IV,VE,Venezuela,Peak,$13.39,$12.87
+US8050500,Alaska (Zone) III,AR,Argentina,NonPeak,$11.82,$18.51
+US8050500,Alaska (Zone) III,AR,Argentina,Peak,$13.95,$21.84
+US8050500,Alaska (Zone) III,AS11,New South Wales/Australian Capital Territory,NonPeak,$8.88,$12.70
+US8050500,Alaska (Zone) III,AS11,New South Wales/Australian Capital Territory,Peak,$10.48,$14.99
+US8050500,Alaska (Zone) III,AS21,Northern Territory,NonPeak,$9.31,$11.24
+US8050500,Alaska (Zone) III,AS21,Northern Territory,Peak,$10.99,$13.26
+US8050500,Alaska (Zone) III,BA,Bahrain,NonPeak,$9.77,$19.00
+US8050500,Alaska (Zone) III,BA,Bahrain,Peak,$11.53,$22.42
+US8050500,Alaska (Zone) III,BE,Belgium,NonPeak,$10.21,$12.99
+US8050500,Alaska (Zone) III,BE,Belgium,Peak,$12.05,$15.33
+US8050500,Alaska (Zone) III,BL,Bolivia,NonPeak,$10.65,$11.54
+US8050500,Alaska (Zone) III,BL,Bolivia,Peak,$12.57,$13.62
+US8050500,Alaska (Zone) III,BR,Brazil - Brazilia,NonPeak,$10.35,$16.89
+US8050500,Alaska (Zone) III,BR,Brazil - Brazilia,Peak,$12.21,$19.93
+US8050500,Alaska (Zone) III,CA10,Ontario,NonPeak,$10.83,$11.66
+US8050500,Alaska (Zone) III,CA10,Ontario,Peak,$12.78,$13.76
+US8050500,Alaska (Zone) III,CA20,Quebec,NonPeak,$11.35,$10.16
+US8050500,Alaska (Zone) III,CA20,Quebec,Peak,$13.39,$11.99
+US8050500,Alaska (Zone) III,CA30,Manitoba,NonPeak,$11.82,$16.98
+US8050500,Alaska (Zone) III,CA30,Manitoba,Peak,$13.95,$20.04
+US8050500,Alaska (Zone) III,CI,Chile,NonPeak,$8.88,$11.75
+US8050500,Alaska (Zone) III,CI,Chile,Peak,$10.48,$13.86
+US8050500,Alaska (Zone) III,CO,Colombia,NonPeak,$9.31,$10.25
+US8050500,Alaska (Zone) III,CO,Colombia,Peak,$10.99,$12.09
+US8050500,Alaska (Zone) III,CS,Costa Rica,NonPeak,$9.77,$17.11
+US8050500,Alaska (Zone) III,CS,Costa Rica,Peak,$11.53,$20.19
+US8050500,Alaska (Zone) III,EC,Ecuador,NonPeak,$10.21,$11.86
+US8050500,Alaska (Zone) III,EC,Ecuador,Peak,$12.05,$13.99
+US8050500,Alaska (Zone) III,ES,El Salvador,NonPeak,$10.65,$10.37
+US8050500,Alaska (Zone) III,ES,El Salvador,Peak,$12.57,$12.24
+US8050500,Alaska (Zone) III,GE,Germany,NonPeak,$10.35,$17.17
+US8050500,Alaska (Zone) III,GE,Germany,Peak,$12.21,$20.26
+US8050500,Alaska (Zone) III,GQ,Guam,NonPeak,$10.83,$10.50
+US8050500,Alaska (Zone) III,GQ,Guam,Peak,$12.78,$12.39
+US8050500,Alaska (Zone) III,GR,Greece,NonPeak,$11.35,$17.59
+US8050500,Alaska (Zone) III,GR,Greece,Peak,$13.39,$20.76
+US8050500,Alaska (Zone) III,GR29,Crete,NonPeak,$11.82,$12.03
+US8050500,Alaska (Zone) III,GR29,Crete,Peak,$13.95,$14.20
+US8050500,Alaska (Zone) III,GT,Guatemala,NonPeak,$8.88,$12.66
+US8050500,Alaska (Zone) III,GT,Guatemala,Peak,$10.48,$14.94
+US8050500,Alaska (Zone) III,HO,Honduras,NonPeak,$9.31,$17.97
+US8050500,Alaska (Zone) III,HO,Honduras,Peak,$10.99,$21.20
+US8050500,Alaska (Zone) III,HU,Hungary,NonPeak,$9.77,$12.36
+US8050500,Alaska (Zone) III,HU,Hungary,Peak,$11.53,$14.58
+US8050500,Alaska (Zone) III,IT,Italy,NonPeak,$10.21,$10.91
+US8050500,Alaska (Zone) III,IT,Italy,Peak,$12.05,$12.87
+US8050500,Alaska (Zone) III,IT10,Sicily,NonPeak,$10.65,$18.51
+US8050500,Alaska (Zone) III,IT10,Sicily,Peak,$12.57,$21.84
+US8050500,Alaska (Zone) III,JA01,Japan-Central,NonPeak,$10.35,$12.70
+US8050500,Alaska (Zone) III,JA01,Japan-Central,Peak,$12.21,$14.99
+US8050500,Alaska (Zone) III,JA02,Japan-South (Excludes Hokkaido),NonPeak,$10.83,$11.24
+US8050500,Alaska (Zone) III,JA02,Japan-South (Excludes Hokkaido),Peak,$12.78,$13.26
+US8050500,Alaska (Zone) III,JA03,Japan-North,NonPeak,$11.35,$19.00
+US8050500,Alaska (Zone) III,JA03,Japan-North,Peak,$13.39,$22.42
+US8050500,Alaska (Zone) III,JA96,Okinawa,NonPeak,$11.82,$12.99
+US8050500,Alaska (Zone) III,JA96,Okinawa,Peak,$13.95,$15.33
+US8050500,Alaska (Zone) III,KS,"Korea, Republic Of",NonPeak,$8.88,$11.54
+US8050500,Alaska (Zone) III,KS,"Korea, Republic Of",Peak,$10.48,$13.62
+US8050500,Alaska (Zone) III,KU,Kuwait,NonPeak,$9.31,$16.89
+US8050500,Alaska (Zone) III,KU,Kuwait,Peak,$10.99,$19.93
+US8050500,Alaska (Zone) III,NL,Netherlands,NonPeak,$9.77,$11.66
+US8050500,Alaska (Zone) III,NL,Netherlands,Peak,$11.53,$13.76
+US8050500,Alaska (Zone) III,NO,Norway,NonPeak,$10.21,$10.16
+US8050500,Alaska (Zone) III,NO,Norway,Peak,$12.05,$11.99
+US8050500,Alaska (Zone) III,PA,Paraguay,NonPeak,$10.65,$16.98
+US8050500,Alaska (Zone) III,PA,Paraguay,Peak,$12.57,$20.04
+US8050500,Alaska (Zone) III,PE,Peru,NonPeak,$10.35,$11.75
+US8050500,Alaska (Zone) III,PE,Peru,Peak,$12.21,$13.86
+US8050500,Alaska (Zone) III,PL,Poland,NonPeak,$10.83,$10.25
+US8050500,Alaska (Zone) III,PL,Poland,Peak,$12.78,$12.09
+US8050500,Alaska (Zone) III,PO,Portugal,NonPeak,$11.35,$17.11
+US8050500,Alaska (Zone) III,PO,Portugal,Peak,$13.39,$20.19
+US8050500,Alaska (Zone) III,PO01,Azores,NonPeak,$11.82,$11.86
+US8050500,Alaska (Zone) III,PO01,Azores,Peak,$13.95,$13.99
+US8050500,Alaska (Zone) III,QA,Qatar,NonPeak,$8.88,$10.37
+US8050500,Alaska (Zone) III,QA,Qatar,Peak,$10.48,$12.24
+US8050500,Alaska (Zone) III,RO,Romania,NonPeak,$9.31,$17.17
+US8050500,Alaska (Zone) III,RO,Romania,Peak,$10.99,$20.26
+US8050500,Alaska (Zone) III,RQ,Puerto Rico,NonPeak,$9.77,$10.50
+US8050500,Alaska (Zone) III,RQ,Puerto Rico,Peak,$11.53,$12.39
+US8050500,Alaska (Zone) III,SA,Saudi Arabia,NonPeak,$10.21,$17.59
+US8050500,Alaska (Zone) III,SA,Saudi Arabia,Peak,$12.05,$20.76
+US8050500,Alaska (Zone) III,SN,Singapore,NonPeak,$10.65,$12.03
+US8050500,Alaska (Zone) III,SN,Singapore,Peak,$12.57,$14.20
+US8050500,Alaska (Zone) III,SP,Spain,NonPeak,$10.35,$12.66
+US8050500,Alaska (Zone) III,SP,Spain,Peak,$12.21,$14.94
+US8050500,Alaska (Zone) III,TU,Turkey,NonPeak,$10.83,$17.97
+US8050500,Alaska (Zone) III,TU,Turkey,Peak,$12.78,$21.20
+US8050500,Alaska (Zone) III,UK,United Kingdom,NonPeak,$11.35,$12.36
+US8050500,Alaska (Zone) III,UK,United Kingdom,Peak,$13.39,$14.58
+US8050500,Alaska (Zone) III,US8030400,Alaska (Zone) IV,NonPeak,$11.82,$10.91
+US8050500,Alaska (Zone) III,US8030400,Alaska (Zone) IV,Peak,$13.95,$12.87
+US8050500,Alaska (Zone) III,US8050500,Alaska (Zone) III,NonPeak,$8.88,$18.51
+US8050500,Alaska (Zone) III,US8050500,Alaska (Zone) III,Peak,$10.48,$21.84
+US8050500,Alaska (Zone) III,US8101000,Alaska (Zone) I,NonPeak,$9.31,$12.70
+US8050500,Alaska (Zone) III,US8101000,Alaska (Zone) I,Peak,$10.99,$14.99
+US8050500,Alaska (Zone) III,US8190100,Alaska (Zone) II,NonPeak,$9.77,$11.24
+US8050500,Alaska (Zone) III,US8190100,Alaska (Zone) II,Peak,$11.53,$13.26
+US8050500,Alaska (Zone) III,US89,Hawaii,NonPeak,$10.21,$19.00
+US8050500,Alaska (Zone) III,US89,Hawaii,Peak,$12.05,$22.42
+US8050500,Alaska (Zone) III,UY,Uruguay,NonPeak,$10.65,$12.99
+US8050500,Alaska (Zone) III,UY,Uruguay,Peak,$12.57,$15.33
+US8050500,Alaska (Zone) III,VE,Venezuela,NonPeak,$10.35,$11.54
+US8050500,Alaska (Zone) III,VE,Venezuela,Peak,$12.21,$13.62
+US8101000,Alaska (Zone) I,AR,Argentina,NonPeak,$10.83,$16.89
+US8101000,Alaska (Zone) I,AR,Argentina,Peak,$12.78,$19.93
+US8101000,Alaska (Zone) I,AS11,New South Wales/Australian Capital Territory,NonPeak,$11.35,$11.66
+US8101000,Alaska (Zone) I,AS11,New South Wales/Australian Capital Territory,Peak,$13.39,$13.76
+US8101000,Alaska (Zone) I,AS21,Northern Territory,NonPeak,$11.82,$10.16
+US8101000,Alaska (Zone) I,AS21,Northern Territory,Peak,$13.95,$11.99
+US8101000,Alaska (Zone) I,BA,Bahrain,NonPeak,$8.88,$16.98
+US8101000,Alaska (Zone) I,BA,Bahrain,Peak,$10.48,$20.04
+US8101000,Alaska (Zone) I,BE,Belgium,NonPeak,$9.31,$11.75
+US8101000,Alaska (Zone) I,BE,Belgium,Peak,$10.99,$13.86
+US8101000,Alaska (Zone) I,BL,Bolivia,NonPeak,$9.77,$10.25
+US8101000,Alaska (Zone) I,BL,Bolivia,Peak,$11.53,$12.09
+US8101000,Alaska (Zone) I,BR,Brazil - Brazilia,NonPeak,$10.21,$17.11
+US8101000,Alaska (Zone) I,BR,Brazil - Brazilia,Peak,$12.05,$20.19
+US8101000,Alaska (Zone) I,CA10,Ontario,NonPeak,$10.65,$11.86
+US8101000,Alaska (Zone) I,CA10,Ontario,Peak,$12.57,$13.99
+US8101000,Alaska (Zone) I,CA20,Quebec,NonPeak,$10.35,$10.37
+US8101000,Alaska (Zone) I,CA20,Quebec,Peak,$12.21,$12.24
+US8101000,Alaska (Zone) I,CA30,Manitoba,NonPeak,$10.83,$17.17
+US8101000,Alaska (Zone) I,CA30,Manitoba,Peak,$12.78,$20.26
+US8101000,Alaska (Zone) I,CI,Chile,NonPeak,$11.35,$10.50
+US8101000,Alaska (Zone) I,CI,Chile,Peak,$13.39,$12.39
+US8101000,Alaska (Zone) I,CO,Colombia,NonPeak,$11.82,$17.59
+US8101000,Alaska (Zone) I,CO,Colombia,Peak,$13.95,$20.76
+US8101000,Alaska (Zone) I,CS,Costa Rica,NonPeak,$8.88,$12.03
+US8101000,Alaska (Zone) I,CS,Costa Rica,Peak,$10.48,$14.20
+US8101000,Alaska (Zone) I,EC,Ecuador,NonPeak,$9.31,$12.66
+US8101000,Alaska (Zone) I,EC,Ecuador,Peak,$10.99,$14.94
+US8101000,Alaska (Zone) I,ES,El Salvador,NonPeak,$9.77,$17.97
+US8101000,Alaska (Zone) I,ES,El Salvador,Peak,$11.53,$21.20
+US8101000,Alaska (Zone) I,GE,Germany,NonPeak,$10.21,$12.36
+US8101000,Alaska (Zone) I,GE,Germany,Peak,$12.05,$14.58
+US8101000,Alaska (Zone) I,GQ,Guam,NonPeak,$10.65,$10.91
+US8101000,Alaska (Zone) I,GQ,Guam,Peak,$12.57,$12.87
+US8101000,Alaska (Zone) I,GR,Greece,NonPeak,$10.35,$18.51
+US8101000,Alaska (Zone) I,GR,Greece,Peak,$12.21,$21.84
+US8101000,Alaska (Zone) I,GR29,Crete,NonPeak,$10.83,$12.70
+US8101000,Alaska (Zone) I,GR29,Crete,Peak,$12.78,$14.99
+US8101000,Alaska (Zone) I,GT,Guatemala,NonPeak,$11.35,$11.24
+US8101000,Alaska (Zone) I,GT,Guatemala,Peak,$13.39,$13.26
+US8101000,Alaska (Zone) I,HO,Honduras,NonPeak,$11.82,$19.00
+US8101000,Alaska (Zone) I,HO,Honduras,Peak,$13.95,$22.42
+US8101000,Alaska (Zone) I,HU,Hungary,NonPeak,$8.88,$12.99
+US8101000,Alaska (Zone) I,HU,Hungary,Peak,$10.48,$15.33
+US8101000,Alaska (Zone) I,IT,Italy,NonPeak,$9.31,$11.54
+US8101000,Alaska (Zone) I,IT,Italy,Peak,$10.99,$13.62
+US8101000,Alaska (Zone) I,IT10,Sicily,NonPeak,$9.77,$16.89
+US8101000,Alaska (Zone) I,IT10,Sicily,Peak,$11.53,$19.93
+US8101000,Alaska (Zone) I,JA01,Japan-Central,NonPeak,$10.21,$11.66
+US8101000,Alaska (Zone) I,JA01,Japan-Central,Peak,$12.05,$13.76
+US8101000,Alaska (Zone) I,JA02,Japan-South (Excludes Hokkaido),NonPeak,$10.65,$10.16
+US8101000,Alaska (Zone) I,JA02,Japan-South (Excludes Hokkaido),Peak,$12.57,$11.99
+US8101000,Alaska (Zone) I,JA03,Japan-North,NonPeak,$10.35,$16.98
+US8101000,Alaska (Zone) I,JA03,Japan-North,Peak,$12.21,$20.04
+US8101000,Alaska (Zone) I,JA96,Okinawa,NonPeak,$10.83,$11.75
+US8101000,Alaska (Zone) I,JA96,Okinawa,Peak,$12.78,$13.86
+US8101000,Alaska (Zone) I,KS,"Korea, Republic Of",NonPeak,$11.35,$10.25
+US8101000,Alaska (Zone) I,KS,"Korea, Republic Of",Peak,$13.39,$12.09
+US8101000,Alaska (Zone) I,KU,Kuwait,NonPeak,$11.82,$17.11
+US8101000,Alaska (Zone) I,KU,Kuwait,Peak,$13.95,$20.19
+US8101000,Alaska (Zone) I,NL,Netherlands,NonPeak,$8.88,$11.86
+US8101000,Alaska (Zone) I,NL,Netherlands,Peak,$10.48,$13.99
+US8101000,Alaska (Zone) I,NO,Norway,NonPeak,$9.31,$10.37
+US8101000,Alaska (Zone) I,NO,Norway,Peak,$10.99,$12.24
+US8101000,Alaska (Zone) I,PA,Paraguay,NonPeak,$9.77,$17.17
+US8101000,Alaska (Zone) I,PA,Paraguay,Peak,$11.53,$20.26
+US8101000,Alaska (Zone) I,PE,Peru,NonPeak,$10.21,$10.50
+US8101000,Alaska (Zone) I,PE,Peru,Peak,$12.05,$12.39
+US8101000,Alaska (Zone) I,PL,Poland,NonPeak,$10.65,$17.59
+US8101000,Alaska (Zone) I,PL,Poland,Peak,$12.57,$20.76
+US8101000,Alaska (Zone) I,PO,Portugal,NonPeak,$10.35,$12.03
+US8101000,Alaska (Zone) I,PO,Portugal,Peak,$12.21,$14.20
+US8101000,Alaska (Zone) I,PO01,Azores,NonPeak,$10.35,$16.89
+US8101000,Alaska (Zone) I,PO01,Azores,Peak,$12.21,$14.20
+US8101000,Alaska (Zone) I,QA,Qatar,NonPeak,$10.83,$11.66
+US8101000,Alaska (Zone) I,QA,Qatar,Peak,$12.78,$14.94
+US8101000,Alaska (Zone) I,RO,Romania,NonPeak,$11.35,$10.16
+US8101000,Alaska (Zone) I,RO,Romania,Peak,$13.39,$21.20
+US8101000,Alaska (Zone) I,RQ,Puerto Rico,NonPeak,$11.82,$16.98
+US8101000,Alaska (Zone) I,RQ,Puerto Rico,Peak,$13.95,$14.58
+US8101000,Alaska (Zone) I,SA,Saudi Arabia,NonPeak,$8.88,$11.75
+US8101000,Alaska (Zone) I,SA,Saudi Arabia,Peak,$10.48,$12.87
+US8101000,Alaska (Zone) I,SN,Singapore,NonPeak,$9.31,$10.25
+US8101000,Alaska (Zone) I,SN,Singapore,Peak,$10.99,$21.84
+US8101000,Alaska (Zone) I,SP,Spain,NonPeak,$9.77,$17.11
+US8101000,Alaska (Zone) I,SP,Spain,Peak,$11.53,$14.99
+US8101000,Alaska (Zone) I,TU,Turkey,NonPeak,$10.21,$11.86
+US8101000,Alaska (Zone) I,TU,Turkey,Peak,$12.05,$13.26
+US8101000,Alaska (Zone) I,UK,United Kingdom,NonPeak,$10.65,$10.37
+US8101000,Alaska (Zone) I,UK,United Kingdom,Peak,$12.57,$22.42
+US8101000,Alaska (Zone) I,US8030400,Alaska (Zone) IV,NonPeak,$10.35,$17.17
+US8101000,Alaska (Zone) I,US8030400,Alaska (Zone) IV,Peak,$12.21,$15.33
+US8101000,Alaska (Zone) I,US8050500,Alaska (Zone) III,NonPeak,$10.83,$10.50
+US8101000,Alaska (Zone) I,US8050500,Alaska (Zone) III,Peak,$12.78,$13.62
+US8101000,Alaska (Zone) I,US8101000,Alaska (Zone) I,NonPeak,$11.35,$17.59
+US8101000,Alaska (Zone) I,US8101000,Alaska (Zone) I,Peak,$13.39,$19.93
+US8101000,Alaska (Zone) I,US8190100,Alaska (Zone) II,NonPeak,$11.82,$12.03
+US8101000,Alaska (Zone) I,US8190100,Alaska (Zone) II,Peak,$13.95,$13.76
+US8101000,Alaska (Zone) I,US89,Hawaii,NonPeak,$8.88,$12.66
+US8101000,Alaska (Zone) I,US89,Hawaii,Peak,$10.48,$11.99
+US8101000,Alaska (Zone) I,UY,Uruguay,NonPeak,$9.31,$17.97
+US8101000,Alaska (Zone) I,UY,Uruguay,Peak,$10.99,$20.04
+US8101000,Alaska (Zone) I,VE,Venezuela,NonPeak,$9.77,$12.36
+US8101000,Alaska (Zone) I,VE,Venezuela,Peak,$11.53,$13.86
+US8190100,Alaska (Zone) II,AR,Argentina,NonPeak,$10.21,$10.91
+US8190100,Alaska (Zone) II,AR,Argentina,Peak,$12.05,$12.09
+US8190100,Alaska (Zone) II,AS11,New South Wales/Australian Capital Territory,NonPeak,$10.65,$18.51
+US8190100,Alaska (Zone) II,AS11,New South Wales/Australian Capital Territory,Peak,$12.57,$20.19
+US8190100,Alaska (Zone) II,AS21,Northern Territory,NonPeak,$10.35,$12.70
+US8190100,Alaska (Zone) II,AS21,Northern Territory,Peak,$12.21,$13.99
+US8190100,Alaska (Zone) II,BA,Bahrain,NonPeak,$10.83,$11.24
+US8190100,Alaska (Zone) II,BA,Bahrain,Peak,$12.78,$12.24
+US8190100,Alaska (Zone) II,BE,Belgium,NonPeak,$11.35,$19.00
+US8190100,Alaska (Zone) II,BE,Belgium,Peak,$13.39,$20.26
+US8190100,Alaska (Zone) II,BL,Bolivia,NonPeak,$11.82,$12.99
+US8190100,Alaska (Zone) II,BL,Bolivia,Peak,$13.95,$12.39
+US8190100,Alaska (Zone) II,BR,Brazil - Brazilia,NonPeak,$8.88,$11.54
+US8190100,Alaska (Zone) II,BR,Brazil - Brazilia,Peak,$10.48,$20.76
+US8190100,Alaska (Zone) II,CA10,Ontario,NonPeak,$9.31,$16.89
+US8190100,Alaska (Zone) II,CA10,Ontario,Peak,$10.99,$14.20
+US8190100,Alaska (Zone) II,CA20,Quebec,NonPeak,$9.77,$11.66
+US8190100,Alaska (Zone) II,CA20,Quebec,Peak,$11.53,$14.94
+US8190100,Alaska (Zone) II,CA30,Manitoba,NonPeak,$10.21,$10.16
+US8190100,Alaska (Zone) II,CA30,Manitoba,Peak,$12.05,$21.20
+US8190100,Alaska (Zone) II,CI,Chile,NonPeak,$10.65,$16.98
+US8190100,Alaska (Zone) II,CI,Chile,Peak,$12.57,$14.58
+US8190100,Alaska (Zone) II,CO,Colombia,NonPeak,$10.35,$11.75
+US8190100,Alaska (Zone) II,CO,Colombia,Peak,$12.21,$12.87
+US8190100,Alaska (Zone) II,CS,Costa Rica,NonPeak,$10.83,$10.25
+US8190100,Alaska (Zone) II,CS,Costa Rica,Peak,$12.78,$21.84
+US8190100,Alaska (Zone) II,EC,Ecuador,NonPeak,$11.35,$17.11
+US8190100,Alaska (Zone) II,EC,Ecuador,Peak,$13.39,$14.99
+US8190100,Alaska (Zone) II,ES,El Salvador,NonPeak,$11.82,$11.86
+US8190100,Alaska (Zone) II,ES,El Salvador,Peak,$13.95,$13.26
+US8190100,Alaska (Zone) II,GE,Germany,NonPeak,$8.88,$10.37
+US8190100,Alaska (Zone) II,GE,Germany,Peak,$10.48,$22.42
+US8190100,Alaska (Zone) II,GQ,Guam,NonPeak,$9.31,$17.17
+US8190100,Alaska (Zone) II,GQ,Guam,Peak,$10.99,$15.33
+US8190100,Alaska (Zone) II,GR,Greece,NonPeak,$9.77,$10.50
+US8190100,Alaska (Zone) II,GR,Greece,Peak,$11.53,$13.62
+US8190100,Alaska (Zone) II,GR29,Crete,NonPeak,$10.21,$17.59
+US8190100,Alaska (Zone) II,GR29,Crete,Peak,$12.05,$19.93
+US8190100,Alaska (Zone) II,GT,Guatemala,NonPeak,$10.65,$12.03
+US8190100,Alaska (Zone) II,GT,Guatemala,Peak,$12.57,$13.76
+US8190100,Alaska (Zone) II,HO,Honduras,NonPeak,$10.35,$12.66
+US8190100,Alaska (Zone) II,HO,Honduras,Peak,$12.21,$11.99
+US8190100,Alaska (Zone) II,HU,Hungary,NonPeak,$10.83,$17.97
+US8190100,Alaska (Zone) II,HU,Hungary,Peak,$12.78,$20.04
+US8190100,Alaska (Zone) II,IT,Italy,NonPeak,$11.35,$12.36
+US8190100,Alaska (Zone) II,IT,Italy,Peak,$13.39,$13.86
+US8190100,Alaska (Zone) II,IT10,Sicily,NonPeak,$11.82,$10.91
+US8190100,Alaska (Zone) II,IT10,Sicily,Peak,$13.95,$12.09
+US8190100,Alaska (Zone) II,JA01,Japan-Central,NonPeak,$8.88,$18.51
+US8190100,Alaska (Zone) II,JA01,Japan-Central,Peak,$10.48,$20.19
+US8190100,Alaska (Zone) II,JA02,Japan-South (Excludes Hokkaido),NonPeak,$9.31,$12.70
+US8190100,Alaska (Zone) II,JA02,Japan-South (Excludes Hokkaido),Peak,$10.99,$13.99
+US8190100,Alaska (Zone) II,JA03,Japan-North,NonPeak,$9.77,$11.24
+US8190100,Alaska (Zone) II,JA03,Japan-North,Peak,$11.53,$12.24
+US8190100,Alaska (Zone) II,JA96,Okinawa,NonPeak,$10.21,$19.00
+US8190100,Alaska (Zone) II,JA96,Okinawa,Peak,$12.05,$20.26
+US8190100,Alaska (Zone) II,KS,"Korea, Republic Of",NonPeak,$10.65,$12.99
+US8190100,Alaska (Zone) II,KS,"Korea, Republic Of",Peak,$12.57,$12.39
+US8190100,Alaska (Zone) II,KU,Kuwait,NonPeak,$10.35,$11.54
+US8190100,Alaska (Zone) II,KU,Kuwait,Peak,$12.21,$20.76
+US8190100,Alaska (Zone) II,NL,Netherlands,NonPeak,$10.83,$16.89
+US8190100,Alaska (Zone) II,NL,Netherlands,Peak,$12.78,$14.20
+US8190100,Alaska (Zone) II,NO,Norway,NonPeak,$11.35,$11.66
+US8190100,Alaska (Zone) II,NO,Norway,Peak,$13.39,$14.94
+US8190100,Alaska (Zone) II,PA,Paraguay,NonPeak,$11.82,$10.16
+US8190100,Alaska (Zone) II,PA,Paraguay,Peak,$13.95,$21.20
+US8190100,Alaska (Zone) II,PE,Peru,NonPeak,$8.88,$16.98
+US8190100,Alaska (Zone) II,PE,Peru,Peak,$10.48,$14.58
+US8190100,Alaska (Zone) II,PL,Poland,NonPeak,$9.31,$11.75
+US8190100,Alaska (Zone) II,PL,Poland,Peak,$10.99,$12.87
+US8190100,Alaska (Zone) II,PO,Portugal,NonPeak,$9.77,$10.25
+US8190100,Alaska (Zone) II,PO,Portugal,Peak,$11.53,$21.84
+US8190100,Alaska (Zone) II,PO01,Azores,NonPeak,$10.21,$17.11
+US8190100,Alaska (Zone) II,PO01,Azores,Peak,$12.05,$14.99
+US8190100,Alaska (Zone) II,QA,Qatar,NonPeak,$10.65,$11.86
+US8190100,Alaska (Zone) II,QA,Qatar,Peak,$12.57,$13.26
+US8190100,Alaska (Zone) II,RO,Romania,NonPeak,$10.35,$10.37
+US8190100,Alaska (Zone) II,RO,Romania,Peak,$12.21,$22.42
+US8190100,Alaska (Zone) II,RQ,Puerto Rico,NonPeak,$10.83,$17.17
+US8190100,Alaska (Zone) II,RQ,Puerto Rico,Peak,$12.78,$15.33
+US8190100,Alaska (Zone) II,SA,Saudi Arabia,NonPeak,$11.35,$10.50
+US8190100,Alaska (Zone) II,SA,Saudi Arabia,Peak,$13.39,$13.62
+US8190100,Alaska (Zone) II,SN,Singapore,NonPeak,$11.82,$17.59
+US8190100,Alaska (Zone) II,SN,Singapore,Peak,$13.95,$19.93
+US8190100,Alaska (Zone) II,SP,Spain,NonPeak,$8.88,$12.03
+US8190100,Alaska (Zone) II,SP,Spain,Peak,$10.48,$13.76
+US8190100,Alaska (Zone) II,TU,Turkey,NonPeak,$9.31,$12.66
+US8190100,Alaska (Zone) II,TU,Turkey,Peak,$10.99,$11.99
+US8190100,Alaska (Zone) II,UK,United Kingdom,NonPeak,$9.77,$17.97
+US8190100,Alaska (Zone) II,UK,United Kingdom,Peak,$11.53,$20.04
+US8190100,Alaska (Zone) II,US8030400,Alaska (Zone) IV,NonPeak,$10.21,$12.36
+US8190100,Alaska (Zone) II,US8030400,Alaska (Zone) IV,Peak,$12.05,$13.86
+US8190100,Alaska (Zone) II,US8050500,Alaska (Zone) III,NonPeak,$10.65,$10.91
+US8190100,Alaska (Zone) II,US8050500,Alaska (Zone) III,Peak,$12.57,$12.09
+US8190100,Alaska (Zone) II,US8101000,Alaska (Zone) I,NonPeak,$10.35,$18.51
+US8190100,Alaska (Zone) II,US8101000,Alaska (Zone) I,Peak,$12.21,$20.19
+US8190100,Alaska (Zone) II,US8190100,Alaska (Zone) II,NonPeak,$10.83,$12.70
+US8190100,Alaska (Zone) II,US8190100,Alaska (Zone) II,Peak,$12.78,$13.99
+US8190100,Alaska (Zone) II,US89,Hawaii,NonPeak,$11.35,$11.24
+US8190100,Alaska (Zone) II,US89,Hawaii,Peak,$13.39,$12.24
+US8190100,Alaska (Zone) II,UY,Uruguay,NonPeak,$11.82,$19.00
+US8190100,Alaska (Zone) II,UY,Uruguay,Peak,$13.95,$20.26
+US8190100,Alaska (Zone) II,VE,Venezuela,NonPeak,$8.88,$12.99
+US8190100,Alaska (Zone) II,VE,Venezuela,Peak,$10.48,$12.39
+US89,Hawaii,AR,Argentina,NonPeak,$9.31,$11.54
+US89,Hawaii,AR,Argentina,Peak,$10.99,$20.76
+US89,Hawaii,AS11,New South Wales/Australian Capital Territory,NonPeak,$9.77,$16.89
+US89,Hawaii,AS11,New South Wales/Australian Capital Territory,Peak,$11.53,$14.20
+US89,Hawaii,AS21,Northern Territory,NonPeak,$10.21,$11.66
+US89,Hawaii,AS21,Northern Territory,Peak,$12.05,$14.94
+US89,Hawaii,BA,Bahrain,NonPeak,$10.65,$10.16
+US89,Hawaii,BA,Bahrain,Peak,$12.57,$21.20
+US89,Hawaii,BE,Belgium,NonPeak,$10.35,$16.98
+US89,Hawaii,BE,Belgium,Peak,$12.21,$14.58
+US89,Hawaii,BL,Bolivia,NonPeak,$10.83,$11.75
+US89,Hawaii,BL,Bolivia,Peak,$12.78,$12.87
+US89,Hawaii,BR,Brazil - Brazilia,NonPeak,$11.35,$10.25
+US89,Hawaii,BR,Brazil - Brazilia,Peak,$13.39,$21.84
+US89,Hawaii,CA10,Ontario,NonPeak,$11.82,$17.11
+US89,Hawaii,CA10,Ontario,Peak,$13.95,$14.99
+US89,Hawaii,CA20,Quebec,NonPeak,$8.88,$11.86
+US89,Hawaii,CA20,Quebec,Peak,$10.48,$13.26
+US89,Hawaii,CA30,Manitoba,NonPeak,$9.31,$10.37
+US89,Hawaii,CA30,Manitoba,Peak,$10.99,$22.42
+US89,Hawaii,CI,Chile,NonPeak,$9.77,$17.17
+US89,Hawaii,CI,Chile,Peak,$11.53,$15.33
+US89,Hawaii,CO,Colombia,NonPeak,$10.21,$10.50
+US89,Hawaii,CO,Colombia,Peak,$12.05,$13.62
+US89,Hawaii,CS,Costa Rica,NonPeak,$10.65,$17.59
+US89,Hawaii,CS,Costa Rica,Peak,$12.57,$19.93
+US89,Hawaii,EC,Ecuador,NonPeak,$10.35,$12.03
+US89,Hawaii,EC,Ecuador,Peak,$12.21,$13.76
+US89,Hawaii,ES,El Salvador,NonPeak,$10.83,$12.66
+US89,Hawaii,ES,El Salvador,Peak,$12.78,$11.99
+US89,Hawaii,GE,Germany,NonPeak,$11.35,$17.97
+US89,Hawaii,GE,Germany,Peak,$13.39,$20.04
+US89,Hawaii,GQ,Guam,NonPeak,$11.82,$12.36
+US89,Hawaii,GQ,Guam,Peak,$13.95,$13.86
+US89,Hawaii,GR,Greece,NonPeak,$8.88,$10.91
+US89,Hawaii,GR,Greece,Peak,$10.48,$12.09
+US89,Hawaii,GR29,Crete,NonPeak,$9.31,$18.51
+US89,Hawaii,GR29,Crete,Peak,$10.99,$20.19
+US89,Hawaii,GT,Guatemala,NonPeak,$9.77,$12.70
+US89,Hawaii,GT,Guatemala,Peak,$11.53,$13.99
+US89,Hawaii,HO,Honduras,NonPeak,$10.21,$11.24
+US89,Hawaii,HO,Honduras,Peak,$12.05,$12.24
+US89,Hawaii,HU,Hungary,NonPeak,$10.65,$19.00
+US89,Hawaii,HU,Hungary,Peak,$12.57,$20.26
+US89,Hawaii,IT,Italy,NonPeak,$10.35,$12.99
+US89,Hawaii,IT,Italy,Peak,$12.21,$12.39
+US89,Hawaii,IT10,Sicily,NonPeak,$10.83,$11.54
+US89,Hawaii,IT10,Sicily,Peak,$12.78,$20.76
+US89,Hawaii,JA01,Japan-Central,NonPeak,$11.35,$16.89
+US89,Hawaii,JA01,Japan-Central,Peak,$13.39,$14.20
+US89,Hawaii,JA02,Japan-South (Excludes Hokkaido),NonPeak,$11.82,$11.66
+US89,Hawaii,JA02,Japan-South (Excludes Hokkaido),Peak,$13.95,$14.94
+US89,Hawaii,JA03,Japan-North,NonPeak,$8.88,$10.16
+US89,Hawaii,JA03,Japan-North,Peak,$10.48,$21.20
+US89,Hawaii,JA96,Okinawa,NonPeak,$9.31,$16.98
+US89,Hawaii,JA96,Okinawa,Peak,$10.99,$14.58
+US89,Hawaii,KS,"Korea, Republic Of",NonPeak,$9.77,$11.75
+US89,Hawaii,KS,"Korea, Republic Of",Peak,$11.53,$12.87
+US89,Hawaii,KU,Kuwait,NonPeak,$10.21,$10.25
+US89,Hawaii,KU,Kuwait,Peak,$12.05,$21.84
+US89,Hawaii,NL,Netherlands,NonPeak,$10.65,$17.11
+US89,Hawaii,NL,Netherlands,Peak,$12.57,$14.99
+US89,Hawaii,NO,Norway,NonPeak,$10.35,$11.86
+US89,Hawaii,NO,Norway,Peak,$12.21,$13.26
+US89,Hawaii,PA,Paraguay,NonPeak,$10.83,$10.37
+US89,Hawaii,PA,Paraguay,Peak,$12.78,$22.42
+US89,Hawaii,PE,Peru,NonPeak,$11.35,$17.17
+US89,Hawaii,PE,Peru,Peak,$13.39,$15.33
+US89,Hawaii,PL,Poland,NonPeak,$11.82,$10.50
+US89,Hawaii,PL,Poland,Peak,$13.95,$13.62
+US89,Hawaii,PO,Portugal,NonPeak,$8.88,$17.59
+US89,Hawaii,PO,Portugal,Peak,$10.48,$19.93
+US89,Hawaii,PO01,Azores,NonPeak,$9.31,$12.03
+US89,Hawaii,PO01,Azores,Peak,$10.99,$13.76
+US89,Hawaii,QA,Qatar,NonPeak,$9.77,$12.66
+US89,Hawaii,QA,Qatar,Peak,$11.53,$11.99
+US89,Hawaii,RO,Romania,NonPeak,$10.21,$17.97
+US89,Hawaii,RO,Romania,Peak,$12.05,$20.04
+US89,Hawaii,RQ,Puerto Rico,NonPeak,$10.65,$12.36
+US89,Hawaii,RQ,Puerto Rico,Peak,$12.57,$13.86
+US89,Hawaii,SA,Saudi Arabia,NonPeak,$10.35,$10.91
+US89,Hawaii,SA,Saudi Arabia,Peak,$12.21,$12.09
+US89,Hawaii,SN,Singapore,NonPeak,$10.83,$18.51
+US89,Hawaii,SN,Singapore,Peak,$12.78,$20.19
+US89,Hawaii,SP,Spain,NonPeak,$11.35,$12.70
+US89,Hawaii,SP,Spain,Peak,$13.39,$13.99
+US89,Hawaii,TU,Turkey,NonPeak,$11.82,$11.24
+US89,Hawaii,TU,Turkey,Peak,$13.95,$12.24
+US89,Hawaii,UK,United Kingdom,NonPeak,$8.88,$19.00
+US89,Hawaii,UK,United Kingdom,Peak,$10.48,$20.26
+US89,Hawaii,US8030400,Alaska (Zone) IV,NonPeak,$9.31,$12.99
+US89,Hawaii,US8030400,Alaska (Zone) IV,Peak,$10.99,$12.39
+US89,Hawaii,US8050500,Alaska (Zone) III,NonPeak,$9.77,$11.54
+US89,Hawaii,US8050500,Alaska (Zone) III,Peak,$11.53,$20.76
+US89,Hawaii,US8101000,Alaska (Zone) I,NonPeak,$10.21,$16.89
+US89,Hawaii,US8101000,Alaska (Zone) I,Peak,$12.05,$14.20
+US89,Hawaii,US8190100,Alaska (Zone) II,NonPeak,$10.65,$11.66
+US89,Hawaii,US8190100,Alaska (Zone) II,Peak,$12.57,$14.94
+US89,Hawaii,US89,Hawaii,NonPeak,$10.35,$10.16
+US89,Hawaii,US89,Hawaii,Peak,$12.21,$21.20
+US89,Hawaii,UY,Uruguay,NonPeak,$10.83,$16.98
+US89,Hawaii,UY,Uruguay,Peak,$12.78,$14.58
+US89,Hawaii,VE,Venezuela,NonPeak,$11.35,$11.75
+US89,Hawaii,VE,Venezuela,Peak,$13.39,$12.87
+UY,Uruguay,AR,Argentina,NonPeak,$11.82,$10.25
+UY,Uruguay,AR,Argentina,Peak,$13.95,$21.84
+UY,Uruguay,AS11,New South Wales/Australian Capital Territory,NonPeak,$8.88,$17.11
+UY,Uruguay,AS11,New South Wales/Australian Capital Territory,Peak,$10.48,$14.99
+UY,Uruguay,AS21,Northern Territory,NonPeak,$9.31,$11.86
+UY,Uruguay,AS21,Northern Territory,Peak,$10.99,$13.26
+UY,Uruguay,BA,Bahrain,NonPeak,$9.77,$10.37
+UY,Uruguay,BA,Bahrain,Peak,$11.53,$22.42
+UY,Uruguay,BE,Belgium,NonPeak,$10.21,$17.17
+UY,Uruguay,BE,Belgium,Peak,$12.05,$15.33
+UY,Uruguay,BL,Bolivia,NonPeak,$10.65,$10.50
+UY,Uruguay,BL,Bolivia,Peak,$12.57,$13.62
+UY,Uruguay,BR,Brazil - Brazilia,NonPeak,$10.35,$17.59
+UY,Uruguay,BR,Brazil - Brazilia,Peak,$12.21,$19.93
+UY,Uruguay,CA10,Ontario,NonPeak,$10.83,$12.03
+UY,Uruguay,CA10,Ontario,Peak,$12.78,$13.76
+UY,Uruguay,CA20,Quebec,NonPeak,$11.35,$12.66
+UY,Uruguay,CA20,Quebec,Peak,$13.39,$11.99
+UY,Uruguay,CA30,Manitoba,NonPeak,$11.82,$17.97
+UY,Uruguay,CA30,Manitoba,Peak,$13.95,$20.04
+UY,Uruguay,CI,Chile,NonPeak,$8.88,$12.36
+UY,Uruguay,CI,Chile,Peak,$10.48,$13.86
+UY,Uruguay,CO,Colombia,NonPeak,$9.31,$10.91
+UY,Uruguay,CO,Colombia,Peak,$10.99,$12.09
+UY,Uruguay,CS,Costa Rica,NonPeak,$9.77,$18.51
+UY,Uruguay,CS,Costa Rica,Peak,$11.53,$20.19
+UY,Uruguay,EC,Ecuador,NonPeak,$10.21,$12.70
+UY,Uruguay,EC,Ecuador,Peak,$12.05,$13.99
+UY,Uruguay,ES,El Salvador,NonPeak,$10.65,$11.24
+UY,Uruguay,ES,El Salvador,Peak,$12.57,$12.24
+UY,Uruguay,GE,Germany,NonPeak,$10.35,$19.00
+UY,Uruguay,GE,Germany,Peak,$12.21,$20.26
+UY,Uruguay,GQ,Guam,NonPeak,$10.83,$12.99
+UY,Uruguay,GQ,Guam,Peak,$12.78,$12.39
+UY,Uruguay,GR,Greece,NonPeak,$11.35,$11.54
+UY,Uruguay,GR,Greece,Peak,$13.39,$20.76
+UY,Uruguay,GR29,Crete,NonPeak,$11.82,$16.89
+UY,Uruguay,GR29,Crete,Peak,$13.95,$14.20
+UY,Uruguay,GT,Guatemala,NonPeak,$8.88,$11.66
+UY,Uruguay,GT,Guatemala,Peak,$10.48,$14.94
+UY,Uruguay,HO,Honduras,NonPeak,$9.31,$10.16
+UY,Uruguay,HO,Honduras,Peak,$10.99,$21.20
+UY,Uruguay,HU,Hungary,NonPeak,$9.77,$16.98
+UY,Uruguay,HU,Hungary,Peak,$11.53,$14.58
+UY,Uruguay,IT,Italy,NonPeak,$10.21,$11.75
+UY,Uruguay,IT,Italy,Peak,$12.05,$12.87
+UY,Uruguay,IT10,Sicily,NonPeak,$10.65,$10.25
+UY,Uruguay,IT10,Sicily,Peak,$12.57,$21.84
+UY,Uruguay,JA01,Japan-Central,NonPeak,$10.35,$17.11
+UY,Uruguay,JA01,Japan-Central,Peak,$12.21,$14.99
+UY,Uruguay,JA02,Japan-South (Excludes Hokkaido),NonPeak,$10.83,$11.86
+UY,Uruguay,JA02,Japan-South (Excludes Hokkaido),Peak,$12.78,$13.26
+UY,Uruguay,JA03,Japan-North,NonPeak,$11.35,$10.37
+UY,Uruguay,JA03,Japan-North,Peak,$13.39,$22.42
+UY,Uruguay,JA96,Okinawa,NonPeak,$11.82,$17.17
+UY,Uruguay,JA96,Okinawa,Peak,$13.95,$15.33
+UY,Uruguay,KS,"Korea, Republic Of",NonPeak,$8.88,$10.50
+UY,Uruguay,KS,"Korea, Republic Of",Peak,$10.48,$13.62
+UY,Uruguay,KU,Kuwait,NonPeak,$9.31,$17.59
+UY,Uruguay,KU,Kuwait,Peak,$10.99,$19.93
+UY,Uruguay,NL,Netherlands,NonPeak,$9.77,$12.03
+UY,Uruguay,NL,Netherlands,Peak,$11.53,$13.76
+UY,Uruguay,NO,Norway,NonPeak,$10.21,$12.66
+UY,Uruguay,NO,Norway,Peak,$12.05,$11.99
+UY,Uruguay,PA,Paraguay,NonPeak,$10.65,$17.97
+UY,Uruguay,PA,Paraguay,Peak,$12.57,$20.04
+UY,Uruguay,PE,Peru,NonPeak,$10.35,$12.36
+UY,Uruguay,PE,Peru,Peak,$12.21,$13.86
+UY,Uruguay,PL,Poland,NonPeak,$10.83,$10.91
+UY,Uruguay,PL,Poland,Peak,$12.78,$12.09
+UY,Uruguay,PO,Portugal,NonPeak,$11.35,$18.51
+UY,Uruguay,PO,Portugal,Peak,$13.39,$20.19
+UY,Uruguay,PO01,Azores,NonPeak,$11.82,$12.70
+UY,Uruguay,PO01,Azores,Peak,$13.95,$13.99
+UY,Uruguay,QA,Qatar,NonPeak,$8.88,$11.24
+UY,Uruguay,QA,Qatar,Peak,$10.48,$12.24
+UY,Uruguay,RO,Romania,NonPeak,$9.31,$19.00
+UY,Uruguay,RO,Romania,Peak,$10.99,$20.26
+UY,Uruguay,RQ,Puerto Rico,NonPeak,$9.77,$12.99
+UY,Uruguay,RQ,Puerto Rico,Peak,$11.53,$12.39
+UY,Uruguay,SA,Saudi Arabia,NonPeak,$10.21,$11.54
+UY,Uruguay,SA,Saudi Arabia,Peak,$12.05,$20.76
+UY,Uruguay,SN,Singapore,NonPeak,$10.65,$16.89
+UY,Uruguay,SN,Singapore,Peak,$12.57,$14.20
+UY,Uruguay,SP,Spain,NonPeak,$10.35,$11.66
+UY,Uruguay,SP,Spain,Peak,$12.21,$14.94
+UY,Uruguay,TU,Turkey,NonPeak,$10.83,$10.16
+UY,Uruguay,TU,Turkey,Peak,$12.78,$21.20
+UY,Uruguay,UK,United Kingdom,NonPeak,$11.35,$16.98
+UY,Uruguay,UK,United Kingdom,Peak,$13.39,$14.58
+UY,Uruguay,US8030400,Alaska (Zone) IV,NonPeak,$11.82,$11.75
+UY,Uruguay,US8030400,Alaska (Zone) IV,Peak,$13.95,$12.87
+UY,Uruguay,US8050500,Alaska (Zone) III,NonPeak,$8.88,$10.25
+UY,Uruguay,US8050500,Alaska (Zone) III,Peak,$10.48,$21.84
+UY,Uruguay,US8101000,Alaska (Zone) I,NonPeak,$9.31,$17.11
+UY,Uruguay,US8101000,Alaska (Zone) I,Peak,$10.99,$14.99
+UY,Uruguay,US8190100,Alaska (Zone) II,NonPeak,$9.77,$11.86
+UY,Uruguay,US8190100,Alaska (Zone) II,Peak,$11.53,$13.26
+UY,Uruguay,US89,Hawaii,NonPeak,$10.21,$10.37
+UY,Uruguay,US89,Hawaii,Peak,$12.05,$22.42
+UY,Uruguay,UY,Uruguay,NonPeak,$10.65,$17.17
+UY,Uruguay,UY,Uruguay,Peak,$12.57,$15.33
+UY,Uruguay,VE,Venezuela,NonPeak,$10.35,$10.50
+UY,Uruguay,VE,Venezuela,Peak,$12.21,$13.62
+VE,Venezuela,AR,Argentina,NonPeak,$10.83,$17.59
+VE,Venezuela,AR,Argentina,Peak,$12.78,$19.93
+VE,Venezuela,AS11,New South Wales/Australian Capital Territory,NonPeak,$11.35,$12.03
+VE,Venezuela,AS11,New South Wales/Australian Capital Territory,Peak,$13.39,$13.76
+VE,Venezuela,AS21,Northern Territory,NonPeak,$11.82,$12.66
+VE,Venezuela,AS21,Northern Territory,Peak,$13.95,$11.99
+VE,Venezuela,BA,Bahrain,NonPeak,$8.88,$17.97
+VE,Venezuela,BA,Bahrain,Peak,$10.48,$20.04
+VE,Venezuela,BE,Belgium,NonPeak,$9.31,$12.36
+VE,Venezuela,BE,Belgium,Peak,$10.99,$13.86
+VE,Venezuela,BL,Bolivia,NonPeak,$9.77,$10.91
+VE,Venezuela,BL,Bolivia,Peak,$11.53,$12.09
+VE,Venezuela,BR,Brazil - Brazilia,NonPeak,$10.21,$18.51
+VE,Venezuela,BR,Brazil - Brazilia,Peak,$12.05,$20.19
+VE,Venezuela,CA10,Ontario,NonPeak,$10.65,$12.70
+VE,Venezuela,CA10,Ontario,Peak,$12.57,$13.99
+VE,Venezuela,CA20,Quebec,NonPeak,$10.35,$11.24
+VE,Venezuela,CA20,Quebec,Peak,$12.21,$12.24
+VE,Venezuela,CA30,Manitoba,NonPeak,$10.83,$19.00
+VE,Venezuela,CA30,Manitoba,Peak,$12.78,$20.26
+VE,Venezuela,CI,Chile,NonPeak,$11.35,$12.99
+VE,Venezuela,CI,Chile,Peak,$13.39,$12.39
+VE,Venezuela,CO,Colombia,NonPeak,$11.82,$11.54
+VE,Venezuela,CO,Colombia,Peak,$13.95,$20.76
+VE,Venezuela,CS,Costa Rica,NonPeak,$8.88,$16.89
+VE,Venezuela,CS,Costa Rica,Peak,$10.48,$14.20
+VE,Venezuela,EC,Ecuador,NonPeak,$9.31,$11.66
+VE,Venezuela,EC,Ecuador,Peak,$10.99,$14.94
+VE,Venezuela,ES,El Salvador,NonPeak,$9.77,$10.16
+VE,Venezuela,ES,El Salvador,Peak,$11.53,$21.20
+VE,Venezuela,GE,Germany,NonPeak,$10.21,$16.98
+VE,Venezuela,GE,Germany,Peak,$12.05,$14.58
+VE,Venezuela,GQ,Guam,NonPeak,$10.65,$11.75
+VE,Venezuela,GQ,Guam,Peak,$12.57,$12.87
+VE,Venezuela,GR,Greece,NonPeak,$10.35,$10.25
+VE,Venezuela,GR,Greece,Peak,$12.21,$21.84
+VE,Venezuela,GR29,Crete,NonPeak,$10.83,$17.11
+VE,Venezuela,GR29,Crete,Peak,$12.78,$14.99
+VE,Venezuela,GT,Guatemala,NonPeak,$11.35,$11.86
+VE,Venezuela,GT,Guatemala,Peak,$13.39,$13.26
+VE,Venezuela,HO,Honduras,NonPeak,$11.82,$10.37
+VE,Venezuela,HO,Honduras,Peak,$13.95,$22.42
+VE,Venezuela,HU,Hungary,NonPeak,$8.88,$17.17
+VE,Venezuela,HU,Hungary,Peak,$10.48,$15.33
+VE,Venezuela,IT,Italy,NonPeak,$9.31,$10.50
+VE,Venezuela,IT,Italy,Peak,$10.99,$13.62
+VE,Venezuela,IT10,Sicily,NonPeak,$9.77,$17.59
+VE,Venezuela,IT10,Sicily,Peak,$11.53,$19.93
+VE,Venezuela,JA01,Japan-Central,NonPeak,$10.21,$12.03
+VE,Venezuela,JA01,Japan-Central,Peak,$12.05,$13.76
+VE,Venezuela,JA02,Japan-South (Excludes Hokkaido),NonPeak,$10.65,$12.66
+VE,Venezuela,JA02,Japan-South (Excludes Hokkaido),Peak,$12.57,$11.99
+VE,Venezuela,JA03,Japan-North,NonPeak,$10.35,$17.97
+VE,Venezuela,JA03,Japan-North,Peak,$12.21,$20.04
+VE,Venezuela,JA96,Okinawa,NonPeak,$10.83,$12.36
+VE,Venezuela,JA96,Okinawa,Peak,$12.78,$13.86
+VE,Venezuela,KS,"Korea, Republic Of",NonPeak,$11.35,$10.91
+VE,Venezuela,KS,"Korea, Republic Of",Peak,$13.39,$12.09
+VE,Venezuela,KU,Kuwait,NonPeak,$11.82,$18.51
+VE,Venezuela,KU,Kuwait,Peak,$13.95,$20.19
+VE,Venezuela,NL,Netherlands,NonPeak,$8.88,$12.70
+VE,Venezuela,NL,Netherlands,Peak,$10.48,$13.99
+VE,Venezuela,NO,Norway,NonPeak,$9.31,$11.24
+VE,Venezuela,NO,Norway,Peak,$10.99,$12.24
+VE,Venezuela,PA,Paraguay,NonPeak,$9.77,$19.00
+VE,Venezuela,PA,Paraguay,Peak,$11.53,$20.26
+VE,Venezuela,PE,Peru,NonPeak,$10.21,$12.99
+VE,Venezuela,PE,Peru,Peak,$12.05,$12.39
+VE,Venezuela,PL,Poland,NonPeak,$10.65,$11.54
+VE,Venezuela,PL,Poland,Peak,$12.57,$20.76
+VE,Venezuela,PO,Portugal,NonPeak,$10.35,$16.89
+VE,Venezuela,PO,Portugal,Peak,$12.21,$14.20
+VE,Venezuela,PO01,Azores,NonPeak,$10.83,$11.66
+VE,Venezuela,PO01,Azores,Peak,$12.78,$14.94
+VE,Venezuela,QA,Qatar,NonPeak,$11.35,$10.16
+VE,Venezuela,QA,Qatar,Peak,$13.39,$21.20
+VE,Venezuela,RO,Romania,NonPeak,$11.82,$16.98
+VE,Venezuela,RO,Romania,Peak,$13.95,$14.58
+VE,Venezuela,RQ,Puerto Rico,NonPeak,$8.88,$11.75
+VE,Venezuela,RQ,Puerto Rico,Peak,$10.48,$12.87
+VE,Venezuela,SA,Saudi Arabia,NonPeak,$9.31,$10.25
+VE,Venezuela,SA,Saudi Arabia,Peak,$10.99,$21.84
+VE,Venezuela,SN,Singapore,NonPeak,$9.77,$17.11
+VE,Venezuela,SN,Singapore,Peak,$11.53,$14.99
+VE,Venezuela,SP,Spain,NonPeak,$10.21,$11.86
+VE,Venezuela,SP,Spain,Peak,$12.05,$13.26
+VE,Venezuela,TU,Turkey,NonPeak,$10.65,$10.37
+VE,Venezuela,TU,Turkey,Peak,$12.57,$22.42
+VE,Venezuela,UK,United Kingdom,NonPeak,$10.35,$17.17
+VE,Venezuela,UK,United Kingdom,Peak,$12.21,$15.33
+VE,Venezuela,US8030400,Alaska (Zone) IV,NonPeak,$10.83,$10.50
+VE,Venezuela,US8030400,Alaska (Zone) IV,Peak,$12.78,$13.62
+VE,Venezuela,US8050500,Alaska (Zone) III,NonPeak,$11.35,$17.59
+VE,Venezuela,US8050500,Alaska (Zone) III,Peak,$13.39,$19.93
+VE,Venezuela,US8101000,Alaska (Zone) I,NonPeak,$11.82,$12.03
+VE,Venezuela,US8101000,Alaska (Zone) I,Peak,$13.95,$13.76
+VE,Venezuela,US8190100,Alaska (Zone) II,NonPeak,$8.88,$12.66
+VE,Venezuela,US8190100,Alaska (Zone) II,Peak,$10.48,$11.99
+VE,Venezuela,US89,Hawaii,NonPeak,$9.31,$17.97
+VE,Venezuela,US89,Hawaii,Peak,$10.99,$20.04
+VE,Venezuela,UY,Uruguay,NonPeak,$9.77,$12.36
+VE,Venezuela,UY,Uruguay,Peak,$11.53,$13.86
+VE,Venezuela,VE,Venezuela,NonPeak,$10.21,$10.91
+VE,Venezuela,VE,Venezuela,Peak,$12.05,$12.09

--- a/pkg/parser/pricing/fixtures/11_3b_conus_to_oconus_prices_golden.csv
+++ b/pkg/parser/pricing/fixtures/11_3b_conus_to_oconus_prices_golden.csv
@@ -1,0 +1,5513 @@
+origin_domestic_price_area_code,origin_domestic_price_area,destination_intl_price_area_id,destination_intl_price_area,season,hhg_shipping_linehaul_price,ub_price
+US11,Maine,AR,Argentina,NonPeak,$15.28,$43.94
+US11,Maine,AR,Argentina,Peak,$18.03,$51.85
+US11,Maine,AS11,New South Wales/Australian Capital Territory,NonPeak,$16.05,$33.70
+US11,Maine,AS11,New South Wales/Australian Capital Territory,Peak,$18.94,$39.77
+US11,Maine,AS21,Northern Territory,NonPeak,$16.80,$31.29
+US11,Maine,AS21,Northern Territory,Peak,$19.82,$36.92
+US11,Maine,BA,Bahrain,NonPeak,$17.57,$44.05
+US11,Maine,BA,Bahrain,Peak,$20.73,$51.98
+US11,Maine,BE,Belgium,NonPeak,$18.33,$33.75
+US11,Maine,BE,Belgium,Peak,$21.63,$39.82
+US11,Maine,BL,Bolivia,NonPeak,$24.38,$31.40
+US11,Maine,BL,Bolivia,Peak,$28.77,$37.05
+US11,Maine,BR,Brazil - Brazilia,NonPeak,$16.00,$44.17
+US11,Maine,BR,Brazil - Brazilia,Peak,$18.88,$52.12
+US11,Maine,CA10,Ontario,NonPeak,$27.63,$33.98
+US11,Maine,CA10,Ontario,Peak,$32.60,$40.10
+US11,Maine,CA20,Quebec,NonPeak,$29.28,$31.45
+US11,Maine,CA20,Quebec,Peak,$34.55,$37.11
+US11,Maine,CA30,Manitoba,NonPeak,$30.90,$44.28
+US11,Maine,CA30,Manitoba,Peak,$36.46,$52.25
+US11,Maine,CI,Chile,NonPeak,$15.28,$34.11
+US11,Maine,CI,Chile,Peak,$18.03,$40.25
+US11,Maine,CO,Colombia,NonPeak,$16.05,$31.63
+US11,Maine,CO,Colombia,Peak,$18.94,$37.32
+US11,Maine,CS,Costa Rica,NonPeak,$16.80,$44.51
+US11,Maine,CS,Costa Rica,Peak,$19.82,$52.52
+US11,Maine,EC,Ecuador,NonPeak,$17.57,$34.33
+US11,Maine,EC,Ecuador,Peak,$20.73,$40.51
+US11,Maine,ES,El Salvador,NonPeak,$18.33,$31.74
+US11,Maine,ES,El Salvador,Peak,$21.63,$37.45
+US11,Maine,GE,Germany,NonPeak,$24.38,$44.62
+US11,Maine,GE,Germany,Peak,$28.77,$52.65
+US11,Maine,GQ,Guam,NonPeak,$16.00,$34.45
+US11,Maine,GQ,Guam,Peak,$18.88,$40.65
+US11,Maine,GR,Greece,NonPeak,$27.63,$31.91
+US11,Maine,GR,Greece,Peak,$32.60,$37.65
+US11,Maine,GR29,Crete,NonPeak,$29.28,$44.74
+US11,Maine,GR29,Crete,Peak,$34.55,$52.79
+US11,Maine,GT,Guatemala,NonPeak,$30.90,$34.56
+US11,Maine,GT,Guatemala,Peak,$36.46,$40.78
+US11,Maine,HO,Honduras,NonPeak,$15.28,$32.09
+US11,Maine,HO,Honduras,Peak,$18.03,$37.87
+US11,Maine,HU,Hungary,NonPeak,$16.05,$44.91
+US11,Maine,HU,Hungary,Peak,$18.94,$52.99
+US11,Maine,IT,Italy,NonPeak,$16.80,$34.74
+US11,Maine,IT,Italy,Peak,$19.82,$40.99
+US11,Maine,IT10,Sicily,NonPeak,$17.57,$32.26
+US11,Maine,IT10,Sicily,Peak,$20.73,$38.07
+US11,Maine,JA01,Japan-Central,NonPeak,$18.33,$45.09
+US11,Maine,JA01,Japan-Central,Peak,$21.63,$53.21
+US11,Maine,JA02,Japan-South (Excludes Hokkaido),NonPeak,$24.38,$34.90
+US11,Maine,JA02,Japan-South (Excludes Hokkaido),Peak,$28.77,$41.18
+US11,Maine,JA03,Japan-North,NonPeak,$16.00,$32.44
+US11,Maine,JA03,Japan-North,Peak,$18.88,$38.28
+US11,Maine,JA96,Okinawa,NonPeak,$27.63,$43.94
+US11,Maine,JA96,Okinawa,Peak,$32.60,$51.85
+US11,Maine,KS,"Korea, Republic Of",NonPeak,$29.28,$33.70
+US11,Maine,KS,"Korea, Republic Of",Peak,$34.55,$39.77
+US11,Maine,KU,Kuwait,NonPeak,$30.90,$31.29
+US11,Maine,KU,Kuwait,Peak,$36.46,$36.92
+US11,Maine,NL,Netherlands,NonPeak,$15.28,$44.05
+US11,Maine,NL,Netherlands,Peak,$18.03,$51.98
+US11,Maine,NO,Norway,NonPeak,$16.05,$33.75
+US11,Maine,NO,Norway,Peak,$18.94,$39.82
+US11,Maine,PA,Paraguay,NonPeak,$16.80,$31.40
+US11,Maine,PA,Paraguay,Peak,$19.82,$37.05
+US11,Maine,PE,Peru,NonPeak,$17.57,$44.17
+US11,Maine,PE,Peru,Peak,$20.73,$52.12
+US11,Maine,PL,Poland,NonPeak,$18.33,$33.98
+US11,Maine,PL,Poland,Peak,$21.63,$40.10
+US11,Maine,PO,Portugal,NonPeak,$24.38,$31.45
+US11,Maine,PO,Portugal,Peak,$28.77,$37.11
+US11,Maine,PO01,Azores,NonPeak,$16.00,$44.28
+US11,Maine,PO01,Azores,Peak,$18.88,$52.25
+US11,Maine,QA,Qatar,NonPeak,$27.63,$34.11
+US11,Maine,QA,Qatar,Peak,$32.60,$40.25
+US11,Maine,RO,Romania,NonPeak,$29.28,$31.63
+US11,Maine,RO,Romania,Peak,$34.55,$37.32
+US11,Maine,RQ,Puerto Rico,NonPeak,$30.90,$44.51
+US11,Maine,RQ,Puerto Rico,Peak,$36.46,$52.52
+US11,Maine,SA,Saudi Arabia,NonPeak,$15.28,$34.33
+US11,Maine,SA,Saudi Arabia,Peak,$18.03,$40.51
+US11,Maine,SN,Singapore,NonPeak,$16.05,$31.74
+US11,Maine,SN,Singapore,Peak,$18.94,$37.45
+US11,Maine,SP,Spain,NonPeak,$16.80,$44.62
+US11,Maine,SP,Spain,Peak,$19.82,$52.65
+US11,Maine,TU,Turkey,NonPeak,$17.57,$34.45
+US11,Maine,TU,Turkey,Peak,$20.73,$40.65
+US11,Maine,UK,United Kingdom,NonPeak,$18.33,$31.91
+US11,Maine,UK,United Kingdom,Peak,$21.63,$37.65
+US11,Maine,US8030400,Alaska (Zone) IV,NonPeak,$24.38,$44.74
+US11,Maine,US8030400,Alaska (Zone) IV,Peak,$28.77,$52.79
+US11,Maine,US8050500,Alaska (Zone) III,NonPeak,$16.00,$34.56
+US11,Maine,US8050500,Alaska (Zone) III,Peak,$18.88,$40.78
+US11,Maine,US8101000,Alaska (Zone) I,NonPeak,$27.63,$32.09
+US11,Maine,US8101000,Alaska (Zone) I,Peak,$32.60,$37.87
+US11,Maine,US8190100,Alaska (Zone) II,NonPeak,$29.28,$44.91
+US11,Maine,US8190100,Alaska (Zone) II,Peak,$34.55,$52.99
+US11,Maine,US89,Hawaii,NonPeak,$30.90,$34.74
+US11,Maine,US89,Hawaii,Peak,$36.46,$40.99
+US11,Maine,UY,Uruguay,NonPeak,$15.28,$32.26
+US11,Maine,UY,Uruguay,Peak,$18.03,$38.07
+US11,Maine,VE,Venezuela,NonPeak,$16.05,$45.09
+US11,Maine,VE,Venezuela,Peak,$18.94,$53.21
+US12,New Hampshire,AR,Argentina,NonPeak,$16.80,$34.90
+US12,New Hampshire,AR,Argentina,Peak,$19.82,$41.18
+US12,New Hampshire,AS11,New South Wales/Australian Capital Territory,NonPeak,$17.57,$32.44
+US12,New Hampshire,AS11,New South Wales/Australian Capital Territory,Peak,$20.73,$38.28
+US12,New Hampshire,AS21,Northern Territory,NonPeak,$18.33,$43.94
+US12,New Hampshire,AS21,Northern Territory,Peak,$21.63,$51.85
+US12,New Hampshire,BA,Bahrain,NonPeak,$24.38,$33.70
+US12,New Hampshire,BA,Bahrain,Peak,$28.77,$39.77
+US12,New Hampshire,BE,Belgium,NonPeak,$16.00,$31.29
+US12,New Hampshire,BE,Belgium,Peak,$18.88,$36.92
+US12,New Hampshire,BL,Bolivia,NonPeak,$27.63,$44.05
+US12,New Hampshire,BL,Bolivia,Peak,$32.60,$51.98
+US12,New Hampshire,BR,Brazil - Brazilia,NonPeak,$29.28,$33.75
+US12,New Hampshire,BR,Brazil - Brazilia,Peak,$34.55,$39.82
+US12,New Hampshire,CA10,Ontario,NonPeak,$30.90,$31.40
+US12,New Hampshire,CA10,Ontario,Peak,$36.46,$37.05
+US12,New Hampshire,CA20,Quebec,NonPeak,$15.28,$44.17
+US12,New Hampshire,CA20,Quebec,Peak,$18.03,$52.12
+US12,New Hampshire,CA30,Manitoba,NonPeak,$16.05,$33.98
+US12,New Hampshire,CA30,Manitoba,Peak,$18.94,$40.10
+US12,New Hampshire,CI,Chile,NonPeak,$16.80,$31.45
+US12,New Hampshire,CI,Chile,Peak,$19.82,$37.11
+US12,New Hampshire,CO,Colombia,NonPeak,$17.57,$44.28
+US12,New Hampshire,CO,Colombia,Peak,$20.73,$52.25
+US12,New Hampshire,CS,Costa Rica,NonPeak,$18.33,$34.11
+US12,New Hampshire,CS,Costa Rica,Peak,$21.63,$40.25
+US12,New Hampshire,EC,Ecuador,NonPeak,$24.38,$31.63
+US12,New Hampshire,EC,Ecuador,Peak,$28.77,$37.32
+US12,New Hampshire,ES,El Salvador,NonPeak,$16.00,$44.51
+US12,New Hampshire,ES,El Salvador,Peak,$18.88,$52.52
+US12,New Hampshire,GE,Germany,NonPeak,$27.63,$34.33
+US12,New Hampshire,GE,Germany,Peak,$32.60,$40.51
+US12,New Hampshire,GQ,Guam,NonPeak,$29.28,$31.74
+US12,New Hampshire,GQ,Guam,Peak,$34.55,$37.45
+US12,New Hampshire,GR,Greece,NonPeak,$30.90,$44.62
+US12,New Hampshire,GR,Greece,Peak,$36.46,$52.65
+US12,New Hampshire,GR29,Crete,NonPeak,$15.28,$34.45
+US12,New Hampshire,GR29,Crete,Peak,$18.03,$40.65
+US12,New Hampshire,GT,Guatemala,NonPeak,$16.05,$31.91
+US12,New Hampshire,GT,Guatemala,Peak,$18.94,$37.65
+US12,New Hampshire,HO,Honduras,NonPeak,$16.80,$44.74
+US12,New Hampshire,HO,Honduras,Peak,$19.82,$52.79
+US12,New Hampshire,HU,Hungary,NonPeak,$17.57,$34.56
+US12,New Hampshire,HU,Hungary,Peak,$20.73,$40.78
+US12,New Hampshire,IT,Italy,NonPeak,$18.33,$32.09
+US12,New Hampshire,IT,Italy,Peak,$21.63,$37.87
+US12,New Hampshire,IT10,Sicily,NonPeak,$24.38,$44.91
+US12,New Hampshire,IT10,Sicily,Peak,$28.77,$52.99
+US12,New Hampshire,JA01,Japan-Central,NonPeak,$16.00,$34.74
+US12,New Hampshire,JA01,Japan-Central,Peak,$18.88,$40.99
+US12,New Hampshire,JA02,Japan-South (Excludes Hokkaido),NonPeak,$27.63,$32.26
+US12,New Hampshire,JA02,Japan-South (Excludes Hokkaido),Peak,$32.60,$38.07
+US12,New Hampshire,JA03,Japan-North,NonPeak,$29.28,$45.09
+US12,New Hampshire,JA03,Japan-North,Peak,$34.55,$53.21
+US12,New Hampshire,JA96,Okinawa,NonPeak,$30.90,$34.90
+US12,New Hampshire,JA96,Okinawa,Peak,$36.46,$41.18
+US12,New Hampshire,KS,"Korea, Republic Of",NonPeak,$15.28,$32.44
+US12,New Hampshire,KS,"Korea, Republic Of",Peak,$18.03,$38.28
+US12,New Hampshire,KU,Kuwait,NonPeak,$16.05,$43.94
+US12,New Hampshire,KU,Kuwait,Peak,$18.94,$51.85
+US12,New Hampshire,NL,Netherlands,NonPeak,$16.80,$33.70
+US12,New Hampshire,NL,Netherlands,Peak,$19.82,$39.77
+US12,New Hampshire,NO,Norway,NonPeak,$17.57,$31.29
+US12,New Hampshire,NO,Norway,Peak,$20.73,$36.92
+US12,New Hampshire,PA,Paraguay,NonPeak,$18.33,$44.05
+US12,New Hampshire,PA,Paraguay,Peak,$21.63,$51.98
+US12,New Hampshire,PE,Peru,NonPeak,$24.38,$33.75
+US12,New Hampshire,PE,Peru,Peak,$28.77,$39.82
+US12,New Hampshire,PL,Poland,NonPeak,$16.00,$31.40
+US12,New Hampshire,PL,Poland,Peak,$18.88,$37.05
+US12,New Hampshire,PO,Portugal,NonPeak,$27.63,$44.17
+US12,New Hampshire,PO,Portugal,Peak,$32.60,$52.12
+US12,New Hampshire,PO01,Azores,NonPeak,$29.28,$33.98
+US12,New Hampshire,PO01,Azores,Peak,$34.55,$40.10
+US12,New Hampshire,QA,Qatar,NonPeak,$30.90,$31.45
+US12,New Hampshire,QA,Qatar,Peak,$36.46,$37.11
+US12,New Hampshire,RO,Romania,NonPeak,$15.28,$44.28
+US12,New Hampshire,RO,Romania,Peak,$18.03,$52.25
+US12,New Hampshire,RQ,Puerto Rico,NonPeak,$16.05,$34.11
+US12,New Hampshire,RQ,Puerto Rico,Peak,$18.94,$40.25
+US12,New Hampshire,SA,Saudi Arabia,NonPeak,$16.80,$31.63
+US12,New Hampshire,SA,Saudi Arabia,Peak,$19.82,$37.32
+US12,New Hampshire,SN,Singapore,NonPeak,$17.57,$44.51
+US12,New Hampshire,SN,Singapore,Peak,$20.73,$52.52
+US12,New Hampshire,SP,Spain,NonPeak,$18.33,$34.33
+US12,New Hampshire,SP,Spain,Peak,$21.63,$40.51
+US12,New Hampshire,TU,Turkey,NonPeak,$24.38,$31.74
+US12,New Hampshire,TU,Turkey,Peak,$28.77,$37.45
+US12,New Hampshire,UK,United Kingdom,NonPeak,$16.00,$44.62
+US12,New Hampshire,UK,United Kingdom,Peak,$18.88,$52.65
+US12,New Hampshire,US8030400,Alaska (Zone) IV,NonPeak,$27.63,$34.45
+US12,New Hampshire,US8030400,Alaska (Zone) IV,Peak,$32.60,$40.65
+US12,New Hampshire,US8050500,Alaska (Zone) III,NonPeak,$29.28,$31.91
+US12,New Hampshire,US8050500,Alaska (Zone) III,Peak,$34.55,$37.65
+US12,New Hampshire,US8101000,Alaska (Zone) I,NonPeak,$30.90,$44.74
+US12,New Hampshire,US8101000,Alaska (Zone) I,Peak,$36.46,$52.79
+US12,New Hampshire,US8190100,Alaska (Zone) II,NonPeak,$15.28,$34.56
+US12,New Hampshire,US8190100,Alaska (Zone) II,Peak,$18.03,$40.78
+US12,New Hampshire,US89,Hawaii,NonPeak,$16.05,$32.09
+US12,New Hampshire,US89,Hawaii,Peak,$18.94,$37.87
+US12,New Hampshire,UY,Uruguay,NonPeak,$16.80,$44.91
+US12,New Hampshire,UY,Uruguay,Peak,$19.82,$52.99
+US12,New Hampshire,VE,Venezuela,NonPeak,$17.57,$34.74
+US12,New Hampshire,VE,Venezuela,Peak,$20.73,$40.99
+US13,Vermont,AR,Argentina,NonPeak,$18.33,$32.26
+US13,Vermont,AR,Argentina,Peak,$21.63,$38.07
+US13,Vermont,AS11,New South Wales/Australian Capital Territory,NonPeak,$24.38,$45.09
+US13,Vermont,AS11,New South Wales/Australian Capital Territory,Peak,$28.77,$53.21
+US13,Vermont,AS21,Northern Territory,NonPeak,$16.00,$34.90
+US13,Vermont,AS21,Northern Territory,Peak,$18.88,$41.18
+US13,Vermont,BA,Bahrain,NonPeak,$27.63,$32.44
+US13,Vermont,BA,Bahrain,Peak,$32.60,$38.28
+US13,Vermont,BE,Belgium,NonPeak,$29.28,$43.94
+US13,Vermont,BE,Belgium,Peak,$34.55,$51.85
+US13,Vermont,BL,Bolivia,NonPeak,$30.90,$33.70
+US13,Vermont,BL,Bolivia,Peak,$36.46,$39.77
+US13,Vermont,BR,Brazil - Brazilia,NonPeak,$15.28,$31.29
+US13,Vermont,BR,Brazil - Brazilia,Peak,$18.03,$36.92
+US13,Vermont,CA10,Ontario,NonPeak,$16.05,$44.05
+US13,Vermont,CA10,Ontario,Peak,$18.94,$51.98
+US13,Vermont,CA20,Quebec,NonPeak,$16.80,$33.75
+US13,Vermont,CA20,Quebec,Peak,$19.82,$39.82
+US13,Vermont,CA30,Manitoba,NonPeak,$17.57,$31.40
+US13,Vermont,CA30,Manitoba,Peak,$20.73,$37.05
+US13,Vermont,CI,Chile,NonPeak,$18.33,$44.17
+US13,Vermont,CI,Chile,Peak,$21.63,$52.12
+US13,Vermont,CO,Colombia,NonPeak,$24.38,$33.98
+US13,Vermont,CO,Colombia,Peak,$28.77,$40.10
+US13,Vermont,CS,Costa Rica,NonPeak,$16.00,$31.45
+US13,Vermont,CS,Costa Rica,Peak,$18.88,$37.11
+US13,Vermont,EC,Ecuador,NonPeak,$27.63,$44.28
+US13,Vermont,EC,Ecuador,Peak,$32.60,$52.25
+US13,Vermont,ES,El Salvador,NonPeak,$29.28,$34.11
+US13,Vermont,ES,El Salvador,Peak,$34.55,$40.25
+US13,Vermont,GE,Germany,NonPeak,$30.90,$31.63
+US13,Vermont,GE,Germany,Peak,$36.46,$37.32
+US13,Vermont,GQ,Guam,NonPeak,$15.28,$44.51
+US13,Vermont,GQ,Guam,Peak,$18.03,$52.52
+US13,Vermont,GR,Greece,NonPeak,$16.05,$34.33
+US13,Vermont,GR,Greece,Peak,$18.94,$40.51
+US13,Vermont,GR29,Crete,NonPeak,$16.80,$31.74
+US13,Vermont,GR29,Crete,Peak,$19.82,$37.45
+US13,Vermont,GT,Guatemala,NonPeak,$17.57,$44.62
+US13,Vermont,GT,Guatemala,Peak,$20.73,$52.65
+US13,Vermont,HO,Honduras,NonPeak,$18.33,$34.45
+US13,Vermont,HO,Honduras,Peak,$21.63,$40.65
+US13,Vermont,HU,Hungary,NonPeak,$24.38,$31.91
+US13,Vermont,HU,Hungary,Peak,$28.77,$37.65
+US13,Vermont,IT,Italy,NonPeak,$16.00,$44.74
+US13,Vermont,IT,Italy,Peak,$18.88,$52.79
+US13,Vermont,IT10,Sicily,NonPeak,$27.63,$34.56
+US13,Vermont,IT10,Sicily,Peak,$32.60,$40.78
+US13,Vermont,JA01,Japan-Central,NonPeak,$29.28,$32.09
+US13,Vermont,JA01,Japan-Central,Peak,$34.55,$37.87
+US13,Vermont,JA02,Japan-South (Excludes Hokkaido),NonPeak,$30.90,$44.91
+US13,Vermont,JA02,Japan-South (Excludes Hokkaido),Peak,$36.46,$52.99
+US13,Vermont,JA03,Japan-North,NonPeak,$15.28,$34.74
+US13,Vermont,JA03,Japan-North,Peak,$18.03,$40.99
+US13,Vermont,JA96,Okinawa,NonPeak,$16.05,$32.26
+US13,Vermont,JA96,Okinawa,Peak,$18.94,$38.07
+US13,Vermont,KS,"Korea, Republic Of",NonPeak,$16.80,$45.09
+US13,Vermont,KS,"Korea, Republic Of",Peak,$19.82,$53.21
+US13,Vermont,KU,Kuwait,NonPeak,$17.57,$34.90
+US13,Vermont,KU,Kuwait,Peak,$20.73,$41.18
+US13,Vermont,NL,Netherlands,NonPeak,$18.33,$32.44
+US13,Vermont,NL,Netherlands,Peak,$21.63,$38.28
+US13,Vermont,NO,Norway,NonPeak,$24.38,$43.94
+US13,Vermont,NO,Norway,Peak,$28.77,$51.85
+US13,Vermont,PA,Paraguay,NonPeak,$16.00,$33.70
+US13,Vermont,PA,Paraguay,Peak,$18.88,$39.77
+US13,Vermont,PE,Peru,NonPeak,$27.63,$31.29
+US13,Vermont,PE,Peru,Peak,$32.60,$36.92
+US13,Vermont,PL,Poland,NonPeak,$29.28,$44.05
+US13,Vermont,PL,Poland,Peak,$34.55,$51.98
+US13,Vermont,PO,Portugal,NonPeak,$30.90,$33.75
+US13,Vermont,PO,Portugal,Peak,$36.46,$39.82
+US13,Vermont,PO01,Azores,NonPeak,$15.28,$31.40
+US13,Vermont,PO01,Azores,Peak,$18.03,$37.05
+US13,Vermont,QA,Qatar,NonPeak,$16.05,$44.17
+US13,Vermont,QA,Qatar,Peak,$18.94,$52.12
+US13,Vermont,RO,Romania,NonPeak,$16.80,$33.98
+US13,Vermont,RO,Romania,Peak,$19.82,$40.10
+US13,Vermont,RQ,Puerto Rico,NonPeak,$17.57,$31.45
+US13,Vermont,RQ,Puerto Rico,Peak,$20.73,$37.11
+US13,Vermont,SA,Saudi Arabia,NonPeak,$18.33,$44.28
+US13,Vermont,SA,Saudi Arabia,Peak,$21.63,$52.25
+US13,Vermont,SN,Singapore,NonPeak,$24.38,$34.11
+US13,Vermont,SN,Singapore,Peak,$28.77,$40.25
+US13,Vermont,SP,Spain,NonPeak,$16.00,$31.63
+US13,Vermont,SP,Spain,Peak,$18.88,$37.32
+US13,Vermont,TU,Turkey,NonPeak,$27.63,$44.51
+US13,Vermont,TU,Turkey,Peak,$32.60,$52.52
+US13,Vermont,UK,United Kingdom,NonPeak,$29.28,$34.33
+US13,Vermont,UK,United Kingdom,Peak,$34.55,$40.51
+US13,Vermont,US8030400,Alaska (Zone) IV,NonPeak,$30.90,$31.74
+US13,Vermont,US8030400,Alaska (Zone) IV,Peak,$36.46,$37.45
+US13,Vermont,US8050500,Alaska (Zone) III,NonPeak,$15.28,$44.62
+US13,Vermont,US8050500,Alaska (Zone) III,Peak,$18.03,$52.65
+US13,Vermont,US8101000,Alaska (Zone) I,NonPeak,$16.05,$34.45
+US13,Vermont,US8101000,Alaska (Zone) I,Peak,$18.94,$40.65
+US13,Vermont,US8190100,Alaska (Zone) II,NonPeak,$16.80,$31.91
+US13,Vermont,US8190100,Alaska (Zone) II,Peak,$19.82,$37.65
+US13,Vermont,US89,Hawaii,NonPeak,$17.57,$44.74
+US13,Vermont,US89,Hawaii,Peak,$20.73,$52.79
+US13,Vermont,UY,Uruguay,NonPeak,$18.33,$34.56
+US13,Vermont,UY,Uruguay,Peak,$21.63,$40.78
+US13,Vermont,VE,Venezuela,NonPeak,$24.38,$32.09
+US13,Vermont,VE,Venezuela,Peak,$28.77,$37.87
+US14,Massachusetts,AR,Argentina,NonPeak,$16.00,$44.91
+US14,Massachusetts,AR,Argentina,Peak,$18.88,$52.99
+US14,Massachusetts,AS11,New South Wales/Australian Capital Territory,NonPeak,$27.63,$34.74
+US14,Massachusetts,AS11,New South Wales/Australian Capital Territory,Peak,$32.60,$40.99
+US14,Massachusetts,AS21,Northern Territory,NonPeak,$29.28,$32.26
+US14,Massachusetts,AS21,Northern Territory,Peak,$34.55,$38.07
+US14,Massachusetts,BA,Bahrain,NonPeak,$30.90,$45.09
+US14,Massachusetts,BA,Bahrain,Peak,$36.46,$53.21
+US14,Massachusetts,BE,Belgium,NonPeak,$15.28,$34.90
+US14,Massachusetts,BE,Belgium,Peak,$18.03,$41.18
+US14,Massachusetts,BL,Bolivia,NonPeak,$16.05,$32.44
+US14,Massachusetts,BL,Bolivia,Peak,$18.94,$38.28
+US14,Massachusetts,BR,Brazil - Brazilia,NonPeak,$16.80,$43.94
+US14,Massachusetts,BR,Brazil - Brazilia,Peak,$19.82,$51.85
+US14,Massachusetts,CA10,Ontario,NonPeak,$17.57,$33.70
+US14,Massachusetts,CA10,Ontario,Peak,$20.73,$39.77
+US14,Massachusetts,CA20,Quebec,NonPeak,$18.33,$31.29
+US14,Massachusetts,CA20,Quebec,Peak,$21.63,$36.92
+US14,Massachusetts,CA30,Manitoba,NonPeak,$24.38,$44.05
+US14,Massachusetts,CA30,Manitoba,Peak,$28.77,$51.98
+US14,Massachusetts,CI,Chile,NonPeak,$16.00,$33.75
+US14,Massachusetts,CI,Chile,Peak,$18.88,$39.82
+US14,Massachusetts,CO,Colombia,NonPeak,$27.63,$31.40
+US14,Massachusetts,CO,Colombia,Peak,$32.60,$37.05
+US14,Massachusetts,CS,Costa Rica,NonPeak,$29.28,$44.17
+US14,Massachusetts,CS,Costa Rica,Peak,$34.55,$52.12
+US14,Massachusetts,EC,Ecuador,NonPeak,$30.90,$33.98
+US14,Massachusetts,EC,Ecuador,Peak,$36.46,$40.10
+US14,Massachusetts,ES,El Salvador,NonPeak,$15.28,$31.45
+US14,Massachusetts,ES,El Salvador,Peak,$18.03,$37.11
+US14,Massachusetts,GE,Germany,NonPeak,$16.05,$44.28
+US14,Massachusetts,GE,Germany,Peak,$18.94,$52.25
+US14,Massachusetts,GQ,Guam,NonPeak,$16.80,$34.11
+US14,Massachusetts,GQ,Guam,Peak,$19.82,$40.25
+US14,Massachusetts,GR,Greece,NonPeak,$17.57,$31.63
+US14,Massachusetts,GR,Greece,Peak,$20.73,$37.32
+US14,Massachusetts,GR29,Crete,NonPeak,$18.33,$44.51
+US14,Massachusetts,GR29,Crete,Peak,$21.63,$52.52
+US14,Massachusetts,GT,Guatemala,NonPeak,$24.38,$34.33
+US14,Massachusetts,GT,Guatemala,Peak,$28.77,$40.51
+US14,Massachusetts,HO,Honduras,NonPeak,$16.00,$31.74
+US14,Massachusetts,HO,Honduras,Peak,$18.88,$37.45
+US14,Massachusetts,HU,Hungary,NonPeak,$27.63,$44.62
+US14,Massachusetts,HU,Hungary,Peak,$32.60,$52.65
+US14,Massachusetts,IT,Italy,NonPeak,$29.28,$34.45
+US14,Massachusetts,IT,Italy,Peak,$34.55,$40.65
+US14,Massachusetts,IT10,Sicily,NonPeak,$30.90,$31.91
+US14,Massachusetts,IT10,Sicily,Peak,$36.46,$37.65
+US14,Massachusetts,JA01,Japan-Central,NonPeak,$15.28,$44.74
+US14,Massachusetts,JA01,Japan-Central,Peak,$18.03,$52.79
+US14,Massachusetts,JA02,Japan-South (Excludes Hokkaido),NonPeak,$16.05,$34.56
+US14,Massachusetts,JA02,Japan-South (Excludes Hokkaido),Peak,$18.94,$40.78
+US14,Massachusetts,JA03,Japan-North,NonPeak,$16.80,$32.09
+US14,Massachusetts,JA03,Japan-North,Peak,$19.82,$37.87
+US14,Massachusetts,JA96,Okinawa,NonPeak,$17.57,$44.91
+US14,Massachusetts,JA96,Okinawa,Peak,$20.73,$52.99
+US14,Massachusetts,KS,"Korea, Republic Of",NonPeak,$18.33,$34.74
+US14,Massachusetts,KS,"Korea, Republic Of",Peak,$21.63,$40.99
+US14,Massachusetts,KU,Kuwait,NonPeak,$24.38,$32.26
+US14,Massachusetts,KU,Kuwait,Peak,$28.77,$38.07
+US14,Massachusetts,NL,Netherlands,NonPeak,$16.00,$45.09
+US14,Massachusetts,NL,Netherlands,Peak,$18.88,$53.21
+US14,Massachusetts,NO,Norway,NonPeak,$27.63,$34.90
+US14,Massachusetts,NO,Norway,Peak,$32.60,$41.18
+US14,Massachusetts,PA,Paraguay,NonPeak,$29.28,$32.44
+US14,Massachusetts,PA,Paraguay,Peak,$34.55,$38.28
+US14,Massachusetts,PE,Peru,NonPeak,$30.90,$43.94
+US14,Massachusetts,PE,Peru,Peak,$36.46,$51.85
+US14,Massachusetts,PL,Poland,NonPeak,$15.28,$33.70
+US14,Massachusetts,PL,Poland,Peak,$18.03,$39.77
+US14,Massachusetts,PO,Portugal,NonPeak,$16.05,$31.29
+US14,Massachusetts,PO,Portugal,Peak,$18.94,$36.92
+US14,Massachusetts,PO01,Azores,NonPeak,$16.80,$44.05
+US14,Massachusetts,PO01,Azores,Peak,$19.82,$51.98
+US14,Massachusetts,QA,Qatar,NonPeak,$17.57,$33.75
+US14,Massachusetts,QA,Qatar,Peak,$20.73,$39.82
+US14,Massachusetts,RO,Romania,NonPeak,$18.33,$31.40
+US14,Massachusetts,RO,Romania,Peak,$21.63,$37.05
+US14,Massachusetts,RQ,Puerto Rico,NonPeak,$24.38,$44.17
+US14,Massachusetts,RQ,Puerto Rico,Peak,$28.77,$52.12
+US14,Massachusetts,SA,Saudi Arabia,NonPeak,$16.00,$33.98
+US14,Massachusetts,SA,Saudi Arabia,Peak,$18.88,$40.10
+US14,Massachusetts,SN,Singapore,NonPeak,$27.63,$31.45
+US14,Massachusetts,SN,Singapore,Peak,$32.60,$37.11
+US14,Massachusetts,SP,Spain,NonPeak,$29.28,$44.28
+US14,Massachusetts,SP,Spain,Peak,$34.55,$52.25
+US14,Massachusetts,TU,Turkey,NonPeak,$30.90,$34.11
+US14,Massachusetts,TU,Turkey,Peak,$36.46,$40.25
+US14,Massachusetts,UK,United Kingdom,NonPeak,$15.28,$31.63
+US14,Massachusetts,UK,United Kingdom,Peak,$18.03,$37.32
+US14,Massachusetts,US8030400,Alaska (Zone) IV,NonPeak,$16.05,$44.51
+US14,Massachusetts,US8030400,Alaska (Zone) IV,Peak,$18.94,$52.52
+US14,Massachusetts,US8050500,Alaska (Zone) III,NonPeak,$16.80,$34.33
+US14,Massachusetts,US8050500,Alaska (Zone) III,Peak,$19.82,$40.51
+US14,Massachusetts,US8101000,Alaska (Zone) I,NonPeak,$17.57,$31.74
+US14,Massachusetts,US8101000,Alaska (Zone) I,Peak,$20.73,$37.45
+US14,Massachusetts,US8190100,Alaska (Zone) II,NonPeak,$18.33,$44.62
+US14,Massachusetts,US8190100,Alaska (Zone) II,Peak,$21.63,$52.65
+US14,Massachusetts,US89,Hawaii,NonPeak,$24.38,$34.45
+US14,Massachusetts,US89,Hawaii,Peak,$28.77,$40.65
+US14,Massachusetts,UY,Uruguay,NonPeak,$16.00,$31.91
+US14,Massachusetts,UY,Uruguay,Peak,$18.88,$37.65
+US14,Massachusetts,VE,Venezuela,NonPeak,$27.63,$44.74
+US14,Massachusetts,VE,Venezuela,Peak,$32.60,$52.79
+US15,Rhode Island,AR,Argentina,NonPeak,$29.28,$34.56
+US15,Rhode Island,AR,Argentina,Peak,$34.55,$40.78
+US15,Rhode Island,AS11,New South Wales/Australian Capital Territory,NonPeak,$30.90,$32.09
+US15,Rhode Island,AS11,New South Wales/Australian Capital Territory,Peak,$36.46,$37.87
+US15,Rhode Island,AS21,Northern Territory,NonPeak,$15.28,$44.91
+US15,Rhode Island,AS21,Northern Territory,Peak,$18.03,$52.99
+US15,Rhode Island,BA,Bahrain,NonPeak,$16.05,$34.74
+US15,Rhode Island,BA,Bahrain,Peak,$18.94,$40.99
+US15,Rhode Island,BE,Belgium,NonPeak,$16.80,$32.26
+US15,Rhode Island,BE,Belgium,Peak,$19.82,$38.07
+US15,Rhode Island,BL,Bolivia,NonPeak,$17.57,$45.09
+US15,Rhode Island,BL,Bolivia,Peak,$20.73,$53.21
+US15,Rhode Island,BR,Brazil - Brazilia,NonPeak,$18.33,$34.90
+US15,Rhode Island,BR,Brazil - Brazilia,Peak,$21.63,$41.18
+US15,Rhode Island,CA10,Ontario,NonPeak,$24.38,$32.44
+US15,Rhode Island,CA10,Ontario,Peak,$28.77,$38.28
+US15,Rhode Island,CA20,Quebec,NonPeak,$16.00,$43.94
+US15,Rhode Island,CA20,Quebec,Peak,$18.88,$51.85
+US15,Rhode Island,CA30,Manitoba,NonPeak,$27.63,$33.70
+US15,Rhode Island,CA30,Manitoba,Peak,$32.60,$39.77
+US15,Rhode Island,CI,Chile,NonPeak,$29.28,$31.29
+US15,Rhode Island,CI,Chile,Peak,$34.55,$36.92
+US15,Rhode Island,CO,Colombia,NonPeak,$30.90,$44.05
+US15,Rhode Island,CO,Colombia,Peak,$36.46,$51.98
+US15,Rhode Island,CS,Costa Rica,NonPeak,$15.28,$33.75
+US15,Rhode Island,CS,Costa Rica,Peak,$18.03,$39.82
+US15,Rhode Island,EC,Ecuador,NonPeak,$16.05,$31.40
+US15,Rhode Island,EC,Ecuador,Peak,$18.94,$37.05
+US15,Rhode Island,ES,El Salvador,NonPeak,$16.80,$44.17
+US15,Rhode Island,ES,El Salvador,Peak,$19.82,$52.12
+US15,Rhode Island,GE,Germany,NonPeak,$17.57,$33.98
+US15,Rhode Island,GE,Germany,Peak,$20.73,$40.10
+US15,Rhode Island,GQ,Guam,NonPeak,$18.33,$31.45
+US15,Rhode Island,GQ,Guam,Peak,$21.63,$37.11
+US15,Rhode Island,GR,Greece,NonPeak,$24.38,$44.28
+US15,Rhode Island,GR,Greece,Peak,$28.77,$52.25
+US15,Rhode Island,GR29,Crete,NonPeak,$16.00,$34.11
+US15,Rhode Island,GR29,Crete,Peak,$18.88,$40.25
+US15,Rhode Island,GT,Guatemala,NonPeak,$27.63,$31.63
+US15,Rhode Island,GT,Guatemala,Peak,$32.60,$37.32
+US15,Rhode Island,HO,Honduras,NonPeak,$29.28,$44.51
+US15,Rhode Island,HO,Honduras,Peak,$34.55,$52.52
+US15,Rhode Island,HU,Hungary,NonPeak,$30.90,$34.33
+US15,Rhode Island,HU,Hungary,Peak,$36.46,$40.51
+US15,Rhode Island,IT,Italy,NonPeak,$15.28,$31.74
+US15,Rhode Island,IT,Italy,Peak,$18.03,$37.45
+US15,Rhode Island,IT10,Sicily,NonPeak,$16.05,$44.62
+US15,Rhode Island,IT10,Sicily,Peak,$18.94,$52.65
+US15,Rhode Island,JA01,Japan-Central,NonPeak,$16.80,$34.45
+US15,Rhode Island,JA01,Japan-Central,Peak,$19.82,$40.65
+US15,Rhode Island,JA02,Japan-South (Excludes Hokkaido),NonPeak,$17.57,$31.91
+US15,Rhode Island,JA02,Japan-South (Excludes Hokkaido),Peak,$20.73,$37.65
+US15,Rhode Island,JA03,Japan-North,NonPeak,$18.33,$44.74
+US15,Rhode Island,JA03,Japan-North,Peak,$21.63,$52.79
+US15,Rhode Island,JA96,Okinawa,NonPeak,$24.38,$34.56
+US15,Rhode Island,JA96,Okinawa,Peak,$28.77,$40.78
+US15,Rhode Island,KS,"Korea, Republic Of",NonPeak,$16.00,$32.09
+US15,Rhode Island,KS,"Korea, Republic Of",Peak,$18.88,$37.87
+US15,Rhode Island,KU,Kuwait,NonPeak,$27.63,$44.91
+US15,Rhode Island,KU,Kuwait,Peak,$32.60,$52.99
+US15,Rhode Island,NL,Netherlands,NonPeak,$29.28,$34.74
+US15,Rhode Island,NL,Netherlands,Peak,$34.55,$40.99
+US15,Rhode Island,NO,Norway,NonPeak,$30.90,$32.26
+US15,Rhode Island,NO,Norway,Peak,$36.46,$38.07
+US15,Rhode Island,PA,Paraguay,NonPeak,$15.28,$45.09
+US15,Rhode Island,PA,Paraguay,Peak,$18.03,$53.21
+US15,Rhode Island,PE,Peru,NonPeak,$16.05,$34.90
+US15,Rhode Island,PE,Peru,Peak,$18.94,$41.18
+US15,Rhode Island,PL,Poland,NonPeak,$16.80,$32.44
+US15,Rhode Island,PL,Poland,Peak,$19.82,$38.28
+US15,Rhode Island,PO,Portugal,NonPeak,$17.57,$43.94
+US15,Rhode Island,PO,Portugal,Peak,$20.73,$51.85
+US15,Rhode Island,PO01,Azores,NonPeak,$18.33,$33.70
+US15,Rhode Island,PO01,Azores,Peak,$21.63,$39.77
+US15,Rhode Island,QA,Qatar,NonPeak,$24.38,$31.29
+US15,Rhode Island,QA,Qatar,Peak,$28.77,$36.92
+US15,Rhode Island,RO,Romania,NonPeak,$16.00,$44.05
+US15,Rhode Island,RO,Romania,Peak,$18.88,$51.98
+US15,Rhode Island,RQ,Puerto Rico,NonPeak,$27.63,$33.75
+US15,Rhode Island,RQ,Puerto Rico,Peak,$32.60,$39.82
+US15,Rhode Island,SA,Saudi Arabia,NonPeak,$29.28,$31.40
+US15,Rhode Island,SA,Saudi Arabia,Peak,$34.55,$37.05
+US15,Rhode Island,SN,Singapore,NonPeak,$30.90,$44.17
+US15,Rhode Island,SN,Singapore,Peak,$36.46,$52.12
+US15,Rhode Island,SP,Spain,NonPeak,$15.28,$33.98
+US15,Rhode Island,SP,Spain,Peak,$18.03,$40.10
+US15,Rhode Island,TU,Turkey,NonPeak,$16.05,$31.45
+US15,Rhode Island,TU,Turkey,Peak,$18.94,$37.11
+US15,Rhode Island,UK,United Kingdom,NonPeak,$16.80,$44.28
+US15,Rhode Island,UK,United Kingdom,Peak,$19.82,$52.25
+US15,Rhode Island,US8030400,Alaska (Zone) IV,NonPeak,$17.57,$34.11
+US15,Rhode Island,US8030400,Alaska (Zone) IV,Peak,$20.73,$40.25
+US15,Rhode Island,US8050500,Alaska (Zone) III,NonPeak,$18.33,$31.63
+US15,Rhode Island,US8050500,Alaska (Zone) III,Peak,$21.63,$37.32
+US15,Rhode Island,US8101000,Alaska (Zone) I,NonPeak,$24.38,$44.51
+US15,Rhode Island,US8101000,Alaska (Zone) I,Peak,$28.77,$52.52
+US15,Rhode Island,US8190100,Alaska (Zone) II,NonPeak,$16.00,$34.33
+US15,Rhode Island,US8190100,Alaska (Zone) II,Peak,$18.88,$40.51
+US15,Rhode Island,US89,Hawaii,NonPeak,$27.63,$31.74
+US15,Rhode Island,US89,Hawaii,Peak,$32.60,$37.45
+US15,Rhode Island,UY,Uruguay,NonPeak,$29.28,$44.62
+US15,Rhode Island,UY,Uruguay,Peak,$34.55,$52.65
+US15,Rhode Island,VE,Venezuela,NonPeak,$30.90,$34.45
+US15,Rhode Island,VE,Venezuela,Peak,$36.46,$40.65
+US16,Connecticut,AR,Argentina,NonPeak,$15.28,$31.91
+US16,Connecticut,AR,Argentina,Peak,$18.03,$37.65
+US16,Connecticut,AS11,New South Wales/Australian Capital Territory,NonPeak,$16.05,$44.74
+US16,Connecticut,AS11,New South Wales/Australian Capital Territory,Peak,$18.94,$52.79
+US16,Connecticut,AS21,Northern Territory,NonPeak,$16.80,$34.56
+US16,Connecticut,AS21,Northern Territory,Peak,$19.82,$40.78
+US16,Connecticut,BA,Bahrain,NonPeak,$17.57,$32.09
+US16,Connecticut,BA,Bahrain,Peak,$20.73,$37.87
+US16,Connecticut,BE,Belgium,NonPeak,$18.33,$44.91
+US16,Connecticut,BE,Belgium,Peak,$21.63,$52.99
+US16,Connecticut,BL,Bolivia,NonPeak,$24.38,$34.74
+US16,Connecticut,BL,Bolivia,Peak,$28.77,$40.99
+US16,Connecticut,BR,Brazil - Brazilia,NonPeak,$16.00,$32.26
+US16,Connecticut,BR,Brazil - Brazilia,Peak,$18.88,$38.07
+US16,Connecticut,CA10,Ontario,NonPeak,$27.63,$45.09
+US16,Connecticut,CA10,Ontario,Peak,$32.60,$53.21
+US16,Connecticut,CA20,Quebec,NonPeak,$29.28,$34.90
+US16,Connecticut,CA20,Quebec,Peak,$34.55,$41.18
+US16,Connecticut,CA30,Manitoba,NonPeak,$30.90,$32.44
+US16,Connecticut,CA30,Manitoba,Peak,$36.46,$38.28
+US16,Connecticut,CI,Chile,NonPeak,$15.28,$43.94
+US16,Connecticut,CI,Chile,Peak,$18.03,$51.85
+US16,Connecticut,CO,Colombia,NonPeak,$16.05,$33.70
+US16,Connecticut,CO,Colombia,Peak,$18.94,$39.77
+US16,Connecticut,CS,Costa Rica,NonPeak,$16.80,$31.29
+US16,Connecticut,CS,Costa Rica,Peak,$19.82,$36.92
+US16,Connecticut,EC,Ecuador,NonPeak,$17.57,$44.05
+US16,Connecticut,EC,Ecuador,Peak,$20.73,$51.98
+US16,Connecticut,ES,El Salvador,NonPeak,$18.33,$33.75
+US16,Connecticut,ES,El Salvador,Peak,$21.63,$39.82
+US16,Connecticut,GE,Germany,NonPeak,$24.38,$31.40
+US16,Connecticut,GE,Germany,Peak,$28.77,$37.05
+US16,Connecticut,GQ,Guam,NonPeak,$16.00,$44.17
+US16,Connecticut,GQ,Guam,Peak,$18.88,$52.12
+US16,Connecticut,GR,Greece,NonPeak,$27.63,$33.98
+US16,Connecticut,GR,Greece,Peak,$32.60,$40.10
+US16,Connecticut,GR29,Crete,NonPeak,$29.28,$31.45
+US16,Connecticut,GR29,Crete,Peak,$34.55,$37.11
+US16,Connecticut,GT,Guatemala,NonPeak,$30.90,$44.28
+US16,Connecticut,GT,Guatemala,Peak,$36.46,$52.25
+US16,Connecticut,HO,Honduras,NonPeak,$15.28,$34.11
+US16,Connecticut,HO,Honduras,Peak,$18.03,$40.25
+US16,Connecticut,HU,Hungary,NonPeak,$16.05,$31.63
+US16,Connecticut,HU,Hungary,Peak,$18.94,$37.32
+US16,Connecticut,IT,Italy,NonPeak,$16.80,$44.51
+US16,Connecticut,IT,Italy,Peak,$19.82,$52.52
+US16,Connecticut,IT10,Sicily,NonPeak,$17.57,$34.33
+US16,Connecticut,IT10,Sicily,Peak,$20.73,$40.51
+US16,Connecticut,JA01,Japan-Central,NonPeak,$18.33,$31.74
+US16,Connecticut,JA01,Japan-Central,Peak,$21.63,$37.45
+US16,Connecticut,JA02,Japan-South (Excludes Hokkaido),NonPeak,$24.38,$44.62
+US16,Connecticut,JA02,Japan-South (Excludes Hokkaido),Peak,$28.77,$52.65
+US16,Connecticut,JA03,Japan-North,NonPeak,$16.00,$34.45
+US16,Connecticut,JA03,Japan-North,Peak,$18.88,$40.65
+US16,Connecticut,JA96,Okinawa,NonPeak,$27.63,$31.91
+US16,Connecticut,JA96,Okinawa,Peak,$32.60,$37.65
+US16,Connecticut,KS,"Korea, Republic Of",NonPeak,$29.28,$44.74
+US16,Connecticut,KS,"Korea, Republic Of",Peak,$34.55,$52.79
+US16,Connecticut,KU,Kuwait,NonPeak,$30.90,$34.56
+US16,Connecticut,KU,Kuwait,Peak,$36.46,$40.78
+US16,Connecticut,NL,Netherlands,NonPeak,$15.28,$32.09
+US16,Connecticut,NL,Netherlands,Peak,$18.03,$37.87
+US16,Connecticut,NO,Norway,NonPeak,$16.05,$44.91
+US16,Connecticut,NO,Norway,Peak,$18.94,$52.99
+US16,Connecticut,PA,Paraguay,NonPeak,$16.80,$34.74
+US16,Connecticut,PA,Paraguay,Peak,$19.82,$40.99
+US16,Connecticut,PE,Peru,NonPeak,$17.57,$32.26
+US16,Connecticut,PE,Peru,Peak,$20.73,$38.07
+US16,Connecticut,PL,Poland,NonPeak,$18.33,$45.09
+US16,Connecticut,PL,Poland,Peak,$21.63,$53.21
+US16,Connecticut,PO,Portugal,NonPeak,$24.38,$34.90
+US16,Connecticut,PO,Portugal,Peak,$28.77,$41.18
+US16,Connecticut,PO01,Azores,NonPeak,$16.00,$32.44
+US16,Connecticut,PO01,Azores,Peak,$18.88,$38.28
+US16,Connecticut,QA,Qatar,NonPeak,$27.63,$43.94
+US16,Connecticut,QA,Qatar,Peak,$32.60,$51.85
+US16,Connecticut,RO,Romania,NonPeak,$29.28,$33.70
+US16,Connecticut,RO,Romania,Peak,$34.55,$39.77
+US16,Connecticut,RQ,Puerto Rico,NonPeak,$30.90,$31.29
+US16,Connecticut,RQ,Puerto Rico,Peak,$36.46,$36.92
+US16,Connecticut,SA,Saudi Arabia,NonPeak,$15.28,$44.05
+US16,Connecticut,SA,Saudi Arabia,Peak,$18.03,$51.98
+US16,Connecticut,SN,Singapore,NonPeak,$16.05,$33.75
+US16,Connecticut,SN,Singapore,Peak,$18.94,$39.82
+US16,Connecticut,SP,Spain,NonPeak,$16.80,$31.40
+US16,Connecticut,SP,Spain,Peak,$19.82,$37.05
+US16,Connecticut,TU,Turkey,NonPeak,$17.57,$44.17
+US16,Connecticut,TU,Turkey,Peak,$20.73,$52.12
+US16,Connecticut,UK,United Kingdom,NonPeak,$18.33,$33.98
+US16,Connecticut,UK,United Kingdom,Peak,$21.63,$40.10
+US16,Connecticut,US8030400,Alaska (Zone) IV,NonPeak,$24.38,$31.45
+US16,Connecticut,US8030400,Alaska (Zone) IV,Peak,$28.77,$37.11
+US16,Connecticut,US8050500,Alaska (Zone) III,NonPeak,$16.00,$44.28
+US16,Connecticut,US8050500,Alaska (Zone) III,Peak,$18.88,$52.25
+US16,Connecticut,US8101000,Alaska (Zone) I,NonPeak,$27.63,$34.11
+US16,Connecticut,US8101000,Alaska (Zone) I,Peak,$32.60,$40.25
+US16,Connecticut,US8190100,Alaska (Zone) II,NonPeak,$29.28,$31.63
+US16,Connecticut,US8190100,Alaska (Zone) II,Peak,$34.55,$37.32
+US16,Connecticut,US89,Hawaii,NonPeak,$30.90,$44.51
+US16,Connecticut,US89,Hawaii,Peak,$36.46,$52.52
+US16,Connecticut,UY,Uruguay,NonPeak,$15.28,$34.33
+US16,Connecticut,UY,Uruguay,Peak,$18.03,$40.51
+US16,Connecticut,VE,Venezuela,NonPeak,$16.05,$31.74
+US16,Connecticut,VE,Venezuela,Peak,$18.94,$37.45
+US17,New York,AR,Argentina,NonPeak,$16.80,$44.62
+US17,New York,AR,Argentina,Peak,$19.82,$52.65
+US17,New York,AS11,New South Wales/Australian Capital Territory,NonPeak,$17.57,$34.45
+US17,New York,AS11,New South Wales/Australian Capital Territory,Peak,$20.73,$40.65
+US17,New York,AS21,Northern Territory,NonPeak,$18.33,$31.91
+US17,New York,AS21,Northern Territory,Peak,$21.63,$37.65
+US17,New York,BA,Bahrain,NonPeak,$24.38,$44.74
+US17,New York,BA,Bahrain,Peak,$28.77,$52.79
+US17,New York,BE,Belgium,NonPeak,$16.00,$34.56
+US17,New York,BE,Belgium,Peak,$18.88,$40.78
+US17,New York,BL,Bolivia,NonPeak,$27.63,$32.09
+US17,New York,BL,Bolivia,Peak,$32.60,$37.87
+US17,New York,BR,Brazil - Brazilia,NonPeak,$29.28,$44.91
+US17,New York,BR,Brazil - Brazilia,Peak,$34.55,$52.99
+US17,New York,CA10,Ontario,NonPeak,$30.90,$34.74
+US17,New York,CA10,Ontario,Peak,$36.46,$40.99
+US17,New York,CA20,Quebec,NonPeak,$15.28,$32.26
+US17,New York,CA20,Quebec,Peak,$18.03,$38.07
+US17,New York,CA30,Manitoba,NonPeak,$16.05,$45.09
+US17,New York,CA30,Manitoba,Peak,$18.94,$53.21
+US17,New York,CI,Chile,NonPeak,$16.80,$34.90
+US17,New York,CI,Chile,Peak,$19.82,$41.18
+US17,New York,CO,Colombia,NonPeak,$17.57,$32.44
+US17,New York,CO,Colombia,Peak,$20.73,$38.28
+US17,New York,CS,Costa Rica,NonPeak,$18.33,$43.94
+US17,New York,CS,Costa Rica,Peak,$21.63,$51.85
+US17,New York,EC,Ecuador,NonPeak,$24.38,$33.70
+US17,New York,EC,Ecuador,Peak,$28.77,$39.77
+US17,New York,ES,El Salvador,NonPeak,$16.00,$31.29
+US17,New York,ES,El Salvador,Peak,$18.88,$36.92
+US17,New York,GE,Germany,NonPeak,$27.63,$44.05
+US17,New York,GE,Germany,Peak,$32.60,$51.98
+US17,New York,GQ,Guam,NonPeak,$29.28,$33.75
+US17,New York,GQ,Guam,Peak,$34.55,$39.82
+US17,New York,GR,Greece,NonPeak,$30.90,$31.40
+US17,New York,GR,Greece,Peak,$36.46,$37.05
+US17,New York,GR29,Crete,NonPeak,$15.28,$44.17
+US17,New York,GR29,Crete,Peak,$18.03,$52.12
+US17,New York,GT,Guatemala,NonPeak,$16.05,$33.98
+US17,New York,GT,Guatemala,Peak,$18.94,$40.10
+US17,New York,HO,Honduras,NonPeak,$16.80,$31.45
+US17,New York,HO,Honduras,Peak,$19.82,$37.11
+US17,New York,HU,Hungary,NonPeak,$17.57,$44.28
+US17,New York,HU,Hungary,Peak,$20.73,$52.25
+US17,New York,IT,Italy,NonPeak,$18.33,$34.11
+US17,New York,IT,Italy,Peak,$21.63,$40.25
+US17,New York,IT10,Sicily,NonPeak,$24.38,$31.63
+US17,New York,IT10,Sicily,Peak,$28.77,$37.32
+US17,New York,JA01,Japan-Central,NonPeak,$16.00,$44.51
+US17,New York,JA01,Japan-Central,Peak,$18.88,$52.52
+US17,New York,JA02,Japan-South (Excludes Hokkaido),NonPeak,$27.63,$34.33
+US17,New York,JA02,Japan-South (Excludes Hokkaido),Peak,$32.60,$40.51
+US17,New York,JA03,Japan-North,NonPeak,$29.28,$31.74
+US17,New York,JA03,Japan-North,Peak,$34.55,$37.45
+US17,New York,JA96,Okinawa,NonPeak,$30.90,$44.62
+US17,New York,JA96,Okinawa,Peak,$36.46,$52.65
+US17,New York,KS,"Korea, Republic Of",NonPeak,$15.28,$34.45
+US17,New York,KS,"Korea, Republic Of",Peak,$18.03,$40.65
+US17,New York,KU,Kuwait,NonPeak,$16.05,$31.91
+US17,New York,KU,Kuwait,Peak,$18.94,$37.65
+US17,New York,NL,Netherlands,NonPeak,$16.80,$44.74
+US17,New York,NL,Netherlands,Peak,$19.82,$52.79
+US17,New York,NO,Norway,NonPeak,$17.57,$34.56
+US17,New York,NO,Norway,Peak,$20.73,$40.78
+US17,New York,PA,Paraguay,NonPeak,$18.33,$32.09
+US17,New York,PA,Paraguay,Peak,$21.63,$37.87
+US17,New York,PE,Peru,NonPeak,$24.38,$44.91
+US17,New York,PE,Peru,Peak,$28.77,$52.99
+US17,New York,PL,Poland,NonPeak,$16.00,$34.74
+US17,New York,PL,Poland,Peak,$18.88,$40.99
+US17,New York,PO,Portugal,NonPeak,$27.63,$32.26
+US17,New York,PO,Portugal,Peak,$32.60,$38.07
+US17,New York,PO01,Azores,NonPeak,$29.28,$45.09
+US17,New York,PO01,Azores,Peak,$34.55,$53.21
+US17,New York,QA,Qatar,NonPeak,$30.90,$34.90
+US17,New York,QA,Qatar,Peak,$36.46,$41.18
+US17,New York,RO,Romania,NonPeak,$15.28,$32.44
+US17,New York,RO,Romania,Peak,$18.03,$38.28
+US17,New York,RQ,Puerto Rico,NonPeak,$16.05,$43.94
+US17,New York,RQ,Puerto Rico,Peak,$18.94,$51.85
+US17,New York,SA,Saudi Arabia,NonPeak,$16.80,$33.70
+US17,New York,SA,Saudi Arabia,Peak,$19.82,$39.77
+US17,New York,SN,Singapore,NonPeak,$17.57,$31.29
+US17,New York,SN,Singapore,Peak,$20.73,$36.92
+US17,New York,SP,Spain,NonPeak,$18.33,$44.05
+US17,New York,SP,Spain,Peak,$21.63,$51.98
+US17,New York,TU,Turkey,NonPeak,$24.38,$33.75
+US17,New York,TU,Turkey,Peak,$28.77,$39.82
+US17,New York,UK,United Kingdom,NonPeak,$16.00,$31.40
+US17,New York,UK,United Kingdom,Peak,$18.88,$37.05
+US17,New York,US8030400,Alaska (Zone) IV,NonPeak,$27.63,$44.17
+US17,New York,US8030400,Alaska (Zone) IV,Peak,$32.60,$52.12
+US17,New York,US8050500,Alaska (Zone) III,NonPeak,$29.28,$33.98
+US17,New York,US8050500,Alaska (Zone) III,Peak,$34.55,$40.10
+US17,New York,US8101000,Alaska (Zone) I,NonPeak,$30.90,$31.45
+US17,New York,US8101000,Alaska (Zone) I,Peak,$36.46,$37.11
+US17,New York,US8190100,Alaska (Zone) II,NonPeak,$15.28,$44.28
+US17,New York,US8190100,Alaska (Zone) II,Peak,$18.03,$52.25
+US17,New York,US89,Hawaii,NonPeak,$16.05,$34.11
+US17,New York,US89,Hawaii,Peak,$18.94,$40.25
+US17,New York,UY,Uruguay,NonPeak,$16.80,$31.63
+US17,New York,UY,Uruguay,Peak,$19.82,$37.32
+US17,New York,VE,Venezuela,NonPeak,$17.57,$44.51
+US17,New York,VE,Venezuela,Peak,$20.73,$52.52
+US19,New Jersey,AR,Argentina,NonPeak,$18.33,$34.33
+US19,New Jersey,AR,Argentina,Peak,$21.63,$40.51
+US19,New Jersey,AS11,New South Wales/Australian Capital Territory,NonPeak,$24.38,$31.74
+US19,New Jersey,AS11,New South Wales/Australian Capital Territory,Peak,$28.77,$37.45
+US19,New Jersey,AS21,Northern Territory,NonPeak,$16.00,$44.62
+US19,New Jersey,AS21,Northern Territory,Peak,$18.88,$52.65
+US19,New Jersey,BA,Bahrain,NonPeak,$27.63,$34.45
+US19,New Jersey,BA,Bahrain,Peak,$32.60,$40.65
+US19,New Jersey,BE,Belgium,NonPeak,$29.28,$31.91
+US19,New Jersey,BE,Belgium,Peak,$34.55,$37.65
+US19,New Jersey,BL,Bolivia,NonPeak,$30.90,$44.74
+US19,New Jersey,BL,Bolivia,Peak,$36.46,$52.79
+US19,New Jersey,BR,Brazil - Brazilia,NonPeak,$15.28,$34.56
+US19,New Jersey,BR,Brazil - Brazilia,Peak,$18.03,$40.78
+US19,New Jersey,CA10,Ontario,NonPeak,$16.05,$32.09
+US19,New Jersey,CA10,Ontario,Peak,$18.94,$37.87
+US19,New Jersey,CA20,Quebec,NonPeak,$16.80,$44.91
+US19,New Jersey,CA20,Quebec,Peak,$19.82,$52.99
+US19,New Jersey,CA30,Manitoba,NonPeak,$17.57,$34.74
+US19,New Jersey,CA30,Manitoba,Peak,$20.73,$40.99
+US19,New Jersey,CI,Chile,NonPeak,$18.33,$32.26
+US19,New Jersey,CI,Chile,Peak,$21.63,$38.07
+US19,New Jersey,CO,Colombia,NonPeak,$24.38,$45.09
+US19,New Jersey,CO,Colombia,Peak,$28.77,$53.21
+US19,New Jersey,CS,Costa Rica,NonPeak,$16.00,$34.90
+US19,New Jersey,CS,Costa Rica,Peak,$18.88,$41.18
+US19,New Jersey,EC,Ecuador,NonPeak,$27.63,$32.44
+US19,New Jersey,EC,Ecuador,Peak,$32.60,$38.28
+US19,New Jersey,ES,El Salvador,NonPeak,$29.28,$43.94
+US19,New Jersey,ES,El Salvador,Peak,$34.55,$51.85
+US19,New Jersey,GE,Germany,NonPeak,$30.90,$33.70
+US19,New Jersey,GE,Germany,Peak,$36.46,$39.77
+US19,New Jersey,GQ,Guam,NonPeak,$15.28,$31.29
+US19,New Jersey,GQ,Guam,Peak,$18.03,$36.92
+US19,New Jersey,GR,Greece,NonPeak,$16.05,$44.05
+US19,New Jersey,GR,Greece,Peak,$18.94,$51.98
+US19,New Jersey,GR29,Crete,NonPeak,$16.80,$33.75
+US19,New Jersey,GR29,Crete,Peak,$19.82,$39.82
+US19,New Jersey,GT,Guatemala,NonPeak,$17.57,$31.40
+US19,New Jersey,GT,Guatemala,Peak,$20.73,$37.05
+US19,New Jersey,HO,Honduras,NonPeak,$18.33,$44.17
+US19,New Jersey,HO,Honduras,Peak,$21.63,$52.12
+US19,New Jersey,HU,Hungary,NonPeak,$24.38,$33.98
+US19,New Jersey,HU,Hungary,Peak,$28.77,$40.10
+US19,New Jersey,IT,Italy,NonPeak,$16.00,$31.45
+US19,New Jersey,IT,Italy,Peak,$18.88,$37.11
+US19,New Jersey,IT10,Sicily,NonPeak,$27.63,$44.28
+US19,New Jersey,IT10,Sicily,Peak,$32.60,$52.25
+US19,New Jersey,JA01,Japan-Central,NonPeak,$29.28,$34.11
+US19,New Jersey,JA01,Japan-Central,Peak,$34.55,$40.25
+US19,New Jersey,JA02,Japan-South (Excludes Hokkaido),NonPeak,$30.90,$31.63
+US19,New Jersey,JA02,Japan-South (Excludes Hokkaido),Peak,$36.46,$37.32
+US19,New Jersey,JA03,Japan-North,NonPeak,$15.28,$44.51
+US19,New Jersey,JA03,Japan-North,Peak,$18.03,$52.52
+US19,New Jersey,JA96,Okinawa,NonPeak,$16.05,$34.33
+US19,New Jersey,JA96,Okinawa,Peak,$18.94,$40.51
+US19,New Jersey,KS,"Korea, Republic Of",NonPeak,$16.80,$31.74
+US19,New Jersey,KS,"Korea, Republic Of",Peak,$19.82,$37.45
+US19,New Jersey,KU,Kuwait,NonPeak,$17.57,$44.62
+US19,New Jersey,KU,Kuwait,Peak,$20.73,$52.65
+US19,New Jersey,NL,Netherlands,NonPeak,$18.33,$34.45
+US19,New Jersey,NL,Netherlands,Peak,$21.63,$40.65
+US19,New Jersey,NO,Norway,NonPeak,$24.38,$31.91
+US19,New Jersey,NO,Norway,Peak,$28.77,$37.65
+US19,New Jersey,PA,Paraguay,NonPeak,$16.00,$44.74
+US19,New Jersey,PA,Paraguay,Peak,$18.88,$52.79
+US19,New Jersey,PE,Peru,NonPeak,$27.63,$34.56
+US19,New Jersey,PE,Peru,Peak,$32.60,$40.78
+US19,New Jersey,PL,Poland,NonPeak,$29.28,$32.09
+US19,New Jersey,PL,Poland,Peak,$34.55,$37.87
+US19,New Jersey,PO,Portugal,NonPeak,$30.90,$44.91
+US19,New Jersey,PO,Portugal,Peak,$36.46,$52.99
+US19,New Jersey,PO01,Azores,NonPeak,$15.28,$34.74
+US19,New Jersey,PO01,Azores,Peak,$18.03,$40.99
+US19,New Jersey,QA,Qatar,NonPeak,$16.05,$32.26
+US19,New Jersey,QA,Qatar,Peak,$18.94,$38.07
+US19,New Jersey,RO,Romania,NonPeak,$16.80,$45.09
+US19,New Jersey,RO,Romania,Peak,$19.82,$53.21
+US19,New Jersey,RQ,Puerto Rico,NonPeak,$17.57,$34.90
+US19,New Jersey,RQ,Puerto Rico,Peak,$20.73,$41.18
+US19,New Jersey,SA,Saudi Arabia,NonPeak,$18.33,$32.44
+US19,New Jersey,SA,Saudi Arabia,Peak,$21.63,$38.28
+US19,New Jersey,SN,Singapore,NonPeak,$24.38,$43.94
+US19,New Jersey,SN,Singapore,Peak,$28.77,$51.85
+US19,New Jersey,SP,Spain,NonPeak,$16.00,$33.70
+US19,New Jersey,SP,Spain,Peak,$18.88,$39.77
+US19,New Jersey,TU,Turkey,NonPeak,$27.63,$31.29
+US19,New Jersey,TU,Turkey,Peak,$32.60,$36.92
+US19,New Jersey,UK,United Kingdom,NonPeak,$29.28,$44.05
+US19,New Jersey,UK,United Kingdom,Peak,$34.55,$51.98
+US19,New Jersey,US8030400,Alaska (Zone) IV,NonPeak,$30.90,$33.75
+US19,New Jersey,US8030400,Alaska (Zone) IV,Peak,$36.46,$39.82
+US19,New Jersey,US8050500,Alaska (Zone) III,NonPeak,$15.28,$31.40
+US19,New Jersey,US8050500,Alaska (Zone) III,Peak,$18.03,$37.05
+US19,New Jersey,US8101000,Alaska (Zone) I,NonPeak,$16.05,$44.17
+US19,New Jersey,US8101000,Alaska (Zone) I,Peak,$18.94,$52.12
+US19,New Jersey,US8190100,Alaska (Zone) II,NonPeak,$16.80,$33.98
+US19,New Jersey,US8190100,Alaska (Zone) II,Peak,$19.82,$40.10
+US19,New Jersey,US89,Hawaii,NonPeak,$17.57,$31.45
+US19,New Jersey,US89,Hawaii,Peak,$20.73,$37.11
+US19,New Jersey,UY,Uruguay,NonPeak,$18.33,$44.28
+US19,New Jersey,UY,Uruguay,Peak,$21.63,$52.25
+US19,New Jersey,VE,Venezuela,NonPeak,$24.38,$34.11
+US19,New Jersey,VE,Venezuela,Peak,$28.77,$40.25
+US20,Pennsylvania,AR,Argentina,NonPeak,$16.00,$31.63
+US20,Pennsylvania,AR,Argentina,Peak,$18.88,$37.32
+US20,Pennsylvania,AS11,New South Wales/Australian Capital Territory,NonPeak,$27.63,$44.51
+US20,Pennsylvania,AS11,New South Wales/Australian Capital Territory,Peak,$32.60,$52.52
+US20,Pennsylvania,AS21,Northern Territory,NonPeak,$29.28,$34.33
+US20,Pennsylvania,AS21,Northern Territory,Peak,$34.55,$40.51
+US20,Pennsylvania,BA,Bahrain,NonPeak,$30.90,$31.74
+US20,Pennsylvania,BA,Bahrain,Peak,$36.46,$37.45
+US20,Pennsylvania,BE,Belgium,NonPeak,$15.28,$44.62
+US20,Pennsylvania,BE,Belgium,Peak,$18.03,$52.65
+US20,Pennsylvania,BL,Bolivia,NonPeak,$16.05,$34.45
+US20,Pennsylvania,BL,Bolivia,Peak,$18.94,$40.65
+US20,Pennsylvania,BR,Brazil - Brazilia,NonPeak,$16.80,$31.91
+US20,Pennsylvania,BR,Brazil - Brazilia,Peak,$19.82,$37.65
+US20,Pennsylvania,CA10,Ontario,NonPeak,$17.57,$44.74
+US20,Pennsylvania,CA10,Ontario,Peak,$20.73,$52.79
+US20,Pennsylvania,CA20,Quebec,NonPeak,$18.33,$34.56
+US20,Pennsylvania,CA20,Quebec,Peak,$21.63,$40.78
+US20,Pennsylvania,CA30,Manitoba,NonPeak,$24.38,$32.09
+US20,Pennsylvania,CA30,Manitoba,Peak,$28.77,$37.87
+US20,Pennsylvania,CI,Chile,NonPeak,$16.00,$44.91
+US20,Pennsylvania,CI,Chile,Peak,$18.88,$52.99
+US20,Pennsylvania,CO,Colombia,NonPeak,$27.63,$34.74
+US20,Pennsylvania,CO,Colombia,Peak,$32.60,$40.99
+US20,Pennsylvania,CS,Costa Rica,NonPeak,$29.28,$32.26
+US20,Pennsylvania,CS,Costa Rica,Peak,$34.55,$38.07
+US20,Pennsylvania,EC,Ecuador,NonPeak,$30.90,$45.09
+US20,Pennsylvania,EC,Ecuador,Peak,$36.46,$53.21
+US20,Pennsylvania,ES,El Salvador,NonPeak,$15.28,$34.90
+US20,Pennsylvania,ES,El Salvador,Peak,$18.03,$41.18
+US20,Pennsylvania,GE,Germany,NonPeak,$16.05,$32.44
+US20,Pennsylvania,GE,Germany,Peak,$18.94,$38.28
+US20,Pennsylvania,GQ,Guam,NonPeak,$16.80,$43.94
+US20,Pennsylvania,GQ,Guam,Peak,$19.82,$51.85
+US20,Pennsylvania,GR,Greece,NonPeak,$17.57,$33.70
+US20,Pennsylvania,GR,Greece,Peak,$20.73,$39.77
+US20,Pennsylvania,GR29,Crete,NonPeak,$18.33,$31.29
+US20,Pennsylvania,GR29,Crete,Peak,$21.63,$36.92
+US20,Pennsylvania,GT,Guatemala,NonPeak,$24.38,$44.05
+US20,Pennsylvania,GT,Guatemala,Peak,$28.77,$51.98
+US20,Pennsylvania,HO,Honduras,NonPeak,$16.00,$33.75
+US20,Pennsylvania,HO,Honduras,Peak,$18.88,$39.82
+US20,Pennsylvania,HU,Hungary,NonPeak,$27.63,$31.40
+US20,Pennsylvania,HU,Hungary,Peak,$32.60,$37.05
+US20,Pennsylvania,IT,Italy,NonPeak,$29.28,$44.17
+US20,Pennsylvania,IT,Italy,Peak,$34.55,$52.12
+US20,Pennsylvania,IT10,Sicily,NonPeak,$30.90,$33.98
+US20,Pennsylvania,IT10,Sicily,Peak,$36.46,$40.10
+US20,Pennsylvania,JA01,Japan-Central,NonPeak,$15.28,$31.45
+US20,Pennsylvania,JA01,Japan-Central,Peak,$18.03,$37.11
+US20,Pennsylvania,JA02,Japan-South (Excludes Hokkaido),NonPeak,$16.05,$44.28
+US20,Pennsylvania,JA02,Japan-South (Excludes Hokkaido),Peak,$18.94,$52.25
+US20,Pennsylvania,JA03,Japan-North,NonPeak,$16.80,$34.11
+US20,Pennsylvania,JA03,Japan-North,Peak,$19.82,$40.25
+US20,Pennsylvania,JA96,Okinawa,NonPeak,$17.57,$31.63
+US20,Pennsylvania,JA96,Okinawa,Peak,$20.73,$37.32
+US20,Pennsylvania,KS,"Korea, Republic Of",NonPeak,$18.33,$44.51
+US20,Pennsylvania,KS,"Korea, Republic Of",Peak,$21.63,$52.52
+US20,Pennsylvania,KU,Kuwait,NonPeak,$24.38,$34.33
+US20,Pennsylvania,KU,Kuwait,Peak,$28.77,$40.51
+US20,Pennsylvania,NL,Netherlands,NonPeak,$16.00,$31.74
+US20,Pennsylvania,NL,Netherlands,Peak,$18.88,$37.45
+US20,Pennsylvania,NO,Norway,NonPeak,$27.63,$44.62
+US20,Pennsylvania,NO,Norway,Peak,$32.60,$52.65
+US20,Pennsylvania,PA,Paraguay,NonPeak,$29.28,$34.45
+US20,Pennsylvania,PA,Paraguay,Peak,$34.55,$40.65
+US20,Pennsylvania,PE,Peru,NonPeak,$30.90,$31.91
+US20,Pennsylvania,PE,Peru,Peak,$36.46,$37.65
+US20,Pennsylvania,PL,Poland,NonPeak,$15.28,$44.74
+US20,Pennsylvania,PL,Poland,Peak,$18.03,$52.79
+US20,Pennsylvania,PO,Portugal,NonPeak,$16.05,$34.56
+US20,Pennsylvania,PO,Portugal,Peak,$18.94,$40.78
+US20,Pennsylvania,PO01,Azores,NonPeak,$16.80,$32.09
+US20,Pennsylvania,PO01,Azores,Peak,$19.82,$37.87
+US20,Pennsylvania,QA,Qatar,NonPeak,$17.57,$44.91
+US20,Pennsylvania,QA,Qatar,Peak,$20.73,$52.99
+US20,Pennsylvania,RO,Romania,NonPeak,$18.33,$34.74
+US20,Pennsylvania,RO,Romania,Peak,$21.63,$40.99
+US20,Pennsylvania,RQ,Puerto Rico,NonPeak,$24.38,$32.26
+US20,Pennsylvania,RQ,Puerto Rico,Peak,$28.77,$38.07
+US20,Pennsylvania,SA,Saudi Arabia,NonPeak,$16.00,$45.09
+US20,Pennsylvania,SA,Saudi Arabia,Peak,$18.88,$53.21
+US20,Pennsylvania,SN,Singapore,NonPeak,$27.63,$34.90
+US20,Pennsylvania,SN,Singapore,Peak,$32.60,$41.18
+US20,Pennsylvania,SP,Spain,NonPeak,$29.28,$32.44
+US20,Pennsylvania,SP,Spain,Peak,$34.55,$38.28
+US20,Pennsylvania,TU,Turkey,NonPeak,$30.90,$43.94
+US20,Pennsylvania,TU,Turkey,Peak,$36.46,$51.85
+US20,Pennsylvania,UK,United Kingdom,NonPeak,$15.28,$33.70
+US20,Pennsylvania,UK,United Kingdom,Peak,$18.03,$39.77
+US20,Pennsylvania,US8030400,Alaska (Zone) IV,NonPeak,$16.05,$31.29
+US20,Pennsylvania,US8030400,Alaska (Zone) IV,Peak,$18.94,$36.92
+US20,Pennsylvania,US8050500,Alaska (Zone) III,NonPeak,$16.80,$44.05
+US20,Pennsylvania,US8050500,Alaska (Zone) III,Peak,$19.82,$51.98
+US20,Pennsylvania,US8101000,Alaska (Zone) I,NonPeak,$17.57,$33.75
+US20,Pennsylvania,US8101000,Alaska (Zone) I,Peak,$20.73,$39.82
+US20,Pennsylvania,US8190100,Alaska (Zone) II,NonPeak,$18.33,$31.40
+US20,Pennsylvania,US8190100,Alaska (Zone) II,Peak,$21.63,$37.05
+US20,Pennsylvania,US89,Hawaii,NonPeak,$24.38,$44.17
+US20,Pennsylvania,US89,Hawaii,Peak,$28.77,$52.12
+US20,Pennsylvania,UY,Uruguay,NonPeak,$16.00,$33.98
+US20,Pennsylvania,UY,Uruguay,Peak,$18.88,$40.10
+US20,Pennsylvania,VE,Venezuela,NonPeak,$27.63,$31.45
+US20,Pennsylvania,VE,Venezuela,Peak,$32.60,$37.11
+US22,Delaware,AR,Argentina,NonPeak,$29.28,$44.28
+US22,Delaware,AR,Argentina,Peak,$34.55,$52.25
+US22,Delaware,AS11,New South Wales/Australian Capital Territory,NonPeak,$30.90,$34.11
+US22,Delaware,AS11,New South Wales/Australian Capital Territory,Peak,$36.46,$40.25
+US22,Delaware,AS21,Northern Territory,NonPeak,$15.28,$31.63
+US22,Delaware,AS21,Northern Territory,Peak,$18.03,$37.32
+US22,Delaware,BA,Bahrain,NonPeak,$16.05,$44.51
+US22,Delaware,BA,Bahrain,Peak,$18.94,$52.52
+US22,Delaware,BE,Belgium,NonPeak,$16.80,$34.33
+US22,Delaware,BE,Belgium,Peak,$19.82,$40.51
+US22,Delaware,BL,Bolivia,NonPeak,$17.57,$31.74
+US22,Delaware,BL,Bolivia,Peak,$20.73,$37.45
+US22,Delaware,BR,Brazil - Brazilia,NonPeak,$18.33,$44.62
+US22,Delaware,BR,Brazil - Brazilia,Peak,$21.63,$52.65
+US22,Delaware,CA10,Ontario,NonPeak,$24.38,$34.45
+US22,Delaware,CA10,Ontario,Peak,$28.77,$40.65
+US22,Delaware,CA20,Quebec,NonPeak,$16.00,$31.91
+US22,Delaware,CA20,Quebec,Peak,$18.88,$37.65
+US22,Delaware,CA30,Manitoba,NonPeak,$27.63,$44.74
+US22,Delaware,CA30,Manitoba,Peak,$32.60,$52.79
+US22,Delaware,CI,Chile,NonPeak,$29.28,$34.56
+US22,Delaware,CI,Chile,Peak,$34.55,$40.78
+US22,Delaware,CO,Colombia,NonPeak,$30.90,$32.09
+US22,Delaware,CO,Colombia,Peak,$36.46,$37.87
+US22,Delaware,CS,Costa Rica,NonPeak,$15.28,$44.91
+US22,Delaware,CS,Costa Rica,Peak,$18.03,$52.99
+US22,Delaware,EC,Ecuador,NonPeak,$16.05,$34.74
+US22,Delaware,EC,Ecuador,Peak,$18.94,$40.99
+US22,Delaware,ES,El Salvador,NonPeak,$16.80,$32.26
+US22,Delaware,ES,El Salvador,Peak,$19.82,$38.07
+US22,Delaware,GE,Germany,NonPeak,$17.57,$45.09
+US22,Delaware,GE,Germany,Peak,$20.73,$53.21
+US22,Delaware,GQ,Guam,NonPeak,$18.33,$34.90
+US22,Delaware,GQ,Guam,Peak,$21.63,$41.18
+US22,Delaware,GR,Greece,NonPeak,$24.38,$32.44
+US22,Delaware,GR,Greece,Peak,$28.77,$38.28
+US22,Delaware,GR29,Crete,NonPeak,$16.00,$43.94
+US22,Delaware,GR29,Crete,Peak,$18.88,$51.85
+US22,Delaware,GT,Guatemala,NonPeak,$27.63,$33.70
+US22,Delaware,GT,Guatemala,Peak,$32.60,$39.77
+US22,Delaware,HO,Honduras,NonPeak,$29.28,$31.29
+US22,Delaware,HO,Honduras,Peak,$34.55,$36.92
+US22,Delaware,HU,Hungary,NonPeak,$30.90,$44.05
+US22,Delaware,HU,Hungary,Peak,$36.46,$51.98
+US22,Delaware,IT,Italy,NonPeak,$15.28,$33.75
+US22,Delaware,IT,Italy,Peak,$18.03,$39.82
+US22,Delaware,IT10,Sicily,NonPeak,$16.05,$31.40
+US22,Delaware,IT10,Sicily,Peak,$18.94,$37.05
+US22,Delaware,JA01,Japan-Central,NonPeak,$16.80,$44.17
+US22,Delaware,JA01,Japan-Central,Peak,$19.82,$52.12
+US22,Delaware,JA02,Japan-South (Excludes Hokkaido),NonPeak,$17.57,$33.98
+US22,Delaware,JA02,Japan-South (Excludes Hokkaido),Peak,$20.73,$40.10
+US22,Delaware,JA03,Japan-North,NonPeak,$18.33,$31.45
+US22,Delaware,JA03,Japan-North,Peak,$21.63,$37.11
+US22,Delaware,JA96,Okinawa,NonPeak,$24.38,$44.28
+US22,Delaware,JA96,Okinawa,Peak,$28.77,$52.25
+US22,Delaware,KS,"Korea, Republic Of",NonPeak,$16.00,$34.11
+US22,Delaware,KS,"Korea, Republic Of",Peak,$18.88,$40.25
+US22,Delaware,KU,Kuwait,NonPeak,$27.63,$31.63
+US22,Delaware,KU,Kuwait,Peak,$32.60,$37.32
+US22,Delaware,NL,Netherlands,NonPeak,$29.28,$44.51
+US22,Delaware,NL,Netherlands,Peak,$34.55,$52.52
+US22,Delaware,NO,Norway,NonPeak,$30.90,$34.33
+US22,Delaware,NO,Norway,Peak,$36.46,$40.51
+US22,Delaware,PA,Paraguay,NonPeak,$15.28,$31.74
+US22,Delaware,PA,Paraguay,Peak,$18.03,$37.45
+US22,Delaware,PE,Peru,NonPeak,$16.05,$44.62
+US22,Delaware,PE,Peru,Peak,$18.94,$52.65
+US22,Delaware,PL,Poland,NonPeak,$16.80,$34.45
+US22,Delaware,PL,Poland,Peak,$19.82,$40.65
+US22,Delaware,PO,Portugal,NonPeak,$17.57,$31.91
+US22,Delaware,PO,Portugal,Peak,$20.73,$37.65
+US22,Delaware,PO01,Azores,NonPeak,$18.33,$44.74
+US22,Delaware,PO01,Azores,Peak,$21.63,$52.79
+US22,Delaware,QA,Qatar,NonPeak,$24.38,$34.56
+US22,Delaware,QA,Qatar,Peak,$28.77,$40.78
+US22,Delaware,RO,Romania,NonPeak,$16.00,$32.09
+US22,Delaware,RO,Romania,Peak,$18.88,$37.87
+US22,Delaware,RQ,Puerto Rico,NonPeak,$27.63,$44.91
+US22,Delaware,RQ,Puerto Rico,Peak,$32.60,$52.99
+US22,Delaware,SA,Saudi Arabia,NonPeak,$29.28,$34.74
+US22,Delaware,SA,Saudi Arabia,Peak,$34.55,$40.99
+US22,Delaware,SN,Singapore,NonPeak,$30.90,$32.26
+US22,Delaware,SN,Singapore,Peak,$36.46,$38.07
+US22,Delaware,SP,Spain,NonPeak,$15.28,$45.09
+US22,Delaware,SP,Spain,Peak,$18.03,$53.21
+US22,Delaware,TU,Turkey,NonPeak,$16.05,$34.90
+US22,Delaware,TU,Turkey,Peak,$18.94,$41.18
+US22,Delaware,UK,United Kingdom,NonPeak,$16.80,$32.44
+US22,Delaware,UK,United Kingdom,Peak,$19.82,$38.28
+US22,Delaware,US8030400,Alaska (Zone) IV,NonPeak,$17.57,$43.94
+US22,Delaware,US8030400,Alaska (Zone) IV,Peak,$20.73,$51.85
+US22,Delaware,US8050500,Alaska (Zone) III,NonPeak,$18.33,$33.70
+US22,Delaware,US8050500,Alaska (Zone) III,Peak,$21.63,$39.77
+US22,Delaware,US8101000,Alaska (Zone) I,NonPeak,$24.38,$31.29
+US22,Delaware,US8101000,Alaska (Zone) I,Peak,$28.77,$36.92
+US22,Delaware,US8190100,Alaska (Zone) II,NonPeak,$16.00,$44.05
+US22,Delaware,US8190100,Alaska (Zone) II,Peak,$18.88,$51.98
+US22,Delaware,US89,Hawaii,NonPeak,$27.63,$33.75
+US22,Delaware,US89,Hawaii,Peak,$32.60,$39.82
+US22,Delaware,UY,Uruguay,NonPeak,$29.28,$31.40
+US22,Delaware,UY,Uruguay,Peak,$34.55,$37.05
+US22,Delaware,VE,Venezuela,NonPeak,$30.90,$44.17
+US22,Delaware,VE,Venezuela,Peak,$36.46,$52.12
+US23,Maryland,AR,Argentina,NonPeak,$15.28,$33.98
+US23,Maryland,AR,Argentina,Peak,$18.03,$40.10
+US23,Maryland,AS11,New South Wales/Australian Capital Territory,NonPeak,$16.05,$31.45
+US23,Maryland,AS11,New South Wales/Australian Capital Territory,Peak,$18.94,$37.11
+US23,Maryland,AS21,Northern Territory,NonPeak,$16.80,$44.28
+US23,Maryland,AS21,Northern Territory,Peak,$19.82,$52.25
+US23,Maryland,BA,Bahrain,NonPeak,$17.57,$34.11
+US23,Maryland,BA,Bahrain,Peak,$20.73,$40.25
+US23,Maryland,BE,Belgium,NonPeak,$18.33,$31.63
+US23,Maryland,BE,Belgium,Peak,$21.63,$37.32
+US23,Maryland,BL,Bolivia,NonPeak,$24.38,$44.51
+US23,Maryland,BL,Bolivia,Peak,$28.77,$52.52
+US23,Maryland,BR,Brazil - Brazilia,NonPeak,$16.00,$34.33
+US23,Maryland,BR,Brazil - Brazilia,Peak,$18.88,$40.51
+US23,Maryland,CA10,Ontario,NonPeak,$27.63,$31.74
+US23,Maryland,CA10,Ontario,Peak,$32.60,$37.45
+US23,Maryland,CA20,Quebec,NonPeak,$29.28,$44.62
+US23,Maryland,CA20,Quebec,Peak,$34.55,$52.65
+US23,Maryland,CA30,Manitoba,NonPeak,$30.90,$34.45
+US23,Maryland,CA30,Manitoba,Peak,$36.46,$40.65
+US23,Maryland,CI,Chile,NonPeak,$15.28,$31.91
+US23,Maryland,CI,Chile,Peak,$18.03,$37.65
+US23,Maryland,CO,Colombia,NonPeak,$16.05,$44.74
+US23,Maryland,CO,Colombia,Peak,$18.94,$52.79
+US23,Maryland,CS,Costa Rica,NonPeak,$16.80,$34.56
+US23,Maryland,CS,Costa Rica,Peak,$19.82,$40.78
+US23,Maryland,EC,Ecuador,NonPeak,$17.57,$32.09
+US23,Maryland,EC,Ecuador,Peak,$20.73,$37.87
+US23,Maryland,ES,El Salvador,NonPeak,$18.33,$44.91
+US23,Maryland,ES,El Salvador,Peak,$21.63,$52.99
+US23,Maryland,GE,Germany,NonPeak,$24.38,$34.74
+US23,Maryland,GE,Germany,Peak,$28.77,$40.99
+US23,Maryland,GQ,Guam,NonPeak,$16.00,$32.26
+US23,Maryland,GQ,Guam,Peak,$18.88,$38.07
+US23,Maryland,GR,Greece,NonPeak,$27.63,$45.09
+US23,Maryland,GR,Greece,Peak,$32.60,$53.21
+US23,Maryland,GR29,Crete,NonPeak,$29.28,$34.90
+US23,Maryland,GR29,Crete,Peak,$34.55,$41.18
+US23,Maryland,GT,Guatemala,NonPeak,$30.90,$32.44
+US23,Maryland,GT,Guatemala,Peak,$36.46,$38.28
+US23,Maryland,HO,Honduras,NonPeak,$15.28,$43.94
+US23,Maryland,HO,Honduras,Peak,$18.03,$51.85
+US23,Maryland,HU,Hungary,NonPeak,$16.05,$33.70
+US23,Maryland,HU,Hungary,Peak,$18.94,$39.77
+US23,Maryland,IT,Italy,NonPeak,$16.80,$31.29
+US23,Maryland,IT,Italy,Peak,$19.82,$36.92
+US23,Maryland,IT10,Sicily,NonPeak,$17.57,$44.05
+US23,Maryland,IT10,Sicily,Peak,$20.73,$51.98
+US23,Maryland,JA01,Japan-Central,NonPeak,$18.33,$33.75
+US23,Maryland,JA01,Japan-Central,Peak,$21.63,$39.82
+US23,Maryland,JA02,Japan-South (Excludes Hokkaido),NonPeak,$24.38,$31.40
+US23,Maryland,JA02,Japan-South (Excludes Hokkaido),Peak,$28.77,$37.05
+US23,Maryland,JA03,Japan-North,NonPeak,$16.00,$44.17
+US23,Maryland,JA03,Japan-North,Peak,$18.88,$52.12
+US23,Maryland,JA96,Okinawa,NonPeak,$27.63,$33.98
+US23,Maryland,JA96,Okinawa,Peak,$32.60,$40.10
+US23,Maryland,KS,"Korea, Republic Of",NonPeak,$29.28,$31.45
+US23,Maryland,KS,"Korea, Republic Of",Peak,$34.55,$37.11
+US23,Maryland,KU,Kuwait,NonPeak,$30.90,$44.28
+US23,Maryland,KU,Kuwait,Peak,$36.46,$52.25
+US23,Maryland,NL,Netherlands,NonPeak,$15.28,$34.11
+US23,Maryland,NL,Netherlands,Peak,$18.03,$40.25
+US23,Maryland,NO,Norway,NonPeak,$16.05,$31.63
+US23,Maryland,NO,Norway,Peak,$18.94,$37.32
+US23,Maryland,PA,Paraguay,NonPeak,$16.80,$44.51
+US23,Maryland,PA,Paraguay,Peak,$19.82,$52.52
+US23,Maryland,PE,Peru,NonPeak,$17.57,$34.33
+US23,Maryland,PE,Peru,Peak,$20.73,$40.51
+US23,Maryland,PL,Poland,NonPeak,$18.33,$31.74
+US23,Maryland,PL,Poland,Peak,$21.63,$37.45
+US23,Maryland,PO,Portugal,NonPeak,$24.38,$44.62
+US23,Maryland,PO,Portugal,Peak,$28.77,$52.65
+US23,Maryland,PO01,Azores,NonPeak,$16.00,$34.45
+US23,Maryland,PO01,Azores,Peak,$18.88,$40.65
+US23,Maryland,QA,Qatar,NonPeak,$27.63,$31.91
+US23,Maryland,QA,Qatar,Peak,$32.60,$37.65
+US23,Maryland,RO,Romania,NonPeak,$29.28,$44.74
+US23,Maryland,RO,Romania,Peak,$34.55,$52.79
+US23,Maryland,RQ,Puerto Rico,NonPeak,$30.90,$34.56
+US23,Maryland,RQ,Puerto Rico,Peak,$36.46,$40.78
+US23,Maryland,SA,Saudi Arabia,NonPeak,$15.28,$32.09
+US23,Maryland,SA,Saudi Arabia,Peak,$18.03,$37.87
+US23,Maryland,SN,Singapore,NonPeak,$16.05,$44.91
+US23,Maryland,SN,Singapore,Peak,$18.94,$52.99
+US23,Maryland,SP,Spain,NonPeak,$16.80,$34.74
+US23,Maryland,SP,Spain,Peak,$19.82,$40.99
+US23,Maryland,TU,Turkey,NonPeak,$17.57,$32.26
+US23,Maryland,TU,Turkey,Peak,$20.73,$38.07
+US23,Maryland,UK,United Kingdom,NonPeak,$18.33,$45.09
+US23,Maryland,UK,United Kingdom,Peak,$21.63,$53.21
+US23,Maryland,US8030400,Alaska (Zone) IV,NonPeak,$24.38,$34.90
+US23,Maryland,US8030400,Alaska (Zone) IV,Peak,$28.77,$41.18
+US23,Maryland,US8050500,Alaska (Zone) III,NonPeak,$16.00,$32.44
+US23,Maryland,US8050500,Alaska (Zone) III,Peak,$18.88,$38.28
+US23,Maryland,US8101000,Alaska (Zone) I,NonPeak,$27.63,$43.94
+US23,Maryland,US8101000,Alaska (Zone) I,Peak,$32.60,$51.85
+US23,Maryland,US8190100,Alaska (Zone) II,NonPeak,$29.28,$33.70
+US23,Maryland,US8190100,Alaska (Zone) II,Peak,$34.55,$39.77
+US23,Maryland,US89,Hawaii,NonPeak,$30.90,$31.29
+US23,Maryland,US89,Hawaii,Peak,$36.46,$36.92
+US23,Maryland,UY,Uruguay,NonPeak,$15.28,$44.05
+US23,Maryland,UY,Uruguay,Peak,$18.03,$51.98
+US23,Maryland,VE,Venezuela,NonPeak,$16.05,$33.75
+US23,Maryland,VE,Venezuela,Peak,$18.94,$39.82
+US24,District Of Columbia,AR,Argentina,NonPeak,$16.80,$31.40
+US24,District Of Columbia,AR,Argentina,Peak,$19.82,$37.05
+US24,District Of Columbia,AS11,New South Wales/Australian Capital Territory,NonPeak,$17.57,$44.17
+US24,District Of Columbia,AS11,New South Wales/Australian Capital Territory,Peak,$20.73,$52.12
+US24,District Of Columbia,AS21,Northern Territory,NonPeak,$18.33,$33.98
+US24,District Of Columbia,AS21,Northern Territory,Peak,$21.63,$40.10
+US24,District Of Columbia,BA,Bahrain,NonPeak,$24.38,$31.45
+US24,District Of Columbia,BA,Bahrain,Peak,$28.77,$37.11
+US24,District Of Columbia,BE,Belgium,NonPeak,$16.00,$44.28
+US24,District Of Columbia,BE,Belgium,Peak,$18.88,$52.25
+US24,District Of Columbia,BL,Bolivia,NonPeak,$27.63,$34.11
+US24,District Of Columbia,BL,Bolivia,Peak,$32.60,$40.25
+US24,District Of Columbia,BR,Brazil - Brazilia,NonPeak,$29.28,$31.63
+US24,District Of Columbia,BR,Brazil - Brazilia,Peak,$34.55,$37.32
+US24,District Of Columbia,CA10,Ontario,NonPeak,$30.90,$44.51
+US24,District Of Columbia,CA10,Ontario,Peak,$36.46,$52.52
+US24,District Of Columbia,CA20,Quebec,NonPeak,$15.28,$34.33
+US24,District Of Columbia,CA20,Quebec,Peak,$18.03,$40.51
+US24,District Of Columbia,CA30,Manitoba,NonPeak,$16.05,$31.74
+US24,District Of Columbia,CA30,Manitoba,Peak,$18.94,$37.45
+US24,District Of Columbia,CI,Chile,NonPeak,$16.80,$44.62
+US24,District Of Columbia,CI,Chile,Peak,$19.82,$52.65
+US24,District Of Columbia,CO,Colombia,NonPeak,$17.57,$34.45
+US24,District Of Columbia,CO,Colombia,Peak,$20.73,$40.65
+US24,District Of Columbia,CS,Costa Rica,NonPeak,$18.33,$31.91
+US24,District Of Columbia,CS,Costa Rica,Peak,$21.63,$37.65
+US24,District Of Columbia,EC,Ecuador,NonPeak,$24.38,$44.74
+US24,District Of Columbia,EC,Ecuador,Peak,$28.77,$52.79
+US24,District Of Columbia,ES,El Salvador,NonPeak,$16.00,$34.56
+US24,District Of Columbia,ES,El Salvador,Peak,$18.88,$40.78
+US24,District Of Columbia,GE,Germany,NonPeak,$27.63,$32.09
+US24,District Of Columbia,GE,Germany,Peak,$32.60,$37.87
+US24,District Of Columbia,GQ,Guam,NonPeak,$29.28,$44.91
+US24,District Of Columbia,GQ,Guam,Peak,$34.55,$52.99
+US24,District Of Columbia,GR,Greece,NonPeak,$30.90,$34.74
+US24,District Of Columbia,GR,Greece,Peak,$36.46,$40.99
+US24,District Of Columbia,GR29,Crete,NonPeak,$15.28,$32.26
+US24,District Of Columbia,GR29,Crete,Peak,$18.03,$38.07
+US24,District Of Columbia,GT,Guatemala,NonPeak,$16.05,$45.09
+US24,District Of Columbia,GT,Guatemala,Peak,$18.94,$53.21
+US24,District Of Columbia,HO,Honduras,NonPeak,$16.80,$34.90
+US24,District Of Columbia,HO,Honduras,Peak,$19.82,$41.18
+US24,District Of Columbia,HU,Hungary,NonPeak,$17.57,$32.44
+US24,District Of Columbia,HU,Hungary,Peak,$20.73,$38.28
+US24,District Of Columbia,IT,Italy,NonPeak,$18.33,$43.94
+US24,District Of Columbia,IT,Italy,Peak,$21.63,$51.85
+US24,District Of Columbia,IT10,Sicily,NonPeak,$24.38,$33.70
+US24,District Of Columbia,IT10,Sicily,Peak,$28.77,$39.77
+US24,District Of Columbia,JA01,Japan-Central,NonPeak,$16.00,$31.29
+US24,District Of Columbia,JA01,Japan-Central,Peak,$18.88,$36.92
+US24,District Of Columbia,JA02,Japan-South (Excludes Hokkaido),NonPeak,$27.63,$44.05
+US24,District Of Columbia,JA02,Japan-South (Excludes Hokkaido),Peak,$32.60,$51.98
+US24,District Of Columbia,JA03,Japan-North,NonPeak,$29.28,$33.75
+US24,District Of Columbia,JA03,Japan-North,Peak,$34.55,$39.82
+US24,District Of Columbia,JA96,Okinawa,NonPeak,$30.90,$31.40
+US24,District Of Columbia,JA96,Okinawa,Peak,$36.46,$37.05
+US24,District Of Columbia,KS,"Korea, Republic Of",NonPeak,$15.28,$44.17
+US24,District Of Columbia,KS,"Korea, Republic Of",Peak,$18.03,$52.12
+US24,District Of Columbia,KU,Kuwait,NonPeak,$16.05,$33.98
+US24,District Of Columbia,KU,Kuwait,Peak,$18.94,$40.10
+US24,District Of Columbia,NL,Netherlands,NonPeak,$16.80,$31.45
+US24,District Of Columbia,NL,Netherlands,Peak,$19.82,$37.11
+US24,District Of Columbia,NO,Norway,NonPeak,$17.57,$44.28
+US24,District Of Columbia,NO,Norway,Peak,$20.73,$52.25
+US24,District Of Columbia,PA,Paraguay,NonPeak,$18.33,$34.11
+US24,District Of Columbia,PA,Paraguay,Peak,$21.63,$40.25
+US24,District Of Columbia,PE,Peru,NonPeak,$24.38,$31.63
+US24,District Of Columbia,PE,Peru,Peak,$28.77,$37.32
+US24,District Of Columbia,PL,Poland,NonPeak,$16.00,$44.51
+US24,District Of Columbia,PL,Poland,Peak,$18.88,$52.52
+US24,District Of Columbia,PO,Portugal,NonPeak,$27.63,$34.33
+US24,District Of Columbia,PO,Portugal,Peak,$32.60,$40.51
+US24,District Of Columbia,PO01,Azores,NonPeak,$29.28,$31.74
+US24,District Of Columbia,PO01,Azores,Peak,$34.55,$37.45
+US24,District Of Columbia,QA,Qatar,NonPeak,$30.90,$44.62
+US24,District Of Columbia,QA,Qatar,Peak,$36.46,$52.65
+US24,District Of Columbia,RO,Romania,NonPeak,$15.28,$34.45
+US24,District Of Columbia,RO,Romania,Peak,$18.03,$40.65
+US24,District Of Columbia,RQ,Puerto Rico,NonPeak,$16.05,$31.91
+US24,District Of Columbia,RQ,Puerto Rico,Peak,$18.94,$37.65
+US24,District Of Columbia,SA,Saudi Arabia,NonPeak,$16.80,$44.74
+US24,District Of Columbia,SA,Saudi Arabia,Peak,$19.82,$52.79
+US24,District Of Columbia,SN,Singapore,NonPeak,$17.57,$34.56
+US24,District Of Columbia,SN,Singapore,Peak,$20.73,$40.78
+US24,District Of Columbia,SP,Spain,NonPeak,$18.33,$32.09
+US24,District Of Columbia,SP,Spain,Peak,$21.63,$37.87
+US24,District Of Columbia,TU,Turkey,NonPeak,$24.38,$44.91
+US24,District Of Columbia,TU,Turkey,Peak,$28.77,$52.99
+US24,District Of Columbia,UK,United Kingdom,NonPeak,$16.00,$34.74
+US24,District Of Columbia,UK,United Kingdom,Peak,$18.88,$40.99
+US24,District Of Columbia,US8030400,Alaska (Zone) IV,NonPeak,$27.63,$32.26
+US24,District Of Columbia,US8030400,Alaska (Zone) IV,Peak,$32.60,$38.07
+US24,District Of Columbia,US8050500,Alaska (Zone) III,NonPeak,$29.28,$45.09
+US24,District Of Columbia,US8050500,Alaska (Zone) III,Peak,$34.55,$53.21
+US24,District Of Columbia,US8101000,Alaska (Zone) I,NonPeak,$30.90,$34.90
+US24,District Of Columbia,US8101000,Alaska (Zone) I,Peak,$36.46,$41.18
+US24,District Of Columbia,US8190100,Alaska (Zone) II,NonPeak,$15.28,$32.44
+US24,District Of Columbia,US8190100,Alaska (Zone) II,Peak,$18.03,$38.28
+US24,District Of Columbia,US89,Hawaii,NonPeak,$16.05,$43.94
+US24,District Of Columbia,US89,Hawaii,Peak,$18.94,$51.85
+US24,District Of Columbia,UY,Uruguay,NonPeak,$16.80,$33.70
+US24,District Of Columbia,UY,Uruguay,Peak,$19.82,$39.77
+US24,District Of Columbia,VE,Venezuela,NonPeak,$17.57,$31.29
+US24,District Of Columbia,VE,Venezuela,Peak,$20.73,$36.92
+US25,Virginia,AR,Argentina,NonPeak,$18.33,$44.05
+US25,Virginia,AR,Argentina,Peak,$21.63,$51.98
+US25,Virginia,AS11,New South Wales/Australian Capital Territory,NonPeak,$24.38,$33.75
+US25,Virginia,AS11,New South Wales/Australian Capital Territory,Peak,$28.77,$39.82
+US25,Virginia,AS21,Northern Territory,NonPeak,$16.00,$31.40
+US25,Virginia,AS21,Northern Territory,Peak,$18.88,$37.05
+US25,Virginia,BA,Bahrain,NonPeak,$27.63,$44.17
+US25,Virginia,BA,Bahrain,Peak,$32.60,$52.12
+US25,Virginia,BE,Belgium,NonPeak,$29.28,$33.98
+US25,Virginia,BE,Belgium,Peak,$34.55,$40.10
+US25,Virginia,BL,Bolivia,NonPeak,$30.90,$31.45
+US25,Virginia,BL,Bolivia,Peak,$36.46,$37.11
+US25,Virginia,BR,Brazil - Brazilia,NonPeak,$15.28,$44.28
+US25,Virginia,BR,Brazil - Brazilia,Peak,$18.03,$52.25
+US25,Virginia,CA10,Ontario,NonPeak,$16.05,$34.11
+US25,Virginia,CA10,Ontario,Peak,$18.94,$40.25
+US25,Virginia,CA20,Quebec,NonPeak,$16.80,$31.63
+US25,Virginia,CA20,Quebec,Peak,$19.82,$37.32
+US25,Virginia,CA30,Manitoba,NonPeak,$17.57,$44.51
+US25,Virginia,CA30,Manitoba,Peak,$20.73,$52.52
+US25,Virginia,CI,Chile,NonPeak,$18.33,$34.33
+US25,Virginia,CI,Chile,Peak,$21.63,$40.51
+US25,Virginia,CO,Colombia,NonPeak,$24.38,$31.74
+US25,Virginia,CO,Colombia,Peak,$28.77,$37.45
+US25,Virginia,CS,Costa Rica,NonPeak,$16.00,$44.62
+US25,Virginia,CS,Costa Rica,Peak,$18.88,$52.65
+US25,Virginia,EC,Ecuador,NonPeak,$27.63,$34.45
+US25,Virginia,EC,Ecuador,Peak,$32.60,$40.65
+US25,Virginia,ES,El Salvador,NonPeak,$29.28,$31.91
+US25,Virginia,ES,El Salvador,Peak,$34.55,$37.65
+US25,Virginia,GE,Germany,NonPeak,$30.90,$44.74
+US25,Virginia,GE,Germany,Peak,$36.46,$52.79
+US25,Virginia,GQ,Guam,NonPeak,$15.28,$34.56
+US25,Virginia,GQ,Guam,Peak,$18.03,$40.78
+US25,Virginia,GR,Greece,NonPeak,$16.05,$32.09
+US25,Virginia,GR,Greece,Peak,$18.94,$37.87
+US25,Virginia,GR29,Crete,NonPeak,$16.80,$44.91
+US25,Virginia,GR29,Crete,Peak,$19.82,$52.99
+US25,Virginia,GT,Guatemala,NonPeak,$17.57,$34.74
+US25,Virginia,GT,Guatemala,Peak,$20.73,$40.99
+US25,Virginia,HO,Honduras,NonPeak,$18.33,$32.26
+US25,Virginia,HO,Honduras,Peak,$21.63,$38.07
+US25,Virginia,HU,Hungary,NonPeak,$24.38,$45.09
+US25,Virginia,HU,Hungary,Peak,$28.77,$53.21
+US25,Virginia,IT,Italy,NonPeak,$16.00,$34.90
+US25,Virginia,IT,Italy,Peak,$18.88,$41.18
+US25,Virginia,IT10,Sicily,NonPeak,$27.63,$32.44
+US25,Virginia,IT10,Sicily,Peak,$32.60,$38.28
+US25,Virginia,JA01,Japan-Central,NonPeak,$29.28,$43.94
+US25,Virginia,JA01,Japan-Central,Peak,$34.55,$51.85
+US25,Virginia,JA02,Japan-South (Excludes Hokkaido),NonPeak,$30.90,$33.70
+US25,Virginia,JA02,Japan-South (Excludes Hokkaido),Peak,$36.46,$39.77
+US25,Virginia,JA03,Japan-North,NonPeak,$15.28,$31.29
+US25,Virginia,JA03,Japan-North,Peak,$18.03,$36.92
+US25,Virginia,JA96,Okinawa,NonPeak,$16.05,$44.05
+US25,Virginia,JA96,Okinawa,Peak,$18.94,$51.98
+US25,Virginia,KS,"Korea, Republic Of",NonPeak,$16.80,$33.75
+US25,Virginia,KS,"Korea, Republic Of",Peak,$19.82,$39.82
+US25,Virginia,KU,Kuwait,NonPeak,$17.57,$31.40
+US25,Virginia,KU,Kuwait,Peak,$20.73,$37.05
+US25,Virginia,NL,Netherlands,NonPeak,$18.33,$44.17
+US25,Virginia,NL,Netherlands,Peak,$21.63,$52.12
+US25,Virginia,NO,Norway,NonPeak,$24.38,$33.98
+US25,Virginia,NO,Norway,Peak,$28.77,$40.10
+US25,Virginia,PA,Paraguay,NonPeak,$16.00,$31.45
+US25,Virginia,PA,Paraguay,Peak,$18.88,$37.11
+US25,Virginia,PE,Peru,NonPeak,$27.63,$44.28
+US25,Virginia,PE,Peru,Peak,$32.60,$52.25
+US25,Virginia,PL,Poland,NonPeak,$29.28,$34.11
+US25,Virginia,PL,Poland,Peak,$34.55,$40.25
+US25,Virginia,PO,Portugal,NonPeak,$30.90,$31.63
+US25,Virginia,PO,Portugal,Peak,$36.46,$37.32
+US25,Virginia,PO01,Azores,NonPeak,$15.28,$44.51
+US25,Virginia,PO01,Azores,Peak,$18.03,$52.52
+US25,Virginia,QA,Qatar,NonPeak,$16.05,$34.33
+US25,Virginia,QA,Qatar,Peak,$18.94,$40.51
+US25,Virginia,RO,Romania,NonPeak,$16.80,$31.74
+US25,Virginia,RO,Romania,Peak,$19.82,$37.45
+US25,Virginia,RQ,Puerto Rico,NonPeak,$17.57,$44.62
+US25,Virginia,RQ,Puerto Rico,Peak,$20.73,$52.65
+US25,Virginia,SA,Saudi Arabia,NonPeak,$18.33,$34.45
+US25,Virginia,SA,Saudi Arabia,Peak,$21.63,$40.65
+US25,Virginia,SN,Singapore,NonPeak,$24.38,$31.91
+US25,Virginia,SN,Singapore,Peak,$28.77,$37.65
+US25,Virginia,SP,Spain,NonPeak,$16.00,$44.74
+US25,Virginia,SP,Spain,Peak,$18.88,$52.79
+US25,Virginia,TU,Turkey,NonPeak,$27.63,$34.56
+US25,Virginia,TU,Turkey,Peak,$32.60,$40.78
+US25,Virginia,UK,United Kingdom,NonPeak,$29.28,$32.09
+US25,Virginia,UK,United Kingdom,Peak,$34.55,$37.87
+US25,Virginia,US8030400,Alaska (Zone) IV,NonPeak,$30.90,$44.91
+US25,Virginia,US8030400,Alaska (Zone) IV,Peak,$36.46,$52.99
+US25,Virginia,US8050500,Alaska (Zone) III,NonPeak,$15.28,$34.74
+US25,Virginia,US8050500,Alaska (Zone) III,Peak,$18.03,$40.99
+US25,Virginia,US8101000,Alaska (Zone) I,NonPeak,$16.05,$32.26
+US25,Virginia,US8101000,Alaska (Zone) I,Peak,$18.94,$38.07
+US25,Virginia,US8190100,Alaska (Zone) II,NonPeak,$16.80,$45.09
+US25,Virginia,US8190100,Alaska (Zone) II,Peak,$19.82,$53.21
+US25,Virginia,US89,Hawaii,NonPeak,$17.57,$34.90
+US25,Virginia,US89,Hawaii,Peak,$20.73,$41.18
+US25,Virginia,UY,Uruguay,NonPeak,$18.33,$32.44
+US25,Virginia,UY,Uruguay,Peak,$21.63,$38.28
+US25,Virginia,VE,Venezuela,NonPeak,$24.38,$43.94
+US25,Virginia,VE,Venezuela,Peak,$28.77,$51.85
+US27,West Virginia,AR,Argentina,NonPeak,$16.00,$33.70
+US27,West Virginia,AR,Argentina,Peak,$18.88,$39.77
+US27,West Virginia,AS11,New South Wales/Australian Capital Territory,NonPeak,$27.63,$31.29
+US27,West Virginia,AS11,New South Wales/Australian Capital Territory,Peak,$32.60,$36.92
+US27,West Virginia,AS21,Northern Territory,NonPeak,$29.28,$44.05
+US27,West Virginia,AS21,Northern Territory,Peak,$34.55,$51.98
+US27,West Virginia,BA,Bahrain,NonPeak,$30.90,$33.75
+US27,West Virginia,BA,Bahrain,Peak,$36.46,$39.82
+US27,West Virginia,BE,Belgium,NonPeak,$15.28,$31.40
+US27,West Virginia,BE,Belgium,Peak,$18.03,$37.05
+US27,West Virginia,BL,Bolivia,NonPeak,$16.05,$44.17
+US27,West Virginia,BL,Bolivia,Peak,$18.94,$52.12
+US27,West Virginia,BR,Brazil - Brazilia,NonPeak,$16.80,$33.98
+US27,West Virginia,BR,Brazil - Brazilia,Peak,$19.82,$40.10
+US27,West Virginia,CA10,Ontario,NonPeak,$17.57,$31.45
+US27,West Virginia,CA10,Ontario,Peak,$20.73,$37.11
+US27,West Virginia,CA20,Quebec,NonPeak,$18.33,$44.28
+US27,West Virginia,CA20,Quebec,Peak,$21.63,$52.25
+US27,West Virginia,CA30,Manitoba,NonPeak,$24.38,$34.11
+US27,West Virginia,CA30,Manitoba,Peak,$28.77,$40.25
+US27,West Virginia,CI,Chile,NonPeak,$16.00,$31.63
+US27,West Virginia,CI,Chile,Peak,$18.88,$37.32
+US27,West Virginia,CO,Colombia,NonPeak,$27.63,$44.51
+US27,West Virginia,CO,Colombia,Peak,$32.60,$52.52
+US27,West Virginia,CS,Costa Rica,NonPeak,$29.28,$34.33
+US27,West Virginia,CS,Costa Rica,Peak,$34.55,$40.51
+US27,West Virginia,EC,Ecuador,NonPeak,$30.90,$31.74
+US27,West Virginia,EC,Ecuador,Peak,$36.46,$37.45
+US27,West Virginia,ES,El Salvador,NonPeak,$15.28,$44.62
+US27,West Virginia,ES,El Salvador,Peak,$18.03,$52.65
+US27,West Virginia,GE,Germany,NonPeak,$16.05,$34.45
+US27,West Virginia,GE,Germany,Peak,$18.94,$40.65
+US27,West Virginia,GQ,Guam,NonPeak,$16.80,$31.91
+US27,West Virginia,GQ,Guam,Peak,$19.82,$37.65
+US27,West Virginia,GR,Greece,NonPeak,$17.57,$44.74
+US27,West Virginia,GR,Greece,Peak,$20.73,$52.79
+US27,West Virginia,GR29,Crete,NonPeak,$18.33,$34.56
+US27,West Virginia,GR29,Crete,Peak,$21.63,$40.78
+US27,West Virginia,GT,Guatemala,NonPeak,$24.38,$32.09
+US27,West Virginia,GT,Guatemala,Peak,$28.77,$37.87
+US27,West Virginia,HO,Honduras,NonPeak,$16.00,$44.91
+US27,West Virginia,HO,Honduras,Peak,$18.88,$52.99
+US27,West Virginia,HU,Hungary,NonPeak,$27.63,$34.74
+US27,West Virginia,HU,Hungary,Peak,$32.60,$40.99
+US27,West Virginia,IT,Italy,NonPeak,$29.28,$32.26
+US27,West Virginia,IT,Italy,Peak,$34.55,$38.07
+US27,West Virginia,IT10,Sicily,NonPeak,$30.90,$45.09
+US27,West Virginia,IT10,Sicily,Peak,$36.46,$53.21
+US27,West Virginia,JA01,Japan-Central,NonPeak,$15.28,$34.90
+US27,West Virginia,JA01,Japan-Central,Peak,$18.03,$41.18
+US27,West Virginia,JA02,Japan-South (Excludes Hokkaido),NonPeak,$16.05,$32.44
+US27,West Virginia,JA02,Japan-South (Excludes Hokkaido),Peak,$18.94,$38.28
+US27,West Virginia,JA03,Japan-North,NonPeak,$16.80,$43.94
+US27,West Virginia,JA03,Japan-North,Peak,$19.82,$51.85
+US27,West Virginia,JA96,Okinawa,NonPeak,$17.57,$33.70
+US27,West Virginia,JA96,Okinawa,Peak,$20.73,$39.77
+US27,West Virginia,KS,"Korea, Republic Of",NonPeak,$18.33,$31.29
+US27,West Virginia,KS,"Korea, Republic Of",Peak,$21.63,$36.92
+US27,West Virginia,KU,Kuwait,NonPeak,$24.38,$44.05
+US27,West Virginia,KU,Kuwait,Peak,$28.77,$51.98
+US27,West Virginia,NL,Netherlands,NonPeak,$16.00,$33.75
+US27,West Virginia,NL,Netherlands,Peak,$18.88,$39.82
+US27,West Virginia,NO,Norway,NonPeak,$27.63,$31.40
+US27,West Virginia,NO,Norway,Peak,$32.60,$37.05
+US27,West Virginia,PA,Paraguay,NonPeak,$29.28,$44.17
+US27,West Virginia,PA,Paraguay,Peak,$34.55,$52.12
+US27,West Virginia,PE,Peru,NonPeak,$30.90,$33.98
+US27,West Virginia,PE,Peru,Peak,$36.46,$40.10
+US27,West Virginia,PL,Poland,NonPeak,$15.28,$31.45
+US27,West Virginia,PL,Poland,Peak,$18.03,$37.11
+US27,West Virginia,PO,Portugal,NonPeak,$16.05,$44.28
+US27,West Virginia,PO,Portugal,Peak,$18.94,$52.25
+US27,West Virginia,PO01,Azores,NonPeak,$16.80,$34.11
+US27,West Virginia,PO01,Azores,Peak,$19.82,$40.25
+US27,West Virginia,QA,Qatar,NonPeak,$17.57,$31.63
+US27,West Virginia,QA,Qatar,Peak,$20.73,$37.32
+US27,West Virginia,RO,Romania,NonPeak,$18.33,$44.51
+US27,West Virginia,RO,Romania,Peak,$21.63,$52.52
+US27,West Virginia,RQ,Puerto Rico,NonPeak,$24.38,$34.33
+US27,West Virginia,RQ,Puerto Rico,Peak,$28.77,$40.51
+US27,West Virginia,SA,Saudi Arabia,NonPeak,$16.00,$31.74
+US27,West Virginia,SA,Saudi Arabia,Peak,$18.88,$37.45
+US27,West Virginia,SN,Singapore,NonPeak,$27.63,$44.62
+US27,West Virginia,SN,Singapore,Peak,$32.60,$52.65
+US27,West Virginia,SP,Spain,NonPeak,$29.28,$34.45
+US27,West Virginia,SP,Spain,Peak,$34.55,$40.65
+US27,West Virginia,TU,Turkey,NonPeak,$30.90,$31.91
+US27,West Virginia,TU,Turkey,Peak,$36.46,$37.65
+US27,West Virginia,UK,United Kingdom,NonPeak,$15.28,$44.74
+US27,West Virginia,UK,United Kingdom,Peak,$18.03,$52.79
+US27,West Virginia,US8030400,Alaska (Zone) IV,NonPeak,$16.05,$34.56
+US27,West Virginia,US8030400,Alaska (Zone) IV,Peak,$18.94,$40.78
+US27,West Virginia,US8050500,Alaska (Zone) III,NonPeak,$16.80,$32.09
+US27,West Virginia,US8050500,Alaska (Zone) III,Peak,$19.82,$37.87
+US27,West Virginia,US8101000,Alaska (Zone) I,NonPeak,$17.57,$44.91
+US27,West Virginia,US8101000,Alaska (Zone) I,Peak,$20.73,$52.99
+US27,West Virginia,US8190100,Alaska (Zone) II,NonPeak,$18.33,$34.74
+US27,West Virginia,US8190100,Alaska (Zone) II,Peak,$21.63,$40.99
+US27,West Virginia,US89,Hawaii,NonPeak,$24.38,$32.26
+US27,West Virginia,US89,Hawaii,Peak,$28.77,$38.07
+US27,West Virginia,UY,Uruguay,NonPeak,$16.00,$45.09
+US27,West Virginia,UY,Uruguay,Peak,$18.88,$53.21
+US27,West Virginia,VE,Venezuela,NonPeak,$27.63,$34.90
+US27,West Virginia,VE,Venezuela,Peak,$32.60,$41.18
+US28,Kentucky,AR,Argentina,NonPeak,$29.28,$32.44
+US28,Kentucky,AR,Argentina,Peak,$34.55,$38.28
+US28,Kentucky,AS11,New South Wales/Australian Capital Territory,NonPeak,$30.90,$43.94
+US28,Kentucky,AS11,New South Wales/Australian Capital Territory,Peak,$36.46,$51.85
+US28,Kentucky,AS21,Northern Territory,NonPeak,$15.28,$33.70
+US28,Kentucky,AS21,Northern Territory,Peak,$18.03,$39.77
+US28,Kentucky,BA,Bahrain,NonPeak,$16.05,$31.29
+US28,Kentucky,BA,Bahrain,Peak,$18.94,$36.92
+US28,Kentucky,BE,Belgium,NonPeak,$16.80,$44.05
+US28,Kentucky,BE,Belgium,Peak,$19.82,$51.98
+US28,Kentucky,BL,Bolivia,NonPeak,$17.57,$33.75
+US28,Kentucky,BL,Bolivia,Peak,$20.73,$39.82
+US28,Kentucky,BR,Brazil - Brazilia,NonPeak,$18.33,$31.40
+US28,Kentucky,BR,Brazil - Brazilia,Peak,$21.63,$37.05
+US28,Kentucky,CA10,Ontario,NonPeak,$24.38,$44.17
+US28,Kentucky,CA10,Ontario,Peak,$28.77,$52.12
+US28,Kentucky,CA20,Quebec,NonPeak,$16.00,$33.98
+US28,Kentucky,CA20,Quebec,Peak,$18.88,$40.10
+US28,Kentucky,CA30,Manitoba,NonPeak,$27.63,$31.45
+US28,Kentucky,CA30,Manitoba,Peak,$32.60,$37.11
+US28,Kentucky,CI,Chile,NonPeak,$29.28,$44.28
+US28,Kentucky,CI,Chile,Peak,$34.55,$52.25
+US28,Kentucky,CO,Colombia,NonPeak,$30.90,$34.11
+US28,Kentucky,CO,Colombia,Peak,$36.46,$40.25
+US28,Kentucky,CS,Costa Rica,NonPeak,$15.28,$31.63
+US28,Kentucky,CS,Costa Rica,Peak,$18.03,$37.32
+US28,Kentucky,EC,Ecuador,NonPeak,$16.05,$44.51
+US28,Kentucky,EC,Ecuador,Peak,$18.94,$52.52
+US28,Kentucky,ES,El Salvador,NonPeak,$16.80,$34.33
+US28,Kentucky,ES,El Salvador,Peak,$19.82,$40.51
+US28,Kentucky,GE,Germany,NonPeak,$17.57,$31.74
+US28,Kentucky,GE,Germany,Peak,$20.73,$37.45
+US28,Kentucky,GQ,Guam,NonPeak,$18.33,$44.62
+US28,Kentucky,GQ,Guam,Peak,$21.63,$52.65
+US28,Kentucky,GR,Greece,NonPeak,$24.38,$34.45
+US28,Kentucky,GR,Greece,Peak,$28.77,$40.65
+US28,Kentucky,GR29,Crete,NonPeak,$16.00,$31.91
+US28,Kentucky,GR29,Crete,Peak,$18.88,$37.65
+US28,Kentucky,GT,Guatemala,NonPeak,$27.63,$44.74
+US28,Kentucky,GT,Guatemala,Peak,$32.60,$52.79
+US28,Kentucky,HO,Honduras,NonPeak,$29.28,$34.56
+US28,Kentucky,HO,Honduras,Peak,$34.55,$40.78
+US28,Kentucky,HU,Hungary,NonPeak,$30.90,$32.09
+US28,Kentucky,HU,Hungary,Peak,$36.46,$37.87
+US28,Kentucky,IT,Italy,NonPeak,$15.28,$44.91
+US28,Kentucky,IT,Italy,Peak,$18.03,$52.99
+US28,Kentucky,IT10,Sicily,NonPeak,$16.05,$34.74
+US28,Kentucky,IT10,Sicily,Peak,$18.94,$40.99
+US28,Kentucky,JA01,Japan-Central,NonPeak,$16.80,$32.26
+US28,Kentucky,JA01,Japan-Central,Peak,$19.82,$38.07
+US28,Kentucky,JA02,Japan-South (Excludes Hokkaido),NonPeak,$17.57,$45.09
+US28,Kentucky,JA02,Japan-South (Excludes Hokkaido),Peak,$20.73,$53.21
+US28,Kentucky,JA03,Japan-North,NonPeak,$18.33,$34.90
+US28,Kentucky,JA03,Japan-North,Peak,$21.63,$41.18
+US28,Kentucky,JA96,Okinawa,NonPeak,$24.38,$32.44
+US28,Kentucky,JA96,Okinawa,Peak,$28.77,$38.28
+US28,Kentucky,KS,"Korea, Republic Of",NonPeak,$16.00,$43.94
+US28,Kentucky,KS,"Korea, Republic Of",Peak,$18.88,$51.85
+US28,Kentucky,KU,Kuwait,NonPeak,$27.63,$33.70
+US28,Kentucky,KU,Kuwait,Peak,$32.60,$39.77
+US28,Kentucky,NL,Netherlands,NonPeak,$29.28,$31.29
+US28,Kentucky,NL,Netherlands,Peak,$34.55,$36.92
+US28,Kentucky,NO,Norway,NonPeak,$30.90,$44.05
+US28,Kentucky,NO,Norway,Peak,$36.46,$51.98
+US28,Kentucky,PA,Paraguay,NonPeak,$15.28,$33.75
+US28,Kentucky,PA,Paraguay,Peak,$18.03,$39.82
+US28,Kentucky,PE,Peru,NonPeak,$16.05,$31.40
+US28,Kentucky,PE,Peru,Peak,$18.94,$37.05
+US28,Kentucky,PL,Poland,NonPeak,$16.80,$44.17
+US28,Kentucky,PL,Poland,Peak,$19.82,$52.12
+US28,Kentucky,PO,Portugal,NonPeak,$17.57,$33.98
+US28,Kentucky,PO,Portugal,Peak,$20.73,$40.10
+US28,Kentucky,PO01,Azores,NonPeak,$18.33,$31.45
+US28,Kentucky,PO01,Azores,Peak,$21.63,$37.11
+US28,Kentucky,QA,Qatar,NonPeak,$24.38,$44.28
+US28,Kentucky,QA,Qatar,Peak,$28.77,$52.25
+US28,Kentucky,RO,Romania,NonPeak,$16.00,$34.11
+US28,Kentucky,RO,Romania,Peak,$18.88,$40.25
+US28,Kentucky,RQ,Puerto Rico,NonPeak,$27.63,$31.63
+US28,Kentucky,RQ,Puerto Rico,Peak,$32.60,$37.32
+US28,Kentucky,SA,Saudi Arabia,NonPeak,$29.28,$44.51
+US28,Kentucky,SA,Saudi Arabia,Peak,$34.55,$52.52
+US28,Kentucky,SN,Singapore,NonPeak,$30.90,$34.33
+US28,Kentucky,SN,Singapore,Peak,$36.46,$40.51
+US28,Kentucky,SP,Spain,NonPeak,$15.28,$31.74
+US28,Kentucky,SP,Spain,Peak,$18.03,$37.45
+US28,Kentucky,TU,Turkey,NonPeak,$16.05,$44.62
+US28,Kentucky,TU,Turkey,Peak,$18.94,$52.65
+US28,Kentucky,UK,United Kingdom,NonPeak,$16.80,$34.45
+US28,Kentucky,UK,United Kingdom,Peak,$19.82,$40.65
+US28,Kentucky,US8030400,Alaska (Zone) IV,NonPeak,$17.57,$31.91
+US28,Kentucky,US8030400,Alaska (Zone) IV,Peak,$20.73,$37.65
+US28,Kentucky,US8050500,Alaska (Zone) III,NonPeak,$18.33,$44.74
+US28,Kentucky,US8050500,Alaska (Zone) III,Peak,$21.63,$52.79
+US28,Kentucky,US8101000,Alaska (Zone) I,NonPeak,$24.38,$34.56
+US28,Kentucky,US8101000,Alaska (Zone) I,Peak,$28.77,$40.78
+US28,Kentucky,US8190100,Alaska (Zone) II,NonPeak,$16.00,$32.09
+US28,Kentucky,US8190100,Alaska (Zone) II,Peak,$18.88,$37.87
+US28,Kentucky,US89,Hawaii,NonPeak,$27.63,$44.91
+US28,Kentucky,US89,Hawaii,Peak,$32.60,$52.99
+US28,Kentucky,UY,Uruguay,NonPeak,$29.28,$34.74
+US28,Kentucky,UY,Uruguay,Peak,$34.55,$40.99
+US28,Kentucky,VE,Venezuela,NonPeak,$30.90,$32.26
+US28,Kentucky,VE,Venezuela,Peak,$36.46,$38.07
+US30,Michigan,AR,Argentina,NonPeak,$15.28,$45.09
+US30,Michigan,AR,Argentina,Peak,$18.03,$53.21
+US30,Michigan,AS11,New South Wales/Australian Capital Territory,NonPeak,$16.05,$34.90
+US30,Michigan,AS11,New South Wales/Australian Capital Territory,Peak,$18.94,$41.18
+US30,Michigan,AS21,Northern Territory,NonPeak,$16.80,$32.44
+US30,Michigan,AS21,Northern Territory,Peak,$19.82,$38.28
+US30,Michigan,BA,Bahrain,NonPeak,$17.57,$43.94
+US30,Michigan,BA,Bahrain,Peak,$20.73,$51.85
+US30,Michigan,BE,Belgium,NonPeak,$18.33,$33.70
+US30,Michigan,BE,Belgium,Peak,$21.63,$39.77
+US30,Michigan,BL,Bolivia,NonPeak,$24.38,$31.29
+US30,Michigan,BL,Bolivia,Peak,$28.77,$36.92
+US30,Michigan,BR,Brazil - Brazilia,NonPeak,$16.00,$44.05
+US30,Michigan,BR,Brazil - Brazilia,Peak,$18.88,$51.98
+US30,Michigan,CA10,Ontario,NonPeak,$27.63,$33.75
+US30,Michigan,CA10,Ontario,Peak,$32.60,$39.82
+US30,Michigan,CA20,Quebec,NonPeak,$29.28,$31.40
+US30,Michigan,CA20,Quebec,Peak,$34.55,$37.05
+US30,Michigan,CA30,Manitoba,NonPeak,$30.90,$44.17
+US30,Michigan,CA30,Manitoba,Peak,$36.46,$52.12
+US30,Michigan,CI,Chile,NonPeak,$15.28,$33.98
+US30,Michigan,CI,Chile,Peak,$18.03,$40.10
+US30,Michigan,CO,Colombia,NonPeak,$16.05,$31.45
+US30,Michigan,CO,Colombia,Peak,$18.94,$37.11
+US30,Michigan,CS,Costa Rica,NonPeak,$16.80,$44.28
+US30,Michigan,CS,Costa Rica,Peak,$19.82,$52.25
+US30,Michigan,EC,Ecuador,NonPeak,$17.57,$34.11
+US30,Michigan,EC,Ecuador,Peak,$20.73,$40.25
+US30,Michigan,ES,El Salvador,NonPeak,$18.33,$31.63
+US30,Michigan,ES,El Salvador,Peak,$21.63,$37.32
+US30,Michigan,GE,Germany,NonPeak,$24.38,$44.51
+US30,Michigan,GE,Germany,Peak,$28.77,$52.52
+US30,Michigan,GQ,Guam,NonPeak,$16.00,$34.33
+US30,Michigan,GQ,Guam,Peak,$18.88,$40.51
+US30,Michigan,GR,Greece,NonPeak,$27.63,$31.74
+US30,Michigan,GR,Greece,Peak,$32.60,$37.45
+US30,Michigan,GR29,Crete,NonPeak,$29.28,$44.62
+US30,Michigan,GR29,Crete,Peak,$34.55,$52.65
+US30,Michigan,GT,Guatemala,NonPeak,$30.90,$34.45
+US30,Michigan,GT,Guatemala,Peak,$36.46,$40.65
+US30,Michigan,HO,Honduras,NonPeak,$15.28,$31.91
+US30,Michigan,HO,Honduras,Peak,$18.03,$37.65
+US30,Michigan,HU,Hungary,NonPeak,$16.05,$44.74
+US30,Michigan,HU,Hungary,Peak,$18.94,$52.79
+US30,Michigan,IT,Italy,NonPeak,$16.80,$34.56
+US30,Michigan,IT,Italy,Peak,$19.82,$40.78
+US30,Michigan,IT10,Sicily,NonPeak,$17.57,$32.09
+US30,Michigan,IT10,Sicily,Peak,$20.73,$37.87
+US30,Michigan,JA01,Japan-Central,NonPeak,$18.33,$44.91
+US30,Michigan,JA01,Japan-Central,Peak,$21.63,$52.99
+US30,Michigan,JA02,Japan-South (Excludes Hokkaido),NonPeak,$24.38,$34.74
+US30,Michigan,JA02,Japan-South (Excludes Hokkaido),Peak,$28.77,$40.99
+US30,Michigan,JA03,Japan-North,NonPeak,$16.00,$32.26
+US30,Michigan,JA03,Japan-North,Peak,$18.88,$38.07
+US30,Michigan,JA96,Okinawa,NonPeak,$27.63,$45.09
+US30,Michigan,JA96,Okinawa,Peak,$32.60,$53.21
+US30,Michigan,KS,"Korea, Republic Of",NonPeak,$29.28,$34.90
+US30,Michigan,KS,"Korea, Republic Of",Peak,$34.55,$41.18
+US30,Michigan,KU,Kuwait,NonPeak,$30.90,$32.44
+US30,Michigan,KU,Kuwait,Peak,$36.46,$38.28
+US30,Michigan,NL,Netherlands,NonPeak,$15.28,$43.94
+US30,Michigan,NL,Netherlands,Peak,$18.03,$51.85
+US30,Michigan,NO,Norway,NonPeak,$16.05,$33.70
+US30,Michigan,NO,Norway,Peak,$18.94,$39.77
+US30,Michigan,PA,Paraguay,NonPeak,$16.80,$31.29
+US30,Michigan,PA,Paraguay,Peak,$19.82,$36.92
+US30,Michigan,PE,Peru,NonPeak,$17.57,$44.05
+US30,Michigan,PE,Peru,Peak,$20.73,$51.98
+US30,Michigan,PL,Poland,NonPeak,$18.33,$33.75
+US30,Michigan,PL,Poland,Peak,$21.63,$39.82
+US30,Michigan,PO,Portugal,NonPeak,$24.38,$31.40
+US30,Michigan,PO,Portugal,Peak,$28.77,$37.05
+US30,Michigan,PO01,Azores,NonPeak,$16.00,$44.17
+US30,Michigan,PO01,Azores,Peak,$18.88,$52.12
+US30,Michigan,QA,Qatar,NonPeak,$27.63,$33.98
+US30,Michigan,QA,Qatar,Peak,$32.60,$40.10
+US30,Michigan,RO,Romania,NonPeak,$29.28,$31.45
+US30,Michigan,RO,Romania,Peak,$34.55,$37.11
+US30,Michigan,RQ,Puerto Rico,NonPeak,$30.90,$44.28
+US30,Michigan,RQ,Puerto Rico,Peak,$36.46,$52.25
+US30,Michigan,SA,Saudi Arabia,NonPeak,$15.28,$34.11
+US30,Michigan,SA,Saudi Arabia,Peak,$18.03,$40.25
+US30,Michigan,SN,Singapore,NonPeak,$16.05,$31.63
+US30,Michigan,SN,Singapore,Peak,$18.94,$37.32
+US30,Michigan,SP,Spain,NonPeak,$16.80,$44.51
+US30,Michigan,SP,Spain,Peak,$19.82,$52.52
+US30,Michigan,TU,Turkey,NonPeak,$17.57,$34.33
+US30,Michigan,TU,Turkey,Peak,$20.73,$40.51
+US30,Michigan,UK,United Kingdom,NonPeak,$18.33,$31.74
+US30,Michigan,UK,United Kingdom,Peak,$21.63,$37.45
+US30,Michigan,US8030400,Alaska (Zone) IV,NonPeak,$24.38,$44.62
+US30,Michigan,US8030400,Alaska (Zone) IV,Peak,$28.77,$52.65
+US30,Michigan,US8050500,Alaska (Zone) III,NonPeak,$16.00,$34.45
+US30,Michigan,US8050500,Alaska (Zone) III,Peak,$18.88,$40.65
+US30,Michigan,US8101000,Alaska (Zone) I,NonPeak,$27.63,$31.91
+US30,Michigan,US8101000,Alaska (Zone) I,Peak,$32.60,$37.65
+US30,Michigan,US8190100,Alaska (Zone) II,NonPeak,$29.28,$44.74
+US30,Michigan,US8190100,Alaska (Zone) II,Peak,$34.55,$52.79
+US30,Michigan,US89,Hawaii,NonPeak,$30.90,$34.56
+US30,Michigan,US89,Hawaii,Peak,$36.46,$40.78
+US30,Michigan,UY,Uruguay,NonPeak,$15.28,$32.09
+US30,Michigan,UY,Uruguay,Peak,$18.03,$37.87
+US30,Michigan,VE,Venezuela,NonPeak,$16.05,$44.91
+US30,Michigan,VE,Venezuela,Peak,$18.94,$52.99
+US32,Wisconsin,AR,Argentina,NonPeak,$16.80,$34.74
+US32,Wisconsin,AR,Argentina,Peak,$19.82,$40.99
+US32,Wisconsin,AS11,New South Wales/Australian Capital Territory,NonPeak,$17.57,$32.26
+US32,Wisconsin,AS11,New South Wales/Australian Capital Territory,Peak,$20.73,$38.07
+US32,Wisconsin,AS21,Northern Territory,NonPeak,$18.33,$45.09
+US32,Wisconsin,AS21,Northern Territory,Peak,$21.63,$53.21
+US32,Wisconsin,BA,Bahrain,NonPeak,$24.38,$34.90
+US32,Wisconsin,BA,Bahrain,Peak,$28.77,$41.18
+US32,Wisconsin,BE,Belgium,NonPeak,$16.00,$32.44
+US32,Wisconsin,BE,Belgium,Peak,$18.88,$38.28
+US32,Wisconsin,BL,Bolivia,NonPeak,$27.63,$43.94
+US32,Wisconsin,BL,Bolivia,Peak,$32.60,$51.85
+US32,Wisconsin,BR,Brazil - Brazilia,NonPeak,$29.28,$33.70
+US32,Wisconsin,BR,Brazil - Brazilia,Peak,$34.55,$39.77
+US32,Wisconsin,CA10,Ontario,NonPeak,$30.90,$31.29
+US32,Wisconsin,CA10,Ontario,Peak,$36.46,$36.92
+US32,Wisconsin,CA20,Quebec,NonPeak,$15.28,$44.05
+US32,Wisconsin,CA20,Quebec,Peak,$18.03,$51.98
+US32,Wisconsin,CA30,Manitoba,NonPeak,$16.05,$33.75
+US32,Wisconsin,CA30,Manitoba,Peak,$18.94,$39.82
+US32,Wisconsin,CI,Chile,NonPeak,$16.80,$31.40
+US32,Wisconsin,CI,Chile,Peak,$19.82,$37.05
+US32,Wisconsin,CO,Colombia,NonPeak,$17.57,$44.17
+US32,Wisconsin,CO,Colombia,Peak,$20.73,$52.12
+US32,Wisconsin,CS,Costa Rica,NonPeak,$18.33,$33.98
+US32,Wisconsin,CS,Costa Rica,Peak,$21.63,$40.10
+US32,Wisconsin,EC,Ecuador,NonPeak,$24.38,$31.45
+US32,Wisconsin,EC,Ecuador,Peak,$28.77,$37.11
+US32,Wisconsin,ES,El Salvador,NonPeak,$16.00,$44.28
+US32,Wisconsin,ES,El Salvador,Peak,$18.88,$52.25
+US32,Wisconsin,GE,Germany,NonPeak,$27.63,$34.11
+US32,Wisconsin,GE,Germany,Peak,$32.60,$40.25
+US32,Wisconsin,GQ,Guam,NonPeak,$29.28,$31.63
+US32,Wisconsin,GQ,Guam,Peak,$34.55,$37.32
+US32,Wisconsin,GR,Greece,NonPeak,$30.90,$44.51
+US32,Wisconsin,GR,Greece,Peak,$36.46,$52.52
+US32,Wisconsin,GR29,Crete,NonPeak,$15.28,$34.33
+US32,Wisconsin,GR29,Crete,Peak,$18.03,$40.51
+US32,Wisconsin,GT,Guatemala,NonPeak,$16.05,$31.74
+US32,Wisconsin,GT,Guatemala,Peak,$18.94,$37.45
+US32,Wisconsin,HO,Honduras,NonPeak,$16.80,$44.62
+US32,Wisconsin,HO,Honduras,Peak,$19.82,$52.65
+US32,Wisconsin,HU,Hungary,NonPeak,$17.57,$34.45
+US32,Wisconsin,HU,Hungary,Peak,$20.73,$40.65
+US32,Wisconsin,IT,Italy,NonPeak,$18.33,$31.91
+US32,Wisconsin,IT,Italy,Peak,$21.63,$37.65
+US32,Wisconsin,IT10,Sicily,NonPeak,$24.38,$44.74
+US32,Wisconsin,IT10,Sicily,Peak,$28.77,$52.79
+US32,Wisconsin,JA01,Japan-Central,NonPeak,$16.00,$34.56
+US32,Wisconsin,JA01,Japan-Central,Peak,$18.88,$40.78
+US32,Wisconsin,JA02,Japan-South (Excludes Hokkaido),NonPeak,$27.63,$32.09
+US32,Wisconsin,JA02,Japan-South (Excludes Hokkaido),Peak,$32.60,$37.87
+US32,Wisconsin,JA03,Japan-North,NonPeak,$29.28,$44.91
+US32,Wisconsin,JA03,Japan-North,Peak,$34.55,$52.99
+US32,Wisconsin,JA96,Okinawa,NonPeak,$30.90,$34.74
+US32,Wisconsin,JA96,Okinawa,Peak,$36.46,$40.99
+US32,Wisconsin,KS,"Korea, Republic Of",NonPeak,$15.28,$32.26
+US32,Wisconsin,KS,"Korea, Republic Of",Peak,$18.03,$38.07
+US32,Wisconsin,KU,Kuwait,NonPeak,$16.05,$45.09
+US32,Wisconsin,KU,Kuwait,Peak,$18.94,$53.21
+US32,Wisconsin,NL,Netherlands,NonPeak,$16.80,$34.90
+US32,Wisconsin,NL,Netherlands,Peak,$19.82,$41.18
+US32,Wisconsin,NO,Norway,NonPeak,$17.57,$32.44
+US32,Wisconsin,NO,Norway,Peak,$20.73,$38.28
+US32,Wisconsin,PA,Paraguay,NonPeak,$18.33,$43.94
+US32,Wisconsin,PA,Paraguay,Peak,$21.63,$51.85
+US32,Wisconsin,PE,Peru,NonPeak,$24.38,$33.70
+US32,Wisconsin,PE,Peru,Peak,$28.77,$39.77
+US32,Wisconsin,PL,Poland,NonPeak,$16.00,$31.29
+US32,Wisconsin,PL,Poland,Peak,$18.88,$36.92
+US32,Wisconsin,PO,Portugal,NonPeak,$27.63,$44.05
+US32,Wisconsin,PO,Portugal,Peak,$32.60,$51.98
+US32,Wisconsin,PO01,Azores,NonPeak,$29.28,$33.75
+US32,Wisconsin,PO01,Azores,Peak,$34.55,$39.82
+US32,Wisconsin,QA,Qatar,NonPeak,$30.90,$31.40
+US32,Wisconsin,QA,Qatar,Peak,$36.46,$37.05
+US32,Wisconsin,RO,Romania,NonPeak,$15.28,$44.17
+US32,Wisconsin,RO,Romania,Peak,$18.03,$52.12
+US32,Wisconsin,RQ,Puerto Rico,NonPeak,$16.05,$33.98
+US32,Wisconsin,RQ,Puerto Rico,Peak,$18.94,$40.10
+US32,Wisconsin,SA,Saudi Arabia,NonPeak,$16.80,$31.45
+US32,Wisconsin,SA,Saudi Arabia,Peak,$19.82,$37.11
+US32,Wisconsin,SN,Singapore,NonPeak,$17.57,$44.28
+US32,Wisconsin,SN,Singapore,Peak,$20.73,$52.25
+US32,Wisconsin,SP,Spain,NonPeak,$18.33,$34.11
+US32,Wisconsin,SP,Spain,Peak,$21.63,$40.25
+US32,Wisconsin,TU,Turkey,NonPeak,$24.38,$31.63
+US32,Wisconsin,TU,Turkey,Peak,$28.77,$37.32
+US32,Wisconsin,UK,United Kingdom,NonPeak,$16.00,$44.51
+US32,Wisconsin,UK,United Kingdom,Peak,$18.88,$52.52
+US32,Wisconsin,US8030400,Alaska (Zone) IV,NonPeak,$27.63,$34.33
+US32,Wisconsin,US8030400,Alaska (Zone) IV,Peak,$32.60,$40.51
+US32,Wisconsin,US8050500,Alaska (Zone) III,NonPeak,$29.28,$31.74
+US32,Wisconsin,US8050500,Alaska (Zone) III,Peak,$34.55,$37.45
+US32,Wisconsin,US8101000,Alaska (Zone) I,NonPeak,$30.90,$44.62
+US32,Wisconsin,US8101000,Alaska (Zone) I,Peak,$36.46,$52.65
+US32,Wisconsin,US8190100,Alaska (Zone) II,NonPeak,$15.28,$34.45
+US32,Wisconsin,US8190100,Alaska (Zone) II,Peak,$18.03,$40.65
+US32,Wisconsin,US89,Hawaii,NonPeak,$16.05,$31.91
+US32,Wisconsin,US89,Hawaii,Peak,$18.94,$37.65
+US32,Wisconsin,UY,Uruguay,NonPeak,$16.80,$44.74
+US32,Wisconsin,UY,Uruguay,Peak,$19.82,$52.79
+US32,Wisconsin,VE,Venezuela,NonPeak,$17.57,$34.56
+US32,Wisconsin,VE,Venezuela,Peak,$20.73,$40.78
+US34,Ohio,AR,Argentina,NonPeak,$18.33,$32.09
+US34,Ohio,AR,Argentina,Peak,$21.63,$37.87
+US34,Ohio,AS11,New South Wales/Australian Capital Territory,NonPeak,$24.38,$44.91
+US34,Ohio,AS11,New South Wales/Australian Capital Territory,Peak,$28.77,$52.99
+US34,Ohio,AS21,Northern Territory,NonPeak,$16.00,$34.74
+US34,Ohio,AS21,Northern Territory,Peak,$18.88,$40.99
+US34,Ohio,BA,Bahrain,NonPeak,$27.63,$32.26
+US34,Ohio,BA,Bahrain,Peak,$32.60,$38.07
+US34,Ohio,BE,Belgium,NonPeak,$29.28,$45.09
+US34,Ohio,BE,Belgium,Peak,$34.55,$53.21
+US34,Ohio,BL,Bolivia,NonPeak,$30.90,$34.90
+US34,Ohio,BL,Bolivia,Peak,$36.46,$41.18
+US34,Ohio,BR,Brazil - Brazilia,NonPeak,$15.28,$32.44
+US34,Ohio,BR,Brazil - Brazilia,Peak,$18.03,$38.28
+US34,Ohio,CA10,Ontario,NonPeak,$16.05,$43.94
+US34,Ohio,CA10,Ontario,Peak,$18.94,$51.85
+US34,Ohio,CA20,Quebec,NonPeak,$16.80,$33.70
+US34,Ohio,CA20,Quebec,Peak,$19.82,$39.77
+US34,Ohio,CA30,Manitoba,NonPeak,$17.57,$31.29
+US34,Ohio,CA30,Manitoba,Peak,$20.73,$36.92
+US34,Ohio,CI,Chile,NonPeak,$18.33,$44.05
+US34,Ohio,CI,Chile,Peak,$21.63,$51.98
+US34,Ohio,CO,Colombia,NonPeak,$24.38,$33.75
+US34,Ohio,CO,Colombia,Peak,$28.77,$39.82
+US34,Ohio,CS,Costa Rica,NonPeak,$16.00,$31.40
+US34,Ohio,CS,Costa Rica,Peak,$18.88,$37.05
+US34,Ohio,EC,Ecuador,NonPeak,$27.63,$44.17
+US34,Ohio,EC,Ecuador,Peak,$32.60,$52.12
+US34,Ohio,ES,El Salvador,NonPeak,$29.28,$33.98
+US34,Ohio,ES,El Salvador,Peak,$34.55,$40.10
+US34,Ohio,GE,Germany,NonPeak,$30.90,$31.45
+US34,Ohio,GE,Germany,Peak,$36.46,$37.11
+US34,Ohio,GQ,Guam,NonPeak,$15.28,$44.28
+US34,Ohio,GQ,Guam,Peak,$18.03,$52.25
+US34,Ohio,GR,Greece,NonPeak,$16.05,$34.11
+US34,Ohio,GR,Greece,Peak,$18.94,$40.25
+US34,Ohio,GR29,Crete,NonPeak,$16.80,$31.63
+US34,Ohio,GR29,Crete,Peak,$19.82,$37.32
+US34,Ohio,GT,Guatemala,NonPeak,$17.57,$44.51
+US34,Ohio,GT,Guatemala,Peak,$20.73,$52.52
+US34,Ohio,HO,Honduras,NonPeak,$18.33,$34.33
+US34,Ohio,HO,Honduras,Peak,$21.63,$40.51
+US34,Ohio,HU,Hungary,NonPeak,$24.38,$31.74
+US34,Ohio,HU,Hungary,Peak,$28.77,$37.45
+US34,Ohio,IT,Italy,NonPeak,$16.00,$44.62
+US34,Ohio,IT,Italy,Peak,$18.88,$52.65
+US34,Ohio,IT10,Sicily,NonPeak,$27.63,$34.45
+US34,Ohio,IT10,Sicily,Peak,$32.60,$40.65
+US34,Ohio,JA01,Japan-Central,NonPeak,$29.28,$31.91
+US34,Ohio,JA01,Japan-Central,Peak,$34.55,$37.65
+US34,Ohio,JA02,Japan-South (Excludes Hokkaido),NonPeak,$30.90,$44.74
+US34,Ohio,JA02,Japan-South (Excludes Hokkaido),Peak,$36.46,$52.79
+US34,Ohio,JA03,Japan-North,NonPeak,$15.28,$34.56
+US34,Ohio,JA03,Japan-North,Peak,$18.03,$40.78
+US34,Ohio,JA96,Okinawa,NonPeak,$16.05,$32.09
+US34,Ohio,JA96,Okinawa,Peak,$18.94,$37.87
+US34,Ohio,KS,"Korea, Republic Of",NonPeak,$16.80,$44.91
+US34,Ohio,KS,"Korea, Republic Of",Peak,$19.82,$52.99
+US34,Ohio,KU,Kuwait,NonPeak,$17.57,$34.74
+US34,Ohio,KU,Kuwait,Peak,$20.73,$40.99
+US34,Ohio,NL,Netherlands,NonPeak,$18.33,$32.26
+US34,Ohio,NL,Netherlands,Peak,$21.63,$38.07
+US34,Ohio,NO,Norway,NonPeak,$24.38,$45.09
+US34,Ohio,NO,Norway,Peak,$28.77,$53.21
+US34,Ohio,PA,Paraguay,NonPeak,$16.00,$34.90
+US34,Ohio,PA,Paraguay,Peak,$18.88,$41.18
+US34,Ohio,PE,Peru,NonPeak,$27.63,$32.44
+US34,Ohio,PE,Peru,Peak,$32.60,$38.28
+US34,Ohio,PL,Poland,NonPeak,$29.28,$43.94
+US34,Ohio,PL,Poland,Peak,$34.55,$51.85
+US34,Ohio,PO,Portugal,NonPeak,$30.90,$33.70
+US34,Ohio,PO,Portugal,Peak,$36.46,$39.77
+US34,Ohio,PO01,Azores,NonPeak,$15.28,$31.29
+US34,Ohio,PO01,Azores,Peak,$18.03,$36.92
+US34,Ohio,QA,Qatar,NonPeak,$16.05,$44.05
+US34,Ohio,QA,Qatar,Peak,$18.94,$51.98
+US34,Ohio,RO,Romania,NonPeak,$16.80,$33.75
+US34,Ohio,RO,Romania,Peak,$19.82,$39.82
+US34,Ohio,RQ,Puerto Rico,NonPeak,$17.57,$31.40
+US34,Ohio,RQ,Puerto Rico,Peak,$20.73,$37.05
+US34,Ohio,SA,Saudi Arabia,NonPeak,$18.33,$44.17
+US34,Ohio,SA,Saudi Arabia,Peak,$21.63,$52.12
+US34,Ohio,SN,Singapore,NonPeak,$24.38,$33.98
+US34,Ohio,SN,Singapore,Peak,$28.77,$40.10
+US34,Ohio,SP,Spain,NonPeak,$16.00,$31.45
+US34,Ohio,SP,Spain,Peak,$18.88,$37.11
+US34,Ohio,TU,Turkey,NonPeak,$27.63,$44.28
+US34,Ohio,TU,Turkey,Peak,$32.60,$52.25
+US34,Ohio,UK,United Kingdom,NonPeak,$29.28,$34.11
+US34,Ohio,UK,United Kingdom,Peak,$34.55,$40.25
+US34,Ohio,US8030400,Alaska (Zone) IV,NonPeak,$30.90,$31.63
+US34,Ohio,US8030400,Alaska (Zone) IV,Peak,$36.46,$37.32
+US34,Ohio,US8050500,Alaska (Zone) III,NonPeak,$15.28,$44.51
+US34,Ohio,US8050500,Alaska (Zone) III,Peak,$18.03,$52.52
+US34,Ohio,US8101000,Alaska (Zone) I,NonPeak,$16.05,$34.33
+US34,Ohio,US8101000,Alaska (Zone) I,Peak,$18.94,$40.51
+US34,Ohio,US8190100,Alaska (Zone) II,NonPeak,$16.80,$31.74
+US34,Ohio,US8190100,Alaska (Zone) II,Peak,$19.82,$37.45
+US34,Ohio,US89,Hawaii,NonPeak,$17.57,$44.62
+US34,Ohio,US89,Hawaii,Peak,$20.73,$52.65
+US34,Ohio,UY,Uruguay,NonPeak,$18.33,$34.45
+US34,Ohio,UY,Uruguay,Peak,$21.63,$40.65
+US34,Ohio,VE,Venezuela,NonPeak,$24.38,$31.91
+US34,Ohio,VE,Venezuela,Peak,$28.77,$37.65
+US36,Indiana,AR,Argentina,NonPeak,$16.00,$44.74
+US36,Indiana,AR,Argentina,Peak,$18.88,$52.79
+US36,Indiana,AS11,New South Wales/Australian Capital Territory,NonPeak,$27.63,$34.56
+US36,Indiana,AS11,New South Wales/Australian Capital Territory,Peak,$32.60,$40.78
+US36,Indiana,AS21,Northern Territory,NonPeak,$29.28,$32.09
+US36,Indiana,AS21,Northern Territory,Peak,$34.55,$37.87
+US36,Indiana,BA,Bahrain,NonPeak,$30.90,$44.91
+US36,Indiana,BA,Bahrain,Peak,$36.46,$52.99
+US36,Indiana,BE,Belgium,NonPeak,$15.28,$34.74
+US36,Indiana,BE,Belgium,Peak,$18.03,$40.99
+US36,Indiana,BL,Bolivia,NonPeak,$16.05,$32.26
+US36,Indiana,BL,Bolivia,Peak,$18.94,$38.07
+US36,Indiana,BR,Brazil - Brazilia,NonPeak,$16.80,$45.09
+US36,Indiana,BR,Brazil - Brazilia,Peak,$19.82,$53.21
+US36,Indiana,CA10,Ontario,NonPeak,$17.57,$34.90
+US36,Indiana,CA10,Ontario,Peak,$20.73,$41.18
+US36,Indiana,CA20,Quebec,NonPeak,$18.33,$32.44
+US36,Indiana,CA20,Quebec,Peak,$21.63,$38.28
+US36,Indiana,CA30,Manitoba,NonPeak,$24.38,$43.94
+US36,Indiana,CA30,Manitoba,Peak,$28.77,$51.85
+US36,Indiana,CI,Chile,NonPeak,$16.00,$33.70
+US36,Indiana,CI,Chile,Peak,$18.88,$39.77
+US36,Indiana,CO,Colombia,NonPeak,$27.63,$31.29
+US36,Indiana,CO,Colombia,Peak,$32.60,$36.92
+US36,Indiana,CS,Costa Rica,NonPeak,$29.28,$44.05
+US36,Indiana,CS,Costa Rica,Peak,$34.55,$51.98
+US36,Indiana,EC,Ecuador,NonPeak,$30.90,$33.75
+US36,Indiana,EC,Ecuador,Peak,$36.46,$39.82
+US36,Indiana,ES,El Salvador,NonPeak,$15.28,$31.40
+US36,Indiana,ES,El Salvador,Peak,$18.03,$37.05
+US36,Indiana,GE,Germany,NonPeak,$16.05,$44.17
+US36,Indiana,GE,Germany,Peak,$18.94,$52.12
+US36,Indiana,GQ,Guam,NonPeak,$16.80,$33.98
+US36,Indiana,GQ,Guam,Peak,$19.82,$40.10
+US36,Indiana,GR,Greece,NonPeak,$17.57,$31.45
+US36,Indiana,GR,Greece,Peak,$20.73,$37.11
+US36,Indiana,GR29,Crete,NonPeak,$18.33,$44.28
+US36,Indiana,GR29,Crete,Peak,$21.63,$52.25
+US36,Indiana,GT,Guatemala,NonPeak,$24.38,$34.11
+US36,Indiana,GT,Guatemala,Peak,$28.77,$40.25
+US36,Indiana,HO,Honduras,NonPeak,$16.00,$31.63
+US36,Indiana,HO,Honduras,Peak,$18.88,$37.32
+US36,Indiana,HU,Hungary,NonPeak,$27.63,$44.51
+US36,Indiana,HU,Hungary,Peak,$32.60,$52.52
+US36,Indiana,IT,Italy,NonPeak,$29.28,$34.33
+US36,Indiana,IT,Italy,Peak,$34.55,$40.51
+US36,Indiana,IT10,Sicily,NonPeak,$30.90,$31.74
+US36,Indiana,IT10,Sicily,Peak,$36.46,$37.45
+US36,Indiana,JA01,Japan-Central,NonPeak,$15.28,$44.62
+US36,Indiana,JA01,Japan-Central,Peak,$18.03,$52.65
+US36,Indiana,JA02,Japan-South (Excludes Hokkaido),NonPeak,$16.05,$34.45
+US36,Indiana,JA02,Japan-South (Excludes Hokkaido),Peak,$18.94,$40.65
+US36,Indiana,JA03,Japan-North,NonPeak,$16.80,$31.91
+US36,Indiana,JA03,Japan-North,Peak,$19.82,$37.65
+US36,Indiana,JA96,Okinawa,NonPeak,$17.57,$44.74
+US36,Indiana,JA96,Okinawa,Peak,$20.73,$52.79
+US36,Indiana,KS,"Korea, Republic Of",NonPeak,$18.33,$34.56
+US36,Indiana,KS,"Korea, Republic Of",Peak,$21.63,$40.78
+US36,Indiana,KU,Kuwait,NonPeak,$24.38,$32.09
+US36,Indiana,KU,Kuwait,Peak,$28.77,$37.87
+US36,Indiana,NL,Netherlands,NonPeak,$16.00,$44.91
+US36,Indiana,NL,Netherlands,Peak,$18.88,$52.99
+US36,Indiana,NO,Norway,NonPeak,$27.63,$34.74
+US36,Indiana,NO,Norway,Peak,$32.60,$40.99
+US36,Indiana,PA,Paraguay,NonPeak,$29.28,$32.26
+US36,Indiana,PA,Paraguay,Peak,$34.55,$38.07
+US36,Indiana,PE,Peru,NonPeak,$30.90,$45.09
+US36,Indiana,PE,Peru,Peak,$36.46,$53.21
+US36,Indiana,PL,Poland,NonPeak,$15.28,$34.90
+US36,Indiana,PL,Poland,Peak,$18.03,$41.18
+US36,Indiana,PO,Portugal,NonPeak,$16.05,$32.44
+US36,Indiana,PO,Portugal,Peak,$18.94,$38.28
+US36,Indiana,PO01,Azores,NonPeak,$16.80,$43.94
+US36,Indiana,PO01,Azores,Peak,$19.82,$51.85
+US36,Indiana,QA,Qatar,NonPeak,$17.57,$33.70
+US36,Indiana,QA,Qatar,Peak,$20.73,$39.77
+US36,Indiana,RO,Romania,NonPeak,$18.33,$31.29
+US36,Indiana,RO,Romania,Peak,$21.63,$36.92
+US36,Indiana,RQ,Puerto Rico,NonPeak,$24.38,$44.05
+US36,Indiana,RQ,Puerto Rico,Peak,$28.77,$51.98
+US36,Indiana,SA,Saudi Arabia,NonPeak,$16.00,$33.75
+US36,Indiana,SA,Saudi Arabia,Peak,$18.88,$39.82
+US36,Indiana,SN,Singapore,NonPeak,$27.63,$31.40
+US36,Indiana,SN,Singapore,Peak,$32.60,$37.05
+US36,Indiana,SP,Spain,NonPeak,$29.28,$44.17
+US36,Indiana,SP,Spain,Peak,$34.55,$52.12
+US36,Indiana,TU,Turkey,NonPeak,$30.90,$33.98
+US36,Indiana,TU,Turkey,Peak,$36.46,$40.10
+US36,Indiana,UK,United Kingdom,NonPeak,$15.28,$31.45
+US36,Indiana,UK,United Kingdom,Peak,$18.03,$37.11
+US36,Indiana,US8030400,Alaska (Zone) IV,NonPeak,$16.05,$44.28
+US36,Indiana,US8030400,Alaska (Zone) IV,Peak,$18.94,$52.25
+US36,Indiana,US8050500,Alaska (Zone) III,NonPeak,$16.80,$34.11
+US36,Indiana,US8050500,Alaska (Zone) III,Peak,$19.82,$40.25
+US36,Indiana,US8101000,Alaska (Zone) I,NonPeak,$17.57,$31.63
+US36,Indiana,US8101000,Alaska (Zone) I,Peak,$20.73,$37.32
+US36,Indiana,US8190100,Alaska (Zone) II,NonPeak,$18.33,$44.51
+US36,Indiana,US8190100,Alaska (Zone) II,Peak,$21.63,$52.52
+US36,Indiana,US89,Hawaii,NonPeak,$24.38,$34.33
+US36,Indiana,US89,Hawaii,Peak,$28.77,$40.51
+US36,Indiana,UY,Uruguay,NonPeak,$16.00,$31.74
+US36,Indiana,UY,Uruguay,Peak,$18.88,$37.45
+US36,Indiana,VE,Venezuela,NonPeak,$27.63,$44.62
+US36,Indiana,VE,Venezuela,Peak,$32.60,$52.65
+US38,Illinois,AR,Argentina,NonPeak,$29.28,$34.45
+US38,Illinois,AR,Argentina,Peak,$34.55,$40.65
+US38,Illinois,AS11,New South Wales/Australian Capital Territory,NonPeak,$30.90,$31.91
+US38,Illinois,AS11,New South Wales/Australian Capital Territory,Peak,$36.46,$37.65
+US38,Illinois,AS21,Northern Territory,NonPeak,$15.28,$44.74
+US38,Illinois,AS21,Northern Territory,Peak,$18.03,$52.79
+US38,Illinois,BA,Bahrain,NonPeak,$16.05,$34.56
+US38,Illinois,BA,Bahrain,Peak,$18.94,$40.78
+US38,Illinois,BE,Belgium,NonPeak,$16.80,$32.09
+US38,Illinois,BE,Belgium,Peak,$19.82,$37.87
+US38,Illinois,BL,Bolivia,NonPeak,$17.57,$44.91
+US38,Illinois,BL,Bolivia,Peak,$20.73,$52.99
+US38,Illinois,BR,Brazil - Brazilia,NonPeak,$18.33,$34.74
+US38,Illinois,BR,Brazil - Brazilia,Peak,$21.63,$40.99
+US38,Illinois,CA10,Ontario,NonPeak,$24.38,$32.26
+US38,Illinois,CA10,Ontario,Peak,$28.77,$38.07
+US38,Illinois,CA20,Quebec,NonPeak,$16.00,$45.09
+US38,Illinois,CA20,Quebec,Peak,$18.88,$53.21
+US38,Illinois,CA30,Manitoba,NonPeak,$27.63,$34.90
+US38,Illinois,CA30,Manitoba,Peak,$32.60,$41.18
+US38,Illinois,CI,Chile,NonPeak,$29.28,$32.44
+US38,Illinois,CI,Chile,Peak,$34.55,$38.28
+US38,Illinois,CO,Colombia,NonPeak,$30.90,$43.94
+US38,Illinois,CO,Colombia,Peak,$36.46,$51.85
+US38,Illinois,CS,Costa Rica,NonPeak,$15.28,$33.70
+US38,Illinois,CS,Costa Rica,Peak,$18.03,$39.77
+US38,Illinois,EC,Ecuador,NonPeak,$16.05,$31.29
+US38,Illinois,EC,Ecuador,Peak,$18.94,$36.92
+US38,Illinois,ES,El Salvador,NonPeak,$16.80,$44.05
+US38,Illinois,ES,El Salvador,Peak,$19.82,$51.98
+US38,Illinois,GE,Germany,NonPeak,$17.57,$33.75
+US38,Illinois,GE,Germany,Peak,$20.73,$39.82
+US38,Illinois,GQ,Guam,NonPeak,$18.33,$31.40
+US38,Illinois,GQ,Guam,Peak,$21.63,$37.05
+US38,Illinois,GR,Greece,NonPeak,$24.38,$44.17
+US38,Illinois,GR,Greece,Peak,$28.77,$52.12
+US38,Illinois,GR29,Crete,NonPeak,$16.00,$33.98
+US38,Illinois,GR29,Crete,Peak,$18.88,$40.10
+US38,Illinois,GT,Guatemala,NonPeak,$27.63,$31.45
+US38,Illinois,GT,Guatemala,Peak,$32.60,$37.11
+US38,Illinois,HO,Honduras,NonPeak,$29.28,$44.28
+US38,Illinois,HO,Honduras,Peak,$34.55,$52.25
+US38,Illinois,HU,Hungary,NonPeak,$30.90,$34.11
+US38,Illinois,HU,Hungary,Peak,$36.46,$40.25
+US38,Illinois,IT,Italy,NonPeak,$15.28,$31.63
+US38,Illinois,IT,Italy,Peak,$18.03,$37.32
+US38,Illinois,IT10,Sicily,NonPeak,$16.05,$44.51
+US38,Illinois,IT10,Sicily,Peak,$18.94,$52.52
+US38,Illinois,JA01,Japan-Central,NonPeak,$16.80,$34.33
+US38,Illinois,JA01,Japan-Central,Peak,$19.82,$40.51
+US38,Illinois,JA02,Japan-South (Excludes Hokkaido),NonPeak,$17.57,$31.74
+US38,Illinois,JA02,Japan-South (Excludes Hokkaido),Peak,$20.73,$37.45
+US38,Illinois,JA03,Japan-North,NonPeak,$18.33,$44.62
+US38,Illinois,JA03,Japan-North,Peak,$21.63,$52.65
+US38,Illinois,JA96,Okinawa,NonPeak,$24.38,$34.45
+US38,Illinois,JA96,Okinawa,Peak,$28.77,$40.65
+US38,Illinois,KS,"Korea, Republic Of",NonPeak,$16.00,$31.91
+US38,Illinois,KS,"Korea, Republic Of",Peak,$18.88,$37.65
+US38,Illinois,KU,Kuwait,NonPeak,$27.63,$44.74
+US38,Illinois,KU,Kuwait,Peak,$32.60,$52.79
+US38,Illinois,NL,Netherlands,NonPeak,$29.28,$34.56
+US38,Illinois,NL,Netherlands,Peak,$34.55,$40.78
+US38,Illinois,NO,Norway,NonPeak,$30.90,$32.09
+US38,Illinois,NO,Norway,Peak,$36.46,$37.87
+US38,Illinois,PA,Paraguay,NonPeak,$15.28,$44.91
+US38,Illinois,PA,Paraguay,Peak,$18.03,$52.99
+US38,Illinois,PE,Peru,NonPeak,$16.05,$34.74
+US38,Illinois,PE,Peru,Peak,$18.94,$40.99
+US38,Illinois,PL,Poland,NonPeak,$16.80,$32.26
+US38,Illinois,PL,Poland,Peak,$19.82,$38.07
+US38,Illinois,PO,Portugal,NonPeak,$17.57,$45.09
+US38,Illinois,PO,Portugal,Peak,$20.73,$53.21
+US38,Illinois,PO01,Azores,NonPeak,$18.33,$34.90
+US38,Illinois,PO01,Azores,Peak,$21.63,$41.18
+US38,Illinois,QA,Qatar,NonPeak,$24.38,$32.44
+US38,Illinois,QA,Qatar,Peak,$28.77,$38.28
+US38,Illinois,RO,Romania,NonPeak,$16.00,$43.94
+US38,Illinois,RO,Romania,Peak,$18.88,$51.85
+US38,Illinois,RQ,Puerto Rico,NonPeak,$27.63,$33.70
+US38,Illinois,RQ,Puerto Rico,Peak,$32.60,$39.77
+US38,Illinois,SA,Saudi Arabia,NonPeak,$29.28,$31.29
+US38,Illinois,SA,Saudi Arabia,Peak,$34.55,$36.92
+US38,Illinois,SN,Singapore,NonPeak,$30.90,$44.05
+US38,Illinois,SN,Singapore,Peak,$36.46,$51.98
+US38,Illinois,SP,Spain,NonPeak,$15.28,$33.75
+US38,Illinois,SP,Spain,Peak,$18.03,$39.82
+US38,Illinois,TU,Turkey,NonPeak,$16.05,$31.40
+US38,Illinois,TU,Turkey,Peak,$18.94,$37.05
+US38,Illinois,UK,United Kingdom,NonPeak,$16.80,$44.17
+US38,Illinois,UK,United Kingdom,Peak,$19.82,$52.12
+US38,Illinois,US8030400,Alaska (Zone) IV,NonPeak,$17.57,$33.98
+US38,Illinois,US8030400,Alaska (Zone) IV,Peak,$20.73,$40.10
+US38,Illinois,US8050500,Alaska (Zone) III,NonPeak,$18.33,$31.45
+US38,Illinois,US8050500,Alaska (Zone) III,Peak,$21.63,$37.11
+US38,Illinois,US8101000,Alaska (Zone) I,NonPeak,$24.38,$44.28
+US38,Illinois,US8101000,Alaska (Zone) I,Peak,$28.77,$52.25
+US38,Illinois,US8190100,Alaska (Zone) II,NonPeak,$16.00,$34.11
+US38,Illinois,US8190100,Alaska (Zone) II,Peak,$18.88,$40.25
+US38,Illinois,US89,Hawaii,NonPeak,$27.63,$31.63
+US38,Illinois,US89,Hawaii,Peak,$32.60,$37.32
+US38,Illinois,UY,Uruguay,NonPeak,$29.28,$44.51
+US38,Illinois,UY,Uruguay,Peak,$34.55,$52.52
+US38,Illinois,VE,Venezuela,NonPeak,$30.90,$34.33
+US38,Illinois,VE,Venezuela,Peak,$36.46,$40.51
+US40,North Carolina,AR,Argentina,NonPeak,$15.28,$31.74
+US40,North Carolina,AR,Argentina,Peak,$18.03,$37.45
+US40,North Carolina,AS11,New South Wales/Australian Capital Territory,NonPeak,$16.05,$44.62
+US40,North Carolina,AS11,New South Wales/Australian Capital Territory,Peak,$18.94,$52.65
+US40,North Carolina,AS21,Northern Territory,NonPeak,$16.80,$34.45
+US40,North Carolina,AS21,Northern Territory,Peak,$19.82,$40.65
+US40,North Carolina,BA,Bahrain,NonPeak,$17.57,$31.91
+US40,North Carolina,BA,Bahrain,Peak,$20.73,$37.65
+US40,North Carolina,BE,Belgium,NonPeak,$18.33,$44.74
+US40,North Carolina,BE,Belgium,Peak,$21.63,$52.79
+US40,North Carolina,BL,Bolivia,NonPeak,$24.38,$34.56
+US40,North Carolina,BL,Bolivia,Peak,$28.77,$40.78
+US40,North Carolina,BR,Brazil - Brazilia,NonPeak,$16.00,$32.09
+US40,North Carolina,BR,Brazil - Brazilia,Peak,$18.88,$37.87
+US40,North Carolina,CA10,Ontario,NonPeak,$27.63,$44.91
+US40,North Carolina,CA10,Ontario,Peak,$32.60,$52.99
+US40,North Carolina,CA20,Quebec,NonPeak,$29.28,$34.74
+US40,North Carolina,CA20,Quebec,Peak,$34.55,$40.99
+US40,North Carolina,CA30,Manitoba,NonPeak,$30.90,$32.26
+US40,North Carolina,CA30,Manitoba,Peak,$36.46,$38.07
+US40,North Carolina,CI,Chile,NonPeak,$15.28,$45.09
+US40,North Carolina,CI,Chile,Peak,$18.03,$53.21
+US40,North Carolina,CO,Colombia,NonPeak,$16.05,$34.90
+US40,North Carolina,CO,Colombia,Peak,$18.94,$41.18
+US40,North Carolina,CS,Costa Rica,NonPeak,$16.80,$32.44
+US40,North Carolina,CS,Costa Rica,Peak,$19.82,$38.28
+US40,North Carolina,EC,Ecuador,NonPeak,$17.57,$43.94
+US40,North Carolina,EC,Ecuador,Peak,$20.73,$51.85
+US40,North Carolina,ES,El Salvador,NonPeak,$18.33,$33.70
+US40,North Carolina,ES,El Salvador,Peak,$21.63,$39.77
+US40,North Carolina,GE,Germany,NonPeak,$24.38,$31.29
+US40,North Carolina,GE,Germany,Peak,$28.77,$36.92
+US40,North Carolina,GQ,Guam,NonPeak,$16.00,$44.05
+US40,North Carolina,GQ,Guam,Peak,$18.88,$51.98
+US40,North Carolina,GR,Greece,NonPeak,$27.63,$33.75
+US40,North Carolina,GR,Greece,Peak,$32.60,$39.82
+US40,North Carolina,GR29,Crete,NonPeak,$29.28,$31.40
+US40,North Carolina,GR29,Crete,Peak,$34.55,$37.05
+US40,North Carolina,GT,Guatemala,NonPeak,$30.90,$44.17
+US40,North Carolina,GT,Guatemala,Peak,$36.46,$52.12
+US40,North Carolina,HO,Honduras,NonPeak,$15.28,$33.98
+US40,North Carolina,HO,Honduras,Peak,$18.03,$40.10
+US40,North Carolina,HU,Hungary,NonPeak,$16.05,$31.45
+US40,North Carolina,HU,Hungary,Peak,$18.94,$37.11
+US40,North Carolina,IT,Italy,NonPeak,$16.80,$44.28
+US40,North Carolina,IT,Italy,Peak,$19.82,$52.25
+US40,North Carolina,IT10,Sicily,NonPeak,$17.57,$34.11
+US40,North Carolina,IT10,Sicily,Peak,$20.73,$40.25
+US40,North Carolina,JA01,Japan-Central,NonPeak,$18.33,$31.63
+US40,North Carolina,JA01,Japan-Central,Peak,$21.63,$37.32
+US40,North Carolina,JA02,Japan-South (Excludes Hokkaido),NonPeak,$24.38,$44.51
+US40,North Carolina,JA02,Japan-South (Excludes Hokkaido),Peak,$28.77,$52.52
+US40,North Carolina,JA03,Japan-North,NonPeak,$16.00,$34.33
+US40,North Carolina,JA03,Japan-North,Peak,$18.88,$40.51
+US40,North Carolina,JA96,Okinawa,NonPeak,$27.63,$31.74
+US40,North Carolina,JA96,Okinawa,Peak,$32.60,$37.45
+US40,North Carolina,KS,"Korea, Republic Of",NonPeak,$29.28,$44.62
+US40,North Carolina,KS,"Korea, Republic Of",Peak,$34.55,$52.65
+US40,North Carolina,KU,Kuwait,NonPeak,$30.90,$34.45
+US40,North Carolina,KU,Kuwait,Peak,$36.46,$40.65
+US40,North Carolina,NL,Netherlands,NonPeak,$15.28,$31.91
+US40,North Carolina,NL,Netherlands,Peak,$18.03,$37.65
+US40,North Carolina,NO,Norway,NonPeak,$16.05,$44.74
+US40,North Carolina,NO,Norway,Peak,$18.94,$52.79
+US40,North Carolina,PA,Paraguay,NonPeak,$16.80,$34.56
+US40,North Carolina,PA,Paraguay,Peak,$19.82,$40.78
+US40,North Carolina,PE,Peru,NonPeak,$17.57,$32.09
+US40,North Carolina,PE,Peru,Peak,$20.73,$37.87
+US40,North Carolina,PL,Poland,NonPeak,$18.33,$44.91
+US40,North Carolina,PL,Poland,Peak,$21.63,$52.99
+US40,North Carolina,PO,Portugal,NonPeak,$24.38,$34.74
+US40,North Carolina,PO,Portugal,Peak,$28.77,$40.99
+US40,North Carolina,PO01,Azores,NonPeak,$16.00,$32.26
+US40,North Carolina,PO01,Azores,Peak,$18.88,$38.07
+US40,North Carolina,QA,Qatar,NonPeak,$27.63,$45.09
+US40,North Carolina,QA,Qatar,Peak,$32.60,$53.21
+US40,North Carolina,RO,Romania,NonPeak,$29.28,$34.90
+US40,North Carolina,RO,Romania,Peak,$34.55,$41.18
+US40,North Carolina,RQ,Puerto Rico,NonPeak,$30.90,$32.44
+US40,North Carolina,RQ,Puerto Rico,Peak,$36.46,$38.28
+US40,North Carolina,SA,Saudi Arabia,NonPeak,$15.28,$43.94
+US40,North Carolina,SA,Saudi Arabia,Peak,$18.03,$51.85
+US40,North Carolina,SN,Singapore,NonPeak,$16.05,$33.70
+US40,North Carolina,SN,Singapore,Peak,$18.94,$39.77
+US40,North Carolina,SP,Spain,NonPeak,$16.80,$31.29
+US40,North Carolina,SP,Spain,Peak,$19.82,$36.92
+US40,North Carolina,TU,Turkey,NonPeak,$17.57,$44.05
+US40,North Carolina,TU,Turkey,Peak,$20.73,$51.98
+US40,North Carolina,UK,United Kingdom,NonPeak,$18.33,$33.75
+US40,North Carolina,UK,United Kingdom,Peak,$21.63,$39.82
+US40,North Carolina,US8030400,Alaska (Zone) IV,NonPeak,$24.38,$31.40
+US40,North Carolina,US8030400,Alaska (Zone) IV,Peak,$28.77,$37.05
+US40,North Carolina,US8050500,Alaska (Zone) III,NonPeak,$16.00,$44.17
+US40,North Carolina,US8050500,Alaska (Zone) III,Peak,$18.88,$52.12
+US40,North Carolina,US8101000,Alaska (Zone) I,NonPeak,$27.63,$33.98
+US40,North Carolina,US8101000,Alaska (Zone) I,Peak,$32.60,$40.10
+US40,North Carolina,US8190100,Alaska (Zone) II,NonPeak,$29.28,$31.45
+US40,North Carolina,US8190100,Alaska (Zone) II,Peak,$34.55,$37.11
+US40,North Carolina,US89,Hawaii,NonPeak,$30.90,$44.28
+US40,North Carolina,US89,Hawaii,Peak,$36.46,$52.25
+US40,North Carolina,UY,Uruguay,NonPeak,$15.28,$34.11
+US40,North Carolina,UY,Uruguay,Peak,$18.03,$40.25
+US40,North Carolina,VE,Venezuela,NonPeak,$16.05,$31.63
+US40,North Carolina,VE,Venezuela,Peak,$18.94,$37.32
+US42,Tennessee,AR,Argentina,NonPeak,$16.80,$44.51
+US42,Tennessee,AR,Argentina,Peak,$19.82,$52.52
+US42,Tennessee,AS11,New South Wales/Australian Capital Territory,NonPeak,$17.57,$34.33
+US42,Tennessee,AS11,New South Wales/Australian Capital Territory,Peak,$20.73,$40.51
+US42,Tennessee,AS21,Northern Territory,NonPeak,$18.33,$31.74
+US42,Tennessee,AS21,Northern Territory,Peak,$21.63,$37.45
+US42,Tennessee,BA,Bahrain,NonPeak,$24.38,$44.62
+US42,Tennessee,BA,Bahrain,Peak,$28.77,$52.65
+US42,Tennessee,BE,Belgium,NonPeak,$16.00,$34.45
+US42,Tennessee,BE,Belgium,Peak,$18.88,$40.65
+US42,Tennessee,BL,Bolivia,NonPeak,$27.63,$31.91
+US42,Tennessee,BL,Bolivia,Peak,$32.60,$37.65
+US42,Tennessee,BR,Brazil - Brazilia,NonPeak,$29.28,$44.74
+US42,Tennessee,BR,Brazil - Brazilia,Peak,$34.55,$52.79
+US42,Tennessee,CA10,Ontario,NonPeak,$30.90,$34.56
+US42,Tennessee,CA10,Ontario,Peak,$36.46,$40.78
+US42,Tennessee,CA20,Quebec,NonPeak,$15.28,$32.09
+US42,Tennessee,CA20,Quebec,Peak,$18.03,$37.87
+US42,Tennessee,CA30,Manitoba,NonPeak,$16.05,$44.91
+US42,Tennessee,CA30,Manitoba,Peak,$18.94,$52.99
+US42,Tennessee,CI,Chile,NonPeak,$16.80,$34.74
+US42,Tennessee,CI,Chile,Peak,$19.82,$40.99
+US42,Tennessee,CO,Colombia,NonPeak,$17.57,$32.26
+US42,Tennessee,CO,Colombia,Peak,$20.73,$38.07
+US42,Tennessee,CS,Costa Rica,NonPeak,$18.33,$45.09
+US42,Tennessee,CS,Costa Rica,Peak,$21.63,$53.21
+US42,Tennessee,EC,Ecuador,NonPeak,$24.38,$34.90
+US42,Tennessee,EC,Ecuador,Peak,$28.77,$41.18
+US42,Tennessee,ES,El Salvador,NonPeak,$16.00,$32.44
+US42,Tennessee,ES,El Salvador,Peak,$18.88,$38.28
+US42,Tennessee,GE,Germany,NonPeak,$27.63,$43.94
+US42,Tennessee,GE,Germany,Peak,$32.60,$51.85
+US42,Tennessee,GQ,Guam,NonPeak,$29.28,$33.70
+US42,Tennessee,GQ,Guam,Peak,$34.55,$39.77
+US42,Tennessee,GR,Greece,NonPeak,$30.90,$31.29
+US42,Tennessee,GR,Greece,Peak,$36.46,$36.92
+US42,Tennessee,GR29,Crete,NonPeak,$15.28,$44.05
+US42,Tennessee,GR29,Crete,Peak,$18.03,$51.98
+US42,Tennessee,GT,Guatemala,NonPeak,$16.05,$33.75
+US42,Tennessee,GT,Guatemala,Peak,$18.94,$39.82
+US42,Tennessee,HO,Honduras,NonPeak,$16.80,$31.40
+US42,Tennessee,HO,Honduras,Peak,$19.82,$37.05
+US42,Tennessee,HU,Hungary,NonPeak,$17.57,$44.17
+US42,Tennessee,HU,Hungary,Peak,$20.73,$52.12
+US42,Tennessee,IT,Italy,NonPeak,$18.33,$33.98
+US42,Tennessee,IT,Italy,Peak,$21.63,$40.10
+US42,Tennessee,IT10,Sicily,NonPeak,$24.38,$31.45
+US42,Tennessee,IT10,Sicily,Peak,$28.77,$37.11
+US42,Tennessee,JA01,Japan-Central,NonPeak,$16.00,$44.28
+US42,Tennessee,JA01,Japan-Central,Peak,$18.88,$52.25
+US42,Tennessee,JA02,Japan-South (Excludes Hokkaido),NonPeak,$27.63,$34.11
+US42,Tennessee,JA02,Japan-South (Excludes Hokkaido),Peak,$32.60,$40.25
+US42,Tennessee,JA03,Japan-North,NonPeak,$29.28,$31.63
+US42,Tennessee,JA03,Japan-North,Peak,$34.55,$37.32
+US42,Tennessee,JA96,Okinawa,NonPeak,$30.90,$44.51
+US42,Tennessee,JA96,Okinawa,Peak,$36.46,$52.52
+US42,Tennessee,KS,"Korea, Republic Of",NonPeak,$15.28,$34.33
+US42,Tennessee,KS,"Korea, Republic Of",Peak,$18.03,$40.51
+US42,Tennessee,KU,Kuwait,NonPeak,$16.05,$31.74
+US42,Tennessee,KU,Kuwait,Peak,$18.94,$37.45
+US42,Tennessee,NL,Netherlands,NonPeak,$16.80,$44.62
+US42,Tennessee,NL,Netherlands,Peak,$19.82,$52.65
+US42,Tennessee,NO,Norway,NonPeak,$17.57,$34.45
+US42,Tennessee,NO,Norway,Peak,$20.73,$40.65
+US42,Tennessee,PA,Paraguay,NonPeak,$18.33,$31.91
+US42,Tennessee,PA,Paraguay,Peak,$21.63,$37.65
+US42,Tennessee,PE,Peru,NonPeak,$24.38,$44.74
+US42,Tennessee,PE,Peru,Peak,$28.77,$52.79
+US42,Tennessee,PL,Poland,NonPeak,$16.00,$34.56
+US42,Tennessee,PL,Poland,Peak,$18.88,$40.78
+US42,Tennessee,PO,Portugal,NonPeak,$27.63,$32.09
+US42,Tennessee,PO,Portugal,Peak,$32.60,$37.87
+US42,Tennessee,PO01,Azores,NonPeak,$29.28,$44.91
+US42,Tennessee,PO01,Azores,Peak,$34.55,$52.99
+US42,Tennessee,QA,Qatar,NonPeak,$30.90,$34.74
+US42,Tennessee,QA,Qatar,Peak,$36.46,$40.99
+US42,Tennessee,RO,Romania,NonPeak,$15.28,$32.26
+US42,Tennessee,RO,Romania,Peak,$18.03,$38.07
+US42,Tennessee,RQ,Puerto Rico,NonPeak,$16.05,$45.09
+US42,Tennessee,RQ,Puerto Rico,Peak,$18.94,$53.21
+US42,Tennessee,SA,Saudi Arabia,NonPeak,$16.80,$34.90
+US42,Tennessee,SA,Saudi Arabia,Peak,$19.82,$41.18
+US42,Tennessee,SN,Singapore,NonPeak,$17.57,$32.44
+US42,Tennessee,SN,Singapore,Peak,$20.73,$38.28
+US42,Tennessee,SP,Spain,NonPeak,$18.33,$43.94
+US42,Tennessee,SP,Spain,Peak,$21.63,$51.85
+US42,Tennessee,TU,Turkey,NonPeak,$24.38,$33.70
+US42,Tennessee,TU,Turkey,Peak,$28.77,$39.77
+US42,Tennessee,UK,United Kingdom,NonPeak,$16.00,$31.29
+US42,Tennessee,UK,United Kingdom,Peak,$18.88,$36.92
+US42,Tennessee,US8030400,Alaska (Zone) IV,NonPeak,$27.63,$44.05
+US42,Tennessee,US8030400,Alaska (Zone) IV,Peak,$32.60,$51.98
+US42,Tennessee,US8050500,Alaska (Zone) III,NonPeak,$29.28,$33.75
+US42,Tennessee,US8050500,Alaska (Zone) III,Peak,$34.55,$39.82
+US42,Tennessee,US8101000,Alaska (Zone) I,NonPeak,$30.90,$31.40
+US42,Tennessee,US8101000,Alaska (Zone) I,Peak,$36.46,$37.05
+US42,Tennessee,US8190100,Alaska (Zone) II,NonPeak,$15.28,$44.17
+US42,Tennessee,US8190100,Alaska (Zone) II,Peak,$18.03,$52.12
+US42,Tennessee,US89,Hawaii,NonPeak,$16.05,$33.98
+US42,Tennessee,US89,Hawaii,Peak,$18.94,$40.10
+US42,Tennessee,UY,Uruguay,NonPeak,$16.80,$31.45
+US42,Tennessee,UY,Uruguay,Peak,$19.82,$37.11
+US42,Tennessee,VE,Venezuela,NonPeak,$17.57,$44.28
+US42,Tennessee,VE,Venezuela,Peak,$20.73,$52.25
+US44,South Carolina,AR,Argentina,NonPeak,$18.33,$34.11
+US44,South Carolina,AR,Argentina,Peak,$21.63,$40.25
+US44,South Carolina,AS11,New South Wales/Australian Capital Territory,NonPeak,$24.38,$31.63
+US44,South Carolina,AS11,New South Wales/Australian Capital Territory,Peak,$28.77,$37.32
+US44,South Carolina,AS21,Northern Territory,NonPeak,$16.00,$44.51
+US44,South Carolina,AS21,Northern Territory,Peak,$18.88,$52.52
+US44,South Carolina,BA,Bahrain,NonPeak,$27.63,$34.33
+US44,South Carolina,BA,Bahrain,Peak,$32.60,$40.51
+US44,South Carolina,BE,Belgium,NonPeak,$29.28,$31.74
+US44,South Carolina,BE,Belgium,Peak,$34.55,$37.45
+US44,South Carolina,BL,Bolivia,NonPeak,$30.90,$44.62
+US44,South Carolina,BL,Bolivia,Peak,$36.46,$52.65
+US44,South Carolina,BR,Brazil - Brazilia,NonPeak,$15.28,$34.45
+US44,South Carolina,BR,Brazil - Brazilia,Peak,$18.03,$40.65
+US44,South Carolina,CA10,Ontario,NonPeak,$16.05,$31.91
+US44,South Carolina,CA10,Ontario,Peak,$18.94,$37.65
+US44,South Carolina,CA20,Quebec,NonPeak,$16.80,$44.74
+US44,South Carolina,CA20,Quebec,Peak,$19.82,$52.79
+US44,South Carolina,CA30,Manitoba,NonPeak,$17.57,$34.56
+US44,South Carolina,CA30,Manitoba,Peak,$20.73,$40.78
+US44,South Carolina,CI,Chile,NonPeak,$18.33,$32.09
+US44,South Carolina,CI,Chile,Peak,$21.63,$37.87
+US44,South Carolina,CO,Colombia,NonPeak,$24.38,$44.91
+US44,South Carolina,CO,Colombia,Peak,$28.77,$52.99
+US44,South Carolina,CS,Costa Rica,NonPeak,$16.00,$34.74
+US44,South Carolina,CS,Costa Rica,Peak,$18.88,$40.99
+US44,South Carolina,EC,Ecuador,NonPeak,$27.63,$32.26
+US44,South Carolina,EC,Ecuador,Peak,$32.60,$38.07
+US44,South Carolina,ES,El Salvador,NonPeak,$29.28,$45.09
+US44,South Carolina,ES,El Salvador,Peak,$34.55,$53.21
+US44,South Carolina,GE,Germany,NonPeak,$30.90,$34.90
+US44,South Carolina,GE,Germany,Peak,$36.46,$41.18
+US44,South Carolina,GQ,Guam,NonPeak,$15.28,$32.44
+US44,South Carolina,GQ,Guam,Peak,$18.03,$38.28
+US44,South Carolina,GR,Greece,NonPeak,$16.05,$43.94
+US44,South Carolina,GR,Greece,Peak,$18.94,$51.85
+US44,South Carolina,GR29,Crete,NonPeak,$16.80,$33.70
+US44,South Carolina,GR29,Crete,Peak,$19.82,$39.77
+US44,South Carolina,GT,Guatemala,NonPeak,$17.57,$31.29
+US44,South Carolina,GT,Guatemala,Peak,$20.73,$36.92
+US44,South Carolina,HO,Honduras,NonPeak,$18.33,$44.05
+US44,South Carolina,HO,Honduras,Peak,$21.63,$51.98
+US44,South Carolina,HU,Hungary,NonPeak,$24.38,$33.75
+US44,South Carolina,HU,Hungary,Peak,$28.77,$39.82
+US44,South Carolina,IT,Italy,NonPeak,$16.00,$31.40
+US44,South Carolina,IT,Italy,Peak,$18.88,$37.05
+US44,South Carolina,IT10,Sicily,NonPeak,$27.63,$44.17
+US44,South Carolina,IT10,Sicily,Peak,$32.60,$52.12
+US44,South Carolina,JA01,Japan-Central,NonPeak,$29.28,$33.98
+US44,South Carolina,JA01,Japan-Central,Peak,$34.55,$40.10
+US44,South Carolina,JA02,Japan-South (Excludes Hokkaido),NonPeak,$30.90,$31.45
+US44,South Carolina,JA02,Japan-South (Excludes Hokkaido),Peak,$36.46,$37.11
+US44,South Carolina,JA03,Japan-North,NonPeak,$15.28,$44.28
+US44,South Carolina,JA03,Japan-North,Peak,$18.03,$52.25
+US44,South Carolina,JA96,Okinawa,NonPeak,$16.05,$34.11
+US44,South Carolina,JA96,Okinawa,Peak,$18.94,$40.25
+US44,South Carolina,KS,"Korea, Republic Of",NonPeak,$16.80,$31.63
+US44,South Carolina,KS,"Korea, Republic Of",Peak,$19.82,$37.32
+US44,South Carolina,KU,Kuwait,NonPeak,$17.57,$44.51
+US44,South Carolina,KU,Kuwait,Peak,$20.73,$52.52
+US44,South Carolina,NL,Netherlands,NonPeak,$18.33,$34.33
+US44,South Carolina,NL,Netherlands,Peak,$21.63,$40.51
+US44,South Carolina,NO,Norway,NonPeak,$24.38,$31.74
+US44,South Carolina,NO,Norway,Peak,$28.77,$37.45
+US44,South Carolina,PA,Paraguay,NonPeak,$16.00,$44.62
+US44,South Carolina,PA,Paraguay,Peak,$18.88,$52.65
+US44,South Carolina,PE,Peru,NonPeak,$27.63,$34.45
+US44,South Carolina,PE,Peru,Peak,$32.60,$40.65
+US44,South Carolina,PL,Poland,NonPeak,$29.28,$31.91
+US44,South Carolina,PL,Poland,Peak,$34.55,$37.65
+US44,South Carolina,PO,Portugal,NonPeak,$30.90,$44.74
+US44,South Carolina,PO,Portugal,Peak,$36.46,$52.79
+US44,South Carolina,PO01,Azores,NonPeak,$15.28,$34.56
+US44,South Carolina,PO01,Azores,Peak,$18.03,$40.78
+US44,South Carolina,QA,Qatar,NonPeak,$16.05,$32.09
+US44,South Carolina,QA,Qatar,Peak,$18.94,$37.87
+US44,South Carolina,RO,Romania,NonPeak,$16.80,$44.91
+US44,South Carolina,RO,Romania,Peak,$19.82,$52.99
+US44,South Carolina,RQ,Puerto Rico,NonPeak,$17.57,$34.74
+US44,South Carolina,RQ,Puerto Rico,Peak,$20.73,$40.99
+US44,South Carolina,SA,Saudi Arabia,NonPeak,$18.33,$32.26
+US44,South Carolina,SA,Saudi Arabia,Peak,$21.63,$38.07
+US44,South Carolina,SN,Singapore,NonPeak,$24.38,$45.09
+US44,South Carolina,SN,Singapore,Peak,$28.77,$53.21
+US44,South Carolina,SP,Spain,NonPeak,$16.00,$34.90
+US44,South Carolina,SP,Spain,Peak,$18.88,$41.18
+US44,South Carolina,TU,Turkey,NonPeak,$27.63,$32.44
+US44,South Carolina,TU,Turkey,Peak,$32.60,$38.28
+US44,South Carolina,UK,United Kingdom,NonPeak,$29.28,$43.94
+US44,South Carolina,UK,United Kingdom,Peak,$34.55,$51.85
+US44,South Carolina,US8030400,Alaska (Zone) IV,NonPeak,$30.90,$33.70
+US44,South Carolina,US8030400,Alaska (Zone) IV,Peak,$36.46,$39.77
+US44,South Carolina,US8050500,Alaska (Zone) III,NonPeak,$15.28,$31.29
+US44,South Carolina,US8050500,Alaska (Zone) III,Peak,$18.03,$36.92
+US44,South Carolina,US8101000,Alaska (Zone) I,NonPeak,$16.05,$44.05
+US44,South Carolina,US8101000,Alaska (Zone) I,Peak,$18.94,$51.98
+US44,South Carolina,US8190100,Alaska (Zone) II,NonPeak,$16.80,$33.75
+US44,South Carolina,US8190100,Alaska (Zone) II,Peak,$19.82,$39.82
+US44,South Carolina,US89,Hawaii,NonPeak,$17.57,$31.40
+US44,South Carolina,US89,Hawaii,Peak,$20.73,$37.05
+US44,South Carolina,UY,Uruguay,NonPeak,$18.33,$44.17
+US44,South Carolina,UY,Uruguay,Peak,$21.63,$52.12
+US44,South Carolina,VE,Venezuela,NonPeak,$24.38,$33.98
+US44,South Carolina,VE,Venezuela,Peak,$28.77,$40.10
+US45,Georgia,AR,Argentina,NonPeak,$16.00,$31.45
+US45,Georgia,AR,Argentina,Peak,$18.88,$37.11
+US45,Georgia,AS11,New South Wales/Australian Capital Territory,NonPeak,$27.63,$44.28
+US45,Georgia,AS11,New South Wales/Australian Capital Territory,Peak,$32.60,$52.25
+US45,Georgia,AS21,Northern Territory,NonPeak,$29.28,$34.11
+US45,Georgia,AS21,Northern Territory,Peak,$34.55,$40.25
+US45,Georgia,BA,Bahrain,NonPeak,$30.90,$31.63
+US45,Georgia,BA,Bahrain,Peak,$36.46,$37.32
+US45,Georgia,BE,Belgium,NonPeak,$15.28,$44.51
+US45,Georgia,BE,Belgium,Peak,$18.03,$52.52
+US45,Georgia,BL,Bolivia,NonPeak,$16.05,$34.33
+US45,Georgia,BL,Bolivia,Peak,$18.94,$40.51
+US45,Georgia,BR,Brazil - Brazilia,NonPeak,$16.80,$31.74
+US45,Georgia,BR,Brazil - Brazilia,Peak,$19.82,$37.45
+US45,Georgia,CA10,Ontario,NonPeak,$17.57,$44.62
+US45,Georgia,CA10,Ontario,Peak,$20.73,$52.65
+US45,Georgia,CA20,Quebec,NonPeak,$18.33,$34.45
+US45,Georgia,CA20,Quebec,Peak,$21.63,$40.65
+US45,Georgia,CA30,Manitoba,NonPeak,$24.38,$31.91
+US45,Georgia,CA30,Manitoba,Peak,$28.77,$37.65
+US45,Georgia,CI,Chile,NonPeak,$16.00,$44.74
+US45,Georgia,CI,Chile,Peak,$18.88,$52.79
+US45,Georgia,CO,Colombia,NonPeak,$27.63,$34.56
+US45,Georgia,CO,Colombia,Peak,$32.60,$40.78
+US45,Georgia,CS,Costa Rica,NonPeak,$29.28,$32.09
+US45,Georgia,CS,Costa Rica,Peak,$34.55,$37.87
+US45,Georgia,EC,Ecuador,NonPeak,$30.90,$44.91
+US45,Georgia,EC,Ecuador,Peak,$36.46,$52.99
+US45,Georgia,ES,El Salvador,NonPeak,$15.28,$34.74
+US45,Georgia,ES,El Salvador,Peak,$18.03,$40.99
+US45,Georgia,GE,Germany,NonPeak,$16.05,$32.26
+US45,Georgia,GE,Germany,Peak,$18.94,$38.07
+US45,Georgia,GQ,Guam,NonPeak,$16.80,$45.09
+US45,Georgia,GQ,Guam,Peak,$19.82,$53.21
+US45,Georgia,GR,Greece,NonPeak,$17.57,$34.90
+US45,Georgia,GR,Greece,Peak,$20.73,$41.18
+US45,Georgia,GR29,Crete,NonPeak,$18.33,$32.44
+US45,Georgia,GR29,Crete,Peak,$21.63,$38.28
+US45,Georgia,GT,Guatemala,NonPeak,$24.38,$43.94
+US45,Georgia,GT,Guatemala,Peak,$28.77,$51.85
+US45,Georgia,HO,Honduras,NonPeak,$16.00,$33.70
+US45,Georgia,HO,Honduras,Peak,$18.88,$39.77
+US45,Georgia,HU,Hungary,NonPeak,$27.63,$31.29
+US45,Georgia,HU,Hungary,Peak,$32.60,$36.92
+US45,Georgia,IT,Italy,NonPeak,$29.28,$44.05
+US45,Georgia,IT,Italy,Peak,$34.55,$51.98
+US45,Georgia,IT10,Sicily,NonPeak,$30.90,$33.75
+US45,Georgia,IT10,Sicily,Peak,$36.46,$39.82
+US45,Georgia,JA01,Japan-Central,NonPeak,$15.28,$31.40
+US45,Georgia,JA01,Japan-Central,Peak,$18.03,$37.05
+US45,Georgia,JA02,Japan-South (Excludes Hokkaido),NonPeak,$16.05,$44.17
+US45,Georgia,JA02,Japan-South (Excludes Hokkaido),Peak,$18.94,$52.12
+US45,Georgia,JA03,Japan-North,NonPeak,$16.80,$33.98
+US45,Georgia,JA03,Japan-North,Peak,$19.82,$40.10
+US45,Georgia,JA96,Okinawa,NonPeak,$17.57,$31.45
+US45,Georgia,JA96,Okinawa,Peak,$20.73,$37.11
+US45,Georgia,KS,"Korea, Republic Of",NonPeak,$18.33,$44.28
+US45,Georgia,KS,"Korea, Republic Of",Peak,$21.63,$52.25
+US45,Georgia,KU,Kuwait,NonPeak,$24.38,$34.11
+US45,Georgia,KU,Kuwait,Peak,$28.77,$40.25
+US45,Georgia,NL,Netherlands,NonPeak,$16.00,$31.63
+US45,Georgia,NL,Netherlands,Peak,$18.88,$37.32
+US45,Georgia,NO,Norway,NonPeak,$27.63,$44.51
+US45,Georgia,NO,Norway,Peak,$32.60,$52.52
+US45,Georgia,PA,Paraguay,NonPeak,$29.28,$34.33
+US45,Georgia,PA,Paraguay,Peak,$34.55,$40.51
+US45,Georgia,PE,Peru,NonPeak,$30.90,$31.74
+US45,Georgia,PE,Peru,Peak,$36.46,$37.45
+US45,Georgia,PL,Poland,NonPeak,$15.28,$44.62
+US45,Georgia,PL,Poland,Peak,$18.03,$52.65
+US45,Georgia,PO,Portugal,NonPeak,$16.05,$34.45
+US45,Georgia,PO,Portugal,Peak,$18.94,$40.65
+US45,Georgia,PO01,Azores,NonPeak,$16.80,$31.91
+US45,Georgia,PO01,Azores,Peak,$19.82,$37.65
+US45,Georgia,QA,Qatar,NonPeak,$17.57,$44.74
+US45,Georgia,QA,Qatar,Peak,$20.73,$52.79
+US45,Georgia,RO,Romania,NonPeak,$18.33,$34.56
+US45,Georgia,RO,Romania,Peak,$21.63,$40.78
+US45,Georgia,RQ,Puerto Rico,NonPeak,$24.38,$32.09
+US45,Georgia,RQ,Puerto Rico,Peak,$28.77,$37.87
+US45,Georgia,SA,Saudi Arabia,NonPeak,$16.00,$44.91
+US45,Georgia,SA,Saudi Arabia,Peak,$18.88,$52.99
+US45,Georgia,SN,Singapore,NonPeak,$27.63,$34.74
+US45,Georgia,SN,Singapore,Peak,$32.60,$40.99
+US45,Georgia,SP,Spain,NonPeak,$29.28,$32.26
+US45,Georgia,SP,Spain,Peak,$34.55,$38.07
+US45,Georgia,TU,Turkey,NonPeak,$30.90,$45.09
+US45,Georgia,TU,Turkey,Peak,$36.46,$53.21
+US45,Georgia,UK,United Kingdom,NonPeak,$15.28,$34.90
+US45,Georgia,UK,United Kingdom,Peak,$18.03,$41.18
+US45,Georgia,US8030400,Alaska (Zone) IV,NonPeak,$16.05,$32.44
+US45,Georgia,US8030400,Alaska (Zone) IV,Peak,$18.94,$38.28
+US45,Georgia,US8050500,Alaska (Zone) III,NonPeak,$16.80,$43.94
+US45,Georgia,US8050500,Alaska (Zone) III,Peak,$19.82,$51.85
+US45,Georgia,US8101000,Alaska (Zone) I,NonPeak,$17.57,$33.70
+US45,Georgia,US8101000,Alaska (Zone) I,Peak,$20.73,$39.77
+US45,Georgia,US8190100,Alaska (Zone) II,NonPeak,$18.33,$31.29
+US45,Georgia,US8190100,Alaska (Zone) II,Peak,$21.63,$36.92
+US45,Georgia,US89,Hawaii,NonPeak,$24.38,$44.05
+US45,Georgia,US89,Hawaii,Peak,$28.77,$51.98
+US45,Georgia,UY,Uruguay,NonPeak,$16.00,$33.75
+US45,Georgia,UY,Uruguay,Peak,$18.88,$39.82
+US45,Georgia,VE,Venezuela,NonPeak,$27.63,$31.40
+US45,Georgia,VE,Venezuela,Peak,$32.60,$37.05
+US47,Alabama,AR,Argentina,NonPeak,$29.28,$44.17
+US47,Alabama,AR,Argentina,Peak,$34.55,$52.12
+US47,Alabama,AS11,New South Wales/Australian Capital Territory,NonPeak,$30.90,$33.98
+US47,Alabama,AS11,New South Wales/Australian Capital Territory,Peak,$36.46,$40.10
+US47,Alabama,AS21,Northern Territory,NonPeak,$15.28,$31.45
+US47,Alabama,AS21,Northern Territory,Peak,$18.03,$37.11
+US47,Alabama,BA,Bahrain,NonPeak,$16.05,$44.28
+US47,Alabama,BA,Bahrain,Peak,$18.94,$52.25
+US47,Alabama,BE,Belgium,NonPeak,$16.80,$34.11
+US47,Alabama,BE,Belgium,Peak,$19.82,$40.25
+US47,Alabama,BL,Bolivia,NonPeak,$17.57,$31.63
+US47,Alabama,BL,Bolivia,Peak,$20.73,$37.32
+US47,Alabama,BR,Brazil - Brazilia,NonPeak,$18.33,$44.51
+US47,Alabama,BR,Brazil - Brazilia,Peak,$21.63,$52.52
+US47,Alabama,CA10,Ontario,NonPeak,$24.38,$34.33
+US47,Alabama,CA10,Ontario,Peak,$28.77,$40.51
+US47,Alabama,CA20,Quebec,NonPeak,$16.00,$31.74
+US47,Alabama,CA20,Quebec,Peak,$18.88,$37.45
+US47,Alabama,CA30,Manitoba,NonPeak,$27.63,$44.62
+US47,Alabama,CA30,Manitoba,Peak,$32.60,$52.65
+US47,Alabama,CI,Chile,NonPeak,$29.28,$34.45
+US47,Alabama,CI,Chile,Peak,$34.55,$40.65
+US47,Alabama,CO,Colombia,NonPeak,$30.90,$31.91
+US47,Alabama,CO,Colombia,Peak,$36.46,$37.65
+US47,Alabama,CS,Costa Rica,NonPeak,$15.28,$44.74
+US47,Alabama,CS,Costa Rica,Peak,$18.03,$52.79
+US47,Alabama,EC,Ecuador,NonPeak,$16.05,$34.56
+US47,Alabama,EC,Ecuador,Peak,$18.94,$40.78
+US47,Alabama,ES,El Salvador,NonPeak,$16.80,$32.09
+US47,Alabama,ES,El Salvador,Peak,$19.82,$37.87
+US47,Alabama,GE,Germany,NonPeak,$17.57,$44.91
+US47,Alabama,GE,Germany,Peak,$20.73,$52.99
+US47,Alabama,GQ,Guam,NonPeak,$18.33,$34.74
+US47,Alabama,GQ,Guam,Peak,$21.63,$40.99
+US47,Alabama,GR,Greece,NonPeak,$24.38,$32.26
+US47,Alabama,GR,Greece,Peak,$28.77,$38.07
+US47,Alabama,GR29,Crete,NonPeak,$16.00,$45.09
+US47,Alabama,GR29,Crete,Peak,$18.88,$53.21
+US47,Alabama,GT,Guatemala,NonPeak,$27.63,$34.90
+US47,Alabama,GT,Guatemala,Peak,$32.60,$41.18
+US47,Alabama,HO,Honduras,NonPeak,$29.28,$32.44
+US47,Alabama,HO,Honduras,Peak,$34.55,$38.28
+US47,Alabama,HU,Hungary,NonPeak,$30.90,$43.94
+US47,Alabama,HU,Hungary,Peak,$36.46,$51.85
+US47,Alabama,IT,Italy,NonPeak,$15.28,$33.70
+US47,Alabama,IT,Italy,Peak,$18.03,$39.77
+US47,Alabama,IT10,Sicily,NonPeak,$16.05,$31.29
+US47,Alabama,IT10,Sicily,Peak,$18.94,$36.92
+US47,Alabama,JA01,Japan-Central,NonPeak,$16.80,$44.05
+US47,Alabama,JA01,Japan-Central,Peak,$19.82,$51.98
+US47,Alabama,JA02,Japan-South (Excludes Hokkaido),NonPeak,$17.57,$33.75
+US47,Alabama,JA02,Japan-South (Excludes Hokkaido),Peak,$20.73,$39.82
+US47,Alabama,JA03,Japan-North,NonPeak,$18.33,$31.40
+US47,Alabama,JA03,Japan-North,Peak,$21.63,$37.05
+US47,Alabama,JA96,Okinawa,NonPeak,$24.38,$44.17
+US47,Alabama,JA96,Okinawa,Peak,$28.77,$52.12
+US47,Alabama,KS,"Korea, Republic Of",NonPeak,$16.00,$33.98
+US47,Alabama,KS,"Korea, Republic Of",Peak,$18.88,$40.10
+US47,Alabama,KU,Kuwait,NonPeak,$27.63,$31.45
+US47,Alabama,KU,Kuwait,Peak,$32.60,$37.11
+US47,Alabama,NL,Netherlands,NonPeak,$29.28,$44.28
+US47,Alabama,NL,Netherlands,Peak,$34.55,$52.25
+US47,Alabama,NO,Norway,NonPeak,$30.90,$34.11
+US47,Alabama,NO,Norway,Peak,$36.46,$40.25
+US47,Alabama,PA,Paraguay,NonPeak,$15.28,$31.63
+US47,Alabama,PA,Paraguay,Peak,$18.03,$37.32
+US47,Alabama,PE,Peru,NonPeak,$16.05,$44.51
+US47,Alabama,PE,Peru,Peak,$18.94,$52.52
+US47,Alabama,PL,Poland,NonPeak,$16.80,$34.33
+US47,Alabama,PL,Poland,Peak,$19.82,$40.51
+US47,Alabama,PO,Portugal,NonPeak,$17.57,$31.74
+US47,Alabama,PO,Portugal,Peak,$20.73,$37.45
+US47,Alabama,PO01,Azores,NonPeak,$18.33,$44.62
+US47,Alabama,PO01,Azores,Peak,$21.63,$52.65
+US47,Alabama,QA,Qatar,NonPeak,$24.38,$34.45
+US47,Alabama,QA,Qatar,Peak,$28.77,$40.65
+US47,Alabama,RO,Romania,NonPeak,$16.00,$31.91
+US47,Alabama,RO,Romania,Peak,$18.88,$37.65
+US47,Alabama,RQ,Puerto Rico,NonPeak,$27.63,$44.74
+US47,Alabama,RQ,Puerto Rico,Peak,$32.60,$52.79
+US47,Alabama,SA,Saudi Arabia,NonPeak,$29.28,$34.56
+US47,Alabama,SA,Saudi Arabia,Peak,$34.55,$40.78
+US47,Alabama,SN,Singapore,NonPeak,$30.90,$32.09
+US47,Alabama,SN,Singapore,Peak,$36.46,$37.87
+US47,Alabama,SP,Spain,NonPeak,$15.28,$44.91
+US47,Alabama,SP,Spain,Peak,$18.03,$52.99
+US47,Alabama,TU,Turkey,NonPeak,$16.05,$34.74
+US47,Alabama,TU,Turkey,Peak,$18.94,$40.99
+US47,Alabama,UK,United Kingdom,NonPeak,$16.80,$32.26
+US47,Alabama,UK,United Kingdom,Peak,$19.82,$38.07
+US47,Alabama,US8030400,Alaska (Zone) IV,NonPeak,$17.57,$45.09
+US47,Alabama,US8030400,Alaska (Zone) IV,Peak,$20.73,$53.21
+US47,Alabama,US8050500,Alaska (Zone) III,NonPeak,$18.33,$34.90
+US47,Alabama,US8050500,Alaska (Zone) III,Peak,$21.63,$41.18
+US47,Alabama,US8101000,Alaska (Zone) I,NonPeak,$24.38,$32.44
+US47,Alabama,US8101000,Alaska (Zone) I,Peak,$28.77,$38.28
+US47,Alabama,US8190100,Alaska (Zone) II,NonPeak,$16.00,$43.94
+US47,Alabama,US8190100,Alaska (Zone) II,Peak,$18.88,$51.85
+US47,Alabama,US89,Hawaii,NonPeak,$27.63,$33.70
+US47,Alabama,US89,Hawaii,Peak,$32.60,$39.77
+US47,Alabama,UY,Uruguay,NonPeak,$29.28,$31.29
+US47,Alabama,UY,Uruguay,Peak,$34.55,$36.92
+US47,Alabama,VE,Venezuela,NonPeak,$30.90,$44.05
+US47,Alabama,VE,Venezuela,Peak,$36.46,$51.98
+US48,Mississippi,AR,Argentina,NonPeak,$15.28,$33.75
+US48,Mississippi,AR,Argentina,Peak,$18.03,$39.82
+US48,Mississippi,AS11,New South Wales/Australian Capital Territory,NonPeak,$16.05,$31.40
+US48,Mississippi,AS11,New South Wales/Australian Capital Territory,Peak,$18.94,$37.05
+US48,Mississippi,AS21,Northern Territory,NonPeak,$16.80,$44.17
+US48,Mississippi,AS21,Northern Territory,Peak,$19.82,$52.12
+US48,Mississippi,BA,Bahrain,NonPeak,$17.57,$33.98
+US48,Mississippi,BA,Bahrain,Peak,$20.73,$40.10
+US48,Mississippi,BE,Belgium,NonPeak,$18.33,$31.45
+US48,Mississippi,BE,Belgium,Peak,$21.63,$37.11
+US48,Mississippi,BL,Bolivia,NonPeak,$24.38,$44.28
+US48,Mississippi,BL,Bolivia,Peak,$28.77,$52.25
+US48,Mississippi,BR,Brazil - Brazilia,NonPeak,$16.00,$34.11
+US48,Mississippi,BR,Brazil - Brazilia,Peak,$18.88,$40.25
+US48,Mississippi,CA10,Ontario,NonPeak,$27.63,$31.63
+US48,Mississippi,CA10,Ontario,Peak,$32.60,$37.32
+US48,Mississippi,CA20,Quebec,NonPeak,$29.28,$44.51
+US48,Mississippi,CA20,Quebec,Peak,$34.55,$52.52
+US48,Mississippi,CA30,Manitoba,NonPeak,$30.90,$34.33
+US48,Mississippi,CA30,Manitoba,Peak,$36.46,$40.51
+US48,Mississippi,CI,Chile,NonPeak,$15.28,$31.74
+US48,Mississippi,CI,Chile,Peak,$18.03,$37.45
+US48,Mississippi,CO,Colombia,NonPeak,$16.05,$44.62
+US48,Mississippi,CO,Colombia,Peak,$18.94,$52.65
+US48,Mississippi,CS,Costa Rica,NonPeak,$16.80,$34.45
+US48,Mississippi,CS,Costa Rica,Peak,$19.82,$40.65
+US48,Mississippi,EC,Ecuador,NonPeak,$17.57,$31.91
+US48,Mississippi,EC,Ecuador,Peak,$20.73,$37.65
+US48,Mississippi,ES,El Salvador,NonPeak,$18.33,$44.74
+US48,Mississippi,ES,El Salvador,Peak,$21.63,$52.79
+US48,Mississippi,GE,Germany,NonPeak,$24.38,$34.56
+US48,Mississippi,GE,Germany,Peak,$28.77,$40.78
+US48,Mississippi,GQ,Guam,NonPeak,$16.00,$32.09
+US48,Mississippi,GQ,Guam,Peak,$18.88,$37.87
+US48,Mississippi,GR,Greece,NonPeak,$27.63,$44.91
+US48,Mississippi,GR,Greece,Peak,$32.60,$52.99
+US48,Mississippi,GR29,Crete,NonPeak,$29.28,$34.74
+US48,Mississippi,GR29,Crete,Peak,$34.55,$40.99
+US48,Mississippi,GT,Guatemala,NonPeak,$30.90,$32.26
+US48,Mississippi,GT,Guatemala,Peak,$36.46,$38.07
+US48,Mississippi,HO,Honduras,NonPeak,$15.28,$45.09
+US48,Mississippi,HO,Honduras,Peak,$18.03,$53.21
+US48,Mississippi,HU,Hungary,NonPeak,$16.05,$34.90
+US48,Mississippi,HU,Hungary,Peak,$18.94,$41.18
+US48,Mississippi,IT,Italy,NonPeak,$16.80,$32.44
+US48,Mississippi,IT,Italy,Peak,$19.82,$38.28
+US48,Mississippi,IT10,Sicily,NonPeak,$17.57,$43.94
+US48,Mississippi,IT10,Sicily,Peak,$20.73,$51.85
+US48,Mississippi,JA01,Japan-Central,NonPeak,$18.33,$33.70
+US48,Mississippi,JA01,Japan-Central,Peak,$21.63,$39.77
+US48,Mississippi,JA02,Japan-South (Excludes Hokkaido),NonPeak,$24.38,$31.29
+US48,Mississippi,JA02,Japan-South (Excludes Hokkaido),Peak,$28.77,$36.92
+US48,Mississippi,JA03,Japan-North,NonPeak,$16.00,$44.05
+US48,Mississippi,JA03,Japan-North,Peak,$18.88,$51.98
+US48,Mississippi,JA96,Okinawa,NonPeak,$27.63,$33.75
+US48,Mississippi,JA96,Okinawa,Peak,$32.60,$39.82
+US48,Mississippi,KS,"Korea, Republic Of",NonPeak,$29.28,$31.40
+US48,Mississippi,KS,"Korea, Republic Of",Peak,$34.55,$37.05
+US48,Mississippi,KU,Kuwait,NonPeak,$30.90,$44.17
+US48,Mississippi,KU,Kuwait,Peak,$36.46,$52.12
+US48,Mississippi,NL,Netherlands,NonPeak,$15.28,$33.98
+US48,Mississippi,NL,Netherlands,Peak,$18.03,$40.10
+US48,Mississippi,NO,Norway,NonPeak,$16.05,$31.45
+US48,Mississippi,NO,Norway,Peak,$18.94,$37.11
+US48,Mississippi,PA,Paraguay,NonPeak,$16.80,$44.28
+US48,Mississippi,PA,Paraguay,Peak,$19.82,$52.25
+US48,Mississippi,PE,Peru,NonPeak,$17.57,$34.11
+US48,Mississippi,PE,Peru,Peak,$20.73,$40.25
+US48,Mississippi,PL,Poland,NonPeak,$18.33,$31.63
+US48,Mississippi,PL,Poland,Peak,$21.63,$37.32
+US48,Mississippi,PO,Portugal,NonPeak,$24.38,$44.51
+US48,Mississippi,PO,Portugal,Peak,$28.77,$52.52
+US48,Mississippi,PO01,Azores,NonPeak,$16.00,$34.33
+US48,Mississippi,PO01,Azores,Peak,$18.88,$40.51
+US48,Mississippi,QA,Qatar,NonPeak,$27.63,$31.74
+US48,Mississippi,QA,Qatar,Peak,$32.60,$37.45
+US48,Mississippi,RO,Romania,NonPeak,$29.28,$44.62
+US48,Mississippi,RO,Romania,Peak,$34.55,$52.65
+US48,Mississippi,RQ,Puerto Rico,NonPeak,$30.90,$34.45
+US48,Mississippi,RQ,Puerto Rico,Peak,$36.46,$40.65
+US48,Mississippi,SA,Saudi Arabia,NonPeak,$15.28,$31.91
+US48,Mississippi,SA,Saudi Arabia,Peak,$18.03,$37.65
+US48,Mississippi,SN,Singapore,NonPeak,$16.05,$44.74
+US48,Mississippi,SN,Singapore,Peak,$18.94,$52.79
+US48,Mississippi,SP,Spain,NonPeak,$16.80,$34.56
+US48,Mississippi,SP,Spain,Peak,$19.82,$40.78
+US48,Mississippi,TU,Turkey,NonPeak,$17.57,$32.09
+US48,Mississippi,TU,Turkey,Peak,$20.73,$37.87
+US48,Mississippi,UK,United Kingdom,NonPeak,$18.33,$44.91
+US48,Mississippi,UK,United Kingdom,Peak,$21.63,$52.99
+US48,Mississippi,US8030400,Alaska (Zone) IV,NonPeak,$24.38,$34.74
+US48,Mississippi,US8030400,Alaska (Zone) IV,Peak,$28.77,$40.99
+US48,Mississippi,US8050500,Alaska (Zone) III,NonPeak,$16.00,$32.26
+US48,Mississippi,US8050500,Alaska (Zone) III,Peak,$18.88,$38.07
+US48,Mississippi,US8101000,Alaska (Zone) I,NonPeak,$27.63,$45.09
+US48,Mississippi,US8101000,Alaska (Zone) I,Peak,$32.60,$53.21
+US48,Mississippi,US8190100,Alaska (Zone) II,NonPeak,$29.28,$34.90
+US48,Mississippi,US8190100,Alaska (Zone) II,Peak,$34.55,$41.18
+US48,Mississippi,US89,Hawaii,NonPeak,$30.90,$32.44
+US48,Mississippi,US89,Hawaii,Peak,$36.46,$38.28
+US48,Mississippi,UY,Uruguay,NonPeak,$15.28,$43.94
+US48,Mississippi,UY,Uruguay,Peak,$18.03,$51.85
+US48,Mississippi,VE,Venezuela,NonPeak,$16.05,$33.70
+US48,Mississippi,VE,Venezuela,Peak,$18.94,$39.77
+US49,Florida-North,AR,Argentina,NonPeak,$16.80,$31.29
+US49,Florida-North,AR,Argentina,Peak,$19.82,$36.92
+US49,Florida-North,AS11,New South Wales/Australian Capital Territory,NonPeak,$17.57,$44.05
+US49,Florida-North,AS11,New South Wales/Australian Capital Territory,Peak,$20.73,$51.98
+US49,Florida-North,AS21,Northern Territory,NonPeak,$18.33,$33.75
+US49,Florida-North,AS21,Northern Territory,Peak,$21.63,$39.82
+US49,Florida-North,BA,Bahrain,NonPeak,$24.38,$31.40
+US49,Florida-North,BA,Bahrain,Peak,$28.77,$37.05
+US49,Florida-North,BE,Belgium,NonPeak,$16.00,$44.17
+US49,Florida-North,BE,Belgium,Peak,$18.88,$52.12
+US49,Florida-North,BL,Bolivia,NonPeak,$27.63,$33.98
+US49,Florida-North,BL,Bolivia,Peak,$32.60,$40.10
+US49,Florida-North,BR,Brazil - Brazilia,NonPeak,$29.28,$31.45
+US49,Florida-North,BR,Brazil - Brazilia,Peak,$34.55,$37.11
+US49,Florida-North,CA10,Ontario,NonPeak,$30.90,$44.28
+US49,Florida-North,CA10,Ontario,Peak,$36.46,$52.25
+US49,Florida-North,CA20,Quebec,NonPeak,$15.28,$34.11
+US49,Florida-North,CA20,Quebec,Peak,$18.03,$40.25
+US49,Florida-North,CA30,Manitoba,NonPeak,$16.05,$31.63
+US49,Florida-North,CA30,Manitoba,Peak,$18.94,$37.32
+US49,Florida-North,CI,Chile,NonPeak,$16.80,$44.51
+US49,Florida-North,CI,Chile,Peak,$19.82,$52.52
+US49,Florida-North,CO,Colombia,NonPeak,$17.57,$34.33
+US49,Florida-North,CO,Colombia,Peak,$20.73,$40.51
+US49,Florida-North,CS,Costa Rica,NonPeak,$18.33,$31.74
+US49,Florida-North,CS,Costa Rica,Peak,$21.63,$37.45
+US49,Florida-North,EC,Ecuador,NonPeak,$24.38,$44.62
+US49,Florida-North,EC,Ecuador,Peak,$28.77,$52.65
+US49,Florida-North,ES,El Salvador,NonPeak,$16.00,$34.45
+US49,Florida-North,ES,El Salvador,Peak,$18.88,$40.65
+US49,Florida-North,GE,Germany,NonPeak,$27.63,$31.91
+US49,Florida-North,GE,Germany,Peak,$32.60,$37.65
+US49,Florida-North,GQ,Guam,NonPeak,$29.28,$44.74
+US49,Florida-North,GQ,Guam,Peak,$34.55,$52.79
+US49,Florida-North,GR,Greece,NonPeak,$30.90,$34.56
+US49,Florida-North,GR,Greece,Peak,$36.46,$40.78
+US49,Florida-North,GR29,Crete,NonPeak,$15.28,$32.09
+US49,Florida-North,GR29,Crete,Peak,$18.03,$37.87
+US49,Florida-North,GT,Guatemala,NonPeak,$16.05,$44.91
+US49,Florida-North,GT,Guatemala,Peak,$18.94,$52.99
+US49,Florida-North,HO,Honduras,NonPeak,$16.80,$34.74
+US49,Florida-North,HO,Honduras,Peak,$19.82,$40.99
+US49,Florida-North,HU,Hungary,NonPeak,$17.57,$32.26
+US49,Florida-North,HU,Hungary,Peak,$20.73,$38.07
+US49,Florida-North,IT,Italy,NonPeak,$18.33,$45.09
+US49,Florida-North,IT,Italy,Peak,$21.63,$53.21
+US49,Florida-North,IT10,Sicily,NonPeak,$24.38,$34.90
+US49,Florida-North,IT10,Sicily,Peak,$28.77,$41.18
+US49,Florida-North,JA01,Japan-Central,NonPeak,$16.00,$32.44
+US49,Florida-North,JA01,Japan-Central,Peak,$18.88,$38.28
+US49,Florida-North,JA02,Japan-South (Excludes Hokkaido),NonPeak,$27.63,$43.94
+US49,Florida-North,JA02,Japan-South (Excludes Hokkaido),Peak,$32.60,$51.85
+US49,Florida-North,JA03,Japan-North,NonPeak,$29.28,$33.70
+US49,Florida-North,JA03,Japan-North,Peak,$34.55,$39.77
+US49,Florida-North,JA96,Okinawa,NonPeak,$30.90,$31.29
+US49,Florida-North,JA96,Okinawa,Peak,$36.46,$36.92
+US49,Florida-North,KS,"Korea, Republic Of",NonPeak,$15.28,$44.05
+US49,Florida-North,KS,"Korea, Republic Of",Peak,$18.03,$51.98
+US49,Florida-North,KU,Kuwait,NonPeak,$16.05,$33.75
+US49,Florida-North,KU,Kuwait,Peak,$18.94,$39.82
+US49,Florida-North,NL,Netherlands,NonPeak,$16.80,$31.40
+US49,Florida-North,NL,Netherlands,Peak,$19.82,$37.05
+US49,Florida-North,NO,Norway,NonPeak,$17.57,$44.17
+US49,Florida-North,NO,Norway,Peak,$20.73,$52.12
+US49,Florida-North,PA,Paraguay,NonPeak,$18.33,$33.98
+US49,Florida-North,PA,Paraguay,Peak,$21.63,$40.10
+US49,Florida-North,PE,Peru,NonPeak,$24.38,$31.45
+US49,Florida-North,PE,Peru,Peak,$28.77,$37.11
+US49,Florida-North,PL,Poland,NonPeak,$16.00,$44.28
+US49,Florida-North,PL,Poland,Peak,$18.88,$52.25
+US49,Florida-North,PO,Portugal,NonPeak,$27.63,$34.11
+US49,Florida-North,PO,Portugal,Peak,$32.60,$40.25
+US49,Florida-North,PO01,Azores,NonPeak,$29.28,$31.63
+US49,Florida-North,PO01,Azores,Peak,$34.55,$37.32
+US49,Florida-North,QA,Qatar,NonPeak,$30.90,$44.51
+US49,Florida-North,QA,Qatar,Peak,$36.46,$52.52
+US49,Florida-North,RO,Romania,NonPeak,$15.28,$34.33
+US49,Florida-North,RO,Romania,Peak,$18.03,$40.51
+US49,Florida-North,RQ,Puerto Rico,NonPeak,$16.05,$31.74
+US49,Florida-North,RQ,Puerto Rico,Peak,$18.94,$37.45
+US49,Florida-North,SA,Saudi Arabia,NonPeak,$16.80,$44.62
+US49,Florida-North,SA,Saudi Arabia,Peak,$19.82,$52.65
+US49,Florida-North,SN,Singapore,NonPeak,$17.57,$34.45
+US49,Florida-North,SN,Singapore,Peak,$20.73,$40.65
+US49,Florida-North,SP,Spain,NonPeak,$18.33,$31.91
+US49,Florida-North,SP,Spain,Peak,$21.63,$37.65
+US49,Florida-North,TU,Turkey,NonPeak,$24.38,$44.74
+US49,Florida-North,TU,Turkey,Peak,$28.77,$52.79
+US49,Florida-North,UK,United Kingdom,NonPeak,$16.00,$34.56
+US49,Florida-North,UK,United Kingdom,Peak,$18.88,$40.78
+US49,Florida-North,US8030400,Alaska (Zone) IV,NonPeak,$27.63,$32.09
+US49,Florida-North,US8030400,Alaska (Zone) IV,Peak,$32.60,$37.87
+US49,Florida-North,US8050500,Alaska (Zone) III,NonPeak,$29.28,$44.91
+US49,Florida-North,US8050500,Alaska (Zone) III,Peak,$34.55,$52.99
+US49,Florida-North,US8101000,Alaska (Zone) I,NonPeak,$30.90,$34.74
+US49,Florida-North,US8101000,Alaska (Zone) I,Peak,$36.46,$40.99
+US49,Florida-North,US8190100,Alaska (Zone) II,NonPeak,$15.28,$32.26
+US49,Florida-North,US8190100,Alaska (Zone) II,Peak,$18.03,$38.07
+US49,Florida-North,US89,Hawaii,NonPeak,$16.05,$45.09
+US49,Florida-North,US89,Hawaii,Peak,$18.94,$53.21
+US49,Florida-North,UY,Uruguay,NonPeak,$16.80,$34.90
+US49,Florida-North,UY,Uruguay,Peak,$19.82,$41.18
+US49,Florida-North,VE,Venezuela,NonPeak,$17.57,$32.44
+US49,Florida-North,VE,Venezuela,Peak,$20.73,$38.28
+US4964400,Florida-South,AR,Argentina,NonPeak,$18.33,$43.94
+US4964400,Florida-South,AR,Argentina,Peak,$21.63,$51.85
+US4964400,Florida-South,AS11,New South Wales/Australian Capital Territory,NonPeak,$24.38,$33.70
+US4964400,Florida-South,AS11,New South Wales/Australian Capital Territory,Peak,$28.77,$39.77
+US4964400,Florida-South,AS21,Northern Territory,NonPeak,$16.00,$31.29
+US4964400,Florida-South,AS21,Northern Territory,Peak,$18.88,$36.92
+US4964400,Florida-South,BA,Bahrain,NonPeak,$27.63,$44.05
+US4964400,Florida-South,BA,Bahrain,Peak,$32.60,$51.98
+US4964400,Florida-South,BE,Belgium,NonPeak,$29.28,$33.75
+US4964400,Florida-South,BE,Belgium,Peak,$34.55,$39.82
+US4964400,Florida-South,BL,Bolivia,NonPeak,$30.90,$31.40
+US4964400,Florida-South,BL,Bolivia,Peak,$36.46,$37.05
+US4964400,Florida-South,BR,Brazil - Brazilia,NonPeak,$15.28,$44.17
+US4964400,Florida-South,BR,Brazil - Brazilia,Peak,$18.03,$52.12
+US4964400,Florida-South,CA10,Ontario,NonPeak,$16.05,$33.98
+US4964400,Florida-South,CA10,Ontario,Peak,$18.94,$40.10
+US4964400,Florida-South,CA20,Quebec,NonPeak,$16.80,$31.45
+US4964400,Florida-South,CA20,Quebec,Peak,$19.82,$37.11
+US4964400,Florida-South,CA30,Manitoba,NonPeak,$17.57,$44.28
+US4964400,Florida-South,CA30,Manitoba,Peak,$20.73,$52.25
+US4964400,Florida-South,CI,Chile,NonPeak,$18.33,$34.11
+US4964400,Florida-South,CI,Chile,Peak,$21.63,$40.25
+US4964400,Florida-South,CO,Colombia,NonPeak,$24.38,$31.63
+US4964400,Florida-South,CO,Colombia,Peak,$28.77,$37.32
+US4964400,Florida-South,CS,Costa Rica,NonPeak,$16.00,$44.51
+US4964400,Florida-South,CS,Costa Rica,Peak,$18.88,$52.52
+US4964400,Florida-South,EC,Ecuador,NonPeak,$27.63,$34.33
+US4964400,Florida-South,EC,Ecuador,Peak,$32.60,$40.51
+US4964400,Florida-South,ES,El Salvador,NonPeak,$29.28,$31.74
+US4964400,Florida-South,ES,El Salvador,Peak,$34.55,$37.45
+US4964400,Florida-South,GE,Germany,NonPeak,$30.90,$44.62
+US4964400,Florida-South,GE,Germany,Peak,$36.46,$52.65
+US4964400,Florida-South,GQ,Guam,NonPeak,$15.28,$34.45
+US4964400,Florida-South,GQ,Guam,Peak,$18.03,$40.65
+US4964400,Florida-South,GR,Greece,NonPeak,$16.05,$31.91
+US4964400,Florida-South,GR,Greece,Peak,$18.94,$37.65
+US4964400,Florida-South,GR29,Crete,NonPeak,$16.80,$44.74
+US4964400,Florida-South,GR29,Crete,Peak,$19.82,$52.79
+US4964400,Florida-South,GT,Guatemala,NonPeak,$17.57,$34.56
+US4964400,Florida-South,GT,Guatemala,Peak,$20.73,$40.78
+US4964400,Florida-South,HO,Honduras,NonPeak,$18.33,$32.09
+US4964400,Florida-South,HO,Honduras,Peak,$21.63,$37.87
+US4964400,Florida-South,HU,Hungary,NonPeak,$24.38,$44.91
+US4964400,Florida-South,HU,Hungary,Peak,$28.77,$52.99
+US4964400,Florida-South,IT,Italy,NonPeak,$16.00,$34.74
+US4964400,Florida-South,IT,Italy,Peak,$18.88,$40.99
+US4964400,Florida-South,IT10,Sicily,NonPeak,$27.63,$32.26
+US4964400,Florida-South,IT10,Sicily,Peak,$32.60,$38.07
+US4964400,Florida-South,JA01,Japan-Central,NonPeak,$29.28,$45.09
+US4964400,Florida-South,JA01,Japan-Central,Peak,$34.55,$53.21
+US4964400,Florida-South,JA02,Japan-South (Excludes Hokkaido),NonPeak,$30.90,$34.90
+US4964400,Florida-South,JA02,Japan-South (Excludes Hokkaido),Peak,$36.46,$41.18
+US4964400,Florida-South,JA03,Japan-North,NonPeak,$15.28,$32.44
+US4964400,Florida-South,JA03,Japan-North,Peak,$18.03,$38.28
+US4964400,Florida-South,JA96,Okinawa,NonPeak,$16.05,$43.94
+US4964400,Florida-South,JA96,Okinawa,Peak,$18.94,$51.85
+US4964400,Florida-South,KS,"Korea, Republic Of",NonPeak,$16.80,$33.70
+US4964400,Florida-South,KS,"Korea, Republic Of",Peak,$19.82,$39.77
+US4964400,Florida-South,KU,Kuwait,NonPeak,$17.57,$31.29
+US4964400,Florida-South,KU,Kuwait,Peak,$20.73,$36.92
+US4964400,Florida-South,NL,Netherlands,NonPeak,$18.33,$44.05
+US4964400,Florida-South,NL,Netherlands,Peak,$21.63,$51.98
+US4964400,Florida-South,NO,Norway,NonPeak,$24.38,$33.75
+US4964400,Florida-South,NO,Norway,Peak,$28.77,$39.82
+US4964400,Florida-South,PA,Paraguay,NonPeak,$16.00,$31.40
+US4964400,Florida-South,PA,Paraguay,Peak,$18.88,$37.05
+US4964400,Florida-South,PE,Peru,NonPeak,$27.63,$44.17
+US4964400,Florida-South,PE,Peru,Peak,$32.60,$52.12
+US4964400,Florida-South,PL,Poland,NonPeak,$29.28,$33.98
+US4964400,Florida-South,PL,Poland,Peak,$34.55,$40.10
+US4964400,Florida-South,PO,Portugal,NonPeak,$30.90,$31.45
+US4964400,Florida-South,PO,Portugal,Peak,$36.46,$37.11
+US4964400,Florida-South,PO01,Azores,NonPeak,$15.28,$44.28
+US4964400,Florida-South,PO01,Azores,Peak,$18.03,$52.25
+US4964400,Florida-South,QA,Qatar,NonPeak,$16.05,$34.11
+US4964400,Florida-South,QA,Qatar,Peak,$18.94,$40.25
+US4964400,Florida-South,RO,Romania,NonPeak,$16.80,$31.63
+US4964400,Florida-South,RO,Romania,Peak,$19.82,$37.32
+US4964400,Florida-South,RQ,Puerto Rico,NonPeak,$17.57,$44.51
+US4964400,Florida-South,RQ,Puerto Rico,Peak,$20.73,$52.52
+US4964400,Florida-South,SA,Saudi Arabia,NonPeak,$18.33,$34.33
+US4964400,Florida-South,SA,Saudi Arabia,Peak,$21.63,$40.51
+US4964400,Florida-South,SN,Singapore,NonPeak,$24.38,$31.74
+US4964400,Florida-South,SN,Singapore,Peak,$28.77,$37.45
+US4964400,Florida-South,SP,Spain,NonPeak,$16.00,$44.62
+US4964400,Florida-South,SP,Spain,Peak,$18.88,$52.65
+US4964400,Florida-South,TU,Turkey,NonPeak,$27.63,$34.45
+US4964400,Florida-South,TU,Turkey,Peak,$32.60,$40.65
+US4964400,Florida-South,UK,United Kingdom,NonPeak,$29.28,$31.91
+US4964400,Florida-South,UK,United Kingdom,Peak,$34.55,$37.65
+US4964400,Florida-South,US8030400,Alaska (Zone) IV,NonPeak,$30.90,$44.74
+US4964400,Florida-South,US8030400,Alaska (Zone) IV,Peak,$36.46,$52.79
+US4964400,Florida-South,US8050500,Alaska (Zone) III,NonPeak,$15.28,$34.56
+US4964400,Florida-South,US8050500,Alaska (Zone) III,Peak,$18.03,$40.78
+US4964400,Florida-South,US8101000,Alaska (Zone) I,NonPeak,$16.05,$32.09
+US4964400,Florida-South,US8101000,Alaska (Zone) I,Peak,$18.94,$37.87
+US4964400,Florida-South,US8190100,Alaska (Zone) II,NonPeak,$16.80,$44.91
+US4964400,Florida-South,US8190100,Alaska (Zone) II,Peak,$19.82,$52.99
+US4964400,Florida-South,US89,Hawaii,NonPeak,$17.57,$34.74
+US4964400,Florida-South,US89,Hawaii,Peak,$20.73,$40.99
+US4964400,Florida-South,UY,Uruguay,NonPeak,$18.33,$32.26
+US4964400,Florida-South,UY,Uruguay,Peak,$21.63,$38.07
+US4964400,Florida-South,VE,Venezuela,NonPeak,$24.38,$45.09
+US4964400,Florida-South,VE,Venezuela,Peak,$28.77,$53.21
+US4965500,Florida Keys,AR,Argentina,NonPeak,$16.00,$34.90
+US4965500,Florida Keys,AR,Argentina,Peak,$18.88,$41.18
+US4965500,Florida Keys,AS11,New South Wales/Australian Capital Territory,NonPeak,$27.63,$32.44
+US4965500,Florida Keys,AS11,New South Wales/Australian Capital Territory,Peak,$32.60,$38.28
+US4965500,Florida Keys,AS21,Northern Territory,NonPeak,$29.28,$43.94
+US4965500,Florida Keys,AS21,Northern Territory,Peak,$34.55,$51.85
+US4965500,Florida Keys,BA,Bahrain,NonPeak,$30.90,$33.70
+US4965500,Florida Keys,BA,Bahrain,Peak,$36.46,$39.77
+US4965500,Florida Keys,BE,Belgium,NonPeak,$15.28,$31.29
+US4965500,Florida Keys,BE,Belgium,Peak,$18.03,$36.92
+US4965500,Florida Keys,BL,Bolivia,NonPeak,$16.05,$44.05
+US4965500,Florida Keys,BL,Bolivia,Peak,$18.94,$51.98
+US4965500,Florida Keys,BR,Brazil - Brazilia,NonPeak,$16.80,$33.75
+US4965500,Florida Keys,BR,Brazil - Brazilia,Peak,$19.82,$39.82
+US4965500,Florida Keys,CA10,Ontario,NonPeak,$17.57,$31.40
+US4965500,Florida Keys,CA10,Ontario,Peak,$20.73,$37.05
+US4965500,Florida Keys,CA20,Quebec,NonPeak,$18.33,$44.17
+US4965500,Florida Keys,CA20,Quebec,Peak,$21.63,$52.12
+US4965500,Florida Keys,CA30,Manitoba,NonPeak,$24.38,$33.98
+US4965500,Florida Keys,CA30,Manitoba,Peak,$28.77,$40.10
+US4965500,Florida Keys,CI,Chile,NonPeak,$16.00,$31.45
+US4965500,Florida Keys,CI,Chile,Peak,$18.88,$37.11
+US4965500,Florida Keys,CO,Colombia,NonPeak,$27.63,$44.28
+US4965500,Florida Keys,CO,Colombia,Peak,$32.60,$52.25
+US4965500,Florida Keys,CS,Costa Rica,NonPeak,$29.28,$34.11
+US4965500,Florida Keys,CS,Costa Rica,Peak,$34.55,$40.25
+US4965500,Florida Keys,EC,Ecuador,NonPeak,$30.90,$31.63
+US4965500,Florida Keys,EC,Ecuador,Peak,$36.46,$37.32
+US4965500,Florida Keys,ES,El Salvador,NonPeak,$15.28,$44.51
+US4965500,Florida Keys,ES,El Salvador,Peak,$18.03,$52.52
+US4965500,Florida Keys,GE,Germany,NonPeak,$16.05,$34.33
+US4965500,Florida Keys,GE,Germany,Peak,$18.94,$40.51
+US4965500,Florida Keys,GQ,Guam,NonPeak,$16.80,$31.74
+US4965500,Florida Keys,GQ,Guam,Peak,$19.82,$37.45
+US4965500,Florida Keys,GR,Greece,NonPeak,$17.57,$44.62
+US4965500,Florida Keys,GR,Greece,Peak,$20.73,$52.65
+US4965500,Florida Keys,GR29,Crete,NonPeak,$18.33,$34.45
+US4965500,Florida Keys,GR29,Crete,Peak,$21.63,$40.65
+US4965500,Florida Keys,GT,Guatemala,NonPeak,$24.38,$31.91
+US4965500,Florida Keys,GT,Guatemala,Peak,$28.77,$37.65
+US4965500,Florida Keys,HO,Honduras,NonPeak,$16.00,$44.74
+US4965500,Florida Keys,HO,Honduras,Peak,$18.88,$52.79
+US4965500,Florida Keys,HU,Hungary,NonPeak,$27.63,$34.56
+US4965500,Florida Keys,HU,Hungary,Peak,$32.60,$40.78
+US4965500,Florida Keys,IT,Italy,NonPeak,$29.28,$32.09
+US4965500,Florida Keys,IT,Italy,Peak,$34.55,$37.87
+US4965500,Florida Keys,IT10,Sicily,NonPeak,$30.90,$44.91
+US4965500,Florida Keys,IT10,Sicily,Peak,$36.46,$52.99
+US4965500,Florida Keys,JA01,Japan-Central,NonPeak,$15.28,$34.74
+US4965500,Florida Keys,JA01,Japan-Central,Peak,$18.03,$40.99
+US4965500,Florida Keys,JA02,Japan-South (Excludes Hokkaido),NonPeak,$16.05,$32.26
+US4965500,Florida Keys,JA02,Japan-South (Excludes Hokkaido),Peak,$18.94,$38.07
+US4965500,Florida Keys,JA03,Japan-North,NonPeak,$16.80,$45.09
+US4965500,Florida Keys,JA03,Japan-North,Peak,$19.82,$53.21
+US4965500,Florida Keys,JA96,Okinawa,NonPeak,$17.57,$34.90
+US4965500,Florida Keys,JA96,Okinawa,Peak,$20.73,$41.18
+US4965500,Florida Keys,KS,"Korea, Republic Of",NonPeak,$18.33,$32.44
+US4965500,Florida Keys,KS,"Korea, Republic Of",Peak,$21.63,$38.28
+US4965500,Florida Keys,KU,Kuwait,NonPeak,$24.38,$43.94
+US4965500,Florida Keys,KU,Kuwait,Peak,$28.77,$51.85
+US4965500,Florida Keys,NL,Netherlands,NonPeak,$16.00,$33.70
+US4965500,Florida Keys,NL,Netherlands,Peak,$18.88,$39.77
+US4965500,Florida Keys,NO,Norway,NonPeak,$27.63,$31.29
+US4965500,Florida Keys,NO,Norway,Peak,$32.60,$36.92
+US4965500,Florida Keys,PA,Paraguay,NonPeak,$29.28,$44.05
+US4965500,Florida Keys,PA,Paraguay,Peak,$34.55,$51.98
+US4965500,Florida Keys,PE,Peru,NonPeak,$30.90,$33.75
+US4965500,Florida Keys,PE,Peru,Peak,$36.46,$39.82
+US4965500,Florida Keys,PL,Poland,NonPeak,$15.28,$31.40
+US4965500,Florida Keys,PL,Poland,Peak,$18.03,$37.05
+US4965500,Florida Keys,PO,Portugal,NonPeak,$16.05,$44.17
+US4965500,Florida Keys,PO,Portugal,Peak,$18.94,$52.12
+US4965500,Florida Keys,PO01,Azores,NonPeak,$16.80,$33.98
+US4965500,Florida Keys,PO01,Azores,Peak,$19.82,$40.10
+US4965500,Florida Keys,QA,Qatar,NonPeak,$17.57,$31.45
+US4965500,Florida Keys,QA,Qatar,Peak,$20.73,$37.11
+US4965500,Florida Keys,RO,Romania,NonPeak,$18.33,$44.28
+US4965500,Florida Keys,RO,Romania,Peak,$21.63,$52.25
+US4965500,Florida Keys,RQ,Puerto Rico,NonPeak,$24.38,$34.11
+US4965500,Florida Keys,RQ,Puerto Rico,Peak,$28.77,$40.25
+US4965500,Florida Keys,SA,Saudi Arabia,NonPeak,$16.00,$31.63
+US4965500,Florida Keys,SA,Saudi Arabia,Peak,$18.88,$37.32
+US4965500,Florida Keys,SN,Singapore,NonPeak,$27.63,$44.51
+US4965500,Florida Keys,SN,Singapore,Peak,$32.60,$52.52
+US4965500,Florida Keys,SP,Spain,NonPeak,$29.28,$34.33
+US4965500,Florida Keys,SP,Spain,Peak,$34.55,$40.51
+US4965500,Florida Keys,TU,Turkey,NonPeak,$30.90,$31.74
+US4965500,Florida Keys,TU,Turkey,Peak,$36.46,$37.45
+US4965500,Florida Keys,UK,United Kingdom,NonPeak,$15.28,$44.62
+US4965500,Florida Keys,UK,United Kingdom,Peak,$18.03,$52.65
+US4965500,Florida Keys,US8030400,Alaska (Zone) IV,NonPeak,$16.05,$34.45
+US4965500,Florida Keys,US8030400,Alaska (Zone) IV,Peak,$18.94,$40.65
+US4965500,Florida Keys,US8050500,Alaska (Zone) III,NonPeak,$16.80,$31.91
+US4965500,Florida Keys,US8050500,Alaska (Zone) III,Peak,$19.82,$37.65
+US4965500,Florida Keys,US8101000,Alaska (Zone) I,NonPeak,$17.57,$44.74
+US4965500,Florida Keys,US8101000,Alaska (Zone) I,Peak,$20.73,$52.79
+US4965500,Florida Keys,US8190100,Alaska (Zone) II,NonPeak,$18.33,$34.56
+US4965500,Florida Keys,US8190100,Alaska (Zone) II,Peak,$21.63,$40.78
+US4965500,Florida Keys,US89,Hawaii,NonPeak,$24.38,$32.09
+US4965500,Florida Keys,US89,Hawaii,Peak,$28.77,$37.87
+US4965500,Florida Keys,UY,Uruguay,NonPeak,$16.00,$44.91
+US4965500,Florida Keys,UY,Uruguay,Peak,$18.88,$52.99
+US4965500,Florida Keys,VE,Venezuela,NonPeak,$27.63,$34.74
+US4965500,Florida Keys,VE,Venezuela,Peak,$32.60,$40.99
+US50,Minnesota,AR,Argentina,NonPeak,$29.28,$32.26
+US50,Minnesota,AR,Argentina,Peak,$34.55,$38.07
+US50,Minnesota,AS11,New South Wales/Australian Capital Territory,NonPeak,$30.90,$45.09
+US50,Minnesota,AS11,New South Wales/Australian Capital Territory,Peak,$36.46,$53.21
+US50,Minnesota,AS21,Northern Territory,NonPeak,$15.28,$34.90
+US50,Minnesota,AS21,Northern Territory,Peak,$18.03,$41.18
+US50,Minnesota,BA,Bahrain,NonPeak,$16.05,$32.44
+US50,Minnesota,BA,Bahrain,Peak,$18.94,$38.28
+US50,Minnesota,BE,Belgium,NonPeak,$16.80,$43.94
+US50,Minnesota,BE,Belgium,Peak,$19.82,$51.85
+US50,Minnesota,BL,Bolivia,NonPeak,$17.57,$33.70
+US50,Minnesota,BL,Bolivia,Peak,$20.73,$39.77
+US50,Minnesota,BR,Brazil - Brazilia,NonPeak,$18.33,$31.29
+US50,Minnesota,BR,Brazil - Brazilia,Peak,$21.63,$36.92
+US50,Minnesota,CA10,Ontario,NonPeak,$24.38,$44.05
+US50,Minnesota,CA10,Ontario,Peak,$28.77,$51.98
+US50,Minnesota,CA20,Quebec,NonPeak,$16.00,$33.75
+US50,Minnesota,CA20,Quebec,Peak,$18.88,$39.82
+US50,Minnesota,CA30,Manitoba,NonPeak,$27.63,$31.40
+US50,Minnesota,CA30,Manitoba,Peak,$32.60,$37.05
+US50,Minnesota,CI,Chile,NonPeak,$29.28,$44.17
+US50,Minnesota,CI,Chile,Peak,$34.55,$52.12
+US50,Minnesota,CO,Colombia,NonPeak,$30.90,$33.98
+US50,Minnesota,CO,Colombia,Peak,$36.46,$40.10
+US50,Minnesota,CS,Costa Rica,NonPeak,$15.28,$31.45
+US50,Minnesota,CS,Costa Rica,Peak,$18.03,$37.11
+US50,Minnesota,EC,Ecuador,NonPeak,$16.05,$44.28
+US50,Minnesota,EC,Ecuador,Peak,$18.94,$52.25
+US50,Minnesota,ES,El Salvador,NonPeak,$16.80,$34.11
+US50,Minnesota,ES,El Salvador,Peak,$19.82,$40.25
+US50,Minnesota,GE,Germany,NonPeak,$17.57,$31.63
+US50,Minnesota,GE,Germany,Peak,$20.73,$37.32
+US50,Minnesota,GQ,Guam,NonPeak,$18.33,$44.51
+US50,Minnesota,GQ,Guam,Peak,$21.63,$52.52
+US50,Minnesota,GR,Greece,NonPeak,$24.38,$34.33
+US50,Minnesota,GR,Greece,Peak,$28.77,$40.51
+US50,Minnesota,GR29,Crete,NonPeak,$16.00,$31.74
+US50,Minnesota,GR29,Crete,Peak,$18.88,$37.45
+US50,Minnesota,GT,Guatemala,NonPeak,$27.63,$44.62
+US50,Minnesota,GT,Guatemala,Peak,$32.60,$52.65
+US50,Minnesota,HO,Honduras,NonPeak,$29.28,$34.45
+US50,Minnesota,HO,Honduras,Peak,$34.55,$40.65
+US50,Minnesota,HU,Hungary,NonPeak,$30.90,$31.91
+US50,Minnesota,HU,Hungary,Peak,$36.46,$37.65
+US50,Minnesota,IT,Italy,NonPeak,$15.28,$44.74
+US50,Minnesota,IT,Italy,Peak,$18.03,$52.79
+US50,Minnesota,IT10,Sicily,NonPeak,$16.05,$34.56
+US50,Minnesota,IT10,Sicily,Peak,$18.94,$40.78
+US50,Minnesota,JA01,Japan-Central,NonPeak,$16.80,$32.09
+US50,Minnesota,JA01,Japan-Central,Peak,$19.82,$37.87
+US50,Minnesota,JA02,Japan-South (Excludes Hokkaido),NonPeak,$17.57,$44.91
+US50,Minnesota,JA02,Japan-South (Excludes Hokkaido),Peak,$20.73,$52.99
+US50,Minnesota,JA03,Japan-North,NonPeak,$18.33,$34.74
+US50,Minnesota,JA03,Japan-North,Peak,$21.63,$40.99
+US50,Minnesota,JA96,Okinawa,NonPeak,$24.38,$32.26
+US50,Minnesota,JA96,Okinawa,Peak,$28.77,$38.07
+US50,Minnesota,KS,"Korea, Republic Of",NonPeak,$16.00,$45.09
+US50,Minnesota,KS,"Korea, Republic Of",Peak,$18.88,$53.21
+US50,Minnesota,KU,Kuwait,NonPeak,$27.63,$34.90
+US50,Minnesota,KU,Kuwait,Peak,$32.60,$41.18
+US50,Minnesota,NL,Netherlands,NonPeak,$29.28,$32.44
+US50,Minnesota,NL,Netherlands,Peak,$34.55,$38.28
+US50,Minnesota,NO,Norway,NonPeak,$30.90,$43.94
+US50,Minnesota,NO,Norway,Peak,$36.46,$51.85
+US50,Minnesota,PA,Paraguay,NonPeak,$15.28,$33.70
+US50,Minnesota,PA,Paraguay,Peak,$18.03,$39.77
+US50,Minnesota,PE,Peru,NonPeak,$16.05,$31.29
+US50,Minnesota,PE,Peru,Peak,$18.94,$36.92
+US50,Minnesota,PL,Poland,NonPeak,$16.80,$44.05
+US50,Minnesota,PL,Poland,Peak,$19.82,$51.98
+US50,Minnesota,PO,Portugal,NonPeak,$17.57,$33.75
+US50,Minnesota,PO,Portugal,Peak,$20.73,$39.82
+US50,Minnesota,PO01,Azores,NonPeak,$18.33,$31.40
+US50,Minnesota,PO01,Azores,Peak,$21.63,$37.05
+US50,Minnesota,QA,Qatar,NonPeak,$24.38,$44.17
+US50,Minnesota,QA,Qatar,Peak,$28.77,$52.12
+US50,Minnesota,RO,Romania,NonPeak,$16.00,$33.98
+US50,Minnesota,RO,Romania,Peak,$18.88,$40.10
+US50,Minnesota,RQ,Puerto Rico,NonPeak,$27.63,$31.45
+US50,Minnesota,RQ,Puerto Rico,Peak,$32.60,$37.11
+US50,Minnesota,SA,Saudi Arabia,NonPeak,$29.28,$44.28
+US50,Minnesota,SA,Saudi Arabia,Peak,$34.55,$52.25
+US50,Minnesota,SN,Singapore,NonPeak,$30.90,$34.11
+US50,Minnesota,SN,Singapore,Peak,$36.46,$40.25
+US50,Minnesota,SP,Spain,NonPeak,$15.28,$31.63
+US50,Minnesota,SP,Spain,Peak,$18.03,$37.32
+US50,Minnesota,TU,Turkey,NonPeak,$16.05,$44.51
+US50,Minnesota,TU,Turkey,Peak,$18.94,$52.52
+US50,Minnesota,UK,United Kingdom,NonPeak,$16.80,$34.33
+US50,Minnesota,UK,United Kingdom,Peak,$19.82,$40.51
+US50,Minnesota,US8030400,Alaska (Zone) IV,NonPeak,$17.57,$31.74
+US50,Minnesota,US8030400,Alaska (Zone) IV,Peak,$20.73,$37.45
+US50,Minnesota,US8050500,Alaska (Zone) III,NonPeak,$18.33,$44.62
+US50,Minnesota,US8050500,Alaska (Zone) III,Peak,$21.63,$52.65
+US50,Minnesota,US8101000,Alaska (Zone) I,NonPeak,$24.38,$34.45
+US50,Minnesota,US8101000,Alaska (Zone) I,Peak,$28.77,$40.65
+US50,Minnesota,US8190100,Alaska (Zone) II,NonPeak,$16.00,$31.91
+US50,Minnesota,US8190100,Alaska (Zone) II,Peak,$18.88,$37.65
+US50,Minnesota,US89,Hawaii,NonPeak,$27.63,$44.74
+US50,Minnesota,US89,Hawaii,Peak,$32.60,$52.79
+US50,Minnesota,UY,Uruguay,NonPeak,$29.28,$34.56
+US50,Minnesota,UY,Uruguay,Peak,$34.55,$40.78
+US50,Minnesota,VE,Venezuela,NonPeak,$30.90,$32.09
+US50,Minnesota,VE,Venezuela,Peak,$36.46,$37.87
+US51,North Dakota,AR,Argentina,NonPeak,$15.28,$44.91
+US51,North Dakota,AR,Argentina,Peak,$18.03,$52.99
+US51,North Dakota,AS11,New South Wales/Australian Capital Territory,NonPeak,$16.05,$34.74
+US51,North Dakota,AS11,New South Wales/Australian Capital Territory,Peak,$18.94,$40.99
+US51,North Dakota,AS21,Northern Territory,NonPeak,$16.80,$32.26
+US51,North Dakota,AS21,Northern Territory,Peak,$19.82,$38.07
+US51,North Dakota,BA,Bahrain,NonPeak,$17.57,$45.09
+US51,North Dakota,BA,Bahrain,Peak,$20.73,$53.21
+US51,North Dakota,BE,Belgium,NonPeak,$18.33,$34.90
+US51,North Dakota,BE,Belgium,Peak,$21.63,$41.18
+US51,North Dakota,BL,Bolivia,NonPeak,$24.38,$32.44
+US51,North Dakota,BL,Bolivia,Peak,$28.77,$38.28
+US51,North Dakota,BR,Brazil - Brazilia,NonPeak,$16.00,$43.94
+US51,North Dakota,BR,Brazil - Brazilia,Peak,$18.88,$51.85
+US51,North Dakota,CA10,Ontario,NonPeak,$27.63,$33.70
+US51,North Dakota,CA10,Ontario,Peak,$32.60,$39.77
+US51,North Dakota,CA20,Quebec,NonPeak,$29.28,$31.29
+US51,North Dakota,CA20,Quebec,Peak,$34.55,$36.92
+US51,North Dakota,CA30,Manitoba,NonPeak,$30.90,$44.05
+US51,North Dakota,CA30,Manitoba,Peak,$36.46,$51.98
+US51,North Dakota,CI,Chile,NonPeak,$15.28,$33.75
+US51,North Dakota,CI,Chile,Peak,$18.03,$39.82
+US51,North Dakota,CO,Colombia,NonPeak,$16.05,$31.40
+US51,North Dakota,CO,Colombia,Peak,$18.94,$37.05
+US51,North Dakota,CS,Costa Rica,NonPeak,$16.80,$44.17
+US51,North Dakota,CS,Costa Rica,Peak,$19.82,$52.12
+US51,North Dakota,EC,Ecuador,NonPeak,$17.57,$33.98
+US51,North Dakota,EC,Ecuador,Peak,$20.73,$40.10
+US51,North Dakota,ES,El Salvador,NonPeak,$18.33,$31.45
+US51,North Dakota,ES,El Salvador,Peak,$21.63,$37.11
+US51,North Dakota,GE,Germany,NonPeak,$24.38,$44.28
+US51,North Dakota,GE,Germany,Peak,$28.77,$52.25
+US51,North Dakota,GQ,Guam,NonPeak,$16.00,$34.11
+US51,North Dakota,GQ,Guam,Peak,$18.88,$40.25
+US51,North Dakota,GR,Greece,NonPeak,$27.63,$31.63
+US51,North Dakota,GR,Greece,Peak,$32.60,$37.32
+US51,North Dakota,GR29,Crete,NonPeak,$29.28,$44.51
+US51,North Dakota,GR29,Crete,Peak,$34.55,$52.52
+US51,North Dakota,GT,Guatemala,NonPeak,$30.90,$34.33
+US51,North Dakota,GT,Guatemala,Peak,$36.46,$40.51
+US51,North Dakota,HO,Honduras,NonPeak,$15.28,$31.74
+US51,North Dakota,HO,Honduras,Peak,$18.03,$37.45
+US51,North Dakota,HU,Hungary,NonPeak,$16.05,$44.62
+US51,North Dakota,HU,Hungary,Peak,$18.94,$52.65
+US51,North Dakota,IT,Italy,NonPeak,$16.80,$34.45
+US51,North Dakota,IT,Italy,Peak,$19.82,$40.65
+US51,North Dakota,IT10,Sicily,NonPeak,$17.57,$31.91
+US51,North Dakota,IT10,Sicily,Peak,$20.73,$37.65
+US51,North Dakota,JA01,Japan-Central,NonPeak,$18.33,$44.74
+US51,North Dakota,JA01,Japan-Central,Peak,$21.63,$52.79
+US51,North Dakota,JA02,Japan-South (Excludes Hokkaido),NonPeak,$24.38,$34.56
+US51,North Dakota,JA02,Japan-South (Excludes Hokkaido),Peak,$28.77,$40.78
+US51,North Dakota,JA03,Japan-North,NonPeak,$16.00,$32.09
+US51,North Dakota,JA03,Japan-North,Peak,$18.88,$37.87
+US51,North Dakota,JA96,Okinawa,NonPeak,$27.63,$44.91
+US51,North Dakota,JA96,Okinawa,Peak,$32.60,$52.99
+US51,North Dakota,KS,"Korea, Republic Of",NonPeak,$29.28,$34.74
+US51,North Dakota,KS,"Korea, Republic Of",Peak,$34.55,$40.99
+US51,North Dakota,KU,Kuwait,NonPeak,$30.90,$32.26
+US51,North Dakota,KU,Kuwait,Peak,$36.46,$38.07
+US51,North Dakota,NL,Netherlands,NonPeak,$15.28,$45.09
+US51,North Dakota,NL,Netherlands,Peak,$18.03,$53.21
+US51,North Dakota,NO,Norway,NonPeak,$16.05,$34.90
+US51,North Dakota,NO,Norway,Peak,$18.94,$41.18
+US51,North Dakota,PA,Paraguay,NonPeak,$16.80,$32.44
+US51,North Dakota,PA,Paraguay,Peak,$19.82,$38.28
+US51,North Dakota,PE,Peru,NonPeak,$17.57,$43.94
+US51,North Dakota,PE,Peru,Peak,$20.73,$51.85
+US51,North Dakota,PL,Poland,NonPeak,$18.33,$33.70
+US51,North Dakota,PL,Poland,Peak,$21.63,$39.77
+US51,North Dakota,PO,Portugal,NonPeak,$24.38,$31.29
+US51,North Dakota,PO,Portugal,Peak,$28.77,$36.92
+US51,North Dakota,PO01,Azores,NonPeak,$16.00,$44.05
+US51,North Dakota,PO01,Azores,Peak,$18.88,$51.98
+US51,North Dakota,QA,Qatar,NonPeak,$27.63,$33.75
+US51,North Dakota,QA,Qatar,Peak,$32.60,$39.82
+US51,North Dakota,RO,Romania,NonPeak,$29.28,$31.40
+US51,North Dakota,RO,Romania,Peak,$34.55,$37.05
+US51,North Dakota,RQ,Puerto Rico,NonPeak,$30.90,$44.17
+US51,North Dakota,RQ,Puerto Rico,Peak,$36.46,$52.12
+US51,North Dakota,SA,Saudi Arabia,NonPeak,$15.28,$33.98
+US51,North Dakota,SA,Saudi Arabia,Peak,$18.03,$40.10
+US51,North Dakota,SN,Singapore,NonPeak,$16.05,$31.45
+US51,North Dakota,SN,Singapore,Peak,$18.94,$37.11
+US51,North Dakota,SP,Spain,NonPeak,$16.80,$44.28
+US51,North Dakota,SP,Spain,Peak,$19.82,$52.25
+US51,North Dakota,TU,Turkey,NonPeak,$17.57,$34.11
+US51,North Dakota,TU,Turkey,Peak,$20.73,$40.25
+US51,North Dakota,UK,United Kingdom,NonPeak,$18.33,$31.63
+US51,North Dakota,UK,United Kingdom,Peak,$21.63,$37.32
+US51,North Dakota,US8030400,Alaska (Zone) IV,NonPeak,$24.38,$44.51
+US51,North Dakota,US8030400,Alaska (Zone) IV,Peak,$28.77,$52.52
+US51,North Dakota,US8050500,Alaska (Zone) III,NonPeak,$16.00,$34.33
+US51,North Dakota,US8050500,Alaska (Zone) III,Peak,$18.88,$40.51
+US51,North Dakota,US8101000,Alaska (Zone) I,NonPeak,$27.63,$31.74
+US51,North Dakota,US8101000,Alaska (Zone) I,Peak,$32.60,$37.45
+US51,North Dakota,US8190100,Alaska (Zone) II,NonPeak,$29.28,$44.62
+US51,North Dakota,US8190100,Alaska (Zone) II,Peak,$34.55,$52.65
+US51,North Dakota,US89,Hawaii,NonPeak,$30.90,$34.45
+US51,North Dakota,US89,Hawaii,Peak,$36.46,$40.65
+US51,North Dakota,UY,Uruguay,NonPeak,$15.28,$31.91
+US51,North Dakota,UY,Uruguay,Peak,$18.03,$37.65
+US51,North Dakota,VE,Venezuela,NonPeak,$16.05,$44.74
+US51,North Dakota,VE,Venezuela,Peak,$18.94,$52.79
+US52,South Dakota,AR,Argentina,NonPeak,$16.80,$34.56
+US52,South Dakota,AR,Argentina,Peak,$19.82,$40.78
+US52,South Dakota,AS11,New South Wales/Australian Capital Territory,NonPeak,$17.57,$32.09
+US52,South Dakota,AS11,New South Wales/Australian Capital Territory,Peak,$20.73,$37.87
+US52,South Dakota,AS21,Northern Territory,NonPeak,$18.33,$44.91
+US52,South Dakota,AS21,Northern Territory,Peak,$21.63,$52.99
+US52,South Dakota,BA,Bahrain,NonPeak,$24.38,$34.74
+US52,South Dakota,BA,Bahrain,Peak,$28.77,$40.99
+US52,South Dakota,BE,Belgium,NonPeak,$16.00,$32.26
+US52,South Dakota,BE,Belgium,Peak,$18.88,$38.07
+US52,South Dakota,BL,Bolivia,NonPeak,$27.63,$45.09
+US52,South Dakota,BL,Bolivia,Peak,$32.60,$53.21
+US52,South Dakota,BR,Brazil - Brazilia,NonPeak,$29.28,$34.90
+US52,South Dakota,BR,Brazil - Brazilia,Peak,$34.55,$41.18
+US52,South Dakota,CA10,Ontario,NonPeak,$30.90,$32.44
+US52,South Dakota,CA10,Ontario,Peak,$36.46,$38.28
+US52,South Dakota,CA20,Quebec,NonPeak,$15.28,$43.94
+US52,South Dakota,CA20,Quebec,Peak,$18.03,$51.85
+US52,South Dakota,CA30,Manitoba,NonPeak,$16.05,$33.70
+US52,South Dakota,CA30,Manitoba,Peak,$18.94,$39.77
+US52,South Dakota,CI,Chile,NonPeak,$16.80,$31.29
+US52,South Dakota,CI,Chile,Peak,$19.82,$36.92
+US52,South Dakota,CO,Colombia,NonPeak,$17.57,$44.05
+US52,South Dakota,CO,Colombia,Peak,$20.73,$51.98
+US52,South Dakota,CS,Costa Rica,NonPeak,$18.33,$33.75
+US52,South Dakota,CS,Costa Rica,Peak,$21.63,$39.82
+US52,South Dakota,EC,Ecuador,NonPeak,$24.38,$31.40
+US52,South Dakota,EC,Ecuador,Peak,$28.77,$37.05
+US52,South Dakota,ES,El Salvador,NonPeak,$16.00,$44.17
+US52,South Dakota,ES,El Salvador,Peak,$18.88,$52.12
+US52,South Dakota,GE,Germany,NonPeak,$27.63,$33.98
+US52,South Dakota,GE,Germany,Peak,$32.60,$40.10
+US52,South Dakota,GQ,Guam,NonPeak,$29.28,$31.45
+US52,South Dakota,GQ,Guam,Peak,$34.55,$37.11
+US52,South Dakota,GR,Greece,NonPeak,$30.90,$44.28
+US52,South Dakota,GR,Greece,Peak,$36.46,$52.25
+US52,South Dakota,GR29,Crete,NonPeak,$15.28,$34.11
+US52,South Dakota,GR29,Crete,Peak,$18.03,$40.25
+US52,South Dakota,GT,Guatemala,NonPeak,$16.05,$31.63
+US52,South Dakota,GT,Guatemala,Peak,$18.94,$37.32
+US52,South Dakota,HO,Honduras,NonPeak,$16.80,$44.51
+US52,South Dakota,HO,Honduras,Peak,$19.82,$52.52
+US52,South Dakota,HU,Hungary,NonPeak,$17.57,$34.33
+US52,South Dakota,HU,Hungary,Peak,$20.73,$40.51
+US52,South Dakota,IT,Italy,NonPeak,$18.33,$31.74
+US52,South Dakota,IT,Italy,Peak,$21.63,$37.45
+US52,South Dakota,IT10,Sicily,NonPeak,$24.38,$44.62
+US52,South Dakota,IT10,Sicily,Peak,$28.77,$52.65
+US52,South Dakota,JA01,Japan-Central,NonPeak,$16.00,$34.45
+US52,South Dakota,JA01,Japan-Central,Peak,$18.88,$40.65
+US52,South Dakota,JA02,Japan-South (Excludes Hokkaido),NonPeak,$27.63,$31.91
+US52,South Dakota,JA02,Japan-South (Excludes Hokkaido),Peak,$32.60,$37.65
+US52,South Dakota,JA03,Japan-North,NonPeak,$29.28,$44.74
+US52,South Dakota,JA03,Japan-North,Peak,$34.55,$52.79
+US52,South Dakota,JA96,Okinawa,NonPeak,$30.90,$34.56
+US52,South Dakota,JA96,Okinawa,Peak,$36.46,$40.78
+US52,South Dakota,KS,"Korea, Republic Of",NonPeak,$15.28,$32.09
+US52,South Dakota,KS,"Korea, Republic Of",Peak,$18.03,$37.87
+US52,South Dakota,KU,Kuwait,NonPeak,$16.05,$44.91
+US52,South Dakota,KU,Kuwait,Peak,$18.94,$52.99
+US52,South Dakota,NL,Netherlands,NonPeak,$16.80,$34.74
+US52,South Dakota,NL,Netherlands,Peak,$19.82,$40.99
+US52,South Dakota,NO,Norway,NonPeak,$17.57,$32.26
+US52,South Dakota,NO,Norway,Peak,$20.73,$38.07
+US52,South Dakota,PA,Paraguay,NonPeak,$18.33,$45.09
+US52,South Dakota,PA,Paraguay,Peak,$21.63,$53.21
+US52,South Dakota,PE,Peru,NonPeak,$24.38,$34.90
+US52,South Dakota,PE,Peru,Peak,$28.77,$41.18
+US52,South Dakota,PL,Poland,NonPeak,$16.00,$32.44
+US52,South Dakota,PL,Poland,Peak,$18.88,$38.28
+US52,South Dakota,PO,Portugal,NonPeak,$27.63,$43.94
+US52,South Dakota,PO,Portugal,Peak,$32.60,$51.85
+US52,South Dakota,PO01,Azores,NonPeak,$29.28,$33.70
+US52,South Dakota,PO01,Azores,Peak,$34.55,$39.77
+US52,South Dakota,QA,Qatar,NonPeak,$30.90,$31.29
+US52,South Dakota,QA,Qatar,Peak,$36.46,$36.92
+US52,South Dakota,RO,Romania,NonPeak,$15.28,$44.05
+US52,South Dakota,RO,Romania,Peak,$18.03,$51.98
+US52,South Dakota,RQ,Puerto Rico,NonPeak,$16.05,$33.75
+US52,South Dakota,RQ,Puerto Rico,Peak,$18.94,$39.82
+US52,South Dakota,SA,Saudi Arabia,NonPeak,$16.80,$31.40
+US52,South Dakota,SA,Saudi Arabia,Peak,$19.82,$37.05
+US52,South Dakota,SN,Singapore,NonPeak,$17.57,$44.17
+US52,South Dakota,SN,Singapore,Peak,$20.73,$52.12
+US52,South Dakota,SP,Spain,NonPeak,$18.33,$33.98
+US52,South Dakota,SP,Spain,Peak,$21.63,$40.10
+US52,South Dakota,TU,Turkey,NonPeak,$24.38,$31.45
+US52,South Dakota,TU,Turkey,Peak,$28.77,$37.11
+US52,South Dakota,UK,United Kingdom,NonPeak,$16.00,$44.28
+US52,South Dakota,UK,United Kingdom,Peak,$18.88,$52.25
+US52,South Dakota,US8030400,Alaska (Zone) IV,NonPeak,$27.63,$34.11
+US52,South Dakota,US8030400,Alaska (Zone) IV,Peak,$32.60,$40.25
+US52,South Dakota,US8050500,Alaska (Zone) III,NonPeak,$29.28,$31.63
+US52,South Dakota,US8050500,Alaska (Zone) III,Peak,$34.55,$37.32
+US52,South Dakota,US8101000,Alaska (Zone) I,NonPeak,$30.90,$44.51
+US52,South Dakota,US8101000,Alaska (Zone) I,Peak,$36.46,$52.52
+US52,South Dakota,US8190100,Alaska (Zone) II,NonPeak,$15.28,$34.33
+US52,South Dakota,US8190100,Alaska (Zone) II,Peak,$18.03,$40.51
+US52,South Dakota,US89,Hawaii,NonPeak,$16.05,$31.74
+US52,South Dakota,US89,Hawaii,Peak,$18.94,$37.45
+US52,South Dakota,UY,Uruguay,NonPeak,$16.80,$44.62
+US52,South Dakota,UY,Uruguay,Peak,$19.82,$52.65
+US52,South Dakota,VE,Venezuela,NonPeak,$17.57,$34.45
+US52,South Dakota,VE,Venezuela,Peak,$20.73,$40.65
+US53,Iowa,AR,Argentina,NonPeak,$18.33,$31.91
+US53,Iowa,AR,Argentina,Peak,$21.63,$37.65
+US53,Iowa,AS11,New South Wales/Australian Capital Territory,NonPeak,$24.38,$44.74
+US53,Iowa,AS11,New South Wales/Australian Capital Territory,Peak,$28.77,$52.79
+US53,Iowa,AS21,Northern Territory,NonPeak,$16.00,$34.56
+US53,Iowa,AS21,Northern Territory,Peak,$18.88,$40.78
+US53,Iowa,BA,Bahrain,NonPeak,$27.63,$32.09
+US53,Iowa,BA,Bahrain,Peak,$32.60,$37.87
+US53,Iowa,BE,Belgium,NonPeak,$29.28,$44.91
+US53,Iowa,BE,Belgium,Peak,$34.55,$52.99
+US53,Iowa,BL,Bolivia,NonPeak,$30.90,$34.74
+US53,Iowa,BL,Bolivia,Peak,$36.46,$40.99
+US53,Iowa,BR,Brazil - Brazilia,NonPeak,$15.28,$32.26
+US53,Iowa,BR,Brazil - Brazilia,Peak,$18.03,$38.07
+US53,Iowa,CA10,Ontario,NonPeak,$16.05,$45.09
+US53,Iowa,CA10,Ontario,Peak,$18.94,$53.21
+US53,Iowa,CA20,Quebec,NonPeak,$16.80,$34.90
+US53,Iowa,CA20,Quebec,Peak,$19.82,$41.18
+US53,Iowa,CA30,Manitoba,NonPeak,$17.57,$32.44
+US53,Iowa,CA30,Manitoba,Peak,$20.73,$38.28
+US53,Iowa,CI,Chile,NonPeak,$18.33,$43.94
+US53,Iowa,CI,Chile,Peak,$21.63,$51.85
+US53,Iowa,CO,Colombia,NonPeak,$24.38,$33.70
+US53,Iowa,CO,Colombia,Peak,$28.77,$39.77
+US53,Iowa,CS,Costa Rica,NonPeak,$16.00,$31.29
+US53,Iowa,CS,Costa Rica,Peak,$18.88,$36.92
+US53,Iowa,EC,Ecuador,NonPeak,$27.63,$44.05
+US53,Iowa,EC,Ecuador,Peak,$32.60,$51.98
+US53,Iowa,ES,El Salvador,NonPeak,$29.28,$33.75
+US53,Iowa,ES,El Salvador,Peak,$34.55,$39.82
+US53,Iowa,GE,Germany,NonPeak,$30.90,$31.40
+US53,Iowa,GE,Germany,Peak,$36.46,$37.05
+US53,Iowa,GQ,Guam,NonPeak,$15.28,$44.17
+US53,Iowa,GQ,Guam,Peak,$18.03,$52.12
+US53,Iowa,GR,Greece,NonPeak,$16.05,$33.98
+US53,Iowa,GR,Greece,Peak,$18.94,$40.10
+US53,Iowa,GR29,Crete,NonPeak,$16.80,$31.45
+US53,Iowa,GR29,Crete,Peak,$19.82,$37.11
+US53,Iowa,GT,Guatemala,NonPeak,$17.57,$44.28
+US53,Iowa,GT,Guatemala,Peak,$20.73,$52.25
+US53,Iowa,HO,Honduras,NonPeak,$18.33,$34.11
+US53,Iowa,HO,Honduras,Peak,$21.63,$40.25
+US53,Iowa,HU,Hungary,NonPeak,$24.38,$31.63
+US53,Iowa,HU,Hungary,Peak,$28.77,$37.32
+US53,Iowa,IT,Italy,NonPeak,$16.00,$44.51
+US53,Iowa,IT,Italy,Peak,$18.88,$52.52
+US53,Iowa,IT10,Sicily,NonPeak,$27.63,$34.33
+US53,Iowa,IT10,Sicily,Peak,$32.60,$40.51
+US53,Iowa,JA01,Japan-Central,NonPeak,$29.28,$31.74
+US53,Iowa,JA01,Japan-Central,Peak,$34.55,$37.45
+US53,Iowa,JA02,Japan-South (Excludes Hokkaido),NonPeak,$30.90,$44.62
+US53,Iowa,JA02,Japan-South (Excludes Hokkaido),Peak,$36.46,$52.65
+US53,Iowa,JA03,Japan-North,NonPeak,$15.28,$34.45
+US53,Iowa,JA03,Japan-North,Peak,$18.03,$40.65
+US53,Iowa,JA96,Okinawa,NonPeak,$16.05,$31.91
+US53,Iowa,JA96,Okinawa,Peak,$18.94,$37.65
+US53,Iowa,KS,"Korea, Republic Of",NonPeak,$16.80,$44.74
+US53,Iowa,KS,"Korea, Republic Of",Peak,$19.82,$52.79
+US53,Iowa,KU,Kuwait,NonPeak,$17.57,$34.56
+US53,Iowa,KU,Kuwait,Peak,$20.73,$40.78
+US53,Iowa,NL,Netherlands,NonPeak,$18.33,$32.09
+US53,Iowa,NL,Netherlands,Peak,$21.63,$37.87
+US53,Iowa,NO,Norway,NonPeak,$24.38,$44.91
+US53,Iowa,NO,Norway,Peak,$28.77,$52.99
+US53,Iowa,PA,Paraguay,NonPeak,$16.00,$34.74
+US53,Iowa,PA,Paraguay,Peak,$18.88,$40.99
+US53,Iowa,PE,Peru,NonPeak,$27.63,$32.26
+US53,Iowa,PE,Peru,Peak,$32.60,$38.07
+US53,Iowa,PL,Poland,NonPeak,$29.28,$45.09
+US53,Iowa,PL,Poland,Peak,$34.55,$53.21
+US53,Iowa,PO,Portugal,NonPeak,$30.90,$34.90
+US53,Iowa,PO,Portugal,Peak,$36.46,$41.18
+US53,Iowa,PO01,Azores,NonPeak,$15.28,$32.44
+US53,Iowa,PO01,Azores,Peak,$18.03,$38.28
+US53,Iowa,QA,Qatar,NonPeak,$16.05,$43.94
+US53,Iowa,QA,Qatar,Peak,$18.94,$51.85
+US53,Iowa,RO,Romania,NonPeak,$16.80,$33.70
+US53,Iowa,RO,Romania,Peak,$19.82,$39.77
+US53,Iowa,RQ,Puerto Rico,NonPeak,$17.57,$31.29
+US53,Iowa,RQ,Puerto Rico,Peak,$20.73,$36.92
+US53,Iowa,SA,Saudi Arabia,NonPeak,$18.33,$44.05
+US53,Iowa,SA,Saudi Arabia,Peak,$21.63,$51.98
+US53,Iowa,SN,Singapore,NonPeak,$24.38,$33.75
+US53,Iowa,SN,Singapore,Peak,$28.77,$39.82
+US53,Iowa,SP,Spain,NonPeak,$16.00,$31.40
+US53,Iowa,SP,Spain,Peak,$18.88,$37.05
+US53,Iowa,TU,Turkey,NonPeak,$27.63,$44.17
+US53,Iowa,TU,Turkey,Peak,$32.60,$52.12
+US53,Iowa,UK,United Kingdom,NonPeak,$29.28,$33.98
+US53,Iowa,UK,United Kingdom,Peak,$34.55,$40.10
+US53,Iowa,US8030400,Alaska (Zone) IV,NonPeak,$30.90,$31.45
+US53,Iowa,US8030400,Alaska (Zone) IV,Peak,$36.46,$37.11
+US53,Iowa,US8050500,Alaska (Zone) III,NonPeak,$15.28,$44.28
+US53,Iowa,US8050500,Alaska (Zone) III,Peak,$18.03,$52.25
+US53,Iowa,US8101000,Alaska (Zone) I,NonPeak,$16.05,$34.11
+US53,Iowa,US8101000,Alaska (Zone) I,Peak,$18.94,$40.25
+US53,Iowa,US8190100,Alaska (Zone) II,NonPeak,$16.80,$31.63
+US53,Iowa,US8190100,Alaska (Zone) II,Peak,$19.82,$37.32
+US53,Iowa,US89,Hawaii,NonPeak,$17.57,$44.51
+US53,Iowa,US89,Hawaii,Peak,$20.73,$52.52
+US53,Iowa,UY,Uruguay,NonPeak,$18.33,$34.33
+US53,Iowa,UY,Uruguay,Peak,$21.63,$40.51
+US53,Iowa,VE,Venezuela,NonPeak,$24.38,$31.74
+US53,Iowa,VE,Venezuela,Peak,$28.77,$37.45
+US55,Nebraska,AR,Argentina,NonPeak,$16.00,$44.62
+US55,Nebraska,AR,Argentina,Peak,$18.88,$52.65
+US55,Nebraska,AS11,New South Wales/Australian Capital Territory,NonPeak,$27.63,$34.45
+US55,Nebraska,AS11,New South Wales/Australian Capital Territory,Peak,$32.60,$40.65
+US55,Nebraska,AS21,Northern Territory,NonPeak,$29.28,$31.91
+US55,Nebraska,AS21,Northern Territory,Peak,$34.55,$37.65
+US55,Nebraska,BA,Bahrain,NonPeak,$30.90,$44.74
+US55,Nebraska,BA,Bahrain,Peak,$36.46,$52.79
+US55,Nebraska,BE,Belgium,NonPeak,$15.28,$34.56
+US55,Nebraska,BE,Belgium,Peak,$18.03,$40.78
+US55,Nebraska,BL,Bolivia,NonPeak,$16.05,$32.09
+US55,Nebraska,BL,Bolivia,Peak,$18.94,$37.87
+US55,Nebraska,BR,Brazil - Brazilia,NonPeak,$16.80,$44.91
+US55,Nebraska,BR,Brazil - Brazilia,Peak,$19.82,$52.99
+US55,Nebraska,CA10,Ontario,NonPeak,$17.57,$34.74
+US55,Nebraska,CA10,Ontario,Peak,$20.73,$40.99
+US55,Nebraska,CA20,Quebec,NonPeak,$18.33,$32.26
+US55,Nebraska,CA20,Quebec,Peak,$21.63,$38.07
+US55,Nebraska,CA30,Manitoba,NonPeak,$24.38,$45.09
+US55,Nebraska,CA30,Manitoba,Peak,$28.77,$53.21
+US55,Nebraska,CI,Chile,NonPeak,$16.00,$34.90
+US55,Nebraska,CI,Chile,Peak,$18.88,$41.18
+US55,Nebraska,CO,Colombia,NonPeak,$27.63,$32.44
+US55,Nebraska,CO,Colombia,Peak,$32.60,$38.28
+US55,Nebraska,CS,Costa Rica,NonPeak,$29.28,$43.94
+US55,Nebraska,CS,Costa Rica,Peak,$34.55,$51.85
+US55,Nebraska,EC,Ecuador,NonPeak,$30.90,$33.70
+US55,Nebraska,EC,Ecuador,Peak,$36.46,$39.77
+US55,Nebraska,ES,El Salvador,NonPeak,$15.28,$31.29
+US55,Nebraska,ES,El Salvador,Peak,$18.03,$36.92
+US55,Nebraska,GE,Germany,NonPeak,$16.05,$44.05
+US55,Nebraska,GE,Germany,Peak,$18.94,$51.98
+US55,Nebraska,GQ,Guam,NonPeak,$16.80,$33.75
+US55,Nebraska,GQ,Guam,Peak,$19.82,$39.82
+US55,Nebraska,GR,Greece,NonPeak,$17.57,$31.40
+US55,Nebraska,GR,Greece,Peak,$20.73,$37.05
+US55,Nebraska,GR29,Crete,NonPeak,$18.33,$44.17
+US55,Nebraska,GR29,Crete,Peak,$21.63,$52.12
+US55,Nebraska,GT,Guatemala,NonPeak,$24.38,$33.98
+US55,Nebraska,GT,Guatemala,Peak,$28.77,$40.10
+US55,Nebraska,HO,Honduras,NonPeak,$16.00,$31.45
+US55,Nebraska,HO,Honduras,Peak,$18.88,$37.11
+US55,Nebraska,HU,Hungary,NonPeak,$27.63,$44.28
+US55,Nebraska,HU,Hungary,Peak,$32.60,$52.25
+US55,Nebraska,IT,Italy,NonPeak,$29.28,$34.11
+US55,Nebraska,IT,Italy,Peak,$34.55,$40.25
+US55,Nebraska,IT10,Sicily,NonPeak,$30.90,$31.63
+US55,Nebraska,IT10,Sicily,Peak,$36.46,$37.32
+US55,Nebraska,JA01,Japan-Central,NonPeak,$15.28,$44.51
+US55,Nebraska,JA01,Japan-Central,Peak,$18.03,$52.52
+US55,Nebraska,JA02,Japan-South (Excludes Hokkaido),NonPeak,$16.05,$34.33
+US55,Nebraska,JA02,Japan-South (Excludes Hokkaido),Peak,$18.94,$40.51
+US55,Nebraska,JA03,Japan-North,NonPeak,$16.80,$31.74
+US55,Nebraska,JA03,Japan-North,Peak,$19.82,$37.45
+US55,Nebraska,JA96,Okinawa,NonPeak,$17.57,$44.62
+US55,Nebraska,JA96,Okinawa,Peak,$20.73,$52.65
+US55,Nebraska,KS,"Korea, Republic Of",NonPeak,$18.33,$34.45
+US55,Nebraska,KS,"Korea, Republic Of",Peak,$21.63,$40.65
+US55,Nebraska,KU,Kuwait,NonPeak,$24.38,$31.91
+US55,Nebraska,KU,Kuwait,Peak,$28.77,$37.65
+US55,Nebraska,NL,Netherlands,NonPeak,$16.00,$44.74
+US55,Nebraska,NL,Netherlands,Peak,$18.88,$52.79
+US55,Nebraska,NO,Norway,NonPeak,$27.63,$34.56
+US55,Nebraska,NO,Norway,Peak,$32.60,$40.78
+US55,Nebraska,PA,Paraguay,NonPeak,$29.28,$32.09
+US55,Nebraska,PA,Paraguay,Peak,$34.55,$37.87
+US55,Nebraska,PE,Peru,NonPeak,$30.90,$44.91
+US55,Nebraska,PE,Peru,Peak,$36.46,$52.99
+US55,Nebraska,PL,Poland,NonPeak,$15.28,$34.74
+US55,Nebraska,PL,Poland,Peak,$18.03,$40.99
+US55,Nebraska,PO,Portugal,NonPeak,$16.05,$32.26
+US55,Nebraska,PO,Portugal,Peak,$18.94,$38.07
+US55,Nebraska,PO01,Azores,NonPeak,$16.80,$45.09
+US55,Nebraska,PO01,Azores,Peak,$19.82,$53.21
+US55,Nebraska,QA,Qatar,NonPeak,$17.57,$34.90
+US55,Nebraska,QA,Qatar,Peak,$20.73,$41.18
+US55,Nebraska,RO,Romania,NonPeak,$18.33,$32.44
+US55,Nebraska,RO,Romania,Peak,$21.63,$38.28
+US55,Nebraska,RQ,Puerto Rico,NonPeak,$24.38,$43.94
+US55,Nebraska,RQ,Puerto Rico,Peak,$28.77,$51.85
+US55,Nebraska,SA,Saudi Arabia,NonPeak,$16.00,$33.70
+US55,Nebraska,SA,Saudi Arabia,Peak,$18.88,$39.77
+US55,Nebraska,SN,Singapore,NonPeak,$27.63,$31.29
+US55,Nebraska,SN,Singapore,Peak,$32.60,$36.92
+US55,Nebraska,SP,Spain,NonPeak,$29.28,$44.05
+US55,Nebraska,SP,Spain,Peak,$34.55,$51.98
+US55,Nebraska,TU,Turkey,NonPeak,$30.90,$33.75
+US55,Nebraska,TU,Turkey,Peak,$36.46,$39.82
+US55,Nebraska,UK,United Kingdom,NonPeak,$15.28,$31.40
+US55,Nebraska,UK,United Kingdom,Peak,$18.03,$37.05
+US55,Nebraska,US8030400,Alaska (Zone) IV,NonPeak,$16.05,$44.17
+US55,Nebraska,US8030400,Alaska (Zone) IV,Peak,$18.94,$52.12
+US55,Nebraska,US8050500,Alaska (Zone) III,NonPeak,$16.80,$33.98
+US55,Nebraska,US8050500,Alaska (Zone) III,Peak,$19.82,$40.10
+US55,Nebraska,US8101000,Alaska (Zone) I,NonPeak,$17.57,$31.45
+US55,Nebraska,US8101000,Alaska (Zone) I,Peak,$20.73,$37.11
+US55,Nebraska,US8190100,Alaska (Zone) II,NonPeak,$18.33,$44.28
+US55,Nebraska,US8190100,Alaska (Zone) II,Peak,$21.63,$52.25
+US55,Nebraska,US89,Hawaii,NonPeak,$24.38,$34.11
+US55,Nebraska,US89,Hawaii,Peak,$28.77,$40.25
+US55,Nebraska,UY,Uruguay,NonPeak,$16.00,$31.63
+US55,Nebraska,UY,Uruguay,Peak,$18.88,$37.32
+US55,Nebraska,VE,Venezuela,NonPeak,$27.63,$44.51
+US55,Nebraska,VE,Venezuela,Peak,$32.60,$52.52
+US56,Missouri,AR,Argentina,NonPeak,$29.28,$34.33
+US56,Missouri,AR,Argentina,Peak,$34.55,$40.51
+US56,Missouri,AS11,New South Wales/Australian Capital Territory,NonPeak,$30.90,$31.74
+US56,Missouri,AS11,New South Wales/Australian Capital Territory,Peak,$36.46,$37.45
+US56,Missouri,AS21,Northern Territory,NonPeak,$15.28,$44.62
+US56,Missouri,AS21,Northern Territory,Peak,$18.03,$52.65
+US56,Missouri,BA,Bahrain,NonPeak,$16.05,$34.45
+US56,Missouri,BA,Bahrain,Peak,$18.94,$40.65
+US56,Missouri,BE,Belgium,NonPeak,$16.80,$31.91
+US56,Missouri,BE,Belgium,Peak,$19.82,$37.65
+US56,Missouri,BL,Bolivia,NonPeak,$17.57,$44.74
+US56,Missouri,BL,Bolivia,Peak,$20.73,$52.79
+US56,Missouri,BR,Brazil - Brazilia,NonPeak,$18.33,$34.56
+US56,Missouri,BR,Brazil - Brazilia,Peak,$21.63,$40.78
+US56,Missouri,CA10,Ontario,NonPeak,$24.38,$32.09
+US56,Missouri,CA10,Ontario,Peak,$28.77,$37.87
+US56,Missouri,CA20,Quebec,NonPeak,$16.00,$44.91
+US56,Missouri,CA20,Quebec,Peak,$18.88,$52.99
+US56,Missouri,CA30,Manitoba,NonPeak,$27.63,$34.74
+US56,Missouri,CA30,Manitoba,Peak,$32.60,$40.99
+US56,Missouri,CI,Chile,NonPeak,$29.28,$32.26
+US56,Missouri,CI,Chile,Peak,$34.55,$38.07
+US56,Missouri,CO,Colombia,NonPeak,$30.90,$45.09
+US56,Missouri,CO,Colombia,Peak,$36.46,$53.21
+US56,Missouri,CS,Costa Rica,NonPeak,$15.28,$34.90
+US56,Missouri,CS,Costa Rica,Peak,$18.03,$41.18
+US56,Missouri,EC,Ecuador,NonPeak,$16.05,$32.44
+US56,Missouri,EC,Ecuador,Peak,$18.94,$38.28
+US56,Missouri,ES,El Salvador,NonPeak,$16.80,$43.94
+US56,Missouri,ES,El Salvador,Peak,$19.82,$51.85
+US56,Missouri,GE,Germany,NonPeak,$17.57,$33.70
+US56,Missouri,GE,Germany,Peak,$20.73,$39.77
+US56,Missouri,GQ,Guam,NonPeak,$18.33,$31.29
+US56,Missouri,GQ,Guam,Peak,$21.63,$36.92
+US56,Missouri,GR,Greece,NonPeak,$24.38,$44.05
+US56,Missouri,GR,Greece,Peak,$28.77,$51.98
+US56,Missouri,GR29,Crete,NonPeak,$16.00,$33.75
+US56,Missouri,GR29,Crete,Peak,$18.88,$39.82
+US56,Missouri,GT,Guatemala,NonPeak,$27.63,$31.40
+US56,Missouri,GT,Guatemala,Peak,$32.60,$37.05
+US56,Missouri,HO,Honduras,NonPeak,$29.28,$44.17
+US56,Missouri,HO,Honduras,Peak,$34.55,$52.12
+US56,Missouri,HU,Hungary,NonPeak,$30.90,$33.98
+US56,Missouri,HU,Hungary,Peak,$36.46,$40.10
+US56,Missouri,IT,Italy,NonPeak,$15.28,$31.45
+US56,Missouri,IT,Italy,Peak,$18.03,$37.11
+US56,Missouri,IT10,Sicily,NonPeak,$16.05,$44.28
+US56,Missouri,IT10,Sicily,Peak,$18.94,$52.25
+US56,Missouri,JA01,Japan-Central,NonPeak,$16.80,$34.11
+US56,Missouri,JA01,Japan-Central,Peak,$19.82,$40.25
+US56,Missouri,JA02,Japan-South (Excludes Hokkaido),NonPeak,$17.57,$31.63
+US56,Missouri,JA02,Japan-South (Excludes Hokkaido),Peak,$20.73,$37.32
+US56,Missouri,JA03,Japan-North,NonPeak,$18.33,$44.51
+US56,Missouri,JA03,Japan-North,Peak,$21.63,$52.52
+US56,Missouri,JA96,Okinawa,NonPeak,$24.38,$34.33
+US56,Missouri,JA96,Okinawa,Peak,$28.77,$40.51
+US56,Missouri,KS,"Korea, Republic Of",NonPeak,$16.00,$31.74
+US56,Missouri,KS,"Korea, Republic Of",Peak,$18.88,$37.45
+US56,Missouri,KU,Kuwait,NonPeak,$27.63,$44.62
+US56,Missouri,KU,Kuwait,Peak,$32.60,$52.65
+US56,Missouri,NL,Netherlands,NonPeak,$29.28,$34.45
+US56,Missouri,NL,Netherlands,Peak,$34.55,$40.65
+US56,Missouri,NO,Norway,NonPeak,$30.90,$31.91
+US56,Missouri,NO,Norway,Peak,$36.46,$37.65
+US56,Missouri,PA,Paraguay,NonPeak,$15.28,$44.74
+US56,Missouri,PA,Paraguay,Peak,$18.03,$52.79
+US56,Missouri,PE,Peru,NonPeak,$16.05,$34.56
+US56,Missouri,PE,Peru,Peak,$18.94,$40.78
+US56,Missouri,PL,Poland,NonPeak,$16.80,$32.09
+US56,Missouri,PL,Poland,Peak,$19.82,$37.87
+US56,Missouri,PO,Portugal,NonPeak,$17.57,$44.91
+US56,Missouri,PO,Portugal,Peak,$20.73,$52.99
+US56,Missouri,PO01,Azores,NonPeak,$18.33,$34.74
+US56,Missouri,PO01,Azores,Peak,$21.63,$40.99
+US56,Missouri,QA,Qatar,NonPeak,$24.38,$32.26
+US56,Missouri,QA,Qatar,Peak,$28.77,$38.07
+US56,Missouri,RO,Romania,NonPeak,$16.00,$45.09
+US56,Missouri,RO,Romania,Peak,$18.88,$53.21
+US56,Missouri,RQ,Puerto Rico,NonPeak,$27.63,$34.90
+US56,Missouri,RQ,Puerto Rico,Peak,$32.60,$41.18
+US56,Missouri,SA,Saudi Arabia,NonPeak,$29.28,$32.44
+US56,Missouri,SA,Saudi Arabia,Peak,$34.55,$38.28
+US56,Missouri,SN,Singapore,NonPeak,$30.90,$43.94
+US56,Missouri,SN,Singapore,Peak,$36.46,$51.85
+US56,Missouri,SP,Spain,NonPeak,$15.28,$33.70
+US56,Missouri,SP,Spain,Peak,$18.03,$39.77
+US56,Missouri,TU,Turkey,NonPeak,$16.05,$31.29
+US56,Missouri,TU,Turkey,Peak,$18.94,$36.92
+US56,Missouri,UK,United Kingdom,NonPeak,$16.80,$44.05
+US56,Missouri,UK,United Kingdom,Peak,$19.82,$51.98
+US56,Missouri,US8030400,Alaska (Zone) IV,NonPeak,$17.57,$33.75
+US56,Missouri,US8030400,Alaska (Zone) IV,Peak,$20.73,$39.82
+US56,Missouri,US8050500,Alaska (Zone) III,NonPeak,$18.33,$31.40
+US56,Missouri,US8050500,Alaska (Zone) III,Peak,$21.63,$37.05
+US56,Missouri,US8101000,Alaska (Zone) I,NonPeak,$24.38,$44.17
+US56,Missouri,US8101000,Alaska (Zone) I,Peak,$28.77,$52.12
+US56,Missouri,US8190100,Alaska (Zone) II,NonPeak,$16.00,$33.98
+US56,Missouri,US8190100,Alaska (Zone) II,Peak,$18.88,$40.10
+US56,Missouri,US89,Hawaii,NonPeak,$27.63,$31.45
+US56,Missouri,US89,Hawaii,Peak,$32.60,$37.11
+US56,Missouri,UY,Uruguay,NonPeak,$29.28,$44.28
+US56,Missouri,UY,Uruguay,Peak,$34.55,$52.25
+US56,Missouri,VE,Venezuela,NonPeak,$30.90,$34.11
+US56,Missouri,VE,Venezuela,Peak,$36.46,$40.25
+US58,Kansas,AR,Argentina,NonPeak,$15.28,$31.63
+US58,Kansas,AR,Argentina,Peak,$18.03,$37.32
+US58,Kansas,AS11,New South Wales/Australian Capital Territory,NonPeak,$16.05,$44.51
+US58,Kansas,AS11,New South Wales/Australian Capital Territory,Peak,$18.94,$52.52
+US58,Kansas,AS21,Northern Territory,NonPeak,$16.80,$34.33
+US58,Kansas,AS21,Northern Territory,Peak,$19.82,$40.51
+US58,Kansas,BA,Bahrain,NonPeak,$17.57,$31.74
+US58,Kansas,BA,Bahrain,Peak,$20.73,$37.45
+US58,Kansas,BE,Belgium,NonPeak,$18.33,$44.62
+US58,Kansas,BE,Belgium,Peak,$21.63,$52.65
+US58,Kansas,BL,Bolivia,NonPeak,$24.38,$34.45
+US58,Kansas,BL,Bolivia,Peak,$28.77,$40.65
+US58,Kansas,BR,Brazil - Brazilia,NonPeak,$16.00,$31.91
+US58,Kansas,BR,Brazil - Brazilia,Peak,$18.88,$37.65
+US58,Kansas,CA10,Ontario,NonPeak,$27.63,$44.74
+US58,Kansas,CA10,Ontario,Peak,$32.60,$52.79
+US58,Kansas,CA20,Quebec,NonPeak,$29.28,$34.56
+US58,Kansas,CA20,Quebec,Peak,$34.55,$40.78
+US58,Kansas,CA30,Manitoba,NonPeak,$30.90,$32.09
+US58,Kansas,CA30,Manitoba,Peak,$36.46,$37.87
+US58,Kansas,CI,Chile,NonPeak,$15.28,$44.91
+US58,Kansas,CI,Chile,Peak,$18.03,$52.99
+US58,Kansas,CO,Colombia,NonPeak,$16.05,$34.74
+US58,Kansas,CO,Colombia,Peak,$18.94,$40.99
+US58,Kansas,CS,Costa Rica,NonPeak,$16.80,$32.26
+US58,Kansas,CS,Costa Rica,Peak,$19.82,$38.07
+US58,Kansas,EC,Ecuador,NonPeak,$17.57,$45.09
+US58,Kansas,EC,Ecuador,Peak,$20.73,$53.21
+US58,Kansas,ES,El Salvador,NonPeak,$18.33,$34.90
+US58,Kansas,ES,El Salvador,Peak,$21.63,$41.18
+US58,Kansas,GE,Germany,NonPeak,$24.38,$32.44
+US58,Kansas,GE,Germany,Peak,$28.77,$38.28
+US58,Kansas,GQ,Guam,NonPeak,$16.00,$43.94
+US58,Kansas,GQ,Guam,Peak,$18.88,$51.85
+US58,Kansas,GR,Greece,NonPeak,$27.63,$33.70
+US58,Kansas,GR,Greece,Peak,$32.60,$39.77
+US58,Kansas,GR29,Crete,NonPeak,$29.28,$31.29
+US58,Kansas,GR29,Crete,Peak,$34.55,$36.92
+US58,Kansas,GT,Guatemala,NonPeak,$30.90,$44.05
+US58,Kansas,GT,Guatemala,Peak,$36.46,$51.98
+US58,Kansas,HO,Honduras,NonPeak,$15.28,$33.75
+US58,Kansas,HO,Honduras,Peak,$18.03,$39.82
+US58,Kansas,HU,Hungary,NonPeak,$16.05,$31.40
+US58,Kansas,HU,Hungary,Peak,$18.94,$37.05
+US58,Kansas,IT,Italy,NonPeak,$16.80,$44.17
+US58,Kansas,IT,Italy,Peak,$19.82,$52.12
+US58,Kansas,IT10,Sicily,NonPeak,$17.57,$33.98
+US58,Kansas,IT10,Sicily,Peak,$20.73,$40.10
+US58,Kansas,JA01,Japan-Central,NonPeak,$18.33,$31.45
+US58,Kansas,JA01,Japan-Central,Peak,$21.63,$37.11
+US58,Kansas,JA02,Japan-South (Excludes Hokkaido),NonPeak,$24.38,$44.28
+US58,Kansas,JA02,Japan-South (Excludes Hokkaido),Peak,$28.77,$52.25
+US58,Kansas,JA03,Japan-North,NonPeak,$16.00,$34.11
+US58,Kansas,JA03,Japan-North,Peak,$18.88,$40.25
+US58,Kansas,JA96,Okinawa,NonPeak,$27.63,$31.63
+US58,Kansas,JA96,Okinawa,Peak,$32.60,$37.32
+US58,Kansas,KS,"Korea, Republic Of",NonPeak,$29.28,$44.51
+US58,Kansas,KS,"Korea, Republic Of",Peak,$34.55,$52.52
+US58,Kansas,KU,Kuwait,NonPeak,$30.90,$34.33
+US58,Kansas,KU,Kuwait,Peak,$36.46,$40.51
+US58,Kansas,NL,Netherlands,NonPeak,$15.28,$31.74
+US58,Kansas,NL,Netherlands,Peak,$18.03,$37.45
+US58,Kansas,NO,Norway,NonPeak,$16.05,$44.62
+US58,Kansas,NO,Norway,Peak,$18.94,$52.65
+US58,Kansas,PA,Paraguay,NonPeak,$16.80,$34.45
+US58,Kansas,PA,Paraguay,Peak,$19.82,$40.65
+US58,Kansas,PE,Peru,NonPeak,$17.57,$31.91
+US58,Kansas,PE,Peru,Peak,$20.73,$37.65
+US58,Kansas,PL,Poland,NonPeak,$18.33,$44.74
+US58,Kansas,PL,Poland,Peak,$21.63,$52.79
+US58,Kansas,PO,Portugal,NonPeak,$24.38,$34.56
+US58,Kansas,PO,Portugal,Peak,$28.77,$40.78
+US58,Kansas,PO01,Azores,NonPeak,$16.00,$32.09
+US58,Kansas,PO01,Azores,Peak,$18.88,$37.87
+US58,Kansas,QA,Qatar,NonPeak,$27.63,$44.91
+US58,Kansas,QA,Qatar,Peak,$32.60,$52.99
+US58,Kansas,RO,Romania,NonPeak,$29.28,$34.74
+US58,Kansas,RO,Romania,Peak,$34.55,$40.99
+US58,Kansas,RQ,Puerto Rico,NonPeak,$30.90,$32.26
+US58,Kansas,RQ,Puerto Rico,Peak,$36.46,$38.07
+US58,Kansas,SA,Saudi Arabia,NonPeak,$15.28,$45.09
+US58,Kansas,SA,Saudi Arabia,Peak,$18.03,$53.21
+US58,Kansas,SN,Singapore,NonPeak,$16.05,$34.90
+US58,Kansas,SN,Singapore,Peak,$18.94,$41.18
+US58,Kansas,SP,Spain,NonPeak,$16.80,$32.44
+US58,Kansas,SP,Spain,Peak,$19.82,$38.28
+US58,Kansas,TU,Turkey,NonPeak,$17.57,$43.94
+US58,Kansas,TU,Turkey,Peak,$20.73,$51.85
+US58,Kansas,UK,United Kingdom,NonPeak,$18.33,$33.70
+US58,Kansas,UK,United Kingdom,Peak,$21.63,$39.77
+US58,Kansas,US8030400,Alaska (Zone) IV,NonPeak,$24.38,$31.29
+US58,Kansas,US8030400,Alaska (Zone) IV,Peak,$28.77,$36.92
+US58,Kansas,US8050500,Alaska (Zone) III,NonPeak,$16.00,$44.05
+US58,Kansas,US8050500,Alaska (Zone) III,Peak,$18.88,$51.98
+US58,Kansas,US8101000,Alaska (Zone) I,NonPeak,$27.63,$33.75
+US58,Kansas,US8101000,Alaska (Zone) I,Peak,$32.60,$39.82
+US58,Kansas,US8190100,Alaska (Zone) II,NonPeak,$29.28,$31.40
+US58,Kansas,US8190100,Alaska (Zone) II,Peak,$34.55,$37.05
+US58,Kansas,US89,Hawaii,NonPeak,$30.90,$44.17
+US58,Kansas,US89,Hawaii,Peak,$36.46,$52.12
+US58,Kansas,UY,Uruguay,NonPeak,$15.28,$33.98
+US58,Kansas,UY,Uruguay,Peak,$18.03,$40.10
+US58,Kansas,VE,Venezuela,NonPeak,$16.05,$31.45
+US58,Kansas,VE,Venezuela,Peak,$18.94,$37.11
+US60,Arkansas,AR,Argentina,NonPeak,$16.80,$44.28
+US60,Arkansas,AR,Argentina,Peak,$19.82,$52.25
+US60,Arkansas,AS11,New South Wales/Australian Capital Territory,NonPeak,$17.57,$34.11
+US60,Arkansas,AS11,New South Wales/Australian Capital Territory,Peak,$20.73,$40.25
+US60,Arkansas,AS21,Northern Territory,NonPeak,$18.33,$31.63
+US60,Arkansas,AS21,Northern Territory,Peak,$21.63,$37.32
+US60,Arkansas,BA,Bahrain,NonPeak,$24.38,$44.51
+US60,Arkansas,BA,Bahrain,Peak,$28.77,$52.52
+US60,Arkansas,BE,Belgium,NonPeak,$16.00,$34.33
+US60,Arkansas,BE,Belgium,Peak,$18.88,$40.51
+US60,Arkansas,BL,Bolivia,NonPeak,$27.63,$31.74
+US60,Arkansas,BL,Bolivia,Peak,$32.60,$37.45
+US60,Arkansas,BR,Brazil - Brazilia,NonPeak,$29.28,$44.62
+US60,Arkansas,BR,Brazil - Brazilia,Peak,$34.55,$52.65
+US60,Arkansas,CA10,Ontario,NonPeak,$30.90,$34.45
+US60,Arkansas,CA10,Ontario,Peak,$36.46,$40.65
+US60,Arkansas,CA20,Quebec,NonPeak,$15.28,$31.91
+US60,Arkansas,CA20,Quebec,Peak,$18.03,$37.65
+US60,Arkansas,CA30,Manitoba,NonPeak,$16.05,$44.74
+US60,Arkansas,CA30,Manitoba,Peak,$18.94,$52.79
+US60,Arkansas,CI,Chile,NonPeak,$16.80,$34.56
+US60,Arkansas,CI,Chile,Peak,$19.82,$40.78
+US60,Arkansas,CO,Colombia,NonPeak,$17.57,$32.09
+US60,Arkansas,CO,Colombia,Peak,$20.73,$37.87
+US60,Arkansas,CS,Costa Rica,NonPeak,$18.33,$44.91
+US60,Arkansas,CS,Costa Rica,Peak,$21.63,$52.99
+US60,Arkansas,EC,Ecuador,NonPeak,$24.38,$34.74
+US60,Arkansas,EC,Ecuador,Peak,$28.77,$40.99
+US60,Arkansas,ES,El Salvador,NonPeak,$16.00,$32.26
+US60,Arkansas,ES,El Salvador,Peak,$18.88,$38.07
+US60,Arkansas,GE,Germany,NonPeak,$27.63,$45.09
+US60,Arkansas,GE,Germany,Peak,$32.60,$53.21
+US60,Arkansas,GQ,Guam,NonPeak,$29.28,$34.90
+US60,Arkansas,GQ,Guam,Peak,$34.55,$41.18
+US60,Arkansas,GR,Greece,NonPeak,$30.90,$32.44
+US60,Arkansas,GR,Greece,Peak,$36.46,$38.28
+US60,Arkansas,GR29,Crete,NonPeak,$15.28,$43.94
+US60,Arkansas,GR29,Crete,Peak,$18.03,$51.85
+US60,Arkansas,GT,Guatemala,NonPeak,$16.05,$33.70
+US60,Arkansas,GT,Guatemala,Peak,$18.94,$39.77
+US60,Arkansas,HO,Honduras,NonPeak,$16.80,$31.29
+US60,Arkansas,HO,Honduras,Peak,$19.82,$36.92
+US60,Arkansas,HU,Hungary,NonPeak,$17.57,$44.05
+US60,Arkansas,HU,Hungary,Peak,$20.73,$51.98
+US60,Arkansas,IT,Italy,NonPeak,$18.33,$33.75
+US60,Arkansas,IT,Italy,Peak,$21.63,$39.82
+US60,Arkansas,IT10,Sicily,NonPeak,$24.38,$31.40
+US60,Arkansas,IT10,Sicily,Peak,$28.77,$37.05
+US60,Arkansas,JA01,Japan-Central,NonPeak,$16.00,$44.17
+US60,Arkansas,JA01,Japan-Central,Peak,$18.88,$52.12
+US60,Arkansas,JA02,Japan-South (Excludes Hokkaido),NonPeak,$27.63,$33.98
+US60,Arkansas,JA02,Japan-South (Excludes Hokkaido),Peak,$32.60,$40.10
+US60,Arkansas,JA03,Japan-North,NonPeak,$29.28,$31.45
+US60,Arkansas,JA03,Japan-North,Peak,$34.55,$37.11
+US60,Arkansas,JA96,Okinawa,NonPeak,$30.90,$44.28
+US60,Arkansas,JA96,Okinawa,Peak,$36.46,$52.25
+US60,Arkansas,KS,"Korea, Republic Of",NonPeak,$15.28,$34.11
+US60,Arkansas,KS,"Korea, Republic Of",Peak,$18.03,$40.25
+US60,Arkansas,KU,Kuwait,NonPeak,$16.05,$31.63
+US60,Arkansas,KU,Kuwait,Peak,$18.94,$37.32
+US60,Arkansas,NL,Netherlands,NonPeak,$16.80,$44.51
+US60,Arkansas,NL,Netherlands,Peak,$19.82,$52.52
+US60,Arkansas,NO,Norway,NonPeak,$17.57,$34.33
+US60,Arkansas,NO,Norway,Peak,$20.73,$40.51
+US60,Arkansas,PA,Paraguay,NonPeak,$18.33,$31.74
+US60,Arkansas,PA,Paraguay,Peak,$21.63,$37.45
+US60,Arkansas,PE,Peru,NonPeak,$24.38,$44.62
+US60,Arkansas,PE,Peru,Peak,$28.77,$52.65
+US60,Arkansas,PL,Poland,NonPeak,$16.00,$34.45
+US60,Arkansas,PL,Poland,Peak,$18.88,$40.65
+US60,Arkansas,PO,Portugal,NonPeak,$27.63,$31.91
+US60,Arkansas,PO,Portugal,Peak,$32.60,$37.65
+US60,Arkansas,PO01,Azores,NonPeak,$29.28,$44.74
+US60,Arkansas,PO01,Azores,Peak,$34.55,$52.79
+US60,Arkansas,QA,Qatar,NonPeak,$30.90,$34.56
+US60,Arkansas,QA,Qatar,Peak,$36.46,$40.78
+US60,Arkansas,RO,Romania,NonPeak,$15.28,$32.09
+US60,Arkansas,RO,Romania,Peak,$18.03,$37.87
+US60,Arkansas,RQ,Puerto Rico,NonPeak,$16.05,$44.91
+US60,Arkansas,RQ,Puerto Rico,Peak,$18.94,$52.99
+US60,Arkansas,SA,Saudi Arabia,NonPeak,$16.80,$34.74
+US60,Arkansas,SA,Saudi Arabia,Peak,$19.82,$40.99
+US60,Arkansas,SN,Singapore,NonPeak,$17.57,$32.26
+US60,Arkansas,SN,Singapore,Peak,$20.73,$38.07
+US60,Arkansas,SP,Spain,NonPeak,$18.33,$45.09
+US60,Arkansas,SP,Spain,Peak,$21.63,$53.21
+US60,Arkansas,TU,Turkey,NonPeak,$24.38,$34.90
+US60,Arkansas,TU,Turkey,Peak,$28.77,$41.18
+US60,Arkansas,UK,United Kingdom,NonPeak,$16.00,$32.44
+US60,Arkansas,UK,United Kingdom,Peak,$18.88,$38.28
+US60,Arkansas,US8030400,Alaska (Zone) IV,NonPeak,$27.63,$43.94
+US60,Arkansas,US8030400,Alaska (Zone) IV,Peak,$32.60,$51.85
+US60,Arkansas,US8050500,Alaska (Zone) III,NonPeak,$29.28,$33.70
+US60,Arkansas,US8050500,Alaska (Zone) III,Peak,$34.55,$39.77
+US60,Arkansas,US8101000,Alaska (Zone) I,NonPeak,$30.90,$31.29
+US60,Arkansas,US8101000,Alaska (Zone) I,Peak,$36.46,$36.92
+US60,Arkansas,US8190100,Alaska (Zone) II,NonPeak,$15.28,$44.05
+US60,Arkansas,US8190100,Alaska (Zone) II,Peak,$18.03,$51.98
+US60,Arkansas,US89,Hawaii,NonPeak,$16.05,$33.75
+US60,Arkansas,US89,Hawaii,Peak,$18.94,$39.82
+US60,Arkansas,UY,Uruguay,NonPeak,$16.80,$31.40
+US60,Arkansas,UY,Uruguay,Peak,$19.82,$37.05
+US60,Arkansas,VE,Venezuela,NonPeak,$17.57,$44.17
+US60,Arkansas,VE,Venezuela,Peak,$20.73,$52.12
+US62,Oklahoma,AR,Argentina,NonPeak,$18.33,$33.98
+US62,Oklahoma,AR,Argentina,Peak,$21.63,$40.10
+US62,Oklahoma,AS11,New South Wales/Australian Capital Territory,NonPeak,$24.38,$31.45
+US62,Oklahoma,AS11,New South Wales/Australian Capital Territory,Peak,$28.77,$37.11
+US62,Oklahoma,AS21,Northern Territory,NonPeak,$16.00,$44.28
+US62,Oklahoma,AS21,Northern Territory,Peak,$18.88,$52.25
+US62,Oklahoma,BA,Bahrain,NonPeak,$27.63,$34.11
+US62,Oklahoma,BA,Bahrain,Peak,$32.60,$40.25
+US62,Oklahoma,BE,Belgium,NonPeak,$29.28,$31.63
+US62,Oklahoma,BE,Belgium,Peak,$34.55,$37.32
+US62,Oklahoma,BL,Bolivia,NonPeak,$30.90,$44.51
+US62,Oklahoma,BL,Bolivia,Peak,$36.46,$52.52
+US62,Oklahoma,BR,Brazil - Brazilia,NonPeak,$15.28,$34.33
+US62,Oklahoma,BR,Brazil - Brazilia,Peak,$18.03,$40.51
+US62,Oklahoma,CA10,Ontario,NonPeak,$16.05,$31.74
+US62,Oklahoma,CA10,Ontario,Peak,$18.94,$37.45
+US62,Oklahoma,CA20,Quebec,NonPeak,$16.80,$44.62
+US62,Oklahoma,CA20,Quebec,Peak,$19.82,$52.65
+US62,Oklahoma,CA30,Manitoba,NonPeak,$17.57,$34.45
+US62,Oklahoma,CA30,Manitoba,Peak,$20.73,$40.65
+US62,Oklahoma,CI,Chile,NonPeak,$18.33,$31.91
+US62,Oklahoma,CI,Chile,Peak,$21.63,$37.65
+US62,Oklahoma,CO,Colombia,NonPeak,$24.38,$44.74
+US62,Oklahoma,CO,Colombia,Peak,$28.77,$52.79
+US62,Oklahoma,CS,Costa Rica,NonPeak,$16.00,$34.56
+US62,Oklahoma,CS,Costa Rica,Peak,$18.88,$40.78
+US62,Oklahoma,EC,Ecuador,NonPeak,$27.63,$32.09
+US62,Oklahoma,EC,Ecuador,Peak,$32.60,$37.87
+US62,Oklahoma,ES,El Salvador,NonPeak,$29.28,$44.91
+US62,Oklahoma,ES,El Salvador,Peak,$34.55,$52.99
+US62,Oklahoma,GE,Germany,NonPeak,$30.90,$34.74
+US62,Oklahoma,GE,Germany,Peak,$36.46,$40.99
+US62,Oklahoma,GQ,Guam,NonPeak,$15.28,$32.26
+US62,Oklahoma,GQ,Guam,Peak,$18.03,$38.07
+US62,Oklahoma,GR,Greece,NonPeak,$16.05,$45.09
+US62,Oklahoma,GR,Greece,Peak,$18.94,$53.21
+US62,Oklahoma,GR29,Crete,NonPeak,$16.80,$34.90
+US62,Oklahoma,GR29,Crete,Peak,$19.82,$41.18
+US62,Oklahoma,GT,Guatemala,NonPeak,$17.57,$32.44
+US62,Oklahoma,GT,Guatemala,Peak,$20.73,$38.28
+US62,Oklahoma,HO,Honduras,NonPeak,$18.33,$43.94
+US62,Oklahoma,HO,Honduras,Peak,$21.63,$51.85
+US62,Oklahoma,HU,Hungary,NonPeak,$24.38,$33.70
+US62,Oklahoma,HU,Hungary,Peak,$28.77,$39.77
+US62,Oklahoma,IT,Italy,NonPeak,$16.00,$31.29
+US62,Oklahoma,IT,Italy,Peak,$18.88,$36.92
+US62,Oklahoma,IT10,Sicily,NonPeak,$27.63,$44.05
+US62,Oklahoma,IT10,Sicily,Peak,$32.60,$51.98
+US62,Oklahoma,JA01,Japan-Central,NonPeak,$29.28,$33.75
+US62,Oklahoma,JA01,Japan-Central,Peak,$34.55,$39.82
+US62,Oklahoma,JA02,Japan-South (Excludes Hokkaido),NonPeak,$30.90,$31.40
+US62,Oklahoma,JA02,Japan-South (Excludes Hokkaido),Peak,$36.46,$37.05
+US62,Oklahoma,JA03,Japan-North,NonPeak,$15.28,$44.17
+US62,Oklahoma,JA03,Japan-North,Peak,$18.03,$52.12
+US62,Oklahoma,JA96,Okinawa,NonPeak,$16.05,$33.98
+US62,Oklahoma,JA96,Okinawa,Peak,$18.94,$40.10
+US62,Oklahoma,KS,"Korea, Republic Of",NonPeak,$16.80,$31.45
+US62,Oklahoma,KS,"Korea, Republic Of",Peak,$19.82,$37.11
+US62,Oklahoma,KU,Kuwait,NonPeak,$17.57,$44.28
+US62,Oklahoma,KU,Kuwait,Peak,$20.73,$52.25
+US62,Oklahoma,NL,Netherlands,NonPeak,$18.33,$34.11
+US62,Oklahoma,NL,Netherlands,Peak,$21.63,$40.25
+US62,Oklahoma,NO,Norway,NonPeak,$24.38,$31.63
+US62,Oklahoma,NO,Norway,Peak,$28.77,$37.32
+US62,Oklahoma,PA,Paraguay,NonPeak,$16.00,$44.51
+US62,Oklahoma,PA,Paraguay,Peak,$18.88,$52.52
+US62,Oklahoma,PE,Peru,NonPeak,$27.63,$34.33
+US62,Oklahoma,PE,Peru,Peak,$32.60,$40.51
+US62,Oklahoma,PL,Poland,NonPeak,$29.28,$31.74
+US62,Oklahoma,PL,Poland,Peak,$34.55,$37.45
+US62,Oklahoma,PO,Portugal,NonPeak,$30.90,$44.62
+US62,Oklahoma,PO,Portugal,Peak,$36.46,$52.65
+US62,Oklahoma,PO01,Azores,NonPeak,$15.28,$34.45
+US62,Oklahoma,PO01,Azores,Peak,$18.03,$40.65
+US62,Oklahoma,QA,Qatar,NonPeak,$16.05,$31.91
+US62,Oklahoma,QA,Qatar,Peak,$18.94,$37.65
+US62,Oklahoma,RO,Romania,NonPeak,$16.80,$44.74
+US62,Oklahoma,RO,Romania,Peak,$19.82,$52.79
+US62,Oklahoma,RQ,Puerto Rico,NonPeak,$17.57,$34.56
+US62,Oklahoma,RQ,Puerto Rico,Peak,$20.73,$40.78
+US62,Oklahoma,SA,Saudi Arabia,NonPeak,$18.33,$32.09
+US62,Oklahoma,SA,Saudi Arabia,Peak,$21.63,$37.87
+US62,Oklahoma,SN,Singapore,NonPeak,$24.38,$44.91
+US62,Oklahoma,SN,Singapore,Peak,$28.77,$52.99
+US62,Oklahoma,SP,Spain,NonPeak,$16.00,$34.74
+US62,Oklahoma,SP,Spain,Peak,$18.88,$40.99
+US62,Oklahoma,TU,Turkey,NonPeak,$27.63,$32.26
+US62,Oklahoma,TU,Turkey,Peak,$32.60,$38.07
+US62,Oklahoma,UK,United Kingdom,NonPeak,$29.28,$45.09
+US62,Oklahoma,UK,United Kingdom,Peak,$34.55,$53.21
+US62,Oklahoma,US8030400,Alaska (Zone) IV,NonPeak,$30.90,$34.90
+US62,Oklahoma,US8030400,Alaska (Zone) IV,Peak,$36.46,$41.18
+US62,Oklahoma,US8050500,Alaska (Zone) III,NonPeak,$15.28,$32.44
+US62,Oklahoma,US8050500,Alaska (Zone) III,Peak,$18.03,$38.28
+US62,Oklahoma,US8101000,Alaska (Zone) I,NonPeak,$16.05,$43.94
+US62,Oklahoma,US8101000,Alaska (Zone) I,Peak,$18.94,$51.85
+US62,Oklahoma,US8190100,Alaska (Zone) II,NonPeak,$16.80,$33.70
+US62,Oklahoma,US8190100,Alaska (Zone) II,Peak,$19.82,$39.77
+US62,Oklahoma,US89,Hawaii,NonPeak,$17.57,$31.29
+US62,Oklahoma,US89,Hawaii,Peak,$20.73,$36.92
+US62,Oklahoma,UY,Uruguay,NonPeak,$18.33,$44.05
+US62,Oklahoma,UY,Uruguay,Peak,$21.63,$51.98
+US62,Oklahoma,VE,Venezuela,NonPeak,$24.38,$33.75
+US62,Oklahoma,VE,Venezuela,Peak,$28.77,$39.82
+US64,Louisiana,AR,Argentina,NonPeak,$16.00,$31.40
+US64,Louisiana,AR,Argentina,Peak,$18.88,$37.05
+US64,Louisiana,AS11,New South Wales/Australian Capital Territory,NonPeak,$27.63,$44.17
+US64,Louisiana,AS11,New South Wales/Australian Capital Territory,Peak,$32.60,$52.12
+US64,Louisiana,AS21,Northern Territory,NonPeak,$29.28,$33.98
+US64,Louisiana,AS21,Northern Territory,Peak,$34.55,$40.10
+US64,Louisiana,BA,Bahrain,NonPeak,$30.90,$31.45
+US64,Louisiana,BA,Bahrain,Peak,$36.46,$37.11
+US64,Louisiana,BE,Belgium,NonPeak,$15.28,$44.28
+US64,Louisiana,BE,Belgium,Peak,$18.03,$52.25
+US64,Louisiana,BL,Bolivia,NonPeak,$16.05,$34.11
+US64,Louisiana,BL,Bolivia,Peak,$18.94,$40.25
+US64,Louisiana,BR,Brazil - Brazilia,NonPeak,$16.80,$31.63
+US64,Louisiana,BR,Brazil - Brazilia,Peak,$19.82,$37.32
+US64,Louisiana,CA10,Ontario,NonPeak,$17.57,$44.51
+US64,Louisiana,CA10,Ontario,Peak,$20.73,$52.52
+US64,Louisiana,CA20,Quebec,NonPeak,$18.33,$34.33
+US64,Louisiana,CA20,Quebec,Peak,$21.63,$40.51
+US64,Louisiana,CA30,Manitoba,NonPeak,$24.38,$31.74
+US64,Louisiana,CA30,Manitoba,Peak,$28.77,$37.45
+US64,Louisiana,CI,Chile,NonPeak,$16.00,$44.62
+US64,Louisiana,CI,Chile,Peak,$18.88,$52.65
+US64,Louisiana,CO,Colombia,NonPeak,$27.63,$34.45
+US64,Louisiana,CO,Colombia,Peak,$32.60,$40.65
+US64,Louisiana,CS,Costa Rica,NonPeak,$29.28,$31.91
+US64,Louisiana,CS,Costa Rica,Peak,$34.55,$37.65
+US64,Louisiana,EC,Ecuador,NonPeak,$30.90,$44.74
+US64,Louisiana,EC,Ecuador,Peak,$36.46,$52.79
+US64,Louisiana,ES,El Salvador,NonPeak,$15.28,$34.56
+US64,Louisiana,ES,El Salvador,Peak,$18.03,$40.78
+US64,Louisiana,GE,Germany,NonPeak,$16.05,$32.09
+US64,Louisiana,GE,Germany,Peak,$18.94,$37.87
+US64,Louisiana,GQ,Guam,NonPeak,$16.80,$44.91
+US64,Louisiana,GQ,Guam,Peak,$19.82,$52.99
+US64,Louisiana,GR,Greece,NonPeak,$17.57,$34.74
+US64,Louisiana,GR,Greece,Peak,$20.73,$40.99
+US64,Louisiana,GR29,Crete,NonPeak,$18.33,$32.26
+US64,Louisiana,GR29,Crete,Peak,$21.63,$38.07
+US64,Louisiana,GT,Guatemala,NonPeak,$24.38,$45.09
+US64,Louisiana,GT,Guatemala,Peak,$28.77,$53.21
+US64,Louisiana,HO,Honduras,NonPeak,$16.00,$34.90
+US64,Louisiana,HO,Honduras,Peak,$18.88,$41.18
+US64,Louisiana,HU,Hungary,NonPeak,$27.63,$32.44
+US64,Louisiana,HU,Hungary,Peak,$32.60,$38.28
+US64,Louisiana,IT,Italy,NonPeak,$29.28,$43.94
+US64,Louisiana,IT,Italy,Peak,$34.55,$51.85
+US64,Louisiana,IT10,Sicily,NonPeak,$30.90,$33.70
+US64,Louisiana,IT10,Sicily,Peak,$36.46,$39.77
+US64,Louisiana,JA01,Japan-Central,NonPeak,$15.28,$31.29
+US64,Louisiana,JA01,Japan-Central,Peak,$18.03,$36.92
+US64,Louisiana,JA02,Japan-South (Excludes Hokkaido),NonPeak,$16.05,$44.05
+US64,Louisiana,JA02,Japan-South (Excludes Hokkaido),Peak,$18.94,$51.98
+US64,Louisiana,JA03,Japan-North,NonPeak,$16.80,$33.75
+US64,Louisiana,JA03,Japan-North,Peak,$19.82,$39.82
+US64,Louisiana,JA96,Okinawa,NonPeak,$17.57,$31.40
+US64,Louisiana,JA96,Okinawa,Peak,$20.73,$37.05
+US64,Louisiana,KS,"Korea, Republic Of",NonPeak,$18.33,$44.17
+US64,Louisiana,KS,"Korea, Republic Of",Peak,$21.63,$52.12
+US64,Louisiana,KU,Kuwait,NonPeak,$24.38,$33.98
+US64,Louisiana,KU,Kuwait,Peak,$28.77,$40.10
+US64,Louisiana,NL,Netherlands,NonPeak,$16.00,$31.45
+US64,Louisiana,NL,Netherlands,Peak,$18.88,$37.11
+US64,Louisiana,NO,Norway,NonPeak,$27.63,$44.28
+US64,Louisiana,NO,Norway,Peak,$32.60,$52.25
+US64,Louisiana,PA,Paraguay,NonPeak,$29.28,$34.11
+US64,Louisiana,PA,Paraguay,Peak,$34.55,$40.25
+US64,Louisiana,PE,Peru,NonPeak,$30.90,$31.63
+US64,Louisiana,PE,Peru,Peak,$36.46,$37.32
+US64,Louisiana,PL,Poland,NonPeak,$15.28,$44.51
+US64,Louisiana,PL,Poland,Peak,$18.03,$52.52
+US64,Louisiana,PO,Portugal,NonPeak,$16.05,$34.33
+US64,Louisiana,PO,Portugal,Peak,$18.94,$40.51
+US64,Louisiana,PO01,Azores,NonPeak,$16.80,$31.74
+US64,Louisiana,PO01,Azores,Peak,$19.82,$37.45
+US64,Louisiana,QA,Qatar,NonPeak,$17.57,$44.62
+US64,Louisiana,QA,Qatar,Peak,$20.73,$52.65
+US64,Louisiana,RO,Romania,NonPeak,$18.33,$34.45
+US64,Louisiana,RO,Romania,Peak,$21.63,$40.65
+US64,Louisiana,RQ,Puerto Rico,NonPeak,$24.38,$31.91
+US64,Louisiana,RQ,Puerto Rico,Peak,$28.77,$37.65
+US64,Louisiana,SA,Saudi Arabia,NonPeak,$16.00,$44.74
+US64,Louisiana,SA,Saudi Arabia,Peak,$18.88,$52.79
+US64,Louisiana,SN,Singapore,NonPeak,$27.63,$34.56
+US64,Louisiana,SN,Singapore,Peak,$32.60,$40.78
+US64,Louisiana,SP,Spain,NonPeak,$29.28,$32.09
+US64,Louisiana,SP,Spain,Peak,$34.55,$37.87
+US64,Louisiana,TU,Turkey,NonPeak,$30.90,$44.91
+US64,Louisiana,TU,Turkey,Peak,$36.46,$52.99
+US64,Louisiana,UK,United Kingdom,NonPeak,$15.28,$34.74
+US64,Louisiana,UK,United Kingdom,Peak,$18.03,$40.99
+US64,Louisiana,US8030400,Alaska (Zone) IV,NonPeak,$16.05,$32.26
+US64,Louisiana,US8030400,Alaska (Zone) IV,Peak,$18.94,$38.07
+US64,Louisiana,US8050500,Alaska (Zone) III,NonPeak,$16.80,$45.09
+US64,Louisiana,US8050500,Alaska (Zone) III,Peak,$19.82,$53.21
+US64,Louisiana,US8101000,Alaska (Zone) I,NonPeak,$17.57,$34.90
+US64,Louisiana,US8101000,Alaska (Zone) I,Peak,$20.73,$41.18
+US64,Louisiana,US8190100,Alaska (Zone) II,NonPeak,$18.33,$32.44
+US64,Louisiana,US8190100,Alaska (Zone) II,Peak,$21.63,$38.28
+US64,Louisiana,US89,Hawaii,NonPeak,$24.38,$43.94
+US64,Louisiana,US89,Hawaii,Peak,$28.77,$51.85
+US64,Louisiana,UY,Uruguay,NonPeak,$16.00,$33.70
+US64,Louisiana,UY,Uruguay,Peak,$18.88,$39.77
+US64,Louisiana,VE,Venezuela,NonPeak,$27.63,$31.29
+US64,Louisiana,VE,Venezuela,Peak,$32.60,$36.92
+US66,Texas-North,AR,Argentina,NonPeak,$29.28,$44.05
+US66,Texas-North,AR,Argentina,Peak,$34.55,$51.98
+US66,Texas-North,AS11,New South Wales/Australian Capital Territory,NonPeak,$30.90,$33.75
+US66,Texas-North,AS11,New South Wales/Australian Capital Territory,Peak,$36.46,$39.82
+US66,Texas-North,AS21,Northern Territory,NonPeak,$15.28,$31.40
+US66,Texas-North,AS21,Northern Territory,Peak,$18.03,$37.05
+US66,Texas-North,BA,Bahrain,NonPeak,$16.05,$44.17
+US66,Texas-North,BA,Bahrain,Peak,$18.94,$52.12
+US66,Texas-North,BE,Belgium,NonPeak,$16.80,$33.98
+US66,Texas-North,BE,Belgium,Peak,$19.82,$40.10
+US66,Texas-North,BL,Bolivia,NonPeak,$17.57,$31.45
+US66,Texas-North,BL,Bolivia,Peak,$20.73,$37.11
+US66,Texas-North,BR,Brazil - Brazilia,NonPeak,$18.33,$44.28
+US66,Texas-North,BR,Brazil - Brazilia,Peak,$21.63,$52.25
+US66,Texas-North,CA10,Ontario,NonPeak,$24.38,$34.11
+US66,Texas-North,CA10,Ontario,Peak,$28.77,$40.25
+US66,Texas-North,CA20,Quebec,NonPeak,$16.00,$31.63
+US66,Texas-North,CA20,Quebec,Peak,$18.88,$37.32
+US66,Texas-North,CA30,Manitoba,NonPeak,$27.63,$44.51
+US66,Texas-North,CA30,Manitoba,Peak,$32.60,$52.52
+US66,Texas-North,CI,Chile,NonPeak,$29.28,$34.33
+US66,Texas-North,CI,Chile,Peak,$34.55,$40.51
+US66,Texas-North,CO,Colombia,NonPeak,$30.90,$31.74
+US66,Texas-North,CO,Colombia,Peak,$36.46,$37.45
+US66,Texas-North,CS,Costa Rica,NonPeak,$15.28,$44.62
+US66,Texas-North,CS,Costa Rica,Peak,$18.03,$52.65
+US66,Texas-North,EC,Ecuador,NonPeak,$16.05,$34.45
+US66,Texas-North,EC,Ecuador,Peak,$18.94,$40.65
+US66,Texas-North,ES,El Salvador,NonPeak,$16.80,$31.91
+US66,Texas-North,ES,El Salvador,Peak,$19.82,$37.65
+US66,Texas-North,GE,Germany,NonPeak,$17.57,$44.74
+US66,Texas-North,GE,Germany,Peak,$20.73,$52.79
+US66,Texas-North,GQ,Guam,NonPeak,$18.33,$34.56
+US66,Texas-North,GQ,Guam,Peak,$21.63,$40.78
+US66,Texas-North,GR,Greece,NonPeak,$24.38,$32.09
+US66,Texas-North,GR,Greece,Peak,$28.77,$37.87
+US66,Texas-North,GR29,Crete,NonPeak,$16.00,$44.91
+US66,Texas-North,GR29,Crete,Peak,$18.88,$52.99
+US66,Texas-North,GT,Guatemala,NonPeak,$27.63,$34.74
+US66,Texas-North,GT,Guatemala,Peak,$32.60,$40.99
+US66,Texas-North,HO,Honduras,NonPeak,$29.28,$32.26
+US66,Texas-North,HO,Honduras,Peak,$34.55,$38.07
+US66,Texas-North,HU,Hungary,NonPeak,$30.90,$45.09
+US66,Texas-North,HU,Hungary,Peak,$36.46,$53.21
+US66,Texas-North,IT,Italy,NonPeak,$15.28,$34.90
+US66,Texas-North,IT,Italy,Peak,$18.03,$41.18
+US66,Texas-North,IT10,Sicily,NonPeak,$16.05,$32.44
+US66,Texas-North,IT10,Sicily,Peak,$18.94,$38.28
+US66,Texas-North,JA01,Japan-Central,NonPeak,$16.80,$43.94
+US66,Texas-North,JA01,Japan-Central,Peak,$19.82,$51.85
+US66,Texas-North,JA02,Japan-South (Excludes Hokkaido),NonPeak,$17.57,$33.70
+US66,Texas-North,JA02,Japan-South (Excludes Hokkaido),Peak,$20.73,$39.77
+US66,Texas-North,JA03,Japan-North,NonPeak,$18.33,$31.29
+US66,Texas-North,JA03,Japan-North,Peak,$21.63,$36.92
+US66,Texas-North,JA96,Okinawa,NonPeak,$24.38,$44.05
+US66,Texas-North,JA96,Okinawa,Peak,$28.77,$51.98
+US66,Texas-North,KS,"Korea, Republic Of",NonPeak,$16.00,$33.75
+US66,Texas-North,KS,"Korea, Republic Of",Peak,$18.88,$39.82
+US66,Texas-North,KU,Kuwait,NonPeak,$27.63,$31.40
+US66,Texas-North,KU,Kuwait,Peak,$32.60,$37.05
+US66,Texas-North,NL,Netherlands,NonPeak,$29.28,$44.17
+US66,Texas-North,NL,Netherlands,Peak,$34.55,$52.12
+US66,Texas-North,NO,Norway,NonPeak,$30.90,$33.98
+US66,Texas-North,NO,Norway,Peak,$36.46,$40.10
+US66,Texas-North,PA,Paraguay,NonPeak,$15.28,$31.45
+US66,Texas-North,PA,Paraguay,Peak,$18.03,$37.11
+US66,Texas-North,PE,Peru,NonPeak,$16.05,$44.28
+US66,Texas-North,PE,Peru,Peak,$18.94,$52.25
+US66,Texas-North,PL,Poland,NonPeak,$16.80,$34.11
+US66,Texas-North,PL,Poland,Peak,$19.82,$40.25
+US66,Texas-North,PO,Portugal,NonPeak,$17.57,$31.63
+US66,Texas-North,PO,Portugal,Peak,$20.73,$37.32
+US66,Texas-North,PO01,Azores,NonPeak,$18.33,$44.51
+US66,Texas-North,PO01,Azores,Peak,$21.63,$52.52
+US66,Texas-North,QA,Qatar,NonPeak,$24.38,$34.33
+US66,Texas-North,QA,Qatar,Peak,$28.77,$40.51
+US66,Texas-North,RO,Romania,NonPeak,$16.00,$31.74
+US66,Texas-North,RO,Romania,Peak,$18.88,$37.45
+US66,Texas-North,RQ,Puerto Rico,NonPeak,$27.63,$44.62
+US66,Texas-North,RQ,Puerto Rico,Peak,$32.60,$52.65
+US66,Texas-North,SA,Saudi Arabia,NonPeak,$29.28,$34.45
+US66,Texas-North,SA,Saudi Arabia,Peak,$34.55,$40.65
+US66,Texas-North,SN,Singapore,NonPeak,$30.90,$31.91
+US66,Texas-North,SN,Singapore,Peak,$36.46,$37.65
+US66,Texas-North,SP,Spain,NonPeak,$15.28,$44.74
+US66,Texas-North,SP,Spain,Peak,$18.03,$52.79
+US66,Texas-North,TU,Turkey,NonPeak,$16.05,$34.56
+US66,Texas-North,TU,Turkey,Peak,$18.94,$40.78
+US66,Texas-North,UK,United Kingdom,NonPeak,$16.80,$32.09
+US66,Texas-North,UK,United Kingdom,Peak,$19.82,$37.87
+US66,Texas-North,US8030400,Alaska (Zone) IV,NonPeak,$17.57,$44.91
+US66,Texas-North,US8030400,Alaska (Zone) IV,Peak,$20.73,$52.99
+US66,Texas-North,US8050500,Alaska (Zone) III,NonPeak,$18.33,$34.74
+US66,Texas-North,US8050500,Alaska (Zone) III,Peak,$21.63,$40.99
+US66,Texas-North,US8101000,Alaska (Zone) I,NonPeak,$24.38,$32.26
+US66,Texas-North,US8101000,Alaska (Zone) I,Peak,$28.77,$38.07
+US66,Texas-North,US8190100,Alaska (Zone) II,NonPeak,$16.00,$45.09
+US66,Texas-North,US8190100,Alaska (Zone) II,Peak,$18.88,$53.21
+US66,Texas-North,US89,Hawaii,NonPeak,$27.63,$34.90
+US66,Texas-North,US89,Hawaii,Peak,$32.60,$41.18
+US66,Texas-North,UY,Uruguay,NonPeak,$29.28,$32.44
+US66,Texas-North,UY,Uruguay,Peak,$34.55,$38.28
+US66,Texas-North,VE,Venezuela,NonPeak,$30.90,$43.94
+US66,Texas-North,VE,Venezuela,Peak,$36.46,$51.85
+US68,Texas-South,AR,Argentina,NonPeak,$15.28,$33.70
+US68,Texas-South,AR,Argentina,Peak,$18.03,$39.77
+US68,Texas-South,AS11,New South Wales/Australian Capital Territory,NonPeak,$16.05,$31.29
+US68,Texas-South,AS11,New South Wales/Australian Capital Territory,Peak,$18.94,$36.92
+US68,Texas-South,AS21,Northern Territory,NonPeak,$16.80,$44.05
+US68,Texas-South,AS21,Northern Territory,Peak,$19.82,$51.98
+US68,Texas-South,BA,Bahrain,NonPeak,$17.57,$33.75
+US68,Texas-South,BA,Bahrain,Peak,$20.73,$39.82
+US68,Texas-South,BE,Belgium,NonPeak,$18.33,$31.40
+US68,Texas-South,BE,Belgium,Peak,$21.63,$37.05
+US68,Texas-South,BL,Bolivia,NonPeak,$24.38,$44.17
+US68,Texas-South,BL,Bolivia,Peak,$28.77,$52.12
+US68,Texas-South,BR,Brazil - Brazilia,NonPeak,$16.00,$33.98
+US68,Texas-South,BR,Brazil - Brazilia,Peak,$18.88,$40.10
+US68,Texas-South,CA10,Ontario,NonPeak,$27.63,$31.45
+US68,Texas-South,CA10,Ontario,Peak,$32.60,$37.11
+US68,Texas-South,CA20,Quebec,NonPeak,$29.28,$44.28
+US68,Texas-South,CA20,Quebec,Peak,$34.55,$52.25
+US68,Texas-South,CA30,Manitoba,NonPeak,$30.90,$34.11
+US68,Texas-South,CA30,Manitoba,Peak,$36.46,$40.25
+US68,Texas-South,CI,Chile,NonPeak,$15.28,$31.63
+US68,Texas-South,CI,Chile,Peak,$18.03,$37.32
+US68,Texas-South,CO,Colombia,NonPeak,$16.05,$44.51
+US68,Texas-South,CO,Colombia,Peak,$18.94,$52.52
+US68,Texas-South,CS,Costa Rica,NonPeak,$16.80,$34.33
+US68,Texas-South,CS,Costa Rica,Peak,$19.82,$40.51
+US68,Texas-South,EC,Ecuador,NonPeak,$17.57,$31.74
+US68,Texas-South,EC,Ecuador,Peak,$20.73,$37.45
+US68,Texas-South,ES,El Salvador,NonPeak,$18.33,$44.62
+US68,Texas-South,ES,El Salvador,Peak,$21.63,$52.65
+US68,Texas-South,GE,Germany,NonPeak,$24.38,$34.45
+US68,Texas-South,GE,Germany,Peak,$28.77,$40.65
+US68,Texas-South,GQ,Guam,NonPeak,$16.00,$31.91
+US68,Texas-South,GQ,Guam,Peak,$18.88,$37.65
+US68,Texas-South,GR,Greece,NonPeak,$27.63,$44.74
+US68,Texas-South,GR,Greece,Peak,$32.60,$52.79
+US68,Texas-South,GR29,Crete,NonPeak,$29.28,$34.56
+US68,Texas-South,GR29,Crete,Peak,$34.55,$40.78
+US68,Texas-South,GT,Guatemala,NonPeak,$30.90,$32.09
+US68,Texas-South,GT,Guatemala,Peak,$36.46,$37.87
+US68,Texas-South,HO,Honduras,NonPeak,$15.28,$44.91
+US68,Texas-South,HO,Honduras,Peak,$18.03,$52.99
+US68,Texas-South,HU,Hungary,NonPeak,$16.05,$34.74
+US68,Texas-South,HU,Hungary,Peak,$18.94,$40.99
+US68,Texas-South,IT,Italy,NonPeak,$16.80,$32.26
+US68,Texas-South,IT,Italy,Peak,$19.82,$38.07
+US68,Texas-South,IT10,Sicily,NonPeak,$17.57,$45.09
+US68,Texas-South,IT10,Sicily,Peak,$20.73,$53.21
+US68,Texas-South,JA01,Japan-Central,NonPeak,$18.33,$34.90
+US68,Texas-South,JA01,Japan-Central,Peak,$21.63,$41.18
+US68,Texas-South,JA02,Japan-South (Excludes Hokkaido),NonPeak,$24.38,$32.44
+US68,Texas-South,JA02,Japan-South (Excludes Hokkaido),Peak,$28.77,$38.28
+US68,Texas-South,JA03,Japan-North,NonPeak,$16.00,$43.94
+US68,Texas-South,JA03,Japan-North,Peak,$18.88,$51.85
+US68,Texas-South,JA96,Okinawa,NonPeak,$27.63,$33.70
+US68,Texas-South,JA96,Okinawa,Peak,$32.60,$39.77
+US68,Texas-South,KS,"Korea, Republic Of",NonPeak,$29.28,$31.29
+US68,Texas-South,KS,"Korea, Republic Of",Peak,$34.55,$36.92
+US68,Texas-South,KU,Kuwait,NonPeak,$30.90,$44.05
+US68,Texas-South,KU,Kuwait,Peak,$36.46,$51.98
+US68,Texas-South,NL,Netherlands,NonPeak,$15.28,$33.75
+US68,Texas-South,NL,Netherlands,Peak,$18.03,$39.82
+US68,Texas-South,NO,Norway,NonPeak,$16.05,$31.40
+US68,Texas-South,NO,Norway,Peak,$18.94,$37.05
+US68,Texas-South,PA,Paraguay,NonPeak,$16.80,$44.17
+US68,Texas-South,PA,Paraguay,Peak,$19.82,$52.12
+US68,Texas-South,PE,Peru,NonPeak,$17.57,$33.98
+US68,Texas-South,PE,Peru,Peak,$20.73,$40.10
+US68,Texas-South,PL,Poland,NonPeak,$18.33,$31.45
+US68,Texas-South,PL,Poland,Peak,$21.63,$37.11
+US68,Texas-South,PO,Portugal,NonPeak,$24.38,$44.28
+US68,Texas-South,PO,Portugal,Peak,$28.77,$52.25
+US68,Texas-South,PO01,Azores,NonPeak,$16.00,$34.11
+US68,Texas-South,PO01,Azores,Peak,$18.88,$40.25
+US68,Texas-South,QA,Qatar,NonPeak,$27.63,$31.63
+US68,Texas-South,QA,Qatar,Peak,$32.60,$37.32
+US68,Texas-South,RO,Romania,NonPeak,$29.28,$44.51
+US68,Texas-South,RO,Romania,Peak,$34.55,$52.52
+US68,Texas-South,RQ,Puerto Rico,NonPeak,$30.90,$34.33
+US68,Texas-South,RQ,Puerto Rico,Peak,$36.46,$40.51
+US68,Texas-South,SA,Saudi Arabia,NonPeak,$15.28,$31.74
+US68,Texas-South,SA,Saudi Arabia,Peak,$18.03,$37.45
+US68,Texas-South,SN,Singapore,NonPeak,$16.05,$44.62
+US68,Texas-South,SN,Singapore,Peak,$18.94,$52.65
+US68,Texas-South,SP,Spain,NonPeak,$16.80,$34.45
+US68,Texas-South,SP,Spain,Peak,$19.82,$40.65
+US68,Texas-South,TU,Turkey,NonPeak,$17.57,$31.91
+US68,Texas-South,TU,Turkey,Peak,$20.73,$37.65
+US68,Texas-South,UK,United Kingdom,NonPeak,$18.33,$44.74
+US68,Texas-South,UK,United Kingdom,Peak,$21.63,$52.79
+US68,Texas-South,US8030400,Alaska (Zone) IV,NonPeak,$24.38,$34.56
+US68,Texas-South,US8030400,Alaska (Zone) IV,Peak,$28.77,$40.78
+US68,Texas-South,US8050500,Alaska (Zone) III,NonPeak,$16.00,$32.09
+US68,Texas-South,US8050500,Alaska (Zone) III,Peak,$18.88,$37.87
+US68,Texas-South,US8101000,Alaska (Zone) I,NonPeak,$27.63,$44.91
+US68,Texas-South,US8101000,Alaska (Zone) I,Peak,$32.60,$52.99
+US68,Texas-South,US8190100,Alaska (Zone) II,NonPeak,$29.28,$34.74
+US68,Texas-South,US8190100,Alaska (Zone) II,Peak,$34.55,$40.99
+US68,Texas-South,US89,Hawaii,NonPeak,$30.90,$32.26
+US68,Texas-South,US89,Hawaii,Peak,$36.46,$38.07
+US68,Texas-South,UY,Uruguay,NonPeak,$15.28,$45.09
+US68,Texas-South,UY,Uruguay,Peak,$18.03,$53.21
+US68,Texas-South,VE,Venezuela,NonPeak,$16.05,$34.90
+US68,Texas-South,VE,Venezuela,Peak,$18.94,$41.18
+US70,Montana,AR,Argentina,NonPeak,$16.80,$32.44
+US70,Montana,AR,Argentina,Peak,$19.82,$38.28
+US70,Montana,AS11,New South Wales/Australian Capital Territory,NonPeak,$17.57,$43.94
+US70,Montana,AS11,New South Wales/Australian Capital Territory,Peak,$20.73,$51.85
+US70,Montana,AS21,Northern Territory,NonPeak,$18.33,$33.70
+US70,Montana,AS21,Northern Territory,Peak,$21.63,$39.77
+US70,Montana,BA,Bahrain,NonPeak,$24.38,$31.29
+US70,Montana,BA,Bahrain,Peak,$28.77,$36.92
+US70,Montana,BE,Belgium,NonPeak,$16.00,$44.05
+US70,Montana,BE,Belgium,Peak,$18.88,$51.98
+US70,Montana,BL,Bolivia,NonPeak,$27.63,$33.75
+US70,Montana,BL,Bolivia,Peak,$32.60,$39.82
+US70,Montana,BR,Brazil - Brazilia,NonPeak,$29.28,$31.40
+US70,Montana,BR,Brazil - Brazilia,Peak,$34.55,$37.05
+US70,Montana,CA10,Ontario,NonPeak,$30.90,$44.17
+US70,Montana,CA10,Ontario,Peak,$36.46,$52.12
+US70,Montana,CA20,Quebec,NonPeak,$15.28,$33.98
+US70,Montana,CA20,Quebec,Peak,$18.03,$40.10
+US70,Montana,CA30,Manitoba,NonPeak,$16.05,$31.45
+US70,Montana,CA30,Manitoba,Peak,$18.94,$37.11
+US70,Montana,CI,Chile,NonPeak,$16.80,$44.28
+US70,Montana,CI,Chile,Peak,$19.82,$52.25
+US70,Montana,CO,Colombia,NonPeak,$17.57,$34.11
+US70,Montana,CO,Colombia,Peak,$20.73,$40.25
+US70,Montana,CS,Costa Rica,NonPeak,$18.33,$31.63
+US70,Montana,CS,Costa Rica,Peak,$21.63,$37.32
+US70,Montana,EC,Ecuador,NonPeak,$24.38,$44.51
+US70,Montana,EC,Ecuador,Peak,$28.77,$52.52
+US70,Montana,ES,El Salvador,NonPeak,$16.00,$34.33
+US70,Montana,ES,El Salvador,Peak,$18.88,$40.51
+US70,Montana,GE,Germany,NonPeak,$27.63,$31.74
+US70,Montana,GE,Germany,Peak,$32.60,$37.45
+US70,Montana,GQ,Guam,NonPeak,$29.28,$44.62
+US70,Montana,GQ,Guam,Peak,$34.55,$52.65
+US70,Montana,GR,Greece,NonPeak,$30.90,$34.45
+US70,Montana,GR,Greece,Peak,$36.46,$40.65
+US70,Montana,GR29,Crete,NonPeak,$15.28,$31.91
+US70,Montana,GR29,Crete,Peak,$18.03,$37.65
+US70,Montana,GT,Guatemala,NonPeak,$16.05,$44.74
+US70,Montana,GT,Guatemala,Peak,$18.94,$52.79
+US70,Montana,HO,Honduras,NonPeak,$16.80,$34.56
+US70,Montana,HO,Honduras,Peak,$19.82,$40.78
+US70,Montana,HU,Hungary,NonPeak,$17.57,$32.09
+US70,Montana,HU,Hungary,Peak,$20.73,$37.87
+US70,Montana,IT,Italy,NonPeak,$18.33,$44.91
+US70,Montana,IT,Italy,Peak,$21.63,$52.99
+US70,Montana,IT10,Sicily,NonPeak,$24.38,$34.74
+US70,Montana,IT10,Sicily,Peak,$28.77,$40.99
+US70,Montana,JA01,Japan-Central,NonPeak,$16.00,$32.26
+US70,Montana,JA01,Japan-Central,Peak,$18.88,$38.07
+US70,Montana,JA02,Japan-South (Excludes Hokkaido),NonPeak,$27.63,$45.09
+US70,Montana,JA02,Japan-South (Excludes Hokkaido),Peak,$32.60,$53.21
+US70,Montana,JA03,Japan-North,NonPeak,$29.28,$34.90
+US70,Montana,JA03,Japan-North,Peak,$34.55,$41.18
+US70,Montana,JA96,Okinawa,NonPeak,$30.90,$32.44
+US70,Montana,JA96,Okinawa,Peak,$36.46,$38.28
+US70,Montana,KS,"Korea, Republic Of",NonPeak,$15.28,$43.94
+US70,Montana,KS,"Korea, Republic Of",Peak,$18.03,$51.85
+US70,Montana,KU,Kuwait,NonPeak,$16.05,$33.70
+US70,Montana,KU,Kuwait,Peak,$18.94,$39.77
+US70,Montana,NL,Netherlands,NonPeak,$16.80,$31.29
+US70,Montana,NL,Netherlands,Peak,$19.82,$36.92
+US70,Montana,NO,Norway,NonPeak,$17.57,$44.05
+US70,Montana,NO,Norway,Peak,$20.73,$51.98
+US70,Montana,PA,Paraguay,NonPeak,$18.33,$33.75
+US70,Montana,PA,Paraguay,Peak,$21.63,$39.82
+US70,Montana,PE,Peru,NonPeak,$24.38,$31.40
+US70,Montana,PE,Peru,Peak,$28.77,$37.05
+US70,Montana,PL,Poland,NonPeak,$16.00,$44.17
+US70,Montana,PL,Poland,Peak,$18.88,$52.12
+US70,Montana,PO,Portugal,NonPeak,$27.63,$33.98
+US70,Montana,PO,Portugal,Peak,$32.60,$40.10
+US70,Montana,PO01,Azores,NonPeak,$29.28,$31.45
+US70,Montana,PO01,Azores,Peak,$34.55,$37.11
+US70,Montana,QA,Qatar,NonPeak,$30.90,$44.28
+US70,Montana,QA,Qatar,Peak,$36.46,$52.25
+US70,Montana,RO,Romania,NonPeak,$15.28,$34.11
+US70,Montana,RO,Romania,Peak,$18.03,$40.25
+US70,Montana,RQ,Puerto Rico,NonPeak,$16.05,$31.63
+US70,Montana,RQ,Puerto Rico,Peak,$18.94,$37.32
+US70,Montana,SA,Saudi Arabia,NonPeak,$16.80,$44.51
+US70,Montana,SA,Saudi Arabia,Peak,$19.82,$52.52
+US70,Montana,SN,Singapore,NonPeak,$17.57,$34.33
+US70,Montana,SN,Singapore,Peak,$20.73,$40.51
+US70,Montana,SP,Spain,NonPeak,$18.33,$31.74
+US70,Montana,SP,Spain,Peak,$21.63,$37.45
+US70,Montana,TU,Turkey,NonPeak,$24.38,$44.62
+US70,Montana,TU,Turkey,Peak,$28.77,$52.65
+US70,Montana,UK,United Kingdom,NonPeak,$16.00,$34.45
+US70,Montana,UK,United Kingdom,Peak,$18.88,$40.65
+US70,Montana,US8030400,Alaska (Zone) IV,NonPeak,$27.63,$31.91
+US70,Montana,US8030400,Alaska (Zone) IV,Peak,$32.60,$37.65
+US70,Montana,US8050500,Alaska (Zone) III,NonPeak,$29.28,$44.74
+US70,Montana,US8050500,Alaska (Zone) III,Peak,$34.55,$52.79
+US70,Montana,US8101000,Alaska (Zone) I,NonPeak,$30.90,$34.56
+US70,Montana,US8101000,Alaska (Zone) I,Peak,$36.46,$40.78
+US70,Montana,US8190100,Alaska (Zone) II,NonPeak,$15.28,$32.09
+US70,Montana,US8190100,Alaska (Zone) II,Peak,$18.03,$37.87
+US70,Montana,US89,Hawaii,NonPeak,$16.05,$44.91
+US70,Montana,US89,Hawaii,Peak,$18.94,$52.99
+US70,Montana,UY,Uruguay,NonPeak,$16.80,$34.74
+US70,Montana,UY,Uruguay,Peak,$19.82,$40.99
+US70,Montana,VE,Venezuela,NonPeak,$17.57,$32.26
+US70,Montana,VE,Venezuela,Peak,$20.73,$38.07
+US72,Wyoming,AR,Argentina,NonPeak,$18.33,$45.09
+US72,Wyoming,AR,Argentina,Peak,$21.63,$53.21
+US72,Wyoming,AS11,New South Wales/Australian Capital Territory,NonPeak,$24.38,$34.90
+US72,Wyoming,AS11,New South Wales/Australian Capital Territory,Peak,$28.77,$41.18
+US72,Wyoming,AS21,Northern Territory,NonPeak,$16.00,$32.44
+US72,Wyoming,AS21,Northern Territory,Peak,$18.88,$38.28
+US72,Wyoming,BA,Bahrain,NonPeak,$27.63,$43.94
+US72,Wyoming,BA,Bahrain,Peak,$32.60,$51.85
+US72,Wyoming,BE,Belgium,NonPeak,$29.28,$33.70
+US72,Wyoming,BE,Belgium,Peak,$34.55,$39.77
+US72,Wyoming,BL,Bolivia,NonPeak,$30.90,$31.29
+US72,Wyoming,BL,Bolivia,Peak,$36.46,$36.92
+US72,Wyoming,BR,Brazil - Brazilia,NonPeak,$15.28,$44.05
+US72,Wyoming,BR,Brazil - Brazilia,Peak,$18.03,$51.98
+US72,Wyoming,CA10,Ontario,NonPeak,$16.05,$33.75
+US72,Wyoming,CA10,Ontario,Peak,$18.94,$39.82
+US72,Wyoming,CA20,Quebec,NonPeak,$16.80,$31.40
+US72,Wyoming,CA20,Quebec,Peak,$19.82,$37.05
+US72,Wyoming,CA30,Manitoba,NonPeak,$17.57,$44.17
+US72,Wyoming,CA30,Manitoba,Peak,$20.73,$52.12
+US72,Wyoming,CI,Chile,NonPeak,$18.33,$33.98
+US72,Wyoming,CI,Chile,Peak,$21.63,$40.10
+US72,Wyoming,CO,Colombia,NonPeak,$24.38,$31.45
+US72,Wyoming,CO,Colombia,Peak,$28.77,$37.11
+US72,Wyoming,CS,Costa Rica,NonPeak,$16.00,$44.28
+US72,Wyoming,CS,Costa Rica,Peak,$18.88,$52.25
+US72,Wyoming,EC,Ecuador,NonPeak,$27.63,$34.11
+US72,Wyoming,EC,Ecuador,Peak,$32.60,$40.25
+US72,Wyoming,ES,El Salvador,NonPeak,$29.28,$31.63
+US72,Wyoming,ES,El Salvador,Peak,$34.55,$37.32
+US72,Wyoming,GE,Germany,NonPeak,$30.90,$44.51
+US72,Wyoming,GE,Germany,Peak,$36.46,$52.52
+US72,Wyoming,GQ,Guam,NonPeak,$15.28,$34.33
+US72,Wyoming,GQ,Guam,Peak,$18.03,$40.51
+US72,Wyoming,GR,Greece,NonPeak,$16.05,$31.74
+US72,Wyoming,GR,Greece,Peak,$18.94,$37.45
+US72,Wyoming,GR29,Crete,NonPeak,$16.80,$44.62
+US72,Wyoming,GR29,Crete,Peak,$19.82,$52.65
+US72,Wyoming,GT,Guatemala,NonPeak,$17.57,$34.45
+US72,Wyoming,GT,Guatemala,Peak,$20.73,$40.65
+US72,Wyoming,HO,Honduras,NonPeak,$18.33,$31.91
+US72,Wyoming,HO,Honduras,Peak,$21.63,$37.65
+US72,Wyoming,HU,Hungary,NonPeak,$24.38,$44.74
+US72,Wyoming,HU,Hungary,Peak,$28.77,$52.79
+US72,Wyoming,IT,Italy,NonPeak,$16.00,$34.56
+US72,Wyoming,IT,Italy,Peak,$18.88,$40.78
+US72,Wyoming,IT10,Sicily,NonPeak,$27.63,$32.09
+US72,Wyoming,IT10,Sicily,Peak,$32.60,$37.87
+US72,Wyoming,JA01,Japan-Central,NonPeak,$29.28,$44.91
+US72,Wyoming,JA01,Japan-Central,Peak,$34.55,$52.99
+US72,Wyoming,JA02,Japan-South (Excludes Hokkaido),NonPeak,$30.90,$34.74
+US72,Wyoming,JA02,Japan-South (Excludes Hokkaido),Peak,$36.46,$40.99
+US72,Wyoming,JA03,Japan-North,NonPeak,$15.28,$32.26
+US72,Wyoming,JA03,Japan-North,Peak,$18.03,$38.07
+US72,Wyoming,JA96,Okinawa,NonPeak,$16.05,$45.09
+US72,Wyoming,JA96,Okinawa,Peak,$18.94,$53.21
+US72,Wyoming,KS,"Korea, Republic Of",NonPeak,$16.80,$34.90
+US72,Wyoming,KS,"Korea, Republic Of",Peak,$19.82,$41.18
+US72,Wyoming,KU,Kuwait,NonPeak,$17.57,$32.44
+US72,Wyoming,KU,Kuwait,Peak,$20.73,$38.28
+US72,Wyoming,NL,Netherlands,NonPeak,$18.33,$43.94
+US72,Wyoming,NL,Netherlands,Peak,$21.63,$51.85
+US72,Wyoming,NO,Norway,NonPeak,$24.38,$33.70
+US72,Wyoming,NO,Norway,Peak,$28.77,$39.77
+US72,Wyoming,PA,Paraguay,NonPeak,$16.00,$31.29
+US72,Wyoming,PA,Paraguay,Peak,$18.88,$36.92
+US72,Wyoming,PE,Peru,NonPeak,$27.63,$44.05
+US72,Wyoming,PE,Peru,Peak,$32.60,$51.98
+US72,Wyoming,PL,Poland,NonPeak,$29.28,$33.75
+US72,Wyoming,PL,Poland,Peak,$34.55,$39.82
+US72,Wyoming,PO,Portugal,NonPeak,$30.90,$31.40
+US72,Wyoming,PO,Portugal,Peak,$36.46,$37.05
+US72,Wyoming,PO01,Azores,NonPeak,$15.28,$44.17
+US72,Wyoming,PO01,Azores,Peak,$18.03,$52.12
+US72,Wyoming,QA,Qatar,NonPeak,$16.05,$33.98
+US72,Wyoming,QA,Qatar,Peak,$18.94,$40.10
+US72,Wyoming,RO,Romania,NonPeak,$16.80,$31.45
+US72,Wyoming,RO,Romania,Peak,$19.82,$37.11
+US72,Wyoming,RQ,Puerto Rico,NonPeak,$17.57,$44.28
+US72,Wyoming,RQ,Puerto Rico,Peak,$20.73,$52.25
+US72,Wyoming,SA,Saudi Arabia,NonPeak,$18.33,$34.11
+US72,Wyoming,SA,Saudi Arabia,Peak,$21.63,$40.25
+US72,Wyoming,SN,Singapore,NonPeak,$24.38,$31.63
+US72,Wyoming,SN,Singapore,Peak,$28.77,$37.32
+US72,Wyoming,SP,Spain,NonPeak,$16.00,$44.51
+US72,Wyoming,SP,Spain,Peak,$18.88,$52.52
+US72,Wyoming,TU,Turkey,NonPeak,$27.63,$34.33
+US72,Wyoming,TU,Turkey,Peak,$32.60,$40.51
+US72,Wyoming,UK,United Kingdom,NonPeak,$29.28,$31.74
+US72,Wyoming,UK,United Kingdom,Peak,$34.55,$37.45
+US72,Wyoming,US8030400,Alaska (Zone) IV,NonPeak,$30.90,$44.62
+US72,Wyoming,US8030400,Alaska (Zone) IV,Peak,$36.46,$52.65
+US72,Wyoming,US8050500,Alaska (Zone) III,NonPeak,$15.28,$34.45
+US72,Wyoming,US8050500,Alaska (Zone) III,Peak,$18.03,$40.65
+US72,Wyoming,US8101000,Alaska (Zone) I,NonPeak,$16.05,$31.91
+US72,Wyoming,US8101000,Alaska (Zone) I,Peak,$18.94,$37.65
+US72,Wyoming,US8190100,Alaska (Zone) II,NonPeak,$16.80,$44.74
+US72,Wyoming,US8190100,Alaska (Zone) II,Peak,$19.82,$52.79
+US72,Wyoming,US89,Hawaii,NonPeak,$17.57,$34.56
+US72,Wyoming,US89,Hawaii,Peak,$20.73,$40.78
+US72,Wyoming,UY,Uruguay,NonPeak,$18.33,$32.09
+US72,Wyoming,UY,Uruguay,Peak,$21.63,$37.87
+US72,Wyoming,VE,Venezuela,NonPeak,$24.38,$44.91
+US72,Wyoming,VE,Venezuela,Peak,$28.77,$52.99
+US74,Colorado,AR,Argentina,NonPeak,$16.00,$34.74
+US74,Colorado,AR,Argentina,Peak,$18.88,$40.99
+US74,Colorado,AS11,New South Wales/Australian Capital Territory,NonPeak,$27.63,$32.26
+US74,Colorado,AS11,New South Wales/Australian Capital Territory,Peak,$32.60,$38.07
+US74,Colorado,AS21,Northern Territory,NonPeak,$29.28,$45.09
+US74,Colorado,AS21,Northern Territory,Peak,$34.55,$53.21
+US74,Colorado,BA,Bahrain,NonPeak,$30.90,$34.90
+US74,Colorado,BA,Bahrain,Peak,$36.46,$41.18
+US74,Colorado,BE,Belgium,NonPeak,$15.28,$32.44
+US74,Colorado,BE,Belgium,Peak,$18.03,$38.28
+US74,Colorado,BL,Bolivia,NonPeak,$16.05,$43.94
+US74,Colorado,BL,Bolivia,Peak,$18.94,$51.85
+US74,Colorado,BR,Brazil - Brazilia,NonPeak,$16.80,$33.70
+US74,Colorado,BR,Brazil - Brazilia,Peak,$19.82,$39.77
+US74,Colorado,CA10,Ontario,NonPeak,$17.57,$31.29
+US74,Colorado,CA10,Ontario,Peak,$20.73,$36.92
+US74,Colorado,CA20,Quebec,NonPeak,$18.33,$44.05
+US74,Colorado,CA20,Quebec,Peak,$21.63,$51.98
+US74,Colorado,CA30,Manitoba,NonPeak,$24.38,$33.75
+US74,Colorado,CA30,Manitoba,Peak,$28.77,$39.82
+US74,Colorado,CI,Chile,NonPeak,$16.00,$31.40
+US74,Colorado,CI,Chile,Peak,$18.88,$37.05
+US74,Colorado,CO,Colombia,NonPeak,$27.63,$44.17
+US74,Colorado,CO,Colombia,Peak,$32.60,$52.12
+US74,Colorado,CS,Costa Rica,NonPeak,$29.28,$33.98
+US74,Colorado,CS,Costa Rica,Peak,$34.55,$40.10
+US74,Colorado,EC,Ecuador,NonPeak,$30.90,$31.45
+US74,Colorado,EC,Ecuador,Peak,$36.46,$37.11
+US74,Colorado,ES,El Salvador,NonPeak,$15.28,$44.28
+US74,Colorado,ES,El Salvador,Peak,$18.03,$52.25
+US74,Colorado,GE,Germany,NonPeak,$16.05,$34.11
+US74,Colorado,GE,Germany,Peak,$18.94,$40.25
+US74,Colorado,GQ,Guam,NonPeak,$16.80,$31.63
+US74,Colorado,GQ,Guam,Peak,$19.82,$37.32
+US74,Colorado,GR,Greece,NonPeak,$17.57,$44.51
+US74,Colorado,GR,Greece,Peak,$20.73,$52.52
+US74,Colorado,GR29,Crete,NonPeak,$18.33,$34.33
+US74,Colorado,GR29,Crete,Peak,$21.63,$40.51
+US74,Colorado,GT,Guatemala,NonPeak,$24.38,$31.74
+US74,Colorado,GT,Guatemala,Peak,$28.77,$37.45
+US74,Colorado,HO,Honduras,NonPeak,$16.00,$44.62
+US74,Colorado,HO,Honduras,Peak,$18.88,$52.65
+US74,Colorado,HU,Hungary,NonPeak,$27.63,$34.45
+US74,Colorado,HU,Hungary,Peak,$32.60,$40.65
+US74,Colorado,IT,Italy,NonPeak,$29.28,$31.91
+US74,Colorado,IT,Italy,Peak,$34.55,$37.65
+US74,Colorado,IT10,Sicily,NonPeak,$30.90,$44.74
+US74,Colorado,IT10,Sicily,Peak,$36.46,$52.79
+US74,Colorado,JA01,Japan-Central,NonPeak,$15.28,$34.56
+US74,Colorado,JA01,Japan-Central,Peak,$18.03,$40.78
+US74,Colorado,JA02,Japan-South (Excludes Hokkaido),NonPeak,$16.05,$32.09
+US74,Colorado,JA02,Japan-South (Excludes Hokkaido),Peak,$18.94,$37.87
+US74,Colorado,JA03,Japan-North,NonPeak,$16.80,$44.91
+US74,Colorado,JA03,Japan-North,Peak,$19.82,$52.99
+US74,Colorado,JA96,Okinawa,NonPeak,$17.57,$34.74
+US74,Colorado,JA96,Okinawa,Peak,$20.73,$40.99
+US74,Colorado,KS,"Korea, Republic Of",NonPeak,$18.33,$32.26
+US74,Colorado,KS,"Korea, Republic Of",Peak,$21.63,$38.07
+US74,Colorado,KU,Kuwait,NonPeak,$24.38,$45.09
+US74,Colorado,KU,Kuwait,Peak,$28.77,$53.21
+US74,Colorado,NL,Netherlands,NonPeak,$16.00,$34.90
+US74,Colorado,NL,Netherlands,Peak,$18.88,$41.18
+US74,Colorado,NO,Norway,NonPeak,$27.63,$32.44
+US74,Colorado,NO,Norway,Peak,$32.60,$38.28
+US74,Colorado,PA,Paraguay,NonPeak,$29.28,$43.94
+US74,Colorado,PA,Paraguay,Peak,$34.55,$51.85
+US74,Colorado,PE,Peru,NonPeak,$30.90,$33.70
+US74,Colorado,PE,Peru,Peak,$36.46,$39.77
+US74,Colorado,PL,Poland,NonPeak,$15.28,$31.29
+US74,Colorado,PL,Poland,Peak,$18.03,$36.92
+US74,Colorado,PO,Portugal,NonPeak,$16.05,$44.05
+US74,Colorado,PO,Portugal,Peak,$18.94,$51.98
+US74,Colorado,PO01,Azores,NonPeak,$16.80,$33.75
+US74,Colorado,PO01,Azores,Peak,$19.82,$39.82
+US74,Colorado,QA,Qatar,NonPeak,$17.57,$31.40
+US74,Colorado,QA,Qatar,Peak,$20.73,$37.05
+US74,Colorado,RO,Romania,NonPeak,$18.33,$44.17
+US74,Colorado,RO,Romania,Peak,$21.63,$52.12
+US74,Colorado,RQ,Puerto Rico,NonPeak,$24.38,$33.98
+US74,Colorado,RQ,Puerto Rico,Peak,$28.77,$40.10
+US74,Colorado,SA,Saudi Arabia,NonPeak,$16.00,$31.45
+US74,Colorado,SA,Saudi Arabia,Peak,$18.88,$37.11
+US74,Colorado,SN,Singapore,NonPeak,$27.63,$44.28
+US74,Colorado,SN,Singapore,Peak,$32.60,$52.25
+US74,Colorado,SP,Spain,NonPeak,$29.28,$34.11
+US74,Colorado,SP,Spain,Peak,$34.55,$40.25
+US74,Colorado,TU,Turkey,NonPeak,$30.90,$31.63
+US74,Colorado,TU,Turkey,Peak,$36.46,$37.32
+US74,Colorado,UK,United Kingdom,NonPeak,$15.28,$44.51
+US74,Colorado,UK,United Kingdom,Peak,$18.03,$52.52
+US74,Colorado,US8030400,Alaska (Zone) IV,NonPeak,$16.05,$34.33
+US74,Colorado,US8030400,Alaska (Zone) IV,Peak,$18.94,$40.51
+US74,Colorado,US8050500,Alaska (Zone) III,NonPeak,$16.80,$31.74
+US74,Colorado,US8050500,Alaska (Zone) III,Peak,$19.82,$37.45
+US74,Colorado,US8101000,Alaska (Zone) I,NonPeak,$17.57,$44.62
+US74,Colorado,US8101000,Alaska (Zone) I,Peak,$20.73,$52.65
+US74,Colorado,US8190100,Alaska (Zone) II,NonPeak,$18.33,$34.45
+US74,Colorado,US8190100,Alaska (Zone) II,Peak,$21.63,$40.65
+US74,Colorado,US89,Hawaii,NonPeak,$24.38,$31.91
+US74,Colorado,US89,Hawaii,Peak,$28.77,$37.65
+US74,Colorado,UY,Uruguay,NonPeak,$16.00,$44.74
+US74,Colorado,UY,Uruguay,Peak,$18.88,$52.79
+US74,Colorado,VE,Venezuela,NonPeak,$27.63,$34.56
+US74,Colorado,VE,Venezuela,Peak,$32.60,$40.78
+US76,Utah,AR,Argentina,NonPeak,$29.28,$32.09
+US76,Utah,AR,Argentina,Peak,$34.55,$37.87
+US76,Utah,AS11,New South Wales/Australian Capital Territory,NonPeak,$30.90,$44.91
+US76,Utah,AS11,New South Wales/Australian Capital Territory,Peak,$36.46,$52.99
+US76,Utah,AS21,Northern Territory,NonPeak,$15.28,$34.74
+US76,Utah,AS21,Northern Territory,Peak,$18.03,$40.99
+US76,Utah,BA,Bahrain,NonPeak,$16.05,$32.26
+US76,Utah,BA,Bahrain,Peak,$18.94,$38.07
+US76,Utah,BE,Belgium,NonPeak,$16.80,$45.09
+US76,Utah,BE,Belgium,Peak,$19.82,$53.21
+US76,Utah,BL,Bolivia,NonPeak,$17.57,$34.90
+US76,Utah,BL,Bolivia,Peak,$20.73,$41.18
+US76,Utah,BR,Brazil - Brazilia,NonPeak,$18.33,$32.44
+US76,Utah,BR,Brazil - Brazilia,Peak,$21.63,$38.28
+US76,Utah,CA10,Ontario,NonPeak,$24.38,$43.94
+US76,Utah,CA10,Ontario,Peak,$28.77,$51.85
+US76,Utah,CA20,Quebec,NonPeak,$16.00,$33.70
+US76,Utah,CA20,Quebec,Peak,$18.88,$39.77
+US76,Utah,CA30,Manitoba,NonPeak,$27.63,$31.29
+US76,Utah,CA30,Manitoba,Peak,$32.60,$36.92
+US76,Utah,CI,Chile,NonPeak,$29.28,$44.05
+US76,Utah,CI,Chile,Peak,$34.55,$51.98
+US76,Utah,CO,Colombia,NonPeak,$30.90,$33.75
+US76,Utah,CO,Colombia,Peak,$36.46,$39.82
+US76,Utah,CS,Costa Rica,NonPeak,$15.28,$31.40
+US76,Utah,CS,Costa Rica,Peak,$18.03,$37.05
+US76,Utah,EC,Ecuador,NonPeak,$16.05,$44.17
+US76,Utah,EC,Ecuador,Peak,$18.94,$52.12
+US76,Utah,ES,El Salvador,NonPeak,$16.80,$33.98
+US76,Utah,ES,El Salvador,Peak,$19.82,$40.10
+US76,Utah,GE,Germany,NonPeak,$17.57,$31.45
+US76,Utah,GE,Germany,Peak,$20.73,$37.11
+US76,Utah,GQ,Guam,NonPeak,$18.33,$44.28
+US76,Utah,GQ,Guam,Peak,$21.63,$52.25
+US76,Utah,GR,Greece,NonPeak,$24.38,$34.11
+US76,Utah,GR,Greece,Peak,$28.77,$40.25
+US76,Utah,GR29,Crete,NonPeak,$16.00,$31.63
+US76,Utah,GR29,Crete,Peak,$18.88,$37.32
+US76,Utah,GT,Guatemala,NonPeak,$27.63,$44.51
+US76,Utah,GT,Guatemala,Peak,$32.60,$52.52
+US76,Utah,HO,Honduras,NonPeak,$29.28,$34.33
+US76,Utah,HO,Honduras,Peak,$34.55,$40.51
+US76,Utah,HU,Hungary,NonPeak,$30.90,$31.74
+US76,Utah,HU,Hungary,Peak,$36.46,$37.45
+US76,Utah,IT,Italy,NonPeak,$15.28,$44.62
+US76,Utah,IT,Italy,Peak,$18.03,$52.65
+US76,Utah,IT10,Sicily,NonPeak,$16.05,$34.45
+US76,Utah,IT10,Sicily,Peak,$18.94,$40.65
+US76,Utah,JA01,Japan-Central,NonPeak,$16.80,$31.91
+US76,Utah,JA01,Japan-Central,Peak,$19.82,$37.65
+US76,Utah,JA02,Japan-South (Excludes Hokkaido),NonPeak,$17.57,$44.74
+US76,Utah,JA02,Japan-South (Excludes Hokkaido),Peak,$20.73,$52.79
+US76,Utah,JA03,Japan-North,NonPeak,$18.33,$34.56
+US76,Utah,JA03,Japan-North,Peak,$21.63,$40.78
+US76,Utah,JA96,Okinawa,NonPeak,$24.38,$32.09
+US76,Utah,JA96,Okinawa,Peak,$28.77,$37.87
+US76,Utah,KS,"Korea, Republic Of",NonPeak,$16.00,$44.91
+US76,Utah,KS,"Korea, Republic Of",Peak,$18.88,$52.99
+US76,Utah,KU,Kuwait,NonPeak,$27.63,$34.74
+US76,Utah,KU,Kuwait,Peak,$32.60,$40.99
+US76,Utah,NL,Netherlands,NonPeak,$29.28,$32.26
+US76,Utah,NL,Netherlands,Peak,$34.55,$38.07
+US76,Utah,NO,Norway,NonPeak,$30.90,$45.09
+US76,Utah,NO,Norway,Peak,$36.46,$53.21
+US76,Utah,PA,Paraguay,NonPeak,$15.28,$34.90
+US76,Utah,PA,Paraguay,Peak,$18.03,$41.18
+US76,Utah,PE,Peru,NonPeak,$16.05,$32.44
+US76,Utah,PE,Peru,Peak,$18.94,$38.28
+US76,Utah,PL,Poland,NonPeak,$16.80,$43.94
+US76,Utah,PL,Poland,Peak,$19.82,$51.85
+US76,Utah,PO,Portugal,NonPeak,$17.57,$33.70
+US76,Utah,PO,Portugal,Peak,$20.73,$39.77
+US76,Utah,PO01,Azores,NonPeak,$18.33,$31.29
+US76,Utah,PO01,Azores,Peak,$21.63,$36.92
+US76,Utah,QA,Qatar,NonPeak,$24.38,$44.05
+US76,Utah,QA,Qatar,Peak,$28.77,$51.98
+US76,Utah,RO,Romania,NonPeak,$16.00,$33.75
+US76,Utah,RO,Romania,Peak,$18.88,$39.82
+US76,Utah,RQ,Puerto Rico,NonPeak,$27.63,$31.40
+US76,Utah,RQ,Puerto Rico,Peak,$32.60,$37.05
+US76,Utah,SA,Saudi Arabia,NonPeak,$29.28,$44.17
+US76,Utah,SA,Saudi Arabia,Peak,$34.55,$52.12
+US76,Utah,SN,Singapore,NonPeak,$30.90,$33.98
+US76,Utah,SN,Singapore,Peak,$36.46,$40.10
+US76,Utah,SP,Spain,NonPeak,$15.28,$31.45
+US76,Utah,SP,Spain,Peak,$18.03,$37.11
+US76,Utah,TU,Turkey,NonPeak,$16.05,$44.28
+US76,Utah,TU,Turkey,Peak,$18.94,$52.25
+US76,Utah,UK,United Kingdom,NonPeak,$16.80,$34.11
+US76,Utah,UK,United Kingdom,Peak,$19.82,$40.25
+US76,Utah,US8030400,Alaska (Zone) IV,NonPeak,$17.57,$31.63
+US76,Utah,US8030400,Alaska (Zone) IV,Peak,$20.73,$37.32
+US76,Utah,US8050500,Alaska (Zone) III,NonPeak,$18.33,$44.51
+US76,Utah,US8050500,Alaska (Zone) III,Peak,$21.63,$52.52
+US76,Utah,US8101000,Alaska (Zone) I,NonPeak,$24.38,$34.33
+US76,Utah,US8101000,Alaska (Zone) I,Peak,$28.77,$40.51
+US76,Utah,US8190100,Alaska (Zone) II,NonPeak,$16.00,$31.74
+US76,Utah,US8190100,Alaska (Zone) II,Peak,$18.88,$37.45
+US76,Utah,US89,Hawaii,NonPeak,$27.63,$44.62
+US76,Utah,US89,Hawaii,Peak,$32.60,$52.65
+US76,Utah,UY,Uruguay,NonPeak,$29.28,$34.45
+US76,Utah,UY,Uruguay,Peak,$34.55,$40.65
+US76,Utah,VE,Venezuela,NonPeak,$30.90,$31.91
+US76,Utah,VE,Venezuela,Peak,$36.46,$37.65
+US77,New Mexico,AR,Argentina,NonPeak,$15.28,$44.74
+US77,New Mexico,AR,Argentina,Peak,$18.03,$52.79
+US77,New Mexico,AS11,New South Wales/Australian Capital Territory,NonPeak,$16.05,$34.56
+US77,New Mexico,AS11,New South Wales/Australian Capital Territory,Peak,$18.94,$40.78
+US77,New Mexico,AS21,Northern Territory,NonPeak,$16.80,$32.09
+US77,New Mexico,AS21,Northern Territory,Peak,$19.82,$37.87
+US77,New Mexico,BA,Bahrain,NonPeak,$17.57,$44.91
+US77,New Mexico,BA,Bahrain,Peak,$20.73,$52.99
+US77,New Mexico,BE,Belgium,NonPeak,$18.33,$34.74
+US77,New Mexico,BE,Belgium,Peak,$21.63,$40.99
+US77,New Mexico,BL,Bolivia,NonPeak,$24.38,$32.26
+US77,New Mexico,BL,Bolivia,Peak,$28.77,$38.07
+US77,New Mexico,BR,Brazil - Brazilia,NonPeak,$16.00,$45.09
+US77,New Mexico,BR,Brazil - Brazilia,Peak,$18.88,$53.21
+US77,New Mexico,CA10,Ontario,NonPeak,$27.63,$34.90
+US77,New Mexico,CA10,Ontario,Peak,$32.60,$41.18
+US77,New Mexico,CA20,Quebec,NonPeak,$29.28,$32.44
+US77,New Mexico,CA20,Quebec,Peak,$34.55,$38.28
+US77,New Mexico,CA30,Manitoba,NonPeak,$30.90,$43.94
+US77,New Mexico,CA30,Manitoba,Peak,$36.46,$51.85
+US77,New Mexico,CI,Chile,NonPeak,$15.28,$33.70
+US77,New Mexico,CI,Chile,Peak,$18.03,$39.77
+US77,New Mexico,CO,Colombia,NonPeak,$16.05,$31.29
+US77,New Mexico,CO,Colombia,Peak,$18.94,$36.92
+US77,New Mexico,CS,Costa Rica,NonPeak,$16.80,$44.05
+US77,New Mexico,CS,Costa Rica,Peak,$19.82,$51.98
+US77,New Mexico,EC,Ecuador,NonPeak,$17.57,$33.75
+US77,New Mexico,EC,Ecuador,Peak,$20.73,$39.82
+US77,New Mexico,ES,El Salvador,NonPeak,$18.33,$31.40
+US77,New Mexico,ES,El Salvador,Peak,$21.63,$37.05
+US77,New Mexico,GE,Germany,NonPeak,$24.38,$44.17
+US77,New Mexico,GE,Germany,Peak,$28.77,$52.12
+US77,New Mexico,GQ,Guam,NonPeak,$16.00,$33.98
+US77,New Mexico,GQ,Guam,Peak,$18.88,$40.10
+US77,New Mexico,GR,Greece,NonPeak,$27.63,$31.45
+US77,New Mexico,GR,Greece,Peak,$32.60,$37.11
+US77,New Mexico,GR29,Crete,NonPeak,$29.28,$44.28
+US77,New Mexico,GR29,Crete,Peak,$34.55,$52.25
+US77,New Mexico,GT,Guatemala,NonPeak,$30.90,$34.11
+US77,New Mexico,GT,Guatemala,Peak,$36.46,$40.25
+US77,New Mexico,HO,Honduras,NonPeak,$15.28,$31.63
+US77,New Mexico,HO,Honduras,Peak,$18.03,$37.32
+US77,New Mexico,HU,Hungary,NonPeak,$16.05,$44.51
+US77,New Mexico,HU,Hungary,Peak,$18.94,$52.52
+US77,New Mexico,IT,Italy,NonPeak,$16.80,$34.33
+US77,New Mexico,IT,Italy,Peak,$19.82,$40.51
+US77,New Mexico,IT10,Sicily,NonPeak,$17.57,$31.74
+US77,New Mexico,IT10,Sicily,Peak,$20.73,$37.45
+US77,New Mexico,JA01,Japan-Central,NonPeak,$18.33,$44.62
+US77,New Mexico,JA01,Japan-Central,Peak,$21.63,$52.65
+US77,New Mexico,JA02,Japan-South (Excludes Hokkaido),NonPeak,$24.38,$34.45
+US77,New Mexico,JA02,Japan-South (Excludes Hokkaido),Peak,$28.77,$40.65
+US77,New Mexico,JA03,Japan-North,NonPeak,$16.00,$31.91
+US77,New Mexico,JA03,Japan-North,Peak,$18.88,$37.65
+US77,New Mexico,JA96,Okinawa,NonPeak,$27.63,$44.74
+US77,New Mexico,JA96,Okinawa,Peak,$32.60,$52.79
+US77,New Mexico,KS,"Korea, Republic Of",NonPeak,$29.28,$34.56
+US77,New Mexico,KS,"Korea, Republic Of",Peak,$34.55,$40.78
+US77,New Mexico,KU,Kuwait,NonPeak,$30.90,$32.09
+US77,New Mexico,KU,Kuwait,Peak,$36.46,$37.87
+US77,New Mexico,NL,Netherlands,NonPeak,$15.28,$44.91
+US77,New Mexico,NL,Netherlands,Peak,$18.03,$52.99
+US77,New Mexico,NO,Norway,NonPeak,$16.05,$34.74
+US77,New Mexico,NO,Norway,Peak,$18.94,$40.99
+US77,New Mexico,PA,Paraguay,NonPeak,$16.80,$32.26
+US77,New Mexico,PA,Paraguay,Peak,$19.82,$38.07
+US77,New Mexico,PE,Peru,NonPeak,$17.57,$45.09
+US77,New Mexico,PE,Peru,Peak,$20.73,$53.21
+US77,New Mexico,PL,Poland,NonPeak,$18.33,$34.90
+US77,New Mexico,PL,Poland,Peak,$21.63,$41.18
+US77,New Mexico,PO,Portugal,NonPeak,$24.38,$32.44
+US77,New Mexico,PO,Portugal,Peak,$28.77,$38.28
+US77,New Mexico,PO01,Azores,NonPeak,$16.00,$43.94
+US77,New Mexico,PO01,Azores,Peak,$18.88,$51.85
+US77,New Mexico,QA,Qatar,NonPeak,$27.63,$33.70
+US77,New Mexico,QA,Qatar,Peak,$32.60,$39.77
+US77,New Mexico,RO,Romania,NonPeak,$29.28,$31.29
+US77,New Mexico,RO,Romania,Peak,$34.55,$36.92
+US77,New Mexico,RQ,Puerto Rico,NonPeak,$30.90,$44.05
+US77,New Mexico,RQ,Puerto Rico,Peak,$36.46,$51.98
+US77,New Mexico,SA,Saudi Arabia,NonPeak,$15.28,$33.75
+US77,New Mexico,SA,Saudi Arabia,Peak,$18.03,$39.82
+US77,New Mexico,SN,Singapore,NonPeak,$16.05,$31.40
+US77,New Mexico,SN,Singapore,Peak,$18.94,$37.05
+US77,New Mexico,SP,Spain,NonPeak,$16.80,$44.17
+US77,New Mexico,SP,Spain,Peak,$19.82,$52.12
+US77,New Mexico,TU,Turkey,NonPeak,$17.57,$33.98
+US77,New Mexico,TU,Turkey,Peak,$20.73,$40.10
+US77,New Mexico,UK,United Kingdom,NonPeak,$18.33,$31.45
+US77,New Mexico,UK,United Kingdom,Peak,$21.63,$37.11
+US77,New Mexico,US8030400,Alaska (Zone) IV,NonPeak,$24.38,$44.28
+US77,New Mexico,US8030400,Alaska (Zone) IV,Peak,$28.77,$52.25
+US77,New Mexico,US8050500,Alaska (Zone) III,NonPeak,$16.00,$34.11
+US77,New Mexico,US8050500,Alaska (Zone) III,Peak,$18.88,$40.25
+US77,New Mexico,US8101000,Alaska (Zone) I,NonPeak,$27.63,$31.63
+US77,New Mexico,US8101000,Alaska (Zone) I,Peak,$32.60,$37.32
+US77,New Mexico,US8190100,Alaska (Zone) II,NonPeak,$29.28,$44.51
+US77,New Mexico,US8190100,Alaska (Zone) II,Peak,$34.55,$52.52
+US77,New Mexico,US89,Hawaii,NonPeak,$30.90,$34.33
+US77,New Mexico,US89,Hawaii,Peak,$36.46,$40.51
+US77,New Mexico,UY,Uruguay,NonPeak,$15.28,$31.74
+US77,New Mexico,UY,Uruguay,Peak,$18.03,$37.45
+US77,New Mexico,VE,Venezuela,NonPeak,$16.05,$44.62
+US77,New Mexico,VE,Venezuela,Peak,$18.94,$52.65
+US79,Arizona,AR,Argentina,NonPeak,$16.80,$34.45
+US79,Arizona,AR,Argentina,Peak,$19.82,$40.65
+US79,Arizona,AS11,New South Wales/Australian Capital Territory,NonPeak,$17.57,$31.91
+US79,Arizona,AS11,New South Wales/Australian Capital Territory,Peak,$20.73,$37.65
+US79,Arizona,AS21,Northern Territory,NonPeak,$18.33,$44.74
+US79,Arizona,AS21,Northern Territory,Peak,$21.63,$52.79
+US79,Arizona,BA,Bahrain,NonPeak,$24.38,$34.56
+US79,Arizona,BA,Bahrain,Peak,$28.77,$40.78
+US79,Arizona,BE,Belgium,NonPeak,$16.00,$32.09
+US79,Arizona,BE,Belgium,Peak,$18.88,$37.87
+US79,Arizona,BL,Bolivia,NonPeak,$27.63,$44.91
+US79,Arizona,BL,Bolivia,Peak,$32.60,$52.99
+US79,Arizona,BR,Brazil - Brazilia,NonPeak,$29.28,$34.74
+US79,Arizona,BR,Brazil - Brazilia,Peak,$34.55,$40.99
+US79,Arizona,CA10,Ontario,NonPeak,$30.90,$32.26
+US79,Arizona,CA10,Ontario,Peak,$36.46,$38.07
+US79,Arizona,CA20,Quebec,NonPeak,$15.28,$45.09
+US79,Arizona,CA20,Quebec,Peak,$18.03,$53.21
+US79,Arizona,CA30,Manitoba,NonPeak,$16.05,$34.90
+US79,Arizona,CA30,Manitoba,Peak,$18.94,$41.18
+US79,Arizona,CI,Chile,NonPeak,$16.80,$32.44
+US79,Arizona,CI,Chile,Peak,$19.82,$38.28
+US79,Arizona,CO,Colombia,NonPeak,$17.57,$43.94
+US79,Arizona,CO,Colombia,Peak,$20.73,$51.85
+US79,Arizona,CS,Costa Rica,NonPeak,$18.33,$33.70
+US79,Arizona,CS,Costa Rica,Peak,$21.63,$39.77
+US79,Arizona,EC,Ecuador,NonPeak,$24.38,$31.29
+US79,Arizona,EC,Ecuador,Peak,$28.77,$36.92
+US79,Arizona,ES,El Salvador,NonPeak,$16.00,$44.05
+US79,Arizona,ES,El Salvador,Peak,$18.88,$51.98
+US79,Arizona,GE,Germany,NonPeak,$27.63,$33.75
+US79,Arizona,GE,Germany,Peak,$32.60,$39.82
+US79,Arizona,GQ,Guam,NonPeak,$29.28,$31.40
+US79,Arizona,GQ,Guam,Peak,$34.55,$37.05
+US79,Arizona,GR,Greece,NonPeak,$30.90,$44.17
+US79,Arizona,GR,Greece,Peak,$36.46,$52.12
+US79,Arizona,GR29,Crete,NonPeak,$15.28,$33.98
+US79,Arizona,GR29,Crete,Peak,$18.03,$40.10
+US79,Arizona,GT,Guatemala,NonPeak,$16.05,$31.45
+US79,Arizona,GT,Guatemala,Peak,$18.94,$37.11
+US79,Arizona,HO,Honduras,NonPeak,$16.80,$44.28
+US79,Arizona,HO,Honduras,Peak,$19.82,$52.25
+US79,Arizona,HU,Hungary,NonPeak,$17.57,$34.11
+US79,Arizona,HU,Hungary,Peak,$20.73,$40.25
+US79,Arizona,IT,Italy,NonPeak,$18.33,$31.63
+US79,Arizona,IT,Italy,Peak,$21.63,$37.32
+US79,Arizona,IT10,Sicily,NonPeak,$24.38,$44.51
+US79,Arizona,IT10,Sicily,Peak,$28.77,$52.52
+US79,Arizona,JA01,Japan-Central,NonPeak,$16.00,$34.33
+US79,Arizona,JA01,Japan-Central,Peak,$18.88,$40.51
+US79,Arizona,JA02,Japan-South (Excludes Hokkaido),NonPeak,$27.63,$31.74
+US79,Arizona,JA02,Japan-South (Excludes Hokkaido),Peak,$32.60,$37.45
+US79,Arizona,JA03,Japan-North,NonPeak,$29.28,$44.62
+US79,Arizona,JA03,Japan-North,Peak,$34.55,$52.65
+US79,Arizona,JA96,Okinawa,NonPeak,$30.90,$34.45
+US79,Arizona,JA96,Okinawa,Peak,$36.46,$40.65
+US79,Arizona,KS,"Korea, Republic Of",NonPeak,$15.28,$31.91
+US79,Arizona,KS,"Korea, Republic Of",Peak,$18.03,$37.65
+US79,Arizona,KU,Kuwait,NonPeak,$16.05,$44.74
+US79,Arizona,KU,Kuwait,Peak,$18.94,$52.79
+US79,Arizona,NL,Netherlands,NonPeak,$16.80,$34.56
+US79,Arizona,NL,Netherlands,Peak,$19.82,$40.78
+US79,Arizona,NO,Norway,NonPeak,$17.57,$32.09
+US79,Arizona,NO,Norway,Peak,$20.73,$37.87
+US79,Arizona,PA,Paraguay,NonPeak,$18.33,$44.91
+US79,Arizona,PA,Paraguay,Peak,$21.63,$52.99
+US79,Arizona,PE,Peru,NonPeak,$24.38,$34.74
+US79,Arizona,PE,Peru,Peak,$28.77,$40.99
+US79,Arizona,PL,Poland,NonPeak,$16.00,$32.26
+US79,Arizona,PL,Poland,Peak,$18.88,$38.07
+US79,Arizona,PO,Portugal,NonPeak,$27.63,$45.09
+US79,Arizona,PO,Portugal,Peak,$32.60,$53.21
+US79,Arizona,PO01,Azores,NonPeak,$29.28,$34.90
+US79,Arizona,PO01,Azores,Peak,$34.55,$41.18
+US79,Arizona,QA,Qatar,NonPeak,$30.90,$32.44
+US79,Arizona,QA,Qatar,Peak,$36.46,$38.28
+US79,Arizona,RO,Romania,NonPeak,$15.28,$43.94
+US79,Arizona,RO,Romania,Peak,$18.03,$51.85
+US79,Arizona,RQ,Puerto Rico,NonPeak,$16.05,$33.70
+US79,Arizona,RQ,Puerto Rico,Peak,$18.94,$39.77
+US79,Arizona,SA,Saudi Arabia,NonPeak,$16.80,$31.29
+US79,Arizona,SA,Saudi Arabia,Peak,$19.82,$36.92
+US79,Arizona,SN,Singapore,NonPeak,$17.57,$44.05
+US79,Arizona,SN,Singapore,Peak,$20.73,$51.98
+US79,Arizona,SP,Spain,NonPeak,$18.33,$33.75
+US79,Arizona,SP,Spain,Peak,$21.63,$39.82
+US79,Arizona,TU,Turkey,NonPeak,$24.38,$31.40
+US79,Arizona,TU,Turkey,Peak,$28.77,$37.05
+US79,Arizona,UK,United Kingdom,NonPeak,$16.00,$44.17
+US79,Arizona,UK,United Kingdom,Peak,$18.88,$52.12
+US79,Arizona,US8030400,Alaska (Zone) IV,NonPeak,$27.63,$33.98
+US79,Arizona,US8030400,Alaska (Zone) IV,Peak,$32.60,$40.10
+US79,Arizona,US8050500,Alaska (Zone) III,NonPeak,$29.28,$31.45
+US79,Arizona,US8050500,Alaska (Zone) III,Peak,$34.55,$37.11
+US79,Arizona,US8101000,Alaska (Zone) I,NonPeak,$30.90,$44.28
+US79,Arizona,US8101000,Alaska (Zone) I,Peak,$36.46,$52.25
+US79,Arizona,US8190100,Alaska (Zone) II,NonPeak,$15.28,$34.11
+US79,Arizona,US8190100,Alaska (Zone) II,Peak,$18.03,$40.25
+US79,Arizona,US89,Hawaii,NonPeak,$16.05,$31.63
+US79,Arizona,US89,Hawaii,Peak,$18.94,$37.32
+US79,Arizona,UY,Uruguay,NonPeak,$16.80,$44.51
+US79,Arizona,UY,Uruguay,Peak,$19.82,$52.52
+US79,Arizona,VE,Venezuela,NonPeak,$17.57,$34.33
+US79,Arizona,VE,Venezuela,Peak,$20.73,$40.51
+US83,Idaho,AR,Argentina,NonPeak,$18.33,$31.74
+US83,Idaho,AR,Argentina,Peak,$21.63,$37.45
+US83,Idaho,AS11,New South Wales/Australian Capital Territory,NonPeak,$24.38,$44.62
+US83,Idaho,AS11,New South Wales/Australian Capital Territory,Peak,$28.77,$52.65
+US83,Idaho,AS21,Northern Territory,NonPeak,$16.00,$34.45
+US83,Idaho,AS21,Northern Territory,Peak,$18.88,$40.65
+US83,Idaho,BA,Bahrain,NonPeak,$27.63,$31.91
+US83,Idaho,BA,Bahrain,Peak,$32.60,$37.65
+US83,Idaho,BE,Belgium,NonPeak,$29.28,$44.74
+US83,Idaho,BE,Belgium,Peak,$34.55,$52.79
+US83,Idaho,BL,Bolivia,NonPeak,$30.90,$34.56
+US83,Idaho,BL,Bolivia,Peak,$36.46,$40.78
+US83,Idaho,BR,Brazil - Brazilia,NonPeak,$15.28,$32.09
+US83,Idaho,BR,Brazil - Brazilia,Peak,$18.03,$37.87
+US83,Idaho,CA10,Ontario,NonPeak,$16.05,$44.91
+US83,Idaho,CA10,Ontario,Peak,$18.94,$52.99
+US83,Idaho,CA20,Quebec,NonPeak,$16.80,$34.74
+US83,Idaho,CA20,Quebec,Peak,$19.82,$40.99
+US83,Idaho,CA30,Manitoba,NonPeak,$17.57,$32.26
+US83,Idaho,CA30,Manitoba,Peak,$20.73,$38.07
+US83,Idaho,CI,Chile,NonPeak,$18.33,$45.09
+US83,Idaho,CI,Chile,Peak,$21.63,$53.21
+US83,Idaho,CO,Colombia,NonPeak,$24.38,$34.90
+US83,Idaho,CO,Colombia,Peak,$28.77,$41.18
+US83,Idaho,CS,Costa Rica,NonPeak,$16.00,$32.44
+US83,Idaho,CS,Costa Rica,Peak,$18.88,$38.28
+US83,Idaho,EC,Ecuador,NonPeak,$27.63,$43.94
+US83,Idaho,EC,Ecuador,Peak,$32.60,$51.85
+US83,Idaho,ES,El Salvador,NonPeak,$29.28,$33.70
+US83,Idaho,ES,El Salvador,Peak,$34.55,$39.77
+US83,Idaho,GE,Germany,NonPeak,$30.90,$31.29
+US83,Idaho,GE,Germany,Peak,$36.46,$36.92
+US83,Idaho,GQ,Guam,NonPeak,$15.28,$44.05
+US83,Idaho,GQ,Guam,Peak,$18.03,$51.98
+US83,Idaho,GR,Greece,NonPeak,$16.05,$33.75
+US83,Idaho,GR,Greece,Peak,$18.94,$39.82
+US83,Idaho,GR29,Crete,NonPeak,$16.80,$31.40
+US83,Idaho,GR29,Crete,Peak,$19.82,$37.05
+US83,Idaho,GT,Guatemala,NonPeak,$17.57,$44.17
+US83,Idaho,GT,Guatemala,Peak,$20.73,$52.12
+US83,Idaho,HO,Honduras,NonPeak,$18.33,$33.98
+US83,Idaho,HO,Honduras,Peak,$21.63,$40.10
+US83,Idaho,HU,Hungary,NonPeak,$24.38,$31.45
+US83,Idaho,HU,Hungary,Peak,$28.77,$37.11
+US83,Idaho,IT,Italy,NonPeak,$16.00,$44.28
+US83,Idaho,IT,Italy,Peak,$18.88,$52.25
+US83,Idaho,IT10,Sicily,NonPeak,$27.63,$34.11
+US83,Idaho,IT10,Sicily,Peak,$32.60,$40.25
+US83,Idaho,JA01,Japan-Central,NonPeak,$29.28,$31.63
+US83,Idaho,JA01,Japan-Central,Peak,$34.55,$37.32
+US83,Idaho,JA02,Japan-South (Excludes Hokkaido),NonPeak,$30.90,$44.51
+US83,Idaho,JA02,Japan-South (Excludes Hokkaido),Peak,$36.46,$52.52
+US83,Idaho,JA03,Japan-North,NonPeak,$15.28,$34.33
+US83,Idaho,JA03,Japan-North,Peak,$18.03,$40.51
+US83,Idaho,JA96,Okinawa,NonPeak,$16.05,$31.74
+US83,Idaho,JA96,Okinawa,Peak,$18.94,$37.45
+US83,Idaho,KS,"Korea, Republic Of",NonPeak,$16.80,$44.62
+US83,Idaho,KS,"Korea, Republic Of",Peak,$19.82,$52.65
+US83,Idaho,KU,Kuwait,NonPeak,$17.57,$34.45
+US83,Idaho,KU,Kuwait,Peak,$20.73,$40.65
+US83,Idaho,NL,Netherlands,NonPeak,$18.33,$31.91
+US83,Idaho,NL,Netherlands,Peak,$21.63,$37.65
+US83,Idaho,NO,Norway,NonPeak,$24.38,$44.74
+US83,Idaho,NO,Norway,Peak,$28.77,$52.79
+US83,Idaho,PA,Paraguay,NonPeak,$16.00,$34.56
+US83,Idaho,PA,Paraguay,Peak,$18.88,$40.78
+US83,Idaho,PE,Peru,NonPeak,$27.63,$32.09
+US83,Idaho,PE,Peru,Peak,$32.60,$37.87
+US83,Idaho,PL,Poland,NonPeak,$29.28,$44.91
+US83,Idaho,PL,Poland,Peak,$34.55,$52.99
+US83,Idaho,PO,Portugal,NonPeak,$30.90,$34.74
+US83,Idaho,PO,Portugal,Peak,$36.46,$40.99
+US83,Idaho,PO01,Azores,NonPeak,$15.28,$32.26
+US83,Idaho,PO01,Azores,Peak,$18.03,$38.07
+US83,Idaho,QA,Qatar,NonPeak,$16.05,$45.09
+US83,Idaho,QA,Qatar,Peak,$18.94,$53.21
+US83,Idaho,RO,Romania,NonPeak,$16.80,$34.90
+US83,Idaho,RO,Romania,Peak,$19.82,$41.18
+US83,Idaho,RQ,Puerto Rico,NonPeak,$17.57,$32.44
+US83,Idaho,RQ,Puerto Rico,Peak,$20.73,$38.28
+US83,Idaho,SA,Saudi Arabia,NonPeak,$18.33,$43.94
+US83,Idaho,SA,Saudi Arabia,Peak,$21.63,$51.85
+US83,Idaho,SN,Singapore,NonPeak,$24.38,$33.70
+US83,Idaho,SN,Singapore,Peak,$28.77,$39.77
+US83,Idaho,SP,Spain,NonPeak,$16.00,$31.29
+US83,Idaho,SP,Spain,Peak,$18.88,$36.92
+US83,Idaho,TU,Turkey,NonPeak,$27.63,$44.05
+US83,Idaho,TU,Turkey,Peak,$32.60,$51.98
+US83,Idaho,UK,United Kingdom,NonPeak,$29.28,$33.75
+US83,Idaho,UK,United Kingdom,Peak,$34.55,$39.82
+US83,Idaho,US8030400,Alaska (Zone) IV,NonPeak,$30.90,$31.40
+US83,Idaho,US8030400,Alaska (Zone) IV,Peak,$36.46,$37.05
+US83,Idaho,US8050500,Alaska (Zone) III,NonPeak,$15.28,$44.17
+US83,Idaho,US8050500,Alaska (Zone) III,Peak,$18.03,$52.12
+US83,Idaho,US8101000,Alaska (Zone) I,NonPeak,$43.94,$18.03
+US83,Idaho,US8101000,Alaska (Zone) I,Peak,$51.85,$51.85
+US83,Idaho,US8190100,Alaska (Zone) II,NonPeak,$33.70,$18.94
+US83,Idaho,US8190100,Alaska (Zone) II,Peak,$39.77,$39.77
+US83,Idaho,US89,Hawaii,NonPeak,$31.29,$19.82
+US83,Idaho,US89,Hawaii,Peak,$36.92,$36.92
+US83,Idaho,UY,Uruguay,NonPeak,$44.05,$20.73
+US83,Idaho,UY,Uruguay,Peak,$51.98,$51.98
+US83,Idaho,VE,Venezuela,NonPeak,$33.75,$21.63
+US83,Idaho,VE,Venezuela,Peak,$39.82,$39.82
+US84,Washington,AR,Argentina,NonPeak,$31.40,$28.77
+US84,Washington,AR,Argentina,Peak,$37.05,$37.05
+US84,Washington,AS11,New South Wales/Australian Capital Territory,NonPeak,$44.17,$18.88
+US84,Washington,AS11,New South Wales/Australian Capital Territory,Peak,$52.12,$52.12
+US84,Washington,AS21,Northern Territory,NonPeak,$33.98,$32.60
+US84,Washington,AS21,Northern Territory,Peak,$40.10,$40.10
+US84,Washington,BA,Bahrain,NonPeak,$31.45,$34.55
+US84,Washington,BA,Bahrain,Peak,$37.11,$37.11
+US84,Washington,BE,Belgium,NonPeak,$44.28,$36.46
+US84,Washington,BE,Belgium,Peak,$52.25,$52.25
+US84,Washington,BL,Bolivia,NonPeak,$34.11,$18.03
+US84,Washington,BL,Bolivia,Peak,$40.25,$40.25
+US84,Washington,BR,Brazil - Brazilia,NonPeak,$31.63,$18.94
+US84,Washington,BR,Brazil - Brazilia,Peak,$37.32,$37.32
+US84,Washington,CA10,Ontario,NonPeak,$44.51,$19.82
+US84,Washington,CA10,Ontario,Peak,$52.52,$52.52
+US84,Washington,CA20,Quebec,NonPeak,$34.33,$20.73
+US84,Washington,CA20,Quebec,Peak,$40.51,$40.51
+US84,Washington,CA30,Manitoba,NonPeak,$31.74,$21.63
+US84,Washington,CA30,Manitoba,Peak,$37.45,$37.45
+US84,Washington,CI,Chile,NonPeak,$44.62,$28.77
+US84,Washington,CI,Chile,Peak,$52.65,$52.65
+US84,Washington,CO,Colombia,NonPeak,$34.45,$18.88
+US84,Washington,CO,Colombia,Peak,$40.65,$40.65
+US84,Washington,CS,Costa Rica,NonPeak,$31.91,$32.60
+US84,Washington,CS,Costa Rica,Peak,$37.65,$37.65
+US84,Washington,EC,Ecuador,NonPeak,$44.74,$34.55
+US84,Washington,EC,Ecuador,Peak,$52.79,$52.79
+US84,Washington,ES,El Salvador,NonPeak,$34.56,$36.46
+US84,Washington,ES,El Salvador,Peak,$40.78,$40.78
+US84,Washington,GE,Germany,NonPeak,$32.09,$18.03
+US84,Washington,GE,Germany,Peak,$37.87,$37.87
+US84,Washington,GQ,Guam,NonPeak,$44.91,$18.94
+US84,Washington,GQ,Guam,Peak,$52.99,$52.99
+US84,Washington,GR,Greece,NonPeak,$34.74,$19.82
+US84,Washington,GR,Greece,Peak,$40.99,$40.99
+US84,Washington,GR29,Crete,NonPeak,$32.26,$20.73
+US84,Washington,GR29,Crete,Peak,$38.07,$38.07
+US84,Washington,GT,Guatemala,NonPeak,$45.09,$21.63
+US84,Washington,GT,Guatemala,Peak,$53.21,$53.21
+US84,Washington,HO,Honduras,NonPeak,$34.90,$28.77
+US84,Washington,HO,Honduras,Peak,$41.18,$41.18
+US84,Washington,HU,Hungary,NonPeak,$32.44,$18.88
+US84,Washington,HU,Hungary,Peak,$38.28,$38.28
+US84,Washington,IT,Italy,NonPeak,$43.94,$32.60
+US84,Washington,IT,Italy,Peak,$51.85,$51.85
+US84,Washington,IT10,Sicily,NonPeak,$33.70,$34.55
+US84,Washington,IT10,Sicily,Peak,$39.77,$39.77
+US84,Washington,JA01,Japan-Central,NonPeak,$31.29,$36.46
+US84,Washington,JA01,Japan-Central,Peak,$36.92,$36.92
+US84,Washington,JA02,Japan-South (Excludes Hokkaido),NonPeak,$44.05,$18.03
+US84,Washington,JA02,Japan-South (Excludes Hokkaido),Peak,$51.98,$51.98
+US84,Washington,JA03,Japan-North,NonPeak,$33.75,$18.94
+US84,Washington,JA03,Japan-North,Peak,$39.82,$39.82
+US84,Washington,JA96,Okinawa,NonPeak,$31.40,$19.82
+US84,Washington,JA96,Okinawa,Peak,$37.05,$37.05
+US84,Washington,KS,"Korea, Republic Of",NonPeak,$44.17,$20.73
+US84,Washington,KS,"Korea, Republic Of",Peak,$52.12,$52.12
+US84,Washington,KU,Kuwait,NonPeak,$33.98,$21.63
+US84,Washington,KU,Kuwait,Peak,$40.10,$40.10
+US84,Washington,NL,Netherlands,NonPeak,$31.45,$28.77
+US84,Washington,NL,Netherlands,Peak,$37.11,$37.11
+US84,Washington,NO,Norway,NonPeak,$44.28,$18.88
+US84,Washington,NO,Norway,Peak,$52.25,$52.25
+US84,Washington,PA,Paraguay,NonPeak,$34.11,$32.60
+US84,Washington,PA,Paraguay,Peak,$40.25,$40.25
+US84,Washington,PE,Peru,NonPeak,$31.63,$34.55
+US84,Washington,PE,Peru,Peak,$37.32,$37.32
+US84,Washington,PL,Poland,NonPeak,$44.51,$36.46
+US84,Washington,PL,Poland,Peak,$52.52,$52.52
+US84,Washington,PO,Portugal,NonPeak,$34.33,$18.03
+US84,Washington,PO,Portugal,Peak,$40.51,$40.51
+US84,Washington,PO01,Azores,NonPeak,$31.74,$18.94
+US84,Washington,PO01,Azores,Peak,$37.45,$37.45
+US84,Washington,QA,Qatar,NonPeak,$44.62,$19.82
+US84,Washington,QA,Qatar,Peak,$52.65,$52.65
+US84,Washington,RO,Romania,NonPeak,$34.45,$20.73
+US84,Washington,RO,Romania,Peak,$40.65,$40.65
+US84,Washington,RQ,Puerto Rico,NonPeak,$31.91,$21.63
+US84,Washington,RQ,Puerto Rico,Peak,$37.65,$37.65
+US84,Washington,SA,Saudi Arabia,NonPeak,$44.74,$28.77
+US84,Washington,SA,Saudi Arabia,Peak,$52.79,$52.79
+US84,Washington,SN,Singapore,NonPeak,$34.56,$18.88
+US84,Washington,SN,Singapore,Peak,$40.78,$40.78
+US84,Washington,SP,Spain,NonPeak,$32.09,$32.60
+US84,Washington,SP,Spain,Peak,$37.87,$37.87
+US84,Washington,TU,Turkey,NonPeak,$44.91,$34.55
+US84,Washington,TU,Turkey,Peak,$52.99,$52.99
+US84,Washington,UK,United Kingdom,NonPeak,$34.74,$36.46
+US84,Washington,UK,United Kingdom,Peak,$40.99,$40.99
+US84,Washington,US8030400,Alaska (Zone) IV,NonPeak,$32.26,$18.03
+US84,Washington,US8030400,Alaska (Zone) IV,Peak,$38.07,$38.07
+US84,Washington,US8050500,Alaska (Zone) III,NonPeak,$45.09,$18.94
+US84,Washington,US8050500,Alaska (Zone) III,Peak,$53.21,$53.21
+US84,Washington,US8101000,Alaska (Zone) I,NonPeak,$34.90,$19.82
+US84,Washington,US8101000,Alaska (Zone) I,Peak,$41.18,$41.18
+US84,Washington,US8190100,Alaska (Zone) II,NonPeak,$32.44,$20.73
+US84,Washington,US8190100,Alaska (Zone) II,Peak,$38.28,$38.28
+US84,Washington,US89,Hawaii,NonPeak,$43.94,$21.63
+US84,Washington,US89,Hawaii,Peak,$51.85,$51.85
+US84,Washington,UY,Uruguay,NonPeak,$33.70,$28.77
+US84,Washington,UY,Uruguay,Peak,$39.77,$39.77
+US84,Washington,VE,Venezuela,NonPeak,$31.29,$18.88
+US84,Washington,VE,Venezuela,Peak,$36.92,$36.92
+US85,Oregon,AR,Argentina,NonPeak,$44.05,$32.60
+US85,Oregon,AR,Argentina,Peak,$51.98,$51.98
+US85,Oregon,AS11,New South Wales/Australian Capital Territory,NonPeak,$33.75,$34.55
+US85,Oregon,AS11,New South Wales/Australian Capital Territory,Peak,$39.82,$39.82
+US85,Oregon,AS21,Northern Territory,NonPeak,$31.40,$36.46
+US85,Oregon,AS21,Northern Territory,Peak,$37.05,$37.05
+US85,Oregon,BA,Bahrain,NonPeak,$44.17,$18.03
+US85,Oregon,BA,Bahrain,Peak,$52.12,$52.12
+US85,Oregon,BE,Belgium,NonPeak,$33.98,$18.94
+US85,Oregon,BE,Belgium,Peak,$40.10,$40.10
+US85,Oregon,BL,Bolivia,NonPeak,$31.45,$19.82
+US85,Oregon,BL,Bolivia,Peak,$37.11,$37.11
+US85,Oregon,BR,Brazil - Brazilia,NonPeak,$44.28,$20.73
+US85,Oregon,BR,Brazil - Brazilia,Peak,$52.25,$52.25
+US85,Oregon,CA10,Ontario,NonPeak,$34.11,$21.63
+US85,Oregon,CA10,Ontario,Peak,$40.25,$40.25
+US85,Oregon,CA20,Quebec,NonPeak,$31.63,$28.77
+US85,Oregon,CA20,Quebec,Peak,$37.32,$37.32
+US85,Oregon,CA30,Manitoba,NonPeak,$44.51,$18.88
+US85,Oregon,CA30,Manitoba,Peak,$52.52,$52.52
+US85,Oregon,CI,Chile,NonPeak,$34.33,$32.60
+US85,Oregon,CI,Chile,Peak,$40.51,$40.51
+US85,Oregon,CO,Colombia,NonPeak,$31.74,$34.55
+US85,Oregon,CO,Colombia,Peak,$37.45,$37.45
+US85,Oregon,CS,Costa Rica,NonPeak,$44.62,$36.46
+US85,Oregon,CS,Costa Rica,Peak,$52.65,$52.65
+US85,Oregon,EC,Ecuador,NonPeak,$34.45,$18.03
+US85,Oregon,EC,Ecuador,Peak,$40.65,$40.65
+US85,Oregon,ES,El Salvador,NonPeak,$31.91,$18.94
+US85,Oregon,ES,El Salvador,Peak,$37.65,$37.65
+US85,Oregon,GE,Germany,NonPeak,$44.74,$19.82
+US85,Oregon,GE,Germany,Peak,$52.79,$52.79
+US85,Oregon,GQ,Guam,NonPeak,$34.56,$20.73
+US85,Oregon,GQ,Guam,Peak,$40.78,$40.78
+US85,Oregon,GR,Greece,NonPeak,$32.09,$21.63
+US85,Oregon,GR,Greece,Peak,$37.87,$37.87
+US85,Oregon,GR29,Crete,NonPeak,$44.91,$28.77
+US85,Oregon,GR29,Crete,Peak,$52.99,$52.99
+US85,Oregon,GT,Guatemala,NonPeak,$34.74,$18.88
+US85,Oregon,GT,Guatemala,Peak,$40.99,$40.99
+US85,Oregon,HO,Honduras,NonPeak,$32.26,$32.60
+US85,Oregon,HO,Honduras,Peak,$38.07,$38.07
+US85,Oregon,HU,Hungary,NonPeak,$45.09,$34.55
+US85,Oregon,HU,Hungary,Peak,$53.21,$53.21
+US85,Oregon,IT,Italy,NonPeak,$34.90,$36.46
+US85,Oregon,IT,Italy,Peak,$41.18,$41.18
+US85,Oregon,IT10,Sicily,NonPeak,$32.44,$18.03
+US85,Oregon,IT10,Sicily,Peak,$38.28,$38.28
+US85,Oregon,JA01,Japan-Central,NonPeak,$43.94,$18.94
+US85,Oregon,JA01,Japan-Central,Peak,$51.85,$51.85
+US85,Oregon,JA02,Japan-South (Excludes Hokkaido),NonPeak,$33.70,$19.82
+US85,Oregon,JA02,Japan-South (Excludes Hokkaido),Peak,$39.77,$39.77
+US85,Oregon,JA03,Japan-North,NonPeak,$31.29,$20.73
+US85,Oregon,JA03,Japan-North,Peak,$36.92,$36.92
+US85,Oregon,JA96,Okinawa,NonPeak,$44.05,$21.63
+US85,Oregon,JA96,Okinawa,Peak,$51.98,$51.98
+US85,Oregon,KS,"Korea, Republic Of",NonPeak,$33.75,$28.77
+US85,Oregon,KS,"Korea, Republic Of",Peak,$39.82,$39.82
+US85,Oregon,KU,Kuwait,NonPeak,$31.40,$18.88
+US85,Oregon,KU,Kuwait,Peak,$37.05,$37.05
+US85,Oregon,NL,Netherlands,NonPeak,$44.17,$32.60
+US85,Oregon,NL,Netherlands,Peak,$52.12,$52.12
+US85,Oregon,NO,Norway,NonPeak,$33.98,$34.55
+US85,Oregon,NO,Norway,Peak,$40.10,$40.10
+US85,Oregon,PA,Paraguay,NonPeak,$31.45,$36.46
+US85,Oregon,PA,Paraguay,Peak,$37.11,$37.11
+US85,Oregon,PE,Peru,NonPeak,$44.28,$18.03
+US85,Oregon,PE,Peru,Peak,$52.25,$52.25
+US85,Oregon,PL,Poland,NonPeak,$34.11,$18.94
+US85,Oregon,PL,Poland,Peak,$40.25,$40.25
+US85,Oregon,PO,Portugal,NonPeak,$31.63,$19.82
+US85,Oregon,PO,Portugal,Peak,$37.32,$37.32
+US85,Oregon,PO01,Azores,NonPeak,$44.51,$20.73
+US85,Oregon,PO01,Azores,Peak,$52.52,$52.52
+US85,Oregon,QA,Qatar,NonPeak,$34.33,$21.63
+US85,Oregon,QA,Qatar,Peak,$40.51,$40.51
+US85,Oregon,RO,Romania,NonPeak,$31.74,$28.77
+US85,Oregon,RO,Romania,Peak,$37.45,$37.45
+US85,Oregon,RQ,Puerto Rico,NonPeak,$44.62,$18.88
+US85,Oregon,RQ,Puerto Rico,Peak,$52.65,$52.65
+US85,Oregon,SA,Saudi Arabia,NonPeak,$34.45,$32.60
+US85,Oregon,SA,Saudi Arabia,Peak,$40.65,$40.65
+US85,Oregon,SN,Singapore,NonPeak,$31.91,$34.55
+US85,Oregon,SN,Singapore,Peak,$37.65,$37.65
+US85,Oregon,SP,Spain,NonPeak,$44.74,$36.46
+US85,Oregon,SP,Spain,Peak,$52.79,$52.79
+US85,Oregon,TU,Turkey,NonPeak,$34.56,$18.03
+US85,Oregon,TU,Turkey,Peak,$40.78,$40.78
+US85,Oregon,UK,United Kingdom,NonPeak,$32.09,$18.94
+US85,Oregon,UK,United Kingdom,Peak,$37.87,$37.87
+US85,Oregon,US8030400,Alaska (Zone) IV,NonPeak,$44.91,$19.82
+US85,Oregon,US8030400,Alaska (Zone) IV,Peak,$52.99,$52.99
+US85,Oregon,US8050500,Alaska (Zone) III,NonPeak,$34.74,$20.73
+US85,Oregon,US8050500,Alaska (Zone) III,Peak,$40.99,$40.99
+US85,Oregon,US8101000,Alaska (Zone) I,NonPeak,$32.26,$21.63
+US85,Oregon,US8101000,Alaska (Zone) I,Peak,$38.07,$38.07
+US85,Oregon,US8190100,Alaska (Zone) II,NonPeak,$45.09,$28.77
+US85,Oregon,US8190100,Alaska (Zone) II,Peak,$53.21,$53.21
+US85,Oregon,US89,Hawaii,NonPeak,$34.90,$18.88
+US85,Oregon,US89,Hawaii,Peak,$41.18,$41.18
+US85,Oregon,UY,Uruguay,NonPeak,$32.44,$32.60
+US85,Oregon,UY,Uruguay,Peak,$38.28,$38.28
+US85,Oregon,VE,Venezuela,NonPeak,$43.94,$34.55
+US85,Oregon,VE,Venezuela,Peak,$51.85,$51.85
+US86,Nevada,AR,Argentina,NonPeak,$33.70,$36.46
+US86,Nevada,AR,Argentina,Peak,$39.77,$39.77
+US86,Nevada,AS11,New South Wales/Australian Capital Territory,NonPeak,$31.29,$18.03
+US86,Nevada,AS11,New South Wales/Australian Capital Territory,Peak,$36.92,$36.92
+US86,Nevada,AS21,Northern Territory,NonPeak,$44.05,$18.94
+US86,Nevada,AS21,Northern Territory,Peak,$51.98,$51.98
+US86,Nevada,BA,Bahrain,NonPeak,$33.75,$19.82
+US86,Nevada,BA,Bahrain,Peak,$39.82,$39.82
+US86,Nevada,BE,Belgium,NonPeak,$31.40,$20.73
+US86,Nevada,BE,Belgium,Peak,$37.05,$37.05
+US86,Nevada,BL,Bolivia,NonPeak,$44.17,$21.63
+US86,Nevada,BL,Bolivia,Peak,$52.12,$52.12
+US86,Nevada,BR,Brazil - Brazilia,NonPeak,$33.98,$28.77
+US86,Nevada,BR,Brazil - Brazilia,Peak,$40.10,$40.10
+US86,Nevada,CA10,Ontario,NonPeak,$31.45,$18.88
+US86,Nevada,CA10,Ontario,Peak,$37.11,$37.11
+US86,Nevada,CA20,Quebec,NonPeak,$44.28,$32.60
+US86,Nevada,CA20,Quebec,Peak,$52.25,$52.25
+US86,Nevada,CA30,Manitoba,NonPeak,$34.11,$34.55
+US86,Nevada,CA30,Manitoba,Peak,$40.25,$40.25
+US86,Nevada,CI,Chile,NonPeak,$31.63,$36.46
+US86,Nevada,CI,Chile,Peak,$37.32,$37.32
+US86,Nevada,CO,Colombia,NonPeak,$44.51,$18.03
+US86,Nevada,CO,Colombia,Peak,$52.52,$52.52
+US86,Nevada,CS,Costa Rica,NonPeak,$34.33,$18.94
+US86,Nevada,CS,Costa Rica,Peak,$40.51,$40.51
+US86,Nevada,EC,Ecuador,NonPeak,$31.74,$19.82
+US86,Nevada,EC,Ecuador,Peak,$37.45,$37.45
+US86,Nevada,ES,El Salvador,NonPeak,$44.62,$20.73
+US86,Nevada,ES,El Salvador,Peak,$52.65,$52.65
+US86,Nevada,GE,Germany,NonPeak,$34.45,$21.63
+US86,Nevada,GE,Germany,Peak,$40.65,$40.65
+US86,Nevada,GQ,Guam,NonPeak,$31.91,$28.77
+US86,Nevada,GQ,Guam,Peak,$37.65,$37.65
+US86,Nevada,GR,Greece,NonPeak,$44.74,$18.88
+US86,Nevada,GR,Greece,Peak,$52.79,$52.79
+US86,Nevada,GR29,Crete,NonPeak,$34.56,$32.60
+US86,Nevada,GR29,Crete,Peak,$40.78,$40.78
+US86,Nevada,GT,Guatemala,NonPeak,$32.09,$34.55
+US86,Nevada,GT,Guatemala,Peak,$37.87,$37.87
+US86,Nevada,HO,Honduras,NonPeak,$44.91,$36.46
+US86,Nevada,HO,Honduras,Peak,$52.99,$52.99
+US86,Nevada,HU,Hungary,NonPeak,$34.74,$18.03
+US86,Nevada,HU,Hungary,Peak,$40.99,$40.99
+US86,Nevada,IT,Italy,NonPeak,$32.26,$18.94
+US86,Nevada,IT,Italy,Peak,$38.07,$38.07
+US86,Nevada,IT10,Sicily,NonPeak,$45.09,$19.82
+US86,Nevada,IT10,Sicily,Peak,$53.21,$53.21
+US86,Nevada,JA01,Japan-Central,NonPeak,$34.90,$20.73
+US86,Nevada,JA01,Japan-Central,Peak,$41.18,$41.18
+US86,Nevada,JA02,Japan-South (Excludes Hokkaido),NonPeak,$32.44,$21.63
+US86,Nevada,JA02,Japan-South (Excludes Hokkaido),Peak,$38.28,$38.28
+US86,Nevada,JA03,Japan-North,NonPeak,$43.94,$28.77
+US86,Nevada,JA03,Japan-North,Peak,$51.85,$51.85
+US86,Nevada,JA96,Okinawa,NonPeak,$33.70,$18.88
+US86,Nevada,JA96,Okinawa,Peak,$39.77,$39.77
+US86,Nevada,KS,"Korea, Republic Of",NonPeak,$31.29,$32.60
+US86,Nevada,KS,"Korea, Republic Of",Peak,$36.92,$36.92
+US86,Nevada,KU,Kuwait,NonPeak,$44.05,$34.55
+US86,Nevada,KU,Kuwait,Peak,$51.98,$51.98
+US86,Nevada,NL,Netherlands,NonPeak,$33.75,$36.46
+US86,Nevada,NL,Netherlands,Peak,$39.82,$39.82
+US86,Nevada,NO,Norway,NonPeak,$31.40,$18.03
+US86,Nevada,NO,Norway,Peak,$37.05,$37.05
+US86,Nevada,PA,Paraguay,NonPeak,$44.17,$18.94
+US86,Nevada,PA,Paraguay,Peak,$52.12,$52.12
+US86,Nevada,PE,Peru,NonPeak,$33.98,$19.82
+US86,Nevada,PE,Peru,Peak,$40.10,$40.10
+US86,Nevada,PL,Poland,NonPeak,$31.45,$20.73
+US86,Nevada,PL,Poland,Peak,$37.11,$37.11
+US86,Nevada,PO,Portugal,NonPeak,$44.28,$21.63
+US86,Nevada,PO,Portugal,Peak,$52.25,$52.25
+US86,Nevada,PO01,Azores,NonPeak,$34.11,$28.77
+US86,Nevada,PO01,Azores,Peak,$40.25,$40.25
+US86,Nevada,QA,Qatar,NonPeak,$31.63,$18.88
+US86,Nevada,QA,Qatar,Peak,$37.32,$37.32
+US86,Nevada,RO,Romania,NonPeak,$44.51,$32.60
+US86,Nevada,RO,Romania,Peak,$52.52,$52.52
+US86,Nevada,RQ,Puerto Rico,NonPeak,$34.33,$34.55
+US86,Nevada,RQ,Puerto Rico,Peak,$40.51,$40.51
+US86,Nevada,SA,Saudi Arabia,NonPeak,$31.74,$36.46
+US86,Nevada,SA,Saudi Arabia,Peak,$37.45,$37.45
+US86,Nevada,SN,Singapore,NonPeak,$44.62,$18.03
+US86,Nevada,SN,Singapore,Peak,$52.65,$52.65
+US86,Nevada,SP,Spain,NonPeak,$34.45,$18.94
+US86,Nevada,SP,Spain,Peak,$40.65,$40.65
+US86,Nevada,TU,Turkey,NonPeak,$31.91,$19.82
+US86,Nevada,TU,Turkey,Peak,$37.65,$37.65
+US86,Nevada,UK,United Kingdom,NonPeak,$44.74,$20.73
+US86,Nevada,UK,United Kingdom,Peak,$52.79,$52.79
+US86,Nevada,US8030400,Alaska (Zone) IV,NonPeak,$34.56,$21.63
+US86,Nevada,US8030400,Alaska (Zone) IV,Peak,$40.78,$40.78
+US86,Nevada,US8050500,Alaska (Zone) III,NonPeak,$32.09,$28.77
+US86,Nevada,US8050500,Alaska (Zone) III,Peak,$37.87,$37.87
+US86,Nevada,US8101000,Alaska (Zone) I,NonPeak,$44.91,$18.88
+US86,Nevada,US8101000,Alaska (Zone) I,Peak,$52.99,$52.99
+US86,Nevada,US8190100,Alaska (Zone) II,NonPeak,$34.74,$32.60
+US86,Nevada,US8190100,Alaska (Zone) II,Peak,$40.99,$40.99
+US86,Nevada,US89,Hawaii,NonPeak,$32.26,$34.55
+US86,Nevada,US89,Hawaii,Peak,$38.07,$38.07
+US86,Nevada,UY,Uruguay,NonPeak,$45.09,$36.46
+US86,Nevada,UY,Uruguay,Peak,$53.21,$53.21
+US86,Nevada,VE,Venezuela,NonPeak,$34.90,$18.03
+US86,Nevada,VE,Venezuela,Peak,$41.18,$41.18
+US87,California-North,AR,Argentina,NonPeak,$32.44,$18.94
+US87,California-North,AR,Argentina,Peak,$38.28,$38.28
+US87,California-North,AS11,New South Wales/Australian Capital Territory,NonPeak,$43.94,$19.82
+US87,California-North,AS11,New South Wales/Australian Capital Territory,Peak,$51.85,$51.85
+US87,California-North,AS21,Northern Territory,NonPeak,$33.70,$20.73
+US87,California-North,AS21,Northern Territory,Peak,$39.77,$39.77
+US87,California-North,BA,Bahrain,NonPeak,$31.29,$21.63
+US87,California-North,BA,Bahrain,Peak,$36.92,$36.92
+US87,California-North,BE,Belgium,NonPeak,$44.05,$28.77
+US87,California-North,BE,Belgium,Peak,$51.98,$51.98
+US87,California-North,BL,Bolivia,NonPeak,$33.75,$18.88
+US87,California-North,BL,Bolivia,Peak,$39.82,$39.82
+US87,California-North,BR,Brazil - Brazilia,NonPeak,$31.40,$32.60
+US87,California-North,BR,Brazil - Brazilia,Peak,$37.05,$37.05
+US87,California-North,CA10,Ontario,NonPeak,$44.17,$34.55
+US87,California-North,CA10,Ontario,Peak,$52.12,$52.12
+US87,California-North,CA20,Quebec,NonPeak,$33.98,$36.46
+US87,California-North,CA20,Quebec,Peak,$40.10,$40.10
+US87,California-North,CA30,Manitoba,NonPeak,$31.45,$18.03
+US87,California-North,CA30,Manitoba,Peak,$37.11,$37.11
+US87,California-North,CI,Chile,NonPeak,$44.28,$18.94
+US87,California-North,CI,Chile,Peak,$52.25,$52.25
+US87,California-North,CO,Colombia,NonPeak,$34.11,$19.82
+US87,California-North,CO,Colombia,Peak,$40.25,$40.25
+US87,California-North,CS,Costa Rica,NonPeak,$31.63,$20.73
+US87,California-North,CS,Costa Rica,Peak,$37.32,$37.32
+US87,California-North,EC,Ecuador,NonPeak,$44.51,$21.63
+US87,California-North,EC,Ecuador,Peak,$52.52,$52.52
+US87,California-North,ES,El Salvador,NonPeak,$34.33,$28.77
+US87,California-North,ES,El Salvador,Peak,$40.51,$40.51
+US87,California-North,GE,Germany,NonPeak,$31.74,$18.88
+US87,California-North,GE,Germany,Peak,$37.45,$37.45
+US87,California-North,GQ,Guam,NonPeak,$44.62,$32.60
+US87,California-North,GQ,Guam,Peak,$52.65,$52.65
+US87,California-North,GR,Greece,NonPeak,$34.45,$34.55
+US87,California-North,GR,Greece,Peak,$40.65,$40.65
+US87,California-North,GR29,Crete,NonPeak,$31.91,$36.46
+US87,California-North,GR29,Crete,Peak,$37.65,$37.65
+US87,California-North,GT,Guatemala,NonPeak,$44.74,$18.03
+US87,California-North,GT,Guatemala,Peak,$52.79,$52.79
+US87,California-North,HO,Honduras,NonPeak,$34.56,$18.94
+US87,California-North,HO,Honduras,Peak,$40.78,$40.78
+US87,California-North,HU,Hungary,NonPeak,$32.09,$19.82
+US87,California-North,HU,Hungary,Peak,$37.87,$37.87
+US87,California-North,IT,Italy,NonPeak,$44.91,$20.73
+US87,California-North,IT,Italy,Peak,$52.99,$52.99
+US87,California-North,IT10,Sicily,NonPeak,$34.74,$21.63
+US87,California-North,IT10,Sicily,Peak,$40.99,$40.99
+US87,California-North,JA01,Japan-Central,NonPeak,$32.26,$28.77
+US87,California-North,JA01,Japan-Central,Peak,$38.07,$38.07
+US87,California-North,JA02,Japan-South (Excludes Hokkaido),NonPeak,$45.09,$18.88
+US87,California-North,JA02,Japan-South (Excludes Hokkaido),Peak,$53.21,$53.21
+US87,California-North,JA03,Japan-North,NonPeak,$34.90,$32.60
+US87,California-North,JA03,Japan-North,Peak,$41.18,$41.18
+US87,California-North,JA96,Okinawa,NonPeak,$32.44,$34.55
+US87,California-North,JA96,Okinawa,Peak,$38.28,$38.28
+US87,California-North,KS,"Korea, Republic Of",NonPeak,$43.94,$36.46
+US87,California-North,KS,"Korea, Republic Of",Peak,$51.85,$51.85
+US87,California-North,KU,Kuwait,NonPeak,$33.70,$18.03
+US87,California-North,KU,Kuwait,Peak,$39.77,$39.77
+US87,California-North,NL,Netherlands,NonPeak,$31.29,$18.94
+US87,California-North,NL,Netherlands,Peak,$36.92,$36.92
+US87,California-North,NO,Norway,NonPeak,$44.05,$19.82
+US87,California-North,NO,Norway,Peak,$51.98,$51.98
+US87,California-North,PA,Paraguay,NonPeak,$33.75,$20.73
+US87,California-North,PA,Paraguay,Peak,$39.82,$39.82
+US87,California-North,PE,Peru,NonPeak,$31.40,$21.63
+US87,California-North,PE,Peru,Peak,$37.05,$37.05
+US87,California-North,PL,Poland,NonPeak,$44.17,$28.77
+US87,California-North,PL,Poland,Peak,$52.12,$52.12
+US87,California-North,PO,Portugal,NonPeak,$33.98,$18.88
+US87,California-North,PO,Portugal,Peak,$40.10,$40.10
+US87,California-North,PO01,Azores,NonPeak,$31.45,$32.60
+US87,California-North,PO01,Azores,Peak,$37.11,$37.11
+US87,California-North,QA,Qatar,NonPeak,$44.28,$34.55
+US87,California-North,QA,Qatar,Peak,$52.25,$52.25
+US87,California-North,RO,Romania,NonPeak,$34.11,$36.46
+US87,California-North,RO,Romania,Peak,$40.25,$40.25
+US87,California-North,RQ,Puerto Rico,NonPeak,$31.63,$18.03
+US87,California-North,RQ,Puerto Rico,Peak,$37.32,$37.32
+US87,California-North,SA,Saudi Arabia,NonPeak,$44.51,$18.94
+US87,California-North,SA,Saudi Arabia,Peak,$52.52,$52.52
+US87,California-North,SN,Singapore,NonPeak,$34.33,$19.82
+US87,California-North,SN,Singapore,Peak,$40.51,$40.51
+US87,California-North,SP,Spain,NonPeak,$31.74,$20.73
+US87,California-North,SP,Spain,Peak,$37.45,$37.45
+US87,California-North,TU,Turkey,NonPeak,$44.62,$21.63
+US87,California-North,TU,Turkey,Peak,$52.65,$52.65
+US87,California-North,UK,United Kingdom,NonPeak,$34.45,$28.77
+US87,California-North,UK,United Kingdom,Peak,$40.65,$40.65
+US87,California-North,US8030400,Alaska (Zone) IV,NonPeak,$31.91,$18.88
+US87,California-North,US8030400,Alaska (Zone) IV,Peak,$37.65,$37.65
+US87,California-North,US8050500,Alaska (Zone) III,NonPeak,$44.74,$32.60
+US87,California-North,US8050500,Alaska (Zone) III,Peak,$52.79,$52.79
+US87,California-North,US8101000,Alaska (Zone) I,NonPeak,$34.56,$34.55
+US87,California-North,US8101000,Alaska (Zone) I,Peak,$40.78,$40.78
+US87,California-North,US8190100,Alaska (Zone) II,NonPeak,$32.09,$36.46
+US87,California-North,US8190100,Alaska (Zone) II,Peak,$37.87,$37.87
+US87,California-North,US89,Hawaii,NonPeak,$44.91,$18.03
+US87,California-North,US89,Hawaii,Peak,$52.99,$52.99
+US87,California-North,UY,Uruguay,NonPeak,$34.74,$18.94
+US87,California-North,UY,Uruguay,Peak,$40.99,$40.99
+US87,California-North,VE,Venezuela,NonPeak,$32.26,$19.82
+US87,California-North,VE,Venezuela,Peak,$38.07,$38.07
+US88,California-South,AR,Argentina,NonPeak,$45.09,$20.73
+US88,California-South,AR,Argentina,Peak,$53.21,$53.21
+US88,California-South,AS11,New South Wales/Australian Capital Territory,NonPeak,$34.90,$21.63
+US88,California-South,AS11,New South Wales/Australian Capital Territory,Peak,$41.18,$41.18
+US88,California-South,AS21,Northern Territory,NonPeak,$32.44,$28.77
+US88,California-South,AS21,Northern Territory,Peak,$38.28,$38.28
+US88,California-South,BA,Bahrain,NonPeak,$43.94,$18.88
+US88,California-South,BA,Bahrain,Peak,$51.85,$51.85
+US88,California-South,BE,Belgium,NonPeak,$33.70,$32.60
+US88,California-South,BE,Belgium,Peak,$39.77,$39.77
+US88,California-South,BL,Bolivia,NonPeak,$31.29,$34.55
+US88,California-South,BL,Bolivia,Peak,$36.92,$36.92
+US88,California-South,BR,Brazil - Brazilia,NonPeak,$44.05,$36.46
+US88,California-South,BR,Brazil - Brazilia,Peak,$51.98,$51.98
+US88,California-South,CA10,Ontario,NonPeak,$33.75,$18.03
+US88,California-South,CA10,Ontario,Peak,$39.82,$39.82
+US88,California-South,CA20,Quebec,NonPeak,$31.40,$18.94
+US88,California-South,CA20,Quebec,Peak,$37.05,$37.05
+US88,California-South,CA30,Manitoba,NonPeak,$44.17,$19.82
+US88,California-South,CA30,Manitoba,Peak,$52.12,$52.12
+US88,California-South,CI,Chile,NonPeak,$33.98,$20.73
+US88,California-South,CI,Chile,Peak,$40.10,$40.10
+US88,California-South,CO,Colombia,NonPeak,$31.45,$21.63
+US88,California-South,CO,Colombia,Peak,$37.11,$37.11
+US88,California-South,CS,Costa Rica,NonPeak,$44.28,$28.77
+US88,California-South,CS,Costa Rica,Peak,$52.25,$52.25
+US88,California-South,EC,Ecuador,NonPeak,$34.11,$18.88
+US88,California-South,EC,Ecuador,Peak,$40.25,$40.25
+US88,California-South,ES,El Salvador,NonPeak,$31.63,$32.60
+US88,California-South,ES,El Salvador,Peak,$37.32,$37.32
+US88,California-South,GE,Germany,NonPeak,$44.51,$34.55
+US88,California-South,GE,Germany,Peak,$52.52,$52.52
+US88,California-South,GQ,Guam,NonPeak,$34.33,$36.46
+US88,California-South,GQ,Guam,Peak,$40.51,$40.51
+US88,California-South,GR,Greece,NonPeak,$31.74,$18.03
+US88,California-South,GR,Greece,Peak,$37.45,$37.45
+US88,California-South,GR29,Crete,NonPeak,$44.62,$18.94
+US88,California-South,GR29,Crete,Peak,$52.65,$52.65
+US88,California-South,GT,Guatemala,NonPeak,$34.45,$19.82
+US88,California-South,GT,Guatemala,Peak,$40.65,$40.65
+US88,California-South,HO,Honduras,NonPeak,$31.91,$20.73
+US88,California-South,HO,Honduras,Peak,$37.65,$37.65
+US88,California-South,HU,Hungary,NonPeak,$44.74,$21.63
+US88,California-South,HU,Hungary,Peak,$52.79,$52.79
+US88,California-South,IT,Italy,NonPeak,$34.56,$28.77
+US88,California-South,IT,Italy,Peak,$40.78,$40.78
+US88,California-South,IT10,Sicily,NonPeak,$32.09,$18.88
+US88,California-South,IT10,Sicily,Peak,$37.87,$37.87
+US88,California-South,JA01,Japan-Central,NonPeak,$44.91,$32.60
+US88,California-South,JA01,Japan-Central,Peak,$52.99,$52.99
+US88,California-South,JA02,Japan-South (Excludes Hokkaido),NonPeak,$34.74,$34.55
+US88,California-South,JA02,Japan-South (Excludes Hokkaido),Peak,$40.99,$40.99
+US88,California-South,JA03,Japan-North,NonPeak,$32.26,$36.46
+US88,California-South,JA03,Japan-North,Peak,$38.07,$38.07
+US88,California-South,JA96,Okinawa,NonPeak,$45.09,$18.03
+US88,California-South,JA96,Okinawa,Peak,$53.21,$53.21
+US88,California-South,KS,"Korea, Republic Of",NonPeak,$34.90,$18.94
+US88,California-South,KS,"Korea, Republic Of",Peak,$41.18,$41.18
+US88,California-South,KU,Kuwait,NonPeak,$32.44,$19.82
+US88,California-South,KU,Kuwait,Peak,$38.28,$38.28
+US88,California-South,NL,Netherlands,NonPeak,$43.94,$20.73
+US88,California-South,NL,Netherlands,Peak,$51.85,$51.85
+US88,California-South,NO,Norway,NonPeak,$33.70,$21.63
+US88,California-South,NO,Norway,Peak,$39.77,$39.77
+US88,California-South,PA,Paraguay,NonPeak,$31.29,$28.77
+US88,California-South,PA,Paraguay,Peak,$36.92,$36.92
+US88,California-South,PE,Peru,NonPeak,$44.05,$18.88
+US88,California-South,PE,Peru,Peak,$51.98,$51.98
+US88,California-South,PL,Poland,NonPeak,$33.75,$32.60
+US88,California-South,PL,Poland,Peak,$39.82,$39.82
+US88,California-South,PO,Portugal,NonPeak,$31.40,$34.55
+US88,California-South,PO,Portugal,Peak,$37.05,$37.05
+US88,California-South,PO01,Azores,NonPeak,$44.17,$36.46
+US88,California-South,PO01,Azores,Peak,$52.12,$52.12
+US88,California-South,QA,Qatar,NonPeak,$33.98,$18.03
+US88,California-South,QA,Qatar,Peak,$40.10,$40.10
+US88,California-South,RO,Romania,NonPeak,$31.45,$18.94
+US88,California-South,RO,Romania,Peak,$37.11,$37.11
+US88,California-South,RQ,Puerto Rico,NonPeak,$44.28,$19.82
+US88,California-South,RQ,Puerto Rico,Peak,$52.25,$52.25
+US88,California-South,SA,Saudi Arabia,NonPeak,$34.11,$20.73
+US88,California-South,SA,Saudi Arabia,Peak,$40.25,$40.25
+US88,California-South,SN,Singapore,NonPeak,$31.63,$21.63
+US88,California-South,SN,Singapore,Peak,$37.32,$37.32
+US88,California-South,SP,Spain,NonPeak,$44.51,$28.77
+US88,California-South,SP,Spain,Peak,$52.52,$52.52
+US88,California-South,TU,Turkey,NonPeak,$34.33,$18.88
+US88,California-South,TU,Turkey,Peak,$40.51,$40.51
+US88,California-South,UK,United Kingdom,NonPeak,$31.74,$32.60
+US88,California-South,UK,United Kingdom,Peak,$37.45,$37.45
+US88,California-South,US8030400,Alaska (Zone) IV,NonPeak,$44.62,$34.55
+US88,California-South,US8030400,Alaska (Zone) IV,Peak,$52.65,$52.65
+US88,California-South,US8050500,Alaska (Zone) III,NonPeak,$34.45,$36.46
+US88,California-South,US8050500,Alaska (Zone) III,Peak,$40.65,$40.65
+US88,California-South,US8101000,Alaska (Zone) I,NonPeak,$31.91,$18.03
+US88,California-South,US8101000,Alaska (Zone) I,Peak,$37.65,$37.65
+US88,California-South,US8190100,Alaska (Zone) II,NonPeak,$44.74,$18.94
+US88,California-South,US8190100,Alaska (Zone) II,Peak,$52.79,$52.79
+US88,California-South,US89,Hawaii,NonPeak,$34.56,$19.82
+US88,California-South,US89,Hawaii,Peak,$40.78,$40.78
+US88,California-South,UY,Uruguay,NonPeak,$32.09,$20.73
+US88,California-South,UY,Uruguay,Peak,$37.87,$37.87
+US88,California-South,VE,Venezuela,NonPeak,$44.91,$21.63
+US88,California-South,VE,Venezuela,Peak,$52.99,$52.99

--- a/pkg/parser/pricing/fixtures/12_3c_oconus_to_conus_prices_golden.csv
+++ b/pkg/parser/pricing/fixtures/12_3c_oconus_to_conus_prices_golden.csv
@@ -1,0 +1,5513 @@
+origin_intl_price_area_id,origin_intl_price_area,destination_domestic_price_area_area,destination_domestic_price_area,season,hhg_shipping_linehaul_price,ub_price
+AR,Argentina,US11,Maine,NonPeak,$15.28,$43.94
+AR,Argentina,US11,Maine,Peak,$18.03,$51.85
+AR,Argentina,US12,New Hampshire,NonPeak,$16.05,$33.70
+AR,Argentina,US12,New Hampshire,Peak,$18.94,$39.77
+AR,Argentina,US13,Vermont,NonPeak,$16.80,$31.29
+AR,Argentina,US13,Vermont,Peak,$19.82,$36.92
+AR,Argentina,US14,Massachusetts,NonPeak,$17.57,$44.05
+AR,Argentina,US14,Massachusetts,Peak,$20.73,$51.98
+AR,Argentina,US15,Rhode Island,NonPeak,$18.33,$33.75
+AR,Argentina,US15,Rhode Island,Peak,$21.63,$39.82
+AR,Argentina,US16,Connecticut,NonPeak,$24.38,$31.40
+AR,Argentina,US16,Connecticut,Peak,$28.77,$37.05
+AR,Argentina,US17,New York,NonPeak,$16.00,$44.17
+AR,Argentina,US17,New York,Peak,$18.88,$52.12
+AR,Argentina,US19,New Jersey,NonPeak,$27.63,$33.98
+AR,Argentina,US19,New Jersey,Peak,$32.60,$40.10
+AR,Argentina,US20,Pennsylvania,NonPeak,$29.28,$31.45
+AR,Argentina,US20,Pennsylvania,Peak,$34.55,$37.11
+AR,Argentina,US22,Delaware,NonPeak,$30.90,$44.28
+AR,Argentina,US22,Delaware,Peak,$36.46,$52.25
+AR,Argentina,US23,Maryland,NonPeak,$15.28,$34.11
+AR,Argentina,US23,Maryland,Peak,$18.03,$40.25
+AR,Argentina,US24,District Of Columbia,NonPeak,$16.05,$31.63
+AR,Argentina,US24,District Of Columbia,Peak,$18.94,$37.32
+AR,Argentina,US25,Virginia,NonPeak,$16.80,$44.51
+AR,Argentina,US25,Virginia,Peak,$19.82,$52.52
+AR,Argentina,US27,West Virginia,NonPeak,$17.57,$34.33
+AR,Argentina,US27,West Virginia,Peak,$20.73,$40.51
+AR,Argentina,US28,Kentucky,NonPeak,$18.33,$31.74
+AR,Argentina,US28,Kentucky,Peak,$21.63,$37.45
+AR,Argentina,US30,Michigan,NonPeak,$24.38,$44.62
+AR,Argentina,US30,Michigan,Peak,$28.77,$52.65
+AR,Argentina,US32,Wisconsin,NonPeak,$16.00,$34.45
+AR,Argentina,US32,Wisconsin,Peak,$18.88,$40.65
+AR,Argentina,US34,Ohio,NonPeak,$27.63,$31.91
+AR,Argentina,US34,Ohio,Peak,$32.60,$37.65
+AR,Argentina,US36,Indiana,NonPeak,$29.28,$44.74
+AR,Argentina,US36,Indiana,Peak,$34.55,$52.79
+AR,Argentina,US38,Illinois,NonPeak,$30.90,$34.56
+AR,Argentina,US38,Illinois,Peak,$36.46,$40.78
+AR,Argentina,US40,North Carolina,NonPeak,$15.28,$32.09
+AR,Argentina,US40,North Carolina,Peak,$18.03,$37.87
+AR,Argentina,US42,Tennessee,NonPeak,$16.05,$44.91
+AR,Argentina,US42,Tennessee,Peak,$18.94,$52.99
+AR,Argentina,US44,South Carolina,NonPeak,$16.80,$34.74
+AR,Argentina,US44,South Carolina,Peak,$19.82,$40.99
+AR,Argentina,US45,Georgia,NonPeak,$17.57,$32.26
+AR,Argentina,US45,Georgia,Peak,$20.73,$38.07
+AR,Argentina,US47,Alabama,NonPeak,$18.33,$45.09
+AR,Argentina,US47,Alabama,Peak,$21.63,$53.21
+AR,Argentina,US48,Mississippi,NonPeak,$24.38,$34.90
+AR,Argentina,US48,Mississippi,Peak,$28.77,$41.18
+AR,Argentina,US49,Florida-North,NonPeak,$16.00,$32.44
+AR,Argentina,US49,Florida-North,Peak,$18.88,$38.28
+AR,Argentina,US4964400,Florida-South,NonPeak,$27.63,$43.94
+AR,Argentina,US4964400,Florida-South,Peak,$32.60,$51.85
+AR,Argentina,US4965500,Florida Keys,NonPeak,$29.28,$33.70
+AR,Argentina,US4965500,Florida Keys,Peak,$34.55,$39.77
+AR,Argentina,US50,Minnesota,NonPeak,$30.90,$31.29
+AR,Argentina,US50,Minnesota,Peak,$36.46,$36.92
+AR,Argentina,US51,North Dakota,NonPeak,$15.28,$44.05
+AR,Argentina,US51,North Dakota,Peak,$18.03,$51.98
+AR,Argentina,US52,South Dakota,NonPeak,$16.05,$33.75
+AR,Argentina,US52,South Dakota,Peak,$18.94,$39.82
+AR,Argentina,US53,Iowa,NonPeak,$16.80,$31.40
+AR,Argentina,US53,Iowa,Peak,$19.82,$37.05
+AR,Argentina,US55,Nebraska,NonPeak,$17.57,$44.17
+AR,Argentina,US55,Nebraska,Peak,$20.73,$52.12
+AR,Argentina,US56,Missouri,NonPeak,$18.33,$33.98
+AR,Argentina,US56,Missouri,Peak,$21.63,$40.10
+AR,Argentina,US58,Kansas,NonPeak,$24.38,$31.45
+AR,Argentina,US58,Kansas,Peak,$28.77,$37.11
+AR,Argentina,US60,Arkansas,NonPeak,$16.00,$44.28
+AR,Argentina,US60,Arkansas,Peak,$18.88,$52.25
+AR,Argentina,US62,Oklahoma,NonPeak,$27.63,$34.11
+AR,Argentina,US62,Oklahoma,Peak,$32.60,$40.25
+AR,Argentina,US64,Louisiana,NonPeak,$29.28,$31.63
+AR,Argentina,US64,Louisiana,Peak,$34.55,$37.32
+AR,Argentina,US66,Texas-North,NonPeak,$30.90,$44.51
+AR,Argentina,US66,Texas-North,Peak,$36.46,$52.52
+AR,Argentina,US68,Texas-South,NonPeak,$15.28,$34.33
+AR,Argentina,US68,Texas-South,Peak,$18.03,$40.51
+AR,Argentina,US70,Montana,NonPeak,$16.05,$31.74
+AR,Argentina,US70,Montana,Peak,$18.94,$37.45
+AR,Argentina,US72,Wyoming,NonPeak,$16.80,$44.62
+AR,Argentina,US72,Wyoming,Peak,$19.82,$52.65
+AR,Argentina,US74,Colorado,NonPeak,$17.57,$34.45
+AR,Argentina,US74,Colorado,Peak,$20.73,$40.65
+AR,Argentina,US76,Utah,NonPeak,$18.33,$31.91
+AR,Argentina,US76,Utah,Peak,$21.63,$37.65
+AR,Argentina,US77,New Mexico,NonPeak,$24.38,$44.74
+AR,Argentina,US77,New Mexico,Peak,$28.77,$52.79
+AR,Argentina,US79,Arizona,NonPeak,$16.00,$34.56
+AR,Argentina,US79,Arizona,Peak,$18.88,$40.78
+AR,Argentina,US83,Idaho,NonPeak,$27.63,$32.09
+AR,Argentina,US83,Idaho,Peak,$32.60,$37.87
+AR,Argentina,US84,Washington,NonPeak,$29.28,$44.91
+AR,Argentina,US84,Washington,Peak,$34.55,$52.99
+AR,Argentina,US85,Oregon,NonPeak,$30.90,$34.74
+AR,Argentina,US85,Oregon,Peak,$36.46,$40.99
+AR,Argentina,US86,Nevada,NonPeak,$15.28,$32.26
+AR,Argentina,US86,Nevada,Peak,$18.03,$38.07
+AR,Argentina,US87,California-North,NonPeak,$16.05,$45.09
+AR,Argentina,US87,California-North,Peak,$18.94,$53.21
+AR,Argentina,US88,California-South,NonPeak,$16.80,$34.90
+AR,Argentina,US88,California-South,Peak,$19.82,$41.18
+AS11,New South Wales/Australian Capital Territory,US11,Maine,NonPeak,$17.57,$32.44
+AS11,New South Wales/Australian Capital Territory,US11,Maine,Peak,$20.73,$38.28
+AS11,New South Wales/Australian Capital Territory,US12,New Hampshire,NonPeak,$18.33,$43.94
+AS11,New South Wales/Australian Capital Territory,US12,New Hampshire,Peak,$21.63,$51.85
+AS11,New South Wales/Australian Capital Territory,US13,Vermont,NonPeak,$24.38,$33.70
+AS11,New South Wales/Australian Capital Territory,US13,Vermont,Peak,$28.77,$39.77
+AS11,New South Wales/Australian Capital Territory,US14,Massachusetts,NonPeak,$16.00,$31.29
+AS11,New South Wales/Australian Capital Territory,US14,Massachusetts,Peak,$18.88,$36.92
+AS11,New South Wales/Australian Capital Territory,US15,Rhode Island,NonPeak,$27.63,$44.05
+AS11,New South Wales/Australian Capital Territory,US15,Rhode Island,Peak,$32.60,$51.98
+AS11,New South Wales/Australian Capital Territory,US16,Connecticut,NonPeak,$29.28,$33.75
+AS11,New South Wales/Australian Capital Territory,US16,Connecticut,Peak,$34.55,$39.82
+AS11,New South Wales/Australian Capital Territory,US17,New York,NonPeak,$30.90,$31.40
+AS11,New South Wales/Australian Capital Territory,US17,New York,Peak,$36.46,$37.05
+AS11,New South Wales/Australian Capital Territory,US19,New Jersey,NonPeak,$15.28,$44.17
+AS11,New South Wales/Australian Capital Territory,US19,New Jersey,Peak,$18.03,$52.12
+AS11,New South Wales/Australian Capital Territory,US20,Pennsylvania,NonPeak,$16.05,$33.98
+AS11,New South Wales/Australian Capital Territory,US20,Pennsylvania,Peak,$18.94,$40.10
+AS11,New South Wales/Australian Capital Territory,US22,Delaware,NonPeak,$16.80,$31.45
+AS11,New South Wales/Australian Capital Territory,US22,Delaware,Peak,$19.82,$37.11
+AS11,New South Wales/Australian Capital Territory,US23,Maryland,NonPeak,$17.57,$44.28
+AS11,New South Wales/Australian Capital Territory,US23,Maryland,Peak,$20.73,$52.25
+AS11,New South Wales/Australian Capital Territory,US24,District Of Columbia,NonPeak,$18.33,$34.11
+AS11,New South Wales/Australian Capital Territory,US24,District Of Columbia,Peak,$21.63,$40.25
+AS11,New South Wales/Australian Capital Territory,US25,Virginia,NonPeak,$24.38,$31.63
+AS11,New South Wales/Australian Capital Territory,US25,Virginia,Peak,$28.77,$37.32
+AS11,New South Wales/Australian Capital Territory,US27,West Virginia,NonPeak,$16.00,$44.51
+AS11,New South Wales/Australian Capital Territory,US27,West Virginia,Peak,$18.88,$52.52
+AS11,New South Wales/Australian Capital Territory,US28,Kentucky,NonPeak,$27.63,$34.33
+AS11,New South Wales/Australian Capital Territory,US28,Kentucky,Peak,$32.60,$40.51
+AS11,New South Wales/Australian Capital Territory,US30,Michigan,NonPeak,$29.28,$31.74
+AS11,New South Wales/Australian Capital Territory,US30,Michigan,Peak,$34.55,$37.45
+AS11,New South Wales/Australian Capital Territory,US32,Wisconsin,NonPeak,$30.90,$44.62
+AS11,New South Wales/Australian Capital Territory,US32,Wisconsin,Peak,$36.46,$52.65
+AS11,New South Wales/Australian Capital Territory,US34,Ohio,NonPeak,$15.28,$34.45
+AS11,New South Wales/Australian Capital Territory,US34,Ohio,Peak,$18.03,$40.65
+AS11,New South Wales/Australian Capital Territory,US36,Indiana,NonPeak,$16.05,$31.91
+AS11,New South Wales/Australian Capital Territory,US36,Indiana,Peak,$18.94,$37.65
+AS11,New South Wales/Australian Capital Territory,US38,Illinois,NonPeak,$16.80,$44.74
+AS11,New South Wales/Australian Capital Territory,US38,Illinois,Peak,$19.82,$52.79
+AS11,New South Wales/Australian Capital Territory,US40,North Carolina,NonPeak,$17.57,$34.56
+AS11,New South Wales/Australian Capital Territory,US40,North Carolina,Peak,$20.73,$40.78
+AS11,New South Wales/Australian Capital Territory,US42,Tennessee,NonPeak,$18.33,$32.09
+AS11,New South Wales/Australian Capital Territory,US42,Tennessee,Peak,$21.63,$37.87
+AS11,New South Wales/Australian Capital Territory,US44,South Carolina,NonPeak,$24.38,$44.91
+AS11,New South Wales/Australian Capital Territory,US44,South Carolina,Peak,$28.77,$52.99
+AS11,New South Wales/Australian Capital Territory,US45,Georgia,NonPeak,$16.00,$34.74
+AS11,New South Wales/Australian Capital Territory,US45,Georgia,Peak,$18.88,$40.99
+AS11,New South Wales/Australian Capital Territory,US47,Alabama,NonPeak,$27.63,$32.26
+AS11,New South Wales/Australian Capital Territory,US47,Alabama,Peak,$32.60,$38.07
+AS11,New South Wales/Australian Capital Territory,US48,Mississippi,NonPeak,$29.28,$45.09
+AS11,New South Wales/Australian Capital Territory,US48,Mississippi,Peak,$34.55,$53.21
+AS11,New South Wales/Australian Capital Territory,US49,Florida-North,NonPeak,$30.90,$34.90
+AS11,New South Wales/Australian Capital Territory,US49,Florida-North,Peak,$36.46,$41.18
+AS11,New South Wales/Australian Capital Territory,US4964400,Florida-South,NonPeak,$15.28,$32.44
+AS11,New South Wales/Australian Capital Territory,US4964400,Florida-South,Peak,$18.03,$38.28
+AS11,New South Wales/Australian Capital Territory,US4965500,Florida Keys,NonPeak,$16.05,$43.94
+AS11,New South Wales/Australian Capital Territory,US4965500,Florida Keys,Peak,$18.94,$51.85
+AS11,New South Wales/Australian Capital Territory,US50,Minnesota,NonPeak,$16.80,$33.70
+AS11,New South Wales/Australian Capital Territory,US50,Minnesota,Peak,$19.82,$39.77
+AS11,New South Wales/Australian Capital Territory,US51,North Dakota,NonPeak,$17.57,$31.29
+AS11,New South Wales/Australian Capital Territory,US51,North Dakota,Peak,$20.73,$36.92
+AS11,New South Wales/Australian Capital Territory,US52,South Dakota,NonPeak,$18.33,$44.05
+AS11,New South Wales/Australian Capital Territory,US52,South Dakota,Peak,$21.63,$51.98
+AS11,New South Wales/Australian Capital Territory,US53,Iowa,NonPeak,$24.38,$33.75
+AS11,New South Wales/Australian Capital Territory,US53,Iowa,Peak,$28.77,$39.82
+AS11,New South Wales/Australian Capital Territory,US55,Nebraska,NonPeak,$16.00,$31.40
+AS11,New South Wales/Australian Capital Territory,US55,Nebraska,Peak,$18.88,$37.05
+AS11,New South Wales/Australian Capital Territory,US56,Missouri,NonPeak,$27.63,$44.17
+AS11,New South Wales/Australian Capital Territory,US56,Missouri,Peak,$32.60,$52.12
+AS11,New South Wales/Australian Capital Territory,US58,Kansas,NonPeak,$29.28,$33.98
+AS11,New South Wales/Australian Capital Territory,US58,Kansas,Peak,$34.55,$40.10
+AS11,New South Wales/Australian Capital Territory,US60,Arkansas,NonPeak,$30.90,$31.45
+AS11,New South Wales/Australian Capital Territory,US60,Arkansas,Peak,$36.46,$37.11
+AS11,New South Wales/Australian Capital Territory,US62,Oklahoma,NonPeak,$15.28,$44.28
+AS11,New South Wales/Australian Capital Territory,US62,Oklahoma,Peak,$18.03,$52.25
+AS11,New South Wales/Australian Capital Territory,US64,Louisiana,NonPeak,$16.05,$34.11
+AS11,New South Wales/Australian Capital Territory,US64,Louisiana,Peak,$18.94,$40.25
+AS11,New South Wales/Australian Capital Territory,US66,Texas-North,NonPeak,$16.80,$31.63
+AS11,New South Wales/Australian Capital Territory,US66,Texas-North,Peak,$19.82,$37.32
+AS11,New South Wales/Australian Capital Territory,US68,Texas-South,NonPeak,$17.57,$44.51
+AS11,New South Wales/Australian Capital Territory,US68,Texas-South,Peak,$20.73,$52.52
+AS11,New South Wales/Australian Capital Territory,US70,Montana,NonPeak,$18.33,$34.33
+AS11,New South Wales/Australian Capital Territory,US70,Montana,Peak,$21.63,$40.51
+AS11,New South Wales/Australian Capital Territory,US72,Wyoming,NonPeak,$24.38,$31.74
+AS11,New South Wales/Australian Capital Territory,US72,Wyoming,Peak,$28.77,$37.45
+AS11,New South Wales/Australian Capital Territory,US74,Colorado,NonPeak,$16.00,$44.62
+AS11,New South Wales/Australian Capital Territory,US74,Colorado,Peak,$18.88,$52.65
+AS11,New South Wales/Australian Capital Territory,US76,Utah,NonPeak,$27.63,$34.45
+AS11,New South Wales/Australian Capital Territory,US76,Utah,Peak,$32.60,$40.65
+AS11,New South Wales/Australian Capital Territory,US77,New Mexico,NonPeak,$29.28,$31.91
+AS11,New South Wales/Australian Capital Territory,US77,New Mexico,Peak,$34.55,$37.65
+AS11,New South Wales/Australian Capital Territory,US79,Arizona,NonPeak,$30.90,$44.74
+AS11,New South Wales/Australian Capital Territory,US79,Arizona,Peak,$36.46,$52.79
+AS11,New South Wales/Australian Capital Territory,US83,Idaho,NonPeak,$15.28,$34.56
+AS11,New South Wales/Australian Capital Territory,US83,Idaho,Peak,$18.03,$40.78
+AS11,New South Wales/Australian Capital Territory,US84,Washington,NonPeak,$16.05,$32.09
+AS11,New South Wales/Australian Capital Territory,US84,Washington,Peak,$18.94,$37.87
+AS11,New South Wales/Australian Capital Territory,US85,Oregon,NonPeak,$16.80,$44.91
+AS11,New South Wales/Australian Capital Territory,US85,Oregon,Peak,$19.82,$52.99
+AS11,New South Wales/Australian Capital Territory,US86,Nevada,NonPeak,$17.57,$34.74
+AS11,New South Wales/Australian Capital Territory,US86,Nevada,Peak,$20.73,$40.99
+AS11,New South Wales/Australian Capital Territory,US87,California-North,NonPeak,$18.33,$32.26
+AS11,New South Wales/Australian Capital Territory,US87,California-North,Peak,$21.63,$38.07
+AS11,New South Wales/Australian Capital Territory,US88,California-South,NonPeak,$24.38,$45.09
+AS11,New South Wales/Australian Capital Territory,US88,California-South,Peak,$28.77,$53.21
+AS21,Northern Territory,US11,Maine,NonPeak,$16.00,$34.90
+AS21,Northern Territory,US11,Maine,Peak,$18.88,$41.18
+AS21,Northern Territory,US12,New Hampshire,NonPeak,$27.63,$32.44
+AS21,Northern Territory,US12,New Hampshire,Peak,$32.60,$38.28
+AS21,Northern Territory,US13,Vermont,NonPeak,$29.28,$43.94
+AS21,Northern Territory,US13,Vermont,Peak,$34.55,$51.85
+AS21,Northern Territory,US14,Massachusetts,NonPeak,$30.90,$33.70
+AS21,Northern Territory,US14,Massachusetts,Peak,$36.46,$39.77
+AS21,Northern Territory,US15,Rhode Island,NonPeak,$15.28,$31.29
+AS21,Northern Territory,US15,Rhode Island,Peak,$18.03,$36.92
+AS21,Northern Territory,US16,Connecticut,NonPeak,$16.05,$44.05
+AS21,Northern Territory,US16,Connecticut,Peak,$18.94,$51.98
+AS21,Northern Territory,US17,New York,NonPeak,$16.80,$33.75
+AS21,Northern Territory,US17,New York,Peak,$19.82,$39.82
+AS21,Northern Territory,US19,New Jersey,NonPeak,$17.57,$31.40
+AS21,Northern Territory,US19,New Jersey,Peak,$20.73,$37.05
+AS21,Northern Territory,US20,Pennsylvania,NonPeak,$18.33,$44.17
+AS21,Northern Territory,US20,Pennsylvania,Peak,$21.63,$52.12
+AS21,Northern Territory,US22,Delaware,NonPeak,$24.38,$33.98
+AS21,Northern Territory,US22,Delaware,Peak,$28.77,$40.10
+AS21,Northern Territory,US23,Maryland,NonPeak,$16.00,$31.45
+AS21,Northern Territory,US23,Maryland,Peak,$18.88,$37.11
+AS21,Northern Territory,US24,District Of Columbia,NonPeak,$27.63,$44.28
+AS21,Northern Territory,US24,District Of Columbia,Peak,$32.60,$52.25
+AS21,Northern Territory,US25,Virginia,NonPeak,$29.28,$34.11
+AS21,Northern Territory,US25,Virginia,Peak,$34.55,$40.25
+AS21,Northern Territory,US27,West Virginia,NonPeak,$30.90,$31.63
+AS21,Northern Territory,US27,West Virginia,Peak,$36.46,$37.32
+AS21,Northern Territory,US28,Kentucky,NonPeak,$15.28,$44.51
+AS21,Northern Territory,US28,Kentucky,Peak,$18.03,$52.52
+AS21,Northern Territory,US30,Michigan,NonPeak,$16.05,$34.33
+AS21,Northern Territory,US30,Michigan,Peak,$18.94,$40.51
+AS21,Northern Territory,US32,Wisconsin,NonPeak,$16.80,$31.74
+AS21,Northern Territory,US32,Wisconsin,Peak,$19.82,$37.45
+AS21,Northern Territory,US34,Ohio,NonPeak,$17.57,$44.62
+AS21,Northern Territory,US34,Ohio,Peak,$20.73,$52.65
+AS21,Northern Territory,US36,Indiana,NonPeak,$18.33,$34.45
+AS21,Northern Territory,US36,Indiana,Peak,$21.63,$40.65
+AS21,Northern Territory,US38,Illinois,NonPeak,$24.38,$31.91
+AS21,Northern Territory,US38,Illinois,Peak,$28.77,$37.65
+AS21,Northern Territory,US40,North Carolina,NonPeak,$16.00,$44.74
+AS21,Northern Territory,US40,North Carolina,Peak,$18.88,$52.79
+AS21,Northern Territory,US42,Tennessee,NonPeak,$27.63,$34.56
+AS21,Northern Territory,US42,Tennessee,Peak,$32.60,$40.78
+AS21,Northern Territory,US44,South Carolina,NonPeak,$29.28,$32.09
+AS21,Northern Territory,US44,South Carolina,Peak,$34.55,$37.87
+AS21,Northern Territory,US45,Georgia,NonPeak,$30.90,$44.91
+AS21,Northern Territory,US45,Georgia,Peak,$36.46,$52.99
+AS21,Northern Territory,US47,Alabama,NonPeak,$15.28,$34.74
+AS21,Northern Territory,US47,Alabama,Peak,$18.03,$40.99
+AS21,Northern Territory,US48,Mississippi,NonPeak,$16.05,$32.26
+AS21,Northern Territory,US48,Mississippi,Peak,$18.94,$38.07
+AS21,Northern Territory,US49,Florida-North,NonPeak,$16.80,$45.09
+AS21,Northern Territory,US49,Florida-North,Peak,$19.82,$53.21
+AS21,Northern Territory,US4964400,Florida-South,NonPeak,$17.57,$34.90
+AS21,Northern Territory,US4964400,Florida-South,Peak,$20.73,$41.18
+AS21,Northern Territory,US4965500,Florida Keys,NonPeak,$18.33,$32.44
+AS21,Northern Territory,US4965500,Florida Keys,Peak,$21.63,$38.28
+AS21,Northern Territory,US50,Minnesota,NonPeak,$24.38,$43.94
+AS21,Northern Territory,US50,Minnesota,Peak,$28.77,$51.85
+AS21,Northern Territory,US51,North Dakota,NonPeak,$16.00,$33.70
+AS21,Northern Territory,US51,North Dakota,Peak,$18.88,$39.77
+AS21,Northern Territory,US52,South Dakota,NonPeak,$27.63,$31.29
+AS21,Northern Territory,US52,South Dakota,Peak,$32.60,$36.92
+AS21,Northern Territory,US53,Iowa,NonPeak,$29.28,$44.05
+AS21,Northern Territory,US53,Iowa,Peak,$34.55,$51.98
+AS21,Northern Territory,US55,Nebraska,NonPeak,$30.90,$33.75
+AS21,Northern Territory,US55,Nebraska,Peak,$36.46,$39.82
+AS21,Northern Territory,US56,Missouri,NonPeak,$15.28,$31.40
+AS21,Northern Territory,US56,Missouri,Peak,$18.03,$37.05
+AS21,Northern Territory,US58,Kansas,NonPeak,$16.05,$44.17
+AS21,Northern Territory,US58,Kansas,Peak,$18.94,$52.12
+AS21,Northern Territory,US60,Arkansas,NonPeak,$16.80,$33.98
+AS21,Northern Territory,US60,Arkansas,Peak,$19.82,$40.10
+AS21,Northern Territory,US62,Oklahoma,NonPeak,$17.57,$31.45
+AS21,Northern Territory,US62,Oklahoma,Peak,$20.73,$37.11
+AS21,Northern Territory,US64,Louisiana,NonPeak,$18.33,$44.28
+AS21,Northern Territory,US64,Louisiana,Peak,$21.63,$52.25
+AS21,Northern Territory,US66,Texas-North,NonPeak,$24.38,$34.11
+AS21,Northern Territory,US66,Texas-North,Peak,$28.77,$40.25
+AS21,Northern Territory,US68,Texas-South,NonPeak,$16.00,$31.63
+AS21,Northern Territory,US68,Texas-South,Peak,$18.88,$37.32
+AS21,Northern Territory,US70,Montana,NonPeak,$27.63,$44.51
+AS21,Northern Territory,US70,Montana,Peak,$32.60,$52.52
+AS21,Northern Territory,US72,Wyoming,NonPeak,$29.28,$34.33
+AS21,Northern Territory,US72,Wyoming,Peak,$34.55,$40.51
+AS21,Northern Territory,US74,Colorado,NonPeak,$30.90,$31.74
+AS21,Northern Territory,US74,Colorado,Peak,$36.46,$37.45
+AS21,Northern Territory,US76,Utah,NonPeak,$15.28,$44.62
+AS21,Northern Territory,US76,Utah,Peak,$18.03,$52.65
+AS21,Northern Territory,US77,New Mexico,NonPeak,$16.05,$34.45
+AS21,Northern Territory,US77,New Mexico,Peak,$18.94,$40.65
+AS21,Northern Territory,US79,Arizona,NonPeak,$16.80,$31.91
+AS21,Northern Territory,US79,Arizona,Peak,$19.82,$37.65
+AS21,Northern Territory,US83,Idaho,NonPeak,$17.57,$44.74
+AS21,Northern Territory,US83,Idaho,Peak,$20.73,$52.79
+AS21,Northern Territory,US84,Washington,NonPeak,$18.33,$34.56
+AS21,Northern Territory,US84,Washington,Peak,$21.63,$40.78
+AS21,Northern Territory,US85,Oregon,NonPeak,$24.38,$32.09
+AS21,Northern Territory,US85,Oregon,Peak,$28.77,$37.87
+AS21,Northern Territory,US86,Nevada,NonPeak,$16.00,$44.91
+AS21,Northern Territory,US86,Nevada,Peak,$18.88,$52.99
+AS21,Northern Territory,US87,California-North,NonPeak,$27.63,$34.74
+AS21,Northern Territory,US87,California-North,Peak,$32.60,$40.99
+AS21,Northern Territory,US88,California-South,NonPeak,$29.28,$32.26
+AS21,Northern Territory,US88,California-South,Peak,$34.55,$38.07
+BA,Bahrain,US11,Maine,NonPeak,$30.90,$45.09
+BA,Bahrain,US11,Maine,Peak,$36.46,$53.21
+BA,Bahrain,US12,New Hampshire,NonPeak,$15.28,$34.90
+BA,Bahrain,US12,New Hampshire,Peak,$18.03,$41.18
+BA,Bahrain,US13,Vermont,NonPeak,$16.05,$32.44
+BA,Bahrain,US13,Vermont,Peak,$18.94,$38.28
+BA,Bahrain,US14,Massachusetts,NonPeak,$16.80,$43.94
+BA,Bahrain,US14,Massachusetts,Peak,$19.82,$51.85
+BA,Bahrain,US15,Rhode Island,NonPeak,$17.57,$33.70
+BA,Bahrain,US15,Rhode Island,Peak,$20.73,$39.77
+BA,Bahrain,US16,Connecticut,NonPeak,$18.33,$31.29
+BA,Bahrain,US16,Connecticut,Peak,$21.63,$36.92
+BA,Bahrain,US17,New York,NonPeak,$24.38,$44.05
+BA,Bahrain,US17,New York,Peak,$28.77,$51.98
+BA,Bahrain,US19,New Jersey,NonPeak,$16.00,$33.75
+BA,Bahrain,US19,New Jersey,Peak,$18.88,$39.82
+BA,Bahrain,US20,Pennsylvania,NonPeak,$27.63,$31.40
+BA,Bahrain,US20,Pennsylvania,Peak,$32.60,$37.05
+BA,Bahrain,US22,Delaware,NonPeak,$29.28,$44.17
+BA,Bahrain,US22,Delaware,Peak,$34.55,$52.12
+BA,Bahrain,US23,Maryland,NonPeak,$30.90,$33.98
+BA,Bahrain,US23,Maryland,Peak,$36.46,$40.10
+BA,Bahrain,US24,District Of Columbia,NonPeak,$15.28,$31.45
+BA,Bahrain,US24,District Of Columbia,Peak,$18.03,$37.11
+BA,Bahrain,US25,Virginia,NonPeak,$16.05,$44.28
+BA,Bahrain,US25,Virginia,Peak,$18.94,$52.25
+BA,Bahrain,US27,West Virginia,NonPeak,$16.80,$34.11
+BA,Bahrain,US27,West Virginia,Peak,$19.82,$40.25
+BA,Bahrain,US28,Kentucky,NonPeak,$17.57,$31.63
+BA,Bahrain,US28,Kentucky,Peak,$20.73,$37.32
+BA,Bahrain,US30,Michigan,NonPeak,$18.33,$44.51
+BA,Bahrain,US30,Michigan,Peak,$21.63,$52.52
+BA,Bahrain,US32,Wisconsin,NonPeak,$24.38,$34.33
+BA,Bahrain,US32,Wisconsin,Peak,$28.77,$40.51
+BA,Bahrain,US34,Ohio,NonPeak,$16.00,$31.74
+BA,Bahrain,US34,Ohio,Peak,$18.88,$37.45
+BA,Bahrain,US36,Indiana,NonPeak,$27.63,$44.62
+BA,Bahrain,US36,Indiana,Peak,$32.60,$52.65
+BA,Bahrain,US38,Illinois,NonPeak,$29.28,$34.45
+BA,Bahrain,US38,Illinois,Peak,$34.55,$40.65
+BA,Bahrain,US40,North Carolina,NonPeak,$30.90,$31.91
+BA,Bahrain,US40,North Carolina,Peak,$36.46,$37.65
+BA,Bahrain,US42,Tennessee,NonPeak,$15.28,$44.74
+BA,Bahrain,US42,Tennessee,Peak,$18.03,$52.79
+BA,Bahrain,US44,South Carolina,NonPeak,$16.05,$34.56
+BA,Bahrain,US44,South Carolina,Peak,$18.94,$40.78
+BA,Bahrain,US45,Georgia,NonPeak,$16.80,$32.09
+BA,Bahrain,US45,Georgia,Peak,$19.82,$37.87
+BA,Bahrain,US47,Alabama,NonPeak,$17.57,$44.91
+BA,Bahrain,US47,Alabama,Peak,$20.73,$52.99
+BA,Bahrain,US48,Mississippi,NonPeak,$18.33,$34.74
+BA,Bahrain,US48,Mississippi,Peak,$21.63,$40.99
+BA,Bahrain,US49,Florida-North,NonPeak,$24.38,$32.26
+BA,Bahrain,US49,Florida-North,Peak,$28.77,$38.07
+BA,Bahrain,US4964400,Florida-South,NonPeak,$16.00,$45.09
+BA,Bahrain,US4964400,Florida-South,Peak,$18.88,$53.21
+BA,Bahrain,US4965500,Florida Keys,NonPeak,$27.63,$34.90
+BA,Bahrain,US4965500,Florida Keys,Peak,$32.60,$41.18
+BA,Bahrain,US50,Minnesota,NonPeak,$29.28,$32.44
+BA,Bahrain,US50,Minnesota,Peak,$34.55,$38.28
+BA,Bahrain,US51,North Dakota,NonPeak,$30.90,$43.94
+BA,Bahrain,US51,North Dakota,Peak,$36.46,$51.85
+BA,Bahrain,US52,South Dakota,NonPeak,$15.28,$33.70
+BA,Bahrain,US52,South Dakota,Peak,$18.03,$39.77
+BA,Bahrain,US53,Iowa,NonPeak,$16.05,$31.29
+BA,Bahrain,US53,Iowa,Peak,$18.94,$36.92
+BA,Bahrain,US55,Nebraska,NonPeak,$16.80,$44.05
+BA,Bahrain,US55,Nebraska,Peak,$19.82,$51.98
+BA,Bahrain,US56,Missouri,NonPeak,$17.57,$33.75
+BA,Bahrain,US56,Missouri,Peak,$20.73,$39.82
+BA,Bahrain,US58,Kansas,NonPeak,$18.33,$31.40
+BA,Bahrain,US58,Kansas,Peak,$21.63,$37.05
+BA,Bahrain,US60,Arkansas,NonPeak,$24.38,$44.17
+BA,Bahrain,US60,Arkansas,Peak,$28.77,$52.12
+BA,Bahrain,US62,Oklahoma,NonPeak,$16.00,$33.98
+BA,Bahrain,US62,Oklahoma,Peak,$18.88,$40.10
+BA,Bahrain,US64,Louisiana,NonPeak,$27.63,$31.45
+BA,Bahrain,US64,Louisiana,Peak,$32.60,$37.11
+BA,Bahrain,US66,Texas-North,NonPeak,$29.28,$44.28
+BA,Bahrain,US66,Texas-North,Peak,$34.55,$52.25
+BA,Bahrain,US68,Texas-South,NonPeak,$30.90,$34.11
+BA,Bahrain,US68,Texas-South,Peak,$36.46,$40.25
+BA,Bahrain,US70,Montana,NonPeak,$15.28,$31.63
+BA,Bahrain,US70,Montana,Peak,$18.03,$37.32
+BA,Bahrain,US72,Wyoming,NonPeak,$16.05,$44.51
+BA,Bahrain,US72,Wyoming,Peak,$18.94,$52.52
+BA,Bahrain,US74,Colorado,NonPeak,$16.80,$34.33
+BA,Bahrain,US74,Colorado,Peak,$19.82,$40.51
+BA,Bahrain,US76,Utah,NonPeak,$17.57,$31.74
+BA,Bahrain,US76,Utah,Peak,$20.73,$37.45
+BA,Bahrain,US77,New Mexico,NonPeak,$18.33,$44.62
+BA,Bahrain,US77,New Mexico,Peak,$21.63,$52.65
+BA,Bahrain,US79,Arizona,NonPeak,$24.38,$34.45
+BA,Bahrain,US79,Arizona,Peak,$28.77,$40.65
+BA,Bahrain,US83,Idaho,NonPeak,$16.00,$31.91
+BA,Bahrain,US83,Idaho,Peak,$18.88,$37.65
+BA,Bahrain,US84,Washington,NonPeak,$27.63,$44.74
+BA,Bahrain,US84,Washington,Peak,$32.60,$52.79
+BA,Bahrain,US85,Oregon,NonPeak,$29.28,$34.56
+BA,Bahrain,US85,Oregon,Peak,$34.55,$40.78
+BA,Bahrain,US86,Nevada,NonPeak,$30.90,$32.09
+BA,Bahrain,US86,Nevada,Peak,$36.46,$37.87
+BA,Bahrain,US87,California-North,NonPeak,$15.28,$44.91
+BA,Bahrain,US87,California-North,Peak,$18.03,$52.99
+BA,Bahrain,US88,California-South,NonPeak,$16.05,$34.74
+BA,Bahrain,US88,California-South,Peak,$18.94,$40.99
+BE,Belgium,US11,Maine,NonPeak,$16.80,$32.26
+BE,Belgium,US11,Maine,Peak,$19.82,$38.07
+BE,Belgium,US12,New Hampshire,NonPeak,$17.57,$45.09
+BE,Belgium,US12,New Hampshire,Peak,$20.73,$53.21
+BE,Belgium,US13,Vermont,NonPeak,$18.33,$34.90
+BE,Belgium,US13,Vermont,Peak,$21.63,$41.18
+BE,Belgium,US14,Massachusetts,NonPeak,$24.38,$32.44
+BE,Belgium,US14,Massachusetts,Peak,$28.77,$38.28
+BE,Belgium,US15,Rhode Island,NonPeak,$16.00,$43.94
+BE,Belgium,US15,Rhode Island,Peak,$18.88,$51.85
+BE,Belgium,US16,Connecticut,NonPeak,$27.63,$33.70
+BE,Belgium,US16,Connecticut,Peak,$32.60,$39.77
+BE,Belgium,US17,New York,NonPeak,$29.28,$31.29
+BE,Belgium,US17,New York,Peak,$34.55,$36.92
+BE,Belgium,US19,New Jersey,NonPeak,$30.90,$44.05
+BE,Belgium,US19,New Jersey,Peak,$36.46,$51.98
+BE,Belgium,US20,Pennsylvania,NonPeak,$15.28,$33.75
+BE,Belgium,US20,Pennsylvania,Peak,$18.03,$39.82
+BE,Belgium,US22,Delaware,NonPeak,$16.05,$31.40
+BE,Belgium,US22,Delaware,Peak,$18.94,$37.05
+BE,Belgium,US23,Maryland,NonPeak,$16.80,$44.17
+BE,Belgium,US23,Maryland,Peak,$19.82,$52.12
+BE,Belgium,US24,District Of Columbia,NonPeak,$17.57,$33.98
+BE,Belgium,US24,District Of Columbia,Peak,$20.73,$40.10
+BE,Belgium,US25,Virginia,NonPeak,$18.33,$31.45
+BE,Belgium,US25,Virginia,Peak,$21.63,$37.11
+BE,Belgium,US27,West Virginia,NonPeak,$24.38,$44.28
+BE,Belgium,US27,West Virginia,Peak,$28.77,$52.25
+BE,Belgium,US28,Kentucky,NonPeak,$16.00,$34.11
+BE,Belgium,US28,Kentucky,Peak,$18.88,$40.25
+BE,Belgium,US30,Michigan,NonPeak,$27.63,$31.63
+BE,Belgium,US30,Michigan,Peak,$32.60,$37.32
+BE,Belgium,US32,Wisconsin,NonPeak,$29.28,$44.51
+BE,Belgium,US32,Wisconsin,Peak,$34.55,$52.52
+BE,Belgium,US34,Ohio,NonPeak,$30.90,$34.33
+BE,Belgium,US34,Ohio,Peak,$36.46,$40.51
+BE,Belgium,US36,Indiana,NonPeak,$15.28,$31.74
+BE,Belgium,US36,Indiana,Peak,$18.03,$37.45
+BE,Belgium,US38,Illinois,NonPeak,$16.05,$44.62
+BE,Belgium,US38,Illinois,Peak,$18.94,$52.65
+BE,Belgium,US40,North Carolina,NonPeak,$16.80,$34.45
+BE,Belgium,US40,North Carolina,Peak,$19.82,$40.65
+BE,Belgium,US42,Tennessee,NonPeak,$17.57,$31.91
+BE,Belgium,US42,Tennessee,Peak,$20.73,$37.65
+BE,Belgium,US44,South Carolina,NonPeak,$18.33,$44.74
+BE,Belgium,US44,South Carolina,Peak,$21.63,$52.79
+BE,Belgium,US45,Georgia,NonPeak,$24.38,$34.56
+BE,Belgium,US45,Georgia,Peak,$28.77,$40.78
+BE,Belgium,US47,Alabama,NonPeak,$16.00,$32.09
+BE,Belgium,US47,Alabama,Peak,$18.88,$37.87
+BE,Belgium,US48,Mississippi,NonPeak,$27.63,$44.91
+BE,Belgium,US48,Mississippi,Peak,$32.60,$52.99
+BE,Belgium,US49,Florida-North,NonPeak,$29.28,$34.74
+BE,Belgium,US49,Florida-North,Peak,$34.55,$40.99
+BE,Belgium,US4964400,Florida-South,NonPeak,$30.90,$32.26
+BE,Belgium,US4964400,Florida-South,Peak,$36.46,$38.07
+BE,Belgium,US4965500,Florida Keys,NonPeak,$15.28,$45.09
+BE,Belgium,US4965500,Florida Keys,Peak,$18.03,$53.21
+BE,Belgium,US50,Minnesota,NonPeak,$16.05,$34.90
+BE,Belgium,US50,Minnesota,Peak,$18.94,$41.18
+BE,Belgium,US51,North Dakota,NonPeak,$16.80,$32.44
+BE,Belgium,US51,North Dakota,Peak,$19.82,$38.28
+BE,Belgium,US52,South Dakota,NonPeak,$17.57,$43.94
+BE,Belgium,US52,South Dakota,Peak,$20.73,$51.85
+BE,Belgium,US53,Iowa,NonPeak,$18.33,$33.70
+BE,Belgium,US53,Iowa,Peak,$21.63,$39.77
+BE,Belgium,US55,Nebraska,NonPeak,$24.38,$31.29
+BE,Belgium,US55,Nebraska,Peak,$28.77,$36.92
+BE,Belgium,US56,Missouri,NonPeak,$16.00,$44.05
+BE,Belgium,US56,Missouri,Peak,$18.88,$51.98
+BE,Belgium,US58,Kansas,NonPeak,$27.63,$33.75
+BE,Belgium,US58,Kansas,Peak,$32.60,$39.82
+BE,Belgium,US60,Arkansas,NonPeak,$29.28,$31.40
+BE,Belgium,US60,Arkansas,Peak,$34.55,$37.05
+BE,Belgium,US62,Oklahoma,NonPeak,$30.90,$44.17
+BE,Belgium,US62,Oklahoma,Peak,$36.46,$52.12
+BE,Belgium,US64,Louisiana,NonPeak,$15.28,$33.98
+BE,Belgium,US64,Louisiana,Peak,$18.03,$40.10
+BE,Belgium,US66,Texas-North,NonPeak,$16.05,$31.45
+BE,Belgium,US66,Texas-North,Peak,$18.94,$37.11
+BE,Belgium,US68,Texas-South,NonPeak,$16.80,$44.28
+BE,Belgium,US68,Texas-South,Peak,$19.82,$52.25
+BE,Belgium,US70,Montana,NonPeak,$17.57,$34.11
+BE,Belgium,US70,Montana,Peak,$20.73,$40.25
+BE,Belgium,US72,Wyoming,NonPeak,$18.33,$31.63
+BE,Belgium,US72,Wyoming,Peak,$21.63,$37.32
+BE,Belgium,US74,Colorado,NonPeak,$24.38,$44.51
+BE,Belgium,US74,Colorado,Peak,$28.77,$52.52
+BE,Belgium,US76,Utah,NonPeak,$16.00,$34.33
+BE,Belgium,US76,Utah,Peak,$18.88,$40.51
+BE,Belgium,US77,New Mexico,NonPeak,$27.63,$31.74
+BE,Belgium,US77,New Mexico,Peak,$32.60,$37.45
+BE,Belgium,US79,Arizona,NonPeak,$29.28,$44.62
+BE,Belgium,US79,Arizona,Peak,$34.55,$52.65
+BE,Belgium,US83,Idaho,NonPeak,$30.90,$34.45
+BE,Belgium,US83,Idaho,Peak,$36.46,$40.65
+BE,Belgium,US84,Washington,NonPeak,$15.28,$31.91
+BE,Belgium,US84,Washington,Peak,$18.03,$37.65
+BE,Belgium,US85,Oregon,NonPeak,$16.05,$44.74
+BE,Belgium,US85,Oregon,Peak,$18.94,$52.79
+BE,Belgium,US86,Nevada,NonPeak,$16.80,$34.56
+BE,Belgium,US86,Nevada,Peak,$19.82,$40.78
+BE,Belgium,US87,California-North,NonPeak,$17.57,$32.09
+BE,Belgium,US87,California-North,Peak,$20.73,$37.87
+BE,Belgium,US88,California-South,NonPeak,$18.33,$44.91
+BE,Belgium,US88,California-South,Peak,$21.63,$52.99
+BL,Bolivia,US11,Maine,NonPeak,$24.38,$34.74
+BL,Bolivia,US11,Maine,Peak,$28.77,$40.99
+BL,Bolivia,US12,New Hampshire,NonPeak,$16.00,$32.26
+BL,Bolivia,US12,New Hampshire,Peak,$18.88,$38.07
+BL,Bolivia,US13,Vermont,NonPeak,$27.63,$45.09
+BL,Bolivia,US13,Vermont,Peak,$32.60,$53.21
+BL,Bolivia,US14,Massachusetts,NonPeak,$29.28,$34.90
+BL,Bolivia,US14,Massachusetts,Peak,$34.55,$41.18
+BL,Bolivia,US15,Rhode Island,NonPeak,$30.90,$32.44
+BL,Bolivia,US15,Rhode Island,Peak,$36.46,$38.28
+BL,Bolivia,US16,Connecticut,NonPeak,$15.28,$43.94
+BL,Bolivia,US16,Connecticut,Peak,$18.03,$51.85
+BL,Bolivia,US17,New York,NonPeak,$16.05,$33.70
+BL,Bolivia,US17,New York,Peak,$18.94,$39.77
+BL,Bolivia,US19,New Jersey,NonPeak,$16.80,$31.29
+BL,Bolivia,US19,New Jersey,Peak,$19.82,$36.92
+BL,Bolivia,US20,Pennsylvania,NonPeak,$17.57,$44.05
+BL,Bolivia,US20,Pennsylvania,Peak,$20.73,$51.98
+BL,Bolivia,US22,Delaware,NonPeak,$18.33,$33.75
+BL,Bolivia,US22,Delaware,Peak,$21.63,$39.82
+BL,Bolivia,US23,Maryland,NonPeak,$24.38,$31.40
+BL,Bolivia,US23,Maryland,Peak,$28.77,$37.05
+BL,Bolivia,US24,District Of Columbia,NonPeak,$16.00,$44.17
+BL,Bolivia,US24,District Of Columbia,Peak,$18.88,$52.12
+BL,Bolivia,US25,Virginia,NonPeak,$27.63,$33.98
+BL,Bolivia,US25,Virginia,Peak,$32.60,$40.10
+BL,Bolivia,US27,West Virginia,NonPeak,$29.28,$31.45
+BL,Bolivia,US27,West Virginia,Peak,$34.55,$37.11
+BL,Bolivia,US28,Kentucky,NonPeak,$30.90,$44.28
+BL,Bolivia,US28,Kentucky,Peak,$36.46,$52.25
+BL,Bolivia,US30,Michigan,NonPeak,$15.28,$34.11
+BL,Bolivia,US30,Michigan,Peak,$18.03,$40.25
+BL,Bolivia,US32,Wisconsin,NonPeak,$16.05,$31.63
+BL,Bolivia,US32,Wisconsin,Peak,$18.94,$37.32
+BL,Bolivia,US34,Ohio,NonPeak,$16.80,$44.51
+BL,Bolivia,US34,Ohio,Peak,$19.82,$52.52
+BL,Bolivia,US36,Indiana,NonPeak,$17.57,$34.33
+BL,Bolivia,US36,Indiana,Peak,$20.73,$40.51
+BL,Bolivia,US38,Illinois,NonPeak,$18.33,$31.74
+BL,Bolivia,US38,Illinois,Peak,$21.63,$37.45
+BL,Bolivia,US40,North Carolina,NonPeak,$24.38,$44.62
+BL,Bolivia,US40,North Carolina,Peak,$28.77,$52.65
+BL,Bolivia,US42,Tennessee,NonPeak,$16.00,$34.45
+BL,Bolivia,US42,Tennessee,Peak,$18.88,$40.65
+BL,Bolivia,US44,South Carolina,NonPeak,$27.63,$31.91
+BL,Bolivia,US44,South Carolina,Peak,$32.60,$37.65
+BL,Bolivia,US45,Georgia,NonPeak,$29.28,$44.74
+BL,Bolivia,US45,Georgia,Peak,$34.55,$52.79
+BL,Bolivia,US47,Alabama,NonPeak,$30.90,$34.56
+BL,Bolivia,US47,Alabama,Peak,$36.46,$40.78
+BL,Bolivia,US48,Mississippi,NonPeak,$15.28,$32.09
+BL,Bolivia,US48,Mississippi,Peak,$18.03,$37.87
+BL,Bolivia,US49,Florida-North,NonPeak,$16.05,$44.91
+BL,Bolivia,US49,Florida-North,Peak,$18.94,$52.99
+BL,Bolivia,US4964400,Florida-South,NonPeak,$16.80,$34.74
+BL,Bolivia,US4964400,Florida-South,Peak,$19.82,$40.99
+BL,Bolivia,US4965500,Florida Keys,NonPeak,$17.57,$32.26
+BL,Bolivia,US4965500,Florida Keys,Peak,$20.73,$38.07
+BL,Bolivia,US50,Minnesota,NonPeak,$18.33,$45.09
+BL,Bolivia,US50,Minnesota,Peak,$21.63,$53.21
+BL,Bolivia,US51,North Dakota,NonPeak,$24.38,$34.90
+BL,Bolivia,US51,North Dakota,Peak,$28.77,$41.18
+BL,Bolivia,US52,South Dakota,NonPeak,$16.00,$32.44
+BL,Bolivia,US52,South Dakota,Peak,$18.88,$38.28
+BL,Bolivia,US53,Iowa,NonPeak,$27.63,$43.94
+BL,Bolivia,US53,Iowa,Peak,$32.60,$51.85
+BL,Bolivia,US55,Nebraska,NonPeak,$29.28,$33.70
+BL,Bolivia,US55,Nebraska,Peak,$34.55,$39.77
+BL,Bolivia,US56,Missouri,NonPeak,$30.90,$31.29
+BL,Bolivia,US56,Missouri,Peak,$36.46,$36.92
+BL,Bolivia,US58,Kansas,NonPeak,$15.28,$44.05
+BL,Bolivia,US58,Kansas,Peak,$18.03,$51.98
+BL,Bolivia,US60,Arkansas,NonPeak,$16.05,$33.75
+BL,Bolivia,US60,Arkansas,Peak,$18.94,$39.82
+BL,Bolivia,US62,Oklahoma,NonPeak,$16.80,$31.40
+BL,Bolivia,US62,Oklahoma,Peak,$19.82,$37.05
+BL,Bolivia,US64,Louisiana,NonPeak,$17.57,$44.17
+BL,Bolivia,US64,Louisiana,Peak,$20.73,$52.12
+BL,Bolivia,US66,Texas-North,NonPeak,$18.33,$33.98
+BL,Bolivia,US66,Texas-North,Peak,$21.63,$40.10
+BL,Bolivia,US68,Texas-South,NonPeak,$24.38,$31.45
+BL,Bolivia,US68,Texas-South,Peak,$28.77,$37.11
+BL,Bolivia,US70,Montana,NonPeak,$16.00,$44.28
+BL,Bolivia,US70,Montana,Peak,$18.88,$52.25
+BL,Bolivia,US72,Wyoming,NonPeak,$27.63,$34.11
+BL,Bolivia,US72,Wyoming,Peak,$32.60,$40.25
+BL,Bolivia,US74,Colorado,NonPeak,$29.28,$31.63
+BL,Bolivia,US74,Colorado,Peak,$34.55,$37.32
+BL,Bolivia,US76,Utah,NonPeak,$30.90,$44.51
+BL,Bolivia,US76,Utah,Peak,$36.46,$52.52
+BL,Bolivia,US77,New Mexico,NonPeak,$15.28,$34.33
+BL,Bolivia,US77,New Mexico,Peak,$18.03,$40.51
+BL,Bolivia,US79,Arizona,NonPeak,$16.05,$31.74
+BL,Bolivia,US79,Arizona,Peak,$18.94,$37.45
+BL,Bolivia,US83,Idaho,NonPeak,$16.80,$44.62
+BL,Bolivia,US83,Idaho,Peak,$19.82,$52.65
+BL,Bolivia,US84,Washington,NonPeak,$17.57,$34.45
+BL,Bolivia,US84,Washington,Peak,$20.73,$40.65
+BL,Bolivia,US85,Oregon,NonPeak,$18.33,$31.91
+BL,Bolivia,US85,Oregon,Peak,$21.63,$37.65
+BL,Bolivia,US86,Nevada,NonPeak,$24.38,$44.74
+BL,Bolivia,US86,Nevada,Peak,$28.77,$52.79
+BL,Bolivia,US87,California-North,NonPeak,$16.00,$34.56
+BL,Bolivia,US87,California-North,Peak,$18.88,$40.78
+BL,Bolivia,US88,California-South,NonPeak,$27.63,$32.09
+BL,Bolivia,US88,California-South,Peak,$32.60,$37.87
+BR,Brazil - Brazilia,US11,Maine,NonPeak,$29.28,$44.91
+BR,Brazil - Brazilia,US11,Maine,Peak,$34.55,$52.99
+BR,Brazil - Brazilia,US12,New Hampshire,NonPeak,$30.90,$34.74
+BR,Brazil - Brazilia,US12,New Hampshire,Peak,$36.46,$40.99
+BR,Brazil - Brazilia,US13,Vermont,NonPeak,$15.28,$32.26
+BR,Brazil - Brazilia,US13,Vermont,Peak,$18.03,$38.07
+BR,Brazil - Brazilia,US14,Massachusetts,NonPeak,$16.05,$45.09
+BR,Brazil - Brazilia,US14,Massachusetts,Peak,$18.94,$53.21
+BR,Brazil - Brazilia,US15,Rhode Island,NonPeak,$16.80,$34.90
+BR,Brazil - Brazilia,US15,Rhode Island,Peak,$19.82,$41.18
+BR,Brazil - Brazilia,US16,Connecticut,NonPeak,$17.57,$32.44
+BR,Brazil - Brazilia,US16,Connecticut,Peak,$20.73,$38.28
+BR,Brazil - Brazilia,US17,New York,NonPeak,$18.33,$43.94
+BR,Brazil - Brazilia,US17,New York,Peak,$21.63,$51.85
+BR,Brazil - Brazilia,US19,New Jersey,NonPeak,$24.38,$33.70
+BR,Brazil - Brazilia,US19,New Jersey,Peak,$28.77,$39.77
+BR,Brazil - Brazilia,US20,Pennsylvania,NonPeak,$16.00,$31.29
+BR,Brazil - Brazilia,US20,Pennsylvania,Peak,$18.88,$36.92
+BR,Brazil - Brazilia,US22,Delaware,NonPeak,$27.63,$44.05
+BR,Brazil - Brazilia,US22,Delaware,Peak,$32.60,$51.98
+BR,Brazil - Brazilia,US23,Maryland,NonPeak,$29.28,$33.75
+BR,Brazil - Brazilia,US23,Maryland,Peak,$34.55,$39.82
+BR,Brazil - Brazilia,US24,District Of Columbia,NonPeak,$30.90,$31.40
+BR,Brazil - Brazilia,US24,District Of Columbia,Peak,$36.46,$37.05
+BR,Brazil - Brazilia,US25,Virginia,NonPeak,$15.28,$44.17
+BR,Brazil - Brazilia,US25,Virginia,Peak,$18.03,$52.12
+BR,Brazil - Brazilia,US27,West Virginia,NonPeak,$16.05,$33.98
+BR,Brazil - Brazilia,US27,West Virginia,Peak,$18.94,$40.10
+BR,Brazil - Brazilia,US28,Kentucky,NonPeak,$16.80,$31.45
+BR,Brazil - Brazilia,US28,Kentucky,Peak,$19.82,$37.11
+BR,Brazil - Brazilia,US30,Michigan,NonPeak,$17.57,$44.28
+BR,Brazil - Brazilia,US30,Michigan,Peak,$20.73,$52.25
+BR,Brazil - Brazilia,US32,Wisconsin,NonPeak,$18.33,$34.11
+BR,Brazil - Brazilia,US32,Wisconsin,Peak,$21.63,$40.25
+BR,Brazil - Brazilia,US34,Ohio,NonPeak,$24.38,$31.63
+BR,Brazil - Brazilia,US34,Ohio,Peak,$28.77,$37.32
+BR,Brazil - Brazilia,US36,Indiana,NonPeak,$16.00,$44.51
+BR,Brazil - Brazilia,US36,Indiana,Peak,$18.88,$52.52
+BR,Brazil - Brazilia,US38,Illinois,NonPeak,$27.63,$34.33
+BR,Brazil - Brazilia,US38,Illinois,Peak,$32.60,$40.51
+BR,Brazil - Brazilia,US40,North Carolina,NonPeak,$29.28,$31.74
+BR,Brazil - Brazilia,US40,North Carolina,Peak,$34.55,$37.45
+BR,Brazil - Brazilia,US42,Tennessee,NonPeak,$30.90,$44.62
+BR,Brazil - Brazilia,US42,Tennessee,Peak,$36.46,$52.65
+BR,Brazil - Brazilia,US44,South Carolina,NonPeak,$15.28,$34.45
+BR,Brazil - Brazilia,US44,South Carolina,Peak,$18.03,$40.65
+BR,Brazil - Brazilia,US45,Georgia,NonPeak,$16.05,$31.91
+BR,Brazil - Brazilia,US45,Georgia,Peak,$18.94,$37.65
+BR,Brazil - Brazilia,US47,Alabama,NonPeak,$16.80,$44.74
+BR,Brazil - Brazilia,US47,Alabama,Peak,$19.82,$52.79
+BR,Brazil - Brazilia,US48,Mississippi,NonPeak,$17.57,$34.56
+BR,Brazil - Brazilia,US48,Mississippi,Peak,$20.73,$40.78
+BR,Brazil - Brazilia,US49,Florida-North,NonPeak,$18.33,$32.09
+BR,Brazil - Brazilia,US49,Florida-North,Peak,$21.63,$37.87
+BR,Brazil - Brazilia,US4964400,Florida-South,NonPeak,$24.38,$44.91
+BR,Brazil - Brazilia,US4964400,Florida-South,Peak,$28.77,$52.99
+BR,Brazil - Brazilia,US4965500,Florida Keys,NonPeak,$16.00,$34.74
+BR,Brazil - Brazilia,US4965500,Florida Keys,Peak,$18.88,$40.99
+BR,Brazil - Brazilia,US50,Minnesota,NonPeak,$27.63,$32.26
+BR,Brazil - Brazilia,US50,Minnesota,Peak,$32.60,$38.07
+BR,Brazil - Brazilia,US51,North Dakota,NonPeak,$29.28,$45.09
+BR,Brazil - Brazilia,US51,North Dakota,Peak,$34.55,$53.21
+BR,Brazil - Brazilia,US52,South Dakota,NonPeak,$30.90,$34.90
+BR,Brazil - Brazilia,US52,South Dakota,Peak,$36.46,$41.18
+BR,Brazil - Brazilia,US53,Iowa,NonPeak,$15.28,$32.44
+BR,Brazil - Brazilia,US53,Iowa,Peak,$18.03,$38.28
+BR,Brazil - Brazilia,US55,Nebraska,NonPeak,$16.05,$43.94
+BR,Brazil - Brazilia,US55,Nebraska,Peak,$18.94,$51.85
+BR,Brazil - Brazilia,US56,Missouri,NonPeak,$16.80,$33.70
+BR,Brazil - Brazilia,US56,Missouri,Peak,$19.82,$39.77
+BR,Brazil - Brazilia,US58,Kansas,NonPeak,$17.57,$31.29
+BR,Brazil - Brazilia,US58,Kansas,Peak,$20.73,$36.92
+BR,Brazil - Brazilia,US60,Arkansas,NonPeak,$18.33,$44.05
+BR,Brazil - Brazilia,US60,Arkansas,Peak,$21.63,$51.98
+BR,Brazil - Brazilia,US62,Oklahoma,NonPeak,$24.38,$33.75
+BR,Brazil - Brazilia,US62,Oklahoma,Peak,$28.77,$39.82
+BR,Brazil - Brazilia,US64,Louisiana,NonPeak,$16.00,$31.40
+BR,Brazil - Brazilia,US64,Louisiana,Peak,$18.88,$37.05
+BR,Brazil - Brazilia,US66,Texas-North,NonPeak,$27.63,$44.17
+BR,Brazil - Brazilia,US66,Texas-North,Peak,$32.60,$52.12
+BR,Brazil - Brazilia,US68,Texas-South,NonPeak,$29.28,$33.98
+BR,Brazil - Brazilia,US68,Texas-South,Peak,$34.55,$40.10
+BR,Brazil - Brazilia,US70,Montana,NonPeak,$30.90,$31.45
+BR,Brazil - Brazilia,US70,Montana,Peak,$36.46,$37.11
+BR,Brazil - Brazilia,US72,Wyoming,NonPeak,$15.28,$44.28
+BR,Brazil - Brazilia,US72,Wyoming,Peak,$18.03,$52.25
+BR,Brazil - Brazilia,US74,Colorado,NonPeak,$16.05,$34.11
+BR,Brazil - Brazilia,US74,Colorado,Peak,$18.94,$40.25
+BR,Brazil - Brazilia,US76,Utah,NonPeak,$16.80,$31.63
+BR,Brazil - Brazilia,US76,Utah,Peak,$19.82,$37.32
+BR,Brazil - Brazilia,US77,New Mexico,NonPeak,$17.57,$44.51
+BR,Brazil - Brazilia,US77,New Mexico,Peak,$20.73,$52.52
+BR,Brazil - Brazilia,US79,Arizona,NonPeak,$18.33,$34.33
+BR,Brazil - Brazilia,US79,Arizona,Peak,$21.63,$40.51
+BR,Brazil - Brazilia,US83,Idaho,NonPeak,$24.38,$31.74
+BR,Brazil - Brazilia,US83,Idaho,Peak,$28.77,$37.45
+BR,Brazil - Brazilia,US84,Washington,NonPeak,$16.00,$44.62
+BR,Brazil - Brazilia,US84,Washington,Peak,$18.88,$52.65
+BR,Brazil - Brazilia,US85,Oregon,NonPeak,$27.63,$34.45
+BR,Brazil - Brazilia,US85,Oregon,Peak,$32.60,$40.65
+BR,Brazil - Brazilia,US86,Nevada,NonPeak,$29.28,$31.91
+BR,Brazil - Brazilia,US86,Nevada,Peak,$34.55,$37.65
+BR,Brazil - Brazilia,US87,California-North,NonPeak,$30.90,$44.74
+BR,Brazil - Brazilia,US87,California-North,Peak,$36.46,$52.79
+BR,Brazil - Brazilia,US88,California-South,NonPeak,$15.28,$34.56
+BR,Brazil - Brazilia,US88,California-South,Peak,$18.03,$40.78
+CA10,Ontario,US11,Maine,NonPeak,$16.05,$32.09
+CA10,Ontario,US11,Maine,Peak,$18.94,$37.87
+CA10,Ontario,US12,New Hampshire,NonPeak,$16.80,$44.91
+CA10,Ontario,US12,New Hampshire,Peak,$19.82,$52.99
+CA10,Ontario,US13,Vermont,NonPeak,$17.57,$34.74
+CA10,Ontario,US13,Vermont,Peak,$20.73,$40.99
+CA10,Ontario,US14,Massachusetts,NonPeak,$18.33,$32.26
+CA10,Ontario,US14,Massachusetts,Peak,$21.63,$38.07
+CA10,Ontario,US15,Rhode Island,NonPeak,$24.38,$45.09
+CA10,Ontario,US15,Rhode Island,Peak,$28.77,$53.21
+CA10,Ontario,US16,Connecticut,NonPeak,$16.00,$34.90
+CA10,Ontario,US16,Connecticut,Peak,$18.88,$41.18
+CA10,Ontario,US17,New York,NonPeak,$27.63,$32.44
+CA10,Ontario,US17,New York,Peak,$32.60,$38.28
+CA10,Ontario,US19,New Jersey,NonPeak,$29.28,$43.94
+CA10,Ontario,US19,New Jersey,Peak,$34.55,$51.85
+CA10,Ontario,US20,Pennsylvania,NonPeak,$30.90,$33.70
+CA10,Ontario,US20,Pennsylvania,Peak,$36.46,$39.77
+CA10,Ontario,US22,Delaware,NonPeak,$15.28,$31.29
+CA10,Ontario,US22,Delaware,Peak,$18.03,$36.92
+CA10,Ontario,US23,Maryland,NonPeak,$16.05,$44.05
+CA10,Ontario,US23,Maryland,Peak,$18.94,$51.98
+CA10,Ontario,US24,District Of Columbia,NonPeak,$16.80,$33.75
+CA10,Ontario,US24,District Of Columbia,Peak,$19.82,$39.82
+CA10,Ontario,US25,Virginia,NonPeak,$17.57,$31.40
+CA10,Ontario,US25,Virginia,Peak,$20.73,$37.05
+CA10,Ontario,US27,West Virginia,NonPeak,$18.33,$44.17
+CA10,Ontario,US27,West Virginia,Peak,$21.63,$52.12
+CA10,Ontario,US28,Kentucky,NonPeak,$24.38,$33.98
+CA10,Ontario,US28,Kentucky,Peak,$28.77,$40.10
+CA10,Ontario,US30,Michigan,NonPeak,$16.00,$31.45
+CA10,Ontario,US30,Michigan,Peak,$18.88,$37.11
+CA10,Ontario,US32,Wisconsin,NonPeak,$27.63,$44.28
+CA10,Ontario,US32,Wisconsin,Peak,$32.60,$52.25
+CA10,Ontario,US34,Ohio,NonPeak,$29.28,$34.11
+CA10,Ontario,US34,Ohio,Peak,$34.55,$40.25
+CA10,Ontario,US36,Indiana,NonPeak,$30.90,$31.63
+CA10,Ontario,US36,Indiana,Peak,$36.46,$37.32
+CA10,Ontario,US38,Illinois,NonPeak,$15.28,$44.51
+CA10,Ontario,US38,Illinois,Peak,$18.03,$52.52
+CA10,Ontario,US40,North Carolina,NonPeak,$16.05,$34.33
+CA10,Ontario,US40,North Carolina,Peak,$18.94,$40.51
+CA10,Ontario,US42,Tennessee,NonPeak,$16.80,$31.74
+CA10,Ontario,US42,Tennessee,Peak,$19.82,$37.45
+CA10,Ontario,US44,South Carolina,NonPeak,$17.57,$44.62
+CA10,Ontario,US44,South Carolina,Peak,$20.73,$52.65
+CA10,Ontario,US45,Georgia,NonPeak,$18.33,$34.45
+CA10,Ontario,US45,Georgia,Peak,$21.63,$40.65
+CA10,Ontario,US47,Alabama,NonPeak,$24.38,$31.91
+CA10,Ontario,US47,Alabama,Peak,$28.77,$37.65
+CA10,Ontario,US48,Mississippi,NonPeak,$16.00,$44.74
+CA10,Ontario,US48,Mississippi,Peak,$18.88,$52.79
+CA10,Ontario,US49,Florida-North,NonPeak,$27.63,$34.56
+CA10,Ontario,US49,Florida-North,Peak,$32.60,$40.78
+CA10,Ontario,US4964400,Florida-South,NonPeak,$29.28,$32.09
+CA10,Ontario,US4964400,Florida-South,Peak,$34.55,$37.87
+CA10,Ontario,US4965500,Florida Keys,NonPeak,$30.90,$44.91
+CA10,Ontario,US4965500,Florida Keys,Peak,$36.46,$52.99
+CA10,Ontario,US50,Minnesota,NonPeak,$15.28,$34.74
+CA10,Ontario,US50,Minnesota,Peak,$18.03,$40.99
+CA10,Ontario,US51,North Dakota,NonPeak,$16.05,$32.26
+CA10,Ontario,US51,North Dakota,Peak,$18.94,$38.07
+CA10,Ontario,US52,South Dakota,NonPeak,$16.80,$45.09
+CA10,Ontario,US52,South Dakota,Peak,$19.82,$53.21
+CA10,Ontario,US53,Iowa,NonPeak,$17.57,$34.90
+CA10,Ontario,US53,Iowa,Peak,$20.73,$41.18
+CA10,Ontario,US55,Nebraska,NonPeak,$18.33,$32.44
+CA10,Ontario,US55,Nebraska,Peak,$21.63,$38.28
+CA10,Ontario,US56,Missouri,NonPeak,$24.38,$43.94
+CA10,Ontario,US56,Missouri,Peak,$28.77,$51.85
+CA10,Ontario,US58,Kansas,NonPeak,$16.00,$33.70
+CA10,Ontario,US58,Kansas,Peak,$18.88,$39.77
+CA10,Ontario,US60,Arkansas,NonPeak,$27.63,$31.29
+CA10,Ontario,US60,Arkansas,Peak,$32.60,$36.92
+CA10,Ontario,US62,Oklahoma,NonPeak,$29.28,$44.05
+CA10,Ontario,US62,Oklahoma,Peak,$34.55,$51.98
+CA10,Ontario,US64,Louisiana,NonPeak,$30.90,$33.75
+CA10,Ontario,US64,Louisiana,Peak,$36.46,$39.82
+CA10,Ontario,US66,Texas-North,NonPeak,$15.28,$31.40
+CA10,Ontario,US66,Texas-North,Peak,$18.03,$37.05
+CA10,Ontario,US68,Texas-South,NonPeak,$16.05,$44.17
+CA10,Ontario,US68,Texas-South,Peak,$18.94,$52.12
+CA10,Ontario,US70,Montana,NonPeak,$16.80,$33.98
+CA10,Ontario,US70,Montana,Peak,$19.82,$40.10
+CA10,Ontario,US72,Wyoming,NonPeak,$17.57,$31.45
+CA10,Ontario,US72,Wyoming,Peak,$20.73,$37.11
+CA10,Ontario,US74,Colorado,NonPeak,$18.33,$44.28
+CA10,Ontario,US74,Colorado,Peak,$21.63,$52.25
+CA10,Ontario,US76,Utah,NonPeak,$24.38,$34.11
+CA10,Ontario,US76,Utah,Peak,$28.77,$40.25
+CA10,Ontario,US77,New Mexico,NonPeak,$16.00,$31.63
+CA10,Ontario,US77,New Mexico,Peak,$18.88,$37.32
+CA10,Ontario,US79,Arizona,NonPeak,$27.63,$44.51
+CA10,Ontario,US79,Arizona,Peak,$32.60,$52.52
+CA10,Ontario,US83,Idaho,NonPeak,$29.28,$34.33
+CA10,Ontario,US83,Idaho,Peak,$34.55,$40.51
+CA10,Ontario,US84,Washington,NonPeak,$30.90,$31.74
+CA10,Ontario,US84,Washington,Peak,$36.46,$37.45
+CA10,Ontario,US85,Oregon,NonPeak,$15.28,$44.62
+CA10,Ontario,US85,Oregon,Peak,$18.03,$52.65
+CA10,Ontario,US86,Nevada,NonPeak,$16.05,$34.45
+CA10,Ontario,US86,Nevada,Peak,$18.94,$40.65
+CA10,Ontario,US87,California-North,NonPeak,$16.80,$31.91
+CA10,Ontario,US87,California-North,Peak,$19.82,$37.65
+CA10,Ontario,US88,California-South,NonPeak,$17.57,$44.74
+CA10,Ontario,US88,California-South,Peak,$20.73,$52.79
+CA20,Quebec,US11,Maine,NonPeak,$18.33,$34.56
+CA20,Quebec,US11,Maine,Peak,$21.63,$40.78
+CA20,Quebec,US12,New Hampshire,NonPeak,$24.38,$32.09
+CA20,Quebec,US12,New Hampshire,Peak,$28.77,$37.87
+CA20,Quebec,US13,Vermont,NonPeak,$16.00,$44.91
+CA20,Quebec,US13,Vermont,Peak,$18.88,$52.99
+CA20,Quebec,US14,Massachusetts,NonPeak,$27.63,$34.74
+CA20,Quebec,US14,Massachusetts,Peak,$32.60,$40.99
+CA20,Quebec,US15,Rhode Island,NonPeak,$29.28,$32.26
+CA20,Quebec,US15,Rhode Island,Peak,$34.55,$38.07
+CA20,Quebec,US16,Connecticut,NonPeak,$30.90,$45.09
+CA20,Quebec,US16,Connecticut,Peak,$36.46,$53.21
+CA20,Quebec,US17,New York,NonPeak,$15.28,$34.90
+CA20,Quebec,US17,New York,Peak,$18.03,$41.18
+CA20,Quebec,US19,New Jersey,NonPeak,$16.05,$32.44
+CA20,Quebec,US19,New Jersey,Peak,$18.94,$38.28
+CA20,Quebec,US20,Pennsylvania,NonPeak,$16.80,$43.94
+CA20,Quebec,US20,Pennsylvania,Peak,$19.82,$51.85
+CA20,Quebec,US22,Delaware,NonPeak,$17.57,$33.70
+CA20,Quebec,US22,Delaware,Peak,$20.73,$39.77
+CA20,Quebec,US23,Maryland,NonPeak,$18.33,$31.29
+CA20,Quebec,US23,Maryland,Peak,$21.63,$36.92
+CA20,Quebec,US24,District Of Columbia,NonPeak,$24.38,$44.05
+CA20,Quebec,US24,District Of Columbia,Peak,$28.77,$51.98
+CA20,Quebec,US25,Virginia,NonPeak,$16.00,$33.75
+CA20,Quebec,US25,Virginia,Peak,$18.88,$39.82
+CA20,Quebec,US27,West Virginia,NonPeak,$27.63,$31.40
+CA20,Quebec,US27,West Virginia,Peak,$32.60,$37.05
+CA20,Quebec,US28,Kentucky,NonPeak,$29.28,$44.17
+CA20,Quebec,US28,Kentucky,Peak,$34.55,$52.12
+CA20,Quebec,US30,Michigan,NonPeak,$30.90,$33.98
+CA20,Quebec,US30,Michigan,Peak,$36.46,$40.10
+CA20,Quebec,US32,Wisconsin,NonPeak,$15.28,$31.45
+CA20,Quebec,US32,Wisconsin,Peak,$18.03,$37.11
+CA20,Quebec,US34,Ohio,NonPeak,$16.05,$44.28
+CA20,Quebec,US34,Ohio,Peak,$18.94,$52.25
+CA20,Quebec,US36,Indiana,NonPeak,$16.80,$34.11
+CA20,Quebec,US36,Indiana,Peak,$19.82,$40.25
+CA20,Quebec,US38,Illinois,NonPeak,$17.57,$31.63
+CA20,Quebec,US38,Illinois,Peak,$20.73,$37.32
+CA20,Quebec,US40,North Carolina,NonPeak,$18.33,$44.51
+CA20,Quebec,US40,North Carolina,Peak,$21.63,$52.52
+CA20,Quebec,US42,Tennessee,NonPeak,$24.38,$34.33
+CA20,Quebec,US42,Tennessee,Peak,$28.77,$40.51
+CA20,Quebec,US44,South Carolina,NonPeak,$16.00,$31.74
+CA20,Quebec,US44,South Carolina,Peak,$18.88,$37.45
+CA20,Quebec,US45,Georgia,NonPeak,$27.63,$44.62
+CA20,Quebec,US45,Georgia,Peak,$32.60,$52.65
+CA20,Quebec,US47,Alabama,NonPeak,$29.28,$34.45
+CA20,Quebec,US47,Alabama,Peak,$34.55,$40.65
+CA20,Quebec,US48,Mississippi,NonPeak,$30.90,$31.91
+CA20,Quebec,US48,Mississippi,Peak,$36.46,$37.65
+CA20,Quebec,US49,Florida-North,NonPeak,$15.28,$44.74
+CA20,Quebec,US49,Florida-North,Peak,$18.03,$52.79
+CA20,Quebec,US4964400,Florida-South,NonPeak,$16.05,$34.56
+CA20,Quebec,US4964400,Florida-South,Peak,$18.94,$40.78
+CA20,Quebec,US4965500,Florida Keys,NonPeak,$16.80,$32.09
+CA20,Quebec,US4965500,Florida Keys,Peak,$19.82,$37.87
+CA20,Quebec,US50,Minnesota,NonPeak,$17.57,$44.91
+CA20,Quebec,US50,Minnesota,Peak,$20.73,$52.99
+CA20,Quebec,US51,North Dakota,NonPeak,$18.33,$34.74
+CA20,Quebec,US51,North Dakota,Peak,$21.63,$40.99
+CA20,Quebec,US52,South Dakota,NonPeak,$24.38,$32.26
+CA20,Quebec,US52,South Dakota,Peak,$28.77,$38.07
+CA20,Quebec,US53,Iowa,NonPeak,$16.00,$45.09
+CA20,Quebec,US53,Iowa,Peak,$18.88,$53.21
+CA20,Quebec,US55,Nebraska,NonPeak,$27.63,$34.90
+CA20,Quebec,US55,Nebraska,Peak,$32.60,$41.18
+CA20,Quebec,US56,Missouri,NonPeak,$29.28,$32.44
+CA20,Quebec,US56,Missouri,Peak,$34.55,$38.28
+CA20,Quebec,US58,Kansas,NonPeak,$30.90,$43.94
+CA20,Quebec,US58,Kansas,Peak,$36.46,$51.85
+CA20,Quebec,US60,Arkansas,NonPeak,$15.28,$33.70
+CA20,Quebec,US60,Arkansas,Peak,$18.03,$39.77
+CA20,Quebec,US62,Oklahoma,NonPeak,$16.05,$31.29
+CA20,Quebec,US62,Oklahoma,Peak,$18.94,$36.92
+CA20,Quebec,US64,Louisiana,NonPeak,$16.80,$44.05
+CA20,Quebec,US64,Louisiana,Peak,$19.82,$51.98
+CA20,Quebec,US66,Texas-North,NonPeak,$17.57,$33.75
+CA20,Quebec,US66,Texas-North,Peak,$20.73,$39.82
+CA20,Quebec,US68,Texas-South,NonPeak,$18.33,$31.40
+CA20,Quebec,US68,Texas-South,Peak,$21.63,$37.05
+CA20,Quebec,US70,Montana,NonPeak,$24.38,$44.17
+CA20,Quebec,US70,Montana,Peak,$28.77,$52.12
+CA20,Quebec,US72,Wyoming,NonPeak,$16.00,$33.98
+CA20,Quebec,US72,Wyoming,Peak,$18.88,$40.10
+CA20,Quebec,US74,Colorado,NonPeak,$27.63,$31.45
+CA20,Quebec,US74,Colorado,Peak,$32.60,$37.11
+CA20,Quebec,US76,Utah,NonPeak,$29.28,$44.28
+CA20,Quebec,US76,Utah,Peak,$34.55,$52.25
+CA20,Quebec,US77,New Mexico,NonPeak,$30.90,$34.11
+CA20,Quebec,US77,New Mexico,Peak,$36.46,$40.25
+CA20,Quebec,US79,Arizona,NonPeak,$15.28,$31.63
+CA20,Quebec,US79,Arizona,Peak,$18.03,$37.32
+CA20,Quebec,US83,Idaho,NonPeak,$16.05,$44.51
+CA20,Quebec,US83,Idaho,Peak,$18.94,$52.52
+CA20,Quebec,US84,Washington,NonPeak,$16.80,$34.33
+CA20,Quebec,US84,Washington,Peak,$19.82,$40.51
+CA20,Quebec,US85,Oregon,NonPeak,$17.57,$31.74
+CA20,Quebec,US85,Oregon,Peak,$20.73,$37.45
+CA20,Quebec,US86,Nevada,NonPeak,$18.33,$44.62
+CA20,Quebec,US86,Nevada,Peak,$21.63,$52.65
+CA20,Quebec,US87,California-North,NonPeak,$24.38,$34.45
+CA20,Quebec,US87,California-North,Peak,$28.77,$40.65
+CA20,Quebec,US88,California-South,NonPeak,$16.00,$31.91
+CA20,Quebec,US88,California-South,Peak,$18.88,$37.65
+CA30,Manitoba,US11,Maine,NonPeak,$27.63,$44.74
+CA30,Manitoba,US11,Maine,Peak,$32.60,$52.79
+CA30,Manitoba,US12,New Hampshire,NonPeak,$29.28,$34.56
+CA30,Manitoba,US12,New Hampshire,Peak,$34.55,$40.78
+CA30,Manitoba,US13,Vermont,NonPeak,$30.90,$32.09
+CA30,Manitoba,US13,Vermont,Peak,$36.46,$37.87
+CA30,Manitoba,US14,Massachusetts,NonPeak,$15.28,$44.91
+CA30,Manitoba,US14,Massachusetts,Peak,$18.03,$52.99
+CA30,Manitoba,US15,Rhode Island,NonPeak,$16.05,$34.74
+CA30,Manitoba,US15,Rhode Island,Peak,$18.94,$40.99
+CA30,Manitoba,US16,Connecticut,NonPeak,$16.80,$32.26
+CA30,Manitoba,US16,Connecticut,Peak,$19.82,$38.07
+CA30,Manitoba,US17,New York,NonPeak,$17.57,$45.09
+CA30,Manitoba,US17,New York,Peak,$20.73,$53.21
+CA30,Manitoba,US19,New Jersey,NonPeak,$18.33,$34.90
+CA30,Manitoba,US19,New Jersey,Peak,$21.63,$41.18
+CA30,Manitoba,US20,Pennsylvania,NonPeak,$24.38,$32.44
+CA30,Manitoba,US20,Pennsylvania,Peak,$28.77,$38.28
+CA30,Manitoba,US22,Delaware,NonPeak,$16.00,$43.94
+CA30,Manitoba,US22,Delaware,Peak,$18.88,$51.85
+CA30,Manitoba,US23,Maryland,NonPeak,$27.63,$33.70
+CA30,Manitoba,US23,Maryland,Peak,$32.60,$39.77
+CA30,Manitoba,US24,District Of Columbia,NonPeak,$29.28,$31.29
+CA30,Manitoba,US24,District Of Columbia,Peak,$34.55,$36.92
+CA30,Manitoba,US25,Virginia,NonPeak,$30.90,$44.05
+CA30,Manitoba,US25,Virginia,Peak,$36.46,$51.98
+CA30,Manitoba,US27,West Virginia,NonPeak,$15.28,$33.75
+CA30,Manitoba,US27,West Virginia,Peak,$18.03,$39.82
+CA30,Manitoba,US28,Kentucky,NonPeak,$16.05,$31.40
+CA30,Manitoba,US28,Kentucky,Peak,$18.94,$37.05
+CA30,Manitoba,US30,Michigan,NonPeak,$16.80,$44.17
+CA30,Manitoba,US30,Michigan,Peak,$19.82,$52.12
+CA30,Manitoba,US32,Wisconsin,NonPeak,$17.57,$33.98
+CA30,Manitoba,US32,Wisconsin,Peak,$20.73,$40.10
+CA30,Manitoba,US34,Ohio,NonPeak,$18.33,$31.45
+CA30,Manitoba,US34,Ohio,Peak,$21.63,$37.11
+CA30,Manitoba,US36,Indiana,NonPeak,$24.38,$44.28
+CA30,Manitoba,US36,Indiana,Peak,$28.77,$52.25
+CA30,Manitoba,US38,Illinois,NonPeak,$16.00,$34.11
+CA30,Manitoba,US38,Illinois,Peak,$18.88,$40.25
+CA30,Manitoba,US40,North Carolina,NonPeak,$27.63,$31.63
+CA30,Manitoba,US40,North Carolina,Peak,$32.60,$37.32
+CA30,Manitoba,US42,Tennessee,NonPeak,$29.28,$44.51
+CA30,Manitoba,US42,Tennessee,Peak,$34.55,$52.52
+CA30,Manitoba,US44,South Carolina,NonPeak,$30.90,$34.33
+CA30,Manitoba,US44,South Carolina,Peak,$36.46,$40.51
+CA30,Manitoba,US45,Georgia,NonPeak,$15.28,$31.74
+CA30,Manitoba,US45,Georgia,Peak,$18.03,$37.45
+CA30,Manitoba,US47,Alabama,NonPeak,$16.05,$44.62
+CA30,Manitoba,US47,Alabama,Peak,$18.94,$52.65
+CA30,Manitoba,US48,Mississippi,NonPeak,$16.80,$34.45
+CA30,Manitoba,US48,Mississippi,Peak,$19.82,$40.65
+CA30,Manitoba,US49,Florida-North,NonPeak,$17.57,$31.91
+CA30,Manitoba,US49,Florida-North,Peak,$20.73,$37.65
+CA30,Manitoba,US4964400,Florida-South,NonPeak,$18.33,$44.74
+CA30,Manitoba,US4964400,Florida-South,Peak,$21.63,$52.79
+CA30,Manitoba,US4965500,Florida Keys,NonPeak,$24.38,$34.56
+CA30,Manitoba,US4965500,Florida Keys,Peak,$28.77,$40.78
+CA30,Manitoba,US50,Minnesota,NonPeak,$16.00,$32.09
+CA30,Manitoba,US50,Minnesota,Peak,$18.88,$37.87
+CA30,Manitoba,US51,North Dakota,NonPeak,$27.63,$44.91
+CA30,Manitoba,US51,North Dakota,Peak,$32.60,$52.99
+CA30,Manitoba,US52,South Dakota,NonPeak,$29.28,$34.74
+CA30,Manitoba,US52,South Dakota,Peak,$34.55,$40.99
+CA30,Manitoba,US53,Iowa,NonPeak,$30.90,$32.26
+CA30,Manitoba,US53,Iowa,Peak,$36.46,$38.07
+CA30,Manitoba,US55,Nebraska,NonPeak,$15.28,$45.09
+CA30,Manitoba,US55,Nebraska,Peak,$18.03,$53.21
+CA30,Manitoba,US56,Missouri,NonPeak,$16.05,$34.90
+CA30,Manitoba,US56,Missouri,Peak,$18.94,$41.18
+CA30,Manitoba,US58,Kansas,NonPeak,$16.80,$32.44
+CA30,Manitoba,US58,Kansas,Peak,$19.82,$38.28
+CA30,Manitoba,US60,Arkansas,NonPeak,$17.57,$43.94
+CA30,Manitoba,US60,Arkansas,Peak,$20.73,$51.85
+CA30,Manitoba,US62,Oklahoma,NonPeak,$18.33,$33.70
+CA30,Manitoba,US62,Oklahoma,Peak,$21.63,$39.77
+CA30,Manitoba,US64,Louisiana,NonPeak,$24.38,$31.29
+CA30,Manitoba,US64,Louisiana,Peak,$28.77,$36.92
+CA30,Manitoba,US66,Texas-North,NonPeak,$16.00,$44.05
+CA30,Manitoba,US66,Texas-North,Peak,$18.88,$51.98
+CA30,Manitoba,US68,Texas-South,NonPeak,$27.63,$33.75
+CA30,Manitoba,US68,Texas-South,Peak,$32.60,$39.82
+CA30,Manitoba,US70,Montana,NonPeak,$29.28,$31.40
+CA30,Manitoba,US70,Montana,Peak,$34.55,$37.05
+CA30,Manitoba,US72,Wyoming,NonPeak,$30.90,$44.17
+CA30,Manitoba,US72,Wyoming,Peak,$36.46,$52.12
+CA30,Manitoba,US74,Colorado,NonPeak,$15.28,$33.98
+CA30,Manitoba,US74,Colorado,Peak,$18.03,$40.10
+CA30,Manitoba,US76,Utah,NonPeak,$16.05,$31.45
+CA30,Manitoba,US76,Utah,Peak,$18.94,$37.11
+CA30,Manitoba,US77,New Mexico,NonPeak,$16.80,$44.28
+CA30,Manitoba,US77,New Mexico,Peak,$19.82,$52.25
+CA30,Manitoba,US79,Arizona,NonPeak,$17.57,$34.11
+CA30,Manitoba,US79,Arizona,Peak,$20.73,$40.25
+CA30,Manitoba,US83,Idaho,NonPeak,$18.33,$31.63
+CA30,Manitoba,US83,Idaho,Peak,$21.63,$37.32
+CA30,Manitoba,US84,Washington,NonPeak,$24.38,$44.51
+CA30,Manitoba,US84,Washington,Peak,$28.77,$52.52
+CA30,Manitoba,US85,Oregon,NonPeak,$16.00,$34.33
+CA30,Manitoba,US85,Oregon,Peak,$18.88,$40.51
+CA30,Manitoba,US86,Nevada,NonPeak,$27.63,$31.74
+CA30,Manitoba,US86,Nevada,Peak,$32.60,$37.45
+CA30,Manitoba,US87,California-North,NonPeak,$29.28,$44.62
+CA30,Manitoba,US87,California-North,Peak,$34.55,$52.65
+CA30,Manitoba,US88,California-South,NonPeak,$30.90,$34.45
+CA30,Manitoba,US88,California-South,Peak,$36.46,$40.65
+CI,Chile,US11,Maine,NonPeak,$15.28,$31.91
+CI,Chile,US11,Maine,Peak,$18.03,$37.65
+CI,Chile,US12,New Hampshire,NonPeak,$16.05,$44.74
+CI,Chile,US12,New Hampshire,Peak,$18.94,$52.79
+CI,Chile,US13,Vermont,NonPeak,$16.80,$34.56
+CI,Chile,US13,Vermont,Peak,$19.82,$40.78
+CI,Chile,US14,Massachusetts,NonPeak,$17.57,$32.09
+CI,Chile,US14,Massachusetts,Peak,$20.73,$37.87
+CI,Chile,US15,Rhode Island,NonPeak,$18.33,$44.91
+CI,Chile,US15,Rhode Island,Peak,$21.63,$52.99
+CI,Chile,US16,Connecticut,NonPeak,$24.38,$34.74
+CI,Chile,US16,Connecticut,Peak,$28.77,$40.99
+CI,Chile,US17,New York,NonPeak,$16.00,$32.26
+CI,Chile,US17,New York,Peak,$18.88,$38.07
+CI,Chile,US19,New Jersey,NonPeak,$27.63,$45.09
+CI,Chile,US19,New Jersey,Peak,$32.60,$53.21
+CI,Chile,US20,Pennsylvania,NonPeak,$29.28,$34.90
+CI,Chile,US20,Pennsylvania,Peak,$34.55,$41.18
+CI,Chile,US22,Delaware,NonPeak,$30.90,$32.44
+CI,Chile,US22,Delaware,Peak,$36.46,$38.28
+CI,Chile,US23,Maryland,NonPeak,$15.28,$43.94
+CI,Chile,US23,Maryland,Peak,$18.03,$51.85
+CI,Chile,US24,District Of Columbia,NonPeak,$16.05,$33.70
+CI,Chile,US24,District Of Columbia,Peak,$18.94,$39.77
+CI,Chile,US25,Virginia,NonPeak,$16.80,$31.29
+CI,Chile,US25,Virginia,Peak,$19.82,$36.92
+CI,Chile,US27,West Virginia,NonPeak,$17.57,$44.05
+CI,Chile,US27,West Virginia,Peak,$20.73,$51.98
+CI,Chile,US28,Kentucky,NonPeak,$18.33,$33.75
+CI,Chile,US28,Kentucky,Peak,$21.63,$39.82
+CI,Chile,US30,Michigan,NonPeak,$24.38,$31.40
+CI,Chile,US30,Michigan,Peak,$28.77,$37.05
+CI,Chile,US32,Wisconsin,NonPeak,$16.00,$44.17
+CI,Chile,US32,Wisconsin,Peak,$18.88,$52.12
+CI,Chile,US34,Ohio,NonPeak,$27.63,$33.98
+CI,Chile,US34,Ohio,Peak,$32.60,$40.10
+CI,Chile,US36,Indiana,NonPeak,$29.28,$31.45
+CI,Chile,US36,Indiana,Peak,$34.55,$37.11
+CI,Chile,US38,Illinois,NonPeak,$30.90,$44.28
+CI,Chile,US38,Illinois,Peak,$36.46,$52.25
+CI,Chile,US40,North Carolina,NonPeak,$15.28,$34.11
+CI,Chile,US40,North Carolina,Peak,$18.03,$40.25
+CI,Chile,US42,Tennessee,NonPeak,$16.05,$31.63
+CI,Chile,US42,Tennessee,Peak,$18.94,$37.32
+CI,Chile,US44,South Carolina,NonPeak,$16.80,$44.51
+CI,Chile,US44,South Carolina,Peak,$19.82,$52.52
+CI,Chile,US45,Georgia,NonPeak,$17.57,$34.33
+CI,Chile,US45,Georgia,Peak,$20.73,$40.51
+CI,Chile,US47,Alabama,NonPeak,$18.33,$31.74
+CI,Chile,US47,Alabama,Peak,$21.63,$37.45
+CI,Chile,US48,Mississippi,NonPeak,$24.38,$44.62
+CI,Chile,US48,Mississippi,Peak,$28.77,$52.65
+CI,Chile,US49,Florida-North,NonPeak,$16.00,$34.45
+CI,Chile,US49,Florida-North,Peak,$18.88,$40.65
+CI,Chile,US4964400,Florida-South,NonPeak,$27.63,$31.91
+CI,Chile,US4964400,Florida-South,Peak,$32.60,$37.65
+CI,Chile,US4965500,Florida Keys,NonPeak,$29.28,$44.74
+CI,Chile,US4965500,Florida Keys,Peak,$34.55,$52.79
+CI,Chile,US50,Minnesota,NonPeak,$30.90,$34.56
+CI,Chile,US50,Minnesota,Peak,$36.46,$40.78
+CI,Chile,US51,North Dakota,NonPeak,$15.28,$32.09
+CI,Chile,US51,North Dakota,Peak,$18.03,$37.87
+CI,Chile,US52,South Dakota,NonPeak,$16.05,$44.91
+CI,Chile,US52,South Dakota,Peak,$18.94,$52.99
+CI,Chile,US53,Iowa,NonPeak,$16.80,$34.74
+CI,Chile,US53,Iowa,Peak,$19.82,$40.99
+CI,Chile,US55,Nebraska,NonPeak,$17.57,$32.26
+CI,Chile,US55,Nebraska,Peak,$20.73,$38.07
+CI,Chile,US56,Missouri,NonPeak,$18.33,$45.09
+CI,Chile,US56,Missouri,Peak,$21.63,$53.21
+CI,Chile,US58,Kansas,NonPeak,$24.38,$34.90
+CI,Chile,US58,Kansas,Peak,$28.77,$41.18
+CI,Chile,US60,Arkansas,NonPeak,$16.00,$32.44
+CI,Chile,US60,Arkansas,Peak,$18.88,$38.28
+CI,Chile,US62,Oklahoma,NonPeak,$27.63,$43.94
+CI,Chile,US62,Oklahoma,Peak,$32.60,$51.85
+CI,Chile,US64,Louisiana,NonPeak,$29.28,$33.70
+CI,Chile,US64,Louisiana,Peak,$34.55,$39.77
+CI,Chile,US66,Texas-North,NonPeak,$30.90,$31.29
+CI,Chile,US66,Texas-North,Peak,$36.46,$36.92
+CI,Chile,US68,Texas-South,NonPeak,$15.28,$44.05
+CI,Chile,US68,Texas-South,Peak,$18.03,$51.98
+CI,Chile,US70,Montana,NonPeak,$16.05,$33.75
+CI,Chile,US70,Montana,Peak,$18.94,$39.82
+CI,Chile,US72,Wyoming,NonPeak,$16.80,$31.40
+CI,Chile,US72,Wyoming,Peak,$19.82,$37.05
+CI,Chile,US74,Colorado,NonPeak,$17.57,$44.17
+CI,Chile,US74,Colorado,Peak,$20.73,$52.12
+CI,Chile,US76,Utah,NonPeak,$18.33,$33.98
+CI,Chile,US76,Utah,Peak,$21.63,$40.10
+CI,Chile,US77,New Mexico,NonPeak,$24.38,$31.45
+CI,Chile,US77,New Mexico,Peak,$28.77,$37.11
+CI,Chile,US79,Arizona,NonPeak,$16.00,$44.28
+CI,Chile,US79,Arizona,Peak,$18.88,$52.25
+CI,Chile,US83,Idaho,NonPeak,$27.63,$34.11
+CI,Chile,US83,Idaho,Peak,$32.60,$40.25
+CI,Chile,US84,Washington,NonPeak,$29.28,$31.63
+CI,Chile,US84,Washington,Peak,$34.55,$37.32
+CI,Chile,US85,Oregon,NonPeak,$30.90,$44.51
+CI,Chile,US85,Oregon,Peak,$36.46,$52.52
+CI,Chile,US86,Nevada,NonPeak,$15.28,$34.33
+CI,Chile,US86,Nevada,Peak,$18.03,$40.51
+CI,Chile,US87,California-North,NonPeak,$16.05,$31.74
+CI,Chile,US87,California-North,Peak,$18.94,$37.45
+CI,Chile,US88,California-South,NonPeak,$16.80,$44.62
+CI,Chile,US88,California-South,Peak,$19.82,$52.65
+CO,Colombia,US11,Maine,NonPeak,$17.57,$34.45
+CO,Colombia,US11,Maine,Peak,$20.73,$40.65
+CO,Colombia,US12,New Hampshire,NonPeak,$18.33,$31.91
+CO,Colombia,US12,New Hampshire,Peak,$21.63,$37.65
+CO,Colombia,US13,Vermont,NonPeak,$24.38,$44.74
+CO,Colombia,US13,Vermont,Peak,$28.77,$52.79
+CO,Colombia,US14,Massachusetts,NonPeak,$16.00,$34.56
+CO,Colombia,US14,Massachusetts,Peak,$18.88,$40.78
+CO,Colombia,US15,Rhode Island,NonPeak,$27.63,$32.09
+CO,Colombia,US15,Rhode Island,Peak,$32.60,$37.87
+CO,Colombia,US16,Connecticut,NonPeak,$29.28,$44.91
+CO,Colombia,US16,Connecticut,Peak,$34.55,$52.99
+CO,Colombia,US17,New York,NonPeak,$30.90,$34.74
+CO,Colombia,US17,New York,Peak,$36.46,$40.99
+CO,Colombia,US19,New Jersey,NonPeak,$15.28,$32.26
+CO,Colombia,US19,New Jersey,Peak,$18.03,$38.07
+CO,Colombia,US20,Pennsylvania,NonPeak,$16.05,$45.09
+CO,Colombia,US20,Pennsylvania,Peak,$18.94,$53.21
+CO,Colombia,US22,Delaware,NonPeak,$16.80,$34.90
+CO,Colombia,US22,Delaware,Peak,$19.82,$41.18
+CO,Colombia,US23,Maryland,NonPeak,$17.57,$32.44
+CO,Colombia,US23,Maryland,Peak,$20.73,$38.28
+CO,Colombia,US24,District Of Columbia,NonPeak,$18.33,$43.94
+CO,Colombia,US24,District Of Columbia,Peak,$21.63,$51.85
+CO,Colombia,US25,Virginia,NonPeak,$24.38,$33.70
+CO,Colombia,US25,Virginia,Peak,$28.77,$39.77
+CO,Colombia,US27,West Virginia,NonPeak,$16.00,$31.29
+CO,Colombia,US27,West Virginia,Peak,$18.88,$36.92
+CO,Colombia,US28,Kentucky,NonPeak,$27.63,$44.05
+CO,Colombia,US28,Kentucky,Peak,$32.60,$51.98
+CO,Colombia,US30,Michigan,NonPeak,$29.28,$33.75
+CO,Colombia,US30,Michigan,Peak,$34.55,$39.82
+CO,Colombia,US32,Wisconsin,NonPeak,$30.90,$31.40
+CO,Colombia,US32,Wisconsin,Peak,$36.46,$37.05
+CO,Colombia,US34,Ohio,NonPeak,$15.28,$44.17
+CO,Colombia,US34,Ohio,Peak,$18.03,$52.12
+CO,Colombia,US36,Indiana,NonPeak,$16.05,$33.98
+CO,Colombia,US36,Indiana,Peak,$18.94,$40.10
+CO,Colombia,US38,Illinois,NonPeak,$16.80,$31.45
+CO,Colombia,US38,Illinois,Peak,$19.82,$37.11
+CO,Colombia,US40,North Carolina,NonPeak,$17.57,$44.28
+CO,Colombia,US40,North Carolina,Peak,$20.73,$52.25
+CO,Colombia,US42,Tennessee,NonPeak,$18.33,$34.11
+CO,Colombia,US42,Tennessee,Peak,$21.63,$40.25
+CO,Colombia,US44,South Carolina,NonPeak,$24.38,$31.63
+CO,Colombia,US44,South Carolina,Peak,$28.77,$37.32
+CO,Colombia,US45,Georgia,NonPeak,$16.00,$44.51
+CO,Colombia,US45,Georgia,Peak,$18.88,$52.52
+CO,Colombia,US47,Alabama,NonPeak,$27.63,$34.33
+CO,Colombia,US47,Alabama,Peak,$32.60,$40.51
+CO,Colombia,US48,Mississippi,NonPeak,$29.28,$31.74
+CO,Colombia,US48,Mississippi,Peak,$34.55,$37.45
+CO,Colombia,US49,Florida-North,NonPeak,$30.90,$44.62
+CO,Colombia,US49,Florida-North,Peak,$36.46,$52.65
+CO,Colombia,US4964400,Florida-South,NonPeak,$15.28,$34.45
+CO,Colombia,US4964400,Florida-South,Peak,$18.03,$40.65
+CO,Colombia,US4965500,Florida Keys,NonPeak,$16.05,$31.91
+CO,Colombia,US4965500,Florida Keys,Peak,$18.94,$37.65
+CO,Colombia,US50,Minnesota,NonPeak,$16.80,$44.74
+CO,Colombia,US50,Minnesota,Peak,$19.82,$52.79
+CO,Colombia,US51,North Dakota,NonPeak,$17.57,$34.56
+CO,Colombia,US51,North Dakota,Peak,$20.73,$40.78
+CO,Colombia,US52,South Dakota,NonPeak,$18.33,$32.09
+CO,Colombia,US52,South Dakota,Peak,$21.63,$37.87
+CO,Colombia,US53,Iowa,NonPeak,$24.38,$44.91
+CO,Colombia,US53,Iowa,Peak,$28.77,$52.99
+CO,Colombia,US55,Nebraska,NonPeak,$16.00,$34.74
+CO,Colombia,US55,Nebraska,Peak,$18.88,$40.99
+CO,Colombia,US56,Missouri,NonPeak,$27.63,$32.26
+CO,Colombia,US56,Missouri,Peak,$32.60,$38.07
+CO,Colombia,US58,Kansas,NonPeak,$29.28,$45.09
+CO,Colombia,US58,Kansas,Peak,$34.55,$53.21
+CO,Colombia,US60,Arkansas,NonPeak,$30.90,$34.90
+CO,Colombia,US60,Arkansas,Peak,$36.46,$41.18
+CO,Colombia,US62,Oklahoma,NonPeak,$15.28,$32.44
+CO,Colombia,US62,Oklahoma,Peak,$18.03,$38.28
+CO,Colombia,US64,Louisiana,NonPeak,$16.05,$43.94
+CO,Colombia,US64,Louisiana,Peak,$18.94,$51.85
+CO,Colombia,US66,Texas-North,NonPeak,$16.80,$33.70
+CO,Colombia,US66,Texas-North,Peak,$19.82,$39.77
+CO,Colombia,US68,Texas-South,NonPeak,$17.57,$31.29
+CO,Colombia,US68,Texas-South,Peak,$20.73,$36.92
+CO,Colombia,US70,Montana,NonPeak,$18.33,$44.05
+CO,Colombia,US70,Montana,Peak,$21.63,$51.98
+CO,Colombia,US72,Wyoming,NonPeak,$24.38,$33.75
+CO,Colombia,US72,Wyoming,Peak,$28.77,$39.82
+CO,Colombia,US74,Colorado,NonPeak,$16.00,$31.40
+CO,Colombia,US74,Colorado,Peak,$18.88,$37.05
+CO,Colombia,US76,Utah,NonPeak,$27.63,$44.17
+CO,Colombia,US76,Utah,Peak,$32.60,$52.12
+CO,Colombia,US77,New Mexico,NonPeak,$29.28,$33.98
+CO,Colombia,US77,New Mexico,Peak,$34.55,$40.10
+CO,Colombia,US79,Arizona,NonPeak,$30.90,$31.45
+CO,Colombia,US79,Arizona,Peak,$36.46,$37.11
+CO,Colombia,US83,Idaho,NonPeak,$15.28,$44.28
+CO,Colombia,US83,Idaho,Peak,$18.03,$52.25
+CO,Colombia,US84,Washington,NonPeak,$16.05,$34.11
+CO,Colombia,US84,Washington,Peak,$18.94,$40.25
+CO,Colombia,US85,Oregon,NonPeak,$16.80,$31.63
+CO,Colombia,US85,Oregon,Peak,$19.82,$37.32
+CO,Colombia,US86,Nevada,NonPeak,$17.57,$44.51
+CO,Colombia,US86,Nevada,Peak,$20.73,$52.52
+CO,Colombia,US87,California-North,NonPeak,$18.33,$34.33
+CO,Colombia,US87,California-North,Peak,$21.63,$40.51
+CO,Colombia,US88,California-South,NonPeak,$24.38,$31.74
+CO,Colombia,US88,California-South,Peak,$28.77,$37.45
+CS,Costa Rica,US11,Maine,NonPeak,$16.00,$44.62
+CS,Costa Rica,US11,Maine,Peak,$18.88,$52.65
+CS,Costa Rica,US12,New Hampshire,NonPeak,$27.63,$34.45
+CS,Costa Rica,US12,New Hampshire,Peak,$32.60,$40.65
+CS,Costa Rica,US13,Vermont,NonPeak,$29.28,$31.91
+CS,Costa Rica,US13,Vermont,Peak,$34.55,$37.65
+CS,Costa Rica,US14,Massachusetts,NonPeak,$30.90,$44.74
+CS,Costa Rica,US14,Massachusetts,Peak,$36.46,$52.79
+CS,Costa Rica,US15,Rhode Island,NonPeak,$15.28,$34.56
+CS,Costa Rica,US15,Rhode Island,Peak,$18.03,$40.78
+CS,Costa Rica,US16,Connecticut,NonPeak,$16.05,$32.09
+CS,Costa Rica,US16,Connecticut,Peak,$18.94,$37.87
+CS,Costa Rica,US17,New York,NonPeak,$16.80,$44.91
+CS,Costa Rica,US17,New York,Peak,$19.82,$52.99
+CS,Costa Rica,US19,New Jersey,NonPeak,$17.57,$34.74
+CS,Costa Rica,US19,New Jersey,Peak,$20.73,$40.99
+CS,Costa Rica,US20,Pennsylvania,NonPeak,$18.33,$32.26
+CS,Costa Rica,US20,Pennsylvania,Peak,$21.63,$38.07
+CS,Costa Rica,US22,Delaware,NonPeak,$24.38,$45.09
+CS,Costa Rica,US22,Delaware,Peak,$28.77,$53.21
+CS,Costa Rica,US23,Maryland,NonPeak,$16.00,$34.90
+CS,Costa Rica,US23,Maryland,Peak,$18.88,$41.18
+CS,Costa Rica,US24,District Of Columbia,NonPeak,$27.63,$32.44
+CS,Costa Rica,US24,District Of Columbia,Peak,$32.60,$38.28
+CS,Costa Rica,US25,Virginia,NonPeak,$29.28,$43.94
+CS,Costa Rica,US25,Virginia,Peak,$34.55,$51.85
+CS,Costa Rica,US27,West Virginia,NonPeak,$30.90,$33.70
+CS,Costa Rica,US27,West Virginia,Peak,$36.46,$39.77
+CS,Costa Rica,US28,Kentucky,NonPeak,$15.28,$31.29
+CS,Costa Rica,US28,Kentucky,Peak,$18.03,$36.92
+CS,Costa Rica,US30,Michigan,NonPeak,$16.05,$44.05
+CS,Costa Rica,US30,Michigan,Peak,$18.94,$51.98
+CS,Costa Rica,US32,Wisconsin,NonPeak,$16.80,$33.75
+CS,Costa Rica,US32,Wisconsin,Peak,$19.82,$39.82
+CS,Costa Rica,US34,Ohio,NonPeak,$17.57,$31.40
+CS,Costa Rica,US34,Ohio,Peak,$20.73,$37.05
+CS,Costa Rica,US36,Indiana,NonPeak,$18.33,$44.17
+CS,Costa Rica,US36,Indiana,Peak,$21.63,$52.12
+CS,Costa Rica,US38,Illinois,NonPeak,$24.38,$33.98
+CS,Costa Rica,US38,Illinois,Peak,$28.77,$40.10
+CS,Costa Rica,US40,North Carolina,NonPeak,$16.00,$31.45
+CS,Costa Rica,US40,North Carolina,Peak,$18.88,$37.11
+CS,Costa Rica,US42,Tennessee,NonPeak,$27.63,$44.28
+CS,Costa Rica,US42,Tennessee,Peak,$32.60,$52.25
+CS,Costa Rica,US44,South Carolina,NonPeak,$29.28,$34.11
+CS,Costa Rica,US44,South Carolina,Peak,$34.55,$40.25
+CS,Costa Rica,US45,Georgia,NonPeak,$30.90,$31.63
+CS,Costa Rica,US45,Georgia,Peak,$36.46,$37.32
+CS,Costa Rica,US47,Alabama,NonPeak,$15.28,$44.51
+CS,Costa Rica,US47,Alabama,Peak,$18.03,$52.52
+CS,Costa Rica,US48,Mississippi,NonPeak,$16.05,$34.33
+CS,Costa Rica,US48,Mississippi,Peak,$18.94,$40.51
+CS,Costa Rica,US49,Florida-North,NonPeak,$16.80,$31.74
+CS,Costa Rica,US49,Florida-North,Peak,$19.82,$37.45
+CS,Costa Rica,US4964400,Florida-South,NonPeak,$17.57,$44.62
+CS,Costa Rica,US4964400,Florida-South,Peak,$20.73,$52.65
+CS,Costa Rica,US4965500,Florida Keys,NonPeak,$18.33,$34.45
+CS,Costa Rica,US4965500,Florida Keys,Peak,$21.63,$40.65
+CS,Costa Rica,US50,Minnesota,NonPeak,$24.38,$31.91
+CS,Costa Rica,US50,Minnesota,Peak,$28.77,$37.65
+CS,Costa Rica,US51,North Dakota,NonPeak,$16.00,$44.74
+CS,Costa Rica,US51,North Dakota,Peak,$18.88,$52.79
+CS,Costa Rica,US52,South Dakota,NonPeak,$27.63,$34.56
+CS,Costa Rica,US52,South Dakota,Peak,$32.60,$40.78
+CS,Costa Rica,US53,Iowa,NonPeak,$29.28,$32.09
+CS,Costa Rica,US53,Iowa,Peak,$34.55,$37.87
+CS,Costa Rica,US55,Nebraska,NonPeak,$30.90,$44.91
+CS,Costa Rica,US55,Nebraska,Peak,$36.46,$52.99
+CS,Costa Rica,US56,Missouri,NonPeak,$15.28,$34.74
+CS,Costa Rica,US56,Missouri,Peak,$18.03,$40.99
+CS,Costa Rica,US58,Kansas,NonPeak,$16.05,$32.26
+CS,Costa Rica,US58,Kansas,Peak,$18.94,$38.07
+CS,Costa Rica,US60,Arkansas,NonPeak,$16.80,$45.09
+CS,Costa Rica,US60,Arkansas,Peak,$19.82,$53.21
+CS,Costa Rica,US62,Oklahoma,NonPeak,$17.57,$34.90
+CS,Costa Rica,US62,Oklahoma,Peak,$20.73,$41.18
+CS,Costa Rica,US64,Louisiana,NonPeak,$18.33,$32.44
+CS,Costa Rica,US64,Louisiana,Peak,$21.63,$38.28
+CS,Costa Rica,US66,Texas-North,NonPeak,$24.38,$43.94
+CS,Costa Rica,US66,Texas-North,Peak,$28.77,$51.85
+CS,Costa Rica,US68,Texas-South,NonPeak,$16.00,$33.70
+CS,Costa Rica,US68,Texas-South,Peak,$18.88,$39.77
+CS,Costa Rica,US70,Montana,NonPeak,$27.63,$31.29
+CS,Costa Rica,US70,Montana,Peak,$32.60,$36.92
+CS,Costa Rica,US72,Wyoming,NonPeak,$29.28,$44.05
+CS,Costa Rica,US72,Wyoming,Peak,$34.55,$51.98
+CS,Costa Rica,US74,Colorado,NonPeak,$30.90,$33.75
+CS,Costa Rica,US74,Colorado,Peak,$36.46,$39.82
+CS,Costa Rica,US76,Utah,NonPeak,$15.28,$31.40
+CS,Costa Rica,US76,Utah,Peak,$18.03,$37.05
+CS,Costa Rica,US77,New Mexico,NonPeak,$16.05,$44.17
+CS,Costa Rica,US77,New Mexico,Peak,$18.94,$52.12
+CS,Costa Rica,US79,Arizona,NonPeak,$16.80,$33.98
+CS,Costa Rica,US79,Arizona,Peak,$19.82,$40.10
+CS,Costa Rica,US83,Idaho,NonPeak,$17.57,$31.45
+CS,Costa Rica,US83,Idaho,Peak,$20.73,$37.11
+CS,Costa Rica,US84,Washington,NonPeak,$18.33,$44.28
+CS,Costa Rica,US84,Washington,Peak,$21.63,$52.25
+CS,Costa Rica,US85,Oregon,NonPeak,$24.38,$34.11
+CS,Costa Rica,US85,Oregon,Peak,$28.77,$40.25
+CS,Costa Rica,US86,Nevada,NonPeak,$16.00,$31.63
+CS,Costa Rica,US86,Nevada,Peak,$18.88,$37.32
+CS,Costa Rica,US87,California-North,NonPeak,$27.63,$44.51
+CS,Costa Rica,US87,California-North,Peak,$32.60,$52.52
+CS,Costa Rica,US88,California-South,NonPeak,$29.28,$34.33
+CS,Costa Rica,US88,California-South,Peak,$34.55,$40.51
+EC,Ecuador,US11,Maine,NonPeak,$30.90,$31.74
+EC,Ecuador,US11,Maine,Peak,$36.46,$37.45
+EC,Ecuador,US12,New Hampshire,NonPeak,$15.28,$44.62
+EC,Ecuador,US12,New Hampshire,Peak,$18.03,$52.65
+EC,Ecuador,US13,Vermont,NonPeak,$16.05,$34.45
+EC,Ecuador,US13,Vermont,Peak,$18.94,$40.65
+EC,Ecuador,US14,Massachusetts,NonPeak,$16.80,$31.91
+EC,Ecuador,US14,Massachusetts,Peak,$19.82,$37.65
+EC,Ecuador,US15,Rhode Island,NonPeak,$17.57,$44.74
+EC,Ecuador,US15,Rhode Island,Peak,$20.73,$52.79
+EC,Ecuador,US16,Connecticut,NonPeak,$18.33,$34.56
+EC,Ecuador,US16,Connecticut,Peak,$21.63,$40.78
+EC,Ecuador,US17,New York,NonPeak,$24.38,$32.09
+EC,Ecuador,US17,New York,Peak,$28.77,$37.87
+EC,Ecuador,US19,New Jersey,NonPeak,$16.00,$44.91
+EC,Ecuador,US19,New Jersey,Peak,$18.88,$52.99
+EC,Ecuador,US20,Pennsylvania,NonPeak,$27.63,$34.74
+EC,Ecuador,US20,Pennsylvania,Peak,$32.60,$40.99
+EC,Ecuador,US22,Delaware,NonPeak,$29.28,$32.26
+EC,Ecuador,US22,Delaware,Peak,$34.55,$38.07
+EC,Ecuador,US23,Maryland,NonPeak,$30.90,$45.09
+EC,Ecuador,US23,Maryland,Peak,$36.46,$53.21
+EC,Ecuador,US24,District Of Columbia,NonPeak,$15.28,$34.90
+EC,Ecuador,US24,District Of Columbia,Peak,$18.03,$41.18
+EC,Ecuador,US25,Virginia,NonPeak,$16.05,$32.44
+EC,Ecuador,US25,Virginia,Peak,$18.94,$38.28
+EC,Ecuador,US27,West Virginia,NonPeak,$16.80,$43.94
+EC,Ecuador,US27,West Virginia,Peak,$19.82,$51.85
+EC,Ecuador,US28,Kentucky,NonPeak,$17.57,$33.70
+EC,Ecuador,US28,Kentucky,Peak,$20.73,$39.77
+EC,Ecuador,US30,Michigan,NonPeak,$18.33,$31.29
+EC,Ecuador,US30,Michigan,Peak,$21.63,$36.92
+EC,Ecuador,US32,Wisconsin,NonPeak,$24.38,$44.05
+EC,Ecuador,US32,Wisconsin,Peak,$28.77,$51.98
+EC,Ecuador,US34,Ohio,NonPeak,$16.00,$33.75
+EC,Ecuador,US34,Ohio,Peak,$18.88,$39.82
+EC,Ecuador,US36,Indiana,NonPeak,$27.63,$31.40
+EC,Ecuador,US36,Indiana,Peak,$32.60,$37.05
+EC,Ecuador,US38,Illinois,NonPeak,$29.28,$44.17
+EC,Ecuador,US38,Illinois,Peak,$34.55,$52.12
+EC,Ecuador,US40,North Carolina,NonPeak,$30.90,$33.98
+EC,Ecuador,US40,North Carolina,Peak,$36.46,$40.10
+EC,Ecuador,US42,Tennessee,NonPeak,$15.28,$31.45
+EC,Ecuador,US42,Tennessee,Peak,$18.03,$37.11
+EC,Ecuador,US44,South Carolina,NonPeak,$16.05,$44.28
+EC,Ecuador,US44,South Carolina,Peak,$18.94,$52.25
+EC,Ecuador,US45,Georgia,NonPeak,$16.80,$34.11
+EC,Ecuador,US45,Georgia,Peak,$19.82,$40.25
+EC,Ecuador,US47,Alabama,NonPeak,$17.57,$31.63
+EC,Ecuador,US47,Alabama,Peak,$20.73,$37.32
+EC,Ecuador,US48,Mississippi,NonPeak,$18.33,$44.51
+EC,Ecuador,US48,Mississippi,Peak,$21.63,$52.52
+EC,Ecuador,US49,Florida-North,NonPeak,$24.38,$34.33
+EC,Ecuador,US49,Florida-North,Peak,$28.77,$40.51
+EC,Ecuador,US4964400,Florida-South,NonPeak,$16.00,$31.74
+EC,Ecuador,US4964400,Florida-South,Peak,$18.88,$37.45
+EC,Ecuador,US4965500,Florida Keys,NonPeak,$27.63,$44.62
+EC,Ecuador,US4965500,Florida Keys,Peak,$32.60,$52.65
+EC,Ecuador,US50,Minnesota,NonPeak,$29.28,$34.45
+EC,Ecuador,US50,Minnesota,Peak,$34.55,$40.65
+EC,Ecuador,US51,North Dakota,NonPeak,$30.90,$31.91
+EC,Ecuador,US51,North Dakota,Peak,$36.46,$37.65
+EC,Ecuador,US52,South Dakota,NonPeak,$15.28,$44.74
+EC,Ecuador,US52,South Dakota,Peak,$18.03,$52.79
+EC,Ecuador,US53,Iowa,NonPeak,$16.05,$34.56
+EC,Ecuador,US53,Iowa,Peak,$18.94,$40.78
+EC,Ecuador,US55,Nebraska,NonPeak,$16.80,$32.09
+EC,Ecuador,US55,Nebraska,Peak,$19.82,$37.87
+EC,Ecuador,US56,Missouri,NonPeak,$17.57,$44.91
+EC,Ecuador,US56,Missouri,Peak,$20.73,$52.99
+EC,Ecuador,US58,Kansas,NonPeak,$18.33,$34.74
+EC,Ecuador,US58,Kansas,Peak,$21.63,$40.99
+EC,Ecuador,US60,Arkansas,NonPeak,$24.38,$32.26
+EC,Ecuador,US60,Arkansas,Peak,$28.77,$38.07
+EC,Ecuador,US62,Oklahoma,NonPeak,$16.00,$45.09
+EC,Ecuador,US62,Oklahoma,Peak,$18.88,$53.21
+EC,Ecuador,US64,Louisiana,NonPeak,$27.63,$34.90
+EC,Ecuador,US64,Louisiana,Peak,$32.60,$41.18
+EC,Ecuador,US66,Texas-North,NonPeak,$29.28,$32.44
+EC,Ecuador,US66,Texas-North,Peak,$34.55,$38.28
+EC,Ecuador,US68,Texas-South,NonPeak,$30.90,$43.94
+EC,Ecuador,US68,Texas-South,Peak,$36.46,$51.85
+EC,Ecuador,US70,Montana,NonPeak,$15.28,$33.70
+EC,Ecuador,US70,Montana,Peak,$18.03,$39.77
+EC,Ecuador,US72,Wyoming,NonPeak,$16.05,$31.29
+EC,Ecuador,US72,Wyoming,Peak,$18.94,$36.92
+EC,Ecuador,US74,Colorado,NonPeak,$16.80,$44.05
+EC,Ecuador,US74,Colorado,Peak,$19.82,$51.98
+EC,Ecuador,US76,Utah,NonPeak,$17.57,$33.75
+EC,Ecuador,US76,Utah,Peak,$20.73,$39.82
+EC,Ecuador,US77,New Mexico,NonPeak,$18.33,$31.40
+EC,Ecuador,US77,New Mexico,Peak,$21.63,$37.05
+EC,Ecuador,US79,Arizona,NonPeak,$24.38,$44.17
+EC,Ecuador,US79,Arizona,Peak,$28.77,$52.12
+EC,Ecuador,US83,Idaho,NonPeak,$16.00,$33.98
+EC,Ecuador,US83,Idaho,Peak,$18.88,$40.10
+EC,Ecuador,US84,Washington,NonPeak,$27.63,$31.45
+EC,Ecuador,US84,Washington,Peak,$32.60,$37.11
+EC,Ecuador,US85,Oregon,NonPeak,$29.28,$44.28
+EC,Ecuador,US85,Oregon,Peak,$34.55,$52.25
+EC,Ecuador,US86,Nevada,NonPeak,$30.90,$34.11
+EC,Ecuador,US86,Nevada,Peak,$36.46,$40.25
+EC,Ecuador,US87,California-North,NonPeak,$15.28,$31.63
+EC,Ecuador,US87,California-North,Peak,$18.03,$37.32
+EC,Ecuador,US88,California-South,NonPeak,$16.05,$44.51
+EC,Ecuador,US88,California-South,Peak,$18.94,$52.52
+ES,El Salvador,US11,Maine,NonPeak,$16.80,$34.33
+ES,El Salvador,US11,Maine,Peak,$19.82,$40.51
+ES,El Salvador,US12,New Hampshire,NonPeak,$17.57,$31.74
+ES,El Salvador,US12,New Hampshire,Peak,$20.73,$37.45
+ES,El Salvador,US13,Vermont,NonPeak,$18.33,$44.62
+ES,El Salvador,US13,Vermont,Peak,$21.63,$52.65
+ES,El Salvador,US14,Massachusetts,NonPeak,$24.38,$34.45
+ES,El Salvador,US14,Massachusetts,Peak,$28.77,$40.65
+ES,El Salvador,US15,Rhode Island,NonPeak,$16.00,$31.91
+ES,El Salvador,US15,Rhode Island,Peak,$18.88,$37.65
+ES,El Salvador,US16,Connecticut,NonPeak,$27.63,$44.74
+ES,El Salvador,US16,Connecticut,Peak,$32.60,$52.79
+ES,El Salvador,US17,New York,NonPeak,$29.28,$34.56
+ES,El Salvador,US17,New York,Peak,$34.55,$40.78
+ES,El Salvador,US19,New Jersey,NonPeak,$30.90,$32.09
+ES,El Salvador,US19,New Jersey,Peak,$36.46,$37.87
+ES,El Salvador,US20,Pennsylvania,NonPeak,$15.28,$44.91
+ES,El Salvador,US20,Pennsylvania,Peak,$18.03,$52.99
+ES,El Salvador,US22,Delaware,NonPeak,$16.05,$34.74
+ES,El Salvador,US22,Delaware,Peak,$18.94,$40.99
+ES,El Salvador,US23,Maryland,NonPeak,$16.80,$32.26
+ES,El Salvador,US23,Maryland,Peak,$19.82,$38.07
+ES,El Salvador,US24,District Of Columbia,NonPeak,$17.57,$45.09
+ES,El Salvador,US24,District Of Columbia,Peak,$20.73,$53.21
+ES,El Salvador,US25,Virginia,NonPeak,$18.33,$34.90
+ES,El Salvador,US25,Virginia,Peak,$21.63,$41.18
+ES,El Salvador,US27,West Virginia,NonPeak,$24.38,$32.44
+ES,El Salvador,US27,West Virginia,Peak,$28.77,$38.28
+ES,El Salvador,US28,Kentucky,NonPeak,$16.00,$43.94
+ES,El Salvador,US28,Kentucky,Peak,$18.88,$51.85
+ES,El Salvador,US30,Michigan,NonPeak,$27.63,$33.70
+ES,El Salvador,US30,Michigan,Peak,$32.60,$39.77
+ES,El Salvador,US32,Wisconsin,NonPeak,$29.28,$31.29
+ES,El Salvador,US32,Wisconsin,Peak,$34.55,$36.92
+ES,El Salvador,US34,Ohio,NonPeak,$30.90,$44.05
+ES,El Salvador,US34,Ohio,Peak,$36.46,$51.98
+ES,El Salvador,US36,Indiana,NonPeak,$15.28,$33.75
+ES,El Salvador,US36,Indiana,Peak,$18.03,$39.82
+ES,El Salvador,US38,Illinois,NonPeak,$16.05,$31.40
+ES,El Salvador,US38,Illinois,Peak,$18.94,$37.05
+ES,El Salvador,US40,North Carolina,NonPeak,$16.80,$44.17
+ES,El Salvador,US40,North Carolina,Peak,$19.82,$52.12
+ES,El Salvador,US42,Tennessee,NonPeak,$17.57,$33.98
+ES,El Salvador,US42,Tennessee,Peak,$20.73,$40.10
+ES,El Salvador,US44,South Carolina,NonPeak,$18.33,$31.45
+ES,El Salvador,US44,South Carolina,Peak,$21.63,$37.11
+ES,El Salvador,US45,Georgia,NonPeak,$24.38,$44.28
+ES,El Salvador,US45,Georgia,Peak,$28.77,$52.25
+ES,El Salvador,US47,Alabama,NonPeak,$16.00,$34.11
+ES,El Salvador,US47,Alabama,Peak,$18.88,$40.25
+ES,El Salvador,US48,Mississippi,NonPeak,$27.63,$31.63
+ES,El Salvador,US48,Mississippi,Peak,$32.60,$37.32
+ES,El Salvador,US49,Florida-North,NonPeak,$29.28,$44.51
+ES,El Salvador,US49,Florida-North,Peak,$34.55,$52.52
+ES,El Salvador,US4964400,Florida-South,NonPeak,$30.90,$34.33
+ES,El Salvador,US4964400,Florida-South,Peak,$36.46,$40.51
+ES,El Salvador,US4965500,Florida Keys,NonPeak,$15.28,$31.74
+ES,El Salvador,US4965500,Florida Keys,Peak,$18.03,$37.45
+ES,El Salvador,US50,Minnesota,NonPeak,$16.05,$44.62
+ES,El Salvador,US50,Minnesota,Peak,$18.94,$52.65
+ES,El Salvador,US51,North Dakota,NonPeak,$16.80,$34.45
+ES,El Salvador,US51,North Dakota,Peak,$19.82,$40.65
+ES,El Salvador,US52,South Dakota,NonPeak,$17.57,$31.91
+ES,El Salvador,US52,South Dakota,Peak,$20.73,$37.65
+ES,El Salvador,US53,Iowa,NonPeak,$18.33,$44.74
+ES,El Salvador,US53,Iowa,Peak,$21.63,$52.79
+ES,El Salvador,US55,Nebraska,NonPeak,$24.38,$34.56
+ES,El Salvador,US55,Nebraska,Peak,$28.77,$40.78
+ES,El Salvador,US56,Missouri,NonPeak,$16.00,$32.09
+ES,El Salvador,US56,Missouri,Peak,$18.88,$37.87
+ES,El Salvador,US58,Kansas,NonPeak,$27.63,$44.91
+ES,El Salvador,US58,Kansas,Peak,$32.60,$52.99
+ES,El Salvador,US60,Arkansas,NonPeak,$29.28,$34.74
+ES,El Salvador,US60,Arkansas,Peak,$34.55,$40.99
+ES,El Salvador,US62,Oklahoma,NonPeak,$30.90,$32.26
+ES,El Salvador,US62,Oklahoma,Peak,$36.46,$38.07
+ES,El Salvador,US64,Louisiana,NonPeak,$15.28,$45.09
+ES,El Salvador,US64,Louisiana,Peak,$18.03,$53.21
+ES,El Salvador,US66,Texas-North,NonPeak,$16.05,$34.90
+ES,El Salvador,US66,Texas-North,Peak,$18.94,$41.18
+ES,El Salvador,US68,Texas-South,NonPeak,$16.80,$32.44
+ES,El Salvador,US68,Texas-South,Peak,$19.82,$38.28
+ES,El Salvador,US70,Montana,NonPeak,$17.57,$43.94
+ES,El Salvador,US70,Montana,Peak,$20.73,$51.85
+ES,El Salvador,US72,Wyoming,NonPeak,$18.33,$33.70
+ES,El Salvador,US72,Wyoming,Peak,$21.63,$39.77
+ES,El Salvador,US74,Colorado,NonPeak,$24.38,$31.29
+ES,El Salvador,US74,Colorado,Peak,$28.77,$36.92
+ES,El Salvador,US76,Utah,NonPeak,$16.00,$44.05
+ES,El Salvador,US76,Utah,Peak,$18.88,$51.98
+ES,El Salvador,US77,New Mexico,NonPeak,$27.63,$33.75
+ES,El Salvador,US77,New Mexico,Peak,$32.60,$39.82
+ES,El Salvador,US79,Arizona,NonPeak,$29.28,$31.40
+ES,El Salvador,US79,Arizona,Peak,$34.55,$37.05
+ES,El Salvador,US83,Idaho,NonPeak,$30.90,$44.17
+ES,El Salvador,US83,Idaho,Peak,$36.46,$52.12
+ES,El Salvador,US84,Washington,NonPeak,$15.28,$33.98
+ES,El Salvador,US84,Washington,Peak,$18.03,$40.10
+ES,El Salvador,US85,Oregon,NonPeak,$16.05,$31.45
+ES,El Salvador,US85,Oregon,Peak,$18.94,$37.11
+ES,El Salvador,US86,Nevada,NonPeak,$16.80,$44.28
+ES,El Salvador,US86,Nevada,Peak,$19.82,$52.25
+ES,El Salvador,US87,California-North,NonPeak,$17.57,$34.11
+ES,El Salvador,US87,California-North,Peak,$20.73,$40.25
+ES,El Salvador,US88,California-South,NonPeak,$18.33,$31.63
+ES,El Salvador,US88,California-South,Peak,$21.63,$37.32
+GE,Germany,US11,Maine,NonPeak,$24.38,$44.51
+GE,Germany,US11,Maine,Peak,$28.77,$52.52
+GE,Germany,US12,New Hampshire,NonPeak,$16.00,$34.33
+GE,Germany,US12,New Hampshire,Peak,$18.88,$40.51
+GE,Germany,US13,Vermont,NonPeak,$27.63,$31.74
+GE,Germany,US13,Vermont,Peak,$32.60,$37.45
+GE,Germany,US14,Massachusetts,NonPeak,$29.28,$44.62
+GE,Germany,US14,Massachusetts,Peak,$34.55,$52.65
+GE,Germany,US15,Rhode Island,NonPeak,$30.90,$34.45
+GE,Germany,US15,Rhode Island,Peak,$36.46,$40.65
+GE,Germany,US16,Connecticut,NonPeak,$15.28,$31.91
+GE,Germany,US16,Connecticut,Peak,$18.03,$37.65
+GE,Germany,US17,New York,NonPeak,$16.05,$44.74
+GE,Germany,US17,New York,Peak,$18.94,$52.79
+GE,Germany,US19,New Jersey,NonPeak,$16.80,$34.56
+GE,Germany,US19,New Jersey,Peak,$19.82,$40.78
+GE,Germany,US20,Pennsylvania,NonPeak,$17.57,$32.09
+GE,Germany,US20,Pennsylvania,Peak,$20.73,$37.87
+GE,Germany,US22,Delaware,NonPeak,$18.33,$44.91
+GE,Germany,US22,Delaware,Peak,$21.63,$52.99
+GE,Germany,US23,Maryland,NonPeak,$24.38,$34.74
+GE,Germany,US23,Maryland,Peak,$28.77,$40.99
+GE,Germany,US24,District Of Columbia,NonPeak,$16.00,$32.26
+GE,Germany,US24,District Of Columbia,Peak,$18.88,$38.07
+GE,Germany,US25,Virginia,NonPeak,$27.63,$45.09
+GE,Germany,US25,Virginia,Peak,$32.60,$53.21
+GE,Germany,US27,West Virginia,NonPeak,$29.28,$34.90
+GE,Germany,US27,West Virginia,Peak,$34.55,$41.18
+GE,Germany,US28,Kentucky,NonPeak,$30.90,$32.44
+GE,Germany,US28,Kentucky,Peak,$36.46,$38.28
+GE,Germany,US30,Michigan,NonPeak,$15.28,$43.94
+GE,Germany,US30,Michigan,Peak,$18.03,$51.85
+GE,Germany,US32,Wisconsin,NonPeak,$16.05,$33.70
+GE,Germany,US32,Wisconsin,Peak,$18.94,$39.77
+GE,Germany,US34,Ohio,NonPeak,$16.80,$31.29
+GE,Germany,US34,Ohio,Peak,$19.82,$36.92
+GE,Germany,US36,Indiana,NonPeak,$17.57,$44.05
+GE,Germany,US36,Indiana,Peak,$20.73,$51.98
+GE,Germany,US38,Illinois,NonPeak,$18.33,$33.75
+GE,Germany,US38,Illinois,Peak,$21.63,$39.82
+GE,Germany,US40,North Carolina,NonPeak,$24.38,$31.40
+GE,Germany,US40,North Carolina,Peak,$28.77,$37.05
+GE,Germany,US42,Tennessee,NonPeak,$16.00,$44.17
+GE,Germany,US42,Tennessee,Peak,$18.88,$52.12
+GE,Germany,US44,South Carolina,NonPeak,$27.63,$33.98
+GE,Germany,US44,South Carolina,Peak,$32.60,$40.10
+GE,Germany,US45,Georgia,NonPeak,$29.28,$31.45
+GE,Germany,US45,Georgia,Peak,$34.55,$37.11
+GE,Germany,US47,Alabama,NonPeak,$30.90,$44.28
+GE,Germany,US47,Alabama,Peak,$36.46,$52.25
+GE,Germany,US48,Mississippi,NonPeak,$15.28,$34.11
+GE,Germany,US48,Mississippi,Peak,$18.03,$40.25
+GE,Germany,US49,Florida-North,NonPeak,$16.05,$31.63
+GE,Germany,US49,Florida-North,Peak,$18.94,$37.32
+GE,Germany,US4964400,Florida-South,NonPeak,$16.80,$44.51
+GE,Germany,US4964400,Florida-South,Peak,$19.82,$52.52
+GE,Germany,US4965500,Florida Keys,NonPeak,$17.57,$34.33
+GE,Germany,US4965500,Florida Keys,Peak,$20.73,$40.51
+GE,Germany,US50,Minnesota,NonPeak,$18.33,$31.74
+GE,Germany,US50,Minnesota,Peak,$21.63,$37.45
+GE,Germany,US51,North Dakota,NonPeak,$24.38,$44.62
+GE,Germany,US51,North Dakota,Peak,$28.77,$52.65
+GE,Germany,US52,South Dakota,NonPeak,$16.00,$34.45
+GE,Germany,US52,South Dakota,Peak,$18.88,$40.65
+GE,Germany,US53,Iowa,NonPeak,$27.63,$31.91
+GE,Germany,US53,Iowa,Peak,$32.60,$37.65
+GE,Germany,US55,Nebraska,NonPeak,$29.28,$44.74
+GE,Germany,US55,Nebraska,Peak,$34.55,$52.79
+GE,Germany,US56,Missouri,NonPeak,$30.90,$34.56
+GE,Germany,US56,Missouri,Peak,$36.46,$40.78
+GE,Germany,US58,Kansas,NonPeak,$15.28,$32.09
+GE,Germany,US58,Kansas,Peak,$18.03,$37.87
+GE,Germany,US60,Arkansas,NonPeak,$16.05,$44.91
+GE,Germany,US60,Arkansas,Peak,$18.94,$52.99
+GE,Germany,US62,Oklahoma,NonPeak,$16.80,$34.74
+GE,Germany,US62,Oklahoma,Peak,$19.82,$40.99
+GE,Germany,US64,Louisiana,NonPeak,$17.57,$32.26
+GE,Germany,US64,Louisiana,Peak,$20.73,$38.07
+GE,Germany,US66,Texas-North,NonPeak,$18.33,$45.09
+GE,Germany,US66,Texas-North,Peak,$21.63,$53.21
+GE,Germany,US68,Texas-South,NonPeak,$24.38,$34.90
+GE,Germany,US68,Texas-South,Peak,$28.77,$41.18
+GE,Germany,US70,Montana,NonPeak,$16.00,$32.44
+GE,Germany,US70,Montana,Peak,$18.88,$38.28
+GE,Germany,US72,Wyoming,NonPeak,$27.63,$43.94
+GE,Germany,US72,Wyoming,Peak,$32.60,$51.85
+GE,Germany,US74,Colorado,NonPeak,$29.28,$33.70
+GE,Germany,US74,Colorado,Peak,$34.55,$39.77
+GE,Germany,US76,Utah,NonPeak,$30.90,$31.29
+GE,Germany,US76,Utah,Peak,$36.46,$36.92
+GE,Germany,US77,New Mexico,NonPeak,$15.28,$44.05
+GE,Germany,US77,New Mexico,Peak,$18.03,$51.98
+GE,Germany,US79,Arizona,NonPeak,$16.05,$33.75
+GE,Germany,US79,Arizona,Peak,$18.94,$39.82
+GE,Germany,US83,Idaho,NonPeak,$16.80,$31.40
+GE,Germany,US83,Idaho,Peak,$19.82,$37.05
+GE,Germany,US84,Washington,NonPeak,$17.57,$44.17
+GE,Germany,US84,Washington,Peak,$20.73,$52.12
+GE,Germany,US85,Oregon,NonPeak,$18.33,$33.98
+GE,Germany,US85,Oregon,Peak,$21.63,$40.10
+GE,Germany,US86,Nevada,NonPeak,$24.38,$31.45
+GE,Germany,US86,Nevada,Peak,$28.77,$37.11
+GE,Germany,US87,California-North,NonPeak,$16.00,$44.28
+GE,Germany,US87,California-North,Peak,$18.88,$52.25
+GE,Germany,US88,California-South,NonPeak,$27.63,$34.11
+GE,Germany,US88,California-South,Peak,$32.60,$40.25
+GQ,Guam,US11,Maine,NonPeak,$29.28,$31.63
+GQ,Guam,US11,Maine,Peak,$34.55,$37.32
+GQ,Guam,US12,New Hampshire,NonPeak,$30.90,$44.51
+GQ,Guam,US12,New Hampshire,Peak,$36.46,$52.52
+GQ,Guam,US13,Vermont,NonPeak,$15.28,$34.33
+GQ,Guam,US13,Vermont,Peak,$18.03,$40.51
+GQ,Guam,US14,Massachusetts,NonPeak,$16.05,$31.74
+GQ,Guam,US14,Massachusetts,Peak,$18.94,$37.45
+GQ,Guam,US15,Rhode Island,NonPeak,$16.80,$44.62
+GQ,Guam,US15,Rhode Island,Peak,$19.82,$52.65
+GQ,Guam,US16,Connecticut,NonPeak,$17.57,$34.45
+GQ,Guam,US16,Connecticut,Peak,$20.73,$40.65
+GQ,Guam,US17,New York,NonPeak,$18.33,$31.91
+GQ,Guam,US17,New York,Peak,$21.63,$37.65
+GQ,Guam,US19,New Jersey,NonPeak,$24.38,$44.74
+GQ,Guam,US19,New Jersey,Peak,$28.77,$52.79
+GQ,Guam,US20,Pennsylvania,NonPeak,$16.00,$34.56
+GQ,Guam,US20,Pennsylvania,Peak,$18.88,$40.78
+GQ,Guam,US22,Delaware,NonPeak,$27.63,$32.09
+GQ,Guam,US22,Delaware,Peak,$32.60,$37.87
+GQ,Guam,US23,Maryland,NonPeak,$29.28,$44.91
+GQ,Guam,US23,Maryland,Peak,$34.55,$52.99
+GQ,Guam,US24,District Of Columbia,NonPeak,$30.90,$34.74
+GQ,Guam,US24,District Of Columbia,Peak,$36.46,$40.99
+GQ,Guam,US25,Virginia,NonPeak,$15.28,$32.26
+GQ,Guam,US25,Virginia,Peak,$18.03,$38.07
+GQ,Guam,US27,West Virginia,NonPeak,$16.05,$45.09
+GQ,Guam,US27,West Virginia,Peak,$18.94,$53.21
+GQ,Guam,US28,Kentucky,NonPeak,$16.80,$34.90
+GQ,Guam,US28,Kentucky,Peak,$19.82,$41.18
+GQ,Guam,US30,Michigan,NonPeak,$17.57,$32.44
+GQ,Guam,US30,Michigan,Peak,$20.73,$38.28
+GQ,Guam,US32,Wisconsin,NonPeak,$18.33,$43.94
+GQ,Guam,US32,Wisconsin,Peak,$21.63,$51.85
+GQ,Guam,US34,Ohio,NonPeak,$24.38,$33.70
+GQ,Guam,US34,Ohio,Peak,$28.77,$39.77
+GQ,Guam,US36,Indiana,NonPeak,$16.00,$31.29
+GQ,Guam,US36,Indiana,Peak,$18.88,$36.92
+GQ,Guam,US38,Illinois,NonPeak,$27.63,$44.05
+GQ,Guam,US38,Illinois,Peak,$32.60,$51.98
+GQ,Guam,US40,North Carolina,NonPeak,$29.28,$33.75
+GQ,Guam,US40,North Carolina,Peak,$34.55,$39.82
+GQ,Guam,US42,Tennessee,NonPeak,$30.90,$31.40
+GQ,Guam,US42,Tennessee,Peak,$36.46,$37.05
+GQ,Guam,US44,South Carolina,NonPeak,$15.28,$44.17
+GQ,Guam,US44,South Carolina,Peak,$18.03,$52.12
+GQ,Guam,US45,Georgia,NonPeak,$16.05,$33.98
+GQ,Guam,US45,Georgia,Peak,$18.94,$40.10
+GQ,Guam,US47,Alabama,NonPeak,$16.80,$31.45
+GQ,Guam,US47,Alabama,Peak,$19.82,$37.11
+GQ,Guam,US48,Mississippi,NonPeak,$17.57,$44.28
+GQ,Guam,US48,Mississippi,Peak,$20.73,$52.25
+GQ,Guam,US49,Florida-North,NonPeak,$18.33,$34.11
+GQ,Guam,US49,Florida-North,Peak,$21.63,$40.25
+GQ,Guam,US4964400,Florida-South,NonPeak,$24.38,$31.63
+GQ,Guam,US4964400,Florida-South,Peak,$28.77,$37.32
+GQ,Guam,US4965500,Florida Keys,NonPeak,$16.00,$44.51
+GQ,Guam,US4965500,Florida Keys,Peak,$18.88,$52.52
+GQ,Guam,US50,Minnesota,NonPeak,$27.63,$34.33
+GQ,Guam,US50,Minnesota,Peak,$32.60,$40.51
+GQ,Guam,US51,North Dakota,NonPeak,$29.28,$31.74
+GQ,Guam,US51,North Dakota,Peak,$34.55,$37.45
+GQ,Guam,US52,South Dakota,NonPeak,$30.90,$44.62
+GQ,Guam,US52,South Dakota,Peak,$36.46,$52.65
+GQ,Guam,US53,Iowa,NonPeak,$15.28,$34.45
+GQ,Guam,US53,Iowa,Peak,$18.03,$40.65
+GQ,Guam,US55,Nebraska,NonPeak,$16.05,$31.91
+GQ,Guam,US55,Nebraska,Peak,$18.94,$37.65
+GQ,Guam,US56,Missouri,NonPeak,$16.80,$44.74
+GQ,Guam,US56,Missouri,Peak,$19.82,$52.79
+GQ,Guam,US58,Kansas,NonPeak,$17.57,$34.56
+GQ,Guam,US58,Kansas,Peak,$20.73,$40.78
+GQ,Guam,US60,Arkansas,NonPeak,$18.33,$32.09
+GQ,Guam,US60,Arkansas,Peak,$21.63,$37.87
+GQ,Guam,US62,Oklahoma,NonPeak,$24.38,$44.91
+GQ,Guam,US62,Oklahoma,Peak,$28.77,$52.99
+GQ,Guam,US64,Louisiana,NonPeak,$16.00,$34.74
+GQ,Guam,US64,Louisiana,Peak,$18.88,$40.99
+GQ,Guam,US66,Texas-North,NonPeak,$27.63,$32.26
+GQ,Guam,US66,Texas-North,Peak,$32.60,$38.07
+GQ,Guam,US68,Texas-South,NonPeak,$29.28,$45.09
+GQ,Guam,US68,Texas-South,Peak,$34.55,$53.21
+GQ,Guam,US70,Montana,NonPeak,$30.90,$34.90
+GQ,Guam,US70,Montana,Peak,$36.46,$41.18
+GQ,Guam,US72,Wyoming,NonPeak,$15.28,$32.44
+GQ,Guam,US72,Wyoming,Peak,$18.03,$38.28
+GQ,Guam,US74,Colorado,NonPeak,$16.05,$43.94
+GQ,Guam,US74,Colorado,Peak,$18.94,$51.85
+GQ,Guam,US76,Utah,NonPeak,$16.80,$33.70
+GQ,Guam,US76,Utah,Peak,$19.82,$39.77
+GQ,Guam,US77,New Mexico,NonPeak,$17.57,$31.29
+GQ,Guam,US77,New Mexico,Peak,$20.73,$36.92
+GQ,Guam,US79,Arizona,NonPeak,$18.33,$44.05
+GQ,Guam,US79,Arizona,Peak,$21.63,$51.98
+GQ,Guam,US83,Idaho,NonPeak,$24.38,$33.75
+GQ,Guam,US83,Idaho,Peak,$28.77,$39.82
+GQ,Guam,US84,Washington,NonPeak,$16.00,$31.40
+GQ,Guam,US84,Washington,Peak,$18.88,$37.05
+GQ,Guam,US85,Oregon,NonPeak,$27.63,$44.17
+GQ,Guam,US85,Oregon,Peak,$32.60,$52.12
+GQ,Guam,US86,Nevada,NonPeak,$29.28,$33.98
+GQ,Guam,US86,Nevada,Peak,$34.55,$40.10
+GQ,Guam,US87,California-North,NonPeak,$30.90,$31.45
+GQ,Guam,US87,California-North,Peak,$36.46,$37.11
+GQ,Guam,US88,California-South,NonPeak,$15.28,$44.28
+GQ,Guam,US88,California-South,Peak,$18.03,$52.25
+GR,Greece,US11,Maine,NonPeak,$16.05,$34.11
+GR,Greece,US11,Maine,Peak,$18.94,$40.25
+GR,Greece,US12,New Hampshire,NonPeak,$16.80,$31.63
+GR,Greece,US12,New Hampshire,Peak,$19.82,$37.32
+GR,Greece,US13,Vermont,NonPeak,$17.57,$44.51
+GR,Greece,US13,Vermont,Peak,$20.73,$52.52
+GR,Greece,US14,Massachusetts,NonPeak,$18.33,$34.33
+GR,Greece,US14,Massachusetts,Peak,$21.63,$40.51
+GR,Greece,US15,Rhode Island,NonPeak,$24.38,$31.74
+GR,Greece,US15,Rhode Island,Peak,$28.77,$37.45
+GR,Greece,US16,Connecticut,NonPeak,$16.00,$44.62
+GR,Greece,US16,Connecticut,Peak,$18.88,$52.65
+GR,Greece,US17,New York,NonPeak,$27.63,$34.45
+GR,Greece,US17,New York,Peak,$32.60,$40.65
+GR,Greece,US19,New Jersey,NonPeak,$29.28,$31.91
+GR,Greece,US19,New Jersey,Peak,$34.55,$37.65
+GR,Greece,US20,Pennsylvania,NonPeak,$30.90,$44.74
+GR,Greece,US20,Pennsylvania,Peak,$36.46,$52.79
+GR,Greece,US22,Delaware,NonPeak,$15.28,$34.56
+GR,Greece,US22,Delaware,Peak,$18.03,$40.78
+GR,Greece,US23,Maryland,NonPeak,$16.05,$32.09
+GR,Greece,US23,Maryland,Peak,$18.94,$37.87
+GR,Greece,US24,District Of Columbia,NonPeak,$16.80,$44.91
+GR,Greece,US24,District Of Columbia,Peak,$19.82,$52.99
+GR,Greece,US25,Virginia,NonPeak,$17.57,$34.74
+GR,Greece,US25,Virginia,Peak,$20.73,$40.99
+GR,Greece,US27,West Virginia,NonPeak,$18.33,$32.26
+GR,Greece,US27,West Virginia,Peak,$21.63,$38.07
+GR,Greece,US28,Kentucky,NonPeak,$24.38,$45.09
+GR,Greece,US28,Kentucky,Peak,$28.77,$53.21
+GR,Greece,US30,Michigan,NonPeak,$16.00,$34.90
+GR,Greece,US30,Michigan,Peak,$18.88,$41.18
+GR,Greece,US32,Wisconsin,NonPeak,$27.63,$32.44
+GR,Greece,US32,Wisconsin,Peak,$32.60,$38.28
+GR,Greece,US34,Ohio,NonPeak,$29.28,$43.94
+GR,Greece,US34,Ohio,Peak,$34.55,$51.85
+GR,Greece,US36,Indiana,NonPeak,$30.90,$33.70
+GR,Greece,US36,Indiana,Peak,$36.46,$39.77
+GR,Greece,US38,Illinois,NonPeak,$15.28,$31.29
+GR,Greece,US38,Illinois,Peak,$18.03,$36.92
+GR,Greece,US40,North Carolina,NonPeak,$16.05,$44.05
+GR,Greece,US40,North Carolina,Peak,$18.94,$51.98
+GR,Greece,US42,Tennessee,NonPeak,$16.80,$33.75
+GR,Greece,US42,Tennessee,Peak,$19.82,$39.82
+GR,Greece,US44,South Carolina,NonPeak,$17.57,$31.40
+GR,Greece,US44,South Carolina,Peak,$20.73,$37.05
+GR,Greece,US45,Georgia,NonPeak,$18.33,$44.17
+GR,Greece,US45,Georgia,Peak,$21.63,$52.12
+GR,Greece,US47,Alabama,NonPeak,$24.38,$33.98
+GR,Greece,US47,Alabama,Peak,$28.77,$40.10
+GR,Greece,US48,Mississippi,NonPeak,$16.00,$31.45
+GR,Greece,US48,Mississippi,Peak,$18.88,$37.11
+GR,Greece,US49,Florida-North,NonPeak,$27.63,$44.28
+GR,Greece,US49,Florida-North,Peak,$32.60,$52.25
+GR,Greece,US4964400,Florida-South,NonPeak,$29.28,$34.11
+GR,Greece,US4964400,Florida-South,Peak,$34.55,$40.25
+GR,Greece,US4965500,Florida Keys,NonPeak,$30.90,$31.63
+GR,Greece,US4965500,Florida Keys,Peak,$36.46,$37.32
+GR,Greece,US50,Minnesota,NonPeak,$15.28,$44.51
+GR,Greece,US50,Minnesota,Peak,$18.03,$52.52
+GR,Greece,US51,North Dakota,NonPeak,$16.05,$34.33
+GR,Greece,US51,North Dakota,Peak,$18.94,$40.51
+GR,Greece,US52,South Dakota,NonPeak,$16.80,$31.74
+GR,Greece,US52,South Dakota,Peak,$19.82,$37.45
+GR,Greece,US53,Iowa,NonPeak,$17.57,$44.62
+GR,Greece,US53,Iowa,Peak,$20.73,$52.65
+GR,Greece,US55,Nebraska,NonPeak,$18.33,$34.45
+GR,Greece,US55,Nebraska,Peak,$21.63,$40.65
+GR,Greece,US56,Missouri,NonPeak,$24.38,$31.91
+GR,Greece,US56,Missouri,Peak,$28.77,$37.65
+GR,Greece,US58,Kansas,NonPeak,$16.00,$44.74
+GR,Greece,US58,Kansas,Peak,$18.88,$52.79
+GR,Greece,US60,Arkansas,NonPeak,$27.63,$34.56
+GR,Greece,US60,Arkansas,Peak,$32.60,$40.78
+GR,Greece,US62,Oklahoma,NonPeak,$29.28,$32.09
+GR,Greece,US62,Oklahoma,Peak,$34.55,$37.87
+GR,Greece,US64,Louisiana,NonPeak,$30.90,$44.91
+GR,Greece,US64,Louisiana,Peak,$36.46,$52.99
+GR,Greece,US66,Texas-North,NonPeak,$15.28,$34.74
+GR,Greece,US66,Texas-North,Peak,$18.03,$40.99
+GR,Greece,US68,Texas-South,NonPeak,$16.05,$32.26
+GR,Greece,US68,Texas-South,Peak,$18.94,$38.07
+GR,Greece,US70,Montana,NonPeak,$16.80,$45.09
+GR,Greece,US70,Montana,Peak,$19.82,$53.21
+GR,Greece,US72,Wyoming,NonPeak,$17.57,$34.90
+GR,Greece,US72,Wyoming,Peak,$20.73,$41.18
+GR,Greece,US74,Colorado,NonPeak,$18.33,$32.44
+GR,Greece,US74,Colorado,Peak,$21.63,$38.28
+GR,Greece,US76,Utah,NonPeak,$24.38,$43.94
+GR,Greece,US76,Utah,Peak,$28.77,$51.85
+GR,Greece,US77,New Mexico,NonPeak,$16.00,$33.70
+GR,Greece,US77,New Mexico,Peak,$18.88,$39.77
+GR,Greece,US79,Arizona,NonPeak,$27.63,$31.29
+GR,Greece,US79,Arizona,Peak,$32.60,$36.92
+GR,Greece,US83,Idaho,NonPeak,$29.28,$44.05
+GR,Greece,US83,Idaho,Peak,$34.55,$51.98
+GR,Greece,US84,Washington,NonPeak,$30.90,$33.75
+GR,Greece,US84,Washington,Peak,$36.46,$39.82
+GR,Greece,US85,Oregon,NonPeak,$15.28,$31.40
+GR,Greece,US85,Oregon,Peak,$18.03,$37.05
+GR,Greece,US86,Nevada,NonPeak,$16.05,$44.17
+GR,Greece,US86,Nevada,Peak,$18.94,$52.12
+GR,Greece,US87,California-North,NonPeak,$16.80,$33.98
+GR,Greece,US87,California-North,Peak,$19.82,$40.10
+GR,Greece,US88,California-South,NonPeak,$17.57,$31.45
+GR,Greece,US88,California-South,Peak,$20.73,$37.11
+GR29,Crete,US11,Maine,NonPeak,$18.33,$44.28
+GR29,Crete,US11,Maine,Peak,$21.63,$52.25
+GR29,Crete,US12,New Hampshire,NonPeak,$24.38,$34.11
+GR29,Crete,US12,New Hampshire,Peak,$28.77,$40.25
+GR29,Crete,US13,Vermont,NonPeak,$16.00,$31.63
+GR29,Crete,US13,Vermont,Peak,$18.88,$37.32
+GR29,Crete,US14,Massachusetts,NonPeak,$27.63,$44.51
+GR29,Crete,US14,Massachusetts,Peak,$32.60,$52.52
+GR29,Crete,US15,Rhode Island,NonPeak,$29.28,$34.33
+GR29,Crete,US15,Rhode Island,Peak,$34.55,$40.51
+GR29,Crete,US16,Connecticut,NonPeak,$30.90,$31.74
+GR29,Crete,US16,Connecticut,Peak,$36.46,$37.45
+GR29,Crete,US17,New York,NonPeak,$15.28,$44.62
+GR29,Crete,US17,New York,Peak,$18.03,$52.65
+GR29,Crete,US19,New Jersey,NonPeak,$16.05,$34.45
+GR29,Crete,US19,New Jersey,Peak,$18.94,$40.65
+GR29,Crete,US20,Pennsylvania,NonPeak,$16.80,$31.91
+GR29,Crete,US20,Pennsylvania,Peak,$19.82,$37.65
+GR29,Crete,US22,Delaware,NonPeak,$17.57,$44.74
+GR29,Crete,US22,Delaware,Peak,$20.73,$52.79
+GR29,Crete,US23,Maryland,NonPeak,$18.33,$34.56
+GR29,Crete,US23,Maryland,Peak,$21.63,$40.78
+GR29,Crete,US24,District Of Columbia,NonPeak,$24.38,$32.09
+GR29,Crete,US24,District Of Columbia,Peak,$28.77,$37.87
+GR29,Crete,US25,Virginia,NonPeak,$16.00,$44.91
+GR29,Crete,US25,Virginia,Peak,$18.88,$52.99
+GR29,Crete,US27,West Virginia,NonPeak,$27.63,$34.74
+GR29,Crete,US27,West Virginia,Peak,$32.60,$40.99
+GR29,Crete,US28,Kentucky,NonPeak,$29.28,$32.26
+GR29,Crete,US28,Kentucky,Peak,$34.55,$38.07
+GR29,Crete,US30,Michigan,NonPeak,$30.90,$45.09
+GR29,Crete,US30,Michigan,Peak,$36.46,$53.21
+GR29,Crete,US32,Wisconsin,NonPeak,$15.28,$34.90
+GR29,Crete,US32,Wisconsin,Peak,$18.03,$41.18
+GR29,Crete,US34,Ohio,NonPeak,$16.05,$32.44
+GR29,Crete,US34,Ohio,Peak,$18.94,$38.28
+GR29,Crete,US36,Indiana,NonPeak,$16.80,$43.94
+GR29,Crete,US36,Indiana,Peak,$19.82,$51.85
+GR29,Crete,US38,Illinois,NonPeak,$17.57,$33.70
+GR29,Crete,US38,Illinois,Peak,$20.73,$39.77
+GR29,Crete,US40,North Carolina,NonPeak,$18.33,$31.29
+GR29,Crete,US40,North Carolina,Peak,$21.63,$36.92
+GR29,Crete,US42,Tennessee,NonPeak,$24.38,$44.05
+GR29,Crete,US42,Tennessee,Peak,$28.77,$51.98
+GR29,Crete,US44,South Carolina,NonPeak,$16.00,$33.75
+GR29,Crete,US44,South Carolina,Peak,$18.88,$39.82
+GR29,Crete,US45,Georgia,NonPeak,$27.63,$31.40
+GR29,Crete,US45,Georgia,Peak,$32.60,$37.05
+GR29,Crete,US47,Alabama,NonPeak,$29.28,$44.17
+GR29,Crete,US47,Alabama,Peak,$34.55,$52.12
+GR29,Crete,US48,Mississippi,NonPeak,$30.90,$33.98
+GR29,Crete,US48,Mississippi,Peak,$36.46,$40.10
+GR29,Crete,US49,Florida-North,NonPeak,$15.28,$31.45
+GR29,Crete,US49,Florida-North,Peak,$18.03,$37.11
+GR29,Crete,US4964400,Florida-South,NonPeak,$16.05,$44.28
+GR29,Crete,US4964400,Florida-South,Peak,$18.94,$52.25
+GR29,Crete,US4965500,Florida Keys,NonPeak,$16.80,$34.11
+GR29,Crete,US4965500,Florida Keys,Peak,$19.82,$40.25
+GR29,Crete,US50,Minnesota,NonPeak,$17.57,$31.63
+GR29,Crete,US50,Minnesota,Peak,$20.73,$37.32
+GR29,Crete,US51,North Dakota,NonPeak,$18.33,$44.51
+GR29,Crete,US51,North Dakota,Peak,$21.63,$52.52
+GR29,Crete,US52,South Dakota,NonPeak,$24.38,$34.33
+GR29,Crete,US52,South Dakota,Peak,$28.77,$40.51
+GR29,Crete,US53,Iowa,NonPeak,$16.00,$31.74
+GR29,Crete,US53,Iowa,Peak,$18.88,$37.45
+GR29,Crete,US55,Nebraska,NonPeak,$27.63,$44.62
+GR29,Crete,US55,Nebraska,Peak,$32.60,$52.65
+GR29,Crete,US56,Missouri,NonPeak,$29.28,$34.45
+GR29,Crete,US56,Missouri,Peak,$34.55,$40.65
+GR29,Crete,US58,Kansas,NonPeak,$30.90,$31.91
+GR29,Crete,US58,Kansas,Peak,$36.46,$37.65
+GR29,Crete,US60,Arkansas,NonPeak,$15.28,$44.74
+GR29,Crete,US60,Arkansas,Peak,$18.03,$52.79
+GR29,Crete,US62,Oklahoma,NonPeak,$16.05,$34.56
+GR29,Crete,US62,Oklahoma,Peak,$18.94,$40.78
+GR29,Crete,US64,Louisiana,NonPeak,$16.80,$32.09
+GR29,Crete,US64,Louisiana,Peak,$19.82,$37.87
+GR29,Crete,US66,Texas-North,NonPeak,$17.57,$44.91
+GR29,Crete,US66,Texas-North,Peak,$20.73,$52.99
+GR29,Crete,US68,Texas-South,NonPeak,$18.33,$34.74
+GR29,Crete,US68,Texas-South,Peak,$21.63,$40.99
+GR29,Crete,US70,Montana,NonPeak,$24.38,$32.26
+GR29,Crete,US70,Montana,Peak,$28.77,$38.07
+GR29,Crete,US72,Wyoming,NonPeak,$16.00,$45.09
+GR29,Crete,US72,Wyoming,Peak,$18.88,$53.21
+GR29,Crete,US74,Colorado,NonPeak,$27.63,$34.90
+GR29,Crete,US74,Colorado,Peak,$32.60,$41.18
+GR29,Crete,US76,Utah,NonPeak,$29.28,$32.44
+GR29,Crete,US76,Utah,Peak,$34.55,$38.28
+GR29,Crete,US77,New Mexico,NonPeak,$30.90,$43.94
+GR29,Crete,US77,New Mexico,Peak,$36.46,$51.85
+GR29,Crete,US79,Arizona,NonPeak,$15.28,$33.70
+GR29,Crete,US79,Arizona,Peak,$18.03,$39.77
+GR29,Crete,US83,Idaho,NonPeak,$16.05,$31.29
+GR29,Crete,US83,Idaho,Peak,$18.94,$36.92
+GR29,Crete,US84,Washington,NonPeak,$16.80,$44.05
+GR29,Crete,US84,Washington,Peak,$19.82,$51.98
+GR29,Crete,US85,Oregon,NonPeak,$17.57,$33.75
+GR29,Crete,US85,Oregon,Peak,$20.73,$39.82
+GR29,Crete,US86,Nevada,NonPeak,$18.33,$31.40
+GR29,Crete,US86,Nevada,Peak,$21.63,$37.05
+GR29,Crete,US87,California-North,NonPeak,$24.38,$44.17
+GR29,Crete,US87,California-North,Peak,$28.77,$52.12
+GR29,Crete,US88,California-South,NonPeak,$16.00,$33.98
+GR29,Crete,US88,California-South,Peak,$18.88,$40.10
+GT,Guatemala,US11,Maine,NonPeak,$27.63,$31.45
+GT,Guatemala,US11,Maine,Peak,$32.60,$37.11
+GT,Guatemala,US12,New Hampshire,NonPeak,$29.28,$44.28
+GT,Guatemala,US12,New Hampshire,Peak,$34.55,$52.25
+GT,Guatemala,US13,Vermont,NonPeak,$30.90,$34.11
+GT,Guatemala,US13,Vermont,Peak,$36.46,$40.25
+GT,Guatemala,US14,Massachusetts,NonPeak,$15.28,$31.63
+GT,Guatemala,US14,Massachusetts,Peak,$18.03,$37.32
+GT,Guatemala,US15,Rhode Island,NonPeak,$16.05,$44.51
+GT,Guatemala,US15,Rhode Island,Peak,$18.94,$52.52
+GT,Guatemala,US16,Connecticut,NonPeak,$16.80,$34.33
+GT,Guatemala,US16,Connecticut,Peak,$19.82,$40.51
+GT,Guatemala,US17,New York,NonPeak,$17.57,$31.74
+GT,Guatemala,US17,New York,Peak,$20.73,$37.45
+GT,Guatemala,US19,New Jersey,NonPeak,$18.33,$44.62
+GT,Guatemala,US19,New Jersey,Peak,$21.63,$52.65
+GT,Guatemala,US20,Pennsylvania,NonPeak,$24.38,$34.45
+GT,Guatemala,US20,Pennsylvania,Peak,$28.77,$40.65
+GT,Guatemala,US22,Delaware,NonPeak,$16.00,$31.91
+GT,Guatemala,US22,Delaware,Peak,$18.88,$37.65
+GT,Guatemala,US23,Maryland,NonPeak,$27.63,$44.74
+GT,Guatemala,US23,Maryland,Peak,$32.60,$52.79
+GT,Guatemala,US24,District Of Columbia,NonPeak,$29.28,$34.56
+GT,Guatemala,US24,District Of Columbia,Peak,$34.55,$40.78
+GT,Guatemala,US25,Virginia,NonPeak,$30.90,$32.09
+GT,Guatemala,US25,Virginia,Peak,$36.46,$37.87
+GT,Guatemala,US27,West Virginia,NonPeak,$15.28,$44.91
+GT,Guatemala,US27,West Virginia,Peak,$18.03,$52.99
+GT,Guatemala,US28,Kentucky,NonPeak,$16.05,$34.74
+GT,Guatemala,US28,Kentucky,Peak,$18.94,$40.99
+GT,Guatemala,US30,Michigan,NonPeak,$16.80,$32.26
+GT,Guatemala,US30,Michigan,Peak,$19.82,$38.07
+GT,Guatemala,US32,Wisconsin,NonPeak,$17.57,$45.09
+GT,Guatemala,US32,Wisconsin,Peak,$20.73,$53.21
+GT,Guatemala,US34,Ohio,NonPeak,$18.33,$34.90
+GT,Guatemala,US34,Ohio,Peak,$21.63,$41.18
+GT,Guatemala,US36,Indiana,NonPeak,$24.38,$32.44
+GT,Guatemala,US36,Indiana,Peak,$28.77,$38.28
+GT,Guatemala,US38,Illinois,NonPeak,$16.00,$43.94
+GT,Guatemala,US38,Illinois,Peak,$18.88,$51.85
+GT,Guatemala,US40,North Carolina,NonPeak,$27.63,$33.70
+GT,Guatemala,US40,North Carolina,Peak,$32.60,$39.77
+GT,Guatemala,US42,Tennessee,NonPeak,$29.28,$31.29
+GT,Guatemala,US42,Tennessee,Peak,$34.55,$36.92
+GT,Guatemala,US44,South Carolina,NonPeak,$30.90,$44.05
+GT,Guatemala,US44,South Carolina,Peak,$36.46,$51.98
+GT,Guatemala,US45,Georgia,NonPeak,$15.28,$33.75
+GT,Guatemala,US45,Georgia,Peak,$18.03,$39.82
+GT,Guatemala,US47,Alabama,NonPeak,$16.05,$31.40
+GT,Guatemala,US47,Alabama,Peak,$18.94,$37.05
+GT,Guatemala,US48,Mississippi,NonPeak,$16.80,$44.17
+GT,Guatemala,US48,Mississippi,Peak,$19.82,$52.12
+GT,Guatemala,US49,Florida-North,NonPeak,$17.57,$33.98
+GT,Guatemala,US49,Florida-North,Peak,$20.73,$40.10
+GT,Guatemala,US4964400,Florida-South,NonPeak,$18.33,$31.45
+GT,Guatemala,US4964400,Florida-South,Peak,$21.63,$37.11
+GT,Guatemala,US4965500,Florida Keys,NonPeak,$24.38,$44.28
+GT,Guatemala,US4965500,Florida Keys,Peak,$28.77,$52.25
+GT,Guatemala,US50,Minnesota,NonPeak,$16.00,$34.11
+GT,Guatemala,US50,Minnesota,Peak,$18.88,$40.25
+GT,Guatemala,US51,North Dakota,NonPeak,$27.63,$31.63
+GT,Guatemala,US51,North Dakota,Peak,$32.60,$37.32
+GT,Guatemala,US52,South Dakota,NonPeak,$29.28,$44.51
+GT,Guatemala,US52,South Dakota,Peak,$34.55,$52.52
+GT,Guatemala,US53,Iowa,NonPeak,$30.90,$34.33
+GT,Guatemala,US53,Iowa,Peak,$36.46,$40.51
+GT,Guatemala,US55,Nebraska,NonPeak,$15.28,$31.74
+GT,Guatemala,US55,Nebraska,Peak,$18.03,$37.45
+GT,Guatemala,US56,Missouri,NonPeak,$16.05,$44.62
+GT,Guatemala,US56,Missouri,Peak,$18.94,$52.65
+GT,Guatemala,US58,Kansas,NonPeak,$16.80,$34.45
+GT,Guatemala,US58,Kansas,Peak,$19.82,$40.65
+GT,Guatemala,US60,Arkansas,NonPeak,$17.57,$31.91
+GT,Guatemala,US60,Arkansas,Peak,$20.73,$37.65
+GT,Guatemala,US62,Oklahoma,NonPeak,$18.33,$44.74
+GT,Guatemala,US62,Oklahoma,Peak,$21.63,$52.79
+GT,Guatemala,US64,Louisiana,NonPeak,$24.38,$34.56
+GT,Guatemala,US64,Louisiana,Peak,$28.77,$40.78
+GT,Guatemala,US66,Texas-North,NonPeak,$16.00,$32.09
+GT,Guatemala,US66,Texas-North,Peak,$18.88,$37.87
+GT,Guatemala,US68,Texas-South,NonPeak,$27.63,$44.91
+GT,Guatemala,US68,Texas-South,Peak,$32.60,$52.99
+GT,Guatemala,US70,Montana,NonPeak,$29.28,$34.74
+GT,Guatemala,US70,Montana,Peak,$34.55,$40.99
+GT,Guatemala,US72,Wyoming,NonPeak,$30.90,$32.26
+GT,Guatemala,US72,Wyoming,Peak,$36.46,$38.07
+GT,Guatemala,US74,Colorado,NonPeak,$15.28,$45.09
+GT,Guatemala,US74,Colorado,Peak,$18.03,$53.21
+GT,Guatemala,US76,Utah,NonPeak,$16.05,$34.90
+GT,Guatemala,US76,Utah,Peak,$18.94,$41.18
+GT,Guatemala,US77,New Mexico,NonPeak,$16.80,$32.44
+GT,Guatemala,US77,New Mexico,Peak,$19.82,$38.28
+GT,Guatemala,US79,Arizona,NonPeak,$17.57,$43.94
+GT,Guatemala,US79,Arizona,Peak,$20.73,$51.85
+GT,Guatemala,US83,Idaho,NonPeak,$18.33,$33.70
+GT,Guatemala,US83,Idaho,Peak,$21.63,$39.77
+GT,Guatemala,US84,Washington,NonPeak,$24.38,$31.29
+GT,Guatemala,US84,Washington,Peak,$28.77,$36.92
+GT,Guatemala,US85,Oregon,NonPeak,$16.00,$44.05
+GT,Guatemala,US85,Oregon,Peak,$18.88,$51.98
+GT,Guatemala,US86,Nevada,NonPeak,$27.63,$33.75
+GT,Guatemala,US86,Nevada,Peak,$32.60,$39.82
+GT,Guatemala,US87,California-North,NonPeak,$29.28,$31.40
+GT,Guatemala,US87,California-North,Peak,$34.55,$37.05
+GT,Guatemala,US88,California-South,NonPeak,$30.90,$44.17
+GT,Guatemala,US88,California-South,Peak,$36.46,$52.12
+HO,Honduras,US11,Maine,NonPeak,$15.28,$33.98
+HO,Honduras,US11,Maine,Peak,$18.03,$40.10
+HO,Honduras,US12,New Hampshire,NonPeak,$16.05,$31.45
+HO,Honduras,US12,New Hampshire,Peak,$18.94,$37.11
+HO,Honduras,US13,Vermont,NonPeak,$16.80,$44.28
+HO,Honduras,US13,Vermont,Peak,$19.82,$52.25
+HO,Honduras,US14,Massachusetts,NonPeak,$17.57,$34.11
+HO,Honduras,US14,Massachusetts,Peak,$20.73,$40.25
+HO,Honduras,US15,Rhode Island,NonPeak,$18.33,$31.63
+HO,Honduras,US15,Rhode Island,Peak,$21.63,$37.32
+HO,Honduras,US16,Connecticut,NonPeak,$24.38,$44.51
+HO,Honduras,US16,Connecticut,Peak,$28.77,$52.52
+HO,Honduras,US17,New York,NonPeak,$16.00,$34.33
+HO,Honduras,US17,New York,Peak,$18.88,$40.51
+HO,Honduras,US19,New Jersey,NonPeak,$27.63,$31.74
+HO,Honduras,US19,New Jersey,Peak,$32.60,$37.45
+HO,Honduras,US20,Pennsylvania,NonPeak,$29.28,$44.62
+HO,Honduras,US20,Pennsylvania,Peak,$34.55,$52.65
+HO,Honduras,US22,Delaware,NonPeak,$30.90,$34.45
+HO,Honduras,US22,Delaware,Peak,$36.46,$40.65
+HO,Honduras,US23,Maryland,NonPeak,$15.28,$31.91
+HO,Honduras,US23,Maryland,Peak,$18.03,$37.65
+HO,Honduras,US24,District Of Columbia,NonPeak,$16.05,$44.74
+HO,Honduras,US24,District Of Columbia,Peak,$18.94,$52.79
+HO,Honduras,US25,Virginia,NonPeak,$16.80,$34.56
+HO,Honduras,US25,Virginia,Peak,$19.82,$40.78
+HO,Honduras,US27,West Virginia,NonPeak,$17.57,$32.09
+HO,Honduras,US27,West Virginia,Peak,$20.73,$37.87
+HO,Honduras,US28,Kentucky,NonPeak,$18.33,$44.91
+HO,Honduras,US28,Kentucky,Peak,$21.63,$52.99
+HO,Honduras,US30,Michigan,NonPeak,$24.38,$34.74
+HO,Honduras,US30,Michigan,Peak,$28.77,$40.99
+HO,Honduras,US32,Wisconsin,NonPeak,$16.00,$32.26
+HO,Honduras,US32,Wisconsin,Peak,$18.88,$38.07
+HO,Honduras,US34,Ohio,NonPeak,$27.63,$45.09
+HO,Honduras,US34,Ohio,Peak,$32.60,$53.21
+HO,Honduras,US36,Indiana,NonPeak,$29.28,$34.90
+HO,Honduras,US36,Indiana,Peak,$34.55,$41.18
+HO,Honduras,US38,Illinois,NonPeak,$30.90,$32.44
+HO,Honduras,US38,Illinois,Peak,$36.46,$38.28
+HO,Honduras,US40,North Carolina,NonPeak,$15.28,$43.94
+HO,Honduras,US40,North Carolina,Peak,$18.03,$51.85
+HO,Honduras,US42,Tennessee,NonPeak,$16.05,$33.70
+HO,Honduras,US42,Tennessee,Peak,$18.94,$39.77
+HO,Honduras,US44,South Carolina,NonPeak,$16.80,$31.29
+HO,Honduras,US44,South Carolina,Peak,$19.82,$36.92
+HO,Honduras,US45,Georgia,NonPeak,$17.57,$44.05
+HO,Honduras,US45,Georgia,Peak,$20.73,$51.98
+HO,Honduras,US47,Alabama,NonPeak,$18.33,$33.75
+HO,Honduras,US47,Alabama,Peak,$21.63,$39.82
+HO,Honduras,US48,Mississippi,NonPeak,$24.38,$31.40
+HO,Honduras,US48,Mississippi,Peak,$28.77,$37.05
+HO,Honduras,US49,Florida-North,NonPeak,$16.00,$44.17
+HO,Honduras,US49,Florida-North,Peak,$18.88,$52.12
+HO,Honduras,US4964400,Florida-South,NonPeak,$27.63,$33.98
+HO,Honduras,US4964400,Florida-South,Peak,$32.60,$40.10
+HO,Honduras,US4965500,Florida Keys,NonPeak,$29.28,$31.45
+HO,Honduras,US4965500,Florida Keys,Peak,$34.55,$37.11
+HO,Honduras,US50,Minnesota,NonPeak,$30.90,$44.28
+HO,Honduras,US50,Minnesota,Peak,$36.46,$52.25
+HO,Honduras,US51,North Dakota,NonPeak,$15.28,$34.11
+HO,Honduras,US51,North Dakota,Peak,$18.03,$40.25
+HO,Honduras,US52,South Dakota,NonPeak,$16.05,$31.63
+HO,Honduras,US52,South Dakota,Peak,$18.94,$37.32
+HO,Honduras,US53,Iowa,NonPeak,$16.80,$44.51
+HO,Honduras,US53,Iowa,Peak,$19.82,$52.52
+HO,Honduras,US55,Nebraska,NonPeak,$17.57,$34.33
+HO,Honduras,US55,Nebraska,Peak,$20.73,$40.51
+HO,Honduras,US56,Missouri,NonPeak,$18.33,$31.74
+HO,Honduras,US56,Missouri,Peak,$21.63,$37.45
+HO,Honduras,US58,Kansas,NonPeak,$24.38,$44.62
+HO,Honduras,US58,Kansas,Peak,$28.77,$52.65
+HO,Honduras,US60,Arkansas,NonPeak,$16.00,$34.45
+HO,Honduras,US60,Arkansas,Peak,$18.88,$40.65
+HO,Honduras,US62,Oklahoma,NonPeak,$27.63,$31.91
+HO,Honduras,US62,Oklahoma,Peak,$32.60,$37.65
+HO,Honduras,US64,Louisiana,NonPeak,$29.28,$44.74
+HO,Honduras,US64,Louisiana,Peak,$34.55,$52.79
+HO,Honduras,US66,Texas-North,NonPeak,$30.90,$34.56
+HO,Honduras,US66,Texas-North,Peak,$36.46,$40.78
+HO,Honduras,US68,Texas-South,NonPeak,$15.28,$32.09
+HO,Honduras,US68,Texas-South,Peak,$18.03,$37.87
+HO,Honduras,US70,Montana,NonPeak,$16.05,$44.91
+HO,Honduras,US70,Montana,Peak,$18.94,$52.99
+HO,Honduras,US72,Wyoming,NonPeak,$16.80,$34.74
+HO,Honduras,US72,Wyoming,Peak,$19.82,$40.99
+HO,Honduras,US74,Colorado,NonPeak,$17.57,$32.26
+HO,Honduras,US74,Colorado,Peak,$20.73,$38.07
+HO,Honduras,US76,Utah,NonPeak,$18.33,$45.09
+HO,Honduras,US76,Utah,Peak,$21.63,$53.21
+HO,Honduras,US77,New Mexico,NonPeak,$24.38,$34.90
+HO,Honduras,US77,New Mexico,Peak,$28.77,$41.18
+HO,Honduras,US79,Arizona,NonPeak,$16.00,$32.44
+HO,Honduras,US79,Arizona,Peak,$18.88,$38.28
+HO,Honduras,US83,Idaho,NonPeak,$27.63,$43.94
+HO,Honduras,US83,Idaho,Peak,$32.60,$51.85
+HO,Honduras,US84,Washington,NonPeak,$29.28,$33.70
+HO,Honduras,US84,Washington,Peak,$34.55,$39.77
+HO,Honduras,US85,Oregon,NonPeak,$30.90,$31.29
+HO,Honduras,US85,Oregon,Peak,$36.46,$36.92
+HO,Honduras,US86,Nevada,NonPeak,$15.28,$44.05
+HO,Honduras,US86,Nevada,Peak,$18.03,$51.98
+HO,Honduras,US87,California-North,NonPeak,$16.05,$33.75
+HO,Honduras,US87,California-North,Peak,$18.94,$39.82
+HO,Honduras,US88,California-South,NonPeak,$16.80,$31.40
+HO,Honduras,US88,California-South,Peak,$19.82,$37.05
+HU,Hungary,US11,Maine,NonPeak,$17.57,$44.17
+HU,Hungary,US11,Maine,Peak,$20.73,$52.12
+HU,Hungary,US12,New Hampshire,NonPeak,$18.33,$33.98
+HU,Hungary,US12,New Hampshire,Peak,$21.63,$40.10
+HU,Hungary,US13,Vermont,NonPeak,$24.38,$31.45
+HU,Hungary,US13,Vermont,Peak,$28.77,$37.11
+HU,Hungary,US14,Massachusetts,NonPeak,$16.00,$44.28
+HU,Hungary,US14,Massachusetts,Peak,$18.88,$52.25
+HU,Hungary,US15,Rhode Island,NonPeak,$27.63,$34.11
+HU,Hungary,US15,Rhode Island,Peak,$32.60,$40.25
+HU,Hungary,US16,Connecticut,NonPeak,$29.28,$31.63
+HU,Hungary,US16,Connecticut,Peak,$34.55,$37.32
+HU,Hungary,US17,New York,NonPeak,$30.90,$44.51
+HU,Hungary,US17,New York,Peak,$36.46,$52.52
+HU,Hungary,US19,New Jersey,NonPeak,$15.28,$34.33
+HU,Hungary,US19,New Jersey,Peak,$18.03,$40.51
+HU,Hungary,US20,Pennsylvania,NonPeak,$16.05,$31.74
+HU,Hungary,US20,Pennsylvania,Peak,$18.94,$37.45
+HU,Hungary,US22,Delaware,NonPeak,$16.80,$44.62
+HU,Hungary,US22,Delaware,Peak,$19.82,$52.65
+HU,Hungary,US23,Maryland,NonPeak,$17.57,$34.45
+HU,Hungary,US23,Maryland,Peak,$20.73,$40.65
+HU,Hungary,US24,District Of Columbia,NonPeak,$18.33,$31.91
+HU,Hungary,US24,District Of Columbia,Peak,$21.63,$37.65
+HU,Hungary,US25,Virginia,NonPeak,$24.38,$44.74
+HU,Hungary,US25,Virginia,Peak,$28.77,$52.79
+HU,Hungary,US27,West Virginia,NonPeak,$16.00,$34.56
+HU,Hungary,US27,West Virginia,Peak,$18.88,$40.78
+HU,Hungary,US28,Kentucky,NonPeak,$27.63,$32.09
+HU,Hungary,US28,Kentucky,Peak,$32.60,$37.87
+HU,Hungary,US30,Michigan,NonPeak,$29.28,$44.91
+HU,Hungary,US30,Michigan,Peak,$34.55,$52.99
+HU,Hungary,US32,Wisconsin,NonPeak,$30.90,$34.74
+HU,Hungary,US32,Wisconsin,Peak,$36.46,$40.99
+HU,Hungary,US34,Ohio,NonPeak,$15.28,$32.26
+HU,Hungary,US34,Ohio,Peak,$18.03,$38.07
+HU,Hungary,US36,Indiana,NonPeak,$16.05,$45.09
+HU,Hungary,US36,Indiana,Peak,$18.94,$53.21
+HU,Hungary,US38,Illinois,NonPeak,$16.80,$34.90
+HU,Hungary,US38,Illinois,Peak,$19.82,$41.18
+HU,Hungary,US40,North Carolina,NonPeak,$17.57,$32.44
+HU,Hungary,US40,North Carolina,Peak,$20.73,$38.28
+HU,Hungary,US42,Tennessee,NonPeak,$18.33,$43.94
+HU,Hungary,US42,Tennessee,Peak,$21.63,$51.85
+HU,Hungary,US44,South Carolina,NonPeak,$24.38,$33.70
+HU,Hungary,US44,South Carolina,Peak,$28.77,$39.77
+HU,Hungary,US45,Georgia,NonPeak,$16.00,$31.29
+HU,Hungary,US45,Georgia,Peak,$18.88,$36.92
+HU,Hungary,US47,Alabama,NonPeak,$27.63,$44.05
+HU,Hungary,US47,Alabama,Peak,$32.60,$51.98
+HU,Hungary,US48,Mississippi,NonPeak,$29.28,$33.75
+HU,Hungary,US48,Mississippi,Peak,$34.55,$39.82
+HU,Hungary,US49,Florida-North,NonPeak,$30.90,$31.40
+HU,Hungary,US49,Florida-North,Peak,$36.46,$37.05
+HU,Hungary,US4964400,Florida-South,NonPeak,$15.28,$44.17
+HU,Hungary,US4964400,Florida-South,Peak,$18.03,$52.12
+HU,Hungary,US4965500,Florida Keys,NonPeak,$16.05,$33.98
+HU,Hungary,US4965500,Florida Keys,Peak,$18.94,$40.10
+HU,Hungary,US50,Minnesota,NonPeak,$16.80,$31.45
+HU,Hungary,US50,Minnesota,Peak,$19.82,$37.11
+HU,Hungary,US51,North Dakota,NonPeak,$17.57,$44.28
+HU,Hungary,US51,North Dakota,Peak,$20.73,$52.25
+HU,Hungary,US52,South Dakota,NonPeak,$18.33,$34.11
+HU,Hungary,US52,South Dakota,Peak,$21.63,$40.25
+HU,Hungary,US53,Iowa,NonPeak,$24.38,$31.63
+HU,Hungary,US53,Iowa,Peak,$28.77,$37.32
+HU,Hungary,US55,Nebraska,NonPeak,$16.00,$44.51
+HU,Hungary,US55,Nebraska,Peak,$18.88,$52.52
+HU,Hungary,US56,Missouri,NonPeak,$27.63,$34.33
+HU,Hungary,US56,Missouri,Peak,$32.60,$40.51
+HU,Hungary,US58,Kansas,NonPeak,$29.28,$31.74
+HU,Hungary,US58,Kansas,Peak,$34.55,$37.45
+HU,Hungary,US60,Arkansas,NonPeak,$30.90,$44.62
+HU,Hungary,US60,Arkansas,Peak,$36.46,$52.65
+HU,Hungary,US62,Oklahoma,NonPeak,$15.28,$34.45
+HU,Hungary,US62,Oklahoma,Peak,$18.03,$40.65
+HU,Hungary,US64,Louisiana,NonPeak,$16.05,$31.91
+HU,Hungary,US64,Louisiana,Peak,$18.94,$37.65
+HU,Hungary,US66,Texas-North,NonPeak,$16.80,$44.74
+HU,Hungary,US66,Texas-North,Peak,$19.82,$52.79
+HU,Hungary,US68,Texas-South,NonPeak,$17.57,$34.56
+HU,Hungary,US68,Texas-South,Peak,$20.73,$40.78
+HU,Hungary,US70,Montana,NonPeak,$18.33,$32.09
+HU,Hungary,US70,Montana,Peak,$21.63,$37.87
+HU,Hungary,US72,Wyoming,NonPeak,$24.38,$44.91
+HU,Hungary,US72,Wyoming,Peak,$28.77,$52.99
+HU,Hungary,US74,Colorado,NonPeak,$16.00,$34.74
+HU,Hungary,US74,Colorado,Peak,$18.88,$40.99
+HU,Hungary,US76,Utah,NonPeak,$27.63,$32.26
+HU,Hungary,US76,Utah,Peak,$32.60,$38.07
+HU,Hungary,US77,New Mexico,NonPeak,$29.28,$45.09
+HU,Hungary,US77,New Mexico,Peak,$34.55,$53.21
+HU,Hungary,US79,Arizona,NonPeak,$30.90,$34.90
+HU,Hungary,US79,Arizona,Peak,$36.46,$41.18
+HU,Hungary,US83,Idaho,NonPeak,$15.28,$32.44
+HU,Hungary,US83,Idaho,Peak,$18.03,$38.28
+HU,Hungary,US84,Washington,NonPeak,$16.05,$43.94
+HU,Hungary,US84,Washington,Peak,$18.94,$51.85
+HU,Hungary,US85,Oregon,NonPeak,$16.80,$33.70
+HU,Hungary,US85,Oregon,Peak,$19.82,$39.77
+HU,Hungary,US86,Nevada,NonPeak,$17.57,$31.29
+HU,Hungary,US86,Nevada,Peak,$20.73,$36.92
+HU,Hungary,US87,California-North,NonPeak,$18.33,$44.05
+HU,Hungary,US87,California-North,Peak,$21.63,$51.98
+HU,Hungary,US88,California-South,NonPeak,$24.38,$33.75
+HU,Hungary,US88,California-South,Peak,$28.77,$39.82
+IT,Italy,US11,Maine,NonPeak,$16.00,$31.40
+IT,Italy,US11,Maine,Peak,$18.88,$37.05
+IT,Italy,US12,New Hampshire,NonPeak,$27.63,$44.17
+IT,Italy,US12,New Hampshire,Peak,$32.60,$52.12
+IT,Italy,US13,Vermont,NonPeak,$29.28,$33.98
+IT,Italy,US13,Vermont,Peak,$34.55,$40.10
+IT,Italy,US14,Massachusetts,NonPeak,$30.90,$31.45
+IT,Italy,US14,Massachusetts,Peak,$36.46,$37.11
+IT,Italy,US15,Rhode Island,NonPeak,$15.28,$44.28
+IT,Italy,US15,Rhode Island,Peak,$18.03,$52.25
+IT,Italy,US16,Connecticut,NonPeak,$16.05,$34.11
+IT,Italy,US16,Connecticut,Peak,$18.94,$40.25
+IT,Italy,US17,New York,NonPeak,$16.80,$31.63
+IT,Italy,US17,New York,Peak,$19.82,$37.32
+IT,Italy,US19,New Jersey,NonPeak,$17.57,$44.51
+IT,Italy,US19,New Jersey,Peak,$20.73,$52.52
+IT,Italy,US20,Pennsylvania,NonPeak,$18.33,$34.33
+IT,Italy,US20,Pennsylvania,Peak,$21.63,$40.51
+IT,Italy,US22,Delaware,NonPeak,$24.38,$31.74
+IT,Italy,US22,Delaware,Peak,$28.77,$37.45
+IT,Italy,US23,Maryland,NonPeak,$16.00,$44.62
+IT,Italy,US23,Maryland,Peak,$18.88,$52.65
+IT,Italy,US24,District Of Columbia,NonPeak,$27.63,$34.45
+IT,Italy,US24,District Of Columbia,Peak,$32.60,$40.65
+IT,Italy,US25,Virginia,NonPeak,$29.28,$31.91
+IT,Italy,US25,Virginia,Peak,$34.55,$37.65
+IT,Italy,US27,West Virginia,NonPeak,$30.90,$44.74
+IT,Italy,US27,West Virginia,Peak,$36.46,$52.79
+IT,Italy,US28,Kentucky,NonPeak,$15.28,$34.56
+IT,Italy,US28,Kentucky,Peak,$18.03,$40.78
+IT,Italy,US30,Michigan,NonPeak,$16.05,$32.09
+IT,Italy,US30,Michigan,Peak,$18.94,$37.87
+IT,Italy,US32,Wisconsin,NonPeak,$16.80,$44.91
+IT,Italy,US32,Wisconsin,Peak,$19.82,$52.99
+IT,Italy,US34,Ohio,NonPeak,$17.57,$34.74
+IT,Italy,US34,Ohio,Peak,$20.73,$40.99
+IT,Italy,US36,Indiana,NonPeak,$18.33,$32.26
+IT,Italy,US36,Indiana,Peak,$21.63,$38.07
+IT,Italy,US38,Illinois,NonPeak,$24.38,$45.09
+IT,Italy,US38,Illinois,Peak,$28.77,$53.21
+IT,Italy,US40,North Carolina,NonPeak,$16.00,$34.90
+IT,Italy,US40,North Carolina,Peak,$18.88,$41.18
+IT,Italy,US42,Tennessee,NonPeak,$27.63,$32.44
+IT,Italy,US42,Tennessee,Peak,$32.60,$38.28
+IT,Italy,US44,South Carolina,NonPeak,$29.28,$43.94
+IT,Italy,US44,South Carolina,Peak,$34.55,$51.85
+IT,Italy,US45,Georgia,NonPeak,$30.90,$33.70
+IT,Italy,US45,Georgia,Peak,$36.46,$39.77
+IT,Italy,US47,Alabama,NonPeak,$15.28,$31.29
+IT,Italy,US47,Alabama,Peak,$18.03,$36.92
+IT,Italy,US48,Mississippi,NonPeak,$16.05,$44.05
+IT,Italy,US48,Mississippi,Peak,$18.94,$51.98
+IT,Italy,US49,Florida-North,NonPeak,$16.80,$33.75
+IT,Italy,US49,Florida-North,Peak,$19.82,$39.82
+IT,Italy,US4964400,Florida-South,NonPeak,$17.57,$31.40
+IT,Italy,US4964400,Florida-South,Peak,$20.73,$37.05
+IT,Italy,US4965500,Florida Keys,NonPeak,$18.33,$44.17
+IT,Italy,US4965500,Florida Keys,Peak,$21.63,$52.12
+IT,Italy,US50,Minnesota,NonPeak,$24.38,$33.98
+IT,Italy,US50,Minnesota,Peak,$28.77,$40.10
+IT,Italy,US51,North Dakota,NonPeak,$16.00,$31.45
+IT,Italy,US51,North Dakota,Peak,$18.88,$37.11
+IT,Italy,US52,South Dakota,NonPeak,$27.63,$44.28
+IT,Italy,US52,South Dakota,Peak,$32.60,$52.25
+IT,Italy,US53,Iowa,NonPeak,$29.28,$34.11
+IT,Italy,US53,Iowa,Peak,$34.55,$40.25
+IT,Italy,US55,Nebraska,NonPeak,$30.90,$31.63
+IT,Italy,US55,Nebraska,Peak,$36.46,$37.32
+IT,Italy,US56,Missouri,NonPeak,$15.28,$44.51
+IT,Italy,US56,Missouri,Peak,$18.03,$52.52
+IT,Italy,US58,Kansas,NonPeak,$16.05,$34.33
+IT,Italy,US58,Kansas,Peak,$18.94,$40.51
+IT,Italy,US60,Arkansas,NonPeak,$16.80,$31.74
+IT,Italy,US60,Arkansas,Peak,$19.82,$37.45
+IT,Italy,US62,Oklahoma,NonPeak,$17.57,$44.62
+IT,Italy,US62,Oklahoma,Peak,$20.73,$52.65
+IT,Italy,US64,Louisiana,NonPeak,$18.33,$34.45
+IT,Italy,US64,Louisiana,Peak,$21.63,$40.65
+IT,Italy,US66,Texas-North,NonPeak,$24.38,$31.91
+IT,Italy,US66,Texas-North,Peak,$28.77,$37.65
+IT,Italy,US68,Texas-South,NonPeak,$16.00,$44.74
+IT,Italy,US68,Texas-South,Peak,$18.88,$52.79
+IT,Italy,US70,Montana,NonPeak,$27.63,$34.56
+IT,Italy,US70,Montana,Peak,$32.60,$40.78
+IT,Italy,US72,Wyoming,NonPeak,$29.28,$32.09
+IT,Italy,US72,Wyoming,Peak,$34.55,$37.87
+IT,Italy,US74,Colorado,NonPeak,$30.90,$44.91
+IT,Italy,US74,Colorado,Peak,$36.46,$52.99
+IT,Italy,US76,Utah,NonPeak,$15.28,$34.74
+IT,Italy,US76,Utah,Peak,$18.03,$40.99
+IT,Italy,US77,New Mexico,NonPeak,$16.05,$32.26
+IT,Italy,US77,New Mexico,Peak,$18.94,$38.07
+IT,Italy,US79,Arizona,NonPeak,$16.80,$45.09
+IT,Italy,US79,Arizona,Peak,$19.82,$53.21
+IT,Italy,US83,Idaho,NonPeak,$17.57,$34.90
+IT,Italy,US83,Idaho,Peak,$20.73,$41.18
+IT,Italy,US84,Washington,NonPeak,$18.33,$32.44
+IT,Italy,US84,Washington,Peak,$21.63,$38.28
+IT,Italy,US85,Oregon,NonPeak,$24.38,$43.94
+IT,Italy,US85,Oregon,Peak,$28.77,$51.85
+IT,Italy,US86,Nevada,NonPeak,$16.00,$33.70
+IT,Italy,US86,Nevada,Peak,$18.88,$39.77
+IT,Italy,US87,California-North,NonPeak,$27.63,$31.29
+IT,Italy,US87,California-North,Peak,$32.60,$36.92
+IT,Italy,US88,California-South,NonPeak,$29.28,$44.05
+IT,Italy,US88,California-South,Peak,$34.55,$51.98
+IT10,Sicily,US11,Maine,NonPeak,$30.90,$33.75
+IT10,Sicily,US11,Maine,Peak,$36.46,$39.82
+IT10,Sicily,US12,New Hampshire,NonPeak,$15.28,$31.40
+IT10,Sicily,US12,New Hampshire,Peak,$18.03,$37.05
+IT10,Sicily,US13,Vermont,NonPeak,$16.05,$44.17
+IT10,Sicily,US13,Vermont,Peak,$18.94,$52.12
+IT10,Sicily,US14,Massachusetts,NonPeak,$16.80,$33.98
+IT10,Sicily,US14,Massachusetts,Peak,$19.82,$40.10
+IT10,Sicily,US15,Rhode Island,NonPeak,$17.57,$31.45
+IT10,Sicily,US15,Rhode Island,Peak,$20.73,$37.11
+IT10,Sicily,US16,Connecticut,NonPeak,$18.33,$44.28
+IT10,Sicily,US16,Connecticut,Peak,$21.63,$52.25
+IT10,Sicily,US17,New York,NonPeak,$24.38,$34.11
+IT10,Sicily,US17,New York,Peak,$28.77,$40.25
+IT10,Sicily,US19,New Jersey,NonPeak,$16.00,$31.63
+IT10,Sicily,US19,New Jersey,Peak,$18.88,$37.32
+IT10,Sicily,US20,Pennsylvania,NonPeak,$27.63,$44.51
+IT10,Sicily,US20,Pennsylvania,Peak,$32.60,$52.52
+IT10,Sicily,US22,Delaware,NonPeak,$29.28,$34.33
+IT10,Sicily,US22,Delaware,Peak,$34.55,$40.51
+IT10,Sicily,US23,Maryland,NonPeak,$30.90,$31.74
+IT10,Sicily,US23,Maryland,Peak,$36.46,$37.45
+IT10,Sicily,US24,District Of Columbia,NonPeak,$15.28,$44.62
+IT10,Sicily,US24,District Of Columbia,Peak,$18.03,$52.65
+IT10,Sicily,US25,Virginia,NonPeak,$16.05,$34.45
+IT10,Sicily,US25,Virginia,Peak,$18.94,$40.65
+IT10,Sicily,US27,West Virginia,NonPeak,$16.80,$31.91
+IT10,Sicily,US27,West Virginia,Peak,$19.82,$37.65
+IT10,Sicily,US28,Kentucky,NonPeak,$17.57,$44.74
+IT10,Sicily,US28,Kentucky,Peak,$20.73,$52.79
+IT10,Sicily,US30,Michigan,NonPeak,$18.33,$34.56
+IT10,Sicily,US30,Michigan,Peak,$21.63,$40.78
+IT10,Sicily,US32,Wisconsin,NonPeak,$24.38,$32.09
+IT10,Sicily,US32,Wisconsin,Peak,$28.77,$37.87
+IT10,Sicily,US34,Ohio,NonPeak,$16.00,$44.91
+IT10,Sicily,US34,Ohio,Peak,$18.88,$52.99
+IT10,Sicily,US36,Indiana,NonPeak,$27.63,$34.74
+IT10,Sicily,US36,Indiana,Peak,$32.60,$40.99
+IT10,Sicily,US38,Illinois,NonPeak,$29.28,$32.26
+IT10,Sicily,US38,Illinois,Peak,$34.55,$38.07
+IT10,Sicily,US40,North Carolina,NonPeak,$30.90,$45.09
+IT10,Sicily,US40,North Carolina,Peak,$36.46,$53.21
+IT10,Sicily,US42,Tennessee,NonPeak,$15.28,$34.90
+IT10,Sicily,US42,Tennessee,Peak,$18.03,$41.18
+IT10,Sicily,US44,South Carolina,NonPeak,$16.05,$32.44
+IT10,Sicily,US44,South Carolina,Peak,$18.94,$38.28
+IT10,Sicily,US45,Georgia,NonPeak,$16.80,$43.94
+IT10,Sicily,US45,Georgia,Peak,$19.82,$51.85
+IT10,Sicily,US47,Alabama,NonPeak,$17.57,$33.70
+IT10,Sicily,US47,Alabama,Peak,$20.73,$39.77
+IT10,Sicily,US48,Mississippi,NonPeak,$18.33,$31.29
+IT10,Sicily,US48,Mississippi,Peak,$21.63,$36.92
+IT10,Sicily,US49,Florida-North,NonPeak,$24.38,$44.05
+IT10,Sicily,US49,Florida-North,Peak,$28.77,$51.98
+IT10,Sicily,US4964400,Florida-South,NonPeak,$16.00,$33.75
+IT10,Sicily,US4964400,Florida-South,Peak,$18.88,$39.82
+IT10,Sicily,US4965500,Florida Keys,NonPeak,$27.63,$31.40
+IT10,Sicily,US4965500,Florida Keys,Peak,$32.60,$37.05
+IT10,Sicily,US50,Minnesota,NonPeak,$29.28,$44.17
+IT10,Sicily,US50,Minnesota,Peak,$34.55,$52.12
+IT10,Sicily,US51,North Dakota,NonPeak,$30.90,$33.98
+IT10,Sicily,US51,North Dakota,Peak,$36.46,$40.10
+IT10,Sicily,US52,South Dakota,NonPeak,$15.28,$31.45
+IT10,Sicily,US52,South Dakota,Peak,$18.03,$37.11
+IT10,Sicily,US53,Iowa,NonPeak,$16.05,$44.28
+IT10,Sicily,US53,Iowa,Peak,$18.94,$52.25
+IT10,Sicily,US55,Nebraska,NonPeak,$16.80,$34.11
+IT10,Sicily,US55,Nebraska,Peak,$19.82,$40.25
+IT10,Sicily,US56,Missouri,NonPeak,$17.57,$31.63
+IT10,Sicily,US56,Missouri,Peak,$20.73,$37.32
+IT10,Sicily,US58,Kansas,NonPeak,$18.33,$44.51
+IT10,Sicily,US58,Kansas,Peak,$21.63,$52.52
+IT10,Sicily,US60,Arkansas,NonPeak,$24.38,$34.33
+IT10,Sicily,US60,Arkansas,Peak,$28.77,$40.51
+IT10,Sicily,US62,Oklahoma,NonPeak,$16.00,$31.74
+IT10,Sicily,US62,Oklahoma,Peak,$18.88,$37.45
+IT10,Sicily,US64,Louisiana,NonPeak,$27.63,$44.62
+IT10,Sicily,US64,Louisiana,Peak,$32.60,$52.65
+IT10,Sicily,US66,Texas-North,NonPeak,$29.28,$34.45
+IT10,Sicily,US66,Texas-North,Peak,$34.55,$40.65
+IT10,Sicily,US68,Texas-South,NonPeak,$30.90,$31.91
+IT10,Sicily,US68,Texas-South,Peak,$36.46,$37.65
+IT10,Sicily,US70,Montana,NonPeak,$15.28,$44.74
+IT10,Sicily,US70,Montana,Peak,$18.03,$52.79
+IT10,Sicily,US72,Wyoming,NonPeak,$16.05,$34.56
+IT10,Sicily,US72,Wyoming,Peak,$18.94,$40.78
+IT10,Sicily,US74,Colorado,NonPeak,$16.80,$32.09
+IT10,Sicily,US74,Colorado,Peak,$19.82,$37.87
+IT10,Sicily,US76,Utah,NonPeak,$17.57,$44.91
+IT10,Sicily,US76,Utah,Peak,$20.73,$52.99
+IT10,Sicily,US77,New Mexico,NonPeak,$18.33,$34.74
+IT10,Sicily,US77,New Mexico,Peak,$21.63,$40.99
+IT10,Sicily,US79,Arizona,NonPeak,$24.38,$32.26
+IT10,Sicily,US79,Arizona,Peak,$28.77,$38.07
+IT10,Sicily,US83,Idaho,NonPeak,$16.00,$45.09
+IT10,Sicily,US83,Idaho,Peak,$18.88,$53.21
+IT10,Sicily,US84,Washington,NonPeak,$27.63,$34.90
+IT10,Sicily,US84,Washington,Peak,$32.60,$41.18
+IT10,Sicily,US85,Oregon,NonPeak,$29.28,$32.44
+IT10,Sicily,US85,Oregon,Peak,$34.55,$38.28
+IT10,Sicily,US86,Nevada,NonPeak,$30.90,$43.94
+IT10,Sicily,US86,Nevada,Peak,$36.46,$51.85
+IT10,Sicily,US87,California-North,NonPeak,$15.28,$33.70
+IT10,Sicily,US87,California-North,Peak,$18.03,$39.77
+IT10,Sicily,US88,California-South,NonPeak,$16.05,$31.29
+IT10,Sicily,US88,California-South,Peak,$18.94,$36.92
+JA01,Japan-Central,US11,Maine,NonPeak,$16.80,$44.05
+JA01,Japan-Central,US11,Maine,Peak,$19.82,$51.98
+JA01,Japan-Central,US12,New Hampshire,NonPeak,$17.57,$33.75
+JA01,Japan-Central,US12,New Hampshire,Peak,$20.73,$39.82
+JA01,Japan-Central,US13,Vermont,NonPeak,$18.33,$31.40
+JA01,Japan-Central,US13,Vermont,Peak,$21.63,$37.05
+JA01,Japan-Central,US14,Massachusetts,NonPeak,$24.38,$44.17
+JA01,Japan-Central,US14,Massachusetts,Peak,$28.77,$52.12
+JA01,Japan-Central,US15,Rhode Island,NonPeak,$16.00,$33.98
+JA01,Japan-Central,US15,Rhode Island,Peak,$18.88,$40.10
+JA01,Japan-Central,US16,Connecticut,NonPeak,$27.63,$31.45
+JA01,Japan-Central,US16,Connecticut,Peak,$32.60,$37.11
+JA01,Japan-Central,US17,New York,NonPeak,$29.28,$44.28
+JA01,Japan-Central,US17,New York,Peak,$34.55,$52.25
+JA01,Japan-Central,US19,New Jersey,NonPeak,$30.90,$34.11
+JA01,Japan-Central,US19,New Jersey,Peak,$36.46,$40.25
+JA01,Japan-Central,US20,Pennsylvania,NonPeak,$15.28,$31.63
+JA01,Japan-Central,US20,Pennsylvania,Peak,$18.03,$37.32
+JA01,Japan-Central,US22,Delaware,NonPeak,$16.05,$44.51
+JA01,Japan-Central,US22,Delaware,Peak,$18.94,$52.52
+JA01,Japan-Central,US23,Maryland,NonPeak,$16.80,$34.33
+JA01,Japan-Central,US23,Maryland,Peak,$19.82,$40.51
+JA01,Japan-Central,US24,District Of Columbia,NonPeak,$17.57,$31.74
+JA01,Japan-Central,US24,District Of Columbia,Peak,$20.73,$37.45
+JA01,Japan-Central,US25,Virginia,NonPeak,$18.33,$44.62
+JA01,Japan-Central,US25,Virginia,Peak,$21.63,$52.65
+JA01,Japan-Central,US27,West Virginia,NonPeak,$24.38,$34.45
+JA01,Japan-Central,US27,West Virginia,Peak,$28.77,$40.65
+JA01,Japan-Central,US28,Kentucky,NonPeak,$16.00,$31.91
+JA01,Japan-Central,US28,Kentucky,Peak,$18.88,$37.65
+JA01,Japan-Central,US30,Michigan,NonPeak,$27.63,$44.74
+JA01,Japan-Central,US30,Michigan,Peak,$32.60,$52.79
+JA01,Japan-Central,US32,Wisconsin,NonPeak,$29.28,$34.56
+JA01,Japan-Central,US32,Wisconsin,Peak,$34.55,$40.78
+JA01,Japan-Central,US34,Ohio,NonPeak,$30.90,$32.09
+JA01,Japan-Central,US34,Ohio,Peak,$36.46,$37.87
+JA01,Japan-Central,US36,Indiana,NonPeak,$15.28,$44.91
+JA01,Japan-Central,US36,Indiana,Peak,$18.03,$52.99
+JA01,Japan-Central,US38,Illinois,NonPeak,$16.05,$34.74
+JA01,Japan-Central,US38,Illinois,Peak,$18.94,$40.99
+JA01,Japan-Central,US40,North Carolina,NonPeak,$16.80,$32.26
+JA01,Japan-Central,US40,North Carolina,Peak,$19.82,$38.07
+JA01,Japan-Central,US42,Tennessee,NonPeak,$17.57,$45.09
+JA01,Japan-Central,US42,Tennessee,Peak,$20.73,$53.21
+JA01,Japan-Central,US44,South Carolina,NonPeak,$18.33,$34.90
+JA01,Japan-Central,US44,South Carolina,Peak,$21.63,$41.18
+JA01,Japan-Central,US45,Georgia,NonPeak,$24.38,$32.44
+JA01,Japan-Central,US45,Georgia,Peak,$28.77,$38.28
+JA01,Japan-Central,US47,Alabama,NonPeak,$16.00,$43.94
+JA01,Japan-Central,US47,Alabama,Peak,$18.88,$51.85
+JA01,Japan-Central,US48,Mississippi,NonPeak,$27.63,$33.70
+JA01,Japan-Central,US48,Mississippi,Peak,$32.60,$39.77
+JA01,Japan-Central,US49,Florida-North,NonPeak,$29.28,$31.29
+JA01,Japan-Central,US49,Florida-North,Peak,$34.55,$36.92
+JA01,Japan-Central,US4964400,Florida-South,NonPeak,$30.90,$44.05
+JA01,Japan-Central,US4964400,Florida-South,Peak,$36.46,$51.98
+JA01,Japan-Central,US4965500,Florida Keys,NonPeak,$15.28,$33.75
+JA01,Japan-Central,US4965500,Florida Keys,Peak,$18.03,$39.82
+JA01,Japan-Central,US50,Minnesota,NonPeak,$16.05,$31.40
+JA01,Japan-Central,US50,Minnesota,Peak,$18.94,$37.05
+JA01,Japan-Central,US51,North Dakota,NonPeak,$16.80,$44.17
+JA01,Japan-Central,US51,North Dakota,Peak,$19.82,$52.12
+JA01,Japan-Central,US52,South Dakota,NonPeak,$17.57,$33.98
+JA01,Japan-Central,US52,South Dakota,Peak,$20.73,$40.10
+JA01,Japan-Central,US53,Iowa,NonPeak,$18.33,$31.45
+JA01,Japan-Central,US53,Iowa,Peak,$21.63,$37.11
+JA01,Japan-Central,US55,Nebraska,NonPeak,$24.38,$44.28
+JA01,Japan-Central,US55,Nebraska,Peak,$28.77,$52.25
+JA01,Japan-Central,US56,Missouri,NonPeak,$16.00,$34.11
+JA01,Japan-Central,US56,Missouri,Peak,$18.88,$40.25
+JA01,Japan-Central,US58,Kansas,NonPeak,$27.63,$31.63
+JA01,Japan-Central,US58,Kansas,Peak,$32.60,$37.32
+JA01,Japan-Central,US60,Arkansas,NonPeak,$29.28,$44.51
+JA01,Japan-Central,US60,Arkansas,Peak,$34.55,$52.52
+JA01,Japan-Central,US62,Oklahoma,NonPeak,$30.90,$34.33
+JA01,Japan-Central,US62,Oklahoma,Peak,$36.46,$40.51
+JA01,Japan-Central,US64,Louisiana,NonPeak,$15.28,$31.74
+JA01,Japan-Central,US64,Louisiana,Peak,$18.03,$37.45
+JA01,Japan-Central,US66,Texas-North,NonPeak,$16.05,$44.62
+JA01,Japan-Central,US66,Texas-North,Peak,$18.94,$52.65
+JA01,Japan-Central,US68,Texas-South,NonPeak,$16.80,$34.45
+JA01,Japan-Central,US68,Texas-South,Peak,$19.82,$40.65
+JA01,Japan-Central,US70,Montana,NonPeak,$17.57,$31.91
+JA01,Japan-Central,US70,Montana,Peak,$20.73,$37.65
+JA01,Japan-Central,US72,Wyoming,NonPeak,$18.33,$44.74
+JA01,Japan-Central,US72,Wyoming,Peak,$21.63,$52.79
+JA01,Japan-Central,US74,Colorado,NonPeak,$24.38,$34.56
+JA01,Japan-Central,US74,Colorado,Peak,$28.77,$40.78
+JA01,Japan-Central,US76,Utah,NonPeak,$16.00,$32.09
+JA01,Japan-Central,US76,Utah,Peak,$18.88,$37.87
+JA01,Japan-Central,US77,New Mexico,NonPeak,$27.63,$44.91
+JA01,Japan-Central,US77,New Mexico,Peak,$32.60,$52.99
+JA01,Japan-Central,US79,Arizona,NonPeak,$29.28,$34.74
+JA01,Japan-Central,US79,Arizona,Peak,$34.55,$40.99
+JA01,Japan-Central,US83,Idaho,NonPeak,$30.90,$32.26
+JA01,Japan-Central,US83,Idaho,Peak,$36.46,$38.07
+JA01,Japan-Central,US84,Washington,NonPeak,$15.28,$45.09
+JA01,Japan-Central,US84,Washington,Peak,$18.03,$53.21
+JA01,Japan-Central,US85,Oregon,NonPeak,$16.05,$34.90
+JA01,Japan-Central,US85,Oregon,Peak,$18.94,$41.18
+JA01,Japan-Central,US86,Nevada,NonPeak,$16.80,$32.44
+JA01,Japan-Central,US86,Nevada,Peak,$19.82,$38.28
+JA01,Japan-Central,US87,California-North,NonPeak,$17.57,$43.94
+JA01,Japan-Central,US87,California-North,Peak,$20.73,$51.85
+JA01,Japan-Central,US88,California-South,NonPeak,$18.33,$33.70
+JA01,Japan-Central,US88,California-South,Peak,$21.63,$39.77
+JA02,Japan-South (Excludes Hokkaido),US11,Maine,NonPeak,$24.38,$31.29
+JA02,Japan-South (Excludes Hokkaido),US11,Maine,Peak,$28.77,$36.92
+JA02,Japan-South (Excludes Hokkaido),US12,New Hampshire,NonPeak,$16.00,$44.05
+JA02,Japan-South (Excludes Hokkaido),US12,New Hampshire,Peak,$18.88,$51.98
+JA02,Japan-South (Excludes Hokkaido),US13,Vermont,NonPeak,$27.63,$33.75
+JA02,Japan-South (Excludes Hokkaido),US13,Vermont,Peak,$32.60,$39.82
+JA02,Japan-South (Excludes Hokkaido),US14,Massachusetts,NonPeak,$29.28,$31.40
+JA02,Japan-South (Excludes Hokkaido),US14,Massachusetts,Peak,$34.55,$37.05
+JA02,Japan-South (Excludes Hokkaido),US15,Rhode Island,NonPeak,$30.90,$44.17
+JA02,Japan-South (Excludes Hokkaido),US15,Rhode Island,Peak,$36.46,$52.12
+JA02,Japan-South (Excludes Hokkaido),US16,Connecticut,NonPeak,$15.28,$33.98
+JA02,Japan-South (Excludes Hokkaido),US16,Connecticut,Peak,$18.03,$40.10
+JA02,Japan-South (Excludes Hokkaido),US17,New York,NonPeak,$16.05,$31.45
+JA02,Japan-South (Excludes Hokkaido),US17,New York,Peak,$18.94,$37.11
+JA02,Japan-South (Excludes Hokkaido),US19,New Jersey,NonPeak,$16.80,$44.28
+JA02,Japan-South (Excludes Hokkaido),US19,New Jersey,Peak,$19.82,$52.25
+JA02,Japan-South (Excludes Hokkaido),US20,Pennsylvania,NonPeak,$17.57,$34.11
+JA02,Japan-South (Excludes Hokkaido),US20,Pennsylvania,Peak,$20.73,$40.25
+JA02,Japan-South (Excludes Hokkaido),US22,Delaware,NonPeak,$18.33,$31.63
+JA02,Japan-South (Excludes Hokkaido),US22,Delaware,Peak,$21.63,$37.32
+JA02,Japan-South (Excludes Hokkaido),US23,Maryland,NonPeak,$24.38,$44.51
+JA02,Japan-South (Excludes Hokkaido),US23,Maryland,Peak,$28.77,$52.52
+JA02,Japan-South (Excludes Hokkaido),US24,District Of Columbia,NonPeak,$16.00,$34.33
+JA02,Japan-South (Excludes Hokkaido),US24,District Of Columbia,Peak,$18.88,$40.51
+JA02,Japan-South (Excludes Hokkaido),US25,Virginia,NonPeak,$27.63,$31.74
+JA02,Japan-South (Excludes Hokkaido),US25,Virginia,Peak,$32.60,$37.45
+JA02,Japan-South (Excludes Hokkaido),US27,West Virginia,NonPeak,$29.28,$44.62
+JA02,Japan-South (Excludes Hokkaido),US27,West Virginia,Peak,$34.55,$52.65
+JA02,Japan-South (Excludes Hokkaido),US28,Kentucky,NonPeak,$30.90,$34.45
+JA02,Japan-South (Excludes Hokkaido),US28,Kentucky,Peak,$36.46,$40.65
+JA02,Japan-South (Excludes Hokkaido),US30,Michigan,NonPeak,$15.28,$31.91
+JA02,Japan-South (Excludes Hokkaido),US30,Michigan,Peak,$18.03,$37.65
+JA02,Japan-South (Excludes Hokkaido),US32,Wisconsin,NonPeak,$16.05,$44.74
+JA02,Japan-South (Excludes Hokkaido),US32,Wisconsin,Peak,$18.94,$52.79
+JA02,Japan-South (Excludes Hokkaido),US34,Ohio,NonPeak,$16.80,$34.56
+JA02,Japan-South (Excludes Hokkaido),US34,Ohio,Peak,$19.82,$40.78
+JA02,Japan-South (Excludes Hokkaido),US36,Indiana,NonPeak,$17.57,$32.09
+JA02,Japan-South (Excludes Hokkaido),US36,Indiana,Peak,$20.73,$37.87
+JA02,Japan-South (Excludes Hokkaido),US38,Illinois,NonPeak,$18.33,$44.91
+JA02,Japan-South (Excludes Hokkaido),US38,Illinois,Peak,$21.63,$52.99
+JA02,Japan-South (Excludes Hokkaido),US40,North Carolina,NonPeak,$24.38,$34.74
+JA02,Japan-South (Excludes Hokkaido),US40,North Carolina,Peak,$28.77,$40.99
+JA02,Japan-South (Excludes Hokkaido),US42,Tennessee,NonPeak,$16.00,$32.26
+JA02,Japan-South (Excludes Hokkaido),US42,Tennessee,Peak,$18.88,$38.07
+JA02,Japan-South (Excludes Hokkaido),US44,South Carolina,NonPeak,$27.63,$45.09
+JA02,Japan-South (Excludes Hokkaido),US44,South Carolina,Peak,$32.60,$53.21
+JA02,Japan-South (Excludes Hokkaido),US45,Georgia,NonPeak,$29.28,$34.90
+JA02,Japan-South (Excludes Hokkaido),US45,Georgia,Peak,$34.55,$41.18
+JA02,Japan-South (Excludes Hokkaido),US47,Alabama,NonPeak,$30.90,$32.44
+JA02,Japan-South (Excludes Hokkaido),US47,Alabama,Peak,$36.46,$38.28
+JA02,Japan-South (Excludes Hokkaido),US48,Mississippi,NonPeak,$15.28,$43.94
+JA02,Japan-South (Excludes Hokkaido),US48,Mississippi,Peak,$18.03,$51.85
+JA02,Japan-South (Excludes Hokkaido),US49,Florida-North,NonPeak,$16.05,$33.70
+JA02,Japan-South (Excludes Hokkaido),US49,Florida-North,Peak,$18.94,$39.77
+JA02,Japan-South (Excludes Hokkaido),US4964400,Florida-South,NonPeak,$16.80,$31.29
+JA02,Japan-South (Excludes Hokkaido),US4964400,Florida-South,Peak,$19.82,$36.92
+JA02,Japan-South (Excludes Hokkaido),US4965500,Florida Keys,NonPeak,$17.57,$44.05
+JA02,Japan-South (Excludes Hokkaido),US4965500,Florida Keys,Peak,$20.73,$51.98
+JA02,Japan-South (Excludes Hokkaido),US50,Minnesota,NonPeak,$18.33,$33.75
+JA02,Japan-South (Excludes Hokkaido),US50,Minnesota,Peak,$21.63,$39.82
+JA02,Japan-South (Excludes Hokkaido),US51,North Dakota,NonPeak,$24.38,$31.40
+JA02,Japan-South (Excludes Hokkaido),US51,North Dakota,Peak,$28.77,$37.05
+JA02,Japan-South (Excludes Hokkaido),US52,South Dakota,NonPeak,$16.00,$44.17
+JA02,Japan-South (Excludes Hokkaido),US52,South Dakota,Peak,$18.88,$52.12
+JA02,Japan-South (Excludes Hokkaido),US53,Iowa,NonPeak,$27.63,$33.98
+JA02,Japan-South (Excludes Hokkaido),US53,Iowa,Peak,$32.60,$40.10
+JA02,Japan-South (Excludes Hokkaido),US55,Nebraska,NonPeak,$29.28,$31.45
+JA02,Japan-South (Excludes Hokkaido),US55,Nebraska,Peak,$34.55,$37.11
+JA02,Japan-South (Excludes Hokkaido),US56,Missouri,NonPeak,$30.90,$44.28
+JA02,Japan-South (Excludes Hokkaido),US56,Missouri,Peak,$36.46,$52.25
+JA02,Japan-South (Excludes Hokkaido),US58,Kansas,NonPeak,$15.28,$34.11
+JA02,Japan-South (Excludes Hokkaido),US58,Kansas,Peak,$18.03,$40.25
+JA02,Japan-South (Excludes Hokkaido),US60,Arkansas,NonPeak,$16.05,$31.63
+JA02,Japan-South (Excludes Hokkaido),US60,Arkansas,Peak,$18.94,$37.32
+JA02,Japan-South (Excludes Hokkaido),US62,Oklahoma,NonPeak,$16.80,$44.51
+JA02,Japan-South (Excludes Hokkaido),US62,Oklahoma,Peak,$19.82,$52.52
+JA02,Japan-South (Excludes Hokkaido),US64,Louisiana,NonPeak,$17.57,$34.33
+JA02,Japan-South (Excludes Hokkaido),US64,Louisiana,Peak,$20.73,$40.51
+JA02,Japan-South (Excludes Hokkaido),US66,Texas-North,NonPeak,$18.33,$31.74
+JA02,Japan-South (Excludes Hokkaido),US66,Texas-North,Peak,$21.63,$37.45
+JA02,Japan-South (Excludes Hokkaido),US68,Texas-South,NonPeak,$24.38,$44.62
+JA02,Japan-South (Excludes Hokkaido),US68,Texas-South,Peak,$28.77,$52.65
+JA02,Japan-South (Excludes Hokkaido),US70,Montana,NonPeak,$16.00,$34.45
+JA02,Japan-South (Excludes Hokkaido),US70,Montana,Peak,$18.88,$40.65
+JA02,Japan-South (Excludes Hokkaido),US72,Wyoming,NonPeak,$27.63,$31.91
+JA02,Japan-South (Excludes Hokkaido),US72,Wyoming,Peak,$32.60,$37.65
+JA02,Japan-South (Excludes Hokkaido),US74,Colorado,NonPeak,$29.28,$44.74
+JA02,Japan-South (Excludes Hokkaido),US74,Colorado,Peak,$34.55,$52.79
+JA02,Japan-South (Excludes Hokkaido),US76,Utah,NonPeak,$30.90,$34.56
+JA02,Japan-South (Excludes Hokkaido),US76,Utah,Peak,$36.46,$40.78
+JA02,Japan-South (Excludes Hokkaido),US77,New Mexico,NonPeak,$15.28,$32.09
+JA02,Japan-South (Excludes Hokkaido),US77,New Mexico,Peak,$18.03,$37.87
+JA02,Japan-South (Excludes Hokkaido),US79,Arizona,NonPeak,$16.05,$44.91
+JA02,Japan-South (Excludes Hokkaido),US79,Arizona,Peak,$18.94,$52.99
+JA02,Japan-South (Excludes Hokkaido),US83,Idaho,NonPeak,$16.80,$34.74
+JA02,Japan-South (Excludes Hokkaido),US83,Idaho,Peak,$19.82,$40.99
+JA02,Japan-South (Excludes Hokkaido),US84,Washington,NonPeak,$17.57,$32.26
+JA02,Japan-South (Excludes Hokkaido),US84,Washington,Peak,$20.73,$38.07
+JA02,Japan-South (Excludes Hokkaido),US85,Oregon,NonPeak,$18.33,$45.09
+JA02,Japan-South (Excludes Hokkaido),US85,Oregon,Peak,$21.63,$53.21
+JA02,Japan-South (Excludes Hokkaido),US86,Nevada,NonPeak,$24.38,$34.90
+JA02,Japan-South (Excludes Hokkaido),US86,Nevada,Peak,$28.77,$41.18
+JA02,Japan-South (Excludes Hokkaido),US87,California-North,NonPeak,$16.00,$32.44
+JA02,Japan-South (Excludes Hokkaido),US87,California-North,Peak,$18.88,$38.28
+JA02,Japan-South (Excludes Hokkaido),US88,California-South,NonPeak,$27.63,$43.94
+JA02,Japan-South (Excludes Hokkaido),US88,California-South,Peak,$32.60,$51.85
+JA03,Japan-North,US11,Maine,NonPeak,$29.28,$33.70
+JA03,Japan-North,US11,Maine,Peak,$34.55,$39.77
+JA03,Japan-North,US12,New Hampshire,NonPeak,$30.90,$31.29
+JA03,Japan-North,US12,New Hampshire,Peak,$36.46,$36.92
+JA03,Japan-North,US13,Vermont,NonPeak,$15.28,$44.05
+JA03,Japan-North,US13,Vermont,Peak,$18.03,$51.98
+JA03,Japan-North,US14,Massachusetts,NonPeak,$16.05,$33.75
+JA03,Japan-North,US14,Massachusetts,Peak,$18.94,$39.82
+JA03,Japan-North,US15,Rhode Island,NonPeak,$16.80,$31.40
+JA03,Japan-North,US15,Rhode Island,Peak,$19.82,$37.05
+JA03,Japan-North,US16,Connecticut,NonPeak,$17.57,$44.17
+JA03,Japan-North,US16,Connecticut,Peak,$20.73,$52.12
+JA03,Japan-North,US17,New York,NonPeak,$18.33,$33.98
+JA03,Japan-North,US17,New York,Peak,$21.63,$40.10
+JA03,Japan-North,US19,New Jersey,NonPeak,$24.38,$31.45
+JA03,Japan-North,US19,New Jersey,Peak,$28.77,$37.11
+JA03,Japan-North,US20,Pennsylvania,NonPeak,$16.00,$44.28
+JA03,Japan-North,US20,Pennsylvania,Peak,$18.88,$52.25
+JA03,Japan-North,US22,Delaware,NonPeak,$27.63,$34.11
+JA03,Japan-North,US22,Delaware,Peak,$32.60,$40.25
+JA03,Japan-North,US23,Maryland,NonPeak,$29.28,$31.63
+JA03,Japan-North,US23,Maryland,Peak,$34.55,$37.32
+JA03,Japan-North,US24,District Of Columbia,NonPeak,$30.90,$44.51
+JA03,Japan-North,US24,District Of Columbia,Peak,$36.46,$52.52
+JA03,Japan-North,US25,Virginia,NonPeak,$15.28,$34.33
+JA03,Japan-North,US25,Virginia,Peak,$18.03,$40.51
+JA03,Japan-North,US27,West Virginia,NonPeak,$16.05,$31.74
+JA03,Japan-North,US27,West Virginia,Peak,$18.94,$37.45
+JA03,Japan-North,US28,Kentucky,NonPeak,$16.80,$44.62
+JA03,Japan-North,US28,Kentucky,Peak,$19.82,$52.65
+JA03,Japan-North,US30,Michigan,NonPeak,$17.57,$34.45
+JA03,Japan-North,US30,Michigan,Peak,$20.73,$40.65
+JA03,Japan-North,US32,Wisconsin,NonPeak,$18.33,$31.91
+JA03,Japan-North,US32,Wisconsin,Peak,$21.63,$37.65
+JA03,Japan-North,US34,Ohio,NonPeak,$24.38,$44.74
+JA03,Japan-North,US34,Ohio,Peak,$28.77,$52.79
+JA03,Japan-North,US36,Indiana,NonPeak,$16.00,$34.56
+JA03,Japan-North,US36,Indiana,Peak,$18.88,$40.78
+JA03,Japan-North,US38,Illinois,NonPeak,$27.63,$32.09
+JA03,Japan-North,US38,Illinois,Peak,$32.60,$37.87
+JA03,Japan-North,US40,North Carolina,NonPeak,$29.28,$44.91
+JA03,Japan-North,US40,North Carolina,Peak,$34.55,$52.99
+JA03,Japan-North,US42,Tennessee,NonPeak,$30.90,$34.74
+JA03,Japan-North,US42,Tennessee,Peak,$36.46,$40.99
+JA03,Japan-North,US44,South Carolina,NonPeak,$15.28,$32.26
+JA03,Japan-North,US44,South Carolina,Peak,$18.03,$38.07
+JA03,Japan-North,US45,Georgia,NonPeak,$16.05,$45.09
+JA03,Japan-North,US45,Georgia,Peak,$18.94,$53.21
+JA03,Japan-North,US47,Alabama,NonPeak,$16.80,$34.90
+JA03,Japan-North,US47,Alabama,Peak,$19.82,$41.18
+JA03,Japan-North,US48,Mississippi,NonPeak,$17.57,$32.44
+JA03,Japan-North,US48,Mississippi,Peak,$20.73,$38.28
+JA03,Japan-North,US49,Florida-North,NonPeak,$18.33,$43.94
+JA03,Japan-North,US49,Florida-North,Peak,$21.63,$51.85
+JA03,Japan-North,US4964400,Florida-South,NonPeak,$24.38,$33.70
+JA03,Japan-North,US4964400,Florida-South,Peak,$28.77,$39.77
+JA03,Japan-North,US4965500,Florida Keys,NonPeak,$16.00,$31.29
+JA03,Japan-North,US4965500,Florida Keys,Peak,$18.88,$36.92
+JA03,Japan-North,US50,Minnesota,NonPeak,$27.63,$44.05
+JA03,Japan-North,US50,Minnesota,Peak,$32.60,$51.98
+JA03,Japan-North,US51,North Dakota,NonPeak,$29.28,$33.75
+JA03,Japan-North,US51,North Dakota,Peak,$34.55,$39.82
+JA03,Japan-North,US52,South Dakota,NonPeak,$30.90,$31.40
+JA03,Japan-North,US52,South Dakota,Peak,$36.46,$37.05
+JA03,Japan-North,US53,Iowa,NonPeak,$15.28,$44.17
+JA03,Japan-North,US53,Iowa,Peak,$18.03,$52.12
+JA03,Japan-North,US55,Nebraska,NonPeak,$16.05,$33.98
+JA03,Japan-North,US55,Nebraska,Peak,$18.94,$40.10
+JA03,Japan-North,US56,Missouri,NonPeak,$16.80,$31.45
+JA03,Japan-North,US56,Missouri,Peak,$19.82,$37.11
+JA03,Japan-North,US58,Kansas,NonPeak,$17.57,$44.28
+JA03,Japan-North,US58,Kansas,Peak,$20.73,$52.25
+JA03,Japan-North,US60,Arkansas,NonPeak,$18.33,$34.11
+JA03,Japan-North,US60,Arkansas,Peak,$21.63,$40.25
+JA03,Japan-North,US62,Oklahoma,NonPeak,$24.38,$31.63
+JA03,Japan-North,US62,Oklahoma,Peak,$28.77,$37.32
+JA03,Japan-North,US64,Louisiana,NonPeak,$16.00,$44.51
+JA03,Japan-North,US64,Louisiana,Peak,$18.88,$52.52
+JA03,Japan-North,US66,Texas-North,NonPeak,$27.63,$34.33
+JA03,Japan-North,US66,Texas-North,Peak,$32.60,$40.51
+JA03,Japan-North,US68,Texas-South,NonPeak,$29.28,$31.74
+JA03,Japan-North,US68,Texas-South,Peak,$34.55,$37.45
+JA03,Japan-North,US70,Montana,NonPeak,$30.90,$44.62
+JA03,Japan-North,US70,Montana,Peak,$36.46,$52.65
+JA03,Japan-North,US72,Wyoming,NonPeak,$15.28,$34.45
+JA03,Japan-North,US72,Wyoming,Peak,$18.03,$40.65
+JA03,Japan-North,US74,Colorado,NonPeak,$16.05,$31.91
+JA03,Japan-North,US74,Colorado,Peak,$18.94,$37.65
+JA03,Japan-North,US76,Utah,NonPeak,$16.80,$44.74
+JA03,Japan-North,US76,Utah,Peak,$19.82,$52.79
+JA03,Japan-North,US77,New Mexico,NonPeak,$17.57,$34.56
+JA03,Japan-North,US77,New Mexico,Peak,$20.73,$40.78
+JA03,Japan-North,US79,Arizona,NonPeak,$18.33,$32.09
+JA03,Japan-North,US79,Arizona,Peak,$21.63,$37.87
+JA03,Japan-North,US83,Idaho,NonPeak,$24.38,$44.91
+JA03,Japan-North,US83,Idaho,Peak,$28.77,$52.99
+JA03,Japan-North,US84,Washington,NonPeak,$16.00,$34.74
+JA03,Japan-North,US84,Washington,Peak,$18.88,$40.99
+JA03,Japan-North,US85,Oregon,NonPeak,$27.63,$32.26
+JA03,Japan-North,US85,Oregon,Peak,$32.60,$38.07
+JA03,Japan-North,US86,Nevada,NonPeak,$29.28,$45.09
+JA03,Japan-North,US86,Nevada,Peak,$34.55,$53.21
+JA03,Japan-North,US87,California-North,NonPeak,$30.90,$34.90
+JA03,Japan-North,US87,California-North,Peak,$36.46,$41.18
+JA03,Japan-North,US88,California-South,NonPeak,$15.28,$32.44
+JA03,Japan-North,US88,California-South,Peak,$18.03,$38.28
+JA96,Okinawa,US11,Maine,NonPeak,$16.05,$43.94
+JA96,Okinawa,US11,Maine,Peak,$18.94,$51.85
+JA96,Okinawa,US12,New Hampshire,NonPeak,$16.80,$33.70
+JA96,Okinawa,US12,New Hampshire,Peak,$19.82,$39.77
+JA96,Okinawa,US13,Vermont,NonPeak,$17.57,$31.29
+JA96,Okinawa,US13,Vermont,Peak,$20.73,$36.92
+JA96,Okinawa,US14,Massachusetts,NonPeak,$18.33,$44.05
+JA96,Okinawa,US14,Massachusetts,Peak,$21.63,$51.98
+JA96,Okinawa,US15,Rhode Island,NonPeak,$24.38,$33.75
+JA96,Okinawa,US15,Rhode Island,Peak,$28.77,$39.82
+JA96,Okinawa,US16,Connecticut,NonPeak,$16.00,$31.40
+JA96,Okinawa,US16,Connecticut,Peak,$18.88,$37.05
+JA96,Okinawa,US17,New York,NonPeak,$27.63,$44.17
+JA96,Okinawa,US17,New York,Peak,$32.60,$52.12
+JA96,Okinawa,US19,New Jersey,NonPeak,$29.28,$33.98
+JA96,Okinawa,US19,New Jersey,Peak,$34.55,$40.10
+JA96,Okinawa,US20,Pennsylvania,NonPeak,$30.90,$31.45
+JA96,Okinawa,US20,Pennsylvania,Peak,$36.46,$37.11
+JA96,Okinawa,US22,Delaware,NonPeak,$15.28,$44.28
+JA96,Okinawa,US22,Delaware,Peak,$18.03,$52.25
+JA96,Okinawa,US23,Maryland,NonPeak,$16.05,$34.11
+JA96,Okinawa,US23,Maryland,Peak,$18.94,$40.25
+JA96,Okinawa,US24,District Of Columbia,NonPeak,$16.80,$31.63
+JA96,Okinawa,US24,District Of Columbia,Peak,$19.82,$37.32
+JA96,Okinawa,US25,Virginia,NonPeak,$17.57,$44.51
+JA96,Okinawa,US25,Virginia,Peak,$20.73,$52.52
+JA96,Okinawa,US27,West Virginia,NonPeak,$18.33,$34.33
+JA96,Okinawa,US27,West Virginia,Peak,$21.63,$40.51
+JA96,Okinawa,US28,Kentucky,NonPeak,$24.38,$31.74
+JA96,Okinawa,US28,Kentucky,Peak,$28.77,$37.45
+JA96,Okinawa,US30,Michigan,NonPeak,$16.00,$44.62
+JA96,Okinawa,US30,Michigan,Peak,$18.88,$52.65
+JA96,Okinawa,US32,Wisconsin,NonPeak,$27.63,$34.45
+JA96,Okinawa,US32,Wisconsin,Peak,$32.60,$40.65
+JA96,Okinawa,US34,Ohio,NonPeak,$29.28,$31.91
+JA96,Okinawa,US34,Ohio,Peak,$34.55,$37.65
+JA96,Okinawa,US36,Indiana,NonPeak,$30.90,$44.74
+JA96,Okinawa,US36,Indiana,Peak,$36.46,$52.79
+JA96,Okinawa,US38,Illinois,NonPeak,$15.28,$34.56
+JA96,Okinawa,US38,Illinois,Peak,$18.03,$40.78
+JA96,Okinawa,US40,North Carolina,NonPeak,$16.05,$32.09
+JA96,Okinawa,US40,North Carolina,Peak,$18.94,$37.87
+JA96,Okinawa,US42,Tennessee,NonPeak,$16.80,$44.91
+JA96,Okinawa,US42,Tennessee,Peak,$19.82,$52.99
+JA96,Okinawa,US44,South Carolina,NonPeak,$17.57,$34.74
+JA96,Okinawa,US44,South Carolina,Peak,$20.73,$40.99
+JA96,Okinawa,US45,Georgia,NonPeak,$18.33,$32.26
+JA96,Okinawa,US45,Georgia,Peak,$21.63,$38.07
+JA96,Okinawa,US47,Alabama,NonPeak,$24.38,$45.09
+JA96,Okinawa,US47,Alabama,Peak,$28.77,$53.21
+JA96,Okinawa,US48,Mississippi,NonPeak,$16.00,$34.90
+JA96,Okinawa,US48,Mississippi,Peak,$18.88,$41.18
+JA96,Okinawa,US49,Florida-North,NonPeak,$27.63,$32.44
+JA96,Okinawa,US49,Florida-North,Peak,$32.60,$38.28
+JA96,Okinawa,US4964400,Florida-South,NonPeak,$29.28,$43.94
+JA96,Okinawa,US4964400,Florida-South,Peak,$34.55,$51.85
+JA96,Okinawa,US4965500,Florida Keys,NonPeak,$30.90,$33.70
+JA96,Okinawa,US4965500,Florida Keys,Peak,$36.46,$39.77
+JA96,Okinawa,US50,Minnesota,NonPeak,$15.28,$31.29
+JA96,Okinawa,US50,Minnesota,Peak,$18.03,$36.92
+JA96,Okinawa,US51,North Dakota,NonPeak,$16.05,$44.05
+JA96,Okinawa,US51,North Dakota,Peak,$18.94,$51.98
+JA96,Okinawa,US52,South Dakota,NonPeak,$16.80,$33.75
+JA96,Okinawa,US52,South Dakota,Peak,$19.82,$39.82
+JA96,Okinawa,US53,Iowa,NonPeak,$17.57,$31.40
+JA96,Okinawa,US53,Iowa,Peak,$20.73,$37.05
+JA96,Okinawa,US55,Nebraska,NonPeak,$18.33,$44.17
+JA96,Okinawa,US55,Nebraska,Peak,$21.63,$52.12
+JA96,Okinawa,US56,Missouri,NonPeak,$24.38,$33.98
+JA96,Okinawa,US56,Missouri,Peak,$28.77,$40.10
+JA96,Okinawa,US58,Kansas,NonPeak,$16.00,$31.45
+JA96,Okinawa,US58,Kansas,Peak,$18.88,$37.11
+JA96,Okinawa,US60,Arkansas,NonPeak,$27.63,$44.28
+JA96,Okinawa,US60,Arkansas,Peak,$32.60,$52.25
+JA96,Okinawa,US62,Oklahoma,NonPeak,$29.28,$34.11
+JA96,Okinawa,US62,Oklahoma,Peak,$34.55,$40.25
+JA96,Okinawa,US64,Louisiana,NonPeak,$30.90,$31.63
+JA96,Okinawa,US64,Louisiana,Peak,$36.46,$37.32
+JA96,Okinawa,US66,Texas-North,NonPeak,$15.28,$44.51
+JA96,Okinawa,US66,Texas-North,Peak,$18.03,$52.52
+JA96,Okinawa,US68,Texas-South,NonPeak,$16.05,$34.33
+JA96,Okinawa,US68,Texas-South,Peak,$18.94,$40.51
+JA96,Okinawa,US70,Montana,NonPeak,$16.80,$31.74
+JA96,Okinawa,US70,Montana,Peak,$19.82,$37.45
+JA96,Okinawa,US72,Wyoming,NonPeak,$17.57,$44.62
+JA96,Okinawa,US72,Wyoming,Peak,$20.73,$52.65
+JA96,Okinawa,US74,Colorado,NonPeak,$18.33,$34.45
+JA96,Okinawa,US74,Colorado,Peak,$21.63,$40.65
+JA96,Okinawa,US76,Utah,NonPeak,$24.38,$31.91
+JA96,Okinawa,US76,Utah,Peak,$28.77,$37.65
+JA96,Okinawa,US77,New Mexico,NonPeak,$16.00,$44.74
+JA96,Okinawa,US77,New Mexico,Peak,$18.88,$52.79
+JA96,Okinawa,US79,Arizona,NonPeak,$27.63,$34.56
+JA96,Okinawa,US79,Arizona,Peak,$32.60,$40.78
+JA96,Okinawa,US83,Idaho,NonPeak,$29.28,$32.09
+JA96,Okinawa,US83,Idaho,Peak,$34.55,$37.87
+JA96,Okinawa,US84,Washington,NonPeak,$30.90,$44.91
+JA96,Okinawa,US84,Washington,Peak,$36.46,$52.99
+JA96,Okinawa,US85,Oregon,NonPeak,$15.28,$34.74
+JA96,Okinawa,US85,Oregon,Peak,$18.03,$40.99
+JA96,Okinawa,US86,Nevada,NonPeak,$16.05,$32.26
+JA96,Okinawa,US86,Nevada,Peak,$18.94,$38.07
+JA96,Okinawa,US87,California-North,NonPeak,$16.80,$45.09
+JA96,Okinawa,US87,California-North,Peak,$19.82,$53.21
+JA96,Okinawa,US88,California-South,NonPeak,$17.57,$34.90
+JA96,Okinawa,US88,California-South,Peak,$20.73,$41.18
+KS,"Korea, Republic Of",US11,Maine,NonPeak,$18.33,$32.44
+KS,"Korea, Republic Of",US11,Maine,Peak,$21.63,$38.28
+KS,"Korea, Republic Of",US12,New Hampshire,NonPeak,$24.38,$43.94
+KS,"Korea, Republic Of",US12,New Hampshire,Peak,$28.77,$51.85
+KS,"Korea, Republic Of",US13,Vermont,NonPeak,$16.00,$33.70
+KS,"Korea, Republic Of",US13,Vermont,Peak,$18.88,$39.77
+KS,"Korea, Republic Of",US14,Massachusetts,NonPeak,$27.63,$31.29
+KS,"Korea, Republic Of",US14,Massachusetts,Peak,$32.60,$36.92
+KS,"Korea, Republic Of",US15,Rhode Island,NonPeak,$29.28,$44.05
+KS,"Korea, Republic Of",US15,Rhode Island,Peak,$34.55,$51.98
+KS,"Korea, Republic Of",US16,Connecticut,NonPeak,$30.90,$33.75
+KS,"Korea, Republic Of",US16,Connecticut,Peak,$36.46,$39.82
+KS,"Korea, Republic Of",US17,New York,NonPeak,$15.28,$31.40
+KS,"Korea, Republic Of",US17,New York,Peak,$18.03,$37.05
+KS,"Korea, Republic Of",US19,New Jersey,NonPeak,$16.05,$44.17
+KS,"Korea, Republic Of",US19,New Jersey,Peak,$18.94,$52.12
+KS,"Korea, Republic Of",US20,Pennsylvania,NonPeak,$16.80,$33.98
+KS,"Korea, Republic Of",US20,Pennsylvania,Peak,$19.82,$40.10
+KS,"Korea, Republic Of",US22,Delaware,NonPeak,$17.57,$31.45
+KS,"Korea, Republic Of",US22,Delaware,Peak,$20.73,$37.11
+KS,"Korea, Republic Of",US23,Maryland,NonPeak,$18.33,$44.28
+KS,"Korea, Republic Of",US23,Maryland,Peak,$21.63,$52.25
+KS,"Korea, Republic Of",US24,District Of Columbia,NonPeak,$24.38,$34.11
+KS,"Korea, Republic Of",US24,District Of Columbia,Peak,$28.77,$40.25
+KS,"Korea, Republic Of",US25,Virginia,NonPeak,$16.00,$31.63
+KS,"Korea, Republic Of",US25,Virginia,Peak,$18.88,$37.32
+KS,"Korea, Republic Of",US27,West Virginia,NonPeak,$27.63,$44.51
+KS,"Korea, Republic Of",US27,West Virginia,Peak,$32.60,$52.52
+KS,"Korea, Republic Of",US28,Kentucky,NonPeak,$29.28,$34.33
+KS,"Korea, Republic Of",US28,Kentucky,Peak,$34.55,$40.51
+KS,"Korea, Republic Of",US30,Michigan,NonPeak,$30.90,$31.74
+KS,"Korea, Republic Of",US30,Michigan,Peak,$36.46,$37.45
+KS,"Korea, Republic Of",US32,Wisconsin,NonPeak,$15.28,$44.62
+KS,"Korea, Republic Of",US32,Wisconsin,Peak,$18.03,$52.65
+KS,"Korea, Republic Of",US34,Ohio,NonPeak,$16.05,$34.45
+KS,"Korea, Republic Of",US34,Ohio,Peak,$18.94,$40.65
+KS,"Korea, Republic Of",US36,Indiana,NonPeak,$16.80,$31.91
+KS,"Korea, Republic Of",US36,Indiana,Peak,$19.82,$37.65
+KS,"Korea, Republic Of",US38,Illinois,NonPeak,$17.57,$44.74
+KS,"Korea, Republic Of",US38,Illinois,Peak,$20.73,$52.79
+KS,"Korea, Republic Of",US40,North Carolina,NonPeak,$18.33,$34.56
+KS,"Korea, Republic Of",US40,North Carolina,Peak,$21.63,$40.78
+KS,"Korea, Republic Of",US42,Tennessee,NonPeak,$24.38,$32.09
+KS,"Korea, Republic Of",US42,Tennessee,Peak,$28.77,$37.87
+KS,"Korea, Republic Of",US44,South Carolina,NonPeak,$16.00,$44.91
+KS,"Korea, Republic Of",US44,South Carolina,Peak,$18.88,$52.99
+KS,"Korea, Republic Of",US45,Georgia,NonPeak,$27.63,$34.74
+KS,"Korea, Republic Of",US45,Georgia,Peak,$32.60,$40.99
+KS,"Korea, Republic Of",US47,Alabama,NonPeak,$29.28,$32.26
+KS,"Korea, Republic Of",US47,Alabama,Peak,$34.55,$38.07
+KS,"Korea, Republic Of",US48,Mississippi,NonPeak,$30.90,$45.09
+KS,"Korea, Republic Of",US48,Mississippi,Peak,$36.46,$53.21
+KS,"Korea, Republic Of",US49,Florida-North,NonPeak,$15.28,$34.90
+KS,"Korea, Republic Of",US49,Florida-North,Peak,$18.03,$41.18
+KS,"Korea, Republic Of",US4964400,Florida-South,NonPeak,$16.05,$32.44
+KS,"Korea, Republic Of",US4964400,Florida-South,Peak,$18.94,$38.28
+KS,"Korea, Republic Of",US4965500,Florida Keys,NonPeak,$16.80,$43.94
+KS,"Korea, Republic Of",US4965500,Florida Keys,Peak,$19.82,$51.85
+KS,"Korea, Republic Of",US50,Minnesota,NonPeak,$17.57,$33.70
+KS,"Korea, Republic Of",US50,Minnesota,Peak,$20.73,$39.77
+KS,"Korea, Republic Of",US51,North Dakota,NonPeak,$18.33,$31.29
+KS,"Korea, Republic Of",US51,North Dakota,Peak,$21.63,$36.92
+KS,"Korea, Republic Of",US52,South Dakota,NonPeak,$24.38,$44.05
+KS,"Korea, Republic Of",US52,South Dakota,Peak,$28.77,$51.98
+KS,"Korea, Republic Of",US53,Iowa,NonPeak,$16.00,$33.75
+KS,"Korea, Republic Of",US53,Iowa,Peak,$18.88,$39.82
+KS,"Korea, Republic Of",US55,Nebraska,NonPeak,$27.63,$31.40
+KS,"Korea, Republic Of",US55,Nebraska,Peak,$32.60,$37.05
+KS,"Korea, Republic Of",US56,Missouri,NonPeak,$29.28,$44.17
+KS,"Korea, Republic Of",US56,Missouri,Peak,$34.55,$52.12
+KS,"Korea, Republic Of",US58,Kansas,NonPeak,$30.90,$33.98
+KS,"Korea, Republic Of",US58,Kansas,Peak,$36.46,$40.10
+KS,"Korea, Republic Of",US60,Arkansas,NonPeak,$15.28,$31.45
+KS,"Korea, Republic Of",US60,Arkansas,Peak,$18.03,$37.11
+KS,"Korea, Republic Of",US62,Oklahoma,NonPeak,$16.05,$44.28
+KS,"Korea, Republic Of",US62,Oklahoma,Peak,$18.94,$52.25
+KS,"Korea, Republic Of",US64,Louisiana,NonPeak,$16.80,$34.11
+KS,"Korea, Republic Of",US64,Louisiana,Peak,$19.82,$40.25
+KS,"Korea, Republic Of",US66,Texas-North,NonPeak,$17.57,$31.63
+KS,"Korea, Republic Of",US66,Texas-North,Peak,$20.73,$37.32
+KS,"Korea, Republic Of",US68,Texas-South,NonPeak,$18.33,$44.51
+KS,"Korea, Republic Of",US68,Texas-South,Peak,$21.63,$52.52
+KS,"Korea, Republic Of",US70,Montana,NonPeak,$24.38,$34.33
+KS,"Korea, Republic Of",US70,Montana,Peak,$28.77,$40.51
+KS,"Korea, Republic Of",US72,Wyoming,NonPeak,$16.00,$31.74
+KS,"Korea, Republic Of",US72,Wyoming,Peak,$18.88,$37.45
+KS,"Korea, Republic Of",US74,Colorado,NonPeak,$27.63,$44.62
+KS,"Korea, Republic Of",US74,Colorado,Peak,$32.60,$52.65
+KS,"Korea, Republic Of",US76,Utah,NonPeak,$29.28,$34.45
+KS,"Korea, Republic Of",US76,Utah,Peak,$34.55,$40.65
+KS,"Korea, Republic Of",US77,New Mexico,NonPeak,$30.90,$31.91
+KS,"Korea, Republic Of",US77,New Mexico,Peak,$36.46,$37.65
+KS,"Korea, Republic Of",US79,Arizona,NonPeak,$15.28,$44.74
+KS,"Korea, Republic Of",US79,Arizona,Peak,$18.03,$52.79
+KS,"Korea, Republic Of",US83,Idaho,NonPeak,$16.05,$34.56
+KS,"Korea, Republic Of",US83,Idaho,Peak,$18.94,$40.78
+KS,"Korea, Republic Of",US84,Washington,NonPeak,$16.80,$32.09
+KS,"Korea, Republic Of",US84,Washington,Peak,$19.82,$37.87
+KS,"Korea, Republic Of",US85,Oregon,NonPeak,$17.57,$44.91
+KS,"Korea, Republic Of",US85,Oregon,Peak,$20.73,$52.99
+KS,"Korea, Republic Of",US86,Nevada,NonPeak,$18.33,$34.74
+KS,"Korea, Republic Of",US86,Nevada,Peak,$21.63,$40.99
+KS,"Korea, Republic Of",US87,California-North,NonPeak,$24.38,$32.26
+KS,"Korea, Republic Of",US87,California-North,Peak,$28.77,$38.07
+KS,"Korea, Republic Of",US88,California-South,NonPeak,$16.00,$45.09
+KS,"Korea, Republic Of",US88,California-South,Peak,$18.88,$53.21
+KU,Kuwait,US11,Maine,NonPeak,$27.63,$34.90
+KU,Kuwait,US11,Maine,Peak,$32.60,$41.18
+KU,Kuwait,US12,New Hampshire,NonPeak,$29.28,$32.44
+KU,Kuwait,US12,New Hampshire,Peak,$34.55,$38.28
+KU,Kuwait,US13,Vermont,NonPeak,$30.90,$43.94
+KU,Kuwait,US13,Vermont,Peak,$36.46,$51.85
+KU,Kuwait,US14,Massachusetts,NonPeak,$15.28,$33.70
+KU,Kuwait,US14,Massachusetts,Peak,$18.03,$39.77
+KU,Kuwait,US15,Rhode Island,NonPeak,$16.05,$31.29
+KU,Kuwait,US15,Rhode Island,Peak,$18.94,$36.92
+KU,Kuwait,US16,Connecticut,NonPeak,$16.80,$44.05
+KU,Kuwait,US16,Connecticut,Peak,$19.82,$51.98
+KU,Kuwait,US17,New York,NonPeak,$17.57,$33.75
+KU,Kuwait,US17,New York,Peak,$20.73,$39.82
+KU,Kuwait,US19,New Jersey,NonPeak,$18.33,$31.40
+KU,Kuwait,US19,New Jersey,Peak,$21.63,$37.05
+KU,Kuwait,US20,Pennsylvania,NonPeak,$24.38,$44.17
+KU,Kuwait,US20,Pennsylvania,Peak,$28.77,$52.12
+KU,Kuwait,US22,Delaware,NonPeak,$16.00,$33.98
+KU,Kuwait,US22,Delaware,Peak,$18.88,$40.10
+KU,Kuwait,US23,Maryland,NonPeak,$27.63,$31.45
+KU,Kuwait,US23,Maryland,Peak,$32.60,$37.11
+KU,Kuwait,US24,District Of Columbia,NonPeak,$29.28,$44.28
+KU,Kuwait,US24,District Of Columbia,Peak,$34.55,$52.25
+KU,Kuwait,US25,Virginia,NonPeak,$30.90,$34.11
+KU,Kuwait,US25,Virginia,Peak,$36.46,$40.25
+KU,Kuwait,US27,West Virginia,NonPeak,$15.28,$31.63
+KU,Kuwait,US27,West Virginia,Peak,$18.03,$37.32
+KU,Kuwait,US28,Kentucky,NonPeak,$16.05,$44.51
+KU,Kuwait,US28,Kentucky,Peak,$18.94,$52.52
+KU,Kuwait,US30,Michigan,NonPeak,$16.80,$34.33
+KU,Kuwait,US30,Michigan,Peak,$19.82,$40.51
+KU,Kuwait,US32,Wisconsin,NonPeak,$17.57,$31.74
+KU,Kuwait,US32,Wisconsin,Peak,$20.73,$37.45
+KU,Kuwait,US34,Ohio,NonPeak,$18.33,$44.62
+KU,Kuwait,US34,Ohio,Peak,$21.63,$52.65
+KU,Kuwait,US36,Indiana,NonPeak,$24.38,$34.45
+KU,Kuwait,US36,Indiana,Peak,$28.77,$40.65
+KU,Kuwait,US38,Illinois,NonPeak,$16.00,$31.91
+KU,Kuwait,US38,Illinois,Peak,$18.88,$37.65
+KU,Kuwait,US40,North Carolina,NonPeak,$27.63,$44.74
+KU,Kuwait,US40,North Carolina,Peak,$32.60,$52.79
+KU,Kuwait,US42,Tennessee,NonPeak,$29.28,$34.56
+KU,Kuwait,US42,Tennessee,Peak,$34.55,$40.78
+KU,Kuwait,US44,South Carolina,NonPeak,$30.90,$32.09
+KU,Kuwait,US44,South Carolina,Peak,$36.46,$37.87
+KU,Kuwait,US45,Georgia,NonPeak,$15.28,$44.91
+KU,Kuwait,US45,Georgia,Peak,$18.03,$52.99
+KU,Kuwait,US47,Alabama,NonPeak,$16.05,$34.74
+KU,Kuwait,US47,Alabama,Peak,$18.94,$40.99
+KU,Kuwait,US48,Mississippi,NonPeak,$16.80,$32.26
+KU,Kuwait,US48,Mississippi,Peak,$19.82,$38.07
+KU,Kuwait,US49,Florida-North,NonPeak,$17.57,$45.09
+KU,Kuwait,US49,Florida-North,Peak,$20.73,$53.21
+KU,Kuwait,US4964400,Florida-South,NonPeak,$18.33,$34.90
+KU,Kuwait,US4964400,Florida-South,Peak,$21.63,$41.18
+KU,Kuwait,US4965500,Florida Keys,NonPeak,$24.38,$32.44
+KU,Kuwait,US4965500,Florida Keys,Peak,$28.77,$38.28
+KU,Kuwait,US50,Minnesota,NonPeak,$16.00,$43.94
+KU,Kuwait,US50,Minnesota,Peak,$18.88,$51.85
+KU,Kuwait,US51,North Dakota,NonPeak,$27.63,$33.70
+KU,Kuwait,US51,North Dakota,Peak,$32.60,$39.77
+KU,Kuwait,US52,South Dakota,NonPeak,$29.28,$31.29
+KU,Kuwait,US52,South Dakota,Peak,$34.55,$36.92
+KU,Kuwait,US53,Iowa,NonPeak,$30.90,$44.05
+KU,Kuwait,US53,Iowa,Peak,$36.46,$51.98
+KU,Kuwait,US55,Nebraska,NonPeak,$15.28,$33.75
+KU,Kuwait,US55,Nebraska,Peak,$18.03,$39.82
+KU,Kuwait,US56,Missouri,NonPeak,$16.05,$31.40
+KU,Kuwait,US56,Missouri,Peak,$18.94,$37.05
+KU,Kuwait,US58,Kansas,NonPeak,$16.80,$44.17
+KU,Kuwait,US58,Kansas,Peak,$19.82,$52.12
+KU,Kuwait,US60,Arkansas,NonPeak,$17.57,$33.98
+KU,Kuwait,US60,Arkansas,Peak,$20.73,$40.10
+KU,Kuwait,US62,Oklahoma,NonPeak,$18.33,$31.45
+KU,Kuwait,US62,Oklahoma,Peak,$21.63,$37.11
+KU,Kuwait,US64,Louisiana,NonPeak,$24.38,$44.28
+KU,Kuwait,US64,Louisiana,Peak,$28.77,$52.25
+KU,Kuwait,US66,Texas-North,NonPeak,$16.00,$34.11
+KU,Kuwait,US66,Texas-North,Peak,$18.88,$40.25
+KU,Kuwait,US68,Texas-South,NonPeak,$27.63,$31.63
+KU,Kuwait,US68,Texas-South,Peak,$32.60,$37.32
+KU,Kuwait,US70,Montana,NonPeak,$29.28,$44.51
+KU,Kuwait,US70,Montana,Peak,$34.55,$52.52
+KU,Kuwait,US72,Wyoming,NonPeak,$30.90,$34.33
+KU,Kuwait,US72,Wyoming,Peak,$36.46,$40.51
+KU,Kuwait,US74,Colorado,NonPeak,$15.28,$31.74
+KU,Kuwait,US74,Colorado,Peak,$18.03,$37.45
+KU,Kuwait,US76,Utah,NonPeak,$16.05,$44.62
+KU,Kuwait,US76,Utah,Peak,$18.94,$52.65
+KU,Kuwait,US77,New Mexico,NonPeak,$16.80,$34.45
+KU,Kuwait,US77,New Mexico,Peak,$19.82,$40.65
+KU,Kuwait,US79,Arizona,NonPeak,$17.57,$31.91
+KU,Kuwait,US79,Arizona,Peak,$20.73,$37.65
+KU,Kuwait,US83,Idaho,NonPeak,$18.33,$44.74
+KU,Kuwait,US83,Idaho,Peak,$21.63,$52.79
+KU,Kuwait,US84,Washington,NonPeak,$24.38,$34.56
+KU,Kuwait,US84,Washington,Peak,$28.77,$40.78
+KU,Kuwait,US85,Oregon,NonPeak,$16.00,$32.09
+KU,Kuwait,US85,Oregon,Peak,$18.88,$37.87
+KU,Kuwait,US86,Nevada,NonPeak,$27.63,$44.91
+KU,Kuwait,US86,Nevada,Peak,$32.60,$52.99
+KU,Kuwait,US87,California-North,NonPeak,$29.28,$34.74
+KU,Kuwait,US87,California-North,Peak,$34.55,$40.99
+KU,Kuwait,US88,California-South,NonPeak,$30.90,$32.26
+KU,Kuwait,US88,California-South,Peak,$36.46,$38.07
+NL,Netherlands,US11,Maine,NonPeak,$15.28,$45.09
+NL,Netherlands,US11,Maine,Peak,$18.03,$53.21
+NL,Netherlands,US12,New Hampshire,NonPeak,$16.05,$34.90
+NL,Netherlands,US12,New Hampshire,Peak,$18.94,$41.18
+NL,Netherlands,US13,Vermont,NonPeak,$16.80,$32.44
+NL,Netherlands,US13,Vermont,Peak,$19.82,$38.28
+NL,Netherlands,US14,Massachusetts,NonPeak,$17.57,$43.94
+NL,Netherlands,US14,Massachusetts,Peak,$20.73,$51.85
+NL,Netherlands,US15,Rhode Island,NonPeak,$18.33,$33.70
+NL,Netherlands,US15,Rhode Island,Peak,$21.63,$39.77
+NL,Netherlands,US16,Connecticut,NonPeak,$24.38,$31.29
+NL,Netherlands,US16,Connecticut,Peak,$28.77,$36.92
+NL,Netherlands,US17,New York,NonPeak,$16.00,$44.05
+NL,Netherlands,US17,New York,Peak,$18.88,$51.98
+NL,Netherlands,US19,New Jersey,NonPeak,$27.63,$33.75
+NL,Netherlands,US19,New Jersey,Peak,$32.60,$39.82
+NL,Netherlands,US20,Pennsylvania,NonPeak,$29.28,$31.40
+NL,Netherlands,US20,Pennsylvania,Peak,$34.55,$37.05
+NL,Netherlands,US22,Delaware,NonPeak,$30.90,$44.17
+NL,Netherlands,US22,Delaware,Peak,$36.46,$52.12
+NL,Netherlands,US23,Maryland,NonPeak,$15.28,$33.98
+NL,Netherlands,US23,Maryland,Peak,$18.03,$40.10
+NL,Netherlands,US24,District Of Columbia,NonPeak,$16.05,$31.45
+NL,Netherlands,US24,District Of Columbia,Peak,$18.94,$37.11
+NL,Netherlands,US25,Virginia,NonPeak,$16.80,$44.28
+NL,Netherlands,US25,Virginia,Peak,$19.82,$52.25
+NL,Netherlands,US27,West Virginia,NonPeak,$17.57,$34.11
+NL,Netherlands,US27,West Virginia,Peak,$20.73,$40.25
+NL,Netherlands,US28,Kentucky,NonPeak,$18.33,$31.63
+NL,Netherlands,US28,Kentucky,Peak,$21.63,$37.32
+NL,Netherlands,US30,Michigan,NonPeak,$24.38,$44.51
+NL,Netherlands,US30,Michigan,Peak,$28.77,$52.52
+NL,Netherlands,US32,Wisconsin,NonPeak,$16.00,$34.33
+NL,Netherlands,US32,Wisconsin,Peak,$18.88,$40.51
+NL,Netherlands,US34,Ohio,NonPeak,$27.63,$31.74
+NL,Netherlands,US34,Ohio,Peak,$32.60,$37.45
+NL,Netherlands,US36,Indiana,NonPeak,$29.28,$44.62
+NL,Netherlands,US36,Indiana,Peak,$34.55,$52.65
+NL,Netherlands,US38,Illinois,NonPeak,$30.90,$34.45
+NL,Netherlands,US38,Illinois,Peak,$36.46,$40.65
+NL,Netherlands,US40,North Carolina,NonPeak,$15.28,$31.91
+NL,Netherlands,US40,North Carolina,Peak,$18.03,$37.65
+NL,Netherlands,US42,Tennessee,NonPeak,$16.05,$44.74
+NL,Netherlands,US42,Tennessee,Peak,$18.94,$52.79
+NL,Netherlands,US44,South Carolina,NonPeak,$16.80,$34.56
+NL,Netherlands,US44,South Carolina,Peak,$19.82,$40.78
+NL,Netherlands,US45,Georgia,NonPeak,$17.57,$32.09
+NL,Netherlands,US45,Georgia,Peak,$20.73,$37.87
+NL,Netherlands,US47,Alabama,NonPeak,$18.33,$44.91
+NL,Netherlands,US47,Alabama,Peak,$21.63,$52.99
+NL,Netherlands,US48,Mississippi,NonPeak,$24.38,$34.74
+NL,Netherlands,US48,Mississippi,Peak,$28.77,$40.99
+NL,Netherlands,US49,Florida-North,NonPeak,$16.00,$32.26
+NL,Netherlands,US49,Florida-North,Peak,$18.88,$38.07
+NL,Netherlands,US4964400,Florida-South,NonPeak,$27.63,$45.09
+NL,Netherlands,US4964400,Florida-South,Peak,$32.60,$53.21
+NL,Netherlands,US4965500,Florida Keys,NonPeak,$29.28,$34.90
+NL,Netherlands,US4965500,Florida Keys,Peak,$34.55,$41.18
+NL,Netherlands,US50,Minnesota,NonPeak,$30.90,$32.44
+NL,Netherlands,US50,Minnesota,Peak,$36.46,$38.28
+NL,Netherlands,US51,North Dakota,NonPeak,$15.28,$43.94
+NL,Netherlands,US51,North Dakota,Peak,$18.03,$51.85
+NL,Netherlands,US52,South Dakota,NonPeak,$16.05,$33.70
+NL,Netherlands,US52,South Dakota,Peak,$18.94,$39.77
+NL,Netherlands,US53,Iowa,NonPeak,$16.80,$31.29
+NL,Netherlands,US53,Iowa,Peak,$19.82,$36.92
+NL,Netherlands,US55,Nebraska,NonPeak,$17.57,$44.05
+NL,Netherlands,US55,Nebraska,Peak,$20.73,$51.98
+NL,Netherlands,US56,Missouri,NonPeak,$18.33,$33.75
+NL,Netherlands,US56,Missouri,Peak,$21.63,$39.82
+NL,Netherlands,US58,Kansas,NonPeak,$24.38,$31.40
+NL,Netherlands,US58,Kansas,Peak,$28.77,$37.05
+NL,Netherlands,US60,Arkansas,NonPeak,$16.00,$44.17
+NL,Netherlands,US60,Arkansas,Peak,$18.88,$52.12
+NL,Netherlands,US62,Oklahoma,NonPeak,$27.63,$33.98
+NL,Netherlands,US62,Oklahoma,Peak,$32.60,$40.10
+NL,Netherlands,US64,Louisiana,NonPeak,$29.28,$31.45
+NL,Netherlands,US64,Louisiana,Peak,$34.55,$37.11
+NL,Netherlands,US66,Texas-North,NonPeak,$30.90,$44.28
+NL,Netherlands,US66,Texas-North,Peak,$36.46,$52.25
+NL,Netherlands,US68,Texas-South,NonPeak,$15.28,$34.11
+NL,Netherlands,US68,Texas-South,Peak,$18.03,$40.25
+NL,Netherlands,US70,Montana,NonPeak,$16.05,$31.63
+NL,Netherlands,US70,Montana,Peak,$18.94,$37.32
+NL,Netherlands,US72,Wyoming,NonPeak,$16.80,$44.51
+NL,Netherlands,US72,Wyoming,Peak,$19.82,$52.52
+NL,Netherlands,US74,Colorado,NonPeak,$17.57,$34.33
+NL,Netherlands,US74,Colorado,Peak,$20.73,$40.51
+NL,Netherlands,US76,Utah,NonPeak,$18.33,$31.74
+NL,Netherlands,US76,Utah,Peak,$21.63,$37.45
+NL,Netherlands,US77,New Mexico,NonPeak,$24.38,$44.62
+NL,Netherlands,US77,New Mexico,Peak,$28.77,$52.65
+NL,Netherlands,US79,Arizona,NonPeak,$16.00,$34.45
+NL,Netherlands,US79,Arizona,Peak,$18.88,$40.65
+NL,Netherlands,US83,Idaho,NonPeak,$27.63,$31.91
+NL,Netherlands,US83,Idaho,Peak,$32.60,$37.65
+NL,Netherlands,US84,Washington,NonPeak,$29.28,$44.74
+NL,Netherlands,US84,Washington,Peak,$34.55,$52.79
+NL,Netherlands,US85,Oregon,NonPeak,$30.90,$34.56
+NL,Netherlands,US85,Oregon,Peak,$36.46,$40.78
+NL,Netherlands,US86,Nevada,NonPeak,$15.28,$32.09
+NL,Netherlands,US86,Nevada,Peak,$18.03,$37.87
+NL,Netherlands,US87,California-North,NonPeak,$16.05,$44.91
+NL,Netherlands,US87,California-North,Peak,$18.94,$52.99
+NL,Netherlands,US88,California-South,NonPeak,$16.80,$34.74
+NL,Netherlands,US88,California-South,Peak,$19.82,$40.99
+NO,Norway,US11,Maine,NonPeak,$17.57,$32.26
+NO,Norway,US11,Maine,Peak,$20.73,$38.07
+NO,Norway,US12,New Hampshire,NonPeak,$18.33,$45.09
+NO,Norway,US12,New Hampshire,Peak,$21.63,$53.21
+NO,Norway,US13,Vermont,NonPeak,$24.38,$34.90
+NO,Norway,US13,Vermont,Peak,$28.77,$41.18
+NO,Norway,US14,Massachusetts,NonPeak,$16.00,$32.44
+NO,Norway,US14,Massachusetts,Peak,$18.88,$38.28
+NO,Norway,US15,Rhode Island,NonPeak,$27.63,$43.94
+NO,Norway,US15,Rhode Island,Peak,$32.60,$51.85
+NO,Norway,US16,Connecticut,NonPeak,$29.28,$33.70
+NO,Norway,US16,Connecticut,Peak,$34.55,$39.77
+NO,Norway,US17,New York,NonPeak,$30.90,$31.29
+NO,Norway,US17,New York,Peak,$36.46,$36.92
+NO,Norway,US19,New Jersey,NonPeak,$15.28,$44.05
+NO,Norway,US19,New Jersey,Peak,$18.03,$51.98
+NO,Norway,US20,Pennsylvania,NonPeak,$16.05,$33.75
+NO,Norway,US20,Pennsylvania,Peak,$18.94,$39.82
+NO,Norway,US22,Delaware,NonPeak,$16.80,$31.40
+NO,Norway,US22,Delaware,Peak,$19.82,$37.05
+NO,Norway,US23,Maryland,NonPeak,$17.57,$44.17
+NO,Norway,US23,Maryland,Peak,$20.73,$52.12
+NO,Norway,US24,District Of Columbia,NonPeak,$18.33,$33.98
+NO,Norway,US24,District Of Columbia,Peak,$21.63,$40.10
+NO,Norway,US25,Virginia,NonPeak,$24.38,$31.45
+NO,Norway,US25,Virginia,Peak,$28.77,$37.11
+NO,Norway,US27,West Virginia,NonPeak,$16.00,$44.28
+NO,Norway,US27,West Virginia,Peak,$18.88,$52.25
+NO,Norway,US28,Kentucky,NonPeak,$27.63,$34.11
+NO,Norway,US28,Kentucky,Peak,$32.60,$40.25
+NO,Norway,US30,Michigan,NonPeak,$29.28,$31.63
+NO,Norway,US30,Michigan,Peak,$34.55,$37.32
+NO,Norway,US32,Wisconsin,NonPeak,$30.90,$44.51
+NO,Norway,US32,Wisconsin,Peak,$36.46,$52.52
+NO,Norway,US34,Ohio,NonPeak,$15.28,$34.33
+NO,Norway,US34,Ohio,Peak,$18.03,$40.51
+NO,Norway,US36,Indiana,NonPeak,$16.05,$31.74
+NO,Norway,US36,Indiana,Peak,$18.94,$37.45
+NO,Norway,US38,Illinois,NonPeak,$16.80,$44.62
+NO,Norway,US38,Illinois,Peak,$19.82,$52.65
+NO,Norway,US40,North Carolina,NonPeak,$17.57,$34.45
+NO,Norway,US40,North Carolina,Peak,$20.73,$40.65
+NO,Norway,US42,Tennessee,NonPeak,$18.33,$31.91
+NO,Norway,US42,Tennessee,Peak,$21.63,$37.65
+NO,Norway,US44,South Carolina,NonPeak,$24.38,$44.74
+NO,Norway,US44,South Carolina,Peak,$28.77,$52.79
+NO,Norway,US45,Georgia,NonPeak,$16.00,$34.56
+NO,Norway,US45,Georgia,Peak,$18.88,$40.78
+NO,Norway,US47,Alabama,NonPeak,$27.63,$32.09
+NO,Norway,US47,Alabama,Peak,$32.60,$37.87
+NO,Norway,US48,Mississippi,NonPeak,$29.28,$44.91
+NO,Norway,US48,Mississippi,Peak,$34.55,$52.99
+NO,Norway,US49,Florida-North,NonPeak,$30.90,$34.74
+NO,Norway,US49,Florida-North,Peak,$36.46,$40.99
+NO,Norway,US4964400,Florida-South,NonPeak,$15.28,$32.26
+NO,Norway,US4964400,Florida-South,Peak,$18.03,$38.07
+NO,Norway,US4965500,Florida Keys,NonPeak,$16.05,$45.09
+NO,Norway,US4965500,Florida Keys,Peak,$18.94,$53.21
+NO,Norway,US50,Minnesota,NonPeak,$16.80,$34.90
+NO,Norway,US50,Minnesota,Peak,$19.82,$41.18
+NO,Norway,US51,North Dakota,NonPeak,$17.57,$32.44
+NO,Norway,US51,North Dakota,Peak,$20.73,$38.28
+NO,Norway,US52,South Dakota,NonPeak,$18.33,$43.94
+NO,Norway,US52,South Dakota,Peak,$21.63,$51.85
+NO,Norway,US53,Iowa,NonPeak,$24.38,$33.70
+NO,Norway,US53,Iowa,Peak,$28.77,$39.77
+NO,Norway,US55,Nebraska,NonPeak,$16.00,$31.29
+NO,Norway,US55,Nebraska,Peak,$18.88,$36.92
+NO,Norway,US56,Missouri,NonPeak,$27.63,$44.05
+NO,Norway,US56,Missouri,Peak,$32.60,$51.98
+NO,Norway,US58,Kansas,NonPeak,$29.28,$33.75
+NO,Norway,US58,Kansas,Peak,$34.55,$39.82
+NO,Norway,US60,Arkansas,NonPeak,$30.90,$31.40
+NO,Norway,US60,Arkansas,Peak,$36.46,$37.05
+NO,Norway,US62,Oklahoma,NonPeak,$15.28,$44.17
+NO,Norway,US62,Oklahoma,Peak,$18.03,$52.12
+NO,Norway,US64,Louisiana,NonPeak,$16.05,$33.98
+NO,Norway,US64,Louisiana,Peak,$18.94,$40.10
+NO,Norway,US66,Texas-North,NonPeak,$16.80,$31.45
+NO,Norway,US66,Texas-North,Peak,$19.82,$37.11
+NO,Norway,US68,Texas-South,NonPeak,$17.57,$44.28
+NO,Norway,US68,Texas-South,Peak,$20.73,$52.25
+NO,Norway,US70,Montana,NonPeak,$18.33,$34.11
+NO,Norway,US70,Montana,Peak,$21.63,$40.25
+NO,Norway,US72,Wyoming,NonPeak,$24.38,$31.63
+NO,Norway,US72,Wyoming,Peak,$28.77,$37.32
+NO,Norway,US74,Colorado,NonPeak,$16.00,$44.51
+NO,Norway,US74,Colorado,Peak,$18.88,$52.52
+NO,Norway,US76,Utah,NonPeak,$27.63,$34.33
+NO,Norway,US76,Utah,Peak,$32.60,$40.51
+NO,Norway,US77,New Mexico,NonPeak,$29.28,$31.74
+NO,Norway,US77,New Mexico,Peak,$34.55,$37.45
+NO,Norway,US79,Arizona,NonPeak,$30.90,$44.62
+NO,Norway,US79,Arizona,Peak,$36.46,$52.65
+NO,Norway,US83,Idaho,NonPeak,$15.28,$34.45
+NO,Norway,US83,Idaho,Peak,$18.03,$40.65
+NO,Norway,US84,Washington,NonPeak,$16.05,$31.91
+NO,Norway,US84,Washington,Peak,$18.94,$37.65
+NO,Norway,US85,Oregon,NonPeak,$16.80,$44.74
+NO,Norway,US85,Oregon,Peak,$19.82,$52.79
+NO,Norway,US86,Nevada,NonPeak,$17.57,$34.56
+NO,Norway,US86,Nevada,Peak,$20.73,$40.78
+NO,Norway,US87,California-North,NonPeak,$18.33,$32.09
+NO,Norway,US87,California-North,Peak,$21.63,$37.87
+NO,Norway,US88,California-South,NonPeak,$24.38,$44.91
+NO,Norway,US88,California-South,Peak,$28.77,$52.99
+PA,Paraguay,US11,Maine,NonPeak,$16.00,$34.74
+PA,Paraguay,US11,Maine,Peak,$18.88,$40.99
+PA,Paraguay,US12,New Hampshire,NonPeak,$27.63,$32.26
+PA,Paraguay,US12,New Hampshire,Peak,$32.60,$38.07
+PA,Paraguay,US13,Vermont,NonPeak,$29.28,$45.09
+PA,Paraguay,US13,Vermont,Peak,$34.55,$53.21
+PA,Paraguay,US14,Massachusetts,NonPeak,$30.90,$34.90
+PA,Paraguay,US14,Massachusetts,Peak,$36.46,$41.18
+PA,Paraguay,US15,Rhode Island,NonPeak,$15.28,$32.44
+PA,Paraguay,US15,Rhode Island,Peak,$18.03,$38.28
+PA,Paraguay,US16,Connecticut,NonPeak,$16.05,$43.94
+PA,Paraguay,US16,Connecticut,Peak,$18.94,$51.85
+PA,Paraguay,US17,New York,NonPeak,$16.80,$33.70
+PA,Paraguay,US17,New York,Peak,$19.82,$39.77
+PA,Paraguay,US19,New Jersey,NonPeak,$17.57,$31.29
+PA,Paraguay,US19,New Jersey,Peak,$20.73,$36.92
+PA,Paraguay,US20,Pennsylvania,NonPeak,$18.33,$44.05
+PA,Paraguay,US20,Pennsylvania,Peak,$21.63,$51.98
+PA,Paraguay,US22,Delaware,NonPeak,$24.38,$33.75
+PA,Paraguay,US22,Delaware,Peak,$28.77,$39.82
+PA,Paraguay,US23,Maryland,NonPeak,$16.00,$31.40
+PA,Paraguay,US23,Maryland,Peak,$18.88,$37.05
+PA,Paraguay,US24,District Of Columbia,NonPeak,$27.63,$44.17
+PA,Paraguay,US24,District Of Columbia,Peak,$32.60,$52.12
+PA,Paraguay,US25,Virginia,NonPeak,$29.28,$33.98
+PA,Paraguay,US25,Virginia,Peak,$34.55,$40.10
+PA,Paraguay,US27,West Virginia,NonPeak,$30.90,$31.45
+PA,Paraguay,US27,West Virginia,Peak,$36.46,$37.11
+PA,Paraguay,US28,Kentucky,NonPeak,$15.28,$44.28
+PA,Paraguay,US28,Kentucky,Peak,$18.03,$52.25
+PA,Paraguay,US30,Michigan,NonPeak,$16.05,$34.11
+PA,Paraguay,US30,Michigan,Peak,$18.94,$40.25
+PA,Paraguay,US32,Wisconsin,NonPeak,$16.80,$31.63
+PA,Paraguay,US32,Wisconsin,Peak,$19.82,$37.32
+PA,Paraguay,US34,Ohio,NonPeak,$17.57,$44.51
+PA,Paraguay,US34,Ohio,Peak,$20.73,$52.52
+PA,Paraguay,US36,Indiana,NonPeak,$18.33,$34.33
+PA,Paraguay,US36,Indiana,Peak,$21.63,$40.51
+PA,Paraguay,US38,Illinois,NonPeak,$24.38,$31.74
+PA,Paraguay,US38,Illinois,Peak,$28.77,$37.45
+PA,Paraguay,US40,North Carolina,NonPeak,$16.00,$44.62
+PA,Paraguay,US40,North Carolina,Peak,$18.88,$52.65
+PA,Paraguay,US42,Tennessee,NonPeak,$27.63,$34.45
+PA,Paraguay,US42,Tennessee,Peak,$32.60,$40.65
+PA,Paraguay,US44,South Carolina,NonPeak,$29.28,$31.91
+PA,Paraguay,US44,South Carolina,Peak,$34.55,$37.65
+PA,Paraguay,US45,Georgia,NonPeak,$30.90,$44.74
+PA,Paraguay,US45,Georgia,Peak,$36.46,$52.79
+PA,Paraguay,US47,Alabama,NonPeak,$15.28,$34.56
+PA,Paraguay,US47,Alabama,Peak,$18.03,$40.78
+PA,Paraguay,US48,Mississippi,NonPeak,$16.05,$32.09
+PA,Paraguay,US48,Mississippi,Peak,$18.94,$37.87
+PA,Paraguay,US49,Florida-North,NonPeak,$16.80,$44.91
+PA,Paraguay,US49,Florida-North,Peak,$19.82,$52.99
+PA,Paraguay,US4964400,Florida-South,NonPeak,$17.57,$34.74
+PA,Paraguay,US4964400,Florida-South,Peak,$20.73,$40.99
+PA,Paraguay,US4965500,Florida Keys,NonPeak,$18.33,$32.26
+PA,Paraguay,US4965500,Florida Keys,Peak,$21.63,$38.07
+PA,Paraguay,US50,Minnesota,NonPeak,$24.38,$45.09
+PA,Paraguay,US50,Minnesota,Peak,$28.77,$53.21
+PA,Paraguay,US51,North Dakota,NonPeak,$16.00,$34.90
+PA,Paraguay,US51,North Dakota,Peak,$18.88,$41.18
+PA,Paraguay,US52,South Dakota,NonPeak,$27.63,$32.44
+PA,Paraguay,US52,South Dakota,Peak,$32.60,$38.28
+PA,Paraguay,US53,Iowa,NonPeak,$29.28,$43.94
+PA,Paraguay,US53,Iowa,Peak,$34.55,$51.85
+PA,Paraguay,US55,Nebraska,NonPeak,$30.90,$33.70
+PA,Paraguay,US55,Nebraska,Peak,$36.46,$39.77
+PA,Paraguay,US56,Missouri,NonPeak,$15.28,$31.29
+PA,Paraguay,US56,Missouri,Peak,$18.03,$36.92
+PA,Paraguay,US58,Kansas,NonPeak,$16.05,$44.05
+PA,Paraguay,US58,Kansas,Peak,$18.94,$51.98
+PA,Paraguay,US60,Arkansas,NonPeak,$16.80,$33.75
+PA,Paraguay,US60,Arkansas,Peak,$19.82,$39.82
+PA,Paraguay,US62,Oklahoma,NonPeak,$17.57,$31.40
+PA,Paraguay,US62,Oklahoma,Peak,$20.73,$37.05
+PA,Paraguay,US64,Louisiana,NonPeak,$18.33,$44.17
+PA,Paraguay,US64,Louisiana,Peak,$21.63,$52.12
+PA,Paraguay,US66,Texas-North,NonPeak,$24.38,$33.98
+PA,Paraguay,US66,Texas-North,Peak,$28.77,$40.10
+PA,Paraguay,US68,Texas-South,NonPeak,$16.00,$31.45
+PA,Paraguay,US68,Texas-South,Peak,$18.88,$37.11
+PA,Paraguay,US70,Montana,NonPeak,$27.63,$44.28
+PA,Paraguay,US70,Montana,Peak,$32.60,$52.25
+PA,Paraguay,US72,Wyoming,NonPeak,$29.28,$34.11
+PA,Paraguay,US72,Wyoming,Peak,$34.55,$40.25
+PA,Paraguay,US74,Colorado,NonPeak,$30.90,$31.63
+PA,Paraguay,US74,Colorado,Peak,$36.46,$37.32
+PA,Paraguay,US76,Utah,NonPeak,$15.28,$44.51
+PA,Paraguay,US76,Utah,Peak,$18.03,$52.52
+PA,Paraguay,US77,New Mexico,NonPeak,$16.05,$34.33
+PA,Paraguay,US77,New Mexico,Peak,$18.94,$40.51
+PA,Paraguay,US79,Arizona,NonPeak,$16.80,$31.74
+PA,Paraguay,US79,Arizona,Peak,$19.82,$37.45
+PA,Paraguay,US83,Idaho,NonPeak,$17.57,$44.62
+PA,Paraguay,US83,Idaho,Peak,$20.73,$52.65
+PA,Paraguay,US84,Washington,NonPeak,$18.33,$34.45
+PA,Paraguay,US84,Washington,Peak,$21.63,$40.65
+PA,Paraguay,US85,Oregon,NonPeak,$24.38,$31.91
+PA,Paraguay,US85,Oregon,Peak,$28.77,$37.65
+PA,Paraguay,US86,Nevada,NonPeak,$16.00,$44.74
+PA,Paraguay,US86,Nevada,Peak,$18.88,$52.79
+PA,Paraguay,US87,California-North,NonPeak,$27.63,$34.56
+PA,Paraguay,US87,California-North,Peak,$32.60,$40.78
+PA,Paraguay,US88,California-South,NonPeak,$29.28,$32.09
+PA,Paraguay,US88,California-South,Peak,$34.55,$37.87
+PE,Peru,US11,Maine,NonPeak,$30.90,$44.91
+PE,Peru,US11,Maine,Peak,$36.46,$52.99
+PE,Peru,US12,New Hampshire,NonPeak,$15.28,$34.74
+PE,Peru,US12,New Hampshire,Peak,$18.03,$40.99
+PE,Peru,US13,Vermont,NonPeak,$16.05,$32.26
+PE,Peru,US13,Vermont,Peak,$18.94,$38.07
+PE,Peru,US14,Massachusetts,NonPeak,$16.80,$45.09
+PE,Peru,US14,Massachusetts,Peak,$19.82,$53.21
+PE,Peru,US15,Rhode Island,NonPeak,$17.57,$34.90
+PE,Peru,US15,Rhode Island,Peak,$20.73,$41.18
+PE,Peru,US16,Connecticut,NonPeak,$18.33,$32.44
+PE,Peru,US16,Connecticut,Peak,$21.63,$38.28
+PE,Peru,US17,New York,NonPeak,$24.38,$43.94
+PE,Peru,US17,New York,Peak,$28.77,$51.85
+PE,Peru,US19,New Jersey,NonPeak,$16.00,$33.70
+PE,Peru,US19,New Jersey,Peak,$18.88,$39.77
+PE,Peru,US20,Pennsylvania,NonPeak,$27.63,$31.29
+PE,Peru,US20,Pennsylvania,Peak,$32.60,$36.92
+PE,Peru,US22,Delaware,NonPeak,$29.28,$44.05
+PE,Peru,US22,Delaware,Peak,$34.55,$51.98
+PE,Peru,US23,Maryland,NonPeak,$30.90,$33.75
+PE,Peru,US23,Maryland,Peak,$36.46,$39.82
+PE,Peru,US24,District Of Columbia,NonPeak,$15.28,$31.40
+PE,Peru,US24,District Of Columbia,Peak,$18.03,$37.05
+PE,Peru,US25,Virginia,NonPeak,$16.05,$44.17
+PE,Peru,US25,Virginia,Peak,$18.94,$52.12
+PE,Peru,US27,West Virginia,NonPeak,$16.80,$33.98
+PE,Peru,US27,West Virginia,Peak,$19.82,$40.10
+PE,Peru,US28,Kentucky,NonPeak,$17.57,$31.45
+PE,Peru,US28,Kentucky,Peak,$20.73,$37.11
+PE,Peru,US30,Michigan,NonPeak,$18.33,$44.28
+PE,Peru,US30,Michigan,Peak,$21.63,$52.25
+PE,Peru,US32,Wisconsin,NonPeak,$24.38,$34.11
+PE,Peru,US32,Wisconsin,Peak,$28.77,$40.25
+PE,Peru,US34,Ohio,NonPeak,$16.00,$31.63
+PE,Peru,US34,Ohio,Peak,$18.88,$37.32
+PE,Peru,US36,Indiana,NonPeak,$27.63,$44.51
+PE,Peru,US36,Indiana,Peak,$32.60,$52.52
+PE,Peru,US38,Illinois,NonPeak,$29.28,$34.33
+PE,Peru,US38,Illinois,Peak,$34.55,$40.51
+PE,Peru,US40,North Carolina,NonPeak,$30.90,$31.74
+PE,Peru,US40,North Carolina,Peak,$36.46,$37.45
+PE,Peru,US42,Tennessee,NonPeak,$15.28,$44.62
+PE,Peru,US42,Tennessee,Peak,$18.03,$52.65
+PE,Peru,US44,South Carolina,NonPeak,$16.05,$34.45
+PE,Peru,US44,South Carolina,Peak,$18.94,$40.65
+PE,Peru,US45,Georgia,NonPeak,$16.80,$31.91
+PE,Peru,US45,Georgia,Peak,$19.82,$37.65
+PE,Peru,US47,Alabama,NonPeak,$17.57,$44.74
+PE,Peru,US47,Alabama,Peak,$20.73,$52.79
+PE,Peru,US48,Mississippi,NonPeak,$18.33,$34.56
+PE,Peru,US48,Mississippi,Peak,$21.63,$40.78
+PE,Peru,US49,Florida-North,NonPeak,$24.38,$32.09
+PE,Peru,US49,Florida-North,Peak,$28.77,$37.87
+PE,Peru,US4964400,Florida-South,NonPeak,$16.00,$44.91
+PE,Peru,US4964400,Florida-South,Peak,$18.88,$52.99
+PE,Peru,US4965500,Florida Keys,NonPeak,$27.63,$34.74
+PE,Peru,US4965500,Florida Keys,Peak,$32.60,$40.99
+PE,Peru,US50,Minnesota,NonPeak,$29.28,$32.26
+PE,Peru,US50,Minnesota,Peak,$34.55,$38.07
+PE,Peru,US51,North Dakota,NonPeak,$30.90,$45.09
+PE,Peru,US51,North Dakota,Peak,$36.46,$53.21
+PE,Peru,US52,South Dakota,NonPeak,$15.28,$34.90
+PE,Peru,US52,South Dakota,Peak,$18.03,$41.18
+PE,Peru,US53,Iowa,NonPeak,$16.05,$32.44
+PE,Peru,US53,Iowa,Peak,$18.94,$38.28
+PE,Peru,US55,Nebraska,NonPeak,$16.80,$43.94
+PE,Peru,US55,Nebraska,Peak,$19.82,$51.85
+PE,Peru,US56,Missouri,NonPeak,$17.57,$33.70
+PE,Peru,US56,Missouri,Peak,$20.73,$39.77
+PE,Peru,US58,Kansas,NonPeak,$18.33,$31.29
+PE,Peru,US58,Kansas,Peak,$21.63,$36.92
+PE,Peru,US60,Arkansas,NonPeak,$24.38,$44.05
+PE,Peru,US60,Arkansas,Peak,$28.77,$51.98
+PE,Peru,US62,Oklahoma,NonPeak,$16.00,$33.75
+PE,Peru,US62,Oklahoma,Peak,$18.88,$39.82
+PE,Peru,US64,Louisiana,NonPeak,$27.63,$31.40
+PE,Peru,US64,Louisiana,Peak,$32.60,$37.05
+PE,Peru,US66,Texas-North,NonPeak,$29.28,$44.17
+PE,Peru,US66,Texas-North,Peak,$34.55,$52.12
+PE,Peru,US68,Texas-South,NonPeak,$30.90,$33.98
+PE,Peru,US68,Texas-South,Peak,$36.46,$40.10
+PE,Peru,US70,Montana,NonPeak,$15.28,$31.45
+PE,Peru,US70,Montana,Peak,$18.03,$37.11
+PE,Peru,US72,Wyoming,NonPeak,$16.05,$44.28
+PE,Peru,US72,Wyoming,Peak,$18.94,$52.25
+PE,Peru,US74,Colorado,NonPeak,$16.80,$34.11
+PE,Peru,US74,Colorado,Peak,$19.82,$40.25
+PE,Peru,US76,Utah,NonPeak,$17.57,$31.63
+PE,Peru,US76,Utah,Peak,$20.73,$37.32
+PE,Peru,US77,New Mexico,NonPeak,$18.33,$44.51
+PE,Peru,US77,New Mexico,Peak,$21.63,$52.52
+PE,Peru,US79,Arizona,NonPeak,$24.38,$34.33
+PE,Peru,US79,Arizona,Peak,$28.77,$40.51
+PE,Peru,US83,Idaho,NonPeak,$16.00,$31.74
+PE,Peru,US83,Idaho,Peak,$18.88,$37.45
+PE,Peru,US84,Washington,NonPeak,$27.63,$44.62
+PE,Peru,US84,Washington,Peak,$32.60,$52.65
+PE,Peru,US85,Oregon,NonPeak,$29.28,$34.45
+PE,Peru,US85,Oregon,Peak,$34.55,$40.65
+PE,Peru,US86,Nevada,NonPeak,$30.90,$31.91
+PE,Peru,US86,Nevada,Peak,$36.46,$37.65
+PE,Peru,US87,California-North,NonPeak,$15.28,$44.74
+PE,Peru,US87,California-North,Peak,$18.03,$52.79
+PE,Peru,US88,California-South,NonPeak,$16.05,$34.56
+PE,Peru,US88,California-South,Peak,$18.94,$40.78
+PL,Poland,US11,Maine,NonPeak,$16.80,$32.09
+PL,Poland,US11,Maine,Peak,$19.82,$37.87
+PL,Poland,US12,New Hampshire,NonPeak,$17.57,$44.91
+PL,Poland,US12,New Hampshire,Peak,$20.73,$52.99
+PL,Poland,US13,Vermont,NonPeak,$18.33,$34.74
+PL,Poland,US13,Vermont,Peak,$21.63,$40.99
+PL,Poland,US14,Massachusetts,NonPeak,$24.38,$32.26
+PL,Poland,US14,Massachusetts,Peak,$28.77,$38.07
+PL,Poland,US15,Rhode Island,NonPeak,$16.00,$45.09
+PL,Poland,US15,Rhode Island,Peak,$18.88,$53.21
+PL,Poland,US16,Connecticut,NonPeak,$27.63,$34.90
+PL,Poland,US16,Connecticut,Peak,$32.60,$41.18
+PL,Poland,US17,New York,NonPeak,$29.28,$32.44
+PL,Poland,US17,New York,Peak,$34.55,$38.28
+PL,Poland,US19,New Jersey,NonPeak,$30.90,$43.94
+PL,Poland,US19,New Jersey,Peak,$36.46,$51.85
+PL,Poland,US20,Pennsylvania,NonPeak,$15.28,$33.70
+PL,Poland,US20,Pennsylvania,Peak,$18.03,$39.77
+PL,Poland,US22,Delaware,NonPeak,$16.05,$31.29
+PL,Poland,US22,Delaware,Peak,$18.94,$36.92
+PL,Poland,US23,Maryland,NonPeak,$16.80,$44.05
+PL,Poland,US23,Maryland,Peak,$19.82,$51.98
+PL,Poland,US24,District Of Columbia,NonPeak,$17.57,$33.75
+PL,Poland,US24,District Of Columbia,Peak,$20.73,$39.82
+PL,Poland,US25,Virginia,NonPeak,$18.33,$31.40
+PL,Poland,US25,Virginia,Peak,$21.63,$37.05
+PL,Poland,US27,West Virginia,NonPeak,$24.38,$44.17
+PL,Poland,US27,West Virginia,Peak,$28.77,$52.12
+PL,Poland,US28,Kentucky,NonPeak,$16.00,$33.98
+PL,Poland,US28,Kentucky,Peak,$18.88,$40.10
+PL,Poland,US30,Michigan,NonPeak,$27.63,$31.45
+PL,Poland,US30,Michigan,Peak,$32.60,$37.11
+PL,Poland,US32,Wisconsin,NonPeak,$29.28,$44.28
+PL,Poland,US32,Wisconsin,Peak,$34.55,$52.25
+PL,Poland,US34,Ohio,NonPeak,$30.90,$34.11
+PL,Poland,US34,Ohio,Peak,$36.46,$40.25
+PL,Poland,US36,Indiana,NonPeak,$15.28,$31.63
+PL,Poland,US36,Indiana,Peak,$18.03,$37.32
+PL,Poland,US38,Illinois,NonPeak,$16.05,$44.51
+PL,Poland,US38,Illinois,Peak,$18.94,$52.52
+PL,Poland,US40,North Carolina,NonPeak,$16.80,$34.33
+PL,Poland,US40,North Carolina,Peak,$19.82,$40.51
+PL,Poland,US42,Tennessee,NonPeak,$17.57,$31.74
+PL,Poland,US42,Tennessee,Peak,$20.73,$37.45
+PL,Poland,US44,South Carolina,NonPeak,$18.33,$44.62
+PL,Poland,US44,South Carolina,Peak,$21.63,$52.65
+PL,Poland,US45,Georgia,NonPeak,$24.38,$34.45
+PL,Poland,US45,Georgia,Peak,$28.77,$40.65
+PL,Poland,US47,Alabama,NonPeak,$16.00,$31.91
+PL,Poland,US47,Alabama,Peak,$18.88,$37.65
+PL,Poland,US48,Mississippi,NonPeak,$27.63,$44.74
+PL,Poland,US48,Mississippi,Peak,$32.60,$52.79
+PL,Poland,US49,Florida-North,NonPeak,$29.28,$34.56
+PL,Poland,US49,Florida-North,Peak,$34.55,$40.78
+PL,Poland,US4964400,Florida-South,NonPeak,$30.90,$32.09
+PL,Poland,US4964400,Florida-South,Peak,$36.46,$37.87
+PL,Poland,US4965500,Florida Keys,NonPeak,$15.28,$44.91
+PL,Poland,US4965500,Florida Keys,Peak,$18.03,$52.99
+PL,Poland,US50,Minnesota,NonPeak,$16.05,$34.74
+PL,Poland,US50,Minnesota,Peak,$18.94,$40.99
+PL,Poland,US51,North Dakota,NonPeak,$16.80,$32.26
+PL,Poland,US51,North Dakota,Peak,$19.82,$38.07
+PL,Poland,US52,South Dakota,NonPeak,$17.57,$45.09
+PL,Poland,US52,South Dakota,Peak,$20.73,$53.21
+PL,Poland,US53,Iowa,NonPeak,$18.33,$34.90
+PL,Poland,US53,Iowa,Peak,$21.63,$41.18
+PL,Poland,US55,Nebraska,NonPeak,$24.38,$32.44
+PL,Poland,US55,Nebraska,Peak,$28.77,$38.28
+PL,Poland,US56,Missouri,NonPeak,$16.00,$43.94
+PL,Poland,US56,Missouri,Peak,$18.88,$51.85
+PL,Poland,US58,Kansas,NonPeak,$27.63,$33.70
+PL,Poland,US58,Kansas,Peak,$32.60,$39.77
+PL,Poland,US60,Arkansas,NonPeak,$29.28,$31.29
+PL,Poland,US60,Arkansas,Peak,$34.55,$36.92
+PL,Poland,US62,Oklahoma,NonPeak,$30.90,$44.05
+PL,Poland,US62,Oklahoma,Peak,$36.46,$51.98
+PL,Poland,US64,Louisiana,NonPeak,$15.28,$33.75
+PL,Poland,US64,Louisiana,Peak,$18.03,$39.82
+PL,Poland,US66,Texas-North,NonPeak,$16.05,$31.40
+PL,Poland,US66,Texas-North,Peak,$18.94,$37.05
+PL,Poland,US68,Texas-South,NonPeak,$16.80,$44.17
+PL,Poland,US68,Texas-South,Peak,$19.82,$52.12
+PL,Poland,US70,Montana,NonPeak,$17.57,$33.98
+PL,Poland,US70,Montana,Peak,$20.73,$40.10
+PL,Poland,US72,Wyoming,NonPeak,$18.33,$31.45
+PL,Poland,US72,Wyoming,Peak,$21.63,$37.11
+PL,Poland,US74,Colorado,NonPeak,$24.38,$44.28
+PL,Poland,US74,Colorado,Peak,$28.77,$52.25
+PL,Poland,US76,Utah,NonPeak,$16.00,$34.11
+PL,Poland,US76,Utah,Peak,$18.88,$40.25
+PL,Poland,US77,New Mexico,NonPeak,$27.63,$31.63
+PL,Poland,US77,New Mexico,Peak,$32.60,$37.32
+PL,Poland,US79,Arizona,NonPeak,$29.28,$44.51
+PL,Poland,US79,Arizona,Peak,$34.55,$52.52
+PL,Poland,US83,Idaho,NonPeak,$30.90,$34.33
+PL,Poland,US83,Idaho,Peak,$36.46,$40.51
+PL,Poland,US84,Washington,NonPeak,$15.28,$31.74
+PL,Poland,US84,Washington,Peak,$18.03,$37.45
+PL,Poland,US85,Oregon,NonPeak,$16.05,$44.62
+PL,Poland,US85,Oregon,Peak,$18.94,$52.65
+PL,Poland,US86,Nevada,NonPeak,$16.80,$34.45
+PL,Poland,US86,Nevada,Peak,$19.82,$40.65
+PL,Poland,US87,California-North,NonPeak,$17.57,$31.91
+PL,Poland,US87,California-North,Peak,$20.73,$37.65
+PL,Poland,US88,California-South,NonPeak,$18.33,$44.74
+PL,Poland,US88,California-South,Peak,$21.63,$52.79
+PO,Portugal,US11,Maine,NonPeak,$24.38,$34.56
+PO,Portugal,US11,Maine,Peak,$28.77,$40.78
+PO,Portugal,US12,New Hampshire,NonPeak,$16.00,$32.09
+PO,Portugal,US12,New Hampshire,Peak,$18.88,$37.87
+PO,Portugal,US13,Vermont,NonPeak,$27.63,$44.91
+PO,Portugal,US13,Vermont,Peak,$32.60,$52.99
+PO,Portugal,US14,Massachusetts,NonPeak,$29.28,$34.74
+PO,Portugal,US14,Massachusetts,Peak,$34.55,$40.99
+PO,Portugal,US15,Rhode Island,NonPeak,$30.90,$32.26
+PO,Portugal,US15,Rhode Island,Peak,$36.46,$38.07
+PO,Portugal,US16,Connecticut,NonPeak,$15.28,$45.09
+PO,Portugal,US16,Connecticut,Peak,$18.03,$53.21
+PO,Portugal,US17,New York,NonPeak,$16.05,$34.90
+PO,Portugal,US17,New York,Peak,$18.94,$41.18
+PO,Portugal,US19,New Jersey,NonPeak,$16.80,$32.44
+PO,Portugal,US19,New Jersey,Peak,$19.82,$38.28
+PO,Portugal,US20,Pennsylvania,NonPeak,$17.57,$43.94
+PO,Portugal,US20,Pennsylvania,Peak,$20.73,$51.85
+PO,Portugal,US22,Delaware,NonPeak,$18.33,$33.70
+PO,Portugal,US22,Delaware,Peak,$21.63,$39.77
+PO,Portugal,US23,Maryland,NonPeak,$24.38,$31.29
+PO,Portugal,US23,Maryland,Peak,$28.77,$36.92
+PO,Portugal,US24,District Of Columbia,NonPeak,$16.00,$44.05
+PO,Portugal,US24,District Of Columbia,Peak,$18.88,$51.98
+PO,Portugal,US25,Virginia,NonPeak,$27.63,$33.75
+PO,Portugal,US25,Virginia,Peak,$32.60,$39.82
+PO,Portugal,US27,West Virginia,NonPeak,$29.28,$31.40
+PO,Portugal,US27,West Virginia,Peak,$34.55,$37.05
+PO,Portugal,US28,Kentucky,NonPeak,$30.90,$44.17
+PO,Portugal,US28,Kentucky,Peak,$36.46,$52.12
+PO,Portugal,US30,Michigan,NonPeak,$15.28,$33.98
+PO,Portugal,US30,Michigan,Peak,$18.03,$40.10
+PO,Portugal,US32,Wisconsin,NonPeak,$16.05,$31.45
+PO,Portugal,US32,Wisconsin,Peak,$18.94,$37.11
+PO,Portugal,US34,Ohio,NonPeak,$16.80,$44.28
+PO,Portugal,US34,Ohio,Peak,$19.82,$52.25
+PO,Portugal,US36,Indiana,NonPeak,$17.57,$34.11
+PO,Portugal,US36,Indiana,Peak,$20.73,$40.25
+PO,Portugal,US38,Illinois,NonPeak,$18.33,$31.63
+PO,Portugal,US38,Illinois,Peak,$21.63,$37.32
+PO,Portugal,US40,North Carolina,NonPeak,$24.38,$44.51
+PO,Portugal,US40,North Carolina,Peak,$28.77,$52.52
+PO,Portugal,US42,Tennessee,NonPeak,$16.00,$34.33
+PO,Portugal,US42,Tennessee,Peak,$18.88,$40.51
+PO,Portugal,US44,South Carolina,NonPeak,$27.63,$31.74
+PO,Portugal,US44,South Carolina,Peak,$32.60,$37.45
+PO,Portugal,US45,Georgia,NonPeak,$29.28,$44.62
+PO,Portugal,US45,Georgia,Peak,$34.55,$52.65
+PO,Portugal,US47,Alabama,NonPeak,$30.90,$34.45
+PO,Portugal,US47,Alabama,Peak,$36.46,$40.65
+PO,Portugal,US48,Mississippi,NonPeak,$15.28,$31.91
+PO,Portugal,US48,Mississippi,Peak,$18.03,$37.65
+PO,Portugal,US49,Florida-North,NonPeak,$16.05,$44.74
+PO,Portugal,US49,Florida-North,Peak,$18.94,$52.79
+PO,Portugal,US4964400,Florida-South,NonPeak,$16.80,$34.56
+PO,Portugal,US4964400,Florida-South,Peak,$19.82,$40.78
+PO,Portugal,US4965500,Florida Keys,NonPeak,$17.57,$32.09
+PO,Portugal,US4965500,Florida Keys,Peak,$20.73,$37.87
+PO,Portugal,US50,Minnesota,NonPeak,$18.33,$44.91
+PO,Portugal,US50,Minnesota,Peak,$21.63,$52.99
+PO,Portugal,US51,North Dakota,NonPeak,$24.38,$34.74
+PO,Portugal,US51,North Dakota,Peak,$28.77,$40.99
+PO,Portugal,US52,South Dakota,NonPeak,$16.00,$32.26
+PO,Portugal,US52,South Dakota,Peak,$18.88,$38.07
+PO,Portugal,US53,Iowa,NonPeak,$27.63,$45.09
+PO,Portugal,US53,Iowa,Peak,$32.60,$53.21
+PO,Portugal,US55,Nebraska,NonPeak,$29.28,$34.90
+PO,Portugal,US55,Nebraska,Peak,$34.55,$41.18
+PO,Portugal,US56,Missouri,NonPeak,$30.90,$32.44
+PO,Portugal,US56,Missouri,Peak,$36.46,$38.28
+PO,Portugal,US58,Kansas,NonPeak,$15.28,$43.94
+PO,Portugal,US58,Kansas,Peak,$18.03,$51.85
+PO,Portugal,US60,Arkansas,NonPeak,$16.05,$33.70
+PO,Portugal,US60,Arkansas,Peak,$18.94,$39.77
+PO,Portugal,US62,Oklahoma,NonPeak,$16.80,$31.29
+PO,Portugal,US62,Oklahoma,Peak,$19.82,$36.92
+PO,Portugal,US64,Louisiana,NonPeak,$17.57,$44.05
+PO,Portugal,US64,Louisiana,Peak,$20.73,$51.98
+PO,Portugal,US66,Texas-North,NonPeak,$18.33,$33.75
+PO,Portugal,US66,Texas-North,Peak,$21.63,$39.82
+PO,Portugal,US68,Texas-South,NonPeak,$24.38,$31.40
+PO,Portugal,US68,Texas-South,Peak,$28.77,$37.05
+PO,Portugal,US70,Montana,NonPeak,$16.00,$44.17
+PO,Portugal,US70,Montana,Peak,$18.88,$52.12
+PO,Portugal,US72,Wyoming,NonPeak,$27.63,$33.98
+PO,Portugal,US72,Wyoming,Peak,$32.60,$40.10
+PO,Portugal,US74,Colorado,NonPeak,$29.28,$31.45
+PO,Portugal,US74,Colorado,Peak,$34.55,$37.11
+PO,Portugal,US76,Utah,NonPeak,$30.90,$44.28
+PO,Portugal,US76,Utah,Peak,$36.46,$52.25
+PO,Portugal,US77,New Mexico,NonPeak,$15.28,$34.11
+PO,Portugal,US77,New Mexico,Peak,$18.03,$40.25
+PO,Portugal,US79,Arizona,NonPeak,$16.05,$31.63
+PO,Portugal,US79,Arizona,Peak,$18.94,$37.32
+PO,Portugal,US83,Idaho,NonPeak,$16.80,$44.51
+PO,Portugal,US83,Idaho,Peak,$19.82,$52.52
+PO,Portugal,US84,Washington,NonPeak,$17.57,$34.33
+PO,Portugal,US84,Washington,Peak,$20.73,$40.51
+PO,Portugal,US85,Oregon,NonPeak,$18.33,$31.74
+PO,Portugal,US85,Oregon,Peak,$21.63,$37.45
+PO,Portugal,US86,Nevada,NonPeak,$24.38,$44.62
+PO,Portugal,US86,Nevada,Peak,$28.77,$52.65
+PO,Portugal,US87,California-North,NonPeak,$16.00,$34.45
+PO,Portugal,US87,California-North,Peak,$18.88,$40.65
+PO,Portugal,US88,California-South,NonPeak,$27.63,$31.91
+PO,Portugal,US88,California-South,Peak,$32.60,$37.65
+PO01,Azores,US11,Maine,NonPeak,$29.28,$44.74
+PO01,Azores,US11,Maine,Peak,$34.55,$52.79
+PO01,Azores,US12,New Hampshire,NonPeak,$30.90,$34.56
+PO01,Azores,US12,New Hampshire,Peak,$36.46,$40.78
+PO01,Azores,US13,Vermont,NonPeak,$15.28,$32.09
+PO01,Azores,US13,Vermont,Peak,$18.03,$37.87
+PO01,Azores,US14,Massachusetts,NonPeak,$16.05,$44.91
+PO01,Azores,US14,Massachusetts,Peak,$18.94,$52.99
+PO01,Azores,US15,Rhode Island,NonPeak,$16.80,$34.74
+PO01,Azores,US15,Rhode Island,Peak,$19.82,$40.99
+PO01,Azores,US16,Connecticut,NonPeak,$17.57,$32.26
+PO01,Azores,US16,Connecticut,Peak,$20.73,$38.07
+PO01,Azores,US17,New York,NonPeak,$18.33,$45.09
+PO01,Azores,US17,New York,Peak,$21.63,$53.21
+PO01,Azores,US19,New Jersey,NonPeak,$24.38,$34.90
+PO01,Azores,US19,New Jersey,Peak,$28.77,$41.18
+PO01,Azores,US20,Pennsylvania,NonPeak,$16.00,$32.44
+PO01,Azores,US20,Pennsylvania,Peak,$18.88,$38.28
+PO01,Azores,US22,Delaware,NonPeak,$27.63,$43.94
+PO01,Azores,US22,Delaware,Peak,$32.60,$51.85
+PO01,Azores,US23,Maryland,NonPeak,$29.28,$33.70
+PO01,Azores,US23,Maryland,Peak,$34.55,$39.77
+PO01,Azores,US24,District Of Columbia,NonPeak,$30.90,$31.29
+PO01,Azores,US24,District Of Columbia,Peak,$36.46,$36.92
+PO01,Azores,US25,Virginia,NonPeak,$15.28,$44.05
+PO01,Azores,US25,Virginia,Peak,$18.03,$51.98
+PO01,Azores,US27,West Virginia,NonPeak,$16.05,$33.75
+PO01,Azores,US27,West Virginia,Peak,$18.94,$39.82
+PO01,Azores,US28,Kentucky,NonPeak,$16.80,$31.40
+PO01,Azores,US28,Kentucky,Peak,$19.82,$37.05
+PO01,Azores,US30,Michigan,NonPeak,$17.57,$44.17
+PO01,Azores,US30,Michigan,Peak,$20.73,$52.12
+PO01,Azores,US32,Wisconsin,NonPeak,$18.33,$33.98
+PO01,Azores,US32,Wisconsin,Peak,$21.63,$40.10
+PO01,Azores,US34,Ohio,NonPeak,$24.38,$31.45
+PO01,Azores,US34,Ohio,Peak,$28.77,$37.11
+PO01,Azores,US36,Indiana,NonPeak,$16.00,$44.28
+PO01,Azores,US36,Indiana,Peak,$18.88,$52.25
+PO01,Azores,US38,Illinois,NonPeak,$27.63,$34.11
+PO01,Azores,US38,Illinois,Peak,$32.60,$40.25
+PO01,Azores,US40,North Carolina,NonPeak,$29.28,$31.63
+PO01,Azores,US40,North Carolina,Peak,$34.55,$37.32
+PO01,Azores,US42,Tennessee,NonPeak,$30.90,$44.51
+PO01,Azores,US42,Tennessee,Peak,$36.46,$52.52
+PO01,Azores,US44,South Carolina,NonPeak,$15.28,$34.33
+PO01,Azores,US44,South Carolina,Peak,$18.03,$40.51
+PO01,Azores,US45,Georgia,NonPeak,$16.05,$31.74
+PO01,Azores,US45,Georgia,Peak,$18.94,$37.45
+PO01,Azores,US47,Alabama,NonPeak,$16.80,$44.62
+PO01,Azores,US47,Alabama,Peak,$19.82,$52.65
+PO01,Azores,US48,Mississippi,NonPeak,$17.57,$34.45
+PO01,Azores,US48,Mississippi,Peak,$20.73,$40.65
+PO01,Azores,US49,Florida-North,NonPeak,$18.33,$31.91
+PO01,Azores,US49,Florida-North,Peak,$21.63,$37.65
+PO01,Azores,US4964400,Florida-South,NonPeak,$24.38,$44.74
+PO01,Azores,US4964400,Florida-South,Peak,$28.77,$52.79
+PO01,Azores,US4965500,Florida Keys,NonPeak,$16.00,$34.56
+PO01,Azores,US4965500,Florida Keys,Peak,$18.88,$40.78
+PO01,Azores,US50,Minnesota,NonPeak,$27.63,$32.09
+PO01,Azores,US50,Minnesota,Peak,$32.60,$37.87
+PO01,Azores,US51,North Dakota,NonPeak,$29.28,$44.91
+PO01,Azores,US51,North Dakota,Peak,$34.55,$52.99
+PO01,Azores,US52,South Dakota,NonPeak,$30.90,$34.74
+PO01,Azores,US52,South Dakota,Peak,$36.46,$40.99
+PO01,Azores,US53,Iowa,NonPeak,$15.28,$32.26
+PO01,Azores,US53,Iowa,Peak,$18.03,$38.07
+PO01,Azores,US55,Nebraska,NonPeak,$16.05,$45.09
+PO01,Azores,US55,Nebraska,Peak,$18.94,$53.21
+PO01,Azores,US56,Missouri,NonPeak,$16.80,$34.90
+PO01,Azores,US56,Missouri,Peak,$19.82,$41.18
+PO01,Azores,US58,Kansas,NonPeak,$17.57,$32.44
+PO01,Azores,US58,Kansas,Peak,$20.73,$38.28
+PO01,Azores,US60,Arkansas,NonPeak,$18.33,$43.94
+PO01,Azores,US60,Arkansas,Peak,$21.63,$51.85
+PO01,Azores,US62,Oklahoma,NonPeak,$24.38,$33.70
+PO01,Azores,US62,Oklahoma,Peak,$28.77,$39.77
+PO01,Azores,US64,Louisiana,NonPeak,$16.00,$31.29
+PO01,Azores,US64,Louisiana,Peak,$18.88,$36.92
+PO01,Azores,US66,Texas-North,NonPeak,$27.63,$44.05
+PO01,Azores,US66,Texas-North,Peak,$32.60,$51.98
+PO01,Azores,US68,Texas-South,NonPeak,$29.28,$33.75
+PO01,Azores,US68,Texas-South,Peak,$34.55,$39.82
+PO01,Azores,US70,Montana,NonPeak,$30.90,$31.40
+PO01,Azores,US70,Montana,Peak,$36.46,$37.05
+PO01,Azores,US72,Wyoming,NonPeak,$15.28,$44.17
+PO01,Azores,US72,Wyoming,Peak,$18.03,$52.12
+PO01,Azores,US74,Colorado,NonPeak,$16.05,$33.98
+PO01,Azores,US74,Colorado,Peak,$18.94,$40.10
+PO01,Azores,US76,Utah,NonPeak,$16.80,$31.45
+PO01,Azores,US76,Utah,Peak,$19.82,$37.11
+PO01,Azores,US77,New Mexico,NonPeak,$17.57,$44.28
+PO01,Azores,US77,New Mexico,Peak,$20.73,$52.25
+PO01,Azores,US79,Arizona,NonPeak,$18.33,$34.11
+PO01,Azores,US79,Arizona,Peak,$21.63,$40.25
+PO01,Azores,US83,Idaho,NonPeak,$24.38,$31.63
+PO01,Azores,US83,Idaho,Peak,$28.77,$37.32
+PO01,Azores,US84,Washington,NonPeak,$16.00,$44.51
+PO01,Azores,US84,Washington,Peak,$18.88,$52.52
+PO01,Azores,US85,Oregon,NonPeak,$27.63,$34.33
+PO01,Azores,US85,Oregon,Peak,$32.60,$40.51
+PO01,Azores,US86,Nevada,NonPeak,$29.28,$31.74
+PO01,Azores,US86,Nevada,Peak,$34.55,$37.45
+PO01,Azores,US87,California-North,NonPeak,$30.90,$44.62
+PO01,Azores,US87,California-North,Peak,$36.46,$52.65
+PO01,Azores,US88,California-South,NonPeak,$15.28,$34.45
+PO01,Azores,US88,California-South,Peak,$18.03,$40.65
+QA,Qatar,US11,Maine,NonPeak,$16.05,$31.91
+QA,Qatar,US11,Maine,Peak,$18.94,$37.65
+QA,Qatar,US12,New Hampshire,NonPeak,$16.80,$44.74
+QA,Qatar,US12,New Hampshire,Peak,$19.82,$52.79
+QA,Qatar,US13,Vermont,NonPeak,$17.57,$34.56
+QA,Qatar,US13,Vermont,Peak,$20.73,$40.78
+QA,Qatar,US14,Massachusetts,NonPeak,$18.33,$32.09
+QA,Qatar,US14,Massachusetts,Peak,$21.63,$37.87
+QA,Qatar,US15,Rhode Island,NonPeak,$24.38,$44.91
+QA,Qatar,US15,Rhode Island,Peak,$28.77,$52.99
+QA,Qatar,US16,Connecticut,NonPeak,$16.00,$34.74
+QA,Qatar,US16,Connecticut,Peak,$18.88,$40.99
+QA,Qatar,US17,New York,NonPeak,$27.63,$32.26
+QA,Qatar,US17,New York,Peak,$32.60,$38.07
+QA,Qatar,US19,New Jersey,NonPeak,$29.28,$45.09
+QA,Qatar,US19,New Jersey,Peak,$34.55,$53.21
+QA,Qatar,US20,Pennsylvania,NonPeak,$30.90,$34.90
+QA,Qatar,US20,Pennsylvania,Peak,$36.46,$41.18
+QA,Qatar,US22,Delaware,NonPeak,$15.28,$32.44
+QA,Qatar,US22,Delaware,Peak,$18.03,$38.28
+QA,Qatar,US23,Maryland,NonPeak,$16.05,$43.94
+QA,Qatar,US23,Maryland,Peak,$18.94,$51.85
+QA,Qatar,US24,District Of Columbia,NonPeak,$16.80,$33.70
+QA,Qatar,US24,District Of Columbia,Peak,$19.82,$39.77
+QA,Qatar,US25,Virginia,NonPeak,$17.57,$31.29
+QA,Qatar,US25,Virginia,Peak,$20.73,$36.92
+QA,Qatar,US27,West Virginia,NonPeak,$18.33,$44.05
+QA,Qatar,US27,West Virginia,Peak,$21.63,$51.98
+QA,Qatar,US28,Kentucky,NonPeak,$24.38,$33.75
+QA,Qatar,US28,Kentucky,Peak,$28.77,$39.82
+QA,Qatar,US30,Michigan,NonPeak,$16.00,$31.40
+QA,Qatar,US30,Michigan,Peak,$18.88,$37.05
+QA,Qatar,US32,Wisconsin,NonPeak,$27.63,$44.17
+QA,Qatar,US32,Wisconsin,Peak,$32.60,$52.12
+QA,Qatar,US34,Ohio,NonPeak,$29.28,$33.98
+QA,Qatar,US34,Ohio,Peak,$34.55,$40.10
+QA,Qatar,US36,Indiana,NonPeak,$30.90,$31.45
+QA,Qatar,US36,Indiana,Peak,$36.46,$37.11
+QA,Qatar,US38,Illinois,NonPeak,$15.28,$44.28
+QA,Qatar,US38,Illinois,Peak,$18.03,$52.25
+QA,Qatar,US40,North Carolina,NonPeak,$16.05,$34.11
+QA,Qatar,US40,North Carolina,Peak,$18.94,$40.25
+QA,Qatar,US42,Tennessee,NonPeak,$16.80,$31.63
+QA,Qatar,US42,Tennessee,Peak,$19.82,$37.32
+QA,Qatar,US44,South Carolina,NonPeak,$17.57,$44.51
+QA,Qatar,US44,South Carolina,Peak,$20.73,$52.52
+QA,Qatar,US45,Georgia,NonPeak,$18.33,$34.33
+QA,Qatar,US45,Georgia,Peak,$21.63,$40.51
+QA,Qatar,US47,Alabama,NonPeak,$24.38,$31.74
+QA,Qatar,US47,Alabama,Peak,$28.77,$37.45
+QA,Qatar,US48,Mississippi,NonPeak,$16.00,$44.62
+QA,Qatar,US48,Mississippi,Peak,$18.88,$52.65
+QA,Qatar,US49,Florida-North,NonPeak,$27.63,$34.45
+QA,Qatar,US49,Florida-North,Peak,$32.60,$40.65
+QA,Qatar,US4964400,Florida-South,NonPeak,$29.28,$31.91
+QA,Qatar,US4964400,Florida-South,Peak,$34.55,$37.65
+QA,Qatar,US4965500,Florida Keys,NonPeak,$30.90,$44.74
+QA,Qatar,US4965500,Florida Keys,Peak,$36.46,$52.79
+QA,Qatar,US50,Minnesota,NonPeak,$15.28,$34.56
+QA,Qatar,US50,Minnesota,Peak,$18.03,$40.78
+QA,Qatar,US51,North Dakota,NonPeak,$16.05,$32.09
+QA,Qatar,US51,North Dakota,Peak,$18.94,$37.87
+QA,Qatar,US52,South Dakota,NonPeak,$16.80,$44.91
+QA,Qatar,US52,South Dakota,Peak,$19.82,$52.99
+QA,Qatar,US53,Iowa,NonPeak,$17.57,$34.74
+QA,Qatar,US53,Iowa,Peak,$20.73,$40.99
+QA,Qatar,US55,Nebraska,NonPeak,$18.33,$32.26
+QA,Qatar,US55,Nebraska,Peak,$21.63,$38.07
+QA,Qatar,US56,Missouri,NonPeak,$24.38,$45.09
+QA,Qatar,US56,Missouri,Peak,$28.77,$53.21
+QA,Qatar,US58,Kansas,NonPeak,$16.00,$34.90
+QA,Qatar,US58,Kansas,Peak,$18.88,$41.18
+QA,Qatar,US60,Arkansas,NonPeak,$27.63,$32.44
+QA,Qatar,US60,Arkansas,Peak,$32.60,$38.28
+QA,Qatar,US62,Oklahoma,NonPeak,$29.28,$43.94
+QA,Qatar,US62,Oklahoma,Peak,$34.55,$51.85
+QA,Qatar,US64,Louisiana,NonPeak,$30.90,$33.70
+QA,Qatar,US64,Louisiana,Peak,$36.46,$39.77
+QA,Qatar,US66,Texas-North,NonPeak,$15.28,$31.29
+QA,Qatar,US66,Texas-North,Peak,$18.03,$36.92
+QA,Qatar,US68,Texas-South,NonPeak,$16.05,$44.05
+QA,Qatar,US68,Texas-South,Peak,$18.94,$51.98
+QA,Qatar,US70,Montana,NonPeak,$16.80,$33.75
+QA,Qatar,US70,Montana,Peak,$19.82,$39.82
+QA,Qatar,US72,Wyoming,NonPeak,$17.57,$31.40
+QA,Qatar,US72,Wyoming,Peak,$20.73,$37.05
+QA,Qatar,US74,Colorado,NonPeak,$18.33,$44.17
+QA,Qatar,US74,Colorado,Peak,$21.63,$52.12
+QA,Qatar,US76,Utah,NonPeak,$24.38,$33.98
+QA,Qatar,US76,Utah,Peak,$28.77,$40.10
+QA,Qatar,US77,New Mexico,NonPeak,$16.00,$31.45
+QA,Qatar,US77,New Mexico,Peak,$18.88,$37.11
+QA,Qatar,US79,Arizona,NonPeak,$27.63,$44.28
+QA,Qatar,US79,Arizona,Peak,$32.60,$52.25
+QA,Qatar,US83,Idaho,NonPeak,$29.28,$34.11
+QA,Qatar,US83,Idaho,Peak,$34.55,$40.25
+QA,Qatar,US84,Washington,NonPeak,$30.90,$31.63
+QA,Qatar,US84,Washington,Peak,$36.46,$37.32
+QA,Qatar,US85,Oregon,NonPeak,$15.28,$44.51
+QA,Qatar,US85,Oregon,Peak,$18.03,$52.52
+QA,Qatar,US86,Nevada,NonPeak,$16.05,$34.33
+QA,Qatar,US86,Nevada,Peak,$18.94,$40.51
+QA,Qatar,US87,California-North,NonPeak,$16.80,$31.74
+QA,Qatar,US87,California-North,Peak,$19.82,$37.45
+QA,Qatar,US88,California-South,NonPeak,$17.57,$44.62
+QA,Qatar,US88,California-South,Peak,$20.73,$52.65
+RO,Romania,US11,Maine,NonPeak,$18.33,$34.45
+RO,Romania,US11,Maine,Peak,$21.63,$40.65
+RO,Romania,US12,New Hampshire,NonPeak,$24.38,$31.91
+RO,Romania,US12,New Hampshire,Peak,$28.77,$37.65
+RO,Romania,US13,Vermont,NonPeak,$16.00,$44.74
+RO,Romania,US13,Vermont,Peak,$18.88,$52.79
+RO,Romania,US14,Massachusetts,NonPeak,$27.63,$34.56
+RO,Romania,US14,Massachusetts,Peak,$32.60,$40.78
+RO,Romania,US15,Rhode Island,NonPeak,$29.28,$32.09
+RO,Romania,US15,Rhode Island,Peak,$34.55,$37.87
+RO,Romania,US16,Connecticut,NonPeak,$30.90,$44.91
+RO,Romania,US16,Connecticut,Peak,$36.46,$52.99
+RO,Romania,US17,New York,NonPeak,$15.28,$34.74
+RO,Romania,US17,New York,Peak,$18.03,$40.99
+RO,Romania,US19,New Jersey,NonPeak,$16.05,$32.26
+RO,Romania,US19,New Jersey,Peak,$18.94,$38.07
+RO,Romania,US20,Pennsylvania,NonPeak,$16.80,$45.09
+RO,Romania,US20,Pennsylvania,Peak,$19.82,$53.21
+RO,Romania,US22,Delaware,NonPeak,$17.57,$34.90
+RO,Romania,US22,Delaware,Peak,$20.73,$41.18
+RO,Romania,US23,Maryland,NonPeak,$18.33,$32.44
+RO,Romania,US23,Maryland,Peak,$21.63,$38.28
+RO,Romania,US24,District Of Columbia,NonPeak,$24.38,$43.94
+RO,Romania,US24,District Of Columbia,Peak,$28.77,$51.85
+RO,Romania,US25,Virginia,NonPeak,$16.00,$33.70
+RO,Romania,US25,Virginia,Peak,$18.88,$39.77
+RO,Romania,US27,West Virginia,NonPeak,$27.63,$31.29
+RO,Romania,US27,West Virginia,Peak,$32.60,$36.92
+RO,Romania,US28,Kentucky,NonPeak,$29.28,$44.05
+RO,Romania,US28,Kentucky,Peak,$34.55,$51.98
+RO,Romania,US30,Michigan,NonPeak,$30.90,$33.75
+RO,Romania,US30,Michigan,Peak,$36.46,$39.82
+RO,Romania,US32,Wisconsin,NonPeak,$15.28,$31.40
+RO,Romania,US32,Wisconsin,Peak,$18.03,$37.05
+RO,Romania,US34,Ohio,NonPeak,$16.05,$44.17
+RO,Romania,US34,Ohio,Peak,$18.94,$52.12
+RO,Romania,US36,Indiana,NonPeak,$16.80,$33.98
+RO,Romania,US36,Indiana,Peak,$19.82,$40.10
+RO,Romania,US38,Illinois,NonPeak,$17.57,$31.45
+RO,Romania,US38,Illinois,Peak,$20.73,$37.11
+RO,Romania,US40,North Carolina,NonPeak,$18.33,$44.28
+RO,Romania,US40,North Carolina,Peak,$21.63,$52.25
+RO,Romania,US42,Tennessee,NonPeak,$24.38,$34.11
+RO,Romania,US42,Tennessee,Peak,$28.77,$40.25
+RO,Romania,US44,South Carolina,NonPeak,$16.00,$31.63
+RO,Romania,US44,South Carolina,Peak,$18.88,$37.32
+RO,Romania,US45,Georgia,NonPeak,$27.63,$44.51
+RO,Romania,US45,Georgia,Peak,$32.60,$52.52
+RO,Romania,US47,Alabama,NonPeak,$29.28,$34.33
+RO,Romania,US47,Alabama,Peak,$34.55,$40.51
+RO,Romania,US48,Mississippi,NonPeak,$30.90,$31.74
+RO,Romania,US48,Mississippi,Peak,$36.46,$37.45
+RO,Romania,US49,Florida-North,NonPeak,$15.28,$44.62
+RO,Romania,US49,Florida-North,Peak,$18.03,$52.65
+RO,Romania,US4964400,Florida-South,NonPeak,$16.05,$34.45
+RO,Romania,US4964400,Florida-South,Peak,$18.94,$40.65
+RO,Romania,US4965500,Florida Keys,NonPeak,$16.80,$31.91
+RO,Romania,US4965500,Florida Keys,Peak,$19.82,$37.65
+RO,Romania,US50,Minnesota,NonPeak,$17.57,$44.74
+RO,Romania,US50,Minnesota,Peak,$20.73,$52.79
+RO,Romania,US51,North Dakota,NonPeak,$18.33,$34.56
+RO,Romania,US51,North Dakota,Peak,$21.63,$40.78
+RO,Romania,US52,South Dakota,NonPeak,$24.38,$32.09
+RO,Romania,US52,South Dakota,Peak,$28.77,$37.87
+RO,Romania,US53,Iowa,NonPeak,$16.00,$44.91
+RO,Romania,US53,Iowa,Peak,$18.88,$52.99
+RO,Romania,US55,Nebraska,NonPeak,$27.63,$34.74
+RO,Romania,US55,Nebraska,Peak,$32.60,$40.99
+RO,Romania,US56,Missouri,NonPeak,$29.28,$32.26
+RO,Romania,US56,Missouri,Peak,$34.55,$38.07
+RO,Romania,US58,Kansas,NonPeak,$30.90,$45.09
+RO,Romania,US58,Kansas,Peak,$36.46,$53.21
+RO,Romania,US60,Arkansas,NonPeak,$15.28,$34.90
+RO,Romania,US60,Arkansas,Peak,$18.03,$41.18
+RO,Romania,US62,Oklahoma,NonPeak,$16.05,$32.44
+RO,Romania,US62,Oklahoma,Peak,$18.94,$38.28
+RO,Romania,US64,Louisiana,NonPeak,$16.80,$43.94
+RO,Romania,US64,Louisiana,Peak,$19.82,$51.85
+RO,Romania,US66,Texas-North,NonPeak,$17.57,$33.70
+RO,Romania,US66,Texas-North,Peak,$20.73,$39.77
+RO,Romania,US68,Texas-South,NonPeak,$18.33,$31.29
+RO,Romania,US68,Texas-South,Peak,$21.63,$36.92
+RO,Romania,US70,Montana,NonPeak,$24.38,$44.05
+RO,Romania,US70,Montana,Peak,$28.77,$51.98
+RO,Romania,US72,Wyoming,NonPeak,$16.00,$33.75
+RO,Romania,US72,Wyoming,Peak,$18.88,$39.82
+RO,Romania,US74,Colorado,NonPeak,$27.63,$31.40
+RO,Romania,US74,Colorado,Peak,$32.60,$37.05
+RO,Romania,US76,Utah,NonPeak,$29.28,$44.17
+RO,Romania,US76,Utah,Peak,$34.55,$52.12
+RO,Romania,US77,New Mexico,NonPeak,$30.90,$33.98
+RO,Romania,US77,New Mexico,Peak,$36.46,$40.10
+RO,Romania,US79,Arizona,NonPeak,$15.28,$31.45
+RO,Romania,US79,Arizona,Peak,$18.03,$37.11
+RO,Romania,US83,Idaho,NonPeak,$16.05,$44.28
+RO,Romania,US83,Idaho,Peak,$18.94,$52.25
+RO,Romania,US84,Washington,NonPeak,$16.80,$34.11
+RO,Romania,US84,Washington,Peak,$19.82,$40.25
+RO,Romania,US85,Oregon,NonPeak,$17.57,$31.63
+RO,Romania,US85,Oregon,Peak,$20.73,$37.32
+RO,Romania,US86,Nevada,NonPeak,$18.33,$44.51
+RO,Romania,US86,Nevada,Peak,$21.63,$52.52
+RO,Romania,US87,California-North,NonPeak,$24.38,$34.33
+RO,Romania,US87,California-North,Peak,$28.77,$40.51
+RO,Romania,US88,California-South,NonPeak,$16.00,$31.74
+RO,Romania,US88,California-South,Peak,$18.88,$37.45
+RQ,Puerto Rico,US11,Maine,NonPeak,$27.63,$44.62
+RQ,Puerto Rico,US11,Maine,Peak,$32.60,$52.65
+RQ,Puerto Rico,US12,New Hampshire,NonPeak,$29.28,$34.45
+RQ,Puerto Rico,US12,New Hampshire,Peak,$34.55,$40.65
+RQ,Puerto Rico,US13,Vermont,NonPeak,$30.90,$31.91
+RQ,Puerto Rico,US13,Vermont,Peak,$36.46,$37.65
+RQ,Puerto Rico,US14,Massachusetts,NonPeak,$15.28,$44.74
+RQ,Puerto Rico,US14,Massachusetts,Peak,$18.03,$52.79
+RQ,Puerto Rico,US15,Rhode Island,NonPeak,$16.05,$34.56
+RQ,Puerto Rico,US15,Rhode Island,Peak,$18.94,$40.78
+RQ,Puerto Rico,US16,Connecticut,NonPeak,$16.80,$32.09
+RQ,Puerto Rico,US16,Connecticut,Peak,$19.82,$37.87
+RQ,Puerto Rico,US17,New York,NonPeak,$17.57,$44.91
+RQ,Puerto Rico,US17,New York,Peak,$20.73,$52.99
+RQ,Puerto Rico,US19,New Jersey,NonPeak,$18.33,$34.74
+RQ,Puerto Rico,US19,New Jersey,Peak,$21.63,$40.99
+RQ,Puerto Rico,US20,Pennsylvania,NonPeak,$24.38,$32.26
+RQ,Puerto Rico,US20,Pennsylvania,Peak,$28.77,$38.07
+RQ,Puerto Rico,US22,Delaware,NonPeak,$16.00,$45.09
+RQ,Puerto Rico,US22,Delaware,Peak,$18.88,$53.21
+RQ,Puerto Rico,US23,Maryland,NonPeak,$27.63,$34.90
+RQ,Puerto Rico,US23,Maryland,Peak,$32.60,$41.18
+RQ,Puerto Rico,US24,District Of Columbia,NonPeak,$29.28,$32.44
+RQ,Puerto Rico,US24,District Of Columbia,Peak,$34.55,$38.28
+RQ,Puerto Rico,US25,Virginia,NonPeak,$30.90,$43.94
+RQ,Puerto Rico,US25,Virginia,Peak,$36.46,$51.85
+RQ,Puerto Rico,US27,West Virginia,NonPeak,$15.28,$33.70
+RQ,Puerto Rico,US27,West Virginia,Peak,$18.03,$39.77
+RQ,Puerto Rico,US28,Kentucky,NonPeak,$16.05,$31.29
+RQ,Puerto Rico,US28,Kentucky,Peak,$18.94,$36.92
+RQ,Puerto Rico,US30,Michigan,NonPeak,$16.80,$44.05
+RQ,Puerto Rico,US30,Michigan,Peak,$19.82,$51.98
+RQ,Puerto Rico,US32,Wisconsin,NonPeak,$17.57,$33.75
+RQ,Puerto Rico,US32,Wisconsin,Peak,$20.73,$39.82
+RQ,Puerto Rico,US34,Ohio,NonPeak,$18.33,$31.40
+RQ,Puerto Rico,US34,Ohio,Peak,$21.63,$37.05
+RQ,Puerto Rico,US36,Indiana,NonPeak,$24.38,$44.17
+RQ,Puerto Rico,US36,Indiana,Peak,$28.77,$52.12
+RQ,Puerto Rico,US38,Illinois,NonPeak,$16.00,$33.98
+RQ,Puerto Rico,US38,Illinois,Peak,$18.88,$40.10
+RQ,Puerto Rico,US40,North Carolina,NonPeak,$27.63,$31.45
+RQ,Puerto Rico,US40,North Carolina,Peak,$32.60,$37.11
+RQ,Puerto Rico,US42,Tennessee,NonPeak,$29.28,$44.28
+RQ,Puerto Rico,US42,Tennessee,Peak,$34.55,$52.25
+RQ,Puerto Rico,US44,South Carolina,NonPeak,$30.90,$34.11
+RQ,Puerto Rico,US44,South Carolina,Peak,$36.46,$40.25
+RQ,Puerto Rico,US45,Georgia,NonPeak,$15.28,$31.63
+RQ,Puerto Rico,US45,Georgia,Peak,$18.03,$37.32
+RQ,Puerto Rico,US47,Alabama,NonPeak,$16.05,$44.51
+RQ,Puerto Rico,US47,Alabama,Peak,$18.94,$52.52
+RQ,Puerto Rico,US48,Mississippi,NonPeak,$16.80,$34.33
+RQ,Puerto Rico,US48,Mississippi,Peak,$19.82,$40.51
+RQ,Puerto Rico,US49,Florida-North,NonPeak,$17.57,$31.74
+RQ,Puerto Rico,US49,Florida-North,Peak,$20.73,$37.45
+RQ,Puerto Rico,US4964400,Florida-South,NonPeak,$18.33,$44.62
+RQ,Puerto Rico,US4964400,Florida-South,Peak,$21.63,$52.65
+RQ,Puerto Rico,US4965500,Florida Keys,NonPeak,$24.38,$34.45
+RQ,Puerto Rico,US4965500,Florida Keys,Peak,$28.77,$40.65
+RQ,Puerto Rico,US50,Minnesota,NonPeak,$16.00,$31.91
+RQ,Puerto Rico,US50,Minnesota,Peak,$18.88,$37.65
+RQ,Puerto Rico,US51,North Dakota,NonPeak,$27.63,$44.74
+RQ,Puerto Rico,US51,North Dakota,Peak,$32.60,$52.79
+RQ,Puerto Rico,US52,South Dakota,NonPeak,$29.28,$34.56
+RQ,Puerto Rico,US52,South Dakota,Peak,$34.55,$40.78
+RQ,Puerto Rico,US53,Iowa,NonPeak,$30.90,$32.09
+RQ,Puerto Rico,US53,Iowa,Peak,$36.46,$37.87
+RQ,Puerto Rico,US55,Nebraska,NonPeak,$15.28,$44.91
+RQ,Puerto Rico,US55,Nebraska,Peak,$18.03,$52.99
+RQ,Puerto Rico,US56,Missouri,NonPeak,$16.05,$34.74
+RQ,Puerto Rico,US56,Missouri,Peak,$18.94,$40.99
+RQ,Puerto Rico,US58,Kansas,NonPeak,$16.80,$32.26
+RQ,Puerto Rico,US58,Kansas,Peak,$19.82,$38.07
+RQ,Puerto Rico,US60,Arkansas,NonPeak,$17.57,$45.09
+RQ,Puerto Rico,US60,Arkansas,Peak,$20.73,$53.21
+RQ,Puerto Rico,US62,Oklahoma,NonPeak,$18.33,$34.90
+RQ,Puerto Rico,US62,Oklahoma,Peak,$21.63,$41.18
+RQ,Puerto Rico,US64,Louisiana,NonPeak,$24.38,$32.44
+RQ,Puerto Rico,US64,Louisiana,Peak,$28.77,$38.28
+RQ,Puerto Rico,US66,Texas-North,NonPeak,$16.00,$43.94
+RQ,Puerto Rico,US66,Texas-North,Peak,$18.88,$51.85
+RQ,Puerto Rico,US68,Texas-South,NonPeak,$27.63,$33.70
+RQ,Puerto Rico,US68,Texas-South,Peak,$32.60,$39.77
+RQ,Puerto Rico,US70,Montana,NonPeak,$29.28,$31.29
+RQ,Puerto Rico,US70,Montana,Peak,$34.55,$36.92
+RQ,Puerto Rico,US72,Wyoming,NonPeak,$30.90,$44.05
+RQ,Puerto Rico,US72,Wyoming,Peak,$36.46,$51.98
+RQ,Puerto Rico,US74,Colorado,NonPeak,$15.28,$33.75
+RQ,Puerto Rico,US74,Colorado,Peak,$18.03,$39.82
+RQ,Puerto Rico,US76,Utah,NonPeak,$16.05,$31.40
+RQ,Puerto Rico,US76,Utah,Peak,$18.94,$37.05
+RQ,Puerto Rico,US77,New Mexico,NonPeak,$16.80,$44.17
+RQ,Puerto Rico,US77,New Mexico,Peak,$19.82,$52.12
+RQ,Puerto Rico,US79,Arizona,NonPeak,$17.57,$33.98
+RQ,Puerto Rico,US79,Arizona,Peak,$20.73,$40.10
+RQ,Puerto Rico,US83,Idaho,NonPeak,$18.33,$31.45
+RQ,Puerto Rico,US83,Idaho,Peak,$21.63,$37.11
+RQ,Puerto Rico,US84,Washington,NonPeak,$24.38,$44.28
+RQ,Puerto Rico,US84,Washington,Peak,$28.77,$52.25
+RQ,Puerto Rico,US85,Oregon,NonPeak,$16.00,$34.11
+RQ,Puerto Rico,US85,Oregon,Peak,$18.88,$40.25
+RQ,Puerto Rico,US86,Nevada,NonPeak,$27.63,$31.63
+RQ,Puerto Rico,US86,Nevada,Peak,$32.60,$37.32
+RQ,Puerto Rico,US87,California-North,NonPeak,$29.28,$44.51
+RQ,Puerto Rico,US87,California-North,Peak,$34.55,$52.52
+RQ,Puerto Rico,US88,California-South,NonPeak,$30.90,$34.33
+RQ,Puerto Rico,US88,California-South,Peak,$36.46,$40.51
+SA,Saudi Arabia,US11,Maine,NonPeak,$15.28,$31.74
+SA,Saudi Arabia,US11,Maine,Peak,$18.03,$37.45
+SA,Saudi Arabia,US12,New Hampshire,NonPeak,$16.05,$44.62
+SA,Saudi Arabia,US12,New Hampshire,Peak,$18.94,$52.65
+SA,Saudi Arabia,US13,Vermont,NonPeak,$16.80,$34.45
+SA,Saudi Arabia,US13,Vermont,Peak,$19.82,$40.65
+SA,Saudi Arabia,US14,Massachusetts,NonPeak,$17.57,$31.91
+SA,Saudi Arabia,US14,Massachusetts,Peak,$20.73,$37.65
+SA,Saudi Arabia,US15,Rhode Island,NonPeak,$18.33,$44.74
+SA,Saudi Arabia,US15,Rhode Island,Peak,$21.63,$52.79
+SA,Saudi Arabia,US16,Connecticut,NonPeak,$24.38,$34.56
+SA,Saudi Arabia,US16,Connecticut,Peak,$28.77,$40.78
+SA,Saudi Arabia,US17,New York,NonPeak,$16.00,$32.09
+SA,Saudi Arabia,US17,New York,Peak,$18.88,$37.87
+SA,Saudi Arabia,US19,New Jersey,NonPeak,$27.63,$44.91
+SA,Saudi Arabia,US19,New Jersey,Peak,$32.60,$52.99
+SA,Saudi Arabia,US20,Pennsylvania,NonPeak,$29.28,$34.74
+SA,Saudi Arabia,US20,Pennsylvania,Peak,$34.55,$40.99
+SA,Saudi Arabia,US22,Delaware,NonPeak,$30.90,$32.26
+SA,Saudi Arabia,US22,Delaware,Peak,$36.46,$38.07
+SA,Saudi Arabia,US23,Maryland,NonPeak,$15.28,$45.09
+SA,Saudi Arabia,US23,Maryland,Peak,$18.03,$53.21
+SA,Saudi Arabia,US24,District Of Columbia,NonPeak,$16.05,$34.90
+SA,Saudi Arabia,US24,District Of Columbia,Peak,$18.94,$41.18
+SA,Saudi Arabia,US25,Virginia,NonPeak,$16.80,$32.44
+SA,Saudi Arabia,US25,Virginia,Peak,$19.82,$38.28
+SA,Saudi Arabia,US27,West Virginia,NonPeak,$17.57,$43.94
+SA,Saudi Arabia,US27,West Virginia,Peak,$20.73,$51.85
+SA,Saudi Arabia,US28,Kentucky,NonPeak,$18.33,$33.70
+SA,Saudi Arabia,US28,Kentucky,Peak,$21.63,$39.77
+SA,Saudi Arabia,US30,Michigan,NonPeak,$24.38,$31.29
+SA,Saudi Arabia,US30,Michigan,Peak,$28.77,$36.92
+SA,Saudi Arabia,US32,Wisconsin,NonPeak,$16.00,$44.05
+SA,Saudi Arabia,US32,Wisconsin,Peak,$18.88,$51.98
+SA,Saudi Arabia,US34,Ohio,NonPeak,$27.63,$33.75
+SA,Saudi Arabia,US34,Ohio,Peak,$32.60,$39.82
+SA,Saudi Arabia,US36,Indiana,NonPeak,$29.28,$31.40
+SA,Saudi Arabia,US36,Indiana,Peak,$34.55,$37.05
+SA,Saudi Arabia,US38,Illinois,NonPeak,$30.90,$44.17
+SA,Saudi Arabia,US38,Illinois,Peak,$36.46,$52.12
+SA,Saudi Arabia,US40,North Carolina,NonPeak,$15.28,$33.98
+SA,Saudi Arabia,US40,North Carolina,Peak,$18.03,$40.10
+SA,Saudi Arabia,US42,Tennessee,NonPeak,$16.05,$31.45
+SA,Saudi Arabia,US42,Tennessee,Peak,$18.94,$37.11
+SA,Saudi Arabia,US44,South Carolina,NonPeak,$16.80,$44.28
+SA,Saudi Arabia,US44,South Carolina,Peak,$19.82,$52.25
+SA,Saudi Arabia,US45,Georgia,NonPeak,$17.57,$34.11
+SA,Saudi Arabia,US45,Georgia,Peak,$20.73,$40.25
+SA,Saudi Arabia,US47,Alabama,NonPeak,$18.33,$31.63
+SA,Saudi Arabia,US47,Alabama,Peak,$21.63,$37.32
+SA,Saudi Arabia,US48,Mississippi,NonPeak,$24.38,$44.51
+SA,Saudi Arabia,US48,Mississippi,Peak,$28.77,$52.52
+SA,Saudi Arabia,US49,Florida-North,NonPeak,$16.00,$34.33
+SA,Saudi Arabia,US49,Florida-North,Peak,$18.88,$40.51
+SA,Saudi Arabia,US4964400,Florida-South,NonPeak,$27.63,$31.74
+SA,Saudi Arabia,US4964400,Florida-South,Peak,$32.60,$37.45
+SA,Saudi Arabia,US4965500,Florida Keys,NonPeak,$29.28,$44.62
+SA,Saudi Arabia,US4965500,Florida Keys,Peak,$34.55,$52.65
+SA,Saudi Arabia,US50,Minnesota,NonPeak,$30.90,$34.45
+SA,Saudi Arabia,US50,Minnesota,Peak,$36.46,$40.65
+SA,Saudi Arabia,US51,North Dakota,NonPeak,$15.28,$31.91
+SA,Saudi Arabia,US51,North Dakota,Peak,$18.03,$37.65
+SA,Saudi Arabia,US52,South Dakota,NonPeak,$16.05,$44.74
+SA,Saudi Arabia,US52,South Dakota,Peak,$18.94,$52.79
+SA,Saudi Arabia,US53,Iowa,NonPeak,$16.80,$34.56
+SA,Saudi Arabia,US53,Iowa,Peak,$19.82,$40.78
+SA,Saudi Arabia,US55,Nebraska,NonPeak,$17.57,$32.09
+SA,Saudi Arabia,US55,Nebraska,Peak,$20.73,$37.87
+SA,Saudi Arabia,US56,Missouri,NonPeak,$18.33,$44.91
+SA,Saudi Arabia,US56,Missouri,Peak,$21.63,$52.99
+SA,Saudi Arabia,US58,Kansas,NonPeak,$24.38,$34.74
+SA,Saudi Arabia,US58,Kansas,Peak,$28.77,$40.99
+SA,Saudi Arabia,US60,Arkansas,NonPeak,$16.00,$32.26
+SA,Saudi Arabia,US60,Arkansas,Peak,$18.88,$38.07
+SA,Saudi Arabia,US62,Oklahoma,NonPeak,$27.63,$45.09
+SA,Saudi Arabia,US62,Oklahoma,Peak,$32.60,$53.21
+SA,Saudi Arabia,US64,Louisiana,NonPeak,$29.28,$34.90
+SA,Saudi Arabia,US64,Louisiana,Peak,$34.55,$41.18
+SA,Saudi Arabia,US66,Texas-North,NonPeak,$30.90,$32.44
+SA,Saudi Arabia,US66,Texas-North,Peak,$36.46,$38.28
+SA,Saudi Arabia,US68,Texas-South,NonPeak,$15.28,$43.94
+SA,Saudi Arabia,US68,Texas-South,Peak,$18.03,$51.85
+SA,Saudi Arabia,US70,Montana,NonPeak,$16.05,$33.70
+SA,Saudi Arabia,US70,Montana,Peak,$18.94,$39.77
+SA,Saudi Arabia,US72,Wyoming,NonPeak,$16.80,$31.29
+SA,Saudi Arabia,US72,Wyoming,Peak,$19.82,$36.92
+SA,Saudi Arabia,US74,Colorado,NonPeak,$17.57,$44.05
+SA,Saudi Arabia,US74,Colorado,Peak,$20.73,$51.98
+SA,Saudi Arabia,US76,Utah,NonPeak,$18.33,$33.75
+SA,Saudi Arabia,US76,Utah,Peak,$21.63,$39.82
+SA,Saudi Arabia,US77,New Mexico,NonPeak,$24.38,$31.40
+SA,Saudi Arabia,US77,New Mexico,Peak,$28.77,$37.05
+SA,Saudi Arabia,US79,Arizona,NonPeak,$16.00,$44.17
+SA,Saudi Arabia,US79,Arizona,Peak,$18.88,$52.12
+SA,Saudi Arabia,US83,Idaho,NonPeak,$27.63,$33.98
+SA,Saudi Arabia,US83,Idaho,Peak,$32.60,$40.10
+SA,Saudi Arabia,US84,Washington,NonPeak,$29.28,$31.45
+SA,Saudi Arabia,US84,Washington,Peak,$34.55,$37.11
+SA,Saudi Arabia,US85,Oregon,NonPeak,$30.90,$44.28
+SA,Saudi Arabia,US85,Oregon,Peak,$36.46,$52.25
+SA,Saudi Arabia,US86,Nevada,NonPeak,$15.28,$34.11
+SA,Saudi Arabia,US86,Nevada,Peak,$18.03,$40.25
+SA,Saudi Arabia,US87,California-North,NonPeak,$16.05,$31.63
+SA,Saudi Arabia,US87,California-North,Peak,$18.94,$37.32
+SA,Saudi Arabia,US88,California-South,NonPeak,$16.80,$44.51
+SA,Saudi Arabia,US88,California-South,Peak,$19.82,$52.52
+SN,Singapore,US11,Maine,NonPeak,$17.57,$34.33
+SN,Singapore,US11,Maine,Peak,$20.73,$40.51
+SN,Singapore,US12,New Hampshire,NonPeak,$18.33,$31.74
+SN,Singapore,US12,New Hampshire,Peak,$21.63,$37.45
+SN,Singapore,US13,Vermont,NonPeak,$24.38,$44.62
+SN,Singapore,US13,Vermont,Peak,$28.77,$52.65
+SN,Singapore,US14,Massachusetts,NonPeak,$16.00,$34.45
+SN,Singapore,US14,Massachusetts,Peak,$18.88,$40.65
+SN,Singapore,US15,Rhode Island,NonPeak,$27.63,$31.91
+SN,Singapore,US15,Rhode Island,Peak,$32.60,$37.65
+SN,Singapore,US16,Connecticut,NonPeak,$29.28,$44.74
+SN,Singapore,US16,Connecticut,Peak,$34.55,$52.79
+SN,Singapore,US17,New York,NonPeak,$30.90,$34.56
+SN,Singapore,US17,New York,Peak,$36.46,$40.78
+SN,Singapore,US19,New Jersey,NonPeak,$15.28,$32.09
+SN,Singapore,US19,New Jersey,Peak,$18.03,$37.87
+SN,Singapore,US20,Pennsylvania,NonPeak,$16.05,$44.91
+SN,Singapore,US20,Pennsylvania,Peak,$18.94,$52.99
+SN,Singapore,US22,Delaware,NonPeak,$16.80,$34.74
+SN,Singapore,US22,Delaware,Peak,$19.82,$40.99
+SN,Singapore,US23,Maryland,NonPeak,$17.57,$32.26
+SN,Singapore,US23,Maryland,Peak,$20.73,$38.07
+SN,Singapore,US24,District Of Columbia,NonPeak,$18.33,$45.09
+SN,Singapore,US24,District Of Columbia,Peak,$21.63,$53.21
+SN,Singapore,US25,Virginia,NonPeak,$24.38,$34.90
+SN,Singapore,US25,Virginia,Peak,$28.77,$41.18
+SN,Singapore,US27,West Virginia,NonPeak,$16.00,$32.44
+SN,Singapore,US27,West Virginia,Peak,$18.88,$38.28
+SN,Singapore,US28,Kentucky,NonPeak,$27.63,$43.94
+SN,Singapore,US28,Kentucky,Peak,$32.60,$51.85
+SN,Singapore,US30,Michigan,NonPeak,$29.28,$33.70
+SN,Singapore,US30,Michigan,Peak,$34.55,$39.77
+SN,Singapore,US32,Wisconsin,NonPeak,$30.90,$31.29
+SN,Singapore,US32,Wisconsin,Peak,$36.46,$36.92
+SN,Singapore,US34,Ohio,NonPeak,$15.28,$44.05
+SN,Singapore,US34,Ohio,Peak,$18.03,$51.98
+SN,Singapore,US36,Indiana,NonPeak,$16.05,$33.75
+SN,Singapore,US36,Indiana,Peak,$18.94,$39.82
+SN,Singapore,US38,Illinois,NonPeak,$16.80,$31.40
+SN,Singapore,US38,Illinois,Peak,$19.82,$37.05
+SN,Singapore,US40,North Carolina,NonPeak,$17.57,$44.17
+SN,Singapore,US40,North Carolina,Peak,$20.73,$52.12
+SN,Singapore,US42,Tennessee,NonPeak,$18.33,$33.98
+SN,Singapore,US42,Tennessee,Peak,$21.63,$40.10
+SN,Singapore,US44,South Carolina,NonPeak,$24.38,$31.45
+SN,Singapore,US44,South Carolina,Peak,$28.77,$37.11
+SN,Singapore,US45,Georgia,NonPeak,$16.00,$44.28
+SN,Singapore,US45,Georgia,Peak,$18.88,$52.25
+SN,Singapore,US47,Alabama,NonPeak,$27.63,$34.11
+SN,Singapore,US47,Alabama,Peak,$32.60,$40.25
+SN,Singapore,US48,Mississippi,NonPeak,$29.28,$31.63
+SN,Singapore,US48,Mississippi,Peak,$34.55,$37.32
+SN,Singapore,US49,Florida-North,NonPeak,$30.90,$44.51
+SN,Singapore,US49,Florida-North,Peak,$36.46,$52.52
+SN,Singapore,US4964400,Florida-South,NonPeak,$15.28,$34.33
+SN,Singapore,US4964400,Florida-South,Peak,$18.03,$40.51
+SN,Singapore,US4965500,Florida Keys,NonPeak,$16.05,$31.74
+SN,Singapore,US4965500,Florida Keys,Peak,$18.94,$37.45
+SN,Singapore,US50,Minnesota,NonPeak,$16.80,$44.62
+SN,Singapore,US50,Minnesota,Peak,$19.82,$52.65
+SN,Singapore,US51,North Dakota,NonPeak,$17.57,$34.45
+SN,Singapore,US51,North Dakota,Peak,$20.73,$40.65
+SN,Singapore,US52,South Dakota,NonPeak,$18.33,$31.91
+SN,Singapore,US52,South Dakota,Peak,$21.63,$37.65
+SN,Singapore,US53,Iowa,NonPeak,$24.38,$44.74
+SN,Singapore,US53,Iowa,Peak,$28.77,$52.79
+SN,Singapore,US55,Nebraska,NonPeak,$16.00,$34.56
+SN,Singapore,US55,Nebraska,Peak,$18.88,$40.78
+SN,Singapore,US56,Missouri,NonPeak,$27.63,$32.09
+SN,Singapore,US56,Missouri,Peak,$32.60,$37.87
+SN,Singapore,US58,Kansas,NonPeak,$29.28,$44.91
+SN,Singapore,US58,Kansas,Peak,$34.55,$52.99
+SN,Singapore,US60,Arkansas,NonPeak,$30.90,$34.74
+SN,Singapore,US60,Arkansas,Peak,$36.46,$40.99
+SN,Singapore,US62,Oklahoma,NonPeak,$15.28,$32.26
+SN,Singapore,US62,Oklahoma,Peak,$18.03,$38.07
+SN,Singapore,US64,Louisiana,NonPeak,$16.05,$45.09
+SN,Singapore,US64,Louisiana,Peak,$18.94,$53.21
+SN,Singapore,US66,Texas-North,NonPeak,$16.80,$34.90
+SN,Singapore,US66,Texas-North,Peak,$19.82,$41.18
+SN,Singapore,US68,Texas-South,NonPeak,$17.57,$32.44
+SN,Singapore,US68,Texas-South,Peak,$20.73,$38.28
+SN,Singapore,US70,Montana,NonPeak,$18.33,$43.94
+SN,Singapore,US70,Montana,Peak,$21.63,$51.85
+SN,Singapore,US72,Wyoming,NonPeak,$24.38,$33.70
+SN,Singapore,US72,Wyoming,Peak,$28.77,$39.77
+SN,Singapore,US74,Colorado,NonPeak,$16.00,$31.29
+SN,Singapore,US74,Colorado,Peak,$18.88,$36.92
+SN,Singapore,US76,Utah,NonPeak,$27.63,$44.05
+SN,Singapore,US76,Utah,Peak,$32.60,$51.98
+SN,Singapore,US77,New Mexico,NonPeak,$29.28,$33.75
+SN,Singapore,US77,New Mexico,Peak,$34.55,$39.82
+SN,Singapore,US79,Arizona,NonPeak,$30.90,$31.40
+SN,Singapore,US79,Arizona,Peak,$36.46,$37.05
+SN,Singapore,US83,Idaho,NonPeak,$15.28,$44.17
+SN,Singapore,US83,Idaho,Peak,$18.03,$52.12
+SN,Singapore,US84,Washington,NonPeak,$16.05,$33.98
+SN,Singapore,US84,Washington,Peak,$18.94,$40.10
+SN,Singapore,US85,Oregon,NonPeak,$16.80,$31.45
+SN,Singapore,US85,Oregon,Peak,$19.82,$37.11
+SN,Singapore,US86,Nevada,NonPeak,$17.57,$44.28
+SN,Singapore,US86,Nevada,Peak,$20.73,$52.25
+SN,Singapore,US87,California-North,NonPeak,$18.33,$34.11
+SN,Singapore,US87,California-North,Peak,$21.63,$40.25
+SN,Singapore,US88,California-South,NonPeak,$24.38,$31.63
+SN,Singapore,US88,California-South,Peak,$28.77,$37.32
+SP,Spain,US11,Maine,NonPeak,$16.00,$44.51
+SP,Spain,US11,Maine,Peak,$18.88,$52.52
+SP,Spain,US12,New Hampshire,NonPeak,$27.63,$34.33
+SP,Spain,US12,New Hampshire,Peak,$32.60,$40.51
+SP,Spain,US13,Vermont,NonPeak,$29.28,$31.74
+SP,Spain,US13,Vermont,Peak,$34.55,$37.45
+SP,Spain,US14,Massachusetts,NonPeak,$30.90,$44.62
+SP,Spain,US14,Massachusetts,Peak,$36.46,$52.65
+SP,Spain,US15,Rhode Island,NonPeak,$15.28,$34.45
+SP,Spain,US15,Rhode Island,Peak,$18.03,$40.65
+SP,Spain,US16,Connecticut,NonPeak,$16.05,$31.91
+SP,Spain,US16,Connecticut,Peak,$18.94,$37.65
+SP,Spain,US17,New York,NonPeak,$16.80,$44.74
+SP,Spain,US17,New York,Peak,$19.82,$52.79
+SP,Spain,US19,New Jersey,NonPeak,$17.57,$34.56
+SP,Spain,US19,New Jersey,Peak,$20.73,$40.78
+SP,Spain,US20,Pennsylvania,NonPeak,$18.33,$32.09
+SP,Spain,US20,Pennsylvania,Peak,$21.63,$37.87
+SP,Spain,US22,Delaware,NonPeak,$24.38,$44.91
+SP,Spain,US22,Delaware,Peak,$28.77,$52.99
+SP,Spain,US23,Maryland,NonPeak,$16.00,$34.74
+SP,Spain,US23,Maryland,Peak,$18.88,$40.99
+SP,Spain,US24,District Of Columbia,NonPeak,$27.63,$32.26
+SP,Spain,US24,District Of Columbia,Peak,$32.60,$38.07
+SP,Spain,US25,Virginia,NonPeak,$29.28,$45.09
+SP,Spain,US25,Virginia,Peak,$34.55,$53.21
+SP,Spain,US27,West Virginia,NonPeak,$30.90,$34.90
+SP,Spain,US27,West Virginia,Peak,$36.46,$41.18
+SP,Spain,US28,Kentucky,NonPeak,$15.28,$32.44
+SP,Spain,US28,Kentucky,Peak,$18.03,$38.28
+SP,Spain,US30,Michigan,NonPeak,$16.05,$43.94
+SP,Spain,US30,Michigan,Peak,$18.94,$51.85
+SP,Spain,US32,Wisconsin,NonPeak,$16.80,$33.70
+SP,Spain,US32,Wisconsin,Peak,$19.82,$39.77
+SP,Spain,US34,Ohio,NonPeak,$17.57,$31.29
+SP,Spain,US34,Ohio,Peak,$20.73,$36.92
+SP,Spain,US36,Indiana,NonPeak,$18.33,$44.05
+SP,Spain,US36,Indiana,Peak,$21.63,$51.98
+SP,Spain,US38,Illinois,NonPeak,$24.38,$33.75
+SP,Spain,US38,Illinois,Peak,$28.77,$39.82
+SP,Spain,US40,North Carolina,NonPeak,$16.00,$31.40
+SP,Spain,US40,North Carolina,Peak,$18.88,$37.05
+SP,Spain,US42,Tennessee,NonPeak,$27.63,$44.17
+SP,Spain,US42,Tennessee,Peak,$32.60,$52.12
+SP,Spain,US44,South Carolina,NonPeak,$29.28,$33.98
+SP,Spain,US44,South Carolina,Peak,$34.55,$40.10
+SP,Spain,US45,Georgia,NonPeak,$30.90,$31.45
+SP,Spain,US45,Georgia,Peak,$36.46,$37.11
+SP,Spain,US47,Alabama,NonPeak,$15.28,$44.28
+SP,Spain,US47,Alabama,Peak,$18.03,$52.25
+SP,Spain,US48,Mississippi,NonPeak,$16.05,$34.11
+SP,Spain,US48,Mississippi,Peak,$18.94,$40.25
+SP,Spain,US49,Florida-North,NonPeak,$16.80,$31.63
+SP,Spain,US49,Florida-North,Peak,$19.82,$37.32
+SP,Spain,US4964400,Florida-South,NonPeak,$17.57,$44.51
+SP,Spain,US4964400,Florida-South,Peak,$20.73,$52.52
+SP,Spain,US4965500,Florida Keys,NonPeak,$18.33,$34.33
+SP,Spain,US4965500,Florida Keys,Peak,$21.63,$40.51
+SP,Spain,US50,Minnesota,NonPeak,$24.38,$31.74
+SP,Spain,US50,Minnesota,Peak,$28.77,$37.45
+SP,Spain,US51,North Dakota,NonPeak,$16.00,$44.62
+SP,Spain,US51,North Dakota,Peak,$18.88,$52.65
+SP,Spain,US52,South Dakota,NonPeak,$27.63,$34.45
+SP,Spain,US52,South Dakota,Peak,$32.60,$40.65
+SP,Spain,US53,Iowa,NonPeak,$29.28,$31.91
+SP,Spain,US53,Iowa,Peak,$34.55,$37.65
+SP,Spain,US55,Nebraska,NonPeak,$30.90,$44.74
+SP,Spain,US55,Nebraska,Peak,$36.46,$52.79
+SP,Spain,US56,Missouri,NonPeak,$15.28,$34.56
+SP,Spain,US56,Missouri,Peak,$18.03,$40.78
+SP,Spain,US58,Kansas,NonPeak,$16.05,$32.09
+SP,Spain,US58,Kansas,Peak,$18.94,$37.87
+SP,Spain,US60,Arkansas,NonPeak,$16.80,$44.91
+SP,Spain,US60,Arkansas,Peak,$19.82,$52.99
+SP,Spain,US62,Oklahoma,NonPeak,$17.57,$34.74
+SP,Spain,US62,Oklahoma,Peak,$20.73,$40.99
+SP,Spain,US64,Louisiana,NonPeak,$18.33,$32.26
+SP,Spain,US64,Louisiana,Peak,$21.63,$38.07
+SP,Spain,US66,Texas-North,NonPeak,$24.38,$45.09
+SP,Spain,US66,Texas-North,Peak,$28.77,$53.21
+SP,Spain,US68,Texas-South,NonPeak,$16.00,$34.90
+SP,Spain,US68,Texas-South,Peak,$18.88,$41.18
+SP,Spain,US70,Montana,NonPeak,$27.63,$32.44
+SP,Spain,US70,Montana,Peak,$32.60,$38.28
+SP,Spain,US72,Wyoming,NonPeak,$29.28,$43.94
+SP,Spain,US72,Wyoming,Peak,$34.55,$51.85
+SP,Spain,US74,Colorado,NonPeak,$30.90,$33.70
+SP,Spain,US74,Colorado,Peak,$36.46,$39.77
+SP,Spain,US76,Utah,NonPeak,$15.28,$31.29
+SP,Spain,US76,Utah,Peak,$18.03,$36.92
+SP,Spain,US77,New Mexico,NonPeak,$16.05,$44.05
+SP,Spain,US77,New Mexico,Peak,$18.94,$51.98
+SP,Spain,US79,Arizona,NonPeak,$16.80,$33.75
+SP,Spain,US79,Arizona,Peak,$19.82,$39.82
+SP,Spain,US83,Idaho,NonPeak,$17.57,$31.40
+SP,Spain,US83,Idaho,Peak,$20.73,$37.05
+SP,Spain,US84,Washington,NonPeak,$18.33,$44.17
+SP,Spain,US84,Washington,Peak,$21.63,$52.12
+SP,Spain,US85,Oregon,NonPeak,$24.38,$33.98
+SP,Spain,US85,Oregon,Peak,$28.77,$40.10
+SP,Spain,US86,Nevada,NonPeak,$16.00,$31.45
+SP,Spain,US86,Nevada,Peak,$18.88,$37.11
+SP,Spain,US87,California-North,NonPeak,$27.63,$44.28
+SP,Spain,US87,California-North,Peak,$32.60,$52.25
+SP,Spain,US88,California-South,NonPeak,$29.28,$34.11
+SP,Spain,US88,California-South,Peak,$34.55,$40.25
+TU,Turkey,US11,Maine,NonPeak,$30.90,$31.63
+TU,Turkey,US11,Maine,Peak,$36.46,$37.32
+TU,Turkey,US12,New Hampshire,NonPeak,$15.28,$44.51
+TU,Turkey,US12,New Hampshire,Peak,$18.03,$52.52
+TU,Turkey,US13,Vermont,NonPeak,$16.05,$34.33
+TU,Turkey,US13,Vermont,Peak,$18.94,$40.51
+TU,Turkey,US14,Massachusetts,NonPeak,$16.80,$31.74
+TU,Turkey,US14,Massachusetts,Peak,$19.82,$37.45
+TU,Turkey,US15,Rhode Island,NonPeak,$17.57,$44.62
+TU,Turkey,US15,Rhode Island,Peak,$20.73,$52.65
+TU,Turkey,US16,Connecticut,NonPeak,$18.33,$34.45
+TU,Turkey,US16,Connecticut,Peak,$21.63,$40.65
+TU,Turkey,US17,New York,NonPeak,$24.38,$31.91
+TU,Turkey,US17,New York,Peak,$28.77,$37.65
+TU,Turkey,US19,New Jersey,NonPeak,$16.00,$44.74
+TU,Turkey,US19,New Jersey,Peak,$18.88,$52.79
+TU,Turkey,US20,Pennsylvania,NonPeak,$27.63,$34.56
+TU,Turkey,US20,Pennsylvania,Peak,$32.60,$40.78
+TU,Turkey,US22,Delaware,NonPeak,$29.28,$32.09
+TU,Turkey,US22,Delaware,Peak,$34.55,$37.87
+TU,Turkey,US23,Maryland,NonPeak,$30.90,$44.91
+TU,Turkey,US23,Maryland,Peak,$36.46,$52.99
+TU,Turkey,US24,District Of Columbia,NonPeak,$15.28,$34.74
+TU,Turkey,US24,District Of Columbia,Peak,$18.03,$40.99
+TU,Turkey,US25,Virginia,NonPeak,$16.05,$32.26
+TU,Turkey,US25,Virginia,Peak,$18.94,$38.07
+TU,Turkey,US27,West Virginia,NonPeak,$16.80,$45.09
+TU,Turkey,US27,West Virginia,Peak,$19.82,$53.21
+TU,Turkey,US28,Kentucky,NonPeak,$17.57,$34.90
+TU,Turkey,US28,Kentucky,Peak,$20.73,$41.18
+TU,Turkey,US30,Michigan,NonPeak,$18.33,$32.44
+TU,Turkey,US30,Michigan,Peak,$21.63,$38.28
+TU,Turkey,US32,Wisconsin,NonPeak,$24.38,$43.94
+TU,Turkey,US32,Wisconsin,Peak,$28.77,$51.85
+TU,Turkey,US34,Ohio,NonPeak,$16.00,$33.70
+TU,Turkey,US34,Ohio,Peak,$18.88,$39.77
+TU,Turkey,US36,Indiana,NonPeak,$27.63,$31.29
+TU,Turkey,US36,Indiana,Peak,$32.60,$36.92
+TU,Turkey,US38,Illinois,NonPeak,$29.28,$44.05
+TU,Turkey,US38,Illinois,Peak,$34.55,$51.98
+TU,Turkey,US40,North Carolina,NonPeak,$30.90,$33.75
+TU,Turkey,US40,North Carolina,Peak,$36.46,$39.82
+TU,Turkey,US42,Tennessee,NonPeak,$15.28,$31.40
+TU,Turkey,US42,Tennessee,Peak,$18.03,$37.05
+TU,Turkey,US44,South Carolina,NonPeak,$16.05,$44.17
+TU,Turkey,US44,South Carolina,Peak,$18.94,$52.12
+TU,Turkey,US45,Georgia,NonPeak,$16.80,$33.98
+TU,Turkey,US45,Georgia,Peak,$19.82,$40.10
+TU,Turkey,US47,Alabama,NonPeak,$17.57,$31.45
+TU,Turkey,US47,Alabama,Peak,$20.73,$37.11
+TU,Turkey,US48,Mississippi,NonPeak,$18.33,$44.28
+TU,Turkey,US48,Mississippi,Peak,$21.63,$52.25
+TU,Turkey,US49,Florida-North,NonPeak,$24.38,$34.11
+TU,Turkey,US49,Florida-North,Peak,$28.77,$40.25
+TU,Turkey,US4964400,Florida-South,NonPeak,$16.00,$31.63
+TU,Turkey,US4964400,Florida-South,Peak,$18.88,$37.32
+TU,Turkey,US4965500,Florida Keys,NonPeak,$27.63,$44.51
+TU,Turkey,US4965500,Florida Keys,Peak,$32.60,$52.52
+TU,Turkey,US50,Minnesota,NonPeak,$29.28,$34.33
+TU,Turkey,US50,Minnesota,Peak,$34.55,$40.51
+TU,Turkey,US51,North Dakota,NonPeak,$30.90,$31.74
+TU,Turkey,US51,North Dakota,Peak,$36.46,$37.45
+TU,Turkey,US52,South Dakota,NonPeak,$15.28,$44.62
+TU,Turkey,US52,South Dakota,Peak,$18.03,$52.65
+TU,Turkey,US53,Iowa,NonPeak,$16.05,$34.45
+TU,Turkey,US53,Iowa,Peak,$18.94,$40.65
+TU,Turkey,US55,Nebraska,NonPeak,$16.80,$31.91
+TU,Turkey,US55,Nebraska,Peak,$19.82,$37.65
+TU,Turkey,US56,Missouri,NonPeak,$17.57,$44.74
+TU,Turkey,US56,Missouri,Peak,$20.73,$52.79
+TU,Turkey,US58,Kansas,NonPeak,$18.33,$34.56
+TU,Turkey,US58,Kansas,Peak,$21.63,$40.78
+TU,Turkey,US60,Arkansas,NonPeak,$24.38,$32.09
+TU,Turkey,US60,Arkansas,Peak,$28.77,$37.87
+TU,Turkey,US62,Oklahoma,NonPeak,$16.00,$44.91
+TU,Turkey,US62,Oklahoma,Peak,$18.88,$52.99
+TU,Turkey,US64,Louisiana,NonPeak,$27.63,$34.74
+TU,Turkey,US64,Louisiana,Peak,$32.60,$40.99
+TU,Turkey,US66,Texas-North,NonPeak,$29.28,$32.26
+TU,Turkey,US66,Texas-North,Peak,$34.55,$38.07
+TU,Turkey,US68,Texas-South,NonPeak,$30.90,$45.09
+TU,Turkey,US68,Texas-South,Peak,$36.46,$53.21
+TU,Turkey,US70,Montana,NonPeak,$15.28,$34.90
+TU,Turkey,US70,Montana,Peak,$18.03,$41.18
+TU,Turkey,US72,Wyoming,NonPeak,$16.05,$32.44
+TU,Turkey,US72,Wyoming,Peak,$18.94,$38.28
+TU,Turkey,US74,Colorado,NonPeak,$16.80,$43.94
+TU,Turkey,US74,Colorado,Peak,$19.82,$51.85
+TU,Turkey,US76,Utah,NonPeak,$17.57,$33.70
+TU,Turkey,US76,Utah,Peak,$20.73,$39.77
+TU,Turkey,US77,New Mexico,NonPeak,$18.33,$31.29
+TU,Turkey,US77,New Mexico,Peak,$21.63,$36.92
+TU,Turkey,US79,Arizona,NonPeak,$24.38,$44.05
+TU,Turkey,US79,Arizona,Peak,$28.77,$51.98
+TU,Turkey,US83,Idaho,NonPeak,$16.00,$33.75
+TU,Turkey,US83,Idaho,Peak,$18.88,$39.82
+TU,Turkey,US84,Washington,NonPeak,$27.63,$31.40
+TU,Turkey,US84,Washington,Peak,$32.60,$37.05
+TU,Turkey,US85,Oregon,NonPeak,$29.28,$44.17
+TU,Turkey,US85,Oregon,Peak,$34.55,$52.12
+TU,Turkey,US86,Nevada,NonPeak,$30.90,$33.98
+TU,Turkey,US86,Nevada,Peak,$36.46,$40.10
+TU,Turkey,US87,California-North,NonPeak,$15.28,$31.45
+TU,Turkey,US87,California-North,Peak,$18.03,$37.11
+TU,Turkey,US88,California-South,NonPeak,$16.05,$44.28
+TU,Turkey,US88,California-South,Peak,$18.94,$52.25
+UK,United Kingdom,US11,Maine,NonPeak,$16.80,$34.11
+UK,United Kingdom,US11,Maine,Peak,$19.82,$40.25
+UK,United Kingdom,US12,New Hampshire,NonPeak,$17.57,$31.63
+UK,United Kingdom,US12,New Hampshire,Peak,$20.73,$37.32
+UK,United Kingdom,US13,Vermont,NonPeak,$18.33,$44.51
+UK,United Kingdom,US13,Vermont,Peak,$21.63,$52.52
+UK,United Kingdom,US14,Massachusetts,NonPeak,$24.38,$34.33
+UK,United Kingdom,US14,Massachusetts,Peak,$28.77,$40.51
+UK,United Kingdom,US15,Rhode Island,NonPeak,$16.00,$31.74
+UK,United Kingdom,US15,Rhode Island,Peak,$18.88,$37.45
+UK,United Kingdom,US16,Connecticut,NonPeak,$27.63,$44.62
+UK,United Kingdom,US16,Connecticut,Peak,$32.60,$52.65
+UK,United Kingdom,US17,New York,NonPeak,$29.28,$34.45
+UK,United Kingdom,US17,New York,Peak,$34.55,$40.65
+UK,United Kingdom,US19,New Jersey,NonPeak,$30.90,$31.91
+UK,United Kingdom,US19,New Jersey,Peak,$36.46,$37.65
+UK,United Kingdom,US20,Pennsylvania,NonPeak,$15.28,$44.74
+UK,United Kingdom,US20,Pennsylvania,Peak,$18.03,$52.79
+UK,United Kingdom,US22,Delaware,NonPeak,$16.05,$34.56
+UK,United Kingdom,US22,Delaware,Peak,$18.94,$40.78
+UK,United Kingdom,US23,Maryland,NonPeak,$16.80,$32.09
+UK,United Kingdom,US23,Maryland,Peak,$19.82,$37.87
+UK,United Kingdom,US24,District Of Columbia,NonPeak,$17.57,$44.91
+UK,United Kingdom,US24,District Of Columbia,Peak,$20.73,$52.99
+UK,United Kingdom,US25,Virginia,NonPeak,$18.33,$34.74
+UK,United Kingdom,US25,Virginia,Peak,$21.63,$40.99
+UK,United Kingdom,US27,West Virginia,NonPeak,$24.38,$32.26
+UK,United Kingdom,US27,West Virginia,Peak,$28.77,$38.07
+UK,United Kingdom,US28,Kentucky,NonPeak,$16.00,$45.09
+UK,United Kingdom,US28,Kentucky,Peak,$18.88,$53.21
+UK,United Kingdom,US30,Michigan,NonPeak,$27.63,$34.90
+UK,United Kingdom,US30,Michigan,Peak,$32.60,$41.18
+UK,United Kingdom,US32,Wisconsin,NonPeak,$29.28,$32.44
+UK,United Kingdom,US32,Wisconsin,Peak,$34.55,$38.28
+UK,United Kingdom,US34,Ohio,NonPeak,$30.90,$43.94
+UK,United Kingdom,US34,Ohio,Peak,$36.46,$51.85
+UK,United Kingdom,US36,Indiana,NonPeak,$15.28,$33.70
+UK,United Kingdom,US36,Indiana,Peak,$18.03,$39.77
+UK,United Kingdom,US38,Illinois,NonPeak,$16.05,$31.29
+UK,United Kingdom,US38,Illinois,Peak,$18.94,$36.92
+UK,United Kingdom,US40,North Carolina,NonPeak,$16.80,$44.05
+UK,United Kingdom,US40,North Carolina,Peak,$19.82,$51.98
+UK,United Kingdom,US42,Tennessee,NonPeak,$17.57,$33.75
+UK,United Kingdom,US42,Tennessee,Peak,$20.73,$39.82
+UK,United Kingdom,US44,South Carolina,NonPeak,$18.33,$31.40
+UK,United Kingdom,US44,South Carolina,Peak,$21.63,$37.05
+UK,United Kingdom,US45,Georgia,NonPeak,$24.38,$44.17
+UK,United Kingdom,US45,Georgia,Peak,$28.77,$52.12
+UK,United Kingdom,US47,Alabama,NonPeak,$16.00,$33.98
+UK,United Kingdom,US47,Alabama,Peak,$18.88,$40.10
+UK,United Kingdom,US48,Mississippi,NonPeak,$27.63,$31.45
+UK,United Kingdom,US48,Mississippi,Peak,$32.60,$37.11
+UK,United Kingdom,US49,Florida-North,NonPeak,$29.28,$44.28
+UK,United Kingdom,US49,Florida-North,Peak,$34.55,$52.25
+UK,United Kingdom,US4964400,Florida-South,NonPeak,$30.90,$34.11
+UK,United Kingdom,US4964400,Florida-South,Peak,$36.46,$40.25
+UK,United Kingdom,US4965500,Florida Keys,NonPeak,$15.28,$31.63
+UK,United Kingdom,US4965500,Florida Keys,Peak,$18.03,$37.32
+UK,United Kingdom,US50,Minnesota,NonPeak,$16.05,$44.51
+UK,United Kingdom,US50,Minnesota,Peak,$18.94,$52.52
+UK,United Kingdom,US51,North Dakota,NonPeak,$16.80,$34.33
+UK,United Kingdom,US51,North Dakota,Peak,$19.82,$40.51
+UK,United Kingdom,US52,South Dakota,NonPeak,$17.57,$31.74
+UK,United Kingdom,US52,South Dakota,Peak,$20.73,$37.45
+UK,United Kingdom,US53,Iowa,NonPeak,$18.33,$44.62
+UK,United Kingdom,US53,Iowa,Peak,$21.63,$52.65
+UK,United Kingdom,US55,Nebraska,NonPeak,$24.38,$34.45
+UK,United Kingdom,US55,Nebraska,Peak,$28.77,$40.65
+UK,United Kingdom,US56,Missouri,NonPeak,$16.00,$31.91
+UK,United Kingdom,US56,Missouri,Peak,$18.88,$37.65
+UK,United Kingdom,US58,Kansas,NonPeak,$27.63,$44.74
+UK,United Kingdom,US58,Kansas,Peak,$32.60,$52.79
+UK,United Kingdom,US60,Arkansas,NonPeak,$29.28,$34.56
+UK,United Kingdom,US60,Arkansas,Peak,$34.55,$40.78
+UK,United Kingdom,US62,Oklahoma,NonPeak,$30.90,$32.09
+UK,United Kingdom,US62,Oklahoma,Peak,$36.46,$37.87
+UK,United Kingdom,US64,Louisiana,NonPeak,$15.28,$44.91
+UK,United Kingdom,US64,Louisiana,Peak,$18.03,$52.99
+UK,United Kingdom,US66,Texas-North,NonPeak,$16.05,$34.74
+UK,United Kingdom,US66,Texas-North,Peak,$18.94,$40.99
+UK,United Kingdom,US68,Texas-South,NonPeak,$16.80,$32.26
+UK,United Kingdom,US68,Texas-South,Peak,$19.82,$38.07
+UK,United Kingdom,US70,Montana,NonPeak,$17.57,$45.09
+UK,United Kingdom,US70,Montana,Peak,$20.73,$53.21
+UK,United Kingdom,US72,Wyoming,NonPeak,$18.33,$34.90
+UK,United Kingdom,US72,Wyoming,Peak,$21.63,$41.18
+UK,United Kingdom,US74,Colorado,NonPeak,$24.38,$32.44
+UK,United Kingdom,US74,Colorado,Peak,$28.77,$38.28
+UK,United Kingdom,US76,Utah,NonPeak,$16.00,$43.94
+UK,United Kingdom,US76,Utah,Peak,$18.88,$51.85
+UK,United Kingdom,US77,New Mexico,NonPeak,$27.63,$33.70
+UK,United Kingdom,US77,New Mexico,Peak,$32.60,$39.77
+UK,United Kingdom,US79,Arizona,NonPeak,$29.28,$31.29
+UK,United Kingdom,US79,Arizona,Peak,$34.55,$36.92
+UK,United Kingdom,US83,Idaho,NonPeak,$30.90,$44.05
+UK,United Kingdom,US83,Idaho,Peak,$36.46,$51.98
+UK,United Kingdom,US84,Washington,NonPeak,$15.28,$33.75
+UK,United Kingdom,US84,Washington,Peak,$18.03,$39.82
+UK,United Kingdom,US85,Oregon,NonPeak,$16.05,$31.40
+UK,United Kingdom,US85,Oregon,Peak,$18.94,$37.05
+UK,United Kingdom,US86,Nevada,NonPeak,$16.80,$44.17
+UK,United Kingdom,US86,Nevada,Peak,$19.82,$52.12
+UK,United Kingdom,US87,California-North,NonPeak,$17.57,$33.98
+UK,United Kingdom,US87,California-North,Peak,$20.73,$40.10
+UK,United Kingdom,US88,California-South,NonPeak,$18.33,$31.45
+UK,United Kingdom,US88,California-South,Peak,$21.63,$37.11
+US8030400,Alaska (Zone) IV,US11,Maine,NonPeak,$24.38,$44.28
+US8030400,Alaska (Zone) IV,US11,Maine,Peak,$28.77,$52.25
+US8030400,Alaska (Zone) IV,US12,New Hampshire,NonPeak,$16.00,$34.11
+US8030400,Alaska (Zone) IV,US12,New Hampshire,Peak,$18.88,$40.25
+US8030400,Alaska (Zone) IV,US13,Vermont,NonPeak,$27.63,$31.63
+US8030400,Alaska (Zone) IV,US13,Vermont,Peak,$32.60,$37.32
+US8030400,Alaska (Zone) IV,US14,Massachusetts,NonPeak,$29.28,$44.51
+US8030400,Alaska (Zone) IV,US14,Massachusetts,Peak,$34.55,$52.52
+US8030400,Alaska (Zone) IV,US15,Rhode Island,NonPeak,$30.90,$34.33
+US8030400,Alaska (Zone) IV,US15,Rhode Island,Peak,$36.46,$40.51
+US8030400,Alaska (Zone) IV,US16,Connecticut,NonPeak,$15.28,$31.74
+US8030400,Alaska (Zone) IV,US16,Connecticut,Peak,$18.03,$37.45
+US8030400,Alaska (Zone) IV,US17,New York,NonPeak,$16.05,$44.62
+US8030400,Alaska (Zone) IV,US17,New York,Peak,$18.94,$52.65
+US8030400,Alaska (Zone) IV,US19,New Jersey,NonPeak,$16.80,$34.45
+US8030400,Alaska (Zone) IV,US19,New Jersey,Peak,$19.82,$40.65
+US8030400,Alaska (Zone) IV,US20,Pennsylvania,NonPeak,$17.57,$31.91
+US8030400,Alaska (Zone) IV,US20,Pennsylvania,Peak,$20.73,$37.65
+US8030400,Alaska (Zone) IV,US22,Delaware,NonPeak,$18.33,$44.74
+US8030400,Alaska (Zone) IV,US22,Delaware,Peak,$21.63,$52.79
+US8030400,Alaska (Zone) IV,US23,Maryland,NonPeak,$24.38,$34.56
+US8030400,Alaska (Zone) IV,US23,Maryland,Peak,$28.77,$40.78
+US8030400,Alaska (Zone) IV,US24,District Of Columbia,NonPeak,$16.00,$32.09
+US8030400,Alaska (Zone) IV,US24,District Of Columbia,Peak,$18.88,$37.87
+US8030400,Alaska (Zone) IV,US25,Virginia,NonPeak,$27.63,$44.91
+US8030400,Alaska (Zone) IV,US25,Virginia,Peak,$32.60,$52.99
+US8030400,Alaska (Zone) IV,US27,West Virginia,NonPeak,$29.28,$34.74
+US8030400,Alaska (Zone) IV,US27,West Virginia,Peak,$34.55,$40.99
+US8030400,Alaska (Zone) IV,US28,Kentucky,NonPeak,$30.90,$32.26
+US8030400,Alaska (Zone) IV,US28,Kentucky,Peak,$36.46,$38.07
+US8030400,Alaska (Zone) IV,US30,Michigan,NonPeak,$15.28,$45.09
+US8030400,Alaska (Zone) IV,US30,Michigan,Peak,$18.03,$53.21
+US8030400,Alaska (Zone) IV,US32,Wisconsin,NonPeak,$16.05,$34.90
+US8030400,Alaska (Zone) IV,US32,Wisconsin,Peak,$18.94,$41.18
+US8030400,Alaska (Zone) IV,US34,Ohio,NonPeak,$16.80,$32.44
+US8030400,Alaska (Zone) IV,US34,Ohio,Peak,$19.82,$38.28
+US8030400,Alaska (Zone) IV,US36,Indiana,NonPeak,$17.57,$43.94
+US8030400,Alaska (Zone) IV,US36,Indiana,Peak,$20.73,$51.85
+US8030400,Alaska (Zone) IV,US38,Illinois,NonPeak,$18.33,$33.70
+US8030400,Alaska (Zone) IV,US38,Illinois,Peak,$21.63,$39.77
+US8030400,Alaska (Zone) IV,US40,North Carolina,NonPeak,$24.38,$31.29
+US8030400,Alaska (Zone) IV,US40,North Carolina,Peak,$28.77,$36.92
+US8030400,Alaska (Zone) IV,US42,Tennessee,NonPeak,$16.00,$44.05
+US8030400,Alaska (Zone) IV,US42,Tennessee,Peak,$18.88,$51.98
+US8030400,Alaska (Zone) IV,US44,South Carolina,NonPeak,$27.63,$33.75
+US8030400,Alaska (Zone) IV,US44,South Carolina,Peak,$32.60,$39.82
+US8030400,Alaska (Zone) IV,US45,Georgia,NonPeak,$29.28,$31.40
+US8030400,Alaska (Zone) IV,US45,Georgia,Peak,$34.55,$37.05
+US8030400,Alaska (Zone) IV,US47,Alabama,NonPeak,$30.90,$44.17
+US8030400,Alaska (Zone) IV,US47,Alabama,Peak,$36.46,$52.12
+US8030400,Alaska (Zone) IV,US48,Mississippi,NonPeak,$15.28,$33.98
+US8030400,Alaska (Zone) IV,US48,Mississippi,Peak,$18.03,$40.10
+US8030400,Alaska (Zone) IV,US49,Florida-North,NonPeak,$16.05,$31.45
+US8030400,Alaska (Zone) IV,US49,Florida-North,Peak,$18.94,$37.11
+US8030400,Alaska (Zone) IV,US4964400,Florida-South,NonPeak,$16.80,$44.28
+US8030400,Alaska (Zone) IV,US4964400,Florida-South,Peak,$19.82,$52.25
+US8030400,Alaska (Zone) IV,US4965500,Florida Keys,NonPeak,$17.57,$34.11
+US8030400,Alaska (Zone) IV,US4965500,Florida Keys,Peak,$20.73,$40.25
+US8030400,Alaska (Zone) IV,US50,Minnesota,NonPeak,$18.33,$31.63
+US8030400,Alaska (Zone) IV,US50,Minnesota,Peak,$21.63,$37.32
+US8030400,Alaska (Zone) IV,US51,North Dakota,NonPeak,$24.38,$44.51
+US8030400,Alaska (Zone) IV,US51,North Dakota,Peak,$28.77,$52.52
+US8030400,Alaska (Zone) IV,US52,South Dakota,NonPeak,$16.00,$34.33
+US8030400,Alaska (Zone) IV,US52,South Dakota,Peak,$18.88,$40.51
+US8030400,Alaska (Zone) IV,US53,Iowa,NonPeak,$27.63,$31.74
+US8030400,Alaska (Zone) IV,US53,Iowa,Peak,$32.60,$37.45
+US8030400,Alaska (Zone) IV,US55,Nebraska,NonPeak,$29.28,$44.62
+US8030400,Alaska (Zone) IV,US55,Nebraska,Peak,$34.55,$52.65
+US8030400,Alaska (Zone) IV,US56,Missouri,NonPeak,$30.90,$34.45
+US8030400,Alaska (Zone) IV,US56,Missouri,Peak,$36.46,$40.65
+US8030400,Alaska (Zone) IV,US58,Kansas,NonPeak,$15.28,$31.91
+US8030400,Alaska (Zone) IV,US58,Kansas,Peak,$18.03,$37.65
+US8030400,Alaska (Zone) IV,US60,Arkansas,NonPeak,$16.05,$44.74
+US8030400,Alaska (Zone) IV,US60,Arkansas,Peak,$18.94,$52.79
+US8030400,Alaska (Zone) IV,US62,Oklahoma,NonPeak,$16.80,$34.56
+US8030400,Alaska (Zone) IV,US62,Oklahoma,Peak,$19.82,$40.78
+US8030400,Alaska (Zone) IV,US64,Louisiana,NonPeak,$17.57,$32.09
+US8030400,Alaska (Zone) IV,US64,Louisiana,Peak,$20.73,$37.87
+US8030400,Alaska (Zone) IV,US66,Texas-North,NonPeak,$18.33,$44.91
+US8030400,Alaska (Zone) IV,US66,Texas-North,Peak,$21.63,$52.99
+US8030400,Alaska (Zone) IV,US68,Texas-South,NonPeak,$24.38,$34.74
+US8030400,Alaska (Zone) IV,US68,Texas-South,Peak,$28.77,$40.99
+US8030400,Alaska (Zone) IV,US70,Montana,NonPeak,$16.00,$32.26
+US8030400,Alaska (Zone) IV,US70,Montana,Peak,$18.88,$38.07
+US8030400,Alaska (Zone) IV,US72,Wyoming,NonPeak,$27.63,$45.09
+US8030400,Alaska (Zone) IV,US72,Wyoming,Peak,$32.60,$53.21
+US8030400,Alaska (Zone) IV,US74,Colorado,NonPeak,$29.28,$34.90
+US8030400,Alaska (Zone) IV,US74,Colorado,Peak,$34.55,$41.18
+US8030400,Alaska (Zone) IV,US76,Utah,NonPeak,$30.90,$32.44
+US8030400,Alaska (Zone) IV,US76,Utah,Peak,$36.46,$38.28
+US8030400,Alaska (Zone) IV,US77,New Mexico,NonPeak,$15.28,$43.94
+US8030400,Alaska (Zone) IV,US77,New Mexico,Peak,$18.03,$51.85
+US8030400,Alaska (Zone) IV,US79,Arizona,NonPeak,$16.05,$33.70
+US8030400,Alaska (Zone) IV,US79,Arizona,Peak,$18.94,$39.77
+US8030400,Alaska (Zone) IV,US83,Idaho,NonPeak,$16.80,$31.29
+US8030400,Alaska (Zone) IV,US83,Idaho,Peak,$19.82,$36.92
+US8030400,Alaska (Zone) IV,US84,Washington,NonPeak,$17.57,$44.05
+US8030400,Alaska (Zone) IV,US84,Washington,Peak,$20.73,$51.98
+US8030400,Alaska (Zone) IV,US85,Oregon,NonPeak,$18.33,$33.75
+US8030400,Alaska (Zone) IV,US85,Oregon,Peak,$21.63,$39.82
+US8030400,Alaska (Zone) IV,US86,Nevada,NonPeak,$24.38,$31.40
+US8030400,Alaska (Zone) IV,US86,Nevada,Peak,$28.77,$37.05
+US8030400,Alaska (Zone) IV,US87,California-North,NonPeak,$16.00,$44.17
+US8030400,Alaska (Zone) IV,US87,California-North,Peak,$18.88,$52.12
+US8030400,Alaska (Zone) IV,US88,California-South,NonPeak,$27.63,$33.98
+US8030400,Alaska (Zone) IV,US88,California-South,Peak,$32.60,$40.10
+US8050500,Alaska (Zone) III,US11,Maine,NonPeak,$29.28,$31.45
+US8050500,Alaska (Zone) III,US11,Maine,Peak,$34.55,$37.11
+US8050500,Alaska (Zone) III,US12,New Hampshire,NonPeak,$30.90,$44.28
+US8050500,Alaska (Zone) III,US12,New Hampshire,Peak,$36.46,$52.25
+US8050500,Alaska (Zone) III,US13,Vermont,NonPeak,$15.28,$34.11
+US8050500,Alaska (Zone) III,US13,Vermont,Peak,$18.03,$40.25
+US8050500,Alaska (Zone) III,US14,Massachusetts,NonPeak,$16.05,$31.63
+US8050500,Alaska (Zone) III,US14,Massachusetts,Peak,$18.94,$37.32
+US8050500,Alaska (Zone) III,US15,Rhode Island,NonPeak,$16.80,$44.51
+US8050500,Alaska (Zone) III,US15,Rhode Island,Peak,$19.82,$52.52
+US8050500,Alaska (Zone) III,US16,Connecticut,NonPeak,$17.57,$34.33
+US8050500,Alaska (Zone) III,US16,Connecticut,Peak,$20.73,$40.51
+US8050500,Alaska (Zone) III,US17,New York,NonPeak,$18.33,$31.74
+US8050500,Alaska (Zone) III,US17,New York,Peak,$21.63,$37.45
+US8050500,Alaska (Zone) III,US19,New Jersey,NonPeak,$24.38,$44.62
+US8050500,Alaska (Zone) III,US19,New Jersey,Peak,$28.77,$52.65
+US8050500,Alaska (Zone) III,US20,Pennsylvania,NonPeak,$16.00,$34.45
+US8050500,Alaska (Zone) III,US20,Pennsylvania,Peak,$18.88,$40.65
+US8050500,Alaska (Zone) III,US22,Delaware,NonPeak,$27.63,$31.91
+US8050500,Alaska (Zone) III,US22,Delaware,Peak,$32.60,$37.65
+US8050500,Alaska (Zone) III,US23,Maryland,NonPeak,$29.28,$44.74
+US8050500,Alaska (Zone) III,US23,Maryland,Peak,$34.55,$52.79
+US8050500,Alaska (Zone) III,US24,District Of Columbia,NonPeak,$30.90,$34.56
+US8050500,Alaska (Zone) III,US24,District Of Columbia,Peak,$36.46,$40.78
+US8050500,Alaska (Zone) III,US25,Virginia,NonPeak,$15.28,$32.09
+US8050500,Alaska (Zone) III,US25,Virginia,Peak,$18.03,$37.87
+US8050500,Alaska (Zone) III,US27,West Virginia,NonPeak,$16.05,$44.91
+US8050500,Alaska (Zone) III,US27,West Virginia,Peak,$18.94,$52.99
+US8050500,Alaska (Zone) III,US28,Kentucky,NonPeak,$16.80,$34.74
+US8050500,Alaska (Zone) III,US28,Kentucky,Peak,$19.82,$40.99
+US8050500,Alaska (Zone) III,US30,Michigan,NonPeak,$17.57,$32.26
+US8050500,Alaska (Zone) III,US30,Michigan,Peak,$20.73,$38.07
+US8050500,Alaska (Zone) III,US32,Wisconsin,NonPeak,$18.33,$45.09
+US8050500,Alaska (Zone) III,US32,Wisconsin,Peak,$21.63,$53.21
+US8050500,Alaska (Zone) III,US34,Ohio,NonPeak,$24.38,$34.90
+US8050500,Alaska (Zone) III,US34,Ohio,Peak,$28.77,$41.18
+US8050500,Alaska (Zone) III,US36,Indiana,NonPeak,$16.00,$32.44
+US8050500,Alaska (Zone) III,US36,Indiana,Peak,$18.88,$38.28
+US8050500,Alaska (Zone) III,US38,Illinois,NonPeak,$27.63,$43.94
+US8050500,Alaska (Zone) III,US38,Illinois,Peak,$32.60,$51.85
+US8050500,Alaska (Zone) III,US40,North Carolina,NonPeak,$29.28,$33.70
+US8050500,Alaska (Zone) III,US40,North Carolina,Peak,$34.55,$39.77
+US8050500,Alaska (Zone) III,US42,Tennessee,NonPeak,$30.90,$31.29
+US8050500,Alaska (Zone) III,US42,Tennessee,Peak,$36.46,$36.92
+US8050500,Alaska (Zone) III,US44,South Carolina,NonPeak,$15.28,$44.05
+US8050500,Alaska (Zone) III,US44,South Carolina,Peak,$18.03,$51.98
+US8050500,Alaska (Zone) III,US45,Georgia,NonPeak,$16.05,$33.75
+US8050500,Alaska (Zone) III,US45,Georgia,Peak,$18.94,$39.82
+US8050500,Alaska (Zone) III,US47,Alabama,NonPeak,$16.80,$31.40
+US8050500,Alaska (Zone) III,US47,Alabama,Peak,$19.82,$37.05
+US8050500,Alaska (Zone) III,US48,Mississippi,NonPeak,$17.57,$44.17
+US8050500,Alaska (Zone) III,US48,Mississippi,Peak,$20.73,$52.12
+US8050500,Alaska (Zone) III,US49,Florida-North,NonPeak,$18.33,$33.98
+US8050500,Alaska (Zone) III,US49,Florida-North,Peak,$21.63,$40.10
+US8050500,Alaska (Zone) III,US4964400,Florida-South,NonPeak,$24.38,$31.45
+US8050500,Alaska (Zone) III,US4964400,Florida-South,Peak,$28.77,$37.11
+US8050500,Alaska (Zone) III,US4965500,Florida Keys,NonPeak,$16.00,$44.28
+US8050500,Alaska (Zone) III,US4965500,Florida Keys,Peak,$18.88,$52.25
+US8050500,Alaska (Zone) III,US50,Minnesota,NonPeak,$27.63,$34.11
+US8050500,Alaska (Zone) III,US50,Minnesota,Peak,$32.60,$40.25
+US8050500,Alaska (Zone) III,US51,North Dakota,NonPeak,$29.28,$31.63
+US8050500,Alaska (Zone) III,US51,North Dakota,Peak,$34.55,$37.32
+US8050500,Alaska (Zone) III,US52,South Dakota,NonPeak,$30.90,$44.51
+US8050500,Alaska (Zone) III,US52,South Dakota,Peak,$36.46,$52.52
+US8050500,Alaska (Zone) III,US53,Iowa,NonPeak,$15.28,$34.33
+US8050500,Alaska (Zone) III,US53,Iowa,Peak,$18.03,$40.51
+US8050500,Alaska (Zone) III,US55,Nebraska,NonPeak,$16.05,$31.74
+US8050500,Alaska (Zone) III,US55,Nebraska,Peak,$18.94,$37.45
+US8050500,Alaska (Zone) III,US56,Missouri,NonPeak,$16.80,$44.62
+US8050500,Alaska (Zone) III,US56,Missouri,Peak,$19.82,$52.65
+US8050500,Alaska (Zone) III,US58,Kansas,NonPeak,$17.57,$34.45
+US8050500,Alaska (Zone) III,US58,Kansas,Peak,$20.73,$40.65
+US8050500,Alaska (Zone) III,US60,Arkansas,NonPeak,$18.33,$31.91
+US8050500,Alaska (Zone) III,US60,Arkansas,Peak,$21.63,$37.65
+US8050500,Alaska (Zone) III,US62,Oklahoma,NonPeak,$24.38,$44.74
+US8050500,Alaska (Zone) III,US62,Oklahoma,Peak,$28.77,$52.79
+US8050500,Alaska (Zone) III,US64,Louisiana,NonPeak,$16.00,$34.56
+US8050500,Alaska (Zone) III,US64,Louisiana,Peak,$18.88,$40.78
+US8050500,Alaska (Zone) III,US66,Texas-North,NonPeak,$27.63,$32.09
+US8050500,Alaska (Zone) III,US66,Texas-North,Peak,$32.60,$37.87
+US8050500,Alaska (Zone) III,US68,Texas-South,NonPeak,$29.28,$44.91
+US8050500,Alaska (Zone) III,US68,Texas-South,Peak,$34.55,$52.99
+US8050500,Alaska (Zone) III,US70,Montana,NonPeak,$30.90,$34.74
+US8050500,Alaska (Zone) III,US70,Montana,Peak,$36.46,$40.99
+US8050500,Alaska (Zone) III,US72,Wyoming,NonPeak,$15.28,$32.26
+US8050500,Alaska (Zone) III,US72,Wyoming,Peak,$18.03,$38.07
+US8050500,Alaska (Zone) III,US74,Colorado,NonPeak,$16.05,$45.09
+US8050500,Alaska (Zone) III,US74,Colorado,Peak,$18.94,$53.21
+US8050500,Alaska (Zone) III,US76,Utah,NonPeak,$16.80,$34.90
+US8050500,Alaska (Zone) III,US76,Utah,Peak,$19.82,$41.18
+US8050500,Alaska (Zone) III,US77,New Mexico,NonPeak,$17.57,$32.44
+US8050500,Alaska (Zone) III,US77,New Mexico,Peak,$20.73,$38.28
+US8050500,Alaska (Zone) III,US79,Arizona,NonPeak,$18.33,$43.94
+US8050500,Alaska (Zone) III,US79,Arizona,Peak,$21.63,$51.85
+US8050500,Alaska (Zone) III,US83,Idaho,NonPeak,$24.38,$33.70
+US8050500,Alaska (Zone) III,US83,Idaho,Peak,$28.77,$39.77
+US8050500,Alaska (Zone) III,US84,Washington,NonPeak,$16.00,$31.29
+US8050500,Alaska (Zone) III,US84,Washington,Peak,$18.88,$36.92
+US8050500,Alaska (Zone) III,US85,Oregon,NonPeak,$27.63,$44.05
+US8050500,Alaska (Zone) III,US85,Oregon,Peak,$32.60,$51.98
+US8050500,Alaska (Zone) III,US86,Nevada,NonPeak,$29.28,$33.75
+US8050500,Alaska (Zone) III,US86,Nevada,Peak,$34.55,$39.82
+US8050500,Alaska (Zone) III,US87,California-North,NonPeak,$30.90,$31.40
+US8050500,Alaska (Zone) III,US87,California-North,Peak,$36.46,$37.05
+US8050500,Alaska (Zone) III,US88,California-South,NonPeak,$15.28,$44.17
+US8050500,Alaska (Zone) III,US88,California-South,Peak,$18.03,$52.12
+US8101000,Alaska (Zone) I,US25,Virginia,NonPeak,$15.28,$43.94
+US8101000,Alaska (Zone) I,US25,Virginia,Peak,$18.03,$51.85
+US8101000,Alaska (Zone) I,US27,West Virginia,NonPeak,$16.05,$33.70
+US8101000,Alaska (Zone) I,US27,West Virginia,Peak,$18.94,$39.77
+US8101000,Alaska (Zone) I,US51,North Dakota,NonPeak,$16.80,$31.29
+US8101000,Alaska (Zone) I,US51,North Dakota,Peak,$19.82,$36.92
+US8101000,Alaska (Zone) I,US56,Missouri,NonPeak,$17.57,$44.05
+US8101000,Alaska (Zone) I,US56,Missouri,Peak,$20.73,$51.98
+US8101000,Alaska (Zone) I,US70,Montana,NonPeak,$18.33,$33.75
+US8101000,Alaska (Zone) I,US70,Montana,Peak,$21.63,$39.82
+US8101000,Alaska (Zone) I,US85,Oregon,NonPeak,$24.38,$31.40
+US8101000,Alaska (Zone) I,US85,Oregon,Peak,$28.77,$37.05
+US8101000,Alaska (Zone) I,US20,Pennsylvania,NonPeak,$16.00,$44.17
+US8101000,Alaska (Zone) I,US20,Pennsylvania,Peak,$18.88,$52.12
+US8101000,Alaska (Zone) I,US4965500,Florida Keys,NonPeak,$27.63,$33.98
+US8101000,Alaska (Zone) I,US4965500,Florida Keys,Peak,$32.60,$40.10
+US8101000,Alaska (Zone) I,US53,Iowa,NonPeak,$29.28,$31.45
+US8101000,Alaska (Zone) I,US53,Iowa,Peak,$34.55,$37.11
+US8101000,Alaska (Zone) I,US72,Wyoming,NonPeak,$30.90,$44.28
+US8101000,Alaska (Zone) I,US72,Wyoming,Peak,$36.46,$52.25
+US8101000,Alaska (Zone) I,US11,Maine,NonPeak,$15.28,$34.11
+US8101000,Alaska (Zone) I,US11,Maine,Peak,$18.03,$40.25
+US8101000,Alaska (Zone) I,US12,New Hampshire,NonPeak,$16.05,$31.63
+US8101000,Alaska (Zone) I,US12,New Hampshire,Peak,$18.94,$37.32
+US8101000,Alaska (Zone) I,US13,Vermont,NonPeak,$16.80,$44.51
+US8101000,Alaska (Zone) I,US13,Vermont,Peak,$19.82,$52.52
+US8101000,Alaska (Zone) I,US14,Massachusetts,NonPeak,$17.57,$34.33
+US8101000,Alaska (Zone) I,US14,Massachusetts,Peak,$20.73,$40.51
+US8101000,Alaska (Zone) I,US15,Rhode Island,NonPeak,$18.33,$31.74
+US8101000,Alaska (Zone) I,US15,Rhode Island,Peak,$21.63,$37.45
+US8101000,Alaska (Zone) I,US16,Connecticut,NonPeak,$24.38,$44.62
+US8101000,Alaska (Zone) I,US16,Connecticut,Peak,$28.77,$52.65
+US8101000,Alaska (Zone) I,US17,New York,NonPeak,$16.00,$34.45
+US8101000,Alaska (Zone) I,US17,New York,Peak,$18.88,$40.65
+US8101000,Alaska (Zone) I,US19,New Jersey,NonPeak,$27.63,$31.91
+US8101000,Alaska (Zone) I,US19,New Jersey,Peak,$32.60,$37.65
+US8101000,Alaska (Zone) I,US22,Delaware,NonPeak,$29.28,$44.74
+US8101000,Alaska (Zone) I,US22,Delaware,Peak,$34.55,$52.79
+US8101000,Alaska (Zone) I,US23,Maryland,NonPeak,$30.90,$34.56
+US8101000,Alaska (Zone) I,US23,Maryland,Peak,$36.46,$40.78
+US8101000,Alaska (Zone) I,US24,District Of Columbia,NonPeak,$15.28,$32.09
+US8101000,Alaska (Zone) I,US24,District Of Columbia,Peak,$18.03,$37.87
+US8101000,Alaska (Zone) I,US28,Kentucky,NonPeak,$16.05,$44.91
+US8101000,Alaska (Zone) I,US28,Kentucky,Peak,$18.94,$52.99
+US8101000,Alaska (Zone) I,US30,Michigan,NonPeak,$16.80,$34.74
+US8101000,Alaska (Zone) I,US30,Michigan,Peak,$19.82,$40.99
+US8101000,Alaska (Zone) I,US32,Wisconsin,NonPeak,$17.57,$32.26
+US8101000,Alaska (Zone) I,US32,Wisconsin,Peak,$20.73,$38.07
+US8101000,Alaska (Zone) I,US34,Ohio,NonPeak,$18.33,$45.09
+US8101000,Alaska (Zone) I,US34,Ohio,Peak,$21.63,$53.21
+US8101000,Alaska (Zone) I,US36,Indiana,NonPeak,$24.38,$34.90
+US8101000,Alaska (Zone) I,US36,Indiana,Peak,$28.77,$41.18
+US8101000,Alaska (Zone) I,US38,Illinois,NonPeak,$16.00,$32.44
+US8101000,Alaska (Zone) I,US38,Illinois,Peak,$18.88,$38.28
+US8101000,Alaska (Zone) I,US40,North Carolina,NonPeak,$27.63,$43.94
+US8101000,Alaska (Zone) I,US40,North Carolina,Peak,$32.60,$51.85
+US8101000,Alaska (Zone) I,US42,Tennessee,NonPeak,$29.28,$33.70
+US8101000,Alaska (Zone) I,US42,Tennessee,Peak,$34.55,$39.77
+US8101000,Alaska (Zone) I,US44,South Carolina,NonPeak,$30.90,$31.29
+US8101000,Alaska (Zone) I,US44,South Carolina,Peak,$36.46,$36.92
+US8101000,Alaska (Zone) I,US45,Georgia,NonPeak,$15.28,$44.05
+US8101000,Alaska (Zone) I,US45,Georgia,Peak,$18.03,$51.98
+US8101000,Alaska (Zone) I,US47,Alabama,NonPeak,$16.05,$33.75
+US8101000,Alaska (Zone) I,US47,Alabama,Peak,$18.94,$39.82
+US8101000,Alaska (Zone) I,US48,Mississippi,NonPeak,$16.80,$31.40
+US8101000,Alaska (Zone) I,US48,Mississippi,Peak,$19.82,$37.05
+US8101000,Alaska (Zone) I,US49,Florida-North,NonPeak,$17.57,$44.17
+US8101000,Alaska (Zone) I,US49,Florida-North,Peak,$20.73,$52.12
+US8101000,Alaska (Zone) I,US4964400,Florida-South,NonPeak,$18.33,$33.98
+US8101000,Alaska (Zone) I,US4964400,Florida-South,Peak,$21.63,$40.10
+US8101000,Alaska (Zone) I,US50,Minnesota,NonPeak,$24.38,$31.45
+US8101000,Alaska (Zone) I,US50,Minnesota,Peak,$28.77,$37.11
+US8101000,Alaska (Zone) I,US52,South Dakota,NonPeak,$16.00,$44.28
+US8101000,Alaska (Zone) I,US52,South Dakota,Peak,$18.88,$52.25
+US8101000,Alaska (Zone) I,US55,Nebraska,NonPeak,$27.63,$34.11
+US8101000,Alaska (Zone) I,US55,Nebraska,Peak,$32.60,$40.25
+US8101000,Alaska (Zone) I,US58,Kansas,NonPeak,$29.28,$31.63
+US8101000,Alaska (Zone) I,US58,Kansas,Peak,$34.55,$37.32
+US8101000,Alaska (Zone) I,US60,Arkansas,NonPeak,$30.90,$44.51
+US8101000,Alaska (Zone) I,US60,Arkansas,Peak,$36.46,$52.52
+US8101000,Alaska (Zone) I,US62,Oklahoma,NonPeak,$15.28,$34.33
+US8101000,Alaska (Zone) I,US62,Oklahoma,Peak,$18.03,$40.51
+US8101000,Alaska (Zone) I,US64,Louisiana,NonPeak,$16.05,$31.74
+US8101000,Alaska (Zone) I,US64,Louisiana,Peak,$18.94,$37.45
+US8101000,Alaska (Zone) I,US66,Texas-North,NonPeak,$16.80,$44.62
+US8101000,Alaska (Zone) I,US66,Texas-North,Peak,$19.82,$52.65
+US8101000,Alaska (Zone) I,US68,Texas-South,NonPeak,$17.57,$34.45
+US8101000,Alaska (Zone) I,US68,Texas-South,Peak,$20.73,$40.65
+US8101000,Alaska (Zone) I,US74,Colorado,NonPeak,$18.33,$31.91
+US8101000,Alaska (Zone) I,US74,Colorado,Peak,$21.63,$37.65
+US8101000,Alaska (Zone) I,US76,Utah,NonPeak,$24.38,$44.74
+US8101000,Alaska (Zone) I,US76,Utah,Peak,$28.77,$52.79
+US8101000,Alaska (Zone) I,US77,New Mexico,NonPeak,$16.00,$34.56
+US8101000,Alaska (Zone) I,US77,New Mexico,Peak,$18.88,$40.78
+US8101000,Alaska (Zone) I,US79,Arizona,NonPeak,$27.63,$32.09
+US8101000,Alaska (Zone) I,US79,Arizona,Peak,$32.60,$37.87
+US8101000,Alaska (Zone) I,US83,Idaho,NonPeak,$29.28,$44.91
+US8101000,Alaska (Zone) I,US83,Idaho,Peak,$34.55,$52.99
+US8101000,Alaska (Zone) I,US84,Washington,NonPeak,$30.90,$34.74
+US8101000,Alaska (Zone) I,US84,Washington,Peak,$36.46,$40.99
+US8101000,Alaska (Zone) I,US86,Nevada,NonPeak,$15.28,$32.26
+US8101000,Alaska (Zone) I,US86,Nevada,Peak,$18.03,$38.07
+US8101000,Alaska (Zone) I,US87,California-North,NonPeak,$16.05,$45.09
+US8101000,Alaska (Zone) I,US87,California-North,Peak,$18.94,$53.21
+US8101000,Alaska (Zone) I,US88,California-South,NonPeak,$16.80,$34.90
+US8101000,Alaska (Zone) I,US88,California-South,Peak,$19.82,$41.18
+US8190100,Alaska (Zone) II,US85,Oregon,NonPeak,$17.57,$32.44
+US8190100,Alaska (Zone) II,US85,Oregon,Peak,$20.73,$38.28
+US8190100,Alaska (Zone) II,US4965500,Florida Keys,NonPeak,$18.33,$43.94
+US8190100,Alaska (Zone) II,US4965500,Florida Keys,Peak,$21.63,$51.85
+US8190100,Alaska (Zone) II,US11,Maine,NonPeak,$24.38,$33.70
+US8190100,Alaska (Zone) II,US11,Maine,Peak,$28.77,$39.77
+US8190100,Alaska (Zone) II,US12,New Hampshire,NonPeak,$16.00,$31.29
+US8190100,Alaska (Zone) II,US12,New Hampshire,Peak,$18.88,$36.92
+US8190100,Alaska (Zone) II,US13,Vermont,NonPeak,$27.63,$44.05
+US8190100,Alaska (Zone) II,US13,Vermont,Peak,$32.60,$51.98
+US8190100,Alaska (Zone) II,US14,Massachusetts,NonPeak,$29.28,$33.75
+US8190100,Alaska (Zone) II,US14,Massachusetts,Peak,$34.55,$39.82
+US8190100,Alaska (Zone) II,US15,Rhode Island,NonPeak,$30.90,$31.40
+US8190100,Alaska (Zone) II,US15,Rhode Island,Peak,$36.46,$37.05
+US8190100,Alaska (Zone) II,US16,Connecticut,NonPeak,$15.28,$44.17
+US8190100,Alaska (Zone) II,US16,Connecticut,Peak,$18.03,$52.12
+US8190100,Alaska (Zone) II,US17,New York,NonPeak,$16.05,$33.98
+US8190100,Alaska (Zone) II,US17,New York,Peak,$18.94,$40.10
+US8190100,Alaska (Zone) II,US19,New Jersey,NonPeak,$16.80,$31.45
+US8190100,Alaska (Zone) II,US19,New Jersey,Peak,$19.82,$37.11
+US8190100,Alaska (Zone) II,US20,Pennsylvania,NonPeak,$17.57,$44.28
+US8190100,Alaska (Zone) II,US20,Pennsylvania,Peak,$20.73,$52.25
+US8190100,Alaska (Zone) II,US22,Delaware,NonPeak,$18.33,$34.11
+US8190100,Alaska (Zone) II,US22,Delaware,Peak,$21.63,$40.25
+US8190100,Alaska (Zone) II,US23,Maryland,NonPeak,$24.38,$31.63
+US8190100,Alaska (Zone) II,US23,Maryland,Peak,$28.77,$37.32
+US8190100,Alaska (Zone) II,US24,District Of Columbia,NonPeak,$16.00,$44.51
+US8190100,Alaska (Zone) II,US24,District Of Columbia,Peak,$18.88,$52.52
+US8190100,Alaska (Zone) II,US25,Virginia,NonPeak,$27.63,$34.33
+US8190100,Alaska (Zone) II,US25,Virginia,Peak,$32.60,$40.51
+US8190100,Alaska (Zone) II,US27,West Virginia,NonPeak,$29.28,$31.74
+US8190100,Alaska (Zone) II,US27,West Virginia,Peak,$34.55,$37.45
+US8190100,Alaska (Zone) II,US28,Kentucky,NonPeak,$30.90,$44.62
+US8190100,Alaska (Zone) II,US28,Kentucky,Peak,$36.46,$52.65
+US8190100,Alaska (Zone) II,US30,Michigan,NonPeak,$15.28,$34.45
+US8190100,Alaska (Zone) II,US30,Michigan,Peak,$18.03,$40.65
+US8190100,Alaska (Zone) II,US32,Wisconsin,NonPeak,$16.05,$31.91
+US8190100,Alaska (Zone) II,US32,Wisconsin,Peak,$18.94,$37.65
+US8190100,Alaska (Zone) II,US34,Ohio,NonPeak,$16.80,$44.74
+US8190100,Alaska (Zone) II,US34,Ohio,Peak,$19.82,$52.79
+US8190100,Alaska (Zone) II,US36,Indiana,NonPeak,$17.57,$34.56
+US8190100,Alaska (Zone) II,US36,Indiana,Peak,$20.73,$40.78
+US8190100,Alaska (Zone) II,US38,Illinois,NonPeak,$18.33,$32.09
+US8190100,Alaska (Zone) II,US38,Illinois,Peak,$21.63,$37.87
+US8190100,Alaska (Zone) II,US40,North Carolina,NonPeak,$24.38,$44.91
+US8190100,Alaska (Zone) II,US40,North Carolina,Peak,$28.77,$52.99
+US8190100,Alaska (Zone) II,US42,Tennessee,NonPeak,$16.00,$34.74
+US8190100,Alaska (Zone) II,US42,Tennessee,Peak,$18.88,$40.99
+US8190100,Alaska (Zone) II,US44,South Carolina,NonPeak,$27.63,$32.26
+US8190100,Alaska (Zone) II,US44,South Carolina,Peak,$32.60,$38.07
+US8190100,Alaska (Zone) II,US45,Georgia,NonPeak,$29.28,$45.09
+US8190100,Alaska (Zone) II,US45,Georgia,Peak,$34.55,$53.21
+US8190100,Alaska (Zone) II,US47,Alabama,NonPeak,$30.90,$34.90
+US8190100,Alaska (Zone) II,US47,Alabama,Peak,$36.46,$41.18
+US8190100,Alaska (Zone) II,US48,Mississippi,NonPeak,$15.28,$32.44
+US8190100,Alaska (Zone) II,US48,Mississippi,Peak,$18.03,$38.28
+US8190100,Alaska (Zone) II,US49,Florida-North,NonPeak,$16.05,$43.94
+US8190100,Alaska (Zone) II,US49,Florida-North,Peak,$18.94,$51.85
+US8190100,Alaska (Zone) II,US4964400,Florida-South,NonPeak,$16.80,$33.70
+US8190100,Alaska (Zone) II,US4964400,Florida-South,Peak,$19.82,$39.77
+US8190100,Alaska (Zone) II,US50,Minnesota,NonPeak,$17.57,$31.29
+US8190100,Alaska (Zone) II,US50,Minnesota,Peak,$20.73,$36.92
+US8190100,Alaska (Zone) II,US51,North Dakota,NonPeak,$18.33,$44.05
+US8190100,Alaska (Zone) II,US51,North Dakota,Peak,$21.63,$51.98
+US8190100,Alaska (Zone) II,US52,South Dakota,NonPeak,$24.38,$33.75
+US8190100,Alaska (Zone) II,US52,South Dakota,Peak,$28.77,$39.82
+US8190100,Alaska (Zone) II,US53,Iowa,NonPeak,$16.00,$31.40
+US8190100,Alaska (Zone) II,US53,Iowa,Peak,$18.88,$37.05
+US8190100,Alaska (Zone) II,US55,Nebraska,NonPeak,$27.63,$44.17
+US8190100,Alaska (Zone) II,US55,Nebraska,Peak,$32.60,$52.12
+US8190100,Alaska (Zone) II,US56,Missouri,NonPeak,$29.28,$33.98
+US8190100,Alaska (Zone) II,US56,Missouri,Peak,$34.55,$40.10
+US8190100,Alaska (Zone) II,US58,Kansas,NonPeak,$30.90,$31.45
+US8190100,Alaska (Zone) II,US58,Kansas,Peak,$36.46,$37.11
+US8190100,Alaska (Zone) II,US60,Arkansas,NonPeak,$15.28,$44.28
+US8190100,Alaska (Zone) II,US60,Arkansas,Peak,$18.03,$52.25
+US8190100,Alaska (Zone) II,US62,Oklahoma,NonPeak,$16.05,$34.11
+US8190100,Alaska (Zone) II,US62,Oklahoma,Peak,$18.94,$40.25
+US8190100,Alaska (Zone) II,US64,Louisiana,NonPeak,$16.80,$31.63
+US8190100,Alaska (Zone) II,US64,Louisiana,Peak,$19.82,$37.32
+US8190100,Alaska (Zone) II,US66,Texas-North,NonPeak,$17.57,$44.51
+US8190100,Alaska (Zone) II,US66,Texas-North,Peak,$20.73,$52.52
+US8190100,Alaska (Zone) II,US68,Texas-South,NonPeak,$18.33,$34.33
+US8190100,Alaska (Zone) II,US68,Texas-South,Peak,$21.63,$40.51
+US8190100,Alaska (Zone) II,US70,Montana,NonPeak,$24.38,$31.74
+US8190100,Alaska (Zone) II,US70,Montana,Peak,$28.77,$37.45
+US8190100,Alaska (Zone) II,US72,Wyoming,NonPeak,$16.00,$44.62
+US8190100,Alaska (Zone) II,US72,Wyoming,Peak,$18.88,$52.65
+US8190100,Alaska (Zone) II,US74,Colorado,NonPeak,$27.63,$34.45
+US8190100,Alaska (Zone) II,US74,Colorado,Peak,$32.60,$40.65
+US8190100,Alaska (Zone) II,US76,Utah,NonPeak,$29.28,$31.91
+US8190100,Alaska (Zone) II,US76,Utah,Peak,$34.55,$37.65
+US8190100,Alaska (Zone) II,US77,New Mexico,NonPeak,$30.90,$44.74
+US8190100,Alaska (Zone) II,US77,New Mexico,Peak,$36.46,$52.79
+US8190100,Alaska (Zone) II,US79,Arizona,NonPeak,$15.28,$34.56
+US8190100,Alaska (Zone) II,US79,Arizona,Peak,$18.03,$40.78
+US8190100,Alaska (Zone) II,US83,Idaho,NonPeak,$16.05,$32.09
+US8190100,Alaska (Zone) II,US83,Idaho,Peak,$18.94,$37.87
+US8190100,Alaska (Zone) II,US84,Washington,NonPeak,$16.80,$44.91
+US8190100,Alaska (Zone) II,US84,Washington,Peak,$19.82,$52.99
+US8190100,Alaska (Zone) II,US86,Nevada,NonPeak,$17.57,$34.74
+US8190100,Alaska (Zone) II,US86,Nevada,Peak,$20.73,$40.99
+US8190100,Alaska (Zone) II,US87,California-North,NonPeak,$18.33,$32.26
+US8190100,Alaska (Zone) II,US87,California-North,Peak,$21.63,$38.07
+US8190100,Alaska (Zone) II,US88,California-South,NonPeak,$24.38,$45.09
+US8190100,Alaska (Zone) II,US88,California-South,Peak,$28.77,$53.21
+US89,Hawaii,US11,Maine,NonPeak,$16.00,$34.90
+US89,Hawaii,US11,Maine,Peak,$18.88,$41.18
+US89,Hawaii,US12,New Hampshire,NonPeak,$27.63,$32.44
+US89,Hawaii,US12,New Hampshire,Peak,$32.60,$38.28
+US89,Hawaii,US13,Vermont,NonPeak,$29.28,$43.94
+US89,Hawaii,US13,Vermont,Peak,$34.55,$51.85
+US89,Hawaii,US14,Massachusetts,NonPeak,$30.90,$33.70
+US89,Hawaii,US14,Massachusetts,Peak,$36.46,$39.77
+US89,Hawaii,US15,Rhode Island,NonPeak,$15.28,$31.29
+US89,Hawaii,US15,Rhode Island,Peak,$18.03,$36.92
+US89,Hawaii,US16,Connecticut,NonPeak,$16.05,$44.05
+US89,Hawaii,US16,Connecticut,Peak,$18.94,$51.98
+US89,Hawaii,US17,New York,NonPeak,$16.80,$33.75
+US89,Hawaii,US17,New York,Peak,$19.82,$39.82
+US89,Hawaii,US19,New Jersey,NonPeak,$17.57,$31.40
+US89,Hawaii,US19,New Jersey,Peak,$20.73,$37.05
+US89,Hawaii,US20,Pennsylvania,NonPeak,$18.33,$44.17
+US89,Hawaii,US20,Pennsylvania,Peak,$21.63,$52.12
+US89,Hawaii,US22,Delaware,NonPeak,$24.38,$33.98
+US89,Hawaii,US22,Delaware,Peak,$28.77,$40.10
+US89,Hawaii,US23,Maryland,NonPeak,$16.00,$31.45
+US89,Hawaii,US23,Maryland,Peak,$18.88,$37.11
+US89,Hawaii,US24,District Of Columbia,NonPeak,$27.63,$44.28
+US89,Hawaii,US24,District Of Columbia,Peak,$32.60,$52.25
+US89,Hawaii,US25,Virginia,NonPeak,$29.28,$34.11
+US89,Hawaii,US25,Virginia,Peak,$34.55,$40.25
+US89,Hawaii,US27,West Virginia,NonPeak,$30.90,$31.63
+US89,Hawaii,US27,West Virginia,Peak,$36.46,$37.32
+US89,Hawaii,US28,Kentucky,NonPeak,$15.28,$44.51
+US89,Hawaii,US28,Kentucky,Peak,$18.03,$52.52
+US89,Hawaii,US30,Michigan,NonPeak,$16.05,$34.33
+US89,Hawaii,US30,Michigan,Peak,$18.94,$40.51
+US89,Hawaii,US32,Wisconsin,NonPeak,$16.80,$31.74
+US89,Hawaii,US32,Wisconsin,Peak,$19.82,$37.45
+US89,Hawaii,US34,Ohio,NonPeak,$17.57,$44.62
+US89,Hawaii,US34,Ohio,Peak,$20.73,$52.65
+US89,Hawaii,US36,Indiana,NonPeak,$18.33,$34.45
+US89,Hawaii,US36,Indiana,Peak,$21.63,$40.65
+US89,Hawaii,US38,Illinois,NonPeak,$24.38,$31.91
+US89,Hawaii,US38,Illinois,Peak,$28.77,$37.65
+US89,Hawaii,US40,North Carolina,NonPeak,$16.00,$44.74
+US89,Hawaii,US40,North Carolina,Peak,$18.88,$52.79
+US89,Hawaii,US42,Tennessee,NonPeak,$27.63,$34.56
+US89,Hawaii,US42,Tennessee,Peak,$32.60,$40.78
+US89,Hawaii,US44,South Carolina,NonPeak,$29.28,$32.09
+US89,Hawaii,US44,South Carolina,Peak,$34.55,$37.87
+US89,Hawaii,US45,Georgia,NonPeak,$30.90,$44.91
+US89,Hawaii,US45,Georgia,Peak,$36.46,$52.99
+US89,Hawaii,US47,Alabama,NonPeak,$15.28,$34.74
+US89,Hawaii,US47,Alabama,Peak,$18.03,$40.99
+US89,Hawaii,US48,Mississippi,NonPeak,$16.05,$32.26
+US89,Hawaii,US48,Mississippi,Peak,$18.94,$38.07
+US89,Hawaii,US49,Florida-North,NonPeak,$16.80,$45.09
+US89,Hawaii,US49,Florida-North,Peak,$19.82,$53.21
+US89,Hawaii,US4964400,Florida-South,NonPeak,$17.57,$34.90
+US89,Hawaii,US4964400,Florida-South,Peak,$20.73,$41.18
+US89,Hawaii,US4965500,Florida Keys,NonPeak,$18.33,$32.44
+US89,Hawaii,US4965500,Florida Keys,Peak,$21.63,$38.28
+US89,Hawaii,US50,Minnesota,NonPeak,$24.38,$43.94
+US89,Hawaii,US50,Minnesota,Peak,$28.77,$51.85
+US89,Hawaii,US51,North Dakota,NonPeak,$16.00,$33.70
+US89,Hawaii,US51,North Dakota,Peak,$18.88,$39.77
+US89,Hawaii,US52,South Dakota,NonPeak,$27.63,$31.29
+US89,Hawaii,US52,South Dakota,Peak,$32.60,$36.92
+US89,Hawaii,US53,Iowa,NonPeak,$29.28,$44.05
+US89,Hawaii,US53,Iowa,Peak,$34.55,$51.98
+US89,Hawaii,US55,Nebraska,NonPeak,$30.90,$33.75
+US89,Hawaii,US55,Nebraska,Peak,$36.46,$39.82
+US89,Hawaii,US56,Missouri,NonPeak,$15.28,$31.40
+US89,Hawaii,US56,Missouri,Peak,$18.03,$37.05
+US89,Hawaii,US58,Kansas,NonPeak,$16.05,$44.17
+US89,Hawaii,US58,Kansas,Peak,$18.94,$52.12
+US89,Hawaii,US60,Arkansas,NonPeak,$16.80,$33.98
+US89,Hawaii,US60,Arkansas,Peak,$19.82,$40.10
+US89,Hawaii,US62,Oklahoma,NonPeak,$17.57,$31.45
+US89,Hawaii,US62,Oklahoma,Peak,$20.73,$37.11
+US89,Hawaii,US64,Louisiana,NonPeak,$18.33,$44.28
+US89,Hawaii,US64,Louisiana,Peak,$21.63,$52.25
+US89,Hawaii,US66,Texas-North,NonPeak,$24.38,$34.11
+US89,Hawaii,US66,Texas-North,Peak,$28.77,$40.25
+US89,Hawaii,US68,Texas-South,NonPeak,$16.00,$31.63
+US89,Hawaii,US68,Texas-South,Peak,$18.88,$37.32
+US89,Hawaii,US70,Montana,NonPeak,$27.63,$44.51
+US89,Hawaii,US70,Montana,Peak,$32.60,$52.52
+US89,Hawaii,US72,Wyoming,NonPeak,$29.28,$34.33
+US89,Hawaii,US72,Wyoming,Peak,$34.55,$40.51
+US89,Hawaii,US74,Colorado,NonPeak,$30.90,$31.74
+US89,Hawaii,US74,Colorado,Peak,$36.46,$37.45
+US89,Hawaii,US76,Utah,NonPeak,$15.28,$44.62
+US89,Hawaii,US76,Utah,Peak,$18.03,$52.65
+US89,Hawaii,US77,New Mexico,NonPeak,$16.05,$34.45
+US89,Hawaii,US77,New Mexico,Peak,$18.94,$40.65
+US89,Hawaii,US79,Arizona,NonPeak,$16.80,$31.91
+US89,Hawaii,US79,Arizona,Peak,$19.82,$37.65
+US89,Hawaii,US83,Idaho,NonPeak,$17.57,$44.74
+US89,Hawaii,US83,Idaho,Peak,$20.73,$52.79
+US89,Hawaii,US84,Washington,NonPeak,$18.33,$34.56
+US89,Hawaii,US84,Washington,Peak,$21.63,$40.78
+US89,Hawaii,US85,Oregon,NonPeak,$24.38,$32.09
+US89,Hawaii,US85,Oregon,Peak,$28.77,$37.87
+US89,Hawaii,US86,Nevada,NonPeak,$16.00,$44.91
+US89,Hawaii,US86,Nevada,Peak,$18.88,$52.99
+US89,Hawaii,US87,California-North,NonPeak,$27.63,$34.74
+US89,Hawaii,US87,California-North,Peak,$32.60,$40.99
+US89,Hawaii,US88,California-South,NonPeak,$29.28,$32.26
+US89,Hawaii,US88,California-South,Peak,$34.55,$38.07
+UY,Uruguay,US11,Maine,NonPeak,$30.90,$45.09
+UY,Uruguay,US11,Maine,Peak,$36.46,$53.21
+UY,Uruguay,US12,New Hampshire,NonPeak,$15.28,$34.90
+UY,Uruguay,US12,New Hampshire,Peak,$18.03,$41.18
+UY,Uruguay,US13,Vermont,NonPeak,$16.05,$32.44
+UY,Uruguay,US13,Vermont,Peak,$18.94,$38.28
+UY,Uruguay,US14,Massachusetts,NonPeak,$16.80,$43.94
+UY,Uruguay,US14,Massachusetts,Peak,$19.82,$51.85
+UY,Uruguay,US15,Rhode Island,NonPeak,$17.57,$33.70
+UY,Uruguay,US15,Rhode Island,Peak,$20.73,$39.77
+UY,Uruguay,US16,Connecticut,NonPeak,$18.33,$31.29
+UY,Uruguay,US16,Connecticut,Peak,$21.63,$36.92
+UY,Uruguay,US17,New York,NonPeak,$24.38,$44.05
+UY,Uruguay,US17,New York,Peak,$28.77,$51.98
+UY,Uruguay,US19,New Jersey,NonPeak,$16.00,$33.75
+UY,Uruguay,US19,New Jersey,Peak,$18.88,$39.82
+UY,Uruguay,US20,Pennsylvania,NonPeak,$27.63,$31.40
+UY,Uruguay,US20,Pennsylvania,Peak,$32.60,$37.05
+UY,Uruguay,US22,Delaware,NonPeak,$29.28,$44.17
+UY,Uruguay,US22,Delaware,Peak,$34.55,$52.12
+UY,Uruguay,US23,Maryland,NonPeak,$30.90,$33.98
+UY,Uruguay,US23,Maryland,Peak,$36.46,$40.10
+UY,Uruguay,US24,District Of Columbia,NonPeak,$15.28,$31.45
+UY,Uruguay,US24,District Of Columbia,Peak,$18.03,$37.11
+UY,Uruguay,US25,Virginia,NonPeak,$16.05,$44.28
+UY,Uruguay,US25,Virginia,Peak,$18.94,$52.25
+UY,Uruguay,US27,West Virginia,NonPeak,$16.80,$34.11
+UY,Uruguay,US27,West Virginia,Peak,$19.82,$40.25
+UY,Uruguay,US28,Kentucky,NonPeak,$17.57,$31.63
+UY,Uruguay,US28,Kentucky,Peak,$20.73,$37.32
+UY,Uruguay,US30,Michigan,NonPeak,$18.33,$44.51
+UY,Uruguay,US30,Michigan,Peak,$21.63,$52.52
+UY,Uruguay,US32,Wisconsin,NonPeak,$24.38,$34.33
+UY,Uruguay,US32,Wisconsin,Peak,$28.77,$40.51
+UY,Uruguay,US34,Ohio,NonPeak,$16.00,$31.74
+UY,Uruguay,US34,Ohio,Peak,$18.88,$37.45
+UY,Uruguay,US36,Indiana,NonPeak,$27.63,$44.62
+UY,Uruguay,US36,Indiana,Peak,$32.60,$52.65
+UY,Uruguay,US38,Illinois,NonPeak,$29.28,$34.45
+UY,Uruguay,US38,Illinois,Peak,$34.55,$40.65
+UY,Uruguay,US40,North Carolina,NonPeak,$30.90,$31.91
+UY,Uruguay,US40,North Carolina,Peak,$36.46,$37.65
+UY,Uruguay,US42,Tennessee,NonPeak,$15.28,$44.74
+UY,Uruguay,US42,Tennessee,Peak,$18.03,$52.79
+UY,Uruguay,US44,South Carolina,NonPeak,$16.05,$34.56
+UY,Uruguay,US44,South Carolina,Peak,$18.94,$40.78
+UY,Uruguay,US45,Georgia,NonPeak,$16.80,$32.09
+UY,Uruguay,US45,Georgia,Peak,$19.82,$37.87
+UY,Uruguay,US47,Alabama,NonPeak,$17.57,$44.91
+UY,Uruguay,US47,Alabama,Peak,$20.73,$52.99
+UY,Uruguay,US48,Mississippi,NonPeak,$18.33,$34.74
+UY,Uruguay,US48,Mississippi,Peak,$21.63,$40.99
+UY,Uruguay,US49,Florida-North,NonPeak,$24.38,$32.26
+UY,Uruguay,US49,Florida-North,Peak,$28.77,$38.07
+UY,Uruguay,US4964400,Florida-South,NonPeak,$16.00,$45.09
+UY,Uruguay,US4964400,Florida-South,Peak,$18.88,$53.21
+UY,Uruguay,US4965500,Florida Keys,NonPeak,$27.63,$34.90
+UY,Uruguay,US4965500,Florida Keys,Peak,$32.60,$41.18
+UY,Uruguay,US50,Minnesota,NonPeak,$29.28,$32.44
+UY,Uruguay,US50,Minnesota,Peak,$34.55,$38.28
+UY,Uruguay,US51,North Dakota,NonPeak,$30.90,$43.94
+UY,Uruguay,US51,North Dakota,Peak,$36.46,$51.85
+UY,Uruguay,US52,South Dakota,NonPeak,$15.28,$33.70
+UY,Uruguay,US52,South Dakota,Peak,$18.03,$39.77
+UY,Uruguay,US53,Iowa,NonPeak,$16.05,$31.29
+UY,Uruguay,US53,Iowa,Peak,$18.94,$36.92
+UY,Uruguay,US55,Nebraska,NonPeak,$16.80,$44.05
+UY,Uruguay,US55,Nebraska,Peak,$19.82,$51.98
+UY,Uruguay,US56,Missouri,NonPeak,$17.57,$33.75
+UY,Uruguay,US56,Missouri,Peak,$20.73,$39.82
+UY,Uruguay,US58,Kansas,NonPeak,$18.33,$31.40
+UY,Uruguay,US58,Kansas,Peak,$21.63,$37.05
+UY,Uruguay,US60,Arkansas,NonPeak,$24.38,$44.17
+UY,Uruguay,US60,Arkansas,Peak,$28.77,$52.12
+UY,Uruguay,US62,Oklahoma,NonPeak,$16.00,$33.98
+UY,Uruguay,US62,Oklahoma,Peak,$18.88,$40.10
+UY,Uruguay,US64,Louisiana,NonPeak,$27.63,$31.45
+UY,Uruguay,US64,Louisiana,Peak,$32.60,$37.11
+UY,Uruguay,US66,Texas-North,NonPeak,$29.28,$44.28
+UY,Uruguay,US66,Texas-North,Peak,$34.55,$52.25
+UY,Uruguay,US68,Texas-South,NonPeak,$30.90,$34.11
+UY,Uruguay,US68,Texas-South,Peak,$36.46,$40.25
+UY,Uruguay,US70,Montana,NonPeak,$15.28,$31.63
+UY,Uruguay,US70,Montana,Peak,$18.03,$37.32
+UY,Uruguay,US72,Wyoming,NonPeak,$16.05,$44.51
+UY,Uruguay,US72,Wyoming,Peak,$18.94,$52.52
+UY,Uruguay,US74,Colorado,NonPeak,$16.80,$34.33
+UY,Uruguay,US74,Colorado,Peak,$19.82,$40.51
+UY,Uruguay,US76,Utah,NonPeak,$17.57,$31.74
+UY,Uruguay,US76,Utah,Peak,$20.73,$37.45
+UY,Uruguay,US77,New Mexico,NonPeak,$18.33,$44.62
+UY,Uruguay,US77,New Mexico,Peak,$21.63,$52.65
+UY,Uruguay,US79,Arizona,NonPeak,$24.38,$34.45
+UY,Uruguay,US79,Arizona,Peak,$28.77,$40.65
+UY,Uruguay,US83,Idaho,NonPeak,$16.00,$31.91
+UY,Uruguay,US83,Idaho,Peak,$18.88,$37.65
+UY,Uruguay,US84,Washington,NonPeak,$27.63,$44.74
+UY,Uruguay,US84,Washington,Peak,$32.60,$52.79
+UY,Uruguay,US85,Oregon,NonPeak,$29.28,$34.56
+UY,Uruguay,US85,Oregon,Peak,$34.55,$40.78
+UY,Uruguay,US86,Nevada,NonPeak,$30.90,$32.09
+UY,Uruguay,US86,Nevada,Peak,$36.46,$37.87
+UY,Uruguay,US87,California-North,NonPeak,$15.28,$44.91
+UY,Uruguay,US87,California-North,Peak,$18.03,$52.99
+UY,Uruguay,US88,California-South,NonPeak,$16.05,$34.74
+UY,Uruguay,US88,California-South,Peak,$18.94,$40.99
+VE,Venezuela,US11,Maine,NonPeak,$16.80,$32.26
+VE,Venezuela,US11,Maine,Peak,$19.82,$38.07
+VE,Venezuela,US12,New Hampshire,NonPeak,$17.57,$45.09
+VE,Venezuela,US12,New Hampshire,Peak,$20.73,$53.21
+VE,Venezuela,US13,Vermont,NonPeak,$18.33,$34.90
+VE,Venezuela,US13,Vermont,Peak,$21.63,$41.18
+VE,Venezuela,US14,Massachusetts,NonPeak,$24.38,$32.44
+VE,Venezuela,US14,Massachusetts,Peak,$28.77,$38.28
+VE,Venezuela,US15,Rhode Island,NonPeak,$16.00,$43.94
+VE,Venezuela,US15,Rhode Island,Peak,$18.88,$51.85
+VE,Venezuela,US16,Connecticut,NonPeak,$27.63,$33.70
+VE,Venezuela,US16,Connecticut,Peak,$32.60,$39.77
+VE,Venezuela,US17,New York,NonPeak,$29.28,$31.29
+VE,Venezuela,US17,New York,Peak,$34.55,$36.92
+VE,Venezuela,US19,New Jersey,NonPeak,$30.90,$44.05
+VE,Venezuela,US19,New Jersey,Peak,$36.46,$51.98
+VE,Venezuela,US20,Pennsylvania,NonPeak,$15.28,$33.75
+VE,Venezuela,US20,Pennsylvania,Peak,$18.03,$39.82
+VE,Venezuela,US22,Delaware,NonPeak,$16.05,$31.40
+VE,Venezuela,US22,Delaware,Peak,$18.94,$37.05
+VE,Venezuela,US23,Maryland,NonPeak,$16.80,$44.17
+VE,Venezuela,US23,Maryland,Peak,$19.82,$52.12
+VE,Venezuela,US24,District Of Columbia,NonPeak,$17.57,$33.98
+VE,Venezuela,US24,District Of Columbia,Peak,$20.73,$40.10
+VE,Venezuela,US25,Virginia,NonPeak,$18.33,$31.45
+VE,Venezuela,US25,Virginia,Peak,$21.63,$37.11
+VE,Venezuela,US27,West Virginia,NonPeak,$24.38,$44.28
+VE,Venezuela,US27,West Virginia,Peak,$28.77,$52.25
+VE,Venezuela,US28,Kentucky,NonPeak,$16.00,$34.11
+VE,Venezuela,US28,Kentucky,Peak,$18.88,$40.25
+VE,Venezuela,US30,Michigan,NonPeak,$27.63,$31.63
+VE,Venezuela,US30,Michigan,Peak,$32.60,$37.32
+VE,Venezuela,US32,Wisconsin,NonPeak,$29.28,$44.51
+VE,Venezuela,US32,Wisconsin,Peak,$34.55,$52.52
+VE,Venezuela,US34,Ohio,NonPeak,$30.90,$34.33
+VE,Venezuela,US34,Ohio,Peak,$36.46,$40.51
+VE,Venezuela,US36,Indiana,NonPeak,$15.28,$31.74
+VE,Venezuela,US36,Indiana,Peak,$18.03,$37.45
+VE,Venezuela,US38,Illinois,NonPeak,$16.05,$44.62
+VE,Venezuela,US38,Illinois,Peak,$18.94,$52.65
+VE,Venezuela,US40,North Carolina,NonPeak,$16.80,$34.45
+VE,Venezuela,US40,North Carolina,Peak,$19.82,$40.65
+VE,Venezuela,US42,Tennessee,NonPeak,$17.57,$31.91
+VE,Venezuela,US42,Tennessee,Peak,$20.73,$37.65
+VE,Venezuela,US44,South Carolina,NonPeak,$18.33,$44.74
+VE,Venezuela,US44,South Carolina,Peak,$21.63,$52.79
+VE,Venezuela,US45,Georgia,NonPeak,$24.38,$34.56
+VE,Venezuela,US45,Georgia,Peak,$28.77,$40.78
+VE,Venezuela,US47,Alabama,NonPeak,$16.00,$32.09
+VE,Venezuela,US47,Alabama,Peak,$18.88,$37.87
+VE,Venezuela,US48,Mississippi,NonPeak,$27.63,$44.91
+VE,Venezuela,US48,Mississippi,Peak,$32.60,$52.99
+VE,Venezuela,US49,Florida-North,NonPeak,$29.28,$34.74
+VE,Venezuela,US49,Florida-North,Peak,$34.55,$40.99
+VE,Venezuela,US4964400,Florida-South,NonPeak,$30.90,$32.26
+VE,Venezuela,US4964400,Florida-South,Peak,$36.46,$38.07
+VE,Venezuela,US4965500,Florida Keys,NonPeak,$15.28,$45.09
+VE,Venezuela,US4965500,Florida Keys,Peak,$18.03,$53.21
+VE,Venezuela,US50,Minnesota,NonPeak,$16.05,$34.90
+VE,Venezuela,US50,Minnesota,Peak,$18.94,$41.18
+VE,Venezuela,US51,North Dakota,NonPeak,$16.80,$32.44
+VE,Venezuela,US51,North Dakota,Peak,$19.82,$38.28
+VE,Venezuela,US52,South Dakota,NonPeak,$17.57,$43.94
+VE,Venezuela,US52,South Dakota,Peak,$20.73,$51.85
+VE,Venezuela,US53,Iowa,NonPeak,$18.33,$33.70
+VE,Venezuela,US53,Iowa,Peak,$21.63,$39.77
+VE,Venezuela,US55,Nebraska,NonPeak,$24.38,$31.29
+VE,Venezuela,US55,Nebraska,Peak,$28.77,$36.92
+VE,Venezuela,US56,Missouri,NonPeak,$16.00,$44.05
+VE,Venezuela,US56,Missouri,Peak,$18.88,$51.98
+VE,Venezuela,US58,Kansas,NonPeak,$27.63,$33.75
+VE,Venezuela,US58,Kansas,Peak,$32.60,$39.82
+VE,Venezuela,US60,Arkansas,NonPeak,$29.28,$31.40
+VE,Venezuela,US60,Arkansas,Peak,$34.55,$37.05
+VE,Venezuela,US62,Oklahoma,NonPeak,$30.90,$44.17
+VE,Venezuela,US62,Oklahoma,Peak,$36.46,$52.12
+VE,Venezuela,US64,Louisiana,NonPeak,$15.28,$33.98
+VE,Venezuela,US64,Louisiana,Peak,$18.03,$40.10
+VE,Venezuela,US66,Texas-North,NonPeak,$16.05,$31.45
+VE,Venezuela,US66,Texas-North,Peak,$18.94,$37.11
+VE,Venezuela,US68,Texas-South,NonPeak,$16.80,$44.28
+VE,Venezuela,US68,Texas-South,Peak,$19.82,$52.25
+VE,Venezuela,US70,Montana,NonPeak,$17.57,$34.11
+VE,Venezuela,US70,Montana,Peak,$20.73,$40.25
+VE,Venezuela,US72,Wyoming,NonPeak,$18.33,$31.63
+VE,Venezuela,US72,Wyoming,Peak,$21.63,$37.32
+VE,Venezuela,US74,Colorado,NonPeak,$24.38,$44.51
+VE,Venezuela,US74,Colorado,Peak,$28.77,$52.52
+VE,Venezuela,US76,Utah,NonPeak,$16.00,$34.33
+VE,Venezuela,US76,Utah,Peak,$18.88,$40.51
+VE,Venezuela,US77,New Mexico,NonPeak,$27.63,$31.74
+VE,Venezuela,US77,New Mexico,Peak,$32.60,$37.45
+VE,Venezuela,US79,Arizona,NonPeak,$29.28,$44.62
+VE,Venezuela,US79,Arizona,Peak,$34.55,$52.65
+VE,Venezuela,US83,Idaho,NonPeak,$30.90,$34.45
+VE,Venezuela,US83,Idaho,Peak,$36.46,$40.65
+VE,Venezuela,US84,Washington,NonPeak,$15.28,$31.91
+VE,Venezuela,US84,Washington,Peak,$18.03,$37.65
+VE,Venezuela,US85,Oregon,NonPeak,$16.05,$44.74
+VE,Venezuela,US85,Oregon,Peak,$18.94,$52.79
+VE,Venezuela,US86,Nevada,NonPeak,$16.80,$34.56
+VE,Venezuela,US86,Nevada,Peak,$19.82,$40.78
+VE,Venezuela,US87,California-North,NonPeak,$17.57,$32.09
+VE,Venezuela,US87,California-North,Peak,$20.73,$37.87
+VE,Venezuela,US88,California-South,NonPeak,$18.33,$44.91
+VE,Venezuela,US88,California-South,Peak,$21.63,$52.99

--- a/pkg/parser/pricing/parse.go
+++ b/pkg/parser/pricing/parse.go
@@ -180,6 +180,39 @@ func InitDataSheetInfo() []XlsxDataSheetInfo {
 		},
 		verify: &verifyDomesticServiceAreaPrices,
 	}
+	// 10: 	3a) OCONUS TO OCONUS Prices
+	xlsxDataSheets[10] = XlsxDataSheetInfo{
+		Description:    swag.String("3a) OCONUS to OCONUS Prices"),
+		outputFilename: swag.String("3a_oconus_to_oconus_prices"),
+		ProcessMethods: []xlsxProcessInfo{{
+			//process: &parseOconusToOconusPrices,
+			process: &parseOconusToOconusPrices,
+		},
+		},
+		verify: &verifyIntlOconusToOconusPrices,
+	}
+
+	// 11: 	3b) CONUS TO OCONUS Prices
+	xlsxDataSheets[11] = XlsxDataSheetInfo{
+		Description:    swag.String("3b) CONUS to OCONUS Prices"),
+		outputFilename: swag.String("3b_conus_to_oconus_prices"),
+		ProcessMethods: []xlsxProcessInfo{{
+			process: &parseConusToOconusPrices,
+		},
+		},
+		verify: &verifyIntlConusToOconusPrices,
+	}
+
+	// 12: 	3c) OCONUS TO CONUS Prices
+	xlsxDataSheets[12] = XlsxDataSheetInfo{
+		Description:    swag.String("3c) OCONUS to CONUS Prices"),
+		outputFilename: swag.String("3c_oconus_to_conus_prices"),
+		ProcessMethods: []xlsxProcessInfo{{
+			process: &parseOconusToConusPrices,
+		},
+		},
+		verify: &verifyIntlOconusToConusPrices,
+	}
 
 	return xlsxDataSheets
 }

--- a/pkg/parser/pricing/parse_international_prices.go
+++ b/pkg/parser/pricing/parse_international_prices.go
@@ -140,7 +140,7 @@ func verifyInternationalPrices(params ParamConfig, sheetIndex int, xlsxSheetNum 
 	const verifyHeaderIndexEnd2 = repeatingHeaderIndexStart + 2
 
 	if xlsxDataSheetNum != sheetIndex {
-		return fmt.Errorf("verifyOconusToOconusPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
+		return fmt.Errorf("verifyInternationalPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
 	}
 
 	// Verify header strings

--- a/pkg/parser/pricing/parse_international_prices.go
+++ b/pkg/parser/pricing/parse_international_prices.go
@@ -1,0 +1,276 @@
+package pricing
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/transcom/mymove/pkg/models"
+)
+
+// parseOconusToOconusPrices: parser for 3a) OCONUS to OCONUS Prices
+var parseOconusToOconusPrices processXlsxSheet = func(params ParamConfig, sheetIndex int) (interface{}, error) {
+	// XLSX Sheet consts
+	const xlsxDataSheetNum int = 10 // 3a) OCONUS TO OCONUS Prices
+	const feeColIndexStart int = 6  // start at column 6 to get the rates
+	const feeRowIndexStart int = 10 // start at row 10 to get the rates
+	const originIntlPriceAreaIDColumn int = 2
+	const originIntlPriceAreaColumn int = 3
+	const destinationIntlPriceAreaIDColumn int = 4
+	const destinationIntlPriceAreaColumn int = 5
+	const numEscalationYearsToProcess = sharedNumEscalationYearsToProcess
+
+	if xlsxDataSheetNum != sheetIndex {
+		return nil, fmt.Errorf("parseOconusToOconusPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
+	}
+
+	var oconusToOconusPrices []models.StageOconusToOconusPrice
+	dataRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[feeRowIndexStart:]
+	for _, row := range dataRows {
+		colIndex := feeColIndexStart
+		// For number of baseline + Escalation years
+		for escalation := 0; escalation < numEscalationYearsToProcess; escalation++ {
+			// For each Rate Season
+			for _, r := range rateSeasons {
+				oconusToOconusPrice := models.StageOconusToOconusPrice{
+					OriginIntlPriceAreaID:      getCell(row.Cells, originIntlPriceAreaIDColumn),
+					OriginIntlPriceArea:        getCell(row.Cells, originIntlPriceAreaColumn),
+					DestinationIntlPriceAreaID: getCell(row.Cells, destinationIntlPriceAreaIDColumn),
+					DestinationIntlPriceArea:   getCell(row.Cells, destinationIntlPriceAreaColumn),
+					Season:                     r,
+				}
+
+				oconusToOconusPrice.HHGShippingLinehaulPrice = getCell(row.Cells, colIndex)
+				colIndex++
+				oconusToOconusPrice.UBPrice = getCell(row.Cells, colIndex)
+
+				if params.ShowOutput == true {
+					log.Printf("%v\n", oconusToOconusPrice)
+				}
+				oconusToOconusPrices = append(oconusToOconusPrices, oconusToOconusPrice)
+
+				colIndex += 2 // skip 1 column (empty column) before starting next Rate type
+			}
+		}
+	}
+	return oconusToOconusPrices, nil
+}
+
+// parseConusToOconusPrices: parser for 3b) CONUS to OCONUS Prices
+var parseConusToOconusPrices processXlsxSheet = func(params ParamConfig, sheetIndex int) (interface{}, error) {
+	// XLSX Sheet consts
+	const xlsxDataSheetNum int = 11 // 3b) CONUS TO OCONUS Prices
+	const feeColIndexStart int = 6  // start at column 6 to get the rates
+	const feeRowIndexStart int = 10 // start at row 10 to get the rates
+	const originDomesticPriceAreaCodeColumn int = 2
+	const originDomesticPriceAreaColumn int = 3
+	const destinationIntlPriceAreaIDColumn int = 4
+	const destinationIntlPriceAreaColumn int = 5
+	const numEscalationYearsToProcess = sharedNumEscalationYearsToProcess
+
+	if xlsxDataSheetNum != sheetIndex {
+		return nil, fmt.Errorf("parseConusToOconusPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
+	}
+
+	var conusToOconusPrices []models.StageConusToOconusPrice
+	dataRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[feeRowIndexStart:]
+	for _, row := range dataRows {
+		colIndex := feeColIndexStart
+		// For number of baseline + Escalation years
+		for escalation := 0; escalation < numEscalationYearsToProcess; escalation++ {
+			// For each Rate Season
+			for _, r := range rateSeasons {
+				conusToOconusPrice := models.StageConusToOconusPrice{
+					OriginDomesticPriceAreaCode: getCell(row.Cells, originDomesticPriceAreaCodeColumn),
+					OriginDomesticPriceArea:     getCell(row.Cells, originDomesticPriceAreaColumn),
+					DestinationIntlPriceAreaID:  getCell(row.Cells, destinationIntlPriceAreaIDColumn),
+					DestinationIntlPriceArea:    getCell(row.Cells, destinationIntlPriceAreaColumn),
+					Season:                      r,
+				}
+
+				conusToOconusPrice.HHGShippingLinehaulPrice = getCell(row.Cells, colIndex)
+				colIndex++
+				conusToOconusPrice.UBPrice = getCell(row.Cells, colIndex)
+
+				if params.ShowOutput == true {
+					log.Printf("%v\n", conusToOconusPrice)
+				}
+				conusToOconusPrices = append(conusToOconusPrices, conusToOconusPrice)
+
+				colIndex += 2 // skip 1 column (empty column) before starting next Rate type
+			}
+		}
+	}
+	return conusToOconusPrices, nil
+}
+
+// parseOconusToConusPrices: parser for 3c) OCONUS to CONUS Prices
+var parseOconusToConusPrices processXlsxSheet = func(params ParamConfig, sheetIndex int) (interface{}, error) {
+	// XLSX Sheet consts
+	const xlsxDataSheetNum int = 12 // 3c) OCONUS TO CONUS Prices
+	const feeColIndexStart int = 6  // start at column 6 to get the rates
+	const feeRowIndexStart int = 10 // start at row 10 to get the rates
+	const originIntlPriceAreaIDColumn int = 2
+	const originIntlPriceAreaColumn int = 3
+	const destinationDomesticPriceAreaCodeColumn int = 4
+	const destinationDomesticPriceAreaColumn int = 5
+	const numEscalationYearsToProcess = sharedNumEscalationYearsToProcess
+
+	if xlsxDataSheetNum != sheetIndex {
+		return nil, fmt.Errorf("parseOconusToConusPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
+	}
+
+	var oconusToConusPrices []models.StageOconusToConusPrice
+	dataRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[feeRowIndexStart:]
+	for _, row := range dataRows {
+		colIndex := feeColIndexStart
+		// For number of baseline + Escalation years
+		for escalation := 0; escalation < numEscalationYearsToProcess; escalation++ {
+			// For each Rate Season
+			for _, r := range rateSeasons {
+				oconusToConusPrice := models.StageOconusToConusPrice{
+					OriginIntlPriceAreaID:            getCell(row.Cells, originIntlPriceAreaIDColumn),
+					OriginIntlPriceArea:              getCell(row.Cells, originIntlPriceAreaColumn),
+					DestinationDomesticPriceAreaCode: getCell(row.Cells, destinationDomesticPriceAreaCodeColumn),
+					DestinationDomesticPriceArea:     getCell(row.Cells, destinationDomesticPriceAreaColumn),
+					Season:                           r,
+				}
+
+				oconusToConusPrice.HHGShippingLinehaulPrice = getCell(row.Cells, colIndex)
+				colIndex++
+				oconusToConusPrice.UBPrice = getCell(row.Cells, colIndex)
+
+				if params.ShowOutput == true {
+					log.Printf("%v\n", oconusToConusPrice)
+				}
+				oconusToConusPrices = append(oconusToConusPrices, oconusToConusPrice)
+
+				colIndex += 2 // skip 1 column (empty column) before starting next Rate type
+			}
+		}
+	}
+	return oconusToConusPrices, nil
+}
+
+func verifyInternationalPrices(params ParamConfig, sheetIndex int, xlsxSheetNum int) error {
+	// XLSX Sheet consts
+	xlsxDataSheetNum := xlsxSheetNum
+	const feeColIndexStart int = 6  // start at column 6 to get the rates
+	const feeRowIndexStart int = 10 // start at row 10 to get the rates
+	const originPriceAreaIDColumn int = 2
+	const originPriceAreaColumn int = 3
+	const destinationPriceAreaIDColumn int = 4
+	const destinationPriceAreaColumn int = 5
+	const numEscalationYearsToProcess = sharedNumEscalationYearsToProcess
+
+	// Check headers
+	const headerIndexStart = feeRowIndexStart - 3
+	const headerIndexStart2 = feeRowIndexStart - 2
+	const verifyHeaderIndexEnd2 = headerIndexStart2 + 2
+	const verifyHeaderIndexEnd = headerIndexStart + 2
+
+	if xlsxDataSheetNum != sheetIndex {
+		return fmt.Errorf("verifyOconusToOconusPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
+	}
+
+	// Verify header strings
+	repeatingHeaders := []string{
+		"HHG Shipping / Linehaul Price (except SIT) (per cwt)",
+		"UB Price (except SIT) (per cwt)",
+	}
+
+	dataRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[headerIndexStart:verifyHeaderIndexEnd]
+	repeatingRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[headerIndexStart2:verifyHeaderIndexEnd2]
+	for dataRowsIndex, row := range dataRows {
+		colIndex := feeColIndexStart
+		// For number of baseline + Escalation years
+		for escalation := 0; escalation < numEscalationYearsToProcess; escalation++ {
+			// For each Rate Season
+			for _, r := range rateSeasons {
+				verificationLog := fmt.Sprintf(" , verfication for row index: %d, colIndex: %d, Escalation: %d, rateSeasons %v",
+					dataRowsIndex, colIndex, escalation, r)
+
+				if dataRowsIndex == 0 {
+					if xlsxSheetNum == 10 {
+						if "OriginIntlPriceAreaID" != removeWhiteSpace(getCell(row.Cells, originPriceAreaIDColumn)) {
+							return fmt.Errorf("format error: Header <OriginIntlPriceAreaID> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, originPriceAreaIDColumn)), verificationLog)
+						}
+						if "OriginIntlPriceArea(PPIRA)" != removeWhiteSpace(getCell(row.Cells, originPriceAreaColumn)) {
+							return fmt.Errorf("format error: Header <OriginIntlPriceArea(PPIRA)> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, originPriceAreaColumn)), verificationLog)
+						}
+						if "DestinationIntlPriceAreaID" != removeWhiteSpace(getCell(row.Cells, destinationPriceAreaIDColumn)) {
+							return fmt.Errorf("format error: Header <DestinationIntlPriceAreaID> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, destinationPriceAreaIDColumn)), verificationLog)
+						}
+
+						if "DestinationIntlPriceArea(PPIRA)" != removeWhiteSpace(getCell(row.Cells, destinationPriceAreaColumn)) {
+							return fmt.Errorf("format error: Header <DestinationIntlPriceArea(PPIRA)> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, destinationPriceAreaColumn)), verificationLog)
+						}
+					}
+
+					if xlsxSheetNum == 11 {
+						if "OriginDomesticPriceAreaCode" != removeWhiteSpace(getCell(row.Cells, originPriceAreaIDColumn)) {
+							return fmt.Errorf("format error: Header <OriginDomesticPriceAreaCode> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, originPriceAreaIDColumn)), verificationLog)
+						}
+						if "OriginDomesticPriceArea(PPDRA)" != removeWhiteSpace(getCell(row.Cells, originPriceAreaColumn)) {
+							return fmt.Errorf("format error: Header <OriginDomesticPriceArea(PPDRA)> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, originPriceAreaColumn)), verificationLog)
+						}
+						if "DestinationIntlPriceAreaID" != removeWhiteSpace(getCell(row.Cells, destinationPriceAreaIDColumn)) {
+							return fmt.Errorf("format error: Header <DestinationIntlPriceAreaID> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, destinationPriceAreaIDColumn)), verificationLog)
+						}
+
+						if "DestinationIntlPriceArea(PPIRA)" != removeWhiteSpace(getCell(row.Cells, destinationPriceAreaColumn)) {
+							return fmt.Errorf("format error: Header <DestinationIntlPriceArea(PPIRA)> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, destinationPriceAreaColumn)), verificationLog)
+						}
+					}
+
+					if xlsxSheetNum == 12 {
+						if "OriginIntlPriceAreaID" != removeWhiteSpace(getCell(row.Cells, originPriceAreaIDColumn)) {
+							return fmt.Errorf("format error: Header <OriginIntlPriceAreaID> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, originPriceAreaIDColumn)), verificationLog)
+						}
+						if "OriginInternationalPriceArea(PPIRA)" != removeWhiteSpace(getCell(row.Cells, originPriceAreaColumn)) {
+							return fmt.Errorf("format error: Header <OriginInternationalPriceArea(PPIRA)> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, originPriceAreaColumn)), verificationLog)
+						}
+						if "DestinationDomesticPriceAreaCode" != removeWhiteSpace(getCell(row.Cells, destinationPriceAreaIDColumn)) {
+							return fmt.Errorf("format error: Header <DestinationDomesticPriceAreaCode> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, destinationPriceAreaIDColumn)), verificationLog)
+						}
+
+						if "DestinationDomesticPriceArea(PPDRA)" != removeWhiteSpace(getCell(row.Cells, destinationPriceAreaColumn)) {
+							return fmt.Errorf("format error: Header <DestinationDomesticPriceArea(PPDRA)> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, destinationPriceAreaColumn)), verificationLog)
+						}
+					}
+
+					for repeatingRowsIndex, row := range repeatingRows {
+						if repeatingRowsIndex == 0 {
+							colIndex := feeColIndexStart
+							for _, repeatingHeader := range repeatingHeaders {
+								if removeWhiteSpace(repeatingHeader) != removeWhiteSpace(getCell(row.Cells, colIndex)) {
+									return fmt.Errorf("format error: Header contains <%s> is missing got <%s> instead\n%s", removeWhiteSpace(repeatingHeader), removeWhiteSpace(getCell(row.Cells, colIndex)), verificationLog)
+								}
+								colIndex++
+							}
+						} else if dataRowsIndex == 1 {
+							if "EXAMPLE" != removeWhiteSpace(getCell(row.Cells, originPriceAreaColumn)) {
+								return fmt.Errorf("format error: Filler text <EXAMPLE> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, originPriceAreaColumn)), verificationLog)
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	return nil
+}
+
+var verifyIntlOconusToOconusPrices verifyXlsxSheet = func(params ParamConfig, sheetIndex int) error {
+	const xlsxSheetNum = 10
+	return verifyInternationalPrices(params, sheetIndex, xlsxSheetNum)
+}
+
+var verifyIntlConusToOconusPrices verifyXlsxSheet = func(params ParamConfig, sheetIndex int) error {
+	const xlsxSheetNum = 11
+	return verifyInternationalPrices(params, sheetIndex, xlsxSheetNum)
+}
+
+var verifyIntlOconusToConusPrices verifyXlsxSheet = func(params ParamConfig, sheetIndex int) error {
+	const xlsxSheetNum = 12
+	return verifyInternationalPrices(params, sheetIndex, xlsxSheetNum)
+}

--- a/pkg/parser/pricing/parse_international_prices.go
+++ b/pkg/parser/pricing/parse_international_prices.go
@@ -164,9 +164,9 @@ func verifyInternationalPrices(params ParamConfig, sheetIndex int, xlsxSheetNum 
 
 	// Check headers
 	const headerIndexStart = feeRowIndexStart - 3
-	const headerIndexStart2 = feeRowIndexStart - 2
-	const verifyHeaderIndexEnd2 = headerIndexStart2 + 2
 	const verifyHeaderIndexEnd = headerIndexStart + 2
+	const repeatingHeaderIndexStart = feeRowIndexStart - 2
+	const verifyHeaderIndexEnd2 = repeatingHeaderIndexStart + 2
 
 	if xlsxDataSheetNum != sheetIndex {
 		return fmt.Errorf("verifyOconusToOconusPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
@@ -179,7 +179,7 @@ func verifyInternationalPrices(params ParamConfig, sheetIndex int, xlsxSheetNum 
 	}
 
 	dataRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[headerIndexStart:verifyHeaderIndexEnd]
-	repeatingRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[headerIndexStart2:verifyHeaderIndexEnd2]
+	repeatingRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[repeatingHeaderIndexStart:verifyHeaderIndexEnd2]
 	for dataRowsIndex, row := range dataRows {
 		colIndex := feeColIndexStart
 		// For number of baseline + Escalation years

--- a/pkg/parser/pricing/parse_international_prices.go
+++ b/pkg/parser/pricing/parse_international_prices.go
@@ -7,17 +7,18 @@ import (
 	"github.com/transcom/mymove/pkg/models"
 )
 
+//same values used in each parse and verify function
+const feeColIndexStart int = 6  // start at column 6 to get the rates
+const feeRowIndexStart int = 10 // start at row 10 to get the rates
+const originPriceAreaIDColumn int = 2
+const originPriceAreaColumn int = 3
+const destinationPriceAreaIDColumn int = 4
+const destinationPriceAreaColumn int = 5
+
 // parseOconusToOconusPrices: parser for 3a) OCONUS to OCONUS Prices
 var parseOconusToOconusPrices processXlsxSheet = func(params ParamConfig, sheetIndex int) (interface{}, error) {
 	// XLSX Sheet consts
 	const xlsxDataSheetNum int = 10 // 3a) OCONUS TO OCONUS Prices
-	const feeColIndexStart int = 6  // start at column 6 to get the rates
-	const feeRowIndexStart int = 10 // start at row 10 to get the rates
-	const originIntlPriceAreaIDColumn int = 2
-	const originIntlPriceAreaColumn int = 3
-	const destinationIntlPriceAreaIDColumn int = 4
-	const destinationIntlPriceAreaColumn int = 5
-	const numEscalationYearsToProcess = sharedNumEscalationYearsToProcess
 
 	if xlsxDataSheetNum != sheetIndex {
 		return nil, fmt.Errorf("parseOconusToOconusPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
@@ -27,29 +28,26 @@ var parseOconusToOconusPrices processXlsxSheet = func(params ParamConfig, sheetI
 	dataRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[feeRowIndexStart:]
 	for _, row := range dataRows {
 		colIndex := feeColIndexStart
-		// For number of baseline + Escalation years
-		for escalation := 0; escalation < numEscalationYearsToProcess; escalation++ {
-			// For each Rate Season
-			for _, r := range rateSeasons {
-				oconusToOconusPrice := models.StageOconusToOconusPrice{
-					OriginIntlPriceAreaID:      getCell(row.Cells, originIntlPriceAreaIDColumn),
-					OriginIntlPriceArea:        getCell(row.Cells, originIntlPriceAreaColumn),
-					DestinationIntlPriceAreaID: getCell(row.Cells, destinationIntlPriceAreaIDColumn),
-					DestinationIntlPriceArea:   getCell(row.Cells, destinationIntlPriceAreaColumn),
-					Season:                     r,
-				}
-
-				oconusToOconusPrice.HHGShippingLinehaulPrice = getCell(row.Cells, colIndex)
-				colIndex++
-				oconusToOconusPrice.UBPrice = getCell(row.Cells, colIndex)
-
-				if params.ShowOutput == true {
-					log.Printf("%v\n", oconusToOconusPrice)
-				}
-				oconusToOconusPrices = append(oconusToOconusPrices, oconusToOconusPrice)
-
-				colIndex += 2 // skip 1 column (empty column) before starting next Rate type
+		// For each Rate Season
+		for _, r := range rateSeasons {
+			oconusToOconusPrice := models.StageOconusToOconusPrice{
+				OriginIntlPriceAreaID:      getCell(row.Cells, originPriceAreaIDColumn),
+				OriginIntlPriceArea:        getCell(row.Cells, originPriceAreaColumn),
+				DestinationIntlPriceAreaID: getCell(row.Cells, destinationPriceAreaIDColumn),
+				DestinationIntlPriceArea:   getCell(row.Cells, destinationPriceAreaColumn),
+				Season:                     r,
 			}
+
+			oconusToOconusPrice.HHGShippingLinehaulPrice = getCell(row.Cells, colIndex)
+			colIndex++
+			oconusToOconusPrice.UBPrice = getCell(row.Cells, colIndex)
+
+			if params.ShowOutput == true {
+				log.Printf("%v\n", oconusToOconusPrice)
+			}
+			oconusToOconusPrices = append(oconusToOconusPrices, oconusToOconusPrice)
+
+			colIndex += 2 // skip 1 column (empty column) before starting next Rate type
 		}
 	}
 	return oconusToOconusPrices, nil
@@ -59,13 +57,6 @@ var parseOconusToOconusPrices processXlsxSheet = func(params ParamConfig, sheetI
 var parseConusToOconusPrices processXlsxSheet = func(params ParamConfig, sheetIndex int) (interface{}, error) {
 	// XLSX Sheet consts
 	const xlsxDataSheetNum int = 11 // 3b) CONUS TO OCONUS Prices
-	const feeColIndexStart int = 6  // start at column 6 to get the rates
-	const feeRowIndexStart int = 10 // start at row 10 to get the rates
-	const originDomesticPriceAreaCodeColumn int = 2
-	const originDomesticPriceAreaColumn int = 3
-	const destinationIntlPriceAreaIDColumn int = 4
-	const destinationIntlPriceAreaColumn int = 5
-	const numEscalationYearsToProcess = sharedNumEscalationYearsToProcess
 
 	if xlsxDataSheetNum != sheetIndex {
 		return nil, fmt.Errorf("parseConusToOconusPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
@@ -75,29 +66,26 @@ var parseConusToOconusPrices processXlsxSheet = func(params ParamConfig, sheetIn
 	dataRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[feeRowIndexStart:]
 	for _, row := range dataRows {
 		colIndex := feeColIndexStart
-		// For number of baseline + Escalation years
-		for escalation := 0; escalation < numEscalationYearsToProcess; escalation++ {
-			// For each Rate Season
-			for _, r := range rateSeasons {
-				conusToOconusPrice := models.StageConusToOconusPrice{
-					OriginDomesticPriceAreaCode: getCell(row.Cells, originDomesticPriceAreaCodeColumn),
-					OriginDomesticPriceArea:     getCell(row.Cells, originDomesticPriceAreaColumn),
-					DestinationIntlPriceAreaID:  getCell(row.Cells, destinationIntlPriceAreaIDColumn),
-					DestinationIntlPriceArea:    getCell(row.Cells, destinationIntlPriceAreaColumn),
-					Season:                      r,
-				}
-
-				conusToOconusPrice.HHGShippingLinehaulPrice = getCell(row.Cells, colIndex)
-				colIndex++
-				conusToOconusPrice.UBPrice = getCell(row.Cells, colIndex)
-
-				if params.ShowOutput == true {
-					log.Printf("%v\n", conusToOconusPrice)
-				}
-				conusToOconusPrices = append(conusToOconusPrices, conusToOconusPrice)
-
-				colIndex += 2 // skip 1 column (empty column) before starting next Rate type
+		// For each Rate Season
+		for _, r := range rateSeasons {
+			conusToOconusPrice := models.StageConusToOconusPrice{
+				OriginDomesticPriceAreaCode: getCell(row.Cells, originPriceAreaIDColumn),
+				OriginDomesticPriceArea:     getCell(row.Cells, originPriceAreaColumn),
+				DestinationIntlPriceAreaID:  getCell(row.Cells, destinationPriceAreaIDColumn),
+				DestinationIntlPriceArea:    getCell(row.Cells, destinationPriceAreaColumn),
+				Season:                      r,
 			}
+
+			conusToOconusPrice.HHGShippingLinehaulPrice = getCell(row.Cells, colIndex)
+			colIndex++
+			conusToOconusPrice.UBPrice = getCell(row.Cells, colIndex)
+
+			if params.ShowOutput == true {
+				log.Printf("%v\n", conusToOconusPrice)
+			}
+			conusToOconusPrices = append(conusToOconusPrices, conusToOconusPrice)
+
+			colIndex += 2 // skip 1 column (empty column) before starting next Rate type
 		}
 	}
 	return conusToOconusPrices, nil
@@ -107,13 +95,6 @@ var parseConusToOconusPrices processXlsxSheet = func(params ParamConfig, sheetIn
 var parseOconusToConusPrices processXlsxSheet = func(params ParamConfig, sheetIndex int) (interface{}, error) {
 	// XLSX Sheet consts
 	const xlsxDataSheetNum int = 12 // 3c) OCONUS TO CONUS Prices
-	const feeColIndexStart int = 6  // start at column 6 to get the rates
-	const feeRowIndexStart int = 10 // start at row 10 to get the rates
-	const originIntlPriceAreaIDColumn int = 2
-	const originIntlPriceAreaColumn int = 3
-	const destinationDomesticPriceAreaCodeColumn int = 4
-	const destinationDomesticPriceAreaColumn int = 5
-	const numEscalationYearsToProcess = sharedNumEscalationYearsToProcess
 
 	if xlsxDataSheetNum != sheetIndex {
 		return nil, fmt.Errorf("parseOconusToConusPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
@@ -123,29 +104,26 @@ var parseOconusToConusPrices processXlsxSheet = func(params ParamConfig, sheetIn
 	dataRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[feeRowIndexStart:]
 	for _, row := range dataRows {
 		colIndex := feeColIndexStart
-		// For number of baseline + Escalation years
-		for escalation := 0; escalation < numEscalationYearsToProcess; escalation++ {
-			// For each Rate Season
-			for _, r := range rateSeasons {
-				oconusToConusPrice := models.StageOconusToConusPrice{
-					OriginIntlPriceAreaID:            getCell(row.Cells, originIntlPriceAreaIDColumn),
-					OriginIntlPriceArea:              getCell(row.Cells, originIntlPriceAreaColumn),
-					DestinationDomesticPriceAreaCode: getCell(row.Cells, destinationDomesticPriceAreaCodeColumn),
-					DestinationDomesticPriceArea:     getCell(row.Cells, destinationDomesticPriceAreaColumn),
-					Season:                           r,
-				}
-
-				oconusToConusPrice.HHGShippingLinehaulPrice = getCell(row.Cells, colIndex)
-				colIndex++
-				oconusToConusPrice.UBPrice = getCell(row.Cells, colIndex)
-
-				if params.ShowOutput == true {
-					log.Printf("%v\n", oconusToConusPrice)
-				}
-				oconusToConusPrices = append(oconusToConusPrices, oconusToConusPrice)
-
-				colIndex += 2 // skip 1 column (empty column) before starting next Rate type
+		// For each Rate Season
+		for _, r := range rateSeasons {
+			oconusToConusPrice := models.StageOconusToConusPrice{
+				OriginIntlPriceAreaID:            getCell(row.Cells, originPriceAreaIDColumn),
+				OriginIntlPriceArea:              getCell(row.Cells, originPriceAreaColumn),
+				DestinationDomesticPriceAreaCode: getCell(row.Cells, destinationPriceAreaIDColumn),
+				DestinationDomesticPriceArea:     getCell(row.Cells, destinationPriceAreaColumn),
+				Season:                           r,
 			}
+
+			oconusToConusPrice.HHGShippingLinehaulPrice = getCell(row.Cells, colIndex)
+			colIndex++
+			oconusToConusPrice.UBPrice = getCell(row.Cells, colIndex)
+
+			if params.ShowOutput == true {
+				log.Printf("%v\n", oconusToConusPrice)
+			}
+			oconusToConusPrices = append(oconusToConusPrices, oconusToConusPrice)
+
+			colIndex += 2 // skip 1 column (empty column) before starting next Rate type
 		}
 	}
 	return oconusToConusPrices, nil
@@ -154,13 +132,6 @@ var parseOconusToConusPrices processXlsxSheet = func(params ParamConfig, sheetIn
 func verifyInternationalPrices(params ParamConfig, sheetIndex int, xlsxSheetNum int) error {
 	// XLSX Sheet consts
 	xlsxDataSheetNum := xlsxSheetNum
-	const feeColIndexStart int = 6  // start at column 6 to get the rates
-	const feeRowIndexStart int = 10 // start at row 10 to get the rates
-	const originPriceAreaIDColumn int = 2
-	const originPriceAreaColumn int = 3
-	const destinationPriceAreaIDColumn int = 4
-	const destinationPriceAreaColumn int = 5
-	const numEscalationYearsToProcess = sharedNumEscalationYearsToProcess
 
 	// Check headers
 	const headerIndexStart = feeRowIndexStart - 3
@@ -182,75 +153,69 @@ func verifyInternationalPrices(params ParamConfig, sheetIndex int, xlsxSheetNum 
 	repeatingRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[repeatingHeaderIndexStart:verifyHeaderIndexEnd2]
 	for dataRowsIndex, row := range dataRows {
 		colIndex := feeColIndexStart
-		// For number of baseline + Escalation years
-		for escalation := 0; escalation < numEscalationYearsToProcess; escalation++ {
-			// For each Rate Season
-			for _, r := range rateSeasons {
-				verificationLog := fmt.Sprintf(" , verfication for row index: %d, colIndex: %d, Escalation: %d, rateSeasons %v",
-					dataRowsIndex, colIndex, escalation, r)
+		// For each Rate Season
+		for _, r := range rateSeasons {
+			verificationLog := fmt.Sprintf(" , verfication for row index: %d, colIndex: %d, rateSeasons %v",
+				dataRowsIndex, colIndex, r)
 
-				if dataRowsIndex == 0 {
-					if xlsxSheetNum == 10 {
-						if "OriginIntlPriceAreaID" != removeWhiteSpace(getCell(row.Cells, originPriceAreaIDColumn)) {
-							return fmt.Errorf("format error: Header <OriginIntlPriceAreaID> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, originPriceAreaIDColumn)), verificationLog)
-						}
-						if "OriginIntlPriceArea(PPIRA)" != removeWhiteSpace(getCell(row.Cells, originPriceAreaColumn)) {
-							return fmt.Errorf("format error: Header <OriginIntlPriceArea(PPIRA)> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, originPriceAreaColumn)), verificationLog)
-						}
-						if "DestinationIntlPriceAreaID" != removeWhiteSpace(getCell(row.Cells, destinationPriceAreaIDColumn)) {
-							return fmt.Errorf("format error: Header <DestinationIntlPriceAreaID> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, destinationPriceAreaIDColumn)), verificationLog)
-						}
-
-						if "DestinationIntlPriceArea(PPIRA)" != removeWhiteSpace(getCell(row.Cells, destinationPriceAreaColumn)) {
-							return fmt.Errorf("format error: Header <DestinationIntlPriceArea(PPIRA)> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, destinationPriceAreaColumn)), verificationLog)
-						}
+			if dataRowsIndex == 0 {
+				if xlsxSheetNum == 10 {
+					if "OriginIntlPriceAreaID" != removeWhiteSpace(getCell(row.Cells, originPriceAreaIDColumn)) {
+						return fmt.Errorf("format error: Header <OriginIntlPriceAreaID> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, originPriceAreaIDColumn)), verificationLog)
 					}
-
-					if xlsxSheetNum == 11 {
-						if "OriginDomesticPriceAreaCode" != removeWhiteSpace(getCell(row.Cells, originPriceAreaIDColumn)) {
-							return fmt.Errorf("format error: Header <OriginDomesticPriceAreaCode> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, originPriceAreaIDColumn)), verificationLog)
-						}
-						if "OriginDomesticPriceArea(PPDRA)" != removeWhiteSpace(getCell(row.Cells, originPriceAreaColumn)) {
-							return fmt.Errorf("format error: Header <OriginDomesticPriceArea(PPDRA)> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, originPriceAreaColumn)), verificationLog)
-						}
-						if "DestinationIntlPriceAreaID" != removeWhiteSpace(getCell(row.Cells, destinationPriceAreaIDColumn)) {
-							return fmt.Errorf("format error: Header <DestinationIntlPriceAreaID> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, destinationPriceAreaIDColumn)), verificationLog)
-						}
-
-						if "DestinationIntlPriceArea(PPIRA)" != removeWhiteSpace(getCell(row.Cells, destinationPriceAreaColumn)) {
-							return fmt.Errorf("format error: Header <DestinationIntlPriceArea(PPIRA)> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, destinationPriceAreaColumn)), verificationLog)
-						}
+					if "OriginIntlPriceArea(PPIRA)" != removeWhiteSpace(getCell(row.Cells, originPriceAreaColumn)) {
+						return fmt.Errorf("format error: Header <OriginIntlPriceArea(PPIRA)> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, originPriceAreaColumn)), verificationLog)
 					}
-
-					if xlsxSheetNum == 12 {
-						if "OriginIntlPriceAreaID" != removeWhiteSpace(getCell(row.Cells, originPriceAreaIDColumn)) {
-							return fmt.Errorf("format error: Header <OriginIntlPriceAreaID> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, originPriceAreaIDColumn)), verificationLog)
-						}
-						if "OriginInternationalPriceArea(PPIRA)" != removeWhiteSpace(getCell(row.Cells, originPriceAreaColumn)) {
-							return fmt.Errorf("format error: Header <OriginInternationalPriceArea(PPIRA)> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, originPriceAreaColumn)), verificationLog)
-						}
-						if "DestinationDomesticPriceAreaCode" != removeWhiteSpace(getCell(row.Cells, destinationPriceAreaIDColumn)) {
-							return fmt.Errorf("format error: Header <DestinationDomesticPriceAreaCode> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, destinationPriceAreaIDColumn)), verificationLog)
-						}
-
-						if "DestinationDomesticPriceArea(PPDRA)" != removeWhiteSpace(getCell(row.Cells, destinationPriceAreaColumn)) {
-							return fmt.Errorf("format error: Header <DestinationDomesticPriceArea(PPDRA)> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, destinationPriceAreaColumn)), verificationLog)
-						}
+					if "DestinationIntlPriceAreaID" != removeWhiteSpace(getCell(row.Cells, destinationPriceAreaIDColumn)) {
+						return fmt.Errorf("format error: Header <DestinationIntlPriceAreaID> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, destinationPriceAreaIDColumn)), verificationLog)
 					}
+					if "DestinationIntlPriceArea(PPIRA)" != removeWhiteSpace(getCell(row.Cells, destinationPriceAreaColumn)) {
+						return fmt.Errorf("format error: Header <DestinationIntlPriceArea(PPIRA)> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, destinationPriceAreaColumn)), verificationLog)
+					}
+				}
 
-					for repeatingRowsIndex, row := range repeatingRows {
-						if repeatingRowsIndex == 0 {
-							colIndex := feeColIndexStart
-							for _, repeatingHeader := range repeatingHeaders {
-								if removeWhiteSpace(repeatingHeader) != removeWhiteSpace(getCell(row.Cells, colIndex)) {
-									return fmt.Errorf("format error: Header contains <%s> is missing got <%s> instead\n%s", removeWhiteSpace(repeatingHeader), removeWhiteSpace(getCell(row.Cells, colIndex)), verificationLog)
-								}
-								colIndex++
+				if xlsxSheetNum == 11 {
+					if "OriginDomesticPriceAreaCode" != removeWhiteSpace(getCell(row.Cells, originPriceAreaIDColumn)) {
+						return fmt.Errorf("format error: Header <OriginDomesticPriceAreaCode> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, originPriceAreaIDColumn)), verificationLog)
+					}
+					if "OriginDomesticPriceArea(PPDRA)" != removeWhiteSpace(getCell(row.Cells, originPriceAreaColumn)) {
+						return fmt.Errorf("format error: Header <OriginDomesticPriceArea(PPDRA)> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, originPriceAreaColumn)), verificationLog)
+					}
+					if "DestinationIntlPriceAreaID" != removeWhiteSpace(getCell(row.Cells, destinationPriceAreaIDColumn)) {
+						return fmt.Errorf("format error: Header <DestinationIntlPriceAreaID> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, destinationPriceAreaIDColumn)), verificationLog)
+					}
+					if "DestinationIntlPriceArea(PPIRA)" != removeWhiteSpace(getCell(row.Cells, destinationPriceAreaColumn)) {
+						return fmt.Errorf("format error: Header <DestinationIntlPriceArea(PPIRA)> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, destinationPriceAreaColumn)), verificationLog)
+					}
+				}
+
+				if xlsxSheetNum == 12 {
+					if "OriginIntlPriceAreaID" != removeWhiteSpace(getCell(row.Cells, originPriceAreaIDColumn)) {
+						return fmt.Errorf("format error: Header <OriginIntlPriceAreaID> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, originPriceAreaIDColumn)), verificationLog)
+					}
+					if "OriginInternationalPriceArea(PPIRA)" != removeWhiteSpace(getCell(row.Cells, originPriceAreaColumn)) {
+						return fmt.Errorf("format error: Header <OriginInternationalPriceArea(PPIRA)> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, originPriceAreaColumn)), verificationLog)
+					}
+					if "DestinationDomesticPriceAreaCode" != removeWhiteSpace(getCell(row.Cells, destinationPriceAreaIDColumn)) {
+						return fmt.Errorf("format error: Header <DestinationDomesticPriceAreaCode> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, destinationPriceAreaIDColumn)), verificationLog)
+					}
+					if "DestinationDomesticPriceArea(PPDRA)" != removeWhiteSpace(getCell(row.Cells, destinationPriceAreaColumn)) {
+						return fmt.Errorf("format error: Header <DestinationDomesticPriceArea(PPDRA)> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, destinationPriceAreaColumn)), verificationLog)
+					}
+				}
+
+				for repeatingRowsIndex, row := range repeatingRows {
+					if repeatingRowsIndex == 0 {
+						colIndex := feeColIndexStart
+						for _, repeatingHeader := range repeatingHeaders {
+							if removeWhiteSpace(repeatingHeader) != removeWhiteSpace(getCell(row.Cells, colIndex)) {
+								return fmt.Errorf("format error: Header contains <%s> is missing got <%s> instead\n%s", removeWhiteSpace(repeatingHeader), removeWhiteSpace(getCell(row.Cells, colIndex)), verificationLog)
 							}
-						} else if dataRowsIndex == 1 {
-							if "EXAMPLE" != removeWhiteSpace(getCell(row.Cells, originPriceAreaColumn)) {
-								return fmt.Errorf("format error: Filler text <EXAMPLE> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, originPriceAreaColumn)), verificationLog)
-							}
+							colIndex++
+						}
+					} else if dataRowsIndex == 1 {
+						if "EXAMPLE" != removeWhiteSpace(getCell(row.Cells, originPriceAreaColumn)) {
+							return fmt.Errorf("format error: Filler text <EXAMPLE> is missing got <%s> instead\n%s", removeWhiteSpace(getCell(row.Cells, originPriceAreaColumn)), verificationLog)
 						}
 					}
 				}

--- a/pkg/parser/pricing/parse_international_prices_test.go
+++ b/pkg/parser/pricing/parse_international_prices_test.go
@@ -2,11 +2,12 @@ package pricing
 
 import (
 	"strconv"
+	"testing"
 	"time"
 )
 
 // Test_parseOconusToOconusPrices
-func (suite *PricingParserSuite) Test_parseOconusToOconusPrices() {
+func (suite *PricingParserSuite) Test_OconusToOconusPrices() {
 	const sheetIndex = 10
 	xlsxDataSheets := InitDataSheetInfo()
 	dataSheet := xlsxDataSheets[sheetIndex]
@@ -21,19 +22,40 @@ func (suite *PricingParserSuite) Test_parseOconusToOconusPrices() {
 		XlsxFile:     suite.xlsxFile,
 		RunVerify:    true,
 	}
+	suite.T().Run("parse oconusToOconus prices", func(t *testing.T) {
+		slice, err := parseOconusToOconusPrices(params, sheetIndex)
+		suite.NoError(err, "parseOconusToOconusPrices function failed")
 
-	slice, err := parseOconusToOconusPrices(params, sheetIndex)
-	suite.NoError(err, "parseOconusToOconusPrices function failed")
+		outputFilename := dataSheet.generateOutputFilename(sheetIndex, params.RunTime, nil)
+		err = createCSV(outputFilename, slice)
+		suite.NoError(err, "could not create CSV")
 
-	outputFilename := dataSheet.generateOutputFilename(sheetIndex, params.RunTime, nil)
-	err = createCSV(outputFilename, slice)
-	suite.NoError(err, "could not create CSV")
+		const goldenFilename string = "10_3a_oconus_to_oconus_prices_golden.csv"
+		suite.helperTestExpectedFileOutput(goldenFilename, outputFilename)
+	})
 
-	const goldenFilename string = "10_3a_oconus_to_oconus_prices_golden.csv"
-	suite.helperTestExpectedFileOutput(goldenFilename, outputFilename)
+	suite.T().Run("attempt to parse oconusToOconus prices with incorrect sheet index", func(t *testing.T) {
+		_, err := parseOconusToOconusPrices(params, 7)
+		if suite.Error(err) {
+			suite.Equal("parseOconusToOconusPrices expected to process sheet 10, but received sheetIndex 7", err.Error())
+		}
+	})
+
+	suite.T().Run("verify oconusToOconus prices", func(t *testing.T) {
+		err := verifyIntlOconusToOconusPrices(params, sheetIndex)
+		suite.NoError(err, "verifyIntlOconusToOconusPrices failed")
+	})
+
+	suite.T().Run("attempt to verify oconusToOconus prices with incorrect sheet index", func(t *testing.T) {
+		err := verifyIntlOconusToOconusPrices(params, 7)
+		if suite.Error(err) {
+			suite.Equal("verifyOconusToOconusPrices expected to process sheet 10, but received sheetIndex 7", err.Error())
+		}
+	})
 }
 
-func (suite *PricingParserSuite) Test_parseConusToOconusPrices() {
+// Test_parseConusToOconusPrices
+func (suite *PricingParserSuite) Test_ConusToOconusPrices() {
 	const sheetIndex = 11
 	xlsxDataSheets := InitDataSheetInfo()
 	dataSheet := xlsxDataSheets[sheetIndex]
@@ -48,19 +70,40 @@ func (suite *PricingParserSuite) Test_parseConusToOconusPrices() {
 		XlsxFile:     suite.xlsxFile,
 		RunVerify:    true,
 	}
+	suite.T().Run("parse conusToOconus prices", func(t *testing.T) {
+		slice, err := parseConusToOconusPrices(params, sheetIndex)
+		suite.NoError(err, "parseConusToOconusPrices function failed")
 
-	slice, err := parseConusToOconusPrices(params, sheetIndex)
-	suite.NoError(err, "parseConusToOconusPrices function failed")
+		outputFilename := dataSheet.generateOutputFilename(sheetIndex, params.RunTime, nil)
+		err = createCSV(outputFilename, slice)
+		suite.NoError(err, "could not create CSV")
 
-	outputFilename := dataSheet.generateOutputFilename(sheetIndex, params.RunTime, nil)
-	err = createCSV(outputFilename, slice)
-	suite.NoError(err, "could not create CSV")
+		const goldenFilename string = "10_3b_conus_to_oconus_prices_golden.csv"
+		suite.helperTestExpectedFileOutput(goldenFilename, outputFilename)
+	})
 
-	const goldenFilename string = "11_3b_conus_to_oconus_prices_golden.csv"
-	suite.helperTestExpectedFileOutput(goldenFilename, outputFilename)
+	suite.T().Run("attempt to parse conusToOconus prices with incorrect sheet index", func(t *testing.T) {
+		_, err := parseConusToOconusPrices(params, 7)
+		if suite.Error(err) {
+			suite.Equal("parseConusToOconusPrices expected to process sheet 11, but received sheetIndex 7", err.Error())
+		}
+	})
+
+	suite.T().Run("verify conusToOconus prices", func(t *testing.T) {
+		err := verifyIntlConusToOconusPrices(params, sheetIndex)
+		suite.NoError(err, "verifyIntlConusToOconusPrices failed")
+	})
+
+	suite.T().Run("attempt to verify conusToOconus prices with incorrect sheet index", func(t *testing.T) {
+		err := verifyIntlConusToOconusPrices(params, 7)
+		if suite.Error(err) {
+			suite.Equal("verifyConusToOconusPrices expected to process sheet 10, but received sheetIndex 7", err.Error())
+		}
+	})
 }
 
-func (suite *PricingParserSuite) Test_parseOconusToConusPrices() {
+// Test_parseOconusToConusPrices
+func (suite *PricingParserSuite) Test_OconusToConusPrices() {
 	const sheetIndex = 12
 	xlsxDataSheets := InitDataSheetInfo()
 	dataSheet := xlsxDataSheets[sheetIndex]
@@ -75,14 +118,34 @@ func (suite *PricingParserSuite) Test_parseOconusToConusPrices() {
 		XlsxFile:     suite.xlsxFile,
 		RunVerify:    true,
 	}
+	suite.T().Run("parse oconusToConus prices", func(t *testing.T) {
+		slice, err := parseOconusToConusPrices(params, sheetIndex)
+		suite.NoError(err, "parseOconusToConusPrices function failed")
 
-	slice, err := parseOconusToConusPrices(params, sheetIndex)
-	suite.NoError(err, "parseOconusToConusPrices function failed")
+		outputFilename := dataSheet.generateOutputFilename(sheetIndex, params.RunTime, nil)
+		err = createCSV(outputFilename, slice)
+		suite.NoError(err, "could not create CSV")
 
-	outputFilename := dataSheet.generateOutputFilename(sheetIndex, params.RunTime, nil)
-	err = createCSV(outputFilename, slice)
-	suite.NoError(err, "could not create CSV")
+		const goldenFilename string = "10_3c_oconus_to_conus_prices_golden.csv"
+		suite.helperTestExpectedFileOutput(goldenFilename, outputFilename)
+	})
 
-	const goldenFilename string = "12_3c_oconus_to_conus_prices_golden.csv"
-	suite.helperTestExpectedFileOutput(goldenFilename, outputFilename)
+	suite.T().Run("attempt to parse oconusToConus prices with incorrect sheet index", func(t *testing.T) {
+		_, err := parseOconusToConusPrices(params, 7)
+		if suite.Error(err) {
+			suite.Equal("parseOconusToConusPrices expected to process sheet 12, but received sheetIndex 7", err.Error())
+		}
+	})
+
+	suite.T().Run("verify oconusToConus prices", func(t *testing.T) {
+		err := verifyIntlOconusToConusPrices(params, sheetIndex)
+		suite.NoError(err, "verifyIntlOconusToConusPrices failed")
+	})
+
+	suite.T().Run("attempt to verify oconusToConus prices with incorrect sheet index", func(t *testing.T) {
+		err := verifyIntlOconusToConusPrices(params, 7)
+		if suite.Error(err) {
+			suite.Equal("verifyOconusToConusPrices expected to process sheet 10, but received sheetIndex 7", err.Error())
+		}
+	})
 }

--- a/pkg/parser/pricing/parse_international_prices_test.go
+++ b/pkg/parser/pricing/parse_international_prices_test.go
@@ -1,0 +1,88 @@
+package pricing
+
+import (
+	"strconv"
+	"time"
+)
+
+// Test_parseOconusToOconusPrices
+func (suite *PricingParserSuite) Test_parseOconusToOconusPrices() {
+	const sheetIndex = 10
+	xlsxDataSheets := InitDataSheetInfo()
+	dataSheet := xlsxDataSheets[sheetIndex]
+
+	params := ParamConfig{
+		ProcessAll:   false,
+		ShowOutput:   false,
+		XlsxFilename: suite.xlsxFilename,
+		XlsxSheets:   []string{strconv.Itoa(sheetIndex)},
+		SaveToFile:   true,
+		RunTime:      time.Now(),
+		XlsxFile:     suite.xlsxFile,
+		RunVerify:    true,
+	}
+
+	slice, err := parseOconusToOconusPrices(params, sheetIndex)
+	suite.NoError(err, "parseOconusToOconusPrices function failed")
+
+	outputFilename := dataSheet.generateOutputFilename(sheetIndex, params.RunTime, nil)
+	err = createCSV(outputFilename, slice)
+	suite.NoError(err, "could not create CSV")
+
+	const goldenFilename string = "10_3a_oconus_to_oconus_prices_golden.csv"
+	suite.helperTestExpectedFileOutput(goldenFilename, outputFilename)
+}
+
+func (suite *PricingParserSuite) Test_parseConusToOconusPrices() {
+	const sheetIndex = 11
+	xlsxDataSheets := InitDataSheetInfo()
+	dataSheet := xlsxDataSheets[sheetIndex]
+
+	params := ParamConfig{
+		ProcessAll:   false,
+		ShowOutput:   false,
+		XlsxFilename: suite.xlsxFilename,
+		XlsxSheets:   []string{strconv.Itoa(sheetIndex)},
+		SaveToFile:   true,
+		RunTime:      time.Now(),
+		XlsxFile:     suite.xlsxFile,
+		RunVerify:    true,
+	}
+
+	slice, err := parseConusToOconusPrices(params, sheetIndex)
+	suite.NoError(err, "parseConusToOconusPrices function failed")
+
+	outputFilename := dataSheet.generateOutputFilename(sheetIndex, params.RunTime, nil)
+	err = createCSV(outputFilename, slice)
+	suite.NoError(err, "could not create CSV")
+
+	const goldenFilename string = "11_3b_conus_to_oconus_prices_golden.csv"
+	suite.helperTestExpectedFileOutput(goldenFilename, outputFilename)
+}
+
+func (suite *PricingParserSuite) Test_parseOconusToConusPrices() {
+	const sheetIndex = 12
+	xlsxDataSheets := InitDataSheetInfo()
+	dataSheet := xlsxDataSheets[sheetIndex]
+
+	params := ParamConfig{
+		ProcessAll:   false,
+		ShowOutput:   false,
+		XlsxFilename: suite.xlsxFilename,
+		XlsxSheets:   []string{strconv.Itoa(sheetIndex)},
+		SaveToFile:   true,
+		RunTime:      time.Now(),
+		XlsxFile:     suite.xlsxFile,
+		RunVerify:    true,
+	}
+
+	slice, err := parseOconusToConusPrices(params, sheetIndex)
+	suite.NoError(err, "parseOconusToConusPrices function failed")
+
+	outputFilename := dataSheet.generateOutputFilename(sheetIndex, params.RunTime, nil)
+	err = createCSV(outputFilename, slice)
+	suite.NoError(err, "could not create CSV")
+
+	const goldenFilename string = "12_3c_oconus_to_conus_prices_golden.csv"
+	suite.helperTestExpectedFileOutput(goldenFilename, outputFilename)
+}

--- a/pkg/parser/pricing/parse_international_prices_test.go
+++ b/pkg/parser/pricing/parse_international_prices_test.go
@@ -78,7 +78,7 @@ func (suite *PricingParserSuite) Test_ConusToOconusPrices() {
 		err = createCSV(outputFilename, slice)
 		suite.NoError(err, "could not create CSV")
 
-		const goldenFilename string = "10_3b_conus_to_oconus_prices_golden.csv"
+		const goldenFilename string = "11_3b_conus_to_oconus_prices_golden.csv"
 		suite.helperTestExpectedFileOutput(goldenFilename, outputFilename)
 	})
 
@@ -126,7 +126,7 @@ func (suite *PricingParserSuite) Test_OconusToConusPrices() {
 		err = createCSV(outputFilename, slice)
 		suite.NoError(err, "could not create CSV")
 
-		const goldenFilename string = "10_3c_oconus_to_conus_prices_golden.csv"
+		const goldenFilename string = "12_3c_oconus_to_conus_prices_golden.csv"
 		suite.helperTestExpectedFileOutput(goldenFilename, outputFilename)
 	})
 

--- a/pkg/parser/pricing/parse_international_prices_test.go
+++ b/pkg/parser/pricing/parse_international_prices_test.go
@@ -49,7 +49,7 @@ func (suite *PricingParserSuite) Test_OconusToOconusPrices() {
 	suite.T().Run("attempt to verify oconusToOconus prices with incorrect sheet index", func(t *testing.T) {
 		err := verifyIntlOconusToOconusPrices(params, 7)
 		if suite.Error(err) {
-			suite.Equal("verifyOconusToOconusPrices expected to process sheet 10, but received sheetIndex 7", err.Error())
+			suite.Equal("verifyInternationalPrices expected to process sheet 10, but received sheetIndex 7", err.Error())
 		}
 	})
 }
@@ -97,7 +97,7 @@ func (suite *PricingParserSuite) Test_ConusToOconusPrices() {
 	suite.T().Run("attempt to verify conusToOconus prices with incorrect sheet index", func(t *testing.T) {
 		err := verifyIntlConusToOconusPrices(params, 7)
 		if suite.Error(err) {
-			suite.Equal("verifyConusToOconusPrices expected to process sheet 10, but received sheetIndex 7", err.Error())
+			suite.Equal("verifyInternationalPrices expected to process sheet 11, but received sheetIndex 7", err.Error())
 		}
 	})
 }
@@ -145,7 +145,7 @@ func (suite *PricingParserSuite) Test_OconusToConusPrices() {
 	suite.T().Run("attempt to verify oconusToConus prices with incorrect sheet index", func(t *testing.T) {
 		err := verifyIntlOconusToConusPrices(params, 7)
 		if suite.Error(err) {
-			suite.Equal("verifyOconusToConusPrices expected to process sheet 10, but received sheetIndex 7", err.Error())
+			suite.Equal("verifyInternationalPrices expected to process sheet 12, but received sheetIndex 7", err.Error())
 		}
 	})
 }


### PR DESCRIPTION
## Description

This parses the pricing spreadsheet international pricing tabs (3a, 3b, 3c).

## Reviewer Notes

3a, 3b, and 3c contain similar data. The only real difference is that the headers are named differently. So, I created a struct for each tab and then use that in the separate parse functions. The verify all happens in one function, and then gets called in individual functions to account for the different tab numbers. 

I'm wondering if I should instead break each tab into it's own file, with individual parse and verify functions. I could see how that might read better. Curious what people's thoughts are on this.

## Setup

To build:
`make clean bin/ghc-pricing-parser`

To run (the `--save` creates CSV files; use `--help` for more options):
`ghc-pricing-parser --filename <path_to_pricing_template> --save`

To run tests:
`go test ./pkg/parser/pricing/`

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/169374862) for this change