### PR TITLE
build and register nginx dokcer file and push to ecr

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -723,6 +723,12 @@ jobs:
           tag: engadmin:dev
           repo: app-engadmin
           working_dir: ~/transcom/milmove_admin/app
+      - build_tag_push:
+          dockerfile: Dockerfile
+          tag: engadmin-nginx:dev
+          repo: app-engadmin-nginx
+          working_dir: ~/transcom/milmove_admin/nginx
+      - announce_failure
 
   # `build_tasks` builds the tasks containers and pushes them to the container repository
   build_tasks:


### PR DESCRIPTION
## Description

Along with the django app we also need a registry of nginx container. This PR adds a build step that builds, tags nginx container and pushes it into ECR.

