### PR TITLE
Don't allow short haul moves in SM workflow

### DIFF
--- a/pkg/gen/internalapi/embedded_spec.go
+++ b/pkg/gen/internalapi/embedded_spec.go
@@ -706,6 +706,9 @@ func init() {
           "404": {
             "description": "ppm discount not found for provided postal codes and original move date"
           },
+          "409": {
+            "description": "distance is less than 50 miles (no short haul moves)"
+          },
           "422": {
             "description": "cannot process request with given information"
           },
@@ -778,6 +781,9 @@ func init() {
           },
           "403": {
             "description": "user is not authorized"
+          },
+          "409": {
+            "description": "distance is less than 50 miles (no short haul moves)"
           },
           "500": {
             "description": "internal server error"
@@ -2285,6 +2291,9 @@ func init() {
           },
           "403": {
             "description": "user is not authorized"
+          },
+          "409": {
+            "description": "distance is less than 50 miles (no short haul moves)"
           },
           "500": {
             "description": "internal server error"
@@ -6891,6 +6900,9 @@ func init() {
           "404": {
             "description": "ppm discount not found for provided postal codes and original move date"
           },
+          "409": {
+            "description": "distance is less than 50 miles (no short haul moves)"
+          },
           "422": {
             "description": "cannot process request with given information"
           },
@@ -6963,6 +6975,9 @@ func init() {
           },
           "403": {
             "description": "user is not authorized"
+          },
+          "409": {
+            "description": "distance is less than 50 miles (no short haul moves)"
           },
           "500": {
             "description": "internal server error"
@@ -8470,6 +8485,9 @@ func init() {
           },
           "403": {
             "description": "user is not authorized"
+          },
+          "409": {
+            "description": "distance is less than 50 miles (no short haul moves)"
           },
           "500": {
             "description": "internal server error"

--- a/pkg/gen/internalapi/internaloperations/ppm/show_p_p_m_estimate_responses.go
+++ b/pkg/gen/internalapi/internaloperations/ppm/show_p_p_m_estimate_responses.go
@@ -153,6 +153,30 @@ func (o *ShowPPMEstimateNotFound) WriteResponse(rw http.ResponseWriter, producer
 	rw.WriteHeader(404)
 }
 
+// ShowPPMEstimateConflictCode is the HTTP code returned for type ShowPPMEstimateConflict
+const ShowPPMEstimateConflictCode int = 409
+
+/*ShowPPMEstimateConflict distance is less than 50 miles (no short haul moves)
+
+swagger:response showPPMEstimateConflict
+*/
+type ShowPPMEstimateConflict struct {
+}
+
+// NewShowPPMEstimateConflict creates ShowPPMEstimateConflict with default headers values
+func NewShowPPMEstimateConflict() *ShowPPMEstimateConflict {
+
+	return &ShowPPMEstimateConflict{}
+}
+
+// WriteResponse to the client
+func (o *ShowPPMEstimateConflict) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
+	rw.Header().Del(runtime.HeaderContentType) //Remove Content-Type on empty responses
+
+	rw.WriteHeader(409)
+}
+
 // ShowPPMEstimateUnprocessableEntityCode is the HTTP code returned for type ShowPPMEstimateUnprocessableEntity
 const ShowPPMEstimateUnprocessableEntityCode int = 422
 

--- a/pkg/gen/internalapi/internaloperations/ppm/show_p_p_m_incentive_responses.go
+++ b/pkg/gen/internalapi/internaloperations/ppm/show_p_p_m_incentive_responses.go
@@ -129,6 +129,30 @@ func (o *ShowPPMIncentiveForbidden) WriteResponse(rw http.ResponseWriter, produc
 	rw.WriteHeader(403)
 }
 
+// ShowPPMIncentiveConflictCode is the HTTP code returned for type ShowPPMIncentiveConflict
+const ShowPPMIncentiveConflictCode int = 409
+
+/*ShowPPMIncentiveConflict distance is less than 50 miles (no short haul moves)
+
+swagger:response showPPMIncentiveConflict
+*/
+type ShowPPMIncentiveConflict struct {
+}
+
+// NewShowPPMIncentiveConflict creates ShowPPMIncentiveConflict with default headers values
+func NewShowPPMIncentiveConflict() *ShowPPMIncentiveConflict {
+
+	return &ShowPPMIncentiveConflict{}
+}
+
+// WriteResponse to the client
+func (o *ShowPPMIncentiveConflict) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
+	rw.Header().Del(runtime.HeaderContentType) //Remove Content-Type on empty responses
+
+	rw.WriteHeader(409)
+}
+
 // ShowPPMIncentiveInternalServerErrorCode is the HTTP code returned for type ShowPPMIncentiveInternalServerError
 const ShowPPMIncentiveInternalServerErrorCode int = 500
 

--- a/pkg/gen/internalapi/internaloperations/ppm/show_p_p_m_sit_estimate_responses.go
+++ b/pkg/gen/internalapi/internaloperations/ppm/show_p_p_m_sit_estimate_responses.go
@@ -129,6 +129,30 @@ func (o *ShowPPMSitEstimateForbidden) WriteResponse(rw http.ResponseWriter, prod
 	rw.WriteHeader(403)
 }
 
+// ShowPPMSitEstimateConflictCode is the HTTP code returned for type ShowPPMSitEstimateConflict
+const ShowPPMSitEstimateConflictCode int = 409
+
+/*ShowPPMSitEstimateConflict distance is less than 50 miles (no short haul moves)
+
+swagger:response showPPMSitEstimateConflict
+*/
+type ShowPPMSitEstimateConflict struct {
+}
+
+// NewShowPPMSitEstimateConflict creates ShowPPMSitEstimateConflict with default headers values
+func NewShowPPMSitEstimateConflict() *ShowPPMSitEstimateConflict {
+
+	return &ShowPPMSitEstimateConflict{}
+}
+
+// WriteResponse to the client
+func (o *ShowPPMSitEstimateConflict) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
+	rw.Header().Del(runtime.HeaderContentType) //Remove Content-Type on empty responses
+
+	rw.WriteHeader(409)
+}
+
 // ShowPPMSitEstimateInternalServerErrorCode is the HTTP code returned for type ShowPPMSitEstimateInternalServerError
 const ShowPPMSitEstimateInternalServerErrorCode int = 500
 

--- a/pkg/handlers/errors.go
+++ b/pkg/handlers/errors.go
@@ -88,6 +88,8 @@ func ResponseForError(logger Logger, err error) middleware.Responder {
 		switch e.Code() {
 		case route.UnsupportedPostalCode, route.UnroutableRoute:
 			return newErrResponse(http.StatusUnprocessableEntity, err)
+		case route.ShortHaulError:
+			return newErrResponse(http.StatusConflict, err)
 		default:
 			return newErrResponse(http.StatusInternalServerError, err)
 		}

--- a/pkg/route/errors.go
+++ b/pkg/route/errors.go
@@ -20,6 +20,8 @@ const (
 	GeocodeResponseDecodingError ErrorCode = "GEOCODE_RESPONSE_DECODE_ERROR"
 	// RoutingResponseDecodingError happens when attempting to decode a routing response
 	RoutingResponseDecodingError ErrorCode = "ROUTING_RESPONSE_DECODE_ERROR"
+	// ShortHaulError - no moves under 50 miles
+	ShortHaulError ErrorCode = "SHORT_HAUL_ERROR"
 	// UnknownError is for when the cause of the error can't be ascertained
 	UnknownError ErrorCode = "UNKNOWN_ERROR"
 )
@@ -135,4 +137,20 @@ func NewRoutingResponseDecodingError(r RoutingResponseBody) Error {
 		baseError{RoutingResponseDecodingError},
 		r,
 	}
+}
+
+type shortHaulError struct {
+	baseError
+	distance int
+}
+
+func NewShortHaulError(moveDistance int) Error {
+	return &shortHaulError{
+		baseError{ShortHaulError},
+		moveDistance,
+	}
+}
+
+func (e *shortHaulError) Error() string {
+	return fmt.Sprintf("Unsupported short haul move distance (%d)", e.distance)
 }

--- a/pkg/route/errors.go
+++ b/pkg/route/errors.go
@@ -141,16 +141,16 @@ func NewRoutingResponseDecodingError(r RoutingResponseBody) Error {
 
 type shortHaulError struct {
 	baseError
-	distance int
+	routingInfo string
 }
 
-func NewShortHaulError(moveDistance int) Error {
+func NewShortHaulError(source LatLong, dest LatLong, moveDistance int) Error {
 	return &shortHaulError{
 		baseError{ShortHaulError},
-		moveDistance,
+		fmt.Sprintf("source: (%s), dest: (%s), distance: (%d)", source.Coords(), dest.Coords(), moveDistance),
 	}
 }
 
 func (e *shortHaulError) Error() string {
-	return fmt.Sprintf("Unsupported short haul move distance (%d)", e.distance)
+	return fmt.Sprintf("Unsupported short haul move distance: (error_code: (%s), routing_info: %s)", e.code, e.routingInfo)
 }

--- a/pkg/route/here_planner.go
+++ b/pkg/route/here_planner.go
@@ -195,9 +195,14 @@ func (p *herePlanner) LatLongTransitDistance(source LatLong, dest LatLong) (int,
 func (p *herePlanner) Zip5TransitDistance(source string, destination string) (int, error) {
 	distance, err := zip5TransitDistanceHelper(p, source, destination)
 	if err != nil {
-		p.logger.Error("Failed to calculate HERE route between ZIPs", zap.String("source", source), zap.String("destination", destination))
+		var msg string
+		if err.(Error).Code() == ShortHaulError {
+			msg = "Unsupported short haul move distance"
+		} else {
+			msg = "Failed to calculate HERE route between ZIPs"
+		}
+		p.logger.Error(msg, zap.String("source", source), zap.String("destination", destination), zap.Int("distance", distance))
 	}
-
 	return distance, err
 }
 

--- a/pkg/route/planner.go
+++ b/pkg/route/planner.go
@@ -59,7 +59,7 @@ func zip5TransitDistanceHelper(planner Planner, source string, destination strin
 		return 0, err
 	}
 	if distance < 50 {
-		err = NewShortHaulError(distance)
+		err = NewShortHaulError(sLL, dLL, distance)
 	}
 	return distance, err
 }

--- a/pkg/route/planner.go
+++ b/pkg/route/planner.go
@@ -54,7 +54,14 @@ func zip5TransitDistanceHelper(planner Planner, source string, destination strin
 	if err != nil {
 		return 0, err
 	}
-	return planner.LatLongTransitDistance(sLL, dLL)
+	distance, err := planner.LatLongTransitDistance(sLL, dLL)
+	if err != nil {
+		return 0, err
+	}
+	if distance < 50 {
+		err = NewShortHaulError(distance)
+	}
+	return distance, err
 }
 
 // Planner is the interface needed by Handlers to be able to evaluate the distance to be used for move accounting

--- a/pkg/route/planner_test.go
+++ b/pkg/route/planner_test.go
@@ -75,14 +75,28 @@ func (suite *PlannerFullSuite) TestAddressPlanner() {
 
 const bradyTXZip = "76825"
 const venturaCAZip = "93007"
+const fillmoreCAZip = "93015"
 
 func (suite *PlannerFullSuite) TestZip5Distance() {
-	distance, err := suite.planner.Zip5TransitDistance(bradyTXZip, venturaCAZip)
-	if err != nil {
-		suite.T().Errorf("Failed to get distance from Source - %v", err)
+	tests := []struct {
+		zip1        string
+		zip2        string
+		distanceMin int
+		distanceMax int
+	}{
+		{zip1: bradyTXZip, zip2: venturaCAZip, distanceMin: 1000, distanceMax: 3000},
+		{zip1: fillmoreCAZip, zip2: venturaCAZip, distanceMin: 30, distanceMax: 49},
 	}
-	if distance < 1000 || distance > 3000 {
-		suite.Fail("Implausible distance from TX to CA")
+	for _, ts := range tests {
+		distance, err := suite.planner.Zip5TransitDistance(ts.zip1, ts.zip2)
+		if ts.distanceMax < 50 {
+			suite.NotNil(err, "Should get error from Zip5 not number")
+		} else {
+			suite.NoError(err, "Failed to get distance from Source - %v", err)
+		}
+		if distance < ts.distanceMin || distance > ts.distanceMax {
+			suite.Fail("Implausible distance", "Implausible distance from %s to %s: %d", ts.zip1, ts.zip2, distance)
+		}
 	}
 }
 

--- a/src/scenes/Moves/Ppm/Weight.jsx
+++ b/src/scenes/Moves/Ppm/Weight.jsx
@@ -166,8 +166,12 @@ export class PpmWeight extends Component {
     this.setState({ [type]: event.target.value });
   };
 
+  hasShortHaulError(rateEngineError) {
+    return rateEngineError && rateEngineError.statusCode === 409 ? true : false;
+  }
+
   chooseEstimateErrorText(hasEstimateError, rateEngineError) {
-    if (rateEngineError != null) {
+    if (this.hasShortHaulError(rateEngineError)) {
       return (
         <Fragment>
           <div className="error-message">
@@ -225,7 +229,7 @@ export class PpmWeight extends Component {
                 hasEstimateInProgress,
                 incentive_estimate_max,
               }}
-              readyToSubmit={!rateEngineError}
+              readyToSubmit={!this.hasShortHaulError(rateEngineError)}
             >
               <h3>How much do you think you'll move?</h3>
               <p>Your weight entitlement: {this.props.entitlement.weight.toLocaleString()} lbs</p>
@@ -346,7 +350,7 @@ export class PpmWeight extends Component {
                 hasEstimateInProgress,
                 incentive_estimate_max,
               }}
-              readyToSubmit={!rateEngineError}
+              readyToSubmit={!this.hasShortHaulError(rateEngineError)}
             >
               {error && (
                 <div className="grid-row">

--- a/src/scenes/Moves/Ppm/Weight.jsx
+++ b/src/scenes/Moves/Ppm/Weight.jsx
@@ -167,7 +167,7 @@ export class PpmWeight extends Component {
   };
 
   chooseEstimateErrorText(hasEstimateError, rateEngineError) {
-    if (rateEngineError) {
+    if (rateEngineError != null) {
       return (
         <Fragment>
           <div className="error-message">

--- a/src/scenes/Moves/Ppm/Weight.jsx
+++ b/src/scenes/Moves/Ppm/Weight.jsx
@@ -183,7 +183,7 @@ export class PpmWeight extends Component {
       );
     }
 
-    if (hasEstimateError) {
+    if (rateEngineError || hasEstimateError) {
       return (
         <Fragment>
           <div className="error-message">

--- a/src/scenes/Moves/Ppm/Weight.jsx
+++ b/src/scenes/Moves/Ppm/Weight.jsx
@@ -166,6 +166,36 @@ export class PpmWeight extends Component {
     this.setState({ [type]: event.target.value });
   };
 
+  chooseEstimateErrorText(hasEstimateError, rateEngineError) {
+    if (rateEngineError) {
+      return (
+        <Fragment>
+          <div className="error-message">
+            <Alert type="warning" heading="Could not retrieve estimate">
+              MilMove does not presently support short-haul PPM moves. Please contact your PPPO.
+            </Alert>
+          </div>
+        </Fragment>
+      );
+    }
+
+    if (hasEstimateError) {
+      return (
+        <Fragment>
+          <div className="error-message">
+            <Alert type="warning" heading="Could not retrieve estimate">
+              There was an issue retrieving an estimate for your incentive. You still qualify, but need to talk with
+              your local transportation office which you can look up on{' '}
+              <a href="move.mil" className="usa-link">
+                move.mil
+              </a>
+            </Alert>
+          </div>
+        </Fragment>
+      );
+    }
+  }
+
   render() {
     const {
       incentive_estimate_min,
@@ -177,6 +207,7 @@ export class PpmWeight extends Component {
       error,
       hasEstimateError,
       selectedWeightInfo,
+      rateEngineError,
     } = this.props;
     const { context: { flags: { progearChanges } } = { flags: { progearChanges: null } } } = this.props;
     const { includesProgear, isProgearMoreThan1000 } = this.state;
@@ -209,20 +240,7 @@ export class PpmWeight extends Component {
                   stateChangeFunc={this.onWeightSelecting}
                   onChange={this.onWeightSelected}
                 />
-
-                {hasEstimateError && (
-                  <Fragment>
-                    <div className="error-message">
-                      <Alert type="warning" heading="Could not retrieve estimate">
-                        There was an issue retrieving an estimate for your incentive. You still qualify, but need to
-                        talk with your local transportation office which you can look up on{' '}
-                        <a href="move.mil" className="usa-link">
-                          move.mil
-                        </a>
-                      </Alert>
-                    </div>
-                  </Fragment>
-                )}
+                {this.chooseEstimateErrorText(hasEstimateError, rateEngineError)}
               </div>
               <div className={`${styles['incentive-estimate-box']} border radius-lg border-base`}>
                 {this.chooseVehicleIcon(this.state.pendingPpmWeight)}
@@ -357,19 +375,7 @@ export class PpmWeight extends Component {
                           }}
                         />
                       </div>
-                      {hasEstimateError && (
-                        <Fragment>
-                          <div className="error-message">
-                            <Alert type="warning" heading="Could not retrieve estimate">
-                              There was an issue retrieving an estimate for your incentive. You still qualify, but need
-                              to talk with your local transportation office which you can look up on{' '}
-                              <a href="move.mil" className="usa-link">
-                                move.mil
-                              </a>
-                            </Alert>
-                          </div>
-                        </Fragment>
-                      )}
+                      {this.chooseEstimateErrorText(hasEstimateError, rateEngineError)}
                       <table className="numeric-info">
                         <tbody>
                           <tr>

--- a/src/scenes/Moves/Ppm/Weight.jsx
+++ b/src/scenes/Moves/Ppm/Weight.jsx
@@ -225,6 +225,7 @@ export class PpmWeight extends Component {
                 hasEstimateInProgress,
                 incentive_estimate_max,
               }}
+              readyToSubmit={!rateEngineError}
             >
               <h3>How much do you think you'll move?</h3>
               <p>Your weight entitlement: {this.props.entitlement.weight.toLocaleString()} lbs</p>
@@ -345,6 +346,7 @@ export class PpmWeight extends Component {
                 hasEstimateInProgress,
                 incentive_estimate_max,
               }}
+              readyToSubmit={!rateEngineError}
             >
               {error && (
                 <div className="grid-row">

--- a/src/scenes/Moves/Ppm/Weight.test.js
+++ b/src/scenes/Moves/Ppm/Weight.test.js
@@ -1,0 +1,43 @@
+import React from 'react';
+import { PpmWeight } from './Weight';
+import { shallow } from 'enzyme';
+
+describe('Weight', () => {
+  describe('Incentive estimate errors', () => {
+    let wrapper;
+    const props = {
+      selectedWeightInfo: { min: 500, max: 1000 },
+      hasLoadSuccess: true,
+    };
+    beforeEach(() => {
+      props.rateEngineError = undefined;
+      props.hasEstimateError = undefined;
+    });
+    it('Should not show an estimate error', () => {
+      wrapper = shallow(<PpmWeight {...props} />);
+      expect(wrapper.find('.error-message').exists()).toBe(false);
+    });
+    it('Should show short haul error', () => {
+      props.rateEngineError = true;
+      wrapper = shallow(<PpmWeight {...props} />);
+      expect(wrapper.find('.error-message').exists()).toBe(true);
+      expect(
+        wrapper
+          .find('Alert')
+          .dive()
+          .text(),
+      ).toMatch(/MilMove does not presently support short-haul PPM moves. Please contact your PPPO./);
+    });
+    it('Should show estimate not retrieved error', () => {
+      props.hasEstimateError = true;
+      wrapper = shallow(<PpmWeight {...props} />);
+      expect(wrapper.find('.error-message').exists()).toBe(true);
+      expect(
+        wrapper
+          .find('Alert')
+          .dive()
+          .text(),
+      ).toMatch(/There was an issue retrieving an estimate for your incentive./);
+    });
+  });
+});

--- a/src/scenes/Moves/Ppm/Weight.test.js
+++ b/src/scenes/Moves/Ppm/Weight.test.js
@@ -7,7 +7,7 @@ describe('Weight', () => {
     selectedWeightInfo: { min: 0, max: 0 },
     hasLoadSuccess: true,
   };
-  it('Renders', () => {
+  it('Component renders', () => {
     expect(shallow(<PpmWeight {...minProps} />).length).toEqual(1);
   });
   describe('Incentive estimate errors', () => {
@@ -15,8 +15,9 @@ describe('Weight', () => {
     it('Should not show an estimate error', () => {
       wrapper = shallow(<PpmWeight {...minProps} />);
       expect(wrapper.find('.error-message').exists()).toBe(false);
+      expect(wrapper.find('ReduxForm').props().readyToSubmit).toEqual(true); // able to continue - just a prob getting estimate
     });
-    it('Should show short haul error', () => {
+    it('Should show short haul error and next button disabled', () => {
       wrapper = shallow(<PpmWeight {...minProps} rateEngineError={true} />);
       expect(wrapper.find('.error-message').exists()).toBe(true);
       expect(
@@ -25,6 +26,7 @@ describe('Weight', () => {
           .dive()
           .text(),
       ).toMatch(/MilMove does not presently support short-haul PPM moves. Please contact your PPPO./);
+      expect(wrapper.find('ReduxForm').props().readyToSubmit).toEqual(false); // next button should be disabled
     });
     it('Should show estimate not retrieved error', () => {
       wrapper = shallow(<PpmWeight {...minProps} hasEstimateError={true} />);
@@ -35,6 +37,7 @@ describe('Weight', () => {
           .dive()
           .text(),
       ).toMatch(/There was an issue retrieving an estimate for your incentive./);
+      expect(wrapper.find('ReduxForm').props().readyToSubmit).toEqual(true); // able to continue - just a prob getting estimate
     });
   });
 });

--- a/src/scenes/Moves/Ppm/Weight.test.js
+++ b/src/scenes/Moves/Ppm/Weight.test.js
@@ -15,18 +15,33 @@ describe('Weight', () => {
     it('Should not show an estimate error', () => {
       wrapper = shallow(<PpmWeight {...minProps} />);
       expect(wrapper.find('.error-message').exists()).toBe(false);
-      expect(wrapper.find('ReduxForm').props().readyToSubmit).toEqual(true); // able to continue - just a prob getting estimate
+      expect(wrapper.find('ReduxForm').props().readyToSubmit).toEqual(true);
     });
-    it('Should show short haul error and next button disabled', () => {
-      wrapper = shallow(<PpmWeight {...minProps} rateEngineError={true} />);
-      expect(wrapper.find('.error-message').exists()).toBe(true);
-      expect(
-        wrapper
-          .find('Alert')
-          .dive()
-          .text(),
-      ).toMatch(/MilMove does not presently support short-haul PPM moves. Please contact your PPPO./);
-      expect(wrapper.find('ReduxForm').props().readyToSubmit).toEqual(false); // next button should be disabled
+    describe('Short Haul Error', () => {
+      it('Should show short haul error and next button disabled', () => {
+        wrapper = shallow(<PpmWeight {...minProps} rateEngineError={{ statusCode: 409 }} />);
+        expect(wrapper.find('.error-message').exists()).toBe(true);
+        expect(
+          wrapper
+            .find('Alert')
+            .dive()
+            .text(),
+        ).toMatch(/MilMove does not presently support short-haul PPM moves. Please contact your PPPO./);
+        expect(wrapper.find('ReduxForm').props().readyToSubmit).toEqual(false); // next button should be disabled
+      });
+    });
+    describe('No rate data error', () => {
+      it('Should show estimate error and next button not disabled', () => {
+        wrapper = shallow(<PpmWeight {...minProps} rateEngineError={{ statusCode: 404 }} />);
+        expect(wrapper.find('.error-message').exists()).toBe(true);
+        expect(
+          wrapper
+            .find('Alert')
+            .dive()
+            .text(),
+        ).toMatch(/There was an issue retrieving an estimate for your incentive./);
+        expect(wrapper.find('ReduxForm').props().readyToSubmit).toEqual(true);
+      });
     });
     it('Should show estimate not retrieved error', () => {
       wrapper = shallow(<PpmWeight {...minProps} hasEstimateError={true} />);
@@ -37,7 +52,7 @@ describe('Weight', () => {
           .dive()
           .text(),
       ).toMatch(/There was an issue retrieving an estimate for your incentive./);
-      expect(wrapper.find('ReduxForm').props().readyToSubmit).toEqual(true); // able to continue - just a prob getting estimate
+      expect(wrapper.find('ReduxForm').props().readyToSubmit).toEqual(true);
     });
   });
 });

--- a/src/scenes/Moves/Ppm/Weight.test.js
+++ b/src/scenes/Moves/Ppm/Weight.test.js
@@ -3,23 +3,21 @@ import { PpmWeight } from './Weight';
 import { shallow } from 'enzyme';
 
 describe('Weight', () => {
+  const minProps = {
+    selectedWeightInfo: { min: 0, max: 0 },
+    hasLoadSuccess: true,
+  };
+  it('Renders', () => {
+    expect(shallow(<PpmWeight {...minProps} />).length).toEqual(1);
+  });
   describe('Incentive estimate errors', () => {
     let wrapper;
-    const props = {
-      selectedWeightInfo: { min: 500, max: 1000 },
-      hasLoadSuccess: true,
-    };
-    beforeEach(() => {
-      props.rateEngineError = undefined;
-      props.hasEstimateError = undefined;
-    });
     it('Should not show an estimate error', () => {
-      wrapper = shallow(<PpmWeight {...props} />);
+      wrapper = shallow(<PpmWeight {...minProps} />);
       expect(wrapper.find('.error-message').exists()).toBe(false);
     });
     it('Should show short haul error', () => {
-      props.rateEngineError = true;
-      wrapper = shallow(<PpmWeight {...props} />);
+      wrapper = shallow(<PpmWeight {...minProps} rateEngineError={true} />);
       expect(wrapper.find('.error-message').exists()).toBe(true);
       expect(
         wrapper
@@ -29,8 +27,7 @@ describe('Weight', () => {
       ).toMatch(/MilMove does not presently support short-haul PPM moves. Please contact your PPPO./);
     });
     it('Should show estimate not retrieved error', () => {
-      props.hasEstimateError = true;
-      wrapper = shallow(<PpmWeight {...props} />);
+      wrapper = shallow(<PpmWeight {...minProps} hasEstimateError={true} />);
       expect(wrapper.find('.error-message').exists()).toBe(true);
       expect(
         wrapper

--- a/src/scenes/Review/EditWeight.jsx
+++ b/src/scenes/Review/EditWeight.jsx
@@ -241,6 +241,33 @@ class EditWeight extends Component {
       });
   };
 
+  chooseEstimateErrorText(hasEstimateError, rateEngineError) {
+    if (rateEngineError) {
+      return (
+        <div className="grid-row">
+          <div className="usa-width-one-whole error-message">
+            <Alert type="warning" heading="Could not retrieve estimate">
+              MilMove does not presently support short-haul PPM moves. Please contact your PPPO.
+            </Alert>
+          </div>
+        </div>
+      );
+    }
+
+    if (hasEstimateError) {
+      return (
+        <div className="grid-row">
+          <div className="usa-width-one-whole error-message">
+            <Alert type="warning" heading="Could not retrieve estimate">
+              There was an issue retrieving an estimate for your incentive. You still qualify but may need to talk with
+              your local PPPO.
+            </Alert>
+          </div>
+        </div>
+      );
+    }
+  }
+
   render() {
     const {
       error,
@@ -250,6 +277,7 @@ class EditWeight extends Component {
       incentive_estimate_min,
       incentive_estimate_max,
       hasEstimateError,
+      rateEngineError,
     } = this.props;
 
     return (
@@ -263,16 +291,7 @@ class EditWeight extends Component {
             </div>
           </div>
         )}
-        {hasEstimateError && (
-          <div className="grid-row">
-            <div className="usa-width-one-whole error-message">
-              <Alert type="warning" heading="Could not retrieve estimate">
-                There was an issue retrieving an estimate for your incentive. You still qualify but may need to talk
-                with your local PPPO.
-              </Alert>
-            </div>
-          </div>
-        )}
+        {this.chooseEstimateErrorText(hasEstimateError, rateEngineError)}
         <div className="grid-row">
           <div className="grid-col-12">
             <EditWeightForm

--- a/src/scenes/Review/EditWeight.jsx
+++ b/src/scenes/Review/EditWeight.jsx
@@ -245,7 +245,7 @@ class EditWeight extends Component {
     if (rateEngineError) {
       return (
         <div className="grid-row">
-          <div className="usa-width-one-whole error-message">
+          <div className="grid-col-12 error-message">
             <Alert type="warning" heading="Could not retrieve estimate">
               MilMove does not presently support short-haul PPM moves. Please contact your PPPO.
             </Alert>
@@ -257,7 +257,7 @@ class EditWeight extends Component {
     if (hasEstimateError) {
       return (
         <div className="grid-row">
-          <div className="usa-width-one-whole error-message">
+          <div className="grid-col-12 error-message">
             <Alert type="warning" heading="Could not retrieve estimate">
               There was an issue retrieving an estimate for your incentive. You still qualify but may need to talk with
               your local PPPO.
@@ -291,7 +291,13 @@ class EditWeight extends Component {
             </div>
           </div>
         )}
-        {this.chooseEstimateErrorText(hasEstimateError, rateEngineError)}
+
+        <div className="grid-container usa-prose">
+          <div className="grid-row">
+            <div className="grid-col-12">{this.chooseEstimateErrorText(hasEstimateError, rateEngineError)}</div>
+          </div>
+        </div>
+
         <div className="grid-row">
           <div className="grid-col-12">
             <EditWeightForm

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -2550,6 +2550,8 @@ paths:
           description: user is not authorized
         404:
           description: ppm discount not found for provided postal codes and original move date
+        409:
+          description: distance is less than 50 miles (no short haul moves)
         422:
           description: cannot process request with given information
         500:
@@ -2600,6 +2602,8 @@ paths:
           description: request requires user authentication
         403:
           description: user is not authorized
+        409:
+          description: distance is less than 50 miles (no short haul moves)
         500:
           description: internal server error
   /users/logged_in:
@@ -3744,6 +3748,8 @@ paths:
           description: request requires user authentication
         403:
           description: user is not authorized
+        409:
+          description: distance is less than 50 miles (no short haul moves)
         500:
           description: internal server error
   /documents:


### PR DESCRIPTION
## Description

Milmove should not allow short haul moves (moves under 50 miles). If a move is under 50 miles, warn the user and prevent the user from continuing.

## Reviewer Notes

This pr prevents the user from submitting the move via the "workflow" but a SM could leave the move, and come back and submit the move from the review screen... Splitting that work out from this pr as service members are submitting short haul moves in production which is causing issues. Get this change in and then work on disallowing all short haul moves from being submitted.

It might be nice to alert the SM earlier in flow process if their move is short haul, but currently we don't calculate the move distance till we try and calculate the estimate...

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

`make db_dev_e2e_populate`
`make server_run`
`make client_run`

login using local user: `needs@orde.rs (milmove)` 
continue move...
hit back button till you can adjust the SMs current duty station. Update it to be `JB Myer-Henderson Hall`
continue move setup and enter destination duty station: `Fort Belvoir`
continue move and on weight selection screen you should see warning and not be able to continue.
(Henderson Hall and Fort Belvoir are < 50 miles apart)

## Code Review Verification Steps

* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-1242?atlOrigin=eyJpIjoiN2U4MDc5OTRlZTljNDBkY2E1Y2VmNTg5ZjdkYmRlMGMiLCJwIjoiaiJ9) for this change

## Screenshots

![Screen Shot 2020-01-13 at 12 03 47 PM](https://user-images.githubusercontent.com/3099491/72285320-7d6aa200-3608-11ea-96d3-03e8d71453e2.png)


<img width="944" alt="Screen Shot 2020-01-13 at 1 40 52 PM" src="https://user-images.githubusercontent.com/3099491/72286277-6dec5880-360a-11ea-95eb-341e77844406.png">


<img width="943" alt="Screen Shot 2020-01-13 at 2 43 09 PM" src="https://user-images.githubusercontent.com/3099491/72292475-12749780-3617-11ea-93b5-b70afde8f5a7.png">
