### PR TITLE
Small updates for local testing of server tests like in CircleCI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -440,7 +440,7 @@ server_test_coverage: db_test_reset db_test_migrate server_test_coverage_generat
 
 .PHONY: server_test_docker
 server_test_docker:
-	docker-compose -f docker-compose.circle.yml --compatibility up --remove-orphans
+	docker-compose -f docker-compose.circle.yml --compatibility up --remove-orphans --abort-on-container-exit
 
 .PHONY: server_test_docker_down
 server_test_docker_down:

--- a/Makefile
+++ b/Makefile
@@ -440,7 +440,11 @@ server_test_coverage: db_test_reset db_test_migrate server_test_coverage_generat
 
 .PHONY: server_test_docker
 server_test_docker:
-	docker-compose -f docker-compose.circle.yml --compatibility up server_test
+	docker-compose -f docker-compose.circle.yml --compatibility up --remove-orphans
+
+.PHONY: server_test_docker_down
+server_test_docker_down:
+	docker-compose -f docker-compose.circle.yml down
 
 #
 # ----- END SERVER TARGETS -----

--- a/docker-compose.circle.yml
+++ b/docker-compose.circle.yml
@@ -15,6 +15,8 @@ services:
       - POSTGRES_DB=test_db
 
   server_test:
+    depends_on:
+      - database
     image: trussworks/circleci-docker-primary:6f138d780444b35181e0048282616f75a451d7b4
     deploy:
       resources:

--- a/scripts/run-server-test-in-circle-container
+++ b/scripts/run-server-test-in-circle-container
@@ -21,4 +21,3 @@ mkdir -p tmp/test-results/gotest
 ## setup a trap incase the tests fail, we still want to generate the report
 trap "bin/go-junit-report < tmp/test-results/gotest/go-test.out >  tmp/test-results/gotest/go-test-report.xml" EXIT
 make server_test_standalone | tee tmp/test-results/gotest/go-test.out
-


### PR DESCRIPTION
## Description

I tried running locally but the DB in the docker-compose file wasn't working. This PR fixes that, adds a dependency, and also an extra target for tearing it down. Nothing fancy here.

```sh
make server_test_docker
make server_test_docker_down
```