### PR TITLE
Vertical center align queue filters

### DIFF
--- a/src/scenes/Office/QueueTable.jsx
+++ b/src/scenes/Office/QueueTable.jsx
@@ -208,7 +208,13 @@ class QueueTable extends Component {
             })}
             getTheadFilterThProps={() => {
               return {
-                style: { position: 'inherit', overflow: 'inherit' },
+                style: {
+                  display: 'flex',
+                  flexDirection: 'column',
+                  justifyContent: 'center',
+                  position: 'inherit',
+                  overflow: 'inherit',
+                },
               };
             }}
             getTableProps={() => {


### PR DESCRIPTION
## Description

The queue filter inputs are not properly vertically aligned. 

Per Kim Ladin: use a centered vertical alignment.

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make server_run
make office_client_run
```

## Code Review Verification Steps

* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-246) for this change

## Screenshots

Before
![image](https://user-images.githubusercontent.com/1522549/69360868-2f58a400-0c40-11ea-9689-7475af3872ff.png)

After
![image](https://user-images.githubusercontent.com/1522549/69360883-3a133900-0c40-11ea-88e2-f547a6a854bf.png)
