### PR TITLE
MB-714 Import data from xlsx sheet 2c Domestic Other Prices into rate engine tables

### DIFF
--- a/pkg/services/ghcimport/fixtures/stage_ghc_pricing.sql
+++ b/pkg/services/ghcimport/fixtures/stage_ghc_pricing.sql
@@ -108,6 +108,30 @@ CREATE TABLE public.stage_domestic_service_areas (
 
 
 --
+-- Name: stage_domestic_other_pack_prices; Type: TABLE; Schema: public; Owner: -
+--
+DROP TABLE IF EXISTS public.stage_domestic_other_pack_prices;
+CREATE TABLE public.stage_domestic_other_pack_prices (
+    services_schedule text NOT NULL,
+    service_provided text NOT NULL,
+    non_peak_price_per_cwt text NOT NULL,
+    peak_price_per_cwt text NOT NULL
+);
+
+
+--
+-- Name: stage_domestic_other_sit_prices; Type: TABLE; Schema: public; Owner: -
+--
+DROP TABLE IF EXISTS public.stage_domestic_other_sit_prices;
+CREATE TABLE public.stage_domestic_other_sit_prices (
+    sit_pickup_delivery_schedule text NOT NULL,
+    service_provided text NOT NULL,
+    non_peak_price_per_cwt text NOT NULL,
+    peak_price_per_cwt text NOT NULL
+);
+
+
+--
 -- Name: stage_international_move_accessorial_prices; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -585,6 +609,27 @@ INSERT INTO public.stage_domestic_service_areas (base_point_city, state, service
 INSERT INTO public.stage_domestic_service_areas (base_point_city, state, service_area_number, zip3s) VALUES ('Springfield', 'MO', '452.0', '656,657,658');
 INSERT INTO public.stage_domestic_service_areas (base_point_city, state, service_area_number, zip3s) VALUES ('Tuscaloosa', 'AL', '004', '354.0');
 INSERT INTO public.stage_domestic_service_areas (base_point_city, state, service_area_number, zip3s) VALUES ('Worthington', 'OH', '616.0', '430.0');
+
+
+--
+-- Data for Name: stage_domestic_other_pack_prices; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+INSERT INTO public.stage_domestic_other_pack_prices (services_schedule, service_provided, non_peak_price_per_cwt, peak_price_per_cwt) VALUES ('1','Packing (per cwt)','$63.33','$65.44');
+INSERT INTO public.stage_domestic_other_pack_prices (services_schedule, service_provided, non_peak_price_per_cwt, peak_price_per_cwt) VALUES ('2','Packing (per cwt)','$72.50','$73.20');
+INSERT INTO public.stage_domestic_other_pack_prices (services_schedule, service_provided, non_peak_price_per_cwt, peak_price_per_cwt) VALUES ('3','Packing (per cwt)','$73.95','$80.00');
+INSERT INTO public.stage_domestic_other_pack_prices (services_schedule, service_provided, non_peak_price_per_cwt, peak_price_per_cwt) VALUES ('1','Unpack (per cwt)','$83.34','$85.44');
+INSERT INTO public.stage_domestic_other_pack_prices (services_schedule, service_provided, non_peak_price_per_cwt, peak_price_per_cwt) VALUES ('2','Unpack (per cwt)','$5.97','$6.50');
+INSERT INTO public.stage_domestic_other_pack_prices (services_schedule, service_provided, non_peak_price_per_cwt, peak_price_per_cwt) VALUES ('3','Unpack (per cwt)','$5.97','$6.50');
+
+
+--
+-- Data for Name: stage_domestic_other_sit_prices; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+INSERT INTO public.stage_domestic_other_sit_prices (sit_pickup_delivery_schedule, service_provided, non_peak_price_per_cwt, peak_price_per_cwt) VALUES ('1','SIT Pickup / Delivery ≤50 miles (per cwt)','$217.96','$220.11');
+INSERT INTO public.stage_domestic_other_sit_prices (sit_pickup_delivery_schedule, service_provided, non_peak_price_per_cwt, peak_price_per_cwt) VALUES ('2','SIT Pickup / Delivery ≤50 miles (per cwt)','$234.40','$241.22');
+INSERT INTO public.stage_domestic_other_sit_prices (sit_pickup_delivery_schedule, service_provided, non_peak_price_per_cwt, peak_price_per_cwt) VALUES ('3','SIT Pickup / Delivery ≤50 miles (per cwt)','$246.25','$250.30');
 
 
 --

--- a/pkg/services/ghcimport/ghc_rateengine_importer.go
+++ b/pkg/services/ghcimport/ghc_rateengine_importer.go
@@ -52,6 +52,11 @@ func (gre *GHCRateEngineImporter) runImports(dbTx *pop.Connection) error {
 		return fmt.Errorf("failed to import re_domestic_service_area_prices: %w", err)
 	}
 
+	err = gre.importREDomesticOtherPrices(dbTx)
+	if err != nil {
+		return fmt.Errorf("failed to import re_domestic_other_prices: %w", err)
+	}
+
 	err = gre.importREInternationalPrices(dbTx)
 	if err != nil {
 		return fmt.Errorf("failed to import re_intl_prices: %w", err)

--- a/pkg/services/ghcimport/import_re_domestic_other_prices.go
+++ b/pkg/services/ghcimport/import_re_domestic_other_prices.go
@@ -36,14 +36,14 @@ func importPackUnpackPrices(db *pop.Connection, serviceToIDMap map[string]uuid.U
 	}
 
 	for _, stagePackPrice := range stagePackPrices {
-		peakCents, convErr := priceToCents(stagePackPrice.PeakPricePerCwt)
-		if convErr != nil {
-			return nil, fmt.Errorf("failed to parse price for service code DPK: %+v error: %w", stagePackPrice.PeakPricePerCwt, convErr)
+		peakCents, err := priceToCents(stagePackPrice.PeakPricePerCwt)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse price for service code DPK: %+v error: %w", stagePackPrice.PeakPricePerCwt, err)
 		}
 
-		nonPeakCents, convErr := priceToCents(stagePackPrice.NonPeakPricePerCwt)
-		if convErr != nil {
-			return nil, fmt.Errorf("failed to parse price for service code DUPK: %+v error: %w", stagePackPrice.NonPeakPricePerCwt, convErr)
+		nonPeakCents, err := priceToCents(stagePackPrice.NonPeakPricePerCwt)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse price for service code DUPK: %+v error: %w", stagePackPrice.NonPeakPricePerCwt, err)
 		}
 
 		servicesSchedule, err := stringToInteger(stagePackPrice.ServicesSchedule)
@@ -100,14 +100,14 @@ func importSitPrices(db *pop.Connection, serviceToIDMap map[string]uuid.UUID, co
 	}
 
 	for _, stageSitPrice := range stageSitPrices {
-		peakCents, convErr := priceToCents(stageSitPrice.PeakPricePerCwt)
-		if convErr != nil {
-			return nil, fmt.Errorf("failed to parse price for service code DOPSIT: %+v error: %w", stageSitPrice.PeakPricePerCwt, convErr)
+		peakCents, err := priceToCents(stageSitPrice.PeakPricePerCwt)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse price for service code DOPSIT: %+v error: %w", stageSitPrice.PeakPricePerCwt, err)
 		}
 
-		nonPeakCents, convErr := priceToCents(stageSitPrice.NonPeakPricePerCwt)
-		if convErr != nil {
-			return nil, fmt.Errorf("failed to parse price for service code DDDSIT: %+v error: %w", stageSitPrice.NonPeakPricePerCwt, convErr)
+		nonPeakCents, err := priceToCents(stageSitPrice.NonPeakPricePerCwt)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse price for service code DDDSIT: %+v error: %w", stageSitPrice.NonPeakPricePerCwt, err)
 		}
 
 		schedule, err := stringToInteger(stageSitPrice.SITPickupDeliverySchedule)

--- a/pkg/services/ghcimport/import_re_domestic_other_prices.go
+++ b/pkg/services/ghcimport/import_re_domestic_other_prices.go
@@ -1,0 +1,195 @@
+package ghcimport
+
+import (
+	"fmt"
+
+	"github.com/gobuffalo/pop"
+	"github.com/gofrs/uuid"
+
+	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/unit"
+)
+
+type DomOtherPriceToInsert struct {
+	model   models.ReDomesticOtherPrice
+	message string
+}
+
+func importPackUnpackPrices(db *pop.Connection, serviceToIDMap map[string]uuid.UUID, contractID uuid.UUID) ([]DomOtherPriceToInsert, error) {
+	var stagePackPrices []models.StageDomesticOtherPackPrice
+	var modelsToSave []DomOtherPriceToInsert
+
+	if err := db.All(&stagePackPrices); err != nil {
+		return nil, fmt.Errorf("error looking up StageDomesticOtherPackPrice data: %w", err)
+	}
+
+	// DPK Dom. Packing
+	packServiceID, found := serviceToIDMap["DPK"]
+	if !found {
+		return nil, fmt.Errorf("missing service [DPK] in map of services")
+	}
+
+	// DUPK Dom. Unpacking
+	unpackServiceID, found := serviceToIDMap["DUPK"]
+	if !found {
+		return nil, fmt.Errorf("missing service [DUPK] in map of services")
+	}
+
+	for _, stagePackPrice := range stagePackPrices {
+		peakCents, convErr := priceToCents(stagePackPrice.PeakPricePerCwt)
+		if convErr != nil {
+			return nil, fmt.Errorf("failed to parse price for service code DPK: %+v error: %w", stagePackPrice.PeakPricePerCwt, convErr)
+		}
+
+		nonPeakCents, convErr := priceToCents(stagePackPrice.NonPeakPricePerCwt)
+		if convErr != nil {
+			return nil, fmt.Errorf("failed to parse price for service code DUPK: %+v error: %w", stagePackPrice.NonPeakPricePerCwt, convErr)
+		}
+
+		servicesSchedule, err := stringToInteger(stagePackPrice.ServicesSchedule)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse ServicesSchedule for pack/unpack: %+v error: %w", stagePackPrice.ServicesSchedule, err)
+		}
+
+		packPeakPriceModel := models.ReDomesticOtherPrice{
+			ContractID:   contractID,
+			Schedule:     servicesSchedule,
+			IsPeakPeriod: true,
+			PriceCents:   unit.Cents(peakCents),
+		}
+		packNonPeakPriceModel := models.ReDomesticOtherPrice{
+			ContractID:   contractID,
+			Schedule:     servicesSchedule,
+			IsPeakPeriod: false,
+			PriceCents:   unit.Cents(nonPeakCents),
+		}
+
+		if stagePackPrice.ServiceProvided == "Packing (per cwt)" {
+			packPeakPriceModel.ServiceID = packServiceID
+			packNonPeakPriceModel.ServiceID = packServiceID
+		} else {
+			packPeakPriceModel.ServiceID = unpackServiceID
+			packNonPeakPriceModel.ServiceID = unpackServiceID
+		}
+
+		modelsToSave = append(modelsToSave, DomOtherPriceToInsert{model: packPeakPriceModel, message: "Peak Pack/Unpack"})
+		modelsToSave = append(modelsToSave, DomOtherPriceToInsert{model: packNonPeakPriceModel, message: "Non-Peak Pack/Unpack"})
+	}
+
+	return modelsToSave, nil
+}
+
+func importSitPrices(db *pop.Connection, serviceToIDMap map[string]uuid.UUID, contractID uuid.UUID) ([]DomOtherPriceToInsert, error) {
+	var stageSitPrices []models.StageDomesticOtherSitPrice
+	var modelsToSave []DomOtherPriceToInsert
+
+	if err := db.All(&stageSitPrices); err != nil {
+		return nil, fmt.Errorf("error looking up StageDomesticOtherSitPrice data: %w", err)
+	}
+
+	// DOPSIT Dom. Origin SIT Pickup
+	originSitPickupID, found := serviceToIDMap["DOPSIT"]
+	if !found {
+		return nil, fmt.Errorf("missing service [DOPSIT] in map of services")
+	}
+
+	// DDDSIT Dom. Destination SIT Delivery
+	destSitDeliveryID, found := serviceToIDMap["DDDSIT"]
+	if !found {
+		return nil, fmt.Errorf("missing service [DDDSIT] in map of services")
+	}
+
+	for _, stageSitPrice := range stageSitPrices {
+		peakCents, convErr := priceToCents(stageSitPrice.PeakPricePerCwt)
+		if convErr != nil {
+			return nil, fmt.Errorf("failed to parse price for service code DOPSIT: %+v error: %w", stageSitPrice.PeakPricePerCwt, convErr)
+		}
+
+		nonPeakCents, convErr := priceToCents(stageSitPrice.NonPeakPricePerCwt)
+		if convErr != nil {
+			return nil, fmt.Errorf("failed to parse price for service code DDDSIT: %+v error: %w", stageSitPrice.NonPeakPricePerCwt, convErr)
+		}
+
+		schedule, err := stringToInteger(stageSitPrice.SITPickupDeliverySchedule)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse SITPickupDeliverySchedule: %+v error: %w", stageSitPrice.SITPickupDeliverySchedule, err)
+		}
+
+		modelsToSave = append(
+			modelsToSave,
+			DomOtherPriceToInsert{model: models.ReDomesticOtherPrice{
+				ContractID:   contractID,
+				ServiceID:    originSitPickupID,
+				Schedule:     schedule,
+				IsPeakPeriod: true,
+				PriceCents:   unit.Cents(peakCents),
+			}, message: "SIT Peak Pickup"})
+		modelsToSave = append(
+			modelsToSave,
+			DomOtherPriceToInsert{model: models.ReDomesticOtherPrice{
+				ContractID:   contractID,
+				ServiceID:    destSitDeliveryID,
+				Schedule:     schedule,
+				IsPeakPeriod: true,
+				PriceCents:   unit.Cents(peakCents),
+			}, message: "SIT Peak Delivery"})
+		modelsToSave = append(
+			modelsToSave,
+			DomOtherPriceToInsert{model: models.ReDomesticOtherPrice{
+				ContractID:   contractID,
+				ServiceID:    originSitPickupID,
+				Schedule:     schedule,
+				IsPeakPeriod: false,
+				PriceCents:   unit.Cents(nonPeakCents),
+			}, message: "SIT Non Peak Pickup"})
+		modelsToSave = append(
+			modelsToSave,
+			DomOtherPriceToInsert{model: models.ReDomesticOtherPrice{
+				ContractID:   contractID,
+				ServiceID:    destSitDeliveryID,
+				Schedule:     schedule,
+				IsPeakPeriod: false,
+				PriceCents:   unit.Cents(nonPeakCents),
+			}, message: "SIT Non Peak Delivery"})
+	}
+
+	return modelsToSave, nil
+}
+
+func saveModel(db *pop.Connection, message string, model *models.ReDomesticOtherPrice) error {
+	verrs, err := db.ValidateAndSave(model)
+	if verrs.HasAny() {
+		return fmt.Errorf("error saving ReDomesticOtherPrice %s: %+v with validation errors: %w", message, model, verrs)
+	}
+	if err != nil {
+		return fmt.Errorf("error saving ReDomesticOtherPrice %s: %+v with error: %w", message, model, err)
+	}
+
+	return nil
+}
+
+func (gre *GHCRateEngineImporter) importREDomesticOtherPrices(db *pop.Connection) error {
+
+	var modelsToSavePack []DomOtherPriceToInsert
+	var modelsToSaveSit []DomOtherPriceToInsert
+
+	var err error
+	modelsToSavePack, err = importPackUnpackPrices(db, gre.serviceToIDMap, gre.contractID)
+	if err != nil {
+		return err
+	}
+
+	modelsToSaveSit, err = importSitPrices(db, gre.serviceToIDMap, gre.contractID)
+	if err != nil {
+		return err
+	}
+
+	modelsToSave := append(modelsToSavePack, modelsToSaveSit...)
+	for _, modelToSave := range modelsToSave {
+		if err := saveModel(db, modelToSave.message, &modelToSave.model); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/services/ghcimport/import_re_domestic_other_prices.go
+++ b/pkg/services/ghcimport/import_re_domestic_other_prices.go
@@ -67,9 +67,11 @@ func importPackUnpackPrices(db *pop.Connection, serviceToIDMap map[string]uuid.U
 		if stagePackPrice.ServiceProvided == "Packing (per cwt)" {
 			packNonPeakPriceModel.ServiceID = packServiceID
 			packPeakPriceModel.ServiceID = packServiceID
-		} else {
+		} else if stagePackPrice.ServiceProvided == "Unpack (per cwt)" {
 			packNonPeakPriceModel.ServiceID = unpackServiceID
 			packPeakPriceModel.ServiceID = unpackServiceID
+		} else {
+			return nil, fmt.Errorf("failed to import pack/unpack prices receieved unexpected ServiceProvided: %s in %+v", stagePackPrice.ServiceProvided, stagePackPrice)
 		}
 
 		modelsToSave = append(modelsToSave, DomOtherPriceToInsert{model: packNonPeakPriceModel, message: "Non-Peak Pack/Unpack"})

--- a/pkg/services/ghcimport/import_re_domestic_other_prices.go
+++ b/pkg/services/ghcimport/import_re_domestic_other_prices.go
@@ -51,29 +51,29 @@ func importPackUnpackPrices(db *pop.Connection, serviceToIDMap map[string]uuid.U
 			return nil, fmt.Errorf("failed to parse ServicesSchedule for pack/unpack: %+v error: %w", stagePackPrice.ServicesSchedule, err)
 		}
 
-		packPeakPriceModel := models.ReDomesticOtherPrice{
-			ContractID:   contractID,
-			Schedule:     servicesSchedule,
-			IsPeakPeriod: true,
-			PriceCents:   unit.Cents(peakCents),
-		}
 		packNonPeakPriceModel := models.ReDomesticOtherPrice{
 			ContractID:   contractID,
 			Schedule:     servicesSchedule,
 			IsPeakPeriod: false,
 			PriceCents:   unit.Cents(nonPeakCents),
 		}
-
-		if stagePackPrice.ServiceProvided == "Packing (per cwt)" {
-			packPeakPriceModel.ServiceID = packServiceID
-			packNonPeakPriceModel.ServiceID = packServiceID
-		} else {
-			packPeakPriceModel.ServiceID = unpackServiceID
-			packNonPeakPriceModel.ServiceID = unpackServiceID
+		packPeakPriceModel := models.ReDomesticOtherPrice{
+			ContractID:   contractID,
+			Schedule:     servicesSchedule,
+			IsPeakPeriod: true,
+			PriceCents:   unit.Cents(peakCents),
 		}
 
-		modelsToSave = append(modelsToSave, DomOtherPriceToInsert{model: packPeakPriceModel, message: "Peak Pack/Unpack"})
+		if stagePackPrice.ServiceProvided == "Packing (per cwt)" {
+			packNonPeakPriceModel.ServiceID = packServiceID
+			packPeakPriceModel.ServiceID = packServiceID
+		} else {
+			packNonPeakPriceModel.ServiceID = unpackServiceID
+			packPeakPriceModel.ServiceID = unpackServiceID
+		}
+
 		modelsToSave = append(modelsToSave, DomOtherPriceToInsert{model: packNonPeakPriceModel, message: "Non-Peak Pack/Unpack"})
+		modelsToSave = append(modelsToSave, DomOtherPriceToInsert{model: packPeakPriceModel, message: "Peak Pack/Unpack"})
 	}
 
 	return modelsToSave, nil
@@ -121,24 +121,6 @@ func importSitPrices(db *pop.Connection, serviceToIDMap map[string]uuid.UUID, co
 				ContractID:   contractID,
 				ServiceID:    originSitPickupID,
 				Schedule:     schedule,
-				IsPeakPeriod: true,
-				PriceCents:   unit.Cents(peakCents),
-			}, message: "SIT Peak Pickup"})
-		modelsToSave = append(
-			modelsToSave,
-			DomOtherPriceToInsert{model: models.ReDomesticOtherPrice{
-				ContractID:   contractID,
-				ServiceID:    destSitDeliveryID,
-				Schedule:     schedule,
-				IsPeakPeriod: true,
-				PriceCents:   unit.Cents(peakCents),
-			}, message: "SIT Peak Delivery"})
-		modelsToSave = append(
-			modelsToSave,
-			DomOtherPriceToInsert{model: models.ReDomesticOtherPrice{
-				ContractID:   contractID,
-				ServiceID:    originSitPickupID,
-				Schedule:     schedule,
 				IsPeakPeriod: false,
 				PriceCents:   unit.Cents(nonPeakCents),
 			}, message: "SIT Non Peak Pickup"})
@@ -151,6 +133,24 @@ func importSitPrices(db *pop.Connection, serviceToIDMap map[string]uuid.UUID, co
 				IsPeakPeriod: false,
 				PriceCents:   unit.Cents(nonPeakCents),
 			}, message: "SIT Non Peak Delivery"})
+		modelsToSave = append(
+			modelsToSave,
+			DomOtherPriceToInsert{model: models.ReDomesticOtherPrice{
+				ContractID:   contractID,
+				ServiceID:    originSitPickupID,
+				Schedule:     schedule,
+				IsPeakPeriod: true,
+				PriceCents:   unit.Cents(peakCents),
+			}, message: "SIT Peak Pickup"})
+		modelsToSave = append(
+			modelsToSave,
+			DomOtherPriceToInsert{model: models.ReDomesticOtherPrice{
+				ContractID:   contractID,
+				ServiceID:    destSitDeliveryID,
+				Schedule:     schedule,
+				IsPeakPeriod: true,
+				PriceCents:   unit.Cents(peakCents),
+			}, message: "SIT Peak Delivery"})
 	}
 
 	return modelsToSave, nil

--- a/pkg/services/ghcimport/import_re_domestic_other_prices_test.go
+++ b/pkg/services/ghcimport/import_re_domestic_other_prices_test.go
@@ -1,0 +1,118 @@
+package ghcimport
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/gofrs/uuid"
+
+	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/unit"
+)
+
+func (suite *GHCRateEngineImportSuite) Test_importREDomesticOtherPrices() {
+	gre := &GHCRateEngineImporter{
+		Logger:       suite.logger,
+		ContractCode: testContractCode,
+	}
+
+	suite.T().Run("import success", func(t *testing.T) {
+		// Prerequisite tables must be loaded.
+		err := gre.importREContract(suite.DB())
+		suite.NoError(err)
+
+		err = gre.loadServiceMap(suite.DB())
+		suite.NoError(err)
+
+		err = gre.importREDomesticOtherPrices(suite.DB())
+		suite.NoError(err)
+
+		suite.helperVerifyDomesticOtherPrices()
+		suite.helperCheckDomesticOtherPriceValue()
+	})
+
+	suite.T().Run("run a second time; should fail immediately due to constraint violation", func(t *testing.T) {
+		err := gre.importREDomesticOtherPrices(suite.DB())
+		if suite.Error(err) {
+			suite.Contains(err.Error(), "duplicate key value violates unique constraint")
+		}
+
+		// Check to see if anything else changed
+		suite.helperVerifyDomesticOtherPrices()
+		suite.helperCheckDomesticOtherPriceValue()
+	})
+}
+
+func (suite *GHCRateEngineImportSuite) Test_importREDomesticOtherPricesFailures() {
+	gre := &GHCRateEngineImporter{
+		Logger:       suite.logger,
+		ContractCode: testContractCode,
+	}
+
+	err := gre.importREContract(suite.DB())
+	suite.NoError(err)
+	suite.NotNil(gre.contractID)
+
+	err = gre.loadServiceMap(suite.DB())
+	suite.NoError(err)
+
+	suite.T().Run("stage_domestic_other_sit_prices table missing", func(t *testing.T) {
+		// drop a staging table that we are depending on to do import
+		dropQuery := fmt.Sprintf("DROP TABLE IF EXISTS %s;", "stage_domestic_other_sit_prices")
+		dropErr := suite.DB().RawQuery(dropQuery).Exec()
+		suite.NoError(dropErr)
+
+		err = gre.importREDomesticOtherPrices(suite.DB())
+		if suite.Error(err) {
+			suite.Equal("error looking up StageDomesticOtherSitPrice data: unable to fetch records: pq: relation \"stage_domestic_other_sit_prices\" does not exist", err.Error())
+		}
+	})
+	suite.T().Run("stage_domestic_other_pack_prices table missing", func(t *testing.T) {
+		// drop a staging table that we are depending on to do import
+		dropQuery := fmt.Sprintf("DROP TABLE IF EXISTS %s;", "stage_domestic_other_pack_prices")
+		dropErr := suite.DB().RawQuery(dropQuery).Exec()
+		suite.NoError(dropErr)
+
+		err = gre.importREDomesticOtherPrices(suite.DB())
+		if suite.Error(err) {
+			suite.Equal("error looking up StageDomesticOtherPackPrice data: unable to fetch records: pq: relation \"stage_domestic_other_pack_prices\" does not exist", err.Error())
+		}
+	})
+}
+
+func (suite *GHCRateEngineImportSuite) helperVerifyDomesticOtherPrices() {
+	count, err := suite.DB().Count(&models.ReDomesticOtherPrice{})
+	suite.NoError(err)
+	suite.Equal(24, count)
+}
+
+func (suite *GHCRateEngineImportSuite) helperCheckDomesticOtherPriceValue() {
+	// Get contract UUID.
+	var contract models.ReContract
+	err := suite.DB().Where("code = ?", testContractCode).First(&contract)
+	suite.NoError(err)
+
+	suite.verifyDomesticOtherPrice(unit.Cents(7395), contract.ID, false, "DPK", 3)
+	suite.verifyDomesticOtherPrice(unit.Cents(8000), contract.ID, true, "DPK", 3)
+	suite.verifyDomesticOtherPrice(unit.Cents(597), contract.ID, false, "DUPK", 2)
+	suite.verifyDomesticOtherPrice(unit.Cents(650), contract.ID, true, "DUPK", 2)
+	suite.verifyDomesticOtherPrice(unit.Cents(23440), contract.ID, false, "DOPSIT", 2)
+	suite.verifyDomesticOtherPrice(unit.Cents(24122), contract.ID, true, "DOPSIT", 2)
+	suite.verifyDomesticOtherPrice(unit.Cents(24625), contract.ID, false, "DDDSIT", 3)
+	suite.verifyDomesticOtherPrice(unit.Cents(25030), contract.ID, true, "DDDSIT", 3)
+}
+
+func (suite *GHCRateEngineImportSuite) verifyDomesticOtherPrice(expected unit.Cents, contractID uuid.UUID, isPeakPeriod bool, serviceCode string, schedule int) {
+	var service models.ReService
+	err := suite.DB().Where("code = ?", serviceCode).First(&service)
+	suite.NoError(err)
+
+	var domesticOtherPrice models.ReDomesticOtherPrice
+	err = suite.DB().
+		Where("contract_id = ?", contractID).
+		Where("service_id = ?", service.ID).
+		Where("is_peak_period = ?", isPeakPeriod).
+		Where("schedule = ?", schedule).First(&domesticOtherPrice)
+	suite.NoError(err)
+	suite.Equal(expected, domesticOtherPrice.PriceCents)
+}


### PR DESCRIPTION
## Description

Parse the data in `stage_domestic_other_pack_prices` and `stage_domestic_other_sit_prices` and insert the data into the `re_domestic_other_prices` table.

## Reviewer Notes

The data should end up in `re_domestic_other_prices`. Note the SIT Pickup/Delivery prices are entered multiple times, once for Pickup and once for Delivery. Please spot check at least a few data points with your xlsx data. There should be 24 rows added

## Setup

Run the tests `make server_test`

Run the importer

```sh
rm -f bin/ghc-pricing-parser
make  bin/ghc-pricing-parser
ghc-pricing-parser --filename pkg/parser/pricing/fixtures/pricing_template_2019-09-19_fake-data.xlsx --contract-code=1234 --display
```

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/tree/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/tree/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [MB-714](https://dp3.atlassian.net/browse/MB-714) for this change