### PR TITLE
Remove dependabot check for missing directory

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -60,14 +60,3 @@ update_configs:
     default_labels:
       - dependencies
       - automerge
-
-  - package_manager: "docker"
-    directory: "/tools"
-    update_schedule: "daily"
-    automerged_updates:
-      - match:
-          dependency_type: "all"
-          update_type: "semver:minor"
-    default_labels:
-      - dependencies
-      - automerge


### PR DESCRIPTION
## Description

Closes #3522 

Recent merge to master removed the `tools/` directory, so no need to check this file anymore.