### PR TITLE
Fix the location of the ecs-service-logs binary in the deploy script

### DIFF
--- a/scripts/ecs-deploy-service-container
+++ b/scripts/ecs-deploy-service-container
@@ -99,7 +99,7 @@ put_metric DeployFail "${name}-${environment}"
 
 echo
 echo "Showing logs from recently stopped tasks:"
-"$DIR"/ecs-service-logs show --cluster "app-${environment}" --service "${name}" --environment "${environment}" --status "STOPPED" --verbose
+"$DIR"/../bin/ecs-service-logs show --cluster "app-${environment}" --service "${name}" --environment "${environment}" --status "STOPPED" --verbose
 echo
 
 echo "* Rolling back to $blue_task_def_arn"


### PR DESCRIPTION
## Description

In a deploy that failed I noticed this line:

```
Service failed to stabilize!

Showing logs from recently stopped tasks:
scripts/ecs-deploy-service-container: line 152: /home/circleci/transcom/mymove/scripts/ecs-service-logs: No such file or directory
```

Turns out we had the wrong location for the `ecs-service-logs` binary. This PR should update that.