### PR TITLE
Remove empty eagers from duty station model

### DIFF
--- a/pkg/models/duty_station.go
+++ b/pkg/models/duty_station.go
@@ -81,14 +81,14 @@ func FetchDSContactInfo(db *pop.Connection, dutyStationID *uuid.UUID) (*DutyStat
 // FetchDutyStation returns a station for a given id
 func FetchDutyStation(ctx context.Context, tx *pop.Connection, id uuid.UUID) (DutyStation, error) {
 	var station DutyStation
-	err := tx.Q().Eager().Find(&station, id)
+	err := tx.Q().Find(&station, id)
 	return station, err
 }
 
 // FetchDutyStationByName returns a station for a given unique name
 func FetchDutyStationByName(tx *pop.Connection, name string) (DutyStation, error) {
 	var station DutyStation
-	err := tx.Where("name = ?", name).Eager().First(&station)
+	err := tx.Where("name = ?", name).Eager("Address").First(&station)
 	return station, err
 }
 
@@ -147,7 +147,6 @@ func FetchDutyStationTransportationOffice(db *pop.Connection, dutyStationID uuid
 func FetchDutyStationsByPostalCode(tx *pop.Connection, postalCode string) (DutyStations, error) {
 	var stations DutyStations
 	query := tx.
-		Eager().
 		Where("addresses.postal_code like $1", postalCode).
 		LeftJoin("addresses", "duty_stations.address_id = addresses.id")
 


### PR DESCRIPTION
## Description

We use `Eager()` without arguments in a few places throughout the app. By default, this causes Pop to eager load every association on the model being queried. We don't often need every relationship to be loaded, so we are firing many unnecessary queries.

This work is part of an effort to identify what it would take to make calls to `Eager` more specific so they won't load every association by default. I'll be writing some more stories to address other instances of using empty `Eager`s.

## Setup

- `make server_run`
- `make client_run`

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-220) for this change
