### PR TITLE
Remove GOPROXY in docker-compose files

### DIFF
--- a/docker-compose.circle.yml
+++ b/docker-compose.circle.yml
@@ -48,7 +48,6 @@ services:
       - ENV=test
       - ENVIRONMENT=test
       - FEATURE_FLAG_ACCESS_CODE=false
-      - GOPROXY=https://gocenter.io
       - HERE_MAPS_APP_CODE
       - HERE_MAPS_APP_ID
       - HERE_MAPS_GEOCODE_ENDPOINT

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -65,7 +65,6 @@ services:
       - EIA_KEY=db2522a43820268a41a802a16ae9fd26 # dummy key generated with openssl rand -hex 16
       - ENVIRONMENT=test
       - FEATURE_FLAG_ACCESS_CODE=false
-      - GOPROXY=https://gocenter.io
       - HERE_MAPS_APP_CODE
       - HERE_MAPS_APP_ID
       - HERE_MAPS_GEOCODE_ENDPOINT

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,7 +61,6 @@ services:
       - EIA_KEY=db2522a43820268a41a802a16ae9fd26 # dummy key generated with openssl rand -hex 16
       - ENVIRONMENT=test
       - FEATURE_FLAG_ACCESS_CODE=false
-      - GOPROXY=https://gocenter.io
       - HERE_MAPS_APP_CODE
       - HERE_MAPS_APP_ID
       - HERE_MAPS_GEOCODE_ENDPOINT


### PR DESCRIPTION
## Description

Our `docker-compose` files were setting the `GOPROXY` environment variable to point to `https://gocenter.io` rather than relying on the [Go 1.13 default](https://golang.org/doc/go1.13#modules).  Using a non-default `GOPROXY` sometimes failed with a 404.  Unless there's a good reason to use the non-default proxy, we should remove the explicit setting of it.

## Setup

`make server_test_docker`
