### PR TITLE
Revert "add audit logging to creating payment request"

### DIFF
--- a/pkg/handlers/primeapi/payment_request.go
+++ b/pkg/handlers/primeapi/payment_request.go
@@ -7,8 +7,6 @@ import (
 	"github.com/gofrs/uuid"
 	"go.uber.org/zap"
 
-	"github.com/transcom/mymove/pkg/services/audit"
-
 	paymentrequestop "github.com/transcom/mymove/pkg/gen/primeapi/primeoperations/payment_requests"
 	"github.com/transcom/mymove/pkg/gen/primemessages"
 	"github.com/transcom/mymove/pkg/handlers"
@@ -33,16 +31,9 @@ type CreatePaymentRequestHandler struct {
 func (h CreatePaymentRequestHandler) Handle(params paymentrequestop.CreatePaymentRequestParams) middleware.Responder {
 	// TODO: authorization to create payment request
 
-	session, logger := h.SessionAndLoggerFromRequest(params.HTTPRequest)
+	logger := h.LoggerFromRequest(params.HTTPRequest)
 
 	payload := params.Body
-
-	// Capture creation attempt in audit log
-	_, err := audit.Capture(&payload, nil, logger, session, params.HTTPRequest)
-	if err != nil {
-		logger.Error("Auditing service error for payment request creation.", zap.Error(err))
-		return paymentrequestop.NewCreatePaymentRequestInternalServerError()
-	}
 
 	if payload == nil {
 		logger.Error("Invalid payment request: params Body is nil")


### PR DESCRIPTION
This reverts commit c423925c96c81cc2eb2a8973d6228ea30d697833.

## Description

The changes in pr #3253 introduced a requirement on session in the prime api, which will not have any session as it uses mutual tls. This change reverts it so the prime-api will function again and I've created a story [MB-1296](https://dp3.atlassian.net/browse/MB-1296) to follow up on adding auditing to the payment-request endpoint.

## Reviewer Notes

## Setup

Follow the directions in `docs/how-to/make-a-sample-prime-api-call.md` to make calls to the prime-api and see a successful message

## References

* [this slack thread](https://ustcdp3.slack.com/archives/CP6PTUPQF/p1579806766020300) explains more about the approach used.
