### PR TITLE
Add circle ci command to exit build without failing

### DIFF
--- a/scripts/compare-deployed-commit
+++ b/scripts/compare-deployed-commit
@@ -40,5 +40,6 @@ else
   echo "* Deployed commit ($deployed_commit) is not an ancestor of the local commit ($local_commit)."
   echo "* The deployed commit is either ahead of the local commit or the commits have different histories."
   echo "* Deploy is blocked."
-  exit 1
+
+  circleci-agent step halt
 fi

--- a/scripts/compare-deployed-commit
+++ b/scripts/compare-deployed-commit
@@ -40,5 +40,9 @@ else
   echo "* Deployed commit ($deployed_commit) is not an ancestor of the local commit ($local_commit)."
   echo "* The deployed commit is either ahead of the local commit or the commits have different histories."
   echo "* Deploy is blocked."
-  circleci-agent step halt
+  if [ -n "${CIRCLECI+x}" ]; then
+    circleci-agent step halt
+  else
+    exit 1
+  fi
 fi

--- a/scripts/compare-deployed-commit
+++ b/scripts/compare-deployed-commit
@@ -40,6 +40,5 @@ else
   echo "* Deployed commit ($deployed_commit) is not an ancestor of the local commit ($local_commit)."
   echo "* The deployed commit is either ahead of the local commit or the commits have different histories."
   echo "* Deploy is blocked."
-
   circleci-agent step halt
 fi


### PR DESCRIPTION
## Description

When multiple builds are initiated at the same, a race condition may occur and our `compare-deployed-commit` script will cause the build to fail. This is by design, since we don't want old code to be deployed on top of newer code. However, gracefully exiting the build is better than failing since it decreases our signal to noise ratio when it comes to build failures.

## Reviewer Notes

- I'm not sure the best way to test this. Should I try committing multiple times and trigger two deploys to experimental?
- According to the [docs](https://circleci.com/docs/2.0/configuration-reference/#ending-a-job-from-within-a-step), it doesn't look like we need an explicit exit code. I want to make sure that makes sense to infra folks.

## Code Review Verification Steps

* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?
