### PR TITLE
move call for helperSetupStagingTables

### DIFF
--- a/pkg/services/ghcimport/import_test.go
+++ b/pkg/services/ghcimport/import_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/gobuffalo/pop"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/zap"
 
@@ -19,21 +20,23 @@ type GHCRateEngineImportSuite struct {
 
 func (suite *GHCRateEngineImportSuite) SetupTest() {
 	suite.DB().TruncateAll()
-
-	suite.helperSetupStagingTables()
 }
 
-func (suite *GHCRateEngineImportSuite) helperSetupStagingTables() {
+func helperSetupStagingTables(t *testing.T, db *pop.Connection) {
 	path := filepath.Join("fixtures", "stage_ghc_pricing.sql")
 	c, ioErr := ioutil.ReadFile(path)
-	suite.NoError(ioErr)
+	if ioErr != nil {
+		t.Fatal(ioErr)
+	}
 
 	sql := string(c)
-	err := suite.DB().RawQuery(sql).Exec()
-	suite.NoError(err)
+	err := db.RawQuery(sql).Exec()
+	if err != nil {
+		t.Fatal(err)
+	}
 }
 
-func TestPricingParserSuite(t *testing.T) {
+func TestGHCRateEngineImportSuite(t *testing.T) {
 	logger, err := zap.NewDevelopment()
 	if err != nil {
 		log.Panic(err)
@@ -43,6 +46,8 @@ func TestPricingParserSuite(t *testing.T) {
 		PopTestSuite: testingsuite.NewPopTestSuite(testingsuite.CurrentPackage()),
 		logger:       logger,
 	}
+
+	helperSetupStagingTables(t, hs.DB())
 
 	suite.Run(t, hs)
 	hs.PopTestSuite.TearDown()


### PR DESCRIPTION
## Description

Get fixture and SQL import for test in place for the rest of the GHC importers to do testing. This is was in a previous PR but the call to load the fixture needed to be called differently once multiple tests were being called.

## Reviewer Notes

n/a

## Setup

```sh
go test -v ./pkg/services/ghcimport
```

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/tree/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/tree/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/tree/master/docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
  * [ ] Secure migrations have been tested using `scripts/run-prod-migrations`
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/169343851) for this change

## Screenshots

n/a
