### PR TITLE
Update information being displayed on TOO page.

### DIFF
--- a/pkg/gen/ghcapi/embedded_spec.go
+++ b/pkg/gen/ghcapi/embedded_spec.go
@@ -1988,6 +1988,10 @@ func init() {
           "type": "string",
           "example": "handle with care"
         },
+        "destinationAddress": {
+          "x-nullabe": true,
+          "$ref": "#/definitions/Address"
+        },
         "id": {
           "type": "string",
           "format": "uuid",
@@ -1998,6 +2002,10 @@ func init() {
           "format": "uuid",
           "example": "1f2270c7-7166-40ae-981e-b200ebdf3054"
         },
+        "pickupAddress": {
+          "x-nullabe": true,
+          "$ref": "#/definitions/Address"
+        },
         "requestedPickupDate": {
           "type": "string",
           "format": "date"
@@ -2005,6 +2013,14 @@ func init() {
         "scheduledPickupDate": {
           "type": "string",
           "format": "date"
+        },
+        "secondaryDeliveryAddress": {
+          "x-nullabe": true,
+          "$ref": "#/definitions/Address"
+        },
+        "secondaryPickupAddress": {
+          "x-nullabe": true,
+          "$ref": "#/definitions/Address"
         },
         "shipmentType": {
           "enum": [
@@ -4641,6 +4657,10 @@ func init() {
           "type": "string",
           "example": "handle with care"
         },
+        "destinationAddress": {
+          "x-nullabe": true,
+          "$ref": "#/definitions/Address"
+        },
         "id": {
           "type": "string",
           "format": "uuid",
@@ -4651,6 +4671,10 @@ func init() {
           "format": "uuid",
           "example": "1f2270c7-7166-40ae-981e-b200ebdf3054"
         },
+        "pickupAddress": {
+          "x-nullabe": true,
+          "$ref": "#/definitions/Address"
+        },
         "requestedPickupDate": {
           "type": "string",
           "format": "date"
@@ -4658,6 +4682,14 @@ func init() {
         "scheduledPickupDate": {
           "type": "string",
           "format": "date"
+        },
+        "secondaryDeliveryAddress": {
+          "x-nullabe": true,
+          "$ref": "#/definitions/Address"
+        },
+        "secondaryPickupAddress": {
+          "x-nullabe": true,
+          "$ref": "#/definitions/Address"
         },
         "shipmentType": {
           "enum": [

--- a/pkg/gen/ghcmessages/m_t_o_shipment.go
+++ b/pkg/gen/ghcmessages/m_t_o_shipment.go
@@ -26,6 +26,9 @@ type MTOShipment struct {
 	// customer remarks
 	CustomerRemarks string `json:"customerRemarks,omitempty"`
 
+	// destination address
+	DestinationAddress *Address `json:"destinationAddress,omitempty"`
+
 	// id
 	// Format: uuid
 	ID strfmt.UUID `json:"id,omitempty"`
@@ -34,6 +37,9 @@ type MTOShipment struct {
 	// Format: uuid
 	MoveTaskOrderID strfmt.UUID `json:"moveTaskOrderID,omitempty"`
 
+	// pickup address
+	PickupAddress *Address `json:"pickupAddress,omitempty"`
+
 	// requested pickup date
 	// Format: date
 	RequestedPickupDate strfmt.Date `json:"requestedPickupDate,omitempty"`
@@ -41,6 +47,12 @@ type MTOShipment struct {
 	// scheduled pickup date
 	// Format: date
 	ScheduledPickupDate strfmt.Date `json:"scheduledPickupDate,omitempty"`
+
+	// secondary delivery address
+	SecondaryDeliveryAddress *Address `json:"secondaryDeliveryAddress,omitempty"`
+
+	// secondary pickup address
+	SecondaryPickupAddress *Address `json:"secondaryPickupAddress,omitempty"`
 
 	// shipment type
 	// Enum: [HHG INTERNATIONAL_HHG INTERNATIONAL_UB]
@@ -63,6 +75,10 @@ func (m *MTOShipment) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
+	if err := m.validateDestinationAddress(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateID(formats); err != nil {
 		res = append(res, err)
 	}
@@ -71,11 +87,23 @@ func (m *MTOShipment) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
+	if err := m.validatePickupAddress(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateRequestedPickupDate(formats); err != nil {
 		res = append(res, err)
 	}
 
 	if err := m.validateScheduledPickupDate(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateSecondaryDeliveryAddress(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateSecondaryPickupAddress(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -101,6 +129,24 @@ func (m *MTOShipment) validateCreatedAt(formats strfmt.Registry) error {
 
 	if err := validate.FormatOf("createdAt", "body", "datetime", m.CreatedAt.String(), formats); err != nil {
 		return err
+	}
+
+	return nil
+}
+
+func (m *MTOShipment) validateDestinationAddress(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.DestinationAddress) { // not required
+		return nil
+	}
+
+	if m.DestinationAddress != nil {
+		if err := m.DestinationAddress.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("destinationAddress")
+			}
+			return err
+		}
 	}
 
 	return nil
@@ -132,6 +178,24 @@ func (m *MTOShipment) validateMoveTaskOrderID(formats strfmt.Registry) error {
 	return nil
 }
 
+func (m *MTOShipment) validatePickupAddress(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.PickupAddress) { // not required
+		return nil
+	}
+
+	if m.PickupAddress != nil {
+		if err := m.PickupAddress.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("pickupAddress")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (m *MTOShipment) validateRequestedPickupDate(formats strfmt.Registry) error {
 
 	if swag.IsZero(m.RequestedPickupDate) { // not required
@@ -153,6 +217,42 @@ func (m *MTOShipment) validateScheduledPickupDate(formats strfmt.Registry) error
 
 	if err := validate.FormatOf("scheduledPickupDate", "body", "date", m.ScheduledPickupDate.String(), formats); err != nil {
 		return err
+	}
+
+	return nil
+}
+
+func (m *MTOShipment) validateSecondaryDeliveryAddress(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.SecondaryDeliveryAddress) { // not required
+		return nil
+	}
+
+	if m.SecondaryDeliveryAddress != nil {
+		if err := m.SecondaryDeliveryAddress.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("secondaryDeliveryAddress")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *MTOShipment) validateSecondaryPickupAddress(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.SecondaryPickupAddress) { // not required
+		return nil
+	}
+
+	if m.SecondaryPickupAddress != nil {
+		if err := m.SecondaryPickupAddress.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("secondaryPickupAddress")
+			}
+			return err
+		}
 	}
 
 	return nil

--- a/pkg/handlers/ghcapi/internal/payloads/model_to_payload.go
+++ b/pkg/handlers/ghcapi/internal/payloads/model_to_payload.go
@@ -155,14 +155,18 @@ func Address(address *models.Address) *ghcmessages.Address {
 
 func MTOShipment(mtoShipment *models.MTOShipment) *ghcmessages.MTOShipment {
 	return &ghcmessages.MTOShipment{
-		ID:                  strfmt.UUID(mtoShipment.ID.String()),
-		MoveTaskOrderID:     strfmt.UUID(mtoShipment.MoveTaskOrderID.String()),
-		ShipmentType:        mtoShipment.ShipmentType,
-		Status:              string(mtoShipment.Status),
-		CustomerRemarks:     *mtoShipment.CustomerRemarks,
-		RequestedPickupDate: strfmt.Date(*mtoShipment.RequestedPickupDate),
-		CreatedAt:           strfmt.DateTime(mtoShipment.CreatedAt),
-		UpdatedAt:           strfmt.DateTime(mtoShipment.UpdatedAt),
+		ID:                       strfmt.UUID(mtoShipment.ID.String()),
+		MoveTaskOrderID:          strfmt.UUID(mtoShipment.MoveTaskOrderID.String()),
+		ShipmentType:             mtoShipment.ShipmentType,
+		Status:                   string(mtoShipment.Status),
+		CustomerRemarks:          *mtoShipment.CustomerRemarks,
+		RequestedPickupDate:      strfmt.Date(*mtoShipment.RequestedPickupDate),
+		PickupAddress:            Address(&mtoShipment.PickupAddress),
+		SecondaryDeliveryAddress: Address(mtoShipment.SecondaryDeliveryAddress),
+		SecondaryPickupAddress:   Address(mtoShipment.SecondaryPickupAddress),
+		DestinationAddress:       Address(&mtoShipment.DestinationAddress),
+		CreatedAt:                strfmt.DateTime(mtoShipment.CreatedAt),
+		UpdatedAt:                strfmt.DateTime(mtoShipment.UpdatedAt),
 	}
 }
 

--- a/pkg/testdatagen/make_mto_shipment.go
+++ b/pkg/testdatagen/make_mto_shipment.go
@@ -50,6 +50,8 @@ func MakeMTOShipment(db *pop.Connection, assertions Assertions) models.MTOShipme
 		PrimeEstimatedWeightRecordedDate: &primeEstimatedWeightDate,
 		PrimeActualWeight:                &actualWeight,
 		ShipmentType:                     models.MTOShipmentTypeHHG,
+		SecondaryPickupAddress:           &pickupAddress,
+		SecondaryDeliveryAddress:         &destinationAddress,
 		Status:                           "SUBMITTED",
 	}
 	// Overwrite values with those from assertions

--- a/src/scenes/Office/TOO/customerDetails.jsx
+++ b/src/scenes/Office/TOO/customerDetails.jsx
@@ -124,6 +124,11 @@ class CustomerDetails extends Component {
                   <th>ID</th>
                   <th>Shipment Type</th>
                   <th>Requested Pick-up Date</th>
+                  <th>Scheduled Pick-up Date</th>
+                  <th>Pick up Address</th>
+                  <th>Secondary Pickup Address</th>
+                  <th>Delivery Address</th>
+                  <th>Secondary Delivery Address</th>
                   <th>Customer Remarks</th>
                 </tr>
               </thead>
@@ -134,6 +139,28 @@ class CustomerDetails extends Component {
                       <td>{items.id}</td>
                       <td>{items.shipmentType}</td>
                       <td>{items.requestedPickupDate}</td>
+                      <td>{items.scheduledPickupDate}</td>
+                      <td>
+                        {items.pickupAddress.street_address_1} {items.pickupAddress.street_address_2}{' '}
+                        {items.pickupAddress.street_address_2} {items.pickupAddress.city} {items.pickupAddress.state}{' '}
+                        {items.pickupAddress.postal_code}
+                      </td>
+                      <td>
+                        {items.secondaryPickupAddress.street_address_1} {items.secondaryPickupAddress.street_address_2}{' '}
+                        {items.secondaryPickupAddress.street_address_2} {items.secondaryPickupAddress.city}{' '}
+                        {items.secondaryPickupAddress.state} {items.secondaryPickupAddress.postal_code}
+                      </td>
+                      <td>
+                        {items.destinationAddress.street_address_1} {items.destinationAddress.street_address_2}{' '}
+                        {items.destinationAddress.street_address_2} {items.destinationAddress.city}{' '}
+                        {items.destinationAddress.state} {items.destinationAddress.postal_code}
+                      </td>
+                      <td>
+                        {items.secondaryDeliveryAddress.street_address_1}{' '}
+                        {items.secondaryDeliveryAddress.street_address_2}{' '}
+                        {items.secondaryDeliveryAddress.street_address_2} {items.secondaryDeliveryAddress.city}{' '}
+                        {items.secondaryDeliveryAddress.state} {items.secondaryDeliveryAddress.postal_code}
+                      </td>
                       <td>{items.customerRemarks}</td>
                     </tr>
                   </Fragment>

--- a/swagger/ghc.yaml
+++ b/swagger/ghc.yaml
@@ -1525,6 +1525,18 @@ definitions:
       requestedPickupDate:
         format: date
         type: string
+      pickupAddress:
+        x-nullabe: true
+        $ref: '#/definitions/Address'
+      destinationAddress:
+        x-nullabe: true
+        $ref: '#/definitions/Address'
+      secondaryPickupAddress:
+        x-nullabe: true
+        $ref: '#/definitions/Address'
+      secondaryDeliveryAddress:
+        x-nullabe: true
+        $ref: '#/definitions/Address'
       customerRemarks:
         type: string
         example: handle with care


### PR DESCRIPTION
## Description

Update what's being shown from mto_shipments to be extended with the fields mentioned in the [Jira story](https://dp3.atlassian.net/browse/MB-1138). Updated back-end to provide the appropriate fields to make this possible.

## Setup

```sh
make db_dev_e2e_populate
```

Then head on over here: http://officelocal:3000/too/customer-moves/6fca843a-a87e-4752-b454-0fac67aa4988/customer/6ac40a00-e762-4f5f-b08d-3ea72a8e4b63 

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/tree/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/tree/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/tree/master/docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
  * [ ] Secure migrations have been tested using `scripts/run-prod-migrations`
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-1138) for this change


## Screenshots

![image](https://user-images.githubusercontent.com/4325613/74182592-f4478a80-4c08-11ea-8d5c-9d219e0db754.png)

