### PR TITLE
MB-1920: Update docker compose files to allow access to prime api

### DIFF
--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -47,6 +47,7 @@ services:
       - database
     ports:
       - '4000:4000'
+      - '9443:9443'
     environment:
       - CLIENT_AUTH_SECRET_KEY
       - CSRF_AUTH_KEY
@@ -73,6 +74,7 @@ services:
       - HTTP_MY_SERVER_NAME=milmovelocal
       - HTTP_OFFICE_SERVER_NAME=officelocal
       - HTTP_ORDERS_SERVER_NAME=orderslocal
+      - HTTP_PRIME_SERVER_NAME=primelocal
       - AWS_CF_DOMAIN=assets.devlocal.move.mil
       - IWS_RBS_HOST
       - LOCAL_STORAGE_ROOT=/tmp
@@ -87,12 +89,14 @@ services:
       - MOVE_MIL_DOD_CA_CERT
       - MOVE_MIL_DOD_TLS_CERT
       - MOVE_MIL_DOD_TLS_KEY
+      - MUTUAL_TLS_ENABLED=1
       - NO_TLS_ENABLED=1
       - NO_TLS_PORT=4000
       - PGPASSWORD=mysecretpassword
       - SERVE_ADMIN=true
       - SERVE_API_GHC=false
       - SERVE_API_INTERNAL=true
+      - SERVE_API_PRIME=true
       - STORAGE_BACKEND=local
     volumes:
       - ./tmp:/tmp

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,7 @@ services:
       - database
     ports:
       - '4000:4000'
+      - '9443:9443'
     environment:
       - CLIENT_AUTH_SECRET_KEY
       - CSRF_AUTH_KEY
@@ -69,6 +70,7 @@ services:
       - HTTP_MY_SERVER_NAME=milmovelocal
       - HTTP_OFFICE_SERVER_NAME=officelocal
       - HTTP_ORDERS_SERVER_NAME=orderslocal
+      - HTTP_PRIME_SERVER_NAME=primelocal
       - AWS_CF_DOMAIN=assets.devlocal.move.mil
       - IWS_RBS_HOST
       - LOCAL_STORAGE_ROOT=/tmp
@@ -83,12 +85,14 @@ services:
       - MOVE_MIL_DOD_CA_CERT
       - MOVE_MIL_DOD_TLS_CERT
       - MOVE_MIL_DOD_TLS_KEY
+      - MUTUAL_TLS_ENABLED=1
       - NO_TLS_ENABLED=1
       - NO_TLS_PORT=4000
       - PGPASSWORD=mysecretpassword
       - SERVE_ADMIN=true
       - SERVE_API_GHC=false
       - SERVE_API_INTERNAL=true
+      - SERVE_API_PRIME=true
       - STORAGE_BACKEND=local
     volumes:
       - ./tmp:/tmp


### PR DESCRIPTION
## Description

Self-explanatory title.

## Setup
NOTE: Make sure the server is not running locally on your machine aka do not have `server_run` going.

```sh
docker-compose -f docker-compose.local.yml up --remove-orphans -d --build
rm -rf bin/prime-api-client && make bin/prime-api-client
prime-api-client --insecure fetch-mtos -v
```

Should get a successful response.

## Code Review Verification Steps
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-1920) for this change