### PR TITLE
Remove SQL Injections w/i MTO Shipment Updater

### DIFF
--- a/pkg/services/mto_shipment/mto_shipment_updater_test.go
+++ b/pkg/services/mto_shipment/mto_shipment_updater_test.go
@@ -132,7 +132,7 @@ func (suite *MTOShipmentServiceSuite) TestMTOShipmentUpdater() {
 	}
 
 	suite.T().Run("Updater can handle optional queries set as nil", func(t *testing.T) {
-		suite.DB().Find(oldMTOShipment, oldMTOShipment.ID)
+		suite.DB().Find(&oldMTOShipment, oldMTOShipment.ID)
 		weight := unit.Pound(123)
 		actualWeight := &weight
 		unmodifiedSince := oldMTOShipment.UpdatedAt


### PR DESCRIPTION
## Description

The way optional queries were built before can lead to a potential security threat via sql injections so @lynzt and I worked on tweaking them. 

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make server_run
make db_test_e2e_populate
```