### PR TITLE
Add teardown to tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -733,11 +733,17 @@ workflows:
     jobs:
       - pre_deps_golang
 
-      - pre_deps_yarn
+      - pre_deps_yarn:
+          filters:
+            branches:
+              ignore: cg_teardown_tests
 
       - check_generated_code:
           requires:
             - pre_deps_golang
+          filters:
+            branches:
+              ignore: cg_teardown_tests
 
       - anti_virus:
           filters:
@@ -748,21 +754,33 @@ workflows:
           requires:
             - pre_deps_golang
             - pre_deps_yarn
+          filters:
+            branches:
+              ignore: cg_teardown_tests
 
       - acceptance_tests_local:
           requires:
             - pre_deps_golang
             - pre_deps_yarn
+          filters:
+            branches:
+              ignore: cg_teardown_tests
 
       - acceptance_tests_experimental:
           requires:
             - pre_deps_golang
             - pre_deps_yarn
+          filters:
+            branches:
+              ignore: cg_teardown_tests
 
       - acceptance_tests_staging:
           requires:
             - pre_deps_golang
             - pre_deps_yarn
+          filters:
+            branches:
+              ignore: cg_teardown_tests
 
       - integration_tests:
           requires:
@@ -799,25 +817,40 @@ workflows:
             - pre_deps_golang
             - pre_deps_yarn
             - acceptance_tests_local # don't bother building and pushing the application if it won't even start properly
+          filters:
+            branches:
+              ignore: cg_teardown_tests
 
       - build_storybook_app:
           requires:
             - anti_virus
             - pre_deps_yarn
+          filters:
+            branches:
+              ignore: cg_teardown_tests
 
       - build_tools:
           requires:
             - anti_virus
             - pre_deps_golang
+          filters:
+            branches:
+              ignore: cg_teardown_tests
 
       - build_migrations:
           requires:
             - anti_virus
             - pre_deps_golang
+          filters:
+            branches:
+              ignore: cg_teardown_tests
 
       - build_tasks:
           requires:
             - build_tools
+          filters:
+            branches:
+              ignore: cg_teardown_tests
 
       - deploy_experimental_migrations:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -775,7 +775,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: placeholder_branch_name
+              ignore: cg_teardown_tests
 
       - client_test:
           requires:
@@ -783,7 +783,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: placeholder_branch_name
+              ignore: cg_teardown_tests
 
       - server_test:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -733,17 +733,11 @@ workflows:
     jobs:
       - pre_deps_golang
 
-      - pre_deps_yarn:
-          filters:
-            branches:
-              ignore: cg_teardown_tests
+      - pre_deps_yarn
 
       - check_generated_code:
           requires:
             - pre_deps_golang
-          filters:
-            branches:
-              ignore: cg_teardown_tests
 
       - anti_virus:
           filters:
@@ -754,33 +748,21 @@ workflows:
           requires:
             - pre_deps_golang
             - pre_deps_yarn
-          filters:
-            branches:
-              ignore: cg_teardown_tests
 
       - acceptance_tests_local:
           requires:
             - pre_deps_golang
             - pre_deps_yarn
-          filters:
-            branches:
-              ignore: cg_teardown_tests
 
       - acceptance_tests_experimental:
           requires:
             - pre_deps_golang
             - pre_deps_yarn
-          filters:
-            branches:
-              ignore: cg_teardown_tests
 
       - acceptance_tests_staging:
           requires:
             - pre_deps_golang
             - pre_deps_yarn
-          filters:
-            branches:
-              ignore: cg_teardown_tests
 
       - integration_tests:
           requires:
@@ -793,7 +775,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: cg_teardown_tests
+              ignore: placeholder_branch_name
 
       - client_test:
           requires:
@@ -801,7 +783,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: cg_teardown_tests
+              ignore: placeholder_branch_name
 
       - server_test:
           requires:
@@ -817,40 +799,25 @@ workflows:
             - pre_deps_golang
             - pre_deps_yarn
             - acceptance_tests_local # don't bother building and pushing the application if it won't even start properly
-          filters:
-            branches:
-              ignore: cg_teardown_tests
 
       - build_storybook_app:
           requires:
             - anti_virus
             - pre_deps_yarn
-          filters:
-            branches:
-              ignore: cg_teardown_tests
 
       - build_tools:
           requires:
             - anti_virus
             - pre_deps_golang
-          filters:
-            branches:
-              ignore: cg_teardown_tests
 
       - build_migrations:
           requires:
             - anti_virus
             - pre_deps_golang
-          filters:
-            branches:
-              ignore: cg_teardown_tests
 
       - build_tasks:
           requires:
             - build_tools
-          filters:
-            branches:
-              ignore: cg_teardown_tests
 
       - deploy_experimental_migrations:
           requires:

--- a/pkg/handlers/ghcapi/api_test.go
+++ b/pkg/handlers/ghcapi/api_test.go
@@ -42,4 +42,5 @@ func TestHandlerSuite(t *testing.T) {
 	}
 
 	suite.Run(t, hs)
+	hs.PopTestSuite.TearDown()
 }

--- a/pkg/handlers/primeapi/api_test.go
+++ b/pkg/handlers/primeapi/api_test.go
@@ -42,4 +42,5 @@ func TestHandlerSuite(t *testing.T) {
 	}
 
 	suite.Run(t, hs)
+	hs.PopTestSuite.TearDown()
 }

--- a/pkg/services/ghcimport/ghc_rateengine_importer_test.go
+++ b/pkg/services/ghcimport/ghc_rateengine_importer_test.go
@@ -105,6 +105,7 @@ func TestGHCRateEngineImportSuite(t *testing.T) {
 	}
 
 	suite.Run(t, hs)
+	hs.PopTestSuite.TearDown()
 }
 
 func (suite *GHCRateEngineImportSuite) TestGHCRateEngineImporter_Import() {


### PR DESCRIPTION
## Description

What's happening here is that the tests aren't being cleaned up. This leaves the DB running for those tests which in turn eats up memory. Then the golang builder doesn't have the necessary resources to build each binary before testing and we end up with random failures, even on tests that properly tear down.