### PR TITLE
MB-673 Make TIO office user to test

### DIFF
--- a/pkg/testdatagen/scenario/e2ebasic.go
+++ b/pkg/testdatagen/scenario/e2ebasic.go
@@ -1019,13 +1019,47 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, log
 	}
 
 	email = "too_role@office.mil"
-	uuidStr = "dcf86235-53d3-43dd-8ee8-54212ae3078f"
+	tooUUID := uuid.Must(uuid.FromString("dcf86235-53d3-43dd-8ee8-54212ae3078f"))
 	testdatagen.MakeUser(db, testdatagen.Assertions{
 		User: models.User{
-			ID:            uuid.Must(uuid.FromString(uuidStr)),
+			ID:            tooUUID,
 			LoginGovEmail: email,
 			Active:        true,
 			Roles:         []roles.Role{tooRole},
+		},
+	})
+	testdatagen.MakeOfficeUser(db, testdatagen.Assertions{
+		OfficeUser: models.OfficeUser{
+			ID:     uuid.FromStringOrNil("144503a6-485c-463e-b943-d3c3bad11b09"),
+			Email:  email,
+			Active: true,
+			UserID: &tooUUID,
+		},
+	})
+
+	/* A user with tio role */
+	tioRole := roles.Role{}
+	err = db.Where("role_type = $1", roles.RoleTypeTIO).First(&tioRole)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	email = "tio_role@office.mil"
+	tioUUID := uuid.Must(uuid.FromString("3b2cc1b0-31a2-4d1b-874f-0591f9127374"))
+	testdatagen.MakeUser(db, testdatagen.Assertions{
+		User: models.User{
+			ID:            tioUUID,
+			LoginGovEmail: email,
+			Active:        true,
+			Roles:         []roles.Role{tioRole},
+		},
+	})
+	testdatagen.MakeOfficeUser(db, testdatagen.Assertions{
+		OfficeUser: models.OfficeUser{
+			ID:     uuid.FromStringOrNil("f1828a35-43fd-42be-8b23-af4d9d51f0f3"),
+			Email:  email,
+			Active: true,
+			UserID: &tioUUID,
 		},
 	})
 


### PR DESCRIPTION
## Description

Acceptance Criteria:

- Users can be granted “TIO” role
- TIO can log in and see an appropriate interface, which is the payment requests screen
- This should eventually replace the current feature flag logic

## Reviewer Notes

- TIO role is already set up
- Added in a user with a TIO role so we can test

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make clean
make db_dev_e2e_populate
make server_run
make office_client_run
```

## Test

1. Open office app and select `tio_role@office.mil` from dev local login screen
2. Navigate to `http://officelocal:3000/payment_requests`
3. To check user role, open up the Redux tool
4. Navigate to `state`
5. Expand `user` -> `userInfo` -> `roles`
6. User should be of `Transportation Invoicing Officer`
![image](https://user-images.githubusercontent.com/1522549/72469893-03b3ef00-3795-11ea-86f3-9875100042f1.png)


## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-673) for this change