### PR TITLE
Use yaml references for circleci docker images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,35 +11,40 @@
 
 version: '2.1'
 
+# References for variables shared across the file
+references:
+  circleci-docker: &circleci-docker milmove/circleci-docker:milmove-app-e955f6e90454414cf3848e17786c41f614ef50db
+  postgres: &postgres postgres:10.10
+
 executors:
   # `mymove_small` and `mymove_medium` use the `milmove/milmove-app` docker image with a checkout of the mymove code
   mymove_small:
     resource_class: small
     working_directory: ~/transcom/mymove
     docker:
-      - image: milmove/circleci-docker:milmove-app-e955f6e90454414cf3848e17786c41f614ef50db
+      - image: *circleci-docker
   mymove_medium:
     resource_class: medium
     working_directory: ~/transcom/mymove
     docker:
-      - image: milmove/circleci-docker:milmove-app-e955f6e90454414cf3848e17786c41f614ef50db
+      - image: *circleci-docker
   mymove_medium_plus:
     resource_class: medium+
     working_directory: ~/transcom/mymove
     docker:
-      - image: milmove/circleci-docker:milmove-app-e955f6e90454414cf3848e17786c41f614ef50db
+      - image: *circleci-docker
   mymove_large:
     resource_class: large
     working_directory: ~/transcom/mymove
     docker:
-      - image: milmove/circleci-docker:milmove-app-e955f6e90454414cf3848e17786c41f614ef50db
+      - image: *circleci-docker
   # `mymove_and_postgres_medium` adds a secondary postgres container to be used during testing.
   mymove_and_postgres_medium:
     resource_class: medium
     working_directory: ~/transcom/mymove
     docker:
-      - image: milmove/circleci-docker:milmove-app-e955f6e90454414cf3848e17786c41f614ef50db
-      - image: postgres:10.10
+      - image: *circleci-docker
+      - image: *postgres
         environment:
           - POSTGRES_PASSWORD: mysecretpassword
           - POSTGRES_DB: test_db
@@ -48,8 +53,8 @@ executors:
     resource_class: large
     working_directory: ~/transcom/mymove
     docker:
-      - image: milmove/circleci-docker:milmove-app-e955f6e90454414cf3848e17786c41f614ef50db
-      - image: postgres:10.10
+      - image: *circleci-docker
+      - image: *postgres
         environment:
           - POSTGRES_PASSWORD: mysecretpassword
           - POSTGRES_DB: test_db


### PR DESCRIPTION
## Description

I recently learned we could use yaml references in the CircleCI config file. This can reduce some copy-pasta we have around docker images, which will make updates easier and less error prone.

## Setup

If CircleCI tests pass then this is good to go.