### PR TITLE
use originalMoveDate for incentive calc on ssw: MB-1520

### DIFF
--- a/pkg/paperwork/shipment_summary.go
+++ b/pkg/paperwork/shipment_summary.go
@@ -57,7 +57,7 @@ func (sswPpmComputer *SSWPPMComputer) ComputeObligations(ssfd models.ShipmentSum
 		destDutyStationZip,
 		distanceMilesFromPickupZip,
 		distanceMilesFromDutyStationZip,
-		*firstPPM.ActualMoveDate,
+		*firstPPM.OriginalMoveDate,
 		0,
 	)
 	if err != nil {
@@ -73,7 +73,7 @@ func (sswPpmComputer *SSWPPMComputer) ComputeObligations(ssfd models.ShipmentSum
 		destDutyStationZip,
 		distanceMilesFromPickupZip,
 		distanceMilesFromDutyStationZip,
-		*firstPPM.ActualMoveDate,
+		*firstPPM.OriginalMoveDate,
 		0,
 	)
 	if err != nil {

--- a/pkg/paperwork/shipment_summary.go
+++ b/pkg/paperwork/shipment_summary.go
@@ -102,8 +102,8 @@ func (sswPpmComputer *SSWPPMComputer) nilCheckPPM(ssfd models.ShipmentSummaryFor
 	if firstPPM.PickupPostalCode == nil || firstPPM.DestinationPostalCode == nil {
 		return models.PersonallyProcuredMove{}, errors.New("missing required address parameter")
 	}
-	if firstPPM.ActualMoveDate == nil {
-		return models.PersonallyProcuredMove{}, errors.New("missing required actual move date parameter")
+	if firstPPM.OriginalMoveDate == nil {
+		return models.PersonallyProcuredMove{}, errors.New("missing required original move date parameter")
 	}
 	return firstPPM, nil
 }

--- a/pkg/paperwork/shipment_summary_test.go
+++ b/pkg/paperwork/shipment_summary_test.go
@@ -137,7 +137,7 @@ func (suite *PaperworkSuite) TestTestComputeObligations() {
 			DestinationZip5:                       destinationPostalCode,
 			DistanceMilesFromOriginPickupZip:      miles,
 			DistanceMilesFromOriginDutyStationZip: miles,
-			Date:                                  actualDate,
+			Date:                                  origMoveDate,
 			DaysInSIT:                             0,
 		}
 		expectActualObligationParams := ppmComputerParams{
@@ -147,7 +147,7 @@ func (suite *PaperworkSuite) TestTestComputeObligations() {
 			DestinationZip5:                       destinationPostalCode,
 			DistanceMilesFromOriginPickupZip:      miles,
 			DistanceMilesFromOriginDutyStationZip: miles,
-			Date:                                  actualDate,
+			Date:                                  origMoveDate,
 			DaysInSIT:                             0,
 		}
 		cost, err := ppmComputer.ComputeObligations(params, planner)


### PR DESCRIPTION
## Description

SSW should use originalMoveDate not actualMoveDate for calculating incentives...

## Setup

`make server_run`
`make client_run`

In the office app, look at an ssw (i created a new move using the `needs@orde.rs` login). Ensure the incentive $$.

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-1520) for this change
