### PR TITLE
Fix docs pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -81,7 +81,7 @@ repos:
         pass_filenames: false
 
   - repo: git://github.com/trussworks/pre-commit-hooks
-    rev: v0.0.2
+    rev: v0.0.3
     hooks:
       - id: gen-docs
         args: ["docs/adr"]


### PR DESCRIPTION
## Description

An upgrade to the way the gen-docs package was modified recently will cause us to break our ADR log. This update will fix any upcoming issues. See https://github.com/transcom/ppp-infra/pull/738 and https://github.com/trussworks/pre-commit-hooks/commit/21d405460301a3850d4550ff883149619ab8b38c