### PR TITLE
Weight entitlement shows base weight: MB-1230

### DIFF
--- a/cypress/integration/mymove/orders.js
+++ b/cypress/integration/mymove/orders.js
@@ -47,7 +47,7 @@ describe('orders entry', function() {
 
     cy.setFeatureFlag('ppmPaymentRequest=false', '/');
     cy.contains('NAS Fort Worth JRB (from Yuma AFB)');
-    cy.get('[data-cy="move-header-weight-estimate"]').contains('7,000 lbs');
+    cy.get('[data-cy="move-header-weight-estimate"]').contains('5,000 lbs');
     cy.contains('Continue Move Setup').click();
     cy.location().should(loc => {
       expect(loc.pathname).to.eq('/orders/upload');

--- a/cypress/integration/mymove/ppm.js
+++ b/cypress/integration/mymove/ppm.js
@@ -7,7 +7,7 @@ describe('completing the ppm flow', function() {
     //profile@comple.te
     cy.signInAsUserPostRequest(milmoveAppName, '13f3949d-0d53-4be4-b1b1-ae4314793f34');
     cy.contains('Fort Gordon (from Yuma AFB)');
-    cy.get('[data-cy="move-header-weight-estimate"]').contains('10,500 lbs');
+    cy.get('[data-cy="move-header-weight-estimate"]').contains('8,000 lbs');
     cy.contains('Continue Move Setup').click();
 
     cy.location().should(loc => {
@@ -123,7 +123,7 @@ describe('completing the ppm flow with a move date that we currently do not have
     //profile@complete.draft
     cy.signInAsUserPostRequest(milmoveAppName, '3b9360a3-3304-4c60-90f4-83d687884070');
     cy.contains('Fort Gordon (from Yuma AFB)');
-    cy.get('[data-cy="move-header-weight-estimate"]').contains('10,500 lbs');
+    cy.get('[data-cy="move-header-weight-estimate"]').contains('8,000 lbs');
     cy.contains('Continue Move Setup').click();
 
     cy.location().should(loc => {

--- a/src/scenes/Landing/MoveSummary.jsx
+++ b/src/scenes/Landing/MoveSummary.jsx
@@ -29,7 +29,8 @@ const MoveInfoHeader = props => {
       {get(move, 'locator') && <div>Move Locator: {get(move, 'locator')}</div>}
       {!isEmpty(entitlement) && (
         <div>
-          Weight Entitlement: <span data-cy="move-header-weight-estimate">{entitlement.sum.toLocaleString()} lbs</span>
+          Weight Entitlement:{' '}
+          <span data-cy="move-header-weight-estimate">{entitlement.weight.toLocaleString()} lbs</span>
         </div>
       )}
     </div>

--- a/src/scenes/Landing/MoveSummary.jsx
+++ b/src/scenes/Landing/MoveSummary.jsx
@@ -29,8 +29,7 @@ const MoveInfoHeader = props => {
       {get(move, 'locator') && <div>Move Locator: {get(move, 'locator')}</div>}
       {!isEmpty(entitlement) && (
         <div>
-          Weight Entitlement:{' '}
-          <span data-cy="move-header-weight-estimate">{entitlement.weight.toLocaleString()} lbs</span>
+          Weight allowance: <span data-cy="move-header-weight-estimate">{entitlement.weight.toLocaleString()} lbs</span>
         </div>
       )}
     </div>


### PR DESCRIPTION
## Description

Currently, the homepage shows `base_weight` + `pro_gear` weight. Change this to show `base_weight` only.

## Setup

`make server_run`
`make client_run`
create move using steps found in this jira ticket(use the progear flag):  (https://dp3.atlassian.net/browse/MB-1231) 

On home page, you should see only the base weight not total weight.
(if you want, you can add a log stmt on `/src/scenes/Landing/MoveSummary.jsx` after line 13 to output the entitlement values: `console.dir(entitlement)` to verify the correct entitlement value is shown.


## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-1231) for this change
