### PR TITLE
correct links to database migrations docs

### DIFF
--- a/docs/data/tspp-data-creation.md
+++ b/docs/data/tspp-data-creation.md
@@ -209,7 +209,7 @@ forcing them to adhere to any table constraints
 and generating new UUIDs to be consistent across environments.
 For info on why having consistent UUIDs is important [see this document](docs/how-to/create-or-deactivate-users.md#a-note-about-uuid_generate_v4)
 
-We'll now [create a new migration](../how-to/migrate-the-database.md#how-to-migrate-the-database) with that data (replace your migration filename):
+We'll now [create a new migration](../database/migrate-the-database.md#how-to-migrate-the-database) with that data (replace your migration filename):
 
 ```bash
 make bin/milmove
@@ -280,7 +280,7 @@ INSERT INTO temp_tsps (standard_carrier_alpha_code, id, import)
   WHERE tsp_id IS NULL;
 ```
 
-[Generate the migration](../how-to/migrate-the-database.md#how-to-migrate-the-database) (replacing your migration filename):
+[Generate the migration](../database/migrate-the-database.md#how-to-migrate-the-database) (replacing your migration filename):
 
 ```bash
 make bin/milmove
@@ -427,7 +427,7 @@ DROP TABLE temp_tsp_discount_rates;
 
 You will have to create a secure migration for this data import. Two files will need to be created,
 the file that contains the real data and a local secure migration (dummy file for dev). Follow the
-[secure migration steps](../how-to/migrate-the-database.md#secure-migrations).
+[secure migration steps](../database/migrate-the-database.md#creating-secure-migrations).
 
 ### How to create the dummy file
 
@@ -443,5 +443,5 @@ data and scrubbing of key columns, output the results, then restore the original
 ./scripts/export-obfuscated-tspp-sample <filename>
 ```
 
-Complete the [secure migration steps](../how-to/migrate-the-database.md#secure-migrations) to
+Complete the [secure migration steps](../database/migrate-the-database.md#creating-secure-migrations) to
 submit both migration files.


### PR DESCRIPTION
## Description

fixing broken links to the database migration docs

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/tree/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/tree/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/tree/master/docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/blob/master/docs/database/migrate-the-database.md#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](tbd) for this change
* [this article](tbd) explains more about the approach used.

## Screenshots

If this PR makes visible UI changes, an image of the finished UI can help reviewers and casual
observers understand the context of the changes. A before image is optional and
can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow instead of using multiple images. You may want to use GIPHY CAPTURE for this! 📸

_Please frame screenshots to show enough useful context but also highlight the affected regions._
