### PR TITLE
Catch error before throwing defer. Add more helpful message

### DIFF
--- a/cmd/milmove/gen_certs_migration.go
+++ b/cmd/milmove/gen_certs_migration.go
@@ -169,10 +169,11 @@ func genCertsMigration(cmd *cobra.Command, args []string) error {
 	if v.GetBool(cli.CACFlag) {
 
 		store, errStore := cli.GetCACStore(v)
-		defer store.Close()
 		if errStore != nil {
-			return errStore
+			return fmt.Errorf("Ensure CAC reader and card inserted: %w", errStore)
 		}
+		defer store.Close()
+
 		cert, errTLSCert := store.TLSCertificate()
 		if errTLSCert != nil {
 			return errTLSCert


### PR DESCRIPTION
## Description

When a user doesn't have their CAC card reader or CAC card inserted they may get an unhelpful error message:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x4fd8b87]
goroutine 1 [running]:
main.genCertsMigration(0xc00043ec80, 0xc0005ffe30, 0x0, 0x3, 0x0, 0x0)
	/Users/username/Projects/mymove/cmd/milmove/gen_certs_migration.go:172 +0x547
github.com/spf13/cobra.(*Command).execute(0xc00043ec80, 0xc0005ffe00, 0x3, 0x3, 0xc00043ec80, 0xc0005ffe00)
	/Users/username/code/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:826 +0x460
github.com/spf13/cobra.(*Command).ExecuteC(0xc0005ad680, 0xc0004cdf48, 0x1, 0x1)
	/Users/username/code/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:914 +0x2fb
github.com/spf13/cobra.(*Command).Execute(...)
	/Users/username/code/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:864
main.main()
	/Users/username/Projects/mymove/cmd/milmove/main.go:121 +0x802
```

The problem was setting up a `defer` in advance of error checking. I've fixed this and also added helpful text so folks can figure out what the error means.