### PR TITLE
Upgrade to Go 1.13.8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,28 +17,28 @@ executors:
     resource_class: small
     working_directory: ~/transcom/mymove
     docker:
-      - image: trussworks/circleci-docker-primary:ba270cf66c7a9ae6dbc8e6190b74163ad71729d0
+      - image: trussworks/circleci-docker-primary:2d679f4bc2c1ab1fc46e2ef440d8ef300da607b8
   mymove_medium:
     resource_class: medium
     working_directory: ~/transcom/mymove
     docker:
-      - image: trussworks/circleci-docker-primary:ba270cf66c7a9ae6dbc8e6190b74163ad71729d0
+      - image: trussworks/circleci-docker-primary:2d679f4bc2c1ab1fc46e2ef440d8ef300da607b8
   mymove_medium_plus:
     resource_class: medium+
     working_directory: ~/transcom/mymove
     docker:
-      - image: trussworks/circleci-docker-primary:ba270cf66c7a9ae6dbc8e6190b74163ad71729d0
+      - image: trussworks/circleci-docker-primary:2d679f4bc2c1ab1fc46e2ef440d8ef300da607b8
   mymove_large:
     resource_class: large
     working_directory: ~/transcom/mymove
     docker:
-      - image: trussworks/circleci-docker-primary:ba270cf66c7a9ae6dbc8e6190b74163ad71729d0
+      - image: trussworks/circleci-docker-primary:2d679f4bc2c1ab1fc46e2ef440d8ef300da607b8
   # `mymove_and_postgres_medium` adds a secondary postgres container to be used during testing.
   mymove_and_postgres_medium:
     resource_class: medium
     working_directory: ~/transcom/mymove
     docker:
-      - image: trussworks/circleci-docker-primary:ba270cf66c7a9ae6dbc8e6190b74163ad71729d0
+      - image: trussworks/circleci-docker-primary:2d679f4bc2c1ab1fc46e2ef440d8ef300da607b8
       - image: postgres:10.10
         environment:
           - POSTGRES_PASSWORD: mysecretpassword
@@ -48,7 +48,7 @@ executors:
     resource_class: large
     working_directory: ~/transcom/mymove
     docker:
-      - image: trussworks/circleci-docker-primary:ba270cf66c7a9ae6dbc8e6190b74163ad71729d0
+      - image: trussworks/circleci-docker-primary:2d679f4bc2c1ab1fc46e2ef440d8ef300da607b8
       - image: postgres:10.10
         environment:
           - POSTGRES_PASSWORD: mysecretpassword

--- a/.github/workflows/go-auto-approve.yml
+++ b/.github/workflows/go-auto-approve.yml
@@ -25,7 +25,7 @@ jobs:
       - name: setup go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.13.7'
+          go-version: '1.13.8'
       - name: Tidy
         run: |
           go version

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -2,7 +2,7 @@
 # BUILDER #
 ###########
 
-FROM trussworks/circleci-docker-primary:ba270cf66c7a9ae6dbc8e6190b74163ad71729d0 as builder
+FROM trussworks/circleci-docker-primary:2d679f4bc2c1ab1fc46e2ef440d8ef300da607b8 as builder
 
 ENV CIRCLECI=true
 

--- a/Dockerfile.migrations_local
+++ b/Dockerfile.migrations_local
@@ -2,7 +2,7 @@
 # BUILDER #
 ###########
 
-FROM trussworks/circleci-docker-primary:ba270cf66c7a9ae6dbc8e6190b74163ad71729d0 as builder
+FROM trussworks/circleci-docker-primary:2d679f4bc2c1ab1fc46e2ef440d8ef300da607b8 as builder
 
 ENV CIRCLECI=true
 

--- a/Dockerfile.tasks_local
+++ b/Dockerfile.tasks_local
@@ -2,7 +2,7 @@
 # BUILDER #
 ###########
 
-FROM trussworks/circleci-docker-primary:ba270cf66c7a9ae6dbc8e6190b74163ad71729d0 as builder
+FROM trussworks/circleci-docker-primary:2d679f4bc2c1ab1fc46e2ef440d8ef300da607b8 as builder
 
 ENV CIRCLECI=true
 

--- a/Dockerfile.tools_local
+++ b/Dockerfile.tools_local
@@ -2,7 +2,7 @@
 # BUILDER #
 ###########
 
-FROM trussworks/circleci-docker-primary:ba270cf66c7a9ae6dbc8e6190b74163ad71729d0 as builder
+FROM trussworks/circleci-docker-primary:2d679f4bc2c1ab1fc46e2ef440d8ef300da607b8 as builder
 
 ENV CIRCLECI=true
 

--- a/docker-compose.circle.yml
+++ b/docker-compose.circle.yml
@@ -17,7 +17,7 @@ services:
   server_test:
     depends_on:
       - database
-    image: trussworks/circleci-docker-primary:ba270cf66c7a9ae6dbc8e6190b74163ad71729d0
+    image: trussworks/circleci-docker-primary:2d679f4bc2c1ab1fc46e2ef440d8ef300da607b8
     deploy:
       resources:
         limits:


### PR DESCRIPTION
Points to the most recent [trussworks/circleci-docker-primary](https://github.com/trussworks/circleci-docker-primary/commit/2d679f4bc2c1ab1fc46e2ef440d8ef300da607b8).