### PR TITLE
[MB-2231] Allow jira ticket id to have brackets in PR title

### DIFF
--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -8,8 +8,8 @@ const githubChecks = () => {
       warn('Please include a description of your PR changes.');
     }
     // PRs should have a Jira ID in the title
-    if (!danger.github.pr.title.match(/^MB-\d+/)) {
-      warn('Please include the Jira ID at the start of the title with the format MB-123');
+    if (!danger.github.pr.title.match(/^(\[MB-\d+\]|MB-\d+)/)) {
+      warn('Please include the Jira ID at the start of the title with the format MB-123 or [MB-123]');
     }
   }
 };


### PR DESCRIPTION
## Description

Jira supports having the id in brackets for linking PRs so Danger should allow that. 

## Reviewer Notes

This PR has brackets and should have no DangerJS warnings.

## Code Review Verification Steps

* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-2231) for this change
* [this slack thread](https://ustcdp3.slack.com/archives/CP6F568DC/p1586440325007200) explains more about the approach used.