### PR TITLE
Fix missing incentive range values not showing: MB-1231

### DIFF
--- a/src/scenes/Landing/MoveSummary/PpmMoveDetails.jsx
+++ b/src/scenes/Landing/MoveSummary/PpmMoveDetails.jsx
@@ -2,7 +2,8 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { get } from 'lodash';
 import IconWithTooltip from 'shared/ToolTip/IconWithTooltip';
-import { formatCents, formatCentsRange } from 'shared/formatters';
+import { formatCents } from 'shared/formatters';
+import { formatIncentiveRange } from 'shared/incentive';
 import FontAwesomeIcon from '@fortawesome/react-fontawesome';
 import faExclamationCircle from '@fortawesome/fontawesome-free-solid/faExclamationCircle';
 import { selectReimbursement } from 'shared/Entities/modules/ppms';
@@ -17,7 +18,7 @@ const PpmMoveDetails = ({ advance, ppm, isMissingWeightTicketDocuments }) => {
       ? `Advance Requested: $${formatCents(advance.requested_amount)}`
       : '';
   const hasSitString = `Temp. Storage: ${ppm.days_in_storage} days ${privateStorageString}`;
-  const incentiveRange = formatCentsRange(ppm.incentive_estimate_min, ppm.incentive_estimate_max);
+  const incentiveRange = formatIncentiveRange(ppm);
 
   return (
     <div className="titled_block">

--- a/src/scenes/Landing/MoveSummary/SubmittedPpmMoveDetails.jsx
+++ b/src/scenes/Landing/MoveSummary/SubmittedPpmMoveDetails.jsx
@@ -2,7 +2,8 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { get } from 'lodash';
 import IconWithTooltip from 'shared/ToolTip/IconWithTooltip';
-import { formatCents, formatCentsRange } from 'shared/formatters';
+import { formatCents } from 'shared/formatters';
+import { formatIncentiveRange } from 'shared/incentive';
 import { selectReimbursement } from 'shared/Entities/modules/ppms';
 import { selectPPMCloseoutDocumentsForMove } from 'shared/Entities/modules/movingExpenseDocuments';
 
@@ -13,12 +14,7 @@ const SubmittedPpmMoveDetails = props => {
     : '';
   const advanceString = ppm.has_requested_advance ? `Advance Requested: $${formatCents(advance.requested_amount)}` : '';
   const hasSitString = `Temp. Storage: ${ppm.days_in_storage} days ${privateStorageString}`;
-
-  let incentiveRange = formatCentsRange(ppm.currentPpm.incentive_estimate_min, ppm.currentPpm.incentive_estimate_max);
-  // work around for for ppm redux storage in multiple places...
-  if (incentiveRange === '') {
-    incentiveRange = formatCentsRange(ppm.incentive_estimate_min, ppm.incentive_estimate_max);
-  }
+  const incentiveRange = formatIncentiveRange(ppm);
 
   return (
     <div className="titled_block">

--- a/src/scenes/Landing/MoveSummary/SubmittedPpmMoveDetails.jsx
+++ b/src/scenes/Landing/MoveSummary/SubmittedPpmMoveDetails.jsx
@@ -13,7 +13,13 @@ const SubmittedPpmMoveDetails = props => {
     : '';
   const advanceString = ppm.has_requested_advance ? `Advance Requested: $${formatCents(advance.requested_amount)}` : '';
   const hasSitString = `Temp. Storage: ${ppm.days_in_storage} days ${privateStorageString}`;
-  const incentiveRange = formatCentsRange(ppm.currentPpm.incentive_estimate_min, ppm.currentPpm.incentive_estimate_max);
+
+  let incentiveRange = formatCentsRange(ppm.currentPpm.incentive_estimate_min, ppm.currentPpm.incentive_estimate_max);
+  // work around for for ppm redux storage in multiple places...
+  if (incentiveRange === '') {
+    incentiveRange = formatCentsRange(ppm.incentive_estimate_min, ppm.incentive_estimate_max);
+  }
+
   return (
     <div className="titled_block">
       <div className="title">Details</div>

--- a/src/shared/incentive.js
+++ b/src/shared/incentive.js
@@ -1,3 +1,14 @@
+import { formatCentsRange } from 'shared/formatters';
+
 export function hasShortHaulError(rateEngineError) {
   return rateEngineError && rateEngineError.statusCode === 409 ? true : false;
+}
+
+export function formatIncentiveRange(ppm) {
+  let incentiveRange = formatCentsRange(ppm.currentPpm.incentive_estimate_min, ppm.currentPpm.incentive_estimate_max);
+  // work around for for ppm redux storage in multiple places...
+  if (incentiveRange === '') {
+    incentiveRange = formatCentsRange(ppm.incentive_estimate_min, ppm.incentive_estimate_max);
+  }
+  return incentiveRange;
 }

--- a/src/shared/incentive.js
+++ b/src/shared/incentive.js
@@ -5,10 +5,10 @@ export function hasShortHaulError(rateEngineError) {
 }
 
 export function formatIncentiveRange(ppm) {
-  let incentiveRange = formatCentsRange(ppm.currentPpm.incentive_estimate_min, ppm.currentPpm.incentive_estimate_max);
+  let incentiveRange = formatCentsRange(ppm.incentive_estimate_min, ppm.incentive_estimate_max);
   // work around for for ppm redux storage in multiple places...
   if (incentiveRange === '') {
-    incentiveRange = formatCentsRange(ppm.incentive_estimate_min, ppm.incentive_estimate_max);
+    incentiveRange = formatCentsRange(ppm.currentPpm.incentive_estimate_min, ppm.currentPpm.incentive_estimate_max);
   }
   return incentiveRange;
 }

--- a/src/shared/incentive.test.js
+++ b/src/shared/incentive.test.js
@@ -12,4 +12,16 @@ describe('incentive', () => {
       expect(incentive.hasShortHaulError()).toBe(false);
     });
   });
+  describe('Check format for incentive range', () => {
+    it('should reutrn range', () => {
+      expect(incentive.formatIncentiveRange({ incentive_estimate_min: 1000, incentive_estimate_max: 2000 })).toEqual(
+        '$10.00 - 20.00',
+      );
+      expect(
+        incentive.formatIncentiveRange({
+          currentPpm: { incentive_estimate_min: 30000, incentive_estimate_max: 40000 },
+        }),
+      ).toEqual('$300.00 - 400.00');
+    });
+  });
 });


### PR DESCRIPTION
## Description

In redux, we're we have 3 versions of ppm data. this is causing bugs since that data isn't in sync. This is a temp fix till we move the ppm data under entities and only update in 1 place.

## Setup

`make server_run`
`make client_run`
SM: create a ppm move. after signature screen, make sure incentive shows... and try reloading and make sure it still shows.
Office: approve move
SM: reload page and make sure incentive still shows.

* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-1231) for this change
