### PR TITLE
Re-enable skipping jobs as github has notified us that this should work again

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -9,10 +9,10 @@ on:
 jobs:
   approve:
     name: auto-approve dependabot PRs
+    if: github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: approve
         uses: hmarr/auto-approve-action@v2.0.0
-        if: github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
In https://github.com/transcom/mymove/commit/6227227814496c48a41deed94ca5b3857907e96a#diff-5ecce909f53842a340be58ba4850af64 we moved the `if` statement because the ability to skip jobs wasn't working. The effect is that we run the github action on every single PR instead of just the dependabot ones. 

Github recently got back to us that [skipping jobs should work again](https://github.community/t5/GitHub-Actions/Status-of-workflows-with-no-running-jobs/td-p/37160). This PR essentially reverts the previous commit.