### PR TITLE
Modify the if statement placement for the github action

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -4,9 +4,9 @@ on: pull_request
 jobs:
   approve:
     name: Auto-approve dependabot PRs
-    if: github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: hmarr/auto-approve-action@v2.0.0
+        if: github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
## Description

I was looking at the Action repo https://github.com/hmarr/auto-approve-action and noticed the `if` statement was paired with the step and not the action. I'm wondering if this means it will stop running on non-dependabot branches. Figured it was worth a try.

The original PR https://github.com/transcom/mymove/pull/2919