### PR TITLE
Add a data-cy to the selector that identifies the actual range and test

### DIFF
--- a/cypress/integration/mymove/ppm.js
+++ b/cypress/integration/mymove/ppm.js
@@ -94,7 +94,7 @@ function SMSubmitsMove() {
   cy.get('.wizard-header').should('not.exist');
   cy.get('#incentive-estimation-slider').click();
 
-  cy.get('[data-cy="incentive-range-text"]').contains('$');
+  cy.get('[data-cy="incentive-range-values"]').contains('$');
 
   cy.nextPage();
 

--- a/src/scenes/Moves/Ppm/Weight.jsx
+++ b/src/scenes/Moves/Ppm/Weight.jsx
@@ -197,7 +197,11 @@ export class PpmWeight extends Component {
         </td>
       );
     } else {
-      return <td className="incentive">{formatCentsRange(incentive_estimate_min, incentive_estimate_max)}</td>;
+      return (
+        <td data-cy="incentive-range-values" className="incentive">
+          {formatCentsRange(incentive_estimate_min, incentive_estimate_max)}
+        </td>
+      );
     }
   }
 


### PR DESCRIPTION
## Description

Flaky tests.  This fixes issue in ppm.js test where we were waiting for the incentive estimate range to show up.

## Setup

`make e2e_test`
run the `ppm.js` file

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

[CircleCI failure](https://circleci.com/gh/transcom/mymove/240234)
