### PR TITLE
Change excluded example to awaiting review in e2e test to reflect how…

### DIFF
--- a/cypress/integration/office/ppmMoveDocuments.js
+++ b/cypress/integration/office/ppmMoveDocuments.js
@@ -5,11 +5,8 @@ describe('office user finds the shipment', function() {
     cy.get('[data-cy=ppm-queue]').click();
   });
   it('office user views ppm panel and goes to a ppm with a move document for awaiting review', function() {
-    officeUserViewsPpmPanel('EXCLDE');
-    officeUserChecksExpensePanelForAlert(false);
-    officeUserEditsDocumentStatus('Expense Document', 'OK', 'EXCLUDE_FROM_CALCULATION');
-    // TODO: double check this alert not showing
-    // officeUserChecksExpensePanelForAlert(true);
+    officeUserViewsPpmPanel('PMTRVW');
+    officeUserChecksExpensePanelForAlert(true);
   });
 });
 
@@ -28,33 +25,6 @@ function officeUserViewsPpmPanel(locatorId) {
   cy.get('.nav-tab')
     .contains('PPM')
     .click();
-}
-
-function officeUserEditsDocumentStatus(documentTitle, oldDocumentStatus, newDocumentStatus) {
-  cy.get('.documents')
-    .get('[data-cy="doc-link"]')
-    .find('a')
-    .contains(documentTitle)
-    .should('have.attr', 'href')
-    .and('match', /^\/moves\/[^/]+\/documents\/[^/]+/)
-    .then(href => {
-      cy.patientVisit(href);
-    });
-
-  cy.get('.panel-field.status').contains(oldDocumentStatus);
-
-  cy.get('.editable-panel-edit').click();
-
-  cy.get('label[for="moveDocument.status"]')
-    .siblings()
-    .first()
-    .children()
-    .select(newDocumentStatus)
-    .blur();
-
-  cy.get('.editable-panel-save').click();
-
-  cy.go(-1);
 }
 
 function officeUserChecksExpensePanelForAlert(alertShown) {

--- a/pkg/testdatagen/scenario/e2ebasic.go
+++ b/pkg/testdatagen/scenario/e2ebasic.go
@@ -429,7 +429,7 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, log
 		},
 		Move: models.Move{
 			ID:      uuid.FromStringOrNil("687e3ee4-62ff-44b3-a5cb-73338c9fdf95"),
-			Locator: "EXCLDE",
+			Locator: "PMTRVW",
 		},
 		PersonallyProcuredMove: models.PersonallyProcuredMove{
 			ID:               uuid.FromStringOrNil("38c4fc15-062f-4325-bceb-13ea167001da"),
@@ -453,7 +453,7 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, log
 			MoveID:                   ppmExcludedCalculations.Move.ID,
 			Move:                     ppmExcludedCalculations.Move,
 			MoveDocumentType:         models.MoveDocumentTypeEXPENSE,
-			Status:                   models.MoveDocumentStatusOK,
+			Status:                   models.MoveDocumentStatusAWAITINGREVIEW,
 			PersonallyProcuredMoveID: &assertions.PersonallyProcuredMove.ID,
 			Title:                    "Expense Document",
 			ID:                       uuid.FromStringOrNil("02021626-20ee-4c65-9194-87e6455f385e"),


### PR DESCRIPTION
… the alert logic is meant to function.

## Description

Adjusts the e2e data we're using for this test so that it's using a move that's `AWAITING_REVIEW`. This also meant we don't need to edit that move during the e2e test. The reason for this is that we're no longer considering a move that's being excluded from the calculation as being a reason for the alert to show on the office site. The change brings the e2e test in line with current expectations.


## Setup
Might need to do a clean before running to make sure the e2e script loads the right stuff for you for e2e tests.

```sh
make clean
make db_test_reset
make e2e_test
```

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/tree/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/tree/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/tree/master/docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
  * [ ] Secure migrations have been tested using `scripts/run-prod-migrations`
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-985) for this change
