### PR TITLE
MB-603 submit actual pickup date

### DIFF
--- a/migrations/app/migrations_manifest.txt
+++ b/migrations/app/migrations_manifest.txt
@@ -447,6 +447,7 @@
 20200204194821_erin_cac.up.sql
 20200205160112_add_enum_values_to_shipment_type_within_mto_shipments.up.sql
 20200206163953_cgilmer_cac.up.sql
+20200208013050_add_actual_pickup_date_to_mto_shipments.up.sql
 20200211150405_mr337_cac.up.sql
 20200211184638_add_approved_date_to_mto_shipments.up.sql
 20200211232054_add_fadd_to_mto_shipments.up.sql

--- a/migrations/app/schema/20200208013050_add_actual_pickup_date_to_mto_shipments.up.sql
+++ b/migrations/app/schema/20200208013050_add_actual_pickup_date_to_mto_shipments.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE mto_shipments
+	ADD COLUMN actual_pickup_date date;

--- a/pkg/gen/primeapi/embedded_spec.go
+++ b/pkg/gen/primeapi/embedded_spec.go
@@ -824,6 +824,10 @@ func init() {
     },
     "MTOShipment": {
       "properties": {
+        "actualPickupDate": {
+          "type": "string",
+          "format": "date"
+        },
         "approvedDate": {
           "type": "string",
           "format": "date",
@@ -2068,6 +2072,10 @@ func init() {
     },
     "MTOShipment": {
       "properties": {
+        "actualPickupDate": {
+          "type": "string",
+          "format": "date"
+        },
         "approvedDate": {
           "type": "string",
           "format": "date",

--- a/pkg/gen/primemessages/m_t_o_shipment.go
+++ b/pkg/gen/primemessages/m_t_o_shipment.go
@@ -19,6 +19,10 @@ import (
 // swagger:model MTOShipment
 type MTOShipment struct {
 
+	// actual pickup date
+	// Format: date
+	ActualPickupDate strfmt.Date `json:"actualPickupDate,omitempty"`
+
 	// approved date
 	// Format: date
 	ApprovedDate *strfmt.Date `json:"approvedDate,omitempty"`
@@ -88,6 +92,10 @@ type MTOShipment struct {
 func (m *MTOShipment) Validate(formats strfmt.Registry) error {
 	var res []error
 
+	if err := m.validateActualPickupDate(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateApprovedDate(formats); err != nil {
 		res = append(res, err)
 	}
@@ -151,6 +159,19 @@ func (m *MTOShipment) Validate(formats strfmt.Registry) error {
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
+	return nil
+}
+
+func (m *MTOShipment) validateActualPickupDate(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.ActualPickupDate) { // not required
+		return nil
+	}
+
+	if err := validate.FormatOf("actualPickupDate", "body", "date", m.ActualPickupDate.String(), formats); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/pkg/handlers/primeapi/internal/payloads/model_to_payload.go
+++ b/pkg/handlers/primeapi/internal/payloads/model_to_payload.go
@@ -164,6 +164,7 @@ func MTOShipment(mtoShipment *models.MTOShipment) *primemessages.MTOShipment {
 		CustomerRemarks:          *mtoShipment.CustomerRemarks,
 		RequestedPickupDate:      strfmt.Date(*mtoShipment.RequestedPickupDate),
 		ScheduledPickupDate:      strfmt.Date(*mtoShipment.ScheduledPickupDate),
+		ActualPickupDate:         strfmt.Date(mtoShipment.ActualPickupDate),
 		PickupAddress:            Address(&mtoShipment.PickupAddress),
 		Status:                   string(mtoShipment.Status),
 		DestinationAddress:       Address(&mtoShipment.DestinationAddress),

--- a/pkg/handlers/primeapi/internal/payloads/model_to_payload.go
+++ b/pkg/handlers/primeapi/internal/payloads/model_to_payload.go
@@ -164,7 +164,7 @@ func MTOShipment(mtoShipment *models.MTOShipment) *primemessages.MTOShipment {
 		CustomerRemarks:          *mtoShipment.CustomerRemarks,
 		RequestedPickupDate:      strfmt.Date(*mtoShipment.RequestedPickupDate),
 		ScheduledPickupDate:      strfmt.Date(*mtoShipment.ScheduledPickupDate),
-		ActualPickupDate:         strfmt.Date(mtoShipment.ActualPickupDate),
+		ActualPickupDate:         strfmt.Date(*mtoShipment.ActualPickupDate),
 		PickupAddress:            Address(&mtoShipment.PickupAddress),
 		Status:                   string(mtoShipment.Status),
 		DestinationAddress:       Address(&mtoShipment.DestinationAddress),

--- a/pkg/handlers/primeapi/internal/payloads/model_to_payload.go
+++ b/pkg/handlers/primeapi/internal/payloads/model_to_payload.go
@@ -164,7 +164,6 @@ func MTOShipment(mtoShipment *models.MTOShipment) *primemessages.MTOShipment {
 		CustomerRemarks:          *mtoShipment.CustomerRemarks,
 		RequestedPickupDate:      strfmt.Date(*mtoShipment.RequestedPickupDate),
 		ScheduledPickupDate:      strfmt.Date(*mtoShipment.ScheduledPickupDate),
-		ActualPickupDate:         strfmt.Date(*mtoShipment.ActualPickupDate),
 		PickupAddress:            Address(&mtoShipment.PickupAddress),
 		Status:                   string(mtoShipment.Status),
 		DestinationAddress:       Address(&mtoShipment.DestinationAddress),
@@ -177,6 +176,10 @@ func MTOShipment(mtoShipment *models.MTOShipment) *primemessages.MTOShipment {
 	if mtoShipment.ApprovedDate != nil && !mtoShipment.ApprovedDate.IsZero() {
 		approvedDate := strfmt.Date(*mtoShipment.ApprovedDate)
 		payload.ApprovedDate = &approvedDate
+	}
+
+	if mtoShipment.ActualPickupDate != nil && !mtoShipment.ActualPickupDate.IsZero() {
+		payload.ActualPickupDate = strfmt.Date(*mtoShipment.ActualPickupDate)
 	}
 
 	if mtoShipment.FirstAvailableDeliveryDate != nil && !mtoShipment.FirstAvailableDeliveryDate.IsZero() {

--- a/pkg/handlers/primeapi/internal/payloads/payload_to_model.go
+++ b/pkg/handlers/primeapi/internal/payloads/payload_to_model.go
@@ -51,6 +51,11 @@ func MTOShipmentModel(mtoShipment *primemessages.MTOShipment) *models.MTOShipmen
 		model.RequestedPickupDate = &requestedPickupDate
 	}
 
+	actualPickupDate := time.Time(mtoShipment.ActualPickupDate)
+	if !actualPickupDate.IsZero() {
+		model.ActualPickupDate = &actualPickupDate
+	}
+
 	if mtoShipment.PickupAddress != nil {
 		model.PickupAddress = *AddressModel(mtoShipment.PickupAddress)
 	}

--- a/pkg/models/mto_shipments.go
+++ b/pkg/models/mto_shipments.go
@@ -45,6 +45,7 @@ type MTOShipment struct {
 	RequestedPickupDate              *time.Time        `db:"requested_pickup_date"`
 	ApprovedDate                     *time.Time        `db:"approved_date"`
 	FirstAvailableDeliveryDate       *time.Time        `db:"first_available_delivery_date"`
+	ActualPickupDate                 time.Time         `db:"actual_pickup_date"`
 	CustomerRemarks                  *string           `db:"customer_remarks"`
 	PickupAddress                    Address           `belongs_to:"addresses"`
 	PickupAddressID                  uuid.UUID         `db:"pickup_address_id"`

--- a/pkg/models/mto_shipments.go
+++ b/pkg/models/mto_shipments.go
@@ -45,7 +45,7 @@ type MTOShipment struct {
 	RequestedPickupDate              *time.Time        `db:"requested_pickup_date"`
 	ApprovedDate                     *time.Time        `db:"approved_date"`
 	FirstAvailableDeliveryDate       *time.Time        `db:"first_available_delivery_date"`
-	ActualPickupDate                 time.Time         `db:"actual_pickup_date"`
+	ActualPickupDate                 *time.Time        `db:"actual_pickup_date"`
 	CustomerRemarks                  *string           `db:"customer_remarks"`
 	PickupAddress                    Address           `belongs_to:"addresses"`
 	PickupAddressID                  uuid.UUID         `db:"pickup_address_id"`

--- a/pkg/services/mto_shipment/mto_shipment_updater.go
+++ b/pkg/services/mto_shipment/mto_shipment_updater.go
@@ -102,6 +102,10 @@ func validateUpdatedMTOShipment(db *pop.Connection, oldShipment *models.MTOShipm
 		oldShipment.FirstAvailableDeliveryDate = updatedShipment.FirstAvailableDeliveryDate
 	}
 
+	if updatedShipment.ActualPickupDate.String() != "" {
+		oldShipment.ActualPickupDate = updatedShipment.ActualPickupDate
+	}
+
 	scheduledPickupTime := *oldShipment.ScheduledPickupDate
 	if updatedShipment.ScheduledPickupDate != nil {
 		scheduledPickupTime = *updatedShipment.ScheduledPickupDate

--- a/pkg/services/mto_shipment/mto_shipment_updater.go
+++ b/pkg/services/mto_shipment/mto_shipment_updater.go
@@ -102,7 +102,7 @@ func validateUpdatedMTOShipment(db *pop.Connection, oldShipment *models.MTOShipm
 		oldShipment.FirstAvailableDeliveryDate = updatedShipment.FirstAvailableDeliveryDate
 	}
 
-	if updatedShipment.ActualPickupDate.String() != "" {
+	if updatedShipment.ActualPickupDate != nil {
 		oldShipment.ActualPickupDate = updatedShipment.ActualPickupDate
 	}
 
@@ -224,6 +224,11 @@ func updateMTOShipment(db *pop.Connection, mtoShipmentID uuid.UUID, unmodifiedSi
 	if updatedShipment.FirstAvailableDeliveryDate != nil {
 		baseQuery = baseQuery + ", \nfirst_available_delivery_date = ?"
 		params = append(params, updatedShipment.FirstAvailableDeliveryDate)
+	}
+
+	if updatedShipment.ActualPickupDate != nil {
+		baseQuery = baseQuery + ", \nactual_pickup_date = ?"
+		params = append(params, updatedShipment.ActualPickupDate)
 	}
 
 	if updatedShipment.ShipmentType != "" {

--- a/pkg/services/mto_shipment/mto_shipment_updater_test.go
+++ b/pkg/services/mto_shipment/mto_shipment_updater_test.go
@@ -16,6 +16,8 @@ func (suite *MTOShipmentServiceSuite) TestMTOShipmentUpdater() {
 	requestedPickupDate := *oldMTOShipment.RequestedPickupDate
 	scheduledPickupDate := time.Date(2018, time.March, 10, 0, 0, 0, 0, time.UTC)
 	firstAvailableDeliveryDate := time.Date(2019, time.March, 10, 0, 0, 0, 0, time.UTC)
+	actualPickupDate := time.Date(2020, time.June, 8, 0, 0, 0, 0, time.UTC)
+
 	secondaryPickupAddress := testdatagen.MakeAddress3(suite.DB(), testdatagen.Assertions{})
 	secondaryDeliveryAddress := testdatagen.MakeAddress4(suite.DB(), testdatagen.Assertions{})
 	primeActualWeight := unit.Pound(1234)
@@ -31,6 +33,7 @@ func (suite *MTOShipmentServiceSuite) TestMTOShipmentUpdater() {
 		SecondaryDeliveryAddress:   &secondaryDeliveryAddress,
 		PrimeActualWeight:          &primeActualWeight,
 		FirstAvailableDeliveryDate: &firstAvailableDeliveryDate,
+		ActualPickupDate:           &actualPickupDate,
 	}
 
 	suite.T().Run("If-Unmodified-Since is not equal to the updated_at date", func(t *testing.T) {
@@ -55,6 +58,7 @@ func (suite *MTOShipmentServiceSuite) TestMTOShipmentUpdater() {
 		suite.NotZero(updatedMTOShipment.SecondaryPickupAddress.ID, secondaryPickupAddress.ID)
 		suite.NotZero(updatedMTOShipment.SecondaryDeliveryAddress.ID, secondaryDeliveryAddress.ID)
 		suite.Equal(updatedMTOShipment.PrimeActualWeight, &primeActualWeight)
+		suite.True(actualPickupDate.Equal(*updatedMTOShipment.ActualPickupDate))
 		suite.True(firstAvailableDeliveryDate.Equal(*updatedMTOShipment.FirstAvailableDeliveryDate))
 	})
 

--- a/swagger/prime.yaml
+++ b/swagger/prime.yaml
@@ -654,6 +654,9 @@ definitions:
       primeEstimatedWeightRecordedDate:
         format: date
         type: string
+      actualPickupDate:
+        format: date
+        type: string
       customerRemarks:
         type: string
         example: handle with care


### PR DESCRIPTION
## Description

Allows prime to update actual pickup date using the UpdateMTOShipments API

## Setup

**Test with go testing**
```sh
make server_run
make db_test_e2e_populate
go test -timeout 30s github.com/transcom/mymove/pkg/services/mto_shipment -count=1 -v 
```

**Test with postman**
Url: 
`{{baseUrl}}/move-task-orders/5d4b25bb-eb04-4c03-9a81-ee0398cb779e/mto-shipments/475579d5-aaa4-4755-8c43-c510381ff9b5`
Body:
```json
{
    "actualPickupDate": "2020-06-07",
    "moveTaskOrderID": "5d4b25bb-eb04-4c03-9a81-ee0398cb779e",
    "id": "475579d5-aaa4-4755-8c43-c510381ff9b5"
}
```
You do need to update the header with the right If-Unmodified-Since value

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-603) for this change
