### PR TITLE
Service Member left align cancel link button on contact page

### DIFF
--- a/src/shared/WizardPage/Form.jsx
+++ b/src/shared/WizardPage/Form.jsx
@@ -117,7 +117,7 @@ export class WizardFormPage extends Component {
         <div className="grid-row" style={{ marginTop: '0.5rem' }}>
           <div className="grid-col margin-top-6 tablet:margin-top-3">
             {!isMobile && (
-              <button className="usa-button usa-button--outline cancel" onClick={this.cancelFlow}>
+              <button className="usa-button usa-button--outline cancel padding-left-0" onClick={this.cancelFlow}>
                 Cancel
               </button>
             )}

--- a/src/shared/WizardPage/Form.jsx
+++ b/src/shared/WizardPage/Form.jsx
@@ -115,12 +115,14 @@ export class WizardFormPage extends Component {
         )}
         <form className={className}>{children}</form>
         <div className="grid-row" style={{ marginTop: '0.5rem' }}>
-          <div className="grid-col-12 text-right margin-top-6 tablet:margin-top-3">
+          <div className="grid-col margin-top-6 tablet:margin-top-3">
             {!isMobile && (
               <button className="usa-button usa-button--outline cancel" onClick={this.cancelFlow}>
                 Cancel
               </button>
             )}
+          </div>
+          <div className="grid-col text-right margin-top-6 tablet:margin-top-3">
             {!hideBackBtn && (
               <button
                 className="usa-button usa-button--outline prev"


### PR DESCRIPTION
## Description

Left aligning the `cancel` link button on the Service Member contact page.

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make server_run
make client_run
```

## Code Review Verification Steps

* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/169464046) for this change
* [this article](https://designsystem.digital.gov/utilities/layout-grid/) explains more about the approach used.

## Screenshots

Before
![image](https://user-images.githubusercontent.com/1522549/68945712-daabb980-0765-11ea-8878-82b3f1ceb980.png)


After
![image](https://user-images.githubusercontent.com/1522549/69109884-dfa28e80-0a2d-11ea-864f-0ba16ce68815.png)
