### PR TITLE
Add go tidy github action

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -2,7 +2,7 @@ name: auto approve
 on:
   pull_request:
     paths-ignore:
-      - '.github/workflows/gosum.yml'
+      - '.github/workflows/go-auto-approve.yml'
       - 'go.mod'
       - 'go.sum'
 

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -1,12 +1,18 @@
-name: Auto approve
-on: pull_request
+name: auto approve
+on:
+  pull_request:
+    paths-ignore:
+      - '.github/workflows/gosum.yml'
+      - 'go.mod'
+      - 'go.sum'
 
 jobs:
   approve:
-    name: Auto-approve dependabot PRs
-    if: github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'
+    name: auto-approve dependabot PRs
     runs-on: ubuntu-latest
     steps:
-      - uses: hmarr/auto-approve-action@v2.0.0
+      - name: approve
+        uses: hmarr/auto-approve-action@v2.0.0
+        if: github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/go-auto-approve.yml
+++ b/.github/workflows/go-auto-approve.yml
@@ -1,0 +1,57 @@
+name: auto approve and tidy
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/gosum.yml'
+      - 'go.mod'
+      - 'go.sum'
+
+# job level conditions don't seem to work at the moment
+# https://github.community/t5/GitHub-Actions/Status-of-workflows-with-no-running-jobs/td-p/37160
+# which is why github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]' is
+# repeated over and over
+jobs:
+  tidy:
+    name: run go mod tidy and updated
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v1
+        if: github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'
+      - name: reattach HEAD to Head Ref
+        run: git checkout "$(echo ${{ github.head_ref }} | sed -E 's|refs/[a-zA-Z]+/||')"
+        if: github.head_ref != '' && (github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]')
+      - name: reattach HEAD to Ref
+        run: git checkout "$(echo ${{ github.ref }} | sed -E 's|refs/[a-zA-Z]+/||')"
+        if: github.head_ref == '' && (github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]')
+      - name: Tidy
+        run: |
+          rm -f go.sum
+          go mod tidy
+        if: github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'
+      - name: set up Git
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config user.name "${GITHUB_ACTOR}"
+          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+          git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
+        if: github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'
+      - name: commit and push changes
+        run: |
+          git add .
+          if output=$(git status --porcelain) && [ ! -z "$output" ]; then
+            git commit -m 'Fix go modules'
+            git push
+          fi
+        if: github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'
+  approve:
+    name: auto-approve dependabot PRs
+    runs-on: ubuntu-latest
+    needs: [tidy]
+    steps:
+      - name: approve
+        uses: hmarr/auto-approve-action@v2.0.0
+        if: github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/go-auto-approve.yml
+++ b/.github/workflows/go-auto-approve.yml
@@ -20,11 +20,8 @@ jobs:
         if: github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'
       - name: reattach HEAD to Head Ref
         # b/c checkout action leaves in detached head state https://github.com/actions/checkout/issues/6
-        run: git checkout "$(echo ${{ github.head_ref }} | sed -E 's|refs/[a-zA-Z]+/||')"
+        run: git checkout "$(echo ${{ github.head_ref }})"
         if: github.head_ref != '' && (github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]')
-      - name: reattach HEAD to Ref
-        run: git checkout "$(echo ${{ github.ref }} | sed -E 's|refs/[a-zA-Z]+/||')"
-        if: github.head_ref == '' && (github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]')
       - name: Tidy
         run: |
           rm -f go.sum


### PR DESCRIPTION
## Description

Dependabot doesn't currently run `go mod tidy` after dependancies are updated https://github.com/dependabot/feedback/issues/215. This PR adds a separate github action specifically for `go` dependabot updates (based on https://github.com/dependabot/feedback/issues/215#issuecomment-550299541). 

## Reviewer Notes

* The checkout GH action leaves the branch in a detached HEAD state, so there's a section of the workflow to [fix this](https://github.com/transcom/mymove/compare/mk-add-go-tidy-gh-action?expand=1#diff-163fa0b12e0273bdbbf70b960c7b9030R21-R27). I had gotten that bit from the issue, but it seemed like it could maybe be simplified to `git checkout "$(echo ${{ github.head_ref }}"`, but was hoping to get a 2nd set of eyes on that part and maybe talk it through.
*  ideally the repetition of `github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'` wouldn't be needed. github actions seem to support [job level conditionals](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idif), but we've had issues with `job` level conditionals generating failures ([which seems like it might be a bug]( https://github.community/t5/GitHub-Actions/Status-of-workflows-with-no-running-jobs/td-p/37160)) when the `if` condition is not met.
* Also, not quite sure the best way to test these. I've been testing against a separate repo https://github.com/mkrump/depupdate-test where I was manually reverting the version and then forcing dependabot to run again.
