### PR TITLE
Make license recognizeable by automated systems

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -573,5 +573,6 @@ UI
 UIs
 dev_db
 5a
+LICENSE.txt
 # Put all custom terms BEFORE this comment, lest 'pre-commit' and 'make spellcheck' yield different errors.
  - ./docs/backend/route-planner.md

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,9 +1,6 @@
-# License Information
-
-Works created by U.S. Federal employees as part of their jobs typically are not eligible for copyright in the United States. In places where the contributions of U.S. Federal employees are not eligible for copyright, this work is in the public domain. In places where it is eligible for copyright, such as some foreign jurisdictions, the remainder of this work is licensed under [the MIT License](https://opensource.org/licenses/MIT), the full text of which is included below.
-
-```text
 Copyright 2017 U.S. Federal Government (in countries where recognized) and TrussWorks
+
+MIT License
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -22,4 +19,3 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-```

--- a/README.md
+++ b/README.md
@@ -8,6 +8,14 @@ This repository contains the application source code for the Personal Property P
 
 This prototype was built by a [Defense Digital Service](https://www.dds.mil/) team in support of USTRANSCOM's mission.
 
+## License Information
+
+Works created by U.S. Federal employees as part of their jobs typically are not eligible for copyright in the United
+States. In places where the contributions of U.S. Federal employees are not eligible for copyright, this work is in
+the public domain. In places where it is eligible for copyright, such as some foreign jurisdictions, the remainder of
+this work is licensed under [the MIT License](https://opensource.org/licenses/MIT), the full text of which is included
+in the [LICENSE.txt](./LICENSE.txt) file in this repository.
+
 ## Table of Contents
 
 <!-- Table of Contents auto-generated with `scripts/generate-md-toc` -->


### PR DESCRIPTION
## Description

It appears that automated systems like godoc.org and pkg.go.dev can't read our repository and display certain information because it can't parse the license. We have an MIT license, but having extra information about the federal government obscures it from being read by other computers. This update fixes our repo so that it will work without losing any information.