### PR TITLE
Update GHC parser to use transaction connection

### DIFF
--- a/pkg/parser/pricing/parse.go
+++ b/pkg/parser/pricing/parse.go
@@ -296,12 +296,12 @@ func InitDataSheetInfo() []XlsxDataSheetInfo {
 }
 
 func Parse(xlsxDataSheets []XlsxDataSheetInfo, params ParamConfig, db *pop.Connection, logger Logger) error {
-	tableFromSliceCreator := dbtools.NewTableFromSliceCreator(db, logger, params.UseTempTables, params.DropIfExists)
-
 	// Must be after processing config param
 	// Run the process function
 
-	err := db.Transaction(func(connection *pop.Connection) error {
+	err := db.Transaction(func(tx *pop.Connection) error {
+		tableFromSliceCreator := dbtools.NewTableFromSliceCreator(tx, logger, params.UseTempTables, params.DropIfExists)
+
 		if params.ProcessAll == true {
 			for i, x := range xlsxDataSheets {
 				if len(x.ProcessMethods) >= 1 {

--- a/pkg/services/dbtools/create_table_from_slice_test.go
+++ b/pkg/services/dbtools/create_table_from_slice_test.go
@@ -98,22 +98,22 @@ func (suite *DBToolsServiceSuite) TestCreateTableFromSlicePermTable() {
 }
 
 func (suite *DBToolsServiceSuite) TestCreateTableFromSliceWithinTransaction() {
-	suite.DB().Transaction(func(tx *pop.Connection) error {
-		tableFromSliceCreator := NewTableFromSliceCreator(tx, suite.logger, true, true)
-		suite.T().Run("create table from slice in a transaction", func(t *testing.T) {
+	suite.T().Run("create table from slice in a transaction", func(t *testing.T) {
+		suite.DB().Transaction(func(tx *pop.Connection) error {
+			tableFromSliceCreator := NewTableFromSliceCreator(tx, suite.logger, true, true)
 			err := tableFromSliceCreator.CreateTableFromSlice(validSlice)
 			suite.NoError(err)
+
+			var testStructs []TestStruct
+			err = tx.Order("name").All(&testStructs)
+			suite.NoError(err)
+			suite.Len(testStructs, 3)
+			for i, testStruct := range testStructs {
+				suite.Equal(validSlice[i], testStruct)
+			}
+			return nil
 		})
 
-		var testStructs []TestStruct
-		err := tx.Order("name").All(&testStructs)
-		suite.NoError(err)
-		suite.Len(testStructs, 3)
-		for i, testStruct := range testStructs {
-			suite.Equal(validSlice[i], testStruct)
-		}
-
-		return nil
 	})
 
 	suite.T().Run("verify data still in database after transaction", func(t *testing.T) {


### PR DESCRIPTION
## Description

Reggie noticed we were creating a transaction but not using the connection object associated with it. This could lead to a transaction rollback not working as expected. This PR aims to fix that.

## Reviewer Notes

Feels like there should have been more to change, but I'm not seeing what.

## Setup

Tests now run as part of server tests.
```sh
make server_test
```

To run the command
```
rm -f bin/ghc-pricing-parser
make  bin/ghc-pricing-parser
ghc-pricing-parser --filename pkg/parser/pricing/fixtures/pricing_template_2019-09-19_fake-data.xlsx --save-csv --display
```

If you have run this before you may need to add the `--drop` flag to drop any stage tables that still exist.

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/tree/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/tree/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [#169687166](https://www.pivotaltracker.com/story/show/169687166) for this change