### PR TITLE
MB-820 add functions for distance calculation

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -548,7 +548,10 @@ LatLongTransitDistance
 Bing
 Zip5ToLatLong
 geocoder
-Zip5's
 LatLong
+Zip3
+Zip5
+Zip5s
+McNally
 # Put all custom terms BEFORE this comment, lest 'pre-commit' and 'make spellcheck' yield different errors.
  - ./docs/backend/route-planner.md

--- a/.spelling
+++ b/.spelling
@@ -541,4 +541,14 @@ aws-vault-wrapper
 aws
 env
 MacOS
+TransitDistance
+Zip5TransitDistance
+Zip3TransitDistance
+LatLongTransitDistance
+Bing
+Zip5ToLatLong
+geocoder
+Zip5's
+LatLong
 # Put all custom terms BEFORE this comment, lest 'pre-commit' and 'make spellcheck' yield different errors.
+ - ./docs/backend/route-planner.md

--- a/docs/backend/route-planner.md
+++ b/docs/backend/route-planner.md
@@ -60,11 +60,13 @@ Turns the input addresses into `LatLong` data via HERE geocoder endpoint, and th
 
 #### Zip5TransitDistance
 
-Uses the `Zip5ToLatLong` method to turn the input Zip5's into `LatLong` data and then uses the `LatLongTransitDistance` method to determine the distance.
+Uses the `Zip5ToLatLong` method to turn the input Zip5s into `LatLong` data and then uses the `LatLongTransitDistance` method to determine the distance.
 
 #### Zip3TransitDistance
 
 `Zip3TransitDistance` is unimplemented and always returns a `NewUnsupportedPostalCodeError`
+
+This method was added to support the requirement that some service item pricing in the rate engine, ie Domestic Linehaul, will use Zip3 based distance calculations. This expectation is documented in the [service item pricing spreadsheet](https://docs.google.com/spreadsheets/d/1NRbxHmvaWV6aXQrxQ2LJhkc5tClAl3Eb1-MRxZ123Tw/edit#gid=0) (Google Docs Link). However, the HERE api uses pre-calculated Zip5 to Latitude and Longitude coordinate map to turn Zip5s into coordinates and then uses the LatLongTransitDistance function to return a distance. Since currently there is no such Zip3 to Latitude and Longitude coordinates map there is no way to do a similar calculation of distance. In talking with product about this we decided if there was not an easy way to implement Zip3 distance in HERE we would only add a stub so that work could continue until a new 3rd party planner, ie Rand McNally, was implemented and could supply a valid Zip3 to Zip3 distance calculation.
 
 #### LatLongTransitDistance
 
@@ -80,7 +82,7 @@ This is an implementation of the Planner interface to be used in various tests.
 
 ## Zip5ToLatLong
 
-The HERE API relies on zip to LatLong data from the [free zip code data project](https://github.com/midwire/free_zipcode_data). This data was used to create a static map of Zip5's to LatLong tuples in
+The HERE API relies on zip to LatLong data from the [free zip code data project](https://github.com/midwire/free_zipcode_data). This data was used to create a static map of Zip5s to LatLong tuples in
 `pkg/route/zip_locale.go`. This file also contains the method which can be used to lookup the data.
 
 ## Chamber

--- a/docs/backend/route-planner.md
+++ b/docs/backend/route-planner.md
@@ -1,0 +1,99 @@
+# Route Planner Guide
+
+## Table of Contents
+
+<!-- Table of Contents auto-generated with `bin/generate-md-toc.sh` -->
+
+<!-- toc -->
+
+* [Route planner interface](#route-planner-interface)
+  * [Interface methods](#interface-methods)
+* [Available route planners](#available-route-planners)
+  * [HERE API](#here-api)
+    * [TransitDistance](#transitdistance)
+    * [Zip5TransitDistance](#zip5transitdistance)
+    * [Zip3TransitDistance](#zip3transitdistance)
+    * [LatLongTransitDistance](#latlongtransitdistance)
+  * [Bing API](#bing-api)
+  * [Test](#test)
+* [Zip5ToLatLong](#zip5tolatlong)
+* [Chamber](#chamber)
+* [Testing](#testing)
+
+Regenerate with "pre-commit run -a markdown-toc"
+
+<!-- tocstop -->
+
+## Route planner interface
+
+In the MyMove project we have an interface for communicating with various Route planning APIs. Currently the project uses the HERE api for distance route calculations. The hope of this doc is to explain some of how it works. The interface and implementations can be found in `pkg/route`.
+
+### Interface methods
+
+The Route Planner interface requires the implementation of the following methods.
+
+```go
+// This method takes a source and destination `models.Address` and returns the distance as an `int`.
+TransitDistance(source *models.Address, destination *models.Address) (int, error)
+
+//This method takes a source and destination `LatLong` and returns the distance as an `int`
+LatLongTransitDistance(source LatLong, destination LatLong) (int, error)
+
+// This method takes a source and destination `Zip5` string and returns the distance as an `int`
+Zip5TransitDistance(source string, destination string) (int, error)
+
+// This method takes a source and destination `Zip3` string and returns the distance as an `int`
+Zip3TransitDistance(source string, destination string) (int, error)
+```
+
+## Available route planners
+
+Below is a list of the current route planner APIs that are implemented, though it appears as of this writing that only HERE API is used.
+
+### HERE API
+
+The HERE API is the currently used 3rd party api for doing route planning in the my move system.
+
+#### TransitDistance
+
+Turns the input addresses into `LatLong` data via HERE geocoder endpoint, and then it runs the `LatLongTransitDistance` method to determine the distance.
+
+#### Zip5TransitDistance
+
+Uses the `Zip5ToLatLong` method to turn the input Zip5's into `LatLong` data and then uses the `LatLongTransitDistance` method to determine the distance.
+
+#### Zip3TransitDistance
+
+`Zip3TransitDistance` is unimplemented and always returns a `NewUnsupportedPostalCodeError`
+
+#### LatLongTransitDistance
+
+This method takes a source and destination `LatLong` and uses the HERE API to calculate the distance between them.
+
+### Bing API
+
+This is an implementation of the Planner interface that uses Bing as a backend. However, as of this writing there are no uses of this class other than in tests.
+
+### Test
+
+This is an implementation of the Planner interface to be used in various tests.
+
+## Zip5ToLatLong
+
+The HERE API relies on zip to LatLong data from the [free zip code data project](https://github.com/midwire/free_zipcode_data). This data was used to create a static map of Zip5's to LatLong tuples in
+`pkg/route/zip_locale.go`. This file also contains the method which can be used to lookup the data.
+
+## Chamber
+
+The following environment variables need to be set to make successful calls to the API. These values are stored in chamber so they are not be checked in.
+
+```sh
+HERE_MAPS_APP_ID
+HERE_MAPS_ROUTING_ENDPOINT
+HERE_MAPS_APP_CODE
+HERE_MAPS_GEOCODE_ENDPOINT
+```
+
+## Testing
+
+There are unit tests under `<planner_name>_test.go` which do some basic validation. There is an integration test which calls out to the real api in `planner_test.go`

--- a/pkg/route/bing_planner.go
+++ b/pkg/route/bing_planner.go
@@ -81,6 +81,10 @@ func (p *bingPlanner) Zip5TransitDistance(source string, destination string) (in
 	return zip5TransitDistanceHelper(p, source, destination)
 }
 
+func (p *bingPlanner) Zip3TransitDistance(source string, destination string) (int, error) {
+	return zip3TransitDistanceHelper(p, source, destination)
+}
+
 func (p *bingPlanner) TransitDistance(source *models.Address, destination *models.Address) (int, error) {
 	return p.wayPointsTransitDistance(urlencodeAddress(source), urlencodeAddress(destination))
 }

--- a/pkg/route/bing_planner.go
+++ b/pkg/route/bing_planner.go
@@ -73,18 +73,22 @@ func (p *bingPlanner) wayPointsTransitDistance(wp1 string, wp2 string) (int, err
 	return int(math.Round(resourceSet.Resources[0].TravelDistance)), nil
 }
 
+// LatLongTransitDistance calculates the distance between two sets of LatLong coordinates
 func (p *bingPlanner) LatLongTransitDistance(source LatLong, dest LatLong) (int, error) {
 	return p.wayPointsTransitDistance(source.Coords(), dest.Coords())
 }
 
+// Zip5TransitDistance calculates the distance between two valid Zip5s
 func (p *bingPlanner) Zip5TransitDistance(source string, destination string) (int, error) {
 	return zip5TransitDistanceHelper(p, source, destination)
 }
 
+// Zip3TransitDistance calculates the distance between two valid Zip3s
 func (p *bingPlanner) Zip3TransitDistance(source string, destination string) (int, error) {
 	return zip3TransitDistanceHelper(p, source, destination)
 }
 
+// TransitDistance calculates the distance between two valid addresses
 func (p *bingPlanner) TransitDistance(source *models.Address, destination *models.Address) (int, error) {
 	return p.wayPointsTransitDistance(urlencodeAddress(source), urlencodeAddress(destination))
 }

--- a/pkg/route/here_planner.go
+++ b/pkg/route/here_planner.go
@@ -163,6 +163,7 @@ func getDistanceMiles(r io.ReadCloser) (int, error) {
 	return int(math.Round(float64(response.Response.Routes[0].Summary.Distance) / metersInAMile)), nil
 }
 
+// LatLongTransitDistance calculates the distance between two sets of LatLong coordinates
 func (p *herePlanner) LatLongTransitDistance(source LatLong, dest LatLong) (int, error) {
 	query := fmt.Sprintf(routeEndpointFormat, p.routeEndPointWithKeys, source.Coords(), dest.Coords())
 	resp, err := p.httpClient.Get(query)
@@ -192,6 +193,7 @@ func (p *herePlanner) LatLongTransitDistance(source LatLong, dest LatLong) (int,
 	}
 }
 
+// Zip5TransitDistance calculates the distance between two valid Zip5s
 func (p *herePlanner) Zip5TransitDistance(source string, destination string) (int, error) {
 	distance, err := zip5TransitDistanceHelper(p, source, destination)
 	if err != nil {
@@ -206,6 +208,7 @@ func (p *herePlanner) Zip5TransitDistance(source string, destination string) (in
 	return distance, err
 }
 
+// Zip3TransitDistance calculates the distance between two valid Zip3s
 func (p *herePlanner) Zip3TransitDistance(source string, destination string) (int, error) {
 	distance, err := zip3TransitDistanceHelper(p, source, destination)
 	if err != nil {
@@ -220,6 +223,7 @@ func (p *herePlanner) Zip3TransitDistance(source string, destination string) (in
 	return distance, err
 }
 
+// TransitDistance calculates the distance between two valid addresses
 func (p *herePlanner) TransitDistance(source *models.Address, destination *models.Address) (int, error) {
 
 	// Convert addresses to LatLong using geocode API. Do via goroutines and channel so we can do two

--- a/pkg/route/here_planner.go
+++ b/pkg/route/here_planner.go
@@ -206,6 +206,20 @@ func (p *herePlanner) Zip5TransitDistance(source string, destination string) (in
 	return distance, err
 }
 
+func (p *herePlanner) Zip3TransitDistance(source string, destination string) (int, error) {
+	distance, err := zip3TransitDistanceHelper(p, source, destination)
+	if err != nil {
+		var msg string
+		if err.(Error).Code() == ShortHaulError {
+			msg = "Unsupported short haul move distance"
+		} else {
+			msg = "Failed to calculate HERE route between ZIPs"
+		}
+		p.logger.Error(msg, zap.String("source", source), zap.String("destination", destination), zap.Int("distance", distance))
+	}
+	return distance, err
+}
+
 func (p *herePlanner) TransitDistance(source *models.Address, destination *models.Address) (int, error) {
 
 	// Convert addresses to LatLong using geocode API. Do via goroutines and channel so we can do two

--- a/pkg/route/here_planner_test.go
+++ b/pkg/route/here_planner_test.go
@@ -214,6 +214,10 @@ func (suite *HereTestSuite) TestZipLookups() {
 	// Postal code errors should be returned
 	_, err := planner.Zip5TransitDistance(badZip, goodZip)
 	suite.checkErrorCode(err, UnsupportedPostalCode)
+
+	// Postal code errors should be returned
+	_, err = planner.Zip3TransitDistance(badZip, goodZip)
+	suite.checkErrorCode(err, UnsupportedPostalCode)
 }
 
 func TestHereTestSuite(t *testing.T) {

--- a/pkg/route/planner.go
+++ b/pkg/route/planner.go
@@ -64,11 +64,16 @@ func zip5TransitDistanceHelper(planner Planner, source string, destination strin
 	return distance, err
 }
 
+func zip3TransitDistanceHelper(planner Planner, source string, destination string) (int, error) {
+	return 0, NewUnsupportedPostalCodeError(source)
+}
+
 // Planner is the interface needed by Handlers to be able to evaluate the distance to be used for move accounting
 type Planner interface {
 	TransitDistance(source *models.Address, destination *models.Address) (int, error)
 	LatLongTransitDistance(source LatLong, destination LatLong) (int, error)
 	Zip5TransitDistance(source string, destination string) (int, error)
+	Zip3TransitDistance(source string, destination string) (int, error)
 }
 
 // InitRoutePlanner validates Route Planner command line flags

--- a/pkg/route/planner_test.go
+++ b/pkg/route/planner_test.go
@@ -100,6 +100,27 @@ func (suite *PlannerFullSuite) TestZip5Distance() {
 	}
 }
 
+const txZip3 = "768"
+const caZip3 = "930"
+const ca2Zip3 = "902"
+
+func (suite *PlannerFullSuite) TestZip3Distance() {
+	tests := []struct {
+		zip1        string
+		zip2        string
+		distanceMin int
+		distanceMax int
+	}{
+		{zip1: txZip3, zip2: caZip3, distanceMin: 1000, distanceMax: 3000},
+		{zip1: ca2Zip3, zip2: caZip3, distanceMin: 30, distanceMax: 49},
+	}
+	for _, ts := range tests {
+		distance, err := suite.planner.Zip3TransitDistance(ts.zip1, ts.zip2)
+		suite.NotNil(err, "Should get error from Zip3 not number")
+		suite.Equal(distance, 0)
+	}
+}
+
 func TestHandlerSuite(t *testing.T) {
 	logger, err := zap.NewDevelopment()
 	if err != nil {

--- a/pkg/route/testing_planner.go
+++ b/pkg/route/testing_planner.go
@@ -18,6 +18,10 @@ func (tp testingPlanner) Zip5TransitDistance(source string, destination string) 
 	return zip5TransitDistanceHelper(tp, source, destination)
 }
 
+func (tp testingPlanner) Zip3TransitDistance(source string, destination string) (int, error) {
+	return zip3TransitDistanceHelper(tp, source, destination)
+}
+
 // NewTestingPlanner constructs a route.Planner to be used when testing other code
 func NewTestingPlanner(distance int) Planner {
 	return testingPlanner{

--- a/pkg/route/testing_planner.go
+++ b/pkg/route/testing_planner.go
@@ -6,18 +6,22 @@ type testingPlanner struct {
 	distance int
 }
 
+// TransitDistance calculates the distance between two valid addresses
 func (tp testingPlanner) TransitDistance(source *models.Address, destination *models.Address) (int, error) {
 	return tp.distance, nil
 }
 
+// LatLongTransitDistance calculates the distance between two sets of LatLong coordinates
 func (tp testingPlanner) LatLongTransitDistance(source LatLong, dest LatLong) (int, error) {
 	return tp.distance, nil
 }
 
+// Zip5TransitDistance calculates the distance between two valid Zip5s
 func (tp testingPlanner) Zip5TransitDistance(source string, destination string) (int, error) {
 	return zip5TransitDistanceHelper(tp, source, destination)
 }
 
+// Zip3TransitDistance calculates the distance between two valid Zip3s
 func (tp testingPlanner) Zip3TransitDistance(source string, destination string) (int, error) {
 	return zip3TransitDistanceHelper(tp, source, destination)
 }


### PR DESCRIPTION
## Description

In preparation for pricing service items on a payment request, the story MB-820 was to create a service object or functions for doing the necessary 3rd party requests for the calculations.

## Reviewer Notes

This PR only covers the subtasks MB-1150, MB-1153, and MB-1154 which cover the Zip3 and Zip5 distance helpers. Since we eventually need to connect to DTOD and/or Rand McNally APIs for these calculations the story was to use the existing HERE api for doing so. This api doesn't include calculation for Zip3s so a stub of that was added.

The reason Zip3 distance is a stub is that currently HERE planner code uses a helper to turn Zip5s into latitude and longitude coordinates and then makes a distance calculation based on the latitude and longitude. However, there is no equivalent way of turning Zip3s into latitude and longitude. So we will look into implementing that once the new 3rd party api is connected.

_**NOTE:** This PR does not complete MB-820 as that includes the function for fuel surcharge calculation._

## Setup

```sh
make server_test
go test -v -p 1 -count 1 ./pkg/route 
```

New docs in `docs/backend/route-planner.md`

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/tree/master/docs/backend.md#logging)
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira MB-820](https://dp3.atlassian.net/browse/MB-820) for this change