### PR TITLE
Add auditing log for when MTO is made available to prime

### DIFF
--- a/pkg/handlers/ghcapi/move_task_order_test.go
+++ b/pkg/handlers/ghcapi/move_task_order_test.go
@@ -58,7 +58,10 @@ func (suite *HandlerSuite) TestGetMoveTaskOrderHandlerIntegration() {
 
 func (suite *HandlerSuite) TestUpdateMoveTaskOrderHandlerIntegration() {
 	moveTaskOrder := testdatagen.MakeMoveTaskOrder(suite.DB(), testdatagen.Assertions{})
+
 	request := httptest.NewRequest("PATCH", "/move-task-orders/{moveTaskOrderID}/status", nil)
+	requestUser := testdatagen.MakeDefaultUser(suite.DB())
+	request = suite.AuthenticateUserRequest(request, requestUser)
 	params := move_task_order.UpdateMoveTaskOrderStatusParams{
 		HTTPRequest:     request,
 		MoveTaskOrderID: moveTaskOrder.ID.String(),

--- a/pkg/services/audit/audit.go
+++ b/pkg/services/audit/audit.go
@@ -18,7 +18,6 @@ import (
 )
 
 func Capture(model interface{}, payload interface{}, logger Logger, session *auth.Session, request *http.Request) ([]zap.Field, error) {
-
 	var logItems []zap.Field
 	eventType := extractEventType(request)
 	msg := flect.Titleize(eventType)


### PR DESCRIPTION
## Setup

```sh
make server_run
make office_client_run
```

Watching your command line, head to http://officelocal:3000/too/customer-moves/ and send an MTO to prime. Confirm an audit log appears.

## Code Review Verification Steps
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-666) for this change