### PR TITLE
Fix bugs w/ incentive estimate calculation: MB-1231/MB-1520

### DIFF
--- a/src/scenes/Landing/MoveSummary.jsx
+++ b/src/scenes/Landing/MoveSummary.jsx
@@ -62,7 +62,7 @@ export class MoveSummaryComponent extends React.Component {
           netWeight = this.props.ppm.weight_estimate;
         }
         this.props.getPpmWeightEstimate(
-          this.props.ppm.actual_move_date || this.props.ppm.original_move_date,
+          this.props.ppm.original_move_date,
           this.props.ppm.pickup_postal_code,
           this.props.originDutyStationZip,
           this.props.orders.id,

--- a/src/scenes/Moves/Ppm/PaymentReview/index.jsx
+++ b/src/scenes/Moves/Ppm/PaymentReview/index.jsx
@@ -33,13 +33,13 @@ class PaymentReview extends Component {
 
   componentDidMount() {
     const { originDutyStationZip, currentPpm } = this.props;
-    const { actual_move_date, pickup_postal_code } = currentPpm;
+    const { original_move_date, pickup_postal_code } = currentPpm;
     this.props.getMoveDocumentsForMove(this.props.moveId).then(({ obj: documents }) => {
       const weightTicketNetWeight = calcNetWeight(documents);
       const netWeight =
         weightTicketNetWeight > this.props.entitlement.sum ? this.props.entitlement.sum : weightTicketNetWeight;
       this.props.getPpmWeightEstimate(
-        actual_move_date,
+        original_move_date,
         pickup_postal_code,
         originDutyStationZip,
         this.props.orders.id,
@@ -50,14 +50,14 @@ class PaymentReview extends Component {
 
   componentDidUpdate(prevProps) {
     const { originDutyStationZip, currentPpm, moveDocuments } = this.props;
-    const { actual_move_date, pickup_postal_code } = currentPpm;
+    const { original_move_date, pickup_postal_code } = currentPpm;
     if (moveDocuments.weightTickets.length !== prevProps.moveDocuments.weightTickets.length) {
       this.props.getMoveDocumentsForMove(this.props.moveId).then(({ obj: documents }) => {
         const weightTicketNetWeight = calcNetWeight(documents);
         const netWeight =
           weightTicketNetWeight > this.props.entitlement.sum ? this.props.entitlement.sum : weightTicketNetWeight;
         this.props.getPpmWeightEstimate(
-          actual_move_date,
+          original_move_date,
           pickup_postal_code,
           originDutyStationZip,
           this.props.orders.id,

--- a/src/scenes/Review/PPMShipmentSummary.jsx
+++ b/src/scenes/Review/PPMShipmentSummary.jsx
@@ -21,12 +21,11 @@ export class PPMShipmentSummary extends Component {
       !this.props.ppmEstimate.rateEngineError
     ) {
       this.props.getPpmWeightEstimate(
-        this.props.original_move_date,
-        this.props.pickup_postal_code,
-        this.props.originDutyStationZip,
-        this.props.destination_postal_code,
+        this.props.ppm.original_move_date,
+        this.props.ppm.pickup_postal_code,
+        this.props.ppmEstimate.originDutyStationZip,
         this.props.orders.id,
-        this.props.weight_estimate,
+        this.props.ppm.weight_estimate,
       );
     }
   }


### PR DESCRIPTION
## Description

This is fixing a few incentive estimate bugs...
1. Use `original_move_date` not `actual_move_date` when calculating the incentive: (SSW change: https://github.com/transcom/mymove/pull/3502)
2. Fix call to `getPpmWeightEstimate` - We were calling the function w/ the wrong params which caused the api to be called w/ the wrong params - and we got a response error. This fixes at least 2 bugs where the incentive was not shown:
- home page w/ pro-gear feature flag
- review move page (if you refresh that page)

## Setup

`make server_run`
`make client_run`
see jira ticket and follow steps to reproduce (I used `needs@orde.rs` as a starting point)

Once the move is created (above), click on edit move... then refresh the page. 
Incentive $$ should not disappear.

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-1231) for this change
* [Jira story2](https://dp3.atlassian.net/browse/MB-1520) for this change
