### PR TITLE
Update logging for payment reminder emails

### DIFF
--- a/cmd/milmove-tasks/send_payment_reminder_email.go
+++ b/cmd/milmove-tasks/send_payment_reminder_email.go
@@ -123,7 +123,6 @@ func sendPaymentReminder(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		logger.Fatal("initializing MoveReviewed", zap.Error(err))
 	}
-	fmt.Printf("%+v\n", movePaymentReminderNotifier)
 
 	err = notificationSender.SendNotification(ctx, movePaymentReminderNotifier)
 	if err != nil {

--- a/pkg/notifications/move_payment_reminder.go
+++ b/pkg/notifications/move_payment_reminder.go
@@ -74,7 +74,7 @@ func (m PaymentReminder) GetEmailInfo() (PaymentReminderEmailInfos, error) {
 	dsn.name AS new_duty_station_name,
 	tos.name AS transportation_office_name,
 	opl.number AS transportation_office_phone,
-m.locator
+	m.locator
 FROM personally_procured_moves ppm
 	JOIN moves m ON ppm.move_id = m.id
 	JOIN orders o ON m.orders_id = o.id

--- a/pkg/notifications/move_payment_reminder.go
+++ b/pkg/notifications/move_payment_reminder.go
@@ -62,6 +62,7 @@ type PaymentReminderEmailInfo struct {
 	TOName               string `db:"transportation_office_name"`
 	TOPhone              string `db:"transportation_office_phone"`
 	MoveDate             string `db:"move_date"`
+	Locator              string `db:"locator"`
 }
 
 func (m PaymentReminder) GetEmailInfo() (PaymentReminderEmailInfos, error) {
@@ -72,7 +73,8 @@ func (m PaymentReminder) GetEmailInfo() (PaymentReminderEmailInfos, error) {
 	ppm.original_move_date as move_date,
 	dsn.name AS new_duty_station_name,
 	tos.name AS transportation_office_name,
-	opl.number AS transportation_office_phone
+	opl.number AS transportation_office_phone,
+m.locator
 FROM personally_procured_moves ppm
 	JOIN moves m ON ppm.move_id = m.id
 	JOIN orders o ON m.orders_id = o.id
@@ -148,8 +150,10 @@ func (m PaymentReminder) formatEmails(PaymentReminderEmailInfos PaymentReminderE
 			textBody:       textBody,
 			onSuccess:      m.OnSuccess(PaymentReminderEmailInfo),
 		}
-		m.logger.Info("generated move reviewed email to service member",
-			zap.String("service member uuid", PaymentReminderEmailInfo.ServiceMemberID.String()))
+		m.logger.Info("generated payment reminder email to service member",
+			zap.String("service member uuid", PaymentReminderEmailInfo.ServiceMemberID.String()),
+			zap.String("moveLocator", PaymentReminderEmailInfo.Locator),
+		)
 		emails = append(emails, smEmail)
 	}
 	return emails, nil

--- a/pkg/notifications/move_payment_reminder_test.go
+++ b/pkg/notifications/move_payment_reminder_test.go
@@ -46,19 +46,19 @@ func (suite *NotificationSuite) TestPaymentReminderFetchSomeFound() {
 	moves := []testdatagen.Assertions{
 		{
 			PersonallyProcuredMove: models.PersonallyProcuredMove{OriginalMoveDate: &date10DaysAgo},
-			Move:                   models.Move{Status: models.MoveStatusAPPROVED},
+			Move:                   models.Move{Status: models.MoveStatusAPPROVED, Locator: "abc456"},
 		},
 		{
 			PersonallyProcuredMove: models.PersonallyProcuredMove{OriginalMoveDate: &date9DaysAgo},
-			Move:                   models.Move{Status: models.MoveStatusAPPROVED},
+			Move:                   models.Move{Status: models.MoveStatusAPPROVED, Locator: "abc123"},
 		},
 		{
 			PersonallyProcuredMove: models.PersonallyProcuredMove{OriginalMoveDate: &date9DaysAgo},
-			Move:                   models.Move{Status: models.MoveStatusDRAFT},
+			Move:                   models.Move{Status: models.MoveStatusDRAFT, Locator: "def123"},
 		},
 		{
 			PersonallyProcuredMove: models.PersonallyProcuredMove{OriginalMoveDate: &date9DaysAgo},
-			Move:                   models.Move{Show: swag.Bool(false)},
+			Move:                   models.Move{Show: swag.Bool(false), Locator: "def456"},
 		},
 	}
 
@@ -79,6 +79,7 @@ func (suite *NotificationSuite) TestPaymentReminderFetchSomeFound() {
 	suite.Equal(ppms[0].IncentiveEstimateMax, emailInfo[0].IncentiveEstimateMax)
 	suite.Equal(ppms[0].Move.Orders.ServiceMember.DutyStation.TransportationOffice.Name, emailInfo[0].TOName)
 	suite.Equal(ppms[0].Move.Orders.ServiceMember.DutyStation.TransportationOffice.PhoneLines[0].Number, emailInfo[0].TOPhone)
+	suite.Equal(ppms[0].Move.Locator, emailInfo[0].Locator)
 }
 
 func (suite *NotificationSuite) TestPaymentReminderFetchNoneFound() {
@@ -309,6 +310,7 @@ func (suite *NotificationSuite) TestFormatPaymentRequestedEmails() {
 			IncentiveTxt:         fmt.Sprintf("You expected to move about %d lbs, which gives you an estimated incentive of %s-%s.", weightEst1.Int(), estimateMin1.ToDollarString(), estimateMax1.ToDollarString()),
 			TOName:               "to1",
 			TOPhone:              "111-111-1111",
+			Locator:              "abc123",
 		},
 		{
 			Email:                &email2,
@@ -319,6 +321,7 @@ func (suite *NotificationSuite) TestFormatPaymentRequestedEmails() {
 			IncentiveTxt:         fmt.Sprintf("You expected to move about %d lbs, which gives you an estimated incentive of %s-%s.", weightEst2.Int(), estimateMin2.ToDollarString(), estimateMax2.ToDollarString()),
 			TOName:               "to2",
 			TOPhone:              "222-222-2222",
+			Locator:              "abc456",
 		},
 		{
 			Email:                &email3,
@@ -329,6 +332,7 @@ func (suite *NotificationSuite) TestFormatPaymentRequestedEmails() {
 			IncentiveTxt:         "",
 			TOName:               "to0",
 			TOPhone:              "000-000-0000",
+			Locator:              "def123",
 		},
 		{
 			// nil emails should be skipped
@@ -340,6 +344,7 @@ func (suite *NotificationSuite) TestFormatPaymentRequestedEmails() {
 			IncentiveTxt:         "",
 			TOName:               "to0",
 			TOPhone:              "000-000-0000",
+			Locator:              "def456",
 		},
 	}
 	formattedEmails, err := pr.formatEmails(emailInfos)


### PR DESCRIPTION
## Description

Update the logging we send to service members to include moveLocator
* Remove unneeded `Println`
* Add moveLocator
* Update tests

## Setup

run notification tests: 
`go test ./pkg/notifications/ -v`

run email for move
`make server_run`
`make server_client`
SM: enter move - enter move date 10 days prior to the current date
Office: approve move
SM: enter weight ticket(s)
in terminal, run cmd: `go run ./cmd/milmove-tasks send-payment-reminder` - you'll see the email in the terminal... 
delete record in notifications
in terminal, run cmd: `go run ./cmd/milmove-tasks send-payment-reminder --email-backend=ses --aws-ses-domain=devlocal.dp3.us --aws-ses-region=us-west-2`
you should see an email appear in your inbox


## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?
