### PR TITLE
[MB-1047] Corrected Urls for missing orderslocal and primelocal in `check-hosts-file`

### DIFF
--- a/scripts/check-hosts-file
+++ b/scripts/check-hosts-file
@@ -10,7 +10,13 @@ function check_host () {
   if [ -z "${host_line}" ]; then
     # shellcheck disable=SC1117
     echo -e "\033[0;33mPlease add ${host} to your hosts file using the command:\033[0m 'echo \"127.0.0.1 ${host}\" | sudo tee -a /etc/hosts'"
-    echo "More information at https://github.com/transcom/mymove#setup-${host}-client"
+    if [ "${host}" = primelocal ]; then
+      echo "More information at https://github.com/transcom/mymove#setup-prime-api"
+    elif [ "${host}" = orderslocal ]; then
+      echo "More information at https://github.com/transcom/mymove#setup-orders-gateway"
+    else
+      echo "More information at https://github.com/transcom/mymove#setup-${host}-client"
+    fi
     exit 1
   fi
 }


### PR DESCRIPTION
## Description

Corrected documentation urls when orderslocal or primelocal aren't configured in `/etc/hosts'

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-1047) for this change
