### PR TITLE
Build tasks inside docker locally for pkcs11 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -546,7 +546,10 @@ jobs:
           keys:
             - go-mod-sources-v2-{{ checksum "go.sum" }}-{{ checksum "scripts/check-go-version" }}}
       - run: make bin/rds-ca-2019-root.pem
-      - run: make tasks_build
+      - run: rm -f pkg/assets/assets.go && make pkg/assets/assets.go
+      - run: rm -f bin/swagger && make bin/swagger
+      - run: make server_generate
+      - run: rm -f bin/milmove-tasks && make bin/milmove-tasks
       - build_tag_push:
           dockerfile: Dockerfile.tasks
           tag: tasks:dev

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -775,7 +775,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: placeholder_branch_name
+              ignore: cg_build_tasks_inside_docker_locally
 
       - client_test:
           requires:
@@ -783,7 +783,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: placeholder_branch_name
+              ignore: cg_build_tasks_inside_docker_locally
 
       - server_test:
           requires:
@@ -791,7 +791,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: placeholder_branch_name
+              ignore: cg_build_tasks_inside_docker_locally
 
       - build_app:
           requires:
@@ -832,28 +832,28 @@ workflows:
             - build_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: cg_build_tasks_inside_docker_locally
 
       - deploy_experimental_tasks:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: cg_build_tasks_inside_docker_locally
 
       - deploy_experimental_app:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: cg_build_tasks_inside_docker_locally
 
       - deploy_experimental_app_client_tls:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: cg_build_tasks_inside_docker_locally
 
       - check_circle_against_staging_sha:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -775,7 +775,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: cg_build_tasks_inside_docker_locally
+              ignore: placeholder_branch_name
 
       - client_test:
           requires:
@@ -783,7 +783,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: cg_build_tasks_inside_docker_locally
+              ignore: placeholder_branch_name
 
       - server_test:
           requires:
@@ -791,7 +791,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: cg_build_tasks_inside_docker_locally
+              ignore: placeholder_branch_name
 
       - build_app:
           requires:
@@ -832,28 +832,28 @@ workflows:
             - build_migrations
           filters:
             branches:
-              only: cg_build_tasks_inside_docker_locally
+              only: placeholder_branch_name
 
       - deploy_experimental_tasks:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: cg_build_tasks_inside_docker_locally
+              only: placeholder_branch_name
 
       - deploy_experimental_app:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: cg_build_tasks_inside_docker_locally
+              only: placeholder_branch_name
 
       - deploy_experimental_app_client_tls:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: cg_build_tasks_inside_docker_locally
+              only: placeholder_branch_name
 
       - check_circle_against_staging_sha:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,12 +90,12 @@ commands:
           at: bin
       - deploy:
           name: Deploy fuel price data task service
-          command: scripts/do-exclusively --job-name ${CIRCLE_JOB} scripts/ecs-deploy-task-container save-fuel-price-data "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/app:git-${CIRCLE_SHA1}" "${APP_ENVIRONMENT}"
+          command: scripts/do-exclusively --job-name ${CIRCLE_JOB} scripts/ecs-deploy-task-container save-fuel-price-data "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/app-tasks:git-${CIRCLE_SHA1}" "${APP_ENVIRONMENT}"
           no_output_timeout: 20m
       - announce_failure
       - deploy:
           name: Deploy post move email survey task service
-          command: scripts/do-exclusively --job-name ${CIRCLE_JOB} scripts/ecs-deploy-task-container send-post-move-survey "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/app:git-${CIRCLE_SHA1}" "${APP_ENVIRONMENT}"
+          command: scripts/do-exclusively --job-name ${CIRCLE_JOB} scripts/ecs-deploy-task-container send-post-move-survey "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/app-tasks:git-${CIRCLE_SHA1}" "${APP_ENVIRONMENT}"
           no_output_timeout: 20m
       - announce_failure
   deploy_app_steps:

--- a/Dockerfile.tasks_local
+++ b/Dockerfile.tasks_local
@@ -4,8 +4,6 @@
 
 FROM trussworks/circleci-docker-primary:6f138d780444b35181e0048282616f75a451d7b4 as builder
 
-ENV GO111MODULE=auto
-
 COPY --chown=circleci:circleci . /home/circleci/project
 WORKDIR /home/circleci/project
 

--- a/Dockerfile.tasks_local
+++ b/Dockerfile.tasks_local
@@ -6,7 +6,6 @@ FROM trussworks/circleci-docker-primary:6f138d780444b35181e0048282616f75a451d7b4
 
 ENV GO111MODULE=auto
 
-RUN pwd
 COPY --chown=circleci:circleci . /home/circleci/project
 WORKDIR /home/circleci/project
 

--- a/Dockerfile.tasks_local
+++ b/Dockerfile.tasks_local
@@ -9,8 +9,12 @@ ENV GO111MODULE=auto
 COPY --chown=circleci:circleci . /home/circleci/project
 WORKDIR /home/circleci/project
 
+RUN make clean
 RUN make bin/rds-ca-2019-root.pem
-RUN make tasks_build
+RUN make pkg/assets/assets.go
+RUN make bin/swagger
+RUN make server_generate
+RUN make bin/milmove-tasks
 
 #########
 # FINAL #

--- a/Dockerfile.tasks_local
+++ b/Dockerfile.tasks_local
@@ -1,5 +1,25 @@
+###########
+# BUILDER #
+###########
+
+FROM trussworks/circleci-docker-primary:6f138d780444b35181e0048282616f75a451d7b4 as builder
+
+ENV GO111MODULE=auto
+
+RUN pwd
+COPY --chown=circleci:circleci . /home/circleci/project
+WORKDIR /home/circleci/project
+
+RUN make bin/rds-ca-2019-root.pem
+RUN make tasks_build
+
+#########
+# FINAL #
+#########
+
 FROM gcr.io/distroless/base:latest
 
-COPY bin_linux/milmove-tasks /bin/milmove-tasks
+COPY --from=builder /home/circleci/project/bin/rds-ca-2019-root.pem /bin/rds-ca-2019-root.pem
+COPY --from=builder /home/circleci/project/bin/milmove-tasks /bin/milmove-tasks
 
 WORKDIR /bin

--- a/Makefile
+++ b/Makefile
@@ -266,9 +266,6 @@ bin_linux/milmove:
 bin/milmove-tasks:
 	go build -ldflags "$(LDFLAGS) $(WEBSERVER_LDFLAGS)" -o bin/milmove-tasks ./cmd/milmove-tasks
 
-bin_linux/milmove-tasks:
-	GOOS=linux GOARCH=amd64 go build -ldflags "$(LDFLAGS) $(WEBSERVER_LDFLAGS)" -o bin_linux/milmove-tasks ./cmd/milmove-tasks
-
 bin/prime-api-client:
 	go build -ldflags "$(LDFLAGS)" -o bin/prime-api-client ./cmd/prime-api-client
 
@@ -708,7 +705,6 @@ db_test_e2e_cleanup: ## Clean up Test DB backup `e2e_test`
 .PHONY: tasks_clean
 tasks_clean: ## Clean Scheduled Task files and docker images
 	rm -f .db_test_migrations_build.stamp
-	rm -rf bin_linux/
 	docker rm -f tasks || true
 
 .PHONY: tasks_build
@@ -720,7 +716,7 @@ tasks_build_docker: server_generate bin/milmove-tasks ## Build Scheduled Task de
 	docker build -f Dockerfile.tasks --tag $(TASKS_DOCKER_CONTAINER):latest .
 
 .PHONY: tasks_build_linux_docker
-tasks_build_linux_docker: bin_linux/milmove-tasks ## Build Scheduled Task binaries (linux) and Docker image (local)
+tasks_build_linux_docker:  ## Build Scheduled Task binaries (linux) and Docker image (local)
 	@echo "Build the docker scheduled tasks container..."
 	docker build -f Dockerfile.tasks_local --tag $(TASKS_DOCKER_CONTAINER):latest .
 

--- a/cmd/ecs-deploy/task_def.go
+++ b/cmd/ecs-deploy/task_def.go
@@ -119,8 +119,11 @@ type ECRImage struct {
 	RepositoryName string
 }
 
-func NewECRImage(imageURI string) *ECRImage {
+func NewECRImage(imageURI string) (*ECRImage, error) {
 	imageParts := strings.Split(imageURI, ":")
+	if len(imageParts) != 2 {
+		return nil, fmt.Errorf("Image URI requires ':'")
+	}
 	repositoryURI, imageTag := imageParts[0], imageParts[1]
 	repositoryURIParts := strings.Split(repositoryURI, "/")
 	repositoryName := repositoryURIParts[1]
@@ -134,7 +137,7 @@ func NewECRImage(imageURI string) *ECRImage {
 		RegistryID:     registryID,
 		RepositoryURI:  repositoryURI,
 		RepositoryName: repositoryName,
-	}
+	}, nil
 }
 
 func initTaskDefFlags(flag *pflag.FlagSet) {
@@ -423,7 +426,10 @@ func taskDefFunction(cmd *cobra.Command, args []string) error {
 	serviceNameShort := serviceNameParts[0]
 
 	// Confirm the image exists
-	ecrImage := NewECRImage(imageURI)
+	ecrImage, errECRImage := NewECRImage(imageURI)
+	if errECRImage != nil {
+		quit(logger, nil, fmt.Errorf("unable to recognize image URI %q: %w", imageURI, errECRImage))
+	}
 	imageIdentifier := ecr.ImageIdentifier{}
 	imageIdentifier.SetImageTag(ecrImage.ImageTag)
 	errImageIdentifierValidate := imageIdentifier.Validate()
@@ -453,6 +459,7 @@ func taskDefFunction(cmd *cobra.Command, args []string) error {
 	// Register the new task definition
 	executionRoleArn := fmt.Sprintf("ecs-task-execution-role-%s-%s", serviceName, environmentName)
 	taskRoleArn := fmt.Sprintf("ecs-task-role-%s-%s", serviceName, environmentName)
+	family := fmt.Sprintf("%s-%s", serviceName, environmentName)
 
 	// handle entrypoint specific logic
 	var awsLogsStreamPrefix string
@@ -460,6 +467,10 @@ func taskDefFunction(cmd *cobra.Command, args []string) error {
 	var portMappings []*ecs.PortMapping
 	var containerDefName string
 	if commandName == binMilMoveTasks {
+		executionRoleArn = fmt.Sprintf("ecs-task-exec-role-%s-%s-%s", serviceNameShort, environmentName, subCommandName)
+		taskRoleArn = fmt.Sprintf("ecs-task-role-%s-%s-%s", serviceNameShort, environmentName, subCommandName)
+		family = fmt.Sprintf("%s-%s-%s", serviceNameShort, environmentName, subCommandName)
+
 		awsLogsStreamPrefix = serviceName
 		awsLogsGroup = fmt.Sprintf("ecs-tasks-%s-%s", serviceNameShort, environmentName)
 		containerDefName = fmt.Sprintf("%s-%s-%s", serviceName, subCommandName, environmentName)
@@ -536,7 +547,7 @@ func taskDefFunction(cmd *cobra.Command, args []string) error {
 		},
 		Cpu:                     aws.String(cpu),
 		ExecutionRoleArn:        aws.String(executionRoleArn),
-		Family:                  aws.String(fmt.Sprintf("%s-%s", serviceName, environmentName)),
+		Family:                  aws.String(family),
 		Memory:                  aws.String(mem),
 		NetworkMode:             aws.String("awsvpc"),
 		RequiresCompatibilities: []*string{aws.String("FARGATE")},

--- a/scripts/ecs-deploy-task-container
+++ b/scripts/ecs-deploy-task-container
@@ -30,6 +30,8 @@ task_def_arn=$("${DIR}/../bin/ecs-deploy" task-def\
   --service app-tasks \
   --environment "${environment}" \
   --image "${image}" \
+  --cpu 256 \
+  --memory 512 \
   --variables-file "${DIR}/../config/env/${environment}.${name}.env" \
   --entrypoint "/bin/milmove-tasks ${name}" \
   --register)


### PR DESCRIPTION
## Description

There are several issues this is addressing:

PKCS11 support in our repo means we can't cross compile this binary for linux on macOS to test locally inside Docker. So instead of cross compiling on macOS this adds a builder container for the binary and builds inside Docker.

The `assets.go` code changes when created inside a linux environment instead of a macOS environment. Having this file checked into the repo doesn't help our build pipeline. To fix this the build steps were changed to rebuild this file from scratch before making the `milmove-tasks` binary.

The ECS deploy binary incorrectly formatted the execution role, task role, and family name for the ECS scheduled tasks. The CircleCI steps additionally pointed to the wrong docker image. Fixing these steps fixes deploys for the tasks.

## Impact

The ECS Schedule Tasks broke sometime between Dec 6, 2019 and Jan 6, 2020. We know this because the fuel prices come out on the 6th of each month and only the January data was missing, meaning the December fuel prices were downloaded correctly.

Part of the debugging issue was the merge of the PKCS11 code in https://github.com/transcom/mymove/pull/3395 on Feb 4, 2020. However, this only complicated debugging locally and should not have had any impact on the compiled binaries.

Part of the issue was the merging of https://github.com/transcom/mymove/pull/3229 on Jan 15. If this was the original problem the fuel prices would have been downloaded on Jan 6 but were not.  

Part of the issue was the compiled `assets.go` file, which [we've been merging since Sept, 2019](https://github.com/transcom/mymove/commits/master/pkg/assets). However, I'd expect that we would have seen this issue sooner.

Finally, it appears that Fuel Price data has not been needed since removing HHG from the application, but it will be important in the next couple weeks. Also, its unclear that missing emails have caused any issues.

## Setup

Try out the tasks:

```sh
make db_dev_run db_dev_migrate
make tasks_save_fuel_price_data
make tasks_send_post_move_survey
```

Also

```sh
rm -f bin/ecs-deploy && make bin/ecs-deploy
./bin/ecs-deploy task-def \
  --aws-account-id "${AWS_ACCOUNT_ID}" \
  --aws-region "${AWS_DEFAULT_REGION}" \
  --service app-tasks \
  --environment experimental \
  --image "923914045601.dkr.ecr.us-west-2.amazonaws.com/app-tasks:git-3554bda70a75c75548b1bd47d01b4f852dea5427" \
  --cpu 256 \
  --memory 512 \
  --variables-file "./config/env/experimental.save-fuel-price-data.env" \
  --entrypoint "/bin/milmove-tasks save-fuel-price-data" \
  --dry-run | jq .
```