### PR TITLE
[MB-680] Add parser for sheet 2c Domestic Other Prices

### DIFF
--- a/pkg/models/stage_pricing.go
+++ b/pkg/models/stage_pricing.go
@@ -37,6 +37,20 @@ type StageDomesticServiceAreaPrice struct {
 	OriginDestinationSITAddlDays          string `db:"origin_destination_sit_addl_days" csv:"origin_destination_sit_addl_days"`
 }
 
+type StageDomesticOtherPackPrice struct {
+	ServicesSchedule   string `db:"services_schedule" csv:"services_schedule"`
+	ServiceProvided    string `db:"service_provided" csv:"service_provided"`
+	NonPeakPricePerCwt string `db:"non_peak_price_per_cwt" csv:"non_peak_price_per_cwt"`
+	PeakPricePerCwt    string `db:"peak_price_per_cwt" csv:"peak_price_per_cwt"`
+}
+
+type StageDomesticOtherSitPrice struct {
+	SITPickupDeliverySchedule string `db:"sit_pickup_delivery_schedule" csv:"sit_pickup_delivery_schedule"`
+	ServiceProvided           string `db:"service_provided" csv:"service_provided"`
+	NonPeakPricePerCwt        string `db:"non_peak_price_per_cwt" csv:"non_peak_price_per_cwt"`
+	PeakPricePerCwt           string `db:"peak_price_per_cwt" csv:"peak_price_per_cwt"`
+}
+
 type StageOconusToOconusPrice struct {
 	OriginIntlPriceAreaID      string `db:"origin_intl_price_area_id" csv:"origin_intl_price_area_id"`
 	OriginIntlPriceArea        string `db:"origin_intl_price_area" csv:"origin_intl_price_area"`

--- a/pkg/parser/pricing/fixtures/8_2c_domestic_other_prices_pack_golden.csv
+++ b/pkg/parser/pricing/fixtures/8_2c_domestic_other_prices_pack_golden.csv
@@ -1,0 +1,7 @@
+services_schedule,service_provided,non_peak_price_per_cwt,peak_price_per_cwt
+1,Packing (per cwt),$63.33,$65.44
+2,Packing (per cwt),$72.50,$73.20
+3,Packing (per cwt),$73.95,$80.00
+1,Unpack (per cwt),$83.34,$85.44
+2,Unpack (per cwt),$5.97,$6.50
+3,Unpack (per cwt),$5.97,$6.50

--- a/pkg/parser/pricing/fixtures/8_2c_domestic_other_prices_sit_golden.csv
+++ b/pkg/parser/pricing/fixtures/8_2c_domestic_other_prices_sit_golden.csv
@@ -1,0 +1,4 @@
+sit_pickup_delivery_schedule,service_provided,non_peak_price_per_cwt,peak_price_per_cwt
+1,SIT Pickup / Delivery ≤50 miles (per cwt),$217.96,$220.11
+2,SIT Pickup / Delivery ≤50 miles (per cwt),$234.40,$241.22
+3,SIT Pickup / Delivery ≤50 miles (per cwt),$246.25,$250.30

--- a/pkg/parser/pricing/parse.go
+++ b/pkg/parser/pricing/parse.go
@@ -185,6 +185,24 @@ func InitDataSheetInfo() []XlsxDataSheetInfo {
 		},
 		verify: &verifyDomesticServiceAreaPrices,
 	}
+
+	// 8: 	2c) Dom. Other Prices
+	xlsxDataSheets[8] = XlsxDataSheetInfo{
+		Description:    swag.String("2c) Dom. Other Prices"),
+		outputFilename: swag.String("2c_domestic_other_prices"),
+		ProcessMethods: []xlsxProcessInfo{
+			{
+				process:    &parseDomesticOtherPricesPack,
+				adtlSuffix: swag.String("pack"),
+			},
+			{
+				process:    &parseDomesticOtherPricesSit,
+				adtlSuffix: swag.String("sit"),
+			},
+		},
+		verify: &verifyDomesticOtherPrices,
+	}
+
 	// 10: 	3a) OCONUS TO OCONUS Prices
 	xlsxDataSheets[10] = XlsxDataSheetInfo{
 		Description:    swag.String("3a) OCONUS to OCONUS Prices"),

--- a/pkg/parser/pricing/parse_domestic_linehaul_prices.go
+++ b/pkg/parser/pricing/parse_domestic_linehaul_prices.go
@@ -23,6 +23,8 @@ var parseDomesticLinehaulPrices processXlsxSheet = func(params ParamConfig, shee
 		return nil, fmt.Errorf("parseDomesticLinehaulPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
 	}
 
+	log.Println("Parsing Domestic Linehaul Prices")
+
 	var domPrices []models.StageDomesticLinehaulPrice
 	dataRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[feeRowIndexStart:]
 	for _, row := range dataRows {

--- a/pkg/parser/pricing/parse_domestic_other_prices.go
+++ b/pkg/parser/pricing/parse_domestic_other_prices.go
@@ -1,0 +1,200 @@
+package pricing
+
+import (
+	"fmt"
+
+	"github.com/transcom/mymove/pkg/models"
+)
+
+var parseDomesticOtherPricesPack processXlsxSheet = func(params ParamConfig, sheetIndex int) (interface{}, error) {
+	// XLSX Sheet consts
+	const xlsxDataSheetNum int = 8 // 2c) Domestic Other Prices
+	const rowIndexStart int = 12
+	const servicesScheduleColumn int = 2
+	const serviceProvidedColumn int = 3
+	const nonPeakPriceColumn int = 4
+	const peakPriceColumn int = 5
+
+	if xlsxDataSheetNum != sheetIndex {
+		return nil, fmt.Errorf("parseDomesticOtherPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
+	}
+
+	var packUnpackPrices []models.StageDomesticOtherPackPrice
+	dataRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[rowIndexStart:]
+	for _, row := range dataRows {
+		packPrice := models.StageDomesticOtherPackPrice{
+			ServicesSchedule:   getCell(row.Cells, servicesScheduleColumn),
+			ServiceProvided:    getCell(row.Cells, serviceProvidedColumn),
+			NonPeakPricePerCwt: getCell(row.Cells, nonPeakPriceColumn),
+			PeakPricePerCwt:    getCell(row.Cells, peakPriceColumn),
+		}
+
+		if packPrice.ServicesSchedule != "" {
+			packUnpackPrices = append(packUnpackPrices, packPrice)
+		} else {
+			break
+		}
+	}
+
+	return packUnpackPrices, nil
+}
+
+var parseDomesticOtherPricesSit processXlsxSheet = func(params ParamConfig, sheetIndex int) (interface{}, error) {
+	// XLSX Sheet consts
+	const xlsxDataSheetNum int = 8 // 2c) Domestic Other Prices
+	const rowIndexStart int = 24
+	const servicesScheduleColumn int = 2
+	const serviceProvidedColumn int = 3
+	const nonPeakPriceColumn int = 4
+	const peakPriceColumn int = 5
+
+	if xlsxDataSheetNum != sheetIndex {
+		return nil, fmt.Errorf("parseDomesticOtherPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
+	}
+
+	var sitPrices []models.StageDomesticOtherSitPrice
+	dataRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[rowIndexStart:]
+	for _, row := range dataRows {
+		sitPrice := models.StageDomesticOtherSitPrice{
+			SITPickupDeliverySchedule: getCell(row.Cells, servicesScheduleColumn),
+			ServiceProvided:           getCell(row.Cells, serviceProvidedColumn),
+			NonPeakPricePerCwt:        getCell(row.Cells, nonPeakPriceColumn),
+			PeakPricePerCwt:           getCell(row.Cells, peakPriceColumn),
+		}
+
+		if sitPrice.SITPickupDeliverySchedule != "" {
+			sitPrices = append(sitPrices, sitPrice)
+		} else {
+			break
+		}
+	}
+
+	return sitPrices, nil
+}
+
+// verifyDomesticOtherPrices: verification 2c) Dom. Other Prices
+var verifyDomesticOtherPrices verifyXlsxSheet = func(params ParamConfig, sheetIndex int) error {
+	const xlsxDataSheetNum int = 8 // 2c) Domestic Other Prices
+	if xlsxDataSheetNum != sheetIndex {
+		return fmt.Errorf("verifyDomesticOtherPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
+	}
+	if err := verifyPackUnpackPrices(params, sheetIndex); err != nil {
+		return err
+	}
+	if err := verifySITPickupPrices(params, sheetIndex); err != nil {
+		return err
+	}
+	return nil
+}
+
+func verifyPackUnpackPrices(params ParamConfig, sheetIndex int) error {
+	// XLSX Sheet consts
+	const rowIndexStart int = 12
+	const servicesScheduleColumn int = 2
+	const serviceProvidedColumn int = 3
+	const nonPeakPriceColumn int = 4
+	const peakPriceColumn int = 5
+
+	// Check headers
+	const headerIndexStart = rowIndexStart - 2
+	const headerIndexEnd = headerIndexStart + 1
+
+	// Verify header strings
+	dataRows := params.XlsxFile.Sheets[sheetIndex].Rows[headerIndexStart:headerIndexEnd]
+	for _, row := range dataRows {
+		if header := removeWhiteSpace(getCell(row.Cells, servicesScheduleColumn)); header != "ServicesSchedule" {
+			return fmt.Errorf("verifyDomesticOtherPrices Pack/Unpack expected to find header 'ServicesSchedule', but received header '%s'", header)
+		}
+		if header := removeWhiteSpace(getCell(row.Cells, serviceProvidedColumn)); header != "ServiceProvided" {
+			return fmt.Errorf("verifyDomesticOtherPrices Pack/Unpack expected to find header 'ServiceProvided', but received header '%s'", header)
+		}
+		if header := removeWhiteSpace(getCell(row.Cells, nonPeakPriceColumn)); header != "Non-Peak(percwt)" {
+			return fmt.Errorf("verifyDomesticOtherPrices Pack/Unpack expected to find header 'Non-Peak(percwt)', but received header '%s'", header)
+		}
+		if header := removeWhiteSpace(getCell(row.Cells, peakPriceColumn)); header != "Peak(percwt)" {
+			return fmt.Errorf("verifyDomesticOtherPrices Pack/Unpack expected to find header 'Peak(percwt)', but received header '%s'", header)
+		}
+	}
+
+	// Check example row
+	const exampleIndexStart = headerIndexStart + 1
+	const exampleIndexEnd = exampleIndexStart + 1
+
+	// Verify example row strings
+	exampleRows := params.XlsxFile.Sheets[sheetIndex].Rows[exampleIndexStart:exampleIndexEnd]
+	for _, row := range exampleRows {
+		if example := getCell(row.Cells, servicesScheduleColumn); example != "X" {
+			return fmt.Errorf("verifyDomesticOtherPrices Pack/Unpack expected to find example 'X' for Services Schedule, but received example '%s'", example)
+		}
+		if example := getCell(row.Cells, serviceProvidedColumn); example != "EXAMPLE (per cwt)" {
+			return fmt.Errorf("verifyDomesticOtherPrices Pack/Unpack expected to find example 'EXAMPLE (per cwt)' for Service Proided, but received example '%s'", example)
+		}
+		if example := getCell(row.Cells, nonPeakPriceColumn); example != "$X.XX" {
+			return fmt.Errorf("verifyDomesticOtherPrices Pack/Unpack expected to find example '$X.XX' for Non-Peak (per cwt), but received example '%s'", example)
+		}
+		if example := getCell(row.Cells, peakPriceColumn); example != "$X.XX" {
+			return fmt.Errorf("verifyDomesticOtherPrices Pack/Unpack expected to find example '$X.XX' for Peak (per cwt), but received example '%s'", example)
+		}
+	}
+
+	return nil
+}
+
+func verifySITPickupPrices(params ParamConfig, sheetIndex int) error {
+	// XLSX Sheet consts
+	const rowIndexStart int = 24
+	const servicesScheduleColumn int = 2
+	const serviceProvidedColumn int = 3
+	const nonPeakPriceColumn int = 4
+	const peakPriceColumn int = 5
+
+	// Check headers
+	const headerIndexStart = rowIndexStart - 2
+	const headerIndexEnd = headerIndexStart + 1
+	const sitHeaderIndexStart = headerIndexStart - 1
+	const sitHeaderIndexEnd = headerIndexStart
+
+	// Verify header strings
+	firstHeaderRows := params.XlsxFile.Sheets[sheetIndex].Rows[sitHeaderIndexStart:sitHeaderIndexEnd]
+	for _, row := range firstHeaderRows {
+		if header := removeWhiteSpace(getCell(row.Cells, servicesScheduleColumn)); header != "SITPickup/DeliverySchedule" {
+			return fmt.Errorf("verifyDomesticOtherPrices SIT Pickup expected to find header 'SITPickup/DeliverySchedule', but received header '%s'", header)
+		}
+	}
+
+	dataRows := params.XlsxFile.Sheets[sheetIndex].Rows[headerIndexStart:headerIndexEnd]
+	for _, row := range dataRows {
+		if header := getCell(row.Cells, serviceProvidedColumn); header != "Service Provided" {
+			return fmt.Errorf("verifyDomesticOtherPrices SIT Pickup expected to find header 'Service Provided', but received header '%s'", header)
+		}
+		if header := removeWhiteSpace(getCell(row.Cells, nonPeakPriceColumn)); header != "Non-Peak(percwt)" {
+			return fmt.Errorf("verifyDomesticOtherPrices SIT Pickup expected to find header 'Non-Peak(percwt)', but received header '%s'", header)
+		}
+		if header := removeWhiteSpace(getCell(row.Cells, peakPriceColumn)); header != "Peak(percwt)" {
+			return fmt.Errorf("verifyDomesticOtherPrices SIT Pickup expected to find header 'Peak(percwt)', but received header '%s'", header)
+		}
+	}
+
+	// Check example row
+	const exampleIndexStart = headerIndexStart + 1
+	const exampleIndexEnd = exampleIndexStart + 1
+
+	// Verify example row strings
+	exampleRows := params.XlsxFile.Sheets[sheetIndex].Rows[exampleIndexStart:exampleIndexEnd]
+	for _, row := range exampleRows {
+		if example := getCell(row.Cells, servicesScheduleColumn); example != "X" {
+			return fmt.Errorf("verifyDomesticOtherPrices SIT Pickup expected to find example 'X' for SITPickup/DeliverySchedule, but received example '%s'", example)
+		}
+		if example := getCell(row.Cells, serviceProvidedColumn); example != "EXAMPLE (per cwt)" {
+			return fmt.Errorf("verifyDomesticOtherPrices SIT Pickup expected to find example 'EXAMPLE (per cwt)' for Service Proided, but received example '%s'", example)
+		}
+		if example := getCell(row.Cells, nonPeakPriceColumn); example != "$X.XX" {
+			return fmt.Errorf("verifyDomesticOtherPrices SIT Pickup expected to find example '$X.XX' for Non-Peak (per cwt), but received example '%s'", example)
+		}
+		if example := getCell(row.Cells, peakPriceColumn); example != "$X.XX" {
+			return fmt.Errorf("verifyDomesticOtherPrices SIT Pickup expected to find example '$X.XX' for Peak (per cwt), but received example '%s'", example)
+		}
+	}
+
+	return nil
+}

--- a/pkg/parser/pricing/parse_domestic_other_prices.go
+++ b/pkg/parser/pricing/parse_domestic_other_prices.go
@@ -2,6 +2,7 @@ package pricing
 
 import (
 	"fmt"
+	"log"
 
 	"github.com/transcom/mymove/pkg/models"
 )
@@ -14,6 +15,10 @@ var parseDomesticOtherPricesPack processXlsxSheet = func(params ParamConfig, she
 	const serviceProvidedColumn int = 3
 	const nonPeakPriceColumn int = 4
 	const peakPriceColumn int = 5
+
+	if params.ShowOutput == true {
+		log.Println("Parsing Domestic Other (Pack/Unpack) Prices")
+	}
 
 	if xlsxDataSheetNum != sheetIndex {
 		return nil, fmt.Errorf("parseDomesticOtherPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
@@ -31,7 +36,13 @@ var parseDomesticOtherPricesPack processXlsxSheet = func(params ParamConfig, she
 
 		if packPrice.ServicesSchedule != "" {
 			packUnpackPrices = append(packUnpackPrices, packPrice)
+			if params.ShowOutput == true {
+				log.Printf("%+v\n", packPrice)
+			}
 		} else {
+			if params.ShowOutput == true {
+				log.Println("Parse of Domestic Other (Pack/Unpack) Prices Complete")
+			}
 			break
 		}
 	}
@@ -47,6 +58,10 @@ var parseDomesticOtherPricesSit processXlsxSheet = func(params ParamConfig, shee
 	const serviceProvidedColumn int = 3
 	const nonPeakPriceColumn int = 4
 	const peakPriceColumn int = 5
+
+	if params.ShowOutput == true {
+		log.Println("Parsing Domestic Other (SIT Pickup/Delivery) Prices")
+	}
 
 	if xlsxDataSheetNum != sheetIndex {
 		return nil, fmt.Errorf("parseDomesticOtherPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
@@ -64,7 +79,13 @@ var parseDomesticOtherPricesSit processXlsxSheet = func(params ParamConfig, shee
 
 		if sitPrice.SITPickupDeliverySchedule != "" {
 			sitPrices = append(sitPrices, sitPrice)
+			if params.ShowOutput == true {
+				log.Printf("%+v\n", sitPrice)
+			}
 		} else {
+			if params.ShowOutput == true {
+				log.Println("Parse of Domestic Other (Pack/Unpack) Prices Complete")
+			}
 			break
 		}
 	}

--- a/pkg/parser/pricing/parse_domestic_other_prices.go
+++ b/pkg/parser/pricing/parse_domestic_other_prices.go
@@ -16,9 +16,7 @@ var parseDomesticOtherPricesPack processXlsxSheet = func(params ParamConfig, she
 	const nonPeakPriceColumn int = 4
 	const peakPriceColumn int = 5
 
-	if params.ShowOutput == true {
-		log.Println("Parsing Domestic Other (Pack/Unpack) Prices")
-	}
+	log.Println("Parsing Domestic Other (Pack/Unpack) Prices")
 
 	if xlsxDataSheetNum != sheetIndex {
 		return nil, fmt.Errorf("parseDomesticOtherPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
@@ -59,9 +57,7 @@ var parseDomesticOtherPricesSit processXlsxSheet = func(params ParamConfig, shee
 	const nonPeakPriceColumn int = 4
 	const peakPriceColumn int = 5
 
-	if params.ShowOutput == true {
-		log.Println("Parsing Domestic Other (SIT Pickup/Delivery) Prices")
-	}
+	log.Println("Parsing Domestic Other (SIT Pickup/Delivery) Prices")
 
 	if xlsxDataSheetNum != sheetIndex {
 		return nil, fmt.Errorf("parseDomesticOtherPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)

--- a/pkg/parser/pricing/parse_domestic_other_prices_test.go
+++ b/pkg/parser/pricing/parse_domestic_other_prices_test.go
@@ -1,0 +1,62 @@
+package pricing
+
+import (
+	"strconv"
+	"time"
+)
+
+// Test_parseDomesticOtherPricesPack
+func (suite *PricingParserSuite) Test_parseDomesticOtherPricesPack() {
+	const sheetIndex = 8
+	xlsxDataSheets := InitDataSheetInfo()
+	dataSheet := xlsxDataSheets[sheetIndex]
+
+	params := ParamConfig{
+		ProcessAll:   false,
+		ShowOutput:   false,
+		XlsxFilename: suite.xlsxFilename,
+		XlsxSheets:   []string{strconv.Itoa(sheetIndex)},
+		SaveToFile:   true,
+		RunTime:      time.Now(),
+		XlsxFile:     suite.xlsxFile,
+		RunVerify:    true,
+	}
+
+	slice, err := parseDomesticOtherPricesPack(params, sheetIndex)
+	suite.NoError(err, "parseDomesticOtherPricesPack function failed")
+
+	outputFilename := dataSheet.generateOutputFilename(sheetIndex, params.RunTime, nil)
+	err = createCSV(outputFilename, slice)
+	suite.NoError(err, "could not create CSV")
+
+	const goldenFilename string = "8_2c_domestic_other_prices_pack_golden.csv"
+	suite.helperTestExpectedFileOutput(goldenFilename, outputFilename)
+}
+
+// Test_parseDomesticOtherPricesSit
+func (suite *PricingParserSuite) Test_parseDomesticOtherPricesSit() {
+	const sheetIndex = 8
+	xlsxDataSheets := InitDataSheetInfo()
+	dataSheet := xlsxDataSheets[sheetIndex]
+
+	params := ParamConfig{
+		ProcessAll:   false,
+		ShowOutput:   false,
+		XlsxFilename: suite.xlsxFilename,
+		XlsxSheets:   []string{strconv.Itoa(sheetIndex)},
+		SaveToFile:   true,
+		RunTime:      time.Now(),
+		XlsxFile:     suite.xlsxFile,
+		RunVerify:    true,
+	}
+
+	slice, err := parseDomesticOtherPricesSit(params, sheetIndex)
+	suite.NoError(err, "parseDomesticOtherPricesSit function failed")
+
+	outputFilename := dataSheet.generateOutputFilename(sheetIndex, params.RunTime, nil)
+	err = createCSV(outputFilename, slice)
+	suite.NoError(err, "could not create CSV")
+
+	const goldenFilename string = "8_2c_domestic_other_prices_sit_golden.csv"
+	suite.helperTestExpectedFileOutput(goldenFilename, outputFilename)
+}

--- a/pkg/parser/pricing/parse_domestic_other_prices_test.go
+++ b/pkg/parser/pricing/parse_domestic_other_prices_test.go
@@ -2,11 +2,12 @@ package pricing
 
 import (
 	"strconv"
+	"testing"
 	"time"
 )
 
 // Test_parseDomesticOtherPricesPack
-func (suite *PricingParserSuite) Test_parseDomesticOtherPricesPack() {
+func (suite *PricingParserSuite) Test_parseDomesticOtherPrices() {
 	const sheetIndex = 8
 	xlsxDataSheets := InitDataSheetInfo()
 	dataSheet := xlsxDataSheets[sheetIndex]
@@ -22,23 +23,34 @@ func (suite *PricingParserSuite) Test_parseDomesticOtherPricesPack() {
 		RunVerify:    true,
 	}
 
-	slice, err := parseDomesticOtherPricesPack(params, sheetIndex)
-	suite.NoError(err, "parseDomesticOtherPricesPack function failed")
+	suite.T().Run("parseDomesticOtherPricesPack", func(t *testing.T) {
+		slice, err := parseDomesticOtherPricesPack(params, sheetIndex)
+		suite.NoError(err, "parseDomesticOtherPricesPack function failed")
 
-	outputFilename := dataSheet.generateOutputFilename(sheetIndex, params.RunTime, nil)
-	err = createCSV(outputFilename, slice)
-	suite.NoError(err, "could not create CSV")
+		outputFilename := dataSheet.generateOutputFilename(sheetIndex, params.RunTime, nil)
+		err = createCSV(outputFilename, slice)
+		suite.NoError(err, "could not create CSV")
 
-	const goldenFilename string = "8_2c_domestic_other_prices_pack_golden.csv"
-	suite.helperTestExpectedFileOutput(goldenFilename, outputFilename)
+		const goldenFilename string = "8_2c_domestic_other_prices_pack_golden.csv"
+		suite.helperTestExpectedFileOutput(goldenFilename, outputFilename)
+	})
+
+	suite.T().Run("parseDomesticOtherPricesSit", func(t *testing.T) {
+		slice, err := parseDomesticOtherPricesSit(params, sheetIndex)
+		suite.NoError(err, "parseDomesticOtherPricesSit function failed")
+
+		outputFilename := dataSheet.generateOutputFilename(sheetIndex, params.RunTime, nil)
+		err = createCSV(outputFilename, slice)
+		suite.NoError(err, "could not create CSV")
+
+		const goldenFilename string = "8_2c_domestic_other_prices_sit_golden.csv"
+		suite.helperTestExpectedFileOutput(goldenFilename, outputFilename)
+	})
 }
 
-// Test_parseDomesticOtherPricesSit
-func (suite *PricingParserSuite) Test_parseDomesticOtherPricesSit() {
-	const sheetIndex = 8
-	xlsxDataSheets := InitDataSheetInfo()
-	dataSheet := xlsxDataSheets[sheetIndex]
-
+// Test_verifyDomesticOtherPrices
+func (suite *PricingParserSuite) Test_verifyDomesticOtherPrices() {
+	sheetIndex := 8
 	params := ParamConfig{
 		ProcessAll:   false,
 		ShowOutput:   false,
@@ -50,13 +62,15 @@ func (suite *PricingParserSuite) Test_parseDomesticOtherPricesSit() {
 		RunVerify:    true,
 	}
 
-	slice, err := parseDomesticOtherPricesSit(params, sheetIndex)
-	suite.NoError(err, "parseDomesticOtherPricesSit function failed")
+	suite.T().Run("verifyDomesticOtherPrices success", func(t *testing.T) {
+		err := verifyDomesticOtherPrices(params, sheetIndex)
+		suite.NoError(err)
+	})
 
-	outputFilename := dataSheet.generateOutputFilename(sheetIndex, params.RunTime, nil)
-	err = createCSV(outputFilename, slice)
-	suite.NoError(err, "could not create CSV")
-
-	const goldenFilename string = "8_2c_domestic_other_prices_sit_golden.csv"
-	suite.helperTestExpectedFileOutput(goldenFilename, outputFilename)
+	suite.T().Run("verifyDomesticOtherPrices with invalid sheetIndex", func(t *testing.T) {
+		err := verifyDomesticOtherPrices(params, 7)
+		if suite.Error(err) {
+			suite.Equal("verifyDomesticOtherPrices expected to process sheet 8, but received sheetIndex 7", err.Error())
+		}
+	})
 }

--- a/pkg/parser/pricing/parse_domestic_service_area_prices.go
+++ b/pkg/parser/pricing/parse_domestic_service_area_prices.go
@@ -23,6 +23,8 @@ var parseDomesticServiceAreaPrices processXlsxSheet = func(params ParamConfig, s
 		return nil, fmt.Errorf("parseDomesticServiceAreaPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
 	}
 
+	log.Println("Parsing Domestic Service Area Prices")
+
 	var domPrices []models.StageDomesticServiceAreaPrice
 	dataRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[feeRowIndexStart:]
 	for _, row := range dataRows {

--- a/pkg/parser/pricing/parse_international_prices.go
+++ b/pkg/parser/pricing/parse_international_prices.go
@@ -24,6 +24,8 @@ var parseOconusToOconusPrices processXlsxSheet = func(params ParamConfig, sheetI
 		return nil, fmt.Errorf("parseOconusToOconusPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
 	}
 
+	log.Println("Parsing Oconus To Oconus Prices")
+
 	var oconusToOconusPrices []models.StageOconusToOconusPrice
 	dataRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[feeRowIndexStart:]
 	for _, row := range dataRows {
@@ -62,6 +64,8 @@ var parseConusToOconusPrices processXlsxSheet = func(params ParamConfig, sheetIn
 		return nil, fmt.Errorf("parseConusToOconusPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
 	}
 
+	log.Println("Parsing Conus To Oconus Prices")
+
 	var conusToOconusPrices []models.StageConusToOconusPrice
 	dataRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[feeRowIndexStart:]
 	for _, row := range dataRows {
@@ -99,6 +103,8 @@ var parseOconusToConusPrices processXlsxSheet = func(params ParamConfig, sheetIn
 	if xlsxDataSheetNum != sheetIndex {
 		return nil, fmt.Errorf("parseOconusToConusPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
 	}
+
+	log.Println("Parsing Oconus To Conus Prices")
 
 	var oconusToConusPrices []models.StageOconusToConusPrice
 	dataRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[feeRowIndexStart:]

--- a/pkg/parser/pricing/parse_nonstandard_location_prices.go
+++ b/pkg/parser/pricing/parse_nonstandard_location_prices.go
@@ -30,6 +30,8 @@ var parseNonStandardLocnPrices processXlsxSheet = func(params ParamConfig, sheet
 		return nil, fmt.Errorf("parseNonStandardLocnPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
 	}
 
+	log.Println("Parsing Non Standard Location Prices")
+
 	var nonStandardLocationPrices []models.StageNonStandardLocnPrice
 	nToNRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[feeRowIndexStart:]
 	nToORows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[feeRowNToOIndexStart:]

--- a/pkg/parser/pricing/parse_other_intl_prices.go
+++ b/pkg/parser/pricing/parse_other_intl_prices.go
@@ -20,6 +20,8 @@ var parseOtherIntlPrices processXlsxSheet = func(params ParamConfig, sheetIndex 
 		return nil, fmt.Errorf("parseOtherIntlPrices expected to process sheet %d, but received sheetIndex %d", xlsxDataSheetNum, sheetIndex)
 	}
 
+	log.Println("Parsing Other International Prices")
+
 	var otherIntlPrices []models.StageOtherIntlPrice
 	dataRows := params.XlsxFile.Sheets[xlsxDataSheetNum].Rows[feeRowIndexStart:]
 


### PR DESCRIPTION
## Description

Parse the 2 different sets of data from sheet `2c Domestic Other Prices` into the appropriate stage tables.

## Reviewer Notes

Run the command and check the stage tables for accuracy.

## Setup

Tests now run as part of server tests.
```sh
make server_test
```

To run the command
```
rm -f bin/ghc-pricing-parser
make  bin/ghc-pricing-parser
ghc-pricing-parser --filename pkg/parser/pricing/fixtures/pricing_template_2019-09-19_fake-data.xlsx --display --use-temp-tables=false --contract-code=1234 --drop
```
If you have run this before you may need to add the `--drop` flag to drop any stage tables that still exist.

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/tree/master/docs/backend.md#logging)
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [MB-680](https://dp3.atlassian.net/browse/MB-680) for this change