### PR TITLE
Regenerate assets.go file

### DIFF
--- a/pkg/assets/assets.go
+++ b/pkg/assets/assets.go
@@ -457,26 +457,16 @@ var _bindata = map[string]func() (*asset, error){
 	"pkg/paperwork/formtemplates/shipment_summary_worksheet_page1.png": pkgPaperworkFormtemplatesShipment_summary_worksheet_page1Png,
 	"pkg/paperwork/formtemplates/shipment_summary_worksheet_page2.png": pkgPaperworkFormtemplatesShipment_summary_worksheet_page2Png,
 	"pkg/paperwork/formtemplates/shipment_summary_worksheet_page3.png": pkgPaperworkFormtemplatesShipment_summary_worksheet_page3Png,
-
-	"pkg/notifications/templates/move_approved_template.html": pkgNotificationsTemplatesMove_approved_templateHtml,
-
-	"pkg/notifications/templates/move_approved_template.txt": pkgNotificationsTemplatesMove_approved_templateTxt,
-
-	"pkg/notifications/templates/move_canceled_template.html": pkgNotificationsTemplatesMove_canceled_templateHtml,
-
-	"pkg/notifications/templates/move_canceled_template.txt": pkgNotificationsTemplatesMove_canceled_templateTxt,
-
-	"pkg/notifications/templates/move_payment_reminder_template.html": pkgNotificationsTemplatesMove_payment_reminder_templateHtml,
-
-	"pkg/notifications/templates/move_payment_reminder_template.txt": pkgNotificationsTemplatesMove_payment_reminder_templateTxt,
-
-	"pkg/notifications/templates/move_reviewed_template.html": pkgNotificationsTemplatesMove_reviewed_templateHtml,
-
-	"pkg/notifications/templates/move_reviewed_template.txt": pkgNotificationsTemplatesMove_reviewed_templateTxt,
-
-	"pkg/notifications/templates/move_submitted_template.html": pkgNotificationsTemplatesMove_submitted_templateHtml,
-
-	"pkg/notifications/templates/move_submitted_template.txt": pkgNotificationsTemplatesMove_submitted_templateTxt,
+	"pkg/notifications/templates/move_approved_template.html":          pkgNotificationsTemplatesMove_approved_templateHtml,
+	"pkg/notifications/templates/move_approved_template.txt":           pkgNotificationsTemplatesMove_approved_templateTxt,
+	"pkg/notifications/templates/move_canceled_template.html":          pkgNotificationsTemplatesMove_canceled_templateHtml,
+	"pkg/notifications/templates/move_canceled_template.txt":           pkgNotificationsTemplatesMove_canceled_templateTxt,
+	"pkg/notifications/templates/move_payment_reminder_template.html":  pkgNotificationsTemplatesMove_payment_reminder_templateHtml,
+	"pkg/notifications/templates/move_payment_reminder_template.txt":   pkgNotificationsTemplatesMove_payment_reminder_templateTxt,
+	"pkg/notifications/templates/move_reviewed_template.html":          pkgNotificationsTemplatesMove_reviewed_templateHtml,
+	"pkg/notifications/templates/move_reviewed_template.txt":           pkgNotificationsTemplatesMove_reviewed_templateTxt,
+	"pkg/notifications/templates/move_submitted_template.html":         pkgNotificationsTemplatesMove_submitted_templateHtml,
+	"pkg/notifications/templates/move_submitted_template.txt":          pkgNotificationsTemplatesMove_submitted_templateTxt,
 }
 
 // AssetDir returns the file names below a certain


### PR DESCRIPTION
## Description

It looks like our generated `assets.go` file reverted back to some old formatting (based on an earlier `go-bindata` version) in #2891.  We fixed the formatting in #2888 and put a version check for `go-bindata` in with #2889, so all this stuff landed about the same time.  I was getting a local diff on this, so this PR just regenerates the file with a recent `go-bindata` version.

## Setup

Do a `make clean server_generate` and verify that `git status` shows no local changes.

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
