### PR TITLE
[MB-2101] Update copy for gas receipts on acceptable expenses page

### DIFF
--- a/src/scenes/Moves/Ppm/AllowableExpenses.jsx
+++ b/src/scenes/Moves/Ppm/AllowableExpenses.jsx
@@ -77,14 +77,17 @@ function AllowableExpenses(props) {
           <hr className="divider" />
           <section style={{ marginBottom: '1.5em' }}>
             <strong>Gas and fuel expenses</strong>
+            <p>Gas and fuel expenses are not reimbursable.</p>
+            <p>If you rented a vehicle to perform your move, you can claim gas expenses for tax purposes.</p>
             <p>
-              Fuel expenses may not be claimed for a PPM unless they exceed the amount paid for mileage and per diem
-              fees on your travel pay. The IRS does not allow you to claim an expense if you were already paid for the
-              mileage. Doing so could result in an IRS audit.
+              You can not claim expenses for fuel for your own vehicles. You will be reimbursed for that fuel via DTS
+              when you claim your mileage. The IRS does not allow you to claim an expense twice, and may audit you if
+              you do so.
             </p>
             <p>
-              If your fuel costs exceed the per diem payment you received, however, you may claim the portion that
-              exceeds that amount.
+              There is one rare exception: If your fuel expenses exceed the amount paid for mileage and per diem fees on
+              your travel pay. You may claim the portion of your fuel expenses for your own vehicles that exceeds that
+              amount.
             </p>
           </section>
           <section style={{ marginBottom: '3.5em' }}>


### PR DESCRIPTION
## Description

Text replaced with better text on the acceptable expenses page.

## Setup

```sh
make server_run
make client_run
```
- login to a service member with a PPM status "In progress"
- click `Request Payment` then on the next page `More About Expenses` (http://milmovelocal:3000/allowable-expenses)
- scroll down to the heading **Gas and fuel expenses**


## Code Review Verification Steps

* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-2101) for this change

## Screenshots

<img width="1214" alt="Screen Shot 2020-03-31 at 4 09 37 PM" src="https://user-images.githubusercontent.com/16230705/78083652-ef7e9780-736a-11ea-8a13-c6f88a3d8af1.png">
