### PR TITLE
[MB-1351] PPM copy update: replace "Marines" with "Marine Corps" in branch of service dropdown

### DIFF
--- a/pkg/gen/internalapi/embedded_spec.go
+++ b/pkg/gen/internalapi/embedded_spec.go
@@ -3307,7 +3307,7 @@ func init() {
         "AIR_FORCE": "Air Force",
         "ARMY": "Army",
         "COAST_GUARD": "Coast Guard",
-        "MARINES": "Marines",
+        "MARINES": "Marine Corps",
         "NAVY": "Navy"
       },
       "x-nullable": true
@@ -9510,7 +9510,7 @@ func init() {
         "AIR_FORCE": "Air Force",
         "ARMY": "Army",
         "COAST_GUARD": "Coast Guard",
-        "MARINES": "Marines",
+        "MARINES": "Marine Corps",
         "NAVY": "Navy"
       },
       "x-nullable": true

--- a/swagger/internal.yaml
+++ b/swagger/internal.yaml
@@ -53,7 +53,7 @@ definitions:
     x-display-value:
       ARMY: Army
       NAVY: Navy
-      MARINES: Marines
+      MARINES: Marine Corps
       AIR_FORCE: Air Force
       COAST_GUARD: Coast Guard
   DutyStationPayload:


### PR DESCRIPTION
## Description

Copy update, on create SM screen the dropdown now shows `Marine Corps` instead of `Marines`

## Setup

```sh
make server_run
make client_run
```

Create new SM, on the first page view the branch of service dropdown

## Code Review Verification Steps

* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-1351) for this change

## Screenshots
<img width="1054" alt="Screen Shot 2020-04-17 at 3 38 59 PM" src="https://user-images.githubusercontent.com/16230705/79619414-a3995580-80c1-11ea-80e4-9e2efa6e80f3.png">
