### PR TITLE
DO NOT MERGE: Testing DB codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,7 +13,4 @@
 /docs/database/* @chrisgilmerproj @tinyels @garrettqmartin8 @gidjin @lynzt @reggieriser @rdhariwal @Ryan-Koch @jim @chrisrcoles
 
 # Migrations are where database schema changes are made and we want them reviewed by people working on our database guidelines
-/migrations/* @chrisgilmerproj @tinyels @garrettqmartin8 @gidjin @lynzt @reggieriser @rdhariwal @Ryan-Koch @jim @chrisrcoles
-
-# we also want to make sure the local migrations are not doing schema changes
-/local_migrations/* @chrisgilmerproj @tinyels @garrettqmartin8 @gidjin @lynzt @reggieriser @rdhariwal @Ryan-Koch @jim @chrisrcoles
+/migrations/** @chrisgilmerproj @tinyels @garrettqmartin8 @gidjin @lynzt @reggieriser @rdhariwal @Ryan-Koch @jim @chrisrcoles

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,4 +13,4 @@
 /docs/database/* @chrisgilmerproj @tinyels @garrettqmartin8 @gidjin @lynzt @reggieriser @rdhariwal @Ryan-Koch @jim @chrisrcoles
 
 # Migrations are where database schema changes are made and we want them reviewed by people working on our database guidelines
-/migrations @chrisgilmerproj @tinyels @garrettqmartin8 @gidjin @lynzt @reggieriser @rdhariwal @Ryan-Koch @jim @chrisrcoles
+/migrations/ @chrisgilmerproj @tinyels @garrettqmartin8 @gidjin @lynzt @reggieriser @rdhariwal @Ryan-Koch @jim @chrisrcoles

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,4 +13,6 @@
 /docs/database/* @chrisgilmerproj @tinyels @garrettqmartin8 @gidjin @lynzt @reggieriser @rdhariwal @Ryan-Koch @jim @chrisrcoles
 
 # Migrations are where database schema changes are made and we want them reviewed by people working on our database guidelines
-/migrations/ @chrisgilmerproj @tinyels @garrettqmartin8 @gidjin @lynzt @reggieriser @rdhariwal @Ryan-Koch @jim @chrisrcoles
+/migrations/app/* @chrisgilmerproj @tinyels @garrettqmartin8 @gidjin @lynzt @reggieriser @rdhariwal @Ryan-Koch @jim @chrisrcoles
+/migrations/app/schema/* @chrisgilmerproj @tinyels @garrettqmartin8 @gidjin @lynzt @reggieriser @rdhariwal @Ryan-Koch @jim @chrisrcoles
+/migrations/app/secure/* @chrisgilmerproj @tinyels @garrettqmartin8 @gidjin @lynzt @reggieriser @rdhariwal @Ryan-Koch @jim @chrisrcoles

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,4 +13,4 @@
 /docs/database/* @chrisgilmerproj @tinyels @garrettqmartin8 @gidjin @lynzt @reggieriser @rdhariwal @Ryan-Koch @jim @chrisrcoles
 
 # Migrations are where database schema changes are made and we want them reviewed by people working on our database guidelines
-/migrations/** @chrisgilmerproj @tinyels @garrettqmartin8 @gidjin @lynzt @reggieriser @rdhariwal @Ryan-Koch @jim @chrisrcoles
+/migrations @chrisgilmerproj @tinyels @garrettqmartin8 @gidjin @lynzt @reggieriser @rdhariwal @Ryan-Koch @jim @chrisrcoles

--- a/migrations/app/migrations_manifest.txt
+++ b/migrations/app/migrations_manifest.txt
@@ -448,3 +448,4 @@
 20200205160112_add_enum_values_to_shipment_type_within_mto_shipments.up.sql
 20200206163953_cgilmer_cac.up.sql
 20200211150405_mr337_cac.up.sql
+20200212204528_testing_codeowners.up.sql

--- a/migrations/app/schema/20200212204528_testing_codeowners.up.sql
+++ b/migrations/app/schema/20200212204528_testing_codeowners.up.sql
@@ -1,0 +1,1 @@
+-- Just testing; nothing to see here

--- a/migrations/app/schema/20200212204528_testing_codeowners.up.sql
+++ b/migrations/app/schema/20200212204528_testing_codeowners.up.sql
@@ -1,1 +1,1 @@
--- Just testing; nothing to see here
+-- Just testing


### PR DESCRIPTION
## Description

**DO NOT MERGE -- TESTING CODEOWNERS**

Since changing the locations of migration files, codeowners aren't showing up anymore on migration changes.  This PR changes a path in `CODEOWNERS` to see if that takes care of it.
