### PR TITLE
Update new path for migration gen commands

### DIFF
--- a/pkg/cli/migration_gen_path.go
+++ b/pkg/cli/migration_gen_path.go
@@ -28,7 +28,7 @@ func (e *errInvalidMigrationGenPath) Error() string {
 
 // InitMigrationFlags initializes the Migration command line flags
 func InitMigrationGenPathFlags(flag *pflag.FlagSet) {
-	flag.StringP(MigrationGenPathFlag, "p", "./migrations", "Path to the migrations folder")
+	flag.StringP(MigrationGenPathFlag, "p", "./migrations/app/schema", "Path to the migrations folder")
 }
 
 // CheckMigration validates migration command line flags

--- a/pkg/cli/migration_gen_path_test.go
+++ b/pkg/cli/migration_gen_path_test.go
@@ -6,7 +6,7 @@ import (
 
 func (suite *cliTestSuite) TestConfigMigrationGenPath() {
 	flagSet := []string{
-		fmt.Sprintf("--%s=%s", MigrationGenPathFlag, "../../migrations"),
+		fmt.Sprintf("--%s=%s", MigrationGenPathFlag, "../../migrations/app/schema"),
 	}
 
 	suite.Setup(InitMigrationGenPathFlags, flagSet)

--- a/pkg/cli/migration_path.go
+++ b/pkg/cli/migration_path.go
@@ -29,7 +29,7 @@ func (e *errInvalidMigrationPath) Error() string {
 
 // InitMigrationFlags initializes the Migration command line flags
 func InitMigrationPathFlags(flag *pflag.FlagSet) {
-	flag.StringP(MigrationPathFlag, "p", "file:///migrations", "Path to the migrations folder")
+	flag.StringP(MigrationPathFlag, "p", "file:///migrations/app/schema", "Path to the migrations folder")
 }
 
 // CheckMigration validates migration command line flags


### PR DESCRIPTION
## Description

In #3496 I missed a couple migration paths.

Try:

```
rm -f bin/milmove && make bin/milmove
milmove gen migration -n test
```