### PR TITLE
Disable docker_layer_caching completely to save money

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,8 @@
 # Caches may have a `v1-` prefix, since caches in CircleCI 2.0 are immutable.
 # A prefix provides an easy way to invalidate a cache.  See https://circleci.com/docs/2.0/caching/#clearing-cache
 #
+# Please do not use docker_layer_caching! It costs too much money to run. Please set to `false`.
+#
 ############
 
 version: '2.1'
@@ -365,7 +367,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          docker_layer_caching: true
+          docker_layer_caching: false
       - restore_cache:
           keys:
             - go-mod-sources-v2-{{ checksum "go.sum" }}-{{ checksum "scripts/check-go-version" }}
@@ -479,7 +481,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          docker_layer_caching: true
+          docker_layer_caching: false
       - restore_cache:
           keys:
             - go-mod-sources-v2-{{ checksum "go.sum" }}-{{ checksum "scripts/check-go-version" }}
@@ -523,7 +525,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          docker_layer_caching: true
+          docker_layer_caching: false
       - run: make bin/chamber
       - run: make bin/rds-combined-ca-bundle.pem
       - run: make server_build
@@ -539,7 +541,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          docker_layer_caching: true
+          docker_layer_caching: false
       - restore_cache:
           keys:
             - go-mod-sources-v2-{{ checksum "go.sum" }}-{{ checksum "scripts/check-go-version" }}}


### PR DESCRIPTION
## Description

It turns out that CircleCI changed their billing model. So instead of $15/month per project for DLC we are now being charged $1500/month in credits based on usage.  This feature does not give us enough benefit for the cost and we need to remove it. 