### PR TITLE
[MB-267] remove remaining references to TSP client

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -217,7 +217,6 @@ commands:
             LOGIN_GOV_CALLBACK_PROTOCOL: http
             LOGIN_GOV_MY_CLIENT_ID: urn:gov:gsa:openidconnect.profiles:sp:sso:dod:mymovemillocal
             LOGIN_GOV_OFFICE_CLIENT_ID: urn:gov:gsa:openidconnect.profiles:sp:sso:dod:officemovemillocal
-            LOGIN_GOV_TSP_CLIENT_ID: urn:gov:gsa:openidconnect.profiles:sp:sso:dod:tspmovemillocal
             LOGIN_GOV_ADMIN_CLIENT_ID: urn:gov:gsa:openidconnect.profiles:sp:sso:dod:adminmovemillocal
             LOGIN_GOV_HOSTNAME: idp.int.identitysandbox.gov
             HERE_MAPS_GEOCODE_ENDPOINT: https://geocoder.cit.api.here.com/6.2/geocode.json

--- a/Makefile
+++ b/Makefile
@@ -656,10 +656,6 @@ e2e_test_docker_mymove: ## Run e2e (end-to-end) Service Member integration tests
 e2e_test_docker_office: ## Run e2e (end-to-end) Office integration tests with docker
 	$(AWS_VAULT) SPEC=cypress/integration/office/**/* ./scripts/run-e2e-test-docker
 
-.PHONY: e2e_test_docker_tsp
-e2e_test_docker_tsp: ## Run e2e (end-to-end) TSP integration tests with docker
-	$(AWS_VAULT) SPEC=cypress/integration/tsp/**/* ./scripts/run-e2e-test-docker
-
 .PHONY: e2e_test_docker_api
 e2e_test_docker_api: ## Run e2e (end-to-end) API integration tests with docker
 	$(AWS_VAULT) SPEC=cypress/integration/api/**/* ./scripts/run-e2e-test-docker

--- a/src/App/index.jsx
+++ b/src/App/index.jsx
@@ -4,7 +4,7 @@ import { Provider } from 'react-redux';
 import Loadable from 'react-loadable';
 
 import LoadingPlaceholder from 'shared/LoadingPlaceholder';
-import { isOfficeSite, isTspSite, isAdminSite, isSystemAdminSite } from 'shared/constants.js';
+import { isOfficeSite, isAdminSite, isSystemAdminSite } from 'shared/constants.js';
 import { store } from 'shared/store';
 import { AppContext, defaultOfficeContext, defaultMyMoveContext, defaultAdminContext } from 'shared/AppContext';
 import { detectFlags } from 'shared/featureFlags.js';
@@ -47,7 +47,6 @@ const App = () => {
         </AppContext.Provider>
       </Provider>
     );
-  else if (isTspSite) return <h1 style={{ textAlign: 'center' }}>TSP App</h1>;
   else if (isSystemAdminSite)
     return (
       <AppContext.Provider value={adminContext}>

--- a/src/App/index.test.js
+++ b/src/App/index.test.js
@@ -1,8 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import App from '.';
-import { shallow } from 'enzyme';
-import * as constants from 'shared/constants.js';
 
 it('renders without crashing', () => {
   const div = document.createElement('div');
@@ -15,14 +13,6 @@ it('renders without crashing', () => {
   //    the test runner to crash. Immediately unmounting the component prevents the crash
   //    and still does the bare minimum of confirming that the whole app mounts without error.
   ReactDOM.unmountComponentAtNode(div);
-});
-
-it('renders the tsp app', () => {
-  constants.isTspSite = true;
-  const wrapper = shallow(<App />);
-  const h1 = wrapper.find('h1');
-  expect(h1.exists()).toBe(true);
-  expect(h1.text()).toEqual('TSP App');
 });
 
 //todo: add tests for routing

--- a/src/shared/constants.js
+++ b/src/shared/constants.js
@@ -12,7 +12,6 @@ export const ppmInfoPacket = '/downloads/ppm_info_sheet.pdf';
 export const hostname = window && window.location && window.location.hostname;
 export const isMilmoveSite = hostname.startsWith('my') || hostname.startsWith('mil') || '';
 export const isOfficeSite = hostname.startsWith('office') || '';
-export const isTspSite = hostname.startsWith('tsp') || '';
 export const isAdminSite = hostname.startsWith('admin') || '';
 export const isSystemAdminSite = isAdminSite; // once we start building program admin, we can flesh this out
 


### PR DESCRIPTION
## Description

This PR removes the few remaining refs to TSP client. A global search for `isTspSite` returns no references.

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/tree/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/tree/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/tree/master/docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
  * [ ] Secure migrations have been tested using `scripts/run-prod-migrations`
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-267) for this change
