### PR TITLE
Fix query builder test expectation

### DIFF
--- a/pkg/services/query/query_builder_test.go
+++ b/pkg/services/query/query_builder_test.go
@@ -178,7 +178,7 @@ func (suite *QueryBuilderSuite) TestFetchMany() {
 		pop.Debug = false
 
 		suite.NoError(err)
-		suite.Len(actualUsers, 2)
+		suite.Len(actualUsers, 4)
 	})
 
 	suite.T().Run("fetches many with time sort desc", func(t *testing.T) {


### PR DESCRIPTION
I'm pretty sure updating this expectation is expecting the correct behavior now, but I'm going to check into that while allowing this to fix master.