### PR TITLE
Clarify the prereqs and how they are installed on mac vs linux

### DIFF
--- a/scripts/prereqs
+++ b/scripts/prereqs
@@ -24,20 +24,25 @@ has docker "Get Docker CE for Mac from https://download.docker.com/mac/stable/Do
 has psql "brew install postgresql"
 has go-bindata "brew install go-bindata"
 has node "brew install node@10 && brew link --force node@10"
-has pkcs11-tool "brew install opensc; chmod go+w /usr/local/bin/pkcs11-tool; brew link opensc"
-has pkcs15-tool "brew install opensc; chmod go+w /usr/local/bin/pkcs15-tool; brew link opensc"
-
-# macOS only
-if [[ $(uname -s) = Darwin ]]; then
-    has watchman "brew install watchman"
-fi
 
 # not on CircleCI
 if [[ -z ${CIRCLECI-} ]]; then
-    has direnv "brew install direnv"
+  # CAC tools
+  has pkcs11-tool "brew install opensc; chmod go+w /usr/local/bin/pkcs11-tool; brew link opensc"
+  has pkcs15-tool "brew install opensc; chmod go+w /usr/local/bin/pkcs15-tool; brew link opensc"
+
+  has direnv "brew install direnv"
+  has entr "brew install entr"
+  has circleci "brew install circleci"
+
+  if [[ $(uname -s) = Darwin ]]; then
+    # macOS only
     has aws-vault "brew cask install aws-vault"
-    has entr "brew install entr"
-    has circleci "brew install circleci"
+    has watchman "brew install watchman"
+  else
+    # Linux
+    has aws-vault "brew install aws-vault"
+  fi
 fi
 
 


### PR DESCRIPTION
## Description

Turns out you install `aws-vault` differently on macOS vs Linux. Also did some other cleanup here.

## Setup

Run:

```sh
prereqs
```
