### PR TITLE
remove unused function setPendingPpmWeight: MB-292

### DIFF
--- a/src/scenes/Moves/Ppm/ducks.js
+++ b/src/scenes/Moves/Ppm/ducks.js
@@ -15,9 +15,6 @@ export const GET_PPM_ESTIMATE = ReduxHelpers.generateAsyncActionTypes('GET_PPM_E
 export const GET_SIT_ESTIMATE = ReduxHelpers.generateAsyncActionTypes('GET_SIT_ESTIMATE');
 
 // Action creation
-export function setPendingPpmWeight(value) {
-  return { type: SET_PENDING_PPM_WEIGHT, payload: value };
-}
 export function getPpmWeightEstimate(moveDate, originZip, originDutyStationZip, destZip, weightEstimate) {
   const action = ReduxHelpers.generateAsyncActions('GET_PPM_ESTIMATE');
   return function (dispatch, getState) {


### PR DESCRIPTION
## Description

We aren't calling `setPendingPpmWeight` anywhere. Remove the function from our code.

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-292) for this change
