### PR TITLE
Remove spouse pro gear question

### DIFF
--- a/src/scenes/Orders/Orders.jsx
+++ b/src/scenes/Orders/Orders.jsx
@@ -1,6 +1,6 @@
 import { get } from 'lodash';
 import PropTypes from 'prop-types';
-import React, { Component, Fragment } from 'react';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { getFormValues } from 'redux-form';
@@ -29,8 +29,6 @@ export class Orders extends Component {
       pendingValues['service_member_id'] = this.props.serviceMemberId;
       pendingValues['new_duty_station_id'] = pendingValues.new_duty_station.id;
       pendingValues['has_dependents'] = pendingValues.has_dependents || false;
-      pendingValues['spouse_has_pro_gear'] =
-        (pendingValues.has_dependents && pendingValues.spouse_has_pro_gear) || false;
       if (this.props.currentOrders) {
         return this.props.updateOrders(this.props.currentOrders.id, pendingValues);
       } else {
@@ -66,16 +64,6 @@ export class Orders extends Component {
         </div>
         <SwaggerField fieldName="report_by_date" swagger={this.props.schema} required />
         <SwaggerField fieldName="has_dependents" swagger={this.props.schema} component={YesNoBoolean} />
-        {get(this.props, 'formValues.has_dependents', false) && (
-          <Fragment>
-            <SwaggerField
-              fieldName="spouse_has_pro_gear"
-              swagger={this.props.schema}
-              component={YesNoBoolean}
-              className="wider-label"
-            />
-          </Fragment>
-        )}
         <Field
           name="new_duty_station"
           component={DutyStationSearchBox}

--- a/src/scenes/Orders/Orders.jsx
+++ b/src/scenes/Orders/Orders.jsx
@@ -1,6 +1,6 @@
 import { get } from 'lodash';
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { getFormValues } from 'redux-form';
@@ -9,6 +9,7 @@ import { Field } from 'redux-form';
 
 import { createOrders, updateOrders } from './ducks';
 import { reduxifyWizardForm } from 'shared/WizardPage/Form';
+import { withContext } from 'shared/AppContext';
 import DutyStationSearchBox from 'scenes/ServiceMembers/DutyStationSearchBox';
 import YesNoBoolean from 'shared/Inputs/YesNoBoolean';
 import { SwaggerField } from 'shared/JsonSchemaForm/JsonSchemaField';
@@ -41,6 +42,7 @@ export class Orders extends Component {
 
   render() {
     const { pages, pageKey, error, currentOrders, serviceMemberId, newDutyStation, currentStation } = this.props;
+    const { context: { flags: { progearChanges } } = { flags: { progearChanges: null } } } = this.props;
     // initialValues has to be null until there are values from the action since only the first values are taken
     const initialValues = currentOrders ? currentOrders : null;
     const newDutyStationErrorMsg =
@@ -66,6 +68,16 @@ export class Orders extends Component {
         </div>
         <SwaggerField fieldName="report_by_date" swagger={this.props.schema} required />
         <SwaggerField fieldName="has_dependents" swagger={this.props.schema} component={YesNoBoolean} />
+        {!progearChanges && get(this.props, 'formValues.has_dependents', false) && (
+          <Fragment>
+            <SwaggerField
+              fieldName="spouse_has_pro_gear"
+              swagger={this.props.schema}
+              component={YesNoBoolean}
+              className="wider-label"
+            />
+          </Fragment>
+        )}
         <Field
           name="new_duty_station"
           component={DutyStationSearchBox}
@@ -104,4 +116,4 @@ function mapDispatchToProps(dispatch) {
     dispatch,
   );
 }
-export default connect(mapStateToProps, mapDispatchToProps)(Orders);
+export default withContext(connect(mapStateToProps, mapDispatchToProps)(Orders));

--- a/src/scenes/Orders/Orders.jsx
+++ b/src/scenes/Orders/Orders.jsx
@@ -29,6 +29,8 @@ export class Orders extends Component {
       pendingValues['service_member_id'] = this.props.serviceMemberId;
       pendingValues['new_duty_station_id'] = pendingValues.new_duty_station.id;
       pendingValues['has_dependents'] = pendingValues.has_dependents || false;
+      pendingValues['spouse_has_pro_gear'] =
+        (pendingValues.has_dependents && pendingValues.spouse_has_pro_gear) || false;
       if (this.props.currentOrders) {
         return this.props.updateOrders(this.props.currentOrders.id, pendingValues);
       } else {

--- a/src/scenes/Review/EditOrders.jsx
+++ b/src/scenes/Review/EditOrders.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { get, concat, includes, map, reject } from 'lodash';
@@ -7,6 +7,7 @@ import { push } from 'react-router-redux';
 import { getFormValues, reduxForm, Field } from 'redux-form';
 
 import Alert from 'shared/Alert'; // eslint-disable-line
+import { withContext } from 'shared/AppContext';
 import { SwaggerField } from 'shared/JsonSchemaForm/JsonSchemaField';
 import DutyStationSearchBox from 'scenes/ServiceMembers/DutyStationSearchBox';
 import YesNoBoolean from 'shared/Inputs/YesNoBoolean';
@@ -36,6 +37,7 @@ let EditOrdersForm = props => {
     initialValues,
     existingUploads,
     deleteQueue,
+    progearChanges,
   } = props;
   const visibleUploads = reject(existingUploads, upload => {
     return includes(deleteQueue, upload.id);
@@ -63,6 +65,16 @@ let EditOrdersForm = props => {
             <SwaggerField fieldName="report_by_date" swagger={schema} required />
             <SwaggerField fieldName="has_dependents" swagger={schema} component={YesNoBoolean} />
             <br />
+            {!progearChanges && get(props, 'formValues.has_dependents', false) && (
+              <Fragment>
+                <SwaggerField
+                  fieldName="spouse_has_pro_gear"
+                  swagger={props.schema}
+                  component={YesNoBoolean}
+                  className="wider-label"
+                />
+              </Fragment>
+            )}
             <Field name="new_duty_station" component={DutyStationSearchBox} />
             <p>Uploads:</p>
             {Boolean(visibleUploads.length) && <UploadsTable uploads={visibleUploads} onDelete={onDelete} />}
@@ -154,6 +166,7 @@ class EditOrders extends Component {
 
   render() {
     const { error, schema, currentOrders, formValues, existingUploads, moveIsApproved } = this.props;
+    const { context: { flags: { progearChanges } } = { flags: { progearChanges: null } } } = this.props;
 
     return (
       <div className="usa-grid">
@@ -183,6 +196,7 @@ class EditOrders extends Component {
               onUpload={this.handleNewUpload}
               onDelete={this.handleDelete}
               formValues={formValues}
+              progearChanges={progearChanges}
             />
           </div>
         )}
@@ -222,4 +236,4 @@ function mapDispatchToProps(dispatch) {
   );
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(EditOrders);
+export default withContext(connect(mapStateToProps, mapDispatchToProps)(EditOrders));

--- a/src/scenes/Review/EditOrders.jsx
+++ b/src/scenes/Review/EditOrders.jsx
@@ -1,4 +1,4 @@
-import React, { Component, Fragment } from 'react';
+import React, { Component } from 'react';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { get, concat, includes, map, reject } from 'lodash';
@@ -62,16 +62,6 @@ let EditOrdersForm = props => {
             <SwaggerField fieldName="issue_date" swagger={schema} required />
             <SwaggerField fieldName="report_by_date" swagger={schema} required />
             <SwaggerField fieldName="has_dependents" swagger={schema} component={YesNoBoolean} />
-            {get(props, 'formValues.has_dependents', false) && (
-              <Fragment>
-                <SwaggerField
-                  fieldName="spouse_has_pro_gear"
-                  swagger={props.schema}
-                  component={YesNoBoolean}
-                  className="wider-label"
-                />
-              </Fragment>
-            )}
             <br />
             <Field name="new_duty_station" component={DutyStationSearchBox} />
             <p>Uploads:</p>


### PR DESCRIPTION
## Description
Removes the spouse pro-gear question from the Orders screen when behind feature flag `?flag:progearChanges=true`. There has been no changes outside of the front-end. Therefore if a SM has previously answered the question and said yes, they will still get 500 lbs listed on their SSW for spouse pro-gear.


## Setup

```sh
make server_run
make client_run
make office_client_run
```

1. Login as needs@orde.rs.
2. When encountering the question if the SM has dependents, click 'Yes'. Verify that no question about spouse pro-gear pops up when `?flag:progearChanges=true`.
3. Finish orders.
4. Have the SM submit a payment request, this requires going through all the steps on both MilMove and Office websites.
5. Verify in the SSW 0 lbs are listed for the spouse pro-gear.
6. Change `spouse_has_pro_gear` for this order in the database to `TRUE`.
7. Verify in a newly generated SSW that 500 lbs are listed for the spouse pro-gear.

## Code Review Verification Steps
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-697) for this change
