### PR TITLE
Invalid input error when adding an MTO Agent

### DIFF
--- a/pkg/services/mto_shipment/mto_shipment_updater.go
+++ b/pkg/services/mto_shipment/mto_shipment_updater.go
@@ -113,6 +113,9 @@ func setNewShipmentFields(planner route.Planner, db *pop.Connection, oldShipment
 	}
 
 	if updatedShipment.MTOAgents != nil {
+		if oldShipment.MTOAgents == nil {
+			return services.NewInvalidInputError(oldShipment.ID, nil, nil, "MTO Agents do not exist")
+		}
 		for i, oldAgent := range oldShipment.MTOAgents {
 			for _, newAgentInfo := range updatedShipment.MTOAgents {
 				if oldAgent.ID == newAgentInfo.ID {


### PR DESCRIPTION
## Description

UpdateMTOShipment endpoint should return an invalid input error if you try to add an agents when it does not have any. It assumes at this point you should have agents that have been added to the shipment earlier on in the process. Previously it was just giving an unhelpful pointer error

## Setup
`make server_run`
Update an MTO shipment to try to add an agent with a random uuid and a name field

## Code Review Verification Steps
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-2102) for this change
