### PR TITLE
Update docs to prefer scan-alb-logs and also to fix bad command

### DIFF
--- a/docs/how-to/search-for-application-errors.md
+++ b/docs/how-to/search-for-application-errors.md
@@ -41,6 +41,14 @@ A simple way to scan the logs is to use a helpful script we've built:
 ../scripts/scan-alb-logs staging 500 2019/01/09,2019/01/10
 ```
 
+You can be more specific with particular domains:
+
+```sh
+../scripts/scan-alb-logs staging 500 2019/01/09,2019/01/10 office.move.mil
+```
+
+**NOTE:** You cannot specify date ranges! You must specify each individual date.
+
 ### More in depth scanning
 
 If you want more control over the results you can continue here OR you can move on to the next section about understanding

--- a/docs/how-to/search-for-application-errors.md
+++ b/docs/how-to/search-for-application-errors.md
@@ -14,7 +14,8 @@ Searching for errors from the application can be difficult.  Here is a playbook 
 Watch [a video of searching ALB errors](https://zoom.us/recording/play/2DGo7KYqrvSAYvvEo2--zG_xx93K0ALUMLHJVXJl0X9WRo0lxkXXLAxp8IPHHDA8)
 to see how this is done in real time.
 
-**NOTE:** ALB logs are only stored in AWS S3, so the only method to search them is to download locally and search via the command line.
+**NOTE:** ALB logs are only stored in AWS S3. You can search them by downloading them locally and searching via the
+command line with the tools below or by using AWS Athena in the AWS Console.
 
 Often we'll see 500 errors from the application that trigger the `alb-staging-target-5xx-limit` alarm on the ALB.
 The text is not super helpful:
@@ -34,10 +35,20 @@ Link to Alarm
 https://console.aws.amazon.com/cloudwatch/home?region=us-west-2#alarm:alarmFilter=ANY;name=alb-staging-target-5xx-limit
 ```
 
+A simple way to scan the logs is to use a helpful script we've built:
+
+```sh
+../scripts/scan-alb-logs staging 500 2019/01/09,2019/01/10
+```
+
+### More in depth scanning
+
+If you want more control over the results you can continue here OR you can move on to the next section about understanding
+ALB log entries.
+
 You can download ALB logs for a specific date by using our `download-alb-logs` command line tool with:
 
 ```sh
-cd transcom-ppp
 ../scripts/download-alb-logs tmp prod 2019/01/09,2019/01/10
 ```
 
@@ -54,7 +65,7 @@ Then search for the errors in the ALB logs using `big-cat`, `gunzip`, `read-alb-
 ```sh
 make build_tools
 export http_code=500
-big-cat ./tmp/*.log.gz | gunzip | read-alb-logs | jq ". | select( .elbStatusCode | startswith(\"${http_code}\")) | {timestamp, clientPort, elbStatusCode, targetStatusCode, request, actionsExecuted}"
+big-cat './tmp/*.log.gz' | gunzip | read-alb-logs | jq ". | select( .elbStatusCode | startswith(\"${http_code}\")) | {timestamp, clientPort, elbStatusCode, targetStatusCode, request, actionsExecuted}"
 ```
 
 And you'll see events like this:
@@ -79,13 +90,6 @@ And you'll see events like this:
 ```
 
 You can use any `jq` filter you want on the output data like filtering on timestamp.
-
-A simpler way to scan the logs is to use a helpful script we've built:
-
-```sh
-cd transcom-ppp
-../scripts/scan-alb-logs staging 500 2019/01/09
-```
 
 #### Understanding ALB Log Entries
 

--- a/scripts/download-alb-logs
+++ b/scripts/download-alb-logs
@@ -13,6 +13,8 @@ set -eu -o pipefail
 #
 # Note: Must run from transcom-ppp/ directory
 #
+# Note: Each date must be specified, not a date range!
+#
 
 [[ $# -ne 3 ]] && echo "Usage: download-alb-logs <dest> <environment:prod|staging|experimental> [<day:YYYY/mm/dd>[,<day:YYYY/mm/dd>]]" && exit 1
 

--- a/scripts/scan-alb-logs
+++ b/scripts/scan-alb-logs
@@ -23,14 +23,15 @@ set -eu -o pipefail
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 readonly DIR
 
-if [[  $# -lt 2 ]]  || [[ $# -gt 3 ]]; then
-    echo "Usage: scan-alb-logs <environment:prod|staging|experimental> <http-code> [<day:YYYY/mm/dd>[,<day:YYYY/mm/dd>]]"
+if [[  $# -lt 2 ]]  || [[ $# -gt 4 ]]; then
+    echo "Usage: scan-alb-logs <environment:prod|staging|experimental> <http-code> [<day:YYYY/mm/dd>[,<day:YYYY/mm/dd>]] [domainName]"
     exit 1
 fi
 
 readonly environment=${1:-}
 readonly http_code=${2:-}
 day=${3:-$(date -u "+%Y/%m/%d")}
+domainName=${4:-}
 
 if ! command -v big-cat > /dev/null; then
   echo "big-cat tool is required."
@@ -46,4 +47,8 @@ fi
 
 rm -rf tmp
 "${DIR}/download-alb-logs" tmp "${environment}" "${day}"
-big-cat "./tmp/*.app-${environment}.*.log.gz" | gunzip | read-alb-logs | jq -c ". | select( .elbStatusCode | startswith(\"${http_code}\")) | {timestamp, clientPort, elbStatusCode, targetStatusCode, request, actionsExecuted}"
+if [[ -n "${domainName}" ]]; then
+  big-cat "./tmp/*.app-${environment}.*.log.gz" | gunzip | read-alb-logs | jq -c ". | select( .elbStatusCode | startswith(\"${http_code}\")) | select(.domainName | startswith(\"${domainName}\")) | {requestType, timestamp, clientPort, elbStatusCode, targetStatusCode, domainName, request, actionsExecuted}"
+else
+  big-cat "./tmp/*.app-${environment}.*.log.gz" | gunzip | read-alb-logs | jq -c ". | select( .elbStatusCode | startswith(\"${http_code}\")) | {requestType, timestamp, clientPort, elbStatusCode, targetStatusCode, domainName, request, actionsExecuted}"
+fi


### PR DESCRIPTION
## Description

A few small fixes to the docs after reviewing a bug in production.

Try this:

```
scan-alb-logs prod 403 2020/01/06,2020/01/07,2020/01/08 office.move.mil
```