### PR TITLE
[WIP] proposal for adding prime user to ghc

### DIFF
--- a/cmd/milmove/serve.go
+++ b/cmd/milmove/serve.go
@@ -756,6 +756,7 @@ func serveFunction(cmd *cobra.Command, args []string) error {
 		primeMux.Use(clientCertMiddleware)
 		primeMux.Use(authentication.PrimeAuthorizationMiddleware(logger))
 		primeMux.Use(middleware.NoCache(logger))
+		primeMux.Use(middleware.PrimeRequester(logger))
 		primeMux.Handle(pat.Get("/swagger.yaml"), fileHandler(v.GetString(cli.PrimeSwaggerFlag)))
 		if v.GetBool(cli.ServeSwaggerUIFlag) {
 			logger.Info("Prime API Swagger UI serving is enabled")

--- a/migrations/app/migrations_manifest.txt
+++ b/migrations/app/migrations_manifest.txt
@@ -470,3 +470,4 @@
 20200226211945_jacquelinemckinney_cac.up.sql
 20200302161838_ryan_cac.up.sql
 20200302220909_donald_cac.up.sql
+20200304172954_create_prime_requester_table.up.sql

--- a/migrations/app/schema/20200304172954_create_prime_requester_table.up.sql
+++ b/migrations/app/schema/20200304172954_create_prime_requester_table.up.sql
@@ -1,0 +1,12 @@
+CREATE TABLE prime_requesters
+(
+    id uuid UNIQUE NOT NULL,
+    name varchar(255) NOT NULL,
+    client_cert_id uuid NOT NULL
+        constraint prime_requester_client_cert_id_fkey references client_certs,
+    last_seen_at timestamp WITH TIME ZONE NOT NULL,
+    created_at timestamp WITH TIME ZONE NOT NULL,
+    updated_at timestamp WITH TIME ZONE NOT NULL,
+    allow_access bool default FALSE,
+    PRIMARY KEY(name, client_cert_id)
+);

--- a/pkg/middleware/prime_requester.go
+++ b/pkg/middleware/prime_requester.go
@@ -1,0 +1,41 @@
+package middleware
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/transcom/mymove/pkg/auth/authentication"
+	"github.com/transcom/mymove/pkg/primerequester"
+)
+
+// PrimeRequester returns a Prime Requester (user) middleware.
+func PrimeRequester(logger Logger) func(next http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Pull requester info from context
+			requester := PrimeRequesterFromContext(r.Context())
+			if requester == nil {
+				logger.Error("unauthorized user for ghc prime")
+				http.Error(w, http.StatusText(401), http.StatusUnauthorized)
+				return
+			}
+			// Store requester access to system along with the client cert used
+			clientCert := authentication.ClientCertFromContext(r.Context())
+			if clientCert == nil {
+				logger.Error("unauthorized user for ghc prime")
+				http.Error(w, http.StatusText(401), http.StatusUnauthorized)
+				return
+			}
+			primerequester.SaveAccess(requester, clientCert)
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// PrimeRequesterFromContext gets the Prime API requester field stored in the request.Context()
+func PrimeRequesterFromContext(ctx context.Context) *string {
+	if requester, ok := ctx.Value("requester").(*string); ok {
+		return requester
+	}
+	return nil
+}

--- a/pkg/models/prime_requester.go
+++ b/pkg/models/prime_requester.go
@@ -1,0 +1,37 @@
+package models
+
+import (
+	"time"
+
+	"github.com/gobuffalo/pop"
+	"github.com/gobuffalo/validate"
+	"github.com/gobuffalo/validate/validators"
+	"github.com/gofrs/uuid"
+)
+
+// PrimeRequester is an object representing the Prime API Requester
+type PrimeRequester struct {
+	ID           uuid.UUID `db:"id"`
+	Name         string    `db:"name"`
+	ClientCertID uuid.UUID `db:"client_cert_id"`
+	AllowAccess  bool      `db:"allow_access"`
+	LastSeenAt   time.Time `db:"last_seen_at"`
+	CreatedAt    time.Time `db:"created_at"`
+	UpdatedAt    time.Time `db:"updated_at"`
+
+	// Associations
+	ClientCert ClientCert `belongs_to:"client_certs"`
+}
+
+// Validate gets run every time you call a "pop.Validate*" (pop.ValidateAndSave, pop.ValidateAndCreate, pop.ValidateAndUpdate) method.
+func (m *PrimeRequester) Validate(tx *pop.Connection) (*validate.Errors, error) {
+	var vs []validate.Validator
+	vs = append(vs,
+		&validators.UUIDIsPresent{Field: m.ID, Name: "ID"},
+		&validators.UUIDIsPresent{Field: m.ClientCertID, Name: "ClientCertID"},
+		&validators.StringIsPresent{Field: m.Name, Name: "Name"})
+	return validate.Validate(vs...), nil
+}
+
+// PrimeRequesters is a list of move task orders
+type PrimeRequesters []PrimeRequester

--- a/pkg/primerequester/prime_requester.go
+++ b/pkg/primerequester/prime_requester.go
@@ -1,0 +1,15 @@
+package primerequester
+
+import "github.com/transcom/mymove/pkg/models"
+
+// SaveAccess saves prime requester field to the database
+func SaveAccess(requester *string, clientCert *models.ClientCert) error {
+
+	// TODO
+
+	// 1. Query prime_requester for an existing user using name and client cert
+	// 2. If the user exists update last_seen_at=now()
+	// 3. If the user does not exist, insert new record and set allow_access=true and last_seen_at=now()
+
+	return nil
+}


### PR DESCRIPTION
## Proposal to add a `prime_requester` table to the GHC Prime API code

I initially created this PR to use for needing a [user ID to upload proof of service docs to S3](https://docs.google.com/document/d/1CxUkdDMOw2-wjdho9mfs6RbEvfFtMl1hF51FELSvhRE/edit). 

But after thinking about this some, I don't think the upload to S3 needs this. But I do think this lightweight table for tracking the prime user is needed because I believe we need to know who is accessing the system beyond just that the prime client system has successfully connected with a cert. This lightweight first pass at using the `requester` will be able to be expanded once we have better requirements around this.

The concept beyond this is simple. Every Prime endpoint requires a `requester` field, the work for that is being done here: https://dp3.atlassian.net/browse/MB-671 . Beyond that, I think it would be beneficial to:

1. Verify that the `requester` string is provided in every Prime API endpoint call.  
2. Record that a user has accessed the system and save the last time they accessed the system
3. Record which client cert was used when the `requester` accessed the system
4. Verify that the `requester` is in fact allowed to access the system. If there is a case where the Prime or the client has notified us that a certain user is NOT allowed to access the system, we should be able to deny that user access.

## Reviewer Notes

n/a

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
echo "Code goes here"
```

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/tree/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/tree/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/tree/master/docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
  * [ ] Secure migrations have been tested using `scripts/run-prod-migrations`
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-1322) for this change
* [Related Jira story](https://dp3.atlassian.net/browse/MB-671) explains more about the approach used.

## Screenshots

n/a
