### PR TITLE
The task role for orders-migrations wasn't working because 'app' was hard coded.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -914,7 +914,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: cg_fix_orders_migration_task_role
+              ignore: placeholder_branch_name
 
       - client_test:
           requires:
@@ -922,7 +922,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: cg_fix_orders_migration_task_role
+              ignore: placeholder_branch_name
 
       - server_test:
           requires:
@@ -930,7 +930,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: cg_fix_orders_migration_task_role
+              ignore: placeholder_branch_name
 
       - build_app:
           requires:
@@ -971,28 +971,28 @@ workflows:
             - build_migrations
           filters:
             branches:
-              only: cg_fix_orders_migration_task_role
+              only: placeholder_branch_name
 
       - deploy_experimental_tasks:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: cg_fix_orders_migration_task_role
+              only: placeholder_branch_name
 
       - deploy_experimental_app:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: cg_fix_orders_migration_task_role
+              only: placeholder_branch_name
 
       - deploy_experimental_app_client_tls:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: cg_fix_orders_migration_task_role
+              only: placeholder_branch_name
 
       - check_circle_against_staging_sha:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -914,7 +914,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: placeholder_branch_name
+              ignore: cg_fix_orders_migration_task_role
 
       - client_test:
           requires:
@@ -922,7 +922,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: placeholder_branch_name
+              ignore: cg_fix_orders_migration_task_role
 
       - server_test:
           requires:
@@ -930,7 +930,7 @@ workflows:
           # if testing on experimental, you can disable these tests by using the commented block below.
           filters:
             branches:
-              ignore: placeholder_branch_name
+              ignore: cg_fix_orders_migration_task_role
 
       - build_app:
           requires:
@@ -971,28 +971,28 @@ workflows:
             - build_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: cg_fix_orders_migration_task_role
 
       - deploy_experimental_tasks:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: cg_fix_orders_migration_task_role
 
       - deploy_experimental_app:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: cg_fix_orders_migration_task_role
 
       - deploy_experimental_app_client_tls:
           requires:
             - deploy_experimental_migrations
           filters:
             branches:
-              only: placeholder_branch_name
+              only: cg_fix_orders_migration_task_role
 
       - check_circle_against_staging_sha:
           requires:

--- a/cmd/ecs-deploy/task_def.go
+++ b/cmd/ecs-deploy/task_def.go
@@ -544,8 +544,9 @@ func taskDefFunction(cmd *cobra.Command, args []string) error {
 		// This needs to be fixed in terraform
 		executionRoleArn = fmt.Sprintf("ecs-task-execution-role-%s-%s", serviceNameShort, environmentName)
 		// TODO: The task role is missing an (s) so we can't use service name
-		// This needs to be fixed in terraform
-		taskRoleArn = fmt.Sprintf("ecs-task-role-app-migration-%s", environmentName)
+		// This is `ecs-task-role-app-migration-experimental` vs `ecs-task-role-app-migration(s)-experimental`
+		// This needs to be fixed in terraform and then rolled out
+		taskRoleArn = fmt.Sprintf("ecs-task-role-%s-migration-%s", serviceNameShort, environmentName)
 	} else {
 		awsLogsStreamPrefix = serviceNameShort
 		awsLogsGroup = fmt.Sprintf("ecs-tasks-%s-%s", serviceName, environmentName)

--- a/cmd/ecs-deploy/task_def.go
+++ b/cmd/ecs-deploy/task_def.go
@@ -500,7 +500,7 @@ func taskDefFunction(cmd *cobra.Command, args []string) error {
 
 	errValidateImage := ecrImage.Validate(serviceECR)
 	if errValidateImage != nil {
-		quit(logger, nil, fmt.Errorf("unable to validate image %v", ecrImage))
+		quit(logger, nil, fmt.Errorf("unable to validate image %v: %w", ecrImage, errValidateImage))
 	}
 
 	// Entrypoint


### PR DESCRIPTION
## Description

The docker containers in AWS ECS run using an AWS IAM role (which contains permission information). I noticed that the Electronic Orders docker containers wouldn't run because they didn't have access to an AWS S3 resource. When I inspected the Task Definition (similar to a Dockerfile) I noticed that the task role for IAM was listed as:

```
arn:aws:iam::923914045601:role/ecs-task-role-app-migration-experimental
```

When it should have been:

```
arn:aws:iam::923914045601:role/ecs-task-role-orders-migration-experimental
```

This is because I'd hard-coded the role name to catch a spelling issue with the word `migration` vs `migrations`. This fix will still contain the misspelling but now it swaps out `app` for `orders` as appropriate.