### PR TITLE
MB-2244 Add shuttle service to prime api client

### DIFF
--- a/cmd/prime-api-client/create_mto_service_item.go
+++ b/cmd/prime-api-client/create_mto_service_item.go
@@ -8,7 +8,6 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"reflect"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -18,12 +17,6 @@ import (
 	mtoServiceItem "github.com/transcom/mymove/pkg/gen/primeclient/mto_service_item"
 	"github.com/transcom/mymove/pkg/gen/primemessages"
 )
-
-// THIS WILL NEED TO BE UPDATED AS WE CONTINUE TO ADD MORE SERVICE ITEMS
-// restrict creation to a list
-var allowedMap = map[primemessages.MTOServiceItemModelType]bool{
-	primemessages.MTOServiceItemModelTypeMTOServiceItemDOFSIT: true,
-}
 
 type getType struct {
 	ModelType primemessages.MTOServiceItemModelType `json:"modelType"`
@@ -64,9 +57,17 @@ func getFileReader(filename string, args []string, logger *log.Logger) *bufio.Re
 	return reader
 }
 
-func getJSONDecoder(filename string, args []string, logger *log.Logger) *json.Decoder {
-	reader := getFileReader(filename, args, logger)
+func getJSONDecoder(reader *bufio.Reader) *json.Decoder {
 	return json.NewDecoder(reader)
+}
+
+func decodeServiceItem(subType primemessages.MTOServiceItem, jsonDecoder *json.Decoder) (primemessages.MTOServiceItem, error) {
+	//jsonDecoder = json.NewDecoder(getFileReader(filename, args, logger))
+	err := jsonDecoder.Decode(&subType)
+	if err != nil {
+		return nil, fmt.Errorf("second decoding data failed: %w", err)
+	}
+	return subType, nil
 }
 
 // CreateMTOServiceItem creates the mto service item for a MTO and/or MTOShipment
@@ -100,7 +101,8 @@ func createMTOServiceItem(cmd *cobra.Command, args []string) error {
 
 	// reading json file so we can unmarshal
 	filename := v.GetString(FilenameFlag)
-	jsonDecoder := getJSONDecoder(filename, args, logger)
+	reader := getFileReader(filename, args, logger)
+	jsonDecoder := getJSONDecoder(reader)
 	// decode first to determine the model type
 	var gt getType
 	err = jsonDecoder.Decode(&gt)
@@ -108,49 +110,32 @@ func createMTOServiceItem(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("first decoding data failed: %w", err)
 	}
 
+	// reset decoder to read from beginning
+	jsonDecoder = getJSONDecoder(getFileReader(filename, args, logger))
+
 	// once decoded, we can type cast into a more specific model type
 	// then decode a second time into subtype
 	var serviceItem primemessages.MTOServiceItem
 	switch gt.ModelType {
 	case primemessages.MTOServiceItemModelTypeMTOServiceItemDOFSIT:
-		var serviceItemSubtype primemessages.MTOServiceItemDOFSIT
-
-		jsonDecoder = json.NewDecoder(getFileReader(filename, args, logger))
-		err = jsonDecoder.Decode(&serviceItemSubtype)
-		if err != nil {
-			return fmt.Errorf("second decoding data failed: %w", err)
-		}
-		serviceItem = &serviceItemSubtype
+		serviceItem, err = decodeServiceItem(&primemessages.MTOServiceItemDOFSIT{}, jsonDecoder)
 	case primemessages.MTOServiceItemModelTypeMTOServiceItemDDFSIT:
-		var serviceItemSubtype primemessages.MTOServiceItemDDFSIT
-
-		jsonDecoder = json.NewDecoder(getFileReader(filename, args, logger))
-		err = jsonDecoder.Decode(&serviceItemSubtype)
-		if err != nil {
-			return fmt.Errorf("second decoding data failed: %w", err)
-		}
-		serviceItem = &serviceItemSubtype
+		serviceItem, err = decodeServiceItem(&primemessages.MTOServiceItemDDFSIT{}, jsonDecoder)
 	case primemessages.MTOServiceItemModelTypeMTOServiceItemDomesticCrating:
-		var serviceItemSubtype primemessages.MTOServiceItemDomesticCrating
-
-		jsonDecoder = json.NewDecoder(getFileReader(filename, args, logger))
-		err = jsonDecoder.Decode(&serviceItemSubtype)
-		if err != nil {
-			return fmt.Errorf("second decoding data failed: %w", err)
-		}
-		serviceItem = &serviceItemSubtype
+		serviceItem, err = decodeServiceItem(&primemessages.MTOServiceItemDomesticCrating{}, jsonDecoder)
 	case primemessages.MTOServiceItemModelTypeMTOServiceItemShuttle:
-		var serviceItemSubtype primemessages.MTOServiceItemShuttle
-
-		jsonDecoder = json.NewDecoder(getFileReader(filename, args, logger))
-		err = jsonDecoder.Decode(&serviceItemSubtype)
-		if err != nil {
-			return fmt.Errorf("second decoding data failed: %w", err)
-		}
-		serviceItem = &serviceItemSubtype
+		serviceItem, err = decodeServiceItem(&primemessages.MTOServiceItemShuttle{}, jsonDecoder)
 	default:
-		return fmt.Errorf("unexpected MTOServiceItem type: %s \n\nexpected model types: %v",
-			gt.ModelType, reflect.ValueOf(allowedMap).MapKeys())
+		err = fmt.Errorf("allowed modelType(): %v", []primemessages.MTOServiceItemModelType{
+			primemessages.MTOServiceItemModelTypeMTOServiceItemDDFSIT,
+			primemessages.MTOServiceItemModelTypeMTOServiceItemDOFSIT,
+			primemessages.MTOServiceItemModelTypeMTOServiceItemDomesticCrating,
+			primemessages.MTOServiceItemModelTypeMTOServiceItemShuttle,
+		})
+	}
+	// return any decoding errors
+	if err != nil {
+		return err
 	}
 
 	// Let's make a request!

--- a/cmd/prime-api-client/create_mto_service_item.go
+++ b/cmd/prime-api-client/create_mto_service_item.go
@@ -62,7 +62,6 @@ func getJSONDecoder(reader *bufio.Reader) *json.Decoder {
 }
 
 func decodeServiceItem(subType primemessages.MTOServiceItem, jsonDecoder *json.Decoder) (primemessages.MTOServiceItem, error) {
-	//jsonDecoder = json.NewDecoder(getFileReader(filename, args, logger))
 	err := jsonDecoder.Decode(&subType)
 	if err != nil {
 		return nil, fmt.Errorf("second decoding data failed: %w", err)

--- a/cmd/prime-api-client/create_mto_service_item.go
+++ b/cmd/prime-api-client/create_mto_service_item.go
@@ -22,12 +22,14 @@ type getType struct {
 	ModelType primemessages.MTOServiceItemModelType `json:"modelType"`
 }
 
+// initCreateMTOServiceItemFlags initializes flags.
 func initCreateMTOServiceItemFlags(flag *pflag.FlagSet) {
 	flag.String(FilenameFlag, "", "Name of the file being passed in")
 
 	flag.SortFlags = false
 }
 
+// checkCreateMTOServiceItemConfig checks the args.
 func checkCreateMTOServiceItemConfig(v *viper.Viper, args []string, logger *log.Logger) error {
 	err := CheckRootConfig(v)
 	if err != nil {
@@ -41,6 +43,7 @@ func checkCreateMTOServiceItemConfig(v *viper.Viper, args []string, logger *log.
 	return nil
 }
 
+// getFileReader will get the bufio file reader.
 func getFileReader(filename string, args []string, logger *log.Logger) *bufio.Reader {
 	var reader *bufio.Reader
 	if filename != "" {
@@ -57,10 +60,12 @@ func getFileReader(filename string, args []string, logger *log.Logger) *bufio.Re
 	return reader
 }
 
+// getJSONDecoder will get a new json decoder.
 func getJSONDecoder(reader *bufio.Reader) *json.Decoder {
 	return json.NewDecoder(reader)
 }
 
+// decodeServiceItem will decode the json into a mto service item type.
 func decodeServiceItem(subType primemessages.MTOServiceItem, jsonDecoder *json.Decoder) (primemessages.MTOServiceItem, error) {
 	err := jsonDecoder.Decode(&subType)
 	if err != nil {

--- a/cmd/prime-api-client/create_mto_service_item.go
+++ b/cmd/prime-api-client/create_mto_service_item.go
@@ -139,6 +139,15 @@ func createMTOServiceItem(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("second decoding data failed: %w", err)
 		}
 		serviceItem = &serviceItemSubtype
+	case primemessages.MTOServiceItemModelTypeMTOServiceItemShuttle:
+		var serviceItemSubtype primemessages.MTOServiceItemShuttle
+
+		jsonDecoder = json.NewDecoder(getFileReader(filename, args, logger))
+		err = jsonDecoder.Decode(&serviceItemSubtype)
+		if err != nil {
+			return fmt.Errorf("second decoding data failed: %w", err)
+		}
+		serviceItem = &serviceItemSubtype
 	default:
 		return fmt.Errorf("unexpected MTOServiceItem type: %s \n\nexpected model types: %v",
 			gt.ModelType, reflect.ValueOf(allowedMap).MapKeys())


### PR DESCRIPTION
## Description

This adds support for creating mto service item shuttle services, `DOSHUT` and `DDSHUT`.

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make db_dev_e2e_populate
make server_run
```

Test with the prime api client:

data.json file
```json
{
  "modelType": "MTOServiceItemShuttle",
  "moveTaskOrderID": "13e78a41-4775-4dae-9de5-598464500f0d",
  "mtoShipmentID": "ede680c1-c790-4512-8965-90f74bc008c1",
  "description": "testttinggg",
  "reServiceCode": "DDSHUT",
  "reason": "just because"
}
```

Run cmd
```sh
go run ./cmd/prime-api-client --insecure create-mto-service-item --filename data.json -v | jq
```

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/tree/master/docs/backend.md#logging)
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-2244) for this change