### PR TITLE
Add actual_move_date and original_move_date to queues payload

### DIFF
--- a/pkg/gen/internalapi/embedded_spec.go
+++ b/pkg/gen/internalapi/embedded_spec.go
@@ -4546,6 +4546,12 @@ func init() {
         "created_at"
       ],
       "properties": {
+        "actual_move_date": {
+          "type": "string",
+          "format": "date",
+          "x-nullable": true,
+          "example": "2018-04-25"
+        },
         "branch_of_service": {
           "type": "string"
         },
@@ -4643,6 +4649,12 @@ func init() {
           "title": "Origin GBLOC",
           "x-nullable": true,
           "example": "LKNQ"
+        },
+        "original_move_date": {
+          "type": "string",
+          "format": "date",
+          "x-nullable": true,
+          "example": "2018-04-25"
         },
         "pm_survey_conducted_date": {
           "type": "string",
@@ -10720,6 +10732,12 @@ func init() {
         "created_at"
       ],
       "properties": {
+        "actual_move_date": {
+          "type": "string",
+          "format": "date",
+          "x-nullable": true,
+          "example": "2018-04-25"
+        },
         "branch_of_service": {
           "type": "string"
         },
@@ -10817,6 +10835,12 @@ func init() {
           "title": "Origin GBLOC",
           "x-nullable": true,
           "example": "LKNQ"
+        },
+        "original_move_date": {
+          "type": "string",
+          "format": "date",
+          "x-nullable": true,
+          "example": "2018-04-25"
         },
         "pm_survey_conducted_date": {
           "type": "string",

--- a/pkg/gen/internalmessages/move_queue_item.go
+++ b/pkg/gen/internalmessages/move_queue_item.go
@@ -19,6 +19,10 @@ import (
 // swagger:model MoveQueueItem
 type MoveQueueItem struct {
 
+	// actual move date
+	// Format: date
+	ActualMoveDate *strfmt.Date `json:"actual_move_date,omitempty"`
+
 	// branch of service
 	// Required: true
 	BranchOfService *string `json:"branch_of_service"`
@@ -88,6 +92,10 @@ type MoveQueueItem struct {
 	// Origin GBLOC
 	OriginGbloc *string `json:"origin_gbloc,omitempty"`
 
+	// original move date
+	// Format: date
+	OriginalMoveDate *strfmt.Date `json:"original_move_date,omitempty"`
+
 	// pm survey conducted date
 	// Format: date-time
 	PmSurveyConductedDate *strfmt.DateTime `json:"pm_survey_conducted_date,omitempty"`
@@ -114,6 +122,10 @@ type MoveQueueItem struct {
 // Validate validates this move queue item
 func (m *MoveQueueItem) Validate(formats strfmt.Registry) error {
 	var res []error
+
+	if err := m.validateActualMoveDate(formats); err != nil {
+		res = append(res, err)
+	}
 
 	if err := m.validateBranchOfService(formats); err != nil {
 		res = append(res, err)
@@ -159,6 +171,10 @@ func (m *MoveQueueItem) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
+	if err := m.validateOriginalMoveDate(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validatePmSurveyConductedDate(formats); err != nil {
 		res = append(res, err)
 	}
@@ -182,6 +198,19 @@ func (m *MoveQueueItem) Validate(formats strfmt.Registry) error {
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
+	return nil
+}
+
+func (m *MoveQueueItem) validateActualMoveDate(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.ActualMoveDate) { // not required
+		return nil
+	}
+
+	if err := validate.FormatOf("actual_move_date", "body", "date", m.ActualMoveDate.String(), formats); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -354,6 +383,19 @@ func (m *MoveQueueItem) validateOrdersType(formats strfmt.Registry) error {
 
 	// value enum
 	if err := m.validateOrdersTypeEnum("orders_type", "body", *m.OrdersType); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *MoveQueueItem) validateOriginalMoveDate(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.OriginalMoveDate) { // not required
+		return nil
+	}
+
+	if err := validate.FormatOf("original_move_date", "body", "date", m.OriginalMoveDate.String(), formats); err != nil {
 		return err
 	}
 

--- a/pkg/handlers/internalapi/move_queue_items.go
+++ b/pkg/handlers/internalapi/move_queue_items.go
@@ -39,6 +39,8 @@ func payloadForMoveQueueItem(MoveQueueItem models.MoveQueueItem) *internalmessag
 		InvoiceApprovedDate:        handlers.FmtDateTimePtr(MoveQueueItem.InvoiceApprovedDate),
 		WeightAllotment:            payloadForWeightAllotmentModel(models.GetWeightAllotment(*MoveQueueItem.Rank)),
 		BranchOfService:            handlers.FmtString(MoveQueueItem.BranchOfService),
+		ActualMoveDate:             handlers.FmtDatePtr(MoveQueueItem.ActualMoveDate),
+		OriginalMoveDate:           handlers.FmtDatePtr(MoveQueueItem.OriginalMoveDate),
 	}
 	return &MoveQueueItemPayload
 }

--- a/pkg/models/queue.go
+++ b/pkg/models/queue.go
@@ -29,6 +29,8 @@ type MoveQueueItem struct {
 	DeliveredDate              *time.Time         `json:"delivered_date" db:"delivered_date"`
 	InvoiceApprovedDate        *time.Time         `json:"invoice_approved_date" db:"invoice_approved_date"`
 	BranchOfService            string             `json:"branch_of_service" db:"branch_of_service"`
+	ActualMoveDate             *time.Time         `json:"actual_move_date" db:"actual_move_date"`
+	OriginalMoveDate           *time.Time         `json:"original_move_date" db:"original_move_date"`
 }
 
 // GetMoveQueueItems gets all moveQueueItems for a specific lifecycleState
@@ -56,7 +58,9 @@ func GetMoveQueueItems(db *pop.Connection, lifecycleState string) ([]MoveQueueIt
 				moves.updated_at as last_modified_date,
 				moves.status as status,
 				ppm.status as ppm_status,
-				origin_duty_station.name as origin_duty_station_name
+				origin_duty_station.name as origin_duty_station_name,
+                ppm.actual_move_date,
+                ppm.original_move_date
 			FROM moves
 			JOIN orders as ord ON moves.orders_id = ord.id
 			JOIN service_members AS sm ON ord.service_member_id = sm.id
@@ -66,7 +70,7 @@ func GetMoveQueueItems(db *pop.Connection, lifecycleState string) ([]MoveQueueIt
 			OR (ppm.status = 'SUBMITTED'
 				AND (NOT moves.status in ('CANCELED', 'DRAFT'))))
 			AND moves.show is true
-			GROUP BY moves.ID, rank, customer_name, edipi, locator, orders_type, move_date, moves.created_at, last_modified_date, moves.status, ppm.submit_date, ppm_status, origin_duty_station.name, sm.affiliation
+			GROUP BY moves.ID, rank, customer_name, edipi, locator, orders_type, move_date, moves.created_at, last_modified_date, moves.status, ppm.submit_date, ppm_status, origin_duty_station.name, sm.affiliation, ppm.actual_move_date, ppm.original_move_date
 		`
 	} else if lifecycleState == "ppm_payment_requested" {
 		query = `
@@ -83,7 +87,9 @@ func GetMoveQueueItems(db *pop.Connection, lifecycleState string) ([]MoveQueueIt
 				moves.status as status,
 				ppm.status as ppm_status,
 				origin_duty_station.name as origin_duty_station_name,
-				destination_duty_station.name as destination_duty_station_name
+				destination_duty_station.name as destination_duty_station_name,
+                ppm.actual_move_date,
+                ppm.original_move_date
 			FROM moves
 			JOIN orders as ord ON moves.orders_id = ord.id
 			JOIN service_members AS sm ON ord.service_member_id = sm.id
@@ -108,7 +114,9 @@ func GetMoveQueueItems(db *pop.Connection, lifecycleState string) ([]MoveQueueIt
 				moves.status as status,
 				ppm.status as ppm_status,
 				origin_duty_station.name as origin_duty_station_name,
-				destination_duty_station.name as destination_duty_station_name
+				destination_duty_station.name as destination_duty_station_name,
+                ppm.actual_move_date,
+                ppm.original_move_date
 			FROM moves
 			JOIN orders as ord ON moves.orders_id = ord.id
 			JOIN service_members AS sm ON ord.service_member_id = sm.id
@@ -133,7 +141,9 @@ func GetMoveQueueItems(db *pop.Connection, lifecycleState string) ([]MoveQueueIt
 				moves.status as status,
 				ppm.status as ppm_status,
 				origin_duty_station.name as origin_duty_station_name,
-				destination_duty_station.name as destination_duty_station_name
+				destination_duty_station.name as destination_duty_station_name,
+                ppm.actual_move_date,
+                ppm.original_move_date
 			FROM moves
 			JOIN orders as ord ON moves.orders_id = ord.id
 			JOIN service_members AS sm ON ord.service_member_id = sm.id
@@ -161,7 +171,9 @@ func GetMoveQueueItems(db *pop.Connection, lifecycleState string) ([]MoveQueueIt
 				moves.status as status,
 				ppm.status as ppm_status,
 				origin_duty_station.name as origin_duty_station_name,
-				destination_duty_station.name as destination_duty_station_name
+				destination_duty_station.name as destination_duty_station_name,
+                ppm.actual_move_date,
+                ppm.original_move_date
 			FROM moves
 			JOIN orders as ord ON moves.orders_id = ord.id
 			JOIN service_members AS sm ON ord.service_member_id = sm.id

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -2292,6 +2292,16 @@ definitions:
         $ref: '#/definitions/WeightAllotment'
       branch_of_service:
         type: string
+      actual_move_date:
+        type: string
+        format: date
+        example: 2018-04-25
+        x-nullable: true
+      original_move_date:
+        type: string
+        format: date
+        example: 2018-04-25
+        x-nullable: true
     required:
       - id
       - status


### PR DESCRIPTION
## Description

We need to see the different dates to know if obligations may have changed based on if those dates are different. 

## Setup

`make server_run`
`make client_run`

open office app. open console and browse to any queue and look at response coming back...`internal/queues/all` - for example.

look at response and notice the `actual_move_date` and `original_move_date` returned... 

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](tbd) for this change
