### PR TITLE
Extend pricing importer to include non-standard location prices (tab 3e)

### DIFF
--- a/pkg/models/stage_pricing.go
+++ b/pkg/models/stage_pricing.go
@@ -1,5 +1,8 @@
 package models
 
+//
+// Tab 1b: Service Areas
+//
 type StageDomesticServiceArea struct {
 	BasePointCity     string `db:"base_point_city" csv:"base_point_city"`
 	State             string `db:"state" csv:"state"`
@@ -12,6 +15,9 @@ type StageInternationalServiceArea struct {
 	RateAreaID string `db:"rate_area_id" csv:"rate_area_id"`
 }
 
+//
+// Tab 2a: Domestic Linehaul Prices
+//
 type StageDomesticLinehaulPrice struct {
 	ServiceAreaNumber string `db:"service_area_number" csv:"service_area_number"`
 	OriginServiceArea string `db:"origin_service_area" csv:"origin_service_area"`
@@ -25,6 +31,9 @@ type StageDomesticLinehaulPrice struct {
 	Rate              string `db:"rate" csv:"rate"`
 }
 
+//
+// Tab 2b: Domestic Service Area Prices
+//
 type StageDomesticServiceAreaPrice struct {
 	ServiceAreaNumber                     string `db:"service_area_number" csv:"service_area_number"`
 	ServiceAreaName                       string `db:"service_area_name" csv:"service_area_name"`
@@ -37,6 +46,9 @@ type StageDomesticServiceAreaPrice struct {
 	OriginDestinationSITAddlDays          string `db:"origin_destination_sit_addl_days" csv:"origin_destination_sit_addl_days"`
 }
 
+//
+// Tab 2c: Other Domestic Prices
+//
 type StageDomesticOtherPackPrice struct {
 	ServicesSchedule   string `db:"services_schedule" csv:"services_schedule"`
 	ServiceProvided    string `db:"service_provided" csv:"service_provided"`
@@ -51,6 +63,9 @@ type StageDomesticOtherSitPrice struct {
 	PeakPricePerCwt           string `db:"peak_price_per_cwt" csv:"peak_price_per_cwt"`
 }
 
+//
+// Tab 3a: OCONUS to OCONUS Prices
+//
 type StageOconusToOconusPrice struct {
 	OriginIntlPriceAreaID      string `db:"origin_intl_price_area_id" csv:"origin_intl_price_area_id"`
 	OriginIntlPriceArea        string `db:"origin_intl_price_area" csv:"origin_intl_price_area"`
@@ -61,6 +76,9 @@ type StageOconusToOconusPrice struct {
 	UBPrice                    string `db:"ub_price" csv:"ub_price"`
 }
 
+//
+// Tab 3b: CONUS to OCONUS Prices
+//
 type StageConusToOconusPrice struct {
 	OriginDomesticPriceAreaCode string `db:"origin_domestic_price_area_code" csv:"origin_domestic_price_area_code"`
 	OriginDomesticPriceArea     string `db:"origin_domestic_price_area" csv:"origin_domestic_price_area"`
@@ -71,6 +89,9 @@ type StageConusToOconusPrice struct {
 	UBPrice                     string `db:"ub_price" csv:"ub_price"`
 }
 
+//
+// Tab 3c: OCONUS to CONUS Prices
+//
 type StageOconusToConusPrice struct {
 	OriginIntlPriceAreaID            string `db:"origin_intl_price_area_id" csv:"origin_intl_price_area_id"`
 	OriginIntlPriceArea              string `db:"origin_intl_price_area" csv:"origin_intl_price_area"`
@@ -81,13 +102,9 @@ type StageOconusToConusPrice struct {
 	UBPrice                          string `db:"ub_price" csv:"ub_price"`
 }
 
-type StagePriceEscalationDiscount struct {
-	ContractYear          string `db:"contract_year" csv:"contract_year"`
-	ForecastingAdjustment string `db:"forecasting_adjustment" csv:"forecasting_adjustment"`
-	Discount              string `db:"discount" csv:"discount"`
-	PriceEscalation       string `db:"price_escalation" csv:"price_escalation"`
-}
-
+//
+// Tab 3d: Other International Prices
+//
 type StageOtherIntlPrice struct {
 	RateAreaCode                          string `db:"rate_area_code" csv:"rate_area_code"`
 	RateAreaName                          string `db:"rate_area_name" csv:"rate_area_name"`
@@ -102,6 +119,23 @@ type StageOtherIntlPrice struct {
 	Season                                string `db:"season" csv:"season"`
 }
 
+//
+// Tab 3e: Non-Standard Location Prices
+//
+type StageNonStandardLocnPrice struct {
+	OriginID        string `db:"origin_id" csv:"origin_id"`
+	OriginArea      string `db:"origin_area" csv:"origin_area"`
+	DestinationID   string `db:"destination_id" csv:"destination_id"`
+	DestinationArea string `db:"destination_area" csv:"destination_area"`
+	MoveType        string `db:"move_type" csv:"move_type"`
+	Season          string `db:"season" csv:"season"`
+	HHGPrice        string `db:"hhg_price" csv:"hhg_price"`
+	UBPrice         string `db:"ub_price" csv:"ub_price"`
+}
+
+//
+// Tab 4a: Management, Counseling, and Transition Prices
+//
 type StageShipmentManagementServicesPrice struct {
 	ContractYear      string `db:"contract_year" csv:"contract_year"`
 	PricePerTaskOrder string `db:"price_per_task_order" csv:"price_per_task_order"`
@@ -117,6 +151,9 @@ type StageTransitionPrice struct {
 	PricePerTaskOrder string `db:"price_total_cost" csv:"price_total_cost"`
 }
 
+//
+// Tab 5a: Accessorial and Additional Prices
+//
 type StageDomesticMoveAccessorialPrices struct {
 	ServicesSchedule string `db:"services_schedule" csv:"services_schedule"`
 	ServiceProvided  string `db:"service_provided" csv:"service_provided"`
@@ -135,13 +172,12 @@ type StageDomesticInternationalAdditionalPrices struct {
 	Factor       string `db:"factor" csv:"factor"`
 }
 
-type StageNonStandardLocnPrice struct {
-	OriginID        string `db:"origin_id" csv:"origin_id"`
-	OriginArea      string `db:"origin_area" csv:"origin_area"`
-	DestinationID   string `db:"destination_id" csv:"destination_id"`
-	DestinationArea string `db:"destination_area" csv:"destination_area"`
-	MoveType        string `db:"move_type" csv:"move_type"`
-	Season          string `db:"season" csv:"season"`
-	HHGPrice        string `db:"hhg_price" csv:"hhg_price"`
-	UBPrice         string `db:"ub_price" csv:"ub_price"`
+//
+// Tab 5b: Price Escalation Discount
+//
+type StagePriceEscalationDiscount struct {
+	ContractYear          string `db:"contract_year" csv:"contract_year"`
+	ForecastingAdjustment string `db:"forecasting_adjustment" csv:"forecasting_adjustment"`
+	Discount              string `db:"discount" csv:"discount"`
+	PriceEscalation       string `db:"price_escalation" csv:"price_escalation"`
 }

--- a/pkg/parser/pricing/fixtures/14_3e_non_standard_locn_prices_golden.csv
+++ b/pkg/parser/pricing/fixtures/14_3e_non_standard_locn_prices_golden.csv
@@ -327,8 +327,8 @@ NSRA11,Asia,NSRA13,Pacific Islands,NSRA to NSRA,NonPeak,$71.61,$47.76
 NSRA11,Asia,NSRA13,Pacific Islands,NSRA to NSRA,Peak,$84.50,$56.36
 NSRA11,Asia,NSRA14,Australia & New Zealand,NSRA to NSRA,NonPeak,$71.89,$44.24
 NSRA11,Asia,NSRA14,Australia & New Zealand,NSRA to NSRA,Peak,$84.83,$52.20
-NSRA7,Europe,NSRA15,Alaska - All other areas,NSRA to NSRA,NonPeak,$72.68,$61.92
-NSRA7,Europe,NSRA15,Alaska - All other areas,NSRA to NSRA,Peak,$85.76,$73.07
+NSRA11,Asia,NSRA15,Alaska - All other areas,NSRA to NSRA,NonPeak,$72.68,$61.92
+NSRA11,Asia,NSRA15,Alaska - All other areas,NSRA to NSRA,Peak,$85.76,$73.07
 NSRA12,Asia - South,NSRA1,Canada West,NSRA to NSRA,NonPeak,$15.28,$47.93
 NSRA12,Asia - South,NSRA1,Canada West,NSRA to NSRA,Peak,$18.03,$56.56
 NSRA12,Asia - South,NSRA2,Canada Central,NSRA to NSRA,NonPeak,$16.05,$44.58

--- a/pkg/services/ghcimport/import_re_domestic_linehaul_prices.go
+++ b/pkg/services/ghcimport/import_re_domestic_linehaul_prices.go
@@ -35,7 +35,7 @@ func (gre *GHCRateEngineImporter) importREDomesticLinehaulPrices(dbTx *pop.Conne
 
 		milesUpperInt, err := stringToInteger(stagePrice.MilesUpper)
 		if err != nil {
-			return fmt.Errorf("could not process miles lower [%s]: %w", stagePrice.MilesUpper, err)
+			return fmt.Errorf("could not process miles upper [%s]: %w", stagePrice.MilesUpper, err)
 		}
 
 		isPeakPeriod, err := isPeakPeriod(stagePrice.Season)
@@ -54,7 +54,7 @@ func (gre *GHCRateEngineImporter) importREDomesticLinehaulPrices(dbTx *pop.Conne
 
 		priceMillicents, err := priceToMillicents(stagePrice.Rate)
 		if err != nil {
-			return fmt.Errorf("could not process rate [%s]: %w", stagePrice.MilesUpper, err)
+			return fmt.Errorf("could not process rate [%s]: %w", stagePrice.Rate, err)
 		}
 
 		domesticLinehaulPrice := models.ReDomesticLinehaulPrice{

--- a/pkg/services/ghcimport/import_re_intl_prices.go
+++ b/pkg/services/ghcimport/import_re_intl_prices.go
@@ -2,6 +2,9 @@ package ghcimport
 
 import (
 	"fmt"
+	"strings"
+
+	"github.com/gofrs/uuid"
 
 	"github.com/transcom/mymove/pkg/unit"
 
@@ -11,56 +14,71 @@ import (
 )
 
 func (gre *GHCRateEngineImporter) importREInternationalPrices(dbTx *pop.Connection) error {
-	//tab 3a) OCONUS to OCONUS data
+	if err := gre.importOconusToOconusPrices(dbTx); err != nil {
+		return fmt.Errorf("could not import OCONUS to OCONUS prices: %w", err)
+	}
+
+	if err := gre.importConusToOconusPrices(dbTx); err != nil {
+		return fmt.Errorf("could not import CONUS to OCONUS prices: %w", err)
+	}
+
+	if err := gre.importOconusToConusPrices(dbTx); err != nil {
+		return fmt.Errorf("could not import OCONUS to CONUS prices: %w", err)
+	}
+
+	if err := gre.importNonStandardLocationPrices(dbTx); err != nil {
+		return fmt.Errorf("could not import non-standard location prices: %w", err)
+	}
+
+	return nil
+}
+
+func (gre *GHCRateEngineImporter) importOconusToOconusPrices(dbTx *pop.Connection) error {
+	// tab 3a) OCONUS to OCONUS data
 	var oconusToOconusPrices []models.StageOconusToOconusPrice
 	err := dbTx.All(&oconusToOconusPrices)
 	if err != nil {
 		return fmt.Errorf("could not read staged OCONUS to OCONUS prices: %w", err)
 	}
 
-	//Int'l O->O Shipping & LH
+	// Int'l O->O Shipping & LH
 	serviceIOOLH, foundService := gre.serviceToIDMap["IOOLH"]
 	if !foundService {
 		return fmt.Errorf("missing service IOOLH in map of services")
 	}
 
-	//Int'l O->O UB
+	// Int'l O->O UB
 	serviceIOOUB, foundService := gre.serviceToIDMap["IOOUB"]
 	if !foundService {
 		return fmt.Errorf("missing service IOOUB in map of services")
 	}
 
-	//loop through the OCONUS to OCONUS data and store in db
+	// loop through the OCONUS to OCONUS data and store in db
 	for _, stageOconusToOconusPrice := range oconusToOconusPrices {
 		var intlPricingModels models.ReIntlPrices
-		var peakPeriod bool
-		peakPeriod, err = isPeakPeriod(stageOconusToOconusPrice.Season)
+		peakPeriod, err := isPeakPeriod(stageOconusToOconusPrice.Season)
 		if err != nil {
 			return fmt.Errorf("could not process season [%s]: %w", stageOconusToOconusPrice.Season, err)
 		}
 
-		originRateArea := stageOconusToOconusPrice.OriginIntlPriceAreaID
-		originRateAreaID, found := gre.internationalRateAreaToIDMap[originRateArea]
+		originRateAreaID, found := gre.internationalRateAreaToIDMap[stageOconusToOconusPrice.OriginIntlPriceAreaID]
 		if !found {
 			return fmt.Errorf("could not find origin rate area [%s] in map", stageOconusToOconusPrice.OriginIntlPriceAreaID)
 		}
 
-		destinationRateArea := stageOconusToOconusPrice.DestinationIntlPriceAreaID
-		destinationRateAreaID, found := gre.internationalRateAreaToIDMap[destinationRateArea]
+		destinationRateAreaID, found := gre.internationalRateAreaToIDMap[stageOconusToOconusPrice.DestinationIntlPriceAreaID]
 		if !found {
 			return fmt.Errorf("could not find destination rate area [%s] in map", stageOconusToOconusPrice.DestinationIntlPriceAreaID)
 		}
 
-		var perUnitCentsHHG int
-		perUnitCentsHHG, err = priceToCents(stageOconusToOconusPrice.HHGShippingLinehaulPrice)
+		perUnitCentsHHG, err := priceToCents(stageOconusToOconusPrice.HHGShippingLinehaulPrice)
 		if err != nil {
 			return fmt.Errorf("could not process linehaul price [%s]: %w", stageOconusToOconusPrice.HHGShippingLinehaulPrice, err)
 		}
 
-		var perUnitCentsUB int
-		perUnitCentsUB, err = priceToCents(stageOconusToOconusPrice.UBPrice)
+		perUnitCentsUB, err := priceToCents(stageOconusToOconusPrice.UBPrice)
 		if err != nil {
-			return fmt.Errorf("could not process UB price [%s]: %w", stageOconusToOconusPrice.HHGShippingLinehaulPrice, err)
+			return fmt.Errorf("could not process UB price [%s]: %w", stageOconusToOconusPrice.UBPrice, err)
 		}
 
 		intlPricingModelIOOLH := models.ReIntlPrice{
@@ -71,7 +89,6 @@ func (gre *GHCRateEngineImporter) importREInternationalPrices(dbTx *pop.Connecti
 			IsPeakPeriod:          peakPeriod,
 			PerUnitCents:          unit.Cents(perUnitCentsHHG),
 		}
-
 		intlPricingModels = append(intlPricingModels, intlPricingModelIOOLH)
 
 		intlPricingModelIOOUB := models.ReIntlPrice{
@@ -82,7 +99,6 @@ func (gre *GHCRateEngineImporter) importREInternationalPrices(dbTx *pop.Connecti
 			IsPeakPeriod:          peakPeriod,
 			PerUnitCents:          unit.Cents(perUnitCentsUB),
 		}
-
 		intlPricingModels = append(intlPricingModels, intlPricingModelIOOUB)
 
 		for _, model := range intlPricingModels {
@@ -96,56 +112,56 @@ func (gre *GHCRateEngineImporter) importREInternationalPrices(dbTx *pop.Connecti
 		}
 	}
 
-	//tab 3b CONUS to OCONUS data
+	return nil
+}
+
+func (gre *GHCRateEngineImporter) importConusToOconusPrices(dbTx *pop.Connection) error {
+	// tab 3b CONUS to OCONUS data
 	var conusToOconusPrices []models.StageConusToOconusPrice
-	err = dbTx.All(&conusToOconusPrices)
+	err := dbTx.All(&conusToOconusPrices)
 	if err != nil {
 		return fmt.Errorf("could not read staged CONUS to OCONUS prices: %w", err)
 	}
 
-	//Int'l C->O Shipping & LH
+	// Int'l C->O Shipping & LH
 	serviceICOLH, foundService := gre.serviceToIDMap["ICOLH"]
 	if !foundService {
 		return fmt.Errorf("missing service ICOLH in map of services")
 	}
 
-	//Int'l C->O UB
+	// Int'l C->O UB
 	serviceICOUB, foundService := gre.serviceToIDMap["ICOUB"]
 	if !foundService {
 		return fmt.Errorf("missing service ICOUB in map of services")
 	}
 
-	//loop through the CONUS to OCONUS data and store in db
+	// loop through the CONUS to OCONUS data and store in db
 	for _, stageConusToOconusPrice := range conusToOconusPrices {
 		var intlPricingModels models.ReIntlPrices
-		var peakPeriod bool
-		peakPeriod, err = isPeakPeriod(stageConusToOconusPrice.Season)
+
+		peakPeriod, err := isPeakPeriod(stageConusToOconusPrice.Season)
 		if err != nil {
 			return fmt.Errorf("could not process season [%s]: %w", stageConusToOconusPrice.Season, err)
 		}
 
-		originRateArea := stageConusToOconusPrice.OriginDomesticPriceAreaCode
-		originRateAreaID, found := gre.domesticRateAreaToIDMap[originRateArea]
+		originRateAreaID, found := gre.domesticRateAreaToIDMap[stageConusToOconusPrice.OriginDomesticPriceAreaCode]
 		if !found {
 			return fmt.Errorf("could not find domestic rate area [%s] in map", stageConusToOconusPrice.OriginDomesticPriceAreaCode)
 		}
 
-		destinationRateArea := stageConusToOconusPrice.DestinationIntlPriceAreaID
-		destinationRateAreaID, found := gre.internationalRateAreaToIDMap[destinationRateArea]
+		destinationRateAreaID, found := gre.internationalRateAreaToIDMap[stageConusToOconusPrice.DestinationIntlPriceAreaID]
 		if !found {
 			return fmt.Errorf("could not find international rate area [%s] in map", stageConusToOconusPrice.DestinationIntlPriceAreaID)
 		}
 
-		var perUnitCentsHHG int
-		perUnitCentsHHG, err = priceToCents(stageConusToOconusPrice.HHGShippingLinehaulPrice)
+		perUnitCentsHHG, err := priceToCents(stageConusToOconusPrice.HHGShippingLinehaulPrice)
 		if err != nil {
 			return fmt.Errorf("could not process linehaul price [%s]: %w", stageConusToOconusPrice.HHGShippingLinehaulPrice, err)
 		}
 
-		var perUnitCentsUB int
-		perUnitCentsUB, err = priceToCents(stageConusToOconusPrice.UBPrice)
+		perUnitCentsUB, err := priceToCents(stageConusToOconusPrice.UBPrice)
 		if err != nil {
-			return fmt.Errorf("could not process UB price [%s]: %w", stageConusToOconusPrice.HHGShippingLinehaulPrice, err)
+			return fmt.Errorf("could not process UB price [%s]: %w", stageConusToOconusPrice.UBPrice, err)
 		}
 
 		intlPricingModelICOLH := models.ReIntlPrice{
@@ -156,7 +172,6 @@ func (gre *GHCRateEngineImporter) importREInternationalPrices(dbTx *pop.Connecti
 			IsPeakPeriod:          peakPeriod,
 			PerUnitCents:          unit.Cents(perUnitCentsHHG),
 		}
-
 		intlPricingModels = append(intlPricingModels, intlPricingModelICOLH)
 
 		intlPricingModelICOUB := models.ReIntlPrice{
@@ -167,7 +182,6 @@ func (gre *GHCRateEngineImporter) importREInternationalPrices(dbTx *pop.Connecti
 			IsPeakPeriod:          peakPeriod,
 			PerUnitCents:          unit.Cents(perUnitCentsUB),
 		}
-
 		intlPricingModels = append(intlPricingModels, intlPricingModelICOUB)
 
 		for _, model := range intlPricingModels {
@@ -181,41 +195,44 @@ func (gre *GHCRateEngineImporter) importREInternationalPrices(dbTx *pop.Connecti
 		}
 	}
 
-	//tab 3c OCONUS to CONUS data
+	return nil
+}
+
+func (gre *GHCRateEngineImporter) importOconusToConusPrices(dbTx *pop.Connection) error {
+	// tab 3c OCONUS to CONUS data
 	var oconusToConusPrices []models.StageOconusToConusPrice
-	err = dbTx.All(&oconusToConusPrices)
+	err := dbTx.All(&oconusToConusPrices)
 	if err != nil {
 		return fmt.Errorf("could not read staged OCONUS to CONUS prices: %w", err)
 	}
 
-	//Int'l O->C Shipping & LH
+	// Int'l O->C Shipping & LH
 	serviceIOCLH, foundService := gre.serviceToIDMap["IOCLH"]
 	if !foundService {
 		return fmt.Errorf("missing service IOCLH in map of services")
 	}
 
-	//Int'l O->C UB
+	// Int'l O->C UB
 	serviceIOCUB, foundService := gre.serviceToIDMap["IOCUB"]
 	if !foundService {
 		return fmt.Errorf("missing service IOCUB in map of services")
 	}
 
-	//loop through the OCONUS to CONUS data and store in db
+	// loop through the OCONUS to CONUS data and store in db
 	for _, stageOconusToConusPrice := range oconusToConusPrices {
 		var intlPricingModels models.ReIntlPrices
+
 		isPeakPeriod, err := isPeakPeriod(stageOconusToConusPrice.Season)
 		if err != nil {
 			return fmt.Errorf("could not process season [%s]: %w", stageOconusToConusPrice.Season, err)
 		}
 
-		originRateArea := stageOconusToConusPrice.OriginIntlPriceAreaID
-		originRateAreaID, found := gre.internationalRateAreaToIDMap[originRateArea]
+		originRateAreaID, found := gre.internationalRateAreaToIDMap[stageOconusToConusPrice.OriginIntlPriceAreaID]
 		if !found {
 			return fmt.Errorf("could not find international rate area [%s] in map", stageOconusToConusPrice.OriginIntlPriceAreaID)
 		}
 
-		destinationRateArea := stageOconusToConusPrice.DestinationDomesticPriceAreaCode
-		destinationRateAreaID, found := gre.domesticRateAreaToIDMap[destinationRateArea]
+		destinationRateAreaID, found := gre.domesticRateAreaToIDMap[stageOconusToConusPrice.DestinationDomesticPriceAreaCode]
 		if !found {
 			return fmt.Errorf("could not find domestic rate area [%s] in map", stageOconusToConusPrice.DestinationDomesticPriceAreaCode)
 		}
@@ -227,7 +244,7 @@ func (gre *GHCRateEngineImporter) importREInternationalPrices(dbTx *pop.Connecti
 
 		perUnitCentsUB, err := priceToCents(stageOconusToConusPrice.UBPrice)
 		if err != nil {
-			return fmt.Errorf("could not process UB price [%s]: %w", stageOconusToConusPrice.HHGShippingLinehaulPrice, err)
+			return fmt.Errorf("could not process UB price [%s]: %w", stageOconusToConusPrice.UBPrice, err)
 		}
 
 		intlPricingModelIOCLH := models.ReIntlPrice{
@@ -238,7 +255,6 @@ func (gre *GHCRateEngineImporter) importREInternationalPrices(dbTx *pop.Connecti
 			IsPeakPeriod:          isPeakPeriod,
 			PerUnitCents:          unit.Cents(perUnitCentsHHG),
 		}
-
 		intlPricingModels = append(intlPricingModels, intlPricingModelIOCLH)
 
 		intlPricingModelIOCUB := models.ReIntlPrice{
@@ -249,13 +265,12 @@ func (gre *GHCRateEngineImporter) importREInternationalPrices(dbTx *pop.Connecti
 			IsPeakPeriod:          isPeakPeriod,
 			PerUnitCents:          unit.Cents(perUnitCentsUB),
 		}
-
 		intlPricingModels = append(intlPricingModels, intlPricingModelIOCUB)
 
 		for _, model := range intlPricingModels {
-			verrs, err := dbTx.ValidateAndSave(&model)
-			if err != nil {
-				return fmt.Errorf("error saving ReIntlPrices: %+v with error: %w", model, err)
+			verrs, dbErr := dbTx.ValidateAndSave(&model)
+			if dbErr != nil {
+				return fmt.Errorf("error saving ReIntlPrices: %+v with error: %w", model, dbErr)
 			}
 			if verrs.HasAny() {
 				return fmt.Errorf("error saving ReIntlPrices: %+v with validation errors: %w", model, verrs)
@@ -264,4 +279,111 @@ func (gre *GHCRateEngineImporter) importREInternationalPrices(dbTx *pop.Connecti
 	}
 
 	return nil
+}
+
+func (gre *GHCRateEngineImporter) importNonStandardLocationPrices(dbTx *pop.Connection) error {
+	// tab 3e) Non-standard location prices
+	var nonStandardLocnPrices []models.StageNonStandardLocnPrice
+	err := dbTx.All(&nonStandardLocnPrices)
+	if err != nil {
+		return fmt.Errorf("could not read staged non-standard location prices: %w", err)
+	}
+
+	// Int'l non-standard HHG
+	serviceNSTH, foundService := gre.serviceToIDMap["NSTH"]
+	if !foundService {
+		return fmt.Errorf("missing service NSTH in map of services")
+	}
+
+	// Int'l non-standard UB
+	serviceNSTUB, foundService := gre.serviceToIDMap["NSTUB"]
+	if !foundService {
+		return fmt.Errorf("missing service NSTUB in map of services")
+	}
+
+	// loop through the non-standard location data and store in db
+	for _, stageNonStandardLocnPrice := range nonStandardLocnPrices {
+		var intlPricingModels models.ReIntlPrices
+
+		peakPeriod, err := isPeakPeriod(stageNonStandardLocnPrice.Season)
+		if err != nil {
+			return fmt.Errorf("could not process season [%s]: %w", stageNonStandardLocnPrice.Season, err)
+		}
+
+		moveToAndFromKind := strings.Split(stageNonStandardLocnPrice.MoveType, " to ")
+		if len(moveToAndFromKind) != 2 {
+			return fmt.Errorf("could not parse move type [%s]", stageNonStandardLocnPrice.MoveType)
+		}
+
+		originRateAreaID, err := gre.getRateAreaIDForKind(stageNonStandardLocnPrice.OriginID, moveToAndFromKind[0])
+		if err != nil {
+			return err
+		}
+
+		destinationRateAreaID, err := gre.getRateAreaIDForKind(stageNonStandardLocnPrice.DestinationID, moveToAndFromKind[1])
+		if err != nil {
+			return err
+		}
+
+		perUnitCentsHHG, err := priceToCents(stageNonStandardLocnPrice.HHGPrice)
+		if err != nil {
+			return fmt.Errorf("could not process linehaul price [%s]: %w", stageNonStandardLocnPrice.HHGPrice, err)
+		}
+
+		perUnitCentsUB, err := priceToCents(stageNonStandardLocnPrice.UBPrice)
+		if err != nil {
+			return fmt.Errorf("could not process UB price [%s]: %w", stageNonStandardLocnPrice.UBPrice, err)
+		}
+
+		intlPricingModelNSTH := models.ReIntlPrice{
+			ContractID:            gre.contractID,
+			ServiceID:             serviceNSTH,
+			OriginRateAreaID:      originRateAreaID,
+			DestinationRateAreaID: destinationRateAreaID,
+			IsPeakPeriod:          peakPeriod,
+			PerUnitCents:          unit.Cents(perUnitCentsHHG),
+		}
+		intlPricingModels = append(intlPricingModels, intlPricingModelNSTH)
+
+		intlPricingModelNSTUB := models.ReIntlPrice{
+			ContractID:            gre.contractID,
+			ServiceID:             serviceNSTUB,
+			OriginRateAreaID:      originRateAreaID,
+			DestinationRateAreaID: destinationRateAreaID,
+			IsPeakPeriod:          peakPeriod,
+			PerUnitCents:          unit.Cents(perUnitCentsUB),
+		}
+		intlPricingModels = append(intlPricingModels, intlPricingModelNSTUB)
+
+		for _, model := range intlPricingModels {
+			verrs, dbErr := dbTx.ValidateAndSave(&model)
+			if dbErr != nil {
+				return fmt.Errorf("error saving ReIntlPrices: %+v with error: %w", model, dbErr)
+			}
+			if verrs.HasAny() {
+				return fmt.Errorf("error saving ReIntlPrices: %+v with validation errors: %w", model, verrs)
+			}
+		}
+	}
+
+	return nil
+}
+
+func (gre *GHCRateEngineImporter) getRateAreaIDForKind(rateArea string, kind string) (uuid.UUID, error) {
+	switch kind {
+	case "NSRA", "OCONUS":
+		intlRateAreaID, found := gre.internationalRateAreaToIDMap[rateArea]
+		if !found {
+			return uuid.Nil, fmt.Errorf("could not find rate area [%s] in international rate area map", rateArea)
+		}
+		return intlRateAreaID, nil
+	case "CONUS":
+		domesticRateAreaID, found := gre.domesticRateAreaToIDMap[rateArea]
+		if !found {
+			return uuid.Nil, fmt.Errorf("could not find rate area [%s] in domestic rate area map", rateArea)
+		}
+		return domesticRateAreaID, nil
+	}
+
+	return uuid.Nil, fmt.Errorf("unexpected rate area kind [%s]", kind)
 }

--- a/pkg/services/ghcimport/import_re_intl_prices_test.go
+++ b/pkg/services/ghcimport/import_re_intl_prices_test.go
@@ -28,8 +28,8 @@ func (suite *GHCRateEngineImportSuite) Test_importREInternationalPrices() {
 		suite.NoError(err)
 		suite.helperVerifyInternationalPrices()
 
-		// Spot check a linehaul price
-		suite.helperCheckInternationalPriceValue()
+		// Spot check prices
+		suite.helperCheckInternationalPriceValues()
 	})
 
 	suite.T().Run("run a second time; should fail immediately due to constraint violation", func(t *testing.T) {
@@ -40,82 +40,96 @@ func (suite *GHCRateEngineImportSuite) Test_importREInternationalPrices() {
 
 		// Check to see if anything else changed
 		suite.helperVerifyInternationalPrices()
-		suite.helperCheckInternationalPriceValue()
+		suite.helperCheckInternationalPriceValues()
 	})
 }
 
 func (suite *GHCRateEngineImportSuite) helperVerifyInternationalPrices() {
 	count, err := suite.DB().Count(&models.ReIntlPrices{})
 	suite.NoError(err)
-	suite.Equal(132, count)
+	suite.Equal(260, count)
 }
 
-func (suite *GHCRateEngineImportSuite) helperCheckInternationalPriceValue() {
+func (suite *GHCRateEngineImportSuite) helperCheckInternationalPriceValues() {
 	// Get contract UUID.
 	var contract models.ReContract
 	err := suite.DB().Where("code = ?", testContractCode).First(&contract)
 	suite.NoError(err)
 
-	// Get service UUID.
-	var serviceIOOLH models.ReService
-	err = suite.DB().Where("code = 'IOOLH'").First(&serviceIOOLH)
-	suite.NoError(err)
+	// Spot check one non-peak/peak record of each type
+	servicesToInsert := []struct {
+		serviceCode         string
+		originRateArea      string
+		destinationRateArea string
+		isPeakPeriod        bool
+		expectedPrice       int
+	}{
+		// 3a: OCONUS to OCONUS
+		{"IOOLH", "GE", "US8101000", false, 1021},
+		{"IOOUB", "GE", "US8101000", false, 1717},
+		{"IOOLH", "GE", "US8101000", true, 1205},
+		{"IOOUB", "GE", "US8101000", true, 2026},
+		// 3b: CONUS to OCONUS
+		{"ICOLH", "US47", "AS11", false, 3090},
+		{"ICOUB", "US47", "AS11", false, 3398},
+		{"ICOLH", "US47", "AS11", true, 3646},
+		{"ICOUB", "US47", "AS11", true, 4010},
+		// 3c: OCONUS to CONUS
+		{"IOCLH", "US8101000", "US68", false, 1757},
+		{"IOCUB", "US8101000", "US68", false, 3445},
+		{"IOCLH", "US8101000", "US68", true, 2073},
+		{"IOCUB", "US8101000", "US68", true, 4065},
+		// 3e: NSRA to NSRA
+		{"NSTH", "NSRA2", "NSRA13", false, 4849},
+		{"NSTUB", "NSRA2", "NSRA13", false, 4793},
+		{"NSTH", "NSRA2", "NSRA13", true, 5722},
+		{"NSTUB", "NSRA2", "NSRA13", true, 5656},
+		// 3e: NSRA to OCONUS
+		{"NSTH", "NSRA13", "AS11", false, 5172},
+		{"NSTUB", "NSRA13", "AS11", false, 1175},
+		{"NSTH", "NSRA13", "AS11", true, 6103},
+		{"NSTUB", "NSRA13", "AS11", true, 1386},
+		// 3e: OCONUS to NSRA
+		{"NSTH", "GE", "NSRA2", false, 4872},
+		{"NSTUB", "GE", "NSRA2", false, 1050},
+		{"NSTH", "GE", "NSRA2", true, 5749},
+		{"NSTUB", "GE", "NSRA2", true, 1239},
+		// 3e: NSRA to CONUS
+		{"NSTH", "NSRA2", "US4965500", false, 931},
+		{"NSTUB", "NSRA2", "US4965500", false, 1717},
+		{"NSTH", "NSRA2", "US4965500", true, 1099},
+		{"NSTUB", "NSRA2", "US4965500", true, 2026},
+		// 3e: CONUS to NSRA
+		{"NSTH", "US68", "NSRA13", false, 1065},
+		{"NSTUB", "US68", "NSRA13", false, 1689},
+		{"NSTH", "US68", "NSRA13", true, 1257},
+		{"NSTUB", "US68", "NSRA13", true, 1993},
+	}
 
-	var serviceIOOUB models.ReService
-	err = suite.DB().Where("code = 'IOOUB'").First(&serviceIOOUB)
-	suite.NoError(err)
+	for _, serviceToInsert := range servicesToInsert {
+		var service models.ReService
+		err = suite.DB().Where("code = ?", serviceToInsert.serviceCode).First(&service)
+		suite.NoError(err)
 
-	// Get origin rate area UUID.
-	var origin *models.ReRateArea
-	origin, err = models.FetchReRateAreaItem(suite.DB(), "GE")
-	suite.NoError(err)
+		// Get origin rate area UUID.
+		var origin *models.ReRateArea
+		origin, err = models.FetchReRateAreaItem(suite.DB(), serviceToInsert.originRateArea)
+		suite.NoError(err)
 
-	// Get destination rate area UUID.
-	var destination *models.ReRateArea
-	destination, err = models.FetchReRateAreaItem(suite.DB(), "US8101000")
-	suite.NoError(err)
+		// Get destination rate area UUID.
+		var destination *models.ReRateArea
+		destination, err = models.FetchReRateAreaItem(suite.DB(), serviceToInsert.destinationRateArea)
+		suite.NoError(err)
 
-	var intlPriceIOOLH models.ReIntlPrice
-	err = suite.DB().
-		Where("contract_id = ?", contract.ID).
-		Where("service_id = ?", serviceIOOLH.ID).
-		Where("origin_rate_area_id = ?", origin.ID).
-		Where("destination_rate_area_id = ?", destination.ID).
-		Where("is_peak_period = false").
-		First(&intlPriceIOOLH)
-	suite.NoError(err)
-	suite.Equal(unit.Cents(1021), intlPriceIOOLH.PerUnitCents)
-
-	var intlPriceIOOLHPeak models.ReIntlPrice
-	err = suite.DB().
-		Where("contract_id = ?", contract.ID).
-		Where("service_id = ?", serviceIOOLH.ID).
-		Where("origin_rate_area_id = ?", origin.ID).
-		Where("destination_rate_area_id = ?", destination.ID).
-		Where("is_peak_period = true").
-		First(&intlPriceIOOLHPeak)
-	suite.NoError(err)
-	suite.Equal(unit.Cents(1205), intlPriceIOOLHPeak.PerUnitCents)
-
-	var intlPriceIOOUB models.ReIntlPrice
-	err = suite.DB().
-		Where("contract_id = ?", contract.ID).
-		Where("service_id = ?", serviceIOOUB.ID).
-		Where("origin_rate_area_id = ?", origin.ID).
-		Where("destination_rate_area_id = ?", destination.ID).
-		Where("is_peak_period = false").
-		First(&intlPriceIOOUB)
-	suite.NoError(err)
-	suite.Equal(unit.Cents(1717), intlPriceIOOUB.PerUnitCents)
-
-	var intlPriceIOOUBPeak models.ReIntlPrice
-	err = suite.DB().
-		Where("contract_id = ?", contract.ID).
-		Where("service_id = ?", serviceIOOUB.ID).
-		Where("origin_rate_area_id = ?", origin.ID).
-		Where("destination_rate_area_id = ?", destination.ID).
-		Where("is_peak_period = true").
-		First(&intlPriceIOOUBPeak)
-	suite.NoError(err)
-	suite.Equal(unit.Cents(2026), intlPriceIOOUBPeak.PerUnitCents)
+		var intlPrice models.ReIntlPrice
+		err = suite.DB().
+			Where("contract_id = ?", contract.ID).
+			Where("service_id = ?", service.ID).
+			Where("origin_rate_area_id = ?", origin.ID).
+			Where("destination_rate_area_id = ?", destination.ID).
+			Where("is_peak_period = ?", serviceToInsert.isPeakPeriod).
+			First(&intlPrice)
+		suite.NoError(err)
+		suite.Equal(unit.Cents(serviceToInsert.expectedPrice), intlPrice.PerUnitCents)
+	}
 }


### PR DESCRIPTION
## Description

This PR loads the non-standard location prices (tab 3e from the pricing template) from the staging tables into the `re_intl_prices` table.

## Reviewer Notes

I found an issue in the pricing template that caused DB constraint violations.  I've fixed it in our local files.  More info in this [Slack thread](https://ustcdp3.slack.com/archives/CQ08Q9FPY/p1578336625005300).

Since this tab of data is going into the same `re_intl_prices` table as tabs 3a, 3b, and 3c, I just added functionality to the existing `import_re_intl_prices.go` file.  I did a little refactoring to more clearly separate the different tabs' data.

## Setup

To do the import:
- `rm bin/ghc-pricing-parser`
- `make bin/ghc-pricing-parser`
- `make db_dev_reset db_dev_migrate`
- `ghc-pricing-parser --filename /path/to/fake/pricing/template.xlsx --contract-code TEST` (a fake pricing template is linked in the references below)

After running this, you should have a bunch of records in the `re_intl_prices` table.  Please spot check a set against the pricing template you imported.

To run the tests:
- `make server_test`

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/tree/master/docs/backend.md#logging)
* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/tree/master/docs/backend.md#querying-the-database-safely) have been satisfied.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-477) for this change
* [Pricing template with fake data](https://docs.google.com/spreadsheets/d/1M1IdJfttPlasa_8NDJMsNIYNXksKMaR0bJsSkn7HpaA/edit#gid=1448507886)
