### PR TITLE
Explicitly call out all exclude rules in the config file for golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -42,9 +42,6 @@ issues:
     # golint: Annoying issue about not having a comment. The rare codebase has such comments
     - (comment on exported (method|function|type|const)|should have( a package)? comment|comment should be of the form)
 
-    # golint: False positive when tests are defined in package 'test'
-    - func name will be used as test\.Test.* by other packages, and that stutters; consider calling this
-
     # gosec: Duplicated errcheck checks
     - G104
   fix: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -56,9 +56,6 @@ issues:
 
     # gosec: Duplicated errcheck checks
     - G104
-
-    # gosec: Too many issues in popular repos
-    - (Expect directory permissions to be 0750 or less|Expect file permissions to be 0600 or less)
   fix: true
 
 run:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -36,9 +36,6 @@ issues:
   # TODO: Slowly remove these where they make sense and fix code
   exclude-use-default: false
   exclude:
-    # errcheck: Almost all programs ignore errors on these functions and in most cases it's ok
-    - Error return value of .((os\.)?std(out|err)\..*|.*Close|.*Flush|os\.Remove(All)?|.*printf?|os\.(Un)?Setenv). is not checked
-
     # golint: Annoying issue about not having a comment. The rare codebase has such comments
     - (comment on exported (method|function|type|const)|should have( a package)? comment|comment should be of the form)
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -51,9 +51,6 @@ issues:
     # staticcheck: Developers tend to write in C-style with an explicit 'break' in a 'switch', so it's ok to ignore
     - ineffective break statement. Did you mean to break out of the outer loop
 
-    # gosec: Too many false-positives on 'unsafe' usage
-    - Use of unsafe calls should be audited
-
     # gosec: Too many false-positives for parametrized shell calls
     - Subprocess launch(ed with variable|ing should be audited)
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -36,9 +36,6 @@ issues:
   # TODO: Slowly remove these where they make sense and fix code
   exclude-use-default: false
   exclude:
-    # golint: Annoying issue about not having a comment. The rare codebase has such comments
-    # - (comment on exported (method|function|type|const)|should have( a package)? comment|comment should be of the form)
-
     # gosec: Duplicated errcheck checks
     # TODO: Remove this when errcheck is enabled above - duplication is ok
     - G104

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -37,7 +37,7 @@ issues:
   exclude-use-default: false
   exclude:
     # golint: Annoying issue about not having a comment. The rare codebase has such comments
-    - (comment on exported (method|function|type|const)|should have( a package)? comment|comment should be of the form)
+    # - (comment on exported (method|function|type|const)|should have( a package)? comment|comment should be of the form)
 
     # gosec: Duplicated errcheck checks
     # TODO: Remove this when errcheck is enabled above - duplication is ok

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,13 +1,6 @@
 linters-settings:
   govet:
     check-shadowing: true
-    settings:
-      printf:
-        funcs:
-          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Infof
-          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Warnf
-          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Errorf
-          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Fatalf
   goimports:
     # put imports beginning with prefix after 3rd-party packages;
     # it's a comma-separated list of prefixes
@@ -38,6 +31,40 @@ issues:
     - path: internal/pkg/dutystationsloader/duty_stations_loader.go
       linters:
         - govet
+
+  # Disable defaults for the exclude patterns and instead list them all out
+  # TODO: Slowly remove these where they make sense and fix code
+  exclude-use-default: false
+  exclude:
+    # errcheck: Almost all programs ignore errors on these functions and in most cases it's ok
+    - Error return value of .((os\.)?std(out|err)\..*|.*Close|.*Flush|os\.Remove(All)?|.*printf?|os\.(Un)?Setenv). is not checked
+
+    # golint: Annoying issue about not having a comment. The rare codebase has such comments
+    - (comment on exported (method|function|type|const)|should have( a package)? comment|comment should be of the form)
+
+    # golint: False positive when tests are defined in package 'test'
+    - func name will be used as test\.Test.* by other packages, and that stutters; consider calling this
+
+    # govet: Common false positives
+    - (possible misuse of unsafe.Pointer|should have signature)
+
+    # staticcheck: Developers tend to write in C-style with an explicit 'break' in a 'switch', so it's ok to ignore
+    - ineffective break statement. Did you mean to break out of the outer loop
+
+    # gosec: Too many false-positives on 'unsafe' usage
+    - Use of unsafe calls should be audited
+
+    # gosec: Too many false-positives for parametrized shell calls
+    - Subprocess launch(ed with variable|ing should be audited)
+
+    # gosec: Duplicated errcheck checks
+    - G104
+
+    # gosec: Too many issues in popular repos
+    - (Expect directory permissions to be 0750 or less|Expect file permissions to be 0600 or less)
+
+    # gosec: False positive is triggered by 'src, err := ioutil.ReadFile(filename)'
+    - Potential file inclusion via variable
   fix: true
 
 run:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -40,6 +40,7 @@ issues:
     - (comment on exported (method|function|type|const)|should have( a package)? comment|comment should be of the form)
 
     # gosec: Duplicated errcheck checks
+    # TODO: Remove this when errcheck is enabled above - duplication is ok
     - G104
   fix: true
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -48,9 +48,6 @@ issues:
     # govet: Common false positives
     - (possible misuse of unsafe.Pointer|should have signature)
 
-    # staticcheck: Developers tend to write in C-style with an explicit 'break' in a 'switch', so it's ok to ignore
-    - ineffective break statement. Did you mean to break out of the outer loop
-
     # gosec: Duplicated errcheck checks
     - G104
   fix: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -51,9 +51,6 @@ issues:
     # staticcheck: Developers tend to write in C-style with an explicit 'break' in a 'switch', so it's ok to ignore
     - ineffective break statement. Did you mean to break out of the outer loop
 
-    # gosec: Too many false-positives for parametrized shell calls
-    - Subprocess launch(ed with variable|ing should be audited)
-
     # gosec: Duplicated errcheck checks
     - G104
   fix: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -45,9 +45,6 @@ issues:
     # golint: False positive when tests are defined in package 'test'
     - func name will be used as test\.Test.* by other packages, and that stutters; consider calling this
 
-    # govet: Common false positives
-    - (possible misuse of unsafe.Pointer|should have signature)
-
     # gosec: Duplicated errcheck checks
     - G104
   fix: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -62,9 +62,6 @@ issues:
 
     # gosec: Too many issues in popular repos
     - (Expect directory permissions to be 0750 or less|Expect file permissions to be 0600 or less)
-
-    # gosec: False positive is triggered by 'src, err := ioutil.ReadFile(filename)'
-    - Potential file inclusion via variable
   fix: true
 
 run:

--- a/cmd/big-cat/main.go
+++ b/cmd/big-cat/main.go
@@ -28,7 +28,7 @@ func main() {
 	}
 	count := 0
 	for _, file := range files {
-		f, err := os.Open(file)
+		f, err := os.Open(filepath.Clean(file))
 		if err != nil {
 			panic(err)
 		}

--- a/cmd/ecs-deploy/task_def.go
+++ b/cmd/ecs-deploy/task_def.go
@@ -112,6 +112,7 @@ const (
 	registerFlag      string = "register"
 )
 
+// ECRImage represents an ECR Image tag broken into its constituent parts
 type ECRImage struct {
 	AWSRegion      string
 	imageURI       string
@@ -121,6 +122,7 @@ type ECRImage struct {
 	RepositoryName string
 }
 
+// NewECRImage returns a new ECR Image object
 func NewECRImage(imageURI string) (*ECRImage, error) {
 	imageParts := strings.Split(imageURI, ":")
 	if len(imageParts) != 2 {

--- a/cmd/ecs-deploy/task_def.go
+++ b/cmd/ecs-deploy/task_def.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
@@ -325,7 +326,7 @@ func buildContainerEnvironment(environmentName string, dbHost string, variablesF
 			log.Fatal(fmt.Errorf("File %q does not exist: %w", variablesFile, err))
 		}
 		// Read contents of variables file into vars
-		vars, readFileErr := ioutil.ReadFile(variablesFile)
+		vars, readFileErr := ioutil.ReadFile(filepath.Clean(variablesFile))
 		if readFileErr != nil {
 			log.Fatal(errors.New("error reading variables file"))
 		}

--- a/cmd/milmove/gen.go
+++ b/cmd/milmove/gen.go
@@ -33,7 +33,7 @@ func closeFile(outfile *os.File) {
 
 func createMigration(path string, filename string, t *template.Template, templateData interface{}) error {
 	if _, err := os.Stat(path); os.IsNotExist(err) {
-		if mkdirErr := os.Mkdir(path, 0755); mkdirErr != nil {
+		if mkdirErr := os.Mkdir(path, 0750); mkdirErr != nil {
 			return errors.Wrapf(mkdirErr, "error creating path %q", path)
 		}
 	}
@@ -69,7 +69,7 @@ func addMigrationToManifest(migrationManifest string, filename string) error {
 
 func writeEmptyFile(migrationPath, filename string) error {
 	if _, err := os.Stat(migrationPath); os.IsNotExist(err) {
-		if mkdirErr := os.Mkdir(migrationPath, 0755); mkdirErr != nil {
+		if mkdirErr := os.Mkdir(migrationPath, 0750); mkdirErr != nil {
 			return errors.Wrapf(mkdirErr, "error creating path %q", migrationPath)
 		}
 	}

--- a/cmd/milmove/gen_disable_user_migration.go
+++ b/cmd/milmove/gen_disable_user_migration.go
@@ -15,6 +15,7 @@ import (
 )
 
 const (
+	// DisableUserEmailFlag is the email of the user to disable
 	DisableUserEmailFlag string = "migration-email"
 
 	// template for adding office users

--- a/cmd/milmove/gen_duty_stations_migration.go
+++ b/cmd/milmove/gen_duty_stations_migration.go
@@ -20,21 +20,23 @@ import (
 )
 
 const (
-	// filename containing the details for new duty stations
+	// DutyStationsFilenameFlag filename containing the details for new duty stations
 	DutyStationsFilenameFlag string = "duty-stations-filename"
 )
 
+// MigrationInfo carries the filename of the migration
 type MigrationInfo struct {
 	Filename string
 }
 
 const (
+	// DutyStationMigration is the duty station migration template
 	DutyStationMigration string = `
 -- Migration generated using: cmd/milmove/gen_duty_stations_migration.go
 -- Duty stations file: {{.Filename}}`
 )
 
-// DutyStationsFilenameFlag initializes add_duty_stations command line flags
+// InitAddDutyStationsFlags initializes add_duty_stations command line flags
 func InitAddDutyStationsFlags(flag *pflag.FlagSet) {
 	flag.StringP(DutyStationsFilenameFlag, "f", "", "File name of csv file containing the new duty stations users")
 }

--- a/cmd/milmove/main_test.go
+++ b/cmd/milmove/main_test.go
@@ -101,7 +101,7 @@ func (suite *webServerSuite) loadContext(variablesFile string) map[string]string
 			suite.logger.Fatal(fmt.Sprintf("File %q does not exist", variablesFile))
 		}
 		// Read contents of variables file into vars
-		vars, err := ioutil.ReadFile(variablesFile)
+		vars, err := ioutil.ReadFile(filepath.Clean(variablesFile))
 		if err != nil {
 			suite.logger.Fatal(fmt.Sprintf("error reading variables from file %s", variablesFile))
 		}

--- a/cmd/model-vet/main.go
+++ b/cmd/model-vet/main.go
@@ -57,18 +57,21 @@ func initFlags(flag *pflag.FlagSet) {
 	flag.SortFlags = false
 }
 
+// Field represents a field in a DB
 type Field struct {
 	name    string
 	dbName  string
 	pointer bool
 }
 
+// Model represents a model in the code corresponding to a DB table
 type Model struct {
 	name   string
 	dbName string
 	fields []Field
 }
 
+// Column represents a column in a table in the DB
 // The fields in this struct have to be public so that they
 // can be set by Pop.
 type Column struct {

--- a/cmd/prime-api-client/main.go
+++ b/cmd/prime-api-client/main.go
@@ -21,7 +21,6 @@ import (
 )
 
 const (
-
 	// CertPathFlag is the path to the certificate to use for TLS
 	CertPathFlag string = "certpath"
 	// KeyPathFlag is the path to the key to use for TLS
@@ -30,13 +29,13 @@ const (
 	HostnameFlag string = "hostname"
 	// PortFlag is the port to connect to
 	PortFlag string = "port"
-	// Insecure flag indicates that TLS verification and validation can be skipped
+	// InsecureFlag indicates that TLS verification and validation can be skipped
 	InsecureFlag string = "insecure"
 	// VerboseFlag holds string identifier for command line usage
 	VerboseFlag string = "verbose"
 )
 
-// initialize flags
+// initializeFlags sets up CLI flags
 func initFlags(flag *pflag.FlagSet) {
 
 	cli.InitCACFlags(flag)
@@ -50,6 +49,7 @@ func initFlags(flag *pflag.FlagSet) {
 	flag.SortFlags = false
 }
 
+// checkConfig checks the config
 func checkConfig(v *viper.Viper, logger *log.Logger) error {
 
 	if err := cli.CheckCAC(v); err != nil {

--- a/cmd/query-lb-logs/main.go
+++ b/cmd/query-lb-logs/main.go
@@ -152,6 +152,7 @@ func getS3BucketByEnv(env, region string) (string, error) {
 	}
 }
 
+// CheckEnv checks the environment for querying
 func CheckEnv(serviceAthena *athena.Athena, logger, infoLogger *log.Logger, v *viper.Viper) {
 
 	//get values from flags

--- a/cmd/read-alb-logs/main.go
+++ b/cmd/read-alb-logs/main.go
@@ -14,6 +14,7 @@ import (
 	"os"
 )
 
+// ALBLog represents a log line from an ALB Log
 type ALBLog struct {
 	RequestType            string `json:"requestType"`
 	Timestamp              string `json:"timestamp"`
@@ -42,6 +43,7 @@ type ALBLog struct {
 	ErrorReason            string `json:"errorReason"`
 }
 
+// NewALBLog returns a new ALBLog object
 func NewALBLog(record []string) ALBLog {
 
 	logLine := ALBLog{

--- a/pkg/auth/authentication/auth.go
+++ b/pkg/auth/authentication/auth.go
@@ -114,6 +114,7 @@ func UserAuthMiddleware(logger Logger) func(next http.Handler) http.Handler {
 	}
 }
 
+// APIContext is the api context interface
 type APIContext interface {
 	RouteInfo(r *http.Request) (*middleware.MatchedRoute, *http.Request, bool)
 }
@@ -165,6 +166,7 @@ func RoleAuthMiddleware(logger Logger) func(context APIContext) func(handler htt
 
 }
 
+// AdminAuthMiddleware is middleware for admin authentication
 func AdminAuthMiddleware(logger Logger) func(next http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		mw := func(w http.ResponseWriter, r *http.Request) {
@@ -182,6 +184,7 @@ func AdminAuthMiddleware(logger Logger) func(next http.Handler) http.Handler {
 	}
 }
 
+// PrimeAuthorizationMiddleware is the prime authorization middleware
 func PrimeAuthorizationMiddleware(logger Logger) func(next http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		mw := func(w http.ResponseWriter, r *http.Request) {
@@ -211,6 +214,7 @@ func (context Context) verificationInProgressURL(session *auth.Session) string {
 	return fmt.Sprintf(context.callbackTemplate, session.Hostname) + "verification-in-progress"
 }
 
+// SetFeatureFlag sets a feature flag in the context
 func (context *Context) SetFeatureFlag(flag FeatureFlag) {
 	if context.featureFlags == nil {
 		context.featureFlags = make(map[string]bool)
@@ -219,6 +223,7 @@ func (context *Context) SetFeatureFlag(flag FeatureFlag) {
 	context.featureFlags[flag.Name] = flag.Active
 }
 
+// GetFeatureFlag gets a feature flag from the context
 func (context *Context) GetFeatureFlag(flag string) bool {
 	if value, ok := context.featureFlags[flag]; ok {
 		return value
@@ -234,6 +239,7 @@ type Context struct {
 	featureFlags     map[string]bool
 }
 
+// FeatureFlag holds the name of a feature flag and if it is enabled
 type FeatureFlag struct {
 	Name   string
 	Active bool

--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -11,7 +11,7 @@ const (
 	// BuildRootFlag is the build root flag
 	BuildRootFlag string = "build-root"
 
-	// Path to the build directory
+	// DefaultBuildRoot Path to the build directory
 	DefaultBuildRoot string = "build"
 )
 

--- a/pkg/cli/cac.go
+++ b/pkg/cli/cac.go
@@ -13,19 +13,23 @@ import (
 	"pault.ag/go/pksigner"
 )
 
+// ErrInvalidPath is an invalid path error
 type ErrInvalidPath struct {
 	Path string
 }
 
+// Error is an error return
 func (e *ErrInvalidPath) Error() string {
 	return fmt.Sprintf("invalid path %q", e.Path)
 }
 
+// ErrInvalidLabel is an invalid label error
 type ErrInvalidLabel struct {
 	Cert string
 	Key  string
 }
 
+// Error is an error return
 func (e *ErrInvalidLabel) Error() string {
 	return fmt.Sprintf("invalid cert label %q or key label %q", e.Cert, e.Key)
 }
@@ -35,11 +39,11 @@ const (
 	CACFlag string = "cac"
 	// PKCS11ModuleFlag is the location of the PCKS11 module to use with the smart card
 	PKCS11ModuleFlag string = "pkcs11module"
-	// TokenLabel is the Token Label to use with the smart card
+	// TokenLabelFlag is the Token Label to use with the smart card
 	TokenLabelFlag string = "tokenlabel"
-	// CertLabel is the Certificate Label to use with the smart card
+	// CertLabelFlag is the Certificate Label to use with the smart card
 	CertLabelFlag string = "certlabel"
-	// KeyLabel is the Key Label to use with the smart card
+	// KeyLabelFlag is the Key Label to use with the smart card
 	KeyLabelFlag string = "keylabel"
 )
 

--- a/pkg/cli/certs.go
+++ b/pkg/cli/certs.go
@@ -22,10 +22,12 @@ const (
 	MoveMilDoDTLSKeyFlag string = "move-mil-dod-tls-key"
 )
 
+// ErrInvalidPKCS7 is an Invalid PKCS7 error
 type ErrInvalidPKCS7 struct {
 	Path string
 }
 
+// Error is the error method
 func (e *ErrInvalidPKCS7) Error() string {
 	return fmt.Sprintf("invalid DER encoded PKCS7 package: %s", e.Path)
 }

--- a/pkg/cli/dbconn.go
+++ b/pkg/cli/dbconn.go
@@ -56,7 +56,7 @@ const (
 	// DbEnvDevelopment is the Development DB Env name
 	DbEnvDevelopment string = "development"
 
-	// The name of the test database
+	// DbNameTest The name of the test database
 	DbNameTest string = "test_db"
 
 	// SSLModeDisable is the disable SSL Mode

--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -10,7 +10,7 @@ const (
 	DebugPProfFlag string = "debug-pprof"
 )
 
-//  InitDebugFlags initializes the Debug command line flags
+// InitDebugFlags initializes the Debug command line flags
 func InitDebugFlags(flag *pflag.FlagSet) {
 	flag.Bool(DebugPProfFlag, false, "Enables the go pprof debugging endpoints")
 }

--- a/pkg/cli/featureflag.go
+++ b/pkg/cli/featureflag.go
@@ -6,12 +6,15 @@ import (
 )
 
 const (
-	FeatureFlagAccessCode       string = "feature-flag-access-code"
-	FeatureFlagRoleBasedAuth    string = "feature-flag-role-based-auth"
+	// FeatureFlagAccessCode is the access-code feature flag
+	FeatureFlagAccessCode string = "feature-flag-access-code"
+	// FeatureFlagRoleBasedAuth is the role-based-auth feature flag
+	FeatureFlagRoleBasedAuth string = "feature-flag-role-based-auth"
+	// FeatureFlagConvertPPMsToGHC is the convert-ppms-to-ghc feature flag
 	FeatureFlagConvertPPMsToGHC string = "feature-flag-convert-ppms-to-ghc"
 )
 
-// InitFeatureFlag initializes FeatureFlags command line flags
+// InitFeatureFlags initializes FeatureFlags command line flags
 func InitFeatureFlags(flag *pflag.FlagSet) {
 	flag.Bool(FeatureFlagAccessCode, false, "Flag (bool) to enable requires-access-code")
 	flag.Bool(FeatureFlagRoleBasedAuth, false, "Flag (bool) to enable role-based-auth")

--- a/pkg/cli/migration_file.go
+++ b/pkg/cli/migration_file.go
@@ -52,14 +52,14 @@ func (e *errInvalidMigrationType) Error() string {
 	return fmt.Sprintf("invalid migration type %q, expecting sql or fizz.", e.Value)
 }
 
-// InitMigrationFlags initializes the Migration command line flags
+// InitMigrationFileFlags initializes the Migration command line flags
 func InitMigrationFileFlags(flag *pflag.FlagSet) {
 	flag.String(MigrationVersionFlag, time.Now().Format(VersionTimeFormat), "migration version: integer representation of datetime, default is current time using Go format "+VersionTimeFormat)
 	flag.StringP(MigrationNameFlag, "n", "", "migration name: alphanumeric, no spaces, underscores and dashes allowed")
 	flag.StringP(MigrationTypeFlag, "t", "sql", "migration type: fizz or sql.")
 }
 
-// CheckMigration validates migration command line flags
+// CheckMigrationFile validates migration command line flags
 func CheckMigrationFile(v *viper.Viper) error {
 	migrationVersion := v.GetString(MigrationVersionFlag)
 	if len(migrationVersion) == 0 {

--- a/pkg/cli/migration_gen_path.go
+++ b/pkg/cli/migration_gen_path.go
@@ -26,12 +26,12 @@ func (e *errInvalidMigrationGenPath) Error() string {
 	return fmt.Sprintf("invalid migration file path %q", e.Path)
 }
 
-// InitMigrationFlags initializes the Migration command line flags
+// InitMigrationGenPathFlags initializes the Migration command line flags
 func InitMigrationGenPathFlags(flag *pflag.FlagSet) {
 	flag.StringP(MigrationGenPathFlag, "p", "./migrations/app/schema", "Path to the migrations folder")
 }
 
-// CheckMigration validates migration command line flags
+// CheckMigrationGenPath validates migration command line flags
 func CheckMigrationGenPath(v *viper.Viper) error {
 	migrationGenPath := v.GetString(MigrationGenPathFlag)
 	if len(migrationGenPath) == 0 {

--- a/pkg/cli/migration_path.go
+++ b/pkg/cli/migration_path.go
@@ -27,12 +27,12 @@ func (e *errInvalidMigrationPath) Error() string {
 	return fmt.Sprintf("invalid migration path %q", e.Path)
 }
 
-// InitMigrationFlags initializes the Migration command line flags
+// InitMigrationPathFlags initializes the Migration command line flags
 func InitMigrationPathFlags(flag *pflag.FlagSet) {
 	flag.StringP(MigrationPathFlag, "p", "file:///migrations/app/schema", "Path to the migrations folder")
 }
 
-// CheckMigration validates migration command line flags
+// CheckMigrationPath validates migration command line flags
 func CheckMigrationPath(v *viper.Viper) error {
 	// Remove any extra quotes around path
 	migrationPath := strings.Trim(v.GetString(MigrationPathFlag), "\"")

--- a/pkg/cli/services.go
+++ b/pkg/cli/services.go
@@ -19,7 +19,7 @@ const (
 	ServeDPSFlag string = "serve-dps"
 	// ServeAPIInternalFlag is the internal api service flag
 	ServeAPIInternalFlag string = "serve-api-internal"
-	// ServeGHCAPIFlag is the ghc api service flag
+	// ServeGHCFlag is the ghc api service flag
 	ServeGHCFlag string = "serve-api-ghc"
 	// ServePrimeFlag is the prime api flag
 	ServePrimeFlag string = "serve-api-prime"

--- a/pkg/cli/webserver.go
+++ b/pkg/cli/webserver.go
@@ -13,13 +13,14 @@ import (
 const (
 	// InterfaceFlag is the Interface Flag
 	InterfaceFlag string = "interface"
+
 	// GracefulShutdownTimeoutFlag is the Graceful Shutdown Timeout Flag
 	GracefulShutdownTimeoutFlag string = "graceful-shutdown-timeout"
 
-	// The default graceful shutdown duration
+	// DefaultGracefulShutdownDuration The default graceful shutdown duration
 	DefaultGracefulShutdownDuration = time.Second * 25
 
-	// The minimum graceful shutdown duration
+	// MinimumGracefulShutdownDuration The minimum graceful shutdown duration
 	MinimumGracefulShutdownDuration = time.Second * 5
 )
 

--- a/pkg/handlers/adminapi/admin_users.go
+++ b/pkg/handlers/adminapi/admin_users.go
@@ -71,12 +71,14 @@ func (h IndexAdminUsersHandler) Handle(params adminuserop.IndexAdminUsersParams)
 	return adminuserop.NewIndexAdminUsersOK().WithContentRange(fmt.Sprintf("admin users %d-%d/%d", pagination.Offset(), pagination.Offset()+queriedAdminUsersCount, totalAdminUsersCount)).WithPayload(payload)
 }
 
+// GetAdminUserHandler retrieves a handler for admin users
 type GetAdminUserHandler struct {
 	handlers.HandlerContext
 	services.AdminUserFetcher
 	services.NewQueryFilter
 }
 
+// Handle retrieves a new admin user
 func (h GetAdminUserHandler) Handle(params adminuserop.GetAdminUserParams) middleware.Responder {
 	_, logger := h.SessionAndLoggerFromRequest(params.HTTPRequest)
 
@@ -94,12 +96,14 @@ func (h GetAdminUserHandler) Handle(params adminuserop.GetAdminUserParams) middl
 	return adminuserop.NewGetAdminUserOK().WithPayload(payload)
 }
 
+// CreateAdminUserHandler is the handler for creating users.
 type CreateAdminUserHandler struct {
 	handlers.HandlerContext
 	services.AdminUserCreator
 	services.NewQueryFilter
 }
 
+// Handle creates an admin user
 func (h CreateAdminUserHandler) Handle(params adminuserop.CreateAdminUserParams) middleware.Responder {
 	payload := params.AdminUser
 	session, logger := h.SessionAndLoggerFromRequest(params.HTTPRequest)
@@ -137,12 +141,14 @@ func (h CreateAdminUserHandler) Handle(params adminuserop.CreateAdminUserParams)
 	return adminuserop.NewCreateAdminUserCreated().WithPayload(returnPayload)
 }
 
+// UpdateAdminUserHandler is the handler for updating users
 type UpdateAdminUserHandler struct {
 	handlers.HandlerContext
 	services.AdminUserUpdater
 	services.NewQueryFilter
 }
 
+// Handle updates admin users
 func (h UpdateAdminUserHandler) Handle(params adminuserop.UpdateAdminUserParams) middleware.Responder {
 	payload := params.AdminUser
 	session, logger := h.SessionAndLoggerFromRequest(params.HTTPRequest)

--- a/pkg/handlers/adminapi/electronic_orders.go
+++ b/pkg/handlers/adminapi/electronic_orders.go
@@ -25,6 +25,7 @@ func payloadForElectronicOrderModel(o models.ElectronicOrder) *adminmessages.Ele
 	}
 }
 
+// IndexElectronicOrdersHandler returns an index of electronic orders
 type IndexElectronicOrdersHandler struct {
 	handlers.HandlerContext
 	services.ElectronicOrderListFetcher
@@ -32,6 +33,7 @@ type IndexElectronicOrdersHandler struct {
 	services.NewPagination
 }
 
+// Handle returns an index of electronic orders
 func (h IndexElectronicOrdersHandler) Handle(params electronicorderop.IndexElectronicOrdersParams) middleware.Responder {
 	logger := h.LoggerFromRequest(params.HTTPRequest)
 	queryFilters := []services.QueryFilter{}
@@ -60,6 +62,7 @@ func (h IndexElectronicOrdersHandler) Handle(params electronicorderop.IndexElect
 	return electronicorderop.NewIndexElectronicOrdersOK().WithContentRange(fmt.Sprintf("electronic_orders %d-%d/%d", pagination.Offset(), pagination.Offset()+queriedOfficeUsersCount, totalElectronicOrdersCount)).WithPayload(payload)
 }
 
+// GetElectronicOrdersTotalsHandler returns totals of electronic orders
 type GetElectronicOrdersTotalsHandler struct {
 	handlers.HandlerContext
 	services.ElectronicOrderCategoryCountFetcher
@@ -89,6 +92,7 @@ func translateComparator(s string) string {
 	return s
 }
 
+// Handle returns electronic orders totals
 func (h GetElectronicOrdersTotalsHandler) Handle(params electronicorderop.GetElectronicOrdersTotalsParams) middleware.Responder {
 	logger := h.LoggerFromRequest(params.HTTPRequest)
 	comparator := ""

--- a/pkg/handlers/adminapi/notifications.go
+++ b/pkg/handlers/adminapi/notifications.go
@@ -26,6 +26,7 @@ func payloadForNotificationModel(n models.Notification) *adminmessages.Notificat
 	}
 }
 
+// IndexNotificationsHandler is the index notification handler
 type IndexNotificationsHandler struct {
 	handlers.HandlerContext
 	services.ListFetcher
@@ -33,6 +34,7 @@ type IndexNotificationsHandler struct {
 	services.NewPagination
 }
 
+// Handle does the index notification
 func (h IndexNotificationsHandler) Handle(params notificationsop.IndexNotificationsParams) middleware.Responder {
 	logger := h.LoggerFromRequest(params.HTTPRequest)
 	queryFilters := h.generateQueryFilters(params.Filter, logger)

--- a/pkg/handlers/adminapi/office_users.go
+++ b/pkg/handlers/adminapi/office_users.go
@@ -93,12 +93,14 @@ func (h IndexOfficeUsersHandler) Handle(params officeuserop.IndexOfficeUsersPara
 	return officeuserop.NewIndexOfficeUsersOK().WithContentRange(fmt.Sprintf("office users %d-%d/%d", pagination.Offset(), pagination.Offset()+queriedOfficeUsersCount, totalOfficeUsersCount)).WithPayload(payload)
 }
 
+// GetOfficeUserHandler retrieves office user handler
 type GetOfficeUserHandler struct {
 	handlers.HandlerContext
 	services.OfficeUserFetcher
 	services.NewQueryFilter
 }
 
+// Handle retrieves an office user
 func (h GetOfficeUserHandler) Handle(params officeuserop.GetOfficeUserParams) middleware.Responder {
 	_, logger := h.SessionAndLoggerFromRequest(params.HTTPRequest)
 
@@ -126,12 +128,14 @@ func (h GetOfficeUserHandler) Handle(params officeuserop.GetOfficeUserParams) mi
 	return officeuserop.NewGetOfficeUserOK().WithPayload(payload)
 }
 
+// CreateOfficeUserHandler creates an office user
 type CreateOfficeUserHandler struct {
 	handlers.HandlerContext
 	services.OfficeUserCreator
 	services.NewQueryFilter
 }
 
+// Handle creates an office user
 func (h CreateOfficeUserHandler) Handle(params officeuserop.CreateOfficeUserParams) middleware.Responder {
 	payload := params.OfficeUser
 	session, logger := h.SessionAndLoggerFromRequest(params.HTTPRequest)
@@ -181,6 +185,7 @@ func (h CreateOfficeUserHandler) Handle(params officeuserop.CreateOfficeUserPara
 	return officeuserop.NewCreateOfficeUserCreated().WithPayload(returnPayload)
 }
 
+// UpdateOfficeUserHandler updates an office user
 type UpdateOfficeUserHandler struct {
 	handlers.HandlerContext
 	services.OfficeUserUpdater
@@ -188,6 +193,7 @@ type UpdateOfficeUserHandler struct {
 	services.UserRoleAssociator
 }
 
+// Handle updates an office user
 func (h UpdateOfficeUserHandler) Handle(params officeuserop.UpdateOfficeUserParams) middleware.Responder {
 	payload := params.OfficeUser
 	session, logger := h.SessionAndLoggerFromRequest(params.HTTPRequest)

--- a/pkg/handlers/errors.go
+++ b/pkg/handlers/errors.go
@@ -33,6 +33,7 @@ type ValidationErrorsResponse struct {
 	Errors map[string]string `json:"errors,omitempty"`
 }
 
+// NewValidationErrorsResponse returns a new validations errors response
 func NewValidationErrorsResponse(verrs *validate.Errors) *ValidationErrorsResponse {
 	errors := make(map[string]string)
 	for _, key := range verrs.Keys() {

--- a/pkg/handlers/ghcapi/customer.go
+++ b/pkg/handlers/ghcapi/customer.go
@@ -14,7 +14,7 @@ import (
 	"github.com/transcom/mymove/pkg/handlers/ghcapi/internal/payloads"
 )
 
-// GetCustomerInfoHandler fetches the information of a specific customer
+// GetCustomerHandler fetches the information of a specific customer
 type GetCustomerHandler struct {
 	handlers.HandlerContext
 	services.CustomerFetcher

--- a/pkg/handlers/ghcapi/internal/payloads/model_to_payload.go
+++ b/pkg/handlers/ghcapi/internal/payloads/model_to_payload.go
@@ -7,6 +7,7 @@ import (
 	"github.com/transcom/mymove/pkg/models"
 )
 
+// MoveTaskOrder payload
 func MoveTaskOrder(moveTaskOrder *models.MoveTaskOrder) *ghcmessages.MoveTaskOrder {
 	if moveTaskOrder == nil {
 		return nil
@@ -23,6 +24,7 @@ func MoveTaskOrder(moveTaskOrder *models.MoveTaskOrder) *ghcmessages.MoveTaskOrd
 	return payload
 }
 
+// Customer payload
 func Customer(customer *models.Customer) *ghcmessages.Customer {
 	if customer == nil {
 		return nil
@@ -42,6 +44,7 @@ func Customer(customer *models.Customer) *ghcmessages.Customer {
 	return &payload
 }
 
+// MoveOrder payload
 func MoveOrder(moveOrder *models.MoveOrder) *ghcmessages.MoveOrder {
 	if moveOrder == nil {
 		return nil
@@ -86,6 +89,7 @@ func MoveOrder(moveOrder *models.MoveOrder) *ghcmessages.MoveOrder {
 	return &payload
 }
 
+// Entitlement payload
 func Entitlement(entitlement *models.Entitlement) *ghcmessages.Entitlements {
 	if entitlement == nil {
 		return nil
@@ -123,6 +127,7 @@ func Entitlement(entitlement *models.Entitlement) *ghcmessages.Entitlements {
 	}
 }
 
+// DutyStation payload
 func DutyStation(dutyStation *models.DutyStation) *ghcmessages.DutyStation {
 	if dutyStation == nil {
 		return nil
@@ -137,6 +142,7 @@ func DutyStation(dutyStation *models.DutyStation) *ghcmessages.DutyStation {
 	return &payload
 }
 
+// Address payload
 func Address(address *models.Address) *ghcmessages.Address {
 	if address == nil {
 		return nil
@@ -153,6 +159,7 @@ func Address(address *models.Address) *ghcmessages.Address {
 	}
 }
 
+// MTOShipment payload
 func MTOShipment(mtoShipment *models.MTOShipment) *ghcmessages.MTOShipment {
 	strfmt.MarshalFormat = strfmt.RFC3339Micro
 	payload := &ghcmessages.MTOShipment{
@@ -178,6 +185,7 @@ func MTOShipment(mtoShipment *models.MTOShipment) *ghcmessages.MTOShipment {
 	return payload
 }
 
+// MTOShipments payload
 func MTOShipments(mtoShipments *models.MTOShipments) *ghcmessages.MTOShipments {
 	payload := make(ghcmessages.MTOShipments, len(*mtoShipments))
 

--- a/pkg/handlers/ghcapi/move_orders.go
+++ b/pkg/handlers/ghcapi/move_orders.go
@@ -39,7 +39,7 @@ func (h GetMoveOrdersHandler) Handle(params moveorderop.GetMoveOrderParams) midd
 	return moveorderop.NewGetMoveOrderOK().WithPayload(moveOrderPayload)
 }
 
-// ListMoveOrders fetches all the move orders
+// ListMoveOrdersHandler fetches all the move orders
 type ListMoveOrdersHandler struct {
 	handlers.HandlerContext
 	services.MoveOrderFetcher
@@ -65,7 +65,7 @@ func (h ListMoveOrdersHandler) Handle(params moveorderop.ListMoveOrdersParams) m
 	return moveorderop.NewListMoveOrdersOK().WithPayload(moveOrdersPayload)
 }
 
-// ListMoveOrders fetches all the move orders
+// ListMoveTaskOrdersHandler fetches all the move orders
 type ListMoveTaskOrdersHandler struct {
 	handlers.HandlerContext
 	services.MoveTaskOrderFetcher

--- a/pkg/handlers/ghcapi/move_task_order.go
+++ b/pkg/handlers/ghcapi/move_task_order.go
@@ -22,7 +22,7 @@ type GetMoveTaskOrderHandler struct {
 	moveTaskOrderFetcher services.MoveTaskOrderFetcher
 }
 
-// GetMoveTaskOrderHandler updates the status of a MoveTaskOrder
+// Handle updates the status of a MoveTaskOrder
 func (h GetMoveTaskOrderHandler) Handle(params movetaskorderops.GetMoveTaskOrderParams) middleware.Responder {
 	logger := h.LoggerFromRequest(params.HTTPRequest)
 
@@ -49,7 +49,7 @@ type UpdateMoveTaskOrderStatusHandlerFunc struct {
 	moveTaskOrderStatusUpdater services.MoveTaskOrderStatusUpdater
 }
 
-// UpdateMoveTaskOrderStatusHandlerFunc updates the status of a MoveTaskOrder
+// Handle updates the status of a MoveTaskOrder
 func (h UpdateMoveTaskOrderStatusHandlerFunc) Handle(params movetaskorderops.UpdateMoveTaskOrderStatusParams) middleware.Responder {
 	session, logger := h.SessionAndLoggerFromRequest(params.HTTPRequest)
 

--- a/pkg/handlers/ghcapi/mto_shipment.go
+++ b/pkg/handlers/ghcapi/mto_shipment.go
@@ -19,6 +19,7 @@ import (
 	"github.com/transcom/mymove/pkg/services/query"
 )
 
+// ListMTOShipmentsHandler returns a list of MTO Shipments
 type ListMTOShipmentsHandler struct {
 	handlers.HandlerContext
 	services.ListFetcher
@@ -70,12 +71,14 @@ func (h ListMTOShipmentsHandler) Handle(params mtoshipmentops.ListMTOShipmentsPa
 	return mtoshipmentops.NewListMTOShipmentsOK().WithPayload(*payload)
 }
 
+// PatchShipmentHandler patches shipments
 type PatchShipmentHandler struct {
 	handlers.HandlerContext
 	services.Fetcher
 	services.MTOShipmentStatusUpdater
 }
 
+// Handle patches shipments
 func (h PatchShipmentHandler) Handle(params mtoshipmentops.PatchMTOShipmentStatusParams) middleware.Responder {
 	logger := h.LoggerFromRequest(params.HTTPRequest)
 

--- a/pkg/handlers/ghcapi/payment_request.go
+++ b/pkg/handlers/ghcapi/payment_request.go
@@ -32,11 +32,13 @@ func payloadForPaymentRequestModel(pr models.PaymentRequest) *ghcmessages.Paymen
 	}
 }
 
+// ListPaymentRequestsHandler lists payments requests
 type ListPaymentRequestsHandler struct {
 	handlers.HandlerContext
 	services.PaymentRequestListFetcher
 }
 
+// Handle lists payment requests
 func (h ListPaymentRequestsHandler) Handle(params paymentrequestop.ListPaymentRequestsParams) middleware.Responder {
 	// TODO: add authorizations
 	logger := h.LoggerFromRequest(params.HTTPRequest)
@@ -55,11 +57,13 @@ func (h ListPaymentRequestsHandler) Handle(params paymentrequestop.ListPaymentRe
 	return paymentrequestop.NewListPaymentRequestsOK().WithPayload(paymentRequestsList)
 }
 
+// GetPaymentRequestHandler gets payment requests
 type GetPaymentRequestHandler struct {
 	handlers.HandlerContext
 	services.PaymentRequestFetcher
 }
 
+// Handle gets payment requests
 func (h GetPaymentRequestHandler) Handle(params paymentrequestop.GetPaymentRequestParams) middleware.Responder {
 	logger := h.LoggerFromRequest(params.HTTPRequest)
 	paymentRequestID, err := uuid.FromString(params.PaymentRequestID.String())
@@ -89,12 +93,14 @@ func (h GetPaymentRequestHandler) Handle(params paymentrequestop.GetPaymentReque
 	return response
 }
 
+// UpdatePaymentRequestStatusHandler updates payment requests status
 type UpdatePaymentRequestStatusHandler struct {
 	handlers.HandlerContext
 	services.PaymentRequestStatusUpdater
 	services.PaymentRequestFetcher
 }
 
+// Handle updates payment requests status
 func (h UpdatePaymentRequestStatusHandler) Handle(params paymentrequestop.UpdatePaymentRequestStatusParams) middleware.Responder {
 	session, logger := h.SessionAndLoggerFromRequest(params.HTTPRequest)
 	paymentRequestID, err := uuid.FromString(params.PaymentRequestID.String())

--- a/pkg/handlers/internalapi/move_queue_items.go
+++ b/pkg/handlers/internalapi/move_queue_items.go
@@ -50,9 +50,10 @@ type ShowQueueHandler struct {
 	handlers.HandlerContext
 }
 
+// JSONDate is a time type
 type JSONDate time.Time
 
-// Dates without timestamps need custom unmarshalling
+// UnmarshalJSON Dates without timestamps need custom unmarshalling
 func (j *JSONDate) UnmarshalJSON(b []byte) error {
 	s := strings.Trim(string(b), "\"")
 	if s == "null" {
@@ -66,6 +67,7 @@ func (j *JSONDate) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
+// QueueSitData is SIT data in a queue
 type QueueSitData struct {
 	ID              uuid.UUID `json:"id"`
 	Status          string    `json:"status"`
@@ -74,6 +76,7 @@ type QueueSitData struct {
 	Location        string    `json:"location"`
 }
 
+// MoveQueueItems is a set of move queue items
 // Implementation of a type and methods in order to use sort.Interface directly.
 // This allows us to call sortQueueItemsByLastModifiedDate in the ShowQueueHandler which will
 // sort the slice by the LastModfiedDate. Doing it this way allows us to avoid having reflect called

--- a/pkg/handlers/primeapi/internal/payloads/model_to_payload.go
+++ b/pkg/handlers/primeapi/internal/payloads/model_to_payload.go
@@ -7,6 +7,7 @@ import (
 	"github.com/transcom/mymove/pkg/models"
 )
 
+// MoveTaskOrder payload
 func MoveTaskOrder(moveTaskOrder *models.MoveTaskOrder) *primemessages.MoveTaskOrder {
 	if moveTaskOrder == nil {
 		return nil
@@ -29,6 +30,7 @@ func MoveTaskOrder(moveTaskOrder *models.MoveTaskOrder) *primemessages.MoveTaskO
 	return payload
 }
 
+// MoveTaskOrders payload
 func MoveTaskOrders(moveTaskOrders *models.MoveTaskOrders) []*primemessages.MoveTaskOrder {
 	payload := make(primemessages.MoveTaskOrders, len(*moveTaskOrders))
 
@@ -38,6 +40,7 @@ func MoveTaskOrders(moveTaskOrders *models.MoveTaskOrders) []*primemessages.Move
 	return payload
 }
 
+// Customer payload
 func Customer(customer *models.Customer) *primemessages.Customer {
 	if customer == nil {
 		return nil
@@ -50,6 +53,7 @@ func Customer(customer *models.Customer) *primemessages.Customer {
 	return &payload
 }
 
+// MoveOrder payload
 func MoveOrder(moveOrders *models.MoveOrder) *primemessages.MoveOrder {
 	if moveOrders == nil {
 		return nil
@@ -70,6 +74,7 @@ func MoveOrder(moveOrders *models.MoveOrder) *primemessages.MoveOrder {
 	return &payload
 }
 
+// Entitlement payload
 func Entitlement(entitlement *models.Entitlement) *primemessages.Entitlements {
 	if entitlement == nil {
 		return nil
@@ -107,6 +112,7 @@ func Entitlement(entitlement *models.Entitlement) *primemessages.Entitlements {
 	}
 }
 
+// DutyStation payload
 func DutyStation(dutyStation *models.DutyStation) *primemessages.DutyStation {
 	if dutyStation == nil {
 		return nil
@@ -121,6 +127,7 @@ func DutyStation(dutyStation *models.DutyStation) *primemessages.DutyStation {
 	return &payload
 }
 
+// Address payload
 func Address(address *models.Address) *primemessages.Address {
 	if address == nil {
 		return nil
@@ -137,6 +144,7 @@ func Address(address *models.Address) *primemessages.Address {
 	}
 }
 
+// PaymentRequest payload
 func PaymentRequest(paymentRequest *models.PaymentRequest) *primemessages.PaymentRequest {
 	return &primemessages.PaymentRequest{
 		ID:              strfmt.UUID(paymentRequest.ID.String()),
@@ -147,6 +155,7 @@ func PaymentRequest(paymentRequest *models.PaymentRequest) *primemessages.Paymen
 	}
 }
 
+// PaymentRequests payload
 func PaymentRequests(paymentRequests *[]models.PaymentRequest) []*primemessages.PaymentRequest {
 	payload := make(primemessages.PaymentRequests, len(*paymentRequests))
 
@@ -156,6 +165,7 @@ func PaymentRequests(paymentRequests *[]models.PaymentRequest) []*primemessages.
 	return payload
 }
 
+// MTOShipment payload
 func MTOShipment(mtoShipment *models.MTOShipment) *primemessages.MTOShipment {
 	payload := &primemessages.MTOShipment{
 		ID:                       strfmt.UUID(mtoShipment.ID.String()),
@@ -190,6 +200,7 @@ func MTOShipment(mtoShipment *models.MTOShipment) *primemessages.MTOShipment {
 	return payload
 }
 
+// MTOShipments payload
 func MTOShipments(mtoShipments *models.MTOShipments) *primemessages.MTOShipments {
 	payload := make(primemessages.MTOShipments, len(*mtoShipments))
 
@@ -199,6 +210,7 @@ func MTOShipments(mtoShipments *models.MTOShipments) *primemessages.MTOShipments
 	return &payload
 }
 
+// MTOServiceItem payload
 func MTOServiceItem(mtoServiceItem *models.MTOServiceItem) *primemessages.MTOServiceItem {
 	return &primemessages.MTOServiceItem{
 		ID:              strfmt.UUID(mtoServiceItem.ID.String()),
@@ -209,6 +221,7 @@ func MTOServiceItem(mtoServiceItem *models.MTOServiceItem) *primemessages.MTOSer
 	}
 }
 
+// MTOServiceItems payload
 func MTOServiceItems(mtoServiceItems *[]models.MTOServiceItem) []*primemessages.MTOServiceItem {
 	payload := make(primemessages.MTOServiceItems, len(*mtoServiceItems))
 

--- a/pkg/handlers/primeapi/internal/payloads/payload_to_model.go
+++ b/pkg/handlers/primeapi/internal/payloads/payload_to_model.go
@@ -10,6 +10,7 @@ import (
 	"github.com/transcom/mymove/pkg/unit"
 )
 
+// AddressModel model
 func AddressModel(address *primemessages.Address) *models.Address {
 	if address == nil {
 		return nil
@@ -26,6 +27,7 @@ func AddressModel(address *primemessages.Address) *models.Address {
 	}
 }
 
+// MTOShipmentModel model
 func MTOShipmentModel(mtoShipment *primemessages.MTOShipment) *models.MTOShipment {
 	if mtoShipment == nil {
 		return nil

--- a/pkg/handlers/primeapi/mto_shipment.go
+++ b/pkg/handlers/primeapi/mto_shipment.go
@@ -16,6 +16,7 @@ import (
 	"github.com/transcom/mymove/pkg/handlers"
 )
 
+// UpdateMTOShipmentHandler is the handler to update MTO shipments
 type UpdateMTOShipmentHandler struct {
 	handlers.HandlerContext
 	mtoShipmentUpdater services.MTOShipmentUpdater

--- a/pkg/handlers/primeapi/payment_request.go
+++ b/pkg/handlers/primeapi/payment_request.go
@@ -23,11 +23,13 @@ func payloadForPaymentRequestModel(pr models.PaymentRequest) *primemessages.Paym
 	}
 }
 
+// CreatePaymentRequestHandler is the handler for creating payment requests
 type CreatePaymentRequestHandler struct {
 	handlers.HandlerContext
 	services.PaymentRequestCreator
 }
 
+// Handle creates the payment request
 func (h CreatePaymentRequestHandler) Handle(params paymentrequestop.CreatePaymentRequestParams) middleware.Responder {
 	// TODO: authorization to create payment request
 

--- a/pkg/handlers/primeapi/upload.go
+++ b/pkg/handlers/primeapi/upload.go
@@ -23,11 +23,13 @@ func payloadForPaymentRequestUploadModel(u models.Upload) *primemessages.Upload 
 	}
 }
 
+// CreateUploadHandler is the create upload handler
 type CreateUploadHandler struct {
 	handlers.HandlerContext
 	services.PaymentRequestUploadCreator
 }
 
+// Handle creates uploads
 func (h *CreateUploadHandler) Handle(params uploadop.CreateUploadParams) middleware.Responder {
 	session, logger := h.SessionAndLoggerFromRequest(params.HTTPRequest)
 	userID := session.UserID // TODO: restrict to prime user when prime auth is implemented

--- a/pkg/iws/testing_person_lookup.go
+++ b/pkg/iws/testing_person_lookup.go
@@ -7,6 +7,7 @@ const edipi = 1234567890
 // TestingPersonLookup is a mock of RBS that returns dummy data
 type TestingPersonLookup struct{}
 
+// NewTestingPersonLookup returns a new Testing Person Lookup
 func NewTestingPersonLookup() (*TestingPersonLookup, error) {
 	return &TestingPersonLookup{}, nil
 }

--- a/pkg/migrate/Buffer.go
+++ b/pkg/migrate/Buffer.go
@@ -9,7 +9,9 @@ import (
 )
 
 var (
-	ErrWait   = errors.New("wait for input")
+	// ErrWait is an error when waiting for input
+	ErrWait = errors.New("wait for input")
+	// ErrClosed is an error when buffer is closed for writing
 	ErrClosed = errors.New("buffer is closed for writing")
 )
 

--- a/pkg/migrate/Exec.go
+++ b/pkg/migrate/Exec.go
@@ -15,6 +15,7 @@ var (
 	endCopyFromStdin = "\\."
 )
 
+// Exec executes a query
 func Exec(inputReader io.Reader, tx *pop.Connection, wait time.Duration) error {
 
 	lines := make(chan string, 1000)

--- a/pkg/migrate/ListFiles.go
+++ b/pkg/migrate/ListFiles.go
@@ -12,11 +12,12 @@ import (
 	"github.com/pkg/errors"
 )
 
+// FileHelper is an afero filesystem struct
 type FileHelper struct {
 	fs afero.Fs
 }
 
-// NewUploader creates and returns a new uploader
+// NewFileHelper creates and returns a new File Helper
 func NewFileHelper() *FileHelper {
 	fs := afero.NewOsFs()
 	return &FileHelper{
@@ -24,6 +25,7 @@ func NewFileHelper() *FileHelper {
 	}
 }
 
+// SetFileSystem sets the file system for the file helper
 func (fh *FileHelper) SetFileSystem(fs afero.Fs) {
 	fh.fs = fs
 }

--- a/pkg/migrate/Stack.go
+++ b/pkg/migrate/Stack.go
@@ -1,35 +1,43 @@
 package migrate
 
+// Stack represents a collection of SQL queries
 type Stack struct {
 	stack []string
 }
 
+// NewStack creates a new Stack with an empty slice of strings for queries
 func NewStack() Stack {
 	return Stack{
 		stack: make([]string, 0),
 	}
 }
 
+// Slice returns the slice of strings from the Stack
 func (s *Stack) Slice() []string {
 	return s.stack
 }
 
+// Empty returns true if the stack has no queries in it
 func (s *Stack) Empty() bool {
 	return len(s.stack) == 0
 }
 
+// Len returns the list of queries in the stack
 func (s *Stack) Len() int {
 	return len(s.stack)
 }
 
+// Push appends a query to the Stack
 func (s *Stack) Push(str string) {
 	s.stack = append(s.stack, str)
 }
 
+// Pop removes the last item from the stack
 func (s *Stack) Pop() {
 	s.stack = s.stack[0 : len(s.stack)-1]
 }
 
+// Last returns the last query from the stack
 func (s *Stack) Last() string {
 	return s.stack[len(s.stack)-1]
 }

--- a/pkg/models/access_code.go
+++ b/pkg/models/access_code.go
@@ -21,6 +21,7 @@ type AccessCode struct {
 	ClaimedAt       *time.Time        `json:"claimed_at" db:"claimed_at"`
 }
 
+// AccessCodes is a slice of AccessCode objects
 type AccessCodes []AccessCode
 
 // Validate gets run every time you call a "pop.Validate*" (pop.ValidateAndSave, pop.ValidateAndCreate, pop.ValidateAndUpdate) method.

--- a/pkg/models/admin_user.go
+++ b/pkg/models/admin_user.go
@@ -11,13 +11,17 @@ import (
 	"github.com/gofrs/uuid"
 )
 
+// AdminRole represents administrative roles
 type AdminRole string
 
 const (
-	SystemAdminRole  AdminRole = "SYSTEM_ADMIN"
+	// SystemAdminRole represents a role for managing the system
+	SystemAdminRole AdminRole = "SYSTEM_ADMIN"
+	// ProgramAdminRole represents a role for managing the program (Note: This is deprecated and should be removed)
 	ProgramAdminRole AdminRole = "PROGRAM_ADMIN"
 )
 
+// ValidRoles returns a slice of valid roles for an admin
 func (ar *AdminRole) ValidRoles() []AdminRole {
 	return []AdminRole{
 		SystemAdminRole,
@@ -25,10 +29,12 @@ func (ar *AdminRole) ValidRoles() []AdminRole {
 	}
 }
 
+// String returns a string representation of the admin role
 func (ar *AdminRole) String() string {
 	return string(*ar)
 }
 
+// AdminUser is someone who operates the Milmove systems
 type AdminUser struct {
 	ID             uuid.UUID    `json:"id" db:"id"`
 	CreatedAt      time.Time    `json:"created_at" db:"created_at"`
@@ -59,6 +65,7 @@ func (a AdminUsers) String() string {
 	return string(ja)
 }
 
+// RoleInclusion is used to validate if a role is valid for inclusion
 type RoleInclusion struct {
 	Name    string
 	Field   AdminRole
@@ -66,6 +73,7 @@ type RoleInclusion struct {
 	Message string
 }
 
+// IsValid validates if RoleInclusion is valid
 func (v *RoleInclusion) IsValid(errors *validate.Errors) {
 	found := false
 	for _, l := range v.List {

--- a/pkg/models/contractors.go
+++ b/pkg/models/contractors.go
@@ -20,6 +20,7 @@ type Contractor struct {
 	ClaimedAt      *time.Time `json:"claimed_at" db:"claimed_at"`
 }
 
+// Contractors is a slice of Contractor objects
 type Contractors []Contractor
 
 // Validate gets run every time you call a "pop.Validate*" (pop.ValidateAndSave, pop.ValidateAndCreate, pop.ValidateAndUpdate) method.

--- a/pkg/models/duty_station.go
+++ b/pkg/models/duty_station.go
@@ -142,7 +142,7 @@ func FetchDutyStationTransportationOffice(db *pop.Connection, dutyStationID uuid
 	return dutyStation.TransportationOffice, nil
 }
 
-// FetchDutyStationByPostalCode returns a station for a given postal code
+// FetchDutyStationsByPostalCode returns a station for a given postal code
 func FetchDutyStationsByPostalCode(tx *pop.Connection, postalCode string) (DutyStations, error) {
 	var stations DutyStations
 	query := tx.

--- a/pkg/models/ghc_entitlements.go
+++ b/pkg/models/ghc_entitlements.go
@@ -21,6 +21,7 @@ type Entitlement struct {
 	UpdatedAt          time.Time        `db:"updated_at"`
 }
 
+// SetWeightAllotment sets the weight allotment
 //TODO probably want to reconsider keeping grade a string rather than enum
 //TODO and possibly consider creating ghc specific GetWeightAllotment should the two
 //TODO diverge in the future
@@ -29,6 +30,7 @@ func (e *Entitlement) SetWeightAllotment(grade string) {
 	e.weightAllotment = &wa
 }
 
+// WeightAllotment returns the weight allotment
 func (e *Entitlement) WeightAllotment() *WeightAllotment {
 	return e.weightAllotment
 }

--- a/pkg/models/move_task_order.go
+++ b/pkg/models/move_task_order.go
@@ -52,6 +52,7 @@ func generateReferenceID(tx *pop.Connection) (string, error) {
 	return newReferenceID, nil
 }
 
+// GenerateReferenceID generates a reference ID for the MTO
 func GenerateReferenceID(tx *pop.Connection) (string, error) {
 	const maxAttempts = 10
 	var referenceID string

--- a/pkg/models/mto_shipments.go
+++ b/pkg/models/mto_shipments.go
@@ -15,25 +15,38 @@ import (
 type MTOShipmentType string
 
 const (
-	MTOShipmentTypeHHG              MTOShipmentType = "HHG"
+	// MTOShipmentTypeHHG is an HHG Shipment Type default
+	MTOShipmentTypeHHG MTOShipmentType = "HHG"
+	// MTOShipmentTypeInternationalHHG is a Shipment Type for International HHG
 	MTOShipmentTypeInternationalHHG MTOShipmentType = "INTERNATIONAL_HHG"
-	MTOShipmentTypeInternationalUB  MTOShipmentType = "INTERNATIONAL_UB"
-	MTOShipmentTypeHHGLongHaulDom   MTOShipmentType = "HHG_LONGHAUL_DOMESTIC"
-	MTOShipmentTypeHHGShortHaulDom  MTOShipmentType = "HHG_SHORTHAUL_DOMESTIC"
-	MTOShipmentTypeHHGIntoNTSDom    MTOShipmentType = "HHG_INTO_NTS_DOMESTIC"
-	MTOShipmentTypeHHGOutOfNTSDom   MTOShipmentType = "HHG_OUTOF_NTS_DOMESTIC"
-	MTOShipmentTypeMotorhome        MTOShipmentType = "MOTORHOME"
-	MTOShipmentTypeBoatHaulAway     MTOShipmentType = "BOAT_HAUL_AWAY"
-	MTOShipmentTypeBoatTowAway      MTOShipmentType = "BOAT_TOW_AWAY"
+	// MTOShipmentTypeInternationalUB is a Shipment Type for International UB
+	MTOShipmentTypeInternationalUB MTOShipmentType = "INTERNATIONAL_UB"
+	// MTOShipmentTypeHHGLongHaulDom is an HHG Shipment Type for Longhaul Domestic
+	MTOShipmentTypeHHGLongHaulDom MTOShipmentType = "HHG_LONGHAUL_DOMESTIC"
+	// MTOShipmentTypeHHGShortHaulDom is an HHG Shipment Type for Shothaul Domestic
+	MTOShipmentTypeHHGShortHaulDom MTOShipmentType = "HHG_SHORTHAUL_DOMESTIC"
+	// MTOShipmentTypeHHGIntoNTSDom is an HHG Shipment Type for going into NTS Domestic
+	MTOShipmentTypeHHGIntoNTSDom MTOShipmentType = "HHG_INTO_NTS_DOMESTIC"
+	// MTOShipmentTypeHHGOutOfNTSDom is an HHG Shipment Type for going out of NTS Domestic
+	MTOShipmentTypeHHGOutOfNTSDom MTOShipmentType = "HHG_OUTOF_NTS_DOMESTIC"
+	// MTOShipmentTypeMotorhome is a Shipment Type for Motorhome
+	MTOShipmentTypeMotorhome MTOShipmentType = "MOTORHOME"
+	// MTOShipmentTypeBoatHaulAway is a Shipment Type for Boat Haul Away
+	MTOShipmentTypeBoatHaulAway MTOShipmentType = "BOAT_HAUL_AWAY"
+	// MTOShipmentTypeBoatTowAway is a Shipment Type for Boat Tow Away
+	MTOShipmentTypeBoatTowAway MTOShipmentType = "BOAT_TOW_AWAY"
 )
 
 // MTOShipmentStatus represents the possible statuses for a mto shipment
 type MTOShipmentStatus string
 
 const (
+	// MTOShipmentStatusSubmitted is the submitted status type for MTO Shipments
 	MTOShipmentStatusSubmitted MTOShipmentStatus = "SUBMITTED"
-	MTOShipmentStatusApproved  MTOShipmentStatus = "APPROVED"
-	MTOShipmentStatusRejected  MTOShipmentStatus = "REJECTED"
+	// MTOShipmentStatusApproved is the approved status type for MTO Shipments
+	MTOShipmentStatusApproved MTOShipmentStatus = "APPROVED"
+	// MTOShipmentStatusRejected is the rejected status type for MTO Shipments
+	MTOShipmentStatusRejected MTOShipmentStatus = "REJECTED"
 )
 
 // MTOShipment is an object representing data for a move task order shipment

--- a/pkg/models/notifications.go
+++ b/pkg/models/notifications.go
@@ -6,6 +6,7 @@ import (
 	"github.com/gofrs/uuid"
 )
 
+// NotificationTypes represents types of notifications
 type NotificationTypes string
 
 const (
@@ -15,6 +16,7 @@ const (
 	MovePaymentReminderEmail NotificationTypes = "MOVE_PAYMENT_REMINDER_EMAIL"
 )
 
+// Notification represents an email sent to a service member
 type Notification struct {
 	ID               uuid.UUID         `db:"id"`
 	ServiceMemberID  uuid.UUID         `db:"service_member_id"`
@@ -24,4 +26,5 @@ type Notification struct {
 	CreatedAt        time.Time         `db:"created_at"`
 }
 
+// Notifications is a slice of notification structs
 type Notifications []Notification

--- a/pkg/models/organization.go
+++ b/pkg/models/organization.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gofrs/uuid"
 )
 
+// Organization represents an organization and their contact information
 type Organization struct {
 	ID        uuid.UUID `json:"id" db:"id"`
 	CreatedAt time.Time `json:"created_at" db:"created_at"`

--- a/pkg/models/payment_request.go
+++ b/pkg/models/payment_request.go
@@ -9,18 +9,25 @@ import (
 	"github.com/gofrs/uuid"
 )
 
+// PaymentRequestStatus is a type of Payment Request Status
 type PaymentRequestStatus string
 
+// String is a string representation of a Payment Request Status
 func (p PaymentRequestStatus) String() string {
 	return string(p)
 }
 
 const (
-	PaymentRequestStatusPending       PaymentRequestStatus = "PENDING"
-	PaymentRequestStatusReviewed      PaymentRequestStatus = "REVIEWED"
-	PaymentRequestStatusSentToGex     PaymentRequestStatus = "SENT_TO_GEX"
+	// PaymentRequestStatusPending is pending
+	PaymentRequestStatusPending PaymentRequestStatus = "PENDING"
+	// PaymentRequestStatusReviewed is reviewed
+	PaymentRequestStatusReviewed PaymentRequestStatus = "REVIEWED"
+	// PaymentRequestStatusSentToGex is sent to gex
+	PaymentRequestStatusSentToGex PaymentRequestStatus = "SENT_TO_GEX"
+	// PaymentRequestStatusReceivedByGex is received by gex
 	PaymentRequestStatusReceivedByGex PaymentRequestStatus = "RECEIVED_BY_GEX"
-	PaymentRequestStatusPaid          PaymentRequestStatus = "PAID"
+	// PaymentRequestStatusPaid is paid
+	PaymentRequestStatusPaid PaymentRequestStatus = "PAID"
 )
 
 var validPaymentRequestStatus = []string{
@@ -52,6 +59,7 @@ type PaymentRequest struct {
 	ProofOfServiceDocs  ProofOfServiceDocs  `has_many:"proof_of_service_docs"`
 }
 
+// PaymentRequests is a slice of PaymentRequest
 type PaymentRequests []PaymentRequest
 
 // Validate gets run every time you call a "pop.Validate*" (pop.ValidateAndSave, pop.ValidateAndCreate, pop.ValidateAndUpdate) method.

--- a/pkg/models/payment_service_item.go
+++ b/pkg/models/payment_service_item.go
@@ -11,18 +11,25 @@ import (
 	"github.com/gofrs/uuid"
 )
 
+// PaymentServiceItemStatus is a type of Payment Service Item Status
 type PaymentServiceItemStatus string
 
+// PaymentServiceItemStatus is a string representation of a Payment Service Item Status
 func (p PaymentServiceItemStatus) String() string {
 	return string(p)
 }
 
 const (
+	// PaymentServiceItemStatusRequested is the requested status
 	PaymentServiceItemStatusRequested PaymentServiceItemStatus = "REQUESTED"
-	PaymentServiceItemStatusApproved  PaymentServiceItemStatus = "APPROVED"
-	PaymentServiceItemStatusDenied    PaymentServiceItemStatus = "DENIED"
+	// PaymentServiceItemStatusApproved is the approved status
+	PaymentServiceItemStatusApproved PaymentServiceItemStatus = "APPROVED"
+	// PaymentServiceItemStatusDenied is the denied status
+	PaymentServiceItemStatusDenied PaymentServiceItemStatus = "DENIED"
+	// PaymentServiceItemStatusSentToGex is the sent-to-gex status
 	PaymentServiceItemStatusSentToGex PaymentServiceItemStatus = "SENT_TO_GEX"
-	PaymentServiceItemStatusPaid      PaymentServiceItemStatus = "PAID"
+	// PaymentServiceItemStatusPaid is the paid status
+	PaymentServiceItemStatusPaid PaymentServiceItemStatus = "PAID"
 )
 
 var validPaymentServiceItemStatus = []string{
@@ -33,6 +40,7 @@ var validPaymentServiceItemStatus = []string{
 	string(PaymentServiceItemStatusPaid),
 }
 
+// PaymentServiceItem represents a payment service item
 type PaymentServiceItem struct {
 	ID               uuid.UUID                `json:"id" db:"id"`
 	PaymentRequestID uuid.UUID                `json:"payment_request_id" db:"payment_request_id"`

--- a/pkg/models/payment_service_item_param.go
+++ b/pkg/models/payment_service_item_param.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gofrs/uuid"
 )
 
+// PaymentServiceItemParam represents a parameter of the Payment Service Item
 type PaymentServiceItemParam struct {
 	ID                    uuid.UUID `json:"id" db:"id"`
 	PaymentServiceItemID  uuid.UUID `json:"payment_service_item_id" db:"payment_service_item_id"`

--- a/pkg/models/proof_of_service_doc.go
+++ b/pkg/models/proof_of_service_doc.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gofrs/uuid"
 )
 
+// ProofOfServiceDoc represents a document for proof of service
 type ProofOfServiceDoc struct {
 	ID               uuid.UUID `json:"id" db:"id"`
 	PaymentRequestID uuid.UUID `json:"payment_request_id" db:"payment_request_id"`

--- a/pkg/models/re_intl_other_price.go
+++ b/pkg/models/re_intl_other_price.go
@@ -28,7 +28,7 @@ type ReIntlOtherPrice struct {
 	RateArea ReRateArea `belongs_to:"re_rate_area"`
 }
 
-// ReIntlOtherPrices
+// ReIntlOtherPrices is a slice of ReIntlOtherPrice
 type ReIntlOtherPrices []ReIntlOtherPrice
 
 // Validate gets run every time you call a "pop.Validate*" (pop.ValidateAndSave, pop.ValidateAndCreate, pop.ValidateAndUpdate) method.

--- a/pkg/models/re_intl_price.go
+++ b/pkg/models/re_intl_price.go
@@ -30,7 +30,7 @@ type ReIntlPrice struct {
 	DestinationRateArea ReRateArea `belongs_to:"re_rate_area"`
 }
 
-// ReIntlPrices
+// ReIntlPrices is a slice of ReIntlPrice objects
 type ReIntlPrices []ReIntlPrice
 
 // Validate gets run every time you call a "pop.Validate*" (pop.ValidateAndSave, pop.ValidateAndCreate, pop.ValidateAndUpdate) method.

--- a/pkg/models/re_service.go
+++ b/pkg/models/re_service.go
@@ -9,20 +9,32 @@ import (
 	"github.com/gofrs/uuid"
 )
 
+// ReServiceName is a type of service name
 type ReServiceName string
 
 const (
-	DomesticLinehaul           ReServiceName = "Dom. Linehaul"
-	FuelSurcharge              ReServiceName = "Fuel Surcharge"
-	DomesticOriginPrice        ReServiceName = "Dom. Origin Price"
-	DomesticDestinationPrice   ReServiceName = "Dom. Destination Price"
-	DomesticPacking            ReServiceName = "Dom. Packing"
-	DomesticUnpacking          ReServiceName = "Dom. Unpacking"
-	DomesticShorthaul          ReServiceName = "Dom. Shorthaul"
-	DomesticNTSPackingFactor   ReServiceName = "Dom. NTS Packing Factor"
-	DomesticMobileHomeFactor   ReServiceName = "Dom. Mobile Home Factor"
+	// DomesticLinehaul is a Service Name for  Domestic Linehaul
+	DomesticLinehaul ReServiceName = "Dom. Linehaul"
+	// FuelSurcharge is a Service Name for  Fuel Surchage
+	FuelSurcharge ReServiceName = "Fuel Surcharge"
+	// DomesticOriginPrice is a Service Name for Domestic Origin Price
+	DomesticOriginPrice ReServiceName = "Dom. Origin Price"
+	// DomesticDestinationPrice  is a Service Name for Domestic Destination Price
+	DomesticDestinationPrice ReServiceName = "Dom. Destination Price"
+	// DomesticPacking a Service Name for Domestic Packing
+	DomesticPacking ReServiceName = "Dom. Packing"
+	// DomesticUnpacking is a Service Name for Domestic Unpacking
+	DomesticUnpacking ReServiceName = "Dom. Unpacking"
+	// DomesticShorthaul is a Service Name for Domestic Shorthaul
+	DomesticShorthaul ReServiceName = "Dom. Shorthaul"
+	// DomesticNTSPackingFactor is a Service Name for Domestic NTS Packing Factor
+	DomesticNTSPackingFactor ReServiceName = "Dom. NTS Packing Factor"
+	// DomesticMobileHomeFactor is a Service Name for Domestic Mobile Home Factor
+	DomesticMobileHomeFactor ReServiceName = "Dom. Mobile Home Factor"
+	// DomesticHaulAwayBoatFactor is a Service Name for Domestic Haul Away Boat Factor
 	DomesticHaulAwayBoatFactor ReServiceName = "Dom. Haul Away Boat Factor"
-	DomesticTowAwayBoatFactor  ReServiceName = "Dom. Tow Away Boat Factor"
+	// DomesticTowAwayBoatFactor is a Service Name for Domestic Tow Away Boat Factor
+	DomesticTowAwayBoatFactor ReServiceName = "Dom. Tow Away Boat Factor"
 )
 
 // ReService model struct

--- a/pkg/models/re_task_order_fee.go
+++ b/pkg/models/re_task_order_fee.go
@@ -11,7 +11,7 @@ import (
 	"github.com/gofrs/uuid"
 )
 
-// ReTaskOrderPrice model struct
+// ReTaskOrderFee model struct
 type ReTaskOrderFee struct {
 	ID             uuid.UUID  `json:"id" db:"id"`
 	ContractYearID uuid.UUID  `json:"contract_year_id" db:"contract_year_id"`
@@ -25,7 +25,7 @@ type ReTaskOrderFee struct {
 	Service      ReService      `belongs_to:"re_service"`
 }
 
-// ReTaskOrderPrices is not required by pop and may be deleted
+// ReTaskOrderFees is not required by pop and may be deleted
 type ReTaskOrderFees []ReTaskOrderFee
 
 // Validate gets run every time you call a "pop.Validate*" (pop.ValidateAndSave, pop.ValidateAndCreate, pop.ValidateAndUpdate) method.

--- a/pkg/models/roles/roles.go
+++ b/pkg/models/roles/roles.go
@@ -9,18 +9,26 @@ import (
 	"github.com/gofrs/uuid"
 )
 
-// Role is an object representing the types of users who can authenticate in the admin app
+// RoleType represents the types of users who can authenticate in the admin app
 type RoleType string
+
+// RoleName represents the names of roles
 type RoleName string
 
 const (
-	RoleTypeTOO                RoleType = "transportation_ordering_officer"
-	RoleTypeCustomer           RoleType = "customer"
-	RoleTypeTIO                RoleType = "transportation_invoicing_officer"
+	// RoleTypeTOO is the Transportation Ordering Officer Role
+	RoleTypeTOO RoleType = "transportation_ordering_officer"
+	// RoleTypeCustomer is the Customer Role
+	RoleTypeCustomer RoleType = "customer"
+	// RoleTypeTIO is the Transportation Invoicing Officer Role
+	RoleTypeTIO RoleType = "transportation_invoicing_officer"
+	// RoleTypeContractingOfficer is the Contracting Officer Role
 	RoleTypeContractingOfficer RoleType = "contracting_officer"
-	RoleTypePPMOfficeUsers     RoleType = "ppm_office_users"
+	// RoleTypePPMOfficeUsers is the PPM Office User Role
+	RoleTypePPMOfficeUsers RoleType = "ppm_office_users"
 )
 
+// Role represents a Role for users
 type Role struct {
 	ID        uuid.UUID `json:"id" db:"id"`
 	RoleType  RoleType  `json:"role_type" db:"role_type"`
@@ -29,8 +37,10 @@ type Role struct {
 	UpdatedAt time.Time `json:"updated_at" db:"updated_at"`
 }
 
+// Roles is a slice of Role objects
 type Roles []Role
 
+// HasRole validates if Role has a role of a particular type
 func (rs Roles) HasRole(roleType RoleType) bool {
 	for _, r := range rs {
 		if r.RoleType == roleType {
@@ -40,6 +50,7 @@ func (rs Roles) HasRole(roleType RoleType) bool {
 	return false
 }
 
+// GetRole returns the role a Role Type
 func (rs Roles) GetRole(roleType RoleType) (Role, bool) {
 	for _, r := range rs {
 		if r.RoleType == roleType {

--- a/pkg/models/service_item_param_key.go
+++ b/pkg/models/service_item_param_key.go
@@ -10,27 +10,37 @@ import (
 	"github.com/gofrs/uuid"
 )
 
+// ServiceItemParamType is a type of service item parameter
 type ServiceItemParamType string
 
+// String is a string representation of a ServiceItemParamType
 func (s ServiceItemParamType) String() string {
 	return string(s)
 }
 
 const (
-	ServiceItemParamTypeString  ServiceItemParamType = "STRING"
-	ServiceItemParamTypeDate    ServiceItemParamType = "DATE"
+	// ServiceItemParamTypeString is a string
+	ServiceItemParamTypeString ServiceItemParamType = "STRING"
+	// ServiceItemParamTypeDate is a date
+	ServiceItemParamTypeDate ServiceItemParamType = "DATE"
+	// ServiceItemParamTypeInteger is an integer
 	ServiceItemParamTypeInteger ServiceItemParamType = "INTEGER"
+	// ServiceItemParamTypeDecimal is a decimal
 	ServiceItemParamTypeDecimal ServiceItemParamType = "DECIMAL"
 )
 
+// ServiceItemParamOrigin is a type of service item parameter origin
 type ServiceItemParamOrigin string
 
+// String is a string representation of a ServiceItemParamOrigin
 func (s ServiceItemParamOrigin) String() string {
 	return string(s)
 }
 
 const (
-	ServiceItemParamOriginPrime  ServiceItemParamOrigin = "PRIME"
+	// ServiceItemParamOriginPrime is the Prime origin
+	ServiceItemParamOriginPrime ServiceItemParamOrigin = "PRIME"
+	// ServiceItemParamOriginSystem is the System origin
 	ServiceItemParamOriginSystem ServiceItemParamOrigin = "SYSTEM"
 )
 
@@ -46,6 +56,7 @@ var validServiceItemParamOrigin = []string{
 	string(ServiceItemParamOriginSystem),
 }
 
+// ServiceItemParamKey is a key for a Service Item Param
 type ServiceItemParamKey struct {
 	ID          uuid.UUID              `json:"id" db:"id"`
 	Key         string                 `json:"key" db:"key"`
@@ -59,6 +70,7 @@ type ServiceItemParamKey struct {
 // ServiceItemParamKeys is not required by pop and may be deleted
 type ServiceItemParamKeys []ServiceItemParamKey
 
+// Validate validates a ServiceItemParamKey
 func (s *ServiceItemParamKey) Validate(tx *pop.Connection) (*validate.Errors, error) {
 	return validate.Validate(
 		&validators.StringIsPresent{Field: s.Key, Name: "Key"},

--- a/pkg/models/service_param.go
+++ b/pkg/models/service_param.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gofrs/uuid"
 )
 
+// ServiceParam is a Service Parameter
 type ServiceParam struct {
 	ID                    uuid.UUID `json:"id" db:"id"`
 	ServiceID             uuid.UUID `json:"service_id" db:"service_id"`

--- a/pkg/models/shipment_summary_worksheet.go
+++ b/pkg/models/shipment_summary_worksheet.go
@@ -72,7 +72,7 @@ type ShipmentSummaryWorksheetPage1Values struct {
 	MileageTotal                    string
 }
 
-//ShipmentSummaryWorkSheetShipments is and object representing shipment line items on Shipment Summary Worksheet
+// ShipmentSummaryWorkSheetShipments is an object representing shipment line items on Shipment Summary Worksheet
 type ShipmentSummaryWorkSheetShipments struct {
 	ShipmentNumberAndTypes  string
 	PickUpDates             string
@@ -80,6 +80,7 @@ type ShipmentSummaryWorkSheetShipments struct {
 	CurrentShipmentStatuses string
 }
 
+// ShipmentSummaryWorkSheetSIT is an object representing SIT on the Shipment Summary Worksheet
 type ShipmentSummaryWorkSheetSIT struct {
 	NumberAndTypes string
 	EntryDates     string
@@ -95,8 +96,10 @@ type ShipmentSummaryWorksheetPage2Values struct {
 	FormattedMovingExpenses
 }
 
+// Dollar represents a type for dollar monetary unit
 type Dollar float64
 
+// String is a string representation of a Dollar
 func (d Dollar) String() string {
 	p := message.NewPrinter(language.English)
 	return p.Sprintf("$%.2f", d)
@@ -159,25 +162,25 @@ type ShipmentSummaryFormData struct {
 	SignedCertification     SignedCertification
 }
 
-//Obligations an object representing the Max Obligation and Actual Obligation sections of the shipment summary worksheet
+// Obligations an object representing the Max Obligation and Actual Obligation sections of the shipment summary worksheet
 type Obligations struct {
 	MaxObligation    Obligation
 	ActualObligation Obligation
 }
 
-//Obligation an object representing the obligations section on the shipment summary worksheet
+// Obligation an object representing the obligations section on the shipment summary worksheet
 type Obligation struct {
 	Gcc   unit.Cents
 	SIT   unit.Cents
 	Miles unit.Miles
 }
 
-//GCC100 calculates the 100% GCC on shipment summary worksheet
+// GCC100 calculates the 100% GCC on shipment summary worksheet
 func (obligation Obligation) GCC100() float64 {
 	return obligation.Gcc.ToDollarFloat()
 }
 
-//GCC95 calculates the 95% GCC on shipment summary worksheet
+// GCC95 calculates the 95% GCC on shipment summary worksheet
 func (obligation Obligation) GCC95() float64 {
 	return obligation.Gcc.MultiplyFloat64(.95).ToDollarFloat()
 }
@@ -187,7 +190,7 @@ func (obligation Obligation) FormatSIT() float64 {
 	return obligation.SIT.ToDollarFloat()
 }
 
-//MaxAdvance calculates the Max Advance on the shipment summary worksheet
+// MaxAdvance calculates the Max Advance on the shipment summary worksheet
 func (obligation Obligation) MaxAdvance() float64 {
 	return obligation.Gcc.MultiplyFloat64(.60).ToDollarFloat()
 }
@@ -445,7 +448,7 @@ func FormatRank(rank *ServiceMemberRank) string {
 	return ""
 }
 
-//FormatValuesShipmentSummaryWorksheetFormPage2 formats the data for page 2 of the Shipment Summary Worksheet
+// FormatValuesShipmentSummaryWorksheetFormPage2 formats the data for page 2 of the Shipment Summary Worksheet
 func FormatValuesShipmentSummaryWorksheetFormPage2(data ShipmentSummaryFormData) (ShipmentSummaryWorksheetPage2Values, error) {
 	var err error
 	page2 := ShipmentSummaryWorksheetPage2Values{}
@@ -461,7 +464,7 @@ func FormatValuesShipmentSummaryWorksheetFormPage2(data ShipmentSummaryFormData)
 	return page2, nil
 }
 
-//FormatValuesShipmentSummaryWorksheetFormPage2 formats the data for page 2 of the Shipment Summary Worksheet
+// FormatValuesShipmentSummaryWorksheetFormPage3 formats the data for page 2 of the Shipment Summary Worksheet
 func FormatValuesShipmentSummaryWorksheetFormPage3(data ShipmentSummaryFormData) ShipmentSummaryWorksheetPage3Values {
 	page3 := ShipmentSummaryWorksheetPage3Values{}
 	page3.PreparationDate = FormatDate(data.PreparationDate)
@@ -471,6 +474,7 @@ func FormatValuesShipmentSummaryWorksheetFormPage3(data ShipmentSummaryFormData)
 	return page3
 }
 
+// FormatOtherExpenses formats other expenses
 func FormatOtherExpenses(docs MovingExpenseDocuments) FormattedOtherExpenses {
 	var expenseDescriptions []string
 	var expenseAmounts []string
@@ -594,6 +598,7 @@ func SubTotalExpenses(expenseDocuments MovingExpenseDocuments) map[string]float6
 	return totals
 }
 
+// SubTotalsMapToStruct takes subtotal map and returns struct
 func SubTotalsMapToStruct(subTotals map[string]float64) (FormattedMovingExpenses, error) {
 	expenses := FormattedMovingExpenses{}
 	err := mapstructure.Decode(subTotals, &expenses)

--- a/pkg/models/stage_pricing.go
+++ b/pkg/models/stage_pricing.go
@@ -3,6 +3,8 @@ package models
 //
 // Tab 1b: Service Areas
 //
+
+// StageDomesticServiceArea is the stage domestic service area
 type StageDomesticServiceArea struct {
 	BasePointCity     string `db:"base_point_city" csv:"base_point_city"`
 	State             string `db:"state" csv:"state"`
@@ -10,6 +12,7 @@ type StageDomesticServiceArea struct {
 	Zip3s             string `db:"zip3s" csv:"zip3s"`
 }
 
+// StageInternationalServiceArea is the stage international service area
 type StageInternationalServiceArea struct {
 	RateArea   string `db:"rate_area" csv:"rate_area"`
 	RateAreaID string `db:"rate_area_id" csv:"rate_area_id"`
@@ -18,6 +21,8 @@ type StageInternationalServiceArea struct {
 //
 // Tab 2a: Domestic Linehaul Prices
 //
+
+// StageDomesticLinehaulPrice is the stage domestic linehaul price
 type StageDomesticLinehaulPrice struct {
 	ServiceAreaNumber string `db:"service_area_number" csv:"service_area_number"`
 	OriginServiceArea string `db:"origin_service_area" csv:"origin_service_area"`
@@ -34,6 +39,8 @@ type StageDomesticLinehaulPrice struct {
 //
 // Tab 2b: Domestic Service Area Prices
 //
+
+// StageDomesticServiceAreaPrice is the stage domestic service area price
 type StageDomesticServiceAreaPrice struct {
 	ServiceAreaNumber                     string `db:"service_area_number" csv:"service_area_number"`
 	ServiceAreaName                       string `db:"service_area_name" csv:"service_area_name"`
@@ -49,6 +56,8 @@ type StageDomesticServiceAreaPrice struct {
 //
 // Tab 2c: Other Domestic Prices
 //
+
+// StageDomesticOtherPackPrice is the stage domestic other pack price
 type StageDomesticOtherPackPrice struct {
 	ServicesSchedule   string `db:"services_schedule" csv:"services_schedule"`
 	ServiceProvided    string `db:"service_provided" csv:"service_provided"`
@@ -56,6 +65,7 @@ type StageDomesticOtherPackPrice struct {
 	PeakPricePerCwt    string `db:"peak_price_per_cwt" csv:"peak_price_per_cwt"`
 }
 
+// StageDomesticOtherSitPrice is  the stage domestic other SIT price
 type StageDomesticOtherSitPrice struct {
 	SITPickupDeliverySchedule string `db:"sit_pickup_delivery_schedule" csv:"sit_pickup_delivery_schedule"`
 	ServiceProvided           string `db:"service_provided" csv:"service_provided"`
@@ -66,6 +76,8 @@ type StageDomesticOtherSitPrice struct {
 //
 // Tab 3a: OCONUS to OCONUS Prices
 //
+
+// StageOconusToOconusPrice is the stage OCONOUS To OCONUS price
 type StageOconusToOconusPrice struct {
 	OriginIntlPriceAreaID      string `db:"origin_intl_price_area_id" csv:"origin_intl_price_area_id"`
 	OriginIntlPriceArea        string `db:"origin_intl_price_area" csv:"origin_intl_price_area"`
@@ -79,6 +91,8 @@ type StageOconusToOconusPrice struct {
 //
 // Tab 3b: CONUS to OCONUS Prices
 //
+
+// StageConusToOconusPrice is the stage CONOUS To OCONUS price
 type StageConusToOconusPrice struct {
 	OriginDomesticPriceAreaCode string `db:"origin_domestic_price_area_code" csv:"origin_domestic_price_area_code"`
 	OriginDomesticPriceArea     string `db:"origin_domestic_price_area" csv:"origin_domestic_price_area"`
@@ -92,6 +106,8 @@ type StageConusToOconusPrice struct {
 //
 // Tab 3c: OCONUS to CONUS Prices
 //
+
+// StageOconusToConusPrice is the stage OCONOUS To CONUS price
 type StageOconusToConusPrice struct {
 	OriginIntlPriceAreaID            string `db:"origin_intl_price_area_id" csv:"origin_intl_price_area_id"`
 	OriginIntlPriceArea              string `db:"origin_intl_price_area" csv:"origin_intl_price_area"`
@@ -105,6 +121,8 @@ type StageOconusToConusPrice struct {
 //
 // Tab 3d: Other International Prices
 //
+
+// StageOtherIntlPrice is the stage other international price
 type StageOtherIntlPrice struct {
 	RateAreaCode                          string `db:"rate_area_code" csv:"rate_area_code"`
 	RateAreaName                          string `db:"rate_area_name" csv:"rate_area_name"`
@@ -122,6 +140,8 @@ type StageOtherIntlPrice struct {
 //
 // Tab 3e: Non-Standard Location Prices
 //
+
+// StageNonStandardLocnPrice is the stage non-standard location price
 type StageNonStandardLocnPrice struct {
 	OriginID        string `db:"origin_id" csv:"origin_id"`
 	OriginArea      string `db:"origin_area" csv:"origin_area"`
@@ -136,16 +156,20 @@ type StageNonStandardLocnPrice struct {
 //
 // Tab 4a: Management, Counseling, and Transition Prices
 //
+
+// StageShipmentManagementServicesPrice is the stage shipment management service price
 type StageShipmentManagementServicesPrice struct {
 	ContractYear      string `db:"contract_year" csv:"contract_year"`
 	PricePerTaskOrder string `db:"price_per_task_order" csv:"price_per_task_order"`
 }
 
+// StageCounselingServicesPrice is the stage counceling service price
 type StageCounselingServicesPrice struct {
 	ContractYear      string `db:"contract_year" csv:"contract_year"`
 	PricePerTaskOrder string `db:"price_per_task_order" csv:"price_per_task_order"`
 }
 
+// StageTransitionPrice is the stage transtion price
 type StageTransitionPrice struct {
 	ContractYear      string `db:"contract_year" csv:"contract_year"`
 	PricePerTaskOrder string `db:"price_total_cost" csv:"price_total_cost"`
@@ -154,18 +178,22 @@ type StageTransitionPrice struct {
 //
 // Tab 5a: Accessorial and Additional Prices
 //
+
+// StageDomesticMoveAccessorialPrices is the stage domestic move accessorial prices
 type StageDomesticMoveAccessorialPrices struct {
 	ServicesSchedule string `db:"services_schedule" csv:"services_schedule"`
 	ServiceProvided  string `db:"service_provided" csv:"service_provided"`
 	PricePerUnit     string `db:"price_per_unit" csv:"price_per_unit"`
 }
 
+// StageInternationalMoveAccessorialPrices is the stage international move accessorial prices
 type StageInternationalMoveAccessorialPrices struct {
 	Market          string `db:"market" csv:"market"`
 	ServiceProvided string `db:"service_provided" csv:"service_provided"`
 	PricePerUnit    string `db:"price_per_unit" csv:"price_per_unit"`
 }
 
+// StageDomesticInternationalAdditionalPrices is the stage domestic international additional prices
 type StageDomesticInternationalAdditionalPrices struct {
 	Market       string `db:"market" csv:"market"`
 	ShipmentType string `db:"shipment_type" csv:"shipment_type"`
@@ -175,6 +203,8 @@ type StageDomesticInternationalAdditionalPrices struct {
 //
 // Tab 5b: Price Escalation Discount
 //
+
+// StagePriceEscalationDiscount is the stage price escalation discount
 type StagePriceEscalationDiscount struct {
 	ContractYear          string `db:"contract_year" csv:"contract_year"`
 	ForecastingAdjustment string `db:"forecasting_adjustment" csv:"forecasting_adjustment"`

--- a/pkg/models/transportation_office.go
+++ b/pkg/models/transportation_office.go
@@ -56,6 +56,7 @@ func (t *TransportationOffice) ValidateUpdate(tx *pop.Connection) (*validate.Err
 	return validate.NewErrors(), nil
 }
 
+// FetchNearestTransportationOffice fetches the nearest transportation office
 func FetchNearestTransportationOffice(tx *pop.Connection, long float32, lat float32) (TransportationOffice, error) {
 	var to TransportationOffice
 

--- a/pkg/models/transportation_ordering_officer.go
+++ b/pkg/models/transportation_ordering_officer.go
@@ -6,6 +6,7 @@ import (
 	"github.com/gofrs/uuid"
 )
 
+// TransportationOrderingOfficer is the ordering officer for transportation
 type TransportationOrderingOfficer struct {
 	ID        uuid.UUID  `json:"id" db:"id"`
 	CreatedAt time.Time  `json:"created_at" db:"created_at"`

--- a/pkg/models/users_roles.go
+++ b/pkg/models/users_roles.go
@@ -6,6 +6,7 @@ import (
 	"github.com/gofrs/uuid"
 )
 
+// UsersRoles represents a user and a role
 type UsersRoles struct {
 	ID        uuid.UUID  `db:"id"`
 	UserID    uuid.UUID  `db:"user_id"`

--- a/pkg/models/validators.go
+++ b/pkg/models/validators.go
@@ -343,6 +343,7 @@ func (v *Float64IsGreaterThan) IsValid(errors *validate.Errors) {
 	errors.Add(validators.GenerateKey(v.Name), fmt.Sprintf("%f is not greater than %f.", v.Field, v.Compared))
 }
 
+// OptionalUUIDIsPresent is a structure for determining if UUID is present, optionally
 type OptionalUUIDIsPresent struct {
 	Name    string
 	Field   *uuid.UUID

--- a/pkg/models/weight_ticket_set_document.go
+++ b/pkg/models/weight_ticket_set_document.go
@@ -20,7 +20,7 @@ const (
 	// WeightTicketSetTypeCAR captures enum value "CAR"
 	WeightTicketSetTypeCAR WeightTicketSetType = "CAR"
 
-	// WeightTicketSetTypeCAR captures enum value "CAR_TRAILER"
+	// WeightTicketSetTypeCARTRAILER captures enum value "CAR_TRAILER"
 	WeightTicketSetTypeCARTRAILER WeightTicketSetType = "CAR_TRAILER"
 
 	// WeightTicketSetTypeBOXTRUCK captures enum value "BOXTRUCK"

--- a/pkg/notifications/move_payment_reminder.go
+++ b/pkg/notifications/move_payment_reminder.go
@@ -48,8 +48,10 @@ func NewPaymentReminder(db *pop.Connection, logger Logger) (*PaymentReminder, er
 	}, nil
 }
 
+// PaymentReminderEmailInfos is a slice of PaymentReminderEmailInfo
 type PaymentReminderEmailInfos []PaymentReminderEmailInfo
 
+// PaymentReminderEmailInfo contains payment reminder data for rendering a template
 type PaymentReminderEmailInfo struct {
 	ServiceMemberID      uuid.UUID   `db:"id"`
 	Email                *string     `db:"personal_email"`
@@ -65,6 +67,7 @@ type PaymentReminderEmailInfo struct {
 	Locator              string `db:"locator"`
 }
 
+// GetEmailInfo fetches payment email information
 func (m PaymentReminder) GetEmailInfo() (PaymentReminderEmailInfos, error) {
 	query := `SELECT sm.id as id, sm.personal_email as personal_email,
 	COALESCE(ppm.weight_estimate, 0) as weight_estimate,
@@ -190,6 +193,7 @@ func (m PaymentReminder) OnSuccess(PaymentReminderEmailInfo PaymentReminderEmail
 	}
 }
 
+// PaymentReminderEmailData is used to render an email template
 type PaymentReminderEmailData struct {
 	DestinationDutyStation string
 	WeightEstimate         string

--- a/pkg/notifications/move_reviewed.go
+++ b/pkg/notifications/move_reviewed.go
@@ -24,7 +24,8 @@ var (
 	moveReviewedRawTextTemplate = string(assets.MustAsset("pkg/notifications/templates/move_reviewed_template.txt"))
 	textTemplate                = text.Must(text.New("text_template").Parse(moveReviewedRawTextTemplate))
 	moveReviewedRawHTMLTemplate = string(assets.MustAsset("pkg/notifications/templates/move_reviewed_template.html"))
-	HTMLTemplate                = html.Must(html.New("text_template").Parse(moveReviewedRawHTMLTemplate))
+	// HTMLTemplate is a template for reviewed moves
+	HTMLTemplate = html.Must(html.New("text_template").Parse(moveReviewedRawHTMLTemplate))
 )
 
 // MoveReviewed has notification content for completed/reviewed moves
@@ -48,8 +49,10 @@ func NewMoveReviewed(db *pop.Connection, logger Logger, date time.Time) (*MoveRe
 	}, nil
 }
 
+// EmailInfos is a slice of email info
 type EmailInfos []EmailInfo
 
+// EmailInfo email information for rendering a template
 type EmailInfo struct {
 	ServiceMemberID    uuid.UUID `db:"id"`
 	Email              *string   `db:"personal_email"`
@@ -57,6 +60,7 @@ type EmailInfo struct {
 	NewDutyStationName string    `db:"new_duty_station_name"`
 }
 
+// GetEmailInfo retreives email information
 func (m MoveReviewed) GetEmailInfo(date time.Time) (EmailInfos, error) {
 	dateString := date.Format("2006-01-02")
 	query := `SELECT sm.id, sm.personal_email, dsn.name AS new_duty_station_name, dso.name AS duty_station_name

--- a/pkg/paperwork/generator.go
+++ b/pkg/paperwork/generator.go
@@ -47,6 +47,7 @@ type pdfCPUWrapper struct {
 	*pdfcpu.Configuration
 }
 
+// Merge merges files
 func (pcw pdfCPUWrapper) Merge(files []io.ReadSeeker, w io.Writer) error {
 	var rscs []io.ReadSeeker
 	for _, f := range files {
@@ -59,10 +60,12 @@ func (pcw pdfCPUWrapper) Merge(files []io.ReadSeeker, w io.Writer) error {
 	return api.Merge(rscs, w, pcw.Configuration)
 }
 
+// Validate validates the api configuration
 func (pcw pdfCPUWrapper) Validate(rs io.ReadSeeker) error {
 	return api.Validate(rs, pcw.Configuration)
 }
 
+// PDFLibrary is the PDF library interface
 type PDFLibrary interface {
 	Merge(rsc []io.ReadSeeker, w io.Writer) error
 	Validate(rs io.ReadSeeker) error
@@ -129,6 +132,7 @@ func (g *Generator) newTempFile() (afero.File, error) {
 	return outputFile, nil
 }
 
+// Cleanup removes filesystem working dir
 func (g *Generator) Cleanup() error {
 	return g.fs.RemoveAll(g.workDir)
 }
@@ -225,6 +229,7 @@ var contentTypeToImageType = map[string]string{
 	"image/png":  "PNG",
 }
 
+// ReduceUnusedSpace reduces unused space
 func ReduceUnusedSpace(file afero.File, g *Generator, contentType string) (imgFile afero.File, width float64, height float64, err error) {
 	// Figure out if the image should be rotated by calculating height and width of image.
 	pic, _, decodeErr := image.Decode(file)

--- a/pkg/paperwork/generator_test.go
+++ b/pkg/paperwork/generator_test.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"path/filepath"
 
 	"github.com/pdfcpu/pdfcpu/pkg/api"
 	"github.com/pdfcpu/pdfcpu/pkg/pdfcpu/validate"
@@ -21,9 +22,9 @@ func (suite *PaperworkSuite) sha256ForPath(path string, fs *afero.Afero) (string
 	var file afero.File
 	var err error
 	if fs != nil {
-		file, err = fs.Open(path)
+		file, err = fs.Open(filepath.Clean(path))
 	} else {
-		file, err = os.Open(path)
+		file, err = os.Open(filepath.Clean(path))
 	}
 	if err != nil {
 		suite.NoError(err)

--- a/pkg/paperwork/paperwork_test.go
+++ b/pkg/paperwork/paperwork_test.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/pkg/errors"
@@ -34,7 +35,7 @@ func (suite *PaperworkSuite) closeFile(file afero.File) {
 }
 
 func (suite *PaperworkSuite) openLocalFile(path string, fs *afero.Afero) (afero.File, error) {
-	file, err := os.Open(path)
+	file, err := os.Open(filepath.Clean(path))
 	if err != nil {
 		return nil, errors.Wrap(err, "could not open file")
 	}

--- a/pkg/parser/pricing/parse.go
+++ b/pkg/parser/pricing/parse.go
@@ -111,6 +111,7 @@ const xlsxSheetsCountMax int = 35
 type processXlsxSheet func(ParamConfig, int) (interface{}, error)
 type verifyXlsxSheet func(ParamConfig, int) error
 
+// XlsxDataSheetInfo is the xlsx data sheet info
 type XlsxDataSheetInfo struct {
 	Description    *string
 	ProcessMethods []xlsxProcessInfo
@@ -123,6 +124,7 @@ type xlsxProcessInfo struct {
 	adtlSuffix *string
 }
 
+// ParamConfig is the parameter conifguration
 type ParamConfig struct {
 	ProcessAll    bool
 	ShowOutput    bool
@@ -139,7 +141,7 @@ type ParamConfig struct {
 	ContractName  string
 }
 
-// InitDataSheetInfo: When adding new functions for parsing sheets, must add new XlsxDataSheetInfo
+// InitDataSheetInfo - When adding new functions for parsing sheets, must add new XlsxDataSheetInfo
 // defining the parse function
 //
 // The index MUST match the sheet that is being processed. Refer to file comments or XLSX to
@@ -315,6 +317,7 @@ func InitDataSheetInfo() []XlsxDataSheetInfo {
 	return xlsxDataSheets
 }
 
+// Parse will parsh xlsx data sheet info
 func Parse(xlsxDataSheets []XlsxDataSheetInfo, params ParamConfig, db *pop.Connection, logger Logger) error {
 	// Must be after processing config param
 	// Run the process function

--- a/pkg/parser/pricing/parse_test.go
+++ b/pkg/parser/pricing/parse_test.go
@@ -386,10 +386,10 @@ func (suite *PricingParserSuite) Test_removeFirstDollarSign() {
 
 func (suite *PricingParserSuite) helperTestExpectedFileOutput(goldenFilename string, currentOutputFilename string) {
 	expected := filepath.Join("fixtures", goldenFilename) // relative path
-	expectedBytes, err := ioutil.ReadFile(expected)
+	expectedBytes, err := ioutil.ReadFile(filepath.Clean(expected))
 	suite.NoErrorf(err, "error loading expected CSV file output fixture <%s>", expected)
 
-	currentBytes, err := ioutil.ReadFile(currentOutputFilename) // relative path
+	currentBytes, err := ioutil.ReadFile(filepath.Clean(currentOutputFilename)) // relative path
 	suite.NoErrorf(err, "error loading current/new output file <%s>", currentOutputFilename)
 
 	suite.Equal(string(expectedBytes), string(currentBytes))

--- a/pkg/payment_request/payment_request_helper.go
+++ b/pkg/payment_request/payment_request_helper.go
@@ -2,6 +2,7 @@ package paymentrequest
 
 import "github.com/gobuffalo/pop"
 
+// RequestPaymentHelper is a helper to connect to the DB
 type RequestPaymentHelper struct {
 	DB *pop.Connection
 }

--- a/pkg/payment_request/service_param_list_fetcher.go
+++ b/pkg/payment_request/service_param_list_fetcher.go
@@ -8,6 +8,7 @@ import (
 	"github.com/transcom/mymove/pkg/models"
 )
 
+// FetchServiceParamList fetches the service param list
 func (p *RequestPaymentHelper) FetchServiceParamList(mtoServiceID uuid.UUID) (models.ServiceParams, error) {
 	mtoServiceItem := models.MTOServiceItem{}
 	serviceParams := models.ServiceParams{}

--- a/pkg/payment_request/service_param_list_valid.go
+++ b/pkg/payment_request/service_param_list_valid.go
@@ -4,6 +4,7 @@ import (
 	"github.com/transcom/mymove/pkg/models"
 )
 
+// ValidServiceParamList validates service params
 func (p *RequestPaymentHelper) ValidServiceParamList(mtoServiceItem models.MTOServiceItem, serviceParams models.ServiceParams, paymentServiceItemParams models.PaymentServiceItemParams) (bool, string) {
 	var errorString string
 	hasError := false

--- a/pkg/payment_request/service_param_value_lookups/distance_zip3_lookup.go
+++ b/pkg/payment_request/service_param_value_lookups/distance_zip3_lookup.go
@@ -1,5 +1,6 @@
 package serviceparamvaluelookups
 
+// DistanceZip3Lookup contains zip3 lookup
 type DistanceZip3Lookup struct {
 }
 

--- a/pkg/payment_request/service_param_value_lookups/requested_pickup_date_lookup.go
+++ b/pkg/payment_request/service_param_value_lookups/requested_pickup_date_lookup.go
@@ -1,5 +1,6 @@
 package serviceparamvaluelookups
 
+// RequestedPickupDateLookup does lookup on requested pickup date
 type RequestedPickupDateLookup struct {
 }
 

--- a/pkg/payment_request/service_param_value_lookups/service_area_origin_lookup.go
+++ b/pkg/payment_request/service_param_value_lookups/service_area_origin_lookup.go
@@ -1,5 +1,6 @@
 package serviceparamvaluelookups
 
+// ServiceAreaOriginLookup does lookup on service area origin
 type ServiceAreaOriginLookup struct {
 }
 

--- a/pkg/payment_request/service_param_value_lookups/service_param_value_lookups.go
+++ b/pkg/payment_request/service_param_value_lookups/service_param_value_lookups.go
@@ -8,6 +8,7 @@ import (
 	"github.com/transcom/mymove/pkg/gen/primemessages"
 )
 
+// ServiceItemParamKeyData contains service item parameter keys
 type ServiceItemParamKeyData struct {
 	lookups            map[string]ServiceItemParamKeyLookup
 	PayloadServiceItem primemessages.ServiceItem
@@ -16,10 +17,12 @@ type ServiceItemParamKeyData struct {
 	MoveTaskOrderID    uuid.UUID
 }
 
+// ServiceItemParamKeyLookup does lookup on service item parameter keys
 type ServiceItemParamKeyLookup interface {
 	lookup(keyData *ServiceItemParamKeyData) (string, error)
 }
 
+// ServiceParamLookupInitialize initializes service parameter lookup
 func ServiceParamLookupInitialize(
 	mtoServiceItemID uuid.UUID,
 	paymentRequestID uuid.UUID,
@@ -45,6 +48,7 @@ func ServiceParamLookupInitialize(
 	return &s
 }
 
+// ServiceParamValue returns a service parameter value from a key
 func (s *ServiceItemParamKeyData) ServiceParamValue(key string) (string, error) {
 	if lookup, ok := s.lookups[key]; ok {
 		value, err := lookup.lookup(s)

--- a/pkg/payment_request/service_param_value_lookups/weight_actual_lookup.go
+++ b/pkg/payment_request/service_param_value_lookups/weight_actual_lookup.go
@@ -1,5 +1,6 @@
 package serviceparamvaluelookups
 
+// WeightActualLookup is the weight actual lookup
 type WeightActualLookup struct {
 }
 

--- a/pkg/payment_request/service_param_value_lookups/weight_billed_actual_lookup.go
+++ b/pkg/payment_request/service_param_value_lookups/weight_billed_actual_lookup.go
@@ -1,5 +1,6 @@
 package serviceparamvaluelookups
 
+// WeightBilledActualLookup is the weight billed actual lookup
 type WeightBilledActualLookup struct {
 }
 

--- a/pkg/payment_request/service_param_value_lookups/weight_estimated_lookup.go
+++ b/pkg/payment_request/service_param_value_lookups/weight_estimated_lookup.go
@@ -1,5 +1,6 @@
 package serviceparamvaluelookups
 
+// WeightEstimatedLookup is the weight estimated lookup
 type WeightEstimatedLookup struct {
 }
 

--- a/pkg/payment_request/service_param_value_lookups/zip_dest_address_lookup.go
+++ b/pkg/payment_request/service_param_value_lookups/zip_dest_address_lookup.go
@@ -1,5 +1,6 @@
 package serviceparamvaluelookups
 
+// ZipDestAddressLookup does zip destination address lookup
 type ZipDestAddressLookup struct {
 }
 

--- a/pkg/payment_request/service_param_value_lookups/zip_pickup_address_lookup.go
+++ b/pkg/payment_request/service_param_value_lookups/zip_pickup_address_lookup.go
@@ -1,5 +1,6 @@
 package serviceparamvaluelookups
 
+// ZipPickupAddressLookup does zip pickup address lookup
 type ZipPickupAddressLookup struct {
 }
 

--- a/pkg/rateengine/rateengine.go
+++ b/pkg/rateengine/rateengine.go
@@ -199,7 +199,7 @@ func (re *RateEngine) computePPMIncludingLHDiscount(weight unit.Pound, originZip
 	return cost, nil
 }
 
-//ComputeLowestCostPPMove uses zip codes to make two calculations for the price of a PPM move - once with the pickup zip and once with the current duty station zip - and returns the lowest cost move.
+// ComputeLowestCostPPMMove uses zip codes to make two calculations for the price of a PPM move - once with the pickup zip and once with the current duty station zip - and returns the lowest cost move.
 func (re *RateEngine) ComputeLowestCostPPMMove(weight unit.Pound, originPickupZip5 string, originDutyStationZip5 string, destinationZip5 string, distanceMilesFromOriginPickupZip int, distanceMilesFromOriginDutyStationZip int, date time.Time, daysInSit int) (cost CostComputation, err error) {
 	costFromOriginPickupZip, err := re.computePPMIncludingLHDiscount(
 		weight,

--- a/pkg/route/errors.go
+++ b/pkg/route/errors.go
@@ -144,6 +144,7 @@ type shortHaulError struct {
 	routingInfo string
 }
 
+// NewShortHaulError is the new short haul error
 func NewShortHaulError(source LatLong, dest LatLong, moveDistance int) Error {
 	return &shortHaulError{
 		baseError{ShortHaulError},

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -81,12 +81,14 @@ func (s *NamedServer) ListenAndServeTLS() error {
 	return s.Serve(listener)
 }
 
+// IsReady returns if a server is ready
 func (s *NamedServer) IsReady() bool {
 	s.IsServerReadyMutex.Lock()
 	defer s.IsServerReadyMutex.Unlock()
 	return s.IsServerReady
 }
 
+// WaitUntilReady waits until the server is ready
 func (s *NamedServer) WaitUntilReady() {
 	times := 0
 	// Wait for server to be ready

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -39,7 +40,7 @@ func (suite *serverSuite) readFile(filename string) []byte {
 	testDataDir := "testdata"
 	filePath := strings.Join([]string{testDataDir, filename}, "/")
 
-	contents, err := ioutil.ReadFile(filePath)
+	contents, err := ioutil.ReadFile(filepath.Clean(filePath))
 	if err != nil {
 		suite.T().Fatalf("failed to read file %s: %s", filename, err)
 	}

--- a/pkg/services/accesscode.go
+++ b/pkg/services/accesscode.go
@@ -27,6 +27,7 @@ type AccessCodeClaimer interface {
 	ClaimAccessCode(code string, serviceMemberID uuid.UUID) (*models.AccessCode, *validate.Errors, error)
 }
 
+// OfficeAccessCodes is a slice of access codes for the office
 type OfficeAccessCodes []adminmessages.AccessCode
 
 // AccessCodeListFetcher is the service object interface for FetchAccessCodeList

--- a/pkg/services/admin_user/admin_user_creator.go
+++ b/pkg/services/admin_user/admin_user_creator.go
@@ -11,6 +11,7 @@ type adminUserCreator struct {
 	builder adminUserQueryBuilder
 }
 
+// CreateAdminUser creates admin user
 func (o *adminUserCreator) CreateAdminUser(user *models.AdminUser, organizationIDFilter []services.QueryFilter) (*models.AdminUser, *validate.Errors, error) {
 	// Use FetchOne to see if we have an organization that matches the provided id
 	var organization models.Organization
@@ -28,6 +29,7 @@ func (o *adminUserCreator) CreateAdminUser(user *models.AdminUser, organizationI
 	return user, nil, nil
 }
 
+// NewAdminUserCreator returns a new admin user creator builder
 func NewAdminUserCreator(builder adminUserQueryBuilder) services.AdminUserCreator {
 	return &adminUserCreator{builder}
 }

--- a/pkg/services/admin_user/admin_user_updater.go
+++ b/pkg/services/admin_user/admin_user_updater.go
@@ -43,6 +43,7 @@ func (o *adminUserUpdater) UpdateAdminUser(id uuid.UUID, payload *adminmessages.
 	return &foundUser, nil, nil
 }
 
+// NewAdminUserUpdater returns a new admin user updater builder
 func NewAdminUserUpdater(builder adminUserQueryBuilder) services.AdminUserUpdater {
 	return &adminUserUpdater{builder}
 }

--- a/pkg/services/audit/audit.go
+++ b/pkg/services/audit/audit.go
@@ -17,6 +17,7 @@ import (
 	"github.com/transcom/mymove/pkg/auth"
 )
 
+// Capture captures an audit record
 func Capture(model interface{}, payload interface{}, logger Logger, session *auth.Session, request *http.Request) ([]zap.Field, error) {
 	var logItems []zap.Field
 	eventType := extractEventType(request)

--- a/pkg/services/duty_stations/load_duty_stations.go
+++ b/pkg/services/duty_stations/load_duty_stations.go
@@ -22,6 +22,7 @@ import (
 const hereRequestTimeout = time.Duration(15) * time.Second
 
 const (
+	// InsertTemplate is the query insert template for duty stations
 	InsertTemplate string = `
 	{{range .}}
 INSERT INTO addresses (id, street_address_1, city, state, postal_code, created_at, updated_at, country) VALUES ('{{.AddressID}}', 'N/A', '{{.Address.City}}', '{{.Address.State}}', '{{.Address.PostalCode}}', now(), now(), 'United States');
@@ -29,6 +30,7 @@ INSERT INTO duty_stations (id, name, affiliation, address_id, created_at, update
 	{{end}}`
 )
 
+// DutyStationMigration represents a duty station migration
 type DutyStationMigration struct {
 	Address       models.Address
 	To            models.TransportationOffice
@@ -37,6 +39,7 @@ type DutyStationMigration struct {
 	DutyStationID uuid.UUID
 }
 
+// StationData represents Duty Station data
 type StationData struct {
 	Unit string
 	Name string
@@ -146,6 +149,7 @@ func (b *MigrationBuilder) nearestTransportationOffice(address models.Address) (
 	return to, nil
 }
 
+// Build builds a migration for loading duty stations
 func (b *MigrationBuilder) Build(dutyStationsFilePath string) ([]DutyStationMigration, error) {
 	stations, err := b.ParseStations(dutyStationsFilePath)
 	if err != nil {

--- a/pkg/services/duty_stations/load_duty_stations.go
+++ b/pkg/services/duty_stations/load_duty_stations.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"time"
@@ -46,7 +47,7 @@ type StationData struct {
 func (b MigrationBuilder) ParseStations(filename string) ([]StationData, error) {
 	var stations []StationData
 
-	csvFile, err := os.Open(filename)
+	csvFile, err := os.Open(filepath.Clean(filename))
 	if err != nil {
 		fmt.Println(err)
 		return stations, err

--- a/pkg/services/electronic_order/electronic_order_category_count_fetcher.go
+++ b/pkg/services/electronic_order/electronic_order_category_count_fetcher.go
@@ -22,7 +22,7 @@ func (o *electronicOrderCategoricalCountsFetcher) FetchElectronicOrderCategorica
 	return counts, nil
 }
 
-// NewElectronicOrderListFetcher returns an implementation of OrdersListFetcher
+// NewElectronicOrdersCategoricalCountsFetcher returns an implementation of OrdersListFetcher
 func NewElectronicOrdersCategoricalCountsFetcher(builder electronicOrderCategoricalCountQueryBuilder) services.ElectronicOrderCategoryCountFetcher {
 	return &electronicOrderCategoricalCountsFetcher{builder}
 }

--- a/pkg/services/ghcimport/fixtures/20191101201107_create-re-services-table-with-values.up.sql
+++ b/pkg/services/ghcimport/fixtures/20191101201107_create-re-services-table-with-values.up.sql
@@ -1,0 +1,37 @@
+INSERT INTO re_services
+(id, code, name, created_at, updated_at)
+VALUES
+('1130e612-94eb-49a7-973d-72f33685e551', 'SMSR', 'Shipment Mgmt Services', now(), now()),
+('9dc919da-9b66-407b-9f17-05c0f03fcb50', 'COSR', 'Counseling Services', now(), now()),
+('8d600f25-1def-422d-b159-617c7d59156e', 'DLH', 'Dom. Linehaul', now(), now()),
+('4b85962e-25d3-4485-b43c-2497c4365598', 'DSH', 'Dom. Shorthaul', now(), now()),
+('2bc3e5cb-adef-46b1-bde9-55570bfdd43e', 'DODP', 'Dom. O/D Price', now(), now()),
+('998beda7-e390-4a83-b15e-578a24326937', 'DFSIT', 'Dom. O/D 1st Day SIT', now(), now()),
+('05eb6ff1-5cf6-4918-b887-8260dda6b9fe', 'DASIT', 'Dom. O/D Add''l SIT', now(), now()),
+('d1a4f062-0ca3-4387-8f8e-3dd20493d0b7', 'DSPD', 'Dom. SIT Pickup/Delivery', now(), now()),
+('bdea5a8d-f15f-47d2-85c9-bba5694802ce', 'DPK', 'Dom. Packing', now(), now()),
+('15f01bc1-0754-4341-8e0f-25c8f04d5a77', 'DUP', 'Dom. Unpacking', now(), now()),
+('68417bd7-4a9d-4472-941e-2ba6aeaf15f4', 'DCRT', 'Dom. Crating', now(), now()),
+('fc14935b-ebd3-4df3-940b-f30e71b6a56c', 'DUCR', 'Dom. Uncrating', now(), now()),
+('d979e8af-501a-44bb-8532-2799753a5810', 'DSSR', 'Dom. Shuttle Service', now(), now()),
+('56bb94cd-f160-4239-a028-b31ffc641eb7', 'IOOLH', 'Int''l O->O Shipping & LH', now(), now()),
+('133bc44a-2c0f-4ff9-a61d-9f2dad349d14', 'IOOUB', 'Int''l O->O UB', now(), now()),
+('07051352-4715-49b5-88e7-045b7541919d', 'ICOLH', 'Int''l C->O Shipping & LH', now(), now()),
+('16949697-6171-47aa-bcd4-479995cc5206', 'ICOUB', 'Int''l C->O UB', now(), now()),
+('d0bb2cae-838a-4fc7-8efc-f7c6ad57431d', 'IOCLH', 'Int''l O->C Shipping & LH', now(), now()),
+('7f14f357-f2ae-42b9-b834-5ab24c2cd2af', 'IOCUB', 'Int''l O->C UB', now(), now()),
+('67ba1eaf-6ffd-49de-9a69-497be7789877', 'IHPK', 'Int''l HHG Pack', now(), now()),
+('56e91c2d-015d-4243-9657-3ed34867abaa', 'IHUP', 'Int''l HHG Unpack', now(), now()),
+('ae84d292-f885-4138-86e2-b451855ffbf2', 'IUBPK', 'Int''l UB Pack', now(), now()),
+('f2739142-97d1-40f3-a8f4-6a9daf390806', 'IUBUP', 'Int''l UB Unpack', now(), now()),
+('b488bf85-ea5e-49c8-ba5c-e2fa278ac806', 'IFSIT', 'Int''l 1st Day SIT', now(), now()),
+('bd424e45-397b-4766-9712-de4ae3a2da36', 'IASIT', 'Int''l Add''l Day SIT', now(), now()),
+('6f4f6e31-0675-4051-b659-89832259f390', 'ISPD', 'Int''l SIT Pickup / Delivery', now(), now()),
+('86203d72-7f7c-49ff-82f0-5b95e4958f60', 'ICRT', 'Int''l. Crating', now(), now()),
+('4132416b-b1aa-42e7-98f2-0ac0a03e8a31', 'IUCR', 'Int''l. Uncrating', now(), now()),
+('624a97c5-dfbf-4da9-a6e9-526b4f95af8d', 'ISSR', 'Int''l. Shuttle Service', now(), now()),
+('7e1c4f99-0054-4fac-a302-1a07a1daf58e', 'NSTH', 'NonStd HHG', now(), now()),
+('a68fa051-b09d-43f3-8290-f56fc89a4fe8', 'NSTUB', 'NonStd UB', now(), now());
+
+
+

--- a/pkg/services/ghcimport/fixtures/20191126160639_update-and-add-values-for-reservices-table.up.sql
+++ b/pkg/services/ghcimport/fixtures/20191126160639_update-and-add-values-for-reservices-table.up.sql
@@ -1,0 +1,47 @@
+UPDATE re_services SET code = 'MS', name = 'Shipment Mgmt. Services', updated_at = now() WHERE id = '1130e612-94eb-49a7-973d-72f33685e551';
+UPDATE re_services SET code = 'CS', updated_at = now() WHERE id = '9dc919da-9b66-407b-9f17-05c0f03fcb50';
+UPDATE re_services SET code = 'DOP', name = 'Dom. Origin Price', updated_at = now() WHERE id = '2bc3e5cb-adef-46b1-bde9-55570bfdd43e';
+UPDATE re_services SET code = 'DOFSIT', name = 'Dom. Origin 1st Day SIT', updated_at = now() WHERE id = '998beda7-e390-4a83-b15e-578a24326937';
+UPDATE re_services SET code = 'DOASIT', name = 'Dom. Origin Add''l SIT', updated_at = now() WHERE id = '05eb6ff1-5cf6-4918-b887-8260dda6b9fe';
+UPDATE re_services SET code = 'DOPSIT', name = 'Dom. Origin SIT Pickup', updated_at = now() WHERE id = 'd1a4f062-0ca3-4387-8f8e-3dd20493d0b7';
+UPDATE re_services SET code = 'DUPK', updated_at = now() WHERE id = '15f01bc1-0754-4341-8e0f-25c8f04d5a77';
+UPDATE re_services SET code = 'DUCRT', updated_at = now() WHERE id = 'fc14935b-ebd3-4df3-940b-f30e71b6a56c';
+UPDATE re_services SET code = 'DOSHUT', name = 'Dom. Origin Shuttle Service', updated_at = now() WHERE id = 'd979e8af-501a-44bb-8532-2799753a5810';
+UPDATE re_services SET name = 'Int''l. O->O Shipping & LH', updated_at = now() WHERE id = '56bb94cd-f160-4239-a028-b31ffc641eb7';
+UPDATE re_services SET name = 'Int''l. O->O UB', updated_at = now() WHERE id = '133bc44a-2c0f-4ff9-a61d-9f2dad349d14';
+UPDATE re_services SET name = 'Int''l. C->O Shipping & LH', updated_at = now() WHERE id = '07051352-4715-49b5-88e7-045b7541919d';
+UPDATE re_services SET name = 'Int''l. C->O UB', updated_at = now() WHERE id = '16949697-6171-47aa-bcd4-479995cc5206';
+UPDATE re_services SET name = 'Int''l. O->C Shipping & LH', updated_at = now() WHERE id = 'd0bb2cae-838a-4fc7-8efc-f7c6ad57431d';
+UPDATE re_services SET name = 'Int''l. O->C UB', updated_at = now() WHERE id = '7f14f357-f2ae-42b9-b834-5ab24c2cd2af';
+UPDATE re_services SET name = 'Int''l. HHG Pack', updated_at = now() WHERE id = '67ba1eaf-6ffd-49de-9a69-497be7789877';
+UPDATE re_services SET code = 'IHUPK', name = 'Int''l. HHG Unpack', updated_at = now() WHERE id = '56e91c2d-015d-4243-9657-3ed34867abaa';
+UPDATE re_services SET name = 'Int''l. UB Pack', updated_at = now() WHERE id = 'ae84d292-f885-4138-86e2-b451855ffbf2';
+UPDATE re_services SET code = 'IUBUPK', name = 'Int''l. UB Unpack', updated_at = now() WHERE id = 'f2739142-97d1-40f3-a8f4-6a9daf390806';
+UPDATE re_services SET code = 'IOFSIT', name = 'Int''l. Origin 1st Day SIT', updated_at = now() WHERE id = 'b488bf85-ea5e-49c8-ba5c-e2fa278ac806';
+UPDATE re_services SET code = 'IOASIT', name = 'Int''l. Origin Add''l Day SIT', updated_at = now() WHERE id = 'bd424e45-397b-4766-9712-de4ae3a2da36';
+UPDATE re_services SET code = 'IOPSIT', name = 'Int''l. Origin SIT Pickup', updated_at = now() WHERE id = '6f4f6e31-0675-4051-b659-89832259f390';
+UPDATE re_services SET code = 'IUCRT', updated_at = now() WHERE id = '4132416b-b1aa-42e7-98f2-0ac0a03e8a31';
+UPDATE re_services SET code = 'IOSHUT', name = 'Int''l. Origin Shuttle Service', updated_at = now() WHERE id = '624a97c5-dfbf-4da9-a6e9-526b4f95af8d';
+UPDATE re_services SET name = 'NonStd. HHG', updated_at = now() WHERE id = '7e1c4f99-0054-4fac-a302-1a07a1daf58e';
+UPDATE re_services SET name = 'NonStd. UB', updated_at = now() WHERE id = 'a68fa051-b09d-43f3-8290-f56fc89a4fe8';
+
+INSERT INTO re_services
+(id, code, name, created_at, updated_at)
+VALUES
+('50f1179a-3b72-4fa1-a951-fe5bcc70bd14', 'DDP', 'Dom. Destination Price', now(), now()),
+('d0561c49-e1a9-40b8-a739-3e639a9d77af', 'DDFSIT', 'Dom. Destination 1st Day SIT', now(), now()),
+('a0ead168-7469-4cb6-bc5b-2ebef5a38f92', 'DDASIT', 'Dom. Destination Add''l SIT', now(), now()),
+('5c80f3b5-548e-4077-9b8e-8d0390e73668', 'DDDSIT', 'Dom. Destination SIT Delivery', now(), now()),
+('556663e3-675a-4b06-8da3-e4f1e9a9d3cd', 'DDSHUT', 'Dom. Destination Shuttle Service', now(), now()),
+('bd6064ca-e780-4ab4-a37b-0ae98eebb244', 'IDFSIT', 'Int''l. Destination 1st Day SIT', now(), now()),
+('806c6d59-57ff-4a3f-9518-ebf29ba9cb10', 'IDASIT', 'Int''l. Destination Add''l Day SIT', now(), now()),
+('28389ee1-56cf-400c-aa52-1501ecdd7c69', 'IDDSIT', 'Int''l. Destination SIT Delivery', now(), now()),
+('22fc07ed-be15-4f50-b941-cbd38153b378', 'IDSHUT', 'Int''l. Destination Shuttle Service', now(), now()),
+('4780b30c-e846-437a-b39a-c499a6b09872', 'FSC', 'Fuel Surcharge', now(), now()),
+('dbd3a39a-6bb9-42da-b81a-9229df7019cf', 'DMHF', 'Dom. Mobile Home Factor', now(), now()),
+('0e45b6f5-f2f5-4235-94e4-7b4cb899eb5d', 'DBTF', 'Dom. Tow Away Boat Factor', now(), now()),
+('2471cc2d-6ed5-4ecc-9d43-db9711c8645b', 'DBHF', 'Dom. Haul Away Boat Factor', now(), now()),
+('20998cfd-bfc7-410b-a3c5-d709ead4f94e', 'IBTF', 'Int’l. Tow Away Boat Factor', now(), now()),
+('387b9654-5685-4ac9-b213-81962be9c145', 'IBHF', 'Int’l. Haul Away Boat Factor', now(), now()),
+('3cc83af7-ecb9-4b33-bbc6-ff1459f001e2', 'DNPKF', 'Dom. NTS Packing Factor', now(), now()),
+('874cb86a-bc39-4f57-a614-53ee3fcacf14', 'INPKF', 'Int’l. NTS Packing Factor', now(), now());

--- a/pkg/services/ghcimport/ghc_rateengine_importer.go
+++ b/pkg/services/ghcimport/ghc_rateengine_importer.go
@@ -7,6 +7,7 @@ import (
 	"github.com/gofrs/uuid"
 )
 
+// GHCRateEngineImporter is the rate engine importer for GHC
 type GHCRateEngineImporter struct {
 	Logger       Logger
 	ContractCode string
@@ -109,6 +110,7 @@ func (gre *GHCRateEngineImporter) runImports(dbTx *pop.Connection) error {
 	return nil
 }
 
+// Import runs the import
 func (gre *GHCRateEngineImporter) Import(db *pop.Connection) error {
 	err := db.Transaction(func(connection *pop.Connection) error {
 		dbTxError := gre.runImports(connection)

--- a/pkg/services/ghcimport/ghc_rateengine_importer_test.go
+++ b/pkg/services/ghcimport/ghc_rateengine_importer_test.go
@@ -62,7 +62,7 @@ func (suite *GHCRateEngineImportSuite) TearDownSuite() {
 func (suite *GHCRateEngineImportSuite) helperSetupStagingTables() {
 	fmt.Print("Importing stage data...")
 	path := filepath.Join("fixtures", "stage_ghc_pricing.sql")
-	c, ioErr := ioutil.ReadFile(path)
+	c, ioErr := ioutil.ReadFile(filepath.Clean(path))
 	suite.NoError(ioErr)
 
 	sql := string(c)
@@ -74,16 +74,16 @@ func (suite *GHCRateEngineImportSuite) helperSetupStagingTables() {
 
 func (suite *GHCRateEngineImportSuite) helperSetupReServicesTable() {
 	fmt.Print("Importing re_services data...")
-	path := filepath.Join("../../../migrations/app/schema", "20191101201107_create-re-services-table-with-values.up.sql")
-	c, ioErr := ioutil.ReadFile(path)
+	path := filepath.Join("./fixtures", "20191101201107_create-re-services-table-with-values.up.sql")
+	c, ioErr := ioutil.ReadFile(filepath.Clean(path))
 	suite.NoError(ioErr)
 
 	sql := string(c)
 	err := suite.DB().RawQuery(sql).Exec()
 	if suite.NoError(err) {
 		// read second migration
-		path = filepath.Join("../../../migrations/app/schema", "20191126160639_update-and-add-values-for-reservices-table.up.sql")
-		c, ioErr = ioutil.ReadFile(path)
+		path = filepath.Join("./fixtures", "20191126160639_update-and-add-values-for-reservices-table.up.sql")
+		c, ioErr = ioutil.ReadFile(filepath.Clean(path))
 		suite.NoError(ioErr)
 
 		sql := string(c)

--- a/pkg/services/ghcimport/import_re_domestic_other_prices.go
+++ b/pkg/services/ghcimport/import_re_domestic_other_prices.go
@@ -10,6 +10,7 @@ import (
 	"github.com/transcom/mymove/pkg/unit"
 )
 
+// DomOtherPriceToInsert is the domestic other price to insert
 type DomOtherPriceToInsert struct {
 	model   models.ReDomesticOtherPrice
 	message string

--- a/pkg/services/ghcrateengine/domestic_shorthaul_pricer.go
+++ b/pkg/services/ghcrateengine/domestic_shorthaul_pricer.go
@@ -14,7 +14,7 @@ import (
 	"github.com/transcom/mymove/pkg/unit"
 )
 
-// NewDomesticServiceAreaPricer is the public constructor for a DomesticRateAreaPricer using Pop
+// NewDomesticShorthaulPricer is the public constructor for a DomesticRateAreaPricer using Pop
 func NewDomesticShorthaulPricer(db *pop.Connection, logger Logger, contractCode string) services.DomesticShorthaulPricer {
 	return &domesticShorthaulPricer{
 		db:           db,
@@ -30,6 +30,7 @@ type domesticShorthaulPricer struct {
 	contractCode string
 }
 
+// PriceDomesticShorthaul does a pricing for domestic short haul
 func (dsh *domesticShorthaulPricer) PriceDomesticShorthaul(moveDate time.Time, distance unit.Miles, weight unit.Pound, serviceArea string) (totalCost unit.Cents, err error) {
 	// Validate parameters
 	if moveDate.IsZero() {

--- a/pkg/services/invoice/invoice_upload_updater_test.go
+++ b/pkg/services/invoice/invoice_upload_updater_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 
 	"github.com/gofrs/uuid"
 	"github.com/pkg/errors"
@@ -22,7 +23,7 @@ import (
 func (suite *InvoiceServiceSuite) openLocalFile(path string) (afero.File, error) {
 	var fs = afero.NewMemMapFs()
 
-	file, err := os.Open(path)
+	file, err := os.Open(filepath.Clean(path))
 	if err != nil {
 		suite.logger.Fatal("Error opening local file", zap.Error(err))
 	}

--- a/pkg/services/move_documents/generic_move_document_updater.go
+++ b/pkg/services/move_documents/generic_move_document_updater.go
@@ -12,12 +12,13 @@ import (
 	"github.com/transcom/mymove/pkg/unit"
 )
 
+// GenericUpdater is a genertic document updater
 type GenericUpdater struct {
 	db *pop.Connection
 	moveDocumentStatusUpdater
 }
 
-//Update updates the generic (non-special case) move documents
+// Update updates the generic (non-special case) move documents
 func (gu GenericUpdater) Update(moveDocumentPayload *internalmessages.MoveDocumentPayload, moveDoc *models.MoveDocument, session *auth.Session) (*models.MoveDocument, *validate.Errors, error) {
 	returnVerrs := validate.NewErrors()
 	newType := models.MoveDocumentType(moveDocumentPayload.MoveDocumentType)

--- a/pkg/services/move_documents/ppm_completer.go
+++ b/pkg/services/move_documents/ppm_completer.go
@@ -13,12 +13,13 @@ import (
 	"github.com/transcom/mymove/pkg/models"
 )
 
+// PPMCompleter completes PPMs
 type PPMCompleter struct {
 	db *pop.Connection
 	moveDocumentStatusUpdater
 }
 
-//Update moves ppm status to complete when ssw is uploaded
+// Update moves ppm status to complete when ssw is uploaded
 func (ppmc PPMCompleter) Update(moveDocumentPayload *internalmessages.MoveDocumentPayload, moveDoc *models.MoveDocument, session *auth.Session) (*models.MoveDocument, *validate.Errors, error) {
 	returnVerrs := validate.NewErrors()
 	newType := models.MoveDocumentType(moveDocumentPayload.MoveDocumentType)

--- a/pkg/services/move_documents/storage_expense_updater.go
+++ b/pkg/services/move_documents/storage_expense_updater.go
@@ -15,12 +15,13 @@ import (
 	"github.com/transcom/mymove/pkg/unit"
 )
 
+// StorageExpenseUpdater updates storage expenses
 type StorageExpenseUpdater struct {
 	db *pop.Connection
 	moveDocumentStatusUpdater
 }
 
-//Update updates the storage expense documents
+// Update updates the storage expense documents
 func (seu StorageExpenseUpdater) Update(moveDocumentPayload *internalmessages.MoveDocumentPayload, moveDoc *models.MoveDocument, session *auth.Session) (*models.MoveDocument, *validate.Errors, error) {
 	returnVerrs := validate.NewErrors()
 	newType := models.MoveDocumentType(moveDocumentPayload.MoveDocumentType)

--- a/pkg/services/move_documents/weight_ticket_updater.go
+++ b/pkg/services/move_documents/weight_ticket_updater.go
@@ -14,12 +14,13 @@ import (
 	"github.com/transcom/mymove/pkg/unit"
 )
 
+// WeightTicketUpdater updates weight tickets
 type WeightTicketUpdater struct {
 	db *pop.Connection
 	moveDocumentStatusUpdater
 }
 
-//Update updates the weight ticket documents
+// Update updates the weight ticket documents
 func (wtu WeightTicketUpdater) Update(moveDocumentPayload *internalmessages.MoveDocumentPayload, moveDoc *models.MoveDocument, session *auth.Session) (*models.MoveDocument, *validate.Errors, error) {
 	returnVerrs := validate.NewErrors()
 	newType := models.MoveDocumentType(moveDocumentPayload.MoveDocumentType)

--- a/pkg/services/move_order/move_order_fetcher.go
+++ b/pkg/services/move_order/move_order_fetcher.go
@@ -17,6 +17,7 @@ type ErrNotFound struct {
 	id uuid.UUID
 }
 
+// Error is the string representation of an error
 func (e ErrNotFound) Error() string {
 	return fmt.Sprintf("move task order id: %s not found", e.id.String())
 }
@@ -32,6 +33,7 @@ type ErrInvalidInput struct {
 	errInvalidInput
 }
 
+// NewErrInvalidInput creates a new error for invalid input
 func NewErrInvalidInput(id uuid.UUID, err error, validationErrors map[string][]string) ErrInvalidInput {
 	return ErrInvalidInput{
 		errInvalidInput{
@@ -42,10 +44,12 @@ func NewErrInvalidInput(id uuid.UUID, err error, validationErrors map[string][]s
 	}
 }
 
+// Error is the string representation of an error
 func (e ErrInvalidInput) Error() string {
 	return fmt.Sprintf("invalid input for move task order id: %s. %s", e.id.String(), e.InvalidFields())
 }
 
+// InvalidFields returns invalid fields for invalid input
 func (e ErrInvalidInput) InvalidFields() map[string]string {
 	es := make(map[string]string)
 	if e.validationErrors == nil {

--- a/pkg/services/move_task_order/move_task_order_fetcher.go
+++ b/pkg/services/move_task_order/move_task_order_fetcher.go
@@ -17,6 +17,7 @@ type ErrNotFound struct {
 	id uuid.UUID
 }
 
+// Error is the string representation of an error
 func (e ErrNotFound) Error() string {
 	return fmt.Sprintf("move task order id: %s not found", e.id.String())
 }
@@ -27,11 +28,12 @@ type errInvalidInput struct {
 	validationErrors map[string][]string
 }
 
-//ErrInvalidInput is returned when an update to a move task order fails a validation rule
+// ErrInvalidInput is returned when an update to a move task order fails a validation rule
 type ErrInvalidInput struct {
 	errInvalidInput
 }
 
+// NewErrInvalidInput returns a new error for invalid input
 func NewErrInvalidInput(id uuid.UUID, err error, validationErrors map[string][]string) ErrInvalidInput {
 	return ErrInvalidInput{
 		errInvalidInput{
@@ -42,10 +44,12 @@ func NewErrInvalidInput(id uuid.UUID, err error, validationErrors map[string][]s
 	}
 }
 
+// Error is the string representation of an error
 func (e ErrInvalidInput) Error() string {
 	return fmt.Sprintf("invalid input for move task order id: %s. %s", e.id.String(), e.InvalidFields())
 }
 
+// InvalidFields returns invalid fields for invalid input
 func (e ErrInvalidInput) InvalidFields() map[string]string {
 	es := make(map[string]string)
 	if e.validationErrors == nil {
@@ -138,7 +142,7 @@ type moveTaskOrderStatusUpdater struct {
 	moveTaskOrderFetcher
 }
 
-// NewMoveTaskOrderFetcher creates a new struct with the service dependencies
+// NewMoveTaskOrderStatusUpdater creates a new struct with the service dependencies
 func NewMoveTaskOrderStatusUpdater(db *pop.Connection) services.MoveTaskOrderStatusUpdater {
 	return &moveTaskOrderStatusUpdater{db, moveTaskOrderFetcher{db}}
 }

--- a/pkg/services/mto_service_item/mto_service_item_creator.go
+++ b/pkg/services/mto_service_item/mto_service_item_creator.go
@@ -15,6 +15,7 @@ type mtoServiceItemCreator struct {
 	builder createMTOServiceItemQueryBuilder
 }
 
+// CreateMTOServiceItem creates an MTO Service Item
 func (o *mtoServiceItemCreator) CreateMTOServiceItem(serviceItem *models.MTOServiceItem) (*models.MTOServiceItem, *validate.Errors, error) {
 	verrs, err := o.builder.CreateOne(serviceItem)
 	if verrs != nil || err != nil {
@@ -24,6 +25,7 @@ func (o *mtoServiceItemCreator) CreateMTOServiceItem(serviceItem *models.MTOServ
 	return serviceItem, nil, nil
 }
 
+// NewMTOServiceItemCreator returns a new MTO service item creator
 func NewMTOServiceItemCreator(builder createMTOServiceItemQueryBuilder) services.MTOServiceItemCreator {
 	return &mtoServiceItemCreator{builder}
 }

--- a/pkg/services/mto_shipment/mto_shipment_fetcher.go
+++ b/pkg/services/mto_shipment/mto_shipment_fetcher.go
@@ -14,12 +14,12 @@ type mtoShipmentFetcher struct {
 	db *pop.Connection
 }
 
-// NewMoveTaskOrderFetcher creates a new struct with the service dependencies
+// NewMTOShipmentFetcher creates a new struct with the service dependencies
 func NewMTOShipmentFetcher(db *pop.Connection) services.MTOShipmentFetcher {
 	return &mtoShipmentFetcher{db}
 }
 
-//FetchMTOShipment retrieves a MTOShipment for a given UUID
+// FetchMTOShipment retrieves a MTOShipment for a given UUID
 func (f mtoShipmentFetcher) FetchMTOShipment(mtoShipmentID uuid.UUID) (*models.MTOShipment, error) {
 	shipment := &models.MTOShipment{}
 	if err := f.db.Eager().Find(shipment, mtoShipmentID); err != nil {

--- a/pkg/services/mto_shipment/mto_shipment_status_updater.go
+++ b/pkg/services/mto_shipment/mto_shipment_status_updater.go
@@ -14,6 +14,7 @@ import (
 	"github.com/transcom/mymove/pkg/services/query"
 )
 
+// UpdateMTOShipmentStatusQueryBuilder is the query builder for updating MTO Shipments
 type UpdateMTOShipmentStatusQueryBuilder interface {
 	FetchOne(model interface{}, filters []services.QueryFilter) error
 }
@@ -24,6 +25,7 @@ type mtoShipmentStatusUpdater struct {
 	siCreator services.MTOServiceItemCreator
 }
 
+// UpdateMTOShipmentStatus updates MTO Shipment Status
 func (o *mtoShipmentStatusUpdater) UpdateMTOShipmentStatus(payload mtoshipmentops.PatchMTOShipmentStatusParams) (*models.MTOShipment, error) {
 	shipmentID := payload.ShipmentID
 	status := models.MTOShipmentStatus(payload.Body.Status)
@@ -213,42 +215,51 @@ func constructMTOServiceItemModels(shipmentID uuid.UUID, mtoID uuid.UUID, reServ
 	return serviceItems
 }
 
+// NewMTOShipmentStatusUpdater creates a new MTO Shipment Status Updater
 func NewMTOShipmentStatusUpdater(db *pop.Connection, builder UpdateMTOShipmentStatusQueryBuilder, siCreator services.MTOServiceItemCreator) services.MTOShipmentStatusUpdater {
 	return &mtoShipmentStatusUpdater{db, builder, siCreator}
 }
 
+// ConflictStatusError returns an error for a conflict in status
 type ConflictStatusError struct {
 	id                   uuid.UUID
 	transitionFromStatus models.MTOShipmentStatus
 	transitionToStatus   models.MTOShipmentStatus
 }
 
+// Error is the string representation of the error
 func (e ConflictStatusError) Error() string {
 	return fmt.Sprintf("shipment with id '%s' can not transition status from '%s' to '%s'. Must be in status '%s'.",
 		e.id.String(), e.transitionFromStatus, e.transitionToStatus, models.MTOShipmentStatusSubmitted)
 }
 
+// NotFoundError is the not found error
 type NotFoundError struct {
 	id uuid.UUID
 }
 
+// Error is the string representation of the error
 func (e NotFoundError) Error() string {
 	return fmt.Sprintf("shipment with id '%s' not found", e.id.String())
 }
 
+// ValidationError is the validation error
 type ValidationError struct {
 	id    uuid.UUID
 	Verrs *validate.Errors
 }
 
+// Error is the string representation of the validation error
 func (e ValidationError) Error() string {
 	return fmt.Sprintf("shipment with id: '%s' could not be updated due to a validation error", e.id.String())
 }
 
+// PreconditionFailedError is the precondition failed error
 type PreconditionFailedError struct {
 	id uuid.UUID
 }
 
+// Error is the string representation of the precondition failed error
 func (e PreconditionFailedError) Error() string {
 	return fmt.Sprintf("shipment with id: '%s' could not be updated due to the record being stale", e.id.String())
 }

--- a/pkg/services/mto_shipment/mto_shipment_updater.go
+++ b/pkg/services/mto_shipment/mto_shipment_updater.go
@@ -34,6 +34,7 @@ type ErrInvalidInput struct {
 	errInvalidInput
 }
 
+// NewErrInvalidInput returns an error for invalid input
 func NewErrInvalidInput(id uuid.UUID, err error, validationErrors map[string][]string, message string) ErrInvalidInput {
 	return ErrInvalidInput{
 		errInvalidInput{
@@ -52,6 +53,7 @@ func (e ErrInvalidInput) Error() string {
 	return fmt.Sprintf("invalid input for move task order id: %s. %s", e.id.String(), e.InvalidFields())
 }
 
+// InvalidFields returns the invalid fields for invalid input
 func (e ErrInvalidInput) InvalidFields() map[string]string {
 	es := make(map[string]string)
 	if e.validationErrors == nil {

--- a/pkg/services/office_user/customer/customer.go
+++ b/pkg/services/office_user/customer/customer.go
@@ -12,7 +12,7 @@ import (
 	"github.com/transcom/mymove/pkg/services"
 )
 
-//ErrNotFound is returned when a given move task order is not found
+// ErrNotFound is returned when a given move task order is not found
 type ErrNotFound struct {
 	id uuid.UUID
 }
@@ -32,6 +32,7 @@ type ErrInvalidInput struct {
 	errInvalidInput
 }
 
+// NewErrInvalidInput returns an error for invalid input
 func NewErrInvalidInput(id uuid.UUID, err error, validationErrors map[string][]string) ErrInvalidInput {
 	return ErrInvalidInput{
 		errInvalidInput{
@@ -46,6 +47,7 @@ func (e ErrInvalidInput) Error() string {
 	return fmt.Sprintf("invalid input for move task order id: %s. %s", e.id.String(), e.InvalidFields())
 }
 
+// InvalidFields returns invalid fields for input
 func (e ErrInvalidInput) InvalidFields() map[string]string {
 	es := make(map[string]string)
 	if e.validationErrors == nil {

--- a/pkg/services/office_user/office_user_creator.go
+++ b/pkg/services/office_user/office_user_creator.go
@@ -11,6 +11,7 @@ type officeUserCreator struct {
 	builder officeUserQueryBuilder
 }
 
+// CreateOfficeUser creates office users
 func (o *officeUserCreator) CreateOfficeUser(user *models.OfficeUser, transportationIDFilter []services.QueryFilter) (*models.OfficeUser, *validate.Errors, error) {
 	// Use FetchOne to see if we have a transportation office that matches the provided id
 	var transportationOffice models.TransportationOffice
@@ -28,6 +29,7 @@ func (o *officeUserCreator) CreateOfficeUser(user *models.OfficeUser, transporta
 	return user, nil, nil
 }
 
+// NewOfficeUserCreator returns a new office user creator
 func NewOfficeUserCreator(builder officeUserQueryBuilder) services.OfficeUserCreator {
 	return &officeUserCreator{builder}
 }

--- a/pkg/services/office_user/office_user_updater.go
+++ b/pkg/services/office_user/office_user_updater.go
@@ -14,6 +14,7 @@ type officeUserUpdater struct {
 	builder officeUserQueryBuilder
 }
 
+// UpdateOfficeUser updates an office user
 func (o *officeUserUpdater) UpdateOfficeUser(id uuid.UUID, payload *adminmessages.OfficeUserUpdatePayload) (*models.OfficeUser, *validate.Errors, error) {
 	var foundUser models.OfficeUser
 	filters := []services.QueryFilter{query.NewQueryFilter("id", "=", id.String())}
@@ -51,6 +52,7 @@ func (o *officeUserUpdater) UpdateOfficeUser(id uuid.UUID, payload *adminmessage
 	return &foundUser, nil, nil
 }
 
+// NewOfficeUserUpdater returns a new office user updater
 func NewOfficeUserUpdater(builder officeUserQueryBuilder) services.OfficeUserUpdater {
 	return &officeUserUpdater{builder}
 }

--- a/pkg/services/pagination.go
+++ b/pkg/services/pagination.go
@@ -1,9 +1,11 @@
 package services
 
+// Pagination represents an interface for pagination
 type Pagination interface {
 	Page() int
 	PerPage() int
 	Offset() int
 }
 
+// NewPagination creates a new Pagination interface
 type NewPagination func(page *int64, perPage *int64) Pagination

--- a/pkg/services/pagination/pagination.go
+++ b/pkg/services/pagination/pagination.go
@@ -7,26 +7,32 @@ type pagination struct {
 	perPage int
 }
 
+// Page represents the page number
 func (p pagination) Page() int {
 	return int(p.page)
 }
 
+// PerPage returns number per page
 func (p pagination) PerPage() int {
 	return int(p.perPage)
 }
 
+// Offset returns the offset in the pagination
 func (p pagination) Offset() int {
 	return int((p.Page() - 1) * p.PerPage())
 }
 
+// DefaultPage returns the default page
 func DefaultPage() int64 {
 	return 1
 }
 
+// DefaultPerPage returns the default per page
 func DefaultPerPage() int64 {
 	return 25
 }
 
+// NewPagination creates a new pagination object
 func NewPagination(page *int64, perPage *int64) services.Pagination {
 	if page == nil {
 		return pagination{int(DefaultPage()), int(DefaultPerPage())}

--- a/pkg/services/payment_request/payment_request_creator.go
+++ b/pkg/services/payment_request/payment_request_creator.go
@@ -19,6 +19,7 @@ type paymentRequestCreator struct {
 	db *pop.Connection
 }
 
+// NewPaymentRequestCreator returns a new payment request creator
 func NewPaymentRequestCreator(db *pop.Connection) services.PaymentRequestCreator {
 	return &paymentRequestCreator{db: db}
 }

--- a/pkg/services/payment_request/payment_request_fetcher.go
+++ b/pkg/services/payment_request/payment_request_fetcher.go
@@ -13,6 +13,7 @@ type paymentRequestFetcher struct {
 	builder paymentRequestQueryBuilder
 }
 
+// NewPaymentRequestFetcher returns a new payment request fetcher
 func NewPaymentRequestFetcher(builder paymentRequestQueryBuilder) services.PaymentRequestFetcher {
 	return &paymentRequestFetcher{builder}
 }

--- a/pkg/services/payment_request/payment_request_list_fetcher.go
+++ b/pkg/services/payment_request/payment_request_list_fetcher.go
@@ -14,6 +14,7 @@ type paymentRequestListFetcher struct {
 	db *pop.Connection
 }
 
+// NewPaymentRequestListFetcher returns a new payment request list fetcher
 func NewPaymentRequestListFetcher(db *pop.Connection) services.PaymentRequestListFetcher {
 	return &paymentRequestListFetcher{db}
 }

--- a/pkg/services/payment_request/payment_request_service_test.go
+++ b/pkg/services/payment_request/payment_request_service_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/transcom/mymove/pkg/testingsuite"
 )
 
+// PaymentRequestServiceSuite is a suite for testing payment requests
 type PaymentRequestServiceSuite struct {
 	testingsuite.PopTestSuite
 	logger Logger

--- a/pkg/services/payment_request/payment_request_status_updater.go
+++ b/pkg/services/payment_request/payment_request_status_updater.go
@@ -15,6 +15,7 @@ type paymentRequestStatusUpdater struct {
 	builder paymentRequestStatusQueryBuilder
 }
 
+// NewPaymentRequestStatusUpdater returns a new payment request status updater
 func NewPaymentRequestStatusUpdater(builder paymentRequestStatusQueryBuilder) services.PaymentRequestStatusUpdater {
 	return &paymentRequestStatusUpdater{builder}
 }

--- a/pkg/services/payment_request/upload_creator.go
+++ b/pkg/services/payment_request/upload_creator.go
@@ -27,6 +27,7 @@ type paymentRequestUploadCreator struct {
 	fileSizeLimit uploader.ByteSize
 }
 
+// NewPaymentRequestUploadCreator returns a new payment request upload creator
 func NewPaymentRequestUploadCreator(db *pop.Connection, logger storage.Logger, fileStorer storage.FileStorer) services.PaymentRequestUploadCreator {
 	return &paymentRequestUploadCreator{db, logger, fileStorer, uploader.MaxFileSizeLimit}
 }

--- a/pkg/services/query/query_association.go
+++ b/pkg/services/query/query_association.go
@@ -8,10 +8,12 @@ type queryAssociation struct {
 	field string
 }
 
+// Field returns a field on a query association
 func (q queryAssociation) Field() string {
 	return q.field
 }
 
+// NewQueryAssociation creates a new query association
 func NewQueryAssociation(field string) services.QueryAssociation {
 	return queryAssociation{
 		field,
@@ -22,6 +24,7 @@ type queryAssociations struct {
 	associations []services.QueryAssociation
 }
 
+// StringGetAssociations returns a slice of string associations
 func (qa queryAssociations) StringGetAssociations() []string {
 	associations := make([]string, 0, len(qa.associations))
 
@@ -32,6 +35,7 @@ func (qa queryAssociations) StringGetAssociations() []string {
 	return associations
 }
 
+// NewQueryAssociations returns new query associations
 func NewQueryAssociations(associations []services.QueryAssociation) services.QueryAssociations {
 	return queryAssociations{
 		associations,

--- a/pkg/services/query/query_builder.go
+++ b/pkg/services/query/query_builder.go
@@ -300,6 +300,7 @@ func (p *Builder) FetchMany(model interface{}, filters []services.QueryFilter, a
 	return nil
 }
 
+// Count returns a count from a filter
 func (p *Builder) Count(model interface{}, filters []services.QueryFilter) (int, error) {
 	t := reflect.TypeOf(model)
 	if t.Kind() != reflect.Ptr {
@@ -326,6 +327,7 @@ func (p *Builder) Count(model interface{}, filters []services.QueryFilter) (int,
 	return count, nil
 }
 
+// CreateOne creates exactly one model
 func (p *Builder) CreateOne(model interface{}) (*validate.Errors, error) {
 	t := reflect.TypeOf(model)
 	if t.Kind() != reflect.Ptr {
@@ -339,6 +341,7 @@ func (p *Builder) CreateOne(model interface{}) (*validate.Errors, error) {
 	return nil, nil
 }
 
+// UpdateOne updates exactly one model
 func (p *Builder) UpdateOne(model interface{}) (*validate.Errors, error) {
 	t := reflect.TypeOf(model)
 	if t.Kind() != reflect.Ptr {
@@ -353,6 +356,7 @@ func (p *Builder) UpdateOne(model interface{}) (*validate.Errors, error) {
 	return nil, nil
 }
 
+// FetchCategoricalCountsFromOneModel returns categorical counts from exactly one model
 func (p *Builder) FetchCategoricalCountsFromOneModel(model interface{}, filters []services.QueryFilter, andFilters *[]services.QueryFilter) (map[interface{}]int, error) {
 	conn := p.db
 	t := reflect.TypeOf(model)
@@ -363,6 +367,7 @@ func (p *Builder) FetchCategoricalCountsFromOneModel(model interface{}, filters 
 	return categoricalCounts, nil
 }
 
+// QueryForAssociations builds a query for associations
 func (p *Builder) QueryForAssociations(model interface{}, associations services.QueryAssociations, filters []services.QueryFilter, pagination services.Pagination, ordering services.QueryOrder) error {
 	t := reflect.TypeOf(model)
 	if t.Kind() != reflect.Ptr {

--- a/pkg/services/upload/upload_information_fetcher.go
+++ b/pkg/services/upload/upload_information_fetcher.go
@@ -10,10 +10,12 @@ import (
 	"github.com/transcom/mymove/pkg/services"
 )
 
+// ErrNotFound returns not found error
 type ErrNotFound struct {
 	id uuid.UUID
 }
 
+// Error is the string representation of not found error
 func (e ErrNotFound) Error() string {
 	return fmt.Sprintf("upload id: %s not found", e.id.String())
 }
@@ -27,6 +29,7 @@ func NewUploadInformationFetcher(db *pop.Connection) services.UploadInformationF
 	return &uploadInformationFetcher{db}
 }
 
+// FetchUploadInformation fetches upload information
 func (uif *uploadInformationFetcher) FetchUploadInformation(uploadID uuid.UUID) (services.UploadInformation, error) {
 	q := `
 SELECT uploads.id as upload_id,

--- a/pkg/services/upload_information.go
+++ b/pkg/services/upload_information.go
@@ -6,6 +6,7 @@ import (
 	"github.com/gofrs/uuid"
 )
 
+// UploadInformation contains information for uploads
 type UploadInformation struct {
 	UploadID               uuid.UUID `db:"upload_id"`
 	ContentType            string    `db:"content_type"`

--- a/pkg/services/users_roles/users_roles.go
+++ b/pkg/services/users_roles/users_roles.go
@@ -14,12 +14,12 @@ type usersRolesCreator struct {
 	db *pop.Connection
 }
 
-// NewNewUsersRolesCreator creates a new struct with the service dependencies
+// NewUsersRolesCreator creates a new struct with the service dependencies
 func NewUsersRolesCreator(db *pop.Connection) services.UserRoleAssociator {
 	return usersRolesCreator{db}
 }
 
-//UpdateUserRoles associates a given user with a set of roles
+// UpdateUserRoles associates a given user with a set of roles
 func (u usersRolesCreator) UpdateUserRoles(userID uuid.UUID, rs []roles.RoleType) ([]models.UsersRoles, error) {
 	_, err := u.addUserRoles(userID, rs)
 	if err != nil {

--- a/pkg/testdatagen/make_admin_user.go
+++ b/pkg/testdatagen/make_admin_user.go
@@ -41,7 +41,7 @@ func MakeAdminUser(db *pop.Connection, assertions Assertions) models.AdminUser {
 	return adminUser
 }
 
-// MakeAdminUser creates a single admin user and associated TransportOffice
+// MakeAdminUserWithNoUser creates a single admin user and associated TransportOffice
 func MakeAdminUserWithNoUser(db *pop.Connection, assertions Assertions) models.AdminUser {
 	// There's a uniqueness constraint on admin user emails so add some randomness
 	email := fmt.Sprintf("admin_%s@example.com", makeRandomString(5))

--- a/pkg/testdatagen/make_move_order.go
+++ b/pkg/testdatagen/make_move_order.go
@@ -9,6 +9,7 @@ import (
 	"github.com/transcom/mymove/pkg/models"
 )
 
+// MakeGrade makes a service member grade
 func MakeGrade() string {
 	grades := [28]string{"E_1",
 		"E_2",

--- a/pkg/testdatagen/make_office_user.go
+++ b/pkg/testdatagen/make_office_user.go
@@ -48,7 +48,7 @@ func MakeOfficeUser(db *pop.Connection, assertions Assertions) models.OfficeUser
 	return officeUser
 }
 
-// MakeOfficeUser creates a single office user and associated TransportOffice
+// MakeOfficeUserWithNoUser creates a single office user and associated TransportOffice
 func MakeOfficeUserWithNoUser(db *pop.Connection, assertions Assertions) models.OfficeUser {
 	// There's a uniqueness constraint on office user emails so add some randomness
 	email := fmt.Sprintf("leo_spaceman_office_%s@example.com", makeRandomString(5))

--- a/pkg/testdatagen/make_organization.go
+++ b/pkg/testdatagen/make_organization.go
@@ -32,7 +32,7 @@ func MakeOrganization(db *pop.Connection, assertions Assertions) models.Organiza
 	return organization
 }
 
-// MakeOrganization makes a default Organization
+// MakeDefaultOrganization makes a default Organization
 func MakeDefaultOrganization(db *pop.Connection) models.Organization {
 	return MakeOrganization(db, Assertions{})
 }

--- a/pkg/uploader/uploader.go
+++ b/pkg/uploader/uploader.go
@@ -18,30 +18,39 @@ import (
 // ErrZeroLengthFile represents an error caused by a file with no content
 var ErrZeroLengthFile = errors.New("File has length of 0")
 
+// ErrTooLarge is an error where the file size exceeds the limit
 type ErrTooLarge struct {
 	FileSize      int64
 	FileSizeLimit ByteSize
 }
 
+// ErrFileSizeLimitExceedsMax is an error where file size exceeds max size
 var ErrFileSizeLimitExceedsMax = errors.Errorf("FileSizeLimit exceeds max of %d bytes", MaxFileSizeLimit)
 
+// MaxFileSizeLimit sets the maximum file size limit
 // Anti-Virus scanning won't be able to scan files larger than 250MB
 // Any unscanned files will not be available for download so while we can upload a larger
 // file of any size the file will be locked from downloading forever.
 const MaxFileSizeLimit = 250 * MB
 
+// ErrTooLarge is the string representation of an error
 func (e ErrTooLarge) Error() string {
 	return fmt.Sprintf("file is too large: %d > %d filesize limit", e.FileSize, e.FileSizeLimit)
 }
 
+// ByteSize is a snack
 type ByteSize int64
 
 const (
-	B  ByteSize = 1
-	KB          = 1000
-	MB          = 1000 * 1000
+	// B Byte
+	B ByteSize = 1
+	// KB KiloByte
+	KB = 1000
+	// MB MegaByte
+	MB = 1000 * 1000
 )
 
+// Int64 returns an integer of the byte size
 func (b ByteSize) Int64() int64 {
 	return int64(b)
 }

--- a/pkg/uploader/uploader_test.go
+++ b/pkg/uploader/uploader_test.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"path"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/mock"
@@ -38,7 +39,7 @@ func (suite *UploaderSuite) SetupTest() {
 }
 
 func (suite *UploaderSuite) openLocalFile(path string) (afero.File, error) {
-	file, err := os.Open(path)
+	file, err := os.Open(filepath.Clean(path))
 	if err != nil {
 		suite.logger.Fatal("Error opening local file", zap.Error(err))
 	}


### PR DESCRIPTION
## Description

I noticed some linters seemed not to be working like they used to on this project only to find out that when we switched to golangci-lint we dropped a host of really important checks. I'm particularly worried about the `gosec` ignores. But also the `golint` ones were important for self-documented code. I'll be using this PR to fix things since this kind of linting is important to our STIG process.