### PR TITLE
MB-1687 rework move task order and mto shipment creation

### DIFF
--- a/pkg/handlers/ghcapi/internal/payloads/model_to_payload.go
+++ b/pkg/handlers/ghcapi/internal/payloads/model_to_payload.go
@@ -195,17 +195,8 @@ func MTOShipment(mtoShipment *models.MTOShipment) *ghcmessages.MTOShipment {
 // MTOShipmentWithEtag payload
 func MTOShipmentWithEtag(mtoShipment *models.MTOShipment) *ghcmessages.MTOShipmentWithEtag {
 	return &ghcmessages.MTOShipmentWithEtag{
-		MTOShipment: ghcmessages.MTOShipment{
-			ID:                  strfmt.UUID(mtoShipment.ID.String()),
-			MoveTaskOrderID:     strfmt.UUID(mtoShipment.MoveTaskOrderID.String()),
-			ShipmentType:        "HHG",
-			Status:              string(mtoShipment.Status),
-			CustomerRemarks:     mtoShipment.CustomerRemarks,
-			RequestedPickupDate: strfmt.Date(*mtoShipment.RequestedPickupDate),
-			CreatedAt:           strfmt.DateTime(mtoShipment.CreatedAt),
-			UpdatedAt:           strfmt.DateTime(mtoShipment.UpdatedAt),
-		},
-		ETag: etag.GenerateEtag(mtoShipment.UpdatedAt),
+		MTOShipment: *MTOShipment(mtoShipment),
+		ETag:        etag.GenerateEtag(mtoShipment.UpdatedAt),
 	}
 }
 

--- a/pkg/handlers/internalapi/moves.go
+++ b/pkg/handlers/internalapi/moves.go
@@ -6,6 +6,8 @@ import (
 	"io/ioutil"
 	"time"
 
+	"github.com/transcom/mymove/pkg/services/converthelper"
+
 	"github.com/transcom/mymove/pkg/cli"
 
 	"github.com/transcom/mymove/pkg/assets"
@@ -166,8 +168,8 @@ func (h SubmitMoveHandler) Handle(params moveop.SubmitMoveForApprovalParams) mid
 	}
 
 	if h.HandlerContext.GetFeatureFlag(cli.FeatureFlagConvertPPMsToGHC) {
-		if moID, convertErr := models.ConvertFromPPMToGHC(h.DB(), move.ID); convertErr != nil {
-			logger.Error("PPM->GHC conversion error", zap.Error(err))
+		if moID, convertErr := converthelper.ConvertFromPPMToGHC(h.DB(), move.ID); convertErr != nil {
+			logger.Error("PPM->GHC conversion error", zap.Error(convertErr))
 			// don't return an error here because we don't want this to break the endpoint
 		} else {
 			logger.Info("PPM->GHC conversion successful. New MoveOrder created.", zap.String("move_order_id", moID.String()))

--- a/pkg/models/move_task_order.go
+++ b/pkg/models/move_task_order.go
@@ -1,9 +1,6 @@
 package models
 
 import (
-	"errors"
-	"fmt"
-	"math/rand"
 	"time"
 
 	"github.com/transcom/mymove/pkg/unit"
@@ -32,6 +29,9 @@ type MoveTaskOrder struct {
 	UpdatedAt          time.Time       `db:"updated_at"`
 }
 
+// MoveTaskOrders is a list of move task orders
+type MoveTaskOrders []MoveTaskOrder
+
 // Validate gets run every time you call a "pop.Validate*" (pop.ValidateAndSave, pop.ValidateAndCreate, pop.ValidateAndUpdate) method.
 func (m *MoveTaskOrder) Validate(tx *pop.Connection) (*validate.Errors, error) {
 	var vs []validate.Validator
@@ -39,38 +39,4 @@ func (m *MoveTaskOrder) Validate(tx *pop.Connection) (*validate.Errors, error) {
 		&validators.UUIDIsPresent{Field: m.MoveOrderID, Name: "MoveOrderID"},
 		&validators.StringIsPresent{Field: m.ReferenceID, Name: "ReferenceID"})
 	return validate.Validate(vs...), nil
-}
-
-// MoveTaskOrders is a list of move task orders
-type MoveTaskOrders []MoveTaskOrder
-
-// GenerateReferenceID creates a random ID for an MTO. Format (xxxx-xxxx) with X being a number 0-9 (ex. 0009-1234. 4321-4444)
-func generateReferenceID(tx *pop.Connection) (string, error) {
-	min := 0
-	max := 9999
-	firstNum := rand.Intn(max - min + 1)
-	secondNum := rand.Intn(max - min + 1)
-	newReferenceID := fmt.Sprintf("%04d-%04d", firstNum, secondNum)
-	count, err := tx.Where(`reference_id= $1`, newReferenceID).Count(&MoveTaskOrder{})
-	if err != nil {
-		return "", err
-	} else if count > 0 {
-		return "", errors.New("move_task_order: reference_id already exists")
-	}
-
-	return newReferenceID, nil
-}
-
-// GenerateReferenceID generates a reference ID for the MTO
-func GenerateReferenceID(tx *pop.Connection) (string, error) {
-	const maxAttempts = 10
-	var referenceID string
-	var err error
-	for i := 0; i < maxAttempts; i++ {
-		referenceID, err = generateReferenceID(tx)
-		if err == nil {
-			return referenceID, nil
-		}
-	}
-	return "", errors.New("move_task_order: failed to generate reference id")
 }

--- a/pkg/models/move_task_order_test.go
+++ b/pkg/models/move_task_order_test.go
@@ -1,9 +1,6 @@
 package models_test
 
 import (
-	"reflect"
-	"strconv"
-	"strings"
 	"testing"
 
 	"github.com/gofrs/uuid"
@@ -13,25 +10,11 @@ import (
 
 func (suite *ModelSuite) TestMoveTaskOrderValidation() {
 	suite.T().Run("test valid MoveTaskOrder", func(t *testing.T) {
-		referenceID, _ := models.GenerateReferenceID(suite.DB())
 		validMoveTaskOrder := models.MoveTaskOrder{
 			MoveOrderID: uuid.Must(uuid.NewV4()),
-			ReferenceID: referenceID,
+			ReferenceID: "Testing",
 		}
 		expErrors := map[string][]string{}
 		suite.verifyValidationErrors(&validMoveTaskOrder, expErrors)
 	})
-}
-
-func (suite *ModelSuite) TestGenerateReferenceID() {
-	r, err := models.GenerateReferenceID(suite.DB())
-	suite.NotNil(r)
-	referenceID := r
-	suite.NoError(err)
-	firstNum, _ := strconv.Atoi(strings.Split(referenceID, "-")[0])
-	secondNum, _ := strconv.Atoi(strings.Split(referenceID, "-")[1])
-	suite.Equal(reflect.TypeOf(referenceID).String(), "string")
-	suite.Equal(firstNum >= 0 && firstNum <= 9999, true)
-	suite.Equal(secondNum >= 0 && secondNum <= 9999, true)
-	suite.Equal(string(referenceID[4]), "-")
 }

--- a/pkg/services/converthelper/convert_suite_test.go
+++ b/pkg/services/converthelper/convert_suite_test.go
@@ -1,0 +1,25 @@
+package converthelper_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/transcom/mymove/pkg/testingsuite"
+)
+
+type ConvertSuite struct {
+	testingsuite.PopTestSuite
+}
+
+func (suite *ConvertSuite) SetupTest() {
+	suite.DB().TruncateAll()
+}
+
+func TestMoveTaskOrderServiceSuite(t *testing.T) {
+	ts := &ConvertSuite{
+		testingsuite.NewPopTestSuite(testingsuite.CurrentPackage()),
+	}
+	suite.Run(t, ts)
+	ts.PopTestSuite.TearDown()
+}

--- a/pkg/services/converthelper/convert_suite_test.go
+++ b/pkg/services/converthelper/convert_suite_test.go
@@ -16,7 +16,7 @@ func (suite *ConvertSuite) SetupTest() {
 	suite.DB().TruncateAll()
 }
 
-func TestMoveTaskOrderServiceSuite(t *testing.T) {
+func TestConvertHelperSuite(t *testing.T) {
 	ts := &ConvertSuite{
 		testingsuite.NewPopTestSuite(testingsuite.CurrentPackage()),
 	}

--- a/pkg/services/converthelper/convert_test.go
+++ b/pkg/services/converthelper/convert_test.go
@@ -1,17 +1,19 @@
-package models_test
+package converthelper_test
 
 import (
 	"github.com/gofrs/uuid"
+
+	"github.com/transcom/mymove/pkg/services/converthelper"
 
 	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"
 )
 
-func (suite *ModelSuite) TestConvert() {
+func (suite *ConvertSuite) TestConvert() {
 	move := testdatagen.MakeMove(suite.DB(), testdatagen.Assertions{})
 	suite.NotNil(move)
 
-	moID, conversionErr := models.ConvertFromPPMToGHC(suite.DB(), move.ID)
+	moID, conversionErr := converthelper.ConvertFromPPMToGHC(suite.DB(), move.ID)
 	suite.FatalNoError(conversionErr)
 
 	var mo models.MoveOrder

--- a/pkg/services/move_task_order.go
+++ b/pkg/services/move_task_order.go
@@ -9,7 +9,7 @@ import (
 	"github.com/transcom/mymove/pkg/models"
 )
 
-// MoveTaskOrderCreator is the service object interface for FetchMoveTaskOrder
+// MoveTaskOrderCreator is the service object interface for CreateMoveTaskOrder
 //go:generate mockery -name MoveTaskOrderCreator
 type MoveTaskOrderCreator interface {
 	CreateMoveTaskOrder(moveTaskOrder *models.MoveTaskOrder) (*models.MoveTaskOrder, *validate.Errors, error)

--- a/pkg/services/move_task_order.go
+++ b/pkg/services/move_task_order.go
@@ -1,12 +1,19 @@
 package services
 
 import (
+	"github.com/gobuffalo/validate"
 	"github.com/gofrs/uuid"
 
 	movetaskorderops "github.com/transcom/mymove/pkg/gen/primeapi/primeoperations/move_task_order"
 
 	"github.com/transcom/mymove/pkg/models"
 )
+
+// MoveTaskOrderCreator is the service object interface for FetchMoveTaskOrder
+//go:generate mockery -name MoveTaskOrderCreator
+type MoveTaskOrderCreator interface {
+	CreateMoveTaskOrder(moveTaskOrder *models.MoveTaskOrder) (*models.MoveTaskOrder, *validate.Errors, error)
+}
 
 // MoveTaskOrderFetcher is the service object interface for FetchMoveTaskOrder
 //go:generate mockery -name MoveTaskOrderFetcher

--- a/pkg/services/move_task_order/move_task_order_creator.go
+++ b/pkg/services/move_task_order/move_task_order_creator.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gobuffalo/uuid"
+	"github.com/gofrs/uuid"
 
 	"github.com/gobuffalo/pop"
 	"github.com/gobuffalo/validate"

--- a/pkg/services/move_task_order/move_task_order_creator.go
+++ b/pkg/services/move_task_order/move_task_order_creator.go
@@ -1,0 +1,96 @@
+package movetaskorder
+
+import (
+	"strings"
+	"time"
+
+	"github.com/gobuffalo/uuid"
+
+	"github.com/gobuffalo/pop"
+	"github.com/gobuffalo/validate"
+
+	"github.com/transcom/mymove/pkg/models"
+	"github.com/transcom/mymove/pkg/services"
+	mtoservicehelper "github.com/transcom/mymove/pkg/services/move_task_order/shared"
+)
+
+type createMoveTaskOrderQueryBuilder interface {
+	CreateOne(model interface{}) (*validate.Errors, error)
+}
+
+type moveTaskOrderCreator struct {
+	builder createMoveTaskOrderQueryBuilder
+	db      *pop.Connection
+}
+
+// CreateMoveTaskOrder creates an MTO Service Item
+func (o *moveTaskOrderCreator) CreateMoveTaskOrder(moveTaskOrder *models.MoveTaskOrder) (*models.MoveTaskOrder, *validate.Errors, error) {
+	// generate reference id if empty
+	if strings.TrimSpace(moveTaskOrder.ReferenceID) == "" {
+		referenceID, err := mtoservicehelper.GenerateReferenceID(o.db)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		moveTaskOrder.ReferenceID = referenceID
+	}
+
+	moveTaskOrder.CreatedAt = time.Now()
+	moveTaskOrder.UpdatedAt = time.Now()
+
+	verrs, err := o.builder.CreateOne(moveTaskOrder)
+	if verrs != nil || err != nil {
+		return nil, verrs, err
+	}
+
+	// create default server items as well
+	err = o.createDefaultServiceItems(moveTaskOrder)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return moveTaskOrder, nil, nil
+}
+
+// NewMoveTaskOrderCreator returns a new MTO service item creator
+func NewMoveTaskOrderCreator(builder createMoveTaskOrderQueryBuilder, db *pop.Connection) services.MoveTaskOrderCreator {
+	return &moveTaskOrderCreator{builder, db}
+}
+
+func (o *moveTaskOrderCreator) createDefaultServiceItems(moveTaskOrder *models.MoveTaskOrder) error {
+	var reServices []models.ReService
+	err := o.db.Where("code in (?)", []string{"MS", "CS"}).All(&reServices)
+
+	if err != nil {
+		return err
+	}
+
+	defaultServiceItems := make(map[uuid.UUID]models.MTOServiceItem)
+	for _, reService := range reServices {
+		defaultServiceItems[reService.ID] = models.MTOServiceItem{
+			ReServiceID:     reService.ID,
+			MoveTaskOrderID: moveTaskOrder.ID,
+		}
+	}
+
+	// Remove the ones that exist on the mto
+	for _, item := range moveTaskOrder.MTOServiceItems {
+		for _, reService := range reServices {
+			if item.ReServiceID == reService.ID {
+				delete(defaultServiceItems, reService.ID)
+			}
+		}
+	}
+
+	for _, serviceItem := range defaultServiceItems {
+		_, err := o.db.ValidateAndCreate(&serviceItem)
+
+		if err != nil {
+			return err
+		}
+
+		moveTaskOrder.MTOServiceItems = append(moveTaskOrder.MTOServiceItems, serviceItem)
+	}
+
+	return nil
+}

--- a/pkg/services/move_task_order/move_task_order_creator.go
+++ b/pkg/services/move_task_order/move_task_order_creator.go
@@ -23,7 +23,7 @@ type moveTaskOrderCreator struct {
 	db      *pop.Connection
 }
 
-// CreateMoveTaskOrder creates an MTO Service Item
+// CreateMoveTaskOrder creates a move task order
 func (o *moveTaskOrderCreator) CreateMoveTaskOrder(moveTaskOrder *models.MoveTaskOrder) (*models.MoveTaskOrder, *validate.Errors, error) {
 	// generate reference id if empty
 	if strings.TrimSpace(moveTaskOrder.ReferenceID) == "" {
@@ -43,7 +43,7 @@ func (o *moveTaskOrderCreator) CreateMoveTaskOrder(moveTaskOrder *models.MoveTas
 		return nil, verrs, err
 	}
 
-	// create default server items as well
+	// create default service items as well
 	err = o.createDefaultServiceItems(moveTaskOrder)
 	if err != nil {
 		return nil, nil, err
@@ -52,7 +52,7 @@ func (o *moveTaskOrderCreator) CreateMoveTaskOrder(moveTaskOrder *models.MoveTas
 	return moveTaskOrder, nil, nil
 }
 
-// NewMoveTaskOrderCreator returns a new MTO service item creator
+// NewMoveTaskOrderCreator returns an new creator
 func NewMoveTaskOrderCreator(builder createMoveTaskOrderQueryBuilder, db *pop.Connection) services.MoveTaskOrderCreator {
 	return &moveTaskOrderCreator{builder, db}
 }

--- a/pkg/services/move_task_order/move_task_order_creator_test.go
+++ b/pkg/services/move_task_order/move_task_order_creator_test.go
@@ -1,0 +1,52 @@
+package movetaskorder_test
+
+import (
+	"testing"
+
+	"github.com/gofrs/uuid"
+
+	"github.com/transcom/mymove/pkg/services/query"
+
+	"github.com/transcom/mymove/pkg/testdatagen"
+
+	. "github.com/transcom/mymove/pkg/services/move_task_order"
+
+	"github.com/transcom/mymove/pkg/models"
+)
+
+func (suite *MoveTaskOrderServiceSuite) TestMoveTaskOrderCreatorIntegration() {
+	testdatagen.MakeReService(suite.DB(), testdatagen.Assertions{
+		ReService: models.ReService{
+			ID:   uuid.FromStringOrNil("1130e612-94eb-49a7-973d-72f33685e551"),
+			Code: "MS",
+		},
+	})
+
+	testdatagen.MakeReService(suite.DB(), testdatagen.Assertions{
+		ReService: models.ReService{
+			ID:   uuid.FromStringOrNil("9dc919da-9b66-407b-9f17-05c0f03fcb50"),
+			Code: "CS",
+		},
+	})
+
+	builder := query.NewQueryBuilder(suite.DB())
+	mtoCreator := NewMoveTaskOrderCreator(builder, suite.DB())
+
+	moveOrder := testdatagen.MakeMoveOrder(suite.DB(), testdatagen.Assertions{})
+	newMto := models.MoveTaskOrder{
+		MoveOrderID: moveOrder.ID,
+	}
+	actualMTO, verrs, err := mtoCreator.CreateMoveTaskOrder(&newMto)
+	suite.NoError(err)
+	suite.Empty(verrs)
+
+	suite.T().Run("move task order is created", func(t *testing.T) {
+		// testing mto
+		suite.NotZero(actualMTO.ID)
+	})
+
+	suite.T().Run("default service items properly created", func(t *testing.T) {
+		// testing default service items
+		suite.Equal(2, len(actualMTO.MTOServiceItems))
+	})
+}

--- a/pkg/services/move_task_order/move_task_order_fetcher.go
+++ b/pkg/services/move_task_order/move_task_order_fetcher.go
@@ -45,43 +45,22 @@ func (f moveTaskOrderFetcher) FetchMoveTaskOrder(moveTaskOrderID uuid.UUID) (*mo
 		}
 	}
 
-	f.createDefaultServiceItems(mto)
-
 	return mto, nil
 }
 
-func (f moveTaskOrderFetcher) createDefaultServiceItems(mto *models.MoveTaskOrder) error {
-	var reServices []models.ReService
-	err := f.db.Where("code in (?)", []string{"MS", "CS"}).All(&reServices)
-
-	if err != nil {
-		return err
-	}
-
-	defaultServiceItems := make(map[uuid.UUID]models.MTOServiceItem)
-	for _, reService := range reServices {
-		defaultServiceItems[reService.ID] = models.MTOServiceItem{
-			ReServiceID:     reService.ID,
-			MoveTaskOrderID: mto.ID,
-		}
-	}
-
-	// Remove the ones that exist on the mto
-	for _, item := range mto.MTOServiceItems {
-		for _, reService := range reServices {
-			if item.ReServiceID == reService.ID {
-				delete(defaultServiceItems, reService.ID)
-			}
-		}
-	}
-
-	for _, serviceItem := range defaultServiceItems {
-		_, err := f.db.ValidateAndCreate(&serviceItem)
-
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
+//MakeAvailableToPrime updates the status of a MoveTaskOrder for a given UUID to make it available to prime
+//func (f moveTaskOrderFetcher) MakeAvailableToPrime(moveTaskOrderID uuid.UUID) (*models.MoveTaskOrder, error) {
+//	mto, err := f.FetchMoveTaskOrder(moveTaskOrderID)
+//	if err != nil {
+//		return &models.MoveTaskOrder{}, err
+//	}
+//	mto.IsAvailableToPrime = true
+//	vErrors, err := f.db.ValidateAndUpdate(mto)
+//	if vErrors.HasAny() {
+//		return &models.MoveTaskOrder{}, services.InvalidInputError{}
+//	}
+//	if err != nil {
+//		return &models.MoveTaskOrder{}, err
+//	}
+//	return mto, nil
+//}

--- a/pkg/services/move_task_order/move_task_order_fetcher.go
+++ b/pkg/services/move_task_order/move_task_order_fetcher.go
@@ -47,20 +47,3 @@ func (f moveTaskOrderFetcher) FetchMoveTaskOrder(moveTaskOrderID uuid.UUID) (*mo
 
 	return mto, nil
 }
-
-//MakeAvailableToPrime updates the status of a MoveTaskOrder for a given UUID to make it available to prime
-//func (f moveTaskOrderFetcher) MakeAvailableToPrime(moveTaskOrderID uuid.UUID) (*models.MoveTaskOrder, error) {
-//	mto, err := f.FetchMoveTaskOrder(moveTaskOrderID)
-//	if err != nil {
-//		return &models.MoveTaskOrder{}, err
-//	}
-//	mto.IsAvailableToPrime = true
-//	vErrors, err := f.db.ValidateAndUpdate(mto)
-//	if vErrors.HasAny() {
-//		return &models.MoveTaskOrder{}, services.InvalidInputError{}
-//	}
-//	if err != nil {
-//		return &models.MoveTaskOrder{}, err
-//	}
-//	return mto, nil
-//}

--- a/pkg/services/move_task_order/move_task_order_fetcher_test.go
+++ b/pkg/services/move_task_order/move_task_order_fetcher_test.go
@@ -1,26 +1,12 @@
-package movetaskorder
+package movetaskorder_test
 
 import (
-	"github.com/gofrs/uuid"
+	. "github.com/transcom/mymove/pkg/services/move_task_order"
 
-	"github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"
 )
 
 func (suite *MoveTaskOrderServiceSuite) TestMoveTaskOrderFetcher() {
-	testdatagen.MakeReService(suite.DB(), testdatagen.Assertions{
-		ReService: models.ReService{
-			ID:   uuid.FromStringOrNil("1130e612-94eb-49a7-973d-72f33685e551"),
-			Code: "MS",
-		},
-	})
-
-	testdatagen.MakeReService(suite.DB(), testdatagen.Assertions{
-		ReService: models.ReService{
-			ID:   uuid.FromStringOrNil("9dc919da-9b66-407b-9f17-05c0f03fcb50"),
-			Code: "CS",
-		},
-	})
 	expectedMoveOrder := testdatagen.MakeMoveOrder(suite.DB(), testdatagen.Assertions{})
 	expectedMTO := testdatagen.MakeMoveTaskOrder(suite.DB(), testdatagen.Assertions{
 		MoveOrder: expectedMoveOrder,
@@ -36,18 +22,6 @@ func (suite *MoveTaskOrderServiceSuite) TestMoveTaskOrderFetcher() {
 	suite.NotNil(expectedMTO.ReferenceID)
 	suite.False(expectedMTO.IsAvailableToPrime)
 	suite.False(expectedMTO.IsCanceled)
-
-	var serviceItems models.MTOServiceItems
-	suite.DB().All(&serviceItems)
-	suite.Equal(2, len(serviceItems))
-
-	// Make sure we don't create more default service items
-	serviceItems = models.MTOServiceItems{}
-	actualMTO, err = mtoFetcher.FetchMoveTaskOrder(expectedMTO.ID)
-	suite.NoError(err)
-
-	suite.DB().All(&serviceItems)
-	suite.Equal(2, len(serviceItems))
 }
 
 func (suite *MoveTaskOrderServiceSuite) TestListMoveTaskOrdersFetcher() {

--- a/pkg/services/move_task_order/move_task_order_service_test.go
+++ b/pkg/services/move_task_order/move_task_order_service_test.go
@@ -1,4 +1,4 @@
-package movetaskorder
+package movetaskorder_test
 
 import (
 	"testing"

--- a/pkg/services/move_task_order/shared/move_task_order_helper.go
+++ b/pkg/services/move_task_order/shared/move_task_order_helper.go
@@ -21,7 +21,7 @@ func GenerateReferenceID(db *pop.Connection) (string, error) {
 			return referenceID, nil
 		}
 	}
-	return "", errors.New("move_task_order: failed to generate reference id")
+	return "", fmt.Errorf("move_task_order: failed to generate reference id; %w", err)
 }
 
 // GenerateReferenceID creates a random ID for an MTO. Format (xxxx-xxxx) with X being a number 0-9 (ex. 0009-1234. 4321-4444)

--- a/pkg/services/move_task_order/shared/move_task_order_helper.go
+++ b/pkg/services/move_task_order/shared/move_task_order_helper.go
@@ -1,0 +1,42 @@
+package movetaskordershared
+
+import (
+	"errors"
+	"fmt"
+	"math/rand"
+
+	"github.com/gobuffalo/pop"
+
+	"github.com/transcom/mymove/pkg/models"
+)
+
+// GenerateReferenceID generates a reference ID for the MTO
+func GenerateReferenceID(db *pop.Connection) (string, error) {
+	const maxAttempts = 10
+	var referenceID string
+	var err error
+	for i := 0; i < maxAttempts; i++ {
+		referenceID, err = generateReferenceIDHelper(db)
+		if err == nil {
+			return referenceID, nil
+		}
+	}
+	return "", errors.New("move_task_order: failed to generate reference id")
+}
+
+// GenerateReferenceID creates a random ID for an MTO. Format (xxxx-xxxx) with X being a number 0-9 (ex. 0009-1234. 4321-4444)
+func generateReferenceIDHelper(db *pop.Connection) (string, error) {
+	min := 0
+	max := 9999
+	firstNum := rand.Intn(max - min + 1)
+	secondNum := rand.Intn(max - min + 1)
+	newReferenceID := fmt.Sprintf("%04d-%04d", firstNum, secondNum)
+	count, err := db.Where(`reference_id= $1`, newReferenceID).Count(&models.MoveTaskOrder{})
+	if err != nil {
+		return "", err
+	} else if count > 0 {
+		return "", errors.New("move_task_order: reference_id already exists")
+	}
+
+	return newReferenceID, nil
+}

--- a/pkg/services/move_task_order/shared/move_task_order_helper_suite_test.go
+++ b/pkg/services/move_task_order/shared/move_task_order_helper_suite_test.go
@@ -1,0 +1,25 @@
+package movetaskordershared_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/transcom/mymove/pkg/testingsuite"
+)
+
+type MoveTaskOrderHelperSuite struct {
+	testingsuite.PopTestSuite
+}
+
+func (suite *MoveTaskOrderHelperSuite) SetupTest() {
+	suite.DB().TruncateAll()
+}
+
+func TestMoveTaskOrderServiceSuite(t *testing.T) {
+	ts := &MoveTaskOrderHelperSuite{
+		testingsuite.NewPopTestSuite(testingsuite.CurrentPackage()),
+	}
+	suite.Run(t, ts)
+	ts.PopTestSuite.TearDown()
+}

--- a/pkg/services/move_task_order/shared/move_task_order_helper_test.go
+++ b/pkg/services/move_task_order/shared/move_task_order_helper_test.go
@@ -1,0 +1,26 @@
+package movetaskordershared_test
+
+import (
+	"reflect"
+	"strconv"
+	"strings"
+	"testing"
+
+	movetaskordershared "github.com/transcom/mymove/pkg/services/move_task_order/shared"
+)
+
+func (suite *MoveTaskOrderHelperSuite) TestMoveTaskOrderGenerateReferenceID() {
+
+	refID, err := movetaskordershared.GenerateReferenceID(suite.DB())
+	suite.T().Run("reference id is properly created", func(t *testing.T) {
+		// testing reference id
+		suite.NoError(err)
+		suite.NotZero(refID)
+		firstNum, _ := strconv.Atoi(strings.Split(refID, "-")[0])
+		secondNum, _ := strconv.Atoi(strings.Split(refID, "-")[1])
+		suite.Equal(reflect.TypeOf(refID).String(), "string")
+		suite.Equal(firstNum >= 0 && firstNum <= 9999, true)
+		suite.Equal(secondNum >= 0 && secondNum <= 9999, true)
+		suite.Equal(string(refID[4]), "-")
+	})
+}

--- a/pkg/testdatagen/make_move_task_order.go
+++ b/pkg/testdatagen/make_move_task_order.go
@@ -3,6 +3,8 @@ package testdatagen
 import (
 	"github.com/gobuffalo/pop"
 
+	mtoservicehelper "github.com/transcom/mymove/pkg/services/move_task_order/shared"
+
 	"github.com/transcom/mymove/pkg/models"
 )
 
@@ -15,7 +17,7 @@ func MakeMoveTaskOrder(db *pop.Connection, assertions Assertions) models.MoveTas
 
 	var referenceID string
 	if assertions.MoveTaskOrder.ReferenceID == "" {
-		referenceID, _ = models.GenerateReferenceID(db)
+		referenceID, _ = mtoservicehelper.GenerateReferenceID(db)
 	}
 
 	var ppmType string

--- a/src/scenes/Office/TOO/customerDetails.jsx
+++ b/src/scenes/Office/TOO/customerDetails.jsx
@@ -191,48 +191,50 @@ class CustomerDetails extends Component {
                         <ApproveRejectModal
                           showModal={items.status === 'SUBMITTED'}
                           approveBtnOnClick={() =>
-                            this.props.patchMTOShipmentStatus(
-                              get(moveTaskOrder, 'id'),
-                              items.id,
-                              'APPROVED',
-                              items.updatedAt,
-                            )
+                            this.props
+                              .patchMTOShipmentStatus(get(moveTaskOrder, 'id'), items.id, 'APPROVED', items.eTag)
+                              .then(() => this.props.getMTOServiceItems(items.moveTaskOrderID))
                           }
                           rejectBtnOnClick={rejectionReason =>
                             this.props.patchMTOShipmentStatus(
                               get(moveTaskOrder, 'id'),
                               items.id,
                               'REJECTED',
-                              items.updatedAt,
+                              items.eTag,
                               rejectionReason,
                             )
                           }
                         />
                       </td>
                     </tr>
+                  </Fragment>
+                ))}
+              </tbody>
+            </table>
+
+            <h2>Shipment Agents</h2>
+            <table>
+              <thead>
+                <tr>
+                  <th>id</th>
+                  <th>Agent Type</th>
+                  <th>First Name</th>
+                  <th>Last Name</th>
+                  <th>Email</th>
+                  <th>Phone</th>
+                </tr>
+              </thead>
+              <tbody>
+                {mtoAgents.map(shipmentAgent => (
+                  <Fragment key={get(shipmentAgent[0], 'id')}>
                     <tr>
-                      <h3>Shipment Agents</h3>
+                      <td>{get(shipmentAgent[0], 'id')}</td>
+                      <td>{get(shipmentAgent[0], 'agentType')}</td>
+                      <td>{get(shipmentAgent[0], 'firstName')}</td>
+                      <td>{get(shipmentAgent[0], 'lastName')}</td>
+                      <td>{get(shipmentAgent[0], 'email')}</td>
+                      <td>{get(shipmentAgent[0], 'phone')}</td>
                     </tr>
-                    {mtoAgents.map(shipmentAgent => (
-                      <Fragment key={shipmentAgent.id}>
-                        <tr>
-                          <th>id</th>
-                          <th>Agent Type</th>
-                          <th>First Name</th>
-                          <th>Last Name</th>
-                          <th>Email</th>
-                          <th>Phone</th>
-                        </tr>
-                        <tr>
-                          <td>{shipmentAgent[0].id}</td>
-                          <td>{shipmentAgent[0].agentType}</td>
-                          <td>{shipmentAgent[0].firstName}</td>
-                          <td>{shipmentAgent[0].lastName}</td>
-                          <td>{shipmentAgent[0].email}</td>
-                          <td>{shipmentAgent[0].phone}</td>
-                        </tr>
-                      </Fragment>
-                    ))}
                   </Fragment>
                 ))}
               </tbody>

--- a/src/shared/Entities/modules/mtoShipments.js
+++ b/src/shared/Entities/modules/mtoShipments.js
@@ -15,7 +15,7 @@ export function patchMTOShipmentStatus(
   moveTaskOrderID,
   shipmentID,
   shipmentStatus,
-  ifUnmodifiedSince,
+  ifMatchETag,
   rejectionReason,
   label = patchMTOShipmentStatusOperation,
   schemaKey = mtoShipmentSchemaKey,
@@ -26,7 +26,7 @@ export function patchMTOShipmentStatus(
     {
       moveTaskOrderID,
       shipmentID,
-      'If-Unmodified-Since': ifUnmodifiedSince,
+      'If-Match': ifMatchETag,
       body: { status: shipmentStatus, rejectionReason },
     },
     { label, schemaKey },


### PR DESCRIPTION
## Description

As a TOO when I click on a move from the /too/customer-moves screen

Then I should see 
- Customer Details
- Entitlements
- Orders Information 
- Customer Requested Shipments

And next to each requested shipment I should see an accept or reject button. 

Clicking accept adds the standard service items for the shipment to the MTO 

Clicking reject does nothing for now. 

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make db_dev_e2e_populate
make server_run client_run
```
Best way to test this is to find the locally generated service member user and submit their move.

Service Member App
1. Dev login
2. Login with `needs@orde.rs (milmove)`
3. Complete move app, sign and submit

Office App
1. Login
2. Navigate to `officelocal:3000/too/customer-moves`
3. Select the move that was just submitted (last one usually)
4. Check Move Task Order if it has a reference ID
5. Check Shipment if there's at least one
6. Try to Approve shipment
7. There should be base service items added now

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/tree/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/tree/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* [ ] There are no aXe warnings for UI.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-1652) for this change