### PR TITLE
[MB-1889] Changed nullability on tariff400ng_full_unpack_rates columns

### DIFF
--- a/migrations/app/migrations_manifest.txt
+++ b/migrations/app/migrations_manifest.txt
@@ -494,3 +494,4 @@
 20200325145334_import_2020_400ng.up.sql
 20200326142555_change_nullability_in_tariff_400ng_full_pack_rate.up.sql
 20200327154306_shauna_cac.up.sql
+20200408212210_change_nullability_in_tariff400ng_full_unpack_rates.up.sql

--- a/migrations/app/schema/20200408212210_change_nullability_in_tariff400ng_full_unpack_rates.up.sql
+++ b/migrations/app/schema/20200408212210_change_nullability_in_tariff400ng_full_unpack_rates.up.sql
@@ -1,0 +1,8 @@
+-- Change nullability
+ALTER TABLE tariff400ng_full_unpack_rates
+    ALTER COLUMN schedule SET NOT NULL,
+    ALTER COLUMN rate_millicents SET NOT NULL,
+    ALTER COLUMN effective_date_lower SET NOT NULL,
+    ALTER COLUMN effective_date_upper SET NOT NULL,
+    ALTER COLUMN created_at SET NOT NULL,
+    ALTER COLUMN updated_at SET NOT NULL;

--- a/pkg/models/tariff400ng_full_unpack_rate.go
+++ b/pkg/models/tariff400ng_full_unpack_rate.go
@@ -28,7 +28,10 @@ type Tariff400ngFullUnpackRates []Tariff400ngFullUnpackRate
 // This method is not required and may be deleted.
 func (t *Tariff400ngFullUnpackRate) Validate(tx *pop.Connection) (*validate.Errors, error) {
 	return validate.Validate(
+		&validators.IntIsPresent{Field: t.Schedule, Name: "Schedule"},
 		&validators.IntIsGreaterThan{Field: t.RateMillicents, Name: "RateMillicents", Compared: -1},
+		&validators.TimeIsPresent{Field: t.EffectiveDateLower, Name: "EffectiveDateLower"},
+		&validators.TimeIsPresent{Field: t.EffectiveDateUpper, Name: "EffectiveDateUpper"},
 		&validators.TimeAfterTime{
 			FirstTime: t.EffectiveDateUpper, FirstName: "EffectiveDateUpper",
 			SecondTime: t.EffectiveDateLower, SecondName: "EffectiveDateLower"},

--- a/pkg/models/tariff400ng_full_unpack_rate_test.go
+++ b/pkg/models/tariff400ng_full_unpack_rate_test.go
@@ -1,50 +1,50 @@
 package models_test
 
 import (
+	"testing"
 	"time"
 
 	. "github.com/transcom/mymove/pkg/models"
 	"github.com/transcom/mymove/pkg/testdatagen"
 )
 
-func (suite *ModelSuite) Test_UnpackEffectiveDateValidation() {
-	now := time.Now()
+func (suite *ModelSuite) Test_Tariff400ngFullUnpackRateValidation() {
+	suite.T().Run("test valid Tariff400ngFullUnpackRate", func(t *testing.T) {
+		now := time.Now()
+		validTariff400ngFullUnpackRate := Tariff400ngFullUnpackRate{
+			Schedule:           1,
+			RateMillicents:     100000,
+			EffectiveDateLower: now,
+			EffectiveDateUpper: now.AddDate(1, 0, 0),
+		}
+		expErrors := map[string][]string{}
+		suite.verifyValidationErrors(&validTariff400ngFullUnpackRate, expErrors)
+	})
 
-	validUnpackRate := Tariff400ngFullUnpackRate{
-		EffectiveDateLower: now,
-		EffectiveDateUpper: now.AddDate(1, 0, 0),
-	}
+	suite.T().Run("test invalid Tariff400ngFullUnpackRate", func(t *testing.T) {
+		invalidTariff400ngFullUnpackRate := Tariff400ngFullUnpackRate{}
+		expErrors := map[string][]string{
+			"schedule":             {"Schedule can not be blank."},
+			"effective_date_lower": {"EffectiveDateLower can not be blank."},
+			"effective_date_upper": {"EffectiveDateUpper can not be blank."},
+		}
+		suite.verifyValidationErrors(&invalidTariff400ngFullUnpackRate, expErrors)
+	})
 
-	expErrors := map[string][]string{}
-	suite.verifyValidationErrors(&validUnpackRate, expErrors)
-
-	invalidUnpackRate := Tariff400ngFullUnpackRate{
-		EffectiveDateLower: now,
-		EffectiveDateUpper: now.AddDate(-1, 0, 0),
-	}
-
-	expErrors = map[string][]string{
-		"effective_date_upper": {"EffectiveDateUpper must be after EffectiveDateLower."},
-	}
-	suite.verifyValidationErrors(&invalidUnpackRate, expErrors)
-}
-
-func (suite *ModelSuite) Test_UnpackRateValidation() {
-	validUnpackRate := Tariff400ngFullUnpackRate{
-		RateMillicents: 100,
-	}
-
-	expErrors := map[string][]string{}
-	suite.verifyValidationErrors(&validUnpackRate, expErrors)
-
-	invalidUnpackRate := Tariff400ngFullUnpackRate{
-		RateMillicents: -1,
-	}
-
-	expErrors = map[string][]string{
-		"rate_millicents": {"-1 is not greater than -1."},
-	}
-	suite.verifyValidationErrors(&invalidUnpackRate, expErrors)
+	suite.T().Run("test negative RateMillicents, badly ordered dates for Tariff400ngFullUnpackRate", func(t *testing.T) {
+		now := time.Now()
+		invalidTariff400ngFullUnpackRate := Tariff400ngFullUnpackRate{
+			Schedule:           1,
+			RateMillicents:     -200000,
+			EffectiveDateLower: now,
+			EffectiveDateUpper: now.AddDate(-1, 0, 0),
+		}
+		expErrors := map[string][]string{
+			"rate_millicents":      {"-200000 is not greater than -1."},
+			"effective_date_upper": {"EffectiveDateUpper must be after EffectiveDateLower."},
+		}
+		suite.verifyValidationErrors(&invalidTariff400ngFullUnpackRate, expErrors)
+	})
 }
 
 func (suite *ModelSuite) Test_UnpackCreateAndSave() {


### PR DESCRIPTION
## Description

In anticipation of turning on the new `model-vet` pre-commit hook (see #3591), we have a series of stories to fix the issues it has identified.  This PR handles the identified problems in the `Tariff400ngFullUnpackRate` model.  Specifically, we're addressing the disconnect that the columns noted below are values in the model (can't be nil) but nullable in the database.

```
Tariff400ngFullUnpackRate
	CreatedAt : created_at is NULL
	UpdatedAt : updated_at is NULL
	Schedule : schedule is NULL
	RateMillicents : rate_millicents is NULL
	EffectiveDateLower : effective_date_lower is NULL
	EffectiveDateUpper : effective_date_upper is NULL
```

For the `tariff400ng_*` tables, all these columns should be required, so we're making them `NOT NULL` in the database.  In addition, we're making sure the model validations reflect the required fields.

## Setup

- `make server_test` to ensure server tests still run as expected.
- `make e2e_test` to ensure integration tests still run as expected.
- `make db_dev_migrate` to apply the new nullability changes.
- `go run cmd/model-vet/main.go` to run the `model-vet` tool and get a report of issues.

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/tree/master/docs/backend.md#logging)
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/tree/master/docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/blob/master/docs/database/migrate-the-database.md#secure-migrations)
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-1889) for this change
