### PR TITLE
Make MoveType in AccessCode model a non-pointer

### DIFF
--- a/cmd/generate_access_codes/main.go
+++ b/cmd/generate_access_codes/main.go
@@ -110,22 +110,18 @@ func main() {
 	}
 	// go run cmd/generate_access_codes/main.go -ppm 2000 -hhg 500
 	for i := 0; i < hhg; i++ {
-		selectedMoveType := models.SelectedMoveTypeHHG
-
 		accessCode := models.AccessCode{
 			Code:     models.GenerateLocator(),
-			MoveType: &selectedMoveType,
+			MoveType: models.SelectedMoveTypeHHG,
 		}
 
 		mustSave(dbConnection, &accessCode)
 	}
 
 	for i := 0; i < ppm; i++ {
-		selectedMoveType := models.SelectedMoveTypePPM
-
 		accessCode := models.AccessCode{
 			Code:     models.GenerateLocator(),
-			MoveType: &selectedMoveType,
+			MoveType: models.SelectedMoveTypePPM,
 		}
 
 		mustSave(dbConnection, &accessCode)

--- a/pkg/handlers/adminapi/access_code_test.go
+++ b/pkg/handlers/adminapi/access_code_test.go
@@ -34,7 +34,7 @@ func (suite *HandlerSuite) TestIndexAccessCodesHandler() {
 		ServiceMemberID: &sm.ID,
 		ServiceMember:   sm,
 		Code:            "ABCXYZ",
-		MoveType:        m.SelectedMoveType,
+		MoveType:        *m.SelectedMoveType,
 	}
 	assertions := testdatagen.Assertions{
 		AccessCode: ac,
@@ -61,7 +61,7 @@ func (suite *HandlerSuite) TestIndexAccessCodesHandler() {
 		suite.Len(okResponse.Payload, 1)
 		suite.Equal(ac.ID.String(), okResponse.Payload[0].ID.String())
 		suite.Equal(ac.Code, okResponse.Payload[0].Code)
-		suite.Equal(string(*ac.MoveType), okResponse.Payload[0].MoveType)
+		suite.Equal(ac.MoveType.String(), okResponse.Payload[0].MoveType)
 		suite.Equal(m.Locator, okResponse.Payload[0].Locator)
 	})
 	suite.T().Run("test failed response", func(t *testing.T) {

--- a/pkg/handlers/internalapi/access_code_test.go
+++ b/pkg/handlers/internalapi/access_code_test.go
@@ -28,7 +28,7 @@ func (suite *HandlerSuite) TestFetchAccessCodeHandler_Success() {
 	code := "TEST0"
 	accessCode := models.AccessCode{
 		Code:            code,
-		MoveType:        &selectedMoveType,
+		MoveType:        selectedMoveType,
 		ServiceMemberID: &serviceMember.ID,
 	}
 
@@ -67,7 +67,7 @@ func (suite *HandlerSuite) TestValidateAccessCodeHandler_Valid() {
 	code := "TEST1"
 	accessCode := models.AccessCode{
 		Code:     code,
-		MoveType: &selectedMoveType,
+		MoveType: selectedMoveType,
 	}
 	fullCode := fmt.Sprintf("%s-%s", selectedMoveType, code)
 	// makes request
@@ -108,7 +108,7 @@ func (suite *HandlerSuite) TestValidateAccessCodeHandler_Invalid() {
 	claimedTime := time.Now()
 	invalidAccessCode := models.AccessCode{
 		Code:            code,
-		MoveType:        &selectedMoveType,
+		MoveType:        selectedMoveType,
 		ServiceMemberID: &smID,
 		ClaimedAt:       &claimedTime,
 	}
@@ -166,7 +166,7 @@ func (suite *HandlerSuite) TestClaimAccessCodeHandler_Success() {
 
 	claimedAccessCode := models.AccessCode{
 		Code:            code,
-		MoveType:        &selectedMoveType,
+		MoveType:        selectedMoveType,
 		ClaimedAt:       &claimedAt,
 		ServiceMemberID: &serviceMember.ID,
 	}

--- a/pkg/models/access_code.go
+++ b/pkg/models/access_code.go
@@ -12,13 +12,13 @@ import (
 
 // AccessCode is an object representing an access code for a service member
 type AccessCode struct {
-	ID              uuid.UUID         `json:"id" db:"id"`
-	ServiceMemberID *uuid.UUID        `json:"service_member_id" db:"service_member_id"`
-	ServiceMember   ServiceMember     `belongs_to:"service_members"`
-	Code            string            `json:"code" db:"code"`
-	MoveType        *SelectedMoveType `json:"move_type" db:"move_type"`
-	CreatedAt       time.Time         `json:"created_at" db:"created_at"`
-	ClaimedAt       *time.Time        `json:"claimed_at" db:"claimed_at"`
+	ID              uuid.UUID        `json:"id" db:"id"`
+	ServiceMemberID *uuid.UUID       `json:"service_member_id" db:"service_member_id"`
+	ServiceMember   ServiceMember    `belongs_to:"service_members"`
+	Code            string           `json:"code" db:"code"`
+	MoveType        SelectedMoveType `json:"move_type" db:"move_type"`
+	CreatedAt       time.Time        `json:"created_at" db:"created_at"`
+	ClaimedAt       *time.Time       `json:"claimed_at" db:"claimed_at"`
 }
 
 // AccessCodes is a slice of AccessCode objects
@@ -28,8 +28,8 @@ type AccessCodes []AccessCode
 // This method is not required and may be deleted.
 func (ac *AccessCode) Validate(tx *pop.Connection) (*validate.Errors, error) {
 	return validate.Validate(
-		&validators.StringIsPresent{Field: string(ac.Code), Name: "Code"},
-		&validators.StringIsPresent{Field: string(*ac.MoveType), Name: "MoveType"},
+		&validators.StringIsPresent{Field: ac.Code, Name: "Code"},
+		&validators.StringIsPresent{Field: ac.MoveType.String(), Name: "MoveType"},
 	), nil
 }
 

--- a/pkg/services/accesscode/access_code_claimer_test.go
+++ b/pkg/services/accesscode/access_code_claimer_test.go
@@ -8,12 +8,10 @@ import (
 func (suite *AccessCodeServiceSuite) TestClaimAccessCode_Success() {
 	serviceMember := testdatagen.MakeDefaultServiceMember(suite.DB())
 
-	selectedMoveType := models.SelectedMoveTypePPM
-
 	code := "CODE12"
 	accessCode := models.AccessCode{
 		Code:     code,
-		MoveType: &selectedMoveType,
+		MoveType: models.SelectedMoveTypePPM,
 	}
 
 	suite.MustSave(&accessCode)
@@ -29,12 +27,10 @@ func (suite *AccessCodeServiceSuite) TestClaimAccessCode_Success() {
 func (suite *AccessCodeServiceSuite) TestClaimAccessCode_Failed() {
 	serviceMember := testdatagen.MakeDefaultServiceMember(suite.DB())
 
-	selectedMoveType := models.SelectedMoveTypePPM
-
 	code := "CODE12"
 	accessCode := models.AccessCode{
 		Code:     code,
-		MoveType: &selectedMoveType,
+		MoveType: models.SelectedMoveTypePPM,
 	}
 
 	suite.MustSave(&accessCode)

--- a/pkg/services/accesscode/access_code_fetcher_test.go
+++ b/pkg/services/accesscode/access_code_fetcher_test.go
@@ -7,13 +7,12 @@ import (
 
 func (suite *AccessCodeServiceSuite) TestFetchAccessCode_FetchAccessCode() {
 	user := testdatagen.MakeDefaultServiceMember(suite.DB())
-	selectedMoveType := models.SelectedMoveTypePPM
 
 	code := "CODE12"
 	serviceMemberID := &user.ID
 	accessCode := models.AccessCode{
 		Code:            code,
-		MoveType:        &selectedMoveType,
+		MoveType:        models.SelectedMoveTypePPM,
 		ServiceMemberID: serviceMemberID,
 	}
 	suite.MustSave(&accessCode)

--- a/pkg/services/accesscode/access_code_list_fetcher_test.go
+++ b/pkg/services/accesscode/access_code_list_fetcher_test.go
@@ -21,18 +21,16 @@ func defaultOrdering() services.QueryOrder {
 }
 
 func (suite *AccessCodeServiceSuite) TestFetchAccessCodeListNoFilterNoAssociation() {
-	ppmMove := models.SelectedMoveTypePPM
 	code1 := "CODE12"
 	accessCode1 := models.AccessCode{
 		Code:     code1,
-		MoveType: &ppmMove,
+		MoveType: models.SelectedMoveTypePPM,
 	}
 	suite.MustSave(&accessCode1)
-	hhgMove := models.SelectedMoveTypeHHG
 	code2 := "12CODE"
 	accessCode2 := models.AccessCode{
 		Code:     code2,
-		MoveType: &hhgMove,
+		MoveType: models.SelectedMoveTypeHHG,
 	}
 	suite.MustSave(&accessCode2)
 	var queryFilters []services.QueryFilter
@@ -54,18 +52,16 @@ func (suite *AccessCodeServiceSuite) TestFetchAccessCodeListNoFilterNoAssociatio
 }
 
 func (suite *AccessCodeServiceSuite) TestFetchAccessCodeListWithFilter() {
-	ppmMove := models.SelectedMoveTypePPM
 	code1 := "CODE12"
 	accessCode1 := models.AccessCode{
 		Code:     code1,
-		MoveType: &ppmMove,
+		MoveType: models.SelectedMoveTypePPM,
 	}
 	suite.MustSave(&accessCode1)
-	hhgMove := models.SelectedMoveTypeHHG
 	code2 := "12CODE"
 	accessCode2 := models.AccessCode{
 		Code:     code2,
-		MoveType: &hhgMove,
+		MoveType: models.SelectedMoveTypeHHG,
 	}
 	suite.MustSave(&accessCode2)
 	var queryFilters []services.QueryFilter
@@ -91,7 +87,7 @@ func (suite *AccessCodeServiceSuite) TestFetchAccessCodeListWithAssociation() {
 		ServiceMemberID: &sm.ID,
 		ServiceMember:   sm,
 		Code:            "ABCXYZ",
-		MoveType:        m.SelectedMoveType,
+		MoveType:        *m.SelectedMoveType,
 	}
 	assertions := testdatagen.Assertions{
 		AccessCode: ac,

--- a/pkg/services/accesscode/access_code_validator_test.go
+++ b/pkg/services/accesscode/access_code_validator_test.go
@@ -11,7 +11,7 @@ func (suite *AccessCodeServiceSuite) TestValidateAccessCode_ValidAccessCode() {
 	code := "CODE12"
 	accessCode := models.AccessCode{
 		Code:     code,
-		MoveType: &selectedMoveType,
+		MoveType: selectedMoveType,
 	}
 	suite.MustSave(&accessCode)
 	validateAccessCode := NewAccessCodeValidator(suite.DB())
@@ -28,7 +28,7 @@ func (suite *AccessCodeServiceSuite) TestValidateAccessCode_InvalidAccessCode() 
 	code := "CODE12"
 	usedAccessCode := models.AccessCode{
 		Code:            code,
-		MoveType:        &selectedMoveType,
+		MoveType:        selectedMoveType,
 		ServiceMemberID: &user.ID,
 	}
 	suite.MustSave(&usedAccessCode)

--- a/pkg/services/query/query_builder_test.go
+++ b/pkg/services/query/query_builder_test.go
@@ -576,7 +576,7 @@ func (suite *QueryBuilderSuite) TestQueryAssociations() {
 	claimedTime := time.Now()
 	invalidAccessCode := models.AccessCode{
 		Code:            code,
-		MoveType:        &selectedMoveType,
+		MoveType:        selectedMoveType,
 		ServiceMemberID: &sm.ID,
 		ClaimedAt:       &claimedTime,
 	}
@@ -584,7 +584,7 @@ func (suite *QueryBuilderSuite) TestQueryAssociations() {
 	code2 := "TEST10"
 	accessCode2 := models.AccessCode{
 		Code:     code2,
-		MoveType: &selectedMoveType,
+		MoveType: selectedMoveType,
 	}
 	suite.MustSave(&accessCode2)
 

--- a/pkg/testdatagen/make_access_code.go
+++ b/pkg/testdatagen/make_access_code.go
@@ -10,15 +10,9 @@ import (
 
 // MakeAccessCode creates a single AccessCode
 func MakeAccessCode(db *pop.Connection, assertions Assertions) models.AccessCode {
-	defaultMoveType := models.SelectedMoveTypePPM
-	selectedMoveType := assertions.AccessCode.MoveType
-	if selectedMoveType == nil {
-		selectedMoveType = &defaultMoveType
-	}
-
 	accessCode := models.AccessCode{
 		Code:      models.GenerateLocator(),
-		MoveType:  selectedMoveType,
+		MoveType:  models.SelectedMoveTypePPM,
 		CreatedAt: time.Now(),
 	}
 

--- a/pkg/testdatagen/scenario/e2ebasic.go
+++ b/pkg/testdatagen/scenario/e2ebasic.go
@@ -571,18 +571,16 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, log
 	/*
 	* Creates two valid, unclaimed access codes
 	 */
-	accessCodePPMMoveType := models.SelectedMoveTypeHHG
 	testdatagen.MakeAccessCode(db, testdatagen.Assertions{
 		AccessCode: models.AccessCode{
 			Code:     "X3FQJK",
-			MoveType: &accessCodePPMMoveType,
+			MoveType: models.SelectedMoveTypeHHG,
 		},
 	})
-	accessCodeHHGMoveType := models.SelectedMoveTypePPM
 	testdatagen.MakeAccessCode(db, testdatagen.Assertions{
 		AccessCode: models.AccessCode{
 			Code:     "ABC123",
-			MoveType: &accessCodeHHGMoveType,
+			MoveType: models.SelectedMoveTypePPM,
 		},
 	})
 	email = "accesscode@mail.com"
@@ -613,7 +611,7 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, log
 	testdatagen.MakeAccessCode(db, testdatagen.Assertions{
 		AccessCode: models.AccessCode{
 			Code:            "ZYX321",
-			MoveType:        &accessCodeHHGMoveType,
+			MoveType:        models.SelectedMoveTypePPM,
 			ServiceMember:   sm,
 			ServiceMemberID: &sm.ID,
 		},


### PR DESCRIPTION
## Description

In anticipation of turning on the new `model-vet` pre-commit hook (see #3591), we have a series of stories to fix the issues it has identified.  This PR handles the identified problems in the `AccessCode` model.  Specifically, we're addressing the disconnect that `MoveType` is a pointer (can accept `nil`) in the model but is not nullable in the database.

```
AccessCode
	*MoveType : move_type is NOT NULL
```

Since the `move_type` column in the DB will never allow a null, this PR changes `MoveType` to a value instead of a pointer.

## Setup

`make server_test` to ensure server tests still run as expected.
`make e2e_test` to ensure integration tests still run as expected.

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/tree/master/docs/backend.md#logging)
* [ ] The requirements listed in [Querying the Database Safely](https://github.com/transcom/mymove/tree/master/docs/backend.md#querying-the-database-safely) have been satisfied.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-1881) for this change
