### PR TITLE
[MB-1890] Changed nullability on tariff400ng_linehaul_rates columns

### DIFF
--- a/migrations/app/migrations_manifest.txt
+++ b/migrations/app/migrations_manifest.txt
@@ -494,3 +494,4 @@
 20200325145334_import_2020_400ng.up.sql
 20200326142555_change_nullability_in_tariff_400ng_full_pack_rate.up.sql
 20200327154306_shauna_cac.up.sql
+20200408215659_change_nullability_in_tariff400ng_linehaul_rates.up.sql

--- a/migrations/app/schema/20200408215659_change_nullability_in_tariff400ng_linehaul_rates.up.sql
+++ b/migrations/app/schema/20200408215659_change_nullability_in_tariff400ng_linehaul_rates.up.sql
@@ -1,0 +1,12 @@
+-- Change nullability
+ALTER TABLE tariff400ng_linehaul_rates
+    ALTER COLUMN distance_miles_lower SET NOT NULL,
+    ALTER COLUMN distance_miles_upper SET NOT NULL,
+    ALTER COLUMN weight_lbs_lower SET NOT NULL,
+    ALTER COLUMN weight_lbs_upper SET NOT NULL,
+    ALTER COLUMN rate_cents SET NOT NULL,
+    ALTER COLUMN effective_date_lower SET NOT NULL,
+    ALTER COLUMN effective_date_upper SET NOT NULL,
+    ALTER COLUMN type SET NOT NULL,
+    ALTER COLUMN created_at SET NOT NULL,
+    ALTER COLUMN updated_at SET NOT NULL;

--- a/pkg/models/tariff400ng_linehaul_rate.go
+++ b/pkg/models/tariff400ng_linehaul_rate.go
@@ -35,27 +35,22 @@ type Tariff400ngLinehaulRates []Tariff400ngLinehaulRate
 // This method is not required and may be deleted.
 func (t *Tariff400ngLinehaulRate) Validate(tx *pop.Connection) (*validate.Errors, error) {
 	return validate.Validate(
-		&validators.IntIsGreaterThan{Field: t.RateCents.Int(), Name: "RateCents", Compared: -1},
+		&validators.IntIsPresent{Field: t.DistanceMilesLower, Name: "DistanceMilesLower"},
+		&validators.IntIsPresent{Field: t.DistanceMilesUpper, Name: "DistanceMilesUpper"},
 		&validators.IntIsLessThan{Field: t.DistanceMilesLower, Name: "DistanceMilesLower",
 			Compared: t.DistanceMilesUpper},
+		&validators.StringIsPresent{Field: t.Type, Name: "Type"},
+		&validators.IntIsPresent{Field: t.WeightLbsLower.Int(), Name: "WeightLbsLower"},
+		&validators.IntIsPresent{Field: t.WeightLbsUpper.Int(), Name: "WeightLbsUpper"},
 		&validators.IntIsLessThan{Field: t.WeightLbsLower.Int(), Name: "WeightLbsLower",
 			Compared: t.WeightLbsUpper.Int()},
+		&validators.IntIsGreaterThan{Field: t.RateCents.Int(), Name: "RateCents", Compared: -1},
+		&validators.TimeIsPresent{Field: t.EffectiveDateLower, Name: "EffectiveDateLower"},
+		&validators.TimeIsPresent{Field: t.EffectiveDateUpper, Name: "EffectiveDateUpper"},
 		&validators.TimeAfterTime{
 			FirstTime: t.EffectiveDateUpper, FirstName: "EffectiveDateUpper",
 			SecondTime: t.EffectiveDateLower, SecondName: "EffectiveDateLower"},
 	), nil
-}
-
-// ValidateCreate gets run every time you call "pop.ValidateAndCreate" method.
-// This method is not required and may be deleted.
-func (t *Tariff400ngLinehaulRate) ValidateCreate(tx *pop.Connection) (*validate.Errors, error) {
-	return validate.NewErrors(), nil
-}
-
-// ValidateUpdate gets run every time you call "pop.ValidateAndUpdate" method.
-// This method is not required and may be deleted.
-func (t *Tariff400ngLinehaulRate) ValidateUpdate(tx *pop.Connection) (*validate.Errors, error) {
-	return validate.NewErrors(), nil
 }
 
 // FetchBaseLinehaulRate takes a move's distance and weight and queries the tariff400ng_linehaul_rates table to find a move's base linehaul rate.

--- a/pkg/models/tariff400ng_linehaul_rate_test.go
+++ b/pkg/models/tariff400ng_linehaul_rate_test.go
@@ -1,6 +1,7 @@
 package models_test
 
 import (
+	"testing"
 	"time"
 
 	. "github.com/transcom/mymove/pkg/models"
@@ -8,108 +9,55 @@ import (
 	"github.com/transcom/mymove/pkg/unit"
 )
 
-func (suite *ModelSuite) Test_LinehaulEffectiveDateValidation() {
-	now := time.Now()
+func (suite *ModelSuite) Test_Tariff400ngLinehaulRateValidation() {
+	suite.T().Run("test valid Tariff400ngLinehaulRate", func(t *testing.T) {
+		now := time.Now()
+		validTariff400ngLinehaulRate := Tariff400ngLinehaulRate{
+			DistanceMilesLower: 100,
+			DistanceMilesUpper: 200,
+			Type:               "ConusLinehaul",
+			WeightLbsLower:     100,
+			WeightLbsUpper:     200,
+			RateCents:          100,
+			EffectiveDateLower: now,
+			EffectiveDateUpper: now.AddDate(1, 0, 0),
+		}
+		expErrors := map[string][]string{}
+		suite.verifyValidationErrors(&validTariff400ngLinehaulRate, expErrors)
+	})
 
-	validLinehaulRate := Tariff400ngLinehaulRate{
-		WeightLbsLower:     100,
-		WeightLbsUpper:     200,
-		DistanceMilesLower: 100,
-		DistanceMilesUpper: 200,
-		EffectiveDateLower: now,
-		EffectiveDateUpper: now.AddDate(1, 0, 0),
-	}
+	suite.T().Run("test invalid Tariff400ngLinehaulRate", func(t *testing.T) {
+		invalidTariff400ngLinehaulRate := Tariff400ngLinehaulRate{}
+		expErrors := map[string][]string{
+			"distance_miles_lower": {"DistanceMilesLower can not be blank.", "0 is not less than 0."},
+			"distance_miles_upper": {"DistanceMilesUpper can not be blank."},
+			"type":                 {"Type can not be blank."},
+			"weight_lbs_lower":     {"WeightLbsLower can not be blank.", "0 is not less than 0."},
+			"weight_lbs_upper":     {"WeightLbsUpper can not be blank."},
+			"effective_date_lower": {"EffectiveDateLower can not be blank."},
+			"effective_date_upper": {"EffectiveDateUpper can not be blank."},
+		}
+		suite.verifyValidationErrors(&invalidTariff400ngLinehaulRate, expErrors)
+	})
 
-	expErrors := map[string][]string{}
-	suite.verifyValidationErrors(&validLinehaulRate, expErrors)
-
-	invalidLinehaulRate := Tariff400ngLinehaulRate{
-		WeightLbsLower:     100,
-		WeightLbsUpper:     200,
-		DistanceMilesLower: 100,
-		DistanceMilesUpper: 200,
-		EffectiveDateLower: now,
-		EffectiveDateUpper: now.AddDate(-1, 0, 0),
-	}
-
-	expErrors = map[string][]string{
-		"effective_date_upper": {"EffectiveDateUpper must be after EffectiveDateLower."},
-	}
-	suite.verifyValidationErrors(&invalidLinehaulRate, expErrors)
-}
-
-func (suite *ModelSuite) Test_LinehaulWeightValidation() {
-	validLinehaulRate := Tariff400ngLinehaulRate{
-		WeightLbsLower:     100,
-		WeightLbsUpper:     200,
-		DistanceMilesLower: 100,
-		DistanceMilesUpper: 200,
-	}
-
-	expErrors := map[string][]string{}
-	suite.verifyValidationErrors(&validLinehaulRate, expErrors)
-
-	invalidLinehaulRate := Tariff400ngLinehaulRate{
-		WeightLbsLower:     200,
-		WeightLbsUpper:     100,
-		DistanceMilesLower: 100,
-		DistanceMilesUpper: 200,
-	}
-
-	expErrors = map[string][]string{
-		"weight_lbs_lower": {"200 is not less than 100."},
-	}
-	suite.verifyValidationErrors(&invalidLinehaulRate, expErrors)
-}
-
-func (suite *ModelSuite) Test_LinehaulRateValidation() {
-	validLinehaulRate := Tariff400ngLinehaulRate{
-		RateCents:          100,
-		WeightLbsLower:     100,
-		WeightLbsUpper:     200,
-		DistanceMilesLower: 100,
-		DistanceMilesUpper: 200,
-	}
-
-	expErrors := map[string][]string{}
-	suite.verifyValidationErrors(&validLinehaulRate, expErrors)
-
-	invalidLinehaulRate := Tariff400ngLinehaulRate{
-		RateCents:          -1,
-		WeightLbsLower:     100,
-		WeightLbsUpper:     200,
-		DistanceMilesLower: 100,
-		DistanceMilesUpper: 200,
-	}
-
-	expErrors = map[string][]string{
-		"rate_cents": {"-1 is not greater than -1."},
-	}
-	suite.verifyValidationErrors(&invalidLinehaulRate, expErrors)
-}
-
-func (suite *ModelSuite) Test_LinehaulDistanceValidation() {
-	validLinehaulRate := Tariff400ngLinehaulRate{
-		WeightLbsLower:     100,
-		WeightLbsUpper:     200,
-		DistanceMilesLower: 100,
-		DistanceMilesUpper: 200,
-	}
-
-	expErrors := map[string][]string{}
-	suite.verifyValidationErrors(&validLinehaulRate, expErrors)
-
-	invalidLinehaulRate := Tariff400ngLinehaulRate{
-		WeightLbsLower:     100,
-		WeightLbsUpper:     200,
-		DistanceMilesLower: 200,
-		DistanceMilesUpper: 100,
-	}
-
-	expErrors = map[string][]string{
-		"distance_miles_lower": {"200 is not less than 100."},
-	}
-	suite.verifyValidationErrors(&invalidLinehaulRate, expErrors)
+	suite.T().Run("test negative RateCents, badly ordered dates for Tariff400ngLinehaulRate", func(t *testing.T) {
+		now := time.Now()
+		invalidTariff400ngLinehaulRate := Tariff400ngLinehaulRate{
+			DistanceMilesLower: 100,
+			DistanceMilesUpper: 200,
+			Type:               "ConusLinehaul",
+			WeightLbsLower:     100,
+			WeightLbsUpper:     200,
+			RateCents:          -200,
+			EffectiveDateLower: now,
+			EffectiveDateUpper: now.AddDate(-1, 0, 0),
+		}
+		expErrors := map[string][]string{
+			"rate_cents":           {"-200 is not greater than -1."},
+			"effective_date_upper": {"EffectiveDateUpper must be after EffectiveDateLower."},
+		}
+		suite.verifyValidationErrors(&invalidTariff400ngLinehaulRate, expErrors)
+	})
 }
 
 func (suite *ModelSuite) Test_FetchBaseLinehaulRate() {


### PR DESCRIPTION
## Description

In anticipation of turning on the new `model-vet` pre-commit hook (see #3591), we have a series of stories to fix the issues it has identified.  This PR handles the identified problems in the `Tariff400ngLinehaulRate` model.  Specifically, we're addressing the disconnect that the columns noted below are values in the model (can't be nil) but nullable in the database.

```
Tariff400ngLinehaulRate
	CreatedAt : created_at is NULL
	UpdatedAt : updated_at is NULL
	DistanceMilesLower : distance_miles_lower is NULL
	DistanceMilesUpper : distance_miles_upper is NULL
	Type : type is NULL
	WeightLbsLower : weight_lbs_lower is NULL
	WeightLbsUpper : weight_lbs_upper is NULL
	RateCents : rate_cents is NULL
	EffectiveDateLower : effective_date_lower is NULL
	EffectiveDateUpper : effective_date_upper is NULL
```

For the `tariff400ng_*` tables, all these columns should be required, so we're making them `NOT NULL` in the database.  In addition, we're making sure the model validations reflect the required fields.

## Setup

- `make server_test` to ensure server tests still run as expected.
- `make e2e_test` to ensure integration tests still run as expected.
- `make db_dev_migrate` to apply the new nullability changes.
- `go run cmd/model-vet/main.go` to run the `model-vet` tool and get a report of issues.

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/tree/master/docs/backend.md#logging)
* Any new migrations/schema changes:
  * [ ] Follow our guidelines for zero-downtime deploys (see [Zero-Downtime Deploys](https://github.com/transcom/mymove/tree/master/docs/database.md#zero-downtime-migrations))
  * [ ] Have been communicated to #dp3-engineering
  * [ ] Secure migrations have been tested following the instructions in our [docs](https://github.com/transcom/mymove/blob/master/docs/database/migrate-the-database.md#secure-migrations)
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-1890) for this change
