### PR TITLE
Allow enabling or disabling IWS RBS, return fake data locally

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -213,6 +213,7 @@ export DPS_COOKIE_NAME="DPSIVV"
 
 # DMDC Identity Web Services Real-Time Broker Service
 export IWS_RBS_HOST="pkict.dmdc.osd.mil"
+export IWS_RBS_ENABLED=1
 
 # Unsecured CSRF Auth Key, for local dev only
 require CSRF_AUTH_KEY "See 'chamber read app-devlocal csrf_auth_key'"

--- a/.envrc
+++ b/.envrc
@@ -212,8 +212,10 @@ export DPS_REDIRECT_URL="https://dpstest.sddc.army.mil/cust"
 export DPS_COOKIE_NAME="DPSIVV"
 
 # DMDC Identity Web Services Real-Time Broker Service
+# To test against DMDC IWS RBS modify IWS_RBS_ENABLED and set to 1 in your .envrc.local
+# It is disabled by default so that no requests are sent to DMDC during development unless explicitly set
+export IWS_RBS_ENABLED=0
 export IWS_RBS_HOST="pkict.dmdc.osd.mil"
-export IWS_RBS_ENABLED=1
 
 # Unsecured CSRF Auth Key, for local dev only
 require CSRF_AUTH_KEY "See 'chamber read app-devlocal csrf_auth_key'"

--- a/cmd/milmove/serve.go
+++ b/cmd/milmove/serve.go
@@ -585,7 +585,7 @@ func serveFunction(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		logger.Fatal("Could not instantiate IWS RBS", zap.Error(err))
 	}
-	handlerContext.SetIWSPersonLookup(*rbs)
+	handlerContext.SetIWSPersonLookup(rbs)
 
 	dpsAuthSecretKey := v.GetString(cli.DPSAuthSecretKeyFlag)
 	dpsCookieDomain := v.GetString(cli.DPSCookieDomainFlag)

--- a/config/env/experimental.app-client-tls.env
+++ b/config/env/experimental.app-client-tls.env
@@ -21,6 +21,7 @@ HERE_MAPS_ROUTING_ENDPOINT=https://route.cit.api.here.com/routing/7.2/calculater
 HTTP_DPS_SERVER_NAME=dps.experimental.move.mil
 HTTP_ORDERS_SERVER_NAME=orders.experimental.move.mil
 HTTP_PRIME_SERVER_NAME=api.experimental.move.mil
+IWS_RBS_ENABLED=1
 IWS_RBS_HOST=pkict.dmdc.osd.mil
 LOGIN_GOV_HOSTNAME=idp.int.identitysandbox.gov
 LOG_TASK_METADATA=true

--- a/config/env/experimental.app.env
+++ b/config/env/experimental.app.env
@@ -26,6 +26,7 @@ HTTP_OFFICE_SERVER_NAME=office.experimental.move.mil
 HTTP_SDDC_PORT=443
 HTTP_SDDC_PROTOCOL=https
 HTTP_SDDC_SERVER_NAME=mymove-experimental.sddc.army.mil
+IWS_RBS_ENABLED=1
 IWS_RBS_HOST=pkict.dmdc.osd.mil
 LOGIN_GOV_HOSTNAME=idp.int.identitysandbox.gov
 LOG_TASK_METADATA=true

--- a/config/env/experimental.orders.env
+++ b/config/env/experimental.orders.env
@@ -8,6 +8,7 @@ DEBUG_LOGGING=true
 DOD_CA_PACKAGE=/config/tls/Certificates_PKCS7_v5.6_DoD.der.p7b
 DOMAIN=experimental.move.mil
 HTTP_ORDERS_SERVER_NAME=orders.experimental.move.mil
+IWS_RBS_ENABLED=1
 IWS_RBS_HOST=pkict.dmdc.osd.mil
 LOG_TASK_METADATA=true
 MUTUAL_TLS_ENABLED=true

--- a/config/env/prod.app-client-tls.env
+++ b/config/env/prod.app-client-tls.env
@@ -18,6 +18,7 @@ HERE_MAPS_GEOCODE_ENDPOINT=https://geocoder.cit.api.here.com/6.2/geocode.json
 HERE_MAPS_ROUTING_ENDPOINT=https://route.cit.api.here.com/routing/7.2/calculateroute.json
 HTTP_DPS_SERVER_NAME=dps.move.mil
 HTTP_ORDERS_SERVER_NAME=orders.move.mil
+IWS_RBS_ENABLED=1
 IWS_RBS_HOST=sadr.dmdc.osd.mil
 LOGIN_GOV_HOSTNAME=secure.login.gov
 LOG_TASK_METADATA=true

--- a/config/env/prod.app.env
+++ b/config/env/prod.app.env
@@ -23,6 +23,7 @@ HTTP_OFFICE_SERVER_NAME=office.move.mil
 HTTP_SDDC_PORT=443
 HTTP_SDDC_PROTOCOL=https
 HTTP_SDDC_SERVER_NAME=mymove.sddc.army.mil
+IWS_RBS_ENABLED=1
 IWS_RBS_HOST=sadr.dmdc.osd.mil
 LOGIN_GOV_HOSTNAME=secure.login.gov
 LOG_TASK_METADATA=true

--- a/config/env/prod.orders.env
+++ b/config/env/prod.orders.env
@@ -8,6 +8,7 @@ DEBUG_LOGGING=true
 DOD_CA_PACKAGE=/config/tls/Certificates_PKCS7_v5.6_DoD.der.p7b
 DOMAIN=move.mil
 HTTP_ORDERS_SERVER_NAME=orders.move.mil
+IWS_RBS_ENABLED=1
 IWS_RBS_HOST=pkict.dmdc.osd.mil
 LOG_TASK_METADATA=true
 MUTUAL_TLS_ENABLED=true

--- a/config/env/staging.app-client-tls.env
+++ b/config/env/staging.app-client-tls.env
@@ -20,6 +20,7 @@ HERE_MAPS_ROUTING_ENDPOINT=https://route.cit.api.here.com/routing/7.2/calculater
 HTTP_DPS_SERVER_NAME=dps.staging.move.mil
 HTTP_ORDERS_SERVER_NAME=orders.staging.move.mil
 HTTP_PRIME_SERVER_NAME=api.staging.move.mil
+IWS_RBS_ENABLED=1
 IWS_RBS_HOST=pkict.dmdc.osd.mil
 LOGIN_GOV_HOSTNAME=idp.int.identitysandbox.gov
 LOG_TASK_METADATA=true

--- a/config/env/staging.app.env
+++ b/config/env/staging.app.env
@@ -25,6 +25,7 @@ HTTP_OFFICE_SERVER_NAME=office.staging.move.mil
 HTTP_SDDC_PORT=443
 HTTP_SDDC_PROTOCOL=https
 HTTP_SDDC_SERVER_NAME=mymove-staging.sddc.army.mil
+IWS_RBS_ENABLED=1
 IWS_RBS_HOST=pkict.dmdc.osd.mil
 LOGIN_GOV_HOSTNAME=idp.int.identitysandbox.gov
 LOG_TASK_METADATA=true

--- a/config/env/staging.orders.env
+++ b/config/env/staging.orders.env
@@ -8,6 +8,7 @@ DEBUG_LOGGING=true
 DOD_CA_PACKAGE=/config/tls/Certificates_PKCS7_v5.6_DoD.der.p7b
 DOMAIN=staging.move.mil
 HTTP_ORDERS_SERVER_NAME=orders.staging.move.mil
+IWS_RBS_ENABLED=1
 IWS_RBS_HOST=pkict.dmdc.osd.mil
 LOG_TASK_METADATA=true
 MUTUAL_TLS_ENABLED=true

--- a/pkg/cli/iws.go
+++ b/pkg/cli/iws.go
@@ -15,7 +15,7 @@ const (
 // InitIWSFlags initializes CSRF command line flags
 func InitIWSFlags(flag *pflag.FlagSet) {
 	flag.String(IWSRBSHostFlag, "", "Hostname for the IWS RBS")
-	flag.Bool(IWSRBSEnabledFlag, false, "enable the IWS RBS service")
+	flag.Bool(IWSRBSEnabledFlag, false, "enable the IWS RBS integration")
 }
 
 // CheckIWS validates IWS command line flags

--- a/pkg/cli/iws.go
+++ b/pkg/cli/iws.go
@@ -8,11 +8,14 @@ import (
 const (
 	// IWSRBSHostFlag is the IWS RBS Host Flag
 	IWSRBSHostFlag string = "iws-rbs-host"
+	// IWSRBSEnabledFlag is the IWS RBS Enabled Flag
+	IWSRBSEnabledFlag string = "iws-rbs-enabled"
 )
 
 // InitIWSFlags initializes CSRF command line flags
 func InitIWSFlags(flag *pflag.FlagSet) {
 	flag.String(IWSRBSHostFlag, "", "Hostname for the IWS RBS")
+	flag.Bool(IWSRBSEnabledFlag, false, "enable the IWS RBS service")
 }
 
 // CheckIWS validates IWS command line flags

--- a/pkg/iws/testing_person_lookup.go
+++ b/pkg/iws/testing_person_lookup.go
@@ -7,6 +7,10 @@ const edipi = 1234567890
 // TestingPersonLookup is a mock of RBS that returns dummy data
 type TestingPersonLookup struct{}
 
+func NewTestingPersonLookup() (*TestingPersonLookup, error) {
+	return &TestingPersonLookup{}, nil
+}
+
 // GetPersonUsingEDIPI returns a static dummy RBS result
 func (r TestingPersonLookup) GetPersonUsingEDIPI(edipi uint64) (*Person, []Personnel, error) {
 	return getTestPerson(), []Personnel{getTestPersonnel()}, nil


### PR DESCRIPTION
## Description

I'm testing out the electronic orders service locally. Unfortunately the fake SSNs I normally send to DMDC IWS RBS don't work anymore and I need to get a new set before I can continue testing. In the meantime I've modified the code here to use a fake `TestPersonLookup` RBS client when the IWS RBS system is not enabled, meaning we essentially get the same EDIPI for each SSN we send over. Essentially this skips calling DMDC and just generates fake data locally. 

I tested this from the transcom/nom repo with this command:

```
bin/nom -host orderslocal -port 9443 -insecure -pkcs11module "${MODULE}" nom_demo_20190404.csv
```

If a person wants to test against the real DMDC endpoint they have to set `export IWS_RBS_ENABLED=1` in their `.envrc.local` which I've noted in the comments. 

As a bonus, modifying the code here means I can re-use the code in https://github.com/transcom/milmove_orders/pull/1 and continue moving towards deployment.