### PR TITLE
MB-60 document storybook practices

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -17,3 +17,6 @@
 
 # Storybook Stories are stored in this directory and should be reviewed by desgin
 /src/stories/ @transcom/truss-design
+
+# The reference, ie approved, images for Loki tests of Storybook Stories are stored in this directory and should be reviewed by desgin
+/.loki/reference/ @transcom/truss-design

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,3 +14,6 @@
 
 # Migrations are where database schema changes are made and we want them reviewed by people working on our database guidelines
 /migrations/ @transcom/truss-db
+
+# Storybook Stories are stored in this directory and should be reviewed by desgin
+/src/stories/ @transcom/truss-design

--- a/.spelling
+++ b/.spelling
@@ -580,5 +580,6 @@ LICENSE.txt
 unix
 mko-x
 docker-clamav#39
+TabNav
 # Put all custom terms BEFORE this comment, lest 'pre-commit' and 'make spellcheck' yield different errors.
  - ./docs/backend/route-planner.md

--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -5,11 +5,11 @@ import 'loki/configure-react';
 import './storybook.scss';
 import '../src/index.scss';
 
-function loadStories() {
-  require('../src/stories/index.stories.jsx');
-  require('../src/stories/statusTimeLine.stories.jsx');
-  require('../src/stories/tabNav.stories.jsx');
-}
+const req = require.context('../src', true, /\.stories\.jsx?$/);
+
+const loadStories = () => {
+  req.keys().forEach(req);
+};
 
 addDecorator(withInfo);
 configure(loadStories, module);

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -4,10 +4,15 @@
 
 <!-- toc -->
 
+* [Design + Engineering Process for new components](#design--engineering-process-for-new-components)
+  * [Design delivers component design](#design-delivers-component-design)
+  * [Engineering](#engineering)
+  * [Update Loki tests accordingly](#update-loki-tests-accordingly)
 * [Testing](#testing)
   * [Test Runners and Libraries](#test-runners-and-libraries)
   * [Writing Tests](#writing-tests)
   * [Browser Testing](#browser-testing)
+  * [Storybook Testing](#storybook-testing)
 * [Code Style](#code-style)
   * [Auto-formatting](#auto-formatting)
   * [Linting](#linting)
@@ -36,6 +41,24 @@ Regenerate with "pre-commit run -a markdown-toc"
 
 <!-- tocstop -->
 
+## Design + Engineering Process for new components
+
+MilMove has defined a process for taking a new component from concept to design to implementation. This section of the doc will describe this process. We use [Storybook](https://storybook.js.org/) for showing the finished components and you can view all current ones on master by going to our [public storybook site](https://storybook.move.mil/). If you want to see things locally please check out the [How To Run Storybook](how-to/run-storybook.md) document.
+
+### Design delivers component design
+
+After the research and initial prototypes are made a designer will create a full design for a new component, card, or page. Once the design has passed the design team's review process the designer will deliver a link to the [Abstract](https://www.abstract.com/) design. Since engineers are not likely to have an Abstract account the designers will ensure that this link is a publicly viewable version. For example here is the link we used for the [TabNav](https://app.abstract.com/share/39907fe2-a5c6-4063-ac68-71bae522e296?mode=build&selected=3210965808-139C6AE4-167B-4B24-B583-C1F45CC3493D) component.
+
+We have added the github `@transcom/truss-design` as code owners of `src/stories` thus requiring their approval for these changes in addition to normal engineering review.
+
+### Engineering
+
+Once an engineer has the Abstract design for a new component they can begin to implement it. The new process requires that all components have a [Storybook](https://storybook.js.org/) story created or updated for it. Storybook stories require approval from someone on the design team before they can be merged, preferable the designer who created the original Abstract design. We are following the [USWDS](#uswds) standard for design and implementation, so please review that section of this document. Be sure to use [USWDS mixins](https://designsystem.digital.gov/utilities/) and any components that are available in `react-uswds`. If there is a USWDS component not already in `react-uswds` please add it to that package and then make use of it.
+
+### Update Loki tests accordingly
+
+We currently use [Loki](https://loki.js.org/) for ensuring our storybook components do not regress as the project goes on. Please ensure you run the tests and add or update new reference images as you create or update components. See [How to Run Loki tests against Storybook](how-to/run-loki-tests-against-storybook.md) document for more details.
+
 ## Testing
 
 ### Test Runners and Libraries
@@ -62,6 +85,11 @@ Regenerate with "pre-commit run -a markdown-toc"
 
 * We use the [Cypress framework](https://www.cypress.io/) for most browser testing, both with chrome and headless chrome
 * For testing on Windows 10 with IE 11 we have a [testing document](https://docs.google.com/document/d/1j04tGHTBpcdS8RSzlSB-dImLbIxsLpsFlCzZUWxUKxg/edit#)
+
+### Storybook Testing
+
+* We use the [Loki](https://loki.js.org/) package for visually testing storybook.
+* For details on how to run, add, or update these tests see [How to Run Loki tests against Storybook](how-to/run-loki-tests-against-storybook.md)
 
 ## Code Style
 

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -237,6 +237,7 @@ Important JS patterns and features to understand.
 Various resources on React, Redux, etc, for a variety of learning styles.
 
 * _Read_: [React Tutorial](https://reactjs.org/tutorial/tutorial.html) - Official tutorial from React. I (Alexi) personally found this cumbersome. If you stick with it you’ll learn the basics.
+* _Read_: [Modern JavaScript Tutorial](https://javascript.info/) - A site with tutorials covering many modern javascript concepts
 * _Watch_: [Getting Started with Redux](https://egghead.io/courses/getting-started-with-redux) - Free 30 video series by the author of Redux.
 * _Watch_: [ReactJS / Redux Tutorial](https://www.youtube.com/playlist?list=PL55RiY5tL51rrC3sh8qLiYHqUV3twEYU_) - ~60 minutes of YouTube videos that will get you up and running with React and Redux. The content is useful, the guy’s voice can be a bit of a challenge.
 * _Watch_: [This video](https://www.youtube.com/watch?list=PLb0IAmt7-GS188xDYE-u1ShQmFFGbrk0v&v=nYkdrAPrdcw) from the introduction of Flux can be useful for some high-level background about the pattern (the MVC bashing is overdone, but otherwise this video is useful.)

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -8,7 +8,7 @@
   * [Test Runners and Libraries](#test-runners-and-libraries)
   * [Writing Tests](#writing-tests)
   * [Browser Testing](#browser-testing)
-* [Style](#style)
+* [Code Style](#code-style)
   * [Auto-formatting](#auto-formatting)
   * [Linting](#linting)
   * [File Layout & Naming](#file-layout--naming)
@@ -16,7 +16,7 @@
   * [Function Declarations](#function-declarations)
   * [Ordering imports](#ordering-imports)
   * [Using Redux](#using-redux)
-  * [Styling Standards](#styling-standards)
+  * [CSS Styling Standards](#css-styling-standards)
     * [Using Sass and CSS Modules](#using-sass-and-css-modules)
     * [Classnames](#classnames)
     * [rem vs. em](#rem-vs-em)
@@ -63,7 +63,7 @@ Regenerate with "pre-commit run -a markdown-toc"
 * We use the [Cypress framework](https://www.cypress.io/) for most browser testing, both with chrome and headless chrome
 * For testing on Windows 10 with IE 11 we have a [testing document](https://docs.google.com/document/d/1j04tGHTBpcdS8RSzlSB-dImLbIxsLpsFlCzZUWxUKxg/edit#)
 
-## Style
+## Code Style
 
 Adhere to Airbnb's [JavaScript Style Guide](https://github.com/airbnb/javascript) unless they conflict with the project’s Prettier or Lint rules.
 
@@ -128,7 +128,7 @@ Adhere to Airbnb's [JavaScript Style Guide](https://github.com/airbnb/javascript
 * Connect higher level components to Redux, pass down props to less significant children. (Avoid connecting everything to Redux.)
 * Use [ducks](https://github.com/erikras/ducks-modular-redux) for organizing code.
 
-### Styling Standards
+### CSS Styling Standards
 
 MilMove is transitioning from anarchistic styling to more organized and standardized styling, so much of the existing code is not yet organized to the current standards.  You can find an example of refactored code styling of `InvoicePane.jsx` in `InvoicePanel.module.scss` and its child components and corresponding stylesheets.  All new components/styling should utilize the below standards. When we touch an existing component, we should try to adjust the styling to follow the standards.
 

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -169,8 +169,9 @@ Understand the [difference between rem and em](https://zellwk.com/blog/rem-vs-em
 
 #### USWDS
 
-* Check the [USWDS Design Standards](https://standards.usa.gov/components/) for a component that matches your needs. Maximize the code view to see what classes to use to replicate the component styles.
-* USWDS has a [Slack chat](https://chat.18f.gov/) you can go to for help. Get invited to it by filling out this form.
+* Check the [Truss USWDS React package](https://github.com/trussworks/react-uswds) for a component that matches your needs. Maximize the code view to see what classes to use to replicate the component styles.
+* If there isn't a component there already Check the [Truss USWDS React package](https://standards.usa.gov/components/) for a component that matches your needs. Please add it to the USWDS React code and then import the new version for use in MilMove.
+* USWDS has a [Slack chat](https://chat.18f.gov/) you can go to for help. Get invited to it by filling out [this form](https://chat.18f.gov/).
 
 ## Tooling
 

--- a/docs/how-to/run-loki-tests-against-storybook.md
+++ b/docs/how-to/run-loki-tests-against-storybook.md
@@ -6,7 +6,8 @@ MilMove uses [Loki](https://loki.js.org/) for testing stories in storybook to en
 
 ### Prereqs
 
-You will need storybook running locally already. See [How to Run Storybook](docs/how-to/run-storybook.md) for details
+* You will need storybook running locally already. See [How to Run Storybook](docs/how-to/run-storybook.md) for details.
+* You will need Docker for Mac running locally as well. You can install the latest stable version from [here](https://download.docker.com/mac/stable/Docker.dmg).
 
 ### Running Loki Tests
 

--- a/docs/how-to/run-storybook.md
+++ b/docs/how-to/run-storybook.md
@@ -8,15 +8,19 @@ Storybook is a user interface development environment and playground for UI comp
 
 Storybook expects _stories_ to be defined for each component to be showcased. These stories are defined in the stories directory `src/stories`
 
-### Dependencies
+### Running with tooling installed locally
+
+This is the flow that most engineers will likely take since they probably have all the dependencies installed already.
+
+#### Dependencies
 
 If this is your first time running storybook you should run `make client_deps` first to ensure storybook packages are installed
 
-### How to run storybook server locally
+#### How to run storybook server locally
 
 To see the components locally simply run `make storybook` and the server will start and automatically open a browser window. If not open [http://localhost:6006](http://localhost:6006)
 
-### How to generate static storybook site files
+#### How to generate static storybook site files
 
 If you wish to generate the static version of storybook run `make build_storybook` and the command will generate the files in `storybook-static`
 

--- a/docs/how-to/run-storybook.md
+++ b/docs/how-to/run-storybook.md
@@ -46,4 +46,4 @@ We use [Loki](https://loki.js.org/) for testing our storybook stories. You will 
 
 ### Story changes require approval of Design
 
-As part of the new process of Design and Engineering collaboration, the design team has been made code owners of the code in `src/stories`. So if you are adding a new story or modifying an existing one you will be required to have a designer give their approval on the GitHub PR.
+As part of the new process of Design and Engineering collaboration, the design team has been made code owners of the code in `src/stories` and the reference, ie approved, images in `.loki/reference`. So if you are adding a new story, modifying an existing one, or updating Loki reference images you will be required to have a designer give their approval on the GitHub PR.

--- a/docs/how-to/run-storybook.md
+++ b/docs/how-to/run-storybook.md
@@ -39,3 +39,11 @@ Storybook Addon Actions can be used to display data received by event handlers i
 #### Knobs
 
 Storybook Addon Knobs allow you to edit props dynamically using the Storybook UI. You can also use Knobs as a dynamic variable inside stories in Storybook. See [the documentation](https://github.com/storybookjs/storybook/tree/master/addons/knobs) for more details.
+
+### Testing Stories
+
+We use [Loki](https://loki.js.org/) for testing our storybook stories. You will need to approve any changes to the reference images before a build will pass. Read [How to Run Loki tests against Storybook](run-loki-tests-against-storybook.md) for details.
+
+### Story changes require approval of Design
+
+As part of the new process of Design and Engineering collaboration, the design team has been made code owners of the code in `src/stories`. So if you are adding a new story or modifying an existing one you will be required to have a designer give their approval on the GitHub PR.


### PR DESCRIPTION
## Description

Adds documentation around the new process for creating storybook stories, getting design approval, loki tests for storybook stories, and some minor tweaks and improvements to other frontend documentation. This PR blocks the merging of #3708 

## Reviewer Notes

Make sure the documentation is clear, that I didn't assume any knowledge that will be confusing for others who may not be as familiar with the MilMove front end.

## Setup

Only documentation chagnes. If you have [grip](https://github.com/joeyespo/grip) installed you can preview the changes in your browser via the command below. Then browsing the following urls

```sh
grip
```

* http://localhost:6419/docs/frontend.md
* http://localhost:6419/docs/how-to/run-loki-tests-against-storybook.md
* http://localhost:6419/docs/how-to/run-storybook.md

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [MB-60](https://dp3.atlassian.net/browse/MB-60) for this change