### PR TITLE
MB-1316 Fix rolename typo

### DIFF
--- a/migrations/20200128024819_fix_rolename_typo.up.sql
+++ b/migrations/20200128024819_fix_rolename_typo.up.sql
@@ -1,0 +1,14 @@
+UPDATE
+    roles
+SET
+    role_name = 'Transportation Ordering Officer'
+WHERE
+    role_type = 'transportation_ordering_officer';
+
+UPDATE
+    roles
+SET
+    role_name = 'Transportation Invoicing Officer'
+WHERE
+    role_type = 'transportation_invoicing_officer';
+

--- a/migrations_manifest.txt
+++ b/migrations_manifest.txt
@@ -438,3 +438,4 @@
 20200115173035_payment_request_add_service_item_param_keys.up.sql
 20200122221118_add_deleted_at_column_to_usersRoles_table.up.sql
 20200124192943_update_tariff400ng_mistaken_rate_area.up.sql
+20200128024819_fix_rolename_typo.up.sql

--- a/pkg/gen/adminapi/embedded_spec.go
+++ b/pkg/gen/adminapi/embedded_spec.go
@@ -1581,7 +1581,7 @@ func init() {
           "type": "string",
           "title": "roleType",
           "x-nullable": true,
-          "example": "transporation_ordering_officer"
+          "example": "transportation_ordering_officer"
         }
       }
     },
@@ -3537,7 +3537,7 @@ func init() {
           "type": "string",
           "title": "roleType",
           "x-nullable": true,
-          "example": "transporation_ordering_officer"
+          "example": "transportation_ordering_officer"
         }
       }
     },

--- a/swagger/admin.yaml
+++ b/swagger/admin.yaml
@@ -508,7 +508,7 @@ definitions:
         title: name
       roleType:
         type: string
-        example: 'transporation_ordering_officer'
+        example: 'transportation_ordering_officer'
         x-nullable: true
         title: roleType
   AdminUserCreatePayload:


### PR DESCRIPTION
## Description

I made a typo in the roleNames when I set up the table.  Fixing.

* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/tree/master/docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-1316?searchSessionId=ed2cd5c5-4ca0-4e7e-9e1d-e1690bbb2008&searchContainerId=10000&searchContentType=issue&searchObjectId=13164) for this change
* [this article](tbd) explains more about the approach used.