### PR TITLE
Modify server tests to also testing orders application

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -775,17 +775,11 @@ workflows:
     jobs:
       - pre_deps_golang
 
-      - pre_deps_yarn:
-          filters:
-            branches:
-              ignore: cg_modify_server_tests_for_orders_application
+      - pre_deps_yarn
 
       - check_generated_code:
           requires:
             - pre_deps_golang
-          filters:
-            branches:
-              ignore: cg_modify_server_tests_for_orders_application
 
       - anti_virus:
           filters:
@@ -796,33 +790,21 @@ workflows:
           requires:
             - pre_deps_golang
             - pre_deps_yarn
-          filters:
-            branches:
-              ignore: cg_modify_server_tests_for_orders_application
 
       - acceptance_tests_local:
           requires:
             - pre_deps_golang
             - pre_deps_yarn
-          filters:
-            branches:
-              ignore: cg_modify_server_tests_for_orders_application
 
       - acceptance_tests_experimental:
           requires:
             - pre_deps_golang
             - pre_deps_yarn
-          filters:
-            branches:
-              ignore: cg_modify_server_tests_for_orders_application
 
       - acceptance_tests_staging:
           requires:
             - pre_deps_golang
             - pre_deps_yarn
-          filters:
-            branches:
-              ignore: cg_modify_server_tests_for_orders_application
 
       - integration_tests:
           requires:
@@ -859,40 +841,25 @@ workflows:
             - pre_deps_golang
             - pre_deps_yarn
             - acceptance_tests_local # don't bother building and pushing the application if it won't even start properly
-          filters:
-            branches:
-              ignore: cg_modify_server_tests_for_orders_application
 
       - build_storybook_app:
           requires:
             - anti_virus
             - pre_deps_yarn
-          filters:
-            branches:
-              ignore: cg_modify_server_tests_for_orders_application
 
       - build_tools:
           requires:
             - anti_virus
             - pre_deps_golang
-          filters:
-            branches:
-              ignore: cg_modify_server_tests_for_orders_application
 
       - build_migrations:
           requires:
             - anti_virus
             - pre_deps_golang
-          filters:
-            branches:
-              ignore: cg_modify_server_tests_for_orders_application
 
       - build_tasks:
           requires:
             - build_tools
-          filters:
-            branches:
-              ignore: cg_modify_server_tests_for_orders_application
 
       - deploy_experimental_migrations:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -470,6 +470,7 @@ jobs:
           keys:
             - go-mod-sources-v2-{{ checksum "go.sum" }}-{{ checksum "scripts/check-go-version" }}
       - run: echo 'export PATH=${PATH}:~/go/bin:~/transcom/mymove/bin' >> $BASH_ENV
+      - run: sudo apt-get update && sudo apt-get install -yy postgresql-client
       - run: make bin/go-junit-report
       - run: make bin/milmove
       - server_tests_step:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -817,7 +817,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: cg_modify_server_tests_for_orders_application
+              ignore: placeholder_branch_name
 
       - client_test:
           requires:
@@ -825,7 +825,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: cg_modify_server_tests_for_orders_application
+              ignore: placeholder_branch_name
 
       - server_test:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -212,6 +212,7 @@ commands:
           command: make server_test_build
           environment:
             APPLICATION: "<< parameters.application >>"
+            GOFLAGS: "-p=4"
       - run:
           name: make db_test_reset for <<parameters.application>>
           command: make db_test_reset
@@ -258,6 +259,7 @@ commands:
             EIA_KEY: db2522a43820268a41a802a16ae9fd26 # dummy key generated with openssl rand -hex 16
             ENV: test
             ENVIRONMENT: test
+            GOFLAGS: "-p=4"
             JUNIT: 1
             MIGRATION_MANIFEST: '/home/circleci/transcom/mymove/migrations/<< parameters.application >>/migrations_manifest.txt'
             MIGRATION_PATH: 'file:///home/circleci/transcom/mymove/migrations/<< parameters.application >>/schema;file:///home/circleci/transcom/mymove/migrations/<< parameters.application >>/secure'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -202,7 +202,7 @@ commands:
           name: 'Describe image scan findings'
           command: scripts/ecr-describe-image-scan-findings << parameters.repo >> ${CIRCLE_SHA1}
 
-  server_tests:
+  server_tests_step:
     parameters:
       application:
         type: string
@@ -456,9 +456,9 @@ jobs:
       - run: echo 'export PATH=${PATH}:~/go/bin:~/transcom/mymove/bin' >> $BASH_ENV
       - run: make bin/go-junit-report
       - run: make bin/milmove
-      - server_tests:
+      - server_tests_step:
           application: app
-      - server_tests:
+      - server_tests_step:
           application: orders
       - store_artifacts:
           path: ~/transcom/mymove/tmp/test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -213,7 +213,21 @@ commands:
           environment:
             APPLICATION: "<< parameters.application >>"
       - run:
-          name: make db_test_migrate <<parameters.application>>
+          name: make db_test_reset for <<parameters.application>>
+          command: make db_test_reset
+          environment:
+            APPLICATION: "<< parameters.application >>"
+            DB_PASSWORD: mysecretpassword
+            DB_USER: postgres
+            DB_HOST: localhost
+            DB_PORT_TEST: 5433
+            DB_PORT: 5432
+            DB_NAME: test_db
+            DB_NAME_TEST: test_db
+            MIGRATION_MANIFEST: '/home/circleci/transcom/mymove/migrations/<< parameters.application >>/migrations_manifest.txt'
+            MIGRATION_PATH: 'file:///home/circleci/transcom/mymove/migrations/<< parameters.application >>/schema;file:///home/circleci/transcom/mymove/migrations/<< parameters.application >>/secure'
+      - run:
+          name: make db_test_migrate for <<parameters.application>>
           command: make db_test_migrate
           environment:
             APPLICATION: "<< parameters.application >>"
@@ -227,7 +241,7 @@ commands:
             MIGRATION_MANIFEST: '/home/circleci/transcom/mymove/migrations/<< parameters.application >>/migrations_manifest.txt'
             MIGRATION_PATH: 'file:///home/circleci/transcom/mymove/migrations/<< parameters.application >>/schema;file:///home/circleci/transcom/mymove/migrations/<< parameters.application >>/secure'
       - run:
-          name: make server_test_standalone <<parameters.application>>
+          name: make server_test_standalone for <<parameters.application>>
           command: |
             echo 'export LOGIN_GOV_SECRET_KEY=$(echo $E2E_LOGIN_GOV_SECRET_KEY | base64 --decode)' >> $BASH_ENV
             source $BASH_ENV

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -772,7 +772,10 @@ workflows:
     jobs:
       - pre_deps_golang
 
-      - pre_deps_yarn
+      - pre_deps_yarn:
+          filters:
+            branches:
+              ignore: cg_modify_server_tests_for_orders_application
 
       - check_generated_code:
           requires:
@@ -787,21 +790,33 @@ workflows:
           requires:
             - pre_deps_golang
             - pre_deps_yarn
+          filters:
+            branches:
+              ignore: cg_modify_server_tests_for_orders_application
 
       - acceptance_tests_local:
           requires:
             - pre_deps_golang
             - pre_deps_yarn
+          filters:
+            branches:
+              ignore: cg_modify_server_tests_for_orders_application
 
       - acceptance_tests_experimental:
           requires:
             - pre_deps_golang
             - pre_deps_yarn
+          filters:
+            branches:
+              ignore: cg_modify_server_tests_for_orders_application
 
       - acceptance_tests_staging:
           requires:
             - pre_deps_golang
             - pre_deps_yarn
+          filters:
+            branches:
+              ignore: cg_modify_server_tests_for_orders_application
 
       - integration_tests:
           requires:
@@ -814,7 +829,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: placeholder_branch_name
+              ignore: cg_modify_server_tests_for_orders_application
 
       - client_test:
           requires:
@@ -822,7 +837,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: placeholder_branch_name
+              ignore: cg_modify_server_tests_for_orders_application
 
       - server_test:
           requires:
@@ -830,7 +845,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: placeholder_branch_name
+              ignore: cg_modify_server_tests_for_orders_application
 
       - build_app:
           requires:
@@ -838,25 +853,40 @@ workflows:
             - pre_deps_golang
             - pre_deps_yarn
             - acceptance_tests_local # don't bother building and pushing the application if it won't even start properly
+          filters:
+            branches:
+              ignore: cg_modify_server_tests_for_orders_application
 
       - build_storybook_app:
           requires:
             - anti_virus
             - pre_deps_yarn
+          filters:
+            branches:
+              ignore: cg_modify_server_tests_for_orders_application
 
       - build_tools:
           requires:
             - anti_virus
             - pre_deps_golang
+          filters:
+            branches:
+              ignore: cg_modify_server_tests_for_orders_application
 
       - build_migrations:
           requires:
             - anti_virus
             - pre_deps_golang
+          filters:
+            branches:
+              ignore: cg_modify_server_tests_for_orders_application
 
       - build_tasks:
           requires:
             - build_tools
+          filters:
+            branches:
+              ignore: cg_modify_server_tests_for_orders_application
 
       - deploy_experimental_migrations:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -780,6 +780,9 @@ workflows:
       - check_generated_code:
           requires:
             - pre_deps_golang
+          filters:
+            branches:
+              ignore: cg_modify_server_tests_for_orders_application
 
       - anti_virus:
           filters:
@@ -845,7 +848,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: cg_modify_server_tests_for_orders_application
+              ignore: placeholder_branch_name
 
       - build_app:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -201,6 +201,53 @@ commands:
       - run:
           name: 'Describe image scan findings'
           command: scripts/ecr-describe-image-scan-findings << parameters.repo >> ${CIRCLE_SHA1}
+
+  server_tests:
+    parameters:
+      application:
+        type: string
+    steps:
+      - run:
+          name: make server_test_build <<parameters.application>>
+          command: make server_test_build
+          environment:
+            APPLICATION: "<< parameters.application >>"
+      - run:
+          name: make db_test_migrate <<parameters.application>>
+          command: make db_test_migrate
+          environment:
+            APPLICATION: "<< parameters.application >>"
+            DB_PASSWORD: mysecretpassword
+            DB_USER: postgres
+            DB_HOST: localhost
+            DB_PORT_TEST: 5433
+            DB_PORT: 5432
+            DB_NAME: test_db
+            DB_NAME_TEST: test_db
+            MIGRATION_MANIFEST: '/home/circleci/transcom/mymove/migrations/<< parameters.application >>/migrations_manifest.txt'
+            MIGRATION_PATH: 'file:///home/circleci/transcom/mymove/migrations/<< parameters.application >>/schema;file:///home/circleci/transcom/mymove/migrations/<< parameters.application >>/secure'
+      - run:
+          name: make server_test_standalone <<parameters.application>>
+          command: |
+            echo 'export LOGIN_GOV_SECRET_KEY=$(echo $E2E_LOGIN_GOV_SECRET_KEY | base64 --decode)' >> $BASH_ENV
+            source $BASH_ENV
+            make server_test_standalone
+          environment:
+            APPLICATION: "<< parameters.application >>"
+            DB_PASSWORD: mysecretpassword
+            DB_USER: postgres
+            DB_HOST: localhost
+            DB_PORT_TEST: 5433
+            DB_PORT: 5432
+            DB_NAME: test_db
+            DB_NAME_TEST: test_db
+            EIA_KEY: db2522a43820268a41a802a16ae9fd26 # dummy key generated with openssl rand -hex 16
+            ENV: test
+            ENVIRONMENT: test
+            JUNIT: 1
+            MIGRATION_MANIFEST: '/home/circleci/transcom/mymove/migrations/<< parameters.application >>/migrations_manifest.txt'
+            MIGRATION_PATH: 'file:///home/circleci/transcom/mymove/migrations/<< parameters.application >>/schema;file:///home/circleci/transcom/mymove/migrations/<< parameters.application >>/secure'
+            SERVE_API_INTERNAL: true
   e2e_tests:
     steps:
       - run:
@@ -409,44 +456,10 @@ jobs:
       - run: echo 'export PATH=${PATH}:~/go/bin:~/transcom/mymove/bin' >> $BASH_ENV
       - run: make bin/go-junit-report
       - run: make bin/milmove
-      - run:
-          name: make db_test_migrate
-          command: make db_test_migrate
-          environment:
-            APPLICATION: app
-            DB_PASSWORD: mysecretpassword
-            DB_USER: postgres
-            DB_HOST: localhost
-            DB_PORT_TEST: 5433
-            DB_PORT: 5432
-            DB_NAME: test_db
-            DB_NAME_TEST: test_db
-            MIGRATION_MANIFEST: '/home/circleci/transcom/mymove/migrations/app/migrations_manifest.txt'
-            MIGRATION_PATH: 'file:///home/circleci/transcom/mymove/migrations/app/schema;file:///home/circleci/transcom/mymove/migrations/app/secure'
-      - run:
-          name: make server_test_standalone
-          command: |
-            echo 'export LOGIN_GOV_SECRET_KEY=$(echo $E2E_LOGIN_GOV_SECRET_KEY | base64 --decode)' >> $BASH_ENV
-            source $BASH_ENV
-            mkdir -p tmp/test-results/gotest
-            # setup a trap incase the tests fail, we still want to generate the report
-            trap "bin/go-junit-report < tmp/test-results/gotest/go-test.out >  tmp/test-results/gotest/go-test-report.xml" EXIT
-            make server_test_standalone | tee tmp/test-results/gotest/go-test.out
-          environment:
-            APPLICATION: app
-            DB_PASSWORD: mysecretpassword
-            DB_USER: postgres
-            DB_HOST: localhost
-            DB_PORT_TEST: 5433
-            DB_PORT: 5432
-            DB_NAME: test_db
-            DB_NAME_TEST: test_db
-            EIA_KEY: db2522a43820268a41a802a16ae9fd26 # dummy key generated with openssl rand -hex 16
-            ENV: test
-            ENVIRONMENT: test
-            MIGRATION_MANIFEST: '/home/circleci/transcom/mymove/migrations/app/migrations_manifest.txt'
-            MIGRATION_PATH: 'file:///home/circleci/transcom/mymove/migrations/app/schema;file:///home/circleci/transcom/mymove/migrations/app/secure'
-            SERVE_API_INTERNAL: true
+      - server_tests:
+          application: app
+      - server_tests:
+          application: orders
       - store_artifacts:
           path: ~/transcom/mymove/tmp/test-results
           destination: test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -208,7 +208,7 @@ commands:
         type: string
     steps:
       - run:
-          name: make server_test_build <<parameters.application>>
+          name: make server_test_build for <<parameters.application>>
           command: make server_test_build
           environment:
             APPLICATION: "<< parameters.application >>"

--- a/Makefile
+++ b/Makefile
@@ -161,7 +161,7 @@ client_deps: .check_hosts.stamp .check_node_version.stamp .client_deps.stamp ## 
 .PHONY: client_build
 client_build: .client_deps.stamp .client_build.stamp ## Build the client
 
-build/index.html: ## milmove serve_app requires this file to boot, but it isn't used during local development
+build/index.html: ## milmove serve requires this file to boot, but it isn't used during local development
 	mkdir -p build
 	touch build/index.html
 
@@ -306,7 +306,7 @@ server_build: bin/milmove ## Build the server
 # This command is for running the server by itself, it will serve the compiled frontend on its own
 # Note: Don't double wrap with aws-vault because the pkg/cli/vault.go will handle it
 server_run_standalone: check_log_dir server_build client_build db_dev_run
-	DEBUG_LOGGING=true ./bin/milmove serve_${APPLICATION} 2>&1 | tee -a log/dev.log
+	DEBUG_LOGGING=true ./bin/milmove serve 2>&1 | tee -a log/dev.log
 
 # This command will rebuild the swagger go code and rerun server on any changes
 server_run:
@@ -323,7 +323,7 @@ server_run_default: .check_hosts.stamp .check_go_version.stamp .check_gopath.sta
 		--excludeDir node_modules \
 		--immediate \
 		--buildArgs "-i -ldflags=\"$(WEBSERVER_LDFLAGS)\"" \
-		serve_${APPLICATION} \
+		serve \
 		2>&1 | tee -a log/dev.log
 
 .PHONY: server_run_debug

--- a/Makefile
+++ b/Makefile
@@ -406,7 +406,7 @@ server_test_standalone: ## Run server unit tests with no deps
 
 .PHONY: server_test_build
 server_test_build:
-	DRY_RUN=1 scripts/run-server-test
+	NO_DB=1 DRY_RUN=1 scripts/run-server-test
 
 .PHONY: server_test_all
 server_test_all: db_dev_reset db_dev_migrate ## Run all server unit tests
@@ -558,6 +558,7 @@ ifndef CIRCLECI
 		echo "No database container"
 else
 	@echo "Relying on CircleCI's database setup to destroy the DB."
+	psql postgres://postgres:$(PGPASSWORD)@localhost:$(DB_PORT_TEST)?sslmode=disable -c 'DROP DATABASE IF EXISTS $(DB_NAME_TEST);'
 endif
 
 .PHONY: db_test_start
@@ -586,6 +587,7 @@ ifndef CIRCLECI
 		createdb -p $(DB_PORT_TEST) -h localhost -U postgres $(DB_NAME_TEST) || true
 else
 	@echo "Relying on CircleCI's database setup to create the DB."
+	psql postgres://postgres:$(PGPASSWORD)@localhost:$(DB_PORT_TEST)?sslmode=disable -c 'CREATE DATABASE $(DB_NAME_TEST);'
 endif
 
 .PHONY: db_test_run

--- a/docker-compose.circle.yml
+++ b/docker-compose.circle.yml
@@ -29,6 +29,7 @@ services:
       - ./:/home/circleci/transcom/mymove
     working_dir: /home/circleci/transcom/mymove
     environment:
+      - APPLICATION
       - CLIENT_AUTH_SECRET_KEY
       - CSRF_AUTH_KEY
       - CIRCLECI=1

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -119,6 +119,7 @@ This subset of development scripts is used for testing
 | --- | --- |
 | `run-e2e-test` | Runs cypress tests with interactive GUI |
 | `run-e2e-test-docker` | Runs cypress tests entirely inside docker containers like in CircleCI |
+| `run-server-test` | Run golang server tests |
 | `run-server-test-in-circle-container` | Executed in docker-compose.circle.yml to run the `make server_test` task in a CircleCI container |
 
 ### Secure Migrations

--- a/scripts/run-server-test
+++ b/scripts/run-server-test
@@ -1,0 +1,84 @@
+#! /usr/bin/env bash
+
+#
+# Run golang server tests
+#
+# Set these environment variables to change behavior:
+# - APPLICATION: 'app' or 'orders' will change which tests are run and which migrations are run for them
+# - CIRCLECI: Will reduce parallelism and make the test output verbose
+# - COVERAGE: '1' will enable test coverage flags
+# - DRY_RUN: '1' will build the tests but not run them
+# - JUNIT: '1' will run go-junit-report on test output
+# - LONG_TEST: '1' will remove the '-short' flag and run extended tests
+# - NO_DB: Will disable the db reset and migration steps
+#
+# Don't run tests in /cmd (those are done in acceptance testing) or for generated code (in /pkg/gen/ or mocks)
+# Disable test caching with `-count 1` - caching was masking local test failures
+
+set -eu -o pipefail
+
+if [ "${APPLICATION}" == "app" ]; then
+  package_list=$(go list ./... | grep -v ordersapi | grep -v \\/pkg\\/gen\\/ | grep -v \\/cmd\\/ | grep -v mocks)
+elif [ "${APPLICATION}" == "orders" ]; then
+  package_list=$(go list ./pkg/handlers/ordersapi)
+else
+  echo "Must provider the environment variable APPLICATION and set to 'app' or 'orders'"
+  exit 1
+fi
+
+# Try to compile tests, but don't run them.
+if [[ "${DRY_RUN:-}" == "1" ]]; then
+  echo "Compiling tests only, not running"
+  # shellcheck disable=SC2086
+	go test -run=nope -count 1 ${package_list}
+  exit 0
+fi
+
+# Like server_test but runs extended tests that may hit external services.
+short_flag="-short"
+if [[ "${LONG_TEST:-}" == "1" ]]; then
+  short_flag=""
+fi
+
+# Add coverage tracker via go cover
+coverage_flag=""
+if [[ "${COVERAGE:-}" == "1" ]]; then
+  coverage_flag="-coverprofile=coverage.out -covermode=count"
+fi
+
+# Set up the test DB instance and wipe it
+# do not run db commands if NO_DB is set to 1
+if [[ "${NO_DB:-}" -ne 1 ]]; then
+  make db_test_reset db_test_migrate
+fi
+
+# Setup test output for reporting
+test_dir="tmp/test-results/gotest/${APPLICATION}"
+test_output_file="${test_dir}/go-test.out"
+test_report_file="${test_dir}/go-test-report.xml"
+mkdir -p "${test_dir}"
+
+function junit_cleanup()
+{
+  # generate the junit report
+  bin/go-junit-report < "${test_output_file}" > "${test_report_file}"
+}
+
+# Set up junit report and ensure its run on exit
+if [[ "${JUNIT:-}" == "1" ]]; then
+  if [ ! -f bin/go-junit-report ]; then
+    make bin/go-junit-report
+  fi
+  # setup a trap incase the tests fail, we still want to generate the report
+  trap junit_cleanup EXIT
+fi
+
+if [ -n "${CIRCLECI+x}" ]; then
+	# Limit the maximum number of tests to run in parallel for CircleCI due to memory constraints.
+	# Add verbose (-v) so go-junit-report can parse it for CircleCI results
+  # shellcheck disable=SC2086
+	DB_NAME="${DB_NAME_TEST}" DB_PORT="${DB_PORT_TEST}" go test -v -parallel 4 -count 1 ${coverage_flag} ${short_flag} ${package_list} | tee "${test_output_file}"
+else
+  # shellcheck disable=SC2086
+	DB_NAME="${DB_NAME_TEST}" DB_PORT="${DB_PORT_TEST}" go test -parallel 8 -count 1 ${coverage_flag} ${short_flag} ${package_list} | tee "${test_output_file}"
+fi

--- a/scripts/run-server-test
+++ b/scripts/run-server-test
@@ -26,11 +26,20 @@ else
   exit 1
 fi
 
+verbose_flag=""
+parallel=8
+if [ -n "${CIRCLECI+x}" ]; then
+	# Limit the maximum number of tests to run in parallel for CircleCI due to memory constraints.
+  parallel=4
+	# Add verbose (-v) so go-junit-report can parse it for CircleCI results
+  verbose_flag="-v"
+fi
+
 # Try to compile tests, but don't run them.
 if [[ "${DRY_RUN:-}" == "1" ]]; then
   echo "Compiling tests only, not running"
   # shellcheck disable=SC2086
-	go test -run=nope -count 1 ${package_list}
+	go test -run=nope -parallel ${parallel} -count 1 ${package_list}
   exit 0
 fi
 
@@ -73,12 +82,5 @@ if [[ "${JUNIT:-}" == "1" ]]; then
   trap junit_cleanup EXIT
 fi
 
-if [ -n "${CIRCLECI+x}" ]; then
-	# Limit the maximum number of tests to run in parallel for CircleCI due to memory constraints.
-	# Add verbose (-v) so go-junit-report can parse it for CircleCI results
-  # shellcheck disable=SC2086
-	DB_NAME="${DB_NAME_TEST}" DB_PORT="${DB_PORT_TEST}" go test -v -parallel 4 -count 1 ${coverage_flag} ${short_flag} ${package_list} | tee "${test_output_file}"
-else
-  # shellcheck disable=SC2086
-	DB_NAME="${DB_NAME_TEST}" DB_PORT="${DB_PORT_TEST}" go test -parallel 8 -count 1 ${coverage_flag} ${short_flag} ${package_list} | tee "${test_output_file}"
-fi
+# shellcheck disable=SC2086
+DB_NAME="${DB_NAME_TEST}" DB_PORT="${DB_PORT_TEST}" go test -parallel "${parallel}" -count 1 ${verbose_flag} ${coverage_flag} ${short_flag} ${package_list} | tee "${test_output_file}"

--- a/scripts/run-server-test-in-circle-container
+++ b/scripts/run-server-test-in-circle-container
@@ -6,18 +6,30 @@
 
 set -eu -o pipefail
 
+if [ "${APPLICATION}" != "app" ] && [ "${APPLICATION}" != "ordres" ]; then
+  echo "Must provider the environment variable APPLICATION and set to 'app' or 'orders'"
+  exit 1
+fi
+
 make clean
 
 go get ./...
 
-# These targets are built with GOARCH=amd64 GOOS=linux and overwrite the local binaries
-make bin/go-junit-report
-make bin/milmove
+# Test that go tests will build first
+make server_test_build
 
+# Migrate the DB
+make bin/milmove
 make db_test_migrate
 
-mkdir -p tmp/test-results/gotest
+function cleanup()
+{
+  # These targets are built with GOARCH=amd64 GOOS=linux and overwrite the local binaries
+  # because docker-compose mounts the local directory and the bin directory is used
+  rm -f bin/milmove
+  rm -f bin/go-junit-report
+}
 
 ## setup a trap incase the tests fail, we still want to generate the report
-trap "bin/go-junit-report < tmp/test-results/gotest/go-test.out >  tmp/test-results/gotest/go-test-report.xml" EXIT
-make server_test_standalone | tee tmp/test-results/gotest/go-test.out
+trap cleanup EXIT
+JUNIT=1 make server_test_standalone


### PR DESCRIPTION
## Description

The modification here is to allow us to run tests against the `app` and `orders` DB's with their different sets of tables and migrations. To do this I've consolidated all the logic for server tests into a script called `scripts/run-server-test`. 

This also fixes the problem with flaky server tests that report a `build failed` error message.

You can now access artifacts for both sets of applications in CircleCI:

<img width="240" alt="Screen Shot 2020-02-14 at 2 43 51 PM" src="https://user-images.githubusercontent.com/219296/74574408-794be000-4f38-11ea-8ff7-7b1880024376.png">

## Setup

Some commands you can try:

```
make server_test
make server_test_coverage
make server_test_docker
```

Then add `export APPLICATION=orders` to your `.envrc` or prepend `APPLICATION=orders` to the commands above and then rerun them all.