### PR TITLE
Add queue filter for destination duty station column

### DIFF
--- a/src/scenes/Office/QueueTable.jsx
+++ b/src/scenes/Office/QueueTable.jsx
@@ -18,7 +18,7 @@ class QueueTable extends Component {
     super();
     this.state = {
       data: [],
-      destDutystationData: [],
+      destDutyStationData: [],
       pages: null,
       loading: true,
       refreshing: false, // only true when the user clicks the refresh button
@@ -86,7 +86,7 @@ class QueueTable extends Component {
       if (this.state.loadingQueue === loadingQueueType) {
         this.setState({
           data: body,
-          destDutystationData: [...destDutyStationDataSet].sort(),
+          destDutyStationData: [...destDutyStationDataSet].sort(),
           pages: 1,
           loading: false,
           refreshing: false,
@@ -96,7 +96,7 @@ class QueueTable extends Component {
     } catch (e) {
       this.setState({
         data: [],
-        destDutystationData: [],
+        destDutyStationData: [],
         pages: 1,
         loading: false,
         refreshing: false,
@@ -126,7 +126,7 @@ class QueueTable extends Component {
   }
 
   getDestinationDutyStations = () => {
-    return this.state.destDutystationData;
+    return this.state.destDutyStationData;
   };
 
   render() {

--- a/src/scenes/Office/queueTableColumns.js
+++ b/src/scenes/Office/queueTableColumns.js
@@ -30,20 +30,6 @@ const locator = CreateReactTableColumn('Locator #', 'locator', {
 const dateFormat = 'DD-MMM-YY';
 const moveDate = CreateReactTableColumn('PPM start', 'move_date', {
   Cell: row => <span className="move_date">{formatDate(row.value)}</span>,
-  filterable: true,
-  filterMethod: (filter, row) => {
-    // Filter dates that are same or before the filtered value
-    if (filter.value === undefined) {
-      return true;
-    } else if (row[filter.id] === undefined) {
-      return false;
-    }
-
-    const rowDate = moment(row[filter.id]);
-    const filterDate = moment(filter.value, dateFormat);
-
-    return rowDate.isSameOrBefore(filterDate);
-  },
   Filter: ({ filter, onChange }) => {
     return (
       <div>
@@ -60,6 +46,20 @@ const moveDate = CreateReactTableColumn('PPM start', 'move_date', {
       </div>
     );
   },
+  filterMethod: (filter, row) => {
+    // Filter dates that are same or before the filtered value
+    if (filter.value === undefined) {
+      return true;
+    } else if (row[filter.id] === undefined) {
+      return false;
+    }
+
+    const rowDate = moment(row[filter.id]);
+    const filterDate = moment(filter.value, dateFormat);
+
+    return rowDate.isSameOrBefore(filterDate);
+  },
+  filterable: true,
 });
 
 const origin = CreateReactTableColumn('Origin', 'origin_duty_station_name', {
@@ -72,14 +72,6 @@ const destination = CreateReactTableColumn('Destination', 'destination_duty_stat
 
 const branchOfService = CreateReactTableColumn('Branch', 'branch_of_service', {
   Cell: row => <span>{row.value}</span>,
-  filterable: true,
-  filterMethod: (filter, row) => {
-    if (filter.value === 'all') {
-      return true;
-    }
-
-    return row[filter.id] === filter.value;
-  },
   Filter: ({ filter, onChange }) => (
     <select
       onChange={event => onChange(event.target.value)}
@@ -94,6 +86,14 @@ const branchOfService = CreateReactTableColumn('Branch', 'branch_of_service', {
       <option value="COAST_GUARD">Coast Guard</option>
     </select>
   ),
+  filterMethod: (filter, row) => {
+    if (filter.value === 'all') {
+      return true;
+    }
+
+    return row[filter.id] === filter.value;
+  },
+  filterable: true,
 });
 
 // Columns used to display in react table

--- a/src/scenes/Office/queueTableColumns.js
+++ b/src/scenes/Office/queueTableColumns.js
@@ -4,6 +4,9 @@ import { formatDate } from 'shared/formatters';
 import SingleDatePicker from 'shared/JsonSchemaForm/SingleDatePicker';
 import moment from 'moment';
 
+// testing
+import Select from 'react-select';
+
 // Abstracting react table column creation
 const CreateReactTableColumn = (header, accessor, options = {}) => ({
   Header: header,
@@ -16,27 +19,59 @@ const CreateReactTableColumn = (header, accessor, options = {}) => ({
 const destination = memoize(destinationDutyStations =>
   CreateReactTableColumn('Destination', 'destination_duty_station_name', {
     Cell: row => <span>{row.value}</span>,
-    Filter: ({ filter, onChange }) => (
-      <select onChange={event => onChange(event.target.value)} value={filter ? filter.value : 'all'}>
-        <option value="all">Show All</option>
-        {destinationDutyStations.map(value => {
-          return (
-            <option key={value} value={value.toLowerCase()}>
-              {value}
-            </option>
-          );
-        })}
-      </select>
-    ),
+    Filter: ({ filter, onChange }) => {
+      const options = destinationDutyStations.map(value => ({ label: value, value: value }));
+      return (
+        <Select
+          options={options}
+          onChange={value => {
+            // value example: {label: "Fort Gordon", value: "Fort Gordon"}
+            return onChange(value ? value : undefined);
+          }}
+          defaultValue={filter ? filter.value : undefined}
+          styles={{
+            // overriding styles to match other table filters
+            control: baseStyles => ({
+              ...baseStyles,
+              height: '1.5rem',
+              minHeight: '1.5rem',
+              border: '1px solid rgba(0,0,0,0.1)',
+            }),
+            indicatorsContainer: baseStyles => ({
+              ...baseStyles,
+              height: '1.5rem',
+            }),
+            clearIndicator: baseStyles => ({
+              ...baseStyles,
+              padding: '0.2rem',
+            }),
+            dropdownIndicator: baseStyles => ({
+              ...baseStyles,
+              padding: '0.2rem',
+            }),
+            input: baseStyles => ({
+              ...baseStyles,
+              margin: '0 2px',
+              paddingTop: '0',
+              paddingBottom: '0',
+            }),
+            valueContainer: baseStyles => ({
+              ...baseStyles,
+              padding: '0 8px',
+            }),
+          }}
+          isClearable
+        />
+      );
+    },
     filterMethod: (filter, row) => {
-      if (filter.value === 'all') {
+      if (filter.value === undefined) {
         return true;
       } else if (row[filter.id] === undefined) {
         return false;
       }
 
-      // filtered value should already be lowercase
-      return row[filter.id].toLowerCase() === filter.value;
+      return row[filter.id].toLowerCase() === filter.value.value.toLowerCase();
     },
     filterable: true,
   }),

--- a/src/scenes/Office/queueTableColumns.js
+++ b/src/scenes/Office/queueTableColumns.js
@@ -73,11 +73,7 @@ const destination = CreateReactTableColumn('Destination', 'destination_duty_stat
 const branchOfService = CreateReactTableColumn('Branch', 'branch_of_service', {
   Cell: row => <span>{row.value}</span>,
   Filter: ({ filter, onChange }) => (
-    <select
-      onChange={event => onChange(event.target.value)}
-      style={{ width: '100%' }}
-      value={filter ? filter.value : 'all'}
-    >
+    <select onChange={event => onChange(event.target.value)} value={filter ? filter.value : 'all'}>
       <option value="all">Show All</option>
       <option value="ARMY">Army</option>
       <option value="NAVY">Navy</option>


### PR DESCRIPTION
## Description

As a PPPO counselor
I want to be able to see only the moves for my duty station
So I can view moves more easily

## Reviewer Notes

- A new state `destDutystationData` was added to the `QueueTable` component. This keeps track of all the destination duty stations the queue has loaded and is used in the dropdown filter at the moment.
- react-select, duty station options are sorted asc order except for the first option.
- react-select v3 encourages using the styles api. See link in references.
- If we want to use the current duty station search box, this would require extensive refactoring. Trying to avoid this one.

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make server_run
make office_client_run
```

## Code Review Verification Steps

* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/168963510) for this change
* [This article encourages the styles api](https://react-select.com/styles#styles)

## Screenshots

![image](https://user-images.githubusercontent.com/1522549/68816653-f1ea8a00-0633-11ea-8b99-b056667240e0.png)

![destination duty station](https://user-images.githubusercontent.com/1522549/68816624-dda68d00-0633-11ea-9e49-be8861b0c076.gif)
