### PR TITLE
Add Reggie's CAC to staging/experimental

### DIFF
--- a/docs/how-to/use-mtls-with-cac.md
+++ b/docs/how-to/use-mtls-with-cac.md
@@ -101,11 +101,16 @@ psql-dev
 > select * from client_certs where subject ILIKE '%GITHUB_USERNAME%';
 ```
 
-Now to test this with transcom/nom you need to enable the Mutual TLS listener and then run the server. To do so modify your `.envrc.local` with this content:
+Now to test this with transcom/nom you need to enable the Mutual TLS listener and then run the server. To do so, first modify your `.envrc.local` with this content:
 
 ```sh
 export MUTUAL_TLS_ENABLED=1
-make db_dev_e2e_populate
+```
+
+Now run the server and test the secure migration:
+
+```sh
+make db_dev_e2e_populate server_run
 go run ./cmd/prime-api-client/main.go --insecure --cac | jq .
 ```
 
@@ -121,6 +126,11 @@ If the secure migration worked you should receive a response similar to
     "moveOrderID": "6fca843a-a87e-4752-b454-0fac67aa4981",
     "mto_service_items": [],
     "payment_requests": [],
+    "mto_shipments": [
+      {
+        ...
+      }
+    ],
     "updatedAt": "2020-01-22"
   }
 ]

--- a/docs/how-to/use-mtls-with-cac.md
+++ b/docs/how-to/use-mtls-with-cac.md
@@ -101,13 +101,7 @@ psql-dev
 > select * from client_certs where subject ILIKE '%GITHUB_USERNAME%';
 ```
 
-Now to test this with transcom/nom you need to enable the Mutual TLS listener and then run the server. To do so, first modify your `.envrc.local` with this content:
-
-```sh
-export MUTUAL_TLS_ENABLED=1
-```
-
-Now run the server and test the secure migration:
+To test this with transcom/nom, run the server and test the secure migration (with your CAC inserted into your reader):
 
 ```sh
 make db_dev_e2e_populate server_run

--- a/migrations/app/migrations_manifest.txt
+++ b/migrations/app/migrations_manifest.txt
@@ -453,3 +453,4 @@
 20200212201441_rd_cac.up.sql
 20200214175204_create_re_zip5_rate_areas_table.up.sql
 20200217200526_gidjin_cac.up.sql
+20200219185845_rriser_cac.up.sql

--- a/migrations/app/secure/20200219185845_rriser_cac.up.sql
+++ b/migrations/app/secure/20200219185845_rriser_cac.up.sql
@@ -1,0 +1,45 @@
+
+-- This migration allows a CAC cert to have read/write access to all orders and the prime API.
+-- The Orders API and the Prime API use client certificate authentication. Only certificates
+-- signed by a trusted CA (such as DISA) are allowed which includes CACs.
+-- Using a person's CAC as the certificate is a convenient way to permit a
+-- single trusted individual to interact with the Orders API and the Prime API. Eventually
+-- this CAC certificate should be removed.
+INSERT INTO public.client_certs (
+	id,
+	sha256_digest,
+	subject,
+	allow_dps_auth_api,
+	allow_orders_api,
+	created_at,
+	updated_at,
+	allow_air_force_orders_read,
+	allow_air_force_orders_write,
+	allow_army_orders_read,
+	allow_army_orders_write,
+	allow_coast_guard_orders_read,
+	allow_coast_guard_orders_write,
+	allow_marine_corps_orders_read,
+	allow_marine_corps_orders_write,
+	allow_navy_orders_read,
+	allow_navy_orders_write,
+	allow_prime)
+VALUES (
+	'03191873-8cc5-4af1-9866-b4bf12842d54',
+	'0d2424942557a8f0db496ba69c20179271ea4513a6cf13f08c6a368c0ae23e74',
+	'CN=reggieriser,OU=DoD+OU=PKI+OU=CONTRACTOR,O=U.S. Government,C=US',
+	false,
+	true,
+	now(),
+	now(),
+	true,
+	true,
+	true,
+	true,
+	true,
+	true,
+	true,
+	true,
+	true,
+	true,
+	true);


### PR DESCRIPTION
## Description

This PR adds Reggie's CAC to staging and experimental (but not prod).  I also made a few doc changes based on some things I noticed while going through the process.

## Setup

Verify that staging and experimental have the appropriate insert, but prod just has a stub file:

```sh
download-secure-migration 20200219185845_rriser_cac.up.sql
```

If you want to run the full migration set:

```
make run_experimental_migrations
make run_staging_migrations
make run_prod_migrations
```

## Code Review Verification Steps

* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/tree/master/docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
  * [ ] Secure migrations have been tested using `scripts/run-prod-migrations`
* [ ] Request review from a member of a different team.

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-1636) for this change
