### PR TITLE
MB-1946: Remove prime tag from yaml

### DIFF
--- a/pkg/gen/primeapi/embedded_spec.go
+++ b/pkg/gen/primeapi/embedded_spec.go
@@ -38,14 +38,14 @@ func init() {
   "paths": {
     "/move-task-orders": {
       "get": {
-        "description": "Gets all move orders",
+        "description": "Gets all move task orders",
         "produces": [
           "application/json"
         ],
         "tags": [
           "moveTaskOrder"
         ],
-        "summary": "Gets all move orders",
+        "summary": "Gets all move task orders",
         "operationId": "fetchMTOUpdates",
         "parameters": [
           {
@@ -103,8 +103,7 @@ func init() {
           "application/json"
         ],
         "tags": [
-          "moveTaskOrder",
-          "prime"
+          "moveTaskOrder"
         ],
         "summary": "Gets a the customer associated with a move task order ID",
         "operationId": "getMoveTaskOrderCustomer",
@@ -166,8 +165,7 @@ func init() {
           "application/json"
         ],
         "tags": [
-          "mtoShipment",
-          "prime"
+          "mtoShipment"
         ],
         "summary": "Updates mto shipment",
         "operationId": "updateMTOShipment",
@@ -255,8 +253,7 @@ func init() {
           "application/json"
         ],
         "tags": [
-          "mtoServiceItem",
-          "prime"
+          "mtoServiceItem"
         ],
         "summary": "Creates mto service items",
         "operationId": "createMTOServiceItem",
@@ -328,8 +325,7 @@ func init() {
           "application/json"
         ],
         "tags": [
-          "moveTaskOrder",
-          "prime"
+          "moveTaskOrder"
         ],
         "summary": "Updates move task order's post counseling information",
         "operationId": "updateMTOPostCounselingInformation",
@@ -1482,14 +1478,14 @@ func init() {
   "paths": {
     "/move-task-orders": {
       "get": {
-        "description": "Gets all move orders",
+        "description": "Gets all move task orders",
         "produces": [
           "application/json"
         ],
         "tags": [
           "moveTaskOrder"
         ],
-        "summary": "Gets all move orders",
+        "summary": "Gets all move task orders",
         "operationId": "fetchMTOUpdates",
         "parameters": [
           {
@@ -1562,8 +1558,7 @@ func init() {
           "application/json"
         ],
         "tags": [
-          "moveTaskOrder",
-          "prime"
+          "moveTaskOrder"
         ],
         "summary": "Gets a the customer associated with a move task order ID",
         "operationId": "getMoveTaskOrderCustomer",
@@ -1637,8 +1632,7 @@ func init() {
           "application/json"
         ],
         "tags": [
-          "mtoShipment",
-          "prime"
+          "mtoShipment"
         ],
         "summary": "Updates mto shipment",
         "operationId": "updateMTOShipment",
@@ -1744,8 +1738,7 @@ func init() {
           "application/json"
         ],
         "tags": [
-          "mtoServiceItem",
-          "prime"
+          "mtoServiceItem"
         ],
         "summary": "Creates mto service items",
         "operationId": "createMTOServiceItem",
@@ -1826,8 +1819,7 @@ func init() {
           "application/json"
         ],
         "tags": [
-          "moveTaskOrder",
-          "prime"
+          "moveTaskOrder"
         ],
         "summary": "Updates move task order's post counseling information",
         "operationId": "updateMTOPostCounselingInformation",

--- a/pkg/gen/primeapi/primeoperations/move_task_order/fetch_m_t_o_updates.go
+++ b/pkg/gen/primeapi/primeoperations/move_task_order/fetch_m_t_o_updates.go
@@ -31,9 +31,9 @@ func NewFetchMTOUpdates(ctx *middleware.Context, handler FetchMTOUpdatesHandler)
 
 /*FetchMTOUpdates swagger:route GET /move-task-orders moveTaskOrder fetchMTOUpdates
 
-Gets all move orders
+Gets all move task orders
 
-Gets all move orders
+Gets all move task orders
 
 */
 type FetchMTOUpdates struct {

--- a/pkg/gen/primeapi/primeoperations/move_task_order/get_move_task_order_customer.go
+++ b/pkg/gen/primeapi/primeoperations/move_task_order/get_move_task_order_customer.go
@@ -29,7 +29,7 @@ func NewGetMoveTaskOrderCustomer(ctx *middleware.Context, handler GetMoveTaskOrd
 	return &GetMoveTaskOrderCustomer{Context: ctx, Handler: handler}
 }
 
-/*GetMoveTaskOrderCustomer swagger:route GET /move-task-orders/{moveTaskOrderID}/customer moveTaskOrder prime getMoveTaskOrderCustomer
+/*GetMoveTaskOrderCustomer swagger:route GET /move-task-orders/{moveTaskOrderID}/customer moveTaskOrder getMoveTaskOrderCustomer
 
 Gets a the customer associated with a move task order ID
 

--- a/pkg/gen/primeapi/primeoperations/move_task_order/update_m_t_o_post_counseling_information.go
+++ b/pkg/gen/primeapi/primeoperations/move_task_order/update_m_t_o_post_counseling_information.go
@@ -34,7 +34,7 @@ func NewUpdateMTOPostCounselingInformation(ctx *middleware.Context, handler Upda
 	return &UpdateMTOPostCounselingInformation{Context: ctx, Handler: handler}
 }
 
-/*UpdateMTOPostCounselingInformation swagger:route PATCH /move-task-orders/{moveTaskOrderID}/post-counseling-info moveTaskOrder prime updateMTOPostCounselingInformation
+/*UpdateMTOPostCounselingInformation swagger:route PATCH /move-task-orders/{moveTaskOrderID}/post-counseling-info moveTaskOrder updateMTOPostCounselingInformation
 
 Updates move task order's post counseling information
 

--- a/pkg/gen/primeapi/primeoperations/mto_service_item/create_m_t_o_service_item.go
+++ b/pkg/gen/primeapi/primeoperations/mto_service_item/create_m_t_o_service_item.go
@@ -29,7 +29,7 @@ func NewCreateMTOServiceItem(ctx *middleware.Context, handler CreateMTOServiceIt
 	return &CreateMTOServiceItem{Context: ctx, Handler: handler}
 }
 
-/*CreateMTOServiceItem swagger:route POST /move-task-orders/{moveTaskOrderID}/mto-shipments/{mtoShipmentID}/mto-service-items mtoServiceItem prime createMTOServiceItem
+/*CreateMTOServiceItem swagger:route POST /move-task-orders/{moveTaskOrderID}/mto-shipments/{mtoShipmentID}/mto-service-items mtoServiceItem createMTOServiceItem
 
 Creates mto service items
 

--- a/pkg/gen/primeapi/primeoperations/mto_shipment/update_m_t_o_shipment.go
+++ b/pkg/gen/primeapi/primeoperations/mto_shipment/update_m_t_o_shipment.go
@@ -29,7 +29,7 @@ func NewUpdateMTOShipment(ctx *middleware.Context, handler UpdateMTOShipmentHand
 	return &UpdateMTOShipment{Context: ctx, Handler: handler}
 }
 
-/*UpdateMTOShipment swagger:route PUT /move-task-orders/{moveTaskOrderID}/mto-shipments/{mtoShipmentID} mtoShipment prime updateMTOShipment
+/*UpdateMTOShipment swagger:route PUT /move-task-orders/{moveTaskOrderID}/mto-shipments/{mtoShipmentID} mtoShipment updateMTOShipment
 
 Updates mto shipment
 

--- a/pkg/gen/primeclient/move_task_order/move_task_order_client.go
+++ b/pkg/gen/primeclient/move_task_order/move_task_order_client.go
@@ -27,9 +27,9 @@ type Client struct {
 }
 
 /*
-FetchMTOUpdates gets all move orders
+FetchMTOUpdates gets all move task orders
 
-Gets all move orders
+Gets all move task orders
 */
 func (a *Client) FetchMTOUpdates(params *FetchMTOUpdatesParams) (*FetchMTOUpdatesOK, error) {
 	// TODO: Validate the params before sending

--- a/swagger/prime.yaml
+++ b/swagger/prime.yaml
@@ -49,9 +49,9 @@ paths:
             $ref: '#/responses/ServerError'
       tags:
         - moveTaskOrder
-      description: Gets all move orders
+      description: Gets all move task orders
       operationId: fetchMTOUpdates
-      summary: Gets all move orders
+      summary: Gets all move task orders
   '/move-task-orders/{moveTaskOrderID}/post-counseling-info':
     parameters:
       - description: ID of move task order to use
@@ -113,7 +113,6 @@ paths:
             $ref: '#/responses/ServerError'
       tags:
         - moveTaskOrder
-        - prime
       description: Updates move task order's post counseling information
       operationId: updateMTOPostCounselingInformation
       summary: Updates move task order's post counseling information
@@ -155,7 +154,6 @@ paths:
             $ref: '#/responses/ServerError'
       tags:
         - moveTaskOrder
-        - prime
       description: Gets a the customer associated with a move task order ID
       operationId: getMoveTaskOrderCustomer
       summary: Gets a the customer associated with a move task order ID
@@ -169,7 +167,6 @@ paths:
       operationId: updateMTOShipment
       tags:
         - mtoShipment
-        - prime
       parameters:
         - in: path
           name: moveTaskOrderID
@@ -228,7 +225,6 @@ paths:
       operationId: createMTOServiceItem
       tags:
         - mtoServiceItem
-        - prime
       parameters:
         - in: path
           name: moveTaskOrderID


### PR DESCRIPTION
## Description

Since the Prime API has been split into its own yaml file, tagging the endpoints as `prime` is no longer needed.

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make server_generate
make server_test
```

## Code Review Verification Steps
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-1946 for this change