### PR TITLE
Add engadminlocal to etc/hosts instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,7 @@ Here are the steps:
   echo "127.0.0.1 orderslocal" | sudo tee -a /etc/hosts
   echo "127.0.0.1 adminlocal" | sudo tee -a /etc/hosts
   echo "127.0.0.1 primelocal" | sudo tee -a /etc/hosts
+  echo "127.0.0.1 engadminlocal" | sudo tee -a /etc/hosts
   ```
 
 Check that the file looks correct with `cat /etc/hosts`:
@@ -316,6 +317,7 @@ Check that the file looks correct with `cat /etc/hosts`:
   127.0.0.1   orderslocal
   127.0.0.1   adminlocal
   127.0.0.1   primelocal
+  127.0.0.1   engadminlocal
 ```
 
 You can also verify this by running `scripts/check-hosts-file`.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ in the [LICENSE.txt](./LICENSE.txt) file in this repository.
   * [Setup: Direnv](#setup-direnv)
     * [Helpful variables for `.envrc.local`](#helpful-variables-for-envrclocal)
   * [Setup: Pre-Commit](#setup-pre-commit)
-  * [Setup: Hosts](#setup-hosts)
   * [Setup: Dependencies](#setup-dependencies)
   * [Setup: Build Tools](#setup-build-tools)
   * [Setup: Database](#setup-database)
@@ -285,42 +284,6 @@ If you wish to not maintain a `.envrc.local` you can alternatively run `cp .envr
 Run `pre-commit install` to install a pre-commit hook into `./git/hooks/pre-commit`.  This is different than `brew install pre-commit` and must be done so that the hook will check files you are about to commit to the repository.  Next install the pre-commit hook libraries with `pre-commit install-hooks`.
 
 Before running `pre-commit run -a` you will need to install Javascript dependencies and generate some golang code from Swagger files. An easier way to handle this is by running `make pre_commit_tests` or `make server generate client_deps && pre-commit run -a`. But it's early to do this so you can feel free to skip running the pre-commit checks at this time.
-
-### Setup: Hosts
-
-You need to modify your `/etc/hosts` file. This is a tricky file to modify and you will need to use `sudo` to edit it.
-Here are the steps:
-
-  ```bash
-  echo "127.0.0.1 milmovelocal" | sudo tee -a /etc/hosts
-  echo "127.0.0.1 officelocal" | sudo tee -a /etc/hosts
-  echo "127.0.0.1 orderslocal" | sudo tee -a /etc/hosts
-  echo "127.0.0.1 adminlocal" | sudo tee -a /etc/hosts
-  echo "127.0.0.1 primelocal" | sudo tee -a /etc/hosts
-  echo "127.0.0.1 engadminlocal" | sudo tee -a /etc/hosts
-  ```
-
-Check that the file looks correct with `cat /etc/hosts`:
-
-  ```text
-  ##
-  # Host Database
-  #
-  # localhost is used to configure the loopback interface
-  # when the system is booting.  Do not change this entry.
-  ##
-  255.255.255.255 broadcasthost
-  ::1             localhost
-  127.0.0.1   localhost
-  127.0.0.1   milmovelocal
-  127.0.0.1   officelocal
-  127.0.0.1   orderslocal
-  127.0.0.1   adminlocal
-  127.0.0.1   primelocal
-  127.0.0.1   engadminlocal
-```
-
-You can also verify this by running `scripts/check-hosts-file`.
 
 ### Setup: Dependencies
 

--- a/scripts/check-hosts-file
+++ b/scripts/check-hosts-file
@@ -7,15 +7,21 @@ set -eu -o pipefail
 function check_host () {
   host=$1
   host_line=$(grep "$host" /etc/hosts || true)
+
+  declare -A host_docs
+  host_docs=(
+    ["milmovelocal"]="setup-milmovelocal-client"
+    ["officelocal"]="setup-officelocal-client"
+    ["adminlocal"]="setup-adminlocal-client"
+    ["orderslocal"]="setup-orders-gateway"
+    ["primelocal"]="setup-prime-api"
+  )
+
   if [ -z "${host_line}" ]; then
     # shellcheck disable=SC1117
     echo -e "\033[0;33mPlease add ${host} to your hosts file using the command:\033[0m 'echo \"127.0.0.1 ${host}\" | sudo tee -a /etc/hosts'"
-    if [ "${host}" = primelocal ]; then
-      echo "More information at https://github.com/transcom/mymove#setup-prime-api"
-    elif [ "${host}" = orderslocal ]; then
-      echo "More information at https://github.com/transcom/mymove#setup-orders-gateway"
-    else
-      echo "More information at https://github.com/transcom/mymove#setup-${host}-client"
+    if [ "${host}" != engadminlocal ]; then
+      echo "More information at https://github.com/transcom/mymove#${host_docs[${host}]}"
     fi
     exit 1
   fi


### PR DESCRIPTION
**Why**: It's required to be able to run the MilMoveLocal app
according to the rest of the README instructions.

