### PR TITLE
Feature flag for tio

### DIFF
--- a/src/scenes/Office/TIO/tio.jsx
+++ b/src/scenes/Office/TIO/tio.jsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+const TIO = () => <h1>This is the TIO interface!</h1>;
+
+export default TIO;

--- a/src/scenes/Office/index.jsx
+++ b/src/scenes/Office/index.jsx
@@ -29,6 +29,7 @@ const DocumentViewer = lazy(() => import('./DocumentViewer'));
 const ScratchPad = lazy(() => import('shared/ScratchPad'));
 const CustomerDetails = lazy(() => import('./TOO/customerDetails'));
 const TOO = lazy(() => import('./TOO/too'));
+const TIO = lazy(() => import('./TIO/tio'));
 
 export class RenderWithOrWithoutHeader extends Component {
   render() {
@@ -67,7 +68,7 @@ export class OfficeWrapper extends Component {
 
   render() {
     const ConditionalWrap = ({ condition, wrap, children }) => (condition ? wrap(children) : <>{children}</>);
-    const { context: { flags: { too } } = { flags: { too: null } } } = this.props;
+    const { context: { flags: { too, tio } } = { flags: { too: null } } } = this.props;
     const DivOrMainTag = detectIE11() ? 'div' : 'main';
     const { userIsLoggedIn } = this.props;
     return (
@@ -160,6 +161,7 @@ export class OfficeWrapper extends Component {
                   <Switch>
                     {too && <PrivateRoute path="/too/placeholder" component={TOO} />}
                     {too && <PrivateRoute path="/too/customer/:customerId/details" component={CustomerDetails} />}
+                    {tio && <PrivateRoute path="/tio/placeholder" component={TIO} />}
                   </Switch>
                 </Suspense>
               </Switch>

--- a/src/shared/featureFlags.js
+++ b/src/shared/featureFlags.js
@@ -20,13 +20,13 @@ const defaultFlags = {
 };
 
 const environmentFlags = {
-  development: Object.assign({}, defaultFlags, { too: true }),
+  development: Object.assign({}, defaultFlags, { tio: true, too: true }),
 
   test: Object.assign({}, defaultFlags),
 
-  experimental: Object.assign({}, defaultFlags, { too: true }),
+  experimental: Object.assign({}, defaultFlags, { tio: true, too: true }),
 
-  staging: Object.assign({}, defaultFlags, { too: true }),
+  staging: Object.assign({}, defaultFlags, { tio: true, too: true }),
 
   production: Object.assign({}, defaultFlags, {
     sitPanel: false,

--- a/src/shared/featureFlags.js
+++ b/src/shared/featureFlags.js
@@ -15,6 +15,7 @@ const defaultFlags = {
   sitPanel: true,
   ppmPaymentRequest: true,
   too: false,
+  tio: false,
   progearChanges: false,
 };
 


### PR DESCRIPTION
## Description

Set up a feature flag that we can use for the TIO interfaces

## Reviewer Notes

I've set the feature flag to `true` for dev, experimental, and staging. So here are some tips for testing!
1. Hitting `http://officelocal:3000/tio/placeholder` should show you a page that has a basic TIO message
2. Hitting `http://officelocal:3000/tio/placeholder?flag:tio=false` (turning the flag off) should show a blank screen, which is the default if a route doesn't exist

## Code Review Verification Steps
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Request review from a member of a different team.
* [ ] Have the Pivotal acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-751) for this change

## Screenshots
<img width="772" alt="Screen Shot 2019-12-04 at 7 53 52 AM" src="https://user-images.githubusercontent.com/4434681/70157947-47321e00-166b-11ea-9873-5c9c252eab44.png">

