### PR TITLE
Modify styling on progear slider

### DIFF
--- a/src/scenes/Moves/Ppm/Weight.jsx
+++ b/src/scenes/Moves/Ppm/Weight.jsx
@@ -201,7 +201,7 @@ export class PpmWeight extends Component {
                 <RangeSlider
                   id="progear-estimation-slider"
                   max={this.props.entitlement.weight}
-                  step={500}
+                  step={this.props.entitlement.weight <= 2500 ? 100 : 500}
                   min={0}
                   defaultValue={500}
                   prependTooltipText="about"

--- a/src/scenes/Moves/Ppm/Weight.module.scss
+++ b/src/scenes/Moves/Ppm/Weight.module.scss
@@ -26,7 +26,6 @@ div.progear-slider-container {
   margin-top: 1em;
 }
 :global {
-
   label.inline_radio {
     padding-bottom: 1em;
   }
@@ -91,4 +90,8 @@ table.numeric-info th {
   th {
     font-weight: bold;
   }
+}
+
+:global .rangeslider-horizontal .rangeslider__fill {
+  background-color: #005ea2;
 }

--- a/src/scenes/Moves/Ppm/Weight.module.scss
+++ b/src/scenes/Moves/Ppm/Weight.module.scss
@@ -75,10 +75,15 @@ table.numeric-info th {
   color: green;
 }
 
-:global .grid-container h3 {
-  font-family: Source Sans Pro Web, Helvetica Neue, Helvetica, Roboto, Arial, sans-serif;
-}
 :global {
+  .grid-container h3 {
+    font-family: Source Sans Pro Web, Helvetica Neue, Helvetica, Roboto, Arial, sans-serif;
+  }
+
+  .rangeslider-horizontal .rangeslider__fill {
+    background-color: #005ea2;
+  }
+
   table th,
   table td {
     border: none;
@@ -90,8 +95,4 @@ table.numeric-info th {
   th {
     font-weight: bold;
   }
-}
-
-:global .rangeslider-horizontal .rangeslider__fill {
-  background-color: #005ea2;
 }

--- a/src/scenes/Moves/Ppm/Weight.module.scss
+++ b/src/scenes/Moves/Ppm/Weight.module.scss
@@ -25,6 +25,11 @@ div.progear-slider-container {
   margin-right: 0;
   margin-top: 1em;
 }
+
+#progear-estimation-slider:focus {
+  outline: none;
+  box-shadow: none;
+}
 :global {
   label.inline_radio {
     padding-bottom: 1em;
@@ -82,6 +87,11 @@ table.numeric-info th {
 
   .rangeslider-horizontal .rangeslider__fill {
     background-color: #005ea2;
+  }
+
+  // pro-gear estimate slider outline
+  input:not([disabled]):focus {
+    outline: none;
   }
 
   table th,

--- a/src/shared/RangeSlider/RangeSlider.module.scss
+++ b/src/shared/RangeSlider/RangeSlider.module.scss
@@ -22,22 +22,29 @@
 :global {
   .usa-range {
     max-width: 100%;
+    height: auto;
+    padding: 0;
   }
 
-  input[type=range]::-webkit-slider-runnable-track {
+  .usa-range:focus {
+    box-shadow: 0 0 0 2pt #2491ff;
+    border-radius: 1em;
+  }
+
+  input[type='range']::-webkit-slider-runnable-track {
     width: 100%;
     height: 16px;
     cursor: pointer;
     border-radius: 1em;
   }
-  input[type=range]::-moz-range-progress {
+  input[type='range']::-moz-range-progress {
     width: 100%;
     height: 16px;
     cursor: pointer;
     background: $color-blue;
     border-radius: 1em;
   }
-  input[type="range"]::-ms-fill-lower {
+  input[type='range']::-ms-fill-lower {
     width: 100%;
     height: 16px;
     cursor: pointer;
@@ -45,21 +52,19 @@
     border-radius: 1em;
   }
 
-  input[type="range"]::-ms-track {
+  input[type='range']::-ms-track {
     color: transparent;
   }
 
-  input[type="range"]::-ms-tooltip {
+  input[type='range']::-ms-tooltip {
     display: none;
   }
 
-  @media screen and (-webkit-min-device-pixel-ratio:0) {
+  @media screen and (-webkit-min-device-pixel-ratio: 0) {
     input[type='range']::-webkit-slider-runnable-track {
       width: 100%;
       cursor: pointer;
       border-radius: 1em;
     }
   }
-
-
 }

--- a/src/shared/RangeSlider/RangeSlider.module.scss
+++ b/src/shared/RangeSlider/RangeSlider.module.scss
@@ -1,22 +1,13 @@
 @import 'shared/styles/themes.scss';
 @import 'shared/styles/colors.scss';
 
-.rangeslider-output:after {
-  content: '';
-  border: 5px solid transparent;
-  border-top-color: #000;
-  border-bottom: 0;
-  position: relative;
-  top: 28px;
-  left: -8%;
+.rangeslider-output {
+  border-color: $color-gray-light;
 }
 
-.slider-min-label {
-  float: left;
-}
-
-.slider-max-label {
-  float: right;
+.range-label-container {
+  display: flex;
+  justify-content: space-between;
 }
 
 :global {
@@ -27,8 +18,7 @@
   }
 
   .usa-range:focus {
-    box-shadow: 0 0 0 2pt #2491ff;
-    border-radius: 1em;
+    box-shadow: none;
   }
 
   input[type='range']::-webkit-slider-runnable-track {
@@ -37,6 +27,7 @@
     cursor: pointer;
     border-radius: 1em;
   }
+
   input[type='range']::-moz-range-progress {
     width: 100%;
     height: 16px;

--- a/src/shared/RangeSlider/index.js
+++ b/src/shared/RangeSlider/index.js
@@ -62,7 +62,7 @@ class RangeSlider extends Component {
     return (
       <div className="rangeslider-container">
         <span
-          className={`${styles['rangeslider-output']} border-base border-1px radius-lg padding-left-1 padding-right-1`}
+          className={`${styles['rangeslider-output']} border-1px radius-lg padding-left-1 padding-right-1`}
           id={'output-' + id}
           htmlFor={id}
         >
@@ -79,8 +79,10 @@ class RangeSlider extends Component {
           onInput={this.onInput}
           onChange={this.onChange}
         />
-        <span className={styles['slider-min-label']}>{min}</span>
-        <span className={styles['slider-max-label']}>{max}</span>
+        <div className={styles['range-label-container']}>
+          <span>{min}</span>
+          <span>{max}</span>
+        </div>
       </div>
     );
   }

--- a/src/shared/styles/colors.scss
+++ b/src/shared/styles/colors.scss
@@ -4,5 +4,6 @@ $color-gold: #fdb81e;
 $color-icon-gray: #ababab;
 $color-gray-lightest: #f1f1f1;
 $color-gray-medium: #a2a2a2;
+$color-gray-light: #b2b2b2;
 $color-red: #cd3504;
-$color-blue: #005ea2
+$color-blue: #005ea2;


### PR DESCRIPTION
## Description

Modify styling on progear slider to have focus outline the range bar instead of a box on the DOM element itself and fix the styling on the original slider because it was not filling in the bar with the color

## Reviewer Notes
- may have to handle the misalignment of the tooltip in a separate story because it may be more involved but the outline fix was something requested because it was confusing people

## Setup
`make server_run`
`make client_run`
View /{moveId}/ppm-incentive page

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-987) for this change

## Screenshots

![image](https://user-images.githubusercontent.com/13622298/72237156-638c7900-358e-11ea-80ba-cd57994952d2.png)
