### PR TITLE
Add office queue filter to origin duty station column

### DIFF
--- a/src/scenes/Office/QueueTable.jsx
+++ b/src/scenes/Office/QueueTable.jsx
@@ -18,6 +18,7 @@ class QueueTable extends Component {
     super();
     this.state = {
       data: [],
+      origDutyStationData: [],
       destDutyStationData: [],
       pages: null,
       loading: true,
@@ -74,8 +75,12 @@ class QueueTable extends Component {
       const body = await this.props.retrieveMoves(this.props.queueType);
       // grab all destination duty station and remove duplicates
       // this will build on top of the current duty stations list we see from the data
+      let origDutyStationDataSet = new Set(this.getOriginDutyStations());
       let destDutyStationDataSet = new Set(this.getDestinationDutyStations());
       body.forEach(value => {
+        if (value.origin_duty_station_name !== undefined && value.origin_duty_station_name !== '') {
+          origDutyStationDataSet.add(value.origin_duty_station_name);
+        }
         if (value.destination_duty_station_name !== undefined && value.destination_duty_station_name !== '') {
           destDutyStationDataSet.add(value.destination_duty_station_name);
         }
@@ -86,6 +91,7 @@ class QueueTable extends Component {
       if (this.state.loadingQueue === loadingQueueType) {
         this.setState({
           data: body,
+          origDutyStationData: [...origDutyStationDataSet].sort(),
           destDutyStationData: [...destDutyStationDataSet].sort(),
           pages: 1,
           loading: false,
@@ -96,6 +102,7 @@ class QueueTable extends Component {
     } catch (e) {
       this.setState({
         data: [],
+        origDutyStationData: [],
         destDutyStationData: [],
         pages: 1,
         loading: false,
@@ -127,6 +134,10 @@ class QueueTable extends Component {
 
   getDestinationDutyStations = () => {
     return this.state.destDutyStationData;
+  };
+
+  getOriginDutyStations = () => {
+    return this.state.origDutyStationData;
   };
 
   render() {
@@ -223,4 +234,9 @@ function mapDispatchToProps(dispatch) {
   return bindActionCreators({ setUserIsLoggedIn }, dispatch);
 }
 
-export default withRouter(connect(mapStateToProps, mapDispatchToProps)(QueueTable));
+export default withRouter(
+  connect(
+    mapStateToProps,
+    mapDispatchToProps,
+  )(QueueTable),
+);

--- a/src/scenes/Office/QueueTable.jsx
+++ b/src/scenes/Office/QueueTable.jsx
@@ -234,9 +234,4 @@ function mapDispatchToProps(dispatch) {
   return bindActionCreators({ setUserIsLoggedIn }, dispatch);
 }
 
-export default withRouter(
-  connect(
-    mapStateToProps,
-    mapDispatchToProps,
-  )(QueueTable),
-);
+export default withRouter(connect(mapStateToProps, mapDispatchToProps)(QueueTable));

--- a/src/scenes/Office/queueTableColumns.js
+++ b/src/scenes/Office/queueTableColumns.js
@@ -15,60 +15,60 @@ const createReactTableColumn = (header, accessor, options = {}) => ({
 });
 
 const getReactSelectFilterSettings = (data = []) => ({
-    Filter: ({ filter, onChange }) => {
+  Filter: ({ filter, onChange }) => {
     const options = data.map(value => ({ label: value, value: value }));
-      return (
-        <Select
-          options={options}
-          onChange={value => {
-            // value example: {label: "Fort Gordon", value: "Fort Gordon"}
-            return onChange(value ? value : undefined);
-          }}
-          defaultValue={filter ? filter.value : undefined}
-          styles={{
-            // overriding styles to match other table filters
-            control: baseStyles => ({
-              ...baseStyles,
-              height: '1.5rem',
-              minHeight: '1.5rem',
-              border: '1px solid rgba(0,0,0,0.1)',
-            }),
-            indicatorsContainer: baseStyles => ({
-              ...baseStyles,
-              height: '1.5rem',
-            }),
-            clearIndicator: baseStyles => ({
-              ...baseStyles,
-              padding: '0.2rem',
-            }),
-            dropdownIndicator: baseStyles => ({
-              ...baseStyles,
-              padding: '0.2rem',
-            }),
-            input: baseStyles => ({
-              ...baseStyles,
-              margin: '0 2px',
-              paddingTop: '0',
-              paddingBottom: '0',
-            }),
-            valueContainer: baseStyles => ({
-              ...baseStyles,
-              padding: '0 8px',
-            }),
-          }}
-          isClearable
-        />
-      );
-    },
-    filterMethod: (filter, row) => {
-      if (filter.value === undefined) {
-        return true;
-      } else if (row[filter.id] === undefined) {
-        return false;
-      }
+    return (
+      <Select
+        options={options}
+        onChange={value => {
+          // value example: {label: "Fort Gordon", value: "Fort Gordon"}
+          return onChange(value ? value : undefined);
+        }}
+        defaultValue={filter ? filter.value : undefined}
+        styles={{
+          // overriding styles to match other table filters
+          control: baseStyles => ({
+            ...baseStyles,
+            height: '1.5rem',
+            minHeight: '1.5rem',
+            border: '1px solid rgba(0,0,0,0.1)',
+          }),
+          indicatorsContainer: baseStyles => ({
+            ...baseStyles,
+            height: '1.5rem',
+          }),
+          clearIndicator: baseStyles => ({
+            ...baseStyles,
+            padding: '0.2rem',
+          }),
+          dropdownIndicator: baseStyles => ({
+            ...baseStyles,
+            padding: '0.2rem',
+          }),
+          input: baseStyles => ({
+            ...baseStyles,
+            margin: '0 2px',
+            paddingTop: '0',
+            paddingBottom: '0',
+          }),
+          valueContainer: baseStyles => ({
+            ...baseStyles,
+            padding: '0 8px',
+          }),
+        }}
+        isClearable
+      />
+    );
+  },
+  filterMethod: (filter, row) => {
+    if (filter.value === undefined) {
+      return true;
+    } else if (row[filter.id] === undefined) {
+      return false;
+    }
 
-      return row[filter.id].toLowerCase() === filter.value.value.toLowerCase();
-    },
+    return row[filter.id].toLowerCase() === filter.value.value.toLowerCase();
+  },
 });
 
 // lodash memoize will prevent unnecessary rendering with the same state
@@ -78,6 +78,14 @@ const destination = memoize(destinationDutyStations =>
     Cell: row => <span>{row.value}</span>,
     filterable: true,
     ...getReactSelectFilterSettings(destinationDutyStations),
+  }),
+);
+
+const origin = memoize(originDutyStations =>
+  createReactTableColumn('Origin', 'origin_duty_station_name', {
+    Cell: row => <span>{row.value}</span>,
+    filterable: true,
+    ...getReactSelectFilterSettings(originDutyStations),
   }),
 );
 
@@ -132,10 +140,6 @@ const moveDate = createReactTableColumn('PPM start', 'move_date', {
   filterable: true,
 });
 
-const origin = createReactTableColumn('Origin', 'origin_duty_station_name', {
-  Cell: row => <span>{row.value}</span>,
-});
-
 const branchOfService = createReactTableColumn('Branch', 'branch_of_service', {
   Cell: row => <span>{row.value}</span>,
   Filter: ({ filter, onChange }) => (
@@ -163,7 +167,7 @@ export const defaultColumns = component => {
   return [
     status,
     customerName,
-    origin,
+    origin(component.getOriginDutyStations()),
     destination(component.getDestinationDutyStations()),
     dodId,
     locator,

--- a/src/scenes/Office/queueTableColumns.js
+++ b/src/scenes/Office/queueTableColumns.js
@@ -14,13 +14,9 @@ const createReactTableColumn = (header, accessor, options = {}) => ({
   ...options,
 });
 
-// lodash memoize will prevent unnecessary rendering with the same state
-// this will re-render if the state changes
-const destination = memoize(destinationDutyStations =>
-  createReactTableColumn('Destination', 'destination_duty_station_name', {
-    Cell: row => <span>{row.value}</span>,
+const getReactSelectFilterSettings = (data = []) => ({
     Filter: ({ filter, onChange }) => {
-      const options = destinationDutyStations.map(value => ({ label: value, value: value }));
+    const options = data.map(value => ({ label: value, value: value }));
       return (
         <Select
           options={options}
@@ -73,7 +69,15 @@ const destination = memoize(destinationDutyStations =>
 
       return row[filter.id].toLowerCase() === filter.value.value.toLowerCase();
     },
+});
+
+// lodash memoize will prevent unnecessary rendering with the same state
+// this will re-render if the state changes
+const destination = memoize(destinationDutyStations =>
+  createReactTableColumn('Destination', 'destination_duty_station_name', {
+    Cell: row => <span>{row.value}</span>,
     filterable: true,
+    ...getReactSelectFilterSettings(destinationDutyStations),
   }),
 );
 

--- a/src/scenes/Office/queueTableColumns.js
+++ b/src/scenes/Office/queueTableColumns.js
@@ -8,7 +8,7 @@ import moment from 'moment';
 import Select from 'react-select';
 
 // Abstracting react table column creation
-const CreateReactTableColumn = (header, accessor, options = {}) => ({
+const createReactTableColumn = (header, accessor, options = {}) => ({
   Header: header,
   accessor: accessor,
   ...options,
@@ -17,7 +17,7 @@ const CreateReactTableColumn = (header, accessor, options = {}) => ({
 // lodash memoize will prevent unnecessary rendering with the same state
 // this will re-render if the state changes
 const destination = memoize(destinationDutyStations =>
-  CreateReactTableColumn('Destination', 'destination_duty_station_name', {
+  createReactTableColumn('Destination', 'destination_duty_station_name', {
     Cell: row => <span>{row.value}</span>,
     Filter: ({ filter, onChange }) => {
       const options = destinationDutyStations.map(value => ({ label: value, value: value }));
@@ -77,7 +77,7 @@ const destination = memoize(destinationDutyStations =>
   }),
 );
 
-const status = CreateReactTableColumn('Status', 'synthetic_status', {
+const status = createReactTableColumn('Status', 'synthetic_status', {
   Cell: row => (
     <span className="status" data-cy="status">
       {capitalize(row.value && row.value.replace('_', ' '))}
@@ -85,16 +85,16 @@ const status = CreateReactTableColumn('Status', 'synthetic_status', {
   ),
 });
 
-const customerName = CreateReactTableColumn('Customer name', 'customer_name');
+const customerName = createReactTableColumn('Customer name', 'customer_name');
 
-const dodId = CreateReactTableColumn('DoD ID', 'edipi');
+const dodId = createReactTableColumn('DoD ID', 'edipi');
 
-const locator = CreateReactTableColumn('Locator #', 'locator', {
+const locator = createReactTableColumn('Locator #', 'locator', {
   Cell: row => <span data-cy="locator">{row.value}</span>,
 });
 
 const dateFormat = 'DD-MMM-YY';
-const moveDate = CreateReactTableColumn('PPM start', 'move_date', {
+const moveDate = createReactTableColumn('PPM start', 'move_date', {
   Cell: row => <span className="move_date">{formatDate(row.value)}</span>,
   Filter: ({ filter, onChange }) => {
     return (
@@ -128,11 +128,11 @@ const moveDate = CreateReactTableColumn('PPM start', 'move_date', {
   filterable: true,
 });
 
-const origin = CreateReactTableColumn('Origin', 'origin_duty_station_name', {
+const origin = createReactTableColumn('Origin', 'origin_duty_station_name', {
   Cell: row => <span>{row.value}</span>,
 });
 
-const branchOfService = CreateReactTableColumn('Branch', 'branch_of_service', {
+const branchOfService = createReactTableColumn('Branch', 'branch_of_service', {
   Cell: row => <span>{row.value}</span>,
   Filter: ({ filter, onChange }) => (
     <select onChange={event => onChange(event.target.value)} value={filter ? filter.value : 'all'}>


### PR DESCRIPTION
## Description

Why
As a PPPO counselor
I want to be able to see only the moves for my origin duty station
So I can approve moves more easily

## Reviewer Notes

- Refactored the react select filter to be re-usable
- New state for the queue component, `origDutyStationData`

## Setup

```sh
make server_run
make office_client_run
```

## Code Review Verification Steps

* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/168963391) for this change

## Screenshots

![image](https://user-images.githubusercontent.com/1522549/68941003-8569ab00-0759-11ea-9d6c-503ae942dd79.png)

![origin duty station](https://user-images.githubusercontent.com/1522549/68941100-bf3ab180-0759-11ea-9b85-1ea3aba936c7.gif)

