### PR TITLE
Add FEATURE_FLAG_CONVERT_PPMS_TO_GHC to all env files.

### DIFF
--- a/config/env/experimental.app.env
+++ b/config/env/experimental.app.env
@@ -15,6 +15,7 @@ DOD_CA_PACKAGE=/config/tls/Certificates_PKCS7_v5.4_DoD.der.p7b
 DOMAIN=experimental.move.mil
 EMAIL_BACKEND=ses
 FEATURE_FLAG_ACCESS_CODE=false
+FEATURE_FLAG_CONVERT_PPMS_TO_GHC=true
 GEX_SEND_PROD_INVOICE=false
 GEX_URL=https://gexweba.daas.dla.mil/msg_data/submit/
 HERE_MAPS_GEOCODE_ENDPOINT=https://geocoder.cit.api.here.com/6.2/geocode.json

--- a/config/env/prod.app.env
+++ b/config/env/prod.app.env
@@ -12,6 +12,7 @@ DOD_CA_PACKAGE=/config/tls/Certificates_PKCS7_v5.4_DoD.der.p7b
 DOMAIN=move.mil
 EMAIL_BACKEND=ses
 FEATURE_FLAG_ACCESS_CODE=true
+FEATURE_FLAG_CONVERT_PPMS_TO_GHC=false
 GEX_SEND_PROD_INVOICE=true
 GEX_URL=https://gexweba.daas.dla.mil/msg_data/submit/
 HERE_MAPS_GEOCODE_ENDPOINT=https://geocoder.cit.api.here.com/6.2/geocode.json

--- a/config/env/staging.app.env
+++ b/config/env/staging.app.env
@@ -14,6 +14,7 @@ DOD_CA_PACKAGE=/config/tls/Certificates_PKCS7_v5.4_DoD.der.p7b
 DOMAIN=staging.move.mil
 EMAIL_BACKEND=ses
 FEATURE_FLAG_ACCESS_CODE=false
+FEATURE_FLAG_CONVERT_PPMS_TO_GHC=true
 GEX_SEND_PROD_INVOICE=false
 GEX_URL=https://gexweba.daas.dla.mil/msg_data/submit/
 HERE_MAPS_GEOCODE_ENDPOINT=https://geocoder.cit.api.here.com/6.2/geocode.json


### PR DESCRIPTION
## Description

This PR enables the PPM->GHC model conversion process on staging and experimental. It is kept disabled in production.

This builds upon the work done in [3227](https://github.com/transcom/mymove/pull/3227).

## Reviewer Notes

I don't think there is a way to test this before merging. Afterwards, we can verify that it is working on staging.