### PR TITLE
Update script to check for current go-bindata version, 3.16.0

### DIFF
--- a/scripts/check-go-bindata-version
+++ b/scripts/check-go-bindata-version
@@ -2,7 +2,7 @@
 
 set -eu -o pipefail
 
-VERSION="v3.15.0"
+VERSION="3.16.0"
 
 GO_BINDATA_VERSION=$(go-bindata --version)
 # shellcheck disable=SC2203


### PR DESCRIPTION
## Description

The version of `go-bindata` available on Homebrew has updated to `3.16.0`. This updates the script checking for this so that it reflects that.



## Setup
If you try to build deps it should happen successfully if you've got `3.16.0` installed.

```sh
make deps
```

## References

* [Homebrew formulae page](https://formulae.brew.sh/formula/go-bindata) explains more about the approach used.
