### PR TITLE
Rename weight_ticket_set to pro_gear_weight

### DIFF
--- a/pkg/handlers/internalapi/weight_ticket_set_documents.go
+++ b/pkg/handlers/internalapi/weight_ticket_set_documents.go
@@ -133,7 +133,7 @@ func (h CreateWeightTicketSetDocumentHandler) Handle(params movedocop.CreateWeig
 	if (string(*payload.WeightTicketSetType) == string(models.WeightTicketSetTypeBOXTRUCK)) ||
 		(string(*payload.WeightTicketSetType) == string(models.WeightTicketSetTypePROGEAR)) {
 		if payload.VehicleNickname == nil {
-			wtTypeErr := fmt.Errorf("weight ticket set for type %s must have values for vehicle make and model", string(*payload.WeightTicketSetType))
+			wtTypeErr := fmt.Errorf("weight ticket set for type %s must have value for vehicle nickname", string(*payload.WeightTicketSetType))
 			return handlers.ResponseForCustomErrors(logger, wtTypeErr, 422)
 		}
 	}

--- a/pkg/handlers/internalapi/weight_ticket_set_documents_test.go
+++ b/pkg/handlers/internalapi/weight_ticket_set_documents_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/transcom/mymove/pkg/testdatagen"
 )
 
-func (suite *HandlerSuite) TestCreateWeightTicketSetDocumentHandler() {
+func (suite *HandlerSuite) TestWeightTicketSetDocumentHandlerValidate() {
 
 	ppm := testdatagen.MakeDefaultPPM(suite.DB())
 	sm := ppm.Move.Orders.ServiceMember
@@ -91,7 +91,7 @@ func (suite *HandlerSuite) TestCreateWeightTicketSetDocumentHandler() {
 
 }
 
-func (suite *HandlerSuite) TestCreateWeightTicketSetDocumentCarHandler() {
+func (suite *HandlerSuite) TestWeightTicketSetDocumentHandlerCreate() {
 	tests := []struct {
 		weightTicketSetType string
 		resultTitle         string
@@ -118,7 +118,7 @@ func (suite *HandlerSuite) TestCreateWeightTicketSetDocumentCarHandler() {
 	}
 }
 
-func (suite *HandlerSuite) TestCreateWeightTicketSetDocumentHandlerFailure() {
+func (suite *HandlerSuite) TestWeightTicketSetDocumentHandlerCreateFailure() {
 
 	ppm := testdatagen.MakeDefaultPPM(suite.DB())
 	sm := ppm.Move.Orders.ServiceMember

--- a/pkg/handlers/internalapi/weight_ticket_set_documents_test.go
+++ b/pkg/handlers/internalapi/weight_ticket_set_documents_test.go
@@ -91,56 +91,34 @@ func (suite *HandlerSuite) TestCreateWeightTicketSetDocumentHandler() {
 
 }
 
-func (suite *HandlerSuite) TestCreateCarWeightTicketSetDocumentHandler() {
-
-	ppm := testdatagen.MakeDefaultPPM(suite.DB())
-	sm := ppm.Move.Orders.ServiceMember
-
-	upload := testdatagen.MakeUpload(suite.DB(), testdatagen.Assertions{
-		Upload: models.Upload{
-			UploaderID: sm.UserID,
-		},
-	})
-	upload.DocumentID = nil
-	suite.MustSave(&upload)
-	uploadIds := []strfmt.UUID{*handlers.FmtUUID(upload.ID)}
-
-	request := httptest.NewRequest("POST", "/fake/path", nil)
-	request = suite.AuthenticateRequest(request, sm)
-
-	weightTicketSetType := internalmessages.WeightTicketSetType("CAR")
-	newWeightTicketSetDocumentPayload := internalmessages.CreateWeightTicketDocumentsPayload{
-		UploadIds:                uploadIds,
-		EmptyWeight:              handlers.FmtInt64(1000),
-		FullWeight:               handlers.FmtInt64(2000),
-		EmptyWeightTicketMissing: handlers.FmtBool(false),
-		FullWeightTicketMissing:  handlers.FmtBool(false),
-		PersonallyProcuredMoveID: handlers.FmtUUID(ppm.ID),
-		VehicleMake:              handlers.FmtString("Radio Flyer"),
-		VehicleModel:             handlers.FmtString("Wagon"),
-		WeightTicketSetType:      &weightTicketSetType,
-		WeightTicketDate:         handlers.FmtDate(testdatagen.NextValidMoveDate),
-		TrailerOwnershipMissing:  handlers.FmtBool(false),
+func (suite *HandlerSuite) TestCreateWeightTicketSetDocumentCarHandler() {
+	tests := []struct {
+		weightTicketSetType string
+		resultTitle         string
+	}{
+		{weightTicketSetType: "CAR", resultTitle: "weight_ticket_set"},
+		{weightTicketSetType: "CAR_TRAILER", resultTitle: "weight_ticket_set"},
+		{weightTicketSetType: "BOX_TRUCK", resultTitle: "weight_ticket_set"},
+		{weightTicketSetType: "PRO_GEAR", resultTitle: "pro_gear_weight"},
 	}
 
-	newWeightTicketSetDocParams := movedocop.CreateWeightTicketDocumentParams{
-		HTTPRequest:                request,
-		CreateWeightTicketDocument: &newWeightTicketSetDocumentPayload,
-		MoveID:                     strfmt.UUID(ppm.MoveID.String()),
-	}
+	for _, t := range tests {
+		newWeightTicketSetDocParams := createWeightTicketSetDocument(suite, t.weightTicketSetType)
 
-	context := handlers.NewHandlerContext(suite.DB(), suite.TestLogger())
-	fakeS3 := storageTest.NewFakeS3Storage(true)
-	context.SetFileStorer(fakeS3)
-	handler := CreateWeightTicketSetDocumentHandler{context}
-	response := handler.Handle(newWeightTicketSetDocParams)
-	suite.IsNotErrResponse(response)
-	createdResponse := response.(*movedocop.CreateWeightTicketDocumentOK)
-	createdPayload := createdResponse.Payload
-	suite.NotNil(createdPayload.ID)
+		context := handlers.NewHandlerContext(suite.DB(), suite.TestLogger())
+		fakeS3 := storageTest.NewFakeS3Storage(true)
+		context.SetFileStorer(fakeS3)
+		handler := CreateWeightTicketSetDocumentHandler{context}
+		response := handler.Handle(newWeightTicketSetDocParams)
+		suite.IsNotErrResponse(response)
+		createdResponse := response.(*movedocop.CreateWeightTicketDocumentOK)
+		createdPayload := createdResponse.Payload
+		suite.NotNil(createdPayload.ID)
+		suite.Equal(*createdPayload.Title, t.resultTitle)
+	}
 }
 
-func (suite *HandlerSuite) TestCreaterWeightTicketSetDocumentHandlerFailure() {
+func (suite *HandlerSuite) TestCreateWeightTicketSetDocumentHandlerFailure() {
 
 	ppm := testdatagen.MakeDefaultPPM(suite.DB())
 	sm := ppm.Move.Orders.ServiceMember
@@ -218,4 +196,46 @@ func (suite *HandlerSuite) TestCreaterWeightTicketSetDocumentHandlerFailure() {
 		response := handler.Handle(newWeightTicketSetDocParams)
 		suite.CheckErrorResponse(response, 422, "weight ticket set for type BOX_TRUCK must have a value for vehicle nickname")
 	})
+}
+
+func createWeightTicketSetDocument(suite *HandlerSuite, weightTicketSetType string) movedocop.CreateWeightTicketDocumentParams {
+
+	ppm := testdatagen.MakeDefaultPPM(suite.DB())
+	sm := ppm.Move.Orders.ServiceMember
+
+	upload := testdatagen.MakeUpload(suite.DB(), testdatagen.Assertions{
+		Upload: models.Upload{
+			UploaderID: sm.UserID,
+		},
+	})
+	upload.DocumentID = nil
+	suite.MustSave(&upload)
+	uploadIds := []strfmt.UUID{*handlers.FmtUUID(upload.ID)}
+
+	request := httptest.NewRequest("POST", "/fake/path", nil)
+	request = suite.AuthenticateRequest(request, sm)
+
+	wtst := internalmessages.WeightTicketSetType(weightTicketSetType)
+	newWeightTicketSetDocumentPayload := internalmessages.CreateWeightTicketDocumentsPayload{
+		UploadIds:                uploadIds,
+		EmptyWeight:              handlers.FmtInt64(1000),
+		FullWeight:               handlers.FmtInt64(2000),
+		EmptyWeightTicketMissing: handlers.FmtBool(false),
+		FullWeightTicketMissing:  handlers.FmtBool(false),
+		PersonallyProcuredMoveID: handlers.FmtUUID(ppm.ID),
+		VehicleNickname:          handlers.FmtString("My red wagon"),
+		VehicleMake:              handlers.FmtString("Radio Flyer"),
+		VehicleModel:             handlers.FmtString("Wagon"),
+		WeightTicketSetType:      &wtst,
+		WeightTicketDate:         handlers.FmtDate(testdatagen.NextValidMoveDate),
+		TrailerOwnershipMissing:  handlers.FmtBool(false),
+	}
+
+	newWeightTicketSetDocParams := movedocop.CreateWeightTicketDocumentParams{
+		HTTPRequest:                request,
+		CreateWeightTicketDocument: &newWeightTicketSetDocumentPayload,
+		MoveID:                     strfmt.UUID(ppm.MoveID.String()),
+	}
+
+	return newWeightTicketSetDocParams
 }

--- a/pkg/models/move.go
+++ b/pkg/models/move.go
@@ -380,56 +380,6 @@ func (m Move) CreateMovingExpenseDocument(
 	return newMovingExpenseDocument, responseVErrors, responseError
 }
 
-// CreateWeightTicketSetDocument creates a moving weight ticket document associated to a move and move document
-func (m Move) CreateWeightTicketSetDocument(
-	db *pop.Connection,
-	uploads Uploads,
-	personallyProcuredMoveID *uuid.UUID,
-	weightTicketSetDocument *WeightTicketSetDocument,
-	moveType SelectedMoveType) (*WeightTicketSetDocument, *validate.Errors, error) {
-
-	weightTicketSetTitle := "weight_ticket_set"
-	if weightTicketSetDocument.WeightTicketSetType == "PRO_GEAR" {
-		weightTicketSetTitle = "pro_gear_weight"
-	}
-
-	var responseError error
-	responseVErrors := validate.NewErrors()
-
-	db.Transaction(func(db *pop.Connection) error {
-		transactionError := errors.New("Rollback The transaction")
-
-		var newMoveDocument *MoveDocument
-		newMoveDocument, responseVErrors, responseError = m.createMoveDocumentWithoutTransaction(
-			db,
-			uploads,
-			personallyProcuredMoveID,
-			MoveDocumentTypeWEIGHTTICKETSET,
-			weightTicketSetTitle,
-			weightTicketSetDocument.VehicleNickname,
-			moveType)
-		if responseVErrors.HasAny() || responseError != nil {
-			return transactionError
-		}
-
-		weightTicketSetDocument.MoveDocument = *newMoveDocument
-		weightTicketSetDocument.MoveDocumentID = newMoveDocument.ID
-
-		verrs, err := db.ValidateAndCreate(weightTicketSetDocument)
-		if err != nil || verrs.HasAny() {
-			responseVErrors.Append(verrs)
-			responseError = errors.Wrap(err, "Error creating moving expense document")
-			weightTicketSetDocument = nil
-			return transactionError
-		}
-
-		return nil
-
-	})
-
-	return weightTicketSetDocument, responseVErrors, responseError
-}
-
 // CreatePPM creates a new PPM associated with this move
 func (m Move) CreatePPM(db *pop.Connection,
 	size *internalmessages.TShirtSize,

--- a/pkg/models/move.go
+++ b/pkg/models/move.go
@@ -388,6 +388,11 @@ func (m Move) CreateWeightTicketSetDocument(
 	weightTicketSetDocument *WeightTicketSetDocument,
 	moveType SelectedMoveType) (*WeightTicketSetDocument, *validate.Errors, error) {
 
+	weightTicketSetTitle := "weight_ticket_set"
+	if weightTicketSetDocument.WeightTicketSetType == "PRO_GEAR" {
+		weightTicketSetTitle = "pro_gear_weight"
+	}
+
 	var responseError error
 	responseVErrors := validate.NewErrors()
 
@@ -400,7 +405,7 @@ func (m Move) CreateWeightTicketSetDocument(
 			uploads,
 			personallyProcuredMoveID,
 			MoveDocumentTypeWEIGHTTICKETSET,
-			"weight_ticket_set",
+			weightTicketSetTitle,
 			weightTicketSetDocument.VehicleNickname,
 			moveType)
 		if responseVErrors.HasAny() || responseError != nil {


### PR DESCRIPTION
## Description

When a SM submits a pro-gear weight ticket, default the title to be `pro_gear_weight` when an office user looks at the list of weight tickets.

## Setup

SM: create a pro-gear weight ticket 
OFFICE: click on move and list of weight tickets should include that pro-gear ticket w/ the title: `pro_gear_weight` and not `weight_ticket_set`


## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-1236) for this change

## Screenshots

<img width="948" alt="Screen Shot 2020-03-09 at 10 25 25 AM" src="https://user-images.githubusercontent.com/3099491/76229503-52f42a00-61f0-11ea-834d-01bd611f49e0.png">
