### PR TITLE
MB-608 ma add role name column to Roles table

### DIFF
--- a/migrations/20200109025141_add_names_to_roles_table.up.sql
+++ b/migrations/20200109025141_add_names_to_roles_table.up.sql
@@ -1,0 +1,41 @@
+ALTER TABLE roles
+    ADD COLUMN role_name VARCHAR(255);
+
+UPDATE
+    roles
+SET
+    role_name = 'Customer'
+WHERE
+    role_type = 'customer';
+
+UPDATE
+    roles
+SET
+    role_name = 'Transporation Ordering Officer'
+WHERE
+    role_type = 'transportation_ordering_officer';
+
+UPDATE
+    roles
+SET
+    role_name = 'Transporation Invoicing Officer'
+WHERE
+    role_type = 'transportation_invoicing_officer';
+
+UPDATE
+    roles
+SET
+    role_name = 'Contracting Officer'
+WHERE
+    role_type = 'contracting_officer';
+
+UPDATE
+    roles
+SET
+    role_name = 'PPP Office User'
+WHERE
+    role_type = 'ppm_office_users';
+
+ALTER TABLE roles
+    ALTER COLUMN role_name SET NOT NULL;
+

--- a/migrations_manifest.txt
+++ b/migrations_manifest.txt
@@ -425,3 +425,4 @@
 20191227144832_add_has_progear_to_personally_procured_moves.up.sql
 20191229183600_add_top_tsp_for_ppms.up.sql
 20191229234501_import_rates_jan_2020.up.sql
+20200109025141_add_names_to_roles_table.up.sql

--- a/pkg/auth/authentication/authgch_test.go
+++ b/pkg/auth/authentication/authgch_test.go
@@ -334,10 +334,12 @@ func (suite *AuthSuite) TestVerifyHasTOORole() {
 	rs := []roles.Role{{
 		ID:       uuid.FromStringOrNil("ed2d2cd7-d427-412a-98bb-a9b391d98d32"),
 		RoleType: roles.RoleTypeCustomer,
+		RoleName: "Customer",
 	},
 		{
 			ID:       uuid.FromStringOrNil("9dc423b6-33b8-493a-a59b-6a823660cb07"),
 			RoleType: roles.RoleTypeTOO,
+			RoleName: "Transportation Ordering Officer",
 		},
 	}
 	suite.NoError(suite.DB().Create(&rs))

--- a/pkg/models/roles/roles.go
+++ b/pkg/models/roles/roles.go
@@ -11,6 +11,7 @@ import (
 
 // Role is an object representing the types of users who can authenticate in the admin app
 type RoleType string
+type RoleName string
 
 const (
 	RoleTypeTOO                RoleType = "transportation_ordering_officer"
@@ -23,6 +24,7 @@ const (
 type Role struct {
 	ID        uuid.UUID `json:"id" db:"id"`
 	RoleType  RoleType  `json:"role_type" db:"role_type"`
+	RoleName  RoleName  `json:"role_name" db:"role_name"`
 	CreatedAt time.Time `json:"created_at" db:"created_at"`
 	UpdatedAt time.Time `json:"updated_at" db:"updated_at"`
 }


### PR DESCRIPTION
## Description

We're giving admin users the ability to assign roles to users, and putting human-readable role names in the db will give us a source of truth for the full name, as well as making it trivial to show those names on the front end.  This PR precedes the full PR which will introduce the role-assigning functionality, so that that work can take advantage of the role names.


## Setup

```sh
make db_dev_reset db_dev_migrate
```

## Code Review Verification Steps

The `roles` table should have a `role_name` column populated with UI-friendly translations of the `role_type`.

## Screenshots

![image](https://user-images.githubusercontent.com/8964335/72036491-9c5fe180-3260-11ea-8851-d67524fe4529.png)

