### PR TITLE
Update go mod tidy GitHub action

### DIFF
--- a/.github/workflows/go-auto-approve.yml
+++ b/.github/workflows/go-auto-approve.yml
@@ -22,9 +22,13 @@ jobs:
         # b/c checkout action leaves in detached head state https://github.com/actions/checkout/issues/6
         run: git checkout "$(echo ${{ github.head_ref }})"
         if: github.head_ref != '' && (github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]')
+      - name: setup go
+        uses: actions/setup-go@v1
+        with:
+          go-version: '1.13.3'
       - name: Tidy
         run: |
-          rm -f go.sum
+          go version
           go mod tidy
         if: github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'
       - name: set up Git

--- a/.github/workflows/go-auto-approve.yml
+++ b/.github/workflows/go-auto-approve.yml
@@ -25,7 +25,7 @@ jobs:
       - name: setup go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.13.3'
+          go-version: '1.13.4'
       - name: Tidy
         run: |
           go version

--- a/docs/how-to/upgrade-go-version.md
+++ b/docs/how-to/upgrade-go-version.md
@@ -44,6 +44,11 @@ For more details read the following sections.
 - Rerun the Go formatter on the codebase with `pre-commit run --all-files go-fmt`
 - Commit the above changes and any reformatted code and make sure everything builds correctly on CircleCI
 
+## Update `github action` yaml
+
+- Update `go-version` in `.github/workflows/go-auto-approve.yml`
+- Commit the above changes and make sure the action builds when pushed to github
+
 ## Notify Folks
 
 - It can be jarring when everything suddenly breaks after pulling from master, so it's a nice courtesy to notify folks in #dp3-engineering that the official Go version will be updated shortly and their local Go version should be upgraded as well

--- a/go.sum
+++ b/go.sum
@@ -126,8 +126,6 @@ github.com/go-openapi/runtime v0.0.0-20180920151709-4f900dc2ade9/go.mod h1:6v9a6
 github.com/go-openapi/runtime v0.19.0/go.mod h1:OwNfisksmmaZse4+gpV3Ne9AyMOlP1lt4sK4FXt0O64=
 github.com/go-openapi/runtime v0.19.4/go.mod h1:X277bwSUBxVlCYR3r7xgZZGKVvBd/29gLDlFGtJ8NL4=
 github.com/go-openapi/runtime v0.19.5/go.mod h1:WIH6IYPXOrtgTClTV8xzdrD20jBlrK25D0aQbdSlqp8=
-github.com/go-openapi/runtime v0.19.7 h1:b2zcE9GCjDVtguugU7+S95vkHjwQEjz/lB+8LOuA9Nw=
-github.com/go-openapi/runtime v0.19.7/go.mod h1:dhGWCTKRXlAfGnQG0ONViOZpjfg0m2gUt9nTQPQZuoo=
 github.com/go-openapi/runtime v0.19.8 h1:la3rOpJ+UnJSCgsgMv/xKHCMCpKJtFVa7ai4mPnV2ts=
 github.com/go-openapi/runtime v0.19.8/go.mod h1:dhGWCTKRXlAfGnQG0ONViOZpjfg0m2gUt9nTQPQZuoo=
 github.com/go-openapi/spec v0.17.0/go.mod h1:XkF/MOi14NmjsfZ8VtAKf8pIlbZzyoTvZsdfssdxcBI=
@@ -150,14 +148,10 @@ github.com/go-openapi/swag v0.19.5/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh
 github.com/go-openapi/validate v0.18.0/go.mod h1:Uh4HdOzKt19xGIGm1qHf/ofbX1YQ4Y+MYsct2VUrAJ4=
 github.com/go-openapi/validate v0.19.2/go.mod h1:1tRCw7m3jtI8eNWEEliiAqUIcBztB2KDnRCRMUi7GTA=
 github.com/go-openapi/validate v0.19.3/go.mod h1:90Vh6jjkTn+OT1Eefm0ZixWNFjhtOH7vS9k0lo6zwJo=
-github.com/go-openapi/validate v0.19.4 h1:LGjO87VyXY3bIKjlYpXSFuLRG2mTeuYlZyeNwFFWpyM=
-github.com/go-openapi/validate v0.19.4/go.mod h1:BkJ0ZmXui7yB0bJXWSXgLPNTmbLVeX/3D1xn/N9mMUM=
 github.com/go-openapi/validate v0.19.5 h1:QhCBKRYqZR+SKo4gl1lPhPahope8/RLt6EVgY8X80w0=
 github.com/go-openapi/validate v0.19.5/go.mod h1:8DJv2CVJQ6kGNpFW6eV9N3JviE1C85nY1c2z52x1Gk4=
 github.com/go-playground/locales v0.13.0 h1:HyWk6mgj5qFqCT5fjGBuRArbVDfE4hi8+e8ceBS/t7Q=
 github.com/go-playground/locales v0.13.0/go.mod h1:taPMhCMXrRLJO55olJkUXHZBHCxTMfnGwq/HNwmWNS8=
-github.com/go-playground/universal-translator v0.16.0 h1:X++omBR/4cE2MNg91AoC3rmGrCjJ8eAeUP/K/EKx4DM=
-github.com/go-playground/universal-translator v0.16.0/go.mod h1:1AnU7NaIRDWWzGEKwgtJRd2xk99HeFyHw3yid4rvQIY=
 github.com/go-playground/universal-translator v0.17.0 h1:icxd5fm+REJzpZx7ZfpaD876Lmtgy7VtROAbHHXk8no=
 github.com/go-playground/universal-translator v0.17.0/go.mod h1:UkSxE5sNxxRwHyU+Scu5vgOQjsIJAF8j9muTVoKLVtA=
 github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=


### PR DESCRIPTION
## Description

We were seeing `go mod tidy` remove seemingly unrelated modules from the `go.sum` file https://github.com/transcom/mymove/pull/3003/commits/8440c5955a5fb18406259b3fdcc3496a3d8ec6af. I was able to reproduce similar behavior locally when i first removed the `go.sum` before running `go mod tidy`. Even though I'd expect the `go.sum` file almost always be the same it makes sense not to be removing this file before running `go mod tidy`, since the hashes should serve as a reference for future builds. 

Also, I noticed a few go dependency PRs were merged that predate this GitHub action, so I included the updated `go.sum` here too.

## Reviewer Notes

Try removing the `go.sum` then running `go mod tidy` check the diff. Reset and try running `go mod tidy` without first removing the `go.sum` file.

