### PR TITLE
MB-701: add progear as weight ticket option

### DIFF
--- a/pkg/gen/internalapi/embedded_spec.go
+++ b/pkg/gen/internalapi/embedded_spec.go
@@ -3664,7 +3664,7 @@ func init() {
         },
         "vehicle_nickname": {
           "type": "string",
-          "title": "Vehicle nickname (ex. \"My car\")"
+          "title": "Vehicle nickname (ex. 'My car')"
         },
         "vehicle_options": {
           "type": "string",
@@ -3672,12 +3672,14 @@ func init() {
           "enum": [
             "CAR",
             "CAR_TRAILER",
-            "BOX_TRUCK"
+            "BOX_TRUCK",
+            "PRO_GEAR"
           ],
           "x-display-value": {
             "BOX_TRUCK": "Box truck",
             "CAR": "Car",
-            "CAR_TRAILER": "Car + Trailer"
+            "CAR_TRAILER": "Car + Trailer",
+            "PRO_GEAR": "Pro-gear"
           }
         },
         "weight_ticket_date": {
@@ -4155,7 +4157,7 @@ func init() {
         },
         "vehicle_nickname": {
           "type": "string",
-          "title": "Vehicle nickname (ex. \"My car\")"
+          "title": "Vehicle nickname (ex. 'My car')"
         },
         "vehicle_options": {
           "type": "string",
@@ -4163,12 +4165,14 @@ func init() {
           "enum": [
             "CAR",
             "CAR_TRAILER",
-            "BOX_TRUCK"
+            "BOX_TRUCK",
+            "PRO_GEAR"
           ],
           "x-display-value": {
             "BOX_TRUCK": "Box truck",
             "CAR": "Car",
-            "CAR_TRAILER": "Car + Trailer"
+            "CAR_TRAILER": "Car + Trailer",
+            "PRO_GEAR": "Pro-gear"
           }
         },
         "weight_ticket_date": {
@@ -5821,12 +5825,14 @@ func init() {
       "enum": [
         "CAR",
         "CAR_TRAILER",
-        "BOX_TRUCK"
+        "BOX_TRUCK",
+        "PRO_GEAR"
       ],
       "x-display-value": {
         "BOX_TRUCK": "Box truck",
         "CAR": "Car",
-        "CAR_TRAILER": "Car + Trailer"
+        "CAR_TRAILER": "Car + Trailer",
+        "PRO_GEAR": "Pro-gear"
       },
       "x-nullable": true
     },
@@ -9510,7 +9516,7 @@ func init() {
         },
         "vehicle_nickname": {
           "type": "string",
-          "title": "Vehicle nickname (ex. \"My car\")"
+          "title": "Vehicle nickname (ex. 'My car')"
         },
         "vehicle_options": {
           "type": "string",
@@ -9518,12 +9524,14 @@ func init() {
           "enum": [
             "CAR",
             "CAR_TRAILER",
-            "BOX_TRUCK"
+            "BOX_TRUCK",
+            "PRO_GEAR"
           ],
           "x-display-value": {
             "BOX_TRUCK": "Box truck",
             "CAR": "Car",
-            "CAR_TRAILER": "Car + Trailer"
+            "CAR_TRAILER": "Car + Trailer",
+            "PRO_GEAR": "Pro-gear"
           }
         },
         "weight_ticket_date": {
@@ -10003,7 +10011,7 @@ func init() {
         },
         "vehicle_nickname": {
           "type": "string",
-          "title": "Vehicle nickname (ex. \"My car\")"
+          "title": "Vehicle nickname (ex. 'My car')"
         },
         "vehicle_options": {
           "type": "string",
@@ -10011,12 +10019,14 @@ func init() {
           "enum": [
             "CAR",
             "CAR_TRAILER",
-            "BOX_TRUCK"
+            "BOX_TRUCK",
+            "PRO_GEAR"
           ],
           "x-display-value": {
             "BOX_TRUCK": "Box truck",
             "CAR": "Car",
-            "CAR_TRAILER": "Car + Trailer"
+            "CAR_TRAILER": "Car + Trailer",
+            "PRO_GEAR": "Pro-gear"
           }
         },
         "weight_ticket_date": {
@@ -11676,12 +11686,14 @@ func init() {
       "enum": [
         "CAR",
         "CAR_TRAILER",
-        "BOX_TRUCK"
+        "BOX_TRUCK",
+        "PRO_GEAR"
       ],
       "x-display-value": {
         "BOX_TRUCK": "Box truck",
         "CAR": "Car",
-        "CAR_TRAILER": "Car + Trailer"
+        "CAR_TRAILER": "Car + Trailer",
+        "PRO_GEAR": "Pro-gear"
       },
       "x-nullable": true
     },

--- a/pkg/gen/internalapi/embedded_spec.go
+++ b/pkg/gen/internalapi/embedded_spec.go
@@ -3668,7 +3668,7 @@ func init() {
         },
         "vehicle_options": {
           "type": "string",
-          "title": "What type of vehicle are these weight tickets for?",
+          "title": "Select weight ticket type",
           "enum": [
             "CAR",
             "CAR_TRAILER",
@@ -4159,7 +4159,7 @@ func init() {
         },
         "vehicle_options": {
           "type": "string",
-          "title": "What type of vehicle are these weight tickets for?",
+          "title": "Select weight ticket type",
           "enum": [
             "CAR",
             "CAR_TRAILER",
@@ -5817,7 +5817,7 @@ func init() {
     },
     "VehicleOptions": {
       "type": "string",
-      "title": "What type of vehicle are these weight tickets for?",
+      "title": "Select weight ticket type",
       "enum": [
         "CAR",
         "CAR_TRAILER",
@@ -9514,7 +9514,7 @@ func init() {
         },
         "vehicle_options": {
           "type": "string",
-          "title": "What type of vehicle are these weight tickets for?",
+          "title": "Select weight ticket type",
           "enum": [
             "CAR",
             "CAR_TRAILER",
@@ -10007,7 +10007,7 @@ func init() {
         },
         "vehicle_options": {
           "type": "string",
-          "title": "What type of vehicle are these weight tickets for?",
+          "title": "Select weight ticket type",
           "enum": [
             "CAR",
             "CAR_TRAILER",
@@ -11672,7 +11672,7 @@ func init() {
     },
     "VehicleOptions": {
       "type": "string",
-      "title": "What type of vehicle are these weight tickets for?",
+      "title": "Select weight ticket type",
       "enum": [
         "CAR",
         "CAR_TRAILER",

--- a/pkg/gen/internalmessages/create_weight_ticket_documents_payload.go
+++ b/pkg/gen/internalmessages/create_weight_ticket_documents_payload.go
@@ -48,13 +48,13 @@ type CreateWeightTicketDocumentsPayload struct {
 	// upload ids
 	UploadIds []strfmt.UUID `json:"upload_ids"`
 
-	// Vehicle nickname (ex. "My car")
+	// Vehicle nickname (ex. 'My car')
 	// Required: true
 	VehicleNickname *string `json:"vehicle_nickname"`
 
 	// Select weight ticket type
 	// Required: true
-	// Enum: [CAR CAR_TRAILER BOX_TRUCK]
+	// Enum: [CAR CAR_TRAILER BOX_TRUCK PRO_GEAR]
 	VehicleOptions *string `json:"vehicle_options"`
 
 	// Full Weight Ticket Date
@@ -208,7 +208,7 @@ var createWeightTicketDocumentsPayloadTypeVehicleOptionsPropEnum []interface{}
 
 func init() {
 	var res []string
-	if err := json.Unmarshal([]byte(`["CAR","CAR_TRAILER","BOX_TRUCK"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["CAR","CAR_TRAILER","BOX_TRUCK","PRO_GEAR"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {
@@ -226,6 +226,9 @@ const (
 
 	// CreateWeightTicketDocumentsPayloadVehicleOptionsBOXTRUCK captures enum value "BOX_TRUCK"
 	CreateWeightTicketDocumentsPayloadVehicleOptionsBOXTRUCK string = "BOX_TRUCK"
+
+	// CreateWeightTicketDocumentsPayloadVehicleOptionsPROGEAR captures enum value "PRO_GEAR"
+	CreateWeightTicketDocumentsPayloadVehicleOptionsPROGEAR string = "PRO_GEAR"
 )
 
 // prop value enum

--- a/pkg/gen/internalmessages/create_weight_ticket_documents_payload.go
+++ b/pkg/gen/internalmessages/create_weight_ticket_documents_payload.go
@@ -52,7 +52,7 @@ type CreateWeightTicketDocumentsPayload struct {
 	// Required: true
 	VehicleNickname *string `json:"vehicle_nickname"`
 
-	// What type of vehicle are these weight tickets for?
+	// Select weight ticket type
 	// Required: true
 	// Enum: [CAR CAR_TRAILER BOX_TRUCK]
 	VehicleOptions *string `json:"vehicle_options"`

--- a/pkg/gen/internalmessages/move_document_payload.go
+++ b/pkg/gen/internalmessages/move_document_payload.go
@@ -96,7 +96,7 @@ type MoveDocumentPayload struct {
 	// Vehicle nickname (ex. "My car")
 	VehicleNickname string `json:"vehicle_nickname,omitempty"`
 
-	// What type of vehicle are these weight tickets for?
+	// Select weight ticket type
 	// Enum: [CAR CAR_TRAILER BOX_TRUCK]
 	VehicleOptions string `json:"vehicle_options,omitempty"`
 

--- a/pkg/gen/internalmessages/move_document_payload.go
+++ b/pkg/gen/internalmessages/move_document_payload.go
@@ -93,11 +93,11 @@ type MoveDocumentPayload struct {
 	// missing trailer ownership documentation
 	TrailerOwnershipMissing *bool `json:"trailer_ownership_missing,omitempty"`
 
-	// Vehicle nickname (ex. "My car")
+	// Vehicle nickname (ex. 'My car')
 	VehicleNickname string `json:"vehicle_nickname,omitempty"`
 
 	// Select weight ticket type
-	// Enum: [CAR CAR_TRAILER BOX_TRUCK]
+	// Enum: [CAR CAR_TRAILER BOX_TRUCK PRO_GEAR]
 	VehicleOptions string `json:"vehicle_options,omitempty"`
 
 	// Weight ticket date
@@ -397,7 +397,7 @@ var moveDocumentPayloadTypeVehicleOptionsPropEnum []interface{}
 
 func init() {
 	var res []string
-	if err := json.Unmarshal([]byte(`["CAR","CAR_TRAILER","BOX_TRUCK"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["CAR","CAR_TRAILER","BOX_TRUCK","PRO_GEAR"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {
@@ -415,6 +415,9 @@ const (
 
 	// MoveDocumentPayloadVehicleOptionsBOXTRUCK captures enum value "BOX_TRUCK"
 	MoveDocumentPayloadVehicleOptionsBOXTRUCK string = "BOX_TRUCK"
+
+	// MoveDocumentPayloadVehicleOptionsPROGEAR captures enum value "PRO_GEAR"
+	MoveDocumentPayloadVehicleOptionsPROGEAR string = "PRO_GEAR"
 )
 
 // prop value enum

--- a/pkg/gen/internalmessages/vehicle_options.go
+++ b/pkg/gen/internalmessages/vehicle_options.go
@@ -14,7 +14,7 @@ import (
 	"github.com/go-openapi/validate"
 )
 
-// VehicleOptions What type of vehicle are these weight tickets for?
+// VehicleOptions Select weight ticket type
 // swagger:model VehicleOptions
 type VehicleOptions string
 

--- a/pkg/gen/internalmessages/vehicle_options.go
+++ b/pkg/gen/internalmessages/vehicle_options.go
@@ -28,6 +28,9 @@ const (
 
 	// VehicleOptionsBOXTRUCK captures enum value "BOX_TRUCK"
 	VehicleOptionsBOXTRUCK VehicleOptions = "BOX_TRUCK"
+
+	// VehicleOptionsPROGEAR captures enum value "PRO_GEAR"
+	VehicleOptionsPROGEAR VehicleOptions = "PRO_GEAR"
 )
 
 // for schema
@@ -35,7 +38,7 @@ var vehicleOptionsEnum []interface{}
 
 func init() {
 	var res []VehicleOptions
-	if err := json.Unmarshal([]byte(`["CAR","CAR_TRAILER","BOX_TRUCK"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["CAR","CAR_TRAILER","BOX_TRUCK","PRO_GEAR"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {

--- a/src/scenes/Moves/Ppm/WeightTicket.jsx
+++ b/src/scenes/Moves/Ppm/WeightTicket.jsx
@@ -256,8 +256,7 @@ class WeightTicket extends Component {
               )}
               <div className="expenses-container">
                 <h3 className="expenses-header">Weight Tickets - {weightTicketSetOrdinal} set</h3>
-                Upload an <strong>empty</strong> & <strong>full</strong> weight ticket below for <em>only</em>{' '}
-                <strong>one</strong> vehicle or trip at a time until they're all uploaded.{' '}
+                Upload weight tickets for each vehicle trip and pro-gear weigh.{' '}
                 <Link to="/weight-ticket-examples" className="usa-link">
                   <FontAwesomeIcon aria-hidden className="color_blue_link" icon={faQuestionCircle} />
                 </Link>

--- a/src/scenes/Moves/Ppm/WeightTicket.jsx
+++ b/src/scenes/Moves/Ppm/WeightTicket.jsx
@@ -272,17 +272,16 @@ class WeightTicket extends Component {
                   value={vehicleType}
                   required
                 />
-                {vehicleType && this.isProGear && (
-                  <SwaggerField
-                    fieldName="vehicle_nickname"
-                    title="Pro-gear type (ex. 'My Pro-gear', 'Spouse Pro-Gear', 'Both')"
-                    swagger={schema}
-                    required
-                  />
-                )}
-                {vehicleType && !this.isProGear && (
-                  <SwaggerField fieldName="vehicle_nickname" swagger={schema} required />
-                )}
+                <SwaggerField
+                  fieldName="vehicle_nickname"
+                  title={
+                    this.isProGear
+                      ? "Pro-gear type (ex. 'My Pro-gear', 'Spouse Pro-Gear', 'Both')"
+                      : "Vehicle nickname (ex. 'My car')"
+                  }
+                  swagger={schema}
+                  required
+                />
                 {vehicleType && this.isCarTrailer && (
                   <>
                     <div className="radio-group-wrapper normalize-margins">

--- a/src/scenes/Moves/Ppm/WeightTicket.jsx
+++ b/src/scenes/Moves/Ppm/WeightTicket.jsx
@@ -36,6 +36,7 @@ const vehicleTypes = {
   CarAndTrailer: 'CAR_TRAILER',
   Car: 'CAR',
   BoxTruck: 'BOX_TRUCK',
+  ProGear: 'PRO_GEAR',
 };
 
 const nextBtnLabels = {
@@ -81,6 +82,10 @@ class WeightTicket extends Component {
 
   get isCarTrailer() {
     return this.state.vehicleType === vehicleTypes.CarAndTrailer;
+  }
+
+  get isProGear() {
+    return this.state.vehicleType === vehicleTypes.ProGear;
   }
 
   hasWeightTicket = uploaderRef => {
@@ -267,7 +272,17 @@ class WeightTicket extends Component {
                   value={vehicleType}
                   required
                 />
-                <SwaggerField fieldName="vehicle_nickname" swagger={schema} required />
+                {vehicleType && this.isProGear && (
+                  <SwaggerField
+                    fieldName="vehicle_nickname"
+                    title="Pro-gear type (ex. 'My Pro-gear', 'Spouse Pro-Gear', 'Both')"
+                    swagger={schema}
+                    required
+                  />
+                )}
+                {vehicleType && !this.isProGear && (
+                  <SwaggerField fieldName="vehicle_nickname" swagger={schema} required />
+                )}
                 {vehicleType && this.isCarTrailer && (
                   <>
                     <div className="radio-group-wrapper normalize-margins">

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -699,10 +699,12 @@ definitions:
       - CAR
       - CAR_TRAILER
       - BOX_TRUCK
+      - PRO_GEAR
     x-display-value:
       CAR: Car
       CAR_TRAILER: Car + Trailer
       BOX_TRUCK: Box truck
+      PRO_GEAR: Pro-gear
   MoveDocumentPayload:
     type: object
     properties:
@@ -763,9 +765,10 @@ definitions:
           CAR: Car
           CAR_TRAILER: Car + Trailer
           BOX_TRUCK: Box truck
+          PRO_GEAR: Pro-gear
       vehicle_nickname:
         type: string
-        title: Vehicle nickname (ex. "My car")
+        title: Vehicle nickname (ex. 'My car')
       empty_weight:
         title: Empty Weight
         type: integer
@@ -980,9 +983,10 @@ definitions:
           CAR: Car
           CAR_TRAILER: Car + Trailer
           BOX_TRUCK: Box truck
+          PRO_GEAR: Pro-gear
       vehicle_nickname:
         type: string
-        title: Vehicle nickname (ex. "My car")
+        title: Vehicle nickname (ex. 'My car')
       empty_weight_ticket_missing:
         title: missing empty weight ticket
         type: boolean

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -694,7 +694,7 @@ definitions:
   VehicleOptions:
     type: string
     x-nullable: true
-    title: What type of vehicle are these weight tickets for?
+    title: Select weight ticket type
     enum: &VehicleOptions
       - CAR
       - CAR_TRAILER
@@ -756,7 +756,7 @@ definitions:
         type: boolean
         x-nullable: true
       vehicle_options:
-        title: What type of vehicle are these weight tickets for?
+        title: Select weight ticket type
         type: string
         enum: *VehicleOptions
         x-display-value:
@@ -973,7 +973,7 @@ definitions:
           format: uuid
           example: c56a4180-65aa-42ec-a945-5fd21dec0538
       vehicle_options:
-        title: What type of vehicle are these weight tickets for?
+        title: Select weight ticket type
         type: string
         enum: *VehicleOptions
         x-display-value:


### PR DESCRIPTION
## Description
This branch adds Pro-Gear as a vehicle type option in the weight ticket set document screen in the payment request process. There's some copy changes.


Still waiting for confirmation whether we need all weight fields for Pro-Gear but should get confirmation end of day.

## Reviewer Notes
Also don't know if the if-then case is efficient. I tried to have a conditional within the SwaggerField but I couldn't nail it.

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make server_run
make client_run
login as ppm@requestingpay.ment
```

## Code Review Verification Steps
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-701) for this change

## Screenshots
<img width="1010" alt="Screen Shot 2019-12-18 at 11 43 02 AM" src="https://user-images.githubusercontent.com/6464062/71119435-1e03a880-21a8-11ea-8cad-c98b61d65f38.png">
