### PR TITLE
Set max length on rejection reason

### DIFF
--- a/migrations/20191209140000_set_max_length_on_rejection_reason.up.sql
+++ b/migrations/20191209140000_set_max_length_on_rejection_reason.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE payment_requests ALTER COLUMN rejection_reason TYPE varchar(255);

--- a/migrations_manifest.txt
+++ b/migrations_manifest.txt
@@ -397,3 +397,4 @@
 20191204160349_add_new_user_type_tables.up.sql
 20191204170511_remove-old-tables.up.sql
 20191204200540_create_and_populate_roles_table.up.sql
+20191209140000_set_max_length_on_rejection_reason.up.sql


### PR DESCRIPTION
## Description

We should always declare a length on `varchar` fields. This recent update broke the django admin experiment. 

https://github.com/transcom/mymove/blob/master/migrations/20191120173320_create_payment_requests_table.up.sql#L7

I've had to do it previously. Could I fix up docs about this?