### PR TITLE
Clear session when attempting to load the devlocal user list

### DIFF
--- a/cmd/milmove/serve.go
+++ b/cmd/milmove/serve.go
@@ -887,7 +887,7 @@ func serveFunction(cmd *cobra.Command, args []string) error {
 		logger.Info("Enabling devlocal auth")
 		localAuthMux := goji.SubMux()
 		root.Handle(pat.New("/devlocal-auth/*"), localAuthMux)
-		localAuthMux.Handle(pat.Get("/login"), authentication.NewUserListHandler(authContext, dbConnection))
+		localAuthMux.Handle(pat.Get("/login"), authentication.NewUserListHandler(authContext, dbConnection, clientAuthSecretKey, noSessionTimeout, useSecureCookie))
 		localAuthMux.Handle(pat.Post("/login"), authentication.NewAssignUserHandler(authContext, dbConnection, appnames, clientAuthSecretKey, noSessionTimeout, useSecureCookie))
 		localAuthMux.Handle(pat.Post("/new"), authentication.NewCreateAndLoginUserHandler(authContext, dbConnection, appnames, clientAuthSecretKey, noSessionTimeout, useSecureCookie))
 		localAuthMux.Handle(pat.Post("/create"), authentication.NewCreateUserHandler(authContext, dbConnection, appnames, clientAuthSecretKey, noSessionTimeout, useSecureCookie))


### PR DESCRIPTION
## Description

I have been tripping on this for a long time. When the session and the database get out of sync, the user gets in a bad state where they can't log out because the app thinks they are logged in, except the front end think you're logged out and so it doesn't render the "logout" links.

The solution is generally to manually clear out the cookies in your browser and start fresh. But why put ourselves through that ritual?

## Reviewer Notes

This PR destroys the current session when a user visits `/devlocal-auth/login`. Yes, this is a GET request, but this change fixes the situation described above without needing to modify any of the other auth logic in the app. Since this is purely a local development tool, I think this is OK.

## Setup (_new and improved!_)

**Checkout the master branch.**

```
$ make db_dev_e2e_populate
$ make server_run
$ make client_run
```

Go to `http://milmovelocal:3000` and create a new MilMove user. Once you see the first profile form, kill the server and:

```
$ make db_dev_e2e_populate
$ make server_run
```

Reload the browser window containing the profile form. It should show you the logged-out homepage. You should now be stuck in this loop:

![can't log in ugh](https://user-images.githubusercontent.com/3331/72941735-5e21f200-3d37-11ea-8a7e-5fae3c0d0cb7.gif)


**Now, check out this branch and restart the server.** You should be able to click `Local Sign In` and actually log in.
