### PR TITLE
Variables file for send payment reminder ECS scheduled task

### DIFF
--- a/config/env/experimental.send-payment-reminder.env
+++ b/config/env/experimental.send-payment-reminder.env
@@ -1,0 +1,7 @@
+DB_IAM=true
+DB_NAME=app
+DB_PORT=5432
+DB_SSL_MODE=verify-full
+DB_SSL_ROOT_CERT=/bin/rds-ca-2019-root.pem
+DB_USER=ecs_user
+EMAIL_BACKEND=ses

--- a/config/env/prod.send-payment-reminder.env
+++ b/config/env/prod.send-payment-reminder.env
@@ -1,0 +1,7 @@
+DB_IAM=true
+DB_NAME=app
+DB_PORT=5432
+DB_SSL_MODE=verify-full
+DB_SSL_ROOT_CERT=/bin/rds-ca-2019-root.pem
+DB_USER=ecs_user
+EMAIL_BACKEND=ses

--- a/config/env/staging.send-payment-reminder.env
+++ b/config/env/staging.send-payment-reminder.env
@@ -1,0 +1,7 @@
+DB_IAM=true
+DB_NAME=app
+DB_PORT=5432
+DB_SSL_MODE=verify-full
+DB_SSL_ROOT_CERT=/bin/rds-ca-2019-root.pem
+DB_USER=ecs_user
+EMAIL_BACKEND=ses

--- a/scripts/ecs-deploy-task-container
+++ b/scripts/ecs-deploy-task-container
@@ -22,22 +22,53 @@ readonly name=$1
 readonly image=$2
 readonly environment=$3
 
-echo "Deploying ${name}"
+readonly RESERVATION_CPU=256
+readonly RESERVATION_MEM=512
 
-task_def_arn=$("${DIR}/../bin/ecs-deploy" task-def\
+echo "Checking for existence of variables file"
+
+variables_file="${DIR}/../config/env/${environment}.${name}.env"
+if [ ! -f "${variables_file}" ]; then
+  echo "Variables file '${variables_file}' does not exist!"
+  exit 1
+fi
+
+echo
+echo "Preparing ECS task definition for ${name}"
+
+"${DIR}/../bin/ecs-deploy" task-def \
   --aws-account-id "${AWS_ACCOUNT_ID}" \
   --aws-region "${AWS_DEFAULT_REGION}" \
   --service app-tasks \
   --environment "${environment}" \
   --image "${image}" \
-  --cpu 256 \
-  --memory 512 \
-  --variables-file "${DIR}/../config/env/${environment}.${name}.env" \
+  --cpu "${RESERVATION_CPU}" \
+  --memory "${RESERVATION_MEM}" \
+  --variables-file "${variables_file}" \
+  --entrypoint "/bin/milmove-tasks ${name}" \
+  --dry-run | jq .
+
+echo
+echo "Registering ECS task definition for ${name}"
+
+task_def_arn=$("${DIR}/../bin/ecs-deploy" task-def \
+  --aws-account-id "${AWS_ACCOUNT_ID}" \
+  --aws-region "${AWS_DEFAULT_REGION}" \
+  --service app-tasks \
+  --environment "${environment}" \
+  --image "${image}" \
+  --cpu "${RESERVATION_CPU}" \
+  --memory "${RESERVATION_MEM}" \
+  --variables-file "${variables_file}" \
   --entrypoint "/bin/milmove-tasks ${name}" \
   --register)
 
 readonly task_def_arn
-echo "Registered ${task_def_arn}"
+echo
+echo "Registered ECS task definition ${task_def_arn}"
+
+echo
+echo "Put new CloudWatch Event target for ${name}"
 
 "${DIR}/../bin/ecs-deploy" put-target \
   --aws-account-id "${AWS_ACCOUNT_ID}" \
@@ -46,3 +77,6 @@ echo "Registered ${task_def_arn}"
   --name "${name}" \
   --task-def-arn "${task_def_arn}" \
   --put-target
+
+echo
+echo "Successfully put new CloudWatch Event target for ${name} with ECS task definition ${task_def_arn}"


### PR DESCRIPTION
## Description

We forgot to add in the env files required for the deploy. And since the script was configured to expect the file to already exist the error was swallowed by the variable and not printed to the screen. The script is changed here to provide better error checking and debug output for folks deploying. It also prints the full task definition so folks can view it in advance. 

This was tested by deploying directly to staging.