### PR TITLE
Updating to go-bindata 3.17

### DIFF
--- a/pkg/assets/assets.go
+++ b/pkg/assets/assets.go
@@ -33,7 +33,7 @@ import (
 func bindataRead(data []byte, name string) ([]byte, error) {
 	gz, err := gzip.NewReader(bytes.NewBuffer(data))
 	if err != nil {
-		return nil, fmt.Errorf("read %q: %v", name, err)
+		return nil, fmt.Errorf("read %q: %w", name, err)
 	}
 
 	var buf bytes.Buffer
@@ -41,7 +41,7 @@ func bindataRead(data []byte, name string) ([]byte, error) {
 	clErr := gz.Close()
 
 	if err != nil {
-		return nil, fmt.Errorf("read %q: %v", name, err)
+		return nil, fmt.Errorf("read %q: %w", name, err)
 	}
 	if clErr != nil {
 		return nil, err

--- a/scripts/check-go-bindata-version
+++ b/scripts/check-go-bindata-version
@@ -2,7 +2,7 @@
 
 set -eu -o pipefail
 
-VERSION="3.16.0"
+VERSION="3.17.0"
 
 GO_BINDATA_VERSION=$(go-bindata --version)
 # shellcheck disable=SC2203


### PR DESCRIPTION
## Description

It looks like homebrew's `go-bindata` formula is now using version 3.17.0.  We had a case recently where someone updated and [started to get local diffs](https://ustcdp3.slack.com/archives/CP6PTUPQF/p1582647390004000) in the generated `assets.go` file.  This PR updates that file and moves the expected version of `go-bindata` to 3.17.0.  The changes to `assets.go` appear to be minor and likely inconsequential for us.

Once this lands, I can send an announcement out on Slack to get the team to update so we're all in sync and not changing `assets.go` back and forth with each PR.
