### PR TITLE
Add Reference ID to MTO Payload

### DIFF
--- a/pkg/gen/ghcapi/embedded_spec.go
+++ b/pkg/gen/ghcapi/embedded_spec.go
@@ -1615,6 +1615,10 @@ func init() {
         "pickupAddress": {
           "$ref": "#/definitions/Address"
         },
+        "referenceId": {
+          "type": "string",
+          "example": "1001-3456"
+        },
         "remarks": {
           "type": "string",
           "example": "Requires more gentle care"
@@ -3786,6 +3790,10 @@ func init() {
         },
         "pickupAddress": {
           "$ref": "#/definitions/Address"
+        },
+        "referenceId": {
+          "type": "string",
+          "example": "1001-3456"
         },
         "remarks": {
           "type": "string",

--- a/pkg/gen/ghcapi/embedded_spec.go
+++ b/pkg/gen/ghcapi/embedded_spec.go
@@ -1617,6 +1617,7 @@ func init() {
         },
         "referenceId": {
           "type": "string",
+          "x-nullable": true,
           "example": "1001-3456"
         },
         "remarks": {
@@ -3793,6 +3794,7 @@ func init() {
         },
         "referenceId": {
           "type": "string",
+          "x-nullable": true,
           "example": "1001-3456"
         },
         "remarks": {

--- a/pkg/gen/ghcmessages/move_task_order.go
+++ b/pkg/gen/ghcmessages/move_task_order.go
@@ -76,6 +76,9 @@ type MoveTaskOrder struct {
 	// pickup address
 	PickupAddress *Address `json:"pickupAddress,omitempty"`
 
+	// reference Id
+	ReferenceID string `json:"referenceId,omitempty"`
+
 	// remarks
 	Remarks string `json:"remarks,omitempty"`
 

--- a/pkg/gen/ghcmessages/move_task_order.go
+++ b/pkg/gen/ghcmessages/move_task_order.go
@@ -77,7 +77,7 @@ type MoveTaskOrder struct {
 	PickupAddress *Address `json:"pickupAddress,omitempty"`
 
 	// reference Id
-	ReferenceID string `json:"referenceId,omitempty"`
+	ReferenceID *string `json:"referenceId,omitempty"`
 
 	// remarks
 	Remarks string `json:"remarks,omitempty"`

--- a/pkg/gen/primeapi/embedded_spec.go
+++ b/pkg/gen/primeapi/embedded_spec.go
@@ -786,6 +786,10 @@ func init() {
         "pickup_address": {
           "$ref": "#/definitions/Address"
         },
+        "referenceId": {
+          "type": "string",
+          "example": "1001-3456"
+        },
         "remarks": {
           "type": "string",
           "example": "Requires more gentle care"
@@ -1907,6 +1911,10 @@ func init() {
         },
         "pickup_address": {
           "$ref": "#/definitions/Address"
+        },
+        "referenceId": {
+          "type": "string",
+          "example": "1001-3456"
         },
         "remarks": {
           "type": "string",

--- a/pkg/gen/primeapi/embedded_spec.go
+++ b/pkg/gen/primeapi/embedded_spec.go
@@ -788,6 +788,7 @@ func init() {
         },
         "referenceId": {
           "type": "string",
+          "x-nullable": true,
           "example": "1001-3456"
         },
         "remarks": {
@@ -1914,6 +1915,7 @@ func init() {
         },
         "referenceId": {
           "type": "string",
+          "x-nullable": true,
           "example": "1001-3456"
         },
         "remarks": {

--- a/pkg/gen/primemessages/customer.go
+++ b/pkg/gen/primemessages/customer.go
@@ -52,6 +52,9 @@ type Customer struct {
 	// pickup address
 	PickupAddress *Address `json:"pickup_address,omitempty"`
 
+	// reference Id
+	ReferenceID string `json:"referenceId,omitempty"`
+
 	// remarks
 	Remarks string `json:"remarks,omitempty"`
 

--- a/pkg/gen/primemessages/customer.go
+++ b/pkg/gen/primemessages/customer.go
@@ -53,7 +53,7 @@ type Customer struct {
 	PickupAddress *Address `json:"pickup_address,omitempty"`
 
 	// reference Id
-	ReferenceID string `json:"referenceId,omitempty"`
+	ReferenceID *string `json:"referenceId,omitempty"`
 
 	// remarks
 	Remarks string `json:"remarks,omitempty"`

--- a/pkg/handlers/ghcapi/move_task_order.go
+++ b/pkg/handlers/ghcapi/move_task_order.go
@@ -97,6 +97,7 @@ func payloadForMoveTaskOrder(moveTaskOrder models.MoveTaskOrder) *ghcmessages.Mo
 		MoveID:                 strfmt.UUID(moveTaskOrder.MoveID.String()),
 		OriginDutyStation:      strfmt.UUID(moveTaskOrder.OriginDutyStationID.String()),
 		PickupAddress:          pickupAddress,
+		ReferenceID:            moveTaskOrder.ReferenceID,
 		Remarks:                moveTaskOrder.CustomerRemarks,
 		RequestedPickupDate:    strfmt.Date(moveTaskOrder.RequestedPickupDate),
 		ServiceItems:           serviceItems,

--- a/pkg/handlers/ghcapi/move_task_order_test.go
+++ b/pkg/handlers/ghcapi/move_task_order_test.go
@@ -46,7 +46,8 @@ func (suite *HandlerSuite) TestUpdateMoveTaskOrderHandlerIntegration() {
 	suite.Assertions.IsType(&move_task_order.UpdateMoveTaskOrderStatusOK{}, response)
 	suite.Equal(moveTaskOrdersPayload.ID, strfmt.UUID(moveTaskOrder.ID.String()))
 	suite.Equal(moveTaskOrdersPayload.Status, "APPROVED")
-	suite.Regexp("^\\d{4}-\\d{4}$", moveTaskOrdersPayload.ReferenceID)
+	suite.NotNil(moveTaskOrdersPayload.ReferenceID)
+	suite.Regexp("^\\d{4}-\\d{4}$", *moveTaskOrdersPayload.ReferenceID)
 }
 
 func (suite *HandlerSuite) TestUpdateMoveTaskOrderHandlerNotFoundError() {
@@ -54,14 +55,14 @@ func (suite *HandlerSuite) TestUpdateMoveTaskOrderHandlerNotFoundError() {
 	request := httptest.NewRequest("PATCH", "/move-task-orders/{moveTaskOrderID}/status", nil)
 	params := move_task_order.UpdateMoveTaskOrderStatusParams{
 		HTTPRequest:     request,
-		Body:            &ghcmessages.MoveTaskOrderStatus{Status: "SUBMITTED"},
+		Body:            &ghcmessages.MoveTaskOrderStatus{Status: "APPROVED"},
 		MoveTaskOrderID: moveTaskOrderID.String(),
 	}
 	context := handlers.NewHandlerContext(suite.DB(), suite.TestLogger())
 
 	// make the request
 	mtoStatusUpdater := &mocks.MoveTaskOrderStatusUpdater{}
-	mtoStatusUpdater.On("UpdateMoveTaskOrderStatus", moveTaskOrderID, models.MoveTaskOrderStatusSubmitted).
+	mtoStatusUpdater.On("UpdateMoveTaskOrderStatus", moveTaskOrderID, models.MoveTaskOrderStatusApproved).
 		Return(&models.MoveTaskOrder{}, movetaskorder.ErrNotFound{})
 	handler := UpdateMoveTaskOrderStatusHandlerFunc{context, mtoStatusUpdater}
 	response := handler.Handle(params)
@@ -74,14 +75,14 @@ func (suite *HandlerSuite) TestUpdateMoveTaskOrderHandlerServerError() {
 	request := httptest.NewRequest("PATCH", "/move-task-orders/{moveTaskOrderID}/status", nil)
 	params := move_task_order.UpdateMoveTaskOrderStatusParams{
 		HTTPRequest:     request,
-		Body:            &ghcmessages.MoveTaskOrderStatus{Status: "SUBMITTED"},
+		Body:            &ghcmessages.MoveTaskOrderStatus{Status: "APPROVED"},
 		MoveTaskOrderID: moveTaskOrderID.String(),
 	}
 	context := handlers.NewHandlerContext(suite.DB(), suite.TestLogger())
 
 	// make the request
 	mtoStatusUpdater := &mocks.MoveTaskOrderStatusUpdater{}
-	mtoStatusUpdater.On("UpdateMoveTaskOrderStatus", moveTaskOrderID, models.MoveTaskOrderStatusSubmitted).
+	mtoStatusUpdater.On("UpdateMoveTaskOrderStatus", moveTaskOrderID, models.MoveTaskOrderStatusApproved).
 		Return(&models.MoveTaskOrder{}, errors.New("something bad happened"))
 	handler := UpdateMoveTaskOrderStatusHandlerFunc{context, mtoStatusUpdater}
 	response := handler.Handle(params)

--- a/pkg/handlers/ghcapi/move_task_order_test.go
+++ b/pkg/handlers/ghcapi/move_task_order_test.go
@@ -28,7 +28,7 @@ func (suite *HandlerSuite) TestUpdateMoveTaskOrderHandlerIntegration() {
 	request := httptest.NewRequest("PATCH", "/move-task-orders/{moveTaskOrderID}/status", nil)
 	params := move_task_order.UpdateMoveTaskOrderStatusParams{
 		HTTPRequest:     request,
-		Body:            &ghcmessages.MoveTaskOrderStatus{Status: "SUBMITTED"},
+		Body:            &ghcmessages.MoveTaskOrderStatus{Status: "APPROVED"},
 		MoveTaskOrderID: moveTaskOrder.ID.String(),
 	}
 	context := handlers.NewHandlerContext(suite.DB(), suite.TestLogger())
@@ -45,7 +45,7 @@ func (suite *HandlerSuite) TestUpdateMoveTaskOrderHandlerIntegration() {
 
 	suite.Assertions.IsType(&move_task_order.UpdateMoveTaskOrderStatusOK{}, response)
 	suite.Equal(moveTaskOrdersPayload.ID, strfmt.UUID(moveTaskOrder.ID.String()))
-	suite.Equal(moveTaskOrdersPayload.Status, "SUBMITTED")
+	suite.Equal(moveTaskOrdersPayload.Status, "APPROVED")
 	suite.Regexp("^\\d{4}-\\d{4}$", moveTaskOrdersPayload.ReferenceID)
 }
 

--- a/pkg/handlers/ghcapi/move_task_order_test.go
+++ b/pkg/handlers/ghcapi/move_task_order_test.go
@@ -28,7 +28,7 @@ func (suite *HandlerSuite) TestUpdateMoveTaskOrderHandlerIntegration() {
 	request := httptest.NewRequest("PATCH", "/move-task-orders/{moveTaskOrderID}/status", nil)
 	params := move_task_order.UpdateMoveTaskOrderStatusParams{
 		HTTPRequest:     request,
-		Body:            &ghcmessages.MoveTaskOrderStatus{Status: "DRAFT"},
+		Body:            &ghcmessages.MoveTaskOrderStatus{Status: "SUBMITTED"},
 		MoveTaskOrderID: moveTaskOrder.ID.String(),
 	}
 	context := handlers.NewHandlerContext(suite.DB(), suite.TestLogger())
@@ -45,7 +45,8 @@ func (suite *HandlerSuite) TestUpdateMoveTaskOrderHandlerIntegration() {
 
 	suite.Assertions.IsType(&move_task_order.UpdateMoveTaskOrderStatusOK{}, response)
 	suite.Equal(moveTaskOrdersPayload.ID, strfmt.UUID(moveTaskOrder.ID.String()))
-	suite.Equal(moveTaskOrdersPayload.Status, "DRAFT")
+	suite.Equal(moveTaskOrdersPayload.Status, "SUBMITTED")
+	suite.Regexp("^\\d{4}-\\d{4}$", moveTaskOrdersPayload.ReferenceID)
 }
 
 func (suite *HandlerSuite) TestUpdateMoveTaskOrderHandlerNotFoundError() {
@@ -53,14 +54,14 @@ func (suite *HandlerSuite) TestUpdateMoveTaskOrderHandlerNotFoundError() {
 	request := httptest.NewRequest("PATCH", "/move-task-orders/{moveTaskOrderID}/status", nil)
 	params := move_task_order.UpdateMoveTaskOrderStatusParams{
 		HTTPRequest:     request,
-		Body:            &ghcmessages.MoveTaskOrderStatus{Status: "DRAFT"},
+		Body:            &ghcmessages.MoveTaskOrderStatus{Status: "SUBMITTED"},
 		MoveTaskOrderID: moveTaskOrderID.String(),
 	}
 	context := handlers.NewHandlerContext(suite.DB(), suite.TestLogger())
 
 	// make the request
 	mtoStatusUpdater := &mocks.MoveTaskOrderStatusUpdater{}
-	mtoStatusUpdater.On("UpdateMoveTaskOrderStatus", moveTaskOrderID, models.MoveTaskOrderStatusDraft).
+	mtoStatusUpdater.On("UpdateMoveTaskOrderStatus", moveTaskOrderID, models.MoveTaskOrderStatusSubmitted).
 		Return(&models.MoveTaskOrder{}, movetaskorder.ErrNotFound{})
 	handler := UpdateMoveTaskOrderStatusHandlerFunc{context, mtoStatusUpdater}
 	response := handler.Handle(params)
@@ -73,14 +74,14 @@ func (suite *HandlerSuite) TestUpdateMoveTaskOrderHandlerServerError() {
 	request := httptest.NewRequest("PATCH", "/move-task-orders/{moveTaskOrderID}/status", nil)
 	params := move_task_order.UpdateMoveTaskOrderStatusParams{
 		HTTPRequest:     request,
-		Body:            &ghcmessages.MoveTaskOrderStatus{Status: "DRAFT"},
+		Body:            &ghcmessages.MoveTaskOrderStatus{Status: "SUBMITTED"},
 		MoveTaskOrderID: moveTaskOrderID.String(),
 	}
 	context := handlers.NewHandlerContext(suite.DB(), suite.TestLogger())
 
 	// make the request
 	mtoStatusUpdater := &mocks.MoveTaskOrderStatusUpdater{}
-	mtoStatusUpdater.On("UpdateMoveTaskOrderStatus", moveTaskOrderID, models.MoveTaskOrderStatusDraft).
+	mtoStatusUpdater.On("UpdateMoveTaskOrderStatus", moveTaskOrderID, models.MoveTaskOrderStatusSubmitted).
 		Return(&models.MoveTaskOrder{}, errors.New("something bad happened"))
 	handler := UpdateMoveTaskOrderStatusHandlerFunc{context, mtoStatusUpdater}
 	response := handler.Handle(params)

--- a/pkg/handlers/primeapi/internal/payloads/model_to_payload.go
+++ b/pkg/handlers/primeapi/internal/payloads/model_to_payload.go
@@ -49,6 +49,7 @@ func MoveTaskOrder(moveTaskOrder models.MoveTaskOrder) *primemessages.MoveTaskOr
 		PrimeActualWeight:                primeActualWeight,
 		PrimeEstimatedWeight:             primeEstimatedWeight,
 		PrimeEstimatedWeightRecordedDate: primeEstimatedWeightRecordedDate,
+		ReferenceID:                      moveTaskOrder.ReferenceID,
 		Remarks:                          moveTaskOrder.CustomerRemarks,
 		RequestedPickupDate:              strfmt.Date(moveTaskOrder.RequestedPickupDate),
 		ScheduledMoveDate:                scheduledMoveDate,

--- a/pkg/handlers/primeapi/internal/payloads/model_to_payload.go
+++ b/pkg/handlers/primeapi/internal/payloads/model_to_payload.go
@@ -49,7 +49,6 @@ func MoveTaskOrder(moveTaskOrder models.MoveTaskOrder) *primemessages.MoveTaskOr
 		PrimeActualWeight:                primeActualWeight,
 		PrimeEstimatedWeight:             primeEstimatedWeight,
 		PrimeEstimatedWeightRecordedDate: primeEstimatedWeightRecordedDate,
-		ReferenceID:                      moveTaskOrder.ReferenceID,
 		Remarks:                          moveTaskOrder.CustomerRemarks,
 		RequestedPickupDate:              strfmt.Date(moveTaskOrder.RequestedPickupDate),
 		ScheduledMoveDate:                scheduledMoveDate,

--- a/pkg/models/move_task_order.go
+++ b/pkg/models/move_task_order.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"errors"
 	"fmt"
 	"math/rand"
 	"time"
@@ -95,5 +96,5 @@ func GenerateReferenceID(tx *pop.Connection) (*string, error) {
 			return &referenceID, nil
 		}
 	}
-	return nil, err
+	return nil, errors.New("move_task_order: failed to generate reference id")
 }

--- a/pkg/models/move_task_order.go
+++ b/pkg/models/move_task_order.go
@@ -50,9 +50,9 @@ type MoveTaskOrder struct {
 type MoveTaskOrderStatus string
 
 const (
-	MoveTaskOrderStatusApproved MoveTaskOrderStatus = "APPROVED"
-	MoveTaskOrderStatusDraft    MoveTaskOrderStatus = "DRAFT"
-	MoveTaskOrderStatusRejected MoveTaskOrderStatus = "REJECTED"
+	MoveTaskOrderStatusApproved  MoveTaskOrderStatus = "APPROVED"
+	MoveTaskOrderStatusSubmitted MoveTaskOrderStatus = "SUBMITTED"
+	MoveTaskOrderStatusRejected  MoveTaskOrderStatus = "REJECTED"
 )
 
 func (m *MoveTaskOrder) Validate(tx *pop.Connection) (*validate.Errors, error) {

--- a/pkg/models/move_task_order.go
+++ b/pkg/models/move_task_order.go
@@ -35,6 +35,7 @@ type MoveTaskOrder struct {
 	PrimeEstimatedWeight             *unit.Pound         `db:"prime_estimated_weight"`
 	PrimeEstimatedWeightRecordedDate *time.Time          `db:"prime_estimated_weight_recorded_date"`
 	RequestedPickupDate              time.Time           `db:"requested_pickup_date"`
+	ReferenceID                      string              `db:"reference_id"`
 	Status                           MoveTaskOrderStatus `db:"status"`
 	ServiceItems                     ServiceItems        `has_many:"service_items"`
 	UpdatedAt                        time.Time           `db:"updated_at"`
@@ -69,10 +70,28 @@ func (m *MoveTaskOrder) Validate(tx *pop.Connection) (*validate.Errors, error) {
 type MoveTaskOrders []MoveTaskOrder
 
 // GenerateReferenceID creates a random ID for an MTO. Format (xxxx-xxxx) with X being a number 0-9 (ex. 0009-1234. 4321-4444)
-func GenerateReferenceID() string {
+func generateReferenceID(tx *pop.Connection) (string, error) {
 	min := 0
 	max := 9999
 	firstNum := rand.Intn(max - min + 1)
 	secondNum := rand.Intn(max - min + 1)
-	return fmt.Sprintf("%04d-%04d", firstNum, secondNum)
+	newReferenceID := fmt.Sprintf("%04d-%04d", firstNum, secondNum)
+	count, err := tx.Where(`reference_id= $1`, newReferenceID).Count(&MoveTaskOrder{})
+	if err != nil || count > 0 {
+		return "", err
+	}
+	return newReferenceID, nil
+}
+
+func GenerateReferenceID(tx *pop.Connection) (string, error) {
+	const maxAttempts = 10
+	var referenceID string
+	var err error
+	for i := 0; i < maxAttempts; i++ {
+		referenceID, err = generateReferenceID(tx)
+		if err == nil {
+			return referenceID, nil
+		}
+	}
+	return "", err
 }

--- a/pkg/models/move_task_order.go
+++ b/pkg/models/move_task_order.go
@@ -35,7 +35,7 @@ type MoveTaskOrder struct {
 	PrimeEstimatedWeight             *unit.Pound         `db:"prime_estimated_weight"`
 	PrimeEstimatedWeightRecordedDate *time.Time          `db:"prime_estimated_weight_recorded_date"`
 	RequestedPickupDate              time.Time           `db:"requested_pickup_date"`
-	ReferenceID                      string              `db:"reference_id"`
+	ReferenceID                      *string             `db:"reference_id"`
 	Status                           MoveTaskOrderStatus `db:"status"`
 	ServiceItems                     ServiceItems        `has_many:"service_items"`
 	UpdatedAt                        time.Time           `db:"updated_at"`
@@ -50,9 +50,9 @@ type MoveTaskOrder struct {
 type MoveTaskOrderStatus string
 
 const (
-	MoveTaskOrderStatusApproved  MoveTaskOrderStatus = "APPROVED"
-	MoveTaskOrderStatusSubmitted MoveTaskOrderStatus = "SUBMITTED"
-	MoveTaskOrderStatusRejected  MoveTaskOrderStatus = "REJECTED"
+	MoveTaskOrderStatusApproved MoveTaskOrderStatus = "APPROVED"
+	MoveTaskOrderStatusDraft    MoveTaskOrderStatus = "DRAFT"
+	MoveTaskOrderStatusRejected MoveTaskOrderStatus = "REJECTED"
 )
 
 func (m *MoveTaskOrder) Validate(tx *pop.Connection) (*validate.Errors, error) {
@@ -83,15 +83,15 @@ func generateReferenceID(tx *pop.Connection) (string, error) {
 	return newReferenceID, nil
 }
 
-func GenerateReferenceID(tx *pop.Connection) (string, error) {
+func GenerateReferenceID(tx *pop.Connection) (*string, error) {
 	const maxAttempts = 10
 	var referenceID string
 	var err error
 	for i := 0; i < maxAttempts; i++ {
 		referenceID, err = generateReferenceID(tx)
 		if err == nil {
-			return referenceID, nil
+			return &referenceID, nil
 		}
 	}
-	return "", err
+	return nil, err
 }

--- a/pkg/models/move_task_order_test.go
+++ b/pkg/models/move_task_order_test.go
@@ -9,7 +9,9 @@ import (
 )
 
 func (suite *ModelSuite) TestGenerateReferenceID() {
-	referenceID, err := models.GenerateReferenceID(suite.DB())
+	r, err := models.GenerateReferenceID(suite.DB())
+	suite.NotNil(r)
+	referenceID := *r
 	suite.NoError(err)
 	firstNum, _ := strconv.Atoi(strings.Split(referenceID, "-")[0])
 	secondNum, _ := strconv.Atoi(strings.Split(referenceID, "-")[1])

--- a/pkg/models/move_task_order_test.go
+++ b/pkg/models/move_task_order_test.go
@@ -9,7 +9,8 @@ import (
 )
 
 func (suite *ModelSuite) TestGenerateReferenceID() {
-	referenceID := models.GenerateReferenceID()
+	referenceID, err := models.GenerateReferenceID(suite.DB())
+	suite.NoError(err)
 	firstNum, _ := strconv.Atoi(strings.Split(referenceID, "-")[0])
 	secondNum, _ := strconv.Atoi(strings.Split(referenceID, "-")[1])
 	suite.Equal(reflect.TypeOf(referenceID).String(), "string")

--- a/pkg/services/move_task_order/move_task_order.go
+++ b/pkg/services/move_task_order/move_task_order.go
@@ -99,6 +99,12 @@ func (f fetchMoveTaskOrder) UpdateMoveTaskOrderStatus(moveTaskOrderID uuid.UUID,
 	if err != nil {
 		return &models.MoveTaskOrder{}, err
 	}
+	if mto.Status != status && status == models.MoveTaskOrderStatusApproved {
+		mto.ReferenceID, err = models.GenerateReferenceID(f.db)
+	}
+	if err != nil {
+		return &models.MoveTaskOrder{}, err
+	}
 	mto.Status = status
 	vErrors, err := f.db.ValidateAndUpdate(mto)
 	if vErrors.HasAny() {

--- a/pkg/services/move_task_order/move_task_order_test.go
+++ b/pkg/services/move_task_order/move_task_order_test.go
@@ -52,20 +52,21 @@ func (suite *MoveTaskOrderServiceSuite) TestMoveTaskOrderStatusUpdater() {
 	serviceItem := testdatagen.MakeServiceItem(suite.DB(), testdatagen.Assertions{})
 	originalMTO := serviceItem.MoveTaskOrder
 	// check not equal to what asserting against below
-	suite.NotEqual(originalMTO.Status, models.MoveTaskOrderStatusApproved)
+	suite.NotEqual(originalMTO.Status, models.MoveTaskOrderStatusSubmitted)
 	mtoStatusUpdater := NewMoveTaskOrderStatusUpdater(suite.DB())
 
 	updatedMTO, err := mtoStatusUpdater.UpdateMoveTaskOrderStatus(originalMTO.ID, models.MoveTaskOrderStatusApproved)
 
 	suite.NoError(err)
 	suite.Equal(models.MoveTaskOrderStatusApproved, updatedMTO.Status)
+	suite.NotNil(updatedMTO.ReferenceID)
 }
 
 func (suite *MoveTaskOrderServiceSuite) TestMoveTaskOrderStatusUpdaterEmptyStatus() {
 	serviceItem := testdatagen.MakeServiceItem(suite.DB(), testdatagen.Assertions{})
 	originalMTO := serviceItem.MoveTaskOrder
 	// check not equal to what asserting against below
-	suite.NotEqual(originalMTO.Status, models.MoveTaskOrderStatusApproved)
+	suite.NotEqual(originalMTO.Status, models.MoveTaskOrderStatusSubmitted)
 	mtoStatusUpdater := NewMoveTaskOrderStatusUpdater(suite.DB())
 
 	_, err := mtoStatusUpdater.UpdateMoveTaskOrderStatus(originalMTO.ID, "")

--- a/pkg/services/move_task_order/move_task_order_test.go
+++ b/pkg/services/move_task_order/move_task_order_test.go
@@ -91,6 +91,21 @@ func (suite *MoveTaskOrderServiceSuite) TestMoveTaskOrderStatusUpdaterDraftStatu
 	suite.Nil(updatedMTO.ReferenceID)
 }
 
+func (suite *MoveTaskOrderServiceSuite) TestMoveTaskOrderStatusUpdaterReferenceIDUnchangedOnRepeatedCalls() {
+	serviceItem := testdatagen.MakeServiceItem(suite.DB(), testdatagen.Assertions{})
+	originalMTO := serviceItem.MoveTaskOrder
+	// check not equal to what asserting against below
+	suite.Equal(originalMTO.Status, models.MoveTaskOrderStatusApproved)
+	suite.NotNil(originalMTO.ReferenceID)
+	mtoStatusUpdater := NewMoveTaskOrderStatusUpdater(suite.DB())
+
+	updatedMTO, err := mtoStatusUpdater.UpdateMoveTaskOrderStatus(originalMTO.ID, models.MoveTaskOrderStatusDraft)
+
+	suite.NoError(err)
+	// Reference ID should not change on repeated calls to Update
+	suite.Equal(*updatedMTO.ReferenceID, *originalMTO.ReferenceID)
+}
+
 func (suite *MoveTaskOrderServiceSuite) TestMoveTaskOrderStatusUpdaterEmptyStatus() {
 	serviceItem := testdatagen.MakeServiceItem(suite.DB(), testdatagen.Assertions{})
 	originalMTO := serviceItem.MoveTaskOrder

--- a/pkg/testdatagen/make_move_task_order.go
+++ b/pkg/testdatagen/make_move_task_order.go
@@ -29,6 +29,7 @@ func MakeMoveTaskOrder(db *pop.Connection, assertions Assertions) models.MoveTas
 	if isZeroUUID(destinationAddress.ID) {
 		destinationAddress = MakeAddress2(db, assertions)
 	}
+	referenceID, _ := models.GenerateReferenceID(db)
 	moveTaskOrder := models.MoveTaskOrder{
 		MoveID:                   move.ID,
 		CustomerID:               sm.ID,
@@ -37,13 +38,14 @@ func MakeMoveTaskOrder(db *pop.Connection, assertions Assertions) models.MoveTas
 		OriginDutyStation:        sm.DutyStation,
 		DestinationDutyStation:   move.Orders.NewDutyStation,
 		DestinationDutyStationID: move.Orders.NewDutyStation.ID,
+		ReferenceID:              referenceID,
 		PickupAddress:            pickupAddress,
 		PickupAddressID:          pickupAddress.ID,
 		DestinationAddress:       destinationAddress,
 		DestinationAddressID:     destinationAddress.ID,
 		RequestedPickupDate:      time.Date(TestYear, time.March, 15, 0, 0, 0, 0, time.UTC),
 		CustomerRemarks:          "Park in the alley",
-		Status:                   models.MoveTaskOrderStatusDraft,
+		Status:                   models.MoveTaskOrderStatusApproved,
 	}
 
 	// Overwrite values with those from assertions

--- a/pkg/testdatagen/make_move_task_order.go
+++ b/pkg/testdatagen/make_move_task_order.go
@@ -29,7 +29,15 @@ func MakeMoveTaskOrder(db *pop.Connection, assertions Assertions) models.MoveTas
 	if isZeroUUID(destinationAddress.ID) {
 		destinationAddress = MakeAddress2(db, assertions)
 	}
-	referenceID, _ := models.GenerateReferenceID(db)
+	mtoStatus := assertions.MoveTaskOrder.Status
+	if mtoStatus == "" {
+		mtoStatus = models.MoveTaskOrderStatusApproved
+	}
+
+	var referenceID *string
+	if assertions.MoveTaskOrder.Status != models.MoveTaskOrderStatusDraft {
+		referenceID, _ = models.GenerateReferenceID(db)
+	}
 	moveTaskOrder := models.MoveTaskOrder{
 		MoveID:                   move.ID,
 		CustomerID:               sm.ID,
@@ -45,7 +53,7 @@ func MakeMoveTaskOrder(db *pop.Connection, assertions Assertions) models.MoveTas
 		DestinationAddressID:     destinationAddress.ID,
 		RequestedPickupDate:      time.Date(TestYear, time.March, 15, 0, 0, 0, 0, time.UTC),
 		CustomerRemarks:          "Park in the alley",
-		Status:                   models.MoveTaskOrderStatusApproved,
+		Status:                   mtoStatus,
 	}
 
 	// Overwrite values with those from assertions

--- a/pkg/testdatagen/scenario/e2ebasic.go
+++ b/pkg/testdatagen/scenario/e2ebasic.go
@@ -865,7 +865,8 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, log
 
 	testdatagen.MakeMoveTaskOrder(db, testdatagen.Assertions{
 		MoveTaskOrder: models.MoveTaskOrder{
-			ID: uuid.FromStringOrNil("1c030e51-b5be-40a2-80bf-97a330891307"),
+			ID:     uuid.FromStringOrNil("1c030e51-b5be-40a2-80bf-97a330891307"),
+			Status: models.MoveTaskOrderStatusDraft,
 		},
 	})
 }

--- a/swagger/ghc.yaml
+++ b/swagger/ghc.yaml
@@ -1151,6 +1151,7 @@ definitions:
       referenceId:
         example: 1001-3456
         type: string
+        x-nullable: true
       remarks:
         example: Requires more gentle care
         type: string

--- a/swagger/ghc.yaml
+++ b/swagger/ghc.yaml
@@ -1148,6 +1148,9 @@ definitions:
         type: string
       pickupAddress:
         $ref: '#/definitions/Address'
+      referenceId:
+        example: 1001-3456
+        type: string
       remarks:
         example: Requires more gentle care
         type: string

--- a/swagger/prime.yaml
+++ b/swagger/prime.yaml
@@ -581,6 +581,7 @@ definitions:
       referenceId:
         example: 1001-3456
         type: string
+        x-nullable: true
       remarks:
         example: Requires more gentle care
         type: string

--- a/swagger/prime.yaml
+++ b/swagger/prime.yaml
@@ -578,6 +578,9 @@ definitions:
       destination_address:
         $ref: '#/definitions/Address'
         x-nullable: true
+      referenceId:
+        example: 1001-3456
+        type: string
       remarks:
         example: Requires more gentle care
         type: string


### PR DESCRIPTION
## Description

The move transfer order should now include a reference number, which we're calling the reference_id.  This PR adds that number to the MTO payload.

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

The Reference ID should be present on the move task order.

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](https://www.pivotaltracker.com/story/show/169582181) for this change