### PR TITLE
Upgrade aws-vault version to 5.2.X

### DIFF
--- a/scripts/check-aws-vault-version
+++ b/scripts/check-aws-vault-version
@@ -5,7 +5,7 @@ set -eu -o pipefail
 YELLOW='\033[0;33m'
 NC='\033[0m' # No Color
 
-VERSION="v5.0"
+VERSION="v5.2"
 
 VAULT_VERSION=$(type -p aws-vault && aws-vault --version)
 


### PR DESCRIPTION
## Description

Similar to https://github.com/transcom/ppp-infra/pull/800

Latest update. We skipped 5.1.X because it was broken.