### PR TITLE
Rename test cases in e2ebasic.go

### DIFF
--- a/pkg/testdatagen/scenario/e2ebasic.go
+++ b/pkg/testdatagen/scenario/e2ebasic.go
@@ -1030,19 +1030,19 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, log
 	})
 
 	// A more recent MTO for demonstrating the since parameter
-	customer2 := testdatagen.MakeCustomer(db, testdatagen.Assertions{
+	customer6 := testdatagen.MakeCustomer(db, testdatagen.Assertions{
 		Customer: models.Customer{
 			ID: uuid.FromStringOrNil("6ac40a00-e762-4f5f-b08d-3ea72a8e4b61"),
 		},
 	})
-	moveOrders2 := testdatagen.MakeMoveOrder(db, testdatagen.Assertions{
+	moveOrders6 := testdatagen.MakeMoveOrder(db, testdatagen.Assertions{
 		MoveOrder: models.MoveOrder{ID: uuid.FromStringOrNil("6fca843a-a87e-4752-b454-0fac67aa4981")},
-		Customer:  customer2,
+		Customer:  customer6,
 	})
 	testdatagen.MakeMoveTaskOrder(db, testdatagen.Assertions{
 		MoveTaskOrder: models.MoveTaskOrder{
 			ID:                 uuid.FromStringOrNil("5d4b25bb-eb04-4c03-9a81-ee0398cb7791"),
-			MoveOrderID:        moveOrders2.ID,
+			MoveOrderID:        moveOrders6.ID,
 			UpdatedAt:          time.Unix(1576779681256, 0),
 			IsAvailableToPrime: true,
 		},


### PR DESCRIPTION
## Description

Explain a little about the changes at a high level.

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
echo "Code goes here"
```

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/tree/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/tree/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/tree/master/docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
  * [ ] Secure migrations have been tested using `scripts/run-prod-migrations`
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](tbd) for this change
* [this article](tbd) explains more about the approach used.

## Screenshots

If this PR makes visible UI changes, an image of the finished UI can help reviewers and casual
observers understand the context of the changes. A before image is optional and
can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow instead of using multiple images. You may want to use GIPHY CAPTURE for this! 📸

_Please frame screenshots to show enough useful context but also highlight the affected regions._
