### PR TITLE
[MB-1783] Add make and model to weight ticket summary for cars/car+trailer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,7 @@ require (
 	github.com/namsral/flag v1.7.4-pre
 	github.com/pdfcpu/pdfcpu v0.2.5
 	github.com/pkg/errors v0.9.1
-	github.com/rickar/cal v1.0.3
+	github.com/rickar/cal v1.0.5
 	github.com/rogpeppe/go-internal v1.5.1 // indirect
 	github.com/spf13/afero v1.2.2
 	github.com/spf13/cobra v0.0.7

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/0xAX/notificator v0.0.0-20191016112426-3962a5ea8da1 // indirect
 	github.com/99designs/aws-vault v4.5.1+incompatible
 	github.com/99designs/keyring v1.1.4
-	github.com/aws/aws-sdk-go v1.30.7
+	github.com/aws/aws-sdk-go v1.30.8
 	github.com/codegangsta/envy v0.0.0-20141216192214-4b78388c8ce4 // indirect
 	github.com/codegangsta/gin v0.0.0-20171026143024-cafe2ce98974
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -467,8 +467,8 @@ github.com/prometheus/common v0.4.0/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y8
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
-github.com/rickar/cal v1.0.3 h1:7gTIMg5oEkLEjDFCvlmXEC8rATyQR/EXMtxIIzHmmm4=
-github.com/rickar/cal v1.0.3/go.mod h1:3GBx8OBrvh4/y/JTxM0e1bUUIHMnqILl1rMANHWExxQ=
+github.com/rickar/cal v1.0.5 h1:ccTH7okdpqbT+X7hlWgQM4Hv3rTvpV8Stu7enQx7ywY=
+github.com/rickar/cal v1.0.5/go.mod h1:3GBx8OBrvh4/y/JTxM0e1bUUIHMnqILl1rMANHWExxQ=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/go-internal v1.1.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.2.2/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=

--- a/go.sum
+++ b/go.sum
@@ -28,8 +28,8 @@ github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a h1:idn718Q4
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496 h1:zV3ejI06GQ59hwDQAvmK1qxOQGB3WuVTRoY0okPTAv0=
 github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496/go.mod h1:oGkLhpf+kjZl6xBf758TQhh5XrAeiJv/7FRz/2spLIg=
-github.com/aws/aws-sdk-go v1.30.7 h1:IaXfqtioP6p9SFAnNfsqdNczbR5UNbYqvcZUSsCAdTY=
-github.com/aws/aws-sdk-go v1.30.7/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
+github.com/aws/aws-sdk-go v1.30.8 h1:4BHbh8K3qKmcnAgToZ2LShldRF9inoqIBccpCLNCy3I=
+github.com/aws/aws-sdk-go v1.30.8/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/boombuler/barcode v1.0.0/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=

--- a/src/scenes/Moves/Ppm/PaymentReview/WeightTicketListItem.jsx
+++ b/src/scenes/Moves/Ppm/PaymentReview/WeightTicketListItem.jsx
@@ -54,6 +54,8 @@ class WeightTicketListItem extends Component {
       num,
       trailer_ownership_missing,
       vehicle_nickname,
+      vehicle_make,
+      vehicle_model,
       weight_ticket_set_type,
       showDelete,
       deleteDocumentListItem,
@@ -63,6 +65,7 @@ class WeightTicketListItem extends Component {
     const { showDeleteConfirmation } = this.state;
     const isInfected = this.areUploadsInfected(uploads);
     const showWeightTicketIcon = weight_ticket_set_type !== 'PRO_GEAR';
+    const showVehicleNickname = weight_ticket_set_type === 'BOX_TRUCK' || 'PRO_GEAR';
     return (
       <div className="ticket-item" style={{ display: 'flex' }}>
         {/* size of largest of the images */}
@@ -81,9 +84,11 @@ class WeightTicketListItem extends Component {
             <h4>
               {isWeightTicketSet && (
                 <>
-                  {vehicle_nickname} {formatToOrdinal(num + 1)} set
+                  {vehicle_make} {vehicle_model}
                 </>
               )}
+              {showVehicleNickname && <>{vehicle_nickname} </>}
+              {isWeightTicketSet && <>{formatToOrdinal(num + 1)} set</>}
             </h4>
             {showDelete && (
               <img

--- a/src/scenes/Moves/Ppm/PaymentReview/WeightTicketListItem.jsx
+++ b/src/scenes/Moves/Ppm/PaymentReview/WeightTicketListItem.jsx
@@ -64,6 +64,7 @@ class WeightTicketListItem extends Component {
     const { showDeleteConfirmation } = this.state;
     const isInfected = this.areUploadsInfected(uploads);
     const showWeightTicketIcon = weight_ticket_set_type !== 'PRO_GEAR';
+    const showVehicleNickname = weight_ticket_set_type === 'BOX_TRUCK' || 'PRO_GEAR';
     const showMakeModel = weight_ticket_set_type === 'CAR' || 'CAR_TRAILER';
     return (
       <div className="ticket-item" style={{ display: 'flex' }}>
@@ -83,9 +84,11 @@ class WeightTicketListItem extends Component {
             <h4>
               {showMakeModel && (
                 <>
-                  {vehicle_make} {vehicle_model} {vehicle_nickname} {formatToOrdinal(num + 1)} set
+                  {vehicle_make} {vehicle_model}
                 </>
               )}
+              {showVehicleNickname && <>{vehicle_nickname} </>}
+              <>{formatToOrdinal(num + 1)} set</>
             </h4>
             {showDelete && (
               <img

--- a/src/scenes/Moves/Ppm/PaymentReview/WeightTicketListItem.jsx
+++ b/src/scenes/Moves/Ppm/PaymentReview/WeightTicketListItem.jsx
@@ -65,7 +65,7 @@ class WeightTicketListItem extends Component {
     const isInfected = this.areUploadsInfected(uploads);
     const showWeightTicketIcon = weight_ticket_set_type !== 'PRO_GEAR';
     const showVehicleNickname = weight_ticket_set_type === 'BOX_TRUCK' || 'PRO_GEAR';
-    const showMakeModel = weight_ticket_set_type === 'CAR' || 'CAR_TRAILER';
+    const showVehicleMakeModel = weight_ticket_set_type === 'CAR' || 'CAR_TRAILER';
     return (
       <div className="ticket-item" style={{ display: 'flex' }}>
         {/* size of largest of the images */}
@@ -82,7 +82,7 @@ class WeightTicketListItem extends Component {
         <div style={{ flex: 1 }}>
           <div className="weight-li-item-container">
             <h4>
-              {showMakeModel && (
+              {showVehicleMakeModel && (
                 <>
                   {vehicle_make} {vehicle_model}
                 </>

--- a/src/scenes/Moves/Ppm/PaymentReview/WeightTicketListItem.jsx
+++ b/src/scenes/Moves/Ppm/PaymentReview/WeightTicketListItem.jsx
@@ -59,6 +59,7 @@ class WeightTicketListItem extends Component {
       weight_ticket_set_type,
       showDelete,
       deleteDocumentListItem,
+      isWeightTicketSet,
       uploads,
     } = this.props;
     const { showDeleteConfirmation } = this.state;
@@ -88,7 +89,7 @@ class WeightTicketListItem extends Component {
                 </>
               )}
               {showVehicleNickname && <>{vehicle_nickname} </>}
-              <>{formatToOrdinal(num + 1)} set</>
+              {isWeightTicketSet && <>{formatToOrdinal(num + 1)} set</>}
             </h4>
             {showDelete && (
               <img

--- a/src/scenes/Moves/Ppm/PaymentReview/WeightTicketListItem.jsx
+++ b/src/scenes/Moves/Ppm/PaymentReview/WeightTicketListItem.jsx
@@ -59,13 +59,12 @@ class WeightTicketListItem extends Component {
       weight_ticket_set_type,
       showDelete,
       deleteDocumentListItem,
-      isWeightTicketSet,
       uploads,
     } = this.props;
     const { showDeleteConfirmation } = this.state;
     const isInfected = this.areUploadsInfected(uploads);
     const showWeightTicketIcon = weight_ticket_set_type !== 'PRO_GEAR';
-    const showVehicleNickname = weight_ticket_set_type === 'BOX_TRUCK' || 'PRO_GEAR';
+    const showMakeModel = weight_ticket_set_type === 'CAR' || 'CAR_TRAILER';
     return (
       <div className="ticket-item" style={{ display: 'flex' }}>
         {/* size of largest of the images */}
@@ -82,13 +81,11 @@ class WeightTicketListItem extends Component {
         <div style={{ flex: 1 }}>
           <div className="weight-li-item-container">
             <h4>
-              {isWeightTicketSet && (
+              {showMakeModel && (
                 <>
-                  {vehicle_make} {vehicle_model}
+                  {vehicle_make} {vehicle_model} {vehicle_nickname} {formatToOrdinal(num + 1)} set
                 </>
               )}
-              {showVehicleNickname && <>{vehicle_nickname} </>}
-              {isWeightTicketSet && <>{formatToOrdinal(num + 1)} set</>}
             </h4>
             {showDelete && (
               <img


### PR DESCRIPTION
## Description

Weight ticket now displays the nickname next to boxtruck and progear, and vehicle make/model next to cars and car+trailers.

## Reviewer Notes

There's likely a more eloquent way to format the conditional for whether to show `vehicle_nickname` vs `vehicle_make`/`vehicle_model`. Please check it out and give constructive feedback if you have any.

## Setup

Add any steps or code to run in this section to help others prepare to run your code:

```sh
make server_run
make client_run
```

Login as a service member with an approved PPM (I used ppm@approv.ed)
Click `Continue Requesting Payment` and view existing weight ticket items, or add some of your own

## Code Review Verification Steps

* [ ] Code follows the guidelines for [Logging](https://github.com/transcom/mymove/tree/master/docs/backend.md#logging)
(https://github.com/transcom/mymove/blob/master/docs/database/migrate-the-database.md#secure-migrations)
* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-1783) for this change

## Screenshots

<img width="1045" alt="Screen Shot 2020-04-17 at 9 33 04 AM" src="https://user-images.githubusercontent.com/16230705/79592315-adee2c00-808e-11ea-8742-45056382161c.png">
