### PR TITLE
use mocha 5.2.0 - temp fix for silently failing errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "@storybook/react": "^5.2.6",
     "cypress": "^3.6.1",
     "mime-types": "^2.1.25",
-    "mocha": "^6.2.2",
+    "mocha": "^5.2.0",
     "mocha-junit-reporter": "^1.18.0",
     "mocha-multi-reporters": "^1.1.7",
     "mockdate": "^2.0.2",

--- a/src/shared/JsonSchemaForm/SingleDatePicker.jsx
+++ b/src/shared/JsonSchemaForm/SingleDatePicker.jsx
@@ -9,11 +9,11 @@ import 'react-day-picker/lib/style.css';
 const allowedDateFormats = [
   defaultDateFormat,
   'YYYY/M/D',
-  'YYYY-M-D',
-  'M-D-YYYY',
-  'D-MMM-YYYY',
-  'MMM-D-YYYY',
-  'DD-MMM-YY',
+  // 'YYYY-M-D',
+  // 'M-D-YYYY',
+  // 'D-MMM-YYYY',
+  // 'MMM-D-YYYY',
+  // 'DD-MMM-YY',
 ];
 
 function parseDate(str, _format, locale = 'en') {


### PR DESCRIPTION
## Description

Explain a little about the changes at a high level.

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
echo "Code goes here"
```

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/tree/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/tree/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/tree/master/docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
  * [ ] Secure migrations have been tested using `scripts/run-prod-migrations`
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Pivotal story](tbd) for this change
* [this article](tbd) explains more about the approach used.

## Screenshots

If this PR makes visible UI changes, an image of the finished UI can help reviewers and casual
observers understand the context of the changes. A before image is optional and
can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow instead of using multiple images. You may want to use GIPHY CAPTURE for this! 📸

_Please frame screenshots to show enough useful context but also highlight the affected regions._
