### PR TITLE
Prime move-task-orders only returns MTOs isAvailableToPrime

### DIFF
--- a/pkg/handlers/primeapi/move_task_order.go
+++ b/pkg/handlers/primeapi/move_task_order.go
@@ -24,7 +24,7 @@ func (h ListMoveTaskOrdersHandler) Handle(params movetaskorderops.ListMoveTaskOr
 
 	var mtos models.MoveTaskOrders
 
-	query := h.DB().Q()
+	query := h.DB().Where("is_available_to_prime = ?", true)
 	if params.Since != nil {
 		since := time.Unix(*params.Since, 0)
 		query = query.Where("updated_at > ?", since)

--- a/pkg/handlers/primeapi/move_task_order_test.go
+++ b/pkg/handlers/primeapi/move_task_order_test.go
@@ -5,13 +5,22 @@ import (
 	"net/http/httptest"
 	"time"
 
+	"github.com/transcom/mymove/pkg/models"
+
 	movetaskorderops "github.com/transcom/mymove/pkg/gen/primeapi/primeoperations/move_task_order"
 	"github.com/transcom/mymove/pkg/handlers"
 	"github.com/transcom/mymove/pkg/testdatagen"
 )
 
 func (suite *HandlerSuite) TestListMoveTaskOrdersHandler() {
-	moveTaskOrder := testdatagen.MakeMoveTaskOrder(suite.DB(), testdatagen.Assertions{})
+	moveTaskOrder := testdatagen.MakeMoveTaskOrder(suite.DB(), testdatagen.Assertions{
+		MoveTaskOrder: models.MoveTaskOrder{
+			IsAvailableToPrime: true,
+		},
+	})
+
+	// unavailable MTO
+	testdatagen.MakeMoveTaskOrder(suite.DB(), testdatagen.Assertions{})
 
 	request := httptest.NewRequest("GET", "/move-task-orders", nil)
 
@@ -34,10 +43,18 @@ func (suite *HandlerSuite) TestListMoveTaskOrdersHandlerReturnsUpdated() {
 	now := time.Now()
 	lastFetch := now.Add(-time.Second)
 
-	moveTaskOrder := testdatagen.MakeMoveTaskOrder(suite.DB(), testdatagen.Assertions{})
+	moveTaskOrder := testdatagen.MakeMoveTaskOrder(suite.DB(), testdatagen.Assertions{
+		MoveTaskOrder: models.MoveTaskOrder{
+			IsAvailableToPrime: true,
+		},
+	})
 
 	// this MTO should not be returned
-	olderMoveTaskOrder := testdatagen.MakeMoveTaskOrder(suite.DB(), testdatagen.Assertions{})
+	olderMoveTaskOrder := testdatagen.MakeMoveTaskOrder(suite.DB(), testdatagen.Assertions{
+		MoveTaskOrder: models.MoveTaskOrder{
+			IsAvailableToPrime: true,
+		},
+	})
 
 	// Pop will overwrite UpdatedAt when saving a model, so use SQL to set it in the past
 	suite.NoError(suite.DB().RawQuery("UPDATE move_task_orders SET updated_at=? WHERE id=?",

--- a/pkg/testdatagen/scenario/e2ebasic.go
+++ b/pkg/testdatagen/scenario/e2ebasic.go
@@ -907,4 +907,22 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, log
 		},
 	})
 
+	// A more recent MTO for demonstrating the since parameter
+	customer2 := testdatagen.MakeCustomer(db, testdatagen.Assertions{
+		Customer: models.Customer{
+			ID: uuid.FromStringOrNil("6ac40a00-e762-4f5f-b08d-3ea72a8e4b61"),
+		},
+	})
+	moveOrders2 := testdatagen.MakeMoveOrder(db, testdatagen.Assertions{
+		MoveOrder: models.MoveOrder{ID: uuid.FromStringOrNil("6fca843a-a87e-4752-b454-0fac67aa4981")},
+		Customer:  customer2,
+	})
+	testdatagen.MakeMoveTaskOrder(db, testdatagen.Assertions{
+		MoveTaskOrder: models.MoveTaskOrder{
+			ID:                 uuid.FromStringOrNil("5d4b25bb-eb04-4c03-9a81-ee0398cb7791"),
+			MoveOrderID:        moveOrders2.ID,
+			UpdatedAt:          time.Unix(1576779681256, 0),
+			IsAvailableToPrime: true,
+		},
+	})
 }


### PR DESCRIPTION
## Description

I noticed that we weren't limiting the MTOs that were returned by this endpoint. This PR adds an additional `WHERE` clause to the query loading the MTOs to enforce this business requirement.

## Setup

First, be sure that you've followed [these setup instructions](https://github.com/transcom/mymove#setup-prime-api).

```sh
$ make db_dev_e2e_populate
$ ./scripts/prime-api move-task-orders | jq
```

You should see that there is only one MTO returned.

## Code Review Verification Steps

* [x] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/tree/master/docs/backend.md#logging)
* [x] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/tree/master/docs/backend.md#querying-the-database-safely) have been satisfied.
* [ ] Request review from a member of a different team.