### PR TITLE
Remove parens from dept indicator values

### DIFF
--- a/cypress/integration/office/officeUserPPM.js
+++ b/cypress/integration/office/officeUserPPM.js
@@ -227,7 +227,7 @@ function officeUserVerifiesAccounting() {
   cy.get('.combo-button').click();
 
   cy.get('span').contains('6789');
-  cy.get('span').contains('57 (Air Force)');
+  cy.get('span').contains('57 Air Force');
   cy.get('span').contains('N002214CSW32Y9');
 }
 

--- a/pkg/gen/internalapi/embedded_spec.go
+++ b/pkg/gen/internalapi/embedded_spec.go
@@ -3983,10 +3983,10 @@ func init() {
         "COAST_GUARD"
       ],
       "x-display-value": {
-        "AIR_FORCE": "57 (Air Force)",
-        "ARMY": "21 (Army)",
-        "COAST_GUARD": "70 (Coast Guard)",
-        "NAVY_AND_MARINES": "17 (Navy and Marine Corps)"
+        "AIR_FORCE": "57 Air Force",
+        "ARMY": "21 Army",
+        "COAST_GUARD": "70 Coast Guard",
+        "NAVY_AND_MARINES": "17 Navy and Marine Corps"
       },
       "x-nullable": true
     },
@@ -10190,10 +10190,10 @@ func init() {
         "COAST_GUARD"
       ],
       "x-display-value": {
-        "AIR_FORCE": "57 (Air Force)",
-        "ARMY": "21 (Army)",
-        "COAST_GUARD": "70 (Coast Guard)",
-        "NAVY_AND_MARINES": "17 (Navy and Marine Corps)"
+        "AIR_FORCE": "57 Air Force",
+        "ARMY": "21 Army",
+        "COAST_GUARD": "70 Coast Guard",
+        "NAVY_AND_MARINES": "17 Navy and Marine Corps"
       },
       "x-nullable": true
     },

--- a/pkg/handlers/internalapi/office_test.go
+++ b/pkg/handlers/internalapi/office_test.go
@@ -23,7 +23,7 @@ func (suite *HandlerSuite) TestApproveMoveHandler() {
 			OrdersTypeDetail:    &hhgPermitted,
 			TAC:                 handlers.FmtString("1234"),
 			SAC:                 handlers.FmtString("sac"),
-			DepartmentIndicator: handlers.FmtString("17 (Navy and Marine Corps)"),
+			DepartmentIndicator: handlers.FmtString("17 Navy and Marine Corps"),
 		},
 	}
 	move := testdatagen.MakeMove(suite.DB(), assertions)

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -1760,10 +1760,10 @@ definitions:
       - AIR_FORCE
       - COAST_GUARD
     x-display-value:
-      NAVY_AND_MARINES: 17 (Navy and Marine Corps)
-      ARMY: 21 (Army)
-      AIR_FORCE: 57 (Air Force)
-      COAST_GUARD: 70 (Coast Guard)
+      NAVY_AND_MARINES: 17 Navy and Marine Corps
+      ARMY: 21 Army
+      AIR_FORCE: 57 Air Force
+      COAST_GUARD: 70 Coast Guard
   Address:
     type: object
     properties:


### PR DESCRIPTION
## Description

Removes parentheses around services in Department Indicator select dropdown.

## Reviewer Notes

Is there anything you would like reviewers to give additional scrutiny?

## Setup

Log in as an office user on officelocal:3000
Go to a move.
In the Basics tab, scroll to the Accounting section, click Edit and look at the dropdown options.

## Code Review Verification Steps

* [ ] There are no aXe warnings for UI.
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-1764) for this change - this is a modification to the original PR
* [this article](tbd) explains more about the approach used.

## Screenshots

![image](https://user-images.githubusercontent.com/13249580/76886746-76495580-683e-11ea-9069-16d8f7125241.png)
