### PR TITLE
Remove broken progear icon: MB-1918

### DIFF
--- a/src/scenes/Moves/Ppm/PaymentReview/WeightTicketListItem.jsx
+++ b/src/scenes/Moves/Ppm/PaymentReview/WeightTicketListItem.jsx
@@ -74,7 +74,6 @@ class WeightTicketListItem extends Component {
               src={WEIGHT_TICKET_IMAGES[weight_ticket_set_type]}
               alt={weight_ticket_set_type}
             />
-            /* eslint-disable security/detect-object-injection */
           )}
         </div>
         <div style={{ flex: 1 }}>

--- a/src/scenes/Moves/Ppm/PaymentReview/WeightTicketListItem.jsx
+++ b/src/scenes/Moves/Ppm/PaymentReview/WeightTicketListItem.jsx
@@ -62,16 +62,20 @@ class WeightTicketListItem extends Component {
     } = this.props;
     const { showDeleteConfirmation } = this.state;
     const isInfected = this.areUploadsInfected(uploads);
+    const showWeightTicketIcon = weight_ticket_set_type !== 'PRO_GEAR';
     return (
       <div className="ticket-item" style={{ display: 'flex' }}>
         {/* size of largest of the images */}
         <div style={{ minWidth: 95 }}>
-          {/*eslint-disable security/detect-object-injection*/}
-          <img
-            className="weight-ticket-image"
-            src={WEIGHT_TICKET_IMAGES[weight_ticket_set_type]}
-            alt={weight_ticket_set_type}
-          />
+          {showWeightTicketIcon && (
+            /* eslint-disable security/detect-object-injection */
+            <img
+              className="weight-ticket-image"
+              src={WEIGHT_TICKET_IMAGES[weight_ticket_set_type]}
+              alt={weight_ticket_set_type}
+            />
+            /* eslint-disable security/detect-object-injection */
+          )}
         </div>
         <div style={{ flex: 1 }}>
           <div className="weight-li-item-container">


### PR DESCRIPTION
## Description

Progear has no associated icon (yet). Remove broken progear icon to show nothing vs a broken icon image.

## Setup

add a progear weight ticket... There should be no broken icon image next to the name

## Code Review Verification Steps

* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-1918) for this change

## Screenshots

<img width="919" alt="Screen Shot 2020-03-06 at 7 59 37 AM" src="https://user-images.githubusercontent.com/3099491/76091003-51bdc580-5f82-11ea-97e4-6cda78782d0e.png">
