### PR TITLE
Add @trussworks/react-uswds module

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "@fortawesome/fontawesome": "^1.1.6",
     "@fortawesome/fontawesome-free-solid": "^5.0.11",
     "@fortawesome/react-fontawesome": "^0.0.20",
+    "@trussworks/react-uswds": "^1.0.0",
     "bytes": "^3.0.0",
     "classnames": "^2.2.5",
     "connected-react-router": "^6.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2680,6 +2680,16 @@
     "@babel/runtime" "^7.5.5"
     "@testing-library/dom" "^5.6.1"
 
+"@trussworks/react-uswds@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@trussworks/react-uswds/-/react-uswds-1.0.0.tgz#1eb61657a4b79ceab68b0abc63105a59296d111a"
+  integrity sha512-tBxbUzIEU4dzNZojKZFuoSj5Tb84OgHeImX/cAhe1dstkmXxvSQdkZRXE+RGQqp4o9VjN0BjNpDiKywsLb8b9w==
+  dependencies:
+    classnames "^2.2.6"
+    react "^16.10.0"
+    react-dom "^16.10.0"
+    uswds "^2.2.1"
+
 "@types/babel__core@^7.1.0":
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.3.tgz#e441ea7df63cd080dfcd02ab199e6d16a735fc30"
@@ -4687,7 +4697,7 @@ classlist-polyfill@^1.0.3:
   resolved "https://registry.yarnpkg.com/classlist-polyfill/-/classlist-polyfill-1.2.0.tgz#935bc2dfd9458a876b279617514638bcaa964a2e"
   integrity sha1-k1vC39lFiodrJ5YXUUY4vKqWSi4=
 
-classnames@^2.2.0, classnames@^2.2.3, classnames@^2.2.5, classnames@~2.2.5:
+classnames@^2.2.0, classnames@^2.2.3, classnames@^2.2.5, classnames@^2.2.6, classnames@~2.2.5:
   version "2.2.6"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
   integrity sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==
@@ -12725,7 +12735,7 @@ react-docgen@^5.0.0:
     node-dir "^0.1.10"
     strip-indent "^3.0.0"
 
-react-dom@^16.12.0, react-dom@^16.8.3:
+react-dom@^16.10.0, react-dom@^16.12.0, react-dom@^16.8.3:
   version "16.12.0"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.12.0.tgz#0da4b714b8d13c2038c9396b54a92baea633fe11"
   integrity sha512-LMxFfAGrcS3kETtQaCkTKjMiifahaMySFDn71fZUNpPHZQEzmk/GiAeIT8JSOrHB23fnuCOMruL2a8NYlw+8Gw==
@@ -13162,7 +13172,7 @@ react-window-size@^1.0.1:
   dependencies:
     babel-runtime "^6.6.1"
 
-react@^16.12.0, react@^16.8.3:
+react@^16.10.0, react@^16.12.0, react@^16.8.3:
   version "16.12.0"
   resolved "https://registry.yarnpkg.com/react/-/react-16.12.0.tgz#0c0a9c6a142429e3614834d5a778e18aa78a0b83"
   integrity sha512-fglqy3k5E+81pA8s+7K0/T3DBCF0ZDOher1elBFzF7O6arXJgzyu/FW+COxFvAWXJoJN9KIZbT2LXlukwphYTA==
@@ -15540,7 +15550,7 @@ use@^3.1.0:
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
   integrity sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==
 
-uswds@2.5.0:
+uswds@2.5.0, uswds@^2.2.1:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/uswds/-/uswds-2.5.0.tgz#cc4c993f86db63ddb5109abf4ac0ab7e1ffff3b2"
   integrity sha512-DQpFpLCqPxxgCUeLYEapvfeP/+E0a3vEzLMYVJJqTOjGWgqwrgeQxgw0U8ip091L67y70709CEE5rYny7kLzSA==


### PR DESCRIPTION
## Description

Truss has released an npm module that provides uswds components as react components

[Truss react-uswds module](https://github.com/trussworks/react-uswds)
[USWDS](https://designsystem.digital.gov/)

## Setup

Run the install for client deps `make client_deps` or `yarn install` and see that the `react-uswds` module is installed

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [MB-1675](https://dp3.atlassian.net/browse/MB-1675) for this change
* [this article](https://github.com/trussworks/react-uswds) explains more about the approach used.