### PR TITLE
Added RDS IAM exit condition if failing

### DIFF
--- a/pkg/iampostgres/iampostgres_test.go
+++ b/pkg/iampostgres/iampostgres_test.go
@@ -61,6 +61,28 @@ func TestGetCurrentPass(t *testing.T) {
 
 }
 
+func TestGetCurrentPassFail(t *testing.T) {
+	// This tests when the timeout is hit
+
+	assert := assert.New(t)
+
+	rdsu := RDSUTest{}
+	rdsu.passes = append(rdsu.passes, "") // set mocked pass to empty to simulate failed cred generation
+	logger, _ := zap.NewProduction()
+	iamConfig.currentIamPass = ""
+
+	EnableIAM("server", "8080", "us-east-1", "dbuser", "***",
+		credentials.NewStaticCredentials("id", "pass", "token"),
+		rdsu,
+		time.NewTicker(2*time.Second),
+		logger)
+
+	// this should block for 30s then return empty string
+	currentPass := GetCurrentPass()
+	assert.Equal(currentPass, "")
+
+}
+
 func TestEnableIAMNormal(t *testing.T) {
 	assert := assert.New(t)
 

--- a/pkg/iampostgres/iampostgres_test.go
+++ b/pkg/iampostgres/iampostgres_test.go
@@ -41,7 +41,7 @@ func TestEnableIamNilCreds(t *testing.T) {
 
 }
 
-func TestGetCurrentPass(t *testing.T) {
+func TestGetCurrentPassword(t *testing.T) {
 	assert := assert.New(t)
 
 	rdsu := RDSUTest{}
@@ -61,7 +61,7 @@ func TestGetCurrentPass(t *testing.T) {
 
 }
 
-func TestGetCurrentPassFail(t *testing.T) {
+func TestGetCurrentPasswordFail(t *testing.T) {
 	// This tests when the timeout is hit
 
 	assert := assert.New(t)

--- a/pkg/iampostgres/iampostgres_test.go
+++ b/pkg/iampostgres/iampostgres_test.go
@@ -27,10 +27,12 @@ func TestEnableIamNilCreds(t *testing.T) {
 	rdsu := RDSUTest{}
 	logger, _ := zap.NewProduction()
 
+	tmr := time.NewTicker(1 * time.Second)
+
 	EnableIAM("server", "8080", "us-east-1", "dbuser", "***",
 		nil,
 		rdsu,
-		time.NewTicker(1*time.Second),
+		tmr,
 		logger)
 	time.Sleep(2 * time.Second)
 
@@ -38,6 +40,7 @@ func TestEnableIamNilCreds(t *testing.T) {
 	t.Logf("Current password: %s", iamConfig.currentIamPass)
 	assert.Equal(iamConfig.currentIamPass, "")
 	iamConfig.currentPassMutex.Unlock()
+	tmr.Stop()
 
 }
 
@@ -49,15 +52,19 @@ func TestGetCurrentPassword(t *testing.T) {
 	logger, _ := zap.NewProduction()
 	iamConfig.currentIamPass = "" // ensure iamConfig is in new state
 
+	tmr := time.NewTicker(2 * time.Second)
+
 	EnableIAM("server", "8080", "us-east-1", "dbuser", "***",
 		credentials.NewStaticCredentials("id", "pass", "token"),
 		rdsu,
-		time.NewTicker(2*time.Second),
+		tmr,
 		logger)
 
 	// this should block for ~ 250ms and then continue
 	currentPass := GetCurrentPass()
 	assert.Equal(currentPass, "abc")
+
+	tmr.Stop()
 
 }
 
@@ -71,15 +78,18 @@ func TestGetCurrentPasswordFail(t *testing.T) {
 	logger, _ := zap.NewProduction()
 	iamConfig.currentIamPass = ""
 
+	tmr := time.NewTicker(1 * time.Second)
+
 	EnableIAM("server", "8080", "us-east-1", "dbuser", "***",
 		credentials.NewStaticCredentials("id", "pass", "token"),
 		rdsu,
-		time.NewTicker(2*time.Second),
+		tmr,
 		logger)
 
 	// this should block for 30s then return empty string
 	currentPass := GetCurrentPass()
 	assert.Equal(currentPass, "")
+	tmr.Stop()
 
 }
 
@@ -91,11 +101,13 @@ func TestEnableIAMNormal(t *testing.T) {
 	rdsu.passes = append(rdsu.passes, testData...)
 	logger, _ := zap.NewProduction()
 
+	tmr := time.NewTicker(2 * time.Second)
+
 	// We use 2 second timer since that builds in a buffer so we have stable tests
 	EnableIAM("server", "8080", "us-east-1", "dbuser", "***",
 		credentials.NewStaticCredentials("id", "pass", "token"),
 		rdsu,
-		time.NewTicker(2*time.Second),
+		tmr,
 		logger)
 
 	lenTestData := len(testData) - 1
@@ -130,6 +142,7 @@ func TestEnableIAMNormal(t *testing.T) {
 
 	// Check that all the passwords have been checked
 	assert.Equal(3, counter)
+	tmr.Stop()
 }
 
 func TestUpdateDSN(t *testing.T) {


### PR DESCRIPTION

## Description

This PR adds an exit condition in the event the server is unable to secure a IAM temporary token for logging into RDS via RDS IAM Authentication. Before this PR it would retry indefinitely (learned the hard way). Exit conditions are wait up to 30s till exiting out and failing. 

Updated the application logs so they don't sound so scary for normal operation.

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

There is an issue that the caller of the `dbconn.go` doesn't exit after receiving an empty password. It sill loads the listener and accepts requests then throws an exception. To keep things simple keeping that behavior out of this PR as it is outside the scope IMO.

After failing to connect to the DB and the IAM driver returning empty creds.
```
main.main
        /home/lee/Dev/mymove/cmd/milmove/main.go:132
runtime.main
        /usr/local/go/src/runtime/proc.go:203
2019-12-10T21:01:54.018Z        INFO    auth/cookie.go:236      Creating session        {"milServername": "milmovelocal", "officeServername": "officelocal", "adminServername": "adminlocal"}
2019-12-10T21:01:54.018Z        INFO    notifications/notification_sender.go:86 Using local email backend      {"domain": "milmovelocal"}
2019-12-10T21:01:54.018Z        INFO    storage/storage.go:111  Using local storage backend     {"local-storage-root": "tmp/storage", "local-storage-web-root": "storage"}
2019-12-10T21:01:54.020Z        INFO    certs/certs.go:30       certitficate chain from move-mil-dod-tls-cert parsed   {"count": 1}
2019-12-10T21:01:54.021Z        INFO    certs/certs.go:38       certitficate chain from move-mil-dod-ca-cert parsed    {"count": 1}
2019-12-10T21:01:54.022Z        INFO    certs/certs.go:49       DOD keypair     {"certificates": 2}
2019-12-10T21:01:54.032Z        DEBUG   milmove/serve.go:527    Server DOD Key Pair Loaded
```

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

Successful connect:
```
2019-12-10T20:42:19.561Z        INFO    cli/dbconn.go:257       Connecting to the database      {"url": "postgres://db_user:*****@rdstest.chsgqg6ccrq7.us-east-2.rds.amazonaws.com:5432/dev_db?sslmode=verify-fu
ll", "db-ssl-root-cert": "bin/rds-combined-ca-bundle.pem"}
2019-12-10T20:42:19.562Z        INFO    iampostgres/iampostgres.go:55   Wait 1 of 120, sleeping for 250ms for IAM loop to populate RDS credentials.
2019-12-10T20:42:19.562Z        INFO    iampostgres/iampostgres.go:95   Waiting 705ms before enabling IAM access for entropy
2019-12-10T20:42:19.812Z        INFO    iampostgres/iampostgres.go:55   Wait 2 of 120, sleeping for 250ms for IAM loop to populate RDS credentials.
2019-12-10T20:42:20.064Z        INFO    iampostgres/iampostgres.go:55   Wait 3 of 120, sleeping for 250ms for IAM loop to populate RDS credentials.
2019-12-10T20:42:20.267Z        INFO    iampostgres/iampostgres.go:104  Using IAM Authentication
2019-12-10T20:42:20.315Z        INFO    iampostgres/iampostgres.go:55   Wait 4 of 120, sleeping for 250ms for IAM loop to populate RDS credentials.
2019-12-10T20:42:20.336Z        INFO    iampostgres/iampostgres.go:114  Successfully generated new IAM token
2019-12-10T20:42:20.566Z        INFO    cli/dbconn.go:362       Starting database ping....
2019-12-10T20:42:21.218Z        INFO    cli/dbconn.go:369       ...DB ping successful!
2019-12-10T20:42:21.760Z        INFO    auth/cookie.go:236      Creating session        {"milServername": "milmovelocal", "officeServername": "officelocal", "adminServername": "adminlocal"}
2019-12-10T20:42:21.760Z        INFO    notifications/notification_sender.go:86 Using local email backend      {"domain": "milmovelocal"}
```


Failed to connect
```
2019-12-10T20:56:11.198Z        INFO    iampostgres/iampostgres.go:55   Wait 1 of 120, sleeping for 250ms for IAM loop to populate RDS credentials.
2019-12-10T20:56:11.198Z        INFO    iampostgres/iampostgres.go:95   Waiting 2.057s before enabling IAM access for entropy
2019-12-10T20:56:11.449Z        INFO    iampostgres/iampostgres.go:55   Wait 2 of 120, sleeping for 250ms for IAM loop to populate RDS credentials.
2019-12-10T20:56:11.702Z        INFO    iampostgres/iampostgres.go:55   Wait 3 of 120, sleeping for 250ms for IAM loop to populate RDS credentials.
2019-12-10T20:56:11.954Z        INFO    iampostgres/iampostgres.go:55   Wait 4 of 120, sleeping for 250ms for IAM loop to populate RDS credentials.
2019-12-10T20:56:12.208Z        INFO    iampostgres/iampostgres.go:55   Wait 5 of 120, sleeping for 250ms for IAM loop to populate RDS credentials.
2019-12-10T20:56:12.460Z        INFO    iampostgres/iampostgres.go:55   Wait 6 of 120, sleeping for 250ms for IAM loop to populate RDS credentials.
2019-12-10T20:56:12.714Z        INFO    iampostgres/iampostgres.go:55   Wait 7 of 120, sleeping for 250ms for IAM loop to populate RDS credentials.
2019-12-10T20:56:12.967Z        INFO    iampostgres/iampostgres.go:55   Wait 8 of 120, sleeping for 250ms for IAM loop to populate RDS credentials.
2019-12-10T20:56:13.220Z        INFO    iampostgres/iampostgres.go:55   Wait 9 of 120, sleeping for 250ms for IAM loop to populate RDS credentials.
2019-12-10T20:56:13.257Z        INFO    iampostgres/iampostgres.go:104  Using IAM Authentication
2019-12-10T20:56:13.297Z        ERROR   iampostgres/iampostgres.go:107  Error building auth token       {"error": "Failed to create RDSIAM token"}
github.com/transcom/mymove/pkg/iampostgres.EnableIAM.func1
        /home/lee/Dev/mymove/pkg/iampostgres/iampostgres.go:107
2019-12-10T20:56:13.474Z        INFO    iampostgres/iampostgres.go:55   Wait 10 of 120, sleeping for 250ms for IAM loop to populate RDS credentials.
.
.
.
.

2019-12-10T20:58:13.322Z        INFO    iampostgres/iampostgres.go:55   Wait 120 of 120, sleeping for 250ms for IAM loop to populate RDS credentials.
2019-12-10T20:58:13.576Z        INFO    iampostgres/iampostgres.go:55   Wait 121 of 120, sleeping for 250ms for IAM loop to populate RDS credentials.
2019-12-10T20:58:13.576Z        ERROR   iampostgres/iampostgres.go:60   Waited 30s for IAM creds to populate and giving up, returning empty password.
```

## Code Review Verification Steps

* [x] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/tree/master/docs/backend.md#logging)
* [x] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/tree/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/tree/master/docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
  * [ ] Secure migrations have been tested using `scripts/run-prod-migrations`
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [x] Request review from a member of a different team.
* [x] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-370) for this change

