### PR TITLE
TRT-132: Add go test debugging to vscode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,7 +1,6 @@
 {
   "version": "0.2.0",
-  "configurations": [
-    {
+  "configurations": [{
       "name": "Chrome",
       "type": "chrome",
       "request": "launch",
@@ -32,8 +31,23 @@
       "port": 2345,
       "host": "127.0.0.1",
       "program": "${workspaceRoot}/cmd/milmove/main.go",
-      "env": {"INTERFACE":"localhost", "DEBUG_LOGGING":"true"},
+      "env": {
+        "INTERFACE": "localhost",
+        "DEBUG_LOGGING": "true"
+      },
       "args": ["serve"],
+      "showLog": true
+    },
+    {
+      "name": "Debug Go Tests",
+      "type": "go",
+      "request": "launch",
+      "mode": "test",
+      "remotePath": "",
+      "port": 2345,
+      "host": "127.0.0.1",
+      "program": "${workspaceRoot}/pkg/handlers/ghcapi/",
+      "args": [],
       "showLog": true
     }
   ]


### PR DESCRIPTION
For this to work, you must start vscode from the command line
in the milmove folder, as described in the docs:
https://code.visualstudio.com/docs/editor/command-line
This will set the proper environment variables

Then modify the "program" property under Debug Go Tests
to point to a test-containing folder.  Only one folder can be debugged
at a time.

## Description

Allow developers using vscode to debug their Go tests in the editor.

## Setup

```sh
cd mymove
code .
```

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/TRT-132) for this change

