### PR TITLE
Sb mb 685 tio show page with dummy data

### DIFF
--- a/pkg/handlers/ghcapi/api.go
+++ b/pkg/handlers/ghcapi/api.go
@@ -8,8 +8,6 @@ import (
 
 	"github.com/go-openapi/loads"
 
-	paymentrequest "github.com/transcom/mymove/pkg/services/payment_request"
-
 	"github.com/transcom/mymove/pkg/gen/ghcapi"
 	ghcops "github.com/transcom/mymove/pkg/gen/ghcapi/ghcoperations"
 	"github.com/transcom/mymove/pkg/handlers"

--- a/pkg/handlers/ghcapi/api.go
+++ b/pkg/handlers/ghcapi/api.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/go-openapi/loads"
 
+	paymentrequest "github.com/transcom/mymove/pkg/services/payment_request"
+
 	"github.com/transcom/mymove/pkg/gen/ghcapi"
 	ghcops "github.com/transcom/mymove/pkg/gen/ghcapi/ghcoperations"
 	"github.com/transcom/mymove/pkg/handlers"
@@ -21,6 +23,10 @@ func NewGhcAPIHandler(context handlers.HandlerContext) http.Handler {
 		log.Fatalln(err)
 	}
 	ghcAPI := ghcops.NewMymoveAPI(ghcSpec)
+	ghcAPI.PaymentRequestsGetPaymentRequestHandler = ShowPaymentRequestHandler{
+		context,
+		paymentrequest.NewPaymentRequestFetcher(context.DB()),
+	}
 
 	ghcAPI.PaymentRequestsListPaymentRequestsHandler = ListPaymentRequestsHandler{
 		context,

--- a/pkg/handlers/ghcapi/payment_request.go
+++ b/pkg/handlers/ghcapi/payment_request.go
@@ -16,7 +16,7 @@ func payloadForPaymentRequestModel(pr models.PaymentRequest) *ghcmessages.Paymen
 	return &ghcmessages.PaymentRequest{
 		ID:              *handlers.FmtUUID(pr.ID),
 		IsFinal:         &pr.IsFinal,
-		RejectionReason: pr.RejectionReason,
+		RejectionReason: &pr.RejectionReason,
 	}
 }
 
@@ -41,4 +41,18 @@ func (h ListPaymentRequestsHandler) Handle(params paymentrequestop.ListPaymentRe
 	}
 
 	return paymentrequestop.NewListPaymentRequestsOK().WithPayload(paymentRequestsList)
+}
+
+type ShowPaymentRequestHandler struct {
+	handlers.HandlerContext
+	services.PaymentRequestFetcher
+}
+
+func (h ShowPaymentRequestHandler) Handle(params paymentrequestop.GetPaymentRequestParams) middleware.Responder {
+	paymentRequest, _, _ := h.FetchPaymentRequest()
+
+	returnPayload := payloadForPaymentRequestModel(*paymentRequest)
+	response := paymentrequestop.NewGetPaymentRequestOK().WithPayload(returnPayload)
+
+	return response
 }

--- a/pkg/handlers/ghcapi/payment_request.go
+++ b/pkg/handlers/ghcapi/payment_request.go
@@ -2,6 +2,7 @@ package ghcapi
 
 import (
 	"github.com/go-openapi/runtime/middleware"
+	"github.com/gofrs/uuid"
 	"go.uber.org/zap"
 
 	paymentrequestop "github.com/transcom/mymove/pkg/gen/ghcapi/ghcoperations/payment_requests"
@@ -49,7 +50,8 @@ type ShowPaymentRequestHandler struct {
 }
 
 func (h ShowPaymentRequestHandler) Handle(params paymentrequestop.GetPaymentRequestParams) middleware.Responder {
-	paymentRequest, _, _ := h.FetchPaymentRequest()
+	paymentRequestID, _ := uuid.FromString(params.PaymentRequestID.String())
+	paymentRequest, _, _ := h.FetchPaymentRequest(paymentRequestID)
 
 	returnPayload := payloadForPaymentRequestModel(*paymentRequest)
 	response := paymentrequestop.NewGetPaymentRequestOK().WithPayload(returnPayload)

--- a/pkg/handlers/ghcapi/payment_request.go
+++ b/pkg/handlers/ghcapi/payment_request.go
@@ -51,7 +51,7 @@ type ShowPaymentRequestHandler struct {
 
 func (h ShowPaymentRequestHandler) Handle(params paymentrequestop.GetPaymentRequestParams) middleware.Responder {
 	paymentRequestID, _ := uuid.FromString(params.PaymentRequestID.String())
-	paymentRequest, _, _ := h.FetchPaymentRequest(paymentRequestID)
+	paymentRequest, _ := h.FetchPaymentRequest(paymentRequestID)
 
 	returnPayload := payloadForPaymentRequestModel(*paymentRequest)
 	response := paymentrequestop.NewGetPaymentRequestOK().WithPayload(returnPayload)

--- a/pkg/handlers/ghcapi/payment_request.go
+++ b/pkg/handlers/ghcapi/payment_request.go
@@ -17,7 +17,7 @@ func payloadForPaymentRequestModel(pr models.PaymentRequest) *ghcmessages.Paymen
 	return &ghcmessages.PaymentRequest{
 		ID:              *handlers.FmtUUID(pr.ID),
 		IsFinal:         &pr.IsFinal,
-		RejectionReason: &pr.RejectionReason,
+		RejectionReason: pr.RejectionReason,
 	}
 }
 

--- a/pkg/services/payment_request.go
+++ b/pkg/services/payment_request.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"github.com/gobuffalo/validate"
+	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/models"
 )
@@ -20,5 +21,5 @@ type PaymentRequestListFetcher interface {
 
 // PaymentRequestFetcher is the exported interface for fetching a payment request
 type PaymentRequestFetcher interface {
-	FetchPaymentRequest() (*models.PaymentRequest, *validate.Errors, error)
+	FetchPaymentRequest(paymentRequestID uuid.UUID) (*models.PaymentRequest, *validate.Errors, error)
 }

--- a/pkg/services/payment_request.go
+++ b/pkg/services/payment_request.go
@@ -17,3 +17,8 @@ type PaymentRequestCreator interface {
 type PaymentRequestListFetcher interface {
 	FetchPaymentRequestList() (*models.PaymentRequests, error)
 }
+
+// PaymentRequestFetcher is the exported interface for fetching a payment request
+type PaymentRequestFetcher interface {
+	FetchPaymentRequest() (*models.PaymentRequest, *validate.Errors, error)
+}

--- a/pkg/services/payment_request.go
+++ b/pkg/services/payment_request.go
@@ -21,5 +21,5 @@ type PaymentRequestListFetcher interface {
 
 // PaymentRequestFetcher is the exported interface for fetching a payment request
 type PaymentRequestFetcher interface {
-	FetchPaymentRequest(paymentRequestID uuid.UUID) (*models.PaymentRequest, *validate.Errors, error)
+	FetchPaymentRequest(paymentRequestID uuid.UUID) (*models.PaymentRequest, error)
 }

--- a/pkg/services/payment_request/payment_request_fetcher.go
+++ b/pkg/services/payment_request/payment_request_fetcher.go
@@ -24,7 +24,7 @@ func (p *paymentRequestFetcher) FetchPaymentRequest(paymentRequestID uuid.UUID) 
 	mockPaymentRequest := models.PaymentRequest{
 		ID:              paymentRequestID,
 		IsFinal:         false,
-		RejectionReason: swag.String(""),
+		RejectionReason: swag.String("I don't approve of this"),
 		CreatedAt:       testdatagen.PeakRateCycleStart,
 		UpdatedAt:       testdatagen.PeakRateCycleStart,
 	}

--- a/pkg/services/payment_request/payment_request_fetcher.go
+++ b/pkg/services/payment_request/payment_request_fetcher.go
@@ -1,0 +1,33 @@
+package paymentrequest
+
+import (
+	"github.com/gobuffalo/pop"
+	"github.com/gobuffalo/validate"
+	"github.com/gofrs/uuid"
+
+	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/services"
+	"github.com/transcom/mymove/pkg/testdatagen"
+)
+
+type paymentRequestFetcher struct {
+	db *pop.Connection
+}
+
+func NewPaymentRequestFetcher(db *pop.Connection) services.PaymentRequestFetcher {
+	return &paymentRequestFetcher{db}
+}
+
+func (p *paymentRequestFetcher) FetchPaymentRequest() (*models.PaymentRequest, *validate.Errors, error) {
+	// A mock payment request. This is temporary and will be replaced with real data eventually.
+	uuid, _ := uuid.NewV4()
+	mockPaymentRequest := models.PaymentRequest{
+		ID:              uuid,
+		IsFinal:         false,
+		RejectionReason: "",
+		CreatedAt:       testdatagen.PeakRateCycleStart,
+		UpdatedAt:       testdatagen.PeakRateCycleStart,
+	}
+
+	return &mockPaymentRequest, nil, nil
+}

--- a/pkg/services/payment_request/payment_request_fetcher.go
+++ b/pkg/services/payment_request/payment_request_fetcher.go
@@ -3,7 +3,6 @@ package paymentrequest
 import (
 	"github.com/go-openapi/swag"
 	"github.com/gobuffalo/pop"
-	"github.com/gobuffalo/validate"
 	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/models"
@@ -19,7 +18,7 @@ func NewPaymentRequestFetcher(db *pop.Connection) services.PaymentRequestFetcher
 	return &paymentRequestFetcher{db}
 }
 
-func (p *paymentRequestFetcher) FetchPaymentRequest(paymentRequestID uuid.UUID) (*models.PaymentRequest, *validate.Errors, error) {
+func (p *paymentRequestFetcher) FetchPaymentRequest(paymentRequestID uuid.UUID) (*models.PaymentRequest, error) {
 	// A mock payment request. This is temporary and will be replaced with real data eventually.
 	mockPaymentRequest := models.PaymentRequest{
 		ID:              paymentRequestID,
@@ -29,5 +28,5 @@ func (p *paymentRequestFetcher) FetchPaymentRequest(paymentRequestID uuid.UUID) 
 		UpdatedAt:       testdatagen.PeakRateCycleStart,
 	}
 
-	return &mockPaymentRequest, nil, nil
+	return &mockPaymentRequest, nil
 }

--- a/pkg/services/payment_request/payment_request_fetcher.go
+++ b/pkg/services/payment_request/payment_request_fetcher.go
@@ -1,6 +1,7 @@
 package paymentrequest
 
 import (
+	"github.com/go-openapi/swag"
 	"github.com/gobuffalo/pop"
 	"github.com/gobuffalo/validate"
 	"github.com/gofrs/uuid"
@@ -23,7 +24,7 @@ func (p *paymentRequestFetcher) FetchPaymentRequest(paymentRequestID uuid.UUID) 
 	mockPaymentRequest := models.PaymentRequest{
 		ID:              paymentRequestID,
 		IsFinal:         false,
-		RejectionReason: "",
+		RejectionReason: swag.String(""),
 		CreatedAt:       testdatagen.PeakRateCycleStart,
 		UpdatedAt:       testdatagen.PeakRateCycleStart,
 	}

--- a/pkg/services/payment_request/payment_request_fetcher.go
+++ b/pkg/services/payment_request/payment_request_fetcher.go
@@ -18,11 +18,10 @@ func NewPaymentRequestFetcher(db *pop.Connection) services.PaymentRequestFetcher
 	return &paymentRequestFetcher{db}
 }
 
-func (p *paymentRequestFetcher) FetchPaymentRequest() (*models.PaymentRequest, *validate.Errors, error) {
+func (p *paymentRequestFetcher) FetchPaymentRequest(paymentRequestID uuid.UUID) (*models.PaymentRequest, *validate.Errors, error) {
 	// A mock payment request. This is temporary and will be replaced with real data eventually.
-	uuid, _ := uuid.NewV4()
 	mockPaymentRequest := models.PaymentRequest{
-		ID:              uuid,
+		ID:              paymentRequestID,
 		IsFinal:         false,
 		RejectionReason: "",
 		CreatedAt:       testdatagen.PeakRateCycleStart,

--- a/src/scenes/Office/TIO/paymentRequestShow.jsx
+++ b/src/scenes/Office/TIO/paymentRequestShow.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { connect } from 'react-redux';
+
+class PaymentRequestShow extends React.Component {
+  render() {
+    const { id } = this.props;
+    return <h1>Payment Request Id {id}</h1>;
+  }
+}
+const mapStateToProps = (_state, props) => ({
+  id: props.match.params.id,
+});
+
+export default connect(mapStateToProps)(PaymentRequestShow);

--- a/src/scenes/Office/TIO/paymentRequestShow.jsx
+++ b/src/scenes/Office/TIO/paymentRequestShow.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
-import { getPaymentRequest } from 'shared/Entities/modules/paymentRequests';
+import { selectPaymentRequest, getPaymentRequest } from 'shared/Entities/modules/paymentRequests';
 
 class PaymentRequestShow extends React.Component {
   componentDidMount() {
@@ -9,13 +9,29 @@ class PaymentRequestShow extends React.Component {
   }
 
   render() {
-    const { id } = this.props;
-    return <h1>Payment Request Id {id}</h1>;
+    const {
+      id,
+      paymentRequest: { isFinal, rejectionReason, serviceItemIDs },
+    } = this.props;
+    return (
+      <div>
+        <h1>Payment Request Id {id}</h1>
+        <ul>
+          <li>isFinal: {`${isFinal}`}</li>
+          <li>rejectionReason: {rejectionReason}</li>
+          <li>serviceItemIds: {serviceItemIDs}</li>
+        </ul>
+      </div>
+    );
   }
 }
-const mapStateToProps = (_state, props) => ({
-  id: props.match.params.id,
-});
+const mapStateToProps = (state, props) => {
+  const id = props.match.params.id;
+  return {
+    id,
+    paymentRequest: selectPaymentRequest(state, id),
+  };
+};
 
 const mapDispatchToProps = dispatch => bindActionCreators({ getPaymentRequest }, dispatch);
 

--- a/src/scenes/Office/TIO/paymentRequestShow.jsx
+++ b/src/scenes/Office/TIO/paymentRequestShow.jsx
@@ -1,7 +1,13 @@
 import React from 'react';
 import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import { getPaymentRequest } from 'shared/Entities/modules/paymentRequests';
 
 class PaymentRequestShow extends React.Component {
+  componentDidMount() {
+    this.props.getPaymentRequest(this.props.id);
+  }
+
   render() {
     const { id } = this.props;
     return <h1>Payment Request Id {id}</h1>;
@@ -11,4 +17,6 @@ const mapStateToProps = (_state, props) => ({
   id: props.match.params.id,
 });
 
-export default connect(mapStateToProps)(PaymentRequestShow);
+const mapDispatchToProps = dispatch => bindActionCreators({ getPaymentRequest }, dispatch);
+
+export default connect(mapStateToProps, mapDispatchToProps)(PaymentRequestShow);

--- a/src/scenes/Office/index.jsx
+++ b/src/scenes/Office/index.jsx
@@ -30,6 +30,7 @@ const ScratchPad = lazy(() => import('shared/ScratchPad'));
 const CustomerDetails = lazy(() => import('./TOO/customerDetails'));
 const TOO = lazy(() => import('./TOO/too'));
 const TIO = lazy(() => import('./TIO/tio'));
+const PaymentRequestShow = lazy(() => import('./TIO/paymentRequestShow'));
 
 export class RenderWithOrWithoutHeader extends Component {
   render() {
@@ -162,6 +163,7 @@ export class OfficeWrapper extends Component {
                     {too && <PrivateRoute path="/too/placeholder" component={TOO} />}
                     {too && <PrivateRoute path="/too/customer/:customerId/details" component={CustomerDetails} />}
                     {tio && <PrivateRoute path="/tio/placeholder" component={TIO} />}
+                    {tio && <PrivateRoute path="/payment_request/:id" component={PaymentRequestShow} />}
                   </Switch>
                 </Suspense>
               </Switch>

--- a/src/scenes/Office/index.jsx
+++ b/src/scenes/Office/index.jsx
@@ -163,7 +163,7 @@ export class OfficeWrapper extends Component {
                     {too && <PrivateRoute path="/too/placeholder" component={TOO} />}
                     {too && <PrivateRoute path="/too/customer/:customerId/details" component={CustomerDetails} />}
                     {tio && <PrivateRoute path="/tio/placeholder" component={TIO} />}
-                    {tio && <PrivateRoute path="/payment_request/:id" component={PaymentRequestShow} />}
+                    {tio && <PrivateRoute path="/payment_requests/:id" component={PaymentRequestShow} />}
                   </Switch>
                 </Suspense>
               </Switch>

--- a/src/shared/Entities/modules/paymentRequests.js
+++ b/src/shared/Entities/modules/paymentRequests.js
@@ -1,0 +1,9 @@
+import { swaggerRequest } from 'shared/Swagger/request';
+import { getGHCClient } from 'shared/Swagger/api';
+
+const getPaymentRequestLabel = 'PaymentRequests.getPaymentRequest';
+
+export function getPaymentRequest(paymentRequestID, label = getPaymentRequestLabel) {
+  const swaggerTag = 'paymentRequests.getPaymentRequest';
+  return swaggerRequest(getGHCClient, swaggerTag, { paymentRequestID }, { label });
+}

--- a/src/shared/Entities/modules/paymentRequests.js
+++ b/src/shared/Entities/modules/paymentRequests.js
@@ -1,9 +1,14 @@
 import { swaggerRequest } from 'shared/Swagger/request';
 import { getGHCClient } from 'shared/Swagger/api';
+import { get } from 'lodash';
 
 const getPaymentRequestLabel = 'PaymentRequests.getPaymentRequest';
 
 export function getPaymentRequest(paymentRequestID, label = getPaymentRequestLabel) {
   const swaggerTag = 'paymentRequests.getPaymentRequest';
   return swaggerRequest(getGHCClient, swaggerTag, { paymentRequestID }, { label });
+}
+
+export function selectPaymentRequest(state, id) {
+  return get(state, `entities.paymentRequests.${id}`) || {};
 }

--- a/src/shared/Entities/schema.js
+++ b/src/shared/Entities/schema.js
@@ -129,3 +129,8 @@ export const customer = new schema.Entity('customer');
 export const customerMoveItem = new schema.Entity('customerMoveItem');
 
 export const customerMoveItems = new schema.Array(customerMoveItem);
+
+// Payment Requests
+export const paymentRequest = new schema.Entity('paymentRequests');
+
+export const paymentRequests = new schema.Array(paymentRequest);


### PR DESCRIPTION
## Description

Add a show page for payment requests with a stubbed API on the backend 

## Reviewer Notes

Swagger is good at catching URLs that don't have actual uuids as a parameter. So, here's a link that will work locally for testing: `http://officelocal:3000/payment_requests/c9df71f2-334f-4f0e-b2e7-050ddb22efa1`

This should not be merged until after the work from Kim and Ryan has been merged (but I borrowed some of Kim's commits in the meantime)

This work is not tested. On the front end, it makes sense to me that we will test this once we have the actual designs in place. On the back end, since the code is temporary, it seemed odd to unit test it. But I am more than happy to let the reviewers tell me otherwise.

## Code Review Verification Steps

* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-685) for this change

## Screenshots

<img width="873" alt="Screen Shot 2019-12-09 at 4 18 14 PM" src="https://user-images.githubusercontent.com/4434681/70484086-87e0cb80-1a9f-11ea-83f7-14348f043d8b.png">
