### PR TITLE
Kill existing debug processes before starting the debug server.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -333,13 +333,10 @@ server_run_default: .check_hosts.stamp .check_go_version.stamp .check_gopath.sta
 		serve \
 		2>&1 | tee -a log/dev.log
 
-
-# This target also kills any process that is running on ports 8080 or 9443 as the debug processes
-# tend to not be cleaned up properly.
 .PHONY: server_run_debug
 server_run_debug: .check_hosts.stamp .check_go_version.stamp .check_gopath.stamp .check_node_version.stamp check_log_dir build/index.html server_generate db_dev_run ## Debug the server
-	lsof -t -i :8080 | xargs kill -9
-	lsof -t -i :9443 | xargs kill -9
+	scripts/kill-process-on-port 8080
+	scripts/kill-process-on-port 9443
 	$(AWS_VAULT) dlv debug cmd/milmove/*.go -- serve 2>&1 | tee -a log/dev.log
 
 .PHONY: build_tools

--- a/Makefile
+++ b/Makefile
@@ -333,8 +333,13 @@ server_run_default: .check_hosts.stamp .check_go_version.stamp .check_gopath.sta
 		serve \
 		2>&1 | tee -a log/dev.log
 
+
+# This target also kills any process that is running on ports 8080 or 9443 as the debug processes
+# tend to not be cleaned up properly.
 .PHONY: server_run_debug
-server_run_debug: check_log_dir ## Debug the server
+server_run_debug: .check_hosts.stamp .check_go_version.stamp .check_gopath.stamp .check_node_version.stamp check_log_dir build/index.html server_generate db_dev_run ## Debug the server
+	lsof -t -i :8080 | xargs kill -9
+	lsof -t -i :9443 | xargs kill -9
 	$(AWS_VAULT) dlv debug cmd/milmove/*.go -- serve 2>&1 | tee -a log/dev.log
 
 .PHONY: build_tools

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -23,6 +23,7 @@ environment.
 | `check-hosts-file` | Script helps ensure that /etc/hosts has all the correct entries in it |
 | `check-node-version` | checks the node version required for the project |
 | `check-opensc-version` | checks the opensc version required for the project |
+| `kill-process-on-port` | asks to kill a process running on the specified port |
 | `prereqs` | validate if all prerequisite programs have been installed |
 
 ## AWS Scripts

--- a/scripts/kill-process-on-port
+++ b/scripts/kill-process-on-port
@@ -1,0 +1,37 @@
+#! /usr/bin/env bash
+#
+# A script that asks and then kills a process running on a certain port.
+#
+
+set -eu -o pipefail
+
+readonly usage="usage: $0 <port>"
+
+function proceed() {
+  proceed_message=${1:-"proceed"}
+  echo -en "\e[31m${proceed_message} (y/N) \e[39m"
+  read -r proceed
+  if [[ "$proceed" =~ ^[^yY]*$ ]]; then
+    echo "exiting"
+    exit 0
+  fi
+}
+
+port=${1:-}
+
+if [[ -z "$port" ]]; then
+  echo "$usage"
+  exit 1
+fi
+
+pid=$(lsof -t -sTCP:LISTEN -i :"$port") || true
+
+if [[ -z "$pid" ]]; then
+  exit 0
+else
+  echo "The following process is running on port $port."
+  lsof -i :"$port" | grep LISTEN
+  proceed "Shall I kill it for you?"
+  kill -9 "$pid"
+  echo "It is done."
+fi

--- a/scripts/kill-process-on-port
+++ b/scripts/kill-process-on-port
@@ -30,7 +30,7 @@ if [[ -z "$pid" ]]; then
   exit 0
 else
   echo "The following process is running on port $port."
-  lsof -i :"$port" | grep LISTEN
+  lsof -sTCP:LISTEN -i :"$port"
   proceed "Shall I kill it for you?"
   kill -9 "$pid"
   echo "It is done."


### PR DESCRIPTION
## Description

For whatever reason, the server processes don't exit cleanly when run through delve. This PR kills any running processes on the server ports so that the debug server can start.

## Reviewer Notes

I also copied the target dependencies from the normal `server_run` as I hit a situation the debug server was failing because one of those dependencies was out of date.

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
$ make server_run_debug

# then exit out of the debugger

$ make server_run_debug
```

The second invocation should work without an error about a port already bring in use.