### PR TITLE
[DRAFT-DELETE] starting to import rate area information

### DIFF
--- a/pkg/models/re_rate_area.go
+++ b/pkg/models/re_rate_area.go
@@ -30,3 +30,24 @@ func (r *ReRateArea) Validate(tx *pop.Connection) (*validate.Errors, error) {
 		&validators.StringIsPresent{Field: r.Name, Name: "Name"},
 	), nil
 }
+
+// FetchReRateAreaItem returns an area for a matching code
+func FetchReRateAreaItem(tx *pop.Connection, code string) (*ReRateArea, error) {
+	var area ReRateArea
+	query := `
+		SELECT * from re_rate_area
+		WHERE
+			code = $1
+	`
+	err := tx.RawQuery(query, code).First(&area)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if area.Code == code {
+		return &area, err
+	}
+
+	return nil, err
+}

--- a/pkg/services/ghcimport/import_re_rate_areas.go
+++ b/pkg/services/ghcimport/import_re_rate_areas.go
@@ -1,6 +1,11 @@
 package ghcimport
 
-import "github.com/gobuffalo/pop"
+import (
+	"github.com/gobuffalo/pop"
+	"github.com/pkg/errors"
+
+	"github.com/transcom/mymove/pkg/models"
+)
 
 type RERateAreasImporter struct {
 	db     *pop.Connection
@@ -8,9 +13,121 @@ type RERateAreasImporter struct {
 }
 
 func (re RERateAreasImporter) Import() error {
+
+	err := re.importDomesticRateAreas()
+	if err != nil {
+		return err
+	}
+
+	err = re.importInternationalRateAreas()
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 
 func (re RERateAreasImporter) Description() string {
 	return "re_rate_area importer"
+}
+
+func (re RERateAreasImporter) importDomesticRateAreas() error {
+	return nil
+}
+
+func (re RERateAreasImporter) importInternationalRateAreas() error {
+
+	// models.StageInternationalServiceArea
+
+	var serviceAreas []models.StageInternationalServiceArea
+	/*
+			query :=
+				`select price_millicents, escalation_compounded
+		         from re_domestic_linehaul_prices dlp
+		         inner join re_contracts c on dlp.contract_id = c.id
+		         inner join re_contract_years cy on c.id = cy.contract_id
+		         inner join re_domestic_service_areas dsa on dlp.domestic_service_area_id = dsa.id
+		         where c.code = $1
+		         and $2 between cy.start_date and cy.end_date
+		         and dlp.is_peak_period = $3
+		         and $4 between dlp.weight_lower and dlp.weight_upper
+		         and $5 between dlp.miles_lower and dlp.miles_upper
+		         and dsa.service_area = $6;`
+			err := p.db.RawQuery(
+				query,
+				p.contractCode,
+				moveDate,
+				isPeakPeriod,
+				effectiveWeight,
+				distance,
+				serviceArea).First(&pe)
+	*/
+
+	query := `SELECT * FROM stage_international_service_areas`
+	err := re.db.RawQuery(query).All(&serviceAreas)
+	if err != nil {
+		return errors.Wrap(err, "")
+	}
+
+	var rateAreaExistMap map[string]bool
+	for _, sa := range serviceAreas {
+		if _, ok := rateAreaExistMap[sa.RateAreaID]; !ok {
+			// query for ReRateArea
+			rateArea, err := models.FetchReRateAreaItem(re.db, sa.RateAreaID)
+			if err != nil {
+				return errors.Wrapf(err, "Failed importing re_rate_area with code <%s>", sa.RateAreaID)
+			}
+			// if it does exist, compare and update information if different
+			if rateArea != nil {
+				update := false
+
+				if rateArea.IsOconus != true {
+					rateArea.IsOconus = true
+					update = true
+				}
+				if rateArea.Name != sa.RateArea {
+					rateArea.Name = sa.RateArea
+					update = true
+				}
+				if update {
+					verrs, err := re.db.ValidateAndSave(rateArea)
+					if err != nil || verrs.HasAny() {
+						var dbError string
+						if err != nil {
+							dbError = err.Error()
+						}
+						if verrs.HasAny() {
+							dbError = dbError + verrs.Error()
+						}
+						return errors.Wrapf(errors.New(dbError), "error saving ReRateArea with rate are ID: %s"+sa.RateAreaID)
+					}
+				}
+			}
+			// if it does not exist, insert into ReRateArea
+			if rateArea == nil {
+				// insert into re_rate_area
+				newRateArea := models.ReRateArea{
+					IsOconus: true,
+					Code:     sa.RateAreaID,
+					Name:     sa.RateArea,
+				}
+				verrs, err := re.db.ValidateAndCreate(&newRateArea)
+				if err != nil || verrs.HasAny() {
+					var dbError string
+					if err != nil {
+						dbError = err.Error()
+					}
+					if verrs.HasAny() {
+						dbError = dbError + verrs.Error()
+					}
+					return errors.Wrapf(errors.New(dbError), "error creating ReRateArea with rate are ID: %s"+sa.RateAreaID)
+				}
+
+				// add to map
+				rateAreaExistMap[rateArea.Code] = true
+			}
+		}
+	}
+
+	return nil
 }


### PR DESCRIPTION
## Description

scratch code delete branch

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
echo "Code goes here"
```

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/tree/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/tree/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/tree/master/docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
  * [ ] Secure migrations have been tested using `scripts/run-prod-migrations`
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](tbd) for this change
* [this article](tbd) explains more about the approach used.

## Screenshots

If this PR makes visible UI changes, an image of the finished UI can help reviewers and casual
observers understand the context of the changes. A before image is optional and
can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow instead of using multiple images. You may want to use GIPHY CAPTURE for this! 📸

_Please frame screenshots to show enough useful context but also highlight the affected regions._
