### PR TITLE
Switch to cypress-multi-reporters

### DIFF
--- a/Dockerfile.cypress
+++ b/Dockerfile.cypress
@@ -4,7 +4,7 @@ FROM cypress/base:10
 # We use `npm install` here because you can't selectively `yarn install` packages and we don't care about a lockfile and
 # `yarn add` won't read from our existing package.json
 COPY package.json /package.json
-RUN npm install --save-dev mocha mocha-multi-reporters mocha-junit-reporter moment
+RUN npm install --save-dev mocha cypress-multi-reporters mocha-junit-reporter moment
 RUN npm install --save-dev --silent cypress
 
 COPY cypress/ /cypress

--- a/cypress.json
+++ b/cypress.json
@@ -1,6 +1,6 @@
 {
   "baseUrl": "http://milmovelocal:4000",
-  "reporter": "mocha-multi-reporters",
+  "reporter": "cypress-multi-reporters",
   "reporterOptions": {
     "configFile": "mocha-reporter-config.json"
   },

--- a/package.json
+++ b/package.json
@@ -89,10 +89,10 @@
     "@storybook/addons": "^5.1.11",
     "@storybook/react": "^5.2.6",
     "cypress": "^3.6.1",
+    "cypress-multi-reporters": "^1.2.3",
     "mime-types": "^2.1.25",
     "mocha": "^6.2.2",
-    "mocha-junit-reporter": "^1.18.0",
-    "mocha-multi-reporters": "^1.1.7",
+    "mocha-junit-reporter": "1.23.1",
     "mockdate": "^2.0.2",
     "prettier": "=1.19.1",
     "react-mock-router": "^1.0.15"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4658,6 +4658,14 @@ cyclist@^1.0.1:
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"
   integrity sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=
 
+cypress-multi-reporters@^1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/cypress-multi-reporters/-/cypress-multi-reporters-1.2.3.tgz#4ba39373631c6521d21931d73f6b0bafa1ccbf83"
+  integrity sha512-W3ItWsbSgMfsQFTuB89OXY5gyqLuM0O2lNEn+mcQAYeMs36TxVLAg3q+Hk0Om+NcWj8OLhM06lBQpnu9+i4gug==
+  dependencies:
+    debug "^4.1.1"
+    lodash "^4.17.11"
+
 cypress@^3.6.1:
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/cypress/-/cypress-3.6.1.tgz#4420957923879f60b7a5146ccbf81841a149b653"
@@ -8867,7 +8875,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@4.17.15, "lodash@>=3.5 <5", lodash@^4.0.0, lodash@^4.0.1, lodash@^4.15.0, lodash@^4.16.4, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.5, lodash@^4.2.1, lodash@~4.17.10, lodash@~4.17.5:
+lodash@4.17.15, "lodash@>=3.5 <5", lodash@^4.0.0, lodash@^4.0.1, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.5, lodash@^4.2.1, lodash@~4.17.10, lodash@~4.17.5:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
@@ -9334,7 +9342,7 @@ mkdirp@0.5.1, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.1:
   dependencies:
     minimist "0.0.8"
 
-mocha-junit-reporter@^1.18.0:
+mocha-junit-reporter@1.23.1:
   version "1.23.1"
   resolved "https://registry.yarnpkg.com/mocha-junit-reporter/-/mocha-junit-reporter-1.23.1.tgz#ba11519c0b967f404e4123dd69bc4ba022ab0f12"
   integrity sha512-qeDvKlZyAH2YJE1vhryvjUQ06t2hcnwwu4k5Ddwn0GQINhgEYFhlGM0DwYCVUHq5cuo32qAW6HDsTHt7zz99Ng==
@@ -9344,14 +9352,6 @@ mocha-junit-reporter@^1.18.0:
     mkdirp "~0.5.1"
     strip-ansi "^4.0.0"
     xml "^1.0.0"
-
-mocha-multi-reporters@^1.1.7:
-  version "1.1.7"
-  resolved "https://registry.yarnpkg.com/mocha-multi-reporters/-/mocha-multi-reporters-1.1.7.tgz#cc7f3f4d32f478520941d852abb64d9988587d82"
-  integrity sha1-zH8/TTL0eFIJQdhSq7ZNmYhYfYI=
-  dependencies:
-    debug "^3.1.0"
-    lodash "^4.16.4"
 
 mocha@^6.2.2:
   version "6.2.2"


### PR DESCRIPTION
## Description

This fixes an issue we were seeing where the Cypress upgrade to 3.7.0 started failing due to an incompatibility between mocha 6 and `mocha-multi-reporters` that had been failing silently since that upgrade.