### PR TITLE
PRIME API should be behind the NLB

### DIFF
--- a/config/app-client-tls.container-definition.json
+++ b/config/app-client-tls.container-definition.json
@@ -165,6 +165,10 @@
     {
       "name": "SERVE_ORDERS",
       "value": "{{ .SERVE_ORDERS }}"
+    },
+    {
+      "name": "SERVE_API_GHC",
+      "value": "{{ .SERVE_API_GHC }}"
     }
   ],
   "logConfiguration": {

--- a/config/app.container-definition.json
+++ b/config/app.container-definition.json
@@ -184,10 +184,6 @@
     {
       "name": "SERVE_API_INTERNAL",
       "value": "{{ .SERVE_API_INTERNAL }}"
-    },
-    {
-      "name": "SERVE_API_GHC",
-      "value": "{{ .SERVE_API_GHC }}"
     }
   ],
   "logConfiguration": {


### PR DESCRIPTION
## Description

The PRIME API should be behind the NLB so that it uses the Mutual TLS listener. This should not be behind the ALB.