### PR TITLE
Add .loki to .dockerignore file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -17,6 +17,7 @@
 /coverage
 coverage.out
 __snapshots__
+.loki
 
 # development
 /mnt


### PR DESCRIPTION
## Description

Don't add `.loki` reference images to docker context for builds.