### PR TITLE
[MB-1777] Added create-payment-request command to prime-api-client

### DIFF
--- a/cmd/prime-api-client/create_payment_request.go
+++ b/cmd/prime-api-client/create_payment_request.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+
+	"github.com/transcom/mymove/pkg/gen/primeclient/payment_requests"
+	"github.com/transcom/mymove/pkg/gen/primemessages"
+)
+
+// initCreatePaymentRequestFlags initializes flags.
+func initCreatePaymentRequestFlags(flag *pflag.FlagSet) {
+	flag.String(FilenameFlag, "", "Path to the file with the payment request JSON payload")
+
+	flag.SortFlags = false
+}
+
+// checkCreatePaymentRequestConfig checks the args.
+func checkCreatePaymentRequestConfig(v *viper.Viper, args []string, logger *log.Logger) error {
+	err := CheckRootConfig(v)
+	if err != nil {
+		return err
+	}
+
+	if v.GetString(FilenameFlag) == "" && (len(args) < 1 || len(args) > 0 && !containsDash(args)) {
+		return errors.New("create-payment-request expects a file to be passed in")
+	}
+
+	return nil
+}
+
+// createPaymentRequest creates the payment request for an MTO
+func createPaymentRequest(cmd *cobra.Command, args []string) error {
+	v := viper.New()
+
+	// Create the logger
+	// Remove the prefix and any datetime data
+	logger := log.New(os.Stdout, "", log.LstdFlags)
+
+	errParseFlags := ParseFlags(cmd, v, args)
+	if errParseFlags != nil {
+		return errParseFlags
+	}
+
+	// Check the config before talking to the CAC
+	err := checkCreatePaymentRequestConfig(v, args, logger)
+	if err != nil {
+		logger.Fatal(err)
+	}
+
+	// cac and api gateway
+	primeGateway, cacStore, errCreateClient := CreatePrimeClient(v)
+	if errCreateClient != nil {
+		return errCreateClient
+	}
+
+	// Defer closing the store until after the API call has completed
+	if cacStore != nil {
+		defer cacStore.Close()
+	}
+
+	// Decode json from file that was passed into create-payment-request
+	filename := v.GetString(FilenameFlag)
+	var reader *bufio.Reader
+	if filename != "" {
+		file, fileErr := os.Open(filepath.Clean(filename))
+		if fileErr != nil {
+			logger.Fatal(fileErr)
+		}
+		reader = bufio.NewReader(file)
+	}
+
+	if len(args) > 0 && containsDash(args) {
+		reader = bufio.NewReader(os.Stdin)
+	}
+
+	jsonDecoder := json.NewDecoder(reader)
+	var paymentRequest primemessages.CreatePaymentRequestPayload
+	err = jsonDecoder.Decode(&paymentRequest)
+	if err != nil {
+		return fmt.Errorf("decoding data failed: %w", err)
+	}
+
+	params := payment_requests.CreatePaymentRequestParams{
+		Body: &paymentRequest,
+	}
+	params.SetTimeout(time.Second * 30)
+
+	resp, errCreatePaymentRequest := primeGateway.PaymentRequests.CreatePaymentRequest(&params)
+	if errCreatePaymentRequest != nil {
+		// If the response cannot be parsed as JSON you may see an error like
+		// is not supported by the TextConsumer, can be resolved by supporting TextUnmarshaler interface
+		// Likely this is because the API doesn't return JSON response for BadRequest OR
+		// The response type is not being set to text
+		logger.Fatal(errCreatePaymentRequest.Error())
+	}
+
+	payload := resp.GetPayload()
+	if payload != nil {
+		payload, errJSONMarshall := json.Marshal(payload)
+		if errJSONMarshall != nil {
+			logger.Fatal(errJSONMarshall)
+		}
+		fmt.Println(string(payload))
+	} else {
+		logger.Fatal(resp.Error())
+	}
+
+	return nil
+}

--- a/cmd/prime-api-client/main.go
+++ b/cmd/prime-api-client/main.go
@@ -103,6 +103,16 @@ func main() {
 	initUpdateMTOStatusFlags(makeAvailableToPrimeCommand.Flags())
 	root.AddCommand(makeAvailableToPrimeCommand)
 
+	createPaymentRequestCommand := &cobra.Command{
+		Use:          "create-payment-request",
+		Short:        "Create payment request",
+		Long:         "Create payment request for a move task order",
+		RunE:         createPaymentRequest,
+		SilenceUsage: true,
+	}
+	initCreatePaymentRequestFlags(createPaymentRequestCommand.Flags())
+	root.AddCommand(createPaymentRequestCommand)
+
 	completionCommand := &cobra.Command{
 		Use:   "completion",
 		Short: "Generates bash completion scripts",

--- a/pkg/testdatagen/scenario/e2ebasic.go
+++ b/pkg/testdatagen/scenario/e2ebasic.go
@@ -1086,7 +1086,7 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, log
 	})
 	mto2 := testdatagen.MakeMoveTaskOrder(db, testdatagen.Assertions{
 		MoveTaskOrder: models.MoveTaskOrder{
-			ID:                 uuid.FromStringOrNil("0da3f34cc-fb94-4e0b-1c90-ba3333cb7791"),
+			ID:                 uuid.FromStringOrNil("da3f34cc-fb94-4e0b-1c90-ba3333cb7791"),
 			MoveOrderID:        moveOrders6.ID,
 			UpdatedAt:          time.Unix(1576779681256, 0),
 			IsAvailableToPrime: true,
@@ -1146,6 +1146,9 @@ func (e e2eBasicScenario) Run(db *pop.Connection, loader *uploader.Uploader, log
 	})
 
 	testdatagen.MakeMTOServiceItem(db, testdatagen.Assertions{
+		MTOServiceItem: models.MTOServiceItem{
+			ID: uuid.FromStringOrNil("8a625314-1922-4987-93c5-a62c0d13f053"),
+		},
 		MoveTaskOrder: mto2,
 	})
 }


### PR DESCRIPTION
## Description

This PR adds a `create-payment-request` command to the `prime-api-client` CLI utility.  This new command allows you to submit a JSON payload of payment request information in our various environments.

## Setup

### Testing Dev

1. First run `make db_dev_e2e_populate` to ensure your database is setup with the E2E data.
2. Next, save this example JSON payload (which references E2E UUIDs) to a file called `pr_payload_dev.json`:
```
{
    "isFinal": false,
    "moveTaskOrderID": "da3f34cc-fb94-4e0b-1c90-ba3333cb7791",
    "serviceItems": [
        {
            "id": "8a625314-1922-4987-93c5-a62c0d13f053",
            "params": [
                {
                    "key": "WeightEstimated",
                    "value": "3254"
                },
                {
                    "key": "RequestedPickupDate",
                    "value": "2020-04-20"
                }
            ]
        }
    ]
}
```
3. Ensure your server is running: `make server_run`
4. Run this command to fetch the "available to prime" MTOs (there's just one of those in E2E data at this time) and notice that there are no payment requests for it yet in the returned JSON: `go run ./cmd/prime-api-client --insecure fetch-mtos | jq`
5. Now let's create a payment request using our payload above.  There are two different ways to do this:
    - With the `--filename` flag: `go run ./cmd/prime-api-client --insecure create-payment-request --filename pr_payload_dev.json | jq`
    - From stdin: `go run ./cmd/prime-api-client --insecure create-payment-request - < pr_payload_dev.json | jq`
6. Fetch the MTOs again and verify the payment request(s) you created are there: `go run ./cmd/prime-api-client --insecure fetch-mtos | jq`

### Testing Experimental (optional)

**NOTE: You must have a CAC to do this part!**

1. Make a copy of the JSON payload above and save it to `pr_payload_exp.json`
2. See what "available to prime" MTOs are out there (you will prompted for your CAC PIN): `go run ./cmd/prime-api-client --cac --hostname api.experimental.move.mil --port 443 fetch-mtos | jq`
3. Edit the `pr_payload_exp.json` file and replace the two UUIDs in it with a `moveTaskOrderID` value and `mtoServiceItems` ID value from the output of step 2. 
4. Create the payment request: `go run ./cmd/prime-api-client --cac --hostname api.experimental.move.mil --port 443 create-payment-request --filename pr_payload_exp.json | jq`
5. Fetch the MTOs again and verify the payment request(s) you created are there: `go run ./cmd/prime-api-client --cac --hostname api.experimental.move.mil --port 443 fetch-mtos | jq`

Testing in the staging environment should be similar, but uses `api.staging.move.mil` instead.

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/tree/master/docs/backend.md#logging)
* [ ] Tested in the Experimental environment (for changes to containers, app startup, or connection to data stores)
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-1777) for this change
