### PR TITLE
Fix additional pointer issues

### DIFF
--- a/pkg/handlers/ghcapi/internal/payloads/model_to_payload.go
+++ b/pkg/handlers/ghcapi/internal/payloads/model_to_payload.go
@@ -53,19 +53,23 @@ func MoveOrder(moveOrder *models.MoveOrder) *ghcmessages.MoveOrder {
 	}
 	entitlements := Entitlement(moveOrder.Entitlement)
 	payload := ghcmessages.MoveOrder{
-		Agency:                 moveOrder.Customer.Agency,
-		CustomerID:             strfmt.UUID(moveOrder.CustomerID.String()),
-		FirstName:              moveOrder.Customer.FirstName,
-		LastName:               moveOrder.Customer.LastName,
 		DestinationDutyStation: destinationDutyStation,
 		Entitlement:            entitlements,
 		OrderNumber:            moveOrder.OrderNumber,
 		OrderTypeDetail:        moveOrder.OrderTypeDetail,
-		ReportByDate:           strfmt.Date(*moveOrder.ReportByDate),
 		ID:                     strfmt.UUID(moveOrder.ID.String()),
 		OriginDutyStation:      originDutyStation,
 	}
 
+	if moveOrder.Customer != nil {
+		payload.Agency = moveOrder.Customer.Agency
+		payload.CustomerID = strfmt.UUID(moveOrder.CustomerID.String())
+		payload.FirstName = moveOrder.Customer.FirstName
+		payload.LastName = moveOrder.Customer.LastName
+	}
+	if moveOrder.ReportByDate != nil {
+		payload.ReportByDate = strfmt.Date(*moveOrder.ReportByDate)
+	}
 	if moveOrder.DateIssued != nil {
 		payload.DateIssued = strfmt.Date(*moveOrder.DateIssued)
 	}

--- a/pkg/handlers/ghcapi/internal/payloads/model_to_payload_test.go
+++ b/pkg/handlers/ghcapi/internal/payloads/model_to_payload_test.go
@@ -1,0 +1,12 @@
+package payloads
+
+import (
+	"testing"
+
+	"github.com/transcom/mymove/pkg/models"
+)
+
+func TestMoveOrder(t *testing.T) {
+	moveOrder := &models.MoveOrder{}
+	MoveOrder(moveOrder)
+}

--- a/src/scenes/Office/TOO/too.jsx
+++ b/src/scenes/Office/TOO/too.jsx
@@ -47,7 +47,7 @@ class TOO extends Component {
                   <td>{`${last_name}, ${first_name}`}</td>
                   <td>{confirmation_number}</td>
                   <td>{agency}</td>
-                  <td>{originDutyStation.name}</td>
+                  <td>{originDutyStation && originDutyStation.name}</td>
                 </tr>
               ),
             )}


### PR DESCRIPTION
## Description

I missed a few spots in a [prior PR](https://github.com/transcom/mymove/pull/3439), so check that one out for some background. We're still getting a 500 on staging (but due to a different reason).

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
$ make db_dev_e2e_populate
$ make office_client_run
$ make server_run
```

1. Visit `/too/customer-moves` and verify that the table of data loads.
2. Choose a row in the`move_orders` table in your `dev_db` database and make every field `NULL` that can store that value.
3. Verify that the table still loads (some values will be missing in one of the move orders now).