### PR TITLE
Overhaul of anti-virus script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,6 @@ storybook-static
 
 # Certs
 *.srl
+
+# anti-virus
+whitelist*.*

--- a/.spelling
+++ b/.spelling
@@ -577,5 +577,8 @@ dev_db
 base64
 Keychain
 LICENSE.txt
+unix
+mko-x
+docker-clamav#39
 # Put all custom terms BEFORE this comment, lest 'pre-commit' and 'make spellcheck' yield different errors.
  - ./docs/backend/route-planner.md

--- a/docs/anti_virus.md
+++ b/docs/anti_virus.md
@@ -1,6 +1,6 @@
 # Anti-Virus
 
-This document provides an overview of the anti-virus solution employed by the MilMove project.
+This document provides an overview of the anti-virus solutions employed by the MilMove project.
 
 Anti-virus scanning is concerned with two parts of the system. The first part is viruses being injected into the source code of the project by folks with permissions to commit and merge code. The second part is viruses being uploaded to the AWS S3 bucket by users and downloaded by other users of the system.
 
@@ -8,7 +8,74 @@ Anti-virus scanning is concerned with two parts of the system. The first part is
 
 Anti-virus scanning of the source code is done via a step in the CI/CD pipeline which in turn calls the `make anti_virus` target in the `Makefile`. The step uses a ClamAV Docker container to scan a copy of the checked out source code prior to building any binaries or docker images for deployment. If a virus is detected the build cannot continue and the anti-virus finding must be dealt with.
 
+### Virus Findings
+
+If a report of a virus is found to have been checked into the github repository by the CircleCI anti-virus job it must be assessed as a real threat. DO NOT ASSUME IT IS TEST FLAKINESS. Check out a fresh copy of the repository, assess with the anti-virus script using `make anti_virus` and determine if the virus is indeed detected.
+
+**NOTE:** If scanning repeatedly find the virus then open an Incident first before doing anything else. An incident for a false positive result is better than no incident for a positive result.
+
+During the incident get help in determining if the finding is a False Positive (read Troubleshooting below) or if it needs further action. Use the incident response procedures to move forward.
+
+### Troubleshooting
+
+#### False Positives
+
 Files that are false positives (like PDF test fixtures) can be white-listed in the `scripts/anti-virus` file by updating the variable `IGNORE_FILES`.
+
+Signatures that are false positives (like `PUA.Pdf.Trojan.EmbeddedJavaScript-1`) can be white listed in the `scripts/anti-virus` file by updating the variable `IGNORE_SIGS`.
+
+#### Outdated ClamAV
+
+If you see this warning you can ignore it:
+
+```text
+Fri Mar  6 19:57:07 2020 -> ^Your ClamAV installation is OUTDATED!
+Fri Mar  6 19:57:07 2020 -> ^Local version: 0.102.1 Recommended version: 0.102.2
+Fri Mar  6 19:57:07 2020 -> DON'T PANIC! Read https://www.clamav.net/documents/upgrading-clamav
+```
+
+The ClamAV maintainers have not yet released an official version for Debian Alpine. That doesn't stop the ClamAV process for trying to determine if there is a new version available and suggesting that you update. They helpfully added `DON'T PANIC!` to try and dissuade folks from thinking this is the reason they are having trouble with ClamAV.
+
+See [mko-x/docker-clamav#39](https://github.com/mko-x/docker-clamav/issues/39) for more information.
+
+#### Docker container exits unpredictably
+
+The ClamAV process starts off by updating its various databases and definitions for virus detection. Here is some of that output:
+
+```text
+Fri Mar  6 19:57:07 2020 -> daily database available for download (remote version: 25743)
+Fri Mar  6 19:57:11 2020 -> Testing database: '/store/tmp/clamav-6e94b769e8d37704da1bf78d7727231c.tmp-daily.cvd' ...
+Fri Mar  6 19:57:22 2020 -> Database test passed.
+Fri Mar  6 19:57:22 2020 -> daily.cvd updated (version: 25743, sigs: 2209759, f-level: 63, builder: raynman)
+Fri Mar  6 19:57:22 2020 -> main database available for download (remote version: 59)
+Fri Mar  6 19:57:29 2020 -> Testing database: '/store/tmp/clamav-e05bb84fe2271bf55ee55ee2506ff284.tmp-main.cvd' ...
+Fri Mar  6 19:57:36 2020 -> Database test passed.
+Fri Mar  6 19:57:36 2020 -> main.cvd updated (version: 59, sigs: 4564902, f-level: 60, builder: sigmgr)
+Fri Mar  6 19:57:36 2020 -> bytecode database available for download (remote version: 331)
+Fri Mar  6 19:57:36 2020 -> Testing database: '/store/tmp/clamav-8c552c424237331bd40cdba9db6f36ff.tmp-bytecode.cvd' ...
+Fri Mar  6 19:57:36 2020 -> Database test passed.
+Fri Mar  6 19:57:36 2020 -> bytecode.cvd updated (version: 331, sigs: 94, f-level: 63, builder: anvilleg)
+Fri Mar  6 19:57:36 2020 -> safebrowsing database available for download (remote version: 49191)
+Fri Mar  6 19:57:39 2020 -> Testing database: '/store/tmp/clamav-21790a79b7578c4fa0d73a103ab50d49.tmp-safebrowsing.cvd' ...
+Fri Mar  6 19:57:43 2020 -> Database test passed.
+Fri Mar  6 19:57:43 2020 -> safebrowsing.cvd updated (version: 49191, sigs: 2213119, f-level: 63, builder: google)
+```
+
+Each update requires a network connection and for the website hosting the files to be available. If either the network is unstable or the website is unavailable then the docker container cannot continue startup and will exit. This is why a retry loop is added to the script, to try to catch intermittent problems. Additionally the script waits for the `/tmp/clamd.sock` unix socket to be available as an indicator that the container was able to start up correctly.
+
+#### My database changes are not being captured
+
+You may need to reload the service with `docker exec -it "${CONTAINER_NAME}" clamdscan --reload`.
+
+#### How do I get inside the container to debug
+
+On your local computer you can just run `make anti_virus` and wait until the script finishes. Once completed you can run the following command to drop into the container to debug:
+
+```sh
+docker exec -it anti_virus /bin/bash
+```
+
+This should drop you in a bash shell. The project files can be found in the `MOUNT_DIR` from the `scripts/anti-virus` script. The ClamAV database files are found at `/store`.
 
 ## Upload Object Scanning in AWS S3
 

--- a/scripts/anti-virus
+++ b/scripts/anti-virus
@@ -122,7 +122,7 @@ fi
 echo
 echo "Creating whitelist of files to ignore:"
 touch "${WHITELIST_FILES}"
-for file in ${IGNORE_FILES}; do
+for file in "${IGNORE_FILES[@]}"; do
   # This step verifies the ignore file exists and also details some info for debugging
   docker exec -it "${CONTAINER_NAME}" ls -alh "${MOUNT_DIR}/${file}"
   # Sigtool format is "MD5sum:Filesize:Comment"
@@ -131,7 +131,7 @@ done
 echo
 echo "Creating whitelist of signatures to ignore:"
 touch "${WHITELIST_SIGS}"
-for sig in ${IGNORE_SIGS}; do
+for sig in "${IGNORE_SIGS[@]}"; do
   echo "${sig}" | tee -a "${WHITELIST_SIGS}"
 done
 

--- a/scripts/anti-virus
+++ b/scripts/anti-virus
@@ -1,12 +1,19 @@
 #! /usr/bin/env bash
 
-set -exu -o pipefail
+set -eu -o pipefail
 
 #
 # Title: Anti Virus Scanning of Source Code
 #
 # More information about the docker setup is found here: https://github.com/mko-x/docker-clamav
 #
+
+function msg_now() {
+  msg=$1
+  echo -e "\n$msg: $(date +"%Y-%m-%dT%H:%M:%S %Z")"
+}
+
+msg_now "Script Start Time"
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../" && pwd )"
 readonly DIR
@@ -18,10 +25,19 @@ CONTAINER_NAME=anti_virus
 readonly CONTAINER_NAME
 MOUNT_DIR=/transcom/mymove
 readonly MOUNT_DIR
-IGNORE_FILES=pkg/testdatagen/testdata/orders.pdf
+IGNORE_FILES=(pkg/testdatagen/testdata/orders.pdf)
 readonly IGNORE_FILES
-WHITELIST=whitelist_files.fp
-readonly WHITELIST
+# WARNING: IGNORE AT OUR PERIL. IF ADDING HERE ADD NOTES!
+# - PUA.Pdf.Trojan.EmbeddedJavaScript-1 is ignored because we don't ship PDFs in any docker containers
+# - orders.pdf.UNOFFICIAL is a finding based on the ignored file above of the same name
+IGNORE_SIGS=(PUA.Pdf.Trojan.EmbeddedJavaScript-1 orders.pdf.UNOFFICIAL)
+readonly IGNORE_SIGS
+# *.fp is preferred over *.hsb
+WHITELIST_FILES=whitelist-files.fp
+readonly WHITELIST_FILES
+# *.ign2 replaces *.ign files
+WHITELIST_SIGS=whitelist-signatures.ign2
+readonly WHITELIST_SIGS
 
 if [ -n "${CIRCLECI+x}" ]; then
   echo "RUNNING IN CIRCLECI"
@@ -31,22 +47,66 @@ fi
 echo
 echo "Cleaning up existing containers and files:"
 docker rm -f "${CONTAINER_NAME}" || true
-rm -f "${WHITELIST}"
+rm -f "${WHITELIST_FILES}"
+rm -f "${WHITELIST_SIGS}"
 
 # Start the clamd service and update with freshclam (takes several minutes to be running)
 echo
 echo "Starting clamd service:"
 docker pull "${DOCKER_IMAGE}"
 
-# Mount the project directory inside for scanning later
-echo
-echo "Mounting the project directory for scanning:"
-docker run -d -p 3310:3310 -v "${DIR}:${MOUNT_DIR}" --name "${CONTAINER_NAME}" "${DOCKER_IMAGE}"
-if ! docker inspect -f '{{.State.Running}}' "${CONTAINER_NAME}"; then
-  docker logs "${CONTAINER_NAME}"
-  echo "Container not running!"
-  exit 1
-fi
+# In the Retry here we are trying to do a couple things:
+# - Let 'freshclam' download all the new virus definitions. If this flakes because of an outage
+#   with ClamAV then the whole docker container can exit prematurely
+# - Wait for the socket to exist so we can connect to it
+#
+# Waiting does take longer but doing work during the startup process (especially while freshclam
+# is updating) means we may be run into a container exiting early and its unclear why.
+
+# Start rerun loop here
+for RETRY_COUNT in {1..5}; do
+  msg_now "Retry Start Time"
+
+  # Mount the project directory inside for scanning later
+  echo
+  echo "Mounting the project directory for scanning:"
+  docker run -d -p 3310:3310 -v "${DIR}:${MOUNT_DIR}" --name "${CONTAINER_NAME}" "${DOCKER_IMAGE}"
+
+  # Need to sleep just long enough for docker to start up
+  sleep 5
+  if [ "$(docker inspect -f '{{.State.Running}}' "${CONTAINER_NAME}")" == "false" ]; then
+    docker logs "${CONTAINER_NAME}"
+    docker rm -f "${CONTAINER_NAME}"
+    echo "Container not running! Retry number ${RETRY_COUNT}"
+    if [ "${RETRY_COUNT}" == "5" ]; then
+      echo "Script cannot continue now that retries are exhuasted"
+      exit 1
+    else
+      break
+    fi
+  else
+    # Remove warning from clamav:
+    # WARNING: Ignoring deprecated option DetectBrokenExecutables at /etc/clamav/clamd.conf:30
+    docker exec -it "${CONTAINER_NAME}" sed -i 's/.*DetectBrokenExecutables.*//' /etc/clamav/clamd.conf
+
+    # Wait for the clamd service to be available by checking on the existence of the socket
+    while true; do
+      if docker exec -it "${CONTAINER_NAME}" ls /tmp/clamd.sock &> /dev/null ; then
+        break
+      else
+        echo "Retry ${RETRY_COUNT}: Waiting ${SLEEP} seconds for clamd service to be available"
+        sleep "${SLEEP}"
+      fi
+    done
+    break
+  fi
+done
+
+msg_now "Retry Complete Time"
+
+#
+# At this point the container needs to be running and be stable.
+#
 
 if [[ -n "${CIRCLECI+x}" ]]; then
   # Can't mount folders in CircleCI so copy this data in
@@ -55,52 +115,72 @@ if [[ -n "${CIRCLECI+x}" ]]; then
 fi
 
 # Create a whitelist of files to ignore
+# The whitelisting is done using `sigtool` to create an md5 hash and placing it in a file
 # See https://www.clamav.net/documents/whitelist-databases
 # See https://owlbearconsulting.com/doku.php?id=linux_wiki:clamav#whitelist_a_file
+# See https://www.clamav.net/documents/file-hash-signatures
 echo
 echo "Creating whitelist of files to ignore:"
-touch "${WHITELIST}"
+touch "${WHITELIST_FILES}"
 for file in ${IGNORE_FILES}; do
-  docker exec -it "${CONTAINER_NAME}" ls "${MOUNT_DIR}/${file}"
-  docker exec -it "${CONTAINER_NAME}" sigtool --md5 "${MOUNT_DIR}/${file}" | tee -a "${WHITELIST}"
+  # This step verifies the ignore file exists and also details some info for debugging
+  docker exec -it "${CONTAINER_NAME}" ls -alh "${MOUNT_DIR}/${file}"
+  # Sigtool format is "MD5sum:Filesize:Comment"
+  docker exec -it "${CONTAINER_NAME}" sigtool --md5 "${MOUNT_DIR}/${file}" | tee -a "${WHITELIST_FILES}"
+done
+echo
+echo "Creating whitelist of signatures to ignore:"
+touch "${WHITELIST_SIGS}"
+for sig in ${IGNORE_SIGS}; do
+  echo "${sig}" | tee -a "${WHITELIST_SIGS}"
 done
 
 # Copy the ignore list into the container in the same directory as the virus database
 echo
 echo "Copying the ignore list into the container:"
-docker cp "${WHITELIST}" "${CONTAINER_NAME}:/store/"
-docker logs "${CONTAINER_NAME}"
-docker exec -it "${CONTAINER_NAME}" chown clamav:clamav "/store/${WHITELIST}"
+docker cp "${WHITELIST_FILES}" "${CONTAINER_NAME}:/store/"
+docker cp "${WHITELIST_SIGS}" "${CONTAINER_NAME}:/store/"
+docker exec -it "${CONTAINER_NAME}" chown root:root "/store/${WHITELIST_FILES}" "/store/${WHITELIST_SIGS}"
 
 echo
 echo "********************************************************************************"
 echo "WARNING: Ignoring these specific files in sigtool format:"
-cat "${WHITELIST}"
+cat "${WHITELIST_FILES}"
 echo "********************************************************************************"
 echo
+echo "********************************************************************************"
+echo "WARNING: Ignoring these specific virus signatures:"
+cat "${WHITELIST_SIGS}"
+echo "********************************************************************************"
 
-# Wait for the clamd service to be available by checking on the existence of the socket
-while true; do
-  if docker exec -it "${CONTAINER_NAME}" ls /tmp/clamd.sock &> /dev/null ; then
-    break
-  else
-    echo "Waiting ${SLEEP} seconds for clamd service to be available"
-    sleep "${SLEEP}"
-  fi
-done
+echo
+echo "Look at all ClamAV files:"
+docker exec -it "${CONTAINER_NAME}" ls -alh "/store/"
+
+echo
+echo "Reload the virus database with ignore files"
+docker exec -it "${CONTAINER_NAME}" clamdscan --reload
 
 # Print the logs so we can see the state of clamd prior to scanning
+echo
+echo "********************************************************************************"
 docker logs "${CONTAINER_NAME}"
 
 # List the version we're working with for auditing reasons
 echo
 echo "Version Information:"
 docker exec -it "${CONTAINER_NAME}" clamd --version
+echo "********************************************************************************"
 echo
 
-# Run the scan against the mounted folder
-docker exec -it "${CONTAINER_NAME}" clamdscan -v "${MOUNT_DIR}"
+# Run the scan against the mounted folder as well as the folder containing virus defs and whitelists
+msg_now "Scan Start Time"
+docker exec -it "${CONTAINER_NAME}" clamdscan -v /store "${MOUNT_DIR}"
+msg_now "Scan End Time"
 
-# Clean up
+# Clean up, useful in developement only
 # docker rm -f "${CONTAINER_NAME}"
-# rm -f "${WHITELIST}"
+# rm -f "${WHITELIST_FILES}"
+# rm -f "${WHITELIST_SIGS}"
+
+msg_now "Script End Time"


### PR DESCRIPTION
## Description

While assessing https://github.com/transcom/mymove/pull/3677 I saw some pretty major structural changes that needed to be addressed. A couple things this does:

- Copies the retry logic from https://github.com/transcom/mymove/pull/3677
- Moves a section of code that waits for the service to be stable up into the retry logic and blocks, which forces us to look for the one signal that should tell us if we can continue: `/tmp/clamd.sock`. This may increase the time on CircleCI by up to a minute or longer but I think it's a valuable tradeoff.
- Fix the `docker inspect` code to work properly since it only returns string values of `true` or `false`
- Added virus signatures to ignore
- Fixed permissions with regards to virus database
- Reload the virus databases after they've been updated with the virus whitelists
- Fix an annoying warning about a deprecated line in `/etc/clamav/clamd.conf` which causes confusion when folks diagnose problems with this script
- Added a bunch of timestamp information to make it easier to know elapsed time of different processes

I'm also personally tracking https://github.com/mko-x/docker-clamav/issues/39 which talks about how the software being loaded is an outdated version, which may be the cause of some intermittent flakiness. 

Honestly the next time I have to touch this will be to make it a separate repo so I can use it in several places across Transcom's git projects. Hopefully this will keep us stable for a while.

## Setup

Try it yourself!

```sh
make clean anti_virus
```