### PR TITLE
Log dev server output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ __snapshots__
 # development
 /mnt
 /tmp
+/log
 
 # All compiled binaries
 /bin/

--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,7 @@ help:  ## Print the help documentation
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
 # Make sure we have a log directory
+$(shell  mkdir -p log)
 
 #
 # ----- END PREAMBLE -----
@@ -312,7 +313,7 @@ server_build_linux: ## Build the server (linux)
 
 # This command is for running the server by itself, it will serve the compiled frontend on its own
 # Note: Don't double wrap with aws-vault because the pkg/cli/vault.go will handle it
-server_run_standalone: log server_build client_build db_dev_run
+server_run_standalone: server_build client_build db_dev_run
 	DEBUG_LOGGING=true ./bin/milmove serve 2>&1 | tee -a log/dev.log
 
 # This command will rebuild the swagger go code and rerun server on any changes
@@ -321,7 +322,7 @@ server_run:
 # This command runs the server behind gin, a hot-reload server
 # Note: Gin is not being used as a proxy so assigning odd port and laddr to keep in IPv4 space.
 # Note: The INTERFACE envar is set to configure the gin build, milmove_gin, local IP4 space with default port 8080.
-server_run_default: log .check_hosts.stamp .check_go_version.stamp .check_gopath.stamp .check_node_version.stamp bin/gin build/index.html server_generate db_dev_run
+server_run_default: .check_hosts.stamp .check_go_version.stamp .check_gopath.stamp .check_node_version.stamp bin/gin build/index.html server_generate db_dev_run
 	INTERFACE=localhost DEBUG_LOGGING=true \
 	$(AWS_VAULT) ./bin/gin \
 		--build ./cmd/milmove \
@@ -334,7 +335,7 @@ server_run_default: log .check_hosts.stamp .check_go_version.stamp .check_gopath
 		2>&1 | tee -a log/dev.log
 
 .PHONY: server_run_debug
-server_run_debug: log ## Debug the server
+server_run_debug: ## Debug the server
 	$(AWS_VAULT) dlv debug cmd/milmove/*.go -- serve 2>&1 | tee -a log/dev.log
 
 .PHONY: build_tools
@@ -443,9 +444,6 @@ server_test_coverage: db_test_reset db_test_migrate server_test_coverage_generat
 .PHONY: server_test_docker
 server_test_docker:
 	docker-compose -f docker-compose.circle.yml --compatibility up server_test
-
-log:
-	mkdir -p log
 
 #
 # ----- END SERVER TARGETS -----


### PR DESCRIPTION
## Description

I've had two separate conversations about how nice it would be to have log files, so here is a simple way to do that using `tee`.

## Reviewer Notes

I'm creating a `log` dir when the `Makefile` is initially parsed. I think that's a cheap enough operation, but LMK if you have thoughts on better ways to do this. I didn't want to have to add a target that then has to be required all over the place for something so basic since it seemed like it would be too easy to miss a place. Plus it would add more noise to our already large `Makefile`.

Note that since this captures output from just the server process, we won't see any of the other logs such as migrations being run or anything from the front end. I think this is a good place to start.

## Setup

```sh
$ make server_run
```

You should see the server output in `log/dev.log`.