### PR TITLE
MB-738 Datepicker improperly handles typing input

### DIFF
--- a/src/scenes/Moves/Ppm/api.js
+++ b/src/scenes/Moves/Ppm/api.js
@@ -1,5 +1,6 @@
 import { getClient, checkResponse } from 'shared/Swagger/api';
-import { formatPayload, formatDateString } from 'shared/utils';
+import { formatPayload } from 'shared/utils';
+import { formatDateForSwagger } from 'shared/dates';
 
 export async function GetPpm(moveId) {
   const client = await getClient();
@@ -40,7 +41,7 @@ export async function UpdatePpm(
 export async function GetPpmWeightEstimate(moveDate, originZip, originDutyStationZip, destZip, weightEstimate) {
   const client = await getClient();
   const response = await client.apis.ppm.showPPMEstimate({
-    original_move_date: formatDateString(moveDate),
+    original_move_date: formatDateForSwagger(moveDate),
     origin_zip: originZip,
     origin_duty_station_zip: originDutyStationZip,
     destination_zip: destZip,
@@ -53,7 +54,7 @@ export async function GetPpmWeightEstimate(moveDate, originZip, originDutyStatio
 export async function GetPpmSitEstimate(moveDate, sitDays, originZip, destZip, weightEstimate) {
   const client = await getClient();
   const response = await client.apis.ppm.showPPMSitEstimate({
-    original_move_date: formatDateString(moveDate),
+    original_move_date: formatDateForSwagger(moveDate),
     days_in_storage: sitDays,
     origin_zip: originZip,
     destination_zip: destZip,

--- a/src/scenes/Office/Ppm/api.js
+++ b/src/scenes/Office/Ppm/api.js
@@ -1,10 +1,10 @@
 import { getClient, checkResponse } from 'shared/Swagger/api';
-import { formatDateString } from 'shared/utils';
+import { formatDateForSwagger } from 'shared/dates';
 
 export async function GetPpmIncentive(moveDate, originZip, originDutyStationZip, destZip, weight) {
   const client = await getClient();
   const response = await client.apis.ppm.showPPMIncentive({
-    original_move_date: formatDateString(moveDate),
+    original_move_date: formatDateForSwagger(moveDate),
     origin_zip: originZip,
     origin_duty_station_zip: originDutyStationZip,
     destination_zip: destZip,

--- a/src/shared/JsonSchemaForm/SingleDatePicker.jsx
+++ b/src/shared/JsonSchemaForm/SingleDatePicker.jsx
@@ -1,36 +1,8 @@
 import React from 'react';
 import DayPickerInput from 'react-day-picker/DayPickerInput';
-import moment from 'moment';
-import { defaultDateFormat } from 'shared/utils';
+import { parseDate, formatDate, defaultDateFormat } from 'shared/dates';
 
 import 'react-day-picker/lib/style.css';
-
-// First date format is take to be the default
-const allowedDateFormats = [
-  defaultDateFormat,
-  'YYYY/M/D',
-  'YYYY-M-D',
-  'M-D-YYYY',
-  'D-MMM-YYYY',
-  'MMM-D-YYYY',
-  'DD-MMM-YY',
-];
-
-function parseDate(str, _format, locale = 'en') {
-  // Ignore default format, and attempt to parse date using allowed formats
-  const m = moment(str, allowedDateFormats, locale, true);
-  if (m.isValid()) {
-    return m.toDate();
-  }
-
-  return undefined;
-}
-
-function formatDate(date, format = defaultDateFormat, locale = 'en') {
-  return moment(date, allowedDateFormats, locale, true)
-    .locale(locale)
-    .format(format);
-}
 
 const getDayPickerProps = disabledDays => {
   return {

--- a/src/shared/JsonSchemaForm/reduxFieldNormalizer.js
+++ b/src/shared/JsonSchemaForm/reduxFieldNormalizer.js
@@ -6,8 +6,7 @@
   For more information: https://redux-form.com/7.4.2/examples/normalizing/
 */
 
-import { swaggerDateFormat } from 'shared/utils';
-import moment from 'moment';
+import { parseDate } from 'shared/dates';
 
 const normalizePhone = value => {
   if (!value) {
@@ -64,7 +63,7 @@ const normalizeZip = value => {
 };
 
 const normalizeDates = value => {
-  return value ? moment(value).format(swaggerDateFormat) : value;
+  return parseDate(value);
 };
 
 const createDigitNormalizer = maxLength => {

--- a/src/shared/JsonSchemaForm/validator.js
+++ b/src/shared/JsonSchemaForm/validator.js
@@ -1,5 +1,5 @@
 import { isFinite, isInteger as rawIsInteger, memoize } from 'lodash';
-import { defaultDateFormat } from 'shared/utils';
+import { defaultDateFormat } from 'shared/dates';
 import moment from 'moment';
 
 const isRequired = value => (value ? undefined : 'Required');

--- a/src/shared/dates.js
+++ b/src/shared/dates.js
@@ -29,10 +29,5 @@ export function formatDate(date, format = defaultDateFormat, locale = 'en') {
     .format(format);
 }
 export function formatDateForSwagger(dateString) {
-  let parsed = moment(dateString, defaultDateFormat);
-  if (parsed.isValid()) {
-    return parsed.format(swaggerDateFormat);
-  }
-
-  return dateString;
+  return formatDate(dateString, swaggerDateFormat);
 }

--- a/src/shared/dates.js
+++ b/src/shared/dates.js
@@ -1,0 +1,38 @@
+import moment from 'moment';
+export const swaggerDateFormat = 'YYYY-MM-DD';
+export const defaultDateFormat = 'M/D/YYYY';
+
+// First date format is take to be the default
+const allowedDateFormats = [
+  defaultDateFormat,
+  'YYYY/M/D',
+  'YYYY-M-D',
+  'M-D-YYYY',
+  'D-MMM-YYYY',
+  'MMM-D-YYYY',
+  'DD-MMM-YY',
+];
+
+export function parseDate(str, _format, locale = 'en') {
+  // Ignore default format, and attempt to parse date using allowed formats
+  const m = moment(str, allowedDateFormats, locale, true);
+  if (m.isValid()) {
+    return m.toDate();
+  }
+
+  return undefined;
+}
+
+export function formatDate(date, format = defaultDateFormat, locale = 'en') {
+  return moment(date, allowedDateFormats, locale, true)
+    .locale(locale)
+    .format(format);
+}
+export function formatDateForSwagger(dateString) {
+  let parsed = moment(dateString, defaultDateFormat);
+  if (parsed.isValid()) {
+    return parsed.format(swaggerDateFormat);
+  }
+
+  return dateString;
+}

--- a/src/shared/dates.test.js
+++ b/src/shared/dates.test.js
@@ -32,7 +32,7 @@ describe('dates', () => {
   describe('formatDateForSwagger', () => {
     describe('when formatting a date that does not match the allowed date formats', () => {
       const result = formatDateForSwagger('8');
-      it('should return something random', () => {
+      it('should return invalid date', () => {
         expect(result).toEqual('Invalid date');
       });
     });

--- a/src/shared/dates.test.js
+++ b/src/shared/dates.test.js
@@ -1,0 +1,47 @@
+import { parseDate, formatDate, formatDateForSwagger } from './dates';
+import moment from 'moment';
+describe('dates', () => {
+  describe('parseDate', () => {
+    describe('when parsing a date that does not match the allowed date formats', () => {
+      const result = parseDate('8');
+      it('should return undefined', () => {
+        expect(result).toBeUndefined();
+      });
+    });
+    describe('when parsing a date that does match the allowed date formats', () => {
+      const result = parseDate('8-23-2019');
+      it('should return a Date that matches that string', () => {
+        expect(result).toEqual(new moment('2019-08-23T00:00:00.000Z').toDate());
+      });
+    });
+  });
+  describe('formatDate', () => {
+    describe('when formatting a date that does not match the allowed date formats', () => {
+      const result = formatDate('8');
+      it('should return "invalid date"', () => {
+        expect(result).toEqual('Invalid date');
+      });
+    });
+    describe('when parsing a date that does the match allowed date formats', () => {
+      const result = formatDate('8-23-2019');
+      it('should return 8/23/2019', () => {
+        expect(result).toEqual('8/23/2019');
+      });
+    });
+  });
+  describe('formatDateString', () => {
+    describe('when formatting a date that does not match the allowed date formats', () => {
+      const result = formatDateForSwagger('8');
+      it('should return something random', () => {
+        //TODO: this does not seem the correct behavior
+        expect(result).toEqual('2019-08-01');
+      });
+    });
+    describe('when parsing a date that does the match allowed date formats', () => {
+      const result = formatDateForSwagger('8-23-2019');
+      it('should return undefined', () => {
+        expect(result).toEqual('2019-08-23');
+      });
+    });
+  });
+});

--- a/src/shared/dates.test.js
+++ b/src/shared/dates.test.js
@@ -39,7 +39,7 @@ describe('dates', () => {
     });
     describe('when parsing a date that does the match allowed date formats', () => {
       const result = formatDateForSwagger('8-23-2019');
-      it('should return undefined', () => {
+      it('should return a date in the format swagger accepts', () => {
         expect(result).toEqual('2019-08-23');
       });
     });

--- a/src/shared/dates.test.js
+++ b/src/shared/dates.test.js
@@ -29,12 +29,11 @@ describe('dates', () => {
       });
     });
   });
-  describe('formatDateString', () => {
+  describe('formatDateForSwagger', () => {
     describe('when formatting a date that does not match the allowed date formats', () => {
       const result = formatDateForSwagger('8');
       it('should return something random', () => {
-        //TODO: this does not seem the correct behavior
-        expect(result).toEqual('2019-08-01');
+        expect(result).toEqual('Invalid date');
       });
     });
     describe('when parsing a date that does the match allowed date formats', () => {

--- a/src/shared/utils.js
+++ b/src/shared/utils.js
@@ -1,14 +1,11 @@
 import React from 'react';
 import { get, includes, find, mapValues, capitalize } from 'lodash';
-import moment from 'moment';
 import FontAwesomeIcon from '@fortawesome/react-fontawesome';
 import faClock from '@fortawesome/fontawesome-free-solid/faClock';
 import faCheck from '@fortawesome/fontawesome-free-solid/faCheck';
 import faExclamationCircle from '@fortawesome/fontawesome-free-solid/faExclamationCircle';
+import { formatDateForSwagger } from './dates';
 import './shared.css';
-
-export const swaggerDateFormat = 'YYYY-MM-DD';
-export const defaultDateFormat = 'M/D/YYYY';
 
 export const no_op = () => undefined;
 export const no_op_action = () => {
@@ -59,15 +56,6 @@ export function fetchActiveShipment(shipments) {
   );
 }
 
-export function formatDateString(dateString) {
-  let parsed = moment(dateString, defaultDateFormat);
-  if (parsed.isValid()) {
-    return parsed.format(swaggerDateFormat);
-  }
-
-  return dateString;
-}
-
 // Formats payload values according to Swagger spec type
 export function formatPayload(payload, def) {
   return mapValues(payload, (val, key) => {
@@ -77,7 +65,7 @@ export function formatPayload(payload, def) {
 
     if (propType === 'string') {
       if (propFormat === 'date') {
-        return formatDateString(val);
+        return formatDateForSwagger(val);
       }
     }
 


### PR DESCRIPTION
## Description
This resolves a bug with the configuration of the DatePicker that is blocking our ability to upgrade cypress. (The older version of cypress was hiding this bug, but it happens to real user).

If you go to any screen in the SM or office app and try to type in a date, it was converting the first character typed into a date and filling the whole field. There was no way to backspace over the things entered. 

Ryan and I determined that the functions being used by the `SingleDatePicker` and the `JsonSchemaForm` to parse and normalize the dates had different behaviors. Both get fired at different points in the event of a user typing, so we were not able to remove one of them. We made one function, placed it in a location where it could be re-used and added unit tests for it. Since there were a few other date parsing functions out there, we also moved `formatDateString` and renamed it to `formatDateForSwagger` to make it clearer what it was doing.


## Reviewer Notes

We changed the behavior of `formatDateForSwagger` so that it also wouldn't generate a date for invalid input. I don't think that would have happened in the system but it seemed like a good thing to do.

## Setup

If you go to any screen in the SM or office app and try to type in a date.

## Code Review Verification Steps

* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [MB-738](https://dp3.atlassian.net/browse/MB-738) for this change

## Screenshots

It used to look like this when you typed '6'
![image](https://user-images.githubusercontent.com/3142631/70831549-d902ff00-1dc0-11ea-8c75-e8244f0cb685.png)
