### PR TITLE
Remove docker layer cachine in some steps and decrease e2e parallelism

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -290,8 +290,6 @@ jobs:
     executor: mymove_medium
     steps:
       - checkout
-      - setup_remote_docker:
-          docker_layer_caching: true
       - run: make anti_virus
       - announce_failure
 
@@ -360,7 +358,7 @@ jobs:
 
   # `integration_tests` runs integration tests using Cypress.  https://www.cypress.io/
   integration_tests:
-    parallelism: 10
+    parallelism: 6
     executor: mymove_medium_plus
     steps:
       - checkout
@@ -391,8 +389,6 @@ jobs:
     executor: mymove_and_postgres_large
     steps:
       - checkout
-      - setup_remote_docker:
-          docker_layer_caching: true
       - restore_cache:
           keys:
             - go-mod-sources-v2-{{ checksum "go.sum" }}-{{ checksum "scripts/check-go-version" }}
@@ -506,8 +502,6 @@ jobs:
     executor: mymove_medium
     steps:
       - checkout
-      - setup_remote_docker:
-          docker_layer_caching: true
       - restore_cache:
           keys:
             - v2-cache-yarn-v2-{{ checksum "yarn.lock" }}


### PR DESCRIPTION
## Description

It appears that Docker Layer Caching (DLC) is costing us too much money. We don't need it in all these steps so I'm removing it.

Also, parallelism in the e2e tests means that we are using DLC in parallel steps. So we can decrease it by making the tests take a little longer too.