### PR TITLE
mb-707 add partitions to athena based on year and month

### DIFF
--- a/cmd/query-lb-logs/main.go
+++ b/cmd/query-lb-logs/main.go
@@ -283,6 +283,10 @@ func createLogTable(serviceAthena *athena.Athena, logger, infoLogger *log.Logger
 			redirect_url string,
 			lambda_error_reason string,
 			new_field string)
+			PARTITIONED BY (
+  				year int,
+  				month int
+			)
 		ROW FORMAT SERDE 'org.apache.hadoop.hive.serde2.RegexSerDe'
 		WITH SERDEPROPERTIES ('input.regex'='([^ ]*) ([^ ]*) ([^ ]*) ([^ ]*):([0-9]*) ([^ ]*)[:-]([0-9]*) ([-.0-9]*) ([-.0-9]*) ([-.0-9]*) (|[-0-9]*) (-|[-0-9]*) ([-0-9]*) ([-0-9]*) \"([^ ]*) ([^ ]*) (- |[^ ]*)\" \"([^\"]*)\" ([A-Z0-9-]+) ([A-Za-z0-9.-]*) ([^ ]*) \"([^\"]*)\" \"([^\"]*)\" \"([^\"]*)\" ([-.0-9]*) ([^ ]*) \"([^\"]*)\" \"([^\"]*)\"($| \"[^ ]*\")(.*)')
 		STORED AS INPUTFORMAT 'org.apache.hadoop.mapred.TextInputFormat'

--- a/cmd/query-lb-logs/main.go
+++ b/cmd/query-lb-logs/main.go
@@ -247,20 +247,20 @@ func CheckEnv(serviceAthena *athena.Athena, logger, infoLogger *log.Logger, v *v
 
 	if !isTableFound {
 		logger.Println("Table not found, creating table....")
-		err = createLogTable(serviceAthena, logger, infoLogger, dbName, logBucket)
-		if err != nil {
-			logger.Fatalf("Failed to create table: %v", err)
+		errCreateLogTable := createLogTable(serviceAthena, logger, infoLogger, dbName, logBucket)
+		if errCreateLogTable != nil {
+			logger.Fatalf("Failed to create table: %v", errCreateLogTable)
 		}
 		logger.Println("creating monthly partitions....")
-		err = createPartitions(serviceAthena, logger, infoLogger, dbName, logBucket)
-		if err != nil {
-			logger.Fatalf("Failed to create partitions: %v", err)
+		errCreatePartitions := createPartitions(serviceAthena, logger, infoLogger, dbName, logBucket)
+		if errCreatePartitions != nil {
+			logger.Fatalf("Failed to create partitions: %v", errCreatePartitions)
 		}
 	} else if v.GetBool(AddPartitions) { // If add partitions flag is set to true then try adding partitions
 		logger.Println("creating monthly partitions....")
-		err = createPartitions(serviceAthena, logger, infoLogger, dbName, logBucket)
-		if err != nil {
-			logger.Fatalf("Failed to create partitions: %v", err)
+		errCreatePartitions := createPartitions(serviceAthena, logger, infoLogger, dbName, logBucket)
+		if errCreatePartitions != nil {
+			logger.Fatalf("Failed to create partitions: %v", errCreatePartitions)
 		}
 		os.Exit(0)
 	}


### PR DESCRIPTION
## Description

Athena queries have been slowing down due to lack of partitioning.  This PR extends the table creation logic and adds partitioning capability so we can run queries like:

```
SELECT actions_executed,
         elb_status_code,
         *
FROM alb_logs
WHERE elb_status_code = 500
        AND month =12
        AND year=2019 limit 100
```

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make build_tools
# delete table alb_logs
query-lb-logs -v true

```

Then navigate to [athena](https://us-west-2.console.aws.amazon.com/athena/home?region=us-west-2#query) in aws and run 
```
SHOW Partitions `alb_logs`;
```

## Code Review Verification Steps

* [x] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/tree/master/docs/backend.md#logging)
* [x] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [x] Request review from a member of a different team.
* [x] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-707?atlOrigin=eyJpIjoiODVlMGU0OGIyYjYzNGM5YTk4OWNjMDNiZjliNjgxYjciLCJwIjoiaiJ9) for this change
* [additional documentation](https://github.com/transcom/ppp-infra/pull/786)

## Screenshots
![image](https://user-images.githubusercontent.com/5003421/71845107-923db780-3095-11ea-949f-2b49c57075dc.png)
