### PR TITLE
Update prime client to split out the parsing of flags from creating the http client

### DIFF
--- a/cmd/prime-api-client/connection.go
+++ b/cmd/prime-api-client/connection.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	runtimeClient "github.com/go-openapi/runtime/client"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"pault.ag/go/pksigner"
@@ -17,19 +16,25 @@ import (
 	primeClient "github.com/transcom/mymove/pkg/gen/primeclient"
 )
 
-// CreateClient creates the prime api client
-func CreateClient(cmd *cobra.Command, v *viper.Viper, args []string) (*primeClient.Mymove, *pksigner.Store, error) {
-	err := cmd.ParseFlags(args)
-	if err != nil {
-		return nil, nil, errors.Wrap(err, "Could not parse args")
+// ParseFlags parses the command line flags
+func ParseFlags(cmd *cobra.Command, v *viper.Viper, args []string) error {
+
+	errParseFlags := cmd.ParseFlags(args)
+	if errParseFlags != nil {
+		return fmt.Errorf("Could not parse args: %w", errParseFlags)
 	}
 	flags := cmd.Flags()
-	err = v.BindPFlags(flags)
-	if err != nil {
-		return nil, nil, errors.Wrap(err, "Could not bind flags")
+	errBindPFlags := v.BindPFlags(flags)
+	if errBindPFlags != nil {
+		return fmt.Errorf("Could not bind flags: %w", errBindPFlags)
 	}
 	v.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 	v.AutomaticEnv()
+	return nil
+}
+
+// CreateClient creates the prime api client
+func CreateClient(v *viper.Viper) (*primeClient.Mymove, *pksigner.Store, error) {
 
 	// Use command line inputs
 	hostname := v.GetString(HostnameFlag)
@@ -41,9 +46,10 @@ func CreateClient(cmd *cobra.Command, v *viper.Viper, args []string) (*primeClie
 	// The client certificate comes from a smart card
 	var store *pksigner.Store
 	if v.GetBool(cli.CACFlag) {
-		store, err = cli.GetCACStore(v)
-		if err != nil {
-			log.Fatal(err)
+		var errGetCACStore error
+		store, errGetCACStore = cli.GetCACStore(v)
+		if errGetCACStore != nil {
+			log.Fatal(errGetCACStore)
 		}
 		cert, errTLSCert := store.TLSCertificate()
 		if errTLSCert != nil {

--- a/cmd/prime-api-client/fetch_mtos.go
+++ b/cmd/prime-api-client/fetch_mtos.go
@@ -63,18 +63,18 @@ func fetchMTOs(cmd *cobra.Command, args []string) error {
 		// is not supported by the TextConsumer, can be resolved by supporting TextUnmarshaler interface
 		// Likely this is because the API doesn't return JSON response for BadRequest OR
 		// The response type is not being set to text
-		log.Fatal(errFetchMTOUpdates.Error())
+		logger.Fatal(errFetchMTOUpdates.Error())
 	}
 
 	payload := resp.GetPayload()
 	if payload != nil {
 		payload, errJSONMarshall := json.Marshal(payload)
 		if errJSONMarshall != nil {
-			log.Fatal(errJSONMarshall)
+			logger.Fatal(errJSONMarshall)
 		}
 		fmt.Println(string(payload))
 	} else {
-		log.Fatal(resp.Error())
+		logger.Fatal(resp.Error())
 	}
 
 	return nil

--- a/cmd/prime-api-client/fetch_mtos.go
+++ b/cmd/prime-api-client/fetch_mtos.go
@@ -8,10 +8,24 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 
 	mto "github.com/transcom/mymove/pkg/gen/primeclient/move_task_order"
 )
+
+func initFetchMTOsFlags(flag *pflag.FlagSet) {
+	flag.SortFlags = false
+}
+
+func checkFetchMTOsConfig(v *viper.Viper, args []string, logger *log.Logger) error {
+	err := CheckRootConfig(v)
+	if err != nil {
+		logger.Fatal(err)
+	}
+
+	return nil
+}
 
 func fetchMTOs(cmd *cobra.Command, args []string) error {
 	v := viper.New()
@@ -20,16 +34,23 @@ func fetchMTOs(cmd *cobra.Command, args []string) error {
 	//Remove the prefix and any datetime data
 	logger := log.New(os.Stdout, "", log.LstdFlags)
 
-	err := CheckRootConfig(v)
+	errParseFlags := ParseFlags(cmd, v, args)
+	if errParseFlags != nil {
+		return errParseFlags
+	}
+
+	// Check the config before talking to the CAC
+	err := checkFetchMTOsConfig(v, args, logger)
 	if err != nil {
 		logger.Fatal(err)
 	}
 
-	primeGateway, cacStore, err := CreateClient(cmd, v, args)
-	if err != nil {
-		return err
+	primeGateway, cacStore, errCreateClient := CreateClient(v)
+	if errCreateClient != nil {
+		return errCreateClient
 	}
 
+	// Defer closing the store until after the API call has completed
 	if cacStore != nil {
 		defer cacStore.Close()
 	}

--- a/cmd/prime-api-client/main.go
+++ b/cmd/prime-api-client/main.go
@@ -71,6 +71,7 @@ func main() {
 		RunE:         fetchMTOs,
 		SilenceUsage: true,
 	}
+	initFetchMTOsFlags(fetchMTOsCommand.Flags())
 	root.AddCommand(fetchMTOsCommand)
 
 	updateMTOShipmentCommand := &cobra.Command{

--- a/cmd/prime-api-client/main.go
+++ b/cmd/prime-api-client/main.go
@@ -4,12 +4,11 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 
 	"github.com/transcom/mymove/pkg/cli"
-
-	"github.com/spf13/cobra"
 )
 
 const (

--- a/cmd/prime-api-client/update_mto_shipment.go
+++ b/cmd/prime-api-client/update_mto_shipment.go
@@ -122,18 +122,18 @@ func updateMTOShipment(cmd *cobra.Command, args []string) error {
 		// is not supported by the TextConsumer, can be resolved by supporting TextUnmarshaler interface
 		// Likely this is because the API doesn't return JSON response for BadRequest OR
 		// The response type is not being set to text
-		log.Fatal(errUpdateMTOShipment.Error())
+		logger.Fatal(errUpdateMTOShipment.Error())
 	}
 
 	payload := resp.GetPayload()
 	if payload != nil {
 		payload, errJSONMarshall := json.Marshal(payload)
 		if errJSONMarshall != nil {
-			log.Fatal(errJSONMarshall)
+			logger.Fatal(errJSONMarshall)
 		}
 		fmt.Println(string(payload))
 	} else {
-		log.Fatal(resp.Error())
+		logger.Fatal(resp.Error())
 	}
 
 	return nil


### PR DESCRIPTION
## Description

I'm using this same code to set up the `orders-api-client` and noticed some things that ought to be fixed structurally.

- We shouldn't mix the http client creation with parsing flags
- Checking errors should always happen in the same pattern even if a command doesn't have flags so that folks new to the code can see successful patterns and intuit how to write new code
- Check the flags for the command BEFORE activating the CAC - nothing like entering your pin to find out you incorrectly used the flags
- Use `logger` instead of `log` everywhere.
- Use the new go1.13 way of wrapping errors.

## Setup

Definitely check against the CAC instead of the mtls certs.

```sh
prime-api-client fetch-mtos --insecure --cac -v
```