### PR TITLE
MB-2090 Add verification check to ensure dependency lock files are not changed during build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -380,7 +380,7 @@ jobs:
       - run: echo 'export PATH=${PATH}:~/go/bin:~/transcom/mymove/bin' >> $BASH_ENV
       - run: rm -rf pkg/assets/assets.go && make pkg/assets/assets.go
       - run: make server_generate mocks_generate
-      - run: scripts/check-generated-code
+      - run: scripts/check-generated-code pkg/gen/ $(find . -type d -name "mocks" -exec echo -n '{} ' \;)
       - save_cache:
           key: go-mod-sources-v2-{{ checksum "go.sum" }}-{{ checksum "scripts/check-go-version" }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -334,6 +334,7 @@ jobs:
       - run:
           name: Install dependencies
           command: for i in $(seq 1 5); do go get ./... && s=0 && break || s=$? && sleep 5; done; (exit $s)
+      - run: scripts/check-generated-code go.sum
       - save_cache:
           key: go-mod-sources-v2-{{ checksum "go.sum" }}-{{ checksum "scripts/check-go-version" }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -357,6 +357,7 @@ jobs:
           # this was workaround that seemed to fix the issue See for details https://github.com/yarnpkg/yarn/issues/7212
           # This is caused by a timing issue when using react-uswds branch. It can be removed once we switch to a released version
           command: yarn install --network-concurrency 1
+      - run: scripts/check-generated-code yarn.lock
       # `v2-cache-yarn-v2-{{ checksum "yarn.lock" }}` is used to cache yarn sources
       - save_cache:
           key: v2-cache-yarn-v2-{{ checksum "yarn.lock" }}

--- a/scripts/check-generated-code
+++ b/scripts/check-generated-code
@@ -4,10 +4,8 @@
 #
 set -eu -o pipefail
 
-pkg_list_mocks=$(find . -type d -name "mocks" -exec echo -n '{} ' \;)
-
 # shellcheck disable=2086
-if [[ -z $(git status -uno --porcelain pkg/gen/ ${pkg_list_mocks} ) ]]; then
+if [[ -z $(git status -uno --porcelain "$@") ]]; then
   echo "generated code hasn't changed"
   exit 0
 else


### PR DESCRIPTION
## Description

There is a case where during the build process the `go.sum` or `yarn.lock` files can be modified. If this is the case it breaks later build steps in a strange way that is confusing. This PR updates the jobs to catch the change and fail the build.

See [MB-2090](https://dp3.atlassian.net/browse/MB-2090) and [this thread in slack](https://ustcdp3.slack.com/archives/CP4U2NKRT/p1585243731026700)

You can see my tests of the changes in the previous CircleCI builds of this branch https://app.circleci.com/pipelines/github/transcom/mymove?branch=MB-2090_check_if_dep_file_changes_during_build 