### PR TITLE
send correct move submitted email: MB-1328

### DIFF
--- a/pkg/notifications/move_submitted.go
+++ b/pkg/notifications/move_submitted.go
@@ -17,9 +17,9 @@ import (
 )
 
 var (
-	moveSubmittedRawTextTemplate = string(assets.MustAsset("pkg/notifications/templates/move_approved_template.txt"))
+	moveSubmittedRawTextTemplate = string(assets.MustAsset("pkg/notifications/templates/move_submitted_template.txt"))
 	moveSubmittedTextTemplate    = text.Must(text.New("text_template").Parse(moveSubmittedRawTextTemplate))
-	moveSubmittedRawHTMLTemplate = string(assets.MustAsset("pkg/notifications/templates/move_approved_template.html"))
+	moveSubmittedRawHTMLTemplate = string(assets.MustAsset("pkg/notifications/templates/move_submitted_template.html"))
 	moveSubmittedHTMLTemplate    = html.Must(html.New("text_template").Parse(moveSubmittedRawHTMLTemplate))
 )
 


### PR DESCRIPTION
## Description

We're sending the wrong email to the SM when they submit a move... We're sending the `move approved` vs the `move submitted`. Fix this 😄 

## Setup

`make server_run`
`make client_run`

Log in as needs@orde.rs and submit a move. Watch server logs when you submit a move and you'll see the output.

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-1328) for this change
