### PR TITLE
Fix cluster name for app

### DIFF
--- a/scripts/ecs-deploy-service-container
+++ b/scripts/ecs-deploy-service-container
@@ -26,6 +26,9 @@ readonly environment=$3
 readonly RESERVATION_CPU=512
 readonly RESERVATION_MEM=2048
 
+# The cluster name is always `app-ENV`
+# Needs to support `app` and `app-client-tls` on the same cluster.
+# So don't overload `$name` and use it here.
 readonly cluster="app-${environment}"
 
 check_arn() {

--- a/scripts/ecs-deploy-service-container
+++ b/scripts/ecs-deploy-service-container
@@ -26,7 +26,7 @@ readonly environment=$3
 readonly RESERVATION_CPU=512
 readonly RESERVATION_MEM=2048
 
-readonly cluster="${name}-${environment}"
+readonly cluster="app-${environment}"
 
 check_arn() {
     local arn=$1


### PR DESCRIPTION
## Description

When passing in the `${name}` variable it sometimes is `app-client-tls` instead of `app`. This just hard-codes app.