### PR TITLE
build and tag docker prod file for milmove admin aka engadmin

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -711,6 +711,8 @@ jobs:
             LOGIN_GOV_CALLBACK_PORT: 3000
             LOGIN_GOV_KID_JWK: milmove_admin
             LOGIN_GOV_JWK_SET_FILENAME: keyset.jwk
+      - setup_remote_docker:
+          docker_layer_caching: false
       - build_tag_push:
           dockerfile: ~/transcom/milmove_admin/app/Dockerfile.prod
           tag: engadmin:dev

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -204,9 +204,12 @@ commands:
         type: string
       repo:
         type: string
+      working_dir:
+        type: string
     steps:
       - run:
           name: 'Build, tag, and push docker image << parameters.tag >> from Dockerfile << parameters.dockerfile >>'
+          working_directory: << parameters.working_dir >>
           command: |
             docker build -f << parameters.dockerfile >> -t << parameters.tag >> .
             aws ecr get-login-password --region $AWS_DEFAULT_REGION | docker login --username AWS --password-stdin ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com
@@ -591,6 +594,7 @@ jobs:
           dockerfile: Dockerfile
           tag: ppp:web-dev
           repo: app
+          working_dir: ~/transcom/mymove
       - announce_failure
 
   # `storybook_tests` runs the loki test suite against the current storybook code
@@ -649,6 +653,7 @@ jobs:
           dockerfile: Dockerfile.migrations
           tag: ppp-migrations:dev
           repo: app-migrations
+          working_dir: ~/transcom/mymove
       - announce_failure
 
   # `build_django_app` builds the django app container and pushes to container repository
@@ -717,6 +722,7 @@ jobs:
           dockerfile: ~/transcom/milmove_admin/app/Dockerfile.prod
           tag: engadmin:dev
           repo: app-engadmin
+          working_dir: ~/transcom/milmove_admin
 
   # `build_tasks` builds the tasks containers and pushes them to the container repository
   build_tasks:
@@ -736,6 +742,7 @@ jobs:
           dockerfile: Dockerfile.tasks
           tag: tasks:dev
           repo: app-tasks
+          working_dir: ~/transcom/mymove
       - announce_failure
 
   # `acceptance_tests_experimental` runs acceptance tests for the webserver against the experimental environment.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -711,6 +711,10 @@ jobs:
             LOGIN_GOV_CALLBACK_PORT: 3000
             LOGIN_GOV_KID_JWK: milmove_admin
             LOGIN_GOV_JWK_SET_FILENAME: keyset.jwk
+      - build_tag_push:
+          dockerfile: ~/transcom/milmove_admin/app/Dockerfile.prod
+          tag: engadmin:dev
+          repo: app-engadmin
 
   # `build_tasks` builds the tasks containers and pushes them to the container repository
   build_tasks:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -722,7 +722,7 @@ jobs:
           dockerfile: ~/transcom/milmove_admin/app/Dockerfile.prod
           tag: engadmin:dev
           repo: app-engadmin
-          working_dir: ~/transcom/milmove_admin
+          working_dir: ~/transcom/milmove_admin/app
 
   # `build_tasks` builds the tasks containers and pushes them to the container repository
   build_tasks:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -719,7 +719,7 @@ jobs:
       - setup_remote_docker:
           docker_layer_caching: false
       - build_tag_push:
-          dockerfile: ~/transcom/milmove_admin/app/Dockerfile.prod
+          dockerfile: Dockerfile.prod
           tag: engadmin:dev
           repo: app-engadmin
           working_dir: ~/transcom/milmove_admin/app


### PR DESCRIPTION
## Description

This PR adds ability to register the engadmin repo into aws ecr so we can use the image as apart of docker compose.

## Code Review Verification Steps

* [x] Request review from a member of a different team.
* [x] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-1683?atlOrigin=eyJpIjoiMTg3YTEwYTVlYTM5NDg2MTk4ZWFiNmQ1YjI5Y2Q1ZjQiLCJwIjoiaiJ9) for this change

## Screenshots

![image](https://user-images.githubusercontent.com/5003421/77437648-49a3b980-6dbb-11ea-81c2-705517b97bfc.png)

