### PR TITLE
Progear inclusion Radio button

### DIFF
--- a/src/scenes/Moves/Ppm/Weight.jsx
+++ b/src/scenes/Moves/Ppm/Weight.jsx
@@ -12,6 +12,7 @@ import { formatCentsRange, formatNumber } from 'shared/formatters';
 import { getPpmWeightEstimate, createOrUpdatePpm, getSelectedWeightInfo } from './ducks';
 import { loadEntitlementsFromState } from 'shared/entitlements';
 import { updatePPMEstimate } from 'shared/Entities/modules/ppms';
+import RadioButton from 'shared/RadioButton';
 import 'react-rangeslider/lib/index.css';
 import styles from './Weight.module.scss';
 import { withContext } from 'shared/AppContext';
@@ -156,6 +157,10 @@ export class PpmWeight extends Component {
     }
   }
 
+  handleChange = (event, type) => {
+    this.setState({ [type]: event.target.value });
+  };
+
   render() {
     const {
       incentive_estimate_min,
@@ -169,6 +174,7 @@ export class PpmWeight extends Component {
       selectedWeightInfo,
     } = this.props;
     const { context: { flags: { progearChanges } } = { flags: { progearChanges: null } } } = this.props;
+    const { includesProgear = 'No' } = this.state;
     return (
       <div>
         {progearChanges && (
@@ -210,6 +216,31 @@ export class PpmWeight extends Component {
                 {formatCentsRange(incentive_estimate_min, incentive_estimate_max)}
               </h3>
               <p className="text-gray-50">Final payment will be based on the weight you actually move.</p>
+            </div>
+            <div className="radio-group-wrapper normalize-margins">
+              <h3>Does that weight include pro-gear?</h3>
+              <RadioButton
+                inputClassName="usa-radio__input inline_radio"
+                labelClassName="usa-radio__label inline_radio"
+                label="Yes"
+                value="Yes"
+                name="includesProgear"
+                checked={includesProgear === 'Yes'}
+                onChange={event => this.handleChange(event, 'includesProgear')}
+              />
+
+              <RadioButton
+                inputClassName="usa-radio__input inline_radio"
+                labelClassName="usa-radio__label inline_radio"
+                label="No"
+                value="No"
+                name="includesProgear"
+                checked={includesProgear === 'No'}
+                onChange={event => this.handleChange(event, 'includesProgear')}
+              />
+              <p>
+                Books, papers, and equipment needed for official duties. <a href="#">What counts as pro-gear?</a>{' '}
+              </p>
             </div>
           </div>
         )}

--- a/src/scenes/Moves/Ppm/Weight.module.scss
+++ b/src/scenes/Moves/Ppm/Weight.module.scss
@@ -53,6 +53,10 @@ div.progear-slider-container {
   .rangeslider .rangeslider__fill {
     background-color: #0071bc;
   }
+
+  label.inline_radio {
+    padding-bottom: 1em;
+  }
 }
 
 table.numeric-info th {


### PR DESCRIPTION
## Description

Adds in a question that indicates whether or not the customer included progear in the weight choice they made with the esitmate slider. The 'no' radio should be pre-selected when the page loads.

## Setup
Need to use the feature flag:
```/ppm-incentive?flag:progearChanges=true```

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/tree/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/tree/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/tree/master/docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
  * [ ] Secure migrations have been tested using `scripts/run-prod-migrations`
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/169151293) for this change

## Screenshots

![image](https://user-images.githubusercontent.com/4325613/68806340-4c331d00-062b-11ea-8d80-740ccc92bea1.png)
