### PR TITLE
Ensure application being run is correct for the target

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -219,6 +219,7 @@ commands:
             make e2e_test_docker
           environment:
             # Env vars needed for the webserver to run inside docker
+            APPLICATION: app
             LOGIN_GOV_CALLBACK_PROTOCOL: http
             LOGIN_GOV_MY_CLIENT_ID: urn:gov:gsa:openidconnect.profiles:sp:sso:dod:mymovemillocal
             LOGIN_GOV_OFFICE_CLIENT_ID: urn:gov:gsa:openidconnect.profiles:sp:sso:dod:officemovemillocal

--- a/Makefile
+++ b/Makefile
@@ -667,6 +667,8 @@ e2e_clean: ## Clean e2e (end-to-end) files and docker images
 
 .PHONY: db_e2e_up
 db_e2e_up: bin/generate-test-data ## Truncate Test DB and Generate e2e (end-to-end) data
+	@echo "Ensure that you're running the correct APPLICATION..."
+	./scripts/ensure-application app
 	@echo "Truncate the ${DB_NAME_TEST} database..."
 	psql postgres://postgres:$(PGPASSWORD)@localhost:$(DB_PORT_TEST)/$(DB_NAME_TEST)?sslmode=disable -c 'TRUNCATE users CASCADE;'
 	@echo "Populate the ${DB_NAME_TEST} database..."
@@ -677,6 +679,8 @@ db_e2e_init: db_test_reset db_test_migrate db_e2e_up ## Initialize e2e (end-to-e
 
 .PHONY: db_dev_e2e_populate
 db_dev_e2e_populate: db_dev_reset db_dev_migrate ## Populate Dev DB with generated e2e (end-to-end) data
+	@echo "Ensure that you're running the correct APPLICATION..."
+	./scripts/ensure-application app
 	@echo "Populate the ${DB_NAME_DEV} database with docker command..."
 	go run github.com/transcom/mymove/cmd/generate-test-data --named-scenario="e2e_basic" --db-env="development"
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -93,6 +93,7 @@ application testing
 | Script Name | Description |
 | --- | --- |
 | `check-docker-size` | Script to check the available disk space Docker has used |
+| `ensure-application` | Ensure APPLICATION is set to `app` or `orders` and matches input value |
 | `export-obfuscated-tspp-sample` | Export a subset of rows from the `transportation_service_provider_performances` table |
 | `find-invoices` |  This script will use available API endpoints to find invoices in whatever environment you specify|
 | `generate-devlocal-cert` | Convenience script for creating a new certificate signed by the DevLocal CA. |

--- a/scripts/ensure-application
+++ b/scripts/ensure-application
@@ -1,0 +1,25 @@
+#! /usr/bin/env bash
+#
+# Ensure APPLICATION is set to `app` or `orders` and matches input value
+#
+# Example:
+#    ensure-application app
+#
+
+set -eu -o pipefail
+
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+readonly check_app=$1
+
+if [ "${APPLICATION}" != "app" ] && [ "${APPLICATION}" != "orders" ] ; then
+  echo "Must provider the environment variable APPLICATION and set to 'app' or 'orders'"
+  exit 1
+fi
+
+if [ "${APPLICATION}" != "${check_app}" ]; then
+    echo -e "${RED}ERROR: You are running the '${APPLICATION}' application. Please modify .envrc.local to use:${NC}"
+    echo -e "${RED}export APPLICATION=${check_app}${NC}"
+    exit 1
+fi

--- a/scripts/run-e2e-test-docker
+++ b/scripts/run-e2e-test-docker
@@ -2,6 +2,8 @@
 
 set -eux -o pipefail
 
+scripts/ensure-application app
+
 # Setting REACT_APP_NODE_ENV to develompent enables the "Local Sign In" button
 export REACT_APP_NODE_ENV=development
 


### PR DESCRIPTION
## Description

If you set `export APPLICATION=orders` in your `.envrc.local` and then try to run `db_dev_e2e_populate` you'll find that you're trying to load app data into the orders DB and you get an unhelpful error message. I've added a script here that should check to ensure you're using the correct application when running. It's also a nice way to ensure you've set the environment variable `APPLICATION`.

```
ensure-application app
ensure-application orders
```