### PR TITLE
Fix CAC scripts to work on MacOS 10.15

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -540,4 +540,5 @@ aws-vault
 aws-vault-wrapper
 aws
 env
+MacOS
 # Put all custom terms BEFORE this comment, lest 'pre-commit' and 'make spellcheck' yield different errors.

--- a/docs/how-to/upload-electronic-orders.md
+++ b/docs/how-to/upload-electronic-orders.md
@@ -8,7 +8,12 @@ Saicoo DOD Military USB-C Common Access Card Reader](https://www.amazon.com/Read
 To get going you will also need to install some software on your machine:
 
 1. `brew install opensc` gives you tools like `pkcs11-tool` and `pkcs15-tool`
-1. Install the official  Military CAC package from [CAC Key Packages](http://militarycac.org/MacVideos.htm#CACKey_packages) to get the driver `/usr/local/lib/pkcs11/cackey.dylib`
+
+## MacOS 10.14 and earlier ONLY
+
+**NOTE:** Skip this section if you are on MacOS `10.15.X` or later!!
+
+Install the official Military CAC package from [CAC Key Packages](http://militarycac.org/MacVideos.htm#CACKey_packages) to get the driver `/usr/local/lib/pkcs11/cackey.dylib`
 
 It's important that you disable default smart card access on your OSX machine. [Read the published instructions](http://militarycac.org/macuninstall.htm#Mojave_(10.14),_High_Sierra_(10.13.x),_and_Sierra_(10.12.x)_Built_in_Smart_Card_Ability). It boils down to removing your CAC from the reader, running this command and restarting your laptop:
 
@@ -16,8 +21,9 @@ It's important that you disable default smart card access on your OSX machine. [
 sudo defaults write /Library/Preferences/com.apple.security.smartcard DisabledTokens -array com.apple.CryptoTokenKit.pivtoken
 ```
 
-This should get you in the state where you can use your CAC to extract certs. You may also want to run these commands
-to check:
+## Prerequisites
+
+To see if you are in a place to use your CAC to extract certs you need to run these commands:
 
 ```sh
 cac-prereqs

--- a/scripts/cac-extract-cert
+++ b/scripts/cac-extract-cert
@@ -6,11 +6,18 @@ set -eu -o pipefail
 # Get a certificate from CAC
 #
 
-readonly MODULE=/usr/local/lib/pkcs11/cackey.dylib
+OS_VERSION=$(/usr/bin/sw_vers -productVersion)
+MAC_OS="10.15"
+if [[ $OS_VERSION == *$MAC_OS* ]]; then
+  MODULE=/usr/local/lib/pkcs11/opensc-pkcs11.so
+elif [[ -f "${MODULE}" ]]; then
+  MODULE=/usr/local/lib/pkcs11/cackey.dylib
+fi
+readonly MODULE
 readonly PKCS11=/usr/local/bin/pkcs11-tool
 
 # Check the CAC Pre-Requirements
 cac-prereqs
 
 # Certificate
-"${PKCS11}" -r --module "${MODULE}" -a "Identity #0" --type cert 2>/dev/null | openssl x509 -inform der -text
+"${PKCS11}" --module "${MODULE}" -r --id 01 --type cert 2>/dev/null | openssl x509 -inform der -text

--- a/scripts/cac-extract-fingerprint
+++ b/scripts/cac-extract-fingerprint
@@ -6,11 +6,18 @@ set -eu -o pipefail
 # Get a sha256 hash of the certificate from CAC
 #
 
-readonly MODULE=/usr/local/lib/pkcs11/cackey.dylib
+OS_VERSION=$(/usr/bin/sw_vers -productVersion)
+MAC_OS="10.15"
+if [[ $OS_VERSION == *$MAC_OS* ]]; then
+  MODULE=/usr/local/lib/pkcs11/opensc-pkcs11.so
+elif [[ -f "${MODULE}" ]]; then
+  MODULE=/usr/local/lib/pkcs11/cackey.dylib
+fi
+readonly MODULE
 readonly PKCS11=/usr/local/bin/pkcs11-tool
 
 # Check the CAC Pre-Requirements
 cac-prereqs
 
 # Fingerprint
-"${PKCS11}" -r --module "${MODULE}" -a "Identity #0" --type cert 2>/dev/null | openssl dgst -sha256| perl -ne 's/^\(stdin\)= //; print'
+"${PKCS11}" --module "${MODULE}" -r --id 01 --type cert 2>/dev/null | openssl dgst -sha256| perl -ne 's/^\(stdin\)= //; print'

--- a/scripts/cac-extract-pubkey
+++ b/scripts/cac-extract-pubkey
@@ -3,14 +3,21 @@
 set -eu -o pipefail
 
 #
-# Get a publick key from CAC
+# Get a public key from CAC
 #
 
-readonly MODULE=/usr/local/lib/pkcs11/cackey.dylib
+OS_VERSION=$(/usr/bin/sw_vers -productVersion)
+MAC_OS="10.15"
+if [[ $OS_VERSION == *$MAC_OS* ]]; then
+  MODULE=/usr/local/lib/pkcs11/opensc-pkcs11.so
+elif [[ -f "${MODULE}" ]]; then
+  MODULE=/usr/local/lib/pkcs11/cackey.dylib
+fi
+readonly MODULE
 readonly PKCS11=/usr/local/bin/pkcs11-tool
 
 # Check the CAC Pre-Requirements
 cac-prereqs
 
 # Pubkey
-"${PKCS11}" -r --module "${MODULE}" -a "Identity #0" --type cert 2>/dev/null | openssl x509 -inform der -pubkey -noout
+"${PKCS11}" --module "${MODULE}" -r --id 01 --type cert 2>/dev/null | openssl x509 -inform der -pubkey -noout

--- a/scripts/cac-extract-subject
+++ b/scripts/cac-extract-subject
@@ -6,11 +6,18 @@ set -eu -o pipefail
 # Get Subject of the certificate from CAC
 #
 
-readonly MODULE=/usr/local/lib/pkcs11/cackey.dylib
+OS_VERSION=$(/usr/bin/sw_vers -productVersion)
+MAC_OS="10.15"
+if [[ $OS_VERSION == *$MAC_OS* ]]; then
+  MODULE=/usr/local/lib/pkcs11/opensc-pkcs11.so
+elif [[ -f "${MODULE}" ]]; then
+  MODULE=/usr/local/lib/pkcs11/cackey.dylib
+fi
+readonly MODULE
 readonly PKCS11=/usr/local/bin/pkcs11-tool
 
 # Check the CAC Pre-Requirements
 cac-prereqs
 
 # Certificate Subject
-"${PKCS11}" -r --module "${MODULE}" -a "Identity #0" --type cert 2>/dev/null | openssl x509 -inform der -noout -subject | perl -ne 's/^subject= //; print'
+"${PKCS11}" --module "${MODULE}" -r --id 01 --type cert 2>/dev/null | openssl x509 -inform der -noout -subject | perl -ne 's/^subject= //; print'

--- a/scripts/cac-extract-token-label
+++ b/scripts/cac-extract-token-label
@@ -6,11 +6,18 @@ set -eu -o pipefail
 # Get the Token Label from CAC
 #
 
-readonly MODULE=/usr/local/lib/pkcs11/cackey.dylib
+OS_VERSION=$(/usr/bin/sw_vers -productVersion)
+MAC_OS="10.15"
+if [[ $OS_VERSION == *$MAC_OS* ]]; then
+  MODULE=/usr/local/lib/pkcs11/opensc-pkcs11.so
+elif [[ -f "${MODULE}" ]]; then
+  MODULE=/usr/local/lib/pkcs11/cackey.dylib
+fi
+readonly MODULE
 readonly PKCS11=/usr/local/bin/pkcs11-tool
 
 # Check the CAC Pre-Requirements
 cac-prereqs
 
 # Token Label
-"${PKCS11}" -r --module "${MODULE}" -a "Identity #0" --list-slots 2>/dev/null| grep label | perl -ne 's/^  token label        : //; print' | head -n1
+"${PKCS11}" --module "${MODULE}" -r --id 01 --list-slots 2>/dev/null| grep label | perl -ne 's/^  token label        : //; print' | head -n1

--- a/scripts/cac-prereqs
+++ b/scripts/cac-prereqs
@@ -22,8 +22,13 @@ if [[ ! -x "${PKCS15}" ]]; then
   exit 1
 fi
 
-if [[ ! -f "${MODULE}" ]]; then
-  echo "${MODULE} has not been installed"
+OS_VERSION=$(/usr/bin/sw_vers -productVersion)
+MAC_OS="10.15"
+if [[ $OS_VERSION != *$MAC_OS* && ! -f "${MODULE}" ]]; then
+  echo "${MODULE} must be installed for MacOS versions prior to ${MAC_OS}"
   echo "Please visit http://militarycac.org/MacVideos.htm#CACKey_packages and follow instructions to install"
+  exit 1
+elif [[ -f "${MODULE}" ]]; then
+  echo "${MODULE} must be removed for MacOS versions equal to or after ${MAC_OS}"
   exit 1
 fi


### PR DESCRIPTION
## Description

When we upgraded to MacOS 10.15 these scripts broke for folks. This updates the scripts to work now with the installed tools.