### PR TITLE
Define CIRCLECI for docker container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -841,7 +841,7 @@ pretty: gofmt ## Run code through JS and Golang formatters
 .PHONY: docker_circleci
 docker_circleci: ## Run CircleCI container locally with project mounted
 	docker pull trussworks/circleci-docker-primary:latest
-	docker run -it --rm=true -v $(PWD):$(PWD) -w $(PWD) trussworks/circleci-docker-primary:latest bash
+	docker run -it --rm=true -v $(PWD):$(PWD) -w $(PWD) -e CIRCLECI=1 trussworks/circleci-docker-primary:latest bash
 
 .PHONY: prune_images
 prune_images:  ## Prune docker images


### PR DESCRIPTION
## Description

Even though I talked about it in https://github.com/transcom/mymove/pull/3582 I forgot to implement it.  This defines `CIRCLECI` env var for the container to fix the make commands.