### PR TITLE
MB-2231 enable danger circleci job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -455,12 +455,9 @@ jobs:
             mkdir -p tmp/test-results/pretest
             pre-commit run -v --all-files golangci-lint | tee tmp/test-results/pretest/golangci-lint.out
       # adding danger checks here as they are similar to our pre-commit hooks
-      # TODO: This step is commented out until we have a GITHUB TOKEN See https://dp3.atlassian.net/browse/MB-2059
-      # - run:
-      #     name: Run DangerJS checks
-      #     command: yarn danger ci --failOnErrors
-      #     environment:
-      #       DANGER_GITHUB_API_TOKEN: 1
+      - run:
+          name: Run DangerJS checks
+          command: yarn danger ci --failOnErrors
       # `pre-commit-dot-cache-{{ checksum ".pre-commit-config.yaml" }}` is used to cache pre-commit plugins.
       - save_cache:
           key: pre-commit-dot-cache-{{ checksum ".pre-commit-config.yaml" }}

--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -10,15 +10,15 @@ if (danger.github && danger.github.pr.body.length < 10) {
 const allFiles = danger.git.modified_files.concat(danger.git.created_files);
 
 // Request changes to app code to also include changes to tests.
-const hasAppChanges = allFiles.some(p => !!p.match(/src\/.*\.jsx?/));
-const hasTestChanges = allFiles.some(p => !!p.match(/src\/.*\.test\.jsx?/));
+const hasAppChanges = allFiles.some((path) => !!path.match(/src\/.*\.jsx?/));
+const hasTestChanges = allFiles.some((path) => !!path.match(/src\/.*\.test\.jsx?/));
 if (hasAppChanges && !hasTestChanges) {
   warn('This PR does not include changes to unit tests, even though it affects app code.');
 }
 
 // Require new src/components files to include changes to storybook
-const hasComponentChanges = danger.git.created_files.some(p => includes(p, 'src/components'));
-const hasStorybookChanges = allFiles.some(p => includes(p, 'src/stories'));
+const hasComponentChanges = danger.git.created_files.some((path) => includes(path, 'src/components'));
+const hasStorybookChanges = allFiles.some((path) => includes(path, 'src/stories'));
 
 if (hasComponentChanges && !hasStorybookChanges) {
   fail('This PR does not include changes to storybook, even though it affects component code.');

--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -1,40 +1,50 @@
 import { includes } from 'lodash';
 import { danger, warn, fail } from 'danger';
 
-if (danger.github) {
-  // No PR is too small to include a description of why you made a change
-  if (danger.github.pr.body.length < 10) {
-    warn('Please include a description of your PR changes.');
+const githubChecks = () => {
+  if (danger.github) {
+    // No PR is too small to include a description of why you made a change
+    if (danger.github.pr.body.length < 10) {
+      warn('Please include a description of your PR changes.');
+    }
+    // PRs should have a Jira ID in the title
+    if (!danger.github.pr.title.match(/^MB-\d+/)) {
+      warn('Please include the Jira ID at the start of the title with the format MB-123');
+    }
   }
-  // PRs should have a Jira ID in the title
-  if (!danger.github.pr.title.match(/^MB-\d+/)) {
-    warn('Please include the Jira ID at the start of the title with the format MB-123');
+};
+
+const fileChecks = () => {
+  // load all modified and new files
+  const allFiles = danger.git.modified_files.concat(danger.git.created_files);
+
+  // Request changes to app code to also include changes to tests.
+  const hasAppChanges = allFiles.some((path) => !!path.match(/src\/.*\.jsx?/));
+  const hasTestChanges = allFiles.some((path) => !!path.match(/src\/.*\.test\.jsx?/));
+  if (hasAppChanges && !hasTestChanges) {
+    warn('This PR does not include changes to unit tests, even though it affects app code.');
   }
-}
 
-// load all modified and new files
-const allFiles = danger.git.modified_files.concat(danger.git.created_files);
+  // Require new src/components files to include changes to storybook
+  const hasComponentChanges = danger.git.created_files.some((path) => includes(path, 'src/components'));
+  const hasStorybookChanges = allFiles.some((path) => includes(path, 'src/stories'));
 
-// Request changes to app code to also include changes to tests.
-const hasAppChanges = allFiles.some((path) => !!path.match(/src\/.*\.jsx?/));
-const hasTestChanges = allFiles.some((path) => !!path.match(/src\/.*\.test\.jsx?/));
-if (hasAppChanges && !hasTestChanges) {
-  warn('This PR does not include changes to unit tests, even though it affects app code.');
-}
+  if (hasComponentChanges && !hasStorybookChanges) {
+    fail('This PR does not include changes to storybook, even though it affects component code.');
+  }
 
-// Require new src/components files to include changes to storybook
-const hasComponentChanges = danger.git.created_files.some((path) => includes(path, 'src/components'));
-const hasStorybookChanges = allFiles.some((path) => includes(path, 'src/stories'));
+  // Request update of yarn.lock if package.json changed but yarn.lock isn't
+  const packageChanged = includes(allFiles, 'package.json');
+  const lockfileChanged = includes(allFiles, 'yarn.lock');
+  if (false && packageChanged && !lockfileChanged) {
+    const message = 'Changes were made to package.json, but not to yarn.lock';
+    const idea = 'Perhaps you need to run `yarn install`?';
+    warn(`${message} - <i>${idea}</i>`);
+  }
+};
 
-if (hasComponentChanges && !hasStorybookChanges) {
-  fail('This PR does not include changes to storybook, even though it affects component code.');
-}
-
-// Request update of yarn.lock if package.json changed but yarn.lock isn't
-const packageChanged = includes(allFiles, 'package.json');
-const lockfileChanged = includes(allFiles, 'yarn.lock');
-if (packageChanged && !lockfileChanged) {
-  const message = 'Changes were made to package.json, but not to yarn.lock';
-  const idea = 'Perhaps you need to run `yarn install`?';
-  warn(`${message} - <i>${idea}</i>`);
+// skip these checks if PR is by dependabot, if we don't have a github object let it run also since we are local
+if (!danger.github || (danger.github && danger.github.pr.user.login !== 'dependabot-preview[bot]')) {
+  githubChecks();
+  fileChecks();
 }

--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -1,9 +1,15 @@
 import { includes } from 'lodash';
 import { danger, warn, fail } from 'danger';
 
-// No PR is too small to include a description of why you made a change
-if (danger.github && danger.github.pr.body.length < 10) {
-  warn('Please include a description of your PR changes.');
+if (danger.github) {
+  // No PR is too small to include a description of why you made a change
+  if (danger.github.pr.body.length < 10) {
+    warn('Please include a description of your PR changes.');
+  }
+  // PRs should have a Jira ID in the title
+  if (!danger.github.pr.title.match(/^MB-\d+/)) {
+    warn('Please include the Jira ID at the start of the title with the format MB-123');
+  }
 }
 
 // load all modified and new files


### PR DESCRIPTION
## Description

This PR enables `pre_test` circleci job to run [dangerjs checks](https://danger.systems/js/) on our PRs. Danger will leave comments about any things it finds on the PR. Most things are just warnings that amount to a comment. 

This PR also adds the ability for danger to verify that the Jira ID is at the start of the PR title. It will just comment that you should, it will not block the PR.

## Reviewer notes

I'm checking with #support-jira to see if they know if the jira id has to be at the start or just anywhere in the title. If prefer start myself but if you feel differently let me know.

## Setup

You can run danger locally by `yarn danger local` or you can check a PR via `yarn danger pr https://github.com/transcom/mymove/pull/3880` 

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [MB-2231](https://dp3.atlassian.net/browse/MB-2231) for this change

## Screenshots

![Sample of dangerjs warning comment](https://user-images.githubusercontent.com/940173/78411131-7b8afc00-75c3-11ea-9b0c-db123d977a08.png)

