### PR TITLE
Add hover state to tooltip

### DIFF
--- a/src/scenes/Office/MoveInfo.jsx
+++ b/src/scenes/Office/MoveInfo.jsx
@@ -121,6 +121,7 @@ const ReferrerQueueLink = props => {
 class MoveInfo extends Component {
   state = {
     redirectToHome: false,
+    hideTooltip: true,
   };
 
   componentDidMount() {
@@ -203,6 +204,10 @@ class MoveInfo extends Component {
         </span>
       );
     }
+  };
+
+  handleToolTipHover = () => {
+    this.setState({ hideTooltip: !this.state.hideTooltip });
   };
 
   render() {
@@ -325,9 +330,9 @@ class MoveInfo extends Component {
                   Please fill out missing data
                 </Alert>
               )}
-              <div>
+              <div onMouseEnter={this.handleToolTipHover} onMouseLeave={this.handleToolTipHover}>
                 <ToolTip
-                  disabled={ordersComplete}
+                  disabled={this.state.hideTooltip}
                   textStyle="tooltiptext-large"
                   toolTipText="Some information about the move is missing or contains errors. Please fix these problems before approving."
                 >


### PR DESCRIPTION
## Description

We want to hide the tooltip by default, but allow office users to hover to see more information.

## Setup

- `make server_run`
- `make client_run`

## Code Review Verification Steps

* [x] User facing changes have been reviewed by design.
* [x] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-576) for this change

## Screenshots

![Screen Recording 2019-11-26 at 09 12 48](https://user-images.githubusercontent.com/3522323/69656286-1fb8d100-102d-11ea-9139-5c150d1298b2.gif)
