### PR TITLE
Prime API swagger fixes

### DIFF
--- a/pkg/gen/primeapi/embedded_spec.go
+++ b/pkg/gen/primeapi/embedded_spec.go
@@ -1121,14 +1121,14 @@ func init() {
               "$ref": "#/definitions/MTOServiceItemDimension"
             },
             "reServiceCode": {
-              "$ref": "#/definitions/ReServiceCode"
-            },
-            "reason": {
               "type": "string",
               "enum": [
                 "DCRT",
                 "DUCRT"
-              ],
+              ]
+            },
+            "reason": {
+              "type": "string",
               "example": "Storage items need to be picked up"
             }
           }
@@ -1164,7 +1164,11 @@ func init() {
               "example": "Things to be moved to the place by shuttle."
             },
             "reServiceCode": {
-              "$ref": "#/definitions/ReServiceCode"
+              "type": "string",
+              "enum": [
+                "DOSHUT",
+                "DDSHUT"
+              ]
             },
             "reason": {
               "type": "string",
@@ -2867,14 +2871,14 @@ func init() {
               "$ref": "#/definitions/MTOServiceItemDimension"
             },
             "reServiceCode": {
-              "$ref": "#/definitions/ReServiceCode"
-            },
-            "reason": {
               "type": "string",
               "enum": [
                 "DCRT",
                 "DUCRT"
-              ],
+              ]
+            },
+            "reason": {
+              "type": "string",
               "example": "Storage items need to be picked up"
             }
           }
@@ -2910,7 +2914,11 @@ func init() {
               "example": "Things to be moved to the place by shuttle."
             },
             "reServiceCode": {
-              "$ref": "#/definitions/ReServiceCode"
+              "type": "string",
+              "enum": [
+                "DOSHUT",
+                "DDSHUT"
+              ]
             },
             "reason": {
               "type": "string",

--- a/pkg/gen/primemessages/m_t_o_service_item_domestic_crating.go
+++ b/pkg/gen/primemessages/m_t_o_service_item_domestic_crating.go
@@ -45,10 +45,10 @@ type MTOServiceItemDomesticCrating struct {
 
 	// re service code
 	// Required: true
-	ReServiceCode ReServiceCode `json:"reServiceCode"`
+	// Enum: [DCRT DUCRT]
+	ReServiceCode *string `json:"reServiceCode"`
 
 	// reason
-	// Enum: [DCRT DUCRT]
 	Reason string `json:"reason,omitempty"`
 }
 
@@ -150,10 +150,10 @@ func (m *MTOServiceItemDomesticCrating) UnmarshalJSON(raw []byte) error {
 
 		// re service code
 		// Required: true
-		ReServiceCode ReServiceCode `json:"reServiceCode"`
+		// Enum: [DCRT DUCRT]
+		ReServiceCode *string `json:"reServiceCode"`
 
 		// reason
-		// Enum: [DCRT DUCRT]
 		Reason string `json:"reason,omitempty"`
 	}
 	buf := bytes.NewBuffer(raw)
@@ -243,10 +243,10 @@ func (m MTOServiceItemDomesticCrating) MarshalJSON() ([]byte, error) {
 
 		// re service code
 		// Required: true
-		ReServiceCode ReServiceCode `json:"reServiceCode"`
+		// Enum: [DCRT DUCRT]
+		ReServiceCode *string `json:"reServiceCode"`
 
 		// reason
-		// Enum: [DCRT DUCRT]
 		Reason string `json:"reason,omitempty"`
 	}{
 
@@ -335,10 +335,6 @@ func (m *MTOServiceItemDomesticCrating) Validate(formats strfmt.Registry) error 
 	}
 
 	if err := m.validateReServiceCode(formats); err != nil {
-		res = append(res, err)
-	}
-
-	if err := m.validateReason(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -445,19 +441,7 @@ func (m *MTOServiceItemDomesticCrating) validateItem(formats strfmt.Registry) er
 	return nil
 }
 
-func (m *MTOServiceItemDomesticCrating) validateReServiceCode(formats strfmt.Registry) error {
-
-	if err := m.ReServiceCode.Validate(formats); err != nil {
-		if ve, ok := err.(*errors.Validation); ok {
-			return ve.ValidateName("reServiceCode")
-		}
-		return err
-	}
-
-	return nil
-}
-
-var mTOServiceItemDomesticCratingTypeReasonPropEnum []interface{}
+var mTOServiceItemDomesticCratingTypeReServiceCodePropEnum []interface{}
 
 func init() {
 	var res []string
@@ -465,26 +449,26 @@ func init() {
 		panic(err)
 	}
 	for _, v := range res {
-		mTOServiceItemDomesticCratingTypeReasonPropEnum = append(mTOServiceItemDomesticCratingTypeReasonPropEnum, v)
+		mTOServiceItemDomesticCratingTypeReServiceCodePropEnum = append(mTOServiceItemDomesticCratingTypeReServiceCodePropEnum, v)
 	}
 }
 
 // property enum
-func (m *MTOServiceItemDomesticCrating) validateReasonEnum(path, location string, value string) error {
-	if err := validate.Enum(path, location, value, mTOServiceItemDomesticCratingTypeReasonPropEnum); err != nil {
+func (m *MTOServiceItemDomesticCrating) validateReServiceCodeEnum(path, location string, value string) error {
+	if err := validate.Enum(path, location, value, mTOServiceItemDomesticCratingTypeReServiceCodePropEnum); err != nil {
 		return err
 	}
 	return nil
 }
 
-func (m *MTOServiceItemDomesticCrating) validateReason(formats strfmt.Registry) error {
+func (m *MTOServiceItemDomesticCrating) validateReServiceCode(formats strfmt.Registry) error {
 
-	if swag.IsZero(m.Reason) { // not required
-		return nil
+	if err := validate.Required("reServiceCode", "body", m.ReServiceCode); err != nil {
+		return err
 	}
 
 	// value enum
-	if err := m.validateReasonEnum("reason", "body", m.Reason); err != nil {
+	if err := m.validateReServiceCodeEnum("reServiceCode", "body", *m.ReServiceCode); err != nil {
 		return err
 	}
 

--- a/pkg/gen/primemessages/m_t_o_service_item_shuttle.go
+++ b/pkg/gen/primemessages/m_t_o_service_item_shuttle.go
@@ -37,7 +37,8 @@ type MTOServiceItemShuttle struct {
 
 	// re service code
 	// Required: true
-	ReServiceCode ReServiceCode `json:"reServiceCode"`
+	// Enum: [DOSHUT DDSHUT]
+	ReServiceCode *string `json:"reServiceCode"`
 
 	// reason
 	// Required: true
@@ -130,7 +131,8 @@ func (m *MTOServiceItemShuttle) UnmarshalJSON(raw []byte) error {
 
 		// re service code
 		// Required: true
-		ReServiceCode ReServiceCode `json:"reServiceCode"`
+		// Enum: [DOSHUT DDSHUT]
+		ReServiceCode *string `json:"reServiceCode"`
 
 		// reason
 		// Required: true
@@ -211,7 +213,8 @@ func (m MTOServiceItemShuttle) MarshalJSON() ([]byte, error) {
 
 		// re service code
 		// Required: true
-		ReServiceCode ReServiceCode `json:"reServiceCode"`
+		// Enum: [DOSHUT DDSHUT]
+		ReServiceCode *string `json:"reServiceCode"`
 
 		// reason
 		// Required: true
@@ -365,12 +368,34 @@ func (m *MTOServiceItemShuttle) validateDescription(formats strfmt.Registry) err
 	return nil
 }
 
+var mTOServiceItemShuttleTypeReServiceCodePropEnum []interface{}
+
+func init() {
+	var res []string
+	if err := json.Unmarshal([]byte(`["DOSHUT","DDSHUT"]`), &res); err != nil {
+		panic(err)
+	}
+	for _, v := range res {
+		mTOServiceItemShuttleTypeReServiceCodePropEnum = append(mTOServiceItemShuttleTypeReServiceCodePropEnum, v)
+	}
+}
+
+// property enum
+func (m *MTOServiceItemShuttle) validateReServiceCodeEnum(path, location string, value string) error {
+	if err := validate.Enum(path, location, value, mTOServiceItemShuttleTypeReServiceCodePropEnum); err != nil {
+		return err
+	}
+	return nil
+}
+
 func (m *MTOServiceItemShuttle) validateReServiceCode(formats strfmt.Registry) error {
 
-	if err := m.ReServiceCode.Validate(formats); err != nil {
-		if ve, ok := err.(*errors.Validation); ok {
-			return ve.ValidateName("reServiceCode")
-		}
+	if err := validate.Required("reServiceCode", "body", m.ReServiceCode); err != nil {
+		return err
+	}
+
+	// value enum
+	if err := m.validateReServiceCodeEnum("reServiceCode", "body", *m.ReServiceCode); err != nil {
 		return err
 	}
 

--- a/pkg/handlers/primeapi/internal/payloads/model_to_payload.go
+++ b/pkg/handlers/primeapi/internal/payloads/model_to_payload.go
@@ -319,7 +319,7 @@ func MTOServiceItem(mtoServiceItem *models.MTOServiceItem) primemessages.MTOServ
 			crate = &models.MTOServiceItemDimension{}
 		}
 		payload = &primemessages.MTOServiceItemDomesticCrating{
-			ReServiceCode: primemessages.ReServiceCode(mtoServiceItem.ReService.Code),
+			ReServiceCode: handlers.FmtString(string(mtoServiceItem.ReService.Code)),
 			Item: &primemessages.MTOServiceItemDimension{
 				ID:     strfmt.UUID(item.ID.String()),
 				Type:   primemessages.DimensionType(item.Type),
@@ -339,7 +339,7 @@ func MTOServiceItem(mtoServiceItem *models.MTOServiceItem) primemessages.MTOServ
 	case models.ReServiceCodeDDSHUT, models.ReServiceCodeDOSHUT:
 		payload = &primemessages.MTOServiceItemShuttle{
 			Description:   mtoServiceItem.Description,
-			ReServiceCode: primemessages.ReServiceCode(mtoServiceItem.ReService.Code),
+			ReServiceCode: handlers.FmtString(string(mtoServiceItem.ReService.Code)),
 			Reason:        mtoServiceItem.Reason,
 		}
 	default:

--- a/pkg/handlers/primeapi/internal/payloads/payload_to_model.go
+++ b/pkg/handlers/primeapi/internal/payloads/payload_to_model.go
@@ -156,7 +156,7 @@ func MTOServiceItemModel(mtoServiceItem primemessages.MTOServiceItem) (*models.M
 	case primemessages.MTOServiceItemModelTypeMTOServiceItemShuttle:
 		shuttleService := mtoServiceItem.(*primemessages.MTOServiceItemShuttle)
 		// values to get from payload
-		model.ReService.Code = models.ReServiceCode(shuttleService.ReServiceCode)
+		model.ReService.Code = models.ReServiceCode(*shuttleService.ReServiceCode)
 		model.Reason = shuttleService.Reason
 		model.Description = shuttleService.Description
 	case primemessages.MTOServiceItemModelTypeMTOServiceItemDomesticCrating:
@@ -169,7 +169,7 @@ func MTOServiceItemModel(mtoServiceItem primemessages.MTOServiceItem) (*models.M
 		}
 
 		// have to get code from payload
-		model.ReService.Code = models.ReServiceCode(domesticCrating.ReServiceCode)
+		model.ReService.Code = models.ReServiceCode(*domesticCrating.ReServiceCode)
 		model.Description = domesticCrating.Description
 		model.Dimensions = models.MTOServiceItemDimensions{
 			models.MTOServiceItemDimension{

--- a/swagger/prime.yaml
+++ b/swagger/prime.yaml
@@ -981,7 +981,10 @@ definitions:
       - type: object
         properties:
           reServiceCode:
-            $ref: '#/definitions/ReServiceCode'
+            type: string
+            enum:
+              - DOSHUT # Domestic Origin Shuttle Service
+              - DDSHUT # Domestic Destination Shuttle Service
           reason:
             type: string
             example: Storage items need to be picked up
@@ -999,13 +1002,13 @@ definitions:
       - type: object
         properties:
           reServiceCode:
-            $ref: '#/definitions/ReServiceCode'
-          reason:
             type: string
-            example: Storage items need to be picked up
             enum:
               - DCRT # Domestic Crating
               - DUCRT # Domestic Uncrating
+          reason:
+            type: string
+            example: Storage items need to be picked up
           item:
             $ref: '#/definitions/MTOServiceItemDimension'
           crate:


### PR DESCRIPTION
## Description

Fixes up the `reServiceCode` being used with shuttle and crating services. The latter had a problem introduced when I resolved a merge conflict in a prior PR. The former needed some adjustment after some feedback.

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/tree/master/docs/backend.md#logging)
* [ ] The requirements listed in
 [Querying the Database Safely](https://github.com/transcom/mymove/tree/master/docs/backend.md#querying-the-database-safely)
 have been satisfied.
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/tree/master/docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/blob/master/docs/database/migrate-the-database.md#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-1320) for this change


