### PR TITLE
Remove 'a' tag from cy.get

### DIFF
--- a/cypress/integration/mymove/ppmCloseout.js
+++ b/cypress/integration/mymove/ppmCloseout.js
@@ -117,7 +117,7 @@ function serviceMemberSkipsStep() {
 }
 
 function serviceMemberSubmitsPaymentRequestWithMissingDocuments() {
-  cy.get('.review-customer-agreement a')
+  cy.get('.review-customer-agreement')
     .contains('Legal Agreement')
     .click();
   cy.location().should(loc => {
@@ -153,7 +153,7 @@ function serviceMemberReviewsDocuments() {
   cy.location().should(loc => {
     expect(loc.pathname).to.match(/^\/moves\/[^/]+\/ppm-payment-review/);
   });
-  cy.get('.review-customer-agreement a')
+  cy.get('.review-customer-agreement')
     .contains('Legal Agreement')
     .click();
   cy.location().should(loc => {


### PR DESCRIPTION
## Description

Possible fix for failing cypress spec. The trailing `a` tag at the end of `cy.get('.review-customer-agreement a')` may have been causing the issue. I removed that tag, and so far tests have been passing. 