### PR TITLE
[MB-684] TIO clonky front end for payment requests

### DIFF
--- a/migrations_manifest.txt
+++ b/migrations_manifest.txt
@@ -397,8 +397,6 @@
 20191204160349_add_new_user_type_tables.up.sql
 20191204170511_remove-old-tables.up.sql
 20191204200540_create_and_populate_roles_table.up.sql
-20191205190530_jppso-assignment-tables.up.sql
-20191205211911_jppso-assignment-data.up.sql
 20191204223817_alter_payment_requests.up.sql
 20191204231026_add_user_id_to_customers.up.sql
 20191205000048_create_proof_of_service_docs.up.sql
@@ -406,6 +404,8 @@
 20191205000702_create_service_item_param_keys.up.sql
 20191205000713_create_service_params.up.sql
 20191205000726_create_payment_service_item_params.up.sql
+20191205190530_jppso-assignment-tables.up.sql
+20191205211911_jppso-assignment-data.up.sql
 20191209140000_set_max_length_on_rejection_reason.up.sql
 20191210171244_create_entitlements.up.sql
 20191210171408_create_move_orders.up.sql

--- a/pkg/handlers/primeapi/payment_request.go
+++ b/pkg/handlers/primeapi/payment_request.go
@@ -48,6 +48,7 @@ func (h CreatePaymentRequestHandler) Handle(params paymentrequestop.CreatePaymen
 	paymentRequest := models.PaymentRequest{
 		IsFinal:         *params.Body.IsFinal,
 		MoveTaskOrderID: mtoID,
+		Status:          "PENDING",
 	}
 
 	moveTaskOrder := models.MoveTaskOrder{}

--- a/src/scenes/Office/TIO/paymentRequestIndex.jsx
+++ b/src/scenes/Office/TIO/paymentRequestIndex.jsx
@@ -10,7 +10,29 @@ class PaymentRequestIndex extends React.Component {
 
   render() {
     console.log(this.props.paymentRequests);
-    return <h1>Helloooooooo</h1>;
+    return (
+      <>
+        <h1>Payment Requests</h1>
+        <table>
+          <thead>
+            <tr>
+              <th>ID</th>
+              <th>Final</th>
+              <th>Rejection Reason</th>
+              <th>Service Item IDs</th>
+            </tr>
+          </thead>
+          {this.props.paymentRequests.map(pr => (
+            <tr>
+              <td>{pr.id}</td>
+              <td>{pr.isFinal}</td>
+              <td>{pr.rejectionReason}</td>
+              <td>{pr.serviceItemIDs}</td>
+            </tr>
+          ))}
+        </table>
+      </>
+    );
   }
 }
 

--- a/src/scenes/Office/TIO/paymentRequestIndex.jsx
+++ b/src/scenes/Office/TIO/paymentRequestIndex.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
-import { getPaymentRequestList } from 'shared/Entities/modules/paymentRequests';
+import { getPaymentRequestList, selectPaymentRequests } from 'shared/Entities/modules/paymentRequests';
 
 class PaymentRequestIndex extends React.Component {
   componentDidMount() {
@@ -9,11 +9,14 @@ class PaymentRequestIndex extends React.Component {
   }
 
   render() {
+    console.log(this.props.paymentRequests);
     return <h1>Helloooooooo</h1>;
   }
 }
 
-const mapStateToProps = (state, ownProps) => ({});
+const mapStateToProps = state => ({
+  paymentRequests: selectPaymentRequests(state),
+});
 
 const mapDispatchToProps = dispatch => bindActionCreators({ getPaymentRequestList }, dispatch);
 

--- a/src/scenes/Office/TIO/paymentRequestIndex.jsx
+++ b/src/scenes/Office/TIO/paymentRequestIndex.jsx
@@ -28,7 +28,7 @@ class PaymentRequestIndex extends React.Component {
                 <td>
                   <Link to={`/payment_requests/${pr.id}`}>{pr.id}</Link>
                 </td>
-                <td>{pr.isFinal}</td>
+                <td>{`${pr.isFinal}`}</td>
                 <td>{pr.rejectionReason}</td>
                 <td>{pr.serviceItemIDs}</td>
               </tr>

--- a/src/scenes/Office/TIO/paymentRequestIndex.jsx
+++ b/src/scenes/Office/TIO/paymentRequestIndex.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { getPaymentRequestList, selectPaymentRequests } from 'shared/Entities/modules/paymentRequests';
+import { Link } from 'react-router-dom';
 
 class PaymentRequestIndex extends React.Component {
   componentDidMount() {
@@ -9,7 +10,6 @@ class PaymentRequestIndex extends React.Component {
   }
 
   render() {
-    console.log(this.props.paymentRequests);
     return (
       <>
         <h1>Payment Requests</h1>
@@ -24,7 +24,9 @@ class PaymentRequestIndex extends React.Component {
           </thead>
           {this.props.paymentRequests.map(pr => (
             <tr>
-              <td>{pr.id}</td>
+              <td>
+                <Link to={`/payment_requests/${pr.id}`}>{pr.id}</Link>
+              </td>
               <td>{pr.isFinal}</td>
               <td>{pr.rejectionReason}</td>
               <td>{pr.serviceItemIDs}</td>

--- a/src/scenes/Office/TIO/paymentRequestIndex.jsx
+++ b/src/scenes/Office/TIO/paymentRequestIndex.jsx
@@ -22,16 +22,18 @@ class PaymentRequestIndex extends React.Component {
               <th>Service Item IDs</th>
             </tr>
           </thead>
-          {this.props.paymentRequests.map(pr => (
-            <tr>
-              <td>
-                <Link to={`/payment_requests/${pr.id}`}>{pr.id}</Link>
-              </td>
-              <td>{pr.isFinal}</td>
-              <td>{pr.rejectionReason}</td>
-              <td>{pr.serviceItemIDs}</td>
-            </tr>
-          ))}
+          <tbody>
+            {this.props.paymentRequests.map(pr => (
+              <tr>
+                <td>
+                  <Link to={`/payment_requests/${pr.id}`}>{pr.id}</Link>
+                </td>
+                <td>{pr.isFinal}</td>
+                <td>{pr.rejectionReason}</td>
+                <td>{pr.serviceItemIDs}</td>
+              </tr>
+            ))}
+          </tbody>
         </table>
       </>
     );

--- a/src/scenes/Office/TIO/paymentRequestIndex.jsx
+++ b/src/scenes/Office/TIO/paymentRequestIndex.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import { getPaymentRequestList } from 'shared/Entities/modules/paymentRequests';
+
+class PaymentRequestIndex extends React.Component {
+  componentDidMount() {
+    this.props.getPaymentRequestList();
+  }
+
+  render() {
+    return <h1>Helloooooooo</h1>;
+  }
+}
+
+const mapStateToProps = (state, ownProps) => ({});
+
+const mapDispatchToProps = dispatch => bindActionCreators({ getPaymentRequestList }, dispatch);
+
+export default connect(mapStateToProps, mapDispatchToProps)(PaymentRequestIndex);

--- a/src/scenes/Office/index.jsx
+++ b/src/scenes/Office/index.jsx
@@ -31,6 +31,7 @@ const CustomerDetails = lazy(() => import('./TOO/customerDetails'));
 const TOO = lazy(() => import('./TOO/too'));
 const TIO = lazy(() => import('./TIO/tio'));
 const PaymentRequestShow = lazy(() => import('./TIO/paymentRequestShow'));
+const PaymentRequestIndex = lazy(() => import('./TIO/paymentRequestIndex'));
 
 export class RenderWithOrWithoutHeader extends Component {
   render() {
@@ -163,6 +164,7 @@ export class OfficeWrapper extends Component {
                     {too && <PrivateRoute path="/too/placeholder" component={TOO} />}
                     {too && <PrivateRoute path="/too/customer/:customerId/details" component={CustomerDetails} />}
                     {tio && <PrivateRoute path="/tio/placeholder" component={TIO} />}
+                    {tio && <PrivateRoute path="/payment_requests" component={PaymentRequestIndex} />}
                     {tio && <PrivateRoute path="/payment_requests/:id" component={PaymentRequestShow} />}
                   </Switch>
                 </Suspense>

--- a/src/scenes/Office/index.jsx
+++ b/src/scenes/Office/index.jsx
@@ -164,8 +164,8 @@ export class OfficeWrapper extends Component {
                     {too && <PrivateRoute path="/too/placeholder" component={TOO} />}
                     {too && <PrivateRoute path="/too/customer/:customerId/details" component={CustomerDetails} />}
                     {tio && <PrivateRoute path="/tio/placeholder" component={TIO} />}
-                    {tio && <PrivateRoute path="/payment_requests" component={PaymentRequestIndex} />}
                     {tio && <PrivateRoute path="/payment_requests/:id" component={PaymentRequestShow} />}
+                    {tio && <PrivateRoute path="/payment_requests" component={PaymentRequestIndex} />}
                   </Switch>
                 </Suspense>
               </Switch>

--- a/src/shared/Entities/modules/paymentRequests.js
+++ b/src/shared/Entities/modules/paymentRequests.js
@@ -18,3 +18,7 @@ export function getPaymentRequestList(label = getPaymentRequestListLabel) {
 export function selectPaymentRequest(state, id) {
   return get(state, `entities.paymentRequests.${id}`) || {};
 }
+
+export function selectPaymentRequests(state) {
+  return get(state, 'entities.paymentRequests') || [];
+}

--- a/src/shared/Entities/modules/paymentRequests.js
+++ b/src/shared/Entities/modules/paymentRequests.js
@@ -20,5 +20,6 @@ export function selectPaymentRequest(state, id) {
 }
 
 export function selectPaymentRequests(state) {
-  return get(state, 'entities.paymentRequests') || [];
+  const paymentRequests = get(state, 'entities.paymentRequests') || {};
+  return Object.values(paymentRequests);
 }

--- a/src/shared/Entities/modules/paymentRequests.js
+++ b/src/shared/Entities/modules/paymentRequests.js
@@ -3,10 +3,16 @@ import { getGHCClient } from 'shared/Swagger/api';
 import { get } from 'lodash';
 
 const getPaymentRequestLabel = 'PaymentRequests.getPaymentRequest';
+const getPaymentRequestListLabel = 'PaymentRequests.getPaymentRequestList';
 
 export function getPaymentRequest(paymentRequestID, label = getPaymentRequestLabel) {
   const swaggerTag = 'paymentRequests.getPaymentRequest';
   return swaggerRequest(getGHCClient, swaggerTag, { paymentRequestID }, { label });
+}
+
+export function getPaymentRequestList(label = getPaymentRequestListLabel) {
+  const swaggerTag = 'paymentRequests.listPaymentRequests';
+  return swaggerRequest(getGHCClient, swaggerTag, {}, { label });
 }
 
 export function selectPaymentRequest(state, id) {


### PR DESCRIPTION
## Description

Add the clonkiest of UIs to view a table of payment requests including ID, final (bool), rejection reason, and service item IDs.

## Reviewer Notes

PR includes small API change, we set the default payment request status to `PENDING` - is that a good move? 

## Setup

```sh
make server_run
make office_client_run
```
navigate to http://officelocal:3000/payment_requests

## Code Review Verification Steps
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-760) for this change

## Screenshots

![Screen Shot 2019-12-11 at 2 15 57 PM](https://user-images.githubusercontent.com/16230705/70665715-049bb300-1c22-11ea-9c41-a016fd929795.png)

