### PR TITLE
Show incentive range after ppm move approved: MB-1231

### DIFF
--- a/src/scenes/Landing/MoveSummary/PpmMoveDetails.jsx
+++ b/src/scenes/Landing/MoveSummary/PpmMoveDetails.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { get } from 'lodash';
 import IconWithTooltip from 'shared/ToolTip/IconWithTooltip';
-import { formatCents } from 'shared/formatters';
+import { formatCents, formatCentsRange } from 'shared/formatters';
 import FontAwesomeIcon from '@fortawesome/react-fontawesome';
 import faExclamationCircle from '@fortawesome/fontawesome-free-solid/faExclamationCircle';
 import { selectReimbursement } from 'shared/Entities/modules/ppms';
@@ -17,6 +17,7 @@ const PpmMoveDetails = ({ advance, ppm, isMissingWeightTicketDocuments }) => {
       ? `Advance Requested: $${formatCents(advance.requested_amount)}`
       : '';
   const hasSitString = `Temp. Storage: ${ppm.days_in_storage} days ${privateStorageString}`;
+  const incentiveRange = formatCentsRange(ppm.incentive_estimate_min, ppm.incentive_estimate_max);
 
   return (
     <div className="titled_block">
@@ -39,7 +40,7 @@ const PpmMoveDetails = ({ advance, ppm, isMissingWeightTicketDocuments }) => {
           </>
         ) : (
           <>
-            <div>${formatCents(ppm.incentive_estimate_min)}</div>
+            <div>{incentiveRange}</div>
             <div style={{ fontSize: '0.90em', color: '#767676' }}>
               <em>Actual payment may vary, subject to Finance review.</em>
             </div>


### PR DESCRIPTION
## Description

Show an incentive range vs a single (min) incentive number after a SM's move is approved.

## Setup

SM: create new ppm move
Office: approve move (by updating required orders fields)
SM: logout and then log back in and look at info screen... You should see an incentive range and not a single incentive value... (you can see the single incentive value on the jira ticket)

## Code Review Verification Steps

* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-1231) for this change

## Screenshots

<img width="685" alt="Screen Shot 2020-02-21 at 10 55 18 AM" src="https://user-images.githubusercontent.com/3099491/75191838-ba9e7580-5718-11ea-86ed-db3baaaab75b.png">
