### PR TITLE
[MB-2051] Update copy on `Edit PPM Weight` page

### DIFF
--- a/src/scenes/Review/EditWeight.jsx
+++ b/src/scenes/Review/EditWeight.jsx
@@ -40,7 +40,7 @@ const examples = [
   {
     weight: 5000,
     incentive: '$3,100 - 3,700',
-    description: 'Renting a moving truck yourself',
+    description: 'A moving truck',
   },
   { weight: 10000, incentive: '$5,900 - 6,800' },
 ];


### PR DESCRIPTION
## Description

Copy updated to "get rid of DITY-only implications"

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make server_run
make client_run
```
- login as service member (I used ppm@paymentrequest.ed)
- click `Edit Move`, scroll down and click `Edit` next to **Weight**
- on the Edit PPM Weight page, scroll down to **Examples**

## Code Review Verification Steps

* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-2051) for this change

## Screenshots

<img width="709" alt="Screen Shot 2020-03-31 at 4 39 27 PM" src="https://user-images.githubusercontent.com/16230705/78085090-c9f38d00-736e-11ea-95a3-e3297d15cf98.png">
