### PR TITLE
[MB-2364] Copy changes on SM Create Your Profile page

### DIFF
--- a/src/scenes/ServiceMembers/DodInfo.jsx
+++ b/src/scenes/ServiceMembers/DodInfo.jsx
@@ -84,13 +84,13 @@ const validateDodForm = (values, form) => {
 
   if (hasSSN) {
     if (ssnPresent && !validSSN) {
-      errors.social_security_number = 'SSN must have 9 digits.';
+      errors.social_security_number = 'SSN must have 9 digits';
     }
   } else {
     if (!ssnPresent) {
       errors.social_security_number = 'Required';
     } else if (!validSSN) {
-      errors.social_security_number = 'SSN must have 9 digits.';
+      errors.social_security_number = 'SSN must have 9 digits';
     }
   }
 

--- a/src/scenes/ServiceMembers/DodInfo.jsx
+++ b/src/scenes/ServiceMembers/DodInfo.jsx
@@ -53,7 +53,7 @@ class SSNField extends Component {
     return (
       <div className={classNames('usa-form-group', { 'usa-form-group--error': displayError })}>
         <label className={classNames('usa-label', { 'usa-label--error': displayError })} htmlFor={name}>
-          Social security number
+          Social Security number
         </label>
         {touched && error && (
           <span className="usa-error-message" id={name + '-error'} role="alert">
@@ -88,7 +88,7 @@ const validateDodForm = (values, form) => {
     }
   } else {
     if (!ssnPresent) {
-      errors.social_security_number = 'Required.';
+      errors.social_security_number = 'Required';
     } else if (!validSSN) {
       errors.social_security_number = 'SSN must have 9 digits.';
     }


### PR DESCRIPTION
## Description

Copy changes on the ServiceMember Create Your Profile page.

## Setup

```sh
make server_run
make client_run
```
Create a new SM, on `Create Your Profile` page, click in and then exit each field without filling them in and view the lovely consistency in red `Required` warnings; also see that Social Security number is now properly formatted

## Code Review Verification Steps

* [ ] There are no aXe warnings for UI.
* [ ] This works in [Supported Browsers and their phone views](https://github.com/transcom/mymove/tree/master/docs/adr/0016-Browser-Support.md) (Chrome, Firefox, IE, Edge).
* [ ] User facing changes have been reviewed by design.
* [ ] Request review from a member of a different team.
* [ ] Have the Jira acceptance criteria been met for this change?

## References

* [Jira story](https://dp3.atlassian.net/browse/MB-2364) for this change


## Screenshots

<img width="1026" alt="Screen Shot 2020-04-20 at 11 36 35 AM" src="https://user-images.githubusercontent.com/16230705/79793105-e5fea480-8304-11ea-8815-7fda2711f42b.png">


