### PR TITLE
Fix typo in "orders" application comparison

### DIFF
--- a/scripts/run-server-test-in-circle-container
+++ b/scripts/run-server-test-in-circle-container
@@ -6,7 +6,7 @@
 
 set -eu -o pipefail
 
-if [ "${APPLICATION}" != "app" ] && [ "${APPLICATION}" != "ordres" ]; then
+if [ "${APPLICATION}" != "app" ] && [ "${APPLICATION}" != "orders" ]; then
   echo "Must provider the environment variable APPLICATION and set to 'app' or 'orders'"
   exit 1
 fi


### PR DESCRIPTION
## Description

Noticed a typo in the string literal used to detect the "orders" application while I was reviewing another PR.
