### PR TITLE
[MB-1054] Disable rate engine table import when filtering xlsxSheets

### DIFF
--- a/cmd/ghc-pricing-parser/main.go
+++ b/cmd/ghc-pricing-parser/main.go
@@ -62,6 +62,8 @@ func main() {
 	// option `xlsxSheets` will override `all` flag
 	if len(params.XlsxSheets) > 0 {
 		params.ProcessAll = false
+		log.Println("Setting --xlsxSheets disables --re-import so no data will be imported into the rate engine tables. Only stage table data will be updated.")
+		params.RunImport = false
 	}
 
 	if params.XlsxFilename == "" {
@@ -151,6 +153,9 @@ func xlsxSheetsUsage(xlsxDataSheets []pricing.XlsxDataSheetInfo) string {
 			message += fmt.Sprintf("%d:  %s\n", i, description)
 		}
 	}
+
+	message += "\n"
+	message += "NOTE: This option disables the Rate Engine table import by disabling the --re-import flag\n"
 
 	return message
 }


### PR DESCRIPTION
## Description

This change is to allow the use of `--xlsxSheets` without error. This needs to happen as when reading only certain sheets we cannot read that data into the respective re_* tables and maintain the foreign key
relationships without a lot more work. So to avoid errors when running with `--xlsxSheets` on this change automatically disables `--re-import`

## Setup

To Run:

```sh
rm -f bin/ghc-pricing-parser
make db_dev_reset db_dev_migrate
make bin/ghc-pricing-parser
ghc-pricing-parser --filename pkg/parser/pricing/fixtures/pricing_template_2019-09-19_fake-data.xlsx --contract-code=12347 --xlsxSheets=8,10
```

Output will look something like this
```
go build -ldflags "" -o bin/ghc-pricing-parser ./cmd/ghc-pricing-parser
# github.com/keybase/go-keychain
cgo-gcc-prolog:203:11: warning: 'SecTrustedApplicationCreateFromPath' is deprecated: first deprecated in macOS 10.15 - No longer supported [-Wdeprecated-declarations]
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/Security.framework/Headers/SecTrustedApplication.h:59:10: note: 'SecTrustedApplicationCreateFromPath' has been explicitly marked deprecated here
2020/01/04 00:48:01 Setting --xlsxSheets disables --re-import so no data will be imported into the rate engine tables. Only stage table data will be updated.
2020/01/04 00:48:01 Importing file pkg/parser/pricing/fixtures/pricing_template_2019-09-19_fake-data.xlsx
2020-01-04T00:48:26.264Z        INFO    cli/dbconn.go:257       Connecting to the database      {"url": "postgres://postgres:*****@localhost:5432/dev_db?sslmode=disable", "db-ssl-root-cert": ""}
2020-01-04T00:48:26.265Z        INFO    cli/dbconn.go:362       Starting database ping....
2020-01-04T00:48:26.275Z        INFO    cli/dbconn.go:369       ...DB ping successful!
2020/01/04 00:48:26 Processing sheet index 8 with Description 2c) Dom. Other Prices
2020/01/04 00:48:26 Parsing Domestic Other (Pack/Unpack) Prices
2020/01/04 00:48:26 Parsing Domestic Other (SIT Pickup/Delivery) Prices
2020/01/04 00:48:26 Completed processing sheet index 8 with Description 2c) Dom. Other Prices
2020/01/04 00:48:26 Processing sheet index 10 with Description 3a) OCONUS to OCONUS Prices
2020/01/04 00:48:26 Parsing Oconus To Oconus Prices
2020/01/04 00:48:26 Completed processing sheet index 10 with Description 3a) OCONUS to OCONUS Prices
```

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/tree/master/docs/backend.md#logging)
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [MB-1054](https://dp3.atlassian.net/browse/MB-1054) for this change
* [This slack thread](https://ustcdp3.slack.com/archives/CP6F568DC/p1578011970019900) explains more about the approach used.
