### PR TITLE
Fix paths for database codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,7 +10,7 @@
 /docs/adr/* @tinyels @chrisrcoles @Ryan-Koch @chrisgilmerproj @jacquelineIO
 
 # Docs about the database should be reviewed by people working on our database guidelines
-/docs/database/* @chrisgilmerproj @tinyels @garrettqmartin8 @gidjin @lynzt @reggieriser @rdhariwal @Ryan-Koch @jim @chrisrcoles
+/docs/database/* @chrisgilmerproj @tinyels @garrettqmartin8 @gidjin @lynzt @reggieriser @rdhariwal @Ryan-Koch @chrisrcoles
 
 # Migrations are where database schema changes are made and we want them reviewed by people working on our database guidelines
-/migrations/ @chrisgilmerproj @tinyels @garrettqmartin8 @gidjin @lynzt @reggieriser @rdhariwal @Ryan-Koch @jim @chrisrcoles
+/migrations/ @chrisgilmerproj @tinyels @garrettqmartin8 @gidjin @lynzt @reggieriser @rdhariwal @Ryan-Koch @chrisrcoles

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,7 +13,4 @@
 /docs/database/* @chrisgilmerproj @tinyels @garrettqmartin8 @gidjin @lynzt @reggieriser @rdhariwal @Ryan-Koch @jim @chrisrcoles
 
 # Migrations are where database schema changes are made and we want them reviewed by people working on our database guidelines
-/migrations/* @chrisgilmerproj @tinyels @garrettqmartin8 @gidjin @lynzt @reggieriser @rdhariwal @Ryan-Koch @jim @chrisrcoles
-
-# we also want to make sure the local migrations are not doing schema changes
-/local_migrations/* @chrisgilmerproj @tinyels @garrettqmartin8 @gidjin @lynzt @reggieriser @rdhariwal @Ryan-Koch @jim @chrisrcoles
+/migrations/ @chrisgilmerproj @tinyels @garrettqmartin8 @gidjin @lynzt @reggieriser @rdhariwal @Ryan-Koch @jim @chrisrcoles


### PR DESCRIPTION
## Description

Automatic assignment of codeowners appears to have broken when we restructured the `migrations` folder.  This is an attempt to fix the paths.

I tried to test this in PR #3527 but couldn't seem to make it trigger the codeowners on the branch.  So maybe it needs to be in master first?

Here's an example from the [GitHub docs](https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax) that seems along the lines of what we're wanting, so I've modeled my changes after it.

```
# In this example, @doctocat owns any files in the build/logs
# directory at the root of the repository and any of its
# subdirectories.
/build/logs/ @doctocat
```
