### PR TITLE
Rename weight_ticket_set to vehicle_weight: MB-1528

### DIFF
--- a/pkg/handlers/internalapi/weight_ticket_set_documents_test.go
+++ b/pkg/handlers/internalapi/weight_ticket_set_documents_test.go
@@ -96,9 +96,9 @@ func (suite *HandlerSuite) TestWeightTicketSetDocumentHandlerCreate() {
 		weightTicketSetType string
 		resultTitle         string
 	}{
-		{weightTicketSetType: "CAR", resultTitle: "weight_ticket_set"},
-		{weightTicketSetType: "CAR_TRAILER", resultTitle: "weight_ticket_set"},
-		{weightTicketSetType: "BOX_TRUCK", resultTitle: "weight_ticket_set"},
+		{weightTicketSetType: "CAR", resultTitle: "vehicle_weight"},
+		{weightTicketSetType: "CAR_TRAILER", resultTitle: "vehicle_weight"},
+		{weightTicketSetType: "BOX_TRUCK", resultTitle: "vehicle_weight"},
 		{weightTicketSetType: "PRO_GEAR", resultTitle: "pro_gear_weight"},
 	}
 

--- a/pkg/models/weight_ticket_set_document.go
+++ b/pkg/models/weight_ticket_set_document.go
@@ -109,8 +109,8 @@ func (m Move) CreateWeightTicketSetDocument(
 	weightTicketSetDocument *WeightTicketSetDocument,
 	moveType SelectedMoveType) (*WeightTicketSetDocument, *validate.Errors, error) {
 
-	weightTicketSetTitle := "weight_ticket_set"
-	if weightTicketSetDocument.WeightTicketSetType == "PRO_GEAR" {
+	weightTicketSetTitle := "vehicle_weight"
+	if weightTicketSetDocument.WeightTicketSetType == WeightTicketSetTypePROGEAR {
 		weightTicketSetTitle = "pro_gear_weight"
 	}
 


### PR DESCRIPTION
## Description

When a SM submits a weight ticket (for car/car+trailer/truck), default the title to be `vehicle_weight` when an office user looks at the list of weight tickets.

## Setup

SM: create a non pro-gear weight ticket
OFFICE: click on move and list of weight tickets should show tickets w/ the title: vehicle_weight and not weight_ticket_set

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-1528) for this change

## Screenshots

<img width="359" alt="Screen Shot 2020-03-10 at 8 55 44 AM" src="https://user-images.githubusercontent.com/3099491/76337447-5dccbe80-62c5-11ea-8d24-4ef02362710f.png">
