### PR TITLE
Update circleci-docker-primary image to point to most recent

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,28 +17,28 @@ executors:
     resource_class: small
     working_directory: ~/transcom/mymove
     docker:
-      - image: trussworks/circleci-docker-primary:6f138d780444b35181e0048282616f75a451d7b4
+      - image: trussworks/circleci-docker-primary:ba270cf66c7a9ae6dbc8e6190b74163ad71729d0
   mymove_medium:
     resource_class: medium
     working_directory: ~/transcom/mymove
     docker:
-      - image: trussworks/circleci-docker-primary:6f138d780444b35181e0048282616f75a451d7b4
+      - image: trussworks/circleci-docker-primary:ba270cf66c7a9ae6dbc8e6190b74163ad71729d0
   mymove_medium_plus:
     resource_class: medium+
     working_directory: ~/transcom/mymove
     docker:
-      - image: trussworks/circleci-docker-primary:6f138d780444b35181e0048282616f75a451d7b4
+      - image: trussworks/circleci-docker-primary:ba270cf66c7a9ae6dbc8e6190b74163ad71729d0
   mymove_large:
     resource_class: large
     working_directory: ~/transcom/mymove
     docker:
-      - image: trussworks/circleci-docker-primary:6f138d780444b35181e0048282616f75a451d7b4
+      - image: trussworks/circleci-docker-primary:ba270cf66c7a9ae6dbc8e6190b74163ad71729d0
   # `mymove_and_postgres_medium` adds a secondary postgres container to be used during testing.
   mymove_and_postgres_medium:
     resource_class: medium
     working_directory: ~/transcom/mymove
     docker:
-      - image: trussworks/circleci-docker-primary:6f138d780444b35181e0048282616f75a451d7b4
+      - image: trussworks/circleci-docker-primary:ba270cf66c7a9ae6dbc8e6190b74163ad71729d0
       - image: postgres:10.10
         environment:
           - POSTGRES_PASSWORD: mysecretpassword
@@ -48,7 +48,7 @@ executors:
     resource_class: large
     working_directory: ~/transcom/mymove
     docker:
-      - image: trussworks/circleci-docker-primary:6f138d780444b35181e0048282616f75a451d7b4
+      - image: trussworks/circleci-docker-primary:ba270cf66c7a9ae6dbc8e6190b74163ad71729d0
       - image: postgres:10.10
         environment:
           - POSTGRES_PASSWORD: mysecretpassword

--- a/.github/workflows/go-auto-approve.yml
+++ b/.github/workflows/go-auto-approve.yml
@@ -25,7 +25,7 @@ jobs:
       - name: setup go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.13.4'
+          go-version: '1.13.7'
       - name: Tidy
         run: |
           go version

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -2,7 +2,7 @@
 # BUILDER #
 ###########
 
-FROM trussworks/circleci-docker-primary:6f138d780444b35181e0048282616f75a451d7b4 as builder
+FROM trussworks/circleci-docker-primary:ba270cf66c7a9ae6dbc8e6190b74163ad71729d0 as builder
 
 ENV CIRCLECI=true
 

--- a/Dockerfile.migrations_local
+++ b/Dockerfile.migrations_local
@@ -2,7 +2,7 @@
 # BUILDER #
 ###########
 
-FROM trussworks/circleci-docker-primary:6f138d780444b35181e0048282616f75a451d7b4 as builder
+FROM trussworks/circleci-docker-primary:ba270cf66c7a9ae6dbc8e6190b74163ad71729d0 as builder
 
 ENV CIRCLECI=true
 

--- a/Dockerfile.tasks_local
+++ b/Dockerfile.tasks_local
@@ -2,7 +2,7 @@
 # BUILDER #
 ###########
 
-FROM trussworks/circleci-docker-primary:6f138d780444b35181e0048282616f75a451d7b4 as builder
+FROM trussworks/circleci-docker-primary:ba270cf66c7a9ae6dbc8e6190b74163ad71729d0 as builder
 
 ENV CIRCLECI=true
 

--- a/Dockerfile.tools_local
+++ b/Dockerfile.tools_local
@@ -2,7 +2,7 @@
 # BUILDER #
 ###########
 
-FROM trussworks/circleci-docker-primary:6f138d780444b35181e0048282616f75a451d7b4 as builder
+FROM trussworks/circleci-docker-primary:ba270cf66c7a9ae6dbc8e6190b74163ad71729d0 as builder
 
 ENV CIRCLECI=true
 

--- a/docker-compose.circle.yml
+++ b/docker-compose.circle.yml
@@ -17,7 +17,7 @@ services:
   server_test:
     depends_on:
       - database
-    image: trussworks/circleci-docker-primary:6f138d780444b35181e0048282616f75a451d7b4
+    image: trussworks/circleci-docker-primary:ba270cf66c7a9ae6dbc8e6190b74163ad71729d0
     deploy:
       resources:
         limits:

--- a/docs/how-to/upgrade-go-version.md
+++ b/docs/how-to/upgrade-go-version.md
@@ -29,25 +29,18 @@ For more details read the following sections.
 ## Update `transcom/mymove` Repo
 
 - After your Docker image PR lands, grab the git hash from [Docker](https://hub.docker.com/r/trussworks/circleci-docker-primary/tags) that corresponds with your merged code
-- Update `.circleci/config.yml` and `Dockerfile.dep_updater` with the updated Docker image git hash and Go version
-  - See [this PR](https://github.com/transcom/mymove/pull/1383/files) as an example
+- Update the following files with the updated Docker image git hash and Go version:
+  - `.circleci/config.yml`
+  - `Dockerfile.local`
+  - `Dockerfile.tasks_local`
+  - `Dockerfile.tools_local`
+  - `docker-compose.circle.yml`
+  - Update `go-version` in `.github/workflows/go-auto-approve.yml`
+  - See [this PR](https://github.com/transcom/mymove/pull/3524/files) as an example
 - For minor go version changes (but not patch changes) update `scripts/check-go-version`.
 - Rerun the Go formatter on the codebase with `pre-commit run --all-files go-fmt`
+- Run `make e2e_test_docker` to test that the `Dockerfile.*local` files work  with the new image.
 - Commit the above changes and any reformatted code and make sure everything builds correctly on CircleCI
-
-## Update `transcom/ppp-infra` Repo
-
-- After your Docker image PR lands, grab the git hash from [Docker](https://hub.docker.com/r/trussworks/circleci-docker-primary/tags) that corresponds with your merged code
-- Update `.circleci/config.yml` and `Dockerfile` with the updated Docker image git hash and Go version
-  - See [this PR](https://github.com/transcom/ppp-infra/pull/525/files) as an example
-- For minor go version changes (but not patch changes) update `scripts/check-go-version`.
-- Rerun the Go formatter on the codebase with `pre-commit run --all-files go-fmt`
-- Commit the above changes and any reformatted code and make sure everything builds correctly on CircleCI
-
-## Update `github action` yaml
-
-- Update `go-version` in `.github/workflows/go-auto-approve.yml`
-- Commit the above changes and make sure the action builds when pushed to github
 
 ## Notify Folks
 


### PR DESCRIPTION
Points to the most recent [`trussworks/circleci-docker-primary`](https://github.com/trussworks/circleci-docker-primary/commit/ba270cf66c7a9ae6dbc8e6190b74163ad71729d0). 