### PR TITLE
Add better logging to PPM->GHC conversion

### DIFF
--- a/pkg/handlers/internalapi/moves.go
+++ b/pkg/handlers/internalapi/moves.go
@@ -166,10 +166,14 @@ func (h SubmitMoveHandler) Handle(params moveop.SubmitMoveForApprovalParams) mid
 	}
 
 	if h.HandlerContext.GetFeatureFlag(cli.FeatureFlagConvertPPMsToGHC) {
-		if _, convertErr := models.ConvertFromPPMToGHC(h.DB(), move.ID); convertErr != nil {
-			logger.Error("problem converting to new data model", zap.Error(err))
+		if moID, convertErr := models.ConvertFromPPMToGHC(h.DB(), move.ID); convertErr != nil {
+			logger.Error("PPM->GHC conversion error", zap.Error(err))
 			// don't return an error here because we don't want this to break the endpoint
+		} else {
+			logger.Info("PPM->GHC conversion successful. New MoveOrder created.", zap.String("move_order_id", moID.String()))
 		}
+	} else {
+		logger.Info("PPM->GHC conversion skipped (env var not set)")
 	}
 
 	movePayload, err := payloadForMoveModel(h.FileStorer(), move.Orders, *move)


### PR DESCRIPTION
## Description

This PR adds logging in every case around the PPM->GHC conversion so that we can know what is happening (or not) without trying to work backwards from a lot of logged SQL queries.

This builds upon the work done in [3227](https://github.com/transcom/mymove/pull/3227).

## Reviewer Notes

You should see something like this, with the text varying based on if things worked or not (or if the feature flag isn't set):

```
2020-01-21T20:56:15.969Z	INFO	internalapi/moves.go:173	PPM->GHC conversion successful. Created MoveOrder	{"git_branch": "jb-better-ghc-conversion-logging", "git_commit": "9d6c670888044d0d66571ef78ba12ea86739f768", "milmove_trace_id": "d014ae2b-d535-48a8-9fbe-b86f842aacb8", "move_order_id": "8f19aaee-b2d4-4e76-b171-f54f797c21b6"}
```

Note that this includes the ID of the new MoveOrder so you can spelunking in your database a bit easier.

## Setup

The usual. Run through the PPM flow. When submitting the move, you should see something logged. You can search for `PPM->GHC` in your console.