### PR TITLE
Fix prime-api-client broken by go upgrade to 1.14

### DIFF
--- a/cmd/prime-api-client/connection.go
+++ b/cmd/prime-api-client/connection.go
@@ -49,7 +49,10 @@ func CreateClient(cmd *cobra.Command, v *viper.Viper, args []string) (*primeClie
 		if errTLSCert != nil {
 			log.Fatal(errTLSCert)
 		}
+
+		// must explicitly state what signature algorithms we allow as of Go 1.14
 		cert.SupportedSignatureAlgorithms = []tls.SignatureScheme{tls.PKCS1WithSHA256}
+
 		// #nosec b/c gosec triggers on InsecureSkipVerify
 		tlsConfig := &tls.Config{
 			Certificates:       []tls.Certificate{*cert},

--- a/cmd/prime-api-client/connection.go
+++ b/cmd/prime-api-client/connection.go
@@ -49,7 +49,7 @@ func CreateClient(cmd *cobra.Command, v *viper.Viper, args []string) (*primeClie
 		if errTLSCert != nil {
 			log.Fatal(errTLSCert)
 		}
-
+		cert.SupportedSignatureAlgorithms = []tls.SignatureScheme{tls.PKCS1WithSHA256}
 		// #nosec b/c gosec triggers on InsecureSkipVerify
 		tlsConfig := &tls.Config{
 			Certificates:       []tls.Certificate{*cert},

--- a/cmd/prime-api-client/connection.go
+++ b/cmd/prime-api-client/connection.go
@@ -50,7 +50,7 @@ func CreateClient(cmd *cobra.Command, v *viper.Viper, args []string) (*primeClie
 			log.Fatal(errTLSCert)
 		}
 
-		// must explicitly state what signature algorithms we allow as of Go 1.14
+		// must explicitly state what signature algorithms we allow as of Go 1.14 to disable RSA-PSS signatures
 		cert.SupportedSignatureAlgorithms = []tls.SignatureScheme{tls.PKCS1WithSHA256}
 
 		// #nosec b/c gosec triggers on InsecureSkipVerify


### PR DESCRIPTION
## Description

There were minor changes that came with Go 1.14 that ended up impacting the prime-api-client. We now need to explicitly state what algorithms are supported by the certificate in order to disable RSA-PSS signatures. 

See: https://golang.org/doc/go1.14#minor_library_changes

## Reviewer Notes

Please let me know if there are additional algorithms the certificate needs to support.

ALSO NEED A CAC TO TEST.

## Setup

```sh
rm -rf bin/prime-api-client && make bin/prime-api-client
prime-api-client fetch-mtos --insecure --cac
prime-api-client fetch-mtos --cac --hostname api.staging.move.mil --port 443
```

Confirm you don't receive a failed TLS handshake error.