### PR TITLE
Update yarn.lock after merge to master

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -9223,7 +9223,7 @@ json5@^1.0.1:
   dependencies:
     minimist "^1.2.0"
 
-json5@^2.1.1, json5@^2.1.2:
+json5@^2.1.0, json5@^2.1.1, json5@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.1.2.tgz#43ef1f0af9835dd624751a6b7fa48874fb2d608e"
   integrity sha512-MoUOQ4WdiN3yxhm7NEVJSJrieAo5hNSLQ5sj05OTRHPL9HOBy8u4Bu88jsC1jvqAdN+E1bJmsUcZH+1HQxliqQ==


### PR DESCRIPTION
## Description

Looks like after a recent merge to master `yarn.lock` needed to be updated. This PR updates it so that the build can continue.