### PR TITLE
Upgrade postgres to 10.12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ version: '2.1'
 # References for variables shared across the file
 references:
   circleci-docker: &circleci-docker milmove/circleci-docker:milmove-app-e955f6e90454414cf3848e17786c41f614ef50db
-  postgres: &postgres postgres:10.10
+  postgres: &postgres postgres:10.12
 
 executors:
   # `mymove_small` and `mymove_medium` use the `milmove/milmove-app` docker image with a checkout of the mymove code

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ DB_DOCKER_CONTAINER_TEST = milmove-db-test
 # The version of the postgres container should match production as closely
 # as possible.
 # https://github.com/transcom/ppp-infra/blob/7ba2e1086ab1b2a0d4f917b407890817327ffb3d/modules/aws-app-environment/database/variables.tf#L48
-DB_DOCKER_CONTAINER_IMAGE = postgres:10.10
+DB_DOCKER_CONTAINER_IMAGE = postgres:10.12
 TASKS_DOCKER_CONTAINER = tasks
 export PGPASSWORD=mysecretpassword
 

--- a/docker-compose.circle.yml
+++ b/docker-compose.circle.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   database:
-    image: postgres:10.10
+    image: postgres:10.12
     restart: always
     deploy:
       resources:

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   database:
-    image: postgres:10.10
+    image: postgres:10.12
     restart: always
     ports:
       - '6432:5432'

--- a/docker-compose.prime.yml
+++ b/docker-compose.prime.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   database:
-    image: postgres:10.10
+    image: postgres:10.12
     restart: always
     ports:
       - '6432:5432'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   database:
-    image: postgres:10.10
+    image: postgres:10.12
     restart: always
     ports:
       - '6432:5432'


### PR DESCRIPTION
## Description

In preparation for https://github.com/transcom/ppp-infra/pull/883 and to address https://nvd.nist.gov/vuln/detail/CVE-2020-1720 we're upgrading to postgres 10.12.