### PR TITLE
Add entitlements fields to MTO view

### DIFF
--- a/migrations/20200109170045_remove_entitlments_columns.up.sql
+++ b/migrations/20200109170045_remove_entitlments_columns.up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE entitlements
+    DROP COLUMN pro_gear_weight_spouse,
+    DROP COLUMN pro_gear_weight;

--- a/migrations/20200109182812_add_authorized_weight_columns.up.sql
+++ b/migrations/20200109182812_add_authorized_weight_columns.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE entitlements
+    ADD authorized_weight int;

--- a/migrations_manifest.txt
+++ b/migrations_manifest.txt
@@ -426,3 +426,4 @@
 20191229183600_add_top_tsp_for_ppms.up.sql
 20191229234501_import_rates_jan_2020.up.sql
 20200109170045_remove_entitlments_columns.up.sql
+20200109182812_add_authorized_weight_columns.up.sql

--- a/migrations_manifest.txt
+++ b/migrations_manifest.txt
@@ -425,3 +425,4 @@
 20191227144832_add_has_progear_to_personally_procured_moves.up.sql
 20191229183600_add_top_tsp_for_ppms.up.sql
 20191229234501_import_rates_jan_2020.up.sql
+20200109170045_remove_entitlments_columns.up.sql

--- a/pkg/gen/ghcapi/embedded_spec.go
+++ b/pkg/gen/ghcapi/embedded_spec.go
@@ -1663,6 +1663,11 @@ func init() {
         "totalDependents": {
           "type": "integer",
           "example": 2
+        },
+        "totalWeight": {
+          "type": "integer",
+          "x-formatting": "weight",
+          "example": 500
         }
       }
     },
@@ -4033,6 +4038,11 @@ func init() {
         "totalDependents": {
           "type": "integer",
           "example": 2
+        },
+        "totalWeight": {
+          "type": "integer",
+          "x-formatting": "weight",
+          "example": 500
         }
       }
     },

--- a/pkg/gen/ghcapi/embedded_spec.go
+++ b/pkg/gen/ghcapi/embedded_spec.go
@@ -1626,6 +1626,12 @@ func init() {
     "Entitlements": {
       "type": "object",
       "properties": {
+        "authorizedWeight": {
+          "type": "integer",
+          "x-formatting": "weight",
+          "x-nullable": true,
+          "example": 2000
+        },
         "dependentsAuthorized": {
           "type": "boolean",
           "x-nullable": true,
@@ -4001,6 +4007,12 @@ func init() {
     "Entitlements": {
       "type": "object",
       "properties": {
+        "authorizedWeight": {
+          "type": "integer",
+          "x-formatting": "weight",
+          "x-nullable": true,
+          "example": 2000
+        },
         "dependentsAuthorized": {
           "type": "boolean",
           "x-nullable": true,

--- a/pkg/gen/ghcmessages/entitlements.go
+++ b/pkg/gen/ghcmessages/entitlements.go
@@ -17,6 +17,9 @@ import (
 // swagger:model Entitlements
 type Entitlements struct {
 
+	// authorized weight
+	AuthorizedWeight *int64 `json:"authorizedWeight,omitempty"`
+
 	// dependents authorized
 	DependentsAuthorized *bool `json:"dependentsAuthorized,omitempty"`
 

--- a/pkg/gen/ghcmessages/entitlements.go
+++ b/pkg/gen/ghcmessages/entitlements.go
@@ -41,6 +41,9 @@ type Entitlements struct {
 
 	// total dependents
 	TotalDependents int64 `json:"totalDependents,omitempty"`
+
+	// total weight
+	TotalWeight int64 `json:"totalWeight,omitempty"`
 }
 
 // Validate validates this entitlements

--- a/pkg/gen/primeapi/embedded_spec.go
+++ b/pkg/gen/primeapi/embedded_spec.go
@@ -884,6 +884,11 @@ func init() {
         "totalDependents": {
           "type": "integer",
           "example": 2
+        },
+        "totalWeight": {
+          "type": "integer",
+          "x-formatting": "weight",
+          "example": 500
         }
       }
     },
@@ -2102,6 +2107,11 @@ func init() {
         "totalDependents": {
           "type": "integer",
           "example": 2
+        },
+        "totalWeight": {
+          "type": "integer",
+          "x-formatting": "weight",
+          "example": 500
         }
       }
     },

--- a/pkg/gen/primeapi/embedded_spec.go
+++ b/pkg/gen/primeapi/embedded_spec.go
@@ -847,6 +847,12 @@ func init() {
     "Entitlements": {
       "type": "object",
       "properties": {
+        "authorizedWeight": {
+          "type": "integer",
+          "x-formatting": "weight",
+          "x-nullable": true,
+          "example": 2000
+        },
         "dependentsAuthorized": {
           "type": "boolean",
           "x-nullable": true,
@@ -2070,6 +2076,12 @@ func init() {
     "Entitlements": {
       "type": "object",
       "properties": {
+        "authorizedWeight": {
+          "type": "integer",
+          "x-formatting": "weight",
+          "x-nullable": true,
+          "example": 2000
+        },
         "dependentsAuthorized": {
           "type": "boolean",
           "x-nullable": true,

--- a/pkg/gen/primemessages/entitlements.go
+++ b/pkg/gen/primemessages/entitlements.go
@@ -17,6 +17,9 @@ import (
 // swagger:model Entitlements
 type Entitlements struct {
 
+	// authorized weight
+	AuthorizedWeight *int64 `json:"authorizedWeight,omitempty"`
+
 	// dependents authorized
 	DependentsAuthorized *bool `json:"dependentsAuthorized,omitempty"`
 

--- a/pkg/gen/primemessages/entitlements.go
+++ b/pkg/gen/primemessages/entitlements.go
@@ -41,6 +41,9 @@ type Entitlements struct {
 
 	// total dependents
 	TotalDependents int64 `json:"totalDependents,omitempty"`
+
+	// total weight
+	TotalWeight int64 `json:"totalWeight,omitempty"`
 }
 
 // Validate validates this entitlements

--- a/pkg/handlers/ghcapi/move_order_test.go
+++ b/pkg/handlers/ghcapi/move_order_test.go
@@ -49,9 +49,10 @@ func (suite *HandlerSuite) TestGetMoveOrderHandlerIntegration() {
 	suite.Equal(uuidTostrfmtUUID(moveOrder.EntitlementID), payloadEntitlement.ID)
 	moveOrderEntitlement := moveOrder.Entitlement
 	suite.NotNil(moveOrderEntitlement)
-	suite.Equal(int64(moveOrderEntitlement.ProGearWeight), payloadEntitlement.ProGearWeight)
-	suite.Equal(int64(moveOrderEntitlement.ProGearWeightSpouse), payloadEntitlement.ProGearWeightSpouse)
-	suite.Equal(int64(moveOrderEntitlement.TotalWeightSelf), payloadEntitlement.TotalWeight)
+	suite.Equal(int64(moveOrderEntitlement.WeightAllotment().ProGearWeight), payloadEntitlement.ProGearWeight)
+	suite.Equal(int64(moveOrderEntitlement.WeightAllotment().ProGearWeightSpouse), payloadEntitlement.ProGearWeightSpouse)
+	suite.Equal(int64(moveOrderEntitlement.WeightAllotment().TotalWeightSelf), payloadEntitlement.TotalWeight)
+	suite.Equal(int64(*moveOrderEntitlement.AuthorizedWeight()), *payloadEntitlement.AuthorizedWeight)
 	suite.Equal(uuidTostrfmtUUID(moveOrder.OriginDutyStation.ID), moveOrdersPayload.OriginDutyStation.ID)
 	suite.NotZero(moveOrder.OriginDutyStation)
 }

--- a/pkg/handlers/ghcapi/move_order_test.go
+++ b/pkg/handlers/ghcapi/move_order_test.go
@@ -45,8 +45,13 @@ func (suite *HandlerSuite) TestGetMoveOrderHandlerIntegration() {
 	suite.Equal(uuidTostrfmtUUID(moveOrder.CustomerID), moveOrdersPayload.CustomerID)
 	suite.Equal(uuidTostrfmtUUID(moveOrder.DestinationDutyStationID), moveOrdersPayload.DestinationDutyStation.ID)
 	suite.NotZero(moveOrder.DestinationDutyStation)
-	suite.Equal(uuidTostrfmtUUID(moveOrder.EntitlementID), moveOrdersPayload.Entitlement.ID)
-	suite.NotZero(moveOrder.Entitlement)
+	payloadEntitlement := moveOrdersPayload.Entitlement
+	suite.Equal(uuidTostrfmtUUID(moveOrder.EntitlementID), payloadEntitlement.ID)
+	moveOrderEntitlement := moveOrder.Entitlement
+	suite.NotNil(moveOrderEntitlement)
+	suite.Equal(int64(moveOrderEntitlement.ProGearWeight), payloadEntitlement.ProGearWeight)
+	suite.Equal(int64(moveOrderEntitlement.ProGearWeightSpouse), payloadEntitlement.ProGearWeightSpouse)
+	suite.Equal(int64(moveOrderEntitlement.TotalWeightSelf), payloadEntitlement.TotalWeight)
 	suite.Equal(uuidTostrfmtUUID(moveOrder.OriginDutyStation.ID), moveOrdersPayload.OriginDutyStation.ID)
 	suite.NotZero(moveOrder.OriginDutyStation)
 }

--- a/pkg/models/ghc_entitlements.go
+++ b/pkg/models/ghc_entitlements.go
@@ -13,8 +13,7 @@ type Entitlement struct {
 	TotalDependents       *int      `db:"total_dependents"`
 	NonTemporaryStorage   *bool     `db:"non_temporary_storage"`
 	PrivatelyOwnedVehicle *bool     `db:"privately_owned_vehicle"`
-	ProGearWeight         *int      `db:"pro_gear_weight"`
-	ProGearWeightSpouse   *int      `db:"pro_gear_weight_spouse"`
+	*WeightAllotment      `db:"-"`
 	StorageInTransit      *int      `db:"storage_in_transit"`
 	CreatedAt             time.Time `db:"created_at"`
 	UpdatedAt             time.Time `db:"updated_at"`

--- a/pkg/models/ghc_entitlements.go
+++ b/pkg/models/ghc_entitlements.go
@@ -8,13 +8,39 @@ import (
 
 // Entitlement is an object representing entitlements for move orders
 type Entitlement struct {
-	ID                    uuid.UUID `db:"id"`
-	DependentsAuthorized  *bool     `db:"dependents_authorized"`
-	TotalDependents       *int      `db:"total_dependents"`
-	NonTemporaryStorage   *bool     `db:"non_temporary_storage"`
-	PrivatelyOwnedVehicle *bool     `db:"privately_owned_vehicle"`
-	*WeightAllotment      `db:"-"`
-	StorageInTransit      *int      `db:"storage_in_transit"`
-	CreatedAt             time.Time `db:"created_at"`
-	UpdatedAt             time.Time `db:"updated_at"`
+	ID                    uuid.UUID        `db:"id"`
+	DependentsAuthorized  *bool            `db:"dependents_authorized"`
+	TotalDependents       *int             `db:"total_dependents"`
+	NonTemporaryStorage   *bool            `db:"non_temporary_storage"`
+	PrivatelyOwnedVehicle *bool            `db:"privately_owned_vehicle"`
+	DBAuthorizedWeight    *int             `db:"authorized_weight"`
+	weightAllotment       *WeightAllotment `db:"-"`
+	StorageInTransit      *int             `db:"storage_in_transit"`
+	CreatedAt             time.Time        `db:"created_at"`
+	UpdatedAt             time.Time        `db:"updated_at"`
+}
+
+//TODO probably want to reconsider keeping grade a string rather than enum
+//TODO and possibly consider creating ghc specific GetWeightAllotment should the two
+//TODO diverge in the future
+func (e *Entitlement) SetWeightAllotment(grade string) {
+	wa := GetWeightAllotment(ServiceMemberRank(grade))
+	e.weightAllotment = &wa
+}
+
+func (e *Entitlement) WeightAllotment() *WeightAllotment {
+	return e.weightAllotment
+}
+
+// AuthorizedWeight returns authorized weight. If authorized weight has not been
+// stored in DBAuthorizedWeight use TotalWeightSelf
+func (e *Entitlement) AuthorizedWeight() *int {
+	switch {
+	case e.DBAuthorizedWeight != nil:
+		return e.DBAuthorizedWeight
+	case e.WeightAllotment() != nil:
+		return &e.WeightAllotment().TotalWeightSelf
+	default:
+		return nil
+	}
 }

--- a/pkg/models/ghc_entitlements.go
+++ b/pkg/models/ghc_entitlements.go
@@ -8,16 +8,17 @@ import (
 
 // Entitlement is an object representing entitlements for move orders
 type Entitlement struct {
-	ID                    uuid.UUID        `db:"id"`
-	DependentsAuthorized  *bool            `db:"dependents_authorized"`
-	TotalDependents       *int             `db:"total_dependents"`
-	NonTemporaryStorage   *bool            `db:"non_temporary_storage"`
-	PrivatelyOwnedVehicle *bool            `db:"privately_owned_vehicle"`
-	DBAuthorizedWeight    *int             `db:"authorized_weight"`
-	weightAllotment       *WeightAllotment `db:"-"`
-	StorageInTransit      *int             `db:"storage_in_transit"`
-	CreatedAt             time.Time        `db:"created_at"`
-	UpdatedAt             time.Time        `db:"updated_at"`
+	ID                    uuid.UUID `db:"id"`
+	DependentsAuthorized  *bool     `db:"dependents_authorized"`
+	TotalDependents       *int      `db:"total_dependents"`
+	NonTemporaryStorage   *bool     `db:"non_temporary_storage"`
+	PrivatelyOwnedVehicle *bool     `db:"privately_owned_vehicle"`
+	//DBAuthorizedWeight is AuthorizedWeight when not null
+	DBAuthorizedWeight *int             `db:"authorized_weight"`
+	weightAllotment    *WeightAllotment `db:"-"`
+	StorageInTransit   *int             `db:"storage_in_transit"`
+	CreatedAt          time.Time        `db:"created_at"`
+	UpdatedAt          time.Time        `db:"updated_at"`
 }
 
 //TODO probably want to reconsider keeping grade a string rather than enum

--- a/pkg/models/ghc_entitlements_test.go
+++ b/pkg/models/ghc_entitlements_test.go
@@ -1,0 +1,25 @@
+package models_test
+
+import (
+	"github.com/transcom/mymove/pkg/models"
+)
+
+func (suite *ModelSuite) TestAuthorizedWeightWhenExistsInDB() {
+	aw := 3000
+	entitlement := models.Entitlement{DBAuthorizedWeight: &aw}
+
+	err := suite.DB().Create(&entitlement)
+	suite.NoError(err)
+
+	suite.Equal(entitlement.DBAuthorizedWeight, entitlement.AuthorizedWeight())
+}
+
+func (suite *ModelSuite) TestAuthorizedWeightWhenNotInDBAndHaveWeightAllotment() {
+	entitlement := models.Entitlement{}
+	entitlement.SetWeightAllotment("E_1")
+
+	err := suite.DB().Create(&entitlement)
+	suite.NoError(err)
+
+	suite.Equal(entitlement.WeightAllotment().TotalWeightSelf, *entitlement.AuthorizedWeight())
+}

--- a/pkg/testdatagen/make_entitlement.go
+++ b/pkg/testdatagen/make_entitlement.go
@@ -10,18 +10,21 @@ import (
 func MakeEntitlement(db *pop.Connection, assertions Assertions) models.Entitlement {
 	truePtr := true
 	dependents := 1
-	proGearWeight := 100
-	proGearWeightSpouse := 200
 	storageInTransit := 2
+	grade := models.ServiceMemberRank(assertions.MoveOrder.Grade)
 
+	if grade == "" {
+		grade = models.ServiceMemberRankE1
+	}
+
+	allotment := models.GetWeightAllotment(grade)
 	entitlement := models.Entitlement{
 		DependentsAuthorized:  &truePtr,
 		TotalDependents:       &dependents,
 		NonTemporaryStorage:   &truePtr,
 		PrivatelyOwnedVehicle: &truePtr,
-		ProGearWeight:         &proGearWeight,
-		ProGearWeightSpouse:   &proGearWeightSpouse,
 		StorageInTransit:      &storageInTransit,
+		WeightAllotment:       &allotment,
 	}
 
 	// Overwrite values with those from assertions

--- a/pkg/testdatagen/make_entitlement.go
+++ b/pkg/testdatagen/make_entitlement.go
@@ -11,21 +11,20 @@ func MakeEntitlement(db *pop.Connection, assertions Assertions) models.Entitleme
 	truePtr := true
 	dependents := 1
 	storageInTransit := 2
-	grade := models.ServiceMemberRank(assertions.MoveOrder.Grade)
+	grade := assertions.MoveOrder.Grade
 
 	if grade == "" {
-		grade = models.ServiceMemberRankE1
+		grade = "E_1"
 	}
 
-	allotment := models.GetWeightAllotment(grade)
 	entitlement := models.Entitlement{
 		DependentsAuthorized:  &truePtr,
 		TotalDependents:       &dependents,
 		NonTemporaryStorage:   &truePtr,
 		PrivatelyOwnedVehicle: &truePtr,
 		StorageInTransit:      &storageInTransit,
-		WeightAllotment:       &allotment,
 	}
+	entitlement.SetWeightAllotment(grade)
 
 	// Overwrite values with those from assertions
 	mergeModels(&entitlement, assertions.Entitlement)

--- a/pkg/testdatagen/make_move_order.go
+++ b/pkg/testdatagen/make_move_order.go
@@ -42,12 +42,17 @@ func MakeGrade() string {
 
 // MakeMoveOrder creates a single MoveOrder and associated set relationships
 func MakeMoveOrder(db *pop.Connection, assertions Assertions) models.MoveOrder {
+	grade := assertions.MoveOrder.Grade
+	if grade == "" {
+		grade = MakeGrade()
+	}
 	customer := assertions.Customer
 	if isZeroUUID(customer.ID) {
 		customer = MakeCustomer(db, assertions)
 	}
 	entitlement := assertions.Entitlement
 	if isZeroUUID(entitlement.ID) {
+		assertions.MoveOrder.Grade = grade
 		entitlement = MakeEntitlement(db, assertions)
 	}
 	originDutyStation := assertions.OriginDutyStation
@@ -59,10 +64,6 @@ func MakeMoveOrder(db *pop.Connection, assertions Assertions) models.MoveOrder {
 		destinationDutyStation = MakeDutyStation(db, assertions)
 	}
 
-	grade := assertions.MoveOrder.Grade
-	if grade == "" {
-		grade = MakeGrade()
-	}
 	moveOrder := models.MoveOrder{
 		Customer:                 customer,
 		CustomerID:               customer.ID,

--- a/src/scenes/Office/TOO/customerDetails.jsx
+++ b/src/scenes/Office/TOO/customerDetails.jsx
@@ -59,6 +59,8 @@ class CustomerDetails extends Component {
               <>
                 <h2>Customer Entitlements</h2>
                 <dl>
+                  <dt>Rank</dt>
+                  <dd>{get(moveOrder, 'grade', '')}</dd>
                   <dt>Dependents Authorized</dt>
                   <dd>{get(entitlements, 'dependentsAuthorized', '').toString()}</dd>
                   <dt>Non Temporary Storage</dt>
@@ -69,6 +71,8 @@ class CustomerDetails extends Component {
                   <dd>{get(entitlements, 'proGearWeightSpouse')}</dd>
                   <dt>Storage In Transit</dt>
                   <dd>{get(entitlements, 'storageInTransit', '').toString()}</dd>
+                  <dt>Total Weight</dt>
+                  <dd>{get(entitlements, 'totalWeight')}</dd>
                   <dt>Total Dependents</dt>
                   <dd>{get(entitlements, 'totalDependents')}</dd>
                 </dl>

--- a/src/scenes/Office/TOO/customerDetails.jsx
+++ b/src/scenes/Office/TOO/customerDetails.jsx
@@ -73,6 +73,8 @@ class CustomerDetails extends Component {
                   <dd>{get(entitlements, 'storageInTransit', '').toString()}</dd>
                   <dt>Total Weight</dt>
                   <dd>{get(entitlements, 'totalWeight')}</dd>
+                  <dt>Authorized Weight</dt>
+                  <dd>{get(entitlements, 'authorizedWeight')}</dd>
                   <dt>Total Dependents</dt>
                   <dd>{get(entitlements, 'totalDependents')}</dd>
                 </dl>

--- a/swagger/ghc.yaml
+++ b/swagger/ghc.yaml
@@ -1173,6 +1173,11 @@ definitions:
         example: 571008b1-b0de-454d-b843-d71be9f02c04
         format: uuid
         type: string
+      authorizedWeight:
+        example: 2000
+        type: integer
+        x-formatting: weight
+        x-nullable: true
       dependentsAuthorized:
         example: true
         type: boolean

--- a/swagger/ghc.yaml
+++ b/swagger/ghc.yaml
@@ -1196,6 +1196,10 @@ definitions:
       storageInTransit:
         example: 90
         type: integer
+      totalWeight:
+        example: 500
+        type: integer
+        x-formatting: weight
       totalDependents:
         example: 2
         type: integer

--- a/swagger/prime.yaml
+++ b/swagger/prime.yaml
@@ -629,6 +629,10 @@ definitions:
       storageInTransit:
         example: 90
         type: integer
+      totalWeight:
+        example: 500
+        type: integer
+        x-formatting: weight
       totalDependents:
         example: 2
         type: integer

--- a/swagger/prime.yaml
+++ b/swagger/prime.yaml
@@ -606,6 +606,11 @@ definitions:
         example: 571008b1-b0de-454d-b843-d71be9f02c04
         format: uuid
         type: string
+      authorizedWeight:
+        example: 2000
+        type: integer
+        x-formatting: weight
+        x-nullable: true
       dependentsAuthorized:
         example: true
         type: boolean


### PR DESCRIPTION
## Description

Add additional fields to customer section on draft MTO page:
* Rank / Grade
* Authorized Weight (pre-populated with weight entitlement)
* Weight Entitlement (derived based on rank)

## Setup

```sh
make db_dev_e2e_populate
make server_run
make office_client_run 
```
Visit http://officelocal:3000/too/customer-moves/ and the additional fields should be present in the Entitlements section.

## Code Review Verification Steps

* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-1050) for this change