### PR TITLE
els fix secure migration script

### DIFF
--- a/scripts/download-secure-migration
+++ b/scripts/download-secure-migration
@@ -42,13 +42,6 @@ if [[ -z "${1:-}" ]]; then
 fi
 readonly production_migration_file="$1"
 
-# Ensure our `aws` command is the one infra has wrapped with aws-vault
-command -v "$aws_command" 2> /dev/null | grep "ppp-infra/scripts/aws" &> /dev/null || \
-  ( echo "error: aws command not pointing to 'ppp-infra/scripts/aws"
-    echo "see https://github.com/transcom/ppp-infra/blob/master/transcom-ppp/README.md#using-aws-vault"
-    exit 1
-  )
-
 # Test AWS command and freshen AWS session token
 ${aws_command} s3 ls "${aws_bucket_prefix}${environments[0]}${aws_bucket_suffix}" > /dev/null
 

--- a/scripts/update-s3-sql-files
+++ b/scripts/update-s3-sql-files
@@ -25,13 +25,6 @@ if [[ -z "${1:-}" ]]; then
 fi
 readonly environment="${1}"
 
-# Ensure our `aws` command is the one infra has wrapped with aws-vault
-command -v "$aws_command" 2> /dev/null | grep "ppp-infra/scripts/aws" &> /dev/null || \
-  ( echo "error: aws command not pointing to 'ppp-infra/scripts/aws"
-    echo "see https://github.com/transcom/ppp-infra/blob/master/transcom-ppp/README.md#using-aws-vault"
-    exit 1
-  )
-
 bucket="${aws_bucket_prefix}${environment}${aws_bucket_suffix}"
 
 # Find only the files that need to be renamed

--- a/scripts/upload-secure-migration
+++ b/scripts/upload-secure-migration
@@ -65,13 +65,6 @@ if [[ ${FILESIZE} -gt ${MAX_FILESIZE} ]]; then
   exit 1
 fi
 
-# Ensure our `aws` command is the one infra has wrapped with aws-vault
-command -v "$aws_command" 2> /dev/null | grep "ppp-infra/scripts/aws" &> /dev/null || \
-  ( echo "error: aws command not pointing to 'ppp-infra/scripts/aws"
-    echo "see https://github.com/transcom/ppp-infra/blob/master/transcom-ppp/README.md#using-aws-vault"
-    exit 1
-  )
-
 # Test AWS command and freshen AWS session token
 ${aws_command} s3 ls "${aws_bucket_prefix}${environments[0]}${aws_bucket_suffix}" > /dev/null
 


### PR DESCRIPTION
## Description

download-secure-migrations, upload-secure-migrations, and update-s3-sql-files were still testing for the ppp-infra version of aws-vault but that is no longer needed. This PR removes those checks.

## to test:
1. follow the steps in [Secure Migrations](https://github.com/transcom/mymove/blob/master/docs/database/migrate-the-database.md#secure-migrations) to create and upload a secure migration to at least one environment
2. use `download-secure-migrations` to download that file

## open questions

should we just delete `update-s3-sql-files` since it is not supposed to be run more than once on an environment?

