### PR TITLE
MB-712: ma change default migration type to sql

### DIFF
--- a/pkg/cli/migration_file.go
+++ b/pkg/cli/migration_file.go
@@ -56,7 +56,7 @@ func (e *errInvalidMigrationType) Error() string {
 func InitMigrationFileFlags(flag *pflag.FlagSet) {
 	flag.String(MigrationVersionFlag, time.Now().Format(VersionTimeFormat), "migration version: integer representation of datetime, default is current time using Go format "+VersionTimeFormat)
 	flag.StringP(MigrationNameFlag, "n", "", "migration name: alphanumeric, no spaces, underscores and dashes allowed")
-	flag.StringP(MigrationTypeFlag, "t", "fizz", "migration type: fizz or sql.")
+	flag.StringP(MigrationTypeFlag, "t", "sql", "migration type: fizz or sql.")
 }
 
 // CheckMigration validates migration command line flags


### PR DESCRIPTION
## Description

Per chat with @chrisgilmerproj , we're changing the default migration type from fizz to sql.
https://ustcdp3.slack.com/archives/CP497TGAU/p1574716482017000

## References

* [Story](https://dp3.atlassian.net/browse/MB-712) for this change