### PR TITLE
MB-1490 Add missing produces/consumes to prime yaml

### DIFF
--- a/pkg/gen/primeapi/embedded_spec.go
+++ b/pkg/gen/primeapi/embedded_spec.go
@@ -414,6 +414,9 @@ func init() {
         "consumes": [
           "application/json"
         ],
+        "produces": [
+          "application/json"
+        ],
         "tags": [
           "moveTaskOrder",
           "prime"
@@ -1911,6 +1914,9 @@ func init() {
       "patch": {
         "description": "Updates a move order's actual weight by ID",
         "consumes": [
+          "application/json"
+        ],
+        "produces": [
           "application/json"
         ],
         "tags": [

--- a/pkg/gen/primeclient/move_task_order/move_task_order_client.go
+++ b/pkg/gen/primeclient/move_task_order/move_task_order_client.go
@@ -149,7 +149,7 @@ func (a *Client) UpdateMoveTaskOrderActualWeight(params *UpdateMoveTaskOrderActu
 		ID:                 "updateMoveTaskOrderActualWeight",
 		Method:             "PATCH",
 		PathPattern:        "/move-task-orders/{moveTaskOrderID}/prime-actual-weight",
-		ProducesMediaTypes: []string{""},
+		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http"},
 		Params:             params,

--- a/swagger/prime.yaml
+++ b/swagger/prime.yaml
@@ -223,6 +223,8 @@ paths:
     patch:
       consumes:
         - application/json
+      produces:
+        - application/json
       parameters:
         - in: body
           name: body


### PR DESCRIPTION
## Description

Produces/Consumes were missing from some of the Prime endpoints.  Looks like others just got merged in by other PRs.  So this is a 2-liner now.  

## Code Review Verification Steps

* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-1490) for this change
