### PR TITLE
Fix for missing address data for duty stations

### DIFF
--- a/pkg/models/duty_station.go
+++ b/pkg/models/duty_station.go
@@ -81,7 +81,7 @@ func FetchDSContactInfo(db *pop.Connection, dutyStationID *uuid.UUID) (*DutyStat
 // FetchDutyStation returns a station for a given id
 func FetchDutyStation(ctx context.Context, tx *pop.Connection, id uuid.UUID) (DutyStation, error) {
 	var station DutyStation
-	err := tx.Q().Find(&station, id)
+	err := tx.Q().Eager("Address").Find(&station, id)
 	return station, err
 }
 


### PR DESCRIPTION
## Description

Adds in an eager call to the handler used to fetch duty stations so that the Address field is populated.

## Setup

No special steps

## References

* [Slack thread](https://ustcdp3.slack.com/archives/CP4EDELTW/p1574700439001700) for this change