### PR TITLE
show actual move date vs planned move date on ssw

### DIFF
--- a/pkg/models/shipment_summary_worksheet.go
+++ b/pkg/models/shipment_summary_worksheet.go
@@ -653,8 +653,8 @@ func FormatPPMWeight(ppm PersonallyProcuredMove) string {
 
 //FormatPPMPickupDate formats a shipments ActualPickupDate for the Shipment Summary Worksheet
 func FormatPPMPickupDate(ppm PersonallyProcuredMove) string {
-	if ppm.OriginalMoveDate != nil {
-		return FormatDate(*ppm.OriginalMoveDate)
+	if ppm.ActualMoveDate != nil {
+		return FormatDate(*ppm.ActualMoveDate)
 	}
 	return ""
 }


### PR DESCRIPTION
## Description

We are currently showing planned move date on the ssw, but for the rate calculation, we use actual move date. Update the ssw to display actual move date date.

## Reviewer Notes

Create a move w/ planned move date different than actual move date and ensure ssw shows correct date.

## Setup

`make server_run`
`make client_run`

## Code Review Verification Steps

* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](tbd) for this change

## Screenshots

