### PR TITLE
MB-1658 - Enable artifacts for pre-commit tests in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -317,18 +317,24 @@ jobs:
           keys:
             - pre-commit-dot-cache-{{ checksum ".pre-commit-config.yaml" }}
       - run: echo 'export PATH=${PATH}:~/go/bin:~/transcom/mymove/bin' >> $BASH_ENV
-      - run: echo 'export GOLANGCI_LINT_CONCURRENCY=1' >> $BASH_ENV
       - run: make bin/swagger
       # this is so we can avoid go mod downloading and resulting in an error on a false positive
       - run: scripts/pre-commit-go-mod || exit 0
       - run:
           name: Run pre-commit tests
-          command: pre-commit run --all-files
+          command: |
+            echo 'export GOLANGCI_LINT_CONCURRENCY=1' >> $BASH_ENV
+            echo 'export GOLANGCI_LINT_VERBOSE=-v' >> $BASH_ENV
+            source $BASH_ENV
+            pre-commit run --all-files | tee tmp/test-results/pretest/pretest.out
       # `pre-commit-dot-cache-{{ checksum ".pre-commit-config.yaml" }}` is used to cache pre-commit plugins.
       - save_cache:
           key: pre-commit-dot-cache-{{ checksum ".pre-commit-config.yaml" }}
           paths:
             - ~/.cache/pre-commit
+      - store_artifacts:
+          path: ~/transcom/mymove/tmp/test-results
+          destination: test-results
       - announce_failure
 
   # `acceptance_tests_local` runs acceptance tests for the webserver against a local environment.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -321,12 +321,16 @@ jobs:
       # this is so we can avoid go mod downloading and resulting in an error on a false positive
       - run: scripts/pre-commit-go-mod || exit 0
       - run:
-          name: Run pre-commit tests
+          name: Run pre-commit tests without golangci-lint
+          command: SKIP=golangci-lint pre-commit run -v --all-files
+      - run:
+          name: Run pre-commit tests with golangci-lint only
           command: |
             echo 'export GOLANGCI_LINT_CONCURRENCY=1' >> $BASH_ENV
             echo 'export GOLANGCI_LINT_VERBOSE=-v' >> $BASH_ENV
             source $BASH_ENV
-            pre-commit run --all-files | tee tmp/test-results/pretest/pretest.out
+            mkdir -p tmp/test-results/pretest
+            pre-commit run -v --all-files golangci-lint | tee tmp/test-results/pretest/golangci-lint.out
       # `pre-commit-dot-cache-{{ checksum ".pre-commit-config.yaml" }}` is used to cache pre-commit plugins.
       - save_cache:
           key: pre-commit-dot-cache-{{ checksum ".pre-commit-config.yaml" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -322,7 +322,8 @@ jobs:
       - run: scripts/pre-commit-go-mod || exit 0
       - run:
           name: Run pre-commit tests without golangci-lint
-          command: SKIP=golangci-lint pre-commit run -v --all-files
+          command: SKIP=golangci-lint pre-commit run --all-files
+      # The output of golangci-lint is an artifact towards STIG compliance
       - run:
           name: Run pre-commit tests with golangci-lint only
           command: |

--- a/.envrc
+++ b/.envrc
@@ -254,8 +254,10 @@ require CLOUD_FRONT_KEY_ID "See 'chamber read app-devlocal cloud_front_key_id'"
 export FEATURE_FLAG_ACCESS_CODE=false
 export FEATURE_FLAG_CONVERT_PPMS_TO_GHC=true
 
-# Set override of golangci-lint concurrency env variable
+# Set golangci-lint concurrency env variable
 export GOLANGCI_LINT_CONCURRENCY=6
+# Set golangci-lint verbosity if value is "-v"
+export GOLANGCI_LINT_VERBOSE=""
 
 # Set DB_DEBUG to true for development to enable sql logging
 export DB_DEBUG=1

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,21 +15,23 @@ linters-settings:
 
 linters:
   enable:
-    - gosec
-    - golint
+    - deadcode
     - gofmt
     - goimports
+    - golint
+    - gosec
     - govet
-    - varcheck
-    - typecheck
-    - structcheck
-    - deadcode
     - ineffassign
+    - structcheck
+    - typecheck
+    - varcheck
   disable:
-    - unused #deprecated https://github.com/dominikh/go-tools/tree/master/cmd/unused
-    - gosimple #deprecated https://github.com/golangci/golangci-lint/issues/357
     - errcheck #requires patching code
     - staticcheck # 30+files need to be patched
+    - gosimple #deprecated https://github.com/golangci/golangci-lint/issues/357
+    - unused #deprecated https://github.com/dominikh/go-tools/tree/master/cmd/unused
+  fast: false
+
 issues:
   exclude-rules:
     # skip analyzing dutystationsloader until repeated tags from embedded types are fixed https://github.com/golang/go/issues/30846
@@ -37,13 +39,16 @@ issues:
       linters:
         - govet
   fix: true
+
 run:
   # timeout for analysis, e.g. 30s, 5m, default is 1m
   deadline: 8m
   concurrency: 1
-
-# which dirs to skip: they won't be analyzed;
+  issues-exit-code: 1
+  tests: true
   skip-dirs:
     - pkg/assets
     - pkg/gen
     - mocks
+  skip-dirs-use-default: true
+  modules-download-mode: readonly

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,8 +32,7 @@ repos:
     rev: v1.23.1
     hooks:
       - id: golangci-lint
-        entry: bash -c 'exec golangci-lint run -j=${GOLANGCI_LINT_CONCURRENCY:-1}' # custom bash so we can override concurrency for faster dev runs
-
+        entry: bash -c 'exec golangci-lint run ${GOLANGCI_LINT_VERBOSE} -j=${GOLANGCI_LINT_CONCURRENCY:-1}' # custom bash so we can override concurrency for faster dev runs
 
   - repo: git://github.com/igorshubovych/markdownlint-cli
     rev: v0.21.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
     rev: v1.23.1
     hooks:
       - id: golangci-lint
-        entry: bash -c 'exec golangci-lint run ${GOLANGCI_LINT_VERBOSE} -j=${GOLANGCI_LINT_CONCURRENCY:-1}' # custom bash so we can override concurrency for faster dev runs
+        entry: bash -c 'exec golangci-lint run -v ${GOLANGCI_LINT_VERBOSE} -j=${GOLANGCI_LINT_CONCURRENCY:-1}' # custom bash so we can override concurrency for faster dev runs
 
   - repo: git://github.com/igorshubovych/markdownlint-cli
     rev: v0.21.0


### PR DESCRIPTION
## Description

Our ISSM would like to be able to review the output of the `gosec` tool being run by `golangci-lint`. We can enable this in CircleCI by making the golangci-lint tool run in verbose mode and capturing the output as a test artifact.

You can get the artifact in CircleCI:

<img width="250" alt="Screen Shot 2020-02-14 at 4 14 25 PM" src="https://user-images.githubusercontent.com/219296/74577651-27f61d80-4f45-11ea-9fc7-634c5555271d.png">

And here's an example https://229393-114694829-gh.circle-artifacts.com/0/test-results/pretest/golangci-lint.out

