### PR TITLE
Include new Pro-Gear fields in Office Estimates Panel on PPM Tab

### DIFF
--- a/pkg/gen/internalapi/embedded_spec.go
+++ b/pkg/gen/internalapi/embedded_spec.go
@@ -5256,6 +5256,11 @@ func init() {
             "YES",
             "NO"
           ],
+          "x-display-value": {
+            "NO": false,
+            "NOT SURE": "Not Sure",
+            "YES": true
+          },
           "x-nullable": true
         },
         "has_pro_gear_over_thousand": {
@@ -5266,6 +5271,11 @@ func init() {
             "YES",
             "NO"
           ],
+          "x-display-value": {
+            "NO": false,
+            "NOT SURE": "Not Sure",
+            "YES": true
+          },
           "x-nullable": true
         },
         "has_requested_advance": {
@@ -11443,6 +11453,11 @@ func init() {
             "YES",
             "NO"
           ],
+          "x-display-value": {
+            "NO": false,
+            "NOT SURE": "Not Sure",
+            "YES": true
+          },
           "x-nullable": true
         },
         "has_pro_gear_over_thousand": {
@@ -11453,6 +11468,11 @@ func init() {
             "YES",
             "NO"
           ],
+          "x-display-value": {
+            "NO": false,
+            "NOT SURE": "Not Sure",
+            "YES": true
+          },
           "x-nullable": true
         },
         "has_requested_advance": {

--- a/pkg/handlers/internalapi/personally_procured_move.go
+++ b/pkg/handlers/internalapi/personally_procured_move.go
@@ -20,6 +20,16 @@ import (
 func payloadForPPMModel(storer storage.FileStorer, personallyProcuredMove models.PersonallyProcuredMove) (*internalmessages.PersonallyProcuredMovePayload, error) {
 
 	documentPayload, err := payloadForDocumentModel(storer, personallyProcuredMove.AdvanceWorksheet)
+	var hasProGear *string
+	if personallyProcuredMove.HasProGear != nil {
+		hpg := string(*personallyProcuredMove.HasProGear)
+		hasProGear = &hpg
+	}
+	var hasProGearOverThousand *string
+	if personallyProcuredMove.HasProGearOverThousand != nil {
+		hpgot := string(*personallyProcuredMove.HasProGearOverThousand)
+		hasProGearOverThousand = &hpgot
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -48,6 +58,8 @@ func payloadForPPMModel(storer storage.FileStorer, personallyProcuredMove models
 		AdvanceWorksheet:              documentPayload,
 		Mileage:                       personallyProcuredMove.Mileage,
 		TotalSitCost:                  handlers.FmtCost(personallyProcuredMove.TotalSITCost),
+		HasProGear:                    hasProGear,
+		HasProGearOverThousand:        hasProGearOverThousand,
 	}
 	if personallyProcuredMove.IncentiveEstimateMin != nil {
 		min := (*personallyProcuredMove.IncentiveEstimateMin).Int64()

--- a/src/scenes/Office/Ppm/PPMEstimatesPanel.jsx
+++ b/src/scenes/Office/Ppm/PPMEstimatesPanel.jsx
@@ -78,6 +78,12 @@ const EstimatesEdit = props => {
             required
           />{' '}
           lbs
+          <SwaggerField title="Is there pro-gear?" fieldName="has_pro_gear" swagger={schema} />
+          <SwaggerField
+            title="Does the pro-gear weigh more then 1,000 lbs?"
+            fieldName="has_pro_gear_over_thousand"
+            swagger={schema}
+          />
           <SwaggerField title="Planned departure date" fieldName="original_move_date" swagger={schema} required />
           <div className="panel-subhead">Storage</div>
           <SwaggerField title="Storage planned?" fieldName="has_sit" swagger={schema} component={YesNoBoolean} />

--- a/src/scenes/Office/Ppm/PPMEstimatesPanel.jsx
+++ b/src/scenes/Office/Ppm/PPMEstimatesPanel.jsx
@@ -32,6 +32,16 @@ const EstimatesDisplay = props => {
           {formatCentsRange(ppm.incentive_estimate_min, ppm.incentive_estimate_max)}
         </PanelField>
         <PanelSwaggerField fieldName="weight_estimate" {...fieldProps} />
+        {fieldProps.values.has_pro_gear && (
+          <PanelSwaggerField title="Is there pro-gear?" fieldName="has_pro_gear" {...fieldProps} />
+        )}
+        {fieldProps.values.has_pro_gear_over_thousand && (
+          <PanelSwaggerField
+            title="Does the pro-gear weigh more then 1,000 lbs?"
+            fieldName="has_pro_gear_over_thousand"
+            {...fieldProps}
+          />
+        )}
         <PanelSwaggerField title="Planned departure" fieldName="original_move_date" {...fieldProps} />
         <PanelField title="Storage planned" fieldName="has_sit">
           {fieldProps.values.has_sit ? 'Yes' : 'No'}

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -537,6 +537,10 @@ definitions:
           - 'YES'
           - 'NO'
         x-nullable: true
+        x-display-value:
+          NOT SURE: Not Sure
+          'YES': Yes
+          'NO': No
       has_pro_gear_over_thousand:
         type: string
         title: Has Pro-Gear Over Thousand Pounds
@@ -545,6 +549,10 @@ definitions:
           - 'YES'
           - 'NO'
         x-nullable: true
+        x-display-value:
+          NOT SURE: Not Sure
+          'YES': Yes
+          'NO': No
       created_at:
         type: string
         format: date-time


### PR DESCRIPTION
## Description

Adds the new fields collected from service members `has_pro_gear` and `has_pro_gear_over_thousand` to the PPM panel in the office app. Office users should be able to view and edit these fields.

## Reviewer Notes

In the edit view, for the time being I've made these optional fields as I wasn't sure if they were required at this point? 


## Setup
```
make server_run
make office_client_run
```

Navigate to the PPM tab in the office app. You should see the new fields. As an office user you should be able to edit these fields and see the edits reflected in the app / database.

## Code Review Verification Steps
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-698) for this change

## Screenshots
![Screen Shot 2020-01-06 at 1 15 48 PM](https://user-images.githubusercontent.com/1036969/71846008-c65dac00-3086-11ea-8687-29d108dfae53.png)

